### PR TITLE
feat(3d): kit lenguaje de forma artesania andina (paleta + patrones + perfiles low-poly)

### DIFF
--- a/src/visual/mundo3d/ArtesaniaAndina.jsx
+++ b/src/visual/mundo3d/ArtesaniaAndina.jsx
@@ -1,0 +1,280 @@
+/*
+ * ArtesaniaAndina.jsx — PRIMITIVAS VISUALES del lenguaje "artesanía andina"
+ * (SVG, three-free, montables por props). La data/paleta/generadores viven en
+ * `artesaniaAndina.js`; aquí solo componentes (regla react-refresh).
+ *
+ * CABLEO (para quien integra; nada de esto está montado aún):
+ *
+ *   · Dentro de una lámina/espejo SVG existente (laminas2d/*): las primitivas
+ *     de banda son `<g>` — se posicionan con props x/y y viven dentro del
+ *     `<svg>` anfitrión. `<PatronesArtesania>` va UNA vez en el `<defs>` del
+ *     anfitrión y habilita fills `url(#artesania-rombos)` etc.
+ *
+ *   · Standalone (storybook / pantalla de estilo): montar `<ShowcaseArtesania>`
+ *     directo — es un `<svg>` completo y autocontenido.
+ *
+ *   · 3D: este archivo NO importa three. Las escenas consumen los perfiles
+ *     (`PERFILES_VASIJA` + `SEGMENTOS_VASIJA`) desde artesaniaAndina.js.
+ *
+ * Sin apropiación: solo geometría de telar (rombo/escalón/zigzag/franja) y
+ * paleta de tintes — ver el límite ético en artesaniaAndina.js.
+ */
+import {
+  ROLES_ANDINOS,
+  TRAZO_ANDINO,
+  MODULO_TELAR,
+  acentoAndino,
+  pathRombo,
+  pathsRomboAnidado,
+  pathZigzag,
+  pathGrecaEscalonada,
+  lineaQueRespira,
+  secuenciaFranjas,
+  pathVasija,
+  VASIJA_TIPOS,
+  PALETA_ANDINA,
+} from './artesaniaAndina.js';
+import './artesaniaAndina.css';
+
+const trazo = {
+  stroke: ROLES_ANDINOS.linea,
+  strokeLinecap: TRAZO_ANDINO.cap,
+  strokeLinejoin: TRAZO_ANDINO.join,
+};
+
+/**
+ * <PatronesArtesania> — los `<pattern>` reutilizables (rombos / zigzag /
+ * escalonado). Montar UNA vez dentro del `<defs>` del svg anfitrión; después
+ * cualquier figura se "teje" con fill={`url(#${prefijo}-rombos)`}.
+ * `prefijo` evita colisiones si hay varios svg en pantalla.
+ */
+export function PatronesArtesania({ prefijo = 'artesania', acento = 0 }) {
+  const m = MODULO_TELAR;
+  const color = acentoAndino(acento);
+  return (
+    <>
+      <pattern id={`${prefijo}-rombos`} width={m} height={m} patternUnits="userSpaceOnUse">
+        <path d={pathRombo(m / 2, m / 2, m * 0.32, m * 0.45)} fill={color} />
+        <path d={pathRombo(m / 2, m / 2, m * 0.14, m * 0.2)} fill={ROLES_ANDINOS.fondo} />
+      </pattern>
+      <pattern id={`${prefijo}-zigzag`} width={m} height={m / 2} patternUnits="userSpaceOnUse">
+        <path
+          d={pathZigzag({ x: 0, y: m * 0.36, ancho: m, alto: m * 0.22, dientes: 2 })}
+          fill="none"
+          strokeWidth={TRAZO_ANDINO.fino}
+          {...trazo}
+          stroke={color}
+        />
+      </pattern>
+      <pattern id={`${prefijo}-escalonado`} width={m * 1.5} height={m} patternUnits="userSpaceOnUse">
+        <path d={pathGrecaEscalonada({ x: m * 0.15, y: m * 0.85, paso: m * 0.2, niveles: 3 })} fill={color} />
+      </pattern>
+    </>
+  );
+}
+
+/**
+ * <BandaChumbe> — banda tejida de rombos anidados (la cinta que remata un
+ * marco, un borde de mundo, el cinturón de una criatura). `<g>` posicionable.
+ */
+export function BandaChumbe({ x = 0, y = 0, ancho = MODULO_TELAR * 8, alto = MODULO_TELAR, acento = 0, conBorde = true }) {
+  const n = Math.max(1, Math.round(ancho / (alto * 1.6)));
+  const paso = ancho / n;
+  const rombos = [];
+  for (let i = 0; i < n; i += 1) {
+    const cx = paso * (i + 0.5);
+    pathsRomboAnidado(cx, alto / 2, paso * 0.44, alto * 0.42, 3).forEach((d, nivel) => {
+      rombos.push(
+        <path
+          key={`${i}-${nivel}`}
+          d={d}
+          fill={nivel % 2 === 0 ? acentoAndino(acento + nivel + i) : ROLES_ANDINOS.papel}
+        />,
+      );
+    });
+  }
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      <rect width={ancho} height={alto} fill={ROLES_ANDINOS.fondo} />
+      {rombos}
+      {conBorde && (
+        <>
+          <path d={lineaQueRespira(0, 0, ancho, 0, { seed: 11 })} fill="none" strokeWidth={TRAZO_ANDINO.grosor} {...trazo} />
+          <path d={lineaQueRespira(0, alto, ancho, alto, { seed: 23 })} fill="none" strokeWidth={TRAZO_ANDINO.grosor} {...trazo} />
+        </>
+      )}
+    </g>
+  );
+}
+
+/**
+ * <GrecaEscalonada> — fila de pirámides escalonadas (remate de horizonte,
+ * borde inferior de un espejo 2D). `<g>` posicionable.
+ */
+export function GrecaEscalonada({ x = 0, y = 0, ancho = MODULO_TELAR * 8, paso = 8, niveles = 3, acento = 0 }) {
+  const anchoGreca = paso * niveles * 2;
+  const n = Math.max(1, Math.floor(ancho / (anchoGreca + paso)));
+  const piezas = [];
+  for (let i = 0; i < n; i += 1) {
+    piezas.push(
+      <path
+        key={i}
+        d={pathGrecaEscalonada({ x: i * (anchoGreca + paso), y: 0, paso, niveles })}
+        fill={acentoAndino(acento + i)}
+      />,
+    );
+  }
+  return <g transform={`translate(${x} ${y})`}>{piezas}</g>;
+}
+
+/**
+ * <FranjasMochila> — bloque de franjas rítmicas (fondos de tarjeta, cuerpos
+ * de criatura, laderas). Determinista por `seed`. `<g>` posicionable.
+ */
+export function FranjasMochila({ x = 0, y = 0, ancho = MODULO_TELAR * 6, alto = MODULO_TELAR * 5, seed = 7 }) {
+  const franjas = secuenciaFranjas({ alto, seed });
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      {franjas.map((f, i) => (
+        <rect key={i} x={0} y={f.y} width={ancho} height={f.alto} fill={f.color} />
+      ))}
+    </g>
+  );
+}
+
+/**
+ * <MarcoTelar> — el marco de tarjeta/mundo: rectángulo de línea que respira
+ * + banda chumbe arriba y greca abajo. Envuelve contenido ajeno (children se
+ * pintan en el hueco interior, en coordenadas del marco).
+ */
+export function MarcoTelar({ x = 0, y = 0, ancho = 320, alto = 200, acento = 0, children }) {
+  const banda = MODULO_TELAR * 0.75;
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      <rect width={ancho} height={alto} rx={10} fill={ROLES_ANDINOS.papel} />
+      <BandaChumbe x={8} y={6} ancho={ancho - 16} alto={banda} acento={acento} conBorde={false} />
+      <GrecaEscalonada x={12} y={alto - 8} ancho={ancho - 24} paso={5} niveles={2} acento={acento + 1} />
+      <g transform={`translate(0 ${banda + 10})`}>{children}</g>
+      {[0, 1].map((i) => (
+        <path
+          key={i}
+          d={
+            i === 0
+              ? lineaQueRespira(4, 4, ancho - 4, 4, { seed: 31 }) + ` L ${ancho - 4} ${alto - 4}`
+              : lineaQueRespira(ancho - 4, alto - 4, 4, alto - 4, { seed: 43 }) + ` L 4 4`
+          }
+          fill="none"
+          strokeWidth={TRAZO_ANDINO.grosor}
+          {...trazo}
+        />
+      ))}
+    </g>
+  );
+}
+
+/**
+ * <VasijaSilueta> — cerámica low-poly en 2D desde el MISMO perfil que usa el
+ * lathe 3D (la silueta no diverge entre dimensiones). Con cinturón chumbe
+ * opcional en la panza. `tipo`: 'olla' | 'cantaro' | 'cuenco'.
+ */
+export function VasijaSilueta({ x = 0, y = 0, alto = 64, tipo = 'olla', acento = 0, conCinturon = true }) {
+  const d = pathVasija(tipo, { cx: 0, cy: 0, alto });
+  const cinturonY = -alto * 0.45;
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      <path d={d} fill={acentoAndino(acento)} strokeWidth={TRAZO_ANDINO.grosor} {...trazo} />
+      {conCinturon && (
+        <path
+          d={pathZigzag({ x: -alto * 0.36, y: cinturonY, ancho: alto * 0.72, alto: alto * 0.08, dientes: 5 })}
+          fill="none"
+          opacity={0.9}
+          strokeWidth={TRAZO_ANDINO.fino}
+          {...trazo}
+          stroke={ROLES_ANDINOS.papel}
+        />
+      )}
+    </g>
+  );
+}
+
+/* Un rótulo pequeño del showcase (estilo compartido). */
+function Rotulo({ x, y, children }) {
+  return (
+    <text x={x} y={y} className="artesania-rotulo">
+      {children}
+    </text>
+  );
+}
+
+/**
+ * <ShowcaseArtesania> — el muestrario autocontenido del lenguaje de forma:
+ * paleta, trazo, patrones, bandas, marco y vasijas. Montable tal cual en un
+ * storybook o pantalla de estilo (`<svg>` completo, responsive por viewBox).
+ */
+export default function ShowcaseArtesania({ ancho = 720 }) {
+  const W = 720;
+  const H = 560;
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      width={ancho}
+      className="artesania-showcase"
+      role="img"
+      aria-label="Muestrario del lenguaje de forma de la artesania andina"
+    >
+      <defs>
+        <PatronesArtesania prefijo="artesania" />
+      </defs>
+      <rect width={W} height={H} fill={ROLES_ANDINOS.fondo} rx={16} />
+
+      {/* título con línea que respira */}
+      <Rotulo x={24} y={36}>lenguaje de forma — telar andino ✕ rubber-hose</Rotulo>
+      <path d={lineaQueRespira(24, 46, W - 24, 46, { ondas: 8, seed: 5 })} fill="none" strokeWidth={TRAZO_ANDINO.grosor} stroke={ROLES_ANDINOS.linea} strokeLinecap="round" />
+
+      {/* fila 1: paleta */}
+      {Object.entries(PALETA_ANDINA).map(([nombre, color], i) => (
+        <g key={nombre} transform={`translate(${24 + i * 76} 62)`}>
+          <rect width={64} height={30} rx={8} fill={color} strokeWidth={TRAZO_ANDINO.fino} stroke={ROLES_ANDINOS.linea} />
+          <Rotulo x={0} y={44}>{nombre}</Rotulo>
+        </g>
+      ))}
+
+      {/* fila 2: bandas tejidas */}
+      <Rotulo x={24} y={132}>chumbe (rombos anidados)</Rotulo>
+      <BandaChumbe x={24} y={140} ancho={320} alto={30} />
+      <Rotulo x={376} y={132}>greca escalonada</Rotulo>
+      <GrecaEscalonada x={376} y={170} ancho={320} paso={9} niveles={3} acento={2} />
+      <Rotulo x={24} y={204}>zigzag / rombos / escalonado como fill de patron</Rotulo>
+      <rect x={24} y={212} width={100} height={56} rx={8} fill="url(#artesania-zigzag)" strokeWidth={TRAZO_ANDINO.fino} stroke={ROLES_ANDINOS.linea} />
+      <rect x={134} y={212} width={100} height={56} rx={8} fill="url(#artesania-rombos)" strokeWidth={TRAZO_ANDINO.fino} stroke={ROLES_ANDINOS.linea} />
+      <rect x={244} y={212} width={100} height={56} rx={8} fill="url(#artesania-escalonado)" strokeWidth={TRAZO_ANDINO.fino} stroke={ROLES_ANDINOS.linea} />
+
+      {/* fila 2b: franjas */}
+      <Rotulo x={376} y={204}>franjas ritmicas (deterministas por seed)</Rotulo>
+      <FranjasMochila x={376} y={212} ancho={150} alto={56} seed={7} />
+      <FranjasMochila x={546} y={212} ancho={150} alto={56} seed={19} />
+
+      {/* fila 3: marco de tarjeta + medallón que respira */}
+      <MarcoTelar x={24} y={292} ancho={320} alto={180} acento={1}>
+        <Rotulo x={16} y={30}>marco telar para tarjetas y espejos 2d</Rotulo>
+        <g transform="translate(160 92)" className="artesania-respira">
+          {pathsRomboAnidado(0, 0, 74, 48, 4).map((d, i) => (
+            <path key={i} d={d} fill={i % 2 === 0 ? acentoAndino(i) : ROLES_ANDINOS.papel} strokeWidth={i === 0 ? TRAZO_ANDINO.grosor : 0} stroke={ROLES_ANDINOS.linea} strokeLinejoin="round" />
+          ))}
+        </g>
+      </MarcoTelar>
+
+      {/* fila 3b: vasijas — mismo perfil que el lathe 3D */}
+      <Rotulo x={376} y={302}>ceramica low-poly (perfil compartido 2d ↔ 3d)</Rotulo>
+      {VASIJA_TIPOS.map((tipo, i) => (
+        <g key={tipo}>
+          <VasijaSilueta x={430 + i * 110} y={430} alto={96} tipo={tipo} acento={i} />
+          <Rotulo x={402 + i * 110} y={452}>{tipo}</Rotulo>
+        </g>
+      ))}
+
+      {/* pie: greca de cierre */}
+      <GrecaEscalonada x={24} y={H - 24} ancho={W - 48} paso={7} niveles={3} acento={3} />
+    </svg>
+  );
+}

--- a/src/visual/mundo3d/__tests__/artesania.smoke.test.jsx
+++ b/src/visual/mundo3d/__tests__/artesania.smoke.test.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import ShowcaseArtesania, {
+  PatronesArtesania,
+  BandaChumbe,
+  GrecaEscalonada,
+  FranjasMochila,
+  MarcoTelar,
+  VasijaSilueta,
+} from '../ArtesaniaAndina.jsx';
+import {
+  PALETA_ANDINA,
+  ROLES_ANDINOS,
+  acentoAndino,
+  secuenciaFranjas,
+  pathVasija,
+  pathGrecaEscalonada,
+  lineaQueRespira,
+  VASIJA_TIPOS,
+} from '../artesaniaAndina.js';
+
+afterEach(() => cleanup());
+
+describe('artesanía andina — generadores puros (three-free)', () => {
+  test('paleta y roles: fondo/línea empatan con el mundo, 5 acentos cíclicos', () => {
+    expect(ROLES_ANDINOS.fondo).toBe(PALETA_ANDINA.crudo);
+    expect(ROLES_ANDINOS.linea).toBe(PALETA_ANDINA.tinta);
+    expect(ROLES_ANDINOS.acentos).toHaveLength(5);
+    expect(acentoAndino(0)).toBe(acentoAndino(5));
+    expect(acentoAndino(-1)).toBe(ROLES_ANDINOS.acentos[4]);
+  });
+
+  test('franjas: deterministas por seed y llenan el alto exacto', () => {
+    const a = secuenciaFranjas({ alto: 120, seed: 7 });
+    const b = secuenciaFranjas({ alto: 120, seed: 7 });
+    const c = secuenciaFranjas({ alto: 120, seed: 19 });
+    expect(a).toEqual(b);
+    expect(a).not.toEqual(c);
+    expect(a.reduce((s, f) => s + f.alto, 0)).toBeCloseTo(120);
+  });
+
+  test('paths: vasijas (todos los perfiles) y greca cierran; la línea respira con Q', () => {
+    VASIJA_TIPOS.forEach((tipo) => {
+      const d = pathVasija(tipo, { alto: 60 });
+      expect(d.startsWith('M ')).toBe(true);
+      expect(d.endsWith('Z')).toBe(true);
+    });
+    expect(pathGrecaEscalonada({}).endsWith('Z')).toBe(true);
+    expect(lineaQueRespira(0, 0, 100, 0, { ondas: 3 })).toContain('Q');
+    expect(lineaQueRespira(0, 0, 100, 0, { seed: 7 })).toBe(lineaQueRespira(0, 0, 100, 0, { seed: 7 }));
+  });
+});
+
+describe('artesanía andina — primitivas SVG montables', () => {
+  test('el showcase monta completo: patrones en defs, rombos y las 3 vasijas', () => {
+    const { container } = render(<ShowcaseArtesania ancho={720} />);
+    const svg = container.querySelector('svg.artesania-showcase');
+    expect(svg).toBeInTheDocument();
+    expect(container.querySelector('#artesania-rombos')).toBeInTheDocument();
+    expect(container.querySelector('#artesania-zigzag')).toBeInTheDocument();
+    expect(container.querySelector('#artesania-escalonado')).toBeInTheDocument();
+    expect(container.querySelector('.artesania-respira')).toBeInTheDocument();
+    expect(container.querySelectorAll('path').length).toBeGreaterThan(20);
+  });
+
+  test('cada primitiva es un <g> montable por props dentro de un svg anfitrión', () => {
+    const { container } = render(
+      <svg viewBox="0 0 400 400">
+        <defs>
+          <PatronesArtesania prefijo="p1" />
+        </defs>
+        <BandaChumbe x={10} y={10} ancho={200} alto={24} />
+        <GrecaEscalonada x={10} y={80} ancho={200} />
+        <FranjasMochila x={10} y={100} ancho={100} alto={80} seed={3} />
+        <MarcoTelar x={120} y={100} ancho={200} alto={120} />
+        <VasijaSilueta x={60} y={360} alto={80} tipo="cantaro" />
+      </svg>,
+    );
+    expect(container.querySelector('#p1-rombos')).toBeInTheDocument();
+    expect(container.querySelectorAll('g').length).toBeGreaterThan(5);
+    expect(container.querySelectorAll('rect').length).toBeGreaterThan(4);
+  });
+});

--- a/src/visual/mundo3d/artesaniaAndina.css
+++ b/src/visual/mundo3d/artesaniaAndina.css
@@ -1,0 +1,43 @@
+/*
+ * artesaniaAndina.css — estilos del kit "artesanía andina". Autocontenido:
+ * cero imágenes/fuentes externas; SOLO transform animado (norte rubber-hose:
+ * squash & stretch sutil), apagado bajo reduced-motion.
+ */
+
+.artesania-showcase {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.artesania-rotulo {
+  font: 600 11px/1.2 system-ui, sans-serif;
+  letter-spacing: 0.04em;
+  fill: #2a2016;
+}
+
+/* La respiración rubber-hose: squash & stretch leve con overshoot. */
+.artesania-respira {
+  animation: artesania-respira 2.4s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+@keyframes artesania-respira {
+  0%,
+  100% {
+    transform: scale(1, 1);
+  }
+  40% {
+    transform: scale(1.04, 0.965);
+  }
+  60% {
+    transform: scale(0.975, 1.035);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .artesania-respira {
+    animation: none;
+  }
+}

--- a/src/visual/mundo3d/artesaniaAndina.js
+++ b/src/visual/mundo3d/artesaniaAndina.js
@@ -1,0 +1,237 @@
+/*
+ * artesaniaAndina.js — EL LENGUAJE DE FORMA "ARTESANÍA ANDINA" (tokens + paleta
+ * + generadores de patrón + perfiles low-poly). Three-free: seguro en el bundle
+ * base, importable desde cualquier lámina 2D o escena 3D.
+ *
+ * QUÉ ES (FASE 4, pulido premium): un kit REUTILIZABLE de siluetas y patrones
+ * inspirados en la artesanía andina colombiana — la geometría del telar (rombos,
+ * zigzag, grecas escalonadas), las franjas rítmicas de la mochila, el perfil de
+ * la cerámica — fusionado con el norte rubber-hose (línea gruesa que respira,
+ * terminales redondas, squash & stretch). Da identidad coherente a mundos y
+ * criaturas sin dibujar cada asset desde cero.
+ *
+ * LÍMITE ÉTICO (sin apropiación): SOLO formas geométricas abstractas y paleta
+ * de tintes naturales. NADA de iconografía sagrada, símbolos rituales ni
+ * motivos identitarios de un pueblo específico (no soles rituales, no figuras
+ * antropo/zoomorfas de tradición, no nombres de clanes). Rombo, escalón, franja
+ * y zigzag son vocabulario geométrico universal del telar.
+ *
+ * CÓMO SE CONSUME (el cableo lo hace quien integra):
+ *
+ *   · 2D (SVG): los generadores devuelven `d` de path o listas de datos.
+ *     Las primitivas listas viven en `ArtesaniaAndina.jsx` (mismo folder).
+ *
+ *   · 3D (R3F, dentro de `escenas/` — perezoso, chunk vendor-three):
+ *       const pts = PERFILES_VASIJA.olla.map(([r, y]) => new THREE.Vector2(r * ESCALA, y * ALTO));
+ *       <mesh><latheGeometry args={[pts, SEGMENTOS_VASIJA]} /><meshLambertMaterial color={PALETA_ANDINA.terracota} /></mesh>
+ *     Perf (DR §6): Lambert/Basic, sin sombras, segmentos acotados.
+ *
+ * Determinismo: todo generador con azar recibe `seed` (mismo tejido siempre).
+ */
+
+// ── PALETA — tintes naturales del textil andino ────────────────────────────
+// Nombres por MATERIA de tinte/fibra, no por símbolo. `crudo` y `tinta`
+// empatan a propósito con el fondo y la línea ya usados por mundo.css.
+export const PALETA_ANDINA = {
+  crudo: '#ece0c7', // fique/lana sin teñir — el fondo del mundo
+  hueso: '#f6efe0', // algodón claro — papel de las láminas
+  tinta: '#2a2016', // negro humo — LA línea rubber-hose
+  terracota: '#b4572e', // barro cocido — cerámica
+  cochinilla: '#973128', // rojo de tinte animal — acento cálido fuerte
+  maiz: '#d9a441', // amarillo dorado — acento luminoso
+  paramo: '#5d7a4b', // verde frailejonal apagado — acento vegetal
+  anil: '#33507a', // azul de añil — acento frío
+  mora: '#6b4a5e', // morado de fruto — acento raro (úselo poco)
+};
+
+// Roles listos: quién es fondo, quién es línea, y el ciclo de acentos en el
+// ORDEN rítmico del textil (cálido → luminoso → frío → vegetal → raro).
+export const ROLES_ANDINOS = {
+  fondo: PALETA_ANDINA.crudo,
+  papel: PALETA_ANDINA.hueso,
+  linea: PALETA_ANDINA.tinta,
+  acentos: [
+    PALETA_ANDINA.terracota,
+    PALETA_ANDINA.maiz,
+    PALETA_ANDINA.anil,
+    PALETA_ANDINA.paramo,
+    PALETA_ANDINA.cochinilla,
+  ],
+};
+
+/** Acento cíclico i → color (para series: franjas, criaturas, mundos). */
+export function acentoAndino(i) {
+  const a = ROLES_ANDINOS.acentos;
+  return a[((i % a.length) + a.length) % a.length];
+}
+
+// ── TRAZO — la línea rubber-hose (Cuphead / Miss Minutes) ──────────────────
+// Terminales y uniones SIEMPRE redondas; dos grosores (estructura vs detalle);
+// `respiracion` es la amplitud de ondulación de `lineaQueRespira`.
+export const TRAZO_ANDINO = {
+  grosor: 3, // contorno estructural
+  fino: 1.4, // detalle interior / hifas del patrón
+  cap: 'round',
+  join: 'round',
+  respiracion: 1.6, // px de vaivén de la línea viva
+};
+
+// El módulo del telar: la baldosa base de todo patrón repetible (px en SVG,
+// unidades de mundo en 3D). Múltiplos de MODULO_TELAR mantienen los patrones
+// en fase cuando se yuxtaponen bandas.
+export const MODULO_TELAR = 24;
+
+// ── PRNG determinista (misma receta LCG de las escenas del framework) ──────
+export function rngArtesania(seed = 7) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+// ── GENERADORES DE PATRÓN (puros → `d` de SVG path) ────────────────────────
+
+/** Un rombo (la unidad madre del telar): centro (cx,cy), semiejes rw/rh. */
+export function pathRombo(cx, cy, rw, rh) {
+  return `M ${cx} ${cy - rh} L ${cx + rw} ${cy} L ${cx} ${cy + rh} L ${cx - rw} ${cy} Z`;
+}
+
+/**
+ * Rombos ANIDADOS (el "ojo" del chumbe, leído solo como geometría): niveles
+ * concéntricos que encogen. Devuelve UNA `d` por nivel (afuera → adentro),
+ * para alternar color por índice con `acentoAndino(i)`.
+ */
+export function pathsRomboAnidado(cx, cy, rw, rh, niveles = 3) {
+  const out = [];
+  for (let i = 0; i < niveles; i += 1) {
+    const f = 1 - i / niveles;
+    out.push(pathRombo(cx, cy, rw * f, rh * f));
+  }
+  return out;
+}
+
+/**
+ * Zigzag de telar (polilínea abierta, para stroke): `dientes` picos de `alto`
+ * a lo largo de `ancho`, arrancando en (x, y). El pico va hacia ARRIBA.
+ */
+export function pathZigzag({ x = 0, y = 0, ancho = MODULO_TELAR * 4, alto = 10, dientes = 4 } = {}) {
+  const paso = ancho / dientes;
+  let d = `M ${x} ${y}`;
+  for (let i = 0; i < dientes; i += 1) {
+    d += ` L ${x + paso * (i + 0.5)} ${y - alto} L ${x + paso * (i + 1)} ${y}`;
+  }
+  return d;
+}
+
+/**
+ * Greca ESCALONADA (pirámide de escalones, subida y bajada): la escalera del
+ * telar como pura geometría. Path CERRADO para fill; base en (x, y), cada
+ * escalón mide `paso` × `paso`, `niveles` escalones por lado.
+ */
+export function pathGrecaEscalonada({ x = 0, y = 0, paso = 8, niveles = 3 } = {}) {
+  let d = `M ${x} ${y}`;
+  let px = x;
+  let py = y;
+  for (let i = 0; i < niveles; i += 1) {
+    py -= paso;
+    d += ` L ${px} ${py}`;
+    px += paso;
+    d += ` L ${px} ${py}`;
+  }
+  for (let i = 0; i < niveles; i += 1) {
+    px += paso;
+    d += ` L ${px} ${py}`;
+    py += paso;
+    d += ` L ${px} ${py}`;
+  }
+  return `${d} Z`;
+}
+
+/**
+ * La LÍNEA QUE RESPIRA (rubber-hose): un trazo recto es un trazo muerto. Esta
+ * devuelve el path de (x1,y1)→(x2,y2) ondulado con `ondas` curvas cuadráticas
+ * de amplitud ±`amplitud` (default: TRAZO_ANDINO.respiracion), determinista
+ * por `seed`. Úsela para contornos de marcos, tallos, horizontes.
+ */
+export function lineaQueRespira(x1, y1, x2, y2, { amplitud = TRAZO_ANDINO.respiracion, ondas = 4, seed = 7 } = {}) {
+  const r = rngArtesania(seed);
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const largo = Math.hypot(dx, dy) || 1;
+  const nx = -dy / largo; // perpendicular unitaria
+  const ny = dx / largo;
+  let d = `M ${x1} ${y1}`;
+  for (let i = 0; i < ondas; i += 1) {
+    const t1 = (i + 0.5) / ondas;
+    const t2 = (i + 1) / ondas;
+    const lado = (i % 2 === 0 ? 1 : -1) * (0.6 + r() * 0.8);
+    const cx = x1 + dx * t1 + nx * amplitud * lado;
+    const cy = y1 + dy * t1 + ny * amplitud * lado;
+    d += ` Q ${cx.toFixed(2)} ${cy.toFixed(2)} ${(x1 + dx * t2).toFixed(2)} ${(y1 + dy * t2).toFixed(2)}`;
+  }
+  return d;
+}
+
+/**
+ * FRANJAS rítmicas (el compás de la mochila, leído solo como ritmo de color):
+ * llena `alto` con bandas horizontales { y, alto, color } alternando bandas
+ * anchas de acento con separadores finos de tinta/crudo. Determinista por
+ * `seed`; `colores` (default ROLES_ANDINOS.acentos) cicla en orden.
+ */
+export function secuenciaFranjas({ alto = MODULO_TELAR * 5, colores = ROLES_ANDINOS.acentos, seed = 7 } = {}) {
+  const r = rngArtesania(seed);
+  const franjas = [];
+  let y = 0;
+  let i = 0;
+  while (y < alto) {
+    const ancha = Math.min(alto - y, MODULO_TELAR * (0.6 + r() * 0.9));
+    franjas.push({ y, alto: ancha, color: colores[i % colores.length] });
+    y += ancha;
+    if (y >= alto) break;
+    const fina = Math.min(alto - y, MODULO_TELAR * 0.16);
+    franjas.push({ y, alto: fina, color: i % 2 === 0 ? ROLES_ANDINOS.linea : ROLES_ANDINOS.papel });
+    y += fina;
+    i += 1;
+  }
+  return franjas;
+}
+
+// ── PERFILES LOW-POLY DE CERÁMICA (una fuente de forma, 2D Y 3D) ───────────
+// Pares [radio, y] normalizados (y ∈ 0..1, radio relativo al alto). Pocos
+// puntos A PROPÓSITO: el facetado ES el estilo low-poly. La MISMA tabla
+// alimenta `latheGeometry` en 3D y `pathVasija` en 2D — la silueta nunca
+// diverge entre dimensiones. Formas genéricas de alfarería (olla / cántaro /
+// cuenco), sin referencia a piezas rituales.
+export const PERFILES_VASIJA = {
+  olla: [
+    [0, 0], [0.3, 0.02], [0.46, 0.18], [0.5, 0.42], [0.42, 0.66],
+    [0.3, 0.78], [0.32, 0.88], [0.37, 0.95], [0.35, 1],
+  ],
+  cantaro: [
+    [0, 0], [0.26, 0.02], [0.44, 0.22], [0.48, 0.46], [0.36, 0.68],
+    [0.18, 0.8], [0.16, 0.92], [0.23, 0.97], [0.21, 1],
+  ],
+  cuenco: [
+    [0, 0], [0.34, 0.03], [0.52, 0.35], [0.62, 0.75], [0.66, 0.9], [0.62, 1],
+  ],
+};
+
+/** Segmentos radiales del lathe: 10 = facetado visible (el look, no un bug). */
+export const SEGMENTOS_VASIJA = 10;
+
+/**
+ * Silueta 2D de una vasija desde el MISMO perfil del lathe: path cerrado
+ * facetado (lado derecho + espejo izquierdo). `base` es el punto de apoyo
+ * (cx, cy en coordenadas SVG, y crece hacia abajo).
+ */
+export function pathVasija(tipo = 'olla', { cx = 0, cy = 0, alto = 60 } = {}) {
+  const perfil = PERFILES_VASIJA[tipo] || PERFILES_VASIJA.olla;
+  const derecha = perfil.map(([pr, py]) => [cx + pr * alto, cy - py * alto]);
+  const izquierda = [...perfil].reverse().map(([pr, py]) => [cx - pr * alto, cy - py * alto]);
+  const pts = [...derecha, ...izquierda];
+  return `M ${pts.map(([px, py]) => `${px.toFixed(2)} ${py.toFixed(2)}`).join(' L ')} Z`;
+}
+
+/** Claves de perfil disponibles, en orden canónico. */
+export const VASIJA_TIPOS = Object.keys(PERFILES_VASIJA);


### PR DESCRIPTION
## Que es (FASE 4 pulido premium)

Kit reutilizable **three-free** que define el lenguaje de forma "artesania andina" para mundos y criaturas 2D/3D: geometria de telar (rombos anidados, grecas escalonadas, zigzag, franjas ritmicas) + perfiles de ceramica low-poly + paleta de tintes naturales, fusionado con el norte rubber-hose (linea que respira, terminales redondas, squash & stretch sutil).

**Limite etico documentado en el kit**: solo geometria abstracta y paleta — nada de iconografia sagrada ni motivos identitarios de un pueblo especifico.

## Archivos (SOLO nuevos, nada existente tocado)

- `src/visual/mundo3d/artesaniaAndina.js` — paleta (`PALETA_ANDINA`/`ROLES_ANDINOS`), tokens de trazo (`TRAZO_ANDINO`, `MODULO_TELAR`), generadores deterministas de patron (paths SVG: rombo, chumbe anidado, zigzag, greca, linea-que-respira, franjas) y perfiles `PERFILES_VASIJA` compartidos 2D<->3D (listos para `latheGeometry`, sin importar three).
- `src/visual/mundo3d/ArtesaniaAndina.jsx` — primitivas SVG montables por props: `PatronesArtesania` (defs de pattern), `BandaChumbe`, `GrecaEscalonada`, `FranjasMochila`, `MarcoTelar`, `VasijaSilueta` + `ShowcaseArtesania` (muestrario svg autocontenido, default export).
- `src/visual/mundo3d/artesaniaAndina.css` — rotulos + animacion respiracion (solo transform; off bajo `prefers-reduced-motion`).
- `src/visual/mundo3d/__tests__/artesania.smoke.test.jsx` — 5 casos.

## Cableo pendiente (para quien integra; documentado en cabeceras)

- Montar `<ShowcaseArtesania />` en el storybook/pantalla de estilo para verlo.
- En laminas/espejos 2D existentes: `<PatronesArtesania>` una vez en `<defs>` del svg anfitrion; las bandas son `<g>` posicionables por x/y.
- En escenas 3D (perezoso, vendor-three): `PERFILES_VASIJA.olla.map(([r,y]) => new THREE.Vector2(r*E, y*A))` -> `<latheGeometry args={[pts, SEGMENTOS_VASIJA]} />` con `meshLambertMaterial` (perf DR §6).
- El barrel `index.js` NO fue tocado (regla solo-archivos-nuevos); si se quiere exportar desde ahi, es un cambio de una linea three-free.

## Verificacion

- `eslint --max-warnings 0` sobre los 3 archivos JS/JSX: limpio (regla i18n incluida, sin disables).
- `vitest run` del smoke: **5/5 verdes** (generadores puros deterministas + render de showcase y primitivas en jsdom).
- `npm run build` completo: **exit 0** (20s; warnings de chunk preexistentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)