### PR TITLE
feat(3d): camara de dioramas por mundo con encuadres curados

### DIFF
--- a/src/visual/mundo3d/CamaraDioramas.jsx
+++ b/src/visual/mundo3d/CamaraDioramas.jsx
@@ -1,0 +1,168 @@
+/*
+ * CamaraDioramas — aplica el ENCUADRE DE DIORAMA de cada mundo (FASE 4).
+ *
+ * Hermano por-mundo de `escenas/CamaraDirector.jsx`: donde aquel es el
+ * game-feel GENÉRICO, este lee la fotografía curada de `camaraDioramas.js`
+ * (posición/target/fov propios de valle, café, sanidad, mercado, animales,
+ * semillero, clima…) y coreografía UN beat de entrada:
+ *
+ *  1. La cámara arranca retirada sobre un arco lateral (retiro/arcoY/grua
+ *     del beat), con el lente un pelo más abierto, y LLEGA al encuadre final
+ *     por damp exponencial (`THREE.MathUtils.damp` — frame-rate independiente,
+ *     nada de lerp por frame fijo). El primer pointerdown del usuario ACELERA
+ *     la llegada (el director cede, sin teletransportes).
+ *
+ *  2. Con `reducedMotion`, `activa=false` o tier 'bajo': la pose final se
+ *     CLAVA en un solo paso al montar y el frame-loop queda inerte (retorno
+ *     temprano, cero trabajo por frame). El encuadre final es idéntico al
+ *     del beat completo: cero regresión.
+ *
+ *  3. Al cambiar `mundoId` el beat corre de nuevo con el encuadre del mundo
+ *     nuevo (cada diorama re-presenta su plano). `unaVezPorSesion` evita
+ *     repetir el show en mundos que re-montan seguido: la segunda visita
+ *     clava la pose final directo.
+ *
+ * Solo MÉTODOS three (copy/set/lookAt/setFocalLength), nunca reasignación de
+ * props de cámara. No dibuja nada (return null) y no toca navegación.
+ *
+ * ── Cableo (lo hace Opus; este archivo es autocontenido) ──────────────────
+ * Dentro del <Canvas> de la escena, junto a los OrbitControls:
+ *
+ *   <CamaraDioramas
+ *     mundoId={mundoId}                 // clave de MUNDO ('cafe', 'valle'…)
+ *     tier={tier}                       // deviceTier: 'alto'|'medio'|'bajo'
+ *     reducedMotion={reducedMotion}     // de detectarTier().reducedMotion
+ *     controls={controlsRef}            // opcional: ref de OrbitControls
+ *   />
+ *
+ * NO montar junto a CamaraDirector en la misma escena (ambos conducen la
+ * misma cámara); este lo reemplaza donde haya encuadre curado.
+ */
+import { useEffect, useRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+import { resolverEncuadre } from './camaraDioramas';
+
+/** Distancia focal (mm de film) que produce un fov vertical dado. */
+const focalDeFov = (camera, fov) =>
+  (0.5 * camera.getFilmHeight()) / Math.tan(THREE.MathUtils.degToRad(fov * 0.5));
+
+/** Umbral de asentamiento: por debajo, la pose se clava exacta y el beat muere. */
+const EPSILON = 0.002;
+
+/* Mundos ya presentados en esta sesión (para `unaVezPorSesion`). */
+const yaPresentados = new Set();
+
+export default function CamaraDioramas({
+  /** Clave de MUNDO (mundoData.js) cuyo encuadre curado se aplica. */
+  mundoId,
+  /** Tier de equipo (deviceTier.js). 'medio' acorta el beat, 'bajo' lo anula. */
+  tier = 'alto',
+  /** true → pose final directa, sin beat (misma pose, cero movimiento). */
+  reducedMotion = false,
+  /** Ref opcional de los OrbitControls hermanos (target compartido). */
+  controls = null,
+  /** false → inerte total (el host decide apagar el director). */
+  activa = true,
+  /** true → el beat de cada mundo corre una sola vez por sesión. */
+  unaVezPorSesion = false,
+}) {
+  const { camera } = useThree();
+  /** Estado del beat en curso; null = asentado (o nunca hubo). */
+  const beatRef = useRef(null);
+
+  useEffect(() => {
+    const enc = resolverEncuadre(mundoId, tier);
+    const hasta = new THREE.Vector3(...enc.posicion);
+    const tHasta = new THREE.Vector3(...enc.target);
+    const fFinal = focalDeFov(camera, enc.fov);
+    const c = controls ? controls.current : null;
+
+    const clavar = () => {
+      beatRef.current = null;
+      camera.position.copy(hasta);
+      camera.setFocalLength(fFinal);
+      if (c) {
+        c.target.copy(tHasta);
+        c.update();
+      }
+      camera.lookAt(tHasta);
+    };
+
+    const sinBeat =
+      !activa ||
+      reducedMotion ||
+      enc.beat.lambda <= 0 ||
+      (unaVezPorSesion && yaPresentados.has(mundoId));
+    if (sinBeat) {
+      clavar();
+      return undefined;
+    }
+    if (unaVezPorSesion) yaPresentados.add(mundoId);
+
+    // Pose de arranque: retroceder sobre el eje target→cámara, girar el arco
+    // alrededor de Y y aplicar la grúa (fracción de la distancia, con signo:
+    // positiva arranca alta y baja, negativa arranca baja y sube).
+    const dir = hasta.clone().sub(tHasta).multiplyScalar(enc.beat.retiro);
+    dir.applyAxisAngle(new THREE.Vector3(0, 1, 0), enc.beat.arcoY);
+    const desde = tHasta.clone().add(dir);
+    desde.setY(desde.y + dir.length() * enc.beat.grua);
+
+    beatRef.current = {
+      hasta,
+      tHasta,
+      fFinal,
+      lambda: enc.beat.lambda,
+      escala: dir.length(), // para normalizar el umbral de asentamiento
+    };
+    camera.position.copy(desde);
+    camera.setFocalLength(fFinal / enc.beat.lente);
+    if (c) c.target.copy(tHasta);
+    camera.lookAt(tHasta);
+
+    // El primer gesto del usuario ACELERA la llegada (capture en window:
+    // los hotspots DOM no burbujean por el canvas). Sin saltos: solo sube
+    // la velocidad del damp y el asentamiento remata solo.
+    const ceder = () => {
+      const b = beatRef.current;
+      if (b) b.lambda = Math.max(b.lambda * 4, 8);
+    };
+    window.addEventListener('pointerdown', ceder, true);
+    return () => {
+      window.removeEventListener('pointerdown', ceder, true);
+      beatRef.current = null;
+    };
+    // El beat re-corre solo cuando cambia el mundo o el contexto de respeto.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mundoId, tier, reducedMotion, activa]);
+
+  useFrame((state, delta) => {
+    const b = beatRef.current;
+    if (!b) return; // asentado: cero trabajo por frame
+    // delta acotado: una pestaña dormida no "salta" la llegada al despertar.
+    const dt = Math.min(delta, 1 / 20);
+    const { position } = camera;
+    position.setX(THREE.MathUtils.damp(position.x, b.hasta.x, b.lambda, dt));
+    position.setY(THREE.MathUtils.damp(position.y, b.hasta.y, b.lambda, dt));
+    position.setZ(THREE.MathUtils.damp(position.z, b.hasta.z, b.lambda, dt));
+    camera.setFocalLength(
+      THREE.MathUtils.damp(camera.getFocalLength(), b.fFinal, b.lambda, dt),
+    );
+    camera.lookAt(b.tHasta);
+    if (position.distanceTo(b.hasta) < EPSILON * b.escala) {
+      // Aterrizaje EXACTO en el encuadre curado; el beat muere aquí.
+      camera.position.copy(b.hasta);
+      camera.setFocalLength(b.fFinal);
+      const c = controls ? controls.current : null;
+      if (c) {
+        c.target.copy(b.tHasta);
+        c.update();
+      }
+      camera.lookAt(b.tHasta);
+      beatRef.current = null;
+    }
+  });
+
+  // Presencia puramente imperativa; nada que dibujar.
+  return null;
+}

--- a/src/visual/mundo3d/camaraDioramas.js
+++ b/src/visual/mundo3d/camaraDioramas.js
@@ -1,0 +1,171 @@
+/*
+ * camaraDioramas — ENCUADRES DE DIORAMA por mundo (FASE 4, fotografía).
+ *
+ * Cada mundo del framework merece su propio "establishing shot": el valle se
+ * lee desde arriba como maqueta querida; el café se camina entre surcos a la
+ * altura del grano; el mercado se llega a pie, a altura de ojos; el clima se
+ * contempla con lente abierto mirando la bóveda. Este módulo es SOLO DATOS
+ * (cero three, cero react): la coreografía vive en `CamaraDioramas.jsx`.
+ *
+ * ── Forma de un encuadre ──────────────────────────────────────────────────
+ *   posicion  [x,y,z]  pose FINAL de la cámara (unidades de mundo; las
+ *                      escenas viven en escala zoom≈6.5 de EscenaBase3D).
+ *   target    [x,y,z]  a dónde mira la cámara en reposo (y el OrbitControls
+ *                      hermano, si el host le pasa su ref al componente).
+ *   fov       número   ángulo final del lente. Corto (36-40) = tele íntimo,
+ *                      abre (46-52) = gran angular de plaza o de cielo.
+ *   beat      objeto   el gesto de ENTRADA (un solo beat, cozy, jamás
+ *                      montaña rusa):
+ *     retiro    factor de retroceso del arranque sobre el eje cámara→target
+ *               (1.4 → arranca 40% más lejos y hace dolly-in).
+ *     arcoY     radianes de giro alrededor de Y en el arranque: el dolly
+ *               dibuja un ARCO lateral, no una recta. Signo = lado.
+ *     grua      fracción de la distancia que la cámara arranca MÁS ALTA
+ *               (grúa que baja). Negativa = arranca baja y sube (semillero).
+ *     lente     factor de apertura inicial del lente (1.12 → ~12% más
+ *               abierto al arrancar; se asienta al fov final). 1 = sin gesto.
+ *     lambda    velocidad del damp exponencial (THREE.MathUtils.damp):
+ *               ~1.6 = llegada larga y contemplativa, ~3 = resuelta.
+ *
+ * Los siete mundos con fotografía propia están curados abajo; el resto cae a
+ * ENCUADRE_DEFECTO (la pose clásica del framework). `resolverEncuadre`
+ * entrega siempre un encuadre COMPLETO y ya ajustado por tier.
+ *
+ * ── Cableo (lo hace Opus, este módulo no toca nada existente) ─────────────
+ *   import { resolverEncuadre } from '../camaraDioramas';
+ *   import CamaraDioramas from '../CamaraDioramas';
+ *   // dentro del <Canvas> de la escena, junto a los OrbitControls:
+ *   <CamaraDioramas mundoId={mundoId} tier={tier}
+ *     reducedMotion={reducedMotion} controls={controlsRef} />
+ *   Nota: CamaraDioramas y CamaraDirector conducen la MISMA cámara — montar
+ *   uno u otro por escena, no ambos (este es el sucesor por-mundo de aquel).
+ */
+
+/** Beat neutro del framework: dolly-in corto con arco sutil y lente que se asienta. */
+export const BEAT_DEFECTO = Object.freeze({
+  retiro: 1.4,
+  arcoY: -0.12,
+  grua: 0.1,
+  lente: 1.1,
+  lambda: 2.1,
+});
+
+/** La pose clásica de EscenaBase3D (zoom 6.5), para mundos sin fotografía propia. */
+export const ENCUADRE_DEFECTO = Object.freeze({
+  posicion: [3.6, 3.25, 6.5],
+  target: [0, 0.7, 0],
+  fov: 42,
+  beat: BEAT_DEFECTO,
+});
+
+/**
+ * Encuadres curados por mundoId (los ids son las claves de MUNDO en
+ * mundoData.js). Cada uno con su intención fotográfica anotada.
+ */
+export const ENCUADRES = Object.freeze({
+  /* VALLE — plano maestro aéreo 3/4: la finca como maqueta querida. Tele
+     suave (38) comprime los planos del valle; la llegada es la más larga de
+     todas: se llega al valle, no se aparece en él. */
+  valle: {
+    posicion: [4.4, 4.8, 8.2],
+    target: [0, 0.9, 0],
+    fov: 38,
+    beat: { retiro: 1.55, arcoY: -0.16, grua: 0.14, lente: 1.12, lambda: 1.6 },
+  },
+
+  /* CAFÉ — caminar el cafetal: cámara baja, a la altura del grano, lente
+     tele íntimo. El arco lateral es el más marcado: entrar ENTRE surcos. */
+  cafe: {
+    posicion: [3.1, 1.9, 5.4],
+    target: [-0.2, 1.05, 0],
+    fov: 36,
+    beat: { retiro: 1.45, arcoY: 0.22, grua: 0.05, lente: 1.1, lambda: 2.0 },
+  },
+
+  /* SANIDAD — mirada de inspección: frontal elevada, sobria, sin arco casi.
+     Llegada resuelta (lambda alto): aquí se viene a revisar, no a pasear. */
+  sanidad: {
+    posicion: [2.3, 2.9, 5.6],
+    target: [0, 0.8, 0],
+    fov: 44,
+    beat: { retiro: 1.25, arcoY: -0.06, grua: 0.12, lente: 1.06, lambda: 3.0 },
+  },
+
+  /* MERCADO — llegar a la plaza a pie: altura de ojos, gran angular de
+     bullicio, grúa casi nula (se entra caminando, no volando). */
+  mercado: {
+    posicion: [3.5, 1.6, 6.0],
+    target: [0, 1.0, 0.2],
+    fov: 48,
+    beat: { retiro: 1.5, arcoY: -0.18, grua: 0.02, lente: 1.08, lambda: 2.2 },
+  },
+
+  /* ANIMALES — al borde del corral: cámara baja y cálida, arco amplio que
+     RODEA el recinto antes de asentarse. */
+  animales: {
+    posicion: [4.1, 1.5, 5.2],
+    target: [0, 0.6, 0],
+    fov: 42,
+    beat: { retiro: 1.4, arcoY: 0.26, grua: 0.06, lente: 1.1, lambda: 1.9 },
+  },
+
+  /* SEMILLERO — ternura macro: cerca y en picado suave sobre las bandejas.
+     Grúa NEGATIVA: la cámara arranca abajo y SUBE a asomarse, como quien se
+     inclina sobre lo recién germinado. */
+  semillero: {
+    posicion: [2.0, 2.5, 3.6],
+    target: [0, 0.4, 0],
+    fov: 38,
+    beat: { retiro: 1.3, arcoY: -0.1, grua: -0.08, lente: 1.12, lambda: 2.4 },
+  },
+
+  /* CLIMA — contemplar la bóveda: lejos y bajo, target alto (se mira el
+     cielo), el lente más abierto del set y la llegada más lenta: las nubes
+     no corren. Escala pareada con EscenaBoveda ([4.6, 3.1, 8.6]). */
+  clima: {
+    posicion: [4.6, 2.6, 8.6],
+    target: [0, 2.2, 0],
+    fov: 50,
+    beat: { retiro: 1.35, arcoY: -0.1, grua: -0.05, lente: 1.14, lambda: 1.5 },
+  },
+});
+
+/** Ids con fotografía curada (útil para tests y para el host). */
+export const ENCUADRE_IDS = Object.freeze(Object.keys(ENCUADRES));
+
+/*
+ * Ajuste por tier de equipo (deviceTier.js: 'alto' | 'medio' | 'bajo'):
+ *  - alto  → el beat completo tal como está curado.
+ *  - medio → llegada más corta (lambda +60%) y sin gesto de lente (el cambio
+ *            de fov re-proyecta cada frame; en equipos medios no vale el
+ *            costo). El encuadre FINAL es idéntico: cero regresión de pose.
+ *  - bajo  → sin beat (lambda 0 = señal de "clavar la pose"): normalmente el
+ *            host ni monta 3D en bajo (permite3D), pero si llega, respeto.
+ */
+const AJUSTE_TIER = Object.freeze({
+  alto: (beat) => beat,
+  medio: (beat) => ({ ...beat, lambda: beat.lambda * 1.6, lente: 1 }),
+  bajo: (beat) => ({ ...beat, lambda: 0, lente: 1 }),
+});
+
+/**
+ * Encuadre completo (posición/target/fov/beat) para un mundo y un tier.
+ * Siempre devuelve objeto NUEVO y completo: mundos sin curaduría caen al
+ * defecto, beats parciales se completan con BEAT_DEFECTO.
+ *
+ * @param {string} mundoId  clave de MUNDO (mundoData.js), p. ej. 'cafe'.
+ * @param {'alto'|'medio'|'bajo'} [tier]
+ * @returns {{ posicion: number[], target: number[], fov: number,
+ *             beat: { retiro:number, arcoY:number, grua:number,
+ *                     lente:number, lambda:number } }}
+ */
+export function resolverEncuadre(mundoId, tier = 'alto') {
+  const base = ENCUADRES[mundoId] || ENCUADRE_DEFECTO;
+  const ajustar = AJUSTE_TIER[tier] || AJUSTE_TIER.alto;
+  return {
+    posicion: [...base.posicion],
+    target: [...base.target],
+    fov: base.fov,
+    beat: ajustar({ ...BEAT_DEFECTO, ...base.beat }),
+  };
+}


### PR DESCRIPTION
## Que hace

FASE 4 — establishing shot propio por mundo. Dos archivos NUEVOS autocontenidos, cero ediciones a codigo existente.

- `src/visual/mundo3d/camaraDioramas.js` — config pura de encuadres por mundoId: `posicion`/`target`/`fov` + `beat` de entrada (`retiro`, `arcoY`, `grua`, `lente`, `lambda`). Siete mundos curados con intencion fotografica anotada (valle aereo 3/4 tele, cafe entre surcos a altura de grano, sanidad frontal de inspeccion, mercado a pie gran angular, animales rodeando el corral, semillero en picado tierno con grua invertida, clima contemplando la boveda con el lente mas abierto). Fallback `ENCUADRE_DEFECTO` (pose clasica zoom 6.5 / fov 42) para el resto. `resolverEncuadre(mundoId, tier)` entrega encuadre completo ya ajustado por tier (medio: llegada corta y sin gesto de lente; bajo: pose clavada).
- `src/visual/mundo3d/CamaraDioramas.jsx` — componente r3f (return null) montable por props `mundoId`/`tier`/`reducedMotion`/`controls`/`activa`/`unaVezPorSesion`. Beat por `THREE.MathUtils.damp` (frame-rate independiente, sin dependencias nuevas — `maath` no esta en package.json). Primer pointerdown acelera la llegada; aterrizaje exacto en la pose curada y frame-loop inerte despues. reducedMotion/tier bajo/`activa=false` clavan la pose en un paso.

## Cableo pendiente (Opus)

Dentro del `<Canvas>` de la escena, junto a los OrbitControls:

```jsx
<CamaraDioramas mundoId={mundoId} tier={tier} reducedMotion={reducedMotion} controls={controlsRef} />
```

Excluyente con `CamaraDirector` en la misma escena (ambos conducen la misma camara); este lo reemplaza donde haya encuadre curado. Detalle completo en los encabezados de ambos archivos.

## Verificacion

- `npx eslint --max-warnings 0` sobre ambos archivos: limpio.
- `timeout 300 npm run build`: exit 0 (18.5s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)