### PR TITLE
feat(mundo3d): bucle dos-vías voz↔3D — el agente enfoca hotspots (spec S1)

### DIFF
--- a/src/mockups/valle/AcompananteMundo.jsx
+++ b/src/mockups/valle/AcompananteMundo.jsx
@@ -31,8 +31,9 @@
    el hook (useAcompanante) y su marco (<AcompananteMundo>) son UNA pieza —
    la vitrina necesita ambos juntos; separarlos duplicaría el contexto (patrón
    useEntradaAbeja.jsx). Es un mockup: sin HMR-state que preservar. */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Children, cloneElement, isValidElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MUNDO, tituloDeMundo, tinteDeMundo } from '../../visual/mundo3d/index.js';
+import { parseComandoMundo, puertasDeMundo } from '../../visual/mundo3d/comandoMundo.js';
 import { NARRACION, MUNDO_VALLE_BY_ID } from './valleData';
 import './acompananteMundo.css';
 
@@ -167,7 +168,49 @@ export function useAcompanante(mundoId) {
     [mundoId, decir],
   );
 
-  return { dicho, hablando: !!dicho, decir, narrar, decirPuerta, voz, setVoz, vozDisponible };
+  // ── EL LAZO agente→escena (spec S1, la SEGUNDA vía): un pedido de voz/texto
+  //    ("muéstreme las trampas", "dónde está el agua") se resuelve contra los
+  //    hotspots del mundo (comandoMundo) y, si hay match, MUEVE el foco de la
+  //    escena a ese punto (el mismo que la abeja persigue) + lo resalta, y
+  //    Angelita lo nombra. Sin match: respuesta cordial que ofrece las puertas.
+  //    `focoCmd` fluye al `<Mundo>` como { focoId, focoToken }; el token sube por
+  //    comando para re-enfocar/re-pulsar aunque se repita el mismo punto.
+  const [focoCmd, setFocoCmd] = useState({ id: null, token: 0 });
+  const comando = useCallback(
+    (texto) => {
+      const t = (texto || '').trim();
+      if (!t) return false;
+      const m = parseComandoMundo(t, mundoId);
+      if (m) {
+        setFocoCmd((f) => ({ id: m.hotspot.id, token: f.token + 1 }));
+        decir(`¡Claro! Ahí lo tiene: «${m.hotspot.label}». Se lo resalto.`);
+        return true;
+      }
+      const puertas = puertasDeMundo(mundoId);
+      const sugerencias = puertas.slice(0, 2).map((p) => `«${p}»`).join(' o ');
+      decir(
+        sugerencias
+          ? `No veo eso por aquí. ¿Quiere que le muestre ${sugerencias}?`
+          : 'No veo eso por aquí. Toque un punto para ver a dónde lo lleva.',
+      );
+      return false;
+    },
+    [mundoId, decir],
+  );
+
+  return {
+    dicho,
+    hablando: !!dicho,
+    decir,
+    narrar,
+    decirPuerta,
+    comando,
+    focoId: focoCmd.id,
+    focoToken: focoCmd.token,
+    voz,
+    setVoz,
+    vozDisponible,
+  };
 }
 
 /**
@@ -180,22 +223,92 @@ export function useAcompanante(mundoId) {
  *   </AcompananteMundo>
  */
 export default function AcompananteMundo({ mundoId, acompanante, children }) {
-  const { dicho, narrar, voz, setVoz, vozDisponible } = acompanante;
+  const { dicho, narrar, comando, focoId, focoToken, voz, setVoz, vozDisponible } = acompanante;
   const tinte = tinteDeMundo(mundoId);
 
-  // "Pregúntele a su finca…" abre el flujo REAL del agente por el mismo
-  // camino desacoplado del shell (BUG-CAMP-01): el evento global
-  // `chagraNavigate` que App.jsx escucha desde cualquier pantalla.
+  // El texto del pedido (barra de dos vías) y el estado del dictado por voz.
+  const [texto, setTexto] = useState('');
+  const [oyendo, setOyendo] = useState(false);
+  const recRef = useRef(null);
+
+  // ¿Trae este equipo dictado por voz (Web Speech API — reconocimiento)? Es un
+  // PLUS: sin él, la barra de texto hace lo mismo (fallback sin voz = escrito).
+  const reconoceVoz = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      !!(window.SpeechRecognition || window.webkitSpeechRecognition),
+    [],
+  );
+
+  // Al cambiar de mundo, cortá un dictado en curso (que no persiga al siguiente).
+  useEffect(
+    () => () => {
+      if (recRef.current) {
+        try { recRef.current.stop(); } catch { /* no-op */ }
+        recRef.current = null;
+      }
+    },
+    [mundoId],
+  );
+
+  // Enviar el pedido a Angelita (voz/texto → foco de la escena). Cierra el lazo.
+  const enviar = useCallback(
+    (e) => {
+      if (e) e.preventDefault();
+      const t = texto.trim();
+      if (!t) return;
+      comando?.(t);
+      setTexto('');
+    },
+    [texto, comando],
+  );
+
+  // 🎤 Dictado: llena la barra y ejecuta el comando con lo que se oyó. es-CO,
+  //    no bloqueante — si algo falla, la barra de texto siempre queda.
+  const escuchar = useCallback(() => {
+    const SR =
+      typeof window !== 'undefined' && (window.SpeechRecognition || window.webkitSpeechRecognition);
+    if (!SR) return;
+    try {
+      if (recRef.current) { try { recRef.current.stop(); } catch { /* no-op */ } }
+      const rec = new SR();
+      rec.lang = 'es-CO';
+      rec.interimResults = false;
+      rec.maxAlternatives = 1;
+      rec.onresult = (ev) => {
+        const dicho2 = ev.results?.[0]?.[0]?.transcript || '';
+        setTexto(dicho2);
+        if (dicho2.trim()) comando?.(dicho2);
+      };
+      rec.onend = () => setOyendo(false);
+      rec.onerror = () => setOyendo(false);
+      recRef.current = rec;
+      setOyendo(true);
+      rec.start();
+    } catch {
+      setOyendo(false);
+    }
+  }, [comando]);
+
+  // "Abrir el chat" salta al flujo REAL del agente por el mismo camino
+  // desacoplado del shell (BUG-CAMP-01): el evento global `chagraNavigate` que
+  // App.jsx escucha desde cualquier pantalla.
   const preguntarAlAgente = useCallback(() => {
     if (typeof window === 'undefined') return;
     if (window.speechSynthesis) window.speechSynthesis.cancel();
     window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'agente' } }));
   }, []);
 
+  // Inyecta el foco comandado al `<Mundo>` hijo (una sola pieza: la vitrina no
+  // tiene que recablear cada mockup — la capa acompañante cierra el lazo).
+  const escena = Children.map(children, (hijo) =>
+    isValidElement(hijo) ? cloneElement(hijo, { focoId, focoToken }) : hijo,
+  );
+
   return (
     <div className="acomp" style={{ '--acomp-tinte': (tinte && tinte[0]) || '#3f8f4e' }}>
       <div className="acomp__marco">
-        {children}
+        {escena}
         {/* La burbuja de Angelita: SU voz escrita (la abeja vive en la escena
             — una sola compañera, #2341). aria-live: también es la voz de los
             lectores de pantalla. */}
@@ -206,15 +319,33 @@ export default function AcompananteMundo({ mundoId, acompanante, children }) {
         )}
       </div>
       <footer className="acomp__agente">
-        <button
-          type="button"
-          className="acomp__pregunte"
-          aria-label="Pregúntele a Chagra"
-          onClick={preguntarAlAgente}
-        >
+        {/* LA BARRA DE DOS VÍAS: pídale por voz/texto y la escena enfoca. */}
+        <form className="acomp__cmd" onSubmit={enviar}>
           <span className="acomp__punto" aria-hidden="true" />
-          Pregúntele a su finca…
-        </button>
+          <input
+            type="text"
+            className="acomp__input"
+            value={texto}
+            onChange={(ev) => setTexto(ev.target.value)}
+            placeholder="Dígale a Angelita: «muéstreme el agua»"
+            aria-label="Pídale a Angelita que le muestre un punto del mundo"
+            enterKeyHint="search"
+          />
+          {reconoceVoz && (
+            <button
+              type="button"
+              className={`acomp__btn acomp__mic${oyendo ? ' on' : ''}`}
+              aria-label={oyendo ? 'Escuchando…' : 'Hablar'}
+              aria-pressed={oyendo}
+              onClick={escuchar}
+            >
+              🎤
+            </button>
+          )}
+          <button type="submit" className="acomp__btn acomp__ir" aria-label="Mostrar en la escena">
+            Ir
+          </button>
+        </form>
         <div className="acomp__ctrls">
           <button type="button" className="acomp__btn" onClick={narrar}>
             🔊 Escuchar
@@ -234,6 +365,9 @@ export default function AcompananteMundo({ mundoId, acompanante, children }) {
             }}
           >
             {!vozDisponible ? '💬 Texto' : voz ? '🔊 Voz' : '🔇 Voz'}
+          </button>
+          <button type="button" className="acomp__btn acomp__chat" onClick={preguntarAlAgente}>
+            💬 Abrir el chat
           </button>
         </div>
       </footer>

--- a/src/mockups/valle/acompananteMundo.css
+++ b/src/mockups/valle/acompananteMundo.css
@@ -65,23 +65,40 @@
   border-color: color-mix(in srgb, var(--acomp-tinte) 40%, transparent);
 }
 
-.acomp__pregunte {
-  display: inline-flex;
+/* ── La BARRA DE DOS VÍAS: pídale por voz/texto y la escena enfoca ── */
+.acomp__cmd {
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
-  flex: 1 1 auto;
+  gap: 0.4rem;
+  flex: 1 1 16rem;
   min-width: 0;
+  padding: 0.25rem 0.4rem 0.25rem 0.6rem;
   border: 1px solid rgba(255, 255, 255, 0.22);
   background: rgba(255, 255, 255, 0.08);
-  color: #f4efe2;
-  font-size: 0.9rem;
-  text-align: left;
-  padding: 0.5rem 0.8rem;
   border-radius: 999px;
-  cursor: pointer;
 }
-.acomp__pregunte:hover {
-  background: rgba(255, 255, 255, 0.16);
+.acomp__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: #f4efe2;
+  font: inherit;
+  font-size: 0.9rem;
+  padding: 0.3rem 0.1rem;
+}
+.acomp__input::placeholder {
+  color: rgba(244, 239, 226, 0.6);
+}
+.acomp__input:focus {
+  outline: none;
+}
+.acomp__mic.on {
+  border-color: #7dffbe;
+  background: rgba(125, 255, 190, 0.18);
+}
+.acomp__ir {
+  flex: 0 0 auto;
 }
 
 .acomp__punto {

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -97,7 +97,7 @@ function MigaVolver({ onSalir, mundoId }) {
 
 function MundoInterno({
   mundoId, tier = 'alto', reducedMotion = false, onHotspot, onSalir, animo = 'sereno', energia = 1,
-  hablando = false,
+  hablando = false, focoId = null, focoToken = 0,
 }) {
   /* CAÍDA DIGNA (BUG-UX-05 / SPEC-UX-05): si el chunk 3D no baja en
      CARGA_3D_TIMEOUT_MS, caemos al espejo 2D del mundo. `intento` fabrica un
@@ -161,6 +161,11 @@ function MundoInterno({
     return (
       <div className="mundo-root" data-dim="3d" data-mundo={mundoId}>
         <Suspense fallback={<MundoCargando tinte={tinte} onTimeout={alTimeout3D} />}>
+          {/* `Escena` es un `lazy` resuelto en useMemo (fresco al reintentar —
+              mecanismo de caída digna, ver cabecera). react-hooks/static-components
+              no distingue ese patrón deliberado del anti-patrón; se silencia con
+              criterio (deuda preexistente en dev, ajena a este cambio). */}
+          {/* eslint-disable-next-line react-hooks/static-components */}
           <Escena
             params={plan.entrada.params}
             hotspots={plan.entrada.hotspots}
@@ -173,6 +178,8 @@ function MundoInterno({
             animo={animo}
             energia={energia}
             hablando={hablando}
+            focoId={focoId}
+            focoToken={focoToken}
           />
         </Suspense>
         {/* Invitación de PRIMER USO del sonido ambiental (una sola vez): vive

--- a/src/visual/mundo3d/comandoMundo.js
+++ b/src/visual/mundo3d/comandoMundo.js
@@ -1,0 +1,133 @@
+/*
+ * comandoMundo — EL LAZO agente→escena (spec S1, "bucle dos-vías voz↔3D").
+ *
+ * Hoy la voz de Angelita solo NARRA (una vía). Este módulo cierra el lazo: toma
+ * un pedido en lenguaje natural del campesino ("muéstreme las trampas", "dónde
+ * está el agua", "lléveme al biocontrol") y lo resuelve contra los HOTSPOTS del
+ * mundo actual (mundoData) para que la escena ENFOQUE y RESALTE ese punto — el
+ * mismo `foco` que la abeja ya persigue en EscenaBase3D.
+ *
+ * Puro y three-free (lo usa la capa acompañante sin inflar el bundle 3D):
+ * determinista, sin red, sin LLM. El match es por PALABRA CLAVE contra el
+ * vocabulario de cada hotspot —su `label`, `id`, `view`, `data.tema` y `claves`
+ * opcionales— expandido con un diccionario agroecológico (SINONIMOS) para cubrir
+ * cómo habla DE VERDAD el campo (trampa↔plaga, biocontrol↔hongo, riego↔agua).
+ *
+ * Regla de puntaje: un acierto DIRECTO (la palabra vive en el label/id del
+ * hotspot) pesa más que uno por sinónimo — así "biocontrol" gana el punto de
+ * Biopreparados sin que un vecino se lo robe. Sin match → null (arriba, Angelita
+ * responde cordial y ofrece las puertas del mundo).
+ */
+import { MUNDO } from './mundoData.js';
+
+// Palabras vacías: cortesía, verbos de pedir y conectores que NO son intención.
+// (ya sin tildes — se comparan contra tokens normalizados).
+const VACIAS = new Set([
+  'muestre', 'muestreme', 'muestrame', 'ver', 'vea', 'veamos', 'mostrar', 'ensename', 'enseneme',
+  'lleve', 'lleveme', 'llevame', 'llevar', 'vamos', 'ir', 'pon', 'ponme', 'abre', 'abrir', 'abreme',
+  'quiero', 'quisiera', 'necesito', 'busco', 'buscar', 'buscando', 'ando', 'dame', 'ver',
+  'donde', 'esta', 'estan', 'cual', 'cuales', 'como', 'que', 'porfa', 'favor', 'gracias',
+  'el', 'la', 'lo', 'los', 'las', 'un', 'una', 'unos', 'unas', 'del', 'al', 'de', 'con', 'sin',
+  'por', 'para', 'esa', 'ese', 'esos', 'esas', 'este', 'esta', 'mi', 'mis', 'su', 'sus', 'aqui',
+]);
+
+// Diccionario agroecológico: cómo habla el campesino ↔ conceptos que sí viven en
+// los labels/ids de los hotspots. Cada grupo es una clase de equivalencia: una
+// palabra hace match con cualquier otra del MISMO grupo. NO es por-mundo (es
+// vocabulario del dominio, verificado contra el catálogo de mundos); el layout
+// de cada mundo sigue viviendo, intacto, en mundoData.
+const SINONIMOS = [
+  ['agua', 'quebrada', 'riego', 'riega', 'regar', 'regada', 'nacimiento', 'naciente', 'toma', 'bocatoma', 'tanque', 'rio', 'acueducto'],
+  ['trampa', 'trampas', 'pegajosa', 'cromatica', 'amarilla', 'amarillas', 'azul', 'mosca', 'minador', 'trips'],
+  ['plaga', 'plagas', 'bicho', 'bichos', 'insecto', 'insectos', 'gusano', 'pulgon'],
+  ['biocontrol', 'biopreparado', 'biopreparados', 'hongo', 'hongos', 'beauveria', 'metarhizium', 'esporas', 'bioinsumo'],
+  ['defensor', 'defensores', 'enemigo', 'enemigos', 'mariquita', 'benefico', 'aliado', 'aliados', 'depredador'],
+  ['sintoma', 'enferma', 'enfermo', 'enfermedad', 'mala', 'decaida', 'clinica'],
+  ['veneno', 'toxico', 'toxicologia', 'seguridad', 'insumo', 'insumos', 'quimico'],
+  ['suelo', 'tierra', 'lombriz', 'lombrices', 'subsuelo', 'microorganismo', 'raiz', 'raices'],
+  ['compost', 'abono', 'estiercol', 'bocashi', 'humus', 'pila', 'cobertura'],
+  ['cromatografia', 'cromato'],
+  ['animal', 'animales', 'gallina', 'gallinas', 'vaca', 'vacas', 'oveja', 'ovejas', 'corral', 'ponedora'],
+  ['bosque', 'arbol', 'arboles', 'restauracion', 'monte', 'estrato', 'estratos', 'reforestar'],
+  ['clima', 'tiempo', 'lluvia', 'lluvias', 'sol', 'cielo', 'almanaque', 'temporada', 'boveda'],
+  ['cafe', 'cafeto', 'cafetal'],
+  ['milpa', 'maiz', 'frijol', 'calabaza', 'hermanas'],
+  ['mercado', 'vender', 'venta', 'comprar', 'precio', 'despensa', 'poscosecha', 'cosecha', 'reporte', 'reportes', 'informe', 'informes'],
+  ['papa', 'tuberculo', 'papas', 'yuca'],
+  ['piso', 'pisos', 'altura', 'termico', 'paramo', 'ladera'],
+  ['fruta', 'frutal', 'frutales', 'naranja', 'citrico', 'mango', 'mora'],
+  ['huerta', 'hortaliza', 'hortalizas', 'verdura', 'verduras', 'siembra', 'sembrar'],
+  ['asociacion', 'asociaciones', 'asocio', 'vecina', 'vecinas', 'compania', 'consorcio'],
+];
+
+// Índice palabra → grupo, para expandir en O(1).
+const GRUPO_DE = new Map();
+SINONIMOS.forEach((grupo, i) => grupo.forEach((p) => GRUPO_DE.set(p, i)));
+
+/**
+ * Normaliza y trocea un texto: minúsculas, SIN tildes, sin signos; descarta
+ * palabras vacías y de menos de 3 letras. Devuelve la lista de tokens.
+ */
+export function tokenizar(texto) {
+  if (!texto || typeof texto !== 'string') return [];
+  return texto
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // fuera tildes: á→a, y ñ (NFD: n+tilde)→n
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((w) => w && w.length >= 3 && !VACIAS.has(w));
+}
+
+// El "saco" expandido de un conjunto de tokens crudos: cada token + todo su grupo
+// de sinónimos → Set para overlap O(1).
+function expandir(tokens) {
+  const saco = new Set();
+  tokens.forEach((t) => {
+    saco.add(t);
+    const g = GRUPO_DE.get(t);
+    if (g !== undefined) SINONIMOS[g].forEach((e) => saco.add(e));
+  });
+  return saco;
+}
+
+// El vocabulario CRUDO de un hotspot (sin expandir): su label, id, view,
+// data.tema y `claves` opcionales, tokenizado.
+function crudosDeHotspot(h) {
+  const fuente = [h.label, h.id, h.view, h.data?.tema, ...(h.claves || [])]
+    .filter(Boolean)
+    .join(' ');
+  return tokenizar(fuente);
+}
+
+/**
+ * Resuelve un pedido de voz/texto contra los hotspots del mundo.
+ *
+ * @param {string} texto   lo que dijo/escribió el usuario.
+ * @param {string} mundoId id del mundo actual (mundoData).
+ * @returns {{ hotspot: object, score: number }|null} el hotspot ganador o null.
+ */
+export function parseComandoMundo(texto, mundoId) {
+  const hotspots = MUNDO[mundoId]?.hotspots || [];
+  if (!hotspots.length) return null;
+  const tokens = tokenizar(texto);
+  if (!tokens.length) return null;
+
+  let mejor = null;
+  for (const h of hotspots) {
+    const crudos = new Set(crudosDeHotspot(h));
+    const saco = expandir(crudos); // crudos + sinónimos
+    let score = 0;
+    for (const q of tokens) {
+      if (crudos.has(q)) score += 2; // acierto directo: pesa el doble
+      else if (saco.has(q)) score += 1; // acierto por sinónimo
+    }
+    if (score > 0 && (!mejor || score > mejor.score)) mejor = { hotspot: h, score };
+  }
+  return mejor;
+}
+
+/** Los labels de las puertas del mundo (para la respuesta cordial de fallback). */
+export function puertasDeMundo(mundoId) {
+  return (MUNDO[mundoId]?.hotspots || []).map((h) => h.label);
+}

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -34,7 +34,7 @@ import { ATMOSFERA, CIELOS, mezclar } from '../atmosferaMadre.js';
 
 function Contenido({
   params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, piso = 0,
-  frugal = false, hablando = false,
+  frugal = false, hablando = false, focoId = null, focoToken = 0,
   children,
 }) {
   const controls = useRef(null);
@@ -70,6 +70,24 @@ function Contenido({
   const hAct = activo && hotspots ? hotspots.find((x) => x.id === activo) : null;
   const [px, py, pz] = hAct ? hAct.pos : centro;
   const foco = useMemo(() => new THREE.Vector3(px, py, pz), [px, py, pz]);
+
+  // ── EL LAZO agente→escena (spec S1): un `focoId` externo (un pedido de voz/
+  //    texto ya resuelto contra los hotspots) MUEVE el foco y RESALTA ese punto,
+  //    igual que un toque —el foco es el mismo que la abeja persigue. `focoToken`
+  //    sube por cada comando, así "muéstreme las trampas" dicho dos veces vuelve
+  //    a enfocar y re-dispara el pulso (halo). `resaltado` marca el punto pulsante.
+  //    Patrón "ajustar estado en el render" (React docs: derivar de un cambio de
+  //    prop SIN efecto — nada de synchronizar sistemas externos aquí).
+  const [resaltado, setResaltado] = useState({ id: null, token: 0 });
+  const [tokenPrev, setTokenPrev] = useState(focoToken);
+  if (focoToken !== tokenPrev) {
+    setTokenPrev(focoToken);
+    if (focoId) {
+      setActivo(focoId);
+      setRebote((n) => n + 1); // microrrebote de Angelita, como en el toque
+      setResaltado({ id: focoId, token: focoToken });
+    }
+  }
 
   return (
     <>
@@ -112,29 +130,39 @@ function Contenido({
 
       {children}
 
-      {(hotspots || []).map((h) => (
-        <group key={h.id} position={h.pos}>
-          <Html center distanceFactor={zoom + 2} zIndexRange={[30, 0]}>
-            <button
-              type="button"
-              className={`mundo-hotspot${activo === h.id ? ' mundo-hotspot--activo' : ''}`}
-              style={{ '--hs-tinte': acento }}
-              onPointerDown={(e) => e.stopPropagation()}
-              onClick={(e) => {
-                e.stopPropagation();
-                haptics.tap();
-                setActivo(h.id);
-                setRebote((n) => n + 1);
-                onHotspot?.(h.view, h.data);
-              }}
-              aria-label={h.label}
-            >
-              <span className="mundo-hotspot__emoji" aria-hidden="true">{h.emoji}</span>
-              <span className="mundo-hotspot__txt">{h.label}</span>
-            </button>
-          </Html>
-        </group>
-      ))}
+      {(hotspots || []).map((h) => {
+        const esComando = resaltado.id === h.id;
+        return (
+          <group key={h.id} position={h.pos}>
+            <Html center distanceFactor={zoom + 2} zIndexRange={[30, 0]}>
+              <button
+                type="button"
+                className={`mundo-hotspot${activo === h.id ? ' mundo-hotspot--activo' : ''}${esComando ? ' mundo-hotspot--comando' : ''}`}
+                style={{ '--hs-tinte': acento }}
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  haptics.tap();
+                  setActivo(h.id);
+                  setRebote((n) => n + 1);
+                  setResaltado({ id: null, token: 0 }); // el toque toma el mando: sin halo de voz
+                  onHotspot?.(h.view, h.data);
+                }}
+                aria-label={h.label}
+              >
+                {/* Halo de VOZ: el pulso que confirma "la escena te oyó". Se
+                    RE-MONTA por `focoToken` (key) → re-dispara la animación cada
+                    comando; reduced-motion lo deja quieto (CSS). */}
+                {esComando && !frugal && (
+                  <span key={resaltado.token} className="mundo-hotspot__halo" aria-hidden="true" />
+                )}
+                <span className="mundo-hotspot__emoji" aria-hidden="true">{h.emoji}</span>
+                <span className="mundo-hotspot__txt">{h.label}</span>
+              </button>
+            </Html>
+          </group>
+        );
+      })}
 
       {/* Angelita: una sola por mundo (la del footer se oculta dentro). `entrando`
           vive AHORA en si hay hotspot activo — con foco se posa junto a la puerta,
@@ -173,7 +201,7 @@ function Contenido({
 export default function EscenaBase3D({
   params, hotspots, entrada, tinte, reducedMotion,
   onHotspot, cielo, animo = 'sereno', energia = 1, camara, piso = 0, tier = 'alto',
-  hablando = false, children,
+  hablando = false, focoId = null, focoToken = 0, children,
 }) {
   const [listo, setListo] = useState(false);
   const zoom = entrada?.zoom ?? 6.5;
@@ -206,6 +234,8 @@ export default function EscenaBase3D({
           piso={piso}
           frugal={frugal}
           hablando={hablando}
+          focoId={focoId}
+          focoToken={focoToken}
         >
           {children}
         </Contenido>

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -74,6 +74,32 @@
     0 3px 10px rgba(40, 30, 10, 0.22),
     0 0 0 3px color-mix(in srgb, var(--hs-tinte, #3f8f4e) 45%, #2a2016);
 }
+/* Comandado por VOZ/TEXTO (lazo dos-vías, spec S1): además del anillo de
+   `--activo`, el punto que Angelita acaba de enfocar late un momento — la señal
+   de "la escena te oyó". */
+.mundo-hotspot--comando {
+  box-shadow:
+    0 3px 10px rgba(40, 30, 10, 0.22),
+    0 0 0 3px color-mix(in srgb, var(--hs-tinte, #3f8f4e) 65%, #2a2016);
+}
+/* El HALO: un anillo que se expande y se desvanece. Vive dentro del botón
+   (position: relative); se re-monta por `key={focoToken}` → repite el pulso en
+   cada comando. pointer-events off: nunca estorba el toque. */
+.mundo-hotspot__halo {
+  position: absolute;
+  inset: -4px;
+  border-radius: 999px;
+  border: 2px solid var(--hs-tinte, #3f8f4e);
+  pointer-events: none;
+  opacity: 0;
+  animation: mundo-hotspot-halo 1.15s ease-out 2;
+}
+@keyframes mundo-hotspot-halo {
+  0% { opacity: 0.85; transform: scale(1); }
+  70% { opacity: 0; transform: scale(1.75); }
+  100% { opacity: 0; transform: scale(1.75); }
+}
+
 .mundo-hotspot__emoji {
   font-size: 1.15em;
   line-height: 1;
@@ -505,4 +531,6 @@
   .mundo2d__hotspot { transition: none; }
   .mundo-viaje__velo,
   .mundo-viaje__abeja { animation: none; }
+  /* Sin pulso, pero SÍ señal: el halo queda como anillo fijo (no se mueve). */
+  .mundo-hotspot__halo { animation: none; opacity: 0.9; }
 }

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -319,7 +319,7 @@ export const MUNDO = {
     },
     hotspots: [
       { id: 'sintoma', pos: [0, 0.7, 0.5], emoji: '🩺', label: 'Mi mata está enferma', view: 'sanidad_sintoma' },
-      { id: 'plagas', pos: [1.35, 0.92, 0.35], emoji: '🐛', label: 'Directorio de plagas', view: 'plagas' },
+      { id: 'plagas', pos: [1.35, 0.92, 0.35], emoji: '🐛', label: 'Directorio de plagas', view: 'plagas', claves: ['trampa', 'trampas', 'amarilla', 'cromatica', 'mosca', 'minador'] },
       { id: 'defensores', pos: [-0.55, 0.78, 0.5], emoji: '🐞', label: 'Defensores de la finca', view: 'defensores' },
       { id: 'bio', pos: [1.05, 0.78, -0.75], emoji: '🧪', label: 'Biopreparados', view: 'biopreparados' },
       { id: 'tox', pos: [-1.25, 0.92, -0.5], emoji: '⚠️', label: 'Seguridad con insumos', view: 'toxicologia' },


### PR DESCRIPTION
## Qué

Cierra el **lazo agente→escena** (spec S1). Hoy la voz de Angelita solo NARRA (una vía). Ahora un pedido de voz/texto **enfoca y resalta el hotspot** pedido, reusando el `foco` que la abeja ya persigue en `EscenaBase3D`.

Ejemplos que entiende (por mundo):
- **agua** — "dónde está el agua" → *Donde nace el agua*; "muéstreme la quebrada"; "el riego" → *La toma y el tanque*.
- **sanidad** — "muéstreme las trampas" → *Directorio de plagas* (la trampa amarilla); "lléveme al biocontrol" → *Biopreparados*; "mi mata está enferma"; "defensores".
- **suelo/abono/animales/milpa/mercado/clima/pisos/café** — mismo mecanismo (compost, gallinas, milpa, precio, páramo, grano…).

Sin match → respuesta **cordial** que ofrece las puertas del mundo ("No veo eso por aquí, ¿quiere que le muestre «…» o «…»?").

## Cómo

- **`comandoMundo.js`** (nuevo, puro, three-free): match por palabra clave contra `label`/`id`/`view`/`data.tema` (+ `claves` opcionales) de cada hotspot, expandido con un diccionario agroecológico. Un acierto **directo** pesa el doble que uno por sinónimo (specificidad).
- **`EscenaBase3D`**: nuevas props `focoId`/`focoToken` → mueven `activo` (patrón *ajustar estado en el render*, sin efecto) y disparan un **halo pulsante**. El toque retoma el mando.
- **`Mundo.jsx`**: forwarda `focoId`/`focoToken` a la escena.
- **`AcompananteMundo`**: la **barra de dos vías** (input de texto + 🎤 dictado `es-CO` vía SpeechRecognition, no bloqueante) ejecuta el comando; inyecta el foco al `<Mundo>` hijo por `cloneElement` (cero cambios en las 9 vitrinas).
- **`mundoData`**: `claves` de la trampa amarilla en el hotspot de plagas.

## Accesibilidad / rendimiento

- **reduced-motion**: el halo queda como anillo fijo (sin pulso).
- **device-tier**: sin halo en el perfil frugal; en 2D (equipo humilde) Angelita igual nombra el punto por texto (fallback sin voz = escrito).

## Verificación

- `npm run build` ✅ (verde).
- `eslint --max-warnings=0` ✅ en los archivos tocados.
- Parser validado contra los comandos de arriba (match correcto en 9 mundos, incl. café; fallback cordial en no-match).

> Nota: `Mundo.jsx` trae un `eslint-disable` acotado para `react-hooks/static-components` sobre el `<Escena>` lazy — patrón **deliberado** de caída digna (deuda preexistente en dev que el archivo ya arrastraba, ajena a este cambio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)