### PR TITLE
feat(mundos): useFincaViva — espejo vivo del dato real cosido a la escena 3D (§5b)

### DIFF
--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -4,9 +4,10 @@
  *   <Mundo mundoId tier reducedMotion onHotspot onSalir animo energia
  *          estadoFinca hayAlerta />
  *
- * `estadoFinca` = { clima, enso, cosechaReciente, saludFinca } — el estado REAL
- * de la finca que Angelita SIEMPRE refleja (auditoría §5b). Sin pasar nada, las
- * escenas usan la MUESTRA de reaccionFinca.js; codex lo cabla con useFincaViva.
+ * `estadoFinca` = { clima, enso, cosechaReciente, saludFinca, animales } — el
+ * estado REAL de la finca que Angelita SIEMPRE refleja (auditoría §5b). Si el
+ * host no lo pasa, se cose aquí con `useFincaViva()` (el espejo vivo del dato
+ * real, offline-first y anti-fabricación); un `estadoFinca` explícito lo pisa.
  *
  * Lee el registro `MUNDO[mundoId]`, resuelve el PLAN con `resolverMundo` (que
  * cruza el arquetipo con el device-tier) y monta lo que toca:
@@ -22,6 +23,7 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react
 import { resolverMundo, tinteDeMundo, tituloDeMundo, emojiDeMundo } from './resolverMundo.js';
 import Mundo2D from './Mundo2D.jsx';
 import useAudioMundo from './useAudioMundo.js';
+import useFincaViva from './useFincaViva.js';
 import InvitacionAudioMundo from './InvitacionAudioMundo.jsx';
 import './mundo.css';
 
@@ -120,6 +122,14 @@ function MundoInterno({
      la transición. Gate interno: toggle opt-in + gesto previo + reduced-motion. */
   useAudioMundo({ mundoId, reducedMotion });
 
+  /* El ESPEJO VIVO del dato real (auditoría §5b): si el host no pasó un
+     `estadoFinca` explícito, lo cosemos aquí desde la finca real (salud, clima,
+     ENSO, cosecha reciente, hato). Three-free y anti-fabricación; un
+     `estadoFinca` pasado por el host manda (p. ej. una vitrina que fije su
+     muestra). Se llama SIEMPRE (antes de cualquier return) por regla de hooks. */
+  const fincaViva = useFincaViva();
+  const estadoReal = estadoFinca ?? fincaViva;
+
   const alTimeout3D = useCallback(() => setCaido3d(true), []);
   const reintentar3D = useCallback(() => {
     setIntento((n) => n + 1);
@@ -165,6 +175,12 @@ function MundoInterno({
 
   if (plan.modo === '3d') {
     if (!Escena) return null;
+    /* El hato REAL cosido al corral: si el espejo vivo trae animales, pisan la
+       muestra de `params.animales` (recinto); si no (hoy: sin fuente de hato),
+       el corral conserva su hato de muestra — no fabricamos animales. */
+    const paramsEscena = estadoReal?.animales?.length
+      ? { ...plan.entrada.params, animales: estadoReal.animales }
+      : plan.entrada.params;
     return (
       <div className="mundo-root" data-dim="3d" data-mundo={mundoId}>
         <Suspense fallback={<MundoCargando tinte={tinte} onTimeout={alTimeout3D} />}>
@@ -175,7 +191,7 @@ function MundoInterno({
           {/* eslint-disable-next-line react-hooks/static-components */}
           <Escena
             mundoId={mundoId}
-            params={plan.entrada.params}
+            params={paramsEscena}
             hotspots={plan.entrada.hotspots}
             entrada={plan.entrada.entrada}
             tinte={tinte}
@@ -185,7 +201,7 @@ function MundoInterno({
             onSalir={onSalir}
             animo={animo}
             energia={energia}
-            estadoFinca={estadoFinca}
+            estadoFinca={estadoReal}
             hayAlerta={hayAlerta}
             hablando={hablando}
             focoId={focoId}

--- a/src/visual/mundo3d/index.js
+++ b/src/visual/mundo3d/index.js
@@ -44,6 +44,12 @@ export {
   default as useAudioMundo, PALETAS_SONORAS, activarAudioPorGesto, soportaAudio,
 } from './useAudioMundo.js';
 
+// Espejo vivo del dato real (three-free, auditoría §5b): arma el `estadoFinca`
+// REAL (salud, clima, ENSO, cosecha reciente, hato) desde los servicios
+// anti-fabricación que ya existen. El host <Mundo> lo cose solo; se exporta para
+// quien quiera pasar `estadoFinca` a mano.
+export { default as useFincaViva } from './useFincaViva.js';
+
 // Invitación de PRIMER USO del sonido (three-free): ya vive dentro del host
 // <Mundo> (app y vitrinas por igual); se exporta por si un mockup la monta suelta.
 export { default as InvitacionAudioMundo } from './InvitacionAudioMundo.jsx';

--- a/src/visual/mundo3d/useFincaViva.js
+++ b/src/visual/mundo3d/useFincaViva.js
@@ -1,0 +1,247 @@
+/*
+ * useFincaViva — EL ESPEJO VIVO del dato real, cosido al mundo 3D (auditoría §5b).
+ *
+ * Este hook NO reinventa nada: CONSUME los servicios anti-fabricación que ya
+ * cablean la finca al Espíritu-guardián (vitalidadEspirituService /
+ * fincaEvolutionService y sus fuentes) y arma el descriptor `estadoFinca` con la
+ * FORMA EXACTA que la escena 3D espera —la que declara reaccionFinca.js (la capa
+ * de reacción de Angelita) y consume CorralVivo.jsx (el hato):
+ *
+ *   estadoFinca = {
+ *     clima,            // 'dorada'|'soleado'|'niebla'|'lluvia'|'noche'
+ *     enso,             // 'nino' | 'nina' | 'neutro'  (fase ENSO efectiva)
+ *     cosechaReciente,  // null | { cultivo, mundoId }
+ *     saludFinca,       // { matasVivas, matasTotal, agua? }  (conteos REALES)
+ *     animales,         // [{ especie, nombre, raza, tamano, estado }]
+ *   }
+ *
+ * CONTRATO ANTI-FABRICACIÓN (el mismo de vitalidadEspirituService): si un dato
+ * no tiene fuente real, va "en camino", NO se inventa un número:
+ *   · saludFinca solo se emite cuando la escena de finca NO está vacía; si aún
+ *     no cargan los procesos (processes === null) o la finca está vacía, se OMITE
+ *     → reaccionFinca cae a su neutro sereno (nunca fingimos salud ni desastre).
+ *   · cosechaReciente es null hasta que el store de cosecha esté cargado y haya
+ *     una cosecha DENTRO de la ventana reciente (si no, no hay banquete).
+ *   · agua NO tiene sensor de humedad de suelo: se deriva un proxy HONESTO de la
+ *     lluvia real de Open-Meteo (documentado abajo) o se omite (neutro).
+ *   · animales NO tiene inventario de hato real (no existe asset animal) → []
+ *     ("dato en camino"); el corral conserva su hato de muestra, no fabricamos.
+ *
+ * Offline-first y three-free (vive en el bundle base del framework, junto al
+ * host <Mundo>): lee caches SÍNCRONOS + se suscribe al evento de clima, como el
+ * molde de convención useClimaAtmosphere.js. Español de Colombia.
+ *
+ * @module visual/mundo3d/useFincaViva
+ */
+import { useEffect, useMemo, useState } from 'react';
+import useAssetStore from '../../store/useAssetStore.js';
+import useCosechaStore from '../../store/useCosechaStore.js';
+import { listFarmProcesses } from '../../db/farmProcessCache.js';
+import { buildFincaScene } from '../../services/fincaSceneService.js';
+import { deriveAtmosphere } from '../../services/atmosphereService.js';
+import { getEnsoPhase } from '../../services/ensoService.js';
+import {
+  getCachedClimaSnapshot,
+  resolveClimaLocation,
+  CLIMA_UPDATED_EVENT,
+} from '../../services/climaService.js';
+
+/** Re-evalúa la atmósfera cada 10 min (mismo ritmo que useClimaAtmosphere). */
+const REEVAL_MS = 10 * 60 * 1000;
+/** Ventana de "cosecha reciente": pasado esto, ya no es un banquete de hoy. */
+const COSECHA_RECIENTE_DIAS = 14;
+
+/* ── mapeos meteo/ENSO → vocabulario del mundo 3D ──────────────────────────── */
+
+/**
+ * Condición meteo real (deriveCondicion) + luz del día real (deriveLuz, por
+ * efemérides de la vereda) → el clima de ESCENA (valleData.CLIMAS). No existe un
+ * "nublado" en ese vocabulario: el día cubierto se lee como 'soleado' (día), y la
+ * hora dorada (amanecer/atardecer) como 'dorada'. Prioridad: lluvia > noche >
+ * niebla > dorada > soleado (mojarse manda; de noche, descansa).
+ *
+ * @param {string|null} luz  'amanecer'|'dia'|'atardecer'|'noche'|null
+ * @param {string|null} condicion  'despejado'|'nublado'|'lluvia'|'niebla'|null
+ * @returns {'dorada'|'soleado'|'niebla'|'lluvia'|'noche'}
+ */
+export function mapearClima(luz, condicion) {
+  if (condicion === 'lluvia') return 'lluvia';
+  if (luz === 'noche') return 'noche';
+  if (condicion === 'niebla') return 'niebla';
+  if (luz === 'amanecer' || luz === 'atardecer') return 'dorada';
+  return 'soleado';
+}
+
+/**
+ * Fase ENSO del servicio ('neutral'|'el_nino'|'la_nina') → el slug corto que
+ * reaccionFinca espera ('nino'|'nina'|'neutro').
+ *
+ * @param {string|null} fase
+ * @returns {'nino'|'nina'|'neutro'}
+ */
+export function mapearEnso(fase) {
+  if (fase === 'el_nino') return 'nino';
+  if (fase === 'la_nina') return 'nina';
+  return 'neutro';
+}
+
+/** 'YYYY-MM-DD' local (mismo criterio que atmosphereService/ejeClima). */
+function isoDiaLocal(d) {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * `agua` (0..1) para saludFinca. NO hay sensor de humedad de suelo en el repo:
+ * derivamos un PROXY honesto de la LLUVIA REAL de hoy (Open-Meteo, la misma
+ * señal que pinta ejeClima). Base 0.5 (neutro: SIN sed falsa un día seco suelto)
+ * subiendo con la lluvia hasta ~0.95 con un aguacero franco (25 mm). La sed real
+ * llega por El Niño + clima seco en reaccionFinca, no por este número. Sin
+ * snapshot de clima → null (reaccionFinca usa su neutro 0.5).
+ *
+ * @param {object|null} snapshot  getCachedClimaSnapshot()
+ * @param {Date} now
+ * @returns {number|null}
+ */
+export function aguaDeLluvia(snapshot, now = new Date()) {
+  const om = snapshot?.openmeteo;
+  if (!om?.available || !Array.isArray(om.forecast_7d)) return null;
+  const hoy = isoDiaLocal(now);
+  const dia = om.forecast_7d.find((d) => d?.date === hoy) || om.forecast_7d[0];
+  const precip = Number(dia?.precip_mm);
+  if (!Number.isFinite(precip)) return null;
+  return Math.max(0, Math.min(1, 0.5 + (Math.min(precip, 25) / 25) * 0.45));
+}
+
+/** Deriva { clima, enso, agua } de la señal de clima/ENSO cacheada (síncrona). */
+function derivarAtmosfera(now = new Date()) {
+  const location = resolveClimaLocation();
+  const snapshot = getCachedClimaSnapshot();
+  const { condicion, luz } = deriveAtmosphere({ snapshot, now, location });
+  return {
+    clima: mapearClima(luz, condicion),
+    enso: mapearEnso(getEnsoPhase()),
+    agua: aguaDeLluvia(snapshot, now),
+  };
+}
+
+/**
+ * cosechaReciente: el cultivo cosechado MÁS reciente si cae dentro de la ventana
+ * (COSECHA_RECIENTE_DIAS). summary frío (null) o cosecha vieja → null (pendiente,
+ * no inventamos un banquete). mundoId queda null: no existe mapeo cultivo→mundo
+ * en el repo y reaccionFinca solo lee `.cultivo`.
+ *
+ * @param {object|null} summary  useCosechaStore.summary (cosechaService.harvestSummary)
+ * @param {Date} now
+ * @returns {null | { cultivo: string, mundoId: null }}
+ */
+export function cosechaRecienteDe(summary, now = new Date()) {
+  const byCrop = summary?.byCrop;
+  if (!Array.isArray(byCrop) || byCrop.length === 0) return null;
+  const ultimaMs = summary?.dateRange?.lastMs;
+  if (!Number.isFinite(ultimaMs)) return null;
+  const limite = now.getTime() - COSECHA_RECIENTE_DIAS * 24 * 60 * 60 * 1000;
+  if (ultimaMs < limite) return null;
+  const reciente = byCrop.reduce(
+    (mejor, c) => (c?.lastMs != null && (mejor == null || c.lastMs > mejor.lastMs) ? c : mejor),
+    null,
+  );
+  if (!reciente?.crop) return null;
+  return { cultivo: reciente.crop, mundoId: null };
+}
+
+/**
+ * Arma el `estadoFinca` completo desde las piezas ya cargadas. Puro: la vista
+ * (useFincaViva) inyecta procesos/plantas/cosecha/atmósfera ya resueltos.
+ */
+function armarEstadoFinca({ processes, plants, summary, atmosfera, now = new Date() }) {
+  const { clima, enso, agua } = atmosfera;
+
+  // saludFinca: conteos REALES de matas (buildFincaScene, la misma fuente que el
+  // panel de vitalidad). Pendiente hasta que carguen los procesos, y OMITIDA si
+  // la finca está vacía → reaccionFinca cae a su neutro (no fingimos salud).
+  let saludFinca;
+  if (Array.isArray(processes)) {
+    const scene = buildFincaScene({ processes, plantAssetsCount: plants?.length || 0 });
+    if (!scene.vacia) {
+      saludFinca = {
+        matasVivas: scene.cultivosActivos,
+        matasTotal: scene.totalCultivos,
+        ...(agua != null ? { agua } : {}),
+      };
+    }
+  }
+
+  return {
+    clima,
+    enso,
+    cosechaReciente: cosechaRecienteDe(summary, now),
+    saludFinca,
+    // Sin inventario de hato real (no hay asset animal): [] = "dato en camino".
+    // El corral conserva su hato de muestra; no fabricamos animales.
+    animales: [],
+  };
+}
+
+/**
+ * useFincaViva — devuelve el `estadoFinca` REAL, vivo y reactivo, para pasarlo a
+ * <Mundo estadoFinca={...}> (que lo cose a la reacción de Angelita y, cuando haya
+ * fuente, al corral). Se re-arma cuando cambian los datos de finca (plantas /
+ * cosecha), el clima (evento CLIMA_UPDATED) o el paso del sol (intervalo).
+ *
+ * @returns {{clima:string, enso:string, cosechaReciente:(null|object), saludFinca:(object|undefined), animales:Array}}
+ */
+export function useFincaViva() {
+  // Procesos reales (IndexedDB, offline-first). null = aún cargando (pendiente).
+  const [processes, setProcesses] = useState(null);
+  // Atmósfera derivada (clima/enso/agua); se refresca por evento + intervalo.
+  const [atmosfera, setAtmosfera] = useState(() => derivarAtmosfera());
+
+  // Reactivos de los stores globales (re-render cuando cambian, para que la
+  // finca 3D siga la realidad sin polling).
+  const plants = useAssetStore((s) => s.plants);
+  const summary = useCosechaStore((s) => s.summary);
+  const cosechaCargando = useCosechaStore((s) => s.isLoading);
+
+  // Cargar los procesos una vez (y limpiar si el hook se desmonta antes).
+  useEffect(() => {
+    let vivo = true;
+    listFarmProcesses()
+      .then((p) => { if (vivo) setProcesses(Array.isArray(p) ? p : []); })
+      .catch(() => { if (vivo) setProcesses([]); });
+    return () => { vivo = false; };
+  }, []);
+
+  // Calentar el store de cosecha si está frío (idempotente: el guard isLoading
+  // evita cargas duplicadas). Así "cosechaReciente" puede poblarse sin depender
+  // de que otra pantalla lo haya cargado antes.
+  useEffect(() => {
+    if (summary == null && !cosechaCargando) {
+      useCosechaStore.getState().loadHarvests();
+    }
+  }, [summary, cosechaCargando]);
+
+  // Seguir el clima real (evento) y el paso del sol (intervalo), como el molde
+  // useClimaAtmosphere: cero fetch propio, solo lee la señal ya cacheada.
+  useEffect(() => {
+    const refrescar = () => setAtmosfera(derivarAtmosfera());
+    refrescar();
+    window.addEventListener(CLIMA_UPDATED_EVENT, refrescar);
+    const id = setInterval(refrescar, REEVAL_MS);
+    return () => {
+      window.removeEventListener(CLIMA_UPDATED_EVENT, refrescar);
+      clearInterval(id);
+    };
+  }, []);
+
+  // Identidad estable mientras las piezas no cambian: reaccionFinca (memoizado
+  // en la escena por identidad de estadoFinca) no recalcula por render.
+  return useMemo(
+    () => armarEstadoFinca({ processes, plants, summary, atmosfera }),
+    [processes, plants, summary, atmosfera],
+  );
+}
+
+export default useFincaViva;


### PR DESCRIPTION
## Qué

Cose el **espejo vivo del dato real** (que ya existía del lado del panel de vitalidad del Espíritu) a la **escena 3D**, sin reinventarlo. Nuevo hook `src/visual/mundo3d/useFincaViva.js` que **consume** los servicios anti-fabricación existentes y produce el `estadoFinca` con la forma EXACTA que las escenas 3D ya esperan:

```
estadoFinca = { clima, enso, cosechaReciente, saludFinca, animales }
```

- `reaccionFinca.js` (Angelita reactiva) deriva de ahí su ánimo/energía + repertorio (mojada/sed/come) y los modificadores de vuelo.
- `CorralVivo.jsx` (el hato) consume `animales` vía `params`.

## Fuentes reales (cero fabricación)

| Campo | Fuente real | Pendiente si… |
|---|---|---|
| `saludFinca.matasVivas/matasTotal` | `fincaSceneService.buildFincaScene` (misma fuente del panel de vitalidad) | procesos aún cargan **o** finca vacía → se **omite** (reacción neutra) |
| `clima` | `atmosphereService.deriveAtmosphere` (luz por efemérides + condición meteo) → CLIMAS de escena | — (cae a clima por hora real del dispositivo) |
| `enso` | `ensoService.getEnsoPhase()` → `nino`/`nina`/`neutro` | — (`neutro` por defecto) |
| `cosechaReciente` | `cosechaService`/`useCosechaStore` (cultivo más reciente en ventana de 14 días) | store frío o cosecha vieja → `null` |
| `saludFinca.agua` | proxy honesto de **lluvia real** de Open-Meteo | sin snapshot → omitido (neutro). No hay sensor de humedad de suelo en el repo |
| `animales` | — (no existe asset animal / inventario de hato) | siempre `[]`; el corral conserva su hato de muestra, **no fabricamos** |

## Cableado del host

`Mundo.jsx` (host único de todos los mundos) llama `useFincaViva()` y lo usa como `estadoFinca` por defecto: `estadoFinca ?? fincaViva`. Un `estadoFinca` explícito del host lo pisa. Alimenta a Angelita reactiva y —cuando exista fuente de hato— al corral (merge de `animales` en `params` solo si el hook trae hato). `EscenaValle` ya threadeaba `estadoFinca` → el valle también refleja el dato real.

## Restricciones respetadas

- **NO se toca** el dibujo/animación de `AbejaAngelita.jsx` (otra tarea en paralelo) — solo capa de dato + wiring.
- Hook **three-free**: vive en el bundle base del framework (verificado: `vendor-three` sigue en su chunk aparte). Exportado desde el barrel `index.js` junto a `useHaptics`/`useAudioMundo`.
- Offline-first: cero fetch propio, lee caches síncronos + evento `chagra:clima:updated` (molde de `useClimaAtmosphere.js`).

## Verificación

- `npm run build` ✓ (exit 0; advertencias de chunk-size/dynamic-import preexistentes, ajenas al cambio)
- `eslint` de los archivos tocados ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)