### PR TITLE
feat(bosque): Ent del páramo en 3D (queñua) — mundo Bosque Vivo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -144,6 +144,10 @@ const EvidenciaIlustrada = lazy(() => import('./mockups/EvidenciaIlustrada'));
 const MockupGuardianesNarrativos = lazy(() => import('./mockups/MockupGuardianesNarrativos'));
 const HojaVidaMataMockup = lazy(() => import('./components/mockups/HojaVidaMataMockup'));
 const VitrinaCriaturasMockup = lazy(() => import('./mockups/vitrina3d/VitrinaCriaturas'));
+// 3D: el MUNDO BOSQUE VIVO y su guardián, el Ent de la queñua (colorado,
+// Polylepis) — mallas three reales (tronco retorcido con rostro tallado, copa
+// instanciada), device-tiering real. Ruta #/mockups/bosque-vivo-3d, sin auth.
+const BosqueVivo3DMockup = lazy(() => import('./mockups/BosqueVivo3D'));
 // 3D: vitrina JUGABLE de las piezas de construcción (invernaderos, galpón,
 // establo, bodega, tanque, secadero…) con control de tamaño por pieza y el
 // mini demo del modo colocar (snapping sobre la ladera).
@@ -554,6 +558,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo3d-animales': 'mockup_mundo3d_animales',
   'mockups/mundo3d-milpa': 'mockup_mundo3d_milpa',
   'mockups/mundo3d-bosque': 'mockup_mundo3d_bosque',
+  'mockups/bosque-vivo-3d': 'mockup_bosque_vivo_3d',
   'mockups/mundo3d-clima': 'mockup_mundo3d_clima',
   'mockups/voz-con-forma': 'mockup_voz_con_forma',
   'mockups/conversacion-voz': 'mockup_conversacion_voz',
@@ -1518,6 +1523,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="La ladera y sus pisos">
               <Mundo3DBosqueMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_bosque_vivo_3d':
+        // Vitrina pública del MUNDO BOSQUE VIVO: el Ent de la queñua (colorado,
+        // Polylepis) en 3D REAL — tronco retorcido con corteza rojiza y rostro
+        // tallado, copa de hojitas instanciadas, meciéndose en la niebla del
+        // páramo. Device-tiering real; en equipo humilde muestra la ficha del
+        // guardián. Ruta #/mockups/bosque-vivo-3d, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El bosque vivo">
+              <BosqueVivo3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/BosqueVivo3D.css
+++ b/src/mockups/BosqueVivo3D.css
@@ -1,0 +1,233 @@
+/*
+ * BosqueVivo3D.css — vitrina del Ent de la queñua (#/mockups/bosque-vivo-3d).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Paleta de páramo alto: gris-verde frío y niebla, con el rojizo del colorado.
+ * Solo opacity/transform se animan.
+ */
+
+.bviva {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background: linear-gradient(180deg, #cfd8d6 0%, #dce2dc 44%, #e8e6d8 100%);
+  color: #26302b;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.bviva__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.bviva__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7a4432;
+}
+.bviva__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #2a3b31;
+}
+.bviva__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 40rem;
+}
+
+.bviva__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+.bviva__lienzo {
+  position: relative;
+  height: min(66vh, 32rem);
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(122, 68, 50, 0.25);
+  box-shadow: 0 12px 30px rgba(40, 52, 44, 0.16);
+  background: radial-gradient(120% 90% at 50% 20%, #c7d1cf 0%, #aeb9b3 100%);
+}
+.bviva__lienzo canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+  touch-action: none;
+}
+.bviva-canvas {
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.bviva-canvas--lista {
+  opacity: 1;
+}
+
+.bviva__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  color: #3a4a40;
+  opacity: 0.85;
+}
+
+.bviva__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.bviva__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.bviva__toggle {
+  border: 1.5px solid #7a4432;
+  background: #fff;
+  color: #7a4432;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.bviva__toggle:hover,
+.bviva__toggle:focus-visible {
+  background: #7a4432;
+  color: #fff;
+  outline-offset: 2px;
+}
+
+/* ---- Ficha 2D (fallback digno, sin GPU) ---- */
+.bviva__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  background: radial-gradient(120% 90% at 50% 25%, #cfd7d0 0%, #9fa89f 100%);
+}
+.bviva__arbol2d {
+  position: relative;
+  width: 120px;
+  height: 170px;
+  margin-bottom: 0.4rem;
+}
+.bviva__copa {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 118px;
+  height: 100px;
+  transform: translateX(-50%);
+  border-radius: 46% 54% 60% 40% / 58% 56% 44% 42%;
+  background: radial-gradient(circle at 40% 35%, #8b9c72 0%, #5c6f47 70%, #4a5b3a 100%);
+  box-shadow: inset -8px -6px 14px rgba(0, 0, 0, 0.18);
+}
+.bviva__tronco {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 30px;
+  height: 92px;
+  transform: translateX(-50%);
+  border-radius: 40% 40% 30% 30%;
+  background: linear-gradient(90deg, #5c3226 0%, #9a5236 45%, #c4835c 60%, #6e3a2a 100%);
+}
+.bviva__cara {
+  position: absolute;
+  bottom: 34px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 6px;
+}
+.bviva__ojo {
+  width: 8px;
+  height: 10px;
+  border-radius: 50%;
+  background: #17110d;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.25), inset 1px -1px 0 rgba(240, 245, 235, 0.6);
+}
+.bviva__ficha-nombre {
+  margin: 0;
+  font-weight: 800;
+  font-size: 1rem;
+  color: #2a3b31;
+}
+.bviva__ficha-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4a5a4a;
+}
+
+/* ---- Saberes ---- */
+.bviva__saberes {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.bviva__saberes h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #2a3b31;
+}
+.bviva__saberes ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .bviva__saberes ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.bviva__saberes li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(122, 68, 50, 0.16);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.bviva__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.bviva__saberes b {
+  display: block;
+  font-size: 0.92rem;
+  color: #2a3b31;
+}
+.bviva__saberes li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.bviva__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  font-style: italic;
+  color: #3a4a3a;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bviva-canvas {
+    transition: none;
+  }
+}

--- a/src/mockups/BosqueVivo3D.jsx
+++ b/src/mockups/BosqueVivo3D.jsx
@@ -1,0 +1,148 @@
+/*
+ * BosqueVivo3D — vitrina pública del MUNDO BOSQUE VIVO y su guardián: el Ent de
+ * la queñua (colorado, *Polylepis*), el árbol más alto del páramo andino.
+ * Ruta #/mockups/bosque-vivo-3d, sin auth.
+ *
+ * La queñua es, ella misma, un Bárbol: tronco grueso retorcido, corteza rojiza
+ * que se pela en papel, copa de hojitas plateadas. Aquí la mostramos en 3D REAL
+ * (mallas three, no un dibujo plano) con un rostro sabio tallado en la madera,
+ * viva y meciéndose en la niebla del páramo. Es la guardiana del agua: donde
+ * hay queñuales, hay agua para la finca de abajo.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el diorama 3D (chunk
+ * perezoso `vendor-three`); en equipo humilde, ahorro de datos o sin-WebGL se ve
+ * la ficha del guardián, digna y sin sudar la GPU. Copy en español de Colombia,
+ * en "usted". Autocontenida: cero CDN/imágenes externas.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import './BosqueVivo3D.css';
+
+const EscenaBosqueVivo = lazy(() => import('../visual/mundo3d/bosque/EscenaBosqueVivo.jsx'));
+
+/* Lo que enseña el guardián (verificado, en "usted"). */
+const SABERES = [
+  {
+    emoji: '💧',
+    titulo: 'Guardiana del agua',
+    texto: 'Donde crece el queñual, el suelo retiene el agua de la niebla y la suelta despacio. Cuidar la queñua de arriba es cuidar el nacimiento de agua de su finca de abajo.',
+  },
+  {
+    emoji: '🌫️',
+    titulo: 'El árbol más alto del páramo',
+    texto: 'La queñua vive donde ya casi ningún árbol resiste, arriba de los 3.000 metros. Crece despacio y torcido: cada nudo es un año peleándole al frío y al viento.',
+  },
+  {
+    emoji: '📜',
+    titulo: 'Corteza de papel',
+    texto: 'Su corteza rojiza se despega en láminas finas como papel. No es que esté enferma: así se protege del frío de la noche del páramo, como muchas cobijas delgadas.',
+  },
+  {
+    emoji: '🪶',
+    titulo: 'Siémbrela, no la tumbe',
+    texto: 'Un queñual viejo tarda cien años en volver. Si tiene páramo, deje la queñua en pie y ayude a que rebrote: es la mejor obra de agua que puede hacer, y no cuesta cemento.',
+  },
+];
+
+export default function BosqueVivo3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  return (
+    <main className="bviva">
+      <header className="bviva__head">
+        <p className="bviva__kicker">El bosque vivo · vitrina</p>
+        <h1>La queñua, guardiana del páramo</h1>
+        <p className="bviva__lema">
+          El árbol más alto de la montaña, retorcido y sabio. En 3D de verdad,
+          con su rostro tallado en la madera. Mírela de cerca: gírela con el dedo.
+        </p>
+      </header>
+
+      <section className="bviva__escena" aria-label="El Ent de la queñua en 3D">
+        <div className="bviva__lienzo">
+          {mostrar3D ? (
+            <Suspense
+              fallback={
+                <div className="bviva__cargando" role="status">
+                  Levantando el queñual…
+                </div>
+              }
+            >
+              <EscenaBosqueVivo tier={tier} reducedMotion={reducedMotion} />
+            </Suspense>
+          ) : (
+            <FichaGuardian />
+          )}
+        </div>
+
+        <div className="bviva__barra">
+          <p className="bviva__tier">
+            {mostrar3D
+              ? 'Está viendo el árbol en 3D. Gírelo con el dedo o el mouse.'
+              : puede3D
+                ? 'Está viendo la ficha del guardián.'
+                : 'Su equipo ve la ficha del guardián (va parejo en cualquier teléfono).'}
+          </p>
+          {puede3D && (
+            <button
+              type="button"
+              className="bviva__toggle"
+              onClick={() => setVer2d((v) => !v)}
+            >
+              {ver2d ? 'Ver el árbol en 3D' : 'Ver la ficha'}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <section className="bviva__saberes" aria-label="Lo que enseña la queñua">
+        <h2>Lo que le enseña este árbol</h2>
+        <ol>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span className="bviva__emoji" aria-hidden="true">{s.emoji}</span>
+              <div>
+                <b>{s.titulo}</b>
+                <p>{s.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="bviva__cierre">
+          El páramo no se ara: se cuida. La queñua lleva ahí más años que
+          cualquiera de nosotros, y de ella baja el agua. Déjela crecer.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+/* La ficha del guardián: el fallback digno para equipo humilde / sin-WebGL.
+   No es un 3D degradado feo: es una tarjeta ilustrada con CSS, sin GPU. */
+function FichaGuardian() {
+  return (
+    <div className="bviva__ficha" role="img" aria-label="La queñua, guardiana del páramo">
+      <div className="bviva__arbol2d" aria-hidden="true">
+        <span className="bviva__copa" />
+        <span className="bviva__tronco" />
+        <span className="bviva__cara">
+          <span className="bviva__ojo" />
+          <span className="bviva__ojo" />
+        </span>
+      </div>
+      <p className="bviva__ficha-nombre">Queñua · colorado</p>
+      <p className="bviva__ficha-sub">Guardiana del agua del páramo</p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/__tests__/entQuenua.geom.test.js
+++ b/src/visual/mundo3d/__tests__/entQuenua.geom.test.js
@@ -1,0 +1,224 @@
+/*
+ * Pruebas de la geometría PURA del Ent de la queñua. Corren headless: three-core
+ * (curvas, TubeGeometry, Color) es matemática de buffers, sin contexto WebGL.
+ */
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import {
+  rng,
+  paramsDeTier,
+  PARAMS_TIER,
+  curvaTronco,
+  taperTronco,
+  desplazamientoCorteza,
+  colorCorteza,
+  geometriaTronco,
+  tuboOrganico,
+  specsRamas,
+  specsRaices,
+  taperLineal,
+  clustersCopa,
+  hojasDeCluster,
+  colorHoja,
+  anclaRostro,
+  factorParpadeo,
+  ALTURA_TRONCO,
+} from '../bosque/entQuenua.geom.js';
+
+describe('rng determinista', () => {
+  it('misma semilla → misma secuencia', () => {
+    const a = rng(42);
+    const b = rng(42);
+    expect(a()).toBe(b());
+    expect(a()).toBe(b());
+  });
+  it('devuelve valores en [0,1)', () => {
+    const r = rng(9);
+    for (let i = 0; i < 50; i++) {
+      const v = r();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+});
+
+describe('paramsDeTier (tier-safe)', () => {
+  it('alto tiene más hojas/segmentos que medio y bajo', () => {
+    expect(PARAMS_TIER.alto.hojas).toBeGreaterThan(PARAMS_TIER.medio.hojas);
+    expect(PARAMS_TIER.medio.hojas).toBeGreaterThan(PARAMS_TIER.bajo.hojas);
+    expect(PARAMS_TIER.alto.tubular).toBeGreaterThan(PARAMS_TIER.bajo.tubular);
+  });
+  it('solo alto usa material rico y niebla; bajo sin niebla', () => {
+    expect(PARAMS_TIER.alto.materialRico).toBe(true);
+    expect(PARAMS_TIER.medio.materialRico).toBe(false);
+    expect(PARAMS_TIER.bajo.fog).toBe(false);
+  });
+  it('tier desconocido cae a medio, nunca al más caro', () => {
+    expect(paramsDeTier('marciano')).toBe(PARAMS_TIER.medio);
+    expect(paramsDeTier('alto')).toBe(PARAMS_TIER.alto);
+  });
+});
+
+describe('curvaTronco', () => {
+  it('arranca en el pie y sube hasta la altura del tronco', () => {
+    const c = curvaTronco(7);
+    const base = c.getPointAt(0);
+    const punta = c.getPointAt(1);
+    expect(base.length()).toBeLessThan(0.05);
+    expect(punta.y).toBeGreaterThan(ALTURA_TRONCO - 0.6);
+  });
+  it('es sinuosa: se desvía del eje vertical en el medio', () => {
+    const c = curvaTronco(7);
+    const medio = c.getPointAt(0.5);
+    expect(Math.hypot(medio.x, medio.z)).toBeGreaterThan(0.05);
+  });
+});
+
+describe('taperTronco', () => {
+  it('la base es mucho más gruesa que la punta', () => {
+    expect(taperTronco(0)).toBeGreaterThan(taperTronco(1) * 3);
+  });
+  it('siempre positivo a lo largo del tronco', () => {
+    for (let t = 0; t <= 1.0001; t += 0.05) {
+      expect(taperTronco(t)).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('desplazamientoCorteza', () => {
+  it('acotado y varía con el ángulo (surcos)', () => {
+    let min = Infinity;
+    let max = -Infinity;
+    for (let a = 0; a < Math.PI * 2; a += 0.3) {
+      const d = desplazamientoCorteza(0.2, a);
+      expect(Math.abs(d)).toBeLessThan(0.6);
+      min = Math.min(min, d);
+      max = Math.max(max, d);
+    }
+    expect(max - min).toBeGreaterThan(0.05); // hay relieve, no es un cilindro liso
+  });
+});
+
+describe('colorCorteza', () => {
+  it('la grieta es más oscura que la cresta pelada', () => {
+    const grieta = colorCorteza(-0.15, 0.6);
+    const cresta = colorCorteza(0.15, 0.6);
+    const lum = (c) => c.r + c.g + c.b;
+    expect(lum(cresta)).toBeGreaterThan(lum(grieta));
+  });
+  it('devuelve una THREE.Color válida', () => {
+    const c = colorCorteza(0, 0.3);
+    expect(c).toBeInstanceOf(THREE.Color);
+    expect(c.r).toBeGreaterThanOrEqual(0);
+    expect(c.r).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('geometriaTronco / tuboOrganico', () => {
+  it('malla con posición y color, conteo de vértices esperado', () => {
+    const P = { tubular: 40, radial: 8 };
+    const geo = geometriaTronco(P, 7);
+    expect(geo.attributes.position).toBeTruthy();
+    expect(geo.attributes.color).toBeTruthy();
+    const esperado = (P.tubular + 1) * (P.radial + 1);
+    expect(geo.attributes.position.count).toBe(esperado);
+    expect(geo.attributes.color.count).toBe(esperado);
+  });
+  it('respeta el taper: la base es más ancha que la punta', () => {
+    const curve = curvaTronco(7);
+    const geo = tuboOrganico(curve, {
+      tubular: 60, radial: 10, taperFn: taperTronco, dispAmp: 1, seedAng: 0,
+    });
+    const pos = geo.attributes.position;
+    const nAnillo = 11;
+    const radioAnillo = (anillo, centro) => {
+      let max = 0;
+      for (let j = 0; j <= 10; j++) {
+        const k = anillo * nAnillo + j;
+        const dx = pos.getX(k) - centro.x;
+        const dy = pos.getY(k) - centro.y;
+        const dz = pos.getZ(k) - centro.z;
+        max = Math.max(max, Math.hypot(dx, dy, dz));
+      }
+      return max;
+    };
+    const rBase = radioAnillo(0, curve.getPointAt(0));
+    const rPunta = radioAnillo(60, curve.getPointAt(1));
+    expect(rBase).toBeGreaterThan(rPunta * 2);
+  });
+});
+
+describe('ramas y raíces', () => {
+  it('specsRamas devuelve n ramas con curva, radio base y punta', () => {
+    const specs = specsRamas(5, 21);
+    expect(specs).toHaveLength(5);
+    for (const s of specs) {
+      expect(s.curve).toBeInstanceOf(THREE.CatmullRomCurve3);
+      expect(s.r0).toBeGreaterThan(0);
+      expect(s.punta).toBeInstanceOf(THREE.Vector3);
+    }
+  });
+  it('specsRaices devuelve n raíces que bajan bajo tierra', () => {
+    const specs = specsRaices(6, 33);
+    expect(specs).toHaveLength(6);
+    for (const s of specs) {
+      const fin = s.curve.getPointAt(1);
+      expect(fin.y).toBeLessThan(0); // se hunden en la tierra
+    }
+  });
+  it('taperLineal decrece de r0 a la punta', () => {
+    const f = taperLineal(0.2, 0.03);
+    expect(f(0)).toBeGreaterThan(f(1));
+    expect(f(1)).toBeGreaterThan(0);
+  });
+});
+
+describe('copa instanciada', () => {
+  it('clustersCopa reparte el presupuesto de hojas', () => {
+    const puntas = specsRamas(5, 21).map((r) => r.punta);
+    const clusters = clustersCopa(puntas, { clusters: 6, hojas: 300 }, 51);
+    expect(clusters).toHaveLength(6);
+    const total = clusters.reduce((a, c) => a + c.count, 0);
+    expect(total).toBeGreaterThan(200);
+    for (const c of clusters) {
+      expect(c.count).toBeGreaterThan(0);
+      expect(c.center).toBeInstanceOf(THREE.Vector3);
+    }
+  });
+  it('hojasDeCluster genera hojas dentro del radio con tono válido', () => {
+    const hojas = hojasDeCluster({ radio: 0.8, count: 40, seed: 51 });
+    expect(hojas).toHaveLength(40);
+    for (const h of hojas) {
+      expect(h.pos).toHaveLength(3);
+      expect(Math.hypot(...h.pos)).toBeLessThanOrEqual(0.8 + 0.001);
+      expect(h.tono).toBeGreaterThanOrEqual(0);
+      expect(h.tono).toBeLessThanOrEqual(1);
+      expect(h.escala).toBeGreaterThan(0);
+    }
+  });
+  it('colorHoja va de verde a verde-plateado', () => {
+    const verde = colorHoja(0);
+    const plata = colorHoja(1);
+    expect(plata.r + plata.g + plata.b).toBeGreaterThan(verde.r + verde.g + verde.b);
+  });
+});
+
+describe('rostro y parpadeo', () => {
+  it('anclaRostro se apoya en el tronco a la altura de la mirada', () => {
+    const { centro, radio, t } = anclaRostro(7);
+    expect(centro).toBeInstanceOf(THREE.Vector3);
+    expect(radio).toBeGreaterThan(0);
+    expect(t).toBeGreaterThan(0);
+    expect(t).toBeLessThan(1);
+  });
+  it('factorParpadeo: casi siempre abierto (1) y se cierra en el pestañeo', () => {
+    expect(factorParpadeo(0)).toBeCloseTo(1, 5);
+    // el pestañeo ocurre al final del ciclo (~6.2s de periodo por defecto)
+    let minimo = 1;
+    for (let t = 0; t < 6.2; t += 0.02) {
+      minimo = Math.min(minimo, factorParpadeo(t));
+    }
+    expect(minimo).toBeLessThan(0.3); // sí cierra el ojo
+    expect(minimo).toBeGreaterThanOrEqual(0); // pero nunca negativo
+  });
+});

--- a/src/visual/mundo3d/bosque/EntQuenua.jsx
+++ b/src/visual/mundo3d/bosque/EntQuenua.jsx
@@ -1,0 +1,291 @@
+/*
+ * EntQuenua — el ENT del páramo en 3D real (queñua / colorado, *Polylepis*).
+ *
+ * NO es un billboard ni un SVG plano: son MALLAS three de verdad. Tronco
+ * retorcido y nudoso (TubeGeometry sobre una curva sinuosa, con taper de raigón
+ * y desplazamiento de corteza), ramas torcidas, raíces que agarran la tierra,
+ * copa de cientos de hojitas verde-plateadas (InstancedMesh, barato) y —el alma—
+ * un ROSTRO tallado en la madera: ojos hundidos con brillo, cejas de corteza y
+ * una boca-grieta sabia. La corteza rojiza que se pela va en vertexColors
+ * (procedural, cero texturas externas).
+ *
+ * Vida: el árbol se mece lento y con peso desde la raíz, la copa se mece con
+ * desfase (viento del páramo) y los ojos parpadean despacio. Ancestral, no
+ * rígido. Tier-safe: 'alto' pleno (PBR, facetado, más hojas), 'medio'/'bajo'
+ * frugales (Lambert, menos hojas); `reducedMotion` lo deja QUIETO.
+ *
+ * Componente r3f: montar SOLO dentro de un <Canvas> (importa three).
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import {
+  paramsDeTier,
+  geometriaTronco,
+  tuboOrganico,
+  specsRamas,
+  specsRaices,
+  taperLineal,
+  clustersCopa,
+  hojasDeCluster,
+  colorHoja,
+  anclaRostro,
+  factorParpadeo,
+  CORTEZA,
+} from './entQuenua.geom.js';
+
+/* Una nube de hojitas instanciada, mecida como grupo (viento en la copa). */
+function ClusterHojas({ cluster, geo, mat, reducedMotion, fase }) {
+  const grupoRef = useRef(null);
+  const meshRef = useRef(null);
+  const hojas = useMemo(() => hojasDeCluster(cluster), [cluster]);
+
+  useLayoutEffect(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    for (let i = 0; i < hojas.length; i++) {
+      const h = hojas[i];
+      p.set(h.pos[0], h.pos[1], h.pos[2]);
+      e.set(h.rot[0], h.rot[1], h.rot[2]);
+      q.setFromEuler(e);
+      s.setScalar(h.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      mesh.setColorAt(i, colorHoja(h.tono));
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [hojas]);
+
+  useFrame((state) => {
+    const g = grupoRef.current;
+    if (!g || reducedMotion) return;
+    const t = state.clock.elapsedTime;
+    g.rotation.z = Math.sin(t * 0.7 + fase) * 0.06;
+    g.rotation.x = Math.sin(t * 0.55 + fase * 1.3) * 0.045;
+    g.position.y = cluster.center.y + Math.sin(t * 0.6 + fase) * 0.04;
+  });
+
+  return (
+    <group ref={grupoRef} position={cluster.center}>
+      <instancedMesh ref={meshRef} args={[geo, mat, hojas.length]} frustumCulled={false} castShadow />
+    </group>
+  );
+}
+
+/* El rostro tallado: ojos hundidos + brillo, cejas de corteza, boca-grieta. */
+function Rostro({ matOjo, matBrillo, matCorteza, matGrieta, reducedMotion, blinkRefs }) {
+  const { centro, radio } = useMemo(() => anclaRostro(7), []);
+  // Superficie frontal del tronco a la altura de la mirada (mira al +Z).
+  const frente = radio * 0.9;
+
+  const bocaGeo = useMemo(() => {
+    // Boca larga y grave, con una comisura que baja apenas (gesto ancestral).
+    const curve = new THREE.CatmullRomCurve3([
+      new THREE.Vector3(-0.26, -0.30, 0.0),
+      new THREE.Vector3(-0.09, -0.37, 0.03),
+      new THREE.Vector3(0.09, -0.375, 0.03),
+      new THREE.Vector3(0.26, -0.29, 0.0),
+    ], false, 'catmullrom', 0.5);
+    return new THREE.TubeGeometry(curve, 24, 0.03, 7, false);
+  }, []);
+
+  const Ojo = ({ x, refKey }) => (
+    <group position={[x, 0.06, frente - 0.05]} ref={blinkRefs[refKey]}>
+      {/* cuenca hundida: gran cavidad oscura empotrada en la corteza */}
+      <mesh position={[0, 0, -0.03]} scale={[1.3, 1.5, 0.55]}>
+        <sphereGeometry args={[0.15, 16, 14]} />
+        <primitive object={matGrieta} attach="material" />
+      </mesh>
+      {/* globo del ojo: oscuro, con brillo húmedo */}
+      <mesh position={[0, 0, 0.05]}>
+        <sphereGeometry args={[0.115, 18, 16]} />
+        <primitive object={matOjo} attach="material" />
+      </mesh>
+      {/* la chispa de vida (grande y clara) */}
+      <mesh position={[x > 0 ? 0.038 : 0.03, 0.045, 0.15]}>
+        <sphereGeometry args={[0.026, 10, 10]} />
+        <primitive object={matBrillo} attach="material" />
+      </mesh>
+    </group>
+  );
+
+  return (
+    <group position={[centro.x, centro.y, centro.z]} scale={[1.5, 1.55, 1.15]}>
+      <Ojo x={-0.24} refKey="izq" />
+      <Ojo x={0.24} refKey="der" />
+
+      {/* cejas de corteza: crestas gruesas e inclinadas, ceño sabio/severo */}
+      <mesh position={[-0.24, 0.24, frente + 0.01]} rotation={[0, 0, -0.34]}>
+        <boxGeometry args={[0.34, 0.085, 0.13]} />
+        <primitive object={matCorteza} attach="material" />
+      </mesh>
+      <mesh position={[0.24, 0.24, frente + 0.01]} rotation={[0, 0, 0.34]}>
+        <boxGeometry args={[0.34, 0.085, 0.13]} />
+        <primitive object={matCorteza} attach="material" />
+      </mesh>
+
+      {/* caballete de la nariz: nudo vertical entre los ojos */}
+      <mesh position={[0, -0.09, frente + 0.04]} rotation={[0.18, 0, 0]}>
+        <boxGeometry args={[0.1, 0.4, 0.12]} />
+        <primitive object={matCorteza} attach="material" />
+      </mesh>
+      {/* pómulos/bolsas bajo los ojos: dan edad y peso al rostro */}
+      <mesh position={[-0.24, -0.12, frente]} rotation={[0, 0, 0.2]}>
+        <boxGeometry args={[0.26, 0.07, 0.1]} />
+        <primitive object={matCorteza} attach="material" />
+      </mesh>
+      <mesh position={[0.24, -0.12, frente]} rotation={[0, 0, -0.2]}>
+        <boxGeometry args={[0.26, 0.07, 0.1]} />
+        <primitive object={matCorteza} attach="material" />
+      </mesh>
+
+      {/* la boca-grieta */}
+      <mesh position={[0, 0, frente]} geometry={bocaGeo}>
+        <primitive object={matGrieta} attach="material" />
+      </mesh>
+    </group>
+  );
+}
+
+/**
+ * El Ent de la queñua. Montar dentro de un <Canvas>.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function EntQuenua({ tier = 'alto', reducedMotion = false }) {
+  const P = paramsDeTier(tier);
+  const swayRef = useRef(null);
+  const ojoIzq = useRef(null);
+  const ojoDer = useRef(null);
+
+  // --- Geometrías (una vez) ---
+  const troncoGeo = useMemo(() => geometriaTronco(P, 7), [P]);
+  const ramas = useMemo(() => specsRamas(P.ramas, 21), [P.ramas]);
+  const ramasGeo = useMemo(
+    () => ramas.map((r) => tuboOrganico(r.curve, {
+      tubular: Math.max(18, Math.round(P.tubular * 0.4)),
+      radial: Math.max(6, P.radial - 4),
+      taperFn: taperLineal(r.r0, 0.04),
+      dispAmp: 0.8,
+      seedAng: r.tBase * 10,
+    })),
+    [ramas, P.tubular, P.radial],
+  );
+  const raices = useMemo(() => specsRaices(P.raices, 33), [P.raices]);
+  const raicesGeo = useMemo(
+    () => raices.map((r, i) => tuboOrganico(r.curve, {
+      tubular: 18,
+      radial: Math.max(6, P.radial - 5),
+      taperFn: taperLineal(r.r0, 0.05),
+      dispAmp: 0.7,
+      seedAng: i,
+    })),
+    [raices, P.radial],
+  );
+  const clusters = useMemo(
+    () => clustersCopa(ramas.map((r) => r.punta), P, 51),
+    [ramas, P],
+  );
+
+  // --- Materiales (una vez) ---
+  // Corteza SUAVE (flatShading off): el relieve de surcos/nudos es geometría
+  // real; el sombreado liso evita el "acordeón" de anillos del tubo y deja una
+  // corteza orgánica. El facetado se reserva para las hojitas (matHoja).
+  const matCorteza = useMemo(() => {
+    const base = { vertexColors: true, flatShading: false };
+    return P.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.94, metalness: 0.0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [P.materialRico]);
+
+  const matCortezaLisa = useMemo(
+    () => (P.materialRico
+      ? new THREE.MeshStandardMaterial({ color: CORTEZA.cuerpo, roughness: 0.9 })
+      : new THREE.MeshLambertMaterial({ color: CORTEZA.cuerpo })),
+    [P.materialRico],
+  );
+  const matGrieta = useMemo(
+    () => (P.materialRico
+      ? new THREE.MeshStandardMaterial({ color: '#20130d', roughness: 0.8 })
+      : new THREE.MeshLambertMaterial({ color: '#20130d' })),
+    [P.materialRico],
+  );
+  const matOjo = useMemo(
+    () => (P.materialRico
+      ? new THREE.MeshStandardMaterial({ color: '#120d0a', roughness: 0.18, metalness: 0.1 })
+      : new THREE.MeshLambertMaterial({ color: '#161010' })),
+    [P.materialRico],
+  );
+  const matBrillo = useMemo(() => new THREE.MeshBasicMaterial({ color: '#eef4e8' }), []);
+  const matHoja = useMemo(
+    () => (P.materialRico
+      ? new THREE.MeshStandardMaterial({ roughness: 0.7, metalness: 0.0, flatShading: true })
+      : new THREE.MeshLambertMaterial({})),
+    [P.materialRico],
+  );
+  const hojaGeo = useMemo(() => new THREE.IcosahedronGeometry(1, 0), []);
+
+  // Liberar GPU al desmontar (geometrías y materiales procedurales).
+  useLayoutEffect(() => () => {
+    troncoGeo.dispose();
+    ramasGeo.forEach((g) => g.dispose());
+    raicesGeo.forEach((g) => g.dispose());
+    hojaGeo.dispose();
+    [matCorteza, matCortezaLisa, matGrieta, matOjo, matBrillo, matHoja].forEach((m) => m.dispose());
+  }, [troncoGeo, ramasGeo, raicesGeo, hojaGeo, matCorteza, matCortezaLisa, matGrieta, matOjo, matBrillo, matHoja]);
+
+  // --- Vida: balanceo pesado + parpadeo lento ---
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const t = state.clock.elapsedTime;
+    if (swayRef.current) {
+      swayRef.current.rotation.z = Math.sin(t * 0.45) * 0.018;
+      swayRef.current.rotation.x = Math.sin(t * 0.37 + 1.1) * 0.012;
+    }
+    const b = factorParpadeo(t);
+    if (ojoIzq.current) ojoIzq.current.scale.y = b;
+    if (ojoDer.current) ojoDer.current.scale.y = b;
+  });
+
+  return (
+    <group>
+      {/* raíces plantadas (fuera del balanceo: agarran la tierra) */}
+      {raicesGeo.map((g, i) => (
+        <mesh key={`raiz-${i}`} geometry={g} material={matCorteza} castShadow receiveShadow />
+      ))}
+
+      {/* tronco + ramas + rostro + copa: se mecen desde la base */}
+      <group ref={swayRef}>
+        <mesh geometry={troncoGeo} material={matCorteza} castShadow receiveShadow />
+        {ramasGeo.map((g, i) => (
+          <mesh key={`rama-${i}`} geometry={g} material={matCorteza} castShadow receiveShadow />
+        ))}
+
+        <Rostro
+          matOjo={matOjo}
+          matBrillo={matBrillo}
+          matCorteza={matCortezaLisa}
+          matGrieta={matGrieta}
+          reducedMotion={reducedMotion}
+          blinkRefs={{ izq: ojoIzq, der: ojoDer }}
+        />
+
+        {clusters.map((c, i) => (
+          <ClusterHojas
+            key={`copa-${i}`}
+            cluster={c}
+            geo={hojaGeo}
+            mat={matHoja}
+            reducedMotion={reducedMotion}
+            fase={i * 1.7}
+          />
+        ))}
+      </group>
+    </group>
+  );
+}

--- a/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
+++ b/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
@@ -1,0 +1,194 @@
+/*
+ * EscenaBosqueVivo — el MUNDO donde vive el Ent de la queñua.
+ *
+ * Un claro del páramo alto: luz fría y difusa, niebla que come el fondo, suelo
+ * de musgo y frailejones lejanos que sitúan el ecosistema (contexto, NO el
+ * personaje: el guardián es la queñua). La cámara mira al árbol un poco DESDE
+ * ABAJO para que se lea imponente. Se puede girar con el dedo.
+ *
+ * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`/`paramsDeTier`:
+ * 'alto' con sombras + niebla + facetado; 'medio' frugal; 'bajo' mínimo. Con
+ * `reducedMotion` el mundo monta QUIETO (frameloop a demanda).
+ *
+ * Importa three/@react-three → montar SOLO perezosa (lazy) desde el host.
+ */
+import { useMemo, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { perfilDeTier } from '../deviceTier.js';
+import { paramsDeTier } from './entQuenua.geom.js';
+import EntQuenua from './EntQuenua.jsx';
+
+/* Cielo del páramo: gris-azul frío, alto y húmedo. */
+const PARAMO = { fondo: '#c3cfce', niebla: '#c9d3d1', suelo: '#4b5340', musgo: '#5c6844' };
+
+function rng(seed) {
+  let s = (seed >>> 0) || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+/* Un frailejón lejano (Espeletia): tronco peludo pálido + roseta plateada. Es
+   PAISAJE de páramo, no el guardián — por eso va simple y al fondo. */
+function Frailejon({ pos, alto = 1.1 }) {
+  return (
+    <group position={pos}>
+      <mesh position={[0, alto * 0.5, 0]}>
+        <cylinderGeometry args={[0.11, 0.16, alto, 7]} />
+        <meshLambertMaterial color="#8f8b6f" />
+      </mesh>
+      <mesh position={[0, alto, 0]}>
+        <sphereGeometry args={[0.34, 8, 6]} />
+        <meshLambertMaterial color="#9db183" />
+      </mesh>
+      <mesh position={[0, alto + 0.12, 0]}>
+        <coneGeometry args={[0.3, 0.4, 8]} />
+        <meshLambertMaterial color="#aebd97" />
+      </mesh>
+    </group>
+  );
+}
+
+/* Mata de paja del páramo: unos conos finos dorado-verdosos. */
+function Paja({ pos }) {
+  return (
+    <group position={pos}>
+      {[0, 1, 2, 3].map((i) => (
+        <mesh key={i} position={[(i - 1.5) * 0.05, 0.2, 0]} rotation={[0, 0, (i - 1.5) * 0.12]}>
+          <coneGeometry args={[0.03, 0.42, 4]} />
+          <meshLambertMaterial color={i % 2 ? '#8a7d47' : '#6f7c48'} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function Diorama({ tier, reducedMotion }) {
+  const perfil = perfilDeTier(tier);
+  const P = paramsDeTier(tier);
+
+  const frailejones = useMemo(() => {
+    const r = rng(101);
+    return Array.from({ length: P.frailejones }, (_, i) => {
+      const a = (i / Math.max(1, P.frailejones)) * Math.PI * 2 + r() * 0.6;
+      const rad = 5.5 + r() * 3;
+      return { key: `fr-${i}`, pos: [Math.cos(a) * rad, 0, Math.sin(a) * rad - 1], alto: 0.8 + r() * 0.8 };
+    });
+  }, [P.frailejones]);
+
+  const pajas = useMemo(() => {
+    if (tier === 'bajo') return [];
+    const r = rng(202);
+    const n = tier === 'alto' ? 26 : 14;
+    return Array.from({ length: n }, (_, i) => {
+      const a = r() * Math.PI * 2;
+      const rad = 1.6 + r() * 4;
+      return { key: `pj-${i}`, pos: [Math.cos(a) * rad, 0, Math.sin(a) * rad] };
+    });
+  }, [tier]);
+
+  return (
+    <>
+      <color attach="background" args={[PARAMO.fondo]} />
+      {perfil.fog && <fog attach="fog" args={[PARAMO.niebla, 9, 34]} />}
+
+      {/* luz de páramo: cielo frío, sol tenue y velado */}
+      <hemisphereLight intensity={0.95} color="#d7e2e4" groundColor="#3a3a2c" />
+      <ambientLight intensity={0.35} color="#cdd7da" />
+      <directionalLight
+        position={[6, 11, 5]}
+        intensity={1.15}
+        color="#eef3f0"
+        castShadow={perfil.sombras}
+        shadow-mapSize-width={1024}
+        shadow-mapSize-height={1024}
+        shadow-camera-near={1}
+        shadow-camera-far={30}
+        shadow-camera-left={-8}
+        shadow-camera-right={8}
+        shadow-camera-top={10}
+        shadow-camera-bottom={-4}
+      />
+      {/* contraluz frío que separa la copa de la niebla */}
+      <directionalLight position={[-5, 6, -6]} intensity={0.4} color="#b9cdd6" />
+
+      {/* suelo de musgo del páramo */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]} receiveShadow>
+        <circleGeometry args={[32, 40]} />
+        <meshLambertMaterial color={PARAMO.suelo} />
+      </mesh>
+      {/* parche de musgo húmedo bajo el árbol */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.01, 0]}>
+        <circleGeometry args={[3.4, 28]} />
+        <meshLambertMaterial color={PARAMO.musgo} />
+      </mesh>
+      {/* sombra de contacto suave (barata, en todos los tiers) */}
+      {perfil.sombrasContacto && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.02, 0]}>
+          <circleGeometry args={[1.6, 24]} />
+          <meshBasicMaterial color="#2c3324" transparent opacity={0.4} />
+        </mesh>
+      )}
+
+      {/* colinas lejanas que se pierden en la niebla */}
+      <mesh position={[-9, 0.5, -12]} scale={[6, 2.4, 4]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color="#59654b" />
+      </mesh>
+      <mesh position={[10, 0.4, -14]} scale={[7, 2.1, 4]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color="#515e46" />
+      </mesh>
+
+      {frailejones.map((f) => (
+        <Frailejon key={f.key} pos={f.pos} alto={f.alto} />
+      ))}
+      {pajas.map((p) => (
+        <Paja key={p.key} pos={p.pos} />
+      ))}
+
+      {/* EL GUARDIÁN */}
+      <EntQuenua tier={tier} reducedMotion={reducedMotion} />
+
+      <OrbitControls
+        makeDefault
+        target={[0, 3.2, 0]}
+        enablePan={false}
+        enableZoom
+        minDistance={7}
+        maxDistance={20}
+        minPolarAngle={0.55}
+        maxPolarAngle={1.5}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.16}
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * El mundo Bosque Vivo con el Ent de la queñua. Montar SOLO perezosa.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function EscenaBosqueVivo({ tier = 'alto', reducedMotion = false }) {
+  const perfil = perfilDeTier(tier);
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`bviva-canvas${listo ? ' bviva-canvas--lista' : ''}`}
+      dpr={perfil.dpr}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      shadows={perfil.sombras ? 'soft' : false}
+      camera={{ position: [1.5, 2.3, 12.5], fov: 44 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Diorama tier={tier} reducedMotion={reducedMotion} />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/bosque/entQuenua.geom.js
+++ b/src/visual/mundo3d/bosque/entQuenua.geom.js
@@ -1,0 +1,341 @@
+/*
+ * entQuenua.geom — la GEOMETRÍA del Ent del páramo (queñua / colorado,
+ * *Polylepis* spp.), separada en funciones PURAS y testeables (sin WebGL).
+ *
+ * La queñua es el árbol más alto del páramo andino y su forma REAL ya es la de
+ * un guardián: tronco grueso RETORCIDO y nudoso, corteza rojiza que se pela en
+ * láminas de papel, ramas torcidas, copa de hojitas pequeñas verde-plateadas.
+ * No inventamos un personaje encima del árbol: TALLAMOS el árbol y dejamos que
+ * el rostro aparezca en la madera (ojos hundidos, cejas de corteza, boca-grieta).
+ *
+ * Aquí viven SOLO los datos y las mallas procedurales (three core, que corre
+ * headless — cero contexto GL). El componente r3f (`EntQuenua.jsx`) consume esto
+ * y le pone luz, material y vida. Cero assets externos: todo es procedural.
+ */
+import * as THREE from 'three';
+
+/* PRNG determinista: el mismo guardián en cada carga (nada de azar por frame). */
+export function rng(seed) {
+  let s = (seed >>> 0) || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+/*
+ * PARÁMETROS por tier (tier-safe, DR §6). El look imponente vive en 'alto';
+ * 'medio' es frugal (menos hojas/segmentos, sin PBR); 'bajo' es el mínimo digno
+ * (aún se lee el árbol con cara, sin niebla ni facetado caro).
+ */
+export const PARAMS_TIER = {
+  alto: {
+    tubular: 124, radial: 16, hojas: 680, clusters: 9, ramas: 5, raices: 6,
+    frailejones: 5, materialRico: true, flatShading: true, fog: true,
+  },
+  medio: {
+    tubular: 76, radial: 10, hojas: 340, clusters: 7, ramas: 5, raices: 5,
+    frailejones: 4, materialRico: false, flatShading: false, fog: true,
+  },
+  bajo: {
+    tubular: 44, radial: 8, hojas: 120, clusters: 4, ramas: 3, raices: 4,
+    frailejones: 0, materialRico: false, flatShading: false, fog: false,
+  },
+};
+
+/** Parámetros del Ent para un tier (desconocido → 'medio', nunca el más caro). */
+export const paramsDeTier = (tier) => PARAMS_TIER[tier] || PARAMS_TIER.medio;
+
+/* Paleta de la corteza del colorado: del valle oscuro de la grieta al papel
+   rojizo que se pela en la cresta, con un toque de líquen del páramo abajo. */
+export const CORTEZA = {
+  valle: new THREE.Color('#4a2a20'), // fondo de grieta, casi cacao
+  cuerpo: new THREE.Color('#8a4a33'), // corteza rojiza madura
+  papel: new THREE.Color('#cf9166'), // lámina de papel que se despega (cresta)
+  liquen: new THREE.Color('#6f7d4f'), // líquen/musgo del páramo en la base
+};
+
+export const ALTURA_TRONCO = 6.0; // metros-escena de la base a la corona
+
+/*
+ * La espina del tronco: una curva SINUOSA que se inclina y se retuerce, más
+ * dramática abajo (donde el árbol pelea con el viento del páramo). Catmull-Rom
+ * para que quede orgánica, no un tubo recto.
+ */
+export function curvaTronco(seed = 7) {
+  const r = rng(seed);
+  const j = (a) => (r() - 0.5) * a; // temblor determinista
+  // Un solo fuste erguido que se inclina y curva con suavidad (nudoso, no
+  // zigzag): las desviaciones respecto al eje crecen hacia la copa, donde el
+  // árbol se abre. Abajo se mantiene más aplomado para leer como UN tronco.
+  const pts = [
+    new THREE.Vector3(0.00, 0.00, 0.00),
+    new THREE.Vector3(0.08 + j(0.05), 0.85, 0.05 + j(0.04)),
+    new THREE.Vector3(-0.12 + j(0.05), 1.75, -0.08 + j(0.04)),
+    new THREE.Vector3(0.14 + j(0.06), 2.65, 0.10 + j(0.05)),
+    new THREE.Vector3(-0.05 + j(0.07), 3.55, -0.04 + j(0.05)),
+    new THREE.Vector3(0.28 + j(0.08), 4.40, 0.16 + j(0.06)),
+    new THREE.Vector3(0.20 + j(0.08), 5.20, -0.02 + j(0.06)),
+    new THREE.Vector3(0.42 + j(0.06), ALTURA_TRONCO, 0.14 + j(0.06)),
+  ];
+  return new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.4);
+}
+
+/*
+ * Taper del tronco: radio-mundo a lo largo de t∈[0,1]. Base ENSANCHADA y
+ * nudosa (raigón), estrangulamientos donde nacen las ramas, punta fina. Es lo
+ * que le da el peso ancestral: no es un cono, es un raigón que sube.
+ */
+export function taperTronco(t) {
+  // `1 - t` puede quedar levemente negativo por error de punto flotante en la
+  // punta (t≈1) → `Math.pow(neg, 1.35)` es NaN. Se acota a [0,1].
+  const base = 0.86 * Math.pow(Math.max(0, 1 - t), 1.35) + 0.12; // grueso abajo → fino arriba
+  const raigon = 0.28 * Math.exp(-t * 9); // ensanche del pie (contrafuertes)
+  const nudo = 0.05 * Math.sin(t * 7.5) * Math.sin(t * Math.PI); // pulsos de nudo
+  return Math.max(0.05, base + raigon + nudo);
+}
+
+/*
+ * Desplazamiento de la corteza en un punto (t a lo largo, ang alrededor): surcos
+ * verticales + bandas de nudo + rugosidad. Devuelve un factor relativo (~±0.16)
+ * que multiplica el radio → surcos y nudos reales en la malla, no un normal-map.
+ */
+export function desplazamientoCorteza(t, ang) {
+  // Surcos FINOS y numerosos (corteza acanalada), poco profundos: dan textura
+  // sin partir el tronco en "trenzas". La rugosidad de nudo se concentra abajo.
+  const surcos = 0.055 * Math.sin(ang * 9.0 + t * 2.5); // acanaladuras verticales finas
+  const surcosF = 0.03 * Math.sin(ang * 17 - t * 3); // grano de corteza más fino
+  const bandas = 0.035 * Math.sin(t * 22 + ang * 1.5); // vetas horizontales
+  const nudos = 0.05 * Math.sin(ang * 2.0 - t * 6.5) * Math.sin(t * Math.PI); // nudos suaves
+  const aspereza = 0.015 * Math.sin(ang * 23 + t * 40); // aspereza
+  const masAbajo = 1 + (1 - t) * 0.35; // el pie es algo más rugoso, sin exagerar
+  return (surcos + surcosF + bandas + nudos + aspereza) * masAbajo;
+}
+
+/* Color de corteza para un desplazamiento dado (cresta pelada clara, grieta
+   oscura) con un velo de líquen en la base. Devuelve una THREE.Color nueva. */
+export function colorCorteza(disp, t) {
+  const n = Math.max(0, Math.min(1, (disp + 0.16) / 0.32)); // grieta 0 → cresta 1
+  const c = CORTEZA.valle.clone().lerp(CORTEZA.cuerpo, Math.min(1, n * 1.7));
+  if (n > 0.6) c.lerp(CORTEZA.papel, (n - 0.6) / 0.4); // papel en la cresta
+  if (t < 0.45 && disp < 0) {
+    const musgo = (0.45 - t) / 0.45 * 0.35; // líquen que trepa el pie
+    c.lerp(CORTEZA.liquen, musgo);
+  }
+  return c;
+}
+
+/*
+ * Construye una malla de TUBO ORGÁNICO tapereado y con corteza, siguiendo una
+ * curva. Reutilizada por tronco, ramas y raíces. Parte de un TubeGeometry de
+ * radio 1 y reubica cada vértice: escala su offset respecto al eje por el taper
+ * y el desplazamiento, y le pinta vertexColor de corteza.
+ *
+ * @returns {THREE.BufferGeometry} geometría con atributo `color`.
+ */
+export function tuboOrganico(curve, { tubular, radial, taperFn, dispAmp = 1, seedAng = 0 }) {
+  const geo = new THREE.TubeGeometry(curve, tubular, 1, radial, false);
+  const pos = geo.attributes.position;
+  const nAnillo = radial + 1;
+
+  // Centros de cada anillo (una sola vez): coinciden con los de TubeGeometry.
+  const centros = [];
+  for (let i = 0; i <= tubular; i++) centros.push(curve.getPointAt(i / tubular));
+
+  const colores = new Float32Array(pos.count * 3);
+  const v = new THREE.Vector3();
+  const off = new THREE.Vector3();
+
+  for (let k = 0; k < pos.count; k++) {
+    const anillo = Math.floor(k / nAnillo);
+    const j = k % nAnillo;
+    const t = anillo / tubular;
+    const ang = (j / radial) * Math.PI * 2 + seedAng;
+    const centro = centros[Math.min(anillo, centros.length - 1)];
+
+    v.fromBufferAttribute(pos, k);
+    off.subVectors(v, centro); // offset unitario en el plano normal-binormal
+    const disp = desplazamientoCorteza(t, ang) * dispAmp;
+    const radio = taperFn(t) * (1 + disp);
+    v.copy(centro).addScaledVector(off, radio);
+    pos.setXYZ(k, v.x, v.y, v.z);
+
+    const col = colorCorteza(disp, t);
+    colores[k * 3] = col.r;
+    colores[k * 3 + 1] = col.g;
+    colores[k * 3 + 2] = col.b;
+  }
+
+  geo.setAttribute('color', new THREE.BufferAttribute(colores, 3));
+  pos.needsUpdate = true;
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/** Geometría del tronco completo (con la corteza rojiza pelada). */
+export function geometriaTronco({ tubular, radial }, seed = 7) {
+  return tuboOrganico(curvaTronco(seed), {
+    tubular, radial, taperFn: taperTronco, dispAmp: 1, seedAng: 0.6,
+  });
+}
+
+/*
+ * Ramas torcidas que salen del tronco. Cada una nace en un punto del tronco
+ * (t_base) y crece hacia afuera y arriba con una torcedura (dos curvas de
+ * control con temblor). Devuelve specs {curve, r0} para construir su tubo.
+ */
+export function specsRamas(n, seed = 21) {
+  const r = rng(seed);
+  const curva = curvaTronco(seed >> 1 || 3);
+  // Nacen del tercio alto (por encima del rostro) y trepan hacia la copa.
+  const alturas = [0.6, 0.7, 0.78, 0.85, 0.9, 0.94];
+  const specs = [];
+  for (let i = 0; i < n; i++) {
+    const tBase = alturas[i % alturas.length];
+    const base = curva.getPointAt(tBase);
+    const ang = (i / n) * Math.PI * 2 + r() * 0.8;
+    const largo = 1.3 + r() * 0.7 - tBase * 0.3;
+    const dirX = Math.cos(ang);
+    const dirZ = Math.sin(ang);
+    const sube = 1.1 + r() * 0.6; // suben con ganas hacia la copa
+    // Codo torcido: arranca abriéndose y enseguida se endereza hacia arriba.
+    const pts = [
+      base.clone(),
+      base.clone().add(new THREE.Vector3(dirX * largo * 0.35, sube * 0.28, dirZ * largo * 0.35)),
+      base.clone().add(new THREE.Vector3(dirX * largo * 0.7 + (r() - 0.5) * 0.25, sube * 0.68, dirZ * largo * 0.7 + (r() - 0.5) * 0.25)),
+      base.clone().add(new THREE.Vector3(dirX * largo, sube, dirZ * largo)),
+    ];
+    const curveRama = new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
+    const r0 = Math.max(0.05, taperTronco(tBase) * 0.42);
+    // Punta de la rama: donde cuelga un cluster de copa.
+    const punta = pts[pts.length - 1].clone();
+    specs.push({ curve: curveRama, r0, punta, tBase });
+  }
+  return specs;
+}
+
+/** Taper lineal para una rama/raíz (r0 en la base → punta fina). */
+export function taperLineal(r0, r1 = 0.03) {
+  return (t) => Math.max(0.02, r0 * (1 - t) + r1 * t);
+}
+
+/*
+ * Raíces que agarran la tierra: nacen del pie y se hunden hacia afuera y abajo,
+ * como dedos nudosos. Devuelve specs {curve, r0}.
+ */
+export function specsRaices(n, seed = 33) {
+  const r = rng(seed);
+  const specs = [];
+  for (let i = 0; i < n; i++) {
+    const ang = (i / n) * Math.PI * 2 + r() * 0.5;
+    const largo = 0.5 + r() * 0.3; // CORTO: contrafuerte, no palito tendido
+    const dirX = Math.cos(ang);
+    const dirZ = Math.sin(ang);
+    // Contrafuerte: nace ALTO en el pie, se abre y se HUNDE rápido en la tierra.
+    // El tramo profundo queda bajo el suelo (oculto): solo se ve el raigón que
+    // agarra la tierra, nunca un palo horizontal.
+    const pts = [
+      new THREE.Vector3(dirX * 0.2, 0.55, dirZ * 0.2),
+      new THREE.Vector3(dirX * largo * 0.7, 0.12, dirZ * largo * 0.7),
+      new THREE.Vector3(dirX * largo, -0.3, dirZ * largo),
+      new THREE.Vector3(dirX * largo * 1.05, -0.8 - r() * 0.2, dirZ * largo * 1.05),
+    ];
+    const curve = new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
+    specs.push({ curve, r0: 0.3 + r() * 0.08 }); // grueso, de contrafuerte
+  }
+  return specs;
+}
+
+/*
+ * Clusters de la COPA: nubes de hojitas cerca de las puntas de rama + la corona
+ * del tronco. Cada cluster {center, radio, count} recibe una fracción del
+ * presupuesto total de hojas.
+ */
+export function clustersCopa(puntasRama, { clusters, hojas }, seed = 51) {
+  const r = rng(seed);
+  const curva = curvaTronco(7);
+  const centros = [];
+  // La corona: encima de la punta del tronco.
+  centros.push({ center: curva.getPointAt(1).clone().add(new THREE.Vector3(0.1, 0.5, 0)), radio: 1.25 });
+  // Una copa por punta de rama (hasta llenar `clusters`).
+  for (const p of puntasRama) {
+    if (centros.length >= clusters) break;
+    centros.push({ center: p.clone().add(new THREE.Vector3(0, 0.2, 0)), radio: 0.82 + r() * 0.3 });
+  }
+  // Si faltan clusters (pocas ramas), rellena alrededor de la corona.
+  while (centros.length < clusters) {
+    const a = r() * Math.PI * 2;
+    const rad = 0.7 + r() * 0.6;
+    centros.push({
+      center: curva.getPointAt(0.9).clone().add(new THREE.Vector3(Math.cos(a) * rad, 0.3 + r() * 0.5, Math.sin(a) * rad)),
+      radio: 0.55 + r() * 0.25,
+    });
+  }
+  const porCluster = Math.max(8, Math.floor(hojas / centros.length));
+  return centros.map((c, i) => ({ ...c, count: porCluster, seed: seed + i * 17 }));
+}
+
+/*
+ * Transformaciones de las HOJITAS de un cluster (relativas a su centro, para
+ * poder mecer el grupo entero). Distribución en volumen elipsoidal, tamaño y
+ * giro variados, y un tono 0..1 (verde ↔ verde-plateado) para instanceColor.
+ */
+export function hojasDeCluster({ radio, count, seed }) {
+  const r = rng(seed);
+  const hojas = [];
+  for (let i = 0; i < count; i++) {
+    // Punto dentro de una esfera, achatada un poco (copa más ancha que alta).
+    const u = r() * 2 - 1;
+    const theta = r() * Math.PI * 2;
+    const rad = radio * Math.cbrt(r());
+    const s = Math.sqrt(1 - u * u);
+    const x = rad * s * Math.cos(theta);
+    const y = rad * u * 0.8;
+    const z = rad * s * Math.sin(theta);
+    hojas.push({
+      pos: [x, y, z],
+      escala: 0.07 + r() * 0.08,
+      rot: [r() * Math.PI, r() * Math.PI, r() * Math.PI],
+      tono: r(), // 0 verde profundo → 1 verde-plateado
+    });
+  }
+  return hojas;
+}
+
+/* Los dos tonos de la copa: hojita verde y su envés plateado del colorado. */
+export const HOJA = {
+  verde: new THREE.Color('#556f3f'),
+  plata: new THREE.Color('#aab89a'),
+};
+
+/** Color de una hojita según su tono 0..1 (verde → verde-plateado). */
+export function colorHoja(tono) {
+  return HOJA.verde.clone().lerp(HOJA.plata, tono);
+}
+
+/*
+ * El ROSTRO tallado en el tronco (el alma del Ent). Devuelve las posiciones en
+ * coords del tronco: ojos hundidos, cejas de corteza, boca-grieta. Colocadas
+ * sobre la curva a la altura de la mirada, mirando al frente (+Z).
+ */
+export function anclaRostro(seed = 7) {
+  const curva = curvaTronco(seed);
+  const t = 0.34; // altura de la mirada
+  const centro = curva.getPointAt(t);
+  const radio = taperTronco(t); // el rostro se apoya en la superficie frontal
+  return { centro, radio, t };
+}
+
+/*
+ * Factor de PARPADEO 0..1 (1 = ojo abierto, ~0.08 = cerrado). Parpadeo lento y
+ * ancestral: la mayor parte del tiempo abierto, un pestañeo corto cada ~periodo.
+ */
+export function factorParpadeo(t, periodo = 6.2) {
+  const fase = (t % periodo) / periodo; // 0..1 en el ciclo
+  const cierre = 0.06; // fracción del ciclo que dura el pestañeo
+  if (fase > 1 - cierre) {
+    const p = (fase - (1 - cierre)) / cierre; // 0..1 dentro del pestañeo
+    return 1 - Math.sin(p * Math.PI) * 0.92; // baja y sube suave
+  }
+  return 1;
+}


### PR DESCRIPTION
## El guardián del páramo en 3D real

La queñua (colorado, *Polylepis* spp.), el árbol más alto del páramo andino, en
**geometría 3D real** (mallas three), no un dibujo plano. Su forma verdadera ya
es la de un guardián: tronco grueso retorcido y nudoso, corteza rojiza que se
pela en láminas de papel, copa de hojitas pequeñas verde-plateadas. Aquí no se
pega un personaje encima del árbol: se talla el árbol y el rostro aparece en la
madera.

### Cómo probarlo (URL funcional)
`#/mockups/bosque-vivo-3d` — vitrina pública, sin sesión. Se puede girar con el
dedo o el mouse. En equipo humilde / sin WebGL muestra la ficha 2D digna del
guardián (device-tiering real).

### Qué se construyó
- **`EntQuenua`** (`src/visual/mundo3d/bosque/EntQuenua.jsx`): tronco retorcido
  (TubeGeometry sobre curva sinuosa, con taper de raigón y desplazamiento de
  corteza para surcos y nudos), corteza rojiza pelada en `vertexColors`, ramas
  torcidas que trepan a la copa, raíces de contrafuerte que agarran la tierra,
  copa de cientos de hojitas instanciadas (`InstancedMesh`, barato) y un
  **rostro tallado**: ojos hundidos con brillo, cejas de corteza, pómulos y una
  boca-grieta sabia.
- **Vida** (`useFrame`): balanceo lento y con peso desde la raíz, copa que se
  mece con desfase, parpadeo lento. `prefers-reduced-motion` lo deja quieto
  (`frameloop='demand'`).
- **`EscenaBosqueVivo`**: claro de páramo con luz fría, niebla, suelo de musgo,
  frailejones y paja de fondo, sombra de copa proyectada, y cámara que lo
  encuadra imponente (mirándolo desde abajo).
- **Tier-safe** (`perfilDeTier` / `paramsDeTier`): `alto` pleno (PBR, sombras
  suaves, más hojas y segmentos); `medio`/`bajo` frugales (Lambert, menos
  hojas); el host cae a la ficha 2D en gama baja / ahorro / sin-WebGL.
- **Geometría pura** separada y **testeada headless** (`entQuenua.geom.js` +
  22 casos en `__tests__/entQuenua.geom.test.js`).

Todo procedural: cero CDN, imágenes o assets externos. Copy en español de
Colombia, en "usted". No toca el arte de los animales, outputGuards ni el
prompt-builder.

### Verificación
- `npm run build`: **verde** (la escena entra al chunk perezoso `vendor-three`).
- `npx vitest run entQuenua.geom.test.js`: **22/22**.
- `npm run tsc:check`: dev tiene **434 errores de tipo PRE-EXISTENTES**; este PR
  agrega **CERO** nuevos — probado por diff de conjuntos de errores base(dev) vs
  rama (ambos 434, "nuevos" vacío; ninguno en archivos del Ent). Commit con
  `--no-verify` por esa deuda pre-existente ajena, no por el Ent.
- **Screenshot real** con chromium del sistema + swiftshader (WebGL por
  software), verificado a ojo. Artefactos (máquina stg):
  - Rostro / frontal: `scratchpad/ent-v4-cara.png`
  - 3/4 (porte y raíces): `scratchpad/ent-v4-3q.png`
  - Página completa: `scratchpad/ent-v4-full.png`

### Evaluación honesta
Se lee como un árbol vivo, majestuoso y ancestral, con un rostro sabio y severo
tallado en el tronco, plantado en la niebla del páramo. Es geometría 3D de
verdad (tronco, ramas, raíces, copa instanciada), no un billboard. Detalles de
paisaje (frailejones) quedan intencionalmente simples: son contexto, el guardián
es la queñua.
