### PR TITLE
feat(3d): vitrina jugable de infraestructura con demo de modo colocar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -147,6 +147,10 @@ const EvidenciaIlustrada = lazy(() => import('./mockups/EvidenciaIlustrada'));
 const MockupGuardianesNarrativos = lazy(() => import('./mockups/MockupGuardianesNarrativos'));
 const HojaVidaMataMockup = lazy(() => import('./components/mockups/HojaVidaMataMockup'));
 const VitrinaCriaturasMockup = lazy(() => import('./mockups/vitrina3d/VitrinaCriaturas'));
+// 3D: vitrina JUGABLE de las piezas de construcción (invernaderos, galpón,
+// establo, bodega, tanque, secadero…) con control de tamaño por pieza y el
+// mini demo del modo colocar (snapping sobre la ladera).
+const VitrinaInfraestructuraMockup = lazy(() => import('./mockups/vitrina3d/VitrinaInfraestructura'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
@@ -538,6 +542,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/infraestructura-3d': 'mockup_infraestructura_3d',
   'mockups/colocar-infraestructura': 'mockup_colocar_infraestructura',
   'mockups/vitrina-3d': 'mockup_vitrina_3d',
+  'mockups/vitrina-infra': 'mockup_vitrina_infra',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1716,6 +1721,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Vitrina de criaturas y mundos">
               <VitrinaCriaturasMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_vitrina_infra':
+        // Vitrina JUGABLE de la librería de infraestructura: las piezas de
+        // construcción del catálogo agrupadas por familia en pestañas, cada una
+        // en su diorama 3D girable con control de tamaño, + el mini demo del
+        // modo colocar (tocar la ladera, snapping a la altura del terreno,
+        // girar 45° y fijar). Ruta #/mockups/vitrina-infra, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Vitrina de infraestructura">
+              <VitrinaInfraestructuraMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/vitrina3d/VitrinaInfraestructura.css
+++ b/src/mockups/vitrina3d/VitrinaInfraestructura.css
@@ -1,0 +1,404 @@
+/*
+ * VitrinaInfraestructura — estilos de la vitrina de piezas de construcción
+ * (#/mockups/vitrina-infra). Cuaderno de laboratorio andino: crema tibia,
+ * tinta profunda, verde páramo y el dorado de la hora dorada del valle.
+ * Móvil-first (320px), táctil (controles >= 44px), autocontenido.
+ */
+
+.vitin {
+  --vitin-crema: #f7f1e2;
+  --vitin-papel: #fffaf0;
+  --vitin-tinta: #2c3324;
+  --vitin-tinta-suave: #5c6350;
+  --vitin-verde: #3f6f4e;
+  --vitin-verde-oscuro: #2d5039;
+  --vitin-dorado: #f2b134;
+  --vitin-borde: #d9cfb4;
+  --vitin-sombra: 0 2px 10px rgba(60, 52, 31, 0.12);
+
+  min-height: 100vh;
+  min-height: 100dvh;
+  background:
+    radial-gradient(1200px 500px at 80% -10%, #fdf6e4 0%, transparent 60%),
+    var(--vitin-crema);
+  color: var(--vitin-tinta);
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  padding-bottom: 3rem;
+}
+
+/* ── Cabecera ─────────────────────────────────────────────────────────────── */
+.vitin__head {
+  padding: 0.9rem 1rem 0.75rem;
+  border-bottom: 2px solid var(--vitin-borde);
+  background: linear-gradient(180deg, var(--vitin-papel) 0%, var(--vitin-crema) 100%);
+  position: relative;
+}
+
+.vitin__headMain {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  max-width: 72rem;
+  margin: 0 auto;
+}
+
+.vitin__back {
+  flex: none;
+  min-height: 44px;
+  padding: 0.45rem 0.85rem;
+  border: 1.5px solid var(--vitin-borde);
+  border-radius: 999px;
+  background: var(--vitin-papel);
+  color: var(--vitin-tinta);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.vitin__back:active { transform: translateY(1px); }
+
+.vitin__title {
+  margin: 0;
+  font-size: 1.25rem;
+  line-height: 1.25;
+  color: var(--vitin-verde-oscuro);
+  letter-spacing: 0.01em;
+}
+
+.vitin__sub {
+  margin: 0.3rem 0 0;
+  font-size: 0.87rem;
+  line-height: 1.45;
+  color: var(--vitin-tinta-suave);
+  max-width: 46rem;
+}
+
+/* ── Controles globales ───────────────────────────────────────────────────── */
+.vitin__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem 1.1rem;
+  max-width: 72rem;
+  margin: 0.8rem auto 0;
+}
+
+.vitin__ctl {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.vitin__ctlLabel,
+.vitin__escalaLabel {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--vitin-tinta-suave);
+}
+
+.vitin__segmented {
+  display: inline-flex;
+  border: 1.5px solid var(--vitin-borde);
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--vitin-papel);
+}
+
+.vitin__seg {
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0.4rem 0.9rem;
+  border: none;
+  background: transparent;
+  color: var(--vitin-tinta-suave);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.vitin__seg.is-on {
+  background: var(--vitin-verde);
+  color: #fdf9ec;
+}
+
+.vitin__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 44px;
+  font-size: 0.87rem;
+  color: var(--vitin-tinta);
+  cursor: pointer;
+  user-select: none;
+}
+.vitin__toggle input {
+  width: 1.15rem;
+  height: 1.15rem;
+  accent-color: var(--vitin-verde);
+}
+
+/* ── Pestañas de familias ─────────────────────────────────────────────────── */
+.vitin__tabs {
+  display: flex;
+  gap: 0.45rem;
+  overflow-x: auto;
+  padding: 0.75rem 0 0.35rem;
+  max-width: 72rem;
+  margin: 0 auto;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+}
+
+.vitin__tab {
+  flex: none;
+  min-height: 44px;
+  padding: 0.45rem 0.95rem;
+  border: 1.5px solid var(--vitin-borde);
+  border-radius: 999px;
+  background: var(--vitin-papel);
+  color: var(--vitin-tinta);
+  font-size: 0.88rem;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.vitin__tab.is-on {
+  background: var(--vitin-verde-oscuro);
+  border-color: var(--vitin-verde-oscuro);
+  color: #fdf9ec;
+}
+
+/* ── Cuerpo y grilla ──────────────────────────────────────────────────────── */
+.vitin__body {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.vitin__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .vitin__grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1024px) {
+  .vitin__grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+/* ── Tarjeta de pieza ─────────────────────────────────────────────────────── */
+.vitin__card {
+  display: flex;
+  flex-direction: column;
+  border: 1.5px solid var(--vitin-borde);
+  border-radius: 14px;
+  background: var(--vitin-papel);
+  box-shadow: var(--vitin-sombra);
+  overflow: hidden;
+}
+
+.vitin__stage {
+  position: relative;
+  height: 230px;
+  background: linear-gradient(180deg, #f6dcae 0%, #efd3a0 100%);
+  touch-action: none; /* el arrastre gira el diorama, no la página */
+}
+
+.vitin__canvas {
+  position: absolute !important;
+  inset: 0;
+}
+
+.vitin__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+  color: #7a6134;
+}
+
+.vitin__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+}
+.vitin__fichaEmoji {
+  font-size: 3.4rem;
+  filter: drop-shadow(0 3px 4px rgba(90, 62, 20, 0.25));
+}
+.vitin__fichaDims {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #7a6134;
+}
+
+.vitin__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.8rem 0.9rem 0.95rem;
+}
+
+.vitin__cardTitle {
+  margin: 0;
+  font-size: 1.02rem;
+  color: var(--vitin-verde-oscuro);
+}
+
+.vitin__cardDesc {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: var(--vitin-tinta-suave);
+}
+
+.vitin__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.vitin__chip {
+  font-size: 0.74rem;
+  font-weight: 600;
+  padding: 0.22rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--vitin-borde);
+  background: var(--vitin-crema);
+  color: var(--vitin-tinta-suave);
+}
+.vitin__chip--dims {
+  background: #eef3e6;
+  border-color: #c7d4b4;
+  color: var(--vitin-verde-oscuro);
+}
+
+.vitin__escala {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+.vitin__escala .vitin__seg {
+  border: 1.5px solid var(--vitin-borde);
+  border-radius: 999px;
+  background: var(--vitin-papel);
+}
+.vitin__escala .vitin__seg.is-on {
+  background: var(--vitin-verde);
+  border-color: var(--vitin-verde);
+  color: #fdf9ec;
+}
+
+/* ── Demo de colocar ──────────────────────────────────────────────────────── */
+.vitin__colocar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.vitin__colocarGuia {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--vitin-tinta-suave);
+  max-width: 48rem;
+}
+.vitin__colocarGuia strong { color: var(--vitin-verde-oscuro); }
+
+.vitin__colocarCtl {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.7rem 1rem;
+}
+
+.vitin__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--vitin-tinta-suave);
+}
+.vitin__field select {
+  min-height: 44px;
+  padding: 0.4rem 0.7rem;
+  border: 1.5px solid var(--vitin-borde);
+  border-radius: 10px;
+  background: var(--vitin-papel);
+  color: var(--vitin-tinta);
+  font-size: 0.9rem;
+  max-width: 20rem;
+}
+
+.vitin__botonera {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.vitin__accion {
+  min-height: 44px;
+  padding: 0.45rem 0.9rem;
+  border: 1.5px solid var(--vitin-borde);
+  border-radius: 999px;
+  background: var(--vitin-papel);
+  color: var(--vitin-tinta);
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.vitin__accion:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.vitin__accion--fijar:not(:disabled) {
+  background: var(--vitin-verde);
+  border-color: var(--vitin-verde);
+  color: #fdf9ec;
+}
+
+.vitin__lienzoColocar {
+  position: relative;
+  height: min(62vh, 460px);
+  min-height: 280px;
+  border: 1.5px solid var(--vitin-borde);
+  border-radius: 14px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #f6dcae 0%, #efd3a0 100%);
+  box-shadow: var(--vitin-sombra);
+  touch-action: none;
+}
+
+.vitin__colocarEstado {
+  margin: 0;
+  font-size: 0.84rem;
+  color: var(--vitin-tinta-suave);
+}
+
+.vitin__aviso {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.9rem 1rem;
+  border: 1.5px dashed var(--vitin-borde);
+  border-radius: 12px;
+  background: var(--vitin-papel);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--vitin-tinta-suave);
+}
+
+/* Pantallas chicas: cabecera compacta */
+@media (max-width: 420px) {
+  .vitin__headMain { flex-direction: column; }
+  .vitin__stage { height: 200px; }
+}

--- a/src/mockups/vitrina3d/VitrinaInfraestructura.jsx
+++ b/src/mockups/vitrina3d/VitrinaInfraestructura.jsx
@@ -1,0 +1,571 @@
+/*
+ * VitrinaInfraestructura — vitrina JUGABLE de la librería de infraestructura 3D
+ * (ruta pública #/mockups/vitrina-infra, sin auth).
+ *
+ * La hermana de la vitrina de criaturas (#/mockups/vitrina-3d), pero para las
+ * piezas de CONSTRUCCIÓN (src/visual/mundo3d/infraestructura): invernaderos,
+ * gallinero, galpón, establo, bodega, compostera, tanque y secadero. Las monta
+ * SIN editarlas, agrupadas por familia en pestañas:
+ *
+ *   · Una pestaña por categoría del catálogo (cultivo protegido, animales,
+ *     almacenamiento, agua, poscosecha): cada pieza vive en su tarjeta con un
+ *     diorama 3D girable + nombre, rol, medidas típicas y control de tamaño.
+ *   · Una pestaña "Colocar en el terreno": el mini demo del modo colocar —
+ *     elija una pieza, toque la ladera y la pieza SE POSA a la altura del
+ *     terreno (snapping); se gira en pasos de 45° y se deja fijada.
+ *
+ * PERF: solo la pestaña activa se monta, y dentro de ella cada tarjeta monta su
+ * Canvas SOLO mientras está en pantalla (IntersectionObserver) — nunca hay diez
+ * contextos WebGL vivos a la vez. Con `reducedMotion`, frameloop='demand' y sin
+ * autorrotación. En equipo humilde (o a voluntad) cae a FICHAS 2D sin WebGL.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Español de
+ * Colombia en "usted". El 3D (three/R3F) viaja en el chunk perezoso de la ruta.
+ */
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import * as THREE from 'three';
+import {
+  INFRAESTRUCTURA,
+  INFRAESTRUCTURA_IDS,
+  INFRAESTRUCTURA_CATEGORIAS,
+} from '../../visual/mundo3d/infraestructura/infraestructuraData.js';
+import Infraestructura from '../../visual/mundo3d/infraestructura/Infraestructura.jsx';
+import { decidirTier, permite3D } from '../../visual/mundo3d/deviceTier.js';
+import { ATMOSFERA } from '../../visual/mundo3d/atmosferaMadre.js';
+import './VitrinaInfraestructura.css';
+
+/* ── Config de la vitrina ──────────────────────────────────────────────────── */
+
+/* Rótulo legible de cada categoría del catálogo (pestañas y chips). */
+const ROTULO_CAT = {
+  'cultivo protegido': { emoji: '🌱', txt: 'Cultivo protegido' },
+  pecuaria: { emoji: '🐄', txt: 'Animales' },
+  almacenamiento: { emoji: '📦', txt: 'Bodega y reciclaje' },
+  agua: { emoji: '💧', txt: 'Agua' },
+  poscosecha: { emoji: '☕', txt: 'Poscosecha' },
+};
+
+const TIERS = [
+  { v: 'alto', label: 'Alto' },
+  { v: 'medio', label: 'Medio' },
+  { v: 'bajo', label: 'Bajo' },
+];
+
+/* Tamaños discretos por tarjeta: escalan las medidas típicas del catálogo.
+   Discretos a propósito: cada cambio re-encuadra la cámara (remonta el lienzo),
+   y eso solo debe pasar por toque deliberado, no arrastrando un slider. */
+const ESCALAS = [
+  { v: 0.75, label: 'Chica' },
+  { v: 1, label: 'Típica' },
+  { v: 1.4, label: 'Grande' },
+];
+
+const ID_COLOCAR = 'colocar';
+
+/* Las pestañas: una por categoría (en orden de catálogo) + el demo de colocar. */
+const PESTANAS = [
+  ...INFRAESTRUCTURA_CATEGORIAS.map((c) => ({
+    id: c,
+    emoji: ROTULO_CAT[c]?.emoji || '🏗️',
+    label: ROTULO_CAT[c]?.txt || c,
+  })),
+  { id: ID_COLOCAR, emoji: '📍', label: 'Colocar en el terreno' },
+];
+
+/* ── Helpers puros ─────────────────────────────────────────────────────────── */
+
+/* Medidas en texto campesino: "15 × 6 × 3 m" (coma decimal, como se dice acá). */
+const num = (v) => `${Math.round(v * 10) / 10}`.replace('.', ',');
+const medidasTexto = (d) => `${num(d.largo)} × ${num(d.ancho)} × ${num(d.alto)} m`;
+
+/* ¿La tarjeta está (cerca de) en pantalla? Monta/suelta su Canvas para acotar
+   los contextos WebGL vivos. Margen generoso para que no parpadee al borde. */
+function useEnVista() {
+  const ref = useRef(null);
+  const [enVista, setEnVista] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setEnVista(true); // sin observer (entorno viejo): mostrar y ya
+      return undefined;
+    }
+    const obs = new IntersectionObserver(
+      ([e]) => setEnVista(e.isIntersecting),
+      { rootMargin: '280px 0px', threshold: 0.01 },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+  return { ref, enVista };
+}
+
+/* ── El diorama de UNA pieza ───────────────────────────────────────────────── */
+
+/* Lienzo 3D de una pieza suelta: hora dorada del valle, un disco de tierra y la
+   construcción centrada. La cámara se encuadra a las medidas; gira con el dedo. */
+function LienzoPieza({ tipo, dims, tier, reducedMotion }) {
+  const span = Math.max(dims.largo, dims.ancho, dims.alto);
+  const d = span * 1.35 + 2.4;
+  return (
+    <Canvas
+      className="vitin__canvas"
+      dpr={[1, tier === 'alto' ? 1.6 : 1.2]}
+      gl={{ antialias: tier === 'alto', powerPreference: 'high-performance' }}
+      camera={{ position: [d * 0.72, d * 0.62, d], fov: 42 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+    >
+      <color attach="background" args={[ATMOSFERA.fondo]} />
+      <hemisphereLight intensity={0.6} color={ATMOSFERA.cielo} groundColor={ATMOSFERA.suelo} />
+      <ambientLight intensity={0.3} color={ATMOSFERA.luz} />
+      <directionalLight position={[6, 9, 4]} intensity={0.95} color={ATMOSFERA.luz} />
+      <directionalLight position={[-5, 4, -6]} intensity={0.22} color={ATMOSFERA.relleno} />
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.01, 0]}>
+        <circleGeometry args={[span * 1.05, 40]} />
+        <meshLambertMaterial color="#b49873" />
+      </mesh>
+      <Suspense fallback={null}>
+        <Infraestructura tipo={tipo} dims={dims} tier={tier} reducedMotion={reducedMotion} />
+      </Suspense>
+      <OrbitControls
+        target={[0, dims.alto * 0.42, 0]}
+        makeDefault
+        enablePan={false}
+        enableZoom
+        minDistance={d * 0.5}
+        maxDistance={d * 2.1}
+        minPolarAngle={0.22}
+        maxPolarAngle={1.45}
+        enableDamping
+        dampingFactor={0.1}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.55}
+      />
+    </Canvas>
+  );
+}
+
+/* Ficha 2D (sin WebGL): el fallback amable del equipo humilde. */
+function FichaPieza({ entry }) {
+  return (
+    <div className="vitin__ficha" aria-hidden="true">
+      <span className="vitin__fichaEmoji">{entry.emoji}</span>
+      <span className="vitin__fichaDims">{medidasTexto(entry.dims)}</span>
+    </div>
+  );
+}
+
+/* Una tarjeta del catálogo: diorama (o ficha 2D) + nombre, rol, medidas y el
+   control de tamaño. El Canvas solo vive mientras la tarjeta está en pantalla. */
+function TarjetaPieza({ entry, modo3D, tier, reducedMotion }) {
+  const { ref, enVista } = useEnVista();
+  const [escala, setEscala] = useState(1);
+  const dims = useMemo(
+    () => ({
+      largo: entry.dims.largo * escala,
+      ancho: entry.dims.ancho * escala,
+      alto: entry.dims.alto * escala,
+    }),
+    [entry, escala],
+  );
+  const rotCat = ROTULO_CAT[entry.categoria];
+  return (
+    <article ref={ref} className="vitin__card">
+      <div className="vitin__stage">
+        {modo3D && enVista ? (
+          <Suspense fallback={<div className="vitin__cargando">Preparando la pieza…</div>}>
+            <LienzoPieza
+              key={escala}
+              tipo={entry.id}
+              dims={dims}
+              tier={tier}
+              reducedMotion={reducedMotion}
+            />
+          </Suspense>
+        ) : (
+          <FichaPieza entry={entry} />
+        )}
+      </div>
+      <div className="vitin__meta">
+        <h3 className="vitin__cardTitle">
+          <span aria-hidden="true">{entry.emoji}</span> {entry.nombre}
+        </h3>
+        <p className="vitin__cardDesc">{entry.descripcion}</p>
+        <div className="vitin__chips">
+          <span className="vitin__chip">
+            {rotCat ? `${rotCat.emoji} ${rotCat.txt}` : entry.categoria}
+          </span>
+          <span className="vitin__chip vitin__chip--dims">📏 {medidasTexto(dims)}</span>
+        </div>
+        <div className="vitin__escala" role="group" aria-label={`Tamaño de ${entry.nombre}`}>
+          <span className="vitin__escalaLabel">Tamaño</span>
+          {ESCALAS.map((e) => (
+            <button
+              key={e.v}
+              type="button"
+              className={`vitin__seg${escala === e.v ? ' is-on' : ''}`}
+              onClick={() => setEscala(e.v)}
+              aria-pressed={escala === e.v}
+            >
+              {e.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+/* ── El mini demo de COLOCAR (snapping sobre el terreno) ───────────────────── */
+
+/* Una ladera de juguete propia (Math puro, determinista): al fondo trepa, al
+   frente baja. La MISMA función posa la pieza (snap a la altura del terreno). */
+const TAM_TERRENO = 26;
+const BORDE = TAM_TERRENO / 2 - 1.6;
+const MAX_COLOCADAS = 12;
+const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+
+function alturaTerreno(x, z) {
+  const t = clamp((-z + 7) / 18, 0, 1);
+  const loma = t * t * (3 - 2 * t) * 4.4; // smoothstep: la subida al páramo
+  const ondul = Math.sin(x * 0.5) * 0.16 + Math.cos(z * 0.4 + x * 0.23) * 0.12;
+  return loma + ondul;
+}
+
+/* Snap de un toque (x, z): se acota al terreno y se posa a su altura. */
+function puntoAterrizado(x, z) {
+  const px = clamp(x, -BORDE, BORDE);
+  const pz = clamp(z, -BORDE, BORDE);
+  return [px, alturaTerreno(px, pz), pz];
+}
+
+/* La ladera 3D: plano desplazado por alturaTerreno, color por altura (cálido
+   abajo, frailejonal arriba). Distingue TOQUE de arrastre de cámara: solo
+   coloca si el dedo no se movió más de unos pocos px entre down y up. */
+function TerrenoDemo({ segmentos, onTocar }) {
+  const geo = useMemo(() => {
+    const g = new THREE.PlaneGeometry(TAM_TERRENO, TAM_TERRENO, segmentos, segmentos);
+    g.rotateX(-Math.PI / 2);
+    const pos = g.attributes.position;
+    const colores = new Float32Array(pos.count * 3);
+    const cBajo = new THREE.Color('#a2b263');
+    const cAlto = new THREE.Color('#6d8a68');
+    const c = new THREE.Color();
+    for (let i = 0; i < pos.count; i++) {
+      const x = pos.getX(i);
+      const z = pos.getZ(i);
+      const y = alturaTerreno(x, z);
+      pos.setY(i, y);
+      c.copy(cBajo).lerp(cAlto, clamp(y / 4.4, 0, 1));
+      colores[i * 3] = c.r;
+      colores[i * 3 + 1] = c.g;
+      colores[i * 3 + 2] = c.b;
+    }
+    g.setAttribute('color', new THREE.BufferAttribute(colores, 3));
+    g.computeVertexNormals();
+    return g;
+  }, [segmentos]);
+  useEffect(() => () => geo.dispose(), [geo]);
+
+  const inicio = useRef(null);
+  return (
+    <mesh
+      geometry={geo}
+      onPointerDown={(e) => {
+        inicio.current = [e.clientX, e.clientY];
+      }}
+      onPointerUp={(e) => {
+        const d = inicio.current;
+        inicio.current = null;
+        if (!d) return;
+        const dx = e.clientX - d[0];
+        const dy = e.clientY - d[1];
+        if (dx * dx + dy * dy > 64) return; // fue giro de cámara, no un toque
+        onTocar(e.point.x, e.point.z);
+      }}
+    >
+      <meshLambertMaterial vertexColors />
+    </mesh>
+  );
+}
+
+/* El anillo dorado que marca el BORRADOR (la pieza aún sin fijar) en el piso. */
+function AnilloBorrador({ borrador }) {
+  const e = INFRAESTRUCTURA[borrador.tipo];
+  const r = Math.max(e.dims.largo, e.dims.ancho) * 0.62 + 0.4;
+  return (
+    <mesh
+      rotation={[-Math.PI / 2, 0, 0]}
+      position={[borrador.pos[0], borrador.pos[1] + 0.07, borrador.pos[2]]}
+    >
+      <ringGeometry args={[r - 0.28, r, 40]} />
+      <meshBasicMaterial color="#f2b134" transparent opacity={0.92} />
+    </mesh>
+  );
+}
+
+/* La sección completa del demo: selector de pieza + lienzo con la ladera +
+   botonera (girar 45°, fijar, quitar). El estado vive SOLO en memoria: es una
+   probadera, no la finca real (el modo completo persiste en su propio mockup). */
+function DemoColocar({ modo3D, tier, reducedMotion }) {
+  const [tipoSel, setTipoSel] = useState(INFRAESTRUCTURA_IDS[0]);
+  const [borrador, setBorrador] = useState(null); // { tipo, pos, rot } | null
+  const [colocadas, setColocadas] = useState([]);
+  const llena = colocadas.length >= MAX_COLOCADAS;
+
+  const tocarTerreno = (x, z) => {
+    setBorrador((b) => ({
+      tipo: tipoSel,
+      pos: puntoAterrizado(x, z),
+      rot: b?.rot || 0,
+    }));
+  };
+  const girar = () => {
+    setBorrador((b) => (b ? { ...b, rot: (b.rot + Math.PI / 4) % (Math.PI * 2) } : b));
+  };
+  const fijar = () => {
+    if (!borrador || llena) return;
+    setColocadas((lista) => [...lista, borrador]);
+    setBorrador(null);
+  };
+  const quitarUltima = () => setColocadas((lista) => lista.slice(0, -1));
+  const despejar = () => {
+    setColocadas([]);
+    setBorrador(null);
+  };
+
+  if (!modo3D) {
+    return (
+      <div className="vitin__aviso" role="note">
+        <span aria-hidden="true">📍</span> El demo de colocar necesita el modo 3D.
+        Apague «Solo fichas 2D» (o pruebe en un equipo con más aliento) para
+        posar piezas sobre la ladera.
+      </div>
+    );
+  }
+
+  return (
+    <div className="vitin__colocar">
+      <p className="vitin__colocarGuia">
+        Elija una pieza y <strong>toque la ladera</strong> donde va: se posa a la
+        altura del terreno. Gírela de a 45° y déjela fijada. Arrastre para mover
+        la cámara. (Probadera en memoria: nada se guarda.)
+      </p>
+      <div className="vitin__colocarCtl">
+        <label className="vitin__field">
+          <span>Pieza</span>
+          <select value={tipoSel} onChange={(e) => setTipoSel(e.target.value)}>
+            {INFRAESTRUCTURA_IDS.map((id) => (
+              <option key={id} value={id}>
+                {INFRAESTRUCTURA[id].emoji} {INFRAESTRUCTURA[id].nombre}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="vitin__botonera">
+          <button type="button" className="vitin__accion" onClick={girar} disabled={!borrador}>
+            ↻ Girar 45°
+          </button>
+          <button
+            type="button"
+            className="vitin__accion vitin__accion--fijar"
+            onClick={fijar}
+            disabled={!borrador || llena}
+          >
+            ✓ Dejarla aquí
+          </button>
+          <button
+            type="button"
+            className="vitin__accion"
+            onClick={quitarUltima}
+            disabled={colocadas.length === 0}
+          >
+            ⌫ Quitar la última
+          </button>
+          <button
+            type="button"
+            className="vitin__accion"
+            onClick={despejar}
+            disabled={colocadas.length === 0 && !borrador}
+          >
+            ✕ Despejar
+          </button>
+        </div>
+      </div>
+      <div className="vitin__lienzoColocar">
+        <Suspense fallback={<div className="vitin__cargando">Preparando la ladera…</div>}>
+          <Canvas
+            className="vitin__canvas"
+            dpr={[1, tier === 'alto' ? 1.6 : 1.2]}
+            gl={{ antialias: tier === 'alto', powerPreference: 'high-performance' }}
+            camera={{ position: [11, 13, 17], fov: 46 }}
+            frameloop={reducedMotion ? 'demand' : 'always'}
+          >
+            <color attach="background" args={[ATMOSFERA.fondo]} />
+            <fog attach="fog" args={[ATMOSFERA.niebla, 26, 62]} />
+            <hemisphereLight intensity={0.62} color={ATMOSFERA.cielo} groundColor={ATMOSFERA.suelo} />
+            <ambientLight intensity={0.3} color={ATMOSFERA.luz} />
+            <directionalLight position={[8, 12, 6]} intensity={0.95} color={ATMOSFERA.luz} />
+            <directionalLight position={[-6, 5, -8]} intensity={0.22} color={ATMOSFERA.relleno} />
+            <TerrenoDemo segmentos={tier === 'alto' ? 56 : 34} onTocar={tocarTerreno} />
+            {colocadas.map((c, i) => (
+              <Infraestructura
+                key={`${c.tipo}-${i}`}
+                tipo={c.tipo}
+                pos={c.pos}
+                rot={c.rot}
+                tier={tier}
+                reducedMotion={reducedMotion}
+              />
+            ))}
+            {borrador && (
+              <>
+                <AnilloBorrador borrador={borrador} />
+                <Infraestructura
+                  tipo={borrador.tipo}
+                  pos={borrador.pos}
+                  rot={borrador.rot}
+                  tier={tier}
+                  reducedMotion={reducedMotion}
+                />
+              </>
+            )}
+            <OrbitControls
+              target={[0, 1.6, 0]}
+              makeDefault
+              enablePan={false}
+              enableZoom
+              minDistance={9}
+              maxDistance={38}
+              minPolarAngle={0.25}
+              maxPolarAngle={1.42}
+              enableDamping
+              dampingFactor={0.1}
+            />
+          </Canvas>
+        </Suspense>
+      </div>
+      <p className="vitin__colocarEstado" aria-live="polite">
+        {llena
+          ? `El terreno está lleno (${MAX_COLOCADAS} piezas): quite alguna para seguir.`
+          : `Piezas fijadas: ${colocadas.length} de ${MAX_COLOCADAS}.`}
+        {borrador
+          ? ` Hay una ${INFRAESTRUCTURA[borrador.tipo].nombre.toLowerCase()} sin fijar.`
+          : ''}
+      </p>
+    </div>
+  );
+}
+
+/* ── La vitrina ────────────────────────────────────────────────────────────── */
+export default function VitrinaInfraestructura({ onBack }) {
+  const tierInicial = useMemo(() => decidirTier(), []);
+  const [pestana, setPestana] = useState(PESTANAS[0].id);
+  const [tier, setTier] = useState(tierInicial === 'bajo' ? 'bajo' : tierInicial);
+  const [soloFichas, setSoloFichas] = useState(() => !permite3D(tierInicial));
+  const [reducedMotion, setReducedMotion] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      !!window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches,
+  );
+  const modo3D = !soloFichas;
+
+  const piezasDePestana = useMemo(
+    () => INFRAESTRUCTURA_IDS.map((id) => INFRAESTRUCTURA[id]).filter((e) => e.categoria === pestana),
+    [pestana],
+  );
+
+  return (
+    <div className="vitin" data-tier={tier}>
+      <header className="vitin__head">
+        <div className="vitin__headMain">
+          <button type="button" className="vitin__back" onClick={() => onBack?.()}>
+            ← Volver
+          </button>
+          <div>
+            <h1 className="vitin__title">Vitrina de infraestructura</h1>
+            <p className="vitin__sub">
+              Las piezas de construcción del catálogo, vivas y girables: véalas
+              por familia, cámbieles el tamaño y pruebe a posarlas en la ladera.
+            </p>
+          </div>
+        </div>
+
+        <div className="vitin__controls" role="group" aria-label="Controles globales">
+          <div className="vitin__ctl">
+            <span className="vitin__ctlLabel">Detalle</span>
+            <div className="vitin__segmented">
+              {TIERS.map((t) => (
+                <button
+                  key={t.v}
+                  type="button"
+                  className={`vitin__seg${tier === t.v ? ' is-on' : ''}`}
+                  onClick={() => setTier(t.v)}
+                  aria-pressed={tier === t.v}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <label className="vitin__toggle">
+            <input
+              type="checkbox"
+              checked={reducedMotion}
+              onChange={(e) => setReducedMotion(e.target.checked)}
+            />
+            <span>Movimiento reducido</span>
+          </label>
+          <label className="vitin__toggle">
+            <input
+              type="checkbox"
+              checked={soloFichas}
+              onChange={(e) => setSoloFichas(e.target.checked)}
+            />
+            <span>Solo fichas 2D</span>
+          </label>
+        </div>
+
+        <nav className="vitin__tabs" aria-label="Familias de infraestructura">
+          {PESTANAS.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              className={`vitin__tab${pestana === p.id ? ' is-on' : ''}`}
+              onClick={() => setPestana(p.id)}
+              aria-pressed={pestana === p.id}
+            >
+              <span aria-hidden="true">{p.emoji}</span> {p.label}
+            </button>
+          ))}
+        </nav>
+      </header>
+
+      <main className="vitin__body">
+        {pestana === ID_COLOCAR ? (
+          <section className="vitin__section" aria-label="Colocar en el terreno">
+            <DemoColocar modo3D={modo3D} tier={tier} reducedMotion={reducedMotion} />
+          </section>
+        ) : (
+          <section
+            className="vitin__section"
+            aria-label={ROTULO_CAT[pestana]?.txt || pestana}
+          >
+            <div className="vitin__grid">
+              {piezasDePestana.map((entry) => (
+                <TarjetaPieza
+                  key={entry.id}
+                  entry={entry}
+                  modo3D={modo3D}
+                  tier={tier}
+                  reducedMotion={reducedMotion}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Qué hace

Vitrina navegable **`#/mockups/vitrina-infra`** (hermana de la vitrina de criaturas `#/mockups/vitrina-3d`) que hace visibles y jugables las piezas de construcción de `src/visual/mundo3d/infraestructura/` — las importa **sin editarlas**.

- **Pestañas por familia** (cultivo protegido · animales · bodega/reciclaje · agua · poscosecha): cada una de las 10 piezas del catálogo en su diorama 3D girable (hora dorada, OrbitControls) con nombre, rol, medidas típicas en metros y **control de tamaño** (chica / típica / grande → escala `dims`).
- **Pestaña «Colocar en el terreno»**: mini demo del modo colocar — se elige la pieza, se **toca la ladera** y la pieza se posa a la altura del terreno (snapping con función de altura propia, Math puro), se gira en pasos de 45° y se deja fijada. Estado solo en memoria (probadera, sin persistencia — el flujo completo con guardado vive en `#/mockups/colocar-infraestructura`).
- **Controles globales**: tier (alto/medio/bajo, inicial por `decidirTier()`), movimiento reducido (`frameloop='demand'`, sin autorrotación) y «Solo fichas 2D» (fallback sin WebGL, default en equipo humilde).

## Perf

- Solo la pestaña activa se monta; cada tarjeta monta su Canvas **solo mientras está en pantalla** (IntersectionObserver, margen 280px) — nunca hay diez contextos WebGL vivos a la vez.
- El 3D viaja en el **chunk perezoso propio** de la ruta (verificado en `dist/assets/VitrinaInfraestructura-*.js`).

## Archivos

- `src/mockups/vitrina3d/VitrinaInfraestructura.jsx` (nuevo)
- `src/mockups/vitrina3d/VitrinaInfraestructura.css` (nuevo, prefijo `vitin__` sin colisiones)
- `src/App.jsx`: lazy import + ruta `mockups/vitrina-infra` + case `mockup_vitrina_infra`, los tres **al final** de su bloque mockup (anti-conflicto), case cerrado con `</ErrorFallback></ErrorBoundary>);`.

## Verificación

- `npx eslint --max-warnings 0` sobre los archivos tocados: **0 warnings**.
- `timeout 300 npm run build` síncrono: **exit 0** (2m22s), chunk perezoso emitido.
- `git merge origin/dev` antes de commitear y antes del PR: al día.

🤖 Generated with [Claude Code](https://claude.com/claude-code)