### PR TITLE
feat(colibri): Colibrí completo — hiperactivo con estelas iridiscentes, lip-sync de pico, poder tornasol, ruanita y prop por mundo

### DIFF
--- a/src/visual/creatures/Colibri.jsx
+++ b/src/visual/creatures/Colibri.jsx
@@ -1,22 +1,34 @@
 import { useId } from 'react';
 import './creatures.css';
 import { CreatureFilters } from './_filters.jsx';
-import { OjosRubber, Cachetes, Sonrisa, RH_INK } from './_rubberhose.jsx';
+import { OjosRubber, Cachetes, Sonrisa, RH_INK, RH_BOCA } from './_rubberhose.jsx';
 import { COLIBRI_PALETA, COLIBRI_PROPORCION } from './faunaAndina.js';
-import { cuerpoDeClima, PERFIL_COLIBRI } from './creatureClimaCuerpo.js';
+import { cuerpoDeClima, PERFIL_COLIBRI, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
+import { AccesoriosClima } from './AccesoriosClima.jsx';
+import { LineBoilFilter } from './LineBoilFilter.jsx';
+import { PropEnMano } from './PropEnMano.jsx';
+import { AuraPoder } from './AuraPoder.jsx';
+import { auraDeBicho } from './transformacion.js';
 
-/* Colibrí chillón — Colibri coruscans (esmeralda andino, el ave-agente de
-   Chagra). Hermano rubber-hose de la abeja Angelita: ADOPTA el mismo kit
-   `_rubberhose.jsx` (ojos de goma, cachetes, sonrisa) y la misma cadencia `rh-*`
-   de `creatures.css` (boil que respira, parpadeo, follow-through, vuelta de
-   campana) — la versión canónica sube al lenguaje de goma sin cambiar de ave.
-   Sigue siendo ÉL: dorso turquesa esmeralda, gorguera violeta iridiscente y el
-   pico recto y largo. Es de AIRE: las alas baten en borrón (`.crt-wing`, que ya
-   trae smear), y el CLIMA le pesa o le apura el aleteo (perfil colibrí: plumas
-   aceitadas que escurren el agua, ágil, aguanta algo la seca). IDENTIDAD en
-   `faunaAndina.js`; CLIMA→cuerpo en `creatureClimaCuerpo.js`.
-   API estable (size/className/inline/animated/title) — los consumidores de la
-   vieja versión SVG heredan el rubber-hose sin tocar su código. */
+/* Colibrí chillón — Colibri coruscans (el ave-agente de Chagra, HIPERACTIVO).
+   Hermano rubber-hose de la abeja Angelita, el oso andino y la rana: compone el
+   MISMO kit `_rubberhose.jsx` (ojos de goma, cachetes, sonrisa) y hereda la
+   MISMA fundación transversal — lip-sync (useLipSync → el PICO habla), modo
+   poder (transformacion), ropa por clima (ropaDeClima), prop por mundo
+   (PropEnMano) y line-boil (LineBoilFilter) — cero código duplicado.
+   Solo cambia el ANIMAL y su CARÁCTER: veloz, nervioso, zumbón, NUNCA quieto.
+   Sigue siendo ÉL: dorso turquesa esmeralda, GORGUERA violeta iridiscente (la
+   firma de la especie) y el pico recto y largo. Es de AIRE: se cierne vibrando
+   y de pronto DARDEA — cambia de dirección de golpe con overshoot — dejando
+   ESTELAS iridiscentes cian↔magenta (afterimages, la firma de SU carácter: el
+   tornasol del plumaje quedándose un instante atrás del cuerpo). Su color de
+   poder es el IRIDISCENTE cian-magenta (no el dorado de la abeja, ni el rojo
+   del oso, ni el verde de la rana). La IDENTIDAD (paleta + proporciones) vive
+   en `faunaAndina.js`; el CLIMA→cuerpo, en `creatureClimaCuerpo.js` con
+   PERFIL_COLIBRI (plumas aceitadas que escurren el agua, ágil) — y como toda
+   AVE: NUNCA suda (las aves no tienen glándulas sudoríparas).
+   API estable (size/className/inline/animated/title) — los consumidores
+   existentes heredan la hiperactividad sin tocar su código. */
 const VIEWBOX = '-15 -16 36 30';
 
 /* Timoneras de la cola (abanico a la izquierda). */
@@ -26,6 +38,34 @@ const COLA = [
   'M-6,3.0 L-12.8,5.4 L-8,3.4 Z',
 ];
 
+/* Alas en borrón (compartidas entre el cuerpo y sus estelas-afterimage). */
+const ALA_DELANTERA = 'M3,-1.6 C-4.6,-15 10.8,-22 17.6,-13 C14.6,-5 8.2,-1.6 3,-1.6 Z';
+const ALA_TRASERA = 'M2,0.6 C-4,12 9,16.4 13.6,8.8 C10.6,3.4 6,1.2 2,0.6 Z';
+
+/* LIP-SYNC de PICO: cuánto abre la mandíbula inferior por visema (V1 cerrado =
+   la sonrisa de siempre; V3 abierto amplio — el chillón chilla). El colibrí no
+   tiene bocota de goma: su boca ES el pico, así que el visema de useLipSync se
+   traduce a apertura de mandíbula (mismo contrato V1..V4, otra anatomía). */
+const ABERTURA_VISEMA = { V2: 0.35, V3: 1, V4: 0.55 };
+
+/* ESTELA iridiscente (afterimage): la silueta simplificada del ave (ala, cuerpo,
+   cabeza, pico, timonera) en un solo tono tornasol. CSS la anima con el MISMO
+   dardo que el cuerpo pero con delay → durante el dardo queda visiblemente
+   ATRÁS (motion trail); cerniéndose casi coincide y solo asoma como fleco
+   cromático en el contorno (el shimmer del plumaje). Decorativa → aria-hidden. */
+function EstelaColibri({ clase, color, opacidad }) {
+  return (
+    <g className={`colibri-estela ${clase}`} fill={color} opacity={opacidad} aria-hidden="true">
+      <path d={ALA_TRASERA} />
+      <path d={COLA[1]} />
+      <ellipse cx="0" cy="0.4" rx={COLIBRI_PROPORCION.troncoRx} ry={COLIBRI_PROPORCION.troncoRy} />
+      <circle cx="6.6" cy="-2.4" r={COLIBRI_PROPORCION.cabezaR} />
+      <path d="M9.6,-2.4 L18.4,-4.2" stroke={color} strokeWidth="1.3" fill="none" strokeLinecap="round" />
+      <path d={ALA_DELANTERA} />
+    </g>
+  );
+}
+
 export function Colibri({
   size = 64,
   className = '',
@@ -33,45 +73,113 @@ export function Colibri({
   animated = true,
   title = 'Colibrí',
   /* Pose de VIDA (idle-life), equivalentes a las de Angelita: 'vuela' (base,
-     aleteo normal) | 'celebra' (giro alegre + aleteo acelerado) | 'reposo'
-     (se posa, alitas plegadas, respira) | 'señala' (se inclina al POI y apunta
-     con el pico). Gestos species-agnostic en `creatures.css` (rh-g-*); solo
-     corren viva (animated). */
+     cernido nervioso + dardos con estela) | 'celebra' (brinco + aleteo a tope)
+     | 'reposo' (se posa, alitas plegadas, respira — el ÚNICO momento quieto)
+     | 'señala' (se inclina al POI y apunta con el pico). Gestos
+     species-agnostic en `creatures.css` (rh-g-*); solo corren viva (animated). */
   pose = 'vuela',
   animo = 'sereno',
   energia = 1,
   clima = null,
-  enso = 'neutro',
-  tier,
+  enso = /** @type {('nino'|'nina'|'neutro')} */ ('neutro'),
+  /* ── LIP-SYNC (sistema transversal, useLipSync) ────────────────────────────
+     visema opcional ('V1'..'V4') que produce useLipSync desde el RMS del TTS:
+     el PICO se abre al hablar (mandíbula inferior + garganta al chillar). Sin
+     visema (o 'V1') = la sonrisita de siempre → avatares/catálogo no cambian.
+     El HOOK vive aparte (no cuelga un AnalyserNode por instancia). */
+  visema = null,
+  /* ── VESTUARIO por clima+hora (ropaDeClima) ───────────────────────────────
+     OPT-IN: con vestuario=true el colibrí se abriga según el clima real
+     (RUANITA de noche/frío). Es un AVE: NUNCA suda (las aves no tienen
+     glándulas sudoríparas) → jamás sombrero ni gotas de sudor, aunque el
+     termómetro suba (se suprimen aquí sin tocar la función compartida).
+     Default false → los consumidores de `clima` existentes NO ven ropa nueva. */
+  vestuario = false,
+  tempC = undefined,
+  /* ── ESTELAS iridiscentes (afterimages — SU firma de carácter) ─────────────
+     Default ON viva: 2 siluetas tornasol (cian y magenta) que persiguen el
+     cuerpo con delay — en cada DARDO quedan atrás como estela de velocidad.
+     estelas={false} las apaga (hosts que quieran al colibrí sobrio). Con
+     animated=false / reduced-motion / tier bajo no existen o quedan ocultas. */
+  estelas = true,
+  /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
+     pleno; 'bajo' apaga lo continuo (dardo + estelas + boil) y deja aleteo y
+     estados reactivos. Sin prop (standalone: avatares, catálogo) = pleno. */
+  tier = undefined,
+  /* ── LÍNEA QUE RESPIRA (line-boil, Cuphead años 30 — LineBoilFilter) ────────
+     OPT-IN: con lineBoil el CONTORNO vibra escalonado (feTurbulence +
+     feDisplacement, ~8fps). Default false → consumidores existentes no
+     cambian. Con animated=false o reduced-motion queda con seed fija. Capa MÁS
+     cara del kit: reservada para su entrada heroica (galería, hero). */
+  lineBoil = false,
+  /* ── MODO PODER (power-up IRIDISCENTE cian-magenta — transformacion.css) ───
+     OPT-IN: con poder=true (y en modo standalone) el colibrí se envuelve en su
+     aura TORNASOL de 4 capas (glow radial cian→magenta, boost, ingravidez,
+     corrientes alternadas). El host lo enciende un rato con usePoderTemporal().
+     En modo inline el power-up lo pone el host DOM (::before/mix-blend no
+     aplican a nodos SVG); acá solo marcamos data-poder. */
+  poder = false,
+  /* ── PROP POR MUNDO (herramienta en las patitas — propsPorMundo/PropEnMano) ─
+     mundoId opcional: al ENTRAR a un mundo el colibrí carga su herramienta
+     colgando de las patitas (agua→manguerita, suelo→lupa, animales→lazo,
+     semillero→canasto…). Sin mundoId (o mundo sin prop) entra con las patitas
+     libres (PropEnMano devuelve null, nunca rompe la escena). */
+  mundoId = null,
   ...rest
 }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
   const glow = `crt-glow-${uid}`;
   const blur = `crt-blur-${uid}`;
+  const boil = `crt-boil-${uid}`;
   const wing = animated ? 'crt-wing' : undefined;
   const vivo = animated;
   const auraOp = Math.max(0.16, Math.min(0.5, 0.2 + 0.3 * (energia ?? 1)));
   const auraR = 5.2 + 1.2 * (energia ?? 1);
+  const estelasOn = vivo && !!estelas;
 
-  // CLIMA → cuerpo (perfil colibrí). El aleteo se apura (dorada) o pesa (lluvia)
-  // escalando la duración base de `.crt-wing` (0.15s). Sin clima = neutro.
+  // CLIMA → cuerpo (perfil colibrí). El aleteo base HIPERVELOZ (0.11s, en el
+  // CSS del bloque colibrí) se apura (dorada) o pesa (lluvia) escalando por
+  // velocidadAlas; solo estampamos inline cuando difiere de 1 para no pisar
+  // los gestos CSS (celebra/reposo). Sin clima = neutro.
   const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: PERFIL_COLIBRI });
   const wingDur = (wing && cuerpoClima.velocidadAlas !== 1)
-    ? { animationDuration: `${(0.15 / cuerpoClima.velocidadAlas).toFixed(3)}s` }
+    ? { animationDuration: `${(0.11 / cuerpoClima.velocidadAlas).toFixed(3)}s` }
     : undefined;
   const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
     ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
     : undefined;
 
+  // Vestuario por clima+hora (opt-in). Es AVE: RUANITA de noche/frío, y NUNCA
+  // sombrero ni sudor (las aves no sudan) — mismo contrato que el oso de
+  // páramo: se suprimen aquí sin tocar la función compartida (sus tests y su
+  // contrato siguen intactos). Sin vestuario o sin clima → nada.
+  const ropaBase = (vestuario && clima) ? ropaDeClimaBicho('colibri', clima, { tempC }) : null;
+  const ropa = ropaBase ? { ...ropaBase, sombrero: false, sudor: false } : null;
+
+  // LIP-SYNC de pico: el visema abre la mandíbula inferior (V3 = chillido
+  // amplio con garganta visible). Determinista, cero estado.
+  const abertura = visema ? (ABERTURA_VISEMA[visema] ?? 0) : 0;
+  const picoBajoX = (17.8 - 1.4 * abertura).toFixed(2);
+  const picoBajoY = (-3.4 + 3.8 * abertura).toFixed(2);
+
   const defs = (
     <defs>
       <CreatureFilters glow={glow} blur={blur} />
+      {/* Line-boil (contorno que hierve) — solo se instancia si se pide. */}
+      {lineBoil && <LineBoilFilter id={boil} animated={vivo} />}
     </defs>
   );
 
-  // ── CUERPO rubber-hose (atrás→adelante): aura, cola, ala trasera, cuerpo
-  //    turquesa con vientre claro, patitas, cabeza (gorguera + ojo + pico),
-  //    ala delantera en borrón. `.crt-body` squashea (boil idle).
+  // PROP DEL MUNDO colgando de las patitas (bajo el cuerpo, a su escala de
+  // pajarito). Sin mundoId o mundo sin prop → null (patitas libres).
+  const propMundo = mundoId ? (
+    <PropEnMano mundoId={mundoId} x={0.6} y={9.8} escala={0.55} ink={RH_INK} animated={vivo} />
+  ) : null;
+
+  // ── CUERPO rubber-hose (atrás→adelante): aura, cola, ala trasera, patitas,
+  //    cuerpo turquesa con vientre claro, ruanita, cabeza (gorguera + ojo +
+  //    pico que habla), ala delantera en borrón, prop. `.crt-body` squashea
+  //    (boil idle — RÁPIDO en el colibrí: cernido nervioso, ver CSS).
   const body = (
     <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
       {/* aura viva */}
@@ -84,7 +192,7 @@ export function Colibri({
 
       {/* ala TRASERA en borrón (batida): detrás del cuerpo, con smear del aleteo */}
       <path className={wing} style={{ animationDelay: '-0.05s', ...wingDur }}
-        d="M2,0.6 C-4,12 9,16.4 13.6,8.8 C10.6,3.4 6,1.2 2,0.6 Z"
+        d={ALA_TRASERA}
         fill={COLIBRI_PALETA.cuerpo} opacity="0.4" stroke="rgba(42,26,12,0.3)" strokeWidth="0.5" />
 
       {/* patitas manguera diminutas (recogidas bajo el cuerpo) */}
@@ -98,20 +206,44 @@ export function Colibri({
       {/* vientre claro (el pecho que sube y baja) */}
       <path d="M-3,2.6 C2.4,4.6 7,4 10,1.8 C6.6,5.8 -0.4,6 -4,2.0 Z" fill={COLIBRI_PALETA.vientre} opacity="0.85" />
 
+      {/* Vestuario por clima+hora (RUANITA de noche/frío) — solo con
+          vestuario=true. Va SOBRE el tronco y BAJO la cabeza y el ala
+          delantera (las alas salen del poncho — el pajarito sigue volando).
+          Sombrero/sudor van suprimidos (las aves no sudan). */}
+      {ropa && (
+        <AccesoriosClima
+          estado={ropa}
+          tronco={{ cx: 0, cy: 0.4, rx: COLIBRI_PROPORCION.troncoRx, ry: COLIBRI_PROPORCION.troncoRy }}
+          cabeza={{ cx: 6.6, cy: -2.4, r: COLIBRI_PROPORCION.cabezaR }}
+          animated={vivo}
+        />
+      )}
+
       {/* cabeza turquesa con contorno */}
       <circle cx="6.6" cy="-2.4" r={COLIBRI_PROPORCION.cabezaR} fill={COLIBRI_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.2" />
-      {/* GORGUERA violeta iridiscente (la firma): mancha bajo la cara + brillo */}
+      {/* GORGUERA violeta iridiscente (la firma de la especie): mancha bajo la
+          cara + brillo tornasol */}
       <path d="M5.0,-0.2 C6.6,2.2 9.4,2.2 10.8,-0.2 C10.2,2.6 5.8,2.8 5.0,-0.2 Z"
         fill={COLIBRI_PALETA.garganta} opacity="0.95" />
       <path d="M6.4,0.2 C7.2,1.2 8.6,1.2 9.4,0.2 C8.6,1.4 7.2,1.4 6.4,0.2 Z"
         fill={COLIBRI_PALETA.gargantaBrillo} opacity="0.8" />
-      {/* chapeta + sonrisa mínima en la base del pico */}
+      {/* chapeta + sonrisa mínima en la base del pico (solo con el pico
+          cerrado: al hablar, el pico ES la boca) */}
       <Cachetes puntos={[{ cx: 5.0, cy: -1.4, r: 1.0 }]} vivo={vivo} />
-      <Sonrisa cx={8.4} cy={-1.0} w={1.8} prof={0.7} />
-      {/* PICO recto y largo (dos mandíbulas de tinta cálida) */}
+      {!abertura && <Sonrisa cx={8.4} cy={-1.0} w={1.8} prof={0.7} />}
+      {/* GARGANTA al chillar (V3/V4: la cuña cálida entre mandíbulas) */}
+      {abertura >= 0.5 && (
+        <path className="colibri-garganta"
+          d={`M9.7,-2.1 L13.6,-2.9 L12.6,${(-2.7 + 2.4 * abertura).toFixed(2)} Z`}
+          fill={RH_BOCA} />
+      )}
+      {/* PICO recto y largo (dos mandíbulas de tinta cálida). La inferior es la
+          que HABLA: se abre según el visema (lip-sync de pico). */}
       <path d="M9.6,-2.4 L18.4,-4.2" stroke={RH_INK} strokeWidth="1.3" fill="none" strokeLinecap="round" />
-      <path d="M9.6,-1.4 L17.8,-3.4" stroke={RH_INK} strokeWidth="0.9" fill="none" strokeLinecap="round" opacity="0.7" />
-      {/* ojo de goma grande (3/4: uno prominente) */}
+      <path d={`M9.6,-1.4 L${picoBajoX},${picoBajoY}`}
+        stroke={RH_INK} strokeWidth="0.9" fill="none" strokeLinecap="round" opacity="0.7" />
+      {/* ojo de goma grande (3/4: uno prominente) — MIRADA RÁPIDA (ver CSS:
+          el colibrí dardea también con los ojitos) */}
       <OjosRubber
         ojos={[{ cx: 6.9, cy: -3.0, r: 1.7 }]}
         mirar={[0.32, 0.2]}
@@ -120,33 +252,63 @@ export function Colibri({
 
       {/* ala DELANTERA en borrón (batida, encima del cuerpo con smear) */}
       <path className={wing} style={wingDur}
-        d="M3,-1.6 C-4.6,-15 10.8,-22 17.6,-13 C14.6,-5 8.2,-1.6 3,-1.6 Z"
+        d={ALA_DELANTERA}
         fill={COLIBRI_PALETA.ala} opacity="0.78" stroke="rgba(42,26,12,0.35)" strokeWidth="0.5" />
+
+      {/* Prop del mundo colgando de las patitas (entra con su herramienta). */}
+      {propMundo}
     </g>
   );
 
-  const cuerpoVivo = vivo ? (
-    <g className="rh-antic">
-      <g className="rh-travieso">{body}</g>
+  // DARDO + ESTELAS: el cuerpo dardea (cambios de dirección bruscos con
+  // overshoot — CSS colibri-dardo) y las 2 siluetas tornasol lo persiguen con
+  // delay (afterimages). Las estelas van DETRÁS (el cuerpo las tapa cerniéndose
+  // y las suelta al dardear). Solo existen viva; CSS las esconde fuera de
+  // 'vuela' y en tier bajo / reduced-motion.
+  const conDardo = estelasOn ? (
+    <g>
+      <EstelaColibri clase="colibri-estela--2" color={COLIBRI_PALETA.irisMagenta} opacidad={0.22} />
+      <EstelaColibri clase="colibri-estela--1" color={COLIBRI_PALETA.irisCian} opacidad={0.3} />
+      <g className="colibri-dardo">{body}</g>
     </g>
-  ) : body;
+  ) : (vivo ? <g className="colibri-dardo">{body}</g> : body);
+
+  // Antics de VIDA (períodos co-primos) SOLO viva; nodos aparte para no pisar
+  // ni el boil de `.crt-body` ni el dardo. El CSS los apaga con RM / tier bajo /
+  // ánimo bajo / durante los gestos.
+  const conAntics = vivo ? (
+    <g className="rh-antic">
+      <g className="rh-travieso">{conDardo}</g>
+    </g>
+  ) : conDardo;
+  // El line-boil (contorno que hierve) envuelve TODO el dibujo cuando se pide
+  // (grupo aparte: no colisiona con el glow del `.crt-body`).
+  const cuerpoVivo = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
 
   const estadoAttrs = {
     'data-creature': 'colibri',
     'data-pose': vivo ? pose : undefined,
     'data-animo': animo,
     'data-tier': tier || undefined,
+    'data-visema': visema || undefined,
+    'data-ruana': ropa?.ruana ? '1' : undefined,
+    'data-mojado': ropa?.mojado ? '1' : undefined,
+    'data-estelas': estelasOn ? '1' : undefined,
+    'data-lineboil': lineBoil ? '1' : undefined,
+    'data-prop': mundoId || undefined,
   };
 
   if (inline) {
+    // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
+    // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
     return (
-      <g className={className} style={estiloClima} {...estadoAttrs}>
+      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
         {defs}
         {cuerpoVivo}
       </g>
     );
   }
-  return (
+  const svg = (
     <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
@@ -154,6 +316,23 @@ export function Colibri({
       {cuerpoVivo}
     </svg>
   );
+  // MODO PODER (standalone): el aura IRIDISCENTE cian-magenta de 4 capas
+  // (transformacion.css + el tornasol del bloque colibrí en creatures.css:
+  // glow radial cian→magenta que rota de tono + corrientes alternadas). El
+  // wrapper DOM es lo único que puede llevar ::before/mix-blend/corrientes.
+  if (poder) {
+    return (
+      <span
+        className="is-powered-up colibri-poder"
+        data-creature-poder="colibri"
+        style={{ '--aura-color': auraDeBicho('colibri'), display: 'inline-flex' }}
+      >
+        {svg}
+        <AuraPoder />
+      </span>
+    );
+  }
+  return svg;
 }
 
 export default Colibri;

--- a/src/visual/creatures/__tests__/Colibri.render.test.jsx
+++ b/src/visual/creatures/__tests__/Colibri.render.test.jsx
@@ -1,0 +1,175 @@
+/**
+ * Colibri.render.test.jsx — los 5 frentes de "Colibrí completo" (espejo de
+ * Angelita y el oso, con el CARÁCTER del HIPERACTIVO: veloz, nervioso, con
+ * estelas iridiscentes). Verifica que las capacidades ADITIVAS del componente
+ * canónico se rendericen sin romper el contrato viejo:
+ *   1. Expresividad veloz — estelas-afterimage (SU firma, default viva),
+ *      line-boil opt-in y dardo (wrapper .colibri-dardo).
+ *   2. Lip-sync — el visema viaja al PICO (data-visema + garganta al chillar).
+ *   3. Modo poder — aura IRIDISCENTE cian-magenta de 4 capas (≠ abeja ≠ oso).
+ *   4. Ruanita por clima — de noche RUANA, y el colibrí NUNCA suda (es ave).
+ *   5. Prop por mundo — la herramienta colgando de las patitas al entrar.
+ * Más la firma de identidad: gorguera violeta iridiscente (Colibri coruscans).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { Colibri } from '../Colibri.jsx';
+import { auraDeBicho } from '../transformacion.js';
+import { COLIBRI_PALETA } from '../faunaAndina.js';
+
+afterEach(cleanup);
+
+describe('Colibri — contrato base intacto', () => {
+  it('render por defecto = svg accesible, sin capas opt-in', () => {
+    const { container } = render(<Colibri />);
+    const svg = container.querySelector('svg[data-creature="colibri"]');
+    expect(svg).toBeTruthy();
+    expect(svg.getAttribute('role')).toBe('img');
+    // Ninguna capa opt-in aparece sin pedirla (no regresión visual).
+    expect(svg.getAttribute('data-lineboil')).toBeNull();
+    expect(svg.getAttribute('data-visema')).toBeNull();
+    expect(svg.getAttribute('data-prop')).toBeNull();
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+  });
+
+  it('siempre trae su GORGUERA violeta iridiscente (identidad de la especie)', () => {
+    const { container } = render(<Colibri />);
+    expect(container.querySelector(`[fill="${COLIBRI_PALETA.garganta}"]`)).toBeTruthy();
+  });
+});
+
+describe('1. Expresividad veloz — estelas, dardo y line-boil', () => {
+  it('viva trae sus 2 ESTELAS iridiscentes por defecto (la firma) + el dardo', () => {
+    const { container } = render(<Colibri animated />);
+    expect(container.querySelector('svg').getAttribute('data-estelas')).toBe('1');
+    expect(container.querySelectorAll('.colibri-estela').length).toBe(2);
+    expect(container.querySelector('.colibri-estela--1')).toBeTruthy();
+    expect(container.querySelector('.colibri-estela--2')).toBeTruthy();
+    expect(container.querySelector('.colibri-dardo')).toBeTruthy();
+  });
+
+  it('las estelas son decorativas (aria-hidden) y tornasol (cian + magenta)', () => {
+    const { container } = render(<Colibri animated />);
+    const estelas = container.querySelectorAll('.colibri-estela');
+    estelas.forEach((e) => expect(e.getAttribute('aria-hidden')).toBe('true'));
+    expect(container.querySelector(`.colibri-estela[fill="${COLIBRI_PALETA.irisCian}"]`)).toBeTruthy();
+    expect(container.querySelector(`.colibri-estela[fill="${COLIBRI_PALETA.irisMagenta}"]`)).toBeTruthy();
+  });
+
+  it('estelas={false} las apaga; animated=false ni las monta (fotograma digno)', () => {
+    const sinEstelas = render(<Colibri animated estelas={false} />);
+    expect(sinEstelas.container.querySelector('.colibri-estela')).toBeNull();
+    cleanup();
+    const quieto = render(<Colibri animated={false} />);
+    expect(quieto.container.querySelector('.colibri-estela')).toBeNull();
+    expect(quieto.container.querySelector('.colibri-dardo')).toBeNull();
+    expect(quieto.container.querySelector('svg').getAttribute('data-estelas')).toBeNull();
+  });
+
+  it('lineBoil instancia el filtro de displacement (línea que respira)', () => {
+    const { container } = render(<Colibri lineBoil animated />);
+    expect(container.querySelector('svg').getAttribute('data-lineboil')).toBe('1');
+    expect(container.querySelector('feDisplacementMap')).toBeTruthy();
+    expect(container.querySelector('feTurbulence')).toBeTruthy();
+  });
+
+  it('sin lineBoil NO se paga el filtro (frugal)', () => {
+    const { container } = render(<Colibri animated />);
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+  });
+});
+
+describe('2. Lip-sync — el visema llega al PICO', () => {
+  it('con visema V3 el pico chilla: data-visema + garganta visible', () => {
+    const { container } = render(<Colibri visema="V3" />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBe('V3');
+    expect(container.querySelector('.colibri-garganta')).toBeTruthy();
+  });
+
+  it('sin visema no marca data-visema ni abre garganta (la sonrisita de siempre)', () => {
+    const { container } = render(<Colibri />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBeNull();
+    expect(container.querySelector('.colibri-garganta')).toBeNull();
+  });
+
+  it('V1 (silencio) = pico cerrado, sin garganta', () => {
+    const { container } = render(<Colibri visema="V1" />);
+    expect(container.querySelector('.colibri-garganta')).toBeNull();
+  });
+});
+
+describe('3. Modo poder — aura IRIDISCENTE cian-magenta (standalone)', () => {
+  it('poder envuelve en .is-powered-up.colibri-poder con SU aura (≠ abeja ≠ oso)', () => {
+    const { container } = render(<Colibri poder />);
+    const wrap = container.querySelector('.is-powered-up');
+    expect(wrap).toBeTruthy();
+    expect(wrap.classList.contains('colibri-poder')).toBe(true);
+    expect(wrap.getAttribute('data-creature-poder')).toBe('colibri');
+    expect(wrap.getAttribute('style')).toContain('--aura-color');
+    expect(wrap.getAttribute('style')).toContain(auraDeBicho('colibri'));
+    expect(auraDeBicho('colibri')).not.toBe(auraDeBicho('abeja-angelita'));
+    expect(auraDeBicho('colibri')).not.toBe(auraDeBicho('oso-andino'));
+    // capa 4: las corrientes (AuraPoder)
+    expect(container.querySelector('.poder-corrientes')).toBeTruthy();
+  });
+
+  it('sin poder no hay wrapper (svg desnudo)', () => {
+    const { container } = render(<Colibri />);
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+    expect(container.querySelector(':scope > svg[data-creature="colibri"]')).toBeTruthy();
+  });
+});
+
+describe('4. Ruanita por clima — se abriga y NUNCA suda (es ave)', () => {
+  it('de noche con vestuario → RUANA y JAMÁS sudor/sombrero', () => {
+    const { container } = render(<Colibri vestuario clima="noche" />);
+    const svg = container.querySelector('svg');
+    expect(svg.getAttribute('data-ruana')).toBe('1');
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+  });
+
+  it('de día caluroso (tempC alta) el colibrí NO suda (las aves no sudan)', () => {
+    const { container } = render(<Colibri vestuario clima="soleado" tempC={30} />);
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+    expect(container.querySelector('.crt-gota-sudor')).toBeNull();
+  });
+
+  it('sin vestuario (avatar/catálogo) → nada de ropa aunque haya clima', () => {
+    const { container } = render(<Colibri clima="noche" />);
+    expect(container.querySelector('svg').getAttribute('data-ruana')).toBeNull();
+  });
+});
+
+describe('5. Prop por mundo — herramienta en las patitas', () => {
+  it('mundoId=suelo → carga la lupa', () => {
+    const { container } = render(<Colibri mundoId="suelo" />);
+    expect(container.querySelector('svg').getAttribute('data-prop')).toBe('suelo');
+    expect(container.querySelector('[data-prop="lupa"]')).toBeTruthy();
+  });
+
+  it('mundoId=agua → carga la manguerita', () => {
+    const { container } = render(<Colibri mundoId="agua" />);
+    expect(container.querySelector('[data-prop="manguera"]')).toBeTruthy();
+  });
+
+  it('mundo sin prop mapeado → patitas libres (no rompe)', () => {
+    const { container } = render(<Colibri mundoId="mundo-fantasma" />);
+    expect(container.querySelector('[data-prop="lupa"]')).toBeNull();
+    expect(container.querySelector('svg[data-creature="colibri"]')).toBeTruthy();
+  });
+});
+
+describe('Anti-regresión — modo inline no rompe la escena', () => {
+  it('inline devuelve un <g> con el data-creature y marca data-poder', () => {
+    const { container } = render(
+      <svg>
+        <Colibri inline poder mundoId="suelo" />
+      </svg>,
+    );
+    const g = container.querySelector('g[data-creature="colibri"]');
+    expect(g).toBeTruthy();
+    expect(g.getAttribute('data-poder')).toBe('1'); // el host DOM pinta el aura
+    expect(g.getAttribute('data-prop')).toBe('suelo');
+  });
+});

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -749,3 +749,113 @@
   /* Fotograma digno: un rastro de vaho visible y quieto si se pidió resoplido. */
   .crt-vaho-mota { opacity: 0.55; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   COLIBRÍ — el CARÁCTER del HIPERACTIVO: veloz, nervioso, zumbón, NUNCA quieto.
+   Aditivo sobre el KIT species-agnostic (no toca abeja/oso/rana): el colibrí
+   acelera SU boil (cernido que vibra), sus ojitos y su aleteo, y suma su firma:
+   el DARDO (cambio de dirección brusco con overshoot) perseguido por ESTELAS
+   iridiscentes cian↔magenta (afterimages con delay). Todo transform/opacity
+   (GPU, gama baja). Gates RM + tier al final del bloque.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* CERNIDO NERVIOSO — el boil del colibrí vibra RAPIDITO (misma forma del
+   rh-boil, período corto): un colibrí cerniéndose nunca está quieto de verdad.
+   Solo duration (longhand): el gate genérico de tier bajo (animation: none, que
+   resetea el nombre) sigue mandando. */
+[data-creature='colibri'] .rh-boil { animation-duration: 0.9s; }
+
+/* ALETEO HIPERVELOZ — más rápido que el de la abeja (0.15s): borrón de verdad.
+   El smear/overshoot ya vienen del keyframe compartido crt-wingbeat. */
+[data-creature='colibri'] .crt-wing { animation-duration: 0.11s; }
+/* Celebrando, a TOPE (pisa el 0.09s genérico: este bloque va después y con la
+   misma especificidad ganaría el 0.11 base — se re-declara explícito). */
+[data-creature='colibri'][data-pose='celebra'] .crt-wing { animation-duration: 0.07s; }
+
+/* OJITOS RÁPIDOS — la mirada dardea y el parpadeo es más seguido (períodos
+   co-primos con el dardo de 3.8s y los antics: nunca el mismo compás). */
+[data-creature='colibri'] .rh-mirada { animation-duration: 4.1s; }
+[data-creature='colibri'] .rh-blink { animation-duration: 3.7s; }
+
+/* DARDO — la firma de movimiento: se cierne, ANTICIPA un pelo y ¡ZAS! cambia de
+   posición de golpe con inclinación al vector y overshoot elástico al frenar;
+   se cierne allá y vuelve con otro dardo (y uno vertical corto de propina).
+   Las ESTELAS corren el MISMO keyframe con delay → quedan visiblemente atrás
+   durante cada dardo (afterimage) y casi coinciden cerniéndose (solo un fleco
+   tornasol en el contorno: el shimmer del plumaje). */
+[data-creature='colibri'] .colibri-dardo,
+[data-creature='colibri'] .colibri-estela {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: colibri-dardo 3.8s cubic-bezier(0.3, 0, 0.2, 1) infinite;
+  will-change: transform;
+}
+[data-creature='colibri'] .colibri-estela--1 { animation-delay: 0.07s; }
+[data-creature='colibri'] .colibri-estela--2 { animation-delay: 0.15s; }
+@keyframes colibri-dardo {
+  0%, 18% { transform: translate(0, 0) rotate(0deg); }            /* se cierne */
+  21%  { transform: translate(-0.9px, 0.4px) rotate(-7deg); }     /* anticipa (coge impulso) */
+  26%  { transform: translate(3.4px, -1.6px) rotate(10deg); }     /* ¡DARDO! arriba-derecha */
+  30%  { transform: translate(2.8px, -1.3px) rotate(3deg); }      /* frena con overshoot */
+  46%  { transform: translate(3px, -1.4px) rotate(4deg); }        /* se cierne allá */
+  49%  { transform: translate(3.9px, -1.1px) rotate(11deg); }     /* anticipa al revés */
+  54%  { transform: translate(-2.7px, 1.2px) rotate(-11deg); }    /* dardo de vuelta */
+  58%  { transform: translate(-2.1px, 0.9px) rotate(-3deg); }     /* asienta elástico */
+  71%  { transform: translate(-2.2px, 1px) rotate(-4deg); }       /* se cierne acá */
+  75%  { transform: translate(-1.9px, -2.5px) rotate(4deg); }     /* dardo vertical corto */
+  79%  { transform: translate(-1.7px, -2.1px) rotate(0deg); }
+  91%, 100% { transform: translate(0, 0) rotate(0deg); }          /* vuelve al centro */
+}
+
+/* Ánimo pleno = TODAVÍA más loco (dardea más seguido; las estelas lo siguen). */
+[data-creature='colibri'][data-animo='pleno'] .colibri-dardo,
+[data-creature='colibri'][data-animo='pleno'] .colibri-estela { animation-duration: 2.7s; }
+
+/* Los gestos con carácter y los ánimos bajos PISAN el dardo: un colibrí posado
+   (reposo), señalando o bajito de ánimo no dardea — el gesto lee limpio. Y las
+   estelas SOLO existen volando: fuera de 'vuela' (o sin pose) se esconden
+   (posado no hay afterimage que valga). */
+[data-creature='colibri'][data-pose='reposo'] .colibri-dardo,
+[data-creature='colibri'][data-pose='señala'] .colibri-dardo,
+[data-creature='colibri'][data-pose='celebra'] .colibri-dardo,
+[data-creature='colibri'][data-animo='sediento'] .colibri-dardo,
+[data-creature='colibri'][data-animo='sediento'] .colibri-estela,
+[data-creature='colibri'][data-animo='descansa'] .colibri-dardo,
+[data-creature='colibri'][data-animo='descansa'] .colibri-estela { animation: none; }
+[data-creature='colibri']:not([data-pose='vuela']) .colibri-estela {
+  animation: none;
+  opacity: 0;
+}
+
+/* MODO PODER IRIDISCENTE — el aura del colibrí no es de un color: es TORNASOL.
+   Sobre la capa 1 species-agnostic (.is-powered-up::before) se pinta el glow
+   radial cian→magenta y se le suma una rotación de tono lenta (el shimmer del
+   plumaje subido a poder). Las corrientes ascendentes alternan cian/magenta.
+   Doble clase (.is-powered-up.colibri-poder) para ganarle a transformacion.css
+   sin depender del orden de import de los bundles CSS. */
+.is-powered-up.colibri-poder::before {
+  background: radial-gradient(circle, #4fd1ff 0%, rgba(255, 79, 209, 0.8) 48%, transparent 72%);
+  animation: poder-aura 1.1s ease-in-out infinite, colibri-tornasol 3.3s linear infinite;
+}
+@keyframes colibri-tornasol {
+  0%, 100% { filter: hue-rotate(0deg); }
+  50%      { filter: hue-rotate(-55deg); }
+}
+.colibri-poder .poder-corriente:nth-child(even) { stroke: #ff4fd1; }
+
+/* device-tier 'bajo': el dardo y las estelas son lo continuo más caro del
+   colibrí → apagados (el aleteo y los estados reactivos siguen contando la
+   verdad). Las estelas quietas taparían el dibujo → ocultas. */
+[data-tier='bajo'][data-creature='colibri'] .colibri-dardo { animation: none; }
+[data-tier='bajo'][data-creature='colibri'] .colibri-estela { animation: none; opacity: 0; }
+
+@media (prefers-reduced-motion: reduce) {
+  [data-creature='colibri'] .colibri-dardo,
+  [data-creature='colibri'] .colibri-estela { animation: none !important; }
+  /* Sin movimiento no hay afterimage: las estelas desaparecen (fotograma digno
+     = el colibrí quieto y legible, sin fantasmas superpuestos). */
+  [data-creature='colibri'] .colibri-estela { opacity: 0; }
+  /* El tornasol del poder también queda quieto (re-gate: la doble clase de
+     arriba le ganaba al gate genérico de transformacion.css). */
+  .is-powered-up.colibri-poder::before { animation: none; }
+}

--- a/src/visual/creatures/faunaAndina.js
+++ b/src/visual/creatures/faunaAndina.js
@@ -49,6 +49,11 @@ export const COLIBRI_PALETA = {
   alaClara: '#bff4ff',
   pico: '#241812',         // pico recto (tinta cálida)
   cola: '#26b894',         // timoneras
+  /* Iridiscencia CIAN↔MAGENTA (su color de poder y el de sus estelas de
+     movimiento — afterimages). El tornasol real del plumaje: según el ángulo
+     el mismo colibrí destella frío o rosado. */
+  irisCian: '#4fd1ff',
+  irisMagenta: '#ff4fd1',
 };
 export const COLIBRI_PROPORCION = {
   troncoRx: 6.0,


### PR DESCRIPTION
## Qué es

El **colibrí chillón** (*Colibri coruscans*) sube al nivel de referencia de la familia (abeja #2424, oso #2425): los **5 frentes** del sistema de personajes sobre el componente canónico `src/visual/creatures/Colibri.jsx`, componiendo la fundación transversal — cero código duplicado, cero fork.

Su carácter: **HIPERACTIVO** — veloz, nervioso, zumbón, nunca quieto. Su firma: **estelas iridiscentes** (afterimages cian↔magenta que persiguen el cuerpo). Su color de poder: **tornasol cian-magenta** (abeja dorado, oso rojo, rana verde).

## Los 5 frentes

1. **Expresividad rubber-hose veloz**
   - **DARDO** (`.colibri-dardo`): se cierne, anticipa y cambia de dirección de golpe con inclinación al vector + overshoot elástico (3 dardos por ciclo de 3.8s; ánimo `pleno` = 2.7s).
   - **ESTELAS afterimage**: 2 siluetas tornasol (cian + magenta) corren el mismo keyframe con delay (70/150ms) → quedan visiblemente atrás en cada dardo; cerniéndose solo asoman como fleco cromático (el shimmer del plumaje). Default ON viva, `estelas={false}` opt-out.
   - Cernido nervioso (boil a 0.9s), aleteo hiperveloz (0.11s base, 0.07s celebrando), ojitos rápidos (mirada 4.1s / blink 3.7s), línea que respira (`lineBoil` → `LineBoilFilter`, opt-in).
2. **Lip-sync**: prop `visema` ('V1'..'V4' de `useLipSync`) traducido a **apertura de PICO** — la mandíbula inferior se abre por visema y en V3/V4 asoma la garganta (`.colibri-garganta`). Misma gramática del sistema, anatomía de ave.
3. **Modo poder**: `poder` → aura de 4 capas (`transformacion.css`) con capa iridiscente propia: glow radial **cian→magenta** + rotación de tono lenta (`colibri-tornasol`) + corrientes alternadas. `--aura-color` sale de `auraDeBicho('colibri')`.
4. **Ropa/clima**: `vestuario` + `ropaDeClimaBicho('colibri', …)` → **ruanita de noche/frío**, y **NUNCA suda** (es ave: sin glándulas sudoríparas) — sombrero/sudor suprimidos igual que el oso, sin tocar la función compartida.
5. **Prop por mundo**: `mundoId` → `PropEnMano` colgando de las patitas a escala pajarito (agua→manguerita, suelo→lupa, animales→lazo, semillero→canasto).

## Anti-conflicto / aditivo estricto

- **No toca** abeja, oso ni rana: bloque COLIBRÍ **al final** de `creatures.css`; claves nuevas `irisCian`/`irisMagenta` en `COLIBRI_PALETA` (aditivas).
- API vieja intacta (`size/className/inline/animated/title/pose/animo/energia/clima/enso/tier`) — los 9 consumidores existentes (mockups, avatares, Valle3D) no cambian.
- Gates completos: **reduced-motion** (dardo/estelas apagados, estelas ocultas — fotograma digno sin fantasmas; tornasol re-gateado), **tier bajo** (dardo/estelas off), gestos (`reposo`/`señala`/`celebra`) y ánimos bajos pisan el dardo.

## Verificación

- `npx vitest run src/visual/creatures` → **103 tests verdes** (8 archivos, incluye `Colibri.render.test.jsx` nuevo: 5 frentes + contrato base + inline).
- `npm run build` → verde.
- `npm run tsc:check` → **0 errores** en archivos del colibrí (el componente viejo traía 1 de `enso`; baseline de deuda ajena intacto).
- Test del consumidor `ChagraAgentAvatar.test.jsx` → 13 verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)