### PR TITLE
feat(valle): fauna ambiental viva — central + giños lejanos, performante

### DIFF
--- a/src/mockups/VitrinaMaestraMundos.jsx
+++ b/src/mockups/VitrinaMaestraMundos.jsx
@@ -58,7 +58,17 @@ import {
 } from '../visual/mundo3d/atmosferaMadre.js';
 import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
 import TransicionMundoKit from '../visual/mundo3d/TransicionMundoKit.jsx';
-import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
+import { FaunaAmbiental } from '../visual/creatures/FaunaAmbiental.jsx';
+import useAvatarCreature from '../hooks/useAvatarCreature.js';
+
+/* EL VALLE VIVO en la galería: los personajes asoman ENTRE los mundos, desde
+   los bordes (nunca sobre los portales ni el chrome), hacen su giño lejano y
+   se van. Pool rotativo tier-safe; se pausa durante el viaje de túnel. */
+const PUNTOS_FAUNA_VITRINA = [
+  { estilo: { left: '2.5%', bottom: '30%' }, tam: 44, lado: 'izq' },
+  { estilo: { right: '3%', bottom: '36%' }, tam: 40, voltear: true, lado: 'der' },
+  { estilo: { left: '14%', top: '24%' }, tam: 30, lado: 'bosque' },
+];
 
 /* ══════════════════════════════════════════════════════════════════════════
    LOS DOCE MUNDOS — datos de la vitrina + importadores perezosos
@@ -1722,6 +1732,11 @@ const CSS_VMX = `
  */
 export default function VitrinaMaestraMundos({ onBack }) {
   const [{ tier, reducedMotion }] = useState(() => decidirTier());
+  /* EL CENTRAL MANDA: el avatar que la persona eligió (perfil/onboarding) es
+     el protagonista de la vitrina — grande, pleno, al frente. Sin elección el
+     hook cae a Angelita. El coro ambiental lo excluye del elenco. */
+  const central = useAvatarCreature();
+  const CuerpoCentral = central.Component;
   const [fase, setFase] = useState('galeria');
   const [viaje, setViaje] = useState(null); // null | 'entrar' | 'salir'
   const [mundoId, setMundoId] = useState(null);
@@ -1849,10 +1864,11 @@ export default function VitrinaMaestraMundos({ onBack }) {
               <small>Toque un portal: el túnel lo lleva y lo trae</small>
             </h2>
             <div className="vmx-abeja">
-              {/* Entrada HEROICA: Angelita en su expresividad plena — el contorno
-                  hierve (line-boil), suelta polen y bate sus alitas de tul. Es la
-                  insignia de Chagra: acá se luce con todo el rubber-hose. */}
-              <AbejaAngelita
+              {/* Entrada HEROICA del CENTRAL (el avatar elegido; hoy Angelita):
+                  expresividad plena — line-boil, polen y alitas de tul. El
+                  protagonista se luce con todo el rubber-hose; el coro
+                  ambiental, a lo lejos, jamás compite con él. */}
+              <CuerpoCentral
                 size={100}
                 animo="pleno"
                 energia={1}
@@ -1896,13 +1912,26 @@ export default function VitrinaMaestraMundos({ onBack }) {
         </button>
       )}
 
-      {/* Angelita entra al mundo: el clon que hace la picada al centro del
+      {/* El CENTRAL entra al mundo: el clon que hace la picada al centro del
           portal durante el cruce (el dolly deja la boca justo ahí). En tier
-          bajo también vuela — el iris la alcanza a mitad de picada. */}
+          bajo también vuela — el iris lo alcanza a mitad de picada. */}
       {!reducedMotion && fase !== 'mundo' && (fase === 'acercando' || viaje === 'entrar') && (
         <div className="vmx-abeja-cruce" aria-hidden="true">
-          <AbejaAngelita size={100} animo="atento" energia={1} animated tier={tier} />
+          <CuerpoCentral size={100} animo="atento" energia={1} animated tier={tier} />
         </div>
+      )}
+
+      {/* El coro ambiental entre los mundos: personajes que vienen del bosque
+          o de los costados, hacen su giño lejano y se van (solo el jaguar
+          aparece mágico). Pausado durante el viaje — la GPU va en el dolly. */}
+      {fase !== 'mundo' && (
+        <FaunaAmbiental
+          central={central.id}
+          tier={tier}
+          reducedMotion={reducedMotion}
+          activo={enGaleria}
+          puntos={PUNTOS_FAUNA_VITRINA}
+        />
       )}
 
       <div className="vmx-vineta" aria-hidden="true" />

--- a/src/visual/creatures/FaunaAmbiental.jsx
+++ b/src/visual/creatures/FaunaAmbiental.jsx
@@ -1,0 +1,247 @@
+/*
+ * FaunaAmbiental — el VALLE VIVO como capa DOM pura (cero three, cero canvas).
+ *
+ * Los personajes de la chagra asoman A LO LEJOS en el valle y en la galería de
+ * mundos: entran con fade, hacen UN gesto de llamar la atención (saltito, seña
+ * con la manita, guiño coqueto) y se van con fade. Rotan por un pool de slots
+ * FIJOS — nunca más de 2–3 a la vez, nunca el mismo repetido — mientras EL
+ * CENTRAL (el avatar elegido) sigue mandando en primer plano, grande y pleno.
+ *
+ * ES UN OVERLAY: se monta SOBRE la escena (el canvas 3D del valle, la galería
+ * de portales, o la rejilla 2D de gama baja) con `position:absolute` y
+ * `pointer-events:none`. No sabe de three ni de cámaras: la lejanía se dice
+ * con TAMAÑO (los ambientales miden 32–46 px; el central 100+) y con puntos de
+ * anclaje en los bordes/horizonte que el host puede afinar por escena.
+ *
+ * PERFORMANCE (el requisito duro — "que no carguen el mundo"):
+ *   - POOLING: los slots son nodos fijos que se REUSAN; el personaje solo se
+ *     swapea al re-entrar (una vez cada ~8–12 s). Cero churn de montaje.
+ *   - LOD: los ambientales van con `animated={false}` — el SVG interno queda
+ *     ESTÁTICO (sin aleteo, sin boil, sin filtros); el único movimiento es el
+ *     gesto del wrapper, transform/opacity-only (composición pura, cero
+ *     layout). Solo el central, que vive fuera de esta capa, va full-detail.
+ *   - TIER: alto=3, medio=2, bajo=1 (y en bajo el gesto se apaga por CSS:
+ *     queda solo el fade — `data-tier='bajo'` reduce todo).
+ *   - REDUCED-MOTION: la capa NI SE MONTA (limite 0). Sin entradas ni salidas.
+ *   - CULLING: los timers se PAUSAN cuando la capa sale de pantalla
+ *     (IntersectionObserver), cuando la pestaña se oculta (visibilitychange)
+ *     y cuando el host la declara inactiva (`activo={false}`, p. ej. durante
+ *     el dolly del túnel, que ya tiene la GPU ocupada).
+ *
+ * La LÓGICA del ritmo (fases, límites, cast) vive pura en faunaAmbiental.js.
+ * UI en usted colombiano; la capa es decorativa → aria-hidden.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { CREATURES } from './index.js';
+import {
+  castAmbiental,
+  crearEstado,
+  avanzar,
+  duracionFase,
+  limiteAmbiental,
+  esMagico,
+  ladoDePunto,
+  CENTRAL_DEFECTO,
+  PUNTOS_DEFECTO,
+} from './faunaAmbiental.js';
+
+/* CSS de la capa (vive aquí: patrón CSS_CIELO de EscenaValle — un archivo).
+   TODO transform/opacity-only: nada que dispare layout ni paint pesado. */
+const CSS_FAUNA_AMB = `
+.fauna-amb { position: absolute; inset: 0; overflow: hidden; pointer-events: none; z-index: 2; }
+.fauna-amb__slot {
+  position: absolute;
+  opacity: 0;
+  transition: opacity 0.7s ease, transform 0.7s ease;
+  will-change: opacity;
+  filter: drop-shadow(0 2px 3px rgba(30, 30, 20, 0.22));
+}
+/* COHERENCIA: cada animal VIENE de algún lado y SE VA por donde vino.
+   Del costado izquierdo/derecho: se desliza entrando a escena. Del bosque:
+   asoma SUBIENDO tras la vegetación del horizonte. El estado oculto define
+   la procedencia; el visible es siempre su puesto (transform none). */
+.fauna-amb__slot[data-entrada='izq'] { transform: translateX(-160%) translateY(6px); }
+.fauna-amb__slot[data-entrada='der'] { transform: translateX(160%) translateY(6px); }
+.fauna-amb__slot[data-entrada='bosque'] { transform: translateY(60%) scale(0.92); }
+/* El JAGUAR es el único que aparece MÁGICO: surge de la nada donde está,
+   condensándose (escala desde chiquito, sin viaje) — espíritu del monte. */
+.fauna-amb__slot[data-magico='1'] { transform: scale(0.35) rotate(-6deg); }
+.fauna-amb__slot[data-fase='entra'],
+.fauna-amb__slot[data-fase='gesto'] { opacity: 0.88; transform: none; }
+.fauna-amb__slot[data-fase='sale'] { opacity: 0; }
+.fauna-amb__gesto { transform-origin: 50% 100%; }
+.fauna-amb__cara--voltea { transform: scaleX(-1); }
+/* Los tres gestos de "¡venga, míreme!" — corren SOLO en la fase gesto. */
+.fauna-amb__slot[data-fase='gesto'][data-gesto='saltito'] .fauna-amb__gesto {
+  animation: fauna-amb-salto 1.3s cubic-bezier(0.34, 1.56, 0.64, 1) 2;
+}
+.fauna-amb__slot[data-fase='gesto'][data-gesto='sena'] .fauna-amb__gesto {
+  animation: fauna-amb-sena 0.65s ease-in-out 4;
+}
+.fauna-amb__slot[data-fase='gesto'][data-gesto='guino'] .fauna-amb__gesto {
+  animation: fauna-amb-guino 2.6s ease-in-out 1;
+}
+/* Saltito rubber-hose: dos brincos con squash & stretch y overshoot. */
+@keyframes fauna-amb-salto {
+  0%, 100% { transform: none; }
+  25% { transform: translateY(-16%) scaleY(1.06) scaleX(0.96); }
+  45% { transform: translateY(0) scaleY(0.92) scaleX(1.08); }
+  62% { transform: translateY(-9%) scaleY(1.04); }
+  80% { transform: translateY(0) scaleY(0.97); }
+}
+/* Seña con la manita: el cuerpo entero se mece desde los pies, llamando. */
+@keyframes fauna-amb-sena {
+  0%, 100% { transform: rotate(0deg); }
+  35% { transform: rotate(-11deg); }
+  70% { transform: rotate(8deg); }
+}
+/* Guiño/asomo coqueto: se ladea, se estira un pelito hacia usted y vuelve. */
+@keyframes fauna-amb-guino {
+  0%, 100% { transform: none; }
+  22% { transform: rotate(-6deg) scale(1.06); }
+  48% { transform: rotate(-6deg) scale(1.06) translateY(-4%); }
+  74% { transform: rotate(3deg) scale(1.01); }
+}
+/* Gama baja: el gesto se apaga — queda apenas el fade (compañía sin costo). */
+.fauna-amb[data-tier='bajo'] .fauna-amb__gesto { animation: none !important; }
+/* Host inactivo (dolly/túnel en curso): todos se apagan de una. */
+.fauna-amb[data-activo='0'] .fauna-amb__slot { opacity: 0 !important; }
+/* Cinturón y tirantes: si el gate de reduced-motion no llegó por props. */
+@media (prefers-reduced-motion: reduce) {
+  .fauna-amb__slot, .fauna-amb__gesto { transition: none !important; animation: none !important; }
+}
+`;
+
+/**
+ * La capa de fauna ambiental. Montarla como hija de un contenedor
+ * `position:relative` que cubra la escena (el host del valle, la vitrina…).
+ *
+ * @param {object} p
+ * @param {string}  [p.central]  slug del avatar protagonista — se EXCLUYE del
+ *   elenco ambiental (el central manda, nadie lo duplica al fondo). El host
+ *   lo saca de `useAvatarCreature()` (src/hooks).
+ * @param {string[]} [p.excluir]  slugs extra fuera del coro (p. ej. Angelita
+ *   donde ella ya vuela en primer plano como acompañante).
+ * @param {'alto'|'medio'|'bajo'} [p.tier]  gama del equipo (deviceTier).
+ * @param {boolean} [p.reducedMotion]  true → la capa ni se monta.
+ * @param {boolean} [p.activo]  false → pausa timers y apaga los slots (p. ej.
+ *   durante el viaje de túnel). Default true.
+ * @param {Array<{estilo: object, tam?: number, voltear?: boolean}>} [p.puntos]
+ *   anclajes por slot (estilos absolutos: left/right/top/bottom en %).
+ * @param {object}  [p.registro]  slug → { Component, nombre } (tests).
+ * @param {string}  [p.className]
+ */
+export function FaunaAmbiental({
+  central = CENTRAL_DEFECTO,
+  excluir = undefined,
+  tier = 'alto',
+  reducedMotion = false,
+  activo = true,
+  puntos = PUNTOS_DEFECTO,
+  registro = CREATURES,
+  className = '',
+}) {
+  const limite = limiteAmbiental(tier, reducedMotion);
+  const cast = useMemo(
+    () => castAmbiental(central, registro, excluir || []),
+    [central, registro, excluir],
+  );
+  const [estado, setEstado] = useState(() => crearEstado(cast, limite));
+  const estadoRef = useRef(estado);
+  const raizRef = useRef(null);
+  /* Culling: fuera de pantalla o pestaña oculta → el reloj se detiene. */
+  const [enPantalla, setEnPantalla] = useState(true);
+  const [pestanaViva, setPestanaViva] = useState(
+    () => typeof document === 'undefined' || !document.hidden,
+  );
+
+  /* Si cambian cast o límite (avatar nuevo, tier), el pool se rearma limpio. */
+  useEffect(() => {
+    estadoRef.current = crearEstado(cast, limite);
+    setEstado(estadoRef.current);
+  }, [cast, limite]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+    const alCambiar = () => setPestanaViva(!document.hidden);
+    document.addEventListener('visibilitychange', alCambiar);
+    return () => document.removeEventListener('visibilitychange', alCambiar);
+  }, []);
+
+  useEffect(() => {
+    const el = raizRef.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return undefined;
+    const io = new IntersectionObserver(([entrada]) => setEnPantalla(entrada.isIntersecting));
+    io.observe(el);
+    return () => io.disconnect();
+  }, [limite]);
+
+  const corriendo = activo && enPantalla && pestanaViva && !reducedMotion && limite > 0;
+
+  /* El RELOJ del pool: una cadena de timeouts POR SLOT (independientes — cada
+     uno respira a su compás determinista). Pausa = cleanup; reanudar rearma la
+     fase actual completa. Nada corre fuera de pantalla. */
+  useEffect(() => {
+    if (!corriendo || estadoRef.current.slots.length === 0) return undefined;
+    let vivo = true;
+    const timers = new Array(estadoRef.current.slots.length);
+    const programar = (i) => {
+      timers[i] = setTimeout(() => {
+        if (!vivo) return;
+        estadoRef.current = avanzar(estadoRef.current, i);
+        setEstado(estadoRef.current);
+        programar(i);
+      }, duracionFase(estadoRef.current.slots[i], i));
+    };
+    estadoRef.current.slots.forEach((_, i) => programar(i));
+    return () => {
+      vivo = false;
+      timers.forEach(clearTimeout);
+    };
+  }, [corriendo, cast, limite]);
+
+  /* Reduced-motion o sin cupo/elenco: la capa NI SE MONTA (cero costo). */
+  if (limite === 0 || estado.slots.length === 0) return null;
+
+  return (
+    <div
+      ref={raizRef}
+      className={`fauna-amb${className ? ` ${className}` : ''}`}
+      aria-hidden="true"
+      data-tier={tier}
+      data-activo={activo ? '1' : '0'}
+    >
+      <style>{CSS_FAUNA_AMB}</style>
+      {estado.slots.map((slot, i) => {
+        const punto = puntos[i % puntos.length] || PUNTOS_DEFECTO[0];
+        const def = slot.slug ? registro[slot.slug] : null;
+        const Cuerpo = def?.Component;
+        const magico = esMagico(slot.slug);
+        return (
+          <div
+            key={i}
+            className="fauna-amb__slot"
+            data-fase={slot.fase}
+            data-gesto={slot.gesto}
+            data-slug={slot.slug || undefined}
+            data-entrada={ladoDePunto(punto)}
+            data-magico={magico ? '1' : undefined}
+            style={punto.estilo}
+          >
+            {Cuerpo && (
+              <div className="fauna-amb__gesto">
+                <div className={punto.voltear ? 'fauna-amb__cara fauna-amb__cara--voltea' : 'fauna-amb__cara'}>
+                  {/* LOD lejano: cuerpo ESTÁTICO (animated=false) — el gesto lo
+                      pone el wrapper. Solo el central, afuera, va full-detail. */}
+                  <Cuerpo size={punto.tam ?? 40} animated={false} title={def.nombre} />
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default FaunaAmbiental;

--- a/src/visual/creatures/__tests__/faunaAmbiental.test.jsx
+++ b/src/visual/creatures/__tests__/faunaAmbiental.test.jsx
@@ -1,0 +1,260 @@
+/**
+ * faunaAmbiental.test.jsx — el VALLE VIVO cumple sus reglas duras:
+ *   1. CAST data-driven: sale del registro (borugo/morrocoy entrarán solos),
+ *      excluye al central (el protagonista no se duplica) y a la microfauna.
+ *   2. CENTRAL manda: resolverCentral valida y cae a Angelita sin avatar.
+ *   3. LÍMITES por tier (alto 3 / medio 2 / bajo 1) y reduced-motion = 0.
+ *   4. POOL rotativo: nunca más de `limite` en escena, nunca repetidos,
+ *      y el ciclo descansa→entra→gesto→sale→descansa rota el elenco.
+ *   5. COHERENCIA de entradas: los animales vienen del bosque o los costados;
+ *      el ÚNICO mágico es el jaguar.
+ *   6. COMPONENTE: pooling real (nodos reusados), reduced-motion ni monta,
+ *      tier bajo un solo slot, y el central queda fuera del coro.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import {
+  castAmbiental,
+  resolverCentral,
+  limiteAmbiental,
+  crearEstado,
+  avanzar,
+  duracionFase,
+  enEscena,
+  esMagico,
+  GESTOS,
+  MAGICOS,
+  MICROFAUNA_EXCLUIDA,
+  CENTRAL_DEFECTO,
+  AMBIENTE_POR_TIER,
+} from '../faunaAmbiental.js';
+import { FaunaAmbiental } from '../FaunaAmbiental.jsx';
+import { CREATURES } from '../index.js';
+
+afterEach(cleanup);
+
+/* Un registro de juguete con componentes triviales (para el pool y el DOM). */
+const Bicho = ({ size = 40, title }) => (
+  <svg width={size} height={size} role="img" aria-label={title} />
+);
+const registroFake = (slugs) =>
+  Object.fromEntries(slugs.map((s) => [s, { Component: Bicho, nombre: s }]));
+
+describe('1. castAmbiental — data-driven desde el registro', () => {
+  it('excluye al central y a la microfauna decorativa; trae al resto', () => {
+    const cast = castAmbiental(CENTRAL_DEFECTO);
+    expect(cast).not.toContain(CENTRAL_DEFECTO);
+    MICROFAUNA_EXCLUIDA.forEach((m) => expect(cast).not.toContain(m));
+    // Los personajes reales del registro sí están (oso, jaguar, colibrí…).
+    expect(cast).toContain('oso-andino');
+    expect(cast).toContain('jaguar');
+    expect(cast).toContain('colibri');
+  });
+
+  it('un personaje NUEVO en el registro entra solo al elenco (borugo-proof)', () => {
+    const registro = { ...CREATURES, borugo: { Component: Bicho, nombre: 'Borugo' } };
+    expect(castAmbiental(CENTRAL_DEFECTO, registro)).toContain('borugo');
+  });
+
+  it('si el central es otro (oso), la abeja entra al coro y el oso sale', () => {
+    const cast = castAmbiental('oso-andino');
+    expect(cast).toContain('abeja-angelita');
+    expect(cast).not.toContain('oso-andino');
+  });
+
+  it('el morrocoy (recién aterrizado en CREATURES) ya está en el elenco', () => {
+    expect(castAmbiental(CENTRAL_DEFECTO)).toContain('morrocoy');
+  });
+
+  it('excluir saca extras del coro (Angelita donde ya es la acompañante)', () => {
+    const cast = castAmbiental('oso-andino', CREATURES, ['abeja-angelita']);
+    expect(cast).not.toContain('abeja-angelita');
+    expect(cast).not.toContain('oso-andino');
+    expect(cast).toContain('jaguar');
+  });
+});
+
+describe('2. resolverCentral — el protagonista con fallback a Angelita', () => {
+  it('slug válido → ese personaje, con su Component y nombre', () => {
+    const c = resolverCentral('jaguar');
+    expect(c.slug).toBe('jaguar');
+    expect(c.Component).toBe(CREATURES.jaguar.Component);
+    expect(c.nombre).toBe(CREATURES.jaguar.nombre);
+  });
+
+  it('sin avatar (null) o slug fantasma → Angelita (punto de integración listo)', () => {
+    expect(resolverCentral(null).slug).toBe(CENTRAL_DEFECTO);
+    expect(resolverCentral('bicho-fantasma').slug).toBe(CENTRAL_DEFECTO);
+    expect(resolverCentral(null).Component).toBe(CREATURES[CENTRAL_DEFECTO].Component);
+  });
+});
+
+describe('3. limiteAmbiental — el presupuesto duro por gama', () => {
+  it('alto=3, medio=2, bajo=1 (nunca saturar)', () => {
+    expect(limiteAmbiental('alto')).toBe(3);
+    expect(limiteAmbiental('medio')).toBe(2);
+    expect(limiteAmbiental('bajo')).toBe(1);
+  });
+
+  it('reduced-motion → CERO ambientales, en cualquier gama', () => {
+    expect(limiteAmbiental('alto', true)).toBe(0);
+    expect(limiteAmbiental('bajo', true)).toBe(0);
+  });
+
+  it('tier desconocido cae al perfil frugal (medio), jamás al caro', () => {
+    expect(limiteAmbiental('marciano')).toBe(AMBIENTE_POR_TIER.medio);
+  });
+});
+
+describe('4. el pool rotativo — invariantes bajo mil vueltas', () => {
+  const cast = ['colibri', 'oso-andino', 'rana-andina', 'perezoso', 'ardilla', 'jaguar'];
+
+  it('crearEstado arma min(limite, cast) slots, todos descansando', () => {
+    const e = crearEstado(cast, 3);
+    expect(e.slots).toHaveLength(3);
+    e.slots.forEach((s) => {
+      expect(s.fase).toBe('descansa');
+      expect(s.slug).toBeNull();
+    });
+    expect(crearEstado(['solo-uno'], 3).slots).toHaveLength(1);
+    expect(crearEstado([], 3).slots).toHaveLength(0);
+  });
+
+  it('NUNCA hay más de limite en escena ni slugs repetidos (500 vueltas)', () => {
+    let e = crearEstado(cast, 3);
+    for (let paso = 0; paso < 500; paso += 1) {
+      e = avanzar(e, paso % 3);
+      const visibles = enEscena(e);
+      expect(visibles.length).toBeLessThanOrEqual(3);
+      expect(new Set(visibles).size).toBe(visibles.length); // sin repetidos
+    }
+  });
+
+  it('el ciclo de un slot es descansa→entra→gesto→sale→descansa', () => {
+    let e = crearEstado(cast, 1);
+    const fases = [];
+    for (let k = 0; k < 4; k += 1) {
+      e = avanzar(e, 0);
+      fases.push(e.slots[0].fase);
+    }
+    expect(fases).toEqual(['entra', 'gesto', 'sale', 'descansa']);
+    expect(e.slots[0].slug).toBe('colibri'); // el slug se CONSERVA al descansar (pooling)
+  });
+
+  it('al re-entrar el slot ROTA de personaje (round-robin sobre el cast)', () => {
+    let e = crearEstado(cast, 1);
+    const vistos = [];
+    for (let ciclo = 0; ciclo < cast.length; ciclo += 1) {
+      e = avanzar(e, 0); // entra
+      vistos.push(e.slots[0].slug);
+      e = avanzar(e, 0); // gesto
+      e = avanzar(e, 0); // sale
+      e = avanzar(e, 0); // descansa
+    }
+    expect(new Set(vistos).size).toBe(cast.length); // pasó TODO el elenco
+  });
+
+  it('el gesto rota entre los tres y las duraciones son deterministas', () => {
+    let e = crearEstado(cast, 2);
+    e = avanzar(e, 0);
+    expect(GESTOS).toContain(e.slots[0].gesto);
+    expect(duracionFase(e.slots[0], 0)).toBeGreaterThan(0);
+    // El descanso se desfasa por slot: el slot 1 espera más que el 0.
+    const d0 = duracionFase({ fase: 'descansa', gen: 0 }, 0);
+    const d1 = duracionFase({ fase: 'descansa', gen: 0 }, 1);
+    expect(d1).toBeGreaterThan(d0);
+  });
+
+  it('avanzar es inmutable (el estado viejo no se toca)', () => {
+    const e = crearEstado(cast, 2);
+    const antes = JSON.stringify(e);
+    avanzar(e, 0);
+    expect(JSON.stringify(e)).toBe(antes);
+  });
+});
+
+describe('5. coherencia de entradas — solo el jaguar es mágico', () => {
+  it('el jaguar aparece mágico; el resto viene de un lado', () => {
+    expect(MAGICOS).toEqual(['jaguar']);
+    expect(esMagico('jaguar')).toBe(true);
+    expect(esMagico('oso-andino')).toBe(false);
+    expect(esMagico(null)).toBe(false);
+  });
+});
+
+describe('6. <FaunaAmbiental> — el DOM cumple el presupuesto', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const registro = registroFake([
+    'abeja-angelita', 'colibri', 'oso-andino', 'rana-andina', 'perezoso',
+  ]);
+
+  it('reduced-motion → la capa NI SE MONTA', () => {
+    const { container } = render(
+      <FaunaAmbiental tier="alto" reducedMotion registro={registro} />,
+    );
+    expect(container.querySelector('.fauna-amb')).toBeNull();
+  });
+
+  it('tier alto monta máximo 3 slots; tier bajo, 1', () => {
+    const a = render(<FaunaAmbiental tier="alto" registro={registro} />);
+    expect(a.container.querySelectorAll('.fauna-amb__slot')).toHaveLength(3);
+    a.unmount();
+    const b = render(<FaunaAmbiental tier="bajo" registro={registro} />);
+    expect(b.container.querySelectorAll('.fauna-amb__slot')).toHaveLength(1);
+  });
+
+  it('POOLING real: al rotar las fases se REUSAN los mismos nodos', () => {
+    const { container } = render(<FaunaAmbiental tier="alto" registro={registro} />);
+    const antes = Array.from(container.querySelectorAll('.fauna-amb__slot'));
+    act(() => {
+      vi.advanceTimersByTime(30000); // varias generaciones de rotación
+    });
+    const despues = Array.from(container.querySelectorAll('.fauna-amb__slot'));
+    expect(despues).toHaveLength(antes.length);
+    antes.forEach((nodo, i) => expect(despues[i]).toBe(nodo)); // el MISMO nodo
+  });
+
+  it('nunca hay más de 3 visibles y el central NO sale en el coro', () => {
+    const { container } = render(
+      <FaunaAmbiental tier="alto" central="abeja-angelita" registro={registro} />,
+    );
+    for (let paso = 0; paso < 12; paso += 1) {
+      act(() => {
+        vi.advanceTimersByTime(2500);
+      });
+      const visibles = Array.from(
+        container.querySelectorAll(".fauna-amb__slot[data-fase='entra'], .fauna-amb__slot[data-fase='gesto'], .fauna-amb__slot[data-fase='sale']"),
+      );
+      expect(visibles.length).toBeLessThanOrEqual(3);
+      visibles.forEach((v) => expect(v.getAttribute('data-slug')).not.toBe('abeja-angelita'));
+    }
+  });
+
+  it('cada slot declara su procedencia (izq/der/bosque) y el jaguar va mágico', () => {
+    const soloJaguar = registroFake(['abeja-angelita', 'jaguar']);
+    const { container } = render(
+      <FaunaAmbiental tier="bajo" central="abeja-angelita" registro={soloJaguar} />,
+    );
+    const slot = container.querySelector('.fauna-amb__slot');
+    expect(['izq', 'der', 'bosque']).toContain(slot.getAttribute('data-entrada'));
+    act(() => {
+      vi.advanceTimersByTime(3300); // el primer descanso (3200) vence → entra
+    });
+    expect(slot.getAttribute('data-fase')).toBe('entra');
+    expect(slot.getAttribute('data-slug')).toBe('jaguar');
+    expect(slot.getAttribute('data-magico')).toBe('1');
+  });
+
+  it('la capa es decorativa: aria-hidden y sin pointer-events', () => {
+    const { container } = render(<FaunaAmbiental tier="medio" registro={registro} />);
+    const capa = container.querySelector('.fauna-amb');
+    expect(capa.getAttribute('aria-hidden')).toBe('true');
+    expect(container.querySelectorAll('.fauna-amb__slot')).toHaveLength(2);
+  });
+});

--- a/src/visual/creatures/faunaAmbiental.js
+++ b/src/visual/creatures/faunaAmbiental.js
@@ -1,0 +1,204 @@
+/*
+ * faunaAmbiental — la LÓGICA PURA del valle vivo (cero React, cero three).
+ *
+ * EL NORTE: los personajes de la chagra HABITAN el valle y la galería de
+ * mundos, pero NO todos al tiempo. Unos aparecen, hacen UN gesto lejano de
+ * llamar la atención (un saltito, una seña con la manita, un guiño coqueto) y
+ * se van; otros entran a reemplazarlos. EL CENTRAL MANDA SIEMPRE: el avatar
+ * elegido por la persona es el protagonista en primer plano — los demás son
+ * ambiente periférico, más pequeños y suaves, y JAMÁS compiten con él.
+ *
+ * Este módulo es la fuente única de tres verdades:
+ *   1. EL CAST — data-driven desde el registro `CREATURES`: al aterrizar un
+ *      personaje nuevo (borugo, morrocoy…) entra SOLO al elenco ambiental,
+ *      sin tocar este archivo. La microfauna decorativa (lombriz/mariposa/
+ *      escarabajo) queda fuera: ella ya vive sembrada por FaunaEscena con
+ *      criterio ecológico, no hace giños de personaje.
+ *   2. EL CENTRAL — `resolverCentral(slug)` valida contra el registro y cae a
+ *      Angelita si no hay avatar elegido (o el hook `useAvatarCreature` aún
+ *      no aterriza). El central se EXCLUYE del cast ambiental: nadie se
+ *      duplica en escena.
+ *   3. EL RITMO — una máquina de estados PURA y determinista por slot
+ *      (descansa → entra → gesto → sale → descansa) con pooling: los slots
+ *      son fijos (máx 2–3 por tier), se REUSAN los nodos y solo se rota QUÉ
+ *      personaje los habita. Nada de spawnear/destruir sin parar.
+ *
+ * PERFORMANCE (requisito duro — "no carguen el mundo"):
+ *   - `limiteAmbiental(tier, reducedMotion)`: alto=3, medio=2, bajo=1, y con
+ *     reduced-motion CERO ambientales (a lo sumo el central quieto).
+ *   - Duraciones deterministas y desfasadas por slot: nunca entran todos a la
+ *     vez, nunca hay más de `limite` en pantalla.
+ *   - El componente (FaunaAmbiental.jsx) pausa los timers fuera de pantalla.
+ */
+import { CREATURES } from './index.js';
+
+/* La microfauna decorativa NO es personaje: ya la siembra FaunaEscena por rol
+   ecológico dentro de los dioramas. El elenco ambiental es de PERSONAJES. */
+export const MICROFAUNA_EXCLUIDA = ['lombriz', 'mariposa', 'escarabajo'];
+
+/* Sin avatar elegido, la protagonista es la insignia de Chagra. */
+export const CENTRAL_DEFECTO = 'abeja-angelita';
+
+/**
+ * El PROTAGONISTA: valida el slug contra el registro y cae a Angelita.
+ * PUNTO DE INTEGRACIÓN con el avatar elegido: cuando `useAvatarCreature()`
+ * aterrice en dev, el host le pasa su slug aquí — una línea y el central
+ * cambia en todos los mundos.
+ * @param {string|null} slug  el avatar elegido (o null si aún no hay).
+ * @param {object} [registro]  slug → { Component, nombre } (default CREATURES).
+ * @returns {{ slug: string, Component: Function, nombre: string }}
+ */
+export function resolverCentral(slug, registro = CREATURES) {
+  if (slug && registro[slug]) return { slug, ...registro[slug] };
+  return { slug: CENTRAL_DEFECTO, ...registro[CENTRAL_DEFECTO] };
+}
+
+/**
+ * El ELENCO ambiental: todos los personajes del registro MENOS el central
+ * (el protagonista no se duplica en el fondo) y la microfauna decorativa.
+ * Data-driven: borugo/morrocoy entran solos al aterrizar en CREATURES.
+ * @param {string} [centralSlug]
+ * @param {object} [registro]
+ * @param {string[]} [excluir]  slugs extra fuera del coro (p. ej. Angelita en
+ *   el valle, donde ella YA vuela en primer plano dentro de Valle3D).
+ * @returns {string[]} slugs del elenco, en el orden del registro.
+ */
+export function castAmbiental(centralSlug = CENTRAL_DEFECTO, registro = CREATURES, excluir = []) {
+  return Object.keys(registro).filter(
+    (s) => s !== centralSlug && !MICROFAUNA_EXCLUIDA.includes(s) && !excluir.includes(s),
+  );
+}
+
+/* Máximo de ambientales EN PANTALLA por gama (pedido del operador: 2–3, jamás
+   saturar; en gama baja uno solo, apenas compañía). */
+export const AMBIENTE_POR_TIER = { alto: 3, medio: 2, bajo: 1 };
+
+/**
+ * Cuántos ambientales caben sin cargar el mundo. Reduced-motion = CERO
+ * (sin entradas/salidas: a lo sumo el central quieto). Tier desconocido cae
+ * al perfil frugal, nunca al caro (misma filosofía de perfilDeTier).
+ */
+export function limiteAmbiental(tier = 'alto', reducedMotion = false) {
+  if (reducedMotion) return 0;
+  return AMBIENTE_POR_TIER[tier] ?? AMBIENTE_POR_TIER.medio;
+}
+
+/* Los GESTOS de llamar la atención, lejanos y breves (rubber-hose de lejos se
+   lee por silueta): saltito con squash, seña con la manita, asomo con guiño. */
+export const GESTOS = ['saltito', 'sena', 'guino'];
+
+/* COHERENCIA DE ENTRADAS (pedido del operador): los animales VIENEN de algún
+   lado — del bosque (asoman tras la vegetación del horizonte) o de los
+   costados de la pantalla — y se van por donde vinieron. El ÚNICO que aparece
+   MÁGICO (surge de la nada, como el espíritu del monte que es) es el jaguar. */
+export const MAGICOS = ['jaguar'];
+
+/** ¿Este personaje aparece mágico (sin venir de ningún lado)? */
+export const esMagico = (slug) => MAGICOS.includes(slug);
+
+/* El compás de cada fase (ms). El gesto es UNO y corto: chispa, no circo. */
+export const FASE_MS = { entra: 700, gesto: 2600, sale: 700 };
+/* El descanso base + el desfase por slot: los slots NUNCA respiran al unísono
+   (tres ondas co-primas de la coreografía de Angelita, versión de reloj). */
+export const DESCANSO_BASE_MS = 3200;
+export const DESCANSO_POR_SLOT_MS = 2100;
+export const DESCANSO_VARIACION_MS = 1300;
+
+/**
+ * El estado inicial del pool: `min(limite, cast)` slots FIJOS, todos
+ * descansando con generaciones desfasadas (i) para que la primera entrada
+ * sea escalonada, nunca un desembarco.
+ * @param {string[]} cast  slugs del elenco (castAmbiental).
+ * @param {number} limite  slots en escena (limiteAmbiental).
+ */
+export function crearEstado(cast, limite) {
+  const n = Math.max(0, Math.min(limite, cast.length));
+  return {
+    cast,
+    cursor: 0,
+    slots: Array.from({ length: n }, (_, i) => ({
+      slug: null,
+      fase: 'descansa',
+      gesto: GESTOS[i % GESTOS.length],
+      gen: i,
+    })),
+  };
+}
+
+/**
+ * Avanza UN slot a su siguiente fase (puro e inmutable — el estado viejo no
+ * se toca). Al pasar de descansa→entra el slot toma el SIGUIENTE personaje
+ * del cast (round-robin con cursor) que no esté ya en otro slot: en escena
+ * nunca hay repetidos. El slug se conserva durante `sale` y `descansa`
+ * (pooling: el nodo se apaga con fade, no se desmonta) y solo se SWAPEA al
+ * volver a entrar.
+ * @param {ReturnType<typeof crearEstado>} estado
+ * @param {number} i  índice del slot que cumplió su fase.
+ */
+export function avanzar(estado, i) {
+  const slots = estado.slots.slice();
+  const s = { ...slots[i] };
+  let cursor = estado.cursor;
+  if (s.fase === 'descansa') {
+    const ocupados = new Set(
+      slots.filter((x, j) => j !== i && x.slug).map((x) => x.slug),
+    );
+    for (let k = 0; k < estado.cast.length; k += 1) {
+      const slug = estado.cast[(cursor + k) % estado.cast.length];
+      if (!ocupados.has(slug)) {
+        s.slug = slug;
+        cursor = (cursor + k + 1) % estado.cast.length;
+        break;
+      }
+    }
+    s.fase = 'entra';
+    s.gen += 1;
+    /* El gesto rota por generación+slot: el mismo bicho no repite la misma
+       gracia dos veces seguidas, y dos slots vecinos no gesticulan igual. */
+    s.gesto = GESTOS[(s.gen + i) % GESTOS.length];
+  } else if (s.fase === 'entra') {
+    s.fase = 'gesto';
+  } else if (s.fase === 'gesto') {
+    s.fase = 'sale';
+  } else {
+    s.fase = 'descansa';
+  }
+  slots[i] = s;
+  return { ...estado, cursor, slots };
+}
+
+/**
+ * Cuánto dura la fase ACTUAL del slot (ms) — el timer que el componente arma
+ * antes de llamar `avanzar`. El descanso se alarga por slot y por generación
+ * (determinista): la rotación nunca cae en un compás de reloj.
+ */
+export function duracionFase(slot, i) {
+  if (slot.fase === 'entra') return FASE_MS.entra;
+  if (slot.fase === 'gesto') return FASE_MS.gesto;
+  if (slot.fase === 'sale') return FASE_MS.sale;
+  return (
+    DESCANSO_BASE_MS + i * DESCANSO_POR_SLOT_MS + (slot.gen % 3) * DESCANSO_VARIACION_MS
+  );
+}
+
+/** Los slugs VISIBLES ahora mismo (entra/gesto/sale — descansa ya se apagó). */
+export function enEscena(estado) {
+  return estado.slots
+    .filter((s) => s.slug && s.fase !== 'descansa')
+    .map((s) => s.slug);
+}
+
+/* Anclajes por defecto de la capa ambiental: bordes y banda del horizonte —
+   lejos del centro donde manda el protagonista. Cada host pasa los suyos.
+   COHERENCIA: `lado` dice DE DÓNDE VIENE el animal ('izq'/'der' = costado de
+   pantalla; 'bosque' = asoma tras la vegetación del horizonte, subiendo) y
+   por ahí mismo se va. Sin `lado`, se infiere del anclaje (right → 'der'). */
+export const PUNTOS_DEFECTO = [
+  { estilo: { left: '5%', top: '38%' }, tam: 46, lado: 'izq' },
+  { estilo: { right: '6%', top: '32%' }, tam: 40, voltear: true, lado: 'der' },
+  { estilo: { left: '34%', top: '24%' }, tam: 32, lado: 'bosque' },
+];
+
+/** De dónde viene el que ocupa este punto (fallback por anclaje). */
+export const ladoDePunto = (punto) =>
+  punto.lado || (punto.estilo?.right != null ? 'der' : 'izq');

--- a/src/visual/mundo3d/escenas/EscenaValle.jsx
+++ b/src/visual/mundo3d/escenas/EscenaValle.jsx
@@ -26,6 +26,22 @@
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Valle3D from '../../../mockups/valle/Valle3D.jsx';
+import { FaunaAmbiental } from '../../creatures/FaunaAmbiental.jsx';
+import useAvatarCreature from '../../../hooks/useAvatarCreature.js';
+
+/* EL VALLE VIVO: los personajes asoman A LO LEJOS (banda del horizonte y
+   bordes), hacen su giño y se van — nunca más de lo que el tier aguanta.
+   EL CENTRAL MANDA: el avatar elegido (useAvatarCreature) se RESERVA para el
+   protagonismo — jamás sale de extra en el coro. Angelita también queda fuera
+   SIEMPRE: ella ya vuela en primer plano DENTRO de Valle3D (CompaneroAbeja);
+   cuando ese acompañante se cable al avatar, esta exclusión sigue valiendo. */
+const PUNTOS_FAUNA_VALLE = [
+  { estilo: { left: '5%', top: '42%' }, tam: 44, lado: 'izq' },
+  { estilo: { right: '6%', top: '36%' }, tam: 38, voltear: true, lado: 'der' },
+  { estilo: { left: '32%', top: '28%' }, tam: 32, lado: 'bosque' },
+];
+/* Constante de módulo: identidad estable para el memo del elenco. */
+const EXCLUIR_FAUNA_VALLE = ['abeja-angelita'];
 
 /* Cuánto dura el clima "prestado" antes de volver solo al real. */
 const DURACION_TOQUE_MS = 9000;
@@ -80,6 +96,9 @@ export default function EscenaValle({
   estadoFinca = undefined, hayAlerta = false, // §5b: Angelita refleja el estado real también en el mapa
 }) {
   const climaReal = params?.clima || entrada?.clima || 'soleado';
+  /* El avatar elegido por la persona: se reserva para el protagonismo (el
+     coro ambiental lo excluye — el central manda, nadie lo duplica de extra). */
+  const avatar = useAvatarCreature();
   /* El clima "prestado" por el toque: null | 'lluvia' | 'dorada'. Mientras vive,
      pisa al real; el temporizador SIEMPRE lo devuelve (honestidad estructural). */
   const [toque, setToque] = useState(null);
@@ -131,6 +150,17 @@ export default function EscenaValle({
         onAlerta={() => onHotspot?.(entrada?.alertaView || 'hoy_finca')}
       />
       <div className="cielotoque__capa">
+        {/* El coro ambiental: personajes que vienen del bosque o los costados,
+            hacen UN gesto de llamar la atención y se van (pool rotativo,
+            tier-safe, pausa fuera de pantalla). Solo el jaguar aparece mágico.
+            Va primero: los botones del cielo quedan encima. */}
+        <FaunaAmbiental
+          central={avatar.id}
+          excluir={EXCLUIR_FAUNA_VALLE}
+          tier={tier}
+          reducedMotion={reducedMotion}
+          puntos={PUNTOS_FAUNA_VALLE}
+        />
         <div className="cielotoque__brillo" aria-hidden="true" />
         {conGotas && gotas.map((g, i) => (
           <span


### PR DESCRIPTION
## El valle vivo

Los personajes de `CREATURES` habitan el **valle 3D** (`EscenaValle`) y la **galería de mundos** (`VitrinaMaestraMundos`): asoman a lo lejos, hacen UN gesto de llamar la atención y se van. **El central manda siempre** — el avatar elegido es el protagonista al frente; el coro es periférico, chiquito y suave.

## Qué trae
- **`src/visual/creatures/faunaAmbiental.js`** — lógica PURA: cast data-driven desde el registro (morrocoy ya entra solo; borugo entrará igual), `resolverCentral` con fallback a Angelita, límites por tier, máquina de estados determinista del pool (descansa→entra→gesto→sale) e inmutable.
- **`src/visual/creatures/FaunaAmbiental.jsx`** — overlay DOM puro (cero three): slots fijos reutilizados, gestos CSS transform-only (saltito rubber-hose con squash, seña con la manita, guiño/asomo).
- **Coherencia de entradas** (pedido del operador): cada punto declara procedencia — `izq`/`der` (costados de pantalla) o `bosque` (asoma subiendo tras la vegetación) — y el animal **se va por donde vino**. El ÚNICO que aparece mágico es el **jaguar** (se condensa de la nada, espíritu del monte).
- **Central = avatar elegido**: cableado REAL a `useAvatarCreature` (#2435, aterrizó durante esta tarea). En la vitrina el protagonista heroico y el clon de la picada son el avatar; en el valle Angelita sigue al frente dentro de `Valle3D` y el coro la excluye siempre (nadie se duplica).

## Performance (requisito duro)
- **Límite concurrente**: alto=3, medio=2, bajo=1; `data-tier='bajo'` además apaga los gestos (queda solo el fade).
- **Pooling**: nodos de slot FIJOS y reutilizados; el personaje solo se swapea al re-entrar (~cada 8–12 s). Test verifica identidad de nodos tras 30 s de rotación.
- **LOD**: ambientales con `animated={false}` → SVG estático sin boil/filtros/aleteo; solo el gesto del wrapper anima (composición pura). Solo el central va full-detail.
- **reduced-motion**: la capa NI SE MONTA (límite 0).
- **Culling**: timers pausados fuera de pantalla (IntersectionObserver), pestaña oculta (visibilitychange) y durante el viaje de túnel (`activo={false}` — la GPU va en el dolly).

## Verificación
- `npm run build` verde (tras rebase a dev actual; la base vieja tenía `creatures.css` roto, corregido por #2434).
- `npx vitest run` → 32/32 (fauna nueva + smoke de mundos): límites por tier, pool sin repetidos en 500 vueltas, rotación de todo el elenco, pooling de nodos real, fallback del central, jaguar mágico, exclusiones.
- eslint limpio en lo nuevo (el error `usePulso` de la vitrina es preexistente en dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)