### PR TITLE
feat(3d): sanidad y mercado como espejo del dato real de la finca (§5b)

### DIFF
--- a/src/visual/mundo3d/escenas/EscenaMercado.jsx
+++ b/src/visual/mundo3d/escenas/EscenaMercado.jsx
@@ -19,6 +19,14 @@
  *
  * Todo `MeshLambert`/`Basic`, sin sombras (contrato de EscenaBase3D). Geometría
  * de primitivas: cero GLTF, offline y liviano.
+ *
+ * ESPEJO VIVO (auditoría §5b): los CANASTOS de producto son el reflejo de la
+ * COSECHA RECIENTE REAL de la finca (`estadoFinca.cosechaReciente`, que arma
+ * useFincaViva). CONTRATO ANTI-FABRICACIÓN ESTRICTO: sin cosecha reciente, la
+ * plaza queda TRANQUILA (canastos vacíos, sin producto) — jamás fingimos una
+ * venta ni surtimos productos que nadie cosechó. Cuando hay cosecha, la plaza se
+ * llena del cultivo REAL que salió de la finca (un lote creíble del mismo
+ * producto, no cuatro surtidos de muestra).
  */
 import { useMemo } from 'react';
 import EscenaBase3D from './EscenaBase3D.jsx';
@@ -31,10 +39,70 @@ import { CIELOS, PALETA } from '../atmosferaMadre.js';
 /* La fauna funcional de la feria (POLINIZADORES entre las flores del puesto y la
    cosecha: sin polinizador no hay cosecha que vender) vive en faunaFuncional.js. */
 
+/* Color del PRODUCTO por cultivo real (los que de verdad salen de una finca
+   andina). Es solo el tono del montón en el canasto; un cultivo no listado cae a
+   un tono producto neutro (ámbar de mimbre), NUNCA a un producto inventado. */
+const COLOR_PRODUCTO = {
+  tomate: '#d24b3a', papa: '#c9a15a', maiz: '#e7c451', cafe: '#7a4a24',
+  frijol: '#8a5a34', arveja: '#7a9a3f', mora: '#5a2a44', aguacate: '#4e6a2e',
+  platano: '#d9c24b', banano: '#e0c34a', yuca: '#cbb98a', cebolla: '#c8b6d6',
+  zanahoria: '#d07a34', lulo: '#d99a2f', uchuva: '#e0b23a', cilantro: '#5f8a3f',
+  repollo: '#8aa84a', curuba: '#c8b23a', naranja: '#e0902f', limon: '#c9d24a',
+  arracacha: '#e0cf9a', habichuela: '#6f9a3f', pepino: '#7fa83f', ahuyama: '#d98a2f',
+};
+/** Tono producto neutro para un cultivo sin color propio (mimbre ámbar). */
+const PRODUCTO_NEUTRO = '#c98a3f';
+
+/** Minúsculas y sin tildes, para casar el nombre del cultivo con el mapa. */
+function normalizaCultivo(nombre) {
+  return String(nombre || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // combina y quita tildes
+    .trim();
+}
+
+/**
+ * Color del producto de un cultivo REAL. Casa por palabra clave contenida
+ * ("tomate chonto" → tomate); si no reconoce el cultivo, tono producto neutro
+ * (nunca inventa que es tomate ni café).
+ */
+function colorDeProducto(cultivo) {
+  const clave = normalizaCultivo(cultivo);
+  if (!clave) return PRODUCTO_NEUTRO;
+  for (const k of Object.keys(COLOR_PRODUCTO)) {
+    if (clave.includes(k)) return COLOR_PRODUCTO[k];
+  }
+  return PRODUCTO_NEUTRO;
+}
+
+/**
+ * Los CANASTOS que van a la plaza, ESPEJO de la cosecha reciente real.
+ * Anti-fabricación: sin cosecha → [] (plaza tranquila, sin producto). Con
+ * cosecha → un par de canastos del MISMO cultivo real (un lote creíble), no un
+ * surtido de muestra. Un `params.canastos` explícito (vitrina) manda por encima.
+ *
+ * @param {object|null} cosechaReciente  { cultivo, mundoId } | null
+ * @param {Array|undefined} override  params.canastos explícito (vitrina)
+ * @returns {Array<{producto:string, color:string, pos:number[]}>}
+ */
+function canastosDeCosecha(cosechaReciente, override) {
+  if (Array.isArray(override)) return override;
+  const cultivo = cosechaReciente?.cultivo;
+  if (!cultivo) return [];
+  const color = colorDeProducto(cultivo);
+  return [
+    { producto: cultivo, color, pos: [-0.85, 0, 0.75] },
+    { producto: cultivo, color, pos: [0.55, 0, 0.7] },
+  ];
+}
+
 /* Un CANASTO de mimbre con su montón de producto. El canasto es un tronco de
    cono facetado (el tejido); encima, una loma de esferitas del color de lo que
-   trae (tomate rojo, papa tierra, maíz dorado, café tostado). */
-function Canasto({ pos, color = '#d24b3a' }) {
+   trae (tomate rojo, papa tierra, maíz dorado, café tostado). `vacio` deja el
+   mimbre SOLO, sin montón: la señal HONESTA de plaza sin cosecha reciente (no
+   fingimos un producto que nadie trajo). */
+function Canasto({ pos, color = '#d24b3a', vacio = false }) {
   // el montoncito: unas esferas apiladas, determinista (misma forma siempre)
   const frutos = useMemo(() => {
     const base = [
@@ -55,8 +123,8 @@ function Canasto({ pos, color = '#d24b3a' }) {
         <torusGeometry args={[0.145, 0.02, 6, 12]} />
         <meshLambertMaterial color="#8a5f30" flatShading />
       </mesh>
-      {/* el producto de la finca */}
-      {frutos.map(([x, y, z], i) => (
+      {/* el producto de la finca (solo si hay cosecha: canasto vacío no lo pone) */}
+      {!vacio && frutos.map(([x, y, z], i) => (
         <mesh key={i} position={[x, y, z]}>
           <sphereGeometry args={[0.055, 7, 6]} />
           <meshLambertMaterial color={color} flatShading />
@@ -183,7 +251,7 @@ function MataCampo({ pos, color = '#4e8f3f' }) {
   );
 }
 
-function Diorama({ params, reducedMotion, tier, fauna }) {
+function Diorama({ params, reducedMotion, tier, fauna, estadoFinca }) {
   const puestos = params?.puestos || [
     { color: '#c96a2f', pos: [-0.85, 0, 0.2] },
     { color: '#3f8f4e', pos: [0.9, 0, -0.1] },
@@ -196,12 +264,18 @@ function Diorama({ params, reducedMotion, tier, fauna }) {
     () => normalizarAnimales((params?.animales || []).filter((a) => a.estado === 'vendido')),
     [params?.animales],
   );
-  const canastos = params?.canastos || [
-    { producto: 'tomate', color: '#d24b3a', pos: [-0.85, 0, 0.75] },
-    { producto: 'papa', color: '#c9a15a', pos: [0.55, 0, 0.7] },
-    { producto: 'maiz', color: '#e7c451', pos: [1.15, 0, 0.35] },
-    { producto: 'cafe', color: '#7a4a24', pos: [-0.35, 0, 0.95] },
-  ];
+  // ESPEJO VIVO de la cosecha reciente REAL (§5b): los canastos son el cultivo
+  // que de verdad salió de la finca. Sin cosecha reciente → [] (plaza tranquila);
+  // jamás surtimos productos de muestra. `params.canastos` explícito (vitrina)
+  // manda por encima del dato real.
+  const canastos = useMemo(
+    () => canastosDeCosecha(estadoFinca?.cosechaReciente, params?.canastos),
+    [estadoFinca?.cosechaReciente, params?.canastos],
+  );
+  // Plaza tranquila: no hay cosecha reciente que traer. La feria queda armada
+  // (puestos, tarima, balanza) con UN canasto VACÍO al frente — señal honesta de
+  // "lista, esperando la cosecha", no un puesto roto ni surtido inventado.
+  const plazaTranquila = canastos.length === 0;
 
   // La parcela del fondo: unas matas de donde sale la cosecha (el origen de la
   // ruta campo→mercado). Repartidas con aire al fondo del diorama.
@@ -247,10 +321,12 @@ function Diorama({ params, reducedMotion, tier, fauna }) {
         <Puesto key={i} pos={p.pos} color={p.color} />
       ))}
 
-      {/* los canastos con la cosecha de la finca (sobre las mesas y el piso) */}
+      {/* los canastos con la cosecha REAL de la finca (sobre las mesas y el piso) */}
       {canastos.map((c, i) => (
         <Canasto key={i} pos={c.pos} color={c.color} />
       ))}
+      {/* plaza tranquila (sin cosecha reciente): un canasto VACÍO que espera */}
+      {plazaTranquila && <Canasto pos={[-0.85, 0, 0.75]} vacio />}
 
       {/* la tarima del sello de procedencia (el terroir andino) */}
       <TarimaProcedencia pos={[-1.4, 0, -0.35]} />
@@ -294,6 +370,7 @@ export default function EscenaMercado(props) {
         reducedMotion={props.reducedMotion}
         tier={props.tier}
         fauna={fauna}
+        estadoFinca={props.estadoFinca}
       />
     </EscenaBase3D>
   );

--- a/src/visual/mundo3d/escenas/EscenaSanidad.jsx
+++ b/src/visual/mundo3d/escenas/EscenaSanidad.jsx
@@ -17,6 +17,16 @@
  *
  * Todo `MeshLambert`/`Basic`, sin sombras (contrato de EscenaBase3D). Geometría
  * de primitivas: cero GLTF, offline y liviano.
+ *
+ * ESPEJO VIVO (auditoría §5b): las MATAS reflejan la SALUD REAL de la finca
+ * (`estadoFinca.saludFinca` = { matasVivas, matasTotal }, que arma useFincaViva
+ * de los conteos reales de matas). CONTRATO ANTI-FABRICACIÓN ESTRICTO: el manejo
+ * (trampas, biocontrol, borde push-pull, enemigos naturales) es la LECCIÓN del
+ * lugar y está SIEMPRE; NUNCA inventamos una plaga ni un bicho dañino. Sin dato
+ * de salud (finca vacía o aún cargando) → huerta SANA/neutra, todas las matas
+ * firmes. Con dato, si hay matas decaídas en la finca REAL, unas matas se ven
+ * decaídas (amarillean y se inclinan) en la misma proporción — el reflejo del
+ * conteo real, no una plaga fabricada.
  */
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
@@ -24,6 +34,42 @@ import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
 import { faunaDeMundo, coreografia } from '../faunaFuncional.js';
 import { CIELOS, PALETA } from '../atmosferaMadre.js';
+
+/* Umbrales del ESPEJO de salud: sobre este ratio de matas vivas la huerta se ve
+   plena; bajo el segundo, más de una mata decae. Deja SIEMPRE al menos una mata
+   firme (la clínica cuida lo que vive). */
+const SALUD_PLENA = 0.85;
+const SALUD_BAJA = 0.6;
+
+/**
+ * Ratio de matas vivas (0..1) o null si no hay dato de salud. null = huerta
+ * neutra/sana (no fingimos ni salud perfecta ni desastre): así lo omite
+ * useFincaViva cuando la finca está vacía o los procesos aún cargan.
+ *
+ * @param {object|undefined} saludFinca  { matasVivas, matasTotal }
+ * @returns {number|null}
+ */
+function ratioSalud(saludFinca) {
+  if (!saludFinca || !Number.isFinite(saludFinca.matasVivas)) return null;
+  const total = saludFinca.matasTotal > 0 ? saludFinca.matasTotal : 1;
+  return Math.max(0, Math.min(1, saludFinca.matasVivas / total));
+}
+
+/**
+ * Cuántas de las `total` matas se ven DECAÍDAS, espejo del ratio de salud real.
+ * null (sin dato) o salud plena → 0. Deja siempre ≥1 firme. NO es una plaga: es
+ * el reflejo honesto del conteo de matas que la finca reporta decaídas.
+ *
+ * @param {number|null} ratio
+ * @param {number} total  matas visibles en el diorama
+ * @returns {number}
+ */
+function matasDecaidas(ratio, total) {
+  const cap = Math.max(0, total - 1);
+  if (ratio == null || ratio >= SALUD_PLENA) return 0;
+  if (ratio >= SALUD_BAJA) return Math.min(1, cap);
+  return Math.min(2, cap);
+}
 
 /* La fauna BENÉFICA billboard de la huerta-clínica (el CONTROLADOR carábido que
    patrulla a ras + POLINIZADORES en la orla de flores) vive en faunaFuncional.js.
@@ -90,21 +136,28 @@ function Trampa({ pos, color = '#f2c531' }) {
   );
 }
 
-/* Una MATA sana: tallo + hojas redondeadas. El verde firme cuenta salud. */
-function Mata({ pos, color = '#4e8f3f' }) {
+/* Una MATA: tallo + hojas redondeadas. El verde firme cuenta salud; `decaida`
+   (espejo de la salud real, NO una plaga) la amarillea, achica y hace inclinar
+   las hojas — la mata que la finca reporta decaída, atendida por la clínica. */
+function Mata({ pos, color = '#4e8f3f', decaida = false }) {
   const hojas = [
     [0, 0.44, 0, 0.17], [0.13, 0.35, 0.05, 0.12], [-0.12, 0.37, -0.05, 0.12],
   ];
+  // Decaída: hoja amarillo-enfermiza, más pequeña y caída; tallo mustio.
+  const colorHoja = decaida ? '#b6a24a' : color;
+  const colorTallo = decaida ? '#6e6636' : '#5a6a2e';
+  const caida = decaida ? -0.06 : 0; // las hojas se hunden un poco
+  const merma = decaida ? 0.82 : 1; // y menguan
   return (
-    <group position={pos}>
+    <group position={pos} rotation={decaida ? [0.14, 0, 0.1] : [0, 0, 0]}>
       <mesh position={[0, 0.2, 0]}>
         <cylinderGeometry args={[0.03, 0.05, 0.42, 5]} />
-        <meshLambertMaterial color="#5a6a2e" flatShading />
+        <meshLambertMaterial color={colorTallo} flatShading />
       </mesh>
       {hojas.map(([x, y, z, r], i) => (
-        <mesh key={i} position={[x, y, z]}>
-          <sphereGeometry args={[r, 8, 7]} />
-          <meshLambertMaterial color={color} flatShading />
+        <mesh key={i} position={[x, y + caida, z]}>
+          <sphereGeometry args={[r * merma, 8, 7]} />
+          <meshLambertMaterial color={colorHoja} flatShading />
         </mesh>
       ))}
     </group>
@@ -151,12 +204,21 @@ function FlorBorde({ pos }) {
   );
 }
 
-function Diorama({ params, reducedMotion, fauna }) {
-  const matas = params?.matas || [
-    { color: '#4e8f3f', pos: [-0.5, 0, 0.35] },
-    { color: '#57993f', pos: [0.55, 0, 0.1] },
-    { color: '#468637', pos: [0.05, 0, -0.55] },
-  ];
+function Diorama({ params, reducedMotion, fauna, estadoFinca }) {
+  // ESPEJO VIVO de la salud real (§5b): cuántas matas se ven decaídas es el
+  // reflejo del ratio de matas vivas de la finca. Sin dato → 0 (huerta sana).
+  // Marcamos las ÚLTIMAS del arreglo (deja las del frente firmes). No es plaga.
+  const matas = useMemo(() => {
+    const base = params?.matas || [
+      { color: '#4e8f3f', pos: [-0.5, 0, 0.35] },
+      { color: '#57993f', pos: [0.55, 0, 0.1] },
+      { color: '#468637', pos: [0.05, 0, -0.55] },
+    ];
+    const ratio = ratioSalud(estadoFinca?.saludFinca);
+    const nDecaidas = matasDecaidas(ratio, base.length);
+    const desde = base.length - nDecaidas;
+    return base.map((m, i) => ({ ...m, decaida: i >= desde }));
+  }, [estadoFinca?.saludFinca, params?.matas]);
   const trampas = params?.trampas || [
     { color: '#f2c531', pos: [1.35, 0, 0.35] }, // amarilla: mosca blanca / minador
     { color: '#3f77c7', pos: [-1.25, 0, -0.5] }, // azul: trips
@@ -205,9 +267,9 @@ function Diorama({ params, reducedMotion, fauna }) {
         <meshBasicMaterial color={PALETA.follajeClaro} transparent opacity={0.7} />
       </mesh>
 
-      {/* las matas sanas que se protegen */}
+      {/* las matas que se protegen (decaída = espejo de la salud real, no plaga) */}
       {matas.map((m, i) => (
-        <Mata key={i} pos={m.pos} color={m.color} />
+        <Mata key={i} pos={m.pos} color={m.color} decaida={m.decaida} />
       ))}
       {/* las trampas cromáticas */}
       {trampas.map((t, i) => (
@@ -236,7 +298,12 @@ export default function EscenaSanidad(props) {
   const fauna = faunaDeMundo(props.mundoId, { tier: props.tier });
   return (
     <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.45, 0] }}>
-      <Diorama params={props.params} reducedMotion={props.reducedMotion} fauna={fauna} />
+      <Diorama
+        params={props.params}
+        reducedMotion={props.reducedMotion}
+        fauna={fauna}
+        estadoFinca={props.estadoFinca}
+      />
     </EscenaBase3D>
   );
 }

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -286,20 +286,19 @@ export const MUNDO = {
     escena: 'mercado',
     valle: { tipo: 'mercado', pos: [1.2, 0, 6.6], escala: 1 },
     params: {
-      // El diorama tiene defaults propios; aquí solo los hacemos explícitos y
-      // deterministas (mismos puestos y canastos 2D↔3D).
+      // Los PUESTOS son el LUGAR (infraestructura de la feria), deterministas.
       puestos: [
         { color: '#c96a2f', pos: [-0.85, 0, 0.2] },   // toldo del vecino
         { color: '#3f8f4e', pos: [0.9, 0, -0.1] },     // toldo de la huerta
       ],
-      canastos: [
-        { producto: 'tomate', color: '#d24b3a', pos: [-0.85, 0, 0.75] },
-        { producto: 'papa', color: '#c9a15a', pos: [0.55, 0, 0.7] },
-        { producto: 'maiz', color: '#e7c451', pos: [1.15, 0, 0.35] },
-        { producto: 'cafe', color: '#7a4a24', pos: [-0.35, 0, 0.95] },
-      ],
+      // Los CANASTOS de producto NO se fijan aquí: son ESPEJO VIVO de la cosecha
+      // reciente REAL (audit §5b). EscenaMercado los deriva de
+      // `estadoFinca.cosechaReciente` (useFincaViva); sin cosecha, la plaza queda
+      // tranquila. Anti-fabricación: jamás surtir un producto que nadie cosechó.
       // EL MISMO HATO del corral (audit §5a.4): el mercado filtra los VENDIDOS y
       // los hace LLEGAR caminando por la ruta campo→plaza. Un dato, dos mundos.
+      // Es la MUESTRA del hato (aún sin inventario real); cuando exista, el host
+      // pisa este arreglo con el hato REAL (misma forma).
       animales: HATO_MUESTRA,
     },
     hotspots: [
@@ -338,13 +337,18 @@ export const MUNDO = {
     escena: 'sanidad',
     valle: { tipo: 'huerta', pos: [3.8, 0, 4.9], escala: 0.95 },
     params: {
-      // El diorama tiene defaults propios; aquí solo los hacemos explícitos y
-      // deterministas (mismas matas y trampas 2D↔3D).
+      // Las MATAS y su SITIO son deterministas; su ESTADO (firme/decaída) NO se
+      // fija aquí: es ESPEJO VIVO de la salud real (audit §5b). EscenaSanidad lo
+      // deriva de `estadoFinca.saludFinca` (useFincaViva); sin dato, todas
+      // firmes. Anti-fabricación: nunca se inventa una plaga ni un bicho dañino.
       matas: [
         { color: '#4e8f3f', pos: [-0.5, 0, 0.35] },
         { color: '#57993f', pos: [0.55, 0, 0.1] },
         { color: '#468637', pos: [0.05, 0, -0.55] },
       ],
+      // Las TRAMPAS (y el biocontrol, el borde push-pull y los enemigos
+      // naturales) son la LECCIÓN del lugar: el manejo SIN veneno está SIEMPRE,
+      // no dependen de que haya plaga (monitoreo permanente, no alarma).
       trampas: [
         { color: '#f2c531', pos: [1.35, 0, 0.35] }, // amarilla: mosca blanca / minador
         { color: '#3f77c7', pos: [-1.25, 0, -0.5] }, // azul: trips


### PR DESCRIPTION
## Qué

Cose los mundos **SANIDAD** y **MERCADO** al dato REAL que arma `useFincaViva` (`estadoFinca`, ya en `dev`), con **contrato anti-fabricación estricto**: sin dato → estado neutro/vacío; jamás se finge una plaga ni una venta.

## Mercado (`EscenaMercado.jsx`)
- Los **canastos de producto** son ahora espejo de `estadoFinca.cosechaReciente` (el cultivo que de verdad salió de la finca).
- **Sin cosecha reciente → plaza tranquila**: un canasto vacío que espera, no un surtido de muestra.
- Color del producto mapeado del cultivo real (por palabra clave; fallback a tono producto neutro — nunca a un producto inventado como tomate/café).
- Infraestructura (puestos, tarima, balanza, ruta, parcela) siempre presente: es el LUGAR, no una venta declarada.

## Sanidad (`EscenaSanidad.jsx`)
- Las **matas** reflejan `estadoFinca.saludFinca` (conteo real de matas vivas/total).
- **Sin dato → huerta sana** (todas firmes). Con matas decaídas en la finca real, unas matas amarillean y se inclinan en la misma proporción — **NO es una plaga**, es el reflejo del conteo real.
- El manejo (trampas cromáticas, biocontrol, borde push-pull, enemigos naturales) es la **lección del lugar** y está **siempre**: monitoreo permanente, no alarma. Nunca se dibuja un bicho dañino inventado.

## Registro (`mundoData.js`)
- `canastos` (mercado) y el estado firme/decaída de las `matas` (sanidad) dejan de fijarse en datos: ahora son espejo vivo derivado en escena desde `estadoFinca`.
- Se conservan puestos, trampas y el hato de muestra (infraestructura + stream de hato ya auditado §5a.4, que el host pisa con el hato real cuando exista).

## Contrato anti-fabricación
| Mundo | Con dato | Sin dato |
|---|---|---|
| Sanidad | matas decaídas ∝ salud real (nunca una plaga nombrada) | huerta sana/neutra |
| Mercado | canastos del cultivo real cosechado | plaza tranquila (canasto vacío) |

Respeta gates `tier`/`reducedMotion`. Solo se tocaron `mundoData.js` + las escenas de sanidad y mercado.

## Verificación
- `vite build` → exit 0 (built in 4m 35s).
- `vitest run src/visual/mundo3d` → **28/28** en verde.
- `eslint` de los 3 archivos → limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)