### PR TITLE
feat(mundo3d): venta/nace/muerte como MOMENTO 3D (§5a.4)

### DIFF
--- a/src/visual/mundo3d/escenas/AnimalMomento.jsx
+++ b/src/visual/mundo3d/escenas/AnimalMomento.jsx
@@ -1,0 +1,271 @@
+/*
+ * AnimalMomento — el cambio de estado de un animal como un MOMENTO memorable
+ * (auditoría FASE 2 §5a.4), no como un salto brusco. Un solo animal, dibujado
+ * con la MISMA morfología del hato (ESPECIES de CorralVivo, primitivas orgánicas
+ * — nunca una caja), pero fuera del InstancedMesh para poder darle su propio
+ * instante: escala, opacidad y gesto que la instancia compartida no permite.
+ *
+ * Tres momentos, la visión del operador ("mis animales son seres, no filas"):
+ *
+ *   · `nace`   — una CRÍA aparece: crece desde casi nada con un brillo cálido y
+ *                unas motas que suben. Alegre, sin estridencia.
+ *   · `muerte` — el animal se RETIRA con respeto: se apaga despacio y se inclina,
+ *                sube una mota tibia (el adiós) y queda una piedrita con una flor.
+ *                Cálido, jamás dramático (no se derrumba, se despide).
+ *   · `llega`  — el VENDIDO viaja al MERCADO: camina desde la parcela (al fondo)
+ *                hasta los puestos y se posa. El MISMO dato en dos mundos: en el
+ *                corral queda su huella-fantasma, aquí llega en cuerpo (la
+ *                consistencia cross-mundo del audit).
+ *
+ * GATE doble (idéntico al resto del corral): sin reduced-motion y con tier
+ * suficiente se anima; si no, se pinta el ESTADO FINAL quieto (cría entera,
+ * memoria con su flor, vendido ya posado) — la información se ve igual, sin
+ * movimiento. Bajo `frameloop='demand'` de reduced-motion useFrame no corre: por
+ * eso el reposo se aplica una vez en el layout.
+ */
+import { useLayoutEffect, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Text } from '@react-three/drei';
+import * as THREE from 'three';
+import { ESPECIES, GeometriaParte } from './CorralVivo.jsx';
+import { PALETA } from '../atmosferaMadre.js';
+
+/* Duración de cada instante (s): el adiós es el más pausado. */
+const DUR = { nace: 2.2, muerte: 3.2, llega: 3.0 };
+
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+const easeOutCubic = (p) => 1 - (1 - p) ** 3;
+const easeInCubic = (p) => p * p * p;
+const easeInOutSine = (p) => -(Math.cos(Math.PI * p) - 1) / 2;
+/* rebote suave al final (la cría "asienta" con un respiro, no un pop seco) */
+const easeOutBack = (p) => {
+  const c1 = 1.70158;
+  const c3 = c1 + 1;
+  return 1 + c3 * (p - 1) ** 3 + c1 * (p - 1) ** 2;
+};
+
+export default function AnimalMomento({
+  animal,
+  modo = 'nace',
+  destino,
+  origen,
+  reducedMotion = false,
+  tier = 'alto',
+  onPick,
+}) {
+  const raiz = useRef(null);   // world: se mueve solo en `llega`
+  const cuerpo = useRef(null); // local: escala/gesto/inclinación del animal
+  const halo = useRef(null);   // brillo de nacimiento
+  const motas = useRef(null);  // motas que suben (nace o adiós)
+  const memoria = useRef(null);// la piedrita con flor (muerte)
+  const inicio = useRef(null);
+
+  const animar = !reducedMotion && tier !== 'bajo';
+  const esp = ESPECIES[animal.especie] || ESPECIES.animal;
+  const s0 = animal.escala || 0.8;
+  const dur = DUR[modo] || 2.4;
+
+  const dest = destino || [0, 0, 0];
+  // el vendido entra por la parcela del fondo (−z) y baja al puesto; los demás
+  // no viajan (nacen/mueren donde están).
+  const orig = origen || (modo === 'llega' ? [dest[0], dest[1], dest[2] - 2.4] : dest);
+
+  // partes con LOD: en gama baja se cae lo `fina` (crestas, orejas, colas).
+  const partes = esp.partes.filter((p) => !p.fina || tier !== 'bajo');
+  const alto = esp.alto * s0;
+
+  // El paso a paso del momento: reescribe transform/opacidad de los refs según
+  // el progreso p∈[0,1]. Se llama por frame (animando) o una vez en reposo (p=1).
+  const aplicar = (p) => {
+    const r = raiz.current;
+    const c = cuerpo.current;
+    if (!r || !c) return;
+
+    if (modo === 'llega') {
+      const e = easeOutCubic(p);
+      r.position.set(
+        orig[0] + (dest[0] - orig[0]) * e,
+        orig[1] + (dest[1] - orig[1]) * e,
+        orig[2] + (dest[2] - orig[2]) * e,
+      );
+      c.rotation.set(0, -Math.PI / 2, 0); // mira hacia +z (baja hacia el puesto)
+      // trote que se asienta: un balanceo que decae al llegar
+      c.position.y = Math.abs(Math.sin(p * Math.PI * 7)) * 0.05 * (1 - e);
+      c.scale.setScalar(s0);
+      opacidadCuerpo(c, 1);
+    } else if (modo === 'nace') {
+      r.position.set(...dest);
+      const crece = 0.12 + 0.88 * easeOutBack(p);
+      c.scale.setScalar(s0 * crece);
+      c.rotation.set(0, 0, 0);
+      c.position.y = 0;
+      opacidadCuerpo(c, clamp01(p * 2)); // se define en el primer tramo
+      if (halo.current) {
+        halo.current.scale.setScalar(s0 * (0.5 + 1.9 * easeOutCubic(p)));
+        halo.current.material.opacity = 0.5 * (1 - p);
+      }
+      subirMotas(p, alto, '#ffe6b0');
+    } else if (modo === 'muerte') {
+      r.position.set(...dest);
+      const e = easeInOutSine(p);
+      c.scale.setScalar(s0);
+      c.rotation.set(0, 0, -0.16 * easeOutCubic(p)); // se inclina despacio
+      c.position.y = -0.03 * easeInCubic(p);          // se recoge, no se derrumba
+      opacidadCuerpo(c, 1 - 0.68 * e);                 // se apaga, no desaparece
+      if (memoria.current) {
+        const m = clamp01((p - 0.3) / 0.7);
+        memoria.current.scale.setScalar(0.5 + 0.5 * easeOutCubic(m));
+        memoria.current.traverse((o) => {
+          if (o.material) o.material.opacity = m;
+        });
+      }
+      subirMotas(p, alto, '#ffdca0'); // el adiós tibio que sube
+    }
+  };
+
+  // opacidad de todas las mallas del cuerpo (few meshes → traverse trivial).
+  const opacidadCuerpo = (c, o) => {
+    for (const hijo of c.children) {
+      if (hijo.material) hijo.material.opacity = o;
+    }
+  };
+
+  // motas tenues que suben y se desvanecen (nacimiento o adiós).
+  const subirMotas = (p, base, color) => {
+    const g = motas.current;
+    if (!g) return;
+    g.visible = animar && p < 0.98;
+    g.children.forEach((mo, i) => {
+      const fase = clamp01(p * 1.4 - i * 0.12);
+      mo.position.y = base * 0.5 + fase * (base + 0.5);
+      if (mo.material) {
+        mo.material.color.set(color);
+        mo.material.opacity = 0.8 * Math.sin(fase * Math.PI);
+      }
+    });
+  };
+
+  useLayoutEffect(() => {
+    inicio.current = null;
+    aplicar(animar ? 0 : 1); // reposo → estado final; animando → arranque limpio
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [animal.id, modo, animar, tier]);
+
+  useFrame((state) => {
+    if (!animar || !raiz.current) return;
+    if (inicio.current == null) inicio.current = state.clock.elapsedTime;
+    aplicar(clamp01((state.clock.elapsedTime - inicio.current) / dur));
+  });
+
+  return (
+    <group ref={raiz}>
+      {/* el cuerpo del animal: mismas partes del hato, como mallas sueltas para
+          poder animarle escala/opacidad/gesto propios */}
+      <group
+        ref={cuerpo}
+        onClick={
+          onPick
+            ? (e) => {
+                e.stopPropagation();
+                onPick(animal);
+              }
+            : undefined
+        }
+      >
+        {partes.map((parte, i) => (
+          <mesh
+            key={i}
+            position={parte.pos || [0, 0, 0]}
+            rotation={parte.rot || [0, 0, 0]}
+            scale={parte.escala || [1, 1, 1]}
+          >
+            <GeometriaParte geo={parte.geo} />
+            <meshLambertMaterial
+              color={parte.porRaza ? animal.colorCss : parte.color}
+              flatShading
+              transparent
+              depthWrite={modo !== 'muerte'}
+            />
+          </mesh>
+        ))}
+      </group>
+
+      {/* el brillo cálido del nacimiento */}
+      {modo === 'nace' && (
+        <mesh ref={halo} position={[0, alto * 0.5, 0]}>
+          <sphereGeometry args={[0.4, 10, 8]} />
+          <meshBasicMaterial color="#ffe6b0" transparent opacity={0} depthWrite={false} />
+        </mesh>
+      )}
+
+      {/* la memoria: una piedrita con su flor, al lado de donde estuvo. Cálida,
+          sin dramatizar — el dato persiste, el ser se recuerda. */}
+      {modo === 'muerte' && (
+        <group ref={memoria} position={[0.22 * s0, 0, 0.14 * s0]}>
+          <mesh position={[0, 0.05, 0]} scale={[1, 0.6, 1]}>
+            <sphereGeometry args={[0.11, 8, 6]} />
+            <meshLambertMaterial color="#8f8574" flatShading transparent opacity={0} />
+          </mesh>
+          <mesh position={[0.03, 0.16, 0.05]}>
+            <cylinderGeometry args={[0.008, 0.011, 0.16, 4]} />
+            <meshLambertMaterial color="#5a7a3a" transparent opacity={0} />
+          </mesh>
+          <mesh position={[0.03, 0.25, 0.05]}>
+            <sphereGeometry args={[0.032, 7, 6]} />
+            <meshLambertMaterial color="#e2b4cf" flatShading transparent opacity={0} />
+          </mesh>
+          {[0, 1, 2, 3].map((k) => {
+            const a = (k / 4) * Math.PI * 2;
+            return (
+              <mesh key={k} position={[0.03 + Math.cos(a) * 0.04, 0.25, 0.05 + Math.sin(a) * 0.04]}>
+                <sphereGeometry args={[0.02, 6, 5]} />
+                <meshLambertMaterial color="#efcfe0" flatShading transparent opacity={0} />
+              </mesh>
+            );
+          })}
+        </group>
+      )}
+
+      {/* las motas que suben (nacimiento o adiós) */}
+      {(modo === 'nace' || modo === 'muerte') && (
+        <group ref={motas}>
+          {[0, 1, 2].map((k) => (
+            <mesh key={k} position={[(k - 1) * 0.09, 0, (k - 1) * 0.05]}>
+              <octahedronGeometry args={[0.035, 0]} />
+              <meshBasicMaterial color="#ffe6b0" transparent opacity={0} depthWrite={false} />
+            </mesh>
+          ))}
+        </group>
+      )}
+
+      {/* el vendido llega con su NOMBRE puesto: el dato viajó con él (mismo ser,
+          otro mundo). Un rótulo de madera clavado, legible por ambas caras. */}
+      {modo === 'llega' && animal.nombre && (
+        <group position={[0, alto + 0.34, 0]}>
+          <mesh position={[0, -0.16, 0]}>
+            <cylinderGeometry args={[0.016, 0.022, 0.32, 5]} />
+            <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
+          </mesh>
+          <mesh>
+            <boxGeometry args={[0.5, 0.18, 0.03]} />
+            <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+          </mesh>
+          {[0.02, -0.02].map((lado) => (
+            <Text
+              key={lado}
+              position={[0, 0, lado]}
+              rotation={[0, lado < 0 ? Math.PI : 0, 0]}
+              fontSize={0.088}
+              maxWidth={0.44}
+              color="#241a10"
+              anchorX="center"
+              anchorY="middle"
+            >
+              {animal.nombre}
+            </Text>
+          ))}
+        </group>
+      )}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/escenas/CorralVivo.jsx
+++ b/src/visual/mundo3d/escenas/CorralVivo.jsx
@@ -4,7 +4,14 @@
  * El hato REAL de la finca se dibuja desde `params.animales`:
  *
  *   [{ especie, nombre, raza, tamano: 'pequeño'|'mediano'|'grande',
- *      estado: 'sano'|'preñada'|'vendido' }]
+ *      estado: 'sano'|'preñada'|'vendido'|'nace'|'muerte' }]
+ *
+ * Un cambio de estado es un MOMENTO (audit §5a.4), no un salto: `nace` hace
+ * APARECER una cría (crece con un brillo cálido), `muerte` la RETIRA con respeto
+ * (se apaga suave y deja una piedrita con flor — sin dramatizar) y `vendido`
+ * la manda al MERCADO (el mismo dato vive en dos mundos: aquí queda su huella,
+ * allá llega caminando). Esos tres los dibuja AnimalMomento; el resto, el hato
+ * instanciado. Todo gateado por reduced-motion + device-tier.
  *
  * y cada animal se ve como ES: la especie da la silueta, el TAMAÑO da la
  * escala (3 cerdos pequeños + 4 medianos + 5 grandes se distinguen a golpe de
@@ -39,6 +46,7 @@ import { useFrame } from '@react-three/fiber';
 import { Html, Text } from '@react-three/drei';
 import * as THREE from 'three';
 import { PALETA } from '../atmosferaMadre.js';
+import AnimalMomento from './AnimalMomento.jsx';
 
 /* ── La escala del TAMAÑO declarado: clases discretas, no continuo (el dato
       del cuaderno dice "pequeño/mediano/grande", el corral lo espeja). ── */
@@ -69,7 +77,7 @@ const PELAJES = ['#c9a06a', '#e7d9c2', '#8a6a55', '#d8b58a', '#efe7d8', '#a55636
  * Las siluetas vienen de los animales low-poly ya validados del recinto
  * (gallina que picotea, vaca capsular, oveja de vellón) + el cerdo criollo.
  */
-const ESPECIES = {
+export const ESPECIES = {
   gallina: {
     gesto: 'picotea',
     alto: 0.5,
@@ -143,7 +151,7 @@ const ESPECIES = {
   },
 };
 
-function GeometriaParte({ geo }) {
+export function GeometriaParte({ geo }) {
   const [tipo, args] = geo;
   if (tipo === 'esfera') return <sphereGeometry args={args} />;
   if (tipo === 'capsula') return <capsuleGeometry args={args} />;
@@ -196,6 +204,12 @@ export function normalizarAnimales(lista) {
     // rumbo pseudo-aleatorio pero DETERMINISTA (mismo hato, mismo corral)
     const rumbo = a.pos ? 0 : (Math.sin((i + 1) * 12.9898) * 43758.5453) % (Math.PI * 2);
     const estado = (a.estado || 'sano').toLowerCase();
+    // El MOMENTO (audit §5a.4): un cambio de estado no es un salto brusco sino un
+    // instante memorable que se ANIMA. `nace` (aparece una cría), `muerte` (se
+    // retira con respeto) y `vendido` (viaja al mercado — mismo dato, dos mundos)
+    // se sacan del hato instanciado y los dibuja AnimalMomento uno por uno.
+    const momento =
+      estado === 'nace' ? 'nace' : estado === 'muerte' ? 'muerte' : estado === 'vendido' ? 'vendido' : null;
     const color = new THREE.Color(colorDe(a, i));
     return {
       id: `${i}-${a.nombre || especie}`,
@@ -204,6 +218,7 @@ export function normalizarAnimales(lista) {
       raza: a.raza || '',
       tamano: a.tamano || 'mediano',
       estado,
+      momento,
       escala,
       pos,
       fase: i * 1.7,
@@ -522,12 +537,22 @@ function PlacaAnimal({ animal, onCerrar }) {
   const alto = ESPECIES[animal.especie].alto * animal.escala + 0.5;
   const meta = [animal.raza, animal.tamano].filter(Boolean).join(' · ');
   const especial = animal.estado !== 'sano';
-  const claseEstado = animal.estado.startsWith('pre') ? 'prenada' : 'vendido';
+  const claseEstado = animal.estado.startsWith('pre')
+    ? 'prenada'
+    : animal.estado === 'nace'
+      ? 'nace'
+      : animal.estado === 'muerte'
+        ? 'muerte'
+        : 'vendido';
   const textoEstado = animal.estado.startsWith('pre')
     ? 'Preñada'
-    : animal.estado === 'vendido'
-      ? 'Vendido'
-      : animal.estado;
+    : animal.estado === 'nace'
+      ? 'Recién nacida'
+      : animal.estado === 'muerte'
+        ? 'En memoria'
+        : animal.estado === 'vendido'
+          ? 'Vendido'
+          : animal.estado;
   return (
     <group position={[animal.pos[0], alto, animal.pos[2]]}>
       <Html center distanceFactor={8.5} zIndexRange={[25, 0]}>
@@ -566,14 +591,23 @@ export default function CorralVivo({ animales: lista, reducedMotion, tier = 'alt
   const animar = !reducedMotion && tier !== 'bajo';
   // LOD gama baja: sin tablas con Text (queda estaca+perilla; la placa nombra)
   const conTabla = tier !== 'bajo';
-  const grupos = useMemo(() => {
+  // El hato instanciado NO incluye los que están viviendo su momento (nace/
+  // muerte): esos los dibuja AnimalMomento, uno por uno, para animarles el
+  // instante (escala/opacidad/gesto propios que la instancia compartida no da).
+  // `vendido` SÍ se queda aquí, como huella-fantasma (su vida está en el mercado).
+  const { grupos, momentos } = useMemo(() => {
     const g = new Map();
+    const mm = [];
     for (const a of animales) {
+      if (a.momento === 'nace' || a.momento === 'muerte') {
+        mm.push(a);
+        continue;
+      }
       const k = `${a.especie}${a.estado === 'vendido' ? '|fantasma' : ''}`;
       if (!g.has(k)) g.set(k, { clave: k, especie: a.especie, fantasma: a.estado === 'vendido', lista: [] });
       g.get(k).lista.push(a);
     }
-    return [...g.values()];
+    return { grupos: [...g.values()], momentos: mm };
   }, [animales]);
   const alPicar = (a) => setSeleccion((s) => (s?.id === a.id ? null : a));
 
@@ -594,6 +628,19 @@ export default function CorralVivo({ animales: lista, reducedMotion, tier = 'alt
               />
             ))}
         </Fragment>
+      ))}
+      {/* Los MOMENTOS del corral: la cría que nace, el que se despide con respeto.
+          Cada uno vive su instante; tocarlo abre su placa igual que a los demás. */}
+      {momentos.map((a) => (
+        <AnimalMomento
+          key={a.id}
+          animal={a}
+          modo={a.momento}
+          destino={a.pos}
+          reducedMotion={reducedMotion}
+          tier={tier}
+          onPick={alPicar}
+        />
       ))}
       <MarcadoresPrenada animales={animales} animar={animar} />
       <CartelesNombres

--- a/src/visual/mundo3d/escenas/EscenaMercado.jsx
+++ b/src/visual/mundo3d/escenas/EscenaMercado.jsx
@@ -23,6 +23,8 @@
 import { useMemo } from 'react';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
+import AnimalMomento from './AnimalMomento.jsx';
+import { normalizarAnimales } from './CorralVivo.jsx';
 import { faunaDeMundo } from '../faunaFuncional.js';
 import { CIELOS, PALETA } from '../atmosferaMadre.js';
 
@@ -181,11 +183,19 @@ function MataCampo({ pos, color = '#4e8f3f' }) {
   );
 }
 
-function Diorama({ params, reducedMotion, fauna }) {
+function Diorama({ params, reducedMotion, tier, fauna }) {
   const puestos = params?.puestos || [
     { color: '#c96a2f', pos: [-0.85, 0, 0.2] },
     { color: '#3f8f4e', pos: [0.9, 0, -0.1] },
   ];
+  // Los VENDIDOS del hato LLEGAN al mercado (audit §5a.4): el mismo dato del
+  // corral, ahora en cuerpo. Bajan caminando por la ruta campo→plaza (desde la
+  // parcela del fondo hasta el frente de los puestos). Normalizamos para heredar
+  // silueta/pelaje/tamaño reales; la posición aquí es la de la ruta, no el corral.
+  const llegando = useMemo(
+    () => normalizarAnimales((params?.animales || []).filter((a) => a.estado === 'vendido')),
+    [params?.animales],
+  );
   const canastos = params?.canastos || [
     { producto: 'tomate', color: '#d24b3a', pos: [-0.85, 0, 0.75] },
     { producto: 'papa', color: '#c9a15a', pos: [0.55, 0, 0.7] },
@@ -249,6 +259,23 @@ function Diorama({ params, reducedMotion, fauna }) {
           ~0.45 sobre el piso sin mesa que la sostuviera). */}
       <Balanza pos={[0.15, 0, 0.55]} />
 
+      {/* los VENDIDOS que llegan del corral: bajan por la ruta y se posan al
+          frente de los puestos, cada uno con su NOMBRE (el dato viajó con él). */}
+      {llegando.map((a, i) => {
+        const x = 0.1 + (i - (llegando.length - 1) / 2) * 0.6;
+        return (
+          <AnimalMomento
+            key={a.id}
+            animal={a}
+            modo="llega"
+            origen={[x, 0, -2.1]}
+            destino={[x, 0, 0.4]}
+            reducedMotion={reducedMotion}
+            tier={tier}
+          />
+        );
+      })}
+
       {/* la fauna que anima la feria (polinizadores de puesto y plaza) */}
       <Fauna items={fauna} reducedMotion={reducedMotion} />
     </group>
@@ -262,7 +289,12 @@ export default function EscenaMercado(props) {
   const fauna = faunaDeMundo(props.mundoId, { tier: props.tier });
   return (
     <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.5, 0] }}>
-      <Diorama params={props.params} reducedMotion={props.reducedMotion} fauna={fauna} />
+      <Diorama
+        params={props.params}
+        reducedMotion={props.reducedMotion}
+        tier={props.tier}
+        fauna={fauna}
+      />
     </EscenaBase3D>
   );
 }

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -149,6 +149,16 @@
   color: #5a5248;
   background: #eee7da;
 }
+/* Recién nacida: verde tierno, celebración serena (un ser nuevo en el corral). */
+.mundo-placa__estado--nace {
+  color: #3f7a4a;
+  background: #e4f1e0;
+}
+/* En memoria: gris cálido, respeto sin luto (se recuerda, no se dramatiza). */
+.mundo-placa__estado--muerte {
+  color: #6a6152;
+  background: #efeae0;
+}
 
 /* ── Angelita dentro de la escena (billboard) ──────────────────────────── */
 /* Tres capas para tres gestos que NO se pisan: la raíz PULSA al narrar, la capa

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -23,6 +23,35 @@
  * (mundosFinca.js) en `resolverTinte`/`tituloMundo` (mundo host).
  */
 
+/*
+ * EL HATO DE MUESTRA — UNA sola fuente para DOS mundos (consistencia cross-mundo,
+ * audit §5a.4). El corral (`animales`) y el mercado lo leen igual: así un animal
+ * VENDIDO (Camilo) queda como huella-fantasma en el corral y a la vez llega
+ * caminando al mercado — el mismo dato, dos mundos. Aquí también viven los
+ * MOMENTOS de muestra: una cría que `nace` y una gallina que se despide con
+ * respeto (`muerte`). Interfaz lista para cablear el hato real de farmOS después
+ * (misma forma; el `estado` real manda el momento).
+ */
+const HATO_MUESTRA = [
+  { especie: 'cerdo', nombre: 'Petunia', raza: 'zungo', tamano: 'grande', estado: 'preñada' },
+  { especie: 'cerdo', nombre: 'Canelo', raza: 'duroc', tamano: 'mediano', estado: 'sano' },
+  { especie: 'cerdo', nombre: 'Rosita', raza: 'landrace', tamano: 'pequeño', estado: 'sano' },
+  { especie: 'cerdo', nombre: 'Manchas', raza: 'sanpedreño', tamano: 'pequeño', estado: 'sano' },
+  { especie: 'cerdo', nombre: 'Tocineta', raza: 'landrace', tamano: 'pequeño', estado: 'sano' },
+  { especie: 'vaca', nombre: 'Lola', raza: 'normando', tamano: 'grande', estado: 'sano' },
+  // Camilo: VENDIDO. En el corral queda su huella; en el mercado llega en cuerpo.
+  { especie: 'vaca', nombre: 'Camilo', raza: 'cebú', tamano: 'grande', estado: 'vendido' },
+  { especie: 'gallina', nombre: 'Turuleca', raza: 'campesina', tamano: 'pequeño', estado: 'sano' },
+  { especie: 'gallina', nombre: 'Canela', raza: 'campesina', tamano: 'mediano', estado: 'sano' },
+  { especie: 'gallina', nombre: 'Carlota', raza: 'ponedora', tamano: 'mediano', estado: 'sano' },
+  { especie: 'oveja', nombre: 'Nube', raza: 'criolla', tamano: 'mediano', estado: 'sano' },
+  { especie: 'oveja', nombre: 'Copito', raza: 'criolla', tamano: 'pequeño', estado: 'sano' },
+  // Lucero: NACE — una cría de oveja aparece junto a Nube y Copito (crece con brillo).
+  { especie: 'oveja', nombre: 'Lucero', raza: 'criolla', tamano: 'pequeño', estado: 'nace' },
+  // Aurelia: se despide con respeto — queda su nombre y una flor (MUERTE, sin drama).
+  { especie: 'gallina', nombre: 'Aurelia', raza: 'campesina', tamano: 'mediano', estado: 'muerte' },
+];
+
 export const MUNDO = {
   // ── SÍ-3D: el espacio mismo enseña ───────────────────────────────────────
 
@@ -89,28 +118,18 @@ export const MUNDO = {
   //    por perfil (como hoy). El corral es ESPEJO del dato (FASE 1 §5a+§5c):
   //    cada animal REAL con su nombre, raza, tamaño y estado — la especie da la
   //    silueta, el tamaño la escala, la raza el pelaje, el estado se ve (preñada
-  //    con señal, vendido como huella translúcida). Interfaz para cablear el
-  //    hato real de farmOS aquí mismo (misma forma; `pos` es opcional — sin él,
-  //    los sitios salen solos). MUESTRA de 12 mientras llega el dato vivo:
+  //    con señal, vendido como huella translúcida). Y el CAMBIO de estado es un
+  //    MOMENTO (audit §5a.4): la cría que `nace` crece con un brillo, el que
+  //    `muere` se retira con respeto (piedrita con flor), el `vendido` deja su
+  //    huella aquí y llega en cuerpo al mercado. Interfaz para cablear el hato
+  //    real de farmOS aquí mismo (misma forma; `pos` es opcional — sin él, los
+  //    sitios salen solos). MUESTRA compartida con el mercado (mismo dato):
   animales: {
     escena: 'recinto',
     valle: { tipo: 'corral', pos: [-4.6, 0, -1.8], escala: 1 },
     gate: 'animales',
     params: {
-      animales: [
-        { especie: 'cerdo', nombre: 'Petunia', raza: 'zungo', tamano: 'grande', estado: 'preñada' },
-        { especie: 'cerdo', nombre: 'Canelo', raza: 'duroc', tamano: 'mediano', estado: 'sano' },
-        { especie: 'cerdo', nombre: 'Rosita', raza: 'landrace', tamano: 'pequeño', estado: 'sano' },
-        { especie: 'cerdo', nombre: 'Manchas', raza: 'sanpedreño', tamano: 'pequeño', estado: 'sano' },
-        { especie: 'cerdo', nombre: 'Tocineta', raza: 'landrace', tamano: 'pequeño', estado: 'sano' },
-        { especie: 'vaca', nombre: 'Lola', raza: 'normando', tamano: 'grande', estado: 'sano' },
-        { especie: 'vaca', nombre: 'Camilo', raza: 'cebú', tamano: 'grande', estado: 'vendido' },
-        { especie: 'gallina', nombre: 'Turuleca', raza: 'campesina', tamano: 'pequeño', estado: 'sano' },
-        { especie: 'gallina', nombre: 'Canela', raza: 'campesina', tamano: 'mediano', estado: 'sano' },
-        { especie: 'gallina', nombre: 'Carlota', raza: 'ponedora', tamano: 'mediano', estado: 'sano' },
-        { especie: 'oveja', nombre: 'Nube', raza: 'criolla', tamano: 'mediano', estado: 'sano' },
-        { especie: 'oveja', nombre: 'Copito', raza: 'criolla', tamano: 'pequeño', estado: 'sano' },
-      ],
+      animales: HATO_MUESTRA,
     },
     hotspots: [
       { id: 'todos', pos: [0, 0.5, 1.2], emoji: '🐮', label: 'Todos los animales', view: 'animales' },
@@ -279,6 +298,9 @@ export const MUNDO = {
         { producto: 'maiz', color: '#e7c451', pos: [1.15, 0, 0.35] },
         { producto: 'cafe', color: '#7a4a24', pos: [-0.35, 0, 0.95] },
       ],
+      // EL MISMO HATO del corral (audit §5a.4): el mercado filtra los VENDIDOS y
+      // los hace LLEGAR caminando por la ruta campo→plaza. Un dato, dos mundos.
+      animales: HATO_MUESTRA,
     },
     hotspots: [
       { id: 'vender', pos: [-0.85, 1.25, 0.2], emoji: '🤝', label: 'Vender y comprar', view: 'mercado' },


### PR DESCRIPTION
## Qué

FASE 2 auditoría (§5a.4): el **cambio de estado de un animal como un MOMENTO memorable**, no como un salto brusco. Sobre el corral-espejo ya mergeado (`CorralVivo` lee `params.animales=[{especie,nombre,raza,tamano,estado}]`), tres instantes:

- **`nace`** — una cría APARECE creciendo desde casi nada con un brillo cálido y motas que suben. Queda como cría en el corral.
- **`muerte`** — el animal se RETIRA con respeto: se apaga suave, se inclina despacio, sube una mota tibia (el adiós) y deja una piedrita con flor. Cálido, sin dramatizar.
- **`vendido`** — sale del corral (queda su huella-fantasma) y **LLEGA al mercado** en cuerpo, caminando por la ruta campo→plaza con su nombre puesto. **Mismo dato, dos mundos** (la consistencia cross-mundo del audit).

## Cómo

- **`AnimalMomento.jsx`** (nuevo): dibuja UN animal con la morfología del hato (`ESPECIES`/`GeometriaParte` reusadas de `CorralVivo`), fuera del `InstancedMesh` para animarle escala/opacidad/gesto propios que la instancia compartida no da.
- **Cross-mundo real**: `HATO_MUESTRA` es UNA fuente que leen el corral y el mercado; `EscenaMercado` filtra los vendidos y los hace llegar por la ruta existente.
- `CorralVivo` saca `nace`/`muerte` del hato instanciado y los delega a `AnimalMomento`; `vendido` sigue como huella-fantasma en el corral. Placa + CSS con palabras cálidas (*Recién nacida* / *En memoria*).
- **Gate doble** reduced-motion + device-tier: sin animación se pinta el estado final quieto (cría entera, memoria con flor, vendido ya posado) — la info se ve igual.

## Datos de muestra

Camilo (vaca, vendido) → llega al mercado · Lucero (oveja, nace) · Aurelia (gallina, muerte). Interfaz lista para cablear el estado real de farmOS después.

## Verificación

- `npm run build` OK.
- Tests de mundo (smoke + agua): 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)