### PR TITLE
feat(voz): enrutar comandos a mundos 3d

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3033,7 +3033,11 @@ export default function App() {
         return (
           <ErrorBoundary>
             <ErrorFallback moduleName="El valle de su finca (3D)">
-              <EntradaValle3DMockup onBack={() => navigate(sinSesion ? 'login' : 'dashboard')} onNavigate={navigate} />
+              <EntradaValle3DMockup
+                onBack={() => navigate(sinSesion ? 'login' : 'dashboard')}
+                onNavigate={navigate}
+                initialMundoId={currentViewData?.mundo}
+              />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/escucha/EscuchaOverlay.jsx
+++ b/src/components/escucha/EscuchaOverlay.jsx
@@ -372,7 +372,7 @@ export default function EscuchaOverlay() {
       setDestino(ruta);
       setFase(FASE_RUMBO);
       rumboTimerRef.current = setTimeout(() => {
-        navegar(ruta.view);
+        navegar(ruta.view, ruta.initialData);
         cerrar();
       }, PAUSA_RUMBO_MS);
       return;

--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -97,7 +97,7 @@ class Valle3DGuard extends Component {
  *   Sin ella (vitrina #/mockups/entrada-3d, sin sesión) Angelita solo las
  *   nombra — el comportamiento de siempre.
  */
-export default function EntradaValle3D({ onBack, onNavigate }) {
+export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = null }) {
   const [clima, setClima] = useState(() => climaPorHora());
 
   // ── El clima es ATMÓSFERA, no un selector (auditoría B8/S8): los chips de
@@ -126,6 +126,17 @@ export default function EntradaValle3D({ onBack, onNavigate }) {
   );
 
   const nav = useNavegacionMundos({ reducedMotion });
+  const viajarAlMundoInicial = nav.viajarAlMundo;
+
+  // La escucha puede llegar con un mundo ya resuelto por el NLU. Se consume
+  // una vez al montar para que volver al valle siga siendo una decisión de la
+  // persona, no un bucle que la devuelva al mismo lugar.
+  const mundoInicialAbierto = useRef(false);
+  useEffect(() => {
+    if (mundoInicialAbierto.current || !initialMundoId) return;
+    mundoInicialAbierto.current = true;
+    viajarAlMundoInicial(initialMundoId);
+  }, [initialMundoId, viajarAlMundoInicial]);
 
   // ── Sonido ambiental 0-KB (spec S3): el valle reclama su paleta (brisa
   //    dorada) mientras la entrada viva; al entrar a un mundo, <Mundo> reclama

--- a/src/services/__tests__/escuchaIntentRouter.test.js
+++ b/src/services/__tests__/escuchaIntentRouter.test.js
@@ -52,6 +52,10 @@ describe('routeUtterance', () => {
     { frase: 'abrame el cafe', esperado: { tipo: 'navegar', view: 'cafe' } },
     { frase: 'quiero ver el suelo', esperado: { tipo: 'navegar', view: 'suelo' } },
     { frase: 'muestreme el mercado', esperado: { tipo: 'navegar', view: 'mercado' } },
+    { frase: 'lleveme al mundo del cafe', esperado: { tipo: 'navegar', view: 'valle3d', mundo: 'cafe' } },
+    { frase: 'muestreme el mundo del agua', esperado: { tipo: 'navegar', view: 'valle3d', mundo: 'agua' } },
+    { frase: 'muestreme el agua', esperado: { tipo: 'navegar', view: 'valle3d', mundo: 'agua' } },
+    { frase: 'hola chagra lleveme al mundo del suelo', esperado: { tipo: 'navegar', view: 'valle3d', mundo: 'suelo' } },
     { frase: '¿por qué se amarilla el tomate?', esperado: { tipo: 'agente' } },
     { frase: '¿por qué se amarilla el café?', esperado: { tipo: 'agente' } },
     { frase: '¿por qué se amarilla el plátano?', esperado: { tipo: 'agente' } },
@@ -82,6 +86,9 @@ describe('routeUtterance', () => {
         view: esperado.view,
         etiqueta: expect.any(String),
       });
+      if (esperado.mundo) {
+        expect(r.initialData).toEqual({ mundo: esperado.mundo });
+      }
     } else {
       expect(r).toMatchObject({ tipo: 'agente' });
       if (r.tipo === 'agente' && 'prompt' in esperado) {

--- a/src/services/escuchaIntentRouter.js
+++ b/src/services/escuchaIntentRouter.js
@@ -27,6 +27,7 @@
  * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino.
  */
 /* eslint-disable chagra-i18n/no-hardcoded-spanish -- etiquetas visibles de destino; deuda de i18n fuera de este cambio */
+import { MUNDO } from '../visual/mundo3d/mundoData.js';
 
 /** Quita tildes/diéresis y baja a minúsculas para matching tolerante a Whisper. */
 export function normalizarHabla(texto) {
@@ -80,6 +81,23 @@ const DESTINOS = Object.freeze([
   { claves: ['activos'], view: 'activos', etiqueta: 'Mi finca' },
 ]);
 
+/* Mundos 3D que se pueden pedir desde la escucha. La fuente de verdad de que
+ * el mundo existe es `MUNDO`; aquí solo viven las formas en que Whisper suele
+ * transcribir cada destino. El resultado siempre abre `valle3d`, que es el
+ * host real de los mundos, con el id que ese host entiende. */
+const MUNDOS_3D = Object.freeze([
+  { id: 'cafe', claves: ['mundo del cafe', 'mundo cafe', 'cafetal'], directas: [], etiqueta: 'El mundo del café' },
+  { id: 'agua', claves: ['mundo del agua', 'mundo agua'], directas: ['agua'], etiqueta: 'El mundo del agua' },
+  { id: 'suelo', claves: ['mundo del suelo', 'mundo suelo', 'suelo vivo'], directas: [], etiqueta: 'El mundo del suelo' },
+  { id: 'animales', claves: ['mundo de los animales', 'mundo animales', 'mundo del animal'], directas: [], etiqueta: 'El mundo de los animales' },
+  { id: 'sanidad', claves: ['mundo de sanidad', 'mundo sanidad'], directas: [], etiqueta: 'El mundo de sanidad' },
+  { id: 'mercado', claves: ['mundo del mercado', 'mundo mercado'], directas: [], etiqueta: 'El mundo del mercado' },
+  { id: 'clima', claves: ['mundo del clima', 'mundo clima'], directas: [], etiqueta: 'El mundo del clima' },
+  { id: 'semillero', claves: ['mundo del semillero', 'mundo semillero', 'vivero'], directas: [], etiqueta: 'El mundo del semillero' },
+]);
+
+const VERBOS_MOSTRAR_MUNDO = ['muestrame', 'muestreme', 'mostrar', 'muestra', 'muestre'];
+
 /* Verbos/locuciones que declaran intención de IR a un lugar de la app.
  * Aceptamos variantes de tuteo/ustedeo E imperativos que Whisper transcribe
  * del habla real ("llevame", "abrime") — lo que ESCUCHAMOS no se limita al
@@ -125,6 +143,24 @@ function buscarDestino(tokens) {
     }
   }
   return null;
+}
+
+function buscarMundo3D(tokens, permiteDestinoDirecto) {
+  for (const mundo of MUNDOS_3D) {
+    if (!MUNDO[mundo.id]) continue;
+    if (mundo.claves.some((clave) => contieneToken(tokens, clave))) return mundo;
+    if (permiteDestinoDirecto && mundo.directas.some((clave) => contieneToken(tokens, clave))) return mundo;
+  }
+  return null;
+}
+
+function rutaMundo3D(mundo) {
+  return {
+    tipo: 'navegar',
+    view: 'valle3d',
+    initialData: { mundo: mundo.id },
+    etiqueta: mundo.etiqueta,
+  };
 }
 
 /**
@@ -182,6 +218,12 @@ export function routeUtterance(texto) {
   }
 
   const destino = buscarDestino(tokens);
+  const muestraMundo = VERBOS_MOSTRAR_MUNDO.some((verbo) => contieneToken(tokens, verbo));
+  const mundo3D = buscarMundo3D(tokens, muestraMundo);
+  if (mundo3D && (tieneVerboNav || tokens.length <= 4)) {
+    return rutaMundo3D(mundo3D);
+  }
+
   if (destino) {
     // Regla 2: verbo de navegación + destino conocido.
     if (tieneVerboNav) {


### PR DESCRIPTION
## Summary
- Añade intents de voz para navegar desde hola chagra a mundos 3D reales.
- Envía el id de mundo al valle 3D y abre ese destino al entrar.
- Conserva las rutas de voz existentes y cubre frases de café, agua y suelo.

## Test plan
- npx vitest run src/services/__tests__/escuchaIntentRouter.test.js
- npx eslint . --max-warnings=0
- npm run build
- npx vitest run (falla por pruebas preexistentes fuera de este cambio, incluido el mockup del valle con carga perezosa)