### PR TITLE
feat(3d): kit de transiciones de entrada/salida de mundo (wipe/iris/zoom/fade)

### DIFF
--- a/src/visual/mundo3d/TransicionMundoKit.jsx
+++ b/src/visual/mundo3d/TransicionMundoKit.jsx
@@ -1,0 +1,153 @@
+/*
+ * TransicionMundoKit — kit de transiciones de entrada/salida de mundo.
+ *
+ * El pase del home al mundo 3D (y de vuelta) como VIAJE, no como cambio de
+ * pantalla — norte: la transición 2D↔3D estilo túnel. Cuatro variantes
+ * reutilizables, todas overlay DOM/CSS puro (CERO three, cero red, offline):
+ *
+ *   · 'wipe'  — barrido vertical con borde de ola orgánica (SVG inline);
+ *   · 'iris'  — portal circular que se cierra al centro y reabre;
+ *   · 'zoom'  — túnel: velo radial que escala hacia adentro + aros de viaje;
+ *   · 'fade'  — cross-fade cálido por un gradiente amanecer.
+ *
+ * CONTRATO TEMPORAL (igual filosofía que TransicionMundo, el velo original):
+ * los callbacks los disparan timers JS deterministas, NUNCA `animationend`.
+ * El CSS anima con la misma duración via `--tmk-ms` pero es decorativo.
+ *   · `onMitad` — pantalla 100% cubierta (meseta 45%–55% de las keyframes):
+ *     AQUÍ el host intercambia la escena debajo del overlay;
+ *   · `onFin`   — pantalla revelada, overlay inerte: desmonte con `activa=false`.
+ * Cada uno se llama a lo sumo UNA vez por activación.
+ *
+ * PROPS
+ *   variante      'wipe'|'iris'|'zoom'|'fade' (desconocida → 'fade')
+ *   activa        bool — al pasar a true corre el ciclo cubrir→mitad→revelar;
+ *                 en false no se monta nada y se cancelan los timers.
+ *   direccion     'entrar' (home → mundo) | 'salir' (mundo → home): cambia el
+ *                 sentido/easing del movimiento, no el contrato temporal.
+ *   tier          'alto'|'medio'|'bajo' (deviceTier): bajo = más corto y sin
+ *                 decoraciones (olas SVG, aros, halos); alto = extras baratos.
+ *   reducedMotion bool — colapsa TODO a un corte simple: cubre instantáneo,
+ *                 onMitad enseguida, desvanece corto (REDUCIDA_MS total).
+ *   colorA/colorB tintes del destino (claro/profundo). Defaults cálidos.
+ *   onMitad/onFin callbacks del contrato temporal (opcionales).
+ *
+ * CABLEO SUGERIDO (lo hace Opus — este archivo no toca nada existente):
+ *   1. El host (p.ej. Mundo.jsx o quien orqueste useNavegacionMundos) monta
+ *      `<TransicionMundoKit activa={viajando} …/>` como hermano del canvas;
+ *   2. en `onMitad` hace el swap de escena (hoy: `completarViaje()` — que con
+ *      este kit puede partirse en swap@mitad + limpieza@fin);
+ *   3. en `onFin` apaga `activa`. Tintes: `tinteDeMundo(mundoId)` de
+ *      resolverMundo.js → colorA/colorB. Tier/reducedMotion: deviceTier.js.
+ *   Este kit puede convivir con el velo TransicionMundo (z-index 44 > 40) o
+ *   reemplazarlo variante por variante.
+ */
+import { useEffect, useRef } from 'react';
+import { duracionTransicion, mitadTransicion, VARIANTES } from './tiemposTransicion.js';
+import './transicionMundoKit.css';
+
+export default function TransicionMundoKit({
+  variante = 'fade',
+  activa = false,
+  direccion = 'entrar',
+  tier = 'medio',
+  reducedMotion = false,
+  colorA = '#f2c063',
+  colorB = '#1d4030',
+  onMitad,
+  onFin,
+}) {
+  const mitadRef = useRef(onMitad);
+  const finRef = useRef(onFin);
+  // Refs "última versión": se actualizan en un effect (no en render) para que
+  // los timers llamen siempre al callback más fresco sin re-armarse.
+  useEffect(() => {
+    mitadRef.current = onMitad;
+    finRef.current = onFin;
+  });
+
+  useEffect(() => {
+    if (!activa) return undefined;
+    let hechoMitad = false;
+    let hechoFin = false;
+    const tMitad = setTimeout(() => {
+      if (!hechoMitad) {
+        hechoMitad = true;
+        mitadRef.current?.();
+      }
+    }, mitadTransicion(variante, tier, reducedMotion));
+    const tFin = setTimeout(() => {
+      if (!hechoFin) {
+        hechoFin = true;
+        finRef.current?.();
+      }
+    }, duracionTransicion(variante, tier, reducedMotion));
+    return () => {
+      hechoMitad = true;
+      hechoFin = true;
+      clearTimeout(tMitad);
+      clearTimeout(tFin);
+    };
+  }, [activa, variante, direccion, tier, reducedMotion]);
+
+  if (!activa) return null;
+
+  // reduced-motion = corte simple: siempre la rama 'fade' + cubierta al instante.
+  const v = reducedMotion ? 'fade' : VARIANTES.includes(variante) ? variante : 'fade';
+  const total = duracionTransicion(v, tier, reducedMotion);
+  const conAdornos = tier !== 'bajo' && !reducedMotion;
+
+  return (
+    <div
+      className="tmk"
+      data-variante={v}
+      data-direccion={direccion === 'salir' ? 'salir' : 'entrar'}
+      data-tier={tier}
+      data-reducida={reducedMotion ? '1' : '0'}
+      style={{ '--tmk-a': colorA, '--tmk-b': colorB, '--tmk-ms': `${total}ms` }}
+      aria-hidden="true"
+      data-testid="tmk"
+    >
+      {(v === 'fade' || v === 'zoom') && <div className="tmk__velo" />}
+
+      {v === 'zoom' && conAdornos && (
+        <>
+          <div className="tmk__aro tmk__aro--1" />
+          <div className="tmk__aro tmk__aro--2" />
+          <div className="tmk__aro tmk__aro--3" />
+        </>
+      )}
+
+      {v === 'iris' && <div className="tmk__iris" />}
+
+      {v === 'wipe' && (
+        <div className="tmk__wipe">
+          {conAdornos && (
+            <svg
+              className="tmk__ola tmk__ola--frente"
+              viewBox="0 0 100 10"
+              preserveAspectRatio="none"
+            >
+              <path d="M0,10 C8,3 16,8 26,5 C36,2 44,9 56,6 C66,3 74,8 86,4 C92,2 96,6 100,5 L100,10 Z" />
+            </svg>
+          )}
+          <div className="tmk__wipe-cuerpo" />
+          {conAdornos && (
+            <svg
+              className="tmk__ola tmk__ola--cola"
+              viewBox="0 0 100 10"
+              preserveAspectRatio="none"
+            >
+              <path d="M0,10 C8,3 16,8 26,5 C36,2 44,9 56,6 C66,3 74,8 86,4 C92,2 96,6 100,5 L100,10 Z" />
+            </svg>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* Variantes como componentes con nombre — azúcar para montar declarativo. */
+export const TransicionWipe = (props) => <TransicionMundoKit {...props} variante="wipe" />;
+export const TransicionIris = (props) => <TransicionMundoKit {...props} variante="iris" />;
+export const TransicionZoom = (props) => <TransicionMundoKit {...props} variante="zoom" />;
+export const TransicionFade = (props) => <TransicionMundoKit {...props} variante="fade" />;

--- a/src/visual/mundo3d/__tests__/transicionMundoKit.test.jsx
+++ b/src/visual/mundo3d/__tests__/transicionMundoKit.test.jsx
@@ -1,0 +1,141 @@
+/*
+ * TransicionMundoKit — contrato temporal del kit de transiciones (three-free).
+ *
+ * Congela:
+ *   · `onMitad` dispara UNA vez a la mitad exacta (pantalla cubierta) y
+ *     `onFin` UNA vez al total — cronometrados por timers, no por CSS;
+ *   · `activa=false` no monta nada y apagarla a mitad de viaje cancela
+ *     los timers pendientes (ni mitad ni fin fantasma);
+ *   · reduced-motion = corte simple: rama 'fade' + REDUCIDA_MS, sin adornos;
+ *   · tier 'bajo' acorta el viaje (FACTOR_TIER_BAJO) y quita decoraciones;
+ *   · variante desconocida cae a 'fade' (nunca revienta);
+ *   · los wrappers con nombre fijan su variante.
+ */
+import React from 'react';
+import { render, screen, cleanup, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach, vi } from 'vitest';
+
+import TransicionMundoKit, { TransicionIris } from '../TransicionMundoKit.jsx';
+import {
+  DURACIONES_MS,
+  REDUCIDA_MS,
+  FACTOR_TIER_BAJO,
+  duracionTransicion,
+  mitadTransicion,
+} from '../tiemposTransicion.js';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('TransicionMundoKit — contrato temporal', () => {
+  test('onMitad a la mitad y onFin al total, cada uno UNA vez', () => {
+    vi.useFakeTimers();
+    const onMitad = vi.fn();
+    const onFin = vi.fn();
+    render(
+      <TransicionMundoKit variante="wipe" activa onMitad={onMitad} onFin={onFin} />,
+    );
+
+    const mitad = mitadTransicion('wipe', 'medio', false);
+    const total = duracionTransicion('wipe', 'medio', false);
+    expect(total).toBe(DURACIONES_MS.wipe);
+
+    act(() => vi.advanceTimersByTime(mitad - 1));
+    expect(onMitad).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(onMitad).toHaveBeenCalledTimes(1);
+    expect(onFin).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(total - mitad));
+    expect(onMitad).toHaveBeenCalledTimes(1);
+    expect(onFin).toHaveBeenCalledTimes(1);
+
+    act(() => vi.advanceTimersByTime(total * 2));
+    expect(onMitad).toHaveBeenCalledTimes(1);
+    expect(onFin).toHaveBeenCalledTimes(1);
+  });
+
+  test('activa=false no monta nada', () => {
+    render(<TransicionMundoKit variante="iris" activa={false} />);
+    expect(screen.queryByTestId('tmk')).not.toBeInTheDocument();
+  });
+
+  test('apagar activa a mitad de viaje cancela los timers pendientes', () => {
+    vi.useFakeTimers();
+    const onMitad = vi.fn();
+    const onFin = vi.fn();
+    const { rerender } = render(
+      <TransicionMundoKit variante="zoom" activa onMitad={onMitad} onFin={onFin} />,
+    );
+
+    act(() => vi.advanceTimersByTime(mitadTransicion('zoom', 'medio', false) - 10));
+    rerender(
+      <TransicionMundoKit
+        variante="zoom"
+        activa={false}
+        onMitad={onMitad}
+        onFin={onFin}
+      />,
+    );
+    act(() => vi.advanceTimersByTime(DURACIONES_MS.zoom * 3));
+
+    expect(onMitad).not.toHaveBeenCalled();
+    expect(onFin).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('tmk')).not.toBeInTheDocument();
+  });
+
+  test('reduced-motion = corte simple: rama fade, REDUCIDA_MS, sin adornos', () => {
+    vi.useFakeTimers();
+    const onMitad = vi.fn();
+    const onFin = vi.fn();
+    const { container } = render(
+      <TransicionMundoKit
+        variante="zoom"
+        activa
+        reducedMotion
+        tier="alto"
+        onMitad={onMitad}
+        onFin={onFin}
+      />,
+    );
+
+    const raiz = screen.getByTestId('tmk');
+    expect(raiz).toHaveAttribute('data-variante', 'fade');
+    expect(raiz).toHaveAttribute('data-reducida', '1');
+    expect(container.querySelector('.tmk__aro')).toBeNull();
+    expect(duracionTransicion('zoom', 'alto', true)).toBe(REDUCIDA_MS);
+
+    act(() => vi.advanceTimersByTime(REDUCIDA_MS));
+    expect(onMitad).toHaveBeenCalledTimes(1);
+    expect(onFin).toHaveBeenCalledTimes(1);
+  });
+
+  test('tier bajo acorta el viaje y quita decoraciones', () => {
+    const { container } = render(
+      <TransicionMundoKit variante="wipe" activa tier="bajo" />,
+    );
+    expect(container.querySelector('.tmk__ola')).toBeNull();
+    expect(container.querySelector('.tmk__wipe-cuerpo')).not.toBeNull();
+    expect(duracionTransicion('wipe', 'bajo', false)).toBe(
+      Math.round(DURACIONES_MS.wipe * FACTOR_TIER_BAJO),
+    );
+  });
+
+  test('variante desconocida cae a fade y direccion invalida a entrar', () => {
+    render(<TransicionMundoKit variante="explosion" activa direccion="teleport" />);
+    const raiz = screen.getByTestId('tmk');
+    expect(raiz).toHaveAttribute('data-variante', 'fade');
+    expect(raiz).toHaveAttribute('data-direccion', 'entrar');
+  });
+
+  test('los wrappers con nombre fijan su variante y respetan direccion', () => {
+    render(<TransicionIris activa direccion="salir" />);
+    const raiz = screen.getByTestId('tmk');
+    expect(raiz).toHaveAttribute('data-variante', 'iris');
+    expect(raiz).toHaveAttribute('data-direccion', 'salir');
+  });
+});

--- a/src/visual/mundo3d/tiemposTransicion.js
+++ b/src/visual/mundo3d/tiemposTransicion.js
@@ -1,0 +1,64 @@
+/*
+ * tiemposTransicion — reloj del kit de transiciones de mundo (TransicionMundoKit).
+ *
+ * Vive separado del JSX por dos razones:
+ *   1. react-refresh/only-export-components: el .jsx solo puede exportar
+ *      componentes (allowConstantExport no cubre objetos/arrays);
+ *   2. el host y los tests necesitan cronometrar sin montar nada.
+ *
+ * El contrato temporal es el mismo del velo original (TransicionMundo):
+ * timers JS deterministas — el CSS anima "a ciegas" con la MISMA duración
+ * via la variable `--tmk-ms`, pero quien manda es el setTimeout. Así el
+ * intercambio de escena nunca depende de `animationend` (pestañas en
+ * segundo plano, throttling, etc.).
+ *
+ * Anatomía de un viaje (fracciones de la duración total):
+ *   0%            → arranca a cubrir la pantalla
+ *   45%–55%       → pantalla 100% cubierta (meseta de intercambio)
+ *   50% (MITAD)   → dispara `onMitad`: el host intercambia la escena DEBAJO
+ *   100%          → pantalla revelada; dispara `onFin`
+ */
+
+/** Variantes disponibles del kit. */
+export const VARIANTES = ['wipe', 'iris', 'zoom', 'fade'];
+
+/** Duración total (cubrir + meseta + revelar) por variante, en ms, tier alto/medio. */
+export const DURACIONES_MS = {
+  wipe: 1200,
+  iris: 1100,
+  zoom: 1300,
+  fade: 900,
+};
+
+/** Con `reducedMotion` TODO colapsa a un corte simple de esta duración. */
+export const REDUCIDA_MS = 160;
+
+/** Tier `bajo` acorta el viaje (menos tiempo de overlay sobre equipos flojos). */
+export const FACTOR_TIER_BAJO = 0.7;
+
+/** Fracción del total en la que la pantalla está garantizadamente cubierta. */
+export const MITAD_FRAC = 0.5;
+
+/**
+ * Duración total del viaje en ms para una combinación dada.
+ * Variante desconocida → cae a `fade` (nunca revienta).
+ *
+ * @param {string} variante 'wipe'|'iris'|'zoom'|'fade'
+ * @param {'alto'|'medio'|'bajo'} tier
+ * @param {boolean} reducedMotion
+ * @returns {number} ms
+ */
+export function duracionTransicion(variante, tier, reducedMotion) {
+  if (reducedMotion) return REDUCIDA_MS;
+  const base = DURACIONES_MS[variante] ?? DURACIONES_MS.fade;
+  return tier === 'bajo' ? Math.round(base * FACTOR_TIER_BAJO) : base;
+}
+
+/**
+ * Momento (ms desde el arranque) en que disparar `onMitad` — centro de la
+ * meseta cubierta. Con `reducedMotion` la cobertura es instantánea, así que
+ * la mitad llega enseguida pero igual dentro de la meseta.
+ */
+export function mitadTransicion(variante, tier, reducedMotion) {
+  return Math.round(duracionTransicion(variante, tier, reducedMotion) * MITAD_FRAC);
+}

--- a/src/visual/mundo3d/transicionMundoKit.css
+++ b/src/visual/mundo3d/transicionMundoKit.css
@@ -1,0 +1,276 @@
+/*
+ * transicionMundoKit.css — coreografías del kit de transiciones de mundo.
+ *
+ * Todas las variantes comparten el mismo contrato: entre el 45% y el 55% de
+ * la animación la pantalla está 100% CUBIERTA (ahí el host intercambia la
+ * escena, cronometrado por los timers JS del componente — el CSS solo
+ * acompaña con la misma duración via --tmk-ms).
+ *
+ * Variables (las setea el componente):
+ *   --tmk-a   tinte claro del destino (borde de ola, aros, centro del velo)
+ *   --tmk-b   tinte profundo del destino (cuerpo que cubre)
+ *   --tmk-ms  duración total del viaje
+ *
+ * Solo transform/opacity en lo caliente (compositor); la única excepción es
+ * el iris (width/height de UN elemento, ~1s, patrón clásico de agujero con
+ * box-shadow gigante — el inverso no es expresable con clip-path animable).
+ */
+
+.tmk {
+  position: fixed;
+  inset: 0;
+  z-index: 44; /* sobre el velo original (.mundo-viaje, z 40) y el canvas */
+  pointer-events: none;
+  overflow: hidden;
+}
+
+/* ============================== FADE cálido ============================= */
+/* Cross-fade por un gradiente amanecer: cubre, meseta, revela. */
+
+.tmk__velo {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(130% 130% at 50% 42%, var(--tmk-a) 0%, var(--tmk-b) 78%);
+  opacity: 0;
+}
+
+.tmk[data-variante='fade'] .tmk__velo {
+  animation: tmk-cubre-revela var(--tmk-ms) ease-in-out both;
+}
+
+@keyframes tmk-cubre-revela {
+  0% {
+    opacity: 0;
+  }
+  45%,
+  55% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+/* =============================== ZOOM túnel ============================= */
+/* El velo radial escala hacia el observador (entrar) o se aleja (salir)
+ * mientras cubre; los aros pasan como paredes del túnel. */
+
+.tmk[data-variante='zoom'] .tmk__velo {
+  animation:
+    tmk-cubre-revela var(--tmk-ms) ease-in-out both,
+    tmk-zoom-profundidad var(--tmk-ms) cubic-bezier(0.55, 0, 0.35, 1) both;
+  will-change: transform, opacity;
+}
+
+.tmk[data-variante='zoom'][data-direccion='salir'] .tmk__velo {
+  animation-direction: normal, reverse; /* la cobertura NO se invierte; la profundidad sí */
+}
+
+@keyframes tmk-zoom-profundidad {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(1.55);
+  }
+}
+
+.tmk__aro {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 46vmax;
+  height: 46vmax;
+  margin: -23vmax 0 0 -23vmax;
+  border-radius: 50%;
+  border: 3px solid var(--tmk-a);
+  opacity: 0;
+  animation: tmk-aro calc(var(--tmk-ms) * 0.55) cubic-bezier(0.3, 0, 0.5, 1) both;
+  will-change: transform, opacity;
+}
+
+.tmk__aro--2 {
+  animation-delay: calc(var(--tmk-ms) * 0.14);
+  border-color: var(--tmk-b);
+}
+
+.tmk__aro--3 {
+  animation-delay: calc(var(--tmk-ms) * 0.28);
+}
+
+.tmk[data-variante='zoom'][data-direccion='salir'] .tmk__aro {
+  animation-direction: reverse;
+}
+
+@keyframes tmk-aro {
+  0% {
+    transform: scale(0.12);
+    opacity: 0;
+  }
+  25% {
+    opacity: 0.85;
+  }
+  100% {
+    transform: scale(2.4);
+    opacity: 0;
+  }
+}
+
+/* Extra barato solo tier alto: leve blur del mundo al fondo del túnel. */
+.tmk[data-tier='alto'][data-variante='zoom'] .tmk__velo {
+  backdrop-filter: blur(5px);
+}
+
+/* ============================ IRIS / portal ============================= */
+/* Agujero circular centrado: la sombra gigante es la cobertura; el agujero
+ * se cierra al centro (pantalla cubierta) y reabre sobre la escena nueva.
+ * El borde es el aro del portal. */
+
+.tmk__iris {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 240vmax;
+  height: 240vmax;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 4px solid var(--tmk-a);
+  box-shadow:
+    0 0 0 260vmax var(--tmk-b),
+    inset 0 0 46px var(--tmk-a);
+  animation: tmk-iris var(--tmk-ms) cubic-bezier(0.65, 0, 0.35, 1) both;
+}
+
+.tmk[data-variante='iris'][data-direccion='salir'] .tmk__iris {
+  /* mismo trazo, respiración distinta: salir abre más suave */
+  animation-timing-function: cubic-bezier(0.35, 0, 0.2, 1);
+}
+
+.tmk[data-tier='bajo'] .tmk__iris,
+.tmk[data-reducida='1'] .tmk__iris {
+  border: 0;
+  box-shadow: 0 0 0 260vmax var(--tmk-b);
+}
+
+@keyframes tmk-iris {
+  0% {
+    width: 240vmax;
+    height: 240vmax;
+  }
+  45%,
+  55% {
+    width: 0vmax;
+    height: 0vmax;
+  }
+  100% {
+    width: 240vmax;
+    height: 240vmax;
+  }
+}
+
+/* ============================ WIPE orgánico ============================= */
+/* Bloque de 220vh (ola frente + cuerpo + ola cola) que barre la pantalla:
+ * entrar sube desde abajo; salir baja desde arriba. Solo transform. */
+
+.tmk__wipe {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 220vh;
+  display: flex;
+  flex-direction: column;
+  animation: tmk-wipe-sube var(--tmk-ms) cubic-bezier(0.6, 0, 0.4, 1) both;
+  will-change: transform;
+}
+
+.tmk[data-variante='wipe'][data-direccion='salir'] .tmk__wipe {
+  animation-name: tmk-wipe-baja;
+}
+
+.tmk__ola {
+  display: block;
+  width: 100%;
+  height: 10vh;
+  flex: none;
+}
+
+.tmk__ola path {
+  fill: var(--tmk-a);
+}
+
+.tmk__ola--cola {
+  transform: scaleY(-1);
+}
+
+.tmk__ola--cola path {
+  fill: var(--tmk-b);
+}
+
+.tmk__wipe-cuerpo {
+  flex: 1;
+  background: linear-gradient(180deg, var(--tmk-a) 0%, var(--tmk-b) 55%);
+}
+
+/* Cobertura en la meseta: bloque en -60vh ⇒ cuerpo tapa 0..100vh completo. */
+@keyframes tmk-wipe-sube {
+  0% {
+    transform: translateY(100vh);
+  }
+  45%,
+  55% {
+    transform: translateY(-60vh);
+  }
+  100% {
+    transform: translateY(-230vh);
+  }
+}
+
+@keyframes tmk-wipe-baja {
+  0% {
+    transform: translateY(-320vh);
+  }
+  45%,
+  55% {
+    transform: translateY(-60vh);
+  }
+  100% {
+    transform: translateY(110vh);
+  }
+}
+
+/* ====================== Reduced motion = corte simple =================== */
+/* Via prop: el componente ya forzó la rama 'fade'; acá la cubierta arranca
+ * YA opaca (el swap de mitad ocurre bajo tapa) y se desvanece corto. */
+
+.tmk[data-reducida='1'] .tmk__velo {
+  animation: tmk-corte var(--tmk-ms) linear both;
+}
+
+@keyframes tmk-corte {
+  0%,
+  62% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+/* Red de seguridad si el host no pasó la prop pero el sistema pide calma:
+ * fuera decoraciones y movimiento, solo el corte simple. */
+@media (prefers-reduced-motion: reduce) {
+  .tmk .tmk__wipe,
+  .tmk .tmk__iris,
+  .tmk .tmk__aro {
+    display: none;
+  }
+
+  .tmk::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: var(--tmk-b);
+    animation: tmk-corte var(--tmk-ms) linear both;
+  }
+}


### PR DESCRIPTION
## Que hay

Kit reutilizable de transiciones para el pase home <-> mundo 3D como VIAJE (norte: tunel 2D<->3D), overlay DOM/CSS puro sobre el canvas — cero three, cero red, barato y offline. **Solo archivos nuevos**, nada existente tocado.

- `src/visual/mundo3d/TransicionMundoKit.jsx` — componente default + wrappers `TransicionWipe` / `TransicionIris` / `TransicionZoom` / `TransicionFade`.
- `src/visual/mundo3d/transicionMundoKit.css` — las 4 coreografias (solo transform/opacity en lo caliente; iris usa el patron clasico de agujero + box-shadow gigante).
- `src/visual/mundo3d/tiemposTransicion.js` — reloj compartido (duraciones, mitad, factores) separado del JSX por react-refresh/only-export-components.
- `src/visual/mundo3d/__tests__/transicionMundoKit.test.jsx` — 7 tests congelan el contrato temporal.

## API

`variante` ('wipe'|'iris'|'zoom'|'fade') · `activa` · `direccion` ('entrar'|'salir') · `tier` ('alto'|'medio'|'bajo') · `reducedMotion` · `colorA`/`colorB` · `onMitad`/`onFin`.

Contrato temporal por timers JS deterministas (no `animationend`): keyframes con meseta 45–55% de pantalla 100% cubierta; `onMitad` (50%) = momento del swap de escena debajo; `onFin` = revelado completo. `reducedMotion` colapsa todo a corte simple (160 ms, cubierta instantanea) + red de seguridad `prefers-reduced-motion` en CSS. Tier bajo acorta (x0.7) y quita decoraciones (olas SVG, aros, halos, blur); tier alto agrega blur leve solo en zoom.

## Variantes

- **wipe organico**: bloque 220vh con borde de ola SVG que barre vertical (entrar sube, salir baja).
- **iris/portal**: agujero circular con aro luminoso que se cierra al centro y reabre.
- **zoom tunel**: velo radial que escala hacia adentro (o afuera al salir) + 3 aros de viaje escalonados.
- **fade calido**: cross-fade por gradiente amanecer.

## Cableo (pendiente, para Opus)

Documentado en el header del componente: montar como hermano del canvas donde orquesta `useNavegacionMundos`, swap de escena en `onMitad`, apagar `activa` en `onFin`, tintes via `tinteDeMundo()`, tier/reducedMotion via `deviceTier.js`. Nota: ya existia `TransicionMundo.jsx` (velo original, z 40) en la base — por la regla de solo-archivos-nuevos el kit vive aparte con z 44 y puede convivir o reemplazarlo variante por variante.

## Verificacion

- `eslint --max-warnings 0` sobre los 4 archivos: limpio.
- `vitest run transicionMundoKit.test.jsx`: 7/7 pass.
- `npm run build` sincrono: exit 0 (2m35s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)