### PR TITLE
feat(bosque): rehacer el Ent y la flora de páramo — barba de usnea, rostro tallado, matas con jerarquía

### DIFF
--- a/index-prod.html
+++ b/index-prod.html
@@ -30,7 +30,13 @@
     <meta name="apple-mobile-web-app-title" content="Chagra" />
     <title>Chagra</title>
     <style>
-      html, body { background: #020617; margin: 0; }
+      /* Cadena de ALTURA completa: sin esto #root colapsa a su contenido y los
+         mundos 3D (que piden height:100%) lo heredan de nada → la escena queda
+         aplastada en una franja del ~15% y el Ent se ve "cortado y pequeñísimo". */
+      html, body { background: #020617; margin: 0; height: 100%; }
+      body { min-height: 100dvh; }
+      #root { height: 100%; min-height: 100dvh; display: flex; flex-direction: column; }
+      #root > * { flex: 1 1 auto; min-height: 0; }
       #pre-loader {
         position: fixed; inset: 0;
         display: flex; flex-direction: column;

--- a/scripts/diag/shot3d-ruta.mjs
+++ b/scripts/diag/shot3d-ruta.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/*
+ * shot3d — captura una ruta 3D del dev server con chromium del sistema + swiftshader.
+ * Uso: node shot3d.mjs <ruta> <salida.png> [--wait ms] [--click selector] [--w px] [--h px]
+ */
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+
+const args = process.argv.slice(2);
+const ruta = args[0];
+const out = args[1];
+const getFlag = (n, d) => {
+  const i = args.indexOf(`--${n}`);
+  return i === -1 ? d : args[i + 1];
+};
+const wait = Number(getFlag('wait', 9000));
+const click = getFlag('click', null);
+const W = Number(getFlag('w', 1280));
+const H = Number(getFlag('h', 900));
+const base = getFlag('base', 'http://127.0.0.1:5173');
+
+const chromiumPath = execSync('which chromium', { encoding: 'utf8' }).trim();
+
+const browser = await chromium.launch({
+  executablePath: chromiumPath,
+  args: [
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--disable-dev-shm-usage',
+    '--use-gl=angle',
+    '--use-angle=swiftshader',
+    '--enable-unsafe-swiftshader',
+    '--ignore-gpu-blocklist',
+  ],
+});
+
+const ctx = await browser.newContext({
+  viewport: { width: W, height: H },
+  deviceScaleFactor: Number(getFlag('dsf', 1)),
+  locale: 'es-CO',
+});
+const page = await ctx.newPage();
+const errores = [];
+page.on('pageerror', (e) => errores.push(`[pageerror] ${e.message}`));
+page.on('console', (m) => {
+  if (m.type() === 'error') errores.push(`[console] ${m.text()}`);
+});
+
+const shell = getFlag('shell', '/index-prod.html');
+await page.goto(`${base}${shell}#${ruta}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForTimeout(wait);
+
+if (click) {
+  try {
+    await page.waitForSelector(click, { timeout: 30000, state: 'attached' });
+    await page.evaluate((sel) => document.querySelector(sel)?.click(), click);
+    await page.waitForTimeout(Number(getFlag('wait2', 5000)));
+  } catch (e) {
+    errores.push(`[click] no se pudo pulsar ${click}: ${e.message}`);
+  }
+}
+
+// ¿hay un canvas y está pintando algo?
+const info = await page.evaluate(() => {
+  const c = document.querySelector('canvas');
+  if (!c) return { canvas: false };
+  return { canvas: true, w: c.width, h: c.height };
+});
+
+const clipArg = getFlag('clip', null); // "x,y,w,h" en px del viewport
+const clip = clipArg ? (() => { const [x, y, w, h] = clipArg.split(',').map(Number); return { x, y, width: w, height: h }; })() : undefined;
+await page.screenshot({ path: out, timeout: 120000, animations: 'disabled', ...(clip ? { clip } : {}) });
+console.log(`[shot3d] ruta=${ruta} out=${out} canvas=${JSON.stringify(info)}`);
+if (errores.length) console.log(`[shot3d] ERRORES:\n${errores.slice(0, 12).join('\n')}`);
+else console.log('[shot3d] sin errores de consola');
+
+await ctx.close();
+await browser.close();

--- a/src/visual/mundo3d/__tests__/bosqueRealismo.test.js
+++ b/src/visual/mundo3d/__tests__/bosqueRealismo.test.js
@@ -1,0 +1,287 @@
+/*
+ * Invariantes del rehecho del Bosque Vivo (Ent + flora de páramo).
+ *
+ * Estos tests existen porque los fallos de esta pieza son SILENCIOSOS: no
+ * lanzan, no salen en consola y no rompen el build — simplemente la cosa no se
+ * ve, y hay que descubrirlo mirando una captura. Los dos que ya nos mordieron:
+ *
+ *   1. La BARBA colgaba a una `z` fija mientras el tronco se ensancha hacia el
+ *      pie → quedaba DENTRO de la madera. El operador reportó "no tiene barba"
+ *      y el código tenía una barba perfectamente construida... enterrada.
+ *   2. `mergeGeometries` devuelve NULL sin avisar si se mezclan geometrías
+ *      indexadas con no-indexadas → r3f hace `if (!geo) return null` y la
+ *      especie desaparece sin un solo error.
+ *
+ * Por eso se verifican NUMÉRICAMENTE, no de vista.
+ */
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import {
+  PARAMS_TIER,
+  curvaTronco,
+  taperTronco,
+  tDeAltura,
+  anclaRostro,
+  desplazamientoRostro,
+  specsBarba,
+  specsUsneaRamas,
+  specsRamas,
+  geometriaHebra,
+  geometriaLaminas,
+  BARBA,
+} from '../bosque/entQuenua.geom.js';
+import {
+  geomFrailejon, geomQuenua, geomEncenillo, geomAliso, geomGaque,
+  geomRoble, geomYarumo, geomMortino, geomRomerillo, geomRoca, geomMusgo,
+  distribucionFlora, floraDeTier, calidadDeTier,
+} from '../bosque/floraParamo.geom.js';
+import { fusionarSeguro, sembrarFollaje, ruidoFbm } from '../bosque/sombreadoVegetal.js';
+
+describe('tDeAltura invierte la curva del tronco', () => {
+  it('devuelve el t cuya altura coincide con la pedida', () => {
+    const curva = curvaTronco(7);
+    for (const y of [0.5, 1.5, 3.0, 5.0]) {
+      const t = tDeAltura(curva, y);
+      expect(curva.getPointAt(t).y).toBeCloseTo(y, 1);
+    }
+  });
+  it('se acota fuera del rango del tronco', () => {
+    const curva = curvaTronco(7);
+    expect(tDeAltura(curva, -5)).toBe(0);
+    expect(tDeAltura(curva, 99)).toBe(1);
+  });
+});
+
+describe('LA BARBA cuelga por FUERA del tronco (el bug de "no tiene barba")', () => {
+  const curva = curvaTronco(7);
+
+  for (const [tier, P] of Object.entries(PARAMS_TIER)) {
+    it(`ningún punto de la barba queda dentro de la madera @ ${tier}`, () => {
+      const { hebras } = specsBarba(91, P.barba);
+      expect(hebras.length).toBeGreaterThan(0);
+      for (const h of hebras) {
+        for (const p of h.pts) {
+          const t = tDeAltura(curva, p.y);
+          const c = curva.getPointAt(t);
+          const distEje = Math.hypot(p.x - c.x, p.z - c.z);
+          // El radio REAL del tronco a esa altura: si la hebra queda por dentro,
+          // el fuste se la traga y la barba desaparece sin error.
+          expect(distEje).toBeGreaterThanOrEqual(taperTronco(t));
+        }
+      }
+    });
+  }
+
+  it('la barba no llega al suelo (es barba, no falda hawaiana)', () => {
+    const { hebras } = specsBarba(91, PARAMS_TIER.alto.barba);
+    const masBaja = Math.min(...hebras.map((h) => h.pts[h.pts.length - 1].y));
+    expect(masBaja).toBeGreaterThan(0.6); // bien por encima de las raíces
+  });
+
+  it('las hebras del mentón son más largas que las de las mejillas', () => {
+    const { hebras } = specsBarba(91, 30);
+    const largo = (h) => h.pts[0].y - h.pts[h.pts.length - 1].y;
+    const centro = hebras[Math.floor(hebras.length / 2)];
+    expect(largo(centro)).toBeGreaterThan(largo(hebras[0]));
+  });
+
+  it('geometriaHebra trae color y peso: raíz fija (0) y punta suelta (~1)', () => {
+    const { hebras } = specsBarba(91, 26);
+    const g = geometriaHebra(hebras[13], BARBA.musgo, 4);
+    expect(g.attributes.color).toBeTruthy();
+    expect(g.attributes.peso).toBeTruthy();
+    const pesos = Array.from(g.attributes.peso.array);
+    expect(Math.min(...pesos)).toBeCloseTo(0, 2);
+    expect(Math.max(...pesos)).toBeGreaterThan(0.5);
+  });
+
+  it('la usnea de las ramas respeta el presupuesto del tier (0 en bajo)', () => {
+    const puntas = specsRamas(5, 21).map((r) => r.punta);
+    expect(specsUsneaRamas(puntas, PARAMS_TIER.alto.usnea, 77)).toHaveLength(22);
+    expect(specsUsneaRamas(puntas, PARAMS_TIER.bajo.usnea, 77)).toHaveLength(0);
+  });
+});
+
+describe('EL ROSTRO se talla en la madera (no se pega encima)', () => {
+  const { centro } = anclaRostro(7);
+  const dir = (u, vy) => {
+    const z = Math.sqrt(Math.max(0, 1 - u * u - vy * vy));
+    return { x: u, y: vy, z };
+  };
+
+  it('las cuencas se HUNDEN y las cejas SOBRESALEN', () => {
+    const cuenca = desplazamientoRostro(dir(-0.46, 0.04), centro.y + 0.04, centro.y);
+    const ceja = desplazamientoRostro(dir(-0.44, 0.12), centro.y + 0.4, centro.y);
+    expect(cuenca).toBeLessThan(-0.15);
+    expect(ceja).toBeGreaterThan(0.05);
+  });
+
+  it('la boca es una grieta hundida', () => {
+    const boca = desplazamientoRostro(dir(0, 0), centro.y - 0.62, centro.y);
+    expect(boca).toBeLessThan(-0.1);
+  });
+
+  it('el rostro SOLO se talla al frente: por detrás el tronco queda intacto', () => {
+    expect(desplazamientoRostro({ x: 0, y: 0, z: -1 }, centro.y, centro.y)).toBe(0);
+    expect(desplazamientoRostro({ x: 1, y: 0, z: 0 }, centro.y, centro.y)).toBe(0);
+  });
+
+  it('lejos de la cara (arriba del fuste) no talla nada', () => {
+    expect(Math.abs(desplazamientoRostro(dir(0, 0), centro.y + 4, centro.y))).toBeLessThan(0.01);
+  });
+});
+
+describe('fusionarSeguro TRUENA en vez de dejar la especie invisible', () => {
+  it('lanza si mergeGeometries no puede fusionar (atributos dispares)', () => {
+    const a = new THREE.BoxGeometry(1, 1, 1);
+    a.setAttribute('color', new THREE.BufferAttribute(new Float32Array(a.attributes.position.count * 3), 3));
+    const b = new THREE.BoxGeometry(1, 1, 1); // sin `color`
+    expect(() => fusionarSeguro([a, b], 'prueba')).toThrow(/prueba/);
+  });
+
+  it('lanza con lista vacía en vez de devolver null', () => {
+    expect(() => fusionarSeguro([], 'vacia')).toThrow(/vacia/);
+  });
+
+  it('fusiona indexadas con no-indexadas sin devolver null', () => {
+    // Éste es EL caso que mordió dos veces: Icosahedron viene no-indexado y
+    // Box indexado. El merge directo devolvía null en silencio.
+    const ico = new THREE.IcosahedronGeometry(1, 0);
+    const box = new THREE.BoxGeometry(1, 1, 1);
+    for (const g of [ico, box]) {
+      g.setAttribute('color', new THREE.BufferAttribute(new Float32Array(g.attributes.position.count * 3), 3));
+    }
+    const fusion = fusionarSeguro([ico, box], 'mixta');
+    expect(fusion).toBeTruthy();
+    expect(fusion.attributes.position.count).toBeGreaterThan(0);
+  });
+});
+
+describe('LAS MATAS ya no son árboles de navidad', () => {
+  const especies = {
+    frailejon: (q) => geomFrailejon({ flor: false, q }, 1),
+    frailejonFlor: (q) => geomFrailejon({ flor: true, q }, 2),
+    quenua: (q) => geomQuenua({ q }, 3),
+    encenillo: (q) => geomEncenillo({ q }, 4),
+    aliso: (q) => geomAliso({ q }, 5),
+    gaque: (q) => geomGaque({ q }, 6),
+    roble: (q) => geomRoble({ q }, 11),
+    yarumo: (q) => geomYarumo({ q }, 12),
+    mortino: (q) => geomMortino({ q }, 7),
+    romerillo: (q) => geomRomerillo({ q }, 8),
+    roca: () => geomRoca(9),
+    musgo: () => geomMusgo(10),
+  };
+
+  for (const tier of ['alto', 'medio', 'bajo']) {
+    for (const [nombre, fn] of Object.entries(especies)) {
+      it(`${nombre} construye con vértices y color horneado @ ${tier}`, () => {
+        const g = fn(calidadDeTier(tier));
+        expect(g).toBeTruthy(); // null = invisible sin error
+        expect(g.attributes.position.count).toBeGreaterThan(0);
+        expect(g.attributes.color).toBeTruthy();
+      });
+    }
+  }
+
+  it('el follaje trae SOMBREADO horneado: el corazón oscuro y la piel encendida', () => {
+    // Es la receta de mayor retorno del DR: sin AO por vértice la copa se lee
+    // como una masa sólida de plastilina.
+    const g = geomGaque({ q: 1 }, 6);
+    const col = g.attributes.color;
+    const lum = [];
+    for (let i = 0; i < col.count; i++) {
+      lum.push(col.getX(i) * 0.3 + col.getY(i) * 0.6 + col.getZ(i) * 0.1);
+    }
+    const min = Math.min(...lum);
+    const max = Math.max(...lum);
+    expect(max - min).toBeGreaterThan(0.1); // hay rango, no un color plano
+  });
+
+  it('las copas tienen HUECOS: sembrar deja menos hojas de las pedidas', () => {
+    // Si saliera el 100%, la copa sería una bola rellena y opaca.
+    const puntos = sembrarFollaje({
+      centro: [0, 0, 0], radio: 1, n: 200, semilla: 3, huecos: 0.5, mordida: 0.4, distMin: 0.3,
+    });
+    expect(puntos.length).toBeLessThan(200);
+    expect(puntos.length).toBeGreaterThan(5);
+  });
+
+  it('las copas tienen borde MORDIDO: el radio varía con la dirección', () => {
+    const puntos = sembrarFollaje({
+      centro: [0, 0, 0], radio: 1, n: 120, semilla: 9, huecos: 0.2, mordida: 0.45, distMin: 0.12,
+    });
+    const radios = puntos.map((p) => Math.hypot(...p.pos));
+    expect(Math.max(...radios) - Math.min(...radios)).toBeGreaterThan(0.2);
+  });
+
+  it('las láminas de papel del Polylepis existen en todos los tiers', () => {
+    for (const [, P] of Object.entries(PARAMS_TIER)) {
+      const g = geometriaLaminas(P, 5);
+      expect(g).toBeTruthy();
+      expect(g.attributes.color).toBeTruthy();
+    }
+  });
+});
+
+describe('DISTRIBUCIÓN en bosquetes (no una grilla ni un anillo)', () => {
+  it('cada especie coloca las matas que pide su tier', () => {
+    for (const tier of ['alto', 'medio', 'bajo']) {
+      const conteos = floraDeTier(tier);
+      const dist = distribucionFlora(conteos, 707);
+      for (const [especie, items] of Object.entries(dist)) {
+        expect(items.length).toBe(conteos[especie]);
+      }
+    }
+  });
+
+  it('las matas no se encajan unas en otras (distancia mínima)', () => {
+    const dist = distribucionFlora(floraDeTier('alto'), 707);
+    const f = dist.frailejon;
+    for (let i = 0; i < f.length; i++) {
+      for (let j = i + 1; j < f.length; j++) {
+        const d = Math.hypot(f[i].pos[0] - f[j].pos[0], f[i].pos[2] - f[j].pos[2]);
+        expect(d).toBeGreaterThan(0.5);
+      }
+    }
+  });
+
+  it('nada invade el claro del Ent: el guardián manda en el centro', () => {
+    const dist = distribucionFlora(floraDeTier('alto'), 707);
+    for (const arbol of [...dist.quenua, ...dist.encenillo, ...dist.aliso, ...dist.gaque]) {
+      expect(Math.hypot(arbol.pos[0], arbol.pos[2])).toBeGreaterThan(5);
+    }
+  });
+
+  it('cada instancia trae variación propia (giro, escala, inclinación, tinte)', () => {
+    const dist = distribucionFlora(floraDeTier('alto'), 707);
+    const escalas = new Set(dist.frailejon.map((i) => i.escala.toFixed(3)));
+    expect(escalas.size).toBeGreaterThan(dist.frailejon.length * 0.5);
+    for (const it of dist.frailejon) {
+      expect(it.tint).toHaveLength(3);
+      expect(it.inclina).toHaveLength(2);
+    }
+  });
+
+  it('es determinista: la misma semilla siembra el mismo bosque', () => {
+    const a = distribucionFlora(floraDeTier('alto'), 707);
+    const b = distribucionFlora(floraDeTier('alto'), 707);
+    expect(a.frailejon.map((i) => i.pos)).toEqual(b.frailejon.map((i) => i.pos));
+  });
+});
+
+describe('ruidoFbm', () => {
+  it('devuelve [0,1] y es determinista', () => {
+    for (let i = 0; i < 50; i++) {
+      const v = ruidoFbm(i * 0.7, i * 0.3, i * 1.1);
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+    expect(ruidoFbm(1.5, 2.5, 3.5)).toBe(ruidoFbm(1.5, 2.5, 3.5));
+  });
+  it('varía en el espacio (no es una constante)', () => {
+    const vals = [];
+    for (let i = 0; i < 30; i++) vals.push(ruidoFbm(i * 0.9, 0, 0));
+    expect(Math.max(...vals) - Math.min(...vals)).toBeGreaterThan(0.2);
+  });
+});

--- a/src/visual/mundo3d/bosque/EntQuenua.jsx
+++ b/src/visual/mundo3d/bosque/EntQuenua.jsx
@@ -1,20 +1,34 @@
 /*
- * EntQuenua — el ENT del páramo en 3D real (queñua / colorado, *Polylepis*).
+ * EntQuenua — el ENT del páramo (queñua / colorado, *Polylepis*).
  *
- * NO es un billboard ni un SVG plano: son MALLAS three de verdad. Tronco
- * retorcido y nudoso (TubeGeometry sobre una curva sinuosa, con taper de raigón
- * y desplazamiento de corteza), ramas torcidas, raíces que agarran la tierra,
- * copa de cientos de hojitas verde-plateadas (InstancedMesh, barato) y —el alma—
- * un ROSTRO tallado en la madera: ojos hundidos con brillo, cejas de corteza y
- * una boca-grieta sabia. La corteza rojiza que se pela va en vertexColors
- * (procedural, cero texturas externas).
+ * REHECHO tras el veredicto del operador: *"no se parece en nada al del Señor de
+ * los Anillos, no tiene barba, no tiene vida"*. Los tres reproches eran ciertos
+ * y cada uno tenía una causa concreta:
  *
- * Vida: el árbol se mece lento y con peso desde la raíz, la copa se mece con
- * desfase (viento del páramo) y los ojos parpadean despacio. Ancestral, no
- * rígido. Tier-safe: 'alto' pleno (PBR, facetado, más hojas), 'medio'/'bajo'
- * frugales (Lambert, menos hojas); `reducedMotion` lo deja QUIETO.
+ *   · SIN BARBA — la barba SÍ estaba en el código, pero colgaba recta a una `z`
+ *     fija desde el mentón mientras el tronco se ensancha hacia el pie: el
+ *     raigón se la tragaba entera y solo asomaban dos matas de liquen junto a la
+ *     boca. Ahora las hebras se cuelgan SIGUIENDO la superficie del tronco
+ *     (`specsBarba` consulta el radio real a cada altura) y no pueden volver a
+ *     enterrarse. Es usnea — "barba de viejo", el líquen colgante real del
+ *     bosque altoandino — y cuelga también de las ramas: el mismo líquen que
+ *     viste al bosque viste al guardián.
+ *   · CARICATURA — la cara era una careta PEGADA encima (cejas de tablón, nariz
+ *     de bola, labios de caja): un antifaz de calabaza. Ahora el rostro se TALLA
+ *     en el propio tronco (`desplazamientoRostro`): cuencas hundidas, cejas de
+ *     corteza, caballete, pómulos y boca-grieta son relieve de la madera, y las
+ *     fibras de la corteza corren por encima. Lo único que se monta aparte son
+ *     los OJOS, que van DENTRO de las cuencas.
+ *   · SIN VIDA — ahora respira (el fuste se hincha despacio), se mece con peso
+ *     desde la raíz, la copa se mece con desfase, la barba ondea por vértice
+ *     (cada hebra con su peso: la raíz quieta, la punta suelta) y parpadea.
  *
- * Componente r3f: montar SOLO dentro de un <Canvas> (importa three).
+ * Registro: el Ent es un personaje-árbol —tiene alma— pero su corteza y su
+ * follaje van REALISTAS. Nada de rubber-hose aquí.
+ *
+ * Tier-safe: 'alto' pleno (PBR, cara densa, más hojas y usnea); 'medio'/'bajo'
+ * frugales; `reducedMotion` lo deja QUIETO. Componente r3f: montar SOLO dentro
+ * de un <Canvas>.
  */
 import { useLayoutEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
@@ -22,6 +36,7 @@ import * as THREE from 'three';
 import {
   paramsDeTier,
   geometriaTronco,
+  geometriaLaminas,
   tuboOrganico,
   specsRamas,
   specsRaices,
@@ -32,12 +47,13 @@ import {
   anclaRostro,
   anclaBrazo,
   factorParpadeo,
-  factorHabla,
-  factorSonrisa,
   specsBarba,
+  specsUsneaRamas,
+  geometriaHebra,
   BARBA,
   CORTEZA,
 } from './entQuenua.geom.js';
+import { fusionarSeguro } from './sombreadoVegetal.js';
 
 /* Una nube de hojitas instanciada, mecida como grupo (viento en la copa). */
 function ClusterHojas({ cluster, geo, mat, reducedMotion, fase }) {
@@ -83,218 +99,133 @@ function ClusterHojas({ cluster, geo, mat, reducedMotion, fase }) {
   );
 }
 
-/* El rostro tallado: ojos hundidos con MIRADA viva (iris + pupila que se mueven),
-   cejas de corteza que fruncen el ceño (ánimo legible) y boca-grieta que murmura
-   (habla despacio con la tierra). Los gestos son sutiles y ancestrales, nunca de
-   caricatura; con reducedMotion el rostro queda quieto y sereno. */
-function Rostro({ matOjo, matBrillo, matIris, matCorteza, matGrieta, reducedMotion, blinkRefs }) {
-  const { centro, radio } = useMemo(() => anclaRostro(7), []);
-  // Superficie frontal del tronco a la altura de la mirada (mira al +Z).
-  const frente = radio * 0.9;
-
-  // Refs de los gestos: la mirada (iris de cada ojo), las cejas y la boca.
-  const gazeIzq = useRef(null);
-  const gazeDer = useRef(null);
-  const cejaIzq = useRef(null);
-  const cejaDer = useRef(null);
-  const mandibulaRef = useRef(null); // la mandíbula que baja al HABLAR (abre hacia abajo)
-  const bocaRef = useRef(null); // el conjunto de la boca (para la sonrisa de las comisuras)
-
-  // Los GESTOS: la vida del rostro. Capas lentas y desfasadas para que nunca se
-  // sienta mecánico — mira alrededor, piensa (frunce), murmura.
-  useFrame((state) => {
-    if (reducedMotion) return;
-    const t = state.clock.elapsedTime;
-    // MIRADA: deriva lenta (recorre, se detiene, vuelve). Ambos ojos juntos.
-    const gx = Math.sin(t * 0.24) * 0.03 + Math.sin(t * 0.09 + 1.1) * 0.015;
-    const gy = Math.sin(t * 0.17 + 0.6) * 0.018;
-    if (gazeIzq.current) gazeIzq.current.position.set(gx, gy, 0.12);
-    if (gazeDer.current) gazeDer.current.position.set(gx, gy, 0.12);
-    // CEJAS: ceño pensativo que sube (asombro suave) y baja (frunce sabio).
-    const ceno = (Math.sin(t * 0.35) + Math.sin(t * 0.12 + 2)) * 0.5; // ~-1..1 lento
-    const frunce = Math.max(0, ceno);
-    const alza = Math.max(0, -ceno);
-    if (cejaIzq.current) {
-      cejaIzq.current.position.y = 0.24 + alza * 0.03 - frunce * 0.015;
-      cejaIzq.current.rotation.z = -0.34 - frunce * 0.18;
-    }
-    if (cejaDer.current) {
-      cejaDer.current.position.y = 0.24 + alza * 0.03 - frunce * 0.015;
-      cejaDer.current.rotation.z = 0.34 + frunce * 0.18;
-    }
-    // BOCA: HABLA con articulaciones claras (sílabas) y SONRÍE apenas. La
-    // mandíbula baja SIEMPRE hacia abajo (nunca invade la nariz); las comisuras
-    // suben con la sonrisa. Gestos legibles a distancia, no un murmullo confuso.
-    const abre = factorHabla(t); // 0..1 apertura
-    const sonrisa = factorSonrisa(t); // 0..1
-    if (mandibulaRef.current) {
-      // baja el mentón (traslada + abre la cavidad hacia abajo). Parte de una
-      // apertura EN REPOSO (labios apenas separados) para que la boca se lea como
-      // boca aun quieta, y crece con el habla — nunca sube hacia la nariz.
-      mandibulaRef.current.position.y = -0.03 - abre * 0.14;
-      mandibulaRef.current.rotation.x = 0.1 + abre * 0.45;
-    }
-    if (bocaRef.current) {
-      // la sonrisa ensancha la boca apenas y la sube un pelín (calidez de sabio)
-      bocaRef.current.scale.x = 1 + sonrisa * 0.06;
-      bocaRef.current.position.y = -0.44 + sonrisa * 0.015;
-    }
-  });
-
-  const Ojo = ({ x, refKey, gazeRef }) => (
-    <group position={[x, 0.06, frente - 0.05]} ref={blinkRefs[refKey]}>
-      {/* cuenca hundida: gran cavidad oscura empotrada en la corteza */}
-      <mesh position={[0, 0, -0.03]} scale={[1.3, 1.5, 0.55]}>
-        <sphereGeometry args={[0.15, 16, 14]} />
+/* UN ojo: globo + iris + pupila + chispa. Vive a nivel de módulo (definirlo
+   dentro de `Ojos` crearía un componente nuevo en cada render). */
+function Ojo({ pos, ojoRef, gazeRef, matOjo, matBrillo, matIris, matGrieta }) {
+  return (
+    <group position={pos} ref={ojoRef}>
+      {/* fondo de cuenca: pozo oscuro que asienta el globo en la madera */}
+      <mesh position={[0, 0, -0.06]} scale={[1.3, 1.1, 0.5]}>
+        <sphereGeometry args={[0.155, 14, 12]} />
         <primitive object={matGrieta} attach="material" />
       </mesh>
       {/* globo del ojo: oscuro, con brillo húmedo */}
-      <mesh position={[0, 0, 0.05]}>
-        <sphereGeometry args={[0.115, 18, 16]} />
+      <mesh>
+        <sphereGeometry args={[0.125, 16, 14]} />
         <primitive object={matOjo} attach="material" />
       </mesh>
-      {/* LA MIRADA: iris cálido + pupila + chispa, en un grupo que deriva lento
-          (el ojo "mira" alrededor). Es el mayor salto de personalidad del rostro. */}
-      <group ref={gazeRef} position={[0, 0, 0.12]}>
+      {/* la MIRADA: iris cálido + pupila + chispa */}
+      <group ref={gazeRef} position={[0, 0, 0.075]}>
         <mesh>
-          <sphereGeometry args={[0.052, 14, 12]} />
+          <sphereGeometry args={[0.06, 12, 10]} />
           <primitive object={matIris} attach="material" />
         </mesh>
-        {/* pupila: pozo oscuro en el centro del iris */}
-        <mesh position={[0, 0, 0.032]}>
-          <sphereGeometry args={[0.03, 12, 10]} />
+        <mesh position={[0, 0, 0.036]}>
+          <sphereGeometry args={[0.032, 10, 8]} />
           <primitive object={matGrieta} attach="material" />
         </mesh>
-        {/* la chispa de vida (catchlight): arriba a un lado */}
-        <mesh position={[0.022, 0.03, 0.05]}>
-          <sphereGeometry args={[0.02, 10, 10]} />
+        <mesh position={[0.024, 0.032, 0.052]}>
+          <sphereGeometry args={[0.021, 8, 8]} />
           <primitive object={matBrillo} attach="material" />
         </mesh>
       </group>
     </group>
   );
+}
+
+/*
+ * LOS OJOS — lo único del rostro que NO es madera tallada.
+ *
+ * Van hundidos DENTRO de las cuencas que `desplazamientoRostro` excava, no
+ * pegados sobre la corteza. Cada ojo: globo oscuro y húmedo, iris cálido con
+ * pupila y una chispa de vida (catchlight). La mirada deriva despacio (mira
+ * alrededor, se detiene, vuelve) y parpadea: es lo que hace que el árbol MIRE.
+ */
+function Ojos({ ancla, matOjo, matBrillo, matIris, matGrieta, reducedMotion, blinkRefs }) {
+  const { centro, radio } = ancla;
+  const gazeIzq = useRef(null);
+  const gazeDer = useRef(null);
+
+  // Dónde excava `desplazamientoRostro` cada cuenca: u = dir.x = ±0.4, mirando
+  // al +Z. El ojo se asienta en el fondo de esa cuenca.
+  const sitio = (signo) => {
+    const dir = new THREE.Vector3(signo * 0.46, 0.06, Math.sqrt(1 - 0.46 * 0.46)).normalize();
+    return centro.clone().addScaledVector(dir, radio * 0.62);
+  };
+  const izq = useMemo(() => sitio(-1), [centro, radio]); // eslint-disable-line react-hooks/exhaustive-deps
+  const der = useMemo(() => sitio(1), [centro, radio]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const t = state.clock.elapsedTime;
+    // Deriva lenta de la mirada: recorre, se detiene, vuelve. Ambos ojos juntos.
+    const gx = Math.sin(t * 0.24) * 0.028 + Math.sin(t * 0.09 + 1.1) * 0.014;
+    const gy = Math.sin(t * 0.17 + 0.6) * 0.016;
+    if (gazeIzq.current) gazeIzq.current.position.set(gx, gy, 0.075);
+    if (gazeDer.current) gazeDer.current.position.set(gx, gy, 0.075);
+  });
 
   return (
-    <group position={[centro.x, centro.y, centro.z]} scale={[1.5, 1.55, 1.15]}>
-      <Ojo x={-0.24} refKey="izq" gazeRef={gazeIzq} />
-      <Ojo x={0.24} refKey="der" gazeRef={gazeDer} />
-
-      {/* cejas de corteza: crestas gruesas e inclinadas, ceño sabio/severo que
-          se mueve (fruncir/alzar) = el ánimo del guardián, legible a distancia */}
-      <mesh ref={cejaIzq} position={[-0.24, 0.24, frente + 0.01]} rotation={[0, 0, -0.34]}>
-        <boxGeometry args={[0.34, 0.085, 0.13]} />
-        <primitive object={matCorteza} attach="material" />
-      </mesh>
-      <mesh ref={cejaDer} position={[0.24, 0.24, frente + 0.01]} rotation={[0, 0, 0.34]}>
-        <boxGeometry args={[0.34, 0.085, 0.13]} />
-        <primitive object={matCorteza} attach="material" />
-      </mesh>
-
-      {/* caballete de la nariz: nudo vertical entre los ojos. MÁS CORTO que antes
-          (terminaba encima de la boca): ahora deja un surco/filtrum limpio hasta
-          los labios para que la boca se lea sola y no choque con la nariz. */}
-      <mesh position={[0, 0.0, frente + 0.04]} rotation={[0.18, 0, 0]}>
-        <boxGeometry args={[0.1, 0.28, 0.12]} />
-        <primitive object={matCorteza} attach="material" />
-      </mesh>
-      {/* base/punta de la nariz: nudo redondeado donde termina el caballete */}
-      <mesh position={[0, -0.17, frente + 0.05]}>
-        <sphereGeometry args={[0.075, 10, 8]} />
-        <primitive object={matCorteza} attach="material" />
-      </mesh>
-      {/* pómulos/bolsas bajo los ojos: dan edad y peso al rostro */}
-      <mesh position={[-0.24, -0.12, frente]} rotation={[0, 0, 0.2]}>
-        <boxGeometry args={[0.26, 0.07, 0.1]} />
-        <primitive object={matCorteza} attach="material" />
-      </mesh>
-      <mesh position={[0.24, -0.12, frente]} rotation={[0, 0, -0.2]}>
-        <boxGeometry args={[0.26, 0.07, 0.1]} />
-        <primitive object={matCorteza} attach="material" />
-      </mesh>
-
-      {/* LA BOCA — rehecha: dos LABIOS de corteza (arriba fijo, abajo en la
-          MANDÍBULA que baja) con una cavidad oscura detrás. Va BIEN bajo la nariz
-          (filtrum limpio) y ABRE hacia abajo → el gesto de HABLAR se lee claro y
-          nunca invade la nariz. Comisuras marcadas para que la sonrisa se note. */}
-      <group ref={bocaRef} position={[0, -0.44, frente]}>
-        {/* cavidad oscura: el fondo de la boca (fijo). Asoma al abrir la mandíbula */}
-        <mesh position={[0, -0.03, -0.05]} scale={[0.3, 0.14, 0.1]}>
-          <sphereGeometry args={[1, 14, 12]} />
-          <primitive object={matGrieta} attach="material" />
-        </mesh>
-
-        {/* labio SUPERIOR: cresta de corteza fija, apenas curvada hacia arriba */}
-        <mesh position={[0, 0.055, 0.03]} rotation={[-0.12, 0, 0]}>
-          <boxGeometry args={[0.42, 0.07, 0.14]} />
-          <primitive object={matCorteza} attach="material" />
-        </mesh>
-        {/* comisuras: nudos en los extremos (dan a la boca su ancho y la sonrisa) */}
-        {[-0.22, 0.22].map((cx) => (
-          <mesh key={cx} position={[cx, 0.0, 0.03]}>
-            <sphereGeometry args={[0.045, 8, 7]} />
-            <primitive object={matCorteza} attach="material" />
-          </mesh>
-        ))}
-
-        {/* la MANDÍBULA: labio inferior + mentón. Baja al hablar (pivota en el
-            origen de este grupo, que está en la línea de los labios). */}
-        <group ref={mandibulaRef}>
-          <mesh position={[0, -0.07, 0.03]} rotation={[0.14, 0, 0]}>
-            <boxGeometry args={[0.4, 0.08, 0.14]} />
-            <primitive object={matCorteza} attach="material" />
-          </mesh>
-          {/* el mentón: nudo macizo bajo el labio (peso de árbol viejo) */}
-          <mesh position={[0, -0.17, 0.0]}>
-            <boxGeometry args={[0.3, 0.1, 0.12]} />
-            <primitive object={matCorteza} attach="material" />
-          </mesh>
-        </group>
-      </group>
+    <group>
+      <Ojo
+        pos={izq} ojoRef={blinkRefs.izq} gazeRef={gazeIzq}
+        matOjo={matOjo} matBrillo={matBrillo} matIris={matIris} matGrieta={matGrieta}
+      />
+      <Ojo
+        pos={der} ojoRef={blinkRefs.der} gazeRef={gazeDer}
+        matOjo={matOjo} matBrillo={matBrillo} matIris={matIris} matGrieta={matGrieta}
+      />
     </group>
   );
 }
 
-/* La BARBA de árbol-anciano (Bárbol): cortinas de musgo que cuelgan de la
-   mandíbula, raicillas leñosas en el mentón y matas de liquen a los lados. Enmarca
-   la boca sin taparla y se mece despacio (un Ent sabio y muy viejo). */
-function Barba({ ancla, matMusgo, matMusgoClaro, matRaiz, matLiquen, matLiquenAzul, reducedMotion }) {
-  const { centro, radio } = ancla;
-  const frente = radio * 0.9;
-  const { mechones, raicillas, liquenes } = useMemo(() => specsBarba(91), []);
-  const grupoRef = useRef(null);
-  useFrame((st) => {
-    if (reducedMotion || !grupoRef.current) return;
-    const t = st.clock.elapsedTime;
-    grupoRef.current.rotation.z = Math.sin(t * 0.5) * 0.02;
-    grupoRef.current.rotation.x = 0.04 + Math.sin(t * 0.4 + 1) * 0.015;
+/*
+ * LOS COLGANTES: la barba de usnea del mentón + la usnea que cuelga de las
+ * ramas, TODO fusionado en una sola malla (una draw-call) con el color ya
+ * horneado y un atributo `peso` por vértice (0 en la raíz → 1 en la punta).
+ *
+ * El meceo se hace por VÉRTICE en CPU: son ~1.5k vértices, nada para un móvil,
+ * y a cambio cada hebra ondula por su cuenta —la raíz quieta y la punta suelta—
+ * en vez de girar en bloque como una peluca. Es el movimiento el que convierte
+ * la barba en barba (DR §3: "geometría de mechones + movimiento + densidad").
+ */
+function Colgantes({ geo, mat, reducedMotion }) {
+  const meshRef = useRef(null);
+  // Copia de las posiciones en reposo: el meceo se calcula SIEMPRE desde la
+  // base (si se acumulara sobre la posición viva, la barba se iría a la deriva).
+  const base = useMemo(() => (geo ? Float32Array.from(geo.attributes.position.array) : null), [geo]);
+
+  useFrame((state) => {
+    const mesh = meshRef.current;
+    if (!mesh || !base || reducedMotion) return;
+    // La geometría se toma del REF de la malla, no de la prop: mutar un valor
+    // que llegó por props está prohibido (y además es mala idea).
+    const viva = mesh.geometry;
+    if (!viva?.attributes?.peso) return;
+    const t = state.clock.elapsedTime;
+    const pos = viva.attributes.position;
+    const peso = viva.attributes.peso;
+    const arr = pos.array;
+    for (let i = 0; i < pos.count; i++) {
+      const k = i * 3;
+      const bx = base[k];
+      const by = base[k + 1];
+      const bz = base[k + 2];
+      const w = peso.array[i];
+      if (w <= 0.0001) continue;
+      // Onda que viaja por la barba: la fase depende del sitio → las hebras no
+      // se mueven todas a la vez (eso es lo que delata una peluca).
+      const a = Math.sin(t * 1.05 + by * 2.2 + bx * 1.6) * 0.05;
+      const b = Math.cos(t * 0.83 + by * 1.7 + bz * 1.9) * 0.038;
+      arr[k] = bx + a * w;
+      arr[k + 1] = by - Math.abs(a) * w * 0.25; // al ondear, cuelga un pelín menos
+      arr[k + 2] = bz + b * w;
+    }
+    pos.needsUpdate = true;
   });
-  return (
-    <group position={[centro.x, centro.y, centro.z]} scale={[1.5, 1.55, 1.15]}>
-      <group ref={grupoRef} position={[0, 0, frente]}>
-        {/* mechones de musgo (cortina de la barba). Cono con la punta hacia ABAJO. */}
-        {mechones.map((m, i) => (
-          <mesh key={`mb-${i}`} position={[m.x, m.yTop - m.len / 2, m.z]} rotation={[Math.PI, 0, m.tilt]}>
-            <coneGeometry args={[m.grosor, m.len, 5]} />
-            <primitive object={m.claro ? matMusgoClaro : matMusgo} attach="material" />
-          </mesh>
-        ))}
-        {/* raicillas leñosas: hebras largas en el centro del mentón */}
-        {raicillas.map((m, i) => (
-          <mesh key={`rc-${i}`} position={[m.x, m.yTop - m.len / 2, m.z]} rotation={[Math.PI, 0, m.tilt]}>
-            <coneGeometry args={[m.grosor, m.len, 5]} />
-            <primitive object={matRaiz} attach="material" />
-          </mesh>
-        ))}
-        {/* matas de liquen prendidas a los lados de la boca */}
-        {liquenes.map((l, i) => (
-          <mesh key={`lq-${i}`} position={l.pos} scale={[l.esc * 1.5, l.esc * 0.55, l.esc]}>
-            <icosahedronGeometry args={[1, 0]} />
-            <primitive object={l.azul ? matLiquenAzul : matLiquen} attach="material" />
-          </mesh>
-        ))}
-      </group>
-    </group>
-  );
+
+  if (!geo) return null;
+  return <mesh ref={meshRef} geometry={geo} material={mat} frustumCulled={false} />;
 }
 
 /* El BRAZO MAESTRO: una rama-brazo que sale del fuste, se estira hacia afuera y
@@ -383,6 +314,9 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
 
   // --- Geometrías (una vez) ---
   const troncoGeo = useMemo(() => geometriaTronco(P, 7), [P]);
+  // Las LÁMINAS de papel del Polylepis: la firma de la especie. Van aparte del
+  // tubo del tronco para no tocar el rostro tallado.
+  const laminasGeo = useMemo(() => geometriaLaminas(P, 5), [P]);
   const ramas = useMemo(() => specsRamas(P.ramas, 21), [P.ramas]);
   const ramasGeo = useMemo(
     () => ramas.map((r) => tuboOrganico(r.curve, {
@@ -410,10 +344,42 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
     [ramas, P],
   );
 
+  // LA BARBA + la usnea de las ramas: todo en UNA malla (una draw-call).
+  const colgantesGeo = useMemo(() => {
+    const { hebras, liquenes } = specsBarba(91, P.barba);
+    const usnea = specsUsneaRamas(ramas.map((r) => r.punta), P.usnea, 77);
+    const partes = [];
+    for (const h of hebras) {
+      partes.push(geometriaHebra(h, h.claro ? BARBA.musgoClaro : BARBA.musgo, 4));
+    }
+    for (const m of usnea) {
+      partes.push(geometriaHebra(m, m.claro ? BARBA.liquen : BARBA.liquenAzul, 3));
+    }
+    // Matas de liquen foliáceo prendidas al arranque de la barba: cosen la
+    // barba a la madera (si no, se lee como peluca puesta encima).
+    for (const l of liquenes) {
+      const g = new THREE.IcosahedronGeometry(1, 0);
+      g.scale(l.esc * 1.5, l.esc * 0.55, l.esc);
+      g.translate(l.pos[0], l.pos[1], l.pos[2]);
+      const col = l.azul ? BARBA.liquenAzul : BARBA.liquen;
+      const n = g.attributes.position.count;
+      const cols = new Float32Array(n * 3);
+      for (let i = 0; i < n; i++) {
+        cols[i * 3] = col.r;
+        cols[i * 3 + 1] = col.g;
+        cols[i * 3 + 2] = col.b;
+      }
+      g.setAttribute('color', new THREE.BufferAttribute(cols, 3));
+      // Quietas (peso 0): están prendidas a la corteza, no cuelgan.
+      g.setAttribute('peso', new THREE.BufferAttribute(new Float32Array(n), 1));
+      partes.push(g);
+    }
+    return fusionarSeguro(partes, 'colgantes-ent');
+  }, [P.barba, P.usnea, ramas]);
+
   // --- Materiales (una vez) ---
-  // Corteza SUAVE (flatShading off): el relieve de surcos/nudos es geometría
-  // real; el sombreado liso evita el "acordeón" de anillos del tubo y deja una
-  // corteza orgánica. El facetado se reserva para las hojitas (matHoja).
+  // Corteza SUAVE (flatShading off): el relieve de surcos, nudos y del ROSTRO es
+  // geometría real; el sombreado liso evita el "acordeón" de anillos del tubo.
   const matCorteza = useMemo(() => {
     const base = { vertexColors: true, flatShading: false };
     return P.materialRico
@@ -440,9 +406,7 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
     [P.materialRico],
   );
   const matBrillo = useMemo(() => new THREE.MeshBasicMaterial({ color: '#eef4e8' }), []);
-  // Iris cálido y VIVO: el glow ámbar que hace que el rostro MIRE (antes el ojo
-  // era una bola oscura con una chispa; con iris + pupila la mirada se lee y se
-  // le puede seguir el gesto). Rico = emisivo real; frugal = básico constante.
+  // Iris cálido y VIVO: el glow ámbar que hace que el rostro MIRE.
   const matIris = useMemo(
     () => (P.materialRico
       ? new THREE.MeshStandardMaterial({ color: '#c98a3a', emissive: '#7a4616', emissiveIntensity: 0.7, roughness: 0.35, metalness: 0.05 })
@@ -456,34 +420,38 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
     [P.materialRico],
   );
   const hojaGeo = useMemo(() => new THREE.IcosahedronGeometry(1, 0), []);
-
-  // Materiales de la BARBA (musgo/liquen/raicilla): Lambert siempre (baratos y
-  // pequeños; el musgo no pide PBR). El ancla del rostro sitúa la barba en el mentón.
-  const matMusgo = useMemo(() => new THREE.MeshLambertMaterial({ color: BARBA.musgo }), []);
-  const matMusgoClaro = useMemo(() => new THREE.MeshLambertMaterial({ color: BARBA.musgoClaro }), []);
-  const matBarbaRaiz = useMemo(() => new THREE.MeshLambertMaterial({ color: BARBA.raicilla }), []);
-  const matLiquen = useMemo(() => new THREE.MeshLambertMaterial({ color: BARBA.liquen }), []);
-  const matLiquenAzul = useMemo(() => new THREE.MeshLambertMaterial({ color: BARBA.liquenAzul }), []);
+  // Los colgantes traen su color horneado (musgo → liquen hacia la punta).
+  const matColgante = useMemo(
+    () => new THREE.MeshLambertMaterial({ vertexColors: true, side: THREE.DoubleSide }),
+    [],
+  );
   const ancla = useMemo(() => anclaRostro(7), []);
 
   // Liberar GPU al desmontar (geometrías y materiales procedurales).
   useLayoutEffect(() => () => {
     troncoGeo.dispose();
+    laminasGeo?.dispose();
     ramasGeo.forEach((g) => g.dispose());
     raicesGeo.forEach((g) => g.dispose());
+    colgantesGeo.dispose();
     hojaGeo.dispose();
-    [matCorteza, matCortezaLisa, matGrieta, matOjo, matBrillo, matIris, matHoja,
-      matMusgo, matMusgoClaro, matBarbaRaiz, matLiquen, matLiquenAzul].forEach((m) => m.dispose());
-  }, [troncoGeo, ramasGeo, raicesGeo, hojaGeo, matCorteza, matCortezaLisa, matGrieta, matOjo, matBrillo, matIris, matHoja,
-    matMusgo, matMusgoClaro, matBarbaRaiz, matLiquen, matLiquenAzul]);
+    [matCorteza, matCortezaLisa, matGrieta, matOjo, matBrillo, matIris, matHoja, matColgante]
+      .forEach((m) => m.dispose());
+  }, [troncoGeo, laminasGeo, ramasGeo, raicesGeo, colgantesGeo, hojaGeo, matCorteza,
+    matCortezaLisa, matGrieta, matOjo, matBrillo, matIris, matHoja, matColgante]);
 
-  // --- Vida: balanceo pesado + parpadeo lento ---
+  // --- Vida: RESPIRACIÓN + balanceo pesado + parpadeo lento ---
   useFrame((state) => {
     if (reducedMotion) return;
     const t = state.clock.elapsedTime;
     if (swayRef.current) {
+      // Se mece con peso desde la raíz (lento: es un árbol viejo, no un junco).
       swayRef.current.rotation.z = Math.sin(t * 0.45) * 0.018;
       swayRef.current.rotation.x = Math.sin(t * 0.37 + 1.1) * 0.012;
+      // RESPIRA: el fuste se hincha y se afloja muy despacio. Es minúsculo
+      // (0.6%) y a propósito: si se nota, ya no es respiración, es un globo.
+      const respira = 1 + Math.sin(t * 0.34) * 0.006;
+      swayRef.current.scale.set(respira, 1 + (respira - 1) * 0.35, respira);
     }
     const b = factorParpadeo(t);
     if (ojoIzq.current) ojoIzq.current.scale.y = b;
@@ -497,33 +465,31 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
         <mesh key={`raiz-${i}`} geometry={g} material={matCorteza} castShadow receiveShadow />
       ))}
 
-      {/* tronco + ramas + rostro + copa: se mecen desde la base */}
+      {/* tronco (con el rostro TALLADO) + ramas + barba + copa: se mecen desde la base */}
       <group ref={swayRef}>
         <mesh geometry={troncoGeo} material={matCorteza} castShadow receiveShadow />
+        {/* la corteza que se DESCAMA en láminas de papel: Polylepis = "muchas
+            escamas". Sin esto el fuste se lee como un tubo marrón liso. */}
+        {laminasGeo && (
+          <mesh geometry={laminasGeo} material={matCorteza} castShadow receiveShadow />
+        )}
         {ramasGeo.map((g, i) => (
           <mesh key={`rama-${i}`} geometry={g} material={matCorteza} castShadow receiveShadow />
         ))}
 
-        <Rostro
+        {/* los OJOS, dentro de las cuencas que talla el tronco */}
+        <Ojos
+          ancla={ancla}
           matOjo={matOjo}
           matBrillo={matBrillo}
           matIris={matIris}
-          matCorteza={matCortezaLisa}
           matGrieta={matGrieta}
           reducedMotion={reducedMotion}
           blinkRefs={{ izq: ojoIzq, der: ojoDer }}
         />
 
-        {/* la BARBA de árbol-anciano (siempre): musgo, liquen y raicillas */}
-        <Barba
-          ancla={ancla}
-          matMusgo={matMusgo}
-          matMusgoClaro={matMusgoClaro}
-          matRaiz={matBarbaRaiz}
-          matLiquen={matLiquen}
-          matLiquenAzul={matLiquenAzul}
-          reducedMotion={reducedMotion}
-        />
+        {/* LA BARBA de usnea + la usnea de las ramas (una sola malla) */}
+        <Colgantes geo={colgantesGeo} mat={matColgante} reducedMotion={reducedMotion} />
 
         {/* el BRAZO MAESTRO que señala el subsuelo (solo en el mundo Ent-maestro) */}
         {señala && (

--- a/src/visual/mundo3d/bosque/EscenaEntMaestro.jsx
+++ b/src/visual/mundo3d/bosque/EscenaEntMaestro.jsx
@@ -53,7 +53,7 @@ const PROF_CUT = 1.7;
 const CARA = PROF_CUT / 2; // el plano frontal expuesto del corte
 
 /* Dónde se planta la vitrina de suelo, al lado del Ent (donde apunta su mano). */
-const CORTE_POS = [2.5, 0, 1.9];
+const CORTE_POS = /** @type {[number, number, number]} */ ([2.5, 0, 1.9]);
 
 /*
  * LAS CAPAS del suelo, de arriba abajo — la lección. `alto` en metros-escena,
@@ -61,12 +61,24 @@ const CORTE_POS = [2.5, 0, 1.9];
  * (Grounded: hojarasca que abriga, humus vivo, zona de raíces, la red de hongos
  * que reparte, y la roca madre de donde nace la tierra.)
  */
+/*
+ * OJO CON LOS COLORES: la primera versión pintaba el humus '#241611' y las
+ * micorrizas '#140f0c' — casi negro puro. Con la luz del páramo (cenital y
+ * difusa) la cara frontal del corte no recibe casi nada, y la vitrina entera se
+ * veía como un AGUJERO NEGRO: la lección existía y era imposible de leer. Ese
+ * era, literalmente, el *"no veo la lección del subsuelo"* del operador.
+ *
+ * La tierra real, iluminada, NO es negra: es parda. Estos tonos siguen siendo
+ * oscuros y siguen dejando brillar la red micorrízica, pero se VEN. Y la banda
+ * de las micorrizas se mantiene la más oscura a propósito, para que el
+ * bioluminiscente resalte contra ella.
+ */
 const CAPAS = [
-  { id: 'hojarasca', nombre: 'Hojarasca', alto: 0.42, color: '#6e4a2a', hint: 'Las hojas caídas que abrigan y alimentan el suelo.' },
-  { id: 'humus', nombre: 'Humus', alto: 0.95, color: '#241611', hint: 'Tierra negra viva: lombrices y bacterias hacen el alimento.' },
-  { id: 'raices', nombre: 'Zona de raíces', alto: 1.15, color: '#3a2618', hint: 'Aquí las matas beben agua y minerales.' },
-  { id: 'micorrizas', nombre: 'Red micorrízica', alto: 1.35, color: '#140f0c', hint: 'El internet de hongos: reparte comida entre las plantas.' },
-  { id: 'roca', nombre: 'Roca madre', alto: 0.92, color: '#4b4a52', hint: 'La piedra de donde, poco a poco, nace la tierra.' },
+  { id: 'hojarasca', nombre: 'Hojarasca', alto: 0.42, color: '#8a6038', hint: 'Las hojas caídas que abrigan y alimentan el suelo.' },
+  { id: 'humus', nombre: 'Humus', alto: 0.95, color: '#4a3325', hint: 'Tierra negra viva: lombrices y bacterias hacen el alimento.' },
+  { id: 'raices', nombre: 'Zona de raíces', alto: 1.15, color: '#63492f', hint: 'Aquí las matas beben agua y minerales.' },
+  { id: 'micorrizas', nombre: 'Red micorrízica', alto: 1.35, color: '#33261c', hint: 'El internet de hongos: reparte comida entre las plantas.' },
+  { id: 'roca', nombre: 'Roca madre', alto: 0.92, color: '#6d6b78', hint: 'La piedra de donde, poco a poco, nace la tierra.' },
 ];
 
 const DUR_CAPA = 3.6; // segundos que el Ent "enseña" cada capa
@@ -123,6 +135,7 @@ function redDeBanda(alto, tier) {
 
 /* La malla de la red (un draw-call, aditiva, respira). */
 function RedMicelio({ geo, reducedMotion }) {
+  const meshRef = useRef(null);
   const mat = useMemo(
     () => new THREE.MeshBasicMaterial({
       vertexColors: true, transparent: true, opacity: 0.92,
@@ -132,11 +145,13 @@ function RedMicelio({ geo, reducedMotion }) {
   );
   useLayoutEffect(() => () => mat.dispose(), [mat]);
   useFrame((st) => {
-    if (reducedMotion) return;
-    mat.opacity = 0.84 + Math.sin(st.clock.elapsedTime * 0.9) * 0.1;
+    if (reducedMotion || !meshRef.current) return;
+    // Vía el ref de la malla: mutar el material del useMemo directamente está
+    // prohibido (valor capturado), y por el ref es el mismo objeto.
+    meshRef.current.material.opacity = 0.84 + Math.sin(st.clock.elapsedTime * 0.9) * 0.1;
   });
   if (!geo) return null;
-  return <mesh geometry={geo} material={mat} frustumCulled={false} />;
+  return <mesh ref={meshRef} geometry={geo} material={mat} frustumCulled={false} />;
 }
 
 /* Los NODOS del micelio (arbúsculos/nodos/esporas), instanciados. */
@@ -254,7 +269,9 @@ function DetalleCapa({ capa, alto, red, reducedMotion }) {
   if (capa.id === 'hojarasca') {
     // hojitas caídas sobre la cara (flecos ocres)
     const hojas = Array.from({ length: 10 }, (_, i) => ({
-      key: i, pos: [(r() - 0.5) * (ANCHO_CUT - 0.4), (r() - 0.5) * alto * 0.6, CARA - 0.02], giro: r() * Math.PI,
+      key: i,
+      pos: /** @type {[number, number, number]} */ ([(r() - 0.5) * (ANCHO_CUT - 0.4), (r() - 0.5) * alto * 0.6, CARA - 0.02]),
+      giro: r() * Math.PI,
     }));
     return (
       <group>
@@ -309,7 +326,9 @@ function DetalleCapa({ capa, alto, red, reducedMotion }) {
   if (capa.id === 'roca') {
     // roca madre: pedruscos facetados grises embebidos
     const rocas = Array.from({ length: 6 }, (_, i) => ({
-      key: i, pos: [(r() - 0.5) * (ANCHO_CUT - 0.4), (r() - 0.5) * alto * 0.7, CARA - 0.05], esc: 0.14 + r() * 0.16,
+      key: i,
+      pos: /** @type {[number, number, number]} */ ([(r() - 0.5) * (ANCHO_CUT - 0.4), (r() - 0.5) * alto * 0.7, CARA - 0.05]),
+      esc: 0.14 + r() * 0.16,
     }));
     return (
       <group>
@@ -360,7 +379,7 @@ function Capa({ capa, activa, red, reducedMotion }) {
 
 /* La VITRINA de suelo completa + la LECCIÓN (qué capa está enseñando el Ent). */
 function CorteSuelo({ tier, reducedMotion }) {
-  const capas = useMemo(centrosCapas, []);
+  const capas = useMemo(() => centrosCapas(), []);
   const bandaMic = useMemo(() => capas.find((c) => c.id === 'micorrizas'), [capas]);
   const red = useMemo(() => redDeBanda(bandaMic.alto, tier), [bandaMic.alto, tier]);
   useLayoutEffect(() => () => red.geo?.dispose(), [red]);
@@ -411,12 +430,26 @@ function Diorama({ tier, reducedMotion }) {
         shadow-camera-bottom={-8}
       />
       <directionalLight position={[-5, 6, -6]} intensity={0.4} color="#b9cdd6" />
+      {/*
+        LUZ DE VITRINA — la clave para que la lección se vea. El sol del páramo
+        viene de arriba, así que la CARA FRONTAL del corte (que mira al +Z, a la
+        cámara) quedaba a contraluz y en sombra: la tierra se leía negra y las
+        capas no existían. Esta luz frontal, casi horizontal, es la que "abre" la
+        vitrina. No castea sombras: es relleno puro y barato.
+      */}
+      <directionalLight
+        position={[CORTE_POS[0] + 1, 1.5, CORTE_POS[2] + 12]}
+        intensity={1.05}
+        color="#f0ead8"
+      />
       {/* relleno cálido bajo tierra: da cuerpo a la red y a las capas */}
       <pointLight position={[CORTE_POS[0], -1.6, CORTE_POS[2] + 1]} intensity={0.6} color="#37d6b0" distance={9} decay={2} />
+      {/* segundo relleno abajo del todo: la roca madre no puede caer a negro */}
+      <pointLight position={[CORTE_POS[0], -4.2, CORTE_POS[2] + 2.5]} intensity={0.5} color="#cfd6dd" distance={7} decay={2} />
 
       {/* parche de musgo del páramo bajo el Ent */}
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.01, 0]} receiveShadow>
-        <circleGeometry args={[3.0, 32]} />
+        <circleGeometry args={[4.2, 32]} />
         <meshLambertMaterial color={PARAMO.musgo} />
       </mesh>
       {/* apron de tierra que lleva del musgo a la vitrina de suelo */}
@@ -433,11 +466,11 @@ function Diorama({ tier, reducedMotion }) {
 
       <OrbitControls
         makeDefault
-        target={[1.5, -0.2, 0.9]}
+        target={[1.5, -1.5, 1.1]}
         enablePan={false}
         enableZoom
-        minDistance={7}
-        maxDistance={22}
+        minDistance={9}
+        maxDistance={26}
         minPolarAngle={0.5}
         maxPolarAngle={1.52}
         enableDamping
@@ -466,7 +499,7 @@ export default function EscenaEntMaestro({ tier = 'alto', reducedMotion = false 
         dpr={perfil.dpr}
         gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
         shadows={perfil.sombras ? 'soft' : false}
-        camera={{ position: [4.5, 2.0, 14], fov: 46 }}
+        camera={{ position: [3.4, 0.2, 14.6], fov: 46 }}
         frameloop={reducedMotion ? 'demand' : 'always'}
         onCreated={() => setListo(true)}
       >

--- a/src/visual/mundo3d/bosque/FloraParamo.jsx
+++ b/src/visual/mundo3d/bosque/FloraParamo.jsx
@@ -1,18 +1,22 @@
 /*
- * FloraParamo — el ECOSISTEMA de páramo que rodea al Ent de la queñua.
+ * FloraParamo — el BOSQUE ALTOANDINO que rodea al Ent de la queñua.
  *
- * Una CAPA de flora altoandina colombiana sembrada alrededor del guardián (que
- * sigue siendo EL árbol mayor y el foco): el frailejonar al frente, el sotobosque
- * de mortiño y romerillo, las rocas con líquen y el musgo del suelo, y —velados
- * por la niebla, en el anillo exterior— los árboles del bosque de niebla: roble
- * andino, aliso, encenillo, gaque y el yarumo plateado/blanco de envés blanco.
- * Así el claro se lee como un páramo VIVO y el Ent RESALTA como el más grande.
+ * Una capa de flora de páramo sembrada en BOSQUETES alrededor del guardián (que
+ * sigue siendo EL árbol mayor y el foco): el frailejonar en el anillo interior,
+ * el sotobosque de mortiño y romerillo en los bordes, las rocas con líquen y el
+ * musgo del suelo, y —velados por la niebla, más lejos— el cortejo leñoso:
+ * queñuas jóvenes (la familia del Ent), encenillos, alisos y gaques.
  *
- * Tier-safe (DR §3): cada especie es UN InstancedMesh de una geometría fusionada
- * → una draw-call por especie por más matas que haya. La flora es PAISAJE: monta
- * quieta (el foco animado es el Ent). Solo en 'alto' se añade un vaho a la deriva.
- * Todo procedural: cero CDN/imágenes externas (la niebla usa una CanvasTexture
- * generada en runtime).
+ * El cortejo cambió tras el rechazo del operador: se fueron el yarumo y el roble
+ * (que son de bosque andino/subandino, no de páramo) y entró la QUEÑUA joven, que
+ * es la misma especie del Ent — el guardián deja de ser un solitario y pasa a ser
+ * el más viejo de su familia.
+ *
+ * Tier-safe: cada especie es UN InstancedMesh de una geometría fusionada con el
+ * color ya horneado → una draw-call por especie por más matas que haya. La flora
+ * es PAISAJE: monta quieta (el foco animado es el Ent). Solo en 'alto' se añade
+ * un vaho a la deriva. Todo procedural: cero CDN/imágenes externas (la niebla usa
+ * una CanvasTexture generada en runtime).
  *
  * Componente r3f: montar dentro del <Canvas> de EscenaBosqueVivo.
  */
@@ -25,8 +29,7 @@ import {
   calidadDeTier,
   distribucionFlora,
   geomFrailejon,
-  geomYarumo,
-  geomRoble,
+  geomQuenua,
   geomEncenillo,
   geomAliso,
   geomGaque,
@@ -36,7 +39,12 @@ import {
   geomMusgo,
 } from './floraParamo.geom.js';
 
-/* Un banco de matas de UNA especie: una geometría, un material, N instancias. */
+/*
+ * Un banco de matas de UNA especie: una geometría, un material, N instancias.
+ * Cada instancia lleva su propia rotación, INCLINACIÓN, escala y tinte: es la
+ * variación por instancia que el DR pide para que un bosque no se lea como el
+ * mismo mesh repetido (retorno alto, costo casi nulo).
+ */
 function Especie({ geo, mat, items, castShadow = false }) {
   const ref = useRef(null);
 
@@ -52,7 +60,10 @@ function Especie({ geo, mat, items, castShadow = false }) {
     for (let i = 0; i < items.length; i++) {
       const it = items[i];
       p.set(it.pos[0], it.pos[1], it.pos[2]);
-      e.set(0, it.rotY, 0);
+      // Inclinación sutil (x,z) + giro propio: ningún ejemplar está a plomo ni
+      // mira igual que su vecino.
+      const inc = it.inclina || [0, 0];
+      e.set(inc[0], it.rotY, inc[1]);
       q.setFromEuler(e);
       s.setScalar(it.escala);
       m.compose(p, q, s);
@@ -118,7 +129,7 @@ function NieblaRasante({ n, reducedMotion }) {
       const ang = (i / n) * Math.PI * 2 + i * 1.3;
       const rad = 7 + (i % 3) * 1.8;
       arr.push({
-        base: [Math.cos(ang) * rad, 1.1 + (i % 2) * 0.5, Math.sin(ang) * rad],
+        base: /** @type {[number, number, number]} */ ([Math.cos(ang) * rad, 1.1 + (i % 2) * 0.5, Math.sin(ang) * rad]),
         fase: i * 2.1,
         amp: 1.2 + (i % 3) * 0.6,
       });
@@ -172,27 +183,28 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false }) {
     const g = {};
     if (conteos.frailejon) g.frailejon = geomFrailejon({ flor: false, q }, 1);
     if (conteos.frailejonFlor) g.frailejonFlor = geomFrailejon({ flor: true, q }, 2);
-    if (conteos.yarumo) g.yarumo = geomYarumo({ q }, 3);
-    if (conteos.roble) g.roble = geomRoble({ q }, 4);
-    if (conteos.encenillo) g.encenillo = geomEncenillo({ q }, 5);
-    if (conteos.aliso) g.aliso = geomAliso({ q }, 6);
-    if (conteos.gaque) g.gaque = geomGaque({ q }, 7);
-    if (conteos.mortino) g.mortino = geomMortino({ q }, 8);
-    if (conteos.romerillo) g.romerillo = geomRomerillo({ q }, 9);
-    if (conteos.roca) g.roca = geomRoca(10);
-    if (conteos.musgo) g.musgo = geomMusgo(11);
+    if (conteos.quenua) g.quenua = geomQuenua({ q }, 3);
+    if (conteos.encenillo) g.encenillo = geomEncenillo({ q }, 4);
+    if (conteos.aliso) g.aliso = geomAliso({ q }, 5);
+    if (conteos.gaque) g.gaque = geomGaque({ q }, 6);
+    if (conteos.mortino) g.mortino = geomMortino({ q }, 7);
+    if (conteos.romerillo) g.romerillo = geomRomerillo({ q }, 8);
+    if (conteos.roca) g.roca = geomRoca(9);
+    if (conteos.musgo) g.musgo = geomMusgo(10);
     return g;
   }, [conteos, q]);
 
-  // --- Material único con vertexColors (cada geometría trae su color horneado). ---
+  // --- Material único con vertexColors (cada geometría trae su color horneado).
+  // OJO: flatShading NO — el sombreado horneado (AO + gradiente) ya da el
+  // volumen, y facetar encima devuelve el look de papiroflexia que se rechazó.
   const mat = useMemo(() => {
-    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    const base = { vertexColors: true, flatShading: false };
     return perfil.materialRico
-      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.9, metalness: 0.0 })
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.92, metalness: 0.0 })
       : new THREE.MeshLambertMaterial(base);
-  }, [perfil.materialRico, perfil.flatShading]);
+  }, [perfil.materialRico]);
 
-  // --- Distribución biogeográfica (una vez por tier). ---
+  // --- Distribución en bosquetes (una vez por tier). ---
   const dist = useMemo(() => distribucionFlora(conteos, 707), [conteos]);
 
   // Liberar GPU al desmontar.
@@ -213,15 +225,14 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false }) {
       <Especie geo={geos.romerillo} mat={mat} items={dist.romerillo} />
       <Especie geo={geos.mortino} mat={mat} items={dist.mortino} />
 
-      {/* Frailejonar: el ícono del páramo, al frente. */}
+      {/* Frailejonar: el ícono del páramo, en el anillo interior. */}
       <Especie geo={geos.frailejon} mat={mat} items={dist.frailejon} />
       <Especie geo={geos.frailejonFlor} mat={mat} items={dist.frailejonFlor} />
 
-      {/* Árboles de fondo (anillo exterior, velados por la niebla). */}
+      {/* El cortejo leñoso (bosquetes exteriores, velados por la niebla). */}
       <Especie geo={geos.gaque} mat={mat} items={dist.gaque} castShadow={sombra} />
+      <Especie geo={geos.quenua} mat={mat} items={dist.quenua} castShadow={sombra} />
       <Especie geo={geos.encenillo} mat={mat} items={dist.encenillo} castShadow={sombra} />
-      <Especie geo={geos.roble} mat={mat} items={dist.roble} castShadow={sombra} />
-      <Especie geo={geos.yarumo} mat={mat} items={dist.yarumo} castShadow={sombra} />
       <Especie geo={geos.aliso} mat={mat} items={dist.aliso} castShadow={sombra} />
 
       {/* Vaho del páramo a la deriva (solo 'alto'). */}

--- a/src/visual/mundo3d/bosque/MundoEntBosque.jsx
+++ b/src/visual/mundo3d/bosque/MundoEntBosque.jsx
@@ -23,7 +23,13 @@ import EscenaBosqueVivo from './EscenaBosqueVivo.jsx';
 import EscenaEntMaestro from './EscenaEntMaestro.jsx';
 import { decidirTier, permite3D } from '../deviceTier.js';
 
-/* La invitación aparece cuando la cámara ya llegó al claro (~5.2s de caminata). */
+/*
+ * La invitación aparece CASI ENSEGUIDA (1.4s). Antes esperaba 5.6s "a que la
+ * cámara llegara al claro", y el operador reportó *"no veo la lección del
+ * subsuelo"*: se quedaba mirando el árbol sin saber que había un camino abajo.
+ * La lección es la razón de existir de la pieza — no puede estar escondida
+ * detrás de una espera larga y un botón que aparece sin avisar.
+ */
 const CSS = `
 .entb { position: relative; width: 100%; height: 100%; overflow: hidden; background: #c3cfce; }
 .entb__panel {
@@ -37,7 +43,7 @@ const CSS = `
   backdrop-filter: blur(6px);
   color: #e9efdd;
   opacity: 0;
-  animation: entb-aparece 0.9s ease 5.6s forwards;
+  animation: entb-aparece 0.9s ease 1.4s forwards;
 }
 .entb__panel--ya { opacity: 1; animation: none; }
 .entb__kicker { margin: 0 0 0.15rem; font: 600 0.68rem/1.2 system-ui, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: #aebd97; }
@@ -67,6 +73,24 @@ const CSS = `
 }
 `;
 
+/*
+ * Modo inicial según el hash: `#bosque_vivo` entra por el bosque y
+ * `#bosque_vivo/microsuelo` cae DIRECTO en la lección de las capas del suelo.
+ *
+ * El router de prod parte el hash por '/' y se queda con el primer segmento
+ * como ruta, así que el segundo viaja libre hasta aquí. Lo leemos nosotros
+ * (el router no reparte `data` a los componentes) — así la lección es
+ * enlazable, compartible y verificable con una captura, sin tocar el router.
+ * OJO: la ruta va SIN barra inicial (`#bosque_vivo`); con `#/bosque_vivo` el
+ * primer segmento queda vacío y el shell cae al valle.
+ */
+function modoDelHash() {
+  if (typeof window === 'undefined') return 'entrada';
+  const raw = window.location.hash.replace(/^#/, '');
+  const sub = raw.split('/')[1];
+  return sub === 'microsuelo' ? 'microsuelo' : 'entrada';
+}
+
 /**
  * El mundo del Ent completo: entrada-landmark + elección + microsuelo.
  * Montar SOLO perezoso (lazy); llena a su contenedor.
@@ -79,7 +103,15 @@ export default function MundoEntBosque({ tier: tierProp, reducedMotion: rmProp }
   const auto = useMemo(() => decidirTier(), []);
   const tier = tierProp ?? (permite3D(auto.tier) ? auto.tier : 'bajo');
   const reducedMotion = rmProp ?? auto.reducedMotion;
-  const [modo, setModo] = useState('entrada'); // 'entrada' | 'microsuelo'
+  const [modo, setModo] = useState(modoDelHash); // 'entrada' | 'microsuelo'
+
+  // El hash sigue al modo (enlazable y con "atrás" del navegador coherente).
+  const irA = (m) => {
+    setModo(m);
+    if (typeof window === 'undefined') return;
+    const base = window.location.hash.replace(/^#/, '').split('/')[0] || 'bosque_vivo';
+    window.location.hash = m === 'microsuelo' ? `#${base}/microsuelo` : `#${base}`;
+  };
 
   return (
     <div className="entb">
@@ -97,7 +129,7 @@ export default function MundoEntBosque({ tier: tierProp, reducedMotion: rmProp }
             <button
               type="button"
               className="entb__bajar"
-              onClick={() => setModo('microsuelo')}
+              onClick={() => irA('microsuelo')}
             >
               Bajar al microsuelo
             </button>
@@ -109,7 +141,7 @@ export default function MundoEntBosque({ tier: tierProp, reducedMotion: rmProp }
           <button
             type="button"
             className="entb__volver"
-            onClick={() => setModo('entrada')}
+            onClick={() => irA('entrada')}
           >
             ← Volver al bosque
           </button>

--- a/src/visual/mundo3d/bosque/entQuenua.geom.js
+++ b/src/visual/mundo3d/bosque/entQuenua.geom.js
@@ -13,6 +13,10 @@
  * y le pone luz, material y vida. Cero assets externos: todo es procedural.
  */
 import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+/* `poner` vive en el taller compartido de vegetación (sombreadoVegetal), que no
+   importa nada de aquí → sin ciclo. */
+import { poner } from './sombreadoVegetal.js';
 
 /* PRNG determinista: el mismo guardián en cada carga (nada de azar por frame). */
 export function rng(seed) {
@@ -30,16 +34,19 @@ export function rng(seed) {
  */
 export const PARAMS_TIER = {
   alto: {
-    tubular: 124, radial: 16, hojas: 680, clusters: 9, ramas: 5, raices: 6,
+    tubular: 150, radial: 16, radialCara: 64, hojas: 680, clusters: 9, ramas: 5, raices: 6,
     frailejones: 5, materialRico: true, flatShading: true, fog: true,
+    barba: 30, usnea: 22, laminas: 34,
   },
   medio: {
-    tubular: 76, radial: 10, hojas: 340, clusters: 7, ramas: 5, raices: 5,
+    tubular: 90, radial: 10, radialCara: 34, hojas: 340, clusters: 7, ramas: 5, raices: 5,
     frailejones: 4, materialRico: false, flatShading: false, fog: true,
+    barba: 20, usnea: 12, laminas: 20,
   },
   bajo: {
-    tubular: 44, radial: 8, hojas: 120, clusters: 4, ramas: 3, raices: 4,
+    tubular: 44, radial: 8, radialCara: 16, hojas: 120, clusters: 4, ramas: 3, raices: 4,
     frailejones: 0, materialRico: false, flatShading: false, fog: false,
+    barba: 12, usnea: 0, laminas: 10,
   },
 };
 
@@ -101,23 +108,44 @@ export function taperTronco(t) {
  * que multiplica el radio → surcos y nudos reales en la malla, no un normal-map.
  */
 export function desplazamientoCorteza(t, ang) {
-  // Surcos FINOS y numerosos (corteza acanalada), poco profundos: dan textura
-  // sin partir el tronco en "trenzas". La rugosidad de nudo se concentra abajo.
-  const surcos = 0.055 * Math.sin(ang * 9.0 + t * 2.5); // acanaladuras verticales finas
-  const surcosF = 0.03 * Math.sin(ang * 17 - t * 3); // grano de corteza más fino
-  const bandas = 0.035 * Math.sin(t * 22 + ang * 1.5); // vetas horizontales
-  const nudos = 0.05 * Math.sin(ang * 2.0 - t * 6.5) * Math.sin(t * Math.PI); // nudos suaves
-  const aspereza = 0.015 * Math.sin(ang * 23 + t * 40); // aspereza
+  /*
+   * OJO CON EL ALIASING — aquí estaba la razón de que el tronco se leyera como
+   * "chocolate de plástico" en vez de corteza:
+   *
+   * la versión anterior metía términos `sin(ang*17)` y `sin(ang*23)`, pero el
+   * tubo tiene ~38 segmentos radiales → esas frecuencias caen en ~2.2 y ~1.6
+   * muestras por ciclo, POR DEBAJO de Nyquist. No se dibujaban como grano fino:
+   * aliasaban a lóbulos anchos y blandos, y el fuste parecía cera derretida.
+   *
+   * Regla: ninguna frecuencia en `ang` por encima de ~radial/4 (≈9 con radial 38).
+   * El detalle fino se busca a lo LARGO (en `t`, que tiene 124 anillos) y con
+   * dos familias de surcos que interfieren — así la corteza sale irregular sin
+   * pedirle a la malla más de lo que puede resolver.
+   */
+  // AMPLITUDES: han de ser hondas o no se ven. Con surcos de ~0.02 sobre un
+  // fuste de 1.3 de diámetro la corteza desaparece y vuelve el "plástico".
+  const surcos = 0.1 * Math.sin(ang * 8.0 + t * 2.5); // acanaladura principal
+  const surcos2 = 0.05 * Math.sin(ang * 5.0 - t * 4.2); // 2ª familia: interfiere
+  const fibra = 0.06 * Math.sin(ang * 16.0 + t * 1.5); // fibra fina (radial≥64)
+  const bandas = 0.03 * Math.sin(t * 18 + ang * 1.5); // vetas horizontales
+  const nudos = 0.05 * Math.sin(ang * 2.0 - t * 6.5) * Math.sin(t * Math.PI); // nudos
+  const grano = 0.022 * Math.sin(t * 46 + ang * 3); // grano fino, a lo largo
   const masAbajo = 1 + (1 - t) * 0.35; // el pie es algo más rugoso, sin exagerar
-  return (surcos + surcosF + bandas + nudos + aspereza) * masAbajo;
+  return (surcos + surcos2 + fibra + bandas + nudos + grano) * masAbajo;
 }
 
 /* Color de corteza para un desplazamiento dado (cresta pelada clara, grieta
    oscura) con un velo de líquen en la base. Devuelve una THREE.Color nueva. */
 export function colorCorteza(disp, t) {
-  const n = Math.max(0, Math.min(1, (disp + 0.16) / 0.32)); // grieta 0 → cresta 1
-  const c = CORTEZA.valle.clone().lerp(CORTEZA.cuerpo, Math.min(1, n * 1.7));
-  if (n > 0.6) c.lerp(CORTEZA.papel, (n - 0.6) / 0.4); // papel en la cresta
+  // Rango de mapeo ESTRECHO (±0.13 en vez de ±0.16) y papel desde n>0.5: la luz
+  // del páramo es plana y difusa, así que si el color de la corteza no trae
+  // contraste propio HORNEADO, el relieve se lava y el tronco se ve liso.
+  const n = Math.max(0, Math.min(1, (disp + 0.13) / 0.26)); // grieta 0 → cresta 1
+  const c = CORTEZA.valle.clone().lerp(CORTEZA.cuerpo, Math.min(1, n * 1.9));
+  if (n > 0.5) c.lerp(CORTEZA.papel, (n - 0.5) / 0.5); // papel en la cresta
+  // Oclusión de contacto: el pie del árbol vive en penumbra (da peso y asienta
+  // el tronco en la tierra en vez de dejarlo flotando).
+  c.multiplyScalar(0.72 + 0.28 * Math.min(1, t / 0.28));
   if (t < 0.45 && disp < 0) {
     const musgo = (0.45 - t) / 0.45 * 0.35; // líquen que trepa el pie
     c.lerp(CORTEZA.liquen, musgo);
@@ -126,14 +154,81 @@ export function colorCorteza(disp, t) {
 }
 
 /*
+ * ── EL ROSTRO TALLADO EN LA MADERA ──────────────────────────────────────────
+ *
+ * El operador rechazó la cara anterior: era una careta pegada ENCIMA del tronco
+ * (cejas de tablón, nariz de bola, ojos almendrados) y se leía como caricatura
+ * de Halloween. El DR §3 es explícito: los rasgos deben INTEGRARSE en la
+ * estructura del tronco "como si fueran formaciones de la corteza", usando las
+ * grietas y protuberancias para formar los contornos.
+ *
+ * Así que ahora el rostro NO se pega: se TALLA. Esta función devuelve un
+ * desplazamiento RELATIVO del radio del tronco (igual que la corteza) que
+ * hunde las cuencas y la boca y saca las cejas, el caballete y los pómulos. La
+ * cara ES la madera: las mismas fibras de corteza corren por encima de ella.
+ *
+ * Trabaja en dirección de MUNDO (`dir`, el vector unitario que sale del eje del
+ * tronco) y no en el ángulo paramétrico del tubo: el marco de Frenet del
+ * TubeGeometry se retuerce a lo largo de la curva, así que el ángulo `j/radial`
+ * NO apunta a un lado fijo del mundo. Con `dir` el rostro siempre mira al +Z.
+ *
+ * @param {{x:number,y:number,z:number}} dir  dirección unitaria hacia afuera.
+ * @param {number} y      altura de mundo del vértice.
+ * @param {number} yOjos  altura de la mirada (la del ancla del rostro).
+ * @returns {number} desplazamiento relativo (negativo = hundido en la madera).
+ */
+export function desplazamientoRostro(dir, y, yOjos) {
+  // Solo la cara frontal: se desvanece hacia los lados y detrás.
+  const frente = dir.z;
+  if (frente <= 0.08) return 0;
+  const mascara = Math.min(1, (frente - 0.08) / 0.52);
+  const u = dir.x; // lateral: -1 izquierda → +1 derecha
+  const v = y - yOjos; // vertical respecto a la mirada
+  // Bulto gaussiano: la herramienta de tallar.
+  const g = (u0, v0, su, sv) => Math.exp(-(((u - u0) ** 2) / su + ((v - v0) ** 2) / sv));
+
+  // Los anchos (su, sv) van DELIBERADAMENTE generosos: con una malla de tubo
+  // hasta 'bajo' tiene pocos anillos por rasgo, y una gaussiana estrecha
+  // produciría picos aislados (aliasing) en vez de una cuenca. Rasgos anchos y
+  // suaves se leen bien en los tres tiers.
+  let d = 0;
+  // CUENCAS: dos pozos donde se hunde la mirada. Es el rasgo que más "cara" da
+  // y el que sostiene los ojos DENTRO de la madera, no encima. Van HONDAS: con
+  // poca profundidad el rostro se difumina en el tronco y no se lee a distancia.
+  d -= 0.56 * g(-0.46, 0.04, 0.15, 0.075);
+  d -= 0.56 * g(0.46, 0.04, 0.15, 0.075);
+  // CEJAS: crestas de corteza sobre las cuencas (el ceño del guardián).
+  // Asimétricas a propósito: la simetría perfecta es lo que delata al muñeco.
+  d += 0.4 * g(-0.44, 0.4, 0.19, 0.045);
+  d += 0.36 * g(0.5, 0.44, 0.19, 0.045);
+  // CABALLETE: el nudo vertical entre las cuencas.
+  d += 0.28 * g(0, 0.1, 0.04, 0.14);
+  // PÓMULOS: peso y edad bajo las cuencas.
+  d += 0.18 * g(-0.5, -0.32, 0.12, 0.07);
+  d += 0.18 * g(0.5, -0.32, 0.12, 0.07);
+  // BOCA: la grieta. Ancha, poco alta y hundida — una fisura de la madera.
+  d -= 0.44 * g(0, -0.62, 0.26, 0.035);
+  // LABIO/MENTÓN: el reborde bajo la grieta que remata la mandíbula.
+  d += 0.22 * g(0, -0.82, 0.22, 0.05);
+  // ARRUGAS: dos surcos que bajan del caballete a las comisuras (edad).
+  d -= 0.12 * g(-0.34, -0.4, 0.045, 0.08);
+  d -= 0.12 * g(0.34, -0.4, 0.045, 0.08);
+
+  return d * mascara;
+}
+
+/*
  * Construye una malla de TUBO ORGÁNICO tapereado y con corteza, siguiendo una
  * curva. Reutilizada por tronco, ramas y raíces. Parte de un TubeGeometry de
  * radio 1 y reubica cada vértice: escala su offset respecto al eje por el taper
  * y el desplazamiento, y le pinta vertexColor de corteza.
  *
+ * Si se le pasa `yOjos`, además TALLA el rostro en la malla (ver
+ * `desplazamientoRostro`): el tronco del Ent y su cara son la misma superficie.
+ *
  * @returns {THREE.BufferGeometry} geometría con atributo `color`.
  */
-export function tuboOrganico(curve, { tubular, radial, taperFn, dispAmp = 1, seedAng = 0 }) {
+export function tuboOrganico(curve, { tubular, radial, taperFn, dispAmp = 1, seedAng = 0, yOjos = null }) {
   const geo = new THREE.TubeGeometry(curve, tubular, 1, radial, false);
   const pos = geo.attributes.position;
   const nAnillo = radial + 1;
@@ -156,11 +251,19 @@ export function tuboOrganico(curve, { tubular, radial, taperFn, dispAmp = 1, see
     v.fromBufferAttribute(pos, k);
     off.subVectors(v, centro); // offset unitario en el plano normal-binormal
     const disp = desplazamientoCorteza(t, ang) * dispAmp;
-    const radio = taperFn(t) * (1 + disp);
+    // El rostro se talla en la MISMA superficie que la corteza: se suma al
+    // mismo desplazamiento radial, así que las fibras de la madera corren por
+    // encima de las cejas y dentro de las cuencas (DR §3: "corteza como arruga").
+    const cara = yOjos === null ? 0 : desplazamientoRostro(off, centro.y, yOjos);
+    const radio = taperFn(t) * (1 + disp + cara);
     v.copy(centro).addScaledVector(off, radio);
     pos.setXYZ(k, v.x, v.y, v.z);
 
-    const col = colorCorteza(disp, t);
+    // La grieta tallada se pinta como grieta: lo hundido va oscuro y la cresta
+    // clara (sombra propia HORNEADA) → la cara se lee incluso con la luz plana
+    // y difusa del páramo, que es la que tenemos. Sin esto el relieve existe
+    // pero se difumina y el rostro "no está".
+    const col = colorCorteza(disp + cara * 0.95, t);
     colores[k * 3] = col.r;
     colores[k * 3 + 1] = col.g;
     colores[k * 3 + 2] = col.b;
@@ -172,11 +275,114 @@ export function tuboOrganico(curve, { tubular, radial, taperFn, dispAmp = 1, see
   return geo;
 }
 
-/** Geometría del tronco completo (con la corteza rojiza pelada). */
-export function geometriaTronco({ tubular, radial }, seed = 7) {
+/**
+ * Geometría del tronco completo: corteza rojiza pelada + EL ROSTRO TALLADO.
+ *
+ * `radialCara` (si viene) manda sobre `radial`: la cara necesita bastantes
+ * vértices alrededor del fuste para que las cuencas y la boca se resuelvan como
+ * formas y no como picos sueltos. Es el único sitio del mundo donde gastamos esa
+ * densidad, porque es el que mira el usuario.
+ *
+ * @param {{tubular: number, radial: number, radialCara?: number}} P
+ * @param {number} [seed]
+ */
+export function geometriaTronco({ tubular, radial, radialCara }, seed = 7) {
+  const { centro } = anclaRostro(seed);
   return tuboOrganico(curvaTronco(seed), {
-    tubular, radial, taperFn: taperTronco, dispAmp: 1, seedAng: 0.6,
+    tubular,
+    radial: radialCara || radial,
+    taperFn: taperTronco,
+    dispAmp: 1,
+    seedAng: 0.6,
+    yOjos: centro.y,
   });
+}
+
+/*
+ * ── LAS LÁMINAS DE PAPEL (la firma de la queñua) ────────────────────────────
+ *
+ * *Polylepis* significa literalmente "muchas escamas": su corteza rojiza se
+ * DESCAMA en láminas finísimas como hojas de papel, que se despegan del tronco
+ * y se enrollan. Es el rasgo que la hace inconfundible en el páramo — y el Ent
+ * es una queñua, así que le tocan.
+ *
+ * Sin ellas el fuste se lee como un tubo marrón liso (que era justo el problema:
+ * "chocolate de plástico"). Con ellas, la silueta del tronco se rompe en cientos
+ * de bordes que atrapan la luz. Y la contradicción quedaba a la vista: las
+ * queñuas del cortejo (floraParamo) SÍ tenían láminas y el guardián no.
+ *
+ * Va como malla aparte (mismo material vertexColors) para no tocar el tubo del
+ * tronco ni el rostro tallado.
+ *
+ * @param {{tubular:number, radial:number, laminas?:number}} P
+ * @returns {THREE.BufferGeometry} una sola malla con todas las láminas.
+ */
+export function geometriaLaminas(P, seed = 5) {
+  const r = rng(seed);
+  const curva = curvaTronco(7);
+  const { centro: anc, radio: radioCara } = anclaRostro(7);
+  const n = P.laminas ?? 30;
+  const partes = [];
+
+  for (let i = 0; i < n; i++) {
+    const t = 0.03 + r() * 0.9;
+    const c = curva.getPointAt(t);
+    const rad = taperTronco(t);
+    const azim = r() * Math.PI * 2;
+    // PEQUEÑAS y CEÑIDAS. Con láminas grandes y despegadas el tronco se llena de
+    // parches planos que se leen como esparadrapos pegados — no como escamas.
+    // La lámina de Polylepis es una viruta fina: aporta como TEXTURA, en
+    // cantidad, no como pieza suelta que se mira una por una.
+    const arco = 0.28 + r() * 0.5; // cuánto del contorno abraza
+    const alto = 0.05 + r() * 0.12;
+
+    // No taparle la CARA al Ent: se saltan las láminas que caerían sobre el
+    // rostro (mirando al +Z, a la altura de la mirada).
+    const miraAlFrente = Math.sin(azim) > 0.35;
+    const enLaCara = Math.abs(c.y - anc.y) < radioCara * 1.5;
+    if (miraAlFrente && enLaCara) continue;
+
+    // La lámina: un casquete de cilindro (una escama despegada), abierto, con
+    // el borde levantado hacia afuera y un poco caído.
+    // Ceñida al fuste: solo el borde inferior se abre (la viruta que se levanta).
+    const lam = new THREE.CylinderGeometry(
+      rad * 1.0, rad * 1.09, alto, 5, 1, true, azim, arco,
+    );
+    poner(lam, [c.x, c.y, c.z], [(r() - 0.5) * 0.12, 0, (r() - 0.5) * 0.12]);
+
+    // Color: el papel expuesto va claro por fuera y la madera viva, oscura,
+    // asoma por debajo → cada escama proyecta su propio borde.
+    const pos = lam.attributes.position;
+    const cols = new Float32Array(pos.count * 3);
+    const col = new THREE.Color();
+    for (let k = 0; k < pos.count; k++) {
+      const y = pos.getY(k);
+      const s = (y - (c.y - alto / 2)) / Math.max(1e-5, alto); // 0 abajo → 1 arriba
+      // Casi del color de la corteza: la escama se despega y APENAS aclara en el
+      // borde levantado. Con papel a tope salían parches salmón que gritaban.
+      col.copy(CORTEZA.valle).lerp(CORTEZA.cuerpo, 0.5 + s * 0.5);
+      if (s > 0.72) col.lerp(CORTEZA.papel, (s - 0.72) / 0.28 * 0.55); // borde
+      col.multiplyScalar(0.7 + s * 0.34);
+      cols[k * 3] = col.r;
+      cols[k * 3 + 1] = col.g;
+      cols[k * 3 + 2] = col.b;
+    }
+    lam.setAttribute('color', new THREE.BufferAttribute(cols, 3));
+    partes.push(lam);
+  }
+
+  if (!partes.length) return null;
+  const buenas = partes.map((g) => (g.index ? g.toNonIndexed() : g));
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    // mergeGeometries devuelve null EN SILENCIO al mezclar indexadas con
+    // no-indexadas → las láminas desaparecerían sin un solo error. Truena.
+    throw new Error('[entQuenua] geometriaLaminas: mergeGeometries devolvió NULL '
+      + '(¿mezcla de geometrías indexadas y no-indexadas?). Las láminas habrían '
+      + 'quedado invisibles sin error.');
+  }
+  g.computeVertexNormals();
+  return g;
 }
 
 /*
@@ -381,56 +587,220 @@ export const BARBA = {
 };
 
 /*
- * Mechones de la barba en coords del rostro (0,0,0 = ancla del mentón; -y cuelga,
- * +z al frente). Forma de barba: larga en el centro (mentón), corta en las
- * mejillas; enmarca la boca SIN taparla (arranca por debajo del labio).
+ * Invierte la curva del tronco: dado un `y` de mundo, ¿en qué `t` va la curva?
+ * La curva es monótona en y, así que basta muestrear y luego interpolar.
+ * Se usa para pegar la barba a la SUPERFICIE del tronco a cada altura.
  */
-export function specsBarba(seed = 91) {
+export function tDeAltura(curva, y, muestras = 48) {
+  const y0 = curva.getPointAt(0).y;
+  const y1 = curva.getPointAt(1).y;
+  if (y <= y0) return 0;
+  if (y >= y1) return 1;
+  let tPrev = 0;
+  let yPrev = y0;
+  for (let i = 1; i <= muestras; i++) {
+    const t = i / muestras;
+    const yi = curva.getPointAt(t).y;
+    if (yi >= y) {
+      const f = (y - yPrev) / Math.max(1e-6, yi - yPrev);
+      return tPrev + (t - tPrev) * f;
+    }
+    tPrev = t;
+    yPrev = yi;
+  }
+  return 1;
+}
+
+/*
+ * ── LA BARBA DE USNEA (el rasgo que faltaba) ────────────────────────────────
+ *
+ * El operador: *"no se parece en nada al del Señor de los Anillos, no tiene
+ * barba, no tiene vida"*. Y tenía razón aunque el código ANTERIOR ya tuviera una
+ * función `specsBarba`: la barba estaba ahí, pero NO SE VEÍA. El fallo era
+ * geométrico y silencioso —
+ *
+ *   los mechones colgaban rectos hacia abajo desde el mentón a una `z` FIJA,
+ *   mientras el tronco se ENSANCHA hacia el pie (el taper tiene raigón). A la
+ *   altura del mentón el radio del tronco es ~0.65, pero un metro más abajo pasa
+ *   de 0.9 → los mechones quedaban DENTRO de la madera. Solo asomaban las matas
+ *   de liquen, junto a la boca. Una barba enterrada en el propio tronco.
+ *
+ * Ahora cada mechón se construye SIGUIENDO LA SUPERFICIE: a cada altura se
+ * consulta el radio real del tronco y la hebra se cuelga por fuera de él, con un
+ * vuelo que crece hacia la punta (la usnea se separa y se mece). Así no puede
+ * volver a tragarse: la barba está definida como "el tronco, más un margen".
+ *
+ * La usnea ("barba de viejo", *Usnea* spp.) no es licencia poética: es el líquen
+ * colgante REAL del bosque altoandino, y es exactamente lo que convierte una
+ * queñua en Bárbol. Es lo más barato que podemos hacer para sacarlo de "árbol
+ * genérico" (DR §3: geometría de mechones + movimiento + densidad).
+ *
+ * @returns {{hebras: object[], liquenes: object[]}} hebras con sus puntos ya en
+ *   coordenadas del TRONCO (mundo), listas para tubular.
+ */
+export function specsBarba(seed = 91, n = 26) {
   const r = rng(seed);
-  const mechones = [];
-  const N = 15;
-  for (let i = 0; i < N; i++) {
-    const f = i / (N - 1); // 0..1 de mejilla izq a der
-    const x = (f - 0.5) * 0.94; // a lo ancho de la mandíbula
-    const centro = Math.max(0, 1 - Math.abs(f - 0.5) * 1.7); // largo hacia el mentón
-    const len = 0.44 + centro * 0.78 + r() * 0.16;
-    mechones.push({
-      x,
-      yTop: -0.56 - Math.abs(f - 0.5) * 0.1, // bajo la boca, sube por las mejillas
-      z: 0.02 + r() * 0.05,
-      len,
-      tilt: (f - 0.5) * 0.7 + (r() - 0.5) * 0.2, // se abren hacia afuera
-      grosor: 0.05 + r() * 0.03,
-      claro: r() > 0.62,
-      fase: i * 1.3,
+  const curva = curvaTronco(seed >> 3 || 7);
+  const { centro: anc, radio: radioCara } = anclaRostro(7);
+
+  // La barba nace bajo la boca-grieta y se reparte por la mandíbula.
+  const yMandibula = anc.y - radioCara * 0.72;
+  const hebras = [];
+
+  for (let i = 0; i < n; i++) {
+    // Reparto IRREGULAR: si las hebras van equiespaciadas por la mandíbula, la
+    // barba sale peinada en filas y se lee como flecos de rafia. Un jitter
+    // fuerte + varias capas en profundidad la enredan, que es como cuelga la
+    // usnea de verdad.
+    const f = n === 1 ? 0.5 : (i / (n - 1)) + (r() - 0.5) * 0.14;
+    // Azimut alrededor del frente del tronco: la barba abraza la mandíbula
+    // (±50°), no es una cortina plana pegada al frente.
+    const azim = Math.PI / 2 - (f - 0.5) * 1.5;
+    // Larga en el mentón, corta en las mejillas (forma de barba, no de flecos).
+    // OJO con el LARGO: el fuste mide 6 y la mandíbula va a y≈1.6, así que una
+    // hebra de 2 termina BAJO TIERRA. La primera versión hacía justo eso y la
+    // barba se leía como falda hawaiana tapando medio árbol. El mentón acaba
+    // sobre y≈0.9: barba de anciano, no enagua.
+    const central = Math.max(0, 1 - Math.abs(f - 0.5) * 1.75);
+    const largo = 0.16 + central * 0.36 + r() * 0.1;
+    // Arranca más arriba en las mejillas (patillas) que en el mentón.
+    const yTop = yMandibula + 0.06 + Math.abs(f - 0.5) * 0.34 - r() * 0.05;
+    // Capa: a qué distancia del tronco cuelga esta hebra (barba con espesor).
+    const capa = r() * 0.055;
+    // Cuánto serpentea (cada hebra a su aire).
+    const ondula = 0.06 + r() * 0.16;
+
+    // Muestrea la hebra a lo largo de su caída, pegada al tronco + vuelo.
+    const K = 6;
+    const pts = [];
+    for (let k = 0; k <= K; k++) {
+      const s = k / K; // 0 raíz → 1 punta
+      const y = yTop - largo * s;
+      const t = tDeAltura(curva, y);
+      const c = curva.getPointAt(t);
+      const radioAqui = taperTronco(t);
+      // Vuelo: la hebra se despega del tronco según cae (si no, se lo traga el
+      // raigón). Crece con s² → arriba abraza, abajo cuelga suelta. Poco vuelo:
+      // con mucho, la barba se abre en campana y vuelve a parecer falda. El
+      // término por hebra reparte la barba en CAPAS (unas cuelgan más adentro
+      // que otras) en vez de dejarlas todas en la misma cáscara.
+      const vuelo = 0.05 + capa + s * s * (0.1 + central * 0.09);
+      // Deriva lateral: cada hebra serpentea a su aire y se enreda con las
+      // vecinas. Sin esto quedan rectas y paralelas = flecos de rafia.
+      const desvio = ondula * Math.sin(s * 3.1 + i * 1.7) * s;
+      const a = azim + desvio;
+      pts.push(new THREE.Vector3(
+        c.x + Math.cos(a) * (radioAqui + vuelo),
+        y,
+        c.z + Math.sin(a) * (radioAqui + vuelo),
+      ));
+    }
+    hebras.push({
+      pts,
+      // Fina y filiforme: la usnea es un hilo, no un fideo. Con hebras gruesas
+      // la barba se lee como plástico peinado.
+      grosor: 0.012 + r() * 0.012 + central * 0.008,
+      claro: r() > 0.6,
+      fase: i * 1.27,
+      // Peso de viento: las del mentón (largas) se mecen más.
+      peso: 0.5 + central * 0.5,
     });
   }
-  // raicillas leñosas: más largas, en el centro (el mentón de Bárbol)
-  const raicillas = [];
-  const M = 4;
-  for (let i = 0; i < M; i++) {
-    raicillas.push({
-      x: (r() - 0.5) * 0.34,
-      yTop: -0.62,
-      z: 0.0 + r() * 0.04,
-      len: 0.98 + r() * 0.6,
-      tilt: (r() - 0.5) * 0.28,
-      grosor: 0.036 + r() * 0.02,
-      fase: i * 2.1,
-    });
-  }
-  // matas de liquen prendidas a lo alto de la barba, a los lados de la boca
+
+  // Matas de liquen foliáceo prendidas a lo alto de la barba, a los lados de la
+  // boca: dan el "enganche" entre la madera y la barba (no una peluca pegada).
   const liquenes = [];
-  const L = 9;
+  const L = Math.max(4, Math.round(n * 0.4));
   for (let i = 0; i < L; i++) {
     const f = i / (L - 1);
+    const azim = Math.PI / 2 - (f - 0.5) * 1.9;
+    const y = yMandibula - 0.12 - r() * 0.26;
+    const t = tDeAltura(curva, y);
+    const c = curva.getPointAt(t);
+    const radioAqui = taperTronco(t);
     liquenes.push({
-      pos: [(f - 0.5) * 0.9, -0.5 - r() * 0.28, 0.05 + r() * 0.05],
-      esc: 0.06 + r() * 0.055,
+      pos: [
+        c.x + Math.cos(azim) * (radioAqui + 0.04),
+        y,
+        c.z + Math.sin(azim) * (radioAqui + 0.04),
+      ],
+      esc: 0.05 + r() * 0.055,
       azul: r() > 0.6,
     });
   }
-  return { mechones, raicillas, liquenes };
+
+  return { hebras, liquenes };
+}
+
+/*
+ * USNEA COLGANTE DE LAS RAMAS: el mismo líquen barbado que cuelga de la copa.
+ * Es lo que hace que el claro se lea como BOSQUE DE NIEBLA altoandino y no como
+ * un árbol de parque — y de paso hace que la barba del Ent no parezca un
+ * disfraz, sino lo mismo que le cuelga a todo el bosque.
+ *
+ * @param {{punta: THREE.Vector3}[]} puntasRama  puntas de las ramas.
+ */
+export function specsUsneaRamas(puntasRama, n = 22, seed = 77) {
+  const r = rng(seed);
+  const mechas = [];
+  if (!puntasRama.length || n <= 0) return mechas;
+  for (let i = 0; i < n; i++) {
+    const base = puntasRama[i % puntasRama.length];
+    const ang = r() * Math.PI * 2;
+    const rad = r() * 0.42;
+    const x = base.x + Math.cos(ang) * rad;
+    const z = base.z + Math.sin(ang) * rad;
+    const yTop = base.y - 0.1 - r() * 0.25;
+    const largo = 0.22 + r() * 0.5;
+    const K = 4;
+    const pts = [];
+    for (let k = 0; k <= K; k++) {
+      const s = k / K;
+      // Cuelga casi a plomo con una deriva suave (no un palo recto).
+      pts.push(new THREE.Vector3(
+        x + Math.sin(s * 2.1 + i) * 0.04 * s,
+        yTop - largo * s,
+        z + Math.cos(s * 1.7 + i) * 0.04 * s,
+      ));
+    }
+    mechas.push({
+      pts,
+      grosor: 0.008 + r() * 0.008,
+      claro: r() > 0.55,
+      fase: i * 0.9,
+      peso: 1,
+    });
+  }
+  return mechas;
+}
+
+/**
+ * Tubula una hebra (barba o usnea) en una malla con color horneado y un
+ * atributo `peso` (0 en la raíz → 1 en la punta) para mecerla por vértice.
+ */
+export function geometriaHebra(hebra, colorBase, radial = 4) {
+  const curva = new THREE.CatmullRomCurve3(hebra.pts, false, 'catmullrom', 0.5);
+  const tub = Math.max(3, hebra.pts.length - 1);
+  const geo = new THREE.TubeGeometry(curva, tub, hebra.grosor, radial, false);
+  const pos = geo.attributes.position;
+  const nAnillo = radial + 1;
+  const colores = new Float32Array(pos.count * 3);
+  const pesos = new Float32Array(pos.count);
+  const c = new THREE.Color();
+  for (let k = 0; k < pos.count; k++) {
+    const anillo = Math.floor(k / nAnillo);
+    const s = anillo / tub; // 0 raíz → 1 punta
+    // La usnea se aclara y se seca hacia la punta.
+    c.copy(colorBase).lerp(BARBA.liquen, s * 0.45);
+    c.multiplyScalar(0.82 + s * 0.28);
+    colores[k * 3] = c.r;
+    colores[k * 3 + 1] = c.g;
+    colores[k * 3 + 2] = c.b;
+    pesos[k] = s * s * (hebra.peso ?? 1); // s²: la raíz no se mueve, la punta sí
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(colores, 3));
+  geo.setAttribute('peso', new THREE.BufferAttribute(pesos, 1));
+  return geo;
 }
 
 /*

--- a/src/visual/mundo3d/bosque/floraParamo.geom.js
+++ b/src/visual/mundo3d/bosque/floraParamo.geom.js
@@ -1,330 +1,636 @@
 /*
- * floraParamo.geom — la GEOMETRÍA del ECOSISTEMA que rodea al Ent de la queñua.
+ * floraParamo.geom — el BOSQUE ALTOANDINO que rodea al Ent de la queñua.
  *
- * El Ent (queñua) es EL árbol mayor y sigue siendo el foco; esto es el páramo que
- * lo acompaña para que el claro se sienta un bosque altoandino VIVO y no un árbol
- * solo. Especies reales del páramo/bosque altoandino colombiano, cada una con su
- * identidad inequívoca:
+ * REHECHO tras el rechazo del operador: *"las matas alrededor ni se diga,
+ * parecen más árboles de navidad que matas"*. Tenía toda la razón, y el DR de
+ * realismo-3d-vegetacion nombra el fallo exacto que teníamos:
  *
- *   · Frailejón (Espeletia)      — el ícono: tallo con enagua de hojas muertas y
- *                                  ROSETA plateada peluda arriba. Va al frente,
- *                                  formando el frailejonar. (Algunos en flor.)
- *   · Yarumo plateado/blanco     — Cecropia telealba: tronco pálido esbelto y copa
- *     (Cecropia telealba)          en sombrilla de hojas palmeadas de ENVÉS BLANCO.
- *   · Roble andino               — Quercus humboldtii: tronco robusto y copa ancha
- *     (Quercus humboldtii)         densa de hoja coriácea oscura (con bellotas).
- *   · Encenillo (Weinmannia)     — árbol de niebla: tronco rojizo, copa oscura y
+ *   ANTES: `CylinderGeometry` recto + un puñado de `IcosahedronGeometry` regados
+ *   en un domo, cada parte con UN color plano horneado (`pintar`). Es la
+ *   definición literal del "cono/esfera de follaje sobre un cilindro" del DR:
+ *   sin conicidad, sin jerarquía de ramas, sin huecos, sin AO, sin gradiente.
+ *   El aliso incluso construía la copa como un CONO explícito. Árbol de navidad.
+ *
+ *   AHORA: todas las especies leñosas salen de `construirArbol`, que aplica las
+ *   recetas del DR por orden de retorno visual:
+ *     · tronco con CURVA, conicidad real, raigón y arruga en la geometría;
+ *     · JERARQUÍA de ramas (primarias en ángulo áureo → secundarias);
+ *     · copas sembradas en los EXTREMOS de rama, con HUECOS y borde MORDIDO
+ *       (el cielo se ve a través → se acabó la masa sólida);
+ *     · sombreado horneado por vértice: AO + gradiente de altura + contraluz;
+ *     · variación determinista por instancia (rotación/escala/inclinación/tinte).
+ *
+ * Cada especie conserva lo que la hace INCONFUNDIBLE (si se ven genéricas,
+ * fallamos):
+ *   · Frailejón (Espeletia)      — roseta vellosa plateada + enagua de hojas
+ *                                  muertas marcescentes. El ícono del páramo.
+ *   · Queñua (Polylepis)         — tronco retorcido + corteza rojiza que se
+ *                                  descama en LÁMINAS DE PAPEL (geometría real).
+ *   · Encenillo (Weinmannia)     — árbol de niebla: tronco rojizo, copa oscura
  *                                  compacta, velo de musgo.
- *   · Aliso (Alnus acuminata)    — tronco gris claro esbelto, copa cónica verde
- *                                  fresca; el vecino más alto (aun así < Ent).
- *   · Gaque (Clusia)             — copa redonda densa de hoja gruesa verde-lustrosa.
- *   · Mortiño (Vaccinium         — arbusto bajo con BAYAS azul-moradas (agraz andino).
- *     meridionale)
- *   · Romerillo                  — mata baja de follaje fino amarillo-verde.
- *   · Rocas con líquen + musgo   — el suelo del páramo.
+ *   · Aliso (Alnus acuminata)    — tronco gris claro esbelto, copa alta y fresca
+ *                                  (alargada e IRREGULAR, nunca un cono).
+ *   · Gaque (Clusia)             — copa redonda densa de hoja gruesa lustrosa.
+ *   · Mortiño (Vaccinium)        — arbusto bajo con bayas azul-moradas (agraz).
+ *   · Romerillo, rocas con líquen, musgo — el suelo y el sotobosque.
  *
- * TÉCNICA tier-safe (DR §3): cada especie se FUSIONA en UNA sola geometría
- * (tronco + follaje + detalles) con color horneado en vertexColors, y luego se
- * dibuja con UN InstancedMesh → una draw-call por especie por más matas que haya.
- * Cero assets externos: todo procedural. Corre headless (three core + merge puro).
- *
- * El componente r3f (`FloraParamo.jsx`) consume esto: instancia, ubica y le pone
- * luz. Aquí viven SOLO los datos y las mallas (nada de WebGL).
+ * TÉCNICA tier-safe: cada especie se fusiona en UNA geometría con el color ya
+ * horneado → UN InstancedMesh → una draw-call por especie por más matas que
+ * haya. Cero assets externos. Corre headless (three core puro).
  */
 import * as THREE from 'three';
-import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
-import { rng } from './entQuenua.geom.js';
+import {
+  rng,
+  ruidoFbm,
+  fusionarSeguro,
+  poner,
+  apuntar,
+  pintarPlano,
+  hornearFollaje,
+  hornearCorteza,
+  tuboOrganico,
+  taperLineal,
+  taperTronco,
+  curvaTronco,
+  sembrarFollaje,
+  matojoHoja,
+} from './sombreadoVegetal.js';
+
+export { rng };
 
 /* -------------------------------------------------------------------------- */
 /*  Presupuesto por tier                                                       */
 /* -------------------------------------------------------------------------- */
 
 /*
- * Cuántas matas de cada especie (tier-safe). 'alto' puebla un ecosistema pleno;
- * 'medio' es frugal; 'bajo' deja lo mínimo para que AÚN se lea "páramo" (unos
- * frailejones, un par de árboles, rocas y musgo) si algo fuerza el 3D. Cada
- * especie es UN InstancedMesh → estos números son instancias, no draw-calls.
+ * Cuántas matas de cada especie. 'alto' puebla un bosque pleno; 'medio' es
+ * frugal; 'bajo' deja lo mínimo para que AÚN se lea "páramo". Cada especie es
+ * UN InstancedMesh → estos números son instancias, no draw-calls.
  */
 export const FLORA_TIER = {
   alto: {
-    frailejon: 30, frailejonFlor: 6, yarumo: 3, roble: 3, encenillo: 4,
-    aliso: 3, gaque: 2, mortino: 10, romerillo: 12, roca: 9, musgo: 12, niebla: 3,
+    frailejon: 34, frailejonFlor: 7, quenua: 5, encenillo: 5, aliso: 4,
+    gaque: 3, mortino: 12, romerillo: 14, roca: 10, musgo: 14, niebla: 3,
   },
   medio: {
-    frailejon: 18, frailejonFlor: 3, yarumo: 2, roble: 2, encenillo: 2,
-    aliso: 2, gaque: 1, mortino: 6, romerillo: 7, roca: 5, musgo: 6, niebla: 0,
+    frailejon: 20, frailejonFlor: 4, quenua: 3, encenillo: 3, aliso: 2,
+    gaque: 2, mortino: 7, romerillo: 8, roca: 6, musgo: 7, niebla: 0,
   },
   bajo: {
-    frailejon: 7, frailejonFlor: 0, yarumo: 1, roble: 1, encenillo: 0,
-    aliso: 0, gaque: 0, mortino: 2, romerillo: 3, roca: 2, musgo: 3, niebla: 0,
+    frailejon: 8, frailejonFlor: 0, quenua: 2, encenillo: 0, aliso: 0,
+    gaque: 0, mortino: 3, romerillo: 3, roca: 2, musgo: 3, niebla: 0,
   },
 };
 
 /** Conteos de flora para un tier (desconocido → frugal, nunca el más caro). */
 export const floraDeTier = (tier) => FLORA_TIER[tier] || FLORA_TIER.medio;
 
-/*
- * Factor de DETALLE geométrico por tier: escala cuántas hojas/blobs lleva cada
- * mata. Menos detalle en gama baja = menos vértices por instancia (que se
- * multiplican por el número de matas).
- */
-export const CALIDAD_TIER = { alto: 1, medio: 0.62, bajo: 0.42 };
+/* Factor de DETALLE geométrico por tier: escala hojas/ramas por mata. */
+export const CALIDAD_TIER = { alto: 1, medio: 0.6, bajo: 0.4 };
 export const calidadDeTier = (tier) => CALIDAD_TIER[tier] ?? CALIDAD_TIER.medio;
 
 /* -------------------------------------------------------------------------- */
-/*  Paleta del páramo (colores horneados en vertexColors)                      */
+/*  Paleta del páramo (horneada en vertexColors)                               */
 /* -------------------------------------------------------------------------- */
 
 export const PAL = {
-  // Frailejón
-  frailejonTronco: '#6f5c40', // tallo bajo la enagua
-  frailejonSeco: '#8a7350', // hojas muertas de la enagua (marcescentes)
-  frailejonPlata: '#bcc6ac', // roseta plateada peluda (la firma)
-  frailejonCorazon: '#cfd7c6', // centro velloso del cogollo
-  frailejonFlor: '#e0c24a', // capítulos amarillos
-  frailejonTallo: '#95a06a', // escapo floral
+  // Frailejón — la roseta plateada vellosa es la firma.
+  frailejonTronco: '#5f4e36',
+  frailejonSeco: '#7d6544', // enagua de hojas muertas marcescentes
+  frailejonSeco2: '#93794f',
+  frailejonPlata: '#a8b79a', // roseta: verde-plata vellosa (NO blanco tiza)
+  frailejonPlataSol: '#c8d3b6',
+  frailejonCorazon: '#b9c4a4',
+  frailejonFlor: '#dcbc46',
+  frailejonTallo: '#8d9866',
 
-  // Yarumo plateado / blanco (Cecropia telealba)
-  yarumoTronco: '#bcbfb2', // tronco pálido anillado
-  yarumoRama: '#a9ac9f',
-  yarumoEnves: '#e2e7dc', // envés BLANCO de la hoja palmeada (la firma)
-  yarumoHaz: '#7f9070', // dejo verde del haz
+  // Queñua (Polylepis) — corteza rojiza en láminas de papel.
+  quenuaGrieta: '#4a2a20',
+  quenuaCuerpo: '#8a4a33',
+  quenuaPapel: '#cf9166',
+  quenuaLamina: '#b9744c',
+  quenuaHoja: '#4e6640',
+  quenuaHojaSol: '#8ba06d',
 
-  // Roble andino (Quercus humboldtii)
-  robleTronco: '#6a5c4a', // corteza gris-parda fisurada
-  robleHoja: '#43593b', // hoja coriácea verde oscuro
-  robleHoja2: '#516b42',
-  robleBellota: '#7a5a34', // bellota
-  robleCapa: '#54432a', // capuchón de la bellota
+  // Encenillo (Weinmannia) — el árbol de la niebla.
+  encenilloGrieta: '#3d2419',
+  encenilloTronco: '#6d4535',
+  encenilloHoja: '#31462d',
+  encenilloHojaSol: '#5c7a4c',
+  encenilloMusgo: '#6b7d4c',
 
-  // Encenillo (Weinmannia tomentosa)
-  encenilloTronco: '#6d4535', // corteza rojiza
-  encenilloHoja: '#3b5236', // copa oscura compacta
-  encenilloMusgo: '#586a44', // velo de musgo del árbol de niebla
+  // Aliso (Alnus acuminata) — corteza gris clara.
+  alisoGrieta: '#5f6156',
+  alisoTronco: '#9a9a8f',
+  alisoLenticela: '#c2c2b4',
+  alisoHoja: '#415c30',
+  alisoHojaSol: '#83a05a',
 
-  // Aliso (Alnus acuminata)
-  alisoTronco: '#9a9a8f', // corteza gris clara
-  alisoHoja: '#4f6d3d', // verde fresco
-  alisoHoja2: '#5c7a46',
-
-  // Gaque (Clusia)
+  // Gaque (Clusia) — hoja gruesa verde muy oscuro lustrosa.
+  gaqueGrieta: '#33291f',
   gaqueTronco: '#57493a',
-  gaqueHoja: '#2f4a2d', // verde muy oscuro lustroso
-  gaqueHoja2: '#37552f',
+  gaqueHoja: '#263d24',
+  gaqueHojaSol: '#4e6f43',
 
-  // Mortiño (Vaccinium meridionale)
-  mortinoHoja: '#3f5a3a',
-  mortinoBrote: '#7a4536', // brote rojizo nuevo
-  mortinoBaya: '#33305c', // baya azul-morada (agraz)
-  mortinoBaya2: '#3d3768',
+  // Mortiño (Vaccinium meridionale) — agraz andino.
+  mortinoRama: '#5a4030',
+  mortinoHoja: '#37502f',
+  mortinoHojaSol: '#6a8248',
+  mortinoBrote: '#7a4536',
+  mortinoBaya: '#33305c',
+  mortinoBaya2: '#454078',
 
-  // Romerillo
-  romerilloHoja: '#79883f',
-  romerilloHoja2: '#8a9a4e',
+  // Roble andino (Quercus humboldtii) — no es de páramo; lo usan la ladera de
+  // restauración y el valle. Copa ancha de hoja coriácea oscura + bellotas.
+  robleTronco: '#6a5c4a',
+  robleHoja: '#3a4f32',
+  robleHojaSol: '#6d8a4e',
+  robleBellota: '#7a5a34',
+  robleCapa: '#54432a',
+
+  // Yarumo plateado (Cecropia telealba) — tampoco es de páramo; ladera + valle.
+  // Su firma: el ENVÉS BLANCO de la hoja palmeada.
+  yarumoTronco: '#bcbfb2',
+  yarumoRama: '#a9ac9f',
+  yarumoEnves: '#e2e7dc',
+  yarumoHaz: '#7f9070',
+
+  // Romerillo.
+  romerilloHoja: '#65763a',
+  romerilloHojaSol: '#98a85c',
   romerilloFlor: '#d8c24a',
 
-  // Suelo
-  roca: '#7c7c70',
-  liquen: '#9aa86a', // líquen pálido sobre la piedra
+  // Suelo.
+  roca: '#77776b',
+  rocaSol: '#9b9b8d',
+  liquen: '#9aa86a',
   liquen2: '#b7c08a',
-  musgo: '#4c5c34',
-  musgo2: '#5a6a3e',
+  musgo: '#46562f',
+  musgoSol: '#6d8049',
 };
 
+/* Líquen del páramo que trepa el pie de todo lo leñoso. */
+const LIQUEN_PIE = '#7c8a5e';
+
 /* -------------------------------------------------------------------------- */
-/*  Utilidades de construcción (fusión + colocación + color horneado)          */
+/*  El constructor de ÁRBOLES (jerarquía de ramas + copas con huecos)          */
 /* -------------------------------------------------------------------------- */
 
-const UP = new THREE.Vector3(0, 1, 0);
+const AUREO = Math.PI * (3 - Math.sqrt(5)); // ángulo áureo: filotaxia real
 
-/** Hornea un color plano en TODOS los vértices (atributo `color`). Idempotente. */
-function pintar(geo, color) {
-  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
-  const n = geo.attributes.position.count;
-  const arr = new Float32Array(n * 3);
-  for (let i = 0; i < n; i++) {
-    arr[i * 3] = c.r;
-    arr[i * 3 + 1] = c.g;
-    arr[i * 3 + 2] = c.b;
+/**
+ * Construye un árbol procedural completo y lo devuelve FUSIONADO (1 draw-call).
+ *
+ * Sigue la receta del DR en orden de retorno: silueta y jerarquía primero,
+ * sombreado horneado encima. Las copas NO son un domo relleno: se siembran
+ * cúmulos en las PUNTAS DE RAMA, cada uno con huecos y borde mordido.
+ *
+ * @param {object} o
+ * @param {string} o.nombre        etiqueta (para que un merge nulo diga quién).
+ * @param {number} o.altura        altura del fuste.
+ * @param {number} o.r0            radio en la base.
+ * @param {number} o.r1            radio en la punta.
+ * @param {number} [o.inclina]     cuánto se inclina el fuste con la altura.
+ * @param {number} [o.sinuoso]     cuánto serpentea alrededor de su eje.
+ * @param {number} [o.raigon]      ensanche del pie (contrafuertes).
+ * @param {number} [o.arruga]      amplitud del relieve de corteza.
+ * @param {object} o.corteza       paleta de corteza (ver hornearCorteza).
+ * @param {object} o.copa          { inicio, ramas, largo, alza, sub, subLargo }
+ * @param {object} o.follaje       { base, sol, luz, radio, hojas, achatado, ... }
+ * @param {number} o.q             calidad (tier): escala el detalle.
+ * @param {number} o.semilla
+ * @param {(partes:THREE.BufferGeometry[], ctx:object)=>void} [o.firma]
+ *        gancho para el rasgo INCONFUNDIBLE de la especie (láminas de papel del
+ *        Polylepis, lenticelas del aliso, musgo del encenillo, bayas…).
+ */
+export function construirArbol(o) {
+  const {
+    nombre, altura, r0, r1, corteza, copa, follaje, q = 1, semilla = 1,
+    inclina = 0.08, sinuoso = 0.1, raigon = 0.35, arruga = 0.13,
+  } = o;
+  const r = rng(semilla);
+  const partes = [];
+
+  // 1) El FUSTE: curva sinuosa + conicidad con raigón + arruga en la malla.
+  const giro = r() * Math.PI * 2;
+  const curva = curvaTronco({ altura, inclina, sinuoso, giro }, semilla);
+  const taper = taperTronco(r0, r1, raigon);
+  const tronco = tuboOrganico(curva, {
+    tubular: Math.max(9, Math.round(16 * q)),
+    radial: Math.max(5, Math.round(9 * q)),
+    taper,
+    arruga,
+    semilla: semilla * 3,
+  });
+  hornearCorteza(tronco, {
+    ...corteza,
+    hastaLiquen: corteza.hastaLiquen ?? altura * 0.3,
+    liquen: corteza.liquen ?? LIQUEN_PIE,
+  });
+  partes.push(tronco);
+
+  // 2) RAMAS PRIMARIAS: nacen del tercio alto, en ángulo áureo (filotaxia real,
+  //    no un reparto regular que se lee como radios de rueda).
+  const nRamas = Math.max(2, Math.round(copa.ramas * q));
+  const puntas = [];
+  const ramaGeos = [];
+  for (let i = 0; i < nRamas; i++) {
+    const f = nRamas === 1 ? 0.5 : i / (nRamas - 1);
+    const tBase = copa.inicio + f * (0.94 - copa.inicio);
+    const base = curva.getPointAt(tBase);
+    const ang = i * AUREO + giro;
+    // Las ramas de abajo son más largas y abiertas; las de arriba, cortas y
+    // erguidas → la copa se estrecha sola, sin ser un cono.
+    const largo = copa.largo * (1.15 - f * 0.5) * (0.8 + r() * 0.4);
+    const alza = copa.alza * (0.7 + f * 0.7);
+    const dirX = Math.cos(ang);
+    const dirZ = Math.sin(ang);
+    const pts = [
+      base.clone(),
+      base.clone().add(new THREE.Vector3(dirX * largo * 0.34, alza * 0.3 + (r() - 0.5) * 0.1, dirZ * largo * 0.34)),
+      base.clone().add(new THREE.Vector3(dirX * largo * 0.72 + (r() - 0.5) * 0.2, alza * 0.68, dirZ * largo * 0.72 + (r() - 0.5) * 0.2)),
+      base.clone().add(new THREE.Vector3(dirX * largo, alza, dirZ * largo)),
+    ];
+    const cRama = new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
+    const rBase = Math.max(0.02, taper(tBase) * 0.4);
+    const g = tuboOrganico(cRama, {
+      tubular: Math.max(5, Math.round(9 * q)),
+      radial: Math.max(4, Math.round(6 * q)),
+      taper: taperLineal(rBase, rBase * 0.28),
+      arruga: arruga * 0.7,
+      semilla: semilla + i * 7,
+    });
+    ramaGeos.push(g);
+    puntas.push({ p: pts[3].clone(), rBase, dir: [dirX, dirZ], nivel: 1 });
+
+    // 3) RAMAS SECUNDARIAS: la jerarquía que el DR pide. Nacen a media rama y
+    //    se abren en otro plano → la silueta deja de ser una estrella plana.
+    const nSub = Math.max(0, Math.round((copa.sub ?? 2) * q));
+    for (let k = 0; k < nSub; k++) {
+      const tk = 0.42 + (k / Math.max(1, nSub)) * 0.45;
+      const bk = cRama.getPointAt(tk);
+      const desvio = ang + (k % 2 ? 1 : -1) * (0.6 + r() * 0.5);
+      const lk = (copa.subLargo ?? largo * 0.5) * (0.7 + r() * 0.5);
+      const pk = [
+        bk.clone(),
+        bk.clone().add(new THREE.Vector3(Math.cos(desvio) * lk * 0.5, alza * 0.22 + r() * 0.12, Math.sin(desvio) * lk * 0.5)),
+        bk.clone().add(new THREE.Vector3(Math.cos(desvio) * lk, alza * 0.42 + r() * 0.16, Math.sin(desvio) * lk)),
+      ];
+      const cSub = new THREE.CatmullRomCurve3(pk, false, 'catmullrom', 0.5);
+      const rk = rBase * 0.5;
+      ramaGeos.push(tuboOrganico(cSub, {
+        tubular: Math.max(4, Math.round(6 * q)),
+        radial: 4,
+        taper: taperLineal(rk, rk * 0.3),
+        arruga: arruga * 0.5,
+        semilla: semilla + i * 13 + k,
+      }));
+      puntas.push({ p: pk[2].clone(), rBase: rk, dir: [Math.cos(desvio), Math.sin(desvio)], nivel: 2 });
+    }
   }
-  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
-  return geo;
-}
+  for (const g of ramaGeos) {
+    hornearCorteza(g, { ...corteza, hastaLiquen: 0, liquen: null });
+    partes.push(g);
+  }
 
-/** Coloca una geometría con posición/rotación/escala (transforma vértices). */
-function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
-  const m = new THREE.Matrix4().compose(
-    new THREE.Vector3(pos[0], pos[1], pos[2]),
-    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
-    new THREE.Vector3(scale[0], scale[1], scale[2]),
-  );
-  geo.applyMatrix4(m);
-  return geo;
-}
+  // 4) LA COPA: un cúmulo por punta de rama. Cada cúmulo trae huecos y borde
+  //    mordido; juntos forman una masa irregular por la que entra el cielo.
+  const cima = curva.getPointAt(1);
+  const centros = puntas.map((pt) => ({
+    centro: /** @type {[number, number, number]} */ ([pt.p.x, pt.p.y + follaje.radio * 0.25, pt.p.z]),
+    radio: follaje.radio * (pt.nivel === 1 ? 1 : 0.66) * (0.75 + r() * 0.5),
+  }));
+  // La corona: remata el fuste para que la copa no se vea "colgada" de ramas.
+  centros.push({ centro: /** @type {[number, number, number]} */ ([cima.x, cima.y + follaje.radio * 0.35, cima.z]), radio: follaje.radio * 0.95 });
 
-/** Orienta el eje +Y de la geometría hacia `dir` y la ubica en `pos` (para hojas
-    que apuntan en cualquier dirección). `esc` escala en el eje local antes de
-    girar (aplana hojas: escala z pequeña → lámina). */
-function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
-  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
-  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
-  const m = new THREE.Matrix4().compose(
-    new THREE.Vector3(pos[0], pos[1], pos[2]),
-    q,
-    new THREE.Vector3(esc[0], esc[1], esc[2]),
-  );
-  geo.applyMatrix4(m);
-  return geo;
-}
+  const totalHojas = Math.max(6, Math.round(follaje.hojas * q));
+  const porCumulo = Math.max(2, Math.floor(totalHojas / centros.length));
+  const yTope = cima.y + follaje.radio * 1.3;
+  const yPie = copa.inicio * altura;
 
-/** Fusiona la lista de partes (ya coloreadas) en UNA geometría.
-    OJO: los poliedros (Icosahedron) son NO-indexados y el resto sí — merge
-    directo devolvía null y la especie quedaba invisible. Se uniformiza todo
-    a no-indexado antes de fusionar. */
-function fusionar(partes) {
-  const buenas = partes.filter(Boolean).map((g) => (g.index ? g.toNonIndexed() : g));
-  const g = mergeGeometries(buenas, false);
-  // Las partes de entrada nunca tocaron la GPU: quedan para el GC.
-  return g;
-}
+  centros.forEach((c, i) => {
+    const puntos = sembrarFollaje({
+      centro: c.centro,
+      radio: c.radio,
+      achatado: follaje.achatado ?? 0.8,
+      n: porCumulo,
+      semilla: semilla * 31 + i * 17,
+      huecos: follaje.huecos ?? 0.42,
+      mordida: follaje.mordida ?? 0.34,
+      distMin: c.radio * (follaje.distMin ?? 0.38),
+    });
+    for (let k = 0; k < puntos.length; k++) {
+      const h = puntos[k];
+      const tam = c.radio * (follaje.escHoja ?? 0.34) * h.esc;
+      const g = matojoHoja(tam, semilla + i * 5 + k, follaje.deform ?? 0.42);
+      poner(g, h.pos, h.giro, [1, follaje.aplana ?? 0.72, 1]);
+      // El sombreado se hornea contra el CÚMULO (AO local) pero con el rango de
+      // altura del ÁRBOL entero → la copa tiene sol arriba y penumbra abajo.
+      hornearFollaje(g, {
+        base: follaje.base,
+        sol: follaje.sol,
+        luz: follaje.luz,
+        centro: c.centro,
+        radio: c.radio * 1.15,
+        yMin: yPie,
+        yMax: yTope,
+        ao: follaje.ao ?? 0.6,
+        manchas: follaje.manchas ?? 0.1,
+      });
+      partes.push(g);
+    }
+  });
 
-/** Pequeña variación determinista de color (para que un bosque no sea plano). */
-function variar(base, r, amt = 0.06) {
-  const c = new THREE.Color(base);
-  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
-  return c;
+  // 5) La FIRMA de la especie (lo que la hace inconfundible).
+  if (o.firma) o.firma(partes, { r, curva, taper, altura, puntas, q, centros });
+
+  return fusionarSeguro(partes, nombre);
 }
 
 /* -------------------------------------------------------------------------- */
-/*  FRAILEJÓN (Espeletia) — el ícono del páramo                                */
+/*  FRAILEJÓN (Espeletia) — el ícono, y el más difícil                         */
 /* -------------------------------------------------------------------------- */
 
 /*
- * Tallo columnar vestido con una ENAGUA de hojas muertas (marcescentes) que
- * cuelgan, coronado por una ROSETA de hojas lanceoladas plateadas y peludas que
- * apuntan hacia arriba y afuera en espiral (ángulo áureo). Esa roseta velluda
- * plateada es lo que lo hace inequívoco. Con `flor`, le nace un escapo con
- * capítulos amarillos.
+ * Dos rasgos lo hacen inconfundible y los dos son geometría, no color:
+ *   · la ENAGUA: el tallo va vestido con las hojas MUERTAS de toda su vida, que
+ *     no se caen (marcescencia) — se apelmazan hacia abajo contra el tallo y lo
+ *     engordan. Es lo que le da su silueta de columna peluda.
+ *   · la ROSETA: hojas lanceoladas, gruesas y VELLOSAS, en espiral áurea,
+ *     apretadas y erguidas formando una copa compacta — no un erizo de púas.
+ *
+ * La versión anterior fallaba justo aquí: pocas hojas, muy separadas, muy
+ * blancas y muy abiertas → parecía un erizo blanco clavado en un palo.
  */
 export function geomFrailejon({ flor = false, q = 1 } = {}, seed = 1) {
   const r = rng(seed);
   const partes = [];
-  const GOLDEN = Math.PI * (3 - Math.sqrt(5));
+  const H = 1.0; // alto del tallo vestido
 
-  // 1) Tallo (mayormente oculto por la enagua).
-  const tronco = new THREE.CylinderGeometry(0.11, 0.14, 1.0, 7, 1);
-  poner(tronco, [0, 0.5, 0]);
-  partes.push(pintar(tronco, PAL.frailejonTronco));
+  // 1) Tallo columnar (casi todo oculto por la enagua).
+  const tallo = new THREE.CylinderGeometry(0.1, 0.13, H, 7, 1);
+  poner(tallo, [0, H / 2, 0]);
+  hornearCorteza(tallo, {
+    grieta: '#3f3324', cuerpo: PAL.frailejonTronco, cresta: '#7d6a4c',
+    liquen: null, hastaLiquen: 0, escalaGrano: 9,
+  });
+  partes.push(tallo);
 
-  // 2) Enagua de hojas muertas: anillos de hojas que cuelgan hacia abajo-afuera.
-  const anillos = Math.max(2, Math.round(3 * q));
-  const porAnillo = Math.max(5, Math.round(7 * q));
+  // 2) ENAGUA: anillos densos de hojas muertas pegadas al tallo, apuntando
+  //    abajo-afuera. Muchas y solapadas: es un manto, no un fleco.
+  const anillos = Math.max(4, Math.round(7 * q));
+  const porAnillo = Math.max(6, Math.round(10 * q));
   for (let a = 0; a < anillos; a++) {
-    const y = 0.26 + a * (0.72 / anillos);
-    const rad = 0.15 - a * 0.02;
+    const f = a / anillos;
+    const y = 0.1 + f * (H - 0.06);
+    const rad = 0.13 - f * 0.015;
     for (let i = 0; i < porAnillo; i++) {
-      const ang = (i / porAnillo) * Math.PI * 2 + a * 0.5;
-      const hoja = new THREE.ConeGeometry(0.05, 0.34, 4, 1);
+      const ang = (i / porAnillo) * Math.PI * 2 + a * 0.71 + r() * 0.16;
+      const largo = 0.3 + r() * 0.1;
+      const hoja = new THREE.ConeGeometry(0.055, largo, 4, 1);
+      // Cuelgan pegadas: casi verticales hacia abajo, apenas abiertas.
       apuntar(
         hoja,
         [Math.cos(ang) * rad, y, Math.sin(ang) * rad],
-        [Math.cos(ang) * 0.8, -0.7, Math.sin(ang) * 0.8],
-        [1, 1, 0.4],
+        [Math.cos(ang) * 0.45, -0.9, Math.sin(ang) * 0.45],
+        [1, 1, 0.42],
       );
-      partes.push(pintar(hoja, variar(PAL.frailejonSeco, r, 0.12)));
+      const seca = r() > 0.5 ? PAL.frailejonSeco : PAL.frailejonSeco2;
+      hornearFollaje(hoja, {
+        base: '#4a3a26', sol: seca, luz: '#a98d5e',
+        centro: [0, y, 0], radio: 0.4, yMin: 0, yMax: H, ao: 0.42, manchas: 0.14,
+      });
+      partes.push(hoja);
     }
   }
 
-  // 3) Roseta plateada: hojas lanceoladas hacia arriba-afuera, en espiral áurea.
-  const nRoseta = Math.max(8, Math.round(16 * q));
-  const cy = 0.98;
+  // 3) ROSETA: hojas lanceoladas apretadas en espiral áurea. Las de afuera se
+  //    abren; las del centro van casi verticales → cogollo compacto y velloso.
+  const nRoseta = Math.max(16, Math.round(34 * q));
+  const cy = H + 0.02;
   for (let i = 0; i < nRoseta; i++) {
-    const ang = i * GOLDEN;
-    const tilt = 0.72 + (i / nRoseta) * 0.5 + (r() - 0.5) * 0.12; // afuera al borde
+    const f = i / nRoseta; // 0 = exterior (vieja) → 1 = centro (nueva)
+    const ang = i * AUREO;
+    // Las viejas se tumban (casi horizontales), las nuevas se yerguen.
+    const tilt = 0.85 - f * 0.62 + (r() - 0.5) * 0.08;
     const s = Math.sin(tilt);
-    const hoja = new THREE.ConeGeometry(0.055, 0.52, 4, 1);
+    const largo = 0.32 - f * 0.1;
+    // ANCHA y CORTA: una hoja de frailejón es una lengua carnosa, no una púa.
+    // La versión anterior usaba conos largos y finos (r=0.062, l=0.5) muy
+    // separados → el conjunto se leía como un ERIZO blanco clavado en un palo,
+    // que es justo lo que el operador rechazó. Ancho ×2 y largo ×0.8, más
+    // hojas y menos abiertas → roseta compacta y vellosa.
+    const hoja = new THREE.ConeGeometry(0.135, largo, 6, 1);
     apuntar(
       hoja,
-      [Math.cos(ang) * 0.04, cy, Math.sin(ang) * 0.04],
+      [Math.cos(ang) * 0.03, cy + f * 0.045, Math.sin(ang) * 0.03],
       [Math.cos(ang) * s, Math.cos(tilt), Math.sin(ang) * s],
-      [1, 1, 0.42],
+      [1, 1, 0.5], // lanceolada: carnosa. Aplanarla a 0.3 la volvía una púa.
     );
-    partes.push(pintar(hoja, variar(PAL.frailejonPlata, r, 0.08)));
+    // Vellosa: verde-plata MATE. Nada de blanco tiza (eso la volvía un erizo de
+    // nieve); el frailejón es verde grisáceo con pelusa que apenas aclara.
+    hornearFollaje(hoja, {
+      base: '#5e6d4e', sol: PAL.frailejonPlata, luz: '#c2cdb0',
+      centro: [0, cy, 0], radio: 0.5, yMin: cy - 0.2, yMax: cy + 0.38,
+      ao: 0.5, manchas: 0.1,
+    });
+    partes.push(hoja);
   }
-  // Cogollo velloso en el centro.
-  const corazon = new THREE.IcosahedronGeometry(0.13, 0);
-  poner(corazon, [0, cy + 0.02, 0], [0, 0, 0], [1, 0.7, 1]);
-  partes.push(pintar(corazon, PAL.frailejonCorazon));
+  // Cogollo velloso: el corazón apretado de la roseta.
+  const corazon = matojoHoja(0.11, seed + 3, 0.3);
+  poner(corazon, [0, cy + 0.08, 0], [0, 0, 0], [1, 0.8, 1]);
+  hornearFollaje(corazon, {
+    base: '#8e9a7c', sol: PAL.frailejonCorazon, luz: '#e2e8d6',
+    centro: [0, cy + 0.08, 0], radio: 0.13, ao: 0.3, manchas: 0.06,
+  });
+  partes.push(corazon);
 
-  // 4) Escapo floral (solo en flor): tallo + capítulos amarillos.
+  // 4) Escapo floral (solo en flor): capítulos amarillos sobre tallo velloso.
   if (flor) {
-    const tallo = new THREE.CylinderGeometry(0.028, 0.04, 0.95, 5, 1);
-    poner(tallo, [0.05, 1.42, 0], [0, 0, 0.08]);
-    partes.push(pintar(tallo, PAL.frailejonTallo));
-    const nCap = Math.max(4, Math.round(7 * q));
+    const tf = new THREE.CylinderGeometry(0.026, 0.038, 0.9, 5, 1);
+    poner(tf, [0.04, cy + 0.44, 0], [0, 0, 0.07]);
+    partes.push(pintarPlano(tf, PAL.frailejonTallo));
+    const nCap = Math.max(4, Math.round(8 * q));
     for (let i = 0; i < nCap; i++) {
-      const ang = (i / nCap) * Math.PI * 2;
-      const rad = 0.1 + r() * 0.06;
-      const cap = new THREE.IcosahedronGeometry(0.055 + r() * 0.02, 0);
-      poner(cap, [0.08 + Math.cos(ang) * rad, 1.82 + r() * 0.1, Math.sin(ang) * rad], [0, 0, 0], [1, 0.7, 1]);
-      partes.push(pintar(cap, variar(PAL.frailejonFlor, r, 0.08)));
+      const ang = i * AUREO;
+      const rad = 0.09 + r() * 0.07;
+      const cap = matojoHoja(0.05 + r() * 0.018, seed + i, 0.24);
+      poner(cap, [0.07 + Math.cos(ang) * rad, cy + 0.86 + r() * 0.1, Math.sin(ang) * rad], [0, 0, 0], [1, 0.72, 1]);
+      hornearFollaje(cap, {
+        base: '#9b8420', sol: PAL.frailejonFlor, luz: '#f3e08a',
+        centro: [0.07, cy + 0.9, 0], radio: 0.2, ao: 0.3, manchas: 0.05,
+      });
+      partes.push(cap);
     }
   }
 
-  return fusionar(partes);
+  return fusionarSeguro(partes, flor ? 'frailejon-flor' : 'frailejon');
 }
 
 /* -------------------------------------------------------------------------- */
-/*  YARUMO PLATEADO / BLANCO (Cecropia telealba)                               */
+/*  QUEÑUA / Polylepis — la corteza de papel                                    */
 /* -------------------------------------------------------------------------- */
 
 /*
- * Pionera esbelta: tronco pálido y recto, ramas en candelabro arriba y una copa
- * en SOMBRILLA de hojas palmeadas (mano de 7 lóbulos) cuyo ENVÉS es blanco-plata.
- * Desde abajo se ve ese blanco: la firma inconfundible del yarumo.
+ * La misma especie del Ent, pero de porte normal: un cortejo de queñuas
+ * jóvenes alrededor del guardián (una familia, no un solitario). Su firma es la
+ * corteza rojiza que se DESCAMA en láminas de papel: se modela con geometría
+ * (anillos de lámina despegada), que es lo único que la lee de verdad.
  */
-export function geomYarumo({ q = 1 } = {}, seed = 2) {
-  const r = rng(seed);
-  const partes = [];
-  const H = 3.4;
+export function geomQuenua({ q = 1 } = {}, seed = 2) {
+  return construirArbol({
+    nombre: 'quenua',
+    altura: 2.3, r0: 0.17, r1: 0.05,
+    inclina: 0.2, sinuoso: 0.2, raigon: 0.4, arruga: 0.16, // retorcida
+    corteza: {
+      grieta: PAL.quenuaGrieta, cuerpo: PAL.quenuaCuerpo, cresta: PAL.quenuaPapel,
+      liquen: LIQUEN_PIE, escalaGrano: 4.5,
+    },
+    copa: { inicio: 0.4, ramas: 5, largo: 0.62, alza: 0.62, sub: 2, subLargo: 0.34 },
+    follaje: {
+      base: '#33452a', sol: PAL.quenuaHojaSol, luz: '#cdd58e',
+      radio: 0.5, hojas: 46, achatado: 0.8, huecos: 0.46, mordida: 0.4,
+      escHoja: 0.36, aplana: 0.7, ao: 0.62, manchas: 0.12,
+    },
+    q,
+    semilla: seed,
+    // FIRMA: las láminas de papel que se despegan del tronco.
+    firma: (partes, { r, curva, taper, q: qq }) => {
+      const n = Math.max(5, Math.round(14 * qq));
+      for (let i = 0; i < n; i++) {
+        const t = 0.06 + r() * 0.72;
+        const c = curva.getPointAt(t);
+        const ang = r() * Math.PI * 2;
+        const rad = taper(t);
+        // Cada lámina es un casquete fino, despegado y curvado hacia afuera.
+        const lam = new THREE.CylinderGeometry(
+          rad * 1.12, rad * 1.2, 0.1 + r() * 0.14, 7, 1, true,
+          ang, 0.7 + r() * 0.9,
+        );
+        poner(lam, [c.x, c.y, c.z], [(r() - 0.5) * 0.3, 0, (r() - 0.5) * 0.3]);
+        hornearFollaje(lam, {
+          base: '#6d3b28', sol: PAL.quenuaPapel, luz: '#e9c2a0',
+          centro: [c.x, c.y, c.z], radio: rad * 1.6,
+          yMin: 0, yMax: 2.3, ao: 0.3, manchas: 0.16,
+        });
+        partes.push(lam);
+      }
+    },
+  });
+}
 
-  const tronco = new THREE.CylinderGeometry(0.08, 0.14, H, 8, 1);
-  poner(tronco, [0, H / 2, 0], [0, 0, 0.03]);
-  partes.push(pintar(tronco, PAL.yarumoTronco));
+/* -------------------------------------------------------------------------- */
+/*  ENCENILLO (Weinmannia tomentosa) — el árbol de la niebla                   */
+/* -------------------------------------------------------------------------- */
 
-  // Ramas en candelabro (pocas, arriba).
-  const nRamas = Math.max(2, Math.round(3 * q));
-  const puntas = [[0, H + 0.05, 0]];
-  for (let i = 0; i < nRamas; i++) {
-    const ang = (i / nRamas) * Math.PI * 2 + 0.4;
-    const largo = 0.7 + r() * 0.3;
-    const rama = new THREE.CylinderGeometry(0.03, 0.05, largo, 5, 1);
-    const dir = [Math.cos(ang) * 0.7, 0.7, Math.sin(ang) * 0.7];
-    const base = [Math.cos(ang) * 0.05, H - 0.35 + i * 0.06, Math.sin(ang) * 0.05];
-    apuntar(rama, [base[0] + dir[0] * largo * 0.3, base[1] + dir[1] * largo * 0.3, base[2] + dir[2] * largo * 0.3], dir);
-    partes.push(pintar(rama, PAL.yarumoRama));
-    puntas.push([base[0] + dir[0] * largo, base[1] + dir[1] * largo, base[2] + dir[2] * largo]);
-  }
+export function geomEncenillo({ q = 1 } = {}, seed = 3) {
+  return construirArbol({
+    nombre: 'encenillo',
+    altura: 2.6, r0: 0.15, r1: 0.045,
+    inclina: 0.1, sinuoso: 0.13, arruga: 0.14,
+    corteza: {
+      grieta: PAL.encenilloGrieta, cuerpo: PAL.encenilloTronco, cresta: '#8a5c46',
+      liquen: '#6f8055', escalaGrano: 6,
+    },
+    // Copa compacta y estrecha: vive apretado en el bosque de niebla.
+    copa: { inicio: 0.46, ramas: 5, largo: 0.5, alza: 0.66, sub: 2, subLargo: 0.3 },
+    follaje: {
+      base: '#22331f', sol: PAL.encenilloHojaSol, luz: '#adc07e',
+      radio: 0.46, hojas: 52, achatado: 0.92, huecos: 0.36, mordida: 0.3,
+      escHoja: 0.36, aplana: 0.8, ao: 0.68, manchas: 0.1,
+    },
+    q,
+    semilla: seed,
+    // FIRMA: el velo de MUSGO que lo cubre (vive envuelto en niebla).
+    firma: (partes, { r, curva, taper, q: qq }) => {
+      const n = Math.max(4, Math.round(11 * qq));
+      for (let i = 0; i < n; i++) {
+        const t = 0.12 + r() * 0.7;
+        const c = curva.getPointAt(t);
+        const ang = r() * Math.PI * 2;
+        const rad = taper(t) * 1.05;
+        const m = matojoHoja(0.1 + r() * 0.07, seed + i * 3, 0.5);
+        poner(m, [c.x + Math.cos(ang) * rad, c.y, c.z + Math.sin(ang) * rad], [r(), r(), r()], [1.3, 0.9, 1.3]);
+        hornearFollaje(m, {
+          base: '#3d4a2a', sol: PAL.encenilloMusgo, luz: '#c2cf94',
+          centro: [c.x, c.y, c.z], radio: 0.4, yMin: 0, yMax: 2.6, ao: 0.4, manchas: 0.2,
+        });
+        partes.push(m);
+      }
+    },
+  });
+}
 
-  // Hojas palmeadas: discos aplanados de 7 lóbulos, envés blanco, colgando.
-  const porPunta = Math.max(2, Math.round(3 * q));
-  for (const p of puntas) {
-    for (let i = 0; i < porPunta; i++) {
-      const ang = (i / porPunta) * Math.PI * 2 + r();
-      const rad = 0.18 + r() * 0.12;
-      const hoja = new THREE.ConeGeometry(0.42, 0.09, 7, 1); // 7-gono chato = "mano"
-      // caída suave hacia afuera (envés hacia el suelo → se ve el blanco)
-      apuntar(
-        hoja,
-        [p[0] + Math.cos(ang) * rad, p[1] - 0.05 - r() * 0.08, p[2] + Math.sin(ang) * rad],
-        [Math.cos(ang) * 0.4, 0.9, Math.sin(ang) * 0.4],
-        [1, 0.5, 1],
-      );
-      partes.push(pintar(hoja, variar(PAL.yarumoEnves, r, 0.05)));
-    }
-  }
+/* -------------------------------------------------------------------------- */
+/*  ALISO (Alnus acuminata) — el vecino esbelto de corteza clara               */
+/* -------------------------------------------------------------------------- */
 
-  return fusionar(partes);
+/*
+ * OJO: la versión anterior construía su copa como un CONO explícito ("copa
+ * cónica: blobs que se estrechan hacia arriba") — el árbol de navidad literal.
+ * Ahora la copa es alta y ovalada pero IRREGULAR: se estrecha porque las ramas
+ * de arriba son cortas, no porque la dibujemos como un cono.
+ */
+export function geomAliso({ q = 1 } = {}, seed = 4) {
+  return construirArbol({
+    nombre: 'aliso',
+    altura: 3.3, r0: 0.13, r1: 0.04,
+    inclina: 0.06, sinuoso: 0.08, raigon: 0.28, arruga: 0.08, // recto y esbelto
+    corteza: {
+      grieta: PAL.alisoGrieta, cuerpo: PAL.alisoTronco, cresta: PAL.alisoLenticela,
+      liquen: '#8a9668', escalaGrano: 7,
+    },
+    copa: { inicio: 0.42, ramas: 6, largo: 0.6, alza: 0.72, sub: 2, subLargo: 0.32 },
+    follaje: {
+      base: '#2c4020', sol: PAL.alisoHojaSol, luz: '#d2dc8e',
+      radio: 0.5, hojas: 56, achatado: 0.86, huecos: 0.5, mordida: 0.42,
+      escHoja: 0.34, aplana: 0.7, ao: 0.58, manchas: 0.12,
+    },
+    q,
+    semilla: seed,
+    // FIRMA: las LENTICELAS: las rayitas claras horizontales de su corteza gris.
+    firma: (partes, { r, curva, taper, q: qq }) => {
+      const n = Math.max(6, Math.round(16 * qq));
+      for (let i = 0; i < n; i++) {
+        const t = 0.06 + r() * 0.68;
+        const c = curva.getPointAt(t);
+        const ang = r() * Math.PI * 2;
+        const rad = taper(t);
+        const len = new THREE.BoxGeometry(0.07 + r() * 0.06, 0.014, 0.03);
+        poner(
+          len,
+          [c.x + Math.cos(ang) * rad * 0.98, c.y, c.z + Math.sin(ang) * rad * 0.98],
+          [0, -ang, 0],
+        );
+        partes.push(pintarPlano(len, PAL.alisoLenticela));
+      }
+    },
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  GAQUE (Clusia) — copa redonda densa de hoja gruesa lustrosa                */
+/* -------------------------------------------------------------------------- */
+
+export function geomGaque({ q = 1 } = {}, seed = 5) {
+  return construirArbol({
+    nombre: 'gaque',
+    altura: 1.9, r0: 0.17, r1: 0.06,
+    inclina: 0.1, sinuoso: 0.1, arruga: 0.1,
+    corteza: {
+      grieta: PAL.gaqueGrieta, cuerpo: PAL.gaqueTronco, cresta: '#75664f',
+      liquen: LIQUEN_PIE, escalaGrano: 6.5,
+    },
+    // Ramas cortas y muy abiertas → domo bajo, ancho y macizo.
+    copa: { inicio: 0.4, ramas: 6, largo: 0.72, alza: 0.34, sub: 2, subLargo: 0.36 },
+    follaje: {
+      base: '#182a17', sol: PAL.gaqueHojaSol, luz: '#9ab97e',
+      radio: 0.56, hojas: 58, achatado: 0.72, huecos: 0.3, mordida: 0.26,
+      escHoja: 0.4, aplana: 0.66, ao: 0.7, manchas: 0.08,
+    },
+    q,
+    semilla: seed,
+  });
 }
 
 /* -------------------------------------------------------------------------- */
@@ -332,295 +638,351 @@ export function geomYarumo({ q = 1 } = {}, seed = 2) {
 /* -------------------------------------------------------------------------- */
 
 /*
- * Árbol robusto de robledal altoandino: tronco grueso de corteza gris-parda
- * fisurada y una copa ANCHA y densa de hoja coriácea verde oscuro, con bellotas.
- * Imponente pero SIEMPRE menor que el Ent (el guardián sigue mandando).
+ * No es de páramo (es del robledal andino, más abajo), así que NO entra en el
+ * cortejo del Ent — pero lo usan la ladera de restauración y el valle, y esos
+ * mundos también merecen dejar de tener bombones. Su firma: tronco grueso y
+ * copa ANCHA y densa de hoja coriácea oscura, con bellotas.
  */
-export function geomRoble({ q = 1 } = {}, seed = 3) {
+export function geomRoble({ q = 1 } = {}, seed = 11) {
+  return construirArbol({
+    nombre: 'roble',
+    altura: 2.5, r0: 0.26, r1: 0.08,
+    inclina: 0.07, sinuoso: 0.1, raigon: 0.42, arruga: 0.15,
+    corteza: {
+      grieta: '#3b3126', cuerpo: PAL.robleTronco, cresta: '#8a7a63',
+      liquen: LIQUEN_PIE, escalaGrano: 5,
+    },
+    // Ramas largas y poco alzadas → la copa se va a lo ANCHO, que es su sello.
+    copa: { inicio: 0.38, ramas: 6, largo: 1.0, alza: 0.5, sub: 2, subLargo: 0.5 },
+    follaje: {
+      base: '#1e2f1a', sol: PAL.robleHojaSol, luz: '#a8bd76',
+      radio: 0.62, hojas: 66, achatado: 0.74, huecos: 0.34, mordida: 0.3,
+      escHoja: 0.38, aplana: 0.7, ao: 0.68, manchas: 0.1,
+    },
+    q,
+    semilla: seed,
+    // FIRMA: las bellotas colgando del borde de la copa.
+    firma: (partes, { r, q: qq, centros }) => {
+      const n = Math.max(2, Math.round(5 * qq));
+      for (let i = 0; i < n; i++) {
+        const c = centros[Math.floor(r() * centros.length) % centros.length];
+        const ang = r() * Math.PI * 2;
+        const rad = c.radio * (0.4 + r() * 0.5);
+        const p = [c.centro[0] + Math.cos(ang) * rad, c.centro[1] - c.radio * 0.5, c.centro[2] + Math.sin(ang) * rad];
+        const bellota = new THREE.IcosahedronGeometry(0.055, 0);
+        poner(bellota, p, [0, 0, 0], [1, 1.45, 1]);
+        partes.push(pintarPlano(bellota, PAL.robleBellota));
+        const capa = new THREE.SphereGeometry(0.048, 6, 4, 0, Math.PI * 2, 0, Math.PI * 0.5);
+        poner(capa, [p[0], p[1] + 0.06, p[2]]);
+        partes.push(pintarPlano(capa, PAL.robleCapa));
+      }
+    },
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  YARUMO PLATEADO / BLANCO (Cecropia telealba)                               */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Tampoco es de páramo (es pionera de bosque andino) pero la usan la ladera y
+ * el valle. Su firma es única y no pasa por el constructor genérico: pocas
+ * ramas en candelabro y una copa en SOMBRILLA de hojas palmeadas grandes cuyo
+ * ENVÉS es blanco-plata — desde abajo se ve ese blanco, y eso es el yarumo.
+ */
+export function geomYarumo({ q = 1 } = {}, seed = 12) {
   const r = rng(seed);
   const partes = [];
-  const H = 2.4;
+  const H = 3.4;
 
-  const tronco = new THREE.CylinderGeometry(0.16, 0.24, H, 8, 1);
-  poner(tronco, [0, H / 2, 0], [0.03, 0, 0.02]);
-  partes.push(pintar(tronco, PAL.robleTronco));
+  // Tronco pálido, esbelto y anillado.
+  const curva = curvaTronco({ altura: H, inclina: 0.07, sinuoso: 0.06, giro: r() * 6.28 }, seed);
+  const taper = taperTronco(0.14, 0.06, 0.2);
+  const tronco = tuboOrganico(curva, {
+    tubular: Math.max(8, Math.round(14 * q)), radial: Math.max(5, Math.round(8 * q)),
+    taper, arruga: 0.05, semilla: seed * 3,
+  });
+  hornearCorteza(tronco, {
+    grieta: '#8e9186', cuerpo: PAL.yarumoTronco, cresta: '#d6d9cc',
+    liquen: LIQUEN_PIE, hastaLiquen: H * 0.18, escalaGrano: 3,
+  });
+  partes.push(tronco);
 
-  // Un par de ramas gruesas bajas que abren la copa ancha.
-  const nRamas = Math.max(2, Math.round(3 * q));
+  // Anillos: las cicatrices de hoja caída que le marcan el tronco.
+  const nAnillos = Math.max(3, Math.round(8 * q));
+  for (let i = 0; i < nAnillos; i++) {
+    const t = 0.12 + (i / nAnillos) * 0.72;
+    const c = curva.getPointAt(t);
+    const rad = taper(t);
+    const anillo = new THREE.TorusGeometry(rad * 1.02, 0.012, 4, 9);
+    poner(anillo, [c.x, c.y, c.z], [Math.PI / 2, 0, 0]);
+    partes.push(pintarPlano(anillo, '#9fa294'));
+  }
+
+  // Ramas en candelabro: pocas, arriba, muy abiertas.
+  const nRamas = Math.max(2, Math.round(4 * q));
+  const puntas = [curva.getPointAt(1).clone()];
   for (let i = 0; i < nRamas; i++) {
-    const ang = (i / nRamas) * Math.PI * 2 + 0.5;
-    const rama = new THREE.CylinderGeometry(0.06, 0.1, 0.9, 6, 1);
-    apuntar(rama, [Math.cos(ang) * 0.3, H - 0.4, Math.sin(ang) * 0.3], [Math.cos(ang) * 0.8, 0.55, Math.sin(ang) * 0.8]);
-    partes.push(pintar(rama, PAL.robleTronco));
+    const ang = i * AUREO + r() * 0.4;
+    const largo = 0.72 + r() * 0.3;
+    const base = curva.getPointAt(0.86 + (i / nRamas) * 0.1);
+    const fin = base.clone().add(new THREE.Vector3(Math.cos(ang) * largo, 0.66 + r() * 0.2, Math.sin(ang) * largo));
+    const cR = new THREE.CatmullRomCurve3([
+      base.clone(),
+      base.clone().lerp(fin, 0.55).add(new THREE.Vector3(0, 0.1, 0)),
+      fin.clone(),
+    ], false, 'catmullrom', 0.5);
+    const g = tuboOrganico(cR, {
+      tubular: 5, radial: 4, taper: taperLineal(0.045, 0.022), arruga: 0.05, semilla: seed + i,
+    });
+    hornearCorteza(g, { grieta: '#8a8d82', cuerpo: PAL.yarumoRama, cresta: '#c8cbbe', liquen: null, hastaLiquen: 0, escalaGrano: 4 });
+    partes.push(g);
+    puntas.push(fin);
   }
 
-  // Copa ancha densa: cúpula amplia de follaje coriáceo oscuro.
-  const nBlobs = Math.max(6, Math.round(12 * q));
-  for (let i = 0; i < nBlobs; i++) {
-    const ang = r() * Math.PI * 2;
-    const rad = 0.2 + r() * 1.05; // ANCHA
-    const y = H + 0.1 + r() * 1.0;
-    const s = 0.42 + r() * 0.42;
-    const blob = new THREE.IcosahedronGeometry(s, 0);
-    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 0.85, 1]);
-    partes.push(pintar(blob, variar(r() > 0.5 ? PAL.robleHoja : PAL.robleHoja2, r, 0.08)));
-  }
-
-  // Bellotas (unas pocas, cuelgan del borde de la copa).
-  if (q > 0.5) {
-    const nBel = Math.max(2, Math.round(4 * q));
-    for (let i = 0; i < nBel; i++) {
-      const ang = r() * Math.PI * 2;
-      const rad = 0.7 + r() * 0.5;
-      const y = H + 0.2 + r() * 0.5;
-      const bellota = new THREE.IcosahedronGeometry(0.06, 0);
-      poner(bellota, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [0, 0, 0], [1, 1.4, 1]);
-      partes.push(pintar(bellota, PAL.robleBellota));
-      const capa = new THREE.SphereGeometry(0.05, 6, 4, 0, Math.PI * 2, 0, Math.PI * 0.5);
-      poner(capa, [Math.cos(ang) * rad, y + 0.07, Math.sin(ang) * rad]);
-      partes.push(pintar(capa, PAL.robleCapa));
+  // Las HOJAS palmeadas: discos grandes de 7 lóbulos, casi horizontales, con el
+  // envés blanco mirando al suelo. Es la sombrilla del yarumo.
+  const porPunta = Math.max(2, Math.round(3 * q));
+  for (const p of puntas) {
+    for (let i = 0; i < porPunta; i++) {
+      const ang = i * AUREO + r() * 1.2;
+      const rad = 0.2 + r() * 0.14;
+      const hoja = new THREE.ConeGeometry(0.44, 0.08, 7, 1); // heptágono chato = "mano"
+      const pos = /** @type {[number, number, number]} */ ([p.x + Math.cos(ang) * rad, p.y - 0.04 - r() * 0.08, p.z + Math.sin(ang) * rad]);
+      apuntar(hoja, pos, [Math.cos(ang) * 0.34, 0.94, Math.sin(ang) * 0.34], [1, 0.5, 1]);
+      // El haz apenas verdea; el envés (abajo) es blanco-plata: el gradiente de
+      // altura de hornearFollaje hace justo eso si le damos un rango corto.
+      hornearFollaje(hoja, {
+        base: PAL.yarumoEnves, sol: PAL.yarumoHaz, luz: '#f2f6ee',
+        centro: pos, radio: 0.5, yMin: pos[1] - 0.06, yMax: pos[1] + 0.06,
+        ao: 0.18, manchas: 0.05,
+      });
+      partes.push(hoja);
     }
   }
 
-  return fusionar(partes);
+  return fusionarSeguro(partes, 'yarumo');
 }
 
 /* -------------------------------------------------------------------------- */
-/*  ENCENILLO (Weinmannia tomentosa) — el árbol de la niebla                   */
+/*  MORTIÑO (Vaccinium meridionale) — el agraz andino                          */
 /* -------------------------------------------------------------------------- */
 
 /*
- * Copa oscura, compacta e irregular sobre tronco rojizo algo torcido, con un
- * velo de musgo (vive envuelto en niebla). Más estrecho y sombrío que el roble.
+ * Arbusto bajo y ramoso. No pasa por `construirArbol` (no tiene fuste): es una
+ * mata de varitas que salen del suelo, con hojita menuda y —la firma— BAYAS
+ * azul-moradas salpicadas.
  */
-export function geomEncenillo({ q = 1 } = {}, seed = 4) {
-  const r = rng(seed);
-  const partes = [];
-  const H = 2.3;
-
-  const tronco = new THREE.CylinderGeometry(0.1, 0.16, H, 7, 1);
-  poner(tronco, [0, H / 2, 0], [0.05, 0, -0.03]);
-  partes.push(pintar(tronco, PAL.encenilloTronco));
-
-  const nBlobs = Math.max(5, Math.round(9 * q));
-  for (let i = 0; i < nBlobs; i++) {
-    const ang = r() * Math.PI * 2;
-    const rad = 0.15 + r() * 0.6; // copa estrecha
-    const y = H + 0.05 + r() * 1.0;
-    const s = 0.34 + r() * 0.3;
-    const blob = new THREE.IcosahedronGeometry(s, 0);
-    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 0.95, 1]);
-    const mossy = r() > 0.65;
-    partes.push(pintar(blob, variar(mossy ? PAL.encenilloMusgo : PAL.encenilloHoja, r, 0.08)));
-  }
-
-  return fusionar(partes);
-}
-
-/* -------------------------------------------------------------------------- */
-/*  ALISO (Alnus acuminata) — el vecino alto de corteza clara                  */
-/* -------------------------------------------------------------------------- */
-
-/*
- * Tronco recto y esbelto de corteza gris clara, copa CÓNICA-ovalada de verde
- * fresco. Es el árbol más alto del cortejo (crece rápido) pero no llega al Ent.
- */
-export function geomAliso({ q = 1 } = {}, seed = 5) {
-  const r = rng(seed);
-  const partes = [];
-  const H = 3.2;
-
-  const tronco = new THREE.CylinderGeometry(0.07, 0.13, H, 8, 1);
-  poner(tronco, [0, H / 2, 0]);
-  partes.push(pintar(tronco, PAL.alisoTronco));
-
-  // Copa cónica: blobs que se estrechan hacia arriba.
-  const nBlobs = Math.max(5, Math.round(10 * q));
-  for (let i = 0; i < nBlobs; i++) {
-    const f = i / nBlobs; // 0 abajo → 1 arriba
-    const ang = r() * Math.PI * 2;
-    const rad = (0.65 - f * 0.5) * (0.4 + r() * 0.8);
-    const y = H - 1.1 + f * 2.0 + r() * 0.2;
-    const s = 0.4 - f * 0.18 + r() * 0.18;
-    const blob = new THREE.IcosahedronGeometry(Math.max(0.16, s), 0);
-    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 1, 1]);
-    partes.push(pintar(blob, variar(r() > 0.5 ? PAL.alisoHoja : PAL.alisoHoja2, r, 0.08)));
-  }
-
-  return fusionar(partes);
-}
-
-/* -------------------------------------------------------------------------- */
-/*  GAQUE (Clusia) — copa redonda de hoja gruesa lustrosa                       */
-/* -------------------------------------------------------------------------- */
-
-/*
- * Copa REDONDA densa y baja de hoja gruesa verde muy oscuro (casi lustrosa),
- * sobre tronco corto y firme. Compacto y sólido.
- */
-export function geomGaque({ q = 1 } = {}, seed = 6) {
-  const r = rng(seed);
-  const partes = [];
-  const H = 1.9;
-
-  const tronco = new THREE.CylinderGeometry(0.13, 0.19, H, 8, 1);
-  poner(tronco, [0, H / 2, 0]);
-  partes.push(pintar(tronco, PAL.gaqueTronco));
-
-  const nBlobs = Math.max(5, Math.round(9 * q));
-  for (let i = 0; i < nBlobs; i++) {
-    const ang = r() * Math.PI * 2;
-    const rad = 0.15 + r() * 0.75;
-    const y = H + 0.15 + r() * 0.7; // domo bajo y ancho
-    const s = 0.4 + r() * 0.38;
-    const blob = new THREE.IcosahedronGeometry(s, 0);
-    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 0.8, 1]);
-    partes.push(pintar(blob, variar(r() > 0.5 ? PAL.gaqueHoja : PAL.gaqueHoja2, r, 0.06)));
-  }
-
-  return fusionar(partes);
-}
-
-/* -------------------------------------------------------------------------- */
-/*  MORTIÑO (Vaccinium meridionale) — arbusto de agraz con bayas azules         */
-/* -------------------------------------------------------------------------- */
-
-/*
- * Mata baja de hojitas verdes con brotes rojizos y —la firma— BAYAS azul-moradas
- * (el agraz andino) salpicadas entre el follaje.
- */
-export function geomMortino({ q = 1 } = {}, seed = 7) {
+export function geomMortino({ q = 1 } = {}, seed = 6) {
   const r = rng(seed);
   const partes = [];
 
-  const nBlobs = Math.max(4, Math.round(7 * q));
-  for (let i = 0; i < nBlobs; i++) {
-    const ang = r() * Math.PI * 2;
-    const rad = r() * 0.32;
-    const y = 0.18 + r() * 0.5;
-    const s = 0.16 + r() * 0.16;
-    const blob = new THREE.IcosahedronGeometry(s, 0);
-    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 1, 1]);
-    const brote = r() > 0.72;
-    partes.push(pintar(blob, variar(brote ? PAL.mortinoBrote : PAL.mortinoHoja, r, 0.08)));
+  // Varitas desde la base (mata ramosa).
+  const nVaras = Math.max(3, Math.round(6 * q));
+  const puntas = [];
+  for (let i = 0; i < nVaras; i++) {
+    const ang = i * AUREO + r() * 0.5;
+    const alto = 0.42 + r() * 0.3;
+    const abre = 0.12 + r() * 0.16;
+    const pts = [
+      new THREE.Vector3(0, 0, 0),
+      new THREE.Vector3(Math.cos(ang) * abre * 0.5, alto * 0.5, Math.sin(ang) * abre * 0.5),
+      new THREE.Vector3(Math.cos(ang) * abre, alto, Math.sin(ang) * abre),
+    ];
+    const c = new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
+    const g = tuboOrganico(c, {
+      tubular: 4, radial: 4, taper: taperLineal(0.022, 0.01), arruga: 0.1, semilla: seed + i,
+    });
+    hornearCorteza(g, { grieta: '#38271c', cuerpo: PAL.mortinoRama, cresta: '#7a5a44', liquen: null, hastaLiquen: 0, escalaGrano: 10 });
+    partes.push(g);
+    puntas.push(pts[2]);
   }
-  // Bayas azul-moradas.
-  const nBayas = Math.max(3, Math.round(10 * q));
+
+  // Hojita menuda alrededor de las varitas.
+  const nHojas = Math.max(6, Math.round(16 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const p = puntas[i % puntas.length];
+    const ang = r() * Math.PI * 2;
+    const rad = 0.06 + r() * 0.16;
+    const pos = [p.x + Math.cos(ang) * rad, 0.16 + r() * 0.42, p.z + Math.sin(ang) * rad];
+    const h = matojoHoja(0.08 + r() * 0.05, seed + i * 3, 0.4);
+    poner(h, pos, [r(), r(), r()], [1, 0.6, 1]);
+    hornearFollaje(h, {
+      base: '#25361f', sol: r() > 0.78 ? PAL.mortinoBrote : PAL.mortinoHojaSol, luz: '#b6c883',
+      centro: [0, 0.4, 0], radio: 0.5, yMin: 0, yMax: 0.8, ao: 0.5, manchas: 0.14,
+    });
+    partes.push(h);
+  }
+
+  // FIRMA: las bayas de agraz, azul-moradas con su punto de brillo.
+  const nBayas = Math.max(3, Math.round(9 * q));
   for (let i = 0; i < nBayas; i++) {
     const ang = r() * Math.PI * 2;
-    const rad = r() * 0.34;
-    const y = 0.15 + r() * 0.5;
-    const baya = new THREE.IcosahedronGeometry(0.04 + r() * 0.015, 0);
-    poner(baya, [Math.cos(ang) * rad, y, Math.sin(ang) * rad]);
-    partes.push(pintar(baya, variar(r() > 0.5 ? PAL.mortinoBaya : PAL.mortinoBaya2, r, 0.1)));
+    const rad = r() * 0.3;
+    const baya = new THREE.IcosahedronGeometry(0.038 + r() * 0.014, 0);
+    poner(baya, [Math.cos(ang) * rad, 0.16 + r() * 0.42, Math.sin(ang) * rad]);
+    hornearFollaje(baya, {
+      base: '#1d1b38', sol: r() > 0.5 ? PAL.mortinoBaya : PAL.mortinoBaya2, luz: '#8f88d0',
+      centro: [Math.cos(ang) * rad, 0.3, Math.sin(ang) * rad], radio: 0.05, ao: 0.3, manchas: 0,
+    });
+    partes.push(baya);
   }
 
-  return fusionar(partes);
+  return fusionarSeguro(partes, 'mortino');
 }
 
 /* -------------------------------------------------------------------------- */
-/*  ROMERILLO — mata baja de follaje fino                                       */
+/*  ROMERILLO — cojín bajo de follaje fino                                      */
 /* -------------------------------------------------------------------------- */
 
-/*
- * Cojín bajo de follaje FINO amarillo-verde (hojita de escama tipo romero de
- * páramo), a veces con puntos de flor amarilla. Relleno del sotobosque.
- */
-export function geomRomerillo({ q = 1 } = {}, seed = 8) {
+export function geomRomerillo({ q = 1 } = {}, seed = 7) {
   const r = rng(seed);
   const partes = [];
-
-  const nRamitas = Math.max(6, Math.round(14 * q));
+  const nRamitas = Math.max(6, Math.round(16 * q));
   for (let i = 0; i < nRamitas; i++) {
-    const ang = r() * Math.PI * 2;
-    const rad = r() * 0.28;
-    const largo = 0.28 + r() * 0.32;
-    const ramita = new THREE.ConeGeometry(0.05, largo, 4, 1);
+    const ang = i * AUREO;
+    const rad = r() * 0.26;
+    const largo = 0.26 + r() * 0.3;
+    const ramita = new THREE.ConeGeometry(0.045, largo, 4, 1);
     apuntar(
       ramita,
-      [Math.cos(ang) * rad, largo * 0.4, Math.sin(ang) * rad],
-      [Math.cos(ang) * 0.35 + (r() - 0.5) * 0.3, 1, Math.sin(ang) * 0.35 + (r() - 0.5) * 0.3],
+      [Math.cos(ang) * rad, largo * 0.42, Math.sin(ang) * rad],
+      [Math.cos(ang) * 0.32 + (r() - 0.5) * 0.28, 1, Math.sin(ang) * 0.32 + (r() - 0.5) * 0.28],
     );
-    partes.push(pintar(ramita, variar(r() > 0.5 ? PAL.romerilloHoja : PAL.romerilloHoja2, r, 0.1)));
+    hornearFollaje(ramita, {
+      base: '#3f4a20', sol: PAL.romerilloHojaSol, luz: '#d8e08e',
+      centro: [0, 0.3, 0], radio: 0.45, yMin: 0, yMax: 0.62, ao: 0.5, manchas: 0.16,
+    });
+    partes.push(ramita);
   }
   if (q > 0.5) {
     const nFlor = Math.max(2, Math.round(5 * q));
     for (let i = 0; i < nFlor; i++) {
       const ang = r() * Math.PI * 2;
-      const rad = r() * 0.26;
-      const flor = new THREE.IcosahedronGeometry(0.035, 0);
-      poner(flor, [Math.cos(ang) * rad, 0.35 + r() * 0.3, Math.sin(ang) * rad]);
-      partes.push(pintar(flor, PAL.romerilloFlor));
+      const rad = r() * 0.24;
+      const flor = new THREE.IcosahedronGeometry(0.032, 0);
+      poner(flor, [Math.cos(ang) * rad, 0.34 + r() * 0.28, Math.sin(ang) * rad]);
+      partes.push(pintarPlano(flor, PAL.romerilloFlor));
     }
   }
-
-  return fusionar(partes);
+  return fusionarSeguro(partes, 'romerillo');
 }
 
 /* -------------------------------------------------------------------------- */
 /*  SUELO — rocas con líquen + montículos de musgo                              */
 /* -------------------------------------------------------------------------- */
 
-/** Roca baja gris con parches de líquen pálido (piedra del páramo). */
-export function geomRoca(seed = 9) {
+/** Roca del páramo: pedrusco irregular con parches de líquen. */
+export function geomRoca(seed = 8) {
   const r = rng(seed);
   const partes = [];
-  const piedra = new THREE.IcosahedronGeometry(0.3, 0);
-  poner(piedra, [0, 0.12, 0], [r(), r(), r()], [1 + r() * 0.4, 0.55 + r() * 0.2, 1 + r() * 0.4]);
-  partes.push(pintar(piedra, variar(PAL.roca, r, 0.08)));
-  // Líquen encima.
+  const piedra = matojoHoja(0.3, seed, 0.34);
+  poner(piedra, [0, 0.1, 0], [r(), r(), r()], [1 + r() * 0.4, 0.5 + r() * 0.2, 1 + r() * 0.4]);
+  hornearFollaje(piedra, {
+    base: '#4a4a42', sol: PAL.rocaSol, luz: '#c4c4b4',
+    centro: [0, 0.05, 0], radio: 0.4, yMin: 0, yMax: 0.32, ao: 0.5, manchas: 0.14,
+  });
+  partes.push(piedra);
   const nLiquen = 2 + Math.round(r() * 2);
   for (let i = 0; i < nLiquen; i++) {
     const ang = r() * Math.PI * 2;
-    const rad = r() * 0.22;
-    const parche = new THREE.IcosahedronGeometry(0.07 + r() * 0.05, 0);
-    poner(parche, [Math.cos(ang) * rad, 0.2 + r() * 0.06, Math.sin(ang) * rad], [0, 0, 0], [1.3, 0.4, 1.3]);
-    partes.push(pintar(parche, variar(r() > 0.5 ? PAL.liquen : PAL.liquen2, r, 0.1)));
+    const rad = r() * 0.2;
+    const parche = matojoHoja(0.07 + r() * 0.05, seed + i * 7, 0.5);
+    poner(parche, [Math.cos(ang) * rad, 0.17 + r() * 0.05, Math.sin(ang) * rad], [0, 0, 0], [1.4, 0.35, 1.4]);
+    hornearFollaje(parche, {
+      base: '#6a7844', sol: r() > 0.5 ? PAL.liquen : PAL.liquen2, luz: '#dfe6b4',
+      centro: [0, 0.2, 0], radio: 0.3, ao: 0.3, manchas: 0.2,
+    });
+    partes.push(parche);
   }
-  return fusionar(partes);
+  return fusionarSeguro(partes, 'roca');
 }
 
-/** Montículo de musgo húmedo (domo bajo). */
-export function geomMusgo(seed = 10) {
+/** Montículo de musgo húmedo (domo bajo e irregular). */
+export function geomMusgo(seed = 9) {
   const r = rng(seed);
-  const domo = new THREE.SphereGeometry(0.28, 8, 5, 0, Math.PI * 2, 0, Math.PI * 0.5);
-  poner(domo, [0, 0, 0], [0, 0, 0], [1 + r() * 0.5, 0.45 + r() * 0.2, 1 + r() * 0.5]);
-  return pintar(domo, variar(r() > 0.5 ? PAL.musgo : PAL.musgo2, r, 0.1));
+  const domo = matojoHoja(0.28, seed, 0.3);
+  poner(domo, [0, 0.02, 0], [0, 0, 0], [1 + r() * 0.5, 0.4 + r() * 0.18, 1 + r() * 0.5]);
+  hornearFollaje(domo, {
+    base: '#2b3a1c', sol: PAL.musgoSol, luz: '#b6c886',
+    centro: [0, 0, 0], radio: 0.32, yMin: 0, yMax: 0.22, ao: 0.45, manchas: 0.22,
+  });
+  return fusionarSeguro([domo], 'musgo');
 }
 
 /* -------------------------------------------------------------------------- */
-/*  DISTRIBUCIÓN biogeográfica alrededor del Ent                               */
+/*  DISTRIBUCIÓN — bosquetes, claros, sotobosque y borde (NO una grilla)       */
 /* -------------------------------------------------------------------------- */
 
 /*
- * Estratos concéntricos (el Ent en el centro, 0,0,0). La cámara ORBITA, así que
- * la composición es un anillo por estrato (no un frente fijo):
- *   · frailejonar + sotobosque + suelo → anillo interior-medio (al frente visual).
- *   · árboles (roble, encenillo, aliso, yarumo, gaque) → anillo exterior, velados
- *     por la niebla → dan fondo y hacen que el Ent RESALTE como el mayor.
- * Devuelve, por especie, instancias {pos, rotY, escala, tint}.
+ * El DR §"La disposición" es tajante: los árboles no crecen en cuadrícula NI en
+ * anillos regulares. La versión anterior sembraba cada especie en un ANILLO
+ * concéntrico con reparto angular parejo (`uniforme: true`) → se leía como un
+ * decorado de teatro alrededor del Ent.
+ *
+ * Ahora: BOSQUETES. Cada especie elige unos pocos núcleos alrededor del claro y
+ * sus matas caen cerca de ellos (dispersión gaussiana). Un campo de ruido decide
+ * la densidad → aparecen claros de verdad. El sotobosque se agolpa en el BORDE
+ * de los bosquetes, que es donde crece en el bosque real.
  */
+
 function tinteInstancia(r, amt) {
   const f = 1 + (r() - 0.5) * amt;
   const h = (r() - 0.5) * amt * 0.4;
-  const cl = (v) => Math.max(0.7, Math.min(1.16, v));
+  const cl = (v) => Math.max(0.72, Math.min(1.16, v));
   return [cl(f + h), cl(f), cl(f - h * 0.6)];
 }
 
-function sembrar(n, rMin, rMax, r, opts = {}) {
+/** Gaussiana estándar por Box-Muller (para dispersar alrededor de un núcleo). */
+function gauss(r) {
+  const u = Math.max(1e-6, r());
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * r());
+}
+
+/**
+ * Siembra `n` matas en BOSQUETES dentro del anillo [rMin, rMax] alrededor del
+ * Ent, respetando los claros del campo de ruido y una distancia mínima entre
+ * matas (nada de matas encajadas unas en otras).
+ */
+function sembrarBosquete(n, rMin, rMax, r, opts = {}) {
+  if (n <= 0) return [];
+  const nucleos = Math.max(1, opts.nucleos ?? Math.ceil(n / 5));
+  const disper = opts.disper ?? 1.5;
+  const distMin = opts.distMin ?? 0.7;
+  const eMin = opts.eMin ?? 0.85;
+  const eMax = opts.eMax ?? 1.2;
+  const claros = opts.claros ?? 0.35;
+
+  // Núcleos de bosquete: repartidos con jitter fuerte (no equiespaciados).
+  const centros = [];
+  for (let i = 0; i < nucleos; i++) {
+    const ang = (i / nucleos) * Math.PI * 2 + (r() - 0.5) * 1.9;
+    const rad = rMin + (rMax - rMin) * (0.25 + r() * 0.6);
+    centros.push([Math.cos(ang) * rad, Math.sin(ang) * rad]);
+  }
+
   const arr = [];
-  const eMin = opts.eMin ?? 0.9;
-  const eMax = opts.eMax ?? 1.15;
-  for (let i = 0; i < n; i++) {
-    // Árboles (uniforme): reparto angular parejo + leve jitter → no se solapan.
-    // Sotobosque/frailejonar (agrupado): ángulo aleatorio → matorral natural.
-    const ang = opts.uniforme
-      ? (i / Math.max(1, n)) * Math.PI * 2 + (r() - 0.5) * 0.7
-      : r() * Math.PI * 2;
-    const rad = rMin + (rMax - rMin) * (opts.haciaAfuera ? Math.sqrt(r()) : r());
+  const intentos = n * 26;
+  for (let i = 0; i < intentos && arr.length < n; i++) {
+    const c = centros[Math.floor(r() * centros.length) % centros.length];
+    const x = c[0] + gauss(r) * disper;
+    const z = c[1] + gauss(r) * disper;
+    const rad = Math.hypot(x, z);
+    if (rad < rMin || rad > rMax) continue;
+    // Claros: el campo de ruido apaga zonas → el bosque respira.
+    if (ruidoFbm(x * 0.16 + 40, 0, z * 0.16 + 40) < claros * 0.55) continue;
+    // Distancia mínima: nada de matas incrustadas.
+    let choca = false;
+    for (let k = 0; k < arr.length; k++) {
+      const q = arr[k].pos;
+      if ((q[0] - x) ** 2 + (q[2] - z) ** 2 < distMin * distMin) { choca = true; break; }
+    }
+    if (choca) continue;
     arr.push({
-      pos: [Math.cos(ang) * rad, 0, Math.sin(ang) * rad],
+      pos: [x, 0, z],
       rotY: r() * Math.PI * 2,
+      // Inclinación sutil por instancia: ningún árbol real está a plomo.
+      inclina: [(r() - 0.5) * (opts.inclina ?? 0.1), (r() - 0.5) * (opts.inclina ?? 0.1)],
       escala: eMin + r() * (eMax - eMin),
       tint: tinteInstancia(r, opts.varia ?? 0.12),
     });
@@ -628,24 +990,48 @@ function sembrar(n, rMin, rMax, r, opts = {}) {
   return arr;
 }
 
-/** Todas las instancias de flora para unos conteos dados. */
+/**
+ * Todas las instancias de flora. El Ent manda en el centro: nada se le encima
+ * y los árboles del cortejo quedan más lejos y más bajos que él.
+ */
 export function distribucionFlora(conteos, seed = 707) {
   const c = conteos;
   return {
-    // Frailejonar: anillo interior-medio, agrupado, mucha variación de tamaño.
-    frailejon: sembrar(c.frailejon, 3.8, 10.5, rng(seed + 1), { eMin: 0.82, eMax: 1.28, varia: 0.14 }),
-    frailejonFlor: sembrar(c.frailejonFlor, 4.5, 9.5, rng(seed + 2), { eMin: 0.9, eMax: 1.2, varia: 0.1 }),
-    // Sotobosque.
-    mortino: sembrar(c.mortino, 4, 12, rng(seed + 3), { eMin: 0.8, eMax: 1.2, varia: 0.12 }),
-    romerillo: sembrar(c.romerillo, 3, 12, rng(seed + 4), { eMin: 0.8, eMax: 1.25, varia: 0.14 }),
+    // Frailejonar: bosquetes densos en el anillo interior-medio. Es lo primero
+    // que se ve y lo que dice "esto es páramo".
+    frailejon: sembrarBosquete(c.frailejon, 3.4, 11, rng(seed + 1), {
+      nucleos: 5, disper: 1.7, distMin: 0.78, eMin: 0.78, eMax: 1.34, varia: 0.15, claros: 0.3, inclina: 0.14,
+    }),
+    frailejonFlor: sembrarBosquete(c.frailejonFlor, 4, 10, rng(seed + 2), {
+      nucleos: 3, disper: 1.9, distMin: 0.9, eMin: 0.9, eMax: 1.22, varia: 0.1, claros: 0.3, inclina: 0.12,
+    }),
+    // Sotobosque: se agolpa en el borde de los bosquetes.
+    mortino: sembrarBosquete(c.mortino, 3, 12.5, rng(seed + 3), {
+      nucleos: 4, disper: 1.8, distMin: 0.7, eMin: 0.78, eMax: 1.25, varia: 0.14, claros: 0.4,
+    }),
+    romerillo: sembrarBosquete(c.romerillo, 2.6, 12.5, rng(seed + 4), {
+      nucleos: 5, disper: 1.9, distMin: 0.62, eMin: 0.75, eMax: 1.3, varia: 0.16, claros: 0.42,
+    }),
     // Suelo.
-    roca: sembrar(c.roca, 2, 11, rng(seed + 5), { eMin: 0.7, eMax: 1.5, varia: 0.1 }),
-    musgo: sembrar(c.musgo, 1.2, 9, rng(seed + 6), { eMin: 0.7, eMax: 1.6, varia: 0.12 }),
-    // Árboles de fondo (anillo exterior, reparto parejo, velados por niebla).
-    gaque: sembrar(c.gaque, 8.5, 14, rng(seed + 7), { eMin: 0.9, eMax: 1.1, uniforme: true, varia: 0.08 }),
-    roble: sembrar(c.roble, 9.5, 16, rng(seed + 8), { eMin: 0.92, eMax: 1.15, uniforme: true, varia: 0.08 }),
-    encenillo: sembrar(c.encenillo, 10, 17, rng(seed + 9), { eMin: 0.85, eMax: 1.1, uniforme: true, varia: 0.08 }),
-    yarumo: sembrar(c.yarumo, 10, 17, rng(seed + 10), { eMin: 0.9, eMax: 1.15, uniforme: true, varia: 0.06 }),
-    aliso: sembrar(c.aliso, 11, 19, rng(seed + 11), { eMin: 0.9, eMax: 1.12, uniforme: true, varia: 0.08 }),
+    roca: sembrarBosquete(c.roca, 1.8, 12, rng(seed + 5), {
+      nucleos: 4, disper: 2.4, distMin: 0.85, eMin: 0.65, eMax: 1.6, varia: 0.12, claros: 0.25,
+    }),
+    musgo: sembrarBosquete(c.musgo, 1.1, 10, rng(seed + 6), {
+      nucleos: 4, disper: 2.2, distMin: 0.6, eMin: 0.7, eMax: 1.7, varia: 0.14, claros: 0.2,
+    }),
+    // El cortejo leñoso: bosquetes en el anillo exterior, velados por la niebla.
+    // Cada especie tiene SU rincón (no se mezclan parejo) → se lee agrupamiento.
+    quenua: sembrarBosquete(c.quenua, 6.5, 13, rng(seed + 7), {
+      nucleos: 2, disper: 1.9, distMin: 2.0, eMin: 0.85, eMax: 1.2, varia: 0.1, claros: 0.2, inclina: 0.12,
+    }),
+    gaque: sembrarBosquete(c.gaque, 8, 14, rng(seed + 8), {
+      nucleos: 2, disper: 1.6, distMin: 2.2, eMin: 0.9, eMax: 1.12, varia: 0.08, claros: 0.2,
+    }),
+    encenillo: sembrarBosquete(c.encenillo, 9, 16, rng(seed + 9), {
+      nucleos: 2, disper: 2.1, distMin: 2.1, eMin: 0.85, eMax: 1.12, varia: 0.09, claros: 0.2, inclina: 0.1,
+    }),
+    aliso: sembrarBosquete(c.aliso, 10, 17.5, rng(seed + 10), {
+      nucleos: 2, disper: 2.2, distMin: 2.3, eMin: 0.9, eMax: 1.14, varia: 0.09, claros: 0.2,
+    }),
   };
 }

--- a/src/visual/mundo3d/bosque/sombreadoVegetal.js
+++ b/src/visual/mundo3d/bosque/sombreadoVegetal.js
@@ -1,0 +1,454 @@
+/*
+ * sombreadoVegetal — el TALLER común de la vegetación procedural del páramo.
+ *
+ * Aquí vive lo que el DR de realismo-3d-vegetacion (2026-06-19) identifica como
+ * el mayor retorno visual por costo, y que la primera versión de la flora NO
+ * tenía. El diagnóstico del DR era exacto: un cono/esfera de follaje sobre un
+ * cilindro, con UN color plano horneado por parte, se lee como "árbol de navidad".
+ *
+ * Las cuatro recetas que aplicamos aquí (DR §2 y §"Entregable"):
+ *
+ *   1. SOMBREADO con profundidad (§1 "Sombreado plano"): en vez de un color
+ *      plano, cada vértice recibe oclusión ambiental horneada (qué tan hundido
+ *      está en la masa de follaje) + gradiente de altura (el sol pega arriba) +
+ *      un dejo de translucidez en el borde de la copa (la hoja a contraluz).
+ *      Es gratis en runtime: viaja en el atributo `color`.
+ *   2. SILUETA irregular (§1 "Silueta irreal"): el borde de la copa se modula
+ *      con ruido y los cúmulos se siembran con huecos → el cielo se ve a través.
+ *   3. JERARQUÍA de ramas (§1 "Ausencia de jerarquía"): troncos con curva y
+ *      conicidad reales, ramas que nacen en ángulo áureo y se subdividen.
+ *   4. FUSIÓN SEGURA: `mergeGeometries` devuelve **null en silencio** si se
+ *      mezclan geometrías indexadas con no-indexadas → r3f hace `if(!geo) return
+ *      null` y la especie NO SE DIBUJA sin un solo error en consola. Ya mordió
+ *      dos veces. Aquí se desindexa TODO y se truena fuerte si el retorno es null.
+ *
+ * Todo es three core puro: corre headless (sin contexto GL) y es testeable.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+
+/* PRNG determinista (LCG): el mismo bosque en cada carga, nunca azar por frame. */
+export function rng(seed) {
+  let s = (seed >>> 0) || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+/* -------------------------------------------------------------------------- */
+/*  Ruido determinista (sin dependencias)                                      */
+/* -------------------------------------------------------------------------- */
+
+/** Hash escalar estable → [0,1). Base del ruido de valor. */
+function hash3(x, y, z) {
+  let h = Math.sin(x * 127.1 + y * 311.7 + z * 74.7) * 43758.5453;
+  h -= Math.floor(h);
+  return h;
+}
+
+const suave = (t) => t * t * (3 - 2 * t); // smoothstep
+
+/**
+ * Ruido de valor 3D en [0,1], continuo y determinista. Sirve para romper la
+ * perfección geométrica: arruga la corteza, muerde el borde de la copa, mancha
+ * el color. Barato: se evalúa en tiempo de construcción, nunca por frame.
+ */
+export function ruido3D(x, y, z) {
+  const xi = Math.floor(x);
+  const yi = Math.floor(y);
+  const zi = Math.floor(z);
+  const xf = suave(x - xi);
+  const yf = suave(y - yi);
+  const zf = suave(z - zi);
+  const lerp = (a, b, t) => a + (b - a) * t;
+  const c = (dx, dy, dz) => hash3(xi + dx, yi + dy, zi + dz);
+  const x00 = lerp(c(0, 0, 0), c(1, 0, 0), xf);
+  const x10 = lerp(c(0, 1, 0), c(1, 1, 0), xf);
+  const x01 = lerp(c(0, 0, 1), c(1, 0, 1), xf);
+  const x11 = lerp(c(0, 1, 1), c(1, 1, 1), xf);
+  return lerp(lerp(x00, x10, yf), lerp(x01, x11, yf), zf);
+}
+
+/** Ruido fractal (2 octavas): detalle grueso + fino. Devuelve [0,1]. */
+export function ruidoFbm(x, y, z) {
+  return ruido3D(x, y, z) * 0.65 + ruido3D(x * 2.3, y * 2.3, z * 2.3) * 0.35;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Fusión segura (la trampa del null silencioso)                              */
+/* -------------------------------------------------------------------------- */
+
+/** Desindexa si hace falta. Uniformar índice es lo que evita el merge → null. */
+export function desindexar(geo) {
+  return geo.index ? geo.toNonIndexed() : geo;
+}
+
+/**
+ * Fusiona partes en UNA geometría (1 draw-call por especie).
+ *
+ * TRUENA si el merge devuelve null en vez de dejar la especie invisible: ese
+ * fallo silencioso ya costó dos depuraciones largas. Todas las partes se
+ * desindexan primero (poliedros vienen no-indexados y cilindros/conos sí →
+ * mezclarlos es exactamente lo que devuelve null).
+ *
+ * @param {THREE.BufferGeometry[]} partes
+ * @param {string} etiqueta  nombre de la especie, para que el error diga QUIÉN.
+ */
+export function fusionarSeguro(partes, etiqueta = 'sin-nombre') {
+  const buenas = partes.filter(Boolean).map(desindexar);
+  if (!buenas.length) {
+    throw new Error(`[sombreadoVegetal] "${etiqueta}": no hay partes que fusionar.`);
+  }
+  // Todas deben declarar los MISMOS atributos o el merge devuelve null.
+  const refAttrs = Object.keys(buenas[0].attributes).sort().join(',');
+  for (let i = 0; i < buenas.length; i++) {
+    const attrs = Object.keys(buenas[i].attributes).sort().join(',');
+    if (attrs !== refAttrs) {
+      throw new Error(
+        `[sombreadoVegetal] "${etiqueta}": la parte ${i} tiene atributos [${attrs}] `
+        + `pero se esperaba [${refAttrs}]. mergeGeometries devolvería null y la `
+        + 'especie no se dibujaría. Revise que TODAS las partes pasen por pintar*().',
+      );
+    }
+  }
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error(
+      `[sombreadoVegetal] "${etiqueta}": mergeGeometries devolvió NULL. `
+      + 'Causa típica: mezcla de geometrías indexadas y no-indexadas, o atributos '
+      + 'dispares. La especie habría quedado INVISIBLE sin error.',
+    );
+  }
+  g.computeVertexNormals();
+  return g;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Colocación                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/** Coloca una geometría (transforma sus vértices) con pos/rot/escala. */
+export function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/** Orienta el eje +Y de la geometría hacia `dir` y la ubica en `pos`. */
+export function apuntar(geo, pos, dir, esc = [1, 1, 1], giro = 0) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
+  if (giro) q.multiply(new THREE.Quaternion().setFromAxisAngle(UP, giro));
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    q,
+    new THREE.Vector3(esc[0], esc[1], esc[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Horneado de color por vértice — el corazón del realismo (DR §"mayor        */
+/*  retorno": AO + gradiente + translucidez + variación)                       */
+/* -------------------------------------------------------------------------- */
+
+/** Aplica un color por vértice calculado por `fn(x, y, z, i) → THREE.Color`. */
+export function pintarPorVertice(geo, fn) {
+  const pos = geo.attributes.position;
+  const arr = new Float32Array(pos.count * 3);
+  const c = new THREE.Color();
+  for (let i = 0; i < pos.count; i++) {
+    const col = fn(pos.getX(i), pos.getY(i), pos.getZ(i), i, c);
+    arr[i * 3] = col.r;
+    arr[i * 3 + 1] = col.g;
+    arr[i * 3 + 2] = col.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Color plano en todos los vértices. Para piezas pequeñas (bayas, flores). */
+export function pintarPlano(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  return pintarPorVertice(geo, () => c);
+}
+
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+
+/**
+ * Hornea el sombreado de un CÚMULO DE FOLLAJE (la receta #1 del DR).
+ *
+ * Tres capas que, juntas, sacan a la copa de "masa sólida verde":
+ *   · AO: el vértice se oscurece según lo HUNDIDO que está en la masa de la
+ *     copa (distancia al centro del cúmulo, normalizada por su radio). El
+ *     interior queda en penumbra y el borde se enciende → volumen real.
+ *   · Gradiente de altura: arriba pega el sol, abajo queda en sombra propia.
+ *   · Translucidez de borde: en la piel exterior la hoja se lee a contraluz →
+ *     se mezcla un verde más claro y amarillento (la falsa SSS del DR, pero
+ *     horneada: cero costo de shader, corre en Android barato).
+ *
+ * @param {THREE.BufferGeometry} geo  geometría YA colocada en coords del árbol.
+ * @param {object} o
+ * @param {THREE.Color|string} o.base    verde de la hoja en penumbra.
+ * @param {THREE.Color|string} o.sol     verde iluminado (arriba/afuera).
+ * @param {THREE.Color|string} [o.luz]   tinte de contraluz (hoja translúcida).
+ * @param {[number,number,number]} o.centro  centro del cúmulo (coords del árbol).
+ * @param {number} o.radio               radio del cúmulo.
+ * @param {number} [o.yMin]   base del rango de altura del gradiente.
+ * @param {number} [o.yMax]   tope del rango de altura del gradiente.
+ * @param {number} [o.ao]                fuerza de la oclusión (0..1).
+ * @param {number} [o.manchas]           variación de ruido por vértice.
+ */
+export function hornearFollaje(geo, o) {
+  const base = new THREE.Color(o.base);
+  const sol = new THREE.Color(o.sol);
+  const luz = new THREE.Color(o.luz ?? '#cfd98a');
+  const [cx, cy, cz] = o.centro;
+  const radio = Math.max(0.001, o.radio);
+  const yMin = o.yMin ?? cy - radio;
+  const yMax = o.yMax ?? cy + radio;
+  const aoK = o.ao ?? 0.62;
+  const manchas = o.manchas ?? 0.1;
+  const tmp = new THREE.Color();
+
+  return pintarPorVertice(geo, (x, y, z) => {
+    // Profundidad dentro del cúmulo: 0 en el corazón → 1 en la piel exterior.
+    const d = Math.sqrt((x - cx) ** 2 + (y - cy) ** 2 + (z - cz) ** 2) / radio;
+    const piel = clamp01(d);
+    // AO: el corazón de la copa queda oscuro; la piel, expuesta.
+    const ao = 1 - aoK * (1 - piel * piel);
+    // Gradiente de altura: el sol viene de arriba.
+    const alt = clamp01((y - yMin) / Math.max(0.001, yMax - yMin));
+    tmp.copy(base).lerp(sol, alt * 0.75 + piel * 0.25);
+    // Contraluz: solo en la piel exterior, y más arriba que abajo.
+    const contra = clamp01((piel - 0.72) / 0.28) * (0.35 + alt * 0.4);
+    if (contra > 0) tmp.lerp(luz, contra * 0.45);
+    tmp.multiplyScalar(ao);
+    // Manchas: rompe el plano uniforme (nubes de hoja más clara/oscura).
+    if (manchas > 0) {
+      const n = ruidoFbm(x * 1.7 + 11, y * 1.7, z * 1.7);
+      tmp.multiplyScalar(1 + (n - 0.5) * manchas * 2);
+    }
+    return tmp;
+  });
+}
+
+/**
+ * Hornea el sombreado de CORTEZA: grieta oscura / cresta clara, oclusión de
+ * contacto contra el suelo y velo de líquen abajo (DR §"Corteza sin textura").
+ *
+ * @param {THREE.BufferGeometry} geo  tronco/rama YA colocado.
+ * @param {object} o
+ * @param {THREE.Color|string} o.grieta  fondo de la fisura.
+ * @param {THREE.Color|string} o.cuerpo  corteza madura.
+ * @param {THREE.Color|string} [o.cresta] lámina expuesta (papel del Polylepis).
+ * @param {THREE.Color|string} [o.liquen] líquen que trepa el pie.
+ * @param {number} [o.escalaGrano]  frecuencia del grano de corteza.
+ * @param {number} [o.hastaLiquen]  altura hasta donde trepa el líquen.
+ */
+export function hornearCorteza(geo, o) {
+  const grieta = new THREE.Color(o.grieta);
+  const cuerpo = new THREE.Color(o.cuerpo);
+  const cresta = new THREE.Color(o.cresta ?? o.cuerpo);
+  const liquen = o.liquen ? new THREE.Color(o.liquen) : null;
+  const grano = o.escalaGrano ?? 5.5;
+  const hastaLiquen = o.hastaLiquen ?? 0;
+  const tmp = new THREE.Color();
+
+  return pintarPorVertice(geo, (x, y, z) => {
+    // Grano de corteza: fibras verticales (mucha frecuencia en el plano XZ,
+    // poca en Y → la veta corre a lo largo del tronco, como en la madera real).
+    const v = ruidoFbm(x * grano * 2.2, y * grano * 0.5, z * grano * 2.2);
+    tmp.copy(grieta).lerp(cuerpo, clamp01(v * 1.5));
+    if (v > 0.62) tmp.lerp(cresta, clamp01((v - 0.62) / 0.38) * 0.8);
+    // Oclusión de contacto: el pie del árbol vive en penumbra.
+    const pie = clamp01(y / 1.1);
+    tmp.multiplyScalar(0.55 + 0.45 * pie);
+    // Líquen del páramo trepando la base (mancha, no capa uniforme).
+    if (liquen && y < hastaLiquen) {
+      const m = ruidoFbm(x * 3.1 + 5, y * 3.1, z * 3.1 + 5);
+      const cuanto = clamp01((hastaLiquen - y) / hastaLiquen) * clamp01((m - 0.42) / 0.58);
+      tmp.lerp(liquen, cuanto * 0.75);
+    }
+    return tmp;
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Geometría orgánica: troncos y ramas con conicidad y arruga reales          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Tubo orgánico sobre una curva: conicidad real + arruga de corteza en la
+ * geometría (no un normal-map). Es la pieza con la que se hacen troncos, ramas
+ * y raíces. El DR insiste: un cilindro perfecto se delata; la conicidad y la
+ * irregularidad son baratas y valen mucho.
+ *
+ * @param {THREE.Curve} curva
+ * @param {object} o
+ * @param {number} o.tubular  segmentos a lo largo.
+ * @param {number} o.radial   segmentos alrededor.
+ * @param {(t:number)=>number} o.taper  radio-mundo en t∈[0,1].
+ * @param {number} [o.arruga]  amplitud relativa del relieve de corteza.
+ * @param {number} [o.semilla] desfase del relieve (para que no se repita).
+ */
+export function tuboOrganico(curva, o) {
+  const { tubular, radial, taper } = o;
+  const arruga = o.arruga ?? 0.12;
+  const semilla = o.semilla ?? 0;
+  const geo = new THREE.TubeGeometry(curva, tubular, 1, radial, false);
+  const pos = geo.attributes.position;
+  const nAnillo = radial + 1;
+
+  const centros = [];
+  for (let i = 0; i <= tubular; i++) centros.push(curva.getPointAt(i / tubular));
+
+  const v = new THREE.Vector3();
+  const off = new THREE.Vector3();
+  for (let k = 0; k < pos.count; k++) {
+    const anillo = Math.floor(k / nAnillo);
+    const j = k % nAnillo;
+    const t = anillo / tubular;
+    const ang = (j / radial) * Math.PI * 2;
+    const centro = centros[Math.min(anillo, centros.length - 1)];
+
+    v.fromBufferAttribute(pos, k);
+    off.subVectors(v, centro);
+    // Arruga: surcos que corren a lo largo + grano fino, más marcados abajo.
+    const surco = Math.sin(ang * 7 + semilla + t * 1.6) * 0.55
+      + Math.sin(ang * 15 - semilla * 2 + t * 3) * 0.25
+      + (ruido3D(Math.cos(ang) * 3 + semilla, t * 9, Math.sin(ang) * 3) - 0.5) * 1.4;
+    const disp = 1 + surco * arruga * (1 + (1 - t) * 0.5);
+    v.copy(centro).addScaledVector(off, Math.max(0.02, taper(t) * disp));
+    pos.setXYZ(k, v.x, v.y, v.z);
+  }
+  pos.needsUpdate = true;
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/** Taper lineal de r0 (base) a r1 (punta). */
+export const taperLineal = (r0, r1 = 0.02) => (t) => Math.max(0.012, r0 * (1 - t) + r1 * t);
+
+/**
+ * Taper de TRONCO: raigón ensanchado al pie (contrafuertes), adelgazamiento
+ * potencial hacia la copa y pulsos de nudo. Nada de conos.
+ */
+export function taperTronco(r0, r1, raigon = 0.35) {
+  return (t) => {
+    const base = (r0 - r1) * Math.pow(Math.max(0, 1 - t), 1.4) + r1;
+    const pie = r0 * raigon * Math.exp(-t * 8);
+    const nudo = r0 * 0.06 * Math.sin(t * 6.5) * Math.sin(t * Math.PI);
+    return Math.max(0.015, base + pie + nudo);
+  };
+}
+
+/**
+ * Curva de tronco con inclinación, curvatura y torsión deterministas. Un árbol
+ * real pelea con el viento: no es un eje recto.
+ */
+export function curvaTronco({ altura, inclina = 0.1, sinuoso = 0.12, giro = 0 }, seed = 1) {
+  const r = rng(seed);
+  const n = 5;
+  const pts = [];
+  for (let i = 0; i <= n; i++) {
+    const t = i / n;
+    const y = altura * t;
+    // La inclinación crece con la altura; la sinuosidad serpentea alrededor.
+    const lean = inclina * altura * t * t;
+    const ang = giro + t * Math.PI * 1.3;
+    const s = sinuoso * altura * (0.25 + t * 0.75);
+    pts.push(new THREE.Vector3(
+      Math.cos(giro) * lean + Math.cos(ang) * s * (r() * 0.6 + 0.2),
+      y,
+      Math.sin(giro) * lean + Math.sin(ang) * s * (r() * 0.6 + 0.2),
+    ));
+  }
+  return new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Cúmulos de follaje con HUECOS y borde irregular (anti árbol-de-navidad)    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Siembra puntos de hoja dentro de un elipsoide, PERO:
+ *   · con rechazo por distancia mínima (Poisson pobre) → no se apelmazan;
+ *   · con huecos: el ruido decide dónde NO hay hoja → el cielo entra;
+ *   · con borde mordido: el radio se modula por dirección → silueta irregular.
+ *
+ * Esto es, literalmente, lo que separa una copa creíble de una bola de helado.
+ *
+ * @returns {{pos:[number,number,number], esc:number, giro:[number,number,number]}[]}
+ */
+export function sembrarFollaje({
+  centro, radio, achatado = 0.78, n, semilla = 1,
+  huecos = 0.42, mordida = 0.34, distMin = 0.34,
+}) {
+  const r = rng(semilla);
+  const puntos = [];
+  const intentos = n * 14;
+  for (let i = 0; i < intentos && puntos.length < n; i++) {
+    // Dirección uniforme en la esfera.
+    const u = r() * 2 - 1;
+    const th = r() * Math.PI * 2;
+    const s = Math.sqrt(1 - u * u);
+    const dx = s * Math.cos(th);
+    const dy = u;
+    const dz = s * Math.sin(th);
+    // Borde mordido: el radio útil depende de la dirección (ruido) → la copa
+    // deja de ser una esfera y adquiere bultos y entrantes.
+    const muerde = 1 - mordida * ruidoFbm(dx * 2 + semilla, dy * 2, dz * 2);
+    const rad = radio * muerde * Math.cbrt(r());
+    const p = [
+      centro[0] + dx * rad,
+      centro[1] + dy * rad * achatado,
+      centro[2] + dz * rad,
+    ];
+    // Huecos: el ruido apaga regiones enteras → claros dentro de la copa.
+    if (huecos > 0 && ruidoFbm(p[0] * 1.15 + 31, p[1] * 1.15, p[2] * 1.15) < huecos * 0.55) continue;
+    // Rechazo por cercanía: nada de grumos apelmazados.
+    let choca = false;
+    for (let k = 0; k < puntos.length; k++) {
+      const q = puntos[k].pos;
+      if ((q[0] - p[0]) ** 2 + (q[1] - p[1]) ** 2 + (q[2] - p[2]) ** 2 < distMin * distMin) {
+        choca = true;
+        break;
+      }
+    }
+    if (choca) continue;
+    puntos.push({
+      pos: /** @type {[number, number, number]} */ (p),
+      esc: 0.62 + r() * 0.55,
+      giro: /** @type {[number, number, number]} */ ([r() * Math.PI, r() * Math.PI, r() * Math.PI]),
+    });
+  }
+  return puntos;
+}
+
+/**
+ * Un "matojo" de hoja: poliedro achatado y deformado con ruido. No es una
+ * esfera — es un manojo irregular. Con `hornearFollaje` encima, se lee como
+ * masa de hojas y no como bola.
+ */
+export function matojoHoja(radio, semilla = 1, deform = 0.42) {
+  const g = new THREE.IcosahedronGeometry(radio, 0);
+  const pos = g.attributes.position;
+  const v = new THREE.Vector3();
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i);
+    const n = ruidoFbm(v.x * 2.6 + semilla, v.y * 2.6, v.z * 2.6) - 0.5;
+    v.multiplyScalar(1 + n * deform * 2);
+    pos.setXYZ(i, v.x, v.y, v.z);
+  }
+  pos.needsUpdate = true;
+  return g;
+}


### PR DESCRIPTION
Rehecho del Bosque Vivo tras el rechazo del operador, en dos pasadas + el bug que
impedía ver la lección del subsuelo. Base: `dev`.

> *"Ya veo el bosque con el Ent pero no veo la lección del subsuelo. Y viendo el
> árbol tranquilamente merece 2-3 pasadas: no se parece en nada al del Señor de
> los Anillos, no tiene barba, no tiene vida. Y las matas alrededor ni se diga,
> parecen más árboles de navidad que matas."*

Cada reproche tenía una causa concreta y localizable. Ninguno era "falta pulir".

## PASADA 1 — el Ent como Bárbol

**La barba ya estaba en el código. Era invisible.** `specsBarba` colgaba los
mechones rectos hacia abajo desde el mentón a una `z` **fija**, mientras el taper
del tronco se ensancha hacia el pie (raigón). A la altura del mentón el radio es
~0.65; un metro más abajo pasa de 0.9 → **el propio fuste se tragaba la barba
entera**. Solo asomaban dos matas de liquen junto a la boca. Por eso "no tiene
barba" era exacto aunque el código tuviera una barba perfectamente construida.

Ahora cada hebra se cuelga **siguiendo la superficie**: a cada altura se consulta
el radio real del tronco (`tDeAltura` invierte la curva) y la hebra cae por fuera
con un vuelo que crece hacia la punta. No puede volver a enterrarse, y hay un test
que lo verifica punto por punto. Es **usnea** — "barba de viejo", el líquen
colgante real del bosque altoandino — y cuelga también de las ramas: el mismo
líquen que viste al bosque viste al guardián.

**El rostro era una careta pegada encima** (cejas de tablón, nariz de bola, labios
de caja) = antifaz de calabaza. Ahora se **talla** en el tronco
(`desplazamientoRostro`): cuencas, cejas, caballete, pómulos y boca-grieta son
relieve de la madera y las fibras de corteza corren por encima. Solo los ojos se
montan aparte, **dentro** de las cuencas. El DR §3 pedía exactamente esto.

**La corteza se leía como "chocolate de plástico"** — y la causa era medible: los
surcos usaban `sin(ang*17)` y `sin(ang*23)` sobre un tubo de 38 segmentos radiales
→ ~2.2 y ~1.6 muestras por ciclo, **por debajo de Nyquist**. No se dibujaban como
grano fino: aliasaban a lóbulos anchos de cera. Ahora ninguna frecuencia en `ang`
pasa de radial/4, el fuste del héroe va más denso y lleva las **láminas de papel**
del *Polylepis* (que las queñuas del cortejo sí tenían y el guardián no).

**Vida**: respiración del fuste (0.6%, si se nota ya es un globo), meceo con peso
desde la raíz, barba que ondea **por vértice** (raíz fija, punta suelta — no gira
en bloque como una peluca) y parpadeo.

## PASADA 2 — las matas dejan de ser árboles de navidad

El DR nombra el fallo y lo teníamos entero: `CylinderGeometry` recto +
`IcosahedronGeometry` regados en un domo, con **un color plano por parte**. Sin
conicidad, sin jerarquía de ramas, sin huecos, sin AO, sin gradiente. El aliso
incluso construía la copa como un **cono explícito**.

Ahora todas las leñosas salen de `construirArbol`, por orden de retorno del DR:

- tronco con curva, conicidad real, raigón y arruga en la geometría;
- **jerarquía de ramas** (primarias en ángulo áureo → secundarias);
- copas sembradas en las **puntas de rama**, con **huecos** y **borde mordido** —
  el cielo entra, se acabó la masa sólida;
- **sombreado horneado por vértice**: AO + gradiente de altura + contraluz. Es la
  receta de mayor retorno del DR y es gratis en runtime;
- variación determinista por instancia (giro, escala, inclinación, tinte).

**Distribución**: se acabaron los anillos concéntricos con reparto angular parejo
(`uniforme: true`), que se leían como un decorado de teatro. Ahora **bosquetes**
con núcleos, **claros** por campo de ruido y distancia mínima entre matas.

**Especies con su firma**: frailejón (roseta carnosa vellosa + enagua — antes eran
conos finos muy separados = un **erizo blanco** clavado en un palo), queñua
(láminas de papel), encenillo (velo de musgo), aliso (lenticelas), gaque, mortiño
(bayas de agraz). El roble y el yarumo **se quedan** aunque no sean de páramo: los
usan `Ladera.jsx` (restauración) y `Valle3D.jsx`, así que quitarlos rompía dos
mundos más. Se reconstruyeron con el constructor nuevo → esos mundos también
mejoran.

## La lección del subsuelo — por qué no se veía

Dos causas, las dos reales:

1. **La vitrina era un agujero negro.** Las capas se pintaban `#241611` y
   `#140f0c` (casi negro puro) y **ninguna luz golpeaba la cara frontal del
   corte** (el sol es cenital; la cara mira a la cámara → quedaba a contraluz).
   La lección existía y era ilegible. Colores de tierra real + una **luz de
   vitrina** frontal + encuadre sobre la unidad pedagógica (rostro + brazo que
   señala + capas).
2. **Estaba escondida** detrás de un botón que aparecía a los 5.6s. Ahora 1.4s, y
   la lección es **deep-linkeable**: `#bosque_vivo/microsuelo` (sin barra inicial)
   — enlazable, compartible y verificable con una captura, sin tocar el router.

## Bug de shell (explica el "Ent cortado y pequeñísimo")

`index-prod.html` no tenía cadena de altura: `#root` colapsaba a su contenido y
los mundos 3D que piden `height:100%` lo heredaban de nada → la escena se
aplastaba en una franja del 15%. **Medido**: el canvas pasa de `2304x270` a
`1280x900`. Afecta a todos los mundos, no solo a este.

## Red de seguridad

- `fusionarSeguro` **truena** si `mergeGeometries` devuelve `null` (la mezcla de
  indexadas y no-indexadas) en vez de dejar la especie invisible sin un solo
  error. Ya mordió dos veces; ahora el error dice **qué especie**.
- **44 tests nuevos** para los invariantes que no se ven: que ningún punto de la
  barba quede dentro de la madera (en los 3 tiers), que la barba no llegue al
  suelo, que el rostro talle y **solo al frente**, que las copas tengan huecos y
  borde irregular, que la distribución no encaje matas ni invada el claro del Ent.

## Presupuesto (tier-safe)

| | alto | medio | bajo |
|---|---|---|---|
| tronco del Ent | ~3.3k t | ~1.1k t | ~255 t |
| árbol de flora | 2.1–3k t | ~1k t | 350–860 t |
| barba / usnea | 30 / 22 | 20 / 12 | 12 / 0 |

Una draw-call por especie (InstancedMesh + geometría fusionada + vertexColors
horneados). Cero assets externos, cero texturas de imagen, cero GLTF.

## Verificación

- `npm run build` **verde**.
- `tsc`: **492 → 465**. Resueltos los **27 que eran míos**; los 465 restantes son
  deuda **preexistente de `dev`** en archivos que no toqué (verificado: no están
  en el diff).
- **85 tests** del bosque en verde (44 nuevos + los 41 existentes del Ent, sin
  tocar su API).
- eslint limpio (incluidos 2 errores preexistentes del archivo que toqué).
- **Capturas reales** de las dos pasadas y del subsuelo — chromium del sistema +
  swiftshader, no un grep del bundle.
- Los 2 tests rojos de `mundo3d` (`hiloVidaVista`, `useAudioMundo`) **fallan igual
  sin este cambio** — verificado con stash. No los toca este PR.

## Honestidad sobre el estado

Mejora clara y medible en los tres frentes, pero no está "terminado": la banda de
micorrizas sigue leyéndose oscura y la red se ve más como brillo que como red, y
la composición del microsuelo tiene aire muerto. Si el operador quiere una tercera
pasada, ahí es donde la pediría.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
