### PR TITLE
feat(mundo3d): librería de infraestructura 3D data-driven + vitrina

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -105,6 +105,11 @@ const Mundo3DMercadoMockup = lazy(() => import('./mockups/Mundo3DMercado'));
 // (guamo/nogal), el grano cereza→pergamino→oro (sin tostar en finca), roya/broca
 // con manejo agroecológico y el beneficio. El 3D va perezoso (vendor-three).
 const Mundo3DCafeMockup = lazy(() => import('./mockups/Mundo3DCafe'));
+// 3D: "La infraestructura de su finca" — vitrina de la LIBRERÍA de construcciones
+// (src/visual/mundo3d/infraestructura): invernaderos, galpón, establo, bodega,
+// compostera, tanque, secadero, media-sombra. Grilla data-driven con device-tier
+// real; el 3D va perezoso (vendor-three), 2D digno en equipo humilde.
+const Infraestructura3DMockup = lazy(() => import('./mockups/Infraestructura3D'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -520,6 +525,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo3d-sanidad': 'mockup_mundo3d_sanidad',
   'mockups/mundo3d-mercado': 'mockup_mundo3d_mercado',
   'mockups/mundo3d-cafe': 'mockup_mundo3d_cafe',
+  'mockups/infraestructura-3d': 'mockup_infraestructura_3d',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1643,6 +1649,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del café">
               <Mundo3DCafeMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_infraestructura_3d':
+        // Vitrina pública de la LIBRERÍA DE INFRAESTRUCTURA 3D: la grilla de todas
+        // las construcciones del catálogo (src/visual/mundo3d/infraestructura) con
+        // device-tiering real. Ruta #/mockups/infraestructura-3d, sin auth.
+        // Invernadero túnel/capilla, media-sombra, gallinero, galpón, establo,
+        // bodega, compostera, tanque y secadero — cada una con sus medidas típicas
+        // en metros, para agregar la infraestructura real de la finca a los mundos.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="La infraestructura de su finca">
+              <Infraestructura3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/Infraestructura3D.css
+++ b/src/mockups/Infraestructura3D.css
@@ -1,0 +1,203 @@
+/*
+ * Infraestructura3D.css — vitrina de la librería de infraestructura 3D
+ * (#/mockups/infraestructura-3d). Autocontenida: sin fuentes/imágenes externas.
+ * Móvil-first desde 320px. Fondo de hora dorada del valle; grilla responsiva.
+ * Solo opacity/transform animables.
+ */
+
+.vinf {
+  --vinf-a: #7a5a38;
+  --vinf-b: #f2d9a8;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background: linear-gradient(180deg, #f6ead2 0%, #f2e2c4 52%, #ecdcbe 100%);
+  color: #33291c;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.vinf__head {
+  max-width: 52rem;
+  margin: 0 auto 1.4rem;
+}
+.vinf__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8a6a3a;
+}
+.vinf__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.3rem);
+  line-height: 1.14;
+  color: #4a331a;
+}
+.vinf__lema {
+  margin: 0.5rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.5;
+  color: #5a4630;
+}
+.vinf__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem 1rem;
+  margin-top: 0.9rem;
+}
+.vinf__cuenta {
+  margin: 0;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #6a5232;
+}
+.vinf__toggle {
+  appearance: none;
+  border: 1px solid #cbae7e;
+  background: #fbf3e2;
+  color: #5a4326;
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 600;
+  padding: 0.42rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+.vinf__toggle:hover {
+  background: #f4e7cd;
+}
+.vinf__toggle:active {
+  transform: scale(0.96);
+}
+.vinf__aviso {
+  margin: 0.7rem 0 0;
+  font-size: 0.86rem;
+  color: #6a5232;
+  background: #fbf3e2;
+  border: 1px solid #e4d3ac;
+  border-radius: 0.6rem;
+  padding: 0.55rem 0.75rem;
+}
+
+/* ── Grupos por categoría ─────────────────────────────────────────────────── */
+.vinf__grupo {
+  max-width: 74rem;
+  margin: 0 auto 1.6rem;
+}
+.vinf__cat {
+  margin: 0.4rem 0 0.7rem;
+  font-size: 1.05rem;
+  color: #4a331a;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-bottom: 2px solid #e0cca0;
+  padding-bottom: 0.35rem;
+}
+
+.vinf__grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 30rem) {
+  .vinf__grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (min-width: 52rem) {
+  .vinf__grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* ── Tarjeta ──────────────────────────────────────────────────────────────── */
+.vinf__card {
+  background: #fbf5e8;
+  border: 1px solid #e6d4ab;
+  border-radius: 0.9rem;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(90, 60, 20, 0.08);
+  display: flex;
+  flex-direction: column;
+}
+.vinf__lienzo {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: linear-gradient(180deg, #f7ead0 0%, #edd9b4 100%);
+  touch-action: none;
+}
+.vinf__canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+}
+.vinf__placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+}
+.vinf__ph-emoji {
+  font-size: 2.8rem;
+  line-height: 1;
+  filter: saturate(0.85);
+}
+.vinf__ph-txt {
+  font-size: 0.78rem;
+  color: #8a6a3a;
+  font-weight: 600;
+}
+
+.vinf__meta {
+  padding: 0.7rem 0.85rem 0.9rem;
+}
+.vinf__meta h3 {
+  margin: 0;
+  font-size: 1.02rem;
+  color: #43301a;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.vinf__medidas {
+  margin: 0.25rem 0 0;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #8a6a3a;
+  font-variant-numeric: tabular-nums;
+}
+.vinf__desc {
+  margin: 0.4rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: #5a4630;
+}
+
+.vinf__pie {
+  max-width: 52rem;
+  margin: 0.5rem auto 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #6a5232;
+  background: #fbf3e2;
+  border: 1px solid #e4d3ac;
+  border-radius: 0.7rem;
+  padding: 0.8rem 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vinf__toggle {
+    transition: none;
+  }
+}

--- a/src/mockups/Infraestructura3D.jsx
+++ b/src/mockups/Infraestructura3D.jsx
@@ -1,0 +1,229 @@
+/*
+ * Infraestructura3D — VITRINA pública de la LIBRERÍA DE INFRAESTRUCTURA 3D
+ * (ruta #/mockups/infraestructura-3d).
+ *
+ * Muestra TODAS las piezas del catálogo (src/visual/mundo3d/infraestructura) en
+ * una grilla, agrupadas por categoría, para revisarlas de un vistazo: cómo se ve
+ * cada invernadero, galpón, tanque o secadero antes de agregarlo a un mundo. Cada
+ * tarjeta trae su diorama 3D low-poly girable + nombre, medidas típicas (metros)
+ * y para qué sirve.
+ *
+ * PERF (device-tiering real del framework): en equipo humilde / ahorro de datos /
+ * menos-movimiento cae a la vista de FICHAS 2D (sin WebGL), y hay un botón para
+ * forzarla. En 3D, cada tarjeta monta su Canvas SOLO cuando entra en pantalla
+ * (IntersectionObserver) y lo suelta al salir — así nunca hay diez contextos
+ * WebGL vivos a la vez. `frameloop='demand'` bajo reduced-motion (diorama quieto).
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en español
+ * de Colombia, en "usted". El 3D (three/R3F) va en el chunk perezoso de esta ruta.
+ */
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import {
+  INFRAESTRUCTURA,
+  INFRAESTRUCTURA_CATEGORIAS,
+} from '../visual/mundo3d/infraestructura/infraestructuraData.js';
+import Infraestructura from '../visual/mundo3d/infraestructura/Infraestructura.jsx';
+import { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import { ATMOSFERA } from '../visual/mundo3d/atmosferaMadre.js';
+import './Infraestructura3D.css';
+
+/* Etiqueta legible de cada categoría del catálogo (con su emoji de familia). */
+const ROTULO_CAT = {
+  'cultivo protegido': { emoji: '🌱', txt: 'Cultivo protegido' },
+  pecuaria: { emoji: '🐄', txt: 'Animales' },
+  almacenamiento: { emoji: '📦', txt: 'Almacenamiento y reciclaje' },
+  agua: { emoji: '💧', txt: 'Agua' },
+  poscosecha: { emoji: '☕', txt: 'Poscosecha' },
+};
+
+/* Formatea las medidas típicas en un texto campesino (largo × ancho × alto). */
+function medidasTexto(dims) {
+  const n = (v) => `${v}`.replace('.', ',');
+  return `${n(dims.largo)} × ${n(dims.ancho)} × ${n(dims.alto)} m`;
+}
+
+/* IntersectionObserver: ¿la tarjeta está (cerca de) en pantalla? Monta/suelta el
+   Canvas para acotar los contextos WebGL vivos. Margen generoso: aparece un poco
+   antes de entrar y se va un poco después de salir (sin parpadeo). */
+function useEnVista() {
+  const ref = useRef(null);
+  const [enVista, setEnVista] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setEnVista(true); // sin observer (SSR/viejo): mostrar y ya
+      return undefined;
+    }
+    const obs = new IntersectionObserver(
+      ([e]) => setEnVista(e.isIntersecting),
+      { rootMargin: '300px 0px', threshold: 0.01 },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+  return { ref, enVista };
+}
+
+/* El lienzo 3D de UNA pieza: fondo dorado del valle, luz de hora dorada, un piso
+   redondo y la infraestructura centrada. Cámara encuadrada a sus medidas; se gira
+   con el dedo (autorotación suave, apagada bajo reduced-motion). */
+function LienzoInfra({ tipo, dims, tier, reducedMotion }) {
+  const span = Math.max(dims.largo, dims.ancho, dims.alto);
+  const d = span * 1.35 + 2.4;
+  const target = [0, dims.alto * 0.42, 0];
+  return (
+    <Canvas
+      className="vinf__canvas"
+      dpr={[1, tier === 'alto' ? 1.6 : 1.2]}
+      gl={{ antialias: tier === 'alto', powerPreference: 'high-performance' }}
+      camera={{ position: [d * 0.72, d * 0.62, d], fov: 42 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+    >
+      <color attach="background" args={[ATMOSFERA.fondo]} />
+      <hemisphereLight intensity={0.6} color={ATMOSFERA.cielo} groundColor={ATMOSFERA.suelo} />
+      <ambientLight intensity={0.3} color={ATMOSFERA.luz} />
+      <directionalLight position={[6, 9, 4]} intensity={0.95} color={ATMOSFERA.luz} />
+      <directionalLight position={[-5, 4, -6]} intensity={0.22} color={ATMOSFERA.relleno} />
+      {/* piso: un disco de tierra tibia que posa la pieza */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.01, 0]}>
+        <circleGeometry args={[span * 1.05, 40]} />
+        <meshLambertMaterial color="#b49873" />
+      </mesh>
+      <Suspense fallback={null}>
+        <Infraestructura tipo={tipo} dims={dims} tier={tier} reducedMotion={reducedMotion} />
+      </Suspense>
+      <OrbitControls
+        target={target}
+        makeDefault
+        enablePan={false}
+        enableZoom
+        minDistance={d * 0.5}
+        maxDistance={d * 2.1}
+        minPolarAngle={0.22}
+        maxPolarAngle={1.45}
+        enableDamping
+        dampingFactor={0.1}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.55}
+      />
+    </Canvas>
+  );
+}
+
+/* Una tarjeta del catálogo: el diorama (o su ficha 2D) + nombre, medidas y para
+   qué sirve. El Canvas solo vive mientras la tarjeta está en pantalla. */
+function TarjetaInfra({ entry, puede3D, reducedMotion, tierBase }) {
+  const { ref, enVista } = useEnVista();
+  const mostrar3D = puede3D && enVista;
+  const tier = tierBase;
+  return (
+    <li className="vinf__card" ref={ref}>
+      <div className="vinf__lienzo" aria-label={`Diorama de ${entry.nombre}`}>
+        {mostrar3D ? (
+          <LienzoInfra tipo={entry.id} dims={entry.dims} tier={tier} reducedMotion={reducedMotion} />
+        ) : (
+          <div className="vinf__placeholder" aria-hidden={puede3D ? 'true' : undefined}>
+            <span className="vinf__ph-emoji">{entry.emoji}</span>
+            {!puede3D && <span className="vinf__ph-txt">Dibujo de la finca</span>}
+          </div>
+        )}
+      </div>
+      <div className="vinf__meta">
+        <h3>
+          <span className="vinf__emoji" aria-hidden="true">{entry.emoji}</span>
+          {entry.nombre}
+        </h3>
+        <p className="vinf__medidas">{medidasTexto(entry.dims)}</p>
+        <p className="vinf__desc">{entry.descripcion}</p>
+      </div>
+    </li>
+  );
+}
+
+export default function Infraestructura3D() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const capaz3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const puede3D = capaz3D && !ver2d;
+  // En la vitrina el diorama chico no necesita el detalle pleno: 'medio' ahorra.
+  const tierBase = decision.tier === 'alto' ? 'alto' : 'medio';
+
+  const total = Object.keys(INFRAESTRUCTURA).length;
+  const porCategoria = useMemo(
+    () =>
+      INFRAESTRUCTURA_CATEGORIAS.map((cat) => ({
+        cat,
+        items: Object.values(INFRAESTRUCTURA).filter((e) => e.categoria === cat),
+      })),
+    [],
+  );
+
+  return (
+    <main className="vinf">
+      <header className="vinf__head">
+        <p className="vinf__kicker">Los mundos de su finca · vitrina</p>
+        <h1>La infraestructura de su finca</h1>
+        <p className="vinf__lema">
+          Estas son las construcciones que puede agregar a sus mundos para verlos
+          parecidos a los de verdad: su invernadero, su galpón, su tanque, su
+          secadero. Cada una con sus medidas típicas — usted las ajusta a las de su
+          finca. Toque un diorama y gírelo con el dedo.
+        </p>
+        <div className="vinf__barra">
+          <p className="vinf__cuenta">{total} construcciones en el catálogo</p>
+          {capaz3D && (
+            <button type="button" className="vinf__toggle" onClick={() => setVer2d((v) => !v)}>
+              {ver2d ? 'Ver en 3D' : 'Ver como dibujo (2D)'}
+            </button>
+          )}
+        </div>
+        {!capaz3D && (
+          <p className="vinf__aviso">
+            Su equipo va mejor con el dibujo: aquí ve las fichas de cada
+            construcción (van parejas en cualquier teléfono).
+          </p>
+        )}
+      </header>
+
+      {porCategoria.map(({ cat, items }) => {
+        const rot = ROTULO_CAT[cat] || { emoji: '🏗️', txt: cat };
+        return (
+          <section key={cat} className="vinf__grupo" aria-label={rot.txt}>
+            <h2 className="vinf__cat">
+              <span aria-hidden="true">{rot.emoji}</span> {rot.txt}
+            </h2>
+            <ul className="vinf__grid">
+              {items.map((entry) => (
+                <TarjetaInfra
+                  key={entry.id}
+                  entry={entry}
+                  puede3D={puede3D}
+                  reducedMotion={reducedMotion}
+                  tierBase={tierBase}
+                />
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+
+      <footer className="vinf__pie">
+        <p>
+          ¿Le falta una construcción? La librería es de datos: se agrega una
+          entrada al catálogo y aparece aquí y en los mundos. Empiece por medir la
+          suya con la cinta.
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/src/mockups/__tests__/infraestructura3d.smoke.test.jsx
+++ b/src/mockups/__tests__/infraestructura3d.smoke.test.jsx
@@ -1,0 +1,52 @@
+/*
+ * Vitrina #/mockups/infraestructura-3d — smoke (jsdom = equipo humilde).
+ *
+ * En jsdom no hay WebGL, así que `decidirTier()` cae a 'bajo' y la vitrina
+ * NO monta ningún Canvas (three-free): muestra las FICHAS 2D de cada
+ * construcción. Se congela que:
+ *   · la página renderiza título + aviso de equipo humilde sin tocar three;
+ *   · aparecen las 10 construcciones del catálogo, agrupadas por categoría;
+ *   · cada ficha trae su nombre y sus medidas típicas en metros.
+ * Así garantizamos que el catálogo (infraestructuraData.js) y el dispatcher
+ * quedan bien cableados aunque el 3D no se pueda montar en el test.
+ */
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import Infraestructura3D from '../Infraestructura3D.jsx';
+import {
+  INFRAESTRUCTURA,
+  INFRAESTRUCTURA_IDS,
+} from '../../visual/mundo3d/infraestructura/infraestructuraData.js';
+
+afterEach(() => cleanup());
+
+describe('vitrina de infraestructura 3D (mockups/infraestructura-3d)', () => {
+  test('renderiza el catálogo completo como fichas 2D en equipo humilde', () => {
+    const { container } = render(<Infraestructura3D />);
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'La infraestructura de su finca' }),
+    ).toBeInTheDocument();
+    // jsdom sin WebGL → fichas 2D, nunca un Canvas ni una pantalla rota
+    expect(container.querySelector('canvas')).toBeNull();
+    // las 10 construcciones del catálogo, una tarjeta cada una
+    expect(container.querySelectorAll('.vinf__card').length).toBe(INFRAESTRUCTURA_IDS.length);
+    expect(INFRAESTRUCTURA_IDS.length).toBe(10);
+  });
+
+  test('cada construcción muestra su nombre y sus medidas típicas', () => {
+    render(<Infraestructura3D />);
+    // el túnel: 15 × 6 × 3 m (los defaults del catálogo)
+    expect(screen.getByText('Invernadero túnel')).toBeInTheDocument();
+    expect(screen.getByText('15 × 6 × 3 m')).toBeInTheDocument();
+    // el tanque cilíndrico: 4 × 4 × 2,5 m (coma decimal, español CO)
+    expect(screen.getByText('Tanque / reservorio')).toBeInTheDocument();
+    expect(screen.getByText('4 × 4 × 2,5 m')).toBeInTheDocument();
+    // toda pieza del catálogo aparece por nombre
+    for (const id of INFRAESTRUCTURA_IDS) {
+      expect(screen.getByText(INFRAESTRUCTURA[id].nombre)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/visual/mundo3d/infraestructura/Infraestructura.jsx
+++ b/src/visual/mundo3d/infraestructura/Infraestructura.jsx
@@ -1,0 +1,59 @@
+/*
+ * Infraestructura — el DISPATCHER que dibuja CUALQUIER pieza del catálogo.
+ *
+ * El puente entre el catálogo three-free (infraestructuraData.js) y las piezas
+ * R3F (piezasInfra.jsx). Se usa como un ladrillo más dentro de cualquier escena
+ * 3D del framework o de la vitrina:
+ *
+ *   <Infraestructura tipo="invernadero_tunel" pos={[2, 0, -1]} rot={0.4}
+ *                    dims={{ largo: 24, ancho: 6, alto: 3.2 }} tier="alto" />
+ *
+ *   · `tipo`  — id del catálogo (INFRAESTRUCTURA). Desconocido → no dibuja nada.
+ *   · `pos`   — posición en el mundo [x, y, z] (default origen).
+ *   · `rot`   — giro en Y (radianes) para orientarla en el terreno.
+ *   · `dims`  — override de medidas { largo, ancho, alto } sobre los defaults del
+ *               catálogo (el usuario mete las de su finca, medidas con cinta).
+ *   · `params`— override de parámetros de la pieza (colores, módulos…).
+ *   · `tier`  — device-tier del framework: 'bajo'/'medio' → `frugal` (menos
+ *               segmentos, sin detalle fino). Respeta el contrato de perf.
+ *   · `reducedMotion` — viaja a la pieza (hoy todas son estáticas; futuro-safe).
+ *
+ * Devuelve un `<group>` de mallas (sin Canvas/luces): quien lo monta pone el
+ * escenario. Agregar la infraestructura real a un mundo = una entrada de datos +
+ * este componente; ver la infraestructura del catálogo junta = la vitrina
+ * (#/mockups/infraestructura-3d).
+ */
+import { INFRAESTRUCTURA } from './infraestructuraData.js';
+import { PIEZAS_INFRA } from './piezasInfra.jsx';
+
+/* Helper puro de tier (no es un componente): se comparte con el barrel/vitrina.
+   El fast-refresh no aplica a esta librería 3D perezosa. */
+// eslint-disable-next-line react-refresh/only-export-components
+export const esFrugal = (tier) => tier === 'bajo' || tier === 'medio';
+
+export default function Infraestructura({
+  tipo,
+  pos = [0, 0, 0],
+  rot = 0,
+  dims: dimsOverride,
+  params: paramsOverride,
+  tier = 'alto',
+  reducedMotion = false,
+}) {
+  const entrada = INFRAESTRUCTURA[tipo];
+  if (!entrada) return null; // tipo desconocido: no dibuja (nunca una caja huérfana)
+
+  const Pieza = PIEZAS_INFRA[entrada.render];
+  if (!Pieza) return null;
+
+  // Medidas y parámetros = defaults del catálogo + overrides del usuario.
+  const dims = { ...entrada.dims, ...(dimsOverride || {}) };
+  const params = { ...entrada.params, ...(paramsOverride || {}) };
+  const frugal = esFrugal(tier);
+
+  return (
+    <group position={pos} rotation={[0, rot, 0]}>
+      <Pieza dims={dims} params={params} frugal={frugal} reducedMotion={reducedMotion} />
+    </group>
+  );
+}

--- a/src/visual/mundo3d/infraestructura/index.js
+++ b/src/visual/mundo3d/infraestructura/index.js
@@ -1,0 +1,30 @@
+/*
+ * src/visual/mundo3d/infraestructura — LA LIBRERÍA DE INFRAESTRUCTURA 3D.
+ *
+ * Data-driven como el registro de mundos: el catálogo (three-free) declara qué
+ * infraestructura existe y con qué medidas; las piezas (R3F) la dibujan low-poly;
+ * el dispatcher `<Infraestructura>` las une. Agregar la infraestructura real de
+ * la finca a un mundo = una entrada en `infraestructuraData.js` + este componente.
+ *
+ *   import Infraestructura, { INFRAESTRUCTURA, INFRAESTRUCTURA_IDS }
+ *     from '.../visual/mundo3d/infraestructura';
+ *
+ * IMPORTANTE (code-split): el catálogo es THREE-FREE; se puede importar en el
+ * bundle base. Las piezas y el dispatcher importan `three`/R3F: móntelos dentro
+ * de un chunk perezoso (la vitrina ya es `React.lazy`), como el resto del 3D.
+ */
+
+// El dispatcher 3D (importa three: perezoso).
+export { default } from './Infraestructura.jsx';
+export { default as Infraestructura, esFrugal } from './Infraestructura.jsx';
+
+// El registro render→componente (three) por si alguien quiere una pieza suelta.
+export { PIEZAS_INFRA } from './piezasInfra.jsx';
+
+// El catálogo + helpers (three-free, seguros en el bundle base).
+export {
+  INFRAESTRUCTURA,
+  INFRAESTRUCTURA_IDS,
+  INFRAESTRUCTURA_CATEGORIAS,
+  infraPorId,
+} from './infraestructuraData.js';

--- a/src/visual/mundo3d/infraestructura/infraestructuraData.js
+++ b/src/visual/mundo3d/infraestructura/infraestructuraData.js
@@ -1,0 +1,206 @@
+/*
+ * INFRAESTRUCTURA — el CATÁLOGO DATA-DRIVEN de la infraestructura de la finca.
+ *
+ * El hermano del registro de mundos (mundoData.js): así como un MUNDO es una
+ * entrada de datos que apunta a un arquetipo de escena, una INFRAESTRUCTURA es
+ * una entrada de datos que apunta a una PIEZA low-poly (`render`). El objetivo:
+ * que el campesino pueda AGREGAR su infraestructura real a los mundos y verla lo
+ * más parecida posible — su invernadero, su galpón, su tanque — poniendo UNA
+ * entrada aquí (o reusando una que ya existe con otras medidas).
+ *
+ *   INFRAESTRUCTURA[id] = {
+ *     id,          // clave estable (== la propiedad)
+ *     nombre,      // nombre campesino, en "usted" (etiquetas de UI)
+ *     emoji,       // ícono para leyendas/fallback 2D
+ *     categoria,   // familia: 'cultivo protegido' | 'pecuaria' | 'poscosecha' | 'agua' | 'almacenamiento'
+ *     render,      // clave de PIEZAS_INFRA (piezasInfra.jsx) — el componente R3F que la dibuja
+ *     dims,        // medidas TÍPICAS en METROS: { largo, ancho, alto } (parametrizables)
+ *     params,      // parámetros propios de la pieza (color, módulos, tipo de techo…)
+ *     descripcion, // una línea didáctica de para qué sirve
+ *   }
+ *
+ * Sumar una infraestructura = UNA de estas entradas. Si su forma ya existe (p.ej.
+ * otra bodega de otro tamaño), es SOLO datos (cambia `dims`/`params`). Si es una
+ * forma genuinamente nueva, se suma su pieza en `piezasInfra.jsx` — igual que un
+ * arquetipo de escena nuevo. Este archivo es THREE-FREE a propósito (como
+ * mundoData.js/arquetipos.js): no importa `three`, así no infla el bundle base;
+ * el mapeo render→componente vive en la capa 3D (piezasInfra.jsx).
+ *
+ * Medidas: tomadas de rangos reales de finca andina de pequeña/mediana escala
+ * (macrotúnel de 6 m de boca, galpón avícola de 8 m, tanque de 4 m…). Son los
+ * DEFAULTS; el usuario las ajusta con su cinta métrica desde `<Infraestructura
+ * dims={{largo, ancho, alto}} />`.
+ */
+
+export const INFRAESTRUCTURA = {
+  // ── Cultivo protegido ────────────────────────────────────────────────────
+
+  // ⛺ INVERNADERO TÚNEL (macrotúnel): un arco de plástico sobre la cama de
+  //    siembra. Lo más común y barato: media caña de guadua/tubo forrada en
+  //    plástico. Boca de ~6 m, alto = radio del arco.
+  invernadero_tunel: {
+    id: 'invernadero_tunel',
+    nombre: 'Invernadero túnel',
+    emoji: '⛺',
+    categoria: 'cultivo protegido',
+    render: 'invernaderoTunel',
+    dims: { largo: 15, ancho: 6, alto: 3 },
+    params: { arcos: 6, plastico: '#dfeef2', puerta: true },
+    descripcion:
+      'El arco de plástico sobre la cama de siembra: guarda el calor y tapa el aguacero. Lo más barato de armar.',
+  },
+
+  // 🏠 INVERNADERO CUADRADO / CAPILLA (dos aguas): paredes rectas y techo a dos
+  //    aguas con cumbrera. Más alto y ventilado que el túnel; el estándar de
+  //    tomate y pimentón bajo cubierta en clima frío andino.
+  invernadero_capilla: {
+    id: 'invernadero_capilla',
+    nombre: 'Invernadero capilla',
+    emoji: '🏠',
+    categoria: 'cultivo protegido',
+    render: 'invernaderoCapilla',
+    dims: { largo: 20, ancho: 8, alto: 4.2 },
+    params: { pared: 2.5, plastico: '#dfeef2', naves: 1 },
+    descripcion:
+      'De paredes rectas y techo a dos aguas (cumbrera). Más alto y aireado que el túnel: el de tomate y pimentón.',
+  },
+
+  // 🌿 MEDIA-SOMBRA / VIVERO (casa de sombra): estructura de techo plano con
+  //    polisombra (malla que corta el sol) y mesas de propagación. Donde nacen
+  //    las plántulas antes de ir al campo.
+  media_sombra: {
+    id: 'media_sombra',
+    nombre: 'Media-sombra / vivero',
+    emoji: '🌿',
+    categoria: 'cultivo protegido',
+    render: 'mediaSombra',
+    dims: { largo: 10, ancho: 6, alto: 2.5 },
+    params: { sombra: '#4f6f42', mesas: 2 },
+    descripcion:
+      'La casa de sombra donde nacen las plántulas: polisombra que corta el sol fuerte y mesas de propagación.',
+  },
+
+  // ── Pecuaria ─────────────────────────────────────────────────────────────
+
+  // 🐔 GALLINERO A CAMPO ABIERTO: un refugio techado (dormida y ponederos) con
+  //    un corral de malla al aire libre. Gallina feliz que picotea afuera y se
+  //    guarda de noche del zorro.
+  gallinero_campo: {
+    id: 'gallinero_campo',
+    nombre: 'Gallinero a campo abierto',
+    emoji: '🐔',
+    categoria: 'pecuaria',
+    render: 'gallineroCampo',
+    dims: { largo: 8, ancho: 5, alto: 2.2 },
+    params: { refugio: 3, malla: '#b9c2b0' },
+    descripcion:
+      'Refugio techado con ponederos y un corral de malla al aire libre: la gallina picotea afuera y se guarda de noche.',
+  },
+
+  // 🏭 GALPÓN (avícola cerrado): nave larga y baja, cerrada, con cortinas
+  //    laterales y techo de zinc. Para lote grande de pollo/gallina bajo control
+  //    de clima.
+  galpon: {
+    id: 'galpon',
+    nombre: 'Galpón avícola',
+    emoji: '🏭',
+    categoria: 'pecuaria',
+    render: 'galpon',
+    dims: { largo: 24, ancho: 8, alto: 3.2 },
+    params: { cortina: '#c9b487', techo: '#8b8578' },
+    descripcion:
+      'Nave larga y cerrada con cortinas laterales y techo de zinc: el lote grande de pollo o gallina bajo control.',
+  },
+
+  // 🐄 ESTABLO (bovinos): cobertizo de lados abiertos con comedero corrido y
+  //    piso firme. La sombra y el techo para ordeño, suplemento y descanso del
+  //    ganado.
+  establo: {
+    id: 'establo',
+    nombre: 'Establo de bovinos',
+    emoji: '🐄',
+    categoria: 'pecuaria',
+    render: 'establo',
+    dims: { largo: 12, ancho: 6, alto: 3.5 },
+    params: { techo: '#8b8578', comedero: true, plazas: 4 },
+    descripcion:
+      'Cobertizo de lados abiertos con comedero corrido y piso firme: sombra y techo para el ordeño y el descanso.',
+  },
+
+  // ── Almacenamiento ───────────────────────────────────────────────────────
+
+  // 📦 ALMACÉN / BODEGA: construcción cerrada de paredes y portón para guardar
+  //    cosecha, herramienta e insumos secos y a la sombra.
+  almacen_bodega: {
+    id: 'almacen_bodega',
+    nombre: 'Almacén / bodega',
+    emoji: '📦',
+    categoria: 'almacenamiento',
+    render: 'almacenBodega',
+    dims: { largo: 8, ancho: 6, alto: 4 },
+    params: { pared: '#e3d7bf', techo: '#8b8578', porton: true },
+    descripcion:
+      'Cerrada, de paredes y portón: guarda la cosecha, la herramienta y los insumos secos y a la sombra.',
+  },
+
+  // ♻️ COMPOSTERA: módulos de tablas (guadua/madera) donde el abono madura por
+  //    tandas — fresco, medio y hecho. El corazón del reciclaje de la finca.
+  compostera: {
+    id: 'compostera',
+    nombre: 'Compostera',
+    emoji: '♻️',
+    categoria: 'almacenamiento',
+    render: 'compostera',
+    dims: { largo: 4.5, ancho: 1.5, alto: 1.2 },
+    params: { modulos: 3, madera: '#7a5a38' },
+    descripcion:
+      'Módulos de tablas donde el abono madura por tandas: fresco, medio y hecho. El reciclaje de la finca.',
+  },
+
+  // ── Agua ─────────────────────────────────────────────────────────────────
+
+  // 💧 TANQUE / RESERVORIO DE AGUA: depósito cilíndrico que guarda el agua de la
+  //    quebrada o la lluvia para el riego y la casa. La seguridad hídrica en
+  //    temporada seca.
+  tanque_agua: {
+    id: 'tanque_agua',
+    nombre: 'Tanque / reservorio',
+    emoji: '💧',
+    categoria: 'agua',
+    render: 'tanqueAgua',
+    dims: { largo: 4, ancho: 4, alto: 2.5 },
+    params: { material: '#9a8b74', tapa: true, tuberia: true },
+    descripcion:
+      'El depósito que guarda el agua de la quebrada o la lluvia para el riego y la casa: la reserva de la sequía.',
+  },
+
+  // ── Poscosecha ───────────────────────────────────────────────────────────
+
+  // ☕ SECADERO DE CAFÉ (parabólico / marquesina): túnel bajo de plástico sobre
+  //    camas elevadas donde el pergamino seca al sol sin mojarse. El paso que
+  //    define la taza.
+  secadero_cafe: {
+    id: 'secadero_cafe',
+    nombre: 'Secadero de café',
+    emoji: '☕',
+    categoria: 'poscosecha',
+    render: 'secaderoCafe',
+    dims: { largo: 12, ancho: 5, alto: 2.6 },
+    params: { plastico: '#e8e0cf', grano: '#d4c199', camas: true },
+    descripcion:
+      'Túnel parabólico sobre camas elevadas: el pergamino seca al sol sin mojarse. El paso que define la taza.',
+  },
+};
+
+/** Ids de todas las infraestructuras registradas, en orden de catálogo. */
+export const INFRAESTRUCTURA_IDS = Object.keys(INFRAESTRUCTURA);
+
+/** Las categorías presentes, en orden de primera aparición (para agrupar la vitrina). */
+export const INFRAESTRUCTURA_CATEGORIAS = INFRAESTRUCTURA_IDS.reduce((acc, id) => {
+  const c = INFRAESTRUCTURA[id].categoria;
+  if (!acc.includes(c)) acc.push(c);
+  return acc;
+}, /** @type {string[]} */ ([]));
+
+/** Resuelve una entrada del catálogo por id (o `null` si no existe). */
+export const infraPorId = (id) => INFRAESTRUCTURA[id] || null;

--- a/src/visual/mundo3d/infraestructura/piezasInfra.jsx
+++ b/src/visual/mundo3d/infraestructura/piezasInfra.jsx
@@ -1,0 +1,722 @@
+/*
+ * piezasInfra — las PIEZAS low-poly de la infraestructura de la finca.
+ *
+ * Un componente R3F por FORMA de construcción (invernadero, galpón, tanque…).
+ * Cada uno recibe el MISMO contrato y devuelve un `<group>` centrado en el origen
+ * con la base en y=0, listo para caer dentro de cualquier escena (EscenaBase3D) o
+ * de la vitrina. Nada de GLTF ni texturas: primitivas + `meshLambertMaterial`
+ * con `flatShading` (el look claymation del framework) y la PALETA madre. El
+ * plástico y la malla son el único material translúcido (opacidad baja).
+ *
+ * CONTRATO uniforme (idéntico para las 10 piezas):
+ *   { dims: { largo, ancho, alto } (metros), params, frugal, reducedMotion }
+ *
+ *   · `largo` corre por X, `ancho` por Z, `alto` por Y. Footprint centrado.
+ *   · `frugal` (device-tier medio/bajo) baja segmentos y suelta detalle fino.
+ *   · las piezas son ESTÁTICAS (sin useFrame) → reduced-motion seguro por
+ *     construcción; el flag viaja por si una pieza futura quiere latir.
+ *
+ * El mapeo id→componente (PIEZAS_INFRA) lo consume `Infraestructura.jsx`; el
+ * catálogo de datos (infraestructuraData.js) es three-free y solo guarda la
+ * CLAVE de render, no el componente — misma disciplina que arquetipos/mundoData.
+ */
+import { useMemo } from 'react';
+import * as THREE from 'three';
+import { PALETA } from '../atmosferaMadre.js';
+
+/* Colores locales de obra que no viven en la PALETA madre (translúcidos y
+   herrajes propios de la infraestructura). Grises CÁLIDOS, jamás neutros. */
+const OBRA = {
+  plastico: '#dfeef2', // el plástico de invernadero (se pinta translúcido)
+  malla: '#b9c2b0', // la malla/polisombra galvanizada, verde-gris
+  zinc: PALETA.lamina, // la teja de zinc
+  concreto: PALETA.concreto, // el piso firme, la placa
+  guadua: '#b39a5e', // la caña/guadua clara de la estructura campesina
+};
+
+/* Material de PLÁSTICO/MALLA translúcido: opacidad baja, doble cara y sin
+   escribir profundidad (evita el sorteo feo entre paños). Reusado por todo lo
+   que sea cubierta de plástico o paño de malla. */
+function matTranslucido(color, opacidad = 0.32) {
+  return (
+    <meshLambertMaterial
+      color={color}
+      transparent
+      opacity={opacidad}
+      depthWrite={false}
+      side={THREE.DoubleSide}
+      flatShading
+    />
+  );
+}
+
+/* Un poste vertical (guadua/madera/tubo): el ladrillo estructural de casi todo. */
+function Poste({ pos, alto, r = 0.06, color = PALETA.madera, seg = 5 }) {
+  return (
+    <mesh position={[pos[0], alto / 2, pos[2]]}>
+      <cylinderGeometry args={[r, r * 1.15, alto, seg]} />
+      <meshLambertMaterial color={color} flatShading />
+    </mesh>
+  );
+}
+
+/* Una placa/piso firme fino centrado (concreto): posa la construcción. */
+function Placa({ largo, ancho, color = OBRA.concreto, alto = 0.08 }) {
+  return (
+    <mesh position={[0, alto / 2, 0]}>
+      <boxGeometry args={[largo, alto, ancho]} />
+      <meshLambertMaterial color={color} flatShading />
+    </mesh>
+  );
+}
+
+// ─── 1. INVERNADERO TÚNEL (macrotúnel) ──────────────────────────────────────
+// Media caña de plástico sobre la cama de siembra. La cubierta es un medio
+// cilindro (dome arriba, base en y=0), estirado en Y para respetar `alto` cuando
+// no es exactamente el radio. Arcos de guadua/tubo cada tanto + tapas de plástico
+// en los extremos + camas de tierra adentro.
+export function InvernaderoTunel({ dims, params = {}, frugal = false }) {
+  const { largo: L, ancho: W, alto: H } = dims;
+  const r = W / 2;
+  const escY = H / r; // estira la media caña para llegar a `alto`
+  const segArco = frugal ? 10 : 18;
+  const nArcos = frugal ? Math.max(2, Math.round((params.arcos ?? 6) / 2)) : (params.arcos ?? 6);
+  const plastico = params.plastico || OBRA.plastico;
+
+  const arcosX = useMemo(
+    () => Array.from({ length: nArcos }, (_, i) => -L / 2 + (i + 0.5) * (L / nArcos)),
+    [nArcos, L],
+  );
+  const camasZ = [-W * 0.22, W * 0.22];
+
+  return (
+    <group>
+      {/* camas de siembra adentro (dos lomos de tierra) */}
+      {!frugal &&
+        camasZ.map((z, i) => (
+          <mesh key={i} position={[0, 0.12, z]}>
+            <boxGeometry args={[L * 0.92, 0.24, W * 0.3]} />
+            <meshLambertMaterial color={PALETA.tierra} flatShading />
+          </mesh>
+        ))}
+
+      {/* la cubierta de plástico (media caña) + arcos, estirados a `alto` */}
+      <group scale={[1, escY, 1]}>
+        {/* piel de plástico */}
+        <mesh rotation={[0, 0, Math.PI / 2]}>
+          <cylinderGeometry args={[r, r, L, segArco, 1, true, 0, Math.PI]} />
+          {matTranslucido(plastico, 0.3)}
+        </mesh>
+        {/* arcos estructurales (medio toro que sube de z=-r a z=+r) */}
+        {arcosX.map((x, i) => (
+          <mesh key={i} position={[x, 0, 0]} rotation={[0, Math.PI / 2, 0]}>
+            <torusGeometry args={[r, 0.05, 5, segArco, Math.PI]} />
+            <meshLambertMaterial color={OBRA.guadua} flatShading />
+          </mesh>
+        ))}
+        {/* tapas de plástico en los dos extremos (medio disco) */}
+        {[-L / 2, L / 2].map((x, i) => (
+          <mesh key={i} position={[x, 0, 0]} rotation={[0, Math.PI / 2, 0]}>
+            <circleGeometry args={[r, segArco, 0, Math.PI]} />
+            {matTranslucido(plastico, 0.22)}
+          </mesh>
+        ))}
+      </group>
+
+      {/* la puerta (marco oscuro) en la tapa frontal */}
+      {params.puerta !== false && (
+        <mesh position={[L / 2 + 0.01, H * 0.32, 0]}>
+          <boxGeometry args={[0.04, H * 0.6, Math.min(1, W * 0.28)]} />
+          <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
+        </mesh>
+      )}
+    </group>
+  );
+}
+
+// ─── 2. INVERNADERO CAPILLA (dos aguas) ─────────────────────────────────────
+// Paredes rectas hasta `pared` y techo a dos aguas hasta `alto` (cumbrera).
+// Postes en las esquinas y a media luz, paños de plástico en las paredes, dos
+// faldones de techo y la viga de cumbrera.
+export function InvernaderoCapilla({ dims, params = {}, frugal = false }) {
+  const { largo: L, ancho: W, alto: H } = dims;
+  const p = Math.min(params.pared ?? 2.5, H - 0.4); // altura de pared (alero)
+  const plastico = params.plastico || OBRA.plastico;
+  const subeTecho = H - p; // lo que sube el techo desde el alero a la cumbrera
+  const faldon = Math.hypot(W / 2, subeTecho); // largo del faldón inclinado
+  const ang = Math.atan2(subeTecho, W / 2); // pendiente del agua
+
+  const postesX = frugal ? [-L / 2, L / 2] : [-L / 2, 0, L / 2];
+
+  return (
+    <group>
+      {/* postes de esquina y de media luz */}
+      {postesX.map((x) =>
+        [-W / 2, W / 2].map((z) => (
+          <Poste key={`${x}:${z}`} pos={[x, 0, z]} alto={p} r={0.07} color={OBRA.guadua} />
+        )),
+      )}
+
+      {/* paños de plástico de las cuatro paredes (hasta el alero) */}
+      {/* laterales largos */}
+      {[-W / 2, W / 2].map((z, i) => (
+        <mesh key={`lat${i}`} position={[0, p / 2, z]}>
+          <boxGeometry args={[L, p, 0.02]} />
+          {matTranslucido(plastico, 0.26)}
+        </mesh>
+      ))}
+      {/* frentes cortos (con hueco de puerta insinuado por ser más translúcido) */}
+      {[-L / 2, L / 2].map((x, i) => (
+        <mesh key={`fr${i}`} position={[x, p / 2, 0]}>
+          <boxGeometry args={[0.02, p, W]} />
+          {matTranslucido(plastico, 0.2)}
+        </mesh>
+      ))}
+
+      {/* viga de cumbrera */}
+      <mesh position={[0, H, 0]}>
+        <boxGeometry args={[L, 0.08, 0.08]} />
+        <meshLambertMaterial color={PALETA.madera} flatShading />
+      </mesh>
+
+      {/* dos faldones de techo a dos aguas (pendiente `ang` desde el alero) */}
+      {[1, -1].map((s) => (
+        <mesh
+          key={s}
+          position={[0, p + subeTecho / 2, (s * W) / 4]}
+          rotation={[s * ang, 0, 0]}
+        >
+          <boxGeometry args={[L, 0.03, faldon]} />
+          {matTranslucido(plastico, 0.3)}
+        </mesh>
+      ))}
+
+      {/* triángulos de los frentes (cerchas de cumbrera) */}
+      {[-L / 2, L / 2].map((x, i) => (
+        <mesh key={`ce${i}`} position={[x, p, 0]}>
+          <cylinderGeometry args={[0.05, 0.05, subeTecho, 4]} />
+          <meshLambertMaterial color={OBRA.guadua} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+// ─── 3. MEDIA-SOMBRA / VIVERO ───────────────────────────────────────────────
+// Techo plano de polisombra sobre postes, paños de malla en los lados y mesas de
+// propagación con bandejas de plántulas.
+export function MediaSombra({ dims, params = {}, frugal = false }) {
+  const { largo: L, ancho: W, alto: H } = dims;
+  const sombra = params.sombra || OBRA.malla;
+  const nMesas = frugal ? 1 : (params.mesas ?? 2);
+
+  const postes = [];
+  for (const x of [-L / 2, 0, L / 2]) for (const z of [-W / 2, W / 2]) postes.push([x, z]);
+
+  const mesasZ = useMemo(
+    () => Array.from({ length: nMesas }, (_, i) => -W / 2 + (i + 0.7) * (W / (nMesas + 0.4))),
+    [nMesas, W],
+  );
+  // plántulas por mesa (deterministas)
+  const plantulas = useMemo(() => {
+    if (frugal) return [];
+    const cols = Math.max(3, Math.round(L / 1.4));
+    return Array.from({ length: cols }, (_, i) => -L / 2 + (i + 0.5) * (L / cols));
+  }, [L, frugal]);
+
+  return (
+    <group>
+      {postes.map(([x, z]) => (
+        <Poste key={`${x}:${z}`} pos={[x, 0, z]} alto={H} r={0.06} color={PALETA.madera} />
+      ))}
+
+      {/* techo plano de polisombra */}
+      <mesh position={[0, H, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[L, W]} />
+        {matTranslucido(sombra, 0.42)}
+      </mesh>
+      {/* paños de malla en los cuatro lados (media altura, aireado) */}
+      {[-W / 2, W / 2].map((z, i) => (
+        <mesh key={`ml${i}`} position={[0, H * 0.55, z]}>
+          <planeGeometry args={[L, H * 0.9]} />
+          {matTranslucido(sombra, 0.3)}
+        </mesh>
+      ))}
+
+      {/* mesas de propagación con bandejas y plántulas */}
+      {mesasZ.map((z, mi) => (
+        <group key={mi} position={[0, 0, z]}>
+          {/* patas */}
+          {[-L / 2 + 0.3, L / 2 - 0.3].map((x) =>
+            [-0.35, 0.35].map((dz) => (
+              <Poste key={`${x}:${dz}`} pos={[x, 0, dz]} alto={0.8} r={0.03} color={PALETA.maderaOscura} seg={4} />
+            )),
+          )}
+          {/* tablero de la mesa */}
+          <mesh position={[0, 0.82, 0]}>
+            <boxGeometry args={[L * 0.94, 0.05, 0.8]} />
+            <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+          </mesh>
+          {/* bandeja de germinación */}
+          <mesh position={[0, 0.87, 0]}>
+            <boxGeometry args={[L * 0.9, 0.05, 0.72]} />
+            <meshLambertMaterial color={PALETA.tierra} flatShading />
+          </mesh>
+          {/* las plántulas: puntitos verdes en fila */}
+          {plantulas.map((x, i) => (
+            <mesh key={i} position={[x, 0.95, 0]}>
+              <coneGeometry args={[0.05, 0.14, 5]} />
+              <meshLambertMaterial color={PALETA.follajeClaro} flatShading />
+            </mesh>
+          ))}
+        </group>
+      ))}
+    </group>
+  );
+}
+
+// ─── 4. GALLINERO A CAMPO ABIERTO ───────────────────────────────────────────
+// Un corral de malla (postes + paños translúcidos) con un refugio techado en una
+// esquina: casita de tablas + techo a un agua + pop-hole y palo de dormir.
+export function GallineroCampo({ dims, params = {}, frugal = false }) {
+  const { largo: L, ancho: W, alto: H } = dims;
+  const malla = params.malla || OBRA.malla;
+  const rf = Math.min(params.refugio ?? 3, Math.min(L, W) - 0.5); // lado del refugio
+  const hR = Math.min(2, H); // alto del refugio
+
+  // postes del perímetro del corral
+  const postes = [];
+  for (const x of [-L / 2, 0, L / 2]) for (const z of [-W / 2, W / 2]) postes.push([x, z]);
+  for (const z of [0]) for (const x of [-L / 2, L / 2]) postes.push([x, z]);
+
+  const refX = -L / 2 + rf / 2; // refugio en el extremo izquierdo
+  const refZ = -W / 2 + rf / 2;
+
+  return (
+    <group>
+      {/* postes del corral */}
+      {postes.map(([x, z], i) => (
+        <Poste key={i} pos={[x, 0, z]} alto={H} r={0.05} color={PALETA.madera} seg={4} />
+      ))}
+      {/* paños de malla del perímetro (cuatro lados) */}
+      {[-W / 2, W / 2].map((z, i) => (
+        <mesh key={`mz${i}`} position={[0, H / 2, z]}>
+          <planeGeometry args={[L, H]} />
+          {matTranslucido(malla, 0.22)}
+        </mesh>
+      ))}
+      {[-L / 2, L / 2].map((x, i) => (
+        <mesh key={`mx${i}`} position={[x, H / 2, 0]} rotation={[0, Math.PI / 2, 0]}>
+          <planeGeometry args={[W, H]} />
+          {matTranslucido(malla, 0.22)}
+        </mesh>
+      ))}
+
+      {/* el refugio en la esquina: cuerpo de tablas */}
+      <group position={[refX, 0, refZ]}>
+        <mesh position={[0, hR * 0.42, 0]}>
+          <boxGeometry args={[rf, hR * 0.84, rf]} />
+          <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+        </mesh>
+        {/* techo a un agua (inclinado) */}
+        <mesh position={[0, hR * 0.9, 0]} rotation={[0.28, 0, 0]}>
+          <boxGeometry args={[rf * 1.15, 0.05, rf * 1.2]} />
+          <meshLambertMaterial color={OBRA.zinc} flatShading />
+        </mesh>
+        {/* pop-hole (la puertita de las gallinas) */}
+        <mesh position={[0, hR * 0.22, rf / 2 + 0.01]}>
+          <boxGeometry args={[rf * 0.3, hR * 0.4, 0.04]} />
+          <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
+        </mesh>
+        {/* rampita de salida */}
+        <mesh position={[0, hR * 0.07, rf / 2 + 0.28]} rotation={[0.5, 0, 0]}>
+          <boxGeometry args={[rf * 0.3, 0.03, 0.5]} />
+          <meshLambertMaterial color={PALETA.madera} flatShading />
+        </mesh>
+      </group>
+
+      {/* un comedero y un bebedero afuera (detalle) */}
+      {!frugal && (
+        <>
+          <mesh position={[L * 0.18, 0.12, 0]}>
+            <cylinderGeometry args={[0.18, 0.22, 0.24, 8]} />
+            <meshLambertMaterial color={OBRA.zinc} flatShading />
+          </mesh>
+          <mesh position={[L * 0.28, 0.1, W * 0.2]}>
+            <cylinderGeometry args={[0.14, 0.16, 0.2, 8]} />
+            <meshLambertMaterial color={PALETA.agua} flatShading />
+          </mesh>
+        </>
+      )}
+    </group>
+  );
+}
+
+// ─── 5. GALPÓN AVÍCOLA (cerrado) ────────────────────────────────────────────
+// Nave larga y baja: zócalo bajo, cortinas laterales enrollables (bandas de
+// color), techo a dos aguas de zinc con alero, y muros de frente/fondo.
+export function Galpon({ dims, params = {}, frugal = false }) {
+  const { largo: L, ancho: W, alto: H } = dims;
+  const cortina = params.cortina || '#c9b487';
+  const techo = params.techo || OBRA.zinc;
+  const zocalo = Math.min(0.6, H * 0.2);
+  const cumbrera = H + Math.min(1.2, W * 0.18);
+  const subeTecho = cumbrera - H;
+  const faldon = Math.hypot(W / 2 + 0.3, subeTecho);
+  const ang = Math.atan2(subeTecho, W / 2 + 0.3);
+
+  return (
+    <group>
+      <Placa largo={L} ancho={W} />
+      {/* postes */}
+      {(frugal ? [-L / 2, L / 2] : [-L / 2, -L / 6, L / 6, L / 2]).map((x) =>
+        [-W / 2, W / 2].map((z) => (
+          <Poste key={`${x}:${z}`} pos={[x, 0, z]} alto={H} r={0.07} color={OBRA.zinc} />
+        )),
+      )}
+      {/* zócalo bajo de bloque en los laterales */}
+      {[-W / 2, W / 2].map((z, i) => (
+        <mesh key={`zo${i}`} position={[0, zocalo / 2, z]}>
+          <boxGeometry args={[L, zocalo, 0.12]} />
+          <meshLambertMaterial color={OBRA.concreto} flatShading />
+        </mesh>
+      ))}
+      {/* cortinas laterales (bandas de lona) */}
+      {[-W / 2, W / 2].map((z, i) => (
+        <mesh key={`co${i}`} position={[0, zocalo + (H - zocalo) / 2, z]}>
+          <boxGeometry args={[L, H - zocalo, 0.06]} />
+          <meshLambertMaterial color={cortina} flatShading />
+        </mesh>
+      ))}
+      {/* muros de frente y fondo */}
+      {[-L / 2, L / 2].map((x, i) => (
+        <mesh key={`mu${i}`} position={[x, H / 2, 0]}>
+          <boxGeometry args={[0.1, H, W]} />
+          <meshLambertMaterial color={PALETA.cal} flatShading />
+        </mesh>
+      ))}
+      {/* techo a dos aguas de zinc con alero */}
+      <mesh position={[0, H, 0]}>
+        <boxGeometry args={[L, 0.08, 0.08]} />
+        <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
+      </mesh>
+      {[1, -1].map((s) => (
+        <mesh
+          key={s}
+          position={[0, H + subeTecho / 2, (s * W) / 4]}
+          rotation={[s * ang, 0, 0]}
+        >
+          <boxGeometry args={[L + 0.4, 0.05, faldon]} />
+          <meshLambertMaterial color={techo} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+// ─── 6. ESTABLO DE BOVINOS ──────────────────────────────────────────────────
+// Cobertizo de lados abiertos: piso firme, postes, pared de tablas atrás, techo
+// a un agua de zinc y comedero corrido al frente.
+export function Establo({ dims, params = {}, frugal = false }) {
+  const { largo: L, ancho: W, alto: H } = dims;
+  const techo = params.techo || OBRA.zinc;
+  const hFrente = H;
+  const hFondo = H - Math.min(0.8, W * 0.14); // techo a un agua (cae hacia el fondo)
+  const faldon = Math.hypot(W, hFrente - hFondo);
+  const ang = Math.atan2(hFrente - hFondo, W);
+
+  return (
+    <group>
+      <Placa largo={L} ancho={W} color={OBRA.concreto} alto={0.1} />
+      {/* postes del frente (altos) y del fondo (bajos) */}
+      {(frugal ? [-L / 2, L / 2] : [-L / 2, 0, L / 2]).map((x) => (
+        <group key={x}>
+          <Poste pos={[x, 0, W / 2]} alto={hFrente} r={0.08} color={PALETA.madera} />
+          <Poste pos={[x, 0, -W / 2]} alto={hFondo} r={0.08} color={PALETA.madera} />
+        </group>
+      ))}
+      {/* pared de tablas atrás (tres listones) */}
+      {[0.35, 0.6, 0.85].map((f, i) => (
+        <mesh key={i} position={[0, hFondo * f, -W / 2]}>
+          <boxGeometry args={[L, hFondo * 0.2, 0.05]} />
+          <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+        </mesh>
+      ))}
+      {/* techo a un agua de zinc (alto al frente z=+W/2, cae hacia el fondo) */}
+      <mesh position={[0, (hFrente + hFondo) / 2 + 0.08, 0]} rotation={[-ang, 0, 0]}>
+        <boxGeometry args={[L + 0.3, 0.06, faldon + 0.3]} />
+        <meshLambertMaterial color={techo} flatShading />
+      </mesh>
+      {/* comedero corrido al frente (canal en U aproximado) */}
+      {params.comedero !== false && (
+        <group position={[0, 0, W / 2 - 0.35]}>
+          <mesh position={[0, 0.45, 0]}>
+            <boxGeometry args={[L * 0.9, 0.1, 0.5]} />
+            <meshLambertMaterial color={OBRA.concreto} flatShading />
+          </mesh>
+          <mesh position={[0, 0.62, 0]}>
+            <boxGeometry args={[L * 0.9, 0.24, 0.14]} />
+            <meshLambertMaterial color={OBRA.concreto} flatShading />
+          </mesh>
+          {/* pasto en el comedero */}
+          {!frugal && (
+            <mesh position={[0, 0.55, 0]}>
+              <boxGeometry args={[L * 0.82, 0.12, 0.28]} />
+              <meshLambertMaterial color={PALETA.follaje} flatShading />
+            </mesh>
+          )}
+        </group>
+      )}
+      {/* divisiones de plaza (postes cortos) */}
+      {!frugal &&
+        params.plazas > 1 &&
+        Array.from({ length: params.plazas - 1 }, (_, i) => {
+          const x = -L / 2 + (i + 1) * (L / params.plazas);
+          return <Poste key={i} pos={[x, 0, 0]} alto={1.1} r={0.05} color={PALETA.maderaOscura} seg={4} />;
+        })}
+    </group>
+  );
+}
+
+// ─── 7. ALMACÉN / BODEGA ────────────────────────────────────────────────────
+// Construcción cerrada: placa, cuatro muros, techo a dos aguas de zinc, portón
+// grande y una ventanita.
+export function AlmacenBodega({ dims, params = {}, frugal = false }) {
+  const { largo: L, ancho: W, alto: H } = dims;
+  const pared = params.pared || '#e3d7bf';
+  const techo = params.techo || OBRA.zinc;
+  const muro = H * 0.72; // alto de muro (el resto es el frontón del techo)
+  const subeTecho = H - muro;
+  const faldon = Math.hypot(W / 2 + 0.25, subeTecho);
+  const ang = Math.atan2(subeTecho, W / 2 + 0.25);
+
+  return (
+    <group>
+      <Placa largo={L + 0.3} ancho={W + 0.3} />
+      {/* cuatro muros */}
+      {[-W / 2, W / 2].map((z, i) => (
+        <mesh key={`z${i}`} position={[0, muro / 2, z]}>
+          <boxGeometry args={[L, muro, 0.12]} />
+          <meshLambertMaterial color={pared} flatShading />
+        </mesh>
+      ))}
+      {[-L / 2, L / 2].map((x, i) => (
+        <mesh key={`x${i}`} position={[x, muro / 2, 0]}>
+          <boxGeometry args={[0.12, muro, W]} />
+          <meshLambertMaterial color={pared} flatShading />
+        </mesh>
+      ))}
+      {/* frontones triangulares (tapan el hueco del techo a dos aguas) */}
+      {[-L / 2, L / 2].map((x, i) => (
+        <mesh key={`ft${i}`} position={[x, muro, 0]}>
+          <cylinderGeometry args={[0.06, 0.06, subeTecho, 4]} />
+          <meshLambertMaterial color={pared} flatShading />
+        </mesh>
+      ))}
+      {/* techo a dos aguas */}
+      <mesh position={[0, H, 0]}>
+        <boxGeometry args={[L + 0.2, 0.08, 0.08]} />
+        <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
+      </mesh>
+      {[1, -1].map((s) => (
+        <mesh
+          key={s}
+          position={[0, muro + subeTecho / 2, (s * W) / 4]}
+          rotation={[s * ang, 0, 0]}
+        >
+          <boxGeometry args={[L + 0.3, 0.06, faldon]} />
+          <meshLambertMaterial color={techo} flatShading />
+        </mesh>
+      ))}
+      {/* portón grande al frente */}
+      {params.porton !== false && (
+        <mesh position={[0, muro * 0.42, W / 2 + 0.02]}>
+          <boxGeometry args={[Math.min(2.4, L * 0.4), muro * 0.82, 0.06]} />
+          <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
+        </mesh>
+      )}
+      {/* ventanita */}
+      {!frugal && (
+        <mesh position={[L * 0.3, muro * 0.62, W / 2 + 0.02]}>
+          <boxGeometry args={[0.7, 0.6, 0.05]} />
+          <meshLambertMaterial color={PALETA.agua} flatShading />
+        </mesh>
+      )}
+    </group>
+  );
+}
+
+// ─── 8. COMPOSTERA ──────────────────────────────────────────────────────────
+// Módulos de tablas (guadua/madera) con montones de compost en distinto punto de
+// madurez: fresco (verdoso), medio (café) y hecho (tierra negra).
+export function Compostera({ dims, params = {}, frugal = false }) {
+  const { largo: L, ancho: W, alto: H } = dims;
+  const n = params.modulos ?? 3;
+  const madera = params.madera || OBRA.guadua;
+  const anchoMod = L / n;
+  const estados = ['#5a6a2e', '#7a5a34', '#3a2c1c']; // fresco → medio → hecho
+
+  const mods = useMemo(
+    () => Array.from({ length: n }, (_, i) => -L / 2 + (i + 0.5) * anchoMod),
+    [n, L, anchoMod],
+  );
+
+  return (
+    <group>
+      {mods.map((x, i) => (
+        <group key={i} position={[x, 0, 0]}>
+          {/* postes de la casilla */}
+          {[-anchoMod / 2, anchoMod / 2].map((dx) =>
+            [-W / 2, W / 2].map((z) => (
+              <Poste key={`${dx}:${z}`} pos={[dx, 0, z]} alto={H} r={0.05} color={PALETA.maderaOscura} seg={4} />
+            )),
+          )}
+          {/* tablas horizontales del fondo y los costados (tres listones) */}
+          {[0.2, 0.5, 0.8].map((f, j) => (
+            <group key={j}>
+              <mesh position={[0, H * f, -W / 2]}>
+                <boxGeometry args={[anchoMod, H * 0.22, 0.04]} />
+                <meshLambertMaterial color={madera} flatShading />
+              </mesh>
+              {i === 0 && (
+                <mesh position={[-anchoMod / 2, H * f, 0]}>
+                  <boxGeometry args={[0.04, H * 0.22, W]} />
+                  <meshLambertMaterial color={madera} flatShading />
+                </mesh>
+              )}
+              <mesh position={[anchoMod / 2, H * f, 0]}>
+                <boxGeometry args={[0.04, H * 0.22, W]} />
+                <meshLambertMaterial color={madera} flatShading />
+              </mesh>
+            </group>
+          ))}
+          {/* el montón de compost, según su estado de madurez */}
+          <mesh position={[0, H * 0.32, 0]} scale={[anchoMod * 0.42, H * 0.6, W * 0.42]}>
+            <sphereGeometry args={[1, frugal ? 6 : 10, frugal ? 5 : 7, 0, Math.PI * 2, 0, Math.PI / 2]} />
+            <meshLambertMaterial color={estados[i % estados.length]} flatShading />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}
+
+// ─── 9. TANQUE / RESERVORIO DE AGUA ─────────────────────────────────────────
+// Depósito cilíndrico con base, agua adentro, tapa opcional y una tubería en L
+// que entra el agua.
+export function TanqueAgua({ dims, params = {}, frugal = false }) {
+  const { ancho: W, alto: H } = dims;
+  const r = W / 2;
+  const material = params.material || PALETA.piedra;
+  const seg = frugal ? 12 : 22;
+
+  return (
+    <group>
+      {/* base anular (poyo) */}
+      <mesh position={[0, 0.06, 0]}>
+        <cylinderGeometry args={[r * 1.06, r * 1.12, 0.12, seg]} />
+        <meshLambertMaterial color={OBRA.concreto} flatShading />
+      </mesh>
+      {/* pared del tanque */}
+      <mesh position={[0, H / 2, 0]}>
+        <cylinderGeometry args={[r, r, H, seg, 1, true]} />
+        <meshLambertMaterial color={material} flatShading side={THREE.DoubleSide} />
+      </mesh>
+      {/* el agua adentro (disco cerca del borde) */}
+      <mesh position={[0, H * 0.86, 0]}>
+        <cylinderGeometry args={[r * 0.95, r * 0.95, 0.06, seg]} />
+        <meshLambertMaterial color={PALETA.agua} flatShading />
+      </mesh>
+      {/* tapa (cono suave) */}
+      {params.tapa !== false && (
+        <mesh position={[0, H + 0.12, 0]}>
+          <coneGeometry args={[r * 1.02, 0.28, seg]} />
+          <meshLambertMaterial color={OBRA.zinc} flatShading />
+        </mesh>
+      )}
+      {/* tubería en L que llena el tanque */}
+      {params.tuberia !== false && (
+        <group>
+          <mesh position={[r + 0.15, H * 0.9, 0]}>
+            <cylinderGeometry args={[0.06, 0.06, 0.5, 6]} />
+            <meshLambertMaterial color={OBRA.zinc} flatShading />
+          </mesh>
+          <mesh position={[r + 0.4, H * 0.9, 0]} rotation={[0, 0, Math.PI / 2]}>
+            <cylinderGeometry args={[0.06, 0.06, H * 0.9, 6]} />
+            <meshLambertMaterial color={OBRA.zinc} flatShading />
+          </mesh>
+        </group>
+      )}
+    </group>
+  );
+}
+
+// ─── 10. SECADERO DE CAFÉ (parabólico / marquesina) ─────────────────────────
+// Túnel bajo de plástico (arco parabólico, más achatado que el invernadero)
+// sobre camas elevadas donde el pergamino seca al sol. Patas + tablero + capa de
+// grano + piel de plástico.
+export function SecaderoCafe({ dims, params = {}, frugal = false }) {
+  const { largo: L, ancho: W, alto: H } = dims;
+  const r = W / 2;
+  const escY = H / r;
+  const plastico = params.plastico || '#e8e0cf';
+  const grano = params.grano || '#d4c199';
+  const seg = frugal ? 10 : 18;
+  const hCama = 0.7; // alto de la cama de secado
+
+  return (
+    <group>
+      {/* camas elevadas: patas + tablero + capa de grano */}
+      {params.camas !== false && (
+        <group>
+          {[-L / 2 + 0.4, 0, L / 2 - 0.4].map((x) =>
+            [-W * 0.28, W * 0.28].map((z) => (
+              <Poste key={`${x}:${z}`} pos={[x, 0, z]} alto={hCama} r={0.04} color={PALETA.madera} seg={4} />
+            )),
+          )}
+          <mesh position={[0, hCama + 0.03, 0]}>
+            <boxGeometry args={[L * 0.94, 0.05, W * 0.66]} />
+            <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+          </mesh>
+          {/* la capa de café en pergamino secándose */}
+          <mesh position={[0, hCama + 0.08, 0]}>
+            <boxGeometry args={[L * 0.9, 0.05, W * 0.6]} />
+            <meshLambertMaterial color={grano} flatShading />
+          </mesh>
+        </group>
+      )}
+
+      {/* la piel parabólica de plástico (media caña achatada) */}
+      <group position={[0, hCama, 0]} scale={[1, escY, 1]}>
+        <mesh rotation={[0, 0, Math.PI / 2]}>
+          <cylinderGeometry args={[r, r, L, seg, 1, true, 0, Math.PI]} />
+          {matTranslucido(plastico, 0.28)}
+        </mesh>
+        {/* arcos del secadero */}
+        {(frugal ? [-L / 2 + 0.5, L / 2 - 0.5] : [-L / 2 + 0.5, 0, L / 2 - 0.5]).map((x, i) => (
+          <mesh key={i} position={[x, 0, 0]} rotation={[0, Math.PI / 2, 0]}>
+            <torusGeometry args={[r, 0.045, 5, seg, Math.PI]} />
+            <meshLambertMaterial color={OBRA.guadua} flatShading />
+          </mesh>
+        ))}
+      </group>
+    </group>
+  );
+}
+
+/* El REGISTRO render→componente. La clave la trae `INFRAESTRUCTURA[id].render`;
+   `Infraestructura.jsx` la resuelve aquí. Sumar una forma nueva = una entrada.
+   No es un componente (mapa de datos): el fast-refresh no aplica a esta librería. */
+// eslint-disable-next-line react-refresh/only-export-components
+export const PIEZAS_INFRA = {
+  invernaderoTunel: InvernaderoTunel,
+  invernaderoCapilla: InvernaderoCapilla,
+  mediaSombra: MediaSombra,
+  gallineroCampo: GallineroCampo,
+  galpon: Galpon,
+  establo: Establo,
+  almacenBodega: AlmacenBodega,
+  compostera: Compostera,
+  tanqueAgua: TanqueAgua,
+  secaderoCafe: SecaderoCafe,
+};


### PR DESCRIPTION
## Qué

Una **librería de infraestructura 3D data-driven** para que el usuario agregue su infraestructura real a los mundos y la vea lo más parecida posible. Misma disciplina que el registro de mundos: agregar una construcción (reusando una forma) es **una entrada de datos**.

Nueva carpeta `src/visual/mundo3d/infraestructura/`:

- **`infraestructuraData.js`** — CATÁLOGO three-free: cada infra con `id`, `nombre`, `categoria`, `dims` típicas (metros), `params` y clave de `render`. No importa `three` (no infla el bundle base).
- **`piezasInfra.jsx`** — 10 piezas low-poly (Lambert + `flatShading`, cero GLTF), contrato uniforme `{ dims, params, frugal, reducedMotion }`, centradas en origen sobre y=0.
- **`Infraestructura.jsx`** — dispatcher `<Infraestructura tipo pos rot dims params tier reducedMotion />` que resuelve catálogo+pieza y aplica el perfil `frugal` por device-tier.
- **`index.js`** — barrel.

## Primera tanda del catálogo (10)

| Construcción | Categoría | Dims por defecto (L×A×Alt, m) |
|---|---|---|
| Invernadero túnel (macrotúnel) | cultivo protegido | 15 × 6 × 3 |
| Invernadero capilla (2 aguas) | cultivo protegido | 20 × 8 × 4,2 |
| Media-sombra / vivero | cultivo protegido | 10 × 6 × 2,5 |
| Gallinero a campo abierto | pecuaria | 8 × 5 × 2,2 |
| Galpón avícola (cerrado) | pecuaria | 24 × 8 × 3,2 |
| Establo de bovinos | pecuaria | 12 × 6 × 3,5 |
| Almacén / bodega | almacenamiento | 8 × 6 × 4 |
| Compostera (3 módulos) | almacenamiento | 4,5 × 1,5 × 1,2 |
| Tanque / reservorio | agua | 4 × 4 × 2,5 |
| Secadero de café (parabólico) | poscosecha | 12 × 5 × 2,6 |

Las medidas son los defaults (rangos reales de finca andina pequeña/mediana); el usuario las ajusta con `dims={{largo, ancho, alto}}`.

## Vitrina

`#/mockups/infraestructura-3d` — grilla por categoría con un diorama girable por tarjeta. Cada Canvas se monta **solo cuando entra en viewport** (IntersectionObserver) y se suelta al salir, para no tener diez contextos WebGL vivos. En equipo humilde / ahorro / reduced-motion cae a **fichas 2D** (three-free), con botón para forzarlo.

## Cómo se agrega infra real a un mundo

`<Infraestructura tipo="galpon" pos={[3,0,-2]} rot={0.4} dims={{largo:30, ancho:9}} />` dentro de cualquier escena del framework.

## Verificación

- `npm run build` ✅ (chunk `Infraestructura3D` ~23 kB; three va al `vendor-three` existente)
- Smoke test jsdom ✅ (monta el catálogo completo como fichas 2D sin tocar three)
- lefthook pre-commit (eslint + scans) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)