### PR TITLE
feat(valle): ciclo diurno vivo — el valle 3D gira con la hora real

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -36,10 +36,11 @@ import {
   MUNDO_VALLE_BY_ID,
   COSA_DEL_DIA,
   CLIMAS,
-  climaPorHora,
   animoDeFinca,
   NARRACION,
 } from './valle/valleData';
+/* El reloj del ciclo diurno vivo (franja real del día + override ?ciclo=). */
+import useCicloDia from '../visual/mundo3d/useCicloDia.js';
 import Valle2DFallback from './valle/Valle2DFallback';
 import AbejaTransicion, { AlMontarEscena } from '../visual/creatures/AbejaTransicion.jsx';
 import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
@@ -111,15 +112,6 @@ class Valle3DGuard extends Component {
  *   nombra — el comportamiento de siempre.
  */
 export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = null }) {
-  const [clima, setClima] = useState(() => climaPorHora());
-
-  // ── El clima es ATMÓSFERA, no un selector (auditoría B8/S8): los chips de
-  //    debug se quitaron de la UI. El valle sigue la hora real de la vereda y
-  //    se re-evalúa solo — amanece, atardece y anochece sin botonera.
-  useEffect(() => {
-    const t = setInterval(() => setClima(climaPorHora()), 5 * 60 * 1000);
-    return () => clearInterval(t);
-  }, []);
   const [focoId, setFocoId] = useState(null);
   const [panel, setPanel] = useState(null); // null | 'alerta' | <mundoId>
   const [voz, setVoz] = useState(true);
@@ -147,6 +139,13 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
       window.matchMedia('(prefers-reduced-motion: reduce)').matches,
     [],
   );
+
+  // ── El clima es ATMÓSFERA, no un selector (auditoría B8/S8): el valle sigue
+  //    el CICLO DIURNO VIVO por la hora real de la vereda (useCicloDia) y se
+  //    re-evalúa solo — amanece, atardece y anochece sin botonera. La franja
+  //    (amanecer→mañana→mediodía→tarde→atardecer→noche) es una piel de CLIMAS;
+  //    `?ciclo=demo` acelera el día para verlo girar y `?ciclo=17.5` lo clava.
+  const { franja: clima } = useCicloDia({ reducedMotion });
 
   const nav = useNavegacionMundos({ reducedMotion });
   const viajarAlMundoInicial = nav.viajarAlMundo;

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -23,7 +23,7 @@
 /* Nota: las props de three (position, args, intensity, castShadow, etc.) son
    válidas en el reconciliador de R3F, no en el DOM — el config de ESLint del
    repo no activa react/no-unknown-property, así que no requieren disable. */
-import { Suspense, useMemo, useRef, useState } from 'react';
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import {
   Html, Float, Stars, OrbitControls, AdaptiveDpr, Detailed, Instances, Instance,
@@ -40,6 +40,11 @@ import { Mariposa } from '../../visual/creatures/Mariposa.jsx';
 import { Escarabajo } from '../../visual/creatures/Escarabajo.jsx';
 import { Lombriz } from '../../visual/creatures/Lombriz.jsx';
 import AnimalesDeFinca from './animales.jsx';
+/* Luciérnagas de la noche: el kit instanciado que ya existe (1-3 draw calls),
+   sembrado sobre la tierra baja del valle cuando la franja las trae. */
+import { ParticulasAmbientales } from '../../visual/mundo3d/ParticulasAmbientales.jsx';
+/* Duración canónica de la transición entre franjas (misma que CielosHora). */
+import { TRANSICION } from '../../visual/mundo3d/cielosHoraData.js';
 import './rotulosValle3D.css';
 import {
   MUNDOS_VALLE,
@@ -1109,6 +1114,131 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false }
   );
 }
 
+/* ── EL CICLO DIURNO VIVO: la atmósfera del valle GIRA con la franja del día ──
+      Antes el fondo/niebla/luces se fijaban declarativos por `clima` y cambiar
+      de piel era un CORTE. Este driver (mismo patrón que CielosHora.jsx) las
+      escribe imperativamente en useFrame y AMORTIGUA cada valor hacia la piel
+      nueva (~2.5 s): amanece, atardece y anochece como un giro del día, no un
+      teletransporte. El sol además LLEVA su posición (`c.sol`): rasante al
+      amanecer, cenital al mediodía (sombras cortas), luna desde el otro lado
+      de noche — las sombras del tier alto giran gratis con él.
+      Cero setState y cero alocación por frame (Color/Vector3 mutados in-place);
+      los props declarativos usan la piel del PRIMER montaje, que no cambia.
+      reducedMotion: snap directo al preset (frameloop 'demand' — la calma que
+      pide la preferencia), la franja igual avanza con el reloj. ── */
+const SOL_DEFECTO = [6, 9, 4];
+
+function estadoAtmosfera(c) {
+  return {
+    fondo: new THREE.Color(c.cielo[1]),
+    domo: new THREE.Color(c.cielo[0]),
+    suelo: new THREE.Color(c.ambiente),
+    luz: new THREE.Color(c.luz),
+    niebla: new THREE.Color(c.niebla),
+    solPos: new THREE.Vector3(...(c.sol || SOL_DEFECTO)),
+    intensidad: c.intensidad,
+    nieblaLejos: c.nieblaLejos + 8,
+  };
+}
+
+function amortiguarAtmosfera(actual, objetivo, k) {
+  actual.fondo.lerp(objetivo.fondo, k);
+  actual.domo.lerp(objetivo.domo, k);
+  actual.suelo.lerp(objetivo.suelo, k);
+  actual.luz.lerp(objetivo.luz, k);
+  actual.niebla.lerp(objetivo.niebla, k);
+  actual.solPos.lerp(objetivo.solPos, k);
+  actual.intensidad += (objetivo.intensidad - actual.intensidad) * k;
+  actual.nieblaLejos += (objetivo.nieblaLejos - actual.nieblaLejos) * k;
+}
+
+function AtmosferaValle({ c, perfil, reducedMotion }) {
+  const objetivo = useMemo(() => estadoAtmosfera(c), [c]);
+  // La piel del primer montaje: alimenta los valores declarativos del JSX (que
+  // nunca deben cambiar tras montar) — un re-render no pisa la animación.
+  const [ini] = useState(() => c);
+  const [actual] = useState(() => estadoAtmosfera(ini));
+
+  const fondoRef = useRef(null);
+  const fogRef = useRef(null);
+  const hemiRef = useRef(null);
+  const ambRef = useRef(null);
+  const solRef = useRef(null);
+
+  const pintar = (e) => {
+    if (fondoRef.current) fondoRef.current.copy(e.fondo);
+    if (fogRef.current) {
+      fogRef.current.color.copy(e.niebla);
+      fogRef.current.far = e.nieblaLejos;
+    }
+    if (hemiRef.current) {
+      hemiRef.current.intensity = e.intensidad * 0.55;
+      hemiRef.current.color.copy(e.domo);
+      hemiRef.current.groundColor.copy(e.suelo);
+    }
+    if (ambRef.current) {
+      ambRef.current.intensity = e.intensidad * 0.35;
+      ambRef.current.color.copy(e.luz);
+    }
+    if (solRef.current) {
+      solRef.current.intensity = e.intensidad;
+      solRef.current.color.copy(e.luz);
+      solRef.current.position.copy(e.solPos);
+    }
+  };
+
+  // Calma pedida → snap: la piel nueva entra completa, sin animar.
+  useEffect(() => {
+    if (!reducedMotion) return;
+    amortiguarAtmosfera(actual, objetivo, 1);
+    pintar(actual);
+  });
+
+  // Transición viva: amortiguación exponencial estable en dt variable.
+  useFrame((_, dt) => {
+    if (reducedMotion) return;
+    const k = 1 - Math.exp((-3 / TRANSICION.duracion) * Math.min(dt, 0.1));
+    amortiguarAtmosfera(actual, objetivo, k);
+    pintar(actual);
+  });
+
+  return (
+    <>
+      <color ref={fondoRef} attach="background" args={[ini.cielo[1]]} />
+      {/* La niebla se paga por fragmento: en perfil 'bajo' se apaga. */}
+      {perfil.fog && (
+        <fog ref={fogRef} attach="fog" args={[ini.niebla, 12, ini.nieblaLejos + 8]} />
+      )}
+      <hemisphereLight
+        ref={hemiRef}
+        intensity={ini.intensidad * 0.55}
+        color={ini.cielo[0]}
+        groundColor={ini.ambiente}
+      />
+      <ambientLight ref={ambRef} intensity={ini.intensidad * 0.35} color={ini.luz} />
+      {/* castShadow SOLO en 'alto': sin shadow-map la escena se dibuja UNA vez
+          por frame, no dos (DR FIX 1 — el mayor ahorro de GPU de un golpe). */}
+      <directionalLight
+        ref={solRef}
+        position={ini.sol || SOL_DEFECTO}
+        intensity={ini.intensidad}
+        color={ini.luz}
+        castShadow={perfil.sombras}
+        shadow-mapSize={[1024, 1024]}
+        shadow-camera-far={30}
+        shadow-camera-left={-12}
+        shadow-camera-right={12}
+        shadow-camera-top={12}
+        shadow-camera-bottom={-12}
+      />
+    </>
+  );
+}
+
+/* Caja de las luciérnagas: la tierra baja del frente del valle (referencia
+   ESTABLE — ParticulasAmbientales re-siembra si la caja cambia). */
+const AREA_LUCIERNAGAS = [18, 2.4, 7];
+
 /* La pose de cámara del valle: UNA fuente para el Canvas y para el establishing
    shot de la CámaraDirector (así el dolly aterriza EXACTO donde siempre). */
 const CAMARA_VALLE = { position: [10.5, 9, 13.5], fov: 40 };
@@ -1134,35 +1264,37 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
   const entrando = !!focoId;
   const nocturno = clima === 'noche';
 
+  // El ciclo trae estrellas GRADUALES (0..1 del presupuesto del tier: unas
+  // pocas se asoman al atardecer, todas de noche) y luciérnagas por densidad.
+  const fracEstrellas = c.estrellas === true ? 1 : Number(c.estrellas) || 0;
+  const luciernagas = Number(c.luciernagas) || 0;
+
   return (
     <>
-      <color attach="background" args={[c.cielo[1]]} />
-      {/* La niebla se paga por fragmento: en perfil 'bajo' se apaga. */}
-      {perfil.fog && <fog attach="fog" args={[c.niebla, 12, c.nieblaLejos + 8]} />}
-      <hemisphereLight intensity={c.intensidad * 0.55} color={c.cielo[0]} groundColor={c.ambiente} />
-      <ambientLight intensity={c.intensidad * 0.35} color={c.luz} />
-      {/* castShadow SOLO en 'alto': sin shadow-map la escena se dibuja UNA vez
-          por frame, no dos (DR FIX 1 — el mayor ahorro de GPU de un golpe). */}
-      <directionalLight
-        position={[6, 9, 4]}
-        intensity={c.intensidad}
-        color={c.luz}
-        castShadow={perfil.sombras}
-        shadow-mapSize={[1024, 1024]}
-        shadow-camera-far={30}
-        shadow-camera-left={-12}
-        shadow-camera-right={12}
-        shadow-camera-top={12}
-        shadow-camera-bottom={-12}
-      />
-      {c.estrellas && perfil.estrellas > 0 && (
+      {/* Fondo + niebla + luces, amortiguadas hacia la franja del día. */}
+      <AtmosferaValle c={c} perfil={perfil} reducedMotion={reducedMotion} />
+      {fracEstrellas > 0 && perfil.estrellas > 0 && (
         <Stars
           radius={40}
           depth={20}
-          count={perfil.estrellas}
+          count={Math.max(24, Math.round(perfil.estrellas * fracEstrellas))}
           factor={3}
           fade
           speed={reducedMotion ? 0 : 1}
+        />
+      )}
+      {/* Luciérnagas: asoman al atardecer y llenan la noche. Kit instanciado
+          (1 draw call), presupuesto por tier adentro; con reduced-motion
+          quedan quietas a brillo medio — presencia sin parpadeo. */}
+      {luciernagas > 0 && (
+        <ParticulasAmbientales
+          tipo="luciernagas"
+          densidad={luciernagas}
+          tier={tier}
+          reducedMotion={reducedMotion}
+          area={AREA_LUCIERNAGAS}
+          position={[0, 0.35, 3.6]}
+          semilla={11}
         />
       )}
 

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -17,6 +17,9 @@
    (ADR-050). */
 
 import { MUNDO_BY_ID } from '../../components/dashboard/mundosFinca';
+/* La franja del día sale de UNA fuente (cielosHoraData): el mismo mapa de
+   bandas que usan los mundos 3D — el valle y los dioramas giran juntos. */
+import { horaDeReloj } from '../../visual/mundo3d/cielosHoraData.js';
 
 /* ── 0. LOS PISOS TÉRMICOS: EL GRADIENTE DE ALTITUD DE LA FINCA ANDINA ───────
  * Una finca de ladera TREPA la montaña: del plátano en tierra caliente abajo
@@ -193,7 +196,12 @@ export const SALUD_FINCA = {
 export function animoDeFinca(clima, { hayAlerta = false, salud = SALUD_FINCA } = {}) {
   const vivas = salud.matasTotal > 0 ? salud.matasVivas / salud.matasTotal : 1;
   // Energía base: mezcla de matas vivas y agua, atenuada por el clima duro.
-  const climaFactor = clima === 'noche' ? 0.55 : clima === 'lluvia' ? 0.8 : 1;
+  // En los filos del día (amanecer/atardecer) la abeja ya baja el ritmo.
+  const climaFactor =
+    clima === 'noche' ? 0.55
+      : clima === 'lluvia' ? 0.8
+        : clima === 'amanecer' || clima === 'atardecer' ? 0.85
+          : 1;
   const energia = Math.max(0.35, Math.min(1, (vivas * 0.65 + salud.agua * 0.35) * climaFactor));
 
   if (hayAlerta) {
@@ -236,8 +244,84 @@ export function animoDeFinca(clima, { hayAlerta = false, salud = SALUD_FINCA } =
  * `grade` = clase modificadora .vfx-grade--* aplicada a un velo DOM sobre el
  * canvas; `cielo`/`luz`/`niebla` alimentan la iluminación de la escena 3D.
  * Una sola geometría, varias "pieles" según el estado real de la vereda.
+ *
+ * CICLO DIURNO VIVO: además de las pieles de CONDICIÓN (soleado/niebla/lluvia,
+ * que vienen del clima real), están las pieles de FRANJA del día (amanecer →
+ * mañana → mediodía → tarde → atardecer → noche) que `climaPorHora` recorre
+ * con el reloj del dispositivo. Campos del ciclo:
+ *   sol         [x,y,z] — posición del sol (o la luna): el ARCO del día, las
+ *               sombras giran y se acortan al mediodía;
+ *   estrellas   0..1 — fracción del presupuesto de estrellas del tier (true
+ *               histórico = 1);
+ *   luciernagas 0..1 — densidad de luciérnagas (asoman al atardecer, plenas
+ *               de noche).
  */
 export const CLIMAS = {
+  amanecer: {
+    etiqueta: 'Amanecer',
+    grade: 'vfx-grade--templado',
+    cielo: ['#a9b4d8', '#f6c9a0'],
+    luz: '#ffc994',
+    ambiente: '#6e5a44',
+    niebla: '#ecc7a2',
+    nieblaLejos: 26,
+    intensidad: 0.95,
+    estrellas: 0.15,
+    sol: [9, 2.5, 5],
+    luciernagas: 0.15,
+  },
+  manana: {
+    etiqueta: 'Mañana dorada',
+    grade: 'vfx-grade--calido',
+    cielo: ['#a5d3e0', '#f4e3b2'],
+    luz: '#ffe9b8',
+    ambiente: '#8a7a52',
+    niebla: '#eeddb4',
+    nieblaLejos: 36,
+    intensidad: 1.2,
+    estrellas: 0,
+    sol: [8, 6, 4.5],
+    luciernagas: 0,
+  },
+  mediodia: {
+    etiqueta: 'Mediodía',
+    grade: 'vfx-grade--calido',
+    cielo: ['#8fd0e8', '#e9f3ea'],
+    luz: '#fff2d2',
+    ambiente: '#9fb6a0',
+    niebla: '#ddeee6',
+    nieblaLejos: 44,
+    intensidad: 1.35,
+    estrellas: 0,
+    sol: [2, 12, 3],
+    luciernagas: 0,
+  },
+  tarde: {
+    etiqueta: 'Tarde',
+    grade: 'vfx-grade--templado',
+    cielo: ['#9fc4dc', '#f2d9a2'],
+    luz: '#ffdf9f',
+    ambiente: '#8f7247',
+    niebla: '#eccf9d',
+    nieblaLejos: 36,
+    intensidad: 1.1,
+    estrellas: 0,
+    sol: [-5, 7, 4],
+    luciernagas: 0,
+  },
+  atardecer: {
+    etiqueta: 'Atardecer',
+    grade: 'vfx-grade--templado',
+    cielo: ['#c98ba0', '#f0955e'],
+    luz: '#ffb37a',
+    ambiente: '#6e4a3a',
+    niebla: '#e8a97f',
+    nieblaLejos: 24,
+    intensidad: 0.9,
+    estrellas: 0.12,
+    sol: [-8, 2.5, 4.5],
+    luciernagas: 0.35,
+  },
   dorada: {
     etiqueta: 'Hora dorada',
     grade: 'vfx-grade--templado',
@@ -248,6 +332,8 @@ export const CLIMAS = {
     nieblaLejos: 30,
     intensidad: 1.15,
     estrellas: false,
+    sol: [6, 9, 4],
+    luciernagas: 0,
   },
   soleado: {
     etiqueta: 'Soleado',
@@ -259,6 +345,8 @@ export const CLIMAS = {
     nieblaLejos: 38,
     intensidad: 1.35,
     estrellas: false,
+    sol: [4, 11, 3],
+    luciernagas: 0,
   },
   niebla: {
     etiqueta: 'Niebla',
@@ -270,6 +358,8 @@ export const CLIMAS = {
     nieblaLejos: 15,
     intensidad: 0.85,
     estrellas: false,
+    sol: [6, 9, 4],
+    luciernagas: 0,
   },
   lluvia: {
     etiqueta: 'Lluvia',
@@ -282,6 +372,8 @@ export const CLIMAS = {
     intensidad: 0.7,
     lluviaViva: true,
     estrellas: false,
+    sol: [6, 9, 4],
+    luciernagas: 0,
   },
   noche: {
     etiqueta: 'Noche',
@@ -293,22 +385,23 @@ export const CLIMAS = {
     nieblaLejos: 22,
     intensidad: 0.5,
     estrellas: true,
+    sol: [-6, 7, -4],
+    luciernagas: 1,
   },
 };
 
 export const ORDEN_CLIMA = ['dorada', 'soleado', 'niebla', 'lluvia', 'noche'];
 
 /**
- * Estado por defecto según la hora REAL del dispositivo (ancla de veracidad,
- * como Apple Weather): madrugada/noche → noche; media mañana → soleado; tarde
- * → hora dorada. Un dato verdadero, no decoración inventada.
+ * Franja del día según la hora REAL del dispositivo (ancla de veracidad, como
+ * Apple Weather): el valle recorre el ciclo completo — amanecer → mañana →
+ * mediodía → tarde → atardecer → noche. Un dato verdadero, no decoración
+ * inventada. Delegado en cielosHoraData.horaDeReloj: LA fuente de franjas,
+ * compartida con los mundos 3D.
+ * @returns {'amanecer'|'manana'|'mediodia'|'tarde'|'atardecer'|'noche'}
  */
 export function climaPorHora(fecha = new Date()) {
-  const h = fecha.getHours();
-  if (h >= 19 || h < 5) return 'noche';
-  if (h >= 16) return 'dorada';
-  if (h >= 11) return 'soleado';
-  return 'dorada';
+  return horaDeReloj(fecha);
 }
 
 /* ── 3. LO QUE EL AGENTE DICE AL PASAR ───────────────────────────────────────

--- a/src/visual/mundo3d/CielosHora.jsx
+++ b/src/visual/mundo3d/CielosHora.jsx
@@ -110,7 +110,7 @@ function amortiguar(actual, objetivo, k) {
  * El cielo por hora del día. Montar DENTRO de un <Canvas>.
  *
  * @param {object} props
- * @param {'amanecer'|'mediodia'|'dorada'|'noche'|'auto'} [props.hora='dorada']
+ * @param {'amanecer'|'manana'|'mediodia'|'tarde'|'dorada'|'atardecer'|'noche'|'auto'} [props.hora='dorada']
  *        Momento del día; 'auto' lo deriva del reloj real (horaDeReloj).
  * @param {'alto'|'medio'|'bajo'} [props.tier='medio']
  *        Tier del equipo (decidirTier); gobierna niebla y estrellas.

--- a/src/visual/mundo3d/atmosferaMadre.js
+++ b/src/visual/mundo3d/atmosferaMadre.js
@@ -51,20 +51,27 @@ export function mezclar(a, b, t) {
 }
 
 /* La RECETA de coherencia valle↔mundo, como ley única: el cielo propio del
-   arquetipo mezclado 60% hacia la hora dorada (B6). Antes vivía inline en
+   arquetipo mezclado 60% hacia la MADRE (B6). Antes vivía inline en
    EscenaBase3D; aquí es parte de la dirección de arte — si un consumidor nuevo
    (minimapa, preview, thumbnail) necesita "cómo se ve la familia X bajo la
    madre", llama esto y sale IGUAL que la escena. Barato (7 lerps); memoizar
-   en quien llama por `cielo`. */
-export function mezclarCielo(cielo) {
+   en quien llama por `cielo` (+ `madre` si varía).
+
+   CICLO DIURNO VIVO: `madre` por defecto es la hora dorada (ATMOSFERA), pero
+   EscenaBase3D ahora pasa el preset de la FRANJA REAL del día (CIELOS_HORA de
+   cielosHoraData vía useCicloDia): el mundo hereda el amanecer, el mediodía o
+   la noche del valle sin que ningún arquetipo se entere. La identidad propia
+   (el 40%) sobrevive igual. La intensidad del mundo se MULTIPLICA por la de la
+   madre (la noche baja todo). */
+export function mezclarCielo(cielo, madre = ATMOSFERA) {
   const propio = { ...CIELOS.neutro, ...(cielo || {}) };
   return {
-    fondo: mezclar(propio.fondo, ATMOSFERA.fondo, 0.6),
-    cielo: mezclar(propio.cielo, ATMOSFERA.cielo, 0.6),
-    suelo: mezclar(propio.suelo, ATMOSFERA.suelo, 0.6),
-    niebla: mezclar(propio.fondo, ATMOSFERA.niebla, 0.7),
-    alfombra: mezclar(propio.suelo, ATMOSFERA.suelo, 0.5),
-    intensidad: propio.intensidad ?? 1,
+    fondo: mezclar(propio.fondo, madre.fondo, 0.6),
+    cielo: mezclar(propio.cielo, madre.cielo, 0.6),
+    suelo: mezclar(propio.suelo, madre.suelo, 0.6),
+    niebla: mezclar(propio.fondo, madre.niebla, 0.7),
+    alfombra: mezclar(propio.suelo, madre.suelo, 0.5),
+    intensidad: (propio.intensidad ?? 1) * (madre.intensidad ?? 1),
   };
 }
 

--- a/src/visual/mundo3d/cielosHoraData.js
+++ b/src/visual/mundo3d/cielosHoraData.js
@@ -39,8 +39,11 @@
  *   estrellas    0..1 — fracción del presupuesto de estrellas del tier
  */
 
-/* Orden canónico del día (útil para UIs de selección y para tests). */
-export const HORAS = ['amanecer', 'mediodia', 'dorada', 'noche'];
+/* Orden canónico del día (útil para UIs de selección y para tests). El CICLO
+   DIURNO VIVO recorre estas franjas con el reloj real (franjaDeHoraDecimal);
+   `dorada` queda como la hora MADRE fuera del arco (espejo de ATMOSFERA, la
+   piel que las escenas piden explícita). */
+export const HORAS = ['amanecer', 'manana', 'mediodia', 'tarde', 'atardecer', 'noche'];
 
 export const CIELOS_HORA = {
   /* madrugada andina: sol rasante durazno, cenit todavía lavanda, bruma baja
@@ -62,6 +65,28 @@ export const CIELOS_HORA = {
     nieblaCerca: 7,
     nieblaLejos: 32,
     estrellas: 0.2,
+    luciernagas: 0.15,
+  },
+  /* la mañana dorada: el sol ya subió del horizonte pero sigue tibio; luz
+     fresca de trabajo temprano, el aire limpio antes del calor */
+  manana: {
+    fondo: '#f4e4bd',
+    cielo: '#f7e2ac',
+    suelo: '#8a7a52',
+    luz: '#ffe9b8',
+    relleno: '#a9c0dc',
+    niebla: '#eeddb4',
+    sombra: '#43351f',
+    intensidad: 1.05,
+    hemisferio: 0.55,
+    ambiente: 0.28,
+    sol: 0.95,
+    rellenoInt: 0.2,
+    solPos: [8, 6, 4.5],
+    nieblaCerca: 10,
+    nieblaLejos: 42,
+    estrellas: 0,
+    luciernagas: 0,
   },
   /* día pleno: marfil claro, sol alto casi blanco, el aire se abre y la
      niebla se va lejos — la hora de trabajar */
@@ -82,6 +107,28 @@ export const CIELOS_HORA = {
     nieblaCerca: 12,
     nieblaLejos: 48,
     estrellas: 0,
+    luciernagas: 0,
+  },
+  /* la tarde: el sol ya cruzó al otro lado del valle y la luz se inclina
+     ámbar; las sombras se alargan hacia el oriente */
+  tarde: {
+    fondo: '#f0dcae',
+    cielo: '#f4d795',
+    suelo: '#8f7247',
+    luz: '#ffdf9f',
+    relleno: '#9fb4d4',
+    niebla: '#eccf9d',
+    sombra: '#3f2d1a',
+    intensidad: 1.02,
+    hemisferio: 0.55,
+    ambiente: 0.28,
+    sol: 0.95,
+    rellenoInt: 0.22,
+    solPos: [-5, 7, 4],
+    nieblaCerca: 10,
+    nieblaLejos: 38,
+    estrellas: 0,
+    luciernagas: 0,
   },
   /* la hora madre: espejo exacto de ATMOSFERA (atmosferaMadre). El sol en
      [6,9,4] calca la direccional de EscenaBase3D para que una escena montada
@@ -103,6 +150,28 @@ export const CIELOS_HORA = {
     nieblaCerca: 9,
     nieblaLejos: 40,
     estrellas: 0,
+    luciernagas: 0,
+  },
+  /* el atardecer: sol rasante al occidente, naranjas y rosas hondos, relleno
+     lavanda del cielo que ya se apaga; las primeras luciérnagas asoman */
+  atardecer: {
+    fondo: '#eeae7e',
+    cielo: '#e9986a',
+    suelo: '#6e4a3a',
+    luz: '#ffb37a',
+    relleno: '#9d8fc9',
+    niebla: '#e8a97f',
+    sombra: '#38222a',
+    intensidad: 0.92,
+    hemisferio: 0.52,
+    ambiente: 0.26,
+    sol: 0.9,
+    rellenoInt: 0.28,
+    solPos: [-8, 2.5, 4.5],
+    nieblaCerca: 8,
+    nieblaLejos: 34,
+    estrellas: 0.12,
+    luciernagas: 0.35,
   },
   /* noche estrellada de páramo: índigo hondo, luna plata desde el otro lado
      del valle, relleno tibio de fogata y el fog cerrando la distancia */
@@ -123,6 +192,7 @@ export const CIELOS_HORA = {
     nieblaCerca: 6,
     nieblaLejos: 30,
     estrellas: 1,
+    luciernagas: 1,
   },
 };
 
@@ -136,17 +206,29 @@ export function presetDeHora(hora) {
 }
 
 /**
- * Deriva la hora del kit del reloj real (franja ecuatorial andina: el sol
- * sale ~6 y se esconde ~18 todo el año, así que las franjas son estables).
+ * Franja del día para una hora DECIMAL (p. ej. 17.5 = 5:30 pm). Es EL mapa del
+ * ciclo diurno vivo: seis franjas ecuatoriales andinas (el sol sale ~6 y se
+ * esconde ~18 todo el año, así que las bandas son estables).
+ * @param {number} h  hora decimal 0..24
+ * @returns {'amanecer'|'manana'|'mediodia'|'tarde'|'atardecer'|'noche'}
+ */
+export function franjaDeHoraDecimal(h) {
+  if (h < 5) return 'noche';
+  if (h < 7) return 'amanecer';
+  if (h < 11) return 'manana';
+  if (h < 15) return 'mediodia';
+  if (h < 17) return 'tarde';
+  if (h < 19) return 'atardecer';
+  return 'noche';
+}
+
+/**
+ * Deriva la franja del kit del reloj real (minutos incluidos).
  * @param {Date} [fecha]
- * @returns {'amanecer'|'mediodia'|'dorada'|'noche'}
+ * @returns {'amanecer'|'manana'|'mediodia'|'tarde'|'atardecer'|'noche'}
  */
 export function horaDeReloj(fecha = new Date()) {
-  const h = fecha.getHours();
-  if (h >= 5 && h < 9) return 'amanecer';
-  if (h >= 9 && h < 16) return 'mediodia';
-  if (h >= 16 && h < 19) return 'dorada';
-  return 'noche';
+  return franjaDeHoraDecimal(fecha.getHours() + fecha.getMinutes() / 60);
 }
 
 /** Mezcla dos hex `#rrggbb` hacia `t` (0 = a, 1 = b) sin three (aritmética pura). */
@@ -171,6 +253,7 @@ const CAMPOS_NUMERO = [
   'nieblaCerca',
   'nieblaLejos',
   'estrellas',
+  'luciernagas',
 ];
 
 /**

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -4,10 +4,10 @@
  * El DR (§4.4, §6) pide que cada arquetipo sea SOLO su diorama; el resto (Canvas,
  * luz, atmósfera, cámara, hotspots, la abeja) se hereda. Aquí vive ese resto: un
  * `<Canvas>` austero (DPR ≤ 1.5, SIN shadow-maps, SIN post-proceso, `frameloop`
- * a demanda si hay reduced-motion), la ATMÓSFERA DE HORA DORADA compartida con
- * el valle (auditoría 3D B5/B6: sol direccional cálido + relleno frío tenue +
- * niebla sutil + sombras de contacto falsas — forma y peso sin pagar sombras
- * reales), `OrbitControls` acotado, los `hotspots` como botones-billboard
+ * a demanda si hay reduced-motion), la ATMÓSFERA DE LA FRANJA DEL DÍA compartida
+ * con el valle (ciclo diurno vivo: la madre de la mezcla es el preset de la hora
+ * real — auditoría 3D B5/B6: sol direccional + relleno frío tenue + niebla sutil
+ * + sombras de contacto falsas), `OrbitControls` acotado, los `hotspots` como botones-billboard
  * accesibles que re-rutean a vistas 2D reales, y Angelita con su coreografía
  * compartida. El arquetipo pasa su geometría como `children`.
  *
@@ -22,7 +22,7 @@
  */
 import { Suspense, lazy, useMemo, useRef, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
-import { Html, OrbitControls } from '@react-three/drei';
+import { Html, OrbitControls, Stars } from '@react-three/drei';
 import { MonitorRendimiento } from '../usePerformanceMonitor.jsx';
 import * as THREE from 'three';
 import { AbejaEscena } from './useEntradaAbeja.jsx';
@@ -30,10 +30,16 @@ import CamaraDirector from './CamaraDirector.jsx';
 import { SombraContacto } from './SombraContacto.jsx';
 import { ESTADO_FINCA_MUESTRA } from './reaccionFinca.js';
 import useHaptics from '../useHaptics.js';
-/* La dirección de arte compartida (hora dorada + cielos por familia) vive en
-   un módulo propio: los arquetipos eligen su CIELOS.<familia>, esta base la
-   mezcla hacia ATMOSFERA. Una sola fuente, cero hexes sueltos. */
-import { ATMOSFERA, mezclarCielo } from '../atmosferaMadre.js';
+/* La dirección de arte compartida (cielos por familia + receta de mezcla) vive
+   en un módulo propio: los arquetipos eligen su CIELOS.<familia>, esta base la
+   mezcla hacia la MADRE de la franja. Una sola fuente, cero hexes sueltos. */
+import { mezclarCielo } from '../atmosferaMadre.js';
+/* CICLO DIURNO VIVO: la madre ya no es la hora dorada clavada — es el preset
+   de la FRANJA REAL del día (cielosHoraData, vía el reloj de useCicloDia). El
+   mundo amanece, atardece y anochece CON el valle; el arquetipo no se entera. */
+import useCicloDia from '../useCicloDia.js';
+import { presetDeHora } from '../cielosHoraData.js';
+import { perfilDeTier } from '../deviceTier.js';
 import CapaVivaMundo from '../CapaVivaMundo.jsx';
 
 /* El bloom sutil de la hora dorada: chunk LAZY con gate ESTRICTO
@@ -59,12 +65,15 @@ function Contenido({
   const acento = (tinte && tinte[0]) || '#3f8f4e';
   const centro = entrada?.centro || /** @type {[number, number, number]} */ ([0, (params?.alto ?? 1.1) * 0.5, 0]);
 
-  // La atmósfera del mundo: su `cielo` propio MEZCLADO 60% hacia la hora dorada
-  // del valle (B6 — hoy entrar a un mundo "aplana" porque cada escena fija un
-  // cielo frío propio). La receta vive AHORA en atmosferaMadre (mezclarCielo):
-  // ley exportada, mismo resultado aquí y en cualquier consumidor futuro.
-  // Memoizado: THREE.Color solo cuando cambia el cielo.
-  const c = useMemo(() => mezclarCielo(cielo), [cielo]);
+  // La atmósfera del mundo: su `cielo` propio MEZCLADO 60% hacia la MADRE de
+  // la franja REAL del día (ciclo diurno vivo — antes la madre era la hora
+  // dorada clavada y entrar a un mundo a medianoche se sentía de otra app).
+  // La receta vive en atmosferaMadre (mezclarCielo): ley exportada, mismo
+  // resultado aquí y en cualquier consumidor. Memoizado por cielo + franja
+  // (la franja cambia unas pocas veces al día; en demo, cada tantos segundos).
+  const { franja } = useCicloDia({ reducedMotion });
+  const madre = useMemo(() => presetDeHora(franja), [franja]);
+  const c = useMemo(() => mezclarCielo(cielo, madre), [cielo, madre]);
 
   // foco = el hotspot activo (o el centro del diorama). Memoizado (auditoría
   // B11: antes era un Vector3 nuevo POR RENDER — basura de GC en el hilo
@@ -99,14 +108,29 @@ function Contenido({
           fragmento → en el perfil mínimo (tier bajo forzado a 3D) se apaga. */}
       {!frugal && <fog attach="fog" args={[c.niebla, zoom * 1.4, zoom * 4.6]} />}
       <hemisphereLight intensity={0.55 * c.intensidad} color={c.cielo} groundColor={c.suelo} />
-      <ambientLight intensity={0.28 * c.intensidad} color={ATMOSFERA.luz} />
-      {/* El sol de la hora dorada — MISMA dirección que el valle ([6,9,4]) para
-          que el lenguaje de sombreado no cambie al entrar. Sin castShadow:
-          Lambert + sombras de contacto falsas dan la forma, gratis. */}
-      <directionalLight position={[6, 9, 4]} intensity={0.9 * c.intensidad} color={ATMOSFERA.luz} />
+      <ambientLight intensity={0.28 * c.intensidad} color={madre.luz} />
+      {/* El sol de la franja — MISMO arco que el valle (solPos del preset:
+          rasante al amanecer, cenital al mediodía, luna de noche) para que el
+          lenguaje de sombreado no cambie al entrar. Sin castShadow: Lambert +
+          sombras de contacto falsas dan la forma, gratis. */}
+      <directionalLight position={madre.solPos} intensity={0.9 * c.intensidad} color={madre.luz} />
       {/* Relleno frío tenue desde el lado opuesto: despega los volúmenes del
           fondo cálido sin matar el contraste (clave del look claymation). */}
-      <directionalLight position={[-5, 4, -6]} intensity={0.22} color={ATMOSFERA.relleno} />
+      <directionalLight position={[-5, 4, -6]} intensity={0.22} color={madre.relleno} />
+      {/* De noche (o en el filo del atardecer/amanecer), las estrellas del
+          presupuesto del tier asoman también DENTRO del mundo: el diorama no
+          se queda con cielo de día mientras el valle duerme. */}
+      {madre.estrellas > 0 && !frugal && (
+        <Stars
+          radius={zoom * 8}
+          depth={30}
+          count={Math.round(perfilDeTier(tier).estrellas * madre.estrellas)}
+          factor={3}
+          saturation={0}
+          fade
+          speed={reducedMotion ? 0 : 0.5}
+        />
+      )}
 
       {/* La alfombra de suelo + el anillo de contacto: posan el diorama en un
           piso en vez de dejarlo a la deriva sobre el color de fondo. Son dos
@@ -123,7 +147,7 @@ function Contenido({
           <SombraContacto
             pos={[0, piso + 0.02, 0]}
             radio={zoom * 0.4}
-            color={ATMOSFERA.sombra}
+            color={madre.sombra}
             opacidad={0.3}
             orden={2}
           />

--- a/src/visual/mundo3d/useCicloDia.js
+++ b/src/visual/mundo3d/useCicloDia.js
@@ -1,0 +1,78 @@
+/*
+ * useCicloDia — EL RELOJ del ciclo diurno vivo (hook compartido, three-free).
+ *
+ * Una sola fuente de "qué hora es en el valle" para la entrada 3D y para los
+ * mundos (EscenaBase3D): deriva la FRANJA del día (amanecer → mañana → mediodía
+ * → tarde → atardecer → noche, cielosHoraData.franjaDeHoraDecimal) de la hora
+ * REAL del dispositivo y se refresca sola cada minuto — el valle amanece,
+ * atardece y anochece sin botonera (auditoría B8/S8: el clima es atmósfera,
+ * no un selector).
+ *
+ * OVERRIDE por URL (dev/demo/QA, nunca UI de producto): `?ciclo=`
+ *   · `ciclo=demo` (o `rapido`)  → día ACELERADO: las 24 h pasan en ~3 min,
+ *     arrancando en la hora real (continuidad, no un salto). Para VER el ciclo
+ *     girar completo en una demo.
+ *   · `ciclo=6` / `ciclo=17.5`   → hora FIJA (decimal). Para fotografiar una
+ *     franja exacta o depurar una paleta.
+ * Se lee del hash o del search (la app enruta por hash: #/ruta?ciclo=demo).
+ *
+ * reducedMotion: el modo demo se APAGA (la franja real del reloj, digna y
+ * fija, sin día-timelapse); la hora fija explícita sí se respeta (es estática).
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { franjaDeHoraDecimal } from './cielosHoraData.js';
+
+/* Un día completo del modo demo, en ms (~7.5 s por hora: cada franja se ve). */
+const DIA_DEMO_MS = 180000;
+
+/** Hora decimal (0..24) del reloj real. */
+export function horaDecimal(fecha = new Date()) {
+  return fecha.getHours() + fecha.getMinutes() / 60 + fecha.getSeconds() / 3600;
+}
+
+/**
+ * Lee el override `ciclo=` de una location (hash y search).
+ * @returns {{ modo: 'demo' } | { modo: 'fijo', hora: number } | null}
+ */
+export function leerCicloParam(loc = typeof window !== 'undefined' ? window.location : null) {
+  if (!loc) return null;
+  const m = `${loc.hash || ''}${loc.search || ''}`.match(/[?&]ciclo=([^&#]+)/);
+  if (!m) return null;
+  const v = decodeURIComponent(m[1]);
+  if (v === 'demo' || v === 'rapido') return { modo: 'demo' };
+  const n = Number(v);
+  if (Number.isFinite(n)) return { modo: 'fijo', hora: ((n % 24) + 24) % 24 };
+  return null;
+}
+
+/**
+ * La franja del día, viva: se re-evalúa sola (cada minuto en tiempo real; cada
+ * segundo en el día acelerado del modo demo).
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.reducedMotion=false]  apaga el modo demo (franja fija).
+ * @returns {{ hora: number, franja: 'amanecer'|'manana'|'mediodia'|'tarde'|'atardecer'|'noche', demo: boolean }}
+ */
+export default function useCicloDia({ reducedMotion = false } = {}) {
+  const param = useMemo(() => leerCicloParam(), []);
+  const demo = !reducedMotion && param?.modo === 'demo';
+  const [hora, setHora] = useState(() => (param?.modo === 'fijo' ? param.hora : horaDecimal()));
+
+  useEffect(() => {
+    if (param?.modo === 'fijo') return undefined;
+    if (demo) {
+      // Día acelerado, anclado a la hora real de arranque (continuidad).
+      const t0 = Date.now();
+      const h0 = horaDecimal();
+      const id = setInterval(
+        () => setHora((h0 + ((Date.now() - t0) / DIA_DEMO_MS) * 24) % 24),
+        1000,
+      );
+      return () => clearInterval(id);
+    }
+    const id = setInterval(() => setHora(horaDecimal()), 60000);
+    return () => clearInterval(id);
+  }, [demo, param]);
+
+  return { hora, franja: franjaDeHoraDecimal(hora), demo };
+}


### PR DESCRIPTION
## Qué

El valle 3D estaba clavado en **hora dorada**: `climaPorHora()` devolvía casi siempre `'dorada'`, así que la Angelita salía siempre dorada y la atmósfera nunca cambiaba. Ahora el valle **recorre el ciclo del día con la hora real** del dispositivo:

**amanecer → mañana → mediodía → tarde → atardecer → noche → amanecer**

Cada franja tiñe TODO: cielo, niebla, luz, **posición del sol** (las sombras giran y se acortan al mediodía) y —vía el sistema que ya existe (`mezclarCielo` en mundos)— el cuerpo de las creatures.

## Cómo (engancha al motor que ya existe, no lo rehace)

- **`cielosHoraData.js`**: de 4 a **6 franjas**. Nuevas `manana`/`tarde`/`atardecer`, cada una con `solPos`, `estrellas` y `luciernagas` graduales (0..1). `franjaDeHoraDecimal` como mapa de bandas + `horaDeReloj` ahora con minutos.
- **`useCicloDia.js`** (nuevo): el reloj compartido three-free. Deriva la franja del reloj real y se refresca sola. **Override dev/QA por URL**:
  - `?ciclo=demo` → día **acelerado** (~3 min todo el ciclo) para VERLO girar en demo/screenshots.
  - `?ciclo=17.5` → **hora fija** (decimal) para fotografiar/depurar una franja.
  - `reducedMotion` apaga el modo demo (franja real digna, sin timelapse).
- **`valleData.CLIMAS`**: pieles de **FRANJA** (amanecer..noche) junto a las de **condición** (soleado/niebla/lluvia). `climaPorHora` delega en `horaDeReloj` — una sola fuente de franjas, compartida con los mundos.
- **`Valle3D.jsx`**: driver `AtmosferaValle` que **amortigua** fondo/niebla/luces/`solPos` hacia la franja nueva (~2.5 s, mismo patrón de `CielosHora`) en vez de cortar. Estrellas graduales + **luciérnagas** (kit `ParticulasAmbientales` que ya existía) al atardecer/noche.
- **`EscenaBase3D.jsx`**: la **madre** de la mezcla ya no es la hora dorada fija — es el preset de la franja real (`useCicloDia` + `presetDeHora`), así los mundos heredan el amanecer/mediodía/noche del valle. Estrellas dentro del mundo de noche. `mezclarCielo` acepta `madre` (default `ATMOSFERA`, retro-compatible).

## Disciplina

- Rama basada en `origin/dev`.
- `npm run build` **verde** (2m36s, síncrono).
- `reducedMotion`: franja fija (snap). Device-tier respetado (estrellas/luciérnagas por presupuesto del tier; niebla off en gama baja).
- Los 4 tests de `entradaValle3D.nav.test.jsx` que fallan en jsdom **ya fallaban en `origin/dev` limpio** (verificado con stash) — no es regresión de este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)