### PR TITLE
feat(mundos): modo colocar infraestructura con snapping al terreno

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -115,6 +115,9 @@ const Mundo3DSemilleroMockup = lazy(() => import('./mockups/Mundo3DSemillero'));
 // compostera, tanque, secadero, media-sombra. Grilla data-driven con device-tier
 // real; el 3D va perezoso (vendor-three), 2D digno en equipo humilde.
 const Infraestructura3DMockup = lazy(() => import('./mockups/Infraestructura3D'));
+// Modo COLOCAR: el usuario elige una construcción del catálogo y la ubica en el
+// terreno (snapping a la ladera, girar en pasos, confirmar); persiste local.
+const ColocarInfraestructuraMockup = lazy(() => import('./mockups/ColocarInfraestructura'));
 // Voz: superficies de voz con forma viva (iris que reacciona al volumen).
 const VozConFormaMockup = lazy(() => import('./mockups/VozConForma'));
 const ConversacionVozMockup = lazy(() => import('./mockups/ConversacionVoz'));
@@ -532,6 +535,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo3d-cafe': 'mockup_mundo3d_cafe',
   'mockups/mundo3d-semillero': 'mockup_mundo3d_semillero',
   'mockups/infraestructura-3d': 'mockup_infraestructura_3d',
+  'mockups/colocar-infraestructura': 'mockup_colocar_infraestructura',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1683,6 +1687,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="La infraestructura de su finca">
               <Infraestructura3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_colocar_infraestructura':
+        // Modo COLOCAR infraestructura: el paso que le sigue a la vitrina — el
+        // usuario elige una construcción del catálogo, toca el terreno donde va
+        // (snapping a la altura de la ladera), la gira en pasos de 45° y la
+        // confirma; la lista {tipo, pos, rot} persiste en el equipo. En gama
+        // baja cae a un plano 2D cenital con el mismo flujo. Ruta
+        // #/mockups/colocar-infraestructura, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Colocar su infraestructura">
+              <ColocarInfraestructuraMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/ColocarInfraestructura.jsx
+++ b/src/mockups/ColocarInfraestructura.jsx
@@ -1,0 +1,465 @@
+/*
+ * ColocarInfraestructura — modo COLOCAR de la librería de infraestructura 3D
+ * (ruta #/mockups/colocar-infraestructura).
+ *
+ * El paso que le sigue a la vitrina (#/mockups/infraestructura-3d): allá el
+ * campesino MIRA el catálogo; aquí lo USA — elige una construcción (galería),
+ * toca el terreno donde va, la gira en pasos de 45° y la confirma. La pieza se
+ * POSA sobre la ladera (snapping a la altura del terreno, la misma fórmula de
+ * ladera andina del valle) y queda guardada en el equipo:
+ *
+ *   localStorage['chagra.infraColocada'] = [{ tipo, pos: [x,y,z], rot }]
+ *
+ * — el mismo shape que consume `<Infraestructura tipo pos rot/>`, así que un
+ * mundo real puede leer esta lista tal cual el día que se cablee a la finca.
+ *
+ * LIGERO a propósito: NO importa Valle3D (ese módulo arrastra criaturas,
+ * animales y toda la data del valle); replica su `alturaTerreno(x, z)` en Math
+ * puro y dibuja una ladera propia y sencilla. Tampoco toca EscenaRecinto ni
+ * EscenaBase3D: es una escena autocontenida.
+ *
+ * PERF (device-tiering real): en equipo humilde / ahorro de datos cae al PLANO
+ * 2D cenital (sin WebGL) con el mismo flujo completo — tocar, girar, confirmar,
+ * guardar — y hay botón para forzarlo. Táctil: todos los controles ≥ 44px.
+ * Autocontenida, móvil-first (320px), español de Colombia en "usted".
+ */
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import * as THREE from 'three';
+import {
+  INFRAESTRUCTURA,
+  INFRAESTRUCTURA_IDS,
+} from '../visual/mundo3d/infraestructura/infraestructuraData.js';
+import Infraestructura from '../visual/mundo3d/infraestructura/Infraestructura.jsx';
+import { decidirTier, permite3D } from '../visual/mundo3d/index.js';
+import { ATMOSFERA } from '../visual/mundo3d/atmosferaMadre.js';
+import './colocar-infraestructura.css';
+
+/* ── El terreno ──────────────────────────────────────────────────────────────
+ * La misma ladera andina de Valle3D (mockups/valle/Valle3D.jsx): al fondo
+ * (z negativo) trepa al páramo, al frente (z positivo) baja a tierra caliente.
+ * Copiada en Math puro (sin THREE.MathUtils) para que el snapping funcione
+ * igual en el plano 2D sin tocar three. Determinista: la pieza se posa encima.
+ */
+const TAM = 30; // lado del terreno en metros (mundo de juguete)
+const BORDE = TAM / 2 - 1.5; // margen: que nada quede colgando del filo
+
+function alturaTerreno(x, z) {
+  const t = Math.min(1, Math.max(0, (-z + 8) / 19)); // smoothstep(-z, -8, 11)
+  const subida = t * t * (3 - 2 * t) * 5.4;
+  const ondul = Math.sin(x * 0.42) * 0.14 + Math.cos(z * 0.36 + x * 0.2) * 0.12;
+  const cauce = -0.32 * Math.exp(-((x - 1.2) ** 2) / 6) * Math.exp(-((z + 1) ** 2) / 55);
+  return subida + ondul + cauce;
+}
+
+const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+
+/* Snap de un punto (x, z) tocado: se acota al terreno y se posa a su altura. */
+function puntoAterrizado(x, z) {
+  const px = clamp(x, -BORDE, BORDE);
+  const pz = clamp(z, -BORDE, BORDE);
+  return [px, alturaTerreno(px, pz), pz];
+}
+
+/* ── Persistencia (estado local del equipo) ────────────────────────────────── */
+const CLAVE_GUARDADO = 'chagra.infraColocada';
+const MAX_COLOCADAS = 40; // techo de cordura: perf y sentido común
+
+function cargarColocadas() {
+  try {
+    const arr = JSON.parse(localStorage.getItem(CLAVE_GUARDADO) || '[]');
+    if (!Array.isArray(arr)) return [];
+    return arr
+      .filter(
+        (c) =>
+          c &&
+          INFRAESTRUCTURA[c.tipo] &&
+          Array.isArray(c.pos) &&
+          c.pos.length === 3 &&
+          c.pos.every(Number.isFinite) &&
+          Number.isFinite(c.rot),
+      )
+      .slice(0, MAX_COLOCADAS);
+  } catch {
+    return []; // guardado corrupto o storage bloqueado: finca vacía, sin drama
+  }
+}
+
+function guardarColocadas(lista) {
+  try {
+    localStorage.setItem(CLAVE_GUARDADO, JSON.stringify(lista));
+  } catch {
+    /* storage lleno/bloqueado: la sesión sigue viva en memoria */
+  }
+}
+
+/* ── La ladera 3D ────────────────────────────────────────────────────────────
+ * Plano desplazado por alturaTerreno + color por altura (cálido abajo, páramo
+ * arriba). Distingue TOQUE de ARRASTRE (OrbitControls): solo coloca si el dedo
+ * no se movió más de unos px entre down y up.
+ */
+function Terreno({ segmentos, onTocar }) {
+  const geo = useMemo(() => {
+    const g = new THREE.PlaneGeometry(TAM, TAM, segmentos, segmentos);
+    g.rotateX(-Math.PI / 2);
+    const pos = g.attributes.position;
+    const colores = new Float32Array(pos.count * 3);
+    const cBajo = new THREE.Color('#9db35f'); // pasto de tierra templada
+    const cAlto = new THREE.Color('#6d8a68'); // frailejonal apagado
+    const c = new THREE.Color();
+    for (let i = 0; i < pos.count; i++) {
+      const x = pos.getX(i);
+      const z = pos.getZ(i);
+      const y = alturaTerreno(x, z);
+      pos.setY(i, y);
+      c.copy(cBajo).lerp(cAlto, clamp(y / 5.4, 0, 1));
+      colores[i * 3] = c.r;
+      colores[i * 3 + 1] = c.g;
+      colores[i * 3 + 2] = c.b;
+    }
+    g.setAttribute('color', new THREE.BufferAttribute(colores, 3));
+    g.computeVertexNormals();
+    return g;
+  }, [segmentos]);
+  useEffect(() => () => geo.dispose(), [geo]);
+
+  const inicio = useRef(null);
+  return (
+    <mesh
+      geometry={geo}
+      onPointerDown={(e) => {
+        inicio.current = [e.clientX, e.clientY];
+      }}
+      onPointerUp={(e) => {
+        const d = inicio.current;
+        inicio.current = null;
+        if (!d) return;
+        const dx = e.clientX - d[0];
+        const dy = e.clientY - d[1];
+        if (dx * dx + dy * dy > 64) return; // fue giro de cámara, no un toque
+        onTocar(e.point.x, e.point.z);
+      }}
+    >
+      <meshLambertMaterial vertexColors />
+    </mesh>
+  );
+}
+
+/* El anillo que marca el BORRADOR (la pieza aún sin confirmar) en el piso. */
+function AnilloBorrador({ borrador }) {
+  const e = INFRAESTRUCTURA[borrador.tipo];
+  const r = Math.max(e.dims.largo, e.dims.ancho) * 0.62 + 0.4;
+  return (
+    <mesh
+      rotation={[-Math.PI / 2, 0, 0]}
+      position={[borrador.pos[0], borrador.pos[1] + 0.07, borrador.pos[2]]}
+    >
+      <ringGeometry args={[r - 0.28, r, 40]} />
+      <meshBasicMaterial color="#f2b134" transparent opacity={0.92} />
+    </mesh>
+  );
+}
+
+/* La escena completa de colocación: ladera + lo ya colocado + el borrador. */
+function EscenaColocar({ tier, reducedMotion, colocadas, borrador, onTocar }) {
+  const segmentos = tier === 'alto' ? 48 : 28;
+  return (
+    <Canvas
+      className="cinf__canvas"
+      dpr={[1, tier === 'alto' ? 1.5 : 1.15]}
+      gl={{ antialias: tier === 'alto', powerPreference: 'high-performance' }}
+      camera={{ position: [0, 13, 19], fov: 46 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+    >
+      <color attach="background" args={[ATMOSFERA.fondo]} />
+      <hemisphereLight intensity={0.62} color={ATMOSFERA.cielo} groundColor={ATMOSFERA.suelo} />
+      <ambientLight intensity={0.28} color={ATMOSFERA.luz} />
+      <directionalLight position={[8, 12, 6]} intensity={0.95} color={ATMOSFERA.luz} />
+      <directionalLight position={[-6, 5, -8]} intensity={0.2} color={ATMOSFERA.relleno} />
+      <Terreno segmentos={segmentos} onTocar={onTocar} />
+      <Suspense fallback={null}>
+        {colocadas.map((c, i) => (
+          <Infraestructura
+            // eslint-disable-next-line react/no-array-index-key -- lista append/pop only
+            key={`${c.tipo}-${i}`}
+            tipo={c.tipo}
+            pos={c.pos}
+            rot={c.rot}
+            tier={tier}
+            reducedMotion={reducedMotion}
+          />
+        ))}
+        {borrador && (
+          <>
+            <Infraestructura
+              tipo={borrador.tipo}
+              pos={borrador.pos}
+              rot={borrador.rot}
+              tier={tier}
+              reducedMotion={reducedMotion}
+            />
+            <AnilloBorrador borrador={borrador} />
+          </>
+        )}
+      </Suspense>
+      <OrbitControls
+        target={[0, 2.2, 0]}
+        makeDefault
+        enablePan={false}
+        enableZoom
+        minDistance={9}
+        maxDistance={38}
+        minPolarAngle={0.25}
+        maxPolarAngle={1.32}
+        enableDamping
+        dampingFactor={0.1}
+      />
+    </Canvas>
+  );
+}
+
+/* ── El plano 2D cenital (gama baja / a elección) ───────────────────────────
+ * Visto desde arriba: páramo al fondo (arriba), tierra caliente al frente
+ * (abajo) — el mismo terreno, sin WebGL. Tocar el plano ubica; los marcadores
+ * son el emoji de cada pieza, girado con el mismo `rot` que guarda el 3D.
+ */
+function pctDesdeMetros(v) {
+  return ((v / (TAM / 2)) + 1) * 50; // [-15, 15] m → [0, 100] %
+}
+
+function Marcador2D({ item, borrador }) {
+  const e = INFRAESTRUCTURA[item.tipo];
+  return (
+    <span
+      className={`cinf__marca${borrador ? ' cinf__marca--borrador' : ''}`}
+      style={{ left: `${pctDesdeMetros(item.pos[0])}%`, top: `${pctDesdeMetros(item.pos[2])}%` }}
+      title={e.nombre}
+    >
+      <span
+        className="cinf__marca-emoji"
+        style={{ transform: `rotate(${Math.round((-item.rot * 180) / Math.PI)}deg)` }}
+        aria-hidden="true"
+      >
+        {e.emoji}
+      </span>
+    </span>
+  );
+}
+
+function Plano2D({ colocadas, borrador, onTocar }) {
+  const ref = useRef(null);
+  return (
+    <div
+      ref={ref}
+      className="cinf__plano"
+      role="application"
+      aria-label="Plano de la finca visto desde arriba. Toque donde va la construcción."
+      onClick={(e) => {
+        const rect = ref.current?.getBoundingClientRect();
+        if (!rect || !rect.width || !rect.height) return;
+        const relX = (e.clientX - rect.left) / rect.width;
+        const relZ = (e.clientY - rect.top) / rect.height;
+        onTocar((relX * 2 - 1) * (TAM / 2), (relZ * 2 - 1) * (TAM / 2));
+      }}
+    >
+      <span className="cinf__plano-rotulo cinf__plano-rotulo--alto">Páramo (arriba)</span>
+      <span className="cinf__plano-rotulo cinf__plano-rotulo--bajo">Tierra caliente (abajo)</span>
+      {colocadas.map((c, i) => (
+        // eslint-disable-next-line react/no-array-index-key -- lista append/pop only
+        <Marcador2D key={`${c.tipo}-${i}`} item={c} />
+      ))}
+      {borrador && <Marcador2D item={borrador} borrador />}
+    </div>
+  );
+}
+
+/* ── El mockup ────────────────────────────────────────────────────────────── */
+const PASO_GIRO = Math.PI / 4; // 45° por toque: preciso sin ser quisquilloso
+
+export default function ColocarInfraestructura() {
+  // Device-tiering REAL (una vez): gama baja / ahorro / menos-movimiento → 2D.
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const capaz3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const en3D = capaz3D && !ver2d;
+  const tier = decision.tier === 'alto' ? 'alto' : 'medio';
+
+  const [colocadas, setColocadas] = useState(cargarColocadas);
+  const [seleccion, setSeleccion] = useState(null); // id elegido en la galería
+  const [borrador, setBorrador] = useState(null); // { tipo, pos, rot } sin confirmar
+  const [aviso, setAviso] = useState(null); // toast corto (aria-live)
+  const timerAviso = useRef(null);
+
+  useEffect(() => () => clearTimeout(timerAviso.current), []);
+  const avisar = (txt) => {
+    setAviso(txt);
+    clearTimeout(timerAviso.current);
+    timerAviso.current = setTimeout(() => setAviso(null), 2600);
+  };
+
+  const elegir = (id) => {
+    setSeleccion(id);
+    setBorrador(null);
+    avisar(`Toque el terreno donde va su ${INFRAESTRUCTURA[id].nombre.toLowerCase()}.`);
+  };
+
+  const tocarTerreno = (x, z) => {
+    const tipo = borrador?.tipo || seleccion;
+    if (!tipo) {
+      avisar('Primero elija una construcción de la lista de abajo.');
+      return;
+    }
+    setBorrador((b) => ({ tipo, pos: puntoAterrizado(x, z), rot: b?.rot || 0 }));
+  };
+
+  const girar = (dir) =>
+    setBorrador((b) => (b ? { ...b, rot: b.rot + dir * PASO_GIRO } : b));
+
+  const confirmar = () => {
+    if (!borrador) return;
+    if (colocadas.length >= MAX_COLOCADAS) {
+      avisar('Ya no cabe más: quite alguna construcción primero.');
+      return;
+    }
+    const lista = [...colocadas, borrador];
+    setColocadas(lista);
+    guardarColocadas(lista);
+    avisar(`Listo: su ${INFRAESTRUCTURA[borrador.tipo].nombre.toLowerCase()} quedó en la finca. ✓`);
+    setBorrador(null);
+    setSeleccion(null);
+  };
+
+  const cancelar = () => {
+    setBorrador(null);
+    setSeleccion(null);
+    setAviso(null);
+  };
+
+  const quitarUltima = () => {
+    if (!colocadas.length) return;
+    const lista = colocadas.slice(0, -1);
+    setColocadas(lista);
+    guardarColocadas(lista);
+    avisar('Se quitó la última construcción.');
+  };
+
+  const entradaBorrador = borrador ? INFRAESTRUCTURA[borrador.tipo] : null;
+  const entradaSeleccion = seleccion ? INFRAESTRUCTURA[seleccion] : null;
+
+  return (
+    <main className="cinf">
+      <header className="cinf__head">
+        <p className="cinf__kicker">Los mundos de su finca · colocar</p>
+        <h1>Ponga su infraestructura en la finca</h1>
+        <p className="cinf__lema">
+          Elija una construcción, toque el terreno donde va, gírela y confírmela.
+          Queda guardada en su equipo.
+        </p>
+        {capaz3D && (
+          <button type="button" className="cinf__toggle" onClick={() => setVer2d((v) => !v)}>
+            {ver2d ? 'Ver en 3D' : 'Ver como plano (2D)'}
+          </button>
+        )}
+        {!capaz3D && (
+          <p className="cinf__aviso-tier">
+            Su equipo va mejor con el plano: aquí ubica sus construcciones vistas
+            desde arriba (va parejo en cualquier teléfono).
+          </p>
+        )}
+      </header>
+
+      <div className="cinf__escena">
+        {en3D ? (
+          <EscenaColocar
+            tier={tier}
+            reducedMotion={reducedMotion}
+            colocadas={colocadas}
+            borrador={borrador}
+            onTocar={tocarTerreno}
+          />
+        ) : (
+          <Plano2D colocadas={colocadas} borrador={borrador} onTocar={tocarTerreno} />
+        )}
+        <p className="cinf__toast" role="status" aria-live="polite">
+          {aviso || ''}
+        </p>
+      </div>
+
+      <section className="cinf__panel" aria-label="Controles de colocación">
+        {borrador && entradaBorrador ? (
+          <div className="cinf__acciones">
+            <p className="cinf__estado">
+              <span aria-hidden="true">{entradaBorrador.emoji}</span> {entradaBorrador.nombre} — toque
+              el terreno para moverla, o gírela y confírmela.
+            </p>
+            <div className="cinf__botonera">
+              <button type="button" className="cinf__btn" onClick={() => girar(-1)}>
+                ⟲ Girar
+              </button>
+              <button type="button" className="cinf__btn" onClick={() => girar(1)}>
+                ⟳ Girar
+              </button>
+              <button type="button" className="cinf__btn cinf__btn--ok" onClick={confirmar}>
+                ✓ Ponerla aquí
+              </button>
+              <button type="button" className="cinf__btn cinf__btn--no" onClick={cancelar}>
+                ✕ Cancelar
+              </button>
+            </div>
+          </div>
+        ) : entradaSeleccion ? (
+          <div className="cinf__acciones">
+            <p className="cinf__estado">
+              <span aria-hidden="true">{entradaSeleccion.emoji}</span> {entradaSeleccion.nombre} —
+              toque el terreno donde va.
+            </p>
+            <div className="cinf__botonera">
+              <button type="button" className="cinf__btn cinf__btn--no" onClick={cancelar}>
+                ✕ Cancelar
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <h2 className="cinf__titulo-galeria">Elija una construcción</h2>
+            <ul className="cinf__galeria">
+              {INFRAESTRUCTURA_IDS.map((id) => {
+                const e = INFRAESTRUCTURA[id];
+                return (
+                  <li key={id}>
+                    <button type="button" className="cinf__ficha" onClick={() => elegir(id)}>
+                      <span className="cinf__ficha-emoji" aria-hidden="true">
+                        {e.emoji}
+                      </span>
+                      <span className="cinf__ficha-nombre">{e.nombre}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </>
+        )}
+        <footer className="cinf__pie">
+          <p className="cinf__cuenta">
+            {colocadas.length === 0
+              ? 'Todavía no ha puesto construcciones.'
+              : `${colocadas.length} ${colocadas.length === 1 ? 'construcción puesta' : 'construcciones puestas'} en su finca.`}
+          </p>
+          {colocadas.length > 0 && !borrador && (
+            <button type="button" className="cinf__btn cinf__btn--suave" onClick={quitarUltima}>
+              Quitar la última
+            </button>
+          )}
+        </footer>
+      </section>
+    </main>
+  );
+}

--- a/src/mockups/colocar-infraestructura.css
+++ b/src/mockups/colocar-infraestructura.css
@@ -1,0 +1,269 @@
+/*
+ * colocar-infraestructura.css — modo COLOCAR infraestructura
+ * (#/mockups/colocar-infraestructura). Móvil-first (320px), táctil ≥ 44px,
+ * paleta tibia de la familia de mundos. Autocontenido: cero assets externos.
+ */
+
+.cinf {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: #f7f1e3;
+  color: #3d3325;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* ── Cabecera ── */
+.cinf__head {
+  padding: 14px 16px 10px;
+}
+.cinf__kicker {
+  margin: 0 0 2px;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8a7a5c;
+}
+.cinf__head h1 {
+  margin: 0 0 4px;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  color: #4a3d28;
+}
+.cinf__lema {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  color: #6b5d44;
+  max-width: 42ch;
+}
+.cinf__toggle {
+  margin-top: 8px;
+  min-height: 44px;
+  padding: 0 16px;
+  border: 1.5px solid #b9a67e;
+  border-radius: 22px;
+  background: #fffdf6;
+  color: #5a4b30;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.cinf__toggle:active {
+  background: #efe6d0;
+}
+.cinf__aviso-tier {
+  margin: 8px 0 0;
+  font-size: 0.82rem;
+  color: #6b5d44;
+}
+
+/* ── Escena (3D o plano) ── */
+.cinf__escena {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 46dvh;
+  margin: 0 10px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1.5px solid #d9c9a3;
+  background: #dfeef2;
+}
+.cinf__canvas {
+  touch-action: none; /* el gesto es del lienzo: girar cámara / tocar terreno */
+}
+
+/* El toast de estado (aria-live): flota abajo de la escena, sin robar toques. */
+.cinf__toast {
+  position: absolute;
+  left: 50%;
+  bottom: 10px;
+  transform: translateX(-50%);
+  margin: 0;
+  max-width: calc(100% - 24px);
+  padding: 8px 14px;
+  border-radius: 18px;
+  background: rgba(61, 51, 37, 0.88);
+  color: #fdf8ec;
+  font-size: 0.84rem;
+  line-height: 1.3;
+  text-align: center;
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.25s ease;
+}
+.cinf__toast:empty {
+  opacity: 0;
+}
+
+/* ── Plano 2D cenital (gama baja / a elección) ── */
+.cinf__plano {
+  position: absolute;
+  inset: 0;
+  cursor: crosshair;
+  /* páramo arriba (z−) → tierra caliente abajo (z+), como la ladera 3D */
+  background: linear-gradient(
+    180deg,
+    #6d8a68 0%,
+    #7d9a62 34%,
+    #9db35f 68%,
+    #b7bd66 100%
+  );
+}
+.cinf__plano-rotulo {
+  position: absolute;
+  left: 10px;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 253, 246, 0.85);
+  text-shadow: 0 1px 2px rgba(40, 50, 35, 0.5);
+  pointer-events: none;
+}
+.cinf__plano-rotulo--alto {
+  top: 8px;
+}
+.cinf__plano-rotulo--bajo {
+  bottom: 8px;
+}
+.cinf__marca {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  font-size: 1.5rem;
+  line-height: 1;
+  pointer-events: none;
+  filter: drop-shadow(0 1px 2px rgba(40, 50, 35, 0.45));
+}
+.cinf__marca-emoji {
+  display: inline-block;
+}
+.cinf__marca--borrador {
+  padding: 5px;
+  border: 2px dashed #f2b134;
+  border-radius: 50%;
+  background: rgba(242, 177, 52, 0.18);
+}
+
+/* ── Panel de control (galería / acciones) ── */
+.cinf__panel {
+  padding: 10px 12px calc(12px + env(safe-area-inset-bottom, 0px));
+}
+.cinf__titulo-galeria {
+  margin: 0 0 8px;
+  font-size: 0.92rem;
+  color: #5a4b30;
+}
+.cinf__galeria {
+  display: flex;
+  gap: 8px;
+  margin: 0;
+  padding: 2px 2px 8px;
+  list-style: none;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+}
+.cinf__ficha {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  min-width: 88px;
+  min-height: 76px; /* táctil holgado, > 44px */
+  padding: 8px 10px;
+  border: 1.5px solid #d9c9a3;
+  border-radius: 12px;
+  background: #fffdf6;
+  color: #4a3d28;
+  cursor: pointer;
+}
+.cinf__ficha:active {
+  background: #efe6d0;
+  border-color: #b9a67e;
+}
+.cinf__ficha-emoji {
+  font-size: 1.6rem;
+  line-height: 1;
+}
+.cinf__ficha-nombre {
+  font-size: 0.74rem;
+  line-height: 1.15;
+  text-align: center;
+}
+
+/* Estado + botonera del borrador */
+.cinf__estado {
+  margin: 0 0 8px;
+  font-size: 0.88rem;
+  line-height: 1.35;
+  color: #5a4b30;
+}
+.cinf__botonera {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.cinf__btn {
+  min-height: 48px;
+  min-width: 44px;
+  padding: 0 16px;
+  border: 1.5px solid #b9a67e;
+  border-radius: 12px;
+  background: #fffdf6;
+  color: #4a3d28;
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.cinf__btn:active {
+  background: #efe6d0;
+}
+.cinf__btn--ok {
+  background: #4f7a3f;
+  border-color: #40632f;
+  color: #fdf8ec;
+}
+.cinf__btn--ok:active {
+  background: #40632f;
+}
+.cinf__btn--no {
+  color: #8a4a35;
+  border-color: #c99f8b;
+}
+.cinf__btn--suave {
+  min-height: 44px;
+  font-weight: 500;
+  font-size: 0.84rem;
+}
+
+/* Pie: cuenta de colocadas + quitar última */
+.cinf__pie {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid #e4d8bd;
+}
+.cinf__cuenta {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #6b5d44;
+}
+
+/* Pantallas más anchas: la galería respira y la escena crece. */
+@media (min-width: 700px) {
+  .cinf__head h1 {
+    font-size: 1.5rem;
+  }
+  .cinf__escena {
+    min-height: 56dvh;
+    margin: 0 16px;
+  }
+  .cinf__panel {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+}


### PR DESCRIPTION
## Qué hace

FASE 3: modo **COLOCAR** — el usuario agrega SU infraestructura y la ve. Ruta `#/mockups/colocar-infraestructura` (sin auth), lazy chunk propio.

- **Galería** del catálogo existente (`src/visual/mundo3d/infraestructura`, 10 piezas): fichas táctiles ≥44px, emoji + nombre.
- **Colocación por toque**: raycast al terreno → la pieza se posa con snapping a la altura de la ladera andina (misma fórmula `alturaTerreno(x,z)` de Valle3D, replicada en Math puro para NO arrastrar el grafo pesado de Valle3D — criaturas, animales, valleData). Distingue toque de arrastre de cámara (umbral 8px).
- **Rotación en pasos** de 45° (⟲/⟳), **confirmar/cancelar**; anillo dorado marca el borrador sin confirmar.
- **Persistencia**: `localStorage['chagra.infraColocada'] = [{tipo, pos, rot}]` — el mismo shape que consume `<Infraestructura/>`; carga validada (tipo en catálogo, pos/rot finitos), toast "ok" al confirmar, "Quitar la última".
- **Device-tier real** (`decidirTier`/`permite3D`): gama baja / a elección cae a un **plano 2D cenital digno** (sin WebGL) con el flujo completo — tocar, girar, confirmar, guardar. `frameloop='demand'` bajo reduced-motion.
- Reusa el dispatcher `<Infraestructura tipo pos rot dims/>` tal cual; **no toca** EscenaRecinto ni EscenaBase3D. Español CO en "usted".

## Verificación

- `npm run build` verde (45.9s); chunk perezoso `ColocarInfraestructura-*.js/.css` generado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)