### PR TITLE
feat(jaguar): Jaguar completo — 5 frentes + toque místico chamánico

### DIFF
--- a/src/visual/creatures/Jaguar.jsx
+++ b/src/visual/creatures/Jaguar.jsx
@@ -1,0 +1,360 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, RH_INK, RH_BOCA } from './_rubberhose.jsx';
+import { JAGUAR_PALETA, JAGUAR_PROPORCION, JAGUAR_SLUG, PERFIL_JAGUAR } from './jaguarIdentidad.js';
+import { cuerpoDeClima, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
+import { AccesoriosClima } from './AccesoriosClima.jsx';
+import { LineBoilFilter } from './LineBoilFilter.jsx';
+import { PropEnMano } from './PropEnMano.jsx';
+import { AuraPoder } from './AuraPoder.jsx';
+import { auraDeBicho } from './transformacion.js';
+
+/* Jaguar — Panthera onca (el felino de tierra cálida/selva). Hermano rubber-hose
+   de la abeja Angelita y el oso andino: compone el MISMO kit `_rubberhose.jsx`
+   (ojos de goma, cachetes, sonrisa, miembros manguera) y hereda la MISMA
+   fundación transversal — lip-sync (useLipSync → BocaVisema), modo poder
+   (transformacion, aura PÚRPURA), ropa por clima (ropaDeClima), prop por mundo
+   (PropEnMano) y line-boil (LineBoilFilter) — cero código duplicado. Solo cambia
+   el ANIMAL y su CARÁCTER: felino MUSCULOSO leonado con ROSETAS (manchas de
+   centro ocre, su firma), majestuoso y ACECHADOR. Su seña de vida es el ACECHO
+   DE HOMBROS (los omóplatos suben al moverse), la COLA que ondea con PESO y la
+   mirada felina ÁMBAR intensa; su squash&stretch es controlado y elegante, no
+   hiperactivo (poder contenido). Es de SUELO: acecha, no vuela — sin alas. Su
+   estado-firma es el RUGIDO corporal (`ruge`) y el modo ACECHO (`acecha`). Su
+   color de poder es el PÚRPURA depredador (no el dorado de la abeja ni el rojo
+   del oso). La IDENTIDAD (paleta + proporciones + perfil de clima) vive en
+   `jaguarIdentidad.js`; el CLIMA→cuerpo, en `creatureClimaCuerpo.js` con
+   PERFIL_JAGUAR (pelaje lustroso que escurre agua, robusto ante la seca) — y de
+   tierra cálida: NUNCA suda (aguanta el calor sin sudar ni sombrero). */
+const VIEWBOX = '-16 -20 32 40';
+
+/* Roseta del jaguar: anillo oscuro con centro ocre (la firma de la especie —
+   mancha CON centro, no el puntito del leopardo). Decorativa (aria-hidden en el
+   grupo padre). */
+function Roseta({ cx, cy, r = 1.5, ink, centro, opacity = 0.9 }) {
+  return (
+    <g opacity={opacity}>
+      <ellipse cx={cx} cy={cy} rx={r} ry={r * 0.88} fill="none" stroke={ink} strokeWidth={r * 0.46} />
+      <circle cx={cx} cy={cy} r={r * 0.3} fill={centro} />
+    </g>
+  );
+}
+
+export function Jaguar({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Jaguar',
+  /* Pose de VIDA (idle-life), species-agnostic (gestos rh-g-* de creatures.css):
+     'anda' (base, con acecho de hombros) | 'celebra' (brinca con brazos en V +
+     overshoot) | 'reposo' (respira hondo, agazapado) | 'señala' (se inclina al
+     POI y apunta con la zarpa). Solo corren viva (animated); con animated=false
+     o reduced-motion queda en fotograma digno e imponente. */
+  pose = 'anda',
+  animo = 'sereno',
+  energia = 1,
+  /* CLIMA REAL escrito en el cuerpo (perfil jaguar). Sin clima (avatares,
+     catálogo) = neutro digno: el jaguar se ve EXACTO como siempre. */
+  clima = null,
+  enso = 'neutro',
+  /* ── LIP-SYNC (sistema transversal, useLipSync) ────────────────────────────
+     visema opcional ('V1'..'V4') que produce useLipSync desde el RMS del TTS: la
+     boca se abre cuando el agente narra. Sin visema (o 'V1') = la sonrisa de
+     goma de siempre → avatares/catálogo no cambian. El HOOK vive aparte (no
+     cuelga un AnalyserNode por instancia); acá solo se consume. El RUGIDO manda
+     sobre el visema (una fiera que ruge no articula fonemas). */
+  visema = null,
+  /* ── VESTUARIO por clima+hora (ropaDeClima) ───────────────────────────────
+     OPT-IN: con vestuario=true el jaguar se abriga según el clima real (RUANA de
+     noche/frío — es de tierra cálida y siente el frío pronto). Es de tierra
+     cálida: NUNCA se sobrecalienta → jamás suda ni sombrero (se suprimen aquí
+     aunque el termómetro suba). Default false → los consumidores de `clima`
+     existentes NO ven ropa nueva. */
+  vestuario = false,
+  tempC = undefined,
+  /* ── RUGE (rugido corporal — la fiera ruge) ────────────────────────────────
+     OPT-IN: el jaguar abre las fauces (colmillos + garganta) y el pecho hincha y
+     SUELTA con peso (el rugido leído en el cuerpo). Su reacción-firma imponente.
+     Default false → sin rugido (avatar sereno). */
+  ruge = false,
+  /* ── ACECHA (modo acecho — el depredador se agazapa) ───────────────────────
+     OPT-IN: los omóplatos SUBEN, la cabeza BAJA y el cuerpo avanza lento y
+     controlado (el acecho felino). Su otra reacción-firma. Default false. */
+  acecha = false,
+  /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
+     pleno; 'bajo' apaga el idle continuo (boil + acecho de hombros + cola) y
+     deja los estados reactivos. Sin prop (standalone: avatares, catálogo) = pleno. */
+  tier,
+  /* ── LÍNEA QUE RESPIRA (line-boil, Cuphead años 30 — LineBoilFilter) ────────
+     OPT-IN: con lineBoil el CONTORNO del jaguar vibra escalonado (feTurbulence +
+     feDisplacement, ~8fps) — el trazo "hierve" como dibujo animado clásico.
+     Default false → los consumidores existentes NO cambian. Con animated=false
+     o reduced-motion queda con seed fija (textura sin vibrar). Capa MÁS cara del
+     kit: reservada para su entrada heroica (galería, hero). */
+  lineBoil = false,
+  /* ── MODO PODER (transformación / power-up PÚRPURA — transformacion.css) ─────
+     OPT-IN: con poder=true (y en modo standalone) el jaguar se envuelve en su
+     aura PÚRPURA depredadora de 4 capas (glow, boost, ingravidez, corrientes) —
+     su firma cuando "sube de nivel". El host lo enciende un rato con
+     usePoderTemporal(). En modo inline el power-up lo pone el host DOM
+     (::before/mix-blend no aplican a nodos SVG); acá solo marcamos data-poder por
+     si el host lo consulta. */
+  poder = false,
+  /* ── PROP POR MUNDO (herramienta en la zarpa — propsPorMundo/PropEnMano) ─────
+     mundoId opcional: al ENTRAR a un mundo el jaguar carga su herramienta
+     (agua→manguerita, suelo→lupa, animales→lazo, semillero→canasto…). Sin
+     mundoId (o mundo sin prop) entra con las zarpas libres. Va en su zarpa
+     IZQUIERDA (la cola cae al lado DERECHO: prop y cola no se pisan). */
+  mundoId = null,
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const boil = `crt-boil-${uid}`;
+  const vivo = animated;
+  const auraOp = Math.max(0.14, Math.min(0.42, 0.18 + 0.26 * (energia ?? 1)));
+  const auraR = 8.5 + 1.6 * (energia ?? 1);
+
+  // CLIMA → cuerpo (determinista, una vez por render): tinte + opacidad al
+  // contorno. El jaguar no tiene alas (velocidadAlas siempre 1: no se usa).
+  const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: PERFIL_JAGUAR });
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
+
+  // Vestuario por clima+hora (opt-in). Perfil jaguar de TIERRA CÁLIDA: la RUANA
+  // de noche/frío; NUNCA sombrero ni sudor (aunque suba el termómetro) — el
+  // jaguar no se sobrecalienta. Los suprimimos aquí sin tocar la función
+  // compartida (su contrato/tests siguen intactos). Sin vestuario/clima → nada.
+  const ropaBase = (vestuario && clima) ? ropaDeClimaBicho(JAGUAR_SLUG, clima, { tempC }) : null;
+  const ropa = ropaBase ? { ...ropaBase, sombrero: false, sudor: false } : null;
+
+  const P = JAGUAR_PALETA;
+  const PR = JAGUAR_PROPORCION;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+      {/* Line-boil (contorno que hierve) — solo se instancia si se pide. */}
+      {lineBoil && <LineBoilFilter id={boil} animated={vivo} />}
+    </defs>
+  );
+
+  // PROP DEL MUNDO en la zarpa izquierda (el lado libre; la cola cae a la
+  // derecha). Sin mundoId o mundo sin prop → PropEnMano devuelve null (zarpas
+  // libres, nunca rompe la escena).
+  const propMundo = mundoId ? (
+    <PropEnMano mundoId={mundoId} x={-11.2} y={7.6} escala={0.72} ink={RH_INK} animated={vivo} />
+  ) : null;
+
+  // BOCA: precedencia RUGIDO > visema > sonrisa. La fiera que ruge abre las
+  // fauces con colmillos + garganta (no articula fonemas); si narra sin rugir,
+  // el visema; en reposo, la sonrisa de goma de siempre.
+  const boca = ruge ? (
+    <g className="jaguar-rugido-boca" aria-hidden="true">
+      <ellipse cx="0" cy="-2.9" rx="2.5" ry="2.1" fill={RH_BOCA} stroke={RH_INK} strokeWidth="0.9" />
+      {/* colmillos superiores (el rugido) */}
+      <path className="jaguar-colmillo" d="M-1.5,-4.4 L-0.7,-4.4 L-1.1,-2.5 Z" fill={P.colmillo} stroke={RH_INK} strokeWidth="0.3" />
+      <path className="jaguar-colmillo" d="M1.5,-4.4 L0.7,-4.4 L1.1,-2.5 Z" fill={P.colmillo} stroke={RH_INK} strokeWidth="0.3" />
+      {/* lengua */}
+      <path d="M-1.1,-2.0 Q0,-0.7 1.1,-2.0 Z" fill="#d1615a" />
+    </g>
+  ) : visema
+    ? <BocaVisema cx={0} cy={-3.4} w={3.4} prof={1.3} visema={visema} />
+    : <Sonrisa cx={0} cy={-3.6} w={3.2} prof={1.2} />;
+
+  // ── CUERPO rubber-hose (atrás→adelante): aura, cola pesada, orejas, patas,
+  //    tronco leonado con vientre crema, rosetas, omóplatos del acecho, bracitos
+  //    manguera, cabeza (hocico + cejas fieras + ojos ámbar/cachetes/boca +
+  //    trufa). `.crt-body` es el nodo que squashea (boil idle jaguar: lento,
+  //    controlado y elegante — poder contenido).
+  const body = (
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* aura viva */}
+      <circle cx="0" cy="2" r={auraR} fill={P.cuerpo} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* COLA LARGA que ondea con PESO (la firma del acecho, al lado derecho para
+          no pisar el prop de la zarpa izquierda). Pivota desde su base en el
+          lomo. Rosetas + punta oscura. */}
+      <g className={vivo ? 'jaguar-cola' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'left bottom' }}>
+        <path d="M8.4,5.4 C13.2,4.4 15.4,0.2 13.8,-4.4 C13.0,-6.6 11.2,-7.2 9.6,-6.4"
+          fill="none" stroke={P.cuerpo} strokeWidth="3.0" strokeLinecap="round" />
+        {/* contorno de tinta encima (la línea que manda del rubber-hose) */}
+        <path d="M8.4,5.4 C13.2,4.4 15.4,0.2 13.8,-4.4 C13.0,-6.6 11.2,-7.2 9.6,-6.4"
+          fill="none" stroke={RH_INK} strokeWidth="0.7" strokeLinecap="round" opacity="0.55" />
+        {/* punta oscura + rosetas de la cola */}
+        <circle cx="9.9" cy="-6.2" r="1.5" fill={P.roseta} />
+        <Roseta cx={13.7} cy={-1.0} r={1.15} ink={P.roseta} centro={P.rosetaCentro} opacity={0.85} />
+        <Roseta cx={11.4} cy={3.6} r={1.1} ink={P.roseta} centro={P.rosetaCentro} opacity={0.85} />
+      </g>
+
+      {/* orejas redondas de felino (detrás de la cabeza, se mecen con
+          follow-through) */}
+      <g className={vivo ? 'rh-sway' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center bottom', animationDelay: '-0.2s' }}>
+        <circle cx="-4.4" cy="-13.4" r={PR.orejaR} fill={P.cuerpo} stroke={RH_INK} strokeWidth="1.2" />
+        <circle cx="-4.4" cy="-13.4" r={PR.orejaR * 0.5} fill={P.oreja} />
+      </g>
+      <g className={vivo ? 'rh-sway' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center bottom', animationDelay: '-0.5s' }}>
+        <circle cx="4.4" cy="-13.4" r={PR.orejaR} fill={P.cuerpo} stroke={RH_INK} strokeWidth="1.2" />
+        <circle cx="4.4" cy="-13.4" r={PR.orejaR * 0.5} fill={P.oreja} />
+      </g>
+
+      {/* patas traseras (muslos musculosos con planta crema, detrás del tronco).
+          Se mecen suave. */}
+      <Miembro d="M-6.6,7.0 C-8.6,9.0 -8.8,10.8 -7.4,12.0" ancho={3.4} punta={[-7.4, 12.2]} puntaR={2.0} pie sway={vivo} delay={-0.7} />
+      <Miembro d="M6.6,7.0 C8.6,9.0 8.8,10.8 7.4,12.0" ancho={3.4} punta={[7.4, 12.2]} puntaR={2.0} pie sway={vivo} delay={-1.0} />
+
+      {/* tronco leonado musculoso con contorno grueso (la línea que respira con
+          el boil) */}
+      <ellipse cx="0" cy="2" rx={PR.troncoRx} ry={PR.troncoRy}
+        fill={P.cuerpo} stroke={RH_INK} strokeWidth="1.4"
+        style={{ filter: `drop-shadow(0 0 6px ${P.cuerpoGlow})` }} />
+      {/* vientre/pecho crema */}
+      <path d="M0,-4.2 C4.2,-3.2 5.4,2 4.0,6.2 C2.4,9.0 -2.4,9.0 -4.0,6.2 C-5.4,2 -4.2,-3.2 0,-4.2 Z"
+        fill={P.vientre} opacity="0.9" />
+
+      {/* ROSETAS del cuerpo (manchas de centro ocre — la firma). Decorativas. */}
+      <g aria-hidden="true">
+        <Roseta cx={-5.4} cy={2.6} r={1.5} ink={P.roseta} centro={P.rosetaCentro} />
+        <Roseta cx={-2.0} cy={5.0} r={1.35} ink={P.roseta} centro={P.rosetaCentro} />
+        <Roseta cx={5.6} cy={1.4} r={1.5} ink={P.roseta} centro={P.rosetaCentro} />
+        <Roseta cx={6.6} cy={4.6} r={1.15} ink={P.roseta} centro={P.rosetaCentro} opacity={0.8} />
+        <Roseta cx={2.4} cy={-0.6} r={1.2} ink={P.roseta} centro={P.rosetaCentro} opacity={0.85} />
+        <Roseta cx={-6.6} cy={-0.8} r={1.2} ink={P.roseta} centro={P.rosetaCentro} opacity={0.8} />
+      </g>
+
+      {/* OMÓPLATOS del ACECHO (la firma del jaguar): dos picos musculosos sobre el
+          lomo que SUBEN al moverse (más en modo acecho). Grupo propio
+          (.jaguar-hombros) que la CSS anima. Van sobre el tronco, detrás de la
+          cabeza y los bracitos. */}
+      <g className="jaguar-hombros" style={{ transformBox: 'fill-box', transformOrigin: 'center bottom' }}>
+        <path d="M-6.4,-1.4 Q-4.4,-6.2 -1.8,-2.6 Z" fill={P.hombro} stroke={RH_INK} strokeWidth="1.1" strokeLinejoin="round" />
+        <path d="M6.4,-1.4 Q4.4,-6.2 1.8,-2.6 Z" fill={P.hombro} stroke={RH_INK} strokeWidth="1.1" strokeLinejoin="round" />
+      </g>
+
+      {/* bracitos manguera (zarpas delanteras) con planta crema, pivote en el
+          HOMBRO para que celebra/señala los alcen desde el hombro. */}
+      <Miembro clase="crt-brazo-l" origen="right top"
+        d="M-7.0,-1.2 C-10.0,0.4 -11.0,3.4 -10.0,6.2" ancho={3.2} punta={[-10.0, 6.6]} puntaR={2.1} pie sway={vivo} delay={-0.15} />
+      <Miembro clase="crt-brazo-r" origen="left top"
+        d="M7.0,-1.2 C10.0,0.4 11.0,3.4 10.0,6.2" ancho={3.2} punta={[10.0, 6.6]} puntaR={2.1} pie sway={vivo} delay={-0.45} />
+
+      {/* CABEZA (grupo propio .jaguar-cabeza para que el ACECHO la baje). */}
+      <g className="jaguar-cabeza" style={{ transformBox: 'fill-box', transformOrigin: 'center top' }}>
+        <circle cx="0" cy="-8.2" r={PR.cabezaR} fill={P.cuerpo} stroke={RH_INK} strokeWidth="1.3" />
+        {/* hocico claro que baja al morro */}
+        <path d="M-2.6,-6.6 C-1.2,-5.2 1.2,-5.2 2.6,-6.6 C2.8,-3.6 1.8,-2.0 0,-1.8 C-1.8,-2.0 -2.8,-3.6 -2.6,-6.6 Z"
+          fill={P.hocico} opacity="0.95" />
+        {/* rosetas de la frente/mejillas (la firma también en la cara) */}
+        <g aria-hidden="true">
+          <Roseta cx={-3.4} cy={-10.6} r={0.95} ink={P.roseta} centro={P.rosetaCentro} opacity={0.8} />
+          <Roseta cx={3.4} cy={-10.6} r={0.95} ink={P.roseta} centro={P.rosetaCentro} opacity={0.8} />
+          <Roseta cx={-4.8} cy={-7.6} r={0.85} ink={P.roseta} centro={P.rosetaCentro} opacity={0.7} />
+          <Roseta cx={4.8} cy={-7.6} r={0.85} ink={P.roseta} centro={P.rosetaCentro} opacity={0.7} />
+        </g>
+        {/* CEJAS FIERAS del depredador (mirada intensa y focalizada): trazos
+            angulados con el extremo INTERNO más bajo. Identidad (no opt-in); se
+            fruncen más al rugir/acechar (CSS). En su grupo .jaguar-cejas. */}
+        <g className="jaguar-cejas" stroke={RH_INK} strokeWidth="1.25" strokeLinecap="round" fill="none">
+          <path d="M-5.0,-11.4 L-1.6,-10.3" />
+          <path d="M5.0,-11.4 L1.6,-10.3" />
+        </g>
+        {/* chapetas + boca + trufa + ojos ámbar dentro de la cara */}
+        <Cachetes puntos={[{ cx: -4.4, cy: -6.4, r: 1.2 }, { cx: 4.4, cy: -6.4, r: 1.2 }]} vivo={vivo} />
+        {boca}
+        {/* trufa (nariz) */}
+        <path d="M-1.3,-4.7 L1.3,-4.7 L0,-3.5 Z" fill={P.nariz} />
+        <OjosRubber
+          ojos={[{ cx: -2.5, cy: -9.2, r: 1.7 }, { cx: 2.5, cy: -9.2, r: 1.7 }]}
+          mirar={[0, 0.1]}
+          parpadea={vivo}
+        />
+        {/* MIRADA FELINA ÁMBAR: iris que enmarca la pupila (sobre la esclerótica,
+            fuera del negro de la pupila) → la intensidad del ojo de gato. */}
+        <g aria-hidden="true" fill="none" stroke={P.iris} strokeWidth="0.55" opacity="0.85">
+          <circle cx="-2.5" cy="-9.2" r="1.32" />
+          <circle cx="2.5" cy="-9.2" r="1.32" />
+        </g>
+      </g>
+
+      {/* Vestuario por clima+hora (RUANA de noche/frío) — solo con vestuario=true.
+          Sombrero/sudor van suprimidos (el jaguar de tierra cálida no suda). */}
+      {ropa && (
+        <AccesoriosClima
+          estado={ropa}
+          tronco={{ cx: 0, cy: 2, rx: PR.troncoRx, ry: PR.troncoRy }}
+          cabeza={{ cx: 0, cy: -8.2, r: PR.cabezaR }}
+          animated={vivo}
+        />
+      )}
+
+      {/* Prop del mundo en la zarpa (entra heroico con su herramienta). */}
+      {propMundo}
+    </g>
+  );
+
+  // Antics de VIDA (períodos co-primos) SOLO viva; nodos aparte para no pisar el
+  // boil de `.crt-body`. El CSS los apaga con RM / tier bajo / ánimo bajo /
+  // durante los gestos (celebra/reposo/señala) y estados (ruge/acecha).
+  const conAntics = vivo ? (
+    <g className="rh-antic">
+      <g className="rh-travieso">{body}</g>
+    </g>
+  ) : body;
+  // El line-boil (contorno que hierve) envuelve TODO el dibujo cuando se pide.
+  const cuerpoVivo = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
+
+  const estadoAttrs = {
+    'data-creature': JAGUAR_SLUG,
+    'data-pose': vivo ? pose : undefined,
+    'data-animo': animo,
+    'data-tier': tier || undefined,
+    'data-visema': visema || undefined,
+    'data-ruana': ropa?.ruana ? '1' : undefined,
+    'data-mojado': ropa?.mojado ? '1' : undefined,
+    'data-ruge': ruge ? '1' : undefined,
+    'data-acecha': acecha ? '1' : undefined,
+    'data-lineboil': lineBoil ? '1' : undefined,
+    'data-prop': mundoId || undefined,
+  };
+
+  if (inline) {
+    // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
+    // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
+    return (
+      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+        {defs}
+        {cuerpoVivo}
+      </g>
+    );
+  }
+  const svg = (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
+      <title>{title}</title>
+      {defs}
+      {cuerpoVivo}
+    </svg>
+  );
+  // MODO PODER (standalone): lo envolvemos en su aura PÚRPURA depredadora de 4
+  // capas (transformacion.css: glow radial + boost + ingravidez + corrientes). El
+  // wrapper DOM es lo único que puede llevar ::before/mix-blend/corrientes.
+  if (poder) {
+    return (
+      <span
+        className="is-powered-up jaguar-poder"
+        data-creature-poder={JAGUAR_SLUG}
+        style={{ '--aura-color': auraDeBicho(JAGUAR_SLUG), display: 'inline-flex' }}
+      >
+        {svg}
+        <AuraPoder />
+      </span>
+    );
+  }
+  return svg;
+}
+
+export default Jaguar;

--- a/src/visual/creatures/Jaguar.jsx
+++ b/src/visual/creatures/Jaguar.jsx
@@ -26,7 +26,17 @@ import { auraDeBicho } from './transformacion.js';
    del oso). La IDENTIDAD (paleta + proporciones + perfil de clima) vive en
    `jaguarIdentidad.js`; el CLIMA→cuerpo, en `creatureClimaCuerpo.js` con
    PERFIL_JAGUAR (pelaje lustroso que escurre agua, robusto ante la seca) — y de
-   tierra cálida: NUNCA suda (aguanta el calor sin sudar ni sombrero). */
+   tierra cálida: NUNCA suda (aguanta el calor sin sudar ni sombrero).
+
+   MÍSTICO (cosmología andino-amazónica: el jaguar es el ANIMAL-ESPÍRITU DEL
+   CHAMÁN — transformación, mundo espiritual, visión nocturna, poder sagrado).
+   Tejido con gusto, permanente y sutil: OJOS LUMINOSOS que respiran
+   (fosforescencia, visión nocturna del espíritu), un AURA ESPECTRAL etérea que
+   lo envuelve (no solo en poder), CONSTELACIONES de geometría sagrada sobre las
+   rosetas (estrellas que titilan, patrón andino) y un SHIMMER espectral en el
+   contorno. En modo poder el aura, los ojos y las estrellas se vuelven
+   CHAMÁNICOS (el jaguar-espíritu se revela). Todo se PODA en tier bajo /
+   reduced-motion (queda un fotograma digno y quieto). */
 const VIEWBOX = '-16 -20 32 40';
 
 /* Roseta del jaguar: anillo oscuro con centro ocre (la firma de la especie —
@@ -40,6 +50,35 @@ function Roseta({ cx, cy, r = 1.5, ink, centro, opacity = 0.9 }) {
     </g>
   );
 }
+
+/* Estrella de constelación — el titileo "de geometría sagrada" sobre las
+   rosetas (el jaguar-espíritu lleva el cielo nocturno en la piel). Sparkle de 4
+   puntas; titila (.jaguar-estrella) solo viva — con animated=false / RM queda
+   quieta y digna. */
+function Estrella({ cx, cy, r = 0.9, color, delay = 0, vivo = false }) {
+  const p = r * 0.26;
+  return (
+    <g
+      className={vivo ? 'jaguar-estrella' : undefined}
+      style={{ transformBox: 'fill-box', transformOrigin: 'center', ...(vivo ? { animationDelay: `${delay}s` } : null) }}
+    >
+      <path
+        d={`M${cx},${cy - r} L${cx + p},${cy - p} L${cx + r},${cy} L${cx + p},${cy + p} L${cx},${cy + r} L${cx - p},${cy + p} L${cx - r},${cy} L${cx - p},${cy - p} Z`}
+        fill={color}
+      />
+    </g>
+  );
+}
+
+/* Vértices de la constelación: coinciden con centros de rosetas (frente + lomo)
+   para que el "cielo" viva SOBRE las manchas. */
+const ESTRELLAS = [
+  { cx: -3.4, cy: -10.6, r: 0.85, d: 0 },
+  { cx: 3.4, cy: -10.6, r: 0.85, d: -0.5 },
+  { cx: -5.4, cy: 2.6, r: 0.95, d: -1.1 },
+  { cx: 2.4, cy: -0.6, r: 0.8, d: -0.7 },
+  { cx: 5.6, cy: 1.4, r: 0.95, d: -1.5 },
+];
 
 export function Jaguar({
   size = 64,
@@ -173,6 +212,13 @@ export function Jaguar({
   //    controlado y elegante — poder contenido).
   const body = (
     <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* AURA ESPECTRAL etérea (PERMANENTE, sutil): la presencia sagrada del
+          jaguar-espíritu del chamán envuelve al felino aun en reposo. Late lento
+          y se vuelve CHAMÁNICA en modo poder (CSS). */}
+      <circle className={vivo ? 'jaguar-aura-espectral' : undefined}
+        cx="0" cy="1.4" r={auraR + 2.6} fill={P.espectral} opacity="0.13"
+        filter={`url(#${blur})`}
+        style={{ transformBox: 'fill-box', transformOrigin: 'center' }} aria-hidden="true" />
       {/* aura viva */}
       <circle cx="0" cy="2" r={auraR} fill={P.cuerpo} opacity={auraOp} filter={`url(#${blur})`} />
 
@@ -212,6 +258,12 @@ export function Jaguar({
       <ellipse cx="0" cy="2" rx={PR.troncoRx} ry={PR.troncoRy}
         fill={P.cuerpo} stroke={RH_INK} strokeWidth="1.4"
         style={{ filter: `drop-shadow(0 0 6px ${P.cuerpoGlow})` }} />
+      {/* SHIMMER MÍSTICO — destello espectral sutil en el contorno (se apoya en
+          el glow del cuerpo; el line-boil lo remata en su entrada heroica).
+          Pulsa lento; se intensifica en modo poder (CSS). */}
+      <ellipse className={vivo ? 'jaguar-shimmer' : undefined}
+        cx="0" cy="2" rx={PR.troncoRx} ry={PR.troncoRy}
+        fill="none" stroke={P.espectral} strokeWidth="0.8" opacity="0.16" aria-hidden="true" />
       {/* vientre/pecho crema */}
       <path d="M0,-4.2 C4.2,-3.2 5.4,2 4.0,6.2 C2.4,9.0 -2.4,9.0 -4.0,6.2 C-5.4,2 -4.2,-3.2 0,-4.2 Z"
         fill={P.vientre} opacity="0.9" />
@@ -224,6 +276,19 @@ export function Jaguar({
         <Roseta cx={6.6} cy={4.6} r={1.15} ink={P.roseta} centro={P.rosetaCentro} opacity={0.8} />
         <Roseta cx={2.4} cy={-0.6} r={1.2} ink={P.roseta} centro={P.rosetaCentro} opacity={0.85} />
         <Roseta cx={-6.6} cy={-0.8} r={1.2} ink={P.roseta} centro={P.rosetaCentro} opacity={0.8} />
+      </g>
+
+      {/* CONSTELACIÓN — geometría sagrada sobre las rosetas: líneas etéreas
+          punteadas (el patrón andino) + estrellas que TITILAN en los centros de
+          mancha. El cielo nocturno del jaguar-espíritu. Decorativa. */}
+      <g className="jaguar-constelacion" aria-hidden="true">
+        <path d="M-3.4,-10.6 L3.4,-10.6" fill="none" stroke={P.espectral}
+          strokeWidth="0.3" strokeLinecap="round" strokeDasharray="0.5 1.1" opacity="0.28" />
+        <path d="M-5.4,2.6 L2.4,-0.6 L5.6,1.4" fill="none" stroke={P.espectral}
+          strokeWidth="0.3" strokeLinecap="round" strokeDasharray="0.5 1.1" opacity="0.28" />
+        {ESTRELLAS.map((e, i) => (
+          <Estrella key={i} cx={e.cx} cy={e.cy} r={e.r} delay={e.d} color={P.estrella} vivo={vivo} />
+        ))}
       </g>
 
       {/* OMÓPLATOS del ACECHO (la firma del jaguar): dos picos musculosos sobre el
@@ -277,6 +342,14 @@ export function Jaguar({
         <g aria-hidden="true" fill="none" stroke={P.iris} strokeWidth="0.55" opacity="0.85">
           <circle cx="-2.5" cy="-9.2" r="1.32" />
           <circle cx="2.5" cy="-9.2" r="1.32" />
+        </g>
+        {/* OJOS LUMINOSOS — fosforescencia del espíritu (visión nocturna del
+            chamán): un halo suave que respira sobre cada ojo. Sutil siempre;
+            CHAMÁNICO (más brillante) en modo poder (CSS). */}
+        <g className={vivo ? 'jaguar-ojo-brillo' : undefined} filter={`url(#${blur})`} aria-hidden="true"
+          style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+          <circle cx="-2.5" cy="-9.2" r="1.15" fill={P.ojoBrillo} opacity="0.55" />
+          <circle cx="2.5" cy="-9.2" r="1.15" fill={P.ojoBrillo} opacity="0.55" />
         </g>
       </g>
 

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -24,6 +24,7 @@ calidad dispar. Aquí vive la **versión canónica** de cada uno.
 | `Colibri` | *Colibri coruscans* | Colibrí chillón andino. Pico largo, garganta violeta, alas que baten. **Rubber-hose** (adoptado). |
 | `OsoAndino` | *Tremarctos ornatus* | Oso de anteojos, guardián del páramo. Mole parda con **anteojos crema** (su firma). De suelo, se sienta. Rubber-hose. |
 | `RanaAndina` | *Atelopus* spp. | Rana arlequín del páramo. Verde húmedo con manchas ocre, vientre dorado, ojos saltones y bocota. Rubber-hose. |
+| `Jaguar` | *Panthera onca* | Felino de tierra cálida. Leonado con **rosetas** (manchas de centro ocre — su firma), musculoso, mirada felina ámbar. Majestuoso y **acechador**: acecho de hombros, cola pesada, rugido. Aura **púrpura**. Rubber-hose. |
 | `Lombriz` | *Martiodrilus crassus* | Lombriz gigante nativa. Cuerpo segmentado con clitelo. Sin animación propia (su movimiento lo da la escena). |
 | `Mariposa` | *Dione juno* | Pasionaria de alas largas. Cuatro alas que abren y cierran. |
 | `Escarabajo` | *Dichotomius belus* | Estercolero colombiano. Élitros brillantes, cuerno, y bola de abono que rueda. |
@@ -91,7 +92,7 @@ que **el oso andino y el colibrí lo hereden sin redibujar**:
 estados reactivos. Standalone (avatares/catálogo) sin `tier` = rubber-hose pleno.
 
 **Estrenado por**: `AbejaAngelita` (referencia de composición del KIT).
-**Ya adoptado por**: `OsoAndino`, `Colibri` y `RanaAndina` — componen las mismas
+**Ya adoptado por**: `OsoAndino`, `Colibri`, `RanaAndina` y `Jaguar` — componen las mismas
 piezas + clases `rh-*` con SUS proporciones (identidad en `faunaAndina.js`), y
 heredan los gestos species-agnostic (`rh-g-celebra` / `rh-g-reposo` /
 `rh-g-senala`) solo con `data-pose`. No se reinventa la cadencia.
@@ -104,7 +105,12 @@ dorada la abeja, **roja** el oso), la **ropa por clima+hora** (`vestuario` →
 (`mundoId` → `PropEnMano`) y el **line-boil** (`lineBoil`). El oso suma su
 CARÁCTER de mole seria: boil más lento y pesado, cejas de ceño, gruñido
 (`resopla` → vaho) y rascado (`rasca`) — todo aditivo en `creatures.css`, RM +
-tier-safe. Los demás bichos heredan la misma fundación pasando sus parámetros.
+tier-safe. El **`Jaguar`** hace lo propio con su carácter de felino ACECHADOR:
+boil controlado y elegante, **acecho de hombros** (los omóplatos suben —
+`.jaguar-hombros`), **cola** que ondea con peso, **cejas fieras**, **rugido**
+corporal (`ruge` → fauces con colmillos) y modo **acecho** (`acecha` → cabeza
+baja + creep agazapado); su aura de poder es **púrpura**. Los demás bichos
+heredan la misma fundación pasando sus parámetros.
 
 ## Técnica
 

--- a/src/visual/creatures/__tests__/Jaguar.render.test.jsx
+++ b/src/visual/creatures/__tests__/Jaguar.render.test.jsx
@@ -1,0 +1,170 @@
+/**
+ * Jaguar.render.test.jsx — los 5 frentes de "Jaguar completo" (espejo de la
+ * abeja/oso, con el CARÁCTER del felino de tierra cálida: majestuoso, poderoso,
+ * ACECHADOR — púrpura en poder). Verifica que las capacidades ADITIVAS del
+ * componente canónico se rendericen sin romper el contrato base:
+ *   1. Expresividad felina — line-boil (contorno que hierve), cejas fieras,
+ *      acecho de hombros, cola pesada, rugido corporal (ruge) y modo acecho.
+ *   2. Lip-sync — el visema viaja a la cara (data-visema).
+ *   3. Modo poder — el aura PÚRPURA de 4 capas (wrapper .is-powered-up, no dorada).
+ *   4. Ropa/clima — de noche RUANA, y el jaguar (tierra cálida) NUNCA suda.
+ *   5. Prop por mundo — la herramienta en la zarpa al entrar.
+ * Más la firma de identidad: es el felino de las ROSETAS y su aura es púrpura.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { Jaguar } from '../Jaguar.jsx';
+import { auraDeBicho } from '../transformacion.js';
+
+afterEach(cleanup);
+
+describe('Jaguar — contrato base intacto', () => {
+  it('render por defecto = svg accesible, sin capas nuevas', () => {
+    const { container } = render(<Jaguar />);
+    const svg = container.querySelector('svg[data-creature="jaguar"]');
+    expect(svg).toBeTruthy();
+    expect(svg.getAttribute('role')).toBe('img');
+    // Ninguna capa opt-in aparece sin pedirla (no regresión visual).
+    expect(svg.getAttribute('data-lineboil')).toBeNull();
+    expect(svg.getAttribute('data-ruge')).toBeNull();
+    expect(svg.getAttribute('data-acecha')).toBeNull();
+    expect(svg.getAttribute('data-prop')).toBeNull();
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+  });
+
+  it('siempre trae su ACECHO DE HOMBROS, su COLA y sus cejas fieras (identidad)', () => {
+    const { container } = render(<Jaguar />);
+    // La seña del depredador (omóplatos + cola + mirada) es identidad, no opt-in.
+    expect(container.querySelector('.jaguar-hombros')).toBeTruthy();
+    expect(container.querySelector('.jaguar-cola')).toBeTruthy();
+    expect(container.querySelector('.jaguar-cejas')).toBeTruthy();
+  });
+});
+
+describe('1. Expresividad felina — line-boil, rugido y acecho', () => {
+  it('lineBoil instancia el filtro de displacement (contorno que hierve)', () => {
+    const { container } = render(<Jaguar lineBoil animated />);
+    expect(container.querySelector('svg').getAttribute('data-lineboil')).toBe('1');
+    expect(container.querySelector('feDisplacementMap')).toBeTruthy();
+    expect(container.querySelector('feTurbulence')).toBeTruthy();
+  });
+
+  it('sin lineBoil NO se paga el filtro (frugal)', () => {
+    const { container } = render(<Jaguar animated />);
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+  });
+
+  it('ruge marca el estado y abre las fauces con colmillos (rugido corporal)', () => {
+    const { container } = render(<Jaguar ruge animated />);
+    expect(container.querySelector('svg').getAttribute('data-ruge')).toBe('1');
+    expect(container.querySelector('.jaguar-rugido-boca')).toBeTruthy();
+    expect(container.querySelectorAll('.jaguar-colmillo').length).toBeGreaterThan(1);
+  });
+
+  it('acecha marca el estado (el depredador se agazapa)', () => {
+    const { container } = render(<Jaguar acecha animated />);
+    expect(container.querySelector('svg').getAttribute('data-acecha')).toBe('1');
+    expect(container.querySelector('.jaguar-cabeza')).toBeTruthy();
+  });
+
+  it('sin ruge no hay fauces abiertas (frugal, avatar sereno)', () => {
+    const { container } = render(<Jaguar animated />);
+    expect(container.querySelector('.jaguar-rugido-boca')).toBeNull();
+    expect(container.querySelector('.jaguar-colmillo')).toBeNull();
+  });
+});
+
+describe('2. Lip-sync — el visema llega a la cara', () => {
+  it('con visema V3 la boca abierta viaja a la cara (data-visema)', () => {
+    const { container } = render(<Jaguar visema="V3" />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBe('V3');
+  });
+
+  it('el RUGIDO manda sobre el visema (una fiera que ruge no articula fonemas)', () => {
+    const { container } = render(<Jaguar ruge visema="V3" />);
+    // el rugido pinta las fauces, no el visema.
+    expect(container.querySelector('.jaguar-rugido-boca')).toBeTruthy();
+  });
+
+  it('sin visema no marca data-visema (la sonrisa de siempre)', () => {
+    const { container } = render(<Jaguar />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBeNull();
+  });
+});
+
+describe('3. Modo poder — aura PÚRPURA de 4 capas (standalone)', () => {
+  it('poder envuelve en .is-powered-up + corrientes, con aura PÚRPURA (no dorada)', () => {
+    const { container } = render(<Jaguar poder />);
+    const wrap = container.querySelector('.is-powered-up');
+    expect(wrap).toBeTruthy();
+    expect(wrap.getAttribute('data-creature-poder')).toBe('jaguar');
+    // el color de aura del jaguar es PÚRPURA depredador (distinto del dorado abeja)
+    expect(wrap.getAttribute('style')).toContain('--aura-color');
+    expect(wrap.getAttribute('style')).toContain(auraDeBicho('jaguar'));
+    expect(auraDeBicho('jaguar')).not.toBe(auraDeBicho('abeja-angelita'));
+    // capa 4: las corrientes (AuraPoder)
+    expect(container.querySelector('.poder-corrientes')).toBeTruthy();
+  });
+
+  it('sin poder no hay wrapper (svg desnudo)', () => {
+    const { container } = render(<Jaguar />);
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+    expect(container.querySelector(':scope > svg[data-creature="jaguar"]')).toBeTruthy();
+  });
+});
+
+describe('4. Ropa/clima — el jaguar se abriga de frío y NUNCA suda', () => {
+  it('de noche con vestuario → RUANA y JAMÁS sudor/sombrero', () => {
+    const { container } = render(<Jaguar vestuario clima="noche" />);
+    const svg = container.querySelector('svg');
+    expect(svg.getAttribute('data-ruana')).toBe('1');
+    // el jaguar de tierra cálida aguanta el calor sin sudar
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+  });
+
+  it('de día caluroso (tempC alta) el jaguar NO suda (tierra cálida, identidad)', () => {
+    const { container } = render(<Jaguar vestuario clima="soleado" tempC={33} />);
+    // aunque el termómetro dispararía sudor en un bicho templado, el jaguar no.
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+    expect(container.querySelector('.crt-gota-sudor')).toBeNull();
+  });
+
+  it('sin vestuario (avatar/catálogo) → nada de ropa aunque haya clima', () => {
+    const { container } = render(<Jaguar clima="noche" />);
+    expect(container.querySelector('svg').getAttribute('data-ruana')).toBeNull();
+  });
+});
+
+describe('5. Prop por mundo — herramienta en la zarpa', () => {
+  it('mundoId=suelo → carga la lupa', () => {
+    const { container } = render(<Jaguar mundoId="suelo" />);
+    expect(container.querySelector('svg').getAttribute('data-prop')).toBe('suelo');
+    expect(container.querySelector('[data-prop="lupa"]')).toBeTruthy();
+  });
+
+  it('mundoId=animales → carga el lazo', () => {
+    const { container } = render(<Jaguar mundoId="animales" />);
+    expect(container.querySelector('[data-prop="lazo"]')).toBeTruthy();
+  });
+
+  it('mundo sin prop mapeado → zarpas libres (no rompe)', () => {
+    const { container } = render(<Jaguar mundoId="mundo-fantasma" />);
+    expect(container.querySelector('[data-prop="lupa"]')).toBeNull();
+    expect(container.querySelector('svg[data-creature="jaguar"]')).toBeTruthy();
+  });
+});
+
+describe('Anti-regresión — modo inline no rompe la escena', () => {
+  it('inline devuelve un <g> con el data-creature y marca data-poder', () => {
+    const { container } = render(
+      <svg>
+        <Jaguar inline poder mundoId="suelo" />
+      </svg>,
+    );
+    const g = container.querySelector('g[data-creature="jaguar"]');
+    expect(g).toBeTruthy();
+    expect(g.getAttribute('data-poder')).toBe('1'); // el host DOM pinta el aura
+    expect(g.getAttribute('data-prop')).toBe('suelo');
+  });
+});

--- a/src/visual/creatures/__tests__/Jaguar.render.test.jsx
+++ b/src/visual/creatures/__tests__/Jaguar.render.test.jsx
@@ -155,6 +155,45 @@ describe('5. Prop por mundo — herramienta en la zarpa', () => {
   });
 });
 
+describe('6. Toque místico — el animal-espíritu del chamán (permanente y sutil)', () => {
+  it('trae SIEMPRE aura espectral, ojos luminosos, constelación y shimmer', () => {
+    const { container } = render(<Jaguar />);
+    expect(container.querySelector('.jaguar-aura-espectral')).toBeTruthy();  // aura etérea permanente
+    expect(container.querySelector('.jaguar-ojo-brillo')).toBeTruthy();      // ojos luminosos
+    expect(container.querySelector('.jaguar-constelacion')).toBeTruthy();    // geometría sagrada
+    expect(container.querySelector('.jaguar-shimmer')).toBeTruthy();         // shimmer espectral
+    // las estrellas titilan (varias, sobre las rosetas)
+    expect(container.querySelectorAll('.jaguar-estrella').length).toBeGreaterThan(1);
+  });
+
+  it('el aura espectral es PERMANENTE (existe sin pedir modo poder)', () => {
+    const { container } = render(<Jaguar />);
+    // no hay power-up, pero el aura sagrada igual envuelve al jaguar
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+    expect(container.querySelector('.jaguar-aura-espectral')).toBeTruthy();
+  });
+
+  it('reduced-motion-safe / tier-safe: con animated=false NO se anima el titileo (fotograma digno)', () => {
+    const { container } = render(<Jaguar animated={false} />);
+    // sin vida: no se cuelgan las clases que animan (aura/ojos/estrellas/shimmer)…
+    expect(container.querySelector('.jaguar-estrella')).toBeNull();
+    expect(container.querySelector('.jaguar-aura-espectral')).toBeNull();
+    expect(container.querySelector('.jaguar-ojo-brillo')).toBeNull();
+    expect(container.querySelector('.jaguar-shimmer')).toBeNull();
+    // …pero la constelación (geometría sagrada) sigue dibujada, quieta y digna.
+    expect(container.querySelector('.jaguar-constelacion')).toBeTruthy();
+  });
+
+  it('modo poder CHAMÁNICO: las estrellas y el aura siguen dentro del power-up', () => {
+    const { container } = render(<Jaguar poder />);
+    const wrap = container.querySelector('.is-powered-up.jaguar-poder');
+    expect(wrap).toBeTruthy();
+    // el jaguar-espíritu se revela: aura + estrellas viven dentro del wrapper
+    expect(wrap.querySelector('.jaguar-aura-espectral')).toBeTruthy();
+    expect(wrap.querySelectorAll('.jaguar-estrella').length).toBeGreaterThan(1);
+  });
+});
+
 describe('Anti-regresión — modo inline no rompe la escena', () => {
   it('inline devuelve un <g> con el data-creature y marca data-poder', () => {
     const { container } = render(

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -749,3 +749,149 @@
   /* Fotograma digno: un rastro de vaho visible y quieto si se pidió resoplido. */
   .crt-vaho-mota { opacity: 0.55; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   JAGUAR — el CARÁCTER del felino: majestuoso, poderoso, ACECHADOR. Poder
+   CONTENIDO (no hiperactivo): squash&stretch controlado y elegante. Aditivo
+   sobre el KIT species-agnostic (no toca a la abeja/oso): el jaguar reescribe SU
+   boil (lento y controlado), suma el ACECHO DE HOMBROS (los omóplatos suben al
+   moverse — su firma), la COLA que ondea con PESO, el RUGIDO corporal y el modo
+   ACECHO (cabeza baja + avance agazapado). Todo transform/opacity (GPU, gama
+   baja). Gates RM + tier al final del bloque.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* BOIL CONTROLADO — el felino no vibra ligero: respira LENTO y con squash
+   ELEGANTE (poder contenido, masa musculosa que asienta suave). Reescribe SOLO
+   el boil del jaguar (misma clase .rh-boil, mayor especificidad por el
+   data-creature) con longhands para no pisar el resto de props de animación. */
+[data-creature='jaguar'] .rh-boil {
+  animation-name: jaguar-boil;
+  animation-duration: 2.9s;
+  animation-timing-function: steps(12, end);
+}
+@keyframes jaguar-boil {
+  0%   { transform: translateY(0) scale(1, 1); }
+  28%  { transform: translateY(-0.15px) scale(0.99, 1.02); }  /* leve estiramiento elegante */
+  54%  { transform: translateY(0.5px) scale(1.035, 0.965); }  /* squash controlado (músculo) */
+  76%  { transform: translateY(0.1px) scale(1.0, 1.0); }      /* asienta sereno */
+  100% { transform: translateY(0) scale(1, 1); }
+}
+
+/* ACECHO DE HOMBROS — los omóplatos SUBEN y bajan al moverse (la seña del
+   depredador). Sube más y más lento en modo acecho. Nodo propio dentro del
+   cuerpo (.jaguar-hombros). */
+.jaguar-hombros {
+  animation: jaguar-hombros 2.9s ease-in-out infinite;
+}
+@keyframes jaguar-hombros {
+  0%, 100% { transform: translateY(0) scaleY(1); }
+  40%      { transform: translateY(-0.9px) scaleY(1.08); }  /* el omóplato se alza */
+  70%      { transform: translateY(-0.2px) scaleY(1.0); }
+}
+
+/* COLA que ONDEA con PESO — vaivén lento en S, pivota desde la base del lomo
+   (transform-origin lo pone el componente en fill-box). Poderosa, no nerviosa. */
+.jaguar-cola {
+  animation: jaguar-cola 3.6s ease-in-out infinite;
+}
+@keyframes jaguar-cola {
+  0%, 100% { transform: rotate(-4deg); }
+  50%      { transform: rotate(6deg); }   /* barrido pesado y elegante */
+}
+
+/* CEJAS FIERAS — la mirada intensa respira apenas; se frunce MÁS al rugir o
+   acechar (el depredador se concentra). */
+.jaguar-cejas {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: jaguar-cejas 7.1s ease-in-out infinite;
+}
+@keyframes jaguar-cejas {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-0.2px); }
+}
+[data-creature='jaguar'][data-ruge='1'] .jaguar-cejas,
+[data-creature='jaguar'][data-acecha='1'] .jaguar-cejas {
+  animation: jaguar-cejas-frunce 1.1s ease-in-out infinite;
+}
+@keyframes jaguar-cejas-frunce {
+  0%, 100% { transform: translateY(0) scaleX(1); }
+  50%      { transform: translateY(0.5px) scaleX(1.05); }  /* baja y aprieta la mirada */
+}
+
+/* RUGE — rugido corporal: el pecho hincha y SUELTA con peso (huff imponente,
+   squash&stretch marcado). Pisa el boil por especificidad (dos atributos). */
+[data-creature='jaguar'][data-ruge='1'] .crt-body {
+  animation: jaguar-rugido 1.6s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes jaguar-rugido {
+  0%, 100% { transform: translateY(0) scale(1, 1); }
+  30%      { transform: translateY(-0.7px) scale(0.96, 1.07); }  /* inhala hondo (stretch) */
+  52%      { transform: translateY(0.7px) scale(1.08, 0.92); }   /* SUELTA el rugido (squash) */
+  74%      { transform: translateY(0.1px) scale(1.01, 1.0); }
+}
+/* Las fauces del rugido palpitan (la garganta que ruge). */
+[data-creature='jaguar'][data-ruge='1'] .jaguar-rugido-boca {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: jaguar-fauces 1.6s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+}
+@keyframes jaguar-fauces {
+  0%, 100% { transform: scale(0.85); }
+  52%      { transform: scale(1.12); }
+}
+
+/* ACECHA — modo acecho: la cabeza BAJA y avanza, los omóplatos suben MÁS (el
+   depredador se agazapa). El cuerpo hace un creep lento y controlado. */
+[data-creature='jaguar'][data-acecha='1'] .jaguar-cabeza {
+  animation: jaguar-acecho-cabeza 3.2s ease-in-out infinite;
+}
+@keyframes jaguar-acecho-cabeza {
+  0%, 100% { transform: translate(0, 0); }
+  50%      { transform: translate(0.4px, 1.1px); }  /* baja y adelanta la testa */
+}
+[data-creature='jaguar'][data-acecha='1'] .jaguar-hombros {
+  animation: jaguar-hombros-acecho 3.2s ease-in-out infinite;
+}
+@keyframes jaguar-hombros-acecho {
+  0%, 100% { transform: translateY(-0.4px) scaleY(1.05); }
+  50%      { transform: translateY(-1.6px) scaleY(1.16); }  /* el lomo del acecho, MÁS alto */
+}
+[data-creature='jaguar'][data-acecha='1'] .crt-body {
+  animation: jaguar-acecho-cuerpo 3.2s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes jaguar-acecho-cuerpo {
+  0%, 100% { transform: translateX(0) scaleY(0.99); }
+  50%      { transform: translateX(0.5px) scaleY(0.97); }  /* creep agazapado, lento */
+}
+
+/* Los estados del jaguar (ruge/acecha) PISAN el arrebato (antic/travieso): una
+   fiera que ruge o acecha no da vueltas de campana — el gesto lee majestuoso. */
+[data-creature='jaguar'][data-ruge='1'] .rh-antic,
+[data-creature='jaguar'][data-ruge='1'] .rh-travieso,
+[data-creature='jaguar'][data-acecha='1'] .rh-antic,
+[data-creature='jaguar'][data-acecha='1'] .rh-travieso { animation: none; }
+
+/* device-tier 'bajo': el boil reescrito del jaguar lo reactivaría (misma clase)
+   → re-apagarlo aquí (mayor especificidad + orden posterior). El acecho de
+   hombros, la cola y las cejas continuas también se cortan; los estados
+   reactivos (ruge/acecha) siguen contando la verdad. */
+[data-tier='bajo'][data-creature='jaguar'] .rh-boil,
+[data-tier='bajo'][data-creature='jaguar'] .jaguar-hombros,
+[data-tier='bajo'][data-creature='jaguar'] .jaguar-cola,
+[data-tier='bajo'][data-creature='jaguar'] .jaguar-cejas { animation: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .jaguar-hombros, .jaguar-cola, .jaguar-cejas,
+  [data-creature='jaguar'][data-ruge='1'] .crt-body,
+  [data-creature='jaguar'][data-ruge='1'] .jaguar-rugido-boca,
+  [data-creature='jaguar'][data-ruge='1'] .jaguar-cejas,
+  [data-creature='jaguar'][data-acecha='1'] .jaguar-cabeza,
+  [data-creature='jaguar'][data-acecha='1'] .jaguar-hombros,
+  [data-creature='jaguar'][data-acecha='1'] .crt-body,
+  [data-creature='jaguar'][data-acecha='1'] .jaguar-cejas { animation: none !important; }
+}

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -895,3 +895,104 @@
   [data-creature='jaguar'][data-acecha='1'] .crt-body,
   [data-creature='jaguar'][data-acecha='1'] .jaguar-cejas { animation: none !important; }
 }
+
+/* ───────────────────────────────────────────────────────────────────────────
+   JAGUAR MÍSTICO — el animal-espíritu del chamán (cosmología andino-amazónica).
+   Capas PERMANENTES y sutiles (elegante, no recargado): aura espectral etérea,
+   ojos luminosos (fosforescencia), estrellas de constelación en las rosetas y
+   un shimmer espectral. En modo poder se vuelven CHAMÁNICAS (se revela el
+   espíritu). Todo transform/opacity. Se PODA en tier bajo / reduced-motion.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+/* AURA ESPECTRAL — la presencia sagrada envuelve al felino; respira lento. */
+.jaguar-aura-espectral {
+  animation: jaguar-aura-espectral 5.2s ease-in-out infinite;
+}
+@keyframes jaguar-aura-espectral {
+  0%, 100% { opacity: 0.11; transform: scale(1); }
+  50%      { opacity: 0.2;  transform: scale(1.05); }
+}
+
+/* OJOS LUMINOSOS — fosforescencia del espíritu (visión nocturna): late suave. */
+.jaguar-ojo-brillo {
+  animation: jaguar-ojo-latido 3.3s ease-in-out infinite;
+}
+@keyframes jaguar-ojo-latido {
+  0%, 100% { opacity: 0.55; transform: scale(0.96); }
+  50%      { opacity: 1;    transform: scale(1.06); }
+}
+
+/* ESTRELLAS de la constelación — titilan como el cielo nocturno andino
+   (staggered por el delay inline de cada estrella). */
+.jaguar-estrella {
+  animation: jaguar-titilar 2.3s ease-in-out infinite;
+}
+@keyframes jaguar-titilar {
+  0%, 100% { opacity: 0.35; transform: scale(0.82); }
+  50%      { opacity: 1;    transform: scale(1.15); }
+}
+
+/* SHIMMER — destello espectral que recorre el contorno (pulso lento). */
+.jaguar-shimmer {
+  animation: jaguar-shimmer 4.6s ease-in-out infinite;
+}
+@keyframes jaguar-shimmer {
+  0%, 100% { opacity: 0.12; }
+  50%      { opacity: 0.32; }
+}
+
+/* MODO PODER CHAMÁNICO — el jaguar-espíritu se revela: el aura, los ojos y las
+   estrellas se intensifican y aceleran. Vale tanto en standalone (wrapper
+   .jaguar-poder) como en inline (data-poder en el <g>). */
+.jaguar-poder .jaguar-aura-espectral,
+[data-creature='jaguar'][data-poder='1'] .jaguar-aura-espectral {
+  animation-name: jaguar-aura-chaman;
+  animation-duration: 3.0s;
+}
+@keyframes jaguar-aura-chaman {
+  0%, 100% { opacity: 0.22; transform: scale(1.02); }
+  50%      { opacity: 0.4;  transform: scale(1.1); }
+}
+.jaguar-poder .jaguar-ojo-brillo,
+[data-creature='jaguar'][data-poder='1'] .jaguar-ojo-brillo {
+  animation-name: jaguar-ojo-chaman;
+  animation-duration: 2.1s;
+}
+@keyframes jaguar-ojo-chaman {
+  0%, 100% { opacity: 0.85; transform: scale(1.02); }
+  50%      { opacity: 1;    transform: scale(1.22); }
+}
+.jaguar-poder .jaguar-estrella,
+[data-creature='jaguar'][data-poder='1'] .jaguar-estrella {
+  animation-name: jaguar-titilar-chaman;
+  animation-duration: 1.5s;
+}
+@keyframes jaguar-titilar-chaman {
+  0%, 100% { opacity: 0.6; transform: scale(1); }
+  50%      { opacity: 1;   transform: scale(1.4); }
+}
+.jaguar-poder .jaguar-shimmer,
+[data-creature='jaguar'][data-poder='1'] .jaguar-shimmer {
+  animation-duration: 2.4s;
+}
+
+/* device-tier 'bajo': PODA el brillo/estrellas místicas (raster caro en gama
+   baja) — se detiene la animación y queda un rastro estático y digno. */
+[data-tier='bajo'][data-creature='jaguar'] .jaguar-aura-espectral,
+[data-tier='bajo'][data-creature='jaguar'] .jaguar-ojo-brillo,
+[data-tier='bajo'][data-creature='jaguar'] .jaguar-shimmer { animation: none; }
+[data-tier='bajo'][data-creature='jaguar'] .jaguar-estrella { animation: none; opacity: 0.4; }
+
+@media (prefers-reduced-motion: reduce) {
+  .jaguar-aura-espectral, .jaguar-ojo-brillo, .jaguar-shimmer,
+  .jaguar-poder .jaguar-aura-espectral,
+  .jaguar-poder .jaguar-ojo-brillo,
+  .jaguar-poder .jaguar-shimmer,
+  [data-creature='jaguar'][data-poder='1'] .jaguar-aura-espectral,
+  [data-creature='jaguar'][data-poder='1'] .jaguar-ojo-brillo,
+  [data-creature='jaguar'][data-poder='1'] .jaguar-shimmer { animation: none !important; }
+  /* Estrellas: sin titileo, quietas y tenues (fotograma digno). */
+  .jaguar-estrella,
+  .jaguar-poder .jaguar-estrella,
+  [data-creature='jaguar'][data-poder='1'] .jaguar-estrella { animation: none !important; opacity: 0.5; }
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -27,6 +27,11 @@ export { avisarSalidaAbeja, resetSalidaAbeja, useSalidaAbeja } from './senalSali
 export { Colibri } from './Colibri.jsx';
 export { OsoAndino } from './OsoAndino.jsx';
 export { RanaAndina } from './RanaAndina.jsx';
+export { Jaguar } from './Jaguar.jsx';
+/* La IDENTIDAD del jaguar como datos (paleta leonada + rosetas, proporciones y
+   su perfil de clima). Solo datos: jamás arrastra three al bundle base — igual
+   que abejaIdentidad/faunaAndina. */
+export { JAGUAR_PALETA, JAGUAR_PROPORCION, JAGUAR_SLUG, PERFIL_JAGUAR } from './jaguarIdentidad.js';
 /* La IDENTIDAD del trío andino como datos (paletas + proporciones). Solo datos:
    jamás arrastra three al bundle base — igual que abejaIdentidad. */
 export {
@@ -71,6 +76,7 @@ import AbejaAngelita from './AbejaAngelita.jsx';
 import Colibri from './Colibri.jsx';
 import OsoAndino from './OsoAndino.jsx';
 import RanaAndina from './RanaAndina.jsx';
+import Jaguar from './Jaguar.jsx';
 import Lombriz from './Lombriz.jsx';
 import Mariposa from './Mariposa.jsx';
 import Escarabajo from './Escarabajo.jsx';
@@ -81,6 +87,7 @@ export const CREATURES = {
   colibri: { Component: Colibri, nombre: 'Colibrí chillón', cientifico: 'Colibri coruscans' },
   'oso-andino': { Component: OsoAndino, nombre: 'Oso andino', cientifico: 'Tremarctos ornatus' },
   'rana-andina': { Component: RanaAndina, nombre: 'Rana arlequín andina', cientifico: 'Atelopus spp.' },
+  jaguar: { Component: Jaguar, nombre: 'Jaguar', cientifico: 'Panthera onca' },
   lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
   mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
   escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },

--- a/src/visual/creatures/jaguarIdentidad.js
+++ b/src/visual/creatures/jaguarIdentidad.js
@@ -1,0 +1,69 @@
+/*
+ * jaguarIdentidad — LA IDENTIDAD VISUAL DEL JAGUAR, COMO DATOS.
+ *
+ * Hermana de `abejaIdentidad.js` y `faunaAndina.js`: el JAGUAR (Panthera onca),
+ * el felino de tierra cálida/selva, tiene aquí su silueta canónica. Rubber-hose
+ * (Cuphead + Miss Minutes) con calidez campesina — el MISMO lenguaje de goma de
+ * la abeja y el oso, otro animal y otro CARÁCTER: majestuoso, poderoso,
+ * ACECHADOR. Sereno pero imponente, se mueve con acecho de hombros (los
+ * omóplatos suben), la cola ondea con peso y la mirada felina es intensa. Su
+ * color de poder es el PÚRPURA depredador (abeja=dorado, oso=rojo, rana=verde,
+ * colibrí=iridiscente).
+ *
+ * REGLA DE ORO (idéntica a abejaIdentidad/faunaAndina): SOLO datos. Cero three,
+ * cero react. La creature del bundle base lo importa; jamás debe arrastrar
+ * `vendor-three`. La CADENCIA (animación) vive en `creatures.css` (clases
+ * `rh-*`/`crt-*`/`jaguar-*`); el DIBUJO compone el KIT `_rubberhose.jsx`; el
+ * CLIMA→cuerpo, en `creatureClimaCuerpo.js` (consumiendo el PERFIL_JAGUAR de
+ * abajo). El aura de poder (púrpura) vive en `transformacion.js` (AURA_POR_BICHO)
+ * y la ropa por clima en `creatureClimaCuerpo.js` (ROPA_PERFIL_POR_BICHO): ambos
+ * ya traen la fila 'jaguar' — este archivo NO la duplica, solo la silueta.
+ */
+
+/* La tinta cálida del contorno es de TODA la familia rubber-hose. */
+export { RH_INK as JAGUAR_TINTA } from './_rubberhose.jsx';
+
+/* Slug estable del jaguar (data-creature, aura, ropa, perfiles). */
+export const JAGUAR_SLUG = 'jaguar';
+
+/* ── JAGUAR — Panthera onca (el felino de tierra cálida/selva). Pelaje leonado
+   dorado con ROSETAS negras de centro ocre (su firma — manchas con centro, NO
+   puntos como el leopardo), vientre crema, cuerpo MUSCULOSO, orejas redondas,
+   mirada felina ÁMBAR intensa y cola larga y pesada. Majestuoso y poderoso. */
+export const JAGUAR_PALETA = {
+  cuerpo: '#d99a45',        // pelaje leonado dorado
+  cuerpoGlow: 'rgba(217,154,69,0.7)',
+  vientre: '#f4e6c8',       // pecho/vientre crema
+  hombro: '#c9853a',        // omóplato un tono más hondo (el músculo del acecho)
+  roseta: '#241608',        // el anillo negro de la roseta (tinta oscura cálida)
+  rosetaCentro: '#a86a24',  // el centro ocre de la roseta (la firma: mancha con centro)
+  hocico: '#f4e6c8',        // morro claro
+  nariz: '#3a2012',         // trufa
+  oreja: '#7a4718',         // dorso oscuro de la oreja
+  iris: '#e8a53a',          // ojo felino ámbar (mirada intensa)
+  colmillo: '#fff8ec',      // colmillos del rugido
+};
+
+export const JAGUAR_PROPORCION = {
+  troncoRx: 10.4,           // musculoso (más ancho que alto)
+  troncoRy: 7.4,
+  cabezaR: 6.2,
+  orejaR: 2.2,              // orejas redondas de felino
+  hombroAlto: 4.2,          // pico del omóplato en el acecho
+};
+
+/*
+ * PERFIL_JAGUAR — el perfil de CLIMA→cuerpo del jaguar para `cuerpoDeClima`
+ * (creatureClimaCuerpo.js). Mismo shape que PERFIL_OSO/PERFIL_RANA — se pasa vía
+ * la opción `perfil`, así NO hay que tocar el archivo compartido (anti-conflicto).
+ *   alas    false → sin aleteo (velocidadAlas siempre 1).
+ *   humedad 0.6  → pelaje lustroso que escurre el agua (no chorrea como la rana).
+ *   difusa  0.5  → felino grande: la niebla apenas lo difumina (como la mole del oso).
+ *   sequia  0.3  → de tierra cálida: robusto ante la seca (poco vulnerable).
+ */
+export const PERFIL_JAGUAR = Object.freeze({
+  alas: false,
+  humedad: 0.6,
+  difusa: 0.5,
+  sequia: 0.3,
+});

--- a/src/visual/creatures/jaguarIdentidad.js
+++ b/src/visual/creatures/jaguarIdentidad.js
@@ -42,6 +42,10 @@ export const JAGUAR_PALETA = {
   oreja: '#7a4718',         // dorso oscuro de la oreja
   iris: '#e8a53a',          // ojo felino ámbar (mirada intensa)
   colmillo: '#fff8ec',      // colmillos del rugido
+  /* ── Místico (el jaguar-espíritu del chamán, cosmología andino-amazónica) ── */
+  espectral: '#b98cff',     // aura etérea / presencia sagrada (violeta espectral)
+  estrella: '#efe6ff',      // el titileo de las constelaciones en las rosetas
+  ojoBrillo: '#ffe6a0',     // fosforescencia del ojo-espíritu (visión nocturna)
 };
 
 export const JAGUAR_PROPORCION = {

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -90,12 +90,31 @@ const VARIANTES_OSO = [
   { label: 'línea que hierve', props: { size: 88, lineBoil: true } },
   { label: 'sin animación', props: { size: 88, animated: false } },
 ];
+/* El JAGUAR completo estrena TODA la fundación transversal (espejo de la abeja/
+   oso, con su carácter): acecho de hombros + cola pesada + line-boil, rugido
+   corporal (ruge), modo acecho (acecha), ruana de noche, modo poder PÚRPURA y
+   prop por mundo. La vitrina lo luce con todo. */
+const VARIANTES_JAGUAR = [
+  { label: '48 px', props: { size: 48 } },
+  { label: 'anda', props: { size: 88 } },
+  { label: 'celebra', props: { size: 88, pose: 'celebra' } },
+  { label: 'reposo', props: { size: 88, pose: 'reposo' } },
+  { label: 'señala', props: { size: 88, pose: 'señala' } },
+  { label: 'ruge', props: { size: 88, ruge: true } },
+  { label: 'acecha', props: { size: 88, acecha: true } },
+  { label: 'ruana de noche', props: { size: 88, vestuario: true, clima: 'noche' } },
+  { label: 'con lupa (suelo)', props: { size: 88, mundoId: 'suelo' } },
+  { label: 'poder PÚRPURA', props: { size: 88, poder: true } },
+  { label: 'línea que hierve', props: { size: 88, lineBoil: true } },
+  { label: 'sin animación', props: { size: 88, animated: false } },
+];
 
 const VARIANTES_POR_SLUG = {
   'abeja-angelita': VARIANTES_ABEJA,
   colibri: VARIANTES_TRIO_AIRE,
   'oso-andino': VARIANTES_OSO,
   'rana-andina': VARIANTES_TRIO_SUELO,
+  jaguar: VARIANTES_JAGUAR,
 };
 
 /* Nota de campo por creature (el registro de la categoría trae nombre + binomio;
@@ -105,6 +124,7 @@ const NOTAS_CREATURE = {
   colibri: 'Pico recto y garganta violeta iridiscente; el ave-agente de Chagra, ya en rubber-hose.',
   'oso-andino': 'Oso de anteojos, guardián del páramo; mole parda entrañable con los anteojos crema (su firma).',
   'rana-andina': 'Rana arlequín del páramo, guardiana del agua; verde húmedo con manchas ocre y ojos saltones.',
+  jaguar: 'Felino de tierra cálida, majestuoso y acechador; leonado con rosetas de centro ocre (su firma), aura púrpura.',
   lombriz: 'La ingeniera del suelo; ondula por segmentos con clitelo marcado.',
   mariposa: 'Alas naranjas con venación; poliniza y anuncia buen suelo.',
   escarabajo: 'Estercolero que entierra el abono; élitros con brillo metálico.',


### PR DESCRIPTION
## Jaguar completo — *Panthera onca* (rubber-hose, felino de tierra cálida)

Personaje NUEVO al mismo nivel de la abeja (#2424) y el oso (#2425). Reutiliza la fundación transversal (no la forka): `_rubberhose.jsx`, `creatureIdle`, `useLipSync`/`BocaVisema`, `transformacion`/`AuraPoder`, `propsPorMundo`/`PropEnMano`, `ropaDeClima`/`AccesoriosClima`, `LineBoilFilter`. Identidad aislada en `jaguarIdentidad.js` (paleta leonada + rosetas + perfil de clima) — cero conflicto con archivos de otros bichos.

### Los 5 frentes (carácter: majestuoso, poderoso, ACECHADOR)
1. **Expresividad rubber-hose felina** — boil controlado y elegante (poder contenido), **acecho de hombros** (los omóplatos suben al moverse — su firma), **cola** que ondea con peso, **cejas fieras**, mirada felina; estados **rugido corporal** (`ruge` → fauces con colmillos) y **acecho** (`acecha` → cabeza baja + creep agazapado). Línea que respira (`lineBoil`).
2. **Lip-sync** — `visema` → `BocaVisema`. El rugido manda sobre el visema.
3. **Modo-poder PÚRPURA** — `poder` → aura púrpura de 4 capas (`auraDeBicho('jaguar')`).
4. **Ropa/clima** — `vestuario`+`clima` → ruana de frío; de tierra cálida **NUNCA suda** (sudor/sombrero suprimidos aunque el termómetro suba).
5. **Prop por mundo** — `mundoId` → herramienta en la zarpa (agua→manguerita, suelo→lupa, animales→lazo…).

### Toque místico (el jaguar-espíritu del chamán — cosmología andino-amazónica)
Permanente y sutil, elegante: **ojos luminosos** (fosforescencia), **aura espectral etérea** permanente, **constelaciones de geometría sagrada** en las rosetas (estrellas que titilan), **shimmer espectral** en el contorno. En modo poder se vuelve **chamánico** (aura/ojos/estrellas se intensifican). Todo se **poda** en tier bajo / reduced-motion.

### Archivos
- **Nuevos**: `Jaguar.jsx`, `jaguarIdentidad.js`, `__tests__/Jaguar.render.test.jsx`.
- **Aditivos** (sin tocar otros bichos): `creatures.css` (bloque jaguar), `index.js`, `registry.js`, `README.md`.

### Verificación
- `npx vitest run src/visual/creatures` → **107 passed** (incluye 6 frentes + identidad del jaguar).
- `npm run build` → **verde**.
- UI en usted, reduced-motion-safe y tier-safe, anti-leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)