### PR TITLE
feat(mockups): murales New Donk por mundo — café, agua y semillero

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -167,6 +167,8 @@ const JuegoMiFincaMockup = lazy(() => import('./mockups/JuegoMiFincaOdyssey'));
 const VentanaValleMockup = lazy(() => import('./components/VentanaValle3D'));
 // New Donk: un plano 2D lado-a-lado embebido DENTRO del valle 3D (Mario Odyssey).
 const NewDonkMockup = lazy(() => import('./mockups/NewDonk2Den3D'));
+// Murales New Donk POR MUNDO: café, agua y semillero — cada uno su plano 2D propio.
+const MuralesNewDonkMockup = lazy(() => import('./mockups/MuralesNewDonk'));
 const VitrinaMaestraMockup = lazy(() => import('./mockups/VitrinaMaestraMundos'));
 const MundoFermentosMockup = lazy(() => import('./mockups/MundoFermentos3D'));
 const GemelosMundosMockup = lazy(() => import('./mockups/GemelosMundos2D'));
@@ -596,6 +598,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/juego-mi-finca': 'mockup_juego_mi_finca',
   'mockups/ventana-valle': 'mockup_ventana_valle',
   'mockups/new-donk': 'mockup_new_donk',
+  'mockups/murales-new-donk': 'mockup_murales_new_donk',
   'mockups/vitrina-maestra': 'mockup_vitrina_maestra',
   'mockups/mundo-fermentos-3d': 'mockup_mundo_fermentos_3d',
   'mockups/gemelos-2d': 'mockup_gemelos_2d',
@@ -1918,6 +1921,17 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="New Donk 2D en 3D">
               <NewDonkMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_murales_new_donk':
+        // Murales New Donk por mundo: café, agua y semillero — tres vallas en el
+        // mismo valle 3D, cada una con su side-scroller 2D propio (parallax +
+        // Angelita) y la cámara aplanándose contra el mural elegido. Sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Murales New Donk por mundo">
+              <MuralesNewDonkMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/MuralesNewDonk.jsx
+++ b/src/mockups/MuralesNewDonk.jsx
@@ -1,0 +1,547 @@
+/*
+ * MuralesNewDonk — vitrina de los murales New Donk POR MUNDO: café, agua y
+ * semillero. Tres vallas viven juntas en el mismo valle 3D, cada una con su
+ * propio side-scroller 2D (parallax + Angelita caminando) con la identidad
+ * visual de su mundo. La cámara reutiliza CamaraOdyssey (TunelOdyssey): se
+ * aplana ortográficamente contra el mural elegido (FOV→20) y el valle — y
+ * los murales vecinos — asoman de verdad por los bordes. NO se desmonta el
+ * Canvas ni hay iris: el cruce es 100% viaje de cámara, igual que en
+ * NewDonk2Den3D.
+ *
+ * Selector: chips abajo (Café / Agua / Semillero). En órbita eligen y entran;
+ * ya adentro, cambian de mural (la cámara sale al valle y entra al otro, un
+ * solo gesto). Tocar una valla en órbita también entra.
+ *
+ * Afordancia de demo/QA: `/?mural=agua&plano=2d#/mockups/murales-new-donk`
+ * arranca ya aplanado contra ese mural (para capturas).
+ *
+ * Con prefers-reduced-motion la cámara salta en un frame y los murales
+ * quedan como láminas quietas.
+ *
+ * Mockup standalone con su propio <Canvas>. Sin auth.
+ */
+import { useCallback, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import { CamaraOdyssey } from '../visual/mundo3d/TunelOdyssey.jsx';
+import { MuralParallax, MURAL_DF } from './murales/MuralParallax.jsx';
+import { MURAL_CAFE } from './murales/muralCafe.jsx';
+import { MURAL_AGUA } from './murales/muralAgua.jsx';
+import { MURAL_SEMILLERO } from './murales/muralSemillero.jsx';
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LAS TRES VALLAS EN EL VALLE — posición + orientación por mundo
+   ══════════════════════════════════════════════════════════════════════════ */
+
+const TEMAS = [MURAL_CAFE, MURAL_AGUA, MURAL_SEMILLERO];
+
+/* Café y semillero flanquean, giradas hacia adentro; agua preside al centro. */
+const VALLAS = {
+  cafe: { pos: [-5.1, 2.0, -0.7], rotY: 0.32 },
+  agua: { pos: [0, 2.0, -1.9], rotY: 0 },
+  semillero: { pos: [5.1, 2.0, -0.7], rotY: -0.32 },
+};
+
+/* Órbita 3D: las tres vallas leídas juntas en el claro. */
+const POSE_VALLE = {
+  pos: new THREE.Vector3(0, 4.4, 12.8),
+  mira: new THREE.Vector3(0, 1.8, -0.8),
+  fov: 52,
+};
+
+/* La "boca" de cada mural: de frente sobre su normal, FOV 20 (casi
+   ortográfico) a 9.2 unidades — el mismo encuadre de NewDonk2Den3D, donde
+   el plano llena ~70% de la vista y el 3D asoma por los bordes. */
+function poseBocaDe(id) {
+  const v = VALLAS[id];
+  const n = new THREE.Vector3(Math.sin(v.rotY), 0, Math.cos(v.rotY));
+  return {
+    pos: new THREE.Vector3().fromArray(v.pos).addScaledVector(n, 9.2),
+    mira: new THREE.Vector3().fromArray(v.pos),
+    fov: 20,
+  };
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   PALETA del valle (verde-vivo, cálida)
+   ══════════════════════════════════════════════════════════════════════════ */
+const P = {
+  cielo: '#e3f3cd',
+  niebla: '#d6ecc0',
+  pasto: '#6fae52',
+  pastoHondo: '#5a9443',
+  senda: '#8fbf6b',
+  follaje: '#3f8a3d',
+  follajeClaro: '#63ad4f',
+  follajeLima: '#8cc95e',
+  tronco: '#7a5a38',
+  piedra: '#93a48b',
+  espora: '#c4ff8e',
+  tinta: '#2a3d1f',
+  crema: '#fdf8e8',
+};
+
+/* ══════════════════════════════════════════════════════════════════════════
+   ESCENA 3D — el valle alrededor (low-poly, lambert, sin sombras)
+   ══════════════════════════════════════════════════════════════════════════ */
+
+function Arbol({ x, z, alto = 2.2, copa = P.follaje, s = 1 }) {
+  return (
+    <group position={[x, 0, z]} scale={s}>
+      <mesh position={[0, alto * 0.35, 0]}>
+        <cylinderGeometry args={[0.1, 0.16, alto * 0.7, 6]} />
+        <meshLambertMaterial color={P.tronco} flatShading />
+      </mesh>
+      <mesh position={[0, alto * 0.72, 0]}>
+        <coneGeometry args={[0.85, alto * 0.9, 7]} />
+        <meshLambertMaterial color={copa} flatShading />
+      </mesh>
+      <mesh position={[0, alto * 1.12, 0]}>
+        <coneGeometry args={[0.55, alto * 0.62, 7]} />
+        <meshLambertMaterial color={P.follajeClaro} flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+function Mata({ x, z, s = 1, color = P.follajeLima }) {
+  return (
+    <group position={[x, 0, z]} scale={s}>
+      <mesh position={[0, 0.28, 0]} scale={[1, 0.72, 1]}>
+        <icosahedronGeometry args={[0.42, 0]} />
+        <meshLambertMaterial color={color} flatShading />
+      </mesh>
+      <mesh position={[0.3, 0.2, 0.14]} scale={[1, 0.6, 1]}>
+        <icosahedronGeometry args={[0.26, 0]} />
+        <meshLambertMaterial color={P.follaje} flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+function Roca({ x, z, s = 1 }) {
+  return (
+    <mesh position={[x, 0.16 * s, z]} scale={[s, s * 0.62, s]} rotation={[0, x + z, 0]}>
+      <dodecahedronGeometry args={[0.34, 0]} />
+      <meshLambertMaterial color={P.piedra} flatShading />
+    </mesh>
+  );
+}
+
+/* Esporas que derivan lento; con reduced-motion quedan suspendidas. */
+const ESPORAS = Array.from({ length: 16 }, (_, i) => ({
+  x: Math.sin(i * 2.4) * (4.2 + (i % 4)),
+  y: 1.1 + ((i * 0.53) % 2.4),
+  z: -1.4 + Math.cos(i * 1.7) * (2.6 + (i % 3)),
+  f: 0.35 + (i % 5) * 0.12,
+  d: i * 1.9,
+  r: 0.035 + (i % 3) * 0.016,
+}));
+
+function Esporas({ reducedMotion }) {
+  const refs = useRef([]);
+  useFrame(({ clock }) => {
+    if (reducedMotion) return;
+    const t = clock.elapsedTime;
+    ESPORAS.forEach((e, i) => {
+      const m = refs.current[i];
+      if (!m) return;
+      m.position.y = e.y + Math.sin(t * e.f + e.d) * 0.32;
+      m.position.x = e.x + Math.cos(t * e.f * 0.7 + e.d) * 0.22;
+    });
+  });
+  return (
+    <group>
+      {ESPORAS.map((e, i) => (
+        <mesh key={i} ref={(m) => { refs.current[i] = m; }} position={[e.x, e.y, e.z]}>
+          <sphereGeometry args={[e.r, 6, 6]} />
+          <meshBasicMaterial color={P.espora} toneMapped={false} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function EscenaValle({ reducedMotion }) {
+  return (
+    <group>
+      <hemisphereLight args={['#f3ffe0', '#48793c', 0.85]} />
+      <directionalLight position={[6, 9, 5]} intensity={1.15} color="#fff3d2" />
+      <ambientLight intensity={0.35} color="#eaffdc" />
+
+      {/* piso y claro */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
+        <circleGeometry args={[30, 40]} />
+        <meshLambertMaterial color={P.pasto} flatShading />
+      </mesh>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.012, 2.2]}>
+        <circleGeometry args={[5.6, 28]} />
+        <meshLambertMaterial color={P.senda} flatShading />
+      </mesh>
+
+      {/* lomas de fondo */}
+      {[[-11, -10, 3.4], [9, -11, 4.2], [0, -14, 5.4], [15, -5, 2.8], [-16, -4, 2.6]].map(([x, z, s], i) => (
+        <mesh key={i} position={[x, -s * 0.45, z]} scale={[s * 1.5, s, s]}>
+          <sphereGeometry args={[1, 12, 10]} />
+          <meshLambertMaterial color={i % 2 ? P.pastoHondo : P.follaje} flatShading />
+        </mesh>
+      ))}
+
+      {/* arboleda ATRÁS y a los LADOS de las vallas — nada cruza por delante,
+          para que en modo 2D el valle asome limpio por los bordes */}
+      <Arbol x={-9.2} z={-2.4} alto={2.7} />
+      <Arbol x={9.4} z={-2.2} alto={2.8} copa={P.follajeClaro} />
+      <Arbol x={-2.6} z={-5.4} alto={3.1} s={1.15} />
+      <Arbol x={2.8} z={-5.8} alto={3.0} s={1.2} copa={P.follajeClaro} />
+      <Arbol x={-7.4} z={-5.2} alto={3.3} s={1.1} />
+      <Arbol x={7.6} z={-5.6} alto={3.2} s={1.15} />
+      <Arbol x={-11.2} z={2.4} alto={2.3} />
+      <Arbol x={11.4} z={2.8} alto={2.4} copa={P.follaje} />
+
+      <Mata x={-3.0} z={1.6} s={1.2} />
+      <Mata x={3.2} z={1.8} s={1.05} color={P.follajeClaro} />
+      <Mata x={-7.3} z={2.2} s={0.9} />
+      <Mata x={7.5} z={2.4} s={1.1} />
+      <Mata x={-1.6} z={4.4} s={0.8} color={P.follajeLima} />
+      <Mata x={2.0} z={4.8} s={0.85} />
+      <Roca x={-4.4} z={2.9} s={1.1} />
+      <Roca x={4.8} z={3.4} s={0.9} />
+      <Roca x={0.2} z={-4.2} s={1.3} />
+
+      <Esporas reducedMotion={reducedMotion} />
+    </group>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   VALLA + MURAL — la valla física (marco, techito, postes) con los colores
+   de madera de su mundo, y el plano 2D pegado en su cara frontal
+   ══════════════════════════════════════════════════════════════════════════ */
+
+function VallaMural({ tema, fase, activo, reducedMotion, onEntrar }) {
+  const [celebra, setCelebra] = useState(false);
+  const timerRef = useRef(null);
+  const v = VALLAS[tema.id];
+  const m = tema.marco3d;
+  const enValle = fase === 'valle3d';
+  const enJuego = fase === 'juego2d' && activo;
+
+  const tocar = useCallback(() => {
+    if (enValle) {
+      onEntrar(tema.id);
+      return;
+    }
+    if (!enJuego) return;
+    setCelebra(true);
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCelebra(false), 1400);
+  }, [enValle, enJuego, onEntrar, tema.id]);
+
+  return (
+    <group position={v.pos} rotation={[0, v.rotY, 0]}>
+      {/* marco esbelto que abraza el plano DOM proyectado (~3.55×2.0 con
+          centro ~0.12 arriba del nominal — medido en NewDonk2Den3D) */}
+      <mesh position={[0, 0.12, -0.14]}>
+        <boxGeometry args={[3.95, 2.3, 0.2]} />
+        <meshLambertMaterial color={m.frente} flatShading />
+      </mesh>
+      {/* techito a dos aguas, cariño campesino */}
+      <mesh position={[0, 1.4, -0.14]} rotation={[0, Math.PI / 4, 0]} scale={[1, 0.45, 1]}>
+        <coneGeometry args={[2.75, 0.55, 4]} />
+        <meshLambertMaterial color={m.techo} flatShading />
+      </mesh>
+      {[-1.75, 1.75].map((x) => (
+        <mesh key={x} position={[x, -1.4, -0.14]}>
+          <cylinderGeometry args={[0.09, 0.12, 1.4, 6]} />
+          <meshLambertMaterial color={m.postes} flatShading />
+        </mesh>
+      ))}
+      <Html
+        transform
+        distanceFactor={MURAL_DF}
+        zIndexRange={[20, 10]}
+        style={{ pointerEvents: 'auto' }}
+      >
+        <div
+          onClick={tocar}
+          role={enValle ? 'button' : undefined}
+          aria-label={enValle
+            ? `Mural del mundo ${tema.nombre}: toque para entrar al plano 2D`
+            : `Plano 2D del mundo ${tema.nombre}`}
+          style={{ cursor: enValle || enJuego ? 'pointer' : 'default' }}
+        >
+          <MuralParallax tema={tema} reducedMotion={reducedMotion} celebra={celebra} />
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   CHROME DOM — títulos, selector de mundos y botones (usted, cordial)
+   ══════════════════════════════════════════════════════════════════════════ */
+
+const CSS_MN = `
+.mn-raiz {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  background: ${P.cielo};
+  font-family: system-ui, sans-serif;
+}
+.mn-raiz canvas { touch-action: none; }
+.mn-chrome { position: absolute; inset: 0; pointer-events: none; z-index: 40; }
+.mn-chrome > * { pointer-events: auto; }
+.mn-titulo {
+  position: absolute;
+  top: 18px;
+  left: 0;
+  right: 0;
+  margin: 0;
+  text-align: center;
+  color: ${P.tinta};
+  font-size: clamp(19px, 3.4vw, 27px);
+  letter-spacing: 0.02em;
+  text-shadow: 0 2px 0 rgba(255, 255, 255, 0.55);
+}
+.mn-sub {
+  position: absolute;
+  top: 52px;
+  left: 0;
+  right: 0;
+  margin: 0;
+  text-align: center;
+  color: #47613a;
+  font-size: clamp(12px, 2vw, 15px);
+}
+.mn-selector {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 10px;
+  padding: 8px;
+  border-radius: 999px;
+  background: rgba(253, 248, 232, 0.88);
+  box-shadow: 0 4px 0 rgba(42, 61, 31, 0.35);
+}
+.mn-chip {
+  padding: 10px 20px;
+  border: 3px solid rgba(42, 61, 31, 0.35);
+  border-radius: 999px;
+  background: transparent;
+  color: ${P.tinta};
+  font-size: 15px;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+.mn-chip:hover { transform: translateY(-2px); }
+.mn-chip[data-activo='1'] {
+  border-color: ${P.tinta};
+  background: ${P.follajeLima};
+}
+.mn-volver {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  padding: 8px 16px;
+  border: 2px solid rgba(42, 61, 31, 0.6);
+  border-radius: 999px;
+  background: rgba(253, 248, 232, 0.9);
+  color: ${P.tinta};
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.mn-salir-valle {
+  position: absolute;
+  bottom: 96px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 11px 22px;
+  border: 3px solid ${P.tinta};
+  border-radius: 999px;
+  background: ${P.crema};
+  color: ${P.tinta};
+  font-size: 15px;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 4px 0 rgba(42, 61, 31, 0.45);
+}
+.mn-pista {
+  position: absolute;
+  bottom: 148px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #4a6a3b;
+  font-size: 13px;
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mn-chip { transition: none; }
+}
+`;
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL MOCKUP — Canvas único; la cámara viaja entre valle y murales
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * MuralesNewDonk — tres murales New Donk (café, agua, semillero), cada uno
+ * su side-scroller 2D con arte propio, dentro del mismo valle 3D.
+ *
+ * @param {object} props
+ * @param {() => void} [props.onBack] vuelve al host (solo visible en órbita).
+ */
+export default function MuralesNewDonk({ onBack }) {
+  const [reducedMotion] = useState(
+    () => typeof window !== 'undefined'
+      && !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches,
+  );
+  /* Arranque directo para demo/QA: ?mural=cafe|agua|semillero&plano=2d */
+  const [muralActivo, setMuralActivo] = useState(() => {
+    if (typeof window === 'undefined') return 'cafe';
+    const pedido = new URLSearchParams(window.location.search).get('mural');
+    return VALLAS[pedido] ? pedido : 'cafe';
+  });
+  const [fase, setFase] = useState(() => (
+    typeof window !== 'undefined'
+      && new URLSearchParams(window.location.search).get('plano') === '2d'
+      ? 'juego2d'
+      : 'valle3d'
+  ));
+  /* Cambio de mural estando adentro: la cámara sale al valle y, al llegar,
+     entra sola al mural pendiente — un solo gesto para el usuario. */
+  const pendienteRef = useRef(null);
+
+  const entrarA = useCallback((id) => {
+    setMuralActivo(id);
+    setFase('acercando');
+  }, []);
+  const salir = useCallback(() => {
+    pendienteRef.current = null;
+    setFase('saliendo');
+  }, []);
+  const elegir = useCallback((id) => {
+    if (fase === 'valle3d') {
+      setMuralActivo(id);
+      setFase('acercando');
+      return;
+    }
+    if (fase === 'juego2d' && id !== muralActivo) {
+      pendienteRef.current = id;
+      setFase('saliendo');
+    }
+  }, [fase, muralActivo]);
+  const alLlegarCamara = useCallback((faseViaje) => {
+    if (faseViaje === 'acercando') {
+      setFase('juego2d');
+      return;
+    }
+    const pendiente = pendienteRef.current;
+    if (pendiente) {
+      pendienteRef.current = null;
+      setMuralActivo(pendiente);
+      setFase('acercando');
+      return;
+    }
+    setFase('valle3d');
+  }, []);
+
+  const poseBoca = useMemo(() => poseBocaDe(muralActivo), [muralActivo]);
+  const temaActivo = TEMAS.find((t) => t.id === muralActivo);
+
+  const enValle = fase === 'valle3d';
+  const enJuego = fase === 'juego2d';
+  const viajando = fase === 'acercando' || fase === 'saliendo';
+
+  const dpr = useMemo(() => [1, 1.5], []);
+
+  return (
+    <section
+      className="mn-raiz"
+      data-fase={fase}
+      data-mural={muralActivo}
+      aria-label="Murales New Donk por mundo: cada mundo tiene su propio plano 2D dentro del valle 3D"
+    >
+      <style>{CSS_MN}</style>
+
+      <Canvas
+        dpr={dpr}
+        gl={{ antialias: true, powerPreference: 'high-performance' }}
+        camera={{ position: POSE_VALLE.pos.toArray(), fov: POSE_VALLE.fov }}
+      >
+        <color attach="background" args={[P.cielo]} />
+        <fog attach="fog" args={[P.niebla, 15, 40]} />
+        <CamaraOdyssey
+          fase={fase}
+          poseValle={POSE_VALLE}
+          poseBoca={poseBoca}
+          reducedMotion={reducedMotion}
+          onLlegada={alLlegarCamara}
+        />
+        <EscenaValle reducedMotion={reducedMotion} />
+        {TEMAS.map((tema) => (
+          <VallaMural
+            key={tema.id}
+            tema={tema}
+            fase={fase}
+            activo={muralActivo === tema.id}
+            reducedMotion={reducedMotion}
+            onEntrar={entrarA}
+          />
+        ))}
+      </Canvas>
+
+      <div className="mn-chrome">
+        {enValle && (
+          <>
+            <h2 className="mn-titulo">Los murales de los mundos</h2>
+            <p className="mn-sub">
+              Cada mundo tiene su propio plano 2D dentro del valle — toque un mural para entrar
+            </p>
+            {onBack && (
+              <button type="button" className="mn-volver" onClick={onBack}>
+                ← Salir
+              </button>
+            )}
+          </>
+        )}
+        {enJuego && (
+          <>
+            <p className="mn-pista">
+              Está en el mural de {temaActivo?.nombre} — el valle sigue ahí, en los bordes
+            </p>
+            <button type="button" className="mn-salir-valle" onClick={salir}>
+              Volver al valle 3D
+            </button>
+          </>
+        )}
+        {viajando && (
+          <p className="mn-pista">
+            {fase === 'acercando' ? `Entrando al mural de ${temaActivo?.nombre}…` : 'Volviendo al valle…'}
+          </p>
+        )}
+        {!viajando && (
+          <div className="mn-selector" role="group" aria-label="Elija el mundo del mural">
+            {TEMAS.map((tema) => (
+              <button
+                key={tema.id}
+                type="button"
+                className="mn-chip"
+                data-activo={muralActivo === tema.id ? '1' : '0'}
+                onClick={() => elegir(tema.id)}
+              >
+                {tema.nombre}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/mockups/murales/MuralParallax.jsx
+++ b/src/mockups/murales/MuralParallax.jsx
@@ -1,0 +1,160 @@
+/*
+ * MuralParallax — el plano 2D side-scroller de los murales New Donk,
+ * PARAMETRIZADO por mundo. Es la generalización del mural genérico de
+ * NewDonk2Den3D: mismas capas (parallax CSS repeat-x + franja de flora SVG
+ * al 200% + suelo + Angelita caminando), pero todo el arte viene de un
+ * objeto `tema` (ver muralCafe.jsx / muralAgua.jsx / muralSemillero.jsx).
+ *
+ * Es DOM/SVG puro: el host lo mete en la escena 3D vía drei <Html transform>
+ * (eso lo hace MuralesNewDonk.jsx — este archivo no sabe de three).
+ *
+ * Con prefers-reduced-motion todas las animaciones quedan quietas y el
+ * mural se lee como lámina digna.
+ */
+import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
+
+/* Mismas dimensiones que el mural original: 640×360 px que con
+   distanceFactor 2.5 proyectan ~4.0 × 2.25 unidades de mundo. */
+export const MURAL_PX = { w: 640, h: 360 };
+export const MURAL_DF = 2.5;
+
+const CSS_MNP = `
+.mnd-mural {
+  position: relative;
+  width: ${MURAL_PX.w}px;
+  height: ${MURAL_PX.h}px;
+  box-sizing: border-box;
+  padding: 12px;
+  border-radius: 18px;
+  font-family: system-ui, sans-serif;
+  user-select: none;
+}
+.mnd-mural__lienzo {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 9px;
+  overflow: hidden;
+}
+/* ── capas parallax genéricas: el arte (gradients) viene inline del tema ── */
+.mnd-capa {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background-repeat: repeat-x;
+  animation: mndScroll linear infinite;
+}
+@keyframes mndScroll {
+  from { background-position-x: 0; }
+  to { background-position-x: var(--mnd-ancho); }
+}
+/* ── franja de flora cercana: pista al 200% con dos copias idénticas ── */
+.mnd-flora { position: absolute; left: 0; right: 0; overflow: hidden; }
+.mnd-flora__pista {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: ${MURAL_PX.w * 2}px;
+  height: 100%;
+  display: flex;
+  animation: mndPista linear infinite;
+}
+@keyframes mndPista { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+.mnd-flora__copia { position: relative; width: 50%; height: 100%; flex: none; }
+/* ── Angelita caminando (quieta en X; el mundo es el que corre) ── */
+.mnd-angelita {
+  position: absolute;
+  bottom: 13.5%;
+  animation: mndCamina 0.62s ease-in-out infinite;
+  transform-origin: 50% 88%;
+  filter: drop-shadow(0 10px 7px rgba(30, 54, 20, 0.32));
+}
+@keyframes mndCamina {
+  0%, 100% { transform: translateY(0) rotate(-2deg); }
+  50% { transform: translateY(-7px) rotate(2.5deg); }
+}
+.mnd-placa {
+  position: absolute;
+  top: 9px;
+  left: 10px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  color: #f6ffe6;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+/* reduced-motion: lámina quieta */
+.mnd-mural[data-rm='1'] .mnd-capa,
+.mnd-mural[data-rm='1'] .mnd-flora__pista,
+.mnd-mural[data-rm='1'] .mnd-angelita { animation: none; }
+`;
+
+/**
+ * Una capa de parallax data-driven.
+ * @param {object} cfg { fondo, tam, height, bottom, opacidad, dur, ancho,
+ *                       bordeArriba, bordeAbajo, posicion }
+ */
+function Capa({ cfg }) {
+  return (
+    <div
+      className="mnd-capa"
+      style={{
+        height: cfg.height,
+        bottom: cfg.bottom ?? 0,
+        backgroundImage: cfg.fondo,
+        backgroundSize: cfg.tam,
+        backgroundPosition: cfg.posicion ?? '0 100%',
+        opacity: cfg.opacidad,
+        borderTop: cfg.bordeArriba,
+        borderBottom: cfg.bordeAbajo,
+        animationDuration: `${cfg.dur}s`,
+        '--mnd-ancho': cfg.ancho,
+      }}
+    />
+  );
+}
+
+/**
+ * El mural 2D de un mundo. DOM puro, listo para <Html transform>.
+ *
+ * @param {object} props
+ * @param {object} props.tema arte del mundo (ver murales/mural*.jsx).
+ * @param {boolean} [props.reducedMotion] congela todas las animaciones.
+ * @param {boolean} [props.celebra] la Angelita celebra (vuelta rubber-hose).
+ */
+export function MuralParallax({ tema, reducedMotion = false, celebra = false }) {
+  const { flora, angelita } = tema;
+  const Copia = flora.Copia;
+  return (
+    <div
+      className="mnd-mural"
+      data-rm={reducedMotion ? '1' : '0'}
+      data-mundo={tema.id}
+      style={{ background: tema.marcoCss, boxShadow: tema.marcoSombra }}
+    >
+      <style>{CSS_MNP}</style>
+      <div className="mnd-mural__lienzo" style={{ background: tema.lienzo }}>
+        {tema.capas.map((c, i) => <Capa key={i} cfg={c} />)}
+        <div className="mnd-flora" style={{ bottom: flora.bottom, height: flora.height }}>
+          <div className="mnd-flora__pista" style={{ animationDuration: `${flora.dur}s` }}>
+            <div className="mnd-flora__copia"><Copia /></div>
+            <div className="mnd-flora__copia"><Copia /></div>
+          </div>
+        </div>
+        <Capa cfg={tema.suelo} />
+        <div className="mnd-angelita" style={{ left: angelita.left }}>
+          <AbejaAngelita
+            size={96}
+            animated={!reducedMotion}
+            pose={celebra ? 'celebra' : 'vuela'}
+            animo={celebra ? (angelita.animoCelebra ?? 'pleno') : (angelita.animo ?? 'sereno')}
+            energia={1}
+            title={`Angelita caminando por el mural de ${tema.nombre}`}
+          />
+        </div>
+        <span className="mnd-placa" style={{ background: tema.placaFondo }}>{tema.placa}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/mockups/murales/muralAgua.jsx
+++ b/src/mockups/murales/muralAgua.jsx
@@ -140,9 +140,9 @@ export const MURAL_AGUA = {
       height: '13%',
       bottom: '15%',
       fondo:
-        'repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.38) 0 14px, rgba(0,0,0,0) 14px 64px), '
+        'repeating-linear-gradient(100deg, rgba(255, 255, 255, 0.28) 0 7px, rgba(0,0,0,0) 7px 46px, rgba(234, 255, 251, 0.18) 46px 52px, rgba(0,0,0,0) 52px 92px), '
         + 'linear-gradient(#8fd8d0, #5fb8b4 60%, #4aa3a3)',
-      tam: '320px 100%, 100% 100%',
+      tam: '368px 100%, 100% 100%',
       dur: 4.5,
       ancho: '-320px',
       bordeArriba: '2px solid rgba(234, 255, 251, 0.75)',

--- a/src/mockups/murales/muralAgua.jsx
+++ b/src/mockups/murales/muralAgua.jsx
@@ -1,0 +1,167 @@
+/*
+ * muralAgua — arte 2D del mural New Donk del MUNDO AGUA.
+ *
+ * Identidad: la quebrada que baja del nacimiento — cerros frescos de niebla,
+ * la cinta de agua corriendo con destellos (es la capa que más rápido viaja),
+ * piedras de río pulidas, juncos con espiga, helechos de orilla y gotas que
+ * brillan. Paleta fresca dentro del tema cálido: verdes menta y aguamarinas
+ * con luz blanca de páramo.
+ */
+
+/* Juncos de orilla con espigas. */
+function Junco2D({ x, alto = 84 }) {
+  return (
+    <svg
+      viewBox="0 0 44 92"
+      width={44}
+      height={92}
+      style={{ position: 'absolute', bottom: 0, left: `${x}%`, height: alto, width: 'auto' }}
+      aria-hidden="true"
+    >
+      <path d="M14,92 C13,60 15,38 12,20" stroke="#3f7a3c" strokeWidth="3.4" fill="none" strokeLinecap="round" />
+      <path d="M23,92 C23,56 22,34 25,12" stroke="#4f9040" strokeWidth="3.4" fill="none" strokeLinecap="round" />
+      <path d="M32,92 C33,62 31,44 34,28" stroke="#356b2c" strokeWidth="3" fill="none" strokeLinecap="round" />
+      <path d="M23,74 C31,66 36,58 38,50" stroke="#4f9040" strokeWidth="2.4" fill="none" strokeLinecap="round" />
+      <rect x="8.6" y="8" width="7" height="18" rx="3.5" fill="#7a5a38" />
+      <rect x="21.6" y="1" width="7" height="18" rx="3.5" fill="#8a6d47" />
+      <rect x="30.8" y="17" width="6" height="15" rx="3" fill="#7a5a38" />
+    </svg>
+  );
+}
+
+/* Piedras de río pulidas, con brillo húmedo. */
+function PiedrasRio2D({ x }) {
+  return (
+    <svg
+      viewBox="0 0 64 32"
+      width={64}
+      height={32}
+      style={{ position: 'absolute', bottom: 0, left: `${x}%`, height: 30, width: 'auto' }}
+      aria-hidden="true"
+    >
+      <ellipse cx="18" cy="22" rx="16" ry="10" fill="#8fa3a0" />
+      <ellipse cx="44" cy="24" rx="14" ry="8" fill="#7b908d" />
+      <ellipse cx="33" cy="14" rx="11" ry="7" fill="#a3b5b0" />
+      <path d="M26,10 C29,8.5 34,8.5 37,10" stroke="#e7f2ee" strokeWidth="2" fill="none" strokeLinecap="round" opacity="0.85" />
+      <path d="M8,18 C11,16.5 15,16.5 18,18" stroke="#dcE9e4" strokeWidth="1.8" fill="none" strokeLinecap="round" opacity="0.7" />
+    </svg>
+  );
+}
+
+/* Helecho de orilla: frondas que se arquean. */
+function Helecho2D({ x, alto = 62 }) {
+  return (
+    <svg
+      viewBox="0 0 60 70"
+      width={60}
+      height={70}
+      style={{ position: 'absolute', bottom: 0, left: `${x}%`, height: alto, width: 'auto' }}
+      aria-hidden="true"
+    >
+      <path d="M30,70 C28,52 18,40 8,36" stroke="#3f8a3d" strokeWidth="3" fill="none" strokeLinecap="round" />
+      <path d="M30,70 C31,50 40,36 52,32" stroke="#4f9040" strokeWidth="3" fill="none" strokeLinecap="round" />
+      <path d="M30,70 C30,50 29,36 30,24" stroke="#356b2c" strokeWidth="3" fill="none" strokeLinecap="round" />
+      {[[12, 40], [18, 46], [24, 54]].map(([cx, cy], i) => (
+        <ellipse key={`a${i}`} cx={cx} cy={cy} rx="5.5" ry="2.6" fill="#61a548" transform={`rotate(-38 ${cx} ${cy})`} />
+      ))}
+      {[[47, 36], [41, 42], [35, 50]].map(([cx, cy], i) => (
+        <ellipse key={`b${i}`} cx={cx} cy={cy} rx="5.5" ry="2.6" fill="#4f9040" transform={`rotate(38 ${cx} ${cy})`} />
+      ))}
+      <ellipse cx="30" cy="28" rx="2.8" ry="5" fill="#61a548" />
+    </svg>
+  );
+}
+
+/* Gota-destello: el agua viva saludando desde la orilla. */
+function GotaBrillo2D({ x, alto = 36 }) {
+  return (
+    <svg
+      viewBox="0 0 30 40"
+      width={30}
+      height={40}
+      style={{ position: 'absolute', bottom: 4, left: `${x}%`, height: alto, width: 'auto' }}
+      aria-hidden="true"
+    >
+      <ellipse cx="15" cy="26" rx="11" ry="12" fill="#eafffb" opacity="0.55" />
+      <path d="M15,6 C20,15 24,20 24,27 A9,9 0 1 1 6,27 C6,20 10,15 15,6 Z" fill="#9fdcd4" stroke="#5fb8b4" strokeWidth="1.6" />
+      <circle cx="11.5" cy="26" r="2.4" fill="#f0fffb" />
+    </svg>
+  );
+}
+
+/* La franja de orilla (una copia; el mural la pone dos veces). */
+function FloraAgua() {
+  return (
+    <>
+      <Helecho2D x={3} alto={64} />
+      <PiedrasRio2D x={14} />
+      <Junco2D x={25} alto={86} />
+      <GotaBrillo2D x={38} />
+      <Junco2D x={48} alto={70} />
+      <PiedrasRio2D x={60} />
+      <Helecho2D x={70} alto={56} />
+      <Junco2D x={82} alto={80} />
+      <GotaBrillo2D x={93} alto={30} />
+    </>
+  );
+}
+
+export const MURAL_AGUA = {
+  id: 'agua',
+  nombre: 'Agua',
+  placa: 'Mundo Agua — la quebrada del nacimiento',
+  placaFondo: 'rgba(32, 84, 78, 0.8)',
+  marcoCss: 'linear-gradient(160deg, #2f6b5e, #1e4a41 70%)',
+  marcoSombra: '0 0 0 3px rgba(20, 54, 46, 0.55), 0 14px 34px rgba(14, 44, 38, 0.35)',
+  /* luz blanca de páramo con cielo menta */
+  lienzo:
+    'radial-gradient(32% 28% at 72% 16%, rgba(240, 255, 250, 0.92) 0 30%, rgba(240, 255, 250, 0) 70%), '
+    + 'linear-gradient(#e7f7ee 0%, #cfeedd 44%, #b7e3c6 60%)',
+  capas: [
+    /* cerros del nacimiento, fríos y con niebla */
+    {
+      height: '58%',
+      fondo: 'radial-gradient(60% 115% at 50% 106%, #9ecfae 0 62%, rgba(0,0,0,0) 63%)',
+      tam: '290px 168px',
+      dur: 58,
+      ancho: '-290px',
+      opacidad: 0.85,
+    },
+    /* la ribera media, verde húmedo */
+    {
+      height: '42%',
+      fondo: 'radial-gradient(58% 112% at 50% 106%, #7dbb84 0 62%, rgba(0,0,0,0) 63%)',
+      tam: '204px 124px',
+      dur: 27,
+      ancho: '-204px',
+    },
+    /* LA QUEBRADA: cinta de agua con destellos — la capa más veloz del mural */
+    {
+      height: '13%',
+      bottom: '15%',
+      fondo:
+        'repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.38) 0 14px, rgba(0,0,0,0) 14px 64px), '
+        + 'linear-gradient(#8fd8d0, #5fb8b4 60%, #4aa3a3)',
+      tam: '320px 100%, 100% 100%',
+      dur: 4.5,
+      ancho: '-320px',
+      bordeArriba: '2px solid rgba(234, 255, 251, 0.75)',
+      bordeAbajo: '2px solid rgba(42, 96, 90, 0.5)',
+    },
+  ],
+  /* la orilla por donde camina Angelita: pasto ribereño con guijarros */
+  suelo: {
+    height: '17%',
+    fondo:
+      'repeating-linear-gradient(90deg, rgba(58, 94, 88, 0.28) 0 6px, rgba(0,0,0,0) 6px 42px), '
+      + 'linear-gradient(#7fbf80, #5da268 55%, #4b8a56)',
+    tam: '640px 100%, 100% 100%',
+    dur: 9,
+    ancho: '-640px',
+    bordeArriba: '3px solid rgba(38, 70, 56, 0.5)',
+  },
+  flora: { Copia: FloraAgua, dur: 15, bottom: '15%', height: '46%' },
+  angelita: { left: '32%', animo: 'sereno', animoCelebra: 'pleno' },
+  /* la valla física en el 3D, madera curada por la humedad */
+  marco3d: { frente: '#4c5f4a', techo: '#74806a', postes: '#5f7058' },
+};

--- a/src/mockups/murales/muralCafe.jsx
+++ b/src/mockups/murales/muralCafe.jsx
@@ -1,0 +1,158 @@
+/*
+ * muralCafe — arte 2D del mural New Donk del MUNDO CAFÉ.
+ *
+ * Identidad: cafetal en ladera con sombrío al amanecer — luz miel, lomas
+ * brumosas, hileras de cafetos punteando la pendiente, guamos de copa ancha
+ * dando sombra, cafetos cargados de cerezas rojas y una canasta de cosecha.
+ * Paleta cálida: mieles, terracotas de suelo cafetero, verdes oliva.
+ */
+
+/* Un cafeto: mata de hojas oscuras brillantes con racimos de cereza roja. */
+function Cafeto2D({ x, alto = 78, brillo = false }) {
+  return (
+    <svg
+      viewBox="0 0 64 96"
+      width={64}
+      height={96}
+      style={{ position: 'absolute', bottom: 0, left: `${x}%`, height: alto, width: 'auto' }}
+      aria-hidden="true"
+    >
+      <path d="M32,96 C31,74 33,52 32,26" stroke="#4a3521" strokeWidth="4" fill="none" strokeLinecap="round" />
+      <path d="M32,74 C23,70 13,69 7,73" stroke="#4a3521" strokeWidth="2.6" fill="none" strokeLinecap="round" />
+      <path d="M32,60 C41,56 51,55 57,59" stroke="#4a3521" strokeWidth="2.6" fill="none" strokeLinecap="round" />
+      <path d="M32,46 C24,42 16,41 11,44" stroke="#4a3521" strokeWidth="2.4" fill="none" strokeLinecap="round" />
+      <ellipse cx="12" cy="70" rx="9" ry="5" fill="#2e5c2b" transform="rotate(-16 12 70)" />
+      <ellipse cx="24" cy="73" rx="8" ry="4.6" fill="#3f7a36" transform="rotate(-8 24 73)" />
+      <ellipse cx="52" cy="56" rx="9" ry="5" fill="#2e5c2b" transform="rotate(14 52 56)" />
+      <ellipse cx="40" cy="59" rx="8" ry="4.6" fill="#3f7a36" transform="rotate(8 40 59)" />
+      <ellipse cx="15" cy="42" rx="8" ry="4.4" fill="#356b2c" transform="rotate(-14 15 42)" />
+      <ellipse cx="32" cy="22" rx="7" ry="9" fill="#3f7a36" />
+      <ellipse cx="27" cy="28" rx="5" ry="6" fill="#2e5c2b" />
+      {/* racimos de cereza pegados a las ramas, como carga real */}
+      <circle cx="27" cy="68" r="3.1" fill="#d9402e" />
+      <circle cx="21" cy="71" r="2.7" fill="#b32b22" />
+      <circle cx="26" cy="74" r="2.5" fill="#d9402e" />
+      <circle cx="38" cy="54" r="3.1" fill={brillo ? '#ff6a4d' : '#d9402e'} />
+      <circle cx="44" cy="57" r="2.7" fill="#b32b22" />
+      <circle cx="39" cy="60" r="2.5" fill="#d9402e" />
+      {brillo && <circle cx="38" cy="52" r="4.6" fill="none" stroke="#ffd9a0" strokeWidth="1.6" opacity="0.9" />}
+      <circle cx="24" cy="44" r="2.6" fill="#c9862c" />
+      <circle cx="19" cy="47" r="2.3" fill="#d9402e" />
+    </svg>
+  );
+}
+
+/* Un guamo de sombrío: tronco esbelto y copa ancha en pisos. */
+function ArbolSombrio2D({ x, alto = 140 }) {
+  return (
+    <svg
+      viewBox="0 0 140 150"
+      width={140}
+      height={150}
+      style={{ position: 'absolute', bottom: 0, left: `${x}%`, height: alto, width: 'auto' }}
+      aria-hidden="true"
+    >
+      <path d="M70,150 C68,110 72,74 67,40" stroke="#5c422a" strokeWidth="6" fill="none" strokeLinecap="round" />
+      <path d="M69,96 C82,86 94,80 104,78" stroke="#5c422a" strokeWidth="3.4" fill="none" strokeLinecap="round" />
+      <path d="M70,78 C58,68 46,62 36,60" stroke="#5c422a" strokeWidth="3.4" fill="none" strokeLinecap="round" />
+      <ellipse cx="46" cy="46" rx="40" ry="15" fill="#3f7a3c" />
+      <ellipse cx="94" cy="38" rx="38" ry="14" fill="#4f8f45" />
+      <ellipse cx="66" cy="26" rx="44" ry="15" fill="#5c9b4a" />
+      <ellipse cx="104" cy="72" rx="24" ry="9" fill="#4f8f45" />
+      <ellipse cx="34" cy="56" rx="22" ry="8.5" fill="#3f7a3c" />
+    </svg>
+  );
+}
+
+/* Canasta de cosecha tejida, con cerezas recién cogidas. */
+function Canasta2D({ x }) {
+  return (
+    <svg
+      viewBox="0 0 48 36"
+      width={48}
+      height={36}
+      style={{ position: 'absolute', bottom: 0, left: `${x}%`, height: 34, width: 'auto' }}
+      aria-hidden="true"
+    >
+      <path d="M6,14 L42,14 L37,34 L11,34 Z" fill="#8a6d47" stroke="#5c422a" strokeWidth="2" />
+      <path d="M9,20 L39,20 M11,27 L37,27" stroke="#5c422a" strokeWidth="1.4" opacity="0.7" />
+      <circle cx="17" cy="12" r="3.4" fill="#d9402e" />
+      <circle cx="25" cy="10" r="3.4" fill="#b32b22" />
+      <circle cx="32" cy="12" r="3.4" fill="#d9402e" />
+      <circle cx="21" cy="8" r="3" fill="#c9862c" />
+    </svg>
+  );
+}
+
+/* La franja de flora cercana (una copia; el mural la pone dos veces). */
+function FloraCafe() {
+  return (
+    <>
+      <ArbolSombrio2D x={2} alto={150} />
+      <Cafeto2D x={17} alto={80} />
+      <Cafeto2D x={28} alto={64} />
+      <Canasta2D x={39} />
+      <Cafeto2D x={48} alto={86} brillo />
+      <ArbolSombrio2D x={59} alto={132} />
+      <Cafeto2D x={76} alto={72} />
+      <Cafeto2D x={88} alto={60} brillo />
+    </>
+  );
+}
+
+export const MURAL_CAFE = {
+  id: 'cafe',
+  nombre: 'Café',
+  placa: 'Mundo Café — cafetal con sombrío',
+  placaFondo: 'rgba(84, 52, 26, 0.8)',
+  marcoCss: 'linear-gradient(160deg, #6b4a2a, #46301b 70%)',
+  marcoSombra: '0 0 0 3px rgba(58, 38, 20, 0.55), 0 14px 34px rgba(46, 30, 14, 0.35)',
+  /* amanecer cafetero: sol miel arriba a la derecha, bruma dorada */
+  lienzo:
+    'radial-gradient(30% 26% at 78% 18%, rgba(255, 214, 140, 0.95) 0 30%, rgba(255, 214, 140, 0) 70%), '
+    + 'linear-gradient(#fbe8bd 0%, #ecd99e 40%, #cfd98f 60%)',
+  capas: [
+    /* lomas brumosas del fondo */
+    {
+      height: '60%',
+      fondo: 'radial-gradient(60% 115% at 50% 106%, #b3cf8e 0 62%, rgba(0,0,0,0) 63%)',
+      tam: '300px 172px',
+      dur: 55,
+      ancho: '-300px',
+      opacidad: 0.8,
+    },
+    /* la ladera media, verde oliva */
+    {
+      height: '44%',
+      fondo: 'radial-gradient(56% 110% at 50% 108%, #85ac5c 0 62%, rgba(0,0,0,0) 63%)',
+      tam: '196px 120px',
+      dur: 27,
+      ancho: '-196px',
+    },
+    /* hilera lejana de cafetos punteando la pendiente */
+    {
+      height: '11%',
+      bottom: '15%',
+      fondo: 'radial-gradient(circle at 50% 62%, #4c7c3a 0 34%, rgba(0,0,0,0) 37%)',
+      tam: '46px 40px',
+      dur: 19,
+      ancho: '-46px',
+      opacidad: 0.9,
+    },
+  ],
+  /* suelo de cafetal: tierra terracota con raizales */
+  suelo: {
+    height: '17%',
+    fondo:
+      'repeating-linear-gradient(90deg, rgba(94, 60, 32, 0.35) 0 8px, rgba(0,0,0,0) 8px 52px), '
+      + 'linear-gradient(#b5854f, #96683c 55%, #7d5530)',
+    tam: '640px 100%, 100% 100%',
+    dur: 9,
+    ancho: '-640px',
+    bordeArriba: '3px solid rgba(74, 46, 22, 0.55)',
+  },
+  flora: { Copia: FloraCafe, dur: 16, bottom: '15%', height: '56%' },
+  angelita: { left: '30%', animo: 'sereno', animoCelebra: 'pleno' },
+  /* la valla física en el 3D, en maderas de beneficiadero */
+  marco3d: { frente: '#5c422a', techo: '#8a6d47', postes: '#7a5a38' },
+};

--- a/src/mockups/murales/muralSemillero.jsx
+++ b/src/mockups/murales/muralSemillero.jsx
@@ -1,0 +1,178 @@
+/*
+ * muralSemillero — arte 2D del mural New Donk del MUNDO SEMILLERO.
+ *
+ * Identidad: las camas de germinación al mediodía tierno — colinas suaves con
+ * domos de invernadero al fondo, hilera de brotes recién nacidos, camas de
+ * madera con surcos sembrados, bandejas de germinación en mesa, la regadera
+ * y un brote grande que brilla de puro nuevo. Paleta cálida y tierna: verdes
+ * limón, maderas claras, sustrato oscuro y rico.
+ */
+
+/* Cama de germinación: cajón de madera con surcos y brotecitos en fila. */
+function CamaGerminacion2D({ x, alto = 68 }) {
+  return (
+    <svg
+      viewBox="0 0 120 74"
+      width={120}
+      height={74}
+      style={{ position: 'absolute', bottom: 0, left: `${x}%`, height: alto, width: 'auto' }}
+      aria-hidden="true"
+    >
+      <rect x="10" y="66" width="8" height="8" fill="#7a5a38" />
+      <rect x="102" y="66" width="8" height="8" fill="#7a5a38" />
+      <rect x="6" y="42" width="108" height="26" rx="3" fill="#8a6d47" stroke="#5c422a" strokeWidth="2.4" />
+      <rect x="11" y="46" width="98" height="10" rx="2" fill="#4a3521" />
+      <path d="M16,51 H104" stroke="#2e2014" strokeWidth="1.6" opacity="0.6" strokeDasharray="6 8" />
+      {[22, 40, 58, 76, 94].map((cx) => (
+        <g key={cx}>
+          <path d={`M${cx},46 C${cx - 1},40 ${cx - 1},36 ${cx},32`} stroke="#4f9040" strokeWidth="2.4" fill="none" strokeLinecap="round" />
+          <ellipse cx={cx - 5} cy="33" rx="5.5" ry="3" fill="#7cc258" transform={`rotate(-24 ${cx - 5} 33)`} />
+          <ellipse cx={cx + 5} cy="33" rx="5.5" ry="3" fill="#61a548" transform={`rotate(24 ${cx + 5} 33)`} />
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+/* Bandeja de germinación sobre mesita de trabajo. */
+function BandejaAlta2D({ x, alto = 78 }) {
+  return (
+    <svg
+      viewBox="0 0 96 84"
+      width={96}
+      height={84}
+      style={{ position: 'absolute', bottom: 0, left: `${x}%`, height: alto, width: 'auto' }}
+      aria-hidden="true"
+    >
+      <path d="M18,84 L22,46 M78,84 L74,46 M14,68 L82,68" stroke="#7a5a38" strokeWidth="4" strokeLinecap="round" />
+      <rect x="10" y="38" width="76" height="12" rx="2.5" fill="#a58757" stroke="#5c422a" strokeWidth="2" />
+      {[20, 34, 48, 62, 76].map((cx) => (
+        <path key={cx} d={`M${cx},40 V48`} stroke="#5c422a" strokeWidth="1.4" opacity="0.6" />
+      ))}
+      {[16, 30, 44, 58, 72].map((cx, i) => (
+        <g key={cx}>
+          <path d={`M${cx + 6},38 C${cx + 5.5},33 ${cx + 6},30 ${cx + 6},27`} stroke="#4f9040" strokeWidth="2" fill="none" strokeLinecap="round" />
+          <ellipse cx={cx + 2.5} cy={27 - (i % 2) * 2} rx="4.4" ry="2.4" fill="#7cc258" transform={`rotate(-22 ${cx + 2.5} ${27 - (i % 2) * 2})`} />
+          <ellipse cx={cx + 9.5} cy={27 - (i % 2) * 2} rx="4.4" ry="2.4" fill="#61a548" transform={`rotate(22 ${cx + 9.5} ${27 - (i % 2) * 2})`} />
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+/* La regadera de lata, con su arco de gotas frescas. */
+function Regadera2D({ x, alto = 46 }) {
+  return (
+    <svg
+      viewBox="0 0 84 60"
+      width={84}
+      height={60}
+      style={{ position: 'absolute', bottom: 0, left: `${x}%`, height: alto, width: 'auto' }}
+      aria-hidden="true"
+    >
+      <rect x="26" y="24" width="34" height="32" rx="6" fill="#6f8577" stroke="#4c5f4a" strokeWidth="2.4" />
+      <path d="M40,24 C40,15 47,12 52,14" stroke="#4c5f4a" strokeWidth="4" fill="none" strokeLinecap="round" />
+      <path d="M28,34 L10,22" stroke="#6f8577" strokeWidth="5.5" strokeLinecap="round" />
+      <ellipse cx="9" cy="21" rx="4.6" ry="3.6" fill="#8a9c8e" stroke="#4c5f4a" strokeWidth="1.6" />
+      <circle cx="4" cy="12" r="2" fill="#9fdcd2" />
+      <circle cx="9" cy="8" r="2.2" fill="#8fd8d0" />
+      <circle cx="15" cy="11" r="1.8" fill="#9fdcd2" />
+    </svg>
+  );
+}
+
+/* Brote grande recién nacido; con brillo = aura de vida nueva. */
+function BroteGrande2D({ x, alto = 58, brillo = false }) {
+  return (
+    <svg
+      viewBox="0 0 52 70"
+      width={52}
+      height={70}
+      style={{ position: 'absolute', bottom: 0, left: `${x}%`, height: alto, width: 'auto' }}
+      aria-hidden="true"
+    >
+      {brillo && <ellipse cx="26" cy="26" rx="22" ry="24" fill="#eaffd0" opacity="0.6" />}
+      <path d="M26,70 C25,52 27,40 26,26" stroke="#4f9040" strokeWidth="4" fill="none" strokeLinecap="round" />
+      <path d="M26,42 C15,38 8,30 8,20 C19,22 25,31 26,40 Z" fill="#7cc258" />
+      <path d="M26,34 C37,30 44,22 44,12 C33,14 27,23 26,32 Z" fill="#61a548" />
+      <ellipse cx="26" cy="20" rx="6" ry="7.5" fill={brillo ? '#c9ff96' : '#8cc95e'} />
+      {brillo && <circle cx="26" cy="18" r="2.8" fill="#f4ffd9" />}
+      <path d="M20,66 C22,64 30,64 32,66" stroke="#4a3521" strokeWidth="3" fill="none" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+/* La franja del semillero (una copia; el mural la pone dos veces). */
+function FloraSemillero() {
+  return (
+    <>
+      <CamaGerminacion2D x={2} alto={70} />
+      <BroteGrande2D x={20} alto={54} />
+      <BandejaAlta2D x={30} alto={80} />
+      <Regadera2D x={46} />
+      <CamaGerminacion2D x={56} alto={64} />
+      <BroteGrande2D x={74} alto={62} brillo />
+      <BandejaAlta2D x={84} alto={74} />
+    </>
+  );
+}
+
+export const MURAL_SEMILLERO = {
+  id: 'semillero',
+  nombre: 'Semillero',
+  placa: 'Mundo Semillero — camas de germinación',
+  placaFondo: 'rgba(74, 84, 28, 0.82)',
+  marcoCss: 'linear-gradient(160deg, #7c8a3a, #55611f 70%)',
+  marcoSombra: '0 0 0 3px rgba(62, 70, 24, 0.55), 0 14px 34px rgba(48, 56, 18, 0.35)',
+  /* mediodía tierno: sol alto y cielo limón */
+  lienzo:
+    'radial-gradient(30% 26% at 70% 16%, rgba(255, 250, 205, 0.95) 0 32%, rgba(255, 250, 205, 0) 70%), '
+    + 'linear-gradient(#f4fadd 0%, #e2f2bb 42%, #cde8a2 60%)',
+  capas: [
+    /* colinas suaves con domos de invernadero asomando */
+    {
+      height: '58%',
+      fondo:
+        'radial-gradient(46% 76% at 50% 102%, rgba(250, 255, 250, 0.7) 0 58%, rgba(0,0,0,0) 61%), '
+        + 'radial-gradient(60% 115% at 50% 106%, #b9dc95 0 62%, rgba(0,0,0,0) 63%)',
+      tam: '300px 132px, 300px 168px',
+      dur: 56,
+      ancho: '-300px',
+      opacidad: 0.85,
+    },
+    /* el lomo verde tierno del vivero */
+    {
+      height: '42%',
+      fondo: 'radial-gradient(58% 112% at 50% 106%, #94c470 0 62%, rgba(0,0,0,0) 63%)',
+      tam: '198px 122px',
+      dur: 26,
+      ancho: '-198px',
+    },
+    /* hilera de brotecitos recién germinados sobre el surco */
+    {
+      height: '8%',
+      bottom: '15%',
+      fondo:
+        'radial-gradient(circle at 50% 26%, #7cc258 0 24%, rgba(0,0,0,0) 28%), '
+        + 'linear-gradient(rgba(0,0,0,0) 55%, rgba(90, 62, 34, 0.55) 55%)',
+      tam: '26px 100%, 26px 100%',
+      dur: 13,
+      ancho: '-26px',
+    },
+  ],
+  /* sustrato oscuro y rico, recién regado */
+  suelo: {
+    height: '17%',
+    fondo:
+      'repeating-linear-gradient(90deg, rgba(46, 30, 14, 0.42) 0 7px, rgba(0,0,0,0) 7px 46px), '
+      + 'linear-gradient(#8a6a44, #6d4f30 55%, #573d24)',
+    tam: '640px 100%, 100% 100%',
+    dur: 9,
+    ancho: '-640px',
+    bordeArriba: '3px solid rgba(52, 34, 16, 0.55)',
+  },
+  flora: { Copia: FloraSemillero, dur: 15, bottom: '15%', height: '46%' },
+  angelita: { left: '38%', animo: 'atento', animoCelebra: 'pleno' },
+  /* la valla física en el 3D, madera clara de vivero */
+  marco3d: { frente: '#8a6d47', techo: '#a58757', postes: '#96784f' },
+};


### PR DESCRIPTION
## Qué hace

Extiende el efecto New Donk (plano 2D embebido en el valle 3D, `NewDonk2Den3D`) a **murales distintos por mundo**: tres vallas conviven en el mismo valle y cada una tiene su propio side-scroller 2D con arte e identidad propios.

- **Café**: cafetal en ladera con sombrío al amanecer — guamos de copa ancha, cafetos cargados de cerezas rojas, canasta de cosecha, suelo terracota.
- **Agua**: la quebrada del nacimiento — cinta de agua con destellos (la capa más veloz del parallax), juncos, piedras de río, helechos, gotas que brillan.
- **Semillero**: camas de germinación al mediodía — domos de invernadero al fondo, hilera de brotes, bandejas en mesa, regadera, brote grande con aura.

## Cómo

- `src/mockups/murales/MuralParallax.jsx`: el plano 2D **parametrizado por tema** (capas parallax data-driven + franja de flora SVG al 200% + Angelita 2D caminando). DOM puro, no sabe de three.
- `src/mockups/murales/muralCafe|muralAgua|muralSemillero.jsx`: arte SVG + paleta + colores de valla por mundo.
- `src/mockups/MuralesNewDonk.jsx`: vitrina con selector (chips Café/Agua/Semillero). **Reutiliza `CamaraOdyssey`** — el cruce es 100% viaje de cámara (FOV→20 casi ortográfico), sin desmontar el Canvas ni iris. Cambiar de mural estando adentro: la cámara sale al valle y entra sola al pendiente.
- `App.jsx`: 3 ediciones mínimas (lazy + slug `mockups/murales-new-donk` + case). No se tocó `NewDonk2Den3D.jsx`.

## Probar

- `#/mockups/murales-new-donk` — órbita con las 3 vallas; toque una o use los chips.
- QA directo: `/?mural=agua&plano=2d#/mockups/murales-new-donk` arranca aplanado contra ese mural.
- `prefers-reduced-motion`: corte de cámara en un frame, murales como láminas quietas.

## Verificación

- `npm run build` verde (2m23s, solo warnings preexistentes de chunk size).

🤖 Generated with [Claude Code](https://claude.com/claude-code)