### PR TITLE
feat(creatures): pasada rubber-hose sobre Angelita 2D + atenuar su malla 3D

### DIFF
--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -31,9 +31,13 @@ export function AbejaAngelita({
   animated = true,
   title = 'Abeja angelita',
   /* Pose de VIDA (idle-life): 'vuela' (default, aleteo normal) | 'celebra'
-     (aleteo rápido, la escena puede darle la vuelta de campana) | 'reposo'
-     (alitas plegadas que respiran despacio). Solo cambia CSS por data-pose:
-     los consumidores existentes no notan nada. */
+     (SALTO con anticipación + brazos en V que rebasan y asientan) | 'reposo'
+     (alitas plegadas + respiración lenta) | 'señala' (se inclina hacia el POI
+     y extiende el bracito apuntando, con overshoot). Los gestos viven en
+     `creatures.css` (keyframes rh-celebra / rh-reposo / rh-senala) y solo se
+     activan cuando la creature está viva (animated); con animated=false o
+     reduced-motion la abeja queda en fotograma digno (bracitos colgando,
+     sonriendo). Solo cambia CSS por data-pose: consumidores viejos no notan nada. */
   pose = 'vuela',
   /* ── REACTIVIDAD AL ESTADO REAL DE LA FINCA (auditoría §5b) ────────────────
      El repertorio de reacción que la escena deriva de la finca (reaccionFinca).
@@ -156,9 +160,15 @@ export function AbejaAngelita({
         </g>
       ))}
 
-      {/* bracitos manguera con mitón crema (delante del tronco, follow-through) */}
-      <Miembro d="M-6.2,1.4 C-8.2,2.4 -9.0,4.1 -8.4,5.9" ancho={2.1} punta={[-8.5, 6.2]} puntaR={1.55} sway={vivo} delay={-0.15} />
-      <Miembro d="M5.4,3.0 C6.9,4.2 7.5,5.9 7.0,7.5" ancho={2.2} punta={[7.0, 7.8]} puntaR={1.6} sway={vivo} delay={-0.45} />
+      {/* bracitos manguera con mitón crema (delante del tronco, follow-through).
+          Marcados (crt-brazo-l/r) y con pivote en el HOMBRO para que los gestos
+          celebra/señala los alcen desde el hombro, no desde el centro del bbox:
+          el hombro izquierdo cae arriba-derecha de su bbox ('right top'); el
+          derecho, arriba-izquierda ('left top'). */}
+      <Miembro clase="crt-brazo-l" origen="right top"
+        d="M-6.2,1.4 C-8.2,2.4 -9.0,4.1 -8.4,5.9" ancho={2.1} punta={[-8.5, 6.2]} puntaR={1.55} sway={vivo} delay={-0.15} />
+      <Miembro clase="crt-brazo-r" origen="left top"
+        d="M5.4,3.0 C6.9,4.2 7.5,5.9 7.0,7.5" ancho={2.2} punta={[7.0, 7.8]} puntaR={1.6} sway={vivo} delay={-0.45} />
 
       {/* cabeza clara con contorno */}
       <circle cx="8.6" cy="-1.0" r={ABEJA_PROPORCION.cabezaR} fill={ABEJA_PALETA.cabeza} stroke={RH_INK} strokeWidth="1.2" />
@@ -187,9 +197,12 @@ export function AbejaAngelita({
   ) : body;
 
   // data-estado agrupa la reacción para el CSS (brillo mojado, jadeo, mordisco).
+  // data-pose SOLO cuando está viva: así los gestos (celebra/reposo/señala) no
+  // corren con animated=false — la abeja queda en fotograma digno (bracitos
+  // colgando, sonriendo). RM lo apaga además por dentro del CSS.
   const estadoAttrs = {
     'data-creature': 'abeja-angelita',
-    'data-pose': pose,
+    'data-pose': vivo ? pose : undefined,
     'data-animo': animo,
     'data-tier': tier || undefined,
     'data-mojada': mojada ? '1' : undefined,

--- a/src/visual/creatures/_rubberhose.jsx
+++ b/src/visual/creatures/_rubberhose.jsx
@@ -99,6 +99,13 @@ export function Sonrisa({ cx = 0, cy = 0, w = 3, prof = 1.4, ink = RH_INK }) {
  * mitón/pie crema en la punta — la firma de Cuphead. Con `rh-sway` cuelga y
  * hace follow-through (secondary motion) en el idle.
  *
+ * `clase` da nombre al miembro (p.ej. 'crt-brazo-r') para que los GESTOS de la
+ * criatura (celebra/señala) lo agarren por CSS; `origen` es su transform-origin
+ * — el HOMBRO/CADERA real dentro del fill-box (para brazos que se alzan, 'top
+ * center' quedaba lejos del hombro y la rotación descolgaba el miembro). El
+ * estilo de pivote se estampa SIEMPRE (haya o no sway): así los gestos ESTÁTICOS
+ * (fotograma digno con animated=false / reduced-motion) también pivotan bien.
+ *
  * @param {Object} props
  * @param {string} props.d
  * @param {number} [props.ancho=2.3]
@@ -107,16 +114,21 @@ export function Sonrisa({ cx = 0, cy = 0, w = 3, prof = 1.4, ink = RH_INK }) {
  * @param {boolean} [props.pie=false]
  * @param {boolean} [props.sway=false]
  * @param {number} [props.delay=0]
+ * @param {string} [props.clase]  clase extra del gesto (p.ej. 'crt-brazo-l')
+ * @param {string} [props.origen='top center']  transform-origin (el hombro)
  */
 export function Miembro({
   d, ancho = 2.3, punta = null, puntaR = 1.6, pie = false, sway = false, delay = 0,
-  ink = RH_INK, glove = RH_GLOVE,
+  clase, origen = 'top center', ink = RH_INK, glove = RH_GLOVE,
 }) {
-  const style = sway
-    ? { transformBox: 'fill-box', transformOrigin: 'top center', animationDelay: `${delay}s` }
-    : undefined;
+  const style = {
+    transformBox: 'fill-box',
+    transformOrigin: origen,
+    ...(sway ? { animationDelay: `${delay}s` } : null),
+  };
+  const clases = [sway ? 'rh-sway' : null, clase].filter(Boolean).join(' ') || undefined;
   return (
-    <g className={sway ? 'rh-sway' : undefined} style={style}>
+    <g className={clases} style={style}>
       <path d={d} stroke={ink} strokeWidth={ancho} fill="none" strokeLinecap="round" strokeLinejoin="round" />
       {punta && (pie ? (
         <ellipse cx={punta[0]} cy={punta[1]} rx={puntaR * 1.15} ry={puntaR * 0.72} fill={glove} stroke={ink} strokeWidth="0.7" />

--- a/src/visual/creatures/creatureClimaCuerpo.js
+++ b/src/visual/creatures/creatureClimaCuerpo.js
@@ -81,19 +81,22 @@ const CLIMA_BASE = {
     velocidadAlas: 0.9,
     altura: 0.85, // vuela corto y cerca — no se pierde en la bruma
   },
-  // La hora dorada: vibrante, dorándose al sol bajo, alas rápidas.
+  // La hora dorada: cálida al sol bajo, alas ágiles. ATENUADA a propósito: el
+  // dorado saturaba y cansaba la vista (la Angelita 3D se veía "solo dorada,
+  // demasiado brillante"). Bajamos saturación/brillo — sigue dorándose, sin
+  // quemar. La des-saturación fina del billboard 3D la remata en mundo.css.
   dorada: {
     humedad: 0,
     opacidad: 1,
-    tinte: 'saturate(1.18) brightness(1.06)',
-    velocidadAlas: 1.3,
-    altura: 1.05, // se luce un poquito más alto
+    tinte: 'saturate(1.05) brightness(1.02)',
+    velocidadAlas: 1.18,
+    altura: 1.04, // se luce un pelín más alto
   },
   // Día claro y honesto: viva, apenas más ágil que el neutro.
   soleado: {
     humedad: 0,
     opacidad: 1,
-    tinte: 'saturate(1.06)',
+    tinte: 'saturate(1.03)',
     velocidadAlas: 1.1,
     altura: 1,
   },

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -65,6 +65,95 @@
   100% { transform: scaleY(0.5) scaleX(0.9); }
 }
 
+/* ═══ GESTOS con CARÁCTER (Cuphead / Miss-Minutes) ══════════════════════════
+   Overshoot + follow-through de verdad: el cuerpo ANTICIPA (squash), rebasa y
+   REGRESA elástico; los bracitos de manguera pivotan desde el HOMBRO (crt-brazo-*
+   traen su transform-origin) rebasando la pose y asentándose un pelo después que
+   el cuerpo (secondary motion). Nada lineal. Los gestos PISAN el boil/sway por
+   especificidad (el data-pose suma un selector). Gate RM/tier al final. ─────── */
+
+/* CELEBRA — brinca: se agacha para coger impulso, SALTA con stretch y aterriza
+   con overshoot elástico; los bracitos se alzan en V rebasando y asentando. */
+[data-creature='abeja-angelita'][data-pose='celebra'] .crt-body {
+  animation: rh-celebra-cuerpo 1.15s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes rh-celebra-cuerpo {
+  0%   { transform: translateY(0) scale(1, 1); }
+  16%  { transform: translateY(1.3px) scale(1.09, 0.9); }   /* anticipa: se agacha (squash) */
+  40%  { transform: translateY(-4.2px) scale(0.9, 1.13); }  /* ¡SALTA! (stretch) */
+  60%  { transform: translateY(0.7px) scale(1.11, 0.9); }   /* aterriza (squash, overshoot) */
+  78%  { transform: translateY(-0.7px) scale(0.98, 1.04); } /* rebote elástico */
+  100% { transform: translateY(0) scale(1, 1); }
+}
+[data-creature='abeja-angelita'][data-pose='celebra'] .crt-brazo-l {
+  animation: rh-celebra-brazo-l 1.15s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+}
+[data-creature='abeja-angelita'][data-pose='celebra'] .crt-brazo-r {
+  animation: rh-celebra-brazo-r 1.15s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+}
+/* La abeja es 3/4 (cabeza a la derecha): una V simétrica metería el brazo
+   derecho DENTRO de la cara. Así que el IZQUIERDO (lado libre) se alza bien
+   arriba y el DERECHO se abre a la derecha sin taparse — celebración dinámica,
+   asimétrica, legible. +θ sube el izq (colgante SW → arriba); −θ abre el der.
+   Rebasan el pico y asientan un pelo (follow-through). */
+@keyframes rh-celebra-brazo-l {
+  0%, 12% { transform: rotate(0deg); }
+  40%  { transform: rotate(150deg); }   /* alza arriba-izquierda, rebasa */
+  62%  { transform: rotate(134deg); }   /* asienta (follow-through) */
+  80%  { transform: rotate(141deg); }
+  100% { transform: rotate(0deg); }
+}
+@keyframes rh-celebra-brazo-r {
+  0%, 12% { transform: rotate(0deg); }
+  40%  { transform: rotate(-112deg); }  /* abre a la derecha (bajo la carita) */
+  62%  { transform: rotate(-98deg); }
+  80%  { transform: rotate(-105deg); }
+  100% { transform: rotate(0deg); }
+}
+
+/* REPOSO — respira: el cuerpo infla y desinfla despacio (inhala suave). Las
+   alitas ya van plegadas (crt-wing-reposo); esto le da el pecho que sube. */
+[data-creature='abeja-angelita'][data-pose='reposo'] .crt-body {
+  animation: rh-reposo-respira 4.4s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes rh-reposo-respira {
+  0%, 100% { transform: translateY(0) scale(1, 1); }
+  50%      { transform: translateY(-0.4px) scale(0.985, 1.03); }  /* inhala */
+}
+
+/* SEÑALA — se inclina hacia el POI (a su derecha, donde mira) rebasando la
+   inclinación y asentándose, y extiende el bracito derecho apuntando. Sostiene
+   el gesto un momento (no es un tic) y vuelve. Overshoot en ambos. */
+[data-creature='abeja-angelita'][data-pose='señala'] .crt-body {
+  animation: rh-senala-cuerpo 2.9s cubic-bezier(0.5, 0, 0.25, 1.4) infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes rh-senala-cuerpo {
+  0%, 100% { transform: rotate(0deg) translateX(0); }
+  20%  { transform: rotate(9deg) translateX(0.7px); }   /* se inclina rebasando */
+  30%  { transform: rotate(6.5deg) translateX(0.5px); } /* asienta apuntando */
+  72%  { transform: rotate(6.5deg) translateX(0.5px); } /* sostiene el gesto */
+  86%  { transform: rotate(-1.5deg) translateX(0); }    /* rebote al enderezarse */
+}
+[data-creature='abeja-angelita'][data-pose='señala'] .crt-brazo-r {
+  animation: rh-senala-brazo 2.9s cubic-bezier(0.5, 0, 0.25, 1.4) infinite;
+}
+/* El bracito derecho apunta abajo-derecha (a una mata/POI en el suelo): así SALE
+   de detrás de la carita (que vive a la derecha) y el gesto se LEE. Rebasa (−52°)
+   y asienta (−44°) sosteniendo, luego recoge (follow-through). */
+@keyframes rh-senala-brazo {
+  0%, 100% { transform: rotate(0deg); }
+  20%  { transform: rotate(-52deg); }   /* extiende apuntando (rebasa) */
+  30%  { transform: rotate(-44deg); }   /* asienta señalando la mata */
+  72%  { transform: rotate(-44deg); }
+  86%  { transform: rotate(-6deg); }    /* recoge con follow-through */
+}
+
 /* ═══════════════════════════════════════════════════════════════════════════
    KIT RUBBER-HOSE (Cuphead + Miss Minutes de Loki) — SPECIES-AGNOSTIC
    Cadencia de goma REUTILIZABLE por cualquier creature. Angelita la estrena;
@@ -184,13 +273,16 @@
 [data-animo='descansa'] .rh-travieso,
 [data-animo='descansa'] .rh-mirada { animation: none; }
 
-/* Los estados reactivos (mojada/sed/comiendo) y el reposo PISAN el arrebato:
-   una abeja empapada o libando no da vueltas de campana. */
+/* Los estados reactivos (mojada/sed/comiendo) y los gestos con carácter
+   (reposo/celebra/señala) PISAN el arrebato: una abeja empapada, libando,
+   celebrando o señalando no da además vueltas de campana — el gesto lee limpio. */
 [data-mojada='1'] .rh-antic, [data-mojada='1'] .rh-travieso,
 [data-sed='1'] .rh-antic, [data-sed='1'] .rh-travieso,
 [data-comiendo='1'] .rh-antic, [data-comiendo='1'] .rh-travieso,
 [data-pose='reposo'] .rh-antic, [data-pose='reposo'] .rh-travieso,
-[data-pose='reposo'] .rh-mirada { animation: none; }
+[data-pose='reposo'] .rh-mirada,
+[data-pose='celebra'] .rh-antic, [data-pose='celebra'] .rh-travieso,
+[data-pose='señala'] .rh-antic, [data-pose='señala'] .rh-travieso { animation: none; }
 
 /* FOLLOW-THROUGH (secondary motion) — antenas, bracitos y patitas de manguera
    se mecen con retardo: delatan que el cuerpo se movió. Cada miembro pone su
@@ -226,7 +318,12 @@
 
 @media (prefers-reduced-motion: reduce) {
   .rh-boil, .rh-blink, .rh-sway, .rh-smear,
-  .rh-antic, .rh-travieso, .rh-mirada, .rh-rubor { animation: none !important; }
+  .rh-antic, .rh-travieso, .rh-mirada, .rh-rubor,
+  /* Los gestos (celebra/reposo/señala) también se congelan: fotograma digno
+     (bracitos colgando, cuerpo neutro, sonriendo). */
+  [data-pose='celebra'] .crt-body, [data-pose='celebra'] .crt-brazo-l, [data-pose='celebra'] .crt-brazo-r,
+  [data-pose='reposo'] .crt-body,
+  [data-pose='señala'] .crt-body, [data-pose='señala'] .crt-brazo-r { animation: none !important; }
 }
 
 /* ── REACCIÓN AL ESTADO REAL DE LA FINCA (auditoría §5b) ──────────────────────

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -165,7 +165,12 @@
    media REBOTA al toque, la cara VOLTEA (scaleX imperativo por frame). */
 .mundo-abeja {
   pointer-events: none;
-  filter: drop-shadow(0 4px 8px rgba(40, 30, 10, 0.28));
+  /* ATENUADA en los mundos 3D a propósito: la Angelita del billboard cansaba
+     la vista — "demasiado brillante, solo dorada". Bajamos saturación y brillo
+     del billboard y suavizamos su sombra. NO toca la Angelita 2D del home ni los
+     avatares: ellos NO montan `.mundo-abeja` (se ven exactamente igual). Esto se
+     compone sobre el tinte de clima del SVG (ya rebajado en creatureClimaCuerpo). */
+  filter: saturate(0.85) brightness(0.95) drop-shadow(0 4px 8px rgba(40, 30, 10, 0.22));
   transform-origin: center bottom;
 }
 .mundo-abeja__rebote {

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -40,6 +40,18 @@ const VARIANTES_CREATURE = [
   { label: 'sin animación', props: { size: 80, animated: false } },
 ];
 
+/* La Angelita estrena los GESTOS con carácter (rubber-hose Cuphead/Miss-Minutes):
+   celebra (salto + brazos en V con overshoot), reposo (respira lento) y señala
+   (se inclina al POI y apunta). La vitrina los muestra como variantes propias. */
+const VARIANTES_ABEJA = [
+  { label: '48 px', props: { size: 48 } },
+  { label: 'vuela', props: { size: 80 } },
+  { label: 'celebra', props: { size: 80, pose: 'celebra' } },
+  { label: 'reposo', props: { size: 80, pose: 'reposo' } },
+  { label: 'señala', props: { size: 80, pose: 'señala' } },
+  { label: 'sin animación', props: { size: 80, animated: false } },
+];
+
 /* Nota de campo por creature (el registro de la categoría trae nombre + binomio;
    la descripción de una línea va aquí). */
 const NOTAS_CREATURE = {
@@ -229,7 +241,7 @@ const ITEMS_CREATURES = Object.entries(CREATURES).map(([slug, meta]) => ({
   render: 'component',
   descripcion: NOTAS_CREATURE[slug] || '',
   props: PROPS_CREATURE,
-  variantes: VARIANTES_CREATURE,
+  variantes: slug === 'abeja-angelita' ? VARIANTES_ABEJA : VARIANTES_CREATURE,
 }));
 
 const ITEMS_LAMINAS = Object.entries(LAMINAS).map(([slug, meta]) => ({


### PR DESCRIPTION
## Qué

Dos cosas sobre la abeja **Angelita**, siguiendo la preferencia del operador (la 2D "se distingue, gestos claros"; la 3D "cansa, demasiado brillante, solo dorada"):

### (A) Rubber-hose sobre la Angelita 2D (`AbejaAngelita.jsx`, DOM/SVG, cero three)
Gestos con **carácter** (Cuphead / Miss-Minutes) — overshoot + follow-through, nada lineal:
- **celebra**: salto con anticipación (squash) → stretch → aterrizaje con overshoot elástico; bracitos que se alzan rebasando y asientan. Como la abeja es 3/4 (carita a la derecha), el brazo del lado libre sube alto y el otro se abre sin taparse la cara.
- **reposo**: alitas plegadas + respiración lenta (el pecho sube y baja).
- **señala**: se inclina hacia el POI rebasando y sostiene el gesto; el bracito apunta abajo-derecha (a la mata), saliendo de detrás de la carita.
- Los bracitos (`Miembro`) ahora **pivotan desde el hombro** (nuevos props `clase` + `origen` en `_rubberhose.jsx`) para que los gestos los alcen bien.
- Squash&stretch del aleteo/flotar y la **línea que respira** (boil) siguen; se preservan.
- `data-pose` solo cuando la creature está **viva**: con `animated=false` o `prefers-reduced-motion` queda en **fotograma digno** (bracitos colgando, sonriendo). Gate RM/tier respetado.

### (B) Atenuar la presencia 3D (sin tocar la 2D del home ni los avatares)
- `creatureClimaCuerpo.js`: el tinte **'dorada'** (el que saturaba) baja de `saturate(1.18) brightness(1.06)` → `1.05 / 1.02`; 'soleado' también.
- `mundo.css`: el billboard `.mundo-abeja` (que **solo** existe dentro de los mundos 3D) se des-satura (`saturate .85 brightness .95`) y suaviza su sombra. La Angelita 2D del home **no** monta `.mundo-abeja`, así que se ve idéntica. El **cruce 2D→3D** (`AbejaTransicion`) queda intacto.

### Vitrina
`registry.js` suma variantes **celebra / reposo / señala** a la Angelita en `#/mockups/visual-lib`.

## Verificación
- `npm run build`: **verde**.
- `vitest run` visualLib.smoke + creatureIdle: **17/17 verdes**.
- Screenshots de las variantes tomadas con chromium del sistema + swiftshader sobre `#/mockups/visual-lib`.

## Notas
- Tema nature/biopunk verde-vivo, UI en usted. Sin dependencias nuevas; todo `transform`/`opacity` (GPU, Android gama baja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)