### PR TITLE
feat(oso): Oso andino completo — peso rubber-hose, lip-sync, poder rojo, ruana y prop por mundo

### DIFF
--- a/src/visual/creatures/OsoAndino.jsx
+++ b/src/visual/creatures/OsoAndino.jsx
@@ -1,21 +1,29 @@
 import { useId } from 'react';
 import './creatures.css';
 import { CreatureFilters } from './_filters.jsx';
-import { OjosRubber, Cachetes, Sonrisa, Miembro, RH_INK } from './_rubberhose.jsx';
+import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, RH_INK } from './_rubberhose.jsx';
 import { OSO_PALETA, OSO_PROPORCION } from './faunaAndina.js';
-import { cuerpoDeClima, PERFIL_OSO } from './creatureClimaCuerpo.js';
+import { cuerpoDeClima, PERFIL_OSO, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
+import { AccesoriosClima } from './AccesoriosClima.jsx';
+import { LineBoilFilter } from './LineBoilFilter.jsx';
+import { PropEnMano } from './PropEnMano.jsx';
+import { AuraPoder } from './AuraPoder.jsx';
+import { auraDeBicho } from './transformacion.js';
 
 /* Oso andino — Tremarctos ornatus (oso de anteojos, el único oso de Suramérica,
-   guardián del páramo). Hermano rubber-hose de la abeja Angelita: compone el
+   GUARDIÁN DEL PÁRAMO). Hermano rubber-hose de la abeja Angelita: compone el
    MISMO kit `_rubberhose.jsx` (ojos de goma, cachetes, sonrisa, miembros
-   manguera) y hereda la MISMA cadencia `rh-*` de `creatures.css` (boil que
-   respira, parpadeo, follow-through, vuelta de campana) — cero animación
-   redibujada. Solo cambia el ANIMAL: mole parda, pesada y entrañable, con los
-   ANTEOJOS crema (su firma) alrededor de los ojos, hocico claro y orejas
-   redondas que se mecen. Es de SUELO: se sienta (no vuela) — sin alas. La
-   IDENTIDAD (paleta + proporciones) vive en `faunaAndina.js`; el CLIMA→cuerpo,
-   en `creatureClimaCuerpo.js` con PERFIL_OSO (pelaje que empapa despacio, mole
-   que la niebla apenas difumina, robusto ante la seca). */
+   manguera) y hereda la MISMA fundación transversal — lip-sync (useLipSync →
+   BocaVisema), modo poder (transformacion), ropa por clima (ropaDeClima), prop
+   por mundo (PropEnMano) y line-boil (LineBoilFilter) — cero código duplicado.
+   Solo cambia el ANIMAL y su CARÁCTER: mole parda, PESADA y SERIA, con los
+   ANTEOJOS crema (su firma) alrededor de los ojos, cejas de sabio gruñón, hocico
+   claro y orejas redondas que se mecen. Es de SUELO: se SIENTA (no vuela) — sin
+   alas. Su voz es de papá-noel (grave, cálida): la boca se abre AMPLIA al hablar.
+   Su color de poder es el ROJO berserker (no el dorado de la abeja). La IDENTIDAD
+   (paleta + proporciones) vive en `faunaAndina.js`; el CLIMA→cuerpo, en
+   `creatureClimaCuerpo.js` con PERFIL_OSO (pelaje que empapa despacio, mole que
+   la niebla apenas difumina, robusto ante la seca) — y de páramo: NUNCA suda. */
 const VIEWBOX = '-16 -20 32 40';
 
 export function OsoAndino({
@@ -36,12 +44,58 @@ export function OsoAndino({
      = neutro digno: el oso se ve EXACTO como siempre. */
   clima = null,
   enso = 'neutro',
+  /* ── LIP-SYNC (sistema transversal, useLipSync) ────────────────────────────
+     visema opcional ('V1'..'V4') que produce useLipSync desde el RMS del TTS:
+     la bocota se abre AMPLIA al hablar (voz grave de papá-noel). Sin visema (o
+     'V1') = la sonrisa de siempre → avatares/catálogo no cambian. El HOOK vive
+     aparte (no cuelga un AnalyserNode por instancia); acá solo se consume. */
+  visema = null,
+  /* ── VESTUARIO por clima+hora (ropaDeClima) ───────────────────────────────
+     OPT-IN: con vestuario=true el oso se abriga según el clima real (RUANA
+     andina de noche/frío del páramo). Es de páramo: NUNCA se sobrecalienta →
+     jamás sombrero ni sudor (se suprimen aquí aunque el termómetro suba).
+     Default false → los consumidores de `clima` existentes NO ven ropa nueva. */
+  vestuario = false,
+  tempC = undefined,
+  /* ── RESOPLA (gruñido corporal — el sabio gruñón resopla) ──────────────────
+     OPT-IN: el oso suelta un VAHO por la trufa y el cuerpo da un huff pesado
+     (squash&stretch lento con peso). Su reacción-firma cuando gruñe/refunfuña.
+     Default false → sin resoplido (avatar sereno). */
+  resopla = false,
+  /* ── RASCA (se rasca con la zarpa) ─────────────────────────────────────────
+     OPT-IN: el oso se rasca la panza con la zarpa derecha (gesto de oso, pausado
+     y entrañable). Default false. */
+  rasca = false,
+  /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
+     pleno; 'bajo' apaga el idle continuo (boil + follow-through) y deja los
+     estados reactivos. Sin prop (standalone: avatares, catálogo) = pleno. */
   tier,
+  /* ── LÍNEA QUE RESPIRA (line-boil, Cuphead años 30 — LineBoilFilter) ────────
+     OPT-IN: con lineBoil el CONTORNO del oso vibra escalonado (feTurbulence +
+     feDisplacement, ~8fps) — el trazo "hierve" como dibujo animado clásico.
+     Default false → los consumidores existentes NO cambian. Con animated=false
+     o reduced-motion queda con seed fija (textura sin vibrar). Capa MÁS cara del
+     kit: reservada para su entrada heroica (galería, hero). */
+  lineBoil = false,
+  /* ── MODO PODER (transformación / power-up ROJO — transformacion.css) ───────
+     OPT-IN: con poder=true (y en modo standalone) el oso se envuelve en su aura
+     ROJA berserker de 4 capas (glow, boost, ingravidez, corrientes) — su firma
+     cuando "sube de nivel". El host lo enciende un rato con usePoderTemporal().
+     En modo inline el power-up lo pone el host DOM (::before/mix-blend no aplican
+     a nodos SVG); acá solo marcamos data-poder por si el host lo consulta. */
+  poder = false,
+  /* ── PROP POR MUNDO (herramienta en la zarpa — propsPorMundo/PropEnMano) ─────
+     mundoId opcional: al ENTRAR a un mundo el oso carga su herramienta
+     (agua→manguerita, suelo→lupa/pala, animales→lazo, semillero→canasto…). Sin
+     mundoId (o mundo sin prop) entra con las zarpas libres. Va en su zarpa
+     IZQUIERDA (la carita es simétrica; el prop cae al lado libre del cuerpo). */
+  mundoId = null,
   ...rest
 }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
   const glow = `crt-glow-${uid}`;
   const blur = `crt-blur-${uid}`;
+  const boil = `crt-boil-${uid}`;
   const vivo = animated;
   const auraOp = Math.max(0.14, Math.min(0.42, 0.18 + 0.26 * (energia ?? 1)));
   const auraR = 8.5 + 1.6 * (energia ?? 1);
@@ -53,15 +107,43 @@ export function OsoAndino({
     ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
     : undefined;
 
+  // Vestuario por clima+hora (opt-in). Perfil oso de PÁRAMO: la RUANA de noche/
+  // frío; NUNCA sombrero ni sudor (aunque suba el termómetro) — el oso no se
+  // sobrecalienta. Los suprimimos aquí sin tocar la función compartida (su
+  // contrato/tests siguen intactos). Sin vestuario o sin clima → nada.
+  const ropaBase = (vestuario && clima) ? ropaDeClimaBicho('oso-andino', clima, { tempC }) : null;
+  const ropa = ropaBase ? { ...ropaBase, sombrero: false, sudor: false } : null;
+
   const defs = (
     <defs>
       <CreatureFilters glow={glow} blur={blur} />
+      {/* Line-boil (contorno que hierve) — solo se instancia si se pide. */}
+      {lineBoil && <LineBoilFilter id={boil} animated={vivo} />}
     </defs>
   );
 
+  // VAHO del resoplido: dos motas claras que salen de la trufa y se disuelven
+  // (el oso resopla — su gruñido corporal). CSS (crt-vaho-mota) las anima; con
+  // animated=false / RM quedan colgando dignas. Opt-in (resopla).
+  const vaho = resopla ? (
+    <g className="crt-vaho" fill={OSO_PALETA.cremaClara} aria-hidden="true" opacity="0.7">
+      <circle className={vivo ? 'crt-vaho-mota' : undefined} cx="2.6" cy="-4.4" r="1.1" />
+      <circle className={vivo ? 'crt-vaho-mota' : undefined} style={{ animationDelay: '-0.7s' }} cx="3.6" cy="-3.2" r="0.85" />
+    </g>
+  ) : null;
+
+  // PROP DEL MUNDO en la zarpa izquierda (el lado libre). El punta del brazo
+  // izquierdo cae en ~(-10.2, 6.4); posamos el prop ahí, a escala de oso (mole
+  // grande). Sin mundoId o mundo sin prop → PropEnMano devuelve null (zarpas
+  // libres, nunca rompe la escena).
+  const propMundo = mundoId ? (
+    <PropEnMano mundoId={mundoId} x={-11.4} y={7.8} escala={0.72} ink={RH_INK} animated={vivo} />
+  ) : null;
+
   // ── CUERPO rubber-hose (atrás→adelante): aura, orejas, patas, tronco pardo
-  //    con pecho crema, bracitos manguera, cabeza (anteojos + ojos/cachetes/
-  //    sonrisa + hocico). `.crt-body` es el nodo que squashea (boil idle).
+  //    con pecho crema, bracitos manguera, cabeza (anteojos + cejas + ojos/
+  //    cachetes/boca + hocico). `.crt-body` es el nodo que squashea (boil idle,
+  //    más LENTO y PESADO en el oso — su masa asienta despacio).
   const body = (
     <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
       {/* aura viva */}
@@ -92,7 +174,8 @@ export function OsoAndino({
       <ellipse cx="0" cy="3.4" rx="3.2" ry="4.2" fill={OSO_PALETA.crema} opacity="0.85" />
 
       {/* bracitos manguera (zarpas) con planta crema, pivote en el HOMBRO para
-          que celebra/señala los alcen desde el hombro (no del centro del bbox). */}
+          que celebra/señala/rasca los alcen desde el hombro (no del centro del
+          bbox). El derecho (crt-brazo-r) es el que rasca la panza. */}
       <Miembro clase="crt-brazo-l" origen="right top"
         d="M-7.2,-1.4 C-10.2,0.2 -11.2,3.2 -10.2,6.0" ancho={3.2} punta={[-10.2, 6.4]} puntaR={2.1} pie sway={vivo} delay={-0.15} />
       <Miembro clase="crt-brazo-r" origen="left top"
@@ -108,9 +191,21 @@ export function OsoAndino({
         {/* puente + hocico crema que baja al morro */}
         <path d="M-2.2,-6.6 C-1,-5.4 1,-5.4 2.2,-6.6 C2.4,-4 1.6,-2.4 0,-2.2 C-1.6,-2.4 -2.4,-4 -2.2,-6.6 Z" />
       </g>
-      {/* chapetas + sonrisa + trufa + ojos de goma dentro de los anteojos */}
+      {/* CEJAS del sabio gruñón (ceño serio): trazos gruesos sobre los anteojos,
+          con el extremo INTERNO más bajo (mirada brava pero noble). Dan la
+          EXPRESIVIDAD de los anteojos — la cara del guardián serio. En un grupo
+          propio (.oso-cejas) que se frunce más cuando resopla (gruñe). */}
+      <g className="oso-cejas" stroke={RH_INK} strokeWidth="1.4" strokeLinecap="round" fill="none">
+        <path d="M-4.7,-12.0 C-3.4,-12.5 -2.1,-12.2 -1.3,-11.4" />
+        <path d="M4.7,-12.0 C3.4,-12.5 2.1,-12.2 1.3,-11.4" />
+      </g>
+      {/* chapetas + boca + trufa + ojos de goma dentro de los anteojos */}
       <Cachetes puntos={[{ cx: -4.4, cy: -6.6, r: 1.25 }, { cx: 4.4, cy: -6.6, r: 1.25 }]} vivo={vivo} />
-      <Sonrisa cx={0} cy={-3.6} w={3.0} prof={1.2} />
+      {/* Boca AMPLIA (voz grave de papá-noel): lip-sync si hay visema; si no, la
+          sonrisa de goma de siempre. Más ancha que la de la abeja (w=3.6). */}
+      {visema
+        ? <BocaVisema cx={0} cy={-3.4} w={3.6} prof={1.35} visema={visema} />
+        : <Sonrisa cx={0} cy={-3.6} w={3.4} prof={1.3} />}
       {/* trufa (nariz) */}
       <ellipse cx="0" cy="-4.6" rx="1.5" ry="1.15" fill={OSO_PALETA.hocico} />
       <OjosRubber
@@ -118,34 +213,64 @@ export function OsoAndino({
         mirar={[0, 0.28]}
         parpadea={vivo}
       />
+
+      {/* Vestuario por clima+hora (RUANA de noche/frío del páramo) — solo con
+          vestuario=true. Sombrero/sudor van suprimidos (el oso no se acalora). */}
+      {ropa && (
+        <AccesoriosClima
+          estado={ropa}
+          tronco={{ cx: 0, cy: 2, rx: OSO_PROPORCION.troncoRx, ry: OSO_PROPORCION.troncoRy }}
+          cabeza={{ cx: 0, cy: -8.2, r: OSO_PROPORCION.cabezaR }}
+          animated={vivo}
+        />
+      )}
+
+      {/* Prop del mundo en la zarpa (entra heroico con su herramienta). */}
+      {propMundo}
+
+      {/* Vaho del resoplido (el gruñido corporal). */}
+      {vaho}
     </g>
   );
 
   // Antics de VIDA (períodos co-primos) SOLO viva; nodos aparte para no pisar
   // el boil de `.crt-body`. El CSS los apaga con RM / tier bajo / ánimo bajo /
-  // durante los gestos (celebra/reposo/señala).
-  const cuerpoVivo = vivo ? (
+  // durante los gestos (celebra/reposo/señala) y estados (resopla/rasca).
+  const conAntics = vivo ? (
     <g className="rh-antic">
       <g className="rh-travieso">{body}</g>
     </g>
   ) : body;
+  // El line-boil (contorno que hierve) envuelve TODO el dibujo cuando se pide:
+  // el feDisplacementMap desplaza el trazo entero (Cuphead). Grupo aparte para
+  // no colisionar con el glow del `.crt-body` (dos filtros, nodos distintos).
+  const cuerpoVivo = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
 
   const estadoAttrs = {
     'data-creature': 'oso-andino',
     'data-pose': vivo ? pose : undefined,
     'data-animo': animo,
     'data-tier': tier || undefined,
+    'data-visema': visema || undefined,
+    'data-ruana': ropa?.ruana ? '1' : undefined,
+    'data-mojado': ropa?.mojado ? '1' : undefined,
+    'data-resopla': resopla ? '1' : undefined,
+    'data-rasca': rasca ? '1' : undefined,
+    'data-lineboil': lineBoil ? '1' : undefined,
+    'data-prop': mundoId || undefined,
   };
 
   if (inline) {
+    // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
+    // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
     return (
-      <g className={className} style={estiloClima} {...estadoAttrs}>
+      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
         {defs}
         {cuerpoVivo}
       </g>
     );
   }
-  return (
+  const svg = (
     <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
@@ -153,6 +278,22 @@ export function OsoAndino({
       {cuerpoVivo}
     </svg>
   );
+  // MODO PODER (standalone): lo envolvemos en su aura ROJA berserker de 4 capas
+  // (transformacion.css: glow radial + boost + ingravidez + corrientes). El
+  // wrapper DOM es lo único que puede llevar ::before/mix-blend/corrientes.
+  if (poder) {
+    return (
+      <span
+        className="is-powered-up oso-poder"
+        data-creature-poder="oso-andino"
+        style={{ '--aura-color': auraDeBicho('oso-andino'), display: 'inline-flex' }}
+      >
+        {svg}
+        <AuraPoder />
+      </span>
+    );
+  }
+  return svg;
 }
 
 export default OsoAndino;

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -96,6 +96,16 @@ piezas + clases `rh-*` con SUS proporciones (identidad en `faunaAndina.js`), y
 heredan los gestos species-agnostic (`rh-g-celebra` / `rh-g-reposo` /
 `rh-g-senala`) solo con `data-pose`. No se reinventa la cadencia.
 
+**Showcase COMPLETO (toda la fundación transversal)**: `AbejaAngelita` y
+`OsoAndino` cablean además — sin duplicar código — el **lip-sync** (`visema` →
+`BocaVisema`), el **modo poder** (`poder` → aura de 4 capas con su color:
+dorada la abeja, **roja** el oso), la **ropa por clima+hora** (`vestuario` →
+`AccesoriosClima`; el oso de páramo **nunca suda**), el **prop por mundo**
+(`mundoId` → `PropEnMano`) y el **line-boil** (`lineBoil`). El oso suma su
+CARÁCTER de mole seria: boil más lento y pesado, cejas de ceño, gruñido
+(`resopla` → vaho) y rascado (`rasca`) — todo aditivo en `creatures.css`, RM +
+tier-safe. Los demás bichos heredan la misma fundación pasando sus parámetros.
+
 ## Técnica
 
 - SVG + CSS puros, **cero dependencias nuevas**; solo `transform`/`opacity`

--- a/src/visual/creatures/__tests__/OsoAndino.render.test.jsx
+++ b/src/visual/creatures/__tests__/OsoAndino.render.test.jsx
@@ -1,0 +1,160 @@
+/**
+ * OsoAndino.render.test.jsx — los 5 frentes de "Oso andino completo" (espejo de
+ * Angelita, con el CARÁCTER del guardián del páramo: mole seria, gruñona, roja
+ * en poder). Verifica que las capacidades ADITIVAS del componente canónico se
+ * rendericen sin romper el contrato viejo:
+ *   1. Expresividad con PESO — line-boil (contorno que hierve), cejas del ceño,
+ *      gruñido (resopla → vaho) y rascado.
+ *   2. Lip-sync — el visema viaja a la cara (data-visema + bocota amplia).
+ *   3. Modo poder — el aura ROJA de 4 capas (wrapper .is-powered-up, no dorada).
+ *   4. Ruana del páramo — de noche RUANA, y el oso NUNCA suda (ni con calor).
+ *   5. Prop por mundo — la herramienta en la zarpa al entrar.
+ * Más la firma de identidad: es el oso de anteojos (crema) y su aura es roja.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { OsoAndino } from '../OsoAndino.jsx';
+import { auraDeBicho } from '../transformacion.js';
+
+afterEach(cleanup);
+
+describe('OsoAndino — contrato base intacto', () => {
+  it('render por defecto = svg accesible, sin capas nuevas', () => {
+    const { container } = render(<OsoAndino />);
+    const svg = container.querySelector('svg[data-creature="oso-andino"]');
+    expect(svg).toBeTruthy();
+    expect(svg.getAttribute('role')).toBe('img');
+    // Ninguna capa opt-in aparece sin pedirla (no regresión visual).
+    expect(svg.getAttribute('data-lineboil')).toBeNull();
+    expect(svg.getAttribute('data-resopla')).toBeNull();
+    expect(svg.getAttribute('data-rasca')).toBeNull();
+    expect(svg.getAttribute('data-prop')).toBeNull();
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+  });
+
+  it('siempre trae sus ANTEOJOS y su ceño serio (identidad de la especie)', () => {
+    const { container } = render(<OsoAndino />);
+    // Las cejas del sabio gruñón son parte de la identidad (no opt-in).
+    expect(container.querySelector('.oso-cejas')).toBeTruthy();
+  });
+});
+
+describe('1. Expresividad con PESO — line-boil, gruñido y rascado', () => {
+  it('lineBoil instancia el filtro de displacement (contorno que hierve)', () => {
+    const { container } = render(<OsoAndino lineBoil animated />);
+    expect(container.querySelector('svg').getAttribute('data-lineboil')).toBe('1');
+    expect(container.querySelector('feDisplacementMap')).toBeTruthy();
+    expect(container.querySelector('feTurbulence')).toBeTruthy();
+  });
+
+  it('sin lineBoil NO se paga el filtro (frugal)', () => {
+    const { container } = render(<OsoAndino animated />);
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+  });
+
+  it('resopla (gruñido) marca el estado y saca el vaho por la trufa', () => {
+    const { container } = render(<OsoAndino resopla animated />);
+    expect(container.querySelector('svg').getAttribute('data-resopla')).toBe('1');
+    expect(container.querySelectorAll('.crt-vaho-mota').length).toBeGreaterThan(1);
+  });
+
+  it('rasca marca el estado (se rasca con la zarpa)', () => {
+    const { container } = render(<OsoAndino rasca animated />);
+    expect(container.querySelector('svg').getAttribute('data-rasca')).toBe('1');
+  });
+
+  it('sin resopla no hay vaho (frugal, avatar sereno)', () => {
+    const { container } = render(<OsoAndino animated />);
+    expect(container.querySelector('.crt-vaho-mota')).toBeNull();
+  });
+});
+
+describe('2. Lip-sync — el visema llega a la bocota', () => {
+  it('con visema V3 la boca abierta viaja a la cara (data-visema)', () => {
+    const { container } = render(<OsoAndino visema="V3" />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBe('V3');
+  });
+
+  it('sin visema no marca data-visema (la sonrisa grave de siempre)', () => {
+    const { container } = render(<OsoAndino />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBeNull();
+  });
+});
+
+describe('3. Modo poder — aura ROJA de 4 capas (standalone)', () => {
+  it('poder envuelve en .is-powered-up + corrientes, con aura ROJA (no dorada)', () => {
+    const { container } = render(<OsoAndino poder />);
+    const wrap = container.querySelector('.is-powered-up');
+    expect(wrap).toBeTruthy();
+    expect(wrap.getAttribute('data-creature-poder')).toBe('oso-andino');
+    // el color de aura del oso es ROJO berserker (distinto del dorado de la abeja)
+    expect(wrap.getAttribute('style')).toContain('--aura-color');
+    expect(wrap.getAttribute('style')).toContain(auraDeBicho('oso-andino'));
+    expect(auraDeBicho('oso-andino')).not.toBe(auraDeBicho('abeja-angelita'));
+    // capa 4: las corrientes (AuraPoder)
+    expect(container.querySelector('.poder-corrientes')).toBeTruthy();
+  });
+
+  it('sin poder no hay wrapper (svg desnudo)', () => {
+    const { container } = render(<OsoAndino />);
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+    expect(container.querySelector(':scope > svg[data-creature="oso-andino"]')).toBeTruthy();
+  });
+});
+
+describe('4. Ruana del páramo — el oso se abriga y NUNCA suda', () => {
+  it('de noche con vestuario → RUANA y JAMÁS sudor/sombrero', () => {
+    const { container } = render(<OsoAndino vestuario clima="noche" />);
+    const svg = container.querySelector('svg');
+    expect(svg.getAttribute('data-ruana')).toBe('1');
+    // el oso de páramo no se acalora en ningún caso
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+  });
+
+  it('de día caluroso (tempC alta) el oso NO suda (páramo, identidad)', () => {
+    const { container } = render(<OsoAndino vestuario clima="soleado" tempC={26} />);
+    // aunque el termómetro dispararía sudor en un bicho templado, el oso no.
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+    expect(container.querySelector('.crt-gota-sudor')).toBeNull();
+  });
+
+  it('sin vestuario (avatar/catálogo) → nada de ropa aunque haya clima', () => {
+    const { container } = render(<OsoAndino clima="noche" />);
+    const svg = container.querySelector('svg');
+    expect(svg.getAttribute('data-ruana')).toBeNull();
+  });
+});
+
+describe('5. Prop por mundo — herramienta en la zarpa', () => {
+  it('mundoId=suelo → carga la lupa', () => {
+    const { container } = render(<OsoAndino mundoId="suelo" />);
+    expect(container.querySelector('svg').getAttribute('data-prop')).toBe('suelo');
+    expect(container.querySelector('[data-prop="lupa"]')).toBeTruthy();
+  });
+
+  it('mundoId=agua → carga la manguerita', () => {
+    const { container } = render(<OsoAndino mundoId="agua" />);
+    expect(container.querySelector('[data-prop="manguera"]')).toBeTruthy();
+  });
+
+  it('mundo sin prop mapeado → zarpas libres (no rompe)', () => {
+    const { container } = render(<OsoAndino mundoId="mundo-fantasma" />);
+    expect(container.querySelector('[data-prop="lupa"]')).toBeNull();
+    expect(container.querySelector('svg[data-creature="oso-andino"]')).toBeTruthy();
+  });
+});
+
+describe('Anti-regresión — modo inline no rompe la escena', () => {
+  it('inline devuelve un <g> con el data-creature y marca data-poder', () => {
+    const { container } = render(
+      <svg>
+        <OsoAndino inline poder mundoId="suelo" />
+      </svg>,
+    );
+    const g = container.querySelector('g[data-creature="oso-andino"]');
+    expect(g).toBeTruthy();
+    expect(g.getAttribute('data-poder')).toBe('1'); // el host DOM pinta el aura
+    expect(g.getAttribute('data-prop')).toBe('suelo');
+  });
+});

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -631,3 +631,121 @@
 @media (prefers-reduced-motion: reduce) {
   .abeja-cruce { display: none; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   OSO ANDINO — el CARÁCTER del guardián: mole PESADA, seria y gruñona.
+   Aditivo sobre el KIT species-agnostic (no toca a la abeja): el oso reescribe
+   SU boil (más lento y con más masa), suma un resoplido/gruñido corporal, el
+   rascado con la zarpa, el ceño de las cejas y el vaho de la trufa. Todo
+   transform/opacity (GPU, gama baja). Gates RM + tier al final del bloque.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* BOIL PESADO — la mole no vibra ligera como la abeja: respira LENTO y asienta
+   con MÁS squash (masa que cae). Reescribe SOLO el boil del oso (misma clase
+   .rh-boil, mayor especificidad por el data-creature) con longhands para no
+   pisar el resto de props de animación. */
+[data-creature='oso-andino'] .rh-boil {
+  animation-name: oso-boil;
+  animation-duration: 2.6s;
+  animation-timing-function: steps(14, end);
+}
+@keyframes oso-boil {
+  0%   { transform: translateY(0) scale(1, 1); }
+  26%  { transform: translateY(-0.2px) scale(0.985, 1.03); }  /* leve stretch (pesa) */
+  52%  { transform: translateY(0.8px) scale(1.06, 0.93); }    /* squash pesado (masa) */
+  74%  { transform: translateY(0.15px) scale(1.0, 1.0); }     /* asienta despacio */
+  100% { transform: translateY(0) scale(1, 1); }
+}
+
+/* CEJAS — el ceño serio respira apenas (vida sin perder la gravedad). Al
+   RESOPLAR (gruñir) se frunce MÁS fuerte: el sabio refunfuña. */
+.oso-cejas {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: oso-cejas 6.7s ease-in-out infinite;
+}
+@keyframes oso-cejas {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-0.25px); }
+}
+[data-creature='oso-andino'][data-resopla='1'] .oso-cejas {
+  animation: oso-cejas-frunce 0.9s ease-in-out infinite;
+}
+@keyframes oso-cejas-frunce {
+  0%, 100% { transform: translateY(0) scaleX(1); }
+  50%      { transform: translateY(0.55px) scaleX(1.06); }  /* baja y aprieta el ceño */
+}
+
+/* RESOPLA — gruñido corporal: el pecho hincha y suelta con PESO (huff lento,
+   squash&stretch marcado). Pisa el boil por especificidad (dos atributos). */
+[data-creature='oso-andino'][data-resopla='1'] .crt-body {
+  animation: oso-resoplido 1.5s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes oso-resoplido {
+  0%, 100% { transform: translateY(0) scale(1, 1); }
+  35%      { transform: translateY(-0.6px) scale(0.97, 1.06); }  /* inhala hondo (stretch) */
+  55%      { transform: translateY(0.7px) scale(1.07, 0.92); }   /* SUELTA el gruñido (squash) */
+  75%      { transform: translateY(0.1px) scale(1.01, 1.0); }
+}
+
+/* VAHO — las motas del resoplido salen de la trufa (adelante-abajo) y se
+   disuelven; los delays inline las desparejan. Solo con animated (rh gating). */
+.crt-vaho-mota {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+  animation: oso-vaho 1.6s ease-out infinite;
+}
+@keyframes oso-vaho {
+  0%   { transform: translate(0, 0) scale(0.5); opacity: 0; }
+  22%  { opacity: 0.75; }
+  100% { transform: translate(3.4px, 2.2px) scale(1.5); opacity: 0; }
+}
+
+/* RASCA — se rasca la panza con la zarpa derecha: vaivén corto y pausado
+   (gesto de oso, entrañable). El brazo pivota del hombro (crt-brazo-r trae su
+   origen). Pisa el sway/gestos por especificidad de dos atributos. */
+[data-creature='oso-andino'][data-rasca='1'] .crt-brazo-r {
+  animation: oso-rasca 0.5s ease-in-out infinite;
+}
+@keyframes oso-rasca {
+  0%, 100% { transform: rotate(-18deg); }
+  50%      { transform: rotate(-30deg); }
+}
+/* Y el cuerpo acompaña el rascado con un meneíto pesado de gusto. */
+[data-creature='oso-andino'][data-rasca='1'] .crt-body {
+  animation: oso-rasca-cuerpo 1.0s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes oso-rasca-cuerpo {
+  0%, 100% { transform: rotate(0deg); }
+  50%      { transform: rotate(1.4deg); }
+}
+
+/* Los estados del oso (resopla/rasca) PISAN el arrebato (antic/travieso): un oso
+   que gruñe o se rasca no da además vueltas de campana — el gesto lee limpio. */
+[data-creature='oso-andino'][data-resopla='1'] .rh-antic,
+[data-creature='oso-andino'][data-resopla='1'] .rh-travieso,
+[data-creature='oso-andino'][data-rasca='1'] .rh-antic,
+[data-creature='oso-andino'][data-rasca='1'] .rh-travieso { animation: none; }
+
+/* device-tier 'bajo': el boil reescrito del oso lo reactivaría (misma clase) →
+   re-apagarlo aquí (mayor especificidad + orden posterior). Las cejas continuas
+   y el vaho decorativo también se cortan; los estados reactivos (resopla/rasca)
+   siguen contando la verdad. */
+[data-tier='bajo'][data-creature='oso-andino'] .rh-boil,
+[data-tier='bajo'][data-creature='oso-andino'] .oso-cejas { animation: none; }
+[data-tier='bajo'] .crt-vaho-mota { animation: none; opacity: 0.5; }
+
+@media (prefers-reduced-motion: reduce) {
+  .oso-cejas, .crt-vaho-mota,
+  [data-creature='oso-andino'][data-resopla='1'] .crt-body,
+  [data-creature='oso-andino'][data-resopla='1'] .oso-cejas,
+  [data-creature='oso-andino'][data-rasca='1'] .crt-brazo-r,
+  [data-creature='oso-andino'][data-rasca='1'] .crt-body { animation: none !important; }
+  /* Fotograma digno: un rastro de vaho visible y quieto si se pidió resoplido. */
+  .crt-vaho-mota { opacity: 0.55; }
+}

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -73,10 +73,28 @@ const VARIANTES_TRIO_SUELO = [
   { label: 'sin animación', props: { size: 80, animated: false } },
 ];
 /* Variantes de vitrina por slug (las que difieren del set genérico). */
+/* El OSO ANDINO completo estrena TODA la fundación transversal (espejo de la
+   abeja, con su carácter): peso y line-boil, gruñido (resopla), rascado, ruana
+   del páramo, modo poder ROJO y prop por mundo. La vitrina lo luce con todo. */
+const VARIANTES_OSO = [
+  { label: '48 px', props: { size: 48 } },
+  { label: 'anda', props: { size: 88 } },
+  { label: 'celebra', props: { size: 88, pose: 'celebra' } },
+  { label: 'reposo', props: { size: 88, pose: 'reposo' } },
+  { label: 'señala', props: { size: 88, pose: 'señala' } },
+  { label: 'gruñe (resopla)', props: { size: 88, resopla: true } },
+  { label: 'se rasca', props: { size: 88, rasca: true } },
+  { label: 'ruana de noche', props: { size: 88, vestuario: true, clima: 'noche' } },
+  { label: 'con lupa (suelo)', props: { size: 88, mundoId: 'suelo' } },
+  { label: 'poder ROJO', props: { size: 88, poder: true } },
+  { label: 'línea que hierve', props: { size: 88, lineBoil: true } },
+  { label: 'sin animación', props: { size: 88, animated: false } },
+];
+
 const VARIANTES_POR_SLUG = {
   'abeja-angelita': VARIANTES_ABEJA,
   colibri: VARIANTES_TRIO_AIRE,
-  'oso-andino': VARIANTES_TRIO_SUELO,
+  'oso-andino': VARIANTES_OSO,
   'rana-andina': VARIANTES_TRIO_SUELO,
 };
 


### PR DESCRIPTION
## Oso andino completo (espejo del trabajo de la abeja, con carácter de oso)

Lleva al **Oso andino** (*Tremarctos ornatus*, guardián del páramo) al mismo nivel de personaje de referencia que Angelita. Personalidad: **mole SERIA, pesada y gruñona**, el sabio protector. Reusa la fundación transversal (NO la forkea) y extiende `creatures.css` de forma **aditiva** (no toca una sola línea de la abeja).

### Los 5 frentes
1. **Expresividad rubber-hose con PESO** — boil propio más lento y con más squash (masa que asienta), `LineBoilFilter` (contorno que hierve), **cejas de ceño serio** (anteojos expresivos), **gruñido corporal** (`resopla` → huff pesado + vaho por la trufa) y **rascado** con la zarpa (`rasca`).
2. **Lip-sync** — prop `visema` → `BocaVisema`, bocota **amplia** (voz grave de papá-noel).
3. **Modo poder ROJO** — prop `poder` → aura de 4 capas con `--aura-color` = `auraDeBicho('oso-andino')` (rojo berserker), no el dorado de la abeja.
4. **Ropa por clima+hora** — prop `vestuario` → **ruana andina** de noche/frío del páramo; el oso **NUNCA suda** (sombrero/sudor suprimidos aunque el termómetro suba — identidad de páramo, sin tocar el contrato compartido de `ropaDeClima`).
5. **Prop por mundo** — prop `mundoId` → `PropEnMano` en la zarpa (agua→manguerita, suelo→lupa, animales→lazo, semillero→canasto…).

### Reglas de la casa
- **Reusa** la foundation (`_rubberhose`, `creatureClimaCuerpo`/`ropaDeClima`, `useLipSync`/`BocaVisema`, `transformacion`/`AuraPoder`, `PropEnMano`, `LineBoilFilter`) — cero código duplicado.
- **Aditivo** en `creatures.css`: bloque `OSO ANDINO` al final; no reescribe ni borra nada de la abeja.
- **reduced-motion-safe** y **tier-safe** (el boil pesado se re-apaga en tier bajo; RM congela con `!important`).
- UI en **usted** colombiano; sin nombres de terceros.

### Dónde se ve
Vitrina `visual-lib` (`registry.js`): variantes del oso con los 5 frentes (anda, celebra, reposo, señala, gruñe, se rasca, ruana de noche, con lupa, poder rojo, línea que hierve).

### Verificación
- `npm run build` verde (30s).
- `npx vitest run src/visual/creatures` → **84/84** verdes (incluye `OsoAndino.render.test.jsx` nuevo con los 5 frentes + identidad).
- `visualLib.smoke` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)