### PR TITLE
feat(3d): ventana-puerta al valle 3D en el home (viewport vivo enmarcado)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -163,6 +163,8 @@ const ValleLluviaMockup = lazy(() => import('./mockups/ValleLluvia3D'));
 const MundoSemilleroMockup = lazy(() => import('./mockups/MundoSemillero3D'));
 const MundoCompostMockup = lazy(() => import('./mockups/MundoCompost3D'));
 const JuegoMiFincaMockup = lazy(() => import('./mockups/JuegoMiFincaOdyssey'));
+// La "ventana-puerta" al valle: viewport 3D vivo enmarcado para el home 2D.
+const VentanaValleMockup = lazy(() => import('./components/VentanaValle3D'));
 const VitrinaMaestraMockup = lazy(() => import('./mockups/VitrinaMaestraMundos'));
 const MundoFermentosMockup = lazy(() => import('./mockups/MundoFermentos3D'));
 const GemelosMundosMockup = lazy(() => import('./mockups/GemelosMundos2D'));
@@ -590,6 +592,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo-semillero-3d': 'mockup_mundo_semillero_3d',
   'mockups/mundo-compost-3d': 'mockup_mundo_compost_3d',
   'mockups/juego-mi-finca': 'mockup_juego_mi_finca',
+  'mockups/ventana-valle': 'mockup_ventana_valle',
   'mockups/vitrina-maestra': 'mockup_vitrina_maestra',
   'mockups/mundo-fermentos-3d': 'mockup_mundo_fermentos_3d',
   'mockups/gemelos-2d': 'mockup_gemelos_2d',
@@ -1901,6 +1904,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Juego Mi finca (túnel Odyssey)">
               <JuegoMiFincaMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_ventana_valle':
+        // La "ventana-puerta" al valle 3D: el widget del home con un viewport
+        // 3D vivo enmarcado (marco orgánico que respira + Angelita) que al
+        // tocarlo entra a la experiencia 3D completa. Sin auth (vitrina).
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Ventana al valle (puerta 3D)">
+              <div style={{ minHeight: '100vh', display: 'grid', placeItems: 'center', background: '#f2ecdb' }}>
+                <VentanaValleMockup onEntrar={() => navigate('valle3d')} />
+              </div>
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/VentanaValle3D.jsx
+++ b/src/components/VentanaValle3D.jsx
@@ -1,0 +1,211 @@
+/*
+ * VentanaValle3D — la "VENTANA-PUERTA" al valle 3D, embebida en el home 2D.
+ *
+ * El home clásico se queda igual; esto se le AGREGA: una ventana de marco
+ * orgánico (biopunk verde-vivo, la enredadera con esporas que laten) con un
+ * viewport 3D VIVO adentro — un asomo del valle que respira — que invita a
+ * tocarla para entrar a la experiencia 3D completa. Es una PUERTA, no un botón
+ * plano: toda la ventana es tappable y llama `onEntrar()`.
+ *
+ * Autocontenido y BARATO (widget persistente del home):
+ *   · Este host NO importa three: la escena (`VentanaValle3DEscena`) va al
+ *     chunk perezoso `vendor-three` y SOLO se pide cuando la ventana entra al
+ *     viewport (IntersectionObserver) — el home no paga three por adelantado.
+ *   · Device-tier (`decidirTier`): alto/medio montan 3D (medio frugal);
+ *     bajo o sin WebGL caen al ESPEJO SVG — el mismo valle, quieto y digno.
+ *   · prefers-reduced-motion: un fotograma (frameloop a demanda, marco quieto).
+ *   · A11y: es un <button> real con nombre accesible; el espejo 2D lleva su
+ *     texto alternativo; foco visible en CSS.
+ *
+ * ── CABLEO (lo hace el host; este archivo no toca el home) ────────────────
+ *
+ *   import VentanaValle3D from './components/VentanaValle3D.jsx';
+ *   // donde el home quiera abrir la puerta al valle:
+ *   <VentanaValle3D onEntrar={() => navigate('valle3d')} />
+ *   // opcionales: tier/reducedMotion si el host ya corrió decidirTier().
+ */
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
+import './ventanaValle3D.css';
+
+const EscenaVentana = lazy(() => import('./VentanaValle3DEscena.jsx'));
+
+/*
+ * El ESPEJO 2D digno: el mismo valle en SVG puro (cero three, cero assets
+ * remotos). Es el piso para tier bajo / sin-WebGL Y el fallback de Suspense
+ * mientras baja el chunk 3D — la ventana nunca queda en blanco ni rota.
+ */
+function Valle2D({ reducedMotion }) {
+  return (
+    <div className="vv-2d">
+      <svg
+        className="vv-2d__paisaje"
+        viewBox="0 0 320 220"
+        preserveAspectRatio="xMidYMax slice"
+        role="img"
+        aria-label="El valle de su finca: lomas verdes con matas y la abeja angelita volando bajo un cielo cálido"
+      >
+        <title>El valle de su finca</title>
+        <defs>
+          <linearGradient id="vv-alba" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="#f6ecd2" />
+            <stop offset="1" stopColor="#eaf0d3" />
+          </linearGradient>
+        </defs>
+        <rect width="320" height="220" fill="url(#vv-alba)" />
+
+        {/* el sol de media mañana con su halo */}
+        <g className={reducedMotion ? '' : 'vv-2d-respira'} style={{ transformOrigin: '244px 54px' }}>
+          <circle cx="244" cy="54" r="30" fill="#f6d78a" opacity="0.35" />
+          <circle cx="244" cy="54" r="17" fill="#f2c766" />
+        </g>
+
+        {/* lomas que se alejan hacia la luz */}
+        <ellipse cx="52" cy="222" rx="160" ry="66" fill="#4c7147" />
+        <ellipse cx="286" cy="230" rx="180" ry="74" fill="#557e4c" />
+        <ellipse cx="160" cy="258" rx="240" ry="92" fill="#6c9a5b" />
+
+        {/* matas low-poly (tallo + copa de hoja viva) */}
+        <g>
+          <rect x="86" y="168" width="4" height="16" rx="2" fill="#6f8a3f" />
+          <path d="M88 132 L104 172 L72 172 Z" fill="#4d8a4a" />
+          <rect x="156" y="178" width="3.4" height="13" rx="1.7" fill="#6f8a3f" />
+          <path d="M157.7 150 L170 182 L145 182 Z" fill="#5f9c50" />
+          <rect x="226" y="172" width="4.4" height="17" rx="2.2" fill="#6f8a3f" />
+          <path d="M228.2 134 L246 176 L210 176 Z" fill="#3f7a45" />
+        </g>
+
+        {/* esporas bio-glow que laten (quietas con reduced-motion) */}
+        <g fill="#d9f7a6">
+          <circle className={reducedMotion ? '' : 'vv-2d-espora'} cx="120" cy="120" r="2.6" />
+          <circle className={reducedMotion ? '' : 'vv-2d-espora vv-2d-espora--tarde'} cx="196" cy="102" r="2.1" />
+          <circle className={reducedMotion ? '' : 'vv-2d-espora vv-2d-espora--lenta'} cx="64" cy="96" r="1.8" />
+        </g>
+      </svg>
+
+      {/* la Angelita 2D volando en el espejo (misma creature del home) */}
+      <div className={`vv-abeja vv-abeja--2d${reducedMotion ? ' vv-abeja--quieta' : ''}`}>
+        <AbejaAngelita size={44} animo="pleno" energia={0.9} animated={!reducedMotion} />
+      </div>
+    </div>
+  );
+}
+
+/* La enredadera del marco: hojas + zarcillos + esporas que LATEN (CSS). Es la
+   firma biopunk de la puerta — dibujada una vez, decorativa (aria-hidden). */
+function EnredaderaMarco() {
+  return (
+    <svg className="vv-enredadera" viewBox="0 0 400 320" aria-hidden="true" focusable="false">
+      {/* zarcillos: espirales de tinta que abrazan las esquinas */}
+      <g fill="none" stroke="#22301c" strokeWidth="3" strokeLinecap="round">
+        <path d="M34 44 C18 30 20 12 40 10 C56 8 60 24 48 30" />
+        <path d="M366 40 C382 26 380 8 360 8 C346 8 342 22 354 27" />
+        <path d="M30 282 C14 294 18 312 38 312 C52 312 55 299 44 294" />
+        <path d="M370 284 C386 296 382 314 362 314 C348 314 345 300 356 296" />
+      </g>
+      {/* hojas de la enredadera (verde-vivo, con nervadura de tinta) */}
+      <g stroke="#22301c" strokeWidth="2.4" strokeLinejoin="round">
+        <path d="M58 16 q20 -14 40 2 q-18 16 -40 -2 Z" fill="#5f9c50" />
+        <path d="M318 14 q-20 -12 -38 4 q16 14 38 -4 Z" fill="#4d8a4a" />
+        <path d="M64 306 q18 14 38 -2 q-16 -16 -38 2 Z" fill="#4d8a4a" />
+        <path d="M312 308 q-18 12 -36 -4 q14 -14 36 4 Z" fill="#5f9c50" />
+        <path d="M6 130 q-10 22 6 38 q12 -18 -6 -38 Z" fill="#3f7a45" />
+        <path d="M394 136 q10 22 -6 36 q-12 -16 6 -36 Z" fill="#3f7a45" />
+      </g>
+      {/* las esporas del marco: gemelas de las de adentro, laten en CSS */}
+      <g fill="#d9f7a6">
+        <circle className="vv-espora" cx="86" cy="10" r="4" />
+        <circle className="vv-espora vv-espora--tarde" cx="342" cy="304" r="3.4" />
+        <circle className="vv-espora vv-espora--lenta" cx="10" cy="196" r="3" />
+        <circle className="vv-espora vv-espora--tarde" cx="392" cy="88" r="2.8" />
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * La ventana-puerta al valle 3D. Montable por props, sin lógica de negocio:
+ * el HOME decide a dónde lleva la puerta (`onEntrar`).
+ *
+ * @param {object} props
+ * @param {() => void} props.onEntrar  al tocar la ventana (toda es tappable).
+ * @param {'alto'|'medio'|'bajo'} [props.tier]  override; sin él corre `decidirTier()`.
+ * @param {boolean} [props.reducedMotion]  override; sin él usa la preferencia del sistema.
+ * @param {string}  [props.titulo='Entrar al valle']  rótulo de la puerta.
+ * @param {string}  [props.pista='Toque para entrar al valle']  la invitación (usted).
+ * @param {string}  [props.className]  clases extra del botón-ventana.
+ */
+export function VentanaValle3D({
+  onEntrar,
+  tier: tierProp,
+  reducedMotion: rmProp,
+  titulo = 'Entrar al valle',
+  pista = 'Toque para entrar al valle',
+  className = '',
+}) {
+  // El tier se decide UNA vez por montaje (es barato pero toca canvas/WebGL).
+  const decision = useMemo(() => decidirTier(), []);
+  const tier = tierProp || decision.tier;
+  const reducedMotion = rmProp ?? decision.reducedMotion;
+  const con3D = permite3D(tier);
+
+  // La escena 3D NO se pide hasta que la ventana entra al viewport: el home
+  // no descarga `vendor-three` por un widget que quedó bajo el fold.
+  const hostRef = useRef(null);
+  const [aLaVista, setALaVista] = useState(false);
+  useEffect(() => {
+    if (!con3D || aLaVista) return undefined;
+    const el = hostRef.current;
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setALaVista(true);
+      return undefined;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setALaVista(true);
+          io.disconnect();
+        }
+      },
+      { rootMargin: '96px' },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [con3D, aLaVista]);
+
+  return (
+    <button
+      type="button"
+      ref={hostRef}
+      className={`vv${className ? ` ${className}` : ''}`}
+      data-tier={tier}
+      onClick={onEntrar}
+      aria-label={`${titulo}. ${pista}`}
+    >
+      {/* el marco orgánico que respira (la firma de la puerta) */}
+      <span className="vv-marco" aria-hidden="true">
+        <span className="vv-vidrio">
+          {con3D && aLaVista ? (
+            <Suspense fallback={<Valle2D reducedMotion={reducedMotion} />}>
+              <EscenaVentana tier={tier === 'alto' ? 'alto' : 'medio'} reducedMotion={reducedMotion} />
+            </Suspense>
+          ) : (
+            <Valle2D reducedMotion={reducedMotion} />
+          )}
+          {/* la luz que se cuela por la ventana (vidrio con brillo cálido) */}
+          <span className="vv-luz" />
+        </span>
+        <EnredaderaMarco />
+      </span>
+
+      {/* la repisa: el rótulo de la puerta */}
+      <span className="vv-repisa">
+        <span className="vv-repisa__titulo">{titulo}</span>
+        <span className="vv-repisa__pista">{pista}</span>
+      </span>
+    </button>
+  );
+}
+
+export default VentanaValle3D;

--- a/src/components/VentanaValle3D.jsx
+++ b/src/components/VentanaValle3D.jsx
@@ -36,7 +36,7 @@ const EscenaVentana = lazy(() => import('./VentanaValle3DEscena.jsx'));
  * remotos). Es el piso para tier bajo / sin-WebGL Y el fallback de Suspense
  * mientras baja el chunk 3D — la ventana nunca queda en blanco ni rota.
  */
-function Valle2D({ reducedMotion }) {
+function Valle2D({ reducedMotion, tier }) {
   return (
     <div className="vv-2d">
       <svg
@@ -86,7 +86,7 @@ function Valle2D({ reducedMotion }) {
 
       {/* la Angelita 2D volando en el espejo (misma creature del home) */}
       <div className={`vv-abeja vv-abeja--2d${reducedMotion ? ' vv-abeja--quieta' : ''}`}>
-        <AbejaAngelita size={44} animo="pleno" energia={0.9} animated={!reducedMotion} />
+        <AbejaAngelita size={44} animo="pleno" energia={0.9} animated={!reducedMotion} tier={tier} />
       </div>
     </div>
   );
@@ -187,11 +187,11 @@ export function VentanaValle3D({
       <span className="vv-marco" aria-hidden="true">
         <span className="vv-vidrio">
           {con3D && aLaVista ? (
-            <Suspense fallback={<Valle2D reducedMotion={reducedMotion} />}>
+            <Suspense fallback={<Valle2D reducedMotion={reducedMotion} tier={tier} />}>
               <EscenaVentana tier={tier === 'alto' ? 'alto' : 'medio'} reducedMotion={reducedMotion} />
             </Suspense>
           ) : (
-            <Valle2D reducedMotion={reducedMotion} />
+            <Valle2D reducedMotion={reducedMotion} tier={tier} />
           )}
           {/* la luz que se cuela por la ventana (vidrio con brillo cálido) */}
           <span className="vv-luz" />

--- a/src/components/VentanaValle3DEscena.jsx
+++ b/src/components/VentanaValle3DEscena.jsx
@@ -1,0 +1,208 @@
+/*
+ * VentanaValle3DEscena — la VIÑETA 3D que vive dentro de la ventana-puerta
+ * del home (`VentanaValle3D.jsx`). NO es una escena-mundo del registro: es un
+ * asomo del valle, un plano fijo con la cámara que RESPIRA (dolly sutil, ±16 cm)
+ * para que la ventana se sienta VIVA sin pedir interacción. La puerta es el
+ * marco de afuera; aquí adentro solo hay paisaje: piso verde-vivo, lomas que se
+ * alejan, matas low-poly, niebla suave de media mañana, esporas bio-glow que
+ * derivan y la Angelita 2D (la MISMA del home, via drei `Html`) flotando.
+ *
+ * Perf (más estricta que las escenas-mundo — esto es un WIDGET PERSISTENTE del
+ * home, DR §6): SOLO MeshLambert/MeshBasic, SIN sombras, SIN post-proceso,
+ * geometría 100% procedural, `powerPreference: 'low-power'` (¡no es la
+ * experiencia plena, es una ventana!), dpr ≤ 1.5 (≤ 1.2 frugal), AdaptiveDpr,
+ * y con reduced-motion `frameloop='demand'` → UN fotograma quieto y digno.
+ *
+ * Importa three/@react-three (chunk `vendor-three`): montarla SOLO perezosa
+ * via `lazy()` desde `VentanaValle3D.jsx` — nunca desde el home directo.
+ */
+import { useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { Html, AdaptiveDpr } from '@react-three/drei';
+import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
+
+/* Luz de media mañana en el valle: cielo cálido, verdes VIVOS (biopunk suave). */
+const CIELO = { fondo: '#eaf0d3', cielo: '#f6ecd2', suelo: '#8fae6a', niebla: '#e6eecb' };
+/* El punto del valle que la ventana enmarca (la cámara siempre lo mira). */
+const FOCO = [0, 0.72, 0];
+
+/* PRNG determinista: la ventana muestra SIEMPRE el mismo valle (cero azar). */
+function rng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+/* La cámara que respira: dolly-in/out lentísimo + un vaivén vertical apenas
+   perceptible. Es TODO el movimiento de cámara de la ventana (sin controles:
+   tocar la ventana es ENTRAR, no orbitar). reduced-motion → quieta. */
+function CamaraRespira({ reducedMotion }) {
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const t = state.clock.elapsedTime;
+    state.camera.position.z = 5.1 + Math.sin(t * 0.32) * 0.16;
+    state.camera.position.y = 1.62 + Math.sin(t * 0.21 + 1.4) * 0.06;
+    state.camera.lookAt(FOCO[0], FOCO[1], FOCO[2]);
+  });
+  return null;
+}
+
+/* Una loma: esfera achatada en verdes que se alejan. */
+function Loma({ pos, radio, color }) {
+  return (
+    <mesh position={pos} scale={[1, 0.4, 1]}>
+      <sphereGeometry args={[radio, 12, 8]} />
+      <meshLambertMaterial color={color} />
+    </mesh>
+  );
+}
+
+/* Una mata low-poly: tallo + copa cónica de hoja viva (y una hojita lateral). */
+function Mata({ pos, alto = 1, hoja = '#4d8a4a' }) {
+  return (
+    <group position={pos}>
+      <mesh position={[0, alto * 0.2, 0]}>
+        <cylinderGeometry args={[0.035, 0.055, alto * 0.4, 5]} />
+        <meshLambertMaterial color="#6f8a3f" />
+      </mesh>
+      <mesh position={[0, alto * 0.58, 0]}>
+        <coneGeometry args={[alto * 0.26, alto * 0.72, 6]} />
+        <meshLambertMaterial color={hoja} />
+      </mesh>
+      <mesh position={[alto * 0.2, alto * 0.34, 0.04]} rotation={[0, 0, -0.9]}>
+        <coneGeometry args={[alto * 0.09, alto * 0.3, 5]} />
+        <meshLambertMaterial color={hoja} />
+      </mesh>
+    </group>
+  );
+}
+
+/* Esporas bio-glow: puntitos verde-luz que derivan sin prisa (el toque biopunk
+   ADENTRO de la ventana; el marco de afuera lleva sus gemelas en CSS). */
+function Esporas({ cuantas, reducedMotion }) {
+  const grupo = useRef(null);
+  const esporas = useMemo(() => {
+    const r = rng(53);
+    return Array.from({ length: cuantas }, (_, i) => ({
+      key: `e${i}`,
+      pos: /** @type {[number, number, number]} */ ([(r() - 0.5) * 4.2, 0.6 + r() * 1.5, (r() - 0.4) * 2.8]),
+      fase: r() * Math.PI * 2,
+      radio: 0.016 + r() * 0.016,
+    }));
+  }, [cuantas]);
+
+  useFrame((state) => {
+    if (reducedMotion || !grupo.current) return;
+    const t = state.clock.elapsedTime;
+    grupo.current.rotation.y = t * 0.025; // deriva: una vuelta cada ~4 min
+    grupo.current.children.forEach((m, i) => {
+      m.position.y = esporas[i].pos[1] + Math.sin(t * 0.4 + esporas[i].fase) * 0.1;
+    });
+  });
+
+  return (
+    <group ref={grupo}>
+      {esporas.map((m) => (
+        <mesh key={m.key} position={m.pos}>
+          <sphereGeometry args={[m.radio, 5, 4]} />
+          <meshBasicMaterial color="#d9f7a6" transparent opacity={0.9} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* La Angelita 2D (la preferida — el MISMO SVG rubber-hose del home) flotando
+   en el valle via `Html`: cruza despacio y sube-baja con las alas batiendo.
+   Decorativa aquí (aria-hidden): la a11y la lleva el botón-ventana de afuera. */
+function AngelitaVuela({ reducedMotion, tier }) {
+  const g = useRef(null);
+  useFrame((state) => {
+    if (reducedMotion || !g.current) return;
+    const t = state.clock.elapsedTime;
+    g.current.position.y = 1.02 + Math.sin(t * 0.85) * 0.1;
+    g.current.position.x = 0.45 + Math.sin(t * 0.19) * 0.35;
+  });
+  return (
+    <group ref={g} position={[0.45, 1.02, 0.9]}>
+      <Html center distanceFactor={6} zIndexRange={[30, 10]} wrapperClass="vv-abeja-html">
+        <div className="vv-abeja" aria-hidden="true">
+          <AbejaAngelita size={46} animo="pleno" energia={0.9} animated={!reducedMotion} tier={tier} />
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+function Vineta({ frugal, reducedMotion, tier }) {
+  const matas = useMemo(() => {
+    const r = rng(29);
+    return Array.from({ length: frugal ? 4 : 7 }, (_, i) => ({
+      key: `t${i}`,
+      pos: /** @type {[number, number, number]} */ ([(r() - 0.5) * 3.8, 0.42, (r() - 0.25) * 2.3]),
+      alto: 0.7 + r() * 0.7,
+      hoja: ['#4d8a4a', '#5f9c50', '#3f7a45'][i % 3],
+    }));
+  }, [frugal]);
+
+  return (
+    <>
+      <color attach="background" args={[CIELO.fondo]} />
+      {/* niebla suave: el fondo del valle se disuelve en la luz (profundidad barata) */}
+      <fog attach="fog" args={[CIELO.niebla, 5.5, 12.5]} />
+      <hemisphereLight intensity={0.95} color={CIELO.cielo} groundColor={CIELO.suelo} />
+      <ambientLight intensity={0.5} color="#fff3da" />
+      <CamaraRespira reducedMotion={reducedMotion} />
+
+      {/* el piso del valle: disco verde-vivo */}
+      <mesh position={[0, 0.26, 0]} scale={[1, 0.16, 1]}>
+        <sphereGeometry args={[3.6, 18, 12]} />
+        <meshLambertMaterial color="#6c9a5b" />
+      </mesh>
+
+      {/* lomas al fondo, tonos que se alejan hacia la niebla */}
+      <Loma pos={[-2.5, 0.5, -2.2]} radio={1.8} color="#5f8a52" />
+      <Loma pos={[2.6, 0.44, -2.5]} radio={2.0} color="#557e4c" />
+      <Loma pos={[0.2, 0.4, -3.3]} radio={2.4} color="#4c7147" />
+
+      {/* las matas sembradas (deterministas) */}
+      {matas.map((m) => (
+        <Mata key={m.key} pos={m.pos} alto={m.alto} hoja={m.hoja} />
+      ))}
+
+      <AngelitaVuela reducedMotion={reducedMotion} tier={tier} />
+      <Esporas cuantas={frugal ? 5 : 9} reducedMotion={reducedMotion} />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * La escena de la ventana. Montarla SOLO perezosa (ver `VentanaValle3D.jsx`).
+ *
+ * @param {object} props
+ * @param {'alto'|'medio'} [props.tier='alto']  medio → frugal (menos matas/esporas, DPR ≤ 1.2, sin AA).
+ * @param {boolean} [props.reducedMotion=false] un fotograma quieto: frameloop a demanda, cero vaivén.
+ */
+export default function VentanaValle3DEscena({ tier = 'alto', reducedMotion = false }) {
+  const [listo, setListo] = useState(false);
+  const frugal = tier !== 'alto';
+  return (
+    <Canvas
+      className={`vv-canvas${listo ? ' vv-canvas--lista' : ''}`}
+      dpr={frugal ? [1, 1.2] : [1, 1.5]}
+      gl={{ antialias: !frugal, powerPreference: 'low-power' }}
+      camera={{ position: [0, 1.62, 5.1], fov: 38 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={({ camera }) => {
+        // El fotograma inicial (y el ÚNICO con reduced-motion) ya mira al foco.
+        camera.lookAt(FOCO[0], FOCO[1], FOCO[2]);
+        setListo(true);
+      }}
+    >
+      <Vineta frugal={frugal} reducedMotion={reducedMotion} tier={tier} />
+    </Canvas>
+  );
+}

--- a/src/components/VentanaValle3DEscena.jsx
+++ b/src/components/VentanaValle3DEscena.jsx
@@ -23,8 +23,9 @@ import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
 
 /* Luz de media mañana en el valle: cielo cálido, verdes VIVOS (biopunk suave). */
 const CIELO = { fondo: '#eaf0d3', cielo: '#f6ecd2', suelo: '#8fae6a', niebla: '#e6eecb' };
-/* El punto del valle que la ventana enmarca (la cámara siempre lo mira). */
-const FOCO = [0, 0.72, 0];
+/* El punto del valle que la ventana enmarca (la cámara siempre lo mira):
+   alto, para que el cuadro reparta cielo/lomas y no lo coma el piso. */
+const FOCO = [0, 1.12, 0];
 
 /* PRNG determinista: la ventana muestra SIEMPRE el mismo valle (cero azar). */
 function rng(seed) {
@@ -42,8 +43,8 @@ function CamaraRespira({ reducedMotion }) {
   useFrame((state) => {
     if (reducedMotion) return;
     const t = state.clock.elapsedTime;
-    state.camera.position.z = 5.1 + Math.sin(t * 0.32) * 0.16;
-    state.camera.position.y = 1.62 + Math.sin(t * 0.21 + 1.4) * 0.06;
+    state.camera.position.z = 4.7 + Math.sin(t * 0.32) * 0.16;
+    state.camera.position.y = 1.35 + Math.sin(t * 0.21 + 1.4) * 0.06;
     state.camera.lookAt(FOCO[0], FOCO[1], FOCO[2]);
   });
   return null;
@@ -159,7 +160,7 @@ function Vineta({ frugal, reducedMotion, tier }) {
       {/* el piso del valle: disco verde-vivo */}
       <mesh position={[0, 0.26, 0]} scale={[1, 0.16, 1]}>
         <sphereGeometry args={[3.6, 18, 12]} />
-        <meshLambertMaterial color="#6c9a5b" />
+        <meshLambertMaterial color="#78a862" />
       </mesh>
 
       {/* lomas al fondo, tonos que se alejan hacia la niebla */}
@@ -167,10 +168,12 @@ function Vineta({ frugal, reducedMotion, tier }) {
       <Loma pos={[2.6, 0.44, -2.5]} radio={2.0} color="#557e4c" />
       <Loma pos={[0.2, 0.4, -3.3]} radio={2.4} color="#4c7147" />
 
-      {/* las matas sembradas (deterministas) */}
+      {/* las matas sembradas (deterministas) + una en primer plano que ancla
+          la composición (sin ella el frente queda vacío y el piso domina) */}
       {matas.map((m) => (
         <Mata key={m.key} pos={m.pos} alto={m.alto} hoja={m.hoja} />
       ))}
+      <Mata pos={[-1.05, 0.42, 1.15]} alto={0.95} hoja="#5f9c50" />
 
       <AngelitaVuela reducedMotion={reducedMotion} tier={tier} />
       <Esporas cuantas={frugal ? 5 : 9} reducedMotion={reducedMotion} />
@@ -194,7 +197,7 @@ export default function VentanaValle3DEscena({ tier = 'alto', reducedMotion = fa
       className={`vv-canvas${listo ? ' vv-canvas--lista' : ''}`}
       dpr={frugal ? [1, 1.2] : [1, 1.5]}
       gl={{ antialias: !frugal, powerPreference: 'low-power' }}
-      camera={{ position: [0, 1.62, 5.1], fov: 38 }}
+      camera={{ position: [0, 1.35, 4.7], fov: 38 }}
       frameloop={reducedMotion ? 'demand' : 'always'}
       onCreated={({ camera }) => {
         // El fotograma inicial (y el ÚNICO con reduced-motion) ya mira al foco.

--- a/src/components/ventanaValle3D.css
+++ b/src/components/ventanaValle3D.css
@@ -111,7 +111,7 @@
   inset: 0;
   background:
     radial-gradient(80% 60% at 62% 24%, rgba(246, 215, 138, 0.22) 0%, rgba(246, 215, 138, 0) 60%),
-    radial-gradient(140% 90% at 50% 108%, rgba(34, 48, 28, 0.22) 0%, rgba(34, 48, 28, 0) 46%);
+    radial-gradient(140% 90% at 50% 108%, rgba(34, 48, 28, 0.14) 0%, rgba(34, 48, 28, 0) 46%);
 }
 
 /* ── la enredadera del marco (hojas + zarcillos + esporas que laten) ─────── */

--- a/src/components/ventanaValle3D.css
+++ b/src/components/ventanaValle3D.css
@@ -1,0 +1,239 @@
+/*
+ * ventanaValle3D.css — la ventana-puerta al valle 3D del home.
+ *
+ * La FIRMA es el MARCO ORGÁNICO QUE RESPIRA: tinta verde profunda cuyo
+ * border-radius muta lentísimo (como tejido vivo), con la enredadera SVG y
+ * esporas bio-glow que laten. Todo lo demás queda quieto y disciplinado.
+ *
+ * Gates de calma/costo:
+ *   · prefers-reduced-motion → TODA animación CSS fuera (un fotograma digno).
+ *   · [data-tier='bajo']     → marco quieto (el equipo humilde no paga vaivén).
+ * El movimiento DENTRO del canvas lo gatea la escena (frameloop a demanda).
+ */
+
+/* ── el botón-ventana (toda la ventana es la puerta) ─────────────────────── */
+.vv {
+  -webkit-tap-highlight-color: transparent;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  width: min(400px, 92vw);
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: transform 0.28s cubic-bezier(0.34, 1.4, 0.5, 1);
+}
+
+.vv:hover,
+.vv:focus-visible {
+  transform: translateY(-2px) scale(1.012);
+}
+.vv:active {
+  transform: translateY(0) scale(0.99);
+}
+
+.vv:focus-visible {
+  outline: none;
+}
+/* el foco visible vive en el MARCO (el outline rectangular pelearía con el blob) */
+.vv:focus-visible .vv-marco {
+  box-shadow:
+    0 0 0 3px #d9f7a6,
+    0 0 0 5px #22301c,
+    0 14px 34px rgba(34, 48, 28, 0.35);
+}
+
+/* Los hijos son transparentes al tacto: el tap SIEMPRE aterriza en el botón
+   (el canvas de r3f nunca se traga el toque de la puerta). */
+.vv-marco,
+.vv-repisa {
+  pointer-events: none;
+}
+
+/* ── el marco orgánico que respira (la firma) ────────────────────────────── */
+.vv-marco {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: 12px;
+  background:
+    radial-gradient(120% 90% at 50% 0%, #35502c 0%, #22301c 58%, #182312 100%);
+  border-radius: 46% 54% 20% 22% / 38% 40% 16% 17%;
+  box-shadow:
+    0 10px 30px rgba(34, 48, 28, 0.32),
+    0 0 22px rgba(184, 233, 134, 0.18),
+    inset 0 1px 6px rgba(217, 247, 166, 0.28);
+  animation: vv-marco-respira 11s ease-in-out infinite;
+}
+
+@keyframes vv-marco-respira {
+  0%, 100% { border-radius: 46% 54% 20% 22% / 38% 40% 16% 17%; }
+  33%      { border-radius: 52% 48% 23% 19% / 42% 36% 14% 19%; }
+  66%      { border-radius: 48% 52% 18% 24% / 36% 43% 18% 15%; }
+}
+
+/* ── el vidrio: el viewport enmarcado ────────────────────────────────────── */
+.vv-vidrio {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border-radius: 42% 50% 16% 18% / 34% 36% 12% 13%;
+  background: #eaf0d3; /* el cielo, mientras llega lo demás: nunca un hueco negro */
+  animation: vv-vidrio-respira 11s ease-in-out infinite;
+}
+
+@keyframes vv-vidrio-respira {
+  0%, 100% { border-radius: 42% 50% 16% 18% / 34% 36% 12% 13%; }
+  33%      { border-radius: 48% 44% 19% 15% / 38% 32% 10% 15%; }
+  66%      { border-radius: 44% 48% 14% 20% / 32% 39% 14% 11%; }
+}
+
+/* el canvas 3D llena el vidrio y aparece en un fundido (sin pop) */
+.vv-canvas {
+  position: absolute !important;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.vv-canvas--lista {
+  opacity: 1;
+}
+
+/* la luz cálida que se cuela por la ventana (vidrio vivo, no video frío) */
+.vv-luz {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(80% 60% at 62% 24%, rgba(246, 215, 138, 0.22) 0%, rgba(246, 215, 138, 0) 60%),
+    radial-gradient(140% 90% at 50% 108%, rgba(34, 48, 28, 0.22) 0%, rgba(34, 48, 28, 0) 46%);
+}
+
+/* ── la enredadera del marco (hojas + zarcillos + esporas que laten) ─────── */
+.vv-enredadera {
+  position: absolute;
+  inset: -14px;
+  width: calc(100% + 28px);
+  height: calc(100% + 28px);
+  overflow: visible;
+}
+
+.vv-espora {
+  animation: vv-late 3.2s ease-in-out infinite;
+  filter: drop-shadow(0 0 4px rgba(217, 247, 166, 0.9));
+  transform-box: fill-box;
+  transform-origin: center;
+}
+.vv-espora--tarde { animation-delay: -1.2s; }
+.vv-espora--lenta { animation-duration: 4.6s; animation-delay: -2.1s; }
+
+@keyframes vv-late {
+  0%, 100% { opacity: 0.55; transform: scale(0.85); }
+  50%      { opacity: 1; transform: scale(1.15); }
+}
+
+/* ── el espejo 2D digno (tier bajo / sin WebGL / fallback de Suspense) ───── */
+.vv-2d {
+  position: absolute;
+  inset: 0;
+}
+.vv-2d__paisaje {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.vv-2d-respira {
+  animation: vv-respira-suave 8s ease-in-out infinite;
+}
+.vv-2d-espora {
+  animation: vv-late 3.6s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+.vv-2d-espora--tarde { animation-delay: -1.4s; }
+.vv-2d-espora--lenta { animation-duration: 5s; animation-delay: -2.4s; }
+
+@keyframes vv-respira-suave {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50%      { transform: scale(1.06); opacity: 0.92; }
+}
+
+/* ── la Angelita (2D en el espejo; via drei Html en el 3D) ───────────────── */
+.vv-abeja {
+  filter: drop-shadow(0 3px 5px rgba(34, 48, 28, 0.3));
+}
+.vv-abeja--2d {
+  position: absolute;
+  left: 34%;
+  top: 38%;
+  animation: vv-abeja-flota 5.2s ease-in-out infinite;
+}
+.vv-abeja--quieta,
+.vv-abeja--2d.vv-abeja--quieta {
+  animation: none;
+}
+
+@keyframes vv-abeja-flota {
+  0%, 100% { transform: translate(0, 0); }
+  33%      { transform: translate(9px, -8px); }
+  66%      { transform: translate(-7px, 5px); }
+}
+
+/* el wrapper del Html de drei no debe tapar el tap de la puerta */
+.vv-abeja-html {
+  pointer-events: none;
+}
+
+/* ── la repisa: el rótulo de la puerta ───────────────────────────────────── */
+.vv-repisa {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  margin-top: -14px; /* la repisa se posa sobre el borde bajo del marco */
+  padding: 10px 22px 11px;
+  background: linear-gradient(180deg, #35502c 0%, #22301c 100%);
+  border-radius: 18px;
+  box-shadow:
+    0 6px 16px rgba(34, 48, 28, 0.3),
+    inset 0 1px 3px rgba(217, 247, 166, 0.25);
+  z-index: 1;
+}
+.vv-repisa__titulo {
+  font-weight: 800;
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+  color: #f2ecd7;
+}
+.vv-repisa__pista {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: #b8e986;
+}
+
+/* ── gates de calma y de equipo humilde ──────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .vv,
+  .vv-marco,
+  .vv-vidrio,
+  .vv-canvas,
+  .vv-espora,
+  .vv-2d-respira,
+  .vv-2d-espora,
+  .vv-abeja--2d {
+    animation: none;
+    transition: none;
+  }
+}
+
+/* gama baja: el marco no paga vaivén (las esporas quedan, son opacity/scale
+   de nodos chiquitos; el blob queda en su primera pose, digno) */
+.vv[data-tier='bajo'] .vv-marco,
+.vv[data-tier='bajo'] .vv-vidrio {
+  animation: none;
+}


### PR DESCRIPTION
## Qué es

La **ventana-puerta 3D** (función C): un viewport 3D vivo enmarcado que se embebe en el home 2D clásico como PUERTA para entrar a la experiencia 3D completa. No es un botón plano: es una ventana al valle que respira.

Preview standalone (vitrina, sin auth): `#/mockups/ventana-valle`

## Componente (autocontenido, listo para cablear)

`src/components/VentanaValle3D.jsx` con prop `onEntrar` (callback al tocar). El home NO fue tocado — el cableado en DashboardLive lo hace el orquestador:

```jsx
<VentanaValle3D onEntrar={() => navigate('valle3d')} />
```

## Diseño

- **Firma**: marco orgánico biopunk de tinta verde profunda cuyo border-radius muta lento (tejido vivo), enredadera SVG con zarcillos/hojas y esporas bio-glow que laten.
- **Adentro**: viñeta del valle — piso verde-vivo, lomas hacia la niebla, matas low-poly, cielo cálido, esporas derivando y la **Angelita 2D** (el mismo SVG rubber-hose, via drei `Html`) flotando. Cámara con dolly de respiración (±16 cm).
- **Repisa**: "Entrar al valle" + "Toque para entrar al valle" (usted).

## Presupuesto (widget persistente del home)

- Host sin three: la escena va en chunk lazy y **solo se pide cuando la ventana entra al viewport** (IntersectionObserver, rootMargin 96px).
- `powerPreference: 'low-power'`, dpr ≤ 1.5 (≤ 1.2 frugal), Lambert/Basic, sin sombras, AdaptiveDpr.
- `decidirTier()`: medio → frugal (sin AA, menos matas/esporas); **bajo / sin WebGL → espejo SVG digno** (mismo valle, quieto, con texto alternativo) — también es el fallback de Suspense.
- `prefers-reduced-motion`: un fotograma (`frameloop='demand'` + CSS quieto).

## A11y

`<button>` real con nombre accesible ("Entrar al valle. Toque para entrar al valle"), foco visible en el marco, hijos `pointer-events: none` (el canvas nunca se traga el tap), fallback con `role=img` + aria-label.

## App.jsx (edición mínima)

Solo la ruta vitrina replicando el patrón `juego-mi-finca`: lazy + slug `mockups/ventana-valle` + case con ErrorBoundary → `onEntrar={() => navigate('valle3d')}`.

## Verificación

`npm run build` verde (30.5s). Chunks confirmados separados: `VentanaValle3D-*.js` (host) y `VentanaValle3DEscena-*.js` (escena; three sigue en `vendor-three`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)