### PR TITLE
Valle 3D: botones muertos revividos, cámara consciente del aspecto, el oso deja de ser secundario

### DIFF
--- a/index-prod.html
+++ b/index-prod.html
@@ -33,7 +33,14 @@
     <meta name="apple-mobile-web-app-title" content="Chagra" />
     <title>Chagra</title>
     <style>
-      html, body { background: #020617; margin: 0; }
+      /* La CADENA DE ALTURA del shell (bug del feedback 2026-07-14): los
+         mundos 3D piden height:100% y lo heredaban de NADA → #root colapsaba
+         y la escena quedaba aplastada en una franja (~18% del alto). Esto
+         explica el Ent "cortado y pequeñísimo" y el grafo "plano". */
+      html, body, #root { height: 100%; background: #020617; margin: 0; }
+      body { min-height: 100dvh; }
+      #root { display: flex; flex-direction: column; }
+      #root > * { flex: 1 1 auto; min-height: 0; }
       #pre-loader {
         position: fixed; inset: 0;
         display: flex; flex-direction: column;

--- a/src/components/VentanaValle3D.jsx
+++ b/src/components/VentanaValle3D.jsx
@@ -137,7 +137,9 @@ function EnredaderaMarco() {
  * @param {string}  [props.className]  clases extra del botón-ventana.
  */
 export function VentanaValle3D({
-  onEntrar,
+  // Sin host que decida (ruta `ventana_valle` de prod, montada sin props), la
+  // puerta lleva a su destino natural: el valle. Antes era un tap muerto.
+  onEntrar = () => { window.location.hash = ''; },
   tier: tierProp,
   reducedMotion: rmProp,
   titulo = 'Entrar al valle',

--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -60,7 +60,11 @@ import Mundo, {
 import CoachMarkToque from '../visual/mundo3d/CoachMarkToque.jsx';
 import { buildSpatialAgentInitialContext } from '../services/spatialAgentContext';
 import { speak, speakKokoro, stop as stopSpeak } from '../services/ttsService.js';
-import { navegarDesde3D } from '../prodApp/wire3DNav.js';
+import { navegarDesde3D, rutaDesdeMundo3D } from '../prodApp/wire3DNav.js';
+/* El VELO ODYSSEY (lenguaje de transición aprobado por el operador): cubrir →
+   swap en la meseta → revelar, con la identidad del DESTINO y variación por
+   tier. Barrel DOM-safe: cero three en el bundle base. */
+import { VeloOdyssey } from '../visual/mundo3d/transiciones/index.js';
 
 // La escena 3D pesada (three/fiber/drei) en su PROPIO chunk perezoso.
 const Valle3D = lazy(() => import('./valle/Valle3D'));
@@ -163,6 +167,18 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
   //    de más abajo). Reduced-motion no llega aquí: el hook salta 'viajando'.
   const usarNewDonk = ENTRADA_NEWDONK && !reducedMotion;
   const [newDonk, setNewDonk] = useState(null);
+
+  // ── El VELO ODYSSEY en los tres viajes del valle:
+  //    · ABRIR una pantalla 2D (`irA`): el velo del destino cubre y el cambio
+  //      de hash va BAJO la meseta cubierta — antes era un corte seco a los
+  //      700ms que mataba la cámara a mitad de vuelo.
+  //    · ENTRAR a un mundo 3D sin New Donk: velo del destino (identidad andina).
+  //    · VOLVER al valle: velo `luz` ("de vuelta a casa") — exhala, no repite
+  //      la ceremonia de entrada.
+  //    Se arma en el handler que zarpa (nunca en un effect) y se apaga solo en
+  //    su `onFin`. Reduced-motion no lo arma: corte directo digno.
+  //    null | { fase: 'entrando'|'saliendo', destino, irA?: mundoId }.
+  const [velo, setVelo] = useState(null);
 
   // La escucha puede llegar con un mundo ya resuelto por el NLU. Se consume
   // una vez al montar para que volver al valle siga siendo una decisión de la
@@ -316,16 +332,35 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
     };
   }, [decir]);
 
+  // ── TOCAR un lugar del valle: la cámara viaja, el panel abre y Angelita
+  //    narra. La persona DECIDE en el panel a dónde seguir (abrir la pantalla
+  //    real o recorrer el mundo en 3D). Antes había aquí un setTimeout de
+  //    700ms que arrancaba a la pantalla 2D con un corte seco: la cámara
+  //    moría a mitad de vuelo y el panel vivía menos de un segundo.
   const entrarMundo = useCallback(
     (id) => {
       setFocoId(id);
       setPanel(id);
       decir(NARRACION[id] || MUNDO_VALLE_BY_ID[id]?.lema || '');
-      // Navegar al 2D correspondiente (wire nav 3D→2D).
-      // Retardo para que la cámara enfoque antes de cambiar de pantalla.
-      setTimeout(() => navegarDesde3D(id), 700);
     },
     [decir],
+  );
+
+  // ── ABRIR la pantalla real de un lugar (el cableo 3D→2D de prod, PR #2453):
+  //    el velo del DESTINO cubre y `navegarDesde3D` corre bajo la meseta — el
+  //    usuario nunca ve el corte del swap de shell. Con reduced-motion, corte
+  //    directo (el velo no se arma).
+  const abrirPantalla = useCallback(
+    (id) => {
+      if (!rutaDesdeMundo3D(id)) return;
+      stopSpeak();
+      if (reducedMotion) {
+        navegarDesde3D(id);
+        return;
+      }
+      setVelo({ fase: 'entrando', destino: id, irA: id });
+    },
+    [reducedMotion],
   );
 
   const abrirAlerta = useCallback(() => {
@@ -384,18 +419,24 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
       // Enciende el mural New Donk en el MISMO tick que zarpa el viaje (mismo
       // render que la fase 'viajando') → el velo queda suprimido y el aplane
       // del valle corre bajo este overlay. Se apaga solo en su `onFin`.
+      // Con el flag New Donk apagado, el velo Odyssey del destino cubre la
+      // entrada (identidad andina) en vez del velo genérico.
       if (usarNewDonk) setNewDonk(id);
+      else if (!reducedMotion) setVelo({ fase: 'entrando', destino: id });
       setPanel(null);
       decir(`Angelita lo lleva a ${tituloDeMundo(id)}.`);
     },
-    [nav, decir, usarNewDonk],
+    [nav, decir, usarNewDonk, reducedMotion],
   );
 
-  // ── VOLVER del mundo al valle (misma transición, en reversa).
+  // ── VOLVER del mundo al valle: el velo Odyssey `luz` — regresar a casa
+  //    exhala (asimetría del lenguaje aprobado), no repite la ceremonia de
+  //    entrada.
   const salirDelMundo = useCallback(() => {
+    if (!reducedMotion) setVelo({ fase: 'saliendo', destino: 'valle' });
     nav.volverAlValle();
     decir('De vuelta al valle de su finca.');
-  }, [nav, decir]);
+  }, [nav, decir, reducedMotion]);
 
   // ── EL MUNDO HABLA (BUG-AG-02, el "cuarto mudo"): al llegar a un mundo,
   //    Angelita lo narra consumiendo `entrada.narra` del registro (BUG-AG-01:
@@ -442,6 +483,9 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
   );
 
   const mundoPanel = panel && panel !== 'alerta' ? MUNDO_VALLE_BY_ID[panel] : null;
+  // ¿Este lugar tiene pantalla real en la app? (wire3DNav). Decide el CTA
+  // primario del panel: abrir la pantalla manda; recorrer el 3D acompaña.
+  const rutaPanel = mundoPanel ? rutaDesdeMundo3D(mundoPanel.id) : null;
 
   return (
     <div className="valle-root" data-clima={clima} onPointerDown={despertarAngelita}>
@@ -477,6 +521,11 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
                 reducedMotion={reducedMotion}
                 tier={equipo.tier}
                 aplanando={!!newDonk && nav.fase === 'viajando'}
+                /* La CÁMARA DE DIRECTOR también en la entrada real (antes solo
+                   la tenía la escena del framework): el barrido establishing
+                   que presenta el valle vivo. Gateada por tier/reduced-motion
+                   adentro; una sola vez por sesión. */
+                camaraDirector
               />
               {/* Dispara el cruce 2D→3D cuando el chunk 3D del valle resolvió
                   (hermano de <Valle3D> en el Suspense). DOM puro, sin three. */}
@@ -540,7 +589,26 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
           onFin={() => setNewDonk(null)}
         />
       )}
-      {nav.enViaje && nav.mundoId && !(newDonk && nav.fase === 'viajando') && (
+      {/* El VELO ODYSSEY del viaje: cubre → swap en la meseta (`onCubierto`) →
+          revela. Con `irA`, el swap es el cambio de hash a la pantalla 2D real
+          (el shell desmonta este árbol ya cubierto: el corte queda escondido).
+          Sin `irA`, el swap es el del framework de mundos. */}
+      {velo && (
+        <VeloOdyssey
+          fase={velo.fase}
+          destino={velo.destino}
+          tier={equipo.tier}
+          reducedMotion={reducedMotion}
+          onCubierto={() => {
+            if (velo.irA) navegarDesde3D(velo.irA);
+            else nav.completarViaje();
+          }}
+          onFin={() => setVelo(null)}
+        />
+      )}
+      {/* Respaldo (viajes que nadie armó, p. ej. el deep-link inicial): el
+          velo clásico de siempre, con su swap al final. */}
+      {nav.enViaje && nav.mundoId && !(newDonk && nav.fase === 'viajando') && !velo && (
         <TransicionMundo
           mundoId={nav.mundoId}
           sentido={nav.fase === 'viajando' ? 'entrar' : 'volver'}
@@ -556,9 +624,13 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
               Dentro de un mundo se esconde: manda la miga del mundo. ── */}
       {!nav.enMundo && (
       <header className="valle-header">
-        <button type="button" className="valle-back" onClick={() => onBack?.()} aria-label="Volver">
-          ‹ Volver
-        </button>
+        {/* Solo si hay a dónde volver: en el HOME de prod este botón se
+            renderizaba sin handler — visible y muerto (feedback operador). */}
+        {onBack && (
+          <button type="button" className="valle-back" onClick={onBack} aria-label="Volver">
+            ‹ Volver
+          </button>
+        )}
         <div className="valle-titulo">
           <span className="valle-titulo__eyebrow">Su finca, hoy</span>
           <h1>El valle de mi finca</h1>
@@ -634,13 +706,27 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
           <h2>{mundoPanel.titulo}</h2>
           <p>{mundoPanel.lema}</p>
           <div className="valle-panel__acciones">
-            {nav.puedeEntrar(mundoPanel.id) ? (
-              <button type="button" className="valle-cta" onClick={() => entrarAlMundo(mundoPanel.id)}>
-                Entrar a este mundo
+            {/* El CTA primario es la PANTALLA REAL de la app (la promesa del
+                cableo 3D→2D); recorrer el diorama 3D queda como acompañante.
+                Antes un setTimeout arrancaba solo, y este panel — con los
+                mundos 3D y sus transiciones aprobadas — era inalcanzable. */}
+            {rutaPanel && (
+              <button type="button" className="valle-cta" onClick={() => abrirPantalla(mundoPanel.id)}>
+                Abrir {mundoPanel.titulo}
               </button>
-            ) : (
+            )}
+            {nav.puedeEntrar(mundoPanel.id) && (
+              <button
+                type="button"
+                className={rutaPanel ? 'valle-ghost' : 'valle-cta'}
+                onClick={() => entrarAlMundo(mundoPanel.id)}
+              >
+                {rutaPanel ? 'Recorrer en 3D' : 'Entrar a este mundo'}
+              </button>
+            )}
+            {!rutaPanel && !nav.puedeEntrar(mundoPanel.id) && (
               /* Degradación elegante: este mundo aún no tiene escena montable
-                 (p. ej. el clima, que YA es el cielo del valle). */
+                 ni pantalla real (p. ej. el clima, que YA es el cielo del valle). */
               <p className="valle-panel__pronto" role="status">
                 Este mundo abre pronto su propia puerta. Por ahora se vive desde el valle.
               </p>

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -40,21 +40,43 @@ import { Colibri } from '../../visual/creatures/Colibri.jsx';
 import { Mariposa } from '../../visual/creatures/Mariposa.jsx';
 import { Escarabajo } from '../../visual/creatures/Escarabajo.jsx';
 import { Lombriz } from '../../visual/creatures/Lombriz.jsx';
-import AnimalesDeFinca from './animales.jsx';
+import AnimalesDeFinca, { MATERIAL_FINCA } from './animales.jsx';
+/* Árboles POR ESPECIE (no genéricos): las mismas mallas del bosque altoandino
+   (roble, aliso, gaque) que ya viven en floraParamo — cada árbol se distingue. */
+import { geomRoble, geomAliso, geomGaque } from '../../visual/mundo3d/bosque/floraParamo.geom.js';
 /* Luciérnagas de la noche: el kit instanciado que ya existe (1-3 draw calls),
    sembrado sobre la tierra baja del valle cuando la franja las trae. */
 import { ParticulasAmbientales } from '../../visual/mundo3d/ParticulasAmbientales.jsx';
 /* Duración canónica de la transición entre franjas (misma que CielosHora). */
 import { TRANSICION } from '../../visual/mundo3d/cielosHoraData.js';
+/* LA DIRECCIÓN del valle (capa de composición sobre valleData): la casa-ancla,
+   los senderos del trajín, los patios de tierra pisada, los vecinos (los
+   personajes en su casa) y la disposición COMPUESTA de los lugares. La ley
+   vive como datos en visual/mundo3d/direccion; las piezas r3f, al lado. */
+import {
+  componerMundos,
+  JERARQUIA_PERSONAJES,
+} from '../../visual/mundo3d/direccion/composicionValle.js';
+import {
+  CasaCampesina,
+  SenderosValle,
+  PatiosLugares,
+  VecinosDelValle,
+} from './composicionValle3D.jsx';
 import './rotulosValle3D.css';
 import {
   MUNDOS_VALLE,
-  MUNDO_VALLE_BY_ID,
   COSA_DEL_DIA,
   CLIMAS,
   PISOS_TERMICOS,
   VEGETACION_PISOS,
 } from './valleData';
+
+/* ── Los mundos YA COMPUESTOS: la disposición del director encima de los
+      datos crudos. valleData no se toca (otros frentes viven ahí); aquí la
+      escena entera consume ESTA lista — geometría, rótulos, faro y foco. ── */
+const MUNDOS_DIR = componerMundos(MUNDOS_VALLE);
+const MUNDO_DIR_BY_ID = Object.fromEntries(MUNDOS_DIR.map((m) => [m.id, m]));
 
 /* Altura del terreno por (x,z): la LADERA ANDINA. El eje z es la montaña — al
    fondo (z negativo) trepa al páramo alto, al frente (z positivo) baja a tierra
@@ -226,10 +248,44 @@ function Quebrada({ color, viva, perfil }) {
   );
 }
 
+/* ── La arboleda POR ESPECIE del landmark 'bosque': roble andino (copa ancha
+      oscura), aliso (cónico de tronco claro) y gaque (domo bajo lustroso) —
+      cada árbol se distingue, nada de conos genéricos. Las mallas son las de
+      floraParamo (color horneado por vértice, 1 draw call por árbol); escala
+      ~0.5 para el diorama. `q` baja el detalle en perfil frugal. ── */
+const SITIOS_ARBOLEDA = [
+  { geom: geomRoble, args: [-0.55, 0, 0.15], esc: 0.52, rot: 0.8, seed: 91 },
+  { geom: geomAliso, args: [0.45, 0, -0.35], esc: 0.5, rot: 2.1, seed: 92 },
+  { geom: geomGaque, args: [0.2, 0, 0.55], esc: 0.55, rot: 4.4, seed: 93 },
+];
+
+function ArboledaEspecies({ q }) {
+  const arboles = useMemo(
+    () => SITIOS_ARBOLEDA.map((s) => ({ ...s, geo: s.geom({ q }, s.seed) })),
+    [q],
+  );
+  return (
+    <group>
+      {arboles.map((a, i) => (
+        <mesh
+          key={i}
+          geometry={a.geo}
+          material={MATERIAL_FINCA}
+          position={/** @type {[number, number, number]} */ (a.args)}
+          rotation={[0, a.rot, 0]}
+          scale={a.esc}
+          castShadow
+        />
+      ))}
+    </group>
+  );
+}
+
 /* ── Materiales/paletas de cada landmark de mundo, por `tipo`. Formas
       redondeadas (cilindros, conos, esferas) — pocas piezas por lugar para
-      dejar aire. ── */
-function LandmarkGeom({ tipo, tinte, reducedMotion }) {
+      dejar aire. La arboleda va por especie (mallas de floraParamo); `q` baja
+      el detalle geométrico en perfil frugal. ── */
+function LandmarkGeom({ tipo, tinte, reducedMotion, q = 1 }) {
   const [fuerte, suave] = tinte;
   switch (tipo) {
     case 'milpa': // maíz: cañas altas con penacho + hojas
@@ -332,40 +388,8 @@ function LandmarkGeom({ tipo, tinte, reducedMotion }) {
           ))}
         </group>
       );
-    case 'bosque': // arboleda: troncos + copas cónicas Y esféricas mezcladas
-      return (
-        <group>
-          {[
-            [-0.5, 0, 0.95, 'cono'],
-            [0.45, 0.2, 1.2, 'esfera'],
-            [0.05, -0.45, 0.85, 'cono'],
-          ].map(([dx, dz, h, forma], i) => (
-            <group key={i} position={[Number(dx), 0, Number(dz)]}>
-              <mesh position={[0, Number(h) * 0.35, 0]} castShadow>
-                <cylinderGeometry args={[0.08, 0.12, Number(h) * 0.7, 6]} />
-                <meshStandardMaterial color="#6b4a2e" flatShading />
-              </mesh>
-              {forma === 'cono' ? (
-                <mesh position={[0, Number(h) * 0.85, 0]} castShadow>
-                  <coneGeometry args={[0.46, Number(h) * 0.95, 8]} />
-                  <meshStandardMaterial color={fuerte} flatShading roughness={1} />
-                </mesh>
-              ) : (
-                <group position={[0, Number(h) * 0.85, 0]}>
-                  <mesh castShadow>
-                    <sphereGeometry args={[0.42, 10, 9]} />
-                    <meshStandardMaterial color={fuerte} flatShading roughness={1} />
-                  </mesh>
-                  <mesh position={[0.22, 0.18, 0.1]} castShadow>
-                    <sphereGeometry args={[0.26, 9, 8]} />
-                    <meshStandardMaterial color={suave} flatShading roughness={1} />
-                  </mesh>
-                </group>
-              )}
-            </group>
-          ))}
-        </group>
-      );
+    case 'bosque': // arboleda POR ESPECIE: roble andino + aliso + gaque
+      return <ArboledaEspecies q={q} />;
     case 'mercado': // puesto de mercado campesino: toldo a dos aguas + mesa + canasto
       return (
         <group>
@@ -677,11 +701,13 @@ function Veleta({ color, reducedMotion = false }) {
       eras. Pocas y bien puestas: el valle se siente vivo, no amontonado. Son
       decorativas (aria-hidden) y no capturan toques. ── */
 const CRIATURAS_VALLE = [
-  { crt: 'mariposa', x: -4.0, z: 2.0, dy: 2.0, size: 30, factor: 8 },
-  { crt: 'mariposa', x: -4.8, z: 2.9, dy: 1.5, size: 24, factor: 8 },
-  { crt: 'colibri', x: 3.6, z: 4.4, dy: 1.9, size: 34, factor: 8 },
+  // (posiciones al día con la DISPOSICIÓN COMPUESTA: la milpa cedió a la
+  //  izquierda y la huerta se arrimó a la casa — sus bichos las siguen.)
+  { crt: 'mariposa', x: -4.8, z: 1.9, dy: 2.0, size: 30, factor: 8 },
+  { crt: 'mariposa', x: -5.6, z: 2.8, dy: 1.5, size: 24, factor: 8 },
+  { crt: 'colibri', x: 3.1, z: 3.9, dy: 1.9, size: 34, factor: 8 },
   { crt: 'escarabajo', x: 4.7, z: -2.9, dy: 0.5, size: 28, factor: 7 },
-  { crt: 'lombriz', x: -1.0, z: 5.2, dy: 0.28, size: 26, factor: 6.5 },
+  { crt: 'lombriz', x: -1.2, z: 5.4, dy: 0.28, size: 26, factor: 6.5 },
 ];
 
 function CriaturaSvg({ tipo, size, animated }) {
@@ -728,19 +754,54 @@ function ProxyLandmark({ tipo, tinte }) {
   );
 }
 
-/* ── Un mundo como LUGAR navegable: SOLO su geometría. Su etiqueta táctil vive
-      en <RotulosLugares/> (piso en píxeles + foco/proximidad + anti-colisión).
-      En perfil frugal el detalle completo SOLO se dibuja de cerca (<Detailed>):
-      la panorámica de arranque —el peor momento— queda en siluetas baratas. ── */
-function MundoLugar({ mundo, reducedMotion, perfil }) {
+/* ── Un mundo como LUGAR navegable: su geometría — y TOCABLE (dirección del
+      valle): tocar la milpa, el corral o la charca entra al mundo igual que su
+      rótulo. El lugar ES el botón; el rótulo lo nombra. El cursor lo dice en
+      desktop; en el teléfono lo dicen el patio de tierra y el sendero que
+      llegan hasta él. Su etiqueta táctil sigue en <RotulosLugares/> (piso en
+      píxeles + foco/proximidad + anti-colisión). En perfil frugal el detalle
+      completo SOLO se dibuja de cerca (<Detailed>): la panorámica de arranque
+      —el peor momento— queda en siluetas baratas. ── */
+function MundoLugar({ mundo, reducedMotion, perfil, onEntrar = null }) {
   const y = alturaTerreno(mundo.pos[0], mundo.pos[2]);
   const detalle = mundo.tipo === 'veleta' ? (
     <Veleta color={mundo.tinte[0]} reducedMotion={reducedMotion} />
   ) : (
-    <LandmarkGeom tipo={mundo.tipo} tinte={mundo.tinte} reducedMotion={reducedMotion} />
+    <LandmarkGeom
+      tipo={mundo.tipo}
+      tinte={mundo.tinte}
+      reducedMotion={reducedMotion}
+      q={perfil.materialRico ? 1 : 0.55}
+    />
   );
   return (
-    <group position={[mundo.pos[0], y, mundo.pos[2]]} scale={mundo.escala}>
+    <group
+      position={[mundo.pos[0], y, mundo.pos[2]]}
+      scale={mundo.escala}
+      onClick={
+        onEntrar
+          ? (e) => {
+              e.stopPropagation();
+              onEntrar(mundo.id);
+            }
+          : undefined
+      }
+      onPointerOver={
+        onEntrar
+          ? (e) => {
+              e.stopPropagation();
+              document.body.style.cursor = 'pointer';
+            }
+          : undefined
+      }
+      onPointerOut={
+        onEntrar
+          ? () => {
+              document.body.style.cursor = '';
+            }
+          : undefined
+      }
+    >
       {perfil.lod ? (
         <Detailed distances={[0, perfil.lodDistancia]}>
           <group>{detalle}</group>
@@ -791,7 +852,7 @@ function RotulosLugares({ mundos, focoId, onEntrar, occluders }) {
 
   // La alerta del día (el faro) siempre se reserva su espacio en pantalla.
   const anclaAlerta = useMemo(() => {
-    const a = MUNDO_VALLE_BY_ID[COSA_DEL_DIA.anclaMundo];
+    const a = MUNDO_DIR_BY_ID[COSA_DEL_DIA.anclaMundo];
     if (!a) return null;
     return new THREE.Vector3(a.pos[0], alturaTerreno(a.pos[0], a.pos[2]) + 2.7, a.pos[2]);
   }, []);
@@ -906,7 +967,7 @@ function RotulosLugares({ mundos, focoId, onEntrar, occluders }) {
 /* ── La cosa del día: un faro pulsante anclado sobre su mundo. Un SOLO destello.
       Toca la señal → onAlerta() (el agente lo dice y ofrece LA acción). ── */
 function Beacon({ onAlerta, reducedMotion, conLuz = true }) {
-  const ancla = MUNDO_VALLE_BY_ID[COSA_DEL_DIA.anclaMundo];
+  const ancla = MUNDO_DIR_BY_ID[COSA_DEL_DIA.anclaMundo];
   const luz = useRef(null);
   const halo = useRef(null);
   useFrame((state) => {
@@ -962,7 +1023,7 @@ function Beacon({ onAlerta, reducedMotion, conLuz = true }) {
       mundo (`entrando`), BAJA y se acerca al lugar — "entra" al mundo, y la
       cámara la acompaña. Su ánimo/energía (salud real de la finca) tiñen su
       color, su aura y qué tan vivo es su vuelo. Mira hacia donde viaja. ── */
-function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false, posRef = null }) {
+function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false, posRef = null, conLuz = false }) {
   const ref = useRef(null);
   const caraRef = useRef(null);
   const prevX = useRef(foco.x);
@@ -1009,8 +1070,20 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
     }
   });
   const size = 44 + Math.round(energiaReal * 14);
+  const luz = JERARQUIA_PERSONAJES.luzProtagonista;
   return (
     <group ref={ref} position={[foco.x + 0.4, foco.y + 2.3, foco.z + 0.6]}>
+      {/* JERARQUÍA: Angelita es la ÚNICA con luz propia — su calidez baña el
+          terreno bajo su vuelo y el ojo la encuentra primero, sobre todo al
+          atardecer y de noche. Solo donde el perfil ya paga luces extra. */}
+      {conLuz && (
+        <pointLight
+          color={luz.color}
+          intensity={luz.intensidad}
+          distance={luz.alcance}
+          position={[0, -0.2, 0]}
+        />
+      )}
       <Html center distanceFactor={9} zIndexRange={[40, 10]}>
         <div className="valle-abeja" aria-hidden="true">
           <div ref={caraRef} className="valle-abeja__cara">
@@ -1110,7 +1183,7 @@ function AplaneNewDonk({ foco, aplanando }) {
       suelta el control para que el usuario siga haciendo zoom a mano). Durante
       el APLANE New Donk cede TODO el control a AplaneNewDonk (early-return): no
       mueve target ni zoom para no pelear con la caída. ── */
-function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false }) {
+function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false, kReposo = 1 }) {
   const trans = useRef(0);
   const prevKey = useRef(focoKey);
   const entrando = focoKey !== 'valle';
@@ -1121,14 +1194,20 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false }
       trans.current = 1; // arrancó una nueva "entrada": acompañar el zoom
       prevKey.current = focoKey;
     }
-    c.target.lerp(new THREE.Vector3(foco.x, foco.y + 0.6, foco.z), 0.06);
+    /* ASIMETRÍA DEL VIAJE (dirección): ENTRAR es decidido (el toque pide ir
+       ya); VOLVER es una exhalación — más lento, el valle se abre con calma y
+       llegar a casa se siente distinto a salir de ella. */
+    const k = entrando ? 0.07 : 0.042;
+    c.target.lerp(new THREE.Vector3(foco.x, foco.y + 0.6, foco.z), k);
     if (trans.current > 0) {
       const cam = c.object;
       const dir = cam.position.clone().sub(c.target);
-      const deseada = entrando ? 9 : 18; // acercarse al entrar, abrir al volver (más aire)
-      dir.setLength(THREE.MathUtils.lerp(dir.length(), deseada, 0.06));
+      // Acercarse al entrar; al volver, abrir hasta el reposo del ASPECTO
+      // real (kReposo): en un teléfono parado el valle respira más lejos.
+      const deseada = entrando ? 9 : 18 * kReposo;
+      dir.setLength(THREE.MathUtils.lerp(dir.length(), deseada, k));
       cam.position.copy(c.target.clone().add(dir));
-      trans.current = Math.max(0, trans.current - 0.012);
+      trans.current = Math.max(0, trans.current - (entrando ? 0.012 : 0.009));
     }
     c.update();
   });
@@ -1283,8 +1362,29 @@ const CAMARA_VALLE = { position: /** @type {[number, number, number]} */ ([10.5,
    DirectorValle aterriza EXACTO aquí para no dar ningún salto al soltar. */
 const MIRA_VALLE = [0, 1.6, 1.4];
 
+/* El REPOSO CONSCIENTE DEL ASPECTO (dirección de cámara): el fov de three es
+   VERTICAL — en un teléfono parado (aspecto ~0.46) los 40° dejan un fov
+   horizontal de ~19° y la composición entera (lugares en x ∈ [-7.5, 7.5], el
+   oso en el borde del monte) queda FUERA del cuadro: medio valle existía y
+   nadie lo veía (la misma clase de fallo que los árboles tras el macizo de la
+   sierra). En pantallas angostas la cámara retrocede y abre un poco el fov —
+   con techo, para no caer en ojo de pez — y el valle entero vuelve al cuadro.
+   En landscape (aspecto ≥ 0.9) la pose aprobada queda EXACTA. */
+function poseValleParaAspecto(aspect) {
+  if (!aspect || aspect >= 0.9) return { position: CAMARA_VALLE.position, fov: CAMARA_VALLE.fov, k: 1 };
+  const k = Math.min(1.6, Math.pow(0.9 / aspect, 0.62));
+  const fov = Math.min(54, Math.round(CAMARA_VALLE.fov * Math.pow(0.9 / aspect, 0.4)));
+  return {
+    position: /** @type {[number, number, number]} */ (CAMARA_VALLE.position.map((v) => v * k)),
+    fov,
+    k,
+  };
+}
+
 /* ── Contenido de la escena (dentro del Canvas). ── */
-function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false, aplanando = false, camaraDirector = false, beatsRef = null, portada = false }) {
+function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false, aplanando = false, camaraDirector = false, beatsRef = null, portada = false, pose = null }) {
+  /* La pose de reposo (aspecto-consciente, viene del host del Canvas). */
+  const poseReposo = pose || { position: CAMARA_VALLE.position, fov: CAMARA_VALLE.fov, k: 1 };
   const controls = useRef(null);
   /* La cámara de director (FASE 4, flag `camaraDirector`) se monta DESPUÉS de
      CamaraViajera y gana por orden de frame durante su barrido. `avatarRef`
@@ -1297,7 +1397,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
   const occluders = useMemo(() => [terrenoRef, cordilleraRef], []);
   const c = CLIMAS[clima];
   const foco = useMemo(() => {
-    const m = focoId ? MUNDO_VALLE_BY_ID[focoId] : null;
+    const m = focoId ? MUNDO_DIR_BY_ID[focoId] : null;
     // Sin foco, la cámara encuadra el corazón del valle (algo hacia el frente,
     // regla de tercios) para dar aire y leer la ladera que sube al fondo.
     if (!m) return new THREE.Vector3(0, 1.0, 1.4);
@@ -1347,16 +1447,41 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
       <Quebrada color={nocturno ? '#2a4a6a' : '#5fb2c9'} viva={c.lluviaViva} perfil={perfil} />
       <VegetacionPisos nocturno={nocturno} perfil={perfil} />
 
-      {MUNDOS_VALLE.map((m) => (
-        <MundoLugar key={m.id} mundo={m} reducedMotion={reducedMotion} perfil={perfil} />
+      {/* LA DIRECCIÓN DEL CUADRO: la casa-ancla donde descansa el ojo (con su
+          ventana cálida), los senderos de tierra pisada que nacen de ella (el
+          rastro del uso diario: el ojo camina por donde caminan los pies) y
+          los patios bajo cada lugar navegable (afordancia sin UI). */}
+      <CasaCampesina alturaDe={alturaTerreno} perfil={perfil} />
+      <SenderosValle alturaDe={alturaTerreno} perfil={perfil} />
+      {!portada && <PatiosLugares mundos={MUNDOS_DIR} alturaDe={alturaTerreno} />}
+
+      {MUNDOS_DIR.map((m) => (
+        <MundoLugar
+          key={m.id}
+          mundo={m}
+          reducedMotion={reducedMotion}
+          perfil={perfil}
+          onEntrar={portada ? null : onEntrar}
+        />
       ))}
+
+      {/* Los VECINOS del valle (el oso, el borugo, el jaguar…): los personajes
+          en su casa, con presencia digna — acompañan a Angelita sin pelearle
+          el primer plano. Billboards DOM baratos: viven en TODOS los tiers
+          (el operador no debería necesitar GPU rica para conocer al oso);
+          la franja horaria decide quién está afuera. */}
+      <VecinosDelValle
+        alturaDe={alturaTerreno}
+        reducedMotion={reducedMotion}
+        franja={clima}
+      />
       {/* MODO PORTADA (la cara de prod.chagra.app): el valle es ATMÓSFERA de
           la entrada — sin rótulos que compitan con el formulario ni faro que
           pida un toque que aún no puede darse. La vida (criaturas, Angelita,
           ciclo del día) se queda: la finca espera, no está muerta. */}
       {!portada && (
         <RotulosLugares
-          mundos={MUNDOS_VALLE}
+          mundos={MUNDOS_DIR}
           focoId={focoId}
           onEntrar={onEntrar}
           occluders={occluders}
@@ -1376,6 +1501,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         hayAlerta={hayAlerta}
         reducedMotion={reducedMotion}
         posRef={camaraDirector ? avatarRef : null}
+        conLuz={perfil.luzBeacon}
       />
 
       <CamaraViajera
@@ -1384,6 +1510,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         controls={controls}
         autoOrbit={autoOrbit}
         aplanando={aplanando}
+        kReposo={poseReposo.k}
       />
       {/* La CÁMARA DE DIRECTOR (FASE 4). Con el flag `camaraDirector`:
           DirectorValle (establishing + follow + beats), montado DESPUÉS de
@@ -1393,9 +1520,9 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
       {camaraDirector ? (
         <DirectorValle
           controls={controls}
-          reposo={CAMARA_VALLE.position}
+          reposo={poseReposo.position}
           mira={MIRA_VALLE}
-          fov={CAMARA_VALLE.fov}
+          fov={poseReposo.fov}
           foco={foco}
           avatarRef={avatarRef}
           beatsRef={beatsRef}
@@ -1409,7 +1536,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
       ) : (
         <CamaraDirector
           controls={controls}
-          reposo={CAMARA_VALLE.position}
+          reposo={poseReposo.position}
           /* En portada la llegada es más lenta y amplia (contemplar, no operar)
              y NO consume la clave 'valle': al cruzar la tranquera, el home aún
              estrena su propio establishing — llegar dos veces se siente bien. */
@@ -1463,13 +1590,25 @@ export default function Valle3D({
      look intacto; 'medio'/'bajo' degradan sombras, DPR, antialias, densidad e
      instancian lo repetido. El default 'alto' preserva a los hosts viejos. */
   const perfil = useMemo(() => perfilDeTier(tier), [tier]);
+  /* La pose de reposo según el ASPECTO del equipo (una vez por montaje: girar
+     el teléfono re-monta rutas enteras en la práctica; no vale un resize
+     listener que mueva la cámara bajo los dedos del usuario). */
+  const pose = useMemo(
+    () =>
+      poseValleParaAspecto(
+        typeof window !== 'undefined' && window.innerHeight > 0
+          ? window.innerWidth / window.innerHeight
+          : 1,
+      ),
+    [],
+  );
   return (
     <Canvas
       className={`valle-canvas${listo ? ' valle-canvas--listo' : ''}`}
       shadows={perfil.sombras}
       dpr={perfil.dpr}
       gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
-      camera={/** @type {any} */ (CAMARA_VALLE)}
+      camera={/** @type {any} */ ({ position: pose.position, fov: pose.fov })}
       frameloop={reducedMotion ? 'demand' : 'always'}
       onCreated={() => setListo(true)}
     >
@@ -1490,6 +1629,7 @@ export default function Valle3D({
           camaraDirector={camaraDirector}
           beatsRef={beatsRef}
           portada={portada}
+          pose={pose}
         />
       </Suspense>
     </Canvas>

--- a/src/mockups/valle/animales.jsx
+++ b/src/mockups/valle/animales.jsx
@@ -14,6 +14,16 @@
  */
 import { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+/* El material COMPARTIDO de las mallas fusionadas con color horneado por
+   vértice (arboleda por especie hoy; el hato realista de finca-realismo-d1
+   cuando mergee — mismo export, cero conflicto). UNO para todas: cada malla
+   fusionada es 1 draw call. */
+export const MATERIAL_FINCA = new THREE.MeshLambertMaterial({
+  vertexColors: true,
+  flatShading: true,
+});
 
 /* Patas: cuatro cilindros finos y cortos, iguales para todos los cuadrúpedos. */
 function Patas({ x = 0.28, z = 0.16, alto = 0.26, r = 0.05, color }) {

--- a/src/mockups/valle/animales.jsx
+++ b/src/mockups/valle/animales.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react-refresh/only-export-components -- exporta MATERIAL_FINCA
+   (constante compartida de las mallas horneadas) además del componente. */
 /*
  * Animales de finca del valle — el mundo 'animales' (antes una casita muda).
  *

--- a/src/mockups/valle/composicionValle3D.jsx
+++ b/src/mockups/valle/composicionValle3D.jsx
@@ -1,0 +1,206 @@
+/*
+ * composicionValle3D — las piezas r3f de la DIRECCIÓN del valle.
+ *
+ * El arte que la composición pide (direccion/composicionValle.js) hecho
+ * geometría procedural, con el mismo contrato del resto del valle: cero
+ * assets remotos, materiales flat/Lambert según perfil, cero alocación por
+ * frame. Recibe `alturaDe(x, z)` del host (Valle3D es dueño del terreno):
+ * nada de aquí importa Valle3D — sin ciclos.
+ *
+ *   · CasaCampesina    — el ancla del cuadro: encalada, zócalo pintado, teja,
+ *                        y la ventana con luz cálida (la casa espera).
+ *   · SenderosValle    — la tierra pisada que nace de la casa: el rastro del
+ *                        uso diario, el ojo camina por donde caminan los pies.
+ *   · PatiosLugares    — el suelo desnudo bajo cada lugar navegable: la
+ *                        afordancia diegética de "aquí se llega".
+ *   · SecundariosDeTierra — los vecinos del monte (el oso, el borugo…) a ras
+ *                        de suelo, lejos y chicos: acompañan, no compiten.
+ *                        Registro-driven: un slug ausente no monta nada.
+ */
+import { useMemo } from 'react';
+import { Html, Instances, Instance } from '@react-three/drei';
+import * as THREE from 'three';
+import { CREATURES } from '../../visual/creatures/index.js';
+import {
+  CASA_VALLE,
+  SENDEROS_VALLE,
+  PATIO,
+  JERARQUIA_PERSONAJES,
+  VECINOS_VALLE,
+} from '../../visual/mundo3d/direccion/composicionValle.js';
+
+/* ── Paleta de la casa campesina (tapia encalada + zócalo + teja) ────────── */
+const CASA = {
+  encalado: '#f3ecdc',
+  zocalo: '#a35a3c', // el zócalo pintado de las casas de vereda
+  teja: '#b0603f',
+  tejaSombra: '#8f4b31',
+  madera: '#6b4a2e',
+  ventana: '#ffd9a0',
+};
+
+/**
+ * La casa campesina: ancla de composición, NO navegable (aria nada, cero
+ * toques). Modesta a propósito: sostiene el cuadro sin pedir protagonismo.
+ * La ventana emisiva es "la casa espera": de día apenas se nota, al
+ * atardecer y de noche es el corazón cálido del valle.
+ */
+export function CasaCampesina({ alturaDe, perfil }) {
+  const [cx, cz] = CASA_VALLE.pos;
+  const y = alturaDe(cx, cz);
+  const rico = perfil.materialRico;
+  return (
+    <group position={[cx, y, cz]} rotation={[0, CASA_VALLE.rotY, 0]}>
+      {/* el zócalo pintado (la franja baja de color de toda casa de vereda) */}
+      <mesh position={[0, 0.11, 0]} castShadow={perfil.sombras} receiveShadow={perfil.sombras}>
+        <boxGeometry args={[1.52, 0.22, 1.06]} />
+        <meshStandardMaterial color={CASA.zocalo} flatShading roughness={1} />
+      </mesh>
+      {/* el muro encalado */}
+      <mesh position={[0, 0.52, 0]} castShadow={perfil.sombras}>
+        <boxGeometry args={[1.48, 0.62, 1.02]} />
+        <meshStandardMaterial color={CASA.encalado} flatShading roughness={1} />
+      </mesh>
+      {/* techo de teja a dos aguas (dos faldones + cumbrera) con alero */}
+      <mesh position={[-0.42, 0.98, 0]} rotation={[0, 0, 0.62]} castShadow={perfil.sombras}>
+        <boxGeometry args={[1.06, 0.06, 1.28]} />
+        <meshStandardMaterial color={CASA.teja} flatShading roughness={1} />
+      </mesh>
+      <mesh position={[0.42, 0.98, 0]} rotation={[0, 0, -0.62]} castShadow={perfil.sombras}>
+        <boxGeometry args={[1.06, 0.06, 1.28]} />
+        <meshStandardMaterial color={CASA.tejaSombra} flatShading roughness={1} />
+      </mesh>
+      <mesh position={[0, 1.24, 0]}>
+        <boxGeometry args={[0.12, 0.07, 1.3]} />
+        <meshStandardMaterial color={CASA.tejaSombra} flatShading roughness={1} />
+      </mesh>
+      {/* la puerta de madera, al frente (el lado del corredor) */}
+      <mesh position={[-0.3, 0.42, 0.52]}>
+        <boxGeometry args={[0.3, 0.52, 0.05]} />
+        <meshStandardMaterial color={CASA.madera} flatShading roughness={1} />
+      </mesh>
+      {/* LA VENTANA CON LUZ: la casa espera (emisiva, cálida, chiquita) */}
+      <mesh position={[0.34, 0.56, 0.52]}>
+        <boxGeometry args={[0.26, 0.24, 0.04]} />
+        <meshStandardMaterial
+          color={CASA.ventana}
+          emissive={CASA.ventana}
+          emissiveIntensity={0.8}
+          flatShading
+        />
+      </mesh>
+      {/* el corredor: dos pies derechos y su tramo de techo (solo tier alto) */}
+      {rico && (
+        <group>
+          {[-0.55, 0.55].map((dx, i) => (
+            <mesh key={i} position={[dx, 0.42, 0.82]} castShadow={perfil.sombras}>
+              <cylinderGeometry args={[0.035, 0.045, 0.84, 6]} />
+              <meshStandardMaterial color={CASA.madera} flatShading roughness={1} />
+            </mesh>
+          ))}
+          <mesh position={[0, 0.9, 0.78]} rotation={[0.32, 0, 0]} castShadow={perfil.sombras}>
+            <boxGeometry args={[1.44, 0.05, 0.5]} />
+            <meshStandardMaterial color={CASA.teja} flatShading roughness={1} />
+          </mesh>
+        </group>
+      )}
+    </group>
+  );
+}
+
+/* ── Senderos: cintas de tierra pisada posadas sobre el terreno ──────────
+   Un tubo enterrado a medias por sendero (queda la venita superior visible):
+   1 draw call por camino, Lambert (los caminos no piden PBR). En frugal solo
+   los principales (`frugal: true`), con menos segmentos. */
+const MAT_SENDERO = new THREE.MeshLambertMaterial({ color: '#a8834f' });
+
+export function SenderosValle({ alturaDe, perfil }) {
+  const rico = perfil.materialRico;
+  const geos = useMemo(
+    () =>
+      SENDEROS_VALLE.filter((s) => rico || s.frugal).map((s) => {
+        const pts = s.puntos.map(([x, z]) => new THREE.Vector3(x, alturaDe(x, z) + 0.03, z));
+        const curva = new THREE.CatmullRomCurve3(pts);
+        // Radio corto y medio hundido: asoma la huella, no un caño.
+        return new THREE.TubeGeometry(curva, s.puntos.length * (rico ? 7 : 5), 0.16, 4, false);
+      }),
+    [alturaDe, rico],
+  );
+  return (
+    <group>
+      {geos.map((g, i) => (
+        <mesh key={i} geometry={g} material={MAT_SENDERO} position={[0, -0.07, 0]} />
+      ))}
+    </group>
+  );
+}
+
+/* ── Patios de tierra pisada bajo los lugares navegables ─────────────────
+   Todos en UNA InstancedMesh (1 draw call). Círculo plano apenas levantado;
+   depthWrite off para no pelear con la ondulación del terreno. */
+export function PatiosLugares({ mundos, alturaDe }) {
+  const sitios = useMemo(
+    () =>
+      mundos.map((m) => ({
+        x: m.pos[0],
+        y: alturaDe(m.pos[0], m.pos[2]) + 0.055,
+        z: m.pos[2],
+        r: PATIO.radioBase * (m.escala || 1),
+      })),
+    [mundos, alturaDe],
+  );
+  return (
+    <Instances limit={sitios.length}>
+      <circleGeometry args={[1, 22]} />
+      <meshLambertMaterial
+        color={PATIO.color}
+        transparent
+        opacity={PATIO.opacidad}
+        depthWrite={false}
+      />
+      {sitios.map((s, i) => (
+        <Instance
+          key={i}
+          position={[s.x, s.y, s.z]}
+          rotation={[-Math.PI / 2, 0, 0]}
+          scale={[s.r, s.r, 1]}
+        />
+      ))}
+    </Instances>
+  );
+}
+
+/* ── Los VECINOS del valle: los personajes en su casa ────────────────────
+   La puesta en escena de los personajes rubber-hose (feedback del operador:
+   el oso y los demás no pueden ser garnish de la abejita). Cada vecino vive
+   en SU rincón (VECINOS_VALLE) con presencia digna, y `franjas` decide
+   cuándo sale — el borugo al caer el sol, el jaguar solo como aparecido.
+   Billboards <Html> aria-hidden, cero toques (JERARQUIA_PERSONAJES): la ley
+   sigue siendo presencia, no interfaz. Un slug que no exista en CREATURES
+   simplemente no monta — las ramas de personajes mejoran el dibujo al
+   mergear sin tocar este mapa. */
+export function VecinosDelValle({ alturaDe, reducedMotion, franja = null }) {
+  return (
+    <group>
+      {VECINOS_VALLE.map((vec, i) => {
+        const reg = CREATURES[vec.slug];
+        if (!reg?.Component) return null;
+        // La franja decide quién está afuera (null = vive a toda hora).
+        if (vec.franjas && franja && !vec.franjas.includes(franja)) return null;
+        const Bicho = reg.Component;
+        const [x, z] = vec.punto;
+        const px = Math.min(vec.px, JERARQUIA_PERSONAJES.vecinoMaxPx);
+        const y = alturaDe(x, z) + (vec.dy ?? 0.3);
+        return (
+          <group key={i} position={[x, y, z]}>
+            <Html center distanceFactor={vec.factor} zIndexRange={[6, 0]} pointerEvents="none">
+              <div className="valle-critter" data-vecino={vec.slug} aria-hidden="true">
+                <Bicho size={px} animated={!reducedMotion} />
+              </div>
+            </Html>
+          </group>
+        );
+      })}
+    </group>
+  );
+}

--- a/src/prodApp/ProdChagraApp.jsx
+++ b/src/prodApp/ProdChagraApp.jsx
@@ -8,7 +8,7 @@
  * resuelve en build-time sin penalizar el build completo.
  */
 import React, { lazy, Suspense, useState, useEffect, useCallback } from 'react';
-import { isAuthenticated, logoutUser } from '../services/authService';
+import { isAuthenticated } from '../services/authService';
 import {
   NUCLEO_3D,
   NUCLEO_APP,
@@ -30,14 +30,6 @@ const OAuthCallback = lazy(() => import('../components/OAuthCallback.jsx'));
 // Cada entrada asocia un importLazy → React.lazy con el path exacto.
 // El manifiesto es la fuente de verdad; esta sección es el puente
 // entre el data-driven declare y el sistema de imports de Vite.
-
-/**
- * @param {string} importPath — ej. 'src/mockups/EntradaValle3D.jsx'
- * @returns {string} path relativo desde este archivo
- */
-function rel(importPath) {
-  return '../' + importPath.replace(/^src\//, '');
-}
 
 // Los imports lazy se declaran EXPLICITAMENTE para que Vite pueda
 // hacer tree-shaking y code-splitting. El mapa RUTAS abajo los indexa.
@@ -315,8 +307,10 @@ export default function ProdChagraApp() {
 
   useEffect(() => {
     const { view, data } = parseHash();
-    setNavData(data ?? null);
     isAuthenticated().then((autenticado) => {
+      // El navData del deep-link se asienta junto con la vista (asíncrono:
+      // un setState síncrono dentro del effect dispara renders en cascada).
+      setNavData(data ?? null);
       setAuth(autenticado);
       if (autenticado) {
         setCurrentView(view || 'valle3d');
@@ -329,7 +323,7 @@ export default function ProdChagraApp() {
       setAuth(false);
       setCurrentView('login');
     });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleLoginSuccess = useCallback(() => {
     setAuth(true);

--- a/src/prodApp/ProdChagraApp.jsx
+++ b/src/prodApp/ProdChagraApp.jsx
@@ -178,7 +178,9 @@ const LAZY_MAP = {
 /**
  * @typedef {Object} RutaRegistrada
  * @property {string} path
- * @property {React.ComponentType} Lazy
+ * @property {React.ComponentType<any>} Lazy — `any`: cada pantalla declara sus
+ *   props (onBack/onNavigate/initialContext…) y el router pasa el set común;
+ *   los componentes ignoran las que no usan.
  */
 
 /** @type {Map<string, RutaRegistrada>} */
@@ -230,23 +232,75 @@ export default function ProdChagraApp() {
   // debe usarse en un if() síncrono — siempre devuelve Promise truthy.
   const [auth, setAuth] = useState(null);
   const [currentView, setCurrentView] = useState('loading');
+  // Datos de navegación (ej. el contexto espacial que EntradaValle3D manda al
+  // agente). Viajan EN el hash (`#vista/<json-uri>`) — parseHash ya los lee —
+  // para sobrevivir recarga y botón atrás del navegador.
+  const [navData, setNavData] = useState(null);
 
-  const navigate = useCallback((view) => {
+  const navigate = useCallback((view, data = null) => {
     if (!view || view === 'loading') return;
+    // Guard de rutas: las pantallas piden vistas que a veces no existen en el
+    // manifiesto de prod (ej. tiles legacy del dashboard). Ignorar el toque es
+    // mejor que caer al valle "porque sí" (el fallback del router confunde).
+    if (!RUTAS.has(view) && view !== 'login' && view !== 'oauth-callback') return;
     // Detener cualquier audio de la vista anterior antes de montar la nueva.
     // El loop eterno reportado ocurre cuando el audio asíncrono resuelve
     // después del desmontaje del componente 3D.
     try { stopAllAudio(); } catch { /* ttsService puede no estar inicializado */ }
+    setNavData(data ?? null);
     setCurrentView(view);
-    window.location.hash = view === 'valle3d' ? '' : '#' + view;
+    const sufijo = data != null ? '/' + encodeURIComponent(JSON.stringify(data)) : '';
+    window.location.hash = view === 'valle3d' && !sufijo ? '' : '#' + view + sufijo;
   }, []);
+
+  // ── El botón atrás DE LA APP (no confundir con el del navegador): las
+  //    pantallas lo esconden si no reciben `onBack` — sin esto, en una PWA
+  //    instalada (sin barra del navegador) el usuario queda atrapado.
+  const volverAtras = useCallback(() => {
+    if (window.history.length > 1) window.history.back();
+    else navigate('valle3d');
+  }, [navigate]);
+
+  const irAlInicio = useCallback(() => navigate('valle3d'), [navigate]);
+
+  // ── Listeners de navegación GLOBAL. ScreenShell (el header de ~70 pantallas
+  //    2D) despacha `chagra:nav` (botones casa/ayuda/campana) y el flujo del
+  //    agente (EntradaValle3D "Pregúntele a su finca…", AcompananteMundo,
+  //    SeedingLog…) despacha `chagraNavigate`. Los listeners vivían SOLO en
+  //    App.jsx (el shell viejo que main-prod NO monta) → en prod eran botones
+  //    muertos: el operador lo cazó ("el botón de casa y el de ayuda no hacen
+  //    nada"). Aquí es donde el evento por fin aterriza.
+  useEffect(() => {
+    const resolver = (view, data) => {
+      if (!view) return;
+      // En prod 3D-first el INICIO es el valle: el botón casa del ScreenShell
+      // pide 'dashboard' (su destino histórico en el shell viejo) — aquí
+      // significa "volver a casa". `#dashboard` directo sigue funcionando.
+      navigate(view === 'dashboard' ? 'valle3d' : view, data);
+    };
+    /** @param {Event & { detail?: any }} e — detail: string (formato simple) u objeto { view, data }. */
+    const onNavSimple = (e) => {
+      const d = e.detail;
+      if (typeof d === 'string') resolver(d, null);
+      else resolver(d?.view, d?.data ?? null);
+    };
+    /** @param {Event & { detail?: any }} e — detail: { view, initialData } (AgentFab/EscuchaOverlay/valle). */
+    const onNavRico = (e) => resolver(e.detail?.view, e.detail?.initialData ?? e.detail?.data ?? null);
+    window.addEventListener('chagra:nav', onNavSimple);
+    window.addEventListener('chagraNavigate', onNavRico);
+    return () => {
+      window.removeEventListener('chagra:nav', onNavSimple);
+      window.removeEventListener('chagraNavigate', onNavRico);
+    };
+  }, [navigate]);
 
   useEffect(() => {
     const onHash = () => {
-      const { view } = parseHash();
+      const { view, data } = parseHash();
       // Verificar auth de forma asíncrona real (isAuthenticated es async)
       isAuthenticated().then((autenticado) => {
         if (autenticado || view === 'login' || view === 'oauth-callback') {
+          setNavData(data ?? null);
           setCurrentView(view || 'valle3d');
         } else {
           setCurrentView('login');
@@ -260,7 +314,8 @@ export default function ProdChagraApp() {
   }, []);
 
   useEffect(() => {
-    const { view } = parseHash();
+    const { view, data } = parseHash();
+    setNavData(data ?? null);
     isAuthenticated().then((autenticado) => {
       setAuth(autenticado);
       if (autenticado) {
@@ -302,9 +357,26 @@ export default function ProdChagraApp() {
 
   if (!Componente) return <ChagraGrowLoader />;
 
+  // El HOME (valle 3D) no lleva `onBack`: no hay a dónde volver desde casa
+  // (las pantallas esconden/muestran su botón según llegue la prop).
+  const esHome = !ruta || ruta.path === 'valle3d';
+
   return (
     <Suspense fallback={<ChagraGrowLoader />}>
-      <Componente />
+      {/* Las pantallas se montaban SIN PROPS: todo CTA interno que llamara
+          `onNavigate`/`onBack` quedaba muerto — y el dashboard directamente
+          CRASHEABA (onClick={() => onNavigate(...)} sin guard → TypeError →
+          ErrorBoundary raíz). Cada componente toma las props que declare e
+          ignora el resto (initialContext la usa AgentScreen; initialMundoId,
+          el valle en deep-links `#valle3d/"agua"`). */}
+      <Componente
+        onBack={esHome ? undefined : volverAtras}
+        onHome={irAlInicio}
+        onNavigate={navigate}
+        initialData={navData ?? undefined}
+        initialContext={navData ?? undefined}
+        initialMundoId={esHome && typeof navData === 'string' ? navData : undefined}
+      />
     </Suspense>
   );
 }

--- a/src/prodApp/wire3DNav.js
+++ b/src/prodApp/wire3DNav.js
@@ -25,7 +25,9 @@ export const RUTA_2D_DESDE_3D = {
   mercado: 'mercados',
   semillero: 'semilla',
   disenio: 'biodiversidad',
-  micorrizas: null, // todavía no hay ruta 2D equivalente
+  // Los hongos no tienen pantalla propia todavía: el mundo subterráneo
+  // (subsuelo) es su casa 2D hasta entonces (fix del director, DIRECCION #3).
+  micorrizas: 'subsuelo',
   bosque_vivo: 'bosque_vivo',
 
   // ── Sub-hotspots de cada escena 3D (mundoData.js hotspots con view:) ─

--- a/src/visual/mundo3d/bosque/floraParamo.geom.js
+++ b/src/visual/mundo3d/bosque/floraParamo.geom.js
@@ -177,9 +177,14 @@ function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
   return geo;
 }
 
-/** Fusiona la lista de partes (ya coloreadas) en UNA geometría indexada. */
+/** Fusiona la lista de partes (ya coloreadas) en UNA geometría.
+    OJO: los poliedros (Icosahedron) son NO-indexados y el resto sí — merge
+    directo devolvía null EN SILENCIO y la especie quedaba invisible (aliso y
+    gaque no se dibujaban en prod; tercera mordida de esta trampa). Se
+    uniformiza todo a no-indexado antes de fusionar (mismo fix ya probado en
+    dev, fable/direccion-valle). */
 function fusionar(partes) {
-  const buenas = partes.filter(Boolean);
+  const buenas = partes.filter(Boolean).map((g) => (g.index ? g.toNonIndexed() : g));
   const g = mergeGeometries(buenas, false);
   // Las partes de entrada nunca tocaron la GPU: quedan para el GC.
   return g;

--- a/src/visual/mundo3d/direccion/composicionValle.js
+++ b/src/visual/mundo3d/direccion/composicionValle.js
@@ -1,0 +1,219 @@
+/*
+ * composicionValle — LA DIRECCIÓN DEL VALLE como datos puros (cero three, cero DOM).
+ *
+ * El valle 3D es la CASA de Chagra: lo primero que ve el campesino y desde
+ * donde sale a todo. Este módulo escribe la dirección que antes estaba
+ * implícita (o ausente): dónde va cada cosa y POR QUÉ, qué manda y qué
+ * acompaña, por dónde camina el ojo. Valle3D lo consume como capa de
+ * composición ENCIMA de valleData (que no se toca: otros frentes viven ahí).
+ *
+ * ── LOS TRES CRITERIOS DEL ENCUADRE ──────────────────────────────────────
+ * La cámara de reposo mira desde [10.5, 9, 13.5] hacia [0, 1.6, 1.4]:
+ * el frente (+z, tierra caliente) queda CERCA y abajo; la ladera trepa al
+ * páramo (-z) al fondo. De ahí las tres franjas de dirección:
+ *
+ *   1. LO DIARIO, A LA MANO (frente, cerca de la casa): lo que el campesino
+ *      toca todos los días — el corral, las eras, el semillero, la huerta.
+ *      La finca real es así: el trajín vive alrededor de la casa.
+ *   2. LO SEMANAL, A MEDIA LADERA: la milpa, el cafetal, el agua. Se sube
+ *      a ellos; el ojo los alcanza sin estorbar el frente.
+ *   3. LO CONTEMPLATIVO, AL FONDO: el monte, la veleta en el filo del
+ *      páramo. Son horizonte: se miran más de lo que se tocan.
+ *
+ * ── EL ANCLA: LA CASA ────────────────────────────────────────────────────
+ * Toda finca se organiza alrededor de su casa, y el valle no tenía una: el
+ * ojo descansaba en pasto vacío. La casa campesina (encalada, zócalo pintado,
+ * techo de teja, la ventana con luz cálida) va donde la mirada de reposo
+ * aterriza — no es un mundo navegable, es el HOGAR: el punto de silencio
+ * del cuadro. Los senderos nacen de ella: el camino dice qué se usa.
+ */
+
+/* ── 1. LA CASA (ancla de composición, no navegable) ─────────────────────
+   Apenas a la izquierda del punto de mira de reposo ([0, 1.6, 1.4]) para
+   componer por tercios: la casa descansa, la quebrada brilla a su derecha,
+   y el faro de la alerta queda con aire propio al frente. */
+export const CASA_VALLE = {
+  pos: [-0.9, 2.6], // [x, z] — la y la da el terreno
+  rotY: 0.42, // el corredor mira hacia la cámara de reposo (suroriente)
+};
+
+/* ── 2. DISPOSICIÓN COMPUESTA de los lugares ─────────────────────────────
+   Override de posición [x, z] por id de mundo. Solo se mueven los que
+   estaban puestos sin componer; los bien contados (agua sobre la quebrada,
+   la veleta en el filo del páramo, el bosque trepando al frío, el cafetal
+   en su piso) se quedan. Reglas duras que cumplen estas coordenadas:
+     · aire mínimo ~2 u entre lugares vecinos (los rótulos ya anti-colisionan
+       en pantalla; esto compone la GEOMETRÍA, no las etiquetas);
+     · cada lugar respeta su piso térmico (valleData.PISOS_TERMICOS);
+     · lo diario rodea la casa; las salidas (mercado) van al borde del cuadro. */
+export const COMPOSICION_LUGARES = {
+  // El corral cierra la esquina izquierda del frente: lo diario, con aire.
+  animales: [-5.4, 5.8],
+  // El semillero entre el corral y las eras, un paso adelante (se cría cerca).
+  semillero: [-3.5, 6.5],
+  // Las eras al frente-izquierda de la casa: donde el faro del día se lee solo.
+  suelo: [-1.6, 5.0],
+  // La huerta ES "la huerta de la casa" (su propia narración): pegada a ella.
+  sanidad: [3.4, 4.4],
+  // El mercado es LA SALIDA a la plaza: borde derecho-frontal, el camino que
+  // se va del cuadro. Antes tapaba el centro-bajo del encuadre.
+  mercado: [4.9, 6.3],
+  // Los hongos en el corazón cultivado, con aire de la casa y de la milpa.
+  micorrizas: [-3.2, 3.7],
+  // La milpa cede un paso a la izquierda para darle aire a los hongos.
+  cultivos: [-5.2, 2.2],
+};
+
+/**
+ * Aplica la disposición compuesta a una lista de mundos del valle
+ * (valleData.MUNDOS_VALLE o equivalente). CUALQUIER vista del valle — la
+ * escena 3D, el gemelo 2D, el fallback dibujado — debe pasar por aquí para
+ * que el mapa sea EL MISMO lugar en todas partes.
+ * @template {{ id: string, pos: number[] }} M
+ * @param {M[]} mundos
+ * @returns {M[]}
+ */
+export function componerMundos(mundos) {
+  return mundos.map((m) => {
+    const pos = COMPOSICION_LUGARES[m.id];
+    return pos ? { ...m, pos: [pos[0], 0, pos[1]] } : m;
+  });
+}
+
+/* ── 3. LOS SENDEROS (la mano del campesino sobre el terreno) ────────────
+   Caminos de tierra pisada que NACEN de la casa: el rastro honesto del uso
+   diario. No son UI — son el valle contando qué se camina. Waypoints [x, z];
+   la y la posa el terreno. `frugal: true` = también en gama media/baja
+   (los principales); el resto solo donde sobra GPU. */
+export const SENDEROS_VALLE = [
+  {
+    id: 'trajin', // casa → eras → semillero → corral: el circuito de la mañana
+    puntos: [[-0.9, 3.0], [-1.6, 4.6], [-3.3, 6.1], [-5.0, 5.9]],
+    frugal: true,
+  },
+  {
+    id: 'plaza', // casa → huerta → mercado → y SALE del cuadro (a la vereda)
+    puntos: [[-0.4, 2.9], [1.4, 4.0], [3.2, 4.7], [4.8, 6.2], [6.6, 7.8]],
+    frugal: true,
+  },
+  {
+    id: 'milpa', // casa → los hongos → la milpa (la subida del lote)
+    puntos: [[-1.3, 2.5], [-3.0, 3.4], [-5.0, 2.4]],
+    frugal: false,
+  },
+  {
+    id: 'agua', // casa → la toma de la quebrada (el viaje del balde)
+    puntos: [[-0.5, 2.2], [0.5, 1.0], [1.3, 0.1]],
+    frugal: false,
+  },
+];
+
+/* ── 4. LOS PATIOS (tierra pisada bajo cada lugar navegable) ─────────────
+   El suelo desnudo donde se trabaja: la señal diegética de "aquí se llega"
+   — el sendero desemboca en un patio, el patio sostiene el lugar. Afordancia
+   sin UI: se entiende sin leer nada. */
+export const PATIO = {
+  radioBase: 0.92, // × escala del lugar
+  color: '#96703f', // tierra pisada: más clara que el pasto, más viva que el barro
+  opacidad: 0.42,
+};
+
+/* ── 5. JERARQUÍA DE PERSONAJES (la ley, en números) ─────────────────────
+   ANGELITA GUÍA. Es la cara de la IA y la compañera de viaje: vuela en
+   primer plano, la cámara la sigue (DirectorValle.follow) y es la única con
+   luz propia. Pero el valle NO es solo suyo — feedback del operador
+   (2026-07-14): "los personajes como el oso y demás aparecen como
+   secundarias a la abejita". Los demás son VECINOS con casa propia: cada uno
+   vive en su rincón del valle con presencia digna (escala real, no garnish
+   de 30px), y la puesta en escena — no el tamaño de Angelita — dice quién
+   guía. Ninguno captura toques: presencia, no interfaz. */
+export const JERARQUIA_PERSONAJES = {
+  /** La guía del valle: la única con follow de cámara y luz propia. */
+  protagonista: 'abeja-angelita',
+  /** Tamaño vivo de Angelita (px del billboard; crece con su energía). */
+  protagonistaPx: [44, 58],
+  /** La luz cálida que la sigue: SOLO ella ilumina (perfil.luzBeacon). */
+  luzProtagonista: { color: '#ffdda6', intensidad: 0.85, alcance: 3.6 },
+  /** Techo de un vecino (px): puede igualar el piso de Angelita (el oso es
+      el mayor de los vecinos), nunca su tamaño pleno ni su primer plano. */
+  vecinoMaxPx: 44,
+  /** Los vecinos viven en SUS lugares (monte, quebrada, matorral), nunca en
+      el centro del encuadre (radio en unidades de mundo alrededor de la mira). */
+  radioSagradoCentro: 3.2,
+  /** Los vecinos jamás capturan toques ni voz: presencia, no interfaz. */
+  interactivos: false,
+};
+
+/* ── 6. LOS VECINOS DEL VALLE (la puesta en escena de los personajes) ─────
+   Personajes rubber-hose, cada uno EN SU CASA del valle: el oso en el borde
+   del monte, la rana en la quebrada, el perezoso en la arboleda. Data-driven
+   contra CREATURES: un slug ausente no monta nada (las ramas de personajes
+   mejoran el dibujo al mergear y este mapa ni se entera).
+
+   `franjas` = cuándo sale (null = siempre): el borugo es crepuscular y el
+   jaguar es un aparecido del amanecer, el atardecer y la niebla — verlo es
+   un premio, no un mueble. Eso también es jerarquía: la frecuencia cuenta.
+
+   Ubicaciones verificadas contra la cámara de reposo ([10.5,9,13.5] →
+   [0,1.6,1.4], fov 40): todas a la vista, ninguna detrás de la cordillera
+   (los picos viven en z≤-15) ni tapada por un lugar compuesto (aire ≥2u del
+   mapa COMPOSICION_LUGARES). El precedente de la sierra (3 de 4 árboles
+   ocultos tras el macizo) no se repite acá. */
+export const VECINOS_VALLE = [
+  {
+    slug: 'oso-andino',
+    punto: [5.4, -1.2], // el borde del monte, junto al bosque que trepa al frío
+    px: 44, // el mayor de los vecinos: presencia de verdad, no miniatura
+    factor: 9, // presencia del mayor: casi el factor de Angelita (9)
+    dy: 0.3,
+    franjas: null, // el oso ronda a toda hora
+  },
+  {
+    slug: 'perezoso',
+    punto: [3.1, -2.2], // colgado a la falda de la arboleda, detrás del oso
+    px: 30,
+    factor: 8,
+    dy: 1.5, // vive arriba, en las ramas
+    franjas: null,
+  },
+  {
+    slug: 'ardilla',
+    punto: [3.2, -1.2], // entre el cafetal y el monte, siempre de paso
+    px: 26,
+    factor: 7.5,
+    dy: 0.25,
+    franjas: null,
+  },
+  {
+    slug: 'rana-andina',
+    punto: [2.4, 2.8], // la orilla baja de la quebrada (el agua es su casa)
+    px: 22,
+    factor: 6.5,
+    dy: 0.18,
+    franjas: null,
+  },
+  {
+    slug: 'morrocoy',
+    punto: [3.2, 6.8], // la tierra caliente del frente, a paso lento
+    px: 26,
+    factor: 7,
+    dy: 0.2,
+    franjas: null,
+  },
+  {
+    slug: 'borugo',
+    punto: [-6.4, 0.4], // el matorral del borde izquierdo, a media ladera
+    px: 34,
+    factor: 8.5,
+    dy: 0.25,
+    franjas: ['atardecer', 'dorada', 'noche', 'amanecer'], // crepuscular real
+  },
+  {
+    slug: 'jaguar',
+    punto: [-5.8, -4.6], // el filo del páramo, lejos, del lado de la veleta: el místico
+    px: 40,
+    factor: 10, // lejos pero con silueta: verlo tiene que sentirse
+    dy: 0.3,
+    franjas: ['amanecer', 'atardecer', 'niebla'], // aparecido, no mueble
+  },
+];

--- a/src/visual/mundo3d/transiciones/CamaraCruce.jsx
+++ b/src/visual/mundo3d/transiciones/CamaraCruce.jsx
@@ -1,0 +1,124 @@
+/*
+ * CamaraCruce — la CÁMARA del cruce Odyssey: el viaje que hace sentir que uno
+ * se MUEVE de un lugar a otro, no que la pantalla cambió.
+ *
+ * Mitad 3D del lenguaje de transición (la mitad DOM es VeloOdyssey). Vive en
+ * archivo propio a propósito: importa three/r3f, así que pertenece al chunk
+ * vendor-three — el barrel `transiciones/index.js` NO lo re-exporta para no
+ * arrastrar three al bundle base (mismo patrón que CamaraNewDonk).
+ *
+ * EL VIAJE (curvaCruce de velosData — la MISMA alma que el velo DOM):
+ *   · ENTRANDO (hacia el umbral del mundo): la cámara primero se RECOGE un
+ *     respiro hacia atrás (anticipación: k<0 — toma aire), se lanza hacia
+ *     adentro con el FOV cerrándose (efecto túnel: el mundo lo absorbe a uno)
+ *     y ATERRIZA pasándose un pelo del punto (overshoot) antes de asentar.
+ *   · SALIENDO (de regreso a casa): sin anticipación ni rebote — la cámara
+ *     EXHALA hacia afuera con el FOV reabriéndose. Volver es más suave que
+ *     ir: uno ya conoce el camino.
+ *   · REPOSO ('casa' | 'umbral'): respiración sutil de cámara viva (se apaga
+ *     con reducedMotion — el encuadre queda quieto, presente).
+ *
+ * La máquina no conoce la escena: el host aporta las DOS poses y decide qué
+ * renderiza a cada lado (mismo contrato que CamaraOdyssey/TunelOdyssey).
+ *
+ * PROPS
+ *   fase           'entrando' | 'saliendo' | 'casa' | 'umbral'
+ *   poseCasa       { pos, mira, fov } — el encuadre del mundo de origen
+ *   poseUmbral     { pos, mira, fov } — el encuadre metido en el destino
+ *   tier           'alto'|'medio'|'bajo' — bajo acorta el viaje (×0.7)
+ *   reducedMotion  bool — corte: la cámara SALTA a la pose final, sin viaje
+ *   viajeSegundos  duración del dolly (default asimétrico: 1.35 ir, 1.05 volver)
+ *   onLlegada      (fase) => void — una vez, al asentar el dolly
+ *
+ * Construya poses sin tocar three con `poseDesdeArrays` (abajo).
+ */
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { useFrame, useThree } from '@react-three/fiber';
+import { curvaCruce, FACTOR_TIER_BAJO } from './velosData.js';
+
+/** Pose de cámara desde arrays planos (el host no necesita importar three). */
+export function poseDesdeArrays({ pos, mira, fov = 44 }) {
+  return {
+    pos: new THREE.Vector3(pos[0], pos[1], pos[2]),
+    mira: new THREE.Vector3(mira[0], mira[1], mira[2]),
+    fov,
+  };
+}
+
+function aplicarFov(camera, fov) {
+  if (Math.abs(camera.fov - fov) < 0.01) return;
+  const focal = (0.5 * camera.getFilmHeight()) / Math.tan(THREE.MathUtils.degToRad(fov) / 2);
+  camera.setFocalLength(focal);
+}
+
+/** Duración por defecto del dolly: ir pesa más que volver. */
+const SEGUNDOS = { entrando: 1.35, saliendo: 1.05 };
+
+export function CamaraCruce({
+  fase = 'casa',
+  poseCasa,
+  poseUmbral,
+  tier = 'alto',
+  reducedMotion = false,
+  viajeSegundos,
+  onLlegada,
+}) {
+  const { camera } = useThree();
+  const anim = useRef({ fasePrevia: null, t: 0, avisado: false });
+  const llegadaRef = useRef(onLlegada);
+  const miraTemporal = useRef(new THREE.Vector3());
+
+  useEffect(() => {
+    llegadaRef.current = onLlegada;
+  });
+
+  useFrame((state, dt) => {
+    const a = anim.current;
+    if (a.fasePrevia !== fase) {
+      a.fasePrevia = fase;
+      a.t = 0;
+      a.avisado = false;
+    }
+    const entra = fase === 'entrando';
+    const sale = fase === 'saliendo';
+
+    if (entra || sale) {
+      const dur =
+        (viajeSegundos ?? SEGUNDOS[entra ? 'entrando' : 'saliendo']) *
+        (tier === 'bajo' ? FACTOR_TIER_BAJO : 1);
+      a.t = Math.min(1, a.t + (reducedMotion ? 1 : Math.min(dt, 0.05) / dur));
+      // La MISMA curva del velo DOM: anticipación (k<0) y, al entrar,
+      // aterrizaje con overshoot (k>1). Volver exhala sin rebote.
+      const k = curvaCruce(a.t, { descubre: entra });
+      const desde = entra ? poseCasa : poseUmbral;
+      const hasta = entra ? poseUmbral : poseCasa;
+      camera.position.lerpVectors(desde.pos, hasta.pos, k);
+      miraTemporal.current.lerpVectors(desde.mira, hasta.mira, k);
+      camera.lookAt(miraTemporal.current);
+      // FOV: entrar se CIERRA tarde (k²: el túnel aprieta al final); volver
+      // se REABRE temprano (√k: la casa se ensancha apenas arranca).
+      const kc = Math.min(1, Math.max(0, k));
+      const kFov = entra ? kc * kc : Math.sqrt(kc);
+      aplicarFov(camera, desde.fov + (hasta.fov - desde.fov) * kFov);
+      if (a.t >= 1 && !a.avisado) {
+        a.avisado = true;
+        llegadaRef.current?.(fase);
+      }
+      return;
+    }
+
+    // Reposo: respiración de cámara viva (quieta bajo reducedMotion).
+    const pose = fase === 'umbral' ? poseUmbral : poseCasa;
+    const t = reducedMotion ? 0 : state.clock.elapsedTime;
+    camera.position.set(
+      pose.pos.x + Math.sin(t * 0.16) * 0.35,
+      pose.pos.y + Math.sin(t * 0.11) * 0.14,
+      pose.pos.z + Math.cos(t * 0.13) * 0.28,
+    );
+    camera.lookAt(pose.mira);
+    aplicarFov(camera, pose.fov);
+  });
+
+  return null;
+}

--- a/src/visual/mundo3d/transiciones/CamaraCruce.jsx
+++ b/src/visual/mundo3d/transiciones/CamaraCruce.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react-refresh/only-export-components -- exporta el helper
+   poseDesdeArrays junto con la cámara (API del módulo de transiciones). */
 /*
  * CamaraCruce — la CÁMARA del cruce Odyssey: el viaje que hace sentir que uno
  * se MUEVE de un lugar a otro, no que la pantalla cambió.

--- a/src/visual/mundo3d/transiciones/VeloOdyssey.jsx
+++ b/src/visual/mundo3d/transiciones/VeloOdyssey.jsx
@@ -1,0 +1,260 @@
+/*
+ * VeloOdyssey — el velo/cortina del cruce entre mundos, con identidad andina.
+ *
+ * Norte Odyssey: pasar de un mundo a otro (valle ↔ bosque ↔ suelo ↔ sierra)
+ * es un MOMENTO, no un corte. Este componente es la mitad DOM del lenguaje
+ * (overlay puro, CERO three, offline); la mitad 3D vive aparte en
+ * `CamaraCruce.jsx` (chunk vendor-three) y respira con la MISMA curva.
+ *
+ * El velo lo elige el DESTINO (velosData.familiaDeVelo):
+ *   · niebla — bancos de bruma del páramo que envuelven (sierra/agua/altura);
+ *   · tierra — el suelo se abre y lo traga a uno (suelo/microsuelo/compost);
+ *   · hojas  — remolino de follaje que cierra el monte (bosque/restauración);
+ *   · luz    — la luz dorada de la casa (valle/hogar, y el default digno).
+ *
+ * ASIMETRÍA: `fase="entrando"` descubre (ceremonial, overshoot al revelar);
+ * `fase="saliendo"` regresa a casa (más corto, tibio, exhala sin rebote).
+ * Cada velo tiene DOS coreografías distintas — no es la misma al revés.
+ *
+ * CONTRATO TEMPORAL (el mismo de TransicionMundo/TransicionMundoKit):
+ * los callbacks los disparan timers JS deterministas, NUNCA `animationend`
+ * (pestañas en segundo plano, throttling). El CSS anima "a ciegas" con la
+ * misma duración via `--vo-ms`.
+ *   · `onCubierto` — pantalla 100% cubierta (54% del viaje, centro de la
+ *     meseta 46%–62%): AQUÍ el host intercambia la escena DEBAJO;
+ *   · `onFin`      — mundo revelado, overlay inerte: desmonte con fase=null.
+ * Cada uno se llama a lo sumo UNA vez por activación.
+ *
+ * TIER-SAFE: gama baja conserva el MISMO velo (identidad intacta) sin
+ * decoraciones (jirones/hojas/piedritas/halos/boil) y 30% más corto — nunca
+ * una pantalla en blanco. `reducedMotion` colapsa a un corte simple digno
+ * con el tinte del velo.
+ *
+ * PROPS
+ *   fase          null | 'entrando' | 'saliendo' — null no monta nada.
+ *   destino       mundoId o familia ('bosque_vivo', 'microsuelo', 'sierra'…).
+ *   velo          override explícito de la identidad ('niebla'|'tierra'|…).
+ *   tier          'alto'|'medio'|'bajo' (deviceTier.decidirTier().tier).
+ *   reducedMotion bool (deviceTier.decidirTier().reducedMotion).
+ *   letrero       texto bajo el velo. Default: al volver, "De vuelta a casa…";
+ *                 al entrar, nada (que hable el mundo). Pase '' para mudo.
+ *   onCubierto / onFin  callbacks del contrato temporal.
+ *
+ * CABLEO SUGERIDO (lo hace Opus — este archivo no toca nada existente):
+ *   el host monta `<VeloOdyssey fase={viaje.fase} destino={viaje.destino}…/>`
+ *   como hermano del canvas; en `onCubierto` hace el swap de escena; en
+ *   `onFin` apaga la fase. O directo con el hook `useCruceMundo`.
+ */
+import { useEffect, useRef } from 'react';
+import { VELOS, familiaDeVelo, duracionCruce, momentoCubierto } from './velosData.js';
+import './veloOdyssey.css';
+
+/* Hoja rubber-hose mínima: silueta gorda + vena, sin detalle que no se lea. */
+function HojaSvg({ claro, profundo }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M12 1.5 C 18.5 6, 20.5 14, 12 22.5 C 3.5 14, 5.5 6, 12 1.5 Z" fill={claro} />
+      <path
+        d="M12 3.5 C 12 9, 12 15, 12 21 M12 9 C 10 10, 9 11, 8.2 12.4 M12 13 C 14 14, 15 15, 15.8 16.4"
+        stroke={profundo}
+        strokeWidth="1.1"
+        strokeLinecap="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+/* Horizonte del suelo: terrones, matas de pasto y una que otra raicilla. */
+const PATH_HORIZONTE =
+  'M0,10 L0,6.2 C5,4.8 8,6.8 13,6 L14.2,3.2 L15.4,6 C23,5.2 27,7 35,6.2 ' +
+  'C39,5.7 41,3.6 43,3.6 C45,3.6 46,6.1 51,6.1 C59,6.6 63,4.6 71,5.1 ' +
+  'L72.8,2.6 L74.6,5.6 C82,5 88,7 100,5.9 L100,10 Z';
+
+export default function VeloOdyssey({
+  fase = null,
+  destino = 'valle',
+  velo = undefined,
+  tier = 'medio',
+  reducedMotion = false,
+  letrero = undefined,
+  onCubierto = undefined,
+  onFin = undefined,
+}) {
+  const cubiertoRef = useRef(onCubierto);
+  const finRef = useRef(onFin);
+  // Refs "última versión": se actualizan en un effect (no en render) para que
+  // los timers llamen siempre al callback más fresco sin re-armarse.
+  useEffect(() => {
+    cubiertoRef.current = onCubierto;
+    finRef.current = onFin;
+  });
+
+  const activo = fase === 'entrando' || fase === 'saliendo';
+  const veloId = velo || familiaDeVelo(destino);
+
+  useEffect(() => {
+    if (!activo) return undefined;
+    let hechoCubierto = false;
+    let hechoFin = false;
+    const f = /** @type {'entrando'|'saliendo'} */ (fase);
+    const t = /** @type {'alto'|'medio'|'bajo'} */ (tier);
+    const tCubierto = setTimeout(() => {
+      if (!hechoCubierto) {
+        hechoCubierto = true;
+        cubiertoRef.current?.();
+      }
+    }, momentoCubierto(veloId, f, t, reducedMotion));
+    const tFin = setTimeout(() => {
+      if (!hechoFin) {
+        hechoFin = true;
+        finRef.current?.();
+      }
+    }, duracionCruce(veloId, f, t, reducedMotion));
+    return () => {
+      hechoCubierto = true;
+      hechoFin = true;
+      clearTimeout(tCubierto);
+      clearTimeout(tFin);
+    };
+  }, [activo, fase, veloId, tier, reducedMotion]);
+
+  if (!activo) return null;
+
+  const total = duracionCruce(
+    veloId,
+    /** @type {'entrando'|'saliendo'} */ (fase),
+    /** @type {'alto'|'medio'|'bajo'} */ (tier),
+    reducedMotion,
+  );
+  const v = VELOS[veloId] ? veloId : 'luz';
+  const { claro, medio, profundo } = VELOS[v];
+  const estilo = {
+    '--vo-claro': claro,
+    '--vo-medio': medio,
+    '--vo-profundo': profundo,
+    '--vo-ms': `${total}ms`,
+  };
+  // Asimetría del texto: volver acoge por defecto; entrar deja hablar al mundo.
+  const texto = letrero !== undefined ? letrero : fase === 'saliendo' ? 'De vuelta a casa…' : '';
+  const conAdornos = tier !== 'bajo' && !reducedMotion;
+  const adornosPlenos = tier === 'alto' && !reducedMotion;
+
+  if (reducedMotion) {
+    return (
+      <div
+        className="vo"
+        data-velo={v}
+        data-fase={fase}
+        data-tier={tier}
+        data-reducida="1"
+        style={estilo}
+        role="status"
+        aria-live="polite"
+        data-testid="velo-odyssey"
+      >
+        <div className="vo__corte" aria-hidden="true" />
+        {texto ? <p className="vo__letrero" style={{ opacity: 1, animation: 'none' }}>{texto}</p> : null}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="vo"
+      data-velo={v}
+      data-fase={fase}
+      data-tier={tier}
+      data-reducida="0"
+      style={estilo}
+      role="status"
+      aria-live="polite"
+      data-testid="velo-odyssey"
+    >
+      {v === 'niebla' && (
+        <>
+          <div className="vo__manto" aria-hidden="true" />
+          {conAdornos && <div className="vo__jiron vo__jiron--1" aria-hidden="true" />}
+          {conAdornos && <div className="vo__jiron vo__jiron--2" aria-hidden="true" />}
+          {adornosPlenos && <div className="vo__jiron vo__jiron--3" aria-hidden="true" />}
+        </>
+      )}
+
+      {v === 'tierra' && (
+        <div className="vo__suelo" aria-hidden="true">
+          <svg
+            className="vo__horizonte vo__horizonte--frente"
+            viewBox="0 0 100 10"
+            preserveAspectRatio="none"
+          >
+            <path d={PATH_HORIZONTE} />
+          </svg>
+          <div className="vo__suelo-cuerpo">
+            {conAdornos && (
+              <>
+                <span className="vo__piedrita vo__piedrita--1" />
+                <span className="vo__piedrita vo__piedrita--2" />
+                <span className="vo__piedrita vo__piedrita--3" />
+                {adornosPlenos && <span className="vo__piedrita vo__piedrita--4" />}
+              </>
+            )}
+          </div>
+          {conAdornos && (
+            <svg
+              className="vo__horizonte vo__horizonte--cola"
+              viewBox="0 0 100 10"
+              preserveAspectRatio="none"
+            >
+              <path d={PATH_HORIZONTE} />
+            </svg>
+          )}
+        </div>
+      )}
+
+      {v === 'hojas' && (
+        <>
+          <div className="vo__fronda" aria-hidden="true" />
+          {conAdornos && (
+            <>
+              <div className="vo__hoja vo__hoja--1" aria-hidden="true">
+                <HojaSvg claro={claro} profundo={profundo} />
+              </div>
+              <div className="vo__hoja vo__hoja--3" aria-hidden="true">
+                <HojaSvg claro={medio} profundo={profundo} />
+              </div>
+            </>
+          )}
+          {adornosPlenos && (
+            <>
+              <div className="vo__hoja vo__hoja--2" aria-hidden="true">
+                <HojaSvg claro={claro} profundo={profundo} />
+              </div>
+              <div className="vo__hoja vo__hoja--4" aria-hidden="true">
+                <HojaSvg claro={medio} profundo={profundo} />
+              </div>
+              <div className="vo__hoja vo__hoja--5" aria-hidden="true">
+                <HojaSvg claro={claro} profundo={profundo} />
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      {v === 'luz' &&
+        (fase === 'entrando' ? (
+          <>
+            <div className="vo__destello" aria-hidden="true" />
+            {adornosPlenos && <div className="vo__halo" aria-hidden="true" />}
+            {adornosPlenos && <div className="vo__halo vo__halo--2" aria-hidden="true" />}
+          </>
+        ) : (
+          <>
+            <div className="vo__abrazo" aria-hidden="true" />
+            {adornosPlenos && <div className="vo__halo" aria-hidden="true" />}
+          </>
+        ))}
+
+      {texto ? <p className="vo__letrero">{texto}</p> : null}
+    </div>
+  );
+}

--- a/src/visual/mundo3d/transiciones/index.js
+++ b/src/visual/mundo3d/transiciones/index.js
@@ -1,0 +1,32 @@
+/*
+ * transiciones — el lenguaje de transición Odyssey entre mundos de Chagra.
+ *
+ * Barrel DOM-SAFE: nada de aquí importa three. La mitad 3D (la cámara del
+ * cruce) se importa DIRECTO desde su archivo para quedar en el chunk
+ * vendor-three del host que la use:
+ *
+ *   import { CamaraCruce, poseDesdeArrays } from './transiciones/CamaraCruce.jsx';
+ *
+ * Piezas:
+ *   · VeloOdyssey    — el velo/cortina con identidad andina por destino;
+ *   · useCruceMundo  — la máquina de estados del viaje (entrar/volver/swap);
+ *   · velosData      — datos y reloj puros (velos, duraciones, curvaCruce).
+ */
+export { default as VeloOdyssey } from './VeloOdyssey.jsx';
+export { useCruceMundo } from './useCruceMundo.js';
+export {
+  VELOS,
+  VELO_IDS,
+  familiaDeVelo,
+  veloDeDestino,
+  duracionCruce,
+  momentoCubierto,
+  curvaCruce,
+  ANTICIPACION_FRAC,
+  CUBIERTO_FRAC,
+  REDUCIDA_MS,
+  FACTOR_TIER_BAJO,
+  EASE_LANZA,
+  EASE_DESCUBRE,
+  EASE_REGRESA,
+} from './velosData.js';

--- a/src/visual/mundo3d/transiciones/useCruceMundo.js
+++ b/src/visual/mundo3d/transiciones/useCruceMundo.js
@@ -22,14 +22,18 @@
  * `cruce.fase` ('quieto'|'entrando'|'saliendo') y `cruce.destino` sirven de
  * insumo para la CamaraCruce si el host tiene canvas 3D. DOM puro, cero three.
  */
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export function useCruceMundo({ tier = 'medio', reducedMotion = false, onSwap = undefined } = {}) {
   const [estado, setEstado] = useState({ fase: 'quieto', destino: null });
+  // Refs "última versión": se actualizan en un effect (no en render) para que
+  // los timers llamen siempre al callback/estado más fresco sin re-armarse.
   const swapRef = useRef(onSwap);
-  swapRef.current = onSwap;
   const estadoRef = useRef(estado);
-  estadoRef.current = estado;
+  useEffect(() => {
+    swapRef.current = onSwap;
+    estadoRef.current = estado;
+  });
 
   const entrar = useCallback((destino) => {
     setEstado((e) => (e.fase === 'quieto' ? { fase: 'entrando', destino } : e));

--- a/src/visual/mundo3d/transiciones/useCruceMundo.js
+++ b/src/visual/mundo3d/transiciones/useCruceMundo.js
@@ -1,0 +1,77 @@
+/*
+ * useCruceMundo — la máquina de estados del cruce Odyssey, lista para cablear.
+ *
+ * Envuelve el ciclo completo de un viaje entre mundos para que el host no
+ * cronometre nada a mano:
+ *
+ *   quieto ──entrar(destino)──▶ entrando ──(velo cubre, onSwap)──▶ entrando
+ *          ◀──────(velo revela: onFin)────────────────────────────┘
+ *   quieto ──volver()─────────▶ saliendo ──(velo cubre, onSwap)──▶ …
+ *
+ * El swap REAL de escena lo hace el host en `onSwap(destino|null)` — se
+ * dispara exactamente cuando la pantalla está 100% cubierta (contrato del
+ * velo). `destino=null` significa "de vuelta a casa".
+ *
+ * USO
+ *   const cruce = useCruceMundo({ tier, reducedMotion, onSwap });
+ *   …
+ *   <button onClick={() => cruce.entrar('bosque_vivo')}>al bosque</button>
+ *   <button onClick={cruce.volver}>a casa</button>
+ *   <VeloOdyssey {...cruce.propsVelo} />
+ *
+ * `cruce.fase` ('quieto'|'entrando'|'saliendo') y `cruce.destino` sirven de
+ * insumo para la CamaraCruce si el host tiene canvas 3D. DOM puro, cero three.
+ */
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+export function useCruceMundo({ tier = 'medio', reducedMotion = false, onSwap = undefined } = {}) {
+  const [estado, setEstado] = useState({ fase: 'quieto', destino: null });
+  const swapRef = useRef(onSwap);
+  swapRef.current = onSwap;
+  const estadoRef = useRef(estado);
+  estadoRef.current = estado;
+
+  const entrar = useCallback((destino) => {
+    setEstado((e) => (e.fase === 'quieto' ? { fase: 'entrando', destino } : e));
+  }, []);
+
+  const volver = useCallback(() => {
+    setEstado((e) => (e.fase === 'quieto' ? { fase: 'saliendo', destino: e.destino } : e));
+  }, []);
+
+  const alCubierto = useCallback(() => {
+    const e = estadoRef.current;
+    swapRef.current?.(e.fase === 'saliendo' ? null : e.destino);
+  }, []);
+
+  const alFin = useCallback(() => {
+    setEstado((e) =>
+      e.fase === 'saliendo' ? { fase: 'quieto', destino: null } : { fase: 'quieto', destino: e.destino },
+    );
+  }, []);
+
+  const propsVelo = useMemo(
+    () => ({
+      fase: estado.fase === 'quieto' ? null : estado.fase,
+      destino: estado.destino || 'valle',
+      tier,
+      reducedMotion,
+      onCubierto: alCubierto,
+      onFin: alFin,
+    }),
+    [estado, tier, reducedMotion, alCubierto, alFin],
+  );
+
+  return {
+    /** 'quieto' | 'entrando' | 'saliendo' */
+    fase: estado.fase,
+    /** mundoId del destino del viaje en curso (o del mundo donde se está). */
+    destino: estado.destino,
+    /** ¿hay un cruce corriendo? (útil para inhibir toques). */
+    viajando: estado.fase !== 'quieto',
+    entrar,
+    volver,
+    /** Spread directo sobre <VeloOdyssey {...propsVelo} />. */
+    propsVelo,
+  };
+}

--- a/src/visual/mundo3d/transiciones/veloOdyssey.css
+++ b/src/visual/mundo3d/transiciones/veloOdyssey.css
@@ -1,0 +1,663 @@
+/*
+ * veloOdyssey.css — coreografías del velo de cruce entre mundos.
+ *
+ * Contrato compartido con velosData.js (NO cambiar uno sin el otro):
+ *   ·  0%–14%   anticipación (el velo se recoge — movimiento contrario);
+ *   · 14%–46%   lanzamiento (cubre con aceleración);
+ *   · 46%–62%   MESETA: pantalla 100% cubierta (el host intercambia escena
+ *               a los 54%, cronometrado por los timers JS del componente);
+ *   · 62%–100%  resolución (revela con overshoot al entrar; exhala al volver).
+ *
+ * Variables (las setea el componente):
+ *   --vo-claro / --vo-medio / --vo-profundo   tríada del velo
+ *   --vo-ms                                   duración total del cruce
+ *
+ * Solo transform/opacity en lo caliente (compositor). La única excepción es
+ * el abrazo de luz al volver (width/height de UN elemento ~1s — el patrón
+ * clásico de iris con box-shadow gigante, igual que TransicionMundoKit).
+ *
+ * Tier: el componente poda las DECORACIONES por tier (jirones, hojas,
+ * piedritas, halos) — este CSS solo degrada detalles (boil, blur) y trae la
+ * red de seguridad reduced-motion.
+ */
+
+.vo {
+  position: fixed;
+  inset: 0;
+  z-index: 46; /* sobre el velo original (40) y el kit (44) */
+  overflow: hidden;
+  pointer-events: auto; /* escudo: nada de toques a mitad del cruce */
+}
+
+/* ============================ NIEBLA (páramo) =========================== */
+/* Entrar: la bruma SUBE del fondo, se recoge, envuelve y se abre en jirones.
+ * Volver: la niebla condensa en el aire, abraza suave y CAE revelando casa. */
+
+.vo__manto {
+  position: absolute;
+  inset: -6% 0;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--vo-claro) 88%, #ffffff) 0%,
+    var(--vo-medio) 46%,
+    color-mix(in srgb, var(--vo-profundo) 85%, #2e4650) 100%
+  );
+  will-change: transform, opacity;
+}
+
+.vo[data-velo='niebla'][data-fase='entrando'] .vo__manto {
+  animation: voNieblaEntra var(--vo-ms) linear both;
+}
+
+.vo[data-velo='niebla'][data-fase='saliendo'] .vo__manto {
+  animation: voNieblaVuelve var(--vo-ms) linear both;
+}
+
+@keyframes voNieblaEntra {
+  0% {
+    transform: translateY(104%) scale(1);
+    opacity: 1;
+    animation-timing-function: ease-out;
+  }
+  14% {
+    /* anticipación: la bruma se recoge un respiro antes de trepar */
+    transform: translateY(109%) scale(1);
+    animation-timing-function: cubic-bezier(0.6, 0.05, 0.8, 0.5);
+  }
+  46%,
+  62% {
+    transform: translateY(0%) scale(1);
+    opacity: 1;
+    animation-timing-function: cubic-bezier(0.22, 1.1, 0.42, 1);
+  }
+  84% {
+    opacity: 0.55;
+  }
+  100% {
+    /* se abre en jirones: crece un poco mientras se disuelve */
+    transform: translateY(-3%) scale(1.14);
+    opacity: 0;
+  }
+}
+
+@keyframes voNieblaVuelve {
+  0% {
+    transform: translateY(0%) scale(1.1);
+    opacity: 0;
+    animation-timing-function: ease-in-out;
+  }
+  14% {
+    opacity: 0.14;
+    animation-timing-function: cubic-bezier(0.55, 0.06, 0.68, 0.5);
+  }
+  46%,
+  62% {
+    transform: translateY(0%) scale(1);
+    opacity: 1;
+    animation-timing-function: cubic-bezier(0.3, 0.6, 0.25, 1);
+  }
+  100% {
+    /* la niebla cae al fondo del valle: uno ya llegó a casa */
+    transform: translateY(78%) scale(1.02);
+    opacity: 0;
+  }
+}
+
+/* Jirones decorativos: bancos alargados que cruzan a distintas alturas. */
+.vo__jiron {
+  position: absolute;
+  width: 72vmax;
+  height: 16vmax;
+  border-radius: 50%;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    color-mix(in srgb, var(--vo-claro) 92%, #ffffff) 0%,
+    transparent 70%
+  );
+  opacity: 0;
+  animation: voJiron calc(var(--vo-ms) * 0.9) ease-in-out both;
+  will-change: transform, opacity;
+}
+
+.vo__jiron--1 {
+  top: 12%;
+  left: -30%;
+}
+
+.vo__jiron--2 {
+  top: 44%;
+  left: 40%;
+  animation-delay: calc(var(--vo-ms) * 0.1);
+  animation-direction: reverse;
+}
+
+.vo__jiron--3 {
+  top: 70%;
+  left: -10%;
+  animation-delay: calc(var(--vo-ms) * 0.18);
+}
+
+@keyframes voJiron {
+  0% {
+    transform: translateX(-18vw);
+    opacity: 0;
+  }
+  30% {
+    opacity: 0.85;
+  }
+  70% {
+    opacity: 0.7;
+  }
+  100% {
+    transform: translateX(26vw);
+    opacity: 0;
+  }
+}
+
+/* ========================= TIERRA (suelo/humus) ========================= */
+/* Bloque de 220vh que barre en vertical: entrar SUBE (uno desciende al
+ * subsuelo); volver BAJA (la tierra cae y uno emerge hacia la luz).
+ * El borde es el horizonte del suelo: pasto, terrones y raicillas (SVG). */
+
+.vo__suelo {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 220vh;
+  display: flex;
+  flex-direction: column;
+  will-change: transform;
+}
+
+.vo[data-velo='tierra'][data-fase='entrando'] .vo__suelo {
+  animation: voTierraEntra var(--vo-ms) linear both;
+}
+
+.vo[data-velo='tierra'][data-fase='saliendo'] .vo__suelo {
+  animation: voTierraVuelve var(--vo-ms) linear both;
+}
+
+.vo__horizonte {
+  display: block;
+  width: 100%;
+  height: 9vh;
+  flex: none;
+}
+
+.vo__horizonte--frente path {
+  fill: var(--vo-claro);
+}
+
+.vo__horizonte--cola {
+  transform: scaleY(-1);
+}
+
+.vo__horizonte--cola path {
+  fill: var(--vo-profundo);
+}
+
+.vo__suelo-cuerpo {
+  flex: 1;
+  position: relative;
+  background: linear-gradient(
+    180deg,
+    var(--vo-claro) 0%,
+    var(--vo-medio) 34%,
+    var(--vo-profundo) 72%
+  );
+}
+
+/* Piedritas y lombriz de aire: motas que viajan con el bloque de tierra. */
+.vo__piedrita {
+  position: absolute;
+  width: 0.9vmax;
+  height: 0.7vmax;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--vo-claro) 55%, var(--vo-profundo));
+  opacity: 0.8;
+}
+
+.vo__piedrita--1 {
+  left: 18%;
+  top: 22%;
+  width: 1.3vmax;
+}
+
+.vo__piedrita--2 {
+  left: 64%;
+  top: 12%;
+}
+
+.vo__piedrita--3 {
+  left: 41%;
+  top: 38%;
+  width: 0.7vmax;
+}
+
+.vo__piedrita--4 {
+  left: 82%;
+  top: 30%;
+  width: 1.1vmax;
+  height: 0.9vmax;
+}
+
+/* Cobertura en meseta: bloque en -60vh ⇒ el cuerpo tapa 0..100vh completo. */
+@keyframes voTierraEntra {
+  0% {
+    transform: translateY(102vh);
+    animation-timing-function: ease-out;
+  }
+  14% {
+    /* anticipación: el suelo se hunde un respiro antes de tragarse el cielo */
+    transform: translateY(108vh);
+    animation-timing-function: cubic-bezier(0.6, 0.05, 0.8, 0.5);
+  }
+  46%,
+  62% {
+    transform: translateY(-60vh);
+    animation-timing-function: cubic-bezier(0.22, 1.16, 0.42, 1);
+  }
+  100% {
+    transform: translateY(-232vh);
+  }
+}
+
+@keyframes voTierraVuelve {
+  0% {
+    transform: translateY(-320vh);
+    animation-timing-function: ease-out;
+  }
+  14% {
+    transform: translateY(-326vh);
+    animation-timing-function: cubic-bezier(0.55, 0.06, 0.68, 0.5);
+  }
+  46%,
+  62% {
+    transform: translateY(-60vh);
+    animation-timing-function: cubic-bezier(0.3, 0.6, 0.25, 1);
+  }
+  100% {
+    transform: translateY(112vh);
+  }
+}
+
+/* ============================ HOJAS (monte) ============================= */
+/* La fronda: un disco de follaje que gira mientras cierra el camino, y al
+ * revelar sigue de largo un pelo (overshoot) antes de disolverse. */
+
+.vo__fronda {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 245vmax;
+  height: 245vmax;
+  margin: -122.5vmax 0 0 -122.5vmax;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--vo-claro) 80%, #ffffff) 0%,
+    var(--vo-medio) 34%,
+    var(--vo-profundo) 76%
+  );
+  opacity: 0;
+  will-change: transform, opacity;
+}
+
+.vo[data-velo='hojas'][data-fase='entrando'] .vo__fronda {
+  animation: voFrondaEntra var(--vo-ms) linear both;
+}
+
+.vo[data-velo='hojas'][data-fase='saliendo'] .vo__fronda {
+  animation: voFrondaVuelve var(--vo-ms) linear both;
+}
+
+@keyframes voFrondaEntra {
+  0% {
+    transform: scale(0.06) rotate(-52deg);
+    opacity: 0;
+    animation-timing-function: ease-out;
+  }
+  14% {
+    /* anticipación: el remolino se enrosca ANTES de abrirse a cubrir */
+    transform: scale(0.035) rotate(-64deg);
+    opacity: 0.9;
+    animation-timing-function: cubic-bezier(0.6, 0.05, 0.8, 0.5);
+  }
+  46%,
+  62% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+    animation-timing-function: cubic-bezier(0.22, 1.2, 0.42, 1);
+  }
+  86% {
+    opacity: 0.5;
+  }
+  100% {
+    /* overshoot: sigue girando de largo mientras el monte se abre */
+    transform: scale(1.3) rotate(26deg);
+    opacity: 0;
+  }
+}
+
+@keyframes voFrondaVuelve {
+  0% {
+    transform: scale(1.28) rotate(30deg);
+    opacity: 0;
+    animation-timing-function: ease-in-out;
+  }
+  14% {
+    opacity: 0.3;
+    animation-timing-function: cubic-bezier(0.55, 0.06, 0.68, 0.5);
+  }
+  46%,
+  62% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+    animation-timing-function: cubic-bezier(0.3, 0.6, 0.25, 1);
+  }
+  100% {
+    /* al volver el remolino se deshoja hacia el centro, sin rebote */
+    transform: scale(0.05) rotate(-40deg);
+    opacity: 0;
+  }
+}
+
+/* Hojas sueltas que cruzan en arco delante de la fronda. */
+.vo__hoja {
+  position: absolute;
+  width: 5.5vmax;
+  height: 5.5vmax;
+  opacity: 0;
+  animation: voHoja calc(var(--vo-ms) * 0.82) cubic-bezier(0.35, 0, 0.4, 1) both;
+  will-change: transform, opacity;
+}
+
+.vo__hoja svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.vo__hoja--1 {
+  left: 6%;
+  top: 64%;
+}
+
+.vo__hoja--2 {
+  left: 26%;
+  top: 18%;
+  animation-delay: calc(var(--vo-ms) * 0.08);
+  width: 4vmax;
+  height: 4vmax;
+}
+
+.vo__hoja--3 {
+  left: 58%;
+  top: 70%;
+  animation-delay: calc(var(--vo-ms) * 0.14);
+}
+
+.vo__hoja--4 {
+  left: 74%;
+  top: 26%;
+  animation-delay: calc(var(--vo-ms) * 0.05);
+  width: 3.4vmax;
+  height: 3.4vmax;
+}
+
+.vo__hoja--5 {
+  left: 42%;
+  top: 44%;
+  animation-delay: calc(var(--vo-ms) * 0.2);
+  width: 4.6vmax;
+  height: 4.6vmax;
+}
+
+@keyframes voHoja {
+  0% {
+    transform: translate(-16vw, 10vh) rotate(-30deg);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  62% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(22vw, -14vh) rotate(280deg);
+    opacity: 0;
+  }
+}
+
+/* ========================== LUZ (casa/valle) ============================ */
+/* Entrar: un destello dorado crece del centro — descubrir a plena luz.
+ * Volver: el hogar ABRAZA desde los bordes (iris cálido que se cierra sobre
+ * uno y reabre): la luz de la casa siempre estuvo ahí. */
+
+.vo__destello {
+  position: absolute;
+  left: 50%;
+  top: 47%;
+  width: 180vmax;
+  height: 180vmax;
+  margin: -90vmax 0 0 -90vmax;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--vo-claro) 70%, #ffffff) 0%,
+    var(--vo-medio) 38%,
+    color-mix(in srgb, var(--vo-profundo) 88%, #142e1c) 80%
+  );
+  opacity: 0;
+  will-change: transform, opacity;
+}
+
+.vo[data-velo='luz'][data-fase='entrando'] .vo__destello {
+  animation: voDestello var(--vo-ms) linear both;
+}
+
+@keyframes voDestello {
+  0% {
+    transform: scale(0.05);
+    opacity: 0;
+    animation-timing-function: ease-out;
+  }
+  14% {
+    /* anticipación: la chispa se aprieta antes de estallar */
+    transform: scale(0.03);
+    opacity: 0.9;
+    animation-timing-function: cubic-bezier(0.6, 0.05, 0.8, 0.5);
+  }
+  46%,
+  62% {
+    transform: scale(1);
+    opacity: 1;
+    animation-timing-function: cubic-bezier(0.22, 1.24, 0.42, 1);
+  }
+  100% {
+    transform: scale(1.12);
+    opacity: 0;
+  }
+}
+
+.vo__abrazo {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 240vmax;
+  height: 240vmax;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 4px solid color-mix(in srgb, var(--vo-claro) 80%, #ffffff);
+  box-shadow:
+    0 0 0 260vmax color-mix(in srgb, var(--vo-medio) 55%, var(--vo-profundo)),
+    inset 0 0 52px var(--vo-claro);
+}
+
+.vo[data-velo='luz'][data-fase='saliendo'] .vo__abrazo {
+  animation: voAbrazo var(--vo-ms) cubic-bezier(0.35, 0, 0.22, 1) both;
+}
+
+/* Gama baja: el abrazo sin aro ni brillo interior (solo la cobertura). */
+.vo[data-tier='bajo'] .vo__abrazo {
+  border: 0;
+  box-shadow: 0 0 0 260vmax var(--vo-profundo);
+}
+
+@keyframes voAbrazo {
+  0% {
+    width: 240vmax;
+    height: 240vmax;
+  }
+  46%,
+  62% {
+    width: 0vmax;
+    height: 0vmax;
+  }
+  100% {
+    width: 240vmax;
+    height: 240vmax;
+  }
+}
+
+/* Halos de la hora dorada (solo decoración). */
+.vo__halo {
+  position: absolute;
+  left: 50%;
+  top: 47%;
+  width: 40vmax;
+  height: 40vmax;
+  margin: -20vmax 0 0 -20vmax;
+  border-radius: 50%;
+  border: 3px solid var(--vo-claro);
+  opacity: 0;
+  animation: voHalo calc(var(--vo-ms) * 0.55) cubic-bezier(0.3, 0, 0.5, 1) both;
+  will-change: transform, opacity;
+}
+
+.vo__halo--2 {
+  animation-delay: calc(var(--vo-ms) * 0.16);
+  border-color: var(--vo-medio);
+}
+
+@keyframes voHalo {
+  0% {
+    transform: scale(0.1);
+    opacity: 0;
+  }
+  30% {
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(2.5);
+    opacity: 0;
+  }
+}
+
+/* ============================ LETRERO =================================== */
+/* Aparece con la cubierta y se despide con la resolución. Asimétrico en el
+ * texto (lo pone el componente): entrar anuncia, volver acoge. */
+
+.vo__letrero {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 9vh;
+  margin: 0;
+  text-align: center;
+  color: #f8fff0;
+  font-size: clamp(14px, 2.4vw, 18px);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-shadow: 0 2px 10px rgba(10, 24, 12, 0.7);
+  opacity: 0;
+  animation: voLetrero var(--vo-ms) linear both;
+}
+
+@keyframes voLetrero {
+  0% {
+    opacity: 0;
+  }
+  22% {
+    opacity: 1;
+  }
+  64% {
+    opacity: 1;
+  }
+  82% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+/* ====================== LINE-BOIL (solo tier alto) ====================== */
+/* El temblor de tinta a ~4 fps sobre las decoraciones: steps(2) entre dos
+ * poses apenas distintas. Vive en el HIJO para no pelear con el viaje del
+ * padre. Barato: un elemento por decoración, transform puro. */
+
+.vo[data-tier='alto'] .vo__hoja svg,
+.vo[data-tier='alto'] .vo__piedrita {
+  animation: voBoil 0.5s steps(2, jump-none) infinite;
+}
+
+@keyframes voBoil {
+  0% {
+    transform: rotate(-1.4deg) scale(1);
+  }
+  100% {
+    transform: rotate(1.4deg) scale(1.03);
+  }
+}
+
+/* Blur atmosférico del manto de niebla: SOLO tier alto (fill-rate caro). */
+.vo[data-tier='alto'][data-velo='niebla'] .vo__jiron {
+  filter: blur(6px);
+}
+
+/* ================== REDUCED MOTION = corte simple digno ================= */
+/* Via prop: el componente monta SOLO .vo__corte — tinte del velo que cubre
+ * al instante (el swap ocurre bajo tapa) y se desvanece corto. */
+
+.vo__corte {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(165deg, var(--vo-medio) 0%, var(--vo-profundo) 68%);
+  animation: voCorte var(--vo-ms) linear both;
+}
+
+@keyframes voCorte {
+  0%,
+  58% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+/* Red de seguridad si el host no pasó la prop pero el sistema pide calma:
+ * fuera coreografías y decoraciones, solo el corte simple. */
+@media (prefers-reduced-motion: reduce) {
+  .vo .vo__manto,
+  .vo .vo__jiron,
+  .vo .vo__suelo,
+  .vo .vo__fronda,
+  .vo .vo__hoja,
+  .vo .vo__destello,
+  .vo .vo__abrazo,
+  .vo .vo__halo {
+    display: none;
+  }
+
+  .vo::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: var(--vo-profundo);
+    animation: voCorte var(--vo-ms) linear both;
+  }
+}

--- a/src/visual/mundo3d/transiciones/velosData.js
+++ b/src/visual/mundo3d/transiciones/velosData.js
@@ -1,0 +1,196 @@
+/*
+ * velosData — el LENGUAJE DE TRANSICIÓN entre mundos, en datos puros (cero DOM,
+ * cero three). Norte: el cruce estilo Odyssey — entrar a un mundo es un
+ * MOMENTO, no un corte de pantalla.
+ *
+ * QUÉ ES UN VELO
+ * No un fade negro genérico: la cortina que cubre y descubre el mundo tiene
+ * identidad ANDINA y la elige el DESTINO del viaje:
+ *
+ *   · 'niebla' — la niebla del páramo sube y envuelve (sierra, agua, altura);
+ *   · 'tierra' — la tierra se abre y lo traga a uno (suelo, microsuelo, compost);
+ *   · 'hojas'  — un remolino de hojas cierra el monte (bosque, restauración);
+ *   · 'luz'    — la luz dorada de la casa (valle, hogar — y el default digno).
+ *
+ * ASIMETRÍA ENTRAR/VOLVER (regla del lenguaje):
+ *   · ENTRAR es DESCUBRIR: más ceremonial, un pelo más largo, el velo se lanza
+ *     con hambre y el destino se revela con overshoot (la sorpresa pesa).
+ *   · VOLVER es REGRESAR A CASA: más corto y más tibio — sin ansiedad, el velo
+ *     exhala. La resolución siempre termina cálida (uno ya conoce ese lugar).
+ *
+ * ANATOMÍA DEL CRUCE (squash & stretch del timing, spec rubber-hose):
+ * fracciones de la duración total, iguales para todos los velos:
+ *
+ *   0%  → 14%   ANTICIPACIÓN  el velo asoma y SE RECOGE (movimiento contrario:
+ *                             toma aire antes de lanzarse — ahí está el peso);
+ *   14% → 46%   LANZAMIENTO   cubre con aceleración franca (el resorte suelto);
+ *   46% → 62%   MESETA        pantalla 100% cubierta — a mitad de meseta (54%)
+ *                             dispara `onCubierto`: el host intercambia la
+ *                             escena DEBAJO del velo;
+ *   62% → 100%  RESOLUCIÓN    revela con overshoot y asentado (back-out): el
+ *                             mundo nuevo "aterriza", no aparece.
+ *
+ * CONTRATO TEMPORAL (misma filosofía que TransicionMundo/TransicionMundoKit):
+ * los callbacks los disparan timers JS deterministas, NUNCA `animationend`.
+ * El CSS anima "a ciegas" con la MISMA duración via `--vo-ms`.
+ *
+ * TIER-SAFE (deviceTier): gama baja NUNCA cae a pantalla en blanco — cae al
+ * MISMO velo sin decoraciones (una sola capa con los colores de su identidad)
+ * y más corto. `reducedMotion` colapsa todo a un corte simple y digno.
+ */
+
+/** Fracción del total en que la anticipación termina y arranca el lanzamiento. */
+export const ANTICIPACION_FRAC = 0.14;
+
+/** Ventana garantizada de pantalla cubierta (el CSS mesetea 46%–62%). */
+export const MESETA_INICIO_FRAC = 0.46;
+export const MESETA_FIN_FRAC = 0.62;
+
+/** Momento de `onCubierto`: centro de la meseta. */
+export const CUBIERTO_FRAC = 0.54;
+
+/** Con `reducedMotion` TODO colapsa a un corte simple de esta duración. */
+export const REDUCIDA_MS = 180;
+/** `onCubierto` bajo reduced-motion (la cubierta es instantánea). */
+export const CUBIERTO_REDUCIDA_MS = 60;
+
+/** Tier `bajo` acorta el viaje: menos tiempo de overlay en equipos flojos. */
+export const FACTOR_TIER_BAJO = 0.7;
+
+/*
+ * EASINGS DEL LENGUAJE (cubic-beziers compartidos velo ↔ cámara ↔ demos).
+ * Nombrados por su papel en la anatomía, no por su matemática:
+ */
+/** Lanzamiento: arranca por debajo de cero — la anticipación vive AQUÍ. */
+export const EASE_LANZA = 'cubic-bezier(0.5, -0.28, 0.75, 0.55)';
+/** Resolución al ENTRAR: back-out con overshoot — el mundo aterriza. */
+export const EASE_DESCUBRE = 'cubic-bezier(0.22, 1.28, 0.42, 1)';
+/** Resolución al VOLVER: exhalar largo, sin rebote — ya es casa. */
+export const EASE_REGRESA = 'cubic-bezier(0.3, 0.6, 0.25, 1)';
+
+/**
+ * LOS VELOS. Colores en tríada [claro, medio, profundo] — el claro es el
+ * corazón/borde vivo, el profundo es el cuerpo que cubre. `ms` asimétrico:
+ * entrar (descubrir) respira más largo que volver (regresar).
+ */
+export const VELOS = {
+  niebla: {
+    id: 'niebla',
+    etiqueta: 'la niebla del páramo',
+    nota: 'Bancos de bruma lechosa que suben, envuelven y se abren en jirones.',
+    claro: '#eef4f4',
+    medio: '#aec7cf',
+    profundo: '#587c88',
+    ms: { entrando: 1450, saliendo: 1150 },
+  },
+  tierra: {
+    id: 'tierra',
+    etiqueta: 'la tierra que se abre',
+    nota: 'El suelo lo traga a uno: horizonte de humus, raicillas y piedritas.',
+    claro: '#c98f4e',
+    medio: '#7a4f2a',
+    profundo: '#33200f',
+    ms: { entrando: 1400, saliendo: 1100 },
+  },
+  hojas: {
+    id: 'hojas',
+    etiqueta: 'el remolino de hojas',
+    nota: 'El monte cierra su follaje sobre el camino y lo vuelve a abrir.',
+    claro: '#a9c86a',
+    medio: '#4f8f3e',
+    profundo: '#16331f',
+    ms: { entrando: 1400, saliendo: 1100 },
+  },
+  luz: {
+    id: 'luz',
+    etiqueta: 'la luz de la casa',
+    nota: 'El amanecer dorado del valle: la luz que abraza al que regresa.',
+    claro: '#ffe9b0',
+    medio: '#f2c063',
+    profundo: '#274a2e',
+    ms: { entrando: 1300, saliendo: 1050 },
+  },
+};
+
+/** Ids válidos, para validación barata y para las demos. */
+export const VELO_IDS = Object.keys(VELOS);
+
+/*
+ * ¿Qué velo le toca a un destino? El mapeo es por FAMILIA de mundo, con
+ * matching laxo por subcadena para no acoplarse al manifiesto de mundos
+ * (mundoIds nuevos caen solos en su familia; lo desconocido cae en 'luz',
+ * que nunca desentona).
+ */
+const FAMILIAS = [
+  { velo: 'tierra', claves: ['suelo', 'microsuelo', 'subsuelo', 'compost', 'abono', 'lombri'] },
+  { velo: 'hojas', claves: ['bosque', 'monte', 'restaura', 'arbol', 'vivero', 'semilla'] },
+  { velo: 'niebla', claves: ['sierra', 'paramo', 'páramo', 'agua', 'nieve', 'altura', 'clima'] },
+  { velo: 'luz', claves: ['valle', 'casa', 'hogar', 'finca'] },
+];
+
+/**
+ * Resuelve la identidad del velo para un destino (mundoId o familia directa).
+ * @param {string} destino p.ej. 'bosque_vivo', 'microsuelo', 'sierra_global'
+ * @returns {'niebla'|'tierra'|'hojas'|'luz'}
+ */
+export function familiaDeVelo(destino) {
+  const d = String(destino || '').toLowerCase();
+  if (VELOS[d]) return /** @type {any} */ (d);
+  for (const f of FAMILIAS) {
+    if (f.claves.some((c) => d.includes(c))) return /** @type {any} */ (f.velo);
+  }
+  return 'luz';
+}
+
+/** El velo completo de un destino (nunca undefined). */
+export const veloDeDestino = (destino) => VELOS[familiaDeVelo(destino)];
+
+/**
+ * Duración total del cruce en ms.
+ * @param {string} veloId 'niebla'|'tierra'|'hojas'|'luz' (desconocido → 'luz')
+ * @param {'entrando'|'saliendo'} fase
+ * @param {'alto'|'medio'|'bajo'} tier
+ * @param {boolean} reducedMotion
+ */
+export function duracionCruce(veloId, fase, tier, reducedMotion) {
+  if (reducedMotion) return REDUCIDA_MS;
+  const velo = VELOS[veloId] || VELOS.luz;
+  const base = velo.ms[fase === 'saliendo' ? 'saliendo' : 'entrando'];
+  return tier === 'bajo' ? Math.round(base * FACTOR_TIER_BAJO) : base;
+}
+
+/**
+ * Momento (ms desde el arranque) de `onCubierto` — centro de la meseta.
+ * Con reduced-motion la cubierta es instantánea: llega enseguida.
+ */
+export function momentoCubierto(veloId, fase, tier, reducedMotion) {
+  if (reducedMotion) return CUBIERTO_REDUCIDA_MS;
+  return Math.round(duracionCruce(veloId, fase, tier, reducedMotion) * CUBIERTO_FRAC);
+}
+
+/**
+ * La curva del cruce como FUNCIÓN (para cámaras y animación imperativa):
+ * t∈[0,1] → k con anticipación (k<0 al arrancar) y, si `descubre`, overshoot
+ * (k>1 antes de asentar). Es la misma alma de EASE_LANZA/EASE_DESCUBRE pero
+ * evaluable por frame — el velo DOM y la cámara 3D respiran igual.
+ *
+ * @param {number} t progreso lineal 0..1
+ * @param {{ descubre?: boolean, anticipo?: number, rebote?: number }} [opts]
+ * @returns {number} k (puede salir de [0,1]: eso ES el squash & stretch)
+ */
+export function curvaCruce(t, { descubre = true, anticipo = 0.055, rebote = 1.15 } = {}) {
+  const x = Math.min(1, Math.max(0, t));
+  if (x < ANTICIPACION_FRAC) {
+    // Se recoge: seno que baja y vuelve a cero justo al soltar el resorte.
+    return -anticipo * Math.sin((x / ANTICIPACION_FRAC) * Math.PI);
+  }
+  const u = (x - ANTICIPACION_FRAC) / (1 - ANTICIPACION_FRAC);
+  if (!descubre) {
+    // Volver: exhalar — easeInOut suave, sin rebote.
+    return u * u * (3 - 2 * u);
+  }
+  // Entrar: back-out — pasa de largo un pelo y asienta (el aterrizaje pesa).
+  const s = rebote;
+  const v = u - 1;
+  return 1 + v * v * ((s + 1) * v + s);
+}


### PR DESCRIPTION
## Qué es

Dirección de cámara/arte del valle 3D de prod + los bugs funcionales del shell que reportó el operador. Aplica lo vigente de `fable/direccion-valle` (revisión del director anterior, base dev) portado a `app-3d`.

## 1. Funcional — la clase entera de botones muertos (commit `6d02679`)

**Causa raíz**: `ProdChagraApp` montaba cada pantalla `<Componente />` **sin props** y sin listeners de `chagra:nav`/`chagraNavigate` (vivían solo en App.jsx, el shell viejo).

- **Botón casa** → valle (inicio 3D-first) y **botón ayuda** → `#help` (alias de faq que ya existía) — los dos del feedback, probados con clicks reales.
- **El dashboard crasheaba la app entera al primer tap** (`onNavigate` undefined sin guard → TypeError → ErrorBoundary raíz). Revivido junto con los hubs (cultivos, animales, hoy, mundos), la campana, el back del agente y el 'Volver' tras guardar un registro.
- `navigate()` con guard de manifiesto (tiles legacy tipo `javier` ya no tumban ni redirigen porque sí); los datos de navegación viajan en el hash (`#agente/<json>` — el contexto espacial del valle llega al agente y sobrevive recarga).
- `wire3DNav`: micorrizas → subsuelo (fix exacto del director). `VentanaValle3D`: tap muerto → default al valle.
- **`index-prod.html`: la cadena de altura del shell NO estaba en esta rama** (el fix del feedback quedó en otro lado) — los mundos heredaban `height:100%` de NADA → escena aplastada (el Ent 'cortado', el grafo 'plano').

## 2. La trampa mergeGeometries — tercera mordida (commit `ea83769`)

En `floraParamo.geom.js` de app-3d, **`geomAliso` y `geomGaque` devolvían `null` incluso a q=1** (indexadas+no-indexadas) → esas especies **no se dibujaban en el bosque de prod** y cualquier consumidor moría con `null.boundingSphere` por frame (canvas negro). Fix de 1 línea (des-indexar antes del merge), el mismo ya probado en dev.
⚠️ **Archivo compartido con el frente del Ent** — commit aparte para cherry-pick/coordinación fácil.

## 3. Cámara y composición (commit `6133a79`)

- **Reposo consciente del aspecto**: el fov de three es vertical — en un teléfono parado los 40° dejaban **~19° horizontales y medio valle fuera del cuadro** (misma clase de fallo que los árboles tras el macizo de la sierra). En pantallas angostas la cámara retrocede y abre fov con techo; **en landscape la pose aprobada queda EXACTA**.
- Porte del director: casa-ancla con ventana cálida, senderos del trajín, patios (afordancia sin UI), disposición compuesta (`componerMundos()` sin tocar valleData), lugares tocables, arboleda por especie, asimetría entrar/volver.
- **Transiciones aprobadas intactas** (New Donk + tier-variation no se tocaron). El velo Odyssey se suma: tocar un lugar ya no arranca a la 2D con un corte seco a los 700ms — panel con **'Abrir <lugar>'** (velo del destino cubre → hash bajo la meseta) + **'Recorrer en 3D'** (los dioramas eran inalcanzables desde el tap en prod). Reduced-motion: corte directo.
- Limitación conocida: al desmontar el shell el velo no alcanza a 'revelar' (la mitad de la coreografía pide velo a nivel shell — apuntado por el director como fix de host).

## 4. Jerarquía de personajes — 'el oso no puede ser secundario'

`VECINOS_VALLE` reemplaza el garnish de 30px gateado a GPU rica: cada personaje **en su casa**, en todos los tiers, registro-driven contra `CREATURES` (las ramas de personajes mejoran el dibujo al mergear sin tocar el mapa):
oso andino en el borde del monte (44px, factor de Angelita) · perezoso en la arboleda · ardilla · rana en la quebrada · morrocoy en tierra caliente · **borugo crepuscular** (sale al caer el sol) · **jaguar místico** (aparecido de amanecer/atardecer/niebla — verlo es premio). Angelita sigue de guía: única con follow y luz propia. Posiciones verificadas contra el **frustum real** (probe por slug): 7/7 visibles en landscape, 5/5 diurnos en portrait.

## Verificación (síncrona, real)

- `npm run build` ✓ · `npm run tsc:check` **limpio** ✓
- Chromium sistema + swiftshader, login inyectado, clicks reales: tap 'El agua' → panel (2 CTAs) → Abrir → velo → `#agua` → **casa** → valle (`#` vacío) → **ayuda** → `#help` → 'Pregúntele' → `#agente`+contexto ✓
- Screenshots antes/después (portrait y landscape, día y atardecer) — el antes desde `origin/app-3d` limpio.

## ⚠️ Coordinación con frentes paralelos

- `floraParamo.geom.js` es del territorio del **Ent/bosque** — solo el hunk `fusionar()` (commit aparte).
- `animales.jsx`: solo se agrega el export `MATERIAL_FINCA` (idéntico al de finca-realismo-d1 → cero conflicto al mergear).
- **El checkout PADRE (`~/Workspace/chagra`, rama app-3d local) tiene trabajo del valle sin commitear** (composicionValle3D.jsx, DIRECCION-VALLE.md…) que NO es de esta rama — parece un porte en progreso de otro frente. No lo toqué; ojo al mergear.

## Deuda que dejo apuntada (fuera de scope, del barrido de controles)

- `GaleriaSierraArboles` (sierra, frente paralelo): árboles héroe y leyenda de pisos con `onEntrar` sin cablear.
- ~15 vistas 3D del manifiesto sin ningún control de salida (vistas-trampa en PWA instalada).
- `RestauracionScreen` navega a `seguimiento_reforestacion` que no existe en ningún manifiesto.
- `chagraToast` no tiene listener en NINGÚN shell (todos los toasts son no-ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)