### PR TITLE
feat(morrocoy): Morrocoy completo — el 8º y último bicho rubber-hose

### DIFF
--- a/src/visual/creatures/Morrocoy.jsx
+++ b/src/visual/creatures/Morrocoy.jsx
@@ -1,0 +1,395 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+import { OjosRubber, Cachetes, Sonrisa, BocaVisema, RH_INK, RH_BOCA } from './_rubberhose.jsx';
+import { MORROCOY_PALETA, MORROCOY_PROPORCION, MORROCOY_SLUG, PERFIL_MORROCOY } from './morrocoyIdentidad.js';
+import { cuerpoDeClima, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
+import { AccesoriosClima } from './AccesoriosClima.jsx';
+import { LineBoilFilter } from './LineBoilFilter.jsx';
+import { PropEnMano } from './PropEnMano.jsx';
+import { AuraPoder } from './AuraPoder.jsx';
+import { auraDeBicho } from './transformacion.js';
+
+/* Morrocoy — Chelonoidis carbonarius (el galápago de patas rojas de tierra
+   cálida). Hermano rubber-hose de la abeja Angelita, el oso andino, la rana y el
+   jaguar: compone el MISMO kit `_rubberhose.jsx` (ojos de goma, cachetes,
+   sonrisa, cuello/patas manguera) y hereda la MISMA fundación transversal —
+   lip-sync (useLipSync → BocaVisema), modo poder (transformacion, aura BRONCE),
+   ropa por clima (ropaDeClima), prop por mundo (PropEnMano) y line-boil
+   (LineBoilFilter) — cero código duplicado. Solo cambia el ANIMAL y su CARÁCTER:
+   el ANCIANO tranquilo de la chagra — ANCESTRAL, LENTO, SABIO y PACIENTE. Su
+   caparazón es un DOMO GEOMÉTRICO de escudos HEXAGONALES (su firma) que
+   "respira" apacible; sus patas y su cabeza son ROJIZAS con escamas naranja-
+   fuego (la marca carbonarius). Su seña de vida es la RETRACCIÓN ELÁSTICA
+   (`seRetrae`): mete cabeza y patas al caparazón estirando y encogiendo con
+   squash&stretch de goma. Su otra reacción-firma es el ASENTIMIENTO sabio
+   (`asiente`): la testa cabecea lento, "sí, mijo, con paciencia". Su squash es
+   LENTO y firme (nada hiperactivo: la sabiduría no corre). Es de SUELO: anda con
+   paso pesado, sin alas. Su color de poder es el BRONCE/COBRE cálido (no el
+   dorado de la abeja ni el púrpura del jaguar). La IDENTIDAD (paleta +
+   proporciones + perfil de clima) vive en `morrocoyIdentidad.js`; el CLIMA→
+   cuerpo, en `creatureClimaCuerpo.js` con PERFIL_MORROCOY (caparazón córneo que
+   escurre el agua, reptil robusto ante la seca) — y de tierra cálida: NUNCA suda
+   (aguanta el calor sin sudar ni sombrero, como el jaguar).
+
+   ANCESTRAL (el anciano de piedra viva): tejido con gusto, permanente y sutil.
+   Cada escudo hexagonal lleva ANILLOS DE EDAD grabados (el tiempo escrito en el
+   domo) y un RESPLANDOR cobrizo lo envuelve como calor de brasa apacible, con un
+   SHIMMER tibio recorriendo el reborde del caparazón. En modo poder el resplandor
+   y las brasas se avivan (el anciano guarda fuego dentro). Todo se PODA en tier
+   bajo / reduced-motion (queda un fotograma digno y quieto). */
+const VIEWBOX = '-16 -20 32 40';
+
+/* Genera el path de un hexágono de vértices arriba/abajo (pointy-top) —
+   la geometría del escudo del caparazón. r = radio al vértice. */
+function hexPath(cx, cy, r) {
+  const pts = [];
+  for (let k = 0; k < 6; k++) {
+    const a = (Math.PI / 180) * (90 + k * 60); // arranca en la punta superior
+    pts.push(`${(cx + r * Math.cos(a)).toFixed(2)},${(cy - r * Math.sin(a)).toFixed(2)}`);
+  }
+  return `M${pts.join(' L')} Z`;
+}
+
+/* Escudo hexagonal del caparazón (la firma del domo geométrico): hexágono de
+   domo con su cara alta iluminada y ANILLOS DE EDAD concéntricos grabados (lo
+   ancestral: el tiempo escrito en la concha). Decorativo (aria-hidden en el
+   grupo padre). */
+function Escudo({ cx, cy, r, P }) {
+  return (
+    <g>
+      <path d={hexPath(cx, cy, r)} fill={P.escudoCentro} stroke={P.escudo} strokeWidth={r * 0.24} strokeLinejoin="round" />
+      {/* anillos de edad concéntricos (el anciano lleva su tiempo grabado) */}
+      <path d={hexPath(cx, cy, r * 0.66)} fill="none" stroke={P.anillo} strokeWidth={r * 0.1} opacity="0.55" strokeLinejoin="round" />
+      <path d={hexPath(cx, cy, r * 0.34)} fill="none" stroke={P.anillo} strokeWidth={r * 0.1} opacity="0.4" strokeLinejoin="round" />
+      {/* brillo de domo en la cara alta del escudo */}
+      <path d={hexPath(cx, cy - r * 0.18, r * 0.5)} fill={P.caparazonAlto} opacity="0.35" />
+    </g>
+  );
+}
+
+/* Escudos del caparazón: la vertebral central (3 escudos apilados) + las
+   costales laterales (2 por lado). El patrón geométrico canónico del galápago. */
+const ESCUDOS = [
+  { cx: 0, cy: -3.6, r: 3.0 },   // vertebral alta
+  { cx: 0, cy: 0.6, r: 3.2 },    // vertebral central
+  { cx: 0, cy: 4.6, r: 2.7 },    // vertebral baja
+  { cx: -5.6, cy: -1.4, r: 2.6 }, // costal izq. alta
+  { cx: 5.6, cy: -1.4, r: 2.6 }, // costal der. alta
+  { cx: -5.9, cy: 3.2, r: 2.4 }, // costal izq. baja
+  { cx: 5.9, cy: 3.2, r: 2.4 },  // costal der. baja
+];
+
+export function Morrocoy({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Morrocoy',
+  /* Pose de VIDA (idle-life), species-agnostic (gestos rh-g-* de creatures.css):
+     'anda' (base, con paso pesado) | 'celebra' (brinca con brazos en V +
+     overshoot) | 'reposo' (respira hondo, se asienta) | 'señala' (se inclina al
+     POI y apunta con la pata). Solo corren viva (animated); con animated=false o
+     reduced-motion queda en fotograma digno y sereno. */
+  pose = 'anda',
+  animo = 'sereno',
+  energia = 1,
+  /* CLIMA REAL escrito en el cuerpo (perfil morrocoy). Sin clima (avatares,
+     catálogo) = neutro digno: el morrocoy se ve EXACTO como siempre. */
+  clima = null,
+  enso = 'neutro',
+  /* ── LIP-SYNC (sistema transversal, useLipSync) ────────────────────────────
+     visema opcional ('V1'..'V4') que produce useLipSync desde el RMS del TTS: la
+     boca (pico) se abre cuando el agente narra. Sin visema (o 'V1') = la sonrisa
+     de goma de siempre → avatares/catálogo no cambian. El HOOK vive aparte (no
+     cuelga un AnalyserNode por instancia); acá solo se consume. La RETRACCIÓN
+     manda sobre el visema (una tortuga metida en su concha no articula). */
+  visema = null,
+  /* ── VESTUARIO por clima+hora (ropaDeClima) ───────────────────────────────
+     OPT-IN: con vestuario=true el morrocoy se abriga según el clima real (RUANA
+     de noche/frío — es de tierra cálida y siente el frío pronto). Es de tierra
+     cálida: NUNCA se sobrecalienta → jamás suda ni sombrero (se suprimen aquí
+     aunque el termómetro suba, contrato compartido con el jaguar). Default false
+     → los consumidores de `clima` existentes NO ven ropa nueva. */
+  vestuario = false,
+  tempC = undefined,
+  /* ── SE RETRAE (retracción elástica — la firma del morrocoy) ────────────────
+     OPT-IN: cabeza y patas ENTRAN al caparazón estirando y encogiendo con
+     squash&stretch de goma (el domo se abomba un pelín al recogerse). Su
+     reacción-firma ancestral: se guarda, paciente. Default false → asoma sereno. */
+  seRetrae = false,
+  /* ── ASIENTE (el asentimiento sabio — el anciano cabecea) ───────────────────
+     OPT-IN: la testa cabecea lento y firme ("sí, mijo, con paciencia"). Su otra
+     reacción-firma. Default false. */
+  asiente = false,
+  /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
+     pleno; 'bajo' apaga el idle continuo (boil + respiración del domo + shimmer)
+     y deja los estados reactivos. Sin prop (standalone: avatares, catálogo) = pleno. */
+  tier,
+  /* ── LÍNEA QUE RESPIRA (line-boil, Cuphead años 30 — LineBoilFilter) ────────
+     OPT-IN: con lineBoil el CONTORNO del morrocoy vibra escalonado (feTurbulence
+     + feDisplacement, ~8fps) — el trazo "hierve" como dibujo animado clásico.
+     Default false → los consumidores existentes NO cambian. Con animated=false o
+     reduced-motion queda con seed fija (textura sin vibrar). Capa MÁS cara del
+     kit: reservada para su entrada heroica (galería, hero). */
+  lineBoil = false,
+  /* ── MODO PODER (transformación / power-up BRONCE — transformacion.css) ──────
+     OPT-IN: con poder=true (y en modo standalone) el morrocoy se envuelve en su
+     aura BRONCE/COBRE de 4 capas (glow, boost, ingravidez, corrientes) — su firma
+     cuando "sube de nivel" (el anciano guarda fuego dentro). El host lo enciende
+     un rato con usePoderTemporal(). En modo inline el power-up lo pone el host
+     DOM (::before/mix-blend no aplican a nodos SVG); acá solo marcamos data-poder
+     por si el host lo consulta. */
+  poder = false,
+  /* ── PROP POR MUNDO (herramienta en la pata — propsPorMundo/PropEnMano) ──────
+     mundoId opcional: al ENTRAR a un mundo el morrocoy carga su herramienta
+     (agua→manguerita, suelo→lupa, animales→lazo, semillero→canasto…). Sin mundoId
+     (o mundo sin prop) entra con las patas libres. Va en su pata delantera
+     IZQUIERDA. */
+  mundoId = null,
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const boil = `crt-boil-${uid}`;
+  const vivo = animated;
+  const auraOp = Math.max(0.14, Math.min(0.42, 0.18 + 0.26 * (energia ?? 1)));
+  const auraR = 9.0 + 1.6 * (energia ?? 1);
+
+  // CLIMA → cuerpo (determinista, una vez por render): tinte + opacidad al
+  // contorno. El morrocoy no tiene alas (velocidadAlas siempre 1: no se usa).
+  const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: PERFIL_MORROCOY });
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
+
+  // Vestuario por clima+hora (opt-in). Perfil morrocoy de TIERRA CÁLIDA: la RUANA
+  // de noche/frío; NUNCA sombrero ni sudor (aunque suba el termómetro) — el
+  // galápago no se sobrecalienta. Los suprimimos aquí sin tocar la función
+  // compartida (su contrato/tests siguen intactos). Sin vestuario/clima → nada.
+  const ropaBase = (vestuario && clima) ? ropaDeClimaBicho(MORROCOY_SLUG, clima, { tempC }) : null;
+  const ropa = ropaBase ? { ...ropaBase, sombrero: false, sudor: false } : null;
+
+  const P = MORROCOY_PALETA;
+  const PR = MORROCOY_PROPORCION;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+      {/* Line-boil (contorno que hierve) — solo se instancia si se pide. */}
+      {lineBoil && <LineBoilFilter id={boil} animated={vivo} />}
+    </defs>
+  );
+
+  // PROP DEL MUNDO en la pata delantera izquierda. Sin mundoId o mundo sin prop →
+  // PropEnMano devuelve null (patas libres, nunca rompe la escena).
+  const propMundo = mundoId ? (
+    <PropEnMano mundoId={mundoId} x={-10.6} y={8.2} escala={0.7} ink={RH_INK} animated={vivo} />
+  ) : null;
+
+  // BOCA (pico): precedencia visema > sonrisa. El morrocoy asoma la testa con su
+  // sonrisa serena; si narra, articula el visema. (La RETRACCIÓN esconde la
+  // cabeza entera vía CSS, no pinta boca aparte.)
+  const boca = visema
+    ? <BocaVisema cx={0} cy={-9.4} w={2.8} prof={1.0} visema={visema} boca={RH_BOCA} />
+    : <Sonrisa cx={0} cy={-9.6} w={2.6} prof={0.95} />;
+
+  // Patas ROJIZAS robustas y cortas (paso pesado). Cada una en su grupo
+  // `.morrocoy-pata` (la RETRACCIÓN las recoge; el idle las mece suave). Pivote
+  // hacia el caparazón para que celebra/señala/retracción las muevan bien.
+  const pata = (x, y, dir, delay, origen) => (
+    <g className={`morrocoy-pata${vivo ? ' rh-sway' : ''}`}
+      style={{ transformBox: 'fill-box', transformOrigin: origen, ...(vivo ? { animationDelay: `${delay}s` } : null) }}>
+      {/* muslo/pata: tubo rojizo con contorno de tinta encima (la línea que manda) */}
+      <path d={`M${x},${y - 3.4} Q${x + dir * 1.6},${y - 0.4} ${x + dir * 1.3},${y + 2.4}`}
+        fill="none" stroke={P.pata} strokeWidth={PR.pataAncho} strokeLinecap="round" />
+      <path d={`M${x},${y - 3.4} Q${x + dir * 1.6},${y - 0.4} ${x + dir * 1.3},${y + 2.4}`}
+        fill="none" stroke={RH_INK} strokeWidth="0.7" strokeLinecap="round" opacity="0.5" />
+      {/* planta con garras (paso pesado) */}
+      <ellipse cx={x + dir * 1.3} cy={y + 2.8} rx="2.4" ry="1.5" fill={P.pata} stroke={RH_INK} strokeWidth="0.8" />
+      <g stroke={RH_INK} strokeWidth="0.5" strokeLinecap="round">
+        <path d={`M${x + dir * 0.1},${y + 3.7} l0,0.9`} />
+        <path d={`M${x + dir * 1.3},${y + 4.0} l0,0.9`} />
+        <path d={`M${x + dir * 2.5},${y + 3.7} l0,0.9`} />
+      </g>
+      {/* escamas naranja-fuego (la marca carbonarius) */}
+      <circle cx={x + dir * 0.7} cy={y - 0.6} r="0.7" fill={P.pataEscama} opacity="0.85" />
+      <circle cx={x + dir * 1.2} cy={y + 1.1} r="0.6" fill={P.pataEscama} opacity="0.7" />
+    </g>
+  );
+
+  // ── CUERPO rubber-hose (atrás→adelante): aura, cola, patas traseras, caparazón
+  //    de domo geométrico (escudos hexagonales + reborde marginal + shimmer
+  //    ancestral), patas delanteras, cabeza (cuello + testa rojiza con escamas +
+  //    ojos ámbar/cachetes/pico). `.crt-body` es el nodo que squashea (boil idle
+  //    morrocoy: LENTO y firme — la sabiduría no corre).
+  const body = (
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* RESPLANDOR ANCESTRAL (PERMANENTE, sutil): el calor de brasa apacible que
+          el anciano guarda dentro del caparazón. Late lento y se aviva en modo
+          poder (CSS). */}
+      <circle className={vivo ? 'morrocoy-resplandor' : undefined}
+        cx="0" cy="1" r={auraR + 2.4} fill={P.resplandor} opacity="0.12"
+        filter={`url(#${blur})`}
+        style={{ transformBox: 'fill-box', transformOrigin: 'center' }} aria-hidden="true" />
+      {/* aura viva bronce */}
+      <circle cx="0" cy="1.2" r={auraR} fill={P.caparazon} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* cola cortita (nub) al ras del reborde */}
+      <path d="M0,8.6 Q1.6,10.4 0.2,11.4 Q-1.4,10.4 0,8.6 Z" fill={P.pata} stroke={RH_INK} strokeWidth="0.8" />
+
+      {/* patas traseras (detrás del caparazón, se recogen en la retracción) */}
+      {pata(-8.4, 5.0, -1, -0.9, 'right top')}
+      {pata(8.4, 5.0, 1, -1.2, 'left top')}
+
+      {/* ── CAPARAZÓN de DOMO GEOMÉTRICO (la firma) — grupo propio
+          `.morrocoy-caparazon` que RESPIRA apacible (y se abomba al retraerse). */}
+      <g className="morrocoy-caparazon" style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+        {/* domo del caparazón (más ancho que alto), contorno grueso que respira */}
+        <ellipse cx="0" cy="1" rx={PR.caparazonRx} ry={PR.caparazonRy}
+          fill={P.caparazon} stroke={RH_INK} strokeWidth="1.5"
+          style={{ filter: `drop-shadow(0 0 6px ${P.caparazonGlow})` }} />
+        {/* cara alta del domo iluminada */}
+        <path d="M-9.4,-2.6 Q0,-9.0 9.4,-2.6 Q0,-5.2 -9.4,-2.6 Z" fill={P.caparazonAlto} opacity="0.55" />
+
+        {/* ESCUDOS HEXAGONALES (el patrón geométrico canónico). Decorativos. */}
+        <g aria-hidden="true">
+          {ESCUDOS.map((e, i) => (
+            <Escudo key={i} cx={e.cx} cy={e.cy} r={e.r} P={P} />
+          ))}
+        </g>
+
+        {/* reborde de escudos MARGINALES (el filo dentado del domo) */}
+        <g aria-hidden="true" fill="none" stroke={P.marginal} strokeWidth="0.7" opacity="0.7">
+          <path d="M-11.0,1.8 Q-10.0,5.2 -7.4,7.6" />
+          <path d="M11.0,1.8 Q10.0,5.2 7.4,7.6" />
+          <path d="M-7.4,7.6 Q-3.7,9.4 0,9.2 Q3.7,9.4 7.4,7.6" strokeDasharray="0.2 2.4" strokeLinecap="round" />
+        </g>
+
+        {/* SHIMMER ANCESTRAL — destello cobrizo tibio en el reborde del caparazón
+            (brasa apacible). Pulsa lento; se aviva en modo poder (CSS). */}
+        <ellipse className={vivo ? 'morrocoy-shimmer' : undefined}
+          cx="0" cy="1" rx={PR.caparazonRx} ry={PR.caparazonRy}
+          fill="none" stroke={P.brasa} strokeWidth="0.9" opacity="0.16" aria-hidden="true" />
+      </g>
+
+      {/* patas delanteras (sobre el caparazón, más claras; se recogen al
+          retraerse). La izquierda carga el prop del mundo. */}
+      {pata(-7.2, 7.2, -1, -0.2, 'right top')}
+      {pata(7.2, 7.2, 1, -0.5, 'left top')}
+
+      {/* ── CABEZA (grupo propio `.morrocoy-cabeza`: la RETRACCIÓN la mete al
+          caparazón y el ASENTIMIENTO la cabecea). Cuello grueso rojizo + testa
+          parda con escamas naranja-fuego (la firma carbonarius). */}
+      <g className="morrocoy-cabeza" style={{ transformBox: 'fill-box', transformOrigin: 'center bottom' }}>
+        {/* cuello que asoma (tubo rojizo con contorno de tinta) */}
+        <path d="M0,-4.6 C-0.4,-6.6 -0.4,-8.0 0,-9.0" fill="none" stroke={P.cabeza} strokeWidth={PR.cuelloAncho} strokeLinecap="round" />
+        <path d="M0,-4.6 C-0.4,-6.6 -0.4,-8.0 0,-9.0" fill="none" stroke={RH_INK} strokeWidth="0.7" strokeLinecap="round" opacity="0.5" />
+        {/* testa */}
+        <circle cx="0" cy="-10.6" r={PR.cabezaR} fill={P.cabeza} stroke={RH_INK} strokeWidth="1.2" />
+        {/* escamas ROJO-NARANJA de la testa (la marca de la especie). Decorativas. */}
+        <g aria-hidden="true" fill={P.cabezaEscama}>
+          <circle cx="-2.0" cy="-12.0" r="0.85" opacity="0.9" />
+          <circle cx="2.1" cy="-11.6" r="0.75" opacity="0.85" />
+          <circle cx="0.2" cy="-13.2" r="0.7" opacity="0.8" />
+          <circle cx="-2.6" cy="-9.8" r="0.6" opacity="0.7" />
+        </g>
+        {/* chapetas + pico (boca) + fosas + ojos ámbar dentro de la cara */}
+        <Cachetes puntos={[{ cx: -2.5, cy: -9.6, r: 0.95 }, { cx: 2.5, cy: -9.6, r: 0.95 }]} vivo={vivo} />
+        {boca}
+        {/* fosas nasales (el pico romo del galápago) */}
+        <circle cx="-0.7" cy="-10.2" r="0.28" fill={P.nariz} />
+        <circle cx="0.7" cy="-10.2" r="0.28" fill={P.nariz} />
+        <OjosRubber
+          ojos={[{ cx: -1.5, cy: -11.4, r: 1.25 }, { cx: 1.5, cy: -11.4, r: 1.25 }]}
+          mirar={[0, 0.08]}
+          parpadea={vivo}
+        />
+        {/* MIRADA SERENA ÁMBAR: anillo tenue que enmarca cada ojo (la calma del
+            anciano). */}
+        <g aria-hidden="true" fill="none" stroke={P.ojoAnillo} strokeWidth="0.4" opacity="0.8">
+          <circle cx="-1.5" cy="-11.4" r="1.0" />
+          <circle cx="1.5" cy="-11.4" r="1.0" />
+        </g>
+      </g>
+
+      {/* Vestuario por clima+hora (RUANA de noche/frío) — solo con vestuario=true.
+          Sombrero/sudor van suprimidos (el morrocoy de tierra cálida no suda). */}
+      {ropa && (
+        <AccesoriosClima
+          estado={ropa}
+          tronco={{ cx: 0, cy: 1, rx: PR.caparazonRx, ry: PR.caparazonRy }}
+          cabeza={{ cx: 0, cy: -10.6, r: PR.cabezaR }}
+          animated={vivo}
+        />
+      )}
+
+      {/* Prop del mundo en la pata (entra sereno con su herramienta). */}
+      {propMundo}
+    </g>
+  );
+
+  // Antics de VIDA (períodos co-primos) SOLO viva; nodos aparte para no pisar el
+  // boil de `.crt-body`. El CSS los apaga con RM / tier bajo / ánimo bajo /
+  // durante los gestos (celebra/reposo/señala) y estados (seRetrae/asiente).
+  const conAntics = vivo ? (
+    <g className="rh-antic">
+      <g className="rh-travieso">{body}</g>
+    </g>
+  ) : body;
+  // El line-boil (contorno que hierve) envuelve TODO el dibujo cuando se pide.
+  const cuerpoVivo = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
+
+  const estadoAttrs = {
+    'data-creature': MORROCOY_SLUG,
+    'data-pose': vivo ? pose : undefined,
+    'data-animo': animo,
+    'data-tier': tier || undefined,
+    'data-visema': visema || undefined,
+    'data-ruana': ropa?.ruana ? '1' : undefined,
+    'data-mojado': ropa?.mojado ? '1' : undefined,
+    'data-retrae': seRetrae ? '1' : undefined,
+    'data-asiente': asiente ? '1' : undefined,
+    'data-lineboil': lineBoil ? '1' : undefined,
+    'data-prop': mundoId || undefined,
+  };
+
+  if (inline) {
+    // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
+    // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
+    return (
+      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+        {defs}
+        {cuerpoVivo}
+      </g>
+    );
+  }
+  const svg = (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
+      <title>{title}</title>
+      {defs}
+      {cuerpoVivo}
+    </svg>
+  );
+  // MODO PODER (standalone): lo envolvemos en su aura BRONCE/COBRE de 4 capas
+  // (transformacion.css: glow radial + boost + ingravidez + corrientes) — su
+  // firma cuando "sube de nivel". El wrapper DOM es lo único que puede llevar
+  // ::before/mix-blend/corrientes.
+  if (poder) {
+    return (
+      <span
+        className="is-powered-up morrocoy-poder"
+        data-creature-poder={MORROCOY_SLUG}
+        style={{ '--aura-color': auraDeBicho(MORROCOY_SLUG), display: 'inline-flex' }}
+      >
+        {svg}
+        <AuraPoder />
+      </span>
+    );
+  }
+  return svg;
+}
+
+export default Morrocoy;

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -27,6 +27,7 @@ calidad dispar. Aquí vive la **versión canónica** de cada uno.
 | `Perezoso` | *Bradypus variegatus* | Perezoso de tres dedos, templado. **Cuelga de una rama** por sus **garras largas** curvas, con **antifaz** y **tinte verdoso** de algas. La quietud extrema: todo en **cámara lenta** (mecerse zen, parpadeo larguísimo). Poder **turquesa**. Rubber-hose, showcase completo. |
 | `Ardilla` | *Notosciurus granatensis* | Ardilla de cola roja del templado. Rufa con **línea dorsal** oscura (su firma), **cola tupida** y dientes de roedor. Ágil e inquieta: su firma es la **inspección invertida** (se cuelga de cabeza). De suelo, se sienta. Rubber-hose. |
 | `Jaguar` | *Panthera onca* | Felino de tierra cálida. Leonado con **rosetas** (manchas de centro ocre — su firma), musculoso, mirada felina ámbar. Majestuoso y **acechador**: acecho de hombros, cola pesada, rugido. Aura **púrpura**. Rubber-hose. |
+| `Morrocoy` | *Chelonoidis carbonarius* | Galápago de patas rojas de tierra cálida. Caparazón de **domo geométrico** (escudos **hexagonales** con anillos de edad — su firma), patas y cabeza **rojizas** con escamas naranja-fuego. **Ancestral, lento, sabio**: caparazón que respira, **retracción elástica** (cabeza y patas entran a la concha), asentimiento sabio. Aura **bronce**. Rubber-hose. |
 | `Lombriz` | *Martiodrilus crassus* | Lombriz gigante nativa. Cuerpo segmentado con clitelo. Sin animación propia (su movimiento lo da la escena). |
 | `Mariposa` | *Dione juno* | Pasionaria de alas largas. Cuatro alas que abren y cierran. |
 | `Escarabajo` | *Dichotomius belus* | Estercolero colombiano. Élitros brillantes, cuerno, y bola de abono que rueda. |
@@ -121,6 +122,16 @@ su gesto-FIRMA la **inspección invertida** (`inspecciona` → se cuelga de cabe
 espiar) más el **roer** una semilla (`roe`). Templada, pero del contrato
 compartido: **nunca suda** (se abriga de noche/frío, jamás gotea). Todo aditivo
 en `creatures.css`, RM + tier-safe.
+
+El **`Morrocoy`** cierra los OCHO con su carácter de galápago ANCESTRAL, LENTO,
+SABIO y PACIENTE (el anciano de la chagra): aura **BRONCE** en poder, boil LENTO
+de **paso pesado** (la sabiduría no corre), **caparazón de domo hexagonal** que
+**respira** (`.morrocoy-caparazon`, escudos con anillos de edad — su firma),
+**patas rojizas** con escamas naranja-fuego, y su gesto-FIRMA la **retracción
+elástica** (`seRetrae` → cabeza y patas entran a la concha con squash&stretch)
+más el **asentimiento sabio** (`asiente`). De tierra cálida y del contrato
+compartido: **nunca suda**. Suma su capa ANCESTRAL permanente (resplandor cobrizo
++ shimmer de brasa). Todo aditivo en `creatures.css`, RM + tier-safe.
 
 ## Técnica
 

--- a/src/visual/creatures/__tests__/Morrocoy.render.test.jsx
+++ b/src/visual/creatures/__tests__/Morrocoy.render.test.jsx
@@ -1,0 +1,190 @@
+/**
+ * Morrocoy.render.test.jsx — los 5 frentes de "Morrocoy completo" (espejo de la
+ * abeja/oso/jaguar, con el CARÁCTER del galápago de tierra cálida: ANCESTRAL,
+ * LENTO, SABIO y PACIENTE — bronce en poder). Verifica que las capacidades
+ * ADITIVAS del componente canónico se rendericen sin romper el contrato base:
+ *   1. Expresividad ancestral — line-boil (contorno que hierve), caparazón de
+ *      domo que respira, retracción elástica (seRetrae) y asentimiento (asiente).
+ *   2. Lip-sync — el visema viaja a la cara (data-visema).
+ *   3. Modo poder — el aura BRONCE de 4 capas (wrapper .is-powered-up, no dorada).
+ *   4. Ropa/clima — de noche RUANA, y el morrocoy (tierra cálida) NUNCA suda.
+ *   5. Prop por mundo — la herramienta en la pata al entrar.
+ * Más la firma de identidad: es el galápago del CAPARAZÓN de domo y su aura es
+ * bronce, con su capa ANCESTRAL (resplandor + shimmer) permanente y sutil.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { Morrocoy } from '../Morrocoy.jsx';
+import { auraDeBicho } from '../transformacion.js';
+
+afterEach(cleanup);
+
+describe('Morrocoy — contrato base intacto', () => {
+  it('render por defecto = svg accesible, sin capas nuevas', () => {
+    const { container } = render(<Morrocoy />);
+    const svg = container.querySelector('svg[data-creature="morrocoy"]');
+    expect(svg).toBeTruthy();
+    expect(svg.getAttribute('role')).toBe('img');
+    // Ninguna capa opt-in aparece sin pedirla (no regresión visual).
+    expect(svg.getAttribute('data-lineboil')).toBeNull();
+    expect(svg.getAttribute('data-retrae')).toBeNull();
+    expect(svg.getAttribute('data-asiente')).toBeNull();
+    expect(svg.getAttribute('data-prop')).toBeNull();
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+  });
+
+  it('siempre trae su CAPARAZÓN de domo y sus patas (identidad)', () => {
+    const { container } = render(<Morrocoy />);
+    // El domo geométrico y las patas rojizas son identidad, no opt-in.
+    expect(container.querySelector('.morrocoy-caparazon')).toBeTruthy();
+    expect(container.querySelector('.morrocoy-cabeza')).toBeTruthy();
+    expect(container.querySelectorAll('.morrocoy-pata').length).toBeGreaterThan(3);
+  });
+});
+
+describe('1. Expresividad ancestral — line-boil, retracción y asentimiento', () => {
+  it('lineBoil instancia el filtro de displacement (contorno que hierve)', () => {
+    const { container } = render(<Morrocoy lineBoil animated />);
+    expect(container.querySelector('svg').getAttribute('data-lineboil')).toBe('1');
+    expect(container.querySelector('feDisplacementMap')).toBeTruthy();
+    expect(container.querySelector('feTurbulence')).toBeTruthy();
+  });
+
+  it('sin lineBoil NO se paga el filtro (frugal)', () => {
+    const { container } = render(<Morrocoy animated />);
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+  });
+
+  it('seRetrae marca el estado (retracción elástica a la concha)', () => {
+    const { container } = render(<Morrocoy seRetrae animated />);
+    expect(container.querySelector('svg').getAttribute('data-retrae')).toBe('1');
+    // la cabeza y las patas (los que se recogen) siguen dibujados.
+    expect(container.querySelector('.morrocoy-cabeza')).toBeTruthy();
+    expect(container.querySelectorAll('.morrocoy-pata').length).toBeGreaterThan(3);
+  });
+
+  it('asiente marca el estado (el anciano cabecea sabio)', () => {
+    const { container } = render(<Morrocoy asiente animated />);
+    expect(container.querySelector('svg').getAttribute('data-asiente')).toBe('1');
+    expect(container.querySelector('.morrocoy-cabeza')).toBeTruthy();
+  });
+});
+
+describe('2. Lip-sync — el visema llega a la cara', () => {
+  it('con visema V3 la boca abierta viaja a la cara (data-visema)', () => {
+    const { container } = render(<Morrocoy visema="V3" />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBe('V3');
+  });
+
+  it('sin visema no marca data-visema (la sonrisa de siempre)', () => {
+    const { container } = render(<Morrocoy />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBeNull();
+  });
+});
+
+describe('3. Modo poder — aura BRONCE de 4 capas (standalone)', () => {
+  it('poder envuelve en .is-powered-up + corrientes, con aura BRONCE (no dorada)', () => {
+    const { container } = render(<Morrocoy poder />);
+    const wrap = container.querySelector('.is-powered-up');
+    expect(wrap).toBeTruthy();
+    expect(wrap.getAttribute('data-creature-poder')).toBe('morrocoy');
+    // el color de aura del morrocoy es BRONCE/COBRE (distinto del dorado abeja)
+    expect(wrap.getAttribute('style')).toContain('--aura-color');
+    expect(wrap.getAttribute('style')).toContain(auraDeBicho('morrocoy'));
+    expect(auraDeBicho('morrocoy')).not.toBe(auraDeBicho('abeja-angelita'));
+    // capa 4: las corrientes (AuraPoder)
+    expect(container.querySelector('.poder-corrientes')).toBeTruthy();
+  });
+
+  it('sin poder no hay wrapper (svg desnudo)', () => {
+    const { container } = render(<Morrocoy />);
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+    expect(container.querySelector(':scope > svg[data-creature="morrocoy"]')).toBeTruthy();
+  });
+});
+
+describe('4. Ropa/clima — el morrocoy se abriga de frío y NUNCA suda', () => {
+  it('de noche con vestuario → RUANA y JAMÁS sudor/sombrero', () => {
+    const { container } = render(<Morrocoy vestuario clima="noche" />);
+    const svg = container.querySelector('svg');
+    expect(svg.getAttribute('data-ruana')).toBe('1');
+    // el morrocoy de tierra cálida aguanta el calor sin sudar
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+  });
+
+  it('de día caluroso (tempC alta) el morrocoy NO suda (tierra cálida, identidad)', () => {
+    const { container } = render(<Morrocoy vestuario clima="soleado" tempC={34} />);
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+    expect(container.querySelector('.crt-gota-sudor')).toBeNull();
+  });
+
+  it('sin vestuario (avatar/catálogo) → nada de ropa aunque haya clima', () => {
+    const { container } = render(<Morrocoy clima="noche" />);
+    expect(container.querySelector('svg').getAttribute('data-ruana')).toBeNull();
+  });
+});
+
+describe('5. Prop por mundo — herramienta en la pata', () => {
+  it('mundoId=suelo → carga la lupa', () => {
+    const { container } = render(<Morrocoy mundoId="suelo" />);
+    expect(container.querySelector('svg').getAttribute('data-prop')).toBe('suelo');
+    expect(container.querySelector('[data-prop="lupa"]')).toBeTruthy();
+  });
+
+  it('mundoId=animales → carga el lazo', () => {
+    const { container } = render(<Morrocoy mundoId="animales" />);
+    expect(container.querySelector('[data-prop="lazo"]')).toBeTruthy();
+  });
+
+  it('mundo sin prop mapeado → patas libres (no rompe)', () => {
+    const { container } = render(<Morrocoy mundoId="mundo-fantasma" />);
+    expect(container.querySelector('[data-prop="lupa"]')).toBeNull();
+    expect(container.querySelector('svg[data-creature="morrocoy"]')).toBeTruthy();
+  });
+});
+
+describe('6. Toque ancestral — el anciano de piedra viva (permanente y sutil)', () => {
+  it('trae SIEMPRE resplandor cobrizo y shimmer del caparazón', () => {
+    const { container } = render(<Morrocoy />);
+    expect(container.querySelector('.morrocoy-resplandor')).toBeTruthy(); // calor ancestral permanente
+    expect(container.querySelector('.morrocoy-shimmer')).toBeTruthy();    // shimmer del reborde
+  });
+
+  it('el resplandor ancestral es PERMANENTE (existe sin pedir modo poder)', () => {
+    const { container } = render(<Morrocoy />);
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+    expect(container.querySelector('.morrocoy-resplandor')).toBeTruthy();
+  });
+
+  it('reduced-motion-safe / tier-safe: con animated=false NO se anima (fotograma digno)', () => {
+    const { container } = render(<Morrocoy animated={false} />);
+    // sin vida: no se cuelgan las clases que animan (resplandor/shimmer/caparazón)…
+    expect(container.querySelector('.morrocoy-resplandor')).toBeNull();
+    expect(container.querySelector('.morrocoy-shimmer')).toBeNull();
+    // …pero el caparazón (el domo) sigue dibujado, quieto y digno.
+    expect(container.querySelector('.morrocoy-caparazon')).toBeTruthy();
+  });
+
+  it('modo poder BRONCE: el resplandor sigue dentro del power-up', () => {
+    const { container } = render(<Morrocoy poder />);
+    const wrap = container.querySelector('.is-powered-up.morrocoy-poder');
+    expect(wrap).toBeTruthy();
+    // el anciano aviva la brasa: resplandor vive dentro del wrapper
+    expect(wrap.querySelector('.morrocoy-resplandor')).toBeTruthy();
+  });
+});
+
+describe('Anti-regresión — modo inline no rompe la escena', () => {
+  it('inline devuelve un <g> con el data-creature y marca data-poder', () => {
+    const { container } = render(
+      <svg>
+        <Morrocoy inline poder mundoId="suelo" />
+      </svg>,
+    );
+    const g = container.querySelector('g[data-creature="morrocoy"]');
+    expect(g).toBeTruthy();
+    expect(g.getAttribute('data-poder')).toBe('1'); // el host DOM pinta el aura
+    expect(g.getAttribute('data-prop')).toBe('suelo');
+  });
+});

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -701,6 +701,9 @@
 
 @media (prefers-reduced-motion: reduce) {
   .rana-salto, .crt-garganta { animation: none !important; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    OSO ANDINO — el CARÁCTER del guardián: mole PESADA, seria y gruñona.
    Aditivo sobre el KIT species-agnostic (no toca a la abeja): el oso reescribe
    SU boil (más lento y con más masa), suma un resoplido/gruñido corporal, el
@@ -926,6 +929,9 @@
   /* El tornasol del poder también queda quieto (re-gate: la doble clase de
      arriba le ganaba al gate genérico de transformacion.css). */
   .is-powered-up.colibri-poder::before { animation: none; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    PEREZOSO (Bradypus variegatus) — el CARÁCTER de la QUIETUD EXTREMA
    ───────────────────────────────────────────────────────────────────────────
    Todo en CÁMARA LENTA: se mece pausado desde la rama, parpadeo larguísimo,
@@ -1010,6 +1016,9 @@
   [data-creature='perezoso'][data-estira='1'] .crt-body { animation: none !important; }
   /* Fotograma digno: una "Z" visible y quieta si se pidió dormita. */
   .perezoso-zzz-mota { opacity: 0.55; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    ARDILLA — el CARÁCTER de la pizpireta: ÁGIL, curiosa, rápida e INQUIETA.
    Aditivo sobre el KIT species-agnostic (no toca a los demás bichos): la ardilla
    reescribe SU boil (más VELOZ y nervioso que la abeja), suma la cola tupida que
@@ -1133,6 +1142,9 @@
   .ardilla-cola, .ardilla-nariz, .ardilla-dientes, .ardilla-bellota,
   [data-creature='ardilla'][data-inspecciona='1'] .crt-body,
   [data-creature='ardilla'][data-roe='1'] .crt-body { animation: none !important; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    JAGUAR — el CARÁCTER del felino: majestuoso, poderoso, ACECHADOR. Poder
    CONTENIDO (no hiperactivo): squash&stretch controlado y elegante. Aditivo
    sobre el KIT species-agnostic (no toca a la abeja/oso): el jaguar reescribe SU
@@ -1377,4 +1389,162 @@
   .jaguar-estrella,
   .jaguar-poder .jaguar-estrella,
   [data-creature='jaguar'][data-poder='1'] .jaguar-estrella { animation: none !important; opacity: 0.5; }
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   MORROCOY — el CARÁCTER del galápago: ANCESTRAL, LENTO, SABIO y PACIENTE (el
+   anciano tranquilo de la chagra). La sabiduría NO corre: squash&stretch LENTO y
+   firme. Aditivo sobre el KIT species-agnostic (no toca a la abeja/oso/jaguar):
+   el morrocoy reescribe SU boil (lento, paso pesado), suma el CAPARAZÓN de domo
+   que RESPIRA apacible, la RETRACCIÓN ELÁSTICA (cabeza y patas entran a la concha
+   con squash&stretch de goma — su firma) y el ASENTIMIENTO sabio (la testa
+   cabecea lento). Todo transform/opacity (GPU, gama baja). Gates RM + tier al
+   final del bloque.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* BOIL LENTO — el anciano no vibra ligero: respira LENTO y con squash de PASO
+   PESADO que asienta suave (masa robusta, paciencia). Reescribe SOLO el boil del
+   morrocoy (misma clase .rh-boil, mayor especificidad por el data-creature) con
+   longhands para no pisar el resto de props de animación. */
+[data-creature='morrocoy'] .rh-boil {
+  animation-name: morrocoy-boil;
+  animation-duration: 3.4s;
+  animation-timing-function: steps(10, end);
+}
+@keyframes morrocoy-boil {
+  0%   { transform: translateY(0) scale(1, 1); }
+  30%  { transform: translateY(-0.12px) scale(0.995, 1.01); } /* leve estiramiento sereno */
+  60%  { transform: translateY(0.4px) scale(1.02, 0.98); }    /* paso pesado que asienta */
+  100% { transform: translateY(0) scale(1, 1); }
+}
+
+/* CAPARAZÓN que RESPIRA — el domo geométrico se abomba apacible (el anciano
+   respira hondo). Nodo propio dentro del cuerpo (.morrocoy-caparazon). */
+.morrocoy-caparazon {
+  animation: morrocoy-respira 4.6s ease-in-out infinite;
+}
+@keyframes morrocoy-respira {
+  0%, 100% { transform: scale(1, 1); }
+  50%      { transform: scale(1.012, 1.02); } /* respiración serena del domo */
+}
+
+/* SE RETRAE — retracción elástica (la firma del morrocoy): cabeza y patas ENTRAN
+   a la concha con squash&stretch de goma, se guardan pacientes y ASOMAN de nuevo.
+   Lazo lento (la tortuga se toma su tiempo). */
+[data-creature='morrocoy'][data-retrae='1'] .morrocoy-cabeza {
+  animation: morrocoy-retrae-cabeza 4.6s ease-in-out infinite;
+}
+@keyframes morrocoy-retrae-cabeza {
+  0%   { transform: translateY(0) scale(1, 1); }
+  20%  { transform: translateY(-0.6px) scale(1.05, 1.03); }  /* estira curioso (anticipación) */
+  50%  { transform: translateY(5.2px) scale(0.5, 0.42); }    /* se mete (squash, escondida) */
+  80%  { transform: translateY(5.2px) scale(0.5, 0.42); }    /* aguanta dentro (paciencia) */
+  100% { transform: translateY(0) scale(1, 1); }             /* asoma de nuevo */
+}
+[data-creature='morrocoy'][data-retrae='1'] .morrocoy-pata {
+  animation: morrocoy-retrae-pata 4.6s ease-in-out infinite;
+}
+@keyframes morrocoy-retrae-pata {
+  0%, 100%  { transform: translateY(0) scaleY(1); }
+  50%, 80%  { transform: translateY(-2.2px) scaleY(0.35); }  /* recoge las patas al caparazón */
+}
+/* el domo se ABOMBA un pelín mientras recoge (pisa la respiración por
+   especificidad: dos atributos + clase). */
+[data-creature='morrocoy'][data-retrae='1'] .morrocoy-caparazon {
+  animation: morrocoy-retrae-domo 4.6s ease-in-out infinite;
+}
+@keyframes morrocoy-retrae-domo {
+  0%, 100%  { transform: scale(1, 1); }
+  50%, 80%  { transform: scale(1.05, 1.08); } /* el domo abomba al guardarse */
+}
+
+/* ASIENTE — el asentimiento sabio: la testa cabecea lento y firme ("sí, mijo,
+   con paciencia"). */
+[data-creature='morrocoy'][data-asiente='1'] .morrocoy-cabeza {
+  animation: morrocoy-asiente 2.8s ease-in-out infinite;
+}
+@keyframes morrocoy-asiente {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  30%      { transform: translateY(0.9px) rotate(2.2deg); }  /* baja la testa (sí) */
+  60%      { transform: translateY(0) rotate(-1.2deg); }
+}
+
+/* Los estados del morrocoy (seRetrae/asiente) PISAN el arrebato (antic/travieso):
+   una tortuga que se guarda o asiente no da vueltas de campana — el gesto lee
+   sereno. */
+[data-creature='morrocoy'][data-retrae='1'] .rh-antic,
+[data-creature='morrocoy'][data-retrae='1'] .rh-travieso,
+[data-creature='morrocoy'][data-asiente='1'] .rh-antic,
+[data-creature='morrocoy'][data-asiente='1'] .rh-travieso { animation: none; }
+
+/* device-tier 'bajo': el boil reescrito del morrocoy lo reactivaría (misma clase)
+   → re-apagarlo aquí (mayor especificidad + orden posterior). La respiración del
+   domo también se corta; los estados reactivos (seRetrae/asiente) siguen contando
+   la verdad. (Las patas usan .rh-sway, ya gateado globalmente.) */
+[data-tier='bajo'][data-creature='morrocoy'] .rh-boil,
+[data-tier='bajo'][data-creature='morrocoy'] .morrocoy-caparazon { animation: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .morrocoy-caparazon,
+  [data-creature='morrocoy'][data-retrae='1'] .morrocoy-cabeza,
+  [data-creature='morrocoy'][data-retrae='1'] .morrocoy-pata,
+  [data-creature='morrocoy'][data-retrae='1'] .morrocoy-caparazon,
+  [data-creature='morrocoy'][data-asiente='1'] .morrocoy-cabeza { animation: none !important; }
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+   MORROCOY ANCESTRAL — el anciano de piedra viva (calor de brasa apacible).
+   Capas PERMANENTES y sutiles (elegante, no recargado): un RESPLANDOR cobrizo
+   que envuelve el caparazón y un SHIMMER tibio recorriendo su reborde. En modo
+   poder se avivan (el anciano guarda fuego dentro). Todo transform/opacity. Se
+   PODA en tier bajo / reduced-motion.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+/* RESPLANDOR — el calor ancestral envuelve al galápago; respira lento. */
+.morrocoy-resplandor {
+  animation: morrocoy-resplandor 5.4s ease-in-out infinite;
+}
+@keyframes morrocoy-resplandor {
+  0%, 100% { opacity: 0.1;  transform: scale(1); }
+  50%      { opacity: 0.18; transform: scale(1.04); }
+}
+
+/* SHIMMER — destello cobrizo tibio que recorre el reborde del caparazón. */
+.morrocoy-shimmer {
+  animation: morrocoy-shimmer 4.8s ease-in-out infinite;
+}
+@keyframes morrocoy-shimmer {
+  0%, 100% { opacity: 0.12; }
+  50%      { opacity: 0.3; }
+}
+
+/* MODO PODER BRONCE — el anciano aviva la brasa: resplandor y shimmer se
+   intensifican y aceleran. Vale en standalone (wrapper .morrocoy-poder) e inline
+   (data-poder en el <g>). */
+.morrocoy-poder .morrocoy-resplandor,
+[data-creature='morrocoy'][data-poder='1'] .morrocoy-resplandor {
+  animation-name: morrocoy-resplandor-brasa;
+  animation-duration: 3.0s;
+}
+@keyframes morrocoy-resplandor-brasa {
+  0%, 100% { opacity: 0.2; transform: scale(1.02); }
+  50%      { opacity: 0.4; transform: scale(1.1); }
+}
+.morrocoy-poder .morrocoy-shimmer,
+[data-creature='morrocoy'][data-poder='1'] .morrocoy-shimmer {
+  animation-duration: 2.4s;
+}
+
+/* device-tier 'bajo': PODA el resplandor/shimmer ancestral (raster caro en gama
+   baja) — se detiene la animación y queda un rastro estático y digno. */
+[data-tier='bajo'][data-creature='morrocoy'] .morrocoy-resplandor,
+[data-tier='bajo'][data-creature='morrocoy'] .morrocoy-shimmer { animation: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .morrocoy-resplandor, .morrocoy-shimmer,
+  .morrocoy-poder .morrocoy-resplandor,
+  .morrocoy-poder .morrocoy-shimmer,
+  [data-creature='morrocoy'][data-poder='1'] .morrocoy-resplandor,
+  [data-creature='morrocoy'][data-poder='1'] .morrocoy-shimmer { animation: none !important; }
 }

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -33,6 +33,11 @@ export { Jaguar } from './Jaguar.jsx';
    su perfil de clima). Solo datos: jamás arrastra three al bundle base — igual
    que abejaIdentidad/faunaAndina. */
 export { JAGUAR_PALETA, JAGUAR_PROPORCION, JAGUAR_SLUG, PERFIL_JAGUAR } from './jaguarIdentidad.js';
+export { Morrocoy } from './Morrocoy.jsx';
+/* La IDENTIDAD del morrocoy como datos (paleta bronce + escudos hexagonales,
+   proporciones y su perfil de clima). Solo datos: jamás arrastra three al bundle
+   base — igual que jaguarIdentidad/faunaAndina. */
+export { MORROCOY_PALETA, MORROCOY_PROPORCION, MORROCOY_SLUG, PERFIL_MORROCOY } from './morrocoyIdentidad.js';
 /* La IDENTIDAD del trío andino como datos (paletas + proporciones). Solo datos:
    jamás arrastra three al bundle base — igual que abejaIdentidad. */
 export {
@@ -82,6 +87,7 @@ import RanaAndina from './RanaAndina.jsx';
 import Perezoso from './Perezoso.jsx';
 import Ardilla from './Ardilla.jsx';
 import Jaguar from './Jaguar.jsx';
+import Morrocoy from './Morrocoy.jsx';
 import Lombriz from './Lombriz.jsx';
 import Mariposa from './Mariposa.jsx';
 import Escarabajo from './Escarabajo.jsx';
@@ -95,6 +101,7 @@ export const CREATURES = {
   perezoso: { Component: Perezoso, nombre: 'Perezoso de tres dedos', cientifico: 'Bradypus variegatus' },
   ardilla: { Component: Ardilla, nombre: 'Ardilla de cola roja', cientifico: 'Notosciurus granatensis' },
   jaguar: { Component: Jaguar, nombre: 'Jaguar', cientifico: 'Panthera onca' },
+  morrocoy: { Component: Morrocoy, nombre: 'Morrocoy de patas rojas', cientifico: 'Chelonoidis carbonarius' },
   lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
   mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
   escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },

--- a/src/visual/creatures/morrocoyIdentidad.js
+++ b/src/visual/creatures/morrocoyIdentidad.js
@@ -1,0 +1,80 @@
+/*
+ * morrocoyIdentidad — LA IDENTIDAD VISUAL DEL MORROCOY, COMO DATOS.
+ *
+ * Hermano de `jaguarIdentidad.js`, `abejaIdentidad.js` y `faunaAndina.js`: el
+ * MORROCOY de patas rojas (Chelonoidis carbonarius), el galápago de tierra
+ * cálida, tiene aquí su silueta canónica. Rubber-hose (Cuphead + Miss Minutes)
+ * con calidez campesina — el MISMO lenguaje de goma de la abeja, el oso y el
+ * jaguar, otro animal y otro CARÁCTER: ANCESTRAL, LENTO, SABIO y PACIENTE (el
+ * anciano tranquilo de la chagra). Se mueve con paso pesado, la cabeza asoma con
+ * calma y su seña de vida es la RETRACCIÓN ELÁSTICA: mete cabeza y patas al
+ * caparazón estirando y encogiendo con squash&stretch de goma. Su color de poder
+ * es el BRONCE/COBRE cálido (abeja=dorado, oso=rojo, rana=verde,
+ * colibrí=iridiscente, jaguar=púrpura, ardilla=ámbar, perezoso=turquesa).
+ *
+ * REGLA DE ORO (idéntica a jaguarIdentidad/faunaAndina): SOLO datos. Cero three,
+ * cero react. La creature del bundle base lo importa; jamás debe arrastrar
+ * `vendor-three`. La CADENCIA (animación) vive en `creatures.css` (clases
+ * `rh-*`/`crt-*`/`morrocoy-*`); el DIBUJO compone el KIT `_rubberhose.jsx`; el
+ * CLIMA→cuerpo, en `creatureClimaCuerpo.js` (consumiendo el PERFIL_MORROCOY de
+ * abajo). El aura de poder (bronce) vive en `transformacion.js` (AURA_POR_BICHO)
+ * y la ropa por clima en `creatureClimaCuerpo.js` (ROPA_PERFIL_POR_BICHO): ambos
+ * ya traen la fila 'morrocoy' — este archivo NO la duplica, solo la silueta.
+ */
+
+/* La tinta cálida del contorno es de TODA la familia rubber-hose. */
+export { RH_INK as MORROCOY_TINTA } from './_rubberhose.jsx';
+
+/* Slug estable del morrocoy (data-creature, aura, ropa, perfiles). */
+export const MORROCOY_SLUG = 'morrocoy';
+
+/* ── MORROCOY — Chelonoidis carbonarius (galápago de patas rojas de tierra
+   cálida). Caparazón de DOMO GEOMÉTRICO bronce-oliva con escudos HEXAGONALES
+   (su firma — cada escudo con anillos de edad), patas y cabeza ROJIZAS con
+   escamas naranja-fuego (la marca de la especie), cabeza que asoma serena.
+   Ancestral y sabio. */
+export const MORROCOY_PALETA = {
+  caparazon: '#8a6a3a',       // domo bronce-oliva del caparazón
+  caparazonGlow: 'rgba(176,118,58,0.7)',
+  caparazonAlto: '#a4823f',   // cara alta del domo (luz cenital)
+  escudo: '#6b4f28',          // borde/surco entre escudos hexagonales
+  escudoCentro: '#9c7838',    // centro del escudo (el domo de cada hexágono)
+  anillo: '#5a3f20',          // anillos de edad grabados en cada escudo (lo ancestral)
+  marginal: '#5a3f20',        // escudos marginales del reborde
+  plastron: '#c9a35c',        // peto/plastrón crema-tierra
+  pata: '#b0562e',            // pata rojiza (patas rojas)
+  pataEscama: '#e07a38',      // escama naranja-fuego (la marca carbonarius)
+  cabeza: '#7a4f2c',          // cabeza parda
+  cabezaEscama: '#e07a38',    // escamas rojo-naranja de la testa (la firma)
+  nariz: '#2f1d10',           // fosas nasales / pico
+  pico: '#4a3418',            // borde del pico (boca de tortuga)
+  ojoAnillo: '#c8862f',       // anillo ámbar del ojo (mirada serena)
+  /* ── Ancestral (el anciano de la chagra: la piedra viva, el petroglifo) ── */
+  resplandor: '#e0a84a',      // resplandor cobrizo del caparazón (calor ancestral)
+  brasa: '#ffcf8a',           // el destello tibio del domo (brasa apacible)
+};
+
+export const MORROCOY_PROPORCION = {
+  caparazonRx: 11.2,          // domo ancho y bajo (más ancho que alto)
+  caparazonRy: 8.2,
+  cabezaR: 3.5,               // cabeza pequeña y serena
+  cuelloAncho: 3.0,           // cuello grueso que asoma
+  pataAncho: 3.6,             // patas robustas y cortas (paso pesado)
+};
+
+/*
+ * PERFIL_MORROCOY — el perfil de CLIMA→cuerpo del morrocoy para `cuerpoDeClima`
+ * (creatureClimaCuerpo.js). Mismo shape que PERFIL_JAGUAR/PERFIL_OSO — se pasa
+ * vía la opción `perfil`, así NO hay que tocar el archivo compartido
+ * (anti-conflicto).
+ *   alas    false → sin aleteo (velocidadAlas siempre 1).
+ *   humedad 0.4  → el caparazón córneo escurre el agua (apenas se ve mojado).
+ *   difusa  0.5  → cuerpo compacto y bajo: la niebla lo difumina a medias.
+ *   sequia  0.25 → de tierra cálida, reptil paciente: muy robusto ante la seca.
+ */
+export const PERFIL_MORROCOY = Object.freeze({
+  alas: false,
+  humedad: 0.4,
+  difusa: 0.5,
+  sequia: 0.25,
+});

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -147,6 +147,25 @@ const VARIANTES_PEREZOSO = [
   { label: 'sin animación', props: { size: 88, animated: false } },
 ];
 
+/* El MORROCOY completo estrena TODA la fundación transversal (espejo de la abeja/
+   oso/jaguar, con su carácter ANCESTRAL): caparazón que respira + line-boil,
+   retracción elástica (seRetrae), asentimiento sabio (asiente), ruana de noche,
+   modo poder BRONCE y prop por mundo. La vitrina lo luce con todo. */
+const VARIANTES_MORROCOY = [
+  { label: '48 px', props: { size: 48 } },
+  { label: 'anda', props: { size: 88 } },
+  { label: 'celebra', props: { size: 88, pose: 'celebra' } },
+  { label: 'reposo', props: { size: 88, pose: 'reposo' } },
+  { label: 'señala', props: { size: 88, pose: 'señala' } },
+  { label: 'se retrae', props: { size: 88, seRetrae: true } },
+  { label: 'asiente', props: { size: 88, asiente: true } },
+  { label: 'ruana de noche', props: { size: 88, vestuario: true, clima: 'noche' } },
+  { label: 'con lupa (suelo)', props: { size: 88, mundoId: 'suelo' } },
+  { label: 'poder BRONCE', props: { size: 88, poder: true } },
+  { label: 'línea que hierve', props: { size: 88, lineBoil: true } },
+  { label: 'sin animación', props: { size: 88, animated: false } },
+];
+
 const VARIANTES_POR_SLUG = {
   'abeja-angelita': VARIANTES_ABEJA,
   colibri: VARIANTES_TRIO_AIRE,
@@ -155,6 +174,7 @@ const VARIANTES_POR_SLUG = {
   perezoso: VARIANTES_PEREZOSO,
   ardilla: VARIANTES_ARDILLA,
   jaguar: VARIANTES_JAGUAR,
+  morrocoy: VARIANTES_MORROCOY,
 };
 
 /* Nota de campo por creature (el registro de la categoría trae nombre + binomio;
@@ -167,6 +187,7 @@ const NOTAS_CREATURE = {
   perezoso: 'Perezoso de tres dedos, la calma total; cuelga de la rama por sus garras largas, antifaz y tinte verdoso de algas. Todo en cámara lenta.',
   ardilla: 'Ardilla de cola roja del templado; rufa con la línea dorsal oscura (su firma), cola tupida y su inspección invertida.',
   jaguar: 'Felino de tierra cálida, majestuoso y acechador; leonado con rosetas de centro ocre (su firma), aura púrpura.',
+  morrocoy: 'Galápago de patas rojas, el anciano ancestral y paciente; caparazón de domo hexagonal (su firma) y patas rojizas, aura bronce. Se retrae elástico a la concha.',
   lombriz: 'La ingeniera del suelo; ondula por segmentos con clitelo marcado.',
   mariposa: 'Alas naranjas con venación; poliniza y anuncia buen suelo.',
   escarabajo: 'Estercolero que entierra el abono; élitros con brillo metálico.',


### PR DESCRIPTION
## Morrocoy — el 8º y último personaje

Morrocoy de patas rojas (*Chelonoidis carbonarius*): el galápago **ANCESTRAL, LENTO, SABIO y PACIENTE** que cierra la biblia de 8 bichos, al nivel de abeja/oso/rana/jaguar/colibrí/ardilla/perezoso. Compone la fundación transversal (cero código duplicado); solo cambia el animal y su carácter de anciano.

### Los 5 frentes (todos cerrados)
1. **Expresividad rubber-hose ancestral** — boil **LENTO** de paso pesado (la sabiduría no corre), **caparazón de domo geométrico** con escudos **hexagonales** (anillos de edad grabados — su firma) que **respira**, **RETRACCIÓN ELÁSTICA** (`seRetrae` → cabeza y patas entran a la concha con squash&stretch de goma, aguantan y asoman de nuevo), **asentimiento sabio** (`asiente` → la testa cabecea lento), parpadeo pausado, **patas rojizas** con escamas naranja-fuego, línea que respira (`lineBoil`). Más una capa **ANCESTRAL** permanente y sutil (resplandor cobrizo + shimmer de brasa), que se aviva en modo poder.
2. **Lip-sync** — prop `visema` → pico (`BocaVisema`).
3. **Modo-poder BRONCE** — `poder` → aura bronce/cobre de 4 capas (`auraDeBicho('morrocoy')`).
4. **Ropa/clima** — `ropaDeClima`/`AccesoriosClima`; de noche/frío ruana, de tierra cálida **NUNCA suda** (contrato compartido con el jaguar).
5. **Prop por mundo** — `propsPorMundo` (agua→manguerita, suelo→lupa, animales→lazo, semillero→canasto).

### Archivos
- **Nuevos**: `Morrocoy.jsx`, `morrocoyIdentidad.js`, `__tests__/Morrocoy.render.test.jsx`.
- **Aditivos** (bloque MORROCOY al final, sin tocar otros bichos): `creatures.css`, `index.js`, `registry.js`, `README.md`.

### ⚠️ Repara deuda pre-existente que rompía el build de `dev`
Al basar la rama en `origin/dev` el build fallaba con `CssSyntaxError: Unclosed block`. Causa: **4 fronteras de sección** en `creatures.css` (rana→oso, colibri→perezoso, perezoso→ardilla, ardilla→jaguar) tenían el `}` de cierre del `@media (prefers-reduced-motion)` **y** el `/* ═══` de apertura del banner **eliminados** (artefacto del merge de ramas fable paralelas). Restaurados los 8 delimitadores (banners ahora 9 abren / 9 cierran). **No** se tocó la lógica de animación de ningún otro bicho. Sin esto, `dev` no compila para nadie.

### Verificación (dura, síncrona)
- `npm run build` ✅ verde (32.7s).
- `npx vitest run src/visual/creatures` ✅ 199 tests / 13 archivos (incluye el test nuevo del morrocoy: contrato base + 5 frentes + toque ancestral + inline).

reduced-motion-safe y tier-safe (gates al final del bloque). Sin strings de UI (no aplica voseo/usted). Anti-leak OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)