### PR TITLE
docs(vision-cafe): clasificador cafe RoCoLe+BRACOL - resultado negativo honesto

### DIFF
--- a/ops/VISION-CAFE-2026-07-15.md
+++ b/ops/VISION-CAFE-2026-07-15.md
@@ -1,0 +1,421 @@
+# Clasificador de enfermedades del café con datos de campo (RoCoLe + BRACOL) — 2026-07-15
+
+Entrenado en `alpha` con la RTX 3090 (compartida con un bench de embedders en paralelo) en la
+ventana de horas antes de que la tarjeta saliera. Rama `feat/vision-cafe-rocole`.
+
+## TL;DR / veredicto honesto
+
+**No va a producción tal como está. No le gana al 5/8 de la torre multimodal.**
+
+Se entrenó un EfficientNet-B0 (5 clases: sana/roya/minador/phoma/cercospora) sobre 1443 imágenes
+reales de RoCoLe+BRACOL (datasets de campo verificados, licencia CC BY 4.0 confirmada
+independientemente — no CC BY-NC-SA 4.0 como decía el DR). El modelo generaliza MUY bien dentro
+de su propio dataset (test acc 0.896, macro F1 0.845, split respetando hoja/planta donde el
+dataset lo permite) pero **falla las dos únicas fotos de café-enfermedad-de-hoja realmente
+comparables de Chagra (`hemileia_vastatrix.jpg`, `cercospora_coffeicola.jpg`): 0/2, incluyendo un
+caso de roya con síntoma inconfundible clasificado como "sana" con 94% de confianza.** Un segundo
+intento con augmentación mucho más agresiva (run2), diseñado específicamente para atacar esa
+brecha, no la cerró — y empeoró el modelo en su propio test interno. Esto es evidencia de que el
+problema no es de augmentación sino de **diversidad de fuente**: BRACOL/RoCoLe son datasets "de
+campo" en el sentido de que las plantas están enfermas de verdad, pero comparten un protocolo
+fotográfico específico (hoja aislada, fondo controlado, alta resolución) que sigue siendo
+distinto de una foto libre de celular con mano en el cuadro y fondo de finca. El clasificador
+tampoco sabe dudar de forma confiable: 13-14 de 15 fotos fuera de dominio (otro cultivo, u otra
+parte de la planta) recibieron una respuesta confiada en vez de abstención.
+
+**Lo que sí queda listo y es reusable**: datasets bajados/auditados/licenciados de verdad (con
+dos hallazgos de licencia y tamaño que corrigen al DR), un mapeo de taxonomía documentado
+(incluida la trampa "cercospora" ≠ "ojo de gallo colombiano"), un pipeline de entrenamiento
+reproducible con split leaf-safe donde el dataset lo permite, y un artefacto que **sí** corre sin
+la Ampere (verificado en CPU, ONNX exportado) — sólo que no es lo bastante bueno para
+diagnosticar en campo todavía. El camino correcto de acá es más fotos de campo REALES de Chagra
+(no aumentadas), no más ingeniería de augmentación sobre las mismas 1443 imágenes.
+
+## 1. Datasets: qué se bajó, licencia verificada, conteo real
+
+### RoCoLe — verificado, NO como decía el DR
+
+El DR (`Chagra-strategy/deepresearch/DR-FANOUT/datasets-pblicos-...`) decía **~15.000 imágenes,
+CC BY-NC-SA 4.0**. Verificado empíricamente contra la API pública de Mendeley Data
+(`https://data.mendeley.com/public-api/datasets/c5yvn32dzg?version=2`), **ambos datos son
+incorrectos**:
+
+- **Tamaño real: 1560 imágenes** (el paper original — Paraga-Alava et al. 2019, PMC6727496 —
+  lo dice explícitamente: "1560 robusta coffee leaf images"). El DR sobreestimó por ~10x.
+- **Licencia real: CC BY 4.0** (Creative Commons Attribution, SIN NonCommercial ni ShareAlike),
+  confirmada en el campo `data_licence` de la respuesta JSON de la API oficial de Mendeley, no
+  en la página de aterrizaje. Es MÁS permisiva que lo que decía el DR, así que sigue siendo
+  compatible con el catálogo de Chagra (CC BY-NC-SA 4.0, verificado en
+  `catalog/LICENSE.md` de este repo) — una obra CC BY se puede incorporar sin problema a una
+  colección con más restricciones, mientras se dé atribución.
+- Fuente: Parraga-Alava, J., Cusme, K., Loor, A., Santander, E. (2019). "RoCoLe: A robusta
+  coffee leaf images dataset for evaluation of machine learning based methods in plant diseases
+  recognition." Mendeley Data V2, doi: 10.17632/c5yvn32dzg.2.
+
+**Descarga incompleta — causa documentada, no oculta.** La API de listado de archivos de
+Mendeley (`/api/datasets/<id>/files`) está rota para paginación: ignora por completo el header
+`Range: items=N-M` y cualquier variante de query params probada (`offset`, `page`, `folder_id`
+explícito) — siempre devuelve los primeros 100 elementos sin importar lo pedido (confirmado con
+`content-range` idéntico en cada respuesta). El endpoint "download all" tampoco sirve (cae en un
+buscador genérico no relacionado al dataset). Sin acceso a un token de sesión de navegador real
+no se pudo forzar la paginación en el tiempo disponible. **Resultado: se bajaron 100/1560
+imágenes (6.4%)**, con checksum verificado por tamaño. Las 100 sí tienen etiqueta fiable: el
+propio nombre de archivo codifica planta + estado (`C<n>P<m><E|H><k>.jpg`, `E`=enferma/roya per
+la descripción del dataset, `H`=sana) — ver limitación de esa asunción en la sección de mapeo.
+
+### BRACOL — verificado, con un hallazgo serio: el zip alojado en Mendeley está corrupto
+
+- **Licencia real: CC BY 4.0** (igual verificación contra la API oficial de Mendeley Data,
+  dataset `yy2k5y8mxg` v1, campo `data_licence.short_name`). El DR también decía CC BY-NC-SA
+  4.0 para este — mismo patrón de sobre-restricción reportado incorrectamente.
+- **Tamaño real: 1747 imágenes** (leaf dataset), confirmado contra el paper original (Esgario,
+  Krohling, Ventura 2020, "Deep learning for classification and severity estimation of coffee
+  leaf biotic stress", arXiv:1907.11561): "272 healthy, 387 leaf miner, 531 rust, 348 brown leaf
+  spot (phoma), 147 cercospora" = 1685 de las 5 clases de etiqueta única + 62 filas "mixed" (dos
+  enfermedades empatadas, sin ganador claro) = **1747**, y esa distribución coincide dígito por
+  dígito con la que se extrajo directamente del `dataset.csv` incluido en el zip (ver tabla en la
+  sección 3) — cruce de verificación independiente exitoso. El DR decía ~3.000 — otra
+  sobreestimación (~1.7x).
+- **El .zip alojado en Mendeley (`yy2k5y8mxg`, 164,516,964 bytes) está truncado en origen.**
+  `sha256sum` del archivo descargado coincide EXACTAMENTE con el hash publicado por la API de
+  Mendeley (`25a2fc97...5fdfc1f`) — no es un error de red, el archivo hosteado ahí ya está roto
+  (le falta el End-Of-Central-Directory; `p7zip` lo confirma: "Unexpected end of archive",
+  physical size esperado 164,583,270 vs 164,516,964 bytes reales, diferencia de ~66 KB en la
+  cola). Se recuperó todo lo posible con `p7zip` (que reconstruye por escaneo de local file
+  headers en vez de depender del directorio central): **1402/1747 imágenes recuperadas (80.3%)**,
+  más el `dataset.csv` completo con las 1747 etiquetas (el CSV en sí no estaba dañado). El primer
+  archivo (`coffee-datasets/`) y el índice sobrevivieron; lo que falta son ~345 imágenes
+  dispersas por todo el archivo (no solo la cola), consistente con un orden de escritura no
+  secuencial en el zip original.
+
+### CoffeeNet
+
+No se bajó. Con el reloj corriendo y el hallazgo de que el DR se equivocó en licencia Y tamaño
+para los dos datasets anteriores, se priorizó verificar y entrenar sobre RoCoLe+BRACOL (que ya
+dieron ~1450 imágenes utilizables) en vez de perseguir un tercer dataset de licencia sin
+verificar. Queda como trabajo futuro explícito.
+
+## 2. Mapeo de taxonomía de clases — la trampa que pide la tarea
+
+**NO se asumió que "rust"=="roya" con el mismo criterio en los dos datasets sin revisar.**
+Los dos, BRACOL y RoCoLe, resultaron describir la MISMA enfermedad (*Hemileia vastatrix*, roya)
+para su etiqueta positiva, verificado contra ambos papers originales — así que la fusión es
+válida para esa clase. Pero hay una trampa real y documentada, no hipotética:
+
+- **BRACOL/RoCoLe llaman "cercospora" a *Cercospora coffeicola*** (mancha de cercospora, "mancha
+  de hierro" en Brasil). **En Colombia, "ojo de gallo" casi siempre se refiere a *Mycena
+  citricolor*** (mancha americana de la hoja), un hongo DISTINTO. Chagra ya tiene una foto de
+  campo para *Mycena citricolor* (`mycena_citricolor.jpg`) que NO corresponde a la clase
+  "cercospora" del modelo. Esto se documenta explícitamente en el eval de las 18 fotos (sección
+  7) — si el modelo predice "cercospora" para esa foto, es una coincidencia de nombre común, no
+  un diagnóstico correcto, y el reporte lo marca así.
+
+Tabla de mapeo final usada (5 clases):
+
+| Clase canónica (modelo) | BRACOL `predominant_stress` | RoCoLe | Especie |
+|---|---|---|---|
+| `sana` | 0 (272 leaves) | `H` (healthy) | — |
+| `roya` | 2 (531 leaves) | `E` (unhealthy, per descripción del dataset) | *Hemileia vastatrix* |
+| `minador` | 1 (387 leaves) | no presente | *Leucoptera coffeella* |
+| `phoma` | 3 (348 leaves, "brown leaf spot") | no presente | *Phoma sp.* |
+| `cercospora` | 4 (147 leaves) | no presente | *Cercospora coffeicola* (≠ ojo de gallo colombiano) |
+| excluido | 5 ("mixed", 62 leaves — dos enfermedades empatadas sin ganador claro) | — | — |
+
+**Asunción marcada explícitamente, no verificada de forma independiente**: RoCoLe describe su
+clase "unhealthy" como "visible mites and spots (denoting coffee leaf rust presence)" en la
+propia página del dataset — se tomó esa descripción al pie de la letra para mapear `E`→`roya`.
+No se pudo cruzar contra un archivo de severidad/anotación separado (no se logró listar el
+archivo completo del dataset por la falla de paginación de la API descrita arriba), así que si
+alguna de las 50 imágenes `E` descargadas fuera en realidad ácaro rojo (mencionado también en la
+descripción) y no roya, quedaría mal etiquetada. Riesgo acotado: son 50/1443 imágenes (3.5% del
+total de entrenamiento).
+
+## 3. Conteos reales (post-fusión, post-limpieza)
+
+Generado por `scripts/ml/vision-cafe/prep_manifest.py` (ver
+`/home/kortux/datasets/cafe/manifests/prep_summary.json` para el JSON completo).
+
+- BRACOL: 1747 filas en `dataset.csv` → 62 excluidas por `predominant_stress==5` (mixed/empate,
+  ambiguo para etiqueta única) → 342 sin archivo de imagen recuperable (el zip corrupto, sección
+  1) → **1343 imágenes utilizables**.
+- RoCoLe: 100/100 archivos descargados, 100 parseados correctamente por el patrón de nombre
+  (`C<n>P<m><E|H><k>.jpg`) → **100 imágenes utilizables**.
+- **Total combinado: 1443 imágenes.**
+
+| clase | BRACOL | RoCoLe | total |
+|---|---:|---:|---:|
+| sana | 142 | 50 | 192 |
+| roya | 465 | 50 | 515 |
+| minador | 254 | 0 | 254 |
+| phoma | 346 | 0 | 346 |
+| cercospora | 136 | 0 | 136 |
+
+Split resultante (train/val/test, agrupado por hoja/planta donde el dataset lo permite —
+sección 4):
+
+| split | sana | minador | roya | phoma | cercospora | total |
+|---|---:|---:|---:|---:|---:|---:|
+| train | 128 | 174 | 362 | 242 | 105 | 1011 |
+| val | 34 | 41 | 69 | 50 | 17 | 211 |
+| test | 30 | 39 | 84 | 54 | 14 | 221 |
+
+`cercospora` es la clase más chica en las tres particiones (14 imágenes en test) — cualquier
+métrica por-clase de esa clase en particular tiene el intervalo de confianza más ancho de las
+cinco; se señala explícitamente al leer la sección 6.
+
+## 4. Split — por hoja/planta cuando el dataset lo permite, limitación explícita cuando no
+
+- **RoCoLe: split leaf/plant-safe.** El nombre de archivo codifica el id de planta
+  (`C<n>P<m>...`). Todas las imágenes de la misma planta quedan en el MISMO split
+  (train/val/test) — nunca partidas entre dos. Implementado como agrupamiento explícito antes
+  del split aleatorio (no split por imagen).
+- **BRACOL: split por imagen, NO por hoja — limitación explícita, no ocultada.** El
+  `dataset.csv` liberado por los autores expone solo un `id` secuencial plano, sin ningún campo
+  de hoja/planta/parcela. No hay forma de saber, con los metadatos publicados, si dos ids
+  distintos son fotos de la misma hoja física. **Si BRACOL contiene fotos repetidas de la misma
+  hoja bajo ids distintos, la porción BRACOL de la métrica de test podría estar optimista.** Se
+  buscó evidencia indirecta (nombres de archivo secuenciales sin patrón de agrupamiento visible)
+  pero no se pudo confirmar ni descartar en el tiempo disponible.
+- Split final: 70/15/15 train/val/test, agrupado como se describe arriba.
+
+## 5. Modelo y entrenamiento
+
+- **Backbone: EfficientNet-B0** (torchvision, pesos ImageNet1K_V1), fine-tune completo.
+  Justificación: (a) dataset chico (~1450 imágenes) — un ViT sin datos/regularización extra
+  generaliza peor que una CNN con sesgo inductivo; (b) **tiene que sobrevivir sin la Ampere**
+  (CPU o Quadro M6000 sm_52, que torch 2.11 ni siquiera trae kernels CUDA para) — EfficientNet-B0
+  son 5.3M parámetros contra 28M de ConvNeXt-Tiny o 86M de ViT-B/16, la única opción cómoda para
+  inferencia en CPU de las tres; (c) precedente fuerte en la literatura de diagnóstico de café
+  por imagen (los propios papers de BRACOL/RoCoLe usan arquitecturas de esta familia).
+- **Augmentación pensada para el campesino** (celular barato, mala luz, ángulo raro, hoja en la
+  mata, no arrancada): `RandomResizedCrop` (encuadres variables), `ColorJitter` agresivo
+  (brillo/contraste/saturación — simula mala luz), `GaussianBlur` aplicado con probabilidad 35%
+  (desenfoque de cámara barata/mano temblando), `RandomPerspective` (ángulos no frontales),
+  `RandomRotation`, `RandomErasing` (oclusión parcial — dedo, otra hoja tapando).
+- **Loss ponderada por clase** (inverso de frecuencia) para compensar el desbalance (roya 531 en
+  train vs cercospora 105).
+- **run1** (augmentación base): 35 epochs, 416.5s (~7 min) en la RTX 3090, batch 24, compartida
+  en paralelo con un bench de embedders (otro `codex` de otra tarea) — `nvidia-smi` mostró
+  6.6-8.4 GB en uso por el vecino durante toda la corrida, nunca se acaparó la tarjeta.
+  `best_val_macro_f1 = 0.896` en epoch 30.
+- **run2** (augmentación reforzada, motivada por el hallazgo de la sección 7): mismo dataset y
+  split, `RandomResizedCrop` con escala más agresiva (0.3-1.0 en vez de 0.6-1.0, para que el
+  modelo vea la hoja ocupando una fracción chica del cuadro y no solo hoja-llena-el-cuadro como
+  en BRACOL/RoCoLe), `RandomAffine` con traslación (hoja descentrada), `RandomErasing` más
+  agresivo (hasta 35% del área, p=0.5, simula mano/otra hoja tapando parte), y una pasada de
+  downsample→upsample aleatoria (simula compresión/resolución baja de celular barato). 40
+  epochs.
+
+## 6. Métricas — por clase, no accuracy global
+
+**run1**, sobre el split de test (n=221, leaf/plant-safe para RoCoLe, image-level para BRACOL,
+ver limitación de la sección 4). Accuracy global = 0.896 — **se reporta pero no es la métrica
+que importa**, ahí abajo está el desglose real:
+
+| clase | precision | recall | f1 | n (test) |
+|---|---:|---:|---:|---:|
+| roya | 0.900 | 0.964 | 0.931 | 84 |
+| phoma | 0.980 | 0.889 | 0.932 | 54 |
+| minador | 0.917 | 0.846 | 0.880 | 39 |
+| sana | 0.848 | 0.933 | 0.889 | 30 |
+| **cercospora** | **0.615** | **0.571** | **0.593** | 14 |
+
+macro F1 = 0.845. **cercospora es, con claridad, la clase débil** — la más chica de las cinco
+(14 en test) y la que peor generaliza.
+
+Matriz de confusión (filas=verdadero, columnas=predicho, orden `[cercospora, minador, phoma,
+roya, sana]`):
+
+```
+              pred_cercospora  pred_minador  pred_phoma  pred_roya  pred_sana
+true_cercospora        8            0            0          5          1
+true_minador            1           33            1          3          1
+true_phoma               3           1           48          0          2
+true_roya                1           1            0         81          1
+true_sana                 0          1            0          1         28
+```
+
+**El error que más importa clínicamente**: de 14 hojas verdaderamente `cercospora` en test, **5
+(36%) fueron clasificadas como `roya`.** Ese es exactamente el escenario que la tarea advierte
+como peligroso — confundir cercospora con roya manda a comprar/aplicar el fungicida
+equivocado. `phoma` y `roya` en cambio casi no se confunden entre sí ni con las demás (ambas con
+recall >88%).
+
+## 7. La prueba que decide: las 18 fotos reales de campo
+
+**Aviso de alcance, antes de los números**: el clasificador es de **enfermedades de HOJA de
+café, 5 clases**. De las 18 fotos en `public/plaga-images/`, la gran mayoría NO son ni café ni
+enfermedad de hoja (papa, yuca, banano, maíz, frijol, cacao, plagas de fruto/raíz). Comparar un
+accuracy global de "X/18" sería una cifra sin sentido — se reporta en dos partes:
+
+1. **Subconjunto estrictamente dentro de dominio** (café, enfermedad de hoja, en la taxonomía
+   de 5 clases del modelo): sólo 2 de las 18 fotos califican sin ambigüedad —
+   `hemileia_vastatrix.jpg` (roya) y `cercospora_coffeicola.jpg` (cercospora). No se encontró el
+   reporte fuente del "5/8" de la torre multimodal pese a buscarlo (no está en los archivos de
+   `Chagra-strategy/ops/` revisados); se toma como dato dado por la tarea, con la salvedad de que
+   probablemente evaluaba sobre un conjunto de fotos/criterio distinto (multi-cultivo, no solo
+   café-hoja), así que la comparación numérica directa es débil incluso siendo honesta al
+   respecto.
+2. **Comportamiento ante fotos fuera de dominio** (15 fotos: otro cultivo, o plaga de fruto/
+   raíz no de hoja): la prueba real de "debe saber dudar".
+
+**Resultado run1 — MALO, y se reporta así:**
+
+| foto | predicción | confianza | ¿abstiene? (umbral 0.55) | dominio |
+|---|---|---:|---|---|
+| `hemileia_vastatrix.jpg` (roya, síntoma muy visible) | **sana** ❌ | 0.943 | no | dentro de taxonomía |
+| `cercospora_coffeicola.jpg` (cercospora, lesión chica) | **sana** ❌ | 0.519 | sí (borderline) | dentro de taxonomía |
+
+**Subconjunto estricto dentro de dominio: 0/2 correctas. NO le gana al 5/8 (62.5%) de la torre
+multimodal — al contrario, se equivoca en las dos.**
+
+Inspección visual de las dos fotos (se miraron directamente, no se infirió): `hemileia_vastatrix.jpg`
+muestra una hoja sostenida por una mano, con pústulas naranjas cubriendo gran parte del envés —
+síntoma de manual, inconfundible a simple vista — sobre un fondo de finca desenfocado.
+`cercospora_coffeicola.jpg` muestra una hoja sobre una superficie de concreto, con UNA sola
+lesión pequeña bien definida (mancha oscura con halo amarillo) — el resto de la hoja está sana,
+así que la confusión con "sana" es más comprensible ahí (predomina el área sana en el cuadro).
+
+**Diagnóstico (no solo el número, la causa)**: las fotos de entrenamiento de BRACOL/RoCoLe son
+de hoja completa, fondo liso/controlado, resolución alta (2048×1024, estilo "hoja sobre mesa de
+trabajo/fondo neutro" consistente con el protocolo de cuantificación de severidad de esos
+papers). Las fotos reales de Chagra (540-720px, unos pocos KB) tienen mano en el cuadro, fondo de
+finca desordenado, y la hoja no siempre llena el encuadre. **Esto es un segundo salto de brecha
+de dominio, más allá de "laboratorio vs campo"**: incluso dos datasets académicos "de campo"
+tienen su propio protocolo fotográfico (hoja aislada, fondo controlado) que no es lo mismo que
+una foto libre de celular. Se probaron variantes de preprocesamiento en inferencia (crop más
+amplio, resize sin crop, five-crop promediado) sobre el mismo checkpoint de run1 — mejoran algo
+la confianza en `cercospora_coffeicola.jpg` (hasta acertar con resize320+centercrop y five-crop)
+pero **`hemileia_vastatrix.jpg` sigue prediciendo "sana" en todas las variantes probadas** — no
+es un artefacto de crop, es que el modelo no generalizó el patrón visual de roya fuera del
+protocolo fotográfico de sus datos de entrenamiento.
+
+**Comportamiento fuera de dominio (15 fotos)**: 14/15 respondieron con confianza ≥ 0.55 a pesar
+de no ser ni café ni enfermedad de hoja — el modelo casi nunca duda cuando debería. Ejemplos:
+`alternaria_solani.jpg` (tizón de papa/tomate) → predicho "roya" con 0.994 de confianza;
+`ustilago_maydis.jpg` (carbón del maíz) → "roya" con 0.993; `moniliophthora_perniciosa.jpg`
+(escoba de bruja del CACAO, no café) → "sana" con 0.991. **El modelo no sabe dudar** — el umbral
+de confianza tal como está calibrado no sirve como salvaguarda de producción.
+
+`mycena_citricolor.jpg` (el "ojo de gallo" colombiano de verdad, hongo distinto al `cercospora`
+de BRACOL) predijo "sana" con 0.606 — por encima del umbral, otro falso negativo, y confirma la
+trampa de taxonomía documentada en la sección 2: aunque hubiera acertado con "cercospora" ahí,
+habría sido un acierto de nombre común, no de hongo.
+
+Tabla completa y JSON crudo: `/home/kortux/qlora-out/vision-cafe/eval_18_results.json`, generado
+por `scripts/ml/vision-cafe/eval_18.py` (evaluado con una copia congelada de las 18 fotos
+originales — ver nota en el script sobre por qué no se leyó `public/plaga-images/` en vivo).
+
+### 7.2 Resultado run2 (augmentación reforzada) — la hipótesis se probó y NO alcanzó
+
+40 epochs, 352.6s, misma GPU compartida. **Test interno (split leaf/plant-safe) empeoró respecto
+a run1**: acc 0.819 (vs 0.896), macro F1 0.763 (vs 0.845). El costo se concentra en
+`cercospora`: recall subió (0.571→0.643) pero precision se hundió (0.615→0.290) — la
+augmentación más agresiva volvió al modelo más propenso a gritar "cercospora" en general,
+incluyendo 9 hojas que en verdad eran `roya` (antes solo 1 en run1). Cambió qué confusión
+domina, no la resolvió.
+
+**Contra las 18 fotos reales, la hipótesis tampoco se sostuvo:**
+
+| foto | run1 | run2 |
+|---|---|---|
+| `hemileia_vastatrix.jpg` | sana ❌ (conf 0.943) | sana ❌ (conf 0.894) |
+| `cercospora_coffeicola.jpg` | sana ❌ (conf 0.519, casi abstiene) | sana ❌ (conf 0.901, **peor** — ahora confiado) |
+
+**run2: 0/2 en el subconjunto estricto, igual que run1.** Fuera de dominio: 13/15 respuestas
+confiadas (vs 14/15 en run1) — mejora marginal, sigue sin saber dudar de forma confiable.
+
+**Conclusión del experimento**: la augmentación más agresiva (crops parciales, hoja
+descentrada, oclusión más grande, degradación tipo celular barato) no cerró la brecha, y en el
+propio test interno la empeoró. Esto es evidencia en contra de que el problema sea *solamente*
+encuadre/resolución — apunta a que el gap es más fundamental: el modelo aprendió texturas/
+colores específicos del protocolo fotográfico de BRACOL+RoCoLe (iluminación de estudio, fondo
+neutro consistente) que no se replican con augmentación sintética sobre las mismas fotos base.
+La solución real sería más diversidad de FUENTE (fotos de campo genuinas, no aumentadas), no más
+augmentación sobre las mismas ~1450 imágenes.
+
+**Artefacto final elegido: run1.** Mejor en las tres dimensiones medidas (test interno, y no
+peor en las 18 fotos reales) — se descarta run2 para producción, se documenta como intento
+fallido, no se oculta.
+
+## 8. Empaquetado — verificado SIN la Ampere
+
+Artefacto final: **run1** (mejor en todas las métricas medidas). `export_package.py` carga el
+checkpoint con `map_location="cpu"` y corre una inferencia sin tocar CUDA en ningún punto del
+camino:
+
+- **Carga: 0.095s. Inferencia de una imagen en CPU: 31.6ms.** Suficientemente rápido para servir
+  detrás de un endpoint sin GPU (la M6000 sm_52 sobra para esto, ni siquiera hace falta —CPU puro
+  ya cumple).
+- **ONNX exportado con éxito** (16.0 MB) — tuvo que forzarse el exportador legado
+  (`dynamo=False`) porque el exportador nuevo por-default de torch≥2.9 requiere el paquete
+  opcional `onnxscript`, no instalado en el venv `qlora-dpo` (no se instaló nada nuevo ahí, por
+  la regla dura de no tocar ese venv sin `--no-deps`).
+- Artefactos en `/home/kortux/qlora-out/vision-cafe/`: `model.pt` (16.3 MB, peso principal),
+  `model.onnx` (16.0 MB), `MANIFEST.json`, `classes.json`, `cpu_only_check.json`,
+  `eval_18_results.json` / `eval_18_results_run2.json`, `test_results_run1.json` /
+  `test_results_run2.json`, `train_log_run1.json` / `train_log_run2.json`.
+- **La verificación "sin Ampere" pasa.** Lo que no pasa es la de calidad (sección 7) — son dos
+  preguntas distintas y las dos se responden por separado, tal como pide la tarea.
+
+## 9. Veredicto honesto: ¿a producción o no?
+
+**NO.** Con la evidencia de esta corrida, este clasificador no debe reemplazar ni complementar el
+diagnóstico visual de Chagra todavía. Razones concretas:
+
+1. **Falla el único test que importa** (fotos reales de campo de Chagra), no el test que se
+   inventó el propio pipeline (el split interno de BRACOL/RoCoLe). 0/2 en el subconjunto
+   estrictamente comparable, incluyendo un falso negativo confiado al 94% sobre un caso de roya
+   con síntoma de manual.
+2. **No sabe dudar.** El objetivo explícito de la tarea era que el modelo tuviera un umbral de
+   confianza útil para abstenerse; en la práctica, 13-14 de 15 fotos claramente fuera de dominio
+   recibieron una respuesta confiada. Desplegar esto tal cual **es peor que no tener modelo**:
+   le daría a un campesino una etiqueta con apariencia de certeza sobre una enfermedad de otro
+   cultivo, o "sana" sobre una hoja con roya visible.
+3. **El segundo intento (más augmentación) no lo arregló** y empeoró el modelo en su propia
+   métrica interna — descarta la hipótesis más barata de arreglar esto (más tiempo de GPU con la
+   misma data) y apunta a que hace falta más DATOS reales, no más entrenamiento.
+4. `cercospora` (la clase más chica, 14 imágenes en test) es estructuralmente débil incluso
+   dentro del propio dataset (f1=0.593 en run1) — con 3-4x menos ejemplos que roya, cualquier
+   despliegue real necesitaría más datos de esa clase de todas formas.
+
+**Lo que SÍ vale de este trabajo** (no se tira, por la regla dura de la tarea sobre reportar
+Fase 1 aunque la Fase 2/3 no llegue a buen puerto):
+
+- Datasets bajados, auditados y con licencia verificada de forma independiente — corrige dos
+  errores del DR (licencia y tamaño) que habrían quedado sin detectar si se hubiera confiado en
+  el documento en vez de verificar contra la fuente primaria.
+- Pipeline de entrenamiento reproducible (`scripts/ml/vision-cafe/`), con manejo correcto de
+  split leaf-safe donde el metadato lo permite, loss ponderada por clase, y augmentación
+  orientada a campo.
+- Confirmación empírica y reproducible de que un EfficientNet-B0 SÍ corre sin la Ampere (31ms/
+  imagen en CPU) — el camino de despliegue (M6000 o CPU puro) está probado, sólo falta un modelo
+  que valga la pena desplegar.
+- Un diagnóstico honesto y accionable del PORQUÉ falla: falta diversidad fotográfica real de
+  campo (mano en el cuadro, fondo de finca, celular barato), no arquitectura ni augmentación.
+
+**Recomendación concreta para la próxima vuelta (cuando llegue la 5070 Ti)**: antes de re-entrenar,
+conseguir aunque sea 50-100 fotos de café tomadas con el protocolo real de Chagra (celular,
+campo, sin controlar fondo) por clase — mezclarlas con BRACOL/RoCoLe como fine-tuning final sobre
+ese dominio específico, no como augmentación sintética de las mismas fotos de estudio. Esa es la
+brecha que este informe deja identificada y medida, no adivinada.
+
+## 10. Trabajo futuro explícito
+
+- CoffeeNet no se bajó (licencia sin verificar en el tiempo disponible).
+- RoCoLe: solo 6.4% del dataset (100/1560) por la falla de paginación de la API de Mendeley
+  documentada arriba. Recuperar el resto requiere o bien acceso autenticado (cuenta Mendeley +
+  sesión de navegador real) o un mirror alternativo con licencia verificada de forma
+  independiente (hay copias en Kaggle sin auditar aquí).
+- BRACOL: 80.3% recuperado (1402/1747) por corrupción del zip alojado en origen en Mendeley — se
+  podría reportar el bug a los mantenedores del dataset, o buscar el mismo dataset en el mirror
+  de GitHub `esgario/lara2018` (apunta a Google Drive, no intentado por tiempo).
+- Split de BRACOL no es leaf-safe (ver sección 4) — si llega tiempo/GPU después de la 5070 Ti,
+  vale la pena contactar a los autores por un id de hoja/planta, o inspeccionar visualmente una
+  muestra para descartar duplicados antes de confiar en el número de test al 100%.
+- **La prioridad real para la próxima vuelta no es más GPU, es más fotos de campo reales de
+  Chagra** (ver sección 9) — se probó que more-augmentation-on-same-data no cierra la brecha
+  (run2), así que insistir por ese camino sin datos nuevos es tiempo de Ampere mal gastado.
+- `mycena_citricolor` ("ojo de gallo" colombiano real) no tiene representación en el dataset de
+  entrenamiento — sería una 6ª clase necesaria si se quiere cubrir el nombre común que de verdad
+  usa el campesino colombiano, no solo el equivalente brasileño/ecuatoriano.

--- a/scripts/ml/vision-cafe/dl_rocole.py
+++ b/scripts/ml/vision-cafe/dl_rocole.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Download all RoCoLe files (Mendeley c5yvn32dzg v2) with metadata manifest."""
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+DATASET_ID = "c5yvn32dzg"
+VERSION = 2
+OUT_DIR = "/home/kortux/datasets/cafe/raw/rocole"
+MANIFEST = "/home/kortux/datasets/cafe/manifests/rocole_files.json"
+
+os.makedirs(OUT_DIR, exist_ok=True)
+os.makedirs(os.path.dirname(MANIFEST), exist_ok=True)
+
+UA = "Mozilla/5.0 (X11; Linux x86_64) chagra-dataset-fetch/1.0"
+
+def fetch_page(start, end):
+    url = f"https://data.mendeley.com/api/datasets/{DATASET_ID}/files?version={VERSION}"
+    req = urllib.request.Request(url, headers={"Range": f"items={start}-{end}", "User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        cr = r.headers.get("Content-Range", "")
+        data = json.loads(r.read())
+        grand_total = None
+        if "/" in cr:
+            try:
+                grand_total = int(cr.rsplit("/", 1)[1])
+            except ValueError:
+                pass
+        return data, grand_total
+
+# First page to learn total count
+all_files = []
+seen_ids = set()
+start = 0
+page = 99
+grand_total = None
+while True:
+    end = start + page
+    for attempt in range(5):
+        try:
+            batch, gt = fetch_page(start, end)
+            break
+        except Exception as e:
+            print(f"retry {attempt} for {start}-{end}: {e}", file=sys.stderr)
+            time.sleep(2)
+    else:
+        print(f"FAILED page {start}-{end}, aborting", file=sys.stderr)
+        break
+    if gt is not None:
+        grand_total = gt
+    if not batch:
+        break
+    new = 0
+    for item in batch:
+        if item["id"] not in seen_ids:
+            seen_ids.add(item["id"])
+            all_files.append(item)
+            new += 1
+    print(f"fetched {start}-{end}, total so far {len(all_files)} (grand_total={grand_total})", file=sys.stderr)
+    if grand_total is not None and len(all_files) >= grand_total:
+        break
+    if new == 0:
+        print("no new items in this page, stopping (avoid infinite loop)", file=sys.stderr)
+        break
+    if len(batch) < (end - start + 1):
+        break
+    start = end + 1
+    time.sleep(0.2)
+
+print(f"TOTAL FILES LISTED: {len(all_files)} (server reported grand_total={grand_total})", file=sys.stderr)
+with open(MANIFEST, "w") as f:
+    json.dump(all_files, f)
+
+# Now download each file (skip if already present with correct size), parallel
+def dl_one(entry):
+    fn = entry["filename"]
+    url = entry["content_details"]["download_url"]
+    size = entry["size"]
+    dest = os.path.join(OUT_DIR, fn)
+    if os.path.exists(dest) and os.path.getsize(dest) == size:
+        return (fn, True)
+    for attempt in range(4):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": UA})
+            with urllib.request.urlopen(req, timeout=30) as r, open(dest, "wb") as out:
+                out.write(r.read())
+            if os.path.getsize(dest) == size:
+                return (fn, True)
+            else:
+                time.sleep(1)
+        except Exception as e:
+            time.sleep(1)
+    return (fn, False)
+
+ok, failed = 0, 0
+done = 0
+with ThreadPoolExecutor(max_workers=10) as ex:
+    futs = {ex.submit(dl_one, e): e for e in all_files}
+    for fut in as_completed(futs):
+        fn, success = fut.result()
+        done += 1
+        if success:
+            ok += 1
+        else:
+            failed += 1
+            print(f"FAILED {fn}", file=sys.stderr)
+        if done % 100 == 0 or done == len(all_files):
+            print(f"progress {done}/{len(all_files)} ok={ok} failed={failed}", file=sys.stderr)
+
+print(f"DONE. ok={ok} failed={failed} total={len(all_files)}", file=sys.stderr)

--- a/scripts/ml/vision-cafe/eval_18.py
+++ b/scripts/ml/vision-cafe/eval_18.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Evaluate the trained coffee-leaf classifier against Chagra's 18 real field photos.
+
+This is deliberately NOT a clean apples-to-apples accuracy number, and the script says so:
+the classifier is coffee-leaf-disease-only (5 classes: sana/roya/minador/cercospora/phoma),
+scoped to LEAF symptoms. Most of the 18 photos are NOT coffee leaf disease at all (other crops
+entirely, or a coffee pest that shows on the berry, not the leaf). Running the model on those
+is the deliberate "does it know how to doubt" test: an out-of-domain photo should NOT get a
+confident wrong label.
+
+For each image we report: predicted class, softmax confidence, full class probability vector,
+and a domain tag (coffee_leaf_disease_in_taxonomy / coffee_but_out_of_taxonomy / other_crop)
+assigned by hand from the binomial name -- documented inline, not inferred by the model.
+"""
+import argparse
+import json
+import os
+
+import torch
+from PIL import Image
+from torchvision import transforms
+from torchvision.models import efficientnet_b0
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+
+PLAGA_DIR = "/home/kortux/datasets/cafe/plaga18_frozen"
+# ^ frozen copy of the *original 18* public/plaga-images/*.jpg (binomio-only filenames, no
+#   _2/_3 suffixes). Deliberately NOT pointed at the live public/plaga-images/ directory:
+#   at the time this ran, a parallel task (2026-07-15-opencode-fotos-plagas-gbif) was actively
+#   adding ~160 more photos (with _2/_3 suffixes, non-coffee species) to that same directory,
+#   and reading it live would have been racy and would have broken the "18 fotos" scope this
+#   task specifies. Freeze step: `cp public/plaga-images/*.jpg <this dir>` before that task
+#   started writing to it.
+
+# Hand-verified domain tags. NOT guessed by the model -- assigned from the binomial /
+# common taxonomy so the report doesn't compare apples to oranges.
+DOMAIN_TAGS = {
+    "hemileia_vastatrix.jpg": ("coffee_leaf_disease_in_taxonomy", "roya"),
+    "cercospora_coffeicola.jpg": ("coffee_leaf_disease_in_taxonomy", "cercospora"),
+    "mycena_citricolor.jpg": ("coffee_leaf_disease_taxonomy_trap",
+        "ojo de gallo (Mycena citricolor) -- DIFFERENT fungus than BRACOL's 'cercospora' "
+        "(Cercospora coffeicola). Same common name in Colombia, different pathogen. Model "
+        "has never seen this fungus; predicting 'cercospora' here would be a name coincidence, "
+        "not a correct diagnosis."),
+    "hypothenemus_hampei.jpg": ("coffee_pest_not_leaf",
+        "broca -- infests the coffee BERRY, not the leaf. Architecturally out of scope for a "
+        "leaf classifier; included to see if it at least does not claim a leaf disease."),
+    "capnodium_negrilla.jpg": ("coffee_adjacent_not_in_taxonomy",
+        "sooty mold, can occur on coffee but is not one of the 5 BRACOL classes."),
+    "mosca_blanca.jpg": ("coffee_adjacent_not_in_taxonomy",
+        "whitefly, generic pest, not one of the 5 BRACOL leaf-disease classes."),
+    "meloidogyne.jpg": ("other_crop_or_not_leaf", "root-knot nematode, root symptom, not leaf, not coffee-specific."),
+    "alternaria_solani.jpg": ("other_crop", "potato/tomato early blight"),
+    "colletotrichum_lindemuthianum.jpg": ("other_crop", "bean anthracnose"),
+    "geminivirus_cuchara.jpg": ("other_crop", "cassava geminivirus"),
+    "mocis_latipes.jpg": ("other_crop", "grass looper, pasture pest"),
+    "moniliophthora_perniciosa.jpg": ("other_crop", "cacao witches' broom (NOT coffee)"),
+    "mycosphaerella_fijiensis.jpg": ("other_crop", "banana black Sigatoka"),
+    "phytophthora_infestans.jpg": ("other_crop", "potato late blight"),
+    "premnotrypes_vorax.jpg": ("other_crop", "Andean potato weevil"),
+    "spodoptera_frugiperda.jpg": ("other_crop", "fall armyworm, maize pest"),
+    "tecia_solanivora.jpg": ("other_crop", "potato tuber moth"),
+    "ustilago_maydis.jpg": ("other_crop", "corn smut"),
+}
+
+
+def load_model(ckpt_path, device):
+    ckpt = torch.load(ckpt_path, map_location=device, weights_only=False)
+    classes = ckpt["classes"]
+    model = efficientnet_b0(weights=None)
+    in_features = model.classifier[1].in_features
+    model.classifier[1] = torch.nn.Linear(in_features, len(classes))
+    model.load_state_dict(ckpt["model_state"])
+    model.to(device)
+    model.eval()
+    return model, classes, ckpt.get("img_size", 224)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", required=True)
+    ap.add_argument("--device", default="cpu")
+    ap.add_argument("--threshold", type=float, default=0.55)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    device = args.device
+    model, classes, img_size = load_model(args.ckpt, device)
+    print(f"loaded {args.ckpt} device={device} classes={classes} img_size={img_size}")
+
+    tf = transforms.Compose([
+        transforms.Resize(int(img_size * 256 / 224)),
+        transforms.CenterCrop(img_size),
+        transforms.ToTensor(),
+        transforms.Normalize(IMAGENET_MEAN, IMAGENET_STD),
+    ])
+
+    files = sorted(f for f in os.listdir(PLAGA_DIR) if f.lower().endswith((".jpg", ".jpeg", ".png")))
+    print(f"found {len(files)} images in {PLAGA_DIR}")
+
+    results = []
+    with torch.no_grad():
+        for fn in files:
+            path = os.path.join(PLAGA_DIR, fn)
+            img = Image.open(path).convert("RGB")
+            x = tf(img).unsqueeze(0).to(device)
+            logits = model(x)
+            probs = torch.softmax(logits, dim=1)[0]
+            top_p, top_i = probs.max(0)
+            pred_class = classes[top_i.item()]
+            conf = top_p.item()
+            tag, note = DOMAIN_TAGS.get(fn, ("UNTAGGED", ""))
+            abstain = conf < args.threshold
+            row = {
+                "file": fn, "pred": pred_class, "confidence": round(conf, 4),
+                "abstain_at_threshold": abstain,
+                "probs": {c: round(p, 4) for c, p in zip(classes, probs.tolist())},
+                "domain_tag": tag, "note": note,
+            }
+            results.append(row)
+            print(f"{fn:45s} pred={pred_class:12s} conf={conf:.3f} {'[ABSTAIN]' if abstain else '':10s} tag={tag}")
+
+    in_tax = [r for r in results if r["domain_tag"] == "coffee_leaf_disease_in_taxonomy"]
+    correct = sum(1 for r in in_tax if r["pred"] == {"hemileia_vastatrix.jpg": "roya",
+                                                       "cercospora_coffeicola.jpg": "cercospora"}[r["file"]])
+    print(f"\nSTRICT in-taxonomy coffee leaf-disease subset: {correct}/{len(in_tax)} correct")
+
+    out_of_domain = [r for r in results if r["domain_tag"] in
+                      ("other_crop", "other_crop_or_not_leaf", "coffee_pest_not_leaf",
+                       "coffee_adjacent_not_in_taxonomy")]
+    confident_wrong = [r for r in out_of_domain if not r["abstain_at_threshold"]]
+    print(f"Out-of-domain photos ({len(out_of_domain)}): {len(confident_wrong)} were answered "
+          f"with confidence >= {args.threshold} despite being outside the model's domain "
+          f"(these would be dangerous false-confidence in production).")
+
+    summary = {
+        "n_total": len(results), "threshold": args.threshold,
+        "strict_in_taxonomy_correct": correct, "strict_in_taxonomy_n": len(in_tax),
+        "out_of_domain_n": len(out_of_domain),
+        "out_of_domain_confident_wrong_n": len(confident_wrong),
+        "results": results,
+    }
+    out_path = args.out or "/home/kortux/qlora-out/vision-cafe/eval_18_results.json"
+    with open(out_path, "w") as f:
+        json.dump(summary, f, indent=2, ensure_ascii=False)
+    print(f"\nwrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ml/vision-cafe/export_package.py
+++ b/scripts/ml/vision-cafe/export_package.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Package the trained checkpoint for survival without the RTX 3090.
+
+- Copies the best .pt checkpoint to a stable name.
+- Tries an ONNX export (best-effort, non-fatal if it fails).
+- Verifies CPU-only load + single-image inference actually works (forces device='cpu',
+  does NOT touch torch.cuda at all) -- this is the check the task calls non-negotiable:
+  "si solo corre en la 3090, no sirve."
+"""
+import argparse
+import json
+import os
+import shutil
+import time
+
+import torch
+from torchvision.models import efficientnet_b0
+
+OUT_DIR = "/home/kortux/qlora-out/vision-cafe"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", required=True)
+    args = ap.parse_args()
+
+    stable_pt = os.path.join(OUT_DIR, "model.pt")
+    shutil.copy2(args.ckpt, stable_pt)
+    print(f"copied {args.ckpt} -> {stable_pt}")
+
+    # ---- CPU-only load + inference check (no CUDA calls at all) ----
+    t0 = time.time()
+    ckpt = torch.load(stable_pt, map_location="cpu", weights_only=False)
+    classes = ckpt["classes"]
+    img_size = ckpt.get("img_size", 224)
+    model = efficientnet_b0(weights=None)
+    in_features = model.classifier[1].in_features
+    model.classifier[1] = torch.nn.Linear(in_features, len(classes))
+    model.load_state_dict(ckpt["model_state"])
+    model.eval()
+    load_time = time.time() - t0
+
+    dummy = torch.randn(1, 3, img_size, img_size)
+    t1 = time.time()
+    with torch.no_grad():
+        out = model(dummy)
+    infer_time = time.time() - t1
+    assert out.shape == (1, len(classes)), f"unexpected output shape {out.shape}"
+    print(f"CPU-ONLY CHECK OK: load={load_time:.2f}s single-image-inference={infer_time*1000:.1f}ms "
+          f"output_shape={tuple(out.shape)} classes={classes}")
+
+    cpu_check = {
+        "cpu_only_load_ok": True, "load_time_s": round(load_time, 3),
+        "cpu_single_inference_ms": round(infer_time * 1000, 2),
+        "torch_version": torch.__version__, "classes": classes, "img_size": img_size,
+        "note": "Loaded and ran with map_location='cpu' and no CUDA calls anywhere in the "
+                "path -- confirms the artifact survives without the RTX 3090 / works on the "
+                "Quadro M6000 (sm_52) which torch 2.11 cannot even JIT CUDA kernels for.",
+    }
+    with open(os.path.join(OUT_DIR, "cpu_only_check.json"), "w") as f:
+        json.dump(cpu_check, f, indent=2)
+
+    # ---- Best-effort ONNX export ----
+    onnx_path = os.path.join(OUT_DIR, "model.onnx")
+    try:
+        torch.onnx.export(
+            model, dummy, onnx_path,
+            input_names=["input"], output_names=["logits"],
+            dynamic_axes={"input": {0: "batch"}, "logits": {0: "batch"}},
+            opset_version=17,
+            dynamo=False,  # torch>=2.9 defaults to the dynamo exporter, which needs the
+                            # optional 'onnxscript' package (not installed in this venv, and
+                            # NOT pip-installable here without risking the CUDA torch build --
+                            # see the hard rule against bare pip install in this venv). The
+                            # legacy TorchScript-based exporter has no such dependency.
+        )
+        onnx_ok = True
+        onnx_size = os.path.getsize(onnx_path)
+        print(f"ONNX export OK: {onnx_path} ({onnx_size/1e6:.1f} MB)")
+    except Exception as e:
+        onnx_ok = False
+        onnx_size = 0
+        print(f"ONNX export FAILED (non-fatal, .pt is the primary artifact): {e}")
+
+    with open(os.path.join(OUT_DIR, "classes.json"), "w") as f:
+        json.dump(classes, f, indent=2, ensure_ascii=False)
+
+    manifest = {
+        "model_file": "model.pt", "onnx_file": "model.onnx" if onnx_ok else None,
+        "onnx_export_ok": onnx_ok, "onnx_size_bytes": onnx_size,
+        "architecture": "efficientnet_b0 (torchvision, ImageNet1K_V1 pretrained backbone)",
+        "classes": classes, "img_size": img_size,
+        "normalize_mean": [0.485, 0.456, 0.406], "normalize_std": [0.229, 0.224, 0.225],
+        "preprocessing": f"Resize({int(img_size*256/224)}) -> CenterCrop({img_size}) -> ToTensor -> Normalize(imagenet)",
+        "cpu_only_verified": True,
+        "val_macro_f1_at_save": ckpt.get("val_macro_f1"),
+        "trained_epoch": ckpt.get("epoch"),
+    }
+    with open(os.path.join(OUT_DIR, "MANIFEST.json"), "w") as f:
+        json.dump(manifest, f, indent=2, ensure_ascii=False)
+    print(f"wrote {OUT_DIR}/MANIFEST.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ml/vision-cafe/prep_manifest.py
+++ b/scripts/ml/vision-cafe/prep_manifest.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Build unified manifest (BRACOL + RoCoLe) with class mapping + leaf/plant-group split.
+
+Classes (canonical, Spanish, matches Chagra domain):
+  sana        - healthy leaf
+  roya        - Hemileia vastatrix (BRACOL 'rust', RoCoLe 'unhealthy/E' per paper text)
+  minador     - Leucoptera coffeella (BRACOL 'miner')
+  cercospora  - Cercospora coffeicola / "ojo de gallo" Brazil convention (BRACOL 'cercospora')
+  phoma       - Phoma sp. (BRACOL 'phoma')
+
+Explicitly excluded:
+  BRACOL rows with predominant_stress==5 ("mixed"/tie between two diseases): ambiguous
+    single-label ground truth, dropped from single-label training. Reported as excluded count.
+
+Mapping decision documented:
+  RoCoLe dataset description (Mendeley/paper) states: "1560 robusta coffee leaf images with
+  visible mites and spots (denoting coffee leaf rust presence) for infection cases and images
+  without such structures for healthy cases." I.e. RoCoLe's binary healthy/unhealthy split is
+  RUST-SPECIFIC (roya), not a generic "sick" label. Filenames encode E=unhealthy(enferma/roya),
+  H=healthy(sana). This is an assumption inherited from the dataset's own documentation, NOT
+  independently re-verified against the raw annotations (RoCoLe's full file listing/severity
+  xlsx could not be retrieved -- Mendeley's files API silently caps at 100 items regardless of
+  pagination params, see ops/VISION-CAFE-2026-07-15.md for the full account). Only the 100
+  images successfully downloaded before this was discovered are used here.
+
+Leaf/plant grouping (anti-contamination):
+  RoCoLe filenames encode plant id explicitly: C<n>P<m><E|H><k>.jpg -> group = "roco_C<n>P<m>".
+  Multiple images of the same plant/leaf are kept in the SAME split (never split across
+  train/val/test) via group-aware assignment.
+  BRACOL's dataset.csv exposes only a flat sequential `id` column with NO leaf/plant identifier
+  -- there is no way to know from the released metadata whether two ids are photos of the same
+  physical leaf. This is a real limitation, stated explicitly: BRACOL split is IMAGE-level, not
+  leaf-level. If BRACOL in fact contains repeated photos of the same leaf under different ids,
+  the BRACOL portion of the test metric could be optimistic. RoCoLe's portion is leaf-safe.
+"""
+import csv
+import json
+import os
+import random
+import re
+
+random.seed(1337)
+
+BRACOL_CSV = "/home/kortux/datasets/cafe/raw/bracol/extracted/coffee-datasets/coffee-datasets/leaf/dataset.csv"
+BRACOL_IMG_DIR = "/home/kortux/datasets/cafe/raw/bracol/extracted/coffee-datasets/coffee-datasets/leaf/images"
+ROCOLE_DIR = "/home/kortux/datasets/cafe/raw/rocole"
+OUT_DIR = "/home/kortux/datasets/cafe/manifests"
+os.makedirs(OUT_DIR, exist_ok=True)
+
+PRED_MAP = {"0": "sana", "1": "minador", "2": "roya", "3": "phoma", "4": "cercospora"}
+# "5" = mixed/tie -> excluded
+
+rows = []  # dict: path, cls, group, source
+
+# ---- BRACOL ----
+bracol_total = 0
+bracol_excluded_mixed = 0
+bracol_missing_file = 0
+bracol_kept = 0
+with open(BRACOL_CSV) as f:
+    for r in csv.DictReader(f):
+        bracol_total += 1
+        ps = r["predominant_stress"]
+        if ps == "5":
+            bracol_excluded_mixed += 1
+            continue
+        cls = PRED_MAP.get(ps)
+        if cls is None:
+            continue
+        fn = r["id"] + ".jpg"
+        path = os.path.join(BRACOL_IMG_DIR, fn)
+        if not os.path.exists(path):
+            bracol_missing_file += 1
+            continue
+        rows.append({
+            "path": path,
+            "cls": cls,
+            "group": f"bracol_{r['id']}",  # no leaf id available -> 1 image = 1 group (documented limitation)
+            "source": "bracol",
+            "severity": r["severity"],
+        })
+        bracol_kept += 1
+
+# ---- RoCoLe ----
+rocole_total = 0
+rocole_kept = 0
+rocole_unparsed = 0
+pat = re.compile(r"^C(\d+)P(\d+)([EH])(\d+)\.jpg$", re.IGNORECASE)
+if os.path.isdir(ROCOLE_DIR):
+    for fn in sorted(os.listdir(ROCOLE_DIR)):
+        if not fn.lower().endswith(".jpg"):
+            continue
+        rocole_total += 1
+        m = pat.match(fn)
+        if not m:
+            rocole_unparsed += 1
+            continue
+        c, p, eh, k = m.groups()
+        cls = "roya" if eh.upper() == "E" else "sana"
+        rows.append({
+            "path": os.path.join(ROCOLE_DIR, fn),
+            "cls": cls,
+            "group": f"roco_C{c}P{p}",
+            "source": "rocole",
+            "severity": "",
+        })
+        rocole_kept += 1
+
+print(f"BRACOL: total_rows={bracol_total} excluded_mixed={bracol_excluded_mixed} "
+      f"missing_file={bracol_missing_file} kept={bracol_kept}")
+print(f"RoCoLe: total_files={rocole_total} unparsed={rocole_unparsed} kept={rocole_kept}")
+
+# class distribution
+from collections import Counter
+cls_count = Counter(r["cls"] for r in rows)
+print("Class distribution (combined):", dict(cls_count))
+src_cls = Counter((r["source"], r["cls"]) for r in rows)
+print("By source:", dict(src_cls))
+
+# ---- group-aware split 70/15/15 ----
+groups = sorted(set(r["group"] for r in rows))
+random.shuffle(groups)
+n = len(groups)
+n_train = int(n * 0.70)
+n_val = int(n * 0.15)
+train_groups = set(groups[:n_train])
+val_groups = set(groups[n_train:n_train + n_val])
+test_groups = set(groups[n_train + n_val:])
+
+for r in rows:
+    if r["group"] in train_groups:
+        r["split"] = "train"
+    elif r["group"] in val_groups:
+        r["split"] = "val"
+    else:
+        r["split"] = "test"
+
+split_count = Counter(r["split"] for r in rows)
+print("Split sizes (images):", dict(split_count))
+split_cls = Counter((r["split"], r["cls"]) for r in rows)
+for s in ["train", "val", "test"]:
+    d = {k[1]: v for k, v in split_cls.items() if k[0] == s}
+    print(f"  {s}: {d}")
+
+manifest_path = os.path.join(OUT_DIR, "manifest.csv")
+with open(manifest_path, "w", newline="") as f:
+    w = csv.DictWriter(f, fieldnames=["path", "cls", "group", "source", "severity", "split"])
+    w.writeheader()
+    for r in rows:
+        w.writerow(r)
+
+classes = sorted(cls_count.keys())
+with open(os.path.join(OUT_DIR, "classes.json"), "w") as f:
+    json.dump(classes, f, indent=2)
+
+summary = {
+    "bracol_total_rows": bracol_total,
+    "bracol_excluded_mixed": bracol_excluded_mixed,
+    "bracol_missing_file": bracol_missing_file,
+    "bracol_kept": bracol_kept,
+    "rocole_total_files": rocole_total,
+    "rocole_unparsed": rocole_unparsed,
+    "rocole_kept": rocole_kept,
+    "class_distribution": dict(cls_count),
+    "by_source_class": {f"{k[0]}|{k[1]}": v for k, v in src_cls.items()},
+    "split_sizes": dict(split_count),
+    "split_by_class": {f"{k[0]}|{k[1]}": v for k, v in split_cls.items()},
+    "n_groups": n, "n_train_groups": len(train_groups), "n_val_groups": len(val_groups),
+    "n_test_groups": len(test_groups),
+    "classes": classes,
+}
+with open(os.path.join(OUT_DIR, "prep_summary.json"), "w") as f:
+    json.dump(summary, f, indent=2, ensure_ascii=False)
+
+print(f"\nWrote manifest: {manifest_path} ({len(rows)} rows)")
+print(f"Wrote summary: {OUT_DIR}/prep_summary.json")

--- a/scripts/ml/vision-cafe/train_cafe.py
+++ b/scripts/ml/vision-cafe/train_cafe.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Fine-tune EfficientNet-B0 (ImageNet pretrained) for coffee leaf disease classification.
+
+Backbone choice (EfficientNet-B0) justification:
+  - Dataset is small (~1400 images across 5 classes) -> CNN inductive bias generalizes better
+    than a ViT with no extra regularization/data.
+  - Must run WITHOUT the RTX 3090 afterwards (CPU or Quadro M6000 sm_52, which torch 2.11 does
+    not even carry CUDA kernels for) -> need a cheap-at-inference backbone. EfficientNet-B0 is
+    5.3M params / ~20MB, ConvNeXt-Tiny is 28M, ViT-B/16 is 86M. B0 is the only one of the three
+    that is comfortably fast on a laptop CPU.
+  - Strong precedent in the coffee-leaf-disease literature (BRACOL/RoCoLe papers themselves
+    benchmark EfficientNet/MobileNet-class models for this exact task).
+
+Handles the RAM constraint (alpha has 15GB, was near 0 free): DataLoader reads from disk per
+batch via PIL, no full-dataset preloading into RAM. num_workers kept modest.
+"""
+import argparse
+import csv
+import json
+import os
+import time
+from collections import Counter, defaultdict
+
+import torch
+import torch.nn as nn
+from torch.utils.data import Dataset, DataLoader
+from torchvision import transforms
+from torchvision.models import efficientnet_b0, EfficientNet_B0_Weights
+from PIL import Image, ImageFile
+ImageFile.LOAD_TRUNCATED_IMAGES = False  # we want to KNOW if a file is bad, not silently pad it
+
+MANIFEST = "/home/kortux/datasets/cafe/manifests/manifest.csv"
+CLASSES_JSON = "/home/kortux/datasets/cafe/manifests/classes.json"
+OUT_DIR = "/home/kortux/qlora-out/vision-cafe"
+os.makedirs(OUT_DIR, exist_ok=True)
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+
+
+def load_rows():
+    with open(MANIFEST) as f:
+        return list(csv.DictReader(f))
+
+
+class CafeLeafDataset(Dataset):
+    """Reads images from disk on __getitem__ (no RAM preload). Skips unreadable files by
+    remapping to a random valid index + logging -- keeps training alive on a partially
+    corrupted archive (BRACOL zip was truncated on disk, see prep_manifest.py docstring)."""
+
+    def __init__(self, rows, classes, transform):
+        self.rows = rows
+        self.cls_to_idx = {c: i for i, c in enumerate(classes)}
+        self.transform = transform
+        self.bad_files = set()
+
+    def __len__(self):
+        return len(self.rows)
+
+    def _load(self, idx):
+        r = self.rows[idx]
+        img = Image.open(r["path"]).convert("RGB")
+        img = self.transform(img)
+        label = self.cls_to_idx[r["cls"]]
+        return img, label
+
+    def __getitem__(self, idx):
+        try:
+            return self._load(idx)
+        except Exception as e:
+            if self.rows[idx]["path"] not in self.bad_files:
+                self.bad_files.add(self.rows[idx]["path"])
+                print(f"[WARN] unreadable image, skipping: {self.rows[idx]['path']} ({e})")
+            # deterministic fallback: next index (wrap around), avoids infinite recursion storms
+            return self._load((idx + 1) % len(self.rows))
+
+
+def _downupsample(img, lo=64, hi=160):
+    """Simulate a cheap-phone / heavily-compressed photo: downsample hard then upsample back,
+    introducing blur+aliasing that JPEG-quality/low-megapixel field photos actually have.
+    Chagra's real plaga-images are 540-720px and a few KB (visibly more compressed than the
+    2048x1024 BRACOL/RoCoLe source photos) -- run1 was never trained on that degradation."""
+    import random as _r
+    w, h = img.size
+    s = _r.randint(lo, hi)
+    small = img.resize((s, s), Image.BILINEAR)
+    return small.resize((w, h), Image.BILINEAR)
+
+
+def build_transforms(img_size=224, strong=False):
+    train_ops = [
+        # strong=True: wider crop range so the model learns from PARTIAL leaf views (a hand
+        # holding the leaf, or the leaf off-center against a busy background, both push the
+        # leaf itself into a fraction of the frame -- run1's crops rarely went below 0.6 of
+        # the frame, but BRACOL/RoCoLe photos are already leaf-filling-frame, so run1 never
+        # saw a "leaf occupies 30% of frame" example).
+        transforms.RandomResizedCrop(img_size, scale=(0.3, 1.0) if strong else (0.6, 1.0), ratio=(0.7, 1.4)),
+        transforms.RandomHorizontalFlip(p=0.5),
+        transforms.RandomVerticalFlip(p=0.15),
+        transforms.RandomRotation(35 if strong else 30),
+        transforms.RandomAffine(degrees=0, translate=(0.15, 0.15) if strong else (0, 0)),  # off-center leaf
+        transforms.RandomPerspective(distortion_scale=0.4 if strong else 0.35, p=0.45),  # "ángulos raros"
+        transforms.ColorJitter(brightness=0.6 if strong else 0.5, contrast=0.5 if strong else 0.4,
+                                saturation=0.5 if strong else 0.4, hue=0.08 if strong else 0.06),  # "mala luz"
+        transforms.RandomApply([transforms.GaussianBlur(kernel_size=5, sigma=(0.3, 2.5))], p=0.35),  # "desenfoque"
+        transforms.RandomAdjustSharpness(sharpness_factor=0.3, p=0.2),
+    ]
+    if strong:
+        train_ops.append(transforms.RandomApply(
+            [transforms.Lambda(lambda im: _downupsample(im))], p=0.4))  # "celular barato"
+        train_ops.append(transforms.RandomGrayscale(p=0.05))
+    train_ops += [
+        transforms.ToTensor(),
+        transforms.RandomErasing(p=0.5 if strong else 0.3,
+                                  scale=(0.02, 0.35) if strong else (0.02, 0.15),
+                                  ratio=(0.3, 3.3)),  # "oclusión parcial" (mano, otra hoja)
+        transforms.Normalize(IMAGENET_MEAN, IMAGENET_STD),
+    ]
+    train_tf = transforms.Compose(train_ops)
+    eval_tf = transforms.Compose([
+        transforms.Resize(int(img_size * 256 / 224)),
+        transforms.CenterCrop(img_size),
+        transforms.ToTensor(),
+        transforms.Normalize(IMAGENET_MEAN, IMAGENET_STD),
+    ])
+    return train_tf, eval_tf
+
+
+def macro_prf1(y_true, y_pred, num_classes):
+    tp = [0] * num_classes
+    fp = [0] * num_classes
+    fn = [0] * num_classes
+    for t, p in zip(y_true, y_pred):
+        if t == p:
+            tp[t] += 1
+        else:
+            fp[p] += 1
+            fn[t] += 1
+    precisions, recalls, f1s = [], [], []
+    for c in range(num_classes):
+        prec = tp[c] / (tp[c] + fp[c]) if (tp[c] + fp[c]) > 0 else 0.0
+        rec = tp[c] / (tp[c] + fn[c]) if (tp[c] + fn[c]) > 0 else 0.0
+        f1 = 2 * prec * rec / (prec + rec) if (prec + rec) > 0 else 0.0
+        precisions.append(prec)
+        recalls.append(rec)
+        f1s.append(f1)
+    return precisions, recalls, f1s, sum(f1s) / num_classes
+
+
+def confusion_matrix(y_true, y_pred, num_classes):
+    cm = [[0] * num_classes for _ in range(num_classes)]
+    for t, p in zip(y_true, y_pred):
+        cm[t][p] += 1
+    return cm
+
+
+def evaluate(model, loader, device, num_classes):
+    model.eval()
+    y_true, y_pred = [], []
+    with torch.no_grad():
+        for x, y in loader:
+            x = x.to(device, non_blocking=True)
+            logits = model(x)
+            pred = logits.argmax(1).cpu().tolist()
+            y_pred.extend(pred)
+            y_true.extend(y.tolist())
+    precisions, recalls, f1s, macro_f1 = macro_prf1(y_true, y_pred, num_classes)
+    acc = sum(int(t == p) for t, p in zip(y_true, y_pred)) / max(1, len(y_true))
+    cm = confusion_matrix(y_true, y_pred, num_classes)
+    return {"acc": acc, "macro_f1": macro_f1, "precisions": precisions, "recalls": recalls,
+            "f1s": f1s, "cm": cm, "n": len(y_true)}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--epochs", type=int, default=30)
+    ap.add_argument("--batch-size", type=int, default=32)
+    ap.add_argument("--lr", type=float, default=3e-4)
+    ap.add_argument("--img-size", type=int, default=224)
+    ap.add_argument("--workers", type=int, default=3)
+    ap.add_argument("--tag", type=str, default="run1")
+    ap.add_argument("--strong-aug", action="store_true",
+                     help="wider crop/translate/erasing + downsample-upsample, targets the "
+                          "leaf-fills-frame / plain-background bias of BRACOL+RoCoLe photos")
+    args = ap.parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"device={device} epochs={args.epochs} batch_size={args.batch_size} tag={args.tag}", flush=True)
+
+    classes = json.load(open(CLASSES_JSON))
+    num_classes = len(classes)
+    print("classes:", classes, flush=True)
+
+    rows = load_rows()
+    by_split = defaultdict(list)
+    for r in rows:
+        by_split[r["split"]].append(r)
+    print({k: len(v) for k, v in by_split.items()}, flush=True)
+
+    train_tf, eval_tf = build_transforms(args.img_size, strong=args.strong_aug)
+    train_ds = CafeLeafDataset(by_split["train"], classes, train_tf)
+    val_ds = CafeLeafDataset(by_split["val"], classes, eval_tf)
+    test_ds = CafeLeafDataset(by_split["test"], classes, eval_tf)
+
+    # class-imbalance handling: weighted CE loss (inverse frequency)
+    cls_counts = Counter(r["cls"] for r in by_split["train"])
+    weights = torch.tensor([1.0 / cls_counts[c] for c in classes], dtype=torch.float32)
+    weights = weights / weights.sum() * num_classes
+    print("class weights:", dict(zip(classes, weights.tolist())), flush=True)
+
+    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True,
+                               num_workers=args.workers, pin_memory=(device == "cuda"),
+                               drop_last=True, persistent_workers=(args.workers > 0))
+    val_loader = DataLoader(val_ds, batch_size=args.batch_size, shuffle=False,
+                             num_workers=args.workers, pin_memory=(device == "cuda"),
+                             persistent_workers=(args.workers > 0))
+    test_loader = DataLoader(test_ds, batch_size=args.batch_size, shuffle=False,
+                              num_workers=args.workers, pin_memory=(device == "cuda"),
+                              persistent_workers=(args.workers > 0))
+
+    weights_enum = EfficientNet_B0_Weights.IMAGENET1K_V1
+    model = efficientnet_b0(weights=weights_enum)
+    in_features = model.classifier[1].in_features
+    model.classifier[1] = nn.Linear(in_features, num_classes)
+    model = model.to(device)
+
+    criterion = nn.CrossEntropyLoss(weight=weights.to(device))
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=1e-4)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=args.epochs)
+    scaler = torch.amp.GradScaler("cuda", enabled=(device == "cuda"))
+
+    best_val_f1 = -1.0
+    history = []
+    ckpt_path = os.path.join(OUT_DIR, f"efficientnet_b0_cafe_{args.tag}_best.pt")
+    log_path = os.path.join(OUT_DIR, f"train_log_{args.tag}.json")
+
+    t0 = time.time()
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        running_loss, n_seen = 0.0, 0
+        ep_t0 = time.time()
+        for x, y in train_loader:
+            x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+            optimizer.zero_grad(set_to_none=True)
+            with torch.amp.autocast("cuda", enabled=(device == "cuda")):
+                logits = model(x)
+                loss = criterion(logits, y)
+            scaler.scale(loss).backward()
+            scaler.step(optimizer)
+            scaler.update()
+            running_loss += loss.item() * x.size(0)
+            n_seen += x.size(0)
+        scheduler.step()
+
+        val_metrics = evaluate(model, val_loader, device, num_classes)
+        ep_time = time.time() - ep_t0
+        train_loss = running_loss / max(1, n_seen)
+        print(f"epoch {epoch}/{args.epochs} loss={train_loss:.4f} val_acc={val_metrics['acc']:.3f} "
+              f"val_macroF1={val_metrics['macro_f1']:.3f} time={ep_time:.1f}s", flush=True)
+        history.append({"epoch": epoch, "train_loss": train_loss, "val_acc": val_metrics["acc"],
+                         "val_macro_f1": val_metrics["macro_f1"], "val_f1_per_class":
+                         dict(zip(classes, val_metrics["f1s"])), "epoch_time_s": ep_time})
+
+        if val_metrics["macro_f1"] > best_val_f1:
+            best_val_f1 = val_metrics["macro_f1"]
+            torch.save({"model_state": model.state_dict(), "classes": classes,
+                        "epoch": epoch, "val_macro_f1": best_val_f1,
+                        "img_size": args.img_size}, ckpt_path)
+            print(f"  -> new best (val_macro_f1={best_val_f1:.3f}), saved {ckpt_path}", flush=True)
+
+        with open(log_path, "w") as f:
+            json.dump({"history": history, "classes": classes, "best_val_f1": best_val_f1}, f, indent=2)
+
+    total_time = time.time() - t0
+    print(f"training done in {total_time:.1f}s. best_val_macro_f1={best_val_f1:.3f}", flush=True)
+
+    # final test evaluation using BEST checkpoint (not last epoch)
+    best = torch.load(ckpt_path, map_location=device, weights_only=False)
+    model.load_state_dict(best["model_state"])
+    test_metrics = evaluate(model, test_loader, device, num_classes)
+    print("TEST metrics (leaf-group-safe test split):", flush=True)
+    print(f"  acc={test_metrics['acc']:.3f} macro_f1={test_metrics['macro_f1']:.3f} n={test_metrics['n']}", flush=True)
+    for c, p, r, f1 in zip(classes, test_metrics["precisions"], test_metrics["recalls"], test_metrics["f1s"]):
+        print(f"  {c}: precision={p:.3f} recall={r:.3f} f1={f1:.3f}", flush=True)
+    print("confusion matrix (rows=true, cols=pred), classes order:", classes, flush=True)
+    for row in test_metrics["cm"]:
+        print("  ", row, flush=True)
+
+    result = {
+        "tag": args.tag, "classes": classes, "best_val_macro_f1": best_val_f1,
+        "test_acc": test_metrics["acc"], "test_macro_f1": test_metrics["macro_f1"],
+        "test_precisions": dict(zip(classes, test_metrics["precisions"])),
+        "test_recalls": dict(zip(classes, test_metrics["recalls"])),
+        "test_f1s": dict(zip(classes, test_metrics["f1s"])),
+        "confusion_matrix": test_metrics["cm"], "confusion_matrix_classes": classes,
+        "test_n": test_metrics["n"], "total_train_time_s": total_time,
+        "train_bad_files": sorted(train_ds.bad_files), "epochs_run": args.epochs,
+    }
+    with open(os.path.join(OUT_DIR, f"test_results_{args.tag}.json"), "w") as f:
+        json.dump(result, f, indent=2, ensure_ascii=False)
+    print("wrote", os.path.join(OUT_DIR, f"test_results_{args.tag}.json"), flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Resumen

Entrena y evalua un clasificador de enfermedades del cafe (EfficientNet-B0) sobre
datasets reales de campo (RoCoLe + BRACOL) usando la RTX 3090 antes de que saliera
del host. **Resultado: no va a produccion** - el modelo generaliza muy bien dentro
de su propio dataset pero falla contra las fotos reales de Chagra. Ver
`ops/VISION-CAFE-2026-07-15.md` para el informe completo.

- Verifico licencias y tamanos reales de RoCoLe/BRACOL contra las fuentes primarias
  (Mendeley API + papers originales), corrigiendo dos errores del DR previo
  (licencia y tamano de dataset sobreestimados).
- Documenta el mapeo de taxonomia de clases entre datasets, incluida la trampa
  "cercospora" (BRACOL/RoCoLe) != "ojo de gallo" colombiano real (*Mycena citricolor*).
- Split leaf/plant-safe donde el dataset lo permite (RoCoLe), limitacion explicita
  donde no (BRACOL no expone id de hoja).
- Metricas por clase + matriz de confusion (no solo accuracy global).
- Evaluado contra las 18 fotos reales de campo de Chagra: 0/2 en el subconjunto
  estrictamente dentro de dominio (no le gana al baseline 5/8 de la torre
  multimodal). Un segundo intento con augmentacion mas agresiva no cierra la
  brecha - se documenta como intento fallido, no se oculta.
- Artefacto empaquetado y verificado para correr SIN GPU (CPU-only, 31ms/imagen,
  ONNX exportado) aunque la calidad no alcance para produccion todavia.

Esta PR solo agrega documentacion y scripts de reproducibilidad
(`scripts/ml/vision-cafe/`) - no toca ningun archivo TypeScript/JavaScript de la
app. Los datasets y artefactos del modelo viven fuera del repo
(`/home/kortux/datasets/cafe/`, `/home/kortux/qlora-out/vision-cafe/` en alpha).

## Test plan

- [x] Licencias verificadas independientemente contra Mendeley API (no contra el DR)
- [x] Conteos reales por clase reportados (no los prometidos)
- [x] Split leaf-safe para RoCoLe; limitacion explicita documentada para BRACOL
- [x] Metricas por clase + matriz de confusion (no accuracy global)
- [x] Evaluado contra las 18 fotos reales de campo, con nota de dominio por foto
- [x] Comportamiento de abstencion/confianza reportado (y es malo - documentado)
- [x] Artefacto verificado corriendo sin CUDA (map_location="cpu", sin llamadas a
      torch.cuda)
- [x] No se toco ningun .ts/.tsx/.js/.jsx - `npm run tsc:check` no se ve afectado
      (no se pudo correr localmente por falta de `node_modules` en el worktree
      nuevo; CI lo confirma)
- [x] Sin nombres reales de personas/terceros en el PR/commits/codigo