### PR TITLE
fix(canary): B0b sube la foto por /api/file/upload (flujo real), no octet-stream (403)

### DIFF
--- a/scripts/lib/canary-modules.mjs
+++ b/scripts/lib/canary-modules.mjs
@@ -380,22 +380,26 @@ async function runPlantaFoto(ctx) {
   if (!created.ok && rels.location) { delete rels.location; created = await farmosWrite(base, token, '/api/asset/plant', { data: { type: 'asset--plant', attributes: { name: `CANARIO planta ${target} ${stamp}`, status: 'active' }, relationships: rels } }); }
   const plantId = created.ok ? created.json?.data?.id : null;
 
-  // Subir la foto al campo `image` de la planta por el flujo NATIVO de farmOS 4.x /
-  // Drupal 10 — el MISMO que usa el cliente real (uploadBinaryToFarmOS en
-  // src/services/apiService.js). Es en DOS pasos:
-  //   A) POST /api/{entity}/{bundle}/{field} (octet-stream) crea un file--file NUEVO
-  //      y devuelve su UUID. OJO: la forma con el UUID en la ruta
-  //      (/api/asset/plant/{id}/image) NO EXISTE en este farmOS (404 sin auth → 500
-  //      con token; verificado 2026-07-11) y ningún código de producción la usa.
-  //   B) PATCH del plant relacionando el file, para que persista (un file--file sin
-  //      referencia queda temporal y el cron de Drupal lo borra ~6 h).
+  // Subir la foto por el MISMO flujo que usa el cliente real de producción
+  // (operatorPhotoService.uploadToFarmOS y syncManager para la evidencia). En DOS pasos:
+  //   A) POST /api/file/upload con multipart FormData (campo `file`): es la ruta
+  //      DEDICADA de farmOS (módulo farm_api) que sube las fotos reales; crea un
+  //      file--file NUEVO y devuelve su UUID en JSON:API. La forma octet-stream
+  //      /api/{entity}/{bundle}/{field} (/api/asset/plant/image) devolvía 403 al
+  //      usuario de pruebas y ningún código de producción la usa (verificado
+  //      2026-07-11..14). undici arma el boundary multipart solo si NO fijamos
+  //      Content-Type — igual que sendToFarmOS, que lo borra cuando el body es FormData.
+  //   B) PATCH del plant relacionando el file en el campo `image`, para que persista
+  //      (un file--file sin referencia queda temporal y el cron de Drupal lo borra ~6 h).
   let fileId = null; let uploadStatus = null;
   if (plantId) {
     const bytes = Buffer.from(CANARY_JPEG_B64, 'base64');
-    const up = await httpFetch(`${base}/api/asset/plant/image`, {
+    const form = new FormData();
+    form.append('file', new Blob([bytes], { type: 'image/jpeg' }), `CANARIO-${target}-${dateStr}.jpg`);
+    const up = await httpFetch(`${base}/api/file/upload`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/octet-stream', 'Content-Disposition': `file; filename="CANARIO-${target}-${dateStr}.jpg"`, Accept: 'application/vnd.api+json' },
-      body: bytes, timeoutMs: 45000,
+      headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.api+json' },
+      body: form, timeoutMs: 45000,
     });
     uploadStatus = up.status;
     if (up.ok && up.json?.data?.id) {


### PR DESCRIPTION
## Qué falla
El check **B0b** (guardar planta con foto) del canario nocturno viene fallando en **dev y prod** con `foto=NO (upload HTTP 403)` desde el 2026-07-12 (antes daba HTTP 500). La planta se crea bien; solo falla la subida de la foto.

## Causa raíz
El paso A de `runPlantaFoto` subía la imagen a `POST /api/asset/plant/image` con `Content-Type: application/octet-stream`. Esa ruta octet-stream (`/api/{entity}/{bundle}/{field}`) devuelve **403** para el usuario de pruebas y **ningún código de producción la usa**. El comentario apuntaba a una función inexistente (`uploadBinaryToFarmOS en src/services/apiService.js`).

El cliente real de producción sube las fotos por la ruta **dedicada** de farmOS:
- `src/services/operatorPhotoService.js` → `uploadToFarmOS()`: `POST /api/file/upload` con `FormData` (`formData.append('file', blob, filename)`).
- `src/services/syncManager.js` (evidencia): mismo `POST /api/file/upload` + `PATCH` para relacionar el `file--file`.

## Fix
El paso A ahora replica ese flujo real: `POST /api/file/upload` con `multipart FormData` (campo `file`), que crea el `file--file` y devuelve su UUID. El paso B (PATCH que relaciona el file al plant en el campo `image`) queda igual. `undici` arma el boundary multipart solo mientras no fijemos `Content-Type` a mano — igual que `sendToFarmOS`, que lo borra para `FormData`.

## Verificación
- `node --check` y `eslint` limpios sobre el archivo.
- `FormData`/`Blob` son globales en Node 20+ (host corre Node 22).
- ⚠️ **No se pudo correr B0b en vivo** contra farmOS en este host (sin `CANARY_CREDS_FILE`/token del sidecar). La verificación end-to-end real es la **corrida nocturna** siguiente; si B0b sigue en 403 sería permiso de farmOS, no el endpoint.

Alcance: solo el harness del canario (`scripts/lib/canary-modules.mjs`). Sin superficie de runtime para usuarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)