### PR TITLE
feat(red): backend del MVP de la red humana (mercado → grafo + reputación)

### DIFF
--- a/src/db/__tests__/redTransactions.test.js
+++ b/src/db/__tests__/redTransactions.test.js
@@ -1,0 +1,127 @@
+/**
+ * redTransactions.test.js — store offline de los TRATOS de la red humana.
+ *
+ * Mock pequeño de IDB con un Map en memoria (mismo patrón que
+ * marketplaceOfertas.test.js). Verifica save/getAll/get/remove/count +
+ * byProductor (con y sin índice disponible).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let store; // Map en memoria keyed by id
+
+const makeTx = () => {
+  const tx = { oncomplete: null, onerror: null, onabort: null };
+  const objectStore = {
+    put(record) {
+      store.set(record.id, record);
+      Promise.resolve().then(() => tx.oncomplete?.());
+    },
+    delete(id) {
+      store.delete(id);
+      Promise.resolve().then(() => tx.oncomplete?.());
+    },
+    get(id) {
+      const req = { onsuccess: null, onerror: null };
+      Promise.resolve().then(() => {
+        req.result = store.get(id) || undefined;
+        req.onsuccess?.();
+      });
+      return req;
+    },
+    getAll() {
+      const req = { onsuccess: null, onerror: null };
+      Promise.resolve().then(() => {
+        req.result = [...store.values()];
+        req.onsuccess?.();
+      });
+      return req;
+    },
+    count() {
+      const req = { onsuccess: null, onerror: null };
+      Promise.resolve().then(() => {
+        req.result = store.size;
+        req.onsuccess?.();
+      });
+      return req;
+    },
+    index() {
+      // Simula ausencia de índice → el servicio degrada a filtrar getAll.
+      return {
+        getAll() {
+          const req = { onsuccess: null, onerror: null };
+          Promise.resolve().then(() => {
+            req.result = [...store.values()];
+            req.onsuccess?.();
+          });
+          return req;
+        },
+      };
+    },
+  };
+  tx.objectStore = () => objectStore;
+  return tx;
+};
+
+const mockDB = { transaction: vi.fn(() => makeTx()) };
+
+vi.mock('../dbCore', () => ({
+  openDB: vi.fn(() => Promise.resolve(mockDB)),
+  STORES: { RED_TRANSACTIONS: 'red_transactions' },
+}));
+
+describe('redTransactions store', () => {
+  beforeEach(() => {
+    store = new Map();
+    vi.clearAllMocks();
+  });
+
+  it('save() persiste y genera id/createdAt si faltan', async () => {
+    const { redTransactions } = await import('../redTransactions');
+    const saved = await redTransactions.save({
+      productorHash: 'p1', producto: 'Tomate', entrega: 'entregado', shareLevel: 2,
+    });
+    expect(saved.id).toMatch(/^trato-/);
+    expect(typeof saved.createdAt).toBe('number');
+    expect(store.size).toBe(1);
+  });
+
+  it('save() respeta id explícito (upsert)', async () => {
+    const { redTransactions } = await import('../redTransactions');
+    await redTransactions.save({ id: 'fijo', producto: 'Papa', cantidad: 1 });
+    await redTransactions.save({ id: 'fijo', producto: 'Papa', cantidad: 5 });
+    expect(store.size).toBe(1);
+    expect((await redTransactions.get('fijo')).cantidad).toBe(5);
+  });
+
+  it('getAll() ordena del más reciente al más antiguo', async () => {
+    const { redTransactions } = await import('../redTransactions');
+    await redTransactions.save({ id: 'a', createdAt: 1000 });
+    await redTransactions.save({ id: 'b', createdAt: 3000 });
+    await redTransactions.save({ id: 'c', createdAt: 2000 });
+    const all = await redTransactions.getAll();
+    expect(all.map((t) => t.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('byProductor() filtra por hash (degrada a getAll sin índice real)', async () => {
+    const { redTransactions } = await import('../redTransactions');
+    await redTransactions.save({ id: '1', productorHash: 'p1' });
+    await redTransactions.save({ id: '2', productorHash: 'p2' });
+    await redTransactions.save({ id: '3', productorHash: 'p1' });
+    const p1 = await redTransactions.byProductor('p1');
+    expect(p1.map((t) => t.id).sort()).toEqual(['1', '3']);
+  });
+
+  it('byProductor() sin hash devuelve vacío', async () => {
+    const { redTransactions } = await import('../redTransactions');
+    expect(await redTransactions.byProductor('')).toEqual([]);
+  });
+
+  it('get() null si no existe; remove() y count()', async () => {
+    const { redTransactions } = await import('../redTransactions');
+    expect(await redTransactions.get('nope')).toBeNull();
+    await redTransactions.save({ id: 'x', producto: 'Mora' });
+    expect(await redTransactions.count()).toBe(1);
+    await redTransactions.remove('x');
+    expect(await redTransactions.count()).toBe(0);
+  });
+});

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -38,7 +38,7 @@
  */
 
 export const DB_NAME = 'ChagraDB';
-export const DB_VERSION = 26;
+export const DB_VERSION = 27;
 
 export const STORES = {
   ASSETS: 'assets',
@@ -109,6 +109,16 @@ export const STORES = {
   // dentro de la app. keyPath 'id' (string generado en cliente). Índices:
   // createdAt (timeline), categoria (filtro), municipio (filtro por ubicación).
   MARKETPLACE_OFERTAS: 'marketplace_ofertas',
+  // v27: red_transactions — TRATOS cerrados de la RED humana (campesino ↔
+  // campesino). Cada trato es el HECHO verificable del que se derivan el grafo
+  // social (productor–cultivo–vereda) y la reputación ganada — subproducto de
+  // transacciones del mercado que ya ocurren (ver services/red/). Append-only
+  // (fuente de verdad; grafo/reputación son cache reconstruible, ADR-019).
+  // Local-first: el dato crudo se queda en el dispositivo; solo cruza a la red
+  // lo marcado opt-in (shareLevel ≥ 2). keyPath 'id' (string cliente). Índices:
+  // createdAt (timeline), productorHash (reputación por productor), producto
+  // (matchmaking por cultivo), vereda (cercanía), shareLevel (compuerta).
+  RED_TRANSACTIONS: 'red_transactions',
 };
 
 let dbInstance = null;
@@ -454,6 +464,22 @@ export const openDB = async () => {
           store.createIndex('createdAt', 'createdAt', { unique: false });
           store.createIndex('categoria', 'categoria', { unique: false });
           store.createIndex('municipio', 'municipio', { unique: false });
+        }
+      }
+
+      // v27: red_transactions — tratos cerrados de la red humana. Cada registro
+      // es un HECHO append-only (quién entregó qué, en qué vereda, con qué
+      // fiabilidad/calidad) del que se derivan el grafo social y la reputación
+      // (services/red/). Local-first + opt-in: solo cruza a la red lo marcado
+      // shareLevel ≥ 2. keyPath 'id'. Índices para reputación/matchmaking.
+      if (event.oldVersion < 27) {
+        if (!db.objectStoreNames.contains(STORES.RED_TRANSACTIONS)) {
+          const store = db.createObjectStore(STORES.RED_TRANSACTIONS, { keyPath: 'id' });
+          store.createIndex('createdAt', 'createdAt', { unique: false });
+          store.createIndex('productorHash', 'productorHash', { unique: false });
+          store.createIndex('producto', 'producto', { unique: false });
+          store.createIndex('vereda', 'vereda', { unique: false });
+          store.createIndex('shareLevel', 'shareLevel', { unique: false });
         }
       }
     };

--- a/src/db/redTransactions.js
+++ b/src/db/redTransactions.js
@@ -1,0 +1,134 @@
+/**
+ * redTransactions.js — CRUD offline-first de los TRATOS de la red humana
+ * (campesino ↔ campesino). Store: red_transactions (ChagraDB v27).
+ *
+ * Un TRATO es el HECHO verificable de un negocio cerrado del mercado (¿quién
+ * entregó qué, en qué vereda, con qué fiabilidad y calidad?). Es la fuente de
+ * verdad append-only de la red: el grafo social y la reputación se DERIVAN de
+ * aquí (services/red/redReputation.js) y son cache reconstruible (ADR-019).
+ *
+ * Todo se persiste LOCAL y sobrevive recargas sin red (mismo patrón que
+ * marketplaceOfertas / glaciarReportes). El dato crudo NO sale del dispositivo:
+ * la compartición a la red es opt-in por `shareLevel` (services/red/redSharing).
+ *
+ * @module db/redTransactions
+ */
+
+import { openDB, STORES } from './dbCore';
+
+/** Genera un id único en cliente (timestamp + random, ordenable por tiempo). */
+export function nuevoTratoId() {
+  return `trato-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export const redTransactions = {
+  /**
+   * Guarda (o reemplaza) un trato. Si no trae `id`/`createdAt`, los genera.
+   * @param {object} trato
+   * @returns {Promise<object>} el trato persistido (con id/createdAt).
+   */
+  async save(trato) {
+    const db = await openDB();
+    const now = Date.now();
+    const record = {
+      ...trato,
+      id: trato.id || nuevoTratoId(),
+      createdAt: trato.createdAt || now,
+    };
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.RED_TRANSACTIONS, 'readwrite');
+      tx.objectStore(STORES.RED_TRANSACTIONS).put(record);
+      tx.oncomplete = () => resolve(record);
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  },
+
+  /**
+   * Devuelve todos los tratos, del más reciente al más antiguo.
+   * @returns {Promise<object[]>}
+   */
+  async getAll() {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.RED_TRANSACTIONS, 'readonly');
+      const req = tx.objectStore(STORES.RED_TRANSACTIONS).getAll();
+      req.onsuccess = () => {
+        const results = req.result || [];
+        results.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+        resolve(results);
+      };
+      req.onerror = () => reject(req.error);
+    });
+  },
+
+  /**
+   * Obtiene un trato por id. Null si no existe.
+   * @param {string} id
+   * @returns {Promise<object|null>}
+   */
+  async get(id) {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.RED_TRANSACTIONS, 'readonly');
+      const req = tx.objectStore(STORES.RED_TRANSACTIONS).get(id);
+      req.onsuccess = () => resolve(req.result || null);
+      req.onerror = () => reject(req.error);
+    });
+  },
+
+  /**
+   * Tratos de un productor (por su hash pseudonimizado). Usa el índice
+   * `productorHash`; degrada a filtrar getAll si el índice no existe (tests).
+   * @param {string} productorHash
+   * @returns {Promise<object[]>}
+   */
+  async byProductor(productorHash) {
+    if (!productorHash) return [];
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.RED_TRANSACTIONS, 'readonly');
+      const objStore = tx.objectStore(STORES.RED_TRANSACTIONS);
+      let req;
+      try {
+        req = objStore.index('productorHash').getAll(productorHash);
+      } catch (_e) {
+        req = objStore.getAll();
+      }
+      req.onsuccess = () => {
+        const rows = req.result || [];
+        resolve(rows.filter((r) => r.productorHash === productorHash));
+      };
+      req.onerror = () => reject(req.error);
+    });
+  },
+
+  /**
+   * Elimina un trato por id (corrección / retracción del registro).
+   * @param {string} id
+   * @returns {Promise<void>}
+   */
+  async remove(id) {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.RED_TRANSACTIONS, 'readwrite');
+      tx.objectStore(STORES.RED_TRANSACTIONS).delete(id);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  },
+
+  /**
+   * Cuenta los tratos registrados.
+   * @returns {Promise<number>}
+   */
+  async count() {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.RED_TRANSACTIONS, 'readonly');
+      const req = tx.objectStore(STORES.RED_TRANSACTIONS).count();
+      req.onsuccess = () => resolve(req.result || 0);
+      req.onerror = () => reject(req.error);
+    });
+  },
+};

--- a/src/services/red/README.md
+++ b/src/services/red/README.md
@@ -1,0 +1,118 @@
+# services/red — Backend del MVP de la RED humana (campesino ↔ campesino)
+
+Capa de **datos + servicios + tipos** de la red de pares de Chagra. **No hay
+UI aquí** — la "cara" la construye aparte quien consuma estos servicios.
+
+## La idea (del DR de red groundeado)
+
+**La puerta es el mercado.** Cada trato del mercado ya codifica quién cultiva
+qué, en qué vereda, con qué fiabilidad entregó y qué calidad calificó el
+comprador. Por eso el **grafo social** y la **reputación** NO se piden ni se
+votan: son **subproducto** de transacciones que ya ocurren. Esto evita el
+_cold-start_ y sirve desde un piloto chico (~15 productores).
+
+Dos capacidades núcleo:
+
+1. **mercado → grafo + reputación** (`redReputation.js`): convierte los tratos
+   en aristas del grafo (productor–cultivo–vereda) + reputación **ganada**
+   (fiabilidad de entrega + calidad), anclada a hechos verificables.
+2. **"Pregúntele al vecino" + ruteo** (`redMatchmaking.js`): dado un problema
+   (cultivo × vereda × síntoma), encuentra al par competente y cercano (que
+   **demostró** éxito con ese cultivo) y decide si enrutarle la duda.
+
+## Local-first / anti-extractivo (inviolable)
+
+El dato crudo vive en el dispositivo por default. La compartición es **opt-in de
+3 niveles** (`redSharing.js`):
+
+| Nivel | Nombre | Qué hace |
+|------:|--------|----------|
+| 1 | `PRIVADO` | Solo en el dispositivo. **Nunca** entra al grafo ni al matchmaking. Default seguro. |
+| 2 | `PARES` | Alimenta grafo + reputación + "pregúntele al vecino". **El MVP opera en 1–2.** |
+| 3 | `CANONIZADO` | Un sabedor lo vuelve conocimiento comunitario. Se **modela** aunque el MVP no lo ejecute todavía. |
+
+`redSharing` es la **única compuerta**: los servicios de grafo/reputación jamás
+leen la lista cruda, solo `filterShareable`. `redactForPeers` recorta lo que los
+pares no necesitan (identidad del comprador, referencias internas, texto libre).
+El nivel 3 es el **puente** con el grafo `DR-SOCIAL-1`
+(`src/data/social-age-schema.json`): `Caso —SE_VUELVE→ ConocimientoComunitario`.
+
+Nada se monetiza en la capa de pares — **el mercado es la única superficie de
+dinero**. El contacto con un vecino reusa el canal directo del mercado
+(WhatsApp) y **solo** si el par expuso un teléfono público (opt-in); sin ese
+consentimiento, el ruteo entrega la intención + el mensaje sugerido, nunca un
+número.
+
+## Cómo se conecta
+
+- **Al mercado** (`marketplaceService.js`, `db/marketplaceOfertas.js`): un trato
+  (`RedTransaction`) referencia la oferta que lo originó. `redService.buildTrato`
+  mapea una oferta del mercado + el desenlace a un trato. `abrirCanal` reusa
+  `construirContacto` del mercado.
+- **A la identidad** (`operatorIdentityService.js`): el `productorHash` es el id
+  **pseudonimizado** del operador (HMAC, Ley 1581 Habeas Data). La reputación se
+  ancla a ese hash, no a un nombre.
+- **Al grafo** (`grafoRelations.js`, `src/data/social-age-schema.json`): el
+  grafo social de la red es complementario al grafo de especies. Para resolver
+  un **síntoma → cultivo** en el ruteo, el caller puede usar
+  `grafoRelations.resolvePestSynonym` antes de llamar a `preguntarAlVecino`.
+- **Al agente**: `preguntarAlVecino(problema, opts)` es el punto de enganche —
+  el asistente llama esto cuando **no sabe** (`agentConfident:false`) o cuando la
+  duda es **local-específica**, y usa la decisión para ofrecer el contacto.
+
+## Modelo de reputación (honesto)
+
+- **Fiabilidad**: media bayesiana con prior neutral `Beta(1,1)` →
+  `(entregas + 1) / (confirmadas + 2)`. Con `n` chico tiende a 0.5 (desconocida),
+  no a 1.0. Entrega parcial pesa 0.5.
+- **Calidad**: promedio de calificaciones 1..5 presentes (o `null`, nunca
+  inventa), normalizado a 0..1.
+- **Confianza por volumen**: `n / (n + 3)` — pondera el ranking sin tapar a un
+  vecino nuevo prometedor.
+- **Recencia (supuesto de Markov)**: decaimiento exponencial con media vida
+  configurable, porque la conducta de entrega **no es estacionaria** (cambio de
+  tierra, práctica o mala cosecha). Ver el docstring de `redReputation.js`.
+- **Nivel** (semáforo humano, espeja `semaforoConfianza` pero para un actor):
+  `nuevo` (sin historial) · `verde` · `ámbar` · `rojo`.
+
+## Persistencia
+
+`db/redTransactions.js` (store `red_transactions`, ChagraDB **v27**) — CRUD
+offline-first, append-only (fuente de verdad). Grafo y reputación son **cache
+reconstruible** (ADR-019). Mismo patrón que `marketplaceOfertas.js`.
+
+## API pública (barrel `index.js`)
+
+```js
+import {
+  // orquestación (async, con I/O)
+  registrarTrato, cargarReputaciones, cargarGrafoSocial, preguntarAlVecino,
+  abrirCanal, buildTrato,
+  // puro
+  computeReputacion, computeAllReputaciones, buildSocialGraph,
+  findCompetentPeers, routeQuestion, buildMensajeVecino,
+  // compuerta anti-extractiva
+  isShareable, filterShareable, redactForPeers, withDefaultShareLevel,
+  // vocabulario
+  SHARE_LEVEL, ENTREGA, CONFIRMADO_POR, NIVEL_REPUTACION,
+} from '@/services/red';
+```
+
+## Qué queda para la "cara" (fable)
+
+Este módulo **no** trae UI. Falta construir (consumiendo lo de arriba):
+
+1. **Cierre de trato desde el mercado**: al contactar/cerrar una oferta, un
+   paso opt-in ("¿se concretó el negocio?") que llame a `registrarTrato` con el
+   desenlace de entrega + una calificación de calidad. Es el gesto mínimo que
+   alimenta toda la red.
+2. **Control de compartición (3 niveles)**: el switch `PRIVADO / PARES /
+   CANONIZADO` por trato, con la copy de `SHARE_LEVEL_COPY`.
+3. **Vista "pregúntele al vecino"**: enganchar `preguntarAlVecino` en el agente
+   y el mercado; mostrar el par sugerido (nivel + cercanía) y el botón que abre
+   el canal (`abrirCanal`) cuando hay contacto público.
+4. **Un `useRedStore` (Zustand)**: fachada reactiva que hidrate desde
+   `cargarReputaciones` / `cargarGrafoSocial` y exponga las acciones (mismo
+   patrón que `useLoteStore` / `useCosechaStore`).
+5. **Tarjeta de reputación** del productor por cultivo (semáforo + fiabilidad +
+   calidad + n), reusando el idioma visual del `SemaforoConfianza`.

--- a/src/services/red/__tests__/redMatchmaking.test.js
+++ b/src/services/red/__tests__/redMatchmaking.test.js
@@ -1,0 +1,144 @@
+/**
+ * redMatchmaking.test.js — "pregúntele al vecino" + ruteo de dudas. Verifica
+ * cercanía, competencia ganada (no declarada) y la decisión de enrutar.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  proximidadTier,
+  findCompetentPeers,
+  buildMensajeVecino,
+  routeQuestion,
+} from '../redMatchmaking.js';
+import { NIVEL_REPUTACION } from '../types.js';
+
+const rep = (o = {}) => ({
+  productorHash: 'p1',
+  producto: 'Tomate',
+  productoNorm: 'tomate',
+  nivel: NIVEL_REPUTACION.VERDE,
+  score: 0.7,
+  vereda: 'El Curí',
+  municipio: 'Choachí',
+  nTransacciones: 4,
+  reciente: 2000,
+  ...o,
+});
+
+describe('proximidadTier', () => {
+  it('misma vereda = 3 (tolerante a tildes/mayúsculas)', () => {
+    expect(proximidadTier({ vereda: 'El Curí' }, { vereda: 'el curi' })).toBe(3);
+  });
+  it('mismo municipio, distinta vereda = 2', () => {
+    expect(proximidadTier(
+      { vereda: 'A', municipio: 'Choachí' },
+      { vereda: 'B', municipio: 'choachi' },
+    )).toBe(2);
+  });
+  it('más lejos = 1', () => {
+    expect(proximidadTier(
+      { vereda: 'A', municipio: 'Choachí' },
+      { vereda: 'B', municipio: 'Ubaque' },
+    )).toBe(1);
+  });
+});
+
+describe('findCompetentPeers', () => {
+  it('filtra por cultivo, excluye rojo y nuevo, y a uno mismo', () => {
+    const reputaciones = [
+      rep({ productorHash: 'p1', nivel: NIVEL_REPUTACION.VERDE }),
+      rep({ productorHash: 'p2', nivel: NIVEL_REPUTACION.ROJO }),
+      rep({ productorHash: 'p3', nivel: NIVEL_REPUTACION.NUEVO }),
+      rep({ productorHash: 'yo', nivel: NIVEL_REPUTACION.VERDE }),
+      rep({ productorHash: 'p4', producto: 'Mora', productoNorm: 'mora' }),
+    ];
+    const peers = findCompetentPeers(
+      { producto: 'Tomate', vereda: 'El Curí', excludeHash: 'yo' },
+      { reputaciones },
+    );
+    expect(peers.map((p) => p.productorHash)).toEqual(['p1']);
+  });
+
+  it('incluye nuevos si allowNuevo', () => {
+    const reputaciones = [rep({ productorHash: 'p3', nivel: NIVEL_REPUTACION.NUEVO })];
+    const peers = findCompetentPeers(
+      { producto: 'Tomate' },
+      { reputaciones, allowNuevo: true },
+    );
+    expect(peers).toHaveLength(1);
+  });
+
+  it('ordena por cercanía y luego por score', () => {
+    const reputaciones = [
+      rep({ productorHash: 'lejano', vereda: 'X', municipio: 'Otro', score: 0.95 }),
+      rep({ productorHash: 'vecino', vereda: 'El Curí', municipio: 'Choachí', score: 0.5 }),
+      rep({ productorHash: 'municipio', vereda: 'Y', municipio: 'Choachí', score: 0.9 }),
+    ];
+    const peers = findCompetentPeers(
+      { producto: 'Tomate', vereda: 'El Curí', municipio: 'Choachí' },
+      { reputaciones },
+    );
+    expect(peers.map((p) => p.productorHash)).toEqual(['vecino', 'municipio', 'lejano']);
+    expect(peers[0].proximidad).toBe(3);
+  });
+
+  it('sin producto no devuelve nada', () => {
+    expect(findCompetentPeers({ producto: '' }, { reputaciones: [rep()] })).toEqual([]);
+  });
+});
+
+describe('buildMensajeVecino', () => {
+  it('cita cultivo, vereda y síntoma en usted, sin revelar identidad', () => {
+    const msg = buildMensajeVecino({ producto: 'Tomate', vereda: 'El Curí', sintoma: 'gota' });
+    expect(msg).toContain('Tomate');
+    expect(msg).toContain('El Curí');
+    expect(msg).toContain('gota');
+    expect(msg).toContain('usted');
+  });
+  it('degrada sin síntoma ni vereda', () => {
+    const msg = buildMensajeVecino({ producto: 'Mora' });
+    expect(msg).toContain('Mora');
+    expect(typeof msg).toBe('string');
+  });
+});
+
+describe('routeQuestion', () => {
+  it('sin vecino competente → no rutea y no inventa contacto', () => {
+    const out = routeQuestion(
+      { producto: 'Tomate', agentConfident: false },
+      { reputaciones: [] },
+    );
+    expect(out.shouldRoute).toBe(false);
+    expect(out.peer).toBeNull();
+    expect(out.motivo).toBe('sin_vecino_competente');
+    expect(out.mensajeSugerido).toBeNull();
+  });
+
+  it('agente no sabe + hay candidato → rutea (agente_no_sabe)', () => {
+    const out = routeQuestion(
+      { producto: 'Tomate', vereda: 'X', municipio: 'Choachí', agentConfident: false },
+      { reputaciones: [rep({ productorHash: 'p2', vereda: 'Y', municipio: 'Choachí' })] },
+    );
+    expect(out.shouldRoute).toBe(true);
+    expect(out.peer.productorHash).toBe('p2');
+    expect(out.motivo).toBe('agente_no_sabe');
+    expect(out.mensajeSugerido).toContain('Tomate');
+  });
+
+  it('agente confiado pero vecino fuerte de la misma vereda → rutea (saber_local)', () => {
+    const out = routeQuestion(
+      { producto: 'Tomate', vereda: 'El Curí', municipio: 'Choachí', agentConfident: true },
+      { reputaciones: [rep({ productorHash: 'p2', vereda: 'El Curí', nivel: NIVEL_REPUTACION.VERDE })] },
+    );
+    expect(out.shouldRoute).toBe(true);
+    expect(out.motivo).toBe('saber_local');
+  });
+
+  it('agente confiado y solo vecino lejano/ámbar → responde el agente', () => {
+    const out = routeQuestion(
+      { producto: 'Tomate', vereda: 'El Curí', municipio: 'Choachí', agentConfident: true },
+      { reputaciones: [rep({ productorHash: 'p2', vereda: 'Otra', municipio: 'Otro', nivel: NIVEL_REPUTACION.AMBAR })] },
+    );
+    expect(out.shouldRoute).toBe(false);
+    expect(out.motivo).toBe('agente_responde');
+  });
+});

--- a/src/services/red/__tests__/redReputation.test.js
+++ b/src/services/red/__tests__/redReputation.test.js
@@ -1,0 +1,198 @@
+/**
+ * redReputation.test.js — "mercado → grafo + reputación". Verifica la math
+ * honesta (suavizado bayesiano, confianza por volumen, recencia) y que el grafo
+ * social se derive solo de los tratos compartibles.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeTerm,
+  computeReputacion,
+  groupTratos,
+  computeAllReputaciones,
+  buildSocialGraph,
+  __MODEL__,
+} from '../redReputation.js';
+import { NIVEL_REPUTACION, ENTREGA } from '../types.js';
+
+let seq = 0;
+const trato = (o = {}) => ({
+  id: `t${seq += 1}`,
+  productorHash: 'p1',
+  compradorHash: null,
+  producto: 'Tomate',
+  cultivoId: null,
+  categoria: 'hortaliza',
+  vereda: 'El Curí',
+  municipio: 'Choachí',
+  cantidad: 10,
+  unidad: 'kg',
+  entrega: ENTREGA.ENTREGADO,
+  calidad: null,
+  confirmadoPor: 'ambos',
+  shareLevel: 2,
+  createdAt: 1000,
+  ...o,
+});
+
+describe('normalizeTerm', () => {
+  it('minúsculas sin tildes y colapsa espacios', () => {
+    expect(normalizeTerm('  El  Curí ')).toBe('el curi');
+    expect(normalizeTerm('Tomate Chonto')).toBe('tomate chonto');
+  });
+});
+
+describe('computeReputacion — suavizado bayesiano', () => {
+  it('n=1 entregado queda "nuevo" y fiabilidad tirada hacia 0.5 (Laplace 2/3)', () => {
+    const rep = computeReputacion([trato()]);
+    expect(rep.nivel).toBe(NIVEL_REPUTACION.NUEVO);
+    expect(rep.fiabilidad).toBeCloseTo(2 / 3, 5);
+    expect(rep.nConfirmadas).toBe(1);
+  });
+
+  it('3 entregas cumplidas → verde con fiabilidad 0.8 (4/5)', () => {
+    const reps = computeReputacion([trato(), trato(), trato()]);
+    expect(reps.fiabilidad).toBeCloseTo(0.8, 5);
+    expect(reps.nivel).toBe(NIVEL_REPUTACION.VERDE);
+    expect(reps.nEntregados).toBe(3);
+  });
+
+  it('2 cumplidas + 1 fallida → ámbar (3/5 = 0.6)', () => {
+    const rep = computeReputacion([
+      trato(), trato(), trato({ entrega: ENTREGA.NO_ENTREGADO }),
+    ]);
+    expect(rep.fiabilidad).toBeCloseTo(0.6, 5);
+    expect(rep.nivel).toBe(NIVEL_REPUTACION.AMBAR);
+  });
+
+  it('fallas de entrega demostradas → rojo', () => {
+    const rep = computeReputacion([
+      trato({ entrega: ENTREGA.NO_ENTREGADO }),
+      trato({ entrega: ENTREGA.NO_ENTREGADO }),
+    ]);
+    expect(rep.fiabilidad).toBeCloseTo(0.25, 5); // (0+1)/(2+2)
+    expect(rep.nivel).toBe(NIVEL_REPUTACION.ROJO);
+  });
+
+  it('entrega parcial pesa 0.5', () => {
+    const rep = computeReputacion([
+      trato({ entrega: ENTREGA.PARCIAL }),
+      trato({ entrega: ENTREGA.PARCIAL }),
+    ]);
+    // sumaPeso=1, nConfirmadas=2 → (1+1)/(2+2)=0.5
+    expect(rep.fiabilidad).toBeCloseTo(0.5, 5);
+  });
+
+  it('los pendientes NO cuentan como confirmadas', () => {
+    const rep = computeReputacion([
+      trato(), trato(), trato({ entrega: ENTREGA.PENDIENTE }),
+    ]);
+    expect(rep.nTransacciones).toBe(3);
+    expect(rep.nConfirmadas).toBe(2);
+  });
+
+  it('calidad: promedio 1..5 y normalizada 0..1', () => {
+    const rep = computeReputacion([
+      trato({ calidad: 5 }), trato({ calidad: 3 }),
+    ]);
+    expect(rep.calidadPromedio).toBeCloseTo(4, 5);
+    expect(rep.calidadNorm).toBeCloseTo(0.75, 5); // (4-1)/4
+  });
+
+  it('sin calificaciones → calidad null (no inventa)', () => {
+    const rep = computeReputacion([trato(), trato()]);
+    expect(rep.calidadPromedio).toBeNull();
+    expect(rep.calidadNorm).toBeNull();
+  });
+
+  it('vereda predominante entre los tratos', () => {
+    const rep = computeReputacion([
+      trato({ vereda: 'El Curí' }),
+      trato({ vereda: 'El Curí' }),
+      trato({ vereda: 'Potrero' }),
+    ]);
+    expect(normalizeTerm(rep.vereda)).toBe('el curi');
+  });
+
+  it('score queda en [0,1]', () => {
+    const rep = computeReputacion([trato(), trato(), trato({ calidad: 5 })]);
+    expect(rep.score).toBeGreaterThanOrEqual(0);
+    expect(rep.score).toBeLessThanOrEqual(1);
+  });
+
+  it('recencia: un trato viejo baja el score (media vida)', () => {
+    const base = [trato(), trato(), trato()];
+    const now = 1000 + __MODEL__.HALF_LIFE_DIAS_DEFAULT * 24 * 60 * 60 * 1000;
+    const sinNow = computeReputacion(base).score;
+    const conRecencia = computeReputacion(base, { now }).score;
+    expect(conRecencia).toBeLessThan(sinNow);
+    expect(conRecencia).toBeCloseTo(sinNow * 0.5, 5);
+  });
+
+  it('input basura → reputación nueva sin lanzar', () => {
+    const rep = computeReputacion(null);
+    expect(rep.nivel).toBe(NIVEL_REPUTACION.NUEVO);
+    expect(rep.nTransacciones).toBe(0);
+  });
+});
+
+describe('groupTratos', () => {
+  it('agrupa por productor + producto normalizado y filtra privados', () => {
+    const grupos = groupTratos([
+      trato({ productorHash: 'p1', producto: 'Tomate', shareLevel: 2 }),
+      trato({ productorHash: 'p1', producto: 'tomate', shareLevel: 2 }), // mismo grupo
+      trato({ productorHash: 'p1', producto: 'Mora', shareLevel: 2 }),
+      trato({ productorHash: 'p2', producto: 'Tomate', shareLevel: 2 }),
+      trato({ productorHash: 'p1', producto: 'Tomate', shareLevel: 1 }), // privado: fuera
+    ]);
+    expect(grupos.get('p1::tomate')).toHaveLength(2);
+    expect(grupos.get('p1::mora')).toHaveLength(1);
+    expect(grupos.get('p2::tomate')).toHaveLength(1);
+  });
+});
+
+describe('computeAllReputaciones', () => {
+  it('una reputación por productor×producto, ordenada por score', () => {
+    const reps = computeAllReputaciones([
+      trato({ productorHash: 'p1', producto: 'Tomate' }),
+      trato({ productorHash: 'p1', producto: 'Tomate' }),
+      trato({ productorHash: 'p1', producto: 'Tomate' }),
+      trato({ productorHash: 'p2', producto: 'Tomate', entrega: ENTREGA.NO_ENTREGADO }),
+      trato({ productorHash: 'p2', producto: 'Tomate', entrega: ENTREGA.NO_ENTREGADO }),
+    ]);
+    expect(reps).toHaveLength(2);
+    expect(reps[0].productorHash).toBe('p1'); // mejor score primero
+    expect(reps[0].nivel).toBe(NIVEL_REPUTACION.VERDE);
+  });
+});
+
+describe('buildSocialGraph', () => {
+  it('deriva nodos + aristas solo de tratos compartibles', () => {
+    const g = buildSocialGraph([
+      trato({ productorHash: 'p1', producto: 'Tomate', vereda: 'El Curí', compradorHash: 'c1' }),
+      trato({ productorHash: 'p1', producto: 'Tomate', vereda: 'El Curí', compradorHash: 'c1', entrega: ENTREGA.NO_ENTREGADO }),
+      trato({ productorHash: 'p2', producto: 'Mora', vereda: 'Potrero', shareLevel: 1 }), // privado
+    ]);
+    expect(g.nodos.productores).toEqual(['p1']);
+    expect(g.nodos.cultivos).toContain('tomate');
+    expect(g.nodos.veredas).toContain('el curi');
+
+    const cultiva = g.cultiva.find((e) => e.productorHash === 'p1');
+    expect(cultiva.count).toBe(2);
+    expect(cultiva.entregados).toBe(1);
+
+    const ubic = g.ubicadoEn.find((e) => e.productorHash === 'p1');
+    expect(ubic.count).toBe(2);
+    expect(ubic.municipio).toBe('Choachí');
+
+    const entrego = g.entregoA.find((e) => e.compradorHash === 'c1');
+    expect(entrego.count).toBe(2);
+
+    expect(g.meta.tratos).toBe(3);
+    expect(g.meta.compartidos).toBe(2);
+  });
+
+  it('sin compradorHash no crea arista ENTREGO_A', () => {
+    const g = buildSocialGraph([trato({ compradorHash: null })]);
+    expect(g.entregoA).toHaveLength(0);
+  });
+});

--- a/src/services/red/__tests__/redService.test.js
+++ b/src/services/red/__tests__/redService.test.js
@@ -1,0 +1,153 @@
+/**
+ * redService.test.js — orquestación de la red. Mockea la persistencia y la
+ * identidad; usa el REAL construirContacto del mercado (verifica el reuse).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  save: vi.fn(),
+  getAll: vi.fn(),
+  computeOperatorHash: vi.fn(),
+  getCurrentOperatorHash: vi.fn(),
+}));
+
+vi.mock('../../../db/redTransactions.js', () => ({
+  redTransactions: { save: h.save, getAll: h.getAll },
+  nuevoTratoId: () => 'trato-x',
+}));
+
+vi.mock('../../operatorIdentityService.js', () => ({
+  computeOperatorHash: h.computeOperatorHash,
+  getCurrentOperatorHash: h.getCurrentOperatorHash,
+}));
+
+import {
+  buildTrato,
+  registrarTrato,
+  cargarReputaciones,
+  cargarGrafoSocial,
+  preguntarAlVecino,
+  abrirCanal,
+} from '../redService.js';
+import { NIVEL_REPUTACION, SHARE_LEVEL, ENTREGA } from '../types.js';
+
+const oferta = {
+  id: 'of1',
+  producto: 'Tomate chonto',
+  categoria: 'hortaliza',
+  vereda: 'El Curí',
+  municipio: 'Choachí',
+  cantidad: 30,
+  unidad: 'kg',
+};
+
+let seq = 0;
+const tratoTomate = (hash, o = {}) => ({
+  id: `t${seq += 1}`,
+  productorHash: hash,
+  compradorHash: null,
+  producto: 'Tomate',
+  productoNorm: 'tomate',
+  categoria: 'hortaliza',
+  vereda: 'El Curí',
+  municipio: 'Choachí',
+  cantidad: 10,
+  unidad: 'kg',
+  entrega: ENTREGA.ENTREGADO,
+  calidad: 5,
+  confirmadoPor: 'ambos',
+  shareLevel: SHARE_LEVEL.PARES,
+  createdAt: seq,
+  ...o,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.save.mockImplementation(async (r) => ({ ...r, id: r.id || 'trato-x', createdAt: r.createdAt || 1 }));
+  h.getAll.mockResolvedValue([]);
+  h.computeOperatorHash.mockImplementation(async (id) => `hash-${id}`);
+  h.getCurrentOperatorHash.mockReturnValue('hash-self');
+});
+
+describe('buildTrato (puro)', () => {
+  it('mapea una oferta del mercado a un trato con default PRIVADO', () => {
+    const t = buildTrato({ oferta, productorHash: 'p1' });
+    expect(t.ofertaId).toBe('of1');
+    expect(t.producto).toBe('Tomate chonto');
+    expect(t.vereda).toBe('El Curí');
+    expect(t.cantidad).toBe(30);
+    expect(t.entrega).toBe(ENTREGA.PENDIENTE);
+    expect(t.shareLevel).toBe(SHARE_LEVEL.PRIVADO);
+  });
+  it('clampa la calidad a 1..5 (o null)', () => {
+    expect(buildTrato({ oferta, productorHash: 'p1', calidad: 4 }).calidad).toBe(4);
+    expect(buildTrato({ oferta, productorHash: 'p1', calidad: 6 }).calidad).toBeNull();
+    expect(buildTrato({ oferta, productorHash: 'p1', calidad: 0 }).calidad).toBeNull();
+  });
+});
+
+describe('registrarTrato', () => {
+  it('pseudonimiza el productorId crudo y persiste', async () => {
+    const saved = await registrarTrato({
+      productorId: 'juan', oferta, entrega: ENTREGA.ENTREGADO, shareLevel: SHARE_LEVEL.PARES,
+    });
+    expect(h.computeOperatorHash).toHaveBeenCalledWith('juan');
+    expect(h.save).toHaveBeenCalledTimes(1);
+    expect(saved.productorHash).toBe('hash-juan');
+    expect(saved.shareLevel).toBe(SHARE_LEVEL.PARES);
+  });
+
+  it('usa el hash del operador actual si no se da identidad', async () => {
+    await registrarTrato({ oferta });
+    expect(h.save).toHaveBeenCalledWith(expect.objectContaining({ productorHash: 'hash-self' }));
+  });
+});
+
+describe('cargarReputaciones / cargarGrafoSocial', () => {
+  it('deriva reputaciones desde los tratos persistidos', async () => {
+    h.getAll.mockResolvedValue([
+      tratoTomate('hash-p2'), tratoTomate('hash-p2'), tratoTomate('hash-p2'),
+    ]);
+    const reps = await cargarReputaciones();
+    expect(reps).toHaveLength(1);
+    expect(reps[0].nivel).toBe(NIVEL_REPUTACION.VERDE);
+  });
+
+  it('deriva el grafo social', async () => {
+    h.getAll.mockResolvedValue([tratoTomate('hash-p2'), tratoTomate('hash-p3')]);
+    const g = await cargarGrafoSocial();
+    expect(g.nodos.productores.sort()).toEqual(['hash-p2', 'hash-p3']);
+  });
+});
+
+describe('preguntarAlVecino', () => {
+  it('rutea al vecino competente y excluye al operador actual', async () => {
+    h.getAll.mockResolvedValue([
+      tratoTomate('hash-p2'), tratoTomate('hash-p2'), tratoTomate('hash-p2'),
+      tratoTomate('hash-self'), tratoTomate('hash-self'), tratoTomate('hash-self'),
+    ]);
+    const out = await preguntarAlVecino({
+      producto: 'Tomate', vereda: 'El Curí', municipio: 'Choachí',
+      sintoma: 'gota', agentConfident: false,
+    });
+    expect(out.shouldRoute).toBe(true);
+    expect(out.peer.productorHash).toBe('hash-p2'); // nunca a uno mismo
+    expect(out.mensajeSugerido).toContain('Tomate');
+  });
+});
+
+describe('abrirCanal (reusa el contacto del mercado)', () => {
+  it('construye el wa.me si hay teléfono público', () => {
+    const canal = abrirCanal({ contactoTel: '3001234567', producto: 'Tomate' });
+    expect(canal).not.toBeNull();
+    expect(canal.href).toContain('https://wa.me/573001234567');
+  });
+  it('respeta un mensaje personalizado', () => {
+    const canal = abrirCanal({ contactoTel: '3001234567' }, { mensaje: 'Hola vecino' });
+    expect(decodeURIComponent(canal.href)).toContain('Hola vecino');
+  });
+  it('sin teléfono público → null (no filtra números sin consentimiento)', () => {
+    expect(abrirCanal({ producto: 'Tomate' })).toBeNull();
+    expect(abrirCanal(null)).toBeNull();
+  });
+});

--- a/src/services/red/__tests__/redSharing.test.js
+++ b/src/services/red/__tests__/redSharing.test.js
@@ -1,0 +1,114 @@
+/**
+ * redSharing.test.js — compuerta anti-extractiva de la red (opt-in 3 niveles).
+ * Verifica el invariante duro: nada privado (nivel 1) cruza a la red, y la
+ * proyección a pares recorta lo que no les corresponde.
+ */
+import { describe, it, expect } from 'vitest';
+import { SHARE_LEVEL } from '../types.js';
+import {
+  normalizeShareLevel,
+  withDefaultShareLevel,
+  isShareable,
+  filterShareable,
+  redactForPeers,
+} from '../redSharing.js';
+
+const trato = (o = {}) => ({
+  id: 't1',
+  productorHash: 'p1',
+  compradorHash: 'c1',
+  ofertaId: 'of1',
+  producto: 'Tomate',
+  categoria: 'hortaliza',
+  vereda: 'El Curí',
+  municipio: 'Choachí',
+  cantidad: 20,
+  unidad: 'kg',
+  entrega: 'entregado',
+  calidad: 5,
+  confirmadoPor: 'ambos',
+  nota: 'texto libre privado',
+  shareLevel: 2,
+  createdAt: 1000,
+  ...o,
+});
+
+describe('normalizeShareLevel', () => {
+  it('acepta 2 (PARES) y 3 (CANONIZADO)', () => {
+    expect(normalizeShareLevel(2)).toBe(SHARE_LEVEL.PARES);
+    expect(normalizeShareLevel(3)).toBe(SHARE_LEVEL.CANONIZADO);
+    expect(normalizeShareLevel('2')).toBe(2);
+  });
+  it('cae a PRIVADO (1) ante cualquier valor inválido/ausente', () => {
+    expect(normalizeShareLevel(undefined)).toBe(SHARE_LEVEL.PRIVADO);
+    expect(normalizeShareLevel(null)).toBe(1);
+    expect(normalizeShareLevel(0)).toBe(1);
+    expect(normalizeShareLevel(5)).toBe(1);
+    expect(normalizeShareLevel('basura')).toBe(1);
+  });
+});
+
+describe('withDefaultShareLevel', () => {
+  it('estampa PRIVADO por default y no muta el original', () => {
+    const original = { producto: 'Mora' };
+    const out = withDefaultShareLevel(original);
+    expect(out.shareLevel).toBe(1);
+    expect(original.shareLevel).toBeUndefined();
+  });
+  it('preserva un nivel válido', () => {
+    expect(withDefaultShareLevel({ shareLevel: 2 }).shareLevel).toBe(2);
+  });
+  it('tolera no-objeto', () => {
+    expect(withDefaultShareLevel(null).shareLevel).toBe(1);
+  });
+});
+
+describe('isShareable', () => {
+  it('exige nivel PARES (2) por default', () => {
+    expect(isShareable(trato({ shareLevel: 1 }))).toBe(false);
+    expect(isShareable(trato({ shareLevel: 2 }))).toBe(true);
+    expect(isShareable(trato({ shareLevel: 3 }))).toBe(true);
+  });
+  it('respeta un minLevel personalizado', () => {
+    expect(isShareable(trato({ shareLevel: 2 }), { minLevel: 3 })).toBe(false);
+    expect(isShareable(trato({ shareLevel: 3 }), { minLevel: 3 })).toBe(true);
+  });
+  it('rechaza input basura', () => {
+    expect(isShareable(null)).toBe(false);
+    expect(isShareable(42)).toBe(false);
+  });
+});
+
+describe('filterShareable', () => {
+  it('deja solo los tratos compartibles', () => {
+    const lista = [
+      trato({ id: 'a', shareLevel: 1 }),
+      trato({ id: 'b', shareLevel: 2 }),
+      trato({ id: 'c', shareLevel: 3 }),
+    ];
+    expect(filterShareable(lista).map((t) => t.id)).toEqual(['b', 'c']);
+  });
+  it('tolera no-array', () => {
+    expect(filterShareable(undefined)).toEqual([]);
+  });
+});
+
+describe('redactForPeers', () => {
+  it('devuelve null para un trato privado (defensa en profundidad)', () => {
+    expect(redactForPeers(trato({ shareLevel: 1 }))).toBeNull();
+  });
+  it('recorta comprador, oferta y texto libre; conserva lo de reputación', () => {
+    const red = redactForPeers(trato({ shareLevel: 2 }));
+    expect(red).not.toBeNull();
+    // Se conserva lo necesario para reputación/matchmaking:
+    expect(red.productorHash).toBe('p1');
+    expect(red.producto).toBe('Tomate');
+    expect(red.vereda).toBe('El Curí');
+    expect(red.entrega).toBe('entregado');
+    expect(red.calidad).toBe(5);
+    // Se recorta lo que los pares NO necesitan:
+    expect(red).not.toHaveProperty('compradorHash');
+    expect(red).not.toHaveProperty('ofertaId');
+    expect(red).not.toHaveProperty('nota');
+  });
+});

--- a/src/services/red/index.js
+++ b/src/services/red/index.js
@@ -1,0 +1,21 @@
+/**
+ * services/red — RED humana de Chagra (campesino ↔ campesino). Backend del MVP.
+ *
+ * Barrel público del módulo. La "cara" (UI) la construye aparte quien consuma
+ * estos servicios; aquí vive solo la capa de datos + lógica.
+ *
+ * Mapa rápido:
+ *   - types.js          — constantes canónicas + typedefs (SHARE_LEVEL, ENTREGA…).
+ *   - redSharing.js     — compuerta anti-extractiva (opt-in 3 niveles).
+ *   - redReputation.js  — mercado → grafo social + reputación ganada (puro).
+ *   - redMatchmaking.js — "pregúntele al vecino" + ruteo de dudas (puro).
+ *   - redService.js     — orquestación con I/O (persistencia + contacto directo).
+ *
+ * @module services/red
+ */
+
+export * from './types.js';
+export * from './redSharing.js';
+export * from './redReputation.js';
+export * from './redMatchmaking.js';
+export * from './redService.js';

--- a/src/services/red/redMatchmaking.js
+++ b/src/services/red/redMatchmaking.js
@@ -1,0 +1,193 @@
+/**
+ * red/redMatchmaking.js — "Pregúntele al vecino" + ruteo de dudas. Lógica PURA
+ * (cero red, cero I/O).
+ *
+ * Dado un problema (cultivo × vereda × síntoma), encuentra al PAR competente y
+ * CERCANO — uno que ya DEMOSTRÓ éxito con ese cultivo en tratos del mercado — y
+ * decide si conviene enrutarle la duda. El asistente enruta al par cuando no
+ * sabe o cuando la duda es local-específica (donde el saber del vecino de la
+ * misma vereda vale más que una respuesta genérica).
+ *
+ * La competencia NO se declara: sale de la reputación GANADA (redReputation).
+ * Un vecino "competente" es el que entregó ese cultivo con buena fiabilidad, no
+ * el que dice saber.
+ *
+ * @module services/red/redMatchmaking
+ */
+
+import { NIVEL_REPUTACION } from './types.js';
+import { normalizeTerm } from './redReputation.js';
+
+/** Etiqueta humana de cada tier de cercanía (usted, español de Colombia). */
+export const PROXIMIDAD_LABEL = Object.freeze({
+  3: 'de su misma vereda',
+  2: 'de su municipio',
+  1: 'de la región',
+});
+
+/** Niveles de reputación que cuentan como "competente" (demostró algo). */
+const NIVELES_COMPETENTES = new Set([NIVEL_REPUTACION.VERDE, NIVEL_REPUTACION.AMBAR]);
+
+/**
+ * Tier de cercanía entre el que pregunta y un par. 3 misma vereda · 2 mismo
+ * municipio · 1 más lejos. Comparación tolerante (sin tildes/mayúsculas).
+ *
+ * @param {{vereda?:string, municipio?:string}} query
+ * @param {{vereda?:string, municipio?:string}} peer
+ * @returns {1|2|3}
+ */
+export function proximidadTier(query, peer) {
+  const qv = normalizeTerm(query?.vereda);
+  const pv = normalizeTerm(peer?.vereda);
+  if (qv && pv && qv === pv) return 3;
+  const qm = normalizeTerm(query?.municipio);
+  const pm = normalizeTerm(peer?.municipio);
+  if (qm && pm && qm === pm) return 2;
+  return 1;
+}
+
+/**
+ * Encuentra pares competentes y cercanos para un cultivo. Ordena por cercanía y
+ * luego por score de reputación (y recencia como desempate). Función pura.
+ *
+ * @param {Object} problema
+ * @param {string} problema.producto — cultivo en cuestión.
+ * @param {string} [problema.vereda]
+ * @param {string} [problema.municipio]
+ * @param {string} [problema.excludeHash] — no sugerirse a uno mismo.
+ * @param {Object} contexto
+ * @param {Array<import('./types.js').Reputacion>} contexto.reputaciones
+ * @param {boolean} [contexto.allowNuevo=false] — incluir productores sin historial.
+ * @returns {Array<import('./types.js').PeerMatch>}
+ */
+export function findCompetentPeers(problema, contexto) {
+  const { producto, vereda = '', municipio = '', excludeHash = '' } = problema || {};
+  const reputaciones = Array.isArray(contexto?.reputaciones) ? contexto.reputaciones : [];
+  const allowNuevo = Boolean(contexto?.allowNuevo);
+  const productoNorm = normalizeTerm(producto);
+  if (!productoNorm) return [];
+
+  const matches = [];
+  for (const rep of reputaciones) {
+    if (!rep || typeof rep !== 'object') continue;
+    if (rep.productoNorm !== productoNorm) continue;
+    if (excludeHash && rep.productorHash === excludeHash) continue;
+    const competente = NIVELES_COMPETENTES.has(rep.nivel)
+      || (allowNuevo && rep.nivel === NIVEL_REPUTACION.NUEVO);
+    if (!competente) continue;
+
+    const proximidad = proximidadTier({ vereda, municipio }, rep);
+    matches.push({
+      productorHash: rep.productorHash,
+      producto: rep.producto,
+      nivel: rep.nivel,
+      score: rep.score,
+      proximidad,
+      proximidadLabel: PROXIMIDAD_LABEL[proximidad],
+      vereda: rep.vereda,
+      municipio: rep.municipio,
+      nTransacciones: rep.nTransacciones,
+      reciente: rep.reciente,
+    });
+  }
+
+  matches.sort(
+    (a, b) => b.proximidad - a.proximidad || b.score - a.score || b.reciente - a.reciente,
+  );
+  return matches;
+}
+
+/**
+ * Construye el mensaje pre-llenado para enviarle al vecino. Español de Colombia
+ * en usted, cálido y directo, SIN revelar la identidad del par a quien
+ * pregunta y sin datos sensibles. Best-effort con el síntoma si viene.
+ *
+ * @param {{producto:string, vereda?:string, sintoma?:string}} params
+ * @returns {string}
+ */
+export function buildMensajeVecino({ producto, vereda = '', sintoma = '' } = {}) {
+  const cultivo = String(producto || 'este cultivo').trim();
+  const lugar = String(vereda || '').trim();
+  const problema = String(sintoma || '').trim();
+
+  const donde = lugar ? ` por la vereda ${lugar}` : '';
+  const conProblema = problema
+    ? ` y se nos presentó ${problema}`
+    : '';
+  return (
+    `Buenas. Le escribo desde la red de Chagra. Estamos con ${cultivo}${donde}${conProblema}. `
+    + `Vi que usted tiene experiencia con ${cultivo}. ¿Le puedo preguntar cómo lo ha manejado?`
+  );
+}
+
+/**
+ * Decide si enrutar una duda a un vecino y a cuál. Regla del DR: el asistente
+ * enruta cuando NO sabe (agentConfident=false) o cuando la duda es
+ * LOCAL-ESPECÍFICA (hay un vecino fuerte de la misma vereda, cuyo saber de
+ * terreno vale más que una respuesta genérica) aunque el agente crea saber.
+ *
+ * Devuelve una decisión honesta y explicable: si no hay vecino competente,
+ * `shouldRoute=false` y `peer=null` (no inventa un contacto).
+ *
+ * @param {Object} problema
+ * @param {string} problema.producto
+ * @param {string} [problema.vereda]
+ * @param {string} [problema.municipio]
+ * @param {string} [problema.sintoma]
+ * @param {boolean} [problema.agentConfident=true] — ¿el agente cree tener respuesta?
+ * @param {string} [problema.excludeHash]
+ * @param {Object} contexto — { reputaciones, allowNuevo }
+ * @returns {{ shouldRoute:boolean, peer:(import('./types.js').PeerMatch|null),
+ *   motivo:string, mensajeSugerido:(string|null),
+ *   candidatos:Array<import('./types.js').PeerMatch> }}
+ */
+export function routeQuestion(problema, contexto) {
+  const {
+    producto,
+    vereda = '',
+    municipio = '',
+    sintoma = '',
+    agentConfident = true,
+    excludeHash = '',
+  } = problema || {};
+
+  const candidatos = findCompetentPeers(
+    { producto, vereda, municipio, excludeHash },
+    contexto,
+  );
+
+  if (candidatos.length === 0) {
+    return {
+      shouldRoute: false,
+      peer: null,
+      motivo: 'sin_vecino_competente',
+      mensajeSugerido: null,
+      candidatos,
+    };
+  }
+
+  const top = candidatos[0];
+  const vecinoLocalFuerte =
+    top.proximidad === 3 && top.nivel === NIVEL_REPUTACION.VERDE;
+
+  // Enruta si el agente no sabe, o si hay un saber local fuerte que aportar.
+  const shouldRoute = !agentConfident || vecinoLocalFuerte;
+  if (!shouldRoute) {
+    return {
+      shouldRoute: false,
+      peer: null,
+      motivo: 'agente_responde',
+      mensajeSugerido: null,
+      candidatos,
+    };
+  }
+
+  const motivo = !agentConfident ? 'agente_no_sabe' : 'saber_local';
+  return {
+    shouldRoute: true,
+    peer: top,
+    motivo,
+    mensajeSugerido: buildMensajeVecino({ producto, vereda, sintoma }),
+    candidatos,
+  };
+}

--- a/src/services/red/redReputation.js
+++ b/src/services/red/redReputation.js
@@ -1,0 +1,343 @@
+/**
+ * red/redReputation.js — el corazón "mercado → grafo + reputación".
+ *
+ * Lógica PURA (cero red, cero I/O, cero React) que convierte una lista de
+ * TRATOS del mercado en (a) el grafo social productor–cultivo–vereda y (b) la
+ * reputación GANADA de cada productor por cultivo. La reputación se ancla a
+ * HECHOS verificables de los tratos (¿entregó?, ¿qué calidad calificó el
+ * comprador?), NUNCA a votos ni a autopercepción.
+ *
+ * Todo lo derivado aquí es cache reconstruible (ADR-019: el log de tratos es la
+ * fuente de verdad; grafo y reputación se recomputan cuando haga falta).
+ *
+ * ── Régimen del dominio (power laws) ──────────────────────────────────────
+ * La actividad de mercado en un piloto rural es de COLA PESADA: unos pocos
+ * productores concentran la mayoría de los tratos y muchos tienen 1–2. Por eso
+ * NO optimizamos el "promedio": usamos suavizado bayesiano para que un n muy
+ * chico no dispare la reputación a 1.0, y un factor de confianza por volumen
+ * para el ranking. Resiliencia > exactitud puntual.
+ *
+ * ── Supuesto de Markov ────────────────────────────────────────────────────
+ * La fiabilidad reciente de un productor se toma como predictor de su fiabilidad
+ * próxima (cadena de Markov de orden 1 sobre su conducta de entrega). VIOLACIÓN
+ * conocida: la conducta NO es estacionaria — cambia de tierra, de práctica o
+ * enfrenta una mala cosecha climática. MITIGACIÓN: (1) decaimiento por recencia
+ * (media vida configurable) para que un acierto viejo pese menos; (2) suavizado
+ * + factor de confianza para que un solo dato no domine. Sin esta sección el
+ * módulo sería una caja opaca.
+ *
+ * @module services/red/redReputation
+ */
+
+import { NIVEL_REPUTACION, ENTREGA } from './types.js';
+import { filterShareable } from './redSharing.js';
+
+// ── Parámetros del modelo (documentados y testeables) ─────────────────────
+
+/** Prior Beta(1,1): neutral. Con n=0 la fiabilidad queda en 0.5 (desconocida). */
+const PRIOR_ENTREGA = 1;
+/** Constante de confianza por volumen: conf = n / (n + K). K=3 → n=3 da 0.5. */
+const K_CONFIANZA = 3;
+/** Media vida de recencia por default (días): un año. */
+const HALF_LIFE_DIAS_DEFAULT = 365;
+/** Mínimo de entregas resueltas para salir de "nuevo". */
+const MIN_CONFIRMADAS = 2;
+/** Umbrales del semáforo humano. */
+const UMBRAL_VERDE = 0.8;
+const UMBRAL_AMBAR = 0.5;
+const UMBRAL_CALIDAD_VERDE = 0.6;
+/** Pesos del compuesto núcleo (fiabilidad vs calidad) cuando hay calidad. */
+const PESO_FIABILIDAD = 0.6;
+const PESO_CALIDAD = 0.4;
+
+const MS_POR_DIA = 24 * 60 * 60 * 1000;
+
+/** Normaliza un término para agrupar/matchear (minúsculas, sin tildes). */
+export function normalizeTerm(value) {
+  return String(value ?? '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+/** Peso de entrega de un trato: entregado 1, parcial 0.5, resto 0. */
+function pesoEntrega(entrega) {
+  if (entrega === ENTREGA.ENTREGADO) return 1;
+  if (entrega === ENTREGA.PARCIAL) return 0.5;
+  return 0;
+}
+
+/**
+ * Valor predominante (moda) de un campo entre una lista de tratos, con
+ * desempate por el trato más reciente. Ignora vacíos.
+ */
+function predominant(tratos, field) {
+  const counts = new Map();
+  let bestRecent = { value: '', ts: -Infinity };
+  for (const t of tratos) {
+    const raw = t?.[field];
+    const value = typeof raw === 'string' ? raw.trim() : '';
+    if (!value) continue;
+    const key = normalizeTerm(value);
+    const prev = counts.get(key) || { value, count: 0 };
+    prev.count += 1;
+    counts.set(key, prev);
+    const ts = Number(t?.createdAt) || 0;
+    if (ts > bestRecent.ts) bestRecent = { value, ts };
+  }
+  let best = null;
+  for (const entry of counts.values()) {
+    if (!best || entry.count > best.count) best = entry;
+  }
+  if (!best) return '';
+  // Desempate: si hay empate de conteo, gana el del trato más reciente.
+  let tied = 0;
+  for (const entry of counts.values()) if (entry.count === best.count) tied += 1;
+  return tied > 1 ? bestRecent.value : best.value;
+}
+
+/** Factor de recencia 0..1 por decaimiento exponencial (1 si no hay `now`). */
+function factorRecencia(reciente, now, halfLifeDias) {
+  if (!Number.isFinite(now)) return 1;
+  const dias = Math.max(0, (now - reciente) / MS_POR_DIA);
+  const hl = halfLifeDias > 0 ? halfLifeDias : HALF_LIFE_DIAS_DEFAULT;
+  return Math.pow(0.5, dias / hl);
+}
+
+/**
+ * Deriva el nivel (semáforo humano) + motivo a partir de los hechos.
+ * @returns {{ nivel: string, motivo: string }}
+ */
+function derivarNivel({ nConfirmadas, fiabilidad, calidadNorm }) {
+  if (nConfirmadas < MIN_CONFIRMADAS) {
+    return { nivel: NIVEL_REPUTACION.NUEVO, motivo: 'sin_historial_suficiente' };
+  }
+  const calidadOk = calidadNorm == null || calidadNorm >= UMBRAL_CALIDAD_VERDE;
+  if (fiabilidad >= UMBRAL_VERDE && calidadOk) {
+    return { nivel: NIVEL_REPUTACION.VERDE, motivo: 'entrega_pareja' };
+  }
+  if (fiabilidad >= UMBRAL_AMBAR) {
+    const motivo = calidadNorm != null && calidadNorm < UMBRAL_CALIDAD_VERDE
+      ? 'calidad_dispareja'
+      : 'entrega_parcial';
+    return { nivel: NIVEL_REPUTACION.AMBAR, motivo };
+  }
+  return { nivel: NIVEL_REPUTACION.ROJO, motivo: 'fallas_de_entrega' };
+}
+
+/**
+ * Computa la reputación de UN productor para UN producto a partir de sus
+ * tratos (ya filtrados por productor+producto, o se filtra aquí por los campos
+ * dados). Función pura y total: input basura → reputación "nueva" honesta.
+ *
+ * @param {Array<Object>} tratos — tratos del grupo (mismos productorHash+producto).
+ * @param {Object} [opts]
+ * @param {number} [opts.now] — epoch ms para el factor de recencia (opcional).
+ * @param {number} [opts.halfLifeDias]
+ * @returns {import('./types.js').Reputacion}
+ */
+export function computeReputacion(tratos, opts = {}) {
+  const lista = Array.isArray(tratos) ? tratos.filter((t) => t && typeof t === 'object') : [];
+  const { now = NaN, halfLifeDias = HALF_LIFE_DIAS_DEFAULT } = opts;
+
+  const productorHash = lista[0]?.productorHash || '';
+  const producto = lista[0]?.producto || '';
+
+  const confirmadas = lista.filter((t) => t.entrega && t.entrega !== ENTREGA.PENDIENTE);
+  const nConfirmadas = confirmadas.length;
+  let nEntregados = 0;
+  let sumaPeso = 0;
+  for (const t of confirmadas) {
+    const w = pesoEntrega(t.entrega);
+    sumaPeso += w;
+    if (w >= 1) nEntregados += 1;
+  }
+
+  // Fiabilidad: media bayesiana con prior neutral (n bajo tiende a 0.5).
+  const fiabilidad = (sumaPeso + PRIOR_ENTREGA) / (nConfirmadas + 2 * PRIOR_ENTREGA);
+
+  // Calidad: promedio de las calificaciones 1..5 presentes.
+  const ratings = lista
+    .map((t) => Number(t.calidad))
+    .filter((n) => Number.isFinite(n) && n >= 1 && n <= 5);
+  const calidadPromedio = ratings.length
+    ? ratings.reduce((a, b) => a + b, 0) / ratings.length
+    : null;
+  const calidadNorm = calidadPromedio == null ? null : (calidadPromedio - 1) / 4;
+
+  const reciente = lista.reduce((mx, t) => Math.max(mx, Number(t.createdAt) || 0), 0);
+
+  const confianza = nConfirmadas / (nConfirmadas + K_CONFIANZA);
+  const recencia = factorRecencia(reciente, now, halfLifeDias);
+  const core = calidadNorm != null
+    ? PESO_FIABILIDAD * fiabilidad + PESO_CALIDAD * calidadNorm
+    : fiabilidad;
+  const score = Math.max(0, Math.min(1, core * (0.5 + 0.5 * confianza) * recencia));
+
+  const { nivel, motivo } = derivarNivel({ nConfirmadas, fiabilidad, calidadNorm });
+
+  return {
+    productorHash,
+    producto,
+    productoNorm: normalizeTerm(producto),
+    vereda: predominant(lista, 'vereda'),
+    municipio: predominant(lista, 'municipio'),
+    nTransacciones: lista.length,
+    nConfirmadas,
+    nEntregados,
+    fiabilidad,
+    calidadPromedio,
+    calidadNorm,
+    reciente,
+    score,
+    nivel,
+    motivo,
+  };
+}
+
+/**
+ * Agrupa una lista de tratos por (productorHash + producto normalizado). Solo
+ * considera los COMPARTIBLES (pasa la compuerta anti-extractiva). Devuelve un
+ * Map keyed por `"<productorHash>::<productoNorm>"`.
+ *
+ * @param {Array<Object>} tratos
+ * @param {{ minLevel?: number }} [opts]
+ * @returns {Map<string, Array<Object>>}
+ */
+export function groupTratos(tratos, opts = {}) {
+  const compartibles = filterShareable(tratos, opts);
+  const grupos = new Map();
+  for (const t of compartibles) {
+    const hash = t.productorHash || '';
+    if (!hash) continue;
+    const key = `${hash}::${normalizeTerm(t.producto)}`;
+    const bucket = grupos.get(key);
+    if (bucket) bucket.push(t);
+    else grupos.set(key, [t]);
+  }
+  return grupos;
+}
+
+/**
+ * Computa TODAS las reputaciones (una por productor×producto) desde la lista
+ * cruda de tratos. Aplica la compuerta anti-extractiva internamente.
+ *
+ * @param {Array<Object>} tratos
+ * @param {Object} [opts] — { now, halfLifeDias, minLevel }
+ * @returns {Array<import('./types.js').Reputacion>}
+ */
+export function computeAllReputaciones(tratos, opts = {}) {
+  const grupos = groupTratos(tratos, opts);
+  const out = [];
+  for (const bucket of grupos.values()) {
+    out.push(computeReputacion(bucket, opts));
+  }
+  // Orden estable útil para UI/tests: mejor score primero.
+  out.sort((a, b) => b.score - a.score || b.reciente - a.reciente);
+  return out;
+}
+
+/**
+ * Construye el grafo social (nodos + aristas agregadas) desde los tratos
+ * compartibles. CULTIVA (productor→cultivo), EN (productor→vereda), ENTREGO_A
+ * (productor→comprador).
+ *
+ * @param {Array<Object>} tratos
+ * @param {{ minLevel?: number }} [opts]
+ * @returns {import('./types.js').SocialGraph}
+ */
+export function buildSocialGraph(tratos, opts = {}) {
+  const total = Array.isArray(tratos) ? tratos.length : 0;
+  const compartibles = filterShareable(tratos, opts);
+
+  const productores = new Set();
+  const cultivos = new Set();
+  const veredas = new Set();
+  const cultivaMap = new Map(); // hash::productoNorm -> arista
+  const ubicadoMap = new Map(); // hash::veredaNorm -> arista
+  const entregoMap = new Map(); // hash::comprador -> arista
+
+  for (const t of compartibles) {
+    const hash = t.productorHash || '';
+    if (!hash) continue;
+    productores.add(hash);
+
+    const producto = t.producto || '';
+    const pNorm = normalizeTerm(producto);
+    if (pNorm) {
+      cultivos.add(pNorm);
+      const key = `${hash}::${pNorm}`;
+      const arista = cultivaMap.get(key) || {
+        productorHash: hash,
+        producto,
+        cultivoId: t.cultivoId ?? null,
+        count: 0,
+        entregados: 0,
+        reciente: 0,
+      };
+      arista.count += 1;
+      if (pesoEntrega(t.entrega) >= 1) arista.entregados += 1;
+      arista.reciente = Math.max(arista.reciente, Number(t.createdAt) || 0);
+      if (!arista.cultivoId && t.cultivoId) arista.cultivoId = t.cultivoId;
+      cultivaMap.set(key, arista);
+    }
+
+    const vereda = (t.vereda || '').trim();
+    if (vereda) {
+      const vNorm = normalizeTerm(vereda);
+      veredas.add(vNorm);
+      const key = `${hash}::${vNorm}`;
+      const arista = ubicadoMap.get(key) || {
+        productorHash: hash,
+        vereda,
+        municipio: t.municipio || '',
+        count: 0,
+      };
+      arista.count += 1;
+      ubicadoMap.set(key, arista);
+    }
+
+    const comprador = t.compradorHash || '';
+    if (comprador) {
+      const key = `${hash}::${comprador}`;
+      const arista = entregoMap.get(key) || {
+        productorHash: hash,
+        compradorHash: comprador,
+        count: 0,
+      };
+      arista.count += 1;
+      entregoMap.set(key, arista);
+    }
+  }
+
+  return {
+    nodos: {
+      productores: [...productores],
+      cultivos: [...cultivos],
+      veredas: [...veredas],
+    },
+    cultiva: [...cultivaMap.values()],
+    ubicadoEn: [...ubicadoMap.values()],
+    entregoA: [...entregoMap.values()],
+    meta: {
+      tratos: total,
+      compartidos: compartibles.length,
+      minShareLevel: opts.minLevel ?? 2,
+    },
+  };
+}
+
+/** Constantes del modelo expuestas para test/telemetría (no reflectar closures). */
+export const __MODEL__ = Object.freeze({
+  PRIOR_ENTREGA,
+  K_CONFIANZA,
+  HALF_LIFE_DIAS_DEFAULT,
+  MIN_CONFIRMADAS,
+  UMBRAL_VERDE,
+  UMBRAL_AMBAR,
+  UMBRAL_CALIDAD_VERDE,
+  PESO_FIABILIDAD,
+  PESO_CALIDAD,
+});

--- a/src/services/red/redService.js
+++ b/src/services/red/redService.js
@@ -1,0 +1,153 @@
+/**
+ * red/redService.js — ORQUESTACIÓN de la red humana. Es la única capa con I/O:
+ * ata la persistencia (db/redTransactions) con la lógica pura (redReputation,
+ * redMatchmaking, redSharing) y REUSA lo que el mercado ya tiene (construir el
+ * contacto directo) y la identidad pseudonimizada del operador (Ley 1581).
+ *
+ * Pipeline "mercado → grafo + reputación":
+ *   1. Un negocio del mercado se cierra → se registra un TRATO (hecho).
+ *   2. Grafo social y reputación se DERIVAN de los tratos compartibles.
+ *   3. "Pregúntele al vecino" rutea una duda al par competente y cercano.
+ *
+ * El contacto con el par NO expone su teléfono a menos que el par lo haya hecho
+ * público (opt-in, mismo canal directo del mercado). Sin ese consentimiento, el
+ * ruteo entrega solo la intención + el mensaje sugerido, nunca un número.
+ *
+ * @module services/red/redService
+ */
+
+import { redTransactions } from '../../db/redTransactions.js';
+import { construirContacto } from '../marketplaceService.js';
+import { computeOperatorHash, getCurrentOperatorHash } from '../operatorIdentityService.js';
+import { ENTREGA, CONFIRMADO_POR } from './types.js';
+import { withDefaultShareLevel } from './redSharing.js';
+import { computeAllReputaciones, buildSocialGraph } from './redReputation.js';
+import { routeQuestion } from './redMatchmaking.js';
+
+/**
+ * Construye un TRATO a partir de una oferta del mercado + el desenlace. PURO:
+ * no persiste ni genera id (eso lo hace la capa de store). Garantiza el
+ * invariante "privado por default" vía withDefaultShareLevel.
+ *
+ * @param {Object} params
+ * @param {Object} [params.oferta] — registro de marketplace_ofertas.
+ * @param {string} params.productorHash — id pseudonimizado del vendedor.
+ * @param {string|null} [params.compradorHash]
+ * @param {string} [params.entrega] — ENTREGA.* (default PENDIENTE).
+ * @param {number|null} [params.calidad] — 1..5 (default null).
+ * @param {string} [params.confirmadoPor] — CONFIRMADO_POR.* (default PRODUCTOR).
+ * @param {number} [params.shareLevel] — nivel opt-in (default PRIVADO).
+ * @param {string|null} [params.cultivoId]
+ * @returns {import('./types.js').RedTransaction}
+ */
+export function buildTrato({
+  oferta = {},
+  productorHash,
+  compradorHash = null,
+  entrega = ENTREGA.PENDIENTE,
+  calidad = null,
+  confirmadoPor = CONFIRMADO_POR.PRODUCTOR,
+  shareLevel,
+  cultivoId = null,
+}) {
+  const cal = Number(calidad);
+  return withDefaultShareLevel({
+    ofertaId: oferta?.id ?? null,
+    productorHash: productorHash || '',
+    compradorHash: compradorHash || null,
+    producto: oferta?.producto ?? '',
+    cultivoId: cultivoId ?? oferta?.cultivoId ?? null,
+    categoria: oferta?.categoria ?? '',
+    vereda: oferta?.vereda ?? '',
+    municipio: oferta?.municipio ?? '',
+    cantidad: Number(oferta?.cantidad) || 0,
+    unidad: oferta?.unidad ?? '',
+    entrega,
+    calidad: Number.isFinite(cal) && cal >= 1 && cal <= 5 ? cal : null,
+    confirmadoPor,
+    shareLevel,
+  });
+}
+
+/**
+ * Resuelve un hash de productor: si viene `productorHash` lo usa; si viene
+ * `productorId` crudo, lo pseudonimiza con operatorIdentityService.
+ * @param {{productorHash?:string, productorId?:string}} input
+ * @returns {Promise<string>}
+ */
+async function resolveProductorHash(input) {
+  if (input?.productorHash) return input.productorHash;
+  if (input?.productorId) return computeOperatorHash(input.productorId);
+  const current = getCurrentOperatorHash();
+  if (current) return current;
+  throw new Error('trato sin identidad de productor');
+}
+
+/**
+ * Registra un TRATO: resuelve la identidad, lo construye y lo persiste.
+ * @param {Object} input — ver buildTrato + { productorId? }.
+ * @returns {Promise<import('./types.js').RedTransaction>}
+ */
+export async function registrarTrato(input) {
+  const productorHash = await resolveProductorHash(input);
+  const trato = buildTrato({ ...input, productorHash });
+  return redTransactions.save(trato);
+}
+
+/**
+ * Carga todas las reputaciones derivadas (productor×producto) desde los tratos.
+ * @param {Object} [opts] — { now, halfLifeDias, minLevel }
+ * @returns {Promise<Array<import('./types.js').Reputacion>>}
+ */
+export async function cargarReputaciones(opts = {}) {
+  const tratos = await redTransactions.getAll();
+  return computeAllReputaciones(tratos, opts);
+}
+
+/**
+ * Carga el grafo social derivado desde los tratos compartibles.
+ * @param {Object} [opts] — { minLevel }
+ * @returns {Promise<import('./types.js').SocialGraph>}
+ */
+export async function cargarGrafoSocial(opts = {}) {
+  const tratos = await redTransactions.getAll();
+  return buildSocialGraph(tratos, opts);
+}
+
+/**
+ * "Pregúntele al vecino": rutea una duda al par competente y cercano. Excluye
+ * al propio operador (no se sugiere a uno mismo). El caller decide qué hacer con
+ * la decisión (mostrar el mensaje sugerido, abrir canal si hay consentimiento).
+ *
+ * @param {Object} problema — { producto, vereda, municipio, sintoma, agentConfident }
+ * @param {Object} [opts] — { now, halfLifeDias, minLevel, allowNuevo }
+ * @returns {Promise<ReturnType<typeof routeQuestion>>}
+ */
+export async function preguntarAlVecino(problema, opts = {}) {
+  const reputaciones = await cargarReputaciones(opts);
+  const excludeHash = getCurrentOperatorHash() || '';
+  return routeQuestion(
+    { ...problema, excludeHash },
+    { reputaciones, allowNuevo: Boolean(opts.allowNuevo) },
+  );
+}
+
+/**
+ * Abre el canal directo con un vecino REUSANDO el contacto del mercado. Solo
+ * funciona si el par expuso un teléfono público (opt-in). Sin ese dato devuelve
+ * null: la red no filtra números sin consentimiento.
+ *
+ * @param {{contactoTel?:string, producto?:string}} contactoPublico
+ * @param {{mensaje?:string}} [opts]
+ * @returns {{href:string, tel:string}|null}
+ */
+export function abrirCanal(contactoPublico, opts = {}) {
+  if (!contactoPublico?.contactoTel) return null;
+  const base = construirContacto(contactoPublico);
+  if (!base) return null;
+  if (opts.mensaje) {
+    const tel = base.href.split('?')[0].replace('https://wa.me/', '');
+    return { href: `https://wa.me/${tel}?text=${encodeURIComponent(opts.mensaje)}`, tel: base.tel };
+  }
+  return base;
+}

--- a/src/services/red/redSharing.js
+++ b/src/services/red/redSharing.js
@@ -1,0 +1,101 @@
+/**
+ * red/redSharing.js — COMPUERTA anti-extractiva de la red. Lógica PURA (cero
+ * red, cero I/O) que decide qué sale del dispositivo y en qué forma.
+ *
+ * Es la barrera que hace honesto el "local-first / anti-extractivo": el dato
+ * crudo nace PRIVADO (nivel 1) y nada entra al grafo social ni al matchmaking a
+ * menos que el productor lo suba, explícito, a PARES (nivel 2) o CANONIZADO
+ * (nivel 3). Un trato privado JAMÁS cruza esta compuerta.
+ *
+ * Además, aun cuando un trato es compartible, `redactForPeers` recorta lo que
+ * los pares NO necesitan (identidad del comprador, referencias internas): a la
+ * red solo cruza lo mínimo para la reputación y el matchmaking.
+ *
+ * @module services/red/redSharing
+ */
+
+import { SHARE_LEVEL } from './types.js';
+
+/**
+ * Normaliza un nivel de compartición a 1..3. Cualquier valor inválido o
+ * ausente cae al más SEGURO (PRIVADO): el default nunca comparte de más.
+ *
+ * @param {*} value
+ * @returns {number} 1 | 2 | 3
+ */
+export function normalizeShareLevel(value) {
+  const n = Number(value);
+  if (n === SHARE_LEVEL.PARES || n === SHARE_LEVEL.CANONIZADO) return n;
+  return SHARE_LEVEL.PRIVADO;
+}
+
+/**
+ * Estampa el nivel por default (PRIVADO) si el trato no trae uno válido. No
+ * muta: devuelve una copia. Úselo al construir un trato para garantizar el
+ * invariante "privado por default".
+ *
+ * @template {{shareLevel?: *}} T
+ * @param {T} trato
+ * @returns {T & {shareLevel:number}}
+ */
+export function withDefaultShareLevel(trato) {
+  const t = trato && typeof trato === 'object' ? trato : /** @type {any} */ ({});
+  return { ...t, shareLevel: normalizeShareLevel(t.shareLevel) };
+}
+
+/**
+ * ¿Este trato puede cruzar la compuerta hacia la red? Por default exige nivel
+ * PARES (2) o superior. Total y defensiva: cualquier input basura → false.
+ *
+ * @param {*} trato
+ * @param {{ minLevel?: number }} [opts]
+ * @returns {boolean}
+ */
+export function isShareable(trato, { minLevel = SHARE_LEVEL.PARES } = {}) {
+  if (!trato || typeof trato !== 'object') return false;
+  return normalizeShareLevel(trato.shareLevel) >= minLevel;
+}
+
+/**
+ * Filtra una lista de tratos dejando solo los compartibles (nivel ≥ minLevel).
+ * Es el ÚNICO punto por el que los servicios de grafo/reputación deben leer los
+ * tratos: nunca operan sobre la lista cruda.
+ *
+ * @param {Array<*>} tratos
+ * @param {{ minLevel?: number }} [opts]
+ * @returns {Array<Object>}
+ */
+export function filterShareable(tratos, opts = {}) {
+  const lista = Array.isArray(tratos) ? tratos : [];
+  return lista.filter((t) => isShareable(t, opts));
+}
+
+/**
+ * Proyección SEGURA de un trato para exponerlo a los pares. Deja solo lo que la
+ * reputación y el matchmaking necesitan; recorta la identidad del comprador,
+ * las referencias internas (ofertaId) y cualquier texto libre. Devuelve null si
+ * el trato no es compartible (defensa en profundidad: aunque el llamador se
+ * equivoque, un privado no se proyecta).
+ *
+ * @param {*} trato
+ * @param {{ minLevel?: number }} [opts]
+ * @returns {Object|null}
+ */
+export function redactForPeers(trato, opts = {}) {
+  if (!isShareable(trato, opts)) return null;
+  return {
+    productorHash: trato.productorHash,
+    producto: trato.producto,
+    cultivoId: trato.cultivoId ?? null,
+    categoria: trato.categoria ?? '',
+    vereda: trato.vereda ?? '',
+    municipio: trato.municipio ?? '',
+    cantidad: trato.cantidad ?? null,
+    unidad: trato.unidad ?? '',
+    entrega: trato.entrega,
+    calidad: trato.calidad ?? null,
+    confirmadoPor: trato.confirmadoPor,
+    shareLevel: normalizeShareLevel(trato.shareLevel),
+    createdAt: trato.createdAt,
+  };
+}

--- a/src/services/red/types.js
+++ b/src/services/red/types.js
@@ -1,0 +1,174 @@
+/**
+ * red/types.js — modelo de datos de la RED humana de Chagra (campesino ↔
+ * campesino). Constantes canónicas + typedefs JSDoc. CERO lógica, CERO red,
+ * CERO I/O: solo el vocabulario compartido por los servicios de la red.
+ *
+ * PRINCIPIO RECTOR (del DR de red groundeado): la red social y la reputación
+ * NO se construyen pidiéndole datos al campesino ni con votos — son
+ * SUBPRODUCTO de transacciones del mercado que YA ocurren. Cada trato cerrado
+ * codifica quién cultiva qué, en qué vereda, con qué fiabilidad de entrega y
+ * qué calidad calificada. De ahí sale el grafo (productor–cultivo–vereda) y la
+ * reputación GANADA, anclada a hechos verificables. Esto evita el cold-start y
+ * sirve desde n muy pequeño (piloto de ~15 productores).
+ *
+ * ANTI-EXTRACTIVO (regla inviolable): el dato crudo vive en el dispositivo por
+ * default. La compartición es opt-in en 3 niveles (ver SHARE_LEVEL). Nada se
+ * monetiza en la capa de pares — el mercado es la única superficie de dinero.
+ *
+ * @module services/red/types
+ */
+
+/**
+ * Niveles de compartición opt-in (anti-extractivo). El dato nace PRIVADO; el
+ * productor decide, paso a paso, cuánto sale de su dispositivo.
+ *
+ *   1 PRIVADO     — solo en el dispositivo. NUNCA entra al grafo ni al
+ *                   matchmaking. Es el default seguro.
+ *   2 PARES       — compartido con los pares de la red: alimenta el grafo
+ *                   social + la reputación + el "pregúntele al vecino". El MVP
+ *                   opera en niveles 1–2.
+ *   3 CANONIZADO  — un sabedor/experto lo canoniza y pasa a conocimiento
+ *                   comunitario (puente con el grafo DR-SOCIAL-1:
+ *                   Caso —SE_VUELVE→ ConocimientoComunitario). Se MODELA aquí
+ *                   aunque el MVP todavía no lo ejecute.
+ *
+ * @readonly
+ * @enum {number}
+ */
+export const SHARE_LEVEL = Object.freeze({
+  PRIVADO: 1,
+  PARES: 2,
+  CANONIZADO: 3,
+});
+
+/** Etiquetas humanas de cada nivel (usted, español de Colombia). */
+export const SHARE_LEVEL_COPY = Object.freeze({
+  [SHARE_LEVEL.PRIVADO]: {
+    label: 'Privado',
+    explica: 'Este dato se queda solo en su teléfono. Nadie más lo ve.',
+  },
+  [SHARE_LEVEL.PARES]: {
+    label: 'Con los vecinos',
+    explica: 'Comparte este trato con la red de pares: ayuda a que un vecino lo encuentre cuando busque quién cultiva lo mismo cerca.',
+  },
+  [SHARE_LEVEL.CANONIZADO]: {
+    label: 'Saber comunitario',
+    explica: 'Un sabedor de la comunidad revisó su práctica y la volvió conocimiento compartido para todos.',
+  },
+});
+
+/**
+ * Resultado de ENTREGA de un trato (el hecho verificable que gana fiabilidad).
+ * @readonly
+ * @enum {string}
+ */
+export const ENTREGA = Object.freeze({
+  ENTREGADO: 'entregado',
+  PARCIAL: 'parcial',
+  NO_ENTREGADO: 'no_entregado',
+  PENDIENTE: 'pendiente',
+});
+
+/**
+ * Quién confirmó el trato (procedencia de la reputación). Cuanto más cruzada
+ * la confirmación, más fuerte el hecho: `ambos` (comprador + productor) es el
+ * ancla más sólida; `productor` (solo el vendedor lo dice) es la más débil.
+ * @readonly
+ * @enum {string}
+ */
+export const CONFIRMADO_POR = Object.freeze({
+  PRODUCTOR: 'productor',
+  COMPRADOR: 'comprador',
+  AMBOS: 'ambos',
+  SISTEMA: 'sistema',
+});
+
+/**
+ * Nivel de reputación de un productor para un cultivo. Espeja el idioma
+ * verde/ámbar/rojo del semáforo de confianza (semaforoConfianza.js), pero para
+ * un actor humano, no para un dato: aquí el color resume HECHOS de entrega, no
+ * curaduría de fuentes.
+ * @readonly
+ * @enum {string}
+ */
+export const NIVEL_REPUTACION = Object.freeze({
+  NUEVO: 'nuevo', // aún sin historial suficiente — honesto, no penaliza
+  VERDE: 'verde', // entregó parejo y con buena calidad
+  AMBAR: 'ambar', // respaldo parcial; conviene confirmar
+  ROJO: 'rojo', // historial de fallas de entrega demostradas
+});
+
+/**
+ * @typedef {Object} RedTransaction
+ * Un TRATO cerrado del mercado, registrado como HECHO append-only. Es el ancla
+ * de todo el grafo y la reputación. Referencia opcionalmente la oferta del
+ * mercado que lo originó.
+ *
+ * @property {string} id                     Id único generado en cliente.
+ * @property {number} createdAt              Epoch ms (ordena el timeline).
+ * @property {string|null} ofertaId          Ref a marketplace_ofertas (o null).
+ * @property {string} productorHash          Id pseudonimizado del vendedor
+ *                                           (operatorIdentityService, Ley 1581).
+ *                                           Es el ancla de la reputación.
+ * @property {string|null} compradorHash     Id pseudonimizado del comprador.
+ * @property {string} producto               Nombre del producto (texto libre).
+ * @property {string|null} cultivoId         Slug de especie resuelto (o null).
+ * @property {string} categoria              Id de categoría del mercado.
+ * @property {string} vereda                 Vereda del trato.
+ * @property {string} municipio              Municipio/departamento.
+ * @property {number} cantidad               Cantidad transada (> 0).
+ * @property {string} unidad                 Unidad (kg, arroba, bulto…).
+ * @property {ENTREGA[keyof ENTREGA]} entrega       Resultado de la entrega.
+ * @property {number|null} calidad           Calificación de calidad 1..5 (o null).
+ * @property {CONFIRMADO_POR[keyof CONFIRMADO_POR]} confirmadoPor  Procedencia.
+ * @property {number} shareLevel             Nivel de compartición opt-in (1..3).
+ */
+
+/**
+ * @typedef {Object} Reputacion
+ * Reputación DERIVADA (materializada) de un productor para UN cultivo. Nunca se
+ * persiste como fuente de verdad — se recomputa desde los tratos (ADR-019: el
+ * log manda, esto es cache reconstruible).
+ *
+ * @property {string} productorHash
+ * @property {string} producto
+ * @property {string} productoNorm          Producto normalizado (matching).
+ * @property {string} vereda                Vereda predominante del productor.
+ * @property {string} municipio             Municipio predominante.
+ * @property {number} nTransacciones        Total de tratos considerados (volumen).
+ * @property {number} nConfirmadas          Tratos con entrega ya resuelta.
+ * @property {number} nEntregados           Entregas cumplidas (parcial = 0.5).
+ * @property {number} fiabilidad            0..1 con suavizado bayesiano (n bajo → 0.5).
+ * @property {number|null} calidadPromedio  Promedio 1..5 (o null si sin calificar).
+ * @property {number|null} calidadNorm      Calidad normalizada 0..1 (o null).
+ * @property {number} reciente              Timestamp del trato más reciente.
+ * @property {number} score                 0..1 compuesto para ranking.
+ * @property {NIVEL_REPUTACION[keyof NIVEL_REPUTACION]} nivel  Semáforo humano.
+ * @property {string} motivo                Motivo legible del nivel.
+ */
+
+/**
+ * @typedef {Object} SocialGraph
+ * Grafo social derivado de los tratos compartibles. Nodos + aristas agregadas.
+ *
+ * @property {{ productores: string[], cultivos: string[], veredas: string[] }} nodos
+ * @property {Array<{productorHash:string, producto:string, cultivoId:string|null, count:number, entregados:number, reciente:number}>} cultiva   Arista CULTIVA.
+ * @property {Array<{productorHash:string, vereda:string, municipio:string, count:number}>} ubicadoEn  Arista EN (productor→vereda).
+ * @property {Array<{productorHash:string, compradorHash:string, count:number}>} entregoA  Arista ENTREGO_A.
+ * @property {{ tratos:number, compartidos:number, minShareLevel:number }} meta
+ */
+
+/**
+ * @typedef {Object} PeerMatch
+ * Un vecino competente encontrado por el matchmaking.
+ * @property {string} productorHash
+ * @property {string} producto
+ * @property {NIVEL_REPUTACION[keyof NIVEL_REPUTACION]} nivel
+ * @property {number} score
+ * @property {number} proximidad            3 misma vereda · 2 mismo municipio · 1 más lejos.
+ * @property {string} proximidadLabel
+ * @property {string} vereda
+ * @property {string} municipio
+ * @property {number} nTransacciones
+ * @property {number} reciente
+ */


### PR DESCRIPTION
## Qué

Núcleo indivisible del **backend** del MVP de la RED humana de Chagra
(campesino ↔ campesino). **Sin UI** — solo capa de datos + servicios + tipos +
tests. La "cara" la construye aparte quien consuma estos servicios.

La puerta es el mercado: el grafo social y la reputación son **subproducto** de
transacciones que ya ocurren (anti cold-start, sirve a n≈15).

## Módulo `src/services/red/`

- **`redReputation.js`** — mercado → grafo social (productor–cultivo–vereda) +
  reputación **ganada**: fiabilidad de entrega (media bayesiana `Beta(1,1)`,
  `n` chico → 0.5, no 1.0) + calidad calificada. Anclada a hechos verificables
  de tratos, no a votos. Documenta régimen de cola pesada (power laws) +
  supuesto de Markov (no estacionariedad → decaimiento por recencia).
- **`redMatchmaking.js`** — "pregúntele al vecino": encuentra al par competente
  (que **demostró** éxito con ese cultivo) y cercano, y decide el ruteo (el
  agente enruta cuando no sabe o cuando la duda es local-específica).
- **`redSharing.js`** — compuerta **anti-extractiva** opt-in de 3 niveles
  (privado → pares → canonizado). El dato crudo nace privado; nada privado
  cruza a la red. `redactForPeers` recorta lo que los pares no necesitan.
- **`redService.js`** — orquestación (única capa con I/O): persistencia + reuso
  de `construirContacto` del mercado + identidad pseudonimizada (Ley 1581).
- **`types.js`** — constantes canónicas + typedefs JSDoc.

## Persistencia

- **`db/redTransactions.js`** + **`dbCore` v27** — store `red_transactions`
  append-only (fuente de verdad; grafo/reputación son cache reconstruible,
  ADR-019). Mismo patrón que `marketplaceOfertas`. Migración **aditiva**.

## Reuso (no duplica)

- `marketplaceService.construirContacto` / oferta del mercado como origen del trato.
- `operatorIdentityService` para el `productorHash` pseudonimizado.
- Idioma verde/ámbar/rojo del `semaforoConfianza` (pero para un actor, no un dato).
- Alinea el nivel 3 (canonizado) con el grafo `DR-SOCIAL-1`
  (`data/social-age-schema.json`): `Caso —SE_VUELVE→ ConocimientoComunitario`.

## Verificación

- **Build**: `npm run build` verde (3m 31s).
- **Tests**: 58 tests nuevos (reputación, matchmaking, gates opt-in,
  persistencia). Regresión: 118 tests verdes incluyendo todos los que importan
  `dbCore` + el mercado (sin romper por el bump v27 aditivo).
- **Lint**: `eslint --max-warnings=0` limpio. Sin voseo. Anti-leak limpio.

## Qué queda para la "cara" (fable)

Detallado en `src/services/red/README.md`: cierre de trato desde el mercado,
switch de compartición (3 niveles), vista "pregúntele al vecino", `useRedStore`
(Zustand) y tarjeta de reputación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)