### PR TITLE
feat(creatures): personalidad idle rubber-hose genérica — Angelita viva

### DIFF
--- a/src/visual/creatures/__tests__/creatureIdle.test.js
+++ b/src/visual/creatures/__tests__/creatureIdle.test.js
@@ -1,0 +1,174 @@
+/*
+ * creatureIdle — la máquina de personalidad idle rubber-hose es PURA y
+ * DETERMINISTA: estos tests fijan ese contrato (misma entrada → misma pose,
+ * cadencia de la vuelta de campana, gates de reduced-motion/tier/noche).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  idleDeCreature, IDLE_PERFILES, IDLE_NEUTRO, semillaDe, azar01, backOut,
+} from '../creatureIdle.js';
+
+/* Barre la línea de tiempo y devuelve los arranques del evento pedido. */
+function arranquesDe(evento, opts, hasta = 140, paso = 0.05) {
+  const inicios = [];
+  let dentro = false;
+  for (let t = 0; t < hasta; t += paso) {
+    const es = idleDeCreature(t, opts).evento === evento;
+    if (es && !dentro) inicios.push(t);
+    dentro = es;
+  }
+  return inicios;
+}
+
+describe('creatureIdle — determinismo', () => {
+  it('misma entrada → exactamente la misma pose (cero azar por frame)', () => {
+    for (const t of [0.4, 7.77, 21.3, 39.9, 88.1]) {
+      const a = idleDeCreature(t, { especie: 'abeja-angelita', hora: 'dorada' });
+      const b = idleDeCreature(t, { especie: 'abeja-angelita', hora: 'dorada' });
+      expect(b).toEqual(a);
+    }
+  });
+
+  it('cada especie tiene semilla propia y estable (nunca sincronizan)', () => {
+    expect(semillaDe('abeja-angelita')).toBe(semillaDe('abeja-angelita'));
+    expect(semillaDe('abeja-angelita')).not.toBe(semillaDe('colibri'));
+    expect(azar01(1, 2, 3)).toBe(azar01(1, 2, 3));
+    expect(azar01(1, 2, 3)).toBeGreaterThanOrEqual(0);
+    expect(azar01(1, 2, 3)).toBeLessThan(1);
+  });
+});
+
+describe('creatureIdle — repertorio de Angelita', () => {
+  const opts = { especie: 'abeja-angelita', hora: 'dorada' };
+
+  it('vuelta de campana cada ~18-22 s (y nunca en el ciclo 0)', () => {
+    const v = IDLE_PERFILES['abeja-angelita'].vuelta;
+    const inicios = arranquesDe('vuelta', opts);
+    expect(inicios.length).toBeGreaterThanOrEqual(3);
+    expect(inicios[0]).toBeGreaterThanOrEqual(v.base); // warmup: nadie gira al nacer
+    for (let i = 1; i < inicios.length; i++) {
+      const gap = inicios[i] - inicios[i - 1];
+      // separación ~base (±jitter); si una vuelta cede su turno por solapar
+      // con una percha, el gap es un múltiplo del período (nunca arbitrario)
+      const n = Math.round(gap / v.base);
+      expect(n).toBeGreaterThanOrEqual(1);
+      expect(n).toBeLessThanOrEqual(3);
+      expect(Math.abs(gap - n * v.base)).toBeLessThanOrEqual(v.jitter + 0.3);
+    }
+  });
+
+  it('la vuelta anticipa (rot negativa), se pasa de rosca y asienta en 360', () => {
+    const v = IDLE_PERFILES['abeja-angelita'].vuelta;
+    // localizar una vuelta REAL (ya resuelta contra los otros carriles) con
+    // detección fina, y muestrear su fase completa
+    const [ini] = arranquesDe('vuelta', opts, 90, 0.01);
+    expect(ini).toBeDefined();
+    const rots = [];
+    for (let f = 0.02; f < 0.99; f += 0.02) rots.push(idleDeCreature(ini + f * v.dur, opts).rot);
+    expect(Math.min(...rots.slice(0, 5))).toBeLessThan(0);   // anticipación: se arma hacia atrás
+    expect(Math.max(...rots)).toBeGreaterThan(v.grados);     // se pasa de rosca (overshoot)
+    expect(Math.abs(rots[rots.length - 1] - v.grados)).toBeLessThanOrEqual(25); // asienta hacia 360≡0
+  });
+
+  it('se posa (percha → pose reposo, posada=1) y despega con overshoot', () => {
+    const inicios = arranquesDe('percha', opts, 200);
+    expect(inicios.length).toBeGreaterThanOrEqual(2);
+    const p = IDLE_PERFILES['abeja-angelita'].percha;
+    const mitad = idleDeCreature(inicios[0] + p.dur * 0.5, opts);
+    expect(mitad.evento).toBe('percha');
+    expect(mitad.pose).toBe('reposo');
+    expect(mitad.posada).toBe(1);
+    // en el despegue la posada asoma negativa un instante (el brinquito)
+    let hop = 0;
+    for (let f = 0.8; f < 1; f += 0.01) {
+      hop = Math.min(hop, idleDeCreature(inicios[0] + p.dur * f, opts).posada);
+    }
+    expect(hop).toBeLessThan(0);
+  });
+
+  it('se asea de vez en cuando (rasca o sacude, decidido por ciclo)', () => {
+    const eventos = new Set();
+    for (let t = 0; t < 300; t += 0.05) eventos.add(idleDeCreature(t, opts).evento);
+    expect(eventos.has('rasca') || eventos.has('sacude')).toBe(true);
+  });
+
+  it('respira siempre: squash & stretch sutil en contrafase', () => {
+    const r = idleDeCreature(3.3, opts); // temprano: ningún evento programado
+    expect(r.evento).toBe('respira');
+    expect(r.activo).toBe(true);
+    expect(Math.abs(r.sx - 1)).toBeLessThan(0.08);
+    expect(Math.sign(r.sx - 1)).toBe(-Math.sign(r.sy - 1)); // contrafase
+  });
+
+  it('celebra al llegar: pose celebra, giro con overshoot y rebotico', () => {
+    const dur = IDLE_PERFILES['abeja-angelita'].celebra.dur;
+    const c = idleDeCreature(50, { ...opts, llegadaHace: dur * 0.5 });
+    expect(c.pose).toBe('celebra');
+    expect(c.evento).toBe('celebra');
+    expect(c.rot).toBeGreaterThan(180);
+    expect(c.sy).toBeGreaterThan(1);
+    // pasada la ventana, vuelve al repertorio normal
+    expect(idleDeCreature(50, { ...opts, llegadaHace: dur + 0.1 }).evento).not.toBe('celebra');
+  });
+});
+
+describe('creatureIdle — gates (noche, reduced-motion, tier)', () => {
+  it('de noche se acurruca: reposo, posada, y CERO piruetas', () => {
+    for (let t = 0; t < 120; t += 0.5) {
+      const n = idleDeCreature(t, { especie: 'abeja-angelita', hora: 'noche' });
+      expect(n.pose).toBe('reposo');
+      expect(n.posada).toBe(1);
+      expect(n.evento).toBe('acurruca');
+    }
+  });
+
+  it('reducedMotion → pose calma ESTÁTICA, activo=false (nadie pide frames)', () => {
+    const dia = idleDeCreature(33, { reducedMotion: true, hora: 'dorada' });
+    expect(dia).toEqual(IDLE_NEUTRO);
+    const noche = idleDeCreature(33, { reducedMotion: true, hora: 'noche' });
+    expect(noche.activo).toBe(false);
+    expect(noche.pose).toBe('reposo');
+    expect(noche.sx).toBe(1);
+    expect(noche.rot).toBe(0);
+  });
+
+  it('tier bajo = frugal: solo respiración, sin giros ni perchas', () => {
+    for (let t = 0; t < 120; t += 0.5) {
+      const b = idleDeCreature(t, { especie: 'abeja-angelita', tier: 'bajo' });
+      expect(b.evento).toBe('respira');
+      expect(b.rot).toBe(0);
+    }
+  });
+});
+
+describe('creatureIdle — genérica por especie (misma máquina, otro animal)', () => {
+  it('los cuatro perfiles de la casa existen y declaran su medio', () => {
+    for (const slug of ['abeja-angelita', 'colibri', 'oso-andino', 'rana-dorada']) {
+      expect(IDLE_PERFILES[slug]).toBeDefined();
+      expect(['aire', 'suelo']).toContain(IDLE_PERFILES[slug].medio);
+      expect(IDLE_PERFILES[slug].poseBase).toBeTruthy();
+    }
+  });
+
+  it('el oso anda (poseBase de suelo) y su timeline NO calca la de la abeja', () => {
+    const oso = idleDeCreature(3.3, { especie: 'oso-andino' });
+    expect(oso.pose).toBe('anda');
+    const vueltasOso = arranquesDe('vuelta', { especie: 'oso-andino' });
+    const vueltasAbeja = arranquesDe('vuelta', { especie: 'abeja-angelita' });
+    expect(vueltasOso).not.toEqual(vueltasAbeja);
+  });
+
+  it('especie desconocida cae al perfil de Angelita (nunca undefined)', () => {
+    const x = idleDeCreature(3.3, { especie: 'quimera-inexistente', semilla: 7 });
+    expect(x.pose).toBe('vuela');
+    expect(x.activo).toBe(true);
+  });
+
+  it('backOut asienta en 1 con pasada por encima en el camino', () => {
+    expect(backOut(1)).toBeCloseTo(1, 6);
+    expect(backOut(0)).toBeCloseTo(0, 6);
+    let pico = 0;
+    for (let x = 0; x <= 1; x += 0.01) pico = Math.max(pico, backOut(x));
+    expect(pico).toBeGreaterThan(1.02); // el overshoot rubber-hose
+  });
+});

--- a/src/visual/creatures/creatureIdle.js
+++ b/src/visual/creatures/creatureIdle.js
@@ -1,0 +1,292 @@
+/*
+ * creatureIdle — LA PERSONALIDAD IDLE de la familia rubber-hose, como funciones
+ * PURAS y DETERMINISTAS (cero Math.random en render, cero three, cero react).
+ *
+ * Es la MISMA máquina de micro-comportamientos para cualquier personaje del
+ * estilo (Cuphead / Miss Minutes): dado el tiempo del reloj de la escena, una
+ * semilla, la hora del día y el perfil de la especie, devuelve la POSE del
+ * instante. Llamarla dos veces con los mismos argumentos da EXACTO lo mismo:
+ * los "eventos" (rascarse, vuelta de campana, posarse) no se sortean por frame
+ * — se derivan con un hash entero de (semilla, evento, número de ciclo), así
+ * que la línea de tiempo completa de cada criatura está decidida de antemano
+ * y aun así se siente impredecible (jitter por ciclo, períodos co-primos).
+ *
+ * REPERTORIO (species-agnostic; el perfil gradúa períodos y amplitudes):
+ *   respira   → squash & stretch sutil continuo (la línea que respira).
+ *   rasca     → se ladea a rascarse (jiggle de patita que decae).
+ *   sacude    → sacudida corta de todo el cuerpo (perro mojado, decae).
+ *   vuelta    → la vuelta de campana juguetona (~18-22 s en Angelita):
+ *               anticipación → giro pasado de rosca → asienta el overshoot.
+ *   percha    → se posa (en una flor/hoja los voladores; se sienta los de
+ *               suelo) y despega con un brinquito de overshoot.
+ *   celebra   → al llegar a un mundo: giro alegre con overshoot + rebotico.
+ *   acurruca  → de noche (hora de cielosHoraData) se recoge y respira hondo.
+ *
+ * CONTRATO con el consumidor (la escena/hook que posee el cuerpo):
+ *   { pose, sx, sy, rot, dy, posada, activo, evento }
+ *   pose    slug discreto para data-pose del svg ('celebra'/'reposo' ya tienen
+ *           CSS en creatures.css; la base es del perfil: 'vuela'/'anda').
+ *   sx/sy   escala squash&stretch (aplicar como transform CSS del billboard).
+ *   rot     grados de giro en el plano (vuelta/celebración/ladeos).
+ *   dy      brinquito vertical en unidades de mundo (pequeño).
+ *   posada  0..1 cuánto bajó a su percha (1 = sentada; puede asomar negativo
+ *           un instante: el saltito de despegue). El consumidor la usa para
+ *           atenuar altura/vagar/bob.
+ *   activo  hay animación idle corriendo → con frameloop='demand' el consumidor
+ *           debe invalidate() SOLO mientras esto sea true.
+ *
+ * QUIÉN ES QUIÉN: la IDENTIDAD (paleta/medidas) sigue en abejaIdentidad.js y
+ * _faunaRubberTokens.js; la CADENCIA CSS en creatures.css. Aquí vive SOLO la
+ * conducta en el tiempo, parametrizada por especie: Angelita la estrena, y el
+ * oso andino, el colibrí y la rana dorada (los otros rubber-hose de la casa)
+ * entran con su perfil sin tocar la máquina.
+ *
+ * reducedMotion → pose CALMA estática (de noche, acurrucada quieta), activo
+ * false: nada anima y nadie pide frames. Tier 'bajo' → solo la respiración.
+ */
+
+/* ── Deterministas: hash entero → [0,1) por (semilla, evento, ciclo) ─────── */
+
+/** Semilla estable por especie (hash del slug — dos especies nunca sincronizan). */
+export function semillaDe(especie) {
+  let h = 9;
+  for (let i = 0; i < especie.length; i++) h = (Math.imul(h, 31) + especie.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+function hashU32(a, b, c) {
+  let h = (Math.imul(a, 374761393) + Math.imul(b, 668265263) + Math.imul(c, 2246822519)) >>> 0;
+  h = Math.imul(h ^ (h >>> 13), 1274126177) >>> 0;
+  return (h ^ (h >>> 16)) >>> 0;
+}
+
+/** Pseudoazar determinista en [0,1) para el ciclo `k` del evento `id`. */
+export function azar01(semilla, id, k) {
+  return hashU32(semilla >>> 0, id, k) / 4294967296;
+}
+
+/* Suavizados clásicos del squash & stretch. */
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+const suave = (x) => { const c = clamp01(x); return c * c * (3 - 2 * c); }; // smoothstep
+/** Ease back-out: pasa de largo (~+10%) y asienta — EL overshoot rubber-hose. */
+export function backOut(x) {
+  const c = 2.04; const u = clamp01(x) - 1;
+  return 1 + u * u * ((c + 1) * u + c);
+}
+
+/**
+ * Ventana determinista del evento `id`: el ciclo k ocupa el tramo
+ * [k·base, (k+1)·base) y el evento arranca en k·base + azar·jitter, dura `dur`.
+ * Separación entre ocurrencias ∈ [base−jitter, base+jitter] (p. ej. la vuelta
+ * de Angelita: base 20, jitter 2 → cada ~18-22 s). El ciclo 0 se salta: nadie
+ * hace piruetas nada más nacer (warmup de un período completo).
+ * @returns {{f:number,k:number}|null} fase 0..1 dentro del evento, o null.
+ */
+export function ventana(t, semilla, id, { base, jitter, dur }) {
+  const k = Math.floor(t / base);
+  if (k <= 0) return null;
+  const inicio = k * base + azar01(semilla, id, k) * jitter;
+  const f = (t - inicio) / dur;
+  return f >= 0 && f < 1 ? { f, k } : null;
+}
+
+/* Ids internos de la línea de tiempo (solo etiquetas del hash). */
+const EV = { vuelta: 3, aseo: 4, tipoAseo: 5, percha: 6 };
+/* Carriles de eventos, cada uno con su período propio (se resuelven por orden
+   de arranque — ver idleDeCreature — para que nunca se pisen a mitad de gesto). */
+const CARRILES = [
+  { tipo: 'percha', id: EV.percha },
+  { tipo: 'vuelta', id: EV.vuelta },
+  { tipo: 'aseo', id: EV.aseo },
+];
+
+/* ── Perfiles por especie: la MISMA máquina, otro animal ─────────────────────
+   medio 'aire' (vuela: se posa en flor/hoja) | 'suelo' (anda: se sienta).
+   respira {freq, amp, vaiven} · vuelta {base, jitter, dur, grados, anticipo}
+   aseo {base, jitter, dur} · percha {base, jitter, dur} · celebra {dur, grados}
+   noche {freq, amp, rot} — la respiración honda del acurruque. */
+export const IDLE_PERFILES = {
+  /* Tetragonisca angustula — inquieta, giro rápido, se posa seguido. */
+  'abeja-angelita': {
+    medio: 'aire', poseBase: 'vuela',
+    respira: { freq: 2.0, amp: 0.038, vaiven: 0.31 },
+    vuelta: { base: 20, jitter: 2, dur: 1.15, grados: 360, anticipo: 26 },
+    aseo: { base: 11, jitter: 3, dur: 0.9 },
+    percha: { base: 38, jitter: 6, dur: 6.5 },
+    celebra: { dur: 1.6, grados: 360 },
+    noche: { freq: 0.9, amp: 0.055, rot: -6 },
+  },
+  /* Colibri coruscans — todavía más nervioso: todo late más rápido. */
+  colibri: {
+    medio: 'aire', poseBase: 'vuela',
+    respira: { freq: 2.7, amp: 0.03, vaiven: 0.43 },
+    vuelta: { base: 16, jitter: 2, dur: 0.85, grados: 360, anticipo: 20 },
+    aseo: { base: 9, jitter: 2.5, dur: 0.7 },
+    percha: { base: 30, jitter: 5, dur: 5 },
+    celebra: { dur: 1.2, grados: 360 },
+    noche: { freq: 1.1, amp: 0.045, rot: -5 },
+  },
+  /* Tremarctos ornatus — pesado y entrañable: respira hondo, voltereta lenta,
+     se rasca la panza largo y se sienta un buen rato. */
+  'oso-andino': {
+    medio: 'suelo', poseBase: 'anda',
+    respira: { freq: 1.05, amp: 0.05, vaiven: 0.23 },
+    vuelta: { base: 36, jitter: 4, dur: 1.9, grados: 360, anticipo: 18 },
+    aseo: { base: 14, jitter: 4, dur: 1.5 },
+    percha: { base: 46, jitter: 8, dur: 9 },
+    celebra: { dur: 2.0, grados: 360 },
+    noche: { freq: 0.55, amp: 0.07, rot: -8 },
+  },
+  /* Phyllobates terribilis — la garganta late; su "vuelta" es la voltereta
+     de brinco y su percha, quedarse quieta en la hoja (es lo suyo). */
+  'rana-dorada': {
+    medio: 'suelo', poseBase: 'anda',
+    respira: { freq: 1.7, amp: 0.06, vaiven: 0.37 },
+    vuelta: { base: 26, jitter: 3, dur: 1.0, grados: 360, anticipo: 22 },
+    aseo: { base: 12, jitter: 3, dur: 0.8 },
+    percha: { base: 24, jitter: 5, dur: 8 },
+    celebra: { dur: 1.4, grados: 360 },
+    noche: { freq: 0.8, amp: 0.06, rot: -4 },
+  },
+};
+
+/* Overshoot del giro (grados que se pasa antes de asentar). */
+const PASADA = 24;
+
+/** Pose neutra congelada (reduced-motion de día, o durante el cruce 2D→3D). */
+export const IDLE_NEUTRO = Object.freeze({
+  pose: 'vuela', sx: 1, sy: 1, rot: 0, dy: 0, posada: 0, activo: false, evento: null,
+});
+/* Calma nocturna estática (reduced-motion de noche): acurrucada, sin animar. */
+const IDLE_CALMA_NOCHE = Object.freeze({
+  pose: 'reposo', sx: 1, sy: 1, rot: 0, dy: 0, posada: 0, activo: false, evento: 'acurruca',
+});
+
+/**
+ * LA MÁQUINA: pose idle del instante `t` para una especie rubber-hose.
+ * Pura y determinista — misma entrada, misma pose.
+ *
+ * @param {number} t  segundos del reloj de la escena (state.clock.elapsedTime).
+ * @param {object} [opts]
+ * @param {string} [opts.especie='abeja-angelita']  slug del perfil (IDLE_PERFILES).
+ * @param {number} [opts.semilla]  override de la semilla (default: semillaDe(especie)).
+ * @param {string} [opts.hora='dorada']  hora de cielosHoraData ('noche' → acurruca).
+ * @param {boolean} [opts.reducedMotion=false]  pose calma estática, activo=false.
+ * @param {string} [opts.tier='alto']  'bajo' → solo respiración (frugal).
+ * @param {number|null} [opts.llegadaHace=null]  segundos desde que llegó a su
+ *   percha en un mundo nuevo (dispara la CELEBRACIÓN); null = no aplica.
+ * @returns {{pose:string,sx:number,sy:number,rot:number,dy:number,posada:number,activo:boolean,evento:string|null}}
+ */
+export function idleDeCreature(t, {
+  especie = 'abeja-angelita', semilla, hora = 'dorada', reducedMotion = false,
+  tier = 'alto', llegadaHace = null,
+} = {}) {
+  const p = IDLE_PERFILES[especie] || IDLE_PERFILES['abeja-angelita'];
+  const deNoche = hora === 'noche';
+  if (reducedMotion) return deNoche ? IDLE_CALMA_NOCHE : IDLE_NEUTRO;
+  const s = (semilla ?? semillaDe(especie)) >>> 0;
+
+  // CELEBRA — llegó a un mundo: giro alegre pasado de rosca + rebotico de gozo.
+  // Gana a todo (hasta de noche se alegra un segundo antes de acurrucarse).
+  if (llegadaHace !== null && llegadaHace >= 0 && llegadaHace < p.celebra.dur) {
+    const f = llegadaHace / p.celebra.dur;
+    return {
+      pose: 'celebra',
+      sx: 1 + 0.1 * Math.sin(Math.PI * f),
+      sy: 1 + 0.16 * Math.sin(Math.PI * f),
+      rot: p.celebra.grados * backOut(f / 0.82),
+      dy: 0.1 * Math.sin(Math.PI * f),
+      posada: 0, activo: true, evento: 'celebra',
+    };
+  }
+
+  // ACURRUCA — de noche se recoge: baja del todo (posada=1), cabecita metida,
+  // respiración honda y lenta. Nada de piruetas: el valle duerme.
+  if (deNoche) {
+    const r = Math.sin(t * p.noche.freq);
+    return {
+      pose: 'reposo',
+      sx: 1 + p.noche.amp * r,
+      sy: 1 - p.noche.amp * 1.25 * r,
+      rot: p.noche.rot + 1.5 * Math.sin(t * p.noche.freq * 0.5),
+      dy: 0, posada: 1, activo: true, evento: 'acurruca',
+    };
+  }
+
+  // RESPIRA — el squash & stretch de base (dos ondas que nunca comparten
+  // compás): sobre él se montan los demás eventos.
+  const resp = Math.sin(t * p.respira.freq) * (1 + 0.35 * Math.sin(t * p.respira.vaiven));
+  let sx = 1 + p.respira.amp * resp;
+  let sy = 1 - p.respira.amp * 1.3 * resp;
+
+  // Tier bajo: frugal — respira y nada más (los antics CSS ya están apagados).
+  if (tier === 'bajo') {
+    return { pose: p.poseBase, sx, sy, rot: 0, dy: 0, posada: 0, activo: true, evento: 'respira' };
+  }
+
+  // ── LÍNEA DE TIEMPO: los tres carriles (percha / vuelta / aseo) tienen
+  //    períodos propios y pueden solaparse. Resolución SIN pre-empciones (cero
+  //    saltos de pose a mitad de gesto), derivada solo de t (pura):
+  //      1. entre los activos gana el que ARRANCÓ primero;
+  //      2. un evento solo VALE si arrancó en silencio (ningún otro carril
+  //         corriendo en su instante de arranque) — si no, se salta entero.
+  const activos = [];
+  for (const carril of CARRILES) {
+    const cfg = p[carril.tipo];
+    const v = ventana(t, s, carril.id, cfg);
+    if (v) activos.push({ tipo: carril.tipo, id: carril.id, cfg, f: v.f, k: v.k, inicio: t - v.f * cfg.dur });
+  }
+  activos.sort((a, b) => a.inicio - b.inicio);
+  let ev = null;
+  for (const cand of activos) {
+    const bloqueado = CARRILES.some((otro) => {
+      if (otro.id === cand.id) return false;
+      const w = ventana(cand.inicio, s, otro.id, p[otro.tipo]);
+      return w !== null && w.f > 0; // otro carril ya corría cuando este arrancó
+    });
+    if (!bloqueado) { ev = cand; break; }
+  }
+
+  // PERCHA — baja a posarse (flor/hoja los de aire; se sienta los de suelo),
+  // reposa con las alitas plegadas y despega con brinquito de overshoot
+  // (posada asoma negativa un instante = el hop).
+  if (ev && ev.tipo === 'percha') {
+    let posada; let pose = p.poseBase;
+    if (ev.f < 0.18) posada = suave(ev.f / 0.18);
+    else if (ev.f < 0.8) { posada = 1; pose = 'reposo'; }
+    else {
+      const d = (ev.f - 0.8) / 0.2;
+      posada = 1 - backOut(d);
+      sy *= 1 + 0.1 * Math.sin(Math.PI * d); // el estirón del despegue
+    }
+    return { pose, sx, sy, rot: 0, dy: 0, posada, activo: true, evento: 'percha' };
+  }
+
+  // VUELTA DE CAMPANA — anticipación (se arma hacia atrás), giro completo
+  // pasado de rosca, y asienta el overshoot. Termina EXACTO en grados≡0.
+  if (ev && ev.tipo === 'vuelta') {
+    const A = p.vuelta.anticipo;
+    let rot;
+    if (ev.f < 0.16) rot = -A * suave(ev.f / 0.16);
+    else if (ev.f < 0.88) rot = -A + (p.vuelta.grados + A + PASADA) * suave((ev.f - 0.16) / 0.72);
+    else rot = p.vuelta.grados + PASADA * (1 - suave((ev.f - 0.88) / 0.12));
+    sx *= 1 + 0.08 * Math.sin(Math.PI * clamp01((ev.f - 0.16) / 0.72)); // smear del giro
+    return { pose: p.poseBase, sx, sy, rot, dy: 0, posada: 0, activo: true, evento: 'vuelta' };
+  }
+
+  // ASEO — rascarse (se ladea, jiggle de patita) o sacudirse (perro mojado);
+  // cuál toca lo decide el hash del ciclo, y ambos DECAEN (no cortan en seco).
+  if (ev && ev.tipo === 'aseo') {
+    const cae = 1 - suave(ev.f);
+    if (azar01(s, EV.tipoAseo, ev.k) < 0.5) {
+      const rot = -9 * Math.sin(Math.PI * Math.min(1, ev.f * 1.15));
+      sy *= 1 + 0.04 * Math.sin(ev.f * Math.PI * 10) * cae;
+      return { pose: p.poseBase, sx, sy, rot, dy: 0, posada: 0, activo: true, evento: 'rasca' };
+    }
+    const rot = 13 * Math.sin(ev.f * Math.PI * 7) * cae;
+    sx *= 1 + 0.05 * Math.sin(ev.f * Math.PI * 14) * cae;
+    return { pose: p.poseBase, sx, sy, rot, dy: 0, posada: 0, activo: true, evento: 'sacude' };
+  }
+
+  return { pose: p.poseBase, sx, sy, rot: 0, dy: 0, posada: 0, activo: true, evento: 'respira' };
+}

--- a/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
+++ b/src/visual/mundo3d/escenas/useEntradaAbeja.jsx
@@ -22,6 +22,8 @@ import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaAngelita } from '../../creatures/AbejaAngelita.jsx';
 import { ABEJA_PRESENCIA, ABEJA_TINTA } from '../../creatures/abejaIdentidad.js';
+import { idleDeCreature, IDLE_NEUTRO } from '../../creatures/creatureIdle.js';
+import { horaDeReloj } from '../cielosHoraData.js';
 import { CRUCE_ATRAPA_MS, CRUCE_SUELTA_MS } from '../../creatures/AbejaTransicion.jsx';
 import { useSalidaAbeja, resetSalidaAbeja } from '../../creatures/senalSalidaAbeja.js';
 import { SombraContacto } from './SombraContacto.jsx';
@@ -98,15 +100,27 @@ function puntoDeCruce(camera, foco, out) {
  *   al <Html> (drei no hereda la visibilidad del group al portal DOM).
  * @param {boolean} [opts.saliendo=false]  el reverso 3D→2D: vuela al punto de
  *   suelta y se apaga en CRUCE_SUELTA_MS (el overlay 'volver' la retoma ahí).
+ * @param {string}  [opts.hora='dorada']  hora de cielosHoraData: de 'noche'
+ *   Angelita se ACURRUCA (idle nocturno de creatureIdle).
+ * @param {string}  [opts.tier='alto']  'bajo' → idle frugal (solo respiración).
  */
 export function useEntradaAbeja(foco, {
   entrando = true, energia = 1, reducedMotion = false, piso = 0, vuelo = VUELO_NEUTRO,
-  cruce = false, saliendo = false,
+  cruce = false, saliendo = false, hora = 'dorada', tier = 'alto',
 } = {}) {
   const ref = useRef(null);
   const caraRef = useRef(null);
   const sombraRef = useRef(null);
   const visRef = useRef(null);
+  // ── PERSONALIDAD IDLE (creatureIdle.js): la capa DOM que recibe el squash &
+  //    stretch/giros (idleRef, hermana del volteo para no pelear con su
+  //    transition CSS), el reloj de llegada (dispara la CELEBRACIÓN), y cachés
+  //    imperativos (string del transform + pose discreta + nodo del svg) para
+  //    escribir al DOM SOLO cuando algo cambió.
+  const idleRef = useRef(null);
+  const llegoEn = useRef(null);
+  const ultimoTf = useRef('');
+  const ultimaPose = useRef('vuela');
   const nacioEn = useRef(null); // reloj del primer frame (ancla del cruce)
   // Fase del cruce de entrada: 'oculta' (pre-atrape) → 'picada' → 'no'.
   // Se decide UNA vez al nacer: si el mesh ya vive, cambiar props no re-cruza.
@@ -160,6 +174,16 @@ export function useEntradaAbeja(foco, {
       fase.current = 'no';
     }
     const empuje = fase.current === 'picada' ? CRUCE_EMPUJE : 1;
+    // ── PERSONALIDAD IDLE (creatureIdle): respira, se rasca/sacude, vuelta de
+    //    campana ~18-22 s, se posa en una flor y despega, celebra al llegar,
+    //    se acurruca de noche. PURA y determinista (t + semilla + hora); en
+    //    pleno cruce va NEUTRA (nadie da piruetas en picada). reducedMotion
+    //    devuelve la pose calma estática (activo=false → cero invalidate).
+    const idle = fase.current !== 'no' ? IDLE_NEUTRO : idleDeCreature(t, {
+      especie: 'abeja-angelita', hora, reducedMotion, tier,
+      llegadaHace: llegoEn.current === null ? null : t - llegoEn.current,
+    });
+    const quieta = Math.max(0, idle.posada);
     // El estado de la finca modula el vuelo: mojada pesa (baja/lenta), sed baja a
     // buscar agua, comiendo tiembla mordisqueando. Multiplicadores de reaccionDeFinca.
     const mAltura = vuelo?.altura ?? 1;
@@ -189,11 +213,14 @@ export function useEntradaAbeja(foco, {
       : (Math.cos(t * 0.55) * 0.3 + Math.sin(t * 0.83 + 1.7) * 0.14) * mVagar;
     // La altura sobre el foco se atenúa con `mAltura` (mojada/sed vuelan más bajo).
     // La percha y la altura de ronda son de la IDENTIDAD compartida (abejaIdentidad).
-    const alto = (entrando ? PERCHA.y : ABEJA_PRESENCIA.rondaAltura) * mAltura;
+    //    `idle.posada` la baja a su percha idle (flor/hoja: la altura se recoge
+    //    a ~28%) y aquieta el vagar y el bob (posada no ronda ni flota); su
+    //    asomo negativo al despegar es el brinquito de overshoot.
+    const alto = (entrando ? PERCHA.y : ABEJA_PRESENCIA.rondaAltura) * mAltura * (1 - 0.72 * idle.posada);
     const dest = _dest.set(
-      foco.x + (entrando ? PERCHA.x : 0.35 + vagarX) + tembleque + arrebato * (entrando ? 0.3 : 1),
-      foco.y + alto + bob + tembleque * 0.5 + arrebato * 0.18,
-      foco.z + (entrando ? PERCHA.z : 0.55 + vagarZ),
+      foco.x + (entrando ? PERCHA.x : 0.35 + vagarX * (1 - quieta)) + tembleque + arrebato * (entrando ? 0.3 : 1),
+      foco.y + alto + bob * (1 - 0.85 * quieta) + idle.dy + tembleque * 0.5 + arrebato * 0.18,
+      foco.z + (entrando ? PERCHA.z : 0.55 + vagarZ * (1 - quieta)),
     );
     ref.current.position.lerp(dest, (entrando ? 0.06 : 0.05) * mVel * empuje);
     // Angelita se posa: al cruzar el umbral de llegada al foco, un roce háptico
@@ -201,6 +228,7 @@ export function useEntradaAbeja(foco, {
     // apaga todo con reduced-motion, pref 'off' o sin soporte).
     if (entrando && posadaEn.current !== foco && ref.current.position.distanceTo(dest) < 0.3) {
       posadaEn.current = foco;
+      llegoEn.current = t; // arranca la CELEBRACIÓN idle (giro alegre + overshoot)
       haptics.abeja();
     }
     if (caraRef.current) {
@@ -208,6 +236,21 @@ export function useEntradaAbeja(foco, {
       if (Math.abs(vx) > 0.0015) caraRef.current.style.transform = `scaleX(${vx < 0 ? -1 : 1})`;
       prevX.current = ref.current.position.x;
     }
+    // El idle se ESCRIBE al DOM en su propia capa (no pisa el volteo ni su
+    // transition): un solo style-write, cacheado por string — sin animación
+    // activa la cadena no cambia y el DOM no se toca. La pose discreta viaja
+    // como data-pose al svg del cuerpo ('celebra'/'reposo' tienen CSS propio).
+    if (idleRef.current) {
+      const tf = `rotate(${idle.rot.toFixed(1)}deg) scale(${idle.sx.toFixed(3)},${idle.sy.toFixed(3)})`;
+      if (tf !== ultimoTf.current) { ultimoTf.current = tf; idleRef.current.style.transform = tf; }
+      if (idle.pose !== ultimaPose.current) {
+        ultimaPose.current = idle.pose;
+        idleRef.current.setAttribute('data-pose', idle.pose);
+      }
+    }
+    // frameloop='demand' respetado: pedir el próximo frame SOLO mientras el
+    // idle anima (con reduced-motion activo=false → nadie pide nada).
+    if (idle.activo) state.invalidate();
     // La sombra de contacto la sigue por el piso: más alto vuela, más ancha y
     // más tenue (peso visual sin shadow-maps). Mismo frame, cero loops extra.
     if (sombraRef.current) {
@@ -218,7 +261,7 @@ export function useEntradaAbeja(foco, {
       sombraRef.current.material.opacity = Math.max(SOMBRA.opacidadMin, SOMBRA.opacidadBase - h * SOMBRA.atenuaPorAltura);
     }
   });
-  return { ref, caraRef, sombraRef, visRef };
+  return { ref, caraRef, sombraRef, visRef, idleRef };
 }
 
 /**
@@ -271,9 +314,13 @@ export function AbejaEscena({
   const mojada = reaccion?.mojada ?? false;
   const sed = reaccion?.sed ?? false;
   const comiendo = reaccion?.comiendo ?? false;
-  const { ref, caraRef, sombraRef, visRef } = useEntradaAbeja(foco, {
+  // La hora del valle (cielosHoraData, franja andina estable): de noche el
+  // idle la ACURRUCA. Se lee UNA vez al montar — la escena vive minutos, y el
+  // idle es determinista respecto de sus entradas (nada de reloj en render).
+  const hora = useMemo(() => horaDeReloj(), []);
+  const { ref, caraRef, sombraRef, visRef, idleRef } = useEntradaAbeja(foco, {
     entrando, energia: energiaReal, reducedMotion, piso, vuelo: reaccion?.vuelo,
-    cruce: cruceVivo, saliendo,
+    cruce: cruceVivo, saliendo, hora, tier,
   });
   // Microrrebote: cada toque de hotspot sube `rebote`; reiniciamos la animación
   // CSS (quitar → reflow → poner) para que dispare aun en toques seguidos. El
@@ -312,17 +359,26 @@ export function AbejaEscena({
             data-comiendo={comiendo && vivo ? '1' : undefined}
           >
             <div ref={reboteRef} className="mundo-abeja__rebote">
-              <div ref={caraRef} className="mundo-abeja__cara">
-                <AbejaAngelita
-                  size={size}
-                  animo={animoReal}
-                  energia={energiaReal}
-                  mojada={mojada}
-                  sed={sed}
-                  comiendo={comiendo}
-                  animated={vivo}
-                  tier={tier}
-                />
+              {/* Cuarta capa de gesto: el IDLE (squash&stretch, vueltas de
+                  campana, celebración) — imperativa por frame desde el hook.
+                  Propia para no pisar la transition del volteo de la cara;
+                  transform-origin default (center) = gira sobre sí misma.
+                  Lleva data-creature para que el hook le cuelgue data-pose
+                  ('celebra'/'reposo', CSS de creatures.css por descendencia)
+                  SIN tocar el svg, que React re-renderiza a su aire. */}
+              <div ref={idleRef} className="mundo-abeja__idle" data-creature="abeja-angelita">
+                <div ref={caraRef} className="mundo-abeja__cara">
+                  <AbejaAngelita
+                    size={size}
+                    animo={animoReal}
+                    energia={energiaReal}
+                    mojada={mojada}
+                    sed={sed}
+                    comiendo={comiendo}
+                    animated={vivo}
+                    tier={tier}
+                  />
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Qué hace

**Máquina de personalidad idle** para la familia rubber-hose, como funciones PURAS y DETERMINISTAS en un archivo nuevo (`src/visual/creatures/creatureIdle.js`), parametrizada por especie: `abeja-angelita` (primer consumidor), `colibri`, `oso-andino` y `rana-dorada` entran con su perfil sin tocar la máquina.

### Repertorio (species-agnostic, el perfil gradúa períodos/amplitudes)
- **Respira**: squash & stretch sutil continuo (dos ondas que no comparten compás).
- **Se rasca / se sacude** de vez en cuando (decaen, no cortan en seco).
- **Vuelta de campana** cada ~18-22 s: anticipación → giro pasado de rosca → asienta el overshoot (termina exacto en 360≡0).
- **Se posa** en una flor/hoja y **despega** con brinquito de overshoot (posada asoma negativa un instante).
- **Celebra** al llegar a un mundo: giro alegre + overshoot + rebotico (gana a todo).
- **Se acurruca de noche** (hora de `cielosHoraData`): reposo, respiración honda, cero piruetas.

### Determinismo y frugalidad
- Cero `Math.random` en render: eventos derivados por hash entero (semilla, evento, ciclo) — misma entrada, misma pose.
- Carriles de eventos resueltos por orden de arranque, sin pre-empciones → cero saltos de pose a mitad de gesto.
- `reducedMotion` → pose calma estática, `activo=false` (nadie pide frames).
- Tier `bajo` → solo respiración. `frameloop='demand'` respetado: `invalidate()` solo mientras el idle anima.

### Enganche mínimo en Angelita
`useEntradaAbeja` calcula la pose en su `useFrame` existente y la aplica:
- una **cuarta capa DOM** propia (`.mundo-abeja__idle`, transform-origin default) para no pisar la transition del volteo de la cara — un solo style-write cacheado por string;
- `data-pose` va en esa capa (con `data-creature` estático) → el CSS existente de `celebra`/`reposo` aplica por descendencia y React nunca lo resetea;
- `posada` recoge la altura de vuelo y aquieta vagar/bob; la llegada a la percha dispara la celebración (mismo umbral del roce háptico).

## Verificación
- `vitest`: 15 tests nuevos del contrato (determinismo, cadencia 18-22 s, anticipación/overshoot, gates RM/tier/noche, perfiles por especie) — 15/15 verdes.
- `eslint` de los 3 archivos tocados: 0.
- `npm run build`: exit 0 (28.6 s).
- Fallo pre-existente ajeno: `useAudioMundo.test.jsx` falla igual en dev limpio (verificado con stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)