### PR TITLE
fix(tts): usar Kokoro para Angelita

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -55,6 +55,7 @@ import Mundo, {
 } from '../visual/mundo3d/index.js';
 /* Coach-mark del primer ingreso (visual, NO depende de la voz — iOS la muda). */
 import CoachMarkToque from '../visual/mundo3d/CoachMarkToque.jsx';
+import { speak, speakKokoro, stop as stopSpeak } from '../services/ttsService.js';
 
 // La escena 3D pesada (three/fiber/drei) en su PROPIO chunk perezoso.
 const Valle3D = lazy(() => import('./valle/Valle3D'));
@@ -191,61 +192,29 @@ export default function EntradaValle3D({ onBack, onNavigate }) {
     [],
   );
 
-  // ── Voz (Web Speech API): el agente DICE. Se calla si el equipo no la trae
-  //    o si el usuario apaga la voz. Prefiere una voz en español.
-  //    (Si esto se productiza, la voz real es Kokoro vía ttsService — default
-  //    `em_santa`; aquí la vitrina usa la del navegador.)
+  // ── Voz: Angelita usa Kokoro en el equipo. Si no puede reproducirlo, el
+  //    respaldo es la voz del navegador.
   const vozDisponible = useMemo(
-    () => typeof window !== 'undefined' && 'speechSynthesis' in window,
+    () => typeof window !== 'undefined',
     [],
   );
 
   // El toggle vive en un ref para que `hablar`/`decir` sean ESTABLES: prender
   // o apagar la voz no debe re-disparar los efectos que narran.
   const vozRef = useRef(voz);
-  const vocesRef = useRef([]);
   useEffect(() => {
     vozRef.current = voz;
   }, [voz]);
 
-  useEffect(() => {
-    if (!vozDisponible) return undefined;
-    const synth = window.speechSynthesis;
-    const actualizarVoces = () => {
-      const voces = synth.getVoices();
-      if (voces.length) vocesRef.current = voces;
-    };
-    actualizarVoces();
-    if (synth.addEventListener) {
-      synth.addEventListener('voiceschanged', actualizarVoces);
-      return () => synth.removeEventListener('voiceschanged', actualizarVoces);
-    }
-    const anterior = synth.onvoiceschanged;
-    synth.onvoiceschanged = actualizarVoces;
-    return () => {
-      if (synth.onvoiceschanged === actualizarVoces) synth.onvoiceschanged = anterior;
-    };
-  }, [vozDisponible]);
-
   const hablar = useCallback((texto) => {
-    if (!vozRef.current || typeof window === 'undefined' || !window.speechSynthesis) return;
-    try {
-      window.speechSynthesis.cancel();
-      const u = new SpeechSynthesisUtterance(texto);
-      u.lang = 'es-CO';
-      u.rate = 0.98;
-      u.pitch = 1;
-      const esVoz = vocesRef.current.find(
-        (v) => v.lang && v.lang.toLowerCase().startsWith('es'),
-      );
-      // Si el navegador todavía no publicó sus voces, conservamos la
-      // burbuja y evitamos que el saludo salga con la voz inglesa por defecto.
-      if (!esVoz) return;
-      u.voice = esVoz;
-      window.speechSynthesis.speak(u);
-    } catch {
-      /* la voz es un plus, nunca bloquea */
-    }
+    if (!vozRef.current || !texto) return;
+    speakKokoro(texto, { lang: 'es', rate: 0.98 })
+      .then((audio) => {
+        if (!audio && vozRef.current) speak(texto, { rate: 0.98, pitch: 1 });
+      })
+      .catch(() => {
+        if (vozRef.current) speak(texto, { rate: 0.98, pitch: 1 });
+      });
   }, []);
 
   // ── Angelita DICE (voz + burbuja): el texto SIEMPRE acompaña a la voz en la
@@ -275,7 +244,7 @@ export default function EntradaValle3D({ onBack, onNavigate }) {
 
   useEffect(
     () => () => {
-      if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+      stopSpeak();
     },
     [],
   );
@@ -316,7 +285,7 @@ export default function EntradaValle3D({ onBack, onNavigate }) {
   const volverAlValle = useCallback(() => {
     setFocoId(null);
     setPanel(null);
-    if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+    stopSpeak();
   }, []);
 
   // El CTA de la alerta: en la APP navega a la pantalla real de la acción
@@ -324,7 +293,7 @@ export default function EntradaValle3D({ onBack, onNavigate }) {
   // (antes era un botón mudo — auditoría FASE 0).
   const accionDelDia = useCallback(() => {
     if (onNavigate && COSA_DEL_DIA.accion?.view) {
-      if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+      stopSpeak();
       onNavigate(COSA_DEL_DIA.accion.view);
       return;
     }
@@ -338,7 +307,7 @@ export default function EntradaValle3D({ onBack, onNavigate }) {
   //    desde cualquier pantalla, incluida esta vitrina, sin acoplar el mockup.
   const preguntarAlAgente = useCallback(() => {
     if (typeof window === 'undefined') return;
-    if (window.speechSynthesis) window.speechSynthesis.cancel();
+    stopSpeak();
     window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'agente' } }));
   }, []);
 
@@ -389,7 +358,7 @@ export default function EntradaValle3D({ onBack, onNavigate }) {
       // MODO APP (FASE 0 game-dev): la puerta ES real — se corta la voz y se
       // navega a la pantalla de verdad. El valle cumple su promesa.
       if (onNavigate) {
-        if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+        stopSpeak();
         onNavigate(view, data);
         return;
       }
@@ -618,7 +587,7 @@ export default function EntradaValle3D({ onBack, onNavigate }) {
             onClick={() => {
               const n = !voz;
               setVoz(n);
-              if (!n && typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+              if (!n) stopSpeak();
             }}
           >
             {!vozDisponible ? '💬 Texto' : voz ? '🔊 Voz' : '🔇 Voz'}

--- a/src/mockups/__tests__/EntradaValle3D.tts.test.jsx
+++ b/src/mockups/__tests__/EntradaValle3D.tts.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const tts = vi.hoisted(() => ({
+  speak: vi.fn(),
+  speakKokoro: vi.fn().mockResolvedValue({}),
+  stop: vi.fn(),
+}));
+
+vi.mock('../../services/ttsService.js', () => tts);
+
+import EntradaValle3D from '../EntradaValle3D.jsx';
+
+afterEach(() => {
+  vi.clearAllMocks();
+  tts.speakKokoro.mockResolvedValue({});
+});
+
+describe('EntradaValle3D', () => {
+  test('narra el saludo de Angelita con Kokoro', async () => {
+    const { container } = render(<EntradaValle3D onBack={() => {}} />);
+
+    fireEvent.pointerDown(container.querySelector('.valle-root'));
+    await act(async () => {});
+
+    expect(tts.speakKokoro).toHaveBeenCalledWith(
+      expect.stringMatching(/Bienvenido/i),
+      { lang: 'es', rate: 0.98 },
+    );
+    expect(tts.speak).not.toHaveBeenCalled();
+  });
+
+  test('usa la voz del navegador si Kokoro no logra hablar', async () => {
+    tts.speakKokoro.mockResolvedValue(null);
+    const { container } = render(<EntradaValle3D onBack={() => {}} />);
+
+    fireEvent.pointerDown(container.querySelector('.valle-root'));
+    await act(async () => {});
+
+    expect(tts.speak).toHaveBeenCalledWith(
+      expect.stringMatching(/Bienvenido/i),
+      { rate: 0.98, pitch: 1 },
+    );
+  });
+});

--- a/src/mockups/valle/AcompananteMundo.jsx
+++ b/src/mockups/valle/AcompananteMundo.jsx
@@ -35,6 +35,7 @@ import { Children, cloneElement, isValidElement, useCallback, useEffect, useMemo
 import { MUNDO, tituloDeMundo, tinteDeMundo } from '../../visual/mundo3d/index.js';
 import { parseComandoMundo, puertasDeMundo } from '../../visual/mundo3d/comandoMundo.js';
 import { NARRACION, MUNDO_VALLE_BY_ID } from './valleData';
+import { speak, speakKokoro, stop as stopSpeak } from '../../services/ttsService.js';
 import './acompananteMundo.css';
 
 /* La narración de un mundo, con la MISMA cadena de fallbacks del shell:
@@ -59,56 +60,26 @@ export function useAcompanante(mundoId) {
   const [voz, setVoz] = useState(true);
 
   const vozDisponible = useMemo(
-    () => typeof window !== 'undefined' && 'speechSynthesis' in window,
+    () => typeof window !== 'undefined',
     [],
   );
 
   // El toggle vive en un ref para que `hablar`/`decir` sean ESTABLES (mismo
   // patrón del shell): prender/apagar la voz no re-dispara la narración.
   const vozRef = useRef(voz);
-  const vocesRef = useRef([]);
   useEffect(() => {
     vozRef.current = voz;
   }, [voz]);
 
-  useEffect(() => {
-    if (!vozDisponible) return undefined;
-    const synth = window.speechSynthesis;
-    const actualizarVoces = () => {
-      const voces = synth.getVoices();
-      if (voces.length) vocesRef.current = voces;
-    };
-    actualizarVoces();
-    if (synth.addEventListener) {
-      synth.addEventListener('voiceschanged', actualizarVoces);
-      return () => synth.removeEventListener('voiceschanged', actualizarVoces);
-    }
-    const anterior = synth.onvoiceschanged;
-    synth.onvoiceschanged = actualizarVoces;
-    return () => {
-      if (synth.onvoiceschanged === actualizarVoces) synth.onvoiceschanged = anterior;
-    };
-  }, [vozDisponible]);
-
   const hablar = useCallback((texto) => {
-    if (!vozRef.current || typeof window === 'undefined' || !window.speechSynthesis) return;
-    try {
-      window.speechSynthesis.cancel();
-      const u = new SpeechSynthesisUtterance(texto);
-      u.lang = 'es-CO';
-      u.rate = 0.98;
-      u.pitch = 1;
-      const esVoz = vocesRef.current.find(
-        (v) => v.lang && v.lang.toLowerCase().startsWith('es'),
-      );
-      // Sin voz en español publicada aún: queda la burbuja (mejor callada la
-      // voz que un saludo con acento inglés por defecto).
-      if (!esVoz) return;
-      u.voice = esVoz;
-      window.speechSynthesis.speak(u);
-    } catch {
-      /* la voz es un plus, nunca bloquea */
-    }
+    if (!vozRef.current || !texto) return;
+    speakKokoro(texto, { lang: 'es', rate: 0.98 })
+      .then((audio) => {
+        if (!audio && vozRef.current) speak(texto, { rate: 0.98, pitch: 1 });
+      })
+      .catch(() => {
+        if (vozRef.current) speak(texto, { rate: 0.98, pitch: 1 });
+      });
   }, []);
 
   // ── Angelita DICE (voz + burbuja): el texto SIEMPRE va a la burbuja
@@ -131,7 +102,7 @@ export function useAcompanante(mundoId) {
   useEffect(
     () => () => {
       if (dichoTimer.current) clearTimeout(dichoTimer.current);
-      if (typeof window !== 'undefined' && window.speechSynthesis) window.speechSynthesis.cancel();
+      stopSpeak();
     },
     [],
   );
@@ -295,7 +266,7 @@ export default function AcompananteMundo({ mundoId, acompanante, children }) {
   // App.jsx escucha desde cualquier pantalla.
   const preguntarAlAgente = useCallback(() => {
     if (typeof window === 'undefined') return;
-    if (window.speechSynthesis) window.speechSynthesis.cancel();
+    stopSpeak();
     window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'agente' } }));
   }, []);
 
@@ -359,9 +330,7 @@ export default function AcompananteMundo({ mundoId, acompanante, children }) {
             onClick={() => {
               const n = !voz;
               setVoz(n);
-              if (!n && typeof window !== 'undefined' && window.speechSynthesis) {
-                window.speechSynthesis.cancel();
-              }
+              if (!n) stopSpeak();
             }}
           >
             {!vozDisponible ? '💬 Texto' : voz ? '🔊 Voz' : '🔇 Voz'}

--- a/src/mockups/valle/__tests__/AcompananteMundo.tts.test.jsx
+++ b/src/mockups/valle/__tests__/AcompananteMundo.tts.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { fireEvent, render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const tts = vi.hoisted(() => ({
+  speak: vi.fn(),
+  speakKokoro: vi.fn().mockResolvedValue({}),
+  stop: vi.fn(),
+}));
+
+vi.mock('../../../services/ttsService.js', () => tts);
+
+import { useAcompanante } from '../AcompananteMundo.jsx';
+
+function VitrinaDePrueba() {
+  const acompanante = useAcompanante('agua');
+  return <button type="button" onClick={acompanante.narrar}>Escuchar</button>;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  tts.speakKokoro.mockResolvedValue({});
+});
+
+describe('useAcompanante', () => {
+  test('narra las vitrinas con Kokoro antes de usar el respaldo', async () => {
+    render(<VitrinaDePrueba />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Escuchar' }));
+    await act(async () => {});
+
+    expect(tts.speakKokoro).toHaveBeenCalledWith(
+      expect.any(String),
+      { lang: 'es', rate: 0.98 },
+    );
+    expect(tts.speak).not.toHaveBeenCalled();
+  });
+
+  test('usa el respaldo del navegador si Kokoro falla', async () => {
+    tts.speakKokoro.mockRejectedValue(new Error('sin audio'));
+    render(<VitrinaDePrueba />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Escuchar' }));
+    await act(async () => {});
+
+    expect(tts.speak).toHaveBeenCalledWith(
+      expect.any(String),
+      { rate: 0.98, pitch: 1 },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Ruta la narración de Angelita del valle y las vitrinas 3D por Kokoro mediante ttsService.
- Conserva Web Speech como respaldo cuando Kokoro no produce audio o falla.
- Agrega pruebas para la ruta principal y el respaldo.

## Test plan
- npx vitest run src/mockups/__tests__/EntradaValle3D.tts.test.jsx src/mockups/valle/__tests__/AcompananteMundo.tts.test.jsx
- npx eslint . --max-warnings=0
- npm run build
- npx vitest run (falla por errores preexistentes fuera de este cambio)