### PR TITLE
feat(mundo3d): fauna funcional animada por rol ecológico

### DIFF
--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -160,6 +160,7 @@ function MundoInterno({
       <div className="mundo-root" data-dim="3d" data-mundo={mundoId}>
         <Suspense fallback={<MundoCargando tinte={tinte} onTimeout={alTimeout3D} />}>
           <Escena
+            mundoId={mundoId}
             params={plan.entrada.params}
             hotspots={plan.entrada.hotspots}
             entrada={plan.entrada.entrada}

--- a/src/visual/mundo3d/escenas/EscenaBoveda.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBoveda.jsx
@@ -37,6 +37,7 @@ import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { faunaDeMundo } from '../faunaFuncional.js';
 import { ATMOSFERA, CIELOS, PALETA } from '../atmosferaMadre.js';
 
 const R_BOVEDA = 9;
@@ -387,12 +388,9 @@ function Montana({ pisos = PISOS_DEF, glaciar = {} }) {
   );
 }
 
-/* La vida del cielo de día: un colibrí y una mariposa cerca de la ladera. De
-   noche no se siembra fauna (honestidad ecológica). */
-const FAUNA_DIA = [
-  { tipo: 'colibri', base: [2.2, 1.5, 1.4], patron: 'revoloteo', size: 28, fase: 0.6 },
-  { tipo: 'mariposa', base: [-1.7, 0.9, 1.6], patron: 'revoloteo', size: 30, fase: 2.2 },
-];
+/* La vida del cielo de día son POLINIZADORES cerca de la ladera (colibrí y
+   mariposa); su definición vive en faunaFuncional.js. De noche no se siembra
+   fauna (la escena lo gatea con `esDia` — honestidad ecológica). */
 
 /* ── CAPA ENSO: la OSCILACIÓN interanual (El Niño–Oscilación del Sur) ────────
  *
@@ -570,7 +568,7 @@ function CapaEnso({ params, tier = 'alto', cima = 3.5, reducedMotion }) {
   );
 }
 
-function Diorama({ params, reducedMotion, tier }) {
+function Diorama({ params, reducedMotion, tier, fauna }) {
   const hora = params?.hora ?? 0.62;
   const temporada = params?.temporada ?? 'lluvia';
   const niebla = params?.niebla ?? 0.6;
@@ -610,7 +608,7 @@ function Diorama({ params, reducedMotion, tier }) {
         </>
       )}
 
-      {esDia && <Fauna items={FAUNA_DIA} reducedMotion={reducedMotion} />}
+      {esDia && <Fauna items={fauna} reducedMotion={reducedMotion} />}
     </group>
   );
 }
@@ -628,7 +626,7 @@ export default function EscenaBoveda(props) {
       camara={{ position: [4.6, 3.1, 8.6], fov: 46 }}
       entrada={{ ...props.entrada, zoom: props.entrada?.zoom ?? 7.5, centro: [0, 2.2, 0] }}
     >
-      <Diorama params={props.params} reducedMotion={props.reducedMotion} tier={props.tier} />
+      <Diorama params={props.params} reducedMotion={props.reducedMotion} tier={props.tier} fauna={faunaDeMundo(props.mundoId, { tier: props.tier })} />
     </EscenaBase3D>
   );
 }

--- a/src/visual/mundo3d/escenas/EscenaCutaway.jsx
+++ b/src/visual/mundo3d/escenas/EscenaCutaway.jsx
@@ -24,6 +24,7 @@ import EscenaBase3D from './EscenaBase3D.jsx';
 import { Lombriz } from '../../creatures/Lombriz.jsx';
 import { Escarabajo } from '../../creatures/Escarabajo.jsx';
 import { Mariposa } from '../../creatures/Mariposa.jsx';
+import { coreografia } from '../faunaFuncional.js';
 import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
 const ANCHO = 4.4;
@@ -261,6 +262,65 @@ function RaizNodulos({ base, largo = 1.4 }) {
   );
 }
 
+/* Avispa parasitoide (Trichogramma / Cotesia — CONTROLADOR biológico de la
+   milpa): PATRULLA sobre el maíz cazando los huevos y larvas del cogollero
+   (Spodoptera frugiperda), la plaga #1 del maíz andino. Cuerpo ámbar con bandas
+   oscuras, cintura fina (pecíolo) y alas translúcidas; low-poly, sin cajas. Su
+   zigzag es la misma coreografía de rol 'patrulla'; se congela con reduced-motion. */
+function AvispaParasitoide({ base, fase = 0, reducedMotion = false }) {
+  const ref = useRef(null);
+  useFrame((state) => {
+    if (reducedMotion || !ref.current) return;
+    const [dx, dy, dz] = coreografia('patrulla', state.clock.elapsedTime, fase);
+    ref.current.position.set(base[0] + dx, base[1] + dy, base[2] + dz);
+  });
+  return (
+    <group ref={ref} position={base} scale={0.62}>
+      {/* cabeza oscura (mira hacia +x) */}
+      <mesh position={[0.15, 0.01, 0]}>
+        <sphereGeometry args={[0.05, 7, 6]} />
+        <meshLambertMaterial color="#2a2018" flatShading />
+      </mesh>
+      {/* antenas */}
+      {[0.03, -0.03].map((z) => (
+        <mesh key={z} position={[0.2, 0.06, z]} rotation={[0, 0, 0.5]}>
+          <cylinderGeometry args={[0.006, 0.006, 0.12, 4]} />
+          <meshLambertMaterial color="#2a2018" />
+        </mesh>
+      ))}
+      {/* tórax ámbar */}
+      <mesh position={[0.04, 0, 0]}>
+        <sphereGeometry args={[0.08, 8, 6]} />
+        <meshLambertMaterial color="#caa23a" flatShading />
+      </mesh>
+      {/* cintura fina (pecíolo) que une tórax y abdomen */}
+      <mesh position={[-0.06, -0.005, 0]} rotation={[0, 0, Math.PI / 2]}>
+        <cylinderGeometry args={[0.018, 0.018, 0.05, 5]} />
+        <meshLambertMaterial color="#caa23a" flatShading />
+      </mesh>
+      {/* abdomen ámbar alargado */}
+      <mesh position={[-0.17, -0.01, 0]} rotation={[0, 0, Math.PI / 2]} scale={[1, 1.5, 1]}>
+        <capsuleGeometry args={[0.06, 0.1, 3, 7]} />
+        <meshLambertMaterial color="#d9a531" flatShading />
+      </mesh>
+      {/* las bandas oscuras (la señal "avispa") */}
+      {[-0.12, -0.19, -0.26].map((x) => (
+        <mesh key={x} position={[x, -0.01, 0]} rotation={[0, Math.PI / 2, 0]}>
+          <torusGeometry args={[0.06, 0.012, 5, 10]} />
+          <meshLambertMaterial color="#2a2018" flatShading />
+        </mesh>
+      ))}
+      {/* alas translúcidas */}
+      {[0.09, -0.09].map((z) => (
+        <mesh key={z} position={[0.02, 0.08, z]} rotation={[z > 0 ? -0.5 : 0.5, 0, 0.2]} scale={[1.7, 1, 0.7]}>
+          <sphereGeometry args={[0.07, 6, 4]} />
+          <meshBasicMaterial color="#eef4f4" transparent opacity={0.42} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
 /* El módulo de las tres hermanas, compuesto sobre la cara del corte. */
 function Milpa({ total, config, reducedMotion }) {
   const cfg = config === true ? {} : (config || {});
@@ -276,10 +336,12 @@ function Milpa({ total, config, reducedMotion }) {
       <GuiaFrijol base={[maizX, total, zF]} alto={maizAlto * 0.9} vueltas={vueltas} />
       <RaizNodulos base={[maizX, total, zRaiz]} largo={total * 0.62} />
       <Calabaza base={[calX, total, zF - 0.05]} />
-      {/* la mariposa que visita la flor de la calabaza (vida, no relleno) */}
+      {/* POLINIZADOR: la mariposa que visita la flor de la calabaza (vida, no relleno) */}
       <Fauna base={[calX - 0.15, total + 0.5, zF + 0.12]} phase={1.7} deriva={0.5} asomo={0.05} reducedMotion={reducedMotion}>
         <Mariposa size={38} animated={!reducedMotion} />
       </Fauna>
+      {/* CONTROLADOR: la avispa parasitoide patrullando sobre el maíz (caza el cogollero) */}
+      <AvispaParasitoide base={[maizX + 0.2, total + maizAlto * 0.82, zF + 0.12]} fase={0.7} reducedMotion={reducedMotion} />
     </group>
   );
 }

--- a/src/visual/mundo3d/escenas/EscenaEstratos.jsx
+++ b/src/visual/mundo3d/escenas/EscenaEstratos.jsx
@@ -18,16 +18,12 @@
 import { useMemo } from 'react';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { faunaDeMundo } from '../faunaFuncional.js';
 import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
-/* Fauna POR ESTRATO: la verticalidad manda. El colibrí arriba (dosel), la
-   mariposa a media altura (arbustos/herbáceas) y el escarabajo a ras (rastrero/
-   raíz) — cada bicho donde de veras vive en el bosque comestible. */
-const FAUNA_ESTRATOS = [
-  { tipo: 'colibri', base: [0.6, 3.0, 0.4], patron: 'revoloteo', size: 28, fase: 0.5 },
-  { tipo: 'mariposa', base: [-0.9, 1.35, 0.6], patron: 'revoloteo', size: 30, fase: 2.0 },
-  { tipo: 'escarabajo', base: [0.8, 0.14, 1.0], patron: 'reptar', size: 30, fase: 1.2 },
-];
+/* La fauna funcional por estrato (POLINIZADORES en dosel/sotobosque + un
+   DESCOMPONEDOR en la hojarasca, para `disenio`; POLINIZADORES del aire
+   templado/frío para `pisos`) vive en faunaFuncional.js, por mundo. */
 
 const ESTRATOS_DEF = [
   { nombre: 'emergente', alto: 3.4, color: '#2f5f34', r: 0.6 },
@@ -55,7 +51,7 @@ function Planta({ x, z, alto, color, r }) {
 }
 
 /* ── El bosque comestible (mundo `disenio`) — sin cambios ─────────────────── */
-function DioramaEstratos({ params, reducedMotion }) {
+function DioramaEstratos({ params, reducedMotion, fauna }) {
   const estratos = params?.estratos || ESTRATOS_DEF;
   const plantas = useMemo(() => {
     const out = [];
@@ -81,8 +77,8 @@ function DioramaEstratos({ params, reducedMotion }) {
       {plantas.map((p) => (
         <Planta key={p.key} x={p.x} z={p.z} alto={p.alto} color={p.color} r={p.r} />
       ))}
-      {/* la vida repartida por estratos: ave arriba, insectos abajo */}
-      <Fauna items={FAUNA_ESTRATOS} reducedMotion={reducedMotion} />
+      {/* la vida repartida por estratos: polinizadores arriba, descomponedor abajo */}
+      <Fauna items={fauna} reducedMotion={reducedMotion} />
     </group>
   );
 }
@@ -99,12 +95,6 @@ const PISO_SUBE = 1.15;
 const PISO_FONDO = 0.7;
 const pisoY = (i) => 0.2 + i * PISO_SUBE; // superficie de la terraza i
 const pisoZ = (i) => 0.6 - i * PISO_FONDO; // se recede al subir (profundidad)
-
-/* Fauna de la ladera: en el aire templado/frío; NADA en el páramo. */
-const FAUNA_PISOS = [
-  { tipo: 'mariposa', base: [-0.7, pisoY(1) + 0.55, pisoZ(1) + 0.5], patron: 'revoloteo', size: 30, fase: 1.4 },
-  { tipo: 'colibri', base: [0.7, pisoY(2) + 0.55, pisoZ(2) + 0.4], patron: 'revoloteo', size: 28, fase: 0.6 },
-];
 
 /* Plátano/frutal (piso cálido): pseudotallo verde + hojas grandes colgantes. */
 function Platano() {
@@ -258,7 +248,7 @@ function Niebla({ x, y, z, r = 0.5 }) {
   );
 }
 
-function DioramaPisos({ params, reducedMotion }) {
+function DioramaPisos({ params, reducedMotion, fauna }) {
   const pisos = useMemo(() => params?.pisos || [], [params?.pisos]);
   // Cultivos por terraza, con aire (2 por piso, jitter determinista).
   const siembra = useMemo(() => {
@@ -335,8 +325,8 @@ function DioramaPisos({ params, reducedMotion }) {
         </mesh>
       </group>
 
-      {/* vida sólo donde vive: mariposa (templado), colibrí (frío/templado) */}
-      <Fauna items={FAUNA_PISOS} reducedMotion={reducedMotion} />
+      {/* vida sólo donde vive: polinizadores del templado/frío; páramo sin fauna */}
+      <Fauna items={fauna} reducedMotion={reducedMotion} />
     </group>
   );
 }
@@ -346,6 +336,7 @@ export default function EscenaEstratos(props) {
   const cielo = esPisos ? CIELOS.ladera : CIELOS.sotobosque;
   const camara = esPisos ? { position: [4.4, 3.7, 6.4], fov: 46 } : { position: [3.5, 3, 6], fov: 44 };
   const centro = esPisos ? [0, 1.95, -0.4] : [0, 1.4, 0];
+  const fauna = faunaDeMundo(props.mundoId, { tier: props.tier });
   return (
     <EscenaBase3D
       {...props}
@@ -354,9 +345,9 @@ export default function EscenaEstratos(props) {
       entrada={{ ...props.entrada, centro }}
     >
       {esPisos ? (
-        <DioramaPisos params={props.params} reducedMotion={props.reducedMotion} />
+        <DioramaPisos params={props.params} reducedMotion={props.reducedMotion} fauna={fauna} />
       ) : (
-        <DioramaEstratos params={props.params} reducedMotion={props.reducedMotion} />
+        <DioramaEstratos params={props.params} reducedMotion={props.reducedMotion} fauna={fauna} />
       )}
     </EscenaBase3D>
   );

--- a/src/visual/mundo3d/escenas/EscenaFlujo.jsx
+++ b/src/visual/mundo3d/escenas/EscenaFlujo.jsx
@@ -19,16 +19,11 @@ import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { faunaDeMundo } from '../faunaFuncional.js';
 import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
-/* La vida del agua, por criterio ecológico: mariposas revoloteando sobre la
-   quebrada, un colibrí en las flores de la ribera (junto a la ronda de monte),
-   y otra mariposa polinizando la huerta regada. Anclada a la curva del agua. */
-const FAUNA_FLUJO = [
-  { tipo: 'colibri', base: [-1.35, 1.75, 0.7], patron: 'revoloteo', size: 30, fase: 0.4 },
-  { tipo: 'mariposa', base: [-0.15, 0.98, 0.72], patron: 'revoloteo', size: 30, fase: 1.6 },
-  { tipo: 'mariposa', base: [2.1, 0.1, -0.15], patron: 'revoloteo', size: 28, fase: 3.0 },
-];
+/* La fauna funcional del agua (POLINIZADORES de ribera y huerta regada) vive en
+   faunaFuncional.js; aquí solo se siembra según el mundo y el device-tier. */
 
 const CURVA_DEFAULT = [
   [-1.8, 2.2, 0.4], [-0.9, 1.4, 0.1], [0, 0.7, -0.2], [0.7, 0.1, 0.1], [1.4, -0.2, 0.5],
@@ -200,7 +195,7 @@ function Cultivo({ pos = [2.3, -0.3, -0.55], surcos = 4, desde, color }) {
   );
 }
 
-function Diorama({ params, tinte, reducedMotion }) {
+function Diorama({ params, tinte, reducedMotion, fauna }) {
   const color = params?.agua || (tinte && tinte[0]) || '#3f8fb0';
   const hitos = params?.hitos;
   const curva3 = useMemo(() => {
@@ -244,17 +239,18 @@ function Diorama({ params, tinte, reducedMotion }) {
           color={color}
         />
       )}
-      {/* la vida que vive del agua: mariposas y un colibrí de ribera */}
-      <Fauna items={FAUNA_FLUJO} reducedMotion={reducedMotion} />
+      {/* la vida que vive del agua: polinizadores de ribera y huerta regada */}
+      <Fauna items={fauna} reducedMotion={reducedMotion} />
     </group>
   );
 }
 
 export default function EscenaFlujo(props) {
   const cielo = CIELOS.agua;
+  const fauna = faunaDeMundo(props.mundoId, { tier: props.tier });
   return (
     <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.9, 0.3] }}>
-      <Diorama params={props.params} tinte={props.tinte} reducedMotion={props.reducedMotion} />
+      <Diorama params={props.params} tinte={props.tinte} reducedMotion={props.reducedMotion} fauna={fauna} />
     </EscenaBase3D>
   );
 }

--- a/src/visual/mundo3d/escenas/EscenaMercado.jsx
+++ b/src/visual/mundo3d/escenas/EscenaMercado.jsx
@@ -23,14 +23,11 @@
 import { useMemo } from 'react';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { faunaDeMundo } from '../faunaFuncional.js';
 import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
-/* La fauna que anima la feria: la mariposa entre las flores del puesto, el
-   colibrí que sobrevuela la plaza. Pocas y por criterio (vida, no enjambre). */
-const FAUNA_MERCADO = [
-  { tipo: 'mariposa', base: [-1.15, 0.7, 0.55], patron: 'revoloteo', size: 28, fase: 0.5 },
-  { tipo: 'colibri', base: [1.2, 1.15, 0.3], patron: 'revoloteo', size: 30, fase: 1.8 },
-];
+/* La fauna funcional de la feria (POLINIZADORES entre las flores del puesto y la
+   cosecha: sin polinizador no hay cosecha que vender) vive en faunaFuncional.js. */
 
 /* Un CANASTO de mimbre con su montón de producto. El canasto es un tronco de
    cono facetado (el tejido); encima, una loma de esferitas del color de lo que
@@ -184,7 +181,7 @@ function MataCampo({ pos, color = '#4e8f3f' }) {
   );
 }
 
-function Diorama({ params, reducedMotion }) {
+function Diorama({ params, reducedMotion, fauna }) {
   const puestos = params?.puestos || [
     { color: '#c96a2f', pos: [-0.85, 0, 0.2] },
     { color: '#3f8f4e', pos: [0.9, 0, -0.1] },
@@ -252,8 +249,8 @@ function Diorama({ params, reducedMotion }) {
           ~0.45 sobre el piso sin mesa que la sostuviera). */}
       <Balanza pos={[0.15, 0, 0.55]} />
 
-      {/* la fauna que anima la feria (mariposa/colibrí) */}
-      <Fauna items={FAUNA_MERCADO} reducedMotion={reducedMotion} />
+      {/* la fauna que anima la feria (polinizadores de puesto y plaza) */}
+      <Fauna items={fauna} reducedMotion={reducedMotion} />
     </group>
   );
 }
@@ -262,9 +259,10 @@ export default function EscenaMercado(props) {
   // Cielo cálido de plaza de mercado a media mañana (se mezcla igual hacia la
   // hora dorada del valle: entrar debe sentirse como acercarse, no otra app).
   const cielo = CIELOS.plaza;
+  const fauna = faunaDeMundo(props.mundoId, { tier: props.tier });
   return (
     <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.5, 0] }}>
-      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
+      <Diorama params={props.params} reducedMotion={props.reducedMotion} fauna={fauna} />
     </EscenaBase3D>
   );
 }

--- a/src/visual/mundo3d/escenas/EscenaRecinto.jsx
+++ b/src/visual/mundo3d/escenas/EscenaRecinto.jsx
@@ -13,6 +13,7 @@ import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { faunaDeMundo } from '../faunaFuncional.js';
 import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
 /* Idle sutil de los animales del corral —el SUJETO del mundo—: reusa el mismo
@@ -42,14 +43,9 @@ function useIdlePecuario(kind, fase, reducedMotion) {
   return ref;
 }
 
-/* La fauna que acompaña el corral: el escarabajo estercolero junto a la pila de
-   estiércol (cierra el ciclo del abono, literal), un colibrí que sobrevuela y
-   una mariposa por la cerca. Las aves/insectos suman a los animales de granja. */
-const FAUNA_RECINTO = [
-  { tipo: 'escarabajo', base: [0.36, 0.18, 0.42], patron: 'reptar', size: 30, fase: 0.5 },
-  { tipo: 'colibri', base: [-0.7, 1.15, 0.5], patron: 'revoloteo', size: 30, fase: 1.2 },
-  { tipo: 'mariposa', base: [1.0, 0.62, 0.85], patron: 'revoloteo', size: 28, fase: 2.6 },
-];
+/* La fauna funcional del corral (un DESCOMPONEDOR insignia —el escarabajo
+   estercolero que procesa el estiércol y cierra el ciclo del abono— más
+   POLINIZADORES por la cerca) vive en faunaFuncional.js, poblada por mundo. */
 
 /* Un animal esquemático: cuerpo + cabeza, tono propio. Es el FALLBACK
    retrocompatible: si un dato viejo trae solo {color, pos} sin `tipo`, se dibuja
@@ -208,7 +204,7 @@ function AnimalDeCorral({ tipo, pos, color, reducedMotion, fase }) {
     : <Animalito pos={pos} color={color} />;
 }
 
-function Diorama({ params, reducedMotion }) {
+function Diorama({ params, reducedMotion, fauna }) {
   const animales = params?.animales || [
     { tipo: 'vaca', color: '#c9a06a', pos: [-1.05, 0, -0.4] },
     { tipo: 'gallina', color: '#e7d9c2', pos: [1.1, 0, 0.5] },
@@ -256,17 +252,18 @@ function Diorama({ params, reducedMotion }) {
           fase={i * 1.7}
         />
       ))}
-      {/* aves e insectos que animan el corral (escarabajo en el abono) */}
-      <Fauna items={FAUNA_RECINTO} reducedMotion={reducedMotion} />
+      {/* la fauna funcional: descomponedor en el abono + polinizadores por la cerca */}
+      <Fauna items={fauna} reducedMotion={reducedMotion} />
     </group>
   );
 }
 
 export default function EscenaRecinto(props) {
   const cielo = CIELOS.corral;
+  const fauna = faunaDeMundo(props.mundoId, { tier: props.tier });
   return (
     <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.4, 0] }}>
-      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
+      <Diorama params={props.params} reducedMotion={props.reducedMotion} fauna={fauna} />
     </EscenaBase3D>
   );
 }

--- a/src/visual/mundo3d/escenas/EscenaSanidad.jsx
+++ b/src/visual/mundo3d/escenas/EscenaSanidad.jsx
@@ -18,29 +18,34 @@
  * Todo `MeshLambert`/`Basic`, sin sombras (contrato de EscenaBase3D). Geometría
  * de primitivas: cero GLTF, offline y liviano.
  */
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import { faunaDeMundo, coreografia } from '../faunaFuncional.js';
 import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
-/* La fauna BENÉFICA que acompaña la huerta-clínica: la mariposa polinizadora en
-   la orla de flores, el colibrí que sobrevuela, y el escarabajo (carábido)
-   depredador que anda a ras cazando larvas en el suelo. Pocas y por criterio
-   ecológico (contrato del DR: vida, no enjambre). */
-const FAUNA_SANIDAD = [
-  { tipo: 'mariposa', base: [1.05, 0.66, 0.78], patron: 'revoloteo', size: 28, fase: 0.4 },
-  { tipo: 'colibri', base: [-0.85, 1.12, 0.42], patron: 'revoloteo', size: 30, fase: 1.6 },
-  { tipo: 'escarabajo', base: [0.28, 0.16, -0.52], patron: 'reptar', size: 28, fase: 2.4 },
-];
+/* La fauna BENÉFICA billboard de la huerta-clínica (el CONTROLADOR carábido que
+   patrulla a ras + POLINIZADORES en la orla de flores) vive en faunaFuncional.js.
+   La mariquita insignia va como malla low-poly, patrullando (abajo). */
 
 /* Una MARIQUITA low-poly (Coccinellidae) — el enemigo natural insignia: una sola
-   larva o adulto come cientos de pulgones. Media esfera roja + cabeza + puntos. */
-function Mariquita({ pos, escala = 1 }) {
+   larva o adulto come cientos de pulgones. Media esfera roja + cabeza + puntos.
+   Como CONTROLADORA, PATRULLA las matas en zigzag buscando pulgón (misma
+   coreografía de rol que la fauna billboard); se congela con reduced-motion. */
+function Mariquita({ pos, escala = 1, fase = 0, reducedMotion = false }) {
+  const ref = useRef(null);
+  useFrame((state) => {
+    if (reducedMotion || !ref.current) return;
+    const [dx, dy, dz] = coreografia('patrulla', state.clock.elapsedTime, fase);
+    // a ras de la hoja: el barrido lateral manda, el zumbido vertical se atenúa.
+    ref.current.position.set(pos[0] + dx, pos[1] + dy * 0.4, pos[2] + dz);
+  });
   const puntos = [
     [0.035, -0.02], [-0.035, -0.02], [0.03, 0.035], [-0.03, 0.035],
   ];
   return (
-    <group position={pos} scale={escala}>
+    <group ref={ref} position={pos} scale={escala}>
       {/* élitros: media esfera roja */}
       <mesh position={[0, 0.06, 0]}>
         <sphereGeometry args={[0.09, 12, 8, 0, Math.PI * 2, 0, Math.PI / 2]} />
@@ -146,7 +151,7 @@ function FlorBorde({ pos }) {
   );
 }
 
-function Diorama({ params, reducedMotion }) {
+function Diorama({ params, reducedMotion, fauna }) {
   const matas = params?.matas || [
     { color: '#4e8f3f', pos: [-0.5, 0, 0.35] },
     { color: '#57993f', pos: [0.55, 0, 0.1] },
@@ -215,12 +220,12 @@ function Diorama({ params, reducedMotion }) {
         <FlorBorde key={i} pos={p} />
       ))}
 
-      {/* los enemigos naturales insignia: dos mariquitas sobre las matas */}
-      <Mariquita pos={[-0.42, 0.5, 0.42]} escala={1} />
-      <Mariquita pos={[0.6, 0.32, 0.12]} escala={0.85} />
+      {/* los enemigos naturales insignia: dos mariquitas patrullando las matas */}
+      <Mariquita pos={[-0.42, 0.5, 0.42]} escala={1} fase={0.8} reducedMotion={reducedMotion} />
+      <Mariquita pos={[0.6, 0.32, 0.12]} escala={0.85} fase={2.9} reducedMotion={reducedMotion} />
 
-      {/* la fauna benéfica que anima la escena (mariposa/colibrí/carábido) */}
-      <Fauna items={FAUNA_SANIDAD} reducedMotion={reducedMotion} />
+      {/* la fauna funcional billboard: carábido patrullando + polinizadores del borde */}
+      <Fauna items={fauna} reducedMotion={reducedMotion} />
     </group>
   );
 }
@@ -228,9 +233,10 @@ function Diorama({ params, reducedMotion }) {
 export default function EscenaSanidad(props) {
   // Cielo fresco y sano de huerta (se mezcla igual hacia la hora dorada del valle).
   const cielo = CIELOS.huerta;
+  const fauna = faunaDeMundo(props.mundoId, { tier: props.tier });
   return (
     <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.45, 0] }}>
-      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
+      <Diorama params={props.params} reducedMotion={props.reducedMotion} fauna={fauna} />
     </EscenaBase3D>
   );
 }

--- a/src/visual/mundo3d/escenas/FaunaEscena.jsx
+++ b/src/visual/mundo3d/escenas/FaunaEscena.jsx
@@ -4,9 +4,14 @@
  * Los dioramas 3D se sentían vacíos. Aquí la vida de la finca (las creatures de
  * `src/visual/creatures`) entra a cualquier escena SIN redibujarse: reusamos el
  * MISMO componente SVG y lo colgamos como billboard `<Html>` de drei —idéntico
- * patrón que Angelita en `useEntradaAbeja.jsx`— con un micro-movimiento suave que
- * la escena posee (revoloteo para lo que vuela, reptar para lo que anda a ras).
- * La creature POSEE el cuerpo; la escena POSEE la coreografía (contrato del DR).
+ * patrón que Angelita en `useEntradaAbeja.jsx`— con un movimiento que la escena
+ * posee, DICTADO POR EL ROL ECOLÓGICO del bicho: el polinizador salta de flor en
+ * flor, el controlador patrulla en zigzag, el descomponedor repta a ras. La
+ * creature POSEE el cuerpo; la escena POSEE la coreografía (contrato del DR).
+ *
+ * El QUÉ (qué bicho, con qué rol, en qué mundo) vive en `faunaFuncional.js`; el
+ * CÓMO (la math del gesto por patrón) también, compartido con las mallas
+ * low-poly (mariquita de sanidad, avispa de la milpa). Aquí solo el andamiaje R3F.
  *
  * RENDIMIENTO: como son billboards DOM (SVG), no aplican `InstancedMesh` (eso es
  * para las MALLAS repetidas —árboles, hifas, postes— que cada arquetipo ya
@@ -24,45 +29,35 @@ import { Colibri } from '../../creatures/Colibri.jsx';
 import { Mariposa } from '../../creatures/Mariposa.jsx';
 import { Escarabajo } from '../../creatures/Escarabajo.jsx';
 import { Lombriz } from '../../creatures/Lombriz.jsx';
+import { coreografia, patronDeRol } from '../faunaFuncional.js';
 
 /* Sólo la fauna reutilizable en escena (Angelita la coloca `useEntradaAbeja`). */
 const COMPS = { colibri: Colibri, mariposa: Mariposa, escarabajo: Escarabajo, lombriz: Lombriz };
 
-/* Micro-movimiento por patrón, en unidades de escena (amplitudes chicas: vida,
-   no espectáculo). `fase` desincroniza varios bichos para que no latan a la par. */
-function deriva(patron, t, fase) {
-  if (patron === 'reptar') {
-    // anda a ras: avance lento en x, con un cabeceo mínimo (escarabajo / lombriz)
-    return [Math.sin(t * 0.4 + fase) * 0.09, Math.abs(Math.sin(t * 1.1 + fase)) * 0.02, 0];
-  }
-  // revoloteo: vuelo suspendido —sube/baja y deriva apenas (colibrí / mariposa)
-  return [
-    Math.sin(t * 0.9 + fase) * 0.12,
-    Math.sin(t * 1.7 + fase) * 0.1,
-    Math.cos(t * 0.8 + fase) * 0.09,
-  ];
-}
-
 /**
- * Un bicho de la librería, posado en la escena como billboard.
+ * Un bicho de la librería, posado en la escena como billboard. Su gesto lo dicta
+ * el ROL (o el `patron` explícito): polinizador salta de flor en flor, controlador
+ * patrulla en zigzag, descomponedor repta a ras.
  * @param {object} p
  * @param {'colibri'|'mariposa'|'escarabajo'|'lombriz'} p.tipo
  * @param {[number,number,number]} p.base  ancla en coordenadas de la escena.
  * @param {number}  [p.size=30]     tamaño en px del SVG (subordinado a Angelita).
- * @param {'revoloteo'|'reptar'} [p.patron='revoloteo']
+ * @param {'polinizador'|'controlador'|'descomponedor'} [p.rol]  rol ecológico.
+ * @param {'polinizar'|'patrulla'|'reptar'|'revoloteo'} [p.patron]  patrón directo (gana al rol).
  * @param {number}  [p.fase=0]      desfase del vaivén.
  * @param {number}  [p.df=7]        distanceFactor (misma escala que Angelita).
  * @param {string}  [p.title]       etiqueta (decorativa; el billboard es aria-hidden).
  * @param {boolean} [p.reducedMotion=false]
  */
 export function Bicho({
-  tipo, base, size = 30, patron = 'revoloteo', fase = 0, df = 7, title, reducedMotion = false,
+  tipo, base, size = 30, rol, patron, fase = 0, df = 7, title, reducedMotion = false,
 }) {
   const ref = useRef(null);
   const Comp = COMPS[tipo];
+  const gesto = patron || patronDeRol(rol);
   useFrame((state) => {
     if (reducedMotion || !ref.current) return;
-    const [dx, dy, dz] = deriva(patron, state.clock.elapsedTime, fase);
+    const [dx, dy, dz] = coreografia(gesto, state.clock.elapsedTime, fase);
     ref.current.position.set(base[0] + dx, base[1] + dy, base[2] + dz);
   });
   if (!Comp) return null;

--- a/src/visual/mundo3d/faunaFuncional.js
+++ b/src/visual/mundo3d/faunaFuncional.js
@@ -1,0 +1,199 @@
+/*
+ * faunaFuncional — la fauna de cada mundo, poblada por su ROL ECOLÓGICO.
+ *
+ * Antes la fauna de escena era decorativa (colibrí/mariposa/escarabajo genéricos
+ * revoloteando igual en todas partes). Aquí cada mundo puebla los animalitos que
+ * de verdad cumplen un ROL en ESE lugar, y el rol MANDA sobre el movimiento
+ * (contrato del DR: la escena posee la coreografía, la creature posee el cuerpo):
+ *
+ *   · polinizador  (colibrí / mariposa / abeja) → va de FLOR EN FLOR: se posa,
+ *     liba y salta en arco a la siguiente. Donde hay flor o cosecha con flor.
+ *   · controlador  (mariquita / carábido / avispa parasitoide) → PATRULLA en
+ *     zigzag buscando plaga. El enemigo natural que cuida la mata sin veneno.
+ *   · descomponedor (lombriz / escarabajo estercolero / colémbolo) → REPTA lento
+ *     a ras del suelo/hojarasca, cerrando el ciclo de la materia (abono).
+ *
+ * ES DATA-DRIVEN: la escena no sabe de ecología, solo pide `faunaDeMundo(id)` y
+ * anima cada bicho según su `patron` (derivado del rol). La CANTIDAD se recorta
+ * por device-tier (`perfilDeTier(tier).criaturas`) — menos individuos en gama
+ * baja, siempre POCOS y bien puestos (vida, no enjambre). El vaivén se congela
+ * con reduced-motion (eso lo gatea la escena; aquí solo se define el gesto).
+ *
+ * Contenido ecológico VERIFICADO por el pareo cultivo↔benéfico de la finca andina
+ * (mismo criterio que las escenas de sanidad/suelo/milpa). Módulo puro (sin R3F):
+ * la math de coreografía la comparten los billboards (FaunaEscena) y las mallas
+ * low-poly (la mariquita de sanidad, la avispa de la milpa).
+ */
+
+import { perfilDeTier } from './deviceTier.js';
+
+/* Los tres roles y su coreografía. `patron` es la clave que lee `coreografia()`. */
+export const ROLES = {
+  polinizador: { patron: 'polinizar', que: 'va de flor en flor y poliniza' },
+  controlador: { patron: 'patrulla', que: 'patrulla buscando plaga (enemigo natural)' },
+  descomponedor: { patron: 'reptar', que: 'repta a ras cerrando el ciclo del abono' },
+};
+
+/** El patrón de movimiento que le toca a un rol (desconocido → revoloteo suave). */
+export const patronDeRol = (rol) => ROLES[rol]?.patron || 'revoloteo';
+
+/* Onda triangular en [-1, 1], periodo 1: da vueltas con ESQUINAS (cambios de
+   rumbo secos) — el zigzag del que patrulla, no la curva suave del que pasea. */
+const tri = (x) => 2 * Math.abs(2 * (x - Math.floor(x + 0.5))) - 1;
+
+/* Los puntos-flor que visita el polinizador (offsets relativos al ancla). Un
+   ramillete corto: se salta entre ellos en bucle, siempre igual (determinista). */
+const FLORES = [
+  [0.30, 0.0, 0.12],
+  [-0.26, 0.07, -0.16],
+  [0.08, 0.13, 0.30],
+  [-0.30, 0.02, 0.22],
+];
+
+/**
+ * CoreografÍa por rol: el offset [dx, dy, dz] (unidades de escena) respecto del
+ * ancla, dado el tiempo `t` y una `fase` que desincroniza a cada bicho. Pura y
+ * determinista (estable en SSR/tests). Amplitudes chicas: vida, no espectáculo.
+ * @param {'polinizar'|'patrulla'|'reptar'|'revoloteo'} patron
+ * @param {number} t     segundos (clock.elapsedTime)
+ * @param {number} [fase]
+ * @returns {[number, number, number]}
+ */
+export function coreografia(patron, t, fase = 0) {
+  if (patron === 'reptar') {
+    // descomponedor: anda a ras, avance lento en x con un cabeceo mínimo.
+    return [Math.sin(t * 0.4 + fase) * 0.09, Math.abs(Math.sin(t * 1.1 + fase)) * 0.02, 0];
+  }
+
+  if (patron === 'patrulla') {
+    // controlador: barrido lateral con reversas secas (zigzag) + un vaivén en
+    // profundidad desfasado = recorrido en diente de sierra sobre el cultivo,
+    // zumbando bajito y alerta (el enemigo natural rastreando la plaga).
+    const u = t * 0.22 + fase;
+    return [
+      tri(u) * 0.34,
+      0.03 + Math.abs(Math.sin(t * 4 + fase)) * 0.03,
+      tri(u + 0.5) * 0.14,
+    ];
+  }
+
+  if (patron === 'polinizar') {
+    // polinizador: se posa y liba en una flor, luego SALTA en arco a la siguiente.
+    const period = 2.4; // segundos por flor (posa + salto)
+    const salto = 0.42; // fracción final del ciclo que dura el salto
+    const u = t * 0.5 + fase * 0.7;
+    const seg = Math.floor(u / period);
+    const f = (u % period) / period; // 0..1 dentro del segmento
+    let e; // avance hacia la próxima flor: 0 mientras liba, ease al saltar
+    if (f < 1 - salto) {
+      e = 0;
+    } else {
+      const g = (f - (1 - salto)) / salto;
+      e = g * g * (3 - 2 * g); // easeInOut
+    }
+    const a = FLORES[seg % FLORES.length];
+    const b = FLORES[(seg + 1) % FLORES.length];
+    const arco = Math.sin(e * Math.PI) * 0.14; // sube al despegar, baja al posarse
+    return [
+      a[0] + (b[0] - a[0]) * e,
+      a[1] + (b[1] - a[1]) * e + arco + Math.sin(t * 3 + fase) * 0.015,
+      a[2] + (b[2] - a[2]) * e,
+    ];
+  }
+
+  // revoloteo genérico (compat): vuelo suspendido, sube/baja y deriva apenas.
+  return [
+    Math.sin(t * 0.9 + fase) * 0.12,
+    Math.sin(t * 1.7 + fase) * 0.1,
+    Math.cos(t * 0.8 + fase) * 0.09,
+  ];
+}
+
+/*
+ * FAUNA FUNCIONAL POR MUNDO. Una entrada por mundo (clave = id de MUNDO); cada
+ * bicho declara su ROL (que fija el patrón) y su ancla en coordenadas de escena.
+ * Ordenados por PRIORIDAD ecológica (el rol insignia primero): así el recorte por
+ * device-tier deja siempre lo que mejor cuenta la lección de ese mundo.
+ *
+ * Los mundos de arquetipo `cutaway` (suelo · abono · milpa) NO se listan aquí:
+ * su fauna funcional la realiza EscenaCutaway de forma procedural y ya es
+ * correcta por rol — DESCOMPONEDORES (lombriz de tierra que asoma por el corte +
+ * escarabajo estercolero que anda la hojarasca) y, en la milpa, un POLINIZADOR
+ * (mariposa en la flor de la calabaza) más un CONTROLADOR (avispa parasitoide
+ * que patrulla sobre el maíz cazando el cogollero). Ver ese archivo.
+ */
+export const FAUNA_MUNDO = {
+  // 🐞 SANIDAD — la huerta-clínica: CONTROLADORES que patrullan (el carábido
+  //    depredador a ras) + POLINIZADORES en el borde de flores aromáticas. (Las
+  //    mariquitas insignia las patrulla EscenaSanidad como malla low-poly.)
+  sanidad: [
+    { tipo: 'escarabajo', rol: 'controlador', base: [0.28, 0.16, -0.52], size: 28, fase: 2.4, nombre: 'Carábido patrullando' },
+    { tipo: 'mariposa', rol: 'polinizador', base: [1.05, 0.66, 0.78], size: 28, fase: 0.4, nombre: 'Mariposa polinizando el borde' },
+    { tipo: 'colibri', rol: 'polinizador', base: [-0.85, 1.12, 0.42], size: 30, fase: 1.6, nombre: 'Colibrí polinizador' },
+  ],
+
+  // 💧 AGUA — la ribera viva: POLINIZADORES en las flores del monte de ronda y en
+  //    la huerta que se riega (el agua sostiene la floración, la flor al benéfico).
+  agua: [
+    { tipo: 'colibri', rol: 'polinizador', base: [-1.35, 1.75, 0.7], size: 30, fase: 0.4, nombre: 'Colibrí en flores de ribera' },
+    { tipo: 'mariposa', rol: 'polinizador', base: [-0.15, 0.98, 0.72], size: 30, fase: 1.6, nombre: 'Mariposa sobre la quebrada' },
+    { tipo: 'mariposa', rol: 'polinizador', base: [2.1, 0.35, -0.15], size: 28, fase: 3.0, nombre: 'Mariposa en la huerta regada' },
+  ],
+
+  // 🌳 DISEÑO — el bosque comestible por estratos: POLINIZADORES arriba (colibrí
+  //    del dosel, mariposa del sotobosque) y un DESCOMPONEDOR en la hojarasca de
+  //    la base (el escarabajo que recicla la materia caída). La verticalidad manda.
+  disenio: [
+    { tipo: 'colibri', rol: 'polinizador', base: [0.6, 3.0, 0.4], size: 28, fase: 0.5, nombre: 'Colibrí del dosel' },
+    { tipo: 'mariposa', rol: 'polinizador', base: [-0.9, 1.35, 0.6], size: 30, fase: 2.0, nombre: 'Mariposa del sotobosque' },
+    { tipo: 'escarabajo', rol: 'descomponedor', base: [0.8, 0.14, 1.0], size: 30, fase: 1.2, nombre: 'Escarabajo de la hojarasca' },
+  ],
+
+  // 🌡️ PISOS — la ladera altitudinal: POLINIZADORES en el aire templado/frío
+  //    (donde de veras vuelan). Bases pre-calculadas de pisoY(i)/pisoZ(i) de la
+  //    escena: piso 1 (templado) y piso 2 (frío). El páramo va SIN fauna (honestidad).
+  pisos: [
+    { tipo: 'mariposa', rol: 'polinizador', base: [-0.7, 1.9, 0.4], size: 30, fase: 1.4, nombre: 'Mariposa del piso templado' },
+    { tipo: 'colibri', rol: 'polinizador', base: [0.7, 3.05, -0.4], size: 28, fase: 0.6, nombre: 'Colibrí del piso frío' },
+  ],
+
+  // ⛅ CLIMA — la bóveda de día: POLINIZADORES cerca de la ladera. De noche no se
+  //    siembra fauna (la escena lo gatea con `esDia`).
+  clima: [
+    { tipo: 'colibri', rol: 'polinizador', base: [2.2, 1.5, 1.4], size: 28, fase: 0.6, nombre: 'Colibrí de la mañana' },
+    { tipo: 'mariposa', rol: 'polinizador', base: [-1.7, 0.9, 1.6], size: 30, fase: 2.2, nombre: 'Mariposa de la ladera' },
+  ],
+
+  // 🧺 MERCADO — la feria: POLINIZADORES entre las flores del puesto y la cosecha
+  //    (recordatorio de que sin polinizador no hay cosecha que vender).
+  mercado: [
+    { tipo: 'mariposa', rol: 'polinizador', base: [-1.15, 0.7, 0.55], size: 28, fase: 0.5, nombre: 'Mariposa entre las flores del puesto' },
+    { tipo: 'colibri', rol: 'polinizador', base: [1.2, 1.15, 0.3], size: 30, fase: 1.8, nombre: 'Colibrí sobre la plaza' },
+  ],
+
+  // 🐔 ANIMALES — el corral y su ciclo del abono: un DESCOMPONEDOR insignia (el
+  //    escarabajo estercolero que procesa el estiércol, cierra el anillo) +
+  //    POLINIZADORES por la cerca (las flores del borde del corral).
+  animales: [
+    { tipo: 'escarabajo', rol: 'descomponedor', base: [0.36, 0.18, 0.42], size: 30, fase: 0.5, nombre: 'Escarabajo estercolero' },
+    { tipo: 'colibri', rol: 'polinizador', base: [-0.7, 1.15, 0.5], size: 30, fase: 1.2, nombre: 'Colibrí del borde' },
+    { tipo: 'mariposa', rol: 'polinizador', base: [1.0, 0.62, 0.85], size: 28, fase: 2.6, nombre: 'Mariposa de la cerca' },
+  ],
+};
+
+/**
+ * La fauna funcional de un mundo, con el `patron` de cada bicho ya resuelto desde
+ * su rol y la lista RECORTADA al cupo del device-tier (menos individuos en gama
+ * baja; gama baja ni monta 3D, así que en la práctica el 3D solo poda en 'medio'
+ * si algún mundo trajera más bichos que su presupuesto). Orden = prioridad
+ * ecológica, así el recorte deja siempre el rol insignia.
+ * @param {string} mundoId  id de MUNDO (p.ej. 'sanidad', 'agua').
+ * @param {{ tier?: 'alto'|'medio'|'bajo', cupo?: number }} [opts]
+ * @returns {Array<object>} items listos para `<Fauna items=…>` (con `patron`).
+ */
+export function faunaDeMundo(mundoId, { tier, cupo } = {}) {
+  const lista = FAUNA_MUNDO[mundoId] || [];
+  const tope = typeof cupo === 'number' ? cupo : perfilDeTier(tier).criaturas;
+  const recortada = tope >= lista.length ? lista : lista.slice(0, Math.max(0, tope));
+  return recortada.map((f) => ({ ...f, patron: f.patron || patronDeRol(f.rol) }));
+}


### PR DESCRIPTION
## Qué

Fauna FUNCIONAL por mundo: cada escena 3D puebla los animalitos que cumplen un **rol ecológico real** ahí, y el rol dicta el movimiento. Antes la fauna era decorativa (colibrí/mariposa/escarabajo genéricos revoloteando igual en todas partes).

## Roles y coreografía

| Rol | Bichos | Movimiento |
|-----|--------|-----------|
| **Polinizador** | colibrí · mariposa | va de **flor en flor** (se posa, liba, salta en arco) |
| **Controlador** | mariquita · carábido · avispa parasitoide | **patrulla en zigzag** buscando plaga |
| **Descomponedor** | lombriz · escarabajo estercolero | **repta lento** a ras, cierra el ciclo del abono |

## Fauna por mundo (contenido ecológico verificado)

- **sanidad** (huerta-clínica): mariquitas insignia **patrullando** las matas + carábido depredador a ras (controladores) + polinizadores en el borde de flores aromáticas.
- **animales** (corral): escarabajo **estercolero** que procesa el estiércol (descomponedor, cierra el anillo del abono) + polinizadores por la cerca.
- **disenio** (bosque comestible): polinizadores en dosel/sotobosque + descomponedor en la hojarasca.
- **milpa** (cutaway): mariposa en la flor de la calabaza (polinizador) + **avispa parasitoide** (Trichogramma/Cotesia) patrullando sobre el maíz cazando el cogollero (Spodoptera).
- **agua**: polinizadores de ribera y huerta regada · **mercado**: polinizadores del puesto y la cosecha · **pisos**: polinizadores del templado/frío (páramo sin fauna) · **clima**: polinizadores de día.
- **suelo/abono** (cutaway): lombrices + escarabajo estercolero (descomponedores) — ya eran funcionales.

## Cómo

- Nuevo `src/visual/mundo3d/faunaFuncional.js`: roles, coreografía pura y determinista por patrón (compartida por los billboards de `FaunaEscena` y las mallas low-poly), fauna por mundo, y recorte por **device-tier** (`perfilDeTier(tier).criaturas` → menos individuos en gama baja).
- `FaunaEscena` delega el gesto en la coreografía de rol; `Bicho` acepta `rol`.
- `mundoId` se enhebra del host (`Mundo.jsx`) a cada escena para poblar por mundo.
- Gate **reduced-motion** (congela el vaivén) mantenido en todas las escenas.

## Verificación

- `npm run build` ✅ (verde; warnings de chunk-size preexistentes).
- Suite mundo3d: `vitest run src/visual/mundo3d/__tests__` → 27/27 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)