### PR TITLE
feat(creatures): trío andino rubber-hose (oso, colibrí, rana)

### DIFF
--- a/src/visual/creatures/Colibri.jsx
+++ b/src/visual/creatures/Colibri.jsx
@@ -1,11 +1,30 @@
 import { useId } from 'react';
 import './creatures.css';
 import { CreatureFilters } from './_filters.jsx';
+import { OjosRubber, Cachetes, Sonrisa, RH_INK } from './_rubberhose.jsx';
+import { COLIBRI_PALETA, COLIBRI_PROPORCION } from './faunaAndina.js';
+import { cuerpoDeClima, PERFIL_COLIBRI } from './creatureClimaCuerpo.js';
 
-/* Colibrí chillón — Colibri coruscans (nativo de los Andes). Pico largo y
-   recto, garganta violeta iridiscente, alas que baten. Versión canónica
-   deducida del mockup "Guardianes que aparecen". */
-const VIEWBOX = '-22 -28 58 52';
+/* Colibrí chillón — Colibri coruscans (esmeralda andino, el ave-agente de
+   Chagra). Hermano rubber-hose de la abeja Angelita: ADOPTA el mismo kit
+   `_rubberhose.jsx` (ojos de goma, cachetes, sonrisa) y la misma cadencia `rh-*`
+   de `creatures.css` (boil que respira, parpadeo, follow-through, vuelta de
+   campana) — la versión canónica sube al lenguaje de goma sin cambiar de ave.
+   Sigue siendo ÉL: dorso turquesa esmeralda, gorguera violeta iridiscente y el
+   pico recto y largo. Es de AIRE: las alas baten en borrón (`.crt-wing`, que ya
+   trae smear), y el CLIMA le pesa o le apura el aleteo (perfil colibrí: plumas
+   aceitadas que escurren el agua, ágil, aguanta algo la seca). IDENTIDAD en
+   `faunaAndina.js`; CLIMA→cuerpo en `creatureClimaCuerpo.js`.
+   API estable (size/className/inline/animated/title) — los consumidores de la
+   vieja versión SVG heredan el rubber-hose sin tocar su código. */
+const VIEWBOX = '-15 -16 36 30';
+
+/* Timoneras de la cola (abanico a la izquierda). */
+const COLA = [
+  'M-6,1.4 L-13.2,-1.4 L-8,1.6 Z',
+  'M-6,2.2 L-13.6,2.2 L-8,2.6 Z',
+  'M-6,3.0 L-12.8,5.4 L-8,3.4 Z',
+];
 
 export function Colibri({
   size = 64,
@@ -13,48 +32,126 @@ export function Colibri({
   inline = false,
   animated = true,
   title = 'Colibrí',
+  /* Pose de VIDA (idle-life), equivalentes a las de Angelita: 'vuela' (base,
+     aleteo normal) | 'celebra' (giro alegre + aleteo acelerado) | 'reposo'
+     (se posa, alitas plegadas, respira) | 'señala' (se inclina al POI y apunta
+     con el pico). Gestos species-agnostic en `creatures.css` (rh-g-*); solo
+     corren viva (animated). */
+  pose = 'vuela',
+  animo = 'sereno',
+  energia = 1,
+  clima = null,
+  enso = 'neutro',
+  tier,
   ...rest
 }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
   const glow = `crt-glow-${uid}`;
   const blur = `crt-blur-${uid}`;
   const wing = animated ? 'crt-wing' : undefined;
+  const vivo = animated;
+  const auraOp = Math.max(0.16, Math.min(0.5, 0.2 + 0.3 * (energia ?? 1)));
+  const auraR = 5.2 + 1.2 * (energia ?? 1);
+
+  // CLIMA → cuerpo (perfil colibrí). El aleteo se apura (dorada) o pesa (lluvia)
+  // escalando la duración base de `.crt-wing` (0.15s). Sin clima = neutro.
+  const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: PERFIL_COLIBRI });
+  const wingDur = (wing && cuerpoClima.velocidadAlas !== 1)
+    ? { animationDuration: `${(0.15 / cuerpoClima.velocidadAlas).toFixed(3)}s` }
+    : undefined;
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
 
   const defs = (
     <defs>
       <CreatureFilters glow={glow} blur={blur} />
     </defs>
   );
+
+  // ── CUERPO rubber-hose (atrás→adelante): aura, cola, ala trasera, cuerpo
+  //    turquesa con vientre claro, patitas, cabeza (gorguera + ojo + pico),
+  //    ala delantera en borrón. `.crt-body` squashea (boil idle).
   const body = (
-    <g className="crt-body" filter={`url(#${glow})`}>
-      <circle r="6" fill="#2dffc4" opacity="0.35" filter={`url(#${blur})`} />
-      <path d="M-6,0.5 L-18,-3.5 L-13,0.5 L-18,4.5 Z" fill="#1f9f86" />
-      <path d="M-7,0 C-1,-6.5 10,-6 14,-1.2 C16.6,1 16.6,3.2 14,4.8 C8.5,8.2 -0.5,7.8 -7,1.4 Z" fill="#2dffc4" />
-      <path d="M-4,3 C3,5.2 10,5 14,2.6 C10,7 1.5,7.2 -5,2.2 Z" fill="#bfffe9" opacity="0.7" />
-      <circle cx="12.4" cy="-2.2" r="4.2" fill="#3be8a6" />
-      <path d="M11.4,0.4 C12.8,2.6 14.6,2.6 15.8,0.6 C14.6,3 11.8,3 11.4,0.4 Z" fill="#b28dff" opacity="0.9" />
-      <circle cx="13.6" cy="-2.8" r="1.2" fill="#04160f" />
-      <circle cx="14" cy="-3.2" r="0.4" fill="#eafff6" />
-      <path d="M16.2,-1.8 C21.5,-2.4 26,-3.1 30.4,-4.4" stroke="#eafff6" strokeWidth="1.4" fill="none" strokeLinecap="round" />
-      <path className={wing} d="M4,-1.6 C-4.5,-16 10.5,-23.5 17.5,-14 C14.8,-5.6 8.2,-1.6 4,-1.6 Z" fill="#4fd8ff" opacity="0.8" />
-      <path className={wing} style={{ animationDelay: '-0.05s' }} d="M5.6,1.8 C0,13.2 13.4,17.8 17.5,10 C14.2,4.2 9.6,1.8 5.6,1.8 Z" fill="#2dffc4" opacity="0.45" />
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* aura viva */}
+      <circle cx="1" cy="0" r={auraR} fill={COLIBRI_PALETA.cuerpo} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* cola (abanico de timoneras a la izquierda) */}
+      <g fill={COLIBRI_PALETA.cola} stroke={RH_INK} strokeWidth="0.5">
+        {COLA.map((d, i) => (<path key={i} d={d} />))}
+      </g>
+
+      {/* ala TRASERA en borrón (batida): detrás del cuerpo, con smear del aleteo */}
+      <path className={wing} style={{ animationDelay: '-0.05s', ...wingDur }}
+        d="M2,0.6 C-4,12 9,16.4 13.6,8.8 C10.6,3.4 6,1.2 2,0.6 Z"
+        fill={COLIBRI_PALETA.cuerpo} opacity="0.4" stroke="rgba(42,26,12,0.3)" strokeWidth="0.5" />
+
+      {/* patitas manguera diminutas (recogidas bajo el cuerpo) */}
+      <path d="M-1.4,4.4 C-1.8,5.8 -1.6,6.6 -1.0,7.0" stroke={RH_INK} strokeWidth="1.1" fill="none" strokeLinecap="round" />
+      <path d="M1.4,4.6 C1.2,6.0 1.4,6.8 2.0,7.2" stroke={RH_INK} strokeWidth="1.1" fill="none" strokeLinecap="round" />
+
+      {/* cuerpo turquesa (gota) con contorno grueso (respira con el boil) */}
+      <ellipse cx="0" cy="0.4" rx={COLIBRI_PROPORCION.troncoRx} ry={COLIBRI_PROPORCION.troncoRy}
+        fill={COLIBRI_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.3"
+        style={{ filter: `drop-shadow(0 0 6px ${COLIBRI_PALETA.cuerpoGlow})` }} />
+      {/* vientre claro (el pecho que sube y baja) */}
+      <path d="M-3,2.6 C2.4,4.6 7,4 10,1.8 C6.6,5.8 -0.4,6 -4,2.0 Z" fill={COLIBRI_PALETA.vientre} opacity="0.85" />
+
+      {/* cabeza turquesa con contorno */}
+      <circle cx="6.6" cy="-2.4" r={COLIBRI_PROPORCION.cabezaR} fill={COLIBRI_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.2" />
+      {/* GORGUERA violeta iridiscente (la firma): mancha bajo la cara + brillo */}
+      <path d="M5.0,-0.2 C6.6,2.2 9.4,2.2 10.8,-0.2 C10.2,2.6 5.8,2.8 5.0,-0.2 Z"
+        fill={COLIBRI_PALETA.garganta} opacity="0.95" />
+      <path d="M6.4,0.2 C7.2,1.2 8.6,1.2 9.4,0.2 C8.6,1.4 7.2,1.4 6.4,0.2 Z"
+        fill={COLIBRI_PALETA.gargantaBrillo} opacity="0.8" />
+      {/* chapeta + sonrisa mínima en la base del pico */}
+      <Cachetes puntos={[{ cx: 5.0, cy: -1.4, r: 1.0 }]} vivo={vivo} />
+      <Sonrisa cx={8.4} cy={-1.0} w={1.8} prof={0.7} />
+      {/* PICO recto y largo (dos mandíbulas de tinta cálida) */}
+      <path d="M9.6,-2.4 L18.4,-4.2" stroke={RH_INK} strokeWidth="1.3" fill="none" strokeLinecap="round" />
+      <path d="M9.6,-1.4 L17.8,-3.4" stroke={RH_INK} strokeWidth="0.9" fill="none" strokeLinecap="round" opacity="0.7" />
+      {/* ojo de goma grande (3/4: uno prominente) */}
+      <OjosRubber
+        ojos={[{ cx: 6.9, cy: -3.0, r: 1.7 }]}
+        mirar={[0.32, 0.2]}
+        parpadea={vivo}
+      />
+
+      {/* ala DELANTERA en borrón (batida, encima del cuerpo con smear) */}
+      <path className={wing} style={wingDur}
+        d="M3,-1.6 C-4.6,-15 10.8,-22 17.6,-13 C14.6,-5 8.2,-1.6 3,-1.6 Z"
+        fill={COLIBRI_PALETA.ala} opacity="0.78" stroke="rgba(42,26,12,0.35)" strokeWidth="0.5" />
     </g>
   );
 
+  const cuerpoVivo = vivo ? (
+    <g className="rh-antic">
+      <g className="rh-travieso">{body}</g>
+    </g>
+  ) : body;
+
+  const estadoAttrs = {
+    'data-creature': 'colibri',
+    'data-pose': vivo ? pose : undefined,
+    'data-animo': animo,
+    'data-tier': tier || undefined,
+  };
+
   if (inline) {
     return (
-      <g className={className} data-creature="colibri">
+      <g className={className} style={estiloClima} {...estadoAttrs}>
         {defs}
-        {body}
+        {cuerpoVivo}
       </g>
     );
   }
   return (
-    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
-      role="img" aria-label={title} data-creature="colibri" {...rest}>
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}
-      {body}
+      {cuerpoVivo}
     </svg>
   );
 }

--- a/src/visual/creatures/OsoAndino.jsx
+++ b/src/visual/creatures/OsoAndino.jsx
@@ -1,0 +1,158 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+import { OjosRubber, Cachetes, Sonrisa, Miembro, RH_INK } from './_rubberhose.jsx';
+import { OSO_PALETA, OSO_PROPORCION } from './faunaAndina.js';
+import { cuerpoDeClima, PERFIL_OSO } from './creatureClimaCuerpo.js';
+
+/* Oso andino — Tremarctos ornatus (oso de anteojos, el único oso de Suramérica,
+   guardián del páramo). Hermano rubber-hose de la abeja Angelita: compone el
+   MISMO kit `_rubberhose.jsx` (ojos de goma, cachetes, sonrisa, miembros
+   manguera) y hereda la MISMA cadencia `rh-*` de `creatures.css` (boil que
+   respira, parpadeo, follow-through, vuelta de campana) — cero animación
+   redibujada. Solo cambia el ANIMAL: mole parda, pesada y entrañable, con los
+   ANTEOJOS crema (su firma) alrededor de los ojos, hocico claro y orejas
+   redondas que se mecen. Es de SUELO: se sienta (no vuela) — sin alas. La
+   IDENTIDAD (paleta + proporciones) vive en `faunaAndina.js`; el CLIMA→cuerpo,
+   en `creatureClimaCuerpo.js` con PERFIL_OSO (pelaje que empapa despacio, mole
+   que la niebla apenas difumina, robusto ante la seca). */
+const VIEWBOX = '-16 -20 32 40';
+
+export function OsoAndino({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Oso andino',
+  /* Pose de VIDA (idle-life), equivalentes a las de Angelita: 'anda' (base) |
+     'celebra' (brinca con brazos en V + overshoot) | 'reposo' (respira hondo,
+     sentado) | 'señala' (se inclina al POI y apunta con la zarpa). Los gestos
+     species-agnostic viven en `creatures.css` (rh-g-*) y solo corren viva
+     (animated); con animated=false o reduced-motion queda en fotograma digno. */
+  pose = 'anda',
+  animo = 'sereno',
+  energia = 1,
+  /* CLIMA REAL escrito en el cuerpo (perfil oso). Sin clima (avatares, catálogo)
+     = neutro digno: el oso se ve EXACTO como siempre. */
+  clima = null,
+  enso = 'neutro',
+  tier,
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const vivo = animated;
+  const auraOp = Math.max(0.14, Math.min(0.42, 0.18 + 0.26 * (energia ?? 1)));
+  const auraR = 8.5 + 1.6 * (energia ?? 1);
+
+  // CLIMA → cuerpo (determinista, una vez por render): tinte + opacidad al
+  // contorno. El oso no tiene alas (velocidadAlas siempre 1: no se usa).
+  const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: PERFIL_OSO });
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+
+  // ── CUERPO rubber-hose (atrás→adelante): aura, orejas, patas, tronco pardo
+  //    con pecho crema, bracitos manguera, cabeza (anteojos + ojos/cachetes/
+  //    sonrisa + hocico). `.crt-body` es el nodo que squashea (boil idle).
+  const body = (
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* aura viva */}
+      <circle cx="0" cy="2" r={auraR} fill={OSO_PALETA.cuerpo} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* orejas redondas (detrás de la cabeza, se mecen con follow-through) */}
+      <g className={vivo ? 'rh-sway' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center bottom', animationDelay: '-0.2s' }}>
+        <circle cx="-4.7" cy="-13.6" r={OSO_PROPORCION.orejaR} fill={OSO_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.2" />
+        <circle cx="-4.7" cy="-13.6" r={OSO_PROPORCION.orejaR * 0.5} fill={OSO_PALETA.oreja} />
+      </g>
+      <g className={vivo ? 'rh-sway' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center bottom', animationDelay: '-0.5s' }}>
+        <circle cx="4.7" cy="-13.6" r={OSO_PROPORCION.orejaR} fill={OSO_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.2" />
+        <circle cx="4.7" cy="-13.6" r={OSO_PROPORCION.orejaR * 0.5} fill={OSO_PALETA.oreja} />
+      </g>
+
+      {/* patas traseras (se sienta): muslos anchos con planta crema, detrás del
+          tronco. Se mecen suave. */}
+      <Miembro d="M-6.4,7.2 C-8.4,9.2 -8.6,11 -7.2,12.2" ancho={3.4} punta={[-7.2, 12.4]} puntaR={2.0} pie sway={vivo} delay={-0.7} />
+      <Miembro d="M6.4,7.2 C8.4,9.2 8.6,11 7.2,12.2" ancho={3.4} punta={[7.2, 12.4]} puntaR={2.0} pie sway={vivo} delay={-1.0} />
+
+      {/* tronco pardo con contorno grueso (la línea que respira con el boil) */}
+      <ellipse cx="0" cy="2" rx={OSO_PROPORCION.troncoRx} ry={OSO_PROPORCION.troncoRy}
+        fill={OSO_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.4"
+        style={{ filter: `drop-shadow(0 0 6px ${OSO_PALETA.cuerpoGlow})` }} />
+      {/* pecho/panza crema (el pelaje claro del pecho) */}
+      <path d="M0,-4.4 C4.4,-3.4 5.6,2 4.2,6.4 C2.6,9.4 -2.6,9.4 -4.2,6.4 C-5.6,2 -4.4,-3.4 0,-4.4 Z"
+        fill={OSO_PALETA.panza} opacity="0.9" />
+      <ellipse cx="0" cy="3.4" rx="3.2" ry="4.2" fill={OSO_PALETA.crema} opacity="0.85" />
+
+      {/* bracitos manguera (zarpas) con planta crema, pivote en el HOMBRO para
+          que celebra/señala los alcen desde el hombro (no del centro del bbox). */}
+      <Miembro clase="crt-brazo-l" origen="right top"
+        d="M-7.2,-1.4 C-10.2,0.2 -11.2,3.2 -10.2,6.0" ancho={3.2} punta={[-10.2, 6.4]} puntaR={2.1} pie sway={vivo} delay={-0.15} />
+      <Miembro clase="crt-brazo-r" origen="left top"
+        d="M7.2,-1.4 C10.2,0.2 11.2,3.2 10.2,6.0" ancho={3.2} punta={[10.2, 6.4]} puntaR={2.1} pie sway={vivo} delay={-0.45} />
+
+      {/* cabeza parda con contorno */}
+      <circle cx="0" cy="-8.2" r={OSO_PROPORCION.cabezaR} fill={OSO_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.3" />
+      {/* ANTEOJOS crema: los anillos claros alrededor de los ojos (la firma de la
+          especie), dibujados DETRÁS de los ojos de goma. */}
+      <g fill={OSO_PALETA.crema} opacity="0.95">
+        <ellipse cx="-2.5" cy="-9.0" rx="2.6" ry="3.0" />
+        <ellipse cx="2.5" cy="-9.0" rx="2.6" ry="3.0" />
+        {/* puente + hocico crema que baja al morro */}
+        <path d="M-2.2,-6.6 C-1,-5.4 1,-5.4 2.2,-6.6 C2.4,-4 1.6,-2.4 0,-2.2 C-1.6,-2.4 -2.4,-4 -2.2,-6.6 Z" />
+      </g>
+      {/* chapetas + sonrisa + trufa + ojos de goma dentro de los anteojos */}
+      <Cachetes puntos={[{ cx: -4.4, cy: -6.6, r: 1.25 }, { cx: 4.4, cy: -6.6, r: 1.25 }]} vivo={vivo} />
+      <Sonrisa cx={0} cy={-3.6} w={3.0} prof={1.2} />
+      {/* trufa (nariz) */}
+      <ellipse cx="0" cy="-4.6" rx="1.5" ry="1.15" fill={OSO_PALETA.hocico} />
+      <OjosRubber
+        ojos={[{ cx: -2.5, cy: -9.2, r: 1.7 }, { cx: 2.5, cy: -9.2, r: 1.7 }]}
+        mirar={[0, 0.28]}
+        parpadea={vivo}
+      />
+    </g>
+  );
+
+  // Antics de VIDA (períodos co-primos) SOLO viva; nodos aparte para no pisar
+  // el boil de `.crt-body`. El CSS los apaga con RM / tier bajo / ánimo bajo /
+  // durante los gestos (celebra/reposo/señala).
+  const cuerpoVivo = vivo ? (
+    <g className="rh-antic">
+      <g className="rh-travieso">{body}</g>
+    </g>
+  ) : body;
+
+  const estadoAttrs = {
+    'data-creature': 'oso-andino',
+    'data-pose': vivo ? pose : undefined,
+    'data-animo': animo,
+    'data-tier': tier || undefined,
+  };
+
+  if (inline) {
+    return (
+      <g className={className} style={estiloClima} {...estadoAttrs}>
+        {defs}
+        {cuerpoVivo}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
+      <title>{title}</title>
+      {defs}
+      {cuerpoVivo}
+    </svg>
+  );
+}
+
+export default OsoAndino;

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -20,8 +20,10 @@ calidad dispar. Aquí vive la **versión canónica** de cada uno.
 
 | Componente | Especie (binomio verificado) | Notas |
 |---|---|---|
-| `AbejaAngelita` | *Tetragonisca angustula* | Meliponino nativo **SIN aguijón** — NO *Apis*. Alitas de tul que baten. |
-| `Colibri` | *Colibri coruscans* | Colibrí chillón andino. Pico largo, garganta violeta, alas que baten. |
+| `AbejaAngelita` | *Tetragonisca angustula* | Meliponino nativo **SIN aguijón** — NO *Apis*. Alitas de tul que baten. Rubber-hose. |
+| `Colibri` | *Colibri coruscans* | Colibrí chillón andino. Pico largo, garganta violeta, alas que baten. **Rubber-hose** (adoptado). |
+| `OsoAndino` | *Tremarctos ornatus* | Oso de anteojos, guardián del páramo. Mole parda con **anteojos crema** (su firma). De suelo, se sienta. Rubber-hose. |
+| `RanaAndina` | *Atelopus* spp. | Rana arlequín del páramo. Verde húmedo con manchas ocre, vientre dorado, ojos saltones y bocota. Rubber-hose. |
 | `Lombriz` | *Martiodrilus crassus* | Lombriz gigante nativa. Cuerpo segmentado con clitelo. Sin animación propia (su movimiento lo da la escena). |
 | `Mariposa` | *Dione juno* | Pasionaria de alas largas. Cuatro alas que abren y cierran. |
 | `Escarabajo` | *Dichotomius belus* | Estercolero colombiano. Élitros brillantes, cuerno, y bola de abono que rueda. |
@@ -89,8 +91,10 @@ que **el oso andino y el colibrí lo hereden sin redibujar**:
 estados reactivos. Standalone (avatares/catálogo) sin `tier` = rubber-hose pleno.
 
 **Estrenado por**: `AbejaAngelita` (referencia de composición del KIT).
-**Pendientes de adoptar**: `OsoAndino` (nuevo) y `Colibri` — componen las mismas
-piezas + clases `rh-*` con SUS proporciones. No hay que reinventar la cadencia.
+**Ya adoptado por**: `OsoAndino`, `Colibri` y `RanaAndina` — componen las mismas
+piezas + clases `rh-*` con SUS proporciones (identidad en `faunaAndina.js`), y
+heredan los gestos species-agnostic (`rh-g-celebra` / `rh-g-reposo` /
+`rh-g-senala`) solo con `data-pose`. No se reinventa la cadencia.
 
 ## Técnica
 

--- a/src/visual/creatures/RanaAndina.jsx
+++ b/src/visual/creatures/RanaAndina.jsx
@@ -1,0 +1,154 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+import { OjosRubber, Cachetes, Sonrisa, Miembro, RH_INK } from './_rubberhose.jsx';
+import { RANA_PALETA, RANA_PROPORCION } from './faunaAndina.js';
+import { cuerpoDeClima, PERFIL_RANA } from './creatureClimaCuerpo.js';
+
+/* Rana arlequín andina — Atelopus del páramo, anfibia guardiana del agua.
+   Hermana rubber-hose de la abeja Angelita: compone el MISMO kit
+   `_rubberhose.jsx` y hereda la MISMA cadencia `rh-*` de `creatures.css` — cero
+   animación redibujada. Solo cambia el ANIMAL: cuerpo verde húmedo achatado con
+   manchas ARLEQUÍN ocre, vientre dorado, OJOS SALTONES enormes en lo alto y una
+   BOCOTA de goma. Es de SUELO: se sienta en la hoja (no vuela) — sin alas. Su
+   PERFIL_RANA la hace la más brillante mojada y la MÁS golpeada por la sequía
+   (la piel se le reseca): el CLIMA→cuerpo lo pone `creatureClimaCuerpo.js`, con
+   un tinte de lluvia que empuja el verde húmedo. IDENTIDAD en `faunaAndina.js`. */
+const VIEWBOX = '-15 -16 30 32';
+
+/* Manchas del patrón arlequín (blobs ocre sobre el dorso verde). */
+const MANCHAS = [
+  { cx: -5.2, cy: 1.2, rx: 1.9, ry: 1.5, c: 'mancha' },
+  { cx: 4.8, cy: 2.0, rx: 2.1, ry: 1.6, c: 'manchaClara' },
+  { cx: -1.0, cy: 5.2, rx: 1.7, ry: 1.3, c: 'mancha' },
+  { cx: 6.0, cy: -1.6, rx: 1.3, ry: 1.1, c: 'manchaClara' },
+];
+
+export function RanaAndina({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Rana arlequín andina',
+  /* Pose de VIDA (idle-life), equivalentes a las de Angelita: 'anda' (base) |
+     'celebra' (brinco de gozo con overshoot) | 'reposo' (respira en la hoja) |
+     'señala' (se inclina al POI y apunta con la manito). Gestos species-agnostic
+     en `creatures.css` (rh-g-*); solo corren viva (animated). */
+  pose = 'anda',
+  animo = 'sereno',
+  energia = 1,
+  clima = null,
+  enso = 'neutro',
+  tier,
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const vivo = animated;
+  const auraOp = Math.max(0.14, Math.min(0.44, 0.18 + 0.28 * (energia ?? 1)));
+  const auraR = 7.6 + 1.4 * (energia ?? 1);
+
+  // CLIMA → cuerpo (perfil rana). Sin clima = neutro digno.
+  const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: PERFIL_RANA });
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+
+  // ── CUERPO rubber-hose (atrás→adelante): aura, ancas traseras, tronco verde
+  //    con manchas + vientre dorado, bracitos manguera con discos, garganta,
+  //    bocota, ojos saltones en cúpula. `.crt-body` squashea (boil idle).
+  const body = (
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* aura viva */}
+      <circle cx="0" cy="1" r={auraR} fill={RANA_PALETA.cuerpo} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* ancas traseras plegadas (los muslos potentes a cada lado, detrás) */}
+      <g className={vivo ? 'rh-sway' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center top', animationDelay: '-0.8s' }}>
+        <path d="M-8.4,1.6 C-11.6,2.6 -12.2,6.6 -9.6,8.8 C-7.6,10.4 -5.4,9.2 -5.0,7.0 C-4.6,4.6 -6.0,2.2 -8.4,1.6 Z"
+          fill={RANA_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.2" />
+        {/* pie palmeado */}
+        <Miembro d="M-9.4,8.4 C-11.4,9.6 -12.6,9.2 -13.4,10.2" ancho={1.6} punta={[-13.4, 10.3]} puntaR={1.3} pie />
+      </g>
+      <g className={vivo ? 'rh-sway' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center top', animationDelay: '-1.1s' }}>
+        <path d="M8.4,1.6 C11.6,2.6 12.2,6.6 9.6,8.8 C7.6,10.4 5.4,9.2 5.0,7.0 C4.6,4.6 6.0,2.2 8.4,1.6 Z"
+          fill={RANA_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.2" />
+        <Miembro d="M9.4,8.4 C11.4,9.6 12.6,9.2 13.4,10.2" ancho={1.6} punta={[13.4, 10.3]} puntaR={1.3} pie />
+      </g>
+
+      {/* tronco verde achatado con contorno grueso (respira con el boil) */}
+      <ellipse cx="0" cy="1.6" rx={RANA_PROPORCION.troncoRx} ry={RANA_PROPORCION.troncoRy}
+        fill={RANA_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.4"
+        style={{ filter: `drop-shadow(0 0 6px ${RANA_PALETA.cuerpoGlow})` }} />
+      {/* manchas arlequín ocre sobre el dorso */}
+      {MANCHAS.map((m, i) => (
+        <ellipse key={i} cx={m.cx} cy={m.cy} rx={m.rx} ry={m.ry} fill={RANA_PALETA[m.c]} opacity="0.92" />
+      ))}
+      {/* vientre dorado (el pecho claro que sube y baja) */}
+      <ellipse cx="0" cy="4.6" rx="5.2" ry="3.4" fill={RANA_PALETA.vientre} opacity="0.9" />
+
+      {/* bracitos manguera con discos de dedo (crema-dorado), pivote en HOMBRO */}
+      <Miembro clase="crt-brazo-l" origen="right top"
+        d="M-6.0,3.0 C-8.6,4.6 -9.2,6.8 -8.2,8.6" ancho={2.0} punta={[-8.2, 8.9]} puntaR={1.5} pie sway={vivo} delay={-0.2} glove={RANA_PALETA.dedo} />
+      <Miembro clase="crt-brazo-r" origen="left top"
+        d="M6.0,3.0 C8.6,4.6 9.2,6.8 8.2,8.6" ancho={2.0} punta={[8.2, 8.9]} puntaR={1.5} pie sway={vivo} delay={-0.5} glove={RANA_PALETA.dedo} />
+
+      {/* garganta que late (papada), bajo la boca */}
+      <ellipse cx="0" cy="-1.2" rx="3.6" ry="2.2" fill={RANA_PALETA.papada} opacity="0.85" />
+      {/* la BOCOTA de goma: sonrisa ancha de rana */}
+      <Sonrisa cx={0} cy={-2.2} w={9.2} prof={2.2} />
+      {/* chapetas campesinas a los lados de la bocota */}
+      <Cachetes puntos={[{ cx: -5.6, cy: -2.6, r: 1.35 }, { cx: 5.6, cy: -2.6, r: 1.35 }]} vivo={vivo} />
+
+      {/* OJOS SALTONES: cúpulas verdes sobre el lomo con el ojo de goma encima
+          (el rasgo de la rana). Párpado que asoma por arriba. */}
+      <circle cx="-4.4" cy="-6.2" r={RANA_PROPORCION.ojoR + 0.7} fill={RANA_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.2" />
+      <circle cx="4.4" cy="-6.2" r={RANA_PROPORCION.ojoR + 0.7} fill={RANA_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.2" />
+      <path d="M-7.2,-7.0 A3.6,3.6 0 0 1 -1.6,-7.0" fill={RANA_PALETA.parpado} opacity="0.9" />
+      <path d="M1.6,-7.0 A3.6,3.6 0 0 1 7.2,-7.0" fill={RANA_PALETA.parpado} opacity="0.9" />
+      <OjosRubber
+        ojos={[{ cx: -4.4, cy: -5.9, r: 2.2 }, { cx: 4.4, cy: -5.9, r: 2.2 }]}
+        mirar={[0, 0.18]}
+        parpadea={vivo}
+      />
+    </g>
+  );
+
+  const cuerpoVivo = vivo ? (
+    <g className="rh-antic">
+      <g className="rh-travieso">{body}</g>
+    </g>
+  ) : body;
+
+  const estadoAttrs = {
+    'data-creature': 'rana-andina',
+    'data-pose': vivo ? pose : undefined,
+    'data-animo': animo,
+    'data-tier': tier || undefined,
+  };
+
+  if (inline) {
+    return (
+      <g className={className} style={estiloClima} {...estadoAttrs}>
+        {defs}
+        {cuerpoVivo}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
+      <title>{title}</title>
+      {defs}
+      {cuerpoVivo}
+    </svg>
+  );
+}
+
+export default RanaAndina;

--- a/src/visual/creatures/creatureClimaCuerpo.js
+++ b/src/visual/creatures/creatureClimaCuerpo.js
@@ -155,6 +155,7 @@ export const PERFILES = Object.freeze({
   colibri: PERFIL_COLIBRI,
   'oso-andino': PERFIL_OSO,
   rana: PERFIL_RANA,
+  'rana-andina': PERFIL_RANA, // alias del slug de la creature 2D (RanaAndina)
 });
 
 function clamp01(n) {

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -154,6 +154,98 @@
   86%  { transform: rotate(-6deg); }    /* recoge con follow-through */
 }
 
+/* ═══ GESTOS con carácter — VERSIÓN SPECIES-AGNOSTIC (rh-g-*) ════════════════
+   La MISMA gramática de gestos (celebra / reposo / señala) para el resto de la
+   familia rubber-hose: el OSO ANDINO, el COLIBRÍ y la RANA la heredan solo con
+   data-pose, sin CSS propio. Angelita NO se toca: sus reglas
+   [data-creature='abeja-angelita'][data-pose=…] tienen MAYOR especificidad (dos
+   atributos) y PISAN estas genéricas (un atributo) — su gesto afinado (3/4,
+   asimétrico) manda sobre el suyo. Aquí los cuerpos frontales/simétricos (oso,
+   rana) alzan una V simétrica; el colibrí celebra a cuerpo + aleteo acelerado.
+   El gate ya está resuelto arriba y abajo con selectores [data-pose] genéricos:
+   la desactivación de antics durante el gesto y el freeze de reduced-motion YA
+   cubren estas clases (mismos selectores). ─────────────────────────────────── */
+
+/* CELEBRA — brinca: anticipa (squash), SALTA con stretch y aterriza con
+   overshoot elástico; los bracitos (si los hay) suben en V simétrica. */
+[data-pose='celebra'] .crt-body {
+  animation: rh-g-celebra 1.15s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes rh-g-celebra {
+  0%   { transform: translateY(0) scale(1, 1); }
+  16%  { transform: translateY(1.6px) scale(1.08, 0.9); }   /* anticipa: se agacha */
+  42%  { transform: translateY(-5px) scale(0.9, 1.14); }    /* ¡SALTA! (stretch) */
+  62%  { transform: translateY(0.8px) scale(1.1, 0.9); }    /* aterriza (overshoot) */
+  80%  { transform: translateY(-0.8px) scale(0.98, 1.04); } /* rebote elástico */
+  100% { transform: translateY(0) scale(1, 1); }
+}
+[data-pose='celebra'] .crt-brazo-l {
+  animation: rh-g-brazo-l 1.15s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+}
+[data-pose='celebra'] .crt-brazo-r {
+  animation: rh-g-brazo-r 1.15s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+}
+/* Brazos de manguera que pivotan del hombro (crt-brazo-* traen su origen): suben
+   en V simétrica rebasando el pico y asentando un pelo (follow-through). */
+@keyframes rh-g-brazo-l {
+  0%, 12% { transform: rotate(0deg); }
+  42%  { transform: rotate(122deg); }   /* alza arriba-izquierda (rebasa) */
+  62%  { transform: rotate(108deg); }   /* asienta */
+  80%  { transform: rotate(114deg); }
+  100% { transform: rotate(0deg); }
+}
+@keyframes rh-g-brazo-r {
+  0%, 12% { transform: rotate(0deg); }
+  42%  { transform: rotate(-122deg); }  /* alza arriba-derecha (rebasa) */
+  62%  { transform: rotate(-108deg); }  /* asienta */
+  80%  { transform: rotate(-114deg); }
+  100% { transform: rotate(0deg); }
+}
+/* Alados (colibrí): la celebración acelera el aleteo. */
+[data-pose='celebra'] .crt-wing { animation-duration: 0.09s; }
+
+/* REPOSO — respira despacio (el pecho sube y baja). Los alados pliegan las alas
+   (reusa crt-wing-reposo). */
+[data-pose='reposo'] .crt-body {
+  animation: rh-g-reposo 4.4s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes rh-g-reposo {
+  0%, 100% { transform: translateY(0) scale(1, 1); }
+  50%      { transform: translateY(-0.4px) scale(0.985, 1.03); }  /* inhala */
+}
+[data-pose='reposo'] .crt-wing {
+  animation: crt-wing-reposo 3.6s ease-in-out infinite alternate;
+}
+
+/* SEÑALA — se inclina hacia el POI (a su derecha) rebasando y asentándose,
+   sostiene el gesto y vuelve; el bracito derecho apunta. */
+[data-pose='señala'] .crt-body {
+  animation: rh-g-senala 2.9s cubic-bezier(0.5, 0, 0.25, 1.4) infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes rh-g-senala {
+  0%, 100% { transform: rotate(0deg) translateX(0); }
+  20%  { transform: rotate(8deg) translateX(0.6px); }   /* se inclina rebasando */
+  30%  { transform: rotate(6deg) translateX(0.4px); }   /* asienta apuntando */
+  72%  { transform: rotate(6deg) translateX(0.4px); }   /* sostiene */
+  86%  { transform: rotate(-1.5deg) translateX(0); }    /* rebote al enderezarse */
+}
+[data-pose='señala'] .crt-brazo-r {
+  animation: rh-g-brazo-senala 2.9s cubic-bezier(0.5, 0, 0.25, 1.4) infinite;
+}
+@keyframes rh-g-brazo-senala {
+  0%, 100% { transform: rotate(0deg); }
+  20%  { transform: rotate(-48deg); }   /* extiende apuntando (rebasa) */
+  30%  { transform: rotate(-40deg); }   /* asienta señalando */
+  72%  { transform: rotate(-40deg); }
+  86%  { transform: rotate(-6deg); }    /* recoge (follow-through) */
+}
+
 /* ═══════════════════════════════════════════════════════════════════════════
    KIT RUBBER-HOSE (Cuphead + Miss Minutes de Loki) — SPECIES-AGNOSTIC
    Cadencia de goma REUTILIZABLE por cualquier creature. Angelita la estrena;

--- a/src/visual/creatures/faunaAndina.js
+++ b/src/visual/creatures/faunaAndina.js
@@ -1,0 +1,77 @@
+/*
+ * faunaAndina — LA IDENTIDAD VISUAL DEL TRÍO ANDINO, COMO DATOS.
+ *
+ * Hermana de `abejaIdentidad.js`: así como Angelita bebe su paleta/medidas de
+ * una fuente única, el OSO ANDINO (Tremarctos ornatus), el COLIBRÍ esmeralda
+ * (Colibri coruscans) y la RANA arlequín (Atelopus, páramo) tienen aquí su
+ * silueta canónica. Los tres son rubber-hose (Cuphead + Miss Minutes) con
+ * calidez campesina andina — el MISMO lenguaje de goma de la abeja, otro animal.
+ *
+ * REGLA DE ORO (idéntica a abejaIdentidad): SOLO datos. Cero three, cero react.
+ * La creature del bundle base lo importa; jamás debe arrastrar `vendor-three`.
+ * La CADENCIA (animación) vive en `creatures.css` (clases `rh-*`/`crt-*`); el
+ * DIBUJO compone el KIT `_rubberhose.jsx`; el CLIMA→cuerpo, en
+ * `creatureClimaCuerpo.js` (perfiles PERFIL_OSO/COLIBRI/RANA).
+ */
+
+/* La tinta cálida del contorno es de TODA la familia rubber-hose. */
+export { RH_INK as FAUNA_TINTA } from './_rubberhose.jsx';
+
+/* ── OSO ANDINO — Tremarctos ornatus (oso de anteojos, único oso de Suramérica).
+   Pelaje pardo-negro, hocico y pecho crema, y los ANTEOJOS crema alrededor de
+   los ojos: su firma. Entrañable y pesado. */
+export const OSO_PALETA = {
+  cuerpo: '#3b2a1e',       // pelaje pardo oscuro
+  cuerpoGlow: 'rgba(90,64,44,0.7)',
+  panza: '#5a4130',        // vientre un tono más cálido
+  crema: '#f0dcb4',        // hocico, pecho y ANTEOJOS (el rasgo de la especie)
+  cremaClara: '#fbeed0',   // realce del pecho
+  hocico: '#241812',       // nariz/trufa
+  oreja: '#2e2016',        // pabellón de la oreja
+};
+export const OSO_PROPORCION = {
+  troncoRx: 10.2,
+  troncoRy: 8.4,
+  cabezaR: 6.8,
+  orejaR: 2.7,
+};
+
+/* ── COLIBRÍ — Colibri coruscans (colibrí chillón / esmeralda andino).
+   Dorso turquesa iridiscente, garganta violeta, vientre claro, pico recto y
+   largo. Nervioso: alas que baten en borrón. */
+export const COLIBRI_PALETA = {
+  cuerpo: '#2fd6ab',       // dorso turquesa esmeralda
+  cuerpoGlow: 'rgba(45,255,196,0.75)',
+  vientre: '#d6fff0',      // pecho/vientre claro
+  garganta: '#b28dff',     // gorguera violeta iridiscente (la firma)
+  gargantaBrillo: '#d9c6ff',
+  ala: '#59e0ff',          // ala en borrón (turquesa-cielo)
+  alaClara: '#bff4ff',
+  pico: '#241812',         // pico recto (tinta cálida)
+  cola: '#26b894',         // timoneras
+};
+export const COLIBRI_PROPORCION = {
+  troncoRx: 6.0,
+  troncoRy: 4.6,
+  cabezaR: 3.4,
+  picoLargo: 9.0,
+};
+
+/* ── RANA — arlequín andina (Atelopus, del páramo). Anfibia: la más brillante
+   mojada y la más golpeada por la seca. Verde húmedo dorsal con manchas
+   arlequín ocre, vientre dorado, ojos saltones enormes y bocota de goma. */
+export const RANA_PALETA = {
+  cuerpo: '#4bbf6a',       // verde musgo húmedo
+  cuerpoGlow: 'rgba(75,191,106,0.7)',
+  vientre: '#f4d774',      // vientre dorado (arlequín)
+  mancha: '#c9772e',       // manchas ocre del patrón arlequín
+  manchaClara: '#e6a23c',
+  papada: '#7fd98f',       // garganta que late
+  dedo: '#f7e6a8',         // discos de los dedos (crema-dorado)
+  parpado: '#3a9e57',      // párpado sobre el ojo saltón
+};
+export const RANA_PROPORCION = {
+  troncoRx: 9.2,
+  troncoRy: 6.2,
+  ojoR: 2.9,
+};

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -25,12 +25,23 @@ export {
 } from './AbejaTransicion.jsx';
 export { avisarSalidaAbeja, resetSalidaAbeja, useSalidaAbeja } from './senalSalidaAbeja.js';
 export { Colibri } from './Colibri.jsx';
+export { OsoAndino } from './OsoAndino.jsx';
+export { RanaAndina } from './RanaAndina.jsx';
+/* La IDENTIDAD del trío andino como datos (paletas + proporciones). Solo datos:
+   jamás arrastra three al bundle base — igual que abejaIdentidad. */
+export {
+  OSO_PALETA, OSO_PROPORCION,
+  COLIBRI_PALETA, COLIBRI_PROPORCION,
+  RANA_PALETA, RANA_PROPORCION, FAUNA_TINTA,
+} from './faunaAndina.js';
 export { Lombriz } from './Lombriz.jsx';
 export { Mariposa } from './Mariposa.jsx';
 export { Escarabajo } from './Escarabajo.jsx';
 
 import AbejaAngelita from './AbejaAngelita.jsx';
 import Colibri from './Colibri.jsx';
+import OsoAndino from './OsoAndino.jsx';
+import RanaAndina from './RanaAndina.jsx';
 import Lombriz from './Lombriz.jsx';
 import Mariposa from './Mariposa.jsx';
 import Escarabajo from './Escarabajo.jsx';
@@ -39,6 +50,8 @@ import Escarabajo from './Escarabajo.jsx';
 export const CREATURES = {
   'abeja-angelita': { Component: AbejaAngelita, nombre: 'Abeja angelita', cientifico: 'Tetragonisca angustula' },
   colibri: { Component: Colibri, nombre: 'Colibrí chillón', cientifico: 'Colibri coruscans' },
+  'oso-andino': { Component: OsoAndino, nombre: 'Oso andino', cientifico: 'Tremarctos ornatus' },
+  'rana-andina': { Component: RanaAndina, nombre: 'Rana arlequín andina', cientifico: 'Atelopus spp.' },
   lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
   mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
   escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -52,11 +52,41 @@ const VARIANTES_ABEJA = [
   { label: 'sin animación', props: { size: 80, animated: false } },
 ];
 
+/* El trío andino rubber-hose (oso / colibrí / rana) estrena los MISMOS gestos
+   species-agnostic que Angelita: celebra (brinco + V con overshoot), reposo
+   (respira) y señala (se inclina al POI y apunta). Base 'vuela' para el colibrí
+   (alado) y 'anda' para el oso y la rana (de suelo). */
+const VARIANTES_TRIO_AIRE = [
+  { label: '48 px', props: { size: 48 } },
+  { label: 'vuela', props: { size: 80 } },
+  { label: 'celebra', props: { size: 80, pose: 'celebra' } },
+  { label: 'reposo', props: { size: 80, pose: 'reposo' } },
+  { label: 'señala', props: { size: 80, pose: 'señala' } },
+  { label: 'sin animación', props: { size: 80, animated: false } },
+];
+const VARIANTES_TRIO_SUELO = [
+  { label: '48 px', props: { size: 48 } },
+  { label: 'anda', props: { size: 80 } },
+  { label: 'celebra', props: { size: 80, pose: 'celebra' } },
+  { label: 'reposo', props: { size: 80, pose: 'reposo' } },
+  { label: 'señala', props: { size: 80, pose: 'señala' } },
+  { label: 'sin animación', props: { size: 80, animated: false } },
+];
+/* Variantes de vitrina por slug (las que difieren del set genérico). */
+const VARIANTES_POR_SLUG = {
+  'abeja-angelita': VARIANTES_ABEJA,
+  colibri: VARIANTES_TRIO_AIRE,
+  'oso-andino': VARIANTES_TRIO_SUELO,
+  'rana-andina': VARIANTES_TRIO_SUELO,
+};
+
 /* Nota de campo por creature (el registro de la categoría trae nombre + binomio;
    la descripción de una línea va aquí). */
 const NOTAS_CREATURE = {
   'abeja-angelita': 'Meliponino sin aguijón, polinizadora de la chagra; alas que baten y antenas vivas.',
-  colibri: 'Pico recto y garganta violeta iridiscente; el ave-agente de Chagra.',
+  colibri: 'Pico recto y garganta violeta iridiscente; el ave-agente de Chagra, ya en rubber-hose.',
+  'oso-andino': 'Oso de anteojos, guardián del páramo; mole parda entrañable con los anteojos crema (su firma).',
+  'rana-andina': 'Rana arlequín del páramo, guardiana del agua; verde húmedo con manchas ocre y ojos saltones.',
   lombriz: 'La ingeniera del suelo; ondula por segmentos con clitelo marcado.',
   mariposa: 'Alas naranjas con venación; poliniza y anuncia buen suelo.',
   escarabajo: 'Estercolero que entierra el abono; élitros con brillo metálico.',
@@ -241,7 +271,7 @@ const ITEMS_CREATURES = Object.entries(CREATURES).map(([slug, meta]) => ({
   render: 'component',
   descripcion: NOTAS_CREATURE[slug] || '',
   props: PROPS_CREATURE,
-  variantes: slug === 'abeja-angelita' ? VARIANTES_ABEJA : VARIANTES_CREATURE,
+  variantes: VARIANTES_POR_SLUG[slug] || VARIANTES_CREATURE,
 }));
 
 const ITEMS_LAMINAS = Object.entries(LAMINAS).map(([slug, meta]) => ({


### PR DESCRIPTION
## Qué

Tres criaturas 2D de la familia **rubber-hose** (Cuphead / Miss Minutes) con calidez andina, hermanas de la abeja Angelita. **Reúsan** los efectos species-agnostic que ya existían — cero animación redibujada, solo cambia el animal:

- **`OsoAndino`** (*Tremarctos ornatus*) — mole parda de suelo con los **anteojos crema** (su firma), orejas que se mecen. `PERFIL_OSO`.
- **`Colibri`** (*Colibri coruscans*) — la versión canónica **sube a rubber-hose** (era el legacy SVG). **API estable** (`size/className/inline/animated/title`), así los ~10 consumidores heredan el nuevo look sin tocar su código. Dorso turquesa, gorguera violeta, pico recto, aleteo en borrón. `PERFIL_COLIBRI`.
- **`RanaAndina`** (*Atelopus* spp., páramo) — verde húmedo con manchas arlequín, vientre dorado, ojos saltones y bocota. `PERFIL_RANA`.

## Cómo reúsa (no reinventa)

- Dibujo → compone el kit `_rubberhose.jsx` (ojos de goma, cachetes, sonrisa, miembros manguera).
- Cadencia → hereda `rh-boil / rh-blink / rh-sway / rh-antic / rh-travieso / rh-mirada` de `creatures.css`.
- Clima → `creatureClimaCuerpo.js` con su perfil de especie (tinte + opacidad + aleteo).
- **Gestos** (celebra / reposo / señala) generalizados a species-agnostic (`rh-g-*`). **La abeja NO se toca**: sus reglas `[data-creature='abeja-angelita'][data-pose]` tienen mayor especificidad y pisan las genéricas. El freeze de `reduced-motion` y el corte de antics durante el gesto ya usaban selectores `[data-pose]` genéricos → cubren al trío sin cambios.

Identidad (paletas + proporciones) en `faunaAndina.js` (solo datos, no arrastra `three` al bundle base). Registradas en `CREATURES` (`index.js`) → publicadas automáticamente en la vitrina `#/mockups/visual-lib` con sus variantes de gesto.

## Verificación

- `npm run build` ✅ (1m17s, solo warnings preexistentes).
- Smoke test de la vitrina `visualLib.smoke.test.jsx` ✅ (2/2) — monta las 4 categorías con el trío incluido.
- Archivos nuevos aislados; el único archivo compartido con cambio de comportamiento es `creatures.css` (aditivo, sin tocar a Angelita).

🤖 Generated with [Claude Code](https://claude.com/claude-code)