### PR TITLE
feat(3d): entrada a mundo estilo New Donk (dolly + aplane) en el flujo vivo valle→mundo

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -52,6 +52,7 @@ import Mundo, {
   tituloDeMundo,
   useNavegacionMundos,
   TransicionMundo,
+  TransicionNewDonk,
   useAudioMundo,
 } from '../visual/mundo3d/index.js';
 /* Coach-mark del primer ingreso (visual, NO depende de la voz — iOS la muda). */
@@ -61,6 +62,15 @@ import { speak, speakKokoro, stop as stopSpeak } from '../services/ttsService.js
 
 // La escena 3D pesada (three/fiber/drei) en su PROPIO chunk perezoso.
 const Valle3D = lazy(() => import('./valle/Valle3D'));
+
+/* ENTRAR a un mundo como MURAL New Donk (flujo vivo): en vez del velo plano, la
+   cámara del valle 3D hace dolly + aplane ortográfico hacia el lugar del mundo
+   (el 3D asoma en los bordes) y solo al caer dentro un destello con la luz del
+   destino cubre el intercambio de escena. Flag de módulo para revertir al velo
+   de un toque. VOLVER al valle conserva el velo (el New Donk es de ENTRADA).
+   Reduced-motion: el hook de navegación salta la fase 'viajando' → corte
+   directo, sin dolly ni overlay (ni este ni el velo se montan). */
+const ENTRADA_NEWDONK = true;
 
 /*
  * DEVICE-TIERING REAL — UNA sola fuente de verdad: `decidirTier()` del
@@ -140,6 +150,18 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
 
   const nav = useNavegacionMundos({ reducedMotion });
   const viajarAlMundoInicial = nav.viajarAlMundo;
+
+  // ── ENTRAR como MURAL New Donk (flujo vivo): mientras la navegación viaja a
+  //    un mundo (fase 'viajando'), la cámara del valle 3D se APLANA hacia el
+  //    lugar (Valle3D `aplanando`) y este overlay corre el destello. El overlay
+  //    SOBREVIVE al swap de escena: se apaga en su propio `onFin` (no al cambiar
+  //    de fase) para poder REVELAR el mundo ya montado bajo el destello. Se
+  //    ENCIENDE en el handler que zarpa el viaje (`entrarAlMundo`), no en un
+  //    effect (react-hooks/set-state-in-effect). Volver al valle conserva el
+  //    velo clásico; el deep-link inicial también (cae al velo por el fallback
+  //    de más abajo). Reduced-motion no llega aquí: el hook salta 'viajando'.
+  const usarNewDonk = ENTRADA_NEWDONK && !reducedMotion;
+  const [newDonk, setNewDonk] = useState(null);
 
   // La escucha puede llegar con un mundo ya resuelto por el NLU. Se consume
   // una vez al montar para que volver al valle siga siendo una decisión de la
@@ -355,10 +377,14 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
   const entrarAlMundo = useCallback(
     (id) => {
       if (!nav.viajarAlMundo(id)) return;
+      // Enciende el mural New Donk en el MISMO tick que zarpa el viaje (mismo
+      // render que la fase 'viajando') → el velo queda suprimido y el aplane
+      // del valle corre bajo este overlay. Se apaga solo en su `onFin`.
+      if (usarNewDonk) setNewDonk(id);
       setPanel(null);
       decir(`Angelita lo lleva a ${tituloDeMundo(id)}.`);
     },
-    [nav, decir],
+    [nav, decir, usarNewDonk],
   );
 
   // ── VOLVER del mundo al valle (misma transición, en reversa).
@@ -446,6 +472,7 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
                 onAlerta={abrirAlerta}
                 reducedMotion={reducedMotion}
                 tier={equipo.tier}
+                aplanando={!!newDonk && nav.fase === 'viajando'}
               />
               {/* Dispara el cruce 2D→3D cuando el chunk 3D del valle resolvió
                   (hermano de <Valle3D> en el Suspense). DOM puro, sin three. */}
@@ -493,10 +520,23 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
         </section>
       )}
 
-      {/* ── El VIAJE (ida o vuelta): la abeja guía; al terminar, el intercambio
-              de escena ocurre debajo del velo. Con reduced-motion ni se monta
-              (el hook corta directo). ── */}
-      {nav.enViaje && nav.mundoId && (
+      {/* ── El VIAJE. ENTRAR (con New Donk): el aplane del valle 3D ocurre en la
+              escena y ESTE overlay corre el destello — el swap va en su punto
+              medio (`onMitad`) y se apaga solo al revelar (`onFin`). VOLVER (o
+              con el flag apagado): el velo clásico, cuyo swap va al final
+              (`onFin`). Con reduced-motion el hook corta directo: nada se
+              monta. ── */}
+      {newDonk && (
+        <TransicionNewDonk
+          mundoId={newDonk}
+          animo={companero.animo}
+          energia={companero.energia}
+          reducedMotion={reducedMotion}
+          onMitad={nav.completarViaje}
+          onFin={() => setNewDonk(null)}
+        />
+      )}
+      {nav.enViaje && nav.mundoId && !(newDonk && nav.fase === 'viajando') && (
         <TransicionMundo
           mundoId={nav.mundoId}
           sentido={nav.fase === 'viajando' ? 'entrar' : 'volver'}

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -24,7 +24,7 @@
    válidas en el reconciliador de R3F, no en el DOM — el config de ESLint del
    repo no activa react/no-unknown-property, así que no requieren disable. */
 import { Suspense, useMemo, useRef, useState } from 'react';
-import { Canvas, useFrame } from '@react-three/fiber';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import {
   Html, Float, Stars, OrbitControls, AdaptiveDpr, Detailed, Instances, Instance,
 } from '@react-three/drei';
@@ -989,16 +989,92 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
   );
 }
 
+/* ── APLANE NEW DONK: el "caer dentro del mundo" del flujo vivo valle→mundo.
+      Cuando `aplanando` se enciende (fase 'viajando' de la navegación), la
+      cámara del valle 3D deja su órbita y hace DOLLY hacia el landmark del
+      mundo destino mientras el lente se APLANA a ~22° (casi ortográfico) — el
+      encuadre New Donk: el mundo destino queda de frente y el resto del valle
+      3D asoma en los bordes, SIN velo plano. El overlay DOM (TransicionNewDonk)
+      corre en paralelo: transparente durante el dolly, luego el destello cubre
+      el intercambio de escena. El dolly dura APLANE_S (< ND_MITAD_MS) para
+      cerrar antes de que el host haga el swap bajo el destello.
+
+      Como CamaraDirector, vive junto a los OrbitControls y NO reasigna props:
+      captura la pose de arranque en su primer frame activo y ESCRIBE la cámara
+      solo por MÉTODOS three (lerpVectors/lookAt/setFocalLength — nunca `cam.fov=`
+      ni `controls.enabled=`, que la regla react-hooks/immutability prohíbe).
+      Se monta de ÚLTIMO en la escena → su useFrame corre después del orbit y de
+      CamaraViajera (que además cede con early-return cuando `aplanando`), así
+      tiene la última palabra sin pelear; los controles quedan habilitados como
+      en el establishing de CamaraDirector. Reduced-motion: el hook de navegación
+      salta la fase 'viajando', así que este componente ni se activa (corte
+      directo valle→mundo). ── */
+const APLANE_S = 0.95; // < ND_MITAD_MS (1.05 s): cierra antes del swap
+const APLANE_FOV = 22; // grados: casi ortográfico (el aplane New Donk)
+const _easeAplane = (p) => (p < 0.5 ? 4 * p * p * p : 1 - (-2 * p + 2) ** 3 / 2);
+
+/* FOV → distancia focal por MÉTODO (setFocalLength), como TunelOdyssey: evita
+   reasignar `camera.fov` (react-hooks/immutability) y refresca la projection. */
+function fovAFocal(camPersp, fov) {
+  return (0.5 * camPersp.getFilmHeight()) / Math.tan(THREE.MathUtils.degToRad(fov) / 2);
+}
+
+function AplaneNewDonk({ foco, aplanando }) {
+  const { camera } = useThree();
+  const camPersp = /** @type {import('three').PerspectiveCamera} */ (camera);
+  const anim = useRef({
+    activo: false,
+    p: 0,
+    desde: new THREE.Vector3(),
+    hasta: new THREE.Vector3(),
+    mira: new THREE.Vector3(),
+    fovDesde: 40,
+  });
+  useFrame((_, delta) => {
+    const a = anim.current;
+    if (!aplanando) {
+      a.activo = false;
+      return;
+    }
+    if (!a.activo) {
+      // Primer frame activo: capturar arranque y calcular la "boca" UNA vez.
+      a.activo = true;
+      a.p = 0;
+      a.desde.copy(camPersp.position);
+      a.fovDesde = camPersp.fov;
+      // Mirar el corazón del landmark, un pelo arriba.
+      a.mira.set(foco.x, foco.y + 0.8, foco.z);
+      // Boca: dolly hacia el lugar desde el lado actual de la cámara, con el
+      // ángulo BAJADO (caer sobre el lugar, no verlo de pájaro) a ~6.4 u.
+      const dir = a.desde.clone().sub(a.mira);
+      dir.y *= 0.5;
+      dir.setLength(6.4);
+      a.hasta.copy(a.mira).add(dir);
+    }
+    a.p = Math.min(1, a.p + Math.min(delta, 1 / 20) / APLANE_S);
+    const k = _easeAplane(a.p);
+    camPersp.position.lerpVectors(a.desde, a.hasta, k);
+    camPersp.lookAt(a.mira);
+    // Aplane del lente: fovDesde → 22° con curva k² (el telefoto acelera al
+    // final, el mundo se "endereza" contra la cámara justo antes del destello).
+    const fov = a.fovDesde + (APLANE_FOV - a.fovDesde) * (k * k);
+    camPersp.setFocalLength(fovAFocal(camPersp, fov));
+  });
+  return null;
+}
+
 /* ── Cámara: viaja suavemente hacia el foco (target) cuando cambia de mundo Y
       HACE ZOOM hacia el lugar — la sensación de ENTRAR con la abeja, no un modal
       plano. El acercamiento solo se fuerza durante la transición (una vez llega,
-      suelta el control para que el usuario siga haciendo zoom a mano). ── */
-function CamaraViajera({ foco, focoKey, controls, autoOrbit }) {
+      suelta el control para que el usuario siga haciendo zoom a mano). Durante
+      el APLANE New Donk cede TODO el control a AplaneNewDonk (early-return): no
+      mueve target ni zoom para no pelear con la caída. ── */
+function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false }) {
   const trans = useRef(0);
   const prevKey = useRef(focoKey);
   const entrando = focoKey !== 'valle';
   useFrame(() => {
-    if (!controls.current) return;
+    if (!controls.current || aplanando) return;
     const c = controls.current;
     if (focoKey !== prevKey.current) {
       trans.current = 1; // arrancó una nueva "entrada": acompañar el zoom
@@ -1038,7 +1114,7 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit }) {
 const CAMARA_VALLE = { position: [10.5, 9, 13.5], fov: 40 };
 
 /* ── Contenido de la escena (dentro del Canvas). ── */
-function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false }) {
+function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false, aplanando = false }) {
   const controls = useRef(null);
   // Occluders de los rótulos: solo terreno + cordillera (raycast barato y es
   // exactamente lo que las etiquetas no deben atravesar).
@@ -1122,6 +1198,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         focoKey={focoId || 'valle'}
         controls={controls}
         autoOrbit={autoOrbit}
+        aplanando={aplanando}
       />
       {/* La CÁMARA DE DIRECTOR (FASE 4): el establishing shot del mapa — dolly
           con arco desde más alto/lejos hasta la pose de siempre, UNA vez por
@@ -1138,6 +1215,10 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         activa={!reducedMotion && tier !== 'bajo'}
         unaVezClave="valle"
       />
+      {/* El aplane New Donk del flujo vivo — montado de ÚLTIMO para tener la
+          última palabra sobre la cámara mientras cae dentro del mundo. Solo
+          hace algo cuando `aplanando` (fase 'viajando'); inerte el resto. */}
+      <AplaneNewDonk foco={foco} aplanando={aplanando} />
       <AdaptiveDpr pixelated />
     </>
   );
@@ -1156,6 +1237,10 @@ export default function Valle3D({
      también en el mapa. Hoy MUESTRA; codex lo cabla con useFincaViva. */
   estadoFinca = ESTADO_FINCA_MUESTRA,
   hayAlerta = false,
+  /* Flujo vivo valle→mundo (New Donk): mientras el host viaja a un mundo, la
+     cámara del valle hace dolly + aplane hacia el landmark en vez de cortar con
+     velo. El host lo enciende en la fase 'viajando'. */
+  aplanando = false,
 }) {
   const [listo, setListo] = useState(false);
   /* El PERFIL DE RENDER del tier (DR-3D-PERF-GAMABAJA): 'alto' conserva este
@@ -1185,6 +1270,7 @@ export default function Valle3D({
           reducedMotion={reducedMotion}
           perfil={perfil}
           tier={tier}
+          aplanando={aplanando}
         />
       </Suspense>
     </Canvas>

--- a/src/visual/mundo3d/TransicionNewDonk.jsx
+++ b/src/visual/mundo3d/TransicionNewDonk.jsx
@@ -1,0 +1,237 @@
+/*
+ * TransicionNewDonk — la entrada a un mundo como MURAL New Donk, en el flujo
+ * vivo valle → mundo. NO es un velo plano: durante el primer tramo el overlay
+ * es TRANSPARENTE y lo que se ve es la cámara del valle 3D haciendo dolly +
+ * aplane casi ortográfico hacia el lugar del mundo (CamaraNewDonk, montada
+ * dentro del Canvas de Valle3D). Solo cuando la cámara ya "cayó" dentro del
+ * lugar, un DESTELLO con la luz del mundo destino crece desde el centro,
+ * cubre el intercambio de escena y se disuelve revelando el mundo.
+ *
+ * Anatomía del viaje (fracciones de ND_VIAJE_MS):
+ *   0%        → overlay transparente: el 3D del valle A LA VISTA, aplanándose
+ *               (el dolly dura ND_APLANE_MS; la abeja se lanza adelante);
+ *   ~42%–64%  → el destello (radial con el tinte del mundo) crece del centro;
+ *   64%–76%   → pantalla 100% cubierta (meseta de intercambio);
+ *   ~70%      → `onMitad`: el host intercambia la escena DEBAJO
+ *               (via useNavegacionMundos.completarViaje);
+ *   100%      → destello disuelto, el mundo revelado; `onFin`: desmontar.
+ *
+ * CONTRATO TEMPORAL (misma filosofía que TransicionMundo/TransicionMundoKit):
+ * los callbacks los disparan timers JS deterministas, NUNCA `animationend`.
+ * El CSS anima con la misma duración via `--tnd-ms` pero es decorativo.
+ * Cada callback se llama a lo sumo UNA vez por montaje.
+ *
+ * `prefers-reduced-motion`: corte directo sin dolly — un tinte plano cubre al
+ * instante, `onMitad` enseguida y un desvanecer corto (ND_REDUCIDA_MS total).
+ * (En el flujo vivo normalmente ni se monta: el hook salta las fases.)
+ *
+ * Overlay DOM puro (CERO three): seguro en el bundle base. La mitad 3D del
+ * efecto vive aparte en escenas/CamaraNewDonk.jsx (chunk vendor-three).
+ */
+import { useEffect, useRef } from 'react';
+import { AbejaAngelita } from '../creatures/AbejaAngelita.jsx';
+import { tinteDeMundo, tituloDeMundo } from './resolverMundo.js';
+
+/** Duración total del viaje New Donk (ms). */
+export const ND_VIAJE_MS = 1500;
+/** Momento de `onMitad` (ms): centro de la meseta cubierta (64%–76%). */
+export const ND_MITAD_MS = 1050;
+/** Duración del dolly+aplane de la cámara del valle (CamaraNewDonk). */
+export const ND_APLANE_MS = 950;
+/** Con reduced-motion TODO colapsa a un corte simple de esta duración. */
+export const ND_REDUCIDA_MS = 200;
+/** `onMitad` bajo reduced-motion (la cubierta es instantánea). */
+export const ND_MITAD_REDUCIDA_MS = 60;
+
+const CSS_TND = `
+.tnd {
+  position: fixed;
+  inset: 0;
+  z-index: 44;
+  overflow: hidden;
+  pointer-events: auto; /* escudo: nada de toques a mitad de la caída */
+}
+/* Viñeta que abraza los bordes mientras el valle se aplana: el 3D sigue a la
+   vista por el centro — la velocidad se siente en el marco, no en un telón. */
+.tnd__vineta {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    120% 92% at 50% 46%,
+    rgba(0, 0, 0, 0) 52%,
+    color-mix(in srgb, var(--tnd-b) 68%, #10230f) 100%
+  );
+  opacity: 0;
+  animation: tndVineta var(--tnd-ms) linear both;
+}
+/* El destello: la luz del mundo destino crece desde el punto de la caída,
+   cubre el intercambio y se disuelve sobre el mundo ya montado. */
+.tnd__destello {
+  position: absolute;
+  left: 50%;
+  top: 46%;
+  width: 175vmax;
+  height: 175vmax;
+  margin: -87.5vmax 0 0 -87.5vmax;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--tnd-a) 72%, #ffffff) 0%,
+    var(--tnd-a) 36%,
+    color-mix(in srgb, var(--tnd-b) 82%, #17301a) 80%
+  );
+  transform: scale(0.04);
+  opacity: 0;
+  animation: tndDestello var(--tnd-ms) linear both;
+}
+/* La abeja se LANZA adentro (se encoge hacia el punto de fuga, delante suyo). */
+.tnd__abeja {
+  position: absolute;
+  left: 50%;
+  top: 46%;
+  opacity: 0;
+  filter: drop-shadow(0 8px 10px rgba(16, 35, 15, 0.35));
+  animation: tndAbeja var(--tnd-ms) ease-in both;
+}
+.tnd__txt {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 9vh;
+  margin: 0;
+  text-align: center;
+  color: #f4ffe6;
+  font-size: clamp(14px, 2.4vw, 18px);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-shadow: 0 2px 10px rgba(16, 35, 15, 0.7);
+  opacity: 0;
+  animation: tndTxt var(--tnd-ms) linear both;
+}
+@keyframes tndVineta {
+  0% { opacity: 0; }
+  18% { opacity: 0.35; }
+  55% { opacity: 0.8; }
+  70% { opacity: 1; }
+  86% { opacity: 0.4; }
+  100% { opacity: 0; }
+}
+@keyframes tndDestello {
+  0% { opacity: 0; transform: scale(0.04); }
+  40% { opacity: 0; transform: scale(0.05); }
+  52% { opacity: 0.85; transform: scale(0.4); }
+  64% { opacity: 1; transform: scale(1); }
+  76% { opacity: 1; transform: scale(1.04); }
+  100% { opacity: 0; transform: scale(1.1); }
+}
+@keyframes tndAbeja {
+  0% { opacity: 0; transform: translate(-50%, 30vh) scale(1); }
+  10% { opacity: 1; }
+  46% { opacity: 1; }
+  58% { opacity: 0; transform: translate(-50%, -2vh) scale(0.26); }
+  100% { opacity: 0; transform: translate(-50%, -2vh) scale(0.26); }
+}
+@keyframes tndTxt {
+  0% { opacity: 0; }
+  14% { opacity: 1; }
+  60% { opacity: 1; }
+  74% { opacity: 0; }
+  100% { opacity: 0; }
+}
+/* Corte reduced-motion: tinte plano, sin dolly ni coreografía. */
+.tnd--corte {
+  background: linear-gradient(160deg, var(--tnd-a), var(--tnd-b) 70%);
+  animation: tndCorte var(--tnd-ms) linear both;
+}
+@keyframes tndCorte {
+  0% { opacity: 1; }
+  55% { opacity: 1; }
+  100% { opacity: 0; }
+}
+`;
+
+/**
+ * @param {object} props
+ * @param {string}  props.mundoId        mundo destino (tinte + título).
+ * @param {string}  [props.animo]        ánimo de Angelita (estado real de la finca).
+ * @param {number}  [props.energia]      energía de Angelita.
+ * @param {boolean} [props.reducedMotion] corte directo, sin dolly.
+ * @param {() => void} [props.onMitad]   pantalla cubierta: intercambie la escena.
+ * @param {() => void} [props.onFin]     mundo revelado: desmonte el overlay.
+ */
+export default function TransicionNewDonk({
+  mundoId,
+  animo = 'sereno',
+  energia = 1,
+  reducedMotion = false,
+  onMitad,
+  onFin,
+}) {
+  const mitadRef = useRef(onMitad);
+  const finRef = useRef(onFin);
+  // Refs "última versión": se actualizan en un effect (no en render) para que
+  // los timers llamen siempre al callback más fresco sin re-armarse.
+  useEffect(() => {
+    mitadRef.current = onMitad;
+    finRef.current = onFin;
+  });
+
+  useEffect(() => {
+    let hechoMitad = false;
+    let hechoFin = false;
+    const tMitad = setTimeout(
+      () => {
+        if (!hechoMitad) {
+          hechoMitad = true;
+          mitadRef.current?.();
+        }
+      },
+      reducedMotion ? ND_MITAD_REDUCIDA_MS : ND_MITAD_MS,
+    );
+    const tFin = setTimeout(
+      () => {
+        if (!hechoFin) {
+          hechoFin = true;
+          finRef.current?.();
+        }
+      },
+      reducedMotion ? ND_REDUCIDA_MS : ND_VIAJE_MS,
+    );
+    return () => {
+      hechoMitad = true;
+      hechoFin = true;
+      clearTimeout(tMitad);
+      clearTimeout(tFin);
+    };
+  }, [mundoId, reducedMotion]);
+
+  const tinte = tinteDeMundo(mundoId);
+  const estilo = {
+    '--tnd-a': tinte[1], // el tono claro del mundo, al centro del destello
+    '--tnd-b': tinte[0], // el tono profundo, hacia el borde
+    '--tnd-ms': `${reducedMotion ? ND_REDUCIDA_MS : ND_VIAJE_MS}ms`,
+  };
+
+  if (reducedMotion) {
+    return (
+      <div className="tnd tnd--corte" style={estilo} role="status" aria-live="polite" data-testid="tnd">
+        <style>{CSS_TND}</style>
+        <p className="tnd__txt" style={{ opacity: 1, animation: 'none' }}>
+          {`Angelita lo lleva a ${tituloDeMundo(mundoId)}…`}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tnd" style={estilo} role="status" aria-live="polite" data-testid="tnd">
+      <style>{CSS_TND}</style>
+      <div className="tnd__vineta" aria-hidden="true" />
+      <div className="tnd__destello" aria-hidden="true" />
+      <div className="tnd__abeja" aria-hidden="true">
+        <AbejaAngelita size={76} animo={animo} energia={energia} animated />
+      </div>
+      <p className="tnd__txt">{`Angelita lo lleva a ${tituloDeMundo(mundoId)}…`}</p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/__tests__/transicionNewDonk.test.jsx
+++ b/src/visual/mundo3d/__tests__/transicionNewDonk.test.jsx
@@ -1,0 +1,89 @@
+/*
+ * TransicionNewDonk — contrato temporal de la entrada New Donk (three-free).
+ *
+ * Congela lo que el flujo vivo valle→mundo depende:
+ *   · `onMitad` dispara UNA vez en ND_MITAD_MS (pantalla cubierta por el
+ *     destello) — ahí el host intercambia la escena;
+ *   · `onFin` dispara UNA vez en ND_VIAJE_MS (mundo revelado) — ahí se desmonta;
+ *   · desmontar a mitad cancela los timers pendientes (ni mitad ni fin fantasma);
+ *   · reduced-motion = corte simple: tiempos reducidos + marca `tnd--corte`;
+ *   · los callbacks los disparan timers JS, nunca `animationend`.
+ */
+import React from 'react';
+import { render, screen, cleanup, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach, vi } from 'vitest';
+
+import TransicionNewDonk, {
+  ND_VIAJE_MS,
+  ND_MITAD_MS,
+  ND_REDUCIDA_MS,
+  ND_MITAD_REDUCIDA_MS,
+} from '../TransicionNewDonk.jsx';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('TransicionNewDonk — contrato temporal', () => {
+  test('onMitad en ND_MITAD_MS y onFin en ND_VIAJE_MS, cada uno UNA vez', () => {
+    vi.useFakeTimers();
+    const onMitad = vi.fn();
+    const onFin = vi.fn();
+    render(<TransicionNewDonk mundoId="suelo" onMitad={onMitad} onFin={onFin} />);
+
+    act(() => vi.advanceTimersByTime(ND_MITAD_MS - 1));
+    expect(onMitad).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(onMitad).toHaveBeenCalledTimes(1);
+    expect(onFin).not.toHaveBeenCalled();
+
+    act(() => vi.advanceTimersByTime(ND_VIAJE_MS - ND_MITAD_MS));
+    expect(onFin).toHaveBeenCalledTimes(1);
+
+    act(() => vi.advanceTimersByTime(ND_VIAJE_MS * 2));
+    expect(onMitad).toHaveBeenCalledTimes(1);
+    expect(onFin).toHaveBeenCalledTimes(1);
+  });
+
+  test('desmontar a mitad de viaje cancela los timers pendientes', () => {
+    vi.useFakeTimers();
+    const onMitad = vi.fn();
+    const onFin = vi.fn();
+    const { unmount } = render(
+      <TransicionNewDonk mundoId="agua" onMitad={onMitad} onFin={onFin} />,
+    );
+
+    act(() => vi.advanceTimersByTime(ND_MITAD_MS - 10));
+    unmount();
+    act(() => vi.advanceTimersByTime(ND_VIAJE_MS * 2));
+
+    expect(onMitad).not.toHaveBeenCalled();
+    expect(onFin).not.toHaveBeenCalled();
+  });
+
+  test('reduced-motion: corte simple con tiempos reducidos', () => {
+    vi.useFakeTimers();
+    const onMitad = vi.fn();
+    const onFin = vi.fn();
+    render(
+      <TransicionNewDonk mundoId="suelo" reducedMotion onMitad={onMitad} onFin={onFin} />,
+    );
+
+    expect(screen.getByTestId('tnd')).toHaveClass('tnd--corte');
+
+    act(() => vi.advanceTimersByTime(ND_MITAD_REDUCIDA_MS));
+    expect(onMitad).toHaveBeenCalledTimes(1);
+
+    act(() => vi.advanceTimersByTime(ND_REDUCIDA_MS - ND_MITAD_REDUCIDA_MS));
+    expect(onFin).toHaveBeenCalledTimes(1);
+  });
+
+  test('monta el overlay (data-testid) en modo normal', () => {
+    render(<TransicionNewDonk mundoId="bosque" />);
+    expect(screen.getByTestId('tnd')).toBeInTheDocument();
+    expect(screen.getByTestId('tnd')).not.toHaveClass('tnd--corte');
+  });
+});

--- a/src/visual/mundo3d/index.js
+++ b/src/visual/mundo3d/index.js
@@ -33,6 +33,14 @@ export { decidirTier, permite3D, perfilDeTier } from './deviceTier.js';
 // Navegación valle ↔ mundos (three-free): la máquina de fases + el viaje DOM.
 export { useNavegacionMundos, puedeEntrarAlMundo } from './useNavegacionMundos.js';
 export { default as TransicionMundo, VIAJE_MS } from './TransicionMundo.jsx';
+// Entrada a un mundo como MURAL New Donk (dolly + aplane ortográfico) para el
+// flujo vivo valle→mundo — alternativa al velo, mismo contrato de timers JS.
+export {
+  default as TransicionNewDonk,
+  ND_VIAJE_MS,
+  ND_MITAD_MS,
+  ND_APLANE_MS,
+} from './TransicionNewDonk.jsx';
 
 // Háptica táctil (three-free, DR-3D-HAPTICA): pulsos semánticos por evento del
 // framework — no-op silencioso donde no hay Vibration API (iOS/Safari, FF129+).


### PR DESCRIPTION
## Qué

Lleva el efecto **New Donk (2D-en-3D)** al flujo vivo `valle → mundo`. Hoy entrar a un mundo usa un **velo 2D** (`TransicionMundo`) que corta con un telón. Ahora, entrar se siente como caer dentro del mural: la **cámara del valle 3D hace dolly + aplane casi ortográfico** (FOV → 22°) hacia el landmark del mundo destino — el resto del valle 3D asoma en los bordes — y solo cuando la cámara ya "cayó" dentro, un **destello** con la luz del mundo cubre el intercambio de escena y se disuelve revelando el mundo.

Volver al valle conserva el **velo clásico** (el New Donk es un efecto de ENTRADA).

## Cómo

- **`src/visual/mundo3d/TransicionNewDonk.jsx`** (NUEVO): overlay DOM puro (cero three), mismo **contrato temporal** que el velo/kit — timers JS deterministas, nunca `animationend`:
  - `onMitad` (ND_MITAD_MS, pantalla cubierta por el destello) → el host intercambia la escena;
  - `onFin` (ND_VIAJE_MS, mundo revelado) → desmonte.
  - Fase transparente al inicio (deja ver el aplane del valle) → viñeta → destello radial con el tinte del mundo. `prefers-reduced-motion` → corte directo.
- **`src/mockups/valle/Valle3D.jsx`**: `AplaneNewDonk` imperativo (solo métodos three: `lerpVectors`/`lookAt`/`setFocalLength`, sin reasignar props → respeta `react-hooks/immutability`), montado **de último** para tener la última palabra sobre la cámara; `CamaraViajera` cede con early-return cuando `aplanando`. Nuevo prop `aplanando`.
- **`src/mockups/EntradaValle3D.jsx`**: cablea la entrada New Donk detrás del flag de módulo `ENTRADA_NEWDONK` manteniendo el mismo contrato (`completarViaje` en el punto medio). El overlay **sobrevive al swap** de escena (se apaga en su `onFin`, no al cambiar de fase) para revelar el mundo bajo el destello. El swap ocurre bajo el destello, así que el Canvas del valle se desmonta cubierto y el mundo destino aparece revelándose. Deep-link inicial cae al velo por fallback.
- Coordinación de timing: `APLANE_S` (0.95 s) < `ND_MITAD_MS` (1.05 s) → el dolly cierra ANTES del swap.

## Alcance

Edits mínimos a la máquina de navegación viva: **cero cambios** a `useNavegacionMundos.js`. El encendido va en el handler `entrarAlMundo` (evento, no effect).

## Verificación

- `npm run build`: verde.
- `npx eslint` sobre los 5 archivos tocados: 0 problemas.
- Test de contrato temporal del overlay: 4/4.
- Suites preexistentes `entradaValle3D.nav` y `useAudioMundo` fallan idéntico en base (jsdom/WebGL/speech mocks) — no es regresión de este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)