### PR TITLE
feat(3d): kit de micro-interacciones de hotspot (HotspotFeedback)

### DIFF
--- a/src/visual/mundo3d/HotspotFeedback.jsx
+++ b/src/visual/mundo3d/HotspotFeedback.jsx
@@ -1,0 +1,342 @@
+/*
+ * HotspotFeedback — kit de micro-interacciones para hotspots 3D (game-feel).
+ *
+ * Tocar un punto de interes debe sentirse VIVO Y CONFIRMADO, no como apretar
+ * un div. Este kit monta, sobre la posicion de cualquier hotspot, el gesto
+ * completo de confirmacion:
+ *
+ *   1. HALO que respira mientras el hotspot esta activo (aro + disco en el
+ *      suelo, el mismo lenguaje de las sombras de contacto del valle).
+ *   2. ONDA/ripple: anillos que se expanden y desvanecen al momento del toque.
+ *   3. CHISPA: estallido breve de particulas ambar que saltan y caen.
+ *   4. DESTELLO: el halo brilla de mas justo al tocar y decae exponencial.
+ *   5. TICK sonoro 0-KB opcional (WebAudio puro, quinta justa C5→G5; el motor
+ *      vive en hotspotFeedbackConfig.js, sin tocar useAudioMundo).
+ *
+ * Y aparte, <HotspotPop>: envolvente de squash & stretch (resorte amortiguado)
+ * para el mesh propio del hotspot — primero aplasta, luego estira con
+ * overshoot y asienta. Se usan juntos pero no se obligan.
+ *
+ * CABLEO (para el host; este archivo no toca ninguna escena):
+ *
+ *   import HotspotFeedback, { HotspotPop } from './HotspotFeedback.jsx';
+ *
+ *   <HotspotFeedback
+ *     activo={seleccionado === h.id}   // estado resaltado; el flanco de subida dispara el estallido
+ *     pos={h.pos}                      // [x,y,z] del hotspot (el halo cae a ras de ese punto)
+ *     tier={tier}                      // 'alto'|'medio'|'bajo' (contrato deviceTier)
+ *     reducedMotion={reducedMotion}    // true → solo halo estatico, sin ondas ni chispas
+ *     conSonido={sonidoActivo}         // tick WebAudio al confirmar (requiere gesto previo: el toque lo es)
+ *     radio={0.5}                      // opcional: tamano del halo en unidades de mundo
+ *     color={'#d9a13b'}                // opcional: tinte alterno (default: ambar canonico)
+ *   />
+ *
+ *   <HotspotPop activo={seleccionado === h.id} reducedMotion={reducedMotion}>
+ *     <mesh onClick={...}>...</mesh>   // el mesh del hotspot, intacto
+ *   </HotspotPop>
+ *
+ * Presupuesto: geometrias declaradas UNA vez (r3f las libera al desmontar);
+ * por frame solo se mutan escalas/opacidades/atributos via refs (cero
+ * setState). Con `activo=false` y sin estallido en vuelo el grupo entero se
+ * apaga (`visible=false`) y el costo es ~0. Tiers y tintes vienen de
+ * hotspotFeedbackConfig.js; los materiales son Basic (sin luz, como pide el
+ * contrato frugal del framework).
+ *
+ * reduced-motion: el kit respeta la calma — queda SOLO el estado resaltado
+ * (halo fijo, sin pulso, sin ondas, sin particulas). El tick sonoro se
+ * mantiene si `conSonido` (audio no es movimiento y confirma igual).
+ */
+import { useEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { mezclar } from './atmosferaMadre.js';
+import {
+  TINTE_FEEDBACK,
+  TIEMPOS_FEEDBACK,
+  POP_FEEDBACK,
+  perfilFeedback,
+  tocarTickHotspot,
+} from './hotspotFeedbackConfig.js';
+
+export default function HotspotFeedback({
+  activo = false,
+  pos = [0, 0, 0],
+  tier = 'alto',
+  reducedMotion = false,
+  conSonido = false,
+  radio = 0.5,
+  color = null,
+}) {
+  const perfil = perfilFeedback(tier);
+
+  /* Tintes: canonicos o derivados del override (la chispa siempre aclara). */
+  const tintes = useMemo(() => {
+    if (!color) return TINTE_FEEDBACK;
+    return { halo: color, onda: color, chispa: mezclar(color, '#ffffff', 0.4) };
+  }, [color]);
+
+  /* refs mutables — todo lo por-frame vive aqui, nunca en estado React */
+  const grupoRef = useRef(null);
+  const aroRef = useRef(null);
+  const discoRef = useRef(null);
+  const ondasRef = useRef([]);
+  const puntosRef = useRef(null);
+  const velRef = useRef(null); // velocidades de chispas (se re-sortean por toque)
+  const t0 = useRef(-1e9); // momento (clock) del ultimo toque
+  const pedirEstallido = useRef(false);
+  const prevActivo = useRef(false);
+
+  /* Posiciones iniciales de las chispas (el frame las re-escribe via ref). */
+  const posChispas = useMemo(
+    () => new Float32Array(perfil.chispas * 3),
+    [perfil.chispas],
+  );
+
+  /* Flanco de subida de `activo` → pedir estallido + tick. El estallido se
+     ARMA aqui pero se dispara dentro de useFrame (alli vive el reloj). */
+  useEffect(() => {
+    if (activo && !prevActivo.current) {
+      pedirEstallido.current = true;
+      if (conSonido) tocarTickHotspot();
+    }
+    prevActivo.current = activo;
+  }, [activo, conSonido]);
+
+  /* Cola maxima del estallido: tras esto el grupo puede apagarse del todo. */
+  const colaEstallido =
+    Math.max(
+      TIEMPOS_FEEDBACK.onda + TIEMPOS_FEEDBACK.ondaEscalon * (perfil.ondas - 1),
+      TIEMPOS_FEEDBACK.chispa,
+    ) + 0.1;
+
+  useFrame((state) => {
+    const g = grupoRef.current;
+    if (!g) return;
+    const t = state.clock.elapsedTime;
+
+    /* disparo pendiente (pedido por el efecto de flanco) */
+    if (pedirEstallido.current) {
+      pedirEstallido.current = false;
+      if (!reducedMotion) {
+        t0.current = t;
+        /* re-sortear chispas: hemisferio hacia arriba, abanico amable */
+        if (!velRef.current || velRef.current.length !== perfil.chispas * 3) {
+          velRef.current = new Float32Array(perfil.chispas * 3);
+        }
+        const vel = velRef.current;
+        for (let i = 0; i < perfil.chispas; i++) {
+          const ang = Math.random() * Math.PI * 2;
+          const vh = (0.45 + Math.random() * 0.75) * radio * 2.2;
+          vel[i * 3] = Math.cos(ang) * vh;
+          vel[i * 3 + 1] = (1.1 + Math.random() * 1.3) * radio * 2.2;
+          vel[i * 3 + 2] = Math.sin(ang) * vh;
+        }
+      }
+    }
+
+    const edad = t - t0.current;
+    const enVuelo = edad < colaEstallido;
+    g.visible = activo || enVuelo;
+    if (!g.visible) return;
+
+    const aro = aroRef.current;
+    const disco = discoRef.current;
+
+    /* reduced-motion: SOLO el estado resaltado, quieto. Nada mas se anima. */
+    if (reducedMotion) {
+      if (aro) {
+        aro.visible = activo;
+        aro.scale.setScalar(radio);
+        aro.material.opacity = 0.62;
+      }
+      if (disco) {
+        disco.visible = activo;
+        disco.scale.setScalar(radio);
+        disco.material.opacity = 0.14;
+      }
+      for (const onda of ondasRef.current) if (onda) onda.visible = false;
+      if (puntosRef.current) puntosRef.current.visible = false;
+      return;
+    }
+
+    /* 1+4) halo que respira + destello del toque (decae exponencial) */
+    const destello = edad >= 0 ? Math.exp(-edad / TIEMPOS_FEEDBACK.destello) : 0;
+    const pulso =
+      1 +
+      TIEMPOS_FEEDBACK.pulsoAmplitud *
+        Math.sin(t * TIEMPOS_FEEDBACK.pulsoHz * Math.PI * 2);
+    if (aro) {
+      aro.visible = activo;
+      aro.scale.setScalar(radio * pulso * (1 + destello * 0.12));
+      aro.material.opacity = 0.5 + 0.45 * destello;
+    }
+    if (disco) {
+      disco.visible = activo;
+      disco.scale.setScalar(radio * pulso);
+      disco.material.opacity = 0.1 + 0.22 * destello;
+    }
+
+    /* 2) ondas de expansion, escalonadas */
+    for (let i = 0; i < ondasRef.current.length; i++) {
+      const onda = ondasRef.current[i];
+      if (!onda) continue;
+      const p = (edad - i * TIEMPOS_FEEDBACK.ondaEscalon) / TIEMPOS_FEEDBACK.onda;
+      if (p <= 0 || p >= 1) {
+        onda.visible = false;
+        continue;
+      }
+      onda.visible = true;
+      onda.scale.setScalar(radio * (0.4 + 2.1 * p));
+      onda.material.opacity = Math.pow(1 - p, 1.6) * 0.75;
+    }
+
+    /* 3) chispas: posicion analitica desde la edad (sin drift de Euler) */
+    const puntos = puntosRef.current;
+    if (puntos && velRef.current) {
+      const pC = edad / TIEMPOS_FEEDBACK.chispa;
+      if (pC <= 0 || pC >= 1) {
+        puntos.visible = false;
+      } else {
+        puntos.visible = true;
+        const attr = puntos.geometry.getAttribute('position');
+        const vel = velRef.current;
+        for (let i = 0; i < perfil.chispas; i++) {
+          attr.array[i * 3] = vel[i * 3] * edad;
+          attr.array[i * 3 + 1] = Math.max(
+            0.02,
+            vel[i * 3 + 1] * edad - 3.4 * edad * edad,
+          );
+          attr.array[i * 3 + 2] = vel[i * 3 + 2] * edad;
+        }
+        attr.needsUpdate = true;
+        puntos.material.opacity = Math.pow(1 - pC, 1.7);
+        puntos.material.size = radio * 0.16 * (1 - 0.4 * pC);
+      }
+    }
+  });
+
+  const blending = perfil.aditivo ? THREE.AdditiveBlending : THREE.NormalBlending;
+
+  return (
+    <group ref={grupoRef} position={pos} visible={false}>
+      {/* disco suave de asiento (el "charco" de luz bajo el hotspot) */}
+      <mesh ref={discoRef} rotation-x={-Math.PI / 2} position-y={0.015}>
+        <circleGeometry args={[0.92, perfil.segmentos]} />
+        <meshBasicMaterial
+          color={tintes.halo}
+          transparent
+          opacity={0}
+          depthWrite={false}
+          blending={blending}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      {/* aro nitido que respira */}
+      <mesh ref={aroRef} rotation-x={-Math.PI / 2} position-y={0.02}>
+        <ringGeometry args={[0.82, 1, perfil.segmentos]} />
+        <meshBasicMaterial
+          color={tintes.halo}
+          transparent
+          opacity={0}
+          depthWrite={false}
+          blending={blending}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      {/* ondas de expansion (una geometria unitaria por anillo, escalada) */}
+      {Array.from({ length: perfil.ondas }, (_, i) => (
+        <mesh
+          key={i}
+          ref={(el) => {
+            ondasRef.current[i] = el;
+          }}
+          rotation-x={-Math.PI / 2}
+          position-y={0.025}
+          visible={false}
+        >
+          <ringGeometry args={[0.9, 1, perfil.segmentos]} />
+          <meshBasicMaterial
+            color={tintes.onda}
+            transparent
+            opacity={0}
+            depthWrite={false}
+            blending={blending}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      ))}
+      {/* chispas de confirmacion (solo tiers con presupuesto) */}
+      {perfil.chispas > 0 && (
+        <points ref={puntosRef} key={perfil.chispas} visible={false}>
+          <bufferGeometry>
+            <bufferAttribute
+              attach="attributes-position"
+              array={posChispas}
+              count={perfil.chispas}
+              itemSize={3}
+            />
+          </bufferGeometry>
+          <pointsMaterial
+            color={tintes.chispa}
+            size={radio * 0.16}
+            sizeAttenuation
+            transparent
+            opacity={0}
+            depthWrite={false}
+            blending={blending}
+          />
+        </points>
+      )}
+    </group>
+  );
+}
+
+/* ------------------------------------------------------------------------ *
+ * <HotspotPop> — squash & stretch del mesh del hotspot.
+ *
+ * Envuelve al hijo en un grupo cuya escala sigue un resorte amortiguado
+ * e^(-k·t)·sin(w·t): primero APLASTA (sy<1, sx/sz>1: conservacion de
+ * volumen), luego estira con overshoot y asienta en 1. Con reduced-motion no
+ * anima nada (grupo pasivo). Barato: un set de escala por frame y solo
+ * durante ~0.85 s tras el toque.
+ * ------------------------------------------------------------------------ */
+export function HotspotPop({
+  activo = false,
+  reducedMotion = false,
+  intensidad = 1,
+  children,
+}) {
+  const ref = useRef(null);
+  const t0 = useRef(-1e9);
+  const pedirPop = useRef(false);
+  const prevActivo = useRef(false);
+
+  useEffect(() => {
+    if (activo && !prevActivo.current) pedirPop.current = true;
+    prevActivo.current = activo;
+  }, [activo]);
+
+  useFrame((state) => {
+    const g = ref.current;
+    if (!g || reducedMotion) return;
+    const t = state.clock.elapsedTime;
+    if (pedirPop.current) {
+      pedirPop.current = false;
+      t0.current = t;
+    }
+    const edad = t - t0.current;
+    if (edad < 0 || edad > POP_FEEDBACK.duracion) {
+      if (g.scale.x !== 1) g.scale.set(1, 1, 1);
+      return;
+    }
+    const s =
+      POP_FEEDBACK.amplitud *
+      intensidad *
+      Math.exp(-POP_FEEDBACK.amortiguacion * edad) *
+      Math.sin(POP_FEEDBACK.frecuencia * edad);
+    /* s>0 al arranque → squash primero; el seno amortiguado hace el resto */
+    g.scale.set(1 + s * POP_FEEDBACK.ejeCruzado, 1 - s, 1 + s * POP_FEEDBACK.ejeCruzado);
+  });
+
+  return <group ref={ref}>{children}</group>;
+}

--- a/src/visual/mundo3d/hotspotFeedbackConfig.js
+++ b/src/visual/mundo3d/hotspotFeedbackConfig.js
@@ -1,0 +1,134 @@
+/*
+ * hotspotFeedbackConfig — la RECETA del game-feel de los hotspots 3D.
+ *
+ * Fuente única de tintes, tiempos y presupuestos del kit <HotspotFeedback>
+ * (ver HotspotFeedback.jsx). Vive separada del componente por la misma razón
+ * que atmosferaMadre vive separada de las escenas: si mañana el toque debe
+ * sentirse más rápido o más ámbar, se ajusta AQUÍ y todos los hotspots del
+ * juego cambian juntos — el ojo lee "mismo lugar".
+ *
+ * Tintes: heredan de la PALETA canónica (atmosferaMadre). El acento de señal
+ * del juego es el ámbar (nunca rojo catástrofe); la chispa lo aclara hacia
+ * blanco para el destello y la onda lo enfría apenas hacia cal para que el
+ * anillo no compita con el halo.
+ *
+ * Presupuestos por tier: mismo contrato que perfilDeTier (deviceTier.js) —
+ * desconocido cae a 'medio' (frugal), nunca al caro. 'bajo' normalmente ni
+ * monta 3D; si algo lo fuerza, este perfil lo deja digno (solo halo + una
+ * onda, cero particulas).
+ */
+import { PALETA, mezclar } from './atmosferaMadre.js';
+
+/* Los tres tintes del feedback (hex listos para materiales). */
+export const TINTE_FEEDBACK = {
+  halo: PALETA.ambar, // el aro que respira mientras el hotspot esta activo
+  onda: mezclar(PALETA.ambar, PALETA.cal, 0.25), // ripple de expansion
+  chispa: mezclar(PALETA.ambar, '#ffffff', 0.4), // destello de confirmacion
+};
+
+/* Tiempos del gesto (segundos, salvo indicado). Afinados para leerse como
+   "confirmado" sin estorbar: todo el estallido cabe bajo un segundo. */
+export const TIEMPOS_FEEDBACK = {
+  onda: 0.9, // vida de cada anillo de expansion
+  ondaEscalon: 0.14, // desfase entre anillos consecutivos
+  chispa: 0.75, // vida del estallido de particulas
+  destello: 0.35, // brillo extra del halo justo al tocar (decae exponencial)
+  pulsoHz: 0.42, // respiracion del halo activo (ciclos por segundo)
+  pulsoAmplitud: 0.06, // cuanto crece/encoge el halo al respirar (fraccion)
+};
+
+/* Squash & stretch del pop (envolvente <HotspotPop>): resorte amortiguado
+   e^(-k·t)·sin(w·t). Primero aplasta, luego estira con overshoot, y asienta. */
+export const POP_FEEDBACK = {
+  amplitud: 0.26, // deformacion maxima (fraccion de la escala)
+  amortiguacion: 5.5, // k: que tan rapido se calma el resorte
+  frecuencia: 17, // w (rad/s): que tan "cartoon" rebota
+  duracion: 0.85, // tras esto la escala queda clavada en 1
+  ejeCruzado: 0.55, // conservacion de volumen: cuanto compensan X/Z frente a Y
+};
+
+/*
+ * Presupuesto por device-tier. Claves:
+ *   ondas     → anillos del ripple por toque
+ *   chispas   → particulas del estallido (0 = sin puntos montados)
+ *   segmentos → resolucion de aros/discos (geometria estatica, se paga 1 vez)
+ *   aditivo   → blending aditivo (glow); en bajo se apaga (fill-rate minimo)
+ */
+const PERFIL_FEEDBACK = {
+  alto: { ondas: 3, chispas: 18, segmentos: 48, aditivo: true },
+  medio: { ondas: 2, chispas: 10, segmentos: 32, aditivo: true },
+  bajo: { ondas: 1, chispas: 0, segmentos: 24, aditivo: false },
+};
+
+/** El presupuesto de feedback del tier (desconocido → frugal, nunca el caro). */
+export const perfilFeedback = (tier) => PERFIL_FEEDBACK[tier] || PERFIL_FEEDBACK.medio;
+
+/*
+ * TICK sonoro 0-KB (WebAudio puro, sin asset): una quinta justa ascendente
+ * C5→G5 en triangulo con sombra de segunda armonica. Suena a "listo" calido,
+ * pariente de la campana/burbuja de useAudioMundo (mismo motor de sintesis,
+ * cero muestras). Ganancias bajas a proposito: confirma, no interrumpe.
+ */
+export const TICK_FEEDBACK = {
+  desde: 523.25, // C5
+  hasta: 783.99, // G5 (quinta justa: resolucion amable)
+  dur: 0.16, // vida total del blip (s)
+  ataque: 0.006, // subida del gain (s)
+  ganancia: 0.11, // pico del fundamental
+  brillo: 0.035, // pico de la 2a armonica (shimmer)
+};
+
+/*
+ * Motor del tick — vive aqui (modulo plano) y no en el .jsx porque el archivo
+ * de componentes solo puede exportar componentes (react-refresh). Un solo
+ * AudioContext perezoso para todos los hotspots de la app; se crea recien en
+ * el primer toque (que ES un gesto del usuario, asi que la autoplay-policy
+ * queda satisfecha). Todo bajo try/catch: si el audio falla, el feedback
+ * visual sigue como si nada.
+ */
+let ctxTick = null;
+
+/** Toca el blip de confirmacion (quinta justa ascendente, ~160 ms). */
+export function tocarTickHotspot() {
+  try {
+    if (typeof window === 'undefined') return;
+    const AC = window.AudioContext || window.webkitAudioContext;
+    if (!AC) return;
+    if (!ctxTick) ctxTick = new AC();
+    if (ctxTick.state === 'suspended') ctxTick.resume();
+
+    const { desde, hasta, dur, ataque, ganancia, brillo } = TICK_FEEDBACK;
+    const t = ctxTick.currentTime;
+
+    /* Fundamental: triangulo con glide exponencial C5→G5. */
+    const osc = ctxTick.createOscillator();
+    osc.type = 'triangle';
+    osc.frequency.setValueAtTime(desde, t);
+    osc.frequency.exponentialRampToValueAtTime(hasta, t + dur * 0.6);
+
+    const gan = ctxTick.createGain();
+    gan.gain.setValueAtTime(0.0001, t);
+    gan.gain.exponentialRampToValueAtTime(ganancia, t + ataque);
+    gan.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+
+    /* Sombra de 2a armonica: el shimmer que lo vuelve "campanita", no "beep". */
+    const osc2 = ctxTick.createOscillator();
+    osc2.type = 'sine';
+    osc2.frequency.setValueAtTime(desde * 2, t);
+    osc2.frequency.exponentialRampToValueAtTime(hasta * 2, t + dur * 0.6);
+
+    const gan2 = ctxTick.createGain();
+    gan2.gain.setValueAtTime(0.0001, t);
+    gan2.gain.exponentialRampToValueAtTime(brillo, t + ataque);
+    gan2.gain.exponentialRampToValueAtTime(0.0001, t + dur * 0.8);
+
+    osc.connect(gan).connect(ctxTick.destination);
+    osc2.connect(gan2).connect(ctxTick.destination);
+    osc.start(t);
+    osc2.start(t);
+    osc.stop(t + dur + 0.05);
+    osc2.stop(t + dur + 0.05);
+  } catch {
+    /* silencio digno: el visual confirma solo */
+  }
+}


### PR DESCRIPTION
## Que es

Kit reutilizable de game-feel para hotspots 3D: tocar un punto de interes se siente vivo y confirmado. **Solo archivos nuevos**, cero ediciones a escenas o hooks existentes — montable por props donde el host decida.

## Archivos

- `src/visual/mundo3d/HotspotFeedback.jsx` — componente principal + `<HotspotPop>` (squash & stretch)
- `src/visual/mundo3d/hotspotFeedbackConfig.js` — tintes, tiempos, presupuesto por tier y motor del tick sonoro

## Efectos

1. **Halo** que respira (aro + disco a ras de suelo, ambar canonico de `PALETA`) mientras `activo`
2. **Ondas/ripple** escalonadas que se expanden y desvanecen al toque
3. **Chispas** de confirmacion (points, trayectoria analitica por edad, sin drift de Euler)
4. **Destello** del halo con decaimiento exponencial justo al tocar
5. **`<HotspotPop>`**: resorte amortiguado `e^(-kt)sin(wt)` — aplasta, estira con overshoot, asienta
6. **Tick sonoro 0-KB** opcional: WebAudio puro (quinta justa C5→G5, triangulo + 2a armonica), AudioContext perezoso creado tras el gesto del toque (autoplay-policy OK)

## Contratos respetados

- **Tier** (`deviceTier`): alto 3 ondas/18 chispas, medio 2/10, bajo 1/0 sin blending aditivo; desconocido cae a frugal
- **reduced-motion**: solo el estado resaltado estatico (halo fijo, sin ondas/chispas/pulso); el tick se mantiene (audio no es movimiento)
- **Direccion de arte**: tintes derivados de `PALETA.ambar` via `mezclar()` (atmosferaMadre); materiales Basic sin luz
- **Presupuesto**: geometrias declaradas una vez; por frame solo mutacion de refs (cero setState); grupo `visible=false` cuando no hay nada que mostrar (~0 costo en reposo)

## Cableo (para quien integre)

```jsx
import HotspotFeedback, { HotspotPop } from './HotspotFeedback.jsx';

<HotspotFeedback activo={sel === h.id} pos={h.pos} tier={tier}
  reducedMotion={reducedMotion} conSonido={sonidoActivo} radio={0.5} />

<HotspotPop activo={sel === h.id} reducedMotion={reducedMotion}>
  <mesh onClick={...}>...</mesh>
</HotspotPop>
```

Props opcionales: `radio` (tamano del halo en unidades de mundo), `color` (tinte alterno; la chispa se aclara sola), `intensidad` en el Pop. Ejemplo completo en el encabezado del componente.

## Verificacion

- `eslint --max-warnings 0` sobre ambos archivos: limpio
- `npm run build`: exitoso (3m)

🤖 Generated with [Claude Code](https://claude.com/claude-code)