### PR TITLE
fix(pwa): precache de chunks lazy para offline-first — AgentOfflineGuard static

### DIFF
--- a/public/chagra-stats.json
+++ b/public/chagra-stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-13T18:19:10.372Z",
+  "generated_at": "2026-07-13T19:57:42.934Z",
   "schema_version": "1.1.0",
   "catalogo": {
     "especies": 581,

--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-13T18:19:10.136Z",
+  "generated_at": "2026-07-13T19:57:42.108Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,7 +47,10 @@ const AgentFab = lazy(() => import('./components/AgentFab'));
 // tap, descomentar el import y el render de <EscuchaFab /> más abajo.
 // import EscuchaFab from './components/escucha/EscuchaFab';
 const EscuchaOverlay = lazy(() => import('./components/escucha/EscuchaOverlay'));
-const AgentOfflineGuard = lazy(() => import('./components/AgentScreen/AgentOfflineGuard'));
+// AgentOfflineGuard DEBE ser eager (static import): es la pantalla que se
+// muestra justamente CUANDO no hay red. Si fuera lazy, el import() fallaría
+// offline sin cache → el usuario nunca vería la pantalla de offline.
+import AgentOfflineGuard from './components/AgentScreen/AgentOfflineGuard';
 // Transición home→conversación: el colibrí en video (~2s). Eager (debe
 // aparecer al instante al enviar desde el hero).
 import ColibriTransition from './components/agent/ColibriTransition';


### PR DESCRIPTION
## Resumen

Verificacion y arreglo del offline-first tras los cambios de bundle-slim (#2443 y #2448) que introdujeron ~175 chunks lazy con React.lazy.

### Hallazgo y fix

**Regresion:** AgentOfflineGuard fue convertido a React.lazy en #2443. Este componente es la pantalla de 'estas offline' — se renderiza justamente CUANDO no hay red. Si su chunk lazy no esta cacheado, el import() falla offline y el usuario ve un ErrorBoundary generico en vez de la pantalla de offline dedicada.

**Fix:** Revertir AgentOfflineGuard a static import. Solo suma ~2KB al main bundle (230.7 KB, dentro del budget de 340 KB).

### Analisis del SW precache

El SW (public/sw.js) usa dos niveles de precache:

1. **Install: entry chunks via index.html parseo** (lineas 124-134)
   - Parsea index.html con regex 
   - **31 chunks precacheados** en CACHE_NAME durante install
   - Incluye: index.js, vendor-react, syncManager, dbCore, useAssetStore, agentService, ragRetriever, etc.

2. **Fetch: cache-on-use para TODOS los /assets/\*** (lineas 229-248)
   - Cache-first con relleno en background
   - Cache hit → servir del cache (offline funciona)
   - Cache miss → fetch de red → cachear → servir
   - Sin red + sin cache → 504 (esperado: chunk nunca cargado online)

Las rutas lazy funcionan offline DESPUES de la primera visita online. Sin cambios en el comportamiento.

### Verificacion

| Check | Resultado |
|---|---|
| Build | OK (2m 9s) |
| Presupuesto | 24.0 MB / 27.5 MB OK |
| Entry chunks precacheados | 31 chunks en index.html |
| Main bundle | 230.7 KB (< 340 KB) |
| tsc:check | 0 errores nuevos (solo pre-existentes en dev) |
| AgentOfflineGuard | Static import — siempre disponible