### PR TITLE
feat(sierra): rehacer los árboles apuntando a realismo — ramificación, sombreado horneado y bosque por bandas

### DIFF
--- a/src/visual/mundo3d/__tests__/arbolMayor.geom.test.js
+++ b/src/visual/mundo3d/__tests__/arbolMayor.geom.test.js
@@ -1,0 +1,402 @@
+/*
+ * Pruebas de la geometría PURA de los árboles de la Sierra. Corren headless:
+ * three-core es matemática de buffers, no necesita WebGL.
+ *
+ * El test que de verdad importa es el de la FUSIÓN: `mergeGeometries` devuelve
+ * null en silencio si las partes traen atributos disparejos, r3f hace
+ * `if (!geo) return null` y la especie desaparece SIN UN SOLO ERROR. Ya mordió
+ * dos veces en este repo — y volvió a morder mientras se escribía este módulo
+ * (las primitivas de three traen `uv`, el tubo ahusado no). Por eso `fusionar`
+ * normaliza atributos y truena, y por eso esto se prueba.
+ */
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import {
+  rng,
+  fusionar,
+  geomArbol,
+  ESPECIES,
+  arbolDePiso,
+  tipoDePiso,
+  calidadDeTier,
+  CALIDAD_TIER,
+  variantesDeTier,
+  tuboAhusado,
+  SOL,
+  JITTER_GIRO,
+} from '../sierra/arbolMayor.geom.js';
+import {
+  BANDAS_BOSQUE,
+  bandaConClima,
+  sembrarEspecie,
+  distribucionBosque,
+  bosqueDeTier,
+  BOSQUE_TIER,
+} from '../sierra/bosqueSierra.js';
+
+const TIPOS = Object.keys(ESPECIES);
+
+describe('rng determinista', () => {
+  it('misma semilla → misma secuencia', () => {
+    const a = rng(42);
+    const b = rng(42);
+    expect(a()).toBe(b());
+    expect(a()).toBe(b());
+  });
+  it('valores en [0,1)', () => {
+    const r = rng(7);
+    for (let i = 0; i < 40; i++) {
+      const v = r();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+});
+
+describe('fusionar — el fallo silencioso que ya mordió dos veces', () => {
+  const conColor = (geo) => {
+    const n = geo.attributes.position.count;
+    geo.setAttribute('color', new THREE.BufferAttribute(new Float32Array(n * 3).fill(0.5), 3));
+    return geo;
+  };
+
+  it('mezcla indexada + NO indexada sin devolver null', () => {
+    const indexada = conColor(new THREE.CylinderGeometry(0.1, 0.2, 1, 6, 1));
+    const noIndexada = conColor(new THREE.IcosahedronGeometry(0.3, 0)); // ya viene sin índice
+    expect(indexada.index).not.toBeNull();
+    const g = fusionar([indexada, noIndexada], 'prueba');
+    expect(g).toBeTruthy();
+    expect(g.attributes.position.count).toBeGreaterThan(0);
+  });
+
+  it('normaliza atributos disparejos (uv sí / uv no) en vez de devolver null', () => {
+    // Cylinder trae uv; un tubo ahusado NO → sin normalizar, esto daba null.
+    const conUv = conColor(new THREE.CylinderGeometry(0.1, 0.1, 1, 5, 1));
+    expect(conUv.attributes.uv).toBeTruthy();
+    const curva = new THREE.CatmullRomCurve3([
+      new THREE.Vector3(0, 0, 0),
+      new THREE.Vector3(0, 0.5, 0),
+      new THREE.Vector3(0, 1, 0),
+    ]);
+    const sinUv = conColor(tuboAhusado(curva, 4, 5, () => 0.1));
+    expect(sinUv.attributes.uv).toBeFalsy();
+
+    const g = fusionar([conUv, sinUv], 'uv-dispar');
+    expect(g).toBeTruthy();
+    expect(g.attributes.uv).toBeFalsy(); // se descarta: no hay texturas en la sierra
+    expect(g.attributes.color).toBeTruthy();
+  });
+
+  it('TRUENA (no devuelve null callado) si una parte no trae color', () => {
+    const buena = conColor(new THREE.IcosahedronGeometry(0.2, 0));
+    const pelada = new THREE.IcosahedronGeometry(0.2, 0);
+    expect(() => fusionar([buena, pelada], 'sin-color')).toThrow(/color horneado/);
+  });
+
+  it('truena con lista vacía en vez de devolver algo inútil', () => {
+    expect(() => fusionar([], 'vacío')).toThrow();
+  });
+});
+
+describe('tuboAhusado — la conicidad que la versión vieja prometía y no hacía', () => {
+  const curva = new THREE.CatmullRomCurve3([
+    new THREE.Vector3(0, 0, 0),
+    new THREE.Vector3(0, 1, 0),
+    new THREE.Vector3(0, 2, 0),
+  ]);
+
+  it('la punta es MÁS DELGADA que la base', () => {
+    const geo = tuboAhusado(curva, 8, 8, (t) => 0.3 * (1 - t * 0.8));
+    const pos = geo.attributes.position;
+    // radio = distancia al eje Y, medido abajo vs arriba
+    let radioAbajo = 0;
+    let radioArriba = 0;
+    for (let i = 0; i < pos.count; i++) {
+      const x = pos.getX(i), y = pos.getY(i), z = pos.getZ(i);
+      const rad = Math.hypot(x, z);
+      if (y < 0.2) radioAbajo = Math.max(radioAbajo, rad);
+      if (y > 1.8) radioArriba = Math.max(radioArriba, rad);
+    }
+    expect(radioAbajo).toBeGreaterThan(0.2);
+    expect(radioArriba).toBeLessThan(radioAbajo * 0.5);
+  });
+
+  it('trae `aRelieve` para poder hornear las grietas de la corteza', () => {
+    const geo = tuboAhusado(curva, 4, 6, () => 0.2, 0.1);
+    const rel = geo.getAttribute('aRelieve');
+    expect(rel).toBeTruthy();
+    expect(rel.count).toBe(geo.attributes.position.count);
+  });
+});
+
+describe('geomArbol — cada especie se construye de verdad', () => {
+  it.each(TIPOS)('%s: fusiona, trae color horneado y no está vacío', (tipo) => {
+    const geo = geomArbol(tipo, { q: 1, variante: 0 });
+    expect(geo).toBeTruthy();
+    expect(geo.attributes.position.count).toBeGreaterThan(100);
+    expect(geo.attributes.color).toBeTruthy();
+    expect(geo.attributes.normal).toBeTruthy();
+    // color por vértice, uno por posición
+    expect(geo.attributes.color.count).toBe(geo.attributes.position.count);
+  });
+
+  it.each(TIPOS)('%s: cabe en el presupuesto (~2-5k triángulos en alto)', (tipo) => {
+    const tris = geomArbol(tipo, { q: 1 }).attributes.position.count / 3;
+    expect(tris).toBeGreaterThan(800); // menos que esto no es un árbol
+    expect(tris).toBeLessThanOrEqual(5600);
+  });
+
+  it.each(TIPOS)('%s: tier bajo cuesta MENOS que tier alto', (tipo) => {
+    const alto = geomArbol(tipo, { q: CALIDAD_TIER.alto }).attributes.position.count;
+    const bajo = geomArbol(tipo, { q: CALIDAD_TIER.bajo }).attributes.position.count;
+    expect(bajo).toBeLessThan(alto);
+  });
+
+  it.each(TIPOS)('%s: es determinista (misma clave → misma malla)', (tipo) => {
+    const a = geomArbol(tipo, { q: 1, variante: 1 });
+    const b = geomArbol(tipo, { q: 1, variante: 1 });
+    expect(a.attributes.position.count).toBe(b.attributes.position.count);
+    expect(a.attributes.position.array[0]).toBe(b.attributes.position.array[0]);
+  });
+
+  it.each(TIPOS)('%s: las variantes dan árboles DISTINTOS (R3: romper la simetría)', (tipo) => {
+    const v0 = geomArbol(tipo, { q: 1, variante: 0 });
+    const v1 = geomArbol(tipo, { q: 1, variante: 1 });
+    // no basta con que cuenten distinto: que la malla no sea la misma
+    const igual =
+      v0.attributes.position.count === v1.attributes.position.count &&
+      v0.attributes.position.array[10] === v1.attributes.position.array[10];
+    expect(igual).toBe(false);
+  });
+
+  it('especie desconocida truena (no devuelve un roble callado)', () => {
+    expect(() => geomArbol('pino-de-navidad')).toThrow(/especie desconocida/);
+  });
+
+  it('el árbol se para en el suelo (y=0), no flota ni se entierra', () => {
+    for (const tipo of TIPOS) {
+      const geo = geomArbol(tipo, { q: 1 });
+      geo.computeBoundingBox();
+      const box = geo.boundingBox;
+      expect(box.min.y).toBeGreaterThan(-0.35); // no se hunde
+      expect(box.min.y).toBeLessThan(0.3); // ni levita
+      // y crece hacia arriba, con la altura declarada (±40%: ramifica orgánico)
+      expect(box.max.y).toBeGreaterThan(ESPECIES[tipo].alto * 0.6);
+    }
+  });
+});
+
+describe('R1 — el sombreado horneado (la receta de mayor retorno del DR)', () => {
+  it('el follaje NO es de un solo color plano: hay AO y gradiente', () => {
+    const geo = geomArbol('roble', { q: 1 });
+    const col = geo.attributes.color;
+    const vistos = new Set();
+    for (let i = 0; i < col.count; i += 7) {
+      vistos.add(`${col.getX(i).toFixed(2)},${col.getY(i).toFixed(2)}`);
+    }
+    // un blob de color plano daría un puñado de tonos; horneado da decenas
+    expect(vistos.size).toBeGreaterThan(30);
+  });
+
+  it('la copa se aclara hacia arriba (gradiente de altura)', () => {
+    const geo = geomArbol('roble', { q: 1 });
+    const pos = geo.attributes.position;
+    const col = geo.attributes.color;
+    geo.computeBoundingBox();
+    const yMax = geo.boundingBox.max.y;
+    let sumaAlto = 0, nAlto = 0, sumaBajo = 0, nBajo = 0;
+    for (let i = 0; i < pos.count; i++) {
+      const y = pos.getY(i);
+      // solo follaje (verde): el tronco tiene su propia lógica
+      const esVerde = col.getY(i) > col.getX(i) * 1.15;
+      if (!esVerde) continue;
+      const brillo = col.getX(i) + col.getY(i) + col.getZ(i);
+      if (y > yMax * 0.8) { sumaAlto += brillo; nAlto++; }
+      else if (y < yMax * 0.55) { sumaBajo += brillo; nBajo++; }
+    }
+    expect(nAlto).toBeGreaterThan(5);
+    expect(nBajo).toBeGreaterThan(5);
+    expect(sumaAlto / nAlto).toBeGreaterThan(sumaBajo / nBajo);
+  });
+
+  it('sss=true hornea contraluz; sss=false no (para instancias que giran)', () => {
+    const con = geomArbol('roble', { q: 1, variante: 0, sss: true });
+    const sin = geomArbol('roble', { q: 1, variante: 0, sss: false });
+    expect(con.attributes.position.count).toBe(sin.attributes.position.count);
+    let difiere = false;
+    for (let i = 0; i < con.attributes.color.count; i++) {
+      if (Math.abs(con.attributes.color.getX(i) - sin.attributes.color.getX(i)) > 0.01) {
+        difiere = true;
+        break;
+      }
+    }
+    expect(difiere).toBe(true);
+  });
+
+  it('el SOL es unitario y el jitter de giro es chico (si no, el contraluz miente)', () => {
+    expect(SOL.length()).toBeCloseTo(1, 5);
+    expect(JITTER_GIRO).toBeGreaterThan(0);
+    expect(JITTER_GIRO).toBeLessThan(0.35);
+  });
+});
+
+describe('catálogo de especies', () => {
+  it('cada piso con árbol resuelve a su especie, ida y vuelta', () => {
+    for (const [clave, def] of Object.entries(ESPECIES)) {
+      expect(arbolDePiso(def.piso)).toBe(def);
+      expect(tipoDePiso(def.piso)).toBe(clave);
+    }
+  });
+  it('los pisos SIN árbol devuelven null (no se inventa uno)', () => {
+    expect(arbolDePiso('superparamo')).toBeNull();
+    expect(arbolDePiso('nival')).toBeNull();
+    expect(tipoDePiso('nival')).toBeNull();
+  });
+  it('cada especie declara nombre, científico y rasgo (van al rótulo)', () => {
+    for (const def of Object.values(ESPECIES)) {
+      expect(def.nombre).toBeTruthy();
+      expect(def.cientifico).toMatch(/^[A-Z][a-z]+ /); // binomial
+      expect(def.rasgo).toBeTruthy();
+      expect(def.alto).toBeGreaterThan(0);
+    }
+  });
+  it('la ceiba es la más alta y la queñua la más baja (silueta relativa real)', () => {
+    const altos = Object.values(ESPECIES).map((e) => e.alto);
+    expect(ESPECIES.ceiba.alto).toBe(Math.max(...altos));
+    expect(ESPECIES.quenua.alto).toBe(Math.min(...altos));
+  });
+  it('calidadDeTier y variantesDeTier: alto ≥ medio ≥ bajo, y lo raro es frugal', () => {
+    expect(calidadDeTier('alto')).toBeGreaterThan(calidadDeTier('medio'));
+    expect(calidadDeTier('medio')).toBeGreaterThan(calidadDeTier('bajo'));
+    expect(calidadDeTier('marciano')).toBe(CALIDAD_TIER.medio);
+    expect(variantesDeTier('alto')).toBeGreaterThanOrEqual(variantesDeTier('bajo'));
+  });
+});
+
+/* ── La DISPOSICIÓN: lo que el operador señaló con nombre propio ───────────── */
+
+describe('bosqueSierra — disposición biogeográfica, no una grilla', () => {
+  // una ladera de prueba: sube parejo con z, con una loma que le da relieve
+  const CIMA = 6.2;
+  const altura = (x, z) => {
+    const base = Math.max(0, ((z + 9) / 10.6) * CIMA * 0.9);
+    return Math.min(CIMA, base + Math.sin(x * 0.7) * 0.35);
+  };
+  const area = { x0: -10, x1: 10, z0: -8.5, z1: 3.5 };
+
+  it('cada árbol cae DENTRO de la banda de altitud de su especie', () => {
+    for (const especie of Object.keys(BANDAS_BOSQUE)) {
+      const banda = bandaConClima(especie, 0);
+      const items = sembrarEspecie({
+        especie, cuantos: 20, altura, cima: CIMA, area, d: 0, seed: 5,
+      });
+      expect(items.length).toBeGreaterThan(0);
+      for (const it of items) {
+        const yf = it.pos[1] / CIMA;
+        expect(yf).toBeGreaterThanOrEqual(banda.min - 1e-6);
+        expect(yf).toBeLessThanOrEqual(banda.max + 1e-6);
+      }
+    }
+  });
+
+  it('LÍNEA ARBÓREA: por encima del páramo no hay un solo árbol', () => {
+    const todo = distribucionBosque({
+      altura, cima: CIMA, area, conteos: bosqueDeTier('alto'), claros: [], d: 0,
+    });
+    const techo = Math.max(...Object.values(BANDAS_BOSQUE).map((b) => b.max));
+    for (const items of Object.values(todo)) {
+      for (const it of items) {
+        expect(it.pos[1] / CIMA).toBeLessThanOrEqual(techo + 1e-6);
+      }
+    }
+  });
+
+  it('NO es una grilla: los vecinos están a distancias desiguales (rodales)', () => {
+    const items = sembrarEspecie({
+      especie: 'roble', cuantos: 30, altura, cima: CIMA, area, d: 0, seed: 11,
+    });
+    expect(items.length).toBeGreaterThan(10);
+    // distancia al vecino más cercano de cada árbol
+    const vecinas = items.map((a) => {
+      let min = Infinity;
+      for (const b of items) {
+        if (a === b) continue;
+        const dx = a.pos[0] - b.pos[0], dz = a.pos[2] - b.pos[2];
+        min = Math.min(min, Math.hypot(dx, dz));
+      }
+      return min;
+    });
+    const media = vecinas.reduce((s, v) => s + v, 0) / vecinas.length;
+    const varianza = vecinas.reduce((s, v) => s + (v - media) ** 2, 0) / vecinas.length;
+    // en una grilla la distancia al vecino es CONSTANTE (varianza ~0). Un bosque
+    // agrupado tiene mucha dispersión: es la diferencia que se ve en pantalla.
+    expect(Math.sqrt(varianza) / media).toBeGreaterThan(0.25);
+  });
+
+  it('los CLAROS de los héroes se respetan (el bosque no se le encima al hito)', () => {
+    const claros = [{ x: 0, z: -2, r: 2.5 }];
+    const items = sembrarEspecie({
+      especie: 'roble', cuantos: 30, altura, cima: CIMA, area, claros, d: 0, seed: 3,
+    });
+    for (const it of items) {
+      const d = Math.hypot(it.pos[0] - 0, it.pos[2] - (-2));
+      expect(d).toBeGreaterThanOrEqual(2.5 - 1e-6);
+    }
+  });
+
+  it('ningún par de árboles se pisa', () => {
+    const items = sembrarEspecie({
+      especie: 'quenua', cuantos: 24, altura, cima: CIMA, area, d: 0, seed: 9,
+    });
+    for (let i = 0; i < items.length; i++) {
+      for (let j = i + 1; j < items.length; j++) {
+        const dx = items[i].pos[0] - items[j].pos[0];
+        const dz = items[i].pos[2] - items[j].pos[2];
+        expect(dx * dx + dz * dz).toBeGreaterThanOrEqual(0.34 - 1e-9);
+      }
+    }
+  });
+
+  it('el clima empuja el bosque CUESTA ARRIBA (migra con su piso)', () => {
+    const hoy = bandaConClima('roble', 0);
+    const futuro = bandaConClima('roble', 1);
+    expect(futuro.min).toBeGreaterThan(hoy.min);
+    expect(futuro.max).toBeGreaterThan(hoy.max);
+  });
+
+  it('variación por instancia: ni giro grande, ni dos árboles idénticos', () => {
+    const items = sembrarEspecie({
+      especie: 'roble', cuantos: 20, altura, cima: CIMA, area, d: 0, seed: 2, variantes: 3,
+    });
+    for (const it of items) {
+      // el giro tiene que ser CHICO: la luz va horneada (ver §ROTACIÓN)
+      expect(Math.abs(it.giroY)).toBeLessThanOrEqual(JITTER_GIRO + 1e-9);
+      expect(it.variante).toBeGreaterThanOrEqual(0);
+      expect(it.variante).toBeLessThan(3);
+      expect(it.escala).toBeGreaterThan(0);
+    }
+    expect(new Set(items.map((i) => i.escala)).size).toBeGreaterThan(5);
+    expect(new Set(items.map((i) => i.variante)).size).toBeGreaterThan(1);
+  });
+
+  it('determinista: la misma semilla siembra el mismo bosque', () => {
+    const args = { especie: 'roble', cuantos: 12, altura, cima: CIMA, area, d: 0, seed: 77 };
+    const a = sembrarEspecie(args);
+    const b = sembrarEspecie(args);
+    expect(a.length).toBe(b.length);
+    expect(a[0].pos).toEqual(b[0].pos);
+  });
+
+  it('tier-safe: alto siembra más que medio, y medio más que bajo', () => {
+    expect(BOSQUE_TIER.alto.roble).toBeGreaterThan(BOSQUE_TIER.medio.roble);
+    expect(BOSQUE_TIER.medio.roble).toBeGreaterThan(BOSQUE_TIER.bajo.roble);
+    expect(bosqueDeTier('marciano')).toBe(BOSQUE_TIER.medio); // lo raro, frugal
+  });
+
+  it('una banda imposible no revienta: devuelve vacío', () => {
+    const items = sembrarEspecie({
+      especie: 'quenua', cuantos: 10, altura: () => 0, cima: CIMA, area, d: 0, seed: 1,
+    });
+    expect(items).toEqual([]); // a nivel del mar no hay queñua, y no truena
+  });
+});

--- a/src/visual/mundo3d/sierra/ArbolMayor.jsx
+++ b/src/visual/mundo3d/sierra/ArbolMayor.jsx
@@ -1,159 +1,98 @@
 /*
- * ArbolMayor — el ÁRBOL MAYOR de un piso térmico, en 3D low-poly de verdad
- * (mallas three, no billboards). Lee la receta de silueta del catálogo
- * `arbolesMayores.js` y la arma con primitivas baratas:
+ * ArbolMayor — un árbol de la Sierra en pantalla. La geometría (ramificación,
+ * conicidad, follaje y TODO el sombreado horneado) vive en `arbolMayor.geom.js`;
+ * aquí solo se monta, se le pone material y se le da vida.
  *
- *   · tronco  — cilindros ahusados (raigón grueso → punta fina). Multitronco en
- *               la queñua (3 tallos abiertos y ladeados); columna en roble y
- *               guayacán; emergente con RAÍCES TABLARES en la ceiba.
- *   · copa    — un puñado de "nubes" de follaje (icosaedros facetados) en
- *               elipsoide: ancha y plana en la ceiba, alta y densa en el roble,
- *               compacta en la queñua. En el guayacán la copa es FLOR dorada
- *               maciza (sin verde): su firma es florecer pelado.
+ * ── QUÉ CAMBIÓ (y por qué) ──────────────────────────────────────────────────
+ * La versión anterior armaba el árbol EN el componente: un tubo de radio
+ * constante por tallo y un puñado de icosaedros sueltos como copa, cada uno con
+ * su propio `<mesh>` y su propio material. Eso era, a la vez, el problema
+ * artístico (el "árbol de navidad" que el DR de realismo diagnostica) y el
+ * problema de rendimiento (una decena de draw-calls por árbol). Ahora:
  *
- * Vida: el árbol se mece lento desde la base (pivote al pie), con fase propia
- * por `semilla`. `reducedMotion` lo deja QUIETO. Tier-safe: en 'alto' facetado y
- * copa plena; en 'medio'/'bajo' menos blobs y material Lambert liso (lo decide
- * quien lo monta via `blobs`/`flat`). Cero texturas: color por material.
+ *   · UNA geometría fusionada por (especie × variante × calidad) → UN mesh, UN
+ *     material, UNA draw-call por árbol. El follaje ya no es un mesh por blob.
+ *   · El color va horneado en el vértice (AO, gradiente, contraluz, variación).
+ *     El material es un Lambert con `vertexColors`: sin shaders propios, que el
+ *     repo no usa ninguno y esto corre en Android barato.
+ *   · CACHÉ de geometría compartida (`cacheArboles.js`): construir un árbol
+ *     cuesta (ramifica y hornea). Cuatro héroes, sus acompañantes y el bosque
+ *     comparten geometría; sin caché se reconstruiría una y otra vez la misma.
+ *     Ojo: la geometría es COMPARTIDA — este componente NO le hace dispose (ver
+ *     la nota de `cacheArboles.js`); el material sí es suyo y sí lo libera.
+ *
+ * ── VIDA ────────────────────────────────────────────────────────────────────
+ * El árbol se mece desde el PIE (pivote abajo), lento, con fase propia. Los
+ * árboles grandes pesan más y se mueven menos. `reducedMotion` los deja quietos.
+ * Es mecido de objeto, no de vértice: sin shader de viento, el follaje no puede
+ * moverse aparte del tronco — y un mecido entero y sobrio miente menos que un
+ * árbol tieso.
  *
  * Componente r3f: montar SOLO dentro de un <Canvas>.
  */
 import { useEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import {
-  ARBOLES_MAYORES,
-  copaBlobs,
-  tallosArbol,
-  raicesTablares,
-} from './arbolesMayores.js';
+import { ESPECIES, calidadDeTier } from './arbolMayor.geom.js';
+import { geomCacheada } from './cacheArboles.js';
 
-/* Un tallo ahusado con leve curva: TubeGeometry sobre una curva de 3 puntos.
-   Barato (pocos segmentos radiales) y da el nudo orgánico de la queñua. */
-function geometriaTallo(tallo, curvaLateral, radioBase) {
-  const [bx, bz] = tallo.base;
-  const h = tallo.alto;
-  const puntas = [
-    new THREE.Vector3(bx, 0, bz),
-    new THREE.Vector3(bx + curvaLateral * 0.4, h * 0.55, bz + curvaLateral * 0.25),
-    new THREE.Vector3(bx + curvaLateral, h, bz + curvaLateral * 0.6),
-  ];
-  const curva = new THREE.CatmullRomCurve3(puntas);
-  const geo = new THREE.TubeGeometry(curva, 6, radioBase, 6, false);
-  // ahusar: estrechar el radio hacia la punta moviendo los anillos superiores
-  return geo;
-}
-
+/**
+ * Un árbol de la Sierra.
+ *
+ * @param {object} props
+ * @param {'quenua'|'roble'|'guayacan'|'ceiba'} [props.tipo='roble']
+ * @param {'alto'|'medio'|'bajo'} [props.tier='alto']  calidad geométrica.
+ * @param {number} [props.variante=0]  otro árbol de la misma especie.
+ * @param {number} [props.escala=1]
+ * @param {[number,number,number]} [props.position]
+ * @param {[number,number,number]} [props.rotation]
+ * @param {boolean} [props.reducedMotion=false]  lo deja quieto.
+ * @param {number} [props.semilla=1]  desfasa el mecido (que no meza todo a la vez).
+ */
 export default function ArbolMayor({
   tipo = 'roble',
+  tier = 'alto',
+  variante = 0,
   escala = 1,
   position = [0, 0, 0],
   rotation = [0, 0, 0],
   reducedMotion = false,
   semilla = 1,
-  blobs,
-  flat = true,
 }) {
-  const def = ARBOLES_MAYORES[tipo] || ARBOLES_MAYORES.roble;
-  const forma = def.forma;
-  const alto = def.alto;
+  const def = ESPECIES[tipo] || ESPECIES.roble;
+  const clave = ESPECIES[tipo] ? tipo : 'roble';
   const pivote = useRef(null);
 
-  /* Receta memoizada: tallos, raíces tablares y nubes de copa. `blobs` permite
-     al host bajar la densidad por tier sin tocar el catálogo. */
-  const armado = useMemo(() => {
-    const formaTier = blobs != null ? { ...forma, blobs } : forma;
-    return {
-      tallos: tallosArbol(forma, alto, semilla),
-      raices: raicesTablares(forma, alto, semilla),
-      copa: copaBlobs(formaTier, alto, semilla),
-    };
-  }, [forma, alto, semilla, blobs]);
-
-  const geomTallos = useMemo(
-    () =>
-      armado.tallos.map((t) => {
-        const curva = t.curva + (forma.inclina || 0) * alto * 0.6;
-        return geometriaTallo(t, curva, alto * 0.045 * t.grosor);
-      }),
-    [armado.tallos, forma.inclina, alto],
+  const geo = useMemo(
+    () => geomCacheada(clave, { q: calidadDeTier(tier), variante }),
+    [clave, tier, variante],
   );
 
-  // Geometría de copa compartida entre blobs (barata: un icosaedro facetado).
-  const geoBlob = useMemo(() => new THREE.IcosahedronGeometry(0.5, flat ? 0 : 1), [flat]);
-  const geoRaiz = useMemo(() => new THREE.BoxGeometry(1, 1, 1), []);
-
-  const cCortezaBase = useMemo(() => new THREE.Color(def.corteza.base), [def]);
-  const cCortezaClara = useMemo(() => new THREE.Color(def.corteza.clara), [def]);
-  const cCopaBase = useMemo(() => new THREE.Color(def.copa.base), [def]);
-  const cCopaClara = useMemo(() => new THREE.Color(def.copa.clara), [def]);
-
-  // libera cada geometría propia cuando se recrea o al desmontar (un effect por
-  // recurso: así nunca se dispone una geometría que otro dep aún usa)
-  useEffect(() => () => geomTallos.forEach((g) => g.dispose()), [geomTallos]);
-  useEffect(() => () => geoBlob.dispose(), [geoBlob]);
-  useEffect(() => () => geoRaiz.dispose(), [geoRaiz]);
+  // el material sí es propio de este árbol: se dispone al desmontar (la
+  // geometría NO: es compartida, ver la nota del caché)
+  const mat = useMemo(
+    () => new THREE.MeshLambertMaterial({ vertexColors: true }),
+    [],
+  );
+  useEffect(() => () => mat.dispose(), [mat]);
 
   const fase = useMemo(() => semilla * 1.7, [semilla]);
 
   useFrame((st) => {
     if (reducedMotion || !pivote.current) return;
     const t = st.clock.elapsedTime;
-    // mecido lento desde el pie: árboles grandes pesan más (menos amplitud)
-    const amp = 0.02 + 0.02 / Math.max(1, alto);
-    pivote.current.rotation.z = (rotation[2] || 0) + Math.sin(t * 0.5 + fase) * amp;
-    pivote.current.rotation.x = (rotation[0] || 0) + Math.cos(t * 0.37 + fase) * amp * 0.5;
+    // los árboles grandes pesan: menos amplitud. El páramo mece más que el valle.
+    const amp = 0.014 + 0.016 / Math.max(1, def.alto);
+    pivote.current.rotation.z = (rotation[2] || 0) + Math.sin(t * 0.45 + fase) * amp;
+    pivote.current.rotation.x = (rotation[0] || 0) + Math.cos(t * 0.33 + fase) * amp * 0.5;
   });
-
-  const alturaCopa = alto * (forma.tipo === 'emergente' ? 0.98 : 0.82);
 
   return (
     <group position={position} scale={escala}>
-      {/* pivote al pie: el mecido gira el árbol entero desde la base */}
+      {/* pivote al pie: el mecido gira el árbol entero desde la base, como un
+          árbol real — no desde el centro, que lo haría patinar */}
       <group ref={pivote} rotation={rotation}>
-        {/* RAÍCES TABLARES (ceiba): aletas verticales que agarran la tierra */}
-        {armado.raices.map((r, i) => (
-          <mesh
-            key={`raiz${i}`}
-            geometry={geoRaiz}
-            position={[Math.cos(r.ang) * r.largo * 0.5, r.alto * 0.5, Math.sin(r.ang) * r.largo * 0.5]}
-            rotation={[0, -r.ang, 0]}
-            scale={[r.largo, r.alto, alto * 0.03]}
-          >
-            <meshLambertMaterial color={cCortezaBase} flatShading={flat} />
-          </mesh>
-        ))}
-
-        {/* TRONCO(S) ahusado(s) */}
-        {geomTallos.map((geo, i) => (
-          <mesh key={`tallo${i}`} geometry={geo}>
-            <meshLambertMaterial
-              color={i === 0 ? cCortezaClara : cCortezaBase}
-              flatShading={flat}
-            />
-          </mesh>
-        ))}
-
-        {/* COPA: nubes de follaje (o de FLOR en el guayacán) sobre el tope */}
-        <group position={[forma.inclina ? forma.inclina * alto * 0.6 : 0, alturaCopa, 0]}>
-          {armado.copa.map((b, i) => {
-            const c = cCopaBase.clone().lerp(cCopaClara, b.tono);
-            return (
-              <mesh
-                key={`copa${i}`}
-                geometry={geoBlob}
-                position={b.pos}
-                scale={b.escala}
-              >
-                <meshLambertMaterial
-                  color={c}
-                  flatShading={flat}
-                  emissive={forma.floracion ? c.clone().multiplyScalar(0.18) : '#000000'}
-                />
-              </mesh>
-            );
-          })}
-        </group>
+        <mesh geometry={geo} material={mat} />
       </group>
     </group>
   );

--- a/src/visual/mundo3d/sierra/GaleriaSierraArboles.jsx
+++ b/src/visual/mundo3d/sierra/GaleriaSierraArboles.jsx
@@ -55,7 +55,7 @@
  *
  * Montar SOLO dentro de un <Canvas> (el named); el default trae el suyo.
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Html, OrbitControls, AdaptiveDpr } from '@react-three/drei';
@@ -63,7 +63,14 @@ import { ATMOSFERA } from '../atmosferaMadre.js';
 import { perfilDeTier } from '../deviceTier.js';
 import { PISOS_TERMICOS } from '../pisosTermicos.js';
 import ArbolMayor from './ArbolMayor.jsx';
-import { arbolDePiso, frailejonar, FRAILEJON } from './arbolesMayores.js';
+import { geomCacheada, limpiarCacheArboles } from './cacheArboles.js';
+import { arbolDePiso, tipoDePiso, calidadDeTier, variantesDeTier } from './arbolMayor.geom.js';
+import { distribucionBosque, bosqueDeTier } from './bosqueSierra.js';
+import { frailejonar } from './arbolesMayores.js';
+/* El frailejón bueno ya existía: `floraParamo.geom` lo arma con su enagua de
+   hojas muertas y su roseta plateada. Antes esta escena dibujaba a mano un palo
+   con una bolita blanca encima —un fósforo— teniendo el bueno al lado. Se reusa. */
+import { geomFrailejon } from '../bosque/floraParamo.geom.js';
 
 /* ── Geometría del monte (coords propias del macizo). X=E-O, Y=altura, Z=pie(−9)
       →cumbre(+1.6). La ladera-galería mira a −z; el diorama entero se gira π en
@@ -153,12 +160,16 @@ function colorMonte(yf, d, out) {
 }
 
 /* Fracción de altura del centro de cada banda (para posar su árbol mayor). Sube
-   con el clima igual que los umbrales de la banda. */
+   con el clima igual que los umbrales de la banda.
+   La X NO va a intervalos parejos a propósito: repartidos cada 4.3 unidades
+   exactas, los cuatro héroes se leían como una FILA —una grilla, justo lo que el
+   DR manda evitar—. Corridos a distancias desiguales, el ojo lee cuatro lugares
+   de una ladera y no cuatro casillas. Siguen bien separados y visibles. */
 const CENTROS = {
-  calido: { base: 0.09, factor: 1.0, x: -6.5 },
-  templado: { base: 0.26, factor: 1.05, x: -2.4 },
-  frio: { base: 0.44, factor: 1.2, x: 2.4 },
-  paramo: { base: 0.61, factor: 1.0, x: 6.4 },
+  calido: { base: 0.09, factor: 1.0, x: -7.4 },
+  templado: { base: 0.26, factor: 1.05, x: -1.6 },
+  frio: { base: 0.44, factor: 1.2, x: 3.9 },
+  paramo: { base: 0.61, factor: 1.0, x: -3.8 },
 };
 /* Punto de la LADERA FRONTAL donde una fracción de altura se posa, a una X dada.
    Busca en el frente (z creciente) el z cuya altura iguala el objetivo. */
@@ -361,17 +372,21 @@ function NieblaBosque({ cuantos, reducedMotion }) {
       ch.position.x = puffs[i].x + Math.sin(t * 0.05 + i * 2.1) * 0.7;
     });
   });
+  /* Muy tenue y MUY aplastada. Antes eran esferas a opacidad 0.4: se leían como
+     pastillas de plástico cruzando la ladera, no como niebla. La niebla del
+     bosque de niebla es un VELO que deja ver a través — si se le ve el borde, ya
+     mintió. Ancha, baja y casi transparente: se lee como jirón, no como bulto. */
   return (
     <group ref={grupo}>
       {puffs.map((p, i) => (
         <group key={i} position={[p.x, p.y, p.z]}>
-          <mesh scale={[p.e * 1.7, p.e * 0.5, p.e * 0.9]}>
-            <sphereGeometry args={[1, 8, 6]} />
-            <meshBasicMaterial color="#fbf3df" transparent opacity={0.4} depthWrite={false} />
+          <mesh scale={[p.e * 3.4, p.e * 0.28, p.e * 1.1]}>
+            <sphereGeometry args={[1, 10, 6]} />
+            <meshBasicMaterial color="#fbf3df" transparent opacity={0.17} depthWrite={false} />
           </mesh>
-          <mesh position={[p.e * 1.2, -p.e * 0.06, 0.2]} scale={[p.e * 0.9, p.e * 0.34, p.e * 0.6]}>
+          <mesh position={[p.e * 1.6, -p.e * 0.05, 0.25]} scale={[p.e * 2.1, p.e * 0.2, p.e * 0.8]}>
             <sphereGeometry args={[1, 8, 6]} />
-            <meshBasicMaterial color="#fbf3df" transparent opacity={0.28} depthWrite={false} />
+            <meshBasicMaterial color="#fbf3df" transparent opacity={0.12} depthWrite={false} />
           </mesh>
         </group>
       ))}
@@ -450,34 +465,130 @@ function CondorAndino({ radio = 6, altura = 7.2, fase = 0, reducedMotion, escala
   );
 }
 
-/* Los frailejones del páramo, alrededor de la queñua: tronco columnar + roseta
-   lanuda plateada + flor amarilla. Baratos, instanciados a mano (~pocos). */
-function Frailejones({ centro, cuantos }) {
-  const items = useMemo(() => {
-    const base = frailejonar(cuantos, 2.2, 7);
-    return base.map((f) => {
+/* ── Un banco de instancias: UNA geometría, UN material, N copias → UNA
+      draw-call. Es el patrón de `FloraParamo.jsx`; aquí lo usan el frailejonar y
+      el bosque de la ladera. ── */
+function Banco({ geo, mat, items }) {
+  const ref = useRef(null);
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(it.inclina?.[0] || 0, it.giroY ?? it.giro ?? 0, it.inclina?.[1] || 0);
+      q.setFromEuler(e);
+      s.setScalar(it.escala ?? 1);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      if (it.tint) {
+        col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+        mesh.setColorAt(i, col);
+      }
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+  if (!geo || !items.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, items.length]} frustumCulled={false} />;
+}
+
+/* Los frailejones del páramo, alrededor de la queñua. Geometría reusada de
+   `floraParamo.geom` (roseta plateada + enagua marcescente), instanciada. */
+function Frailejones({ centro, cuantos, tier }) {
+  const q = calidadDeTier(tier);
+  const geo = useMemo(() => geomFrailejon({ q }, 21), [q]);
+  const geoFlor = useMemo(() => geomFrailejon({ flor: true, q }, 22), [q]);
+  const mat = useMemo(() => new THREE.MeshLambertMaterial({ vertexColors: true }), []);
+  useEffect(() => () => { geo.dispose(); geoFlor.dispose(); mat.dispose(); }, [geo, geoFlor, mat]);
+
+  const { simples, floridos } = useMemo(() => {
+    const base = frailejonar(cuantos, 2.6, 7).map((f) => {
       const wx = centro[0] + f.pos[0];
       const wz = centro[2] + f.pos[2];
-      return { ...f, world: [wx, alturaMonte(wx, wz), wz] };
+      return {
+        pos: /** @type {[number, number, number]} */ ([wx, alturaMonte(wx, wz), wz]),
+        giroY: f.giro,
+        // el frailejón real ronda 1-2 m: aquí va chico contra el árbol mayor
+        escala: 0.3 + f.alto * 0.42,
+      };
     });
+    // uno de cada cinco, en flor (no todos: el páramo no florece en bloque)
+    return {
+      simples: base.filter((_, i) => i % 5 !== 0),
+      floridos: base.filter((_, i) => i % 5 === 0),
+    };
   }, [centro, cuantos]);
+
   return (
     <group>
-      {items.map((f, i) => (
-        <group key={i} position={f.world} rotation={[0, f.giro, 0]}>
-          <mesh position={[0, f.alto / 2, 0]}>
-            <cylinderGeometry args={[0.05, 0.07, f.alto, 6]} />
-            <meshLambertMaterial color={FRAILEJON.tronco} flatShading />
-          </mesh>
-          <mesh position={[0, f.alto, 0]}>
-            <sphereGeometry args={[0.13, 7, 5]} />
-            <meshLambertMaterial color={FRAILEJON.roseta} flatShading />
-          </mesh>
-          <mesh position={[0, f.alto + 0.09, 0]}>
-            <sphereGeometry args={[0.045, 6, 5]} />
-            <meshLambertMaterial color={FRAILEJON.flor} />
-          </mesh>
-        </group>
+      <Banco geo={geo} mat={mat} items={simples} />
+      <Banco geo={geoFlor} mat={mat} items={floridos} />
+    </group>
+  );
+}
+
+/* ── EL BOSQUE DE LA LADERA — lo que faltaba para que esto fuera un monte ────
+      Cada especie vive en SU banda de altitud y se agrupa en rodales (ver
+      `bosqueSierra.js`). Por especie y variante: un InstancedMesh. Los árboles
+      de relleno usan calidad 'bajo' aunque el tier sea alto — son LOD: a esa
+      distancia lo único que se lee es la silueta, y el detalle ahí es plata
+      tirada (DR §LOD). El detalle fino se lo queda el héroe, que está cerca. ── */
+function BosqueLadera({ tier, d, claros }) {
+  const conteos = bosqueDeTier(tier);
+  const variantes = variantesDeTier(tier);
+  const mat = useMemo(() => new THREE.MeshLambertMaterial({ vertexColors: true }), []);
+  useEffect(() => () => mat.dispose(), [mat]);
+
+  const siembra = useMemo(
+    () =>
+      distribucionBosque({
+        altura: alturaMonte,
+        cima: CIMA,
+        /* El bosque arranca LADERA ARRIBA, no en la orilla: el pie del monte le
+           queda a la cámara 2.4x más cerca que la cumbre, y sembrarlo hasta el
+           borde ponía un muro de árboles delante de todo — tapaba el macizo y a
+           los propios héroes. Dejar libre la franja de playa también es honesto:
+           ahí hay arena, no bosque. */
+        area: { x0: -ANCHO / 2 + 1.5, x1: ANCHO / 2 - 1.5, z0: Z_FRENTE + 2.6, z1: Z_CUMBRE + 2.2 },
+        conteos,
+        claros,
+        d,
+        variantes,
+      }),
+    [conteos, claros, d, variantes],
+  );
+
+  // agrupa las instancias por (especie, variante): cada grupo, una draw-call
+  const bancos = useMemo(() => {
+    const out = [];
+    for (const [especie, items] of Object.entries(siembra)) {
+      for (let v = 0; v < variantes; v++) {
+        const suyos = items.filter((it) => it.variante === v);
+        if (!suyos.length) continue;
+        out.push({
+          clave: `${especie}-${v}`,
+          // sss=false: estas instancias giran (poco, pero giran) y además se ven
+          // de lejos; el contraluz horneado no se justifica. AO y gradiente sí
+          // viajan (son invariantes al giro en Y).
+          geo: geomCacheada(especie, { q: calidadDeTier('bajo'), variante: v, sss: false }),
+          items: suyos,
+        });
+      }
+    }
+    return out;
+  }, [siembra, variantes]);
+
+  return (
+    <group>
+      {bancos.map((b) => (
+        <Banco key={b.clave} geo={b.geo} mat={mat} items={b.items} />
       ))}
     </group>
   );
@@ -521,7 +632,6 @@ const CLARO_PISO = {
 function VinetaPiso({ pisoId, ancla, def, tier, reducedMotion }) {
   const rica = tier === 'alto';
   const media = rica || tier === 'medio';
-  const flat = tier === 'alto';
 
   /* offsets relativos al ancla, con la Y muestreada del monte (el compañero se
      posa en SU punto de la ladera, no flota a la altura del héroe) */
@@ -580,10 +690,10 @@ function VinetaPiso({ pisoId, ancla, def, tier, reducedMotion }) {
       {pisoId === 'frio' && rica && (
         <>
           <group position={rel(-1.25, 0.55)}>
-            <ArbolMayor tipo="roble" escala={0.42} semilla={7.3} blobs={4} flat={flat} reducedMotion={reducedMotion} />
+            <ArbolMayor tipo="roble" tier={tier} variante={1} escala={0.42} semilla={7.3} reducedMotion={reducedMotion} />
           </group>
           <group position={rel(1.2, -0.4)}>
-            <ArbolMayor tipo="roble" escala={0.3} semilla={4.6} blobs={3} flat={flat} reducedMotion={reducedMotion} />
+            <ArbolMayor tipo="roble" tier={tier} variante={2} escala={0.3} semilla={4.6} reducedMotion={reducedMotion} />
           </group>
           <mesh position={[0.4, def.alto * 0.55, 0.9]} scale={[1.5, 0.4, 0.7]}>
             <sphereGeometry args={[1, 8, 6]} />
@@ -607,7 +717,7 @@ function VinetaPiso({ pisoId, ancla, def, tier, reducedMotion }) {
       )}
       {pisoId === 'paramo' && rica && (
         <group position={rel(-1.2, 0.35)}>
-          <ArbolMayor tipo="quenua" escala={0.52} semilla={9.1} blobs={3} flat={flat} reducedMotion={reducedMotion} />
+          <ArbolMayor tipo="quenua" tier={tier} variante={1} escala={0.52} semilla={9.1} reducedMotion={reducedMotion} />
         </group>
       )}
     </group>
@@ -653,7 +763,6 @@ function HeroArbol({ pisoId, d, tier, reducedMotion, onEntrar, resaltado }) {
   });
 
   if (!def || !piso) return null;
-  const blobs = tier === 'alto' ? undefined : tier === 'medio' ? 4 : 3;
   const escala = tier === 'bajo' ? 0.85 : 1;
   return (
     <group
@@ -670,11 +779,11 @@ function HeroArbol({ pisoId, d, tier, reducedMotion, onEntrar, resaltado }) {
       </mesh>
       <ArbolMayor
         tipo={tipoDeArbol(pisoId)}
+        tier={tier}
+        variante={0}
         escala={escala}
         reducedMotion={reducedMotion}
         semilla={pisoId.length + cfg.x}
-        blobs={blobs}
-        flat={tier === 'alto'}
       />
       <VinetaPiso pisoId={pisoId} ancla={ancla} def={def} tier={tier} reducedMotion={reducedMotion} />
       {/* anillo sutil de "aquí está su árbol mayor" cuando es el piso del usuario */}
@@ -707,9 +816,10 @@ function HeroArbol({ pisoId, d, tier, reducedMotion, onEntrar, resaltado }) {
   );
 }
 
-/* Mapa piso→arquetipo de árbol (la clave del catálogo arbolesMayores). */
+/* Mapa piso→arquetipo de árbol. Lo resuelve el catálogo (cada especie declara su
+   piso), así no hay dos listas que se puedan desincronizar. */
 function tipoDeArbol(pisoId) {
-  return { paramo: 'quenua', frio: 'roble', templado: 'guayacan', calido: 'ceiba' }[pisoId] || 'roble';
+  return tipoDePiso(pisoId) || 'roble';
 }
 
 /* Luces de la hora dorada: el sol rasante entra por la derecha-atrás (donde
@@ -764,6 +874,24 @@ export function SierraArbolesDiorama({
     [d],
   );
 
+  /* Los claros de los héroes: el bosque los rodea pero no se les encima, así el
+     hito sigue siendo tocable y legible. Se recalculan con el clima porque los
+     héroes MIGRAN cuesta arriba (y su claro viaja con ellos). */
+  const claros = useMemo(
+    () =>
+      ['calido', 'templado', 'frio', 'paramo'].map((pid) => {
+        const c = CENTROS[pid];
+        const a = anclaLadera(c.x, c.base, d, c.factor);
+        const def = arbolDePiso(pid);
+        return { x: a[0], z: a[2], r: (def?.alto || 2) * 0.95 };
+      }),
+    [d],
+  );
+
+  // la caché de geometría es compartida entre héroes y bosque: se libera cuando
+  // se va la ESCENA, no cuando se desmonta un árbol suelto
+  useEffect(() => () => limpiarCacheArboles(), []);
+
   return (
     <>
       {atmosfera && <color attach="background" args={[ATMOSFERA.fondo]} />}
@@ -782,8 +910,13 @@ export function SierraArbolesDiorama({
           <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
         </mesh>
 
+        {/* EL BOSQUE: cada especie en su banda de altitud, en rodales. Va ANTES
+            que los héroes porque es el telón contra el que se leen (y el que les
+            da la escala que no tenían cuando la ladera estaba pelada). */}
+        <BosqueLadera tier={tier} d={d} claros={claros} />
+
         {/* frailejonar del páramo, junto a la queñua */}
-        {frailejones > 0 && <Frailejones centro={anclaParamo} cuantos={frailejones} />}
+        {frailejones > 0 && <Frailejones centro={anclaParamo} cuantos={frailejones} tier={tier} />}
 
         {/* la niebla enganchada al bosque de niebla (piso frío) */}
         {nubes > 0 && <NieblaBosque cuantos={nubes} reducedMotion={reducedMotion} />}
@@ -801,15 +934,22 @@ export function SierraArbolesDiorama({
           />
         ))}
 
-        {/* el cóndor andino, planeando sobre la nieve (fauna realista) */}
+        {/* El cóndor andino, planeando sobre la nieve (fauna realista).
+            A escala 1 medía 2.3 unidades de punta a punta —casi tanto como el
+            roble mayor, que son 2.7—: un pajarraco del tamaño de un árbol, que
+            de cerca se leía como un borrón negro. El cóndor tiene la mayor
+            envergadura de los Andes (~3 m) pero un roble andino pasa de 20 m:
+            la proporción real es ~1:7. A esta escala se lee por su SILUETA
+            —alas fijas en diedro, primarias abiertas—, que es justo como se
+            reconoce un cóndor de verdad: por el perfil contra el cielo. */}
         {Array.from({ length: condores }).map((_, i) => (
           <CondorAndino
             key={i}
             radio={5.8 + i * 1.7}
-            altura={7.2 + i * 0.6}
+            altura={7.6 + i * 0.6}
             fase={i * 2.3}
             reducedMotion={reducedMotion}
-            escala={1 - i * 0.15}
+            escala={0.4 - i * 0.06}
           />
         ))}
       </group>
@@ -825,21 +965,36 @@ function DerivaCamara({ controles, reducedMotion }) {
   const dir = useRef(1);
   const quieto = useRef(false);
   const enganchado = useRef(false);
-  useEffect(() => () => {
-    const c = controles.current;
-    if (c && enganchado.current) {
-      c.removeEventListener('start', c.__gsierraParar);
-      c.removeEventListener('end', c.__gsierraSoltar);
-    }
+  /* Los handlers viven en refs de ESTE componente. Antes se colgaban como
+     propiedades (`__gsierraParar`) del objeto de controles —que llega por prop—
+     para poder desengancharlos después: eso muta un objeto ajeno y además el
+     linter lo prohíbe. En un ref propio se guardan igual y no se ensucia nada. */
+  const parar = useRef(() => { quieto.current = true; });
+  const soltar = useRef(() => { quieto.current = false; });
+
+  useEffect(() => {
+    const ref = controles;
+    // copiados aquí a propósito: en la limpieza hay que quitar EXACTAMENTE los
+    // mismos handlers que se engancharon, no lo que el ref diga entonces
+    const alParar = parar.current;
+    const alSoltar = soltar.current;
+    return () => {
+      const c = ref.current;
+      if (c && enganchado.current) {
+        c.removeEventListener('start', alParar);
+        c.removeEventListener('end', alSoltar);
+        enganchado.current = false;
+      }
+    };
   }, [controles]);
+
   useFrame((_, dt) => {
     const c = controles.current;
     if (!c) return;
+    // los controles aparecen después del primer frame: se engancha al verlos
     if (!enganchado.current) {
-      c.__gsierraParar = () => { quieto.current = true; };
-      c.__gsierraSoltar = () => { quieto.current = false; };
-      c.addEventListener('start', c.__gsierraParar);
-      c.addEventListener('end', c.__gsierraSoltar);
+      c.addEventListener('start', parar.current);
+      c.addEventListener('end', soltar.current);
       enganchado.current = true;
     }
     if (quieto.current || reducedMotion) return;
@@ -906,13 +1061,17 @@ button.gsierra-leyenda__banda:focus-visible .gsierra-leyenda__nombre, button.gsi
       Las bandas con árbol mayor son botones que entran a su mundo. ── */
 function LeyendaPisos({ clima, pisoUsuario, onEntrarPiso }) {
   const d = clamp(clima, 0, 1);
+  /* Las bandas se apilan: cada una arranca donde terminó la anterior. Antes esto
+     era un `.map()` que reasignaba un `let` de afuera —mutación durante el
+     render, que el linter marca—. Un bucle que acumula en local dice lo mismo
+     sin ese enredo. */
+  const bandas = [];
   let base = 0;
-  const bandas = BANDAS.map((b) => {
+  for (const b of BANDAS) {
     const top = Number.isFinite(b.top) ? topDesplazado(b, d) : 1;
-    const seg = { id: b.id, alto: Math.max(0.02, top - base), base };
+    bandas.push({ id: b.id, alto: Math.max(0.02, top - base), base });
     base = Math.min(top, 1);
-    return seg;
-  });
+  }
   const conArbol = new Set(['calido', 'templado', 'frio', 'paramo']);
   return (
     <div className="gsierra-leyenda" role="group" aria-label="Pisos térmicos de la Sierra, del mar a la nieve. Las bandas con árbol entran a su mundo.">

--- a/src/visual/mundo3d/sierra/arbolMayor.geom.js
+++ b/src/visual/mundo3d/sierra/arbolMayor.geom.js
@@ -1,0 +1,819 @@
+/*
+ * arbolMayor.geom — la GEOMETRÍA de los árboles de la Sierra, apuntando a
+ * REALISMO. Geometría pura: cero three-en-pantalla, cero React, cero texturas,
+ * cero assets. Corre headless (es matemática de buffers) y se testea headless.
+ *
+ * ── POR QUÉ SE REHIZO (el veredicto: "parece una caricatura mal hecha") ───────
+ * La versión anterior era el "árbol de navidad" de manual: un cono/elipsoide de
+ * blobs de follaje encima de un cilindro de tronco. El DR de realismo
+ * (deepresearch/DR-FANOUT/realismo-3d-vegetacion-*-2026-06-19.md) diagnostica
+ * exactamente ese fallo y ordena las recetas por RETORNO VISUAL POR COSTO. Este
+ * módulo las aplica, en ese orden:
+ *
+ *   R1 · SOMBREADO DE FOLLAJE (el mayor retorno del DR) — horneado en
+ *        `vertexColors`, sin shaders propios:
+ *          · AO por vértice: el follaje hondo de la copa y las axilas de rama
+ *            se oscurecen; las caras que miran al suelo pierden cielo.
+ *          · Gradiente de altura: la copa se aclara hacia arriba.
+ *          · TRANSLUCIDEZ a contraluz (la hoja encendida): se puede HORNEAR
+ *            porque el sol de esta escena es FIJO (hora dorada). Ver §EL SOL.
+ *          · Variación de color por hoja/cluster y por instancia.
+ *   R2 · SILUETA Y JERARQUÍA DE RAMAS — ramificación recursiva (tronco → ramas
+ *        primarias → secundarias → terciarias) con conicidad REAL y curvatura.
+ *        El follaje se cuelga de las PUNTAS de rama, no en una cáscara de
+ *        elipsoide: por eso la copa sale irregular y CON HUECOS —se ve cielo
+ *        entre las hojas— sin tener que "hacerle huecos" a mano.
+ *   R3 · ROTURA DE LA SIMETRÍA — `variante` genera árboles distintos de la misma
+ *        especie (el DR: "10 árboles diferentes valen más que 100 idénticos").
+ *   R4 · TRONCO SIN TEXTURA — conicidad real + rugosidad de corteza en la
+ *        geometría + color de vértice más oscuro en los valles del relieve.
+ *
+ * ── EL SOL ES FIJO (y por eso se puede hornear la luz) ───────────────────────
+ * `GaleriaSierraArboles` alumbra con un directional en [-11, 8, 4] (coords del
+ * grupo del diorama). El sol no se mueve nunca: la cara encendida de un árbol es
+ * SIEMPRE la misma. Eso permite hornear en el vértice lo que un Lambert no sabe
+ * hacer —AO y translucidez a contraluz— sin escribir un shader (el repo no usa
+ * ninguno: corre en Android barato y en una Quadro vieja).
+ *
+ * OJO con lo que NO se hornea: la difusa del sol la calcula el Lambert con la
+ * luz real. Hornearla también la contaría DOS VECES. Aquí solo va lo que el
+ * Lambert no puede: oclusión, contraluz, gradiente y variación (todo albedo).
+ *
+ * ── ROTACIÓN Y LUZ HORNEADA (la regla que hay que respetar al instanciar) ────
+ * Si una instancia gira en Y, la luz horneada gira con ella y el contraluz queda
+ * mirando a cualquier lado. Por eso:
+ *   · AO y gradiente son invariantes al giro en Y (radiales/verticales) → libres.
+ *   · La TRANSLUCIDEZ es direccional → las instancias usan `giroMax` chico
+ *     (±0.18 rad); la variedad la dan las VARIANTES de geometría, no el giro.
+ * `JITTER_GIRO` es ese tope y está exportado para que el consumidor no lo invente.
+ *
+ * ── PRESUPUESTO ─────────────────────────────────────────────────────────────
+ * Una geometría FUSIONADA por (especie × variante) → un InstancedMesh → una
+ * draw-call, por más árboles que haya. `q` (calidad por tier) recorta niveles de
+ * rama y hojas. ~2-4k triángulos por árbol héroe en 'alto'; el bosque de relleno
+ * usa `q` bajo (~300-600).
+ *
+ * ⚠️ `mergeGeometries` devuelve null EN SILENCIO al mezclar geometría indexada
+ * con no-indexada, y r3f hace `if (!geo) return null` → la especie desaparece sin
+ * un solo error. Ya mordió dos veces en este repo. `fusionar()` desindexa TODO
+ * antes de mezclar y TRUENA si el merge devuelve null: mejor romper el build que
+ * enviar un árbol invisible.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+
+/* Ruido determinista: el mismo árbol en todos los equipos, y cachea limpio en el
+   service worker (nada de Math.random). */
+export function rng(seed) {
+  let s = (seed >>> 0) || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const lerp = (a, b, t) => a + (b - a) * t;
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+
+/** Dirección del sol en coordenadas del diorama (ver §EL SOL). Unitaria. */
+export const SOL = new THREE.Vector3(-11, 8, 4).normalize();
+
+/** Tope de giro en Y al instanciar: más que esto y el contraluz horneado miente. */
+export const JITTER_GIRO = 0.18;
+
+/** Calidad geométrica por tier (recorta ramas y hojas, no especies). */
+export const CALIDAD_TIER = { alto: 1, medio: 0.6, bajo: 0.38 };
+export const calidadDeTier = (tier) => CALIDAD_TIER[tier] ?? CALIDAD_TIER.medio;
+
+/* -------------------------------------------------------------------------- */
+/*  Fusión y pintado                                                           */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Los ÚNICOS atributos que sobreviven a la fusión. `mergeGeometries` exige que
+ * TODAS las partes traigan exactamente el mismo juego de atributos, y falla
+ * devolviendo null si una trae uno de más. Las primitivas de three
+ * (Icosahedron/Cylinder/Extrude) traen `uv`; `tuboAhusado` no (no hay texturas
+ * en todo el módulo: el color va en el vértice). Esa sola diferencia bastaba
+ * para devolver null. Se normaliza a este juego y se acabó la clase de bug.
+ */
+const ATRIBUTOS = ['position', 'normal', 'color'];
+
+/**
+ * Fusiona partes en UNA geometría. Desindexa y normaliza atributos antes (ver el
+ * aviso de cabecera) y TRUENA si el merge falla: un árbol invisible es peor que
+ * un build roto, porque no avisa.
+ *
+ * @param {Array<THREE.BufferGeometry|null>} partes
+ * @param {string} etiqueta  para que el error diga QUÉ especie reventó.
+ * @returns {THREE.BufferGeometry}
+ */
+export function fusionar(partes, etiqueta = 'árbol') {
+  const buenas = partes.filter(Boolean).map((g) => {
+    const plana = g.index ? g.toNonIndexed() : g;
+    if (!plana.attributes.normal) plana.computeVertexNormals();
+    // fuera todo lo que no sea position/normal/color (uv, aRelieve, tangentes…)
+    for (const nombre of Object.keys(plana.attributes)) {
+      if (!ATRIBUTOS.includes(nombre)) plana.deleteAttribute(nombre);
+    }
+    return plana;
+  });
+  if (!buenas.length) throw new Error(`[arbolMayor.geom] ${etiqueta}: sin partes que fusionar`);
+
+  // Un color faltante convierte el merge en null (o, peor, en un árbol negro).
+  const sinColor = buenas.findIndex((g) => !g.attributes.color);
+  if (sinColor >= 0) {
+    throw new Error(
+      `[arbolMayor.geom] ${etiqueta}: la parte #${sinColor} no trae color horneado`,
+    );
+  }
+
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error(
+      `[arbolMayor.geom] ${etiqueta}: mergeGeometries devolvió null ` +
+        `(${buenas.length} partes). Atributos disparejos entre partes.`,
+    );
+  }
+  return g;
+}
+
+/**
+ * Hornea color por vértice llamando a `fn(posición, normal, índice) → THREE.Color`.
+ * Necesita normales: las calcula si faltan. Es el único punto donde se decide el
+ * albedo — todo el sombreado horneado (R1) pasa por aquí.
+ */
+export function pintarPorVertice(geo, fn) {
+  if (!geo.attributes.normal) geo.computeVertexNormals();
+  const pos = geo.attributes.position;
+  const nor = geo.attributes.normal;
+  const arr = new Float32Array(pos.count * 3);
+  const p = new THREE.Vector3();
+  const n = new THREE.Vector3();
+  for (let i = 0; i < pos.count; i++) {
+    p.fromBufferAttribute(pos, i);
+    n.fromBufferAttribute(nor, i);
+    const c = fn(p, n, i);
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Color plano en todos los vértices (para piezas que no necesitan degradado). */
+export function pintar(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  return pintarPorVertice(geo, () => c);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  R4 · Tubo AHUSADO — el tronco/rama que SÍ se estrecha                      */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La versión vieja usaba TubeGeometry (radio CONSTANTE) y un comentario que
+ * prometía "ahusar: estrechar el radio hacia la punta" … seguido de `return geo`.
+ * El ahusado nunca existió: todas las ramas eran tubos parejos. Aquí se construye
+ * anillo por anillo con el radio interpolado, que además deja meter rugosidad de
+ * corteza y hornear las grietas.
+ */
+
+/**
+ * Tubo de radio variable a lo largo de una curva.
+ *
+ * @param {THREE.Curve} curva
+ * @param {number} segs    anillos a lo largo (detalle longitudinal).
+ * @param {number} radial  vértices por anillo (detalle transversal).
+ * @param {(t:number)=>number} radioDe  radio en t∈[0,1] (0=base, 1=punta).
+ * @param {number} rugosidad  0=cilindro perfecto; ~0.1 = corteza irregular.
+ * @param {number} faseRug    desfasa la rugosidad (que dos ramas no se repitan).
+ * @returns {THREE.BufferGeometry} con `position`, `normal` y `aRelieve` (0..1,
+ *   cuánto SALE el vértice respecto al radio liso → para oscurecer las grietas).
+ */
+export function tuboAhusado(curva, segs, radial, radioDe, rugosidad = 0, faseRug = 0) {
+  const frames = curva.computeFrenetFrames(segs, false);
+  const pos = new Float32Array((segs + 1) * radial * 3);
+  const relieve = new Float32Array((segs + 1) * radial);
+  const idx = [];
+  const p = new THREE.Vector3();
+  const v = new THREE.Vector3();
+  let k = 0;
+
+  for (let i = 0; i <= segs; i++) {
+    const t = i / segs;
+    curva.getPointAt(t, p);
+    const N = frames.normals[i];
+    const B = frames.binormals[i];
+    const rad = radioDe(t);
+    for (let j = 0; j < radial; j++) {
+      const a = (j / radial) * Math.PI * 2;
+      // Corteza: dos senos cruzados → costillas verticales que serpentean. No es
+      // ruido puro a propósito: la corteza real tiene grano, no confeti.
+      const grano =
+        Math.sin(a * 3 + faseRug) * 0.6 + Math.sin(a * 7 - t * 5 + faseRug * 1.7) * 0.4;
+      const rel = grano * 0.5 + 0.5; // 0..1
+      const wob = 1 + grano * rugosidad;
+      v.copy(p)
+        .addScaledVector(N, Math.cos(a) * rad * wob)
+        .addScaledVector(B, Math.sin(a) * rad * wob);
+      pos[k * 3] = v.x;
+      pos[k * 3 + 1] = v.y;
+      pos[k * 3 + 2] = v.z;
+      relieve[k] = rel;
+      k++;
+    }
+  }
+  for (let i = 0; i < segs; i++) {
+    for (let j = 0; j < radial; j++) {
+      const a = i * radial + j;
+      const b = i * radial + ((j + 1) % radial);
+      const c = (i + 1) * radial + j;
+      const d = (i + 1) * radial + ((j + 1) % radial);
+      idx.push(a, c, b, b, c, d);
+    }
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('aRelieve', new THREE.BufferAttribute(relieve, 1));
+  geo.setIndex(idx);
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/**
+ * Hornea la corteza: base oscura, grietas (relieve bajo) más oscuras aún, y las
+ * costillas expuestas más claras. Sin una sola textura.
+ * `aRelieve` se consume aquí y se BORRA: si sobreviviera, la fusión con partes que
+ * no lo traen devolvería null (justo el fallo silencioso de la cabecera).
+ */
+function hornearCorteza(geo, base, clara, r) {
+  const rel = geo.getAttribute('aRelieve');
+  const cBase = new THREE.Color(base);
+  const cClara = new THREE.Color(clara);
+  const tmp = new THREE.Color();
+  const jitter = 0.94 + r() * 0.12; // cada rama, un pelo distinta
+  pintarPorVertice(geo, (p, n, i) => {
+    const rl = rel ? rel.getX(i) : 0.5;
+    tmp.copy(cBase).lerp(cClara, Math.pow(rl, 1.3));
+    // el pie del tronco recibe menos cielo: oclusión de contacto con el suelo
+    const contacto = smoothstep(0.0, 0.55, p.y);
+    tmp.multiplyScalar(lerp(0.62, 1, contacto) * jitter);
+    return tmp;
+  });
+  geo.deleteAttribute('aRelieve');
+  return geo;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  R2 · Ramificación recursiva — la jerarquía que da la SILUETA               */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Un L-system "de bolsillo": el tronco se parte en ramas primarias, esas en
+ * secundarias, y así hasta `niveles`. Cada rama:
+ *   · se estrecha (taper) respecto de su madre,
+ *   · se curva (fototropismo: la punta busca arriba; gravitropismo: pesa),
+ *   · diverge un ángulo de su madre y reparte a sus hijas en azimut.
+ * Las PUNTAS terminales son donde se cuelga el follaje: por eso la copa hereda la
+ * irregularidad del ramaje y aparecen los huecos. No hay ningún elipsoide.
+ */
+
+/** Un vector perpendicular a `d` (cualquiera, estable). */
+function perpendicular(d) {
+  const a = Math.abs(d.y) < 0.92 ? new THREE.Vector3(0, 1, 0) : new THREE.Vector3(1, 0, 0);
+  return new THREE.Vector3().crossVectors(d, a).normalize();
+}
+
+/**
+ * Hace crecer una rama y, recursivamente, sus hijas.
+ *
+ * @param {object} arg
+ * @param {THREE.Vector3} arg.base   de dónde sale.
+ * @param {THREE.Vector3} arg.dir    hacia dónde apunta (unitario).
+ * @param {number} arg.largo
+ * @param {number} arg.radio         radio en la base de ESTA rama.
+ * @param {number} arg.nivel         0 = tronco.
+ * @param {object} arg.cfg           receta de la especie (ver ESPECIES).
+ * @param {Function} arg.r           rng.
+ * @param {Array} arg.ramas          salida: {curva, r0, r1, nivel}.
+ * @param {Array} arg.puntas         salida: {pos, dir, nivel} donde va el follaje.
+ */
+function crecer({ base, dir, largo, radio, nivel, cfg, r, ramas, puntas }) {
+  // La rama no es recta: se curva. `curvatura` la tuerce lateralmente y
+  // `subeALaLuz` levanta la punta (o la deja caer, si es negativo).
+  const lat = perpendicular(dir).multiplyScalar((r() - 0.5) * cfg.curvatura * largo);
+  const arriba = new THREE.Vector3(0, 1, 0).multiplyScalar(cfg.subeALaLuz * largo * (nivel ? 1 : 0.35));
+
+  const p0 = base.clone();
+  const p1 = base.clone().addScaledVector(dir, largo * 0.5).add(lat.clone().multiplyScalar(0.5)).add(arriba.clone().multiplyScalar(0.25));
+  const p2 = base.clone().addScaledVector(dir, largo).add(lat).add(arriba);
+  const curva = new THREE.CatmullRomCurve3([p0, p1, p2]);
+
+  ramas.push({ curva, r0: radio, r1: radio * cfg.taper, nivel });
+
+  const dirPunta = new THREE.Vector3().subVectors(p2, p1).normalize();
+
+  if (nivel >= cfg.niveles) {
+    puntas.push({ pos: p2, dir: dirPunta, nivel });
+    return;
+  }
+
+  // Hijas: menos y más cortas a cada nivel. `hijos` puede ser fraccional por
+  // tier → se redondea con el rng (así 2.4 da a veces 2 y a veces 3).
+  const nf = cfg.hijos[Math.min(nivel, cfg.hijos.length - 1)];
+  const n = Math.max(1, Math.floor(nf) + (r() < nf % 1 ? 1 : 0));
+  const az0 = r() * Math.PI * 2;
+  const eje = perpendicular(dirPunta);
+
+  for (let i = 0; i < n; i++) {
+    const az = az0 + (i / n) * Math.PI * 2 + (r() - 0.5) * 0.7;
+    const div = cfg.divergencia * (0.65 + r() * 0.7);
+    const d = dirPunta
+      .clone()
+      .applyAxisAngle(eje, div)
+      .applyAxisAngle(dirPunta, az)
+      .normalize();
+    // punto de salida: reparte las hijas por el tramo alto de la madre (no todas
+    // del mismo nudo: eso es lo que delata al árbol procedural)
+    const donde = lerp(cfg.saleDesde, 1, r());
+    const salida = curva.getPointAt(clamp(donde, 0, 1));
+    crecer({
+      base: salida,
+      dir: d,
+      largo: largo * cfg.acorta * (0.8 + r() * 0.4),
+      radio: radio * cfg.taper * (0.72 + r() * 0.2),
+      nivel: nivel + 1,
+      cfg,
+      r,
+      ramas,
+      puntas,
+    });
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/*  R1 · Follaje: cluster en la PUNTA de rama, con sombreado horneado          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Un cluster de follaje: poliedro bajo, achatado y deformado (nunca una esfera
+ * limpia). Se hornea aquí todo el R1.
+ *
+ * @param {object} arg
+ * @param {THREE.Vector3} arg.centro     posición del cluster.
+ * @param {number} arg.radio
+ * @param {THREE.Vector3} arg.centroCopa centroide de la copa (para el AO).
+ * @param {number} arg.radioCopa
+ * @param {number} arg.yMin @param {number} arg.yMax  extremos de la copa (gradiente).
+ * @param {object} arg.pal  paleta de la especie.
+ * @param {Function} arg.r
+ * @param {boolean} arg.sss  hornear translucidez direccional (solo si el árbol
+ *   no va a girar; ver §ROTACIÓN Y LUZ HORNEADA).
+ */
+function clusterFollaje({ centro, radio, centroCopa, radioCopa, yMin, yMax, pal, r, sss }) {
+  const geo = new THREE.IcosahedronGeometry(radio, 0);
+  // Deformar: que no quede ni una esfera ni dos clusters iguales.
+  const pos = geo.getAttribute('position');
+  const v = new THREE.Vector3();
+  const kx = 0.75 + r() * 0.55;
+  const ky = 0.5 + r() * 0.34; // achatado: las copas no son bolas
+  const kz = 0.75 + r() * 0.55;
+  const f1 = r() * 6.283;
+  const f2 = r() * 6.283;
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i);
+    const bulto = 1 + Math.sin(v.x * 5.5 + f1) * 0.14 + Math.sin(v.y * 6.1 + f2) * 0.12;
+    pos.setXYZ(i, v.x * kx * bulto, v.y * ky * bulto, v.z * kz * bulto);
+  }
+  geo.computeVertexNormals();
+  geo.translate(centro.x, centro.y, centro.z);
+
+  // Qué tan HONDO está el cluster en la copa (0 = al borde, 1 = en el corazón).
+  const dCentro = new THREE.Vector3().subVectors(centro, centroCopa).length();
+  const profundidad = 1 - clamp(dCentro / Math.max(0.001, radioCopa), 0, 1);
+  const expuesto = 1 - profundidad;
+
+  const cBase = new THREE.Color(pal.hoja);
+  const cClara = new THREE.Color(pal.hojaClara);
+  const cLuz = new THREE.Color(pal.contraluz);
+  const tono = r(); // variación por cluster (R3)
+  const tmp = new THREE.Color();
+
+  return pintarPorVertice(geo, (p, n) => {
+    tmp.copy(cBase).lerp(cClara, tono * 0.55);
+
+    // ── AO horneado: el corazón de la copa no ve el cielo ──
+    let ao = lerp(1, 0.62, profundidad);
+    // …y las caras que miran hacia abajo, tampoco (el cielo viene de arriba)
+    ao *= lerp(0.74, 1.08, n.y * 0.5 + 0.5);
+
+    // ── Gradiente de altura: la copa se enciende hacia arriba ──
+    const yf = clamp((p.y - yMin) / Math.max(0.001, yMax - yMin), 0, 1);
+    ao *= lerp(0.84, 1.12, yf);
+
+    tmp.multiplyScalar(clamp(ao, 0.4, 1.2));
+
+    // ── Translucidez a contraluz (R1, el mayor retorno) ──
+    // El Lambert va a apagar esta cara porque mira EN CONTRA del sol; al subirle
+    // el albedo hacia un verde-oro, la hoja queda encendida por dentro en vez de
+    // apagada. Solo en el follaje expuesto: la hoja honda no tiene luz que pasar.
+    if (sss) {
+      const contra = clamp(-n.dot(SOL), 0, 1);
+      const glow = Math.pow(contra, 2.2) * expuesto * 0.85;
+      if (glow > 0.001) tmp.lerp(cLuz, glow);
+    }
+    return tmp;
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Firmas de especie                                                          */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Cada especie es una RECETA de ramificación + paleta. Los números salen de la
+ * silueta real del árbol, no de "lo que se ve bonito":
+ *
+ *   niveles      profundidad de ramificación (más = copa más fina)
+ *   hijos[]      ramas hijas por nivel
+ *   divergencia  ángulo con que la hija se abre de la madre (rad)
+ *   acorta       cuánto más corta es la hija (0..1)
+ *   taper        cuánto adelgaza cada rama
+ *   curvatura    serpenteo lateral (queñua alto = retorcida)
+ *   subeALaLuz   la punta busca el cielo (+) o cuelga (−)
+ *   saleDesde    desde qué fracción de la madre salen las hijas
+ *   troncos      tallos desde el pie (queñua multitallo)
+ *   inclina      el árbol entero ladeado (viento del páramo)
+ */
+export const ESPECIES = {
+  /* QUEÑUA (Polylepis) — el límite arbóreo más alto del mundo. Multitallo,
+     RETORCIDA, y su firma es la corteza cobriza que se descama en láminas de
+     papel: eso es GEOMETRÍA (láminas), no un color rojizo. Copa compacta y
+     menuda (hoja diminuta) — y baja: aquí arriba nada crece derecho. */
+  quenua: {
+    nombre: 'Queñua',
+    cientifico: 'Polylepis quadrijuga',
+    rasgo: 'el bosque más alto del mundo: corteza de papel y tronco retorcido',
+    piso: 'paramo',
+    alto: 1.55,
+    troncos: 3,
+    inclina: 0.14,
+    niveles: 3,
+    hijos: [2.6, 2.4, 2.2],
+    divergencia: 0.72,
+    acorta: 0.62,
+    taper: 0.62,
+    curvatura: 0.62, // la más retorcida del catálogo
+    subeALaLuz: 0.24,
+    saleDesde: 0.42,
+    radioBase: 0.052,
+    follaje: { radio: 0.2, porPunta: 1.5 },
+    laminas: true, // corteza que se descama (firma)
+    pal: {
+      corteza: '#8f4526',
+      cortezaClara: '#d08046',
+      lamina: '#e0996a', // la lámina que se levanta, iluminada por dentro
+      hoja: '#4d6b41',
+      hojaClara: '#8ba470',
+      contraluz: '#cfd98a',
+    },
+  },
+
+  /* ROBLE ANDINO (Quercus humboldtii) — el único roble nativo de Colombia. El
+     gran árbol de la tierra fría: tronco grueso, ramas primarias que salen BAJO
+     y se abren horizontales, copa ancha y pesada que se extiende más que sube. */
+  roble: {
+    nombre: 'Roble andino',
+    cientifico: 'Quercus humboldtii',
+    rasgo: 'el gran árbol de la tierra fría: copa ancha, madera lenta',
+    piso: 'frio',
+    alto: 2.7,
+    troncos: 1,
+    inclina: 0.02,
+    niveles: 4,
+    hijos: [3.4, 2.6, 2.3, 2],
+    divergencia: 0.82, // se abre mucho: la copa manda a lo ancho
+    acorta: 0.7,
+    taper: 0.68,
+    curvatura: 0.3,
+    subeALaLuz: 0.16,
+    saleDesde: 0.3, // ramas primarias bajas (firma del roble)
+    radioBase: 0.13,
+    follaje: { radio: 0.3, porPunta: 1.7 },
+    laminas: false,
+    pal: {
+      corteza: '#5c4b3c',
+      cortezaClara: '#8a7660',
+      hoja: '#436636',
+      hojaClara: '#75974c',
+      contraluz: '#b9cc5f',
+    },
+  },
+
+  /* GUAYACÁN AMARILLO (Handroanthus chrysanthus) — florece PELADO: se le cae
+     toda la hoja y estalla en oro. Es el árbol donde la jerarquía de ramas queda
+     a la vista, así que el ramaje tiene que aguantar el primer plano. */
+  guayacan: {
+    nombre: 'Guayacán amarillo',
+    cientifico: 'Handroanthus chrysanthus',
+    rasgo: 'florece de oro, sin una sola hoja',
+    piso: 'templado',
+    alto: 2.3,
+    troncos: 1,
+    inclina: 0.03,
+    niveles: 4,
+    hijos: [3, 2.6, 2.4, 2.2],
+    divergencia: 0.6,
+    acorta: 0.66,
+    taper: 0.66,
+    curvatura: 0.34,
+    subeALaLuz: 0.3, // ramaje ascendente, en copa de vaso
+    saleDesde: 0.44,
+    radioBase: 0.1,
+    follaje: { radio: 0.2, porPunta: 2.2 }, // racimos de FLOR, no hojas
+    laminas: false,
+    floracion: true,
+    pal: {
+      corteza: '#6b6152',
+      cortezaClara: '#988a72',
+      hoja: '#e8b32a',
+      hojaClara: '#ffd85e',
+      contraluz: '#fff0a8', // la flor a contraluz es casi blanca
+    },
+  },
+
+  /* CEIBA (Ceiba pentandra) — la emergente: rompe el dosel y se abre en
+     PARASOL sobre el bosque. Firma doble: raíces tablares (contrafuertes) y esa
+     copa plana y altísima. Tronco verdoso-gris, casi liso. */
+  ceiba: {
+    nombre: 'Ceiba',
+    cientifico: 'Ceiba pentandra',
+    rasgo: 'raíces tablares y una copa que emerge sobre todo el bosque',
+    piso: 'calido',
+    alto: 3.2,
+    troncos: 1,
+    inclina: 0,
+    niveles: 4,
+    hijos: [4, 2.8, 2.4, 2.2],
+    divergencia: 0.86, // muy abierta: el parasol
+    acorta: 0.74,
+    taper: 0.72,
+    curvatura: 0.26,
+    subeALaLuz: -0.04, // la copa se APLANA, no sube
+    saleDesde: 0.82, // todo el ramaje arriba: debajo, tronco limpio
+    radioBase: 0.16,
+    tablares: 5,
+    follaje: { radio: 0.52, porPunta: 1.2 }, // pocos y grandes: dosel, no confeti
+    laminas: false,
+    pal: {
+      corteza: '#7c8368',
+      cortezaClara: '#a3a985',
+      hoja: '#5a8a48',
+      hojaClara: '#82ad5f',
+      contraluz: '#c8dd72',
+    },
+  },
+};
+
+/** El árbol de un piso térmico (o null: superpáramo y nival no tienen árbol). */
+export function arbolDePiso(pisoId) {
+  return Object.values(ESPECIES).find((e) => e.piso === pisoId) || null;
+}
+/** La clave de catálogo del árbol de un piso ('quenua' | 'roble' | …). */
+export function tipoDePiso(pisoId) {
+  return Object.keys(ESPECIES).find((k) => ESPECIES[k].piso === pisoId) || null;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Piezas de firma                                                            */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * LÁMINAS de la queñua: su corteza se descama en hojas de papel que se levantan
+ * del tronco. El DR es explícito: la clave es la GEOMETRÍA de las láminas que se
+ * desprenden, no el color. Son cascarones curvos, pegados y despegándose.
+ */
+function laminasCorteza(curva, cfg, r, q) {
+  const n = Math.max(3, Math.round(9 * q));
+  const partes = [];
+  const cLam = new THREE.Color(cfg.pal.lamina);
+  const cOsc = new THREE.Color(cfg.pal.corteza);
+  const tmp = new THREE.Color();
+  const p = new THREE.Vector3();
+  const frames = curva.computeFrenetFrames(16, false);
+
+  for (let i = 0; i < n; i++) {
+    const t = 0.1 + r() * 0.75;
+    curva.getPointAt(t, p);
+    const fi = Math.min(15, Math.round(t * 16));
+    const N = frames.normals[fi];
+    const B = frames.binormals[fi];
+    const a = r() * Math.PI * 2;
+    const rad = cfg.radioBase * lerp(1, cfg.taper, t) * 1.02;
+
+    // cascarón: un trozo de cilindro que se abre del tronco
+    const alto = 0.1 + r() * 0.16;
+    const arco = 0.7 + r() * 0.8;
+    const lam = new THREE.CylinderGeometry(rad, rad * 1.16, alto, 4, 1, true, a, arco);
+    // se despega: la lámina se aleja del eje y se ladea
+    const despegue = 0.006 + r() * 0.02;
+    lam.translate(Math.cos(a + arco / 2) * despegue, 0, Math.sin(a + arco / 2) * despegue);
+    lam.rotateX((r() - 0.5) * 0.5);
+
+    const m = new THREE.Matrix4().makeBasis(N, new THREE.Vector3().crossVectors(N, B), B);
+    lam.applyMatrix4(m);
+    lam.translate(p.x, p.y, p.z);
+
+    // la lámina levantada se enciende por el borde (papel a contraluz)
+    const brillo = 0.55 + r() * 0.45;
+    partes.push(
+      pintarPorVertice(lam, (_, nn) => {
+        const contra = clamp(-nn.dot(SOL), 0, 1);
+        tmp.copy(cOsc).lerp(cLam, brillo);
+        tmp.lerp(new THREE.Color(cfg.pal.lamina), Math.pow(contra, 2) * 0.5);
+        return tmp;
+      }),
+    );
+  }
+  return partes;
+}
+
+/*
+ * RAÍCES TABLARES de la ceiba: contrafuertes que salen del pie como aletas y
+ * agarran la tierra. Sin ellas, la ceiba es un palo cualquiera.
+ */
+function raicesTablares(cfg, r) {
+  const n = cfg.tablares || 0;
+  const partes = [];
+  const cBase = new THREE.Color(cfg.pal.corteza);
+  const cClara = new THREE.Color(cfg.pal.cortezaClara);
+  const tmp = new THREE.Color();
+
+  for (let i = 0; i < n; i++) {
+    const a = (i / n) * Math.PI * 2 + r() * 0.4;
+    const largo = cfg.alto * (0.16 + r() * 0.07);
+    const altoAleta = cfg.alto * (0.2 + r() * 0.1);
+
+    // Perfil de aleta: sube pegada al tronco y baja en curva hasta el suelo.
+    const forma = new THREE.Shape();
+    forma.moveTo(0, 0);
+    forma.lineTo(0, altoAleta);
+    forma.quadraticCurveTo(largo * 0.5, altoAleta * 0.22, largo, 0);
+    forma.lineTo(0, 0);
+    const geo = new THREE.ExtrudeGeometry(forma, {
+      depth: cfg.radioBase * 0.5,
+      bevelEnabled: false,
+    });
+    geo.translate(0, 0, -cfg.radioBase * 0.25);
+    geo.rotateY(-a);
+    geo.translate(Math.cos(a) * cfg.radioBase * 0.6, 0, Math.sin(a) * cfg.radioBase * 0.6);
+
+    partes.push(
+      pintarPorVertice(geo, (p) => {
+        // el pie de la aleta se hunde en sombra: oclusión de contacto
+        const alto = clamp(p.y / Math.max(0.001, altoAleta), 0, 1);
+        tmp.copy(cBase).lerp(cClara, alto * 0.5);
+        tmp.multiplyScalar(lerp(0.55, 1, smoothstep(0, 0.5, alto)));
+        return tmp;
+      }),
+    );
+  }
+  return partes;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  El árbol completo                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Construye UN árbol fusionado, con el sombreado ya horneado.
+ *
+ * @param {string} tipo  clave de ESPECIES ('quenua'|'roble'|'guayacan'|'ceiba').
+ * @param {object} [opts]
+ * @param {number} [opts.q=1]         calidad geométrica (calidadDeTier).
+ * @param {number} [opts.variante=0]  MISMA especie, OTRO árbol (R3).
+ * @param {boolean} [opts.sss=true]   hornear contraluz (ver §ROTACIÓN).
+ * @returns {THREE.BufferGeometry} fusionada, con `color` horneado.
+ */
+export function geomArbol(tipo, { q = 1, variante = 0, sss = true } = {}) {
+  const cfg = ESPECIES[tipo];
+  if (!cfg) throw new Error(`[arbolMayor.geom] especie desconocida: ${tipo}`);
+
+  const r = rng((tipo.length * 977 + variante * 7919 + 13) >>> 0);
+  const partes = [];
+  const ramas = [];
+  const puntas = [];
+
+  // ── Estructura: uno o varios tallos desde el pie ──
+  const nTroncos = cfg.troncos;
+  for (let ti = 0; ti < nTroncos; ti++) {
+    const a = (ti / nTroncos) * Math.PI * 2 + r() * 0.8;
+    const off = nTroncos > 1 ? cfg.radioBase * (1.1 + r() * 1.5) : 0;
+    const base = new THREE.Vector3(Math.cos(a) * off, 0, Math.sin(a) * off);
+    // los multitallo se abren en abanico desde el pie
+    const abre = nTroncos > 1 ? 0.1 + r() * 0.16 : 0;
+    const dir = new THREE.Vector3(Math.cos(a) * abre, 1, Math.sin(a) * abre).normalize();
+    // + la inclinación del árbol entero (viento)
+    if (cfg.inclina) dir.x += cfg.inclina * (0.6 + r() * 0.8);
+    dir.normalize();
+
+    crecer({
+      base,
+      dir,
+      largo: cfg.alto * (nTroncos > 1 ? 0.46 + r() * 0.2 : 0.56),
+      radio: cfg.radioBase * (nTroncos > 1 ? 0.66 + r() * 0.24 : 1),
+      nivel: 0,
+      cfg,
+      r,
+      ramas,
+      puntas,
+    });
+  }
+
+  // ── Leño: cada rama, un tubo ahusado con corteza horneada ──
+  // Detalle por nivel y por tier: el tronco se ve, las ramitas no.
+  for (const rama of ramas) {
+    const finura = 1 - rama.nivel / (cfg.niveles + 1);
+    const segs = Math.max(2, Math.round(lerp(2, 7, finura) * clamp(q, 0.4, 1)));
+    const radial = Math.max(3, Math.round(lerp(3, 8, finura) * clamp(q, 0.5, 1)));
+    const rugosidad = rama.nivel === 0 ? 0.1 : 0.05;
+    const geo = tuboAhusado(
+      rama.curva,
+      segs,
+      radial,
+      (t) => lerp(rama.r0, rama.r1, Math.pow(t, 0.8)),
+      rugosidad,
+      r() * 6.283,
+    );
+    partes.push(hornearCorteza(geo, cfg.pal.corteza, cfg.pal.cortezaClara, r));
+  }
+
+  // ── Firmas de especie ──
+  if (cfg.laminas) {
+    // las láminas van en los tallos (nivel 0), que es donde se ven
+    for (const rama of ramas.filter((x) => x.nivel === 0)) {
+      partes.push(...laminasCorteza(rama.curva, cfg, r, q));
+    }
+  }
+  if (cfg.tablares) partes.push(...raicesTablares(cfg, r));
+
+  // ── Follaje en las puntas (de aquí sale la silueta y los huecos) ──
+  const caja = new THREE.Box3();
+  const pts = puntas.map((p) => p.pos);
+  if (pts.length) caja.setFromPoints(pts);
+  const centroCopa = new THREE.Vector3();
+  caja.getCenter(centroCopa);
+  const radioCopa = Math.max(0.001, caja.getSize(new THREE.Vector3()).length() * 0.5);
+  const yMin = caja.min.y;
+  const yMax = caja.max.y;
+
+  const porPunta = cfg.follaje.porPunta;
+  for (const punta of puntas) {
+    const n = Math.max(1, Math.round(porPunta * clamp(q, 0.45, 1)));
+    for (let i = 0; i < n; i++) {
+      // el cluster se corre un poco hacia afuera de la punta: el follaje ENVUELVE
+      // el final de la ramita, no se posa encima como un sombrero
+      const jit = new THREE.Vector3(
+        (r() - 0.5) * cfg.follaje.radio * 1.5,
+        (r() - 0.5) * cfg.follaje.radio * 1.1,
+        (r() - 0.5) * cfg.follaje.radio * 1.5,
+      );
+      const centro = punta.pos
+        .clone()
+        .addScaledVector(punta.dir, cfg.follaje.radio * 0.35)
+        .add(jit);
+      const radio = cfg.follaje.radio * (0.62 + r() * 0.62);
+      partes.push(
+        clusterFollaje({
+          centro,
+          radio,
+          centroCopa,
+          radioCopa,
+          yMin,
+          yMax,
+          pal: cfg.pal,
+          r,
+          sss,
+        }),
+      );
+    }
+  }
+
+  const geo = fusionar(partes, `${tipo}#${variante}`);
+  geo.computeVertexNormals();
+  geo.computeBoundingSphere();
+  return geo;
+}
+
+/**
+ * Cuántas VARIANTES distintas de una especie conviene generar por tier. Cada
+ * variante es una draw-call más, y el retorno cae rápido: 3 ya rompen el patrón.
+ */
+export const VARIANTES_TIER = { alto: 3, medio: 2, bajo: 1 };
+export const variantesDeTier = (tier) => VARIANTES_TIER[tier] ?? VARIANTES_TIER.medio;

--- a/src/visual/mundo3d/sierra/bosqueSierra.js
+++ b/src/visual/mundo3d/sierra/bosqueSierra.js
@@ -1,0 +1,239 @@
+/*
+ * bosqueSierra — la DISPOSICIÓN del bosque sobre la ladera. Datos puros: cero
+ * three, cero React. Decide DÓNDE va cada árbol; la geometría la pone
+ * `arbolMayor.geom.js` y el montaje `GaleriaSierraArboles.jsx`.
+ *
+ * ── POR QUÉ EXISTE ──────────────────────────────────────────────────────────
+ * El veredicto del operador señaló "la disposición" con nombre propio. Y tenía
+ * razón: la ladera era un monte PELADO con cuatro árboles gigantes en fila, uno
+ * por piso, repartidos a intervalos parejos de X. Nada de eso existe en la
+ * naturaleza, y el ojo lo cachó al instante: sin bosque alrededor no hay ESCALA
+ * —un árbol solo en una loma lisa se lee como un juguete sobre una mesa— y una
+ * fila regular se lee como una grilla, que es lo contrario de un monte.
+ *
+ * ── LA REGLA (el DR de realismo, §disposición biogeográfica) ────────────────
+ * "Los árboles no crecen en una cuadrícula": agrupamiento, claros, sotobosque,
+ * borde, y densidad mandada por ruido. Aquí eso se aterriza así:
+ *
+ *   1. BANDA DE ALTITUD, no de X. Cada especie vive en su franja de altura real
+ *      (su piso térmico) y se siembra por RECHAZO: se propone un punto y se
+ *      acepta solo si la altura del terreno ahí cae en su banda. Como la ladera
+ *      tiene relieve, el bosque se acomoda solo siguiendo las curvas de nivel:
+ *      sube por las vaguadas, se corta en los filos. Nadie dibujó ese contorno —
+ *      sale de cruzar la banda con el terreno, que es como pasa de verdad.
+ *   2. RODALES, no reparto parejo. Los árboles nacen en GRUPOS alrededor de unos
+ *      pocos centros, con caída gaussiana. Entre rodal y rodal queda monte
+ *      abierto.
+ *   3. LÍNEA ARBÓREA. Por encima del páramo NO hay árboles: superpáramo y nival
+ *      van pelados. La queñua (Polylepis) es el último árbol y por eso marca el
+ *      filo del bosque — es literalmente el bosque más alto del mundo.
+ *   4. CLAROS. Cada héroe se para en su propio claro: el bosque lo rodea pero no
+ *      se le encima, así sigue siendo el hito que se toca para entrar.
+ *   5. BORDE. Los árboles del filo de la banda salen más chicos (achaparrados por
+ *      el viento y el frío), como en un ecotono real.
+ *
+ * Todo determinista (rng de semilla): el mismo bosque en todos los equipos, y
+ * cachea limpio en el service worker.
+ */
+import { rng, ESPECIES, JITTER_GIRO } from './arbolMayor.geom.js';
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const lerp = (a, b, t) => a + (b - a) * t;
+
+/*
+ * La franja de altitud de cada especie, en FRACCIÓN de la altura del monte
+ * (0 = orilla del mar, 1 = cumbre). Coinciden con las bandas de color del
+ * terreno: el bosque y el piso térmico cuentan la misma historia.
+ *
+ * `sube` es cuánto trepa la banda con el clima (0=hoy … 1=2050): el mismo
+ * corrimiento que ya aplica el monte a su color. El bosque MIGRA con su piso.
+ */
+export const BANDAS_BOSQUE = {
+  ceiba: { min: 0.015, max: 0.15, sube: 1.0 },
+  guayacan: { min: 0.13, max: 0.33, sube: 1.05 },
+  roble: { min: 0.31, max: 0.53, sube: 1.2 },
+  quenua: { min: 0.5, max: 0.7, sube: 1.0 }, // el último bosque: arriba, nada
+};
+
+/** El corrimiento máximo de las bandas con el clima (mismo número que el monte). */
+export const SUBIDA_MAX = 0.14;
+
+/** La banda de una especie ya desplazada por el clima `d` (0=hoy, 1=2050). */
+export function bandaConClima(especie, d = 0) {
+  const b = BANDAS_BOSQUE[especie];
+  if (!b) return null;
+  const off = d * SUBIDA_MAX * b.sube;
+  return { min: clamp(b.min + off, 0, 0.95), max: clamp(b.max + off, 0, 0.96) };
+}
+
+/*
+ * Cuántos árboles de relleno por especie y tier. NO son draw-calls: cada especie
+ * (por variante) es UN InstancedMesh. Son instancias, que cuestan triángulos.
+ * 'bajo' guarda lo justo para que la ladera no se lea pelada.
+ */
+export const BOSQUE_TIER = {
+  alto: { ceiba: 16, guayacan: 26, roble: 40, quenua: 32 },
+  medio: { ceiba: 8, guayacan: 12, roble: 20, quenua: 15 },
+  bajo: { ceiba: 3, guayacan: 5, roble: 8, quenua: 6 },
+};
+export const bosqueDeTier = (tier) => BOSQUE_TIER[tier] || BOSQUE_TIER.medio;
+
+/**
+ * Siembra los árboles de UNA especie por rechazo dentro de su banda de altitud.
+ *
+ * @param {object} arg
+ * @param {string} arg.especie          clave de ESPECIES.
+ * @param {number} arg.cuantos
+ * @param {(x:number,z:number)=>number} arg.altura  altura del terreno en mundo.
+ * @param {number} arg.cima             altura de referencia (para la fracción).
+ * @param {{x0:number,x1:number,z0:number,z1:number}} arg.area  dónde se puede sembrar.
+ * @param {Array<{x:number,z:number,r:number}>} [arg.claros]  zonas prohibidas.
+ * @param {number} [arg.d]              clima 0..1.
+ * @param {number} [arg.seed]
+ * @param {number} [arg.variantes]      cuántas variantes de geometría repartir.
+ * @returns {Array<{pos:[number,number,number], giroY:number, escala:number, tint:[number,number,number], variante:number}>}
+ */
+export function sembrarEspecie({
+  especie,
+  cuantos,
+  altura,
+  cima,
+  area,
+  claros = [],
+  d = 0,
+  seed = 1,
+  variantes = 3,
+}) {
+  const banda = bandaConClima(especie, d);
+  if (!banda || cuantos <= 0) return [];
+  const r = rng(seed);
+  const out = [];
+
+  // ── 1) Centros de RODAL: pocos, dentro de la banda. El bosque nace en grupos. ──
+  const nGrupos = Math.max(2, Math.round(cuantos / 5));
+  const grupos = [];
+  let intentos = 0;
+  while (grupos.length < nGrupos && intentos < 900) {
+    intentos++;
+    const x = lerp(area.x0, area.x1, r());
+    const z = lerp(area.z0, area.z1, r());
+    const yf = altura(x, z) / cima;
+    if (yf < banda.min || yf > banda.max) continue;
+    grupos.push({ x, z, radio: 1.1 + r() * 2.2 });
+  }
+  if (!grupos.length) return [];
+
+  // ── 2) Árboles alrededor de los rodales, por rechazo contra la banda ──
+  intentos = 0;
+  const tope = cuantos * 90;
+  while (out.length < cuantos && intentos < tope) {
+    intentos++;
+    const g = grupos[Math.floor(r() * grupos.length) % grupos.length];
+    // caída hacia el borde del rodal (√ = uniforme en el disco; sin √ = apretado
+    // al centro, que es lo que hace un rodal de verdad)
+    const ang = r() * Math.PI * 2;
+    const rad = g.radio * r() * r() * 1.6;
+    const x = g.x + Math.cos(ang) * rad;
+    const z = g.z + Math.sin(ang) * rad;
+    if (x < area.x0 || x > area.x1 || z < area.z0 || z > area.z1) continue;
+
+    const y = altura(x, z);
+    const yf = y / cima;
+    // la banda manda: aquí es donde el bosque agarra la curva de nivel
+    if (yf < banda.min || yf > banda.max) continue;
+
+    // los claros de los héroes no se invaden
+    let enClaro = false;
+    for (const c of claros) {
+      const dx = x - c.x, dz = z - c.z;
+      if (dx * dx + dz * dz < c.r * c.r) { enClaro = true; break; }
+    }
+    if (enClaro) continue;
+
+    // no se pisan entre ellos
+    let choca = false;
+    for (const o of out) {
+      const dx = x - o.pos[0], dz = z - o.pos[2];
+      if (dx * dx + dz * dz < 0.34) { choca = true; break; }
+    }
+    if (choca) continue;
+
+    // ── 3) BORDE: al filo de su banda el árbol sale achaparrado (ecotono real) ──
+    const centro = (banda.min + banda.max) / 2;
+    const mitad = Math.max(0.001, (banda.max - banda.min) / 2);
+    const alFilo = clamp(Math.abs(yf - centro) / mitad, 0, 1);
+    const vigor = lerp(1, 0.62, alFilo * alFilo);
+
+    out.push({
+      pos: /** @type {[number, number, number]} */ ([x, y, z]),
+      // giro CHICO a propósito: la luz va horneada y un giro grande la haría
+      // mentir (ver §ROTACIÓN en arbolMayor.geom.js). La variedad la dan las
+      // variantes de geometría, no el giro.
+      giroY: (r() - 0.5) * 2 * JITTER_GIRO,
+      // Escala CHICA a propósito: son el bosque de fondo, no el hito. El héroe
+      // de cada piso mide 2-3x esto — la proporción de un emergente viejo sobre
+      // el dosel, que es justo lo que se ve en un bosque real. Con la escala
+      // grande, el bosque se comía la montaña y al héroe.
+      escala: vigor * (0.26 + r() * 0.2),
+      tint: tinte(r),
+      variante: Math.floor(r() * variantes) % variantes,
+    });
+  }
+  return out;
+}
+
+/**
+ * Variación de color por instancia (R3 del DR): que no haya dos árboles iguales.
+ * @returns {[number, number, number]}
+ */
+function tinte(r) {
+  const f = 0.9 + r() * 0.2; // claro/oscuro
+  const verde = 1 + (r() - 0.5) * 0.1; // más o menos verde
+  const cl = (v) => clamp(v, 0.72, 1.15);
+  return [cl(f), cl(f * verde), cl(f * (1 - (verde - 1) * 0.5))];
+}
+
+/**
+ * Todo el bosque de relleno de la ladera.
+ *
+ * @param {object} arg
+ * @param {(x:number,z:number)=>number} arg.altura
+ * @param {number} arg.cima
+ * @param {{x0:number,x1:number,z0:number,z1:number}} arg.area
+ * @param {object} arg.conteos          bosqueDeTier(tier).
+ * @param {Array<{x:number,z:number,r:number}>} arg.claros
+ * @param {number} [arg.d=0]            clima.
+ * @param {number} [arg.variantes=3]
+ * @param {number} [arg.seed=4242]
+ * @returns {Record<string, Array>} instancias por especie.
+ */
+export function distribucionBosque({
+  altura,
+  cima,
+  area,
+  conteos,
+  claros = [],
+  d = 0,
+  variantes = 3,
+  seed = 4242,
+}) {
+  /** @type {Record<string, any[]>} */
+  const out = {};
+  let i = 0;
+  for (const especie of Object.keys(BANDAS_BOSQUE)) {
+    if (!ESPECIES[especie]) continue;
+    i++;
+    out[especie] = sembrarEspecie({
+      especie,
+      cuantos: conteos[especie] || 0,
+      altura,
+      cima,
+      area,
+      claros,
+      d,
+      variantes,
+      seed: seed + i * 131,
+    });
+  }
+  return out;
+}

--- a/src/visual/mundo3d/sierra/cacheArboles.js
+++ b/src/visual/mundo3d/sierra/cacheArboles.js
@@ -1,0 +1,48 @@
+/*
+ * cacheArboles — la CACHÉ de geometrías de árbol, compartida por toda la escena.
+ *
+ * Vive en su propio módulo, y no dentro de `ArbolMayor.jsx`, por dos razones:
+ *   · Fast Refresh: un archivo de componente que además exporta funciones pierde
+ *     el refresco en caliente (regla `react-refresh/only-export-components`).
+ *   · Es un recurso de ESCENA, no de componente: los cuatro héroes, sus
+ *     acompañantes y los ~100 árboles del bosque comparten las mismas mallas.
+ *
+ * Construir un árbol cuesta (ramifica, hornea AO/contraluz, fusiona). Como
+ * `geomArbol` es determinista —misma clave, misma malla—, se puede cachear sin
+ * miedo y compartir la MISMA instancia de geometría entre meshes.
+ *
+ * ⚠️ Justo porque se comparte, ningún componente puede hacerle `dispose()` al
+ * desmontarse: le arrancaría la malla de las manos a otro que sigue vivo. Se
+ * libera todo junto con `limpiarCacheArboles()`, y eso lo llama quien desmonta
+ * la ESCENA entera.
+ */
+import { geomArbol } from './arbolMayor.geom.js';
+
+/** @type {Map<string, import('three').BufferGeometry>} */
+const cache = new Map();
+
+/**
+ * Geometría de un árbol, cacheada. Determinista: misma clave → misma malla.
+ *
+ * @param {string} tipo  clave de ESPECIES ('quenua'|'roble'|'guayacan'|'ceiba').
+ * @param {object} [opts] `{ q, variante, sss }` (ver arbolMayor.geom.js).
+ * @returns {import('three').BufferGeometry}
+ */
+export function geomCacheada(tipo, { q = 1, variante = 0, sss = true } = {}) {
+  const clave = `${tipo}|${q}|${variante}|${sss ? 1 : 0}`;
+  let geo = cache.get(clave);
+  if (!geo) {
+    geo = geomArbol(tipo, { q, variante, sss });
+    cache.set(clave, geo);
+  }
+  return geo;
+}
+
+/** Libera las geometrías compartidas. La llama quien desmonta la ESCENA entera. */
+export function limpiarCacheArboles() {
+  for (const geo of cache.values()) geo.dispose();
+  cache.clear();
+}
+
+/** Cuántas mallas hay cacheadas (para pruebas y diagnóstico). */
+export const tamanoCacheArboles = () => cache.size;


### PR DESCRIPTION
## El veredicto

> *"Tiene intenciones muy lindas pero se queda en eso... Parece más una **caricatura mal hecha** que un mundo 3D realista. Hazlo que de verdad parezca real. Los **árboles feos**, cómo se ve todo, **la disposición**."*

Los tres puntos, uno por uno. No era un bug: era nivel de acabado.

## Qué estaba mal (verificado, no supuesto)

La captura del *antes* muestra el diagnóstico exacto que hace el DR de realismo:

- **Los árboles eran hexágonos flotando sobre palos.** La copa era un puñado de icosaedros sueltos repartidos en un elipsoide: el "árbol de navidad" de manual. Sin ramas, sin huecos, sin silueta.
- **El tronco nunca se ahusó.** `ArbolMayor.jsx` tenía literalmente el comentario `// ahusar: estrechar el radio hacia la punta` seguido de `return geo`. El ahusado se documentó y no se implementó: todas las ramas eran tubos de radio constante.
- **La ladera estaba pelada** y los 4 héroes en fila, a intervalos parejos de X. Un árbol solo en una loma lisa se lee como un juguete sobre una mesa — no hay escala.
- **Un mesh y un material por cada blob de follaje** (decenas de draw-calls por árbol).

## Las recetas del DR que usé (en su orden de retorno visual por costo)

| | Receta | Cómo |
|---|---|---|
| **R1** | **Sombreado de follaje** — el DR dice que es *el* punto de mayor retorno | AO por vértice + gradiente de altura + **translucidez a contraluz**, todo horneado en `vertexColors` |
| **R2** | Silueta y jerarquía de ramas | Ramificación recursiva con conicidad real; **el follaje cuelga de las puntas de rama** |
| **R3** | Romper la simetría | Variantes de geometría por especie + variación de color por instancia |
| **R4** | Tronco sin textura | Conicidad + rugosidad de corteza en geometría, grietas horneadas |
| — | Disposición biogeográfica | Bandas de altitud + rodales + claros + línea arbórea |

### El hallazgo que hizo posible R1 sin shaders

El repo **no tiene un solo shader propio** (`grep onBeforeCompile|ShaderMaterial` → 0), y con razón: corre en Android barato y en una Quadro vieja. El DR pide translucidez a contraluz, que normalmente es shader.

Pero **el sol de esta escena es fijo** (hora dorada, `directionalLight` en `[-11, 8, 4]`). Si el sol no se mueve, la cara encendida de un árbol es siempre la misma → **la contraluz se puede hornear en el vértice**. Eso entrega la receta #1 del DR entera, en CPU, sin tocar el pipeline.

Con un cuidado que quedó documentado: **no se hornea la difusa** — la pone el Lambert con la luz real, y hornearla la contaría dos veces. Solo va lo que el Lambert no sabe hacer (oclusión, contraluz, gradiente, variación).

Corolario que también quedó escrito: **si una instancia gira en Y, la luz horneada gira con ella**. Por eso el giro por instancia está acotado a ±0.18 rad (`JITTER_GIRO`) y la variedad la dan las *variantes de geometría*, no el giro. El bosque de fondo usa `sss: false` directamente.

### Por qué el follaje va en las puntas de rama

Es el cambio que más se ve. Colgando el follaje de las puntas terminales, **la copa hereda la irregularidad del ramaje**: los huecos y la silueta salen solos, no hay que "hacerle huecos" a un elipsoide. Se ve cielo entre las hojas porque las ramas no llegan a todas partes — como en un árbol.

### La disposición

`bosqueSierra.js` siembra **por rechazo contra bandas de altitud**, no por X. Como la ladera tiene relieve, el bosque **sigue solo las curvas de nivel**: sube por las vaguadas, se corta en los filos. Nadie dibujó ese contorno.

Además: rodales en vez de reparto parejo · claros para que el héroe siga siendo el hito tocable · borde achaparrado (ecotono) · **línea arbórea real**: sobre el páramo no hay un solo árbol, y la queñua marca el filo — es literalmente el bosque más alto del mundo.

## Las especies, por su firma y no genéricas

- **Queñua** (*Polylepis*) — multitallo retorcida + **láminas de corteza que se descaman**. El DR es explícito: la clave es la *geometría* de las láminas, no el color rojizo.
- **Roble andino** (*Quercus humboldtii*) — ramas primarias bajas, copa que se extiende más de lo que sube.
- **Guayacán** (*Handroanthus chrysanthus*) — florece pelado. Es donde la jerarquía de ramas queda a la vista.
- **Ceiba** (*Ceiba pentandra*) — raíces tablares + parasol emergente.

## Rendimiento

Una geometría fusionada por especie×variante → un `InstancedMesh` → **una draw-call**. 2.8–5.0k triángulos por héroe en `alto` (dentro del presupuesto); el bosque usa calidad `bajo` como LOD — a esa distancia solo se lee la silueta y el detalle ahí es plata tirada. Caché de geometría compartida entre héroes y bosque.

## El `mergeGeometries` null volvió a morder

Y el guard hizo su trabajo: **tronó en vez de dibujar un árbol invisible**. La causa nueva: las primitivas de three traen `uv`, el tubo ahusado no → atributos disparejos → `null` silencioso. `fusionar()` ahora normaliza a `position/normal/color` y truena con el nombre de la especie. Cubierto por test.

## Verificación

- `npm run build:prod` verde · `tsc` **sin errores en `src/`** (los 21 restantes son de `node_modules`, preexistentes en dev) · **eslint limpio** · **49 tests headless**
- Los tests cubren lo que importa: fusión con atributos disparejos, conicidad real (la punta *es* más delgada que la base), AO/gradiente horneados, bandas de altitud, línea arbórea, claros respetados, y **"no es una grilla"** (dispersión de la distancia al vecino más cercano — en una grilla es constante).
- **Capturas antes/después en WebGL real** (chromium del sistema + swiftshader, sobre `build:prod`, ruta `#sierra_global`). Cero errores de consola.

## Notas para el revisor

- **Base `dev`**, no main: es donde vive el arte 3D (`main` no tiene ni el directorio `sierra/`).
- **Toqué dos cosas que no eran mías** porque bloqueaban el commit: `DerivaCamara` colgaba sus handlers como propiedades del objeto de controles que recibe *por prop* (mutación de un objeto ajeno) y la leyenda reasignaba un `let` durante el render. Ambos ya rompían eslint en `dev`; van corregidos sin cambiar comportamiento.
- El frailejonar ahora **reusa** `geomFrailejon` de `floraParamo.geom.js` (roseta plateada + enagua marcescente) en vez del palo con bolita que esta escena dibujaba a mano teniendo el bueno al lado.
- El cóndor medía **2.3 unidades** de punta a punta contra un roble de 2.7 — un pajarraco del tamaño de un árbol. La proporción real es ~1:7; ahora se lee por su silueta, que es como se reconoce un cóndor de verdad.

## Lo que NO alcancé (honesto)

La **composición general** mejoró pero no está resuelta: el macizo todavía se lee algo lavado detrás del bosque, y la cámara deja el pie del monte 2.4x más cerca que la cumbre, lo que aprieta el primer plano. Eso es trabajo de encuadre/atmósfera, de otra pasada — no quise tocar cámara y color de terreno en el mismo PR que la geometría.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
