### PR TITLE
experiment(embedder): fine-tune contrastivo sobre nombres regionales del grafo

### DIFF
--- a/scripts/embedder-finetune/README.md
+++ b/scripts/embedder-finetune/README.md
@@ -1,0 +1,54 @@
+# Embedder fine-tune experiment — nombres regionales de especies (2026-07-15)
+
+Experimento de fine-tuning contrastivo sobre un embedder multilingüe (`intfloat/multilingual-e5-large`)
+usando pares reales `(nombre regional/común, especie)` extraídos del grafo de conocimiento de Chagra
+(`RegionalLabel` + `Species.nombres_comunes`), con negativos duros por género/familia botánica.
+
+**Objetivo:** medir si un embedder fine-tuneado sobre nombres regionales colombianos distingue mejor
+especies fácilmente confundibles en el habla campesina (`papa`/`papaya`/`papayuela`, passifloras,
+`tomate`/`tomate de árbol`, `brassica oleracea`, `arracacha`/`yuca`) que un embedder pretrained sin tocar.
+
+**Resultado (ver `results/` para el JSON completo):**
+
+| Métrica | Base | Fine-tuned | Δ |
+|---|---|---|---|
+| Recall@1 global | 31.6% | 36.2% | +4.7pp |
+| Recall@5 global | 43.6% | 49.9% | +6.3pp |
+| MRR global | 0.373 | 0.421 | +0.049 |
+| Recall@1 confundibles | 28.6% | 33.2% | +4.5pp |
+| Recall@5 confundibles | 42.7% | 54.3% | +11.6pp |
+
+El fine-tune mejora sustancialmente en 3 de 5 grupos de confundibles (tomate/tomate-de-árbol,
+brassica oleracea, papa/papaya/papayuela) pero **no mejora** (o empeora levemente) en passifloras
+y en arracacha-vs-yuca — este último es un caso de confusión entre familias botánicas distintas
+(Apiaceae vs Euphorbiaceae) que los negativos duros por taxonomía no cubren. **Veredicto: no se
+reemplaza el embedder de producción con este checkpoint** — la señal es real y vale la pena iterar,
+pero el resultado es desparejo en justo los casos más difíciles. Detalle completo, tabla de
+confundibles y el hallazgo de un artefacto de colapso (documentos vacíos en el corpus atrayendo
+queries fuera de distribución) en el reporte interno de operaciones.
+
+## Reproducir
+
+Requiere GPU (o CPU, más lento) con `torch` + `transformers` instalados, y acceso al grafo AGE de
+Chagra (`chagra_kg`, Apache AGE sobre Postgres) para regenerar los pares. Los scripts asumen que
+ya existen tres extractos planos del grafo (`species.jsonl`, `regional_labels.jsonl`,
+`species_family.psv` — ver cabecera de `build_pairs.py` para el formato exacto y las queries Cypher
+usadas para generarlos).
+
+```bash
+# 1. Construir pares + split honesto por especie + corpus de recuperación
+python build_pairs.py
+
+# 2. Entrenar (InfoNCE manual + negativos duros por género/familia, sin sentence-transformers)
+python train_embedder.py --epochs 4 --batch-size 16 --neg-k 2
+
+# 3. Evaluar base vs fine-tuned (recall@1/@5/MRR global + subset de confundibles)
+python eval_embedder.py --model intfloat/multilingual-e5-large --tag base --out results/eval_base.json
+python eval_embedder.py --model <path al checkpoint fine-tuneado> --tag finetuned --out results/eval_finetuned.json
+
+# 4. (Opcional) exportar a ONNX para servir sin torch/CUDA
+python export_onnx.py
+```
+
+No se incluye el checkpoint del modelo (binarios grandes, no van en este repo) — solo el código y
+las métricas para reproducir el experimento.

--- a/scripts/embedder-finetune/build_pairs.py
+++ b/scripts/embedder-finetune/build_pairs.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+Construye pares (query, species_id) reales desde el grafo AGE de Chagra
+(RegionalLabel + Species.nombres_comunes), mas indices de familia/genero
+para negativos duros, y hace split HONESTO por especie.
+
+Entradas (ya volcadas desde postgres-farm/chagra_kg):
+  ~/embedder-ft/species.jsonl          -- properties(s) por cada Species
+  ~/embedder-ft/regional_labels.jsonl  -- properties(r) por cada RegionalLabel
+  ~/embedder-ft/species_family.psv     -- "species_id"|"Family" (psql -t -A, pipe-sep)
+
+Salidas:
+  ~/embedder-ft/corpus.jsonl        -- {species_id, text} documento por especie (TODAS, 742)
+  ~/embedder-ft/pairs_train.jsonl   -- {query, species_id, source}
+  ~/embedder-ft/pairs_test.jsonl    -- {query, species_id, source}
+  ~/embedder-ft/family.json         -- {species_id: family_name}
+  ~/embedder-ft/genus.json          -- {species_id: genus}
+  ~/embedder-ft/confusable_ids.json -- lista de species_id del set de confundibles
+  ~/embedder-ft/split_report.json   -- stats del split para el reporte
+"""
+import json, re, random, sys
+from pathlib import Path
+from collections import defaultdict
+
+BASE = Path.home() / "embedder-ft"
+random.seed(1337)
+
+# ---------- 1. cargar species.jsonl ----------
+species = {}
+with open(BASE / "species.jsonl", encoding="utf-8") as f:
+    for line in f:
+        line = line.strip()
+        if not line or line in ("LOAD", "SET"):
+            continue
+        try:
+            props = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        sid = props.get("id")
+        if not sid:
+            continue
+        species[sid] = props
+
+print(f"[species] cargadas {len(species)} especies", file=sys.stderr)
+
+# ---------- 2. cargar regional_labels.jsonl ----------
+raw_labels = []
+with open(BASE / "regional_labels.jsonl", encoding="utf-8") as f:
+    for line in f:
+        line = line.strip()
+        if not line or line in ("LOAD", "SET"):
+            continue
+        try:
+            props = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        raw_labels.append(props)
+
+print(f"[regional_labels] cargados {len(raw_labels)} nodos", file=sys.stderr)
+
+# ---------- 3. cargar species_family.psv ----------
+family_of = {}
+with open(BASE / "species_family.psv", encoding="utf-8") as f:
+    for line in f:
+        line = line.strip()
+        if not line or line in ("LOAD", "SET"):
+            continue
+        parts = line.split("|")
+        if len(parts) != 2:
+            continue
+        sid = parts[0].strip('"')
+        fam = parts[1].strip('"')
+        family_of[sid] = fam
+
+print(f"[family] {len(family_of)} especies con familia", file=sys.stderr)
+
+# ---------- 4. genero desde nombre_cientifico ----------
+def genus_of(sci_name: str) -> str:
+    if not sci_name:
+        return ""
+    tok = sci_name.strip().split()
+    if not tok:
+        return ""
+    g = tok[0].strip(".,").lower()
+    if g in ("x", "×"):
+        g = tok[1].strip(".,").lower() if len(tok) > 1 else g
+    return g
+
+genus_of_species = {}
+for sid, props in species.items():
+    genus_of_species[sid] = genus_of(props.get("nombre_cientifico", ""))
+
+# ---------- 5. normalizar RegionalLabel -> (query, species_id, confidence) ----------
+skipped_missing_species = 0
+seen_pairs = set()
+positives = []  # (query, species_id, source)
+
+def add_pair(query, sid, source):
+    global skipped_missing_species
+    query = (query or "").strip()
+    if not query or not sid:
+        return
+    if sid not in species:
+        skipped_missing_species += 1
+        return
+    key = (query.lower(), sid)
+    if key in seen_pairs:
+        return
+    seen_pairs.add(key)
+    positives.append({"query": query, "species_id": sid, "source": source})
+
+for props in raw_labels:
+    sid = props.get("canonical_species_id") or props.get("species_id")
+    surface = props.get("surface_form") or props.get("label")
+    add_pair(surface, sid, "regional_label")
+
+n_regional = len(positives)
+print(f"[regional_label] {n_regional} pares validos, {skipped_missing_species} descartados (species_id inexistente)", file=sys.stderr)
+
+# ---------- 6. nombres_comunes por especie ----------
+n_before = len(positives)
+for sid, props in species.items():
+    ncs = props.get("nombres_comunes") or []
+    if isinstance(ncs, str):
+        ncs = [ncs]
+    for nc in ncs:
+        add_pair(nc, sid, "nombres_comunes")
+    nc1 = props.get("nombre_comun")
+    if nc1:
+        add_pair(nc1, sid, "nombre_comun")
+
+print(f"[nombres_comunes+nombre_comun] +{len(positives) - n_before} pares nuevos", file=sys.stderr)
+print(f"[total] {len(positives)} pares (query, species_id) unicos", file=sys.stderr)
+
+# ---------- 7. set de confundibles (forzado a TEST) ----------
+CONFUSABLE_GROUPS = {
+    "papa_vs_papaya_vs_papayuela": [
+        "solanum_tuberosum", "solanum_tuberosum_argentina", "solanum_tuberosum_carrera_negra",
+        "solanum_tuberosum_diacol_capiro", "solanum_tuberosum_pastusa_suprema", "solanum_tuberosum_sabanera",
+        "solanum_phureja",
+        "carica_papaya",
+        "vasconcellea_pubescens", "vasconcellea_goudotiana",
+    ],
+    "passifloras": [
+        "passiflora_edulis_flavicarpa", "passiflora_edulis_amarilla_colombia", "passiflora_edulis_morada",
+        "passiflora_ligularis", "passiflora_tripartita_mollissima", "passiflora_quadrangularis",
+        "passiflora_incarnata", "passiflora_maliformis", "passiflora_tarminiana",
+    ],
+    "tomate_vs_tomate_de_arbol": [
+        "solanum_lycopersicum", "solanum_lycopersicum_cerasiforme", "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano", "solanum_lycopersicum_sungold",
+        "solanum_betaceum", "solanum_betaceum_morado", "solanum_betaceum_naranja",
+    ],
+    "brassica_oleracea": [
+        "brassica_oleracea_acephala_curly", "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian", "brassica_oleracea_botrytis",
+        "brassica_oleracea_capitata_alba", "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_gemmifera", "brassica_oleracea_italica",
+        "brassica_oleracea_sabauda", "brassica_oleracea_sabellica",
+        "brassica_oleracea_var_acephala", "brassica_oleracea_var_capitata",
+    ],
+    "arracacha_vs_yuca": [
+        "arracacia_xanthorrhiza", "arracacia_xanthorrhiza_amarilla",
+        "manihot_esculenta", "manihot_glaziovii",
+    ],
+}
+confusable_ids = set()
+for grp in CONFUSABLE_GROUPS.values():
+    for sid in grp:
+        if sid in species:
+            confusable_ids.add(sid)
+        else:
+            print(f"  [warn] confusable id no existe en grafo: {sid}", file=sys.stderr)
+
+print(f"[confusables] {len(confusable_ids)} species_id forzados a TEST", file=sys.stderr)
+
+# ---------- 8. split por ESPECIE (no por par) ----------
+all_species_with_pairs = sorted({p["species_id"] for p in positives})
+pool = [s for s in all_species_with_pairs if s not in confusable_ids]
+random.shuffle(pool)
+n_test_target = round(0.18 * len(all_species_with_pairs))
+n_test_from_pool = max(0, n_test_target - len(confusable_ids & set(all_species_with_pairs)))
+test_species = set(pool[:n_test_from_pool]) | (confusable_ids & set(all_species_with_pairs))
+train_species = set(all_species_with_pairs) - test_species
+
+pairs_train = [p for p in positives if p["species_id"] in train_species]
+pairs_test = [p for p in positives if p["species_id"] in test_species]
+
+print(f"[split] especies train={len(train_species)} test={len(test_species)} (de {len(all_species_with_pairs)} con pares)", file=sys.stderr)
+print(f"[split] pares train={len(pairs_train)} test={len(pairs_test)}", file=sys.stderr)
+
+# ---------- 9. corpus: un documento por CADA especie (742) ----------
+def doc_text(props):
+    nombre = props.get("nombre_comun", "")
+    sci = props.get("nombre_cientifico", "")
+    teaser = props.get("teaser", "") or ""
+    parts = [x for x in [nombre, f"({sci})" if sci else "", teaser] if x]
+    return " ".join(parts).strip()
+
+corpus = [{"species_id": sid, "text": doc_text(props)} for sid, props in species.items()]
+
+# ---------- 10. escribir salidas ----------
+with open(BASE / "corpus.jsonl", "w", encoding="utf-8") as f:
+    for row in corpus:
+        f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+with open(BASE / "pairs_train.jsonl", "w", encoding="utf-8") as f:
+    for row in pairs_train:
+        f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+with open(BASE / "pairs_test.jsonl", "w", encoding="utf-8") as f:
+    for row in pairs_test:
+        f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+with open(BASE / "family.json", "w", encoding="utf-8") as f:
+    json.dump(family_of, f, ensure_ascii=False)
+
+with open(BASE / "genus.json", "w", encoding="utf-8") as f:
+    json.dump(genus_of_species, f, ensure_ascii=False)
+
+with open(BASE / "confusable_ids.json", "w", encoding="utf-8") as f:
+    json.dump({"groups": CONFUSABLE_GROUPS, "flat": sorted(confusable_ids)}, f, ensure_ascii=False, indent=2)
+
+report = {
+    "n_species_total": len(species),
+    "n_species_with_nombres_comunes": sum(1 for p in species.values() if p.get("nombres_comunes")),
+    "n_regional_labels_raw": len(raw_labels),
+    "n_regional_label_pairs_valid": n_regional,
+    "n_regional_label_pairs_skipped_missing_species": skipped_missing_species,
+    "n_pairs_total": len(positives),
+    "n_species_with_pairs": len(all_species_with_pairs),
+    "n_species_train": len(train_species),
+    "n_species_test": len(test_species),
+    "n_pairs_train": len(pairs_train),
+    "n_pairs_test": len(pairs_test),
+    "n_confusable_species": len(confusable_ids),
+    "n_families": len(set(family_of.values())),
+    "split_seed": 1337,
+}
+with open(BASE / "split_report.json", "w", encoding="utf-8") as f:
+    json.dump(report, f, ensure_ascii=False, indent=2)
+
+print(json.dumps(report, ensure_ascii=False, indent=2))

--- a/scripts/embedder-finetune/e5_common.py
+++ b/scripts/embedder-finetune/e5_common.py
@@ -1,0 +1,36 @@
+"""Utilidades compartidas para cargar/encodear con modelos estilo E5
+(mean pooling + normalize + prefijos 'query:'/'passage:').
+Sin sentence-transformers: solo transformers+torch puro para no arriesgar
+el torch CUDA del venv qlora-dpo (ver CLAUDE.md: nunca pip install sin --no-deps).
+"""
+import torch
+import torch.nn.functional as F
+from transformers import AutoTokenizer, AutoModel
+
+
+def load_model(name_or_path, device="cuda", dtype=torch.bfloat16):
+    tok = AutoTokenizer.from_pretrained(name_or_path)
+    model = AutoModel.from_pretrained(name_or_path, torch_dtype=dtype)
+    model.to(device)
+    return tok, model
+
+
+def average_pool(last_hidden_states, attention_mask):
+    mask = attention_mask[..., None].bool()
+    last_hidden = last_hidden_states.masked_fill(~mask, 0.0)
+    return last_hidden.sum(dim=1) / attention_mask.sum(dim=1)[..., None].clamp(min=1)
+
+
+def encode_texts(texts, tok, model, device, prefix, max_length=128, batch_size=32, grad=False):
+    """texts: list[str] SIN prefijo. prefix: 'query: ' o 'passage: '."""
+    all_emb = []
+    ctx = torch.enable_grad() if grad else torch.no_grad()
+    with ctx:
+        for i in range(0, len(texts), batch_size):
+            chunk = [prefix + (t if t else "") for t in texts[i:i + batch_size]]
+            enc = tok(chunk, max_length=max_length, padding=True, truncation=True, return_tensors="pt").to(device)
+            out = model(**enc)
+            emb = average_pool(out.last_hidden_state, enc["attention_mask"])
+            emb = F.normalize(emb, p=2, dim=1)
+            all_emb.append(emb if grad else emb.detach())
+    return torch.cat(all_emb, dim=0)

--- a/scripts/embedder-finetune/eval_embedder.py
+++ b/scripts/embedder-finetune/eval_embedder.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Evalua un modelo E5 (base HF id o path local) sobre pairs_test.jsonl sacado
+del split HONESTO por especie, con corpus.jsonl completo (742 especies)
+como universo de recuperacion. Reporta recall@1, recall@5, MRR global y
+sobre el subconjunto de "confundibles" (papa/papaya/papayuela, passifloras,
+tomate/tomate de arbol, brassica oleracea, arracacha/yuca).
+"""
+import argparse, json, sys
+from pathlib import Path
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).parent))
+from e5_common import load_model, encode_texts
+
+BASE = Path.home() / "embedder-ft"
+
+
+def load_jsonl(p):
+    out = []
+    with open(p, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True, help="HF id o path local")
+    ap.add_argument("--device", default=None)
+    ap.add_argument("--dtype", default="float32", choices=["float32", "bfloat16"])
+    ap.add_argument("--pairs", default=str(BASE / "pairs_test.jsonl"))
+    ap.add_argument("--out", default=None, help="path JSON de salida")
+    ap.add_argument("--tag", default="model")
+    args = ap.parse_args()
+
+    device = args.device or ("cuda" if torch.cuda.is_available() else "cpu")
+    dtype = torch.bfloat16 if args.dtype == "bfloat16" else torch.float32
+
+    corpus_rows = load_jsonl(BASE / "corpus.jsonl")
+    pairs = load_jsonl(args.pairs)
+    confusable = json.loads((BASE / "confusable_ids.json").read_text(encoding="utf-8"))
+    confusable_flat = set(confusable["flat"])
+    # mapa species_id -> nombre de grupo confundible
+    id_to_group = {}
+    for gname, ids in confusable["groups"].items():
+        for sid in ids:
+            id_to_group[sid] = gname
+
+    sid_list = [r["species_id"] for r in corpus_rows]
+    doc_texts = [r["text"] for r in corpus_rows]
+    nombre_by_sid = {}
+    # recuperar nombre_comun de species.jsonl para reporte legible
+    with open(BASE / "species.jsonl", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line in ("LOAD", "SET"):
+                continue
+            d = json.loads(line)
+            nombre_by_sid[d.get("id")] = d.get("nombre_comun", d.get("id"))
+
+    print(f"[eval:{args.tag}] cargando modelo {args.model} en {device} ({args.dtype})", flush=True)
+    tok, model = load_model(args.model, device=device, dtype=dtype)
+    model.eval()
+
+    print(f"[eval:{args.tag}] encodeando corpus ({len(doc_texts)} docs)...", flush=True)
+    doc_emb = encode_texts(doc_texts, tok, model, device, "passage: ", max_length=128, batch_size=32, grad=False)
+
+    queries = [p["query"] for p in pairs]
+    true_sids = [p["species_id"] for p in pairs]
+    print(f"[eval:{args.tag}] encodeando {len(queries)} queries de test...", flush=True)
+    q_emb = encode_texts(queries, tok, model, device, "query: ", max_length=32, batch_size=32, grad=False)
+
+    sim = q_emb @ doc_emb.t()  # [Q, D]
+    ranks = []
+    top1_sid = []
+    for i in range(sim.shape[0]):
+        order = torch.argsort(sim[i], descending=True).tolist()
+        ranked_sids = [sid_list[j] for j in order]
+        true_sid = true_sids[i]
+        rank = ranked_sids.index(true_sid) + 1
+        ranks.append(rank)
+        top1_sid.append(ranked_sids[0])
+
+    def metrics(idxs):
+        if not idxs:
+            return {"n": 0, "recall_at_1": None, "recall_at_5": None, "mrr": None}
+        rs = [ranks[i] for i in idxs]
+        n = len(rs)
+        r1 = sum(1 for r in rs if r == 1) / n
+        r5 = sum(1 for r in rs if r <= 5) / n
+        mrr = sum(1.0 / r for r in rs) / n
+        return {"n": n, "recall_at_1": r1, "recall_at_5": r5, "mrr": mrr}
+
+    all_idx = list(range(len(pairs)))
+    conf_idx = [i for i in all_idx if true_sids[i] in confusable_flat]
+
+    global_metrics = metrics(all_idx)
+    confusable_metrics = metrics(conf_idx)
+
+    by_source = {}
+    for i in all_idx:
+        src = pairs[i].get("source", "?")
+        by_source.setdefault(src, []).append(i)
+    source_metrics = {src: metrics(idxs) for src, idxs in by_source.items()}
+
+    by_group = {}
+    for i in conf_idx:
+        g = id_to_group.get(true_sids[i], "?")
+        by_group.setdefault(g, []).append(i)
+    group_metrics = {g: metrics(idxs) for g, idxs in by_group.items()}
+
+    confusable_details = []
+    for i in conf_idx:
+        confusable_details.append({
+            "query": queries[i],
+            "true_species": true_sids[i],
+            "true_nombre": nombre_by_sid.get(true_sids[i], true_sids[i]),
+            "group": id_to_group.get(true_sids[i], "?"),
+            "rank": ranks[i],
+            "top1_species": top1_sid[i],
+            "top1_nombre": nombre_by_sid.get(top1_sid[i], top1_sid[i]),
+            "correct": ranks[i] == 1,
+        })
+
+    result = {
+        "tag": args.tag,
+        "model": args.model,
+        "n_test_pairs": len(pairs),
+        "n_corpus_docs": len(doc_texts),
+        "global": global_metrics,
+        "confusable": confusable_metrics,
+        "by_source": source_metrics,
+        "by_confusable_group": group_metrics,
+        "confusable_details": confusable_details,
+    }
+
+    print(json.dumps({k: v for k, v in result.items() if k != "confusable_details"}, indent=2, ensure_ascii=False))
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"[eval:{args.tag}] guardado en {args.out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/embedder-finetune/export_onnx.py
+++ b/scripts/embedder-finetune/export_onnx.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Exporta el embedder fine-tuneado a ONNX (mean-pooling + L2-normalize
+incluidos en el grafo) para poder servirlo sin torch/CUDA. Best-effort:
+si algo falla, el HF format (config.json+model.safetensors+tokenizer)
+sigue siendo el artefacto principal y ya se verifico que corre en CPU.
+"""
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers import AutoTokenizer, AutoModel
+
+MODEL_DIR = Path.home() / "qlora-out" / "embedder" / "finetuned"
+OUT_DIR = Path.home() / "qlora-out" / "embedder" / "onnx"
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+class E5Embedder(nn.Module):
+    def __init__(self, base):
+        super().__init__()
+        self.base = base
+
+    def forward(self, input_ids, attention_mask):
+        out = self.base(input_ids=input_ids, attention_mask=attention_mask)
+        last_hidden = out.last_hidden_state
+        mask = attention_mask[..., None].bool()
+        summed = last_hidden.masked_fill(~mask, 0.0).sum(dim=1)
+        counts = attention_mask.sum(dim=1)[..., None].clamp(min=1)
+        pooled = summed / counts
+        return F.normalize(pooled, p=2, dim=1)
+
+
+def main():
+    tok = AutoTokenizer.from_pretrained(MODEL_DIR)
+    base = AutoModel.from_pretrained(MODEL_DIR, dtype=torch.float32)
+    base.eval()
+    model = E5Embedder(base)
+    model.eval()
+
+    sample = tok(["query: papa criolla", "passage: la papa es un tuberculo andino"],
+                 padding=True, truncation=True, max_length=64, return_tensors="pt")
+
+    onnx_path = OUT_DIR / "model.onnx"
+    torch.onnx.export(
+        model,
+        (sample["input_ids"], sample["attention_mask"]),
+        str(onnx_path),
+        input_names=["input_ids", "attention_mask"],
+        output_names=["embedding"],
+        dynamic_axes={
+            "input_ids": {0: "batch", 1: "seq"},
+            "attention_mask": {0: "batch", 1: "seq"},
+            "embedding": {0: "batch"},
+        },
+        opset_version=17,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    print(f"[onnx] exportado a {onnx_path}", flush=True)
+
+    import onnx
+    onnx.checker.check_model(str(onnx_path))
+    print("[onnx] checker.check_model OK", flush=True)
+
+    tok.save_pretrained(OUT_DIR)
+    print(f"[onnx] tokenizer guardado en {OUT_DIR}", flush=True)
+
+    try:
+        import onnxruntime as ort
+        import numpy as np
+        sess = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+        feed = {
+            "input_ids": sample["input_ids"].numpy().astype("int64"),
+            "attention_mask": sample["attention_mask"].numpy().astype("int64"),
+        }
+        result = sess.run(["embedding"], feed)[0]
+        print(f"[onnxruntime] inferencia OK, shape={result.shape}", flush=True)
+        with torch.no_grad():
+            torch_out = model(sample["input_ids"], sample["attention_mask"]).numpy()
+        diff = abs(result - torch_out).max()
+        print(f"[onnxruntime] max abs diff vs torch = {diff:.6f}", flush=True)
+    except ImportError:
+        print("[onnxruntime] no instalado -- se omite verificacion de inferencia end-to-end", flush=True)
+    except Exception as e:
+        print(f"[onnxruntime] fallo verificacion: {e}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/embedder-finetune/results/eval_base.json
+++ b/scripts/embedder-finetune/results/eval_base.json
@@ -1,0 +1,2062 @@
+{
+  "tag": "base",
+  "model": "intfloat/multilingual-e5-large",
+  "n_test_pairs": 621,
+  "n_corpus_docs": 742,
+  "global": {
+    "n": 621,
+    "recall_at_1": 0.31561996779388085,
+    "recall_at_5": 0.4363929146537842,
+    "mrr": 0.3725396284673508
+  },
+  "confusable": {
+    "n": 199,
+    "recall_at_1": 0.2864321608040201,
+    "recall_at_5": 0.4271356783919598,
+    "mrr": 0.3542057851898318
+  },
+  "by_source": {
+    "regional_label": {
+      "n": 68,
+      "recall_at_1": 0.2647058823529412,
+      "recall_at_5": 0.3235294117647059,
+      "mrr": 0.30375602368058935
+    },
+    "nombre_comun": {
+      "n": 100,
+      "recall_at_1": 0.93,
+      "recall_at_5": 0.98,
+      "mrr": 0.9526162790697673
+    },
+    "nombres_comunes": {
+      "n": 453,
+      "recall_at_1": 0.18763796909492272,
+      "recall_at_5": 0.3333333333333333,
+      "mrr": 0.2548125204436382
+    }
+  },
+  "by_confusable_group": {
+    "arracacha_vs_yuca": {
+      "n": 36,
+      "recall_at_1": 0.3055555555555556,
+      "recall_at_5": 0.4166666666666667,
+      "mrr": 0.35646554639292305
+    },
+    "passifloras": {
+      "n": 52,
+      "recall_at_1": 0.23076923076923078,
+      "recall_at_5": 0.3076923076923077,
+      "mrr": 0.2632212190508984
+    },
+    "papa_vs_papaya_vs_papayuela": {
+      "n": 44,
+      "recall_at_1": 0.2727272727272727,
+      "recall_at_5": 0.4318181818181818,
+      "mrr": 0.3524280801244059
+    },
+    "tomate_vs_tomate_de_arbol": {
+      "n": 39,
+      "recall_at_1": 0.2564102564102564,
+      "recall_at_5": 0.46153846153846156,
+      "mrr": 0.36202003509860337
+    },
+    "brassica_oleracea": {
+      "n": 28,
+      "recall_at_1": 0.42857142857142855,
+      "recall_at_5": 0.6071428571428571,
+      "mrr": 0.5121811177737565
+    }
+  },
+  "confusable_details": [
+    {
+      "query": "yuca_brava",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "manihot_esculenta",
+      "top1_nombre": "Yuca brava amazónica",
+      "correct": true
+    },
+    {
+      "query": "taxo",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 502,
+      "top1_species": "theobroma_gileri",
+      "top1_nombre": "Bacao",
+      "correct": false
+    },
+    {
+      "query": "chaucha",
+      "true_species": "solanum_phureja",
+      "true_nombre": "Papa criolla",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 508,
+      "top1_species": "cyclanthera_pedata",
+      "top1_nombre": "Achocha",
+      "correct": false
+    },
+    {
+      "query": "chupita",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 728,
+      "top1_species": "tagetes_minuta",
+      "top1_nombre": "Chinchilla",
+      "correct": false
+    },
+    {
+      "query": "taxo",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 645,
+      "top1_species": "theobroma_gileri",
+      "top1_nombre": "Bacao",
+      "correct": false
+    },
+    {
+      "query": "cholupa",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 319,
+      "top1_species": "passiflora_edulis_morada",
+      "top1_nombre": "Gulupa",
+      "correct": false
+    },
+    {
+      "query": "granadilla de fraile",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_maliformis",
+      "top1_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "correct": true
+    },
+    {
+      "query": "curuba de castilla",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_tripartita_mollissima",
+      "top1_nombre": "Curuba de Castilla",
+      "correct": true
+    },
+    {
+      "query": "tacso",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 662,
+      "top1_species": "zanthoxylum_rhoifolium",
+      "top1_nombre": "Tachuelo",
+      "correct": false
+    },
+    {
+      "query": "curuba india",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 636,
+      "top1_species": "passiflora_tripartita_mollissima",
+      "top1_nombre": "Curuba de Castilla",
+      "correct": false
+    },
+    {
+      "query": "parcha",
+      "true_species": "passiflora_edulis_flavicarpa",
+      "true_nombre": "Maracuyá",
+      "group": "passifloras",
+      "rank": 197,
+      "top1_species": "passiflora_quadrangularis",
+      "top1_nombre": "Badea",
+      "correct": false
+    },
+    {
+      "query": "gulupa morada",
+      "true_species": "passiflora_edulis_morada",
+      "true_nombre": "Gulupa",
+      "group": "passifloras",
+      "rank": 16,
+      "top1_species": "lactuca_sativa_roble_morada",
+      "top1_nombre": "Lechuga hoja de roble morada",
+      "correct": false
+    },
+    {
+      "query": "tamarillo",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 6,
+      "top1_species": "talisia_olivaeformis",
+      "top1_nombre": "Mamoncillo",
+      "correct": false
+    },
+    {
+      "query": "tomate de palo",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 10,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "zanahoria blanca",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "arracacia_xanthorrhiza",
+      "top1_nombre": "Arracacha / Zanahoria blanca",
+      "correct": true
+    },
+    {
+      "query": "apio criollo",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 523,
+      "top1_species": "apium_graveolens",
+      "top1_nombre": "Apio",
+      "correct": false
+    },
+    {
+      "query": "racacha",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "arracacia_xanthorrhiza",
+      "top1_nombre": "Arracacha / Zanahoria blanca",
+      "correct": true
+    },
+    {
+      "query": "mandioca",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "manihot_esculenta",
+      "top1_nombre": "Yuca brava amazónica",
+      "correct": true
+    },
+    {
+      "query": "casabe (planta)",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 525,
+      "top1_species": "chusquea_tessellata",
+      "top1_nombre": "Chusque",
+      "correct": false
+    },
+    {
+      "query": "guacamota",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 50,
+      "top1_species": "guazuma_ulmifolia",
+      "top1_nombre": "Guácimo",
+      "correct": false
+    },
+    {
+      "query": "papayo",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 2,
+      "top1_species": "vasconcellea_pubescens",
+      "top1_nombre": "Papayuela / Papayo de monte",
+      "correct": false
+    },
+    {
+      "query": "mamon (papaya)",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 110,
+      "top1_species": "melicoccus_bijugatus",
+      "top1_nombre": "Mamón",
+      "correct": false
+    },
+    {
+      "query": "casabe",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 444,
+      "top1_species": "quararibea_cordata",
+      "top1_nombre": "Zapote",
+      "correct": false
+    },
+    {
+      "query": "yuca brava",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "manihot_esculenta",
+      "top1_nombre": "Yuca brava amazónica",
+      "correct": true
+    },
+    {
+      "query": "parchita",
+      "true_species": "passiflora_edulis_flavicarpa",
+      "true_nombre": "Maracuyá",
+      "group": "passifloras",
+      "rank": 173,
+      "top1_species": "passiflora_quadrangularis",
+      "top1_nombre": "Badea",
+      "correct": false
+    },
+    {
+      "query": "chupitá",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 694,
+      "top1_species": "chusquea_tessellata",
+      "top1_nombre": "Chusque",
+      "correct": false
+    },
+    {
+      "query": "papa criolla",
+      "true_species": "solanum_phureja",
+      "true_nombre": "Papa criolla",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_phureja",
+      "top1_nombre": "Papa criolla",
+      "correct": true
+    },
+    {
+      "query": "gulupa",
+      "true_species": "passiflora_edulis_morada",
+      "true_nombre": "Gulupa",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_edulis_morada",
+      "top1_nombre": "Gulupa",
+      "correct": true
+    },
+    {
+      "query": "granadilla",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 3,
+      "top1_species": "passiflora_maliformis",
+      "top1_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "correct": false
+    },
+    {
+      "query": "Kale rizado verde",
+      "true_species": "brassica_oleracea_acephala_curly",
+      "true_nombre": "Kale rizado verde",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_acephala_curly",
+      "top1_nombre": "Kale rizado verde",
+      "correct": true
+    },
+    {
+      "query": "Kale toscano / Cavolo nero",
+      "true_species": "brassica_oleracea_acephala_lacinato",
+      "true_nombre": "Kale toscano / Cavolo nero",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_acephala_lacinato",
+      "top1_nombre": "Kale toscano / Cavolo nero",
+      "correct": true
+    },
+    {
+      "query": "Kale morado / Red Russian",
+      "true_species": "brassica_oleracea_acephala_red_russian",
+      "true_nombre": "Kale morado / Red Russian",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_acephala_red_russian",
+      "top1_nombre": "Kale morado / Red Russian",
+      "correct": true
+    },
+    {
+      "query": "maracuyá amarillo",
+      "true_species": "passiflora_edulis_flavicarpa",
+      "true_nombre": "Maracuyá",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_edulis_flavicarpa",
+      "top1_nombre": "Maracuyá",
+      "correct": true
+    },
+    {
+      "query": "Maracuyá",
+      "true_species": "passiflora_edulis_flavicarpa",
+      "true_nombre": "Maracuyá",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_edulis_flavicarpa",
+      "top1_nombre": "Maracuyá",
+      "correct": true
+    },
+    {
+      "query": "frutilla",
+      "true_species": "solanum_lycopersicum_sungold",
+      "true_nombre": "Tomate cherry amarillo / Sungold",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 479,
+      "top1_species": "espeletia_barclayana",
+      "top1_nombre": "Frailejón motoso",
+      "correct": false
+    },
+    {
+      "query": "Tomate cherry amarillo / Sungold",
+      "true_species": "solanum_lycopersicum_sungold",
+      "true_nombre": "Tomate cherry amarillo / Sungold",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_lycopersicum_sungold",
+      "top1_nombre": "Tomate cherry amarillo / Sungold",
+      "correct": true
+    },
+    {
+      "query": "tomatillo",
+      "true_species": "solanum_lycopersicum_cerasiforme_uvalina",
+      "true_nombre": "Tomate cherry uvalina / Grape",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 12,
+      "top1_species": "physalis_philadelphica",
+      "top1_nombre": "Tomatillo verde",
+      "correct": false
+    },
+    {
+      "query": "Tomate cherry uvalina / Grape",
+      "true_species": "solanum_lycopersicum_cerasiforme_uvalina",
+      "true_nombre": "Tomate cherry uvalina / Grape",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_lycopersicum_cerasiforme_uvalina",
+      "top1_nombre": "Tomate cherry uvalina / Grape",
+      "correct": true
+    },
+    {
+      "query": "Col rizada / Kale",
+      "true_species": "brassica_oleracea_var_acephala",
+      "true_nombre": "Col rizada / Kale",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_var_acephala",
+      "top1_nombre": "Col rizada / Kale",
+      "correct": true
+    },
+    {
+      "query": "Papayuela endémica",
+      "true_species": "vasconcellea_goudotiana",
+      "true_nombre": "Papayuela endémica",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "vasconcellea_goudotiana",
+      "top1_nombre": "Papayuela endémica",
+      "correct": true
+    },
+    {
+      "query": "Papa Argentina",
+      "true_species": "solanum_tuberosum_argentina",
+      "true_nombre": "Papa Argentina",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum_argentina",
+      "top1_nombre": "Papa Argentina",
+      "correct": true
+    },
+    {
+      "query": "granada de castilla",
+      "true_species": "passiflora_edulis_morada",
+      "true_nombre": "Gulupa",
+      "group": "passifloras",
+      "rank": 399,
+      "top1_species": "passiflora_maliformis",
+      "top1_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "correct": false
+    },
+    {
+      "query": "granadilla",
+      "true_species": "passiflora_edulis_morada",
+      "true_nombre": "Gulupa",
+      "group": "passifloras",
+      "rank": 394,
+      "top1_species": "passiflora_maliformis",
+      "top1_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "correct": false
+    },
+    {
+      "query": "maracuyá",
+      "true_species": "passiflora_edulis_morada",
+      "true_nombre": "Gulupa",
+      "group": "passifloras",
+      "rank": 467,
+      "top1_species": "passiflora_edulis_flavicarpa",
+      "top1_nombre": "Maracuyá",
+      "correct": false
+    },
+    {
+      "query": "granada china",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 23,
+      "top1_species": "passiflora_tarminiana",
+      "top1_nombre": "Granadilla común / Granadilla de China",
+      "correct": false
+    },
+    {
+      "query": "cranix",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 445,
+      "top1_species": "hedyosmum_bonplandianum",
+      "top1_nombre": "Granizo",
+      "correct": false
+    },
+    {
+      "query": "granada-china",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 26,
+      "top1_species": "passiflora_tarminiana",
+      "top1_nombre": "Granadilla común / Granadilla de China",
+      "correct": false
+    },
+    {
+      "query": "granadilla de china",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 3,
+      "top1_species": "passiflora_tarminiana",
+      "top1_nombre": "Granadilla común / Granadilla de China",
+      "correct": false
+    },
+    {
+      "query": "parchita amarilla",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 394,
+      "top1_species": "cucurbita_moschata",
+      "top1_nombre": "Ahuyama Amarilla",
+      "correct": false
+    },
+    {
+      "query": "ceibey",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 504,
+      "top1_species": "ceiba_pentandra",
+      "top1_nombre": "Ceiba algodón",
+      "correct": false
+    },
+    {
+      "query": "chinola",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 264,
+      "top1_species": "jacaranda_copaia",
+      "top1_nombre": "Chingalé",
+      "correct": false
+    },
+    {
+      "query": "curuba",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 60,
+      "top1_species": "passiflora_tripartita_mollissima",
+      "top1_nombre": "Curuba de Castilla",
+      "correct": false
+    },
+    {
+      "query": "flor de las cinco lagas",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 114,
+      "top1_species": "cattleya_trianae",
+      "top1_nombre": "Flor de Mayo",
+      "correct": false
+    },
+    {
+      "query": "maracuyá",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 237,
+      "top1_species": "passiflora_edulis_flavicarpa",
+      "top1_nombre": "Maracuyá",
+      "correct": false
+    },
+    {
+      "query": "parcha",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 415,
+      "top1_species": "passiflora_quadrangularis",
+      "top1_nombre": "Badea",
+      "correct": false
+    },
+    {
+      "query": "parchita",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 398,
+      "top1_species": "passiflora_quadrangularis",
+      "top1_nombre": "Badea",
+      "correct": false
+    },
+    {
+      "query": "Gulupa amarilla colombiana",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_edulis_amarilla_colombia",
+      "top1_nombre": "Gulupa amarilla colombiana",
+      "correct": true
+    },
+    {
+      "query": "lima tomate",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 30,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "tomate",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 5,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "tomate extranjero",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 2,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "tomate de palo",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 6,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "tomate de árbol",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum_naranja",
+      "top1_nombre": "Tomate de árbol naranja",
+      "correct": true
+    },
+    {
+      "query": "tomato de arbol",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 2,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": false
+    },
+    {
+      "query": "tamarillo",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 123,
+      "top1_species": "talisia_olivaeformis",
+      "top1_nombre": "Mamoncillo",
+      "correct": false
+    },
+    {
+      "query": "tomate serrano",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 5,
+      "top1_species": "solanum_lycopersicum_cerasiforme",
+      "top1_nombre": "Tomate cherry estándar",
+      "correct": false
+    },
+    {
+      "query": "Tomate de árbol naranja",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum_naranja",
+      "top1_nombre": "Tomate de árbol naranja",
+      "correct": true
+    },
+    {
+      "query": "lima tomate",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 63,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "tomate",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 7,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "tomate extranjero",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 5,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "tomate de palo",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 16,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "tomate de árbol",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 3,
+      "top1_species": "solanum_betaceum_naranja",
+      "top1_nombre": "Tomate de árbol naranja",
+      "correct": false
+    },
+    {
+      "query": "tomato de arbol",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 3,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": false
+    },
+    {
+      "query": "tamarillo",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 290,
+      "top1_species": "talisia_olivaeformis",
+      "top1_nombre": "Mamoncillo",
+      "correct": false
+    },
+    {
+      "query": "tomate serrano",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 6,
+      "top1_species": "solanum_lycopersicum_cerasiforme",
+      "top1_nombre": "Tomate cherry estándar",
+      "correct": false
+    },
+    {
+      "query": "Tomate de árbol morado",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum_morado",
+      "top1_nombre": "Tomate de árbol morado",
+      "correct": true
+    },
+    {
+      "query": "frutilla",
+      "true_species": "solanum_lycopersicum",
+      "true_nombre": "Tomate chonto",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 201,
+      "top1_species": "espeletia_barclayana",
+      "top1_nombre": "Frailejón motoso",
+      "correct": false
+    },
+    {
+      "query": "Tomate chonto",
+      "true_species": "solanum_lycopersicum",
+      "true_nombre": "Tomate chonto",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": true
+    },
+    {
+      "query": "apio",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 116,
+      "top1_species": "apium_graveolens",
+      "top1_nombre": "Apio",
+      "correct": false
+    },
+    {
+      "query": "arracacha",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 2,
+      "top1_species": "arracacia_xanthorrhiza",
+      "top1_nombre": "Arracacha / Zanahoria blanca",
+      "correct": false
+    },
+    {
+      "query": "arracache",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 2,
+      "top1_species": "arracacia_xanthorrhiza",
+      "top1_nombre": "Arracacha / Zanahoria blanca",
+      "correct": false
+    },
+    {
+      "query": "maya",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 490,
+      "top1_species": "cnidoscolus_aconitifolius",
+      "top1_nombre": "Chaya",
+      "correct": false
+    },
+    {
+      "query": "sacha zanahoria",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 151,
+      "top1_species": "plukenetia_volubilis",
+      "top1_nombre": "Sacha inchi",
+      "correct": false
+    },
+    {
+      "query": "yurak zanahoria",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 252,
+      "top1_species": "solanum_nigrum",
+      "top1_nombre": "Yerbamora",
+      "correct": false
+    },
+    {
+      "query": "zanahoria",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 138,
+      "top1_species": "daucus_carota_subsp_sativus",
+      "top1_nombre": "Zanahoria",
+      "correct": false
+    },
+    {
+      "query": "zanahoria blanca",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 44,
+      "top1_species": "arracacia_xanthorrhiza",
+      "top1_nombre": "Arracacha / Zanahoria blanca",
+      "correct": false
+    },
+    {
+      "query": "Arracacha amarilla",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "arracacia_xanthorrhiza_amarilla",
+      "top1_nombre": "Arracacha amarilla",
+      "correct": true
+    },
+    {
+      "query": "frutilla",
+      "true_species": "solanum_lycopersicum_cerasiforme",
+      "true_nombre": "Tomate cherry estándar",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 550,
+      "top1_species": "espeletia_barclayana",
+      "top1_nombre": "Frailejón motoso",
+      "correct": false
+    },
+    {
+      "query": "Tomate cherry estándar",
+      "true_species": "solanum_lycopersicum_cerasiforme",
+      "true_nombre": "Tomate cherry estándar",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_lycopersicum_cerasiforme",
+      "top1_nombre": "Tomate cherry estándar",
+      "correct": true
+    },
+    {
+      "query": "frutilla",
+      "true_species": "solanum_lycopersicum_san_marzano",
+      "true_nombre": "Tomate San Marzano",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 742,
+      "top1_species": "espeletia_barclayana",
+      "top1_nombre": "Frailejón motoso",
+      "correct": false
+    },
+    {
+      "query": "Tomate San Marzano",
+      "true_species": "solanum_lycopersicum_san_marzano",
+      "true_nombre": "Tomate San Marzano",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_lycopersicum_san_marzano",
+      "top1_nombre": "Tomate San Marzano",
+      "correct": true
+    },
+    {
+      "query": "Repollo morado",
+      "true_species": "brassica_oleracea_capitata_rubra",
+      "true_nombre": "Repollo morado",
+      "group": "brassica_oleracea",
+      "rank": 6,
+      "top1_species": "rhizophora_mangle",
+      "top1_nombre": "mangle rojo",
+      "correct": false
+    },
+    {
+      "query": "chinpalu",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 530,
+      "top1_species": "jacaranda_copaia",
+      "top1_nombre": "Chingalé",
+      "correct": false
+    },
+    {
+      "query": "papa",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 6,
+      "top1_species": "solanum_tuberosum",
+      "top1_nombre": "Papa parda pastusa",
+      "correct": false
+    },
+    {
+      "query": "papa leona",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 10,
+      "top1_species": "solanum_tuberosum_diacol_capiro",
+      "top1_nombre": "Papa Diacol Capiro",
+      "correct": false
+    },
+    {
+      "query": "papa pulos",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 130,
+      "top1_species": "solanum_tuberosum",
+      "top1_nombre": "Papa parda pastusa",
+      "correct": false
+    },
+    {
+      "query": "papa uvilla",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 28,
+      "top1_species": "pourouma_cecropiifolia_silvestre",
+      "top1_nombre": "Uvilla silvestre",
+      "correct": false
+    },
+    {
+      "query": "patata",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 113,
+      "top1_species": "ipomoea_batatas",
+      "top1_nombre": "Batata / Camote",
+      "correct": false
+    },
+    {
+      "query": "potato",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 286,
+      "top1_species": "ipomoea_batatas_morada",
+      "top1_nombre": "Batata morada",
+      "correct": false
+    },
+    {
+      "query": "sacha papa",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 31,
+      "top1_species": "plukenetia_volubilis",
+      "top1_nombre": "Sacha inchi",
+      "correct": false
+    },
+    {
+      "query": "Papa Sabanera",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum_sabanera",
+      "top1_nombre": "Papa Sabanera",
+      "correct": true
+    },
+    {
+      "query": "curuba",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 570,
+      "top1_species": "passiflora_tripartita_mollissima",
+      "top1_nombre": "Curuba de Castilla",
+      "correct": false
+    },
+    {
+      "query": "granadilla de bueso",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 4,
+      "top1_species": "hedyosmum_bonplandianum",
+      "top1_nombre": "Granizo",
+      "correct": false
+    },
+    {
+      "query": "granadilla de hueso",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 2,
+      "top1_species": "hedyosmum_bonplandianum",
+      "top1_nombre": "Granizo",
+      "correct": false
+    },
+    {
+      "query": "granadilla de piedra",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_maliformis",
+      "top1_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "correct": true
+    },
+    {
+      "query": "guerito",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 256,
+      "top1_species": "sechium_edule",
+      "top1_nombre": "Guatila / Chayote",
+      "correct": false
+    },
+    {
+      "query": "parcha cimarrona",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 153,
+      "top1_species": "loricaria_complanata",
+      "top1_nombre": "Escobilla paramuna",
+      "correct": false
+    },
+    {
+      "query": "Granadilla de fraile / Maracuyá silvestre",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_maliformis",
+      "top1_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "correct": true
+    },
+    {
+      "query": "gullán",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 240,
+      "top1_species": "hedyosmum_bonplandianum",
+      "top1_nombre": "Granizo",
+      "correct": false
+    },
+    {
+      "query": "taksu",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 515,
+      "top1_species": "zanthoxylum_rhoifolium",
+      "top1_nombre": "Tachuelo",
+      "correct": false
+    },
+    {
+      "query": "curuba ecuatoriana",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 426,
+      "top1_species": "carapa_guianensis",
+      "top1_nombre": "andiroba",
+      "correct": false
+    },
+    {
+      "query": "curuba quiteña",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 579,
+      "top1_species": "chusquea_tessellata",
+      "top1_nombre": "Chusque",
+      "correct": false
+    },
+    {
+      "query": "tacso amarillo",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 586,
+      "top1_species": "zanthoxylum_rhoifolium",
+      "top1_nombre": "Tachuelo",
+      "correct": false
+    },
+    {
+      "query": "Granadilla común / Granadilla de China",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_tarminiana",
+      "top1_nombre": "Granadilla común / Granadilla de China",
+      "correct": true
+    },
+    {
+      "query": "col",
+      "true_species": "brassica_oleracea_var_capitata",
+      "true_nombre": "Repollo",
+      "group": "brassica_oleracea",
+      "rank": 34,
+      "top1_species": "brassica_oleracea_var_acephala",
+      "top1_nombre": "Col rizada / Kale",
+      "correct": false
+    },
+    {
+      "query": "col repollo",
+      "true_species": "brassica_oleracea_var_capitata",
+      "true_nombre": "Repollo",
+      "group": "brassica_oleracea",
+      "rank": 10,
+      "top1_species": "bejaria_resinosa",
+      "top1_nombre": "Pegamosco",
+      "correct": false
+    },
+    {
+      "query": "lombarda",
+      "true_species": "brassica_oleracea_var_capitata",
+      "true_nombre": "Repollo",
+      "group": "brassica_oleracea",
+      "rank": 219,
+      "top1_species": "lonchocarpus_utilis",
+      "top1_nombre": "Barbasco",
+      "correct": false
+    },
+    {
+      "query": "repollo",
+      "true_species": "brassica_oleracea_var_capitata",
+      "true_nombre": "Repollo",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_var_capitata",
+      "top1_nombre": "Repollo",
+      "correct": true
+    },
+    {
+      "query": "andigena",
+      "true_species": "solanum_tuberosum_carrera_negra",
+      "true_nombre": "Papa Negra Carrera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 59,
+      "top1_species": "carapa_guianensis",
+      "top1_nombre": "andiroba",
+      "correct": false
+    },
+    {
+      "query": "papa amarilla",
+      "true_species": "solanum_tuberosum_carrera_negra",
+      "true_nombre": "Papa Negra Carrera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 17,
+      "top1_species": "arracacia_xanthorrhiza_amarilla",
+      "top1_nombre": "Arracacha amarilla",
+      "correct": false
+    },
+    {
+      "query": "Papa Negra Carrera",
+      "true_species": "solanum_tuberosum_carrera_negra",
+      "true_nombre": "Papa Negra Carrera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum_carrera_negra",
+      "top1_nombre": "Papa Negra Carrera",
+      "correct": true
+    },
+    {
+      "query": "airo bai a’so",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 397,
+      "top1_species": "theobroma_gileri",
+      "top1_nombre": "Bacao",
+      "correct": false
+    },
+    {
+      "query": "apach mama",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 77,
+      "top1_species": "puma_concolor",
+      "top1_nombre": "Puma",
+      "correct": false
+    },
+    {
+      "query": "api lumu",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 227,
+      "top1_species": "capsicum_annuum_generic",
+      "top1_nombre": "Ají",
+      "correct": false
+    },
+    {
+      "query": "arajuno lumu",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 326,
+      "top1_species": "miconia_theizans",
+      "top1_nombre": "tuno",
+      "correct": false
+    },
+    {
+      "query": "auka lumu",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 214,
+      "top1_species": "blighia_sapida",
+      "top1_nombre": "Ackee",
+      "correct": false
+    },
+    {
+      "query": "awa llakta lumu",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 219,
+      "top1_species": "moringa_oleifera",
+      "top1_nombre": "Moringa",
+      "correct": false
+    },
+    {
+      "query": "aypi",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 335,
+      "top1_species": "capsicum_frutescens",
+      "top1_nombre": "Ají",
+      "correct": false
+    },
+    {
+      "query": "a’so",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 439,
+      "top1_species": "glycine_max",
+      "top1_nombre": "Soya",
+      "correct": false
+    },
+    {
+      "query": "Yuca brava amazónica",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "manihot_esculenta",
+      "top1_nombre": "Yuca brava amazónica",
+      "correct": true
+    },
+    {
+      "query": "Papa Pastusa Suprema",
+      "true_species": "solanum_tuberosum_pastusa_suprema",
+      "true_nombre": "Papa Pastusa Suprema",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum_pastusa_suprema",
+      "top1_nombre": "Papa Pastusa Suprema",
+      "correct": true
+    },
+    {
+      "query": "Papa Diacol Capiro",
+      "true_species": "solanum_tuberosum_diacol_capiro",
+      "true_nombre": "Papa Diacol Capiro",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum_diacol_capiro",
+      "top1_nombre": "Papa Diacol Capiro",
+      "correct": true
+    },
+    {
+      "query": "col",
+      "true_species": "brassica_oleracea_capitata_alba",
+      "true_nombre": "Repollo blanco",
+      "group": "brassica_oleracea",
+      "rank": 94,
+      "top1_species": "brassica_oleracea_var_acephala",
+      "top1_nombre": "Col rizada / Kale",
+      "correct": false
+    },
+    {
+      "query": "col repollo",
+      "true_species": "brassica_oleracea_capitata_alba",
+      "true_nombre": "Repollo blanco",
+      "group": "brassica_oleracea",
+      "rank": 27,
+      "top1_species": "bejaria_resinosa",
+      "top1_nombre": "Pegamosco",
+      "correct": false
+    },
+    {
+      "query": "lombarda",
+      "true_species": "brassica_oleracea_capitata_alba",
+      "true_nombre": "Repollo blanco",
+      "group": "brassica_oleracea",
+      "rank": 145,
+      "top1_species": "lonchocarpus_utilis",
+      "top1_nombre": "Barbasco",
+      "correct": false
+    },
+    {
+      "query": "repollo",
+      "true_species": "brassica_oleracea_capitata_alba",
+      "true_nombre": "Repollo blanco",
+      "group": "brassica_oleracea",
+      "rank": 5,
+      "top1_species": "brassica_oleracea_var_capitata",
+      "top1_nombre": "Repollo",
+      "correct": false
+    },
+    {
+      "query": "Repollo blanco",
+      "true_species": "brassica_oleracea_capitata_alba",
+      "true_nombre": "Repollo blanco",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_capitata_alba",
+      "top1_nombre": "Repollo blanco",
+      "correct": true
+    },
+    {
+      "query": "col de milán",
+      "true_species": "brassica_oleracea_sabauda",
+      "true_nombre": "Repollo rizado / Savoy",
+      "group": "brassica_oleracea",
+      "rank": 589,
+      "top1_species": "mentha_pulegium",
+      "top1_nombre": "Poleo",
+      "correct": false
+    },
+    {
+      "query": "col de saboya",
+      "true_species": "brassica_oleracea_sabauda",
+      "true_nombre": "Repollo rizado / Savoy",
+      "group": "brassica_oleracea",
+      "rank": 2,
+      "top1_species": "holcus_lanatus",
+      "top1_nombre": "Saboya",
+      "correct": false
+    },
+    {
+      "query": "col lombarda",
+      "true_species": "brassica_oleracea_sabauda",
+      "true_nombre": "Repollo rizado / Savoy",
+      "group": "brassica_oleracea",
+      "rank": 344,
+      "top1_species": "lonchocarpus_utilis",
+      "top1_nombre": "Barbasco",
+      "correct": false
+    },
+    {
+      "query": "Repollo rizado / Savoy",
+      "true_species": "brassica_oleracea_sabauda",
+      "true_nombre": "Repollo rizado / Savoy",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_sabauda",
+      "top1_nombre": "Repollo rizado / Savoy",
+      "correct": true
+    },
+    {
+      "query": "gullán",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 416,
+      "top1_species": "hedyosmum_bonplandianum",
+      "top1_nombre": "Granizo",
+      "correct": false
+    },
+    {
+      "query": "taksu",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 466,
+      "top1_species": "zanthoxylum_rhoifolium",
+      "top1_nombre": "Tachuelo",
+      "correct": false
+    },
+    {
+      "query": "taxo cultivado",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 281,
+      "top1_species": "theobroma_gileri",
+      "top1_nombre": "Bacao",
+      "correct": false
+    },
+    {
+      "query": "taxo de castilla",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_tripartita_mollissima",
+      "top1_nombre": "Curuba de Castilla",
+      "correct": true
+    },
+    {
+      "query": "taxo silvestre",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 685,
+      "top1_species": "uva_bifera",
+      "top1_nombre": "Tilo / Tilo silvestre",
+      "correct": false
+    },
+    {
+      "query": "lima tomate",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 46,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "tomate",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 7,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "tomate extranjero",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 10,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": false
+    },
+    {
+      "query": "tomate de árbol",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 2,
+      "top1_species": "solanum_betaceum_naranja",
+      "top1_nombre": "Tomate de árbol naranja",
+      "correct": false
+    },
+    {
+      "query": "tomato de arbol",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": true
+    },
+    {
+      "query": "tomate serrano",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 8,
+      "top1_species": "solanum_lycopersicum_cerasiforme",
+      "top1_nombre": "Tomate cherry estándar",
+      "correct": false
+    },
+    {
+      "query": "Tomate de árbol / Tamarillo",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": true
+    },
+    {
+      "query": "chinpalu",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 81,
+      "top1_species": "jacaranda_copaia",
+      "top1_nombre": "Chingalé",
+      "correct": false
+    },
+    {
+      "query": "papa",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum",
+      "top1_nombre": "Papa parda pastusa",
+      "correct": true
+    },
+    {
+      "query": "papa leona",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 2,
+      "top1_species": "solanum_tuberosum_diacol_capiro",
+      "top1_nombre": "Papa Diacol Capiro",
+      "correct": false
+    },
+    {
+      "query": "papa pulos",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum",
+      "top1_nombre": "Papa parda pastusa",
+      "correct": true
+    },
+    {
+      "query": "papa uvilla",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 2,
+      "top1_species": "pourouma_cecropiifolia_silvestre",
+      "top1_nombre": "Uvilla silvestre",
+      "correct": false
+    },
+    {
+      "query": "patata",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 4,
+      "top1_species": "ipomoea_batatas",
+      "top1_nombre": "Batata / Camote",
+      "correct": false
+    },
+    {
+      "query": "potato",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 20,
+      "top1_species": "ipomoea_batatas_morada",
+      "top1_nombre": "Batata morada",
+      "correct": false
+    },
+    {
+      "query": "sacha papa",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 2,
+      "top1_species": "plukenetia_volubilis",
+      "top1_nombre": "Sacha inchi",
+      "correct": false
+    },
+    {
+      "query": "Papa parda pastusa",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum",
+      "top1_nombre": "Papa parda pastusa",
+      "correct": true
+    },
+    {
+      "query": "badea",
+      "true_species": "passiflora_quadrangularis",
+      "true_nombre": "Badea",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_quadrangularis",
+      "top1_nombre": "Badea",
+      "correct": true
+    },
+    {
+      "query": "granadilla",
+      "true_species": "passiflora_quadrangularis",
+      "true_nombre": "Badea",
+      "group": "passifloras",
+      "rank": 74,
+      "top1_species": "passiflora_maliformis",
+      "top1_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "correct": false
+    },
+    {
+      "query": "granadilla real",
+      "true_species": "passiflora_quadrangularis",
+      "true_nombre": "Badea",
+      "group": "passifloras",
+      "rank": 159,
+      "top1_species": "passiflora_tarminiana",
+      "top1_nombre": "Granadilla común / Granadilla de China",
+      "correct": false
+    },
+    {
+      "query": "brecolera",
+      "true_species": "brassica_oleracea_italica",
+      "true_nombre": "Brócoli",
+      "group": "brassica_oleracea",
+      "rank": 6,
+      "top1_species": "espeletia_barclayana",
+      "top1_nombre": "Frailejón motoso",
+      "correct": false
+    },
+    {
+      "query": "brécol",
+      "true_species": "brassica_oleracea_italica",
+      "true_nombre": "Brócoli",
+      "group": "brassica_oleracea",
+      "rank": 3,
+      "top1_species": "lonchocarpus_utilis",
+      "top1_nombre": "Barbasco",
+      "correct": false
+    },
+    {
+      "query": "brócoli",
+      "true_species": "brassica_oleracea_italica",
+      "true_nombre": "Brócoli",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_italica",
+      "top1_nombre": "Brócoli",
+      "correct": true
+    },
+    {
+      "query": "coliflor",
+      "true_species": "brassica_oleracea_botrytis",
+      "true_nombre": "Coliflor",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_botrytis",
+      "top1_nombre": "Coliflor",
+      "correct": true
+    },
+    {
+      "query": "Yuca de árbol / Caucho de Ceará",
+      "true_species": "manihot_glaziovii",
+      "true_nombre": "Yuca de árbol / Caucho de Ceará",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "manihot_glaziovii",
+      "top1_nombre": "Yuca de árbol / Caucho de Ceará",
+      "correct": true
+    },
+    {
+      "query": "Pasionaria medicinal",
+      "true_species": "passiflora_incarnata",
+      "true_nombre": "Pasionaria medicinal",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_incarnata",
+      "top1_nombre": "Pasionaria medicinal",
+      "correct": true
+    },
+    {
+      "query": "apio",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 381,
+      "top1_species": "apium_graveolens",
+      "top1_nombre": "Apio",
+      "correct": false
+    },
+    {
+      "query": "arracacha",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "arracacia_xanthorrhiza",
+      "top1_nombre": "Arracacha / Zanahoria blanca",
+      "correct": true
+    },
+    {
+      "query": "arracache",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "arracacia_xanthorrhiza",
+      "top1_nombre": "Arracacha / Zanahoria blanca",
+      "correct": true
+    },
+    {
+      "query": "maya",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 268,
+      "top1_species": "cnidoscolus_aconitifolius",
+      "top1_nombre": "Chaya",
+      "correct": false
+    },
+    {
+      "query": "sacha zanahoria",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 5,
+      "top1_species": "plukenetia_volubilis",
+      "top1_nombre": "Sacha inchi",
+      "correct": false
+    },
+    {
+      "query": "yurak zanahoria",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 86,
+      "top1_species": "solanum_nigrum",
+      "top1_nombre": "Yerbamora",
+      "correct": false
+    },
+    {
+      "query": "zanahoria",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 2,
+      "top1_species": "daucus_carota_subsp_sativus",
+      "top1_nombre": "Zanahoria",
+      "correct": false
+    },
+    {
+      "query": "Arracacha / Zanahoria blanca",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "arracacia_xanthorrhiza",
+      "top1_nombre": "Arracacha / Zanahoria blanca",
+      "correct": true
+    },
+    {
+      "query": "chamburo",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 560,
+      "top1_species": "astrocaryum_chambira",
+      "top1_nombre": "Chambira",
+      "correct": false
+    },
+    {
+      "query": "chanpuru",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 611,
+      "top1_species": "curatella_americana",
+      "top1_nombre": "chaparro",
+      "correct": false
+    },
+    {
+      "query": "chiblacán",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 718,
+      "top1_species": "loricaria_complanata",
+      "top1_nombre": "Escobilla paramuna",
+      "correct": false
+    },
+    {
+      "query": "chihualcán",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 594,
+      "top1_species": "baccharis_macrantha",
+      "top1_nombre": "chilco",
+      "correct": false
+    },
+    {
+      "query": "jigacho",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 603,
+      "top1_species": "nectandra_acutifolia",
+      "top1_nombre": "Jigua",
+      "correct": false
+    },
+    {
+      "query": "papayuela",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "vasconcellea_pubescens",
+      "top1_nombre": "Papayuela / Papayo de monte",
+      "correct": true
+    },
+    {
+      "query": "rolo jimba",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 725,
+      "top1_species": "pleurotus_djamor",
+      "top1_nombre": "Hongo Rosa",
+      "correct": false
+    },
+    {
+      "query": "siglalón",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 691,
+      "top1_species": "espeletiopsis_santanderensis",
+      "top1_nombre": "Frailejón/tache",
+      "correct": false
+    },
+    {
+      "query": "Papayuela / Papayo de monte",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 3,
+      "top1_species": "vasconcellea_goudotiana",
+      "top1_nombre": "Papayuela endémica",
+      "correct": false
+    },
+    {
+      "query": "fruta bomba",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 295,
+      "top1_species": "solanum_nigrum",
+      "top1_nombre": "Yerbamora",
+      "correct": false
+    },
+    {
+      "query": "papaya de monte",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 10,
+      "top1_species": "vasconcellea_pubescens",
+      "top1_nombre": "Papayuela / Papayo de monte",
+      "correct": false
+    },
+    {
+      "query": "papaya de pájaro",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 4,
+      "top1_species": "vasconcellea_pubescens",
+      "top1_nombre": "Papayuela / Papayo de monte",
+      "correct": false
+    },
+    {
+      "query": "mamón",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 67,
+      "top1_species": "melicoccus_bijugatus",
+      "top1_nombre": "Mamón",
+      "correct": false
+    },
+    {
+      "query": "papaya",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "carica_papaya",
+      "top1_nombre": "Papaya",
+      "correct": true
+    },
+    {
+      "query": "papayero",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 26,
+      "top1_species": "vasconcellea_pubescens",
+      "top1_nombre": "Papayuela / Papayo de monte",
+      "correct": false
+    },
+    {
+      "query": "col rizada",
+      "true_species": "brassica_oleracea_sabellica",
+      "true_nombre": "Kale morado / Col rizada morada",
+      "group": "brassica_oleracea",
+      "rank": 4,
+      "top1_species": "brassica_oleracea_var_acephala",
+      "top1_nombre": "Col rizada / Kale",
+      "correct": false
+    },
+    {
+      "query": "col crespa",
+      "true_species": "brassica_oleracea_sabellica",
+      "true_nombre": "Kale morado / Col rizada morada",
+      "group": "brassica_oleracea",
+      "rank": 32,
+      "top1_species": "lactuca_sativa_crispa_verde",
+      "top1_nombre": "Lechuga crespa verde",
+      "correct": false
+    },
+    {
+      "query": "Kale morado / Col rizada morada",
+      "true_species": "brassica_oleracea_sabellica",
+      "true_nombre": "Kale morado / Col rizada morada",
+      "group": "brassica_oleracea",
+      "rank": 2,
+      "top1_species": "rhizophora_mangle",
+      "top1_nombre": "mangle rojo",
+      "correct": false
+    },
+    {
+      "query": "col de bruselas",
+      "true_species": "brassica_oleracea_gemmifera",
+      "true_nombre": "Coles de Bruselas",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_gemmifera",
+      "top1_nombre": "Coles de Bruselas",
+      "correct": true
+    },
+    {
+      "query": "repollo de bruselas",
+      "true_species": "brassica_oleracea_gemmifera",
+      "true_nombre": "Coles de Bruselas",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_gemmifera",
+      "top1_nombre": "Coles de Bruselas",
+      "correct": true
+    },
+    {
+      "query": "Coles de Bruselas",
+      "true_species": "brassica_oleracea_gemmifera",
+      "true_nombre": "Coles de Bruselas",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_gemmifera",
+      "top1_nombre": "Coles de Bruselas",
+      "correct": true
+    }
+  ]
+}

--- a/scripts/embedder-finetune/results/eval_finetuned.json
+++ b/scripts/embedder-finetune/results/eval_finetuned.json
@@ -1,0 +1,2062 @@
+{
+  "tag": "finetuned",
+  "model": "/home/kortux/qlora-out/embedder/finetuned",
+  "n_test_pairs": 621,
+  "n_corpus_docs": 742,
+  "global": {
+    "n": 621,
+    "recall_at_1": 0.36231884057971014,
+    "recall_at_5": 0.499194847020934,
+    "mrr": 0.42122067595292834
+  },
+  "confusable": {
+    "n": 199,
+    "recall_at_1": 0.3316582914572864,
+    "recall_at_5": 0.542713567839196,
+    "mrr": 0.4180393936616293
+  },
+  "by_source": {
+    "regional_label": {
+      "n": 68,
+      "recall_at_1": 0.3088235294117647,
+      "recall_at_5": 0.38235294117647056,
+      "mrr": 0.3451866808921326
+    },
+    "nombre_comun": {
+      "n": 100,
+      "recall_at_1": 0.97,
+      "recall_at_5": 1.0,
+      "mrr": 0.9833333333333333
+    },
+    "nombres_comunes": {
+      "n": 453,
+      "recall_at_1": 0.23620309050772628,
+      "recall_at_5": 0.40618101545253865,
+      "mrr": 0.3085474881518105
+    }
+  },
+  "by_confusable_group": {
+    "arracacha_vs_yuca": {
+      "n": 36,
+      "recall_at_1": 0.2777777777777778,
+      "recall_at_5": 0.3888888888888889,
+      "mrr": 0.32765377458915806
+    },
+    "passifloras": {
+      "n": 52,
+      "recall_at_1": 0.23076923076923078,
+      "recall_at_5": 0.36538461538461536,
+      "mrr": 0.2770586065915312
+    },
+    "papa_vs_papaya_vs_papayuela": {
+      "n": 44,
+      "recall_at_1": 0.3181818181818182,
+      "recall_at_5": 0.5454545454545454,
+      "mrr": 0.41665813065114643
+    },
+    "tomate_vs_tomate_de_arbol": {
+      "n": 39,
+      "recall_at_1": 0.358974358974359,
+      "recall_at_5": 0.7692307692307693,
+      "mrr": 0.5168405325352514
+    },
+    "brassica_oleracea": {
+      "n": 28,
+      "recall_at_1": 0.5714285714285714,
+      "recall_at_5": 0.75,
+      "mrr": 0.6606256211846302
+    }
+  },
+  "confusable_details": [
+    {
+      "query": "yuca_brava",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "manihot_esculenta",
+      "top1_nombre": "Yuca brava amazónica",
+      "correct": true
+    },
+    {
+      "query": "taxo",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 518,
+      "top1_species": "chrysanthemum_sp",
+      "top1_nombre": "chrysanthemum_sp",
+      "correct": false
+    },
+    {
+      "query": "chaucha",
+      "true_species": "solanum_phureja",
+      "true_nombre": "Papa criolla",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 261,
+      "top1_species": "cyclanthera_pedata",
+      "top1_nombre": "Achocha",
+      "correct": false
+    },
+    {
+      "query": "chupita",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 481,
+      "top1_species": "tagetes_minuta",
+      "top1_nombre": "Chinchilla",
+      "correct": false
+    },
+    {
+      "query": "taxo",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 563,
+      "top1_species": "chrysanthemum_sp",
+      "top1_nombre": "chrysanthemum_sp",
+      "correct": false
+    },
+    {
+      "query": "cholupa",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 583,
+      "top1_species": "passiflora_edulis_morada",
+      "top1_nombre": "Gulupa",
+      "correct": false
+    },
+    {
+      "query": "granadilla de fraile",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_maliformis",
+      "top1_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "correct": true
+    },
+    {
+      "query": "curuba de castilla",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_tripartita_mollissima",
+      "top1_nombre": "Curuba de Castilla",
+      "correct": true
+    },
+    {
+      "query": "tacso",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 576,
+      "top1_species": "zanthoxylum_rhoifolium",
+      "top1_nombre": "Tachuelo",
+      "correct": false
+    },
+    {
+      "query": "curuba india",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 551,
+      "top1_species": "passiflora_tripartita_mollissima",
+      "top1_nombre": "Curuba de Castilla",
+      "correct": false
+    },
+    {
+      "query": "parcha",
+      "true_species": "passiflora_edulis_flavicarpa",
+      "true_nombre": "Maracuyá",
+      "group": "passifloras",
+      "rank": 54,
+      "top1_species": "passiflora_quadrangularis",
+      "top1_nombre": "Badea",
+      "correct": false
+    },
+    {
+      "query": "gulupa morada",
+      "true_species": "passiflora_edulis_morada",
+      "true_nombre": "Gulupa",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_edulis_morada",
+      "top1_nombre": "Gulupa",
+      "correct": true
+    },
+    {
+      "query": "tamarillo",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": true
+    },
+    {
+      "query": "tomate de palo",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": true
+    },
+    {
+      "query": "zanahoria blanca",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "arracacia_xanthorrhiza",
+      "top1_nombre": "Arracacha / Zanahoria blanca",
+      "correct": true
+    },
+    {
+      "query": "apio criollo",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 568,
+      "top1_species": "apium_graveolens",
+      "top1_nombre": "Apio",
+      "correct": false
+    },
+    {
+      "query": "racacha",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 9,
+      "top1_species": "oreocallis_grandiflora",
+      "top1_nombre": "Ñacha (Oreocallis grandiflora)",
+      "correct": false
+    },
+    {
+      "query": "mandioca",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "manihot_esculenta",
+      "top1_nombre": "Yuca brava amazónica",
+      "correct": true
+    },
+    {
+      "query": "casabe (planta)",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 498,
+      "top1_species": "bertholletia_excelsa",
+      "top1_nombre": "Castaño amazónico",
+      "correct": false
+    },
+    {
+      "query": "guacamota",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 55,
+      "top1_species": "schizolobium_parahyba",
+      "top1_nombre": "Guacamayo",
+      "correct": false
+    },
+    {
+      "query": "papayo",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "carica_papaya",
+      "top1_nombre": "Papaya",
+      "correct": true
+    },
+    {
+      "query": "mamon (papaya)",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 3,
+      "top1_species": "melicoccus_bijugatus",
+      "top1_nombre": "Mamón",
+      "correct": false
+    },
+    {
+      "query": "casabe",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 295,
+      "top1_species": "astrocaryum_chambira",
+      "top1_nombre": "Chambira",
+      "correct": false
+    },
+    {
+      "query": "yuca brava",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "manihot_esculenta",
+      "top1_nombre": "Yuca brava amazónica",
+      "correct": true
+    },
+    {
+      "query": "parchita",
+      "true_species": "passiflora_edulis_flavicarpa",
+      "true_nombre": "Maracuyá",
+      "group": "passifloras",
+      "rank": 43,
+      "top1_species": "passiflora_quadrangularis",
+      "top1_nombre": "Badea",
+      "correct": false
+    },
+    {
+      "query": "chupitá",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 546,
+      "top1_species": "tagetes_minuta",
+      "top1_nombre": "Chinchilla",
+      "correct": false
+    },
+    {
+      "query": "papa criolla",
+      "true_species": "solanum_phureja",
+      "true_nombre": "Papa criolla",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_phureja",
+      "top1_nombre": "Papa criolla",
+      "correct": true
+    },
+    {
+      "query": "gulupa",
+      "true_species": "passiflora_edulis_morada",
+      "true_nombre": "Gulupa",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_edulis_morada",
+      "top1_nombre": "Gulupa",
+      "correct": true
+    },
+    {
+      "query": "granadilla",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_ligularis",
+      "top1_nombre": "Granadilla",
+      "correct": true
+    },
+    {
+      "query": "Kale rizado verde",
+      "true_species": "brassica_oleracea_acephala_curly",
+      "true_nombre": "Kale rizado verde",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_acephala_curly",
+      "top1_nombre": "Kale rizado verde",
+      "correct": true
+    },
+    {
+      "query": "Kale toscano / Cavolo nero",
+      "true_species": "brassica_oleracea_acephala_lacinato",
+      "true_nombre": "Kale toscano / Cavolo nero",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_acephala_lacinato",
+      "top1_nombre": "Kale toscano / Cavolo nero",
+      "correct": true
+    },
+    {
+      "query": "Kale morado / Red Russian",
+      "true_species": "brassica_oleracea_acephala_red_russian",
+      "true_nombre": "Kale morado / Red Russian",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_acephala_red_russian",
+      "top1_nombre": "Kale morado / Red Russian",
+      "correct": true
+    },
+    {
+      "query": "maracuyá amarillo",
+      "true_species": "passiflora_edulis_flavicarpa",
+      "true_nombre": "Maracuyá",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_edulis_flavicarpa",
+      "top1_nombre": "Maracuyá",
+      "correct": true
+    },
+    {
+      "query": "Maracuyá",
+      "true_species": "passiflora_edulis_flavicarpa",
+      "true_nombre": "Maracuyá",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_edulis_flavicarpa",
+      "top1_nombre": "Maracuyá",
+      "correct": true
+    },
+    {
+      "query": "frutilla",
+      "true_species": "solanum_lycopersicum_sungold",
+      "true_nombre": "Tomate cherry amarillo / Sungold",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 152,
+      "top1_species": "prunus_domestica",
+      "top1_nombre": "Ciruela",
+      "correct": false
+    },
+    {
+      "query": "Tomate cherry amarillo / Sungold",
+      "true_species": "solanum_lycopersicum_sungold",
+      "true_nombre": "Tomate cherry amarillo / Sungold",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_lycopersicum_sungold",
+      "top1_nombre": "Tomate cherry amarillo / Sungold",
+      "correct": true
+    },
+    {
+      "query": "tomatillo",
+      "true_species": "solanum_lycopersicum_cerasiforme_uvalina",
+      "true_nombre": "Tomate cherry uvalina / Grape",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 4,
+      "top1_species": "physalis_philadelphica",
+      "top1_nombre": "Tomatillo verde",
+      "correct": false
+    },
+    {
+      "query": "Tomate cherry uvalina / Grape",
+      "true_species": "solanum_lycopersicum_cerasiforme_uvalina",
+      "true_nombre": "Tomate cherry uvalina / Grape",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_lycopersicum_cerasiforme_uvalina",
+      "top1_nombre": "Tomate cherry uvalina / Grape",
+      "correct": true
+    },
+    {
+      "query": "Col rizada / Kale",
+      "true_species": "brassica_oleracea_var_acephala",
+      "true_nombre": "Col rizada / Kale",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_var_acephala",
+      "top1_nombre": "Col rizada / Kale",
+      "correct": true
+    },
+    {
+      "query": "Papayuela endémica",
+      "true_species": "vasconcellea_goudotiana",
+      "true_nombre": "Papayuela endémica",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "vasconcellea_goudotiana",
+      "top1_nombre": "Papayuela endémica",
+      "correct": true
+    },
+    {
+      "query": "Papa Argentina",
+      "true_species": "solanum_tuberosum_argentina",
+      "true_nombre": "Papa Argentina",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum_argentina",
+      "top1_nombre": "Papa Argentina",
+      "correct": true
+    },
+    {
+      "query": "granada de castilla",
+      "true_species": "passiflora_edulis_morada",
+      "true_nombre": "Gulupa",
+      "group": "passifloras",
+      "rank": 161,
+      "top1_species": "punica_granatum",
+      "top1_nombre": "Granado",
+      "correct": false
+    },
+    {
+      "query": "granadilla",
+      "true_species": "passiflora_edulis_morada",
+      "true_nombre": "Gulupa",
+      "group": "passifloras",
+      "rank": 121,
+      "top1_species": "passiflora_ligularis",
+      "top1_nombre": "Granadilla",
+      "correct": false
+    },
+    {
+      "query": "maracuyá",
+      "true_species": "passiflora_edulis_morada",
+      "true_nombre": "Gulupa",
+      "group": "passifloras",
+      "rank": 156,
+      "top1_species": "passiflora_edulis_flavicarpa",
+      "top1_nombre": "Maracuyá",
+      "correct": false
+    },
+    {
+      "query": "granada china",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 3,
+      "top1_species": "punica_granatum",
+      "top1_nombre": "Granado",
+      "correct": false
+    },
+    {
+      "query": "cranix",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 59,
+      "top1_species": "lantana_camara",
+      "top1_nombre": "Camaroncillo",
+      "correct": false
+    },
+    {
+      "query": "granada-china",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 3,
+      "top1_species": "passiflora_tarminiana",
+      "top1_nombre": "Granadilla común / Granadilla de China",
+      "correct": false
+    },
+    {
+      "query": "granadilla de china",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 2,
+      "top1_species": "passiflora_tarminiana",
+      "top1_nombre": "Granadilla común / Granadilla de China",
+      "correct": false
+    },
+    {
+      "query": "parchita amarilla",
+      "true_species": "passiflora_ligularis",
+      "true_nombre": "Granadilla",
+      "group": "passifloras",
+      "rank": 89,
+      "top1_species": "cinchona_officinalis",
+      "top1_nombre": "Quina amarilla",
+      "correct": false
+    },
+    {
+      "query": "ceibey",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 543,
+      "top1_species": "ceiba_pentandra",
+      "top1_nombre": "Ceiba algodón",
+      "correct": false
+    },
+    {
+      "query": "chinola",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 234,
+      "top1_species": "tagetes_minuta",
+      "top1_nombre": "Chinchilla",
+      "correct": false
+    },
+    {
+      "query": "curuba",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 40,
+      "top1_species": "passiflora_tripartita_mollissima",
+      "top1_nombre": "Curuba de Castilla",
+      "correct": false
+    },
+    {
+      "query": "flor de las cinco lagas",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 87,
+      "top1_species": "cattleya_trianae",
+      "top1_nombre": "Flor de Mayo",
+      "correct": false
+    },
+    {
+      "query": "maracuyá",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 189,
+      "top1_species": "passiflora_edulis_flavicarpa",
+      "top1_nombre": "Maracuyá",
+      "correct": false
+    },
+    {
+      "query": "parcha",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 364,
+      "top1_species": "passiflora_quadrangularis",
+      "top1_nombre": "Badea",
+      "correct": false
+    },
+    {
+      "query": "parchita",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 300,
+      "top1_species": "passiflora_quadrangularis",
+      "top1_nombre": "Badea",
+      "correct": false
+    },
+    {
+      "query": "Gulupa amarilla colombiana",
+      "true_species": "passiflora_edulis_amarilla_colombia",
+      "true_nombre": "Gulupa amarilla colombiana",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_edulis_amarilla_colombia",
+      "top1_nombre": "Gulupa amarilla colombiana",
+      "correct": true
+    },
+    {
+      "query": "lima tomate",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 3,
+      "top1_species": "citrus_latifolia",
+      "top1_nombre": "Limón Tahití",
+      "correct": false
+    },
+    {
+      "query": "tomate",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 2,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": false
+    },
+    {
+      "query": "tomate extranjero",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 2,
+      "top1_species": "physalis_philadelphica",
+      "top1_nombre": "Tomatillo verde",
+      "correct": false
+    },
+    {
+      "query": "tomate de palo",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 2,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": false
+    },
+    {
+      "query": "tomate de árbol",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 2,
+      "top1_species": "solanum_betaceum_morado",
+      "top1_nombre": "Tomate de árbol morado",
+      "correct": false
+    },
+    {
+      "query": "tomato de arbol",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 3,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": false
+    },
+    {
+      "query": "tamarillo",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 24,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": false
+    },
+    {
+      "query": "tomate serrano",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum_naranja",
+      "top1_nombre": "Tomate de árbol naranja",
+      "correct": true
+    },
+    {
+      "query": "Tomate de árbol naranja",
+      "true_species": "solanum_betaceum_naranja",
+      "true_nombre": "Tomate de árbol naranja",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum_naranja",
+      "top1_nombre": "Tomate de árbol naranja",
+      "correct": true
+    },
+    {
+      "query": "lima tomate",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 4,
+      "top1_species": "citrus_latifolia",
+      "top1_nombre": "Limón Tahití",
+      "correct": false
+    },
+    {
+      "query": "tomate",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 4,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": false
+    },
+    {
+      "query": "tomate extranjero",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 3,
+      "top1_species": "physalis_philadelphica",
+      "top1_nombre": "Tomatillo verde",
+      "correct": false
+    },
+    {
+      "query": "tomate de palo",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 3,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": false
+    },
+    {
+      "query": "tomate de árbol",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum_morado",
+      "top1_nombre": "Tomate de árbol morado",
+      "correct": true
+    },
+    {
+      "query": "tomato de arbol",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 2,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": false
+    },
+    {
+      "query": "tamarillo",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 75,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": false
+    },
+    {
+      "query": "tomate serrano",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 4,
+      "top1_species": "solanum_betaceum_naranja",
+      "top1_nombre": "Tomate de árbol naranja",
+      "correct": false
+    },
+    {
+      "query": "Tomate de árbol morado",
+      "true_species": "solanum_betaceum_morado",
+      "true_nombre": "Tomate de árbol morado",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum_morado",
+      "top1_nombre": "Tomate de árbol morado",
+      "correct": true
+    },
+    {
+      "query": "frutilla",
+      "true_species": "solanum_lycopersicum",
+      "true_nombre": "Tomate chonto",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 316,
+      "top1_species": "prunus_domestica",
+      "top1_nombre": "Ciruela",
+      "correct": false
+    },
+    {
+      "query": "Tomate chonto",
+      "true_species": "solanum_lycopersicum",
+      "true_nombre": "Tomate chonto",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_lycopersicum",
+      "top1_nombre": "Tomate chonto",
+      "correct": true
+    },
+    {
+      "query": "apio",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 505,
+      "top1_species": "apium_graveolens",
+      "top1_nombre": "Apio",
+      "correct": false
+    },
+    {
+      "query": "arracacha",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "arracacia_xanthorrhiza_amarilla",
+      "top1_nombre": "Arracacha amarilla",
+      "correct": true
+    },
+    {
+      "query": "arracache",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "arracacia_xanthorrhiza_amarilla",
+      "top1_nombre": "Arracacha amarilla",
+      "correct": true
+    },
+    {
+      "query": "maya",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 682,
+      "top1_species": "cattleya_trianae",
+      "top1_nombre": "Flor de Mayo",
+      "correct": false
+    },
+    {
+      "query": "sacha zanahoria",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 72,
+      "top1_species": "plukenetia_volubilis",
+      "top1_nombre": "Sacha inchi",
+      "correct": false
+    },
+    {
+      "query": "yurak zanahoria",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 368,
+      "top1_species": "chrysanthemum_sp",
+      "top1_nombre": "chrysanthemum_sp",
+      "correct": false
+    },
+    {
+      "query": "zanahoria",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 167,
+      "top1_species": "daucus_carota_subsp_sativus",
+      "top1_nombre": "Zanahoria",
+      "correct": false
+    },
+    {
+      "query": "zanahoria blanca",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 141,
+      "top1_species": "arracacia_xanthorrhiza",
+      "top1_nombre": "Arracacha / Zanahoria blanca",
+      "correct": false
+    },
+    {
+      "query": "Arracacha amarilla",
+      "true_species": "arracacia_xanthorrhiza_amarilla",
+      "true_nombre": "Arracacha amarilla",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "arracacia_xanthorrhiza_amarilla",
+      "top1_nombre": "Arracacha amarilla",
+      "correct": true
+    },
+    {
+      "query": "frutilla",
+      "true_species": "solanum_lycopersicum_cerasiforme",
+      "true_nombre": "Tomate cherry estándar",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 307,
+      "top1_species": "prunus_domestica",
+      "top1_nombre": "Ciruela",
+      "correct": false
+    },
+    {
+      "query": "Tomate cherry estándar",
+      "true_species": "solanum_lycopersicum_cerasiforme",
+      "true_nombre": "Tomate cherry estándar",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_lycopersicum_cerasiforme",
+      "top1_nombre": "Tomate cherry estándar",
+      "correct": true
+    },
+    {
+      "query": "frutilla",
+      "true_species": "solanum_lycopersicum_san_marzano",
+      "true_nombre": "Tomate San Marzano",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 651,
+      "top1_species": "prunus_domestica",
+      "top1_nombre": "Ciruela",
+      "correct": false
+    },
+    {
+      "query": "Tomate San Marzano",
+      "true_species": "solanum_lycopersicum_san_marzano",
+      "true_nombre": "Tomate San Marzano",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_lycopersicum_san_marzano",
+      "top1_nombre": "Tomate San Marzano",
+      "correct": true
+    },
+    {
+      "query": "Repollo morado",
+      "true_species": "brassica_oleracea_capitata_rubra",
+      "true_nombre": "Repollo morado",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_capitata_rubra",
+      "top1_nombre": "Repollo morado",
+      "correct": true
+    },
+    {
+      "query": "chinpalu",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 403,
+      "top1_species": "jacaranda_copaia",
+      "top1_nombre": "Chingalé",
+      "correct": false
+    },
+    {
+      "query": "papa",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 10,
+      "top1_species": "solanum_tuberosum_argentina",
+      "top1_nombre": "Papa Argentina",
+      "correct": false
+    },
+    {
+      "query": "papa leona",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 8,
+      "top1_species": "solanum_tuberosum_diacol_capiro",
+      "top1_nombre": "Papa Diacol Capiro",
+      "correct": false
+    },
+    {
+      "query": "papa pulos",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 11,
+      "top1_species": "solanum_tuberosum",
+      "top1_nombre": "Papa parda pastusa",
+      "correct": false
+    },
+    {
+      "query": "papa uvilla",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 11,
+      "top1_species": "pourouma_cecropiifolia_silvestre",
+      "top1_nombre": "Uvilla silvestre",
+      "correct": false
+    },
+    {
+      "query": "patata",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 13,
+      "top1_species": "ipomoea_batatas",
+      "top1_nombre": "Batata / Camote",
+      "correct": false
+    },
+    {
+      "query": "potato",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 45,
+      "top1_species": "ipomoea_batatas",
+      "top1_nombre": "Batata / Camote",
+      "correct": false
+    },
+    {
+      "query": "sacha papa",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 2,
+      "top1_species": "plukenetia_volubilis",
+      "top1_nombre": "Sacha inchi",
+      "correct": false
+    },
+    {
+      "query": "Papa Sabanera",
+      "true_species": "solanum_tuberosum_sabanera",
+      "true_nombre": "Papa Sabanera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum_sabanera",
+      "top1_nombre": "Papa Sabanera",
+      "correct": true
+    },
+    {
+      "query": "curuba",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 706,
+      "top1_species": "passiflora_tripartita_mollissima",
+      "top1_nombre": "Curuba de Castilla",
+      "correct": false
+    },
+    {
+      "query": "granadilla de bueso",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 5,
+      "top1_species": "passiflora_ligularis",
+      "top1_nombre": "Granadilla",
+      "correct": false
+    },
+    {
+      "query": "granadilla de hueso",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 4,
+      "top1_species": "passiflora_ligularis",
+      "top1_nombre": "Granadilla",
+      "correct": false
+    },
+    {
+      "query": "granadilla de piedra",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 4,
+      "top1_species": "passiflora_ligularis",
+      "top1_nombre": "Granadilla",
+      "correct": false
+    },
+    {
+      "query": "guerito",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 417,
+      "top1_species": "sechium_edule",
+      "top1_nombre": "Guatila / Chayote",
+      "correct": false
+    },
+    {
+      "query": "parcha cimarrona",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 245,
+      "top1_species": "loricaria_complanata",
+      "top1_nombre": "Escobilla paramuna",
+      "correct": false
+    },
+    {
+      "query": "Granadilla de fraile / Maracuyá silvestre",
+      "true_species": "passiflora_maliformis",
+      "true_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_maliformis",
+      "top1_nombre": "Granadilla de fraile / Maracuyá silvestre",
+      "correct": true
+    },
+    {
+      "query": "gullán",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 94,
+      "top1_species": "cestrum_nocturnum",
+      "top1_nombre": "Galán de noche",
+      "correct": false
+    },
+    {
+      "query": "taksu",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 555,
+      "top1_species": "chrysanthemum_sp",
+      "top1_nombre": "chrysanthemum_sp",
+      "correct": false
+    },
+    {
+      "query": "curuba ecuatoriana",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 429,
+      "top1_species": "passiflora_tripartita_mollissima",
+      "top1_nombre": "Curuba de Castilla",
+      "correct": false
+    },
+    {
+      "query": "curuba quiteña",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 560,
+      "top1_species": "passiflora_tripartita_mollissima",
+      "top1_nombre": "Curuba de Castilla",
+      "correct": false
+    },
+    {
+      "query": "tacso amarillo",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 550,
+      "top1_species": "cosmos_sulphureus",
+      "top1_nombre": "Cosmos amarillo",
+      "correct": false
+    },
+    {
+      "query": "Granadilla común / Granadilla de China",
+      "true_species": "passiflora_tarminiana",
+      "true_nombre": "Granadilla común / Granadilla de China",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_tarminiana",
+      "top1_nombre": "Granadilla común / Granadilla de China",
+      "correct": true
+    },
+    {
+      "query": "col",
+      "true_species": "brassica_oleracea_var_capitata",
+      "true_nombre": "Repollo",
+      "group": "brassica_oleracea",
+      "rank": 37,
+      "top1_species": "brassica_oleracea_var_acephala",
+      "top1_nombre": "Col rizada / Kale",
+      "correct": false
+    },
+    {
+      "query": "col repollo",
+      "true_species": "brassica_oleracea_var_capitata",
+      "true_nombre": "Repollo",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_var_capitata",
+      "top1_nombre": "Repollo",
+      "correct": true
+    },
+    {
+      "query": "lombarda",
+      "true_species": "brassica_oleracea_var_capitata",
+      "true_nombre": "Repollo",
+      "group": "brassica_oleracea",
+      "rank": 177,
+      "top1_species": "lavandula_angustifolia",
+      "top1_nombre": "Lavanda",
+      "correct": false
+    },
+    {
+      "query": "repollo",
+      "true_species": "brassica_oleracea_var_capitata",
+      "true_nombre": "Repollo",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_var_capitata",
+      "top1_nombre": "Repollo",
+      "correct": true
+    },
+    {
+      "query": "andigena",
+      "true_species": "solanum_tuberosum_carrera_negra",
+      "true_nombre": "Papa Negra Carrera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 466,
+      "top1_species": "carapa_guianensis",
+      "top1_nombre": "andiroba",
+      "correct": false
+    },
+    {
+      "query": "papa amarilla",
+      "true_species": "solanum_tuberosum_carrera_negra",
+      "true_nombre": "Papa Negra Carrera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 4,
+      "top1_species": "mammea_americana",
+      "top1_nombre": "Mamey amarillo",
+      "correct": false
+    },
+    {
+      "query": "Papa Negra Carrera",
+      "true_species": "solanum_tuberosum_carrera_negra",
+      "true_nombre": "Papa Negra Carrera",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum_carrera_negra",
+      "top1_nombre": "Papa Negra Carrera",
+      "correct": true
+    },
+    {
+      "query": "airo bai a’so",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 187,
+      "top1_species": "chrysanthemum_sp",
+      "top1_nombre": "chrysanthemum_sp",
+      "correct": false
+    },
+    {
+      "query": "apach mama",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 75,
+      "top1_species": "pouteria_sapota",
+      "top1_nombre": "Mamey colorado",
+      "correct": false
+    },
+    {
+      "query": "api lumu",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 75,
+      "top1_species": "solanum_quitoense",
+      "top1_nombre": "Lulo / Naranjilla / Chuva",
+      "correct": false
+    },
+    {
+      "query": "arajuno lumu",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 107,
+      "top1_species": "solanum_quitoense",
+      "top1_nombre": "Lulo / Naranjilla / Chuva",
+      "correct": false
+    },
+    {
+      "query": "auka lumu",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 49,
+      "top1_species": "chrysanthemum_sp",
+      "top1_nombre": "chrysanthemum_sp",
+      "correct": false
+    },
+    {
+      "query": "awa llakta lumu",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 123,
+      "top1_species": "solanum_quitoense",
+      "top1_nombre": "Lulo / Naranjilla / Chuva",
+      "correct": false
+    },
+    {
+      "query": "aypi",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 89,
+      "top1_species": "cyperus_articulatus",
+      "top1_nombre": "Papiro andino",
+      "correct": false
+    },
+    {
+      "query": "a’so",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 369,
+      "top1_species": "oreopanax_floribundum",
+      "top1_nombre": "Mano de oso",
+      "correct": false
+    },
+    {
+      "query": "Yuca brava amazónica",
+      "true_species": "manihot_esculenta",
+      "true_nombre": "Yuca brava amazónica",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "manihot_esculenta",
+      "top1_nombre": "Yuca brava amazónica",
+      "correct": true
+    },
+    {
+      "query": "Papa Pastusa Suprema",
+      "true_species": "solanum_tuberosum_pastusa_suprema",
+      "true_nombre": "Papa Pastusa Suprema",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum_pastusa_suprema",
+      "top1_nombre": "Papa Pastusa Suprema",
+      "correct": true
+    },
+    {
+      "query": "Papa Diacol Capiro",
+      "true_species": "solanum_tuberosum_diacol_capiro",
+      "true_nombre": "Papa Diacol Capiro",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum_diacol_capiro",
+      "top1_nombre": "Papa Diacol Capiro",
+      "correct": true
+    },
+    {
+      "query": "col",
+      "true_species": "brassica_oleracea_capitata_alba",
+      "true_nombre": "Repollo blanco",
+      "group": "brassica_oleracea",
+      "rank": 29,
+      "top1_species": "brassica_oleracea_var_acephala",
+      "top1_nombre": "Col rizada / Kale",
+      "correct": false
+    },
+    {
+      "query": "col repollo",
+      "true_species": "brassica_oleracea_capitata_alba",
+      "true_nombre": "Repollo blanco",
+      "group": "brassica_oleracea",
+      "rank": 2,
+      "top1_species": "brassica_oleracea_var_capitata",
+      "top1_nombre": "Repollo",
+      "correct": false
+    },
+    {
+      "query": "lombarda",
+      "true_species": "brassica_oleracea_capitata_alba",
+      "true_nombre": "Repollo blanco",
+      "group": "brassica_oleracea",
+      "rank": 109,
+      "top1_species": "lavandula_angustifolia",
+      "top1_nombre": "Lavanda",
+      "correct": false
+    },
+    {
+      "query": "repollo",
+      "true_species": "brassica_oleracea_capitata_alba",
+      "true_nombre": "Repollo blanco",
+      "group": "brassica_oleracea",
+      "rank": 2,
+      "top1_species": "brassica_oleracea_var_capitata",
+      "top1_nombre": "Repollo",
+      "correct": false
+    },
+    {
+      "query": "Repollo blanco",
+      "true_species": "brassica_oleracea_capitata_alba",
+      "true_nombre": "Repollo blanco",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_capitata_alba",
+      "top1_nombre": "Repollo blanco",
+      "correct": true
+    },
+    {
+      "query": "col de milán",
+      "true_species": "brassica_oleracea_sabauda",
+      "true_nombre": "Repollo rizado / Savoy",
+      "group": "brassica_oleracea",
+      "rank": 371,
+      "top1_species": "brassica_oleracea_gemmifera",
+      "top1_nombre": "Coles de Bruselas",
+      "correct": false
+    },
+    {
+      "query": "col de saboya",
+      "true_species": "brassica_oleracea_sabauda",
+      "true_nombre": "Repollo rizado / Savoy",
+      "group": "brassica_oleracea",
+      "rank": 2,
+      "top1_species": "holcus_lanatus",
+      "top1_nombre": "Saboya",
+      "correct": false
+    },
+    {
+      "query": "col lombarda",
+      "true_species": "brassica_oleracea_sabauda",
+      "true_nombre": "Repollo rizado / Savoy",
+      "group": "brassica_oleracea",
+      "rank": 549,
+      "top1_species": "brassica_oleracea_acephala_lacinato",
+      "top1_nombre": "Kale toscano / Cavolo nero",
+      "correct": false
+    },
+    {
+      "query": "Repollo rizado / Savoy",
+      "true_species": "brassica_oleracea_sabauda",
+      "true_nombre": "Repollo rizado / Savoy",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_sabauda",
+      "top1_nombre": "Repollo rizado / Savoy",
+      "correct": true
+    },
+    {
+      "query": "gullán",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 212,
+      "top1_species": "cestrum_nocturnum",
+      "top1_nombre": "Galán de noche",
+      "correct": false
+    },
+    {
+      "query": "taksu",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 379,
+      "top1_species": "chrysanthemum_sp",
+      "top1_nombre": "chrysanthemum_sp",
+      "correct": false
+    },
+    {
+      "query": "taxo cultivado",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 387,
+      "top1_species": "triticum_aestivum",
+      "top1_nombre": "Trigo",
+      "correct": false
+    },
+    {
+      "query": "taxo de castilla",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 3,
+      "top1_species": "bertholletia_excelsa",
+      "top1_nombre": "Castaño amazónico",
+      "correct": false
+    },
+    {
+      "query": "taxo silvestre",
+      "true_species": "passiflora_tripartita_mollissima",
+      "true_nombre": "Curuba de Castilla",
+      "group": "passifloras",
+      "rank": 690,
+      "top1_species": "uva_bifera",
+      "top1_nombre": "Tilo / Tilo silvestre",
+      "correct": false
+    },
+    {
+      "query": "lima tomate",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 2,
+      "top1_species": "citrus_latifolia",
+      "top1_nombre": "Limón Tahití",
+      "correct": false
+    },
+    {
+      "query": "tomate",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": true
+    },
+    {
+      "query": "tomate extranjero",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 4,
+      "top1_species": "physalis_philadelphica",
+      "top1_nombre": "Tomatillo verde",
+      "correct": false
+    },
+    {
+      "query": "tomate de árbol",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 3,
+      "top1_species": "solanum_betaceum_morado",
+      "top1_nombre": "Tomate de árbol morado",
+      "correct": false
+    },
+    {
+      "query": "tomato de arbol",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": true
+    },
+    {
+      "query": "tomate serrano",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 6,
+      "top1_species": "solanum_betaceum_naranja",
+      "top1_nombre": "Tomate de árbol naranja",
+      "correct": false
+    },
+    {
+      "query": "Tomate de árbol / Tamarillo",
+      "true_species": "solanum_betaceum",
+      "true_nombre": "Tomate de árbol / Tamarillo",
+      "group": "tomate_vs_tomate_de_arbol",
+      "rank": 1,
+      "top1_species": "solanum_betaceum",
+      "top1_nombre": "Tomate de árbol / Tamarillo",
+      "correct": true
+    },
+    {
+      "query": "chinpalu",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 239,
+      "top1_species": "jacaranda_copaia",
+      "top1_nombre": "Chingalé",
+      "correct": false
+    },
+    {
+      "query": "papa",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 3,
+      "top1_species": "solanum_tuberosum_argentina",
+      "top1_nombre": "Papa Argentina",
+      "correct": false
+    },
+    {
+      "query": "papa leona",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 3,
+      "top1_species": "solanum_tuberosum_diacol_capiro",
+      "top1_nombre": "Papa Diacol Capiro",
+      "correct": false
+    },
+    {
+      "query": "papa pulos",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum",
+      "top1_nombre": "Papa parda pastusa",
+      "correct": true
+    },
+    {
+      "query": "papa uvilla",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 2,
+      "top1_species": "pourouma_cecropiifolia_silvestre",
+      "top1_nombre": "Uvilla silvestre",
+      "correct": false
+    },
+    {
+      "query": "patata",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 26,
+      "top1_species": "ipomoea_batatas",
+      "top1_nombre": "Batata / Camote",
+      "correct": false
+    },
+    {
+      "query": "potato",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 116,
+      "top1_species": "ipomoea_batatas",
+      "top1_nombre": "Batata / Camote",
+      "correct": false
+    },
+    {
+      "query": "sacha papa",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 4,
+      "top1_species": "plukenetia_volubilis",
+      "top1_nombre": "Sacha inchi",
+      "correct": false
+    },
+    {
+      "query": "Papa parda pastusa",
+      "true_species": "solanum_tuberosum",
+      "true_nombre": "Papa parda pastusa",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "solanum_tuberosum",
+      "top1_nombre": "Papa parda pastusa",
+      "correct": true
+    },
+    {
+      "query": "badea",
+      "true_species": "passiflora_quadrangularis",
+      "true_nombre": "Badea",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_quadrangularis",
+      "top1_nombre": "Badea",
+      "correct": true
+    },
+    {
+      "query": "granadilla",
+      "true_species": "passiflora_quadrangularis",
+      "true_nombre": "Badea",
+      "group": "passifloras",
+      "rank": 108,
+      "top1_species": "passiflora_ligularis",
+      "top1_nombre": "Granadilla",
+      "correct": false
+    },
+    {
+      "query": "granadilla real",
+      "true_species": "passiflora_quadrangularis",
+      "true_nombre": "Badea",
+      "group": "passifloras",
+      "rank": 158,
+      "top1_species": "passiflora_ligularis",
+      "top1_nombre": "Granadilla",
+      "correct": false
+    },
+    {
+      "query": "brecolera",
+      "true_species": "brassica_oleracea_italica",
+      "true_nombre": "Brócoli",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_italica",
+      "top1_nombre": "Brócoli",
+      "correct": true
+    },
+    {
+      "query": "brécol",
+      "true_species": "brassica_oleracea_italica",
+      "true_nombre": "Brócoli",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_italica",
+      "top1_nombre": "Brócoli",
+      "correct": true
+    },
+    {
+      "query": "brócoli",
+      "true_species": "brassica_oleracea_italica",
+      "true_nombre": "Brócoli",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_italica",
+      "top1_nombre": "Brócoli",
+      "correct": true
+    },
+    {
+      "query": "coliflor",
+      "true_species": "brassica_oleracea_botrytis",
+      "true_nombre": "Coliflor",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_botrytis",
+      "top1_nombre": "Coliflor",
+      "correct": true
+    },
+    {
+      "query": "Yuca de árbol / Caucho de Ceará",
+      "true_species": "manihot_glaziovii",
+      "true_nombre": "Yuca de árbol / Caucho de Ceará",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "manihot_glaziovii",
+      "top1_nombre": "Yuca de árbol / Caucho de Ceará",
+      "correct": true
+    },
+    {
+      "query": "Pasionaria medicinal",
+      "true_species": "passiflora_incarnata",
+      "true_nombre": "Pasionaria medicinal",
+      "group": "passifloras",
+      "rank": 1,
+      "top1_species": "passiflora_incarnata",
+      "top1_nombre": "Pasionaria medicinal",
+      "correct": true
+    },
+    {
+      "query": "apio",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 599,
+      "top1_species": "apium_graveolens",
+      "top1_nombre": "Apio",
+      "correct": false
+    },
+    {
+      "query": "arracacha",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 3,
+      "top1_species": "arracacia_xanthorrhiza_amarilla",
+      "top1_nombre": "Arracacha amarilla",
+      "correct": false
+    },
+    {
+      "query": "arracache",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 3,
+      "top1_species": "arracacia_xanthorrhiza_amarilla",
+      "top1_nombre": "Arracacha amarilla",
+      "correct": false
+    },
+    {
+      "query": "maya",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 506,
+      "top1_species": "cattleya_trianae",
+      "top1_nombre": "Flor de Mayo",
+      "correct": false
+    },
+    {
+      "query": "sacha zanahoria",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 3,
+      "top1_species": "plukenetia_volubilis",
+      "top1_nombre": "Sacha inchi",
+      "correct": false
+    },
+    {
+      "query": "yurak zanahoria",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 26,
+      "top1_species": "chrysanthemum_sp",
+      "top1_nombre": "chrysanthemum_sp",
+      "correct": false
+    },
+    {
+      "query": "zanahoria",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 2,
+      "top1_species": "daucus_carota_subsp_sativus",
+      "top1_nombre": "Zanahoria",
+      "correct": false
+    },
+    {
+      "query": "Arracacha / Zanahoria blanca",
+      "true_species": "arracacia_xanthorrhiza",
+      "true_nombre": "Arracacha / Zanahoria blanca",
+      "group": "arracacha_vs_yuca",
+      "rank": 1,
+      "top1_species": "arracacia_xanthorrhiza",
+      "top1_nombre": "Arracacha / Zanahoria blanca",
+      "correct": true
+    },
+    {
+      "query": "chamburo",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 473,
+      "top1_species": "astrocaryum_chambira",
+      "top1_nombre": "Chambira",
+      "correct": false
+    },
+    {
+      "query": "chanpuru",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 255,
+      "top1_species": "psychotria_viridis",
+      "top1_nombre": "Chacruna",
+      "correct": false
+    },
+    {
+      "query": "chiblacán",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 708,
+      "top1_species": "tecoma_stans",
+      "top1_nombre": "Chicalá",
+      "correct": false
+    },
+    {
+      "query": "chihualcán",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 496,
+      "top1_species": "tecoma_stans",
+      "top1_nombre": "Chicalá",
+      "correct": false
+    },
+    {
+      "query": "jigacho",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 482,
+      "top1_species": "nectandra_acutifolia",
+      "top1_nombre": "Jigua",
+      "correct": false
+    },
+    {
+      "query": "papayuela",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "vasconcellea_pubescens",
+      "top1_nombre": "Papayuela / Papayo de monte",
+      "correct": true
+    },
+    {
+      "query": "rolo jimba",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 684,
+      "top1_species": "simarouba_amara",
+      "top1_nombre": "Simaruba",
+      "correct": false
+    },
+    {
+      "query": "siglalón",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 611,
+      "top1_species": "samanea_saman",
+      "top1_nombre": "Samán",
+      "correct": false
+    },
+    {
+      "query": "Papayuela / Papayo de monte",
+      "true_species": "vasconcellea_pubescens",
+      "true_nombre": "Papayuela / Papayo de monte",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "vasconcellea_pubescens",
+      "top1_nombre": "Papayuela / Papayo de monte",
+      "correct": true
+    },
+    {
+      "query": "fruta bomba",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 5,
+      "top1_species": "ananas_comosus",
+      "top1_nombre": "Piña",
+      "correct": false
+    },
+    {
+      "query": "papaya de monte",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 2,
+      "top1_species": "vasconcellea_pubescens",
+      "top1_nombre": "Papayuela / Papayo de monte",
+      "correct": false
+    },
+    {
+      "query": "papaya de pájaro",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "carica_papaya",
+      "top1_nombre": "Papaya",
+      "correct": true
+    },
+    {
+      "query": "mamón",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 19,
+      "top1_species": "melicoccus_bijugatus",
+      "top1_nombre": "Mamón",
+      "correct": false
+    },
+    {
+      "query": "papaya",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 1,
+      "top1_species": "carica_papaya",
+      "top1_nombre": "Papaya",
+      "correct": true
+    },
+    {
+      "query": "papayero",
+      "true_species": "carica_papaya",
+      "true_nombre": "Papaya",
+      "group": "papa_vs_papaya_vs_papayuela",
+      "rank": 2,
+      "top1_species": "vasconcellea_pubescens",
+      "top1_nombre": "Papayuela / Papayo de monte",
+      "correct": false
+    },
+    {
+      "query": "col rizada",
+      "true_species": "brassica_oleracea_sabellica",
+      "true_nombre": "Kale morado / Col rizada morada",
+      "group": "brassica_oleracea",
+      "rank": 2,
+      "top1_species": "brassica_oleracea_var_acephala",
+      "top1_nombre": "Col rizada / Kale",
+      "correct": false
+    },
+    {
+      "query": "col crespa",
+      "true_species": "brassica_oleracea_sabellica",
+      "true_nombre": "Kale morado / Col rizada morada",
+      "group": "brassica_oleracea",
+      "rank": 6,
+      "top1_species": "brassica_oleracea_gemmifera",
+      "top1_nombre": "Coles de Bruselas",
+      "correct": false
+    },
+    {
+      "query": "Kale morado / Col rizada morada",
+      "true_species": "brassica_oleracea_sabellica",
+      "true_nombre": "Kale morado / Col rizada morada",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_sabellica",
+      "top1_nombre": "Kale morado / Col rizada morada",
+      "correct": true
+    },
+    {
+      "query": "col de bruselas",
+      "true_species": "brassica_oleracea_gemmifera",
+      "true_nombre": "Coles de Bruselas",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_gemmifera",
+      "top1_nombre": "Coles de Bruselas",
+      "correct": true
+    },
+    {
+      "query": "repollo de bruselas",
+      "true_species": "brassica_oleracea_gemmifera",
+      "true_nombre": "Coles de Bruselas",
+      "group": "brassica_oleracea",
+      "rank": 4,
+      "top1_species": "brassica_oleracea_var_capitata",
+      "top1_nombre": "Repollo",
+      "correct": false
+    },
+    {
+      "query": "Coles de Bruselas",
+      "true_species": "brassica_oleracea_gemmifera",
+      "true_nombre": "Coles de Bruselas",
+      "group": "brassica_oleracea",
+      "rank": 1,
+      "top1_species": "brassica_oleracea_gemmifera",
+      "top1_nombre": "Coles de Bruselas",
+      "correct": true
+    }
+  ]
+}

--- a/scripts/embedder-finetune/results/split_report.json
+++ b/scripts/embedder-finetune/results/split_report.json
@@ -1,0 +1,16 @@
+{
+  "n_species_total": 742,
+  "n_species_with_nombres_comunes": 507,
+  "n_regional_labels_raw": 325,
+  "n_regional_label_pairs_valid": 218,
+  "n_regional_label_pairs_skipped_missing_species": 52,
+  "n_pairs_total": 3013,
+  "n_species_with_pairs": 734,
+  "n_species_train": 602,
+  "n_species_test": 132,
+  "n_pairs_train": 2392,
+  "n_pairs_test": 621,
+  "n_confusable_species": 43,
+  "n_families": 130,
+  "split_seed": 1337
+}

--- a/scripts/embedder-finetune/train_embedder.py
+++ b/scripts/embedder-finetune/train_embedder.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Fine-tune contrastivo de intfloat/multilingual-e5-large sobre pares
+(query regional/nombre-comun -> especie) del grafo AGE de Chagra,
+con negativos duros por genero/familia botanica.
+
+InfoNCE manual (equivalente a MultipleNegativesRankingLoss) porque NO
+instalamos sentence-transformers en el venv qlora-dpo (riesgo de clobbear
+el torch CUDA -- ver CLAUDE.md). Solo transformers + torch puro.
+"""
+import argparse, json, random, time, sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).parent))
+from e5_common import load_model, encode_texts
+
+BASE = Path.home() / "embedder-ft"
+
+
+def load_jsonl(p):
+    out = []
+    with open(p, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-model", default="intfloat/multilingual-e5-large")
+    ap.add_argument("--epochs", type=int, default=4)
+    ap.add_argument("--batch-size", type=int, default=16)
+    ap.add_argument("--neg-k", type=int, default=2)
+    ap.add_argument("--lr", type=float, default=2e-5)
+    ap.add_argument("--max-length-doc", type=int, default=128)
+    ap.add_argument("--max-length-query", type=int, default=32)
+    ap.add_argument("--out-dir", default=str(Path.home() / "qlora-out" / "embedder" / "finetuned"))
+    ap.add_argument("--scale", type=float, default=20.0)
+    ap.add_argument("--seed", type=int, default=1337)
+    args = ap.parse_args()
+
+    random.seed(args.seed)
+    torch.manual_seed(args.seed)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"[env] device={device} torch={torch.__version__}", flush=True)
+    if device == "cuda":
+        print(f"[env] gpu={torch.cuda.get_device_name(0)}", flush=True)
+
+    pairs = load_jsonl(BASE / "pairs_train.jsonl")
+    corpus_rows = load_jsonl(BASE / "corpus.jsonl")
+    corpus = {r["species_id"]: r["text"] for r in corpus_rows}
+    genus = json.loads((BASE / "genus.json").read_text(encoding="utf-8"))
+    family = json.loads((BASE / "family.json").read_text(encoding="utf-8"))
+
+    all_species = list(corpus.keys())
+
+    genus_to_species = {}
+    for sid, g in genus.items():
+        if not g:
+            continue
+        genus_to_species.setdefault(g, []).append(sid)
+    family_to_species = {}
+    for sid, fam in family.items():
+        family_to_species.setdefault(fam, []).append(sid)
+
+    rng = random.Random(args.seed)
+
+    def sample_hard_negs(sid, k):
+        chosen = []
+        g = genus.get(sid, "")
+        cand = [s for s in genus_to_species.get(g, []) if s != sid] if g else []
+        rng.shuffle(cand)
+        chosen.extend(cand[:k])
+        if len(chosen) < k:
+            fam = family.get(sid, "")
+            cand2 = [s for s in family_to_species.get(fam, []) if s != sid and s not in chosen] if fam else []
+            rng.shuffle(cand2)
+            chosen.extend(cand2[: (k - len(chosen))])
+        while len(chosen) < k:
+            s = rng.choice(all_species)
+            if s != sid and s not in chosen:
+                chosen.append(s)
+        return chosen[:k]
+
+    print(f"[data] {len(pairs)} pares de train, {len(corpus)} docs en corpus, {len(genus_to_species)} generos, {len(family_to_species)} familias", flush=True)
+
+    tok, model = load_model(args.base_model, device=device, dtype=torch.bfloat16)
+    model.train()
+
+    optim = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=0.01)
+    steps_per_epoch = (len(pairs) + args.batch_size - 1) // args.batch_size
+    total_steps = steps_per_epoch * args.epochs
+    warmup_steps = max(1, int(0.1 * total_steps))
+
+    def lr_lambda(step):
+        if step < warmup_steps:
+            return step / warmup_steps
+        prog = (step - warmup_steps) / max(1, total_steps - warmup_steps)
+        return max(0.05, 1.0 - prog)
+
+    sched = torch.optim.lr_scheduler.LambdaLR(optim, lr_lambda)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    global_step = 0
+    t0 = time.time()
+    for epoch in range(args.epochs):
+        rng.shuffle(pairs)
+        epoch_loss = 0.0
+        n_batches = 0
+        for i in range(0, len(pairs), args.batch_size):
+            batch = pairs[i:i + args.batch_size]
+            B = len(batch)
+            queries = [p["query"] for p in batch]
+            pos_sids = [p["species_id"] for p in batch]
+
+            doc_sids_flat = []
+            for sid in pos_sids:
+                doc_sids_flat.append(sid)
+                doc_sids_flat.extend(sample_hard_negs(sid, args.neg_k))
+            doc_texts_flat = [corpus.get(sid, "") for sid in doc_sids_flat]
+
+            q_emb = encode_texts(queries, tok, model, device, "query: ",
+                                  max_length=args.max_length_query, batch_size=len(queries), grad=True)
+            d_emb = encode_texts(doc_texts_flat, tok, model, device, "passage: ",
+                                  max_length=args.max_length_doc, batch_size=len(doc_texts_flat), grad=True)
+
+            sim = q_emb @ d_emb.t() * args.scale
+            labels = torch.tensor([j * (1 + args.neg_k) for j in range(B)], device=device, dtype=torch.long)
+            loss = F.cross_entropy(sim, labels)
+
+            optim.zero_grad(set_to_none=True)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optim.step()
+            sched.step()
+
+            epoch_loss += loss.item()
+            n_batches += 1
+            global_step += 1
+            if global_step % 20 == 0 or global_step == 1:
+                elapsed = time.time() - t0
+                print(f"[step {global_step}/{total_steps}] epoch={epoch} loss={loss.item():.4f} "
+                      f"lr={sched.get_last_lr()[0]:.2e} elapsed={elapsed:.0f}s", flush=True)
+
+        print(f"[epoch {epoch}] loss_avg={epoch_loss/max(1,n_batches):.4f} ({n_batches} batches)", flush=True)
+        ckpt_dir = out_dir.parent / f"ckpt-epoch{epoch}"
+        model.save_pretrained(ckpt_dir)
+        tok.save_pretrained(ckpt_dir)
+        print(f"[epoch {epoch}] checkpoint guardado en {ckpt_dir}", flush=True)
+
+    model.save_pretrained(out_dir)
+    tok.save_pretrained(out_dir)
+    meta = {
+        "base_model": args.base_model,
+        "epochs": args.epochs,
+        "batch_size": args.batch_size,
+        "neg_k": args.neg_k,
+        "lr": args.lr,
+        "n_train_pairs": len(pairs),
+        "total_steps": global_step,
+        "train_seconds": time.time() - t0,
+        "seed": args.seed,
+    }
+    (out_dir / "train_meta.json").write_text(json.dumps(meta, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"[done] modelo final guardado en {out_dir}", flush=True)
+    print(json.dumps(meta, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Resumen

Experimento (no un cambio de producción): fine-tune contrastivo de `intfloat/multilingual-e5-large`
usando 3013 pares reales `(nombre regional/común, especie)` extraídos del grafo de conocimiento
(`RegionalLabel` + `Species.nombres_comunes`), con split honesto por especie y negativos duros por
género/familia botánica. Objetivo: medir si mejora la resolución de nombres fácilmente confundibles
en el habla campesina (`papa`/`papaya`/`papayuela`, passifloras, `tomate`/`tomate de árbol`,
`brassica oleracea`, `arracacha`/`yuca`) frente al mismo modelo sin fine-tune.

## Resultado

| Métrica | Base | Fine-tuned | Δ |
|---|---|---|---|
| Recall@1 global | 31.6% | 36.2% | +4.7pp |
| Recall@5 global | 43.6% | 49.9% | +6.3pp |
| MRR global | 0.373 | 0.421 | +0.049 |
| Recall@1 confundibles | 28.6% | 33.2% | +4.5pp |
| Recall@5 confundibles | 42.7% | 54.3% | +11.6pp |

Mejora fuerte en 3 de 5 grupos de confundibles (tomate/tomate-de-árbol +30.8pp en R@5, brassica
oleracea +14.3pp en R@1, papa/papaya/papayuela +11.4pp en R@5) pero **no mejora en passifloras**
(R@1 plano) y **empeora en arracacha-vs-yuca** (confusión entre familias botánicas distintas que
los negativos duros taxonómicos no cubren).

**Veredicto: NO se reemplaza el embedder de producción (`snowflake-arctic-embed2` vía Ollama) con
este checkpoint.** La señal es real y justifica seguir iterando, pero el resultado es desparejo
justo en los casos más difíciles, y el checkpoint (formato HF/ONNX) no es compatible con el runtime
de Ollama actual sin una migración de stack fuera de alcance de este experimento.

## Qué trae este PR

- `scripts/embedder-finetune/build_pairs.py` — arma pares + split honesto por especie + corpus desde
  un dump plano del grafo AGE.
- `scripts/embedder-finetune/e5_common.py` — carga/encode estilo E5 (mean-pooling + normalize) sin
  `sentence-transformers` (para no arriesgar el torch CUDA compartido del entorno de entrenamiento).
- `scripts/embedder-finetune/train_embedder.py` — entrenamiento InfoNCE manual con negativos duros.
- `scripts/embedder-finetune/eval_embedder.py` — recall@1/@5/MRR base vs fine-tuned + tabla de
  confundibles.
- `scripts/embedder-finetune/export_onnx.py` — empaquetado a ONNX, verificado (checker OK,
  diferencia vs. PyTorch ~1e-6).
- `scripts/embedder-finetune/results/*.json` — métricas completas de ambas corridas.

No se sube el checkpoint del modelo (binario grande, ~1.1GB HF / ~2.1GB ONNX) — queda documentado
dónde vive y cómo se verificó (carga y corre en CPU puro, sin GPU) en el reporte interno de
operaciones. Reporte completo con tabla de confundibles detallada, análisis de por qué
arracacha/yuca empeora, y un hallazgo colateral de calidad de datos (8 especies con documento
vacío en el corpus por un batch de ingesta con esquema distinto) en `ops/EMBEDDER-FINETUNE-2026-07-15.md`
(repo interno).

## Test plan

- [x] `nvidia-smi` capturado en vivo mostrando 100% util / 10GB VRAM durante el entrenamiento (evidencia de carga real, no simulada).
- [x] Split verificado por especie (no por par) — los 43 `species_id` de los grupos de confundibles forzados a TEST, cero pares suyos en train.
- [x] Modelo fine-tuneado verificado cargando y corriendo en CPU puro (`CUDA_VISIBLE_DEVICES=""`), sin la GPU.
- [x] Export ONNX verificado con `onnx.checker.check_model` + inferencia `onnxruntime` CPU comparada contra PyTorch (diff máx ~1e-6).
- [x] Eval corrida sobre el mismo corpus/queries para base y fine-tuned (comparación de a igual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)