### PR TITLE
feat(3d): cruce 2D->3D de Angelita — una sola abeja entre capas + personalidad de vuelo

### DIFF
--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -95,6 +95,11 @@ export function AbejaAngelita({
   //    (ámbar con contorno + chumbe), bracitos, cabeza (ojos/cachetes/sonrisa/
   //    antenas), probóscide, gotas. `.crt-body` es el nodo que squashea (boil
   //    idle + estados reactivos, que lo pisan por especificidad).
+  //    ENCIMA van DOS wrappers de VIDA con períodos co-primos (6.3s / 9.7s):
+  //    `rh-travieso` (saltitos de lado, wobble, double-take) y `rh-antic` (la
+  //    vuelta de campana Miss-Minutes con anticipación y overshoot). Tres capas
+  //    de transform que nunca caen en el mismo compás = idle impredecible, vivo.
+  //    El CSS los apaga con RM, tier bajo, estados reactivos y ánimo bajito.
   const body = (
     <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
       {/* aura viva */}
@@ -128,7 +133,7 @@ export function AbejaAngelita({
       {/* cabeza clara con contorno */}
       <circle cx="8.6" cy="-1.0" r="4.4" fill="#ffd76a" stroke={RH_INK} strokeWidth="1.2" />
       {/* chapetas campesinas + sonrisa + ojos de goma (parpadean juntos) */}
-      <Cachetes puntos={[{ cx: 10.4, cy: 0.7, r: 1.15 }, { cx: 6.9, cy: 0.3, r: 0.85 }]} />
+      <Cachetes puntos={[{ cx: 10.4, cy: 0.7, r: 1.15 }, { cx: 6.9, cy: 0.3, r: 0.85 }]} vivo={vivo} />
       <Sonrisa cx={8.9} cy={1.4} w={2.8} prof={1.1} />
       <OjosRubber
         ojos={[{ cx: 10.1, cy: -1.9, r: 1.95 }, { cx: 7.4, cy: -2.2, r: 1.45 }]}
@@ -143,6 +148,13 @@ export function AbejaAngelita({
       {gotas}
     </g>
   );
+  // Las capas de antics envuelven al cuerpo SOLO cuando está vivo (animated):
+  // nodos aparte para que sus transforms no pisen el boil de `.crt-body`.
+  const cuerpoVivo = vivo ? (
+    <g className="rh-antic">
+      <g className="rh-travieso">{body}</g>
+    </g>
+  ) : body;
 
   // data-estado agrupa la reacción para el CSS (brillo mojado, jadeo, mordisco).
   const estadoAttrs = {
@@ -159,7 +171,7 @@ export function AbejaAngelita({
     return (
       <g className={className} {...estadoAttrs}>
         {defs}
-        {body}
+        {cuerpoVivo}
       </g>
     );
   }
@@ -168,7 +180,7 @@ export function AbejaAngelita({
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}
-      {body}
+      {cuerpoVivo}
     </svg>
   );
 }

--- a/src/visual/creatures/AbejaTransicion.jsx
+++ b/src/visual/creatures/AbejaTransicion.jsx
@@ -1,0 +1,99 @@
+/*
+ * AbejaTransicion — el CRUCE de capa 2D → 3D de Angelita (el handoff).
+ *
+ * Hoy el viaje del host (TransicionMundo) deja a la abeja 2D en el centro de la
+ * pantalla y, al montar el mundo, el mesh (useEntradaAbeja) aparecía en su
+ * percha SIN puente: dos abejas, ninguna continuidad. Este overlay DOM puro
+ * (CERO three, seguro en el bundle base) cierra ese hueco CRONOMETRANDO el
+ * cruce con la coreografía del mesh:
+ *
+ *   entrar:  la 2D retoma donde el velo la soltó → ANTICIPA (se echa atrás,
+ *            coge impulso) → se CLAVA en barrel roll hacia el punto de atrape
+ *            (centro, ~36% de alto) encogiéndose → se apaga SECA en
+ *            CRUCE_ATRAPA_MS — el instante EXACTO en que el mesh de
+ *            useEntradaAbeja nace alto sobre el foco y baja en picada a su
+ *            percha. Una sola abeja que voló de la capa DOM al mundo 3D.
+ *   volver:  el reverso corto — brota chiquita del punto de atrape (el mundo
+ *            "la soltó") y crece hacia usted, fundiéndose donde el velo del
+ *            viaje del host la recoge con su propia abeja.
+ *
+ * El tiempo lo maneja un timer (no `animationend`): determinista, testeable y
+ * a prueba de pestañas en segundo plano (mismo contrato que TransicionMundo).
+ * `reduced-motion`: el que monta ya lo salta (cruce instantáneo); si llega
+ * montado igual, llama `onFin` de inmediato y el CSS no dibuja nada.
+ * Device-tier 'bajo': queda el cruce simple (posición + timing) sin barrel
+ * roll ni puff — el CSS gatea por [data-tier].
+ */
+import { useEffect, useRef } from 'react';
+import { AbejaAngelita } from './AbejaAngelita.jsx';
+import './creatures.css';
+
+/** Instante del ATRAPE (ms): la 2D se apaga y el mesh aparece. La coreografía
+    del mesh (useEntradaAbeja) importa ESTA constante — una sola fuente. */
+export const CRUCE_ATRAPA_MS = 760;
+/** Vida total del overlay al entrar (deja terminar el puff del atrape). */
+export const CRUCE_ENTRAR_MS = 980;
+/** Vida del reverso al volver (corto: la vuelta no debe sentirse lenta). */
+export const CRUCE_VOLVER_MS = 620;
+
+/**
+ * Centinela de montaje: se coloca DENTRO del `<Suspense>` junto a la escena
+ * perezosa — Suspense revela a todos los hijos juntos, así que su `useEffect`
+ * dispara exactamente cuando el chunk 3D resolvió y la escena montó. Es lo que
+ * permite arrancar el cruce sincronizado con el nacimiento del mesh (y no con
+ * un chunk que quizá sigue bajando con la señal del campo).
+ */
+export function AlMontarEscena({ onMonta }) {
+  const cb = useRef(onMonta);
+  useEffect(() => {
+    cb.current?.();
+  }, []);
+  return null;
+}
+
+export default function AbejaTransicion({
+  sentido = 'entrar', // 'entrar' (2D se clava al mundo) | 'volver' (brota del mundo)
+  animo = 'sereno',
+  energia = 1,
+  tier = 'alto',
+  reducedMotion = false,
+  onFin,
+}) {
+  const finRef = useRef(onFin);
+  useEffect(() => {
+    finRef.current = onFin;
+  });
+
+  useEffect(() => {
+    let hecho = false;
+    const dura = sentido === 'entrar' ? CRUCE_ENTRAR_MS : CRUCE_VOLVER_MS;
+    const t = setTimeout(
+      () => {
+        if (!hecho) {
+          hecho = true;
+          finRef.current?.();
+        }
+      },
+      reducedMotion ? 0 : dura,
+    );
+    return () => {
+      hecho = true;
+      clearTimeout(t);
+    };
+  }, [sentido, reducedMotion]);
+
+  if (reducedMotion) return null;
+
+  return (
+    <div className={`abeja-cruce abeja-cruce--${sentido}`} data-tier={tier} aria-hidden="true">
+      <div className="abeja-cruce__pos">
+        <div className="abeja-cruce__vuelo">
+          <div className="abeja-cruce__giro">
+            <AbejaAngelita size={76} animo={animo} energia={energia} animated tier={tier} />
+          </div>
+        </div>
+        {sentido === 'entrar' && <span className="abeja-cruce__puff" />}
+      </div>
+    </div>
+  );
+}

--- a/src/visual/creatures/AbejaTransicion.jsx
+++ b/src/visual/creatures/AbejaTransicion.jsx
@@ -23,6 +23,24 @@
  * montado igual, llama `onFin` de inmediato y el CSS no dibuja nada.
  * Device-tier 'bajo': queda el cruce simple (posición + timing) sin barrel
  * roll ni puff — el CSS gatea por [data-tier].
+ *
+ * ── CABLEADO EN EL HOST (Mundo.jsx / quien navega) — para Opus ──────────────
+ * El lado MESH ya es AUTÓNOMO: al montar una escena, `useEntradaAbeja` corre el
+ * cruce de ENTRADA solo (nace oculta y aparece en CRUCE_ATRAPA_MS). Falta solo
+ * el overlay 2D y la señal de vuelta, dos puntos:
+ *
+ *   1. ENTRAR — dentro del `<Suspense>` de Mundo.jsx, HERMANO de la escena
+ *      perezosa: `<AlMontarEscena onMonta={() => setCruce('entrar')} />`. Con
+ *      `cruce === 'entrar'` el host monta `<AbejaTransicion sentido="entrar"
+ *      tier={tier} reducedMotion={rm} onFin={() => setCruce(null)} />` como
+ *      overlay del contenedor del mundo (posición absoluta sobre el canvas).
+ *      Con `reducedMotion` NO montar nada (el mesh ya aparece al instante).
+ *   2. VOLVER — cuando la navegación pasa a 'regresando' (volverAlValle, SIN
+ *      reducedMotion): llamar `avisarSalidaAbeja()` (el mesh vuela al punto de
+ *      suelta y se apaga en CRUCE_SUELTA_MS) y montar `<AbejaTransicion
+ *      sentido="volver" …/>` en el mismo instante — el overlay brota de ese
+ *      mismo punto ~100 ms después: empalme de capas. La señal se auto-resetea
+ *      al montar la siguiente escena (no hay que limpiarla a mano).
  */
 import { useEffect, useRef } from 'react';
 import { AbejaAngelita } from './AbejaAngelita.jsx';
@@ -35,6 +53,14 @@ export const CRUCE_ATRAPA_MS = 760;
 export const CRUCE_ENTRAR_MS = 980;
 /** Vida del reverso al volver (corto: la vuelta no debe sentirse lenta). */
 export const CRUCE_VOLVER_MS = 620;
+/** Instante de la SUELTA al volver (ms desde `avisarSalidaAbeja()`): el mesh
+    vuela hacia el punto de suelta y se APAGA aquí, cuando el overlay 'volver'
+    (que el host monta en el mismo instante) ya brotó (~100 ms). El pequeño
+    solape es a propósito: cubre el relevo de capas sin hueco. */
+export const CRUCE_SUELTA_MS = 180;
+/* La SEÑAL de salida (avisarSalidaAbeja / useSalidaAbeja) vive en
+   `senalSalidaAbeja.js` — módulo propio para que este archivo de componentes
+   quede fast-refresh-limpio. */
 
 /**
  * Centinela de montaje: se coloca DENTRO del `<Suspense>` junto a la escena

--- a/src/visual/creatures/_rubberhose.jsx
+++ b/src/visual/creatures/_rubberhose.jsx
@@ -44,9 +44,15 @@ export function OjosRubber({ ojos = [], mirar = [0.32, 0.34], parpadea = true, i
         return (
           <g key={i}>
             <circle cx={o.cx} cy={o.cy} r={o.r} fill="#fffaf0" stroke={ink} strokeWidth={o.r * 0.42} />
-            <circle cx={px} cy={py} r={pr} fill="#20130a" />
-            {/* catchlight arriba-izquierda: la chispa de vida del ojo */}
-            <circle cx={px - pr * 0.4} cy={py - pr * 0.5} r={pr * 0.42} fill="#fffdf7" />
+            {/* pupila + catchlight en su grupo `rh-mirada`: cuando la criatura
+                está viva, las pupilas se van de reojo y miran arriba curiosas
+                (período co-primo con el parpadeo — nunca el mismo compás).
+                Ambos ojos comparten la clase → dardean sincronizados. */}
+            <g className={parpadea ? 'rh-mirada' : undefined}>
+              <circle cx={px} cy={py} r={pr} fill="#20130a" />
+              {/* catchlight arriba-izquierda: la chispa de vida del ojo */}
+              <circle cx={px - pr * 0.4} cy={py - pr * 0.5} r={pr * 0.42} fill="#fffdf7" />
+            </g>
           </g>
         );
       })}
@@ -58,10 +64,12 @@ export function OjosRubber({ ojos = [], mirar = [0.32, 0.34], parpadea = true, i
  * Chapetas / cachetes campesinos: el rubor coral que da ternura andina.
  * @param {Array<{cx:number,cy:number,r:number}>} puntos
  * @param {string} [color=RH_CHEEK]
+ * @param {boolean} [vivo=false]  activa `rh-rubor`: las chapetas se encienden
+ *   un instante en un ciclo largo (el CSS lo gatea por RM/tier).
  */
-export function Cachetes({ puntos = [], color = RH_CHEEK }) {
+export function Cachetes({ puntos = [], color = RH_CHEEK, vivo = false }) {
   return (
-    <g fill={color} opacity="0.72">
+    <g fill={color} opacity="0.72" className={vivo ? 'rh-rubor' : undefined}>
       {puntos.map((p, i) => (
         <ellipse key={i} cx={p.cx} cy={p.cy} rx={p.r} ry={p.r * 0.72} />
       ))}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -94,17 +94,96 @@
 
 /* PARPADEO — la chispa de vida de los ojos de goma: abiertos casi todo el ciclo,
    cierran SECO un par de fotogramas. Se aplica al grupo de ojos (los dos a la
-   vez). Snappy, no stepped (un parpadeo es 1-2 frames). */
+   vez). Snappy, no stepped (un parpadeo es 1-2 frames). IRREGULAR a propósito:
+   un parpadeo suelto y luego un parpadeo DOBLE (blink-blink) más adelante en el
+   ciclo — la cadencia pareja delataba al robot. */
 .rh-blink {
   transform-box: fill-box;
   transform-origin: center;
-  animation: rh-blink 4.2s linear infinite;
+  animation: rh-blink 5.6s linear infinite;
 }
 @keyframes rh-blink {
-  0%, 93%, 100% { transform: scaleY(1); }
-  96%           { transform: scaleY(0.12); }  /* cierra */
-  98%           { transform: scaleY(1); }      /* abre */
+  0%, 36%, 40%, 74%, 78%, 82%, 86%, 100% { transform: scaleY(1); }
+  38% { transform: scaleY(0.12); }  /* parpadeo suelto */
+  76% { transform: scaleY(0.1); }   /* blink-blink: dos golpes seguidos */
+  80% { transform: scaleY(0.14); }
 }
+
+/* MIRADA — pupilas que reaccionan: se van de reojo, miran arriba curiosas y
+   vuelven. Período co-primo con el parpadeo y los antics para que el conjunto
+   NUNCA caiga en el mismo compás (vida, no loop). Ampitudes en unidades del
+   viewBox (≈2px en un avatar de 64). */
+.rh-mirada {
+  animation: rh-mirada 7.9s ease-in-out infinite;
+}
+@keyframes rh-mirada {
+  0%, 22%, 40%, 58%, 76%, 100% { transform: translate(0, 0); }
+  25%, 36% { transform: translate(-0.55px, 0.12px); }   /* de reojo (sospecha algo) */
+  61%, 71% { transform: translate(0.45px, -0.38px); }   /* arriba: ¿y eso qué era? */
+}
+
+/* ANTIC — el arrebato Miss-Minutes: casi todo el ciclo es identidad, y de
+   pronto ANTICIPA (se echa atrás con squash, agarra impulso) y da la VUELTA
+   DE CAMPANA completa con stretch, overshoot y asentada. El 360→0 del cierre
+   de loop es invisible (mismo ángulo). Wrapper propio: no pisa el boil. */
+.rh-antic {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: rh-antic 9.7s ease-in-out infinite;
+}
+@keyframes rh-antic {
+  0%, 55% { transform: rotate(0deg) scale(1, 1); }
+  58%, 60% { transform: rotate(-11deg) scale(0.93, 1.09); }  /* anticipación + hold */
+  67% { transform: rotate(338deg) scale(1.08, 0.92); }       /* ¡la vuelta! (smear de squash) */
+  71% { transform: rotate(367deg) scale(0.97, 1.04); }       /* overshoot elástico */
+  75%, 100% { transform: rotate(360deg) scale(1, 1); }
+}
+
+/* TRAVIESO — micro-antics de otro período: un saltito de lado con wobble
+   (double-take de cuerpo) y un brinquito curioso más tarde. Chispa, no epilepsia:
+   amplitudes de ~1 unidad y ventanas cortas dentro de un ciclo largo. */
+.rh-travieso {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: rh-travieso 6.3s ease-in-out infinite;
+}
+@keyframes rh-travieso {
+  0%, 29%, 46%, 74%, 90%, 100% { transform: translate(0, 0) rotate(0deg); }
+  32% { transform: translate(-1.1px, -0.5px) rotate(-5deg); }  /* saltito de lado */
+  36% { transform: translate(-1.1px, -0.4px) rotate(4deg); }   /* wobble (double-take) */
+  41% { transform: translate(0.4px, 0.2px) rotate(-2deg); }    /* rebote de vuelta */
+  79% { transform: translate(0, -0.95px) rotate(4deg); }       /* brinquito curioso */
+  84% { transform: translate(0, 0.3px) rotate(-2deg); }
+}
+
+/* RUBOR — las chapetas se encienden un momento (calidez andina, período largo). */
+.rh-rubor {
+  animation: rh-rubor 12.7s ease-in-out infinite;
+}
+@keyframes rh-rubor {
+  0%, 62%, 78%, 100% { opacity: 0.72; }
+  68%, 72% { opacity: 0.95; }
+}
+
+/* El ánimo modula la locura: 'pleno' = más chispa (antics más seguidos);
+   'sediento'/'descansa' = sin arrebatos ni miradas traviesas (está bajita de
+   ánimo — el aleteo y los estados reactivos siguen contando la verdad). */
+[data-animo='pleno'] .rh-antic { animation-duration: 6.8s; }
+[data-animo='pleno'] .rh-travieso { animation-duration: 4.7s; }
+[data-animo='sediento'] .rh-antic,
+[data-animo='sediento'] .rh-travieso,
+[data-animo='sediento'] .rh-mirada,
+[data-animo='descansa'] .rh-antic,
+[data-animo='descansa'] .rh-travieso,
+[data-animo='descansa'] .rh-mirada { animation: none; }
+
+/* Los estados reactivos (mojada/sed/comiendo) y el reposo PISAN el arrebato:
+   una abeja empapada o libando no da vueltas de campana. */
+[data-mojada='1'] .rh-antic, [data-mojada='1'] .rh-travieso,
+[data-sed='1'] .rh-antic, [data-sed='1'] .rh-travieso,
+[data-comiendo='1'] .rh-antic, [data-comiendo='1'] .rh-travieso,
+[data-pose='reposo'] .rh-antic, [data-pose='reposo'] .rh-travieso,
+[data-pose='reposo'] .rh-mirada { animation: none; }
 
 /* FOLLOW-THROUGH (secondary motion) — antenas, bracitos y patitas de manguera
    se mecen con retardo: delatan que el cuerpo se movió. Cada miembro pone su
@@ -132,10 +211,15 @@
 /* device-tier 'bajo': corta lo continuo (ahorro gama baja). Los estados
    reactivos siguen (feedback importante) por su mayor especificidad. */
 [data-tier='bajo'] .rh-boil,
-[data-tier='bajo'] .rh-sway { animation: none; }
+[data-tier='bajo'] .rh-sway,
+[data-tier='bajo'] .rh-antic,
+[data-tier='bajo'] .rh-travieso,
+[data-tier='bajo'] .rh-mirada,
+[data-tier='bajo'] .rh-rubor { animation: none; }
 
 @media (prefers-reduced-motion: reduce) {
-  .rh-boil, .rh-blink, .rh-sway, .rh-smear { animation: none !important; }
+  .rh-boil, .rh-blink, .rh-sway, .rh-smear,
+  .rh-antic, .rh-travieso, .rh-mirada, .rh-rubor { animation: none !important; }
 }
 
 /* ── REACCIÓN AL ESTADO REAL DE LA FINCA (auditoría §5b) ──────────────────────
@@ -219,4 +303,116 @@
   [data-creature='abeja-angelita'][data-sed='1'] .crt-body,
   [data-creature='abeja-angelita'][data-comiendo='1'] .crt-lengua,
   [data-creature='abeja-angelita'][data-comiendo='1'] .crt-body { animation: none !important; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   EL CRUCE 2D → 3D (AbejaTransicion.jsx) — el handoff de capas.
+   Overlay DOM puro sobre el mundo recién montado: la Angelita 2D ANTICIPA
+   (se echa atrás, agarra impulso) y se CLAVA hacia el punto de atrape
+   (centro, ~36% de alto — donde el mesh de useEntradaAbeja nace y la
+   "atrapa" en el mismo instante: CRUCE_ATRAPA_MS). Al volver, el reverso:
+   brota chiquita del punto de atrape y crece hacia usted, empalmando con el
+   velo del viaje del host. Todo transform/opacity; pointer-events: none.
+   ═══════════════════════════════════════════════════════════════════════════ */
+.abeja-cruce {
+  position: absolute;
+  inset: 0;
+  z-index: 45; /* sobre canvas y miga (5), bajo el velo del viaje del host */
+  overflow: hidden;
+  pointer-events: none;
+}
+/* El punto de ATRAPE: ancla de 0×0 donde la 2D se apaga y el mesh enciende.
+   El flex con caja 0×0 centra al hijo exactamente sobre el punto. */
+.abeja-cruce__pos {
+  position: absolute;
+  left: 50%;
+  top: 36%;
+  width: 0;
+  height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.abeja-cruce__vuelo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  will-change: transform, opacity;
+  filter: drop-shadow(0 6px 14px rgba(20, 30, 15, 0.35));
+}
+.abeja-cruce__giro { will-change: transform; }
+.abeja-cruce__giro > svg { display: block; }
+
+/* ENTRAR: retoma donde el velo del host soltó a la abeja (centro, escala ~.55),
+   anticipa y se clava hacia el punto de atrape encogiéndose — el zoom "hacia
+   adentro" de la escena. La opacidad muere SECA justo en el atrape. */
+.abeja-cruce--entrar .abeja-cruce__vuelo {
+  animation: abeja-cruce-entra 0.76s cubic-bezier(0.5, 0, 0.65, 1) both;
+}
+.abeja-cruce--entrar .abeja-cruce__giro {
+  animation: abeja-cruce-gira 0.76s cubic-bezier(0.55, 0, 0.6, 1) both;
+}
+@keyframes abeja-cruce-entra {
+  0%   { transform: translateY(24vh) scale(0.55); opacity: 0; }
+  14%  { transform: translateY(24vh) scale(0.55); opacity: 1; }   /* retoma el hilo */
+  38%  { transform: translateY(27vh) scale(0.62, 0.5); }          /* anticipación: coge impulso */
+  46%  { transform: translateY(25vh) scale(0.5, 0.66); }          /* estira al despegar */
+  92%  { opacity: 1; }
+  100% { transform: translateY(0) scale(0.1); opacity: 0; }        /* ¡atrapada por el mesh! */
+}
+@keyframes abeja-cruce-gira {
+  0%, 38% { transform: rotate(0deg); }
+  44%  { transform: rotate(-16deg); }    /* wind-up */
+  100% { transform: rotate(326deg); }    /* barrel roll del clavado */
+}
+/* El puff del atrape: un anillo que revienta donde la 2D desapareció (vende
+   el "pop" del cruce de capa). Nace con el atrape, muere solo. */
+.abeja-cruce__puff {
+  position: absolute;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 214, 106, 0.9);
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.2);
+  left: 0;
+  top: 0;
+  will-change: transform, opacity;
+  animation: abeja-cruce-puff 0.3s ease-out 0.68s both;
+}
+@keyframes abeja-cruce-puff {
+  0%   { transform: translate(-50%, -50%) scale(0.2); opacity: 0.9; }
+  100% { transform: translate(-50%, -50%) scale(1.4); opacity: 0; }
+}
+
+/* VOLVER: el reverso — brota chiquita del punto de atrape (el mesh "la soltó"),
+   crece hacia usted con overshoot y se FUNDE al final: el velo del viaje del
+   host la recoge ahí con su propia abeja creciendo (empalme de capas). */
+.abeja-cruce--volver .abeja-cruce__vuelo {
+  animation: abeja-cruce-vuelve 0.62s cubic-bezier(0.3, 0.6, 0.45, 1) both;
+}
+.abeja-cruce--volver .abeja-cruce__giro {
+  animation: abeja-cruce-desgira 0.62s ease-out both;
+}
+@keyframes abeja-cruce-vuelve {
+  0%   { transform: translateY(0) scale(0.1); opacity: 0; }
+  16%  { transform: translateY(2vh) scale(0.2, 0.26); opacity: 1; }  /* brota estirada */
+  72%  { transform: translateY(18vh) scale(0.54, 0.48); }            /* overshoot squash */
+  88%  { transform: translateY(21vh) scale(0.5); opacity: 1; }
+  100% { transform: translateY(22vh) scale(0.52); opacity: 0; }      /* la recoge el velo */
+}
+@keyframes abeja-cruce-desgira {
+  0%   { transform: rotate(-300deg); }   /* deshace el barrel roll al salir */
+  100% { transform: rotate(0deg); }
+}
+
+/* Gama baja: el cruce queda (posición + timing son lo que empalma), pero sin
+   barrel roll ni puff (menos capas animando a la vez). */
+[data-tier='bajo'].abeja-cruce .abeja-cruce__giro { animation: none; }
+[data-tier='bajo'].abeja-cruce .abeja-cruce__puff { animation: none; opacity: 0; }
+
+/* RM defensivo: el que monta el overlay ya lo salta con reduced-motion; si
+   algún host se equivoca, aquí no se anima nada (y no se ve nada). */
+@media (prefers-reduced-motion: reduce) {
+  .abeja-cruce { display: none; }
 }

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -110,15 +110,18 @@
 }
 
 /* MIRADA — pupilas que reaccionan: se van de reojo, miran arriba curiosas y
-   vuelven. Período co-primo con el parpadeo y los antics para que el conjunto
-   NUNCA caiga en el mismo compás (vida, no loop). Ampitudes en unidades del
-   viewBox (≈2px en un avatar de 64). */
+   vuelven. Con DOUBLE-TAKE (Miss Minutes): tras el reojo, un vistazo SECO al
+   lado contrario y de vuelta — "¿ah? …¡AH!". Período co-primo con el parpadeo
+   y los antics para que el conjunto NUNCA caiga en el mismo compás (vida, no
+   loop). Amplitudes en unidades del viewBox (≈2px en un avatar de 64). */
 .rh-mirada {
   animation: rh-mirada 7.9s ease-in-out infinite;
 }
 @keyframes rh-mirada {
-  0%, 22%, 40%, 58%, 76%, 100% { transform: translate(0, 0); }
-  25%, 36% { transform: translate(-0.55px, 0.12px); }   /* de reojo (sospecha algo) */
+  0%, 20%, 47%, 58%, 76%, 100% { transform: translate(0, 0); }
+  23%, 34% { transform: translate(-0.55px, 0.12px); }   /* de reojo (sospecha algo) */
+  38% { transform: translate(0.5px, 0); }               /* double-take: ¡al otro lado! */
+  41%, 44% { transform: translate(-0.5px, 0.1px); }     /* …no, sí era allá */
   61%, 71% { transform: translate(0.45px, -0.38px); }   /* arriba: ¿y eso qué era? */
 }
 
@@ -140,18 +143,22 @@
 }
 
 /* TRAVIESO — micro-antics de otro período: un saltito de lado con wobble
-   (double-take de cuerpo) y un brinquito curioso más tarde. Chispa, no epilepsia:
-   amplitudes de ~1 unidad y ventanas cortas dentro de un ciclo largo. */
+   (double-take de cuerpo), el WIGGLE Miss-Minutes (meneíto sabroso de caderas,
+   su firma) y un brinquito curioso al final. Chispa, no epilepsia: amplitudes
+   de ~1 unidad, ventanas cortas dentro de un ciclo largo, easing suave. */
 .rh-travieso {
   transform-box: fill-box;
   transform-origin: center;
   animation: rh-travieso 6.3s ease-in-out infinite;
 }
 @keyframes rh-travieso {
-  0%, 29%, 46%, 74%, 90%, 100% { transform: translate(0, 0) rotate(0deg); }
+  0%, 29%, 46%, 56%, 72%, 90%, 100% { transform: translate(0, 0) rotate(0deg); }
   32% { transform: translate(-1.1px, -0.5px) rotate(-5deg); }  /* saltito de lado */
   36% { transform: translate(-1.1px, -0.4px) rotate(4deg); }   /* wobble (double-take) */
   41% { transform: translate(0.4px, 0.2px) rotate(-2deg); }    /* rebote de vuelta */
+  59% { transform: translate(0.25px, 0) rotate(3.5deg); }      /* wiggle: menea… */
+  63% { transform: translate(-0.25px, 0) rotate(-3.5deg); }    /* …para acá… */
+  67% { transform: translate(0.15px, 0) rotate(2deg); }        /* …y asienta contenta */
   79% { transform: translate(0, -0.95px) rotate(4deg); }       /* brinquito curioso */
   84% { transform: translate(0, 0.3px) rotate(-2deg); }
 }

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -11,6 +11,15 @@
  * Props comunes: { size, className, inline, animated, title }.
  */
 export { AbejaAngelita } from './AbejaAngelita.jsx';
+/* El CRUCE 2D→3D de Angelita (overlay DOM puro, cero three — seguro en el
+   bundle base). El host de mundos lo monta al entrar/volver; la señal
+   `avisarSalidaAbeja` avisa al mesh que la abeja sale (ver AbejaTransicion.jsx,
+   sección "CABLEADO EN EL HOST"). */
+export {
+  default as AbejaTransicion, AlMontarEscena,
+  CRUCE_ATRAPA_MS, CRUCE_ENTRAR_MS, CRUCE_VOLVER_MS, CRUCE_SUELTA_MS,
+} from './AbejaTransicion.jsx';
+export { avisarSalidaAbeja, resetSalidaAbeja, useSalidaAbeja } from './senalSalidaAbeja.js';
 export { Colibri } from './Colibri.jsx';
 export { Lombriz } from './Lombriz.jsx';
 export { Mariposa } from './Mariposa.jsx';

--- a/src/visual/creatures/senalSalidaAbeja.js
+++ b/src/visual/creatures/senalSalidaAbeja.js
@@ -1,0 +1,47 @@
+/*
+ * LA SEÑAL DE SALIDA de Angelita (host → mesh, sin prop-drilling).
+ *
+ * Parte del CRUCE 2D↔3D (ver AbejaTransicion.jsx, sección "CABLEADO EN EL
+ * HOST"). Mundo.jsx y EscenaBase3D no se tocan para este cruce, y el `<Canvas>`
+ * de r3f es OTRO reconciler (un Context de React no lo atraviesa). El canal es
+ * un store externo mínimo (useSyncExternalStore): el host avisa "la abeja
+ * sale" al iniciar la vuelta al valle y el mesh (AbejaEscena, dentro del
+ * canvas) lo escucha donde esté — vuela al punto de suelta y se apaga en
+ * CRUCE_SUELTA_MS, donde el overlay 'volver' la retoma.
+ *
+ * Se resetea solo al montar la siguiente escena (AbejaEscena lo hace en su
+ * mount/unmount) — sin ese reset, la próxima abeja nacería ya "saliendo" y no
+ * aparecería nunca. Módulo propio (no dentro de AbejaTransicion.jsx) para que
+ * el archivo de componentes quede fast-refresh-limpio.
+ */
+import { useSyncExternalStore } from 'react';
+
+let salidaSaliendo = false;
+const salidaSubs = new Set();
+
+function emitirSalida(v) {
+  if (salidaSaliendo === v) return;
+  salidaSaliendo = v;
+  salidaSubs.forEach((fn) => fn());
+}
+
+/** El host la llama al iniciar la vuelta al valle (fase 'regresando'). */
+export function avisarSalidaAbeja() {
+  emitirSalida(true);
+}
+
+/** Limpia la señal (AbejaEscena lo hace sola al montar/desmontar). */
+export function resetSalidaAbeja() {
+  emitirSalida(false);
+}
+
+function suscribirSalida(fn) {
+  salidaSubs.add(fn);
+  return () => salidaSubs.delete(fn);
+}
+const leerSalida = () => salidaSaliendo;
+
+/** ¿La abeja del mundo está saliendo? (reactivo; cruza el reconciler de r3f). */
+export function useSalidaAbeja() {
+  return useSyncExternalStore(suscribirSalida, leerSalida, leerSalida);
+}

--- a/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
+++ b/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
@@ -21,6 +21,7 @@ import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaAngelita } from '../../creatures/AbejaAngelita.jsx';
+import { CRUCE_ATRAPA_MS } from '../../creatures/AbejaTransicion.jsx';
 import { SombraContacto } from './SombraContacto.jsx';
 import { reaccionDeFinca } from './reaccionFinca.js';
 import useHaptics from '../useHaptics.js';
@@ -28,6 +29,17 @@ import useHaptics from '../useHaptics.js';
 /* Vuelo neutro: cuando la escena aún no pasa `estadoFinca` (contrato viejo),
    la coreografía se comporta EXACTO como antes (todos los multiplicadores en 1). */
 const VUELO_NEUTRO = { altura: 1, velocidad: 1, vagar: 1, tiembla: 0 };
+
+/* EL CRUCE 2D→3D (AbejaTransicion): el mesh nace OCULTO, alto sobre el foco y
+   corrido hacia la cámara (arriba-centro de la pantalla — donde la Angelita 2D
+   del overlay se clava y desaparece), espera el instante del ATRAPE y entonces
+   aparece y baja en PICADA a su percha. Misma constante de tiempo que el
+   overlay = una sola abeja cruzando de capa. */
+const CRUCE_ATRAPA_S = CRUCE_ATRAPA_MS / 1000;
+const CRUCE_PICADA_S = 1.6; // ventana post-atrape con lerp reforzado (el clavado)
+const CRUCE_EMPUJE = 2.6; // refuerzo del lerp durante la picada
+const CRUCE_ALTO = 2.6; // cuánto más alto nace sobre su percha
+const CRUCE_CERCA = 2.2; // cuánto más cerca de la cámara (z) nace
 
 /**
  * Devuelve `{ ref, caraRef, sombraRef }` para colgar del `<group>` de la abeja,
@@ -44,13 +56,21 @@ const VUELO_NEUTRO = { altura: 1, velocidad: 1, vagar: 1, tiembla: 0 };
  * @param {object}  [opts.vuelo]  modificadores de reaccionDeFinca: mojada vuela
  *   más bajo/lento, sed baja a buscar agua, comiendo tiembla mordisqueando.
  *   `{ altura, velocidad, vagar, tiembla }` — multiplicadores (1 = vuelo normal).
+ * @param {boolean} [opts.cruce=false]  el CRUCE 2D→3D: nace oculta, alta y
+ *   cerca de la cámara, aparece en CRUCE_ATRAPA_MS (cuando la 2D del overlay
+ *   se apaga) y baja en picada a su percha. `visRef` (devuelto) debe colgarse
+ *   del billboard DOM para que la ocultación llegue al <Html> (drei no hereda
+ *   la visibilidad del group al portal DOM).
  */
 export function useEntradaAbeja(foco, {
   entrando = true, energia = 1, reducedMotion = false, piso = 0, vuelo = VUELO_NEUTRO,
+  cruce = false,
 } = {}) {
   const ref = useRef(null);
   const caraRef = useRef(null);
   const sombraRef = useRef(null);
+  const visRef = useRef(null);
+  const nacioEn = useRef(null); // reloj del primer frame (ancla del cruce)
   const prevX = useRef(foco.x);
   // Háptica de "posarse" (DR-3D-HAPTICA): UNA sola vez por foco, al cruzar el
   // umbral de llegada. El foco solo cambia por tap del usuario (hotspot) o al

--- a/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
+++ b/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
@@ -21,7 +21,8 @@ import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaAngelita } from '../../creatures/AbejaAngelita.jsx';
-import { CRUCE_ATRAPA_MS } from '../../creatures/AbejaTransicion.jsx';
+import { CRUCE_ATRAPA_MS, CRUCE_SUELTA_MS } from '../../creatures/AbejaTransicion.jsx';
+import { useSalidaAbeja, resetSalidaAbeja } from '../../creatures/senalSalidaAbeja.js';
 import { SombraContacto } from './SombraContacto.jsx';
 import { reaccionDeFinca } from './reaccionFinca.js';
 import useHaptics from '../useHaptics.js';
@@ -30,22 +31,49 @@ import useHaptics from '../useHaptics.js';
    la coreografía se comporta EXACTO como antes (todos los multiplicadores en 1). */
 const VUELO_NEUTRO = { altura: 1, velocidad: 1, vagar: 1, tiembla: 0 };
 
-/* EL CRUCE 2D→3D (AbejaTransicion): el mesh nace OCULTO, alto sobre el foco y
-   corrido hacia la cámara (arriba-centro de la pantalla — donde la Angelita 2D
-   del overlay se clava y desaparece), espera el instante del ATRAPE y entonces
-   aparece y baja en PICADA a su percha. Misma constante de tiempo que el
-   overlay = una sola abeja cruzando de capa. */
+/* EL CRUCE 2D→3D (AbejaTransicion): el mesh nace OCULTO exactamente en el
+   PUNTO DE ATRAPE — el píxel de pantalla donde la Angelita 2D del overlay se
+   clava y desaparece (centro, 36% de alto: `.abeja-cruce__pos` en
+   creatures.css) — espera el instante del ATRAPE y entonces aparece y baja en
+   PICADA a su percha. Misma constante de tiempo que el overlay = una sola
+   abeja cruzando de capa. Al VOLVER, el reverso: `avisarSalidaAbeja()` (señal
+   del host) la manda de vuelta al mismo punto y se apaga en CRUCE_SUELTA_MS,
+   donde el overlay 'volver' la retoma. El punto NO se estima con offsets a
+   ojo: se DES-PROYECTA de la cámara real de la escena (NDC → mundo), así el
+   empalme cae en el mismo píxel en cualquier arquetipo/zoom. */
 const CRUCE_ATRAPA_S = CRUCE_ATRAPA_MS / 1000;
+const CRUCE_SUELTA_S = CRUCE_SUELTA_MS / 1000;
 const CRUCE_PICADA_S = 1.6; // ventana post-atrape con lerp reforzado (el clavado)
 const CRUCE_EMPUJE = 2.6; // refuerzo del lerp durante la picada
-const CRUCE_ALTO = 2.6; // cuánto más alto nace sobre su percha
-const CRUCE_CERCA = 2.2; // cuánto más cerca de la cámara (z) nace
+const CRUCE_HUIDA = 0.24; // lerp de la salida (fuerte: la suelta es un suspiro)
+/* NDC-y del punto de atrape = el `top: 36%` del overlay: 1 − 2·0.36. Si el CSS
+   mueve el punto, mover ESTE número con él (una sola pareja de verdades). */
+const CRUCE_NDC_Y = 0.28;
+/* A qué profundidad (fracción de la distancia cámara→foco) vive el punto de
+   cruce sobre ese rayo de pantalla: cerca de la cámara para que el billboard
+   (que escala por distancia) nazca GRANDE como la 2D y encoja al clavarse. */
+const CRUCE_HONDO = 0.5;
+
+/* Temporales reutilizados por frame (cero alloc en el loop). */
+const _punto = new THREE.Vector3();
+const _dest = new THREE.Vector3();
+
+/* El punto de cruce en coordenadas de MUNDO: des-proyecta el píxel del overlay
+   (NDC x=0, y=CRUCE_NDC_Y) a un rayo de cámara y toma el punto del rayo a
+   CRUCE_HONDO de la distancia cámara→foco. */
+function puntoDeCruce(camera, foco, out) {
+  out.set(0, CRUCE_NDC_Y, 0.5).unproject(camera);
+  out.sub(camera.position).normalize();
+  return out.multiplyScalar(camera.position.distanceTo(foco) * CRUCE_HONDO)
+    .add(camera.position);
+}
 
 /**
- * Devuelve `{ ref, caraRef, sombraRef }` para colgar del `<group>` de la abeja,
- * de su cara (para el volteo) y de su sombra de contacto (el blob que la sigue
- * por el piso — auditoría 3D: la abeja no debe volar "a la deriva").
- * Corre `useFrame` (debe usarse DENTRO de un `<Canvas>`).
+ * Devuelve `{ ref, caraRef, sombraRef, visRef }` para colgar del `<group>` de
+ * la abeja, de su cara (para el volteo), de su sombra de contacto (el blob que
+ * la sigue por el piso — auditoría 3D: la abeja no debe volar "a la deriva") y
+ * del billboard DOM (la visibilidad del cruce). Corre `useFrame` (debe usarse
+ * DENTRO de un `<Canvas>`).
  *
  * @param {THREE.Vector3} foco  a dónde va la abeja (hotspot activo o centro).
  * @param {object} [opts]
@@ -56,22 +84,34 @@ const CRUCE_CERCA = 2.2; // cuánto más cerca de la cámara (z) nace
  * @param {object}  [opts.vuelo]  modificadores de reaccionDeFinca: mojada vuela
  *   más bajo/lento, sed baja a buscar agua, comiendo tiembla mordisqueando.
  *   `{ altura, velocidad, vagar, tiembla }` — multiplicadores (1 = vuelo normal).
- * @param {boolean} [opts.cruce=false]  el CRUCE 2D→3D: nace oculta, alta y
- *   cerca de la cámara, aparece en CRUCE_ATRAPA_MS (cuando la 2D del overlay
- *   se apaga) y baja en picada a su percha. `visRef` (devuelto) debe colgarse
- *   del billboard DOM para que la ocultación llegue al <Html> (drei no hereda
- *   la visibilidad del group al portal DOM).
+ * @param {boolean} [opts.cruce=false]  el CRUCE 2D→3D: nace oculta en el punto
+ *   de atrape (des-proyectado de la cámara), aparece en CRUCE_ATRAPA_MS
+ *   (cuando la 2D del overlay se apaga) y baja en picada a su percha. `visRef`
+ *   (devuelto) debe colgarse del billboard DOM para que la ocultación llegue
+ *   al <Html> (drei no hereda la visibilidad del group al portal DOM).
+ * @param {boolean} [opts.saliendo=false]  el reverso 3D→2D: vuela al punto de
+ *   suelta y se apaga en CRUCE_SUELTA_MS (el overlay 'volver' la retoma ahí).
  */
 export function useEntradaAbeja(foco, {
   entrando = true, energia = 1, reducedMotion = false, piso = 0, vuelo = VUELO_NEUTRO,
-  cruce = false,
+  cruce = false, saliendo = false,
 } = {}) {
   const ref = useRef(null);
   const caraRef = useRef(null);
   const sombraRef = useRef(null);
   const visRef = useRef(null);
   const nacioEn = useRef(null); // reloj del primer frame (ancla del cruce)
+  // Fase del cruce de entrada: 'oculta' (pre-atrape) → 'picada' → 'no'.
+  // Se decide UNA vez al nacer: si el mesh ya vive, cambiar props no re-cruza.
+  const fase = useRef(cruce && !reducedMotion ? 'oculta' : 'no');
+  const salioEn = useRef(null); // reloj del inicio de la salida
   const prevX = useRef(foco.x);
+  // Visibilidad del billboard DOM + su sombra (el <Html> de drei es un portal:
+  // no hereda `group.visible`, así que se apaga a mano por estilo).
+  const ponVis = (visible) => {
+    if (visRef.current) visRef.current.style.visibility = visible ? '' : 'hidden';
+    if (sombraRef.current) sombraRef.current.visible = visible;
+  };
   // Háptica de "posarse" (DR-3D-HAPTICA): UNA sola vez por foco, al cruzar el
   // umbral de llegada. El foco solo cambia por tap del usuario (hotspot) o al
   // montar la escena (que nace de un tap para entrar al mundo) → gesto-derivado.
@@ -80,6 +120,39 @@ export function useEntradaAbeja(foco, {
   useFrame((state) => {
     if (!ref.current) return;
     const t = state.clock.elapsedTime;
+    if (nacioEn.current === null) nacioEn.current = t;
+    const vida = t - nacioEn.current;
+
+    // ── SALIDA (cruce 3D→2D): la señal del host la manda de vuelta al punto de
+    //    suelta (el mismo píxel del overlay, des-proyectado de la cámara VIVA —
+    //    si el usuario orbitó, igual cae donde el 2D brota) y se apaga en
+    //    CRUCE_SUELTA_S. Con reduced-motion no hay viaje: el host corta en seco
+    //    y este mesh muere con la escena, visible hasta el final.
+    if (saliendo && !reducedMotion) {
+      if (fase.current === 'oculta') { ponVis(false); return; } // salió antes de nacer
+      if (salioEn.current === null) salioEn.current = t;
+      if (t - salioEn.current >= CRUCE_SUELTA_S) { ponVis(false); return; }
+      puntoDeCruce(state.camera, foco, _punto);
+      ref.current.position.lerp(_punto, CRUCE_HUIDA);
+      return; // sin vagar ni sombra: es un suspiro de 180 ms hacia la cámara
+    }
+    salioEn.current = null;
+
+    // ── ENTRADA (cruce 2D→3D): oculta y CLAVADA en el punto de atrape hasta el
+    //    instante exacto en que la 2D del overlay se apaga (CRUCE_ATRAPA_S desde
+    //    el montaje de la escena — el mismo ancla del overlay, que el host monta
+    //    con AlMontarEscena); entonces aparece y cae en PICADA (lerp reforzado)
+    //    hacia su percha de siempre. Una sola abeja cruzando de capa.
+    if (fase.current === 'oculta') {
+      puntoDeCruce(state.camera, foco, _punto);
+      ref.current.position.copy(_punto);
+      if (vida < CRUCE_ATRAPA_S) { ponVis(false); return; }
+      fase.current = 'picada';
+      ponVis(true);
+    } else if (fase.current === 'picada' && vida >= CRUCE_ATRAPA_S + CRUCE_PICADA_S) {
+      fase.current = 'no';
+    }
+    const empuje = fase.current === 'picada' ? CRUCE_EMPUJE : 1;
     // El estado de la finca modula el vuelo: mojada pesa (baja/lenta), sed baja a
     // buscar agua, comiendo tiembla mordisqueando. Multiplicadores de reaccionDeFinca.
     const mAltura = vuelo?.altura ?? 1;
@@ -87,20 +160,34 @@ export function useEntradaAbeja(foco, {
     const mVagar = vuelo?.vagar ?? 1;
     const tiembla = reducedMotion ? 0 : (vuelo?.tiembla ?? 0);
     const brio = (0.35 + 0.65 * energia) * mVel; // la energía y el clima animan el vuelo
-    const bob = reducedMotion ? 0 : Math.sin(t * (1.6 + brio)) * (0.06 + 0.12 * brio);
+    // Bob IRREGULAR (Miss-Minutes): el vaivén base respira sobre otra onda más
+    // lenta — nunca el mismo compás, la flotada se siente decidida, no de reloj.
+    const bob = reducedMotion
+      ? 0
+      : Math.sin(t * (1.6 + brio)) * (0.06 + 0.12 * brio) * (1 + 0.3 * Math.sin(t * 0.73));
     // Temblor de sed/mordisco: sacudida rápida y corta (nervio, no vaivén).
     const tembleque = tiembla ? Math.sin(t * 13) * tiembla : 0;
-    // Al reposo deriva en un círculo calmo; al entrar se posa junto al lugar.
-    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.55) * 0.6 * mVagar;
-    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.55) * 0.4 * mVagar;
+    // ARREBATO curioso: casi siempre 0; cada ~26 s la ventana del seno abre ~2 s
+    // y Angelita se escora de lado a fisgonear (double-take de vuelo) y vuelve.
+    // Suave por construcción (es el pico de un seno) — chispa, no epilepsia.
+    const arrebato = reducedMotion ? 0 : Math.max(0, Math.sin(t * 0.24) - 0.94) * 6 * mVagar;
+    // Al reposo deriva VAGABUNDA: tres ondas co-primas (nunca repite el mismo
+    // óvalo — ronda viva, impredecible). Al entrar se posa junto al lugar, con
+    // apenas un resto de arrebato (fisgonea sin soltar su percha).
+    const vagarX = reducedMotion || entrando
+      ? 0
+      : (Math.sin(t * 0.55) * 0.42 + Math.sin(t * 1.37) * 0.13 + Math.sin(t * 0.19) * 0.22) * mVagar;
+    const vagarZ = reducedMotion || entrando
+      ? 0
+      : (Math.cos(t * 0.55) * 0.3 + Math.sin(t * 0.83 + 1.7) * 0.14) * mVagar;
     // La altura sobre el foco se atenúa con `mAltura` (mojada/sed vuelan más bajo).
     const alto = (entrando ? 0.85 : 1.6) * mAltura;
-    const dest = new THREE.Vector3(
-      foco.x + (entrando ? 0.45 : 0.35 + vagarX) + tembleque,
-      foco.y + alto + bob + tembleque * 0.5,
+    const dest = _dest.set(
+      foco.x + (entrando ? 0.45 : 0.35 + vagarX) + tembleque + arrebato * (entrando ? 0.3 : 1),
+      foco.y + alto + bob + tembleque * 0.5 + arrebato * 0.18,
       foco.z + (entrando ? 0.6 : 0.55 + vagarZ),
     );
-    ref.current.position.lerp(dest, (entrando ? 0.06 : 0.05) * mVel);
+    ref.current.position.lerp(dest, (entrando ? 0.06 : 0.05) * mVel * empuje);
     // Angelita se posa: al cruzar el umbral de llegada al foco, un roce háptico
     // (una vez por foco — el ref evita repetir por frame; el gate del hook
     // apaga todo con reduced-motion, pref 'off' o sin soporte).
@@ -123,7 +210,7 @@ export function useEntradaAbeja(foco, {
       sombraRef.current.material.opacity = Math.max(0.06, 0.3 - h * 0.06);
     }
   });
-  return { ref, caraRef, sombraRef };
+  return { ref, caraRef, sombraRef, visRef };
 }
 
 /**
@@ -143,6 +230,11 @@ export function AbejaEscena({
   // 'bajo' Angelita apaga el idle continuo (boil + follow-through) y conserva
   // el aleteo + los estados reactivos. La escena lo hereda del host <Mundo>.
   tier = 'alto',
+  // El CRUCE 2D→3D corre por defecto: toda escena-mundo nace con Angelita
+  // clavándose desde la capa 2D (y aun sin el overlay cableado, la entrada en
+  // picada se sostiene sola). `cruce={false}` para montajes sin viaje
+  // (storybook, catálogo). Reduced-motion lo apaga por dentro (aparece ya).
+  cruce = true,
   // ── EL ESTADO REAL DE LA FINCA (auditoría §5b) ─────────────────────────────
   //    Angelita SIEMPRE refleja tu realidad: llueve→mojada, Niño/sequía→sed,
   //    cosecha→come de eso, ánimo por salud. Interfaz LIMPIA; hoy MUESTRA, codex
@@ -150,6 +242,15 @@ export function AbejaEscena({
   //    `animo`/`energia` sueltos de siempre (contrato viejo intacto).
   estadoFinca = null, hayAlerta = false,
 }) {
+  // La señal de SALIDA del host (avisarSalidaAbeja): cruza el reconciler de r3f
+  // vía store externo. Al montar se limpia (la señal es de la escena ANTERIOR);
+  // al desmontar también, para no dejar el flag prendido entre mundos.
+  const saliendo = useSalidaAbeja();
+  useEffect(() => {
+    resetSalidaAbeja();
+    return resetSalidaAbeja;
+  }, []);
+  const cruceVivo = cruce && !reducedMotion;
   // La CAPA de reacción (pura, desacoplada de la especie): del estado real sale
   // el ánimo, la energía, y el repertorio (mojada/sed/comiendo) + modificadores
   // de vuelo. Con estadoFinca manda la reacción; sin él, el contrato viejo.
@@ -162,8 +263,9 @@ export function AbejaEscena({
   const mojada = reaccion?.mojada ?? false;
   const sed = reaccion?.sed ?? false;
   const comiendo = reaccion?.comiendo ?? false;
-  const { ref, caraRef, sombraRef } = useEntradaAbeja(foco, {
+  const { ref, caraRef, sombraRef, visRef } = useEntradaAbeja(foco, {
     entrando, energia: energiaReal, reducedMotion, piso, vuelo: reaccion?.vuelo,
+    cruce: cruceVivo, saliendo,
   });
   // Microrrebote: cada toque de hotspot sube `rebote`; reiniciamos la animación
   // CSS (quitar → reflow → poner) para que dispare aun en toques seguidos. El
@@ -185,9 +287,14 @@ export function AbejaEscena({
       <group ref={ref} position={[foco.x + 0.45, foco.y + 0.85, foco.z + 0.6]}>
         <Html center distanceFactor={7} zIndexRange={[40, 10]}>
           {/* Reacción al estado real, también en el wrapper (brillo mojado,
-              temblor sediento, bamboleo de mordisco — rubber-hose). Gate RM. */}
+              temblor sediento, bamboleo de mordisco — rubber-hose). Gate RM.
+              `visRef` + visibility inicial: con cruce, el billboard nace oculto
+              (el estilo inline evita el flash del portal antes del primer
+              useFrame; después el hook lo maneja imperativo). */}
           <div
+            ref={visRef}
             className="mundo-abeja"
+            style={cruceVivo ? { visibility: 'hidden' } : undefined}
             aria-hidden="true"
             data-hablando={hablando && vivo ? '1' : undefined}
             data-mojada={mojada && vivo ? '1' : undefined}


### PR DESCRIPTION
## Qué es

Cierra la lógica del CRUCE 2D→3D empezada en `feat/angelita-viva-handoff` (agente caído; su commit f1a02f8d viene incluido): la Angelita 2D rubber-hose se clava hacia la escena al entrar a un mundo y el mesh 3D entra CRONOMETRADO desde la misma posición de pantalla — se lee como UNA sola abeja que voló de la capa DOM al mundo 3D. Reverso al volver al home.

## Cómo funciona

**Entrar (mesh, autónomo — ya activo sin cablear nada):**
- `useEntradaAbeja` nace con fase `oculta`: el mesh se clava en el **punto de atrape** — el píxel del overlay (centro, 36% de alto) **des-proyectado de la cámara real** (NDC→mundo, `puntoDeCruce()`), no offsets a ojo: el empalme cae en el mismo píxel en cualquier arquetipo/zoom.
- En `CRUCE_ATRAPA_MS` (760 ms, constante compartida con el overlay) aparece y cae en **picada** (lerp reforzado `CRUCE_EMPUJE` por `CRUCE_PICADA_S`) a su percha.
- El billboard `<Html>` de drei es un portal (no hereda `group.visible`): la ocultación va por `visRef` + estilo inline inicial (cero flash pre-primer-frame).

**Volver (señal host→mesh):**
- `avisarSalidaAbeja()` (`senalSalidaAbeja.js`, store externo con `useSyncExternalStore` — cruza el reconciler de r3f, sin tocar Mundo/EscenaBase3D) manda el mesh al punto de suelta; se apaga en `CRUCE_SUELTA_MS` (180 ms) mientras el overlay `volver` brota ahí (~100 ms): relevo con solape, sin hueco.
- La señal se auto-resetea en mount/unmount de `AbejaEscena`.

**Personalidad a 11 (cálida, nunca epiléptica):**
- Vuelo 3D: deriva vagabunda de tres ondas co-primas (nunca repite el óvalo), **arrebatos curiosos** cada ~26 s (ventana de ~2 s, suave por construcción), bob irregular sobre segunda onda.
- Idle 2D: **double-take de pupilas** (reojo → vistazo seco al otro lado → vuelve) y **wiggle Miss-Minutes** en `rh-travieso`; se suman a los antics del handoff (vuelta de campana, boil, parpadeo irregular, rubor).

**Gates:** `reducedMotion` → cruce apagado (mesh aparece al instante, overlay retorna null + `onFin` inmediato; idle congelado por CSS). `tier bajo` → cruce simple (posición+timing, sin barrel roll ni puff) e idle continuo apagado (CSS existente).

## Cableado pendiente (Opus — Mundo.jsx NO se tocó)

Documentado en `AbejaTransicion.jsx` § *CABLEADO EN EL HOST*, exportado también por `creatures/index.js`:
1. **Entrar**: `<AlMontarEscena onMonta={…}/>` dentro del `<Suspense>` de Mundo.jsx, hermano de la escena perezosa → montar `<AbejaTransicion sentido="entrar"/>` como overlay. (Sin esto, la entrada en picada del mesh igual se sostiene sola.)
2. **Volver**: en fase `regresando` (sin RM): `avisarSalidaAbeja()` + montar `<AbejaTransicion sentido="volver"/>`.

## Verificación

- `npm run build` exit 0 (síncrono, post-merge con dev).
- `vitest run src/visual` 38/38 verdes; suite completa pre-merge exit 0.
- ESLint de los archivos tocados: 0 problemas (señal movida a módulo propio por `react-refresh/only-export-components`).

Archivos: solo `src/visual/creatures/*` + `useEntradaAbeja.jsx` (diff contra dev verificado: 7 archivos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)