### PR TITLE
feat(3d): pisos térmicos como bandas navegables sobre la Sierra

### DIFF
--- a/src/visual/mundo3d/PisosTermicosBandas.jsx
+++ b/src/visual/mundo3d/PisosTermicosBandas.jsx
@@ -1,0 +1,296 @@
+/*
+ * PisosTermicosBandas — OVERLAY r3f de los pisos térmicos sobre la Sierra.
+ *
+ * NO dibuja la montaña (esa es la `VistaGlobalSierra`, otra pieza): dibuja las
+ * BANDAS de piso térmico como un aura de contorno translúcida que envuelve la
+ * silueta por altitud. Se COMPONE con la montaña por PROPS (nunca la edita): la
+ * montaña le pasa su escala (`alturaCumbre`, `radioBase`, `radioCumbre`, `centro`)
+ * y la banda se coloca en la altura real de cada piso (metros → fracción de la
+ * cumbre, ver `pisosTermicos.js`). Con los defaults también luce sola en vitrina.
+ *
+ * QUÉ HACE, fiel al encargo (SIERRA-NEVADA-VISTA-GLOBAL):
+ *   · Cada piso es una banda RESALTABLE y NAVEGABLE (clic o botón → onSeleccionPiso).
+ *   · Resalta el piso del USUARIO ("usted está aquí"): más opaca + filo de acento
+ *     + respiración sutil (si hay movimiento permitido).
+ *   · Los pisos NO compatibles quedan VISIBLES pero ATENUADOS —"existe, explórelo,
+ *     no es de su piso"—: honestidad, jamás ocultarlos.
+ *   · Anti-fabricación: sin `pisoUsuario` NINGUNO se resalta (todos neutros).
+ *
+ * OFFLINE-FIRST: etiquetas por `<Html>` DOM (fuente de la página, sin red); geometría
+ * low-poly (cilindros abiertos), `meshBasicMaterial` translúcido sin luces ni sombras
+ * (capa de guía, no de terreno). El nº de segmentos se recorta por device-tier.
+ *
+ * ── CABLEO (lo hace la montaña; este archivo no toca App.jsx/escenas) ──────────
+ *
+ *   import PisosTermicosBandas from './visual/mundo3d/PisosTermicosBandas.jsx';
+ *   // DENTRO del <Canvas> de la Sierra, como hijo de la escena:
+ *   <PisosTermicosBandas
+ *     pisoUsuario={fincaViva.pisoTermico}   // id | metros | { altitud } | null
+ *     tier={tier}
+ *     reducedMotion={reducedMotion}
+ *     alturaCumbre={5} radioBase={4} radioCumbre={0.35} centro={[0, 0, 0]}
+ *     onSeleccionPiso={(piso) => entrarAPiso(piso)}
+ *   />
+ */
+import { useMemo, useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import * as THREE from 'three';
+import {
+  compatibilidadPiso,
+  altitudAFraccion,
+  CUMBRE_SIERRA_M,
+  ESTADO_PISO,
+} from './pisosTermicos.js';
+import { permite3D, perfilDeTier } from './deviceTier.js';
+
+const lerp = (a, b, t) => a + (b - a) * t;
+
+/* Opacidad base de la banda por estado de compatibilidad: el suyo manda, los
+   otros quedan tenues pero presentes (honestidad: se ven, se exploran). */
+const OPACIDAD = {
+  [ESTADO_PISO.SUYO]: 0.42,
+  [ESTADO_PISO.COLINDANTE]: 0.24,
+  [ESTADO_PISO.OTRO]: 0.12,
+  [ESTADO_PISO.NEUTRO]: 0.18,
+};
+
+/* La frase honesta que acompaña a cada piso según su relación con el del usuario. */
+const NOTA_ESTADO = {
+  [ESTADO_PISO.SUYO]: 'Usted está aquí',
+  [ESTADO_PISO.COLINDANTE]: 'Colinda con el suyo',
+  [ESTADO_PISO.OTRO]: 'Explórelo — no es de su piso',
+  [ESTADO_PISO.NEUTRO]: '',
+};
+
+/**
+ * Una banda de piso: cilindro abierto (aro de contorno) a la altura del rango,
+ * navegable (clic o botón). Refs SOLO se tocan dentro de `useFrame` (nunca en
+ * render). El aro de acento y la respiración solo se encienden para el piso del
+ * usuario y con movimiento permitido.
+ */
+function BandaPiso({
+  piso,
+  geo,
+  reducedMotion,
+  animar,
+  resaltado,
+  mostrarEtiqueta,
+  etiquetaDistancia,
+  onSeleccionPiso,
+}) {
+  const matRef = useRef(null);
+  const acentoRef = useRef(null);
+  const [hover, setHover] = useState(false);
+
+  const opacidadBase = OPACIDAD[piso.estado] ?? OPACIDAD[ESTADO_PISO.NEUTRO];
+  const bump = (hover ? 0.12 : 0) + (resaltado ? 0.14 : 0);
+  const opacidad = Math.min(0.9, opacidadBase + bump);
+  const respira = animar && piso.esMio && !reducedMotion;
+
+  useFrame((state) => {
+    if (!respira) return;
+    const t = state.clock.elapsedTime;
+    const onda = (Math.sin(t * 1.4) + 1) * 0.5; // 0..1 lento
+    if (matRef.current) matRef.current.opacity = opacidad + onda * 0.14;
+    if (acentoRef.current) {
+      const s = 1 + onda * 0.015;
+      acentoRef.current.scale.set(s, 1, s);
+    }
+  });
+
+  const seleccionar = (e) => {
+    if (e && typeof e.stopPropagation === 'function') e.stopPropagation();
+    onSeleccionPiso?.(piso);
+  };
+
+  return (
+    <group position={[0, geo.centerY, 0]}>
+      {/* la banda: aro de contorno translúcido, sin luz ni z-write (guía, no terreno) */}
+      <mesh
+        onPointerDown={seleccionar}
+        onPointerOver={(e) => {
+          e.stopPropagation();
+          setHover(true);
+        }}
+        onPointerOut={(e) => {
+          e.stopPropagation();
+          setHover(false);
+        }}
+      >
+        <cylinderGeometry
+          args={[geo.radioTop, geo.radioBottom, geo.altura, geo.segmentos, 1, true]}
+        />
+        <meshBasicMaterial
+          ref={matRef}
+          color={piso.color}
+          transparent
+          opacity={opacidad}
+          side={THREE.DoubleSide}
+          depthWrite={false}
+        />
+      </mesh>
+
+      {/* filo de acento en el borde alto: el "usted está aquí" del piso del usuario */}
+      {(piso.esMio || resaltado) && (
+        <mesh ref={acentoRef} position={[0, geo.altura / 2, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <torusGeometry args={[geo.radioTop, geo.radioTop * 0.02 + 0.012, 6, geo.segmentos]} />
+          <meshBasicMaterial color={piso.color} transparent opacity={0.9} depthWrite={false} />
+        </mesh>
+      )}
+
+      {/* etiqueta DOM (offline): nombre + rango + la nota honesta del estado */}
+      {mostrarEtiqueta && (
+        <Html
+          position={[geo.radioTop, 0, 0]}
+          center
+          distanceFactor={etiquetaDistancia}
+          zIndexRange={[24, 0]}
+          style={{ pointerEvents: 'none' }}
+        >
+          <button
+            type="button"
+            onClick={seleccionar}
+            onPointerEnter={() => setHover(true)}
+            onPointerLeave={() => setHover(false)}
+            data-piso={piso.id}
+            data-estado={piso.estado}
+            style={{
+              pointerEvents: 'auto',
+              cursor: 'pointer',
+              border: 'none',
+              borderRadius: 10,
+              padding: '4px 9px',
+              font: '600 12px/1.15 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+              color: piso.esMio ? '#241a10' : '#3a3226',
+              background: piso.esMio ? 'rgba(255,251,240,0.94)' : 'rgba(250,246,236,0.8)',
+              boxShadow: piso.esMio
+                ? '0 2px 8px rgba(60,44,20,0.28)'
+                : '0 1px 4px rgba(60,44,20,0.16)',
+              opacity: piso.estado === ESTADO_PISO.OTRO ? 0.82 : 1,
+              whiteSpace: 'nowrap',
+              transform: `translateX(${piso.esMio ? 6 : 2}px)`,
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                display: 'inline-block',
+                width: 8,
+                height: 8,
+                borderRadius: 3,
+                marginRight: 6,
+                verticalAlign: 'baseline',
+                background: piso.color,
+              }}
+            />
+            <span style={{ fontWeight: 700 }}>{piso.nombre}</span>
+            <span style={{ opacity: 0.66, fontWeight: 500 }}>
+              {'  '}
+              {piso.min}–{piso.max} m
+            </span>
+            {NOTA_ESTADO[piso.estado] ? (
+              <span
+                style={{
+                  display: 'block',
+                  marginTop: 1,
+                  fontSize: 10,
+                  fontWeight: piso.esMio ? 700 : 500,
+                  opacity: 0.82,
+                }}
+              >
+                {NOTA_ESTADO[piso.estado]}
+              </span>
+            ) : null}
+          </button>
+        </Html>
+      )}
+    </group>
+  );
+}
+
+/**
+ * El overlay de bandas. Se monta como hijo del `<Canvas>` de la Sierra.
+ *
+ * @param {object}   props
+ * @param {string|number|object|null} [props.pisoUsuario]  piso del predio: id
+ *        ('frio'…) | metros (1850) | { altitud|pisoTermico|… } | null → nada resaltado.
+ * @param {'alto'|'medio'|'bajo'} [props.tier='alto']  device-tier (recorta segmentos/anim).
+ * @param {boolean}  [props.reducedMotion=false]  apaga la respiración del piso del usuario.
+ * @param {(piso:object)=>void} [props.onSeleccionPiso]  se llama al tocar una banda.
+ * @param {[number,number,number]} [props.centro=[0,0,0]]  origen de la ladera en escena.
+ * @param {number}   [props.alturaCumbre=5]  Y de escena en la cumbre.
+ * @param {number}   [props.radioBase=4]  radio de escena al nivel del mar.
+ * @param {number}   [props.radioCumbre=0.35]  radio de escena en la cumbre.
+ * @param {number}   [props.holgura=1.06]  cuánto se separa la banda de la silueta (aura).
+ * @param {number}   [props.cotaMaxima=CUMBRE_SIERRA_M]  metros en la cumbre (mapeo altitud→Y).
+ * @param {boolean}  [props.mostrarEtiquetas=true]  etiquetas DOM por piso.
+ * @param {string|null} [props.pisoActivo=null]  id de piso a resaltar por control externo (legenda/hover).
+ */
+export default function PisosTermicosBandas({
+  pisoUsuario = null,
+  tier = 'alto',
+  reducedMotion = false,
+  onSeleccionPiso,
+  centro = [0, 0, 0],
+  alturaCumbre = 5,
+  radioBase = 4,
+  radioCumbre = 0.35,
+  holgura = 1.06,
+  cotaMaxima = CUMBRE_SIERRA_M,
+  mostrarEtiquetas = true,
+  pisoActivo = null,
+}) {
+  const { pisos } = useMemo(() => compatibilidadPiso(pisoUsuario), [pisoUsuario]);
+
+  const segmentos = useMemo(() => {
+    const seg = perfilDeTier(tier)?.segmentosTerreno ?? 40;
+    return Math.max(24, Math.min(48, seg));
+  }, [tier]);
+
+  // Geometría de cada banda: metros → fracción de cumbre → Y y radio de escena.
+  const bandas = useMemo(() => {
+    const radioA = (frac) => lerp(radioBase, radioCumbre, frac) * holgura;
+    const yA = (frac) => frac * alturaCumbre;
+    const alturaMinima = Math.max(0.05, alturaCumbre * 0.02);
+    return pisos.map((piso) => {
+      const fracMin = altitudAFraccion(piso.min, cotaMaxima);
+      const fracMax = altitudAFraccion(piso.max, cotaMaxima);
+      const yBottom = yA(fracMin);
+      const yTop = yA(fracMax);
+      const altura = Math.max(alturaMinima, yTop - yBottom);
+      return {
+        piso,
+        geo: {
+          centerY: (yBottom + yTop) / 2,
+          altura,
+          radioBottom: radioA(fracMin),
+          radioTop: radioA(fracMax),
+          segmentos,
+        },
+      };
+    });
+  }, [pisos, radioBase, radioCumbre, holgura, alturaCumbre, cotaMaxima, segmentos]);
+
+  const animar = permite3D(tier);
+  // La etiqueta escala con la montaña para que no se agigante en cumbres chicas.
+  const etiquetaDistancia = Math.max(4, alturaCumbre * 1.6);
+
+  return (
+    <group position={centro} name="pisos-termicos-bandas">
+      {bandas.map(({ piso, geo }) => (
+        <BandaPiso
+          key={piso.id}
+          piso={piso}
+          geo={geo}
+          reducedMotion={reducedMotion}
+          animar={animar}
+          resaltado={pisoActivo === piso.id}
+          mostrarEtiqueta={mostrarEtiquetas}
+          etiquetaDistancia={etiquetaDistancia}
+          onSeleccionPiso={onSeleccionPiso}
+        />
+      ))}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/pisosTermicos.js
+++ b/src/visual/mundo3d/pisosTermicos.js
@@ -1,0 +1,287 @@
+/*
+ * pisosTermicos — LOS PISOS TÉRMICOS de la Sierra Nevada de Santa Marta como
+ * DATO puro (cero three, cero React): el gradiente altitudinal que estructura
+ * TODA la navegación del mundo 3D. Del mar de Palomino (0 m) a la nieve del Pico
+ * Cristóbal Colón / Simón Bolívar (5 775 m, IGAC) en ~42 km — el único macizo
+ * litoral del mundo que reúne todos los pisos, continuos, desde el nivel del mar.
+ *
+ * Este módulo NO dibuja: expone (1) los rangos de altitud reales por piso, su
+ * color térmico, su vegetación y QUÉ MUNDOS/funciones de Chagra viven en cada
+ * uno; y (2) el helper `compatibilidadPiso(pisoUsuario)` que, dado el piso de la
+ * tierra del usuario, marca cada piso como SUYO / colindante / otro — todos
+ * EXPLORABLES. Lo consume el overlay `PisosTermicosBandas.jsx` (bandas r3f) y
+ * cualquier vista que necesite el catálogo por altura.
+ *
+ * HONESTIDAD DE CONTEXTO (anti-fabricación): sin un piso de usuario NO se resalta
+ * ninguno (estado 'neutro'); y los pisos que NO son el suyo quedan igual de
+ * visibles y visitables — "existe, explórelo, no es de su piso" —, nunca ocultos
+ * ni fingidos como aplicables a su predio.
+ *
+ * RESPETO: la Sierra es territorio sagrado y habitado. Se acredita a los cuatro
+ * pueblos y a la Línea Negra (ver `ATRIBUCION_SIERRA`); aquí solo van hechos
+ * geográficos y ecológicos, sin iconografía ceremonial.
+ *
+ * Fuentes: DR sierra-geo-render (gemini, 2026-06-19) + catálogo thermal_zones +
+ * clasificación altitudinal de Caldas. Cotas de picos: IGAC.
+ */
+
+/** Cota de la cumbre de la Sierra (Pico Cristóbal Colón / Simón Bolívar), IGAC. */
+export const CUMBRE_SIERRA_M = 5775;
+
+/**
+ * Hitos de referencia para anclar la silueta (los consume la montaña; este
+ * módulo no los dibuja). Del mar a la cumbre.
+ */
+export const HITOS_SIERRA = [
+  { id: 'palomino', nombre: 'Palomino', m: 0, nota: 'el mar Caribe al pie de la Sierra' },
+  { id: 'simmonds', nombre: 'Pico Simmonds', m: 5560 },
+  { id: 'colon', nombre: 'Pico Cristóbal Colón', m: 5775 },
+  { id: 'bolivar', nombre: 'Pico Simón Bolívar', m: 5775 },
+];
+
+/**
+ * Crédito del territorio. Cadena lista para mostrar junto a la montaña; la
+ * decisión de uso público de identidad cultural es de producto (consulta
+ * comunitaria), no de render.
+ */
+export const ATRIBUCION_SIERRA =
+  'Territorio ancestral kogui, arhuaco (iku), wiwa y kankuamo — corazón de la Línea Negra.';
+
+/**
+ * Los pisos térmicos de la Sierra, de abajo (mar) a arriba (nieve). Cada uno:
+ *   · min / max  — rango de altitud REAL en metros (DR sierra-geo-render).
+ *   · color      — térmico: dorado abajo → azul-plata/blanco arriba.
+ *   · vegetacion — el paisaje del piso (sin cultígenos de adorno).
+ *   · mundos     — las funciones de Chagra que VIVEN por ecología en ese piso
+ *                  (`view` = destino real de navegación). `transversal: true`
+ *                  marca las que existen en varios pisos y solo se anclan aquí
+ *                  como puerta.
+ *   · cultivable — si el piso admite cultivo (páramo arriba: se cuida, no se ara).
+ *
+ * El orden es de menor a mayor altitud (índice = altura relativa).
+ */
+export const PISOS_TERMICOS = [
+  {
+    id: 'calido',
+    nombre: 'Cálido',
+    min: 0,
+    max: 1000,
+    color: '#cba04a',
+    vegetacion: 'Bosque seco tropical y manglar; palma, banano, cacao, cítricos, mango.',
+    cultivable: true,
+    mundos: [
+      { id: 'milpa', nombre: 'La milpa: maíz, fríjol y calabaza', view: 'milpa_cultivo' },
+      { id: 'frutales', nombre: 'Frutales de tierra caliente', view: 'frutales' },
+      { id: 'animales', nombre: 'El corral y sus animales', view: 'animales' },
+      { id: 'mercado', nombre: 'El mercado y la despensa', view: 'mercado', transversal: true },
+    ],
+  },
+  {
+    id: 'templado',
+    nombre: 'Templado',
+    min: 1000,
+    max: 2000,
+    color: '#6f9e4a',
+    vegetacion: 'Bosque húmedo tropical; café bajo sombra, frutales, caña, pastos.',
+    cultivable: true,
+    mundos: [
+      { id: 'cafe', nombre: 'El café bajo sombra', view: 'cafe' },
+      { id: 'disenio', nombre: 'El bosque de alimentos', view: 'restauracion' },
+      { id: 'semillero', nombre: 'El semillero y el vivero', view: 'germinacion' },
+      { id: 'frutales', nombre: 'Frutales de clima medio', view: 'frutales' },
+    ],
+  },
+  {
+    id: 'frio',
+    nombre: 'Frío',
+    min: 2000,
+    max: 3000,
+    color: '#4f8f7d',
+    vegetacion: 'Bosque andino y de niebla; papa, hortalizas, mora, tomate de árbol.',
+    cultivable: true,
+    mundos: [
+      { id: 'tuberculos', nombre: 'La papa y los tubérculos', view: 'tuberculos' },
+      { id: 'hortalizas', nombre: 'La huerta de hortalizas', view: 'hortalizas' },
+      { id: 'suelo', nombre: 'El suelo vivo', view: 'salud_suelo', transversal: true },
+      { id: 'agua', nombre: 'La quebrada y el riego', view: 'agua' },
+    ],
+  },
+  {
+    id: 'paramo',
+    nombre: 'Páramo',
+    min: 3000,
+    max: 4000,
+    color: '#9fb6bf',
+    vegetacion: 'Frailejones (Espeletia), pajonales y arbustos bajos; la fábrica de agua.',
+    cultivable: false,
+    mundos: [
+      { id: 'agua', nombre: 'Donde nace el agua', view: 'agua' },
+      { id: 'restauracion', nombre: 'El páramo se cuida', view: 'restauracion' },
+      { id: 'biodiversidad', nombre: 'El frailejón y la niebla', view: 'biodiversidad' },
+    ],
+  },
+  {
+    id: 'superparamo',
+    nombre: 'Superpáramo',
+    min: 4000,
+    max: 4800,
+    color: '#b9c6cc',
+    vegetacion: 'Líquenes, musgos y cojines rasantes; vida al límite del frío.',
+    cultivable: false,
+    mundos: [
+      { id: 'conservacion', nombre: 'Vida al límite del frío', view: 'biodiversidad' },
+    ],
+  },
+  {
+    id: 'nival',
+    nombre: 'Nival',
+    min: 4800,
+    max: CUMBRE_SIERRA_M,
+    color: '#eef2f4',
+    vegetacion: 'Sin vegetación: glaciar y nieve perpetua, hoy en retroceso.',
+    cultivable: false,
+    mundos: [
+      { id: 'glaciar', nombre: 'La nieve y su retroceso', view: 'hoy_finca' },
+    ],
+  },
+];
+
+/** Estados de compatibilidad de un piso respecto al del usuario. */
+export const ESTADO_PISO = {
+  SUYO: 'suyo', // es el piso de su predio
+  COLINDANTE: 'colindante', // el vecino inmediato (su tierra puede alcanzarlo)
+  OTRO: 'otro', // otro piso: visible y explorable, no aplica a su predio
+  NEUTRO: 'neutro', // sin piso de usuario: nada resaltado
+};
+
+/** Piso por id (o `null`). */
+export function pisoPorId(id) {
+  if (!id) return null;
+  return PISOS_TERMICOS.find((p) => p.id === id) || null;
+}
+
+/**
+ * El piso cuyo rango contiene esa altitud (metros). Por debajo de 0 → cálido;
+ * por encima de la cumbre → nival. Cada rango es [min, max) salvo el último,
+ * que cierra en la cumbre.
+ */
+export function pisoPorAltitud(metros) {
+  if (typeof metros !== 'number' || Number.isNaN(metros)) return null;
+  if (metros < 0) return PISOS_TERMICOS[0];
+  const ultimo = PISOS_TERMICOS[PISOS_TERMICOS.length - 1];
+  if (metros >= ultimo.max) return ultimo;
+  return PISOS_TERMICOS.find((p) => metros >= p.min && metros < p.max) || ultimo;
+}
+
+/**
+ * Normaliza el piso del usuario a un id de piso (o `null` si no se sabe — que es
+ * la señal de "no resaltar nada"). Acepta, con tolerancia:
+ *   · un id de piso            → 'calido' | 'templado' | 'frio' | 'paramo' | …
+ *   · un nombre                → 'Páramo', 'frio'
+ *   · una altitud en metros    → 1850  (número o string numérica)
+ *   · un objeto de finca viva  → { pisoTermico | piso | zona | id }  ó
+ *                                { altitud | altitudM | metros | msnm | elevacion }
+ * NO inventa: si nada calza, devuelve `null`.
+ */
+export function normalizarPisoUsuario(pisoUsuario) {
+  if (pisoUsuario == null) return null;
+
+  if (typeof pisoUsuario === 'number') {
+    return pisoPorAltitud(pisoUsuario)?.id ?? null;
+  }
+
+  if (typeof pisoUsuario === 'string') {
+    const s = pisoUsuario.trim().toLowerCase();
+    if (!s) return null;
+    const porId = PISOS_TERMICOS.find((p) => p.id === s);
+    if (porId) return porId.id;
+    const porNombre = PISOS_TERMICOS.find((p) => p.nombre.toLowerCase() === s);
+    if (porNombre) return porNombre.id;
+    const num = Number(s);
+    if (!Number.isNaN(num) && s !== '') return pisoPorAltitud(num)?.id ?? null;
+    return null;
+  }
+
+  if (typeof pisoUsuario === 'object') {
+    const idCampo =
+      pisoUsuario.pisoTermico ?? pisoUsuario.piso ?? pisoUsuario.zona ?? pisoUsuario.id;
+    if (typeof idCampo === 'string') {
+      const anidado = normalizarPisoUsuario(idCampo);
+      if (anidado) return anidado;
+    }
+    const metros =
+      pisoUsuario.altitud ??
+      pisoUsuario.altitudM ??
+      pisoUsuario.metros ??
+      pisoUsuario.msnm ??
+      pisoUsuario.elevacion;
+    if (typeof metros === 'number') return pisoPorAltitud(metros)?.id ?? null;
+    if (typeof metros === 'string' && metros.trim() !== '') {
+      const num = Number(metros);
+      if (!Number.isNaN(num)) return pisoPorAltitud(num)?.id ?? null;
+    }
+  }
+
+  return null;
+}
+
+/** Fracción 0..1 de una altitud respecto a la cumbre (para mapear a la ladera). */
+export function altitudAFraccion(metros, cumbre = CUMBRE_SIERRA_M) {
+  const c = cumbre > 0 ? cumbre : CUMBRE_SIERRA_M;
+  return Math.max(0, Math.min(1, metros / c));
+}
+
+/**
+ * Anota TODOS los pisos según el del usuario. Devuelve un objeto estable:
+ *   { pisoUsuarioId, hayPisoUsuario, pisos: [ { ...piso, esMio, estado,
+ *     compatible, colindante, explorable, distancia } ] }
+ *
+ * · esMio       — es el piso de su predio.
+ * · compatible  — sus funciones aplican DIRECTO a su predio (solo el suyo:
+ *                 honestidad estricta).
+ * · colindante  — vecino inmediato (su tierra puede alcanzarlo).
+ * · explorable  — SIEMPRE true: cualquier piso se puede visitar/aprender.
+ * · distancia   — |índice - índice del usuario| (o null si no hay usuario).
+ *
+ * Sin piso de usuario válido → todo 'neutro', nada resaltado (anti-fabricación).
+ */
+export function compatibilidadPiso(pisoUsuario) {
+  const pisoUsuarioId = normalizarPisoUsuario(pisoUsuario);
+  const idxUsuario = pisoUsuarioId
+    ? PISOS_TERMICOS.findIndex((p) => p.id === pisoUsuarioId)
+    : -1;
+  const hayPisoUsuario = idxUsuario >= 0;
+
+  const pisos = PISOS_TERMICOS.map((piso, i) => {
+    if (!hayPisoUsuario) {
+      return {
+        ...piso,
+        esMio: false,
+        estado: ESTADO_PISO.NEUTRO,
+        compatible: false,
+        colindante: false,
+        explorable: true,
+        distancia: null,
+      };
+    }
+    const distancia = Math.abs(i - idxUsuario);
+    const esMio = distancia === 0;
+    const colindante = distancia === 1;
+    const estado = esMio
+      ? ESTADO_PISO.SUYO
+      : colindante
+        ? ESTADO_PISO.COLINDANTE
+        : ESTADO_PISO.OTRO;
+    return {
+      ...piso,
+      esMio,
+      estado,
+      compatible: esMio,
+      colindante,
+      explorable: true,
+      distancia,
+    };
+  });
+
+  return { pisoUsuarioId, hayPisoUsuario, pisos };
+}


### PR DESCRIPTION
## Qué

Dos piezas **nuevas** (cero edición de archivos existentes) que se **componen por props** con la montaña maestra `VistaGlobalSierra` (la construye otra pieza en paralelo):

### `src/visual/mundo3d/pisosTermicos.js` — datos puros (sin three)
- Los **seis pisos térmicos** de la Sierra Nevada con **rangos de altitud reales** (DR `sierra-geo-render`): Cálido 0–1000, Templado 1000–2000, Frío 2000–3000, Páramo 3000–4000, Superpáramo 4000–4800, Nival 4800–5775 m.
- Cota de cumbre **5775 m** (Pico Cristóbal Colón / Simón Bolívar, IGAC); hitos `Palomino` (0 m) y `Pico Simmonds` (5560 m) como referencia para la silueta.
- Por piso: color térmico, vegetación y **qué mundos de Chagra viven por ecología** en él (`view` real de navegación; transversales marcadas).
- `compatibilidadPiso(pisoUsuario)`: marca cada piso como **suyo / colindante / otro**, todos `explorable`. Normalización tolerante del piso del usuario (id | metros | objeto de finca viva). **Sin piso de usuario válido → todo neutro, nada resaltado** (anti-fabricación).
- `ATRIBUCION_SIERRA`: crédito a los cuatro pueblos (kogui, arhuaco/iku, wiwa, kankuamo) y la Línea Negra.

### `src/visual/mundo3d/PisosTermicosBandas.jsx` — overlay r3f
- Bandas de contorno translúcidas por altitud, montables **dentro del `<Canvas>`** de la Sierra.
- **Navegables**: clic sobre la banda o botón accesible → `onSeleccionPiso(piso)`.
- Resalta el **piso del usuario** ("Usted está aquí") con filo de acento + respiración sutil; los **no compatibles quedan visibles pero atenuados** ("Explórelo — no es de su piso"): honestidad, sin ocultar.
- Etiquetas `Html` DOM (offline, fuente de la página, sin red). Segmentos y animación recortados por **device-tier** y **reduced-motion**.
- Props: `pisoUsuario`, `tier`, `reducedMotion`, `onSeleccionPiso` + contrato espacial (`centro`, `alturaCumbre`, `radioBase`, `radioCumbre`, `cotaMaxima`, `holgura`, `mostrarEtiquetas`, `pisoActivo`).

## Verificación
- `npx eslint … --max-warnings 0` → **0 errores / 0 warnings** (sin eslint-disable).
- `npm run build` → **exit 0** (3m 4s; warnings de chunks preexistentes, ajenos).
- Script de lógica (Node): **40/40** — fronteras de altitud, normalización multi-shape, compatibilidad estricta (solo 1 compatible), anti-fabricación (sin usuario → todo neutro pero explorable).

## Notas
- Regla dura respetada: **solo archivos nuevos**; el cableo lo hará la montaña (documentado en el header de cada archivo).
- Base `dev`. Rama reseteada a `origin/dev` antes del commit (mi base venía de un promote en main) para un diff limpio de solo estas 2 piezas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)