### PR TITLE
fix(mundo3d): ampliar espera de carga 3d

### DIFF
--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -52,7 +52,7 @@ const ESCENAS_3D = Object.fromEntries(
 /* Cuánto esperamos el chunk 3D antes de la CAÍDA DIGNA al 2D. Con señal
    intermitente (el caso normal del campo) un fetch colgado NO lanza error —
    el ErrorBoundary nunca lo ve; este timeout sí. */
-export const CARGA_3D_TIMEOUT_MS = 9000;
+export const CARGA_3D_TIMEOUT_MS = 15000;
 
 function MundoCargando({ tinte, onTimeout }) {
   /* El fallback vive SOLO mientras Suspense espera el chunk: si el chunk llega,
@@ -157,18 +157,20 @@ function MundoInterno({
     const espejo = resolverMundo(mundoId, 'bajo');
     return (
       <div className="mundo-root" data-dim="2d" data-mundo={mundoId} data-caida3d="1">
-        {espejo.modo === '2d' && (
-          <Mundo2D
-            escena={espejo.escena}
-            motivo={espejo.motivo}
-            entrada={espejo.entrada}
-            tinte={tinte}
-            reducedMotion={reducedMotion}
-            onHotspot={onHotspot}
-            animo={animo}
-            energia={energia}
-          />
-        )}
+        <div className="mundo-caida__contenido">
+          {espejo.modo === '2d' && (
+            <Mundo2D
+              escena={espejo.escena}
+              motivo={espejo.motivo}
+              entrada={espejo.entrada}
+              tinte={tinte}
+              reducedMotion={reducedMotion}
+              onHotspot={onHotspot}
+              animo={animo}
+              energia={energia}
+            />
+          )}
+        </div>
         {/* Sin invitación de audio acá: el aviso de caída ya ocupa ese lugar
             (señal mala ≠ momento de invitar); queda para la próxima entrada. */}
         <AvisoCaida3D tinte={tinte} onReintentar={reintentar3D} />

--- a/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
+++ b/src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
@@ -1,14 +1,19 @@
 import React from 'react';
-import { render, cleanup } from '@testing-library/react';
+import { act, render, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, test, expect, afterEach } from 'vitest';
+import {
+  describe, test, expect, afterEach, vi,
+} from 'vitest';
 
-import Mundo from '../Mundo.jsx';
+import Mundo, { CARGA_3D_TIMEOUT_MS } from '../Mundo.jsx';
 import { resolverMundo } from '../resolverMundo.js';
 import { MUNDO } from '../mundoData.js';
 import { ARQUETIPOS, ARQUETIPOS_3D, ARQUETIPOS_2D } from '../arquetipos.js';
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
   test('arquetipos: 5 dioramas 3D + arquetipos 2D de primera clase', () => {
@@ -88,5 +93,21 @@ describe('framework de mundos — resolución data-driven (2D + 3D)', () => {
       <Mundo mundoId="suelo" tier="bajo" onHotspot={() => {}} onSalir={() => {}} />,
     );
     expect(c2.querySelector('.mundo-root[data-dim="2d"]')).toBeInTheDocument();
+  });
+
+  test('espera 15 segundos y reserva una fila propia para el aviso de caída 3D', () => {
+    vi.useFakeTimers();
+    const { container } = render(<Mundo mundoId="cafe" tier="alto" />);
+
+    act(() => vi.advanceTimersByTime(CARGA_3D_TIMEOUT_MS - 1));
+    expect(container.querySelector('[data-caida3d="1"]')).not.toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(1));
+    const raiz = container.querySelector('[data-caida3d="1"]');
+    expect(raiz).toBeInTheDocument();
+    expect(raiz.querySelector('.mundo-caida__contenido')).toContainElement(
+      raiz.querySelector('.mundo2d'),
+    );
+    expect(raiz.querySelector('.mundo-caida')).toBeInTheDocument();
   });
 });

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -311,15 +311,13 @@
 
 /* ── Caída digna: el chunk 3D no bajó (señal intermitente) → espejo 2D ──── */
 .mundo-caida {
-  position: absolute;
-  left: 12px;
-  right: 12px;
-  bottom: 12px;
+  position: relative;
   z-index: 6;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem 0.8rem;
+  margin: 0 12px 12px;
   padding: 0.6rem 0.8rem;
   color: #2a2016;
   background: rgba(255, 251, 242, 0.95);
@@ -351,9 +349,15 @@
   outline: 2px solid #2a2016;
   outline-offset: 2px;
 }
-/* que el aviso no tape el final del espejo 2D en pantallas de 320px */
-.mundo-root[data-caida3d='1'] .mundo2d {
-  padding-bottom: 7.5rem;
+/* El espejo y el aviso ocupan filas distintas: nunca se enciman. */
+.mundo-root[data-caida3d='1'] {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+}
+.mundo-caida__contenido {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
 }
 
 /* ── La miga: volver al valle + dónde-estoy (consistente en todo mundo) ── */


### PR DESCRIPTION
## Summary
- Amplía a 15 segundos la espera del chunk 3D antes de activar la caída digna.
- Separa el espejo 2D y el aviso en filas de layout para evitar texto encimado.
- Añade cobertura del umbral y de la estructura de caída.

## Test plan
- npx vitest run src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
- npx eslint src/visual/mundo3d/Mundo.jsx src/visual/mundo3d/__tests__/mundo.smoke.test.jsx
- npm run build
- npx vitest run (fallos preexistentes ajenos, ejecución interrumpida tras quedar bloqueada)
- npx eslint . --max-warnings=0 (sin errores emitidos, ejecución interrumpida tras quedar bloqueada)