### PR TITLE
feat(3d): vitrina de mundos 3D del valle (#/mockups/vitrina-mundos)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -151,6 +151,10 @@ const VitrinaCriaturasMockup = lazy(() => import('./mockups/vitrina3d/VitrinaCri
 // establo, bodega, tanque, secadero…) con control de tamaño por pieza y el
 // mini demo del modo colocar (snapping sobre la ladera).
 const VitrinaInfraestructuraMockup = lazy(() => import('./mockups/vitrina3d/VitrinaInfraestructura'));
+// 3D: vitrina/galería de los MUNDOS del valle (valle, café, sanidad, mercado,
+// animales, semillero, clima). Cada tarjeta previsualiza el mundo en su diorama
+// con su encuadre de cámara curado (camaraDioramas) + botón «Entrar» al host real.
+const VitrinaMundosMockup = lazy(() => import('./mockups/vitrina3d/VitrinaMundos'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
@@ -543,6 +547,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/colocar-infraestructura': 'mockup_colocar_infraestructura',
   'mockups/vitrina-3d': 'mockup_vitrina_3d',
   'mockups/vitrina-infra': 'mockup_vitrina_infra',
+  'mockups/vitrina-mundos': 'mockup_vitrina_mundos',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1734,6 +1739,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Vitrina de infraestructura">
               <VitrinaInfraestructuraMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_vitrina_mundos':
+        // Vitrina/galería de los MUNDOS 3D del valle: valle, café, sanidad,
+        // mercado, animales, semillero y clima. Cada tarjeta previsualiza el
+        // mundo en su diorama con el encuadre de cámara curado (camaraDioramas)
+        // y un botón «Entrar» que lo abre a pantalla completa con el host real
+        // <Mundo> (hotspots + abeja Angelita, caída digna a 2D). A lo sumo un
+        // Canvas WebGL vivo a la vez. Ruta #/mockups/vitrina-mundos, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Vitrina de mundos 3D">
+              <VitrinaMundosMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/vitrina3d/VitrinaMundos.css
+++ b/src/mockups/vitrina3d/VitrinaMundos.css
@@ -1,0 +1,343 @@
+/*
+ * VitrinaMundos — estilos de la galería de mundos 3D del valle
+ * (#/mockups/vitrina-mundos). Cuaderno de laboratorio andino: crema tibia,
+ * tinta profunda, verde páramo y el dorado de la hora dorada. Móvil-first
+ * (320px), táctil (controles >= 44px), autocontenido (cero CDN/imágenes).
+ * Solo transform/opacity animados; reduced-motion los apaga.
+ */
+
+.vmun {
+  --vmun-crema: #f7f1e2;
+  --vmun-papel: #fffaf0;
+  --vmun-tinta: #2c3324;
+  --vmun-tinta-suave: #5c6350;
+  --vmun-verde: #3f6f4e;
+  --vmun-verde-oscuro: #2d5039;
+  --vmun-dorado: #f2b134;
+  --vmun-borde: #d9cfb4;
+  --vmun-sombra: 0 2px 10px rgba(60, 52, 31, 0.12);
+
+  min-height: 100vh;
+  min-height: 100dvh;
+  background:
+    radial-gradient(1200px 500px at 80% -10%, #fdf6e4 0%, transparent 60%),
+    var(--vmun-crema);
+  color: var(--vmun-tinta);
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  padding-bottom: 3rem;
+}
+
+/* ── Cabecera ─────────────────────────────────────────────────────────────── */
+.vmun__head {
+  padding: 0.9rem 1rem 0.85rem;
+  border-bottom: 2px solid var(--vmun-borde);
+  background: linear-gradient(180deg, var(--vmun-papel) 0%, var(--vmun-crema) 100%);
+}
+
+.vmun__headMain {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  max-width: 72rem;
+  margin: 0 auto;
+}
+
+.vmun__back {
+  flex: none;
+  min-height: 44px;
+  padding: 0.45rem 0.85rem;
+  border: 1.5px solid var(--vmun-borde);
+  border-radius: 999px;
+  background: var(--vmun-papel);
+  color: var(--vmun-tinta);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.vmun__back:active { transform: translateY(1px); }
+.vmun__back:focus-visible { outline: 3px solid var(--vmun-verde); outline-offset: 2px; }
+
+.vmun__kicker {
+  margin: 0 0 0.15rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--vmun-verde);
+}
+
+.vmun__title {
+  margin: 0;
+  font-size: 1.3rem;
+  line-height: 1.2;
+  color: var(--vmun-verde-oscuro);
+  letter-spacing: 0.01em;
+}
+
+.vmun__sub {
+  margin: 0.3rem 0 0;
+  font-size: 0.87rem;
+  line-height: 1.45;
+  color: var(--vmun-tinta-suave);
+  max-width: 46rem;
+}
+
+/* ── Controles globales ───────────────────────────────────────────────────── */
+.vmun__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem 1.1rem;
+  max-width: 72rem;
+  margin: 0.85rem auto 0;
+}
+
+.vmun__ctl { display: flex; align-items: center; gap: 0.5rem; }
+
+.vmun__ctlLabel {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--vmun-tinta-suave);
+}
+
+.vmun__segmented {
+  display: inline-flex;
+  border: 1.5px solid var(--vmun-borde);
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--vmun-papel);
+}
+.vmun__seg {
+  min-height: 40px;
+  padding: 0.35rem 0.85rem;
+  border: 0;
+  background: transparent;
+  color: var(--vmun-tinta-suave);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.vmun__seg + .vmun__seg { border-left: 1.5px solid var(--vmun-borde); }
+.vmun__seg.is-on { background: var(--vmun-verde); color: #fff; }
+.vmun__seg:focus-visible { outline: 3px solid var(--vmun-verde-oscuro); outline-offset: -3px; }
+
+.vmun__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--vmun-tinta-suave);
+  cursor: pointer;
+}
+.vmun__toggle input { width: 18px; height: 18px; accent-color: var(--vmun-verde); }
+
+/* ── Cuerpo / grilla ──────────────────────────────────────────────────────── */
+.vmun__body { max-width: 72rem; margin: 0 auto; padding: 1rem; }
+
+.vmun__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+@media (min-width: 640px) {
+  .vmun__grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1000px) {
+  .vmun__grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+.vmun__card {
+  display: flex;
+  flex-direction: column;
+  border: 1.5px solid var(--vmun-borde);
+  border-radius: 16px;
+  overflow: hidden;
+  background: var(--vmun-papel);
+  box-shadow: var(--vmun-sombra);
+}
+
+/* El escenario: caja de proporción fija; el diorama/afiche la llena. */
+.vmun__stage {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  min-height: 220px;
+  background: #ece0c7;
+}
+
+.vmun__lienzo,
+.vmun__poster {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* El diorama vive dentro (el <Canvas> del framework llena el 100%). */
+.vmun__lienzo { display: block; }
+.vmun__lienzo--2d { overflow: auto; background: var(--vmun-crema); }
+
+.vmun__loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--vmun-tinta-suave);
+  background: #ece0c7;
+}
+
+/* El afiche de la tarjeta dormida: tinte del mundo + emoji grande. */
+.vmun__poster {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border: 0;
+  cursor: pointer;
+  color: #fff;
+  background:
+    radial-gradient(120% 90% at 50% 12%, color-mix(in srgb, var(--a) 65%, #fff 0%) 0%, var(--a) 55%, var(--b) 130%);
+  -webkit-tap-highlight-color: transparent;
+}
+.vmun__posterEmoji {
+  font-size: clamp(2.6rem, 12vw, 3.6rem);
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.25));
+  transition: transform 0.25s ease;
+}
+.vmun__poster:hover .vmun__posterEmoji { transform: scale(1.08) rotate(-3deg); }
+.vmun__posterTxt {
+  font-size: 1.05rem;
+  font-weight: 700;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+}
+.vmun__posterHint {
+  font-size: 0.75rem;
+  opacity: 0.9;
+  background: rgba(0, 0, 0, 0.22);
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+}
+.vmun__poster:focus-visible { outline: 4px solid #fff; outline-offset: -6px; }
+
+/* ── Metadatos de la tarjeta ──────────────────────────────────────────────── */
+.vmun__meta { padding: 0.75rem 0.85rem 0.85rem; display: flex; flex-direction: column; gap: 0.4rem; }
+
+.vmun__cardTitle {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 1.2;
+  color: var(--vmun-verde-oscuro);
+}
+.vmun__cardDesc {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--vmun-tinta-suave);
+}
+
+.vmun__acciones { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.2rem; }
+
+.vmun__prev,
+.vmun__entrar {
+  min-height: 44px;
+  padding: 0.5rem 0.95rem;
+  border-radius: 999px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+.vmun__prev {
+  border: 1.5px solid var(--vmun-borde);
+  background: var(--vmun-papel);
+  color: var(--vmun-tinta);
+}
+.vmun__entrar {
+  flex: 1 1 auto;
+  border: 0;
+  background: var(--vmun-verde);
+  color: #fff;
+}
+.vmun__entrar:active,
+.vmun__prev:active { transform: translateY(1px); }
+.vmun__entrar:focus-visible,
+.vmun__prev:focus-visible { outline: 3px solid var(--vmun-verde-oscuro); outline-offset: 2px; }
+
+.vmun__pie {
+  max-width: 46rem;
+  margin: 1.25rem auto 0;
+  padding: 0 0.25rem;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--vmun-tinta-suave);
+  text-align: center;
+}
+
+/* ── Pantalla completa: el mundo real ─────────────────────────────────────── */
+.vmun__full {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  background: #ece0c7;
+}
+
+.vmun__fullStage { position: relative; flex: 1 1 auto; min-height: 0; }
+.vmun__fullStage .mundo-root { border-radius: 0; height: 100%; }
+
+.vmun__salir {
+  position: absolute;
+  top: max(0.6rem, env(safe-area-inset-top));
+  right: 0.6rem;
+  z-index: 62;
+  width: 44px;
+  height: 44px;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(20, 30, 20, 0.55);
+  color: #fff;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+}
+.vmun__salir:active { transform: translateY(1px); }
+.vmun__salir:focus-visible { outline: 3px solid #fff; outline-offset: 2px; }
+
+.vmun__pista {
+  flex: none;
+  margin: 0;
+  padding: 0.6rem 1rem calc(0.6rem + env(safe-area-inset-bottom));
+  font-size: 0.85rem;
+  line-height: 1.35;
+  text-align: center;
+  color: var(--vmun-tinta);
+  background: var(--vmun-papel);
+  border-top: 1.5px solid var(--vmun-borde);
+}
+
+/* Rótulo solo-lectores (accesibilidad). */
+.vmun__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vmun__posterEmoji,
+  .vmun__poster:hover .vmun__posterEmoji { transition: none; transform: none; }
+}

--- a/src/mockups/vitrina3d/VitrinaMundos.jsx
+++ b/src/mockups/vitrina3d/VitrinaMundos.jsx
@@ -1,0 +1,303 @@
+/*
+ * VitrinaMundos — vitrina/galería de los MUNDOS 3D del valle (ruta pública
+ * #/mockups/vitrina-mundos, sin auth). La hermana de la vitrina de criaturas
+ * (#/mockups/vitrina-3d) y la de infraestructura (#/mockups/vitrina-infra),
+ * pero para los MUNDOS del framework `src/visual/mundo3d`: el valle, el café,
+ * la sanidad, el mercado, los animales, el semillero y el clima.
+ *
+ * Cada tarjeta previsualiza un mundo EN SU DIORAMA, encuadrado con la fotografía
+ * curada de `camaraDioramas.js` (posición/target/fov propios por mundo), y trae
+ * un botón «Entrar» que abre el mundo a pantalla completa con el host real
+ * `<Mundo>` (hotspots tocables, abeja Angelita, caída digna a 2D). Nada se
+ * reimplementa: se IMPORTA el framework tal cual (escenas + resolverEncuadre +
+ * MUNDO + resolverMundo), sin editarlo.
+ *
+ * PERF — a lo sumo UN contexto WebGL vivo a la vez: solo la tarjeta ACTIVA monta
+ * su diorama (las demás muestran un afiche con el tinte del mundo); y mientras el
+ * modo «Entrar» a pantalla completa está abierto, las previsualizaciones no se
+ * montan. Controles globales de detalle (device-tier) y de movimiento reducido,
+ * como en las vitrinas hermanas. En equipo humilde la previsualización cae a la
+ * ficha 2D digna del mundo (device-tiering real del framework).
+ *
+ * Estética: cuaderno de laboratorio andino. Crema tibia, tinta profunda, verde
+ * páramo y el dorado de la hora dorada. Móvil-first (320px), autocontenido (cero
+ * CDN/imágenes externas). Español de Colombia, en «usted».
+ */
+import { lazy, Suspense, useMemo, useRef, useState } from 'react';
+import Mundo, { permite3D } from '../../visual/mundo3d/index.js';
+import { MUNDO } from '../../visual/mundo3d/mundoData.js';
+import { resolverEncuadre } from '../../visual/mundo3d/camaraDioramas.js';
+import { tinteDeMundo, tituloDeMundo, emojiDeMundo } from '../../visual/mundo3d/resolverMundo.js';
+import './VitrinaMundos.css';
+
+// Importadores PEREZOSOS de las escenas 3D (chunk `vendor-three`): el mapa se
+// arma UNA vez a nivel de módulo, así cada componente tiene identidad estable
+// (no se crea en el render → sin `react-hooks/static-components`). El import()
+// solo dispara al montar la tarjeta activa.
+const ESCENAS = {
+  valle: lazy(() => import('../../visual/mundo3d/escenas/EscenaValle.jsx')),
+  cafe: lazy(() => import('../../visual/mundo3d/escenas/EscenaCafe.jsx')),
+  sanidad: lazy(() => import('../../visual/mundo3d/escenas/EscenaSanidad.jsx')),
+  mercado: lazy(() => import('../../visual/mundo3d/escenas/EscenaMercado.jsx')),
+  recinto: lazy(() => import('../../visual/mundo3d/escenas/EscenaRecinto.jsx')),
+  semillero: lazy(() => import('../../visual/mundo3d/escenas/EscenaSemillero.jsx')),
+  boveda: lazy(() => import('../../visual/mundo3d/escenas/EscenaBoveda.jsx')),
+};
+
+// Los siete mundos del valle con fotografía de diorama curada (ENCUADRES de
+// camaraDioramas.js), en el orden en que se recorren. La copia es de ESTE
+// archivo (una línea por mundo); el nombre/emoji/tinte se resuelven del
+// framework para no duplicarlos (valle no vive en el manifiesto: lo rotulamos).
+const MUNDOS = [
+  { id: 'valle', texto: 'El valle entero como maqueta viva: cada lugar es un mundo al que puede entrar.' },
+  { id: 'cafe', texto: 'El cafetal bajo sombra: la cereza que se vuelve pergamino y oro, la roya y el beneficio.' },
+  { id: 'sanidad', texto: 'La huerta-clínica: trampas de color, biocontrol y enemigos naturales, sin veneno.' },
+  { id: 'mercado', texto: 'El mercado campesino: la cadena corta del campo a la mesa, con precio justo.' },
+  { id: 'animales', texto: 'El corral y su ciclo cerrado del abono: del animal a la tierra y de vuelta.' },
+  { id: 'semillero', texto: 'El semillero: germinar, repicar y endurecer la matica bajo el túnel protegido.' },
+  { id: 'clima', texto: 'La bóveda del cielo andino: la hora del día, las dos lluvias y el páramo que hace agua.' },
+];
+
+const TIERS = [
+  { v: 'alto', label: 'Alto' },
+  { v: 'medio', label: 'Medio' },
+  { v: 'bajo', label: 'Bajo' },
+];
+
+// Valle no está en el manifiesto real (mundosFinca): su rótulo va aquí.
+const ROTULO_VALLE = { titulo: 'El valle', emoji: '🗺️' };
+
+const NOOP = () => {};
+
+function rotuloDe(id) {
+  if (id === 'valle') return ROTULO_VALLE;
+  return { titulo: tituloDeMundo(id), emoji: emojiDeMundo(id) };
+}
+
+// ── Previsualización de UN mundo en su diorama (o su ficha 2D en gama baja) ───
+function PreviewMundo({ mundoId, tier, reducedMotion }) {
+  // Gama baja: el device-tier del framework decide 2D; montamos el host `<Mundo>`
+  // que resuelve el espejo 2D digno del mundo (misma lección, sin WebGL).
+  if (!permite3D(tier)) {
+    return (
+      <div className="vmun__lienzo vmun__lienzo--2d">
+        <Mundo
+          mundoId={mundoId}
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onHotspot={NOOP}
+          onSalir={null}
+          animo="sereno"
+          energia={0.9}
+        />
+      </div>
+    );
+  }
+
+  const d = MUNDO[mundoId];
+  const Escena = ESCENAS[d?.escena];
+  if (!Escena) return null;
+
+  // El encuadre de DIORAMA curado (camaraDioramas.js): posición/target/fov
+  // propios del mundo → la cámara inicial (y el reposo del director) del diorama.
+  const enc = resolverEncuadre(mundoId, tier);
+
+  return (
+    <div className="vmun__lienzo">
+      <Suspense fallback={<div className="vmun__loading">Preparando el mundo…</div>}>
+        <Escena
+          mundoId={mundoId}
+          params={d.params}
+          hotspots={d.hotspots}
+          entrada={{ ...d.entrada, centro: enc.target }}
+          tinte={tinteDeMundo(mundoId)}
+          tier={tier}
+          reducedMotion={reducedMotion}
+          camara={{ position: enc.posicion, fov: enc.fov }}
+          onHotspot={NOOP}
+          animo="sereno"
+          energia={0.9}
+        />
+      </Suspense>
+    </div>
+  );
+}
+
+// ── Tarjeta de un mundo (afiche → previsualización viva al activarla) ─────────
+function TarjetaMundo({ mundoId, texto, activo, tier, reducedMotion, onActivar, onEntrar }) {
+  const { titulo, emoji } = rotuloDe(mundoId);
+  const [a, b] = tinteDeMundo(mundoId);
+
+  return (
+    <article className="vmun__card" style={{ '--a': a, '--b': b }}>
+      <div className="vmun__stage">
+        {activo ? (
+          <PreviewMundo mundoId={mundoId} tier={tier} reducedMotion={reducedMotion} />
+        ) : (
+          <button
+            type="button"
+            className="vmun__poster"
+            onClick={onActivar}
+            aria-label={`Previsualizar ${titulo} en 3D`}
+          >
+            <span className="vmun__posterEmoji" aria-hidden="true">{emoji}</span>
+            <span className="vmun__posterTxt">{titulo}</span>
+            <span className="vmun__posterHint">Toque para verlo en 3D</span>
+          </button>
+        )}
+      </div>
+
+      <div className="vmun__meta">
+        <h3 className="vmun__cardTitle">
+          <span aria-hidden="true">{emoji}</span> {titulo}
+        </h3>
+        <p className="vmun__cardDesc">{texto}</p>
+        <div className="vmun__acciones">
+          {!activo && (
+            <button type="button" className="vmun__prev" onClick={onActivar}>
+              Previsualizar
+            </button>
+          )}
+          <button type="button" className="vmun__entrar" onClick={onEntrar}>
+            Entrar ›
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+// ── Pantalla completa: el mundo real (host `<Mundo>` con hotspots + abeja) ────
+function MundoPantalla({ mundoId, tier, reducedMotion, onSalir }) {
+  const { titulo } = rotuloDe(mundoId);
+  const [pista, setPista] = useState(null);
+  const pistaTimer = useRef(null);
+
+  const alHotspot = (view) => {
+    // La vitrina no navega a vistas reales: acusa a dónde LLEVARÍA ese punto,
+    // buscando su rótulo en los hotspots del mundo (dato del framework).
+    const h = (MUNDO[mundoId]?.hotspots || []).find((x) => x.view === view);
+    setPista(h ? h.label : null);
+    if (pistaTimer.current) clearTimeout(pistaTimer.current);
+    pistaTimer.current = setTimeout(() => setPista(null), 3200);
+  };
+
+  return (
+    <div className="vmun__full" role="dialog" aria-modal="true" aria-label={titulo}>
+      <button type="button" className="vmun__salir" onClick={onSalir} aria-label="Salir del mundo">
+        ✕
+      </button>
+      <div className="vmun__fullStage">
+        <Mundo
+          mundoId={mundoId}
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onHotspot={alHotspot}
+          onSalir={onSalir}
+          animo="sereno"
+          energia={0.9}
+        />
+      </div>
+      <p className="vmun__pista" role="status" aria-live="polite">
+        {pista
+          ? `Este punto lo llevaría a: ${pista}`
+          : 'Toque un punto del mundo para ver a dónde lo lleva. Toque «‹ El valle» o la ✕ para volver.'}
+      </p>
+    </div>
+  );
+}
+
+// ── La vitrina ───────────────────────────────────────────────────────────────
+export default function VitrinaMundos({ onBack }) {
+  const [tier, setTier] = useState('alto');
+  const [reducedMotion, setReducedMotion] = useState(false);
+  // Cuál tarjeta tiene el diorama vivo (a lo sumo una) y cuál mundo está abierto
+  // a pantalla completa. Con `entrado` activo NO se monta ninguna previsualización.
+  const [activo, setActivo] = useState('valle');
+  const [entrado, setEntrado] = useState(null);
+
+  const rotEntrado = useMemo(() => (entrado ? rotuloDe(entrado) : null), [entrado]);
+
+  return (
+    <div className="vmun" data-tier={tier}>
+      <header className="vmun__head">
+        <div className="vmun__headMain">
+          <button type="button" className="vmun__back" onClick={() => onBack?.()}>
+            ← Volver
+          </button>
+          <div>
+            <p className="vmun__kicker">Los mundos de su valle · vitrina</p>
+            <h1 className="vmun__title">Vitrina de mundos 3D</h1>
+            <p className="vmun__sub">
+              Previsualice cada mundo del valle en su diorama y entre a recorrerlo.
+              Toque un mundo para verlo en 3D; toque «Entrar» para meterse, con la
+              abeja Angelita y los puntos tocables.
+            </p>
+          </div>
+        </div>
+
+        <div className="vmun__controls" role="group" aria-label="Controles globales">
+          <div className="vmun__ctl">
+            <span className="vmun__ctlLabel">Detalle</span>
+            <div className="vmun__segmented">
+              {TIERS.map((t) => (
+                <button
+                  key={t.v}
+                  type="button"
+                  className={`vmun__seg${tier === t.v ? ' is-on' : ''}`}
+                  onClick={() => setTier(t.v)}
+                  aria-pressed={tier === t.v}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <label className="vmun__toggle">
+            <input
+              type="checkbox"
+              checked={reducedMotion}
+              onChange={(e) => setReducedMotion(e.target.checked)}
+            />
+            <span>Movimiento reducido</span>
+          </label>
+        </div>
+      </header>
+
+      <main className="vmun__body">
+        <div className="vmun__grid">
+          {MUNDOS.map((m) => (
+            <TarjetaMundo
+              key={m.id}
+              mundoId={m.id}
+              texto={m.texto}
+              activo={!entrado && activo === m.id}
+              tier={tier}
+              reducedMotion={reducedMotion}
+              onActivar={() => setActivo(m.id)}
+              onEntrar={() => setEntrado(m.id)}
+            />
+          ))}
+        </div>
+        <p className="vmun__pie">
+          Cada mundo es un lugar del valle. En equipo humilde o con «movimiento
+          reducido», la previsualización cae a la ficha 2D digna del mundo: la
+          misma lección, sin exigirle 3D al equipo.
+        </p>
+      </main>
+
+      {entrado && (
+        <MundoPantalla
+          key={`${entrado}-${tier}`}
+          mundoId={entrado}
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onSalir={() => setEntrado(null)}
+        />
+      )}
+
+      {/* Rótulo accesible del mundo abierto (fuera de foco visual). */}
+      {rotEntrado && <span className="vmun__sr">{rotEntrado.titulo}</span>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Qué

Una **vitrina/galería de los mundos 3D del valle**: previsualizar y **entrar** a cada mundo (valle, café, sanidad, mercado, animales, semillero, clima) desde una sola pantalla. Ruta pública `#/mockups/vitrina-mundos` (sin auth), hermana de `#/mockups/vitrina-3d` y `#/mockups/vitrina-infra`.

Cada tarjeta muestra el mundo **en su diorama con su encuadre de cámara curado** (`resolverEncuadre` de `camaraDioramas.js`: posición/target/fov propios por mundo) + nombre + un botón **«Entrar»** que abre el mundo a pantalla completa con el host real `<Mundo>` (hotspots tocables, abeja Angelita, caída digna a 2D).

## Cómo

- **Importa el framework `src/visual/mundo3d` sin editarlo**: escenas cargadas perezosas (chunk `vendor-three`), `resolverEncuadre`, `MUNDO`, `resolverMundo` (tinte/título/emoji).
- **A lo sumo un contexto WebGL vivo a la vez**: solo la tarjeta activa monta su diorama (las demás muestran un afiche con el tinte del mundo); con «Entrar» abierto no se monta ninguna previsualización. Mismo criterio de perf que las vitrinas hermanas.
- **Controles globales** de detalle (device-tier alto/medio/bajo) y movimiento reducido. En gama baja (o con movimiento reducido) la previsualización cae a la **ficha 2D digna** del mundo.
- Ruta agregada **al final** del bloque mockup de `App.jsx` (lazy import + `MOCKUP_HASH_ROUTES` + `case`).

## Archivos

- `src/mockups/vitrina3d/VitrinaMundos.jsx` (nuevo)
- `src/mockups/vitrina3d/VitrinaMundos.css` (nuevo)
- `src/App.jsx` (lazy import + ruta `#/mockups/vitrina-mundos`)

## Verificación

- `npx eslint --max-warnings 0` sobre los archivos nuevos + `App.jsx`: **0 errores/warnings** (i18n, `react-hooks/refs`, `react-hooks/static-components`, `react-refresh/only-export-components` limpios).
- `npm run build`: **exit 0** (warnings de tamaño de chunk preexistentes, ajenas al cambio).
- Merge de `origin/dev` al día antes del PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)