### PR TITLE
feat(ardilla): creature completa rubber-hose (5 frentes)

### DIFF
--- a/src/visual/creatures/Ardilla.jsx
+++ b/src/visual/creatures/Ardilla.jsx
@@ -1,0 +1,317 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, RH_INK } from './_rubberhose.jsx';
+import { ARDILLA_PALETA, ARDILLA_PROPORCION } from './faunaAndina.js';
+import { cuerpoDeClima, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
+import { AccesoriosClima } from './AccesoriosClima.jsx';
+import { LineBoilFilter } from './LineBoilFilter.jsx';
+import { PropEnMano } from './PropEnMano.jsx';
+import { AuraPoder } from './AuraPoder.jsx';
+import { auraDeBicho } from './transformacion.js';
+
+/* Ardilla de cola roja andina — Notosciurus granatensis (clima TEMPLADO).
+   Hermana rubber-hose de la abeja Angelita y del trío andino: compone el MISMO
+   kit `_rubberhose.jsx` (ojos de goma, cachetes, sonrisa, miembros manguera) y
+   hereda la MISMA fundación transversal — lip-sync (useLipSync → BocaVisema),
+   modo poder (transformacion, ÁMBAR), ropa por clima (ropaDeClima), prop por
+   mundo (PropEnMano) y line-boil (LineBoilFilter) — cero código duplicado.
+   Solo cambia el ANIMAL y su CARÁCTER: pizpireta RUFA con la LÍNEA DORSAL oscura
+   (su firma), COLA TUPIDA que se sacude, orejitas y DIENTES de roedor. Es de
+   SUELO: se SIENTA (no vuela) — sin alas. ÁGIL, curiosa, rápida e INQUIETA: su
+   boil es más VELOZ y nervioso que el de la abeja, la cola tiembla, la nariz
+   olfatea y su gesto-FIRMA es la INSPECCIÓN INVERTIDA (se cuelga de cabeza a
+   mirar). Roe semillas (roer/olfatear). La IDENTIDAD (paleta + proporciones)
+   vive en `faunaAndina.js`; el CLIMA→cuerpo, en `creatureClimaCuerpo.js`. Es
+   templada pero, como el resto de la familia, NUNCA suda (contrato compartido:
+   se abriga de noche/frío, jamás gotea sudor). */
+const VIEWBOX = '-18 -22 36 44';
+
+export function Ardilla({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Ardilla de cola roja',
+  /* Pose de VIDA (idle-life), equivalentes a las del resto de la familia: 'anda'
+     (base) | 'celebra' (brinca con brazos en V + overshoot) | 'reposo' (respira)
+     | 'señala' (se inclina al POI y apunta). Gestos species-agnostic (rh-g-*) en
+     `creatures.css`; solo corren viva (animated). */
+  pose = 'anda',
+  animo = 'sereno',
+  energia = 1,
+  /* CLIMA REAL escrito en el cuerpo. Sin clima (avatares, catálogo) = neutro
+     digno: la ardilla se ve EXACTA como siempre. */
+  clima = null,
+  enso = 'neutro',
+  /* ── LIP-SYNC (sistema transversal, useLipSync) ────────────────────────────
+     visema opcional ('V1'..'V4') que produce useLipSync desde el RMS del TTS:
+     la boquita se abre al hablar (voz ágil y chillona). Sin visema (o 'V1') = la
+     sonrisa de siempre → avatares/catálogo no cambian. El HOOK vive aparte; acá
+     solo se consume. */
+  visema = null,
+  /* ── VESTUARIO por clima+hora (ropaDeClima) ───────────────────────────────
+     OPT-IN: con vestuario=true la ardilla se abriga según el clima real (RUANA
+     de noche/frío). Templada, pero del contrato compartido: NUNCA suda (el sudor
+     se suprime aquí aunque el termómetro suba). Default false → los consumidores
+     de `clima` existentes NO ven ropa nueva. */
+  vestuario = false,
+  tempC = undefined,
+  /* ── INSPECCIÓN INVERTIDA (el gesto-FIRMA — se cuelga de cabeza a mirar) ────
+     OPT-IN: la ardilla se voltea de cabeza y espía curiosa hacia los lados (su
+     pose icónica de ardilla en el tronco). Su reacción-firma cuando husmea algo.
+     Default false → avatar en pie sereno. */
+  inspecciona = false,
+  /* ── ROE (roer/olfatear — mordisquea una semilla) ──────────────────────────
+     OPT-IN: la ardilla sostiene una bellota y la ROE a mordiscos rápidos (los
+     incisivos castañetean, olfateo veloz). Default false. */
+  roe = false,
+  /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
+     pleno; 'bajo' apaga el idle continuo (boil + cola + olfateo) y deja los
+     estados reactivos. Sin prop (standalone) = pleno. */
+  tier,
+  /* ── LÍNEA QUE RESPIRA (line-boil, Cuphead años 30 — LineBoilFilter) ────────
+     OPT-IN: con lineBoil el CONTORNO de la ardilla vibra escalonado (~8fps) — el
+     trazo "hierve" como dibujo animado clásico. Default false. Con animated=false
+     o reduced-motion queda con seed fija (textura sin vibrar). */
+  lineBoil = false,
+  /* ── MODO PODER (transformación / power-up ÁMBAR — transformacion.css) ──────
+     OPT-IN: con poder=true (standalone) la ardilla se envuelve en su aura ÁMBAR
+     de 4 capas (glow, boost, ingravidez, corrientes) — su firma al "subir de
+     nivel". En modo inline lo pone el host DOM; acá solo marcamos data-poder. */
+  poder = false,
+  /* ── PROP POR MUNDO (herramienta en la patita — propsPorMundo/PropEnMano) ────
+     mundoId opcional: al ENTRAR a un mundo la ardilla carga su herramienta
+     (agua→manguerita, suelo→lupa, animales→lazo, semillero→canasto…). Sin
+     mundoId (o mundo sin prop) entra con las patitas libres. Va en su patita
+     DERECHA (la cola tupida ocupa el flanco izquierdo). */
+  mundoId = null,
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const boil = `crt-boil-${uid}`;
+  const vivo = animated;
+  const auraOp = Math.max(0.14, Math.min(0.44, 0.18 + 0.28 * (energia ?? 1)));
+  const auraR = 7.8 + 1.5 * (energia ?? 1);
+  const P = ARDILLA_PROPORCION;
+  const C = ARDILLA_PALETA;
+
+  // CLIMA → cuerpo (determinista). La ardilla no tiene alas (velocidadAlas 1: no
+  // se usa). Sin perfil propio → usa el de referencia (defecto); su piso térmico
+  // templado ya vive en el perfil de ROPA (ROPA_PERFIL_POR_BICHO.ardilla).
+  const cuerpoClima = cuerpoDeClima(clima, { enso, tier });
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
+
+  // Vestuario por clima+hora (opt-in). CONTRATO COMPARTIDO: la ardilla NUNCA
+  // suda — suprimimos sudor aquí (sin tocar la función compartida: su contrato/
+  // tests siguen intactos). Sí se pone RUANA de noche/frío y su sombrerito al
+  // sol (templada: se cubre, pero no gotea). Sin vestuario o sin clima → nada.
+  const ropaBase = (vestuario && clima) ? ropaDeClimaBicho('ardilla', clima, { tempC }) : null;
+  const ropa = ropaBase ? { ...ropaBase, sudor: false } : null;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+      {lineBoil && <LineBoilFilter id={boil} animated={vivo} />}
+    </defs>
+  );
+
+  // PROP DEL MUNDO en la patita DERECHA (la cola ocupa el flanco izquierdo). La
+  // punta del bracito derecho cae en ~(9.4, 7); posamos el prop ahí a escala de
+  // ardilla (menudita). Sin mundoId o mundo sin prop → PropEnMano devuelve null.
+  const propMundo = mundoId ? (
+    <PropEnMano mundoId={mundoId} x={9.6} y={7.4} escala={0.58} ink={RH_INK} animated={vivo} />
+  ) : null;
+
+  // La BELLOTA que roe (solo con roe): entre las patitas, a la altura de la boca.
+  const bellota = roe ? (
+    <g className="ardilla-bellota" aria-hidden="true">
+      <ellipse cx="0" cy="0.6" rx="1.7" ry="2.0" fill={C.bellota} stroke={RH_INK} strokeWidth="0.7" />
+      <path d="M-1.7,-0.6 A1.7,1.4 0 0 1 1.7,-0.6 Z" fill="#5f3a17" stroke={RH_INK} strokeWidth="0.5" />
+      <path d="M0,-2.0 L0,-3.0" stroke={RH_INK} strokeWidth="0.7" strokeLinecap="round" />
+    </g>
+  ) : null;
+
+  // ── CUERPO rubber-hose (atrás→adelante): aura, COLA tupida, patas traseras,
+  //    tronco rufo con vientre crema, línea DORSAL, bracitos, cabeza (orejas +
+  //    ojos curiosos + hocico que olfatea + dientes de roedor). `.crt-body` es el
+  //    nodo que squashea (boil idle, más VELOZ y nervioso en la ardilla). El
+  //    grupo entero se INVIERTE con `inspecciona` (se cuelga de cabeza).
+  const body = (
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* aura viva */}
+      <circle cx="0" cy="2" r={auraR} fill={C.cuerpo} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* COLA TUPIDA (detrás de todo, flanco izquierdo, arquea sobre el lomo).
+          Se sacude nerviosa (`.ardilla-cola`, pivote en la base). */}
+      <g className={vivo ? 'ardilla-cola' : undefined}
+        style={{ transformBox: 'fill-box', transformOrigin: 'center bottom' }}>
+        {/* pluma exterior */}
+        <path
+          d="M-2,11 C-9,11 -13.4,6 -12.8,-1 C-12.2,-8 -8.6,-14.6 -1.6,-16
+             C-5.6,-17.4 -11.8,-15.6 -13.8,-10.6 C-15.8,-6 -16,1 -12.2,6.6
+             C-9.6,10.2 -6,12 -2,11 Z"
+          fill={C.cola} stroke={RH_INK} strokeWidth="1.3" strokeLinejoin="round"
+          style={{ filter: `drop-shadow(0 0 5px ${C.cuerpoGlow})` }} />
+        {/* núcleo claro (volumen tupido) */}
+        <path
+          d="M-3,9 C-8.4,8.6 -11.4,4 -11,-1.6 C-10.5,-7.2 -7.6,-12.4 -2.6,-13.6
+             C-6,-14 -9.8,-11.4 -11,-6.6 C-12.1,-2 -11.6,4 -8.4,7.6
+             C-6.6,9.4 -4.6,9.6 -3,9 Z"
+          fill={C.colaClara} opacity="0.7" />
+        {/* mechones de la punta (tupida) */}
+        <g stroke={RH_INK} strokeWidth="0.8" strokeLinecap="round" fill="none" opacity="0.85">
+          <path d="M-13.6,-10 l-1.6,-1.1" />
+          <path d="M-15.2,-6 l-1.7,-0.4" />
+          <path d="M-15.6,-1 l-1.8,0.3" />
+          <path d="M-3.2,-15.6 l-0.6,-1.7" />
+        </g>
+      </g>
+
+      {/* patas traseras (se sienta): plantas crema, detrás del tronco. Se mecen. */}
+      <Miembro d="M-4.6,8.4 C-6.2,10 -6.6,11.6 -5.4,12.6" ancho={3.0} punta={[-5.4, 12.8]} puntaR={1.8} pie sway={vivo} delay={-0.6} />
+      <Miembro d="M4.6,8.4 C6.2,10 6.6,11.6 5.4,12.6" ancho={3.0} punta={[5.4, 12.8]} puntaR={1.8} pie sway={vivo} delay={-0.9} />
+
+      {/* tronco rufo con contorno grueso (la línea que respira con el boil) */}
+      <ellipse cx="0" cy="2.4" rx={P.troncoRx} ry={P.troncoRy}
+        fill={C.cuerpo} stroke={RH_INK} strokeWidth="1.4"
+        style={{ filter: `drop-shadow(0 0 6px ${C.cuerpoGlow})` }} />
+      {/* manto DORSAL oscuro sobre el lomo/hombros (la espalda vista de frente) */}
+      <path d="M0,-5.4 C5.4,-5 6.6,-1.4 5.6,2.6 C3,-1 -3,-1 -5.6,2.6 C-6.6,-1.4 -5.4,-5 0,-5.4 Z"
+        fill={C.dorsal} opacity="0.92" />
+      {/* vientre crema (el pecho claro que sube y baja) */}
+      <ellipse cx="0" cy="4.6" rx="4.4" ry="5.4" fill={C.panza} opacity="0.92" />
+      <ellipse cx="0" cy="5.6" rx="2.6" ry="3.6" fill={C.vientre} opacity="0.85" />
+
+      {/* bracitos manguera (patitas delanteras) con plantita crema, pivote en el
+          HOMBRO para que celebra/señala los alcen. Se juntan al pecho (pose de
+          ardilla que sostiene). */}
+      <Miembro clase="crt-brazo-l" origen="right top"
+        d="M-4.4,-0.8 C-6.6,0.8 -6.2,4.4 -2.6,5.2" ancho={2.4} punta={[-2.6, 5.4]} puntaR={1.5} pie sway={vivo} delay={-0.15} />
+      <Miembro clase="crt-brazo-r" origen="left top"
+        d="M4.4,-0.8 C6.6,0.8 6.2,4.4 2.6,5.2" ancho={2.4} punta={[2.6, 5.4]} puntaR={1.5} pie sway={vivo} delay={-0.4} />
+
+      {/* la BELLOTA que roe (entre las patitas). */}
+      {bellota}
+
+      {/* orejitas (detrás de la cabeza, se mecen con follow-through) */}
+      <g className={vivo ? 'rh-sway' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center bottom', animationDelay: '-0.25s' }}>
+        <path d="M-4.4,-12.4 C-4.9,-15.4 -3.6,-16.4 -2.2,-14.4 C-1.9,-13.2 -2.9,-12.4 -4.4,-12.4 Z"
+          fill={C.cuerpo} stroke={RH_INK} strokeWidth="1.1" strokeLinejoin="round" />
+        <path d="M-3.9,-12.9 C-4.1,-14.4 -3.4,-14.9 -2.8,-13.9 Z" fill={C.oreja} />
+      </g>
+      <g className={vivo ? 'rh-sway' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center bottom', animationDelay: '-0.55s' }}>
+        <path d="M4.4,-12.4 C4.9,-15.4 3.6,-16.4 2.2,-14.4 C1.9,-13.2 2.9,-12.4 4.4,-12.4 Z"
+          fill={C.cuerpo} stroke={RH_INK} strokeWidth="1.1" strokeLinejoin="round" />
+        <path d="M3.9,-12.9 C4.1,-14.4 3.4,-14.9 2.8,-13.9 Z" fill={C.oreja} />
+      </g>
+
+      {/* cabeza rufa con contorno */}
+      <circle cx="0" cy="-9" r={P.cabezaR} fill={C.cuerpo} stroke={RH_INK} strokeWidth="1.3" />
+      {/* LÍNEA DORSAL: la franja oscura por la coronilla/frente (la firma de la
+          especie). En su grupo propio (.ardilla-dorsal) — identidad, no opt-in. */}
+      <g className="ardilla-dorsal" fill={C.dorsal}>
+        <path d="M-1.3,-13.8 C-0.5,-14.4 0.5,-14.4 1.3,-13.8 C1.0,-11.6 0.9,-9.6 0.7,-8.4
+                 C0.3,-8.9 -0.3,-8.9 -0.7,-8.4 C-0.9,-9.6 -1.0,-11.6 -1.3,-13.8 Z" opacity="0.95" />
+      </g>
+      {/* chapetas + boca + dientes + hocico + ojos de goma curiosos */}
+      <Cachetes puntos={[{ cx: -3.8, cy: -6.9, r: 1.2 }, { cx: 3.8, cy: -6.9, r: 1.2 }]} vivo={vivo} />
+      {/* Boca: lip-sync si hay visema; si no, la sonrisita de goma de siempre. */}
+      {visema
+        ? <BocaVisema cx={0} cy={-6.0} w={2.8} prof={1.05} visema={visema} />
+        : <Sonrisa cx={0} cy={-6.2} w={2.6} prof={1.05} />}
+      {/* DIENTES de roedor: los dos incisivos bajo la boca (castañetean al roer). */}
+      <g className="ardilla-dientes" style={{ transformBox: 'fill-box', transformOrigin: 'center top' }}>
+        <rect x="-1.0" y="-5.5" width="0.9" height="1.7" rx="0.28" fill={C.diente} stroke={RH_INK} strokeWidth="0.35" />
+        <rect x="0.1" y="-5.5" width="0.9" height="1.7" rx="0.28" fill={C.diente} stroke={RH_INK} strokeWidth="0.35" />
+      </g>
+      {/* hocico/trufa que OLFATEA (nariz que tiembla — inquieta). */}
+      <g className={vivo ? 'ardilla-nariz' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+        <ellipse cx="0" cy="-7.4" rx="1.15" ry="0.9" fill={C.hocico} />
+      </g>
+      <OjosRubber
+        ojos={[{ cx: -2.2, cy: -9.6, r: 1.75 }, { cx: 2.2, cy: -9.6, r: 1.75 }]}
+        mirar={[0, 0.2]}
+        parpadea={vivo}
+      />
+
+      {/* Vestuario por clima+hora (RUANA de noche/frío) — solo con vestuario=true.
+          Sudor suprimido (contrato compartido: la ardilla nunca gotea). */}
+      {ropa && (
+        <AccesoriosClima
+          estado={ropa}
+          tronco={{ cx: 0, cy: 2.4, rx: P.troncoRx, ry: P.troncoRy }}
+          cabeza={{ cx: 0, cy: -9, r: P.cabezaR }}
+          animated={vivo}
+        />
+      )}
+
+      {/* Prop del mundo en la patita (entra con su herramienta). */}
+      {propMundo}
+    </g>
+  );
+
+  // Antics de VIDA (períodos co-primos) SOLO viva; nodos aparte para no pisar el
+  // boil de `.crt-body`. El CSS los apaga con RM / tier bajo / ánimo bajo / durante
+  // los gestos (celebra/reposo/señala) y estados (inspecciona/roe).
+  const conAntics = vivo ? (
+    <g className="rh-antic">
+      <g className="rh-travieso">{body}</g>
+    </g>
+  ) : body;
+  // El line-boil (contorno que hierve) envuelve TODO el dibujo cuando se pide.
+  const cuerpoVivo = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
+
+  const estadoAttrs = {
+    'data-creature': 'ardilla',
+    'data-pose': vivo ? pose : undefined,
+    'data-animo': animo,
+    'data-tier': tier || undefined,
+    'data-visema': visema || undefined,
+    'data-ruana': ropa?.ruana ? '1' : undefined,
+    'data-mojado': ropa?.mojado ? '1' : undefined,
+    'data-inspecciona': inspecciona ? '1' : undefined,
+    'data-roe': roe ? '1' : undefined,
+    'data-lineboil': lineBoil ? '1' : undefined,
+    'data-prop': mundoId || undefined,
+  };
+
+  if (inline) {
+    // En modo inline el power-up lo pone el host DOM; acá solo marcamos data-poder.
+    return (
+      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+        {defs}
+        {cuerpoVivo}
+      </g>
+    );
+  }
+  const svg = (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
+      <title>{title}</title>
+      {defs}
+      {cuerpoVivo}
+    </svg>
+  );
+  // MODO PODER (standalone): lo envolvemos en su aura ÁMBAR de 4 capas
+  // (transformacion.css: glow radial + boost + ingravidez + corrientes).
+  if (poder) {
+    return (
+      <span
+        className="is-powered-up ardilla-poder"
+        data-creature-poder="ardilla"
+        style={{ '--aura-color': auraDeBicho('ardilla'), display: 'inline-flex' }}
+      >
+        {svg}
+        <AuraPoder />
+      </span>
+    );
+  }
+  return svg;
+}
+
+export default Ardilla;

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -24,6 +24,7 @@ calidad dispar. Aquí vive la **versión canónica** de cada uno.
 | `Colibri` | *Colibri coruscans* | Colibrí chillón andino. Pico largo, garganta violeta, alas que baten. **Rubber-hose** (adoptado). |
 | `OsoAndino` | *Tremarctos ornatus* | Oso de anteojos, guardián del páramo. Mole parda con **anteojos crema** (su firma). De suelo, se sienta. Rubber-hose. |
 | `RanaAndina` | *Atelopus* spp. | Rana arlequín del páramo. Verde húmedo con manchas ocre, vientre dorado, ojos saltones y bocota. Rubber-hose. |
+| `Ardilla` | *Notosciurus granatensis* | Ardilla de cola roja del templado. Rufa con **línea dorsal** oscura (su firma), **cola tupida** y dientes de roedor. Ágil e inquieta: su firma es la **inspección invertida** (se cuelga de cabeza). De suelo, se sienta. Rubber-hose. |
 | `Lombriz` | *Martiodrilus crassus* | Lombriz gigante nativa. Cuerpo segmentado con clitelo. Sin animación propia (su movimiento lo da la escena). |
 | `Mariposa` | *Dione juno* | Pasionaria de alas largas. Cuatro alas que abren y cierran. |
 | `Escarabajo` | *Dichotomius belus* | Estercolero colombiano. Élitros brillantes, cuerno, y bola de abono que rueda. |
@@ -105,6 +106,14 @@ dorada la abeja, **roja** el oso), la **ropa por clima+hora** (`vestuario` →
 CARÁCTER de mole seria: boil más lento y pesado, cejas de ceño, gruñido
 (`resopla` → vaho) y rascado (`rasca`) — todo aditivo en `creatures.css`, RM +
 tier-safe. Los demás bichos heredan la misma fundación pasando sus parámetros.
+
+La **`Ardilla`** cierra la misma fundación completa con su CARÁCTER opuesto —
+pizpireta, ÁGIL, curiosa e INQUIETA: aura **ÁMBAR** en poder, boil VELOZ (no
+pesado), **cola tupida** que se sacude, hocico que olfatea, dientes de roedor y
+su gesto-FIRMA la **inspección invertida** (`inspecciona` → se cuelga de cabeza a
+espiar) más el **roer** una semilla (`roe`). Templada, pero del contrato
+compartido: **nunca suda** (se abriga de noche/frío, jamás gotea). Todo aditivo
+en `creatures.css`, RM + tier-safe.
 
 ## Técnica
 

--- a/src/visual/creatures/__tests__/Ardilla.render.test.jsx
+++ b/src/visual/creatures/__tests__/Ardilla.render.test.jsx
@@ -1,0 +1,162 @@
+/**
+ * Ardilla.render.test.jsx — los 5 frentes de "Ardilla completa" (espejo de la
+ * abeja y del oso, con el CARÁCTER pizpireta: ágil, curiosa, rápida e inquieta,
+ * ÁMBAR en poder). Verifica que las capacidades ADITIVAS del componente canónico
+ * se rendericen sin romper el contrato base:
+ *   1. Expresividad ÁGIL — line-boil (contorno que hierve), INSPECCIÓN INVERTIDA
+ *      (su firma: se cuelga de cabeza), roer (dientes + bellota) y la cola tupida.
+ *   2. Lip-sync — el visema viaja a la cara (data-visema).
+ *   3. Modo poder — el aura ÁMBAR de 4 capas (wrapper .is-powered-up, no dorada).
+ *   4. Ropa por clima — de noche RUANA, y la ardilla NUNCA suda (contrato común).
+ *   5. Prop por mundo — la herramienta en la patita al entrar.
+ * Más la firma de identidad: la LÍNEA DORSAL siempre presente y su aura ámbar.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { Ardilla } from '../Ardilla.jsx';
+import { auraDeBicho } from '../transformacion.js';
+
+afterEach(cleanup);
+
+describe('Ardilla — contrato base intacto', () => {
+  it('render por defecto = svg accesible, sin capas nuevas', () => {
+    const { container } = render(<Ardilla />);
+    const svg = container.querySelector('svg[data-creature="ardilla"]');
+    expect(svg).toBeTruthy();
+    expect(svg.getAttribute('role')).toBe('img');
+    // Ninguna capa opt-in aparece sin pedirla (no regresión visual).
+    expect(svg.getAttribute('data-lineboil')).toBeNull();
+    expect(svg.getAttribute('data-inspecciona')).toBeNull();
+    expect(svg.getAttribute('data-roe')).toBeNull();
+    expect(svg.getAttribute('data-prop')).toBeNull();
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+  });
+
+  it('siempre trae su LÍNEA DORSAL y su cola tupida (identidad de la especie)', () => {
+    const { container } = render(<Ardilla />);
+    // La línea dorsal oscura es parte de la identidad (no opt-in).
+    expect(container.querySelector('.ardilla-dorsal')).toBeTruthy();
+    // La cola tupida está siempre (viva anima; aquí solo que exista).
+    expect(container.querySelector('.ardilla-cola')).toBeTruthy();
+  });
+});
+
+describe('1. Expresividad ÁGIL — line-boil, inspección invertida y roer', () => {
+  it('lineBoil instancia el filtro de displacement (contorno que hierve)', () => {
+    const { container } = render(<Ardilla lineBoil animated />);
+    expect(container.querySelector('svg').getAttribute('data-lineboil')).toBe('1');
+    expect(container.querySelector('feDisplacementMap')).toBeTruthy();
+    expect(container.querySelector('feTurbulence')).toBeTruthy();
+  });
+
+  it('sin lineBoil NO se paga el filtro (frugal)', () => {
+    const { container } = render(<Ardilla animated />);
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+  });
+
+  it('inspecciona (su FIRMA) marca el estado (se cuelga de cabeza)', () => {
+    const { container } = render(<Ardilla inspecciona animated />);
+    expect(container.querySelector('svg').getAttribute('data-inspecciona')).toBe('1');
+  });
+
+  it('roe marca el estado y saca la bellota que mordisquea', () => {
+    const { container } = render(<Ardilla roe animated />);
+    expect(container.querySelector('svg').getAttribute('data-roe')).toBe('1');
+    expect(container.querySelector('.ardilla-bellota')).toBeTruthy();
+    // los dientes de roedor están para castañetear
+    expect(container.querySelector('.ardilla-dientes')).toBeTruthy();
+  });
+
+  it('sin roe no hay bellota (frugal, avatar sereno)', () => {
+    const { container } = render(<Ardilla animated />);
+    expect(container.querySelector('.ardilla-bellota')).toBeNull();
+  });
+});
+
+describe('2. Lip-sync — el visema llega a la boquita', () => {
+  it('con visema V3 la boca abierta viaja a la cara (data-visema)', () => {
+    const { container } = render(<Ardilla visema="V3" />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBe('V3');
+  });
+
+  it('sin visema no marca data-visema (la sonrisa de siempre)', () => {
+    const { container } = render(<Ardilla />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBeNull();
+  });
+});
+
+describe('3. Modo poder — aura ÁMBAR de 4 capas (standalone)', () => {
+  it('poder envuelve en .is-powered-up + corrientes, con aura ÁMBAR (no dorada)', () => {
+    const { container } = render(<Ardilla poder />);
+    const wrap = container.querySelector('.is-powered-up');
+    expect(wrap).toBeTruthy();
+    expect(wrap.getAttribute('data-creature-poder')).toBe('ardilla');
+    expect(wrap.getAttribute('style')).toContain('--aura-color');
+    expect(wrap.getAttribute('style')).toContain(auraDeBicho('ardilla'));
+    // el color de aura de la ardilla es ÁMBAR (distinto del dorado de la abeja)
+    expect(auraDeBicho('ardilla')).not.toBe(auraDeBicho('abeja-angelita'));
+    // capa 4: las corrientes (AuraPoder)
+    expect(container.querySelector('.poder-corrientes')).toBeTruthy();
+  });
+
+  it('sin poder no hay wrapper (svg desnudo)', () => {
+    const { container } = render(<Ardilla />);
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+    expect(container.querySelector(':scope > svg[data-creature="ardilla"]')).toBeTruthy();
+  });
+});
+
+describe('4. Ropa por clima — se abriga y NUNCA suda (contrato compartido)', () => {
+  it('de noche con vestuario → RUANA y JAMÁS sudor', () => {
+    const { container } = render(<Ardilla vestuario clima="noche" />);
+    const svg = container.querySelector('svg');
+    expect(svg.getAttribute('data-ruana')).toBe('1');
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+  });
+
+  it('de día caluroso (tempC alta) la ardilla NO suda (contrato compartido)', () => {
+    const { container } = render(<Ardilla vestuario clima="soleado" tempC={30} />);
+    // aunque el termómetro dispararía sudor en un bicho templado, la ardilla no.
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+    expect(container.querySelector('.crt-gota-sudor')).toBeNull();
+  });
+
+  it('sin vestuario (avatar/catálogo) → nada de ropa aunque haya clima', () => {
+    const { container } = render(<Ardilla clima="noche" />);
+    expect(container.querySelector('svg').getAttribute('data-ruana')).toBeNull();
+  });
+});
+
+describe('5. Prop por mundo — herramienta en la patita', () => {
+  it('mundoId=suelo → carga la lupa', () => {
+    const { container } = render(<Ardilla mundoId="suelo" />);
+    expect(container.querySelector('svg').getAttribute('data-prop')).toBe('suelo');
+    expect(container.querySelector('[data-prop="lupa"]')).toBeTruthy();
+  });
+
+  it('mundoId=semillero → carga el canasto', () => {
+    const { container } = render(<Ardilla mundoId="semillero" />);
+    expect(container.querySelector('[data-prop="canasto"]')).toBeTruthy();
+  });
+
+  it('mundo sin prop mapeado → patitas libres (no rompe)', () => {
+    const { container } = render(<Ardilla mundoId="mundo-fantasma" />);
+    expect(container.querySelector('[data-prop="lupa"]')).toBeNull();
+    expect(container.querySelector('svg[data-creature="ardilla"]')).toBeTruthy();
+  });
+});
+
+describe('Anti-regresión — modo inline no rompe la escena', () => {
+  it('inline devuelve un <g> con el data-creature y marca data-poder', () => {
+    const { container } = render(
+      <svg>
+        <Ardilla inline poder mundoId="suelo" />
+      </svg>,
+    );
+    const g = container.querySelector('g[data-creature="ardilla"]');
+    expect(g).toBeTruthy();
+    expect(g.getAttribute('data-poder')).toBe('1'); // el host DOM pinta el aura
+    expect(g.getAttribute('data-prop')).toBe('suelo');
+  });
+});

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -749,3 +749,129 @@
   /* Fotograma digno: un rastro de vaho visible y quieto si se pidió resoplido. */
   .crt-vaho-mota { opacity: 0.55; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   ARDILLA — el CARÁCTER de la pizpireta: ÁGIL, curiosa, rápida e INQUIETA.
+   Aditivo sobre el KIT species-agnostic (no toca a los demás bichos): la ardilla
+   reescribe SU boil (más VELOZ y nervioso que la abeja), suma la cola tupida que
+   se sacude, el hocico que olfatea, los dientes que castañetean al roer y su
+   gesto-FIRMA: la INSPECCIÓN INVERTIDA (se cuelga de cabeza a espiar). Todo
+   transform/opacity (GPU, gama baja). Gates RM + tier al final del bloque.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* BOIL VELOZ — no respira lento como el oso: vibra RÁPIDO y nervioso (la ardilla
+   nunca está quieta). Reescribe SOLO el boil de la ardilla (misma clase .rh-boil,
+   mayor especificidad por el data-creature) con longhands. */
+[data-creature='ardilla'] .rh-boil {
+  animation-name: ardilla-boil;
+  animation-duration: 1.05s;
+  animation-timing-function: steps(20, end);
+}
+@keyframes ardilla-boil {
+  0%   { transform: translateY(0) scale(1, 1); }
+  20%  { transform: translateY(-0.35px) scale(0.97, 1.05); }  /* stretch ágil */
+  48%  { transform: translateY(0.3px) scale(1.05, 0.95); }    /* squash veloz */
+  70%  { transform: translateY(-0.12px) scale(0.99, 1.02); }  /* overshoot */
+  100% { transform: translateY(0) scale(1, 1); }
+}
+
+/* COLA TUPIDA — se sacude nerviosa (flick de ardilla), pivote en la base. Idle
+   continuo: su secondary-motion firma. Se acelera cuando husmea o roe. */
+.ardilla-cola {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: ardilla-cola 2.1s ease-in-out infinite;
+}
+@keyframes ardilla-cola {
+  0%, 100% { transform: rotate(0deg) scaleY(1); }
+  22% { transform: rotate(-4.5deg); }                    /* latigazo a un lado */
+  46% { transform: rotate(3.6deg) scaleY(1.03); }        /* sacudida nerviosa */
+  66% { transform: rotate(-2.2deg); }
+  82% { transform: rotate(1.4deg); }
+}
+[data-creature='ardilla'][data-inspecciona='1'] .ardilla-cola,
+[data-creature='ardilla'][data-roe='1'] .ardilla-cola { animation-duration: 0.95s; }
+
+/* OLFATEA — el hocico tiembla en olfateos rápidos (inquieta). Idle continuo,
+   sutil. Más veloz aún cuando roe. */
+.ardilla-nariz {
+  animation: ardilla-olfatea 1.35s ease-in-out infinite;
+}
+@keyframes ardilla-olfatea {
+  0%, 100% { transform: translateY(0) scale(1, 1); }
+  18% { transform: translateY(-0.22px) scale(1.14, 0.92); }  /* olfateo rápido */
+  32% { transform: translateY(0) scale(1, 1); }
+  48% { transform: translateY(-0.16px) scale(1.1, 0.94); }
+  62% { transform: translateY(0) scale(1, 1); }
+}
+[data-creature='ardilla'][data-roe='1'] .ardilla-nariz { animation-duration: 0.5s; }
+
+/* INSPECCIÓN INVERTIDA — el gesto-FIRMA: se voltea de cabeza (overshoot), asienta
+   invertida y espía curiosa a un lado y al otro, luego se endereza. Pisa el boil
+   por especificidad (dos atributos). */
+[data-creature='ardilla'][data-inspecciona='1'] .crt-body {
+  animation: ardilla-invierte 3.4s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+@keyframes ardilla-invierte {
+  0%   { transform: rotate(0deg); }
+  16%  { transform: rotate(185deg) scale(0.97, 1.03); }             /* se cuelga (overshoot) */
+  24%  { transform: rotate(178deg); }                               /* asienta invertida */
+  40%  { transform: rotate(180deg) translateX(1.1px); }             /* espía a un lado (curiosa) */
+  56%  { transform: rotate(180deg) translateX(-1.1px); }            /* …y al otro */
+  72%  { transform: rotate(179deg); }
+  86%  { transform: rotate(7deg) scale(1.02, 0.98); }               /* se endereza (rebasa) */
+  100% { transform: rotate(0deg); }
+}
+
+/* ROE — mordisqueo rápido: el cuerpo da un bob veloz y menudo (roer). Pisa el
+   boil por especificidad. */
+[data-creature='ardilla'][data-roe='1'] .crt-body {
+  animation: ardilla-roe 0.34s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes ardilla-roe {
+  0%, 100% { transform: translateY(0) scale(1, 1); }
+  50%      { transform: translateY(0.4px) scale(1.03, 0.96); }  /* mordisco veloz */
+}
+/* Los DIENTES castañetean rapidísimo al roer (los incisivos de roedor). */
+.ardilla-dientes { transform-box: fill-box; transform-origin: center top; }
+[data-creature='ardilla'][data-roe='1'] .ardilla-dientes {
+  animation: ardilla-castaneteo 0.16s steps(2, end) infinite;
+}
+@keyframes ardilla-castaneteo {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(0.4px); }
+}
+/* La bellota tiembla un poco mientras la roe. */
+.ardilla-bellota { transform-box: fill-box; transform-origin: center; }
+[data-creature='ardilla'][data-roe='1'] .ardilla-bellota {
+  animation: ardilla-bellota-tiembla 0.16s steps(2, end) infinite;
+}
+@keyframes ardilla-bellota-tiembla {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-0.35px); }
+}
+
+/* Los estados de la ardilla (inspecciona/roe) PISAN el arrebato (antic/travieso):
+   una ardilla colgada de cabeza o royendo no da además vueltas de campana. */
+[data-creature='ardilla'][data-inspecciona='1'] .rh-antic,
+[data-creature='ardilla'][data-inspecciona='1'] .rh-travieso,
+[data-creature='ardilla'][data-roe='1'] .rh-antic,
+[data-creature='ardilla'][data-roe='1'] .rh-travieso { animation: none; }
+
+/* device-tier 'bajo': el boil reescrito de la ardilla lo reactivaría (misma
+   clase) → re-apagarlo aquí (mayor especificidad + orden posterior). La cola y el
+   olfateo continuos también se cortan; los estados reactivos (inspecciona/roe)
+   siguen contando la verdad. */
+[data-tier='bajo'][data-creature='ardilla'] .rh-boil,
+[data-tier='bajo'][data-creature='ardilla'] .ardilla-cola,
+[data-tier='bajo'][data-creature='ardilla'] .ardilla-nariz { animation: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ardilla-cola, .ardilla-nariz, .ardilla-dientes, .ardilla-bellota,
+  [data-creature='ardilla'][data-inspecciona='1'] .crt-body,
+  [data-creature='ardilla'][data-roe='1'] .crt-body { animation: none !important; }
+}

--- a/src/visual/creatures/faunaAndina.js
+++ b/src/visual/creatures/faunaAndina.js
@@ -75,3 +75,30 @@ export const RANA_PROPORCION = {
   troncoRy: 6.2,
   ojoR: 2.9,
 };
+
+/* ── ARDILLA — Notosciurus granatensis (ardilla de cola roja andina, clima
+   TEMPLADO). Hermana rubber-hose del trío: mismo kit `_rubberhose.jsx`, misma
+   cadencia `rh-*`, otro animal. Pelaje RUFO cálido con la LÍNEA DORSAL oscura
+   marcada (su firma), vientre crema, COLA TUPIDA que se sacude, orejitas y los
+   DIENTES de roedor. Su CARÁCTER: ágil, curiosa, rápida e inquieta — su gesto-
+   firma es la INSPECCIÓN INVERTIDA (se cuelga de cabeza a mirar). Su color de
+   poder es el ÁMBAR (auraDeBicho('ardilla')). */
+export const ARDILLA_PALETA = {
+  cuerpo: '#b5652f',        // pelaje rufo cálido (templado)
+  cuerpoGlow: 'rgba(200,120,60,0.7)',
+  dorsal: '#5f3115',        // LÍNEA DORSAL oscura — la firma de la especie
+  panza: '#e8c48a',         // vientre crema-canela
+  vientre: '#f6e4bd',       // realce claro del pecho
+  cola: '#c4762f',          // cola tupida (rufo un tono más vivo)
+  colaClara: '#e6b06a',     // escarcha/borde de la cola tupida
+  oreja: '#894622',         // pabellón interno de la oreja
+  diente: '#fff6e2',        // incisivos de roedor (crema)
+  hocico: '#2f1c10',        // nariz/trufa
+  bellota: '#8a5a2b',       // la semilla que roe
+};
+export const ARDILLA_PROPORCION = {
+  troncoRx: 7.0,
+  troncoRy: 8.0,
+  cabezaR: 5.6,
+  orejaR: 1.9,
+};

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -27,12 +27,14 @@ export { avisarSalidaAbeja, resetSalidaAbeja, useSalidaAbeja } from './senalSali
 export { Colibri } from './Colibri.jsx';
 export { OsoAndino } from './OsoAndino.jsx';
 export { RanaAndina } from './RanaAndina.jsx';
+export { Ardilla } from './Ardilla.jsx';
 /* La IDENTIDAD del trío andino como datos (paletas + proporciones). Solo datos:
    jamás arrastra three al bundle base — igual que abejaIdentidad. */
 export {
   OSO_PALETA, OSO_PROPORCION,
   COLIBRI_PALETA, COLIBRI_PROPORCION,
-  RANA_PALETA, RANA_PROPORCION, FAUNA_TINTA,
+  RANA_PALETA, RANA_PROPORCION,
+  ARDILLA_PALETA, ARDILLA_PROPORCION, FAUNA_TINTA,
 } from './faunaAndina.js';
 export { Lombriz } from './Lombriz.jsx';
 export { Mariposa } from './Mariposa.jsx';
@@ -71,6 +73,7 @@ import AbejaAngelita from './AbejaAngelita.jsx';
 import Colibri from './Colibri.jsx';
 import OsoAndino from './OsoAndino.jsx';
 import RanaAndina from './RanaAndina.jsx';
+import Ardilla from './Ardilla.jsx';
 import Lombriz from './Lombriz.jsx';
 import Mariposa from './Mariposa.jsx';
 import Escarabajo from './Escarabajo.jsx';
@@ -81,6 +84,7 @@ export const CREATURES = {
   colibri: { Component: Colibri, nombre: 'Colibrí chillón', cientifico: 'Colibri coruscans' },
   'oso-andino': { Component: OsoAndino, nombre: 'Oso andino', cientifico: 'Tremarctos ornatus' },
   'rana-andina': { Component: RanaAndina, nombre: 'Rana arlequín andina', cientifico: 'Atelopus spp.' },
+  ardilla: { Component: Ardilla, nombre: 'Ardilla de cola roja', cientifico: 'Notosciurus granatensis' },
   lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
   mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
   escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -91,11 +91,31 @@ const VARIANTES_OSO = [
   { label: 'sin animación', props: { size: 88, animated: false } },
 ];
 
+/* La ARDILLA completa estrena TODA la fundación transversal (espejo de la abeja
+   y del oso, con su CARÁCTER pizpireta): boil veloz + line-boil, INSPECCIÓN
+   INVERTIDA (su firma), roer, ruana, modo poder ÁMBAR y prop por mundo. La
+   vitrina la luce con todo. */
+const VARIANTES_ARDILLA = [
+  { label: '48 px', props: { size: 48 } },
+  { label: 'anda', props: { size: 88 } },
+  { label: 'celebra', props: { size: 88, pose: 'celebra' } },
+  { label: 'reposo', props: { size: 88, pose: 'reposo' } },
+  { label: 'señala', props: { size: 88, pose: 'señala' } },
+  { label: 'inspección invertida', props: { size: 88, inspecciona: true } },
+  { label: 'roe una semilla', props: { size: 88, roe: true } },
+  { label: 'ruana de noche', props: { size: 88, vestuario: true, clima: 'noche' } },
+  { label: 'con lupa (suelo)', props: { size: 88, mundoId: 'suelo' } },
+  { label: 'poder ÁMBAR', props: { size: 88, poder: true } },
+  { label: 'línea que hierve', props: { size: 88, lineBoil: true } },
+  { label: 'sin animación', props: { size: 88, animated: false } },
+];
+
 const VARIANTES_POR_SLUG = {
   'abeja-angelita': VARIANTES_ABEJA,
   colibri: VARIANTES_TRIO_AIRE,
   'oso-andino': VARIANTES_OSO,
   'rana-andina': VARIANTES_TRIO_SUELO,
+  ardilla: VARIANTES_ARDILLA,
 };
 
 /* Nota de campo por creature (el registro de la categoría trae nombre + binomio;
@@ -105,6 +125,7 @@ const NOTAS_CREATURE = {
   colibri: 'Pico recto y garganta violeta iridiscente; el ave-agente de Chagra, ya en rubber-hose.',
   'oso-andino': 'Oso de anteojos, guardián del páramo; mole parda entrañable con los anteojos crema (su firma).',
   'rana-andina': 'Rana arlequín del páramo, guardiana del agua; verde húmedo con manchas ocre y ojos saltones.',
+  ardilla: 'Ardilla de cola roja del templado; rufa con la línea dorsal oscura (su firma), cola tupida y su inspección invertida.',
   lombriz: 'La ingeniera del suelo; ondula por segmentos con clitelo marcado.',
   mariposa: 'Alas naranjas con venación; poliniza y anuncia buen suelo.',
   escarabajo: 'Estercolero que entierra el abono; élitros con brillo metálico.',


### PR DESCRIPTION
## Ardilla completa — *Notosciurus granatensis* (cola roja, templado)

Nueva creature al nivel de referencia de abeja/oso/rana. **Archivo nuevo**
`src/visual/creatures/Ardilla.jsx` siguiendo EXACTAMENTE el patrón de
`OsoAndino.jsx`. **Usa la foundation, no la forkea.**

### Identidad
Rufa cálida con **línea dorsal** oscura marcada (su firma), **cola tupida**,
orejitas y **dientes de roedor**. Carácter **ágil, curiosa, rápida e inquieta**.
Color de poder **ámbar** (`auraDeBicho('ardilla')`).

### Los 5 frentes
1. **Expresividad rubber-hose ágil** — boil VELOZ y nervioso (reescribe su
   `.rh-boil`), **cola que se sacude**, **inspección invertida** (`inspecciona`
   → se cuelga de cabeza a espiar: su gesto-firma), **roer** una semilla (`roe`
   → dientes que castañetean + bellota), **olfateo** (nariz que tiembla), ojos
   curiosos (`rh-mirada`), **línea que respira** (`lineBoil` → `LineBoilFilter`).
2. **Lip-sync** — `visema` → `BocaVisema` en la cara.
3. **Modo-poder ÁMBAR** — `poder` → aura de 4 capas (`AuraPoder`).
4. **Ropa/clima** — `ropaDeClimaBicho('ardilla', …)` → ruana de noche/frío;
   templada pero del **contrato compartido: NUNCA suda** (sudor suprimido).
5. **Prop por mundo** — `mundoId` → `PropEnMano` en la patita derecha (la cola
   ocupa el flanco izquierdo).

### Anti-conflicto
Aditivo en compartidos: bloque ARDILLA al final de `creatures.css`, fila nueva en
`index.js`/`registry.js`/`README.md`. **No toca** abeja/oso/rana/colibrí/jaguar.
`reduced-motion` + `data-tier='bajo'` safe. UI en usted.

### Verificación
- `npm run build` verde.
- `npx vitest run src/visual/creatures` verde — 102/102 (incluye
  `Ardilla.render.test.jsx`, 5 frentes + identidad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)