### PR TITLE
feat(3d): bloom sutil solo en tier alto + coherencia de material valle-mundo

### DIFF
--- a/src/visual/mundo3d/atmosferaMadre.js
+++ b/src/visual/mundo3d/atmosferaMadre.js
@@ -22,6 +22,12 @@
  *                 puros no existen aquí a propósito: bajo un sol dorado hasta
  *                 el concreto se tiñe (concreto/lamina son grises CÁLIDOS).
  *
+ * Y dos piezas de coherencia derivadas (mismo contrato, cero costo por frame):
+ *   - mezclarCielo : la receta 60%-hacia-la-madre que usa EscenaBase3D, como
+ *                    ley exportada — cualquier consumidor nuevo pinta IGUAL.
+ *   - BLOOM        : los parámetros del bloom sutil del tier alto. Dirección
+ *                    de arte central, no un número suelto por escena.
+ *
  * Rendimiento: solo constantes y una mezcla de Color memoizable — nada de esto
  * cuesta por frame ni rompe el device-tier (la base decide qué enciende).
  */
@@ -43,6 +49,34 @@ export const ATMOSFERA = {
 export function mezclar(a, b, t) {
   return `#${new THREE.Color(a).lerp(new THREE.Color(b), t).getHexString()}`;
 }
+
+/* La RECETA de coherencia valle↔mundo, como ley única: el cielo propio del
+   arquetipo mezclado 60% hacia la hora dorada (B6). Antes vivía inline en
+   EscenaBase3D; aquí es parte de la dirección de arte — si un consumidor nuevo
+   (minimapa, preview, thumbnail) necesita "cómo se ve la familia X bajo la
+   madre", llama esto y sale IGUAL que la escena. Barato (7 lerps); memoizar
+   en quien llama por `cielo`. */
+export function mezclarCielo(cielo) {
+  const propio = { ...CIELOS.neutro, ...(cielo || {}) };
+  return {
+    fondo: mezclar(propio.fondo, ATMOSFERA.fondo, 0.6),
+    cielo: mezclar(propio.cielo, ATMOSFERA.cielo, 0.6),
+    suelo: mezclar(propio.suelo, ATMOSFERA.suelo, 0.6),
+    niebla: mezclar(propio.fondo, ATMOSFERA.niebla, 0.7),
+    alfombra: mezclar(propio.suelo, ATMOSFERA.suelo, 0.5),
+    intensidad: propio.intensidad ?? 1,
+  };
+}
+
+/* El bloom de la hora dorada (tier alto): parámetros de dirección de arte, no
+   de cada escena. `umbral` alto = solo los brillos francos (sol en el agua,
+   ámbar de señal, cal al sol) florecen; `fuerza` baja = un velo tibio, jamás
+   neón. Un solo bloom en todo el juego = la luz se siente del mismo atardecer. */
+export const BLOOM = {
+  fuerza: 0.18, // sutil: abraza los brillos, no los revienta
+  radio: 0.55, // difusión corta — halo pegado a la fuente
+  umbral: 0.85, // solo lo francamente luminoso entra al pase
+};
 
 /* El cielo propio de cada familia de mundo. EscenaBase3D lo MEZCLA 60% hacia
    ATMOSFERA, así que estos valores son el acento, no el resultado final.

--- a/src/visual/mundo3d/escenas/BloomSutil.jsx
+++ b/src/visual/mundo3d/escenas/BloomSutil.jsx
@@ -1,0 +1,79 @@
+/*
+ * BloomSutil — el velo luminoso de la hora dorada, SOLO para el tier alto.
+ *
+ * Un UnrealBloomPass discreto (parámetros en atmosferaMadre.BLOOM: umbral alto,
+ * fuerza baja) que hace florecer apenas los brillos francos — el sol en el
+ * agua, el ámbar de una señal, la cal al mediodía — sin volver neón el
+ * claymation. Coherencia valle↔mundo: un solo bloom, una sola receta, la luz
+ * se lee del mismo atardecer en todas las escenas.
+ *
+ * CONTRATO DE COSTO (DR-3D-PERF-GAMABAJA): este archivo es un chunk LAZY que
+ * EscenaBase3D solo importa con `tier === 'alto' && !reducedMotion` — medio y
+ * bajo ni lo descargan. Aquí dentro no hay gate propio: quien monta, paga.
+ * Cero dependencias nuevas: EffectComposer/UnrealBloomPass/OutputPass vienen
+ * de `three/addons` (ya en el árbol de three).
+ *
+ * El `useFrame` con prioridad 1 TOMA el render (r3f apaga su render automático
+ * cuando alguien renderiza con prioridad > 0): la escena pasa por el composer
+ * (render → bloom → OutputPass, que repone tone mapping + sRGB del gl). El
+ * tamaño y el pixel-ratio se siguen en caliente porque AdaptiveDpr los mueve
+ * durante el regress.
+ */
+import { useEffect, useMemo, useRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+import { BLOOM } from '../atmosferaMadre.js';
+
+export default function BloomSutil() {
+  const gl = useThree((s) => s.gl);
+  const scene = useThree((s) => s.scene);
+  const camera = useThree((s) => s.camera);
+  const size = useThree((s) => s.size);
+  const prAnterior = useRef(0);
+
+  const composer = useMemo(() => {
+    const comp = new EffectComposer(gl);
+    comp.addPass(new RenderPass(scene, camera));
+    // La resolución real la pone el efecto de resize de abajo (recrear el
+    // composer por cada resize tiraría los render targets); aquí un stub.
+    comp.addPass(new UnrealBloomPass(
+      new THREE.Vector2(1, 1),
+      BLOOM.fuerza,
+      BLOOM.radio,
+      BLOOM.umbral,
+    ));
+    // OutputPass al final: repone el tone mapping + la conversión sRGB que el
+    // composer se salta (sin él, la hora dorada sale lavada y lineal).
+    comp.addPass(new OutputPass());
+    return comp;
+  }, [gl, scene, camera]);
+
+  // Resize vivo (viewport/orientación). Aparte del dispose: cambiar de tamaño
+  // NO debe soltar los render targets, solo redimensionarlos.
+  useEffect(() => {
+    composer.setSize(size.width, size.height);
+  }, [composer, size]);
+
+  // Al desmontar (o recrear por gl/scene/camera): soltar los render targets.
+  // El render automático de r3f vuelve solo — el useFrame prioridad 1 muere
+  // con el mount.
+  useEffect(() => () => composer.dispose(), [composer]);
+
+  useFrame(() => {
+    // AdaptiveDpr baja/sube el DPR durante el regress: seguirlo en caliente,
+    // si no el bloom queda borroso (o carísimo) tras cada gesto de órbita.
+    const pr = gl.getPixelRatio();
+    if (pr !== prAnterior.current) {
+      prAnterior.current = pr;
+      composer.setPixelRatio(pr);
+      composer.setSize(size.width, size.height);
+    }
+    composer.render();
+  }, 1);
+
+  return null;
+}

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -20,7 +20,7 @@
  * no como abrir otra app). `piso` (y del suelo, default 0) posa la alfombra y
  * las sombras de contacto; solo cutaway lo necesita (su bloque centra en 0).
  */
-import { Suspense, useMemo, useRef, useState } from 'react';
+import { Suspense, lazy, useMemo, useRef, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Html, OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import * as THREE from 'three';
@@ -32,7 +32,12 @@ import useHaptics from '../useHaptics.js';
 /* La dirección de arte compartida (hora dorada + cielos por familia) vive en
    un módulo propio: los arquetipos eligen su CIELOS.<familia>, esta base la
    mezcla hacia ATMOSFERA. Una sola fuente, cero hexes sueltos. */
-import { ATMOSFERA, CIELOS, mezclar } from '../atmosferaMadre.js';
+import { ATMOSFERA, mezclarCielo } from '../atmosferaMadre.js';
+
+/* El bloom sutil de la hora dorada: chunk LAZY con gate ESTRICTO
+   `tier === 'alto' && !reducedMotion` — medio y bajo NI LO DESCARGAN
+   (el import dinámico solo dispara cuando el elemento llega a renderizarse). */
+const BloomSutil = lazy(() => import('./BloomSutil.jsx'));
 
 function Contenido({
   params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, piso = 0,
@@ -54,18 +59,10 @@ function Contenido({
 
   // La atmósfera del mundo: su `cielo` propio MEZCLADO 60% hacia la hora dorada
   // del valle (B6 — hoy entrar a un mundo "aplana" porque cada escena fija un
-  // cielo frío propio). Memoizado: THREE.Color solo cuando cambia el cielo.
-  const c = useMemo(() => {
-    const propio = { ...CIELOS.neutro, ...(cielo || {}) };
-    return {
-      fondo: mezclar(propio.fondo, ATMOSFERA.fondo, 0.6),
-      cielo: mezclar(propio.cielo, ATMOSFERA.cielo, 0.6),
-      suelo: mezclar(propio.suelo, ATMOSFERA.suelo, 0.6),
-      niebla: mezclar(propio.fondo, ATMOSFERA.niebla, 0.7),
-      alfombra: mezclar(propio.suelo, ATMOSFERA.suelo, 0.5),
-      intensidad: propio.intensidad ?? 1,
-    };
-  }, [cielo]);
+  // cielo frío propio). La receta vive AHORA en atmosferaMadre (mezclarCielo):
+  // ley exportada, mismo resultado aquí y en cualquier consumidor futuro.
+  // Memoizado: THREE.Color solo cuando cambia el cielo.
+  const c = useMemo(() => mezclarCielo(cielo), [cielo]);
 
   // foco = el hotspot activo (o el centro del diorama). Memoizado (auditoría
   // B11: antes era un Vector3 nuevo POR RENDER — basura de GC en el hilo
@@ -214,6 +211,15 @@ function Contenido({
         activa={!reducedMotion && !frugal}
       />
       <AdaptiveDpr pixelated />
+      {/* Bloom SUTIL solo donde sobra GPU: tier alto sin reduced-motion. El
+          gate es estricto a propósito (contrato de costo del DR de gama baja):
+          medio/bajo no montan el pase NI descargan su chunk, y reduced-motion
+          tampoco (su frameloop 'demand' no le debe un composer a nadie). */}
+      {tier === 'alto' && !reducedMotion && (
+        <Suspense fallback={null}>
+          <BloomSutil />
+        </Suspense>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Qué hace

Redo limpio (el intento previo divergió de una base vieja). Dos entregas sobre el `EscenaBase3D.jsx` ACTUAL de dev (respeta `tier`/`camaraInicial`/`estadoFinca`/`hablando`/`focoId`/`hayAlerta` y la API vigente de `atmosferaMadre.js`):

### 1. Bloom sutil SOLO en tier alto
- **Nuevo** `src/visual/mundo3d/escenas/BloomSutil.jsx`: `UnrealBloomPass` de `three/addons` (cero dependencias nuevas), composer `RenderPass → UnrealBloomPass → OutputPass` (el OutputPass repone tone mapping + sRGB; sin él la hora dorada sale lavada).
- Gate **estricto** en `EscenaBase3D`: `tier === 'alto' && !reducedMotion`. Lazy import → medio/bajo **ni descargan el chunk** (verificado: `dist/assets/BloomSutil-*.js` sale como chunk propio).
- Sigue el DPR en caliente (AdaptiveDpr lo mueve durante el regress), resize sin tirar render targets, `dispose()` limpio al desmontar.

### 2. Coherencia valle↔mundo (atmosferaMadre EXTENDIDA, sin romper API)
- `ATMOSFERA` / `CIELOS` / `mezclar` / `PALETA` intactos — consumidores actuales no se tocan.
- **`mezclarCielo(cielo)`** nuevo: la receta 60%-hacia-la-madre que vivía inline en `EscenaBase3D` ahora es ley exportada — cualquier consumidor futuro (minimapa, preview) pinta idéntico a la escena.
- **`BLOOM`** nuevo: parámetros del pase (umbral 0.85 alto, fuerza 0.18 baja, radio 0.55) como dirección de arte central — un solo bloom en todo el juego, la luz se lee del mismo atardecer.

## Archivos (solo los 3 asignados)
- `src/visual/mundo3d/escenas/BloomSutil.jsx` (nuevo)
- `src/visual/mundo3d/escenas/EscenaBase3D.jsx` (lazy import + gate + usa `mezclarCielo`)
- `src/visual/mundo3d/atmosferaMadre.js` (extendido)

## Verificación
- `npx eslint --max-warnings 0` sobre los 3 archivos: limpio, sin directivas `eslint-disable`.
- `npm run build` exit 0 (dos veces: antes y después del re-merge de `origin/dev`).
- Chunk lazy confirmado en `dist/assets/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)