### PR TITLE
feat(3d): kit de particulas ambientales de la hora dorada

### DIFF
--- a/src/visual/mundo3d/ParticulasAmbientales.jsx
+++ b/src/visual/mundo3d/ParticulasAmbientales.jsx
@@ -1,0 +1,346 @@
+/*
+ * ParticulasAmbientales — el AIRE de los dioramas: polen dorado que flota,
+ * luciérnagas que pulsan al atardecer, motas de polvo en un rayo de luz y
+ * mariposas que cruzan la escena. Grupo R3F autocontenido, montable como child
+ * de cualquier escena-mundo.
+ *
+ * CABLEO (para el host, sin tocar este archivo):
+ *
+ *   import { ParticulasAmbientales } from '../ParticulasAmbientales.jsx';
+ *   // dentro del <Canvas> de la escena, junto a la fauna:
+ *   <ParticulasAmbientales tipo="polen" tier={tier} reducedMotion={reducedMotion} />
+ *   <ParticulasAmbientales tipo="polvo" position={[2.5, 0.4, -1]} tier={tier} reducedMotion={reducedMotion} />
+ *   <ParticulasAmbientales tipo="luciernagas" densidad={0.7} tier={tier} reducedMotion={reducedMotion} />
+ *
+ *   - `tier` y `reducedMotion` vienen de `decidirTier()` (deviceTier.js), igual
+ *     que en el resto del framework. `bajo` monta una fracción; mariposas en
+ *     `bajo` no montan.
+ *   - `area` y `position` sitúan la nube; los defaults por tipo (particulasData)
+ *     asumen escenas de ~10 unidades de lado. Pase `area` ESTABLE (constante de
+ *     módulo o useMemo del host): la nube se re-siembra si cambia.
+ *   - El polvo trae inclinación de haz por defecto; `rotation` la sobreescribe.
+ *   - Asume el frameloop continuo de las escenas vivas (igual que FaunaEscena);
+ *     con `frameloop="demand"` la nube queda congelada en su siembra, que es
+ *     exactamente el modo reduced-motion.
+ *   - Debe importarse desde una escena (chunk perezoso vendor-three): este
+ *     archivo importa `three` y `@react-three/fiber`.
+ *
+ * FRUGALIDAD: cada nube es UN `THREE.Points` (1 draw call); los buffers se mutan
+ * en sitio en `useFrame` (cero asignaciones por frame). Las mariposas son 3
+ * `InstancedMesh` (alas izq/der + cuerpo) con ≤4 instancias y matrices
+ * recompuestas sobre temporales de módulo. Presupuestos por tier en
+ * `particulasData.js`; en gama baja el total del kit queda en decenas de
+ * vértices — no compite con los 30 fps de nadie.
+ *
+ * REDUCED-MOTION (contrato del framework): polen y polvo quedan QUIETOS en su
+ * siembra (presencia sin movimiento); las luciérnagas quedan quietas a brillo
+ * medio fijo (sin parpadeo); las mariposas NO montan — congeladas en el aire
+ * leen como glitch, no como calma.
+ */
+import { useEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { useFrame } from '@react-three/fiber';
+import { PARTICULAS, conteoParticulas, crearRng } from './particulasData.js';
+
+/* ------------------------------------------------------------------------- *
+ * Sprite suave compartido: un radial-gradient de 64px generado UNA vez. Sin él
+ * los Points son cuadrados duros; con él, cada partícula es un halo. Cacheado a
+ * nivel de módulo (todas las nubes comparten la textura) y con guarda SSR.
+ * ------------------------------------------------------------------------- */
+let spriteCache = null;
+function spriteSuave() {
+  if (spriteCache) return spriteCache;
+  if (typeof document === 'undefined') return null;
+  const lienzo = document.createElement('canvas');
+  lienzo.width = 64;
+  lienzo.height = 64;
+  const ctx = lienzo.getContext('2d');
+  if (!ctx) return null;
+  const grad = ctx.createRadialGradient(32, 32, 0, 32, 32, 32);
+  grad.addColorStop(0, 'rgba(255,255,255,1)');
+  grad.addColorStop(0.45, 'rgba(255,255,255,0.55)');
+  grad.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, 64, 64);
+  spriteCache = new THREE.CanvasTexture(lienzo);
+  return spriteCache;
+}
+
+/* ------------------------------------------------------------------------- *
+ * NubePuntos — polen / polvo / luciérnagas sobre un único THREE.Points.
+ * La siembra (posiciones, colores, fases) es determinista por `semilla`.
+ * ------------------------------------------------------------------------- */
+function NubePuntos({ cfg, n, zona, reducedMotion, semilla }) {
+  const puntos = useRef(null);
+
+  const datos = useMemo(() => {
+    const rng = crearRng(semilla);
+    const pos = new Float32Array(n * 3);
+    const base = new Float32Array(n * 3);
+    const col = new Float32Array(n * 3);
+    const colBase = new Float32Array(n * 3);
+    const fase = new Float32Array(n);
+    const vel = new Float32Array(n);
+    const color = new THREE.Color();
+    const [ax, ay, az] = zona;
+    for (let i = 0; i < n; i++) {
+      const j = i * 3;
+      base[j] = (rng() - 0.5) * ax;
+      base[j + 1] = rng() * ay;
+      base[j + 2] = (rng() - 0.5) * az;
+      pos[j] = base[j];
+      pos[j + 1] = base[j + 1];
+      pos[j + 2] = base[j + 2];
+      fase[i] = rng() * Math.PI * 2;
+      vel[i] = 0.6 + rng() * 0.8;
+      color.set(cfg.colores[Math.floor(rng() * cfg.colores.length)]);
+      /* Luciérnaga quieta (reduced-motion): brillo medio horneado, sin pulso. */
+      const brillo = cfg.parpadeo && reducedMotion ? cfg.parpadeo.quieto : 1;
+      colBase[j] = color.r;
+      colBase[j + 1] = color.g;
+      colBase[j + 2] = color.b;
+      col[j] = color.r * brillo;
+      col[j + 1] = color.g * brillo;
+      col[j + 2] = color.b * brillo;
+    }
+    return { pos, base, col, colBase, fase, vel };
+  }, [cfg, n, zona, reducedMotion, semilla]);
+
+  useFrame(({ clock }) => {
+    if (reducedMotion || !puntos.current) return;
+    const t = clock.elapsedTime;
+    const geo = puntos.current.geometry;
+    const p = geo.attributes.position.array;
+    const { base, fase, vel } = datos;
+    const [, ay] = zona;
+    const amp = cfg.deriva?.vaiven ?? 0.3;
+
+    if (cfg.gesto === 'flotar') {
+      /* Polen: asciende despacio y ondula; sale por arriba, reaparece abajo. */
+      const sube = cfg.deriva.ascenso;
+      for (let i = 0; i < datos.fase.length; i++) {
+        const j = i * 3;
+        p[j] = base[j] + Math.sin(t * 0.5 * vel[i] + fase[i]) * amp;
+        p[j + 1] = (base[j + 1] + t * sube * vel[i]) % ay;
+        p[j + 2] = base[j + 2] + Math.cos(t * 0.4 * vel[i] + fase[i]) * amp;
+      }
+    } else if (cfg.gesto === 'errar') {
+      /* Luciérnagas: erran despacio y PULSAN con desfase (flash asimétrico). */
+      const c = geo.attributes.color.array;
+      const { colBase } = datos;
+      const { frecuencia, minimo } = cfg.parpadeo;
+      for (let i = 0; i < datos.fase.length; i++) {
+        const j = i * 3;
+        p[j] = base[j] + Math.sin(t * 0.3 * vel[i] + fase[i]) * amp;
+        p[j + 1] = base[j + 1] + Math.sin(t * 0.23 * vel[i] + fase[i] * 2.1) * amp * 0.5;
+        p[j + 2] = base[j + 2] + Math.cos(t * 0.27 * vel[i] + fase[i]) * amp;
+        const onda = Math.max(0, Math.sin(t * frecuencia * vel[i] + fase[i] * 3));
+        const pulso = minimo + (1 - minimo) * onda * onda * onda;
+        c[j] = colBase[j] * pulso;
+        c[j + 1] = colBase[j + 1] * pulso;
+        c[j + 2] = colBase[j + 2] * pulso;
+      }
+      geo.attributes.color.needsUpdate = true;
+    } else {
+      /* Polvo: suspensión browniana mínima dentro del haz. */
+      for (let i = 0; i < datos.fase.length; i++) {
+        const j = i * 3;
+        p[j] = base[j] + Math.sin(t * 0.15 * vel[i] + fase[i]) * amp;
+        p[j + 1] = base[j + 1] + Math.sin(t * 0.1 * vel[i] + fase[i] * 1.7) * amp * 1.4;
+        p[j + 2] = base[j + 2] + Math.cos(t * 0.12 * vel[i] + fase[i]) * amp;
+      }
+    }
+    geo.attributes.position.needsUpdate = true;
+  });
+
+  /* La nube se mueve dentro de su caja: culling por esfera inicial recortaría
+     partículas vivas al borde del encuadre. */
+  return (
+    <points ref={puntos} frustumCulled={false}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[datos.pos, 3]} />
+        <bufferAttribute attach="attributes-color" args={[datos.col, 3]} />
+      </bufferGeometry>
+      <pointsMaterial
+        map={spriteSuave()}
+        size={cfg.tam}
+        vertexColors
+        transparent
+        opacity={cfg.opacidad}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        sizeAttenuation
+      />
+    </points>
+  );
+}
+
+/* ------------------------------------------------------------------------- *
+ * Mariposas — 3 InstancedMesh (ala izq, ala der, cuerpo). Cada mariposa cruza
+ * la zona con rumbo propio y reentra por el lado opuesto; el aleteo rota cada
+ * ala sobre su bisagra (la geometría va trasladada para que el eje quede en el
+ * cuerpo). Temporales de módulo: cero asignaciones por frame.
+ * ------------------------------------------------------------------------- */
+const M_BASE = new THREE.Matrix4();
+const M_ALA = new THREE.Matrix4();
+const M_FIN = new THREE.Matrix4();
+const DUMMY = new THREE.Object3D();
+
+function Mariposas({ cfg, n, zona, semilla }) {
+  const izq = useRef(null);
+  const der = useRef(null);
+  const cuerpo = useRef(null);
+
+  const geos = useMemo(() => {
+    const [aw, ah] = cfg.ala;
+    const gIzq = new THREE.PlaneGeometry(aw, ah);
+    gIzq.rotateX(-Math.PI / 2);
+    gIzq.translate(aw / 2 + 0.015, 0, 0);
+    const gDer = new THREE.PlaneGeometry(aw, ah);
+    gDer.rotateX(-Math.PI / 2);
+    gDer.translate(-aw / 2 - 0.015, 0, 0);
+    return { gIzq, gDer };
+  }, [cfg]);
+  useEffect(() => {
+    const { gIzq, gDer } = geos;
+    return () => {
+      gIzq.dispose();
+      gDer.dispose();
+    };
+  }, [geos]);
+
+  const datos = useMemo(() => {
+    const rng = crearRng(semilla + 101);
+    const [ax, , az] = zona;
+    const { velocidad, aleteo, altura } = cfg.vuelo;
+    const lista = [];
+    for (let i = 0; i < n; i++) {
+      const ang = rng() * Math.PI * 2;
+      lista.push({
+        dir: [Math.sin(ang), Math.cos(ang)],
+        centro: [(rng() - 0.5) * ax * 0.4, (rng() - 0.5) * az * 0.4],
+        alturaBase: altura * (0.6 + rng() * 0.4),
+        vel: velocidad[0] + rng() * (velocidad[1] - velocidad[0]),
+        aleteo: aleteo[0] + rng() * (aleteo[1] - aleteo[0]),
+        fase: rng() * Math.PI * 2,
+        recorrido: Math.max(ax, az) + 3,
+        color: cfg.colores[Math.floor(rng() * cfg.colores.length)],
+      });
+    }
+    return lista;
+  }, [cfg, n, zona, semilla]);
+
+  /* Colores por instancia: una vez por siembra. */
+  useEffect(() => {
+    const tinta = new THREE.Color();
+    const marron = new THREE.Color(cfg.colorCuerpo);
+    datos.forEach((d, i) => {
+      tinta.set(d.color);
+      izq.current?.setColorAt(i, tinta);
+      der.current?.setColorAt(i, tinta);
+      cuerpo.current?.setColorAt(i, marron);
+    });
+    for (const ref of [izq, der, cuerpo]) {
+      if (ref.current?.instanceColor) ref.current.instanceColor.needsUpdate = true;
+    }
+  }, [cfg, datos]);
+
+  useFrame(({ clock }) => {
+    if (!izq.current || !der.current || !cuerpo.current) return;
+    const t = clock.elapsedTime;
+    for (let i = 0; i < datos.length; i++) {
+      const d = datos[i];
+      /* Avance sobre el rumbo, con reentrada por el lado opuesto. */
+      const s = ((t * d.vel + d.fase * 2) % d.recorrido) - d.recorrido / 2;
+      const x = d.centro[0] + d.dir[0] * s;
+      const z = d.centro[1] + d.dir[1] * s;
+      const y = d.alturaBase + Math.sin(t * 1.3 + d.fase) * cfg.vuelo.bamboleo;
+      DUMMY.position.set(x, y, z);
+      DUMMY.rotation.set(0, Math.atan2(d.dir[0], d.dir[1]), 0);
+      DUMMY.updateMatrix();
+      M_BASE.copy(DUMMY.matrix);
+      const flap = Math.sin(t * d.aleteo + d.fase) * 0.95;
+      M_ALA.makeRotationZ(flap);
+      M_FIN.multiplyMatrices(M_BASE, M_ALA);
+      izq.current.setMatrixAt(i, M_FIN);
+      M_ALA.makeRotationZ(-flap);
+      M_FIN.multiplyMatrices(M_BASE, M_ALA);
+      der.current.setMatrixAt(i, M_FIN);
+      cuerpo.current.setMatrixAt(i, M_BASE);
+    }
+    izq.current.instanceMatrix.needsUpdate = true;
+    der.current.instanceMatrix.needsUpdate = true;
+    cuerpo.current.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <group>
+      <instancedMesh ref={izq} args={[undefined, undefined, n]} geometry={geos.gIzq} frustumCulled={false}>
+        <meshBasicMaterial side={THREE.DoubleSide} />
+      </instancedMesh>
+      <instancedMesh ref={der} args={[undefined, undefined, n]} geometry={geos.gDer} frustumCulled={false}>
+        <meshBasicMaterial side={THREE.DoubleSide} />
+      </instancedMesh>
+      <instancedMesh ref={cuerpo} args={[undefined, undefined, n]} frustumCulled={false}>
+        <boxGeometry args={cfg.cuerpo} />
+        <meshBasicMaterial />
+      </instancedMesh>
+    </group>
+  );
+}
+
+/**
+ * Kit de partículas ambientales de la hora dorada. Monte una instancia por
+ * efecto (varias conviven sin pisarse: cada una es 1-3 draw calls).
+ *
+ * @param {object} p
+ * @param {'polen'|'luciernagas'|'polvo'|'mariposas'} [p.tipo='polen']
+ * @param {number}  [p.densidad=1]      multiplicador del conteo, acotado [0, 2].
+ * @param {'alto'|'medio'|'bajo'} [p.tier='medio']  de `decidirTier()`.
+ * @param {boolean} [p.reducedMotion=false]  quieto (polen/polvo/luciérnagas) o
+ *                                           apagado (mariposas).
+ * @param {[number,number,number]} [p.area]  caja [ancho, alto, fondo]; default
+ *                                           por tipo. Pase referencia ESTABLE.
+ * @param {[number,number,number]} [p.position=[0,0,0]]  ancla en la escena
+ *                                           (base de la caja, y=0 es el piso).
+ * @param {[number,number,number]} [p.rotation]  inclinación del grupo; el polvo
+ *                                           trae su sesgo de haz por defecto.
+ * @param {number}  [p.semilla=7]        siembra determinista (variar por escena).
+ */
+export function ParticulasAmbientales({
+  tipo = 'polen',
+  densidad = 1,
+  tier = 'medio',
+  reducedMotion = false,
+  area = null,
+  position = [0, 0, 0],
+  rotation = null,
+  semilla = 7,
+}) {
+  const cfg = PARTICULAS[tipo];
+  if (!cfg) return null;
+  const n = conteoParticulas(cfg, tier, densidad);
+  if (n <= 0) return null;
+  if (cfg.mariposa && reducedMotion) return null;
+  const zona = area || cfg.area;
+  const giro = rotation || cfg.rotacion || [0, 0, 0];
+  /* La key re-siembra la nube entera si cambia el presupuesto o la caja: los
+     buffers de un <bufferAttribute> solo se leen al montar. */
+  const clave = `${tipo}:${n}:${semilla}:${reducedMotion ? 1 : 0}:${zona.join(',')}`;
+  return (
+    <group position={position} rotation={giro}>
+      {cfg.mariposa ? (
+        <Mariposas key={clave} cfg={cfg} n={n} zona={zona} semilla={semilla} />
+      ) : (
+        <NubePuntos
+          key={clave}
+          cfg={cfg}
+          n={n}
+          zona={zona}
+          reducedMotion={reducedMotion}
+          semilla={semilla}
+        />
+      )}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/__tests__/particulasData.test.js
+++ b/src/visual/mundo3d/__tests__/particulasData.test.js
@@ -1,0 +1,51 @@
+import { describe, test, expect } from 'vitest';
+
+import { PARTICULAS, conteoParticulas, crearRng } from '../particulasData.js';
+
+describe('particulasData — presupuestos del kit de partículas (puras)', () => {
+  test('los cuatro tipos existen con presupuesto por tier completo', () => {
+    for (const tipo of ['polen', 'luciernagas', 'polvo', 'mariposas']) {
+      const cfg = PARTICULAS[tipo];
+      expect(cfg, tipo).toBeDefined();
+      for (const tier of ['alto', 'medio', 'bajo']) {
+        expect(typeof cfg.conteo[tier], `${tipo}.${tier}`).toBe('number');
+      }
+      /* tier bajo NUNCA recibe más que medio, ni medio más que alto. */
+      expect(cfg.conteo.bajo).toBeLessThanOrEqual(cfg.conteo.medio);
+      expect(cfg.conteo.medio).toBeLessThanOrEqual(cfg.conteo.alto);
+    }
+  });
+
+  test('mariposas en tier bajo no montan (coherente con criaturas:0)', () => {
+    expect(conteoParticulas(PARTICULAS.mariposas, 'bajo')).toBe(0);
+  });
+
+  test('densidad escala pero queda acotada a [0, 2]', () => {
+    const cfg = PARTICULAS.polen;
+    const base = conteoParticulas(cfg, 'alto', 1);
+    expect(conteoParticulas(cfg, 'alto', 0.5)).toBe(Math.round(base * 0.5));
+    expect(conteoParticulas(cfg, 'alto', 9)).toBe(base * 2);
+    expect(conteoParticulas(cfg, 'alto', -3)).toBe(0);
+    expect(conteoParticulas(cfg, 'alto', NaN)).toBe(base);
+  });
+
+  test('tier desconocido cae al presupuesto medio, nunca al caro', () => {
+    const cfg = PARTICULAS.polvo;
+    expect(conteoParticulas(cfg, 'ultra')).toBe(cfg.conteo.medio);
+    expect(conteoParticulas(null, 'alto')).toBe(0);
+  });
+
+  test('crearRng es determinista por semilla y queda en [0, 1)', () => {
+    const a = crearRng(7);
+    const b = crearRng(7);
+    const c = crearRng(8);
+    const serieA = [a(), a(), a()];
+    const serieB = [b(), b(), b()];
+    expect(serieA).toEqual(serieB);
+    expect(serieA).not.toEqual([c(), c(), c()]);
+    for (const v of serieA) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+});

--- a/src/visual/mundo3d/particulasData.js
+++ b/src/visual/mundo3d/particulasData.js
@@ -1,0 +1,115 @@
+/*
+ * particulasData — el QUÉ del kit de partículas ambientales.
+ *
+ * Los dioramas tienen fauna (FaunaEscena) y clima (atmosferaMadre), pero el AIRE
+ * estaba vacío: sin polen a contraluz, sin motas en los rayos, sin luciérnagas al
+ * caer la tarde. Este archivo define los CUATRO tipos del kit y sus presupuestos;
+ * la math del movimiento vive en `ParticulasAmbientales.jsx` (mismo contrato que
+ * faunaFuncional: el QUÉ en data, el CÓMO en el componente).
+ *
+ * FRUGALIDAD (DR-3D-PERF-GAMABAJA): cada nube es UN `THREE.Points` (1 draw call,
+ * buffers mutados en sitio, cero GC por frame); las mariposas son 3 InstancedMesh
+ * (alas izq/der + cuerpo, ≤4 instancias). Los conteos por tier son el presupuesto
+ * DURO: `bajo` recibe una fracción y las mariposas ni montan (coherente con
+ * `criaturas: 0` del perfil bajo de deviceTier).
+ *
+ * PALETA: hereda la hora dorada de `atmosferaMadre.js` (ATMOSFERA.luz #ffd79a,
+ * niebla #f0c98d) — nada de blancos puros ni neones; hasta la luciérnaga es
+ * cálida, como corresponde bajo un sol dorado de valle.
+ */
+
+/*
+ * PRNG determinista (mulberry32): la misma `semilla` produce la misma nube en
+ * cada montaje/test/SSR. Evita `Math.random()` para que los snapshots y los
+ * remounts (StrictMode) no "salten".
+ */
+export function crearRng(semilla = 1) {
+  let a = semilla >>> 0;
+  return function rng() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/*
+ * Cada tipo declara:
+ *   conteo    → presupuesto por tier ANTES del multiplicador `densidad`.
+ *   colores   → paleta (se sortea por partícula, vertex-colors).
+ *   tam       → tamaño del sprite en unidades de mundo (sizeAttenuation).
+ *   opacidad  → alfa del material (todas aditivas: brillan sin tapar).
+ *   area      → caja por defecto [ancho, alto, fondo] donde vive la nube.
+ *   gesto     → qué loop de movimiento corre el componente.
+ *   rotacion  → inclinación por defecto del grupo (el haz de polvo va sesgado).
+ *   parpadeo  → solo luciérnagas: [frecuencia base, brillo mínimo].
+ *   mariposa  → ruta especial: mallas instanciadas, no puntos.
+ */
+export const PARTICULAS = {
+  /* Polen dorado a contraluz: sube despacio, ondula, y al salir por arriba
+     reaparece abajo. El alma de la hora dorada. */
+  polen: {
+    conteo: { alto: 90, medio: 48, bajo: 20 },
+    colores: ['#ffd79a', '#f7c66b', '#ffeec0'],
+    tam: 0.09,
+    opacidad: 0.8,
+    area: [9, 4, 9],
+    gesto: 'flotar',
+    deriva: { ascenso: 0.14, vaiven: 0.32 },
+  },
+
+  /* Luciérnagas del atardecer: pocas, grandes, erran despacio y PULSAN con
+     desfase propio (nunca en coro). Con reduced-motion quedan quietas a brillo
+     medio: presencia sin parpadeo. */
+  luciernagas: {
+    conteo: { alto: 22, medio: 12, bajo: 6 },
+    colores: ['#fff3b0', '#ffe08a', '#eaf0a0'],
+    tam: 0.17,
+    opacidad: 0.9,
+    area: [8, 2.6, 8],
+    gesto: 'errar',
+    deriva: { vaiven: 0.85 },
+    parpadeo: { frecuencia: 0.9, minimo: 0.1, quieto: 0.55 },
+  },
+
+  /* Motas de polvo en un rayo de luz: nube angosta y alta, sesgada como haz que
+     entra por un claro; casi inmóviles, apenas suspendidas. */
+  polvo: {
+    conteo: { alto: 80, medio: 40, bajo: 16 },
+    colores: ['#f0c98d', '#eadfc4'],
+    tam: 0.055,
+    opacidad: 0.38,
+    area: [1.7, 4.6, 1.7],
+    gesto: 'suspension',
+    deriva: { vaiven: 0.2 },
+    rotacion: [0, 0, -0.32],
+  },
+
+  /* Mariposas que cruzan la escena: cada una con rumbo propio, aleteo con
+     desfase y colores de ala sorteados. En `bajo` no montan (criaturas: 0) y
+     con reduced-motion tampoco: una mariposa congelada en el aire lee como
+     glitch, no como calma. */
+  mariposas: {
+    conteo: { alto: 4, medio: 2, bajo: 0 },
+    colores: ['#e8a24a', '#f2c94c', '#c96f3a', '#e8e0c8'],
+    colorCuerpo: '#5a4326',
+    area: [10, 1.6, 10],
+    ala: [0.3, 0.2],
+    cuerpo: [0.045, 0.045, 0.22],
+    vuelo: { velocidad: [0.5, 0.9], aleteo: [7, 10], altura: 1.6, bamboleo: 0.22 },
+    mariposa: true,
+  },
+};
+
+/*
+ * El presupuesto final de una nube: conteo del tier × densidad, con densidad
+ * acotada a [0, 2] (el kit es sutil por contrato: ni un `densidad={9}` de un
+ * caller entusiasta puede convertirlo en tormenta).
+ */
+export function conteoParticulas(cfg, tier, densidad = 1) {
+  if (!cfg || !cfg.conteo) return 0;
+  const base = cfg.conteo[tier] ?? cfg.conteo.medio ?? 0;
+  const factor = Math.min(2, Math.max(0, Number.isFinite(densidad) ? densidad : 1));
+  return Math.round(base * factor);
+}


### PR DESCRIPTION
## Que trae

Kit reutilizable de particulas ambientales para dar vida al aire de los dioramas 3D. **Solo archivos nuevos** — ninguna escena existente fue tocada; el cableo queda documentado en el header del componente para que se monte donde se decida.

### Archivos
- `src/visual/mundo3d/ParticulasAmbientales.jsx` — grupo R3F montable como child de una escena.
- `src/visual/mundo3d/particulasData.js` — el QUE: presupuestos por tier, paleta, gestos (contrato faunaFuncional: data/componente).
- `src/visual/mundo3d/__tests__/particulasData.test.js` — 5 tests puros de presupuestos y RNG determinista.

### Tipos
| tipo | efecto | render |
|---|---|---|
| `polen` | motas doradas que ascienden y ondulan, reentran por abajo | 1 `THREE.Points` |
| `luciernagas` | pocas, erran despacio, pulso asimetrico con desfase propio | 1 `THREE.Points` |
| `polvo` | haz sesgado de motas casi inmoviles | 1 `THREE.Points` |
| `mariposas` | cruzan la escena con rumbo propio, aleteo con bisagra | 3 `InstancedMesh` (n<=4) |

### Props
`tipo`, `densidad` (acotada [0,2]), `tier` (de `decidirTier()`), `reducedMotion`, `area`, `position`, `rotation`, `semilla`.

### Frugalidad
- Buffers mutados en sitio en `useFrame`, cero asignaciones por frame; temporales de modulo para matrices.
- Presupuesto por tier: `bajo` recibe fraccion (p.ej. polen 90/48/20) y mariposas ni montan (coherente con `criaturas: 0` del perfil bajo de deviceTier).
- Sprite radial compartido (CanvasTexture 64px, cache de modulo), blending aditivo, `depthWrite: false`.

### reduced-motion
Polen/polvo quedan quietos en su siembra; luciernagas quietas a brillo medio fijo (sin parpadeo); mariposas apagadas (congeladas en el aire leen como glitch).

### Paleta
Heredada de la hora dorada de `atmosferaMadre.js` (#ffd79a / #f0c98d): nada de blancos puros ni neones.

## Verificacion
- `eslint --max-warnings 0` sobre los 3 archivos nuevos: limpio.
- `vitest run` test nuevo: 5/5.
- `npm run build`: exit 0 (20s).

## Cableo sugerido (Opus)
```jsx
<ParticulasAmbientales tipo="polen" tier={tier} reducedMotion={reducedMotion} />
<ParticulasAmbientales tipo="polvo" position={[2.5, 0.4, -1]} tier={tier} reducedMotion={reducedMotion} />
```
Importar desde una escena (chunk perezoso vendor-three). `area` debe ser referencia estable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)