### PR TITLE
feat(creatures): el cuerpo reacciona al clima real (species-agnostic)

### DIFF
--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -3,6 +3,7 @@ import './creatures.css';
 import { CreatureFilters } from './_filters.jsx';
 import { OjosRubber, Cachetes, Sonrisa, Miembro, AntenaRubber, RH_INK } from './_rubberhose.jsx';
 import { ABEJA_PALETA, ABEJA_PROPORCION } from './abejaIdentidad.js';
+import { cuerpoDeClima, PERFIL_ABEJA } from './creatureClimaCuerpo.js';
 
 /* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
    Apis). Cuerpo ámbar rayado (chumbe andino), cabeza clara, alitas de tul.
@@ -49,6 +50,13 @@ export function AbejaAngelita({
   mojada = false,
   sed = false,
   comiendo = false,
+  /* ── EL CLIMA REAL escrito en el CUERPO (angelitaClimaCuerpo.js) ───────────
+     clima/enso del estadoFinca REAL (useFincaViva): lluvia→brillo mojado y
+     alas pesadas, Niño+día claro→tono deshidratado y alas lentas, niebla→
+     silueta difusa, dorada→vibrante y alas rápidas. Sin clima (avatares,
+     catálogo) = neutro digno: la abeja se ve EXACTO como siempre. */
+  clima = null,
+  enso = 'neutro',
   /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
      pleno; 'bajo' apaga el idle continuo (boil + follow-through) y deja el
      aleteo + estados reactivos. Sin prop (standalone: avatares, catálogo) =
@@ -64,6 +72,22 @@ export function AbejaAngelita({
   // El aura respira con la energía real de la finca (matas vivas + agua).
   const auraOp = Math.max(0.16, Math.min(0.5, 0.2 + 0.3 * (energia ?? 1)));
   const auraR = 5.4 + 1.2 * (energia ?? 1);
+
+  // ── EL CLIMA REAL en el cuerpo (creatureClimaCuerpo, perfil abeja). Determinista,
+  //    una vez por render: tinte + opacidad al contorno; el aleteo se acelera
+  //    (dorada) o pesa (lluvia) escalando la duración base de `.crt-wing` (0.15s).
+  //    Sin clima → neutro: filtro/opacidad nulos, aleteo base. RM: como `wing` va
+  //    solo con `animated`, la duración cuelga de nodos ya quietos (inocua).
+  const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: PERFIL_ABEJA });
+  // Solo estampamos duración inline cuando el clima REALMENTE cambia el aleteo
+  // (≠1): así un clima neutro NO pisa los overrides de pose ('celebra'/'reposo').
+  const wingDur = (wing && cuerpoClima.velocidadAlas !== 1)
+    ? { animationDuration: `${(0.15 / cuerpoClima.velocidadAlas).toFixed(3)}s` }
+    : undefined;
+  // Filtro/opacidad de clima para el nodo raíz (svg autónomo o <g> inline).
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
 
   const defs = (
     <defs>
@@ -108,10 +132,12 @@ export function AbejaAngelita({
       {/* aura viva */}
       <circle r={auraR} fill={ABEJA_PALETA.cuerpo} opacity={auraOp} filter={`url(#${blur})`} />
 
-      {/* alitas de tul con contorno + smear (crt-wingbeat ya lleva el estirón) */}
-      <ellipse className={wing} cx="-1.8" cy="-7" rx="6" ry="3.6" fill={ABEJA_PALETA.alaTul}
+      {/* alitas de tul con contorno + smear (crt-wingbeat ya lleva el estirón).
+          La duración del aleteo la modula el clima real (wingDur): dorada rápida,
+          lluvia pesada. celebra/reposo (data-pose) mandan por especificidad CSS. */}
+      <ellipse className={wing} style={wingDur} cx="-1.8" cy="-7" rx="6" ry="3.6" fill={ABEJA_PALETA.alaTul}
         opacity="0.62" stroke="rgba(42,26,12,0.4)" strokeWidth="0.5" />
-      <ellipse className={wing} style={{ animationDelay: '-0.07s' }} cx="2.2" cy="-6.4"
+      <ellipse className={wing} style={{ animationDelay: '-0.07s', ...wingDur }} cx="2.2" cy="-6.4"
         rx="4.6" ry="2.8" fill={ABEJA_PALETA.alaTulClara} opacity="0.5" stroke="rgba(42,26,12,0.35)" strokeWidth="0.5" />
 
       {/* patitas manguera con pie crema (detrás del tronco, se mecen suave) */}
@@ -173,14 +199,14 @@ export function AbejaAngelita({
 
   if (inline) {
     return (
-      <g className={className} {...estadoAttrs}>
+      <g className={className} style={estiloClima} {...estadoAttrs}>
         {defs}
         {cuerpoVivo}
       </g>
     );
   }
   return (
-    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}

--- a/src/visual/creatures/creatureClimaCuerpo.js
+++ b/src/visual/creatures/creatureClimaCuerpo.js
@@ -1,0 +1,212 @@
+/*
+ * creatureClimaCuerpo — el CLIMA REAL escrito en el CUERPO de una CREATURE
+ * rubber-hose andina (species-agnostic).
+ *
+ * La coreografía (useEntradaAbeja + reaccionFinca) ya modula el VUELO con el
+ * estado real de la finca; este módulo es la pieza hermana para el DIBUJO: una
+ * función PURA y determinista que traduce el `clima` del `estadoFinca` REAL
+ * (useFincaViva → Open-Meteo/efemérides, vocabulario de valleData.CLIMAS) en
+ * parámetros de cuerpo que la creature aplica tal cual.
+ *
+ * GENÉRICO A PROPÓSITO: toda la familia rubber-hose (abeja Angelita, colibrí,
+ * oso andino, rana…) comparte el MISMO lenguaje CSS/SVG — `.crt-body`,
+ * `.crt-wing`, glow/blur de `_filters.jsx`, contorno de tinta que respira — así
+ * que la MISMA lógica clima→cuerpo (mojado / sed / niebla / vibrante) vale para
+ * todas. Lo único que cambia es CUÁNTO le pega cada clima a cada especie: eso
+ * vive en un PERFIL. Angelita (abeja) es el primer consumidor; el resto entra
+ * pasando su perfil.
+ *
+ *   cuerpoDeClima(clima, { enso, tier, perfil }) → {
+ *     humedad,       // 0..1 — cuánta agua carga el cuerpo (para creatures que
+ *                    //   dibujan su propia mojadura: gotas, rocío, brillo)
+ *     opacidad,      // 0..1 — presencia: la niebla la vuelve silueta difusa
+ *     tinte,         // null | string — filtro CSS determinista (sequía apagada,
+ *                    //   dorada vibrante, lluvia con brillo mojado)
+ *     velocidadAlas, // multiplicador del aleteo (1 = base): dorada rápida,
+ *                    //   lluvia pesada y lenta. En especies SIN alas → 1.
+ *     altura,        // multiplicador de vuelo COMPLEMENTARIO al de reaccionFinca
+ *                    //   (niebla vuela corto, dorada un poco más alto). Se
+ *                    //   MULTIPLICA con reaccion.vuelo.altura; lluvia/sequía van
+ *                    //   en 1 aquí porque su descenso ya lo pone reaccionFinca.
+ *   }
+ *
+ * REGLAS DE LA CASA:
+ *   · Sin clima (standalone: avatares, catálogo, storybook) → NEUTRO digno:
+ *     todo en 1, tinte null. La creature se ve EXACTO como siempre.
+ *   · Determinista: cero azar, cero reloj — mismo clima, mismo cuerpo.
+ *   · Frugal por tier: en 'bajo' no hay blur (raster caro en gama baja); la
+ *     niebla se dice solo con opacidad. Los demás filtros son estáticos (se
+ *     pintan una vez, no por frame) y opacity/filter van por GPU.
+ *   · reducedMotion NO vive aquí: `velocidadAlas` solo lo aplica la creature
+ *     cuando anima (con RM las alas ya están quietas; queda el estado visual).
+ *   · Los tintes son filtros CSS y NO colores de atmosferaMadre.js a propósito:
+ *     ese módulo importa `three` y las creatures viven en el bundle BASE (2D:
+ *     home, avatares) — importarlo aquí arrastraría three fuera del chunk
+ *     perezoso vendor-three. La dirección de arte se honra en los valores
+ *     (cálido dorado, sequía sepia-tierra), no en el import.
+ */
+
+/** El cuerpo NEUTRO (sin dato de clima): la creature de siempre, sin disfraz. */
+export const CUERPO_NEUTRO = Object.freeze({
+  humedad: 0,
+  opacidad: 1,
+  tinte: null,
+  velocidadAlas: 1,
+  altura: 1,
+});
+
+/*
+ * CLIMA_BASE — la respuesta CANÓNICA de cuerpo por clima, calibrada para una
+ * creature de referencia (un polinizador alado: la abeja). El PERFIL de cada
+ * especie escala estos valores. `humedad` y la caída de `opacidad` se atenúan
+ * por perfil; `velocidadAlas` se anula si la especie no tiene alas; el `tinte`
+ * es dirección de arte compartida (bajo el mismo sol todas se doran igual), y el
+ * perfil puede sustituirlo por especie vía `perfil.tintes[clima]`.
+ */
+const CLIMA_BASE = {
+  // Mojada: brillo húmedo (la piel destella), alas pesadas de agua. El vuelo
+  // bajo/pesado lo pone reaccionFinca (mojada) → altura 1 aquí (no doble-contar).
+  lluvia: {
+    humedad: 1,
+    opacidad: 1,
+    tinte: 'saturate(1.06) brightness(1.05) contrast(1.06)',
+    velocidadAlas: 0.72,
+    altura: 1,
+  },
+  // Casi no se ve: silueta difusa entre la bruma, con algo de rocío encima.
+  niebla: {
+    humedad: 0.35,
+    opacidad: 0.5,
+    tinte: 'saturate(0.85) blur(0.5px)',
+    velocidadAlas: 0.9,
+    altura: 0.85, // vuela corto y cerca — no se pierde en la bruma
+  },
+  // La hora dorada: vibrante, dorándose al sol bajo, alas rápidas.
+  dorada: {
+    humedad: 0,
+    opacidad: 1,
+    tinte: 'saturate(1.18) brightness(1.06)',
+    velocidadAlas: 1.3,
+    altura: 1.05, // se luce un poquito más alto
+  },
+  // Día claro y honesto: viva, apenas más ágil que el neutro.
+  soleado: {
+    humedad: 0,
+    opacidad: 1,
+    tinte: 'saturate(1.06)',
+    velocidadAlas: 1.1,
+    altura: 1,
+  },
+  // La finca duerme: presencia serena, medio tono abajo, aleteo de reposo.
+  noche: {
+    humedad: 0,
+    opacidad: 0.92,
+    tinte: 'saturate(0.9) brightness(0.92)',
+    velocidadAlas: 0.7,
+    altura: 0.9,
+  },
+};
+
+/* Sequía (El Niño resecando un día claro): con sed, tono apagado tierra, alas
+   más lentas. El bajar a buscar sombra ya lo hace reaccionFinca (sed) → altura 1. */
+const SEQUIA_BASE = {
+  humedad: 0,
+  opacidad: 1,
+  tinte: 'saturate(0.72) sepia(0.18) brightness(0.96)',
+  velocidadAlas: 0.8,
+  altura: 1,
+};
+
+/*
+ * PERFILES por especie. Campos (todos con defecto = pasar de largo como la
+ * abeja de referencia, así una llamada SIN perfil se comporta idéntica):
+ *   alas    boolean  ¿tiene aleteo? false → velocidadAlas siempre 1.
+ *   humedad 0..1     cuán visiblemente carga agua (escala `humedad`).
+ *   difusa  0..1     cuánto la disuelve la niebla (escala la CAÍDA de opacidad).
+ *   sequia  0..1     vulnerabilidad a la sequía; 0 = inmune (no reacciona).
+ *   tintes  {clima→str}  sustituye tintes por identidad de especie (opcional).
+ */
+export const PERFIL_ABEJA = Object.freeze({
+  alas: true, humedad: 1, difusa: 1, sequia: 1,
+});
+/* Colibrí: plumas aceitadas que escurren el agua (menos mojado), ágil y
+   pequeño (la niebla lo traga casi como a la abeja), aguanta algo la seca. */
+export const PERFIL_COLIBRI = Object.freeze({
+  alas: true, humedad: 0.55, difusa: 0.9, sequia: 0.7,
+});
+/* Oso andino: pelaje que empapa despacio, mole grande (la niebla apenas lo
+   difumina), robusto ante la seca. Sin alas. */
+export const PERFIL_OSO = Object.freeze({
+  alas: false, humedad: 0.7, difusa: 0.45, sequia: 0.4,
+});
+/* Rana: anfibia — la más brillante mojada y la MÁS golpeada por la sequía
+   (la piel se le reseca). Sin alas. Su tinte de lluvia empuja el verde húmedo. */
+export const PERFIL_RANA = Object.freeze({
+  alas: false, humedad: 1, difusa: 0.85, sequia: 1,
+  tintes: { lluvia: 'saturate(1.2) brightness(1.06) contrast(1.05)' },
+});
+
+/** Registro consultable slug→perfil (para cablear el selector de avatar). */
+export const PERFILES = Object.freeze({
+  'abeja-angelita': PERFIL_ABEJA,
+  colibri: PERFIL_COLIBRI,
+  'oso-andino': PERFIL_OSO,
+  rana: PERFIL_RANA,
+});
+
+function clamp01(n) {
+  return Math.max(0, Math.min(1, n));
+}
+
+/* La sequía manda sobre el brillo del día: El Niño sobre un día claro
+   (mismo criterio de sed de reaccionFinca — coherencia cuerpo↔vuelo). */
+function esSequia(clima, enso) {
+  return enso === 'nino' && (clima === 'soleado' || clima === 'dorada');
+}
+
+/* Aplica el PERFIL de especie sobre una respuesta base de clima. Escala la
+   humedad, atenúa la caída de opacidad, anula el aleteo si no hay alas y deja
+   sustituir el tinte por identidad. Determinista y barato (una vez por cambio
+   de clima, no por frame). */
+function aplicarPerfil(base, perfil, clima, tier) {
+  const humedad = clamp01(base.humedad * (perfil.humedad ?? 1));
+  // opacidad: la creature parte de 1 y la niebla la BAJA; el perfil escala esa
+  // caída (una mole difumina menos). difusa=1 → caída plena; 0 → nunca se borra.
+  const caida = (1 - base.opacidad) * (perfil.difusa ?? 1);
+  const opacidad = clamp01(1 - caida);
+  const velocidadAlas = perfil.alas === false ? 1 : base.velocidadAlas;
+  // tinte: identidad de especie si la define; si no, el canónico. En tier bajo
+  // se poda el blur (raster caro en gama baja): la opacidad sola cuenta la niebla.
+  let tinte = perfil.tintes?.[clima] ?? base.tinte;
+  if (tier === 'bajo' && typeof tinte === 'string' && tinte.includes('blur(')) {
+    tinte = tinte.replace(/\s*blur\([^)]*\)/g, '').trim() || null;
+  }
+  return { humedad, opacidad, tinte, velocidadAlas, altura: base.altura };
+}
+
+/**
+ * Deriva los parámetros de CUERPO de una creature del clima real de la finca.
+ *
+ * @param {('dorada'|'soleado'|'niebla'|'lluvia'|'noche'|null|undefined)} clima
+ *   el clima de escena del `estadoFinca` REAL (mapearClima de useFincaViva).
+ *   Desconocido o ausente → CUERPO_NEUTRO (estado digno, jamás inventado).
+ * @param {object} [opts]
+ * @param {('nino'|'nina'|'neutro')} [opts.enso='neutro'] fase ENSO efectiva —
+ *   El Niño sobre día claro = sequía (tono deshidratado, alas lentas).
+ * @param {('alto'|'medio'|'bajo')} [opts.tier] device-tier: 'bajo' evita blur.
+ * @param {object} [opts.perfil=PERFIL_ABEJA] perfil de especie (ver PERFILES).
+ * @returns {{humedad:number, opacidad:number, tinte:(string|null), velocidadAlas:number, altura:number}}
+ */
+export function cuerpoDeClima(clima, { enso = 'neutro', tier, perfil = PERFIL_ABEJA } = {}) {
+  const p = perfil || PERFIL_ABEJA;
+  // Sequía (Niño + día claro): gana sobre 'dorada'/'soleado' salvo especie
+  // inmune (perfil.sequia === 0), que entonces ve su clima normal.
+  if (esSequia(clima, enso) && (p.sequia ?? 1) > 0) {
+    return aplicarPerfil(SEQUIA_BASE, p, clima, tier);
+  }
+  const base = CLIMA_BASE[clima];
+  if (!base) return CUERPO_NEUTRO; // sin dato / vocabulario desconocido → digno
+  return aplicarPerfil(base, p, clima, tier);
+}
+
+export default cuerpoDeClima;

--- a/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
+++ b/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
@@ -21,6 +21,7 @@ import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaAngelita } from '../../creatures/AbejaAngelita.jsx';
+import { cuerpoDeClima, PERFIL_ABEJA } from '../../creatures/creatureClimaCuerpo.js';
 import { ABEJA_PRESENCIA, ABEJA_TINTA } from '../../creatures/abejaIdentidad.js';
 import { CRUCE_ATRAPA_MS, CRUCE_SUELTA_MS } from '../../creatures/AbejaTransicion.jsx';
 import { useSalidaAbeja, resetSalidaAbeja } from '../../creatures/senalSalidaAbeja.js';
@@ -271,8 +272,23 @@ export function AbejaEscena({
   const mojada = reaccion?.mojada ?? false;
   const sed = reaccion?.sed ?? false;
   const comiendo = reaccion?.comiendo ?? false;
+  // ── EL CLIMA REAL en el CUERPO (creatureClimaCuerpo): del mismo estadoFinca
+  //    salen clima/enso que la creature pinta (tinte, opacidad, aleteo). Aquí solo
+  //    tomamos su `altura` para COMPLEMENTAR la coreografía (niebla vuela corto,
+  //    dorada un poco más alto); se MULTIPLICA con la de reaccionFinca (lluvia/sed
+  //    ya bajan el vuelo) para no doble-contar. El resto lo aplica el dibujo.
+  const climaReal = estadoFinca?.clima ?? null;
+  const ensoReal = estadoFinca?.enso ?? 'neutro';
+  const cuerpoClima = useMemo(
+    () => cuerpoDeClima(climaReal, { enso: ensoReal, tier, perfil: PERFIL_ABEJA }),
+    [climaReal, ensoReal, tier],
+  );
+  const vueloClima = useMemo(() => {
+    const base = reaccion?.vuelo ?? VUELO_NEUTRO;
+    return cuerpoClima.altura === 1 ? base : { ...base, altura: base.altura * cuerpoClima.altura };
+  }, [reaccion, cuerpoClima]);
   const { ref, caraRef, sombraRef, visRef } = useEntradaAbeja(foco, {
-    entrando, energia: energiaReal, reducedMotion, piso, vuelo: reaccion?.vuelo,
+    entrando, energia: energiaReal, reducedMotion, piso, vuelo: vueloClima,
     cruce: cruceVivo, saliendo,
   });
   // Microrrebote: cada toque de hotspot sube `rebote`; reiniciamos la animación
@@ -320,6 +336,8 @@ export function AbejaEscena({
                   mojada={mojada}
                   sed={sed}
                   comiendo={comiendo}
+                  clima={climaReal}
+                  enso={ensoReal}
                   animated={vivo}
                   tier={tier}
                 />


### PR DESCRIPTION
## Qué

El **cuerpo** de las creatures rubber-hose ahora reacciona al **clima REAL** de la finca (el `clima`/`enso` del `estadoFinca` que ya recibe la escena vía `useFincaViva`), no a la muestra hardcodeada:

- **Lluvia** → brillo húmedo + alas pesadas y lentas (el vuelo bajo lo pone `reaccionFinca`).
- **Sequía / El Niño** (día claro) → tono apagado/deshidratado, alas más lentas.
- **Niebla** → silueta difusa (opacidad baja, blur solo en tier alto/medio).
- **Sol / hora dorada** → vibrante, alas rápidas.
- **Noche** → presencia serena, medio tono abajo.
- **Sin dato de clima** → neutro digno (avatares/catálogo se ven idénticos).

## Arquitectura (genérica, no casada con la abeja)

Módulo **NUEVO** `src/visual/creatures/creatureClimaCuerpo.js`: función **pura y determinista** `cuerpoDeClima(clima, { enso, tier, perfil })` → `{ humedad, opacidad, tinte, velocidadAlas, altura }`. Toda la familia rubber-hose comparte el mismo lenguaje CSS/SVG (`.crt-body`, `.crt-wing`, glow/blur), así que la MISMA lógica clima→cuerpo vale para todas; lo único por especie es **cuánto** le pega cada clima → vive en un **PERFIL**:

- `PERFIL_ABEJA` (referencia, primer consumidor)
- `PERFIL_COLIBRI`, `PERFIL_OSO` (andino), `PERFIL_RANA` — más registro `PERFILES` slug→perfil para el futuro selector de avatar.

## Cambios de consumo (mínimos)

- `AbejaAngelita.jsx`: aplica `tinte`+`opacidad` al contorno y modula la duración del aleteo. No se reescribe: solo se leen los params. Props nuevas `clima`/`enso` (opcionales; sin ellas, comportamiento idéntico).
- `useEntradaAbeja.jsx` (`AbejaEscena`): pliega `altura` del clima en el `vuelo` (multiplica con `reaccionFinca`, sin doble-contar) y pasa `clima`/`enso` al cuerpo.

## Reglas cumplidas

- Clima del `estadoFinca` REAL (no hardcode); sin dato → neutro.
- Determinista (cero `Math.random`/reloj en render), frugal por `tier` (sin blur en gama baja), gate `reducedMotion` intacto (aleteo solo con `animated`).
- `creatureClimaCuerpo.js` **no importa `three`** → se queda en el bundle base (2D: home/avatares), no arrastra el chunk `vendor-three`.

## Verificación

- `npm run build` exit 0 (~33 s).
- `npx eslint` de los 3 archivos → 0.
- Smoke tests 3D (`mundoAbejas3D`, `valleEnCalma`, `hiloVidaVista`) → 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)