### PR TITLE
feat(perf): PerformanceMonitor + tiers dinamicos de presupuesto 3D

### DIFF
--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -26,11 +26,16 @@
 import { Suspense, useMemo, useRef, useState } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import {
-  Html, Float, Stars, OrbitControls, AdaptiveDpr, Detailed, Instances, Instance,
+  Html, Float, Stars, OrbitControls, Detailed, Instances, Instance,
 } from '@react-three/drei';
 import * as THREE from 'three';
 import { perfilDeTier } from '../../visual/mundo3d/deviceTier.js';
 import CamaraDirector from '../../visual/mundo3d/escenas/CamaraDirector.jsx';
+import MonitorRendimiento, {
+  detectarTierInicial,
+  presupuestoDeTier,
+  useTierPerformance,
+} from '../../visual/mundo3d/usePerformanceMonitor.jsx';
 import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
 /* La CAPA DE ESTADO de Angelita (auditoría §5b): módulo puro, sin three — el
    mismo repertorio (mojada/sed/comiendo/vuelo) que usan los mundos 3D. */
@@ -655,13 +660,18 @@ function CriaturaSvg({ tipo, size, animated }) {
   return <Lombriz size={size} animated={animated} />;
 }
 
-function CriaturasValle({ reducedMotion, cupo }) {
+function CriaturasValle({ reducedMotion, cupo, tier }) {
+  const rendimiento = useTierPerformance({ tier, reducedMotion });
+  const cupoVivo = Math.min(
+    cupo ?? rendimiento.presupuesto.maxCriaturasAmbientales,
+    rendimiento.presupuesto.maxCriaturasAmbientales,
+  );
   // Cada criatura es un <Html> (nodo DOM con matriz CSS por frame): en frugal
   // se siembran menos; en 'bajo' ninguna (el valle vive igual con los mundos).
-  if (!cupo) return null;
+  if (!cupoVivo) return null;
   return (
     <group>
-      {CRIATURAS_VALLE.slice(0, cupo).map((c, i) => {
+      {CRIATURAS_VALLE.slice(0, cupoVivo).map((c, i) => {
         const y = alturaTerreno(c.x, c.z) + c.dy;
         return (
           <group key={i} position={[c.x, y, c.z]}>
@@ -1060,6 +1070,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
 
   return (
     <>
+      {!reducedMotion && <MonitorRendimiento key={tier} tier={tier} />}
       <color attach="background" args={[c.cielo[1]]} />
       {/* La niebla se paga por fragmento: en perfil 'bajo' se apaga. */}
       {perfil.fog && <fog attach="fog" args={[c.niebla, 12, c.nieblaLejos + 8]} />}
@@ -1105,7 +1116,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         occluders={occluders}
       />
 
-      <CriaturasValle reducedMotion={reducedMotion} cupo={perfil.criaturas} />
+      <CriaturasValle reducedMotion={reducedMotion} cupo={perfil.criaturas} tier={tier} />
       <Beacon onAlerta={onAlerta} reducedMotion={reducedMotion} conLuz={perfil.luzBeacon} />
       <CompaneroAbeja
         foco={foco}
@@ -1138,7 +1149,6 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         activa={!reducedMotion && tier !== 'bajo'}
         unaVezClave="valle"
       />
-      <AdaptiveDpr pixelated />
     </>
   );
 }
@@ -1158,16 +1168,18 @@ export default function Valle3D({
   hayAlerta = false,
 }) {
   const [listo, setListo] = useState(false);
+  const tierInicial = useMemo(() => detectarTierInicial({ tier, reducedMotion }), [tier, reducedMotion]);
   /* El PERFIL DE RENDER del tier (DR-3D-PERF-GAMABAJA): 'alto' conserva este
      look intacto; 'medio'/'bajo' degradan sombras, DPR, antialias, densidad e
      instancian lo repetido. El default 'alto' preserva a los hosts viejos. */
-  const perfil = useMemo(() => perfilDeTier(tier), [tier]);
+  const perfil = useMemo(() => perfilDeTier(tierInicial), [tierInicial]);
+  const presupuesto = useMemo(() => presupuestoDeTier(tierInicial), [tierInicial]);
   return (
     <Canvas
       className={`valle-canvas${listo ? ' valle-canvas--listo' : ''}`}
       shadows={perfil.sombras}
-      dpr={perfil.dpr}
-      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      dpr={presupuesto.dpr}
+      gl={{ antialias: tierInicial === 'alto', powerPreference: 'high-performance' }}
       camera={CAMARA_VALLE}
       frameloop={reducedMotion ? 'demand' : 'always'}
       onCreated={() => setListo(true)}
@@ -1184,7 +1196,7 @@ export default function Valle3D({
           onAlerta={onAlerta}
           reducedMotion={reducedMotion}
           perfil={perfil}
-          tier={tier}
+          tier={tierInicial}
         />
       </Suspense>
     </Canvas>

--- a/src/visual/mundo3d/CapaVivaMundo.jsx
+++ b/src/visual/mundo3d/CapaVivaMundo.jsx
@@ -51,6 +51,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { MomentoNace, MomentoCosecha, MomentoVende } from './MomentosFinca.jsx';
 import HotspotFeedback from './HotspotFeedback.jsx';
 import { ParticulasAmbientales } from './ParticulasAmbientales.jsx';
+import { useTierPerformance } from './usePerformanceMonitor.jsx';
 
 /*
  * Ventana de carga: cambios de estadoFinca dentro de este lapso tras montar se
@@ -115,6 +116,10 @@ export default function CapaVivaMundo({
   activo = true,
   hotspotActivoId = null,
 }) {
+  const rendimiento = useTierPerformance({ tier, reducedMotion });
+  const presupuesto = rendimiento.presupuesto;
+  const tierVivo = rendimiento.tier;
+
   /* ── beats vivos (estado React; los flancos se detectan en el efecto) ── */
   const [beatNace, setBeatNace] = useState(null); // { clave }
   const [beatCosecha, setBeatCosecha] = useState(null); // { clave, cultivo }
@@ -184,8 +189,9 @@ export default function CapaVivaMundo({
           key={n.tipo}
           tipo={n.tipo}
           densidad={n.densidad}
-          tier={tier}
+          tier={tierVivo}
           reducedMotion={reducedMotion}
+          maxParticulas={presupuesto.maxFlora}
           semilla={semilla}
         />
       ))}

--- a/src/visual/mundo3d/ParticulasAmbientales.jsx
+++ b/src/visual/mundo3d/ParticulasAmbientales.jsx
@@ -299,6 +299,8 @@ function Mariposas({ cfg, n, zona, semilla }) {
  * @param {'alto'|'medio'|'bajo'} [p.tier='medio']  de `decidirTier()`.
  * @param {boolean} [p.reducedMotion=false]  quieto (polen/polvo/luciérnagas) o
  *                                           apagado (mariposas).
+ * @param {number}  [p.maxParticulas=Infinity] tope adicional del presupuesto
+ *                                           vivo, útil para `useTierPerformance`.
  * @param {[number,number,number]} [p.area]  caja [ancho, alto, fondo]; default
  *                                           por tipo. Pase referencia ESTABLE.
  * @param {[number,number,number]} [p.position=[0,0,0]]  ancla en la escena
@@ -312,6 +314,7 @@ export function ParticulasAmbientales({
   densidad = 1,
   tier = 'medio',
   reducedMotion = false,
+  maxParticulas = Infinity,
   area = null,
   position = [0, 0, 0],
   rotation = null,
@@ -319,7 +322,9 @@ export function ParticulasAmbientales({
 }) {
   const cfg = PARTICULAS[tipo];
   if (!cfg) return null;
-  const n = conteoParticulas(cfg, tier, densidad);
+  const nBase = conteoParticulas(cfg, tier, densidad);
+  const limite = Number.isFinite(maxParticulas) ? Math.max(0, Math.floor(maxParticulas)) : Infinity;
+  const n = Math.min(nBase, limite);
   if (n <= 0) return null;
   if (cfg.mariposa && reducedMotion) return null;
   const zona = area || cfg.area;

--- a/src/visual/mundo3d/__tests__/usePerformanceMonitor.test.js
+++ b/src/visual/mundo3d/__tests__/usePerformanceMonitor.test.js
@@ -6,6 +6,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   TECHO_DPR,
+  presupuestoDeTier,
+  detectarTierInicial,
   factorInicialPorTier,
   nivelPorFactor,
   dprPorFactor,
@@ -48,6 +50,38 @@ describe('derivaciones puras', () => {
     expect(escalaParticulasPorFactor(1)).toBe(1);
     expect(escalaParticulasPorFactor(0)).toBe(0.4);
     expect(escalaParticulasPorFactor(0.5)).toBe(0.7);
+  });
+
+  it('presupuestoDeTier: alto pleno, medio frugal, bajo minimo', () => {
+    expect(presupuestoDeTier('alto')).toEqual({
+      maxCriaturasAmbientales: 5,
+      maxFlora: 100,
+      bloom: true,
+      sombras: true,
+      dpr: 1.5,
+      postfx: true,
+    });
+    expect(presupuestoDeTier('medio')).toEqual({
+      maxCriaturasAmbientales: 3,
+      maxFlora: 56,
+      bloom: false,
+      sombras: false,
+      dpr: 1.25,
+      postfx: false,
+    });
+    expect(presupuestoDeTier('bajo')).toEqual({
+      maxCriaturasAmbientales: 1,
+      maxFlora: 24,
+      bloom: false,
+      sombras: false,
+      dpr: 1,
+      postfx: false,
+    });
+  });
+
+  it('detectarTierInicial baja el techo con UA viejo o valle3d apagado', () => {
+    expect(detectarTierInicial({ tier: 'alto', ua: 'Mozilla/5.0 (Linux; Android 7.0; Pixel)' })).toBe('bajo');
+    expect(detectarTierInicial({ tier: 'alto', valle3d: false })).toBe('bajo');
   });
 });
 
@@ -93,6 +127,29 @@ describe('store de calidad', () => {
     __internos.acusarCambio({ factor: 0.2, fps: 25 }); // bajar si se puede
     expect(leerCalidad().factor).toBe(0.2);
     expect(leerCalidad().nivel).toBe('bajo');
+  });
+
+  it('baja el tier cuando el FPS se mantiene por debajo de 30', () => {
+    sembrarCalidad('alto');
+    for (let i = 0; i < 4; i += 1) {
+      __internos.acusarCambio({ factor: 0.95, fps: 28 });
+    }
+    const c = leerCalidad();
+    expect(c.tier).toBe('medio');
+    expect(c.presupuesto).toEqual(presupuestoDeTier('medio'));
+    expect(c.dpr).toBeLessThanOrEqual(TECHO_DPR.medio);
+  });
+
+  it('sube el tier con histeresis cuando el FPS se mantiene alto', () => {
+    sembrarCalidad('alto');
+    for (let i = 0; i < 4; i += 1) {
+      __internos.acusarCambio({ factor: 0.95, fps: 28 });
+    }
+    for (let i = 0; i < 5; i += 1) {
+      __internos.acusarCambio({ factor: 0.95, fps: 60 });
+    }
+    expect(leerCalidad().tier).toBe('alto');
+    expect(leerCalidad().presupuesto).toEqual(presupuestoDeTier('alto'));
   });
 
   it('reiniciarCalidad limpia fallback y fps', () => {

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -22,13 +22,17 @@
  */
 import { Suspense, lazy, useMemo, useRef, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
-import { Html, OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { Html, OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaEscena } from './useEntradaAbeja.jsx';
 import CamaraDirector from './CamaraDirector.jsx';
 import { SombraContacto } from './SombraContacto.jsx';
 import { ESTADO_FINCA_MUESTRA } from './reaccionFinca.js';
 import useHaptics from '../useHaptics.js';
+import MonitorRendimiento, {
+  detectarTierInicial,
+  presupuestoDeTier,
+} from '../usePerformanceMonitor.jsx';
 /* La dirección de arte compartida (hora dorada + cielos por familia) vive en
    un módulo propio: los arquetipos eligen su CIELOS.<familia>, esta base la
    mezcla hacia ATMOSFERA. Una sola fuente, cero hexes sueltos. */
@@ -44,6 +48,8 @@ function Contenido({
   params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, piso = 0,
   frugal = false, tier = 'alto', hablando = false, focoId = null, focoToken = 0,
   estadoFinca = ESTADO_FINCA_MUESTRA, hayAlerta = false, camaraInicial,
+  tierInicial = 'medio',
+  presupuestoInicial,
   children,
 }) {
   const controls = useRef(null);
@@ -92,6 +98,7 @@ function Contenido({
 
   return (
     <>
+      {!reducedMotion && <MonitorRendimiento key={tierInicial} tier={tierInicial} />}
       <color attach="background" args={[c.fondo]} />
       {/* Niebla sutil: profundidad atmosférica sin lavar el diorama (arranca
           detrás de él y se funde con la niebla dorada del valle). Se paga por
@@ -224,12 +231,11 @@ function Contenido({
         respiro={zoom * 0.005}
         activa={!reducedMotion && !frugal}
       />
-      <AdaptiveDpr pixelated />
       {/* Bloom SUTIL solo donde sobra GPU: tier alto sin reduced-motion. El
           gate es estricto a propósito (contrato de costo del DR de gama baja):
           medio/bajo no montan el pase NI descargan su chunk, y reduced-motion
           tampoco (su frameloop 'demand' no le debe un composer a nadie). */}
-      {tier === 'alto' && !reducedMotion && (
+      {presupuestoInicial.bloom && !reducedMotion && (
         <Suspense fallback={null}>
           <BloomSutil />
         </Suspense>
@@ -250,16 +256,18 @@ export default function EscenaBase3D({
   const [listo, setListo] = useState(false);
   const zoom = entrada?.zoom ?? 6.5;
   const cam = camara || { position: [zoom * 0.55, zoom * 0.5, zoom], fov: 42 };
+  const tierInicial = useMemo(() => detectarTierInicial({ tier, reducedMotion }), [tier, reducedMotion]);
+  const presupuestoInicial = useMemo(() => presupuestoDeTier(tierInicial), [tierInicial]);
   /* Device-tiering (DR-3D-PERF-GAMABAJA §2): el andamiaje ya es frugal por
      contrato (sin sombras, Lambert); lo que gradúa el tier son los píxeles
      (DPR/antialias) y, en el perfil mínimo, la niebla y las alfombras. */
-  const frugal = tier === 'bajo';
-  const dpr = tier === 'alto' ? [1, 1.5] : tier === 'medio' ? [1, 1.3] : 1;
+  const frugal = tierInicial === 'bajo';
+  const dpr = presupuestoInicial.dpr;
   return (
     <Canvas
       className={`mundo-canvas${listo ? ' mundo-canvas--listo' : ''}`}
       dpr={dpr}
-      gl={{ antialias: tier === 'alto', powerPreference: 'high-performance' }}
+      gl={{ antialias: tierInicial === 'alto', powerPreference: 'high-performance' }}
       camera={cam}
       frameloop={reducedMotion ? 'demand' : 'always'}
       onCreated={() => setListo(true)}
@@ -284,6 +292,8 @@ export default function EscenaBase3D({
           estadoFinca={estadoFinca}
           hayAlerta={hayAlerta}
           camaraInicial={cam}
+          tierInicial={tierInicial}
+          presupuestoInicial={presupuestoInicial}
         >
           {children}
         </Contenido>

--- a/src/visual/mundo3d/usePerformanceMonitor.jsx
+++ b/src/visual/mundo3d/usePerformanceMonitor.jsx
@@ -40,9 +40,8 @@
  * el barrel `mundo3d/index.js` (regla del barrel: three-free). Importarlo SOLO
  * desde código 3D perezoso (escenas/, chunk vendor-three), como useEntradaAbeja.
  *
- * IMPORTANTE (cableo): `EscenaBase3D` hoy monta `<AdaptiveDpr>` de drei, que
- * también llama `setDpr`. Al cablear este monitor con `ajustarDpr` (default)
- * hay que RETIRAR `<AdaptiveDpr>` o pasar `ajustarDpr={false}`: dos manos en la
+ * IMPORTANTE (cableo): si el Canvas todavía usa `<AdaptiveDpr>`, hay que
+ * quitarlo o montar este monitor con `ajustarDpr={false}`. Dos manos en la
  * misma perilla pelean. Y con `frameloop='demand'` (reduced-motion) el muestreo
  * de fps no significa nada: no montar el monitor en ese modo.
  */
@@ -52,16 +51,97 @@
    componente monitor) que se importa SIEMPRE dentro de un <Canvas> vía el
    chunk vendor-three; no es hot-reload-sensible. Van juntos a propósito: el
    monitor escribe el store y las escenas leen las derivaciones. */
-import { useEffect, useState, useSyncExternalStore } from 'react';
+import { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import { useThree } from '@react-three/fiber';
 import { PerformanceMonitor } from '@react-three/drei';
+import usePrefsStore from '../../store/usePrefsStore.js';
+import { decidirTier } from './deviceTier.js';
 
 /* ─── 1) Derivaciones puras (sin canvas, sin GPU, sin React) ────────────── */
 
 /** Techo de DPR por tier estático. El DR §6 prohíbe pasar de 1.5. */
 export const TECHO_DPR = { alto: 1.5, medio: 1.25, bajo: 1 };
 
+const TIERS = ['bajo', 'medio', 'alto'];
+const FPS_BAJO = 30;
+const FPS_ALTO = 52;
+const FPS_BAJO_CONSECUTIVOS = 4;
+const FPS_ALTO_CONSECUTIVOS = 5;
+
 const clamp01 = (x) => Math.max(0, Math.min(1, x));
+
+const indiceTier = (tier) => Math.max(0, TIERS.indexOf(tier));
+
+const limitarTier = (tier, techo = 'alto') => TIERS[Math.min(indiceTier(tier), indiceTier(techo))] || 'bajo';
+
+const tierInferior = (tier) => TIERS[Math.max(0, indiceTier(tier) - 1)] || 'bajo';
+
+const tierSuperior = (tier, techo = 'alto') => {
+  const siguiente = TIERS[Math.min(TIERS.length - 1, indiceTier(tier) + 1)] || 'alto';
+  return limitarTier(siguiente, techo);
+};
+
+const objCongelado = (obj) => Object.freeze(obj);
+
+export const PRESUPUESTO_TIER = objCongelado({
+  alto: objCongelado({
+    maxCriaturasAmbientales: 5,
+    maxFlora: 100,
+    bloom: true,
+    sombras: true,
+    dpr: 1.5,
+    postfx: true,
+  }),
+  medio: objCongelado({
+    maxCriaturasAmbientales: 3,
+    maxFlora: 56,
+    bloom: false,
+    sombras: false,
+    dpr: 1.25,
+    postfx: false,
+  }),
+  bajo: objCongelado({
+    maxCriaturasAmbientales: 1,
+    maxFlora: 24,
+    bloom: false,
+    sombras: false,
+    dpr: 1,
+    postfx: false,
+  }),
+});
+
+export function presupuestoDeTier(tier) {
+  return PRESUPUESTO_TIER[tier] || PRESUPUESTO_TIER.medio;
+}
+
+/**
+ * Heurística de arranque para el presupuesto vivo.
+ * Usa el tier del host como techo, pero lo baja si el equipo o la ruta lo
+ * sugieren (UA viejo, ahorro, bajo recurso, valle3d apagado).
+ * @param {{
+ *   tier?: 'alto'|'medio'|'bajo',
+ *   valle3d?: boolean,
+ *   ua?: string,
+ * }} [opts]
+ * @returns {'alto'|'medio'|'bajo'}
+ */
+export function detectarTierInicial({ tier, valle3d = true, ua } = {}) {
+  if (!valle3d) return 'bajo';
+
+  const decision = decidirTier();
+  let base = decision.tier;
+
+  if (TIERS.includes(tier)) {
+    base = limitarTier(base, tier);
+  }
+
+  const userAgent = ua ?? (typeof window !== 'undefined' ? window.navigator?.userAgent ?? '' : '');
+  const androidViejo = /Android\s([0-6]|7\.[0-1])/.test(userAgent);
+  const iosViejo = /(iPhone|iPad|iPod).+OS (1[0-2])_/.test(userAgent);
+  if (androidViejo || iosViejo) base = 'bajo';
+
+  return base;
+}
 
 /**
  * Factor de arranque por tier: 'alto' parte pleno (solo puede bajar si el
@@ -112,39 +192,54 @@ export function escalaParticulasPorFactor(factor) {
 
 /**
  * @typedef {Object} Calidad3D
- * @property {'alto'|'medio'|'bajo'} tier    techo estático (deviceTier)
+ * @property {'alto'|'medio'|'bajo'} tier    tier actual en vivo
+ * @property {'alto'|'medio'|'bajo'} techo   techo de escalado del monitor
  * @property {number} factor                 0..1 continuo del monitor
  * @property {'alto'|'medio'|'bajo'} nivel   perilla discreta en vivo
- * @property {number} dpr                    DPR cuantizado, ≤ TECHO_DPR[tier]
+ * @property {number} dpr                    DPR cuantizado, ≤ techo del presupuesto
  * @property {number} escalaParticulas       0.4..1 para conteos/densidades
  * @property {boolean} fallback              calidad clavada hacia abajo
  */
 
-/** @param {'alto'|'medio'|'bajo'} tier @param {number} factor @param {boolean} fallback @returns {Calidad3D} */
-function derivar(tier, factor, fallback) {
+/** @param {'alto'|'medio'|'bajo'} tier @param {'alto'|'medio'|'bajo'} techo @param {number} factor @param {boolean} fallback @param {number} fps */
+function derivar(tier, techo, factor, fallback, fps = 0) {
+  const cierre = limiteTierSeguro(techo);
+  const t = limitarTier(tier, cierre);
   const f = Math.round(clamp01(factor) * 100) / 100;
+  const presupuesto = presupuestoDeTier(t);
   return Object.freeze({
-    tier,
+    tier: t,
+    techo: cierre,
     factor: f,
     fallback,
+    fps,
     nivel: nivelPorFactor(f),
-    dpr: dprPorFactor(f, TECHO_DPR[tier] ?? 1.25),
+    presupuesto,
+    dpr: dprPorFactor(f, presupuesto.dpr ?? TECHO_DPR[t] ?? 1.25),
     escalaParticulas: escalaParticulasPorFactor(f),
   });
 }
 
-let calidad = derivar('medio', factorInicialPorTier('medio'), false);
+function limiteTierSeguro(tier) {
+  return TIERS.includes(tier) ? tier : 'medio';
+}
+
+let calidad = derivar('medio', 'medio', factorInicialPorTier('medio'), false, 0);
 let fpsUltimo = 0;
+let frioPersistente = 0;
+let calientePersistente = 0;
 const oyentes = new Set();
 
 /** Notifica SOLO si algo derivado cambió (el fps queda fuera a propósito). */
 function emitir(sig) {
   if (
     sig.tier === calidad.tier &&
+    sig.techo === calidad.techo &&
     sig.factor === calidad.factor &&
     sig.nivel === calidad.nivel &&
     sig.dpr === calidad.dpr &&
-    sig.fallback === calidad.fallback
+    sig.fallback === calidad.fallback &&
+    sig.fps === calidad.fps
   ) return;
   calidad = sig;
   oyentes.forEach((fn) => fn());
@@ -172,32 +267,79 @@ export function leerFps() {
  * @param {'alto'|'medio'|'bajo'} tier
  */
 export function sembrarCalidad(tier) {
-  if (tier === calidad.tier) return;
-  emitir(derivar(tier, factorInicialPorTier(tier), false));
+  const techo = limiteTierSeguro(tier);
+  if (calidad.techo === techo) return;
+  frioPersistente = 0;
+  calientePersistente = 0;
+  emitir(derivar(techo, techo, factorInicialPorTier(techo), false, fpsUltimo));
 }
 
 /** Reset total (tests / dev). @param {'alto'|'medio'|'bajo'} [tier] */
 export function reiniciarCalidad(tier = 'medio') {
   fpsUltimo = 0;
-  calidad = derivar(tier, factorInicialPorTier(tier), false);
+  frioPersistente = 0;
+  calientePersistente = 0;
+  calidad = derivar(tier, tier, factorInicialPorTier(tier), false, 0);
   oyentes.forEach((fn) => fn());
+}
+
+function registrarFPS(fps) {
+  if (!Number.isFinite(fps)) return;
+  fpsUltimo = fps;
+  if (fps < FPS_BAJO) {
+    frioPersistente += 1;
+    calientePersistente = 0;
+    return;
+  }
+  if (fps >= FPS_ALTO) {
+    calientePersistente += 1;
+    frioPersistente = 0;
+    return;
+  }
+  frioPersistente = 0;
+  calientePersistente = 0;
+}
+
+function aplicarTierSegunFPS() {
+  let siguiente = calidad.tier;
+  if (frioPersistente >= FPS_BAJO_CONSECUTIVOS) {
+    siguiente = tierInferior(calidad.tier);
+    frioPersistente = 0;
+  } else if (calientePersistente >= FPS_ALTO_CONSECUTIVOS) {
+    siguiente = tierSuperior(calidad.tier, calidad.techo);
+    calientePersistente = 0;
+  }
+  if (siguiente !== calidad.tier) {
+    emitir(derivar(siguiente, calidad.techo, calidad.factor, calidad.fallback, fpsUltimo));
+  }
 }
 
 /** Callback de cambio del monitor drei. Tras fallback solo se acepta bajar. */
 function acusarCambio(api) {
-  fpsUltimo = api.fps;
+  registrarFPS(api.fps);
   const factor = calidad.fallback ? Math.min(calidad.factor, api.factor) : api.factor;
-  emitir(derivar(calidad.tier, factor, calidad.fallback));
+  emitir(derivar(calidad.tier, calidad.techo, factor, calidad.fallback, fpsUltimo));
+  aplicarTierSegunFPS();
 }
 
 /** Callback de fallback del monitor drei: clava la calidad hacia abajo. */
 function acusarFallback(api) {
-  fpsUltimo = api.fps;
-  emitir(derivar(calidad.tier, Math.min(calidad.factor, api.factor), true));
+  registrarFPS(api.fps);
+  emitir(derivar(calidad.tier, calidad.techo, Math.min(calidad.factor, api.factor), true, fpsUltimo));
 }
 
 /** Internos expuestos SOLO para tests unitarios (no consumir en escenas). */
-export const __internos = { acusarCambio, acusarFallback, emitir, derivar };
+export const __internos = {
+  acusarCambio,
+  acusarFallback,
+  emitir,
+  derivar,
+  registrarFPS,
+  aplicarTierSegunFPS,
+  limitarTier,
+  tierInferior,
+  tierSuperior,
+};
 
 /* ─── 3) Piezas React ───────────────────────────────────────────────────── */
 
@@ -208,6 +350,38 @@ export const __internos = { acusarCambio, acusarFallback, emitir, derivar };
  */
 export function useCalidad3D() {
   return useSyncExternalStore(suscribir, leerCalidad, leerCalidad);
+}
+
+/**
+ * Lectura reactiva del presupuesto vivo. El `tierInicial` sale de la heurística
+ * del host; `tier`/`presupuesto` vienen del store dinámico.
+ * @param {{
+ *   tier?: 'alto'|'medio'|'bajo',
+ *   reducedMotion?: boolean,
+ *   valle3d?: boolean,
+ *   ua?: string,
+ * }} [opts]
+ */
+export function useTierPerformance({ tier, reducedMotion = false, valle3d = true, ua } = {}) {
+  const valle3dHabilitado = usePrefsStore((s) => s.valle3d);
+  const tierInicial = useMemo(
+    () => detectarTierInicial({
+      tier,
+      valle3d: valle3d && valle3dHabilitado,
+      ua,
+    }),
+    [tier, valle3d, valle3dHabilitado, ua],
+  );
+  const calidadViva = useCalidad3D();
+  return {
+    tierInicial,
+    tier: calidadViva.tier,
+    presupuesto: calidadViva.presupuesto || presupuestoDeTier(calidadViva.tier),
+    reducedMotion,
+    samplerActivo: !reducedMotion,
+    fallback: calidadViva.fallback,
+    dpr: calidadViva.dpr,
+  };
 }
 
 /** Aplica el DPR del store al renderer. Hijo del Canvas, no dibuja nada. */


### PR DESCRIPTION
## Summary\n- Added a shared tier performance service with initial heuristics, runtime tier hysteresis, and per-tier render budgets.\n- Wired the shared budget into EscenaBase3D, CapaVivaMundo, ParticulasAmbientales, and the valle mockup so ambient life and scene density consume the same budget.\n- Added unit coverage for budget mapping, initial tier heuristics, and tier changes driven by sustained low or high FPS.\n\n## Test plan\n- npx vitest run src/visual/mundo3d/__tests__/usePerformanceMonitor.test.js\n- npm run build\n- npx eslint src/visual/mundo3d/usePerformanceMonitor.jsx src/visual/mundo3d/escenas/EscenaBase3D.jsx src/visual/mundo3d/CapaVivaMundo.jsx src/visual/mundo3d/ParticulasAmbientales.jsx src/mockups/valle/Valle3D.jsx src/visual/mundo3d/__tests__/usePerformanceMonitor.test.js\n- npx vitest run (reported multiple unrelated preexisting failures in other suites)\n- npx eslint . --max-warnings=0 (hit Node heap OOM before completion)