### PR TITLE
feat(mundos): Angelita reactiva al estado real de la finca (§5b)

### DIFF
--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -31,6 +31,9 @@ import {
 import * as THREE from 'three';
 import { perfilDeTier } from '../../visual/mundo3d/deviceTier.js';
 import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
+/* La CAPA DE ESTADO de Angelita (auditoría §5b): módulo puro, sin three — el
+   mismo repertorio (mojada/sed/comiendo/vuelo) que usan los mundos 3D. */
+import { reaccionDeFinca, ESTADO_FINCA_MUESTRA } from '../../visual/mundo3d/escenas/reaccionFinca.js';
 import { Colibri } from '../../visual/creatures/Colibri.jsx';
 import { Mariposa } from '../../visual/creatures/Mariposa.jsx';
 import { Escarabajo } from '../../visual/creatures/Escarabajo.jsx';
@@ -922,37 +925,62 @@ function Beacon({ onAlerta, reducedMotion, conLuz = true }) {
       mundo (`entrando`), BAJA y se acerca al lugar — "entra" al mundo, y la
       cámara la acompaña. Su ánimo/energía (salud real de la finca) tiñen su
       color, su aura y qué tan vivo es su vuelo. Mira hacia donde viaja. ── */
-function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion }) {
+function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false }) {
   const ref = useRef(null);
   const caraRef = useRef(null);
   const prevX = useRef(foco.x);
+  // Reacción al estado REAL de la finca (§5b): mismo repertorio que los mundos.
+  // Con estadoFinca manda la reacción; sin él, el contrato viejo (animo/energia).
+  const reaccion = useMemo(
+    () => (estadoFinca ? reaccionDeFinca(estadoFinca, { hayAlerta }) : null),
+    [estadoFinca, hayAlerta],
+  );
+  const animoReal = reaccion?.animo ?? animo;
+  const energiaReal = reaccion?.energia ?? energia;
+  const vuelo = reaccion?.vuelo;
   useFrame((state) => {
     if (!ref.current) return;
     const t = state.clock.elapsedTime;
-    const brio = 0.35 + 0.65 * energia; // la energía anima el vuelo
+    // Modificadores de reaccionDeFinca: mojada pesa (baja/lenta), sed baja a
+    // buscar agua, comiendo tiembla mordisqueando. Sin estado, todo queda en 1.
+    const mAltura = vuelo?.altura ?? 1;
+    const mVel = vuelo?.velocidad ?? 1;
+    const mVagar = vuelo?.vagar ?? 1;
+    const tiembla = reducedMotion ? 0 : (vuelo?.tiembla ?? 0);
+    const brio = (0.35 + 0.65 * energiaReal) * mVel; // energía y clima animan el vuelo
     const bob = reducedMotion ? 0 : Math.sin(t * (1.6 + brio)) * (0.1 + 0.16 * brio);
+    const tembleque = tiembla ? Math.sin(t * 13) * tiembla : 0;
     // Al reposo deriva en un círculo calmo; al entrar se posa junto al lugar.
-    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.55) * 0.9;
-    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.55) * 0.6;
+    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.55) * 0.9 * mVagar;
+    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.55) * 0.6 * mVagar;
+    const alto = (entrando ? 1.05 : 2.3) * mAltura;
     const dest = new THREE.Vector3(
-      foco.x + (entrando ? 0.55 : 0.4 + vagarX),
-      foco.y + (entrando ? 1.05 : 2.3) + bob,
+      foco.x + (entrando ? 0.55 : 0.4 + vagarX) + tembleque,
+      foco.y + alto + bob + tembleque * 0.5,
       foco.z + (entrando ? 0.7 : 0.6 + vagarZ),
     );
-    ref.current.position.lerp(dest, entrando ? 0.05 : 0.045);
+    ref.current.position.lerp(dest, (entrando ? 0.05 : 0.045) * mVel);
     if (caraRef.current) {
       const vx = ref.current.position.x - prevX.current;
       if (Math.abs(vx) > 0.0015) caraRef.current.style.transform = `scaleX(${vx < 0 ? -1 : 1})`;
       prevX.current = ref.current.position.x;
     }
   });
-  const size = 44 + Math.round(energia * 14);
+  const size = 44 + Math.round(energiaReal * 14);
   return (
     <group ref={ref} position={[foco.x + 0.4, foco.y + 2.3, foco.z + 0.6]}>
       <Html center distanceFactor={9} zIndexRange={[40, 10]}>
         <div className="valle-abeja" aria-hidden="true">
           <div ref={caraRef} className="valle-abeja__cara">
-            <AbejaAngelita size={size} animo={animo} energia={energia} animated={!reducedMotion} />
+            <AbejaAngelita
+              size={size}
+              animo={animoReal}
+              energia={energiaReal}
+              mojada={reaccion?.mojada ?? false}
+              sed={reaccion?.sed ?? false}
+              comiendo={reaccion?.comiendo ?? false}
+              animated={!reducedMotion}
+            />
           </div>
         </div>
       </Html>
@@ -1005,7 +1033,7 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit }) {
 }
 
 /* ── Contenido de la escena (dentro del Canvas). ── */
-function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil }) {
+function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil, estadoFinca = null, hayAlerta = false }) {
   const controls = useRef(null);
   // Occluders de los rótulos: solo terreno + cordillera (raycast barato y es
   // exactamente lo que las etiquetas no deben atravesar).
@@ -1079,6 +1107,8 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         entrando={entrando}
         animo={animo}
         energia={energia}
+        estadoFinca={estadoFinca}
+        hayAlerta={hayAlerta}
         reducedMotion={reducedMotion}
       />
 
@@ -1102,6 +1132,10 @@ export default function Valle3D({
   onAlerta,
   reducedMotion,
   tier = 'alto',
+  /* El estado REAL de la finca (auditoría §5b): Angelita SIEMPRE lo refleja,
+     también en el mapa. Hoy MUESTRA; codex lo cabla con useFincaViva. */
+  estadoFinca = ESTADO_FINCA_MUESTRA,
+  hayAlerta = false,
 }) {
   const [listo, setListo] = useState(false);
   /* El PERFIL DE RENDER del tier (DR-3D-PERF-GAMABAJA): 'alto' conserva este
@@ -1124,6 +1158,8 @@ export default function Valle3D({
           focoId={focoId}
           animo={animo}
           energia={energia}
+          estadoFinca={estadoFinca}
+          hayAlerta={hayAlerta}
           onEntrar={onEntrar}
           onAlerta={onAlerta}
           reducedMotion={reducedMotion}

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -18,21 +18,63 @@ export function AbejaAngelita({
      (alitas plegadas que respiran despacio). Solo cambia CSS por data-pose:
      los consumidores existentes no notan nada. */
   pose = 'vuela',
+  /* ── REACTIVIDAD AL ESTADO REAL DE LA FINCA (auditoría §5b) ────────────────
+     El repertorio de reacción que la escena deriva de la finca (reaccionFinca).
+     La creature lo interpreta con SU cuerpo (gotas, probóscide, brillo) — estética
+     rubber-hose (Miss Minutes / Cuphead): squash-and-stretch, elástico, expresivo.
+     Todo opcional: sin estos props la abeja se ve EXACTO como antes.
+       animo    → piel/aura: 'pleno'|'sereno'|'atento'|'sediento'|'descansa'
+       energia  → 0..1 viveza (aura y tamaño del brillo)
+       mojada   → llueve: gotas que escurren + brillo húmedo
+       sed      → Niño/sequía: saca la lengüita y jadea
+       comiendo → hay cosecha: baja la probóscide y liba (mordisquea) */
+  animo = 'sereno',
+  energia = 1,
+  mojada = false,
+  sed = false,
+  comiendo = false,
   ...rest
 }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
   const glow = `crt-glow-${uid}`;
   const blur = `crt-blur-${uid}`;
   const wing = animated ? 'crt-wing' : undefined;
+  // El aura respira con la energía real de la finca (matas vivas + agua).
+  const auraOp = Math.max(0.16, Math.min(0.5, 0.2 + 0.3 * (energia ?? 1)));
+  const auraR = 5.4 + 1.2 * (energia ?? 1);
 
   const defs = (
     <defs>
       <CreatureFilters glow={glow} blur={blur} />
     </defs>
   );
+  // Probóscide (lengüita): sale con SED (jadeo) o al COMER (libar). Cuelga de la
+  // cabeza (cx≈9). CSS la anima según data-sed/data-comiendo; RM la deja quieta.
+  // El <g> EXTERNO posiciona (attr transform); el INTERNO (.crt-lengua) anima —
+  // si el CSS animara el mismo nodo del translate, lo pisaría (CSS transform
+  // gana sobre el atributo) y la lengüita saltaría al centro del cuerpo.
+  const lengua = (sed || comiendo) ? (
+    <g transform="translate(9.6 2)">
+      <g className="crt-lengua">
+        <path d="M0,0 C-0.4,2.6 0.4,4.4 0,6.2" stroke="#c9524e" strokeWidth="1.1"
+          fill="none" strokeLinecap="round" />
+        <circle cx="0" cy="6.4" r="1.05" fill="#c9524e" />
+      </g>
+    </g>
+  ) : null;
+  // Gotas de lluvia que escurren del cuerpo/alas cuando está MOJADA. Rubber-hose:
+  // caen con un rebotico. CSS (crt-gota) las anima; RM las deja colgando.
+  const gotas = mojada ? (
+    <g className="crt-gotas" fill="#bfe6ff" opacity="0.9">
+      <path className="crt-gota" d="M-6,4 q-1.1,1.8 0,3.2 q1.1,-1.4 0,-3.2 Z" />
+      <path className="crt-gota" style={{ animationDelay: '-0.5s' }} d="M2,5.2 q-1,1.7 0,3 q1,-1.3 0,-3 Z" />
+      <path className="crt-gota" style={{ animationDelay: '-1.1s' }} d="M8,3.4 q-0.9,1.5 0,2.7 q0.9,-1.2 0,-2.7 Z" />
+    </g>
+  ) : null;
+
   const body = (
     <g className="crt-body" filter={`url(#${glow})`}>
-      <circle r="6" fill="#ffb54f" opacity="0.35" filter={`url(#${blur})`} />
+      <circle r={auraR} fill="#ffb54f" opacity={auraOp} filter={`url(#${blur})`} />
       <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
         style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
       <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
@@ -40,14 +82,26 @@ export function AbejaAngelita({
       <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
       <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
       <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
+      {lengua}
       <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
       <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
+      {gotas}
     </g>
   );
 
+  // data-estado agrupa la reacción para el CSS (brillo mojado, jadeo, mordisco).
+  const estadoAttrs = {
+    'data-creature': 'abeja-angelita',
+    'data-pose': pose,
+    'data-animo': animo,
+    'data-mojada': mojada ? '1' : undefined,
+    'data-sed': sed ? '1' : undefined,
+    'data-comiendo': comiendo ? '1' : undefined,
+  };
+
   if (inline) {
     return (
-      <g className={className} data-creature="abeja-angelita" data-pose={pose}>
+      <g className={className} {...estadoAttrs}>
         {defs}
         {body}
       </g>
@@ -55,7 +109,7 @@ export function AbejaAngelita({
   }
   return (
     <svg viewBox={VIEWBOX} width={size} height={size} className={className}
-      role="img" aria-label={title} data-creature="abeja-angelita" data-pose={pose} {...rest}>
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}
       {body}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -60,6 +60,85 @@
   100% { transform: scaleY(0.5) scaleX(0.9); }
 }
 
+/* ── REACCIÓN AL ESTADO REAL DE LA FINCA (auditoría §5b) ──────────────────────
+   Estética rubber-hose (Miss Minutes de Loki / Cuphead): squash-and-stretch,
+   rebote elástico, gestos exagerados y con carácter — nada tímido.
+   Todo transform/opacity (GPU, Android gama baja). RM lo congela abajo. */
+
+/* MOJADA — gotas que escurren del cuerpo con un rebotico al caer. */
+.crt-gota {
+  transform-box: fill-box;
+  transform-origin: center top;
+  animation: crt-gota-cae 1.7s cubic-bezier(0.5, 0, 0.7, 1) infinite;
+}
+@keyframes crt-gota-cae {
+  0%   { transform: translateY(0) scaleY(0.7); opacity: 0; }
+  15%  { transform: translateY(0) scaleY(1.15); opacity: 0.95; }
+  70%  { transform: translateY(6px) scaleY(1); opacity: 0.85; }
+  85%  { transform: translateY(8px) scaleY(0.5) scaleX(1.4); opacity: 0.4; } /* splash */
+  100% { transform: translateY(9px) scaleY(0.2); opacity: 0; }
+}
+/* El cuerpo mojado pesa: un vaivén lento y cargado (vuela con esfuerzo). */
+[data-creature='abeja-angelita'][data-mojada='1'] .crt-body {
+  animation: crt-mojada-peso 2.4s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+@keyframes crt-mojada-peso {
+  0%, 100% { transform: translateY(0) scaleY(1); }
+  50%      { transform: translateY(0.6px) scaleY(0.97); }
+}
+
+/* SED — la lengüita jadea: sale y entra rápido, con rebote (Niño/sequía). */
+.crt-lengua {
+  transform-box: fill-box;
+  transform-origin: center top;
+}
+[data-creature='abeja-angelita'][data-sed='1'] .crt-lengua {
+  animation: crt-jadeo 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+}
+@keyframes crt-jadeo {
+  0%, 100% { transform: scaleY(0.55); }
+  50%      { transform: scaleY(1.1); }
+}
+/* El cuerpo sediento jadea también: pecho que sube y baja rapidito. */
+[data-creature='abeja-angelita'][data-sed='1'] .crt-body {
+  animation: crt-jadeo-pecho 0.5s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+@keyframes crt-jadeo-pecho {
+  0%, 100% { transform: scaleY(1); }
+  50%      { transform: scaleY(1.08) scaleX(0.97); }
+}
+
+/* COMIENDO — liba de la cosecha: la probóscide bucea (mordisqueo) y el cuerpo
+   da el squash-and-stretch de cada picotazo. Rubber-hose puro. */
+[data-creature='abeja-angelita'][data-comiendo='1'] .crt-lengua {
+  animation: crt-liba 0.62s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+@keyframes crt-liba {
+  0%, 100% { transform: translateY(0) scaleY(1); }
+  45%      { transform: translateY(2px) scaleY(1.25); }
+  60%      { transform: translateY(2px) scaleY(1.25); }
+}
+[data-creature='abeja-angelita'][data-comiendo='1'] .crt-body {
+  animation: crt-mordisco 0.62s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes crt-mordisco {
+  0%, 100% { transform: translateY(0) scale(1, 1); }
+  45%      { transform: translateY(1.5px) scale(1.06, 0.9); } /* squash al picar */
+  70%      { transform: translateY(-1px) scale(0.96, 1.06); } /* stretch al subir */
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .crt-wing, .crt-fwing, .crt-ball, .crt-legs { animation: none !important; }
+  .crt-wing, .crt-fwing, .crt-ball, .crt-legs,
+  .crt-gota, .crt-lengua,
+  [data-creature='abeja-angelita'][data-mojada='1'] .crt-body,
+  [data-creature='abeja-angelita'][data-sed='1'] .crt-lengua,
+  [data-creature='abeja-angelita'][data-sed='1'] .crt-body,
+  [data-creature='abeja-angelita'][data-comiendo='1'] .crt-lengua,
+  [data-creature='abeja-angelita'][data-comiendo='1'] .crt-body { animation: none !important; }
 }

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -1,7 +1,12 @@
 /*
  * <Mundo> — EL HOST ÚNICO del framework de mundos (2D + 3D en una sola pieza).
  *
- *   <Mundo mundoId tier reducedMotion onHotspot onSalir animo energia />
+ *   <Mundo mundoId tier reducedMotion onHotspot onSalir animo energia
+ *          estadoFinca hayAlerta />
+ *
+ * `estadoFinca` = { clima, enso, cosechaReciente, saludFinca } — el estado REAL
+ * de la finca que Angelita SIEMPRE refleja (auditoría §5b). Sin pasar nada, las
+ * escenas usan la MUESTRA de reaccionFinca.js; codex lo cabla con useFincaViva.
  *
  * Lee el registro `MUNDO[mundoId]`, resuelve el PLAN con `resolverMundo` (que
  * cruza el arquetipo con el device-tier) y monta lo que toca:
@@ -99,6 +104,7 @@ function MigaVolver({ onSalir, mundoId }) {
 function MundoInterno({
   mundoId, tier = 'alto', reducedMotion = false, onHotspot, onSalir, animo = 'sereno', energia = 1,
   hablando = false, focoId = null, focoToken = 0,
+  estadoFinca = undefined, hayAlerta = false, // undefined → la escena usa su MUESTRA
 }) {
   /* CAÍDA DIGNA (BUG-UX-05 / SPEC-UX-05): si el chunk 3D no baja en
      CARGA_3D_TIMEOUT_MS, caemos al espejo 2D del mundo. `intento` fabrica un
@@ -179,6 +185,8 @@ function MundoInterno({
             onSalir={onSalir}
             animo={animo}
             energia={energia}
+            estadoFinca={estadoFinca}
+            hayAlerta={hayAlerta}
             hablando={hablando}
             focoId={focoId}
             focoToken={focoToken}

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -26,6 +26,7 @@ import { Html, OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaEscena } from './useEntradaAbeja.jsx';
 import { SombraContacto } from './SombraContacto.jsx';
+import { ESTADO_FINCA_MUESTRA } from './reaccionFinca.js';
 import useHaptics from '../useHaptics.js';
 /* La dirección de arte compartida (hora dorada + cielos por familia) vive en
    un módulo propio: los arquetipos eligen su CIELOS.<familia>, esta base la
@@ -35,6 +36,7 @@ import { ATMOSFERA, CIELOS, mezclar } from '../atmosferaMadre.js';
 function Contenido({
   params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, piso = 0,
   frugal = false, hablando = false, focoId = null, focoToken = 0,
+  estadoFinca = ESTADO_FINCA_MUESTRA, hayAlerta = false,
   children,
 }) {
   const controls = useRef(null);
@@ -175,6 +177,8 @@ function Contenido({
         rebote={rebote}
         animo={animo}
         energia={energia}
+        estadoFinca={estadoFinca}
+        hayAlerta={hayAlerta}
         reducedMotion={reducedMotion}
         piso={piso}
       />
@@ -201,7 +205,11 @@ function Contenido({
 export default function EscenaBase3D({
   params, hotspots, entrada, tinte, reducedMotion,
   onHotspot, cielo, animo = 'sereno', energia = 1, camara, piso = 0, tier = 'alto',
-  hablando = false, focoId = null, focoToken = 0, children,
+  hablando = false, focoId = null, focoToken = 0,
+  /* El estado REAL de la finca (auditoría §5b): Angelita SIEMPRE lo refleja.
+     Hoy MUESTRA (reaccionFinca); codex lo cabla con useFincaViva sin tocar
+     esta interfaz. `hayAlerta` la pone atenta si hay algo del día pendiente. */
+  estadoFinca = ESTADO_FINCA_MUESTRA, hayAlerta = false, children,
 }) {
   const [listo, setListo] = useState(false);
   const zoom = entrada?.zoom ?? 6.5;
@@ -236,6 +244,8 @@ export default function EscenaBase3D({
           hablando={hablando}
           focoId={focoId}
           focoToken={focoToken}
+          estadoFinca={estadoFinca}
+          hayAlerta={hayAlerta}
         >
           {children}
         </Contenido>

--- a/src/visual/mundo3d/escenas/EscenaValle.jsx
+++ b/src/visual/mundo3d/escenas/EscenaValle.jsx
@@ -14,7 +14,10 @@
  */
 import Valle3D from '../../../mockups/valle/Valle3D.jsx';
 
-export default function EscenaValle({ params, entrada, reducedMotion = false, onHotspot, animo = 'sereno', energia = 1, tier = 'alto' }) {
+export default function EscenaValle({
+  params, entrada, reducedMotion = false, onHotspot, animo = 'sereno', energia = 1, tier = 'alto',
+  estadoFinca = undefined, hayAlerta = false, // §5b: Angelita refleja el estado real también en el mapa
+}) {
   const clima = params?.clima || entrada?.clima || 'soleado';
   return (
     <Valle3D
@@ -22,6 +25,8 @@ export default function EscenaValle({ params, entrada, reducedMotion = false, on
       focoId={null}
       animo={animo}
       energia={energia}
+      estadoFinca={estadoFinca}
+      hayAlerta={hayAlerta}
       tier={tier}
       reducedMotion={reducedMotion}
       onEntrar={(id) => onHotspot?.('mundo', { mundoId: id })}

--- a/src/visual/mundo3d/escenas/reaccionFinca.js
+++ b/src/visual/mundo3d/escenas/reaccionFinca.js
@@ -1,0 +1,141 @@
+/*
+ * reaccionFinca — LA CAPA DE ESTADO de Angelita (auditoría §5b).
+ *
+ * "Tu finca es un lugar vivo que refleja tu realidad." Este módulo traduce el
+ * ESTADO REAL de la finca en un REPERTORIO de reacción que la escena aplica al
+ * cuerpo de la abeja. Es a propósito una función PURA y DESACOPLADA de la especie:
+ * el día que entre el selector de avatar (AVATAR_GAME.md — chivito de páramo, rana,
+ * abeja...), cada Espíritu reacciona con SU repertorio a este mismo descriptor.
+ * Angelita es hoy el prototipo de ese sistema.
+ *
+ * ENTRADA — `estadoFinca` (interfaz LIMPIA, hoy datos de MUESTRA):
+ *   {
+ *     clima,           // 'dorada'|'soleado'|'niebla'|'lluvia'|'noche' (CLIMAS)
+ *     enso,            // fase ENSO: 'nino' (sequía/calor) | 'nina' (más lluvia) | 'neutro'
+ *     cosechaReciente, // null | { cultivo: 'café', mundoId: 'cafetal' } — algo que libar
+ *     saludFinca,      // { matasVivas, matasTotal, agua(0..1) } — la vitalidad real
+ *   }
+ * El backend (useFincaViva, lo cabla codex después) alimenta ESTA MISMA forma:
+ * logs de matas → saludFinca, Open-Meteo → clima/enso, cosechas del ciclo →
+ * cosechaReciente. Aquí solo hay MUESTRA para poder verlo hoy.
+ *
+ * SALIDA — descriptor de reacción que consume `useEntradaAbeja`/`AbejaEscena`:
+ *   {
+ *     animo,     // piel/gesto: 'pleno'|'sereno'|'atento'|'sediento'|'descansa'
+ *     energia,   // 0..1 vivacidad del vuelo/aura (de la salud real)
+ *     mojada,    // llueve → gotas y brillo, vuela más bajo y lento
+ *     sed,       // Niño/sequía → jadea, busca agua abajo
+ *     comiendo,  // hay cosecha → revolotea sobre el fruto y liba
+ *     cultivo,   // qué liba (para el copy/gesto), o null
+ *     frase,     // una línea en usted, puntual (sin muros de texto)
+ *     vuelo,     // modificadores de la coreografía: { altura, velocidad, vagar, tiembla }
+ *   }
+ */
+
+/* Estado de MUESTRA: una finca sana bajo lluvia — así "llueve → mojada" se ve
+   HOY sin backend. Codex lo reemplaza por el estado real (useFincaViva). */
+export const ESTADO_FINCA_MUESTRA = {
+  clima: 'lluvia',
+  enso: 'neutro',
+  cosechaReciente: null,
+  saludFinca: { matasVivas: 34, matasTotal: 41, agua: 0.72 },
+};
+
+const SALUD_DEFECTO = { matasVivas: 34, matasTotal: 41, agua: 0.72 };
+
+/* Umbral de sed: agua baja de reserva, o El Niño empujando calor/sequía. */
+const AGUA_SEDIENTA = 0.35;
+
+/**
+ * Deriva el repertorio de reacción de Angelita del estado real de la finca.
+ * Prioridad del ÁNIMO: sed > alerta pendiente > noche > salud. Los flags de
+ * clima (mojada) y de cosecha (comiendo) son ORTOGONALES: la abeja puede estar
+ * mojada Y libando a la vez (es una finca viva, pasan cosas juntas).
+ *
+ * @param {object} [estadoFinca=ESTADO_FINCA_MUESTRA]
+ * @param {object} [opts]
+ * @param {boolean} [opts.hayAlerta=false]  ¿lo del día sigue sin atender?
+ * @returns descriptor de reacción (ver cabecera del módulo).
+ */
+export function reaccionDeFinca(estadoFinca = ESTADO_FINCA_MUESTRA, { hayAlerta = false } = {}) {
+  const {
+    clima = 'dorada',
+    enso = 'neutro',
+    cosechaReciente = null,
+    saludFinca = SALUD_DEFECTO,
+  } = estadoFinca || {};
+  const total = saludFinca.matasTotal > 0 ? saludFinca.matasTotal : 1;
+  const vivas = Math.max(0, Math.min(1, saludFinca.matasVivas / total));
+  const agua = Math.max(0, Math.min(1, saludFinca.agua ?? 0.5));
+
+  const llueve = clima === 'lluvia';
+  const nino = enso === 'nino';
+  // Sed: reserva baja, o El Niño en un clima que reseca (no bajo lluvia).
+  const sed = agua < AGUA_SEDIENTA || (nino && (clima === 'soleado' || clima === 'dorada'));
+  const comiendo = !!(cosechaReciente && cosechaReciente.cultivo);
+  const cultivo = comiendo ? cosechaReciente.cultivo : null;
+
+  // Energía: mezcla de matas vivas y agua, atenuada por el clima duro y la sed.
+  const climaFactor = clima === 'noche' ? 0.55 : llueve ? 0.8 : 1;
+  const sedFactor = sed ? 0.75 : 1;
+  const energia = Math.max(
+    0.3,
+    Math.min(1, (vivas * 0.65 + agua * 0.35) * climaFactor * sedFactor),
+  );
+
+  // ── ÁNIMO (piel/gesto). Prioridad: sed > alerta > noche > salud plena.
+  let animo = 'sereno';
+  let frase = 'La abeja anda serena, echándole ojo a la finca.';
+  if (sed) {
+    animo = 'sediento';
+    frase = nino
+      ? 'Angelita jadea con este calorón del Niño: a la finca le hace falta agua.'
+      : 'La abeja la ve con sed: a la finca le hace falta agua.';
+  } else if (hayAlerta) {
+    animo = 'atento';
+    frase = 'Angelita anda pendiente: hay algo que atender hoy.';
+  } else if (clima === 'noche') {
+    animo = 'descansa';
+    frase = 'Angelita descansa; la finca duerme tranquila esta noche.';
+  } else if (vivas >= 0.85 && agua >= 0.55) {
+    animo = 'pleno';
+    frase = 'Angelita anda contenta: sus matas están vivas y con agua.';
+  }
+  if (comiendo && !sed) {
+    // Libar es alegría: si no hay sed que la opaque, la cosecha manda el copy.
+    frase = `Angelita revolotea sobre ${cultivo}: hay cosecha y se da un banquete.`;
+  }
+
+  // ── VUELO (modificadores de la coreografía que aplica useEntradaAbeja).
+  //    altura/velocidad/vagar son multiplicadores (1 = vuelo normal); `tiembla`
+  //    es la amplitud de un temblor nervioso (sed) o de mordisco (comiendo).
+  const vuelo = {
+    altura: 1,
+    velocidad: 1,
+    vagar: 1,
+    tiembla: 0,
+  };
+  if (mojadaLenta(llueve)) {
+    vuelo.altura = 0.6; // pesada por el agua, vuela más bajo
+    vuelo.velocidad = 0.72; // y más lento
+    vuelo.vagar = 0.8;
+  }
+  if (sed) {
+    vuelo.altura = 0.5; // baja a buscar agua/sombra
+    vuelo.velocidad = 0.85;
+    vuelo.tiembla = 0.06; // aleteo nervioso, jadeo
+  }
+  if (comiendo) {
+    vuelo.altura = Math.min(vuelo.altura, 0.7); // se acerca al fruto
+    vuelo.tiembla = Math.max(vuelo.tiembla, 0.04); // micro-lunges de mordisco
+  }
+
+  return { animo, energia, mojada: llueve, sed, comiendo, cultivo, frase, vuelo };
+}
+
+/* pequeño helper nombrado para que el `if` de arriba se lea como intención */
+function mojadaLenta(llueve) {
+  return llueve;
+}
+
+export default reaccionDeFinca;

--- a/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
+++ b/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
@@ -16,13 +16,18 @@
    coreografía + su componente de escena) se importa SIEMPRE perezoso dentro de
    un <Canvas> vía EscenaBase3D; no es hot-reload-sensible. Van juntos a propósito:
    la creature posee el cuerpo, la escena posee la coreografía (contrato del DR). */
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaAngelita } from '../../creatures/AbejaAngelita.jsx';
 import { SombraContacto } from './SombraContacto.jsx';
+import { reaccionDeFinca } from './reaccionFinca.js';
 import useHaptics from '../useHaptics.js';
+
+/* Vuelo neutro: cuando la escena aún no pasa `estadoFinca` (contrato viejo),
+   la coreografía se comporta EXACTO como antes (todos los multiplicadores en 1). */
+const VUELO_NEUTRO = { altura: 1, velocidad: 1, vagar: 1, tiembla: 0 };
 
 /**
  * Devuelve `{ ref, caraRef, sombraRef }` para colgar del `<group>` de la abeja,
@@ -36,9 +41,12 @@ import useHaptics from '../useHaptics.js';
  * @param {number}  [opts.energia=1]      0..1 — vivacidad del vuelo (de la salud real).
  * @param {boolean} [opts.reducedMotion=false]  congela el vaivén a un fotograma.
  * @param {number}  [opts.piso=0]  y del suelo donde se proyecta la sombra.
+ * @param {object}  [opts.vuelo]  modificadores de reaccionDeFinca: mojada vuela
+ *   más bajo/lento, sed baja a buscar agua, comiendo tiembla mordisqueando.
+ *   `{ altura, velocidad, vagar, tiembla }` — multiplicadores (1 = vuelo normal).
  */
 export function useEntradaAbeja(foco, {
-  entrando = true, energia = 1, reducedMotion = false, piso = 0,
+  entrando = true, energia = 1, reducedMotion = false, piso = 0, vuelo = VUELO_NEUTRO,
 } = {}) {
   const ref = useRef(null);
   const caraRef = useRef(null);
@@ -52,17 +60,27 @@ export function useEntradaAbeja(foco, {
   useFrame((state) => {
     if (!ref.current) return;
     const t = state.clock.elapsedTime;
-    const brio = 0.35 + 0.65 * energia; // la energía anima el vuelo
+    // El estado de la finca modula el vuelo: mojada pesa (baja/lenta), sed baja a
+    // buscar agua, comiendo tiembla mordisqueando. Multiplicadores de reaccionDeFinca.
+    const mAltura = vuelo?.altura ?? 1;
+    const mVel = vuelo?.velocidad ?? 1;
+    const mVagar = vuelo?.vagar ?? 1;
+    const tiembla = reducedMotion ? 0 : (vuelo?.tiembla ?? 0);
+    const brio = (0.35 + 0.65 * energia) * mVel; // la energía y el clima animan el vuelo
     const bob = reducedMotion ? 0 : Math.sin(t * (1.6 + brio)) * (0.06 + 0.12 * brio);
+    // Temblor de sed/mordisco: sacudida rápida y corta (nervio, no vaivén).
+    const tembleque = tiembla ? Math.sin(t * 13) * tiembla : 0;
     // Al reposo deriva en un círculo calmo; al entrar se posa junto al lugar.
-    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.55) * 0.6;
-    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.55) * 0.4;
+    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.55) * 0.6 * mVagar;
+    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.55) * 0.4 * mVagar;
+    // La altura sobre el foco se atenúa con `mAltura` (mojada/sed vuelan más bajo).
+    const alto = (entrando ? 0.85 : 1.6) * mAltura;
     const dest = new THREE.Vector3(
-      foco.x + (entrando ? 0.45 : 0.35 + vagarX),
-      foco.y + (entrando ? 0.85 : 1.6) + bob,
+      foco.x + (entrando ? 0.45 : 0.35 + vagarX) + tembleque,
+      foco.y + alto + bob + tembleque * 0.5,
       foco.z + (entrando ? 0.6 : 0.55 + vagarZ),
     );
-    ref.current.position.lerp(dest, entrando ? 0.06 : 0.05);
+    ref.current.position.lerp(dest, (entrando ? 0.06 : 0.05) * mVel);
     // Angelita se posa: al cruzar el umbral de llegada al foco, un roce háptico
     // (una vez por foco — el ref evita repetir por frame; el gate del hook
     // apaga todo con reduced-motion, pref 'off' o sin soporte).
@@ -101,9 +119,27 @@ export function useEntradaAbeja(foco, {
 export function AbejaEscena({
   foco, entrando = true, animo = 'sereno', energia = 1, reducedMotion = false, piso = 0,
   hablando = false, rebote = 0,
+  // ── EL ESTADO REAL DE LA FINCA (auditoría §5b) ─────────────────────────────
+  //    Angelita SIEMPRE refleja tu realidad: llueve→mojada, Niño/sequía→sed,
+  //    cosecha→come de eso, ánimo por salud. Interfaz LIMPIA; hoy MUESTRA, codex
+  //    cabla el dato real con useFincaViva. Si NO se pasa, la abeja usa el
+  //    `animo`/`energia` sueltos de siempre (contrato viejo intacto).
+  estadoFinca = null, hayAlerta = false,
 }) {
+  // La CAPA de reacción (pura, desacoplada de la especie): del estado real sale
+  // el ánimo, la energía, y el repertorio (mojada/sed/comiendo) + modificadores
+  // de vuelo. Con estadoFinca manda la reacción; sin él, el contrato viejo.
+  const reaccion = useMemo(
+    () => (estadoFinca ? reaccionDeFinca(estadoFinca, { hayAlerta }) : null),
+    [estadoFinca, hayAlerta],
+  );
+  const animoReal = reaccion?.animo ?? animo;
+  const energiaReal = reaccion?.energia ?? energia;
+  const mojada = reaccion?.mojada ?? false;
+  const sed = reaccion?.sed ?? false;
+  const comiendo = reaccion?.comiendo ?? false;
   const { ref, caraRef, sombraRef } = useEntradaAbeja(foco, {
-    entrando, energia, reducedMotion, piso,
+    entrando, energia: energiaReal, reducedMotion, piso, vuelo: reaccion?.vuelo,
   });
   // Microrrebote: cada toque de hotspot sube `rebote`; reiniciamos la animación
   // CSS (quitar → reflow → poner) para que dispare aun en toques seguidos. El
@@ -118,19 +154,33 @@ export function AbejaEscena({
     const t = setTimeout(() => el.removeAttribute('data-rebote'), 640);
     return () => clearTimeout(t);
   }, [rebote, reducedMotion]);
-  const size = 40 + Math.round(energia * 12);
+  const size = 40 + Math.round(energiaReal * 12);
+  const vivo = !reducedMotion;
   return (
     <>
       <group ref={ref} position={[foco.x + 0.45, foco.y + 0.85, foco.z + 0.6]}>
         <Html center distanceFactor={7} zIndexRange={[40, 10]}>
+          {/* Reacción al estado real, también en el wrapper (brillo mojado,
+              temblor sediento, bamboleo de mordisco — rubber-hose). Gate RM. */}
           <div
             className="mundo-abeja"
             aria-hidden="true"
-            data-hablando={hablando && !reducedMotion ? '1' : undefined}
+            data-hablando={hablando && vivo ? '1' : undefined}
+            data-mojada={mojada && vivo ? '1' : undefined}
+            data-sed={sed && vivo ? '1' : undefined}
+            data-comiendo={comiendo && vivo ? '1' : undefined}
           >
             <div ref={reboteRef} className="mundo-abeja__rebote">
               <div ref={caraRef} className="mundo-abeja__cara">
-                <AbejaAngelita size={size} animo={animo} energia={energia} animated={!reducedMotion} />
+                <AbejaAngelita
+                  size={size}
+                  animo={animoReal}
+                  energia={energiaReal}
+                  mojada={mojada}
+                  sed={sed}
+                  comiendo={comiendo}
+                  animated={vivo}
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Qué hace

FASE 1 auditoría §5b: **Angelita SIEMPRE reactiva al estado real.** Nueva capa de estado `reaccionFinca.js` (función pura, desacoplada de la especie — lista para el selector de avatar futuro) que traduce el estado de la finca al repertorio de la abeja:

| Estado | Reacción |
|---|---|
| `clima: lluvia` | Mojada: gotas que escurren con splash, brillo, vuela más bajo y pesado |
| `enso: nino` / sequía / agua baja | Sed: jadea (lengüita con rebote, pecho agitado), baja a buscar agua, temblor nervioso |
| `cosechaReciente` | Liba el fruto: probóscide que bucea + squash & stretch por picotazo |
| `saludFinca` (matas vivas + agua) | Ánimo (`pleno/sereno/atento/sediento/descansa`) y energía del vuelo/aura |

Estética **rubber-hose** (ref. del operador: Cuphead / Miss Minutes): curvas con overshoot, squash & stretch, solo `transform`/`opacity`.

## Interfaz (para el cableo real)

```js
estadoFinca = { clima, enso, cosechaReciente, saludFinca: { matasVivas, matasTotal, agua } }
```

- HOY: datos de MUESTRA (`ESTADO_FINCA_MUESTRA`, finca sana bajo lluvia → se ve ya).
- DESPUÉS: codex cablea `useFincaViva` → pasa `estadoFinca` real a `<Mundo>` / `Valle3D` sin tocar nada más.
- Sin `estadoFinca` explícito los contratos viejos (`animo`/`energia`) siguen intactos.

## Dónde vive

- `escenas/reaccionFinca.js` (nuevo): derivación pura + muestra.
- `AbejaAngelita`: gotas/probóscide/aura por props opcionales + data-attrs.
- `creatures.css`: animaciones nuevas, congeladas bajo `prefers-reduced-motion` (fotograma digno: el estado se lee quieto).
- `useEntradaAbeja`/`AbejaEscena`: modificadores de vuelo `{ altura, velocidad, vagar, tiembla }`.
- `EscenaBase3D` → todos los mundos por spread; `Mundo.jsx` expone la prop; `EscenaValle`/`Valle3D` (CompaneroAbeja) para el mapa.

## Verificación

- `npx eslint` sobre los 7 archivos tocados: limpio (`--max-warnings=0`).
- `npm run build`: verde (34.5s).
- Nota: lefthook no está en PATH en este entorno → el auto-bump de versión no corrió en el commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)