### PR TITLE
feat(3d): calidad adaptativa en runtime sobre PerformanceMonitor de drei (FASE 0)

### DIFF
--- a/src/visual/mundo3d/__tests__/usePerformanceMonitor.test.js
+++ b/src/visual/mundo3d/__tests__/usePerformanceMonitor.test.js
@@ -1,0 +1,106 @@
+/*
+ * usePerformanceMonitor — tests de las derivaciones puras y del store.
+ * Sin canvas, sin GPU: el monitor drei real solo corre dentro de un Canvas;
+ * aquí se ejercita la política (niveles, DPR, escala, siembra, fallback).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  TECHO_DPR,
+  factorInicialPorTier,
+  nivelPorFactor,
+  dprPorFactor,
+  escalaParticulasPorFactor,
+  leerCalidad,
+  leerFps,
+  sembrarCalidad,
+  reiniciarCalidad,
+  __internos,
+} from '../usePerformanceMonitor.jsx';
+
+describe('derivaciones puras', () => {
+  it('factorInicialPorTier: alto pleno, medio a media marcha, bajo minimo', () => {
+    expect(factorInicialPorTier('alto')).toBe(1);
+    expect(factorInicialPorTier('medio')).toBe(0.6);
+    expect(factorInicialPorTier('bajo')).toBe(0.2);
+  });
+
+  it('nivelPorFactor: umbrales 0.7 y 0.35', () => {
+    expect(nivelPorFactor(1)).toBe('alto');
+    expect(nivelPorFactor(0.7)).toBe('alto');
+    expect(nivelPorFactor(0.69)).toBe('medio');
+    expect(nivelPorFactor(0.35)).toBe('medio');
+    expect(nivelPorFactor(0.34)).toBe('bajo');
+    expect(nivelPorFactor(0)).toBe('bajo');
+  });
+
+  it('dprPorFactor: cuantizado a 0.25, acotado a [1, techo]', () => {
+    expect(dprPorFactor(1, 1.5)).toBe(1.5);
+    expect(dprPorFactor(0, 1.5)).toBe(1);
+    expect(dprPorFactor(0.5, 1.5)).toBe(1.25);
+    expect(dprPorFactor(0.6, 1.25)).toBe(1.25);
+    expect(dprPorFactor(2, 1.5)).toBe(1.5); // clamp de factor fuera de rango
+    expect(dprPorFactor(-1, 1.5)).toBe(1);
+    // nunca por encima del techo del DR (1.5)
+    expect(dprPorFactor(1, TECHO_DPR.alto)).toBeLessThanOrEqual(1.5);
+  });
+
+  it('escalaParticulasPorFactor: lineal 0.4..1, nunca vacia la escena', () => {
+    expect(escalaParticulasPorFactor(1)).toBe(1);
+    expect(escalaParticulasPorFactor(0)).toBe(0.4);
+    expect(escalaParticulasPorFactor(0.5)).toBe(0.7);
+  });
+});
+
+describe('store de calidad', () => {
+  beforeEach(() => {
+    reiniciarCalidad('medio');
+  });
+
+  it('arranca sembrado por tier con derivados coherentes', () => {
+    sembrarCalidad('alto');
+    const c = leerCalidad();
+    expect(c.tier).toBe('alto');
+    expect(c.factor).toBe(1);
+    expect(c.nivel).toBe('alto');
+    expect(c.dpr).toBe(TECHO_DPR.alto);
+    expect(c.fallback).toBe(false);
+  });
+
+  it('sembrar el mismo tier es idempotente: conserva lo aprendido', () => {
+    sembrarCalidad('alto');
+    __internos.acusarCambio({ factor: 0.5, fps: 38 });
+    const aprendido = leerCalidad();
+    sembrarCalidad('alto'); // remonte de escena, mismo equipo
+    expect(leerCalidad()).toBe(aprendido);
+    expect(leerFps()).toBe(38);
+  });
+
+  it('el DPR en vivo respeta el techo del tier', () => {
+    sembrarCalidad('medio');
+    __internos.acusarCambio({ factor: 1, fps: 60 });
+    expect(leerCalidad().dpr).toBeLessThanOrEqual(TECHO_DPR.medio);
+  });
+
+  it('fallback clava la calidad: acepta bajadas, ignora subidas', () => {
+    sembrarCalidad('alto');
+    __internos.acusarFallback({ factor: 0.4, fps: 30 });
+    expect(leerCalidad().fallback).toBe(true);
+    expect(leerCalidad().factor).toBe(0.4);
+
+    __internos.acusarCambio({ factor: 0.9, fps: 60 }); // intento de subir
+    expect(leerCalidad().factor).toBe(0.4);
+
+    __internos.acusarCambio({ factor: 0.2, fps: 25 }); // bajar si se puede
+    expect(leerCalidad().factor).toBe(0.2);
+    expect(leerCalidad().nivel).toBe('bajo');
+  });
+
+  it('reiniciarCalidad limpia fallback y fps', () => {
+    __internos.acusarFallback({ factor: 0.1, fps: 20 });
+    reiniciarCalidad('medio');
+    const c = leerCalidad();
+    expect(c.fallback).toBe(false);
+    expect(c.factor).toBe(0.6);
+    expect(leerFps()).toBe(0);
+  });
+});

--- a/src/visual/mundo3d/usePerformanceMonitor.jsx
+++ b/src/visual/mundo3d/usePerformanceMonitor.jsx
@@ -1,0 +1,289 @@
+/*
+ * usePerformanceMonitor — CALIDAD ADAPTATIVA EN VIVO (FASE 0, complementa deviceTier).
+ *
+ * `deviceTier.js` decide UNA VEZ, antes de montar, si el equipo aguanta 3D y a
+ * qué techo ('alto'|'medio'|'bajo'). Este módulo mide fps REALES en runtime con
+ * el `<PerformanceMonitor>` de drei y gradúa la calidad EN CALIENTE dentro de
+ * ese techo: DPR, densidad de partículas y efectos suben o bajan sin desmontar
+ * la escena. El tier estático es el TECHO; este monitor es el TERMOSTATO.
+ * Ninguno reemplaza al otro.
+ *
+ * Piezas exportadas:
+ *   <MonitorRendimiento tier={tier}>  — wrapper del PerformanceMonitor de drei.
+ *       Se monta DENTRO del `<Canvas>` (usa useFrame). Publica la calidad en un
+ *       store módulo-local y, salvo `ajustarDpr={false}`, aplica el DPR él
+ *       mismo vía `setDpr` de fiber.
+ *   useCalidad3D()                    — hook de lectura reactiva
+ *       (useSyncExternalStore). Funciona dentro Y fuera del Canvas: el store
+ *       puentea los dos árboles de React sin depender de contexto. Devuelve
+ *       `{ nivel, factor, dpr, escalaParticulas, fallback, tier }`.
+ *   leerCalidad() / leerFps()         — getters no-reactivos (para useFrame,
+ *       donde un re-render por muestreo sería contraproducente).
+ *   nivelPorFactor / dprPorFactor / escalaParticulasPorFactor /
+ *   factorInicialPorTier              — derivaciones puras (testables sin GPU).
+ *
+ * Contratos:
+ *   - `nivel` ('alto'|'medio'|'bajo') es la perilla DISCRETA: efectos on/off
+ *     (niebla, animaciones secundarias, sombreado caro). `factor` (0..1) y
+ *     `escalaParticulas` (0.4..1) son las perillas CONTINUAS (densidades,
+ *     distancias de dibujo, conteos de instancias).
+ *   - El fps NO viaja en el snapshot reactivo (re-renderizaría consumidores
+ *     sin necesidad); se consulta con `leerFps()`.
+ *   - Tras `fallback` (el equipo osciló más de `flipflops` veces) la calidad
+ *     queda CLAVADA hacia abajo: se aceptan bajadas, se ignoran subidas.
+ *     Estable es mejor que bonito (DR §4.4).
+ *   - Store singleton: asume UN Canvas 3D activo a la vez (hoy: el host
+ *     `<Mundo>`). Lo aprendido persiste entre escenas del mismo tier — el
+ *     equipo no cambia por navegar.
+ *
+ * IMPORTANTE (code-split): este módulo importa drei/fiber. NO exportarlo desde
+ * el barrel `mundo3d/index.js` (regla del barrel: three-free). Importarlo SOLO
+ * desde código 3D perezoso (escenas/, chunk vendor-three), como useEntradaAbeja.
+ *
+ * IMPORTANTE (cableo): `EscenaBase3D` hoy monta `<AdaptiveDpr>` de drei, que
+ * también llama `setDpr`. Al cablear este monitor con `ajustarDpr` (default)
+ * hay que RETIRAR `<AdaptiveDpr>` o pasar `ajustarDpr={false}`: dos manos en la
+ * misma perilla pelean. Y con `frameloop='demand'` (reduced-motion) el muestreo
+ * de fps no significa nada: no montar el monitor en ese modo.
+ */
+
+/* eslint-disable react-refresh/only-export-components -- mismo contrato que
+   useEntradaAbeja.jsx: módulo 3D perezoso (store + derivaciones puras + su
+   componente monitor) que se importa SIEMPRE dentro de un <Canvas> vía el
+   chunk vendor-three; no es hot-reload-sensible. Van juntos a propósito: el
+   monitor escribe el store y las escenas leen las derivaciones. */
+import { useEffect, useState, useSyncExternalStore } from 'react';
+import { useThree } from '@react-three/fiber';
+import { PerformanceMonitor } from '@react-three/drei';
+
+/* ─── 1) Derivaciones puras (sin canvas, sin GPU, sin React) ────────────── */
+
+/** Techo de DPR por tier estático. El DR §6 prohíbe pasar de 1.5. */
+export const TECHO_DPR = { alto: 1.5, medio: 1.25, bajo: 1 };
+
+const clamp01 = (x) => Math.max(0, Math.min(1, x));
+
+/**
+ * Factor de arranque por tier: 'alto' parte pleno (solo puede bajar si el
+ * equipo no rinde); 'medio' parte a media marcha (puede subir si sorprende).
+ * @param {'alto'|'medio'|'bajo'} tier
+ * @returns {number} 0..1
+ */
+export function factorInicialPorTier(tier) {
+  if (tier === 'alto') return 1;
+  if (tier === 'medio') return 0.6;
+  return 0.2;
+}
+
+/**
+ * Perilla discreta a partir del factor continuo del monitor.
+ * @param {number} factor 0..1
+ * @returns {'alto'|'medio'|'bajo'}
+ */
+export function nivelPorFactor(factor) {
+  if (factor >= 0.7) return 'alto';
+  if (factor >= 0.35) return 'medio';
+  return 'bajo';
+}
+
+/**
+ * DPR cuantizado a pasos de 0.25 dentro de [1, techo]. La cuantización evita
+ * re-dimensionar el framebuffer por micro-cambios de factor (eso también jankea).
+ * @param {number} factor 0..1
+ * @param {number} [techo] tope de DPR (default 1.5, DR §6)
+ * @returns {number}
+ */
+export function dprPorFactor(factor, techo = 1.5) {
+  const crudo = 1 + clamp01(factor) * (techo - 1);
+  return Math.min(techo, Math.max(1, Math.round(crudo * 4) / 4));
+}
+
+/**
+ * Escala de densidad de partículas/instancias: lineal 0.4..1. Nunca por debajo
+ * del 40% — una escena rala se ve rota, no frugal.
+ * @param {number} factor 0..1
+ * @returns {number}
+ */
+export function escalaParticulasPorFactor(factor) {
+  return Math.round((0.4 + 0.6 * clamp01(factor)) * 100) / 100;
+}
+
+/* ─── 2) Store módulo-local (puentea árbol DOM y árbol fiber) ───────────── */
+
+/**
+ * @typedef {Object} Calidad3D
+ * @property {'alto'|'medio'|'bajo'} tier    techo estático (deviceTier)
+ * @property {number} factor                 0..1 continuo del monitor
+ * @property {'alto'|'medio'|'bajo'} nivel   perilla discreta en vivo
+ * @property {number} dpr                    DPR cuantizado, ≤ TECHO_DPR[tier]
+ * @property {number} escalaParticulas       0.4..1 para conteos/densidades
+ * @property {boolean} fallback              calidad clavada hacia abajo
+ */
+
+/** @param {'alto'|'medio'|'bajo'} tier @param {number} factor @param {boolean} fallback @returns {Calidad3D} */
+function derivar(tier, factor, fallback) {
+  const f = Math.round(clamp01(factor) * 100) / 100;
+  return Object.freeze({
+    tier,
+    factor: f,
+    fallback,
+    nivel: nivelPorFactor(f),
+    dpr: dprPorFactor(f, TECHO_DPR[tier] ?? 1.25),
+    escalaParticulas: escalaParticulasPorFactor(f),
+  });
+}
+
+let calidad = derivar('medio', factorInicialPorTier('medio'), false);
+let fpsUltimo = 0;
+const oyentes = new Set();
+
+/** Notifica SOLO si algo derivado cambió (el fps queda fuera a propósito). */
+function emitir(sig) {
+  if (
+    sig.tier === calidad.tier &&
+    sig.factor === calidad.factor &&
+    sig.nivel === calidad.nivel &&
+    sig.dpr === calidad.dpr &&
+    sig.fallback === calidad.fallback
+  ) return;
+  calidad = sig;
+  oyentes.forEach((fn) => fn());
+}
+
+function suscribir(fn) {
+  oyentes.add(fn);
+  return () => oyentes.delete(fn);
+}
+
+/** Snapshot vigente, no-reactivo (seguro dentro de useFrame). @returns {Calidad3D} */
+export function leerCalidad() {
+  return calidad;
+}
+
+/** fps del último muestreo que movió el factor (no-reactivo, para HUD/debug). */
+export function leerFps() {
+  return fpsUltimo;
+}
+
+/**
+ * Siembra el store con el tier estático. Idempotente: si el tier no cambió,
+ * conserva lo aprendido (factor y candado de fallback) — navegar entre mundos
+ * no borra lo que el equipo ya demostró.
+ * @param {'alto'|'medio'|'bajo'} tier
+ */
+export function sembrarCalidad(tier) {
+  if (tier === calidad.tier) return;
+  emitir(derivar(tier, factorInicialPorTier(tier), false));
+}
+
+/** Reset total (tests / dev). @param {'alto'|'medio'|'bajo'} [tier] */
+export function reiniciarCalidad(tier = 'medio') {
+  fpsUltimo = 0;
+  calidad = derivar(tier, factorInicialPorTier(tier), false);
+  oyentes.forEach((fn) => fn());
+}
+
+/** Callback de cambio del monitor drei. Tras fallback solo se acepta bajar. */
+function acusarCambio(api) {
+  fpsUltimo = api.fps;
+  const factor = calidad.fallback ? Math.min(calidad.factor, api.factor) : api.factor;
+  emitir(derivar(calidad.tier, factor, calidad.fallback));
+}
+
+/** Callback de fallback del monitor drei: clava la calidad hacia abajo. */
+function acusarFallback(api) {
+  fpsUltimo = api.fps;
+  emitir(derivar(calidad.tier, Math.min(calidad.factor, api.factor), true));
+}
+
+/** Internos expuestos SOLO para tests unitarios (no consumir en escenas). */
+export const __internos = { acusarCambio, acusarFallback, emitir, derivar };
+
+/* ─── 3) Piezas React ───────────────────────────────────────────────────── */
+
+/**
+ * Lectura reactiva de la calidad en vivo. Usable dentro del Canvas (escenas,
+ * arquetipos) y fuera (HUD, botones de la PWA): el store es el puente.
+ * @returns {Calidad3D}
+ */
+export function useCalidad3D() {
+  return useSyncExternalStore(suscribir, leerCalidad, leerCalidad);
+}
+
+/** Aplica el DPR del store al renderer. Hijo del Canvas, no dibuja nada. */
+function AjusteDpr() {
+  const setDpr = useThree((s) => s.setDpr);
+  const { dpr } = useCalidad3D();
+  useEffect(() => {
+    setDpr(dpr);
+  }, [setDpr, dpr]);
+  return null;
+}
+
+/**
+ * Límites de fps por defecto: por debajo de 45 sostenido baja calidad; al
+ * clavar el refresco (>=60, o >=100 en pantallas rápidas) la sube. drei
+ * compara `fps >= superior` para subir y `fps < inferior` para bajar.
+ * @param {number} hz refresco detectado
+ * @returns {[number, number]}
+ */
+const limitesPorDefecto = (hz) => (hz > 100 ? [45, 100] : [45, 60]);
+
+/**
+ * Wrapper del `<PerformanceMonitor>` de drei con la política Chagra. Montar
+ * UNA vez, DENTRO del `<Canvas>`, con el tier de `decidirTier()`.
+ *
+ * OJO drei: `flipflops` cuenta CADA cambio de factor (no solo oscilaciones);
+ * con el default 12, una escalada monótona de 'medio' a pleno (4 pasos) queda
+ * lejos del candado, pero un equipo que serrucha termina clavado abajo.
+ *
+ * @param {{
+ *   tier?: 'alto'|'medio'|'bajo',
+ *   ajustarDpr?: boolean,
+ *   ms?: number,
+ *   iterations?: number,
+ *   step?: number,
+ *   flipflops?: number,
+ *   limites?: (hz: number) => [number, number],
+ *   children?: import('react').ReactNode,
+ * }} props
+ */
+export function MonitorRendimiento({
+  tier = 'medio',
+  ajustarDpr = true,
+  ms = 250,
+  iterations = 8,
+  step = 0.1,
+  flipflops = 12,
+  limites = limitesPorDefecto,
+  children = null,
+}) {
+  /* Siembra ANTES del primer render de drei (su `factor` inicial se captura en
+     un useState interno): initializer de estado, idempotente bajo StrictMode. */
+  const [factorArranque] = useState(() => {
+    sembrarCalidad(tier);
+    return leerCalidad().factor;
+  });
+  /* Si el tier cambia en caliente (raro: re-resolución del host), re-siembra. */
+  useEffect(() => {
+    sembrarCalidad(tier);
+  }, [tier]);
+
+  return (
+    <PerformanceMonitor
+      factor={factorArranque}
+      ms={ms}
+      iterations={iterations}
+      step={step}
+      flipflops={flipflops}
+      bounds={limites}
+      onChange={acusarCambio}
+      onFallback={acusarFallback}
+    >
+      {ajustarDpr ? <AjusteDpr /> : null}
+      {children}
+    </PerformanceMonitor>
+  );
+}
+
+export default MonitorRendimiento;

--- a/src/visual/mundo3d/usePerformanceMonitor.md
+++ b/src/visual/mundo3d/usePerformanceMonitor.md
@@ -1,0 +1,113 @@
+# usePerformanceMonitor — calidad adaptativa en vivo (FASE 0)
+
+Degradación dinámica de rendimiento para el 3D de Chagra. Mide fps reales con
+el `<PerformanceMonitor>` de `@react-three/drei` y gradúa la calidad en
+caliente (DPR, densidad de partículas, efectos) para que la gama baja no se
+congele. **Complementa** el device-tier estático (`deviceTier.js`), no lo
+reemplaza: el tier es el techo, este monitor es el termostato.
+
+Archivo: `src/visual/mundo3d/usePerformanceMonitor.jsx` (autocontenido; nada
+existente fue tocado). Tests: `__tests__/usePerformanceMonitor.test.js`.
+
+## Modelo
+
+```text
+decidirTier() ──(una vez, antes de montar)──► tier 'alto'|'medio'|'bajo'
+                                                │  techo: TECHO_DPR[tier]
+<MonitorRendimiento tier={tier}>  (dentro del Canvas)
+   └─ drei <PerformanceMonitor> mide fps → factor 0..1 (sube/baja de a `step`)
+        └─ store módulo-local → { nivel, factor, dpr, escalaParticulas, fallback }
+             ├─ AjusteDpr aplica `setDpr(dpr)` al renderer (opcional)
+             └─ useCalidad3D() en cualquier componente (dentro O fuera del Canvas)
+```
+
+- `nivel` (`'alto'|'medio'|'bajo'`): perilla **discreta** — efectos on/off
+  (niebla, animaciones secundarias, materiales caros).
+- `factor` (0..1) y `escalaParticulas` (0.4..1): perillas **continuas** —
+  conteos de instancias, densidades, distancias de dibujo.
+- `dpr`: cuantizado a pasos de 0.25, siempre `≤ TECHO_DPR[tier]` (DR §6: ≤1.5).
+- `fallback`: si el equipo serrucha demasiado (`flipflops`), la calidad queda
+  clavada hacia abajo (acepta bajadas, ignora subidas). Estable > bonito.
+- El store es singleton (un Canvas activo a la vez, el host `<Mundo>`) y
+  persiste lo aprendido entre escenas del mismo tier.
+
+## Cableo propuesto (para Opus)
+
+**1. Montar el monitor dentro del Canvas** — en `escenas/EscenaBase3D.jsx`,
+dentro de `<Canvas>`:
+
+```jsx
+import MonitorRendimiento from '../usePerformanceMonitor.jsx';
+
+<Canvas dpr={[1, 1.5]} /* ...igual que hoy... */>
+  {!reducedMotion && <MonitorRendimiento tier={tier} />}
+  <Suspense fallback={null}>...</Suspense>
+</Canvas>
+```
+
+Dos condiciones NO negociables del cableo:
+
+- **Retirar `<AdaptiveDpr pixelated />`** (hoy en el `<Contenido>` de
+  `EscenaBase3D`) o montar `<MonitorRendimiento ajustarDpr={false} />`. Ambos
+  llaman `setDpr`; dos manos en la misma perilla pelean.
+- **No montar el monitor con `frameloop='demand'`** (camino reduced-motion):
+  sin frames continuos el muestreo de fps no significa nada. El gate
+  `!reducedMotion` de arriba lo resuelve.
+
+`tier` viene de `decidirTier()` que ya calcula el host `<Mundo>`; hay que
+pasarlo como prop hasta `EscenaBase3D` (hoy no llega — es el único cambio de
+firma que pide el cableo). Mientras no llegue, el default `'medio'` es seguro.
+
+**2. Consumir la calidad en las escenas/arquetipos** (dentro del Canvas):
+
+```jsx
+import { useCalidad3D } from '../usePerformanceMonitor.jsx';
+
+function Particulas({ base = 120 }) {
+  const { nivel, escalaParticulas } = useCalidad3D();
+  const n = Math.round(base * escalaParticulas); // 48..120 segun rendimiento
+  return (
+    <>
+      <Instancias cantidad={n} />
+      {nivel === 'alto' && <NieblaCara />} {/* efecto on/off por nivel */}
+    </>
+  );
+}
+```
+
+**3. Dentro de `useFrame`** usar los getters no-reactivos (cero re-renders):
+
+```js
+import { leerCalidad, leerFps } from '../usePerformanceMonitor.jsx';
+
+useFrame(() => {
+  if (leerCalidad().nivel !== 'alto') return; // saltar animacion secundaria
+});
+```
+
+**4. Fuera del Canvas** (HUD de la PWA, storybook): `useCalidad3D()` funciona
+igual — el store puentea los dos árboles de React, sin ContextBridge.
+
+## Reglas duras
+
+- **NO exportar desde el barrel** `mundo3d/index.js`: este módulo importa
+  drei/fiber y el barrel es three-free por contrato (code-split). Importarlo
+  solo desde código 3D perezoso (`escenas/`, chunk `vendor-three`), igual que
+  `useEntradaAbeja`.
+- `reiniciarCalidad(tier)` es para tests/dev; las escenas no lo llaman.
+- `__internos` es solo para tests unitarios.
+
+## Props de `<MonitorRendimiento>` (defaults pensados para Chagra)
+
+| prop | default | qué hace |
+|---|---|---|
+| `tier` | `'medio'` | techo estático de `decidirTier()` |
+| `ajustarDpr` | `true` | aplica `setDpr` él mismo |
+| `ms` / `iterations` | `250` / `8` | ventana de muestreo (~2s por decisión) |
+| `step` | `0.1` | cuánto sube/baja el factor por decisión |
+| `flipflops` | `12` | cambios totales antes del candado (drei cuenta CADA cambio, no solo oscilaciones) |
+| `limites` | `hz>100 ? [45,100] : [45,60]` | baja bajo 45 fps sostenido; sube al clavar el refresco |
+
+Factor inicial por tier: `alto` arranca en 1.0 (solo puede bajar), `medio` en
+0.6 (puede subir si el equipo sorprende). Umbrales de `nivel`: ≥0.7 alto,
+≥0.35 medio.


### PR DESCRIPTION
## Que hace

Degradacion dinamica de rendimiento para el 3D: mide fps reales en vivo con el `<PerformanceMonitor>` de @react-three/drei y gradua la calidad en caliente (DPR, densidad de particulas, efectos) para que la gama baja no se congele. **Complementa** el device-tier estatico (`deviceTier.js`) sin reemplazarlo: el tier es el techo, este monitor es el termostato.

## Archivos (SOLO nuevos, nada existente tocado)

- `src/visual/mundo3d/usePerformanceMonitor.jsx` — modulo autocontenido:
  - `<MonitorRendimiento tier>` wrapper de drei, se monta dentro del Canvas; publica calidad en store modulo-local y aplica `setDpr` (desactivable con `ajustarDpr={false}`).
  - `useCalidad3D()` — lectura reactiva `{ nivel, factor, dpr, escalaParticulas, fallback, tier }`; funciona dentro Y fuera del Canvas (useSyncExternalStore, sin ContextBridge).
  - `leerCalidad()` / `leerFps()` — getters no-reactivos para `useFrame`.
  - Derivaciones puras exportadas y testeadas.
- `src/visual/mundo3d/usePerformanceMonitor.md` — doc de consumo + cableo propuesto.
- `src/visual/mundo3d/__tests__/usePerformanceMonitor.test.js` — 9 tests (puras + store + fallback pegajoso), sin GPU.

## Politica

- DPR cuantizado a pasos de 0.25, siempre <= `TECHO_DPR[tier]` (<= 1.5, DR seccion 6).
- `nivel` discreto (efectos on/off) + `factor`/`escalaParticulas` continuos (densidades). Particulas nunca bajan del 40%.
- Fallback pegajoso: si el equipo oscila mas de `flipflops`, la calidad queda clavada hacia abajo (acepta bajadas, ignora subidas).
- Lo aprendido persiste entre escenas del mismo tier.

## Cableo pendiente (Opus)

Detallado en `usePerformanceMonitor.md`. Resumen:
1. Montar `{!reducedMotion && <MonitorRendimiento tier={tier} />}` dentro del `<Canvas>` de `EscenaBase3D`.
2. **Retirar `<AdaptiveDpr pixelated />`** (o pasar `ajustarDpr={false}`): ambos llaman `setDpr` y pelean.
3. NO montar el monitor con `frameloop='demand'" (reduced-motion): el muestreo de fps no significa nada ahi.
4. Pasar `tier` de `decidirTier()` como prop hasta `EscenaBase3D` (unico cambio de firma); mientras tanto el default 'medio' es seguro.
5. NO exportar desde el barrel `mundo3d/index.js` (importa drei/fiber; el barrel es three-free por contrato).

## Verificacion

- `eslint --max-warnings 0` sobre los archivos nuevos: limpio (disable file-level de react-refresh con justificacion, mismo precedente que `useEntradaAbeja.jsx`).
- `tsc:check`: 0 errores aportados (los de `speciesResolver.test.js` son baseline pre-existente).
- `vitest`: 9/9 pasan.
- `timeout 300 npm run build`: exit 0 (29s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)