### PR TITLE
feat(ops): auditor CI de integraciones construidas y no conectadas

### DIFF
--- a/.github/workflows/integraciones-audit.yml
+++ b/.github/workflows/integraciones-audit.yml
@@ -1,0 +1,42 @@
+name: Integraciones no consumidas
+
+# Gate anti-patrón "se construye y no se conecta" (ADR-INTEGRACIONES-NO-CONSUMIDAS,
+# Chagra-strategy/ops/, privado). Falla si una capacidad (export "de conocimiento" en
+# src/services/grafoRelations.js, o — cuando chagra-pro está disponible — un endpoint
+# del sidecar agro-mcp) no tiene consumidor real en src/ Y no está declarada en
+# ops/integraciones-no-consumidas.json con razón + fecha.
+#
+# Este job SOLO tiene acceso al repo público (chagra) — chagra-pro es privado y no se
+# clona acá (anti-leak, ver el header de scripts/audit-integraciones.mjs). Por eso el
+# script degrada con gracia: audita lo que puede ver (grafoRelations.js) y salta la
+# parte de endpoints del sidecar con un warning explícito. La auditoría cruzada
+# completa (con chagra-pro) corre en dev local o en un futuro job del lado
+# chagra-pro que clona este repo público (esa dirección de lectura sí es segura).
+#
+# Barato a propósito (segundos, sin build, sin red, sin GPU) — mismo criterio que
+# unit-tests.yml: correr SIEMPRE en cada PR a main es viable solo si es gratis.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: audit-integraciones
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Auditar integraciones no consumidas
+        run: node scripts/audit-integraciones.mjs

--- a/ops/integraciones-no-consumidas.json
+++ b/ops/integraciones-no-consumidas.json
@@ -1,0 +1,57 @@
+{
+  "_meta": {
+    "description": "Allowlist de capacidades (exports same-repo / endpoints del sidecar agro-mcp) construidas y verificadas como SIN consumidor real en src/, declaradas a propósito en vez de quedar como un olvido silencioso. Cada entrada requiere reason + date. Ver ops/audit-integraciones.mjs (el script que lo hace cumplir en CI) y el ADR de contexto.",
+    "adr": "Chagra-strategy/ops/ADR-INTEGRACIONES-NO-CONSUMIDAS-2026-07-15.md (repo privado — discute el detalle de infraestructura y de chagra-pro que no puede vivir acá)",
+    "how_to_add_entry": "Si scripts/audit-integraciones.mjs falla por una capacidad nueva sin consumidor: (1) decidí primero si DEBE cablearse — si sí, cableala y borrá esta entrada en vez de agregarla; (2) si no debe cablearse ahora (razón de producto, infra rota, latencia, offline-first, etc.), agregá una entrada acá con reason concreta + date de hoy. Una entrada sin razón real es exactamente el problema que este archivo existe para prevenir."
+  },
+  "same_repo": [
+    {
+      "id": "grafoRelations.getKnowledgeTopics",
+      "file": "src/services/grafoRelations.js",
+      "export": "getKnowledgeTopics",
+      "reason": "Conocimiento offline (piso_termico/micorrizas/polinizacion/cambio_climatico/fitoquimica/alelopatia) agregado a grafo-relations.json 2026-07-14. La función existe y tiene test, pero cablearla al prompt del agente requiere decidir un disparador (¿qué mensaje amerita inyectar qué tópico? — no hay heurística todavía, y hacerlo mal infla el prompt sin criterio) más presupuesto de tokens. Es una decisión de diseño de grounding, no un cableado de una línea. Caso 1 del ADR — pendiente de diseño, no de olvido.",
+      "date": "2026-07-15"
+    },
+    {
+      "id": "grafoRelations.getKnowledgeTopic",
+      "file": "src/services/grafoRelations.js",
+      "export": "getKnowledgeTopic",
+      "reason": "Mismo caso que getKnowledgeTopics — accesor de un tópico puntual, sin disparador todavía. Ver esa entrada.",
+      "date": "2026-07-15"
+    },
+    {
+      "id": "grafoRelations.buildKnowledgeTopicBlock",
+      "file": "src/services/grafoRelations.js",
+      "export": "buildKnowledgeTopicBlock",
+      "reason": "Formatea el bloque de grounding para el system prompt a partir de getKnowledgeTopic — mismo caso, depende de que exista el disparador antes de que tenga sentido cablear el formateador.",
+      "date": "2026-07-15"
+    }
+  ],
+  "sidecar_endpoints": [
+    {
+      "endpoint": "/hybrid-retrieve",
+      "reason": "Retrieve híbrido pgvector+grafo AGE (PR #148 chagra-pro, 2026-06-02), usado hoy solo internamente por /deep-research (PR #149) — cero consumidores desde el chat interactivo (confirmado: 7 días de logs del sidecar en alpha, cero hits fuera de deep-research). Decisión: NO cablear todavía. Motivo verificado 2026-07-15: la extensión pgvector del contenedor postgres-farm en alpha está rota a nivel de infraestructura (falta el .so de la extensión tras una recreación del contenedor — deuda ya trackeada en guatoc-nixos/modules/agriculture/postgres-farm.nix desde 2026-06-13, catálogo dice 'instalada' pero el binario no está). Confirmado empíricamente: cualquier query a corpus_chunks falla con 'could not access file \"$libdir/vector\"', y el endpoint responde 200 con results:[] silenciosamente en vez de degraded:true — cablearlo hoy sería conectar un tubo roto y reportarlo como 'activado'. Aun arreglada la infra, falta validar latencia real (la medida hoy no es representativa — el query nunca llega a ejecutar el HNSW) y solapamiento con el RAG cliente (BM25+arctic-embed2 sobre rag-embeddings.json) antes de cablear en un chat voice-first. Ver ADR para el detalle completo.",
+      "date": "2026-07-15"
+    },
+    {
+      "endpoint": "/telemetry/summary",
+      "reason": "Por diseño explícito (comentario del propio server.ts, chagra-pro): 'Pensado para el panel privado del operador, NO para la PWA pública'. No es un gap — el endpoint hermano /telemetry/usage sí tiene consumidor real en src/ (usageTelemetrySync.js) porque ese sí es analítica de producto pensada para agregarse desde el cliente.",
+      "date": "2026-07-15"
+    },
+    {
+      "endpoint": "/clima/refresh",
+      "reason": "Fuerza un refresh en vivo del snapshot de clima cacheado; el cliente lee vía /clima/snapshot (sí consumido, getClimaSnapshot). No encontré un comentario de diseño explícito que declare /clima/refresh como ops-only (a diferencia de /telemetry/summary) — a diferencia de ese caso, esto queda como sospecha razonable, no como certeza. Allowlisted para no bloquear CI mientras se decide si el cliente necesita forzar un refresh manual (ej. botón \"actualizar clima\") o si es puramente un trigger de cron/ops.",
+      "date": "2026-07-15"
+    },
+    {
+      "endpoint": "/resolve-entities-batch",
+      "reason": "Construido (chagra-pro #276, QUICK-13) para 'cuando el PWA quiere prefetch de varias preguntas recientes del chat' — la feature de prefetch del lado cliente que lo consumiría nunca se construyó. Mismo patrón que hybrid-retrieve y piso_termico: infraestructura pagada, cero consumidores. Encontrado por este mismo script durante su primera corrida (2026-07-15) — no estaba en el reporte original de 3 casos del operador; se suma como Caso 4 del ADR.",
+      "date": "2026-07-15"
+    },
+    {
+      "endpoint": "/resolve-ubicacion",
+      "reason": "Construido chagra-pro #77 (serie ubicación, PRs #75-77) para una cascada Tier1/Tier2 vía sidecar. El propio spec tests/ubicacion-auto.spec.js lo documenta: 'muchos tests están skipped hasta que se mergee el PR 4/4'. Ese PR4 SÍ se mergeó (#1143, 2026-06) pero implementó otra cosa — un fallback OFFLINE (32 dptos x municipios curados) para cuando Nominatim falla, no la llamada al sidecar. locationService.js::resolveUbicacion() es una reimplementación cliente (Nominatim + fallback offline) con el mismo nombre mas no llama al endpoint. A diferencia de los otros casos, esto NO parece un olvido sino una decisión de producto razonable (mejor para offline-first evitar el round-trip a alpha) que dejó el endpoint del sidecar como infraestructura huérfana sin que nadie lo haya limpiado del lado chagra-pro. No cablear — si acaso, evaluar deprecar el endpoint en chagra-pro. Caso 5 del ADR, encontrado por este script.",
+      "date": "2026-07-15"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:unit:watch": "vitest",
     "coverage": "vitest run --coverage",
     "audit:bundle": "node scripts/audit-bundle.mjs",
+    "audit:integraciones": "node scripts/audit-integraciones.mjs",
     "grafo:snapshot": "node scripts/snapshot-grafo-crecimiento.mjs",
     "gen:stats": "node scripts/gen-chagra-stats.mjs",
     "validate:ngsi": "node scripts/export-ngsi-ld.mjs",

--- a/scripts/audit-integraciones.mjs
+++ b/scripts/audit-integraciones.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+/**
+ * audit-integraciones.mjs — auditor de "construido pero no conectado"
+ * =====================================================================
+ * Ver ADR-INTEGRACIONES-NO-CONSUMIDAS-2026-07-15 (Chagra-strategy/ops/,
+ * privado — discute los 3 casos fuente y el detalle de chagra-pro que no
+ * puede vivir en este repo público).
+ *
+ * QUÉ AUDITA
+ * ----------
+ * 1. Exports "de conocimiento" declarados en SAME_REPO_TARGETS abajo:
+ *    ¿los llama alguien en `src/` fuera de su propio módulo y su test?
+ * 2. (Solo si `chagra-pro` está disponible en este filesystem — ver
+ *    "TRAMPA REPO PRIVADO" abajo) Endpoints del sidecar agro-mcp
+ *    (`chagra-pro/modules/agro-mcp/sidecar/src/server.ts`): ¿los llama
+ *    alguien en `src/`?
+ *
+ * Cualquier capacidad SIN consumidor y SIN entrada en el allowlist
+ * (`ops/integraciones-no-consumidas.json`) hace fallar el script (exit 1).
+ * El allowlist es la forma de decir "esto es una decisión, no un olvido" —
+ * cada entrada requiere `reason` + `date`.
+ *
+ * TRAMPA REPO PRIVADO (anti-leak, ver ADR)
+ * -----------------------------------------
+ * `chagra` es público, `chagra-pro` privado. Este script NUNCA escribe a
+ * disco nada leído de `chagra-pro` — el parseo de `server.ts` (regex sobre
+ * rutas `app.get/app.post`, ver `extractSidecarEndpoints`) vive solo en
+ * memoria durante la corrida y se descarta al salir. Ningún archivo de
+ * chagra-pro se commitea ni se copia a este repo.
+ *
+ * Resolución de la ruta a chagra-pro (mismo patrón que `audit-bundle.mjs`
+ * con `INTERNAL_PRESET_PATH`):
+ *   1. env `CHAGRA_PRO_PATH` — explícito (dev local con nombre de carpeta
+ *      distinto, o un futuro job de CI privilegiado en chagra-pro que
+ *      clona este repo público — esa dirección NO es leak: privado leyendo
+ *      público es seguro).
+ *   2. `../chagra-pro` relativo a la raíz de este repo — convención local.
+ * Si ninguno existe (el caso normal de CI del repo público en GitHub
+ * Actions, que NO tiene acceso a chagra-pro), la auditoría de endpoints del
+ * sidecar se SALTA con un warning explícito y el script solo audita
+ * SAME_REPO_TARGETS. Eso es aceptable — igual que en audit-bundle.mjs, el
+ * repo público no puede fallar un gate por contenido que no puede ver.
+ *
+ * LÍMITE CONOCIDO (documentado a propósito, no ocultado)
+ * --------------------------------------------------------
+ * La detección de "consumidor" es un grep de la ruta del endpoint (string
+ * literal) o del nombre del export sobre los archivos de `src/`. Esto NO
+ * ve:
+ *   - imports dinámicos por variable/path construido en runtime (ej.
+ *     `loadProModules.js`, que arma el path desde una env var),
+ *   - llamadas indirectas vía un wrapper genérico si el string del
+ *     endpoint no aparece literal (ej. `callTool(name)` con `name` armado
+ *     en runtime en vez de la ruta completa).
+ * Si un caso legítimo cae en alguno de estos huecos, la respuesta NO es
+ * afinar el regex hasta la perfección (ruido = la gente lo silencia) sino
+ * declararlo en el allowlist con la razón "false positive conocido: <por
+ * qué>" — así el hueco queda documentado igual que un no-consumo real.
+ *
+ * Exit codes: 0 limpio · 1 hay capacidades sin consumidor y sin allowlist
+ * · 2 problema de ejecución (archivo target ausente, allowlist mal formado).
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const SRC_DIR = join(ROOT, 'src');
+const ALLOWLIST_PATH = join(ROOT, 'ops/integraciones-no-consumidas.json');
+
+function die(code, msg) {
+  console.error(`\x1b[31m✗ ${msg}\x1b[0m`);
+  process.exit(code);
+}
+function ok(msg) { console.log(`\x1b[32m✓\x1b[0m ${msg}`); }
+function warn(msg) { console.log(`\x1b[33m⚠\x1b[0m ${msg}`); }
+
+// ---------------------------------------------------------------------------
+// SAME_REPO_TARGETS — capacidades declaradas explícitamente para auditar.
+// A propósito NO es "todo export de src/" (eso sería ruido: imports
+// dinámicos, re-exports, barrels). Es una lista curada que se amplía cuando
+// se descubre un nuevo caso "construido y no conectado" (el mismo patrón
+// que motivó este script — ver ADR).
+// ---------------------------------------------------------------------------
+const SAME_REPO_TARGETS = [
+  {
+    id: 'grafoRelations.getKnowledgeTopics',
+    file: 'src/services/grafoRelations.js',
+    export: 'getKnowledgeTopics',
+  },
+  {
+    id: 'grafoRelations.getKnowledgeTopic',
+    file: 'src/services/grafoRelations.js',
+    export: 'getKnowledgeTopic',
+  },
+  {
+    id: 'grafoRelations.buildKnowledgeTopicBlock',
+    file: 'src/services/grafoRelations.js',
+    export: 'buildKnowledgeTopicBlock',
+  },
+];
+
+// Rutas del sidecar que son introspección/ops, no "capacidad de producto" —
+// no tiene sentido exigirles un consumidor en el chat del agente. Igual que
+// audit-bundle.mjs excluye vendor false-positives, esto es una exclusión
+// documentada, no silenciosa.
+const SIDECAR_INFRA_ENDPOINTS = new Set([
+  '/healthz',
+  '/health',
+  '/metrics',
+  '/cache/stats',
+  '/resolve-cache/stats',
+  '/tools',
+]);
+
+function walk(dir, exts) {
+  const out = [];
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.')) continue;
+    const p = join(dir, entry);
+    const st = statSync(p);
+    if (st.isDirectory()) out.push(...walk(p, exts));
+    else if (exts.has(extname(p))) out.push(p);
+  }
+  return out;
+}
+
+const SRC_EXTS = new Set(['.js', '.jsx', '.mjs', '.ts', '.tsx']);
+const allSrcFiles = walk(SRC_DIR, SRC_EXTS);
+
+// -----------------------------
+// 1) SAME_REPO_TARGETS audit
+// -----------------------------
+function auditSameRepoTarget(target) {
+  const targetFile = resolve(ROOT, target.file);
+  if (!existsSync(targetFile)) {
+    return { ...target, status: 'error', detail: `archivo no existe: ${target.file}` };
+  }
+  const wordBoundary = new RegExp(`\\b${target.export}\\b`);
+  let consumers = 0;
+  for (const f of allSrcFiles) {
+    if (f === targetFile) continue; // el propio módulo no cuenta
+    if (f.includes('__tests__')) continue; // los propios tests no cuentan como consumidor real
+    let content;
+    try { content = readFileSync(f, 'utf8'); } catch { continue; }
+    if (wordBoundary.test(content)) { consumers++; break; }
+  }
+  return { ...target, status: consumers > 0 ? 'consumed' : 'orphan' };
+}
+
+const sameRepoResults = SAME_REPO_TARGETS.map(auditSameRepoTarget);
+
+// -----------------------------
+// 2) Sidecar endpoints audit (condicional a chagra-pro presente)
+// -----------------------------
+const CHAGRA_PRO_PATH = process.env.CHAGRA_PRO_PATH || resolve(ROOT, '../chagra-pro');
+const SERVER_TS = join(CHAGRA_PRO_PATH, 'modules/agro-mcp/sidecar/src/server.ts');
+const chagraProAvailable = existsSync(SERVER_TS);
+
+function extractSidecarEndpoints(serverTsPath) {
+  const content = readFileSync(serverTsPath, 'utf8');
+  const re = /app\.(?:get|post)\(\s*["'`]([^"'`]+)["'`]/g;
+  const found = new Set();
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    const path = m[1];
+    if (path.includes('${')) continue; // ruta templada (ej. /tools/${name}) — multiplexer genérico, no capacidad fija
+    found.add(path);
+  }
+  return [...found].sort();
+}
+
+let sidecarResults = [];
+if (chagraProAvailable) {
+  const endpoints = extractSidecarEndpoints(SERVER_TS);
+  sidecarResults = endpoints
+    .filter((ep) => !SIDECAR_INFRA_ENDPOINTS.has(ep))
+    .map((ep) => {
+      let consumers = 0;
+      for (const f of allSrcFiles) {
+        let content;
+        try { content = readFileSync(f, 'utf8'); } catch { continue; }
+        if (content.includes(ep)) { consumers++; break; }
+      }
+      return { endpoint: ep, status: consumers > 0 ? 'consumed' : 'orphan' };
+    });
+} else {
+  warn(`chagra-pro no disponible en "${CHAGRA_PRO_PATH}" (ni CHAGRA_PRO_PATH) — se salta la auditoría de endpoints del sidecar.`);
+  warn('Esto es esperado en CI del repo público. Para la auditoría completa, correr con chagra-pro clonado al lado (o CHAGRA_PRO_PATH=<ruta>).');
+}
+
+// -----------------------------
+// Allowlist
+// -----------------------------
+if (!existsSync(ALLOWLIST_PATH)) die(2, `falta el allowlist: ${ALLOWLIST_PATH}`);
+let allowlist;
+try {
+  allowlist = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf8'));
+} catch (e) {
+  die(2, `allowlist mal formado (${ALLOWLIST_PATH}): ${e.message}`);
+}
+
+function validateAllowlistEntry(entry, label) {
+  if (!entry.reason || typeof entry.reason !== 'string' || !entry.reason.trim()) {
+    die(2, `allowlist: entrada "${label}" sin "reason" — una excepción sin razón no es una decisión, es un olvido con papeleo.`);
+  }
+  if (!entry.date || !/^\d{4}-\d{2}-\d{2}$/.test(entry.date)) {
+    die(2, `allowlist: entrada "${label}" sin "date" válida (YYYY-MM-DD).`);
+  }
+}
+
+const allowedSameRepoIds = new Map();
+for (const e of allowlist.same_repo || []) {
+  validateAllowlistEntry(e, e.id || '(sin id)');
+  allowedSameRepoIds.set(e.id, e);
+}
+const allowedEndpoints = new Map();
+for (const e of allowlist.sidecar_endpoints || []) {
+  validateAllowlistEntry(e, e.endpoint || '(sin endpoint)');
+  allowedEndpoints.set(e.endpoint, e);
+}
+
+// -----------------------------
+// Reporte + veredicto
+// -----------------------------
+console.log('Chagra — auditor de integraciones no consumidas');
+console.log(`  targets same-repo:     ${SAME_REPO_TARGETS.length}`);
+console.log(`  chagra-pro disponible: ${chagraProAvailable ? SERVER_TS : 'no'}`);
+console.log(`  endpoints auditados:   ${sidecarResults.length}${chagraProAvailable ? '' : ' (saltado)'}`);
+console.log('');
+
+const failures = [];
+const skippedAllowlisted = [];
+
+for (const r of sameRepoResults) {
+  if (r.status === 'error') { failures.push(`[same-repo] ${r.id}: ${r.detail}`); continue; }
+  if (r.status === 'consumed') { ok(`same-repo consumido: ${r.id}`); continue; }
+  const allow = allowedSameRepoIds.get(r.id);
+  if (allow) { skippedAllowlisted.push(r.id); warn(`same-repo SIN consumidor pero allowlisted: ${r.id} — ${allow.reason} (${allow.date})`); continue; }
+  failures.push(`[same-repo] ${r.id} (${r.file}::${r.export}) — SIN consumidor en src/ y SIN entrada en allowlist`);
+}
+
+for (const r of sidecarResults) {
+  if (r.status === 'consumed') { ok(`endpoint consumido: ${r.endpoint}`); continue; }
+  const allow = allowedEndpoints.get(r.endpoint);
+  if (allow) { skippedAllowlisted.push(r.endpoint); warn(`endpoint SIN consumidor pero allowlisted: ${r.endpoint} — ${allow.reason} (${allow.date})`); continue; }
+  failures.push(`[sidecar] ${r.endpoint} — SIN consumidor en src/ y SIN entrada en allowlist`);
+}
+
+console.log('');
+if (failures.length === 0) {
+  ok(`Auditoría limpia — ${skippedAllowlisted.length} excepción(es) declarada(s), 0 huérfanos sin declarar.`);
+  process.exit(0);
+}
+
+console.error(`\x1b[31m✗ ${failures.length} capacidad(es) construida(s) y no conectada(s), sin declarar\x1b[0m`);
+for (const f of failures) console.error(`  ${f}`);
+console.error('');
+console.error('Si esto es una decisión de producto (no un olvido), declarala en');
+console.error(`  ${ALLOWLIST_PATH.slice(ROOT.length + 1)}`);
+console.error('con { reason, date }. Si no lo es, cableala o borrá el código muerto.');
+process.exit(1);


### PR DESCRIPTION
## Qué

Cierra permanentemente el patrón "se construye una integración y no se conecta" (3+ casos verificados el mismo día: `/hybrid-retrieve` del sidecar agro-mcp, exports de conocimiento en `grafoRelations.js`, guarda taxonómica A24 ya removida) con dos cosas:

1. **Decisión sobre el caso puntual `/hybrid-retrieve`**: NO se cablea en este PR. Verificado en vivo contra `alpha` que la extensión `pgvector` de `postgres-farm` está rota (`vector.so` ausente del contenedor — deuda documentada desde 2026-06-13 en `guatoc-nixos`), así que el endpoint responde `200 {results:[], degraded:false}` silenciosamente vacío en vez de fallar ruidoso. Cablearlo hoy sería enchufar un tubo roto y reportarlo como "activado" — exactamente el bug que este PR existe para prevenir. Detalle completo + plan de qué falta antes de cablearlo (arreglar infra, medir latencia real, medir solapamiento con el RAG del cliente) en el ADR privado.

2. **Test CI permanente** (`scripts/audit-integraciones.mjs`, corre en `.github/workflows/integraciones-audit.yml`): enumera capacidades declaradas (exports "de conocimiento" en `grafoRelations.js`, y — solo si `chagra-pro` está clonado al lado, ver nota anti-leak abajo — endpoints del sidecar) y falla si alguna no tiene consumidor real en `src/` y no está declarada con `reason`+`date` en `ops/integraciones-no-consumidas.json`. Corriéndolo contra el `chagra-pro` real encontró **2 casos nuevos no reportados** (`/resolve-entities-batch`, `/resolve-ubicacion`) en su primera corrida — quedan documentados en el allowlist.

## Anti-leak (chagra público / chagra-pro privado)

El script nunca escribe a disco nada leído de `chagra-pro` — el parseo de `server.ts` vive en memoria durante la corrida. En CI del repo público (sin `chagra-pro` disponible) la auditoría de endpoints se salta con un warning explícito y el job solo audita `grafoRelations.js` — mismo patrón de degradación que `audit-bundle.mjs` ya usa con `PROHIBITED_INTERNAL.md`.

## Documentación

`Chagra-strategy/ops/ADR-INTEGRACIONES-NO-CONSUMIDAS-2026-07-15.md` (privado): los 5 casos con evidencia, la decisión completa sobre `/hybrid-retrieve` (incluye la verificación empírica del bug de infraestructura), cómo funciona el test, y por qué importa (trabajo pagado que no rinde y que además se cree hecho).

## Test plan

- [x] `node scripts/audit-integraciones.mjs` — exit 0 sin `chagra-pro` (modo CI público, warning explícito de que se salta la parte de endpoints).
- [x] `CHAGRA_PRO_PATH=../chagra-pro node scripts/audit-integraciones.mjs` — exit 0 con el sidecar real, 20 endpoints auditados, 8 excepciones declaradas.
- [x] Verificado que el gate es real: quitar `/hybrid-retrieve` del allowlist y correr de nuevo → `exit 1` con el mensaje exacto; restaurar la entrada → `exit 0` de nuevo.
- [x] `npx eslint scripts/audit-integraciones.mjs` limpio.
- [x] `package.json` y el allowlist JSON validan.
- [ ] CI del repo (una vez abierto el PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)