### PR TITLE
fix(sembrar): fallback graceful sin client_id + smoke 2 rutas 3D nuevas

### DIFF
--- a/scripts/smoke-focalizado.mjs
+++ b/scripts/smoke-focalizado.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/** Smoke test focalizado: 2 nuevas rutas 3D + 4 timeouts previos + sembrar fix */
+import { chromium } from 'playwright';
+import { resolve } from 'node:path';
+import { mkdirSync } from 'node:fs';
+
+const BASE = 'http://127.0.0.1:4500';
+const OUT = resolve(import.meta.dirname, '..', 'smoke-prod');
+const CHROMIUM = '/run/current-system/sw/bin/chromium';
+const FAKE_TOKEN = 'smoke-test-token';
+const FAKE_EXPIRY = Date.now() + 86400_000;
+
+const RUTAS = [
+  { path: 'bosque_vivo', label: 'NUEVA 3D: bosque_vivo (MundoEntBosque)' },
+  { path: 'sierra_global', label: 'ACTUALIZADA 3D: sierra_global (GaleriaSierraArboles)' },
+  { path: 'sembrar', label: 'FIX: sembrar (SeedingLog fallback sin client_id)' },
+  { path: 'aliados_finca', label: 'TIMEOUT previo: aliados_finca (45s)' },
+  { path: 'plant_asset', label: 'TIMEOUT previo: plant_asset (45s)' },
+  { path: 'mundo_cultivos', label: 'TIMEOUT previo: mundo_cultivos (45s)' },
+  { path: 'mercado', label: 'TIMEOUT previo: mercado (45s)' },
+];
+
+const ERROR_TEXTS = ['Algo falló', 'error inesperado', 'Ocurrió un error'];
+
+async function run() {
+  const browser = await chromium.launch({
+    executablePath: CHROMIUM,
+    headless: true,
+    args: ['--use-gl=swiftshader', '--enable-unsafe-swiftshader', '--no-sandbox', '--disable-gpu'],
+  });
+
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+
+  // Sembrar token
+  const sp = await ctx.newPage();
+  await sp.goto(BASE, { waitUntil: 'domcontentloaded', timeout: 20000 });
+  await sp.waitForTimeout(2000);
+  await sp.evaluate(({ token, expiry }) => {
+    localStorage.setItem('farmos_access_token', token);
+    localStorage.setItem('farmos_refresh_token', token);
+    localStorage.setItem('farmos_token_expiry', String(expiry));
+  }, { token: FAKE_TOKEN, expiry: FAKE_EXPIRY });
+  await sp.close();
+
+  await ctx.newPage().then(async (p) => {
+    await p.goto(`${BASE}/#valle3d`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+    await p.waitForTimeout(3000);
+    const body = await p.content();
+    console.log('[setup] Auth bypass:', !body.includes('Usuario'));
+    await p.close();
+  });
+
+  console.log('');
+
+  for (const { path, label } of RUTAS) {
+    const page = await ctx.newPage();
+    const errors = [];
+    page.on('console', (msg) => { if (msg.type() === 'error') errors.push(msg.text()); });
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    try {
+      await page.goto(`${BASE}/#${path}`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+      await page.waitForTimeout(10000); // más margen para 3D pesado
+
+      const body = await page.content();
+      const lower = body.toLowerCase();
+
+      let status = 'OK';
+      for (const t of ERROR_TEXTS) {
+        if (lower.includes(t.toLowerCase())) { status = 'CRASH'; break; }
+      }
+      if (status === 'OK' && body.length < 2000) status = 'BLANCO';
+
+      const slug = path.replace(/[^a-zA-Z0-9_-]/g, '_');
+      const ss = resolve(OUT, `${slug}-v2.png`);
+      await page.screenshot({ path: ss, timeout: 45000 });
+
+      const errSuffix = errors.length ? ` (${errors.length} console errors)` : '';
+      console.log(`[${status.padEnd(6)}] ${label}${errSuffix}`);
+
+      if (status === 'CRASH') {
+        for (const e of errors.slice(0, 3)) console.log(`         ${e.substring(0, 120)}`);
+      }
+    } catch (e) {
+      console.log(`[TIMEOUT] ${label} — ${e.message.substring(0, 80)}`);
+    } finally {
+      await page.close();
+    }
+  }
+
+  await browser.close();
+  console.log('\nDone.');
+}
+
+run().catch(e => { console.error('FATAL:', e.message); process.exit(1); });

--- a/src/components/SeedingLog.jsx
+++ b/src/components/SeedingLog.jsx
@@ -3,7 +3,26 @@
  * a nivel de archivo —mismo criterio que SpeciesSelect / SeguimientoProcesoScreen—
  */
 // @ts-nocheck
+import { ENV } from '../config/env.js';
+
 export default function SeedingLog({ onBack, onSave, initialData: initialDataRaw }) {
+  // Fallback graceful: sin conexión a farmOS (env vars no definidas), mostrar
+  // estado vacío digno en vez de romper el ErrorBoundary.
+  if (!ENV.FARMOS_CLIENT_ID) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] px-6 text-center text-slate-300">
+        <div className="text-5xl mb-4" aria-hidden="true">🌱</div>
+        <h2 className="text-lg font-semibold text-slate-200 mb-2">Configuración de siembra no disponible</h2>
+        <p className="text-sm text-slate-400 max-w-sm">Conéctese a su finca para registrar siembras. Sin conexión a farmOS, esta sección no puede cargarse.</p>
+        {onBack && (
+          <button onClick={onBack} className="mt-6 px-5 py-2 rounded-xl bg-slate-700 text-slate-200 text-sm hover:bg-slate-600 transition-colors">
+            Volver
+          </button>
+        )}
+      </div>
+    );
+  }
+
   // Bug B4 piloto 2026-05-28: QuickActionsPanel "Agregar planta" navega a
   // 'sembrar' sin pasar currentViewData → App.jsx pasa initialData={null} →
   // default param `= {}` NO aplica con null (solo con undefined) → línea 18


### PR DESCRIPTION
## Resumen

- **Fix:** SeedingLog ahora muestra fallback digno cuando `VITE_FARMOS_CLIENT_ID` no está definida (sin .env / sin backend). No rompe ErrorBoundary.
- **Smoke:** Las 2 rutas 3D nuevas (bosque_vivo, sierra_global con GaleriaSierraArboles) renderizan OK.
- **Verificación timeouts previos:** Los 4 timeouts del smoke anterior (aliados_finca, plant_asset, mundo_cultivos, mercado) eran falsos positivos por lentitud de headless. Con 10s de espera + 45s screenshot timeout, los 4 pasan OK.

## Smoke test focalizado (7 rutas)

| Ruta | Estado | Notas |
|---|---|---|
| bosque_vivo (MundoEntBosque) | ✅ OK | 9 console errors (esperables sin backend) |
| sierra_global (GaleriaSierraArboles) | ✅ OK | 2 console errors |
| sembrar (SeedingLog fix) | ✅ OK | Muestra fallback sin crash |
| aliados_finca | ✅ OK | Falso positivo previo |
| plant_asset | ✅ OK | Falso positivo previo |
| mundo_cultivos | ✅ OK | Falso positivo previo |
| mercado | ✅ OK | Falso positivo previo |

## Cambios

- `src/components/SeedingLog.jsx`: importa ENV, verifica FARMOS_CLIENT_ID, muestra fallback si vacío
- `scripts/smoke-focalizado.mjs`: script de smoke test focalizado