### PR TITLE
feat(borugo): animal de cierre — el 9º y último bicho (5 frentes)

### DIFF
--- a/src/visual/creatures/Borugo.jsx
+++ b/src/visual/creatures/Borugo.jsx
@@ -1,0 +1,356 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, RH_INK } from './_rubberhose.jsx';
+import { BORUGO_PALETA, BORUGO_PROPORCION, BORUGO_SLUG, PERFIL_BORUGO } from './borugoIdentidad.js';
+import { cuerpoDeClima, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
+import { AccesoriosClima } from './AccesoriosClima.jsx';
+import { LineBoilFilter } from './LineBoilFilter.jsx';
+import { PropEnMano } from './PropEnMano.jsx';
+import { AuraPoder } from './AuraPoder.jsx';
+import { auraDeBicho } from './transformacion.js';
+
+/* Borugo — Cuniculus taczanowskii (la paca/lapa de montaña andina, el roedor
+   NOCTURNO de la vereda). El 9º y ÚLTIMO personaje: el ANIMAL DE CIERRE. Hermano
+   rubber-hose de la abeja Angelita, el oso, el jaguar y la ardilla: compone el
+   MISMO kit `_rubberhose.jsx` (ojos de goma, cachetes, sonrisa, miembros
+   manguera) y hereda la MISMA fundación transversal — lip-sync (useLipSync →
+   BocaVisema), modo poder (transformacion, aura PLATA LUNAR), ropa por clima
+   (ropaDeClima), prop por mundo (PropEnMano) y line-boil (LineBoilFilter) — cero
+   código duplicado. Solo cambia el ANIMAL y su CARÁCTER: roedor ROBUSTO pardo con
+   HILERAS de motas crema por los flancos (su firma inconfundible), hocico con
+   BIGOTES, ojos GRANDES nocturnos y orejitas atentas. TIERNO, tímido, sereno,
+   NOCTURNO: el alma dulce del grupo, el que despierta el instinto de cuidar. Su
+   seña de vida es el OLFATEO (la nariz que tiembla, los bigotes que se abren, las
+   orejitas que se enderezan) y el ACURRUCARSE (se ovilla a salvo, digno). Su
+   squash&stretch es SUAVE y tímido (nada de comedia bruta). Es de SUELO: patas
+   cortas, no vuela — sin alas. Su color de poder es la PLATA LUNAR / blanco
+   luminoso (no el dorado de la abeja ni el púrpura del jaguar).
+
+   EL HOMENAJE (el alma de este personaje): en la vereda lo cazan con perros para
+   vender su carne; en el mundo de Chagra lo honramos AL REVÉS — vivo, a salvo,
+   querido y digno. Nada de cacería, sangre ni victimismo: solo ternura, dignidad
+   y esperanza. Es el corazón emotivo del cierre.
+
+   NOCTURNO SAGRADO (permanente y sutil, elegante, no recargado): las MOTAS crema
+   de los flancos BRILLAN tenue con luz lunar y los ojos grandes reflejan la LUNA
+   (un halo suave que respira). En modo poder ese brillo se vuelve PLATA LUNAR
+   pleno (el ser protegido por fin se revela seguro). Todo se PODA en tier bajo /
+   reduced-motion (queda un fotograma digno y quieto). */
+const VIEWBOX = '-16 -20 32 40';
+
+/* Mota crema de los flancos: la firma inconfundible del borugo (hileras de
+   puntos claros por los costados). Decorativa (aria-hidden en el grupo padre). */
+function Mota({ cx, cy, r = 1.0, fill, opacity = 0.95 }) {
+  return <ellipse cx={cx} cy={cy} rx={r} ry={r * 0.86} fill={fill} opacity={opacity} />;
+}
+
+/* HILERAS de motas por flanco (la firma). Dos filas escalonadas a cada lado del
+   tronco; coords en el viewBox del cuerpo. La luz lunar (overlay) se pinta con
+   los MISMOS centros para que el brillo viva SOBRE las motas. */
+const MOTAS = [
+  // flanco izquierdo (dos hileras)
+  { cx: -6.6, cy: -0.6, r: 1.05 }, { cx: -7.2, cy: 2.2, r: 1.1 }, { cx: -6.4, cy: 4.8, r: 0.95 },
+  { cx: -3.8, cy: 0.4, r: 0.9 }, { cx: -4.2, cy: 3.4, r: 0.95 }, { cx: -3.4, cy: 5.8, r: 0.8 },
+  // flanco derecho (dos hileras)
+  { cx: 6.6, cy: -0.6, r: 1.05 }, { cx: 7.2, cy: 2.2, r: 1.1 }, { cx: 6.4, cy: 4.8, r: 0.95 },
+  { cx: 3.8, cy: 0.4, r: 0.9 }, { cx: 4.2, cy: 3.4, r: 0.95 }, { cx: 3.4, cy: 5.8, r: 0.8 },
+];
+
+export function Borugo({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Borugo',
+  /* Pose de VIDA (idle-life), species-agnostic (gestos rh-g-* de creatures.css):
+     'anda' (base, con olfateo tímido) | 'celebra' (brinca con bracitos en V +
+     overshoot suave) | 'reposo' (respira hondo, ovillado) | 'señala' (se inclina
+     al POI y apunta con la patita). Solo corren viva (animated); con
+     animated=false o reduced-motion queda en fotograma digno y tierno. */
+  pose = 'anda',
+  animo = 'sereno',
+  energia = 1,
+  /* CLIMA REAL escrito en el cuerpo (perfil borugo). Sin clima (avatares,
+     catálogo) = neutro digno: el borugo se ve EXACTO como siempre. */
+  clima = null,
+  enso = 'neutro',
+  /* ── LIP-SYNC (sistema transversal, useLipSync) ────────────────────────────
+     visema opcional ('V1'..'V4') que produce useLipSync desde el RMS del TTS: la
+     boca se abre cuando el agente narra. Sin visema (o 'V1') = la sonrisa de
+     goma de siempre → avatares/catálogo no cambian. El HOOK vive aparte; acá
+     solo se consume. */
+  visema = null,
+  /* ── VESTUARIO por clima+hora (ropaDeClima) ───────────────────────────────
+     OPT-IN: con vestuario=true el borugo se abriga según el clima real (RUANA de
+     noche/frío — es de montaña húmeda y nocturno, siente el frío pronto). NUNCA
+     suda (contrato compartido de páramo): jamás sombrero ni sudor, aunque el
+     termómetro suba. Default false → los consumidores de `clima` existentes NO
+     ven ropa nueva. */
+  vestuario = false,
+  tempC = undefined,
+  /* ── OLFATEA (olfateo tímido — su reacción-firma tierna) ────────────────────
+     OPT-IN: la nariz TIEMBLA más, los bigotes se ABREN y las orejitas se
+     ENDEREZAN (el roedor nocturno husmea el aire con dulzura). Default false →
+     olfateo idle suave (avatar sereno). */
+  olfatea = false,
+  /* ── ACURRUCA (se ovilla a salvo — el instinto de cuidar) ───────────────────
+     OPT-IN: el cuerpo se REDONDEA y encoge suave y la cabecita se recoge (el ser
+     protegido, digno y tranquilo). Su otra reacción-firma, el corazón emotivo
+     del cierre. Default false. */
+  acurruca = false,
+  /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
+     pleno; 'bajo' apaga el idle continuo (boil + olfateo + bigotes + brillo
+     lunar) y deja los estados reactivos. Sin prop (standalone: avatares,
+     catálogo) = pleno. */
+  tier,
+  /* ── LÍNEA QUE RESPIRA (line-boil, Cuphead años 30 — LineBoilFilter) ────────
+     OPT-IN: con lineBoil el CONTORNO del borugo vibra escalonado (feTurbulence +
+     feDisplacement, ~8fps) — el trazo "hierve" como dibujo animado clásico.
+     Default false → los consumidores existentes NO cambian. Con animated=false o
+     reduced-motion queda con seed fija (textura sin vibrar). Capa MÁS cara del
+     kit: reservada para su entrada heroica (galería, hero). */
+  lineBoil = false,
+  /* ── MODO PODER (transformación / power-up PLATA LUNAR — transformacion.css) ──
+     OPT-IN: con poder=true (y en modo standalone) el borugo se envuelve en su
+     aura PLATA LUNAR de 4 capas (glow, boost, ingravidez, corrientes) — su firma
+     cuando "sube de nivel": el ser protegido que se revela seguro bajo la luna.
+     El host lo enciende un rato con usePoderTemporal(). En modo inline el
+     power-up lo pone el host DOM (::before/mix-blend no aplican a nodos SVG); acá
+     solo marcamos data-poder por si el host lo consulta. */
+  poder = false,
+  /* ── PROP POR MUNDO (herramienta en la patita — propsPorMundo/PropEnMano) ─────
+     mundoId opcional: al ENTRAR a un mundo el borugo carga su herramienta
+     (agua→manguerita, suelo→lupa, animales→lazo, semillero→canasto…). Sin
+     mundoId (o mundo sin prop) entra con las patitas libres. */
+  mundoId = null,
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const boil = `crt-boil-${uid}`;
+  const vivo = animated;
+  const auraOp = Math.max(0.14, Math.min(0.4, 0.16 + 0.24 * (energia ?? 1)));
+  const auraR = 8.2 + 1.5 * (energia ?? 1);
+
+  // CLIMA → cuerpo (determinista, una vez por render): tinte + opacidad al
+  // contorno. El borugo no tiene alas (velocidadAlas siempre 1: no se usa).
+  const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: PERFIL_BORUGO });
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
+
+  // Vestuario por clima+hora (opt-in). Perfil de montaña húmeda/nocturno: la
+  // RUANA de noche/frío; NUNCA sombrero ni sudor (aunque suba el termómetro) — el
+  // borugo no se sobrecalienta. Los suprimimos aquí sin tocar la función
+  // compartida (su contrato/tests siguen intactos). Sin vestuario/clima → nada.
+  const ropaBase = (vestuario && clima) ? ropaDeClimaBicho(BORUGO_SLUG, clima, { tempC }) : null;
+  const ropa = ropaBase ? { ...ropaBase, sombrero: false, sudor: false } : null;
+
+  const P = BORUGO_PALETA;
+  const PR = BORUGO_PROPORCION;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+      {/* Line-boil (contorno que hierve) — solo se instancia si se pide. */}
+      {lineBoil && <LineBoilFilter id={boil} animated={vivo} />}
+    </defs>
+  );
+
+  // PROP DEL MUNDO en la patita izquierda. Sin mundoId o mundo sin prop →
+  // PropEnMano devuelve null (patitas libres, nunca rompe la escena).
+  const propMundo = mundoId ? (
+    <PropEnMano mundoId={mundoId} x={-10.6} y={7.4} escala={0.7} ink={RH_INK} animated={vivo} />
+  ) : null;
+
+  // BOCA: visema (el agente narra) o la sonrisa tímida de siempre. El borugo es
+  // dulce: aun narrando, boquita pequeña.
+  const boca = visema
+    ? <BocaVisema cx={0} cy={-3.0} w={2.6} prof={1.0} visema={visema} />
+    : <Sonrisa cx={0} cy={-3.2} w={2.4} prof={0.9} />;
+
+  // ── CUERPO rubber-hose (atrás→adelante): aura, patitas traseras, tronco pardo
+  //    con vientre crema, MOTAS de los flancos (la firma) + su luz lunar,
+  //    bracitos manguera, cabeza (hocico + ojos grandes/cachetes/boca + trufa +
+  //    bigotes + dientecitos), orejitas. `.crt-body` es el nodo que squashea
+  //    (boil idle borugo: suave y tímido — ternura, no comedia).
+  const body = (
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* aura viva (presencia cálida) */}
+      <circle cx="0" cy="2" r={auraR} fill={P.cuerpo} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* orejitas cortas y atentas (detrás de la cabeza, se enderezan al
+          olfatear). Grupo propio (.borugo-orejas). */}
+      <g className="borugo-orejas" style={{ transformBox: 'fill-box', transformOrigin: 'center bottom' }}>
+        <ellipse cx="-3.2" cy="-12.4" rx={PR.orejaR} ry={PR.orejaR * 1.15} fill={P.cuerpo} stroke={RH_INK} strokeWidth="1.1" />
+        <ellipse cx="-3.2" cy="-12.2" rx={PR.orejaR * 0.5} ry={PR.orejaR * 0.7} fill={P.oreja} />
+        <ellipse cx="3.2" cy="-12.4" rx={PR.orejaR} ry={PR.orejaR * 1.15} fill={P.cuerpo} stroke={RH_INK} strokeWidth="1.1" />
+        <ellipse cx="3.2" cy="-12.2" rx={PR.orejaR * 0.5} ry={PR.orejaR * 0.7} fill={P.oreja} />
+      </g>
+
+      {/* patitas traseras cortas (con plantita crema, detrás del tronco). Se
+          mecen suave. */}
+      <Miembro d="M-5.6,7.6 C-6.8,9.4 -6.6,10.8 -5.2,11.6" ancho={3.0} punta={[-5.2, 11.8]} puntaR={1.8} pie sway={vivo} delay={-0.7} glove={P.vientre} />
+      <Miembro d="M5.6,7.6 C6.8,9.4 6.6,10.8 5.2,11.6" ancho={3.0} punta={[5.2, 11.8]} puntaR={1.8} pie sway={vivo} delay={-1.0} glove={P.vientre} />
+
+      {/* tronco pardo robusto con contorno grueso (la línea que respira con el
+          boil) */}
+      <ellipse cx="0" cy="2" rx={PR.troncoRx} ry={PR.troncoRy}
+        fill={P.cuerpo} stroke={RH_INK} strokeWidth="1.4"
+        style={{ filter: `drop-shadow(0 0 5px ${P.cuerpoGlow})` }} />
+      {/* lomo un tono más hondo (sombra dorsal) */}
+      <path d="M-8.6,-2.4 C-4,-6.6 4,-6.6 8.6,-2.4 C6,-4.2 -6,-4.2 -8.6,-2.4 Z"
+        fill={P.lomo} opacity="0.55" />
+      {/* vientre/panza crema */}
+      <path d="M0,-3.6 C4.0,-2.8 5.2,2.2 3.8,6.4 C2.2,9.0 -2.2,9.0 -3.8,6.4 C-5.2,2.2 -4.0,-2.8 0,-3.6 Z"
+        fill={P.vientre} opacity="0.92" />
+
+      {/* MOTAS de los flancos (hileras crema — LA FIRMA). Decorativas. */}
+      <g aria-hidden="true">
+        {MOTAS.map((m, i) => (
+          <Mota key={i} cx={m.cx} cy={m.cy} r={m.r} fill={P.mota} />
+        ))}
+      </g>
+      {/* LUZ LUNAR sobre las motas — brillo tenue nocturno (permanente y sutil).
+          Late lento; se vuelve PLATA LUNAR pleno en modo poder (CSS). Decorativa. */}
+      <g className={vivo ? 'borugo-motas-luz' : undefined} filter={`url(#${blur})`} aria-hidden="true"
+        style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+        {MOTAS.map((m, i) => (
+          <Mota key={i} cx={m.cx} cy={m.cy} r={m.r * 0.72} fill={P.motaLuz} opacity={0.5} />
+        ))}
+      </g>
+
+      {/* bracitos manguera (patitas delanteras) con plantita crema, pivote en el
+          HOMBRO para que celebra/señala los alcen desde el hombro. */}
+      <Miembro clase="crt-brazo-l" origen="right top"
+        d="M-6.2,-0.6 C-8.8,0.8 -9.6,3.4 -8.6,5.8" ancho={2.8} punta={[-8.6, 6.0]} puntaR={1.8} pie sway={vivo} delay={-0.15} glove={P.vientre} />
+      <Miembro clase="crt-brazo-r" origen="left top"
+        d="M6.2,-0.6 C8.8,0.8 9.6,3.4 8.6,5.8" ancho={2.8} punta={[8.6, 6.0]} puntaR={1.8} pie sway={vivo} delay={-0.45} glove={P.vientre} />
+
+      {/* CABEZA (grupo propio .borugo-cabeza para que el ACURRUCARSE la recoja). */}
+      <g className="borugo-cabeza" style={{ transformBox: 'fill-box', transformOrigin: 'center bottom' }}>
+        <circle cx="0" cy="-7.6" r={PR.cabezaR} fill={P.cuerpo} stroke={RH_INK} strokeWidth="1.3" />
+        {/* hocico romo claro que baja al morro */}
+        <path d="M-2.4,-6.0 C-1.1,-4.7 1.1,-4.7 2.4,-6.0 C2.6,-3.4 1.6,-2.0 0,-1.9 C-1.6,-2.0 -2.6,-3.4 -2.4,-6.0 Z"
+          fill={P.hocico} opacity="0.95" />
+        {/* chapetas (rubor tímido) */}
+        <Cachetes puntos={[{ cx: -4.0, cy: -5.8, r: 1.15 }, { cx: 4.0, cy: -5.8, r: 1.15 }]} vivo={vivo} />
+        {boca}
+        {/* dientecitos de roedor (tímidos, suaves — no agresivos). Bajo la boca. */}
+        <path d="M-0.8,-2.4 L0.8,-2.4 L0.7,-1.2 L-0.7,-1.2 Z" fill={P.diente} stroke={RH_INK} strokeWidth="0.25" opacity="0.9" />
+        <line x1="0" y1="-2.4" x2="0" y2="-1.2" stroke={RH_INK} strokeWidth="0.22" />
+        {/* trufa (nariz que TIEMBLA al olfatear) — grupo propio .borugo-nariz */}
+        <g className="borugo-nariz" style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+          <path d="M-1.2,-4.4 L1.2,-4.4 L0,-3.2 Z" fill={P.nariz} />
+        </g>
+        {/* BIGOTES (los del hocico, se abren al olfatear) — grupo .borugo-bigotes */}
+        <g className="borugo-bigotes" stroke={P.bigote} strokeWidth="0.4" strokeLinecap="round" fill="none"
+          style={{ transformBox: 'fill-box', transformOrigin: 'center' }} aria-hidden="true">
+          <path d={`M-1.6,-3.8 Q-4.4,-4.2 -${PR.bigoteLargo},-4.6`} />
+          <path d="M-1.6,-3.4 Q-4.2,-3.4 -5.0,-3.2" />
+          <path d="M-1.6,-3.0 Q-4.0,-2.6 -4.8,-2.0" />
+          <path d={`M1.6,-3.8 Q4.4,-4.2 ${PR.bigoteLargo},-4.6`} />
+          <path d="M1.6,-3.4 Q4.2,-3.4 5.0,-3.2" />
+          <path d="M1.6,-3.0 Q4.0,-2.6 4.8,-2.0" />
+        </g>
+        {/* OJOS GRANDES nocturnos (dulces) */}
+        <OjosRubber
+          ojos={[{ cx: -2.4, cy: -8.4, r: 1.95 }, { cx: 2.4, cy: -8.4, r: 1.95 }]}
+          mirar={[0, 0.12]}
+          parpadea={vivo}
+        />
+        {/* iris cálido oscuro que enmarca la pupila (ojo nocturno grande) */}
+        <g aria-hidden="true" fill="none" stroke={P.iris} strokeWidth="0.5" opacity="0.7">
+          <circle cx="-2.4" cy="-8.4" r="1.5" />
+          <circle cx="2.4" cy="-8.4" r="1.5" />
+        </g>
+        {/* LA LUNA en los ojos — un halo suave que respira sobre cada ojo (el
+            nocturno refleja la luna). Sutil siempre; PLATA LUNAR pleno en modo
+            poder (CSS). */}
+        <g className={vivo ? 'borugo-ojo-luna' : undefined} filter={`url(#${blur})`} aria-hidden="true"
+          style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+          <circle cx="-2.4" cy="-8.6" r="0.95" fill={P.ojoBrillo} opacity="0.6" />
+          <circle cx="2.4" cy="-8.6" r="0.95" fill={P.ojoBrillo} opacity="0.6" />
+        </g>
+      </g>
+
+      {/* Vestuario por clima+hora (RUANA de noche/frío) — solo con vestuario=true.
+          Sombrero/sudor van suprimidos (el borugo nocturno/páramo no suda). */}
+      {ropa && (
+        <AccesoriosClima
+          estado={ropa}
+          tronco={{ cx: 0, cy: 2, rx: PR.troncoRx, ry: PR.troncoRy }}
+          cabeza={{ cx: 0, cy: -7.6, r: PR.cabezaR }}
+          animated={vivo}
+        />
+      )}
+
+      {/* Prop del mundo en la patita (entra tierno con su herramienta). */}
+      {propMundo}
+    </g>
+  );
+
+  // Antics de VIDA (períodos co-primos) SOLO viva; nodos aparte para no pisar el
+  // boil de `.crt-body`. El CSS los apaga con RM / tier bajo / ánimo bajo /
+  // durante los gestos (celebra/reposo/señala) y estados (olfatea/acurruca).
+  const conAntics = vivo ? (
+    <g className="rh-antic">
+      <g className="rh-travieso">{body}</g>
+    </g>
+  ) : body;
+  // El line-boil (contorno que hierve) envuelve TODO el dibujo cuando se pide.
+  const cuerpoVivo = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
+
+  const estadoAttrs = {
+    'data-creature': BORUGO_SLUG,
+    'data-pose': vivo ? pose : undefined,
+    'data-animo': animo,
+    'data-tier': tier || undefined,
+    'data-visema': visema || undefined,
+    'data-ruana': ropa?.ruana ? '1' : undefined,
+    'data-mojado': ropa?.mojado ? '1' : undefined,
+    'data-olfatea': olfatea ? '1' : undefined,
+    'data-acurruca': acurruca ? '1' : undefined,
+    'data-lineboil': lineBoil ? '1' : undefined,
+    'data-prop': mundoId || undefined,
+  };
+
+  if (inline) {
+    // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
+    // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
+    return (
+      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+        {defs}
+        {cuerpoVivo}
+      </g>
+    );
+  }
+  const svg = (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
+      <title>{title}</title>
+      {defs}
+      {cuerpoVivo}
+    </svg>
+  );
+  // MODO PODER (standalone): lo envolvemos en su aura PLATA LUNAR de 4 capas
+  // (transformacion.css: glow radial + boost + ingravidez + corrientes). El
+  // wrapper DOM es lo único que puede llevar ::before/mix-blend/corrientes.
+  if (poder) {
+    return (
+      <span
+        className="is-powered-up borugo-poder"
+        data-creature-poder={BORUGO_SLUG}
+        style={{ '--aura-color': auraDeBicho(BORUGO_SLUG), display: 'inline-flex' }}
+      >
+        {svg}
+        <AuraPoder />
+      </span>
+    );
+  }
+  return svg;
+}
+
+export default Borugo;

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -28,6 +28,7 @@ calidad dispar. Aquí vive la **versión canónica** de cada uno.
 | `Ardilla` | *Notosciurus granatensis* | Ardilla de cola roja del templado. Rufa con **línea dorsal** oscura (su firma), **cola tupida** y dientes de roedor. Ágil e inquieta: su firma es la **inspección invertida** (se cuelga de cabeza). De suelo, se sienta. Rubber-hose. |
 | `Jaguar` | *Panthera onca* | Felino de tierra cálida. Leonado con **rosetas** (manchas de centro ocre — su firma), musculoso, mirada felina ámbar. Majestuoso y **acechador**: acecho de hombros, cola pesada, rugido. Aura **púrpura**. Rubber-hose. |
 | `Morrocoy` | *Chelonoidis carbonarius* | Galápago de patas rojas de tierra cálida. Caparazón de **domo geométrico** (escudos **hexagonales** con anillos de edad — su firma), patas y cabeza **rojizas** con escamas naranja-fuego. **Ancestral, lento, sabio**: caparazón que respira, **retracción elástica** (cabeza y patas entran a la concha), asentimiento sabio. Aura **bronce**. Rubber-hose. |
+| `Borugo` | *Cuniculus taczanowskii* | La paca/lapa de montaña andina, roedor **nocturno**. Pardo con **hileras de motas crema** en los flancos (su firma), hocico con bigotes, ojos grandes que reflejan la luna. **Tierno, tímido, sereno**: olfateo (`olfatea`) y acurrucarse a salvo (`acurruca`). Aura **plata lunar**. El **animal de cierre** — honrado vivo, a salvo y digno. Rubber-hose. |
 | `Lombriz` | *Martiodrilus crassus* | Lombriz gigante nativa. Cuerpo segmentado con clitelo. Sin animación propia (su movimiento lo da la escena). |
 | `Mariposa` | *Dione juno* | Pasionaria de alas largas. Cuatro alas que abren y cierran. |
 | `Escarabajo` | *Dichotomius belus* | Estercolero colombiano. Élitros brillantes, cuerno, y bola de abono que rueda. |
@@ -132,6 +133,17 @@ elástica** (`seRetrae` → cabeza y patas entran a la concha con squash&stretch
 más el **asentimiento sabio** (`asiente`). De tierra cálida y del contrato
 compartido: **nunca suda**. Suma su capa ANCESTRAL permanente (resplandor cobrizo
 + shimmer de brasa). Todo aditivo en `creatures.css`, RM + tier-safe.
+
+El **`Borugo`** cierra la familia (9º y ÚLTIMO bicho, el **animal de cierre**) con
+su CARÁCTER de **ternura nocturna** — la paca de montaña, tímida y serena: aura
+**PLATA LUNAR** en poder, boil SUAVE (nada de comedia bruta), **hileras de motas
+crema** en los flancos (su firma) que brillan tenue con luz lunar, **ojos grandes**
+que reflejan la luna, **bigotes** que se abren y **orejitas** atentas; su gesto-
+FIRMA es el **olfateo** (`olfatea` → la nariz que tiembla + bigotes + orejas) y el
+**acurrucarse a salvo** (`acurruca` → se ovilla digno, el corazón emotivo del
+cierre). Nocturno de montaña: **nunca suda** (ruana de noche/frío). En la vereda
+lo cazan; aquí lo honramos **vivo, a salvo y querido**. Todo aditivo en
+`creatures.css`, RM + tier-safe.
 
 ## Técnica
 

--- a/src/visual/creatures/__tests__/Borugo.render.test.jsx
+++ b/src/visual/creatures/__tests__/Borugo.render.test.jsx
@@ -1,0 +1,203 @@
+/**
+ * Borugo.render.test.jsx — los 5 frentes de "Borugo completo" (espejo del
+ * jaguar/oso, con el CARÁCTER del 9º y ÚLTIMO bicho — el ANIMAL DE CIERRE: la
+ * paca de montaña andina, TIERNA, tímida, serena, NOCTURNA — plata lunar en
+ * poder). Verifica que las capacidades ADITIVAS del componente canónico se
+ * rendericen sin romper el contrato base:
+ *   1. Expresividad tierna — line-boil (contorno que hierve), olfateo (nariz +
+ *      bigotes + orejas), acurrucarse a salvo (acurruca), motas crema de flancos.
+ *   2. Lip-sync — el visema viaja a la cara (data-visema).
+ *   3. Modo poder — el aura PLATA LUNAR de 4 capas (wrapper .is-powered-up, no dorada).
+ *   4. Ropa/clima — de noche RUANA, y el borugo (nocturno de páramo) NUNCA suda.
+ *   5. Prop por mundo — la herramienta en la patita al entrar.
+ * Más la firma de identidad: es el roedor de las MOTAS crema y su aura es plata
+ * lunar; y el HOMENAJE — honrado vivo, a salvo y digno (nada de cacería).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { Borugo } from '../Borugo.jsx';
+import { auraDeBicho } from '../transformacion.js';
+import { CREATURES } from '../index.js';
+
+afterEach(cleanup);
+
+describe('Borugo — contrato base intacto', () => {
+  it('render por defecto = svg accesible, sin capas nuevas', () => {
+    const { container } = render(<Borugo />);
+    const svg = container.querySelector('svg[data-creature="borugo"]');
+    expect(svg).toBeTruthy();
+    expect(svg.getAttribute('role')).toBe('img');
+    // Ninguna capa opt-in aparece sin pedirla (no regresión visual).
+    expect(svg.getAttribute('data-lineboil')).toBeNull();
+    expect(svg.getAttribute('data-olfatea')).toBeNull();
+    expect(svg.getAttribute('data-acurruca')).toBeNull();
+    expect(svg.getAttribute('data-prop')).toBeNull();
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+  });
+
+  it('siempre trae su NARIZ, sus BIGOTES y sus OREJITAS (identidad tierna)', () => {
+    const { container } = render(<Borugo />);
+    // la seña del roedor nocturno (olfateo + bigotes + orejas) es identidad.
+    expect(container.querySelector('.borugo-nariz')).toBeTruthy();
+    expect(container.querySelector('.borugo-bigotes')).toBeTruthy();
+    expect(container.querySelector('.borugo-orejas')).toBeTruthy();
+  });
+
+  it('está registrado como el binomio correcto (Cuniculus taczanowskii)', () => {
+    expect(CREATURES.borugo).toBeTruthy();
+    expect(CREATURES.borugo.cientifico).toBe('Cuniculus taczanowskii');
+  });
+});
+
+describe('1. Expresividad tierna — line-boil, olfateo y acurrucarse', () => {
+  it('lineBoil instancia el filtro de displacement (contorno que hierve)', () => {
+    const { container } = render(<Borugo lineBoil animated />);
+    expect(container.querySelector('svg').getAttribute('data-lineboil')).toBe('1');
+    expect(container.querySelector('feDisplacementMap')).toBeTruthy();
+    expect(container.querySelector('feTurbulence')).toBeTruthy();
+  });
+
+  it('sin lineBoil NO se paga el filtro (frugal)', () => {
+    const { container } = render(<Borugo animated />);
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+  });
+
+  it('olfatea marca el estado (la nariz tiembla, los bigotes se abren)', () => {
+    const { container } = render(<Borugo olfatea animated />);
+    expect(container.querySelector('svg').getAttribute('data-olfatea')).toBe('1');
+    expect(container.querySelector('.borugo-nariz')).toBeTruthy();
+    expect(container.querySelector('.borugo-bigotes')).toBeTruthy();
+  });
+
+  it('acurruca marca el estado (se ovilla a salvo — el corazón del cierre)', () => {
+    const { container } = render(<Borugo acurruca animated />);
+    expect(container.querySelector('svg').getAttribute('data-acurruca')).toBe('1');
+    expect(container.querySelector('.borugo-cabeza')).toBeTruthy();
+  });
+
+  it('trae SIEMPRE sus MOTAS crema de los flancos (la firma inconfundible)', () => {
+    const { container } = render(<Borugo />);
+    // varias motas + su capa de luz lunar
+    expect(container.querySelector('.borugo-motas-luz')).toBeTruthy();
+  });
+});
+
+describe('2. Lip-sync — el visema llega a la cara', () => {
+  it('con visema V3 la boca abierta viaja a la cara (data-visema)', () => {
+    const { container } = render(<Borugo visema="V3" />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBe('V3');
+  });
+
+  it('sin visema no marca data-visema (la sonrisa tímida de siempre)', () => {
+    const { container } = render(<Borugo />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBeNull();
+  });
+});
+
+describe('3. Modo poder — aura PLATA LUNAR de 4 capas (standalone)', () => {
+  it('poder envuelve en .is-powered-up + corrientes, con aura PLATA LUNAR (no dorada)', () => {
+    const { container } = render(<Borugo poder />);
+    const wrap = container.querySelector('.is-powered-up');
+    expect(wrap).toBeTruthy();
+    expect(wrap.getAttribute('data-creature-poder')).toBe('borugo');
+    // el color de aura del borugo es PLATA LUNAR (distinto del dorado abeja)
+    expect(wrap.getAttribute('style')).toContain('--aura-color');
+    expect(wrap.getAttribute('style')).toContain(auraDeBicho('borugo'));
+    expect(auraDeBicho('borugo')).not.toBe(auraDeBicho('abeja-angelita'));
+    // capa 4: las corrientes (AuraPoder)
+    expect(container.querySelector('.poder-corrientes')).toBeTruthy();
+  });
+
+  it('sin poder no hay wrapper (svg desnudo)', () => {
+    const { container } = render(<Borugo />);
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+    expect(container.querySelector(':scope > svg[data-creature="borugo"]')).toBeTruthy();
+  });
+});
+
+describe('4. Ropa/clima — el borugo se abriga de frío y NUNCA suda', () => {
+  it('de noche con vestuario → RUANA y JAMÁS sudor/sombrero', () => {
+    const { container } = render(<Borugo vestuario clima="noche" />);
+    const svg = container.querySelector('svg');
+    expect(svg.getAttribute('data-ruana')).toBe('1');
+    // el borugo nocturno/páramo aguanta sin sudar
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+  });
+
+  it('de día caluroso (tempC alta) el borugo NO suda (nocturno de páramo, identidad)', () => {
+    const { container } = render(<Borugo vestuario clima="soleado" tempC={33} />);
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+    expect(container.querySelector('.crt-gota-sudor')).toBeNull();
+  });
+
+  it('sin vestuario (avatar/catálogo) → nada de ropa aunque haya clima', () => {
+    const { container } = render(<Borugo clima="noche" />);
+    expect(container.querySelector('svg').getAttribute('data-ruana')).toBeNull();
+  });
+});
+
+describe('5. Prop por mundo — herramienta en la patita', () => {
+  it('mundoId=suelo → carga la lupa', () => {
+    const { container } = render(<Borugo mundoId="suelo" />);
+    expect(container.querySelector('svg').getAttribute('data-prop')).toBe('suelo');
+    expect(container.querySelector('[data-prop="lupa"]')).toBeTruthy();
+  });
+
+  it('mundoId=animales → carga el lazo', () => {
+    const { container } = render(<Borugo mundoId="animales" />);
+    expect(container.querySelector('[data-prop="lazo"]')).toBeTruthy();
+  });
+
+  it('mundo sin prop mapeado → patitas libres (no rompe)', () => {
+    const { container } = render(<Borugo mundoId="mundo-fantasma" />);
+    expect(container.querySelector('[data-prop="lupa"]')).toBeNull();
+    expect(container.querySelector('svg[data-creature="borugo"]')).toBeTruthy();
+  });
+});
+
+describe('6. Nocturno sagrado — el brillo lunar (permanente y sutil)', () => {
+  it('trae SIEMPRE la luz de las motas y la luna en los ojos', () => {
+    const { container } = render(<Borugo />);
+    expect(container.querySelector('.borugo-motas-luz')).toBeTruthy();  // motas que brillan tenue
+    expect(container.querySelector('.borugo-ojo-luna')).toBeTruthy();   // la luna en los ojos
+  });
+
+  it('el brillo lunar es PERMANENTE (existe sin pedir modo poder)', () => {
+    const { container } = render(<Borugo />);
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+    expect(container.querySelector('.borugo-motas-luz')).toBeTruthy();
+  });
+
+  it('reduced-motion-safe / tier-safe: con animated=false NO se anima el brillo (fotograma digno)', () => {
+    const { container } = render(<Borugo animated={false} />);
+    // sin vida: no se cuelgan las clases que animan (motas/ojos/nariz/bigotes)…
+    expect(container.querySelector('.borugo-motas-luz')).toBeNull();
+    expect(container.querySelector('.borugo-ojo-luna')).toBeNull();
+    expect(container.querySelector('.borugo-nariz')).toBeTruthy(); // el nodo sigue dibujado, quieto
+    // …pero las motas (la firma) siguen dibujadas, quietas y dignas (elipses crema).
+    expect(container.querySelector('svg[data-creature="borugo"]')).toBeTruthy();
+  });
+
+  it('modo poder PLATA LUNAR: la luz de las motas sigue dentro del power-up', () => {
+    const { container } = render(<Borugo poder />);
+    const wrap = container.querySelector('.is-powered-up.borugo-poder');
+    expect(wrap).toBeTruthy();
+    // el ser protegido se revela: la luz lunar vive dentro del wrapper
+    expect(wrap.querySelector('.borugo-motas-luz')).toBeTruthy();
+  });
+});
+
+describe('Anti-regresión — modo inline no rompe la escena', () => {
+  it('inline devuelve un <g> con el data-creature y marca data-poder', () => {
+    const { container } = render(
+      <svg>
+        <Borugo inline poder mundoId="suelo" />
+      </svg>,
+    );
+    const g = container.querySelector('g[data-creature="borugo"]');
+    expect(g).toBeTruthy();
+    expect(g.getAttribute('data-poder')).toBe('1'); // el host DOM pinta el aura
+    expect(g.getAttribute('data-prop')).toBe('suelo');
+  });
+});

--- a/src/visual/creatures/borugoIdentidad.js
+++ b/src/visual/creatures/borugoIdentidad.js
@@ -1,0 +1,82 @@
+/*
+ * borugoIdentidad — LA IDENTIDAD VISUAL DEL BORUGO, COMO DATOS.
+ *
+ * Hermana de `jaguarIdentidad.js` y `faunaAndina.js`: el BORUGO (Cuniculus
+ * taczanowskii — la paca/lapa de montaña andina, el roedor nocturno de la
+ * vereda), tiene aquí su silueta canónica. Rubber-hose (Cuphead + Miss Minutes)
+ * con calidez campesina — el MISMO lenguaje de goma de la abeja, el oso y el
+ * jaguar, otro animal y otro CARÁCTER: TIERNO, tímido, sereno, NOCTURNO. El alma
+ * dulce del grupo, el que despierta el instinto de cuidar.
+ *
+ * EL ANIMAL DE CIERRE. En la realidad de la vereda lo cazan con perros para
+ * vender su carne; en el mundo de Chagra lo honramos AL REVÉS: vivo, a salvo,
+ * querido y digno. Nada de cacería ni sangre — solo ternura, dignidad y
+ * esperanza. Su color de poder es la PLATA LUNAR / blanco luminoso (nocturno,
+ * sagrado, un ser protegido que por fin se revela seguro) — distinto de los 8:
+ * dorado (abeja), rojo (oso), verde (rana), iridiscente (colibrí), púrpura
+ * (jaguar), ámbar (ardilla), turquesa (perezoso), bronce/ámbar-rojizo (morrocoy).
+ *
+ * REGLA DE ORO (idéntica a jaguarIdentidad/faunaAndina): SOLO datos. Cero three,
+ * cero react. La creature del bundle base lo importa; jamás debe arrastrar
+ * `vendor-three`. La CADENCIA (animación) vive en `creatures.css` (clases
+ * `rh-*`/`crt-*`/`borugo-*`); el DIBUJO compone el KIT `_rubberhose.jsx`; el
+ * CLIMA→cuerpo, en `creatureClimaCuerpo.js` (consumiendo el PERFIL_BORUGO de
+ * abajo). El aura de poder (plata lunar) vive en `transformacion.js`
+ * (AURA_POR_BICHO) y la ropa por clima en `creatureClimaCuerpo.js`
+ * (ROPA_PERFIL_POR_BICHO): ambos ya traen la fila 'borugo' — este archivo NO la
+ * duplica, solo la silueta.
+ */
+
+/* La tinta cálida del contorno es de TODA la familia rubber-hose. */
+export { RH_INK as BORUGO_TINTA } from './_rubberhose.jsx';
+
+/* Slug estable del borugo (data-creature, aura, ropa, perfiles). */
+export const BORUGO_SLUG = 'borugo';
+
+/* ── BORUGO — Cuniculus taczanowskii (la paca de montaña andina). Cuerpo
+   ROBUSTO de pelaje PARDO cálido, con la firma inconfundible: HILERAS de motas
+   crema/blancas por los flancos. Hocico romo con BIGOTES, ojos GRANDES nocturnos
+   que reflejan la luna, orejitas cortas y atentas, patas cortas. Tierno, tímido,
+   sereno. */
+export const BORUGO_PALETA = {
+  cuerpo: '#8a5a34',        // pelaje pardo cálido (montaña andina)
+  cuerpoGlow: 'rgba(138,90,52,0.65)',
+  lomo: '#6f4526',          // dorso un tono más hondo
+  vientre: '#e9d5b4',       // panza clara crema
+  hocico: '#a9744a',        // morro un poco más claro que el lomo
+  nariz: '#3a2214',         // trufa (nariz que tiembla al olfatear)
+  oreja: '#5a3a22',         // interior de la orejita corta
+  mota: '#f5ead0',          // las motas crema de los flancos (LA FIRMA)
+  motaLuz: '#fffaf0',       // el brillo tenue nocturno sobre las motas (luz lunar)
+  bigote: '#e8dcc4',        // los bigotes claros
+  iris: '#4a3320',          // ojo nocturno cálido oscuro (grande, dulce)
+  ojoBrillo: '#fff6e0',     // catchlight lunar en el ojo (la luna reflejada)
+  diente: '#fff8ec',        // incisivos suaves de roedor (tímidos, no agresivos)
+  /* ── Nocturno sagrado (el ser protegido, la plata lunar) ── */
+  luna: '#eaf2ff',          // el halo de luz lunar / plata (aura de poder, brillo de motas)
+};
+
+export const BORUGO_PROPORCION = {
+  troncoRx: 9.8,            // robusto (más ancho que alto, roedor macizo)
+  troncoRy: 7.0,
+  cabezaR: 5.6,
+  orejaR: 1.5,             // orejita corta y redonda (nocturna, atenta)
+  bigoteLargo: 5.2,        // los bigotes que se abren al olfatear
+};
+
+/*
+ * PERFIL_BORUGO — el perfil de CLIMA→cuerpo del borugo para `cuerpoDeClima`
+ * (creatureClimaCuerpo.js). Mismo shape que PERFIL_OSO/PERFIL_JAGUAR — se pasa
+ * vía la opción `perfil`, así NO hay que tocar el archivo compartido
+ * (anti-conflicto).
+ *   alas    false → sin aleteo (velocidadAlas siempre 1).
+ *   humedad 0.6  → pelaje denso que empapa despacio (no chorrea como la rana).
+ *   difusa  0.5  → roedor macizo: la niebla apenas lo difumina (como la mole del oso).
+ *   sequia  0.4  → de montaña húmeda: sufre algo la seca, pero es robusto.
+ */
+export const PERFIL_BORUGO = Object.freeze({
+  alas: false,
+  humedad: 0.6,
+  difusa: 0.5,
+  sequia: 0.4,
+});

--- a/src/visual/creatures/creatureClimaCuerpo.js
+++ b/src/visual/creatures/creatureClimaCuerpo.js
@@ -244,6 +244,9 @@ export const ROPA_PERFIL_POR_BICHO = Object.freeze({
   ardilla: { frioC: 11, calorC: 26, sudaAlSol: true },
   perezoso: { frioC: 12, calorC: 27, sudaAlSol: true },
   morrocoy: { frioC: 16, calorC: 32, sudaAlSol: true },
+  // Borugo: roedor NOCTURNO de montaña húmeda — siente el frío pronto y de páramo
+  // NUNCA suda (como el oso/la rana).
+  borugo: { frioC: 8, calorC: 22, sudaAlSol: false },
 });
 
 /* Perfil neutro (slug desconocido / standalone). */

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1548,3 +1548,178 @@
   [data-creature='morrocoy'][data-poder='1'] .morrocoy-resplandor,
   [data-creature='morrocoy'][data-poder='1'] .morrocoy-shimmer { animation: none !important; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   BORUGO (Cuniculus taczanowskii) — el 9º y ÚLTIMO bicho, el ANIMAL DE CIERRE.
+   ───────────────────────────────────────────────────────────────────────────
+   El CARÁCTER de la TERNURA NOCTURNA: la paca de montaña, tímida, serena, dulce.
+   Movimientos SUAVES (nada de comedia bruta): olfateo con la nariz que tiembla,
+   bigotes que se abren, orejitas atentas, ojos grandes que reflejan la luna y
+   las MOTAS crema de los flancos que brillan tenue (nocturno). Aditivo sobre el
+   KIT species-agnostic (no toca a ningún otro bicho): el borugo reescribe SU
+   boil (suave y tímido), suma el olfateo (nariz + bigotes + orejas), el
+   acurrucarse a salvo (el corazón emotivo del cierre) y el brillo lunar
+   permanente (motas + ojos). En modo poder ese brillo se vuelve PLATA LUNAR
+   pleno (el ser protegido que se revela seguro). Todo transform/opacity (GPU,
+   gama baja). Gates RM + tier al final del bloque.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* BOIL SUAVE — el borugo NO vibra ligero ni salta: respira TÍMIDO, con squash
+   pequeño y dulce (ternura, poder contenido de un animalito manso). Reescribe
+   SOLO el boil del borugo (misma clase .rh-boil, mayor especificidad por el
+   data-creature) con longhands para no pisar el resto de props de animación. */
+[data-creature='borugo'] .rh-boil {
+  animation-name: borugo-boil;
+  animation-duration: 3.4s;
+  animation-timing-function: ease-in-out;
+}
+@keyframes borugo-boil {
+  0%, 100% { transform: translateY(0) scale(1, 1); }
+  50%      { transform: translateY(0.35px) scale(1.012, 0.988); } /* respiración suave y tímida */
+}
+
+/* NARIZ que TIEMBLA — el olfateo idle del roedor nocturno (permanente, tenue). */
+.borugo-nariz {
+  animation: borugo-olfateo 1.9s ease-in-out infinite;
+}
+@keyframes borugo-olfateo {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50%      { transform: translateY(0.25px) scale(1.06); }  /* husmea el aire */
+}
+
+/* BIGOTES — se mecen apenas (permanente, delicado). */
+.borugo-bigotes {
+  animation: borugo-bigotes 3.7s ease-in-out infinite;
+}
+@keyframes borugo-bigotes {
+  0%, 100% { transform: scaleX(1) rotate(0deg); }
+  50%      { transform: scaleX(1.02) rotate(0.4deg); }
+}
+
+/* OREJITAS — atentas, se enderezan apenas (permanente, tímido). */
+.borugo-orejas {
+  animation: borugo-orejas 4.3s ease-in-out infinite;
+}
+@keyframes borugo-orejas {
+  0%, 100% { transform: translateY(0) scaleY(1); }
+  50%      { transform: translateY(-0.3px) scaleY(1.05); }  /* se enderezan atentas */
+}
+
+/* OLFATEA — la reacción-firma tierna: la nariz tiembla MÁS rápido, los bigotes
+   se ABREN y las orejitas se ENDEREZAN (husmea el aire con dulzura). Pisan el
+   idle por especificidad (dos atributos). */
+[data-creature='borugo'][data-olfatea='1'] .borugo-nariz {
+  animation: borugo-olfateo-vivo 0.55s ease-in-out infinite;
+}
+@keyframes borugo-olfateo-vivo {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50%      { transform: translateY(0.4px) scale(1.12); }
+}
+[data-creature='borugo'][data-olfatea='1'] .borugo-bigotes {
+  animation: borugo-bigotes-abre 0.55s ease-in-out infinite;
+}
+@keyframes borugo-bigotes-abre {
+  0%, 100% { transform: scaleX(1) rotate(0deg); }
+  50%      { transform: scaleX(1.14) rotate(1.2deg); }  /* los bigotes se abren */
+}
+[data-creature='borugo'][data-olfatea='1'] .borugo-orejas {
+  animation: borugo-orejas-perk 0.9s ease-in-out infinite;
+}
+@keyframes borugo-orejas-perk {
+  0%, 100% { transform: translateY(-0.3px) scaleY(1.06); }
+  50%      { transform: translateY(-0.9px) scaleY(1.14); }  /* atentas, alerta dulce */
+}
+
+/* ACURRUCA — se ovilla a SALVO: el cuerpo se REDONDEA y encoge suave y la
+   cabecita se recoge (el ser protegido, digno y tranquilo). El corazón emotivo
+   del cierre — lento y tierno, nunca brusco. Pisa el boil por especificidad. */
+[data-creature='borugo'][data-acurruca='1'] .crt-body {
+  animation: borugo-acurruca 4.6s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes borugo-acurruca {
+  0%, 100% { transform: translateY(0) scale(1, 1); }
+  50%      { transform: translateY(1px) scale(1.04, 0.94); }  /* se ovilla, hondo y calmo */
+}
+[data-creature='borugo'][data-acurruca='1'] .borugo-cabeza {
+  animation: borugo-cabeza-recoge 4.6s ease-in-out infinite;
+}
+@keyframes borugo-cabeza-recoge {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50%      { transform: translateY(1.1px) scale(0.97); }  /* recoge la cabecita, a salvo */
+}
+
+/* Los estados del borugo (olfatea/acurruca) PISAN el arrebato (antic/travieso):
+   un animalito que husmea tímido o se ovilla a salvo no da vueltas de campana. */
+[data-creature='borugo'][data-olfatea='1'] .rh-antic,
+[data-creature='borugo'][data-olfatea='1'] .rh-travieso,
+[data-creature='borugo'][data-acurruca='1'] .rh-antic,
+[data-creature='borugo'][data-acurruca='1'] .rh-travieso { animation: none; }
+
+/* ── NOCTURNO SAGRADO — el brillo lunar (permanente y sutil) ─────────────────
+   Las MOTAS crema de los flancos brillan tenue y los OJOS grandes reflejan la
+   luna; en modo poder se vuelve PLATA LUNAR pleno (el ser protegido se revela). */
+.borugo-motas-luz {
+  animation: borugo-motas-luz 5.4s ease-in-out infinite;
+}
+@keyframes borugo-motas-luz {
+  0%, 100% { opacity: 0.35; }
+  50%      { opacity: 0.62; }
+}
+.borugo-ojo-luna {
+  animation: borugo-ojo-luna 3.6s ease-in-out infinite;
+}
+@keyframes borugo-ojo-luna {
+  0%, 100% { opacity: 0.55; transform: scale(0.96); }
+  50%      { opacity: 0.95; transform: scale(1.08); }
+}
+
+/* MODO PODER PLATA LUNAR — el brillo se intensifica y acelera (el ser protegido
+   por fin se revela seguro bajo la luna). Vale en standalone (wrapper
+   .borugo-poder) y en inline (data-poder en el <g>). */
+.borugo-poder .borugo-motas-luz,
+[data-creature='borugo'][data-poder='1'] .borugo-motas-luz {
+  animation-name: borugo-motas-lunar;
+  animation-duration: 3.0s;
+}
+@keyframes borugo-motas-lunar {
+  0%, 100% { opacity: 0.6; }
+  50%      { opacity: 1; }
+}
+.borugo-poder .borugo-ojo-luna,
+[data-creature='borugo'][data-poder='1'] .borugo-ojo-luna {
+  animation-name: borugo-ojo-lunar;
+  animation-duration: 2.2s;
+}
+@keyframes borugo-ojo-lunar {
+  0%, 100% { opacity: 0.85; transform: scale(1.02); }
+  50%      { opacity: 1;    transform: scale(1.2); }
+}
+
+/* device-tier 'bajo': el boil reescrito del borugo lo reactivaría (misma clase)
+   → re-apagarlo aquí (mayor especificidad + orden posterior). El olfateo, los
+   bigotes, las orejas y el brillo lunar continuos también se cortan; los estados
+   reactivos (olfatea/acurruca) siguen contando la verdad. */
+[data-tier='bajo'][data-creature='borugo'] .rh-boil,
+[data-tier='bajo'][data-creature='borugo'] .borugo-nariz,
+[data-tier='bajo'][data-creature='borugo'] .borugo-bigotes,
+[data-tier='bajo'][data-creature='borugo'] .borugo-orejas,
+[data-tier='bajo'][data-creature='borugo'] .borugo-ojo-luna { animation: none; }
+[data-tier='bajo'][data-creature='borugo'] .borugo-motas-luz { animation: none; opacity: 0.5; }
+
+@media (prefers-reduced-motion: reduce) {
+  [data-creature='borugo'] .rh-boil,
+  .borugo-nariz, .borugo-bigotes, .borugo-orejas, .borugo-ojo-luna,
+  .borugo-poder .borugo-ojo-luna,
+  [data-creature='borugo'][data-poder='1'] .borugo-ojo-luna,
+  [data-creature='borugo'][data-olfatea='1'] .borugo-nariz,
+  [data-creature='borugo'][data-olfatea='1'] .borugo-bigotes,
+  [data-creature='borugo'][data-olfatea='1'] .borugo-orejas,
+  [data-creature='borugo'][data-acurruca='1'] .crt-body,
+  [data-creature='borugo'][data-acurruca='1'] .borugo-cabeza { animation: none !important; }
+  /* Motas: sin titileo, quietas y tenues (fotograma digno). */
+  .borugo-motas-luz,
+  .borugo-poder .borugo-motas-luz,
+  [data-creature='borugo'][data-poder='1'] .borugo-motas-luz { animation: none !important; opacity: 0.5; }
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -38,6 +38,11 @@ export { Morrocoy } from './Morrocoy.jsx';
    proporciones y su perfil de clima). Solo datos: jamás arrastra three al bundle
    base — igual que jaguarIdentidad/faunaAndina. */
 export { MORROCOY_PALETA, MORROCOY_PROPORCION, MORROCOY_SLUG, PERFIL_MORROCOY } from './morrocoyIdentidad.js';
+export { Borugo } from './Borugo.jsx';
+/* La IDENTIDAD del borugo como datos (paleta parda + motas crema, proporciones y
+   su perfil de clima). El 9º y ÚLTIMO bicho — el ANIMAL DE CIERRE. Solo datos:
+   jamás arrastra three al bundle base — igual que jaguarIdentidad/abejaIdentidad. */
+export { BORUGO_PALETA, BORUGO_PROPORCION, BORUGO_SLUG, PERFIL_BORUGO } from './borugoIdentidad.js';
 /* La IDENTIDAD del trío andino como datos (paletas + proporciones). Solo datos:
    jamás arrastra three al bundle base — igual que abejaIdentidad. */
 export {
@@ -52,7 +57,7 @@ export { Mariposa } from './Mariposa.jsx';
 export { Escarabajo } from './Escarabajo.jsx';
 
 /* ── SISTEMA DE PERSONAJES (transversal, species-agnostic) ───────────────────
-   La FUNDACIÓN que heredan los 8 bichos: lip-sync, modo poder, prop-por-mundo,
+   La FUNDACIÓN que heredan los 9 bichos: lip-sync, modo poder, prop-por-mundo,
    ropa por clima+hora y el line-boil. Cada bicho = parámetros (aura, perfil,
    props), no código duplicado. Estrenado por Angelita; fable engancha el resto. */
 // Lip-sync 2D por RMS del TTS.
@@ -88,6 +93,7 @@ import Perezoso from './Perezoso.jsx';
 import Ardilla from './Ardilla.jsx';
 import Jaguar from './Jaguar.jsx';
 import Morrocoy from './Morrocoy.jsx';
+import Borugo from './Borugo.jsx';
 import Lombriz from './Lombriz.jsx';
 import Mariposa from './Mariposa.jsx';
 import Escarabajo from './Escarabajo.jsx';
@@ -102,6 +108,7 @@ export const CREATURES = {
   ardilla: { Component: Ardilla, nombre: 'Ardilla de cola roja', cientifico: 'Notosciurus granatensis' },
   jaguar: { Component: Jaguar, nombre: 'Jaguar', cientifico: 'Panthera onca' },
   morrocoy: { Component: Morrocoy, nombre: 'Morrocoy de patas rojas', cientifico: 'Chelonoidis carbonarius' },
+  borugo: { Component: Borugo, nombre: 'Borugo', cientifico: 'Cuniculus taczanowskii' },
   lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
   mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
   escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },

--- a/src/visual/creatures/transformacion.js
+++ b/src/visual/creatures/transformacion.js
@@ -35,6 +35,7 @@ export const AURA_POR_BICHO = Object.freeze({
   ardilla: '#ff9f1c',          // chispas ámbar
   perezoso: '#1ec9b7',         // turquesa/teal zen irónico (distinto del verde de la rana)
   morrocoy: '#ff7a3c',         // caparazón que brilla (ámbar-rojizo)
+  borugo: '#dbe8ff',           // PLATA LUNAR / blanco luminoso (nocturno sagrado, el animal de cierre)
 });
 
 /* Aura por defecto si el slug no está mapeado (la dorada de la guía). */

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -166,6 +166,26 @@ const VARIANTES_MORROCOY = [
   { label: 'sin animación', props: { size: 88, animated: false } },
 ];
 
+/* El BORUGO completo — el 9º y ÚLTIMO bicho, el ANIMAL DE CIERRE — estrena TODA
+   la fundación transversal con su CARÁCTER TIERNO y NOCTURNO: olfateo tímido
+   (`olfatea`), acurrucarse a salvo (`acurruca`), boil suave, motas crema que
+   brillan con luz lunar, ruana de noche, modo poder PLATA LUNAR y prop por mundo.
+   La vitrina lo luce con todo. */
+const VARIANTES_BORUGO = [
+  { label: '48 px', props: { size: 48 } },
+  { label: 'anda', props: { size: 88 } },
+  { label: 'celebra', props: { size: 88, pose: 'celebra' } },
+  { label: 'reposo', props: { size: 88, pose: 'reposo' } },
+  { label: 'señala', props: { size: 88, pose: 'señala' } },
+  { label: 'olfatea', props: { size: 88, olfatea: true } },
+  { label: 'se acurruca', props: { size: 88, acurruca: true } },
+  { label: 'ruana de noche', props: { size: 88, vestuario: true, clima: 'noche' } },
+  { label: 'con lupa (suelo)', props: { size: 88, mundoId: 'suelo' } },
+  { label: 'poder PLATA LUNAR', props: { size: 88, poder: true } },
+  { label: 'línea que hierve', props: { size: 88, lineBoil: true } },
+  { label: 'sin animación', props: { size: 88, animated: false } },
+];
+
 const VARIANTES_POR_SLUG = {
   'abeja-angelita': VARIANTES_ABEJA,
   colibri: VARIANTES_TRIO_AIRE,
@@ -175,6 +195,7 @@ const VARIANTES_POR_SLUG = {
   ardilla: VARIANTES_ARDILLA,
   jaguar: VARIANTES_JAGUAR,
   morrocoy: VARIANTES_MORROCOY,
+  borugo: VARIANTES_BORUGO,
 };
 
 /* Nota de campo por creature (el registro de la categoría trae nombre + binomio;
@@ -188,6 +209,7 @@ const NOTAS_CREATURE = {
   ardilla: 'Ardilla de cola roja del templado; rufa con la línea dorsal oscura (su firma), cola tupida y su inspección invertida.',
   jaguar: 'Felino de tierra cálida, majestuoso y acechador; leonado con rosetas de centro ocre (su firma), aura púrpura.',
   morrocoy: 'Galápago de patas rojas, el anciano ancestral y paciente; caparazón de domo hexagonal (su firma) y patas rojizas, aura bronce. Se retrae elástico a la concha.',
+  borugo: 'La paca de montaña andina, roedor nocturno tierno; pardo con hileras de motas crema (su firma), olfateo tímido y aura plata lunar. El animal de cierre — vivo, a salvo y digno.',
   lombriz: 'La ingeniera del suelo; ondula por segmentos con clitelo marcado.',
   mariposa: 'Alas naranjas con venación; poliniza y anuncia buen suelo.',
   escarabajo: 'Estercolero que entierra el abono; élitros con brillo metálico.',


### PR DESCRIPTION
## Borugo — el animal de cierre 🌙

El **9º y ÚLTIMO** personaje de fauna: el **borugo** (*Cuniculus taczanowskii*, la paca/lapa de montaña andina), el roedor **nocturno** de la vereda. Componente rubber-hose **nuevo** que hereda la fundación transversal completa (kit `_rubberhose`, lip-sync, modo poder, ropa por clima, prop por mundo, line-boil) — cero duplicación.

Lo honramos **vivo, a salvo, querido y digno** — ternura, dignidad y esperanza. Nada de cacería ni sangre. El corazón emotivo del cierre.

### Identidad
Cuerpo robusto pardo con **hileras de motas crema en los flancos** (su firma), hocico con bigotes, ojos grandes nocturnos, orejitas atentas. Tierno, tímido, sereno. Color de poder: **plata lunar** (distinto de los otros 8: dorado/rojo/verde/iridiscente/púrpura/ámbar/turquesa/bronce).

### Los 5 frentes
1. **Expresividad tierna rubber-hose** — boil suave (nada de comedia bruta), **olfateo** (`olfatea`: nariz que tiembla + bigotes que se abren + orejitas que se enderezan), **acurrucarse a salvo** (`acurruca`), motas crema con **brillo lunar** permanente, ojos que reflejan la luna, **line-boil**.
2. **Lip-sync** — prop `visema` → `BocaVisema` cuando el agente narra.
3. **Modo poder PLATA LUNAR** — aura plateada/blanca de 4 capas (`auraDeBicho('borugo')`).
4. **Ropa/clima** — ruana de noche/frío; nocturno de páramo, **NUNCA suda** (contrato compartido).
5. **Prop por mundo** — herramienta en la patita al entrar (agua→manguerita, suelo→lupa, animales→lazo, semillero→canasto).

### Archivos
- **Nuevos**: `Borugo.jsx`, `borugoIdentidad.js`, `__tests__/Borugo.render.test.jsx`.
- **Aditivos** (fila BORUGO al final, sin tocar los otros 8): `index.js`, `registry.js`, `transformacion.js`, `creatureClimaCuerpo.js`, `creatures.css`, `README.md`.

### Verificación
- `npm run build` ✓ verde (38s).
- `npx vitest run src/visual/creatures` ✓ 14 archivos / **222 tests** verde (borugo suma 21).
- reduced-motion + tier-safe. UI en usted. No toca `outputGuards.js` ni `externalAiPromptBuilder.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)