### PR TITLE
feat(valle): cámara de director (establishing + follow + beats, tier-safe)

### DIFF
--- a/src/mockups/valle/DirectorValle.jsx
+++ b/src/mockups/valle/DirectorValle.jsx
@@ -1,0 +1,144 @@
+/*
+ * DirectorValle — el COMPONENTE r3f de la cámara de director del valle 3D.
+ *
+ * Cablea la lógica pura de `directorValle.js` a la cámara y a los OrbitControls
+ * del valle. Vive DENTRO del `<Canvas>` y se monta DESPUÉS de `CamaraViajera`
+ * (no en vez de: la viajera sigue llevando el target hacia el mundo enfocado).
+ * Como el resto de las cámaras de `mundo3d`, NO reasigna props de three: escribe
+ * cámara y target solo por métodos (position/lerp/lookAt/setFocalLength) — regla
+ * react-hooks/immutability.
+ *
+ * ── Sin peleas de cámara (por ORDEN de frame, no por banderas) ─────────────
+ * El orden de `useFrame` sigue el orden de montaje: como el director va DESPUÉS
+ * de la viajera, tiene la última palabra sobre la cámara. Durante el barrido
+ * establishing / el asentamiento el director ESCRIBE pose absoluta
+ * (position + lookAt + focal), así que sobrescribe lo que la viajera haya puesto
+ * ese frame — sin necesidad de que la viajera "ceda". En gameplay el director NO
+ * conduce: solo suma follow y beats como offsets aditivos sobre el target/lente,
+ * que la viajera respeta. El aplane New Donk del túnel se monta de ÚLTIMO y tiene
+ * la última palabra: con `aplanando` el director se repliega y devuelve lo aditivo.
+ *
+ * ── Tier + calma (regla dura) ─────────────────────────────────────────────
+ * `modoDirector` decide: tier alto = 'cine' (establishing + follow + beats),
+ * tier medio = 'sobrio' (establishing corto + follow, sin beats), y tier bajo,
+ * `prefers-reduced-motion` o `activa=false` = 'fijo' (INERTE TOTAL: el
+ * componente no toca la cámara — el encuadre digno de siempre). El monitor de
+ * rendimiento (usePerformanceMonitor) NO se toca aquí: su tier ya llega por
+ * prop, igual que al resto de la escena.
+ */
+import { useEffect, useRef } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import {
+  crearDirector,
+  modoDirector,
+  reclamarPresentacion,
+  pasoDirector,
+  acelerarPresentacion,
+  anticiparEntrada,
+  aplicarPoseInicial,
+} from './directorValle.js';
+
+/**
+ * @param {Object} props
+ * @param {{ current: any }} props.controls  ref de los OrbitControls hermanos.
+ * @param {number[]} props.reposo   [x,y,z] pose jugable de la cámara.
+ * @param {number[]} props.mira     [x,y,z] target de reposo del valle.
+ * @param {number} [props.fov]      fov jugable (el del Canvas).
+ * @param {import('three').Vector3} props.foco  el foco vigente (CamaraViajera).
+ * @param {{ current: import('three').Vector3|null }} [props.avatarRef]  posición
+ *   viva del avatar central (Angelita) — el follow la sigue con lead.
+ * @param {{ current: (import('./directorValle.js').BeatValle & { n?: number })|null }} [props.beatsRef]
+ *   buzón de beats del host (fauna/Ent): un objeto con `n` incremental. El
+ *   director lo LEE (nunca lo escribe: recuerda el último `n` consumido) — así
+ *   no se muta un prop-ref (regla react-hooks/immutability).
+ * @param {boolean} [props.entrando]   hay un mundo enfocado (no seguir avatar).
+ * @param {boolean} [props.aplanando]  el aplane del túnel manda: el director cede.
+ * @param {boolean} [props.activa]     false → inerte total.
+ * @param {string} [props.tier]        gama del equipo ('alto'|'medio'|'bajo').
+ * @param {boolean} [props.reducedMotion]
+ * @param {string} [props.unaVezClave]  clave de presentación una-vez-por-sesión.
+ */
+export default function DirectorValle({
+  controls,
+  reposo,
+  mira,
+  fov = 40,
+  foco,
+  avatarRef = null,
+  beatsRef = null,
+  entrando = false,
+  aplanando = false,
+  activa = true,
+  tier = 'alto',
+  reducedMotion = false,
+  unaVezClave = null,
+}) {
+  const invalidate = useThree((s) => s.invalidate);
+  // La cámara del valle es PerspectiveCamera (Canvas la crea así); el store la
+  // tipa como Camera genérica — el cast la alinea con lo que espera el director
+  // (getFocalLength/setFocalLength). Es un método, no una prop (immutability OK).
+  const camera = /** @type {import('three').PerspectiveCamera} */ (useThree((s) => s.camera));
+  const stRef = useRef(null);
+  const prevEntrando = useRef(entrando);
+  /* Último beat consumido (por `n`): el director LEE beatsRef sin escribirlo. */
+  const ultimoBeatN = useRef(0);
+
+  const modo = modoDirector({ activo: activa, tier, reducedMotion });
+
+  // Construir (o soltar) el director cuando cambia el modo. En 'fijo' queda
+  // null: el useFrame es un no-op y la cámara se queda como la dejó el Canvas.
+  useEffect(() => {
+    if (modo === 'fijo') {
+      stRef.current = null;
+      return undefined;
+    }
+    const presentar = reclamarPresentacion(unaVezClave);
+    const st = crearDirector({ modo, reposo, mira, fov, presentar });
+    stRef.current = st;
+    // Clava el arranque del barrido ANTES del primer pintado (sin flash en la
+    // pose de reposo del Canvas). Sin presentación no hace nada.
+    aplicarPoseInicial(st, camera);
+    invalidate(); // despierta el frameloop 'demand' si lo hubiera
+    // El primer gesto del usuario acelera la presentación (capture en window:
+    // también los hotspots DOM, que no burbujean por el canvas). Sin saltos.
+    const cortar = () => acelerarPresentacion(stRef.current);
+    window.addEventListener('pointerdown', cortar, true);
+    return () => window.removeEventListener('pointerdown', cortar, true);
+    // Solo depende del modo: reposo/mira/fov son estables (constantes de módulo).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modo]);
+
+  useFrame((state, delta) => {
+    const st = stRef.current;
+    if (!st) return;
+    // Flanco de entrada a un mundo → anticipación focal (solo cine, adentro
+    // decide). Se dispara ANTES de que el aplane New Donk tome el control.
+    if (entrando && !prevEntrando.current) anticiparEntrada(st);
+    prevEntrando.current = entrando;
+
+    // Drenar el buzón de beats del host (fauna/Ent/alerta) SIN escribirlo: se
+    // consume cuando su `n` supera al último visto (contador local).
+    const pend = beatsRef ? beatsRef.current : null;
+    if (pend && (pend.n ?? 0) > ultimoBeatN.current) {
+      ultimoBeatN.current = pend.n ?? 0;
+      st.beatPendiente = pend;
+    }
+
+    const conduciendo = pasoDirector(
+      st,
+      {
+        camara: camera,
+        controls: controls ? controls.current : null,
+        foco,
+        avatarPos: avatarRef ? avatarRef.current : null,
+        entrando,
+        aplanando,
+        t: state.clock.elapsedTime,
+      },
+      delta,
+    );
+    if (conduciendo) invalidate(); // presentación en curso: pedir el próximo frame
+  });
+
+  return null;
+}

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -31,6 +31,7 @@ import {
 import * as THREE from 'three';
 import { perfilDeTier } from '../../visual/mundo3d/deviceTier.js';
 import CamaraDirector from '../../visual/mundo3d/escenas/CamaraDirector.jsx';
+import DirectorValle from './DirectorValle.jsx';
 import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
 /* La CAPA DE ESTADO de Angelita (auditoría §5b): módulo puro, sin three — el
    mismo repertorio (mojada/sed/comiendo/vuelo) que usan los mundos 3D. */
@@ -931,7 +932,7 @@ function Beacon({ onAlerta, reducedMotion, conLuz = true }) {
       mundo (`entrando`), BAJA y se acerca al lugar — "entra" al mundo, y la
       cámara la acompaña. Su ánimo/energía (salud real de la finca) tiñen su
       color, su aura y qué tan vivo es su vuelo. Mira hacia donde viaja. ── */
-function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false }) {
+function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false, posRef = null }) {
   const ref = useRef(null);
   const caraRef = useRef(null);
   const prevX = useRef(foco.x);
@@ -966,6 +967,11 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
       foco.z + (entrando ? 0.7 : 0.6 + vagarZ),
     );
     ref.current.position.lerp(dest, (entrando ? 0.05 : 0.045) * mVel);
+    // Comparte su posición viva para que la cámara de director la SIGA (follow
+    // con lead): copia dentro del Vector3 compartido (mutación por método sobre
+    // un local — no reasigna el prop, como CamaraViajera con controls.current).
+    const destinoPos = posRef ? posRef.current : null;
+    if (destinoPos) destinoPos.copy(ref.current.position);
     if (caraRef.current) {
       const vx = ref.current.position.x - prevX.current;
       if (Math.abs(vx) > 0.0015) caraRef.current.style.transform = `scaleX(${vx < 0 ? -1 : 1})`;
@@ -1242,10 +1248,18 @@ const AREA_LUCIERNAGAS = [18, 2.4, 7];
 /* La pose de cámara del valle: UNA fuente para el Canvas y para el establishing
    shot de la CámaraDirector (así el dolly aterriza EXACTO donde siempre). */
 const CAMARA_VALLE = { position: [10.5, 9, 13.5], fov: 40 };
+/* El target de reposo del valle: el corazón del mapa, al que CamaraViajera
+   lleva el target sin foco ((0,1.0,1.4) + 0.6 en y). El establishing del
+   DirectorValle aterriza EXACTO aquí para no dar ningún salto al soltar. */
+const MIRA_VALLE = [0, 1.6, 1.4];
 
 /* ── Contenido de la escena (dentro del Canvas). ── */
-function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false, aplanando = false }) {
+function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false, aplanando = false, camaraDirector = false, beatsRef = null }) {
   const controls = useRef(null);
+  /* La cámara de director (FASE 4, flag `camaraDirector`) se monta DESPUÉS de
+     CamaraViajera y gana por orden de frame durante su barrido. `avatarRef`
+     recibe la posición viva de Angelita (Vector3 estable) para el follow. */
+  const avatarRef = useRef(new THREE.Vector3());
   // Occluders de los rótulos: solo terreno + cordillera (raycast barato y es
   // exactamente lo que las etiquetas no deben atravesar).
   const terrenoRef = useRef(null);
@@ -1323,6 +1337,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         estadoFinca={estadoFinca}
         hayAlerta={hayAlerta}
         reducedMotion={reducedMotion}
+        posRef={camaraDirector ? avatarRef : null}
       />
 
       <CamaraViajera
@@ -1332,21 +1347,38 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         autoOrbit={autoOrbit}
         aplanando={aplanando}
       />
-      {/* La CÁMARA DE DIRECTOR (FASE 4): el establishing shot del mapa — dolly
-          con arco desde más alto/lejos hasta la pose de siempre, UNA vez por
-          sesión (volver de un mundo no lo repite). Sin `mirada`: el target ya
-          lo lleva CamaraViajera; aquí solo posición + FOV. La respiración del
-          encuadre es aditiva y convive con su lerp. Gama baja o reduced-motion:
-          cámara simple (inerte). */}
-      <CamaraDirector
-        controls={controls}
-        reposo={CAMARA_VALLE.position}
-        duracion={2.4}
-        amplio={1.3}
-        respiro={0.05}
-        activa={!reducedMotion && tier !== 'bajo'}
-        unaVezClave="valle"
-      />
+      {/* La CÁMARA DE DIRECTOR (FASE 4). Con el flag `camaraDirector`:
+          DirectorValle (establishing + follow + beats), montado DESPUÉS de
+          CamaraViajera para ganar por orden de frame durante el barrido. Sin
+          flag: la CamaraDirector clásica intacta (establishing + respiro). Gama
+          baja o reduced-motion: ambas caen a cámara simple (inerte). */}
+      {camaraDirector ? (
+        <DirectorValle
+          controls={controls}
+          reposo={CAMARA_VALLE.position}
+          mira={MIRA_VALLE}
+          fov={CAMARA_VALLE.fov}
+          foco={foco}
+          avatarRef={avatarRef}
+          beatsRef={beatsRef}
+          entrando={entrando}
+          aplanando={aplanando}
+          activa
+          tier={tier}
+          reducedMotion={reducedMotion}
+          unaVezClave="valle"
+        />
+      ) : (
+        <CamaraDirector
+          controls={controls}
+          reposo={CAMARA_VALLE.position}
+          duracion={2.4}
+          amplio={1.3}
+          respiro={0.05}
+          activa={!reducedMotion && tier !== 'bajo'}
+          unaVezClave="valle"
+        />
+      )}
       {/* El aplane New Donk del flujo vivo — montado de ÚLTIMO para tener la
           última palabra sobre la cámara mientras cae dentro del mundo. Solo
           hace algo cuando `aplanando` (fase 'viajando'); inerte el resto. */}
@@ -1373,6 +1405,13 @@ export default function Valle3D({
      cámara del valle hace dolly + aplane hacia el landmark en vez de cortar con
      velo. El host lo enciende en la fase 'viajando'. */
   aplanando = false,
+  /* FASE 4 — cámara de director (establishing + follow + beats). Detrás de un
+     flag para no tocar la cámara actual: off = comportamiento clásico. Va
+     gateada por tier/reduced-motion adentro (tier bajo o calma = cámara fija). */
+  camaraDirector = false,
+  /* Buzón de beats coreografiados (fauna/Ent/alerta): el host (EscenaValle)
+     empuja aquí `{ tipo, lado, slug, magico }` y el director lo consume. */
+  beatsRef = null,
 }) {
   const [listo, setListo] = useState(false);
   /* El PERFIL DE RENDER del tier (DR-3D-PERF-GAMABAJA): 'alto' conserva este
@@ -1403,6 +1442,8 @@ export default function Valle3D({
           perfil={perfil}
           tier={tier}
           aplanando={aplanando}
+          camaraDirector={camaraDirector}
+          beatsRef={beatsRef}
         />
       </Suspense>
     </Canvas>

--- a/src/mockups/valle/__tests__/directorValle.test.js
+++ b/src/mockups/valle/__tests__/directorValle.test.js
@@ -1,0 +1,283 @@
+/*
+ * directorValle — pruebas de la LÓGICA PURA de la cámara de director del valle.
+ *
+ * Se ejercita con una PerspectiveCamera real de three (solo matemática, sin
+ * WebGL) y un stub de OrbitControls ({ target, update }). El corazón de la
+ * suite es la GARANTÍA DURA: en modo 'fijo' (reduced-motion / tier bajo / flag
+ * apagado) el director NO mueve la cámara ni un ápice.
+ */
+import { describe, test, expect, beforeEach } from 'vitest';
+import * as THREE from 'three';
+import {
+  modoDirector,
+  crearDirector,
+  pasoDirector,
+  dispararBeat,
+  anticiparEntrada,
+  acelerarPresentacion,
+  reclamarPresentacion,
+  _resetPresentaciones,
+  waypointsPresentacion,
+  aplicarPoseInicial,
+  easeViaje,
+  SLUG_ENT,
+  PRESENTACION_S,
+  BEAT_COOLDOWN_S,
+} from '../directorValle.js';
+
+/** @type {[number, number, number]} */
+const REPOSO = [10.5, 9, 13.5];
+/** @type {[number, number, number]} */
+const MIRA = [0, 1.6, 1.4];
+const FOV = 40;
+
+function nuevaCamara() {
+  const cam = new THREE.PerspectiveCamera(FOV, 1, 0.1, 100);
+  cam.position.set(...REPOSO);
+  cam.lookAt(new THREE.Vector3(...MIRA));
+  cam.updateMatrixWorld();
+  return cam;
+}
+
+function nuevoControls(target = MIRA) {
+  return { target: new THREE.Vector3(...target), update: () => {} };
+}
+
+/** Corre n frames del director a dt fijo, refrescando la matriz de la cámara. */
+function correr(st, ctx, n, dt = 1 / 60) {
+  let ultimo = false;
+  for (let i = 0; i < n; i += 1) {
+    ultimo = pasoDirector(st, { ...ctx, t: i * dt }, dt);
+    ctx.camara.updateMatrixWorld();
+  }
+  return ultimo;
+}
+
+beforeEach(() => {
+  _resetPresentaciones();
+});
+
+describe('modoDirector — gating por tier y calma', () => {
+  test('tier alto y activo → cine', () => {
+    expect(modoDirector({ activo: true, tier: 'alto', reducedMotion: false })).toBe('cine');
+  });
+  test('tier medio → sobrio', () => {
+    expect(modoDirector({ tier: 'medio' })).toBe('sobrio');
+  });
+  test('tier bajo → fijo (regla dura)', () => {
+    expect(modoDirector({ tier: 'bajo' })).toBe('fijo');
+  });
+  test('prefers-reduced-motion → fijo aunque el equipo sea alto', () => {
+    expect(modoDirector({ tier: 'alto', reducedMotion: true })).toBe('fijo');
+  });
+  test('flag apagado (activo=false) → fijo', () => {
+    expect(modoDirector({ activo: false, tier: 'alto' })).toBe('fijo');
+  });
+});
+
+describe('modo fijo — el director NO mueve la cámara', () => {
+  test('cámara y target quedan EXACTOS tras muchos frames, con avatar y beat pendientes', () => {
+    const st = crearDirector({ modo: 'fijo', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: true });
+    expect(st.fase).toBe('gameplay'); // fijo nunca presenta
+    const cam = nuevaCamara();
+    const controls = nuevoControls();
+    const posCam0 = cam.position.clone();
+    const focal0 = cam.getFocalLength();
+    const target0 = controls.target.clone();
+
+    // Aunque el host pida beats y haya avatar moviéndose: en fijo, nada.
+    st.beatPendiente = { tipo: 'fauna', lado: 'izq' };
+    anticiparEntrada(st);
+    const avatarPos = new THREE.Vector3(3, 4, 2);
+    const conduce = correr(
+      st,
+      { camara: cam, controls, foco: new THREE.Vector3(...MIRA), avatarPos, entrando: false },
+      120,
+    );
+
+    expect(conduce).toBe(false);
+    expect(cam.position.distanceTo(posCam0)).toBe(0);
+    expect(controls.target.distanceTo(target0)).toBe(0);
+    expect(cam.getFocalLength()).toBe(focal0);
+  });
+});
+
+describe('establishing — barrido que asienta en la pose jugable', () => {
+  test('cine: arranca lejos, CONDUCE, y aterriza EXACTO en el reposo → gameplay', () => {
+    const st = crearDirector({ modo: 'cine', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: true });
+    expect(st.fase).toBe('presenta');
+    const cam = nuevaCamara();
+    const controls = nuevoControls();
+    const ctx = { camara: cam, controls, foco: new THREE.Vector3(...MIRA), avatarPos: null, entrando: false };
+
+    // Primer frame: el barrido toma el control y salta al inicio de la curva
+    // (bien lejos del reposo) — el director conduce.
+    const conduce0 = pasoDirector(st, { ...ctx, t: 0 }, 1 / 60);
+    cam.updateMatrixWorld();
+    expect(conduce0).toBe(true);
+    expect(cam.position.distanceTo(new THREE.Vector3(...REPOSO))).toBeGreaterThan(5);
+
+    // Corre el barrido completo (6 s) + el asentamiento con margen.
+    correr(st, ctx, Math.ceil((PRESENTACION_S.cine + 4) * 60));
+    expect(st.fase).toBe('gameplay');
+    expect(cam.position.distanceTo(new THREE.Vector3(...REPOSO))).toBeLessThan(0.02);
+    // El target aterriza en la mira jugable salvo la RESPIRACIÓN del encuadre
+    // (vaivén aditivo ~centímetros, igual que el CamaraDirector clásico).
+    expect(controls.target.distanceTo(new THREE.Vector3(...MIRA))).toBeLessThan(0.12);
+    expect(cam.getFocalLength()).toBeCloseTo(nuevaCamara().getFocalLength(), 1);
+  });
+
+  test('aplicarPoseInicial clava el arranque del barrido antes del primer frame', () => {
+    const st = crearDirector({ modo: 'cine', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: true });
+    const cam = nuevaCamara();
+    // Antes: la cámara está en el reposo (la del Canvas).
+    expect(cam.position.distanceTo(new THREE.Vector3(...REPOSO))).toBeLessThan(0.001);
+    aplicarPoseInicial(st, cam);
+    // Después: saltó al primer punto del barrido (lejos del reposo), sin frames.
+    expect(cam.position.distanceTo(new THREE.Vector3(...REPOSO))).toBeGreaterThan(5);
+    expect(st.pres.arranco).toBe(true);
+  });
+
+  test('aplicarPoseInicial en modo fijo (sin presentación) no toca la cámara', () => {
+    const st = crearDirector({ modo: 'fijo', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: true });
+    const cam = nuevaCamara();
+    const pos0 = cam.position.clone();
+    aplicarPoseInicial(st, cam);
+    expect(cam.position.distanceTo(pos0)).toBe(0);
+  });
+
+  test('el barrido no repite dos veces por sesión (una-vez-por-clave)', () => {
+    expect(reclamarPresentacion('valle')).toBe(true);
+    expect(reclamarPresentacion('valle')).toBe(false);
+    const st = crearDirector({
+      modo: 'cine', reposo: REPOSO, mira: MIRA, fov: FOV,
+      presentar: reclamarPresentacion('valle'),
+    });
+    expect(st.fase).toBe('gameplay'); // ya presentada: entra directo a jugar
+  });
+
+  test('el toque del usuario ACELERA la presentación (no la teletransporta)', () => {
+    const st = crearDirector({ modo: 'cine', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: true });
+    const cam = nuevaCamara();
+    const controls = nuevoControls();
+    const ctx = { camara: cam, controls, foco: new THREE.Vector3(...MIRA), avatarPos: null, entrando: false };
+    pasoDirector(st, { ...ctx, t: 0 }, 1 / 60);
+    acelerarPresentacion(st);
+    expect(st.pres.p).toBeGreaterThan(0.8);
+    // Tras acelerar, el resto del barrido remata rápido y el resorte asienta.
+    correr(st, ctx, 400);
+    expect(st.fase).toBe('gameplay');
+  });
+});
+
+describe('follow — la cámara se inclina hacia el avatar (con lead), acotado', () => {
+  test('un avatar desplazado empuja el target un pelo, dentro del tope', () => {
+    const st = crearDirector({ modo: 'cine', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: false });
+    expect(st.fase).toBe('gameplay');
+    const cam = nuevaCamara();
+    const controls = nuevoControls();
+    const target0 = controls.target.clone();
+    const foco = new THREE.Vector3(...MIRA);
+    const avatarPos = new THREE.Vector3(MIRA[0] + 4, MIRA[1] + 1, MIRA[2] + 3);
+    correr(st, { camara: cam, controls, foco, avatarPos, entrando: false }, 90);
+
+    const desvio = controls.target.distanceTo(target0);
+    expect(desvio).toBeGreaterThan(0.02); // sí sigue
+    expect(desvio).toBeLessThan(1.4); // pero es un lean, no una persecución
+  });
+
+  test('entrando a un mundo, el follow del avatar se suelta (manda el foco)', () => {
+    const st = crearDirector({ modo: 'cine', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: false });
+    const cam = nuevaCamara();
+    const controls = nuevoControls();
+    const target0 = controls.target.clone();
+    const foco = new THREE.Vector3(...MIRA);
+    const avatarPos = new THREE.Vector3(MIRA[0] + 5, MIRA[1], MIRA[2] + 5);
+    correr(st, { camara: cam, controls, foco, avatarPos, entrando: true }, 90);
+    // Solo queda la respiración mínima del encuadre (amplitud ~centímetros).
+    expect(controls.target.distanceTo(target0)).toBeLessThan(0.12);
+  });
+});
+
+describe('beats — micro reencuadres, admisión dura y restauración', () => {
+  test('dispararBeat: solo en cine + gameplay, y respeta el cooldown', () => {
+    const cine = crearDirector({ modo: 'cine', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: false });
+    expect(dispararBeat(cine, { tipo: 'fauna', lado: 'der' }, 0)).toBe(true);
+    // Ya hay uno en curso: el segundo no entra.
+    expect(dispararBeat(cine, { tipo: 'fauna', lado: 'izq' }, 0)).toBe(false);
+
+    const sobrio = crearDirector({ modo: 'sobrio', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: false });
+    expect(dispararBeat(sobrio, { tipo: 'fauna', lado: 'der' }, 0)).toBe(false);
+  });
+
+  test('un beat de fauna hace push-in por lente y REGRESA el focal al reposo', () => {
+    const st = crearDirector({ modo: 'cine', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: false });
+    const cam = nuevaCamara();
+    const controls = nuevoControls();
+    const focal0 = cam.getFocalLength();
+    const ctx = { camara: cam, controls, foco: new THREE.Vector3(...MIRA), avatarPos: null, entrando: false };
+
+    st.beatPendiente = { tipo: 'fauna', lado: 'der' };
+    // A mitad del beat el focal es MÁS largo (telefoto: push-in).
+    correr(st, ctx, 30);
+    expect(cam.getFocalLength()).toBeGreaterThan(focal0 + 0.1);
+
+    // Pasado el beat entero, el focal vuelve a su sitio y el beat queda quieto.
+    correr(st, ctx, 400);
+    expect(st.beat.fase).toBe('quieto');
+    expect(cam.getFocalLength()).toBeCloseTo(focal0, 1);
+  });
+
+  test('el Ent pide un plano más LARGO que un bicho cualquiera', () => {
+    const a = crearDirector({ modo: 'cine', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: false });
+    const b = crearDirector({ modo: 'cine', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: false });
+    dispararBeat(a, { tipo: 'fauna', lado: 'bosque', slug: SLUG_ENT }, 0);
+    dispararBeat(b, { tipo: 'fauna', lado: 'izq' }, 0);
+    expect(a.beat.sosten).toBeGreaterThan(b.beat.sosten);
+  });
+});
+
+describe('anticipación de entrada — el lente se abre y suelta (solo cine)', () => {
+  test('cine: abre el focal transitorio y lo restaura', () => {
+    const st = crearDirector({ modo: 'cine', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: false });
+    const cam = nuevaCamara();
+    const controls = nuevoControls();
+    const focal0 = cam.getFocalLength();
+    const ctx = { camara: cam, controls, foco: new THREE.Vector3(...MIRA), avatarPos: null, entrando: false };
+    anticiparEntrada(st);
+    correr(st, ctx, 8);
+    expect(cam.getFocalLength()).toBeLessThan(focal0 - 0.05); // más abierto (gran angular)
+    correr(st, ctx, 300);
+    expect(cam.getFocalLength()).toBeCloseTo(focal0, 1);
+  });
+
+  test('sobrio: anticiparEntrada no hace nada', () => {
+    const st = crearDirector({ modo: 'sobrio', reposo: REPOSO, mira: MIRA, fov: FOV, presentar: false });
+    anticiparEntrada(st);
+    expect(st.anticipo.meta).toBe(0);
+  });
+});
+
+describe('utilitarios puros', () => {
+  test('easeViaje es un ease-in-out en [0,1] sin sobrepasar', () => {
+    expect(easeViaje(0)).toBeCloseTo(0, 6);
+    expect(easeViaje(1)).toBeCloseTo(1, 6);
+    expect(easeViaje(0.5)).toBeCloseTo(0.5, 6);
+    for (let p = 0; p <= 1.0001; p += 0.1) {
+      const e = easeViaje(p);
+      expect(e).toBeGreaterThanOrEqual(-1e-9);
+      expect(e).toBeLessThanOrEqual(1 + 1e-9);
+    }
+  });
+
+  test('waypointsPresentacion: cine trae más planos que sobrio', () => {
+    const cine = waypointsPresentacion('cine', REPOSO, MIRA);
+    const sobrio = waypointsPresentacion('sobrio', REPOSO, MIRA);
+    expect(cine.pos.length).toBeGreaterThan(sobrio.pos.length);
+    expect(cine.pos.length).toBe(cine.mira.length);
+  });
+
+  test('BEAT_COOLDOWN_S es un respiro sensato (varios segundos)', () => {
+    expect(BEAT_COOLDOWN_S).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/src/mockups/valle/directorValle.js
+++ b/src/mockups/valle/directorValle.js
@@ -1,0 +1,612 @@
+/*
+ * directorValle — la LÓGICA PURA de la cámara de director del valle 3D.
+ *
+ * El acabado cinematográfico del mapa, en tres gestos (DR "Game-feel y cámara
+ * director 3D"): PRESENTACIÓN (un barrido establishing alto que muestra el
+ * valle vivo — la ladera, la quebrada, los mundos — y ASIENTA con resorte en
+ * la pose jugable de siempre), FOLLOW suave del avatar (la cámara se inclina
+ * apenas hacia donde vuela, con LEAD de anticipación por su velocidad) y
+ * BEATS coreografiados (micro push-in / reencuadres breves cuando un bicho
+ * del coro ambiental hace su guiño lejano, cuando aparece el Ent de cameo,
+ * cuando llega la alerta del día, o la anticipación focal al entrar a un
+ * mundo por el túnel).
+ *
+ * ES UN MÓDULO SIN REACT NI CANVAS: opera sobre una cámara three y el target
+ * de unos OrbitControls que le presta el componente (DirectorValle.jsx). Así
+ * se testea entero en jsdom con una PerspectiveCamera real — incluida la
+ * garantía dura de que en modo 'fijo' (reduced-motion / tier bajo / flag off)
+ * NO SE MUEVE NADA.
+ *
+ * ── Movimiento (rubber-hose, jamás brusco) ────────────────────────────────
+ *  · El barrido viaja por una curva Catmull-Rom con ease-in-out senoidal (la
+ *    grúa no rebota) y REMATA con resorte sub-amortiguado (ζ≈0.86): sobrepasa
+ *    el encuadre un pelito y se asienta — el settle con overshoot mínimo.
+ *  · Follow y beats van como OFFSETS ADITIVOS por delta de frame (el patrón
+ *    "respiro" de escenas/CamaraDirector): conviven con CamaraViajera y con
+ *    el orbit del usuario sin pelear — nadie es dueño exclusivo del target.
+ *  · El damping continuo (follow, envolventes de beat, anticipación focal) usa
+ *    `maath/easing` — `damp3` para vectores y `damp` para escalares: suave,
+ *    frame-rate independiente y con `delta` acotado (una pestaña dormida no
+ *    dispara nada al despertar). El ÚNICO gesto que maath no cubre es el settle
+ *    CON OVERSHOOT del establishing (maath es exponencial puro, sin rebote):
+ *    ese remate va por un resorte sub-amortiguado semi-implícito hand-rolled,
+ *    igual que `escenas/CamaraDirector` y `CamaraDirector` (raíz).
+ *
+ * ── Respeto (tier + calma) ────────────────────────────────────────────────
+ *  · 'cine'   (tier alto): cinematografía completa — barrido + follow + beats.
+ *  · 'sobrio' (tier medio): presentación corta sin rebote + follow; sin beats.
+ *  · 'fijo'   (tier bajo, prefers-reduced-motion o flag apagado): INERTE
+ *    TOTAL — la cámara queda como la dejan el Canvas y CamaraViajera (el
+ *    encuadre digno de siempre; cero regresión).
+ * Cero alocación por frame: los Vector3 del estado se mutan in-place.
+ */
+import * as THREE from 'three';
+import { damp, damp3 } from 'maath/easing';
+
+/* ── Constantes del director (valores del DR: conservadores y suaves) ────── */
+
+/** Duración del barrido de presentación por modo (s). */
+export const PRESENTACION_S = { cine: 6.0, sobrio: 2.6 };
+/** Amortiguación del resorte de asentamiento: sub-crítica en cine (overshoot
+    rubber-hose mínimo), crítica en sobrio (llega resuelto, sin rebote). */
+const ZETA = { cine: 0.86, sobrio: 1 };
+/** Frecuencia del resorte de asentamiento (rad/s aprox.). */
+const OMEGA_ASIENTA = { cine: 2.1, sobrio: 3.0 };
+/** Umbral de asentamiento, relativo a la escala del tramo final. */
+const EPSILON = 0.004;
+/** Focal mínima de seguridad (mm de film): nada voltea el lente. */
+const FOCAL_MIN = 6;
+/** Cooldown entre beats (s): chispa ocasional, no circo. */
+export const BEAT_COOLDOWN_S = 9;
+/** El primer gesto del usuario ACELERA la presentación hasta aquí. */
+const PRESENTACION_CORTE = 0.86;
+
+/* Push-in (fracción de la distancia cámara→target) y sostén (s) por beat.
+   El Ent es el anciano del páramo: su cameo pide un plano más quieto y largo. */
+const BEATS = {
+  fauna: { push: 0.06, sosten: 1.1, lean: 0.8 },
+  magico: { push: 0.08, sosten: 1.4, lean: 0.9 },
+  ent: { push: 0.09, sosten: 2.2, lean: 1.0 },
+  alerta: { push: 0.08, sosten: 1.6, lean: 0.0 },
+};
+/** El slug del Ent en el coro ambiental (CREATURES). */
+export const SLUG_ENT = 'ent-frailejon';
+
+/* Follow del avatar: pesos chicos — la cámara se INCLINA, no persigue.
+   Los `st*` son `smoothTime` de maath/easing (s ~ tiempo de llegada). */
+const FOLLOW = {
+  peso: 0.16, // cuánto del desvío del avatar respecto al foco entra al target
+  lead: { cine: 0.42, sobrio: 0.26 }, // s de anticipación por velocidad
+  tope: 1.1, // clamp del offset (unidades de mundo)
+  stOffset: 0.55, // smoothTime del offset hacia su meta (damp3)
+  stVel: 0.25, // smoothTime del suavizado de la velocidad del avatar
+  respiro: 0.05, // vaivén vertical del encuadre (respiración, u. de mundo)
+};
+
+/* smoothTime (s) de las envolventes de beat y de la anticipación focal. */
+const ST_BEAT = { sube: 0.3, baja: 0.6 };
+const ST_ANTICIPO = { sube: 0.11, baja: 0.42 };
+
+/* Anticipación al entrar a un mundo (túnel Odyssey): el lente se ABRE un 6%
+   un instante (la anticipación rubber-hose) y suelta — el zoom-in que sigue
+   (CamaraViajera + aplane New Donk) remata el gesto. Solo focal: cero pelea. */
+const ANTICIPO = { abre: 0.06 };
+
+/* Vector cero reusable (meta de decaimiento del damp3): jamás se muta. */
+const ZERO3 = Object.freeze(new THREE.Vector3());
+
+/* ── El BARRIDO de presentación ───────────────────────────────────────────
+   Waypoints en unidades de mundo del valle (terreno 34×34; la cordillera al
+   fondo en z≈-15, la quebrada baja de (-3.4,-7.2) a (3.6,8), los mundos entre
+   z -2.5 y 6.5). Arranca ALTO sobre el páramo mirando la ladera, planea sobre
+   la quebrada y los mundos, y cae hacia la pose jugable. El último tramo lo
+   cubre el resorte de asentamiento (por eso la curva termina CERCA del reposo,
+   no encima). El modo sobrio recorta el barrido a un dolly corto en arco. */
+export function waypointsPresentacion(modo, reposo, mira) {
+  const [rx, ry, rz] = reposo;
+  const [mx, my, mz] = mira;
+  if (modo === 'sobrio') {
+    return {
+      pos: [
+        [rx * 1.35, ry * 1.5 + 1.5, rz * 1.35],
+        [rx * 1.16, ry * 1.22 + 0.7, rz * 1.16],
+        [rx * 1.045, ry * 1.06, rz * 1.045],
+      ],
+      mira: [
+        [mx, my + 1.2, mz - 1.5],
+        [mx, my + 0.5, mz - 0.6],
+        [mx, my + 0.12, mz - 0.15],
+      ],
+      fovDesde: 44,
+    };
+  }
+  return {
+    pos: [
+      [-13, 15.5, -6], // alto sobre el páramo: la ladera entera y el río de lado
+      [-14.5, 11, 6], // planeo por el costado: la quebrada baja en cuadro
+      [-4, 8.6, 15], // frente del valle: los mundos y la fauna, de cerca
+      [rx * 0.86, ry * 1.06, rz * 0.94], // casi la pose jugable (remata el resorte)
+    ],
+    mira: [
+      [1.5, 2.6, 2.5],
+      [0.5, 1.6, 0.8],
+      [0.2, 1.2, 0.6],
+      [mx, my + 0.1, mz - 0.1],
+    ],
+    fovDesde: 46,
+  };
+}
+
+/* ── Utilitarios de movimiento (frame-rate independientes) ────────────────── */
+
+/** Ease-in-out senoidal del travelling: arranca y frena con calma, sin rebote. */
+export const easeViaje = (p) => 0.5 - 0.5 * Math.cos(Math.PI * p);
+
+/**
+ * Un paso semi-implícito de resorte para un Vector3 (muta pos y vel).
+ * ζ<1 asienta con overshoot suave; ζ=1 es damp crítico.
+ */
+function pasoResorteV3(pos, vel, hasta, omega, zeta, dt) {
+  const k = omega * omega;
+  const c = 2 * zeta * omega;
+  vel.set(
+    vel.x + (-c * vel.x - k * (pos.x - hasta.x)) * dt,
+    vel.y + (-c * vel.y - k * (pos.y - hasta.y)) * dt,
+    vel.z + (-c * vel.z - k * (pos.z - hasta.z)) * dt,
+  );
+  pos.addScaledVector(vel, dt);
+}
+
+/** El mismo paso de resorte para un escalar. Devuelve [valor, vel]. */
+function pasoResorte(valor, vel, hasta, omega, zeta, dt) {
+  const v = vel + (-2 * zeta * omega * vel - omega * omega * (valor - hasta)) * dt;
+  return [valor + v * dt, v];
+}
+
+/** Distancia focal (mm de film) que produce un fov vertical dado. */
+function focalDeFov(camara, fov) {
+  return (0.5 * camara.getFilmHeight()) / Math.tan(THREE.MathUtils.degToRad(fov * 0.5));
+}
+
+/* ── El MODO del director ─────────────────────────────────────────────────── */
+
+/**
+ * Decide cuánta cinematografía aguanta la sesión. La regla dura del DR:
+ * reduced-motion y tier bajo NO mueven la cámara (encuadre digno fijo).
+ *
+ * @param {{ activo?: boolean, tier?: string, reducedMotion?: boolean }} p
+ * @returns {'cine'|'sobrio'|'fijo'}
+ */
+export function modoDirector({ activo = true, tier = 'alto', reducedMotion = false } = {}) {
+  if (!activo || reducedMotion || tier === 'bajo') return 'fijo';
+  return tier === 'medio' ? 'sobrio' : 'cine';
+}
+
+/* ── Presentación una-vez-por-sesión (mismo espíritu que escenas/CamaraDirector) ── */
+const yaPresentados = new Set();
+
+/** ¿Toca presentar esta clave? (la marca al preguntarse: volver no repite). */
+export function reclamarPresentacion(clave) {
+  if (clave === null || clave === undefined) return true;
+  if (yaPresentados.has(clave)) return false;
+  yaPresentados.add(clave);
+  return true;
+}
+
+/** Solo para tests: olvida las presentaciones ya corridas. */
+export function _resetPresentaciones() {
+  yaPresentados.clear();
+}
+
+/* ── El ESTADO del director ───────────────────────────────────────────────── */
+
+/**
+ * @typedef {Object} BeatValle  Un beat pedido por el host.
+ * @property {number} [n]                 identidad (contador del host).
+ * @property {'fauna'|'alerta'} tipo      qué pasó en el valle.
+ * @property {'izq'|'der'|'bosque'} [lado]  por dónde asomó el bicho.
+ * @property {string} [slug]              qué bicho (SLUG_ENT = cameo del Ent).
+ * @property {boolean} [magico]           apareció mágico (el jaguar).
+ */
+
+/**
+ * Crea el estado mutable del director. `presentar` ya viene decidido por el
+ * componente (modo ≠ fijo + reclamarPresentacion de la clave de sesión).
+ *
+ * @param {Object} o
+ * @param {'cine'|'sobrio'|'fijo'} o.modo
+ * @param {number[]} o.reposo   [x,y,z] pose jugable de la cámara (CAMARA_VALLE).
+ * @param {number[]} o.mira     [x,y,z] target de reposo del valle.
+ * @param {number} o.fov        fov jugable (el del Canvas).
+ * @param {boolean} [o.presentar]  true → arranca con el barrido establishing.
+ */
+export function crearDirector({ modo, reposo, mira, fov, presentar = false }) {
+  const conPres = modo !== 'fijo' && presentar;
+  const wp = conPres ? waypointsPresentacion(modo, reposo, mira) : null;
+  return {
+    modo,
+    /** 'presenta' (barrido) → 'asienta' (resorte al reposo) → 'gameplay'. */
+    fase: conPres ? 'presenta' : 'gameplay',
+    reposo: new THREE.Vector3(...reposo),
+    miraReposo: new THREE.Vector3(...mira),
+    fovReposo: fov,
+    pres: conPres
+      ? {
+          p: 0,
+          dur: PRESENTACION_S[modo] || PRESENTACION_S.sobrio,
+          curvaPos: new THREE.CatmullRomCurve3(wp.pos.map((v) => new THREE.Vector3(...v))),
+          curvaMira: new THREE.CatmullRomCurve3(wp.mira.map((v) => new THREE.Vector3(...v))),
+          fovDesde: wp.fovDesde,
+          arranco: false,
+        }
+      : null,
+    /* La mirada que conduce el director mientras presenta/asienta. */
+    mira: new THREE.Vector3(...mira),
+    velPos: new THREE.Vector3(),
+    velMira: new THREE.Vector3(),
+    velFov: 0,
+    fovActual: conPres ? wp.fovDesde : fov,
+    /* Beat en curso + el pendiente que dejó el host. */
+    beat: {
+      fase: 'quieto', // 'va' | 'sostiene' | 'vuelve'
+      t: 0,
+      env: 0, // envolvente 0..1 (damped)
+      push: 0, // push-in vigente por LENTE (fracción de focal, no dolly)
+      sosten: 0,
+      lean: new THREE.Vector3(),
+      aplicadoFocal: 0, // factor de push-in ya aplicado (delta por frame)
+      aplicadoLean: new THREE.Vector3(),
+      listoEn: 0, // reloj: cuándo vuelve a haber cupo (cooldown)
+    },
+    /** @type {BeatValle|null} */
+    beatPendiente: null,
+    /* Follow aditivo del avatar (+ respiración del encuadre). */
+    foll: {
+      off: new THREE.Vector3(),
+      aplicado: new THREE.Vector3(),
+      meta: new THREE.Vector3(),
+      velAvatar: new THREE.Vector3(),
+      prevAvatar: new THREE.Vector3(),
+      conPrev: false,
+    },
+    /* Anticipación focal al entrar a un mundo (solo cine). */
+    anticipo: { env: 0, meta: 0, aplicado: 0 },
+    /* Escratch compartido (cero alocación por frame). */
+    _v: new THREE.Vector3(),
+    _w: new THREE.Vector3(),
+  };
+}
+
+/* ── Órdenes del host ─────────────────────────────────────────────────────── */
+
+/**
+ * Pide un beat. La admisión es DURA: solo en modo cine, en gameplay (nunca
+ * encima de la presentación), sin otro beat en curso y respetando el cooldown.
+ *
+ * @param {ReturnType<typeof crearDirector>} st
+ * @param {BeatValle|null} beat
+ * @param {number} ahora  reloj de la escena (s).
+ * @returns {boolean} true si el beat entró.
+ */
+export function dispararBeat(st, beat, ahora) {
+  if (!beat || st.modo !== 'cine' || st.fase !== 'gameplay') return false;
+  const b = st.beat;
+  if (b.fase !== 'quieto' || ahora < b.listoEn) return false;
+  const receta =
+    beat.tipo === 'alerta'
+      ? BEATS.alerta
+      : beat.slug === SLUG_ENT
+        ? BEATS.ent
+        : beat.magico
+          ? BEATS.magico
+          : BEATS.fauna;
+  b.fase = 'va';
+  b.t = 0;
+  b.env = 0;
+  b.push = receta.push;
+  b.sosten = receta.sosten;
+  b.lean.set(0, 0, 0);
+  if (beat.tipo === 'fauna' && receta.lean > 0) {
+    // El reencuadre se INCLINA hacia el lado por donde asomó el bicho: en el
+    // eje derecha/izquierda DE CÁMARA (se resuelve en el paso, con la cámara).
+    b.lean.set(beat.lado === 'izq' ? -receta.lean : beat.lado === 'der' ? receta.lean : 0, 0.12, 0);
+    if (beat.lado === 'bosque') b.lean.set(0, 0.28, -0.5); // asoma tras el horizonte: tilt arriba
+  }
+  return true;
+}
+
+/**
+ * Anticipación al entrar a un mundo (el lente se abre un instante y suelta).
+ * Solo cine; los otros modos entran directo con la CamaraViajera de siempre.
+ * @param {ReturnType<typeof crearDirector>} st
+ */
+export function anticiparEntrada(st) {
+  if (st.modo !== 'cine' || st.fase !== 'gameplay') return;
+  st.anticipo.meta = 1;
+}
+
+/** El primer gesto del usuario acelera la presentación (nunca teletransporta). */
+export function acelerarPresentacion(st) {
+  if (st.pres && st.fase === 'presenta') st.pres.p = Math.max(st.pres.p, PRESENTACION_CORTE);
+}
+
+/**
+ * Clava la cámara en el PRIMER punto del barrido, en el efecto de montaje —
+ * ANTES del primer pintado. Sin esto habría un fotograma en la pose de reposo
+ * (la del Canvas) antes de que el primer frame salte al arranque del barrido.
+ * Marca `pr.arranco` para que `pasoDirector` no la re-inicialice.
+ *
+ * @param {ReturnType<typeof crearDirector>} st
+ * @param {import('three').PerspectiveCamera} camara
+ */
+export function aplicarPoseInicial(st, camara) {
+  if (!st.pres || st.fase !== 'presenta') return;
+  const pr = st.pres;
+  pr.arranco = true;
+  pr.curvaPos.getPoint(0, camara.position);
+  pr.curvaMira.getPoint(0, st.mira);
+  st.fovActual = pr.fovDesde;
+  camara.setFocalLength(Math.max(focalDeFov(camara, pr.fovDesde), FOCAL_MIN));
+  camara.lookAt(st.mira);
+}
+
+/* ── EL PASO por frame ────────────────────────────────────────────────────── */
+
+/**
+ * Avanza el director un frame. Muta cámara/target SOLO por métodos three.
+ *
+ * @param {ReturnType<typeof crearDirector>} st
+ * @param {Object} ctx
+ * @param {import('three').PerspectiveCamera} ctx.camara
+ * @param {{ target: import('three').Vector3, update: () => void }|null} ctx.controls
+ *        los OrbitControls hermanos (o un stub en tests). null → sin target.
+ * @param {import('three').Vector3} ctx.foco  el foco vigente de CamaraViajera.
+ * @param {import('three').Vector3|null} [ctx.avatarPos]  posición viva del avatar.
+ * @param {boolean} [ctx.entrando]   hay un mundo en foco (no seguir al avatar).
+ * @param {boolean} [ctx.aplanando]  el aplane New Donk manda: el director cede.
+ * @param {number} ctx.t   reloj de la escena (s).
+ * @param {number} dtCrudo  delta del frame (s), se acota adentro.
+ * @returns {boolean} true si el director CONDUCE la cámara este frame (la
+ *          CamaraViajera debe ceder — presentación en curso).
+ */
+export function pasoDirector(st, ctx, dtCrudo) {
+  if (st.modo === 'fijo') return false;
+  const { camara, controls } = ctx;
+  const dt = Math.min(dtCrudo, 1 / 20);
+
+  /* El aplane del túnel tiene la última palabra: el director se repliega y
+     devuelve lo aditivo que tuviera puesto (para no contaminar la captura de
+     AplaneNewDonk, que corre DESPUÉS en el mismo frame). */
+  if (ctx.aplanando) {
+    devolverAditivos(st, camara, controls);
+    return false;
+  }
+
+  /* ── 1) PRESENTACIÓN: el barrido establishing ── */
+  if (st.fase === 'presenta' && st.pres) {
+    const pr = st.pres;
+    if (!pr.arranco) {
+      pr.arranco = true;
+      camara.position.copy(pr.curvaPos.getPoint(0));
+      st.mira.copy(pr.curvaMira.getPoint(0));
+      st.fovActual = pr.fovDesde;
+      camara.setFocalLength(Math.max(focalDeFov(camara, pr.fovDesde), FOCAL_MIN));
+      camara.lookAt(st.mira);
+    }
+    pr.p = Math.min(1, pr.p + dt / pr.dur);
+    const e = easeViaje(pr.p);
+    pr.curvaPos.getPoint(e, camara.position);
+    pr.curvaMira.getPoint(e, st.mira);
+    st.fovActual = THREE.MathUtils.lerp(pr.fovDesde, st.fovReposo, e);
+    camara.setFocalLength(Math.max(focalDeFov(camara, st.fovActual), FOCAL_MIN));
+    camara.lookAt(st.mira);
+    if (pr.p >= 1) {
+      // El barrido terminó CERCA del reposo: el resorte remata la llegada.
+      st.fase = 'asienta';
+      st.velPos.set(0, 0, 0);
+      st.velMira.set(0, 0, 0);
+      st.velFov = 0;
+    }
+    return true;
+  }
+
+  /* ── 2) ASENTAMIENTO: resorte (overshoot mínimo en cine) a la pose jugable ── */
+  if (st.fase === 'asienta') {
+    const omega = OMEGA_ASIENTA[st.modo] || OMEGA_ASIENTA.sobrio;
+    const zeta = ZETA[st.modo] || 1;
+    pasoResorteV3(camara.position, st.velPos, st.reposo, omega, zeta, dt);
+    pasoResorteV3(st.mira, st.velMira, st.miraReposo, omega, zeta, dt);
+    const [f, vf] = pasoResorte(st.fovActual, st.velFov, st.fovReposo, omega, zeta, dt);
+    st.fovActual = f;
+    st.velFov = vf;
+    camara.setFocalLength(Math.max(focalDeFov(camara, st.fovActual), FOCAL_MIN));
+    camara.lookAt(st.mira);
+    const eps = EPSILON * Math.max(st.reposo.length(), 1);
+    if (
+      camara.position.distanceTo(st.reposo) < eps &&
+      st.velPos.length() < eps * 6 &&
+      st.mira.distanceTo(st.miraReposo) < eps
+    ) {
+      // Aterrizaje EXACTO en el encuadre jugable de siempre; cero regresión.
+      camara.position.copy(st.reposo);
+      st.mira.copy(st.miraReposo);
+      st.fovActual = st.fovReposo;
+      camara.setFocalLength(Math.max(focalDeFov(camara, st.fovReposo), FOCAL_MIN));
+      camara.lookAt(st.mira);
+      if (controls) {
+        controls.target.copy(st.miraReposo);
+        controls.update();
+      }
+      st.fase = 'gameplay';
+    }
+    return true;
+  }
+
+  /* ── 3) GAMEPLAY: follow aditivo + beats. La CamaraViajera conduce. ── */
+  pasoFollow(st, ctx, dt);
+  pasoBeat(st, ctx, dt);
+  pasoAnticipo(st, camara, dt);
+  return false;
+}
+
+/* El follow del avatar + la respiración del encuadre, como OFFSET ADITIVO por
+   delta (patrón respiro): meta = desvío del avatar respecto al foco, pesado y
+   con LEAD por velocidad; el offset se amortigua hacia la meta y al target se
+   le aplica SOLO la diferencia contra lo ya aplicado. */
+function pasoFollow(st, ctx, dt) {
+  const { controls, foco, avatarPos } = ctx;
+  if (!controls) return;
+  const f = st.foll;
+
+  // Velocidad del avatar (suavizada con damp3): el LEAD mira hacia donde VA.
+  if (avatarPos) {
+    if (f.conPrev && dt > 0) {
+      st._v.copy(avatarPos).sub(f.prevAvatar).divideScalar(dt);
+      damp3(f.velAvatar, st._v, FOLLOW.stVel, dt);
+    }
+    f.prevAvatar.copy(avatarPos);
+    f.conPrev = true;
+  } else {
+    damp3(f.velAvatar, ZERO3, FOLLOW.stVel, dt); // sin avatar, la velocidad decae a 0
+  }
+
+  // La meta del offset: solo en reposo del valle (entrando manda el foco).
+  if (avatarPos && !ctx.entrando) {
+    const lead = FOLLOW.lead[st.modo] ?? FOLLOW.lead.sobrio;
+    f.meta
+      .copy(avatarPos)
+      .sub(foco)
+      .multiplyScalar(FOLLOW.peso)
+      .addScaledVector(f.velAvatar, lead * FOLLOW.peso * 2);
+    f.meta.y *= 0.35; // el vaivén vertical del vuelo no bambolea el encuadre
+    if (f.meta.length() > FOLLOW.tope) f.meta.setLength(FOLLOW.tope);
+  } else {
+    f.meta.set(0, 0, 0);
+  }
+  // La respiración del encuadre (dos senos lentos desfasados, amplitud mínima).
+  const t = ctx.t;
+  const respiro =
+    Math.sin(t * 0.45) * FOLLOW.respiro + Math.sin(t * 0.23 + 1.7) * FOLLOW.respiro * 0.5;
+
+  damp3(f.off, f.meta, FOLLOW.stOffset, dt); // maath: offset trailing suave hacia la meta
+  // Aplicar el DELTA contra lo ya aplicado (aditivo: convive con todos).
+  st._v.copy(f.off);
+  st._v.y += respiro;
+  st._w.copy(st._v).sub(f.aplicado);
+  controls.target.add(st._w);
+  f.aplicado.copy(st._v);
+}
+
+/* El beat en curso: micro push-in por LENTE (focal) + lean del target, ambos
+   como envolvente amortiguada que SIEMPRE vuelve a cero. El push va por focal
+   (no por dolly de posición) A PROPÓSITO: OrbitControls reposiciona la cámara
+   desde su esférica en cada `update()`, así que mover camera.position pelearía;
+   el focal, en cambio, no lo toca nadie más en gameplay → cero conflicto. */
+function pasoBeat(st, ctx, dt) {
+  const { camara, controls } = ctx;
+  const b = st.beat;
+
+  // ¿Hay un pendiente del host? (la admisión vive en dispararBeat)
+  if (st.beatPendiente) {
+    const pedido = st.beatPendiente;
+    st.beatPendiente = null;
+    if (dispararBeat(st, pedido, ctx.t) && pedido.tipo === 'fauna' && b.lean.x !== 0) {
+      // Resolver el lean izquierda/derecha EN EJES DE CÁMARA (columna X de su
+      // matriz de mundo): screen-left es screen-left desde cualquier órbita.
+      const lx = b.lean.x;
+      st._v.setFromMatrixColumn(camara.matrixWorld, 0).setY(0).normalize();
+      b.lean.set(st._v.x * lx, b.lean.y, st._v.z * lx);
+    }
+  }
+  if (b.fase === 'quieto') return;
+
+  b.t += dt;
+  let metaEnv = 0;
+  if (b.fase === 'va') {
+    metaEnv = 1;
+    if (b.env > 0.86) {
+      b.fase = 'sostiene';
+      b.t = 0;
+    }
+  } else if (b.fase === 'sostiene') {
+    metaEnv = 1;
+    if (b.t >= b.sosten) {
+      b.fase = 'vuelve';
+      b.t = 0;
+    }
+  } // 'vuelve' → metaEnv 0
+  damp(b, 'env', metaEnv, b.fase === 'vuelve' ? ST_BEAT.baja : ST_BEAT.sube, dt);
+  if (b.fase === 'vuelve' && b.env < 0.01) {
+    b.env = 0;
+    b.fase = 'quieto';
+    b.listoEn = ctx.t + BEAT_COOLDOWN_S;
+  }
+
+  // Push-in por LENTE (factor multiplicativo con delta contra lo ya aplicado):
+  // focal más largo = telefoto que se acerca; se deshace solo al volver env→0.
+  const factorNuevo = 1 + b.push * b.env;
+  const factorViejo = 1 + b.push * b.aplicadoFocal;
+  camara.setFocalLength(
+    Math.max((camara.getFocalLength() / factorViejo) * factorNuevo, FOCAL_MIN),
+  );
+  b.aplicadoFocal = b.env;
+  // Lean del target (aditivo, restaurable): el reencuadre se inclina y vuelve.
+  if (controls) {
+    st._w.copy(b.lean).multiplyScalar(b.env).sub(b.aplicadoLean);
+    controls.target.add(st._w);
+    b.aplicadoLean.copy(b.lean).multiplyScalar(b.env);
+  }
+}
+
+/* La anticipación focal: sube rápido, suelta suave; puro setFocalLength por
+   delta multiplicativo — no toca posición ni target. */
+function pasoAnticipo(st, camara, dt) {
+  const a = st.anticipo;
+  if (a.meta === 0 && a.env < 0.001 && a.aplicado === 0) return;
+  damp(a, 'env', a.meta, a.meta > a.env ? ST_ANTICIPO.sube : ST_ANTICIPO.baja, dt);
+  if (a.meta === 1 && a.env > 0.92) a.meta = 0; // llegó: soltar
+  const factorNuevo = 1 - ANTICIPO.abre * a.env;
+  const factorViejo = 1 - ANTICIPO.abre * a.aplicado;
+  camara.setFocalLength(
+    Math.max((camara.getFocalLength() / factorViejo) * factorNuevo, FOCAL_MIN),
+  );
+  a.aplicado = a.env;
+  if (a.meta === 0 && a.env < 0.001) {
+    // Restaurado por completo: cerrar en limpio (sin residuo flotante).
+    camara.setFocalLength(Math.max(camara.getFocalLength() / factorNuevo, FOCAL_MIN));
+    a.env = 0;
+    a.aplicado = 0;
+  }
+}
+
+/* Devuelve TODO lo aditivo puesto (follow, beat, anticipo) — se llama cuando
+   otro sistema (el aplane del túnel) va a capturar la pose de la cámara. */
+function devolverAditivos(st, camara, controls) {
+  const f = st.foll;
+  const b = st.beat;
+  if (controls) {
+    controls.target.sub(f.aplicado);
+    controls.target.sub(b.aplicadoLean);
+  }
+  f.aplicado.set(0, 0, 0);
+  f.off.set(0, 0, 0);
+  b.aplicadoLean.set(0, 0, 0);
+  if (b.aplicadoFocal !== 0) {
+    // Deshacer el push-in por lente (factor multiplicativo).
+    camara.setFocalLength(
+      Math.max(camara.getFocalLength() / (1 + b.push * b.aplicadoFocal), FOCAL_MIN),
+    );
+    b.aplicadoFocal = 0;
+  }
+  if (b.fase !== 'quieto') {
+    b.fase = 'quieto';
+    b.env = 0;
+  }
+  const a = st.anticipo;
+  if (a.aplicado !== 0) {
+    camara.setFocalLength(Math.max(camara.getFocalLength() / (1 - ANTICIPO.abre * a.aplicado), FOCAL_MIN));
+    a.env = 0;
+    a.meta = 0;
+    a.aplicado = 0;
+  }
+}

--- a/src/visual/mundo3d/escenas/EscenaValle.jsx
+++ b/src/visual/mundo3d/escenas/EscenaValle.jsx
@@ -94,8 +94,17 @@ const CSS_CIELO = `
 export default function EscenaValle({
   params, entrada, reducedMotion = false, onHotspot, animo = 'sereno', energia = 1, tier = 'alto',
   estadoFinca = undefined, hayAlerta = false, // §5b: Angelita refleja el estado real también en el mapa
+  /* FASE 4 — cámara de director (establishing + follow + beats). ON por defecto
+     en la escena del framework (el "wow" de bienvenida); tier/reduced-motion la
+     gatean adentro (tier bajo o calma = cámara fija). Un solo prop la apaga. */
+  camaraDirector = true,
 }) {
   const climaReal = params?.clima || entrada?.clima || 'soleado';
+  /* Buzón de beats para el director: el coro ambiental (FaunaAmbiental) marca
+     sus slots con `data-fase='gesto'` al hacer su giño; un MutationObserver
+     (abajo) traduce ESO en un beat de cámara — sin tocar el arte ni la capa. */
+  const beatsRef = useRef(null);
+  const raizRef = useRef(null);
   /* El avatar elegido por la persona: se reserva para el protagonismo (el
      coro ambiental lo excluye — el central manda, nadie lo duplica de extra). */
   const avatar = useAvatarCreature();
@@ -117,6 +126,42 @@ export default function EscenaValle({
     if (timerRef.current) clearTimeout(timerRef.current);
   }, []);
 
+  /* Beats de cámara desde el coro ambiental: cuando un slot de FaunaAmbiental
+     entra en su gesto (`data-fase='gesto'`), lo traducimos a un beat para el
+     director — lado por dónde asomó (`data-entrada`), quién (`data-slug`: el
+     Ent 'ent-frailejon' pide su plano largo) y si fue mágico (`data-magico`).
+     Cero acoplamiento al arte: solo se LEEN atributos que la capa ya publica.
+     Solo en tier alto y con movimiento (el director solo hace beats en 'cine';
+     en calma la fauna ni se monta). */
+  useEffect(() => {
+    if (!camaraDirector || reducedMotion || tier !== 'alto') return undefined;
+    const raiz = raizRef.current;
+    if (!raiz || typeof MutationObserver === 'undefined') return undefined;
+    const obs = new MutationObserver((mutaciones) => {
+      for (const m of mutaciones) {
+        const el = /** @type {HTMLElement} */ (m.target);
+        if (
+          el.nodeType === 1 &&
+          el.classList &&
+          el.classList.contains('fauna-amb__slot') &&
+          el.getAttribute('data-fase') === 'gesto'
+        ) {
+          // `n` incremental: el director lo drena por contador (lee, no escribe
+          // este ref — así no se muta un prop-ref del lado del director).
+          beatsRef.current = {
+            n: (beatsRef.current?.n ?? 0) + 1,
+            tipo: 'fauna',
+            lado: el.getAttribute('data-entrada') || undefined,
+            slug: el.getAttribute('data-slug') || undefined,
+            magico: el.getAttribute('data-magico') === '1',
+          };
+        }
+      }
+    });
+    obs.observe(raiz, { attributes: true, attributeFilter: ['data-fase'], subtree: true });
+    return () => obs.disconnect();
+  }, [camaraDirector, reducedMotion, tier]);
+
   /* Gotas deterministas: posición/tempo por hash de índice, presupuesto por tier. */
   const gotas = useMemo(() => {
     const n = GOTAS_POR_TIER[tier] ?? GOTAS_POR_TIER.alto;
@@ -133,6 +178,7 @@ export default function EscenaValle({
 
   return (
     <div
+      ref={raizRef}
       className={`cielotoque${toque ? ` cielotoque--${toque}` : ''}${reducedMotion ? ' cielotoque--rm' : ''}`}
       data-clima-real={climaReal}
     >
@@ -146,6 +192,8 @@ export default function EscenaValle({
         hayAlerta={hayAlerta}
         tier={tier}
         reducedMotion={reducedMotion}
+        camaraDirector={camaraDirector}
+        beatsRef={beatsRef}
         onEntrar={(id) => onHotspot?.('mundo', { mundoId: id })}
         onAlerta={() => onHotspot?.(entrada?.alertaView || 'hoy_finca')}
       />


### PR DESCRIPTION
## Cámara de director del valle 3D (FASE 4)

El acabado cinematográfico del mapa del valle: una cámara que se siente **dirigida** (indie premium), no estática. Detrás del flag `camaraDirector` (ON por defecto en la escena del framework `EscenaValle`, OFF en el mockup crudo), y **tier-safe**.

### Los tres gestos
1. **Establishing shot** al entrar: un barrido cinematográfico lento (alto sobre el páramo → planeo por la quebrada → frente de los mundos) que **asienta** con resorte sub-amortiguado (overshoot mínimo) en la pose jugable de siempre — aterrizaje EXACTO, cero regresión de encuadre. Una vez por sesión (volver de un mundo no lo repite). El primer toque del usuario lo acelera; nunca teletransporta.
2. **Follow suave** del avatar central (Angelita): la cámara se **inclina** hacia donde vuela con `damp3` de `maath/easing` + **lead** de anticipación por su velocidad, acotado (es un lean, no una persecución). Al entrar a un mundo se suelta (manda el foco).
3. **Beats coreografiados**: micro reencuadres breves con easing —
   - **fauna ambiental** hace su giño lejano → push-in por **lente** (no dolly, para no pelear con OrbitControls) + lean hacia el lado por donde asomó;
   - **el Ent** (`ent-frailejon`) → su plano más quieto y largo;
   - **entrada a un mundo** (túnel Odyssey) → anticipación focal (el lente se abre un instante y suelta).
   Con cooldown entre beats (chispa, no circo).

### Gating por tier (regla dura)
`modoDirector`: tier **alto = 'cine'** (todo), **medio = 'sobrio'** (establishing corto sin rebote + follow, sin beats), y **bajo / `prefers-reduced-motion` / flag off = 'fijo'** (INERTE TOTAL: no toca la cámara — el encuadre digno fijo). El `usePerformanceMonitor`/perf-tiers ya en dev se **reusa** (el tier llega por prop; no se toca el monitor).

### Integración limpia
- `DirectorValle` se monta **después** de `CamaraViajera` y gana por **orden de frame** durante el barrido (escribe pose absoluta) — sin banderas de cesión ni mutar prop-refs. En gameplay solo suma offsets aditivos (follow + beat lean) que la viajera respeta. El aplane New Donk del túnel conserva la última palabra.
- Movimiento: `maath/easing` `damp3`/`damp` para el damping continuo; resorte hand-rolled solo para el settle-con-overshoot del establishing (maath es exponencial puro, sin rebote), igual que las otras cámaras de `mundo3d`.
- Beats sin tocar el arte: `EscenaValle` observa los `data-fase='gesto'`/`data-slug`/`data-entrada` que `FaunaAmbiental` ya publica (MutationObserver) y empuja un buzón con `n` incremental; el director lo **lee** por contador (nunca escribe el prop-ref).

### Archivos
- `src/mockups/valle/directorValle.js` (nuevo) — lógica pura testeable (cero React/Canvas).
- `src/mockups/valle/DirectorValle.jsx` (nuevo) — componente r3f que la cablea.
- `src/mockups/valle/__tests__/directorValle.test.js` (nuevo) — 21 pruebas.
- `src/mockups/valle/Valle3D.jsx` — flag `camaraDirector` + `beatsRef`; `CompaneroAbeja` comparte su posición viva; monta el director.
- `src/visual/mundo3d/escenas/EscenaValle.jsx` — enciende el flag + puente de beats de la fauna.

### Verificación
- `npm run build` verde.
- `npm run tsc:check` sin errores nuevos (los 4 restantes en `Valle3D`/`EscenaValle` son pre-existentes idénticos a `origin/dev`: props `tier`/`area`/`camera` que no se tocaron).
- `npx vitest run` del director **21/21** + smokes del valle **67/67** verdes. (Dos fallos ajenos preexistentes en `useAudioMundo`/`hiloVidaVista` no importan este código; byte-idénticos a `origin/dev`.)
- `eslint --max-warnings=0` limpio en los 5 archivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
