### PR TITLE
feat(juego): prototipo nivel 1 del Metal Slug del campo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -160,6 +160,9 @@ const ValleLluviaMockup = lazy(() => import('./mockups/ValleLluvia3D'));
 const MundoSemilleroMockup = lazy(() => import('./mockups/MundoSemillero3D'));
 const MundoCompostMockup = lazy(() => import('./mockups/MundoCompost3D'));
 const JuegoMiFincaMockup = lazy(() => import('./mockups/JuegoMiFincaOdyssey'));
+// Metal Slug del campo: run-and-gun agroecológico (nivel 1). Angelita "combate"
+// plagas reales con control biológico y libera al oso andino cazado. Sin auth.
+const MetalSlugCampoMockup = lazy(() => import('./mockups/MetalSlugCampo'));
 // La "ventana-puerta" al valle: viewport 3D vivo enmarcado para el home 2D.
 const VentanaValleMockup = lazy(() => import('./components/VentanaValle3D'));
 // New Donk: un plano 2D lado-a-lado embebido DENTRO del valle 3D (Mario Odyssey).
@@ -593,6 +596,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo-semillero-3d': 'mockup_mundo_semillero_3d',
   'mockups/mundo-compost-3d': 'mockup_mundo_compost_3d',
   'mockups/juego-mi-finca': 'mockup_juego_mi_finca',
+  'mockups/metal-slug-campo': 'mockup_metal_slug_campo',
   'mockups/ventana-valle': 'mockup_ventana_valle',
   'mockups/new-donk': 'mockup_new_donk',
   'mockups/murales-new-donk': 'mockup_murales_new_donk',
@@ -1922,6 +1926,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Juego Mi finca (túnel Odyssey)">
               <JuegoMiFincaMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_metal_slug_campo':
+        // Metal Slug del campo (nivel 1): side-scroller run-and-gun agroecológico.
+        // Angelita recorre la huerta templada, controla plagas reales con el
+        // aliado biológico correcto (ficha didáctica al vencerlas), libera al oso
+        // andino cazado (mensaje de conservación) y aprende el par plaga↔control.
+        // Reusa defensoresGameEngine + metalSlugCampoData. Sin auth (vitrina).
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Metal Slug del campo (nivel 1)">
+              <MetalSlugCampoMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/MetalSlugCampo.jsx
+++ b/src/mockups/MetalSlugCampo.jsx
@@ -1,0 +1,965 @@
+/**
+ * MetalSlugCampo — prototipo jugable del "Metal Slug del campo" (nivel 1).
+ *
+ * Run-and-gun agroecológico SIN violencia: Angelita la abeja recorre la huerta de
+ * la ladera templada (NIVELES[0]), "combate" plagas reales lanzando el CONTROL
+ * BIOLÓGICO correcto (Bt, mariquita, Beauveria, crisopa), libera al oso andino
+ * cazado (rehén estilo POW) y aprende con fichas didácticas al vencer cada plaga.
+ *
+ * REÚSA (no reinventa motores):
+ *   - Física de salto y colisiones → `defensoresGameEngine` vía `metalSlugCampoEngine`
+ *     (`avanzarFisica`, `rectsOverlap`).
+ *   - Lógica de disparo/par arma↔plaga/rescate → `metalSlugCampoEngine` (puro, testeado).
+ *   - Data agronómica REAL → `../data/metalSlugCampoData` (enemigos, armas, rehenes, nivel).
+ *   - Sprites rubber-hose canónicos → `../visual/creatures` (Abeja héroe, Oso rehén).
+ *   - Tier + reduced-motion → `../visual/mundo3d/deviceTier` (mismo criterio que el Odyssey).
+ *
+ * Determinismo: la simulación corre a PASO FIJO (1/60 s) con acumulador, así el
+ * salto/gravedad usan las constantes del engine base tal cual sus tests.
+ * Offline-safe: cero red, es-CO en «usted». reduced-motion: sin screenshake ni
+ * wobble decorativo (la locomoción esencial se mantiene).
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- Juego servido solo en es-CO
+   (mismo criterio que metalSlugCampoData / defensoresFincaData): copy pedagógico
+   campesino en «usted», no strings de UI transversal migrables a messages.js. */
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AbejaAngelita, OsoAndino } from '../visual/creatures';
+import { decidirTier } from '../visual/mundo3d/deviceTier.js';
+import {
+  NIVELES,
+  getEnemigo,
+  getArma,
+  getRehen,
+} from '../data/metalSlugCampoData';
+import {
+  armasDeNivel,
+  crearProyectil,
+  avanzarProyectil,
+  resolverImpactoArma,
+  alcanzaRehen,
+  patrullarPlaga,
+  evaluarFinCampo,
+  PUNTOS_PLAGA,
+  PUNTOS_REHEN,
+} from '../services/metalSlugCampoEngine';
+import {
+  avanzarFisica,
+  rectsOverlap,
+  JUMP_VELOCITY,
+  MOVE_SPEED,
+} from '../services/defensoresGameEngine';
+
+/* ── Geometría del mundo (coords diseño; x→derecha, y→abajo). ───────────────── */
+const ALTO_2D = 520; // alto de diseño de la vista
+const SUELO_Y = 432; // línea del piso (donde apoyan los pies)
+const MUNDO_W = 2720; // ancho total del nivel
+const STEP = 1 / 60; // paso fijo de simulación (s)
+const MAX_DT = 0.05; // clamp anti-saltos (pestaña en segundo plano)
+const JUGADOR_W = 48;
+const JUGADOR_H = 66;
+const ENERGIA_INICIAL = 3;
+const INVULN_MS = 1200;
+const DISPARO_COOLDOWN_MS = 260;
+const FICHA_MS = 3200; // pausa breve de la ficha didáctica
+const NIVEL = NIVELES[0];
+
+/* Paleta cálida de la ladera templada (misma familia térmica del repo). */
+const PAL = Object.freeze({
+  cielo: '#bfe3ef',
+  cieloBajo: '#eaf3d9',
+  lomaLejos: '#a9c69b',
+  lomaCerca: '#7fae74',
+  suelo: '#8a6a44',
+  sueloClaro: '#a8814f',
+  pasto: '#6fa650',
+  tinta: '#3a2a1a',
+});
+
+/* Color del proyectil según el ROL biológico real del arma (data-driven). */
+const COLOR_POR_TIPO = Object.freeze({
+  microbiano: '#2bb3a3', // Bt / Beauveria (hongo/bacteria)
+  depredador: '#d1443b', // mariquita / crisopa
+  parasitoide: '#e0a021', // avispitas
+  botanico: '#5aa03c', // purín de ortiga
+});
+
+/* Arsenal CURADO del prototipo: intersección con el arsenal real del nivel (sin
+   invento). Enseña los pares que de verdad se enfrentan en el nivel 1. */
+const ARSENAL_CURADO = ['bt', 'catarina', 'beauveria', 'crisopa'];
+
+/* Instancias de plaga sembradas por el nivel (grounding: todas son de NIVEL.enemigos). */
+const SIEMBRA_PLAGAS = [
+  { enemigoId: 'cogollero', x: 560, vuela: false },
+  { enemigoId: 'pulgon', x: 900, vuela: false },
+  { enemigoId: 'moscablanca', x: 1240, vuela: true },
+  { enemigoId: 'afido', x: 1560, vuela: false },
+  { enemigoId: 'cogollero', x: 1900, vuela: false },
+  { enemigoId: 'moscablanca', x: 2180, vuela: true },
+];
+
+/* ── Estado inicial del mundo (puro, recomponible al reintentar). ───────────── */
+function crearMundo() {
+  const enemigos = SIEMBRA_PLAGAS.map((s, i) => {
+    const eh = s.vuela ? 40 : 46;
+    const ew = s.vuela ? 46 : 52;
+    const baseY = s.vuela ? SUELO_Y - 150 : SUELO_Y - eh;
+    return {
+      id: `${s.enemigoId}#${i}`,
+      enemigoId: s.enemigoId,
+      x: s.x,
+      y: baseY,
+      w: ew,
+      h: eh,
+      vivo: true,
+      vuela: s.vuela,
+      dir: i % 2 === 0 ? -1 : 1,
+      vel: s.vuela ? 46 : 34,
+      xMin: s.x - 90,
+      xMax: s.x + 90,
+      fase: i * 0.7,
+    };
+  });
+  return {
+    jugador: {
+      x: 120,
+      y: SUELO_Y - JUGADOR_H,
+      vy: 0,
+      onGround: true,
+      mira: 1,
+      w: JUGADOR_W,
+      h: JUGADOR_H,
+      energia: ENERGIA_INICIAL,
+      invulnHasta: 0,
+    },
+    enemigos,
+    proyectiles: [],
+    rehen: { x: 2500, y: SUELO_Y - 88, w: 80, h: 88, liberado: false },
+    cam: 0,
+    puntaje: 0,
+    armaIdx: 0,
+    ultimoDisparo: 0,
+    shakeHasta: 0,
+    shakeMag: 0,
+    reloj: 0,
+  };
+}
+
+/* ── SIMULACIÓN (scope de módulo: sin estado React, muta el mundo `w`). ──────── */
+
+/**
+ * Un tick de simulación de PASO FIJO (STEP s). Muta `w` en sitio y marca eventos
+ * discretos (`w._evento*`) que `despacharEventos` traslada luego a React.
+ * Reusa el motor puro para física, patrulla, disparo e impacto.
+ *
+ * @param {Object} w          mundo mutable.
+ * @param {number} ahora      timestamp (performance.now) para invulnerabilidad.
+ * @param {{izq:boolean,der:boolean,salto:boolean}} teclas  entrada actual.
+ * @param {boolean} reducedMotion  gate de screenshake/flotar decorativo.
+ */
+function simularTick(w, ahora, teclas, reducedMotion) {
+  const k = teclas;
+  const j = w.jugador;
+  w.reloj += STEP;
+
+  /* andar */
+  const dir = (k.der ? 1 : 0) - (k.izq ? 1 : 0);
+  if (dir !== 0) j.mira = dir;
+  j.x = Math.max(30, Math.min(MUNDO_W - j.w - 10, j.x + dir * MOVE_SPEED));
+
+  /* salto + gravedad + suelo (reusa el engine base, paso por tick) */
+  if (k.salto && j.onGround) {
+    j.vy = JUMP_VELOCITY;
+    j.onGround = false;
+  }
+  const fis = avanzarFisica({ y: j.y, vy: j.vy, onGround: j.onGround }, SUELO_Y, j.h);
+  j.y = fis.y;
+  j.vy = fis.vy;
+  j.onGround = fis.onGround;
+
+  /* patrulla de plagas (determinista) + leve flotar de las que vuelan */
+  for (const e of w.enemigos) {
+    if (!e.vivo) continue;
+    const p = patrullarPlaga(e, STEP, e.xMin, e.xMax);
+    e.x = p.x;
+    e.dir = p.dir;
+    if (e.vuela) {
+      const base = SUELO_Y - 150;
+      e.y = base + (reducedMotion ? 0 : Math.sin(w.reloj * 2.2 + e.fase) * 16);
+    }
+  }
+
+  /* proyectiles: avanzar + resolver impacto (EL PAR arma↔plaga) */
+  const vivos = [];
+  for (const proy of w.proyectiles) {
+    const movido = avanzarProyectil(proy, STEP, MUNDO_W);
+    if (!movido) continue;
+    const { plagas, impacto } = resolverImpactoArma(movido, w.enemigos);
+    if (impacto) {
+      w.enemigos = plagas;
+      if (impacto.correcto) {
+        w.puntaje += PUNTOS_PLAGA;
+        w._eventoFicha = impacto.enemigoId;
+        w._shake = Math.max(w._shake || 0, reducedMotion ? 0 : 5);
+      } else {
+        w._eventoErrado = impacto.enemigoId;
+        w._shake = Math.max(w._shake || 0, reducedMotion ? 0 : 3);
+      }
+      // proyectil consumido: no se reencola
+    } else {
+      vivos.push(movido);
+    }
+  }
+  w.proyectiles = vivos;
+
+  /* contacto jugador↔plaga viva → pierde energía (con invulnerabilidad breve) */
+  if (ahora >= j.invulnHasta) {
+    for (const e of w.enemigos) {
+      if (e.vivo && rectsOverlap(j, e)) {
+        j.energia -= 1;
+        j.invulnHasta = ahora + INVULN_MS;
+        w._shake = Math.max(w._shake || 0, reducedMotion ? 0 : 8);
+        w._eventoGolpe = true;
+        break;
+      }
+    }
+  }
+
+  /* rescate del rehén (oso andino cazado) */
+  if (alcanzaRehen(j, w.rehen)) {
+    w.rehen.liberado = true;
+    w.puntaje += PUNTOS_REHEN;
+    w._eventoRehen = true;
+    w._shake = Math.max(w._shake || 0, reducedMotion ? 0 : 6);
+  }
+
+  /* fin de nivel */
+  const plagasVivas = w.enemigos.filter((e) => e.vivo).length;
+  const res = evaluarFinCampo({
+    energia: j.energia,
+    plagasVivas,
+    rehenLiberado: w.rehen.liberado,
+  });
+  if (res.estado !== 'jugando') {
+    w._eventoFin = res;
+  }
+}
+
+/**
+ * Traslada a React los eventos discretos que el tick marcó en `w`.
+ * @param {Object} w
+ * @param {boolean} reducedMotion
+ * @param {{setFicha:Function,setToast:Function,setAvisoRehen:Function,setFin:Function,finRef:Object}} d
+ */
+function despacharEventos(w, reducedMotion, d) {
+  if (w._shake && !reducedMotion) {
+    w.shakeMag = w._shake;
+    w.shakeHasta = performance.now() + 220;
+    w._shake = 0;
+  }
+  if (w._eventoFicha) {
+    d.setFicha({ enemigoId: w._eventoFicha });
+    w._eventoFicha = null;
+  }
+  if (w._eventoErrado) {
+    const e = getEnemigo(w._eventoErrado);
+    d.setToast(`Ese control no le sirve a ${e?.nombre_comun || 'esa plaga'}. Pruebe con su aliado correcto.`);
+    w._eventoErrado = null;
+  }
+  if (w._eventoGolpe) {
+    w._eventoGolpe = null;
+  }
+  if (w._eventoRehen) {
+    d.setAvisoRehen(getRehen(NIVEL.rehen));
+    w._eventoRehen = null;
+  }
+  if (w._eventoFin) {
+    d.finRef.current = w._eventoFin;
+    d.setFin(w._eventoFin);
+    d.setFicha(null);
+    d.setAvisoRehen(null);
+    w._eventoFin = null;
+  }
+}
+
+/* ════════════════════════════════════════════════════════════════════════════
+ * COMPONENTE
+ * ════════════════════════════════════════════════════════════════════════════ */
+export default function MetalSlugCampo({ onBack }) {
+  const [{ tier, reducedMotion }] = useState(() => decidirTier());
+  const [pantalla, setPantalla] = useState('intro'); // 'intro' | 'juego'
+
+  const arsenal = useMemo(
+    () => ARSENAL_CURADO.filter((id) => armasDeNivel(NIVEL.numero).includes(id)),
+    [],
+  );
+
+  return (
+    <div className="msc-root" data-tier={tier} data-rm={reducedMotion ? '1' : '0'}>
+      <StyleMSC />
+      <button type="button" className="msc-volver" onClick={onBack}>
+        ← Volver
+      </button>
+
+      {pantalla === 'intro' ? (
+        <Intro nivel={NIVEL} arsenal={arsenal} onJugar={() => setPantalla('juego')} />
+      ) : (
+        <Juego
+          tier={tier}
+          reducedMotion={reducedMotion}
+          arsenal={arsenal}
+          onSalirIntro={() => setPantalla('intro')}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ── Pantalla de inicio: contexto del nivel + arsenal. ──────────────────────── */
+function Intro({ nivel, arsenal, onJugar }) {
+  return (
+    <div className="msc-intro">
+      <div className="msc-intro-card">
+        <p className="msc-kicker">Metal Slug del campo · Nivel {nivel.numero}</p>
+        <h1 className="msc-titulo">{nivel.nombre}</h1>
+        <p className="msc-intro-texto">{nivel.intro}</p>
+        <div className="msc-arsenal-intro">
+          <span className="msc-arsenal-rotulo">Su arsenal de control biológico:</span>
+          <ul>
+            {arsenal.map((id) => {
+              const a = getArma(id);
+              return (
+                <li key={id}>
+                  <b style={{ color: COLOR_POR_TIPO[a?.tipo] || PAL.tinta }}>■</b> {a?.nombre}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+        <p className="msc-ayuda">
+          Muévase con <kbd>←</kbd> <kbd>→</kbd>, salte con <kbd>espacio</kbd>, dispare con <kbd>J</kbd>{' '}
+          y cambie de control biológico con <kbd>K</kbd>. En el celular, use los botones de abajo.
+          Cada plaga se controla con su aliado correcto: si se equivoca, la plaga aguanta.
+        </p>
+        <button type="button" className="msc-btn-jugar" onClick={onJugar}>
+          ¡A cuidar la finca!
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════════════════
+ * JUEGO — RAF de paso fijo. Posiciones en worldRef; React re-renderiza por frame
+ * (pocas entidades) y los sprites pesados van memoizados. Overlays pausan la sim.
+ * ════════════════════════════════════════════════════════════════════════════ */
+function Juego({ tier, reducedMotion, arsenal, onSalirIntro }) {
+  const vistaRef = useRef(null);
+  const teclasRef = useRef({ izq: false, der: false, salto: false });
+  const anchoRef = useRef(760);
+  const pausaRef = useRef(false);
+  const finRef = useRef(null);
+
+  // El mundo canónico y mutable vive en `worldRef`; `vista` es el snapshot que
+  // se pinta cada frame (mismo objeto al montar, copias superficiales luego).
+  const [vista, setVista] = useState(crearMundo);
+  const worldRef = useRef(vista);
+  const [ficha, setFicha] = useState(null); // { enemigoId } — pausa breve didáctica
+  const [avisoRehen, setAvisoRehen] = useState(null); // mensaje de conservación
+  const [toast, setToast] = useState(null); // feedback transitorio (arma equivocada)
+  const [fin, setFin] = useState(null); // { estado, razon }
+
+  /* medir ancho visible en unidades de diseño (para la cámara) */
+  useEffect(() => {
+    const el = vistaRef.current;
+    if (!el) return undefined;
+    const medir = () => {
+      const r = el.getBoundingClientRect();
+      const escala = Math.max(0.3, r.height / ALTO_2D);
+      anchoRef.current = r.width / escala;
+    };
+    medir();
+    const ro = new ResizeObserver(medir);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  /* disparar: crea un proyectil desde el frente del jugador si pasó el cooldown */
+  const disparar = useCallback(() => {
+    const w = worldRef.current;
+    if (pausaRef.current || finRef.current) return;
+    const ahora = performance.now();
+    if (ahora - w.ultimoDisparo < DISPARO_COOLDOWN_MS) return;
+    w.ultimoDisparo = ahora;
+    const j = w.jugador;
+    const px = j.mira > 0 ? j.x + j.w : j.x - 26;
+    const proy = crearProyectil({
+      x: px,
+      y: j.y + 22,
+      dir: j.mira,
+      armaId: arsenal[w.armaIdx % arsenal.length],
+    });
+    w.proyectiles.push(proy);
+  }, [arsenal]);
+
+  /* cambiar de arma (control biológico) */
+  const cambiarArma = useCallback(() => {
+    const w = worldRef.current;
+    w.armaIdx = (w.armaIdx + 1) % arsenal.length;
+    setVista({ ...w });
+  }, [arsenal]);
+
+  /* reiniciar el nivel EN SITIO (sin desmontar): mundo fresco + limpiar overlays */
+  const reiniciar = useCallback(() => {
+    worldRef.current = crearMundo();
+    finRef.current = null;
+    pausaRef.current = false;
+    teclasRef.current = { izq: false, der: false, salto: false };
+    setFin(null);
+    setFicha(null);
+    setAvisoRehen(null);
+    setToast(null);
+    setVista({ ...worldRef.current });
+  }, []);
+
+  /* teclado */
+  useEffect(() => {
+    const abajo = (e) => {
+      const k = teclasRef.current;
+      if (e.key === 'ArrowLeft' || e.key === 'a' || e.key === 'A') {
+        k.izq = true;
+        e.preventDefault();
+      } else if (e.key === 'ArrowRight' || e.key === 'd' || e.key === 'D') {
+        k.der = true;
+        e.preventDefault();
+      } else if (e.key === 'ArrowUp' || e.key === ' ' || e.key === 'w' || e.key === 'W') {
+        k.salto = true;
+        e.preventDefault();
+      } else if ((e.key === 'j' || e.key === 'J' || e.key === 'f' || e.key === 'F') && !e.repeat) {
+        disparar();
+      } else if ((e.key === 'k' || e.key === 'K') && !e.repeat) {
+        cambiarArma();
+      } else if ((e.key === 'Enter' || e.key === 'e') && !e.repeat) {
+        // cerrar overlays didácticos con Enter
+        if (ficha) setFicha(null);
+        if (avisoRehen) setAvisoRehen(null);
+      }
+    };
+    const arriba = (e) => {
+      const k = teclasRef.current;
+      if (e.key === 'ArrowLeft' || e.key === 'a' || e.key === 'A') k.izq = false;
+      else if (e.key === 'ArrowRight' || e.key === 'd' || e.key === 'D') k.der = false;
+      else if (e.key === 'ArrowUp' || e.key === ' ' || e.key === 'w' || e.key === 'W') k.salto = false;
+    };
+    window.addEventListener('keydown', abajo);
+    window.addEventListener('keyup', arriba);
+    return () => {
+      window.removeEventListener('keydown', abajo);
+      window.removeEventListener('keyup', arriba);
+    };
+  }, [disparar, cambiarArma, ficha, avisoRehen]);
+
+  /* la ficha didáctica se despide sola (pausa breve, no rompe el ritmo) */
+  useEffect(() => {
+    if (!ficha) return undefined;
+    pausaRef.current = true;
+    const t = setTimeout(() => setFicha(null), FICHA_MS);
+    return () => clearTimeout(t);
+  }, [ficha]);
+  useEffect(() => {
+    // al cerrarse ficha y aviso, se reanuda (si no hay otro overlay abierto)
+    if (!ficha && !avisoRehen) pausaRef.current = false;
+    else pausaRef.current = true;
+  }, [ficha, avisoRehen]);
+
+  /* toast transitorio (arma equivocada) */
+  useEffect(() => {
+    if (!toast) return undefined;
+    const t = setTimeout(() => setToast(null), 1700);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  /* ── EL LATIDO: un solo rAF, paso fijo, todo por el motor puro. ───────────── */
+  useEffect(() => {
+    const dispatch = { setFicha, setToast, setAvisoRehen, setFin, finRef };
+    let raf = 0;
+    let prev = performance.now();
+    let acc = 0;
+    const paso = (ahora) => {
+      const dt = Math.min(MAX_DT, (ahora - prev) / 1000);
+      prev = ahora;
+      const w = worldRef.current;
+
+      if (!pausaRef.current && !finRef.current) {
+        acc += dt;
+        while (acc >= STEP) {
+          simularTick(w, ahora, teclasRef.current, reducedMotion);
+          acc -= STEP;
+        }
+        // efectos discretos acumulados en el tick se despachan abajo
+        despacharEventos(w, reducedMotion, dispatch);
+      }
+
+      // cámara (suave, incluso en pausa para que no salte)
+      const ancho = anchoRef.current;
+      const objetivo = Math.max(0, Math.min(MUNDO_W - ancho, w.jugador.x - ancho * 0.4));
+      w.cam += (objetivo - w.cam) * Math.min(1, dt * 6);
+
+      // screenshake + parpadeo de invulnerabilidad: SE CALCULAN AQUÍ (zona impura
+      // del rAF) y se guardan en el mundo, para que el render los lea puros.
+      const enShake = !reducedMotion && ahora < w.shakeHasta;
+      w.shakeX = enShake ? (Math.random() - 0.5) * w.shakeMag : 0;
+      w.shakeY = enShake ? (Math.random() - 0.5) * w.shakeMag : 0;
+      w.invulnVisible = ahora < w.jugador.invulnHasta;
+
+      setVista({ ...w });
+      raf = requestAnimationFrame(paso);
+    };
+    raf = requestAnimationFrame(paso);
+    return () => cancelAnimationFrame(raf);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /* controles táctiles */
+  const tocar = useCallback((tecla, valor) => {
+    teclasRef.current[tecla] = valor;
+  }, []);
+
+  /* ── Render ──────────────────────────────────────────────────────────────── */
+  const w = vista;
+  const escala = useEscala(vistaRef);
+  const shake = { x: w.shakeX || 0, y: w.shakeY || 0 };
+  const armaActual = getArma(arsenal[w.armaIdx % arsenal.length]);
+  const plagasVivas = w.enemigos.filter((e) => e.vivo).length;
+  const invuln = !!w.invulnVisible;
+
+  return (
+    <div className="msc-juego">
+      <div ref={vistaRef} className="msc-vista">
+        <div className="msc-cielo" aria-hidden="true" />
+        <div
+          className="msc-loma msc-loma--lejos"
+          aria-hidden="true"
+          style={{ transform: `translate3d(${-w.cam * 0.28}px,0,0)` }}
+        />
+        <div
+          className="msc-loma msc-loma--cerca"
+          aria-hidden="true"
+          style={{ transform: `translate3d(${-w.cam * 0.52}px,0,0)` }}
+        />
+
+        <div
+          className="msc-marco"
+          style={{ transform: `scale(${escala}) translate3d(${shake.x}px,${shake.y}px,0)` }}
+        >
+          <div
+            className="msc-mundo"
+            style={{ width: MUNDO_W, transform: `translate3d(${-w.cam}px,0,0)` }}
+          >
+            {/* piso */}
+            <div className="msc-suelo" style={{ width: MUNDO_W, top: SUELO_Y }} />
+            <div className="msc-pasto" style={{ width: MUNDO_W, top: SUELO_Y - 8 }} />
+
+            {/* cultivos decorativos (maíz + frijol) */}
+            {DECOR.map((d) => (
+              <div key={`d${d.x}`} className={`msc-mata msc-mata--${d.t}`} style={{ left: d.x, top: SUELO_Y - d.h, height: d.h }} />
+            ))}
+
+            {/* plagas */}
+            {w.enemigos.map((e) =>
+              e.vivo ? (
+                <div
+                  key={e.id}
+                  className="msc-plaga"
+                  data-dir={e.dir}
+                  style={{ left: e.x, top: e.y, width: e.w, height: e.h }}
+                >
+                  <PlagaSprite enemigoId={e.enemigoId} reducedMotion={reducedMotion} />
+                </div>
+              ) : null,
+            )}
+
+            {/* proyectiles */}
+            {w.proyectiles.map((p) => {
+              const a = getArma(p.armaId);
+              return (
+                <div
+                  key={p.id}
+                  className="msc-proyectil"
+                  style={{
+                    left: p.x,
+                    top: p.y,
+                    width: p.w,
+                    height: p.h,
+                    background: COLOR_POR_TIPO[a?.tipo] || '#fff',
+                  }}
+                />
+              );
+            })}
+
+            {/* rehén (oso andino) */}
+            <div
+              className={`msc-rehen ${w.rehen.liberado ? 'msc-rehen--libre' : 'msc-rehen--preso'}`}
+              style={{ left: w.rehen.x, top: w.rehen.y, width: w.rehen.w, height: w.rehen.h }}
+            >
+              {!w.rehen.liberado && <div className="msc-jaula" aria-hidden="true" />}
+              <SpriteOso tier={tier} reducedMotion={reducedMotion} />
+              {!w.rehen.liberado && <div className="msc-sos" aria-hidden="true">¡SOS!</div>}
+            </div>
+
+            {/* jugador (Angelita) */}
+            <div
+              className="msc-jugador"
+              data-mira={w.jugador.mira}
+              data-aire={w.jugador.onGround ? '0' : '1'}
+              data-inv={invuln ? '1' : '0'}
+              style={{ left: w.jugador.x, top: w.jugador.y, width: w.jugador.w, height: w.jugador.h }}
+            >
+              <SpriteHeroe tier={tier} reducedMotion={reducedMotion} />
+            </div>
+          </div>
+        </div>
+
+        {/* HUD */}
+        <div className="msc-hud">
+          <div className="msc-hud-izq">
+            <span className="msc-energia" aria-label={`Energía ${w.jugador.energia}`}>
+              {Array.from({ length: ENERGIA_INICIAL }).map((_, i) => (
+                <b key={i} className={i < w.jugador.energia ? 'on' : 'off'}>♥</b>
+              ))}
+            </span>
+            <span className="msc-puntaje">{w.puntaje} pts</span>
+          </div>
+          <div className="msc-hud-der">
+            <span className="msc-plagas-cnt">Plagas: {plagasVivas}</span>
+            <span className="msc-rehen-cnt">{w.rehen.liberado ? 'Oso a salvo ✓' : 'Oso: rescátelo'}</span>
+          </div>
+          <button type="button" className="msc-arma-actual" onClick={cambiarArma}>
+            <b style={{ color: COLOR_POR_TIPO[armaActual?.tipo] || '#fff' }}>■</b>
+            <span>{armaActual?.nombre}</span>
+            <em>cambiar (K)</em>
+          </button>
+        </div>
+
+        {/* ficha didáctica al controlar una plaga (pausa breve) */}
+        {ficha && <FichaDidactica enemigoId={ficha.enemigoId} onCerrar={() => setFicha(null)} />}
+
+        {/* aviso de conservación al liberar al rehén */}
+        {avisoRehen && <AvisoConservacion rehen={avisoRehen} onCerrar={() => setAvisoRehen(null)} />}
+
+        {/* toast de arma equivocada */}
+        {toast && <div className="msc-toast" role="status">{toast}</div>}
+
+        {/* fin de nivel */}
+        {fin && (
+          <FinNivel
+            fin={fin}
+            puntaje={w.puntaje}
+            onReintentar={reiniciar}
+            onSalir={onSalirIntro}
+          />
+        )}
+      </div>
+
+      {/* controles táctiles */}
+      <div className="msc-controles" aria-hidden={false}>
+        <div className="msc-mov">
+          <button
+            type="button"
+            className="msc-ctrl"
+            onPointerDown={() => tocar('izq', true)}
+            onPointerUp={() => tocar('izq', false)}
+            onPointerLeave={() => tocar('izq', false)}
+            aria-label="Izquierda"
+          >
+            ◀
+          </button>
+          <button
+            type="button"
+            className="msc-ctrl"
+            onPointerDown={() => tocar('der', true)}
+            onPointerUp={() => tocar('der', false)}
+            onPointerLeave={() => tocar('der', false)}
+            aria-label="Derecha"
+          >
+            ▶
+          </button>
+        </div>
+        <div className="msc-acciones">
+          <button
+            type="button"
+            className="msc-ctrl msc-ctrl--sec"
+            onClick={cambiarArma}
+            aria-label="Cambiar control biológico"
+          >
+            ⟳
+          </button>
+          <button
+            type="button"
+            className="msc-ctrl msc-ctrl--fire"
+            onClick={disparar}
+            aria-label="Lanzar control biológico"
+          >
+            ✷
+          </button>
+          <button
+            type="button"
+            className="msc-ctrl msc-ctrl--jump"
+            onPointerDown={() => tocar('salto', true)}
+            onPointerUp={() => tocar('salto', false)}
+            onPointerLeave={() => tocar('salto', false)}
+            aria-label="Saltar"
+          >
+            ⤒
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* Escala reactiva de la vista (para el marco). Se recalcula por resize. */
+function useEscala(vistaRef) {
+  const [escala, setEscala] = useState(1);
+  useEffect(() => {
+    const el = vistaRef.current;
+    if (!el) return undefined;
+    const medir = () => {
+      const r = el.getBoundingClientRect();
+      setEscala(Math.max(0.3, r.height / ALTO_2D));
+    };
+    medir();
+    const ro = new ResizeObserver(medir);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [vistaRef]);
+  return escala;
+}
+
+/* ── Cultivos decorativos del piso. ─────────────────────────────────────────── */
+const DECOR = [
+  { x: 360, h: 96, t: 'maiz' }, { x: 720, h: 70, t: 'frijol' },
+  { x: 1080, h: 96, t: 'maiz' }, { x: 1420, h: 66, t: 'frijol' },
+  { x: 1760, h: 96, t: 'maiz' }, { x: 2040, h: 70, t: 'frijol' },
+  { x: 2340, h: 96, t: 'maiz' },
+];
+
+/* ── Sprites (memoizados: no re-renderizan por frame). ──────────────────────── */
+const SpriteHeroe = memo(function SpriteHeroe({ tier, reducedMotion }) {
+  return <AbejaAngelita size={JUGADOR_H + 20} inline={false} animated={!reducedMotion} tier={tier} title="Angelita" />;
+});
+
+const SpriteOso = memo(function SpriteOso({ tier, reducedMotion }) {
+  return <OsoAndino size={92} inline={false} animated={!reducedMotion} tier={tier} title="Oso andino" />;
+});
+
+/* Plaga: sprite chunky rubber-hose-ish con ojos saltones (humor). Data-driven por
+   enemigoId; sin dependencias de creatures (las plagas no son fauna canónica). */
+const PlagaSprite = memo(function PlagaSprite({ enemigoId, reducedMotion }) {
+  const anim = reducedMotion ? undefined : 'msc-wobble';
+  if (enemigoId === 'moscablanca') {
+    return (
+      <svg viewBox="0 0 60 52" className={anim} width="100%" height="100%">
+        <g>
+          <ellipse cx="20" cy="20" rx="16" ry="10" fill="#f4f4ee" stroke={PAL.tinta} strokeWidth="2.2" opacity="0.9" />
+          <ellipse cx="40" cy="20" rx="16" ry="10" fill="#eef0e6" stroke={PAL.tinta} strokeWidth="2.2" opacity="0.9" />
+          <ellipse cx="30" cy="34" rx="14" ry="12" fill="#e9e4cf" stroke={PAL.tinta} strokeWidth="2.4" />
+          <circle cx="25" cy="32" r="4.4" fill="#fff" stroke={PAL.tinta} strokeWidth="1.6" />
+          <circle cx="35" cy="32" r="4.4" fill="#fff" stroke={PAL.tinta} strokeWidth="1.6" />
+          <circle cx="25.6" cy="33" r="1.9" fill={PAL.tinta} />
+          <circle cx="35.6" cy="33" r="1.9" fill={PAL.tinta} />
+        </g>
+      </svg>
+    );
+  }
+  if (enemigoId === 'pulgon' || enemigoId === 'afido') {
+    const c = enemigoId === 'afido' ? '#7bbf4f' : '#9ccf5e';
+    return (
+      <svg viewBox="0 0 56 50" className={anim} width="100%" height="100%">
+        <g>
+          <ellipse cx="20" cy="30" rx="13" ry="12" fill={c} stroke={PAL.tinta} strokeWidth="2.4" />
+          <ellipse cx="36" cy="32" rx="11" ry="10" fill={c} stroke={PAL.tinta} strokeWidth="2.2" opacity="0.92" />
+          <circle cx="16" cy="27" r="3.6" fill="#fff" stroke={PAL.tinta} strokeWidth="1.4" />
+          <circle cx="24" cy="27" r="3.6" fill="#fff" stroke={PAL.tinta} strokeWidth="1.4" />
+          <circle cx="16.5" cy="28" r="1.6" fill={PAL.tinta} />
+          <circle cx="24.5" cy="28" r="1.6" fill={PAL.tinta} />
+          <path d="M20 6 L20 18 M14 10 L20 18 L26 10" fill="none" stroke={PAL.tinta} strokeWidth="1.8" strokeLinecap="round" />
+        </g>
+      </svg>
+    );
+  }
+  // cogollero (oruga verde por segmentos)
+  return (
+    <svg viewBox="0 0 64 48" className={anim} width="100%" height="100%">
+      <g>
+        {[12, 24, 36, 48].map((cx, i) => (
+          <circle key={cx} cx={cx} cy={30 - (i % 2) * 2} r="11" fill={i === 3 ? '#a7d06a' : '#8fbf55'} stroke={PAL.tinta} strokeWidth="2.4" />
+        ))}
+        <circle cx="52" cy="24" r="3.4" fill="#fff" stroke={PAL.tinta} strokeWidth="1.4" />
+        <circle cx="52.8" cy="24.6" r="1.6" fill={PAL.tinta} />
+        <path d="M50 32 q4 3 8 0" fill="none" stroke={PAL.tinta} strokeWidth="1.8" strokeLinecap="round" />
+      </g>
+    </svg>
+  );
+});
+
+/* ── Ficha didáctica al controlar una plaga. ────────────────────────────────── */
+function FichaDidactica({ enemigoId, onCerrar }) {
+  const e = getEnemigo(enemigoId);
+  if (!e) return null;
+  return (
+    <div className="msc-overlay msc-overlay--ficha" role="dialog" aria-label={`Ficha de ${e.nombre_comun}`}>
+      <div className="msc-ficha">
+        <span className="msc-ficha-tag">¡Plaga controlada!</span>
+        <h3>{e.nombre_comun} <i>({e.nombre_cientifico})</i></h3>
+        <p className="msc-ficha-cultivo"><b>Ataca:</b> {e.cultivo_objetivo}</p>
+        <p className="msc-ficha-ficha">{e.ficha}</p>
+        <button type="button" className="msc-ficha-ok" onClick={onCerrar}>Seguir (Enter)</button>
+      </div>
+    </div>
+  );
+}
+
+/* ── Aviso de conservación al liberar al rehén. ─────────────────────────────── */
+function AvisoConservacion({ rehen, onCerrar }) {
+  return (
+    <div className="msc-overlay msc-overlay--rehen" role="dialog" aria-label={`Rescate de ${rehen.nombre}`}>
+      <div className="msc-aviso">
+        <span className="msc-aviso-tag">¡Liberado!</span>
+        <h3>{rehen.nombre}</h3>
+        <p className="msc-aviso-porque"><b>Por qué lo cazan:</b> {rehen.por_que_lo_cazan}</p>
+        <p className="msc-aviso-msg">{rehen.mensaje_educativo}</p>
+        <p className="msc-aviso-iucn">{rehen.amenaza}</p>
+        <button type="button" className="msc-ficha-ok" onClick={onCerrar}>Seguir (Enter)</button>
+      </div>
+    </div>
+  );
+}
+
+/* ── Fin de nivel. ──────────────────────────────────────────────────────────── */
+function FinNivel({ fin, puntaje, onReintentar, onSalir }) {
+  const gano = fin.estado === 'gano';
+  return (
+    <div className="msc-overlay msc-overlay--fin" role="dialog" aria-label="Fin del nivel">
+      <div className={`msc-fin ${gano ? 'msc-fin--gano' : 'msc-fin--perdio'}`}>
+        <h2>{gano ? '¡Finca cuidada!' : 'Se acabó la energía'}</h2>
+        <p>{fin.razon}</p>
+        <p className="msc-fin-puntaje">{puntaje} puntos</p>
+        <button type="button" className="msc-btn-jugar" onClick={onReintentar}>
+          {gano ? 'Jugar de nuevo' : 'Reintentar'}
+        </button>
+        <button type="button" className="msc-fin-salir" onClick={onSalir}>
+          Volver al inicio
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════════════════
+ * ESTILOS (embebidos, prefijo msc-, self-contained, offline-safe).
+ * ════════════════════════════════════════════════════════════════════════════ */
+function StyleMSC() {
+  return (
+    <style>{`
+.msc-root{position:fixed;inset:0;overflow:hidden;background:#12100c;font-family:'Baloo 2',system-ui,sans-serif;color:${PAL.tinta};user-select:none;-webkit-user-select:none;touch-action:none;}
+.msc-volver{position:absolute;top:10px;left:10px;z-index:40;background:rgba(0,0,0,.42);color:#fff;border:2px solid rgba(255,255,255,.5);border-radius:11px;padding:7px 13px;font-weight:800;font-size:15px;cursor:pointer;}
+.msc-volver:hover{background:rgba(0,0,0,.6);}
+
+/* intro */
+.msc-intro{position:absolute;inset:0;display:grid;place-items:center;padding:18px;background:linear-gradient(160deg,#2a3a24,#463a1e 70%);}
+.msc-intro-card{max-width:560px;width:100%;background:#f4ecd6;border:4px solid ${PAL.tinta};border-radius:22px;box-shadow:0 14px 0 rgba(0,0,0,.35);padding:22px 24px;}
+.msc-kicker{margin:0 0 4px;font-weight:900;letter-spacing:.03em;color:#b5632a;text-transform:uppercase;font-size:13px;}
+.msc-titulo{margin:0 0 8px;font-size:30px;line-height:1.05;font-weight:900;color:#3a2a1a;}
+.msc-intro-texto{margin:0 0 14px;font-size:16px;line-height:1.35;}
+.msc-arsenal-intro{background:#fff8e6;border:2px dashed #caa25a;border-radius:13px;padding:10px 14px;margin-bottom:12px;}
+.msc-arsenal-rotulo{font-weight:800;font-size:14px;}
+.msc-arsenal-intro ul{margin:6px 0 0;padding-left:2px;list-style:none;display:grid;gap:3px;font-size:14.5px;}
+.msc-arsenal-intro b{margin-right:6px;font-size:15px;}
+.msc-ayuda{font-size:13.5px;line-height:1.4;color:#5c4a35;margin:0 0 16px;}
+.msc-ayuda kbd{background:#fff;border:1.5px solid ${PAL.tinta};border-bottom-width:3px;border-radius:6px;padding:1px 6px;font-weight:800;font-size:12.5px;}
+.msc-btn-jugar{display:block;width:100%;background:#e0532b;color:#fff;border:3px solid ${PAL.tinta};border-bottom-width:6px;border-radius:15px;padding:13px;font-size:19px;font-weight:900;cursor:pointer;transition:transform .08s;}
+.msc-btn-jugar:active{transform:translateY(3px);border-bottom-width:3px;}
+
+/* juego */
+.msc-juego{position:absolute;inset:0;display:flex;flex-direction:column;}
+.msc-vista{position:relative;flex:1;overflow:hidden;background:${PAL.cielo};}
+.msc-cielo{position:absolute;inset:0;background:linear-gradient(${PAL.cielo} 0%,${PAL.cieloBajo} 72%);}
+.msc-loma{position:absolute;left:-10%;right:-10%;bottom:14%;height:200px;will-change:transform;}
+.msc-loma--lejos{background:radial-gradient(120% 100% at 50% 100%,${PAL.lomaLejos} 0 60%,transparent 61%);opacity:.8;bottom:20%;height:240px;}
+.msc-loma--cerca{background:radial-gradient(120% 100% at 40% 100%,${PAL.lomaCerca} 0 58%,transparent 59%);bottom:12%;height:220px;}
+.msc-marco{position:absolute;top:0;left:0;transform-origin:top left;will-change:transform;}
+.msc-mundo{position:absolute;top:0;left:0;height:${ALTO_2D}px;will-change:transform;}
+.msc-suelo{position:absolute;left:0;height:${ALTO_2D}px;background:linear-gradient(${PAL.suelo} 0 12px,${PAL.sueloClaro} 12px 100%);}
+.msc-pasto{position:absolute;left:0;height:14px;background:repeating-linear-gradient(90deg,${PAL.pasto} 0 8px,#5f9345 8px 16px);border-radius:6px 6px 0 0;}
+.msc-mata{position:absolute;width:26px;border-radius:8px 8px 0 0;}
+.msc-mata--maiz{background:linear-gradient(#8bbf4a,#6d9c37);box-shadow:inset -4px 0 0 rgba(0,0,0,.12);}
+.msc-mata--maiz::after{content:"";position:absolute;top:6px;left:50%;width:12px;height:26px;background:#e6c34a;border-radius:6px;transform:translateX(-50%);}
+.msc-mata--frijol{background:linear-gradient(#7bab54,#557f36);border-radius:12px 12px 0 0;box-shadow:inset -3px 0 0 rgba(0,0,0,.12);}
+.msc-plaga{position:absolute;will-change:transform;}
+.msc-plaga[data-dir="1"]{transform:scaleX(-1);}
+.msc-proyectil{position:absolute;border-radius:50%;box-shadow:0 0 8px rgba(255,255,255,.6),inset 0 0 4px rgba(255,255,255,.7);border:2px solid rgba(0,0,0,.35);will-change:transform;}
+.msc-jugador{position:absolute;display:grid;place-items:center;will-change:transform;}
+.msc-jugador[data-mira="-1"]{transform:scaleX(-1);}
+.msc-jugador[data-inv="1"]{animation:msc-parpadeo .18s steps(2,end) infinite;}
+.msc-rehen{position:absolute;display:grid;place-items:end center;}
+.msc-jaula{position:absolute;inset:-6px -4px 0;border:3px solid #6b6b6b;border-radius:8px;background:repeating-linear-gradient(90deg,transparent 0 10px,rgba(80,80,80,.55) 10px 13px);pointer-events:none;}
+.msc-rehen--libre .msc-jaula{display:none;}
+.msc-sos{position:absolute;top:-20px;left:50%;transform:translateX(-50%);background:#e0532b;color:#fff;font-weight:900;font-size:12px;padding:1px 7px;border-radius:8px;border:2px solid ${PAL.tinta};}
+.msc-rehen--libre{animation:msc-brinco .5s ease;}
+
+/* HUD */
+.msc-hud{position:absolute;top:8px;left:0;right:0;z-index:20;display:flex;align-items:flex-start;justify-content:space-between;gap:8px;padding:0 12px 0 96px;pointer-events:none;}
+.msc-hud-izq,.msc-hud-der{display:flex;flex-direction:column;gap:3px;background:rgba(0,0,0,.34);border-radius:12px;padding:6px 11px;color:#fff;font-weight:800;}
+.msc-hud-der{text-align:right;font-size:13.5px;}
+.msc-energia b{font-size:19px;color:#ff5a4d;}
+.msc-energia b.off{color:rgba(255,255,255,.28);}
+.msc-puntaje{font-size:17px;color:#ffd66b;}
+.msc-arma-actual{pointer-events:auto;display:flex;align-items:center;gap:7px;background:rgba(0,0,0,.42);border:2px solid rgba(255,255,255,.5);border-radius:12px;padding:6px 11px;color:#fff;font-weight:800;font-size:14px;cursor:pointer;position:absolute;right:12px;top:64px;max-width:60%;}
+.msc-arma-actual b{font-size:16px;}
+.msc-arma-actual em{font-style:normal;opacity:.7;font-size:11.5px;font-weight:700;}
+
+/* overlays */
+.msc-overlay{position:absolute;inset:0;z-index:30;display:grid;place-items:center;background:rgba(20,15,8,.5);padding:18px;animation:msc-aparece .18s ease;}
+.msc-ficha,.msc-aviso,.msc-fin{max-width:440px;width:100%;background:#f7efda;border:4px solid ${PAL.tinta};border-radius:20px;box-shadow:0 12px 0 rgba(0,0,0,.32);padding:18px 20px;}
+.msc-ficha-tag,.msc-aviso-tag{display:inline-block;background:#4d9e4a;color:#fff;font-weight:900;font-size:12.5px;padding:3px 10px;border-radius:9px;margin-bottom:6px;}
+.msc-aviso-tag{background:#3f8fd0;}
+.msc-ficha h3,.msc-aviso h3{margin:2px 0 8px;font-size:20px;color:#3a2a1a;}
+.msc-ficha h3 i,.msc-aviso h3 i{font-weight:600;font-size:15px;color:#7a6a52;}
+.msc-ficha p,.msc-aviso p{margin:0 0 7px;font-size:15px;line-height:1.35;}
+.msc-ficha-cultivo b,.msc-aviso-porque b{color:#b5632a;}
+.msc-aviso-iucn{font-size:12.5px;color:#7a6a52;font-style:italic;}
+.msc-ficha-ok{margin-top:6px;background:#3a2a1a;color:#fff;border:none;border-radius:11px;padding:9px 16px;font-weight:800;font-size:15px;cursor:pointer;}
+.msc-fin{text-align:center;}
+.msc-fin h2{margin:0 0 8px;font-size:26px;}
+.msc-fin--gano h2{color:#3d8b3a;}
+.msc-fin--perdio h2{color:#c14a2c;}
+.msc-fin-puntaje{font-size:22px;font-weight:900;color:#b5632a;margin:8px 0 14px;}
+.msc-fin-salir{margin-top:9px;background:none;border:none;color:#7a6a52;font-weight:800;font-size:14px;text-decoration:underline;cursor:pointer;}
+.msc-toast{position:absolute;bottom:120px;left:50%;transform:translateX(-50%);z-index:25;background:rgba(180,60,30,.94);color:#fff;font-weight:800;font-size:14px;padding:9px 16px;border-radius:13px;max-width:80%;text-align:center;box-shadow:0 5px 0 rgba(0,0,0,.3);animation:msc-aparece .16s ease;}
+
+/* controles táctiles */
+.msc-controles{position:relative;z-index:22;display:flex;align-items:center;justify-content:space-between;gap:10px;padding:10px 16px 16px;background:linear-gradient(rgba(0,0,0,0),rgba(0,0,0,.28));}
+.msc-mov,.msc-acciones{display:flex;gap:10px;}
+.msc-ctrl{width:60px;height:60px;border-radius:50%;border:3px solid rgba(255,255,255,.65);background:rgba(0,0,0,.4);color:#fff;font-size:24px;font-weight:900;cursor:pointer;display:grid;place-items:center;}
+.msc-ctrl:active{transform:scale(.92);background:rgba(0,0,0,.6);}
+.msc-ctrl--fire{width:74px;height:74px;background:rgba(224,83,43,.85);border-color:#fff;font-size:30px;}
+.msc-ctrl--jump{background:rgba(60,140,90,.82);}
+.msc-ctrl--sec{width:52px;height:52px;font-size:20px;}
+
+/* animaciones (gated por reduced-motion vía data-rm) */
+@keyframes msc-wobble{0%,100%{transform:rotate(-4deg)}50%{transform:rotate(4deg)}}
+.msc-wobble{animation:msc-wobble 1.1s ease-in-out infinite;transform-origin:50% 70%;}
+@keyframes msc-parpadeo{0%{opacity:1}50%{opacity:.35}100%{opacity:1}}
+@keyframes msc-brinco{0%{transform:translateY(0)}40%{transform:translateY(-22px)}100%{transform:translateY(0)}}
+@keyframes msc-aparece{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
+.msc-root[data-rm="1"] .msc-wobble{animation:none;}
+.msc-root[data-rm="1"] .msc-jugador[data-inv="1"]{animation:none;opacity:.6;}
+.msc-root[data-rm="1"] .msc-rehen--libre{animation:none;}
+.msc-root[data-rm="1"] .msc-overlay,.msc-root[data-rm="1"] .msc-toast{animation:none;}
+@media (prefers-reduced-motion: reduce){
+  .msc-wobble{animation:none;}
+  .msc-jugador[data-inv="1"]{animation:none;opacity:.6;}
+}
+`}</style>
+  );
+}

--- a/src/services/__tests__/metalSlugCampoEngine.test.js
+++ b/src/services/__tests__/metalSlugCampoEngine.test.js
@@ -1,0 +1,168 @@
+/**
+ * metalSlugCampoEngine.test.js — lógica PURA del Metal Slug del campo.
+ *
+ * El foco (lo que pidió el prototipo): el par plaga↔arma CORRECTO vs INCORRECTO.
+ *   - Arma correcta (control biológico real) → plaga controlada.
+ *   - Arma equivocada → la plaga SOBREVIVE y el juego puede enseñar el par.
+ * Más: proyectiles (avance/expiración), rescate de rehén, patrulla determinista,
+ * arsenal derivado del nivel (data-driven) y fin de nivel.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  armasDeNivel,
+  crearProyectil,
+  avanzarProyectil,
+  resolverImpactoArma,
+  alcanzaRehen,
+  patrullarPlaga,
+  evaluarFinCampo,
+  PROYECTIL_VEL,
+} from '../metalSlugCampoEngine';
+
+/** Fábrica de una plaga-instancia mínima para los tests de colisión. */
+function plaga(enemigoId, over = {}) {
+  return { id: `${enemigoId}#1`, enemigoId, x: 300, y: 200, w: 40, h: 40, vivo: true, ...over };
+}
+
+describe('armasDeNivel — arsenal derivado del data (sin invento)', () => {
+  it('nivel 1 reúne los controladores reales de sus plagas', () => {
+    const armas = armasDeNivel(1);
+    // Nivel 1 = cogollero, pulgon, afido, moscablanca. Sus controladores reales:
+    expect(armas).toContain('bt'); // cogollero
+    expect(armas).toContain('catarina'); // pulgon/afido (mariquita)
+    expect(armas).toContain('beauveria'); // moscablanca
+    // Sin duplicados aunque una plaga comparta controlador (crisopa aparece 1 vez).
+    expect(new Set(armas).size).toBe(armas.length);
+  });
+
+  it('nivel inexistente → arsenal vacío', () => {
+    expect(armasDeNivel(999)).toEqual([]);
+  });
+});
+
+describe('crearProyectil — cápsula de benéficos', () => {
+  it('sale hacia la derecha con velocidad positiva', () => {
+    const p = crearProyectil({ x: 100, y: 50, dir: 1, armaId: 'bt' });
+    expect(p.vx).toBe(PROYECTIL_VEL);
+    expect(p.armaId).toBe('bt');
+    expect(p.w).toBeGreaterThan(0);
+  });
+  it('sale hacia la izquierda con velocidad negativa', () => {
+    const p = crearProyectil({ x: 100, y: 50, dir: -1, armaId: 'catarina' });
+    expect(p.vx).toBe(-PROYECTIL_VEL);
+    expect(p.dir).toBe(-1);
+  });
+});
+
+describe('avanzarProyectil — vuelo y expiración', () => {
+  it('avanza según dt y velocidad', () => {
+    const p = crearProyectil({ x: 100, y: 50, dir: 1, armaId: 'bt', id: 1 });
+    const p2 = avanzarProyectil(p, 0.1, 2000);
+    expect(p2).not.toBeNull();
+    expect(p2.x).toBeCloseTo(100 + PROYECTIL_VEL * 0.1, 5);
+  });
+  it('se descarta (null) al salir del mundo por la derecha', () => {
+    const p = crearProyectil({ x: 1990, y: 50, dir: 1, armaId: 'bt', id: 2 });
+    expect(avanzarProyectil(p, 1, 2000)).toBeNull();
+  });
+  it('se descarta (null) al salir por la izquierda', () => {
+    const p = crearProyectil({ x: 10, y: 50, dir: -1, armaId: 'bt', id: 3 });
+    expect(avanzarProyectil(p, 1, 2000)).toBeNull();
+  });
+});
+
+describe('resolverImpactoArma — EL PAR plaga↔arma (correcto vs incorrecto)', () => {
+  it('arma CORRECTA controla la plaga (Bt → cogollero)', () => {
+    const proy = crearProyectil({ x: 300, y: 200, dir: 1, armaId: 'bt', id: 10 });
+    const plagas = [plaga('cogollero')];
+    const { plagas: next, impacto } = resolverImpactoArma(proy, plagas);
+    expect(impacto).not.toBeNull();
+    expect(impacto.enemigoId).toBe('cogollero');
+    expect(impacto.correcto).toBe(true);
+    expect(next[0].vivo).toBe(false); // controlada
+  });
+
+  it('arma EQUIVOCADA NO controla: la plaga sobrevive (Beauveria → cogollero)', () => {
+    const proy = crearProyectil({ x: 300, y: 200, dir: 1, armaId: 'beauveria', id: 11 });
+    const plagas = [plaga('cogollero')];
+    const { plagas: next, impacto } = resolverImpactoArma(proy, plagas);
+    expect(impacto).not.toBeNull();
+    expect(impacto.correcto).toBe(false); // enseña el par equivocado
+    expect(next[0].vivo).toBe(true); // SIGUE VIVA
+  });
+
+  it('mariquita (catarina) SÍ controla al pulgón', () => {
+    const proy = crearProyectil({ x: 300, y: 200, dir: 1, armaId: 'catarina', id: 12 });
+    const { impacto, plagas } = resolverImpactoArma(proy, [plaga('pulgon')]);
+    expect(impacto.correcto).toBe(true);
+    expect(plagas[0].vivo).toBe(false);
+  });
+
+  it('Beauveria SÍ controla a la mosca blanca', () => {
+    const proy = crearProyectil({ x: 300, y: 200, dir: 1, armaId: 'beauveria', id: 13 });
+    const { impacto } = resolverImpactoArma(proy, [plaga('moscablanca')]);
+    expect(impacto.correcto).toBe(true);
+  });
+
+  it('sin solape → no hay impacto (el tiro pasa de largo)', () => {
+    const proy = crearProyectil({ x: 900, y: 200, dir: 1, armaId: 'bt', id: 14 });
+    const { impacto, plagas } = resolverImpactoArma(proy, [plaga('cogollero')]);
+    expect(impacto).toBeNull();
+    expect(plagas[0].vivo).toBe(true);
+  });
+
+  it('ignora plagas ya controladas y pega a la primera viva que solapa', () => {
+    const proy = crearProyectil({ x: 300, y: 200, dir: 1, armaId: 'bt', id: 15 });
+    const plagas = [
+      plaga('cogollero', { id: 'a', vivo: false }),
+      plaga('cogollero', { id: 'b', vivo: true }),
+    ];
+    const { plagas: next, impacto } = resolverImpactoArma(proy, plagas);
+    expect(impacto.id).toBe('b');
+    expect(next[1].vivo).toBe(false);
+    expect(next[0].vivo).toBe(false); // seguía muerta
+  });
+});
+
+describe('alcanzaRehen — rescate del animal cazado', () => {
+  const jugador = { x: 500, y: 200, w: 44, h: 60 };
+  it('true al tocar un rehén no liberado', () => {
+    const rehen = { x: 520, y: 210, w: 50, h: 50, liberado: false };
+    expect(alcanzaRehen(jugador, rehen)).toBe(true);
+  });
+  it('false si ya está liberado', () => {
+    const rehen = { x: 520, y: 210, w: 50, h: 50, liberado: true };
+    expect(alcanzaRehen(jugador, rehen)).toBe(false);
+  });
+  it('false sin rehén', () => {
+    expect(alcanzaRehen(jugador, null)).toBe(false);
+  });
+});
+
+describe('patrullarPlaga — patrulla determinista con rebote', () => {
+  it('rebota en el borde derecho e invierte dirección', () => {
+    const { x, dir } = patrullarPlaga({ x: 995, dir: 1, vel: 100 }, 1, 0, 1000);
+    expect(x).toBe(1000);
+    expect(dir).toBe(-1);
+  });
+  it('rebota en el borde izquierdo', () => {
+    const { x, dir } = patrullarPlaga({ x: 5, dir: -1, vel: 100 }, 1, 0, 1000);
+    expect(x).toBe(0);
+    expect(dir).toBe(1);
+  });
+});
+
+describe('evaluarFinCampo — condición de victoria/derrota', () => {
+  it('gana al controlar todas las plagas y liberar al rehén', () => {
+    expect(evaluarFinCampo({ energia: 2, plagasVivas: 0, rehenLiberado: true }).estado).toBe('gano');
+  });
+  it('sigue jugando si falta el rehén', () => {
+    expect(evaluarFinCampo({ energia: 2, plagasVivas: 0, rehenLiberado: false }).estado).toBe('jugando');
+  });
+  it('sigue jugando si quedan plagas', () => {
+    expect(evaluarFinCampo({ energia: 2, plagasVivas: 3, rehenLiberado: true }).estado).toBe('jugando');
+  });
+  it('pierde si la energía llega a 0', () => {
+    expect(evaluarFinCampo({ energia: 0, plagasVivas: 1, rehenLiberado: false }).estado).toBe('perdio');
+  });
+});

--- a/src/services/metalSlugCampoEngine.js
+++ b/src/services/metalSlugCampoEngine.js
@@ -1,0 +1,200 @@
+/**
+ * metalSlugCampoEngine — lógica PURA del "Metal Slug del campo".
+ *
+ * Run-and-gun agroecológico SIN violencia: el jugador recorre la finca, "combate"
+ * plagas reales con CONTROL BIOLÓGICO (el arma correcta para cada plaga) y libera
+ * fauna cazada. Este módulo NO dibuja ni toca el DOM: solo decide, con funciones
+ * deterministas y testeables.
+ *
+ * REÚSA, no reinventa:
+ *   - Física de salto, colisiones AABB y puntaje → `defensoresGameEngine.js`
+ *     (`avanzarFisica`, `rectsOverlap`, `sumarPuntaje`, `clamp`, constantes).
+ *   - Data agronómica y el par arma↔plaga REAL → `../data/metalSlugCampoData.js`
+ *     (`armaControlaEnemigo`, `getEnemigo`, `getRehen`, `getNivel`).
+ *
+ * El corazón pedagógico vive en `resolverImpactoArma`: un disparo solo "controla"
+ * la plaga si el arma es el controlador biológico CORRECTO (Bt→cogollero,
+ * mariquita→pulgón, Beauveria→mosca blanca...). Con el arma equivocada la plaga
+ * sobrevive y el juego enseña el par correcto. Cero invento: el par sale del data.
+ *
+ * Convención de coordenadas (idéntica al engine base): x crece a la derecha,
+ * y crece HACIA ABAJO. Offline-safe: cero red.
+ */
+
+import { rectsOverlap, clamp, sumarPuntaje } from './defensoresGameEngine';
+import { armaControlaEnemigo, getEnemigo, getNivel } from '../data/metalSlugCampoData';
+
+/** Velocidad horizontal base del proyectil de control biológico (px/seg). */
+export const PROYECTIL_VEL = 640;
+/** Ancho/alto del proyectil (una "cápsula" de benéficos). */
+export const PROYECTIL_W = 26;
+export const PROYECTIL_H = 16;
+/** Puntos al liberar un rehén (animal cazado) — el mayor premio moral del nivel. */
+export const PUNTOS_REHEN = 100;
+/** Puntos por plaga controlada con el arma correcta (alineado al engine base). */
+export const PUNTOS_PLAGA = 25;
+
+/**
+ * Deriva el arsenal de control biológico disponible en un nivel: la unión de los
+ * controladores REALES de las plagas de ese nivel (data-driven, sin invento).
+ *
+ * @param {number} numero  número de nivel (1..N).
+ * @returns {string[]} ids de ARMAS únicos, en orden estable de aparición.
+ */
+export function armasDeNivel(numero) {
+  const nivel = getNivel(numero);
+  if (!nivel) return [];
+  const vistas = new Set();
+  const orden = [];
+  for (const enemigoId of nivel.enemigos) {
+    const e = getEnemigo(enemigoId);
+    if (!e) continue;
+    for (const armaId of e.controladores) {
+      if (!vistas.has(armaId)) {
+        vistas.add(armaId);
+        orden.push(armaId);
+      }
+    }
+  }
+  return orden;
+}
+
+/**
+ * Crea un proyectil de control biológico saliendo del jugador hacia `dir`.
+ *
+ * @param {Object} p
+ * @param {number} p.x     x del centro de tiro (ej. frente del jugador).
+ * @param {number} p.y     y (parte superior) del proyectil.
+ * @param {1|-1} p.dir     dirección de la mira (1 derecha, -1 izquierda).
+ * @param {string} p.armaId  arma activa (define qué plaga controla).
+ * @param {number} [p.id]  id de instancia (para React keys); por defecto un contador.
+ * @returns {{ id:number, armaId:string, dir:1|-1, x:number, y:number, w:number, h:number, vx:number }}
+ */
+let _proyectilSeq = 0;
+export function crearProyectil({ x, y, dir, armaId, id }) {
+  const d = dir >= 0 ? 1 : -1;
+  return {
+    id: id ?? (_proyectilSeq += 1),
+    armaId,
+    dir: d,
+    x,
+    y,
+    w: PROYECTIL_W,
+    h: PROYECTIL_H,
+    vx: d * PROYECTIL_VEL,
+  };
+}
+
+/**
+ * Avanza un proyectil un tick. Devuelve el proyectil movido, o `null` si salió
+ * del mundo (para que la UI lo descarte).
+ *
+ * @param {{x:number,vx:number,w:number}} p
+ * @param {number} dt        delta en segundos.
+ * @param {number} mundoW    ancho del mundo (límite derecho).
+ * @returns {Object|null}
+ */
+export function avanzarProyectil(p, dt, mundoW) {
+  const x = p.x + p.vx * dt;
+  if (x + p.w < 0 || x > mundoW) return null;
+  return { ...p, x };
+}
+
+/**
+ * EL CORAZÓN: resuelve el impacto de un proyectil contra las plagas vivas.
+ *
+ * Recorre las plagas y busca la PRIMERA viva que solape con el proyectil.
+ *   - Si el arma es el controlador CORRECTO de esa plaga → la plaga queda
+ *     controlada (`vivo:false`) y `impacto.correcto = true`.
+ *   - Si el arma es la EQUIVOCADA → la plaga SOBREVIVE (control biológico es
+ *     específico, no un insecticida universal) y `impacto.correcto = false`:
+ *     la UI aprovecha para enseñar el par correcto.
+ *   - Sin solape con ninguna plaga viva → `impacto: null` (el tiro sigue/expira).
+ *
+ * En ambos casos de solape el proyectil se considera consumido (la UI lo quita).
+ *
+ * @param {{x:number,y:number,w:number,h:number,armaId:string}} proyectil
+ * @param {Array<{id:(string|number),enemigoId:string,x:number,y:number,w:number,h:number,vivo:boolean}>} plagas
+ * @returns {{ plagas: Array, impacto: null | { id:(string|number), enemigoId:string, correcto:boolean } }}
+ */
+export function resolverImpactoArma(proyectil, plagas) {
+  for (let i = 0; i < plagas.length; i += 1) {
+    const plaga = plagas[i];
+    if (!plaga.vivo) continue;
+    if (!rectsOverlap(proyectil, plaga)) continue;
+    const correcto = armaControlaEnemigo(proyectil.armaId, plaga.enemigoId);
+    const plagasNext = correcto
+      ? plagas.map((p, j) => (j === i ? { ...p, vivo: false } : p))
+      : plagas;
+    return {
+      plagas: plagasNext,
+      impacto: { id: plaga.id, enemigoId: plaga.enemigoId, correcto },
+    };
+  }
+  return { plagas, impacto: null };
+}
+
+/**
+ * ¿El jugador alcanza al rehén (animal cazado) para liberarlo?
+ * Puro solape AABB; la UI dispara el mensaje de conservación al liberarlo.
+ *
+ * @param {{x:number,y:number,w:number,h:number}} jugador
+ * @param {?{x:number,y:number,w:number,h:number,liberado:boolean}} rehen
+ * @returns {boolean} true solo si el rehén existe, no está liberado y hay contacto.
+ */
+export function alcanzaRehen(jugador, rehen) {
+  if (!rehen || rehen.liberado) return false;
+  return rectsOverlap(jugador, rehen);
+}
+
+/**
+ * Patrulla horizontal simple y determinista de una plaga entre [xMin, xMax].
+ * Rebota en los bordes (invierte `dir`). Sin aleatoriedad → testeable.
+ *
+ * @param {{x:number,dir:1|-1,vel:number}} plaga
+ * @param {number} dt
+ * @param {number} xMin
+ * @param {number} xMax
+ * @returns {{ x:number, dir:1|-1 }}
+ */
+export function patrullarPlaga(plaga, dt, xMin, xMax) {
+  let dir = plaga.dir >= 0 ? 1 : -1;
+  let x = plaga.x + dir * plaga.vel * dt;
+  if (x <= xMin) {
+    x = xMin;
+    dir = 1;
+  } else if (x >= xMax) {
+    x = xMax;
+    dir = -1;
+  }
+  return { x, dir };
+}
+
+/**
+ * Evalúa el fin del nivel del Metal Slug del campo.
+ *
+ * Gana cuando controló TODAS las plagas y liberó al rehén. Pierde si la energía
+ * llega a 0. (El jefe estructural queda para niveles siguientes; el nivel 1 del
+ * prototipo cierra con plagas + rehén.)
+ *
+ * @param {Object} p
+ * @param {number} p.energia
+ * @param {number} p.plagasVivas
+ * @param {boolean} p.rehenLiberado
+ * @returns {{ estado:'jugando'|'gano'|'perdio', razon:string }}
+ */
+export function evaluarFinCampo({ energia, plagasVivas, rehenLiberado }) {
+  if (energia <= 0) {
+    return { estado: 'perdio', razon: 'Se quedó sin energía. Vuelva a intentarlo, la finca lo espera.' };
+  }
+  if (plagasVivas <= 0 && rehenLiberado) {
+    return {
+      estado: 'gano',
+      razon: 'Cuidó la huerta con control biológico y liberó al animal. Así se cuida el campo.',
+    };
+  }
+  return { estado: 'jugando', razon: '' };
+}
+
+// Re-export utilidades del engine base para que el componente importe de un solo lugar.
+export { clamp, sumarPuntaje, rectsOverlap };


### PR DESCRIPTION
## Qué es
Prototipo **jugable de punta a punta** del "Metal Slug del campo" (nivel 1): un run-and-gun 2D lateral agroecológico **sin violencia**. Angelita la abeja recorre la huerta de la ladera templada (`NIVELES[0]`), "combate" plagas reales lanzando el **control biológico correcto**, libera al **oso andino cazado** (rehén estilo POW) y aprende con **fichas didácticas**.

## Cómo probarlo
Ruta nueva sin auth: **`#/mockups/metal-slug-campo`**

Controles: `←`/`→` mover, `espacio` saltar, `J` disparar, `K` cambiar de control biológico. En celular, botones táctiles.

## Qué recicla (no reinventa motores)
- **Física + colisiones** → `defensoresGameEngine` (`avanzarFisica`, `rectsOverlap`) — **no modificado**.
- **Par arma↔plaga REAL** → `armaControlaEnemigo` de `metalSlugCampoData` (data ya en dev).
- **Sprites rubber-hose** → `visual/creatures` (Abeja héroe, Oso rehén).
- **tier + reduced-motion** → `deviceTier` (mismo criterio que el mockup Odyssey).

## Archivos
- `src/services/metalSlugCampoEngine.js` — **motor PURO nuevo** (compone sobre el engine base + data). Lógica testeable del par correcto/incorrecto, proyectiles, rescate, patrulla determinista, fin de nivel.
- `src/services/__tests__/metalSlugCampoEngine.test.js` — **22 tests** (incluye el par plaga↔arma correcto/incorrecto/miss).
- `src/mockups/MetalSlugCampo.jsx` — componente jugable (RAF de paso fijo, cámara, HUD, ficha didáctica, aviso de conservación, juice).
- `src/App.jsx` — lazy import + ruta hash + case de render.

## Jugable ✅
- Side-scroller con cámara lateral y salto (física del engine base, paso fijo determinista).
- 6 plagas del data (cogollero, pulgón, áfido, mosca blanca) patrullando; al vencerlas con el aliado correcto → **ficha didáctica** (cultivo que atacan + control), pausa breve.
- Arsenal de control biológico (Bt, mariquita, Beauveria, crisopa) derivado del data; **arma equivocada → la plaga aguanta** y enseña el par.
- 1 rehén (oso andino) → rescate dispara **mensaje de conservación** (por qué lo cazan + rol ecológico + IUCN).
- HUD (energía, puntaje, plagas restantes, arma actual) + screenshake/squash&stretch/parpadeo, todo **reduced-motion + tier aware**.
- Fin de nivel (ganar/perder) con reintentar en sitio.

## Pendiente (fuera del alcance del nivel 1)
- Jefe estructural (sequía) — `JEFES` ya está en data para el siguiente paso.
- Niveles 2-4 (cafetal/milpa/páramo) — data lista, falta cablear más biomas.
- Sonido y pulido de sprites de plaga (hoy SVG chunky propios).

## Verificación
- `npx eslint <tocados> --max-warnings=0` → limpio.
- `npx vitest run` (motor nuevo + engine base + data) → **116 passed**.
- `npm run build` → verde; chunk `MetalSlugCampo` code-split (~42 KB).
- Smoke render en jsdom (monta intro → entra al juego → HUD, sin crash) — verificado y descartado (no commiteado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)