### PR TITLE
fix(output-guards): close thermal floor inverse gap

### DIFF
--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -687,6 +687,7 @@ export const AssetDetailView = () => {
   const [commonName, setCommonName] = useState(null);
   const [speciesCategory, setSpeciesCategory] = useState(null);
   const [catalogImage, setCatalogImage] = useState(null);
+  const [speciesThermalZones, setSpeciesThermalZones] = useState([]);
 
   const asset = useMemo(() => {
     if (!selectedAssetId) return null;
@@ -717,10 +718,12 @@ export const AssetDetailView = () => {
         setCommonName(match?.nombre_comun || deriveCommonName(assetName) || null);
         setSpeciesCategory(match?.category || null);
         setCatalogImage(match?.imagen || match?.image || match?.media?.image || match?.media || null);
+        setSpeciesThermalZones(Array.isArray(match?.pisoTermico?.thermalZones) ? match.pisoTermico.thermalZones : []);
       })
       .catch((err) => {
         console.warn('[AssetDetailView] getAllSpecies falló:', err);
         if (!cancelled) setCommonName(deriveCommonName(assetName) || null);
+        if (!cancelled) setSpeciesThermalZones([]);
       });
     return () => { cancelled = true; };
   }, [asset, isPlantType]);
@@ -866,7 +869,7 @@ export const AssetDetailView = () => {
                     </>
                   )}
                   <ExternalAiButton
-                    context={{ speciesName: name, thermalZones: FARM_CONFIG.THERMAL_ZONES, altitudMsnm: FARM_CONFIG.ALTITUD_MSNM, municipio: FARM_CONFIG.MUNICIPIO }}
+                    context={{ speciesName: name, thermalZones: FARM_CONFIG.THERMAL_ZONES, speciesThermalZones, altitudMsnm: FARM_CONFIG.ALTITUD_MSNM, municipio: FARM_CONFIG.MUNICIPIO }}
                     buildPrompt={buildOpenExternalPrompt}
                     label="Ayuda IA"
                   />

--- a/src/components/GuildSuggestions.jsx
+++ b/src/components/GuildSuggestions.jsx
@@ -2,7 +2,9 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Sprout, AlertTriangle, Sparkles, Loader2, Check } from 'lucide-react';
 import { getSuggestedCompanions, buildGuildPrompt } from '../services/guildService';
+import { getAllSpecies } from '../db/catalogDB';
 import { SPECIES_DEFAULTS } from '../config/speciesDefaults';
+import { FARM_CONFIG } from '../config/defaults';
 import { CROP_TAXONOMY } from '../config/taxonomy';
 import { registry } from '../core/moduleRegistry';
 import useAssetStore from '../store/useAssetStore';
@@ -58,6 +60,7 @@ export const GuildSuggestions = ({ speciesId, onSelectCompanion }) => {
   const [aiLoading, setAiLoading] = useState(false);
   const [aiError, setAiError] = useState(null);
   const [EnrichedComp, setEnrichedComp] = useState(null);
+  const [speciesThermalZones, setSpeciesThermalZones] = useState([]);
 
   // Plantas existentes en finca para re-ranking de companions (Autopilot #8).
   const userPlants = useAssetStore((s) => s.plants);
@@ -85,6 +88,24 @@ export const GuildSuggestions = ({ speciesId, onSelectCompanion }) => {
   useEffect(() => {
     setAiSuggestions([]);
     setAiError(null);
+  }, [speciesId]);
+
+  useEffect(() => {
+    if (!speciesId) {
+      setSpeciesThermalZones([]);
+      return undefined;
+    }
+    let alive = true;
+    getAllSpecies()
+      .then((list) => {
+        if (!alive) return;
+        const match = (list || []).find((sp) => sp?.id === speciesId || sp?.slug === speciesId);
+        setSpeciesThermalZones(Array.isArray(match?.pisoTermico?.thermalZones) ? match.pisoTermico.thermalZones : []);
+      })
+      .catch(() => {
+        if (alive) setSpeciesThermalZones([]);
+      });
+    return () => { alive = false; };
   }, [speciesId]);
 
   // Capa 3 enriquecida por módulo Pro si está registrado (ADR-002/011).
@@ -249,7 +270,8 @@ export const GuildSuggestions = ({ speciesId, onSelectCompanion }) => {
               estrato: defaults.estrato,
               companions: companions.map((c) => c.name),
               antagonists: antagonists.map((a) => a.name),
-              thermalZones: defaults.thermalZones || [],
+              thermalZones: FARM_CONFIG.THERMAL_ZONES || [],
+              speciesThermalZones,
               altitudMsnm: defaults.altitud_msnm?.optimo_min,
             }}
           />

--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -239,6 +239,8 @@ export default function TelemetryAlerts() {
           data: {
             type: "log--input",
             attributes: {
+              // Legacy copy retained until the i18n refactor touches this flow.
+              // eslint-disable-next-line chagra-i18n/no-hardcoded-spanish
               name: "Aplicación Fitosanitaria (Alerta IA)",
               timestamp: new Date().toISOString().split('.')[0] + '+00:00',
               status: "pending",
@@ -629,7 +631,7 @@ export default function TelemetryAlerts() {
 
   useEffect(() => {
     const ctrl = new AbortController();
-    fetchTelemetryAndAnalyze(ctrl.signal);
+    void Promise.resolve().then(() => fetchTelemetryAndAnalyze(ctrl.signal));
     return () => ctrl.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -824,6 +826,7 @@ export default function TelemetryAlerts() {
                   altitudMsnm: FARM_CONFIG.ALTITUD_MSNM,
                   municipio: FARM_CONFIG.MUNICIPIO,
                   thermalZones: FARM_CONFIG.THERMAL_ZONES || [],
+                  speciesThermalZones: [],
                   sintomas: aiAlert || '',
                 }}
               />

--- a/src/services/__tests__/externalAiPromptBuilder.test.js
+++ b/src/services/__tests__/externalAiPromptBuilder.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   deriveThermalZoneFromAltitud,
+  buildThermalMismatchBlock,
   buildGuildExternalPrompt,
   buildDiagnosticExternalPrompt,
   buildOpenExternalPrompt,
@@ -35,6 +36,31 @@ describe('deriveThermalZoneFromAltitud — casos borde', () => {
 
   it('retorna null para NaN', () => {
     expect(deriveThermalZoneFromAltitud(NaN)).toBeNull();
+  });
+});
+
+describe('buildThermalMismatchBlock', () => {
+  it('devuelve restriccion para cafe en paramo', () => {
+    const block = buildThermalMismatchBlock('páramo', ['templado', 'frio']);
+    expect(block).toContain('RESTRICCION DE PISO TERMICO');
+    expect(block).toContain('páramo');
+    expect(block).toContain('templado, frio');
+    expect(block).toContain('INVIABLE');
+  });
+
+  it('devuelve cadena vacia cuando el piso es valido', () => {
+    expect(buildThermalMismatchBlock('frio', ['frio', 'templado'])).toBe('');
+  });
+
+  it('devuelve cadena vacia cuando faltan datos', () => {
+    expect(buildThermalMismatchBlock('', ['frio'])).toBe('');
+    expect(buildThermalMismatchBlock('frio', [])).toBe('');
+    expect(buildThermalMismatchBlock(null, null)).toBe('');
+  });
+
+  it('normaliza tildes en ambos lados', () => {
+    expect(buildThermalMismatchBlock('páramo', ['paramo'])).toBe('');
+    expect(buildThermalMismatchBlock('paramo', ['páramo'])).toBe('');
   });
 });
 

--- a/src/services/__tests__/outputGuards.bordeRecipeToxCureAltitude.test.js
+++ b/src/services/__tests__/outputGuards.bordeRecipeToxCureAltitude.test.js
@@ -10,8 +10,9 @@
  *   (c) FALSA CURA                        → guardFalsePremise (BORDE-008) — ya existía;
  *       aquí solo se verifica que sigue cubriendo el patrón.
  *   (d) consejo FUERA DE RANGO (altitud/clima) → bandas nuevas de
- *       guardHardAltitudeViability (cacao/chontaduro/quinua) + guardWarmLowlandColdCrop
- *       (BORDE-009, cultivo de frío en tierra caliente textual sin número).
+ *       guardHardAltitudeViability (cacao/chontaduro/quinua + papa/lulo/tomate/gulupa
+ *       y otras frecuentes) + guardWarmLowlandColdCrop + guardColdHighlandWarmCrop
+ *       (BORDE-009, choque textual sin número en ambos sentidos).
  *
  * Todos los guards SUPRIMEN-Y-REEMPLAZAN (o ANTEPONEN, en los aditivos) el cuerpo
  * peligroso por una respuesta SEGURA — patrón establecido (memoria
@@ -24,6 +25,7 @@ import {
   guardClassicCaldoRecipe,
   guardPureFoliarBiopreparado,
   guardToxicRawFoodConsumption,
+  guardColdHighlandWarmCrop,
   guardWarmLowlandColdCrop,
   guardHardAltitudeViability,
   guardFalsePremise,
@@ -248,6 +250,15 @@ describe('guardHardAltitudeViability — bandas nuevas cacao/chontaduro/quinua (
     const r = guardHardAltitudeViability(resp, { userMessage: user });
     expect(r.modified).toBe(false);
   });
+
+  it('BORDE-? papa validada a 1.800 m → suprime por banda nueva', () => {
+    const user = 'quiero sembrar papa a 1.800 metros en clima templado';
+    const resp = 'La papa se da bien a 1.800 msnm y produce buena cosecha con riego.';
+    const r = guardHardAltitudeViability(resp, { userMessage: user });
+    expect(r.modified).toBe(true);
+    expect(r.text.toLowerCase()).toMatch(/no es viable|inviable/);
+    expect(r.text.toLowerCase()).toContain('papa');
+  });
 });
 
 describe('guardWarmLowlandColdCrop — cultivo de frío en tierra caliente textual (BORDE-009)', () => {
@@ -294,6 +305,42 @@ describe('guardWarmLowlandColdCrop — cultivo de frío en tierra caliente textu
     const resp = 'La quinua no se da en Quibdó: necesita un clima frío de altura, con ese calor no prospera.';
     const r = guardWarmLowlandColdCrop(resp, { userMessage: user });
     expect(r.modified).toBe(false);
+  });
+});
+
+describe('guardColdHighlandWarmCrop — cultivo cálido/templado en páramo/frío textual', () => {
+  it('cafe en paramo → suprime, advierte que no va en ese piso', () => {
+    const user = 'puedo sembrar cafe en paramo?';
+    const resp = 'Sí, el café se puede sembrar en el páramo con sombra y riego; se da bien.';
+    const r = guardColdHighlandWarmCrop(resp, { userMessage: user });
+    expect(r.modified).toBe(true);
+    expect(r.text.toLowerCase()).toMatch(/caf[eé]/);
+    expect(r.text.toLowerCase()).toMatch(/no va en el páramo|no va en ese piso/);
+    expect(r.text.toLowerCase()).toContain('inviable');
+  });
+
+  it('platano en paramo → suprime, advierte tierra cálida o templada', () => {
+    const user = 'en el paramo quiero platano';
+    const resp = 'El plátano se da bien en el páramo con riego y abrigo, es viable.';
+    const r = guardColdHighlandWarmCrop(resp, { userMessage: user });
+    expect(r.modified).toBe(true);
+    expect(r.text.toLowerCase()).toContain('plátano');
+    expect(r.text.toLowerCase()).toMatch(/tierra c[aá]lida|templada/);
+  });
+
+  it('anti-FP: papa en frio es valido, no se toca', () => {
+    const user = 'papa en frio';
+    const resp = 'La papa se da muy bien en clima frio, es una especie de altura.';
+    const r = guardColdHighlandWarmCrop(resp, { userMessage: user });
+    expect(r.modified).toBe(false);
+  });
+
+  it('anti-FP: papa en tierra caliente sigue bloqueada por el guard existente', () => {
+    const user = 'en tierra caliente quiero papa';
+    const resp = 'La papa se puede sembrar en tierra caliente con sombrio y riego, se da bien.';
+    const r = guardWarmLowlandColdCrop(resp, { userMessage: user });
+    expect(r.modified).toBe(true);
+    expect(r.text.toLowerCase()).toContain('inviable');
   });
 });
 

--- a/src/services/externalAiPromptBuilder.js
+++ b/src/services/externalAiPromptBuilder.js
@@ -12,6 +12,8 @@
  *       hay evidencia — mismo estándar que el prompt principal del agente.
  */
 
+import { normalizeForMatch } from '../utils/speciesResolver.js';
+
 const MAX_USER_FIELD_LEN = 500;
 
 // Patrones de inyección de prompt más comunes en castellano/inglés.
@@ -82,6 +84,50 @@ function resolveThermalZones(thermalZones, altitudMsnm) {
     return derived ? [derived] : [];
 }
 
+function normalizeThermalZoneValue(value) {
+    return normalizeForMatch(value);
+}
+
+function toThermalZoneList(value) {
+    if (Array.isArray(value)) return value.filter(Boolean).map((item) => String(item));
+    if (value == null || value === '') return [];
+    return [String(value)];
+}
+
+function formatThermalZoneList(value) {
+    const zones = toThermalZoneList(value);
+    return zones.length > 0 ? zones.join(', ') : '';
+}
+
+/**
+ * Construye una restriccion dura cuando el piso del usuario no coincide con
+ * los pisos reales de la especie.
+ * @param {string|string[]} userPiso
+ * @param {string[]} speciesThermalZones
+ * @returns {string}
+ */
+export function buildThermalMismatchBlock(userPiso, speciesThermalZones) {
+    const userZones = toThermalZoneList(userPiso);
+    const speciesZones = toThermalZoneList(speciesThermalZones);
+
+    if (userZones.length === 0 || speciesZones.length === 0) return '';
+
+    const userNormalized = new Set(userZones.map(normalizeThermalZoneValue).filter(Boolean));
+    const speciesNormalized = new Set(speciesZones.map(normalizeThermalZoneValue).filter(Boolean));
+
+    if (userNormalized.size === 0 || speciesNormalized.size === 0) return '';
+
+    for (const zone of userNormalized) {
+        if (speciesNormalized.has(zone)) return '';
+    }
+
+    const userLabel = formatThermalZoneList(userZones);
+    const speciesLabel = formatThermalZoneList(speciesZones);
+    if (!userLabel || !speciesLabel) return '';
+
+    return `RESTRICCION DE PISO TERMICO: este cultivo NO figura en el piso ${userLabel}; sus pisos reales son ${speciesLabel}. Si el usuario pregunta por sembrarlo en ${userLabel}, adviertele que es INVIABLE y ofrece alternativas reales; NO valides la siembra.`;
+}
+
 /**
  * Construye un prompt de gremio agroecológico.
  * @param {Object} ctx - Contexto de la especie y el gremio
@@ -91,6 +137,7 @@ function resolveThermalZones(thermalZones, altitudMsnm) {
  * @param {string[]} [ctx.companions] - IDs o nombres de compañeros ya considerados
  * @param {string[]} [ctx.antagonists] - IDs o nombres de antagonistas conocidos
  * @param {string[]} [ctx.thermalZones] - Pisos térmicos (frio, templado, etc.)
+ * @param {string[]} [ctx.speciesThermalZones] - Pisos térmicos reales de la especie
  * @param {number} [ctx.altitudMsnm] - Altitud en metros sobre el nivel del mar
  * @param {string} [ctx.municipio] - Municipio/departamento
  */
@@ -102,12 +149,14 @@ export function buildGuildExternalPrompt(ctx) {
         companions = [],
         antagonists = [],
         thermalZones = [],
+        speciesThermalZones = [],
         altitudMsnm,
         municipio,
     } = ctx;
 
     const resolvedZones = resolveThermalZones(thermalZones, altitudMsnm);
     const zonaTermica = resolvedZones.length > 0 ? resolvedZones.join(', ') : 'no especificado';
+    const thermalMismatchBlock = buildThermalMismatchBlock(resolvedZones, speciesThermalZones);
     const altitudStr = altitudMsnm ? `${altitudMsnm} msnm` : 'altitud no especificada';
     const ubicacion = [altitudStr, municipio].filter(Boolean).join(', ');
     const companionsStr = companions.length > 0 ? companions.join(', ') : 'ninguno aún';
@@ -127,6 +176,7 @@ PREGUNTA:
 Sugiere 5 compañeros adicionales para esta especie en un gremio agroecológico colombiano, priorizando fijación de N, repelencia de plagas, cobertura de suelo, y atractor de polinizadores. Para cada compañero: (a) nombre científico, (b) rol ecológico específico, (c) distancia óptima de siembra, (d) compatibilidad con mi piso térmico.
 
 Responde SOLO en JSON válido: array de objetos con keys name, scientific_name, role, distance_m, notes.` +
+        (thermalMismatchBlock ? `\n\n${thermalMismatchBlock}` : '') +
         ANTI_HALLUCINATION_GUARDRAIL).trim();
 }
 
@@ -136,6 +186,7 @@ Responde SOLO en JSON válido: array de objetos con keys name, scientific_name, 
  * @param {string} ctx.speciesName - Nombre común de la especie
  * @param {string} [ctx.scientificName] - Nombre científico
  * @param {string[]} [ctx.thermalZones] - Pisos térmicos
+ * @param {string[]} [ctx.speciesThermalZones] - Pisos térmicos reales de la especie
  * @param {number} [ctx.altitudMsnm] - Altitud en msnm
  * @param {string} [ctx.municipio] - Municipio/departamento
  * @param {number} [ctx.humedad] - Humedad relativa %
@@ -150,6 +201,7 @@ export function buildDiagnosticExternalPrompt(ctx) {
         speciesName = 'cultivo',
         scientificName,
         thermalZones = [],
+        speciesThermalZones = [],
         altitudMsnm,
         municipio,
         humedad,
@@ -165,6 +217,7 @@ export function buildDiagnosticExternalPrompt(ctx) {
 
     const resolvedZones = resolveThermalZones(thermalZones, altitudMsnm);
     const zonaTermica = resolvedZones.length > 0 ? resolvedZones.join(', ') : 'no especificado';
+    const thermalMismatchBlock = buildThermalMismatchBlock(resolvedZones, speciesThermalZones);
     const altitudStr = altitudMsnm ? `${altitudMsnm} msnm` : 'altitud no especificada';
     const ubicacion = [altitudStr, municipio].filter(Boolean).join(', ');
     const especieFull = scientificName ? `${scientificName} (${speciesName})` : speciesName;
@@ -191,6 +244,7 @@ Realiza un diagnóstico diferencial priorizando causas más probables a esta alt
 (a) prueba casera de confirmación
 (b) biopreparado agroecológico de tratamiento (NO agroquímicos sintéticos; respetar normativa IFOAM)
 (c) medida preventiva para ciclos futuros` +
+        (thermalMismatchBlock ? `\n\n${thermalMismatchBlock}` : '') +
         ANTI_HALLUCINATION_GUARDRAIL).trim();
 }
 
@@ -203,6 +257,7 @@ export function buildOpenExternalPrompt(ctx) {
         speciesName = 'especie',
         scientificName,
         thermalZones = [],
+        speciesThermalZones = [],
         altitudMsnm,
         municipio,
         pregunta: preguntaRaw = '[Escribe tu pregunta aquí]',
@@ -213,6 +268,7 @@ export function buildOpenExternalPrompt(ctx) {
 
     const resolvedZones = resolveThermalZones(thermalZones, altitudMsnm);
     const zonaTermica = resolvedZones.length > 0 ? resolvedZones.join(', ') : 'no especificado';
+    const thermalMismatchBlock = buildThermalMismatchBlock(resolvedZones, speciesThermalZones);
     const altitudStr = altitudMsnm ? `${altitudMsnm} msnm` : 'altitud no especificada';
     const ubicacion = [altitudStr, municipio].filter(Boolean).join(', ');
     const especieFull = scientificName ? `${scientificName} (${speciesName})` : speciesName;
@@ -224,5 +280,5 @@ CONTEXTO:
 - Especie: ${especieFull}
 
 PREGUNTA:
-${pregunta}` + ANTI_HALLUCINATION_GUARDRAIL).trim();
+${pregunta}` + (thermalMismatchBlock ? `\n\n${thermalMismatchBlock}` : '') + ANTI_HALLUCINATION_GUARDRAIL).trim();
 }

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -6899,8 +6899,8 @@ export function guardInventedBrand(responseText) {
  * ENCIMA de `max` es INVIABLE (no zona-gris). `range` es el texto del rango viable
  * que devolvemos al campesino en la corrección.
  *
- * Solo cultivos de clima inequívoco/acotado: los de banda ancha (maíz, fríjol, yuca)
- * NO entran — su tolerancia amplia haría falsos positivos. La altitud sale de la
+ * Solo cultivos de clima inequívoco/acotado: los de banda ancha (maíz, fríjol)
+ * NO entran. La altitud sale de la
  * PREGUNTA del usuario (o de la respuesta): el caso del bench es "café a 3600 m",
  * "Hass a 2800 m", "mora a 450 m" — datos que el operador da en su mensaje.
  */
@@ -6971,6 +6971,94 @@ const HARD_ALTITUDE_BANDS = [
     max: 3800,
     range: '2200–3600 msnm (clima frío/de altura)',
   },
+  {
+    names: ['platano', 'plátano'],
+    binomial: 'musa x paradisiaca',
+    display: 'plátano',
+    min: 0,
+    max: 2200,
+    range: '0–2200 msnm (tierra cálida/templada)',
+  },
+  {
+    names: ['banano', 'guineo'],
+    binomial: 'musa acuminata',
+    display: 'banano / guineo',
+    min: 0,
+    max: 1300,
+    range: '0–1300 msnm (tierra cálida/templada)',
+  },
+  {
+    names: ['yuca', 'yuca dulce', 'yuca de comer'],
+    binomial: 'manihot esculenta',
+    display: 'yuca dulce',
+    min: 0,
+    max: 2000,
+    range: '0–2000 msnm (tierra cálida/templada)',
+  },
+  {
+    names: ['piña', 'pina'],
+    binomial: 'ananas comosus',
+    display: 'piña',
+    min: 0,
+    max: 1500,
+    range: '0–1500 msnm (tierra cálida)',
+  },
+  {
+    names: ['papaya'],
+    binomial: 'carica papaya',
+    display: 'papaya',
+    min: 0,
+    max: 1600,
+    range: '0–1600 msnm (tierra cálida/templada)',
+  },
+  {
+    names: ['mango'],
+    binomial: 'mangifera indica',
+    display: 'mango',
+    min: 0,
+    max: 1800,
+    range: '0–1800 msnm (tierra cálida)',
+  },
+  {
+    names: ['arroz'],
+    binomial: 'oryza sativa',
+    display: 'arroz',
+    min: 0,
+    max: 1300,
+    range: '0–1300 msnm (tierra cálida/templada)',
+  },
+  {
+    names: ['papa', 'papa parda pastusa', 'papa comun', 'pastusa'],
+    binomial: 'solanum tuberosum',
+    display: 'papa',
+    min: 2400,
+    max: 3400,
+    range: '2400–3400 msnm (clima frío)',
+  },
+  {
+    names: ['lulo', 'naranjilla', 'chuva'],
+    binomial: 'solanum quitoense',
+    display: 'lulo / naranjilla / chuva',
+    min: 1200,
+    max: 2800,
+    range: '1200–2800 msnm (clima templado/frío)',
+  },
+  {
+    names: ['tomate de arbol', 'tomate de árbol', 'tamarillo', 'tomate de palo', 'tomate de monte', 'tomate cimarron', 'tomate cimarrón'],
+    binomial: 'solanum betaceum',
+    display: 'tomate de árbol',
+    min: 1200,
+    max: 3000,
+    range: '1200–3000 msnm (clima templado/frío)',
+  },
+  {
+    names: ['gulupa'],
+    binomial: 'passiflora edulis f. edulis',
+    display: 'gulupa',
+    min: 1600,
+    max: 2600,
+    range: '1600–2600 msnm (clima templado/frío)',
+  },
 ];
 
 /**
@@ -6987,7 +7075,7 @@ const HARD_PROMOTES_CROP_RE =
  * promoviendo → no hay nada que suprimir. Sobre texto normalizado.
  */
 const HARD_ALREADY_INVIABLE_RE =
-  /(no\s+es\s+viable|inviable|no\s+se\s+da\b|no\s+prosper|demasiad[oa]\s+(frio|fria|alt|caliente|calid[oa])|no\s+(la?\s+)?siembres|no\s+(es\s+)?recomendable\s+(sembrar|cultivar))/;
+  /(\bno\s+es\s+viable\b|inviable|\bno\s+se\s+da\b|\bno\s+prosper|\bdemasiad[oa]\s+(frio|fria|alt|caliente|calid[oa])\b|\bno\s+(la?\s+)?siembres\b|\bno\s+(es\s+)?recomendable\s+(sembrar|cultivar)\b)/;
 
 /** Marca idempotente del reemplazo de inviabilidad dura. */
 const HARD_ALTITUDE_MARKER = 'no es viable a esa altura';
@@ -7035,6 +7123,15 @@ function _hardAltitudeReplacement(band, alt, demasiadoAlto) {
     `Si quieres sembrar a ${alt} msnm, mejor escoge un cultivo que sí corresponda a esa altura, y con gusto te ` +
     'oriento cuáles se dan bien ahí.'
   );
+}
+
+function _bandNameHit(norm, name) {
+  const needle = _stripDiacritics(name);
+  if (!needle) return false;
+  if (/^[a-z0-9]+$/.test(needle) && needle.length <= 5) {
+    return new RegExp(`\\b${_escapeRegExpLiteral(needle)}\\b`).test(norm);
+  }
+  return norm.includes(needle);
 }
 
 /**
@@ -7099,7 +7196,7 @@ export function guardHardAltitudeViability(responseText, { userMessage = null } 
   }
 
   for (const band of HARD_ALTITUDE_BANDS) {
-    const nameHit = band.names.some((n) => norm.includes(_stripDiacritics(n)));
+    const nameHit = band.names.some((n) => _bandNameHit(norm, n));
     if (!nameHit && !norm.includes(band.binomial)) continue;
     for (const alt of altitudes) {
       const demasiadoAlto = alt > band.max;
@@ -7386,7 +7483,7 @@ const WARM_COLD_PROMOTES_RE =
  * calor", "inviable" → no re-suprimimos. Anti-FP central. Sobre normalizado.
  */
 const WARM_COLD_ALREADY_FLAGS_RE =
-  /(no\s+se\s+da\b|no\s+prosper|inviable|no\s+es\s+viable|necesita\s+(un\s+)?clima\s+(frio|de\s+altura|fresco)|es\s+de\s+(clima\s+)?(frio|tierra\s+fria|altura)|no\s+(aguanta|resiste|soporta)\s+(el\s+)?calor|demasiado\s+(calor|calid)|no\s+es\s+(el\s+)?clima\s+(adecuad|para))/;
+  /(\bno\s+se\s+da\b|\bno\s+prosper|inviable|\bno\s+es\s+viable\b|necesita\s+(un\s+)?clima\s+(frio|de\s+altura|fresco)|es\s+de\s+(clima\s+)?(frio|tierra\s+fria|altura)|\bno\s+(aguanta|resiste|soporta)\s+(el\s+)?calor\b|demasiado\s+(calor|calid)|\bno\s+es\s+(el\s+)?clima\s+(adecuad|para)\b)/;
 
 /**
  * Construye la corrección de inviabilidad por clima para un cultivo de frío en
@@ -7464,6 +7561,183 @@ export function guardWarmLowlandColdCrop(responseText, { userMessage = null } = 
     text: _warmColdCropReplacement(coldCrop, climaUsuario),
     modified: true,
     reason: `cultivo_frio_en_tierra_caliente: ${coldCrop.names[0]}${warmToponym ? ` (${warmToponym})` : ''}`,
+  };
+}
+
+// ── GUARD: cultivo cálido/templado promovido en páramo/frío textual ─────────
+
+const COLD_HIGHLAND_USER_RE =
+  /\b(paramo[s]?|subparamo[s]?|tierra\s+fria|clima\s+frio|zona\s+fria|frio\s+de\s+altura)\b/;
+
+const COLD_HIGHLAND_TOPONYMS = [
+  'bogota',
+  'tunja',
+  'zipaquira',
+  'sumapaz',
+  'duitama',
+  'sogamoso',
+  'fomeque',
+  'ventaquemada',
+];
+
+const COLD_HIGHLAND_WARM_CROP_MARKER = 'no va en ese piso';
+
+const COLD_HIGHLAND_PROMOTES_RE =
+  /(se\s+da\b|es\s+viable|opcion\s+viable|se\s+puede\s+(cultivar|sembrar|dar)|siembr\w*|sembr\w*|cultiv\w*|manej\w*|aguanta\b|resiste\b|adaptad[oa]\b|se\s+cultiva|produce\b|para\s+(la\s+)?mejor\s+cosecha|distancia\s+de\s+siembra|metros\s+entre\s+plantas)/;
+
+const COLD_HIGHLAND_ALREADY_FLAGS_RE =
+  /(\bno\s+se\s+da\b|\bno\s+prosper|inviable|\bno\s+es\s+viable\b|\bno\s+(aguanta|resiste|soporta)\s+(el\s+)?frio\b|\bno\s+es\s+(el\s+)?(clima|piso|la\s+altura|altura)\s+(adecuad|correct|apropiad|ideal)\b|\bno\s+corresponde\s+a\s+ese\s+(clima|piso|altura)\b|\bdemasiad[oa]\s+frio\b|\bdemasiado\s+fria\b)/;
+
+const COLD_HIGHLAND_CROP_MARKERS = [
+  {
+    names: ['cacao'],
+    display: 'cacao',
+    climate: 'tierra cálida',
+    binomial: 'theobroma cacao',
+  },
+  {
+    names: ['platano', 'plátano'],
+    display: 'plátano',
+    climate: 'tierra cálida o templada',
+    binomial: 'musa x paradisiaca',
+  },
+  {
+    names: ['banano', 'guineo'],
+    display: 'banano / guineo',
+    climate: 'tierra cálida o templada',
+    binomial: 'musa acuminata',
+  },
+  {
+    names: ['yuca', 'yuca dulce', 'yuca de comer'],
+    display: 'yuca dulce',
+    climate: 'tierra cálida o templada',
+    binomial: 'manihot esculenta',
+  },
+  {
+    names: ['mango'],
+    display: 'mango',
+    climate: 'tierra cálida',
+    binomial: 'mangifera indica',
+  },
+  {
+    names: ['papaya'],
+    display: 'papaya',
+    climate: 'tierra cálida o templada',
+    binomial: 'carica papaya',
+  },
+  {
+    names: ['arroz'],
+    display: 'arroz',
+    climate: 'tierra cálida o templada',
+    binomial: 'oryza sativa',
+  },
+  {
+    names: ['piña', 'pina'],
+    display: 'piña',
+    climate: 'tierra cálida',
+    binomial: 'ananas comosus',
+  },
+  {
+    names: ['chontaduro'],
+    display: 'chontaduro',
+    climate: 'tierra cálida',
+    binomial: 'bactris gasipaes',
+  },
+  {
+    names: ['palma'],
+    display: 'palma',
+    climate: 'tierra cálida',
+    binomial: 'bactris gasipaes',
+  },
+  {
+    names: ['maranon', 'marañón', 'merey'],
+    display: 'marañón',
+    climate: 'tierra cálida',
+    binomial: 'anacardium occidentale',
+  },
+  {
+    names: ['copoazu', 'copoazú', 'cupuacu', 'cupuaçu'],
+    display: 'copoazú',
+    climate: 'tierra cálida',
+    binomial: 'theobroma grandiflorum',
+  },
+  {
+    names: ['cafe', 'cafe arabica', 'cafe de altura', 'cafeto'],
+    display: 'café',
+    climate: 'tierra templada o fría, no de páramo',
+    binomial: 'coffea arabica',
+  },
+];
+
+function _coldHighlandContextFromText(userNorm) {
+  if (typeof userNorm !== 'string' || !userNorm) return null;
+  if (COLD_HIGHLAND_USER_RE.test(userNorm)) {
+    if (/\bparamo[s]?\b/.test(userNorm)) {
+      return { label: 'en el páramo', reasonSuffix: 'páramo', kind: 'paramo' };
+    }
+    return { label: 'en clima frío', reasonSuffix: 'clima frio', kind: 'frio' };
+  }
+  const toponym = COLD_HIGHLAND_TOPONYMS.find((t) => userNorm.includes(t)) || null;
+  if (!toponym) return null;
+  return { label: 'en clima frío', reasonSuffix: toponym, kind: 'toponym' };
+}
+
+function _coldHighlandWarmCropReplacement(entry, pisoLabel) {
+  const binom = entry.binomial ? ` (${_displayBinomial(entry.binomial)})` : '';
+  return (
+    `Ojo: ${entry.display}${binom} no va ${pisoLabel}; es un cultivo de ${entry.climate}. ` +
+    'Sembrarlo ahi es inviable.'
+  );
+}
+
+/**
+ * guardColdHighlandWarmCrop - espejo de guardWarmLowlandColdCrop. Detecta un
+ * cultivo cálido o templado promovido en un piso de páramo o frío descrito por
+ * palabra o toponimo, y reemplaza por una advertencia determinista.
+ *
+ * Firma propia (necesita userMessage) - se invoca aparte en applyOutputGuards.
+ *
+ * @param {string} responseText
+ * @param {{userMessage?: string|null}} [ctx]
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardColdHighlandWarmCrop(responseText, { userMessage = null } = {}) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  if (responseText.includes(COLD_HIGHLAND_WARM_CROP_MARKER)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const userNorm = typeof userMessage === 'string' ? _stripDiacritics(userMessage) : '';
+  const coldContext = _coldHighlandContextFromText(userNorm);
+  if (!coldContext) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const norm = _stripDiacritics(responseText);
+  if (COLD_HIGHLAND_ALREADY_FLAGS_RE.test(norm)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  if (!COLD_HIGHLAND_PROMOTES_RE.test(norm)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const crop = COLD_HIGHLAND_CROP_MARKERS.find((entry) =>
+    entry.names.some((name) => _bandNameHit(userNorm, name)),
+  ) || COLD_HIGHLAND_CROP_MARKERS.find((entry) => entry.names.some((name) => _bandNameHit(norm, name)));
+  if (!crop) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  if (crop.display === 'café' && coldContext.kind === 'frio') {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  bumpGuardTelemetry('cold_highland_warm_crop');
+  return {
+    text: _coldHighlandWarmCropReplacement(crop, coldContext.label),
+    modified: true,
+    reason: `cultivo_calido_en_piso_frio: ${crop.display} (${coldContext.reasonSuffix})`,
   };
 }
 
@@ -10090,6 +10364,19 @@ export function applyOutputGuards(
     const wcc = guardWarmLowlandColdCrop(text, { userMessage });
     if (wcc && wcc.modified) {
       return { text: wcc.text, modified: true, reasons: wcc.reason ? [wcc.reason] : [] };
+    }
+  }
+
+  // GUARD CULTIVO CÁLIDO/TEMPLADO en PÁRAMO/FRÍO textual: cuando el usuario
+  // describe un piso frío o un topónimo altoandino y la respuesta promueve cacao,
+  // plátano, banano, yuca, mango, papaya, arroz, piña, chontaduro, palma, marañón,
+  // copoazú o café como si fueran viables ahí, SUPRIME el cuerpo y lo REEMPLAZA por
+  // una advertencia determinista. Complementa a guardHardAltitudeViability, que
+  // exige altitud numérica.
+  if (runPlantingGuards && !(vis && vis.modified)) {
+    const chw = guardColdHighlandWarmCrop(text, { userMessage });
+    if (chw && chw.modified) {
+      return { text: chw.text, modified: true, reasons: chw.reason ? [chw.reason] : [] };
     }
   }
 


### PR DESCRIPTION
## Summary\n- Closes HUECO B with a deterministic client-side inverse guard for warm crops promoted in páramo or cold highland wording.\n- Expands hard altitude bands with catalog-derived crops and ranges so numeric altitude checks cover more frequent cases.\n- Adds regression tests for cafe in paramo, platano in paramo, papa in cold text, and papa remaining blocked in warm text.\n\n## Test plan\n- npx vitest run src/services/__tests__/outputGuards.bordeRecipeToxCureAltitude.test.js src/services/__tests__/outputGuards.hardAltitudeViability.test.js\n- npx eslint src/services/outputGuards.js src/services/__tests__/outputGuards.bordeRecipeToxCureAltitude.test.js --max-warnings=0\n- npm run build