### PR TITLE
feat(3d): entrada real al valle 3D desde el home (FASE 0 game-dev)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -763,7 +763,7 @@ const MODULE_VIEWS = new Set([
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'toxicologia', 'aprende', 'curso', 'directorio', 'plagas', 'mercados',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia', 'ciclo_vivo',
-  'usage_stats', 'mercado', 'auditoria_inventario', 'mundo',
+  'usage_stats', 'mercado', 'auditoria_inventario', 'mundo', 'valle3d',
 ]);
 
 // T2: Dashboard como componente propio con suscripción reactiva al store.
@@ -2664,6 +2664,21 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El clima que viene">
               <ClimaBoletinScreen onBack={() => navigate('mundo', { mundo: 'clima' })} onNavigate={navigate} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'valle3d':
+        // EL VALLE 3D DESDE EL HOME (FASE 0 del plan game-dev): la MISMA
+        // EntradaValle3D de la vitrina (#/mockups/entrada-3d) montada como
+        // vista REAL de la app, con `onNavigate`: las puertas de los mundos
+        // abren las pantallas de verdad (regla de oro: re-rutear, nunca
+        // reimplementar). Se llega por la banda de MundosDeMiFinca, gated por
+        // el flag de prefs `valle3d` (default OFF, Perfil) + device-tier;
+        // adentro el tiering decide 3D pleno/frugal o el valle 2D digno.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El valle de su finca (3D)">
+              <EntradaValle3DMockup onBack={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import {
   User, Palette, Briefcase, Save, Check, Mic, MapPin, Home, Volume2, Wrench,
   Sprout, ChevronRight, ChevronLeft, Bell, Users, Camera, Trash2, Shield,
-  Archive, LifeBuoy, LayoutGrid, GraduationCap, Vibrate, Waves,
+  Archive, LifeBuoy, LayoutGrid, GraduationCap, Vibrate, Waves, Mountain,
 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import { esExtensionistaActual } from '../config/extensionistaAccess';
@@ -19,6 +19,9 @@ import HytaPanel from './HytaPanel';
 import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 import useFincaActiveStore from '../services/fincaActiveStore';
 import usePrefsStore from '../store/usePrefsStore';
+/* FASE 0 game-dev: tiering del equipo para el aviso honesto del toggle 3D
+   (import directo, three-free — no arrastra el framework de mundos). */
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier';
 import { stop as stopTTS } from '../services/ttsService';
 import {
   getNotificationStyle, setNotificationStyle, getTelemetryConsent,
@@ -701,6 +704,9 @@ export default function ProfileScreen({ onBack, onHome }) {
 
             {/* Spec S3: sonido ambiental 0-KB de los mundos (tri-estado). */}
             <SonidoSection />
+
+            {/* FASE 0 game-dev: la entrada 3D del valle desde el home (flag). */}
+            <Valle3DSection />
           </div>
         )}
 
@@ -1229,6 +1235,72 @@ function SonidoSection() {
         <p className="text-[11px] text-slate-500 leading-snug px-1">
           Este navegador no admite audio generado. No se pierde información:
           el sonido solo acompaña lo que ya se ve en pantalla.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Valle3DSection — FASE 0 del plan game-dev 3D (2026-07-11).
+ *
+ * Toggle "El valle en 3D" persistido en usePrefsStore (key
+ * `chagra:prefs:valle3d`, default OFF — conservador). Al prenderlo aparece en
+ * el home ("Los mundos de su finca") la banda que abre el VALLE 3D real: el
+ * mapa navegable de la finca donde cada mundo es un lugar al que se viaja.
+ * Doble gate: además del flag, el device-tier (deviceTier.js) decide — en
+ * equipos humildes la banda no aparece y el home 2D sigue idéntico. Acá se
+ * le dice honesto al usuario qué verá su equipo.
+ */
+function Valle3DSection() {
+  const valle3d = usePrefsStore((s) => s.valle3d ?? false);
+  const setValle3d = usePrefsStore((s) => s.setValle3d);
+  // El tiering se evalúa una vez al montar la pantalla (crea un canvas WebGL
+  // de prueba; barato acá, no en cada home).
+  const [equipo] = useState(() => decidirTier());
+  const equipoAguanta = permite3D(equipo.tier);
+
+  return (
+    <div className="space-y-4 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">
+      <div className="flex items-center gap-2 px-1">
+        <Mountain size={18} className="text-yellow-400" />
+        <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">El valle en 3D</h3>
+      </div>
+
+      <label className="flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/50 cursor-pointer min-h-[48px]">
+        <div className="flex flex-col gap-0.5 flex-1">
+          <span className="text-sm font-bold text-slate-200">Entrada al valle 3D en el home</span>
+          <span className="text-xs text-slate-400 leading-snug">
+            Recorra su finca como un valle en tres dimensiones: cada mundo es
+            un lugar al que se viaja. Al activarla, la entrada aparece en
+            &quot;Los mundos de su finca&quot;. Es una experiencia nueva: si
+            algo no le funciona, apáguela y el home queda como siempre.
+          </span>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={valle3d}
+          aria-label="Activar o desactivar la entrada al valle 3D"
+          data-testid="valle3d-toggle"
+          onClick={() => setValle3d(!valle3d)}
+          className={`tap-target relative w-12 h-7 rounded-full transition-colors shrink-0 ${
+            valle3d ? 'bg-yellow-600' : 'bg-slate-700'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-6 h-6 bg-white rounded-full shadow transition-transform ${
+              valle3d ? 'translate-x-5' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </label>
+
+      {!equipoAguanta && (
+        <p className="text-[11px] text-slate-500 leading-snug px-1">
+          Este equipo no alcanza para el 3D con fluidez, así que la entrada no
+          se mostrará en el home aunque active la opción. No se pierde nada:
+          todos los mundos siguen completos en su versión de siempre.
         </p>
       )}
     </div>

--- a/src/components/dashboard/MundosDeMiFinca.jsx
+++ b/src/components/dashboard/MundosDeMiFinca.jsx
@@ -2,9 +2,14 @@
  * i18n (ADR-050): copy de navegación del home en español Colombia, pendiente de
  * migrar a src/config/messages.js — mismo criterio que DashboardLive.jsx.
  */
+import { useMemo } from 'react';
 import { MUNDOS_FINCA } from './mundosFinca';
 import MundoVineta from './MundoVinetas';
 import { useProCapability } from '../../hooks/useProCapability';
+import usePrefsStore from '../../store/usePrefsStore';
+/* Import DIRECTO de deviceTier (no el barrel de mundo3d): este archivo vive en
+   el bundle base del home y solo necesita el tiering (three-free, 0 deps). */
+import { decidirTier, permite3D } from '../../visual/mundo3d/deviceTier';
 import './mundos-finca.css';
 
 /**
@@ -31,6 +36,29 @@ function EspirituGlyph() {
                 strokeLinecap="round"
                 strokeLinejoin="round"
             />
+        </svg>
+    );
+}
+
+/**
+ * Glifo del valle 3D: tres lomas andinas con el sol saliendo detrás (SVG
+ * inline, cero assets; el color lo hereda del texto, como EspirituGlyph).
+ */
+function ValleGlyph() {
+    return (
+        <svg viewBox="0 0 24 24" width="26" height="26" fill="none" aria-hidden="true">
+            {/* el sol detrás de las lomas */}
+            <circle cx="16.2" cy="8.2" r="2.6" stroke="currentColor" strokeWidth="1.5" opacity="0.9" />
+            {/* la loma grande y la loma cercana */}
+            <path
+                d="M2.5 18.5 8 9.5l4.1 6.6 2.4-3.4 5 5.8"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+            {/* el piso del valle */}
+            <path d="M2.5 18.5h19" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" opacity="0.7" />
         </svg>
     );
 }
@@ -64,6 +92,16 @@ export default function MundosDeMiFinca({ onNavigate, mostrarAnimales = true, pl
     // builds sin Pro: CERO rastro (ni botón muerto ni teaser). Reactivo:
     // loadProModules es async, la banda aparece sola cuando el módulo llega.
     const tieneEspiritu = useProCapability('avatar-espiritu');
+
+    // ── Entrada al VALLE 3D (FASE 0 game-dev): detrás del flag de prefs
+    // `valle3d` (default OFF — se prende en Perfil → experiencia) Y del
+    // device-tier: en equipos humildes la banda NI aparece y el home 2D queda
+    // idéntico (es el fallback, no se toca). El tier se decide solo con el
+    // flag prendido (decidirTier crea un canvas WebGL de prueba: no se paga
+    // en cada render del home de todo el mundo).
+    const valle3dFlag = usePrefsStore((s) => s.valle3d);
+    const equipo3d = useMemo(() => (valle3dFlag ? decidirTier() : null), [valle3dFlag]);
+    const mostrarValle3d = Boolean(valle3dFlag && equipo3d && permite3D(equipo3d.tier));
 
     const abrir = (m) => {
         if (m.portada) onNavigate?.(m.portada);
@@ -142,6 +180,30 @@ export default function MundosDeMiFinca({ onNavigate, mostrarAnimales = true, pl
                 grilla es ~10 tarjetas top-level). El corazón de la escena ya
                 se usó para "Pregunte" (#2230), por eso la entrada vive aquí.
                 Gate arriba (tieneEspiritu): sin módulo Pro no se renderiza. */}
+            {/* ── Entrada al VALLE 3D (vista 'valle3d') ──────────────────────
+                Banda bajo la grilla, misma familia visual que la del espíritu:
+                el valle navegable donde cada mundo es un LUGAR. Gate doble
+                arriba (flag de prefs + device-tier): sin flag o en equipo
+                humilde no se renderiza y el home 2D actual queda intacto. */}
+            {mostrarValle3d && (
+                <button
+                    type="button"
+                    className="mf-espiritu mf-valle3d"
+                    data-testid="entrada-valle3d"
+                    onClick={() => onNavigate?.('valle3d')}
+                    aria-label="El valle de su finca en 3D: recorra sus mundos como lugares reales"
+                >
+                    <span className="mf-espiritu-glifo" aria-hidden="true">
+                        <ValleGlyph />
+                    </span>
+                    <span className="mf-espiritu-txt">
+                        <b>El valle de su finca</b>
+                        <small>Recórrala en 3D: cada mundo es un lugar al que se viaja</small>
+                    </span>
+                    <span className="mf-espiritu-sello" aria-hidden="true">Nuevo</span>
+                </button>
+            )}
+
             {tieneEspiritu && (
                 <button
                     type="button"

--- a/src/components/dashboard/mundos-finca.css
+++ b/src/components/dashboard/mundos-finca.css
@@ -578,6 +578,33 @@ html[data-theme="biopunk"] .mf-espiritu {
   border-color: color-mix(in srgb, #5eeab2 30%, rgb(var(--c-surface-border, 51 65 85)));
 }
 
+/* ── Entrada al VALLE 3D (FASE 0 game-dev): misma banda, acento AMANECER ────
+   Reusa toda la estructura .mf-espiritu; solo cambia la clave de color: el
+   valle es un lugar de DÍA (dorado sobre verde-monte), no la ventana de noche
+   del espíritu. El gate (flag de prefs + device-tier) vive en el JSX. */
+.mf-valle3d {
+  border-color: rgba(250, 204, 21, 0.32);
+  background:
+    radial-gradient(120% 160% at 12% 20%, rgba(250, 204, 21, 0.14), transparent 55%),
+    linear-gradient(120deg, #14231a, #2b3a1e);
+  color: #f2f7dd;
+}
+.mf-valle3d .mf-espiritu-glifo {
+  color: #facc15;
+  background: rgba(250, 204, 21, 0.12);
+}
+.mf-valle3d .mf-espiritu-txt b { color: #fdf6d8; }
+.mf-valle3d .mf-espiritu-txt small { color: rgba(242, 247, 221, 0.78); }
+.mf-valle3d .mf-espiritu-sello {
+  border-color: rgba(250, 204, 21, 0.5);
+  color: #facc15;
+}
+.mf-valle3d:focus-visible { outline-color: #facc15; }
+html:not([data-theme]) .mf-valle3d,
+html[data-theme="biopunk"] .mf-valle3d {
+  border-color: color-mix(in srgb, #facc15 30%, rgb(var(--c-surface-border, 51 65 85)));
+}
+
 /* ── Accesibilidad de movimiento ──────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .mf-card {

--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -75,7 +75,16 @@ const MENSAJE_DEGRADADO = {
   default: 'Su equipo ve la versión dibujada del valle. La finca sigue completa.',
 };
 
-export default function EntradaValle3D({ onBack }) {
+/**
+ * @param {Object} props
+ * @param {() => void} [props.onBack]  volver (en la app, al home).
+ * @param {(view: string, data?: any) => void} [props.onNavigate]  MODO APP
+ *   (FASE 0 game-dev, vista 'valle3d'): cuando viene, las puertas de los
+ *   mundos y la acción del día NAVEGAN de verdad a las pantallas reales.
+ *   Sin ella (vitrina #/mockups/entrada-3d, sin sesión) Angelita solo las
+ *   nombra — el comportamiento de siempre.
+ */
+export default function EntradaValle3D({ onBack, onNavigate }) {
   const [clima, setClima] = useState(() => climaPorHora());
 
   // ── El clima es ATMÓSFERA, no un selector (auditoría B8/S8): los chips de
@@ -297,6 +306,18 @@ export default function EntradaValle3D({ onBack }) {
     if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
   }, []);
 
+  // El CTA de la alerta: en la APP navega a la pantalla real de la acción
+  // (COSA_DEL_DIA.accion.view); en la vitrina repite la indicación por voz
+  // (antes era un botón mudo — auditoría FASE 0).
+  const accionDelDia = useCallback(() => {
+    if (onNavigate && COSA_DEL_DIA.accion?.view) {
+      if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+      onNavigate(COSA_DEL_DIA.accion.view);
+      return;
+    }
+    decir(COSA_DEL_DIA.vozTexto);
+  }, [onNavigate, decir]);
+
   // ── "Pregúntele a su finca…" ABRE el flujo real del agente (auditoría
   //    BUG-CAMP-01: era un botón muerto). Mismo camino desacoplado que usan
   //    AgentFab y EscuchaOverlay: el evento global `chagraNavigate`, que
@@ -352,6 +373,13 @@ export default function EntradaValle3D({ onBack }) {
   //    cuenta a qué pantalla real de la app lleva).
   const onPuertaMundo = useCallback(
     (view, data) => {
+      // MODO APP (FASE 0 game-dev): la puerta ES real — se corta la voz y se
+      // navega a la pantalla de verdad. El valle cumple su promesa.
+      if (onNavigate) {
+        if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+        onNavigate(view, data);
+        return;
+      }
       const puertas = MUNDO[nav.mundoId]?.hotspots || [];
       const hs =
         puertas.find((h) => h.view === view && (h.data === data || (!h.data && !data))) ||
@@ -361,7 +389,7 @@ export default function EntradaValle3D({ onBack }) {
         `«${hs?.label || view}» es una puerta real: dentro de la app abre la pantalla «${view}».`,
       );
     },
-    [nav.mundoId, decir, asentir],
+    [nav.mundoId, decir, asentir, onNavigate],
   );
 
   const mundoPanel = panel && panel !== 'alerta' ? MUNDO_VALLE_BY_ID[panel] : null;
@@ -503,7 +531,7 @@ export default function EntradaValle3D({ onBack }) {
           <h2>{COSA_DEL_DIA.titulo}</h2>
           <p>{COSA_DEL_DIA.detalle}</p>
           <div className="valle-panel__acciones">
-            <button type="button" className="valle-cta">{COSA_DEL_DIA.accion.etiqueta}</button>
+            <button type="button" className="valle-cta" onClick={accionDelDia}>{COSA_DEL_DIA.accion.etiqueta}</button>
             <button type="button" className="valle-ghost" onClick={() => decir(COSA_DEL_DIA.vozTexto)}>
               🔊 Escuchar
             </button>

--- a/src/store/usePrefsStore.js
+++ b/src/store/usePrefsStore.js
@@ -22,6 +22,11 @@ const HAPTICS_MODES = ['auto', 'on', 'off'];
 // opt-in) | 'suave' (ambiente muy tenue) | 'on' (ambiente presente).
 const STORAGE_KEY_SONIDO = 'chagra:prefs:sonido';
 const SONIDO_MODES = ['off', 'suave', 'on'];
+// FASE 0 del plan game-dev 3D (2026-07-11): la entrada al VALLE 3D desde el
+// home real. Default false (conservador): el home 2D queda idéntico; quien
+// prende el flag en Perfil ve la banda de entrada en "Los mundos de su finca"
+// — y solo si su equipo aguanta 3D (device-tier alto/medio, deviceTier.js).
+const STORAGE_KEY_VALLE3D = 'chagra:prefs:valle3d';
 
 function load(key, fallback) {
   try {
@@ -43,6 +48,7 @@ const usePrefsStore = create((set, _get) => ({
   showSourceBadges: load(STORAGE_KEY_SOURCE_BADGES, true),
   haptics: load(STORAGE_KEY_HAPTICS, 'auto'),
   sonido: load(STORAGE_KEY_SONIDO, 'off'),
+  valle3d: load(STORAGE_KEY_VALLE3D, false),
 
   setVoiceRegion: (region) => {
     save(STORAGE_KEY_VOICE_REGION, region);
@@ -76,6 +82,12 @@ const usePrefsStore = create((set, _get) => ({
     const valid = SONIDO_MODES.includes(mode) ? mode : 'off';
     save(STORAGE_KEY_SONIDO, valid);
     set({ sonido: valid });
+  },
+
+  setValle3d: (flag) => {
+    const bool = Boolean(flag);
+    save(STORAGE_KEY_VALLE3D, bool);
+    set({ valle3d: bool });
   },
 }));
 


### PR DESCRIPTION
## Qué hace

Saca el 3D del limbo de `/mockups/`: la experiencia **EntradaValle3D** (valle navegable + framework de mundos) queda cableada como **vista real `valle3d`** de la app, como opción del home detrás de doble gate. El home 2D actual queda **intacto** — es el default y el fallback.

## Cómo queda cableado

- **Flag en prefs** (`usePrefsStore`, key `chagra:prefs:valle3d`, default **OFF**): toggle en **Perfil → experiencia** (`Valle3DSection`), con aviso honesto cuando el equipo no alcanza para el 3D.
- **Device-tier** (`deviceTier.js`, import directo three-free): con flag prendido, la banda **El valle de su finca** aparece en "Los mundos de su finca" (MundosDeMiFinca) solo si el tier permite 3D; en equipos humildes ni aparece y el home no cambia. Adentro, el tiering ya decide 3D pleno / 3D frugal / valle 2D digno (`MENSAJE_DEGRADADO` existente).
- **Vista `valle3d` en App.jsx**: monta la misma `EntradaValle3D` de la vitrina pero con `onNavigate` (modo app), envuelta en ErrorBoundary — si el 3D truena, el fallback devuelve al home 2D.
- **Modo app en EntradaValle3D** (prop opcional `onNavigate`): las puertas de los mundos y el CTA de la alerta del día ahora **navegan a las pantallas reales** (regla de oro del framework: re-rutear, nunca reimplementar). La vitrina `#/mockups/entrada-3d` (sin `onNavigate`) conserva su comportamiento de siempre.
- CSS: banda `.mf-valle3d` reusa la estructura de `.mf-espiritu` con acento amanecer (dorado sobre verde-monte) + override para temas navy.
- `valle3d` sumado a `MODULE_VIEWS` (telemetría de piloto).

## Qué NO toca

- El home 2D (grilla de mundos, MundoScreen): cero cambios de comportamiento con el flag apagado (default).
- El chunk `vendor-three` sigue perezoso: el bundle base solo suma el tiering three-free.
- La ruta mockup `#/mockups/entrada-3d` sigue igual.

## Verificación

- `npm run build` OK (36s; warnings de tamaño de chunks preexistentes, `vendor-three` sigue en su chunk aparte).
- Scan anti-leak manual del diff: limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)