### PR TITLE
feat(avatar): selección de avatar en perfil y onboarding

### DIFF
--- a/src/components/OnboardingCondensado.jsx
+++ b/src/components/OnboardingCondensado.jsx
@@ -14,6 +14,7 @@ import {
   SkipForward,
 } from 'lucide-react';
 import ChagraAgentAvatarColibri from './ChagraAgentAvatarColibri';
+import AvatarSelector from './Settings/AvatarSelector';
 import { useGeolocation } from '../hooks/useGeolocation';
 import {
   resolveUbicacion,
@@ -615,6 +616,16 @@ export default function OnboardingCondensado({
                   );
                 })}
               </div>
+            </div>
+
+            {/* Elija su animal (saltable): el avatar del usuario. Persiste al
+                toque en usePrefsStore (avatarCreatureId); si no toca nada,
+                queda la abeja Angelita. Mismo selector del Perfil. */}
+            <div data-testid="onb2-avatar">
+              <p className="text-[11px] uppercase tracking-widest font-bold text-emerald-400/90 mb-2">
+                Elija su animal (si quiere)
+              </p>
+              <AvatarSelector compact />
             </div>
           </>
         )}

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -9,6 +9,8 @@ import { esExtensionistaActual } from '../config/extensionistaAccess';
 import ThemeSelector from './common/ThemeSelector';
 import ThemeLivePreview from './common/ThemeLivePreview';
 import AgentAvatarSelector from './Settings/AgentAvatarSelector';
+import AvatarSelector from './Settings/AvatarSelector';
+import useAvatarCreature from '../hooks/useAvatarCreature';
 import BackgroundSelector from './Settings/BackgroundSelector';
 import BackupExportButton from './BackupExportButton';
 import CuadernoPDFButton from './CuadernoPDFButton';
@@ -314,6 +316,9 @@ export default function ProfileScreen({ onBack, onHome }) {
   const selectableThemes = getSelectableThemes(fincaVivaHomePerfilActivo());
   const themeLabel = selectableThemes.find((t) => t.id === theme)?.label || theme;
   const ttsEnabled = usePrefsStore((s) => s.ttsEnabled);
+  // El animal elegido por la persona (Apariencia → "Su animal de la chagra"):
+  // sin foto de perfil, la cédula muestra su bicho en vez del ícono genérico.
+  const avatarCreature = useAvatarCreature();
   const activeFincaSlug = useFincaActiveStore((s) => s.activeFincaSlug);
   const municipio = (() => {
     try { return getProfileMunicipio(); } catch (_) { return null; }
@@ -388,7 +393,13 @@ export default function ProfileScreen({ onBack, onHome }) {
                       data-testid="profile-photo-img"
                     />
                   ) : (
-                    <User size={38} className="text-emerald-400" aria-hidden="true" />
+                    <span data-testid="profile-avatar-creature" className="pointer-events-none">
+                      <avatarCreature.Component
+                        size={56}
+                        animated={false}
+                        title={`Su animal: ${avatarCreature.nombre}`}
+                      />
+                    </span>
                   )}
                 </div>
                 <button
@@ -589,6 +600,9 @@ export default function ProfileScreen({ onBack, onHome }) {
             </div>
 
             <BackgroundSelector />
+            {/* El animal del USUARIO (avatar propio, registro de creatures) —
+                distinto del avatar del agente IA de abajo. */}
+            <AvatarSelector />
             <AgentAvatarSelector />
 
             {/* Estilo de notificación (operador 2026-06-06 + 2026-06-11):

--- a/src/components/Settings/AvatarSelector.jsx
+++ b/src/components/Settings/AvatarSelector.jsx
@@ -1,0 +1,107 @@
+import { useMemo } from 'react';
+import { Check } from 'lucide-react';
+import usePrefsStore from '../../store/usePrefsStore';
+import { CREATURES } from '../../visual/creatures/index.js';
+
+/**
+ * AvatarSelector — "Elija su animal": el avatar del USUARIO (no del agente).
+ *
+ * Grilla DATA-DRIVEN de los personajes de fauna del registro CREATURES
+ * (src/visual/creatures/index.js): cualquier bicho nuevo que entre al
+ * registro (p. ej. el borugo) aparece aquí sin tocar este archivo.
+ *
+ * La elección persiste de inmediato en usePrefsStore (`avatarCreatureId`,
+ * localStorage `chagra:prefs:avatar-creature`) — no hay botón "guardar".
+ * El resto de la app la lee vía useAvatarCreature() (hooks/).
+ *
+ * Reutilizado en: Perfil → Apariencia, y el paso de identidad del
+ * onboarding condensado (`compact`, saltable — default abeja Angelita).
+ *
+ * Accesible: radiogroup + radios reales para teclado y lector de pantalla.
+ * Reduced-motion-safe: con `prefers-reduced-motion` los bichos se dibujan
+ * quietos (animated=false); además solo anima el elegido, para no hervir
+ * diez contornos a la vez en equipos modestos.
+ */
+export default function AvatarSelector({ compact = false, className = '' }) {
+    const avatarCreatureId = usePrefsStore((s) => s.avatarCreatureId);
+    const setAvatarCreatureId = usePrefsStore((s) => s.setAvatarCreatureId);
+
+    const opciones = useMemo(
+        () => Object.entries(CREATURES).map(([id, meta]) => ({ id, ...meta })),
+        [],
+    );
+
+    const reduceMotion = useMemo(() => {
+        try {
+            return window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false;
+        } catch (_) {
+            return false;
+        }
+    }, []);
+
+    return (
+        <div
+            className={`bg-slate-900/60 border border-slate-800 rounded-2xl p-4 space-y-3 ${className}`}
+            data-testid="avatar-selector"
+        >
+            <div>
+                <h4 className="text-sm font-bold text-slate-200">Su animal de la chagra</h4>
+                <p className="text-xs text-slate-500 leading-relaxed mt-0.5">
+                    Elija su animal — lo acompaña como su avatar en la app. Toque para elegir.
+                </p>
+            </div>
+            <div
+                role="radiogroup"
+                aria-label="Elija su animal"
+                className={`grid gap-2.5 ${compact ? 'grid-cols-4' : 'grid-cols-3'}`}
+            >
+                {opciones.map((opt) => {
+                    const selected = avatarCreatureId === opt.id;
+                    const Creature = opt.Component;
+                    return (
+                        <button
+                            key={opt.id}
+                            type="button"
+                            role="radio"
+                            aria-checked={selected}
+                            aria-label={opt.nombre}
+                            onClick={() => setAvatarCreatureId(opt.id)}
+                            data-testid={`avatar-opcion-${opt.id}`}
+                            className={`relative flex flex-col items-center gap-1.5 px-1.5 rounded-xl border-2 transition-all active:scale-95 ${
+                                compact ? 'py-2.5' : 'py-3.5'
+                            } ${
+                                selected
+                                    ? 'border-emerald-500 bg-emerald-900/20 ring-2 ring-emerald-500/40'
+                                    : 'border-slate-700 bg-slate-900 hover:border-slate-600'
+                            }`}
+                        >
+                            {selected && (
+                                <span
+                                    className="absolute top-1.5 right-1.5 inline-flex items-center justify-center w-5 h-5 rounded-full bg-emerald-500 text-white"
+                                    aria-hidden="true"
+                                >
+                                    <Check size={12} strokeWidth={3} />
+                                </span>
+                            )}
+                            <Creature
+                                size={compact ? 44 : 56}
+                                animated={selected && !reduceMotion}
+                                title=""
+                            />
+                            <span className="text-center min-w-0 w-full">
+                                <span className="block text-[11px] sm:text-xs font-bold text-slate-100 leading-tight truncate">
+                                    {opt.nombre}
+                                </span>
+                                {!compact && (
+                                    <span className="block text-[9px] italic text-slate-500 mt-0.5 leading-tight truncate">
+                                        {opt.cientifico}
+                                    </span>
+                                )}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/src/components/Settings/__tests__/AvatarSelector.test.jsx
+++ b/src/components/Settings/__tests__/AvatarSelector.test.jsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, renderHook, act } from '@testing-library/react';
+import AvatarSelector from '../AvatarSelector';
+import usePrefsStore, { AVATAR_CREATURE_DEFAULT } from '../../../store/usePrefsStore';
+import { CREATURES } from '../../../visual/creatures/index.js';
+import useAvatarCreature, { resolveAvatarCreature } from '../../../hooks/useAvatarCreature';
+
+/**
+ * AvatarSelector ("Elija su animal") + useAvatarCreature.
+ * La grilla es DATA-DRIVEN del registro CREATURES: se asercionan las opciones
+ * contra el registro (no contra una lista a mano), así el test sigue verde
+ * cuando aterrice el borugo.
+ */
+
+const STORAGE_KEY = 'chagra:prefs:avatar-creature';
+
+beforeEach(() => {
+    localStorage.clear();
+    usePrefsStore.setState({ avatarCreatureId: AVATAR_CREATURE_DEFAULT });
+});
+
+describe('AvatarSelector — grilla data-driven', () => {
+    it('renderiza UNA opción por cada creature del registro', () => {
+        render(<AvatarSelector />);
+        const radios = screen.getAllByRole('radio');
+        expect(radios).toHaveLength(Object.keys(CREATURES).length);
+        for (const id of Object.keys(CREATURES)) {
+            expect(screen.getByTestId(`avatar-opcion-${id}`)).toBeInTheDocument();
+        }
+    });
+
+    it('la abeja Angelita viene elegida por defecto', () => {
+        render(<AvatarSelector />);
+        expect(screen.getByTestId('avatar-opcion-abeja-angelita')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('grupo accesible: radiogroup con label en usted', () => {
+        render(<AvatarSelector />);
+        expect(screen.getByRole('radiogroup', { name: 'Elija su animal' })).toBeInTheDocument();
+    });
+
+    it('tocar un animal lo elige, desmarca el anterior y persiste', () => {
+        render(<AvatarSelector />);
+        fireEvent.click(screen.getByTestId('avatar-opcion-jaguar'));
+        expect(screen.getByTestId('avatar-opcion-jaguar')).toHaveAttribute('aria-checked', 'true');
+        expect(screen.getByTestId('avatar-opcion-abeja-angelita')).toHaveAttribute('aria-checked', 'false');
+        expect(JSON.parse(localStorage.getItem(STORAGE_KEY))).toBe('jaguar');
+        expect(usePrefsStore.getState().avatarCreatureId).toBe('jaguar');
+    });
+
+    it('modo compact renderiza el mismo registro completo', () => {
+        render(<AvatarSelector compact />);
+        expect(screen.getAllByRole('radio')).toHaveLength(Object.keys(CREATURES).length);
+    });
+});
+
+describe('useAvatarCreature — resolución slug→personaje', () => {
+    it('devuelve el default (abeja) sin elección previa', () => {
+        const { result } = renderHook(() => useAvatarCreature());
+        expect(result.current.id).toBe(AVATAR_CREATURE_DEFAULT);
+        expect(result.current.Component).toBe(CREATURES[AVATAR_CREATURE_DEFAULT].Component);
+        expect(result.current.nombre).toBe(CREATURES[AVATAR_CREATURE_DEFAULT].nombre);
+    });
+
+    it('sigue la elección del store en vivo', () => {
+        const { result } = renderHook(() => useAvatarCreature());
+        act(() => {
+            usePrefsStore.getState().setAvatarCreatureId('oso-andino');
+        });
+        expect(result.current.id).toBe('oso-andino');
+        expect(result.current.Component).toBe(CREATURES['oso-andino'].Component);
+        expect(JSON.parse(localStorage.getItem(STORAGE_KEY))).toBe('oso-andino');
+    });
+
+    it('slug desconocido (bicho retirado / typo) cae al default', () => {
+        expect(resolveAvatarCreature('borugo-que-no-existe').id).toBe(AVATAR_CREATURE_DEFAULT);
+        expect(resolveAvatarCreature(null).id).toBe(AVATAR_CREATURE_DEFAULT);
+    });
+
+    it('todo slug del registro resuelve a su propio personaje', () => {
+        for (const [id, meta] of Object.entries(CREATURES)) {
+            const r = resolveAvatarCreature(id);
+            expect(r.id).toBe(id);
+            expect(r.Component).toBe(meta.Component);
+        }
+    });
+});

--- a/src/hooks/useAvatarCreature.js
+++ b/src/hooks/useAvatarCreature.js
@@ -1,0 +1,32 @@
+import usePrefsStore, { AVATAR_CREATURE_DEFAULT } from '../store/usePrefsStore';
+import { CREATURES } from '../visual/creatures/index.js';
+
+/**
+ * useAvatarCreature — el animal que la persona eligió como SU avatar.
+ *
+ * Resuelve el slug persistido en usePrefsStore (`avatarCreatureId`) contra el
+ * registro CREATURES (src/visual/creatures) y devuelve el personaje completo:
+ *
+ *   const { id, Component, nombre, cientifico } = useAvatarCreature();
+ *   <Component size={64} />
+ *
+ * Data-driven: cualquier bicho nuevo que aterrice en CREATURES (p. ej. el
+ * borugo) queda disponible sin tocar este hook. Si el slug guardado no existe
+ * en el registro (typo, bicho retirado), cae al default: la abeja Angelita.
+ *
+ * Consumidores conocidos: ProfileScreen (cédula), OnboardingCondensado
+ * (paso identidad) y — próximamente — el valle 3D (protagonista elegido).
+ */
+export default function useAvatarCreature() {
+  const avatarCreatureId = usePrefsStore((s) => s.avatarCreatureId);
+  return resolveAvatarCreature(avatarCreatureId);
+}
+
+/** Resolución pura slug→personaje (usable fuera de React). */
+export function resolveAvatarCreature(slug) {
+  const id = slug && CREATURES[slug] ? slug : AVATAR_CREATURE_DEFAULT;
+  const meta = CREATURES[id];
+  return { id, Component: meta.Component, nombre: meta.nombre, cientifico: meta.cientifico };
+}
+
+export { AVATAR_CREATURE_DEFAULT };

--- a/src/store/__tests__/usePrefsStore.test.js
+++ b/src/store/__tests__/usePrefsStore.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import usePrefsStore from '../usePrefsStore.js';
+import usePrefsStore, { AVATAR_CREATURE_DEFAULT } from '../usePrefsStore.js';
 
 /**
  * Tests de usePrefsStore: preferencias persistidas en localStorage (voz, TTS,
@@ -15,6 +15,7 @@ beforeEach(() => {
     voiceRegionIntensity: 1,
     ttsEnabled: true,
     showSourceBadges: true,
+    avatarCreatureId: AVATAR_CREATURE_DEFAULT,
   });
 });
 
@@ -25,6 +26,7 @@ describe('usePrefsStore — defaults', () => {
     expect(s.voiceRegionIntensity).toBe(1);
     expect(s.ttsEnabled).toBe(true);
     expect(s.showSourceBadges).toBe(true);
+    expect(s.avatarCreatureId).toBe(AVATAR_CREATURE_DEFAULT);
   });
 });
 
@@ -53,5 +55,18 @@ describe('setters actualizan estado y persisten', () => {
     usePrefsStore.getState().setShowSourceBadges(null);
     expect(usePrefsStore.getState().showSourceBadges).toBe(false);
     expect(JSON.parse(localStorage.getItem('chagra:prefs:show-source-badges'))).toBe(false);
+  });
+
+  it('setAvatarCreatureId persiste el slug elegido', () => {
+    usePrefsStore.getState().setAvatarCreatureId('jaguar');
+    expect(usePrefsStore.getState().avatarCreatureId).toBe('jaguar');
+    expect(JSON.parse(localStorage.getItem('chagra:prefs:avatar-creature'))).toBe('jaguar');
+  });
+
+  it('setAvatarCreatureId con valor vacío/no-string cae al default (abeja)', () => {
+    usePrefsStore.getState().setAvatarCreatureId('');
+    expect(usePrefsStore.getState().avatarCreatureId).toBe(AVATAR_CREATURE_DEFAULT);
+    usePrefsStore.getState().setAvatarCreatureId(null);
+    expect(usePrefsStore.getState().avatarCreatureId).toBe(AVATAR_CREATURE_DEFAULT);
   });
 });

--- a/src/store/usePrefsStore.js
+++ b/src/store/usePrefsStore.js
@@ -32,6 +32,13 @@ const STORAGE_KEY_VALLE3D = 'chagra:prefs:valle3d';
 // carga posterior a esta migración lo vuelve a encender una sola vez y después
 // respeta el valor elegido por el usuario.
 const STORAGE_KEY_VALLE3D_MIGRATED = 'chagra:prefs:valle3d:migrated-v1';
+// Avatar del USUARIO (2026-07-13): el animal de la chagra que la persona
+// elige como su avatar (slug del registro CREATURES de src/visual/creatures).
+// Default: la abeja angelita. El store solo persiste el slug como string —
+// la resolución slug→componente vive en useAvatarCreature (hooks), para no
+// arrastrar los SVG de fauna a todo consumidor del store.
+const STORAGE_KEY_AVATAR_CREATURE = 'chagra:prefs:avatar-creature';
+export const AVATAR_CREATURE_DEFAULT = 'abeja-angelita';
 
 function load(key, fallback) {
   try {
@@ -68,6 +75,7 @@ const usePrefsStore = create((set, _get) => ({
   haptics: load(STORAGE_KEY_HAPTICS, 'auto'),
   sonido: load(STORAGE_KEY_SONIDO, 'off'),
   valle3d: loadValle3d(),
+  avatarCreatureId: load(STORAGE_KEY_AVATAR_CREATURE, AVATAR_CREATURE_DEFAULT),
 
   setVoiceRegion: (region) => {
     save(STORAGE_KEY_VOICE_REGION, region);
@@ -101,6 +109,12 @@ const usePrefsStore = create((set, _get) => ({
     const valid = SONIDO_MODES.includes(mode) ? mode : 'off';
     save(STORAGE_KEY_SONIDO, valid);
     set({ sonido: valid });
+  },
+
+  setAvatarCreatureId: (id) => {
+    const slug = typeof id === 'string' && id.trim() ? id.trim() : AVATAR_CREATURE_DEFAULT;
+    save(STORAGE_KEY_AVATAR_CREATURE, slug);
+    set({ avatarCreatureId: slug });
   },
 
   setValle3d: (flag) => {


### PR DESCRIPTION
## Qué hace
La persona elige **su animal de la chagra** como avatar propio (distinto del avatar del agente IA).

- **Grilla data-driven** del registro `CREATURES` (`src/visual/creatures/index.js`): los 11 bichos actuales aparecen solos (morrocoy incluido) y el borugo entrará sin tocar el selector.
- **Persistencia**: `usePrefsStore.avatarCreatureId` (localStorage `chagra:prefs:avatar-creature`), default abeja Angelita. El store solo guarda el slug — la resolución slug→componente vive en el hook, para no arrastrar los SVG de fauna a todo consumidor del store.
- **Hook `useAvatarCreature()`** (+ `resolveAvatarCreature` puro): devuelve `{ id, Component, nombre, cientifico }` con fallback al default si el slug no existe. Listo para que el valle 3D ponga al elegido de protagonista.
- **Perfil → Apariencia**: `<AvatarSelector />` junto a los otros selectores; la cédula del hub muestra el animal elegido cuando no hay foto de perfil.
- **Onboarding condensado (paso identidad)**: bloque "Elija su animal (si quiere)" con el mismo selector en modo `compact` — saltable, sin toque queda la abeja.

## A11y / motion / tono
- `radiogroup` + `radio` reales (teclado y lector de pantalla), labels por animal.
- Reduced-motion-safe: con `prefers-reduced-motion` todo quieto; sin ella solo anima el bicho elegido (no hierven 11 contornos a la vez).
- UI en usted colombiano ("Elija su animal", "Toque para elegir").

## Verificación
- `npm run build` verde (36s). Nota: la base de dev de hace 3 días tenía `creatures.css` roto (media query sin cerrar) — rebasé sobre `origin/dev` actual, que ya lo trae sano; este PR no toca `creatures.css`.
- `npx vitest run` de lo tocado: 27/27 verdes (AvatarSelector + usePrefsStore + ProfileScreen hub/photo). Tests registry-driven: siguen verdes cuando entre el borugo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)