### PR TITLE
feat(red): UI de la red humana campesino↔campesino

### DIFF
--- a/src/components/MercadosScreen.jsx
+++ b/src/components/MercadosScreen.jsx
@@ -6,8 +6,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Store, Plus, Search, MapPin, Phone, Trash2, ArrowLeft, Tag, Info,
-  Sprout, AlertCircle, CheckCircle2,
+  Sprout, AlertCircle, CheckCircle2, Users, Handshake,
 } from 'lucide-react';
+import RedVecinosPanel from './red/RedVecinosPanel';
+import CierreTratoSheet from './red/CierreTratoSheet';
 import { ScreenShell } from './common/ScreenShell';
 import EmptyStateCampo from './common/EmptyStateCampo.jsx';
 import ErrorStateCampo from './common/ErrorStateCampo.jsx';
@@ -55,7 +57,7 @@ import {
  * @param {(pregunta: string) => void} [props.onAskAgent] - opcional, puente al agente desde la vista "Vender mejor".
  */
 export default function MercadosScreen({ onBack, onNavigate: _onNavigate }) {
-  const [tab, setTab] = useState('explorar'); // 'explorar' | 'publicar'
+  const [tab, setTab] = useState('explorar'); // 'explorar' | 'publicar' | 'vecinos'
   const [publicadas, setPublicadas] = useState([]);
   const [cargando, setCargando] = useState(true);
   const [errorCarga, setErrorCarga] = useState(false);
@@ -154,6 +156,19 @@ export default function MercadosScreen({ onBack, onNavigate: _onNavigate }) {
           >
             <Plus size={16} /> Publicar
           </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'vecinos'}
+            onClick={() => setTab('vecinos')}
+            className={`flex-1 min-h-[44px] rounded-lg font-bold text-sm flex items-center justify-center gap-2 transition-colors ${
+              tab === 'vecinos'
+                ? 'bg-emerald-600 text-white'
+                : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+            }`}
+          >
+            <Users size={16} /> Vecinos
+          </button>
         </div>
 
         {tab === 'explorar' && (
@@ -176,6 +191,10 @@ export default function MercadosScreen({ onBack, onNavigate: _onNavigate }) {
         {tab === 'publicar' && (
           <PublicarPanel onPublicada={handlePublicada} onCancelar={() => setTab('explorar')} />
         )}
+
+        {/* RED humana campesino↔campesino: el mercado es la puerta de la red
+            (los tratos alimentan grafo + reputación), por eso vive aquí. */}
+        {tab === 'vecinos' && <RedVecinosPanel />}
       </div>
 
       {detalle && (
@@ -367,6 +386,10 @@ function DetalleOferta({ oferta, onClose, onEliminar }) {
   const ref = resolverPrecioReferencia(oferta.producto);
   const precio = formatearCOP(oferta.precio);
   const cat = CATEGORIAS.find((c) => c.id === oferta.categoria);
+  // RED humana: paso de cierre "¿se concretó el negocio?" — el gesto que
+  // alimenta el grafo social + la reputación (services/red). Solo para
+  // ofertas PROPIAS: el productor registra su propio trato.
+  const [cerrandoTrato, setCerrandoTrato] = useState(false);
 
   return (
     <div
@@ -444,6 +467,19 @@ function DetalleOferta({ oferta, onClose, onEliminar }) {
             Chagra no procesa pagos ni garantiza la transacción.
           </p>
 
+          {/* Cierre de trato (solo ofertas propias): alimenta la RED humana —
+              de este registro salen el grafo social y la reputación ganada. */}
+          {!oferta.demo && (
+            <button
+              type="button"
+              onClick={() => setCerrandoTrato(true)}
+              data-testid="abrir-cierre-trato"
+              className="w-full min-h-[48px] rounded-xl border border-emerald-500/40 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-300 font-bold text-sm flex items-center justify-center gap-2"
+            >
+              <Handshake size={16} /> ¿Ya vendió? Registrar el trato
+            </button>
+          )}
+
           {/* Retirar publicación (solo ofertas propias, no ejemplos) */}
           {!oferta.demo && (
             <button
@@ -456,6 +492,10 @@ function DetalleOferta({ oferta, onClose, onEliminar }) {
           )}
         </div>
       </div>
+
+      {cerrandoTrato && (
+        <CierreTratoSheet oferta={oferta} onClose={() => setCerrandoTrato(false)} />
+      )}
     </div>
   );
 }

--- a/src/components/red/CierreTratoSheet.jsx
+++ b/src/components/red/CierreTratoSheet.jsx
@@ -1,0 +1,207 @@
+/* i18n (ADR-050): etiquetas user-facing en español Colombia — mismo criterio
+ * de archivo que MercadosScreen. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { useState } from 'react';
+import {
+  ArrowLeft, CheckCircle2, Star, Handshake, AlertCircle,
+} from 'lucide-react';
+import useRedStore from '../../store/useRedStore';
+import { ENTREGA, SHARE_LEVEL } from '../../services/red';
+import NivelCompartirSwitch from './NivelCompartirSwitch';
+
+/**
+ * CierreTratoSheet — "¿Se concretó el negocio?": el paso de CIERRE de un trato
+ * del mercado. Es el gesto mínimo que alimenta TODA la red humana: de este
+ * registro salen el grafo social y la reputación ganada (mercado → grafo,
+ * services/red/README.md). Sin pedir nada extra: producto, vereda y cantidad
+ * ya vienen de la oferta.
+ *
+ * Tres preguntas, ninguna obligatoria de más:
+ *   1. ¿Cómo terminó la entrega? (el hecho verificable)
+ *   2. ¿Cómo calificaron la calidad? (opcional, 1..5 — o nada, nunca se inventa)
+ *   3. ¿Con quién comparte este trato? (compuerta opt-in; nace PRIVADO)
+ *
+ * @param {Object} props
+ * @param {Object} props.oferta - la oferta del mercado que originó el trato.
+ * @param {() => void} props.onClose
+ * @param {(trato:Object) => void} [props.onRegistrado]
+ */
+
+const ENTREGA_OPCIONES = [
+  { valor: ENTREGA.ENTREGADO, label: 'Sí, entregué el producto' },
+  { valor: ENTREGA.PARCIAL, label: 'Entregué una parte' },
+  { valor: ENTREGA.NO_ENTREGADO, label: 'No se dio la entrega' },
+  { valor: ENTREGA.PENDIENTE, label: 'Cerramos el trato, entrega pendiente' },
+];
+
+export default function CierreTratoSheet({ oferta, onClose, onRegistrado }) {
+  const registrarTrato = useRedStore((s) => s.registrarTrato);
+  const [entrega, setEntrega] = useState(ENTREGA.ENTREGADO);
+  const [calidad, setCalidad] = useState(/** @type {number|null} */ (null));
+  const [shareLevel, setShareLevel] = useState(SHARE_LEVEL.PRIVADO);
+  const [guardando, setGuardando] = useState(false);
+  const [error, setError] = useState(/** @type {string|null} */ (null));
+  const [registrado, setRegistrado] = useState(false);
+
+  const handleRegistrar = async () => {
+    setGuardando(true);
+    setError(null);
+    const trato = await registrarTrato({ oferta, entrega, calidad, shareLevel });
+    setGuardando(false);
+    if (!trato) {
+      setError('No se pudo guardar el trato. Su registro no se perdió: intente de nuevo.');
+      return;
+    }
+    setRegistrado(true);
+    if (onRegistrado) onRegistrado(trato);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] bg-black/70 flex items-end sm:items-center justify-center p-0 sm:p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Registrar el trato de ${oferta?.producto || 'su producto'}`}
+      onClick={(e) => {
+        // stopPropagation: este sheet puede vivir DENTRO del backdrop de
+        // DetalleOferta (que también cierra al click) — cerrar el sheet no
+        // debe cerrar el detalle de la oferta.
+        e.stopPropagation();
+        onClose();
+      }}
+    >
+      <div
+        className="w-full sm:max-w-md bg-slate-900 rounded-t-2xl sm:rounded-2xl border border-slate-700 max-h-[90dvh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-slate-800 sticky top-0 bg-slate-900 z-10">
+          <button type="button" onClick={onClose} aria-label="Cerrar" className="p-2 -ml-2 text-slate-400 hover:text-white">
+            <ArrowLeft size={20} />
+          </button>
+          <span className="font-bold text-white text-sm truncate px-2 flex items-center gap-2">
+            <Handshake size={16} className="text-emerald-400" aria-hidden="true" /> ¿Se concretó el negocio?
+          </span>
+          <span className="w-8" />
+        </div>
+
+        {registrado ? (
+          <div className="p-4 space-y-4" data-testid="trato-registrado">
+            <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-4 text-center">
+              <CheckCircle2 size={28} className="text-emerald-400 mx-auto" aria-hidden="true" />
+              <p className="text-white font-bold mt-2">Trato registrado en su cuaderno.</p>
+              <p className="text-slate-300 text-sm mt-1 leading-snug">
+                {shareLevel >= SHARE_LEVEL.PARES
+                  ? 'Como lo compartió con los vecinos, este trato ya ayuda a que otro campesino lo encuentre cuando busque quién cultiva lo mismo cerca.'
+                  : 'Quedó privado en su teléfono. Cuando quiera, puede compartirlo con los vecinos para que la red lo conozca.'}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="w-full min-h-[48px] rounded-xl bg-emerald-600 hover:bg-emerald-500 text-white font-bold"
+            >
+              Listo
+            </button>
+          </div>
+        ) : (
+          <div className="p-4 space-y-5">
+            <p className="text-sm text-slate-300 leading-snug">
+              Registre cómo terminó el trato de <strong className="text-white">{oferta?.producto}</strong>.
+              Con esto su palabra queda respaldada por hechos, y los vecinos de la
+              red pueden confiar en usted sin conocerlo todavía.
+            </p>
+
+            {/* 1. La entrega: el hecho verificable que gana fiabilidad. */}
+            <fieldset>
+              <legend className="text-sm font-semibold text-slate-200 mb-2">¿Cómo terminó la entrega?</legend>
+              <div className="space-y-1.5" role="radiogroup" aria-label="Resultado de la entrega">
+                {ENTREGA_OPCIONES.map((op) => (
+                  <button
+                    key={op.valor}
+                    type="button"
+                    role="radio"
+                    aria-checked={entrega === op.valor}
+                    onClick={() => setEntrega(op.valor)}
+                    data-testid={`entrega-${op.valor}`}
+                    className={`w-full min-h-[44px] rounded-lg border px-3 py-2 text-left text-sm font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 ${
+                      entrega === op.valor
+                        ? 'border-emerald-500 bg-emerald-600/20 text-emerald-200'
+                        : 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700'
+                    }`}
+                  >
+                    {op.label}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+
+            {/* 2. Calidad calificada (opcional — nunca se inventa). */}
+            <fieldset>
+              <legend className="text-sm font-semibold text-slate-200 mb-1">
+                ¿Cómo calificó el comprador la calidad? <span className="text-slate-500 font-normal">(opcional)</span>
+              </legend>
+              <div className="flex items-center gap-1" role="radiogroup" aria-label="Calificación de calidad, de 1 a 5">
+                {[1, 2, 3, 4, 5].map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    role="radio"
+                    aria-checked={calidad === n}
+                    aria-label={`${n} de 5`}
+                    onClick={() => setCalidad(calidad === n ? null : n)}
+                    data-testid={`calidad-${n}`}
+                    className="p-2 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+                  >
+                    <Star
+                      size={22}
+                      aria-hidden="true"
+                      className={calidad != null && n <= calidad ? 'text-amber-400 fill-amber-400' : 'text-slate-600'}
+                    />
+                  </button>
+                ))}
+                {calidad != null && (
+                  <span className="text-xs text-slate-400 ml-1">{calidad} de 5</span>
+                )}
+              </div>
+              <p className="text-[11px] text-slate-500 mt-1 leading-snug">
+                Si no se la calificaron, déjelo vacío. Un dato en blanco es más
+                honesto que uno inventado.
+              </p>
+            </fieldset>
+
+            {/* 3. La compuerta: con quién comparte este trato. */}
+            <fieldset>
+              <legend className="text-sm font-semibold text-slate-200 mb-2">¿Con quién comparte este trato?</legend>
+              <NivelCompartirSwitch value={shareLevel} onChange={setShareLevel} />
+            </fieldset>
+
+            {error && (
+              <p className="text-rose-400 text-sm flex items-center gap-1.5" data-testid="trato-error">
+                <AlertCircle size={14} aria-hidden="true" /> {error}
+              </p>
+            )}
+
+            <div className="flex gap-2 pt-1">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 min-h-[48px] rounded-xl bg-slate-800 hover:bg-slate-700 text-slate-300 font-bold"
+              >
+                Ahora no
+              </button>
+              <button
+                type="button"
+                onClick={handleRegistrar}
+                disabled={guardando}
+                data-testid="registrar-trato"
+                className="flex-1 min-h-[48px] rounded-xl bg-emerald-600 hover:bg-emerald-500 disabled:opacity-60 text-white font-bold flex items-center justify-center gap-2"
+              >
+                <CheckCircle2 size={18} aria-hidden="true" /> {guardando ? 'Guardando…' : 'Registrar el trato'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/red/NivelCompartirSwitch.jsx
+++ b/src/components/red/NivelCompartirSwitch.jsx
@@ -1,0 +1,87 @@
+import { Lock, Users, BookOpenCheck, ShieldCheck } from 'lucide-react';
+import { SHARE_LEVEL, SHARE_LEVEL_COPY } from '../../services/red';
+
+/**
+ * NivelCompartirSwitch — la COMPUERTA opt-in de 3 niveles de la red humana
+ * (privado → con los vecinos → saber comunitario). Es el control con el que el
+ * productor decide, paso a paso, cuánto de su trato sale del dispositivo.
+ *
+ * Reglas que este control hace visibles (services/red/README.md):
+ *   - El dato nace PRIVADO. Nadie lo abre por él.
+ *   - En "Con los vecinos" NADA privado cruza: el comprador se anonimiza
+ *     (redactForPeers) y solo viajan los hechos del trato.
+ *   - "Saber comunitario" (nivel 3) se muestra pero está deshabilitado: lo
+ *     canoniza un sabedor de la comunidad, no un botón — el MVP opera en 1–2.
+ *
+ * Accesible: radiogroup real, foco visible, sin animación (reduced-motion safe).
+ *
+ * @param {Object} props
+ * @param {number} props.value - SHARE_LEVEL.* actual.
+ * @param {(nivel:number) => void} props.onChange
+ * @param {boolean} [props.disabled]
+ */
+export default function NivelCompartirSwitch({ value, onChange, disabled = false }) {
+  const niveles = [
+    { nivel: SHARE_LEVEL.PRIVADO, Icon: Lock, habilitado: true },
+    { nivel: SHARE_LEVEL.PARES, Icon: Users, habilitado: true },
+    // Nivel 3 se MODELA pero no se ejecuta en el MVP: lo activa un sabedor.
+    { nivel: SHARE_LEVEL.CANONIZADO, Icon: BookOpenCheck, habilitado: false },
+  ];
+  const copyActual = SHARE_LEVEL_COPY[value] || SHARE_LEVEL_COPY[SHARE_LEVEL.PRIVADO];
+
+  return (
+    <div data-testid="nivel-compartir">
+      <div
+        role="radiogroup"
+        aria-label="¿Con quién comparte este trato?"
+        className="grid grid-cols-3 gap-1.5"
+      >
+        {niveles.map((op) => {
+          const { nivel, habilitado } = op;
+          const IconNivel = op.Icon;
+          const activo = value === nivel;
+          const copy = SHARE_LEVEL_COPY[nivel];
+          return (
+            <button
+              key={nivel}
+              type="button"
+              role="radio"
+              aria-checked={activo}
+              disabled={disabled || !habilitado}
+              onClick={() => habilitado && onChange(nivel)}
+              data-testid={`nivel-compartir-${nivel}`}
+              title={habilitado ? copy.explica : 'Este nivel lo activa un sabedor de la comunidad. Todavía no está disponible.'}
+              className={`min-h-[56px] rounded-lg border px-2 py-2 flex flex-col items-center justify-center gap-1 text-xs font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 ${
+                activo
+                  ? 'border-emerald-500 bg-emerald-600/20 text-emerald-200'
+                  : habilitado
+                    ? 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700'
+                    : 'border-slate-800 bg-slate-900 text-slate-600 cursor-not-allowed'
+              }`}
+            >
+              <IconNivel size={15} aria-hidden="true" />
+              {copy.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Qué significa el nivel elegido — en las palabras de la compuerta. */}
+      <p className="text-xs text-slate-400 leading-snug mt-2" data-testid="nivel-compartir-explica">
+        {copyActual.explica}
+      </p>
+
+      {/* La promesa anti-extractiva, siempre visible cuando se comparte. */}
+      {value === SHARE_LEVEL.PARES && (
+        <p className="text-[11px] text-slate-500 leading-snug mt-1.5 flex gap-1.5">
+          <ShieldCheck size={13} className="shrink-0 mt-0.5 text-emerald-500/70" aria-hidden="true" />
+          <span>
+            Con los vecinos solo viajan los hechos del trato: producto, vereda,
+            entrega y calidad. El nombre del comprador y sus notas privadas
+            <strong> nunca</strong> salen de su teléfono. Este saber no se vende.
+          </span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/red/PreguntarVecinoPanel.jsx
+++ b/src/components/red/PreguntarVecinoPanel.jsx
@@ -1,0 +1,207 @@
+import { useMemo, useState } from 'react';
+import {
+  Search, Phone, MapPin, ClipboardCopy, Sprout, Info,
+} from 'lucide-react';
+import useRedStore from '../../store/useRedStore';
+import { marketplaceOfertas } from '../../db/marketplaceOfertas';
+import { getProfile } from '../../services/userProfileService';
+import { NIVEL_REPUTACION_COPY } from './reputacionCopy';
+import { encontrarContactoPublico } from './contactoPublico';
+
+/**
+ * PreguntarVecinoPanel — "Pregúntele al vecino": la vista donde una duda de
+ * cultivo se rutea al PAR competente y cercano de la red (redMatchmaking).
+ *
+ * La IA aquí es PUENTE, no reemplazo del saber campesino: Chagra no responde
+ * la duda — encuentra al vecino que ya DEMOSTRÓ éxito con ese cultivo en
+ * tratos reales del mercado, y le arma el mensaje para que hablen entre
+ * personas. El agente engancha este mismo flujo cuando no sabe
+ * (agentConfident:false) o cuando la duda es local-específica.
+ *
+ * Privacidad (inviolable): el teléfono del vecino SOLO aparece si él mismo lo
+ * expuso público en una oferta del mercado (opt-in). Sin ese consentimiento se
+ * entrega el mensaje sugerido para llevarlo al encuentro — nunca un número.
+ *
+ * @param {Object} props
+ * @param {string} [props.productoInicial] - prellenar el cultivo de la duda.
+ */
+
+export default function PreguntarVecinoPanel({ productoInicial = '' }) {
+  const preguntarAlVecino = useRedStore((s) => s.preguntarAlVecino);
+  const abrirCanal = useRedStore((s) => s.abrirCanal);
+  const perfil = useMemo(() => getProfile(), []);
+
+  const [producto, setProducto] = useState(productoInicial);
+  const [sintoma, setSintoma] = useState('');
+  const [buscando, setBuscando] = useState(false);
+  const [decision, setDecision] = useState(/** @type {Object|null} */ (null));
+  const [contacto, setContacto] = useState(/** @type {Object|null} */ (null));
+  const [mensaje, setMensaje] = useState('');
+  const [copiado, setCopiado] = useState(false);
+
+  const handleBuscar = async () => {
+    const q = producto.trim();
+    if (!q) return;
+    setBuscando(true);
+    setCopiado(false);
+    // agentConfident:false — quien busca aquí YA decidió preguntarle a una
+    // persona, no al modelo. La decisión de ruteo excluye al propio operador.
+    const dec = await preguntarAlVecino({
+      producto: q,
+      vereda: perfil?.vereda || '',
+      municipio: perfil?.municipio || perfil?.departamento || '',
+      sintoma: sintoma.trim(),
+      agentConfident: false,
+    });
+    setDecision(dec);
+    setMensaje(dec?.mensajeSugerido || '');
+    if (dec?.peer) {
+      try {
+        const ofertas = await marketplaceOfertas.getAll();
+        setContacto(encontrarContactoPublico(dec.peer, ofertas));
+      } catch {
+        setContacto(null); // sin ofertas legibles no hay contacto — se degrada al mensaje
+      }
+    } else {
+      setContacto(null);
+    }
+    setBuscando(false);
+  };
+
+  const handleCopiar = async () => {
+    try {
+      await navigator.clipboard.writeText(mensaje);
+      setCopiado(true);
+    } catch {
+      setCopiado(false);
+    }
+  };
+
+  const peer = decision?.peer || null;
+  const canal = peer && contacto ? abrirCanal(contacto, { mensaje }) : null;
+  const nivelCopy = peer ? (NIVEL_REPUTACION_COPY[peer.nivel] || null) : null;
+
+  return (
+    <div className="space-y-4" data-testid="preguntar-vecino">
+      {/* La duda: cultivo + qué está pasando. */}
+      <div className="space-y-3">
+        <label className="block">
+          <span className="block text-sm font-semibold text-slate-200 mb-1.5">¿Sobre qué cultivo tiene la duda?</span>
+          <input
+            type="text"
+            value={producto}
+            onChange={(e) => setProducto(e.target.value)}
+            placeholder="Ej: tomate, mora, café…"
+            aria-label="Cultivo de la duda"
+            className="w-full px-3 py-2.5 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500 text-sm min-h-[44px] focus:border-emerald-500 focus:outline-none"
+          />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-semibold text-slate-200 mb-1.5">
+            ¿Qué está pasando? <span className="text-slate-500 font-normal">(opcional)</span>
+          </span>
+          <input
+            type="text"
+            value={sintoma}
+            onChange={(e) => setSintoma(e.target.value)}
+            placeholder="Ej: se le amarillan las hojas de abajo…"
+            aria-label="Síntoma o duda"
+            className="w-full px-3 py-2.5 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500 text-sm min-h-[44px] focus:border-emerald-500 focus:outline-none"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={handleBuscar}
+          disabled={buscando || !producto.trim()}
+          data-testid="buscar-vecino"
+          className="w-full min-h-[48px] rounded-xl bg-emerald-600 hover:bg-emerald-500 disabled:opacity-60 text-white font-bold flex items-center justify-center gap-2"
+        >
+          <Search size={17} aria-hidden="true" /> {buscando ? 'Buscando…' : 'Buscar un vecino que sepa'}
+        </button>
+      </div>
+
+      {/* La decisión de ruteo, honesta en ambos sentidos. */}
+      {decision && !peer && (
+        <div className="rounded-lg border border-slate-700 bg-slate-800/60 p-3 flex gap-2 text-sm text-slate-300" data-testid="sin-vecino">
+          <Sprout size={16} className="text-slate-400 shrink-0 mt-0.5" aria-hidden="true" />
+          <span>
+            Todavía no hay en la red un vecino que haya <strong>demostrado</strong> experiencia
+            con ese cultivo. No le vamos a inventar un contacto: la red crece con
+            cada trato que los vecinos registran y comparten en el mercado.
+          </span>
+        </div>
+      )}
+
+      {peer && (
+        <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-3 space-y-3" data-testid="vecino-sugerido">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="font-bold text-white text-sm">
+                Hay un vecino {peer.proximidadLabel} que ya cultivó {peer.producto}.
+              </p>
+              <p className="text-slate-400 text-xs mt-0.5 flex items-center gap-1">
+                <MapPin size={11} aria-hidden="true" />
+                {[peer.vereda, peer.municipio].filter(Boolean).join(', ') || 'Ubicación sin registrar'}
+                {' · '}{peer.nTransacciones} trato{peer.nTransacciones === 1 ? '' : 's'} en la red
+              </p>
+            </div>
+            {nivelCopy && (
+              <span className={`shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded-full border text-[11px] font-bold ${nivelCopy.chip}`}>
+                <nivelCopy.Icon size={12} aria-hidden="true" /> {nivelCopy.label}
+              </span>
+            )}
+          </div>
+
+          {/* El mensaje es de usted, no del modelo: editable antes de enviar. */}
+          <label className="block">
+            <span className="block text-xs font-semibold text-slate-300 mb-1">Su mensaje (revíselo y ajústelo si quiere)</span>
+            <textarea
+              value={mensaje}
+              onChange={(e) => setMensaje(e.target.value)}
+              rows={4}
+              aria-label="Mensaje para el vecino"
+              className="w-full px-3 py-2 rounded-lg bg-slate-800 border border-slate-700 text-white text-sm leading-snug resize-none focus:border-emerald-500 focus:outline-none"
+            />
+          </label>
+
+          {canal ? (
+            <a
+              href={canal.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid="abrir-canal"
+              className="w-full min-h-[48px] rounded-xl bg-emerald-600 hover:bg-emerald-500 text-white font-bold flex items-center justify-center gap-2"
+            >
+              <Phone size={17} aria-hidden="true" /> Escribirle por WhatsApp
+            </a>
+          ) : (
+            <div className="space-y-2">
+              <div className="rounded-lg border border-slate-700 bg-slate-800/60 p-3 flex gap-2 text-xs text-slate-300" data-testid="sin-contacto">
+                <Info size={14} className="text-slate-400 shrink-0 mt-0.5" aria-hidden="true" />
+                <span>
+                  Este vecino no ha compartido un teléfono público, y Chagra no
+                  entrega números sin permiso. Lleve el mensaje al mercado
+                  campesino o a la agrofería y pregúntele en persona.
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={handleCopiar}
+                data-testid="copiar-mensaje"
+                className="w-full min-h-[44px] rounded-lg border border-slate-600 bg-slate-800 hover:bg-slate-700 text-slate-200 font-semibold text-sm flex items-center justify-center gap-2"
+              >
+                <ClipboardCopy size={15} aria-hidden="true" /> {copiado ? 'Mensaje copiado' : 'Copiar el mensaje'}
+              </button>
+            </div>
+          )}
+
+          <p className="text-[11px] text-slate-500 leading-snug">
+            Chagra solo hace el puente: la respuesta es del vecino y la
+            conversación es entre ustedes. Preguntar y responder aquí no cuesta
+            ni paga — el saber no se vende.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/red/RedVecinosPanel.jsx
+++ b/src/components/red/RedVecinosPanel.jsx
@@ -1,0 +1,95 @@
+/* i18n (ADR-050): etiquetas user-facing en español Colombia — mismo criterio
+ * de archivo que MercadosScreen. */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { useEffect, useMemo } from 'react';
+import { Users, Handshake } from 'lucide-react';
+import useRedStore from '../../store/useRedStore';
+import { getCurrentOperatorHash } from '../../services/operatorIdentityService';
+import PreguntarVecinoPanel from './PreguntarVecinoPanel';
+import ReputacionCard from './ReputacionCard';
+
+/**
+ * RedVecinosPanel — el tab "Vecinos" del mercado: la cara de la RED humana.
+ *
+ * El mercado es la puerta de la red (DR de red groundeado): cada trato
+ * registrado ya dice quién cultiva qué y cómo cumple — por eso esta vista vive
+ * DENTRO del mercado y no en una pantalla aparte. Dos superficies:
+ *
+ *   1. "Pregúntele al vecino" — rutear una duda al par que demostró saber.
+ *   2. "Así lo ve la red a usted" — su reputación GANADA por cultivo (los
+ *      mismos semáforos que ven los vecinos: sin sorpresas ni letra menuda).
+ *
+ * Nada aquí monetiza el saber; la única superficie de dinero sigue siendo la
+ * compra-venta del mercado.
+ */
+export default function RedVecinosPanel() {
+  const reputaciones = useRedStore((s) => s.reputaciones);
+  const grafo = useRedStore((s) => s.grafo);
+  const isLoading = useRedStore((s) => s.isLoading);
+  const cargar = useRedStore((s) => s.cargar);
+
+  useEffect(() => {
+    // Hidratar derivadas al montar (async vía IndexedDB — mismo patrón
+    // "cargar al montar" de MercadosScreen.recargar).
+    cargar();
+  }, [cargar]);
+
+  const miHash = getCurrentOperatorHash() || '';
+  const mias = useMemo(
+    () => reputaciones.filter((r) => r.productorHash === miHash),
+    [reputaciones, miHash],
+  );
+
+  return (
+    <div className="space-y-6" data-testid="red-vecinos">
+      {/* Encuadre: la red es entre personas; la IA solo tiende el puente. */}
+      <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-3 flex gap-2.5">
+        <Users className="text-emerald-400 shrink-0 mt-0.5" size={18} aria-hidden="true" />
+        <p className="text-sm text-emerald-100/90 leading-snug">
+          La red de vecinos conecta a quien tiene una duda con quien ya la
+          resolvió en su tierra. <strong>Campesino le responde a campesino</strong>;
+          Chagra solo los presenta. Preguntar no cuesta: el saber no se vende.
+        </p>
+      </div>
+
+      <section aria-label="Pregúntele al vecino">
+        <h3 className="text-white font-bold text-base mb-3">Pregúntele al vecino</h3>
+        <PreguntarVecinoPanel />
+      </section>
+
+      <section aria-label="Su reputación en la red">
+        <h3 className="text-white font-bold text-base mb-1">Así lo ve la red a usted</h3>
+        <p className="text-xs text-slate-400 mb-3 leading-snug">
+          Su reputación no se pide ni se vota: se gana con los tratos que usted
+          registra y decide compartir. Esto es exactamente lo que ve un vecino.
+        </p>
+        {isLoading && mias.length === 0 ? (
+          <p className="text-sm text-slate-400" data-testid="red-cargando">Cargando su red…</p>
+        ) : mias.length > 0 ? (
+          <ul className="space-y-3">
+            {mias.map((rep) => (
+              <li key={`${rep.productorHash}-${rep.productoNorm}`}>
+                <ReputacionCard reputacion={rep} esUsted />
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="rounded-lg border border-slate-700 bg-slate-800/60 p-3 flex gap-2 text-sm text-slate-300" data-testid="red-sin-reputacion">
+            <Handshake size={16} className="text-slate-400 shrink-0 mt-0.5" aria-hidden="true" />
+            <span>
+              Todavía no tiene tratos compartidos con los vecinos. Cuando cierre
+              una venta de una oferta suya, regístrela y compártala
+              &ldquo;con los vecinos&rdquo;: así la red va conociendo su palabra.
+            </span>
+          </div>
+        )}
+        {grafo?.meta?.tratos > 0 && (
+          <p className="text-[11px] text-slate-500 mt-2" data-testid="red-meta">
+            En este dispositivo: {grafo.meta.tratos} trato{grafo.meta.tratos === 1 ? '' : 's'} registrado{grafo.meta.tratos === 1 ? '' : 's'},
+            {' '}{grafo.meta.compartidos} compartido{grafo.meta.compartidos === 1 ? '' : 's'} con la red.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/red/ReputacionCard.jsx
+++ b/src/components/red/ReputacionCard.jsx
@@ -1,0 +1,90 @@
+import { MapPin, Star } from 'lucide-react';
+import { NIVEL_REPUTACION } from '../../services/red';
+import { NIVEL_REPUTACION_COPY, MOTIVO_REPUTACION_COPY } from './reputacionCopy';
+
+/**
+ * ReputacionCard — la reputación GANADA de un productor para UN cultivo.
+ *
+ * Espeja el idioma verde/ámbar/rojo del SemaforoConfianza del agente, pero
+ * para un actor humano: aquí el color resume HECHOS de entrega del mercado
+ * (quién entregó qué y cómo lo calificaron), no curaduría de fuentes. Por eso
+ * la tarjeta habla en tratos contables ("entregó 4 de 5") y no en estrellas
+ * abstractas: la confianza se muestra con su porqué, sin exponer nada privado
+ * (ni nombres, ni compradores, ni notas — solo lo que ya cruzó la compuerta).
+ *
+ * `nuevo` es un nivel HONESTO, no un castigo: sin historial suficiente se
+ * dice "vecino nuevo en la red", nunca se inventa un puntaje.
+ *
+ * @param {Object} props
+ * @param {import('../../services/red/types.js').Reputacion} props.reputacion
+ * @param {string} [props.titulo] - encabezado opcional (default: el producto).
+ * @param {boolean} [props.esUsted] - la tarjeta es del propio operador.
+ */
+
+export default function ReputacionCard({ reputacion, titulo, esUsted = false }) {
+  if (!reputacion) return null;
+  const copy = NIVEL_REPUTACION_COPY[reputacion.nivel] || NIVEL_REPUTACION_COPY[NIVEL_REPUTACION.NUEVO];
+  const motivo = MOTIVO_REPUTACION_COPY[reputacion.motivo] || null;
+  const { Icon } = copy;
+  const ubic = [reputacion.vereda, reputacion.municipio].filter(Boolean).join(', ');
+  const fiabilidadPct = Math.round((reputacion.fiabilidad || 0) * 100);
+  const tieneHistorial = reputacion.nConfirmadas > 0;
+
+  return (
+    <div
+      className="rounded-xl border border-slate-700 bg-slate-900/70 p-3"
+      data-testid="reputacion-card"
+      data-nivel={reputacion.nivel}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h4 className="font-bold text-white text-sm leading-tight truncate">
+            {titulo || reputacion.producto}
+          </h4>
+          <p className="text-slate-400 text-xs mt-0.5">
+            {esUsted ? 'Usted en la red' : 'Un vecino de la red'}
+            {ubic ? ` · ${ubic}` : ''}
+          </p>
+        </div>
+        {/* Semáforo humano: mismo idioma que el semáforo de confianza del
+            agente, pero sobre hechos de entrega. */}
+        <span
+          className={`shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded-full border text-[11px] font-bold ${copy.chip}`}
+          data-testid="reputacion-nivel"
+        >
+          <Icon size={12} aria-hidden="true" /> {copy.label}
+        </span>
+      </div>
+
+      {/* Los HECHOS, contables — no un puntaje abstracto. */}
+      <div className="mt-2 text-xs text-slate-300 space-y-1">
+        {tieneHistorial ? (
+          <>
+            <p data-testid="reputacion-fiabilidad">
+              Cumplió la entrega en <strong>{reputacion.nConfirmadas}</strong> trato{reputacion.nConfirmadas === 1 ? '' : 's'} confirmado{reputacion.nConfirmadas === 1 ? '' : 's'} ({fiabilidadPct}% de fiabilidad).
+            </p>
+            {reputacion.calidadPromedio != null && (
+              <p className="flex items-center gap-1" data-testid="reputacion-calidad">
+                <Star size={11} className="text-amber-400" aria-hidden="true" />
+                Calidad calificada: {reputacion.calidadPromedio.toFixed(1)} de 5.
+              </p>
+            )}
+          </>
+        ) : (
+          <p data-testid="reputacion-sin-historial">
+            Sin entregas confirmadas todavía en la red.
+          </p>
+        )}
+        {motivo && (
+          <p className="text-slate-400 leading-snug" data-testid="reputacion-motivo">{motivo}</p>
+        )}
+      </div>
+
+      {ubic === '' && (
+        <p className="text-slate-500 text-[11px] mt-1.5 flex items-center gap-1">
+          <MapPin size={11} aria-hidden="true" /> Sin vereda registrada en sus tratos.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/red/__tests__/CierreTratoSheet.test.jsx
+++ b/src/components/red/__tests__/CierreTratoSheet.test.jsx
@@ -1,0 +1,84 @@
+/**
+ * CierreTratoSheet — "¿Se concretó el negocio?", el gesto que alimenta la red.
+ *
+ * Contrato cubierto:
+ *   - Registra el trato con el desenlace elegido (entrega + calidad opcional +
+ *     nivel de compartición) delegando en useRedStore.registrarTrato.
+ *   - El trato nace PRIVADO por default (compuerta cerrada).
+ *   - La calidad es opcional: sin calificar viaja null, nunca se inventa.
+ *   - Al registrar muestra confirmación honesta según el nivel elegido.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+
+const registrarTrato = vi.fn();
+vi.mock('../../../store/useRedStore', () => ({
+  default: (selector) => selector({ registrarTrato }),
+}));
+
+import CierreTratoSheet from '../CierreTratoSheet';
+import { ENTREGA, SHARE_LEVEL } from '../../../services/red';
+
+afterEach(() => cleanup());
+beforeEach(() => {
+  registrarTrato.mockReset();
+  registrarTrato.mockResolvedValue({ id: 'trato-1' });
+});
+
+const OFERTA = { id: 'of-1', producto: 'Mora de Castilla', vereda: 'El Rosal', municipio: 'Choachí' };
+
+describe('CierreTratoSheet', () => {
+  it('registra con defaults honestos: entregado, sin calidad, PRIVADO', async () => {
+    render(<CierreTratoSheet oferta={OFERTA} onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId('registrar-trato'));
+
+    await waitFor(() => expect(registrarTrato).toHaveBeenCalledWith({
+      oferta: OFERTA,
+      entrega: ENTREGA.ENTREGADO,
+      calidad: null,
+      shareLevel: SHARE_LEVEL.PRIVADO,
+    }));
+    expect(await screen.findByTestId('trato-registrado')).toBeTruthy();
+    // Quedó privado → se le dice, y se le recuerda que puede abrir la compuerta.
+    expect(screen.getByText(/Quedó privado en su teléfono/i)).toBeTruthy();
+  });
+
+  it('registra entrega parcial + calidad 4 + compartido con los vecinos', async () => {
+    const onRegistrado = vi.fn();
+    render(<CierreTratoSheet oferta={OFERTA} onClose={() => {}} onRegistrado={onRegistrado} />);
+
+    fireEvent.click(screen.getByTestId(`entrega-${ENTREGA.PARCIAL}`));
+    fireEvent.click(screen.getByTestId('calidad-4'));
+    fireEvent.click(screen.getByTestId(`nivel-compartir-${SHARE_LEVEL.PARES}`));
+    fireEvent.click(screen.getByTestId('registrar-trato'));
+
+    await waitFor(() => expect(registrarTrato).toHaveBeenCalledWith({
+      oferta: OFERTA,
+      entrega: ENTREGA.PARCIAL,
+      calidad: 4,
+      shareLevel: SHARE_LEVEL.PARES,
+    }));
+    expect(onRegistrado).toHaveBeenCalledWith({ id: 'trato-1' });
+    expect(await screen.findByText(/ya ayuda a que otro campesino lo encuentre/i)).toBeTruthy();
+  });
+
+  it('si el registro falla, muestra error honesto y no pasa a "registrado"', async () => {
+    registrarTrato.mockResolvedValue(null);
+    render(<CierreTratoSheet oferta={OFERTA} onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId('registrar-trato'));
+
+    expect(await screen.findByTestId('trato-error')).toBeTruthy();
+    expect(screen.queryByTestId('trato-registrado')).toBeNull();
+  });
+
+  it('tocar de nuevo la misma estrella des-califica (vuelve a null)', async () => {
+    render(<CierreTratoSheet oferta={OFERTA} onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId('calidad-3'));
+    fireEvent.click(screen.getByTestId('calidad-3'));
+    fireEvent.click(screen.getByTestId('registrar-trato'));
+
+    await waitFor(() => expect(registrarTrato).toHaveBeenCalledWith(
+      expect.objectContaining({ calidad: null }),
+    ));
+  });
+});

--- a/src/components/red/__tests__/NivelCompartirSwitch.test.jsx
+++ b/src/components/red/__tests__/NivelCompartirSwitch.test.jsx
@@ -1,0 +1,54 @@
+/**
+ * NivelCompartirSwitch — la compuerta opt-in de 3 niveles.
+ *
+ * Contrato cubierto (anti-extractivo, services/red/README.md):
+ *   - Los 3 niveles se ven; "Saber comunitario" (canonizado) está deshabilitado
+ *     en el MVP (lo activa un sabedor, no un botón).
+ *   - Cambiar de nivel dispara onChange con el SHARE_LEVEL correcto.
+ *   - En "Con los vecinos" se muestra la promesa: nada privado cruza, el
+ *     comprador se anonimiza, el saber no se vende.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import NivelCompartirSwitch from '../NivelCompartirSwitch';
+import { SHARE_LEVEL } from '../../../services/red';
+
+afterEach(() => cleanup());
+
+describe('NivelCompartirSwitch', () => {
+  it('muestra los 3 niveles como radiogroup, con canonizado deshabilitado', () => {
+    render(<NivelCompartirSwitch value={SHARE_LEVEL.PRIVADO} onChange={() => {}} />);
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(3);
+    expect(screen.getByTestId(`nivel-compartir-${SHARE_LEVEL.PRIVADO}`).getAttribute('aria-checked')).toBe('true');
+    // Nivel 3: se modela pero no se ejecuta — lo canoniza un sabedor.
+    expect(screen.getByTestId(`nivel-compartir-${SHARE_LEVEL.CANONIZADO}`).disabled).toBe(true);
+  });
+
+  it('cambiar a "Con los vecinos" dispara onChange(PARES)', () => {
+    const onChange = vi.fn();
+    render(<NivelCompartirSwitch value={SHARE_LEVEL.PRIVADO} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId(`nivel-compartir-${SHARE_LEVEL.PARES}`));
+    expect(onChange).toHaveBeenCalledWith(SHARE_LEVEL.PARES);
+  });
+
+  it('el nivel canonizado deshabilitado NO dispara onChange', () => {
+    const onChange = vi.fn();
+    render(<NivelCompartirSwitch value={SHARE_LEVEL.PRIVADO} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId(`nivel-compartir-${SHARE_LEVEL.CANONIZADO}`));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('explica el nivel elegido en las palabras de la compuerta (privado)', () => {
+    render(<NivelCompartirSwitch value={SHARE_LEVEL.PRIVADO} onChange={() => {}} />);
+    expect(screen.getByTestId('nivel-compartir-explica').textContent)
+      .toMatch(/se queda solo en su teléfono/i);
+  });
+
+  it('en PARES muestra la promesa anti-extractiva: nada privado cruza, el saber no se vende', () => {
+    render(<NivelCompartirSwitch value={SHARE_LEVEL.PARES} onChange={() => {}} />);
+    expect(screen.getByText(/nunca/i)).toBeTruthy();
+    expect(screen.getByText(/El nombre del comprador y sus notas privadas/i)).toBeTruthy();
+    expect(screen.getByText(/Este saber no se vende/i)).toBeTruthy();
+  });
+});

--- a/src/components/red/__tests__/PreguntarVecinoPanel.test.jsx
+++ b/src/components/red/__tests__/PreguntarVecinoPanel.test.jsx
@@ -1,0 +1,156 @@
+/**
+ * PreguntarVecinoPanel — "Pregúntele al vecino": la IA como puente, no
+ * reemplazo del saber campesino.
+ *
+ * Contrato cubierto:
+ *   - Rutea la duda con agentConfident:false (quien busca aquí ya decidió
+ *     preguntarle a una persona) y muestra al par competente + cercano.
+ *   - Sin vecino competente: deflección honesta, NO inventa un contacto.
+ *   - Sin teléfono público: NO filtra números — entrega el mensaje para
+ *     llevarlo al encuentro (copiar), con la explicación del porqué.
+ *   - Con contacto público (opt-in del mercado): botón de WhatsApp vía
+ *     abrirCanal.
+ *   - encontrarContactoPublico: matching best-effort SOLO sobre ofertas
+ *     reales con teléfono (demo y sin tel quedan fuera).
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+const preguntarAlVecino = vi.fn();
+const abrirCanal = vi.fn();
+vi.mock('../../../store/useRedStore', () => ({
+  default: (selector) => selector({ preguntarAlVecino, abrirCanal }),
+}));
+
+const getAll = vi.fn();
+vi.mock('../../../db/marketplaceOfertas', () => ({
+  marketplaceOfertas: { getAll: (...a) => getAll(...a) },
+}));
+
+vi.mock('../../../services/userProfileService', () => ({
+  getProfile: () => ({ vereda: 'El Rosal', municipio: 'Choachí' }),
+}));
+
+import PreguntarVecinoPanel from '../PreguntarVecinoPanel';
+import { encontrarContactoPublico } from '../contactoPublico';
+
+afterEach(() => cleanup());
+beforeEach(() => {
+  preguntarAlVecino.mockReset();
+  abrirCanal.mockReset();
+  getAll.mockReset();
+  getAll.mockResolvedValue([]);
+});
+
+const PEER = {
+  productorHash: 'h-vecino',
+  producto: 'Mora de Castilla',
+  nivel: 'verde',
+  score: 0.7,
+  proximidad: 3,
+  proximidadLabel: 'de su misma vereda',
+  vereda: 'El Rosal',
+  municipio: 'Choachí',
+  nTransacciones: 4,
+  reciente: Date.now(),
+};
+
+const DECISION_CON_PEER = {
+  shouldRoute: true,
+  peer: PEER,
+  motivo: 'agente_no_sabe',
+  mensajeSugerido: 'Buenas. Le escribo desde la red de Chagra…',
+  candidatos: [PEER],
+};
+
+async function buscar(producto = 'mora') {
+  fireEvent.change(screen.getByLabelText(/Cultivo de la duda/i), { target: { value: producto } });
+  fireEvent.click(screen.getByTestId('buscar-vecino'));
+}
+
+describe('PreguntarVecinoPanel', () => {
+  it('rutea la duda con agentConfident:false y muestra al vecino cercano', async () => {
+    preguntarAlVecino.mockResolvedValue(DECISION_CON_PEER);
+    abrirCanal.mockReturnValue(null);
+    render(<PreguntarVecinoPanel />);
+    await buscar('mora');
+
+    expect(await screen.findByTestId('vecino-sugerido')).toBeTruthy();
+    expect(preguntarAlVecino).toHaveBeenCalledWith(expect.objectContaining({
+      producto: 'mora',
+      vereda: 'El Rosal',
+      municipio: 'Choachí',
+      agentConfident: false,
+    }));
+    expect(screen.getByText(/de su misma vereda/i)).toBeTruthy();
+    // El mensaje es de la persona: editable antes de enviar.
+    expect(screen.getByLabelText(/Mensaje para el vecino/i).value).toMatch(/red de Chagra/i);
+    // El saber no se vende — el principio queda a la vista.
+    expect(screen.getByText(/el saber no se vende/i)).toBeTruthy();
+  });
+
+  it('sin vecino competente deflecta honestamente (no inventa contacto)', async () => {
+    preguntarAlVecino.mockResolvedValue({
+      shouldRoute: false, peer: null, motivo: 'sin_vecino_competente', mensajeSugerido: null, candidatos: [],
+    });
+    render(<PreguntarVecinoPanel />);
+    await buscar('quinua');
+
+    expect(await screen.findByTestId('sin-vecino')).toBeTruthy();
+    expect(screen.queryByTestId('vecino-sugerido')).toBeNull();
+  });
+
+  it('sin teléfono público NO filtra números: explica y ofrece copiar el mensaje', async () => {
+    preguntarAlVecino.mockResolvedValue(DECISION_CON_PEER);
+    abrirCanal.mockReturnValue(null);
+    render(<PreguntarVecinoPanel />);
+    await buscar('mora');
+
+    await screen.findByTestId('vecino-sugerido');
+    expect(screen.getByTestId('sin-contacto').textContent).toMatch(/no entrega números sin permiso/i);
+    expect(screen.getByTestId('copiar-mensaje')).toBeTruthy();
+    expect(screen.queryByTestId('abrir-canal')).toBeNull();
+  });
+
+  it('con contacto público (opt-in del mercado) abre el canal de WhatsApp', async () => {
+    preguntarAlVecino.mockResolvedValue(DECISION_CON_PEER);
+    getAll.mockResolvedValue([
+      { id: 'of-9', producto: 'Mora de castilla', vereda: 'El Rosal', contactoTel: '3001234567' },
+    ]);
+    abrirCanal.mockReturnValue({ href: 'https://wa.me/573001234567?text=hola', tel: '3001234567' });
+    render(<PreguntarVecinoPanel />);
+    await buscar('mora');
+
+    const link = await screen.findByTestId('abrir-canal');
+    expect(link.getAttribute('href')).toMatch(/wa\.me/);
+    expect(abrirCanal).toHaveBeenCalledWith(
+      expect.objectContaining({ contactoTel: '3001234567' }),
+      expect.objectContaining({ mensaje: expect.stringMatching(/red de Chagra/i) }),
+    );
+  });
+});
+
+describe('encontrarContactoPublico (puro)', () => {
+  const OFERTAS = [
+    { id: 'a', producto: 'Mora de Castilla', vereda: 'Otra', contactoTel: '111', demo: true },
+    { id: 'b', producto: 'Mora de Castilla', vereda: 'Otra', contactoTel: '' },
+    { id: 'c', producto: 'mora de castilla', vereda: 'Lejos', contactoTel: '222' },
+    { id: 'd', producto: 'MORA DE CASTILLA', vereda: 'El Rosal', contactoTel: '333' },
+  ];
+
+  it('excluye demos y ofertas sin teléfono; prefiere la de la misma vereda', () => {
+    const out = encontrarContactoPublico(PEER, OFERTAS);
+    expect(out.id).toBe('d');
+  });
+
+  it('sin match de vereda cae a la primera oferta real con teléfono', () => {
+    const out = encontrarContactoPublico({ ...PEER, vereda: 'Ninguna' }, OFERTAS);
+    expect(out.id).toBe('c');
+  });
+
+  it('sin producto que coincida devuelve null (no adivina)', () => {
+    expect(encontrarContactoPublico({ ...PEER, producto: 'café' }, OFERTAS)).toBeNull();
+    expect(encontrarContactoPublico(null, OFERTAS)).toBeNull();
+    expect(encontrarContactoPublico(PEER, null)).toBeNull();
+  });
+});

--- a/src/components/red/__tests__/ReputacionCard.test.jsx
+++ b/src/components/red/__tests__/ReputacionCard.test.jsx
@@ -1,0 +1,76 @@
+/**
+ * ReputacionCard — reputación GANADA por cultivo, en hechos contables.
+ *
+ * Contrato cubierto:
+ *   - Verde: semáforo "Entrega cumplida" + los hechos (n tratos, fiabilidad %).
+ *   - Nuevo: honesto — "vecino nuevo", sin puntaje inventado.
+ *   - Calidad solo se pinta si fue calificada (null → no se inventa).
+ *   - Nada privado: la tarjeta habla de "un vecino", nunca de un nombre.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import ReputacionCard from '../ReputacionCard';
+
+afterEach(() => cleanup());
+
+const REP_VERDE = {
+  productorHash: 'h-abc',
+  producto: 'Tomate chonto',
+  productoNorm: 'tomate chonto',
+  vereda: 'La Unión',
+  municipio: 'Choachí',
+  nTransacciones: 5,
+  nConfirmadas: 4,
+  nEntregados: 4,
+  fiabilidad: 0.83,
+  calidadPromedio: 4.5,
+  calidadNorm: 0.875,
+  reciente: Date.now(),
+  score: 0.7,
+  nivel: 'verde',
+  motivo: 'entrega_pareja',
+};
+
+const REP_NUEVA = {
+  ...REP_VERDE,
+  nTransacciones: 1,
+  nConfirmadas: 0,
+  nEntregados: 0,
+  fiabilidad: 0.5,
+  calidadPromedio: null,
+  calidadNorm: null,
+  nivel: 'nuevo',
+  motivo: 'sin_historial_suficiente',
+};
+
+describe('ReputacionCard', () => {
+  it('verde: semáforo + hechos contables (tratos confirmados y fiabilidad)', () => {
+    render(<ReputacionCard reputacion={REP_VERDE} />);
+    expect(screen.getByTestId('reputacion-nivel').textContent).toMatch(/Entrega cumplida/i);
+    expect(screen.getByTestId('reputacion-fiabilidad').textContent).toMatch(/4/);
+    expect(screen.getByTestId('reputacion-fiabilidad').textContent).toMatch(/83% de fiabilidad/i);
+    expect(screen.getByTestId('reputacion-calidad').textContent).toMatch(/4\.5 de 5/);
+    expect(screen.getByTestId('reputacion-motivo').textContent).toMatch(/entregado parejo/i);
+    // Privacidad: un vecino, no un nombre ni un hash a la vista.
+    expect(screen.getByText(/Un vecino de la red/i)).toBeTruthy();
+    expect(screen.queryByText(/h-abc/)).toBeNull();
+  });
+
+  it('nuevo: honesto, sin historial suficiente y sin puntaje inventado', () => {
+    render(<ReputacionCard reputacion={REP_NUEVA} />);
+    expect(screen.getByTestId('reputacion-nivel').textContent).toMatch(/Vecino nuevo/i);
+    expect(screen.getByTestId('reputacion-sin-historial')).toBeTruthy();
+    expect(screen.queryByTestId('reputacion-calidad')).toBeNull();
+    expect(screen.getByTestId('reputacion-motivo').textContent).toMatch(/no es malo: es honesto/i);
+  });
+
+  it('esUsted cambia el encuadre a "Usted en la red"', () => {
+    render(<ReputacionCard reputacion={REP_VERDE} esUsted />);
+    expect(screen.getByText(/Usted en la red/i)).toBeTruthy();
+  });
+
+  it('sin reputación no pinta nada (graceful)', () => {
+    const { container } = render(<ReputacionCard reputacion={null} />);
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/src/components/red/contactoPublico.js
+++ b/src/components/red/contactoPublico.js
@@ -1,0 +1,30 @@
+import { normalizeTerm } from '../../services/red';
+
+/**
+ * contactoPublico — matching best-effort entre un vecino sugerido por el
+ * matchmaking y las ofertas del mercado donde ese vecino expuso (opt-in) un
+ * teléfono público. Vive aparte del componente (regla react-refresh) y es
+ * PURO, para poderse testear sin UI.
+ *
+ * Privacidad (inviolable, services/red/README.md): la red NUNCA filtra un
+ * número que el par no haya hecho público en el mercado. Por eso el matching
+ * solo mira ofertas reales (no demo) CON teléfono, y si no hay coincidencia
+ * devuelve null — el caller degrada al mensaje sugerido, nunca adivina.
+ *
+ * @param {import('../../services/red/types.js').PeerMatch} peer
+ * @param {Array<Object>} ofertas - registros de marketplace_ofertas.
+ * @returns {Object|null} la oferta con contacto público, o null.
+ */
+export function encontrarContactoPublico(peer, ofertas) {
+  if (!peer || !Array.isArray(ofertas)) return null;
+  const productoNorm = normalizeTerm(peer.producto);
+  if (!productoNorm) return null;
+  const candidatas = ofertas.filter((o) => (
+    o && !o.demo && o.contactoTel
+    && normalizeTerm(o.producto) === productoNorm
+  ));
+  if (candidatas.length === 0) return null;
+  const veredaNorm = normalizeTerm(peer.vereda);
+  const mismaVereda = candidatas.find((o) => veredaNorm && normalizeTerm(o.vereda) === veredaNorm);
+  return mismaVereda || candidatas[0];
+}

--- a/src/components/red/reputacionCopy.js
+++ b/src/components/red/reputacionCopy.js
@@ -1,0 +1,49 @@
+import { BadgeCheck, AlertTriangle, OctagonAlert, Sprout } from 'lucide-react';
+import { NIVEL_REPUTACION } from '../../services/red';
+
+/**
+ * reputacionCopy — el vocabulario visual del semáforo de reputación de la RED
+ * humana. Vive aparte de los componentes (regla react-refresh: un archivo de
+ * componente solo exporta componentes) para que ReputacionCard y
+ * PreguntarVecinoPanel hablen el MISMO idioma verde/ámbar/rojo.
+ *
+ * Espeja el idioma del SemaforoConfianza del agente, pero para un actor
+ * humano: aquí el color resume HECHOS de entrega del mercado, no curaduría de
+ * fuentes. `nuevo` es honestidad, no castigo.
+ */
+export const NIVEL_REPUTACION_COPY = Object.freeze({
+  [NIVEL_REPUTACION.NUEVO]: {
+    label: 'Vecino nuevo en la red',
+    Icon: Sprout,
+    chip: 'bg-slate-700/60 text-slate-300 border-slate-600',
+  },
+  [NIVEL_REPUTACION.VERDE]: {
+    label: 'Entrega cumplida',
+    Icon: BadgeCheck,
+    chip: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/40',
+  },
+  [NIVEL_REPUTACION.AMBAR]: {
+    label: 'Conviene confirmar',
+    Icon: AlertTriangle,
+    chip: 'bg-amber-500/15 text-amber-300 border-amber-500/40',
+  },
+  [NIVEL_REPUTACION.ROJO]: {
+    label: 'Con fallas de entrega',
+    Icon: OctagonAlert,
+    chip: 'bg-rose-500/15 text-rose-300 border-rose-500/40',
+  },
+});
+
+/** El porqué del semáforo, en palabras de la finca (motivo de redReputation). */
+export const MOTIVO_REPUTACION_COPY = Object.freeze({
+  sin_historial_suficiente:
+    'Todavía no tiene tratos suficientes en la red para calificarlo. Eso no es malo: es honesto.',
+  entrega_pareja:
+    'Ha entregado parejo en los tratos de la red, y con buena calidad cuando la calificaron.',
+  entrega_parcial:
+    'Ha cumplido en parte. Antes de cerrar un trato grande, confirme con él la entrega.',
+  calidad_dispareja:
+    'Entrega, pero la calidad que le han calificado ha sido dispareja.',
+  fallas_de_entrega:
+    'Registra fallas de entrega en tratos de la red. Confirme bien antes de comprometerse.',
+});

--- a/src/store/__tests__/useRedStore.test.js
+++ b/src/store/__tests__/useRedStore.test.js
@@ -1,0 +1,123 @@
+/**
+ * useRedStore — fachada reactiva de la RED humana.
+ *
+ * Contrato cubierto:
+ *   - cargar() hidrata reputaciones + grafo social desde services/red.
+ *   - registrarTrato() delega al servicio y REHIDRATA las derivadas (el trato
+ *     nuevo debe reflejarse en reputación/grafo sin recargar la app).
+ *   - setNivelCompartir() persiste el cambio de compuerta NORMALIZADO — un
+ *     nivel inválido cae a PRIVADO, nunca se comparte de más por accidente.
+ *   - Errores de I/O degradan a estado honesto (error legible), no a crash.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/red', async () => {
+  const types = await vi.importActual('../../services/red/types.js');
+  const sharing = await vi.importActual('../../services/red/redSharing.js');
+  return {
+    ...types,
+    normalizeShareLevel: sharing.normalizeShareLevel,
+    registrarTrato: vi.fn(),
+    cargarReputaciones: vi.fn(),
+    cargarGrafoSocial: vi.fn(),
+    preguntarAlVecino: vi.fn(),
+    abrirCanal: vi.fn(),
+  };
+});
+
+vi.mock('../../db/redTransactions', () => ({
+  redTransactions: {
+    get: vi.fn(),
+    save: vi.fn(),
+  },
+}));
+
+import {
+  registrarTrato, cargarReputaciones, cargarGrafoSocial, SHARE_LEVEL,
+} from '../../services/red';
+import { redTransactions } from '../../db/redTransactions';
+import useRedStore from '../useRedStore';
+
+const REPUTACIONES = [{ productorHash: 'h1', producto: 'Tomate', productoNorm: 'tomate', nivel: 'verde' }];
+const GRAFO = { nodos: { productores: ['h1'], cultivos: ['tomate'], veredas: [] }, meta: { tratos: 1, compartidos: 1, minShareLevel: 2 } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useRedStore.getState().reset();
+  cargarReputaciones.mockResolvedValue(REPUTACIONES);
+  cargarGrafoSocial.mockResolvedValue(GRAFO);
+});
+
+describe('useRedStore — hidratación', () => {
+  it('cargar() hidrata reputaciones + grafo desde los servicios de red', async () => {
+    await useRedStore.getState().cargar();
+    const s = useRedStore.getState();
+    expect(s.reputaciones).toEqual(REPUTACIONES);
+    expect(s.grafo).toEqual(GRAFO);
+    expect(s.isLoading).toBe(false);
+    expect(s.error).toBeNull();
+    expect(s.lastLoadedAt).toBeTruthy();
+  });
+
+  it('un fallo de carga degrada a error honesto, no a crash', async () => {
+    cargarReputaciones.mockRejectedValue(new Error('IndexedDB caída'));
+    const out = await useRedStore.getState().cargar();
+    expect(out).toBeNull();
+    const s = useRedStore.getState();
+    expect(s.error).toBe('IndexedDB caída');
+    expect(s.isLoading).toBe(false);
+  });
+});
+
+describe('useRedStore — registrarTrato', () => {
+  it('delega al servicio y rehidrata las derivadas', async () => {
+    const trato = { id: 'trato-1', producto: 'Tomate', shareLevel: SHARE_LEVEL.PARES };
+    registrarTrato.mockResolvedValue(trato);
+
+    const out = await useRedStore.getState().registrarTrato({ oferta: { producto: 'Tomate' } });
+
+    expect(out).toEqual(trato);
+    expect(registrarTrato).toHaveBeenCalledWith({ oferta: { producto: 'Tomate' } });
+    // Rehidratación: el trato nuevo debe verse en reputación/grafo.
+    expect(cargarReputaciones).toHaveBeenCalled();
+    expect(useRedStore.getState().reputaciones).toEqual(REPUTACIONES);
+  });
+
+  it('si el registro falla, devuelve null y deja error legible', async () => {
+    registrarTrato.mockRejectedValue(new Error('sin identidad de productor'));
+    const out = await useRedStore.getState().registrarTrato({});
+    expect(out).toBeNull();
+    expect(useRedStore.getState().error).toBe('sin identidad de productor');
+  });
+});
+
+describe('useRedStore — setNivelCompartir (la compuerta)', () => {
+  it('persiste el nivel nuevo y rehidrata', async () => {
+    redTransactions.get.mockResolvedValue({ id: 'trato-1', shareLevel: SHARE_LEVEL.PRIVADO });
+    redTransactions.save.mockImplementation(async (t) => t);
+
+    const out = await useRedStore.getState().setNivelCompartir('trato-1', SHARE_LEVEL.PARES);
+
+    expect(out.shareLevel).toBe(SHARE_LEVEL.PARES);
+    expect(redTransactions.save).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'trato-1', shareLevel: SHARE_LEVEL.PARES }),
+    );
+    expect(cargarReputaciones).toHaveBeenCalled();
+  });
+
+  it('un nivel inválido cae a PRIVADO — nunca se comparte de más', async () => {
+    redTransactions.get.mockResolvedValue({ id: 'trato-1', shareLevel: SHARE_LEVEL.PARES });
+    redTransactions.save.mockImplementation(async (t) => t);
+
+    const out = await useRedStore.getState().setNivelCompartir('trato-1', 99);
+
+    expect(out.shareLevel).toBe(SHARE_LEVEL.PRIVADO);
+  });
+
+  it('trato inexistente devuelve null sin tocar la persistencia', async () => {
+    redTransactions.get.mockResolvedValue(null);
+    const out = await useRedStore.getState().setNivelCompartir('nope', SHARE_LEVEL.PARES);
+    expect(out).toBeNull();
+    expect(redTransactions.save).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/useRedStore.js
+++ b/src/store/useRedStore.js
@@ -1,0 +1,134 @@
+/* i18n (ADR-050): mensajes de error user-facing en español Colombia. La regla
+ * chagra-i18n es soft (warn); se desactiva a nivel de archivo siguiendo el
+ * mismo criterio que MercadosScreen para no bloquear el pre-commit
+ * (max-warnings=0). */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { create } from 'zustand';
+import {
+  registrarTrato as registrarTratoRed,
+  cargarReputaciones,
+  cargarGrafoSocial,
+  preguntarAlVecino as preguntarAlVecinoRed,
+  abrirCanal,
+  normalizeShareLevel,
+} from '../services/red';
+import { redTransactions } from '../db/redTransactions';
+
+/**
+ * useRedStore — fachada reactiva de la RED humana (campesino ↔ campesino).
+ *
+ * Hidrata desde los servicios de `services/red` (mismo patrón que
+ * useCosechaStore: este store NO es fuente de verdad — los tratos viven
+ * append-only en `db/redTransactions`; reputaciones y grafo social son cache
+ * DERIVADA y reconstruible, ADR-019). La UI solo pinta lo que sale de aquí.
+ *
+ * Principio anti-extractivo (inviolable, ver services/red/README.md): nada de
+ * lo que pasa por este store monetiza el saber — la única superficie de
+ * dinero es el mercado. El grafo y la reputación solo ven tratos con
+ * shareLevel >= PARES (la compuerta vive en redSharing, no aquí).
+ */
+const useRedStore = create((set, get) => ({
+  /** @type {Array<import('../services/red/types.js').Reputacion>} */
+  reputaciones: [],
+  /** @type {import('../services/red/types.js').SocialGraph|null} */
+  grafo: null,
+  isLoading: false,
+  error: null,
+  lastLoadedAt: null,
+
+  /**
+   * Hidrata reputaciones + grafo social desde los tratos persistidos.
+   * @returns {Promise<{reputaciones:Array, grafo:Object}|null>}
+   */
+  cargar: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const [reputaciones, grafo] = await Promise.all([
+        cargarReputaciones(),
+        cargarGrafoSocial(),
+      ]);
+      set({ reputaciones, grafo, isLoading: false, lastLoadedAt: Date.now() });
+      return { reputaciones, grafo };
+    } catch (err) {
+      set({ isLoading: false, error: err?.message || 'No se pudo cargar la red' });
+      return null;
+    }
+  },
+
+  /**
+   * Registra un TRATO cerrado del mercado (el gesto que alimenta toda la red)
+   * y rehidrata las derivadas. Delega la construcción + persistencia al
+   * servicio (identidad pseudonimizada, privado-por-default).
+   * @param {Object} input - ver services/red/redService.buildTrato.
+   * @returns {Promise<Object|null>} el trato persistido, o null si falló.
+   */
+  registrarTrato: async (input) => {
+    try {
+      const trato = await registrarTratoRed(input);
+      await get().cargar();
+      return trato;
+    } catch (err) {
+      set({ error: err?.message || 'No se pudo registrar el trato' });
+      return null;
+    }
+  },
+
+  /**
+   * Cambia el nivel de compartición de un trato YA registrado (el productor
+   * siempre puede abrir o cerrar la compuerta de su propio dato). Niveles
+   * inválidos caen a PRIVADO — nunca se comparte de más por accidente.
+   * @param {string} tratoId
+   * @param {number} nivel - SHARE_LEVEL.*
+   * @returns {Promise<Object|null>} el trato actualizado, o null.
+   */
+  setNivelCompartir: async (tratoId, nivel) => {
+    try {
+      const trato = await redTransactions.get(tratoId);
+      if (!trato) return null;
+      const actualizado = { ...trato, shareLevel: normalizeShareLevel(nivel) };
+      await redTransactions.save(actualizado);
+      await get().cargar();
+      return actualizado;
+    } catch (err) {
+      set({ error: err?.message || 'No se pudo cambiar el nivel de compartición' });
+      return null;
+    }
+  },
+
+  /**
+   * "Pregúntele al vecino": rutea una duda al par competente y cercano.
+   * Passthrough al servicio (la decisión no se cachea: cada duda es nueva).
+   * @param {Object} problema - { producto, vereda, municipio, sintoma, agentConfident }
+   * @param {Object} [opts]
+   * @returns {Promise<Object|null>} la decisión de ruteo, o null si falló.
+   */
+  preguntarAlVecino: async (problema, opts = {}) => {
+    try {
+      return await preguntarAlVecinoRed(problema, opts);
+    } catch (err) {
+      set({ error: err?.message || 'No se pudo buscar un vecino' });
+      return null;
+    }
+  },
+
+  /**
+   * Abre el canal directo (WhatsApp del mercado) con un vecino que expuso
+   * teléfono público. Sin consentimiento devuelve null — la red no filtra
+   * números. Passthrough síncrono a redService.abrirCanal.
+   */
+  abrirCanal,
+
+  reset: () => set({
+    reputaciones: [], grafo: null, isLoading: false, error: null, lastLoadedAt: null,
+  }),
+}));
+
+// Al cambiar de finca (tenant), invalidar las derivadas en memoria — mismo
+// patrón que useCosechaStore.
+if (typeof window !== 'undefined') {
+  window.addEventListener('tenantChanged', () => {
+    useRedStore.getState().reset();
+  });
+}
+
+export default useRedStore;


### PR DESCRIPTION
## Qué es

La **cara** del backend de la RED humana (`src/services/red`, ya en dev): el mercado es la puerta — cada trato registrado alimenta el grafo social y la reputación ganada, sin pedirle datos a nadie.

## Los 5 frentes

1. **`useRedStore` (Zustand)** — hidrata de `cargarReputaciones`/`cargarGrafoSocial`; acciones `registrarTrato`, `preguntarAlVecino`, `abrirCanal`, `setNivelCompartir` (nivel inválido cae a PRIVADO — nunca se comparte de más). Mismo patrón que `useCosechaStore`, reset en `tenantChanged`.
2. **Cierre de trato** — `CierreTratoSheet` ("¿Se concretó el negocio?") desde el detalle de una **oferta propia** del mercado: entrega + calidad opcional (1..5, o nada — nunca se inventa) + compuerta de compartición.
3. **Switch de 3 niveles** — `NivelCompartirSwitch` con la copy canónica de `SHARE_LEVEL_COPY`; explica qué cruza en cada nivel (en pares el comprador se anonimiza y nada privado sale); *canonizado* visible pero deshabilitado (lo activa un sabedor — el MVP opera en 1–2).
4. **"Pregúntele al vecino"** — `PreguntarVecinoPanel` en el tab **Vecinos** del mercado: rutea con `agentConfident:false`, muestra al par competente+cercano con su semáforo, mensaje editable, y abre WhatsApp **solo** si el vecino expuso teléfono público en una oferta (`encontrarContactoPublico`, puro y testeado); si no, deflección honesta + copiar mensaje. La IA es puente, no reemplazo.
5. **`ReputacionCard`** — semáforo humano verde/ámbar/rojo/**nuevo** (espeja el idioma del `SemaforoConfianza` del agente) con hechos contables ("cumplió en 4 tratos confirmados, 83% de fiabilidad") y el porqué, sin exponer nombres ni hashes.

## Decisiones

- **Todo en archivos nuevos** (`src/components/red/`, `src/store/useRedStore.js`) + un solo enganche en `MercadosScreen.jsx` (tab Vecinos + botón de cierre en `DetalleOferta`). Cero cambios en `App.jsx`, `AgentScreen` o `services/red/*`.
- **Gancho del agente pendiente a propósito**: `PreguntarVecinoPanel` acepta `productoInicial` y el ruteo ya soporta `agentConfident:false` — montar el nudge en el chat cuando el semáforo dé rojo es un follow-up de bajo riesgo (AgentScreen es alto churn).
- La red **no monetiza el saber**: preguntar/responder no cuesta ni paga; la única superficie de dinero sigue siendo la compra-venta del mercado.

## Verificación

- `npx vitest run` — **31 tests verdes** (6 archivos: store + 4 componentes + suite existente de MercadosScreen).
- `npm run build` — verde.
- `npx eslint` de todo lo tocado — limpio (0 errores, 0 warnings).
- Accesible: radiogroups reales, `aria-checked`, foco visible, sin animaciones (reduced-motion safe), targets ≥44px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)