### PR TITLE
feat(mundo3d): mundo SEMILLERO/VIVERO 3D (germinación · repique · endurecimiento)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -105,6 +105,11 @@ const Mundo3DMercadoMockup = lazy(() => import('./mockups/Mundo3DMercado'));
 // (guamo/nogal), el grano cereza→pergamino→oro (sin tostar en finca), roya/broca
 // con manejo agroecológico y el beneficio. El 3D va perezoso (vendor-three).
 const Mundo3DCafeMockup = lazy(() => import('./mockups/Mundo3DCafe'));
+// 3D: "El mundo del semillero" — monta <Mundo mundoId="semillero"> del
+// framework: el semillero/vivero (arquetipo nuevo `semillero`, familia recinto):
+// germinación en bandeja, repique a bolsa, endurecimiento, semilla propia vs
+// comprada y el túnel de media-sombra. El 3D va perezoso (vendor-three).
+const Mundo3DSemilleroMockup = lazy(() => import('./mockups/Mundo3DSemillero'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -520,6 +525,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo3d-sanidad': 'mockup_mundo3d_sanidad',
   'mockups/mundo3d-mercado': 'mockup_mundo3d_mercado',
   'mockups/mundo3d-cafe': 'mockup_mundo3d_cafe',
+  'mockups/mundo3d-semillero': 'mockup_mundo3d_semillero',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1643,6 +1649,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del café">
               <Mundo3DCafeMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo3d_semillero':
+        // Vitrina pública del MUNDO DEL SEMILLERO: monta <Mundo mundoId="semillero">
+        // del framework (src/visual/mundo3d) con device-tiering real. Ruta
+        // #/mockups/mundo3d-semillero, sin auth. El semillero/vivero: germinación
+        // en bandeja (sustrato + humedad), repique a bolsa/era, endurecimiento al
+        // sol, semilla propia vs comprada y el túnel de media-sombra que protege
+        // del frío y la lluvia.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo del semillero">
+              <Mundo3DSemilleroMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/dashboard/MundoVinetas.jsx
+++ b/src/components/dashboard/MundoVinetas.jsx
@@ -585,6 +585,42 @@ function VinetaMango() {
     );
 }
 
+/** 🌱 Semillero y vivero — túnel de media-sombra, bandeja germinadora y plántulas. */
+function VinetaSemillero() {
+    return (
+        <svg {...SVG_PROPS}>
+            <rect width="180" height="90" fill="#e6f0cf" />
+            {/* sol tibio de mañana */}
+            <circle cx="152" cy="20" r="10" fill="#ffe8a6" />
+            <circle cx="152" cy="20" r="6" fill="#fff4cf" />
+            {/* piso del vivero */}
+            <path d="M-4 60 Q60 52 120 58 T184 54 V90 H-4 Z" fill="#b7c98a" />
+            <path d="M-4 72 Q70 64 184 70 V90 H-4 Z" fill="#8ea85e" />
+            {/* el túnel de media-sombra: arco traslúcido + costillas */}
+            <path d="M22 74 A46 40 0 0 1 114 74 Z" fill="#c7e0a0" opacity=".55" />
+            <g stroke="#8a6a44" strokeWidth="3" fill="none" strokeLinecap="round">
+                <path d="M22 74 A46 40 0 0 1 114 74" />
+                <path d="M40 74 A28 34 0 0 1 96 74" opacity=".8" />
+                <path d="M56 74 A12 30 0 0 1 80 74" opacity=".6" />
+            </g>
+            {/* la bandeja germinadora con brotes por etapa */}
+            <rect x="42" y="66" width="52" height="10" rx="2" fill="#5a4326" />
+            <rect x="44" y="64" width="48" height="4" fill="#3a2c1c" />
+            <g stroke="#3f8f4e" strokeWidth="2.4" strokeLinecap="round" fill="none">
+                <path d="M50 64 v-4" /><path d="M58 64 v-6" /><path d="M66 64 v-8" />
+                <path d="M74 64 v-9 M74 61 q4 -1 5 -4" /><path d="M84 64 v-10 M84 60 q-4 -1 -5 -4 M84 58 q4 -1 5 -4" />
+            </g>
+            {/* la bolsa del repique en primer plano (plántula ya crecida) */}
+            <g transform="translate(140 62)">
+                <path d="M-9 16 L-7 2 L7 2 L9 16 Z" fill="#2a2622" />
+                <path d="M0 2 v-14" stroke="#5a6a2e" strokeWidth="2.6" strokeLinecap="round" fill="none" />
+                <path d="M0 -6 q-6 -2 -8 -8" stroke="#3f8f4e" strokeWidth="2.6" strokeLinecap="round" fill="none" />
+                <path d="M0 -9 q6 -2 8 -8" stroke="#3f8f4e" strokeWidth="2.6" strokeLinecap="round" fill="none" />
+            </g>
+        </svg>
+    );
+}
+
 /** Viñeta por id de mundo (fuente única para tarjeta + pantalla de mundo). */
 const VINETAS = {
     cultivos: VinetaCultivos,
@@ -602,6 +638,7 @@ const VINETAS = {
     animales: VinetaAnimales,
     mercado: VinetaMercado,
     disenio: VinetaDisenio,
+    semillero: VinetaSemillero,
 };
 
 /**

--- a/src/components/dashboard/mundosFinca.js
+++ b/src/components/dashboard/mundosFinca.js
@@ -261,6 +261,21 @@ export const MUNDOS_FINCA = [
             { view: 'seguimiento_paramo', label: 'Páramo', desc: 'Conservación del páramo y su agua', emoji: '🏔️' },
         ],
     },
+    {
+        id: 'semillero',
+        titulo: 'Semillero y vivero',
+        emoji: '🌱',
+        lema: 'Del grano a la plántula: germine, repique y endurezca antes de llevar al campo',
+        // Verde tierno de vivero (distinto del verde de trabajo de Cultivos).
+        tinte: ['#4f9d5b', '#e6f0cf'],
+        entradas: [
+            { view: 'germinacion', label: 'Semilleros: qué nace', desc: 'Ponga a germinar en bandeja, con sustrato suelto y humedad, y vea cuáles semillas prenden', emoji: '🫘' },
+            { view: 'semilla', label: 'Semilla propia', desc: 'Seleccione, guarde y pruebe su semilla criolla — cuándo le sale mejor que la comprada', emoji: '🌾' },
+            { view: 'sembrar', label: 'Repicar y llevar al campo', desc: 'Anote el trasplante de la bandeja a la bolsa o la era, y de ahí al lote', emoji: '🌱' },
+            { view: 'ciclo', label: 'Cómo va la matica', desc: 'La vida de la plántula etapa por etapa, del brote al endurecimiento', emoji: '🔄' },
+            { view: 'calendario_finca', label: 'Cuándo sembrar', desc: 'Las fechas de semillero y trasplante para su clima', emoji: '🗓️' },
+        ],
+    },
 ];
 
 /** Mapa id → mundo, para resolver desde la ruta 'mundo'. */

--- a/src/mockups/Mundo3DSemillero.css
+++ b/src/mockups/Mundo3DSemillero.css
@@ -1,0 +1,152 @@
+/*
+ * Mundo3DSemillero.css — vitrina pública del mundo del semillero
+ * (#/mockups/mundo3d-semillero). Autocontenida: sin fuentes/imágenes externas.
+ * Móvil-first desde 320px. Solo opacity/transform animables; reduced-motion las
+ * apaga.
+ */
+
+.m3dsem {
+  --m3dsem-a: #4f9d5b;
+  --m3dsem-b: #e6f0cf;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background:
+    linear-gradient(180deg, var(--m3dsem-b) 0%, #eef5df 44%, #d5e7bf 100%);
+  color: #23331c;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.m3dsem__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.m3dsem__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--m3dsem-a);
+}
+.m3dsem__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #2c5a2e;
+}
+.m3dsem__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.m3dsem__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+.m3dsem__escena .mundo-root {
+  height: min(62vh, 30rem);
+  min-height: 300px;
+  border: 1px solid rgba(79, 157, 91, 0.28);
+  box-shadow: 0 10px 28px rgba(35, 51, 28, 0.14);
+}
+.m3dsem__escena .mundo-root[data-dim='2d'] {
+  height: auto;
+  background: #f4f9ea;
+}
+
+.m3dsem__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.m3dsem__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.m3dsem__toggle {
+  border: 1.5px solid var(--m3dsem-a);
+  background: #fff;
+  color: var(--m3dsem-a);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.m3dsem__toggle:hover,
+.m3dsem__toggle:focus-visible {
+  background: var(--m3dsem-a);
+  color: #fff;
+  outline-offset: 2px;
+}
+
+.m3dsem__nota {
+  margin: 0.5rem 0 0;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.78);
+  border-left: 3px solid var(--m3dsem-a);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.m3dsem__leyenda {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.m3dsem__leyenda h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #2c5a2e;
+}
+.m3dsem__leyenda ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .m3dsem__leyenda ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.m3dsem__leyenda li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.76);
+  border: 1px solid rgba(79, 157, 91, 0.18);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.m3dsem__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.m3dsem__leyenda b {
+  display: block;
+  font-size: 0.92rem;
+  color: #2c5a2e;
+}
+.m3dsem__leyenda li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.m3dsem__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #35502a;
+}

--- a/src/mockups/Mundo3DSemillero.jsx
+++ b/src/mockups/Mundo3DSemillero.jsx
@@ -1,0 +1,152 @@
+/*
+ * Mundo3DSemillero — vitrina pública del MUNDO DEL SEMILLERO / VIVERO (ruta
+ * #/mockups/mundo3d-semillero).
+ *
+ * El semillero de la finca andina: cómo se cría la matica desde el grano hasta
+ * que aguanta el campo. El diorama enseña la propagación con lo que de verdad se
+ * hace en finca — las bandejas germinadoras con su sustrato y su humedad (la
+ * semilla que despierta), el repique de la bandeja a la bolsa cuando la plántula
+ * tiene fuerza, el endurecimiento al borde soleado para aclimatarla antes de
+ * llevarla al lote, la semilla propia (criolla, guardada) al lado de la comprada,
+ * y el túnel de media-sombra que la resguarda del frío de la madrugada y del
+ * golpe de la lluvia. Nada de atajos: crianza paciente, esperanzadora.
+ *
+ * NO reimplementa nada: monta `<Mundo mundoId="semillero">` del framework
+ * (src/visual/mundo3d) con el device-tiering REAL (`decidirTier`). En equipo
+ * humilde (o con "menos movimiento") se ve la ficha 2D digna; en gama media/alta,
+ * el diorama 3D low-poly (chunk perezoso `vendor-three`) con la abeja Angelita
+ * entrando al mundo. Los puntos del recinto son las mismas puertas del registro:
+ * aquí (vitrina sin sesión) muestran a qué pantalla real de la app llevan, en vez
+ * de navegar.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en
+ * español de Colombia, en "usted".
+ */
+import { useMemo, useState } from 'react';
+import Mundo, { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import AcompananteMundo, { useAcompanante } from './valle/AcompananteMundo.jsx';
+import './Mundo3DSemillero.css';
+
+const TINTE = ['#4f9d5b', '#e6f0cf'];
+
+/* Lo que se ve en el semillero, contado en una leyenda didáctica y verificada:
+   propagación real (germinación, repique, endurecimiento y semilla), bajo el
+   túnel que la protege. */
+const LEYENDA = [
+  {
+    emoji: '🫘',
+    titulo: 'La germinación en bandeja',
+    texto: 'La semilla despierta en las celdas de la bandeja, con su sustrato suelto y húmedo. Riegue fino y seguido, sin encharcar: la semilla se ahoga si la deja en agua. Ahí ve cuáles prenden y cuáles no — y no gasta el lote en semilla que no iba a nacer.',
+  },
+  {
+    emoji: '🌱',
+    titulo: 'El repique o trasplante',
+    texto: 'Cuando la plántula ya tiene sus primeras hojas verdaderas y raíz firme, se pasa de la bandeja a la bolsa o a la era. Tómela por la hoja, nunca por el tallo, y siémbrela a la misma hondura. Ese cambio le da espacio para que engorde antes de ir al campo.',
+  },
+  {
+    emoji: '☀️',
+    titulo: 'El endurecimiento',
+    texto: 'Antes de llevarla al lote, sáquela unos días al borde soleado, al sol y al viento, y aflójele el riego. Así se aclimata: una matica criada consentida bajo techo, plantada de una en pleno campo, se quema o se marchita. Endurecerla es que aguante afuera.',
+  },
+  {
+    emoji: '🌾',
+    titulo: 'Semilla propia o comprada',
+    texto: 'La semilla criolla, seleccionada de sus mejores matas y bien guardada, sale gratis y ya está hecha a su clima. La comprada sirve para variedades nuevas o híbridos, pero de esos no guarde semilla (los hijos salen disparejos). Sepa qué tiene en la mano antes de sembrar.',
+  },
+  {
+    emoji: '⛺',
+    titulo: 'El semillero protegido',
+    texto: 'El túnel de media-sombra le hace techo a lo tierno: corta el golpe de la lluvia y guarda el calor de la helada de madrugada. La plántula recién nacida no aguanta el frío ni el aguacero de frente — por eso el semillero va tapado hasta que la mata tenga con qué defenderse.',
+  },
+];
+
+export default function Mundo3DSemillero() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d ? 'bajo' : decision.tier;
+
+  // La capa acompañante (BUG P1 "vitrinas mudas"): Angelita narra el mundo al
+  // entrar y acusa las puertas tocadas — voz + burbuja de texto; si el equipo
+  // no trae voz o está apagada, la burbuja ES la voz. Nunca mudo.
+  const acompanante = useAcompanante('semillero');
+
+  return (
+    <main
+      className="m3dsem"
+      style={{ '--m3dsem-a': TINTE[0], '--m3dsem-b': TINTE[1] }}
+    >
+      <header className="m3dsem__head">
+        <p className="m3dsem__kicker">Los mundos de su finca · vitrina</p>
+        <h1>El mundo del semillero</h1>
+        <p className="m3dsem__lema">
+          Asómese al vivero: cómo se cría la matica desde el grano. Germínela en
+          bandeja, repíquela a la bolsa, endurézcala al sol y guárdese su semilla —
+          todo bajo el túnel que la protege del frío y la lluvia. Del grano a la
+          mata lista para el campo.
+        </p>
+      </header>
+
+      <section className="m3dsem__escena" aria-label="El semillero de la finca">
+        <AcompananteMundo mundoId="semillero" acompanante={acompanante}>
+          <Mundo
+            mundoId="semillero"
+            tier={tier}
+            reducedMotion={reducedMotion}
+            onHotspot={acompanante.decirPuerta}
+            onSalir={null}
+            animo="atento"
+            energia={0.9}
+            hablando={acompanante.hablando}
+          />
+        </AcompananteMundo>
+        <div className="m3dsem__barra">
+          <p className="m3dsem__tier">
+            {tier === 'bajo'
+              ? 'Está viendo la ficha del semillero (va parejo en cualquier equipo).'
+              : 'Está viendo el diorama 3D. Puede girarlo con el dedo.'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="m3dsem__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver en 3D' : 'Ver la ficha 2D'}
+            </button>
+          )}
+        </div>
+        <p className="m3dsem__nota">Toque un punto del semillero para ver a dónde lo lleva.</p>
+      </section>
+
+      <section className="m3dsem__leyenda" aria-label="El semillero, pieza por pieza">
+        <h2>El semillero, pieza por pieza</h2>
+        <ol>
+          {LEYENDA.map((p) => (
+            <li key={p.titulo}>
+              <span className="m3dsem__emoji" aria-hidden="true">{p.emoji}</span>
+              <div>
+                <b>{p.titulo}</b>
+                <p>{p.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="m3dsem__cierre">
+          El semillero es donde empieza toda cosecha, y donde se gana o se pierde
+          barato: aquí una matica mala no cuesta un lote, cuesta una celda. Semilla
+          buena, sustrato suelto, humedad medida y paciencia — y al campo se van
+          matas que ya saben pararse solas. Del grano fuerte sale la finca fuerte.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -390,6 +390,34 @@ function LandmarkGeom({ tipo, tinte, reducedMotion }) {
       );
     case 'veleta': // poste con veleta que gira con el viento
       return <Veleta color={fuerte} reducedMotion={reducedMotion} />;
+    case 'semillero': // túnel de media-sombra del vivero: arcos + techo traslúcido + bandeja
+      return (
+        <group>
+          {/* los arcos del túnel (medio-toroide de pie), en tono madera */}
+          {[-0.42, 0, 0.42].map((dz, i) => (
+            <mesh key={i} position={[0, 0, dz]}>
+              <torusGeometry args={[0.5, 0.028, 6, 18, Math.PI]} />
+              <meshStandardMaterial color="#8a6a44" flatShading roughness={1} />
+            </mesh>
+          ))}
+          {/* el techo de media-sombra (traslúcido) que cubre los arcos */}
+          <mesh position={[0, 0, 0]} rotation={[Math.PI / 2, 0, 0]}>
+            <cylinderGeometry args={[0.5, 0.5, 1.0, 16, 1, true, Math.PI, Math.PI]} />
+            <meshStandardMaterial color={suave} transparent opacity={0.4} side={2} roughness={1} />
+          </mesh>
+          {/* la bandeja germinadora adentro, con sus brotecitos */}
+          <mesh position={[0, 0.12, 0]}>
+            <boxGeometry args={[0.5, 0.08, 0.6]} />
+            <meshStandardMaterial color="#5a4326" flatShading roughness={1} />
+          </mesh>
+          {[[-0.14, -0.18], [0.02, 0], [0.16, 0.2], [-0.06, 0.22], [0.1, -0.2]].map(([bx, bz], i) => (
+            <mesh key={i} position={[bx, 0.24, bz]}>
+              <coneGeometry args={[0.045, 0.16, 5]} />
+              <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+            </mesh>
+          ))}
+        </group>
+      );
     default:
       return (
         <mesh position={[0, 0.3, 0]}>

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -132,6 +132,9 @@ const LUGARES = [
   // El mercado, abajo en la tierra caliente, cerca de la salida a la plaza: el
   // puesto con su toldo donde la cosecha de la finca sale a venderse.
   { id: 'mercado', pos: [1.2, 0, 6.6], escala: 1, tipo: 'mercado' },
+  // El semillero, abajo cerca de la casa: el túnel de media-sombra donde nace y
+  // se cría la matica antes de salir al lote. (anti-conflicto: lugar nuevo al final.)
+  { id: 'semillero', pos: [-2.6, 0, 6.2], escala: 1, tipo: 'semillero' },
 ];
 
 /**
@@ -331,4 +334,6 @@ export const NARRACION = {
     'La plaza campesina. Aquí llega su cosecha derecho a la mesa: venda directo, con su sello y a precio justo.',
   pisos:
     'Suba por la montaña: del cálido al páramo, cada piso con lo suyo. Arriba manda el frailejón, que le peina el agua a la niebla y la entrega despacio al suelo. Por eso el páramo se cuida, no se ara.',
+  semillero:
+    'El semillero, bajo su túnel de media-sombra. Aquí nace la matica: la semilla despierta en la bandeja, se repica a la bolsa y se endurece al sol antes de irse al campo. Del grano fuerte sale la finca fuerte.',
 };

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -35,6 +35,7 @@ const IMPORTA_ESCENA = {
   mercado: () => import('./escenas/EscenaMercado.jsx'),
   // (anti-conflicto de merge) importadores de escena nuevos SIEMPRE al final:
   cafe: () => import('./escenas/EscenaCafe.jsx'),
+  semillero: () => import('./escenas/EscenaSemillero.jsx'),
 };
 const ESCENAS_3D = Object.fromEntries(
   Object.entries(IMPORTA_ESCENA).map(([k, importa]) => [k, lazy(importa)]),

--- a/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
+++ b/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
@@ -12,7 +12,7 @@ afterEach(() => cleanup());
 
 describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
   test('arquetipos: 5 dioramas 3D + arquetipos 2D de primera clase', () => {
-    expect(ARQUETIPOS_3D.sort()).toEqual(['boveda', 'cafe', 'cutaway', 'estratos', 'flujo', 'mercado', 'recinto', 'sanidad', 'valle']);
+    expect(ARQUETIPOS_3D.sort()).toEqual(['boveda', 'cafe', 'cutaway', 'estratos', 'flujo', 'mercado', 'recinto', 'sanidad', 'semillero', 'valle']);
     ['lamina', 'infografia', 'ficha', 'mirror', 'valle2d'].forEach((k) => {
       expect(ARQUETIPOS_2D).toContain(k);
       expect(ARQUETIPOS[k].dim).toBe('2d');

--- a/src/visual/mundo3d/arquetipos.js
+++ b/src/visual/mundo3d/arquetipos.js
@@ -83,6 +83,16 @@ export const ARQUETIPOS = {
     nombre: 'El cafetal bajo sombra', clave: 'el cultivo bandera: café de sombra, el grano cereza→pergamino→oro, roya/broca y beneficio',
     ejemplo: 'cafe', tambien: [],
   },
+  // El semillero/vivero: la familia del `recinto` (un lugar cercado y PROTEGIDO
+  // que se camina), pero su lección es la PROPAGACIÓN — germinar en bandeja,
+  // repicar a bolsa/era y endurecer la plántula bajo el túnel de media-sombra
+  // antes de llevarla al campo. En equipo humilde cae a su ficha 2D (infografía
+  // del semillero). (anti-conflicto: arquetipo 3D nuevo al final del bloque.)
+  semillero: {
+    dim: '3d', role: 'mundo3d-archetype', motivo: 'semillero', espejo: 'mirror',
+    nombre: 'El semillero/vivero', clave: 'la propagación: germinar, repicar y endurecer bajo el túnel protegido',
+    ejemplo: 'semillero', tambien: [],
+  },
 
   // ── Arquetipos 2D (primera clase) ────────────────────────────────────────
   mirror: {

--- a/src/visual/mundo3d/escenas/EscenaSemillero.jsx
+++ b/src/visual/mundo3d/escenas/EscenaSemillero.jsx
@@ -1,0 +1,277 @@
+/*
+ * EscenaSemillero — ARQUETIPO `semillero`: el SEMILLERO/VIVERO y la propagación.
+ *
+ * De la familia del `recinto` (un lugar cercado y PROTEGIDO que se camina), pero
+ * su lección no es el ciclo del abono ni el manejo de plagas: es cómo se CRÍA la
+ * matica desde el grano hasta que aguanta el campo. El espacio mismo enseña la
+ * propagación de la finca andina, paso por paso:
+ *
+ *   · el TÚNEL de media-sombra — arcos con techo traslúcido que resguardan del
+ *     frío de la madrugada y del golpe de la lluvia (por eso el semillero va
+ *     tapado: la plántula tierna se hiela o se ahoga a la intemperie);
+ *   · las BANDEJAS GERMINADORAS — cajones con sustrato y las celdas donde la
+ *     semilla despierta: unas apenas asoman, otras ya son plántula (la
+ *     germinación contada como progresión, con su humedad);
+ *   · las BOLSAS del REPIQUE — cuando la plántula tiene fuerza se pasa de la
+ *     bandeja a la bolsa (o a la era): matas más grandes, ya con raíz firme;
+ *   · la ERA DE ENDURECIMIENTO — al borde soleado, al aire, unas matas se
+ *     ACLIMATAN antes de ir al lote (si salen consentidas del túnel, el sol y el
+ *     viento del campo las queman);
+ *   · la ESTACIÓN DE SEMILLA — la propia (criolla, guardada en su vasija) al
+ *     lado de la comprada (el sobre): de dónde sale lo que se siembra.
+ *
+ * Todo `MeshLambert`/`Basic`, sin sombras (contrato de EscenaBase3D). Geometría
+ * de primitivas: cero GLTF, offline y liviano.
+ */
+import { useMemo } from 'react';
+import EscenaBase3D from './EscenaBase3D.jsx';
+import { Fauna } from './FaunaEscena.jsx';
+import { CIELOS, PALETA } from '../atmosferaMadre.js';
+
+/* La fauna que ronda el vivero: la mariposa que entra por el borde abierto del
+   túnel hacia las matas endurecidas, y el colibrí que asoma. Pocas y por
+   criterio (contrato del DR: vida, no enjambre). */
+const FAUNA_SEMILLERO = [
+  { tipo: 'mariposa', base: [1.0, 0.62, 1.02], patron: 'revoloteo', size: 28, fase: 0.5 },
+  { tipo: 'colibri', base: [-0.9, 1.0, 0.5], patron: 'revoloteo', size: 28, fase: 1.7 },
+];
+
+/* Un BROTE de bandeja: un conito verde de altura variable. La altura CUENTA la
+   etapa (semilla que apenas rompe → plántula de dos hojas). */
+function Brote({ pos, h = 0.12, color = '#6fae4a' }) {
+  return (
+    <mesh position={pos}>
+      <coneGeometry args={[0.032, h, 5]} />
+      <meshLambertMaterial color={color} flatShading />
+    </mesh>
+  );
+}
+
+/* Una BANDEJA GERMINADORA: cajón con sustrato oscuro y una retícula de brotes en
+   distintas etapas — la germinación hecha visible. Determinista (mismo dibujo
+   2D↔3D): las etapas salen de un patrón fijo, no de aleatorio. */
+function Bandeja({ pos, rot = 0 }) {
+  // 4 x 3 celdas; la etapa (altura del brote) crece de una esquina a la otra:
+  // arriba-izquierda apenas semilla, abajo-derecha ya plántula.
+  const celdas = useMemo(() => {
+    const cols = 4;
+    const filas = 3;
+    const out = [];
+    for (let i = 0; i < cols; i += 1) {
+      for (let j = 0; j < filas; j += 1) {
+        const t = (i + j) / (cols + filas - 2); // 0..1 progresión de etapa
+        const x = (i - (cols - 1) / 2) * 0.11;
+        const z = (j - (filas - 1) / 2) * 0.11;
+        out.push({ x, z, h: 0.05 + t * 0.16, color: t < 0.3 ? '#8aa86a' : '#5f9e3f' });
+      }
+    }
+    return out;
+  }, []);
+  return (
+    <group position={pos} rotation={[0, rot, 0]}>
+      {/* el borde/cajón de la bandeja (madera clara del vivero) */}
+      <mesh position={[0, 0.05, 0]}>
+        <boxGeometry args={[0.56, 0.1, 0.42]} />
+        <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+      </mesh>
+      {/* el sustrato húmedo (tierra negra del semillero) */}
+      <mesh position={[0, 0.11, 0]}>
+        <boxGeometry args={[0.5, 0.04, 0.36]} />
+        <meshLambertMaterial color="#3a2c1c" />
+      </mesh>
+      {/* los brotes por celda, cada uno en su etapa */}
+      {celdas.map((c, i) => (
+        <Brote key={i} pos={[c.x, 0.14 + c.h * 0.5, c.z]} h={c.h} color={c.color} />
+      ))}
+    </group>
+  );
+}
+
+/* Una BOLSA del repique: la plántula ya crecida, pasada de la bandeja a su bolsa
+   negra de vivero. Bolsa (cono truncado oscuro) + tallo + hojas. */
+function Bolsa({ pos, alto = 0.34, color = '#4e8f3f' }) {
+  const hojas = [
+    [0, alto + 0.02, 0, 0.11],
+    [0.09, alto - 0.06, 0.03, 0.08],
+    [-0.08, alto - 0.05, -0.03, 0.08],
+  ];
+  return (
+    <group position={pos}>
+      {/* la bolsa negra con su sustrato */}
+      <mesh position={[0, 0.11, 0]}>
+        <cylinderGeometry args={[0.1, 0.12, 0.22, 8]} />
+        <meshLambertMaterial color="#2a2622" flatShading />
+      </mesh>
+      <mesh position={[0, 0.22, 0]}>
+        <cylinderGeometry args={[0.1, 0.1, 0.02, 8]} />
+        <meshLambertMaterial color="#3a2c1c" />
+      </mesh>
+      {/* el tallo */}
+      <mesh position={[0, alto * 0.5 + 0.16, 0]}>
+        <cylinderGeometry args={[0.02, 0.03, alto, 5]} />
+        <meshLambertMaterial color="#5a6a2e" flatShading />
+      </mesh>
+      {/* las hojas */}
+      {hojas.map(([x, y, z, r], i) => (
+        <mesh key={i} position={[x, y + 0.1, z]}>
+          <sphereGeometry args={[r, 8, 7]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* La ESTACIÓN DE SEMILLA: un tablón con la semilla PROPIA (criolla, en su vasija
+   de barro con los granos a la vista) al lado de la COMPRADA (el sobre impreso).
+   De dónde sale lo que se siembra — y por qué guardar la propia. */
+function EstacionSemilla({ pos }) {
+  const granos = [
+    [-0.03, 0.02], [0.03, -0.02], [0, 0.03], [-0.04, -0.03], [0.05, 0.01],
+  ];
+  return (
+    <group position={pos}>
+      {/* el tablón sobre dos soportes */}
+      {[-0.24, 0.24].map((dx, i) => (
+        <mesh key={i} position={[dx, 0.14, 0]}>
+          <cylinderGeometry args={[0.03, 0.035, 0.28, 5]} />
+          <meshLambertMaterial color={PALETA.madera} flatShading />
+        </mesh>
+      ))}
+      <mesh position={[0, 0.3, 0]}>
+        <boxGeometry args={[0.68, 0.05, 0.34]} />
+        <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+      </mesh>
+      {/* semilla PROPIA: la totuma/vasija de barro con los granos criollos */}
+      <mesh position={[-0.2, 0.4, 0]}>
+        <sphereGeometry args={[0.11, 12, 8, 0, Math.PI * 2, 0, Math.PI / 2]} />
+        <meshLambertMaterial color="#9a5a34" flatShading />
+      </mesh>
+      {granos.map(([gx, gz], i) => (
+        <mesh key={i} position={[-0.2 + gx, 0.43, gz]}>
+          <sphereGeometry args={[0.022, 6, 5]} />
+          <meshLambertMaterial color={PALETA.ambar} flatShading />
+        </mesh>
+      ))}
+      {/* semilla COMPRADA: el sobre parado, de color impreso (distinto del barro) */}
+      <mesh position={[0.22, 0.42, 0]} rotation={[0, 0, 0.08]}>
+        <boxGeometry args={[0.16, 0.22, 0.02]} />
+        <meshLambertMaterial color="#3f77c7" flatShading />
+      </mesh>
+      <mesh position={[0.22, 0.46, 0.012]}>
+        <boxGeometry args={[0.1, 0.06, 0.006]} />
+        <meshLambertMaterial color="#efe7d8" />
+      </mesh>
+    </group>
+  );
+}
+
+/* Una REGADERA de mano: la humedad del semillero (regar fino y seguido, no
+   ahogar). Cuerpo + pico + asa, en lámina cálida. */
+function Regadera({ pos }) {
+  return (
+    <group position={pos}>
+      <mesh position={[0, 0.1, 0]}>
+        <cylinderGeometry args={[0.09, 0.1, 0.16, 10]} />
+        <meshLambertMaterial color={PALETA.lamina} flatShading />
+      </mesh>
+      {/* el pico */}
+      <mesh position={[0.14, 0.13, 0]} rotation={[0, 0, -0.7]}>
+        <cylinderGeometry args={[0.015, 0.02, 0.2, 6]} />
+        <meshLambertMaterial color={PALETA.lamina} flatShading />
+      </mesh>
+      {/* el asa */}
+      <mesh position={[-0.02, 0.22, 0]} rotation={[Math.PI / 2, 0, 0]}>
+        <torusGeometry args={[0.06, 0.012, 6, 12, Math.PI]} />
+        <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+function Diorama({ params, reducedMotion }) {
+  const bandejas = params?.bandejas || [
+    { pos: [-0.35, 0, 0.35], rot: 0.1 },
+    { pos: [0.32, 0, 0.3], rot: -0.08 },
+  ];
+  const bolsas = params?.bolsas || [
+    { pos: [-1.2, 0, -0.15], alto: 0.34, color: '#4e8f3f' },
+    { pos: [-1.15, 0, 0.3], alto: 0.3, color: '#57993f' },
+    { pos: [-0.85, 0, -0.55], alto: 0.38, color: '#468637' },
+  ];
+
+  // El TÚNEL de media-sombra: arcos (medio-toroide) repartidos a lo largo de z.
+  const radio = 1.35;
+  const largo = 2.4;
+  const arcos = useMemo(() => {
+    const n = 4;
+    return Array.from({ length: n }, (_, i) => (-largo / 2) + (i / (n - 1)) * largo);
+  }, []);
+
+  return (
+    <group>
+      {/* piso del vivero (tierra apisonada, algo de gravilla) */}
+      <mesh position={[0, -0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[2, 28]} />
+        <meshLambertMaterial color="#8a7a56" />
+      </mesh>
+      {/* la cama central del semillero (lomo de tierra bajo el túnel) */}
+      <mesh position={[0, 0.04, 0.05]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[1.9, 1.3]} />
+        <meshLambertMaterial color="#6b5636" />
+      </mesh>
+
+      {/* EL TÚNEL: los arcos de media-sombra (protección del frío y la lluvia) */}
+      {arcos.map((z, i) => (
+        <mesh key={i} position={[0, 0, z]}>
+          <torusGeometry args={[radio, 0.03, 6, 22, Math.PI]} />
+          <meshLambertMaterial color={PALETA.madera} flatShading />
+        </mesh>
+      ))}
+      {/* el techo traslúcido (la media-sombra): media-luna extruida a lo largo */}
+      <mesh position={[0, 0, 0]} rotation={[Math.PI / 2, 0, 0]}>
+        <cylinderGeometry args={[radio, radio, largo, 20, 1, true, Math.PI, Math.PI]} />
+        <meshBasicMaterial
+          color={PALETA.follajeClaro}
+          transparent
+          opacity={0.22}
+          side={2}
+          depthWrite={false}
+        />
+      </mesh>
+
+      {/* las BANDEJAS germinadoras con sus brotes por etapa */}
+      {bandejas.map((b, i) => (
+        <Bandeja key={i} pos={b.pos} rot={b.rot} />
+      ))}
+      {/* la regadera: la humedad del semillero */}
+      <Regadera pos={[0.75, 0, 0.2]} />
+
+      {/* las BOLSAS del repique (plántulas ya crecidas, con raíz firme) */}
+      {bolsas.map((b, i) => (
+        <Bolsa key={i} pos={b.pos} alto={b.alto} color={b.color} />
+      ))}
+
+      {/* la ESTACIÓN DE SEMILLA: la propia y la comprada, al fondo */}
+      <EstacionSemilla pos={[1.05, 0, -0.55]} />
+
+      {/* la ERA DE ENDURECIMIENTO: al borde soleado, FUERA del techo, unas matas
+          se aclimatan al sol y al viento antes de irse al campo */}
+      <Bolsa pos={[0.85, 0, 1.0]} alto={0.42} color="#5a9a3f" />
+      <Bolsa pos={[1.15, 0, 0.75]} alto={0.38} color="#4e8f3f" />
+
+      {/* la fauna que anima el vivero (mariposa/colibrí) */}
+      <Fauna items={FAUNA_SEMILLERO} reducedMotion={reducedMotion} />
+    </group>
+  );
+}
+
+export default function EscenaSemillero(props) {
+  // Cielo fresco y verde de vivero (se mezcla igual hacia la hora dorada del valle).
+  const cielo = CIELOS.huerta;
+  return (
+    <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.5, 0] }}>
+      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
+    </EscenaBase3D>
+  );
+}

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -448,6 +448,57 @@ export const MUNDO = {
     ],
     entrada: { zoom: 8, narra: 'pisos' },
   },
+
+  // 🌱 EL SEMILLERO / VIVERO — arquetipo SÍ-3D `semillero`: la PROPAGACIÓN hecha
+  //    lugar. El diorama muestra cómo se cría la matica desde el grano hasta que
+  //    aguanta el campo, con lo que de verdad se hace en finca: las BANDEJAS
+  //    germinadoras con su sustrato y su humedad (la semilla que despierta), el
+  //    REPIQUE de la bandeja a la BOLSA cuando la plántula tiene fuerza, la ERA de
+  //    ENDURECIMIENTO al borde soleado (aclimatar antes de llevar al lote), la
+  //    ESTACIÓN de SEMILLA (la propia/criolla al lado de la comprada) y el TÚNEL
+  //    de media-sombra que la resguarda del frío de la madrugada y de la lluvia.
+  //    Cada punto es una puerta a una pantalla REAL. En equipo humilde cae a su
+  //    ficha 2D digna (la infografía del semillero).
+  //    (anti-conflicto de merge: entrada de mundo nueva SIEMPRE al final.)
+  semillero: {
+    escena: 'semillero',
+    valle: { tipo: 'semillero', pos: [-2.6, 0, 6.2], escala: 1 },
+    params: {
+      // El diorama tiene defaults propios; aquí los hacemos explícitos y
+      // deterministas (mismas bandejas y bolsas 2D↔3D).
+      bandejas: [
+        { pos: [-0.35, 0, 0.35], rot: 0.1 },
+        { pos: [0.32, 0, 0.3], rot: -0.08 },
+      ],
+      bolsas: [
+        { pos: [-1.2, 0, -0.15], alto: 0.34, color: '#4e8f3f' },
+        { pos: [-1.15, 0, 0.3], alto: 0.3, color: '#57993f' },
+        { pos: [-0.85, 0, -0.55], alto: 0.38, color: '#468637' },
+      ],
+    },
+    hotspots: [
+      { id: 'germinar', pos: [0, 0.62, 0.35], emoji: '🫘', label: 'Semilleros: qué nace', view: 'germinacion' },
+      { id: 'repique', pos: [-1.15, 0.7, -0.1], emoji: '🌱', label: 'Repicar y llevar al campo', view: 'sembrar' },
+      { id: 'endurecer', pos: [0.95, 0.72, 0.95], emoji: '☀️', label: 'Endurecer la matica', view: 'ciclo' },
+      { id: 'semilla', pos: [1.1, 0.72, -0.55], emoji: '🌾', label: 'Semilla propia', view: 'semilla' },
+      { id: 'frio', pos: [0, 1.5, -0.7], emoji: '⛺', label: 'Cuídelo del frío', view: 'hoy_finca' },
+    ],
+    entrada: { zoom: 7, narra: 'semillero' },
+    // El gemelo 2D digno: la ficha del semillero (misma lección, en notas).
+    fallback2d: {
+      escena: 'infografia',
+      params: {
+        titulo: 'El semillero de la finca',
+        notas: [
+          'Germine en bandeja con sustrato suelto y húmedo: riegue fino y seguido, sin encharcar (la semilla se ahoga en agua).',
+          'Repique a bolsa o era cuando la plántula tenga hojas verdaderas y raíz firme: tómela por la hoja, nunca por el tallo.',
+          'Endurézcala unos días al sol y al viento antes de llevarla al lote, o el campo la quema.',
+          'Guarde su semilla criolla de las mejores matas; de híbridos comprados no guarde semilla (los hijos salen disparejos).',
+          'Tape el semillero: el túnel de media-sombra corta la lluvia y guarda el calor de la helada de madrugada.',
+        ],
+      },
+    },
+  },
 };
 
 /** Ids de todos los mundos registrados. */


### PR DESCRIPTION
## Qué es

Nuevo **MUNDO SEMILLERO / VIVERO 3D** del framework de mundos (`src/visual/mundo3d`), replicando el patrón EXACTO de los mundos ya integrados (sanidad · mercado · café). Ruta de vitrina: `#/mockups/mundo3d-semillero`.

El espacio mismo enseña la **propagación** de la finca andina:

- **Germinación** — bandejas germinadoras con sustrato húmedo y brotes por etapa (semilla→plántula).
- **Repique / trasplante** — bolsas de vivero con la plántula ya crecida, pasada de la bandeja a bolsa/era.
- **Endurecimiento** — matas al borde soleado, fuera del techo, aclimatándose antes de ir al lote.
- **Semilla propia vs comprada** — la vasija de barro con grano criollo al lado del sobre comercial.
- **Semillero protegido** — túnel de media-sombra que corta la lluvia y guarda el calor de la helada.

Arquetipo elegido: familia **recinto** (un lugar cercado y protegido que se camina), con escena propia `EscenaSemillero.jsx` (misma decisión que sanidad/mercado/café: arquetipo nuevo + escena dedicada).

## Cambios

**Escena 3D + registro del framework**
- `arquetipos.js` — arquetipo 3D `semillero` (al final del bloque).
- `escenas/EscenaSemillero.jsx` — diorama low-poly (primitivas, `MeshLambert/Basic`, sin sombras, offline).
- `Mundo.jsx` — `IMPORTA_ESCENA.semillero` (al final).
- `mundoData.js` — entrada `semillero` (hotspots a vistas reales: germinacion/sembrar/ciclo/semilla/hoy_finca) + `fallback2d` infografía. **Al final del registro.**

**Vitrina + acompañante**
- `mockups/Mundo3DSemillero.jsx` + `.css` — monta `<Mundo mundoId="semillero">` con device-tiering real, toggle 2D/3D, leyenda didáctica; envuelto en `AcompananteMundo` (Angelita: voz + burbuja). Copy es-CO en *usted*.
- `App.jsx` — lazy import + ruta `mockups/mundo3d-semillero` + `case` de render. **Todo al final de sus bloques (anti-conflicto).**

**Entrada desde el valle + home**
- `valleData.js` — landmark en `LUGARES` (al final) + `NARRACION.semillero`.
- `Valle3D.jsx` — geometría de landmark `tipo: 'semillero'` (túnel de media-sombra + bandeja).
- `mundosFinca.js` — mundo de home `semillero` (título/emoji/tinte reales) + `MundoVinetas.jsx` viñeta ilustrada.
- `mundo.smoke.test.jsx` — contrato de arquetipos 3D actualizado.

## Verificación

- `npm run build` ✅ (síncrono; solo warnings pre-existentes de chunk-size).
- Tests verdes: `MundosDeMiFinca.reachability`, `MundosDeMiFinca.espiritu`, `mundo3d/mundo.smoke`, `navegacion`, y los dashboard-mundos (Arbol/DashboardLive.redistribucion/FincaVivaHero/PanelVitalidad/FincaVivaResto) en aislamiento.
- Las 2 fallas `GuardianEspiritu` del dir de dashboard completo son **pre-existentes en `origin/dev`** (mock sin `getGuardianEspecie`), reproducidas con el árbol limpio sin este cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)