### PR TITLE
feat(visual): prepara mundos por piso termico

### DIFF
--- a/Chagra-strategy/ops/SIERRA-NAV3-WORLDS-POR-PISO-TERMICO.md
+++ b/Chagra-strategy/ops/SIERRA-NAV3-WORLDS-POR-PISO-TERMICO.md
@@ -1,0 +1,45 @@
+# Sierra nav3: mundos por piso termico
+
+## Alcance
+
+Esta preparacion conecta el registro de mundos con el modelo puro de pisos termicos. No agrega geometria, escenas, iconos, materiales ni cambios de arte. La proyeccion se calcula en memoria y no se persiste en Asset, Log ni IndexedDB.
+
+## Modelo de datos
+
+Cada entrada de `MUNDO` declara `pisoTermico`, el piso que sirve como anclaje de su puerta en la Sierra. El valor debe ser uno de los ids de `PISOS_TERMICOS`: `calido`, `templado`, `frio`, `paramo`, `superparamo` o `nival`.
+
+`mundosPorPisoTermico(pisoUsuario)` combina tres fuentes:
+
+1. `mundoData.js`: identidad, escena, rutas y piso de anclaje.
+2. `pisosTermicos.js`: rangos altitudinales y `compatibilidadPiso`.
+3. El piso de la finca aportado por `useFincaViva`: primero `profile.piso_termico`, luego `profile.finca_altitud` o el alias historico `profile.altitud`.
+
+La salida conserva dos lecturas del mismo catalogo:
+
+- `mundos`: lista plana para busqueda y navegacion.
+- `pisos`: pisos de menor a mayor altitud, cada uno con su arreglo `mundos`.
+
+Cada mundo derivado incluye `altitudM`, `altitudFraccion`, `compatible`, `estadoCompatibilidad` y `explorable`. `altitudM` es el punto medio del rango y solo funciona como coordenada logica. La escena puede resolver una coordenada de terreno distinta sin cambiar el dato fuente.
+
+## Semantica de compatibilidad
+
+`compatible` es verdadero solo cuando el piso de anclaje coincide con el piso confirmado de la finca. Un piso vecino queda como `colindante`. Todos los mundos mantienen `explorable: true`; la compatibilidad orienta el contexto y nunca bloquea `viajarAlMundo`.
+
+Si el perfil no aporta piso ni altitud valida, `pisoUsuarioId` queda en `null`, todos los estados quedan `neutro` y no se resalta nada.
+
+## Puntos de integracion para VistaGlobalSierra
+
+1. El host llama `useFincaViva()` y pasa `estadoFinca.pisoTermico` tanto a `VistaGlobalSierra` como a `useNavegacionMundos({ pisoUsuario })`.
+2. El host itera `nav.catalogoPisos.pisos` y sus `mundos`. No debe volver a unir `MUNDO` con `PISOS_TERMICOS` dentro de la escena.
+3. Para colocar una puerta por altitud, el host usa `mundo.altitudFraccion` como entrada al resolver de ladera. La posicion X/Z, separacion entre puertas y ajuste a la superficie pertenecen a una tarea visual posterior.
+4. Al activar una puerta, el host llama `nav.viajarAlMundo(mundo.id)`. El estado de compatibilidad solo modifica copy o enfasis futuro, no la posibilidad de entrar.
+5. `VistaGlobalSierra` ya acepta `pisoUsuario`; debe conservar el estado neutro cuando el dato no exista.
+
+## Decisiones diferidas
+
+- Distribucion horizontal y prevencion de solapamientos entre puertas del mismo piso.
+- Componentes r3f o DOM para puertas, rotulos y estados de compatibilidad.
+- Copy visible para mundo propio, colindante u otro.
+- Reubicacion de anclajes cuando investigacion agronomica indique que un mundo requiere otro piso principal.
+
+Estas decisiones incluyen arte o interaccion y quedan fuera de esta preparacion.

--- a/src/visual/mundo3d/__tests__/mundosPorPisoTermico.test.js
+++ b/src/visual/mundo3d/__tests__/mundosPorPisoTermico.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+import { MUNDO, MUNDO_IDS } from '../mundoData.js';
+import { mundosPorPisoTermico } from '../mundosPorPisoTermico.js';
+import { pisoTermicoDePerfil } from '../useFincaViva.js';
+
+describe('mundosPorPisoTermico', () => {
+  test('anota todos los mundos y los ordena por pisos de menor a mayor altitud', () => {
+    const catalogo = mundosPorPisoTermico(null);
+
+    expect(catalogo.mundos.map((mundo) => mundo.id).sort()).toEqual([...MUNDO_IDS].sort());
+    expect(catalogo.pisos.map((piso) => piso.id)).toEqual([
+      'calido', 'templado', 'frio', 'paramo', 'superparamo', 'nival',
+    ]);
+    expect(catalogo.mundos.every((mundo) => mundo.explorable)).toBe(true);
+    expect(catalogo.mundos.every((mundo) => mundo.estadoCompatibilidad === 'neutro')).toBe(true);
+    expect(catalogo.mundos.every((mundo) => mundo.altitudFraccion >= 0 && mundo.altitudFraccion <= 1)).toBe(true);
+  });
+
+  test('marca compatible solo el piso de la finca sin ocultar los demas mundos', () => {
+    const catalogo = mundosPorPisoTermico('frío');
+    const mundoPisos = catalogo.mundos.find((mundo) => mundo.id === 'pisos');
+    const mundoCafe = catalogo.mundos.find((mundo) => mundo.id === 'cafe');
+
+    expect(catalogo.pisoUsuarioId).toBe('frio');
+    expect(mundoPisos).toMatchObject({ compatible: true, estadoCompatibilidad: 'suyo' });
+    expect(mundoCafe).toMatchObject({ compatible: false, estadoCompatibilidad: 'colindante', explorable: true });
+  });
+
+  test('cada entrada del registro declara un piso termico valido', () => {
+    const idsValidos = new Set(mundosPorPisoTermico(null).pisos.map((piso) => piso.id));
+    expect(Object.entries(MUNDO).filter(([, mundo]) => !idsValidos.has(mundo.pisoTermico))).toEqual([]);
+  });
+});
+
+describe('pisoTermicoDePerfil', () => {
+  test('prioriza el piso declarado y cae a la altitud real', () => {
+    expect(pisoTermicoDePerfil({ piso_termico: 'páramo', finca_altitud: 1500 })).toBe('paramo');
+    expect(pisoTermicoDePerfil({ finca_altitud: 2450 })).toBe('frio');
+    expect(pisoTermicoDePerfil({})).toBeNull();
+  });
+});

--- a/src/visual/mundo3d/__tests__/navegacion.test.jsx
+++ b/src/visual/mundo3d/__tests__/navegacion.test.jsx
@@ -22,13 +22,14 @@ afterEach(() => {
 });
 
 /* Sonda mínima: expone la máquina del hook como DOM para poder conducirla. */
-function Sonda({ reducedMotion = false }) {
-  const nav = useNavegacionMundos({ reducedMotion });
+function Sonda({ reducedMotion = false, pisoUsuario = null }) {
+  const nav = useNavegacionMundos({ reducedMotion, pisoUsuario });
   return (
     <div>
       <output data-testid="fase">{nav.fase}</output>
       <output data-testid="mundo">{nav.mundoId || '-'}</output>
       <output data-testid="pronto">{nav.pronto || '-'}</output>
+      <output data-testid="piso">{nav.catalogoPisos.pisoUsuarioId || '-'}</output>
       <button type="button" onClick={() => nav.viajarAlMundo('agua')}>ir-agua</button>
       <button type="button" onClick={() => nav.viajarAlMundo('clima')}>ir-clima</button>
       <button type="button" onClick={() => nav.viajarAlMundo('__fantasma__')}>ir-fantasma</button>
@@ -88,6 +89,11 @@ describe('useNavegacionMundos — la máquina valle ↔ mundo', () => {
     render(<Sonda />);
     fireEvent.click(screen.getByText('volver'));
     expect(fase()).toBe('valle');
+  });
+
+  test('expone el catalogo termico para el host de la Sierra', () => {
+    render(<Sonda pisoUsuario="templado" />);
+    expect(screen.getByTestId('piso')).toHaveTextContent('templado');
   });
 });
 

--- a/src/visual/mundo3d/index.js
+++ b/src/visual/mundo3d/index.js
@@ -23,6 +23,7 @@ export { default as Mundo2D } from './Mundo2D.jsx';
 
 // Datos + arquetipos + resolución (three-free, seguros en el bundle base).
 export { MUNDO, MUNDO_IDS } from './mundoData.js';
+export { mundosPorPisoTermico } from './mundosPorPisoTermico.js';
 export {
   ARQUETIPOS, ARQUETIPOS_KEYS, ARQUETIPOS_3D, ARQUETIPOS_2D, esArquetipo3D,
 } from './arquetipos.js';

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -14,6 +14,7 @@
  *     valle,      // (opcional) landmark en el mapa del valle: { tipo, pos, escala }
  *     gate,       // (opcional) perfil requerido (p.ej. 'animales')
  *     ambiental,  // (opcional) el clima ya vive en el ambiente del valle
+ *     pisoTermico,// piso de anclaje en la Sierra (la compatibilidad se deriva)
  *   }
  *
  * Sumar un mundo = UNA de estas entradas + assets de la librería (lámina/creature/
@@ -58,6 +59,7 @@ export const MUNDO = {
   // 🌱 EL SUELO VIVO — el PROTOTIPO del DR (cutaway). Reusa mundoSubsueloEngine
   //    para la densidad de vida (`params.vida` 0..1; aquí, valor de muestra).
   suelo: {
+    pisoTermico: 'templado',
     escena: 'cutaway',
     valle: { tipo: 'era', pos: [-1.1, 0, 3.6], escala: 1 },
     params: {
@@ -84,6 +86,7 @@ export const MUNDO = {
   //    Todo es DATOS: la curva de la quebrada + los hitos del recorrido los
   //    leen por igual el diorama 3D (EscenaFlujo) y su gemelo 2D (FondoFlujo).
   agua: {
+    pisoTermico: 'paramo',
     escena: 'flujo',
     valle: { tipo: 'quebrada', pos: [0.6, 0, -1.4], escala: 1 },
     params: {
@@ -125,6 +128,7 @@ export const MUNDO = {
   //    real de farmOS aquí mismo (misma forma; `pos` es opcional — sin él, los
   //    sitios salen solos). MUESTRA compartida con el mercado (mismo dato):
   animales: {
+    pisoTermico: 'calido',
     escena: 'recinto',
     valle: { tipo: 'corral', pos: [-4.6, 0, -1.8], escala: 1 },
     gate: 'animales',
@@ -141,6 +145,7 @@ export const MUNDO = {
 
   // 🌳 DISEÑO DE LA FINCA — la verticalidad del bosque comestible (estratos).
   disenio: {
+    pisoTermico: 'templado',
     escena: 'estratos',
     valle: { tipo: 'bosque', pos: [4.8, 0, -2.6], escala: 1.1 },
     params: {},
@@ -155,6 +160,7 @@ export const MUNDO = {
   // 🗺️ EL VALLE — el mapa navegable (valle). Es "un mundo más" del registro: su
   //    escena ES el mapa entero; sus hotspots son los demás mundos.
   valle: {
+    pisoTermico: 'calido',
     escena: 'valle',
     params: { clima: 'soleado' },
     entrada: { narra: 'bienvenida', clima: 'soleado', alertaView: 'hoy_finca' },
@@ -165,6 +171,7 @@ export const MUNDO = {
   // 🐄 ESTIÉRCOL Y COMPOST — REUSA `cutaway` para el corte de la pila (capas
   //    café/verde, calor). Prueba viva de "sumar un SÍ-3D = datos, sin código".
   abono: {
+    pisoTermico: 'templado',
     escena: 'cutaway',
     valle: { tipo: 'huerta', pos: [1.8, 0, 4.4], escala: 0.95 },
     params: {
@@ -186,6 +193,7 @@ export const MUNDO = {
 
   // 🌾 CULTIVOS — arquetipo `lamina`: reusa la lámina de maíz de la librería.
   cultivos: {
+    pisoTermico: 'calido',
     escena: 'lamina',
     valle: { tipo: 'milpa', pos: [-3.2, 0, 1.6], escala: 1.15 },
     params: { lamina: 'maiz' },
@@ -208,6 +216,7 @@ export const MUNDO = {
   //    Cada punto es una puerta a una pantalla REAL. En equipo humilde cae a su
   //    ficha 2D digna (la infografía del café).
   cafe: {
+    pisoTermico: 'templado',
     escena: 'cafe',
     valle: { tipo: 'cafetal', pos: [3.4, 0, 2.2], escala: 1 },
     params: {
@@ -257,6 +266,7 @@ export const MUNDO = {
 
   // 🍊 FRUTALES — arquetipo `ficha`: tarjeta de especie foto-secuencial.
   frutales: {
+    pisoTermico: 'calido',
     escena: 'ficha',
     params: {
       nombre: 'Frutales de la finca',
@@ -283,6 +293,7 @@ export const MUNDO = {
   //    intermediario). Cada punto es una puerta a una pantalla REAL. En equipo
   //    humilde cae a su ficha 2D digna (la infografía del mercado y la despensa).
   mercado: {
+    pisoTermico: 'calido',
     escena: 'mercado',
     valle: { tipo: 'mercado', pos: [1.2, 0, 6.6], escala: 1 },
     params: {
@@ -334,6 +345,7 @@ export const MUNDO = {
   //    (mariquita, carábido). Cada punto es una puerta a una pantalla REAL. En
   //    equipo humilde cae a su ficha 2D digna (la infografía de la sanidad).
   sanidad: {
+    pisoTermico: 'templado',
     escena: 'sanidad',
     valle: { tipo: 'huerta', pos: [3.8, 0, 4.9], escala: 0.95 },
     params: {
@@ -388,6 +400,7 @@ export const MUNDO = {
   //    hacia 2040–2050). NOTA DE CONCIENCIA, esperanza no colapso: el páramo es la
   //    fábrica de agua. En equipo humilde cae al gemelo 2D (mirror → cielo).
   clima: {
+    pisoTermico: 'paramo',
     escena: 'boveda',
     valle: { tipo: 'veleta', pos: [-3.8, 0, -4.8], escala: 1 },
     ambiental: true,
@@ -430,6 +443,7 @@ export const MUNDO = {
   //    arquetipo `cutaway` (mismas capas + vida) y enciende el módulo `milpa`.
   //    Policultivo, no monocultivo: juntas rinden más y se cuidan (push-pull).
   milpa: {
+    pisoTermico: 'calido',
     escena: 'cutaway',
     params: {
       vida: 0.5,
@@ -464,6 +478,7 @@ export const MUNDO = {
   //    gradiente ALTITUDINAL, que vive en `params.pisos` (de bajo a alto) y lo
   //    leen por igual el diorama 3D y su gemelo 2D. Vitrina: #/mockups/mundo3d-bosque.
   pisos: {
+    pisoTermico: 'frio',
     escena: 'estratos',
     params: {
       // Pisos de bajo (cálido) a alto (páramo). Verificado (catálogo thermal_zones
@@ -498,6 +513,7 @@ export const MUNDO = {
   //    ficha 2D digna (la infografía del semillero).
   //    (anti-conflicto de merge: entrada de mundo nueva SIEMPRE al final.)
   semillero: {
+    pisoTermico: 'templado',
     escena: 'semillero',
     valle: { tipo: 'semillero', pos: [-2.6, 0, 6.2], escala: 1 },
     params: {

--- a/src/visual/mundo3d/mundosPorPisoTermico.js
+++ b/src/visual/mundo3d/mundosPorPisoTermico.js
@@ -1,0 +1,52 @@
+/*
+ * Proyeccion pura del registro MUNDO sobre los pisos termicos de la Sierra.
+ * No persiste estado ni contiene decisiones visuales: entrega al host los
+ * mundos agrupados de menor a mayor altitud y su compatibilidad con la finca.
+ */
+import { MUNDO } from './mundoData.js';
+import { altitudAFraccion, compatibilidadPiso } from './pisosTermicos.js';
+
+/**
+ * @param {unknown} pisoUsuario id, nombre, altitud u objeto aceptado por compatibilidadPiso
+ * @returns {{pisoUsuarioId:string|null, hayPisoUsuario:boolean, pisos:Array<object>, mundos:Array<object>}}
+ */
+export function mundosPorPisoTermico(pisoUsuario) {
+  const compatibilidad = compatibilidadPiso(pisoUsuario);
+  const pisosPorId = new Map(compatibilidad.pisos.map((piso) => [piso.id, piso]));
+  const mundos = Object.entries(MUNDO).map(([id, mundo]) => {
+    const piso = pisosPorId.get(mundo.pisoTermico);
+    if (!piso) {
+      throw new Error(`El mundo "${id}" no tiene un piso termico valido`);
+    }
+    const altitudM = (piso.min + piso.max) / 2;
+    return {
+      id,
+      mundo,
+      pisoTermico: piso.id,
+      altitudM,
+      altitudFraccion: altitudAFraccion(altitudM),
+      compatible: piso.compatible,
+      estadoCompatibilidad: piso.estado,
+      explorable: piso.explorable,
+    };
+  });
+
+  const mundosPorPiso = new Map();
+  mundos.forEach((mundo) => {
+    const grupo = mundosPorPiso.get(mundo.pisoTermico) || [];
+    grupo.push(mundo);
+    mundosPorPiso.set(mundo.pisoTermico, grupo);
+  });
+
+  return {
+    pisoUsuarioId: compatibilidad.pisoUsuarioId,
+    hayPisoUsuario: compatibilidad.hayPisoUsuario,
+    pisos: compatibilidad.pisos.map((piso) => ({
+      ...piso,
+      mundos: mundosPorPiso.get(piso.id) || [],
+    })),
+    mundos,
+  };
+}
+
+export default mundosPorPisoTermico;

--- a/src/visual/mundo3d/useFincaViva.js
+++ b/src/visual/mundo3d/useFincaViva.js
@@ -45,6 +45,8 @@ import {
   resolveClimaLocation,
   CLIMA_UPDATED_EVENT,
 } from '../../services/climaService.js';
+import { getProfile } from '../../services/userProfileService.js';
+import { normalizarPisoUsuario } from './pisosTermicos.js';
 
 /** Re-evalúa la atmósfera cada 10 min (mismo ritmo que useClimaAtmosphere). */
 const REEVAL_MS = 10 * 60 * 1000;
@@ -152,11 +154,18 @@ export function cosechaRecienteDe(summary, now = new Date()) {
   return { cultivo: reciente.crop, mundoId: null };
 }
 
+/** Piso confirmado del perfil, o derivado de la altitud real de la finca. */
+export function pisoTermicoDePerfil(profile) {
+  const declarado = normalizarPisoUsuario(profile?.piso_termico);
+  if (declarado) return declarado;
+  return normalizarPisoUsuario(profile?.finca_altitud ?? profile?.altitud);
+}
+
 /**
  * Arma el `estadoFinca` completo desde las piezas ya cargadas. Puro: la vista
  * (useFincaViva) inyecta procesos/plantas/cosecha/atmósfera ya resueltos.
  */
-function armarEstadoFinca({ processes, plants, summary, atmosfera, now = new Date() }) {
+function armarEstadoFinca({ processes, plants, summary, atmosfera, pisoTermico, now = new Date() }) {
   const { clima, enso, agua } = atmosfera;
 
   // saludFinca: conteos REALES de matas (buildFincaScene, la misma fuente que el
@@ -177,6 +186,7 @@ function armarEstadoFinca({ processes, plants, summary, atmosfera, now = new Dat
   return {
     clima,
     enso,
+    pisoTermico,
     cosechaReciente: cosechaRecienteDe(summary, now),
     saludFinca,
     // Sin inventario de hato real (no hay asset animal): [] = "dato en camino".
@@ -204,6 +214,9 @@ export function useFincaViva() {
   const plants = useAssetStore((s) => s.plants);
   const summary = useCosechaStore((s) => s.summary);
   const cosechaCargando = useCosechaStore((s) => s.isLoading);
+  let profile = null;
+  try { profile = getProfile(); } catch (_) { profile = null; }
+  const pisoTermico = pisoTermicoDePerfil(profile);
 
   // Cargar los procesos una vez (y limpiar si el hook se desmonta antes).
   useEffect(() => {
@@ -239,8 +252,8 @@ export function useFincaViva() {
   // Identidad estable mientras las piezas no cambian: reaccionFinca (memoizado
   // en la escena por identidad de estadoFinca) no recalcula por render.
   return useMemo(
-    () => armarEstadoFinca({ processes, plants, summary, atmosfera }),
-    [processes, plants, summary, atmosfera],
+    () => armarEstadoFinca({ processes, plants, summary, atmosfera, pisoTermico }),
+    [processes, plants, summary, atmosfera, pisoTermico],
   );
 }
 

--- a/src/visual/mundo3d/useNavegacionMundos.js
+++ b/src/visual/mundo3d/useNavegacionMundos.js
@@ -21,9 +21,10 @@
  *
  * Sin three, sin DOM: puro estado. Seguro en el bundle base.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { resolverMundo } from './resolverMundo.js';
 import useHaptics from './useHaptics.js';
+import { mundosPorPisoTermico } from './mundosPorPisoTermico.js';
 
 /** ¿Este mundo tiene una escena montable (3D o 2D) en el registro? */
 export function puedeEntrarAlMundo(mundoId) {
@@ -34,6 +35,7 @@ export function puedeEntrarAlMundo(mundoId) {
 /**
  * @param {object} [opts]
  * @param {boolean} [opts.reducedMotion=false]  corte simple: sin fases de viaje.
+ * @param {unknown} [opts.pisoUsuario=null] piso o altitud real de la finca.
  * @returns {{
  *   fase: 'valle'|'viajando'|'mundo'|'regresando',
  *   mundoId: string|null,
@@ -45,7 +47,7 @@ export function puedeEntrarAlMundo(mundoId) {
  *   puedeEntrar: (id: string) => boolean,
  * }}
  */
-export function useNavegacionMundos({ reducedMotion = false } = {}) {
+export function useNavegacionMundos({ reducedMotion = false, pisoUsuario = null } = {}) {
   const [estado, setEstado] = useState({ fase: 'valle', mundoId: null });
   // El mundo que aún no abre su puerta (para el aviso "pronto" del host).
   const [pronto, setPronto] = useState(null);
@@ -55,10 +57,13 @@ export function useNavegacionMundos({ reducedMotion = false } = {}) {
   // el reducedMotion del host manda para que el gate sea coherente con
   // el resto del árbol de mundos.
   const haptics = useHaptics({ reducedMotion });
+  const catalogoPisos = useMemo(() => mundosPorPisoTermico(pisoUsuario), [pisoUsuario]);
   // Espejo de la fase actual para disparar hápticas FUERA del updater de
   // estado (los updaters deben ser puros — StrictMode los corre dos veces).
   const faseRef = useRef(estado.fase);
-  faseRef.current = estado.fase;
+  useEffect(() => {
+    faseRef.current = estado.fase;
+  }, [estado.fase]);
 
   useEffect(() => () => clearTimeout(prontoTimer.current), []);
 
@@ -114,5 +119,6 @@ export function useNavegacionMundos({ reducedMotion = false } = {}) {
     volverAlValle,
     completarViaje,
     puedeEntrar: puedeEntrarAlMundo,
+    catalogoPisos,
   };
 }


### PR DESCRIPTION
## Summary
- anota cada entrada de MUNDO con un piso termico de anclaje
- deriva mundos agrupados por altitud y compatibilidad sin persistir estado
- expone el piso real desde useFincaViva y el catalogo desde useNavegacionMundos
- documenta el cableo futuro de VistaGlobalSierra sin tocar escenas ni arte

## Test plan
- [x] npx vitest run src/visual/mundo3d/__tests__/mundosPorPisoTermico.test.js src/visual/mundo3d/__tests__/navegacion.test.jsx (12 passed)
- [x] npx eslint sobre todos los archivos JS/JSX modificados --max-warnings=0
- [x] npm run build
- [ ] npx vitest run global: presenta fallos preexistentes/no relacionados en voz, perfiles, estilos, banners, NGSI y benchmarks; se interrumpio despues de registrar los fallos
- [ ] npx eslint . --max-warnings=0: no termino ni emitio diagnosticos tras mas de siete minutos; lint focalizado y hook pre-commit pasaron
