### PR TITLE
feat(3d): kit de cielos por hora del día (amanecer/mediodía/dorada/noche)

### DIFF
--- a/src/visual/mundo3d/CielosHora.jsx
+++ b/src/visual/mundo3d/CielosHora.jsx
@@ -1,0 +1,224 @@
+/*
+ * CielosHora — el cielo del valle según la HORA DEL DÍA (componente r3f).
+ *
+ * Aplica un preset de cielosHoraData dentro de un <Canvas>: fondo, niebla,
+ * hemisferio cielo/suelo, ambiente, sol direccional (que arquea con la hora)
+ * y relleno frío opuesto — el MISMO esquema de luces de EscenaBase3D, para
+ * que una escena iluminada por este kit se lea como hermana de las existentes.
+ * De noche siembra estrellas (presupuesto del tier × fracción del preset).
+ *
+ * NO está cableado a nada: es un módulo autocontenido que se monta por props.
+ *
+ * CABLEO (para quien integre — no toca este archivo):
+ *   1. Dentro de un <Canvas> cualquiera:
+ *        <CielosHora hora="noche" tier={tier} reducedMotion={reducedMotion} />
+ *      Reemplaza (no suma) al bloque fondo/fog/luces de la escena: montar los
+ *      dos duplicaría luces. En una escena nueva, este componente ES el cielo.
+ *   2. `hora` fija por escena, o `hora="auto"` para derivarla del reloj real
+ *      (franjas de horaDeReloj; se refresca sola cada minuto).
+ *   3. `tier`/`reducedMotion` vienen de decidirTier() como en <Mundo>: el
+ *      perfil del tier decide niebla sí/no y el presupuesto de estrellas.
+ *   4. Exportarlo en mundo3d/index.js si se quiere lazy-load con el resto.
+ *
+ * TRANSICIÓN: al cambiar `hora`, todos los valores (colores, intensidades,
+ * posición del sol, niebla) se amortiguan exponencialmente hacia el preset
+ * nuevo (~`duracion` segundos): el día "gira" en vez de saltar. Con
+ * `reducedMotion` no hay animación: el preset entra directo (snap), que es
+ * exactamente la calma que pide la preferencia.
+ *
+ * RENDIMIENTO: el estado animado vive en refs y se escribe imperativamente en
+ * useFrame (cero setState por frame, cero alocación por frame: los Color y
+ * Vector3 se mutan in-place). Los props declarativos usan el preset del PRIMER
+ * montaje, que nunca cambia: un re-render del padre no pisa la animación.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Stars } from '@react-three/drei';
+import * as THREE from 'three';
+import { presetDeHora, horaDeReloj, TRANSICION } from './cielosHoraData.js';
+import { perfilDeTier } from './deviceTier.js';
+
+/* La direccional de relleno vive fija al lado opuesto del valle (como en
+   EscenaBase3D); solo su color e intensidad cambian con la hora. */
+const RELLENO_POS = [-5, 4, -6];
+
+/* Convierte un preset (hex + números) a objetos three mutables in-place. */
+function estadoDesde(p) {
+  return {
+    fondo: new THREE.Color(p.fondo),
+    cielo: new THREE.Color(p.cielo),
+    suelo: new THREE.Color(p.suelo),
+    luz: new THREE.Color(p.luz),
+    relleno: new THREE.Color(p.relleno),
+    niebla: new THREE.Color(p.niebla),
+    solPos: new THREE.Vector3(...p.solPos),
+    intensidad: p.intensidad,
+    hemisferio: p.hemisferio,
+    ambiente: p.ambiente,
+    sol: p.sol,
+    rellenoInt: p.rellenoInt,
+    nieblaCerca: p.nieblaCerca,
+    nieblaLejos: p.nieblaLejos,
+  };
+}
+
+/* Escribe el estado en los nodos three ya montados (los null se saltan: la
+   niebla puede no existir en tier bajo). Todas las intensidades por luz van
+   multiplicadas por la intensidad global de la hora, como en EscenaBase3D. */
+function pintar(n, e) {
+  if (n.fondo.current) n.fondo.current.copy(e.fondo);
+  if (n.fog.current) {
+    n.fog.current.color.copy(e.niebla);
+    n.fog.current.near = e.nieblaCerca;
+    n.fog.current.far = e.nieblaLejos;
+  }
+  if (n.hemi.current) {
+    n.hemi.current.intensity = e.hemisferio * e.intensidad;
+    n.hemi.current.color.copy(e.cielo);
+    n.hemi.current.groundColor.copy(e.suelo);
+  }
+  if (n.amb.current) {
+    n.amb.current.intensity = e.ambiente * e.intensidad;
+    n.amb.current.color.copy(e.luz);
+  }
+  if (n.sol.current) {
+    n.sol.current.intensity = e.sol * e.intensidad;
+    n.sol.current.color.copy(e.luz);
+    n.sol.current.position.copy(e.solPos);
+  }
+  if (n.rell.current) {
+    n.rell.current.intensity = e.rellenoInt * e.intensidad;
+    n.rell.current.color.copy(e.relleno);
+  }
+}
+
+/* Amortigua `actual` hacia `objetivo` con factor k (colores, números y sol). */
+function amortiguar(actual, objetivo, k) {
+  actual.fondo.lerp(objetivo.fondo, k);
+  actual.cielo.lerp(objetivo.cielo, k);
+  actual.suelo.lerp(objetivo.suelo, k);
+  actual.luz.lerp(objetivo.luz, k);
+  actual.relleno.lerp(objetivo.relleno, k);
+  actual.niebla.lerp(objetivo.niebla, k);
+  actual.solPos.lerp(objetivo.solPos, k);
+  for (const c of ['intensidad', 'hemisferio', 'ambiente', 'sol', 'rellenoInt', 'nieblaCerca', 'nieblaLejos']) {
+    actual[c] += (objetivo[c] - actual[c]) * k;
+  }
+}
+
+/**
+ * El cielo por hora del día. Montar DENTRO de un <Canvas>.
+ *
+ * @param {object} props
+ * @param {'amanecer'|'mediodia'|'dorada'|'noche'|'auto'} [props.hora='dorada']
+ *        Momento del día; 'auto' lo deriva del reloj real (horaDeReloj).
+ * @param {'alto'|'medio'|'bajo'} [props.tier='medio']
+ *        Tier del equipo (decidirTier); gobierna niebla y estrellas.
+ * @param {boolean} [props.reducedMotion=false]
+ *        true → sin transición animada: el preset entra directo.
+ * @param {number} [props.duracion] Segundos de la transición entre horas.
+ */
+export default function CielosHora({
+  hora = 'dorada',
+  tier = 'medio',
+  reducedMotion = false,
+  duracion = TRANSICION.duracion,
+}) {
+  const perfil = perfilDeTier(tier);
+
+  // 'auto': la hora sale del reloj y se refresca sola cada minuto.
+  const [horaReloj, setHoraReloj] = useState(() => horaDeReloj());
+  useEffect(() => {
+    if (hora !== 'auto') return undefined;
+    const id = setInterval(() => setHoraReloj(horaDeReloj()), 60000);
+    return () => clearInterval(id);
+  }, [hora]);
+  const horaEfectiva = hora === 'auto' ? horaReloj : hora;
+
+  const objetivo = useMemo(() => estadoDesde(presetDeHora(horaEfectiva)), [horaEfectiva]);
+
+  // El preset del PRIMER montaje, congelado (lazy useState): alimenta los
+  // valores declarativos del JSX, que nunca deben cambiar tras montar. Es
+  // dato plano (hex + números), NO una ref: leerlo en render es legal.
+  const [ini] = useState(() => presetDeHora(horaEfectiva));
+  // Estado animado: objetos three mutables, estables entre renders (nunca se
+  // hace setState, solo se mutan in-place en useFrame/efecto).
+  const [actual] = useState(() => estadoDesde(ini));
+
+  // Refs de los nodos three, individuales (el bundle en objeto lo arma cada
+  // callback en runtime): su `.current` SOLO se toca dentro de useFrame/
+  // efectos, nunca en render.
+  const fondoRef = useRef(null);
+  const fogRef = useRef(null);
+  const hemiRef = useRef(null);
+  const ambRef = useRef(null);
+  const solRef = useRef(null);
+  const rellRef = useRef(null);
+  const bundle = () => ({
+    fondo: fondoRef,
+    fog: fogRef,
+    hemi: hemiRef,
+    amb: ambRef,
+    sol: solRef,
+    rell: rellRef,
+  });
+
+  // Calma pedida → snap: el preset nuevo entra completo, sin animar.
+  useEffect(() => {
+    if (!reducedMotion) return;
+    amortiguar(actual, objetivo, 1);
+    pintar(bundle(), actual);
+  });
+
+  // Transición viva: amortiguación exponencial estable en dt variable.
+  useFrame((_, dt) => {
+    if (reducedMotion) return;
+    const k = 1 - Math.exp((-3 / Math.max(duracion, 0.001)) * Math.min(dt, 0.1));
+    amortiguar(actual, objetivo, k);
+    pintar(bundle(), actual);
+  });
+
+  // Estrellas: presupuesto del tier × fracción de la hora DESTINO (aparecen
+  // al pedir la noche; drei las funde suave con `fade`). Quietas en calma.
+  const preset = presetDeHora(horaEfectiva);
+  const nEstrellas = Math.round(perfil.estrellas * preset.estrellas);
+
+  return (
+    <group>
+      <color ref={fondoRef} attach="background" args={[ini.fondo]} />
+      {perfil.fog && (
+        <fog ref={fogRef} attach="fog" args={[ini.niebla, ini.nieblaCerca, ini.nieblaLejos]} />
+      )}
+      <hemisphereLight
+        ref={hemiRef}
+        intensity={ini.hemisferio * ini.intensidad}
+        color={ini.cielo}
+        groundColor={ini.suelo}
+      />
+      <ambientLight ref={ambRef} intensity={ini.ambiente * ini.intensidad} color={ini.luz} />
+      <directionalLight
+        ref={solRef}
+        position={ini.solPos}
+        intensity={ini.sol * ini.intensidad}
+        color={ini.luz}
+      />
+      <directionalLight
+        ref={rellRef}
+        position={RELLENO_POS}
+        intensity={ini.rellenoInt * ini.intensidad}
+        color={ini.relleno}
+      />
+      {nEstrellas > 0 && (
+        <Stars
+          radius={80}
+          depth={40}
+          count={nEstrellas}
+          factor={3}
+          saturation={0}
+          fade
+          speed={reducedMotion ? 0 : 0.5}
+        />
+      )}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/cielosHoraData.js
+++ b/src/visual/mundo3d/cielosHoraData.js
@@ -1,0 +1,187 @@
+/*
+ * cielosHoraData — el KIT DE CIELOS POR HORA del valle (datos puros, sin three).
+ *
+ * atmosferaMadre fija LA hora dorada como atmósfera compartida de los mundos.
+ * Este módulo la extiende en el tiempo: cuatro momentos del mismo día andino
+ * (amanecer → mediodía → hora dorada → noche estrellada) con la MISMA lógica
+ * de luz que EscenaBase3D (hemisferio cielo/suelo + ambiente + sol direccional
+ * + relleno frío opuesto), para que cambiar de hora se sienta como el mismo
+ * valle girando bajo el sol, no como cuatro escenas distintas.
+ *
+ * Coherencia de paleta (de dónde sale cada hora):
+ *   - dorada   : ESPEJO exacto de `ATMOSFERA` (atmosferaMadre / CLIMAS.dorada
+ *                de valleData). Es la hora madre; si aquella cambia, este
+ *                preset debe actualizarse a mano (se duplica a propósito para
+ *                que este archivo siga siendo three-free y autocontenido).
+ *   - amanecer : keyframe t=0 de la bóveda del clima (horizonte '#f6c9a0',
+ *                cenit '#3f4f80') — durazno rasante con relleno lavanda.
+ *   - mediodia : el marfil claro de la familia `neutro`, aclarado y con el sol
+ *                casi blanco en el cenit; la niebla se corre lejos.
+ *   - noche    : keyframe t=1 de la bóveda ('#26325a' / '#0d1330') — índigo
+ *                hondo, luna plata y un relleno tibio de fogata lejana (el
+ *                único calor que queda del día).
+ *
+ * Es DATO PURO (strings y números): lo pueden consumir tests, el 2D digno o
+ * cualquier render sin pagar el chunk de three. La única función con costo es
+ * `mezclaHex`/`mezclarPresets` (aritmética de enteros, cero alocación THREE).
+ *
+ * Forma de cada preset:
+ *   fondo        hex  — scene.background
+ *   cielo/suelo  hex  — hemisphereLight (bóveda / rebote de tierra)
+ *   luz          hex  — sol (o luna): direccional principal + ambiente
+ *   relleno      hex  — direccional opuesta, tenue (cielo abierto / fogata)
+ *   niebla       hex  — color del fog (si el tier lo permite)
+ *   sombra       hex  — tinte sugerido para sombras de contacto
+ *   intensidad   num  — multiplicador global de la hora (la noche baja todo)
+ *   hemisferio/ambiente/sol/rellenoInt num — intensidades base por luz
+ *   solPos       [x,y,z] — posición del sol/luna (el arco del día)
+ *   nieblaCerca/nieblaLejos num — near/far del fog (la noche cierra el valle)
+ *   estrellas    0..1 — fracción del presupuesto de estrellas del tier
+ */
+
+/* Orden canónico del día (útil para UIs de selección y para tests). */
+export const HORAS = ['amanecer', 'mediodia', 'dorada', 'noche'];
+
+export const CIELOS_HORA = {
+  /* madrugada andina: sol rasante durazno, cenit todavía lavanda, bruma baja
+     y las últimas estrellas despidiéndose */
+  amanecer: {
+    fondo: '#f3cba0',
+    cielo: '#f6c9a0',
+    suelo: '#6e5a44',
+    luz: '#ffc994',
+    relleno: '#8fa2cc',
+    niebla: '#ecc7a2',
+    sombra: '#3c2f40',
+    intensidad: 0.9,
+    hemisferio: 0.5,
+    ambiente: 0.24,
+    sol: 0.85,
+    rellenoInt: 0.3,
+    solPos: [9, 2.5, 5],
+    nieblaCerca: 7,
+    nieblaLejos: 32,
+    estrellas: 0.2,
+  },
+  /* día pleno: marfil claro, sol alto casi blanco, el aire se abre y la
+     niebla se va lejos — la hora de trabajar */
+  mediodia: {
+    fondo: '#efe7cf',
+    cielo: '#f8f2dd',
+    suelo: '#a3854f',
+    luz: '#fff2d2',
+    relleno: '#adc2d8',
+    niebla: '#ecdfc0',
+    sombra: '#4a3d28',
+    intensidad: 1.15,
+    hemisferio: 0.6,
+    ambiente: 0.3,
+    sol: 1.0,
+    rellenoInt: 0.18,
+    solPos: [2, 12, 3],
+    nieblaCerca: 12,
+    nieblaLejos: 48,
+    estrellas: 0,
+  },
+  /* la hora madre: espejo exacto de ATMOSFERA (atmosferaMadre). El sol en
+     [6,9,4] calca la direccional de EscenaBase3D para que una escena montada
+     con este preset se vea IGUAL a las escenas existentes. */
+  dorada: {
+    fondo: '#f2d9a8',
+    cielo: '#f7c66b',
+    suelo: '#8a6b4a',
+    luz: '#ffd79a',
+    relleno: '#9db8d9',
+    niebla: '#f0c98d',
+    sombra: '#3a2a18',
+    intensidad: 1,
+    hemisferio: 0.55,
+    ambiente: 0.28,
+    sol: 0.9,
+    rellenoInt: 0.22,
+    solPos: [6, 9, 4],
+    nieblaCerca: 9,
+    nieblaLejos: 40,
+    estrellas: 0,
+  },
+  /* noche estrellada de páramo: índigo hondo, luna plata desde el otro lado
+     del valle, relleno tibio de fogata y el fog cerrando la distancia */
+  noche: {
+    fondo: '#151d3a',
+    cielo: '#26325a',
+    suelo: '#181410',
+    luz: '#b9c6e6',
+    relleno: '#6b5638',
+    niebla: '#1a2340',
+    sombra: '#05070f',
+    intensidad: 0.55,
+    hemisferio: 0.3,
+    ambiente: 0.12,
+    sol: 0.35,
+    rellenoInt: 0.1,
+    solPos: [-6, 7, -4],
+    nieblaCerca: 6,
+    nieblaLejos: 30,
+    estrellas: 1,
+  },
+};
+
+/* Transición por defecto entre horas (segundos). El componente la anima con
+   amortiguación exponencial; `reducedMotion` la salta por completo. */
+export const TRANSICION = { duracion: 2.5 };
+
+/** Preset de una hora, con fallback a la hora madre (nunca undefined). */
+export function presetDeHora(hora) {
+  return CIELOS_HORA[hora] || CIELOS_HORA.dorada;
+}
+
+/**
+ * Deriva la hora del kit del reloj real (franja ecuatorial andina: el sol
+ * sale ~6 y se esconde ~18 todo el año, así que las franjas son estables).
+ * @param {Date} [fecha]
+ * @returns {'amanecer'|'mediodia'|'dorada'|'noche'}
+ */
+export function horaDeReloj(fecha = new Date()) {
+  const h = fecha.getHours();
+  if (h >= 5 && h < 9) return 'amanecer';
+  if (h >= 9 && h < 16) return 'mediodia';
+  if (h >= 16 && h < 19) return 'dorada';
+  return 'noche';
+}
+
+/** Mezcla dos hex `#rrggbb` hacia `t` (0 = a, 1 = b) sin three (aritmética pura). */
+export function mezclaHex(a, b, t) {
+  const pa = parseInt(a.slice(1), 16);
+  const pb = parseInt(b.slice(1), 16);
+  const canal = (p, d) => (p >> d) & 0xff;
+  const paso = (x, y) => Math.round(x + (y - x) * t);
+  const r = paso(canal(pa, 16), canal(pb, 16));
+  const g = paso(canal(pa, 8), canal(pb, 8));
+  const bl = paso(canal(pa, 0), canal(pb, 0));
+  return '#' + ((r << 16) | (g << 8) | bl).toString(16).padStart(6, '0');
+}
+
+const CAMPOS_COLOR = ['fondo', 'cielo', 'suelo', 'luz', 'relleno', 'niebla', 'sombra'];
+const CAMPOS_NUMERO = [
+  'intensidad',
+  'hemisferio',
+  'ambiente',
+  'sol',
+  'rellenoInt',
+  'nieblaCerca',
+  'nieblaLejos',
+  'estrellas',
+];
+
+/**
+ * Interpola dos presets completos hacia `t` (0 = a, 1 = b): colores por canal,
+ * números lineal, posición del sol componente a componente. Útil para derivar
+ * horas intermedias (p. ej. un atardecer 30% noche) o para tests del arco.
+ */
+export function mezclarPresets(a, b, t) {
+  const out = {};
+  for (const campo of CAMPOS_COLOR) out[campo] = mezclaHex(a[campo], b[campo], t);
+  for (const campo of CAMPOS_NUMERO) out[campo] = a[campo] + (b[campo] - a[campo]) * t;
+  out.solPos = a.solPos.map((v, i) => v + (b.solPos[i] - v) * t);
+  return out;
+}


### PR DESCRIPTION
## Qué

Kit de cielos por hora del día para las escenas 3D: presets de atmósfera para **amanecer, mediodía, hora dorada y noche estrellada**, coherentes con la paleta andina cálida del valle. Cada preset define color de cielo/fondo/suelo/luz/relleno/niebla + intensidades por luz + el arco del sol, y una transición suave entre horas. Da riqueza atmosférica y sensación de tiempo vivo.

## Archivos nuevos (autocontenidos, no tocan nada existente)

- **`src/visual/mundo3d/cielosHoraData.js`** — datos puros (three-free): 4 presets + orden canónico `HORAS`, derivación de hora por reloj real (`horaDeReloj`, franjas ecuatoriales andinas), y mezcla three-free (`mezclaHex`/`mezclarPresets`) para horas intermedias. Consumible por tests o el 2D digno sin pagar el chunk de three.
- **`src/visual/mundo3d/CielosHora.jsx`** — componente r3f que aplica el preset dentro de un `<Canvas>` con **el mismo esquema de luces de `EscenaBase3D`** (hemisferio cielo/suelo + ambiente + sol direccional que arquea + relleno frío opuesto). Estrellas de noche según presupuesto del tier. Transición amortiguada exponencial entre horas; `reducedMotion` → snap directo sin animar.

## Coherencia de paleta

- **dorada** = espejo exacto de `atmosferaMadre.ATMOSFERA` (la hora madre); sol en `[6,9,4]` calca la direccional de `EscenaBase3D`.
- **amanecer** / **noche** calcan los keyframes `t=0` / `t=1` de la bóveda del clima (`EscenaBoveda`).
- **mediodía** = marfil claro de la familia `neutro`, aclarado, sol casi blanco al cenit.

## Props

`hora` (`'amanecer'|'mediodia'|'dorada'|'noche'|'auto'`), `tier` (`'alto'|'medio'|'bajo'`), `reducedMotion`, `duracion`.

## Cableo (lo hace Opus — no toca este PR)

Montar dentro de un `<Canvas>`: `<CielosHora hora="noche" tier={tier} reducedMotion={reducedMotion} />`. **Reemplaza** (no suma) al bloque fondo/fog/luces de la escena. `hora="auto"` la deriva del reloj. Detalle completo en el bloque `CABLEO` del componente.

## Verificación

- `eslint --max-warnings 0` sobre ambos archivos: **exit 0** (incl. `react-hooks/refs`; refs mutadas solo en `useFrame`/efectos, `useState` lazy para estado animado).
- `npm run build`: **exit 0** (built in 1m 35s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)