### PR TITLE
feat(mundo3d): cámara de director — establishing shot + encuadre que respira (FASE 4)

### DIFF
--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -30,6 +30,7 @@ import {
 } from '@react-three/drei';
 import * as THREE from 'three';
 import { perfilDeTier } from '../../visual/mundo3d/deviceTier.js';
+import CamaraDirector from '../../visual/mundo3d/escenas/CamaraDirector.jsx';
 import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
 /* La CAPA DE ESTADO de Angelita (auditoría §5b): módulo puro, sin three — el
    mismo repertorio (mojada/sed/comiendo/vuelo) que usan los mundos 3D. */
@@ -1032,8 +1033,12 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit }) {
   );
 }
 
+/* La pose de cámara del valle: UNA fuente para el Canvas y para el establishing
+   shot de la CámaraDirector (así el dolly aterriza EXACTO donde siempre). */
+const CAMARA_VALLE = { position: [10.5, 9, 13.5], fov: 40 };
+
 /* ── Contenido de la escena (dentro del Canvas). ── */
-function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil, estadoFinca = null, hayAlerta = false }) {
+function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false }) {
   const controls = useRef(null);
   // Occluders de los rótulos: solo terreno + cordillera (raycast barato y es
   // exactamente lo que las etiquetas no deben atravesar).
@@ -1118,6 +1123,21 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         controls={controls}
         autoOrbit={autoOrbit}
       />
+      {/* La CÁMARA DE DIRECTOR (FASE 4): el establishing shot del mapa — dolly
+          con arco desde más alto/lejos hasta la pose de siempre, UNA vez por
+          sesión (volver de un mundo no lo repite). Sin `mirada`: el target ya
+          lo lleva CamaraViajera; aquí solo posición + FOV. La respiración del
+          encuadre es aditiva y convive con su lerp. Gama baja o reduced-motion:
+          cámara simple (inerte). */}
+      <CamaraDirector
+        controls={controls}
+        reposo={CAMARA_VALLE.position}
+        duracion={2.4}
+        amplio={1.3}
+        respiro={0.05}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="valle"
+      />
       <AdaptiveDpr pixelated />
     </>
   );
@@ -1148,7 +1168,7 @@ export default function Valle3D({
       shadows={perfil.sombras}
       dpr={perfil.dpr}
       gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
-      camera={{ position: [10.5, 9, 13.5], fov: 40 }}
+      camera={CAMARA_VALLE}
       frameloop={reducedMotion ? 'demand' : 'always'}
       onCreated={() => setListo(true)}
     >
@@ -1164,6 +1184,7 @@ export default function Valle3D({
           onAlerta={onAlerta}
           reducedMotion={reducedMotion}
           perfil={perfil}
+          tier={tier}
         />
       </Suspense>
     </Canvas>

--- a/src/visual/mundo3d/escenas/CamaraDirector.jsx
+++ b/src/visual/mundo3d/escenas/CamaraDirector.jsx
@@ -1,0 +1,151 @@
+/*
+ * CamaraDirector — el GAME-FEEL de cámara compartido (FASE 4, pulido indie).
+ *
+ * Tres gestos de director, todos SUTILES y cálidos (juego cozy, no montaña rusa):
+ *
+ *  1. ESTABLISHING SHOT al montar: la cámara arranca un poco más atrás, más
+ *     alta y con un pelo de arco lateral, y hace DOLLY con ease-out hacia el
+ *     encuadre de reposo mientras el lente se asienta (unos grados más abierto
+ *     → base, vía `setFocalLength`): la escena "se revela" en vez de aparecer
+ *     clavada. Coreografiado con el velo de `TransicionMundo` (VIAJE_MS≈1s):
+ *     el velo cubre la primera mitad del dolly y al abrirse la cámara todavía
+ *     está llegando — entrar se siente como LLEGAR. El primer gesto del
+ *     usuario (pointerdown) ACELERA el resto del ease: el director cede,
+ *     siempre, sin teletransportes.
+ *
+ *  2. ENCUADRE QUE RESPIRA: terminado el intro, un vaivén vertical mínimo del
+ *     target (dos senos lentos desfasados, amplitud ~centímetros de mundo).
+ *     Es ADITIVO por delta de frame — no pelea con el orbit del usuario ni
+ *     con otras cámaras (p. ej. `CamaraViajera` del valle) que muevan el
+ *     mismo target.
+ *
+ *  3. RESPETO: con `activa=false` (reduced-motion o tier bajo) el componente
+ *     es INERTE TOTAL — cero listeners, cero trabajo por frame, la cámara se
+ *     queda quieta en la pose del Canvas. El estado FINAL del intro es
+ *     EXACTAMENTE la pose de reposo de siempre: cero regresión de encuadre.
+ *
+ * No toca navegación ni escenas: vive junto a los OrbitControls y solo mueve
+ * cámara/target (por MÉTODOS three — copy/lerp/lookAt/setFocalLength — nunca
+ * reasignando props: react-hooks/immutability). Los controles quedan
+ * habilitados durante el intro: como cada frame reescribe la pose, el arrastre
+ * del usuario "entra" apenas termina el ease acelerado por su propio toque.
+ * `unaVezClave` evita repetir el show en escenas que re-montan seguido (el
+ * valle re-monta en cada regreso; su establishing corre una vez por sesión).
+ */
+import { useEffect, useRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+
+const easeOutCubic = (p) => 1 - (1 - p) ** 3;
+
+/* Claves ya presentadas en esta sesión: volver al valle no repite su intro. */
+const yaPresentados = new Set();
+
+export default function CamaraDirector({
+  /** ref de los OrbitControls hermanos (target compartido). */
+  controls,
+  /** [x,y,z] — pose FINAL de la cámara: la misma que ya fija el Canvas. */
+  reposo,
+  /** [x,y,z] — target del ARRANQUE (un pelín alto: revela con tilt-down).
+      null → el intro no toca el target (p. ej. el valle, donde ya lo lleva
+      `CamaraViajera`). */
+  mirada = null,
+  /** Duración del dolly (s). El velo del viaje cubre la primera mitad. */
+  duracion = 2.1,
+  /** Factor de retroceso del arranque (1.45 → 45% más lejos). */
+  amplio = 1.45,
+  /** Amplitud (unidades de mundo) de la respiración del encuadre. 0 → sin. */
+  respiro = 0.03,
+  /** false → inerte total (reduced-motion / tier bajo / frameloop demand). */
+  activa = true,
+  /** Si viene, el intro corre UNA vez por sesión para esa clave. */
+  unaVezClave = null,
+}) {
+  const { camera } = useThree();
+  // ¿Saltar el intro? Se decide UNA vez al montar (ref-initializer): inactiva,
+  // o clave ya presentada. La respiración igual queda gateada por `activa`.
+  const saltarIntro = useRef(!activa || (unaVezClave !== null && yaPresentados.has(unaVezClave)));
+  /** Estado del intro en curso; null = terminado (o nunca hubo). */
+  const intro = useRef(null);
+  const respiroPrev = useRef(0);
+
+  useEffect(() => {
+    if (saltarIntro.current) return undefined;
+    if (unaVezClave !== null) yaPresentados.add(unaVezClave);
+    const c = controls.current;
+    const hasta = new THREE.Vector3(...reposo);
+    // Target de reposo: el que los controles ya traen (0,0,0 por default) —
+    // así el estado final es idéntico al encuadre de siempre.
+    const tHasta = c ? c.target.clone() : new THREE.Vector3();
+    const tDesde = mirada ? new THREE.Vector3(...mirada) : null;
+    const pivote = tDesde || tHasta;
+    // La pose amplia: retroceder sobre el eje cámara→pivote, girar un pelo
+    // alrededor de Y (el dolly dibuja un ARCO, no una recta) y subir un poco
+    // (grúa suave). Todo proporcional a la escala de la escena.
+    const dir = hasta.clone().sub(pivote).multiplyScalar(amplio);
+    dir.applyAxisAngle(new THREE.Vector3(0, 1, 0), -0.12);
+    const desde = pivote.clone().add(dir);
+    desde.setY(desde.y + dir.length() * 0.1);
+
+    // El "lente que se asienta": del focal de reposo (el fov que ya fijó el
+    // Canvas) a uno ~12% más corto (más abierto) al arrancar. `setFocalLength`
+    // actualiza fov + projection matrix por método.
+    const fRep = camera.getFocalLength();
+    const fAmp = fRep / 1.12;
+    intro.current = { p: 0, desde, hasta, tDesde, tHasta, fAmp, fRep };
+    camera.position.copy(desde);
+    camera.setFocalLength(fAmp);
+    if (tDesde && c) c.target.copy(tDesde);
+    camera.lookAt(tDesde || tHasta);
+
+    // El primer gesto del usuario ACELERA la presentación (capture en window:
+    // también los hotspots DOM, que no burbujean por el canvas). Sin saltos:
+    // solo adelanta el progreso y el ease-out remata en ~0.3 s.
+    const cortar = () => {
+      const st = intro.current;
+      if (st) st.p = Math.max(st.p, 0.82);
+    };
+    window.addEventListener('pointerdown', cortar, true);
+    return () => window.removeEventListener('pointerdown', cortar, true);
+    // Intro de montaje: corre exactamente una vez, con las props del arranque.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useFrame((state, delta) => {
+    const c = controls.current;
+    const st = intro.current;
+    if (st) {
+      // delta acotado: una pestaña dormida no "salta" el dolly al despertar.
+      st.p = Math.min(1, st.p + Math.min(delta, 1 / 20) / duracion);
+      const e = easeOutCubic(st.p);
+      camera.position.lerpVectors(st.desde, st.hasta, e);
+      if (st.tDesde && c) c.target.lerpVectors(st.tDesde, st.tHasta, e);
+      camera.setFocalLength(THREE.MathUtils.lerp(st.fAmp, st.fRep, e));
+      camera.lookAt(c ? c.target : st.tHasta);
+      if (st.p >= 1) {
+        // Aterrizaje EXACTO en la pose de reposo. El target solo se fija si
+        // este director lo condujo (`mirada`); si otro lo lleva (CamaraViajera
+        // en el valle), ni tocarlo.
+        camera.position.copy(st.hasta);
+        camera.setFocalLength(st.fRep);
+        if (c) {
+          if (st.tDesde) c.target.copy(st.tHasta);
+          c.update();
+        }
+        intro.current = null;
+      }
+      return;
+    }
+    // ── La respiración del encuadre (solo activa y con amplitud) ──
+    if (!activa || respiro <= 0 || !c) return;
+    const t = state.clock.elapsedTime;
+    const b = Math.sin(t * 0.45) * respiro + Math.sin(t * 0.23 + 1.7) * respiro * 0.5;
+    // Aditivo por delta contra el frame anterior: convive con el orbit del
+    // usuario y con cualquier otro sistema que mueva el mismo target.
+    c.target.setY(c.target.y + b - respiroPrev.current);
+    respiroPrev.current = b;
+  });
+
+  // Presencia puramente imperativa; nada que dibujar.
+  return null;
+}

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -25,6 +25,7 @@ import { Canvas } from '@react-three/fiber';
 import { Html, OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaEscena } from './useEntradaAbeja.jsx';
+import CamaraDirector from './CamaraDirector.jsx';
 import { SombraContacto } from './SombraContacto.jsx';
 import { ESTADO_FINCA_MUESTRA } from './reaccionFinca.js';
 import useHaptics from '../useHaptics.js';
@@ -36,7 +37,7 @@ import { ATMOSFERA, CIELOS, mezclar } from '../atmosferaMadre.js';
 function Contenido({
   params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, piso = 0,
   frugal = false, hablando = false, focoId = null, focoToken = 0,
-  estadoFinca = ESTADO_FINCA_MUESTRA, hayAlerta = false,
+  estadoFinca = ESTADO_FINCA_MUESTRA, hayAlerta = false, camaraInicial,
   children,
 }) {
   const controls = useRef(null);
@@ -197,6 +198,20 @@ function Contenido({
         autoRotate={!reducedMotion && !activo}
         autoRotateSpeed={0.25}
       />
+      {/* La CÁMARA DE DIRECTOR (FASE 4): establishing shot al entrar (dolly con
+          arco + FOV que se asienta, coreografiado con el velo del viaje) y un
+          encuadre que respira apenas. La `mirada` arranca un pelín sobre el
+          corazón del diorama y baja al target de siempre (tilt-down de revelado);
+          la pose final es EXACTA a la de hoy. Inerte con reduced-motion o en el
+          perfil mínimo (gama baja forzada a 3D): ahí la cámara queda simple. */}
+      <CamaraDirector
+        controls={controls}
+        reposo={camaraInicial.position}
+        mirada={[centro[0], centro[1] + zoom * 0.12, centro[2]]}
+        duracion={2.1}
+        respiro={zoom * 0.005}
+        activa={!reducedMotion && !frugal}
+      />
       <AdaptiveDpr pixelated />
     </>
   );
@@ -246,6 +261,7 @@ export default function EscenaBase3D({
           focoToken={focoToken}
           estadoFinca={estadoFinca}
           hayAlerta={hayAlerta}
+          camaraInicial={cam}
         >
           {children}
         </Contenido>


### PR DESCRIPTION
## Qué hace

Game-feel de cámara de director para el 3D (FASE 4, pulido indie premium): sutil, cálido, cozy — no mareante.

- **`CamaraDirector.jsx` (nuevo, compartido)**: al entrar a un mundo la cámara arranca más atrás/alta y hace **dolly con arco + grúa suave** hacia el encuadre de reposo mientras el **lente se asienta** (~12% más abierto → base, vía `setFocalLength`). Coreografiado con el velo de `TransicionMundo` (1050 ms): el velo cubre la primera mitad del dolly — al abrirse, la cámara todavía está llegando.
- **El director cede**: el primer `pointerdown` del usuario acelera el resto del ease (~0.3 s), sin saltos.
- **Encuadre que respira**: terminado el intro, vaivén vertical mínimo del target (dos senos lentos desfasados), **aditivo por delta de frame** — convive con el orbit del usuario y con `CamaraViajera`.
- **EscenaBase3D**: mirada de arranque un pelín sobre el corazón del diorama que baja al target de siempre (tilt-down de revelado). La pose final es EXACTA a la de hoy → cero regresión de encuadre.
- **Valle3D**: establishing shot del mapa **una vez por sesión** (volver de un mundo no lo repite); solo posición + lente, el target sigue en manos de `CamaraViajera`. Pose extraída a `CAMARA_VALLE` (una fuente para Canvas y director).

## Respeto (a11y + gama baja)

- `prefers-reduced-motion` → inerte total: cámara quieta en la pose del Canvas, cero listeners ni trabajo por frame.
- Tier **bajo** → cámara simple (inerte); medio/alto reciben el intro (un dolly no cuesta píxeles).

## Qué NO toca

- Lógica de navegación (`useNavegacionMundos`, `TransicionMundo`) intacta.
- Escenas de contenido (cutaway/flujo/recinto/…) intactas: el director vive junto a los `OrbitControls` del andamiaje.
- Solo métodos three (`copy`/`lerp`/`lookAt`/`setFocalLength`) — compatible con `react-hooks/immutability`.

## Verificación

- `npx eslint` sobre los 3 archivos tocados: limpio.
- `npm run build`: verde (45.7 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)