### PR TITLE
feat(3d): vitrina showcase de criaturas y mundos sin cablear

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -146,6 +146,7 @@ const DiagnosticoSobreFoto = lazy(() => import('./mockups/DiagnosticoSobreFoto')
 const EvidenciaIlustrada = lazy(() => import('./mockups/EvidenciaIlustrada'));
 const MockupGuardianesNarrativos = lazy(() => import('./mockups/MockupGuardianesNarrativos'));
 const HojaVidaMataMockup = lazy(() => import('./components/mockups/HojaVidaMataMockup'));
+const VitrinaCriaturasMockup = lazy(() => import('./mockups/vitrina3d/VitrinaCriaturas'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
@@ -536,6 +537,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo3d-semillero': 'mockup_mundo3d_semillero',
   'mockups/infraestructura-3d': 'mockup_infraestructura_3d',
   'mockups/colocar-infraestructura': 'mockup_colocar_infraestructura',
+  'mockups/vitrina-3d': 'mockup_vitrina_3d',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1701,6 +1703,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Colocar su infraestructura">
               <ColocarInfraestructuraMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_vitrina_3d':
+        // Vitrina/showcase de los componentes visuales nuevos que quedaron en
+        // src/visual/ sin cablear (criaturas rubber-hose, micro-fauna del suelo,
+        // ciclo de la mata, escarcha/valle, hilo de vida, onboarding descubrir).
+        // Galería navegable con controles de tier/movimiento/estado para que el
+        // operador los vea vivos y dé feedback. Ruta #/mockups/vitrina-3d, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Vitrina de criaturas y mundos">
+              <VitrinaCriaturasMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/vitrina3d/VitrinaCriaturas.css
+++ b/src/mockups/vitrina3d/VitrinaCriaturas.css
@@ -1,0 +1,436 @@
+/*
+ * VitrinaCriaturas.css — cuaderno de laboratorio andino.
+ * Crema tibia, tinta profunda, verde páramo. Mobile-first (320px), aprovecha
+ * el escritorio con una grilla fluida. Solo transform/opacity animados.
+ */
+
+.vitrina {
+  --v-crema: #fbf5e9;
+  --v-crema-2: #f4ead4;
+  --v-tinta: #2a2016;
+  --v-tinta-suave: #6b5c46;
+  --v-verde: #3f8f4e;
+  --v-verde-hondo: #2f6d43;
+  --v-borde: #e3d5b8;
+  --v-sombra: rgba(58, 44, 22, 0.14);
+
+  min-height: 100vh;
+  min-height: 100dvh;
+  background:
+    radial-gradient(120% 80% at 50% -10%, #fffaf0 0%, var(--v-crema) 55%, var(--v-crema-2) 100%);
+  color: var(--v-tinta);
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Cabecera ─────────────────────────────────────────────────────────────── */
+.vitrina__head {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  padding: 14px clamp(12px, 4vw, 28px) 10px;
+  background: rgba(251, 245, 233, 0.92);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--v-borde);
+}
+
+.vitrina__headMain {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.vitrina__back {
+  flex: 0 0 auto;
+  margin-top: 2px;
+  padding: 7px 13px;
+  border: 1px solid var(--v-borde);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--v-tinta);
+  font-size: 0.86rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+.vitrina__back:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px var(--v-sombra);
+}
+
+.vitrina__title {
+  margin: 0;
+  font-size: clamp(1.15rem, 4.2vw, 1.5rem);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.vitrina__sub {
+  margin: 3px 0 0;
+  max-width: 62ch;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--v-tinta-suave);
+}
+
+/* Controles globales */
+.vitrina__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 20px;
+  max-width: 1180px;
+  margin: 12px auto 0;
+}
+
+.vitrina__ctl {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.vitrina__ctlLabel {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--v-tinta-suave);
+}
+
+.vitrina__segmented {
+  display: inline-flex;
+  padding: 3px;
+  border-radius: 10px;
+  background: var(--v-crema-2);
+  border: 1px solid var(--v-borde);
+}
+
+.vitrina__seg {
+  padding: 5px 12px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--v-tinta-suave);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.vitrina__seg.is-on {
+  background: var(--v-verde);
+  color: #fff;
+  box-shadow: 0 2px 6px rgba(47, 109, 67, 0.35);
+}
+
+.vitrina__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--v-tinta);
+  cursor: pointer;
+}
+.vitrina__toggle input {
+  width: 17px;
+  height: 17px;
+  accent-color: var(--v-verde);
+  cursor: pointer;
+}
+
+/* Navegación por secciones */
+.vitrina__tabs {
+  display: flex;
+  gap: 8px;
+  max-width: 1180px;
+  margin: 12px auto 0;
+  padding-bottom: 2px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+}
+
+.vitrina__tab {
+  flex: 0 0 auto;
+  padding: 7px 14px;
+  border: 1px solid var(--v-borde);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--v-tinta-suave);
+  font-size: 0.83rem;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.vitrina__tab:hover {
+  transform: translateY(-1px);
+}
+.vitrina__tab.is-on {
+  background: var(--v-tinta);
+  color: var(--v-crema);
+  border-color: var(--v-tinta);
+}
+
+/* ── Cuerpo ───────────────────────────────────────────────────────────────── */
+.vitrina__body {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: clamp(14px, 3vw, 26px) clamp(12px, 4vw, 28px) 60px;
+}
+
+.vitrina__sectionCtl,
+.vitrina__section .vitrina__sectionCtl {
+  margin-bottom: 14px;
+}
+
+.vitrina__grid {
+  display: grid;
+  gap: clamp(14px, 2.5vw, 22px);
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 250px), 1fr));
+}
+.vitrina__grid--wide {
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 380px), 1fr));
+}
+
+/* ── Tarjeta de demo ──────────────────────────────────────────────────────── */
+.vitrina__card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--v-borde);
+  border-radius: 16px;
+  background: #fff;
+  overflow: hidden;
+  box-shadow: 0 6px 20px var(--v-sombra);
+}
+
+.vitrina__stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 16px;
+  min-height: 180px;
+  background:
+    linear-gradient(180deg, #fffdf8 0%, #f7efdd 100%);
+  border-bottom: 1px solid var(--v-borde);
+}
+.vitrina__card--creature .vitrina__stage {
+  background:
+    radial-gradient(70% 70% at 50% 40%, #fffef9 0%, #f3ead6 100%);
+}
+.vitrina__card--canvas .vitrina__stage,
+.vitrina__card--dom .vitrina__stage {
+  padding: 0;
+  min-height: unset;
+}
+
+.vitrina__creatureWrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 150px;
+}
+
+/* Anfitrión de canvas / lienzos 3D */
+.vitrina__lienzoWrap {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  min-height: 260px;
+  background: #eef2e6;
+}
+.vitrina__lienzoWrap--tall {
+  aspect-ratio: 3 / 4;
+  min-height: 380px;
+}
+.vitrina__lienzo {
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+}
+/* los mundos 3D con canvas propio llenan su contenedor */
+.vitrina__lienzoWrap > .microfauna,
+.vitrina__lienzoWrap > .ciclo-mata,
+.vitrina__lienzoWrap > .vcalma {
+  width: 100%;
+  height: 100%;
+}
+
+.vitrina__loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--v-tinta-suave);
+  background: #eef2e6;
+}
+
+/* Estados DOM */
+.vitrina__domStage {
+  width: 100%;
+  padding: 18px;
+  background: linear-gradient(180deg, #f0f6ec 0%, #e6efdd 100%);
+}
+
+.vitrina__onbStage {
+  position: relative;
+  width: 100%;
+  min-height: 320px;
+  overflow: hidden;
+}
+.vitrina__onbFondo {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, #cfe6f2 0%, #f4ecd2 68%, #d9e6c2 100%);
+}
+.vitrina__onbSol {
+  position: absolute;
+  top: 18%;
+  left: 50%;
+  width: 74px;
+  height: 74px;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff3c9 0%, #ffd980 60%, rgba(255, 217, 128, 0) 72%);
+}
+.vitrina__onbCerro {
+  position: absolute;
+  bottom: 0;
+  left: -8%;
+  width: 70%;
+  height: 55%;
+  background: #7ba05b;
+  border-radius: 50% 50% 0 0 / 100% 100% 0 0;
+  opacity: 0.9;
+}
+.vitrina__onbCerro--2 {
+  left: auto;
+  right: -10%;
+  width: 66%;
+  height: 46%;
+  background: #6a9350;
+  opacity: 0.85;
+}
+
+/* ── Meta de la tarjeta ───────────────────────────────────────────────────── */
+.vitrina__meta {
+  padding: 13px 15px 15px;
+}
+.vitrina__cardTitle {
+  margin: 0;
+  font-size: 1.02rem;
+  font-weight: 700;
+}
+.vitrina__cardDesc {
+  margin: 5px 0 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: var(--v-tinta-suave);
+}
+
+.vitrina__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 11px;
+}
+.vitrina__chip {
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: var(--v-crema-2);
+  border: 1px solid var(--v-borde);
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--v-tinta-suave);
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+}
+
+/* ── Controles locales dentro de una tarjeta / sección ────────────────────── */
+.vitrina__localCtl {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 16px;
+  padding: 12px 15px;
+  border-top: 1px dashed var(--v-borde);
+  background: #fffdf7;
+}
+
+.vitrina__field {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--v-tinta);
+}
+.vitrina__field select {
+  padding: 5px 9px;
+  border: 1px solid var(--v-borde);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--v-tinta);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.vitrina__field--range {
+  gap: 9px;
+}
+.vitrina__field--range input[type='range'] {
+  width: 140px;
+  accent-color: var(--v-verde);
+  cursor: pointer;
+}
+
+.vitrina__mini {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--v-tinta);
+  cursor: pointer;
+}
+.vitrina__mini input {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--v-verde);
+  cursor: pointer;
+}
+
+.vitrina__relaunch {
+  padding: 7px 14px;
+  border: 1px solid var(--v-verde);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--v-verde-hondo);
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.vitrina__relaunch:hover {
+  background: var(--v-verde);
+  color: #fff;
+}
+
+.vitrina__sectionCtl .vitrina__field select {
+  min-width: 130px;
+}
+
+@media (max-width: 480px) {
+  .vitrina__headMain {
+    flex-wrap: wrap;
+  }
+  .vitrina__field--range input[type='range'] {
+    width: 108px;
+  }
+}

--- a/src/mockups/vitrina3d/VitrinaCriaturas.jsx
+++ b/src/mockups/vitrina3d/VitrinaCriaturas.jsx
@@ -1,0 +1,531 @@
+/*
+ * VitrinaCriaturas — vitrina/showcase de los componentes visuales nuevos que
+ * quedaron en `src/visual/` sin cablear a una pantalla real. Ruta pública
+ * #/mockups/vitrina-3d (sin auth), pensada para que el operador los vea vivos
+ * y dé feedback.
+ *
+ * Monta —sin editarlos— las piezas nuevas, agrupadas en secciones navegables:
+ *   · Criaturas rubber-hose (SVG): mariquita, abejorro, lombriz, escarabajo,
+ *     abeja angelita, espíritu guardián.
+ *   · Micro-fauna del suelo (3D): el diorama del suelo vivo.
+ *   · Ciclo de vida (3D): la mata de sembrar a cosecha.
+ *   · Clima y efectos (3D): escarcha/helada + valle en calma.
+ *   · Estados y guías (DOM): hilo de vida narrado + onboarding "descubrir".
+ *
+ * Cada sección trae controles para variar props (device-tier, movimiento
+ * reducido, estado, especie, ánimo…). Solo se monta la sección activa, así que
+ * a lo sumo un Canvas de three vive a la vez (amable con la gama baja).
+ *
+ * Estética: cuaderno de laboratorio andino. Crema tibia, tinta profunda,
+ * verde páramo. Mobile-first, autocontenido (cero enlaces/imágenes externas).
+ */
+import { useState, Suspense } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+
+// Criaturas rubber-hose (SVG puro, sin three)
+import {
+  MariquitaRubber,
+  AbejorroRubber,
+  LombrizRubber,
+  EscarabajoRubber,
+} from '../../visual/creatures/FaunaRubberhose.jsx';
+import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
+import { EspirituGuardian } from '../../visual/creatures/EspirituGuardian.jsx';
+
+// Mundos 3D — traen su propio <Canvas> adentro
+import MicrofaunaSuelo from '../../visual/mundo3d/MicrofaunaSuelo.jsx';
+import CicloMata from '../../visual/mundo3d/CicloMata.jsx';
+import ValleEnCalma from '../../visual/mundo3d/ValleEnCalma.jsx';
+
+// Efecto 3D — es un grupo <three>, necesita un Canvas anfitrión (lo ponemos aquí)
+import EscarchaHelada from '../../visual/mundo3d/EscarchaHelada.jsx';
+
+// Capas DOM (cero three)
+import HiloVidaVista from '../../visual/mundo3d/HiloVidaVista.jsx';
+import OnboardingDescubrir from '../../visual/mundo3d/OnboardingDescubrir.jsx';
+
+import './VitrinaCriaturas.css';
+
+// ── Config de secciones (para la barra de navegación) ────────────────────────
+const SECCIONES = [
+  { id: 'criaturas', emoji: '🐞', label: 'Criaturas rubber-hose' },
+  { id: 'microfauna', emoji: '🪱', label: 'Micro-fauna del suelo' },
+  { id: 'ciclo', emoji: '🌱', label: 'Ciclo de vida' },
+  { id: 'clima', emoji: '❄️', label: 'Clima y efectos' },
+  { id: 'estados', emoji: '🫧', label: 'Estados y guías' },
+];
+
+const TIERS = [
+  { v: 'alto', label: 'Alto' },
+  { v: 'medio', label: 'Medio' },
+  { v: 'bajo', label: 'Bajo' },
+];
+
+const ESTADOS_GUARDIAN = [
+  { v: 'sereno', label: 'Sereno' },
+  { v: 'alerta', label: 'Alerta' },
+  { v: 'celebrando', label: 'Celebrando' },
+];
+
+const ESPECIES = [
+  { v: 'tomate', label: 'Tomate' },
+  { v: 'frijol', label: 'Fríjol' },
+  { v: 'maiz', label: 'Maíz' },
+  { v: 'generico', label: 'La mata' },
+];
+
+const ANIMOS_ABEJA = [
+  { v: 'pleno', label: 'Pleno' },
+  { v: 'sereno', label: 'Sereno' },
+  { v: 'atento', label: 'Atento' },
+  { v: 'sediento', label: 'Sediento' },
+  { v: 'descansa', label: 'Descansa' },
+];
+
+// Paradas de ejemplo para el onboarding "descubrir" (datos ficticios de demo)
+const HOTSPOTS_DEMO = [
+  { id: 'huerta', label: 'La huerta', emoji: '🥬', tinte: '#3f8f4e', pista: 'Aquí crecen sus hortalizas del día a día.' },
+  { id: 'agua', label: 'El nacimiento', emoji: '💧', tinte: '#2f7fb0', pista: 'El agua que nace y recorre su terreno.' },
+  { id: 'bosque', label: 'El bosque', emoji: '🌳', tinte: '#2f6d43', pista: 'La sombra alta que protege el suelo.' },
+];
+
+// ── Piezas presentacionales de la vitrina ────────────────────────────────────
+function Chip({ children }) {
+  return <span className="vitrina__chip">{children}</span>;
+}
+
+function DemoCard({ titulo, descripcion, props: propList = [], variante, children }) {
+  return (
+    <article className={`vitrina__card${variante ? ` vitrina__card--${variante}` : ''}`}>
+      <div className="vitrina__stage">{children}</div>
+      <div className="vitrina__meta">
+        <h3 className="vitrina__cardTitle">{titulo}</h3>
+        {descripcion && <p className="vitrina__cardDesc">{descripcion}</p>}
+        {propList.length > 0 && (
+          <div className="vitrina__chips">
+            {propList.map((p) => (
+              <Chip key={p}>{p}</Chip>
+            ))}
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+// Anfitrión three para el efecto de escarcha (que es un grupo, no una escena).
+function EscarchaDemo({ tier, reducedMotion, intensidad }) {
+  return (
+    <Canvas
+      className="vitrina__lienzo"
+      dpr={tier === 'bajo' ? [1, 1] : [1, 1.5]}
+      camera={{ position: [0, 2.6, 5.4], fov: 44 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      gl={{ antialias: tier !== 'bajo', powerPreference: 'high-performance' }}
+    >
+      <color attach="background" args={['#d7e6f2']} />
+      <hemisphereLight intensity={0.95} color="#eaf3ff" groundColor="#8ea4b8" />
+      <directionalLight position={[3, 6, 4]} intensity={0.7} color="#ffffff" />
+      <ambientLight intensity={0.4} color="#eef4ff" />
+      <mesh rotation-x={-Math.PI / 2} position={[0, -0.01, 0]}>
+        <circleGeometry args={[3.2, 56]} />
+        <meshStandardMaterial color="#6f8a6a" roughness={0.95} />
+      </mesh>
+      <EscarchaHelada
+        intensidad={intensidad}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        area={2.9}
+        altura={0}
+      />
+      <OrbitControls
+        makeDefault
+        enablePan={false}
+        target={[0, 0.2, 0]}
+        minDistance={3.6}
+        maxDistance={9}
+        minPolarAngle={0.3}
+        maxPolarAngle={1.45}
+        enableDamping
+        dampingFactor={0.09}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.2}
+      />
+      <AdaptiveDpr pixelated />
+    </Canvas>
+  );
+}
+
+// ── Vitrina ──────────────────────────────────────────────────────────────────
+export default function VitrinaCriaturas({ onBack }) {
+  const [seccion, setSeccion] = useState('criaturas');
+  const [tier, setTier] = useState('alto');
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  // controles locales por sección
+  const [guardianEstado, setGuardianEstado] = useState('sereno');
+  const [guardianEnergia, setGuardianEnergia] = useState(1);
+  const [especie, setEspecie] = useState('tomate');
+  const [abejaAnimo, setAbejaAnimo] = useState('sereno');
+  const [abejaMojada, setAbejaMojada] = useState(false);
+  const [abejaSed, setAbejaSed] = useState(false);
+  const [escarchaIntensidad, setEscarchaIntensidad] = useState(0.7);
+  const [onbKey, setOnbKey] = useState(0);
+
+  const animated = !reducedMotion;
+
+  return (
+    <div className="vitrina" data-tier={tier}>
+      {/* Cabecera */}
+      <header className="vitrina__head">
+        <div className="vitrina__headMain">
+          <button type="button" className="vitrina__back" onClick={() => onBack?.()}>
+            ← Volver
+          </button>
+          <div>
+            <h1 className="vitrina__title">Vitrina de criaturas y mundos</h1>
+            <p className="vitrina__sub">
+              Los componentes visuales nuevos, vivos y con controles. Toque para
+              variar el detalle, el movimiento y el estado.
+            </p>
+          </div>
+        </div>
+
+        {/* Controles globales */}
+        <div className="vitrina__controls" role="group" aria-label="Controles globales">
+          <div className="vitrina__ctl">
+            <span className="vitrina__ctlLabel">Detalle</span>
+            <div className="vitrina__segmented">
+              {TIERS.map((t) => (
+                <button
+                  key={t.v}
+                  type="button"
+                  className={`vitrina__seg${tier === t.v ? ' is-on' : ''}`}
+                  onClick={() => setTier(t.v)}
+                  aria-pressed={tier === t.v}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <label className="vitrina__toggle">
+            <input
+              type="checkbox"
+              checked={reducedMotion}
+              onChange={(e) => setReducedMotion(e.target.checked)}
+            />
+            <span>Movimiento reducido</span>
+          </label>
+        </div>
+
+        {/* Navegación de secciones */}
+        <nav className="vitrina__tabs" aria-label="Secciones de la vitrina">
+          {SECCIONES.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              className={`vitrina__tab${seccion === s.id ? ' is-on' : ''}`}
+              onClick={() => setSeccion(s.id)}
+              aria-pressed={seccion === s.id}
+            >
+              <span aria-hidden="true">{s.emoji}</span> {s.label}
+            </button>
+          ))}
+        </nav>
+      </header>
+
+      <main className="vitrina__body">
+        {/* ── Criaturas rubber-hose ─────────────────────────────────────── */}
+        {seccion === 'criaturas' && (
+          <section className="vitrina__section" aria-label="Criaturas rubber-hose">
+            <div className="vitrina__grid">
+              <DemoCard
+                titulo="Mariquita"
+                descripcion="Control natural de plagas. Squash-and-stretch al posarse."
+                props={['size', 'tier', 'animated', 'look', 'mostrarRol']}
+                variante="creature"
+              >
+                <MariquitaRubber size={108} tier={tier} animated={animated} mostrarRol />
+              </DemoCard>
+
+              <DemoCard
+                titulo="Abejorro"
+                descripcion="Polinizador robusto de zumbido lento."
+                props={['size', 'tier', 'animated', 'mostrarRol']}
+                variante="creature"
+              >
+                <AbejorroRubber size={112} tier={tier} animated={animated} mostrarRol />
+              </DemoCard>
+
+              <DemoCard
+                titulo="Lombriz"
+                descripcion="Airea el suelo. Cuerpo de manguera que se ondula."
+                props={['size', 'tier', 'animated', 'mostrarRol']}
+                variante="creature"
+              >
+                <LombrizRubber size={112} tier={tier} animated={animated} mostrarRol />
+              </DemoCard>
+
+              <DemoCard
+                titulo="Escarabajo"
+                descripcion="Descompone la materia y devuelve humus al suelo."
+                props={['size', 'tier', 'animated', 'mostrarRol']}
+                variante="creature"
+              >
+                <EscarabajoRubber size={112} tier={tier} animated={animated} mostrarRol />
+              </DemoCard>
+
+              <DemoCard
+                titulo="Abeja angelita"
+                descripcion="Meliponino local. Reacciona al ánimo, a la lluvia y a la sed."
+                props={['size', 'animated', 'animo', 'energia', 'mojada', 'sed']}
+                variante="creature"
+              >
+                <div className="vitrina__creatureWrap">
+                  <AbejaAngelita
+                    size={116}
+                    animated={animated}
+                    animo={abejaAnimo}
+                    energia={0.9}
+                    mojada={abejaMojada}
+                    sed={abejaSed}
+                  />
+                </div>
+                <div className="vitrina__localCtl">
+                  <label className="vitrina__field">
+                    <span>Ánimo</span>
+                    <select value={abejaAnimo} onChange={(e) => setAbejaAnimo(e.target.value)}>
+                      {ANIMOS_ABEJA.map((a) => (
+                        <option key={a.v} value={a.v}>{a.label}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="vitrina__mini">
+                    <input type="checkbox" checked={abejaMojada} onChange={(e) => setAbejaMojada(e.target.checked)} />
+                    <span>Lluvia</span>
+                  </label>
+                  <label className="vitrina__mini">
+                    <input type="checkbox" checked={abejaSed} onChange={(e) => setAbejaSed(e.target.checked)} />
+                    <span>Sed</span>
+                  </label>
+                </div>
+              </DemoCard>
+
+              <DemoCard
+                titulo="Espíritu guardián"
+                descripcion="El acompañante de su finca. Su gesto cambia con el estado."
+                props={['size', 'tier', 'estado', 'energia', 'reducedMotion']}
+                variante="creature"
+              >
+                <div className="vitrina__creatureWrap">
+                  <EspirituGuardian
+                    size={124}
+                    tier={tier}
+                    animated={animated}
+                    reducedMotion={reducedMotion}
+                    estado={guardianEstado}
+                    energia={guardianEnergia}
+                  />
+                </div>
+                <div className="vitrina__localCtl">
+                  <label className="vitrina__field">
+                    <span>Estado</span>
+                    <select value={guardianEstado} onChange={(e) => setGuardianEstado(e.target.value)}>
+                      {ESTADOS_GUARDIAN.map((s) => (
+                        <option key={s.v} value={s.v}>{s.label}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="vitrina__field vitrina__field--range">
+                    <span>Energía</span>
+                    <input
+                      type="range"
+                      min="0.35"
+                      max="1"
+                      step="0.05"
+                      value={guardianEnergia}
+                      onChange={(e) => setGuardianEnergia(parseFloat(e.target.value))}
+                    />
+                  </label>
+                </div>
+              </DemoCard>
+            </div>
+          </section>
+        )}
+
+        {/* ── Micro-fauna del suelo ─────────────────────────────────────── */}
+        {seccion === 'microfauna' && (
+          <section className="vitrina__section" aria-label="Micro-fauna del suelo">
+            <div className="vitrina__grid vitrina__grid--wide">
+              <DemoCard
+                titulo="Micro-fauna del suelo"
+                descripcion="El suelo está vivo: lombrices, colémbolos y raíces en un corte 3D. Arrastre para girar."
+                props={['tier', 'reducedMotion', 'vida', 'mostrarNombres']}
+                variante="canvas"
+              >
+                <div className="vitrina__lienzoWrap">
+                  <Suspense fallback={<div className="vitrina__loading">Preparando el suelo vivo…</div>}>
+                    <MicrofaunaSuelo
+                      tier={tier}
+                      reducedMotion={reducedMotion}
+                      vida={0.9}
+                      mostrarNombres
+                    />
+                  </Suspense>
+                </div>
+              </DemoCard>
+            </div>
+          </section>
+        )}
+
+        {/* ── Ciclo de vida ─────────────────────────────────────────────── */}
+        {seccion === 'ciclo' && (
+          <section className="vitrina__section" aria-label="Ciclo de vida de la mata">
+            <div className="vitrina__sectionCtl">
+              <label className="vitrina__field">
+                <span>Especie</span>
+                <select value={especie} onChange={(e) => setEspecie(e.target.value)}>
+                  {ESPECIES.map((s) => (
+                    <option key={s.v} value={s.v}>{s.label}</option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <div className="vitrina__grid vitrina__grid--wide">
+              <DemoCard
+                titulo="Ciclo de la mata"
+                descripcion="De sembrar a cosecha, con su barra de etapas. Toque una etapa o deje correr el time-lapse."
+                props={['especie', 'tier', 'reducedMotion', 'autoplay', 'etapaInicial']}
+                variante="canvas"
+              >
+                <div className="vitrina__lienzoWrap vitrina__lienzoWrap--tall">
+                  <Suspense fallback={<div className="vitrina__loading">Preparando la mata…</div>}>
+                    <CicloMata
+                      key={`${especie}-${tier}`}
+                      especie={especie}
+                      tier={tier}
+                      reducedMotion={reducedMotion}
+                      autoplay={!reducedMotion}
+                    />
+                  </Suspense>
+                </div>
+              </DemoCard>
+            </div>
+          </section>
+        )}
+
+        {/* ── Clima y efectos ───────────────────────────────────────────── */}
+        {seccion === 'clima' && (
+          <section className="vitrina__section" aria-label="Clima y efectos">
+            <div className="vitrina__grid vitrina__grid--wide">
+              <DemoCard
+                titulo="Escarcha / helada"
+                descripcion="La escarcha del alba que se posa sobre el suelo. La intensidad regula cuánta cubre."
+                props={['intensidad', 'tier', 'reducedMotion', 'area']}
+                variante="canvas"
+              >
+                <div className="vitrina__lienzoWrap">
+                  <Suspense fallback={<div className="vitrina__loading">Preparando el amanecer frío…</div>}>
+                    <EscarchaDemo
+                      tier={tier}
+                      reducedMotion={reducedMotion}
+                      intensidad={escarchaIntensidad}
+                    />
+                  </Suspense>
+                </div>
+                <div className="vitrina__localCtl">
+                  <label className="vitrina__field vitrina__field--range">
+                    <span>Intensidad</span>
+                    <input
+                      type="range"
+                      min="0.1"
+                      max="1"
+                      step="0.05"
+                      value={escarchaIntensidad}
+                      onChange={(e) => setEscarchaIntensidad(parseFloat(e.target.value))}
+                    />
+                  </label>
+                </div>
+              </DemoCard>
+
+              <DemoCard
+                titulo="Valle en calma"
+                descripcion="El estado de reposo: nada urgente que atender. En gama baja cae a un espejo 2D."
+                props={['tier', 'reducedMotion', 'mensaje', 'detalle']}
+                variante="canvas"
+              >
+                <div className="vitrina__lienzoWrap">
+                  <Suspense fallback={<div className="vitrina__loading">Preparando el valle…</div>}>
+                    <ValleEnCalma tier={tier} reducedMotion={reducedMotion} />
+                  </Suspense>
+                </div>
+              </DemoCard>
+            </div>
+          </section>
+        )}
+
+        {/* ── Estados y guías (DOM) ─────────────────────────────────────── */}
+        {seccion === 'estados' && (
+          <section className="vitrina__section" aria-label="Estados y guías">
+            <div className="vitrina__grid vitrina__grid--wide">
+              <DemoCard
+                titulo="Hilo de vida"
+                descripcion="Una capa de prosa cálida que narra en palabras lo que la escena muestra."
+                props={['cielo', 'animo', 'energia', 'lugar', 'pendientes']}
+                variante="dom"
+              >
+                <div className="vitrina__domStage">
+                  <HiloVidaVista
+                    cielo="despejado"
+                    animo="sereno"
+                    energia={0.85}
+                    lugar="la huerta"
+                    reducedMotion={reducedMotion}
+                    pendientes={[
+                      { id: 'r1', tema: 'riego', view: 'tareas' },
+                      { id: 'r2', tema: 'observación de una mata', view: 'seguimiento' },
+                    ]}
+                    onIrA={() => {}}
+                  />
+                </div>
+              </DemoCard>
+
+              <DemoCard
+                titulo="Onboarding: descubrir el valle"
+                descripcion="El primer recorrido guiado, paso a paso, sobre la escena. Sin voz, siempre con salida amable."
+                props={['hotspots', 'onListo', 'onDestacar', 'reducedMotion']}
+                variante="dom"
+              >
+                <div className="vitrina__onbStage">
+                  <div className="vitrina__onbFondo" aria-hidden="true">
+                    <span className="vitrina__onbSol" />
+                    <span className="vitrina__onbCerro" />
+                    <span className="vitrina__onbCerro vitrina__onbCerro--2" />
+                  </div>
+                  <OnboardingDescubrir
+                    key={onbKey}
+                    hotspots={HOTSPOTS_DEMO}
+                    reducedMotion={reducedMotion}
+                    onListo={() => {}}
+                    onDestacar={() => {}}
+                  />
+                </div>
+                <div className="vitrina__localCtl">
+                  <button
+                    type="button"
+                    className="vitrina__relaunch"
+                    onClick={() => setOnbKey((k) => k + 1)}
+                  >
+                    ↻ Volver a mostrar el recorrido
+                  </button>
+                </div>
+              </DemoCard>
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Qué

Vitrina/showcase navegable que hace VISIBLES los componentes visuales nuevos de `src/visual/` que quedaron sin cablear a una pantalla real, para que el operador los vea vivos y dé feedback.

Ruta pública (sin auth): **`#/mockups/vitrina-3d`**

## Secciones

- **Criaturas rubber-hose** (SVG): mariquita, abejorro, lombriz, escarabajo, abeja angelita, espíritu guardián.
- **Micro-fauna del suelo** (3D): el diorama del suelo vivo, orbitable.
- **Ciclo de vida** (3D): la mata de sembrar a cosecha, con selector de especie.
- **Clima y efectos** (3D): escarcha/helada (con anfitrión de Canvas propio) + valle en calma.
- **Estados y guías** (DOM): hilo de vida narrado + onboarding "descubrir el valle".

## Controles

Globales: device-tier (Alto/Medio/Bajo) y movimiento reducido. Locales por sección: estado y energía del guardián, ánimo/lluvia/sed de la abeja, especie del ciclo, intensidad de la escarcha, relanzar el onboarding.

## Notas de implementación

- **No** edita ninguno de los componentes que muestra ni otros archivos: solo agrega `src/mockups/vitrina3d/VitrinaCriaturas.{jsx,css}` y UNA ruta al final del bloque de mockups en `src/App.jsx`.
- Solo se monta la sección activa → a lo sumo un `Canvas` de three vive a la vez (amable con gama baja).
- `EscarchaHelada` es un grupo `<three>`, así que la vitrina le da un Canvas anfitrión con luces y suelo.
- Lint `--max-warnings 0` limpio; `npm run build` verde (exit 0), chunk `VitrinaCriaturas-*.js` emitido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)