### PR TITLE
feat(creatures): Angelita rubber-hose pleno + KIT reutilizable (oso/colibrí)

### DIFF
--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,11 +1,24 @@
 import { useId } from 'react';
 import './creatures.css';
 import { CreatureFilters } from './_filters.jsx';
+import { OjosRubber, Cachetes, Sonrisa, Miembro, AntenaRubber, RH_INK } from './_rubberhose.jsx';
 
 /* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
-   Apis). Cuerpo ámbar rayado, cabeza clara, alitas de tul. Versión canónica
-   deducida del mockup "Guardianes que aparecen". */
+   Apis). Cuerpo ámbar rayado (chumbe andino), cabeza clara, alitas de tul.
+   Elevada al lenguaje RUBBER-HOSE PLENO (Cuphead + Miss Minutes de Loki):
+   contorno grueso que respira, ojos de goma con pupila grande y brillo, cachetes
+   campesinos, bracitos/patitas de manguera con mitones, antenas con bombillo que
+   hacen follow-through, y squash-&-stretch en el idle (boil ~12fps). El DIBUJO
+   compone el KIT reutilizable `_rubberhose.jsx` (que el oso andino y el colibrí
+   heredan); la CADENCIA vive en `creatures.css` (clases `rh-*`, gate RM + tier). */
 const VIEWBOX = '-15 -15 32 30';
+
+/* Rayas del cuerpo tejidas como CHUMBE andino: banda de tinta con hilo tierra. */
+const BANDAS = [
+  { x: -3.6, y0: -4.7, y1: 4.7 },
+  { x: 0.4, y0: -5.0, y1: 5.0 },
+  { x: 4.0, y0: -4.0, y1: 4.0 },
+];
 
 export function AbejaAngelita({
   size = 64,
@@ -33,12 +46,18 @@ export function AbejaAngelita({
   mojada = false,
   sed = false,
   comiendo = false,
+  /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
+     pleno; 'bajo' apaga el idle continuo (boil + follow-through) y deja el
+     aleteo + estados reactivos. Sin prop (standalone: avatares, catálogo) =
+     pleno. El CSS gatea por [data-tier='bajo']; RM lo congela por encima. */
+  tier,
   ...rest
 }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
   const glow = `crt-glow-${uid}`;
   const blur = `crt-blur-${uid}`;
   const wing = animated ? 'crt-wing' : undefined;
+  const vivo = animated;
   // El aura respira con la energía real de la finca (matas vivas + agua).
   const auraOp = Math.max(0.16, Math.min(0.5, 0.2 + 0.3 * (energia ?? 1)));
   const auraR = 5.4 + 1.2 * (energia ?? 1);
@@ -49,12 +68,12 @@ export function AbejaAngelita({
     </defs>
   );
   // Probóscide (lengüita): sale con SED (jadeo) o al COMER (libar). Cuelga de la
-  // cabeza (cx≈9). CSS la anima según data-sed/data-comiendo; RM la deja quieta.
+  // cabeza (cx≈9.6). CSS la anima según data-sed/data-comiendo; RM la deja quieta.
   // El <g> EXTERNO posiciona (attr transform); el INTERNO (.crt-lengua) anima —
   // si el CSS animara el mismo nodo del translate, lo pisaría (CSS transform
   // gana sobre el atributo) y la lengüita saltaría al centro del cuerpo.
   const lengua = (sed || comiendo) ? (
-    <g transform="translate(9.6 2)">
+    <g transform="translate(9.6 2.4)">
       <g className="crt-lengua">
         <path d="M0,0 C-0.4,2.6 0.4,4.4 0,6.2" stroke="#c9524e" strokeWidth="1.1"
           fill="none" strokeLinecap="round" />
@@ -72,19 +91,55 @@ export function AbejaAngelita({
     </g>
   ) : null;
 
+  // ── CUERPO rubber-hose. Orden de atrás→adelante: aura, alas, patitas, tronco
+  //    (ámbar con contorno + chumbe), bracitos, cabeza (ojos/cachetes/sonrisa/
+  //    antenas), probóscide, gotas. `.crt-body` es el nodo que squashea (boil
+  //    idle + estados reactivos, que lo pisan por especificidad).
   const body = (
-    <g className="crt-body" filter={`url(#${glow})`}>
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* aura viva */}
       <circle r={auraR} fill="#ffb54f" opacity={auraOp} filter={`url(#${blur})`} />
-      <ellipse cx="0" cy="0" rx="8.5" ry="5.4" fill="#ffb54f"
+
+      {/* alitas de tul con contorno + smear (crt-wingbeat ya lleva el estirón) */}
+      <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff"
+        opacity="0.62" stroke="rgba(42,26,12,0.4)" strokeWidth="0.5" />
+      <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4"
+        rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" stroke="rgba(42,26,12,0.35)" strokeWidth="0.5" />
+
+      {/* patitas manguera con pie crema (detrás del tronco, se mecen suave) */}
+      <Miembro d="M-2.6,4.4 C-3.2,6.6 -3.4,8 -3.0,9.2" ancho={1.9} punta={[-3.0, 9.4]} puntaR={1.3} pie sway={vivo} delay={-0.6} />
+      <Miembro d="M1.8,4.7 C1.4,6.8 1.3,8.2 1.8,9.4" ancho={1.9} punta={[1.8, 9.6]} puntaR={1.3} pie sway={vivo} delay={-0.95} />
+
+      {/* tronco ámbar con contorno grueso (la línea que respira con el boil) */}
+      <ellipse cx="0" cy="0" rx="8.6" ry="5.4" fill="#ffb54f" stroke={RH_INK} strokeWidth="1.3"
         style={{ filter: 'drop-shadow(0 0 6px rgba(255,181,79,0.9))' }} />
-      <path d="M-3.2,-4.9 L-3.2,4.9 M0.8,-5.2 L0.8,5.2 M4.4,-4.2 L4.4,4.2"
-        stroke="#3a2410" strokeWidth="1.6" strokeLinecap="round" />
-      <circle cx="8.2" cy="-0.8" r="3.4" fill="#ffd76a" />
-      <circle cx="9.3" cy="-1.6" r="0.9" fill="#04160f" />
-      <path d="M11,-2.4 C12.4,-3.4 13.7,-3.4 14.7,-2.6" stroke="#3a2410" strokeWidth="0.7" fill="none" strokeLinecap="round" />
+      {/* rayas = chumbe: banda de tinta + hilo tierra */}
+      {BANDAS.map((b, i) => (
+        <g key={i}>
+          <path d={`M${b.x},${b.y0} L${b.x},${b.y1}`} stroke={RH_INK} strokeWidth="1.9" strokeLinecap="round" />
+          <path d={`M${b.x},${b.y0 + 0.6} L${b.x},${b.y1 - 0.6}`} stroke="#9c3b1e" strokeWidth="0.7" strokeLinecap="round" />
+        </g>
+      ))}
+
+      {/* bracitos manguera con mitón crema (delante del tronco, follow-through) */}
+      <Miembro d="M-6.2,1.4 C-8.2,2.4 -9.0,4.1 -8.4,5.9" ancho={2.1} punta={[-8.5, 6.2]} puntaR={1.55} sway={vivo} delay={-0.15} />
+      <Miembro d="M5.4,3.0 C6.9,4.2 7.5,5.9 7.0,7.5" ancho={2.2} punta={[7.0, 7.8]} puntaR={1.6} sway={vivo} delay={-0.45} />
+
+      {/* cabeza clara con contorno */}
+      <circle cx="8.6" cy="-1.0" r="4.4" fill="#ffd76a" stroke={RH_INK} strokeWidth="1.2" />
+      {/* chapetas campesinas + sonrisa + ojos de goma (parpadean juntos) */}
+      <Cachetes puntos={[{ cx: 10.4, cy: 0.7, r: 1.15 }, { cx: 6.9, cy: 0.3, r: 0.85 }]} />
+      <Sonrisa cx={8.9} cy={1.4} w={2.8} prof={1.1} />
+      <OjosRubber
+        ojos={[{ cx: 10.1, cy: -1.9, r: 1.95 }, { cx: 7.4, cy: -2.2, r: 1.45 }]}
+        mirar={[0.3, 0.34]}
+        parpadea={vivo}
+      />
+      {/* antenas con bombillo que se mecen (secondary motion) */}
+      <AntenaRubber d="M7.7,-4.7 C6.7,-7.3 7.0,-9.3 8.3,-10.1" bulbo={[8.3, -10.3]} sway={vivo} delay={0} />
+      <AntenaRubber d="M9.7,-4.6 C11.0,-6.7 11.3,-8.7 10.5,-10.3" bulbo={[10.5, -10.5]} sway={vivo} delay={-0.3} />
+
       {lengua}
-      <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill="#bfeaff" opacity="0.6" />
-      <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4" rx="4.6" ry="2.8" fill="#eafff6" opacity="0.5" />
       {gotas}
     </g>
   );
@@ -94,6 +149,7 @@ export function AbejaAngelita({
     'data-creature': 'abeja-angelita',
     'data-pose': pose,
     'data-animo': animo,
+    'data-tier': tier || undefined,
     'data-mojada': mojada ? '1' : undefined,
     'data-sed': sed ? '1' : undefined,
     'data-comiendo': comiendo ? '1' : undefined,

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -61,6 +61,37 @@ import { Colibri, AbejaAngelita } from '@/visual/creatures';
 Consumidor de referencia: **`src/mockups/MockupGuardianesNarrativos.jsx`**
 (usa las 5 criaturas en modo `inline`).
 
+## KIT rubber-hose (Cuphead + Miss Minutes) — reutilizable
+
+El lenguaje de animación **"de goma"** (Cuphead + Miss Minutes de Loki) fusionado
+con la calidez campesina andina vive en **dos artefactos species-agnostic**, para
+que **el oso andino y el colibrí lo hereden sin redibujar**:
+
+- **`_rubberhose.jsx`** — RASGOS SVG de goma parametrizables:
+  - `OjosRubber({ ojos, mirar, parpadea })` — ojos grandes con pupila de goma +
+    brillo (catchlight); uno (perfil) o dos (3/4). Parpadean juntos (`rh-blink`).
+  - `Cachetes({ puntos })` — chapetas coral (rubor campesino).
+  - `Sonrisa({ cx, cy, w, prof })` — el arco amable de todo rubber-hose.
+  - `Miembro({ d, punta, pie, sway, delay })` — brazo/pata de **manguera** con
+    mitón/pie crema (la firma de Cuphead); `sway` = follow-through.
+  - `AntenaRubber({ d, bulbo, sway })` — antena con bombillo que se mece.
+  - Constantes: `RH_INK` (tinta cálida andina), `RH_GLOVE`, `RH_CHEEK`.
+- **`creatures.css` → sección KIT** — la CADENCIA como clases `rh-*`:
+  - `.rh-boil` — idle vivo: squash-&-stretch que respira (~12fps stepped, con
+    anticipación + overshoot). Va al nodo-cuerpo.
+  - `.rh-blink` — parpadeo seco de los ojos.
+  - `.rh-sway` — follow-through (secondary motion) de antenas/brazos/patas.
+  - `.rh-smear` — smear de miembro para golpes rápidos (p.ej. zarpazo del oso).
+  - Aleteo (`.crt-wing`) ya lleva **smear** incorporado (estirón en el golpe).
+
+**Gate obligatorio**: `prefers-reduced-motion` congela todo el KIT; `data-tier='bajo'`
+(device-tier) apaga lo continuo (boil + follow-through) y conserva aleteo +
+estados reactivos. Standalone (avatares/catálogo) sin `tier` = rubber-hose pleno.
+
+**Estrenado por**: `AbejaAngelita` (referencia de composición del KIT).
+**Pendientes de adoptar**: `OsoAndino` (nuevo) y `Colibri` — componen las mismas
+piezas + clases `rh-*` con SUS proporciones. No hay que reinventar la cadencia.
+
 ## Técnica
 
 - SVG + CSS puros, **cero dependencias nuevas**; solo `transform`/`opacity`

--- a/src/visual/creatures/_rubberhose.jsx
+++ b/src/visual/creatures/_rubberhose.jsx
@@ -1,0 +1,133 @@
+/*
+ * KIT RUBBER-HOSE — primitivas SVG del lenguaje de animación "goma" (Cuphead +
+ * Miss Minutes de Loki) FUSIONADO con la calidez campesina andina.
+ *
+ * Species-agnostic A PROPÓSITO: Angelita lo estrena, pero el oso andino y el
+ * colibrí lo heredan sin redibujar (contrato de la casa: "antes de dibujar,
+ * búscalo aquí"). Aquí viven los RASGOS de goma (ojos expresivos, cachetes/
+ * chapetas, miembros manguera, antenas con bombillo, sonrisa); la CADENCIA
+ * (boil ~12fps, parpadeo, follow-through, smear) vive en `creatures.css` como
+ * clases `rh-*` que estas piezas activan por className.
+ *
+ * Todo es transform/opacity friendly y sin dependencias nuevas (GPU, Android
+ * gama baja). El gate reduced-motion + device-tier está en el CSS: estas piezas
+ * solo PONEN las clases; el CSS decide si corren.
+ */
+
+/* Tinta cálida (no negro puro): el contorno grueso "andino" de toda la familia.
+   Rubber-hose = línea que manda; que sea tierra-oscura, no industrial. */
+export const RH_INK = '#2a1a0c';
+/* Guante/mitón crema (manos de goma) y chapeta coral (cachete campesino). */
+export const RH_GLOVE = '#fff3d8';
+export const RH_CHEEK = '#f2907a';
+
+/**
+ * Ojos expresivos de goma (Cuphead/Miss Minutes): esclerótica blanca con
+ * contorno grueso, pupila GRANDE y brillo (catchlight). Un mismo grupo parpadea
+ * (`rh-blink`) para que los dos ojos cierren sincronizados.
+ *
+ * @param {Array<{cx:number,cy:number,r:number}>} ojos  uno (perfil, colibrí) o
+ *   dos (3/4, abeja/oso). El primero es el "cercano" (puede ser más grande).
+ * @param {[number,number]} [mirar=[0.32,0.34]]  a dónde apunta la pupila, como
+ *   fracción del radio (x,y). Al voltear la criatura el scaleX lo refleja solo.
+ * @param {boolean} [parpadea=true]  activa `rh-blink` (el CSS lo gatea por RM/tier).
+ * @param {string}  [ink=RH_INK]  color del contorno.
+ */
+export function OjosRubber({ ojos = [], mirar = [0.32, 0.34], parpadea = true, ink = RH_INK }) {
+  const [mx, my] = mirar;
+  return (
+    <g className={parpadea ? 'rh-blink' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+      {ojos.map((o, i) => {
+        const pr = o.r * 0.62; // pupila grande (goma), no puntito
+        const px = o.cx + mx * o.r;
+        const py = o.cy + my * o.r;
+        return (
+          <g key={i}>
+            <circle cx={o.cx} cy={o.cy} r={o.r} fill="#fffaf0" stroke={ink} strokeWidth={o.r * 0.42} />
+            <circle cx={px} cy={py} r={pr} fill="#20130a" />
+            {/* catchlight arriba-izquierda: la chispa de vida del ojo */}
+            <circle cx={px - pr * 0.4} cy={py - pr * 0.5} r={pr * 0.42} fill="#fffdf7" />
+          </g>
+        );
+      })}
+    </g>
+  );
+}
+
+/**
+ * Chapetas / cachetes campesinos: el rubor coral que da ternura andina.
+ * @param {Array<{cx:number,cy:number,r:number}>} puntos
+ * @param {string} [color=RH_CHEEK]
+ */
+export function Cachetes({ puntos = [], color = RH_CHEEK }) {
+  return (
+    <g fill={color} opacity="0.72">
+      {puntos.map((p, i) => (
+        <ellipse key={i} cx={p.cx} cy={p.cy} rx={p.r} ry={p.r * 0.72} />
+      ))}
+    </g>
+  );
+}
+
+/**
+ * Sonrisa de goma: el arco que hace que TODA criatura rubber-hose se vea amable.
+ * @param {number} cx @param {number} cy centro de la boca
+ * @param {number} [w=3] ancho @param {number} [prof=1.4] profundidad del arco
+ */
+export function Sonrisa({ cx = 0, cy = 0, w = 3, prof = 1.4, ink = RH_INK }) {
+  const x0 = cx - w / 2;
+  const x1 = cx + w / 2;
+  return (
+    <path d={`M${x0},${cy} Q${cx},${cy + prof} ${x1},${cy}`} stroke={ink}
+      strokeWidth="0.9" fill="none" strokeLinecap="round" />
+  );
+}
+
+/**
+ * Miembro de MANGUERA (brazo/pata de goma): tubo de contorno redondeado con un
+ * mitón/pie crema en la punta — la firma de Cuphead. Con `rh-sway` cuelga y
+ * hace follow-through (secondary motion) en el idle.
+ *
+ * @param {string}  d  el path del tubo (usar curvas suaves; los caps redondos lo cierran).
+ * @param {number}  [ancho=2.3]  grosor del tubo.
+ * @param {[number,number]|null} [punta=null]  centro del mitón/pie; null = tubo pelado.
+ * @param {number}  [puntaR=1.6]  radio del mitón/pie.
+ * @param {boolean} [pie=false]  la punta es un pie (elipse) en vez de mano (círculo).
+ * @param {boolean} [sway=false]  activa el follow-through `rh-sway`.
+ * @param {number}  [delay=0]  desfase del sway (para que brazos/patas no vayan a la par).
+ */
+export function Miembro({
+  d, ancho = 2.3, punta = null, puntaR = 1.6, pie = false, sway = false, delay = 0,
+  ink = RH_INK, glove = RH_GLOVE,
+}) {
+  const style = sway
+    ? { transformBox: 'fill-box', transformOrigin: 'top center', animationDelay: `${delay}s` }
+    : undefined;
+  return (
+    <g className={sway ? 'rh-sway' : undefined} style={style}>
+      <path d={d} stroke={ink} strokeWidth={ancho} fill="none" strokeLinecap="round" strokeLinejoin="round" />
+      {punta && (pie ? (
+        <ellipse cx={punta[0]} cy={punta[1]} rx={puntaR * 1.15} ry={puntaR * 0.72} fill={glove} stroke={ink} strokeWidth="0.7" />
+      ) : (
+        <circle cx={punta[0]} cy={punta[1]} r={puntaR} fill={glove} stroke={ink} strokeWidth="0.7" />
+      ))}
+    </g>
+  );
+}
+
+/**
+ * Antena de goma con bombillo (punta redonda). Con `rh-sway` se mece con
+ * follow-through — la secondary motion que delata que el cuerpo se movió.
+ * @param {string} d  el tallo (curva). @param {[number,number]} bulbo  centro de la bolita.
+ */
+export function AntenaRubber({ d, bulbo, bulboR = 1.15, sway = false, delay = 0, ink = RH_INK }) {
+  const style = sway
+    ? { transformBox: 'fill-box', transformOrigin: 'bottom center', animationDelay: `${delay}s` }
+    : undefined;
+  return (
+    <g className={sway ? 'rh-sway' : undefined} style={style}>
+      <path d={d} stroke={ink} strokeWidth="1.1" fill="none" strokeLinecap="round" />
+      <circle cx={bulbo[0]} cy={bulbo[1]} r={bulboR} fill={ink} />
+    </g>
+  );
+}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -4,15 +4,20 @@
    es responsabilidad de la escena que consume la criatura.
    reduced-motion = criatura quieta en un fotograma digno. ─── */
 
-/* aleteo rápido (abeja / colibrí) */
+/* aleteo rápido (abeja / colibrí) — con SMEAR rubber-hose: en el golpe hacia
+   abajo el ala se ESTIRA (scaleX) para sugerir la velocidad (motion blur
+   dibujado), y sale con un pequeño overshoot al volver. Ambas especies heredan
+   el estirón sin tocar su dibujo. */
 .crt-wing {
   transform-box: fill-box;
   transform-origin: center bottom;
-  animation: crt-wingbeat 0.13s ease-in-out infinite alternate;
+  animation: crt-wingbeat 0.15s ease-in-out infinite;
 }
 @keyframes crt-wingbeat {
-  0% { transform: scaleY(1) scaleX(1); }
-  100% { transform: scaleY(0.6) scaleX(0.9); }
+  0%   { transform: scaleY(1) scaleX(1); }
+  38%  { transform: scaleY(0.52) scaleX(1.18); }  /* smear: estirón al bajar rápido */
+  55%  { transform: scaleY(0.66) scaleX(0.9); }   /* overshoot al frenar */
+  100% { transform: scaleY(1) scaleX(1); }
 }
 
 /* alas de mariposa que abren y cierran */
@@ -58,6 +63,79 @@
 @keyframes crt-wing-reposo {
   0% { transform: scaleY(0.4) scaleX(0.86); }
   100% { transform: scaleY(0.5) scaleX(0.9); }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   KIT RUBBER-HOSE (Cuphead + Miss Minutes de Loki) — SPECIES-AGNOSTIC
+   Cadencia de goma REUTILIZABLE por cualquier creature. Angelita la estrena;
+   el OSO ANDINO y el COLIBRÍ la heredan poniendo estas mismas clases `rh-*`
+   sobre las piezas del KIT `_rubberhose.jsx` — cero animación redibujada.
+   Todo transform/opacity (GPU, Android gama baja).
+   GATE: reduced-motion la congela (fotograma digno); device-tier 'bajo' apaga
+   lo CONTINUO (boil + follow-through) y conserva aleteo + estados reactivos.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* BOIL — el idle vivo: squash-&-stretch que RESPIRA en cadencia dibujada
+   (~12fps vía steps) con anticipación y overshoot. Rubber-hose nunca queda
+   clavado; el contorno "respira" con el cuerpo. Se aplica al nodo-cuerpo; los
+   estados reactivos (mojada/sed/comiendo) lo PISAN por especificidad. */
+.rh-boil {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: rh-boil 1.5s steps(18, end) infinite;
+}
+@keyframes rh-boil {
+  0%   { transform: translateY(0) scale(1, 1); }
+  22%  { transform: translateY(-0.3px) scale(0.975, 1.05); }  /* stretch (anticipa) */
+  50%  { transform: translateY(0.4px) scale(1.05, 0.95); }    /* squash */
+  72%  { transform: translateY(-0.15px) scale(0.99, 1.02); }  /* overshoot */
+  100% { transform: translateY(0) scale(1, 1); }
+}
+
+/* PARPADEO — la chispa de vida de los ojos de goma: abiertos casi todo el ciclo,
+   cierran SECO un par de fotogramas. Se aplica al grupo de ojos (los dos a la
+   vez). Snappy, no stepped (un parpadeo es 1-2 frames). */
+.rh-blink {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: rh-blink 4.2s linear infinite;
+}
+@keyframes rh-blink {
+  0%, 93%, 100% { transform: scaleY(1); }
+  96%           { transform: scaleY(0.12); }  /* cierra */
+  98%           { transform: scaleY(1); }      /* abre */
+}
+
+/* FOLLOW-THROUGH (secondary motion) — antenas, bracitos y patitas de manguera
+   se mecen con retardo: delatan que el cuerpo se movió. Cada miembro pone su
+   transform-origin (hombro/base) y su animation-delay inline para no ir a la par. */
+.rh-sway {
+  animation: rh-sway 2.4s ease-in-out infinite;
+}
+@keyframes rh-sway {
+  0%, 100% { transform: rotate(0deg); }
+  50%      { transform: rotate(3.6deg); }
+}
+
+/* SMEAR de miembro — para golpes rápidos (p.ej. el zarpazo del oso andino): el
+   miembro se estira y sesga en el frame veloz. Artefacto del KIT listo para
+   reutilizar; la abeja no lo usa (su smear vive en el aleteo). */
+.rh-smear {
+  transform-box: fill-box;
+  animation: rh-smear 0.42s ease-in-out infinite;
+}
+@keyframes rh-smear {
+  0%, 100% { transform: scaleX(1) skewX(0); }
+  50%      { transform: scaleX(1.3) skewX(-6deg); }
+}
+
+/* device-tier 'bajo': corta lo continuo (ahorro gama baja). Los estados
+   reactivos siguen (feedback importante) por su mayor especificidad. */
+[data-tier='bajo'] .rh-boil,
+[data-tier='bajo'] .rh-sway { animation: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .rh-boil, .rh-blink, .rh-sway, .rh-smear { animation: none !important; }
 }
 
 /* ── REACCIÓN AL ESTADO REAL DE LA FINCA (auditoría §5b) ──────────────────────

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -35,7 +35,7 @@ import { ATMOSFERA, CIELOS, mezclar } from '../atmosferaMadre.js';
 
 function Contenido({
   params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, piso = 0,
-  frugal = false, hablando = false, focoId = null, focoToken = 0,
+  frugal = false, tier = 'alto', hablando = false, focoId = null, focoToken = 0,
   estadoFinca = ESTADO_FINCA_MUESTRA, hayAlerta = false,
   children,
 }) {
@@ -181,6 +181,7 @@ function Contenido({
         hayAlerta={hayAlerta}
         reducedMotion={reducedMotion}
         piso={piso}
+        tier={tier}
       />
 
       <OrbitControls
@@ -241,6 +242,7 @@ export default function EscenaBase3D({
           energia={energia}
           piso={piso}
           frugal={frugal}
+          tier={tier}
           hablando={hablando}
           focoId={focoId}
           focoToken={focoToken}

--- a/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
+++ b/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
@@ -119,6 +119,10 @@ export function useEntradaAbeja(foco, {
 export function AbejaEscena({
   foco, entrando = true, animo = 'sereno', energia = 1, reducedMotion = false, piso = 0,
   hablando = false, rebote = 0,
+  // Device-tier (DR-3D-PERF-GAMABAJA): gradúa el rubber-hose del cuerpo — en
+  // 'bajo' Angelita apaga el idle continuo (boil + follow-through) y conserva
+  // el aleteo + los estados reactivos. La escena lo hereda del host <Mundo>.
+  tier = 'alto',
   // ── EL ESTADO REAL DE LA FINCA (auditoría §5b) ─────────────────────────────
   //    Angelita SIEMPRE refleja tu realidad: llueve→mojada, Niño/sequía→sed,
   //    cosecha→come de eso, ánimo por salud. Interfaz LIMPIA; hoy MUESTRA, codex
@@ -180,6 +184,7 @@ export function AbejaEscena({
                   sed={sed}
                   comiendo={comiendo}
                   animated={vivo}
+                  tier={tier}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Qué

Eleva la abeja **Angelita** al lenguaje **rubber-hose pleno** (Cuphead + Miss Minutes de Loki) fusionado con la calidez campesina andina, y extrae un **KIT reutilizable** para que el **oso andino** y el **colibrí** hereden la misma estética sin redibujar.

## Dibujo (AbejaAngelita.jsx)

- Contorno grueso cálido (tinta andina, no negro puro) que **respira** con el cuerpo.
- **Ojos de goma** grandes con pupila prominente + brillo (catchlight), 3/4.
- **Chapetas** coral (rubor campesino) + **sonrisa** amable.
- **Bracitos/patitas de manguera** con mitón/pie crema (la firma de Cuphead).
- **Antenas con bombillo** que hacen follow-through (secondary motion).
- Rayas del cuerpo tejidas estilo **chumbe** (banda de tinta + hilo tierra).
- ViewBox intacto → **cero regresión de escala** en los consumidores existentes.

## Animación (creatures.css)

- **Boil** idle: squash-&-stretch que respira en cadencia dibujada (~12fps stepped) con anticipación + overshoot.
- **Parpadeo** seco de los ojos.
- **Follow-through** (`rh-sway`) de antenas/brazos/patas.
- **Smear** en el aleteo (estirón en el golpe) — lo hereda también el colibrí.

## KIT reutilizable (oso andino + colibrí)

- `_rubberhose.jsx` — rasgos SVG parametrizables: `OjosRubber`, `Cachetes`, `Sonrisa`, `Miembro`, `AntenaRubber` + paleta (`RH_INK`/`RH_GLOVE`/`RH_CHEEK`).
- `creatures.css` → sección KIT — clases `rh-*` species-agnostic.
- README documenta la adopción para `OsoAndino` (nuevo) y `Colibri`.

## Gate (obligatorio)

- `prefers-reduced-motion` → congela todo el KIT (fotograma digno).
- `device-tier='bajo'` → apaga lo continuo (boil + follow-through), conserva aleteo + estados reactivos. Cableado `Mundo → EscenaBase3D → AbejaEscena → AbejaAngelita` (`data-tier`).
- Standalone (avatares/catálogo) sin tier = rubber-hose pleno.

## Verificación

- `npm run build` ✓ (36s, sin errores; advertencias de chunk preexistentes).
- Estados reactivos previos (mojada/sed/comiendo/pose/habla/rebote) intactos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)