### PR TITLE
feat(creatures): sistema base de personajes (lip-sync, modo poder, prop-por-mundo, clima)

### DIFF
--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -400,6 +400,21 @@ export function isAudioPlaying() {
   return audioPlaying;
 }
 
+/**
+ * Elemento <audio> que está sonando ahora (Kokoro/XTTS/streaming), o null.
+ *
+ * Getter puro y aditivo (no cambia el playback) para que el LIP-SYNC 2D
+ * ([[reference_animacion_rubber_hose_spec]] §2) pueda colgar un AnalyserNode
+ * sobre el audio activo y derivar visemas del RMS. Web Speech no tiene elemento
+ * (devuelve null) → el hook cae a su boca de relleno. El blob URL de Kokoro es
+ * same-origin, así que `createMediaElementSource` no lo contamina.
+ *
+ * @returns {HTMLAudioElement|null}
+ */
+export function getActiveAudio() {
+  return currentKokoroAudio;
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Streaming sentence-by-sentence (Free 7→10 fix-pack)
 // ──────────────────────────────────────────────────────────────────────────
@@ -1126,6 +1141,8 @@ export default {
   // TIER 2 #5: estado observable de reproducción para la UI "hablando".
   onSpeakingChange,
   isAudioPlaying,
+  // Lip-sync 2D: el <audio> activo para colgar un AnalyserNode encima.
+  getActiveAudio,
   getVoices,
   getSpanishVoice,
   replayLast,

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,9 +1,10 @@
 import { useId } from 'react';
 import './creatures.css';
 import { CreatureFilters } from './_filters.jsx';
-import { OjosRubber, Cachetes, Sonrisa, Miembro, AntenaRubber, RH_INK } from './_rubberhose.jsx';
+import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, AntenaRubber, RH_INK } from './_rubberhose.jsx';
 import { ABEJA_PALETA, ABEJA_PROPORCION } from './abejaIdentidad.js';
-import { cuerpoDeClima, PERFIL_ABEJA } from './creatureClimaCuerpo.js';
+import { cuerpoDeClima, PERFIL_ABEJA, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
+import { AccesoriosClima } from './AccesoriosClima.jsx';
 
 /* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
    Apis). Cuerpo ámbar rayado (chumbe andino), cabeza clara, alitas de tul.
@@ -61,6 +62,19 @@ export function AbejaAngelita({
      catálogo) = neutro digno: la abeja se ve EXACTO como siempre. */
   clima = null,
   enso = 'neutro',
+  /* ── LIP-SYNC (sistema transversal, useLipSync) ────────────────────────────
+     visema opcional ('V1'..'V4') que produce useLipSync desde el RMS del TTS:
+     la boquita cambia de forma al hablar. Sin visema (o 'V1') = la sonrisa de
+     siempre → los avatares/catálogo no cambian. El HOOK vive aparte para no
+     colgar un AnalyserNode en cada instancia; acá solo se consume el estado. */
+  visema = null,
+  /* ── VESTUARIO por clima+hora (ropaDeClima) ───────────────────────────────
+     OPT-IN: con vestuario=true la abeja se abriga según el clima real (ruana de
+     noche/frío — mata el bug de sudar de noche —, sombrero+sudor al sol cálido).
+     Default false → los consumidores de `clima` existentes NO ven accesorios
+     nuevos (solo el tinte de piel de cuerpoDeClima). tempC afina frío/calor. */
+  vestuario = false,
+  tempC,
   /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
      pleno; 'bajo' apaga el idle continuo (boil + follow-through) y deja el
      aleteo + estados reactivos. Sin prop (standalone: avatares, catálogo) =
@@ -92,6 +106,10 @@ export function AbejaAngelita({
   const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
     ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
     : undefined;
+
+  // Vestuario por clima+hora (opt-in). Perfil abeja: neutro, suda al sol de día,
+  // ruana de noche. Sin vestuario o sin clima → nada (comportamiento histórico).
+  const ropa = (vestuario && clima) ? ropaDeClimaBicho('abeja-angelita', clima, { tempC }) : null;
 
   const defs = (
     <defs>
@@ -174,7 +192,10 @@ export function AbejaAngelita({
       <circle cx="8.6" cy="-1.0" r={ABEJA_PROPORCION.cabezaR} fill={ABEJA_PALETA.cabeza} stroke={RH_INK} strokeWidth="1.2" />
       {/* chapetas campesinas + sonrisa + ojos de goma (parpadean juntos) */}
       <Cachetes puntos={[{ cx: 10.4, cy: 0.7, r: 1.15 }, { cx: 6.9, cy: 0.3, r: 0.85 }]} vivo={vivo} />
-      <Sonrisa cx={8.9} cy={1.4} w={2.8} prof={1.1} />
+      {/* Boca: lip-sync si hay visema; si no, la sonrisa de goma de siempre. */}
+      {visema
+        ? <BocaVisema cx={8.9} cy={1.4} w={2.8} prof={1.1} visema={visema} />
+        : <Sonrisa cx={8.9} cy={1.4} w={2.8} prof={1.1} />}
       <OjosRubber
         ojos={[{ cx: 10.1, cy: -1.9, r: 1.95 }, { cx: 7.4, cy: -2.2, r: 1.45 }]}
         mirar={[0.3, 0.34]}
@@ -183,6 +204,16 @@ export function AbejaAngelita({
       {/* antenas con bombillo que se mecen (secondary motion) */}
       <AntenaRubber d="M7.7,-4.7 C6.7,-7.3 7.0,-9.3 8.3,-10.1" bulbo={[8.3, -10.3]} sway={vivo} delay={0} />
       <AntenaRubber d="M9.7,-4.6 C11.0,-6.7 11.3,-8.7 10.5,-10.3" bulbo={[10.5, -10.5]} sway={vivo} delay={-0.3} />
+
+      {/* Vestuario por clima+hora (ruana/sombrero/sudor) — solo con vestuario=true. */}
+      {ropa && (
+        <AccesoriosClima
+          estado={ropa}
+          tronco={{ cx: 0, cy: 0, rx: ABEJA_PROPORCION.troncoRx, ry: ABEJA_PROPORCION.troncoRy }}
+          cabeza={{ cx: 8.6, cy: -1.0, r: ABEJA_PROPORCION.cabezaR }}
+          animated={vivo}
+        />
+      )}
 
       {lengua}
       {gotas}
@@ -208,6 +239,10 @@ export function AbejaAngelita({
     'data-mojada': mojada ? '1' : undefined,
     'data-sed': sed ? '1' : undefined,
     'data-comiendo': comiendo ? '1' : undefined,
+    'data-visema': visema || undefined,
+    'data-ruana': ropa?.ruana ? '1' : undefined,
+    'data-sombrero': ropa?.sombrero ? '1' : undefined,
+    'data-sudor': ropa?.sudor ? '1' : undefined,
   };
 
   if (inline) {

--- a/src/visual/creatures/AccesoriosClima.jsx
+++ b/src/visual/creatures/AccesoriosClima.jsx
@@ -1,0 +1,101 @@
+/*
+ * AccesoriosClima — el VESTUARIO de clima dibujado (ruana / sombrero / sudor),
+ * species-agnostic. Consume el estado de `ropaDeClima` (creatureClimaCuerpo) y lo
+ * pinta sobre la creature: ruana de noche/frío, sombrero + sudor al sol cálido.
+ *
+ * La creature pasa sus ANCLAS (cabeza, tronco) en unidades de su viewBox; así el
+ * mismo componente viste a cualquier bicho sin saber su dibujo. Rubber-hose
+ * andino: contorno cálido, ruana con franjas, sombrero aguadeño de paja.
+ *
+ * `mojado`/`niebla` NO se dibujan acá (la creature ya los cuenta con sus gotas y
+ * la opacidad de `cuerpoDeClima`): este módulo es SOLO la ropa que se pone.
+ */
+
+import { RH_INK } from './_rubberhose.jsx';
+import './climaAccesorios.css';
+
+/* Paleta andina de la ruana (lana natural + franjas tierra/rojo). */
+const RUANA = {
+  pano: '#7a5a3c',
+  franja: '#a83f2e',
+  franja2: '#d9b26a',
+};
+const PAJA = '#e2c079';
+const BANDA = '#5a3c22';
+const SUDOR = '#bfe6ff';
+
+/**
+ * @param {Object} props
+ * @param {{ruana?:boolean, sombrero?:boolean, sudor?:boolean}} props.estado  de ropaDeClima.
+ * @param {{cx:number, cy:number, r:number}} props.cabeza  ancla/medida de la cabeza.
+ * @param {{cx:number, cy:number, rx:number, ry:number}} props.tronco  ancla del tronco.
+ * @param {string} [props.ink=RH_INK]
+ * @param {boolean} [props.animated=true]  mece la ruana / salta el sudor.
+ * @returns {JSX.Element|null}
+ */
+export function AccesoriosClima({ estado, cabeza, tronco, ink = RH_INK, animated = true }) {
+  if (!estado) return null;
+  const { ruana, sombrero, sudor } = estado;
+  if (!ruana && !sombrero && !sudor) return null;
+
+  const t = tronco || { cx: 0, cy: 0, rx: 8, ry: 5 };
+  const h = cabeza || { cx: 0, cy: -6, r: 4 };
+
+  // ── RUANA: poncho sobre el tronco, con abertura de cuello y franjas. ──────
+  const ruanaEl = ruana ? (() => {
+    const w = t.rx * 1.18;
+    const top = t.cy - t.ry * 0.45;
+    const hem = t.cy + t.ry * 1.05;
+    return (
+      <g className={animated ? 'crt-ruana' : undefined}>
+        <path
+          d={`M${t.cx - w},${top} Q${t.cx},${top - t.ry * 0.7} ${t.cx + w},${top}
+              L${t.cx + w * 0.86},${hem} Q${t.cx},${hem + 1.6} ${t.cx - w * 0.86},${hem} Z`}
+          fill={RUANA.pano} stroke={ink} strokeWidth="1.1" strokeLinejoin="round"
+        />
+        {/* franjas horizontales del tejido */}
+        <path d={`M${t.cx - w * 0.94},${t.cy + t.ry * 0.2} L${t.cx + w * 0.94},${t.cy + t.ry * 0.2}`}
+          stroke={RUANA.franja} strokeWidth="1.1" />
+        <path d={`M${t.cx - w * 0.9},${t.cy + t.ry * 0.55} L${t.cx + w * 0.9},${t.cy + t.ry * 0.55}`}
+          stroke={RUANA.franja2} strokeWidth="0.7" />
+        {/* abertura del cuello (V) */}
+        <path d={`M${t.cx - 1.7},${top} L${t.cx},${top + t.ry * 0.5} L${t.cx + 1.7},${top}`}
+          fill="none" stroke={ink} strokeWidth="0.9" strokeLinecap="round" />
+      </g>
+    );
+  })() : null;
+
+  // ── SOMBRERO: aguadeño de paja sobre la cabeza. ──────────────────────────
+  const sombreroEl = sombrero ? (() => {
+    const hy = h.cy - h.r * 0.9;
+    return (
+      <g>
+        <ellipse cx={h.cx} cy={hy} rx={h.r * 1.45} ry={h.r * 0.42} fill={PAJA} stroke={ink} strokeWidth="0.9" />
+        <path d={`M${h.cx - h.r * 0.78},${hy} Q${h.cx},${hy - h.r * 1.25} ${h.cx + h.r * 0.78},${hy} Z`}
+          fill={PAJA} stroke={ink} strokeWidth="0.9" />
+        <path d={`M${h.cx - h.r * 0.72},${hy - h.r * 0.34} Q${h.cx},${hy - h.r * 0.2} ${h.cx + h.r * 0.72},${hy - h.r * 0.34}`}
+          fill="none" stroke={BANDA} strokeWidth="1.1" />
+      </g>
+    );
+  })() : null;
+
+  // ── SUDOR: gotitas que saltan de la sien (solo día + sol + calor). ────────
+  const sudorEl = sudor ? (
+    <g className={animated ? 'crt-sudor' : undefined} fill={SUDOR} stroke={ink} strokeWidth="0.4">
+      <path className="crt-gota-sudor"
+        d={`M${h.cx + h.r * 0.95},${h.cy - h.r * 0.35} q-0.7,1.2 0,2.2 q0.7,-0.9 0,-2.2 Z`} />
+      <path className="crt-gota-sudor" style={{ animationDelay: '-0.6s' }}
+        d={`M${h.cx + h.r * 0.55},${h.cy - h.r * 0.75} q-0.6,1 0,1.9 q0.6,-0.8 0,-1.9 Z`} />
+    </g>
+  ) : null;
+
+  return (
+    <g data-accesorios-clima="">
+      {ruanaEl}
+      {sombreroEl}
+      {sudorEl}
+    </g>
+  );
+}
+
+export default AccesoriosClima;

--- a/src/visual/creatures/AuraPoder.jsx
+++ b/src/visual/creatures/AuraPoder.jsx
@@ -1,0 +1,55 @@
+/*
+ * AuraPoder — Capa 4 del power-up: las CORRIENTES ascendentes
+ * (ficha DR animación rubber-hose §4). SVG absoluto, pointer-events
+ * none, con N líneas verticales que suben y se desvanecen escalonadas (el
+ * stagger por :nth-child vive en `transformacion.css`).
+ *
+ * Species-agnostic: solo depende de `--aura-color`. Se monta DENTRO del wrapper
+ * `.is-powered-up` (que ya define la variable). Decorativo → aria-hidden.
+ */
+
+import './transformacion.css';
+
+/**
+ * @param {object} props
+ * @param {number} [props.n=5]  cuántas corrientes (spec: 4–6).
+ * @param {string} [props.color]  fuerza `--aura-color` local (si el wrapper no
+ *   la define). Normalmente se hereda del `.is-powered-up`.
+ * @param {number} [props.grosor=2.2]  ancho de línea (unidades del viewBox 0..100).
+ */
+export function AuraPoder({ n = 5, color, grosor = 2.2 }) {
+  const cantidad = Math.max(2, Math.min(6, n | 0));
+  const izq = 12;
+  const ancho = 76; // reparte las corrientes en el 76% central
+  const paso = ancho / (cantidad - 1);
+  return (
+    <svg
+      className="poder-corrientes"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      style={color ? { '--aura-color': color } : undefined}
+    >
+      {Array.from({ length: cantidad }).map((_, i) => {
+        const x = izq + i * paso;
+        // Altura de arranque alterna un poco → corrientes desparejas (vida).
+        const y2 = 62 - (i % 2) * 8;
+        return (
+          <line
+            key={i}
+            className="poder-corriente"
+            x1={x}
+            y1={100}
+            x2={x}
+            y2={y2}
+            stroke="var(--aura-color)"
+            strokeWidth={grosor}
+            strokeLinecap="round"
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+export default AuraPoder;

--- a/src/visual/creatures/LineBoilFilter.jsx
+++ b/src/visual/creatures/LineBoilFilter.jsx
@@ -1,0 +1,69 @@
+/*
+ * LineBoilFilter — el filtro SVG de LINE-BOIL reutilizable (contorno que vibra,
+ * estética años 30 / Cuphead — ficha DR animación rubber-hose §1).
+ *
+ * `feTurbulence` (baseFrequency 0.02–0.03) + `feDisplacementMap` (scale 4–5)
+ * desplazan el trazo; NO fluido → ESCALONADO a ~8fps rotando la `seed` en 3
+ * estados con SMIL discreto (0.4s), tal cual la ficha. Cualquier creature lo
+ * aplica con `filter="url(#id)"`.
+ *
+ * Cada instancia necesita un `id` ÚNICO (usá `useId()` en la creature) para no
+ * colisionar con otras en la misma página. GPU-friendly y sin dependencias.
+ *
+ * GATE: el line-boil es MOVIMIENTO — con `prefers-reduced-motion` pasá
+ * `animated={false}` (la creature ya sabe si debe congelar) y el filtro queda
+ * estático (una seed fija): el trazo sigue con su textura pero sin vibrar.
+ */
+
+/* Los 3 estados de seed que rotan (line-boil de 3 fotogramas). */
+export const BOIL_SEEDS = [2, 11, 23];
+
+/**
+ * @param {Object} props
+ * @param {string} props.id  id ÚNICO del filtro (useId de la creature).
+ * @param {number} [props.baseFrequency=0.025]  turbulencia (spec 0.02–0.03).
+ * @param {number} [props.scale=4.5]  desplazamiento (spec 4.0–5.0).
+ * @param {boolean} [props.animated=true]  rota la seed (line-boil). false = fijo.
+ * @param {number[]} [props.seeds=BOIL_SEEDS]  los 3 estados de seed.
+ * @param {string} [props.dur='0.4s']  duración del ciclo escalonado.
+ * @returns {JSX.Element}
+ */
+export function LineBoilFilter({
+  id,
+  baseFrequency = 0.025,
+  scale = 4.5,
+  animated = true,
+  seeds = BOIL_SEEDS,
+  dur = '0.4s',
+}) {
+  return (
+    <filter id={id} x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence
+        type="fractalNoise"
+        baseFrequency={baseFrequency}
+        numOctaves="1"
+        seed={seeds[0]}
+        result="rh-boil-noise"
+      >
+        {animated && (
+          <animate
+            attributeName="seed"
+            values={seeds.join(';')}
+            dur={dur}
+            calcMode="discrete"
+            repeatCount="indefinite"
+          />
+        )}
+      </feTurbulence>
+      <feDisplacementMap
+        in="SourceGraphic"
+        in2="rh-boil-noise"
+        scale={scale}
+        xChannelSelector="R"
+        yChannelSelector="G"
+      />
+    </filter>
+  );
+}
+
+export default LineBoilFilter;

--- a/src/visual/creatures/PropEnMano.jsx
+++ b/src/visual/creatures/PropEnMano.jsx
@@ -1,0 +1,167 @@
+/*
+ * PropEnMano — el SLOT que pone el prop del mundo EN LA MANO del personaje.
+ *
+ * Data-driven (biblia de personajes): `mundoId` → `propDeMundo` → un
+ * dibujo del registro `DIBUJO_PROP`. Rubber-hose andino: contorno cálido grueso
+ * (RH_INK) + acento de color, siluetas simples y reconocibles. Son PLACEHOLDERS
+ * dignos para que el sistema funcione HOY; fable refina el arte por-prop luego
+ * (mismo contrato: un dibujo por id).
+ *
+ * Species-agnostic: la creature pasa el ANCLA de su mano (x,y), el tamaño y si
+ * mira a la izquierda (flip). Sin prop mapeado → no renderiza nada (manos
+ * libres, jamás rompe la escena).
+ */
+
+import { RH_INK, RH_GLOVE } from './_rubberhose.jsx';
+import { propDeMundo } from './propsPorMundo.js';
+
+const ACENTO = {
+  agua: '#4fb0e0',
+  hoja: '#4a9b3e',
+  madera: '#9c6b3f',
+  cafe: '#b3402e',
+  fruta: '#ff8b1f',
+  cuerda: '#c9a24b',
+  tela: '#d94f4f',
+  piedra: '#8a8f98',
+};
+
+/* Cada dibujo vive centrado en (0,0), pensado para ~12u de alto en el viewBox de
+   la creature. Reciben `ink` para heredar la tinta de la familia. */
+export const DIBUJO_PROP = Object.freeze({
+  // Manguera: tubo curvo con boquilla + gota (agua).
+  manguera: ({ ink }) => (
+    <g>
+      <path d="M-5,4 C-5,0 -1,-1 1,-3 C2,-4 3,-4 4,-4.6" stroke={ink} strokeWidth="1.8"
+        fill="none" strokeLinecap="round" />
+      <rect x="3.4" y="-6.2" width="2.6" height="2.4" rx="0.6" fill={ACENTO.agua} stroke={ink} strokeWidth="0.7" />
+      <path d="M4.7,-6.4 q-0.7,-1.4 0,-2.4 q0.7,1 0,2.4 Z" fill={ACENTO.agua} />
+    </g>
+  ),
+  // Lupa: aro + mango (inspeccionar el suelo/plagas).
+  lupa: ({ ink }) => (
+    <g>
+      <circle cx="-1.5" cy="-1.5" r="3.4" fill="rgba(190,230,255,0.5)" stroke={ink} strokeWidth="1.4" />
+      <path d="M1.2,1.2 L4.4,4.4" stroke={ink} strokeWidth="2" strokeLinecap="round" />
+    </g>
+  ),
+  // Lazo: cuerda con lazada (arriar animales).
+  lazo: ({ ink }) => (
+    <g fill="none" stroke={ACENTO.cuerda} strokeWidth="1.4" strokeLinecap="round">
+      <ellipse cx="-1" cy="-2.5" rx="3.2" ry="4" stroke={ACENTO.cuerda} />
+      <path d="M-3.4,0.6 C-4.5,3 -3.5,5 -2,5.6" />
+      <circle cx="-2" cy="5.8" r="0.8" fill={ACENTO.cuerda} stroke="none" />
+    </g>
+  ),
+  // Canasto: trapecio tejido (semillero / mercado).
+  canasto: ({ ink }) => (
+    <g>
+      <path d="M-4.4,-1 L4.4,-1 L3.2,5 L-3.2,5 Z" fill={ACENTO.madera} stroke={ink} strokeWidth="1.1" />
+      <path d="M-4.4,-1 C-3,-3.2 3,-3.2 4.4,-1" fill="none" stroke={ink} strokeWidth="1.1" />
+      <path d="M-2.2,-1 L-1.6,5 M0,-1 L0,5 M2.2,-1 L1.6,5" stroke={ink} strokeWidth="0.5" opacity="0.6" />
+    </g>
+  ),
+  // Rama de café: tallo con cerezas rojas.
+  'rama-cafe': ({ ink }) => (
+    <g>
+      <path d="M0,5 C0,1 0.4,-2 0,-5" stroke={ACENTO.hoja} strokeWidth="1.4" fill="none" strokeLinecap="round" />
+      <path d="M0,-1 q3,-1 4,1" stroke={ACENTO.hoja} strokeWidth="1" fill="none" />
+      <circle cx="-1.6" cy="1.5" r="1.4" fill={ACENTO.cafe} stroke={ink} strokeWidth="0.5" />
+      <circle cx="1.7" cy="0.2" r="1.4" fill={ACENTO.cafe} stroke={ink} strokeWidth="0.5" />
+      <circle cx="-0.3" cy="-2.4" r="1.3" fill={ACENTO.cafe} stroke={ink} strokeWidth="0.5" />
+    </g>
+  ),
+  // Horqueta: mango + dientes (voltear el compost).
+  horqueta: ({ ink }) => (
+    <g stroke={ink} strokeLinecap="round" fill="none">
+      <path d="M0,6 L0,-3" strokeWidth="1.6" stroke={ACENTO.madera} />
+      <path d="M-2.4,-6 L-2.4,-3 M0,-6.4 L0,-3 M2.4,-6 L2.4,-3" strokeWidth="1.3" />
+      <path d="M-2.6,-3 L2.6,-3" strokeWidth="1.3" />
+    </g>
+  ),
+  // Azadón: mango + pala en ángulo (cultivar).
+  azadon: ({ ink }) => (
+    <g>
+      <path d="M-3,6 L2,-4" stroke={ACENTO.madera} strokeWidth="1.6" strokeLinecap="round" />
+      <path d="M1,-3.4 L5,-5.4 L5.6,-3.6 L2,-1.6 Z" fill={ACENTO.piedra} stroke={ink} strokeWidth="0.8" />
+    </g>
+  ),
+  // Mazorca: elote con hojas (milpa).
+  mazorca: ({ ink }) => (
+    <g>
+      <ellipse cx="0" cy="0" rx="2.4" ry="5" fill="#f2c94c" stroke={ink} strokeWidth="1" />
+      <path d="M-1.2,-4 L-1.2,4 M0,-4.6 L0,4.6 M1.2,-4 L1.2,4" stroke={ink} strokeWidth="0.4" opacity="0.5" />
+      <path d="M-2.2,3 C-4,4 -4,6 -2.6,6.4 M2.2,3 C4,4 4,6 2.6,6.4" fill={ACENTO.hoja} stroke={ACENTO.hoja} strokeWidth="1.2" />
+    </g>
+  ),
+  // Naranja: fruta con hojita (frutales).
+  naranja: ({ ink }) => (
+    <g>
+      <circle cx="0" cy="1" r="4" fill={ACENTO.fruta} stroke={ink} strokeWidth="1.1" />
+      <path d="M0.5,-3 q2.5,-1.5 3.5,0.4 q-2.4,0.8 -3.5,-0.4 Z" fill={ACENTO.hoja} stroke={ink} strokeWidth="0.5" />
+    </g>
+  ),
+  // Paraguas: capota + mango (clima / lluvia).
+  paraguas: ({ ink }) => (
+    <g>
+      <path d="M-5,-1 C-5,-6 5,-6 5,-1 Z" fill={ACENTO.tela} stroke={ink} strokeWidth="1.1" />
+      <path d="M0,-1 L0,5 q0,1.6 1.8,1.4" stroke={ink} strokeWidth="1.3" fill="none" strokeLinecap="round" />
+    </g>
+  ),
+  // Mapa: pergamino enrollado (valle).
+  mapa: ({ ink }) => (
+    <g>
+      <rect x="-4.4" y="-3.4" width="8.8" height="6.8" rx="0.8" fill={RH_GLOVE} stroke={ink} strokeWidth="1.1" />
+      <path d="M-2.4,-1 L1,0.4 L3,-1.6 M-2,1.6 L2.4,1" stroke={ACENTO.hoja} strokeWidth="0.8" fill="none" strokeLinecap="round" />
+      <circle cx="1" cy="0.4" r="0.7" fill={ACENTO.cafe} />
+    </g>
+  ),
+  // Montaña: pisos térmicos (mapa vertical de la finca).
+  montana: ({ ink }) => (
+    <g>
+      <path d="M-5,5 L-1.5,-3 L1,1 L3,-4 L6,5 Z" fill={ACENTO.piedra} stroke={ink} strokeWidth="1" />
+      <path d="M-1.5,-3 L-2.6,-1 L-0.4,-1 Z M3,-4 L1.9,-2 L4.2,-2 Z" fill="#f5f7fa" />
+    </g>
+  ),
+  // Regla: herramienta de diseño (disenio).
+  regla: ({ ink }) => (
+    <g>
+      <rect x="-5" y="-1.6" width="10" height="3.2" rx="0.5" fill="#e8c76a" stroke={ink} strokeWidth="1" />
+      <path d="M-3,-1.6 L-3,0 M-1,-1.6 L-1,0.6 M1,-1.6 L1,0 M3,-1.6 L3,0.6" stroke={ink} strokeWidth="0.5" />
+    </g>
+  ),
+});
+
+/**
+ * Renderiza el prop del mundo en la mano de la creature (o nada si el mundo no
+ * tiene prop / el prop no está en el registro).
+ *
+ * @param {object} props
+ * @param {string} props.mundoId  id del mundo (MUNDO[*] de mundoData).
+ * @param {number} [props.x=0]  ancla X en unidades del viewBox de la creature.
+ * @param {number} [props.y=0]  ancla Y.
+ * @param {number} [props.escala=1]  factor de tamaño.
+ * @param {boolean} [props.flip=false]  espejar (personaje mirando a la izquierda).
+ * @param {string} [props.ink=RH_INK]  tinta del contorno (heredá la de la familia).
+ * @param {boolean} [props.animated=true]  si mece el prop (follow-through `rh-sway`).
+ * @returns {JSX.Element|null}
+ */
+export function PropEnMano({ mundoId, x = 0, y = 0, escala = 1, flip = false, ink = RH_INK, animated = true }) {
+  const propId = propDeMundo(mundoId);
+  if (!propId) return null;
+  const Dibujo = DIBUJO_PROP[propId];
+  if (!Dibujo) return null;
+  const sx = (flip ? -1 : 1) * escala;
+  return (
+    <g
+      data-prop={propId}
+      className={animated ? 'rh-sway' : undefined}
+      transform={`translate(${x} ${y}) scale(${sx} ${escala})`}
+      style={animated ? { transformBox: 'fill-box', transformOrigin: 'top center' } : undefined}
+    >
+      <Dibujo ink={ink} />
+    </g>
+  );
+}
+
+export default PropEnMano;

--- a/src/visual/creatures/__tests__/creatureClimaCuerpo.ropa.test.js
+++ b/src/visual/creatures/__tests__/creatureClimaCuerpo.ropa.test.js
@@ -1,0 +1,93 @@
+/**
+ * creatureClimaCuerpo.ropa.test.js — VESTUARIO por clima+hora
+ * (biblia de personajes). El caso clave: la abeja NO suda de noche.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ropaDeClima,
+  ropaDeClimaBicho,
+  ropaPerfilDeBicho,
+  ROPA_NEUTRA,
+  ROPA_PERFIL_DEFECTO,
+} from '../creatureClimaCuerpo.js';
+
+describe('ropaDeClima — gates de clima/hora', () => {
+  it('sin clima → vestuario neutro (nada puesto)', () => {
+    expect(ropaDeClima(null)).toEqual(ROPA_NEUTRA);
+    expect(ropaDeClima(undefined)).toEqual(ROPA_NEUTRA);
+  });
+
+  it('DE NOCHE → ruana, y NUNCA sudor (el bug muerto)', () => {
+    const r = ropaDeClima('noche');
+    expect(r.ruana).toBe(true);
+    expect(r.sudor).toBe(false);
+    expect(r.sombrero).toBe(false);
+  });
+
+  it('de noche calurosa (tempC alta) sigue sin sudar — la noche manda', () => {
+    const r = ropaDeClima('noche', { tempC: 30 });
+    expect(r.ruana).toBe(true);
+    expect(r.sudor).toBe(false);
+  });
+
+  it('sol de día (perfil que suda) → sombrero + sudor, sin ruana', () => {
+    const r = ropaDeClima('soleado', { perfil: ROPA_PERFIL_DEFECTO });
+    expect(r.sombrero).toBe(true);
+    expect(r.sudor).toBe(true);
+    expect(r.ruana).toBe(false);
+  });
+
+  it('hora dorada cuenta como sol de día', () => {
+    expect(ropaDeClima('dorada').sudor).toBe(true);
+  });
+
+  it('sol pero bicho que NO suda al sol (páramo, sin temp) → sin sombrero', () => {
+    const oso = ropaPerfilDeBicho('oso-andino');
+    const r = ropaDeClima('soleado', { perfil: oso });
+    expect(r.sombrero).toBe(false);
+    expect(r.sudor).toBe(false);
+  });
+
+  it('temperatura real manda: sol + calor sobre calorC → suda aunque el perfil sea de páramo', () => {
+    const oso = ropaPerfilDeBicho('oso-andino'); // calorC 18
+    const r = ropaDeClima('soleado', { perfil: oso, tempC: 22 });
+    expect(r.sudor).toBe(true);
+  });
+
+  it('día soleado pero FRÍO (tempC bajo frioC) → ruana, sin sudor', () => {
+    const r = ropaDeClima('soleado', { tempC: 2 }); // frioC default 12
+    expect(r.ruana).toBe(true);
+    expect(r.sudor).toBe(false);
+    expect(r.sombrero).toBe(false);
+  });
+
+  it('lluvia → mojado; niebla → niebla; sin sombrero en ninguna', () => {
+    const ll = ropaDeClima('lluvia');
+    expect(ll.mojado).toBe(true);
+    expect(ll.sombrero).toBe(false);
+    const nb = ropaDeClima('niebla');
+    expect(nb.niebla).toBe(true);
+    expect(nb.sombrero).toBe(false);
+  });
+
+  it('ruana y sombrero son mutuamente excluyentes', () => {
+    for (const clima of ['noche', 'soleado', 'dorada', 'lluvia', 'niebla']) {
+      for (const tempC of [undefined, 0, 15, 35]) {
+        const r = ropaDeClima(clima, { tempC });
+        expect(r.ruana && r.sombrero).toBe(false);
+      }
+    }
+  });
+});
+
+describe('ropaDeClimaBicho — por slug', () => {
+  it('oso de noche → ruana', () => {
+    expect(ropaDeClimaBicho('oso-andino', 'noche').ruana).toBe(true);
+  });
+  it('abeja al sol → suda', () => {
+    expect(ropaDeClimaBicho('abeja-angelita', 'soleado').sudor).toBe(true);
+  });
+  it('slug desconocido usa perfil neutro (no explota)', () => {
+    expect(ropaDeClimaBicho('bicho-fantasma', 'soleado').sudor).toBe(true);
+  });
+});

--- a/src/visual/creatures/__tests__/lipSyncCore.test.js
+++ b/src/visual/creatures/__tests__/lipSyncCore.test.js
@@ -1,0 +1,95 @@
+/**
+ * lipSyncCore.test.js — lógica pura del lip-sync 2D por RMS
+ * (ficha DR animación rubber-hose §2). Sin navegador.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  VISEMA,
+  UMBRAL_RMS,
+  visemaDesdeRMS,
+  rmsDeMuestras,
+  crearDebounceVisema,
+  visemaFallback,
+} from '../lipSyncCore.js';
+
+describe('visemaDesdeRMS — umbrales del spec (5% / 30% / 70%)', () => {
+  it('silencio y por debajo de 5% → boca cerrada (V1)', () => {
+    expect(visemaDesdeRMS(0)).toBe(VISEMA.CERRADA);
+    expect(visemaDesdeRMS(0.049)).toBe(VISEMA.CERRADA);
+  });
+  it('5%–30% → entreabierta (V2)', () => {
+    expect(visemaDesdeRMS(UMBRAL_RMS.ENTREABIERTA)).toBe(VISEMA.ENTREABIERTA);
+    expect(visemaDesdeRMS(0.2)).toBe(VISEMA.ENTREABIERTA);
+    expect(visemaDesdeRMS(0.299)).toBe(VISEMA.ENTREABIERTA);
+  });
+  it('31%–70% → fruncida (V4)', () => {
+    expect(visemaDesdeRMS(UMBRAL_RMS.FRUNCIDA)).toBe(VISEMA.FRUNCIDA);
+    expect(visemaDesdeRMS(0.5)).toBe(VISEMA.FRUNCIDA);
+    expect(visemaDesdeRMS(0.699)).toBe(VISEMA.FRUNCIDA);
+  });
+  it('>70% (picos) → abierta amplia (V3)', () => {
+    expect(visemaDesdeRMS(UMBRAL_RMS.ABIERTA)).toBe(VISEMA.ABIERTA);
+    expect(visemaDesdeRMS(0.95)).toBe(VISEMA.ABIERTA);
+  });
+  it('valores no finitos o negativos → cerrada (defensivo)', () => {
+    expect(visemaDesdeRMS(NaN)).toBe(VISEMA.CERRADA);
+    expect(visemaDesdeRMS(-1)).toBe(VISEMA.CERRADA);
+    expect(visemaDesdeRMS(undefined)).toBe(VISEMA.CERRADA);
+  });
+});
+
+describe('rmsDeMuestras', () => {
+  it('bytes en silencio (centrados en 128) → RMS 0', () => {
+    expect(rmsDeMuestras(new Uint8Array([128, 128, 128, 128]))).toBe(0);
+  });
+  it('bytes con desviación → RMS conocido (byte normaliza en /128)', () => {
+    // 128±64 → cada muestra vale 0.5 → RMS = 0.5
+    const r = rmsDeMuestras(new Uint8Array([192, 64, 192, 64]));
+    expect(r).toBeCloseTo(0.5, 6);
+  });
+  it('Float32Array ya en [-1,1]', () => {
+    expect(rmsDeMuestras(new Float32Array([1, -1, 1, -1]))).toBeCloseTo(1, 6);
+    expect(rmsDeMuestras(new Float32Array([0, 0]))).toBe(0);
+  });
+  it('sin muestras → 0', () => {
+    expect(rmsDeMuestras(new Uint8Array([]))).toBe(0);
+    expect(rmsDeMuestras(null)).toBe(0);
+  });
+});
+
+describe('crearDebounceVisema — anti jaw-chomping', () => {
+  it('un candidato nuevo solo gana tras sostenerse `ms`', () => {
+    const d = crearDebounceVisema({ ms: 50, inicial: VISEMA.CERRADA });
+    expect(d(VISEMA.CERRADA, 0)).toBe(VISEMA.CERRADA);
+    expect(d(VISEMA.ABIERTA, 10)).toBe(VISEMA.CERRADA);  // candidato arranca
+    expect(d(VISEMA.ABIERTA, 40)).toBe(VISEMA.CERRADA);  // 30ms < 50
+    expect(d(VISEMA.ABIERTA, 60)).toBe(VISEMA.ABIERTA);  // 50ms sostenido → cambia
+  });
+  it('volver al estable cancela una transición en curso (temblor de umbral)', () => {
+    const d = crearDebounceVisema({ ms: 50, inicial: VISEMA.CERRADA });
+    d(VISEMA.CERRADA, 0);
+    d(VISEMA.ENTREABIERTA, 10);              // candidato
+    expect(d(VISEMA.CERRADA, 20)).toBe(VISEMA.CERRADA); // vuelve → reset
+    d(VISEMA.ENTREABIERTA, 30);              // candidato de nuevo (desde 30)
+    expect(d(VISEMA.ENTREABIERTA, 70)).toBe(VISEMA.CERRADA); // 40ms < 50
+    expect(d(VISEMA.ENTREABIERTA, 85)).toBe(VISEMA.ENTREABIERTA); // 55ms → cambia
+  });
+});
+
+describe('visemaFallback — boca de relleno determinista', () => {
+  it('siempre devuelve un visema válido', () => {
+    const validos = new Set(Object.values(VISEMA));
+    for (let t = 0; t < 2000; t += 17) {
+      expect(validos.has(visemaFallback(t))).toBe(true);
+    }
+  });
+  it('es determinista (mismo t, mismo visema) y no constante', () => {
+    expect(visemaFallback(123)).toBe(visemaFallback(123));
+    const muestras = new Set();
+    for (let t = 0; t < 1000; t += 5) muestras.add(visemaFallback(t));
+    expect(muestras.size).toBeGreaterThan(1); // la boca se mueve
+  });
+  it('entrada no finita → no explota (t=0)', () => {
+    expect(Object.values(VISEMA)).toContain(visemaFallback(NaN));
+  });
+});

--- a/src/visual/creatures/__tests__/propsPorMundo.test.js
+++ b/src/visual/creatures/__tests__/propsPorMundo.test.js
@@ -1,0 +1,52 @@
+/**
+ * propsPorMundo.test.js — resolución del prop-por-mundo + integridad del
+ * registro de dibujos (biblia de personajes).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  propDeMundo,
+  mundoTieneProp,
+  PROP_POR_MUNDO,
+  PROPS_CONOCIDOS,
+} from '../propsPorMundo.js';
+import { DIBUJO_PROP } from '../PropEnMano.jsx';
+
+describe('propDeMundo — mapa del spec', () => {
+  it('mundos con prop nombrado en la ficha', () => {
+    expect(propDeMundo('agua')).toBe('manguera');
+    expect(propDeMundo('suelo')).toBe('lupa');
+    expect(propDeMundo('animales')).toBe('lazo');
+    expect(propDeMundo('semillero')).toBe('canasto');
+    expect(propDeMundo('cafe')).toBe('rama-cafe');
+    expect(propDeMundo('abono')).toBe('horqueta'); // compost
+  });
+
+  it('mundo sin prop mapeado → null (manos libres)', () => {
+    expect(propDeMundo('mundo-inexistente')).toBeNull();
+  });
+
+  it('entrada no-string → null (defensivo)', () => {
+    expect(propDeMundo(undefined)).toBeNull();
+    expect(propDeMundo(42)).toBeNull();
+    expect(propDeMundo(null)).toBeNull();
+  });
+
+  it('mundoTieneProp coincide con propDeMundo', () => {
+    expect(mundoTieneProp('agua')).toBe(true);
+    expect(mundoTieneProp('mundo-inexistente')).toBe(false);
+  });
+});
+
+describe('integridad del registro', () => {
+  it('todo prop mapeado tiene un dibujo en DIBUJO_PROP', () => {
+    for (const propId of PROPS_CONOCIDOS) {
+      expect(DIBUJO_PROP[propId], `falta dibujo para prop "${propId}"`).toBeTypeOf('function');
+    }
+  });
+
+  it('PROPS_CONOCIDOS no tiene duplicados y cubre el mapa', () => {
+    const valores = new Set(Object.values(PROP_POR_MUNDO));
+    expect(new Set(PROPS_CONOCIDOS).size).toBe(PROPS_CONOCIDOS.length);
+    expect(new Set(PROPS_CONOCIDOS)).toEqual(valores);
+  });
+});

--- a/src/visual/creatures/__tests__/transformacion.test.js
+++ b/src/visual/creatures/__tests__/transformacion.test.js
@@ -1,0 +1,26 @@
+/**
+ * transformacion.test.js — resolución del aura por bicho (modo poder).
+ */
+import { describe, it, expect } from 'vitest';
+import { auraDeBicho, AURA_POR_BICHO, AURA_DEFECTO } from '../transformacion.js';
+
+describe('auraDeBicho', () => {
+  it('devuelve el color del bicho conocido', () => {
+    expect(auraDeBicho('abeja-angelita')).toBe('#ffd54a');
+    expect(auraDeBicho('jaguar')).toBe('#a855f7');
+    expect(auraDeBicho('oso-andino')).toBe('#ff3b30');
+  });
+
+  it('slug desconocido / no-string → aura por defecto', () => {
+    expect(auraDeBicho('bicho-fantasma')).toBe(AURA_DEFECTO);
+    expect(auraDeBicho(null)).toBe(AURA_DEFECTO);
+    expect(auraDeBicho(undefined)).toBe(AURA_DEFECTO);
+    expect(auraDeBicho(123)).toBe(AURA_DEFECTO);
+  });
+
+  it('todo valor del mapa es un color hex válido', () => {
+    for (const color of Object.values(AURA_POR_BICHO)) {
+      expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+});

--- a/src/visual/creatures/_rubberhose.jsx
+++ b/src/visual/creatures/_rubberhose.jsx
@@ -161,3 +161,56 @@ export function AntenaRubber({ d, bulbo, bulboR = 1.15, sway = false, delay = 0,
     </g>
   );
 }
+
+/* Boca interior (garganta) para las bocas abiertas — un rojo cálido tenue. */
+export const RH_BOCA = '#8a3b34';
+
+/**
+ * BocaVisema — la BOCA de goma en sus 4 formas de LIP-SYNC
+ * (ficha DR animación rubber-hose §2). Consume el `visema` que produce
+ * `useLipSync` ('V1'..'V4') y dibuja:
+ *   V1 CERRADA     → el arco amable de siempre (Sonrisa) — silencio / M,B,P.
+ *   V2 ENTREABIERTA→ boca apenas abierta (S,Z,T,D,F,V).
+ *   V4 FRUNCIDA    → labios en "O" (O,U,W).
+ *   V3 ABIERTA     → apertura amplia con garganta y lengüita (A,E).
+ *
+ * Species-agnostic: cualquier bicho la coloca en su cara (cx,cy,w). Sin visema
+ * (o 'V1') se ve EXACTO como la sonrisa neutra → no rompe caras existentes.
+ *
+ * @param {Object} props
+ * @param {number} [props.cx=0] @param {number} [props.cy=0] centro de la boca.
+ * @param {number} [props.w=3]  ancho de referencia (el de la sonrisa del bicho).
+ * @param {number} [props.prof=1.1]  profundidad del arco cerrado.
+ * @param {string} [props.visema='V1']
+ * @param {string} [props.ink=RH_INK] @param {string} [props.boca=RH_BOCA]
+ */
+export function BocaVisema({ cx = 0, cy = 0, w = 3, prof = 1.1, visema = 'V1', ink = RH_INK, boca = RH_BOCA }) {
+  if (visema === 'V2') {
+    // Entreabierta: elipse chata, apenas separa los labios.
+    return (
+      <g>
+        <ellipse cx={cx} cy={cy + prof * 0.3} rx={w * 0.32} ry={prof * 0.55} fill={boca} stroke={ink} strokeWidth="0.7" />
+      </g>
+    );
+  }
+  if (visema === 'V4') {
+    // Fruncida en "O": labios redondeados hacia adentro.
+    return (
+      <g>
+        <circle cx={cx} cy={cy + prof * 0.4} r={w * 0.26} fill={boca} stroke={ink} strokeWidth="0.9" />
+        <circle cx={cx} cy={cy + prof * 0.4} r={w * 0.13} fill="#5c231f" />
+      </g>
+    );
+  }
+  if (visema === 'V3') {
+    // Abierta amplia: garganta + lengüita (los picos A,E).
+    return (
+      <g>
+        <ellipse cx={cx} cy={cy + prof * 0.55} rx={w * 0.42} ry={prof * 1.05} fill={boca} stroke={ink} strokeWidth="0.9" />
+        <path d={`M${cx - w * 0.3},${cy + prof * 1.1} Q${cx},${cy + prof * 1.7} ${cx + w * 0.3},${cy + prof * 1.1} Z`} fill="#d1615a" />
+      </g>
+    );
+  }
+  // V1 (o desconocido): la sonrisa cerrada de siempre.
+  return <Sonrisa cx={cx} cy={cy} w={w} prof={prof} ink={ink} />;
+}

--- a/src/visual/creatures/climaAccesorios.css
+++ b/src/visual/creatures/climaAccesorios.css
@@ -1,0 +1,35 @@
+/*
+ * climaAccesorios.css — cadencia de los accesorios de clima (ruana/sombrero/sudor)
+ * de `AccesoriosClima.jsx`. Todo transform/opacity (GPU, gama baja). RM congela.
+ */
+
+/* SUDOR — la gotita salta de la frente y cae (solo con sol de día caluroso). */
+.crt-sudor .crt-gota-sudor {
+  transform-box: fill-box;
+  transform-origin: center top;
+  animation: crt-sudor-salta 1.2s ease-in infinite;
+}
+@keyframes crt-sudor-salta {
+  0%   { transform: translate(0, 0) scale(1); opacity: 0; }
+  12%  { opacity: 0.95; }
+  70%  { transform: translate(1.2px, 5px) scale(1.05); opacity: 0.9; }
+  100% { transform: translate(1.6px, 8px) scale(0.7); opacity: 0; }
+}
+
+/* RUANA — respira suave con el cuerpo (pliegue que se mece). */
+.crt-ruana {
+  transform-box: fill-box;
+  transform-origin: center top;
+  animation: crt-ruana-mece 3.4s ease-in-out infinite;
+}
+@keyframes crt-ruana-mece {
+  0%, 100% { transform: skewX(0deg); }
+  50%      { transform: skewX(1.4deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crt-sudor .crt-gota-sudor,
+  .crt-ruana { animation: none; }
+  /* Fotograma digno: la gota de sudor visible y quieta en la frente. */
+  .crt-sudor .crt-gota-sudor { opacity: 0.9; }
+}

--- a/src/visual/creatures/creatureClimaCuerpo.js
+++ b/src/visual/creatures/creatureClimaCuerpo.js
@@ -214,3 +214,96 @@ export function cuerpoDeClima(clima, { enso = 'neutro', tier, perfil = PERFIL_AB
 }
 
 export default cuerpoDeClima;
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * ROPA / CUERPO por CLIMA + HORA  (extensión — biblia de personajes)
+ * ───────────────────────────────────────────────────────────────────────────
+ * `cuerpoDeClima` (arriba) modula PIEL: mojado / niebla / tinte / aleteo. Esto
+ * es la capa de VESTUARIO: ruana, sombrero y sudor. Mismo vocabulario de clima
+ * de escena ('dorada'|'soleado'|'niebla'|'lluvia'|'noche') — la HORA ya viaja
+ * ahí ('noche' = de noche; 'dorada'/'soleado' = día con sol).
+ *
+ * El BUG que mata: la abeja SUDANDO de noche. Regla dura → de noche se pone la
+ * RUANA (nunca suda); el sudor SOLO sale de día, con sol y calor. Species-
+ * agnostic: cada bicho trae su umbral térmico (según su piso); la lógica es una.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Perfil de VESTUARIO por bicho (derivado del piso térmico de la biblia):
+ *   frioC     °C por debajo de la cual siente frío → ruana (además de la noche).
+ *   calorC    °C a la cual (o más), de día y con sol, suda → sombrero+sudor.
+ *   sudaAlSol cuando NO hay temperatura, ¿suda igual con sol de día? Los de
+ *             páramo/frío (oso, rana) NO; los templados/cálidos SÍ (default).
+ */
+export const ROPA_PERFIL_POR_BICHO = Object.freeze({
+  'abeja-angelita': { frioC: 12, calorC: 26, sudaAlSol: true },
+  'oso-andino': { frioC: 4, calorC: 18, sudaAlSol: false },
+  'rana-andina': { frioC: 8, calorC: 22, sudaAlSol: false }, // slug real de la creature
+  'rana-arlequin': { frioC: 8, calorC: 22, sudaAlSol: false }, // alias biblia
+  colibri: { frioC: 11, calorC: 26, sudaAlSol: true },
+  jaguar: { frioC: 16, calorC: 32, sudaAlSol: true },
+  ardilla: { frioC: 11, calorC: 26, sudaAlSol: true },
+  perezoso: { frioC: 12, calorC: 27, sudaAlSol: true },
+  morrocoy: { frioC: 16, calorC: 32, sudaAlSol: true },
+});
+
+/* Perfil neutro (slug desconocido / standalone). */
+export const ROPA_PERFIL_DEFECTO = Object.freeze({ frioC: 12, calorC: 26, sudaAlSol: true });
+
+/**
+ * Perfil de vestuario de un bicho por slug. Desconocido → neutro.
+ * @param {string} slug
+ * @returns {{frioC:number, calorC:number, sudaAlSol:boolean}}
+ */
+export function ropaPerfilDeBicho(slug) {
+  return (typeof slug === 'string' && ROPA_PERFIL_POR_BICHO[slug]) || ROPA_PERFIL_DEFECTO;
+}
+
+/** Vestuario NEUTRO (sin clima): sin abrigo ni sudor. */
+export const ROPA_NEUTRA = Object.freeze({
+  ruana: false, sombrero: false, sudor: false, mojado: false, niebla: false,
+});
+
+/**
+ * Resuelve el VESTUARIO del bicho para un clima de escena + (opcional) la °C real.
+ *
+ * @param {('dorada'|'soleado'|'niebla'|'lluvia'|'noche'|null|undefined)} clima
+ *   clima de escena (mismo vocabulario que cuerpoDeClima). Desconocido → neutro.
+ * @param {object} [opts]
+ * @param {{frioC:number, calorC:number, sudaAlSol:boolean}} [opts.perfil=ROPA_PERFIL_DEFECTO]
+ * @param {number} [opts.tempC]  °C real si se conoce (afina frío/calor). Sin ella,
+ *   se infiere del clima + piso (sol de día = calor salvo bichos de páramo).
+ * @returns {{ruana:boolean, sombrero:boolean, sudor:boolean, mojado:boolean, niebla:boolean}}
+ */
+export function ropaDeClima(clima, { perfil = ROPA_PERFIL_DEFECTO, tempC } = {}) {
+  const p = perfil || ROPA_PERFIL_DEFECTO;
+  if (clima == null) return ROPA_NEUTRA;
+
+  const esNoche = clima === 'noche';
+  const soleadoDia = clima === 'soleado' || clima === 'dorada';
+  const lluvia = clima === 'lluvia';
+  const niebla = clima === 'niebla';
+
+  const tieneTemp = Number.isFinite(tempC);
+  const frioPorTemp = tieneTemp ? tempC <= p.frioC : false;
+  // Calor: por °C si la hay; si no, sol de día basta salvo bichos que no sudan.
+  const calorEfectivo = tieneTemp ? tempC >= p.calorC : (soleadoDia && p.sudaAlSol !== false);
+
+  // RUANA: de noche o con frío. (Bug muerto: de noche → ruana, jamás sudor.)
+  const ruana = esNoche || frioPorTemp;
+  // SOMBRERO + SUDOR: solo de día, con sol, con calor y sin ruana.
+  const sombrero = !esNoche && soleadoDia && calorEfectivo && !ruana;
+  const sudor = sombrero;
+
+  return { ruana, sombrero, sudor, mojado: lluvia, niebla };
+}
+
+/**
+ * Azúcar: vestuario directo desde el slug del bicho.
+ * @param {string} slug
+ * @param {('dorada'|'soleado'|'niebla'|'lluvia'|'noche'|null|undefined)} clima
+ * @param {object} [opts]  { tempC }
+ * @returns {{ruana:boolean, sombrero:boolean, sudor:boolean, mojado:boolean, niebla:boolean}}
+ */
+export function ropaDeClimaBicho(slug, clima, { tempC } = {}) {
+  return ropaDeClima(clima, { perfil: ropaPerfilDeBicho(slug), tempC });
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -38,6 +38,35 @@ export { Lombriz } from './Lombriz.jsx';
 export { Mariposa } from './Mariposa.jsx';
 export { Escarabajo } from './Escarabajo.jsx';
 
+/* ── SISTEMA DE PERSONAJES (transversal, species-agnostic) ───────────────────
+   La FUNDACIÓN que heredan los 8 bichos: lip-sync, modo poder, prop-por-mundo,
+   ropa por clima+hora y el line-boil. Cada bicho = parámetros (aura, perfil,
+   props), no código duplicado. Estrenado por Angelita; fable engancha el resto. */
+// Lip-sync 2D por RMS del TTS.
+export { useLipSync } from './useLipSync.js';
+export {
+  VISEMA, UMBRAL_RMS, DEBOUNCE_MS,
+  visemaDesdeRMS, rmsDeMuestras, crearDebounceVisema, visemaFallback,
+} from './lipSyncCore.js';
+export { BocaVisema, RH_BOCA } from './_rubberhose.jsx';
+// Transformación "modo poder".
+export { AuraPoder } from './AuraPoder.jsx';
+export {
+  AURA_POR_BICHO, AURA_DEFECTO, CLASE_PODER, PODER_MS,
+  auraDeBicho, usePoderTemporal,
+} from './transformacion.js';
+// Prop-por-mundo (herramienta en la mano al entrar a cada mundo).
+export { PROP_POR_MUNDO, PROPS_CONOCIDOS, propDeMundo, mundoTieneProp } from './propsPorMundo.js';
+export { PropEnMano, DIBUJO_PROP } from './PropEnMano.jsx';
+// Ropa/cuerpo por clima+hora (ruana/sombrero/sudor) + su dibujo.
+export {
+  ROPA_PERFIL_POR_BICHO, ROPA_PERFIL_DEFECTO, ROPA_NEUTRA,
+  ropaDeClima, ropaDeClimaBicho, ropaPerfilDeBicho,
+} from './creatureClimaCuerpo.js';
+export { AccesoriosClima } from './AccesoriosClima.jsx';
+// Line-boil (contorno que vibra, años 30).
+export { LineBoilFilter, BOIL_SEEDS } from './LineBoilFilter.jsx';
+
 import AbejaAngelita from './AbejaAngelita.jsx';
 import Colibri from './Colibri.jsx';
 import OsoAndino from './OsoAndino.jsx';

--- a/src/visual/creatures/lipSyncCore.js
+++ b/src/visual/creatures/lipSyncCore.js
@@ -1,0 +1,136 @@
+/*
+ * lipSyncCore — LÓGICA PURA del lip-sync 2D por amplitud RMS (sin visemas del TTS).
+ *
+ * Kokoro/Web-Speech no exponen visemas fonéticos; los DERIVAMOS de la ENERGÍA
+ * del audio (RMS) en tiempo real. Cuatro formas de boca (ficha DR Gemini,
+ * ficha DR animación rubber-hose §2). Este módulo NO toca el DOM ni el
+ * AudioContext: solo transforma números → visema, con un debounce anti
+ * "jaw-chomping". El HOOK (`useLipSync.js`) lo alimenta con el RMS real; los
+ * TESTS lo prueban sin navegador.
+ *
+ * Species-agnostic: cualquier bicho consume el mismo `data-visema`; su boca
+ * dibuja las 4 formas a su manera (fable pone el arte por-bicho).
+ */
+
+/* Los 4 visemas (claves estables que viajan como `data-visema` al SVG). */
+export const VISEMA = Object.freeze({
+  CERRADA: 'V1',     // silencio / M,B,P
+  ENTREABIERTA: 'V2', // S,Z,T,D,F,V
+  ABIERTA: 'V3',     // A,E — apertura amplia (picos)
+  FRUNCIDA: 'V4',    // O,U,W — labios fruncidos
+});
+
+/* Umbrales de RMS del spec (fracción 0..1): 5% / 30% / 70%.
+   <5% cerrada · 5–30% entreabierta · 31–70% fruncida · >70% abierta. */
+export const UMBRAL_RMS = Object.freeze({
+  ENTREABIERTA: 0.05,
+  FRUNCIDA: 0.30,
+  ABIERTA: 0.70,
+});
+
+/* Debounce por defecto (ms): un visema debe sostenerse ~50ms antes de cambiar,
+   si no la mandíbula "castañetea" a cada frame (jaw-chomping). */
+export const DEBOUNCE_MS = 50;
+
+/**
+ * RMS → visema, según los umbrales del spec. Función pura, sin estado.
+ *
+ * NOTA de orden (del spec): por MAGNITUD las bocas van V1<V2<V4<V3 — la boca
+ * "fruncida" (O/U) ocupa la franja media-alta (31–70%) y la "abierta" (A/E) solo
+ * los picos (>70%). No es un typo: sigue ficha DR animación rubber-hose.
+ *
+ * @param {number} rms  energía RMS normalizada (0..1). Valores fuera de rango o
+ *   no finitos → boca cerrada (defensivo).
+ * @returns {'V1'|'V2'|'V3'|'V4'}
+ */
+export function visemaDesdeRMS(rms) {
+  if (!Number.isFinite(rms) || rms < UMBRAL_RMS.ENTREABIERTA) return VISEMA.CERRADA;
+  if (rms < UMBRAL_RMS.FRUNCIDA) return VISEMA.ENTREABIERTA;
+  if (rms < UMBRAL_RMS.ABIERTA) return VISEMA.FRUNCIDA;
+  return VISEMA.ABIERTA;
+}
+
+/**
+ * RMS de una ventana de muestras de dominio-tiempo.
+ *
+ * AnalyserNode.getByteTimeDomainData entrega bytes centrados en 128 (silencio).
+ * Normalizamos a [-1,1], sacamos la raíz del promedio de cuadrados. Acepta
+ * Uint8Array (byte, centrado en 128) o Float32Array (ya en [-1,1]).
+ *
+ * @param {Uint8Array|Float32Array|number[]} muestras
+ * @returns {number} RMS en 0..1 (0 si no hay muestras).
+ */
+export function rmsDeMuestras(muestras) {
+  if (!muestras || muestras.length === 0) return 0;
+  const esByte = muestras instanceof Uint8Array;
+  let suma = 0;
+  for (let i = 0; i < muestras.length; i++) {
+    const v = esByte ? (muestras[i] - 128) / 128 : muestras[i];
+    suma += v * v;
+  }
+  return Math.sqrt(suma / muestras.length);
+}
+
+/**
+ * Crea un debouncer de visema con estado propio (closure). Devuelve una función
+ * `siguiente(visemaCrudo, ahoraMs)` que aplica histéresis temporal: un visema
+ * nuevo solo "gana" si se sostiene `ms` desde que se propuso. Evita el castañeteo
+ * cuando el RMS tiembla en un borde de umbral.
+ *
+ * Pura y determinista respecto al reloj que le pasás (`ahoraMs`) → testeable con
+ * un reloj falso, sin timers reales.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.ms=DEBOUNCE_MS]  tiempo de sostenimiento requerido.
+ * @param {string} [opts.inicial=VISEMA.CERRADA]  visema de arranque.
+ * @returns {(visemaCrudo:string, ahoraMs:number) => string} visema estabilizado.
+ */
+export function crearDebounceVisema({ ms = DEBOUNCE_MS, inicial = VISEMA.CERRADA } = {}) {
+  let estable = inicial;       // el visema que estamos mostrando
+  let pendiente = inicial;     // el candidato a cambio
+  let desde = -Infinity;       // desde cuándo el candidato se sostiene
+
+  return function siguiente(visemaCrudo, ahoraMs) {
+    const t = Number.isFinite(ahoraMs) ? ahoraMs : 0;
+    if (visemaCrudo === estable) {
+      // volvió al estable: cancela cualquier transición en curso
+      pendiente = estable;
+      desde = t;
+      return estable;
+    }
+    if (visemaCrudo !== pendiente) {
+      // candidato nuevo: arranca su reloj
+      pendiente = visemaCrudo;
+      desde = t;
+      return estable;
+    }
+    // mismo candidato sostenido: ¿ya cumplió el tiempo?
+    if (t - desde >= ms) {
+      estable = pendiente;
+    }
+    return estable;
+  };
+}
+
+/**
+ * Generador de la boca "de relleno" (fallback digno) cuando NO hay AnalyserNode
+ * (Web Speech, sin WebAudio, o el navegador no deja intervenir el audio): mientras
+ * el agente habla, la boca aletea con un patrón pseudo-aleatorio determinista
+ * (no todo abierto: mezcla entreabierta/fruncida/abierta con pausas cerradas)
+ * para que se LEA como habla sin necesitar la señal real.
+ *
+ * Determinista en función de `tMs` → testeable. No usa Math.random.
+ *
+ * @param {number} tMs  tiempo transcurrido hablando (ms).
+ * @returns {'V1'|'V2'|'V3'|'V4'}
+ */
+export function visemaFallback(tMs) {
+  const t = Number.isFinite(tMs) ? tMs : 0;
+  // Dos senoidales co-primas → "sílabas" irregulares; a ratos cierra (pausa).
+  const s = Math.sin(t / 90) * 0.6 + Math.sin(t / 37) * 0.4; // -1..1 aprox
+  const amp = (s + 1) / 2; // 0..1
+  if (amp < 0.18) return VISEMA.CERRADA;
+  if (amp < 0.5) return VISEMA.ENTREABIERTA;
+  if (amp < 0.8) return VISEMA.FRUNCIDA;
+  return VISEMA.ABIERTA;
+}

--- a/src/visual/creatures/propsPorMundo.js
+++ b/src/visual/creatures/propsPorMundo.js
@@ -1,0 +1,59 @@
+/*
+ * propsPorMundo — DATA-DRIVEN: qué prop lleva el personaje en la mano al ENTRAR
+ * a cada mundo (biblia de personajes, mapa prop-por-mundo). El bicho
+ * del piso térmico entra heroico con su herramienta: agua→manguera, suelo→lupa,
+ * animales→lazo, semillero→canasto, café→rama de café, compost→horqueta…
+ *
+ * Aquí SOLO viven los datos + el resolver (puro, testeable). El DIBUJO del prop
+ * y su colocación en la mano viven en `PropEnMano.jsx`. Los ids de mundo salen
+ * de `src/visual/mundo3d/mundoData.js` (MUNDO[*]).
+ *
+ * Species-agnostic: el prop depende del MUNDO, no del bicho. Un mundo sin prop
+ * mapeado → null (el personaje entra con las manos libres, sin romperse).
+ */
+
+/* mundoId → id de prop (clave del registro de dibujos en PropEnMano). */
+export const PROP_POR_MUNDO = Object.freeze({
+  agua: 'manguera',
+  suelo: 'lupa',
+  animales: 'lazo',
+  semillero: 'canasto',
+  cafe: 'rama-cafe',
+  abono: 'horqueta',   // compost
+  cultivos: 'azadon',
+  milpa: 'mazorca',
+  frutales: 'naranja',
+  mercado: 'canasto',
+  sanidad: 'lupa',
+  clima: 'paraguas',
+  valle: 'mapa',
+  pisos: 'montana',
+  disenio: 'regla',
+});
+
+/**
+ * Prop de un mundo por su id. Desconocido/no-string → null (manos libres).
+ *
+ * @param {string} mundoId
+ * @returns {string|null} id de prop o null.
+ */
+export function propDeMundo(mundoId) {
+  if (typeof mundoId !== 'string') return null;
+  return PROP_POR_MUNDO[mundoId] || null;
+}
+
+/**
+ * ¿Este mundo tiene prop de entrada?
+ * @param {string} mundoId
+ * @returns {boolean}
+ */
+export function mundoTieneProp(mundoId) {
+  return propDeMundo(mundoId) !== null;
+}
+
+/* Los ids de prop que el registro de dibujos DEBE saber pintar (contrato: si
+   agregás un mundo→prop nuevo acá, agregá su dibujo en PropEnMano.DIBUJO_PROP).
+   El test cruza ambos para que no quede un mundo apuntando a un prop sin dibujo. */
+export const PROPS_CONOCIDOS = Object.freeze(
+  Array.from(new Set(Object.values(PROP_POR_MUNDO))),
+);

--- a/src/visual/creatures/transformacion.css
+++ b/src/visual/creatures/transformacion.css
@@ -1,0 +1,97 @@
+/*
+ * transformacion.css — POWER-UP "modo poder" species-agnostic (aprobado para
+ * TODOS los bichos). Clase maestra `.is-powered-up` + variable `--aura-color`:
+ * cambiando SOLO esa variable cada bicho tiene su aura (abeja dorada, oso rojo,
+ * rana verde, jaguar púrpura…). Cuatro capas de la ficha DR
+ * (ficha DR animación rubber-hose §4). Todo CSS/SVG, cero WebGL.
+ *
+ * DÓNDE VA: sobre un ELEMENTO HTML que envuelve a la creature (avatar/diálogo).
+ * Los pseudo-elementos (::before) y `mix-blend-mode` no aplican a nodos SVG, por
+ * eso la capa 1/2/3 viven en el wrapper DOM; la capa 4 (corrientes) es el
+ * componente `AuraPoder`. Fable extiende a inline por-bicho después.
+ *
+ * GATE: `prefers-reduced-motion` deja el aura ESTÁTICA (sigue leyéndose "en
+ * modo poder") pero sin latir ni levitar.
+ */
+
+.is-powered-up {
+  /* Aura por defecto: dorada (Angelita). Cada bicho la pisa con su color. */
+  --aura-color: #ffd54a;
+  position: relative;
+  transform-origin: center bottom;
+  /* Capa 2 — BOOST estático: satura, aviva y aureola el contorno. */
+  filter: saturate(180%) brightness(120%) drop-shadow(0 0 15px var(--aura-color));
+  /* Capa 3 — INGRAVIDEZ: se agranda y flota (loop senoidal en el keyframe). */
+  animation: poder-levita 1.8s ease-in-out infinite;
+  will-change: transform, filter;
+}
+
+/* Capa 1 — AURA RADIAL: resplandor por detrás que LATE (scale 1.5↔2.2,
+   opacity 0.8↔0.4), fundido en pantalla (screen) para sumar luz, no tapar. */
+.is-powered-up::before {
+  content: '';
+  position: absolute;
+  inset: -35%;
+  z-index: -1;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--aura-color) 0%, transparent 70%);
+  mix-blend-mode: screen;
+  pointer-events: none;
+  animation: poder-aura 1.1s ease-in-out infinite;
+}
+
+@keyframes poder-aura {
+  0%, 100% { transform: scale(1.5); opacity: 0.4; }
+  50%      { transform: scale(2.2); opacity: 0.8; }
+}
+
+@keyframes poder-levita {
+  0%, 100% { transform: scale(1.05) translateY(-10px); }
+  50%      { transform: scale(1.05) translateY(-16px); }
+}
+
+/* Capa 4 — CORRIENTES ascendentes: líneas verticales que suben y se desvanecen,
+   escalonadas por :nth-child (energía que emana). El SVG lo pone `AuraPoder`. */
+.poder-corrientes {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.poder-corriente {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+  animation: poder-sube 0.95s linear infinite;
+}
+
+@keyframes poder-sube {
+  0%   { transform: translateY(25%);  opacity: 0; }
+  18%  { opacity: 0.9; }
+  100% { transform: translateY(-140%); opacity: 0; }
+}
+
+/* Stagger: cada corriente arranca en un momento distinto → chorro continuo. */
+.poder-corriente:nth-child(1) { animation-delay: 0s; }
+.poder-corriente:nth-child(2) { animation-delay: 0.16s; }
+.poder-corriente:nth-child(3) { animation-delay: 0.32s; }
+.poder-corriente:nth-child(4) { animation-delay: 0.48s; }
+.poder-corriente:nth-child(5) { animation-delay: 0.64s; }
+.poder-corriente:nth-child(6) { animation-delay: 0.8s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .is-powered-up,
+  .is-powered-up::before,
+  .poder-corriente {
+    animation: none;
+  }
+  /* Fotograma digno: aura visible (poder ON) pero quieta, y una sola corriente
+     insinuada; sin flotar (transform neutro para no dejarla desplazada). */
+  .is-powered-up { transform: scale(1.05); }
+  .is-powered-up::before { opacity: 0.6; transform: scale(1.9); }
+  .poder-corriente { opacity: 0.5; }
+}

--- a/src/visual/creatures/transformacion.js
+++ b/src/visual/creatures/transformacion.js
@@ -1,0 +1,84 @@
+/*
+ * transformacion — helper del power-up "modo poder" (biblia de personajes).
+ *
+ * Dos cosas:
+ *   1) AURA_POR_BICHO — el color de aura de cada bicho (lo ÚNICO que cambia entre
+ *      especies: la clase `.is-powered-up` y las 4 capas son idénticas). Datos
+ *      puros, testeables.
+ *   2) usePoderTemporal — hook para DISPARAR la transformación un rato (la
+ *      "mega-celebra"): activás y a los `ms` se apaga sola.
+ *
+ * Uso típico (avatar/diálogo):
+ *   const { poderoso, activar } = usePoderTemporal();
+ *   <div className={poderoso ? 'is-powered-up' : ''}
+ *        style={{ '--aura-color': auraDeBicho('abeja-angelita') }}>
+ *     <AbejaAngelita /> {poderoso && <AuraPoder />}
+ *   </div>
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/* La clase maestra (por si algún consumidor DOM la togglea sin React). */
+export const CLASE_PODER = 'is-powered-up';
+
+/* Aura por bicho (biblia de personajes — tabla de transformación).
+   Claves = slugs estables de la creature. Solo el COLOR difiere; el resto del
+   efecto es transversal. Los tonos "iridiscente/chispas" se aproximan con un
+   color base — fable los refina con gradientes por-bicho después. */
+export const AURA_POR_BICHO = Object.freeze({
+  'abeja-angelita': '#ffd54a', // dorada clásica
+  'oso-andino': '#ff3b30',     // roja berserker
+  'rana-andina': '#39d98a',    // verde-zen (slug real de la creature)
+  'rana-arlequin': '#39d98a',  // alias biblia
+  colibri: '#4fd1ff',          // iridiscente (aprox. celeste)
+  jaguar: '#a855f7',           // púrpura depredador
+  ardilla: '#ff9f1c',          // chispas ámbar
+  perezoso: '#9acd32',         // verde-musgo zen irónico
+  morrocoy: '#ff7a3c',         // caparazón que brilla (ámbar-rojizo)
+});
+
+/* Aura por defecto si el slug no está mapeado (la dorada de la guía). */
+export const AURA_DEFECTO = '#ffd54a';
+
+/**
+ * Color de aura de un bicho por su slug. Desconocido/no-string → aura por
+ * defecto (nunca undefined, así `--aura-color` siempre tiene valor).
+ *
+ * @param {string} slug
+ * @returns {string} color CSS.
+ */
+export function auraDeBicho(slug) {
+  return (typeof slug === 'string' && AURA_POR_BICHO[slug]) || AURA_DEFECTO;
+}
+
+/* Duración por defecto de la mega-celebra (ms). */
+export const PODER_MS = 2600;
+
+/**
+ * Hook para disparar el power-up TEMPORAL (la "mega-celebra"). `activar()` lo
+ * enciende y lo apaga solo a los `ms`. Reentrante: llamar de nuevo reinicia el
+ * reloj (no se acumula ni parpadea).
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.ms=PODER_MS]
+ * @returns {{ poderoso: boolean, activar: () => void, apagar: () => void }}
+ */
+export function usePoderTemporal({ ms = PODER_MS } = {}) {
+  const [poderoso, setPoderoso] = useState(false);
+  const timerRef = useRef(0);
+
+  const apagar = useCallback(() => {
+    clearTimeout(timerRef.current);
+    setPoderoso(false);
+  }, []);
+
+  const activar = useCallback(() => {
+    setPoderoso(true);
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setPoderoso(false), ms);
+  }, [ms]);
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  return { poderoso, activar, apagar };
+}

--- a/src/visual/creatures/useLipSync.js
+++ b/src/visual/creatures/useLipSync.js
@@ -1,0 +1,171 @@
+/*
+ * useLipSync — HOOK de lip-sync 2D para las creatures.
+ *
+ * Engancha `ttsService.onSpeakingChange` (¿está hablando el agente?) + un
+ * `AudioContext.createAnalyser()` sobre el <audio> activo (`getActiveAudio`) para
+ * derivar VISEMAS de la energía RMS en tiempo real
+ * (ficha DR animación rubber-hose §2). La lógica pura (umbral RMS →
+ * visema, debounce anti-castañeteo, boca de relleno) vive en `lipSyncCore.js`
+ * (testeada sin navegador); acá solo está el cableado del audio + rAF.
+ *
+ * Species-agnostic: devuelve un `data-visema` ('V1'..'V4') que CUALQUIER creature
+ * pone en su nodo raíz; el SVG dibuja las 4 bocas a su manera.
+ *
+ * FALLBACK DIGNO (contrato): si no hay WebAudio, o el audio es Web-Speech (sin
+ * elemento), o el navegador no deja intervenir el <audio>, la boca aletea igual
+ * con `visemaFallback` mientras el agente hable. Nunca se queda muda-abierta.
+ *
+ * GPU/gama-baja: un solo AudioContext compartido, un solo rAF activo solo
+ * mientras habla, y respeta `prefers-reduced-motion` (boca cerrada, sin rAF).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import ttsService from '../../services/ttsService.js';
+import {
+  VISEMA,
+  visemaDesdeRMS,
+  rmsDeMuestras,
+  crearDebounceVisema,
+  visemaFallback,
+  DEBOUNCE_MS,
+} from './lipSyncCore.js';
+
+/* Un AudioContext por pestaña (crearlos es caro y hay un tope del navegador).
+   MediaElementSource: solo UNO por elemento — cacheamos por WeakMap para no
+   volver a intentar (createMediaElementSource dos veces tira). */
+let ctxCompartido = null;
+const fuentesPorAudio = new WeakMap();
+
+function obtenerContexto() {
+  if (typeof window === 'undefined') return null;
+  const AC = window.AudioContext || window.webkitAudioContext;
+  if (!AC) return null;
+  if (!ctxCompartido) {
+    try { ctxCompartido = new AC(); } catch { return null; }
+  }
+  return ctxCompartido;
+}
+
+function prefiereMenosMovimiento() {
+  try {
+    return typeof window !== 'undefined'
+      && window.matchMedia
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch { return false; }
+}
+
+/**
+ * @param {object} [opts]
+ * @param {boolean} [opts.activo=true]  permite apagar el hook (p.ej. tier bajo).
+ * @param {number}  [opts.debounceMs=DEBOUNCE_MS]
+ * @returns {{ visema: string, hablando: boolean }}
+ */
+export function useLipSync({ activo = true, debounceMs = DEBOUNCE_MS } = {}) {
+  const [visema, setVisema] = useState(VISEMA.CERRADA);
+  const [hablando, setHablando] = useState(false);
+
+  // Refs mutables que el loop lee sin re-suscribirse.
+  const hablandoRef = useRef(false);
+  const rafRef = useRef(0);
+  const analyserRef = useRef(null);
+  const bufRef = useRef(null);
+  const audioRef = useRef(null);
+  const debounceRef = useRef(crearDebounceVisema({ ms: debounceMs }));
+  const inicioFallbackRef = useRef(0);
+
+  useEffect(() => {
+    debounceRef.current = crearDebounceVisema({ ms: debounceMs });
+  }, [debounceMs]);
+
+  useEffect(() => {
+    if (!activo || prefiereMenosMovimiento()) {
+      setVisema(VISEMA.CERRADA);
+      return undefined;
+    }
+
+    const ahora = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+    // Intenta colgar un analyser sobre el <audio> activo. Devuelve true si lo
+    // logró (hay señal real); false → usaremos la boca de relleno.
+    const intentarAnalizarReal = () => {
+      const el = ttsService.getActiveAudio?.();
+      if (!el) return false;
+      if (audioRef.current === el && analyserRef.current) return true; // ya cableado
+      const ctx = obtenerContexto();
+      if (!ctx) return false;
+      try {
+        if (ctx.state === 'suspended') ctx.resume?.();
+        let fuente = fuentesPorAudio.get(el);
+        if (!fuente) {
+          fuente = ctx.createMediaElementSource(el);
+          fuente.connect(ctx.destination); // sin esto el audio se silencia
+          fuentesPorAudio.set(el, fuente);
+        }
+        const analyser = ctx.createAnalyser();
+        analyser.fftSize = 256;              // barato; suficiente para RMS
+        analyser.smoothingTimeConstant = 0.4;
+        fuente.connect(analyser);
+        analyserRef.current = analyser;
+        bufRef.current = new Uint8Array(analyser.fftSize);
+        audioRef.current = el;
+        return true;
+      } catch {
+        // createMediaElementSource ya usado / bloqueado → relleno.
+        analyserRef.current = null;
+        audioRef.current = null;
+        return false;
+      }
+    };
+
+    const loop = () => {
+      if (!hablandoRef.current) return; // se apaga en el listener
+      let crudo;
+      if (analyserRef.current && bufRef.current) {
+        analyserRef.current.getByteTimeDomainData(bufRef.current);
+        crudo = visemaDesdeRMS(rmsDeMuestras(bufRef.current));
+      } else if (intentarAnalizarReal()) {
+        crudo = VISEMA.CERRADA; // primer frame recién cableado
+      } else {
+        crudo = visemaFallback(ahora() - inicioFallbackRef.current);
+      }
+      const estable = debounceRef.current(crudo, ahora());
+      setVisema((prev) => (prev === estable ? prev : estable));
+      rafRef.current = requestAnimationFrame(loop);
+    };
+
+    const onSpeaking = (spk) => {
+      setHablando(spk);
+      hablandoRef.current = spk;
+      if (spk) {
+        inicioFallbackRef.current = ahora();
+        debounceRef.current = crearDebounceVisema({ ms: debounceMs });
+        intentarAnalizarReal(); // por si ya hay elemento
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = requestAnimationFrame(loop);
+      } else {
+        cancelAnimationFrame(rafRef.current);
+        // suelta el analyser del elemento anterior (la fuente se cachea aparte)
+        analyserRef.current = null;
+        audioRef.current = null;
+        bufRef.current = null;
+        setVisema(VISEMA.CERRADA);
+      }
+    };
+
+    // Estado inicial (por si ya estaba hablando al montar).
+    if (ttsService.isAudioPlaying?.()) onSpeaking(true);
+
+    const desuscribir = ttsService.onSpeakingChange(onSpeaking);
+    return () => {
+      desuscribir?.();
+      cancelAnimationFrame(rafRef.current);
+      analyserRef.current = null;
+      audioRef.current = null;
+      bufRef.current = null;
+    };
+  }, [activo, debounceMs]);
+
+  return { visema, hablando };
+}
+
+export default useLipSync;


### PR DESCRIPTION
## Que es

Fundacion **transversal, species-agnostic** del sistema de personajes rubber-hose (todo CSS/SVG, cero WebGL). El scaffold sobre el que las pasadas de arte solo tienen que poner el dibujo por-bicho. Estrenado en la Angelita (opt-in, sin cambiarle el look).

## Las 4 piezas + utils

1. **Lip-sync 2D por RMS** — `useLipSync.js` engancha `ttsService.onSpeakingChange` + un `AudioContext.createAnalyser()` sobre el `<audio>` activo (nuevo getter `ttsService.getActiveAudio`). La logica pura vive en `lipSyncCore.js`: visema por umbral **5% / 30% / 70%** (V1 cerrada / V2 entreabierta / V4 fruncida / V3 abierta), debounce ~50ms anti-castaneteo, y **fallback digno** (boca de relleno determinista) cuando no hay AnalyserNode o el TTS es Web-Speech. `BocaVisema` dibuja las 4 formas.
2. **Modo poder (power-up)** — `transformacion.css` con la clase maestra `.is-powered-up` en 4 capas (aura radial `::before`, boost de filtro, ingravidez senoidal, corrientes) gobernadas por `--aura-color`. `AuraPoder.jsx` pone las corrientes; `AURA_POR_BICHO` mapea el color por bicho; `usePoderTemporal` dispara el efecto un rato (mega-celebra).
3. **Prop-por-mundo** — `propsPorMundo.js` (`PROP_POR_MUNDO` data-driven: agua->manguera, suelo->lupa, animales->lazo, semillero->canasto, cafe->rama, compost->horqueta...) + `PropEnMano.jsx` (slot que pone el prop en la mano al entrar al mundo, con registro de dibujos SVG).
4. **Ropa por clima+hora** — extiende `creatureClimaCuerpo.js` con `ropaDeClima`: **ruana de noche/frio** (mata el bug de la abeja sudando de noche), **sombrero+sudor SOLO al sol calido**, mojado en lluvia. Perfil termico por bicho. `AccesoriosClima.jsx` los dibuja.
- **Line-boil** reutilizable (`LineBoilFilter.jsx`): `feTurbulence` + `feDisplacementMap` escalonado en 3 seeds (SMIL discreto 0.4s).

## Disciplina
- **Build**: `npm run build` verde (5m13s).
- **Tests**: 51 tests puros nuevos verdes (visema/RMS, gates de clima, resolucion de prop, aura).
- Gate `prefers-reduced-motion` + `data-tier='bajo'` en todo lo animado.
- Cambio a `ttsService` = **1 getter aditivo** (`getActiveAudio`), no toca el playback.
- Angelita: props nuevas `visema` y `vestuario` son **opt-in** (default off) — los consumidores existentes no cambian.

## Nota (pre-existente en dev, NO de este PR)
`ttsService.voice.test.js` tiene 2 asserts stale que esperan `em_alex` mientras el codigo hoy usa `em_santa`/`ef_dora` (verificado: fallan en `origin/dev` sin este PR). Es una decision de la linea de voz, fuera de alcance aca.

## Que queda para fable (arte por-bicho)
- Enganchar lip-sync (`useLipSync`->`visema`), `vestuario`, prop-por-mundo y modo poder en los otros 7 bichos.
- Refinar el arte de props/ruana/sombrero y los gradientes de aura por especie (iridiscente colibri, chispas ardilla, etc.).
- Aplicar el line-boil al contorno de cada creature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)