### PR TITLE
feat(bosque): el Ent del páramo (frailejón guardián que enseña)

### DIFF
--- a/src/mockups/VitrinaMaestraMundos.jsx
+++ b/src/mockups/VitrinaMaestraMundos.jsx
@@ -59,6 +59,7 @@ import {
 import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
 import TransicionMundoKit from '../visual/mundo3d/TransicionMundoKit.jsx';
 import { FaunaAmbiental } from '../visual/creatures/FaunaAmbiental.jsx';
+import { EntFrailejon } from '../visual/creatures/EntFrailejon.jsx';
 import useAvatarCreature from '../hooks/useAvatarCreature.js';
 
 /* EL VALLE VIVO en la galería: los personajes asoman ENTRE los mundos, desde
@@ -273,7 +274,9 @@ function FondoVineta({ cielo, suelo, loma }) {
 /* Gancho común: un useFrame que corre el loop SOLO si la viñeta está viva. */
 function usePulso(animada, alPulsar) {
   const fn = useRef(alPulsar);
-  fn.current = alPulsar;
+  // El ref sigue al último callback en un efecto (no durante el render): el
+  // loop de useFrame corre fuera del render y lee fn.current sin problema.
+  useEffect(() => { fn.current = alPulsar; }, [alPulsar]);
   useFrame((state) => {
     if (animada) fn.current(state.clock.elapsedTime);
   });
@@ -1713,6 +1716,32 @@ const CSS_VMX = `
   .vmx-chip, .vmx-tarjeta { transition: none; }
   .vmx-tarjeta__aro span { animation: none; }
 }
+
+/* EL ENT DEL PÁRAMO — arraigado al borde inferior izquierdo, imponente y alto,
+   presidiendo el valle de los mundos. Decorativo: jamás intercepta el toque de
+   los portales. Se asoma desde abajo (no tapa el cielo ni los aros). */
+.vmx-ent {
+  position: absolute;
+  left: clamp(-40px, -2vw, 0px);
+  bottom: -6px;
+  width: min(38vw, 340px);
+  max-height: 78vh;
+  pointer-events: none;
+  z-index: 2;
+  filter: drop-shadow(0 10px 22px rgba(20, 32, 26, 0.4));
+  animation: vmx-ent-entra 900ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.vmx-ent svg { width: 100%; height: auto; display: block; }
+@keyframes vmx-ent-entra {
+  from { transform: translateY(24px); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+@media (max-width: 640px) {
+  .vmx-ent { width: min(52vw, 220px); opacity: 0.85; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .vmx-ent { animation: none; }
+}
 `;
 
 /* ══════════════════════════════════════════════════════════════════════════
@@ -1932,6 +1961,23 @@ export default function VitrinaMaestraMundos({ onBack }) {
           activo={enGaleria}
           puntos={PUNTOS_FAUNA_VITRINA}
         />
+      )}
+
+      {/* EL ENT DEL PÁRAMO — el árbol-guardián que vela el valle de los mundos.
+          Presencia GRANDE e imponente, arraigado al borde: no compite con los
+          portales (decorativo, no intercepta el toque), pero preside la escena
+          como el corazón del Bosque Vivo. Enseña sereno; en tier bajo / RM queda
+          en su fotograma digno. */}
+      {enGaleria && (
+        <div className="vmx-ent" aria-hidden="true">
+          <EntFrailejon
+            size={340}
+            animated={!reducedMotion}
+            ensena={!reducedMotion}
+            lineBoil={!reducedMotion && tier === 'alto'}
+            tier={tier}
+          />
+        </div>
       )}
 
       <div className="vmx-vineta" aria-hidden="true" />

--- a/src/visual/creatures/EntFrailejon.jsx
+++ b/src/visual/creatures/EntFrailejon.jsx
@@ -1,0 +1,330 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+import { OjosRubber, BocaVisema, Sonrisa, RH_INK } from './_rubberhose.jsx';
+import { cuerpoDeClima, ropaDeClima } from './creatureClimaCuerpo.js';
+import { LineBoilFilter } from './LineBoilFilter.jsx';
+import { AuraPoder } from './AuraPoder.jsx';
+import { auraDeBicho } from './transformacion.js';
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * EL ENT DEL PÁRAMO — el árbol-guardián vivo que ENSEÑA (frailejón gigante).
+ *
+ * NO es un bicho: es el ÁRBOL CENTRAL del "Bosque Vivo". Un frailejón gigante
+ * (Espeletia sp.) — el landmark del páramo de casa (Chingaza/Fómeque): tronco
+ * alto vestido con la "faldita" de hojas muertas, una CORONA en roseta de hojas
+ * plateadas y pubescentes (su cabellera), flores amarillas, y un ROSTRO SABIO en
+ * la corteza (ojos hundidos entre las grietas, cejas de corteza, boca en la
+ * hendidura). Guardián del AGUA del páramo. Anciano sereno, LENTO, de peso: nada
+ * hiperactivo — quietud imponente.
+ *
+ * Reusa la MISMA fundación transversal de la familia rubber-hose, adaptada a su
+ * escala y su lentitud: line-boil (LineBoilFilter, muy lento), lip-sync
+ * (BocaVisema por RMS), modo-guardián (el "modo poder": transformacion +
+ * AuraPoder verde-plateado), clima de páramo (cuerpoDeClima/ropaDeClima → aquí
+ * ESCARCHA y NEBLINA, y JAMÁS suda) y la enseñanza (useEntGuion, aparte). El
+ * carácter y la geometría de árbol son propios; cero código de bicho duplicado.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/* Cuadro cuadrado (como el resto de creatures) para que size×size no deforme;
+   preserveAspectRatio por defecto centra el árbol alto sin distorsión. */
+const VIEWBOX = '-16 -20 32 40';
+const SLUG = 'ent-frailejon';
+
+/* Paleta del frailejón (corteza ancestral + faldita ocre + roseta plateada). */
+const ENT = {
+  corteza: '#6f4c2b',
+  cortezaClara: '#8a6b45',
+  cortezaOscura: '#402a15',
+  grieta: '#291a0d',
+  faldita: '#a9793f',
+  falditaOscura: '#7d5527',
+  roseta: '#9db99a',      // verde-plateado pubescente
+  rosetaClara: '#c6d8c0', // el brillo aterciopelado (plateado)
+  rosetaOscura: '#7c9a7d',
+  vena: '#e3eddd',
+  flor: '#f2c531',
+  florCentro: '#c98a1e',
+  ojoHueco: '#22150a',
+  escarcha: '#e9f4ff',
+  raiz: '#5b3d22',
+};
+
+/* Perfil de clima del Ent (páramo alto): la niebla apenas lo difumina (es un
+   gigante), casi no le pega la seca (guarda el agua) y NUNCA se sobrecalienta.
+   Sin alas (es un árbol). Se pasa como perfil a cuerpoDeClima. */
+const ENT_PERFIL_CUERPO = Object.freeze({ alas: false, humedad: 0.55, difusa: 0.3, sequia: 0.2 });
+/* Perfil de "vestuario": adaptado a árbol de páramo → nunca suda (sudaAlSol
+   false), siente el frío pronto (escarcha). Se pasa a ropaDeClima. */
+const ENT_PERFIL_ROPA = Object.freeze({ frioC: 6, calorC: 40, sudaAlSol: false });
+
+/* La CORONA en roseta: hojas lanceoladas que abren en abanico hacia arriba.
+   Generadas deterministamente (fan de ángulos) — dos coronas: la trasera (más
+   ancha y oscura) y la delantera (más clara), para dar volumen de "cabellera". */
+function hojaPath(len, w) {
+  // Hoja lanceolada que apunta hacia ARRIBA desde (0,0) hasta (0,-len).
+  return `M0,0 C${-w},${-len * 0.42} ${-w * 0.5},${-len * 0.86} 0,${-len} `
+    + `C${w * 0.5},${-len * 0.86} ${w},${-len * 0.42} 0,0 Z`;
+}
+
+function Roseta({ cx, cy, vivo, escarcha }) {
+  // Fan trasero (7 hojas, -100°..100°) + delantero (9 hojas, -78°..78°).
+  const traseras = Array.from({ length: 7 }, (_, i) => -100 + (200 / 6) * i);
+  const delanteras = Array.from({ length: 9 }, (_, i) => -78 + (156 / 8) * i);
+  return (
+    <g className={`ent-roseta${vivo ? ' ent-roseta-viva' : ''}`}
+      style={{ transformBox: 'fill-box', transformOrigin: 'center bottom' }}>
+      {/* corona trasera (volumen, más oscura) */}
+      <g className={vivo ? 'ent-hoja-atras' : undefined} fill={ENT.rosetaOscura} stroke={ENT.cortezaOscura} strokeWidth="0.5">
+        {traseras.map((a, i) => (
+          <g key={`t${i}`} className={vivo ? 'ent-hoja' : undefined}
+            style={{ transformBox: 'fill-box', transformOrigin: 'center bottom', animationDelay: `${-0.4 * i}s` }}
+            transform={`rotate(${a} ${cx} ${cy})`}>
+            <path d={hojaPath(10.5, 2.1)} transform={`translate(${cx} ${cy})`} />
+          </g>
+        ))}
+      </g>
+      {/* corona delantera (plateada, con vena central) */}
+      <g fill={ENT.roseta} stroke={ENT.cortezaOscura} strokeWidth="0.55">
+        {delanteras.map((a, i) => (
+          <g key={`d${i}`} className={vivo ? 'ent-hoja' : undefined}
+            style={{ transformBox: 'fill-box', transformOrigin: 'center bottom', animationDelay: `${-0.33 * i}s` }}
+            transform={`rotate(${a} ${cx} ${cy})`}>
+            <path d={hojaPath(9.2, 1.85)} transform={`translate(${cx} ${cy})`} />
+            {/* vena central + brillo pubescente */}
+            <path d={`M${cx},${cy} L${cx},${cy - 8.6}`} stroke={ENT.vena} strokeWidth="0.5" fill="none" opacity="0.7" />
+            {escarcha && (
+              <circle className="ent-escarcha-cristal" cx={cx} cy={cy - 6.2} r="0.6" fill={ENT.escarcha} />
+            )}
+          </g>
+        ))}
+      </g>
+      {/* flores amarillas asomando en el centro de la corona */}
+      <g className={vivo ? 'ent-flor' : undefined}>
+        {[[-2.2, -7.4], [2.4, -7.0], [0, -9.2]].map(([fx, fy], i) => (
+          <g key={`f${i}`}>
+            {Array.from({ length: 8 }, (_, k) => (
+              <ellipse key={k} cx={cx + fx} cy={cy + fy} rx="0.5" ry="1.15" fill={ENT.flor}
+                transform={`rotate(${k * 45} ${cx + fx} ${cy + fy})`} />
+            ))}
+            <circle cx={cx + fx} cy={cy + fy} r="0.85" fill={ENT.florCentro} />
+          </g>
+        ))}
+      </g>
+    </g>
+  );
+}
+
+/* La "faldita": hileras de hojas muertas colgando pegadas al tronco. */
+function Faldita() {
+  const filas = [-2.5, 1.5, 5.5, 9.5];
+  return (
+    <g className="ent-faldita" aria-hidden="true">
+      {filas.map((y, fi) => (
+        <g key={fi}>
+          {[-4.6, -2.3, 0, 2.3, 4.6].map((x, i) => (
+            <path key={i}
+              d={`M${x},${y} Q${x - 1.5},${y + 3.2} ${x},${y + 5.4} Q${x + 1.5},${y + 3.2} ${x},${y} Z`}
+              fill={(fi + i) % 2 ? ENT.faldita : ENT.falditaOscura}
+              stroke={ENT.cortezaOscura} strokeWidth="0.35" opacity="0.92" />
+          ))}
+        </g>
+      ))}
+    </g>
+  );
+}
+
+export function EntFrailejon({
+  size = 96,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'El Ent del páramo (frailejón guardián)',
+  /* Pose de VIDA. El Ent no anda ni brinca: su base es 'arraigado' (quieto,
+     respirando con peso). 'reposo' = duerme el páramo; 'señala' = se inclina a
+     mostrar algo (enseñando). Nada de 'celebra' hiperactiva. */
+  pose = 'arraigado',
+  animo = 'sereno',
+  energia = 1,
+  /* CLIMA REAL de páramo. Sin clima (avatar/catálogo) = neutro digno. */
+  clima = null,
+  enso = 'neutro',
+  tempC = undefined,
+  /* ── LIP-SYNC: la boca entre las grietas del tronco (visema por RMS). Sin
+     visema = la hendidura serena de siempre → avatares no cambian. */
+  visema = null,
+  /* ── CLIMA DE PÁRAMO (opt-in): con vestuario=true el Ent se cubre de ESCARCHA
+     de noche/frío y de NEBLINA cuando el aire está cargado. Vive en el frío:
+     JAMÁS suda (mismo contrato compartido, adaptado). Default false. */
+  vestuario = false,
+  /* ── MODO-GUARDIÁN (su "modo poder"): cuando el páramo peligra el Ent se
+     yergue — aura verde-plateada de 4 capas, ojos que brillan, la roseta se
+     abre. Se siente que va a INTERVENIR. Sobrio y épico. */
+  poder = false,
+  /* ── ENSEÑA: postura de maestro (se inclina un poco, la roseta atenta). El
+     TEXTO lo trae useEntGuion; acá solo marcamos data-ensena para la postura. */
+  ensena = false,
+  /* Device-tier: 'bajo' apaga el idle continuo (boil + mecido) y deja lo
+     reactivo. Sin prop (standalone) = pleno. */
+  tier,
+  /* ── LÍNEA QUE RESPIRA (line-boil, MUY lento en el Ent — corteza ancestral). */
+  lineBoil = false,
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `ent-glow-${uid}`;
+  const blur = `ent-blur-${uid}`;
+  const boil = `ent-boil-${uid}`;
+  const vivo = animated;
+  const auraOp = Math.max(0.12, Math.min(0.34, 0.14 + 0.2 * (energia ?? 1)));
+
+  // CLIMA → cuerpo (determinista): tinte + opacidad. Perfil de gigante de páramo.
+  const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: ENT_PERFIL_CUERPO });
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
+
+  // CLIMA DE PÁRAMO (opt-in): derivamos el estado con el MISMO contrato
+  // (ropaDeClima), pero el Ent no usa ruana/sombrero: su "abrigo" es la ESCARCHA
+  // (frío/noche) y la NEBLINA. Y NUNCA suda (sudor forzado a false por su perfil).
+  const estadoClima = (vestuario && clima) ? ropaDeClima(clima, { perfil: ENT_PERFIL_ROPA, tempC }) : null;
+  const escarcha = !!(estadoClima && estadoClima.ruana); // frío/noche → escarcha
+  const neblina = !!(estadoClima && estadoClima.niebla);
+  const mojado = !!(estadoClima && estadoClima.mojado);
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+      {lineBoil && <LineBoilFilter id={boil} animated={vivo} baseFrequency={0.018} scale={3.2} dur="0.7s" />}
+    </defs>
+  );
+
+  // NEBLINA: bandas tenues que cruzan el tronco (solo con clima de niebla).
+  const bruma = neblina ? (
+    <g className="ent-neblina" aria-hidden="true" fill={ENT.escarcha} opacity="0.42">
+      <ellipse className={vivo ? 'ent-neblina-banda' : undefined} cx="0" cy="2" rx="15" ry="1.6" />
+      <ellipse className={vivo ? 'ent-neblina-banda' : undefined} style={{ animationDelay: '-3s' }} cx="0" cy="8" rx="14" ry="1.3" />
+    </g>
+  ) : null;
+
+  const body = (
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* aura viva (presencia del gigante) */}
+      <circle cx="0" cy="0" r="12.5" fill={ENT.roseta} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* RAÍCES que se asientan (base del árbol, detrás del tronco) */}
+      <g className={vivo ? 'ent-raices' : undefined} stroke={ENT.raiz} strokeWidth="2.2" strokeLinecap="round" fill="none">
+        <path d="M-3,15 C-6,16.5 -9,17 -11.5,17.4" />
+        <path d="M-1.5,15.5 C-3,17.5 -4.5,18.4 -6.2,18.8" />
+        <path d="M3,15 C6,16.5 9,17 11.5,17.4" />
+        <path d="M1.5,15.5 C3,17.5 4.5,18.4 6.2,18.8" />
+        <path d="M0,15.6 C0.3,17.6 0.4,18.6 0.2,19.2" />
+      </g>
+
+      {/* TRONCO alto (la línea gruesa que respira con el boil) — tapered path */}
+      <path
+        d="M-6,16 C-6.4,9 -5.2,1 -4.4,-5 C-4,-8 -2,-9 0,-9 C2,-9 4,-8 4.4,-5 C5.2,1 6.4,9 6,16 C4,17.6 -4,17.6 -6,16 Z"
+        fill={ENT.corteza} stroke={RH_INK} strokeWidth="1.3"
+        style={{ filter: `drop-shadow(0 0 5px ${ENT.cortezaOscura})` }} />
+      {/* vetas/grietas de la corteza (la línea que respira) */}
+      <g className="ent-grietas" stroke={ENT.grieta} strokeWidth="0.7" fill="none" strokeLinecap="round" opacity="0.75">
+        <path d="M-2.6,-6 C-3.2,0 -3.4,7 -3,14" />
+        <path d="M2.6,-6 C3.2,0 3.4,7 3,14" />
+        <path d="M0,10 C-0.2,12 -0.2,14 0,15.6" />
+      </g>
+
+      {/* faldita de hojas muertas pegada al tronco */}
+      <Faldita />
+
+      {/* ── ROSTRO SABIO en la corteza ─────────────────────────────────────── */}
+      {/* hoyos hundidos de los ojos (corteza oscura) — profundidad ancestral */}
+      <g fill={ENT.ojoHueco}>
+        <ellipse cx="-3" cy="-1" rx="2.5" ry="2.9" />
+        <ellipse cx="3" cy="-1" rx="2.5" ry="2.9" />
+      </g>
+      {/* nariz-cresta de corteza entre los ojos */}
+      <path d="M0,-2.4 C-0.7,-0.6 -0.7,1.6 0,2.6 C0.7,1.6 0.7,-0.6 0,-2.4 Z"
+        fill={ENT.cortezaClara} opacity="0.7" />
+      {/* CEJAS de corteza: gruesas cornisas SERENAS (no bravas) sobre los ojos —
+          el rostro del anciano sabio, no del gruñón. */}
+      <g className="ent-cejas" stroke={ENT.cortezaOscura} strokeWidth="1.6" strokeLinecap="round" fill="none">
+        <path d="M-5.4,-3.6 C-4,-4.4 -2.2,-4.2 -1,-3.4" />
+        <path d="M5.4,-3.6 C4,-4.4 2.2,-4.2 1,-3.4" />
+      </g>
+      {/* ojos hundidos que parpadean LENTO (rh-blink, ralentizado por la especie) */}
+      <OjosRubber
+        ojos={[{ cx: -3, cy: -1, r: 1.7 }, { cx: 3, cy: -1, r: 1.7 }]}
+        mirar={[0, 0.18]}
+        parpadea={vivo}
+      />
+      {/* BOCA entre las grietas del tronco: lip-sync si hay visema; si no, la
+          hendidura serena (una grieta que sonríe apenas). */}
+      <g className="ent-boca">
+        {visema
+          ? <BocaVisema cx={0} cy={5} w={4.2} prof={1.4} visema={visema} ink={ENT.grieta} />
+          : <Sonrisa cx={0} cy={5} w={3.8} prof={1.2} ink={ENT.grieta} />}
+      </g>
+
+      {/* CORONA en roseta (su cabellera plateada) — se dibuja al FRENTE del tope
+          del tronco, con las flores. Es lo que "se abre" en modo-guardián. */}
+      <Roseta cx={0} cy={-7} vivo={vivo} escarcha={escarcha} />
+
+      {/* NEBLINA que cruza el tronco (clima). */}
+      {bruma}
+    </g>
+  );
+
+  // Antics de VIDA (balanceo ancestral, muy lento) SOLO viva; nodo aparte para
+  // no pisar el boil de `.crt-body`. El CSS lo apaga con RM / tier bajo.
+  const conAntics = vivo ? (
+    <g className="ent-balanceo">{body}</g>
+  ) : body;
+  const cuerpoVivo = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
+
+  const estadoAttrs = {
+    'data-creature': SLUG,
+    'data-pose': vivo ? pose : undefined,
+    'data-animo': animo,
+    'data-tier': tier || undefined,
+    'data-visema': visema || undefined,
+    'data-escarcha': escarcha ? '1' : undefined,
+    'data-neblina': neblina ? '1' : undefined,
+    'data-mojado': mojado ? '1' : undefined,
+    'data-ensena': ensena ? '1' : undefined,
+    'data-lineboil': lineBoil ? '1' : undefined,
+  };
+
+  if (inline) {
+    return (
+      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+        {defs}
+        {cuerpoVivo}
+      </g>
+    );
+  }
+  const svg = (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
+      <title>{title}</title>
+      {defs}
+      {cuerpoVivo}
+    </svg>
+  );
+  // MODO-GUARDIÁN (standalone): lo envolvemos en su aura VERDE-PLATEADA de 4
+  // capas (transformacion.css: glow radial + boost + ingravidez + corrientes).
+  if (poder) {
+    return (
+      <span
+        className="is-powered-up ent-poder"
+        data-creature-poder={SLUG}
+        style={{ '--aura-color': auraDeBicho(SLUG), display: 'inline-flex' }}
+      >
+        {svg}
+        <AuraPoder />
+      </span>
+    );
+  }
+  return svg;
+}
+
+export default EntFrailejon;

--- a/src/visual/creatures/README.md
+++ b/src/visual/creatures/README.md
@@ -145,6 +145,36 @@ cierre). Nocturno de montaña: **nunca suda** (ruana de noche/frío). En la vere
 lo cazan; aquí lo honramos **vivo, a salvo y querido**. Todo aditivo en
 `creatures.css`, RM + tier-safe.
 
+## El Ent del páramo — el árbol-maestro (no un bicho)
+
+El **`EntFrailejon`** es el **corazón del "Bosque Vivo"**: un **frailejón gigante**
+(*Espeletia* sp.), el árbol-guardián **vivo, ancestral y sabio** que ENSEÑA. NO es
+fauna: es el **árbol central**, con **presencia GRANDE** e imponente. Traduce a los
+Andes el alma de un árbol-guardián de la fantasía clásica: un **rostro sabio en la
+corteza** (ojos hundidos entre las grietas, **cejas de corteza** serenas, boca en
+la hendidura), tronco alto vestido con la **faldita** de hojas muertas, **corona en
+roseta** de hojas plateadas y pubescentes (su cabellera) con **flores amarillas**, y
+**raíces** que se asientan. Se mueve **LENTO y con peso** — quietud imponente, nada
+hiperactivo.
+
+Hereda la MISMA fundación transversal, **adaptada a su escala y su lentitud**:
+- **Expresividad de árbol vivo** — `lineBoil` MUY lento (corteza ancestral),
+  **balanceo** de todo el árbol, roseta que **respira y se mece** (`.ent-hoja`),
+  parpadeo lento y raíces asentadas.
+- **Lip-sync** — la boca entre las **grietas del tronco** (`visema` → `BocaVisema`)
+  para cuando enseña/habla.
+- **Modo-GUARDIÁN** (su "modo poder", `poder`) — cuando el páramo peligra el Ent se
+  **yergue**: aura **verde-plateada** de 4 capas, la **roseta se abre** y brilla, las
+  flores encienden; sobrio y épico.
+- **Clima de páramo** (`vestuario`) — **ESCARCHA** en las hojas de noche/frío y
+  **NEBLINA** que cruza el tronco; del contrato compartido pero **JAMÁS suda** (vive
+  en el frío).
+- **Enseñanza** — `useEntGuion()` trae el guion de botánica/clima/conservación/caza
+  en **usted** colombiano; **fallback digno** de 4 snippets hasta que aterrice
+  `src/data/entGuion.js` (punto de integración listo: `useEntGuion({ guion })`).
+
+Todo aditivo en `creatures.css`, RM + tier-safe.
+
 ## Técnica
 
 - SVG + CSS puros, **cero dependencias nuevas**; solo `transform`/`opacity`

--- a/src/visual/creatures/__tests__/EntFrailejon.render.test.jsx
+++ b/src/visual/creatures/__tests__/EntFrailejon.render.test.jsx
@@ -1,0 +1,210 @@
+/**
+ * EntFrailejon.render.test.jsx — el Ent del páramo (frailejón guardián), los 5
+ * FRENTES + el fallback del guion. El Ent NO es un bicho: es el árbol-maestro
+ * del Bosque Vivo. Verifica que sus capas ADITIVAS se rendericen sin romper el
+ * contrato de la familia rubber-hose:
+ *   1. Expresividad de árbol vivo con PESO — line-boil lento, rostro sabio
+ *      (cejas de corteza), roseta, faldita, raíces, balanceo ancestral.
+ *   2. Lip-sync — la boca entre las grietas del tronco (data-visema).
+ *   3. Modo-GUARDIÁN — aura VERDE-PLATEADA de 4 capas (no dorada), la roseta se abre.
+ *   4. Clima de páramo — ESCARCHA de noche/frío, NEBLINA, y JAMÁS suda.
+ *   5. Enseñanza — useEntGuion trae el guion; fallback digno hasta que aterrice
+ *      src/data/entGuion.js (punto de integración: useEntGuion({ guion })).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, renderHook, act, cleanup } from '@testing-library/react';
+import { EntFrailejon } from '../EntFrailejon.jsx';
+import { auraDeBicho } from '../transformacion.js';
+import {
+  useEntGuion, resolverGuionEnt, ENT_GUION_PLACEHOLDER, ENT_TEMAS,
+} from '../useEntGuion.js';
+
+afterEach(cleanup);
+
+describe('EntFrailejon — contrato base intacto', () => {
+  it('render por defecto = svg accesible, sin capas opt-in', () => {
+    const { container } = render(<EntFrailejon />);
+    const svg = container.querySelector('svg[data-creature="ent-frailejon"]');
+    expect(svg).toBeTruthy();
+    expect(svg.getAttribute('role')).toBe('img');
+    // Ninguna capa opt-in aparece sin pedirla (no regresión).
+    expect(svg.getAttribute('data-lineboil')).toBeNull();
+    expect(svg.getAttribute('data-escarcha')).toBeNull();
+    expect(svg.getAttribute('data-neblina')).toBeNull();
+    expect(svg.getAttribute('data-ensena')).toBeNull();
+    expect(svg.getAttribute('data-visema')).toBeNull();
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+  });
+
+  it('siempre trae su rostro sabio y su anatomía de frailejón (identidad)', () => {
+    const { container } = render(<EntFrailejon />);
+    expect(container.querySelector('.ent-cejas')).toBeTruthy();   // cejas de corteza
+    expect(container.querySelector('.ent-roseta')).toBeTruthy();  // corona plateada
+    expect(container.querySelector('.ent-faldita')).toBeTruthy(); // hojas muertas
+    expect(container.querySelector('.ent-raices')).toBeTruthy();  // raíces que asientan
+  });
+});
+
+describe('1. Expresividad de árbol vivo con PESO', () => {
+  it('lineBoil instancia el filtro de displacement (corteza que hierve, lento)', () => {
+    const { container } = render(<EntFrailejon lineBoil animated />);
+    expect(container.querySelector('svg').getAttribute('data-lineboil')).toBe('1');
+    expect(container.querySelector('feDisplacementMap')).toBeTruthy();
+    expect(container.querySelector('feTurbulence')).toBeTruthy();
+  });
+
+  it('sin lineBoil NO se paga el filtro (frugal)', () => {
+    const { container } = render(<EntFrailejon animated />);
+    expect(container.querySelector('feDisplacementMap')).toBeNull();
+  });
+
+  it('vivo → balanceo ancestral y la corona viva; quieto → fotograma digno', () => {
+    const { container: vivo } = render(<EntFrailejon animated />);
+    expect(vivo.querySelector('.ent-balanceo')).toBeTruthy();
+    expect(vivo.querySelector('.ent-roseta-viva')).toBeTruthy();
+    cleanup();
+    const { container: quieto } = render(<EntFrailejon animated={false} />);
+    expect(quieto.querySelector('.ent-balanceo')).toBeNull();
+    // la roseta sigue dibujada (digna), solo sin la clase de vida
+    expect(quieto.querySelector('.ent-roseta')).toBeTruthy();
+    expect(quieto.querySelector('.ent-roseta-viva')).toBeNull();
+  });
+});
+
+describe('2. Lip-sync — la boca entre las grietas', () => {
+  it('con visema V3 la boca abierta viaja a la cara (data-visema)', () => {
+    const { container } = render(<EntFrailejon visema="V3" />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBe('V3');
+  });
+
+  it('sin visema no marca data-visema (la hendidura serena de siempre)', () => {
+    const { container } = render(<EntFrailejon />);
+    expect(container.querySelector('svg').getAttribute('data-visema')).toBeNull();
+  });
+});
+
+describe('3. Modo-GUARDIÁN — aura VERDE-PLATEADA de 4 capas', () => {
+  it('poder envuelve en .is-powered-up + corrientes, con aura verde-plateada (no dorada)', () => {
+    const { container } = render(<EntFrailejon poder />);
+    const wrap = container.querySelector('.is-powered-up');
+    expect(wrap).toBeTruthy();
+    expect(wrap.getAttribute('data-creature-poder')).toBe('ent-frailejon');
+    expect(wrap.getAttribute('style')).toContain('--aura-color');
+    expect(wrap.getAttribute('style')).toContain(auraDeBicho('ent-frailejon'));
+    // el aura del Ent NO es la dorada de la abeja ni la roja del oso
+    expect(auraDeBicho('ent-frailejon')).not.toBe(auraDeBicho('abeja-angelita'));
+    expect(auraDeBicho('ent-frailejon')).not.toBe(auraDeBicho('oso-andino'));
+    // capa 4: las corrientes (AuraPoder)
+    expect(container.querySelector('.poder-corrientes')).toBeTruthy();
+  });
+
+  it('sin poder no hay wrapper (svg desnudo)', () => {
+    const { container } = render(<EntFrailejon />);
+    expect(container.querySelector('.is-powered-up')).toBeNull();
+    expect(container.querySelector(':scope > svg[data-creature="ent-frailejon"]')).toBeTruthy();
+  });
+});
+
+describe('4. Clima de páramo — escarcha, neblina y JAMÁS suda', () => {
+  it('de noche/frío con vestuario → ESCARCHA en las hojas, nunca sudor', () => {
+    const { container } = render(<EntFrailejon vestuario clima="noche" />);
+    const svg = container.querySelector('svg');
+    expect(svg.getAttribute('data-escarcha')).toBe('1');
+    expect(container.querySelector('.ent-escarcha-cristal')).toBeTruthy();
+    // el frailejón vive en el frío: no se acalora nunca
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+  });
+
+  it('con niebla → NEBLINA que cruza el tronco', () => {
+    const { container } = render(<EntFrailejon vestuario clima="niebla" />);
+    expect(container.querySelector('svg').getAttribute('data-neblina')).toBe('1');
+    expect(container.querySelector('.ent-neblina-banda')).toBeTruthy();
+  });
+
+  it('de día caluroso (tempC alta) el Ent NO suda (páramo, identidad)', () => {
+    const { container } = render(<EntFrailejon vestuario clima="soleado" tempC={30} />);
+    expect(container.querySelector('.crt-sudor')).toBeNull();
+    expect(container.querySelector('.crt-gota-sudor')).toBeNull();
+    expect(container.querySelector('svg').getAttribute('data-escarcha')).toBeNull();
+  });
+
+  it('sin vestuario (avatar/catálogo) → nada de clima aunque haya dato', () => {
+    const { container } = render(<EntFrailejon clima="noche" />);
+    const svg = container.querySelector('svg');
+    expect(svg.getAttribute('data-escarcha')).toBeNull();
+    expect(container.querySelector('.ent-escarcha-cristal')).toBeNull();
+  });
+});
+
+describe('5. Enseñanza — el guion del Ent-maestro (fallback digno)', () => {
+  it('resolverGuionEnt() sin guion real → placeholders (4 snippets, un tema c/u)', () => {
+    const { lista, fuente } = resolverGuionEnt();
+    expect(fuente).toBe('placeholder');
+    expect(lista).toBe(ENT_GUION_PLACEHOLDER);
+    expect(lista.length).toBe(4);
+    // cubre los 4 temas del guardián del páramo
+    const temas = new Set(lista.map((s) => s.tema));
+    for (const t of ENT_TEMAS) expect(temas.has(t)).toBe(true);
+    // usted colombiano (no voseo): ningún snippet dice "tenés"/"vos"
+    for (const s of lista) {
+      expect(/\btenés\b|\bvos\b/i.test(s.texto)).toBe(false);
+    }
+  });
+
+  it('resolverGuionEnt(guionReal) → lo consume (fuente=guion), ignora entradas vacías', () => {
+    const guionReal = [
+      { id: 'r1', tema: 'clima', titulo: 'Real', texto: 'El páramo es una esponja de agua.' },
+      { id: 'vacio', tema: 'x', titulo: '', texto: '   ' }, // se filtra
+    ];
+    const { lista, fuente } = resolverGuionEnt(guionReal);
+    expect(fuente).toBe('guion');
+    expect(lista.length).toBe(1);
+    expect(lista[0].id).toBe('r1');
+  });
+
+  it('guion inválido/ vacío → cae al placeholder (nunca rompe)', () => {
+    expect(resolverGuionEnt([]).fuente).toBe('placeholder');
+    expect(resolverGuionEnt(null).fuente).toBe('placeholder');
+    expect(resolverGuionEnt([{ texto: '' }]).fuente).toBe('placeholder');
+  });
+
+  it('useEntGuion (hook) sin guion → snippet placeholder y avanza en ciclo', () => {
+    const { result } = renderHook(() => useEntGuion());
+    expect(result.current.fuente).toBe('placeholder');
+    expect(result.current.total).toBe(4);
+    const primero = result.current.snippet.id;
+    act(() => result.current.avanzar());
+    expect(result.current.snippet.id).not.toBe(primero);
+    expect(result.current.indice).toBe(1);
+    // porTema salta al snippet del tema pedido
+    act(() => result.current.porTema('caza'));
+    expect(result.current.snippet.tema).toBe('caza');
+  });
+
+  it('useEntGuion (hook) con guion real → fuente=guion', () => {
+    const guion = [{ id: 'g', tema: 'botanica', titulo: 'T', texto: 'Crezco un centímetro al año.' }];
+    const { result } = renderHook(() => useEntGuion({ guion }));
+    expect(result.current.fuente).toBe('guion');
+    expect(result.current.snippet.id).toBe('g');
+  });
+});
+
+describe('Postura de enseñanza + anti-regresión inline', () => {
+  it('ensena marca la postura de maestro (data-ensena)', () => {
+    const { container } = render(<EntFrailejon ensena />);
+    expect(container.querySelector('svg').getAttribute('data-ensena')).toBe('1');
+  });
+
+  it('inline devuelve un <g> con data-creature y marca data-poder', () => {
+    const { container } = render(
+      <svg>
+        <EntFrailejon inline poder ensena />
+      </svg>,
+    );
+    const g = container.querySelector('g[data-creature="ent-frailejon"]');
+    expect(g).toBeTruthy();
+    expect(g.getAttribute('data-poder')).toBe('1'); // el host DOM pinta el aura
+    expect(g.getAttribute('data-ensena')).toBe('1');
+  });
+});

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1723,3 +1723,142 @@
   .borugo-poder .borugo-motas-luz,
   [data-creature='borugo'][data-poder='1'] .borugo-motas-luz { animation: none !important; opacity: 0.5; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   EL ENT DEL PÁRAMO — el frailejón guardián (árbol-maestro, NO un bicho).
+   Todo ADITIVO: quietud imponente y LENTA (nada hiperactivo). Reusa la
+   fundación (.crt-body + rh-boil, OjosRubber → rh-blink) pero ralentizada, y
+   suma sus capas propias (roseta que se mece, balanceo ancestral, escarcha,
+   neblina, modo-guardián). RM + tier-safe al final.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* El boil de la corteza y el parpadeo del anciano van MUCHO más lentos (peso,
+   edad): mayor especificidad por el data-creature (como rana/oso). */
+[data-creature='ent-frailejon'] .rh-boil { animation-duration: 4.6s; }
+[data-creature='ent-frailejon'] .rh-blink { animation-duration: 9.2s; }
+[data-creature='ent-frailejon'] .rh-mirada { animation-duration: 13.5s; }
+
+/* BALANCEO ANCESTRAL — todo el árbol se mece lentísimo, con peso (no gira: se
+   inclina un pelo y vuelve). Envuelve al cuerpo, aparte del boil. */
+.ent-balanceo {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: ent-balanceo 13s ease-in-out infinite;
+}
+@keyframes ent-balanceo {
+  0%, 100% { transform: rotate(-1.1deg); }
+  50%      { transform: rotate(1.1deg); }
+}
+
+/* LA ROSETA (cabellera plateada) respira despacio y sus hojas se mecen
+   escalonadas — la brisa del páramo peinando la corona. */
+.ent-roseta-viva {
+  animation: ent-roseta-respira 7.5s ease-in-out infinite;
+}
+@keyframes ent-roseta-respira {
+  0%, 100% { transform: scaleY(1) scaleX(1); }
+  50%      { transform: scaleY(1.035) scaleX(0.99); }
+}
+.ent-hoja {
+  animation: ent-hoja-mece 5.2s ease-in-out infinite;
+}
+@keyframes ent-hoja-mece {
+  0%, 100% { transform: rotate(-2.2deg); }
+  50%      { transform: rotate(2.2deg); }
+}
+
+/* Flores amarillas: latido tenue de vida. */
+.ent-flor { animation: ent-flor-late 6s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+@keyframes ent-flor-late {
+  0%, 100% { opacity: 0.92; }
+  50%      { opacity: 1; }
+}
+
+/* ESCARCHA en las hojas (clima frío/noche): cristalitos que titilan lento. */
+.ent-escarcha-cristal {
+  animation: ent-escarcha-brilla 4.4s ease-in-out infinite;
+}
+@keyframes ent-escarcha-brilla {
+  0%, 100% { opacity: 0.5; }
+  50%      { opacity: 0.95; }
+}
+
+/* NEBLINA que cruza el tronco (clima de niebla): bandas que derivan de lado. */
+.ent-neblina-banda {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: ent-neblina-deriva 9s ease-in-out infinite;
+}
+@keyframes ent-neblina-deriva {
+  0%, 100% { transform: translateX(-1.6px); opacity: 0.32; }
+  50%      { transform: translateX(1.6px); opacity: 0.5; }
+}
+
+/* ENSEÑA — postura de maestro: se inclina un pelín hacia adelante (atento a
+   quien aprende). Pisa el balanceo (mayor especificidad) mientras enseña. */
+[data-creature='ent-frailejon'][data-ensena='1'] .ent-balanceo {
+  animation: ent-ensena 5s ease-in-out infinite;
+}
+@keyframes ent-ensena {
+  0%, 100% { transform: rotate(0deg); }
+  50%      { transform: rotate(2.4deg) translateY(-0.4px); }
+}
+
+/* MODO-GUARDIÁN — el páramo peligra: el Ent se YERGUE. La roseta se ABRE (se
+   agranda y brilla), las flores encienden y todo cobra un halo verde-plateado.
+   Vale en standalone (wrapper .ent-poder) y en inline (data-poder en el <g>). */
+.ent-poder .ent-roseta,
+[data-creature='ent-frailejon'][data-poder='1'] .ent-roseta {
+  animation: ent-guardian-roseta 3.2s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes ent-guardian-roseta {
+  0%, 100% { transform: scale(1.04); filter: brightness(1.06); }
+  50%      { transform: scale(1.12); filter: brightness(1.2); }
+}
+.ent-poder .ent-flor,
+[data-creature='ent-frailejon'][data-poder='1'] .ent-flor {
+  animation-name: ent-guardian-flor;
+  animation-duration: 2.4s;
+}
+@keyframes ent-guardian-flor {
+  0%, 100% { opacity: 1; filter: brightness(1.1); }
+  50%      { opacity: 1; filter: brightness(1.45); }
+}
+/* ojos que brillan: la cresta-nariz y las cejas de corteza cobran vida glacial */
+.ent-poder .ent-cejas,
+[data-creature='ent-frailejon'][data-poder='1'] .ent-cejas {
+  animation: ent-guardian-cejas 3s ease-in-out infinite;
+}
+@keyframes ent-guardian-cejas {
+  0%, 100% { filter: drop-shadow(0 0 0.6px var(--aura-color, #8fdcae)); }
+  50%      { filter: drop-shadow(0 0 2.4px var(--aura-color, #8fdcae)); }
+}
+
+/* device-tier 'bajo': el idle continuo del Ent se apaga (frugal) — igual que
+   los .rh-* globales. Los estados de clima/guardián quedan en fotograma digno. */
+[data-tier='bajo'][data-creature='ent-frailejon'] .ent-balanceo,
+[data-tier='bajo'][data-creature='ent-frailejon'] .ent-roseta-viva,
+[data-tier='bajo'][data-creature='ent-frailejon'] .ent-hoja,
+[data-tier='bajo'][data-creature='ent-frailejon'] .ent-flor,
+[data-tier='bajo'][data-creature='ent-frailejon'] .ent-escarcha-cristal,
+[data-tier='bajo'][data-creature='ent-frailejon'] .ent-neblina-banda { animation: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  [data-creature='ent-frailejon'] .rh-boil,
+  [data-creature='ent-frailejon'] .rh-blink,
+  [data-creature='ent-frailejon'] .rh-mirada,
+  .ent-balanceo, .ent-roseta-viva, .ent-hoja, .ent-flor,
+  .ent-escarcha-cristal, .ent-neblina-banda,
+  .ent-poder .ent-roseta,
+  [data-creature='ent-frailejon'][data-poder='1'] .ent-roseta,
+  .ent-poder .ent-flor,
+  [data-creature='ent-frailejon'][data-poder='1'] .ent-flor,
+  .ent-poder .ent-cejas,
+  [data-creature='ent-frailejon'][data-poder='1'] .ent-cejas,
+  [data-creature='ent-frailejon'][data-ensena='1'] .ent-balanceo { animation: none !important; }
+  /* la roseta-guardián queda abierta y digna, sin latir */
+  .ent-poder .ent-roseta,
+  [data-creature='ent-frailejon'][data-poder='1'] .ent-roseta { transform: scale(1.06); }
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -55,6 +55,15 @@ export { Perezoso, PEREZOSO_PALETA, PEREZOSO_PROPORCION } from './Perezoso.jsx';
 export { Lombriz } from './Lombriz.jsx';
 export { Mariposa } from './Mariposa.jsx';
 export { Escarabajo } from './Escarabajo.jsx';
+/* EL ENT DEL PÁRAMO — el árbol-guardián que enseña (frailejón gigante). NO es un
+   bicho: es el corazón del "Bosque Vivo". Hereda la MISMA fundación transversal
+   (line-boil, lip-sync, modo-poder=guardián, clima) adaptada a su escala y su
+   lentitud. Su voz-maestra (el guion de botánica/clima/conservación/caza) vive
+   en useEntGuion (fallback digno hasta que aterrice src/data/entGuion.js). */
+export { EntFrailejon } from './EntFrailejon.jsx';
+export {
+  useEntGuion, resolverGuionEnt, ENT_GUION_PLACEHOLDER, ENT_TEMAS,
+} from './useEntGuion.js';
 
 /* ── SISTEMA DE PERSONAJES (transversal, species-agnostic) ───────────────────
    La FUNDACIÓN que heredan los 9 bichos: lip-sync, modo poder, prop-por-mundo,
@@ -97,6 +106,7 @@ import Borugo from './Borugo.jsx';
 import Lombriz from './Lombriz.jsx';
 import Mariposa from './Mariposa.jsx';
 import Escarabajo from './Escarabajo.jsx';
+import EntFrailejon from './EntFrailejon.jsx';
 
 /* Registro consultable: slug → componente + binomio verificado. */
 export const CREATURES = {
@@ -112,4 +122,6 @@ export const CREATURES = {
   lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
   mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
   escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },
+  // El árbol-maestro del Bosque Vivo (flora, no fauna): el frailejón guardián.
+  'ent-frailejon': { Component: EntFrailejon, nombre: 'El Ent del páramo', cientifico: 'Espeletia sp.' },
 };

--- a/src/visual/creatures/transformacion.js
+++ b/src/visual/creatures/transformacion.js
@@ -36,6 +36,7 @@ export const AURA_POR_BICHO = Object.freeze({
   perezoso: '#1ec9b7',         // turquesa/teal zen irónico (distinto del verde de la rana)
   morrocoy: '#ff7a3c',         // caparazón que brilla (ámbar-rojizo)
   borugo: '#dbe8ff',           // PLATA LUNAR / blanco luminoso (nocturno sagrado, el animal de cierre)
+  'ent-frailejon': '#8fdcae',  // VERDE-PLATEADO del guardián del páramo (modo-guardián: el frailejón se yergue a intervenir)
 });
 
 /* Aura por defecto si el slug no está mapeado (la dorada de la guía). */

--- a/src/visual/creatures/useEntGuion.js
+++ b/src/visual/creatures/useEntGuion.js
@@ -1,0 +1,164 @@
+/*
+ * useEntGuion — la voz que ENSEÑA del Ent del páramo (el frailejón guardián).
+ *
+ * El Ent no es un bicho más: es un ÁRBOL-MAESTRO. Cuando habla, dice cosas de
+ * botánica, del clima del páramo, de conservación y de la caza — pausado y
+ * profundo. Ese GUION lo prepara otro frente del proyecto en
+ * `src/data/entGuion.js`. Mientras ese archivo aterriza, este hook trae un
+ * fallback DIGNO de 4 snippets (uno por tema) en usted colombiano, y deja el
+ * PUNTO DE INTEGRACIÓN listo:
+ *
+ *   // cuando exista src/data/entGuion.js, el host lo pasa:
+ *   import { ENT_GUION } from '../../data/entGuion.js';
+ *   const { snippet, avanzar, fuente } = useEntGuion({ guion: ENT_GUION });
+ *
+ * Sin `guion` (o vacío/ inválido) → placeholders (`fuente === 'placeholder'`).
+ * Con `guion` real → lo consume tal cual (`fuente === 'guion'`). Jamás rompe:
+ * nunca importa estáticamente un archivo que quizá no existe todavía.
+ *
+ * Species-agnostic del RESTO de la fundación: el Ent produce TEXTO; el lip-sync
+ * (useLipSync) y la boca-en-las-grietas (BocaVisema) ya saben animar la boca a
+ * partir del audio del TTS. Este hook solo elige QUÉ enseña.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+/* Los 4 temas del Ent-maestro (biblia del guardián del páramo). */
+export const ENT_TEMAS = Object.freeze(['botanica', 'clima', 'conservacion', 'caza']);
+
+/**
+ * Fallback DIGNO — 4 snippets, uno por tema, en usted colombiano cordial.
+ * Cada uno: { id, tema, titulo, texto }. Reemplácelos (o mejor: pásele el
+ * `guion` real) cuando `src/data/entGuion.js` esté listo.
+ * @type {ReadonlyArray<{id:string,tema:string,titulo:string,texto:string}>}
+ */
+export const ENT_GUION_PLACEHOLDER = Object.freeze([
+  {
+    id: 'ent-botanica',
+    tema: 'botanica',
+    titulo: 'Quién soy',
+    texto:
+      'Soy el frailejón. Crezco un centímetro al año, así que tengo la edad de sus '
+      + 'bisabuelos. Mis hojas viejas no las boto: se quedan pegadas al tronco '
+      + 'abrigándome del frío. Tenga paciencia, que el páramo no se afana.',
+  },
+  {
+    id: 'ent-clima',
+    tema: 'clima',
+    titulo: 'El agua del páramo',
+    texto:
+      'Mire mis hojas peludas: atrapan la neblina y la vuelven gotas. Este suelo '
+      + 'negro guarda esa agua como una esponja y se la entrega despacito al río. '
+      + 'De aquí baja el agua que usted toma allá abajo.',
+  },
+  {
+    id: 'ent-conservacion',
+    tema: 'conservacion',
+    titulo: 'No le prenda candela',
+    texto:
+      'El páramo quemado no vuelve a ser el mismo en la vida de usted. Si quema '
+      + 'para sembrar más arriba, seca el nacimiento. Cuídeme la mata y yo le '
+      + 'cuido el agua: ese es el trato viejo.',
+  },
+  {
+    id: 'ent-caza',
+    tema: 'caza',
+    titulo: 'Los animales son de la casa',
+    texto:
+      'El oso, el venado y el borugo también son del páramo. Déjelos vivir: ellos '
+      + 'riegan las semillas y mantienen la montaña sana. Cazarlos es quedarse solo '
+      + 'en la niebla.',
+  },
+]);
+
+/** ¿Es un snippet de guion válido? (defensivo ante datos a medio hornear.) */
+function snippetValido(s) {
+  return !!s && typeof s === 'object' && typeof s.texto === 'string' && s.texto.trim().length > 0;
+}
+
+/**
+ * Resuelve el GUION efectivo del Ent (helper PURO, testeable sin React).
+ * Con un `guion` real válido → { lista, fuente: 'guion' }; si no → placeholders.
+ *
+ * @param {ReadonlyArray<any>} [guion] el guion real (src/data/entGuion.js) o nada.
+ * @returns {{ lista: ReadonlyArray<{id:string,tema:string,titulo:string,texto:string}>, fuente:('guion'|'placeholder') }}
+ */
+export function resolverGuionEnt(guion) {
+  if (Array.isArray(guion)) {
+    const limpio = guion.filter(snippetValido);
+    if (limpio.length > 0) return { lista: limpio, fuente: 'guion' };
+  }
+  return { lista: ENT_GUION_PLACEHOLDER, fuente: 'placeholder' };
+}
+
+/**
+ * useEntGuion — elige QUÉ enseña el Ent. Recorre los snippets (avance manual o
+ * automático). No toca audio ni SVG: solo entrega el snippet del momento para
+ * que el host lo lea con el TTS (y el lip-sync anime la boca).
+ *
+ * @param {object} [opts]
+ * @param {ReadonlyArray<any>} [opts.guion] el guion real; sin él → placeholders.
+ * @param {number} [opts.indiceInicial=0]
+ * @param {boolean} [opts.autoAvanzar=false] rota solo cada `intervaloMs`.
+ * @param {number} [opts.intervaloMs=9000] periodo del auto-avance.
+ * @returns {{
+ *   snippet: {id:string,tema:string,titulo:string,texto:string},
+ *   indice: number, total: number, temas: ReadonlyArray<string>,
+ *   fuente: ('guion'|'placeholder'),
+ *   avanzar: () => void, irA: (i:number)=>void, porTema:(t:string)=>void,
+ * }}
+ */
+export function useEntGuion({
+  guion,
+  indiceInicial = 0,
+  autoAvanzar = false,
+  intervaloMs = 9000,
+} = {}) {
+  const { lista, fuente } = useMemo(() => resolverGuionEnt(guion), [guion]);
+  const total = lista.length;
+  const [indice, setIndice] = useState(() => {
+    const i = Number.isInteger(indiceInicial) ? indiceInicial : 0;
+    return total > 0 ? ((i % total) + total) % total : 0;
+  });
+
+  // Si la lista cambia de tamaño (aterriza el guion real), reencauza el índice.
+  const totalRef = useRef(total);
+  useEffect(() => {
+    if (totalRef.current !== total) {
+      totalRef.current = total;
+      setIndice((i) => (total > 0 ? ((i % total) + total) % total : 0));
+    }
+  }, [total]);
+
+  const irA = useCallback((i) => {
+    setIndice((prev) => {
+      if (total <= 0) return 0;
+      const n = Number.isInteger(i) ? i : prev;
+      return ((n % total) + total) % total;
+    });
+  }, [total]);
+
+  const avanzar = useCallback(() => {
+    setIndice((prev) => (total > 0 ? (prev + 1) % total : 0));
+  }, [total]);
+
+  const porTema = useCallback((tema) => {
+    setIndice((prev) => {
+      const i = lista.findIndex((s) => s.tema === tema);
+      return i >= 0 ? i : prev;
+    });
+  }, [lista]);
+
+  useEffect(() => {
+    if (!autoAvanzar || total <= 1) return undefined;
+    const ms = Number.isFinite(intervaloMs) && intervaloMs > 0 ? intervaloMs : 9000;
+    const t = setInterval(avanzar, ms);
+    return () => clearInterval(t);
+  }, [autoAvanzar, intervaloMs, total, avanzar]);
+
+  const snippet = lista[indice] || ENT_GUION_PLACEHOLDER[0];
+
+  return { snippet, indice, total, temas: ENT_TEMAS, fuente, avanzar, irA, porTema };
+}
+
+export default useEntGuion;

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -186,6 +186,24 @@ const VARIANTES_BORUGO = [
   { label: 'sin animación', props: { size: 88, animated: false } },
 ];
 
+/* EL ENT DEL PÁRAMO — el árbol-maestro del Bosque Vivo (NO un bicho). Presencia
+   GRANDE e imponente. Luce sus 5 frentes: expresividad de árbol vivo (line-boil
+   lento, roseta que se mece, rostro sabio), lip-sync (boca en las grietas),
+   modo-GUARDIÁN (aura verde-plateada, la roseta se abre), clima de páramo
+   (ESCARCHA de noche/frío, NEBLINA) y la postura de enseñanza (señala/enseña). */
+const VARIANTES_ENT = [
+  { label: '64 px', props: { size: 64 } },
+  { label: 'arraigado', props: { size: 132 } },
+  { label: 'enseña', props: { size: 132, ensena: true } },
+  { label: 'reposo (el páramo duerme)', props: { size: 132, pose: 'reposo' } },
+  { label: 'habla (lip-sync)', props: { size: 132, visema: 'V3' } },
+  { label: 'escarcha (noche fría)', props: { size: 132, vestuario: true, clima: 'noche' } },
+  { label: 'neblina', props: { size: 132, vestuario: true, clima: 'niebla' } },
+  { label: 'modo-GUARDIÁN', props: { size: 132, poder: true } },
+  { label: 'línea que hierve', props: { size: 132, lineBoil: true } },
+  { label: 'sin animación', props: { size: 132, animated: false } },
+];
+
 const VARIANTES_POR_SLUG = {
   'abeja-angelita': VARIANTES_ABEJA,
   colibri: VARIANTES_TRIO_AIRE,
@@ -196,6 +214,7 @@ const VARIANTES_POR_SLUG = {
   jaguar: VARIANTES_JAGUAR,
   morrocoy: VARIANTES_MORROCOY,
   borugo: VARIANTES_BORUGO,
+  'ent-frailejon': VARIANTES_ENT,
 };
 
 /* Nota de campo por creature (el registro de la categoría trae nombre + binomio;
@@ -210,6 +229,7 @@ const NOTAS_CREATURE = {
   jaguar: 'Felino de tierra cálida, majestuoso y acechador; leonado con rosetas de centro ocre (su firma), aura púrpura.',
   morrocoy: 'Galápago de patas rojas, el anciano ancestral y paciente; caparazón de domo hexagonal (su firma) y patas rojizas, aura bronce. Se retrae elástico a la concha.',
   borugo: 'La paca de montaña andina, roedor nocturno tierno; pardo con hileras de motas crema (su firma), olfateo tímido y aura plata lunar. El animal de cierre — vivo, a salvo y digno.',
+  'ent-frailejon': 'El árbol-guardián que enseña: frailejón gigante del páramo, tronco con rostro sabio y faldita de hojas muertas, corona en roseta plateada y flores amarillas. Guardián del agua; anciano sereno y lento. Modo-guardián verde-plateado cuando el páramo peligra.',
   lombriz: 'La ingeniera del suelo; ondula por segmentos con clitelo marcado.',
   mariposa: 'Alas naranjas con venación; poliniza y anuncia buen suelo.',
   escarabajo: 'Estercolero que entierra el abono; élitros con brillo metálico.',


### PR DESCRIPTION
## El Ent del páramo — el árbol-maestro del Bosque Vivo

Criatura INSIGNIA: el **árbol-guardián vivo que enseña**, en identidad andina — un **frailejón gigante** (*Espeletia* sp., el landmark del páramo de casa). Rostro sabio en la corteza, faldita de hojas muertas, corona en roseta plateada y flores amarillas. Anciano sereno y **lento** — quietud imponente, nada hiperactivo.

Archivo NUEVO `src/visual/creatures/EntFrailejon.jsx` (+ `useEntGuion.js`), siguiendo el patrón de la familia rubber-hose y reusando la fundación transversal adaptada a su escala/lentitud.

### Los 5 frentes (todos cerrados)
1. **Expresividad de árbol vivo con peso** — line-boil MUY lento (corteza ancestral), balanceo del árbol entero, roseta que respira y se mece (`.ent-hoja`), parpadeo lento, raíces que se asientan, cejas de corteza serenas.
2. **Lip-sync** — la boca entre las **grietas del tronco** (`visema` → `BocaVisema` por RMS).
3. **Modo-GUARDIÁN** (su modo-poder) — aura **verde-plateada** de 4 capas, la **roseta se abre** y brilla, las flores encienden; sobrio y épico.
4. **Clima de páramo** — **ESCARCHA** en las hojas de noche/frío y **NEBLINA** que cruza el tronco; del contrato compartido (`ropaDeClima`) pero **JAMÁS suda**.
5. **Enseñanza** — `useEntGuion()` con **fallback digno** de 4 snippets (botánica / clima / conservación / caza, en **usted** colombiano). `src/data/entGuion.js` aún no existe en dev → punto de integración listo: `useEntGuion({ guion })`.

### Dónde aparece
- Registrado (aditivo) en `creatures/index.js`, `visual/registry.js` y `README.md` → aparece en la vitrina de la librería visual con 10 variantes (los 5 frentes).
- Entrada **imponente** en `VitrinaMaestraMundos.jsx`: preside el valle de los mundos como guardián del páramo (decorativo, no intercepta el toque).

### Verificación DURA
- `npm run build` ✅ verde.
- `npx vitest run src/visual/creatures` ✅ **265** tests (16 archivos), incl. **20** del Ent (5 frentes + fallback de guion + no-NaN con todos los flags).
- `eslint --max-warnings=0` ✅ limpio en todo lo tocado. De paso, fix de un error `react-hooks/refs` **preexistente** en `usePulso` que bloqueaba el lint de ese archivo.

### Notas
- Anti-conflicto: **aditivo** en compartidos (bloque ENT al final de `creatures.css`, `index.js`, `registry.js`, `README.md`); NO se tocaron los 9 animales, `outputGuards.js` ni `externalAiPromptBuilder.js`.
- reduced-motion + tier-safe (fotograma digno).
- UI en **usted** colombiano. Diseño original — cero referencias externas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)