### PR TITLE
feat(vitrina): reinvención completa — El mirador de los mundos (realista, tier-safe) + 2 fixes cazados

### DIFF
--- a/src/mockups/VitrinaMaestraMundos.jsx
+++ b/src/mockups/VitrinaMaestraMundos.jsx
@@ -1,66 +1,79 @@
 /*
  * VitrinaMaestraMundos — la PUERTA MAESTRA a todos los mundos 3D de Chagra.
  *
- * EL NORTE (DR mario-2d-3d + JuegoMiFincaOdyssey): el cruce entre mundos no es
- * un cambio de pantalla, es un VIAJE. Esta vitrina es un VALLE ANDINO VIVO con
- * doce portales de piedra sembrados en dos terrazas — cada uno guarda un mundo
- * (valle, café, sanidad, mercado, animales, semillero, compost, agua, páramo,
- * suelo vivo, lluvia, Sierra). Al tocar un portal la cámara hace el viaje
- * Odyssey: dolly hacia la boca con el FOV estrechándose 46→15 en curva k²
- * (succión de túnel) y el IRIS del kit cubre la pantalla; DEBAJO del velo se
- * intercambia la escena y el iris reabre ya adentro. Al volver, el reverso con
- * curva √k (bocanada de aire). Nunca hay corte seco.
+ * REINVENCIÓN COMPLETA (feedback operador 2026-07-14: "está feíta, bien feíta,
+ * merece una reinvención completa; lo único que sirve son los efectos de
+ * entrada"). QUÉ ES AHORA: un MIRADOR ANDINO REALISTA a la hora dorada — el
+ * lugar desde donde se ven los doce mundos de la finca. Registro visual del
+ * proyecto: los MUNDOS van realistas (los personajes rubber-hose viven en el
+ * chrome DOM y en la fauna ambiental, nunca dentro del paisaje).
  *
- * LAS TRES LEYES DE ESTA REVISIÓN (pedido del operador):
- *  1. EL PAISAJE ES UN LUGAR: valle andino a la hora dorada — cordilleras que
- *     se pierden en la niebla, terrazas de cultivo, una quebrada que baja
- *     brillando entre las dos filas, árboles y pasto instanciados, luciérnagas
- *     y hongos ámbar (el acento biopunk amable). Los portales se sienten
- *     sembrados en un mundo, no botones sobre un fondo.
- *  2. CADA VENTANA LLENA SU CÍRCULO: dentro de cada aro vive una VIÑETA
- *     completa — cielo propio, suelo propio y una mini-escena que ocupa toda
- *     la boca, animada en loop sutil (una viñeta = un useFrame barato de
- *     transformaciones, jamás materiales nuevos por frame).
- *  3. LA VIÑETA DICE A DÓNDE SE ENTRA: café = cafetal en ladera con granos
- *     rojos; agua = quebrada corriendo; suelo = perfil de tierra con lombriz;
- *     animales = gallina picoteando en su corral; semillero = camas
- *     germinando; mercado = puesto con toldo; lluvia = nube soltando gotas…
- *     El usuario SABE qué mundo es antes de tocar.
+ * LO QUE SE CONSERVÓ (lo único aprobado — los efectos de entrada):
+ *   · El viaje Odyssey de cámara: dolly a la boca con FOV 46→15 en curva k²
+ *     (succión de túnel) y regreso en √k (bocanada). CamaraVitrina INTACTA.
+ *   · El IRIS del TransicionMundoKit con su contrato onMitad (swap bajo velo).
+ *   · La picada del avatar al centro del portal durante el cruce.
+ *   · La máquina de fases galeria → acercando → mundo → saliendo.
  *
- * MÁXIMO UN CANVAS VIVO: la galería muestra viñetas low-poly, no las escenas
+ * LO QUE SE REINVENTÓ (aplicando el DR realismo-3d-vegetacion 2026-06-19):
+ *   · Cielo: DOMO con gradiente horneado (horizonte ámbar → cénit azul), no un
+ *     color plano de fondo.
+ *   · Cordilleras: CRESTAS fractales con perspectiva atmosférica y nieve en la
+ *     capa lejana — no lomas de esfera.
+ *   · Terreno: pradera CONTINUA ondulada por ruido con parches de color por
+ *     vértice, plaza pisada y sendero de entrada — no un disco verde plano.
+ *   · Árboles: las especies REALES del bosque altoandino (roble, aliso, gaque,
+ *     encenillo, yarumo) de floraParamo.geom — siluetas irregulares, copas con
+ *     huecos, color horneado con gradiente de altura, variación por instancia.
+ *     (De paso se cazó el bug que las tenía INVISIBLES: mergeGeometries null.)
+ *   · Portales: arcos de PIEDRA SECA campesina (dovelas individuales con
+ *     jitter, AO radial horneado, musgo en las juntas) — no aros de parque
+ *     temático. Un InstancedMesh para los 12.
+ *   · Viñetas: DIORAMAS realistas horneados en una geometría por mundo (el
+ *     cafetal con surcos, los frailejones con su enagua, la cresta nevada) —
+ *     12 draw-calls estáticas, CERO useFrame por viñeta (antes eran 12 loops).
+ *
+ * MÁXIMO UN CANVAS VIVO: la galería muestra dioramas horneados, no las escenas
  * reales. El mundo real se monta por lazy import SOLO al cruzar, cuando el
  * Canvas de la vitrina ya se desmontó bajo el iris (contrato onMitad del kit).
  *
- * TÉCNICA / GAMA BAJA (DR §2, §4, §5):
- *  - Iris: overlay DOM/CSS del kit existente (timers deterministas).
- *  - 3D: MeshLambert + flatShading, sin sombras ni post; dpr por tier;
- *    vegetación por instancedMesh (1 draw call por especie) y luciérnagas por
- *    <points> (1 draw call). Tier 'medio' recorta cantidades, no ideas.
- *  - Tier 'bajo' NI monta el Canvas: la rejilla DOM conserva el ritual con
- *    viñetas CSS (gradiente por mundo + emoji flotando barato).
- *  - Lazy import por mundo, precalentado al elegir (el dolly esconde el chunk).
- *  - prefers-reduced-motion: sin dolly ni loops; las viñetas posan quietas.
- *
- * DIRECCIÓN DE ARTE: atmosferaMadre (cielo `huerta` mezclado a la hora dorada,
- * la misma ley de EscenaBase3D) + los aros de piedra del túnel Odyssey.
+ * TÉCNICA / GAMA BAJA: MeshLambert + vertexColors, sin sombras ni post; dpr
+ * por tier; una draw-call por especie/pieza; tier 'medio' recorta cantidades y
+ * detalle (q), no ideas. Tier 'bajo' NI monta el Canvas: rejilla DOM digna.
+ * prefers-reduced-motion: sin dolly ni deriva; el mirador posa quieto.
  *
  * Mockup standalone con su propio <Canvas>. NO toca App.jsx ni mundoData.
  */
 import { Suspense, lazy, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
-import {
-  ATMOSFERA,
-  CIELOS,
-  PALETA,
-  mezclar,
-  mezclarCielo,
-} from '../visual/mundo3d/atmosferaMadre.js';
 import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
 import TransicionMundoKit from '../visual/mundo3d/TransicionMundoKit.jsx';
 import { FaunaAmbiental } from '../visual/creatures/FaunaAmbiental.jsx';
 import { EntFrailejon } from '../visual/creatures/EntFrailejon.jsx';
 import useAvatarCreature from '../hooks/useAvatarCreature.js';
+import {
+  PALM,
+  geomCieloDomo,
+  geomCordilleras,
+  geomTerreno,
+  geomQuebrada,
+  geomPiedrasQuebrada,
+  geomArcoPiedra,
+  geomLajasSendero,
+  geomLomitas,
+  alturaTerreno,
+  CAUCE_QUEBRADA,
+} from '../visual/mundo3d/vitrina/miradorAndino.geom.js';
+import { geomVineta } from '../visual/mundo3d/vitrina/vinetasMundos.geom.js';
+import {
+  geomRoble,
+  geomAliso,
+  geomGaque,
+  geomEncenillo,
+  calidadDeTier,
+} from '../visual/mundo3d/bosque/floraParamo.geom.js';
+import { rng } from '../visual/mundo3d/bosque/entQuenua.geom.js';
 
 /* EL VALLE VIVO en la galería: los personajes asoman ENTRE los mundos, desde
    los bordes (nunca sobre los portales ni el chrome), hacen su giño lejano y
@@ -92,35 +105,41 @@ const IMPORTADORES = {
   sierra: () => import('../visual/mundo3d/VistaGlobalSierra.jsx'),
 };
 
-const COMPONENTES = Object.fromEntries(
-  Object.entries(IMPORTADORES).map(([id, imp]) => [id, lazy(() => imp().then(m => (/** @type {any} */ (m)).default || m))]),
+/* React 19 exige que lazy() resuelva a `{ default: Componente }` — devolver el
+   componente pelado (el `m.default || m` heredado) tronaba TODO cruce con
+   "Lazy element type must resolve to a class or function" (cazado 2026-07-15). */
+const COMPONENTES = /** @type {Record<string, import('react').ComponentType<any>>} */ (
+  Object.fromEntries(
+    Object.entries(IMPORTADORES).map(([id, imp]) => [
+      id,
+      lazy(() => imp().then((m) => ({ default: (/** @type {any} */ (m)).default || m }))),
+    ]),
+  )
 );
 
 /* La fila de ADELANTE (los mundos del diario) y la de ATRÁS en su terraza.
-   El orden ES el arco, de izquierda a derecha. */
+   El orden ES el arco, de izquierda a derecha. colorA/colorB alimentan el
+   iris del cruce, los chips y la rejilla 2D — no el paisaje. */
 const FILA_FRENTE = [
-  { id: 'valle', titulo: 'El valle', emoji: '🏡', motivo: 'valle', colorA: '#f2c063', colorB: '#1d4030' },
-  { id: 'cafe', titulo: 'El café', emoji: '☕', motivo: 'cafe', colorA: '#c96a2f', colorB: '#3a2416' },
-  { id: 'agua', titulo: 'El agua', emoji: '💧', motivo: 'agua', colorA: '#7db8d4', colorB: '#1e3a4f' },
-  { id: 'sanidad', titulo: 'La sanidad', emoji: '🐞', motivo: 'sanidad', colorA: '#f2c531', colorB: '#2e4020' },
-  { id: 'mercado', titulo: 'El mercado', emoji: '🧺', motivo: 'mercado', colorA: '#e0a458', colorB: '#4a2c18' },
-  { id: 'animales', titulo: 'Los animales', emoji: '🐔', motivo: 'animales', colorA: '#d9a066', colorB: '#3f2a1a' },
+  { id: 'valle', titulo: 'El valle', emoji: '🏡', colorA: '#f2c063', colorB: '#1d4030' },
+  { id: 'cafe', titulo: 'El café', emoji: '☕', colorA: '#c96a2f', colorB: '#3a2416' },
+  { id: 'agua', titulo: 'El agua', emoji: '💧', colorA: '#7db8d4', colorB: '#1e3a4f' },
+  { id: 'sanidad', titulo: 'La sanidad', emoji: '🐞', colorA: '#f2c531', colorB: '#2e4020' },
+  { id: 'mercado', titulo: 'El mercado', emoji: '🧺', colorA: '#e0a458', colorB: '#4a2c18' },
+  { id: 'animales', titulo: 'Los animales', emoji: '🐔', colorA: '#d9a066', colorB: '#3f2a1a' },
 ];
 const FILA_ATRAS = [
-  { id: 'semillero', titulo: 'El semillero', emoji: '🌱', motivo: 'semillero', colorA: '#9fc46a', colorB: '#25391c' },
-  { id: 'suelo', titulo: 'El suelo vivo', emoji: '🪱', motivo: 'suelo', colorA: '#a97b4f', colorB: '#2b1d10' },
-  { id: 'sierra', titulo: 'La Sierra', emoji: '🏔️', motivo: 'sierra', colorA: '#e8ddc0', colorB: '#274035' },
-  { id: 'paramo', titulo: 'El páramo', emoji: '🌫️', motivo: 'paramo', colorA: '#aec7cf', colorB: '#2a3b40' },
-  { id: 'lluvia', titulo: 'La lluvia', emoji: '🌧️', motivo: 'lluvia', colorA: '#9fb3c8', colorB: '#26323f' },
-  { id: 'compost', titulo: 'El compost', emoji: '🍂', motivo: 'compost', colorA: '#8a6a3a', colorB: '#241a0e' },
+  { id: 'semillero', titulo: 'El semillero', emoji: '🌱', colorA: '#9fc46a', colorB: '#25391c' },
+  { id: 'suelo', titulo: 'El suelo vivo', emoji: '🪱', colorA: '#a97b4f', colorB: '#2b1d10' },
+  { id: 'sierra', titulo: 'La Sierra', emoji: '🏔️', colorA: '#e8ddc0', colorB: '#274035' },
+  { id: 'paramo', titulo: 'El páramo', emoji: '🌫️', colorA: '#aec7cf', colorB: '#2a3b40' },
+  { id: 'lluvia', titulo: 'La lluvia', emoji: '🌧️', colorA: '#9fb3c8', colorB: '#26323f' },
+  { id: 'compost', titulo: 'El compost', emoji: '🍂', colorA: '#8a6a3a', colorB: '#241a0e' },
 ];
 
 /* ══════════════════════════════════════════════════════════════════════════
    GEOMETRÍA DE LA GALERÍA — arcos, poses y bocas (constantes de módulo)
    ══════════════════════════════════════════════════════════════════════════ */
-
-/* La hora de la galería: la huerta bajo la madre (misma receta de EscenaBase3D). */
-const CIELO = mezclarCielo(CIELOS.huerta);
 
 /* Hacia dónde miran los portales: un punto entre el centro y la cámara. */
 const CENTRO_MIRA = new THREE.Vector3(0, 1.3, 9);
@@ -130,6 +149,15 @@ const POSE_GALERIA = {
   mira: new THREE.Vector3(0, 1.6, -1.5),
   fov: 46,
 };
+/* En PORTRAIT el FOV horizontal se estrangula (hFov = f(vFov·aspecto)) y el
+   arco de portales queda fuera de cuadro: la pose de galería se adapta —
+   más FOV y cámara más atrás — para que el mirador completo quepa parado. */
+const POSE_GALERIA_ANGOSTA = {
+  pos: new THREE.Vector3(0, 3.4, 17.2),
+  mira: new THREE.Vector3(0, 1.95, -1.5),
+  fov: 58,
+};
+const poseGaleria = (aspecto) => (aspecto < 0.9 ? POSE_GALERIA_ANGOSTA : POSE_GALERIA);
 const TMP_MIRA = new THREE.Vector3();
 
 const VIAJE_S = 1.25; // dolly perspectiva↔casi-orto (s) — mismo pulso Odyssey
@@ -137,12 +165,6 @@ const FOV_BOCA = 15;
 
 /* easeInOutCubic — el dolly acelera suave y "cae" dentro del portal. */
 const suavizar = (t) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
-
-/* Azar determinista barato para sembrar vegetación (mismo valle en cada visita). */
-const azar = (n) => {
-  const s = Math.sin(n * 127.1 + 311.7) * 43758.5453;
-  return s - Math.floor(s);
-};
 
 /* Fija el FOV por MÉTODO (setFocalLength recalcula la proyección solo): el
    mismo patrón de CamaraDirector/CamaraOdyssey — nada de asignar propiedades. */
@@ -176,7 +198,7 @@ const PORTALES = [
 const PORTAL_POR_ID = Object.fromEntries(PORTALES.map((p) => [p.id, p]));
 
 /* ══════════════════════════════════════════════════════════════════════════
-   CÁMARA — el viaje Odyssey de la vitrina (INTACTO: no tocar el cruce)
+   CÁMARA — el viaje Odyssey de la vitrina (INTACTO: es lo aprobado)
    ══════════════════════════════════════════════════════════════════════════ */
 
 /* Órbita viva → dolly a la boca del portal elegido (FOV 46→15, k²) → sostiene
@@ -196,23 +218,24 @@ function CamaraVitrina({ fase, boca, reducedMotion, onLlegada }) {
       a.t = 0;
       a.avisado = false;
     }
+    const pose = poseGaleria(/** @type {any} */ (camera).aspect ?? 1);
     const entra = fase === 'acercando';
     const sale = fase === 'saliendo';
     if ((entra || sale) && boca) {
       a.t = Math.min(1, a.t + (reducedMotion ? 1 : Math.min(dt, 0.05) / VIAJE_S));
       const k = suavizar(a.t);
-      const posDesde = entra ? POSE_GALERIA.pos : boca.pos;
-      const posHasta = entra ? boca.pos : POSE_GALERIA.pos;
-      const miraDesde = entra ? POSE_GALERIA.mira : boca.mira;
-      const miraHasta = entra ? boca.mira : POSE_GALERIA.mira;
+      const posDesde = entra ? pose.pos : boca.pos;
+      const posHasta = entra ? boca.pos : pose.pos;
+      const miraDesde = entra ? pose.mira : boca.mira;
+      const miraHasta = entra ? boca.mira : pose.mira;
       camera.position.lerpVectors(posDesde, posHasta, k);
       TMP_MIRA.lerpVectors(miraDesde, miraHasta, k);
       camera.lookAt(TMP_MIRA);
       /* FOV con curva k² al entrar (se estrecha tarde: succión de túnel) y
          √k al salir (se abre pronto: bocanada de aire) — la ley Odyssey. */
       const kFov = entra ? k * k : Math.sqrt(k);
-      const fovDesde = entra ? POSE_GALERIA.fov : FOV_BOCA;
-      const fovHasta = entra ? FOV_BOCA : POSE_GALERIA.fov;
+      const fovDesde = entra ? pose.fov : FOV_BOCA;
+      const fovHasta = entra ? FOV_BOCA : pose.fov;
       aplicarFov(camera, fovDesde + (fovHasta - fovDesde) * kFov);
       if (a.t >= 1 && !a.avisado) {
         a.avisado = true;
@@ -222,12 +245,12 @@ function CamaraVitrina({ fase, boca, reducedMotion, onLlegada }) {
       /* Órbita viva: vaivén determinista de brisa; la cámara es del director. */
       const t = reducedMotion ? 0 : state.clock.elapsedTime;
       camera.position.set(
-        POSE_GALERIA.pos.x + Math.sin(t * 0.14) * 0.5,
-        POSE_GALERIA.pos.y + Math.sin(t * 0.1) * 0.18,
-        POSE_GALERIA.pos.z + Math.cos(t * 0.12) * 0.35,
+        pose.pos.x + Math.sin(t * 0.14) * 0.5,
+        pose.pos.y + Math.sin(t * 0.1) * 0.18,
+        pose.pos.z + Math.cos(t * 0.12) * 0.35,
       );
-      camera.lookAt(POSE_GALERIA.mira);
-      aplicarFov(camera, POSE_GALERIA.fov);
+      camera.lookAt(pose.mira);
+      aplicarFov(camera, pose.fov);
     } else {
       /* Bajo el iris: la cámara sostiene la boca del portal, quieta. */
       camera.position.copy(boca.pos);
@@ -239,792 +262,333 @@ function CamaraVitrina({ fase, boca, reducedMotion, onLlegada }) {
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
-   VIÑETAS — cada círculo LLENO con la mini-escena viva de SU mundo
-   ══════════════════════════════════════════════════════════════════════════
-   Contrato compartido:
-   - Cada viñeta vive dentro de la boca del aro (radio útil ~0.66) y se apoya
-     en un FONDO propio (cielo + media luna de suelo) que llena el círculo.
-   - Un solo useFrame por viñeta, solo transformaciones sobre refs (posición,
-     rotación, escala, emissiveIntensity) — jamás materiales nuevos por frame.
-   - `animada=false` (reduced motion) deja la pose inicial, digna y quieta. */
-
-/* El lienzo del círculo: cielo de fondo + media luna de suelo + loma lejana.
-   Esto es lo que garantiza que la ventana se vea LLENA, no un ícono flotando. */
-function FondoVineta({ cielo, suelo, loma = null }) {
-  return (
-    <group>
-      <mesh position={[0, 0, -0.34]}>
-        <circleGeometry args={[0.74, 26]} />
-        <meshLambertMaterial color={cielo} emissive={cielo} emissiveIntensity={0.35} />
-      </mesh>
-      {loma && (
-        <mesh position={[0.16, -0.02, -0.325]} scale={[1.15, 0.42, 1]}>
-          <circleGeometry args={[0.5, 16]} />
-          <meshLambertMaterial color={loma} />
-        </mesh>
-      )}
-      <mesh position={[0, 0, -0.31]}>
-        <circleGeometry args={[0.72, 26, Math.PI, Math.PI]} />
-        <meshLambertMaterial color={suelo} />
-      </mesh>
-    </group>
-  );
-}
-
-/* Gancho común: un useFrame que corre el loop SOLO si la viñeta está viva. */
-function usePulso(animada, alPulsar) {
-  const fn = useRef(alPulsar);
-  // El ref sigue al último callback en un efecto (no durante el render): el
-  // loop de useFrame corre fuera del render y lee fn.current sin problema.
-  useEffect(() => { fn.current = alPulsar; }, [alPulsar]);
-  useFrame((state) => {
-    if (animada) fn.current(state.clock.elapsedTime);
-  });
-}
-
-/* 🏡 VALLE — la casita encalada en su loma, humo respirando de la chimenea. */
-function VinetaValle({ animada }) {
-  const humos = useRef([]);
-  const arbol = useRef(null);
-  usePulso(animada, (t) => {
-    humos.current.forEach((m, i) => {
-      if (!m) return;
-      const k = (t * 0.3 + i / 3) % 1;
-      m.position.y = 0.34 + k * 0.34;
-      m.position.x = 0.21 + Math.sin(k * 5 + i) * 0.03;
-      const s = 0.03 + k * 0.055;
-      m.scale.setScalar(s);
-      m.material.opacity = 0.85 * (1 - k);
-    });
-    if (arbol.current) arbol.current.rotation.z = Math.sin(t * 1.1) * 0.05;
-  });
-  return (
-    <group>
-      <FondoVineta cielo="#cfe4d8" suelo={PALETA.follaje} loma={PALETA.follajeOscuro} />
-      {/* la casita del valle */}
-      <group position={[0.1, -0.08, -0.22]}>
-        <mesh position={[0, 0.08, 0]}>
-          <boxGeometry args={[0.34, 0.24, 0.24]} />
-          <meshLambertMaterial color={PALETA.cal} flatShading />
-        </mesh>
-        <mesh position={[0, 0.27, 0]} rotation={[0, Math.PI / 4, 0]}>
-          <coneGeometry args={[0.28, 0.18, 4]} />
-          <meshLambertMaterial color="#a55e3a" flatShading />
-        </mesh>
-        <mesh position={[0.11, 0.32, 0]}>
-          <boxGeometry args={[0.05, 0.12, 0.05]} />
-          <meshLambertMaterial color={PALETA.piedra} flatShading />
-        </mesh>
-        <mesh position={[0, 0.06, 0.125]}>
-          <planeGeometry args={[0.08, 0.14]} />
-          <meshLambertMaterial color={PALETA.maderaOscura} />
-        </mesh>
-      </group>
-      {/* humo vivo */}
-      {[0, 1, 2].map((i) => (
-        <mesh key={i} ref={(m) => (humos.current[i] = m)} position={[0.21, 0.34 + i * 0.11, -0.2]}>
-          <sphereGeometry args={[1, 6, 5]} />
-          <meshBasicMaterial color="#f4ede0" transparent opacity={0.6} depthWrite={false} />
-        </mesh>
-      ))}
-      {/* el árbol guardián meciéndose */}
-      <group ref={arbol} position={[-0.34, -0.1, -0.18]}>
-        <mesh position={[0, 0.06, 0]}>
-          <cylinderGeometry args={[0.025, 0.04, 0.16, 5]} />
-          <meshLambertMaterial color={PALETA.madera} flatShading />
-        </mesh>
-        <mesh position={[0, 0.24, 0]}>
-          <coneGeometry args={[0.15, 0.32, 6]} />
-          <meshLambertMaterial color={PALETA.follajeOscuro} flatShading />
-        </mesh>
-      </group>
-      {/* camino que baja al umbral */}
-      <mesh position={[0, -0.42, -0.28]} rotation={[0, 0, 0.35]} scale={[1, 0.35, 1]}>
-        <circleGeometry args={[0.32, 10]} />
-        <meshLambertMaterial color={PALETA.tierraClara} />
-      </mesh>
-    </group>
-  );
-}
-
-/* ☕ CAFETAL — la ladera diagonal con matas en surco y granos rojos latiendo. */
-function VinetaCafe({ animada }) {
-  const matas = useRef([]);
-  const grano = useRef(null);
-  usePulso(animada, (t) => {
-    matas.current.forEach((g, i) => {
-      if (g) g.rotation.z = Math.sin(t * 1.3 + i * 1.7) * 0.06;
-    });
-    if (grano.current) grano.current.emissiveIntensity = 0.35 + (Math.sin(t * 2.4) + 1) * 0.3;
-  });
-  const posiciones = [
-    [-0.34, -0.02, 1.05],
-    [0.02, -0.16, 1.25],
-    [0.38, -0.3, 1.0],
-  ];
-  return (
-    <group>
-      <FondoVineta cielo="#f2ddb0" suelo="#7a5230" />
-      {/* la ladera en diagonal — se LEE cafetal de montaña */}
-      <mesh position={[0, -0.16, -0.3]} rotation={[0, 0, 0.38]}>
-        <planeGeometry args={[1.5, 0.55]} />
-        <meshLambertMaterial color={PALETA.tierra} />
-      </mesh>
-      {posiciones.map(([x, y, s], i) => (
-        <group key={i} ref={(g) => (matas.current[i] = g)} position={[x, y, -0.24]} scale={[s * 0.9, s * 0.9, 0.6]}>
-          <mesh position={[0, -0.06, 0]}>
-            <cylinderGeometry args={[0.02, 0.03, 0.14, 5]} />
-            <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
-          </mesh>
-          <mesh position={[0, 0.1, 0]}>
-            <sphereGeometry args={[0.16, 8, 6]} />
-            <meshLambertMaterial color={PALETA.follajeOscuro} flatShading />
-          </mesh>
-          {[[-0.09, 0.05], [0.05, -0.02], [0.11, 0.09], [-0.02, 0.14]].map(([gx, gy], j) => (
-            <mesh key={j} position={[gx, gy + 0.06, 0.13]}>
-              <sphereGeometry args={[0.028, 6, 5]} />
-              {i === 1 && j === 1 ? (
-                <meshLambertMaterial ref={grano} color="#c22f28" emissive="#e04338" emissiveIntensity={0.4} flatShading />
-              ) : (
-                <meshLambertMaterial color="#b8352f" flatShading />
-              )}
-            </mesh>
-          ))}
-        </group>
-      ))}
-      {/* el canasto de recolección al pie */}
-      <mesh position={[-0.02, -0.44, -0.2]}>
-        <cylinderGeometry args={[0.09, 0.06, 0.1, 7]} />
-        <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-      </mesh>
-    </group>
-  );
-}
-
-/* 💧 AGUA — la quebrada que corre en diagonal con destellos viajando. */
-function VinetaAgua({ animada }) {
-  const destellos = useRef([]);
-  const junco = useRef(null);
-  usePulso(animada, (t) => {
-    destellos.current.forEach((m, i) => {
-      if (!m) return;
-      const k = (t * 0.22 + i / 3) % 1;
-      m.position.x = -0.52 + k * 1.04;
-      m.position.y = 0.3 - k * 0.62;
-      m.material.opacity = 0.9 * Math.sin(k * Math.PI);
-    });
-    if (junco.current) junco.current.rotation.z = Math.sin(t * 1.6) * 0.1;
-  });
-  return (
-    <group>
-      <FondoVineta cielo="#d8ecdc" suelo={PALETA.follaje} loma="#5f8a5f" />
-      {/* el cauce cruza TODO el círculo */}
-      <mesh position={[0, -0.14, -0.3]} rotation={[0, 0, -0.55]}>
-        <planeGeometry args={[1.6, 0.34]} />
-        <meshLambertMaterial color={PALETA.agua} emissive={PALETA.agua} emissiveIntensity={0.25} />
-      </mesh>
-      <mesh position={[0.02, -0.13, -0.29]} rotation={[0, 0, -0.55]}>
-        <planeGeometry args={[1.6, 0.1]} />
-        <meshLambertMaterial color="#6fb3cc" />
-      </mesh>
-      {/* destellos que VIAJAN aguas abajo — el agua corre */}
-      {[0, 1, 2].map((i) => (
-        <mesh key={i} ref={(m) => (destellos.current[i] = m)} position={[-0.5 + i * 0.35, 0.28 - i * 0.2, -0.27]}>
-          <sphereGeometry args={[0.035, 6, 5]} />
-          <meshBasicMaterial color="#eaf7ff" transparent opacity={0.8} depthWrite={false} />
-        </mesh>
-      ))}
-      {/* piedras de orilla */}
-      {[[-0.3, -0.38], [0.34, 0.08], [0.12, -0.42]].map(([x, y], i) => (
-        <mesh key={i} position={[x, y, -0.26]} rotation={[0.3, i, 0]}>
-          <dodecahedronGeometry args={[0.07, 0]} />
-          <meshLambertMaterial color={PALETA.piedra} flatShading />
-        </mesh>
-      ))}
-      {/* junco meciéndose */}
-      <group ref={junco} position={[-0.42, -0.2, -0.24]}>
-        <mesh position={[0, 0.14, 0]}>
-          <cylinderGeometry args={[0.012, 0.02, 0.3, 4]} />
-          <meshLambertMaterial color={PALETA.follajeClaro} flatShading />
-        </mesh>
-        <mesh position={[0, 0.32, 0]}>
-          <sphereGeometry args={[0.035, 5, 4]} />
-          <meshLambertMaterial color={PALETA.ambar} flatShading />
-        </mesh>
-      </group>
-    </group>
-  );
-}
-
-/* 🐞 SANIDAD — la hoja grande con la mariquita patrullando (control biológico). */
-function VinetaSanidad({ animada }) {
-  const bicho = useRef(null);
-  const hoja = useRef(null);
-  usePulso(animada, (t) => {
-    if (bicho.current) {
-      const x = Math.sin(t * 0.7) * 0.24;
-      bicho.current.position.x = x;
-      bicho.current.rotation.y = Math.cos(t * 0.7) > 0 ? 0.35 : Math.PI - 0.35;
-    }
-    if (hoja.current) hoja.current.rotation.z = 0.12 + Math.sin(t * 0.9) * 0.04;
-  });
-  return (
-    <group>
-      <FondoVineta cielo="#e6f0c8" suelo={PALETA.follaje} />
-      {/* la mata vigilada */}
-      <mesh position={[-0.3, -0.18, -0.28]}>
-        <coneGeometry args={[0.18, 0.4, 6]} />
-        <meshLambertMaterial color={PALETA.follajeOscuro} flatShading />
-      </mesh>
-      {/* la HOJA protagonista, llenando el círculo */}
-      <group ref={hoja} position={[0.05, -0.05, -0.26]} rotation={[0, 0, 0.12]}>
-        <mesh scale={[1, 0.55, 1]}>
-          <circleGeometry args={[0.42, 12]} />
-          <meshLambertMaterial color={PALETA.follajeClaro} side={THREE.DoubleSide} />
-        </mesh>
-        <mesh position={[0, 0, 0.005]} scale={[0.9, 0.06, 1]}>
-          <circleGeometry args={[0.42, 8]} />
-          <meshLambertMaterial color={PALETA.follaje} />
-        </mesh>
-        {/* la mariquita que patrulla */}
-        <group ref={bicho} position={[0, 0.06, 0.05]}>
-          <mesh scale={[1.2, 0.85, 1]}>
-            <sphereGeometry args={[0.065, 8, 6]} />
-            <meshLambertMaterial color="#c22f28" flatShading />
-          </mesh>
-          <mesh position={[0.07, 0.01, 0]}>
-            <sphereGeometry args={[0.035, 6, 5]} />
-            <meshLambertMaterial color="#241a12" flatShading />
-          </mesh>
-          {[[-0.02, 0.05], [0.03, -0.04]].map(([px, pz], i) => (
-            <mesh key={i} position={[px, 0.055, pz]}>
-              <sphereGeometry args={[0.016, 4, 4]} />
-              <meshLambertMaterial color="#241a12" flatShading />
-            </mesh>
-          ))}
-        </group>
-      </group>
-      {/* la trampa amarilla — señal de manejo sano */}
-      <group position={[0.42, -0.14, -0.29]}>
-        <mesh position={[0, -0.1, 0]}>
-          <cylinderGeometry args={[0.012, 0.012, 0.3, 4]} />
-          <meshLambertMaterial color={PALETA.madera} flatShading />
-        </mesh>
-        <mesh position={[0, 0.1, 0]}>
-          <planeGeometry args={[0.14, 0.12]} />
-          <meshLambertMaterial color="#f2c531" emissive="#f2c531" emissiveIntensity={0.3} side={THREE.DoubleSide} />
-        </mesh>
-      </group>
-    </group>
-  );
-}
-
-/* 🧺 MERCADO — el puesto con toldo, banderines y la cosecha en el mesón. */
-function VinetaMercado({ animada }) {
-  const banderin = useRef(null);
-  const frutas = useRef([]);
-  usePulso(animada, (t) => {
-    if (banderin.current) banderin.current.rotation.z = Math.sin(t * 1.8) * 0.07;
-    frutas.current.forEach((m, i) => {
-      if (m) m.position.y = -0.16 + Math.abs(Math.sin(t * 1.4 + i * 2.1)) * 0.018;
-    });
-  });
-  return (
-    <group>
-      <FondoVineta cielo="#f4e4ba" suelo={PALETA.tierraClara} />
-      {/* postes y toldo — el puesto llena la boca */}
-      {[-0.3, 0.3].map((x) => (
-        <mesh key={x} position={[x, -0.08, -0.26]}>
-          <cylinderGeometry args={[0.022, 0.022, 0.6, 4]} />
-          <meshLambertMaterial color={PALETA.madera} flatShading />
-        </mesh>
-      ))}
-      <mesh position={[0, 0.3, -0.24]} rotation={[0.18, 0, 0]}>
-        <boxGeometry args={[0.78, 0.05, 0.3]} />
-        <meshLambertMaterial color="#c96a2f" flatShading />
-      </mesh>
-      <mesh position={[0, 0.24, -0.1]}>
-        <boxGeometry args={[0.78, 0.07, 0.02]} />
-        <meshLambertMaterial color="#e8b04a" flatShading />
-      </mesh>
-      {/* banderines de plaza */}
-      <group ref={banderin} position={[0, 0.42, -0.22]}>
-        {[-0.24, -0.08, 0.08, 0.24].map((x, i) => (
-          <mesh key={x} position={[x, 0.02 - Math.abs(x) * 0.18, 0]} rotation={[0, 0, Math.PI]}>
-            <coneGeometry args={[0.035, 0.07, 3]} />
-            <meshLambertMaterial color={i % 2 ? '#b8352f' : '#f2c531'} flatShading />
-          </mesh>
-        ))}
-      </group>
-      {/* el mesón con la cosecha */}
-      <mesh position={[0, -0.26, -0.2]}>
-        <boxGeometry args={[0.66, 0.06, 0.22]} />
-        <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-      </mesh>
-      {[['#b8352f', -0.2], [PALETA.ambar, 0], ['#7a9a3f', 0.2]].map(([c, x], i) => (
-        <mesh key={i} ref={(m) => (frutas.current[i] = m)} position={[/** @type {number} */ (x), -0.16, -0.18]}>
-          <sphereGeometry args={[0.065, 7, 6]} />
-          <meshLambertMaterial color={c} flatShading />
-        </mesh>
-      ))}
-      <mesh position={[0, -0.45, -0.22]}>
-        <cylinderGeometry args={[0.12, 0.09, 0.12, 7]} />
-        <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-      </mesh>
-    </group>
-  );
-}
-
-/* 🐔 ANIMALES — el corral con la gallina picoteando y su pollito. */
-function VinetaAnimales({ animada }) {
-  const cabeza = useRef(null);
-  const pollito = useRef(null);
-  usePulso(animada, (t) => {
-    if (cabeza.current) cabeza.current.rotation.x = Math.max(0, Math.sin(t * 2.1)) * 0.85;
-    if (pollito.current) {
-      pollito.current.position.y = -0.3 + Math.abs(Math.sin(t * 3.2)) * 0.035;
-      pollito.current.rotation.y = Math.sin(t * 0.8) * 0.5;
-    }
-  });
-  return (
-    <group>
-      <FondoVineta cielo="#f0e2c2" suelo={PALETA.tierraClara} />
-      {/* la cerca del corral cruza el círculo */}
-      {[-0.42, 0, 0.42].map((x) => (
-        <mesh key={x} position={[x, -0.06, -0.3]}>
-          <boxGeometry args={[0.035, 0.42, 0.035]} />
-          <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
-        </mesh>
-      ))}
-      {[0.06, -0.14].map((y) => (
-        <mesh key={y} position={[0, y, -0.29]}>
-          <boxGeometry args={[1.0, 0.035, 0.03]} />
-          <meshLambertMaterial color={PALETA.madera} flatShading />
-        </mesh>
-      ))}
-      {/* la gallina que picotea */}
-      <group position={[-0.14, -0.26, -0.2]}>
-        <mesh scale={[1, 0.9, 1.25]}>
-          <sphereGeometry args={[0.14, 8, 6]} />
-          <meshLambertMaterial color={PALETA.cal} flatShading />
-        </mesh>
-        <mesh position={[-0.1, 0.06, 0]} rotation={[0.4, 0, 0]} scale={[0.5, 0.8, 1]}>
-          <sphereGeometry args={[0.1, 6, 5]} />
-          <meshLambertMaterial color="#e8ddc8" flatShading />
-        </mesh>
-        <group ref={cabeza} position={[0.1, 0.1, 0]}>
-          <mesh position={[0.03, 0.05, 0]}>
-            <sphereGeometry args={[0.07, 7, 6]} />
-            <meshLambertMaterial color={PALETA.cal} flatShading />
-          </mesh>
-          <mesh position={[0.1, 0.05, 0]} rotation={[0, 0, -Math.PI / 2]}>
-            <coneGeometry args={[0.022, 0.06, 4]} />
-            <meshLambertMaterial color={PALETA.ambar} flatShading />
-          </mesh>
-          <mesh position={[0.03, 0.12, 0]}>
-            <sphereGeometry args={[0.025, 5, 4]} />
-            <meshLambertMaterial color="#b8352f" flatShading />
-          </mesh>
-        </group>
-      </group>
-      {/* el pollito saltarín */}
-      <group ref={pollito} position={[0.24, -0.3, -0.18]}>
-        <mesh>
-          <sphereGeometry args={[0.06, 7, 6]} />
-          <meshLambertMaterial color="#e8c04a" flatShading />
-        </mesh>
-        <mesh position={[0.02, 0.06, 0]}>
-          <sphereGeometry args={[0.04, 6, 5]} />
-          <meshLambertMaterial color="#e8c04a" flatShading />
-        </mesh>
-      </group>
-      {/* granitos en el piso */}
-      {[[-0.02, -0.42], [0.1, -0.38]].map(([x, y], i) => (
-        <mesh key={i} position={[x, y, -0.2]}>
-          <sphereGeometry args={[0.018, 4, 4]} />
-          <meshLambertMaterial color={PALETA.ambar} flatShading />
-        </mesh>
-      ))}
-    </group>
-  );
-}
-
-/* 🌱 SEMILLERO — las camas con brotes que GERMINAN en oleada escalonada. */
-function VinetaSemillero({ animada }) {
-  const brotes = useRef([]);
-  usePulso(animada, (t) => {
-    brotes.current.forEach((m, i) => {
-      if (!m) return;
-      const k = (t * 0.2 + i * 0.23) % 1;
-      const s = Math.min(1, k * 2.2);
-      m.scale.set(0.25 + s * 0.75, Math.max(0.08, s), 0.25 + s * 0.75);
-    });
-  });
-  const filas = [
-    { y: -0.16, z: -0.28, xs: [-0.3, -0.1, 0.1, 0.3] },
-    { y: -0.36, z: -0.22, xs: [-0.38, -0.14, 0.12, 0.36] },
-  ];
-  let idx = 0;
-  return (
-    <group>
-      <FondoVineta cielo="#e2eecb" suelo={PALETA.tierra} />
-      {/* las dos camas de germinación */}
-      {filas.map((f, fi) => (
-        <group key={fi}>
-          <mesh position={[0, f.y - 0.07, f.z]}>
-            <boxGeometry args={[fi ? 0.94 : 0.78, 0.09, 0.16]} />
-            <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
-          </mesh>
-          <mesh position={[0, f.y - 0.045, f.z + 0.005]}>
-            <boxGeometry args={[fi ? 0.88 : 0.72, 0.05, 0.14]} />
-            <meshLambertMaterial color={PALETA.tierra} flatShading />
-          </mesh>
-          {f.xs.map((x) => {
-            const i = idx++;
-            return (
-              <mesh key={x} ref={(m) => (brotes.current[i] = m)} position={[x, f.y + 0.06, f.z + 0.01]}>
-                <coneGeometry args={[0.045, 0.16, 5]} />
-                <meshLambertMaterial color={PALETA.follajeClaro} flatShading />
-              </mesh>
-            );
-          })}
-        </group>
-      ))}
-      {/* el arco del túnel de propagación */}
-      <mesh position={[0, 0.02, -0.3]} rotation={[Math.PI / 2, 0, 0]}>
-        <torusGeometry args={[0.42, 0.018, 5, 12, Math.PI]} />
-        <meshLambertMaterial color={PALETA.cal} flatShading />
-      </mesh>
-      <mesh position={[0, 0.02, -0.24]} rotation={[Math.PI / 2, 0, 0]}>
-        <torusGeometry args={[0.5, 0.018, 5, 12, Math.PI]} />
-        <meshLambertMaterial color={PALETA.cal} flatShading />
-      </mesh>
-      {/* el sol que llama a los brotes */}
-      <mesh position={[0.4, 0.42, -0.32]}>
-        <circleGeometry args={[0.11, 12]} />
-        <meshBasicMaterial color="#ffdf8a" />
-      </mesh>
-    </group>
-  );
-}
-
-/* 🪱 SUELO VIVO — el perfil de tierra con la lombriz ondulando entre raíces. */
-function VinetaSuelo({ animada }) {
-  const anillos = useRef([]);
-  usePulso(animada, (t) => {
-    anillos.current.forEach((m, i) => {
-      if (m) m.position.y = m.userData.y + Math.sin(t * 2.4 + i * 1.15) * 0.028;
-    });
-  });
-  return (
-    <group>
-      <FondoVineta cielo="#e9d9b6" suelo="#4a3320" />
-      {/* pasto arriba: la franja viva */}
-      <mesh position={[0, 0.14, -0.3]}>
-        <planeGeometry args={[1.44, 0.1]} />
-        <meshLambertMaterial color={PALETA.follaje} />
-      </mesh>
-      {[-0.5, -0.28, -0.02, 0.26, 0.5].map((x, i) => (
-        <mesh key={x} position={[x, 0.22, -0.29]} rotation={[0, 0, (i % 2 ? -1 : 1) * 0.15]}>
-          <coneGeometry args={[0.03, 0.12, 4]} />
-          <meshLambertMaterial color={PALETA.follajeClaro} flatShading />
-        </mesh>
-      ))}
-      {/* perfil de tierra con horizonte */}
-      <mesh position={[0, -0.2, -0.31]}>
-        <planeGeometry args={[1.44, 0.62]} />
-        <meshLambertMaterial color={PALETA.tierra} />
-      </mesh>
-      {/* raíces colgando */}
-      {[-0.34, 0.02, 0.38].map((x, i) => (
-        <group key={x} position={[x, 0.02, -0.28]}>
-          <mesh rotation={[0, 0, i % 2 ? 0.2 : -0.15]}>
-            <cylinderGeometry args={[0.008, 0.018, 0.3, 4]} />
-            <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-          </mesh>
-        </group>
-      ))}
-      {/* LA LOMBRIZ — cinco anillos que ondulan (el suelo respira) */}
-      {[-0.26, -0.13, 0, 0.13, 0.26].map((x, i) => {
-        const y = -0.24;
-        return (
-          <mesh
-            key={x}
-            ref={(m) => {
-              if (m) {
-                m.userData.y = y;
-                anillos.current[i] = m;
-              }
-            }}
-            position={[x, y, -0.24]}
-          >
-            <sphereGeometry args={[i === 4 ? 0.055 : 0.065, 7, 6]} />
-            <meshLambertMaterial color="#c9708c" flatShading />
-          </mesh>
-        );
-      })}
-      {/* poros de vida: piedritas y humus */}
-      {[[-0.42, -0.4], [0.18, -0.44], [0.44, -0.3]].map(([x, y], i) => (
-        <mesh key={i} position={[x, y, -0.27]}>
-          <dodecahedronGeometry args={[0.035, 0]} />
-          <meshLambertMaterial color={PALETA.piedra} flatShading />
-        </mesh>
-      ))}
-    </group>
-  );
-}
-
-/* 🏔️ SIERRA — el pico nevado sobre su laguna, con la nube pasando. */
-function VinetaSierra({ animada }) {
-  const nube = useRef(null);
-  const laguna = useRef(null);
-  usePulso(animada, (t) => {
-    if (nube.current) nube.current.position.x = Math.sin(t * 0.22) * 0.3;
-    if (laguna.current) laguna.current.emissiveIntensity = 0.25 + (Math.sin(t * 1.1) + 1) * 0.12;
-  });
-  return (
-    <group>
-      <FondoVineta cielo="#d2e2ea" suelo="#5f7a56" />
-      {/* la laguna sagrada */}
-      <mesh position={[0, -0.34, -0.3]} scale={[1, 0.4, 1]}>
-        <circleGeometry args={[0.5, 16]} />
-        <meshLambertMaterial ref={laguna} color={PALETA.agua} emissive={PALETA.agua} emissiveIntensity={0.3} />
-      </mesh>
-      {/* la montaña madre con nieve */}
-      <mesh position={[0, 0.02, -0.31]}>
-        <coneGeometry args={[0.44, 0.66, 7]} />
-        <meshLambertMaterial color={PALETA.follajeOscuro} flatShading />
-      </mesh>
-      <mesh position={[-0.3, -0.12, -0.315]}>
-        <coneGeometry args={[0.26, 0.38, 6]} />
-        <meshLambertMaterial color="#4a6a45" flatShading />
-      </mesh>
-      <mesh position={[0, 0.28, -0.3]}>
-        <coneGeometry args={[0.16, 0.2, 7]} />
-        <meshLambertMaterial color="#f4f1e6" flatShading />
-      </mesh>
-      {/* la nube viajera */}
-      <group ref={nube} position={[0, 0.36, -0.26]}>
-        {[[-0.08, 0, 0.06], [0.05, 0.02, 0.08], [0.16, -0.01, 0.05]].map(([x, y, r], i) => (
-          <mesh key={i} position={[x, y, 0]}>
-            <sphereGeometry args={[r, 6, 5]} />
-            <meshBasicMaterial color="#fbf7ec" transparent opacity={0.92} depthWrite={false} />
-          </mesh>
-        ))}
-      </group>
-      {/* frailejoncitos de orilla */}
-      {[-0.4, 0.42].map((x) => (
-        <mesh key={x} position={[x, -0.26, -0.26]}>
-          <coneGeometry args={[0.05, 0.14, 5]} />
-          <meshLambertMaterial color="#b8c46a" flatShading />
-        </mesh>
-      ))}
-    </group>
-  );
-}
-
-/* 🌫️ PÁRAMO — frailejones entre bancos de niebla que van y vienen. */
-function VinetaParamo({ animada }) {
-  const brumas = useRef([]);
-  usePulso(animada, (t) => {
-    brumas.current.forEach((m, i) => {
-      if (!m) return;
-      m.position.x = Math.sin(t * 0.18 + i * 2.4) * 0.26 * (i % 2 ? -1 : 1);
-      m.material.opacity = 0.4 + Math.sin(t * 0.3 + i) * 0.14;
-    });
-  });
-  const frailejon = (x, y, s, key) => (
-    <group key={key} position={[x, y, -0.27]} scale={[s, s, s]}>
-      <mesh position={[0, -0.08, 0]}>
-        <cylinderGeometry args={[0.05, 0.065, 0.22, 6]} />
-        <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
-      </mesh>
-      {[0, 1, 2, 3, 4].map((i) => (
-        <mesh
-          key={i}
-          position={[Math.sin((i / 5) * Math.PI * 2) * 0.08, 0.05, Math.cos((i / 5) * Math.PI * 2) * 0.08]}
-          rotation={[Math.PI / 3.4, (i / 5) * Math.PI * 2, 0]}
-        >
-          <coneGeometry args={[0.04, 0.2, 4]} />
-          <meshLambertMaterial color="#b8c46a" flatShading />
-        </mesh>
-      ))}
-      <mesh position={[0, 0.1, 0]}>
-        <sphereGeometry args={[0.055, 6, 5]} />
-        <meshLambertMaterial color="#d9c95a" flatShading />
-      </mesh>
-    </group>
-  );
-  return (
-    <group>
-      <FondoVineta cielo="#dde6de" suelo="#7a8a5a" loma="#93a385" />
-      {frailejon(-0.26, -0.16, 1.15, 'a')}
-      {frailejon(0.24, -0.3, 0.95, 'b')}
-      {frailejon(0.44, -0.06, 0.7, 'c')}
-      {/* los bancos de niebla vivos */}
-      {[0.12, -0.1, 0.3].map((y, i) => (
-        <mesh key={i} ref={(m) => (brumas.current[i] = m)} position={[0, y, -0.2 + i * 0.02]} scale={[1, 0.16, 1]}>
-          <circleGeometry args={[0.55, 12]} />
-          <meshBasicMaterial color="#eef2ea" transparent opacity={0.45} depthWrite={false} />
-        </mesh>
-      ))}
-    </group>
-  );
-}
-
-/* 🌧️ LLUVIA — la nube madre soltando gotas sobre la mata que las recibe. */
-function VinetaLluvia({ animada }) {
-  const gotas = useRef([]);
-  const mata = useRef(null);
-  usePulso(animada, (t) => {
-    gotas.current.forEach((m, i) => {
-      if (!m) return;
-      const k = (t * 0.55 + i * 0.19) % 1;
-      m.position.y = 0.22 - k * 0.62;
-      m.position.x = m.userData.x;
-      m.material.opacity = k < 0.08 ? k * 9 : 1 - k * 0.35;
-    });
-    if (mata.current) mata.current.rotation.z = Math.sin(t * 1.8) * 0.07;
-  });
-  return (
-    <group>
-      <FondoVineta cielo="#c9d3d8" suelo={PALETA.follaje} />
-      {/* la nube que llena el cielo del círculo */}
-      <group position={[0, 0.32, -0.28]}>
-        {[[-0.22, 0, 0.14], [-0.02, 0.06, 0.18], [0.2, 0, 0.15], [0.36, -0.02, 0.1]].map(([x, y, r], i) => (
-          <mesh key={i} position={[x, y, 0]}>
-            <sphereGeometry args={[r, 7, 6]} />
-            <meshLambertMaterial color="#c3cdd4" flatShading />
-          </mesh>
-        ))}
-      </group>
-      {/* las gotas cayendo en loop */}
-      {[-0.34, -0.17, 0, 0.17, 0.34].map((x, i) => (
-        <mesh
-          key={x}
-          ref={(m) => {
-            if (m) {
-              m.userData.x = x;
-              gotas.current[i] = m;
-            }
-          }}
-          position={[x, 0.1, -0.24]}
-          scale={[0.6, 1.4, 0.6]}
-        >
-          <sphereGeometry args={[0.028, 5, 5]} />
-          <meshBasicMaterial color="#9fd3e8" transparent opacity={0.9} depthWrite={false} />
-        </mesh>
-      ))}
-      {/* la mata agradecida y su charco */}
-      <mesh position={[0.05, -0.5, -0.26]} scale={[1, 0.3, 1]}>
-        <circleGeometry args={[0.3, 12]} />
-        <meshLambertMaterial color={PALETA.agua} emissive={PALETA.agua} emissiveIntensity={0.2} />
-      </mesh>
-      <group ref={mata} position={[-0.05, -0.42, -0.24]}>
-        <mesh position={[0, 0.1, 0]}>
-          <coneGeometry args={[0.12, 0.26, 6]} />
-          <meshLambertMaterial color={PALETA.follajeClaro} flatShading />
-        </mesh>
-      </group>
-    </group>
-  );
-}
-
-/* 🍂 COMPOST — la pila caliente: hoja que cae, vapor que sube. */
-function VinetaCompost({ animada }) {
-  const hoja = useRef(null);
-  const vapores = useRef([]);
-  usePulso(animada, (t) => {
-    if (hoja.current) {
-      const k = (t * 0.28) % 1;
-      hoja.current.position.y = 0.42 - k * 0.6;
-      hoja.current.position.x = 0.1 + Math.sin(k * 7) * 0.09;
-      hoja.current.rotation.z = k * 5;
-      hoja.current.material.opacity = k > 0.9 ? (1 - k) * 10 : 1;
-    }
-    vapores.current.forEach((m, i) => {
-      if (!m) return;
-      const k = (t * 0.24 + i / 2) % 1;
-      m.position.y = -0.1 + k * 0.45;
-      m.position.x = -0.16 + i * 0.14 + Math.sin(k * 4 + i) * 0.04;
-      m.scale.setScalar(0.03 + k * 0.06);
-      m.material.opacity = 0.5 * (1 - k);
-    });
-  });
-  return (
-    <group>
-      <FondoVineta cielo="#eedebc" suelo={PALETA.tierraClara} />
-      {/* la pila por capas — se lee compostera */}
-      <mesh position={[0, -0.34, -0.28]}>
-        <coneGeometry args={[0.42, 0.24, 9]} />
-        <meshLambertMaterial color={PALETA.tierra} flatShading />
-      </mesh>
-      <mesh position={[0, -0.2, -0.28]}>
-        <coneGeometry args={[0.32, 0.2, 9]} />
-        <meshLambertMaterial color="#5a6a2e" flatShading />
-      </mesh>
-      <mesh position={[0, -0.08, -0.28]}>
-        <coneGeometry args={[0.2, 0.16, 8]} />
-        <meshLambertMaterial color="#8a6a3a" flatShading />
-      </mesh>
-      {/* la horqueta clavada al lado */}
-      <group position={[-0.42, -0.2, -0.26]} rotation={[0, 0, 0.25]}>
-        <mesh>
-          <cylinderGeometry args={[0.015, 0.015, 0.5, 4]} />
-          <meshLambertMaterial color={PALETA.madera} flatShading />
-        </mesh>
-        <mesh position={[0, -0.26, 0]}>
-          <boxGeometry args={[0.1, 0.06, 0.02]} />
-          <meshLambertMaterial color={PALETA.lamina} flatShading />
-        </mesh>
-      </group>
-      {/* vapor de pila viva */}
-      {[0, 1, 2].map((i) => (
-        <mesh key={i} ref={(m) => (vapores.current[i] = m)} position={[-0.16 + i * 0.14, 0, -0.24]}>
-          <sphereGeometry args={[1, 6, 5]} />
-          <meshBasicMaterial color="#f6efe0" transparent opacity={0.4} depthWrite={false} />
-        </mesh>
-      ))}
-      {/* la hoja que cae eternamente */}
-      <mesh ref={hoja} position={[0.1, 0.42, -0.22]} scale={[1, 0.6, 1]}>
-        <circleGeometry args={[0.07, 6]} />
-        <meshBasicMaterial color="#c96a2f" transparent opacity={1} side={THREE.DoubleSide} />
-      </mesh>
-    </group>
-  );
-}
-
-/* El registro viñeta-por-mundo (data-driven, mismo espíritu del route-registry). */
-const VINETAS = {
-  valle: VinetaValle,
-  cafe: VinetaCafe,
-  agua: VinetaAgua,
-  sanidad: VinetaSanidad,
-  mercado: VinetaMercado,
-  animales: VinetaAnimales,
-  semillero: VinetaSemillero,
-  suelo: VinetaSuelo,
-  sierra: VinetaSierra,
-  paramo: VinetaParamo,
-  lluvia: VinetaLluvia,
-  compost: VinetaCompost,
-};
-
-/* ══════════════════════════════════════════════════════════════════════════
-   PORTAL — aro de piedra + garganta + la VIÑETA VIVA llenando la boca
+   EL PAISAJE — cielo, cordilleras, pradera, quebrada (geoms horneadas)
    ══════════════════════════════════════════════════════════════════════════ */
 
-function PortalMundo({ portal, elegido, interactivo, animada, onElegir, onSenalar }) {
-  const halo = useRef(null);
-  const Vineta = VINETAS[portal.motivo] ?? VinetaValle;
+/* Materiales de módulo (compartidos, nunca por frame). El paisaje lambertiano
+   recibe la luz dorada; el cielo y el agua llevan su color horneado sin luz. */
+const MAT_PAISAJE = new THREE.MeshLambertMaterial({ vertexColors: true });
+const MAT_HORNEADO = new THREE.MeshBasicMaterial({ vertexColors: true });
+const MAT_CIELO = new THREE.MeshBasicMaterial({ vertexColors: true, side: THREE.BackSide, fog: false });
+/* Cordilleras: la perspectiva atmosférica va HORNEADA — el fog encima la
+   lavaba a beige plano. Sin fog, la receta del DR se ve tal cual se horneó. */
+const MAT_CORDILLERA = new THREE.MeshBasicMaterial({ vertexColors: true, fog: false });
 
-  /* El halo interior respira; si es el elegido, se enciende (la promesa). */
+/* El domo + el sol bajo + nubes largas de tarde a la deriva. */
+function CieloMirador({ animada }) {
+  const nubes = useRef([]);
+  const geoDomo = useMemo(() => geomCieloDomo(), []);
+  useLayoutEffect(() => () => geoDomo.dispose(), [geoDomo]);
+  useFrame((state) => {
+    if (!animada) return;
+    const t = state.clock.elapsedTime;
+    nubes.current.forEach((g, i) => {
+      if (g) g.position.x = g.userData.x + Math.sin(t * 0.02 + i * 2) * 3.2;
+    });
+  });
+  return (
+    <group>
+      <mesh geometry={geoDomo} material={MAT_CIELO} />
+      {/* el sol de la hora dorada, con su halo velado */}
+      <mesh position={[13, 8.2, -44]}>
+        <circleGeometry args={[3.6, 24]} />
+        <meshBasicMaterial color="#fbe7b4" fog={false} />
+      </mesh>
+      <mesh position={[13, 8.2, -44.5]}>
+        <circleGeometry args={[8.0, 24]} />
+        <meshBasicMaterial color="#f4d493" transparent opacity={0.4} fog={false} depthWrite={false} />
+      </mesh>
+      {/* nubes estiradas de tarde (lamina alta, no algodón) */}
+      {[
+        { x: -15, y: 11, z: -42, s: 1.5, op: 0.5 },
+        { x: 10, y: 13.5, z: -40, s: 1.1, op: 0.38 },
+      ].map((n, i) => (
+        <group
+          key={i}
+          ref={(g) => {
+            if (g) {
+              g.userData.x = n.x;
+              nubes.current[i] = g;
+            }
+          }}
+          position={[n.x, n.y, n.z]}
+          scale={[n.s, n.s, n.s]}
+        >
+          {[[-3.2, 0, 2.2], [0, 0.3, 3.0], [3.4, -0.1, 2.4]].map(([x, y, r], j) => (
+            <mesh key={j} position={[x, y, 0]} scale={[2.2, 0.4, 1]}>
+              <sphereGeometry args={[r, 8, 6]} />
+              <meshBasicMaterial color="#f7ecd6" transparent opacity={n.op} fog={false} depthWrite={false} />
+            </mesh>
+          ))}
+        </group>
+      ))}
+    </group>
+  );
+}
+
+/* La pradera + cordilleras + quebrada + sendero, todas geoms horneadas. */
+function PaisajeMirador({ tier }) {
+  const geos = useMemo(
+    () => ({
+      cordilleras: geomCordilleras(),
+      terreno: geomTerreno({ segmentos: tier === 'alto' ? 64 : 44 }),
+      quebrada: geomQuebrada(),
+      piedras: geomPiedrasQuebrada(),
+      lajas: geomLajasSendero(),
+      lomitas: geomLomitas(
+        PORTALES.filter((p) => p.atras).map((p) => [p.pos[0], p.pos[1] - 2.2, p.pos[2]]),
+      ),
+    }),
+    [tier],
+  );
+  useLayoutEffect(() => () => Object.values(geos).forEach((g) => g.dispose()), [geos]);
+  return (
+    <group>
+      {/* cordilleras HORNEADAS sin luz ni fog: la perspectiva atmosférica ya
+          vive en sus vertexColors — Lambert las apagaba, el fog las lavaba */}
+      <mesh geometry={geos.cordilleras} material={MAT_CORDILLERA} />
+      <mesh geometry={geos.terreno} material={MAT_PAISAJE} />
+      <mesh geometry={geos.lomitas} material={MAT_PAISAJE} />
+      <mesh geometry={geos.quebrada} material={MAT_HORNEADO} />
+      <mesh geometry={geos.piedras} material={MAT_PAISAJE} />
+      <mesh geometry={geos.lajas} material={MAT_PAISAJE} />
+    </group>
+  );
+}
+
+/* Destellos que VIAJAN aguas abajo por el cauce — el agua corre. */
+const TMP_GOTA = new THREE.Vector3();
+function DestellosQuebrada({ animada }) {
+  const destellos = useRef([]);
+  useFrame((state) => {
+    if (!animada) return;
+    const t = state.clock.elapsedTime;
+    destellos.current.forEach((m, i) => {
+      if (!m) return;
+      const k = (t * 0.07 + i / 4) % 1;
+      const f = k * (CAUCE_QUEBRADA.length - 1);
+      const seg = Math.min(CAUCE_QUEBRADA.length - 2, Math.floor(f));
+      const [x0, z0] = CAUCE_QUEBRADA[seg];
+      const [x1, z1] = CAUCE_QUEBRADA[seg + 1];
+      TMP_GOTA.set(x0 + (x1 - x0) * (f - seg), 0.09, z0 + (z1 - z0) * (f - seg));
+      m.position.copy(TMP_GOTA);
+      m.material.opacity = 0.8 * Math.sin(k * Math.PI);
+    });
+  });
+  return (
+    <group>
+      {[0, 1, 2, 3].map((i) => (
+        <mesh key={i} ref={(m) => (destellos.current[i] = m)} position={[0, 0.09, -9 + i * 4]}>
+          <sphereGeometry args={[0.06, 6, 5]} />
+          <meshBasicMaterial color="#f2fbff" transparent opacity={0.8} depthWrite={false} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   ÁRBOLES — el bosque altoandino real, instanciado con variación
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* Un banco de matas de UNA especie: una geometría, un material, N instancias
+   con giro/escala/tinte deterministas (DR: variación por instancia). */
+function Especie({ geo, items }) {
+  const ref = useRef(null);
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, (it.ladeo ?? 0));
+      q.setFromEuler(e);
+      s.set(it.escala * (it.anchoExtra ?? 1), it.escala, it.escala * (it.anchoExtra ?? 1));
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+  if (!geo || !items.length) return null;
+  return <instancedMesh ref={ref} args={[geo, MAT_PAISAJE, items.length]} frustumCulled={false} />;
+}
+
+/* Bosquetes: los árboles se AGRUPAN (DR: agrupamiento y claros, no cuadrícula).
+   Zonas seguras: flancos del claro y el anillo detrás de la fila de atrás.
+   Jamás sobre la plaza (r<10 despejada para portales/cámara) ni el sendero. */
+const ZONAS_ARBOLEDA = [
+  { cx: -13.5, cz: 2.5, radio: 4.5, n: 7 }, // bosquete del flanco izquierdo
+  { cx: 13.5, cz: 2.0, radio: 4.5, n: 7 }, // bosquete del flanco derecho
+  { cx: -10, cz: -12.5, radio: 3.0, n: 4 }, // detrás de la terraza, izquierda
+  { cx: 10.5, cz: -12.5, radio: 3.0, n: 4 }, // detrás de la terraza, derecha
+  { cx: 0, cz: -17, radio: 2.6, n: 3 }, // el telón de fondo central (lejos: no asoma sobre los arcos)
+  { cx: -11, cz: 9.5, radio: 2.6, n: 3 }, // marco del primer plano (izq)
+  { cx: 11.5, cz: 9.0, radio: 2.6, n: 3 }, // marco del primer plano (der)
+];
+
+function ArbolesMirador({ tier }) {
+  const q = calidadDeTier(tier);
+  const geos = useMemo(
+    () => ({
+      roble: geomRoble({ q }, 4),
+      aliso: geomAliso({ q }, 6),
+      gaque: geomGaque({ q }, 7),
+      encenillo: geomEncenillo({ q }, 5),
+    }),
+    [q],
+  );
+  useLayoutEffect(() => () => Object.values(geos).forEach((g) => g.dispose()), [geos]);
+
+  const items = useMemo(() => {
+    const r = rng(1717);
+    // sin yarumo: su sombrilla plateada lee "antena" a esta distancia
+    const especies = ['roble', 'aliso', 'gaque', 'encenillo'];
+    /** @type {Record<string, Array<any>>} */
+    const porEspecie = { roble: [], aliso: [], gaque: [], encenillo: [] };
+    const factor = tier === 'alto' ? 1 : 0.6;
+    for (const zona of ZONAS_ARBOLEDA) {
+      const n = Math.max(2, Math.round(zona.n * factor));
+      // cada bosquete tiene una especie DOMINANTE y acompañantes (agrupamiento)
+      const dominante = especies[Math.floor(r() * especies.length)];
+      for (let i = 0; i < n; i++) {
+        const a = r() * Math.PI * 2;
+        const rad = Math.sqrt(r()) * zona.radio;
+        const x = zona.cx + Math.cos(a) * rad;
+        const z = zona.cz + Math.sin(a) * rad * 0.85;
+        const esp = r() < 0.6 ? dominante : especies[Math.floor(r() * especies.length)];
+        const tintK = 1.15 + r() * 0.4; // tinte por instancia (rompe lo idéntico y levanta el verde al sol)
+        porEspecie[esp].push({
+          pos: [x, alturaTerreno(x, z) - 0.05, z],
+          rotY: r() * Math.PI * 2,
+          ladeo: (r() - 0.5) * 0.06,
+          escala: 1.0 + r() * 0.9,
+          anchoExtra: 0.92 + r() * 0.16,
+          tint: [tintK, tintK * (0.96 + r() * 0.08), tintK * (0.92 + r() * 0.1)],
+        });
+      }
+    }
+    return porEspecie;
+  }, [tier]);
+
+  return (
+    <group>
+      <Especie geo={geos.roble} items={items.roble} />
+      <Especie geo={geos.aliso} items={items.aliso} />
+      <Especie geo={geos.gaque} items={items.gaque} />
+      <Especie geo={geos.encenillo} items={items.encenillo} />
+    </group>
+  );
+}
+
+/* Chispa redonda para las luciérnagas (CanvasTexture runtime, sin assets):
+   sin textura, <points> pinta CUADRADOS. */
+function texturaChispa() {
+  const s = 32;
+  const cv = document.createElement('canvas');
+  cv.width = cv.height = s;
+  const ctx = cv.getContext('2d');
+  const g = ctx.createRadialGradient(s / 2, s / 2, 0, s / 2, s / 2, s / 2);
+  g.addColorStop(0, 'rgba(255,255,255,1)');
+  g.addColorStop(0.4, 'rgba(255,240,200,0.7)');
+  g.addColorStop(1, 'rgba(255,240,200,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, s, s);
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+/* Luciérnagas doradas de la tarde (1 draw call; el group ondula entero). */
+function Luciernagas({ tier, animada }) {
+  const grupo = useRef(null);
+  const n = tier === 'alto' ? 48 : 24;
+  const mapa = useMemo(() => texturaChispa(), []);
+  useLayoutEffect(() => () => mapa.dispose(), [mapa]);
+  const posiciones = useMemo(() => {
+    const r = rng(909);
+    const arr = new Float32Array(n * 3);
+    for (let i = 0; i < n; i += 1) {
+      const a = r() * Math.PI * 2;
+      const rad = 3 + r() * 8.5;
+      arr[i * 3] = Math.sin(a) * rad;
+      arr[i * 3 + 1] = 0.4 + r() * 3.0;
+      arr[i * 3 + 2] = -Math.cos(a) * rad * 0.9 + 1;
+    }
+    return arr;
+  }, [n]);
+
+  useFrame((state) => {
+    if (!animada || !grupo.current) return;
+    const t = state.clock.elapsedTime;
+    grupo.current.position.y = Math.sin(t * 0.4) * 0.25;
+    grupo.current.rotation.y = Math.sin(t * 0.1) * 0.12;
+  });
+
+  return (
+    <group ref={grupo}>
+      <points>
+        <bufferGeometry>
+          <bufferAttribute attach="attributes-position" args={[posiciones, 3]} />
+        </bufferGeometry>
+        <pointsMaterial map={mapa} color="#ffe9b0" size={0.14} sizeAttenuation transparent opacity={0.75} depthWrite={false} />
+      </points>
+    </group>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   PORTAL — arco de piedra seca + diorama horneado + brasa que llama
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* El arco es UNA geometría instanciada 12 veces (misma cantera). */
+function ArcosPiedra({ tier }) {
+  const q = calidadDeTier(tier);
+  const geo = useMemo(() => geomArcoPiedra({ q }, 88), [q]);
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  const ref = useRef(null);
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const m = new THREE.Matrix4();
+    const p = new THREE.Vector3();
+    const e = new THREE.Euler();
+    const qt = new THREE.Quaternion();
+    const s = new THREE.Vector3(1, 1, 1);
+    PORTALES.forEach((portal, i) => {
+      p.set(portal.pos[0], portal.pos[1], portal.pos[2]);
+      e.set(0, portal.rotY, portal.atras ? -0.02 : 0.02);
+      qt.setFromEuler(e);
+      m.compose(p, qt, s);
+      mesh.setMatrixAt(i, m);
+    });
+    mesh.instanceMatrix.needsUpdate = true;
+  }, []);
+  return <instancedMesh ref={ref} args={[geo, MAT_PAISAJE, PORTALES.length]} frustumCulled={false} />;
+}
+
+function PortalMundo({ portal, elegido, interactivo, tier, onElegir, onSenalar }) {
+  const halo = useRef(null);
+  const q = calidadDeTier(tier);
+  const geoVineta = useMemo(() => geomVineta(portal.id, { q }), [portal.id, q]);
+  useLayoutEffect(() => () => geoVineta.dispose(), [geoVineta]);
+
+  /* La brasa del umbral respira; si es el elegido, se enciende (la promesa).
+     Único useFrame por portal — las viñetas son geometría horneada, quieta. */
   useFrame((state) => {
     const h = halo.current;
     if (!h) return;
     const t = state.clock.elapsedTime;
-    const base = elegido ? 1.6 : 0.55;
-    h.emissiveIntensity = base + Math.sin(t * 2.1 + portal.rotY * 3) * 0.18;
+    const base = elegido ? 1.5 : 0.32;
+    h.emissiveIntensity = base + Math.sin(t * 1.7 + portal.rotY * 3) * 0.1;
   });
 
   const alTocar = useCallback(
@@ -1052,449 +616,68 @@ function PortalMundo({ portal, elegido, interactivo, animada, onElegir, onSenala
   );
 
   return (
-    <group position={portal.pos} rotation={[0, portal.rotY, 0]}>
-      {/* aro de piedra (el mismo lenguaje del túnel Odyssey) */}
-      <mesh rotation={[0, 0, portal.atras ? -0.06 : 0.07]}>
-        <torusGeometry args={[0.88, 0.19, 8, 18]} />
-        <meshLambertMaterial color={PALETA.piedra} flatShading />
+    <group position={portal.pos} rotation={[0, portal.rotY, portal.atras ? -0.02 : 0.02]}>
+      {/* garganta de sombra tras el diorama (profundidad de la boca) */}
+      <mesh position={[0, 0, -0.55]} rotation={[Math.PI / 2, 0, 0]}>
+        <cylinderGeometry args={[0.8, 0.8, 0.9, 16, 1, true]} />
+        <meshLambertMaterial color="#241f18" side={THREE.BackSide} />
       </mesh>
-      {/* la enredadera que abraza el aro — el valle se trepa a la piedra */}
-      <mesh rotation={[0, 0, portal.atras ? 0.5 : -0.4]}>
-        <torusGeometry args={[0.9, 0.045, 5, 12, Math.PI * 0.85]} />
-        <meshLambertMaterial color={PALETA.follaje} flatShading />
+      {/* EL DIORAMA horneado del mundo, llenando la boca del arco */}
+      <mesh geometry={geoVineta} material={MAT_HORNEADO} scale={[1.06, 1.06, 1]} />
+      {/* la brasa del umbral: un aro fino que respira con el color del mundo */}
+      <mesh position={[0, 0, 0.045]}>
+        <torusGeometry args={[0.78, 0.016, 5, 26]} />
+        <meshLambertMaterial
+          ref={halo}
+          color={portal.colorA}
+          emissive={portal.colorA}
+          emissiveIntensity={0.32}
+        />
       </mesh>
-      {/* halo interior que respira (la luz del mundo llamando) */}
-      <mesh position={[0, 0, 0.02]}>
-        <torusGeometry args={[0.72, 0.035, 6, 20]} />
-        <meshLambertMaterial ref={halo} color={portal.colorA} emissive={portal.colorA} emissiveIntensity={0.55} />
-      </mesh>
-      {/* garganta hacia adentro de la loma */}
-      <mesh position={[0, 0, -0.5]} rotation={[Math.PI / 2, 0, 0]}>
-        <cylinderGeometry args={[0.76, 0.76, 1.0, 14, 1, true]} />
-        <meshLambertMaterial color={ATMOSFERA.sombra} side={THREE.BackSide} />
-      </mesh>
-      {/* LA VENTANA VIVA: la viñeta del mundo llenando toda la boca. Los
-          eventos van en el group para que CUALQUIER pieza de la viñeta sea
-          tocable — la ventana completa es el botón. */}
-      <group onClick={alTocar} onPointerOver={manito} onPointerOut={normal}>
-        <Vineta animada={animada} />
-      </group>
-      {/* piedra de umbral */}
-      <mesh position={[0.72, -0.92, 0.28]} rotation={[0.2, 0.9, 0]}>
-        <dodecahedronGeometry args={[0.18, 0]} />
-        <meshLambertMaterial color={PALETA.concreto} flatShading />
+      {/* la VENTANA ENTERA es el botón: blanco de toque invisible y generoso */}
+      <mesh position={[0, 0, 0.1]} onClick={alTocar} onPointerOver={manito} onPointerOut={normal}>
+        <circleGeometry args={[0.95, 18]} />
+        <meshBasicMaterial transparent opacity={0} depthWrite={false} />
       </mesh>
     </group>
   );
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
-   EL VALLE — el paisaje verde-vivo donde los portales son LUGARES
-   ══════════════════════════════════════════════════════════════════════════ */
-
-/* El sol bajo y sus nubes: básicos sin niebla, pegados al horizonte. */
-function CieloDorado() {
-  const nubes = useRef([]);
-  useFrame((state) => {
-    const t = state.clock.elapsedTime;
-    nubes.current.forEach((g, i) => {
-      if (g) g.position.x = g.userData.x + Math.sin(t * 0.03 + i * 2) * 3.5;
-    });
-  });
-  return (
-    <group>
-      {/* el sol de la hora dorada, con su halo */}
-      <mesh position={[9, 7.5, -46]}>
-        <circleGeometry args={[4.4, 24]} />
-        <meshBasicMaterial color="#ffdf9a" fog={false} />
-      </mesh>
-      <mesh position={[9, 7.5, -46.5]}>
-        <circleGeometry args={[8.5, 24]} />
-        <meshBasicMaterial color="#f7cd7e" transparent opacity={0.35} fog={false} depthWrite={false} />
-      </mesh>
-      {/* nubes largas de tarde */}
-      {[
-        { x: -14, y: 10, z: -44, s: 1.4 },
-        { x: 12, y: 12.5, z: -42, s: 1 },
-      ].map((n, i) => (
-        <group
-          key={i}
-          ref={(g) => {
-            if (g) {
-              g.userData.x = n.x;
-              nubes.current[i] = g;
-            }
-          }}
-          position={[n.x, n.y, n.z]}
-          scale={[n.s, n.s, n.s]}
-        >
-          {[[-2.4, 0, 1.6], [0, 0.5, 2.2], [2.6, 0, 1.8]].map(([x, y, r], j) => (
-            <mesh key={j} position={[x, y, 0]} scale={[1.6, 0.55, 1]}>
-              <sphereGeometry args={[r, 8, 6]} />
-              <meshBasicMaterial color="#faf0da" transparent opacity={0.75} fog={false} depthWrite={false} />
-            </mesh>
-          ))}
-        </group>
-      ))}
-    </group>
-  );
-}
-
-/* Cordilleras que se pierden en la niebla dorada: 4 planos de profundidad. */
-function Cordilleras() {
-  const capas = [
-    { z: -18, y: -1.2, color: mezclar(PALETA.follajeOscuro, CIELO.fondo, 0.25), lomas: [[-11, 5.6], [-2, 6.4], [8, 5.2], [15, 4.6]] },
-    { z: -26, y: -0.8, color: mezclar(PALETA.follaje, CIELO.fondo, 0.5), lomas: [[-16, 7], [-5, 8.2], [6, 7.4], [16, 6.6]] },
-    { z: -34, y: -0.4, color: mezclar(PALETA.follajeOscuro, CIELO.fondo, 0.7), lomas: [[-12, 10], [2, 11.5], [14, 9.5]] },
-    { z: -42, y: 0, color: mezclar('#6b7a8a', CIELO.fondo, 0.82), lomas: [[-6, 13], [9, 14]] },
-  ];
-  return (
-    <group>
-      {capas.map((c, i) => (
-        <group key={i}>
-          {c.lomas.map(([x, r], j) => (
-            <mesh key={j} position={[x, c.y - r * 0.55, c.z]} scale={[1.9, 1, 0.6]}>
-              <sphereGeometry args={[r, 10, 8]} />
-              <meshLambertMaterial color={c.color} flatShading />
-            </mesh>
-          ))}
-        </group>
-      ))}
-    </group>
-  );
-}
-
-/* Las terrazas de cultivo detrás de la fila de atrás — el valle SE SIEMBRA.
-   ARCOS ABIERTOS solo del lado del fondo (θ ∈ [π/2, 3π/2] ⇒ z<0): un cilindro
-   cerrado a estos radios pasaría por la POSE de la cámara (z=+12.8) y su
-   pared taparía todo el encuadre (bug cazado por screenshot en la 1ª pasada). */
-function Terrazas() {
-  return (
-    <group>
-      {[
-        { r: 13.5, y: 1.4, color: mezclar(PALETA.follaje, CIELO.alfombra, 0.3) },
-        { r: 15.5, y: 2.6, color: mezclar(PALETA.follajeClaro, CIELO.alfombra, 0.4) },
-        { r: 17.5, y: 3.8, color: mezclar(PALETA.follajeOscuro, CIELO.alfombra, 0.35) },
-      ].map((t, i) => (
-        <mesh key={i} position={[0, t.y - 0.9, -6]}>
-          <cylinderGeometry args={[t.r, t.r + 1.6, 1.8, 26, 1, true, Math.PI / 2, Math.PI]} />
-          <meshLambertMaterial color={t.color} flatShading side={THREE.DoubleSide} />
-        </mesh>
-      ))}
-    </group>
-  );
-}
-
-/* La quebrada que baja entre las dos filas, con destellos que VIAJAN. */
-const CAUCE = [
-  new THREE.Vector3(0.4, 0.06, -11.5),
-  new THREE.Vector3(-0.2, 0.05, -8),
-  new THREE.Vector3(0.5, 0.04, -4.5),
-  new THREE.Vector3(-0.4, 0.03, -1),
-  new THREE.Vector3(0.8, 0.02, 3),
-  new THREE.Vector3(2.2, 0.01, 7.5),
-  new THREE.Vector3(3.4, 0.01, 11),
-];
-const TMP_GOTA = new THREE.Vector3();
-
-function Quebrada({ animada }) {
-  const destellos = useRef([]);
-  const tramos = useMemo(() => {
-    const lista = [];
-    for (let i = 0; i < CAUCE.length - 1; i += 1) {
-      const a = CAUCE[i];
-      const b = CAUCE[i + 1];
-      const medio = new THREE.Vector3().addVectors(a, b).multiplyScalar(0.5);
-      const largo = a.distanceTo(b) + 0.7;
-      const rotY = Math.atan2(b.x - a.x, b.z - a.z);
-      lista.push({ medio, largo, rotY });
-    }
-    return lista;
-  }, []);
-
-  useFrame((state) => {
-    if (!animada) return;
-    const t = state.clock.elapsedTime;
-    destellos.current.forEach((m, i) => {
-      if (!m) return;
-      const k = (t * 0.07 + i / 4) % 1;
-      const f = k * (CAUCE.length - 1);
-      const seg = Math.min(CAUCE.length - 2, Math.floor(f));
-      TMP_GOTA.lerpVectors(CAUCE[seg], CAUCE[seg + 1], f - seg);
-      m.position.set(TMP_GOTA.x, TMP_GOTA.y + 0.06, TMP_GOTA.z);
-      m.material.opacity = 0.85 * Math.sin(k * Math.PI);
-    });
-  });
-
-  return (
-    <group>
-      {tramos.map((tr, i) => (
-        <mesh key={i} position={tr.medio} rotation={[-Math.PI / 2, 0, -tr.rotY]}>
-          <planeGeometry args={[0.9, tr.largo]} />
-          <meshLambertMaterial color={PALETA.agua} emissive={PALETA.agua} emissiveIntensity={0.3} />
-        </mesh>
-      ))}
-      {[0, 1, 2, 3].map((i) => (
-        <mesh key={i} ref={(m) => (destellos.current[i] = m)} position={[0, 0.1, -9 + i * 4]}>
-          <sphereGeometry args={[0.07, 6, 5]} />
-          <meshBasicMaterial color="#eaf7ff" transparent opacity={0.8} depthWrite={false} />
-        </mesh>
-      ))}
-      {/* piedras de orilla a lo largo del cauce */}
-      {CAUCE.slice(0, 6).map((p, i) => (
-        <mesh
-          key={i}
-          position={[p.x + (i % 2 ? 0.7 : -0.75), 0.06, p.z + 0.8]}
-          rotation={[0.2, i * 1.3, 0.1]}
-          scale={[1, 0.7, 1]}
-        >
-          <dodecahedronGeometry args={[0.16 + azar(i) * 0.1, 0]} />
-          <meshLambertMaterial color={PALETA.piedra} flatShading />
-        </mesh>
-      ))}
-    </group>
-  );
-}
-
-/* Vegetación instanciada: árboles (2 especies), pasto y arbustos — pocos draw
-   calls para un valle POBLADO. Matrices sembradas una vez, deterministas. */
-function sembrarInstancias(ref, n, colocar) {
-  if (!ref) return;
-  const dummy = new THREE.Object3D();
-  for (let i = 0; i < n; i += 1) {
-    colocar(dummy, i);
-    dummy.updateMatrix();
-    ref.setMatrixAt(i, dummy.matrix);
-  }
-  ref.instanceMatrix.needsUpdate = true;
-}
-
-/* Puestos que no chocan con portales ni quebrada: anillos exteriores. */
-function puestoVerde(i, radioBase) {
-  const a = (azar(i * 3 + 1) - 0.5) * 2.6; // abanico frente a la cámara
-  const r = radioBase + azar(i * 7 + 2) * 4;
-  return [Math.sin(a) * r, -Math.cos(a) * r * 0.92];
-}
-
-function Vegetacion({ tier }) {
-  const alto = tier === 'alto';
-  const nArboles = alto ? 16 : 10;
-  const nRedondos = alto ? 8 : 5;
-  const nPasto = alto ? 90 : 48;
-  const nArbustos = alto ? 22 : 12;
-
-  const troncos = useRef(null);
-  const copas = useRef(null);
-  const copasRedondas = useRef(null);
-  const pasto = useRef(null);
-  const arbustos = useRef(null);
-
-  useLayoutEffect(() => {
-    /* árboles cónicos (pino andino / eucalipto joven) en el borde del claro */
-    const puestos = Array.from({ length: nArboles }, (_, i) => {
-      const [x, z] = puestoVerde(i, 12.5);
-      return { x, z, s: 0.8 + azar(i * 11) * 0.9 };
-    });
-    sembrarInstancias(troncos.current, nArboles, (d, i) => {
-      const p = puestos[i];
-      d.position.set(p.x, 0.5 * p.s, p.z);
-      d.scale.set(p.s, p.s, p.s);
-      d.rotation.set(0, azar(i) * Math.PI, 0);
-    });
-    sembrarInstancias(copas.current, nArboles, (d, i) => {
-      const p = puestos[i];
-      d.position.set(p.x, 1.75 * p.s, p.z);
-      d.scale.set(p.s, p.s, p.s);
-      d.rotation.set(0, azar(i) * Math.PI, 0);
-    });
-    /* árboles redondos (guayabo/cítrico) más cerca, entre portales */
-    sembrarInstancias(copasRedondas.current, nRedondos, (d, i) => {
-      const [x, z] = puestoVerde(i + 40, 8.2);
-      const s = 0.5 + azar(i * 13 + 5) * 0.5;
-      d.position.set(x * 1.15, 1.05 * s, z);
-      d.scale.set(s, s * 0.9, s);
-    });
-    /* pasto: mechones por el claro, esquivando el centro de la cámara */
-    sembrarInstancias(pasto.current, nPasto, (d, i) => {
-      const a = azar(i * 5 + 3) * Math.PI * 2;
-      const r = 2.5 + azar(i * 9 + 4) * 9;
-      const s = 0.5 + azar(i * 17) * 0.8;
-      d.position.set(Math.sin(a) * r, 0.09 * s, -Math.cos(a) * r * 0.85 + 1);
-      d.scale.set(s, s, s);
-      d.rotation.set(0, a * 3, (azar(i) - 0.5) * 0.2);
-    });
-    /* arbustos bajos que arropan los umbrales */
-    sembrarInstancias(arbustos.current, nArbustos, (d, i) => {
-      const a = azar(i * 21 + 8) * Math.PI * 2;
-      const r = 4 + azar(i * 23 + 6) * 8.5;
-      const s = 0.3 + azar(i * 29) * 0.45;
-      d.position.set(Math.sin(a) * r, 0.16 * s, -Math.cos(a) * r * 0.9);
-      d.scale.set(s, s * 0.8, s);
-    });
-  }, [nArboles, nRedondos, nPasto, nArbustos]);
-
-  return (
-    <group>
-      <instancedMesh ref={troncos} args={[undefined, undefined, nArboles]}>
-        <cylinderGeometry args={[0.09, 0.14, 1.0, 5]} />
-        <meshLambertMaterial color={PALETA.madera} flatShading />
-      </instancedMesh>
-      <instancedMesh ref={copas} args={[undefined, undefined, nArboles]}>
-        <coneGeometry args={[0.62, 1.7, 7]} />
-        <meshLambertMaterial color={PALETA.follajeOscuro} flatShading />
-      </instancedMesh>
-      <instancedMesh ref={copasRedondas} args={[undefined, undefined, nRedondos]}>
-        <sphereGeometry args={[0.85, 8, 6]} />
-        <meshLambertMaterial color={PALETA.follaje} flatShading />
-      </instancedMesh>
-      <instancedMesh ref={pasto} args={[undefined, undefined, nPasto]}>
-        <coneGeometry args={[0.1, 0.32, 4]} />
-        <meshLambertMaterial color={PALETA.follajeClaro} flatShading />
-      </instancedMesh>
-      <instancedMesh ref={arbustos} args={[undefined, undefined, nArbustos]}>
-        <sphereGeometry args={[0.5, 7, 5]} />
-        <meshLambertMaterial color={mezclar(PALETA.follaje, PALETA.follajeClaro, 0.4)} flatShading />
-      </instancedMesh>
-    </group>
-  );
-}
-
-/* Luciérnagas doradas + esporas: el pulso biopunk amable del valle (1 draw
-   call; el group entero ondula, jamás se reescribe el buffer). */
-function Luciernagas({ tier, animada }) {
-  const grupo = useRef(null);
-  const n = tier === 'alto' ? 56 : 28;
-  const posiciones = useMemo(() => {
-    const arr = new Float32Array(n * 3);
-    for (let i = 0; i < n; i += 1) {
-      const a = azar(i * 3 + 0.7) * Math.PI * 2;
-      const r = 3 + azar(i * 5 + 1.3) * 8.5;
-      arr[i * 3] = Math.sin(a) * r;
-      arr[i * 3 + 1] = 0.4 + azar(i * 7 + 2.1) * 3.2;
-      arr[i * 3 + 2] = -Math.cos(a) * r * 0.9 + 1;
-    }
-    return arr;
-  }, [n]);
-
-  useFrame((state) => {
-    if (!animada || !grupo.current) return;
-    const t = state.clock.elapsedTime;
-    grupo.current.position.y = Math.sin(t * 0.4) * 0.25;
-    grupo.current.rotation.y = Math.sin(t * 0.1) * 0.12;
-  });
-
-  return (
-    <group ref={grupo}>
-      <points>
-        <bufferGeometry>
-          <bufferAttribute attach="attributes-position" args={[posiciones, 3]} />
-        </bufferGeometry>
-        <pointsMaterial color="#ffe49a" size={0.11} sizeAttenuation transparent opacity={0.85} depthWrite={false} />
-      </points>
-    </group>
-  );
-}
-
-/* Hongos ámbar al pie de los umbrales — la firma biopunk que respira. */
-function HongosAmbar({ animada }) {
-  const gorros = useRef([]);
-  useFrame((state) => {
-    if (!animada) return;
-    const t = state.clock.elapsedTime;
-    gorros.current.forEach((m, i) => {
-      if (m) m.emissiveIntensity = 0.5 + Math.sin(t * 1.4 + i * 2.2) * 0.25;
-    });
-  });
-  const puestos = [
-    [-4.2, -3.9], [4.5, -3.6], [-1.6, -5.6], [2, -5.8], [-6.8, -1.9],
-  ];
-  return (
-    <group>
-      {puestos.map(([x, z], i) => (
-        <group key={i} position={[x, 0, z]} scale={[1, 1, 1]}>
-          <mesh position={[0, 0.09, 0]}>
-            <cylinderGeometry args={[0.03, 0.045, 0.18, 5]} />
-            <meshLambertMaterial color={PALETA.cal} flatShading />
-          </mesh>
-          <mesh position={[0, 0.2, 0]}>
-            <coneGeometry args={[0.11, 0.12, 7]} />
-            <meshLambertMaterial
-              ref={(m) => (gorros.current[i] = m)}
-              color={PALETA.ambar}
-              emissive={PALETA.ambar}
-              emissiveIntensity={0.5}
-              flatShading
-            />
-          </mesh>
-        </group>
-      ))}
-    </group>
-  );
-}
-
-/* ══════════════════════════════════════════════════════════════════════════
-   GALERÍA — el valle completo con las dos terrazas de portales
+   GALERÍA — el mirador completo con las dos terrazas de portales
    ══════════════════════════════════════════════════════════════════════════ */
 
 function GaleriaVitrina({ elegidoId, interactivo, tier, reducedMotion, onElegir, onSenalar }) {
   const animada = !reducedMotion;
   return (
     <group>
-      <color attach="background" args={[CIELO.fondo]} />
-      <fog attach="fog" args={[CIELO.niebla, 17, 46]} />
-      <hemisphereLight args={[CIELO.cielo, CIELO.suelo, 0.95 * CIELO.intensidad]} />
-      <directionalLight position={[7, 8, -6]} intensity={1.15} color={ATMOSFERA.luz} />
-      <directionalLight position={[-5, 4, 6]} intensity={0.24} color={ATMOSFERA.relleno} />
+      <fog attach="fog" args={[PALM.neblina, 20, 54]} />
+      {/* la luz de la hora dorada: el sol rasante ILUMINA lo que la cámara ve
+          (clave cálida desde el frente-derecha) + contraluz que separa copas */}
+      <hemisphereLight args={['#d9e2e8', '#54503a', 1.05]} />
+      <directionalLight position={[11, 9, 9]} intensity={1.2} color="#ffd9a2" />
+      <directionalLight position={[-7, 7, -14]} intensity={0.4} color="#e8c890" />
 
-      {/* el cielo de la tarde: sol bajo + nubes lentas */}
-      <CieloDorado />
-
-      {/* alfombra del claro — verde vivo, no plano: dos tonos */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.02, 0]}>
-        <circleGeometry args={[30, 32]} />
-        <meshLambertMaterial color={mezclar(CIELO.alfombra, PALETA.follaje, 0.45)} flatShading />
-      </mesh>
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.01, 2]}>
-        <circleGeometry args={[7.5, 22]} />
-        <meshLambertMaterial color={mezclar(CIELO.alfombra, PALETA.follajeClaro, 0.35)} flatShading />
-      </mesh>
-
-      {/* la profundidad del valle: cordilleras + terrazas sembradas */}
-      <Cordilleras />
-      <Terrazas />
-
-      {/* la quebrada viva bajando entre las filas */}
-      <Quebrada animada={animada} />
-
-      {/* la vida del claro */}
-      <Vegetacion tier={tier} />
+      <CieloMirador animada={animada} />
+      <PaisajeMirador tier={tier} />
+      <DestellosQuebrada animada={animada} />
+      <ArbolesMirador tier={tier} />
       <Luciernagas tier={tier} animada={animada} />
-      <HongosAmbar animada={animada} />
 
-      {/* los doce portales en sus terrazas */}
+      {/* los doce arcos de piedra seca (una cantera, un InstancedMesh) */}
+      <ArcosPiedra tier={tier} />
+
+      {/* cada boca: su diorama + su brasa + su blanco de toque */}
       {PORTALES.map((p) => (
-        <group key={p.id}>
-          {/* el asiento: lomita para la fila de atrás, umbral para la del frente */}
-          {p.atras ? (
-            <mesh position={[p.pos[0], p.pos[1] - 2.2, p.pos[2]]} scale={[1.25, 0.72, 1.1]}>
-              <sphereGeometry args={[1.7, 10, 8]} />
-              <meshLambertMaterial color={mezclar(PALETA.follaje, CIELO.alfombra, 0.3)} flatShading />
-            </mesh>
-          ) : (
-            <mesh position={[p.pos[0], 0.03, p.pos[2]]} rotation={[-Math.PI / 2, 0, 0]}>
-              <circleGeometry args={[1.35, 14]} />
-              <meshLambertMaterial color={PALETA.tierraClara} flatShading />
-            </mesh>
-          )}
-          <PortalMundo
-            portal={p}
-            elegido={elegidoId === p.id}
-            interactivo={interactivo}
-            animada={animada}
-            onElegir={onElegir}
-            onSenalar={onSenalar}
-          />
-        </group>
+        <PortalMundo
+          key={p.id}
+          portal={p}
+          elegido={elegidoId === p.id}
+          interactivo={interactivo}
+          tier={tier}
+          onElegir={onElegir}
+          onSenalar={onSenalar}
+        />
       ))}
     </group>
   );
@@ -1510,7 +693,7 @@ const CSS_VMX = `
   height: 100dvh;
   min-height: 480px;
   overflow: hidden;
-  background: ${CIELO.fondo};
+  background: linear-gradient(${PALM.cieloCenit} 0%, ${PALM.cieloHorizonte} 70%, ${PALM.pastoBase} 100%);
   font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
   color: #3a2a18;
 }
@@ -1556,12 +739,12 @@ const CSS_VMX = `
   gap: 12px;
 }
 .vmx-abeja { flex: 0 0 auto; filter: drop-shadow(0 3px 4px rgba(58,42,24,0.25)); transition: opacity 150ms ease; }
-/* mientras Angelita cruza, su puesto del chrome queda vacío al instante */
+/* mientras el avatar cruza, su puesto del chrome queda vacío al instante */
 .vmx-raiz[data-fase='acercando'] .vmx-abeja,
 .vmx-raiz[data-viaje='1'] .vmx-abeja { opacity: 0; }
 
-/* ── Angelita ENTRA al mundo: la picada hacia la boca del portal ──
-   El dolly centra el portal elegido en pantalla; la abeja sale de su puesto
+/* ── el avatar ENTRA al mundo: la picada hacia la boca del portal ──
+   El dolly centra el portal elegido en pantalla; el avatar sale de su puesto
    (arriba a la derecha), traza un arco y se clava en el centro encogiéndose
    hasta desaparecer — mismo pulso del viaje (1.25 s), ease-in de succión. */
 .vmx-abeja-cruce {
@@ -1675,7 +858,7 @@ const CSS_VMX = `
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 12px;
   padding: 96px 16px calc(20px + env(safe-area-inset-bottom, 0px));
-  background: linear-gradient(${CIELO.cielo} 0%, ${CIELO.fondo} 55%, ${mezclar(CIELO.fondo, PALETA.tierraClara, 0.3)} 100%);
+  background: linear-gradient(${PALM.cieloCenit} 0%, ${PALM.cieloHorizonte} 55%, ${PALM.tierraPisada} 100%);
 }
 .vmx-tarjeta {
   appearance: none;
@@ -1698,7 +881,7 @@ const CSS_VMX = `
   width: 84px;
   height: 84px;
   border-radius: 50%;
-  border: 7px solid ${PALETA.piedra};
+  border: 7px solid ${PALM.piedra};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1718,8 +901,8 @@ const CSS_VMX = `
 }
 
 /* EL ENT DEL PÁRAMO — arraigado al borde inferior izquierdo, imponente y alto,
-   presidiendo el valle de los mundos. Decorativo: jamás intercepta el toque de
-   los portales. Se asoma desde abajo (no tapa el cielo ni los aros). */
+   presidiendo el mirador. Decorativo: jamás intercepta el toque de los
+   portales. Se asoma desde abajo (no tapa el cielo ni los arcos). */
 .vmx-ent {
   position: absolute;
   left: clamp(-40px, -2vw, 0px);
@@ -1749,7 +932,7 @@ const CSS_VMX = `
    ══════════════════════════════════════════════════════════════════════════ */
 
 /**
- * VitrinaMaestraMundos — galería de portales con el cruce túnel/Odyssey hacia
+ * VitrinaMaestraMundos — el mirador andino con el cruce túnel/Odyssey hacia
  * TODOS los mundos 3D de Chagra.
  *
  * Fases (`fase`): galeria → acercando (dolly+FOV) → mundo → saliendo → galeria.
@@ -1830,7 +1013,7 @@ export default function VitrinaMaestraMundos({ onBack }) {
       data-fase={fase}
       data-viaje={viaje ? '1' : '0'}
       data-tier={tier}
-      aria-label="Vitrina maestra: un valle andino de portales lleva a cada mundo 3D de la finca con un viaje de túnel"
+      aria-label="Vitrina maestra: un mirador andino de arcos de piedra lleva a cada mundo 3D de la finca con un viaje de túnel"
     >
       <style>{CSS_VMX}</style>
 
@@ -1889,8 +1072,8 @@ export default function VitrinaMaestraMundos({ onBack }) {
         <div className="vmx-chrome">
           <div className="vmx-cabecera">
             <h2 className="vmx-titulo">
-              La vitrina de los mundos
-              <small>Toque un portal: el túnel lo lleva y lo trae</small>
+              El mirador de los mundos
+              <small>Toque un arco: el túnel lo lleva y lo trae</small>
             </h2>
             <div className="vmx-abeja">
               {/* Entrada HEROICA del CENTRAL (el avatar elegido; hoy Angelita):
@@ -1963,11 +1146,10 @@ export default function VitrinaMaestraMundos({ onBack }) {
         />
       )}
 
-      {/* EL ENT DEL PÁRAMO — el árbol-guardián que vela el valle de los mundos.
-          Presencia GRANDE e imponente, arraigado al borde: no compite con los
-          portales (decorativo, no intercepta el toque), pero preside la escena
-          como el corazón del Bosque Vivo. Enseña sereno; en tier bajo / RM queda
-          en su fotograma digno. */}
+      {/* EL ENT DEL PÁRAMO — el árbol-guardián que vela el mirador. Presencia
+          GRANDE e imponente, arraigada al borde: no compite con los portales
+          (decorativo, no intercepta el toque), pero preside la escena como el
+          corazón del Bosque Vivo. En tier bajo / RM queda en su pose digna. */}
       {enGaleria && (
         <div className="vmx-ent" aria-hidden="true">
           <EntFrailejon
@@ -1989,7 +1171,7 @@ export default function VitrinaMaestraMundos({ onBack }) {
             fallback={
               <div
                 className="vmx-telon"
-                style={{ background: `linear-gradient(160deg, ${portal.colorB} 0%, ${mezclar(portal.colorB, portal.colorA, 0.35)} 100%)` }}
+                style={{ background: `linear-gradient(160deg, ${portal.colorB} 0%, ${portal.colorA} 140%)` }}
               >
                 <span aria-hidden="true">{portal.emoji}</span>
                 Entrando a {portal.titulo.toLowerCase()}…

--- a/src/visual/mundo3d/bosque/floraParamo.geom.js
+++ b/src/visual/mundo3d/bosque/floraParamo.geom.js
@@ -177,10 +177,26 @@ function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
   return geo;
 }
 
-/** Fusiona la lista de partes (ya coloreadas) en UNA geometría indexada. */
+/**
+ * Fusiona la lista de partes (ya coloreadas) en UNA geometría.
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO si las partes mezclan geometrías
+ * indexadas (Cone/Cylinder/Sphere) con no-indexadas (Icosahedron/Dodecahedron).
+ * Ese null invisible tenía APAGADAS seis especies (frailejón, roble, encenillo,
+ * aliso, gaque, romerillo) — cazado 2026-07-15. Se DESINDEXA todo antes de
+ * fusionar y se TRUENA si aun así falla: mejor un error de build que una
+ * especie invisible en producción.
+ */
 function fusionar(partes) {
-  const buenas = partes.filter(Boolean);
+  const buenas = partes.filter(Boolean).map((p) => {
+    const plana = p.index ? p.toNonIndexed() : p;
+    if (plana !== p) p.dispose();
+    return plana;
+  });
   const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error('floraParamo: mergeGeometries devolvió null — atributos incompatibles entre partes');
+  }
   // Las partes de entrada nunca tocaron la GPU: quedan para el GC.
   return g;
 }

--- a/src/visual/mundo3d/vitrina/__tests__/vitrina.geom.test.js
+++ b/src/visual/mundo3d/vitrina/__tests__/vitrina.geom.test.js
@@ -1,0 +1,165 @@
+/*
+ * Pruebas de la geometría PURA del mirador de la Vitrina Maestra. Corren
+ * headless: three-core + merge es matemática de buffers, sin WebGL.
+ *
+ * La prueba CLAVE es la anti-null: mergeGeometries devuelve null EN SILENCIO
+ * al mezclar geometrías indexadas con no-indexadas (o con sets de atributos
+ * distintos) y la pieza desaparece sin error. Ya mordió tres veces — la
+ * tercera tenía INVISIBLES seis especies del páramo (frailejón, roble,
+ * encenillo, aliso, gaque, romerillo). Aquí toda fusión TRUENA si falla,
+ * y estas pruebas construyen TODAS las piezas para atrapar regresiones.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  fusionar,
+  pintar,
+  pintarPorVertice,
+  ruido1D,
+  fbm1D,
+  ruido2D,
+  fbm2D,
+  alturaTerreno,
+  geomCieloDomo,
+  geomCordilleras,
+  geomTerreno,
+  geomQuebrada,
+  geomPiedrasQuebrada,
+  geomArcoPiedra,
+  geomLomitas,
+  geomLajasSendero,
+} from '../miradorAndino.geom.js';
+import { VINETAS_GEOM, geomVineta } from '../vinetasMundos.geom.js';
+import {
+  geomFrailejon,
+  geomYarumo,
+  geomRoble,
+  geomEncenillo,
+  geomAliso,
+  geomGaque,
+  geomMortino,
+  geomRomerillo,
+} from '../../bosque/floraParamo.geom.js';
+import * as THREE from 'three';
+
+/** La geometría existe, tiene vértices y trae color horneado. */
+function esGeomValida(g) {
+  expect(g).toBeTruthy();
+  expect(g.attributes.position.count).toBeGreaterThan(0);
+  expect(g.attributes.color).toBeTruthy();
+  expect(g.attributes.color.count).toBe(g.attributes.position.count);
+}
+
+describe('fusionar (la fusión segura)', () => {
+  it('mezcla indexadas (cono) con no-indexadas (icosaedro) sin devolver null', () => {
+    const cono = pintar(new THREE.ConeGeometry(1, 2, 5), '#446644');
+    const ico = pintar(new THREE.IcosahedronGeometry(0.5, 0), '#664444');
+    const g = fusionar([cono, ico], 'test');
+    esGeomValida(g);
+  });
+
+  it('descarta uv para uniformar atributos (parte con uv + parte sin uv)', () => {
+    const plano = pintar(new THREE.PlaneGeometry(1, 1), '#446644'); // con uv
+    const pelada = new THREE.BufferGeometry(); // sin uv
+    pelada.setAttribute(
+      'position',
+      new THREE.BufferAttribute(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), 3),
+    );
+    pelada.computeVertexNormals();
+    pintar(pelada, '#664444');
+    const g = fusionar([plano, pelada], 'test');
+    esGeomValida(g);
+  });
+});
+
+describe('ruido determinista', () => {
+  it('misma entrada → misma salida, en [0,1]', () => {
+    expect(ruido1D(3.7, 5)).toBe(ruido1D(3.7, 5));
+    expect(ruido2D(3.7, -2.1, 5)).toBe(ruido2D(3.7, -2.1, 5));
+    for (const x of [0, 0.3, 7.7, -4.2, 100.5]) {
+      expect(fbm1D(x, 3)).toBeGreaterThanOrEqual(0);
+      expect(fbm1D(x, 3)).toBeLessThanOrEqual(1);
+      expect(fbm2D(x, x * 0.7, 3)).toBeGreaterThanOrEqual(0);
+      expect(fbm2D(x, x * 0.7, 3)).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('el paisaje del mirador', () => {
+  it('cielo, cordilleras, terreno, quebrada, piedras, lajas y lomitas construyen', () => {
+    esGeomValida(geomCieloDomo());
+    esGeomValida(geomCordilleras());
+    esGeomValida(geomTerreno({ segmentos: 24 }));
+    esGeomValida(geomQuebrada());
+    esGeomValida(geomPiedrasQuebrada());
+    esGeomValida(geomLajasSendero());
+    esGeomValida(geomLomitas([[0, 0, -9], [4, 0.5, -9]]));
+  });
+
+  it('el arco de piedra construye en todas las calidades de tier', () => {
+    for (const q of [1, 0.62, 0.42]) {
+      esGeomValida(geomArcoPiedra({ q }));
+    }
+  });
+
+  it('alturaTerreno: plaza casi llana adentro, falda que sube afuera', () => {
+    // la plaza de los portales (r<9) es prácticamente plana
+    expect(Math.abs(alturaTerreno(0, 6))).toBeLessThan(0.2);
+    expect(Math.abs(alturaTerreno(-5, 3))).toBeLessThan(0.2);
+    // el pie de monte sube de verdad
+    expect(alturaTerreno(0, -28)).toBeGreaterThan(1);
+  });
+
+  it('pintarPorVertice hornea un color por vértice', () => {
+    const g = new THREE.PlaneGeometry(1, 1);
+    pintarPorVertice(g, (x) => new THREE.Color(x > 0 ? '#ffffff' : '#000000'));
+    expect(g.attributes.color.count).toBe(g.attributes.position.count);
+  });
+});
+
+describe('las doce viñetas-diorama', () => {
+  it('hay viñeta para los DOCE mundos del manifiesto', () => {
+    const mundos = [
+      'valle', 'cafe', 'agua', 'sanidad', 'mercado', 'animales',
+      'semillero', 'suelo', 'sierra', 'paramo', 'lluvia', 'compost',
+    ];
+    expect(Object.keys(VINETAS_GEOM).sort()).toEqual([...mundos].sort());
+  });
+
+  it.each(Object.keys(VINETAS_GEOM))('la viñeta "%s" construye con color horneado', (id) => {
+    esGeomValida(geomVineta(id, { q: 1 }));
+    esGeomValida(geomVineta(id, { q: 0.62 })); // tier medio
+  });
+
+  it('geomVineta truena con un mundo desconocido (bug de datos, no silencio)', () => {
+    expect(() => geomVineta('narnia')).toThrow(/no hay viñeta/);
+  });
+
+  it('cada viñeta cabe en la boca del arco (XY dentro de ~0.8)', () => {
+    for (const id of Object.keys(VINETAS_GEOM)) {
+      const g = geomVineta(id, { q: 1 });
+      g.computeBoundingBox();
+      const bb = g.boundingBox;
+      expect(bb.max.x).toBeLessThanOrEqual(0.85);
+      expect(bb.min.x).toBeGreaterThanOrEqual(-0.85);
+      expect(bb.max.y).toBeLessThanOrEqual(0.85);
+      expect(bb.min.y).toBeGreaterThanOrEqual(-0.85);
+    }
+  });
+});
+
+describe('regresión: las especies del páramo ya no desaparecen en silencio', () => {
+  // Antes del arreglo de `fusionar` en floraParamo.geom, SEIS de estas
+  // devolvían null (mezcla indexada/no-indexada) y las matas no se dibujaban.
+  it.each([
+    ['frailejon', () => geomFrailejon({}, 3)],
+    ['yarumo', () => geomYarumo({}, 3)],
+    ['roble', () => geomRoble({}, 3)],
+    ['encenillo', () => geomEncenillo({}, 3)],
+    ['aliso', () => geomAliso({}, 3)],
+    ['gaque', () => geomGaque({}, 3)],
+    ['mortino', () => geomMortino({}, 3)],
+    ['romerillo', () => geomRomerillo({}, 3)],
+  ])('%s construye (no-null) con color horneado', (_n, fn) => {
+    esGeomValida(fn());
+  });
+});

--- a/src/visual/mundo3d/vitrina/miradorAndino.geom.js
+++ b/src/visual/mundo3d/vitrina/miradorAndino.geom.js
@@ -1,0 +1,610 @@
+/*
+ * miradorAndino.geom — el PAISAJE REALISTA de la Vitrina Maestra.
+ *
+ * REINVENCIÓN (feedback 2026-07-14: "está feíta, bien feíta"): la vitrina deja
+ * de ser botones sobre un fondo plano y pasa a ser un MIRADOR ANDINO a la hora
+ * dorada. Registro visual: los MUNDOS van realistas (los personajes rubber-hose
+ * viven en el chrome DOM, no aquí). Este módulo aplica el DR
+ * realismo-3d-vegetacion (2026-06-19) al paisaje:
+ *
+ *   · Cielo = DOMO con gradiente vertical horneado en vertexColors (no un color
+ *     plano de fondo): horizonte ámbar → cénit azul desaturado.
+ *   · Cordilleras = CRESTAS de ruido fractal (bandas cilíndricas desplazadas),
+ *     tres planos de profundidad con perspectiva atmosférica horneada y nieve
+ *     en la capa lejana (el guiño a la Sierra). Nada de esferas-loma.
+ *   · Terreno = plano CONTINUO ondulado por fbm con variación de color por
+ *     vértice (pasto seco/húmedo, tierra pisada en la plaza y el sendero).
+ *     El ojo caza el patrón plano al instante (DR §1): se rompe con ruido.
+ *   · Portales = arcos de PIEDRA SECA campesina: bloques individuales con
+ *     jitter determinista de escala/rotación, variación de color por bloque,
+ *     AO radial horneado (la cara interior del arco, más oscura) y musgo en
+ *     las juntas altas. Lenguaje de camino real, no aro de parque temático.
+ *
+ * TÉCNICA tier-safe: todo se FUSIONA en pocas geometrías con color horneado
+ * (vertexColors) → una draw-call por pieza. Cero assets externos. Corre
+ * headless (three core + merge puro): testeable en vitest sin WebGL.
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO al mezclar geometrías indexadas
+ * con no-indexadas (Icosahedron/Dodecahedron NO traen índice; Cone/Box/Cylinder
+ * sí). Ya mordió tres veces. Aquí `fusionar()` DESINDEXA todas las partes antes
+ * de fusionar y TRUENA si el resultado es null.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del mirador (hora dorada andina)                                    */
+/* -------------------------------------------------------------------------- */
+
+export const PALM = {
+  // Cielo (gradiente del domo)
+  cieloCenit: '#8aa7c4', // azul desaturado de tarde
+  cieloMedio: '#cbd3cd',
+  cieloHorizonte: '#f0cf92', // ámbar de hora dorada
+  neblina: '#ddc9a2', // color de la niebla de distancia (fog)
+
+  // Cordilleras (perspectiva atmosférica: cerca oscuro → lejos pálido)
+  cordCerca: '#49573f',
+  cordMedia: '#5f6a63',
+  cordLejos: '#8a94a4',
+  nieve: '#f2f1e8',
+
+  // Terreno
+  pastoBase: '#5d7241',
+  pastoSeco: '#8a9155',
+  pastoHumedo: '#465f35',
+  tierraPisada: '#9a8054',
+  tierraHumeda: '#6b5638',
+
+  // Agua (río andino: turbio-verdoso, nunca azul piscina)
+  agua: '#6f96a0',
+  aguaHonda: '#3d5c66',
+  espuma: '#dbe8e2',
+
+  // Piedra del arco
+  piedra: '#8c8579',
+  piedraClara: '#a29a8a',
+  piedraOscura: '#6e685e',
+  musgoPiedra: '#5c6a3c',
+  liquen: '#9aa86a',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Utilidades (fusión segura + horneado de color)                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Fusiona partes en UNA geometría. DESINDEXA todo antes (icosaedros y
+ * dodecaedros vienen sin índice; cilindros y conos con él — mezclarlos
+ * devuelve null EN SILENCIO). Si aun así falla, TRUENA: mejor un error de
+ * build que una especie invisible en producción.
+ * @param {THREE.BufferGeometry[]} partes
+ * @param {string} quien — etiqueta para el error
+ * @returns {THREE.BufferGeometry}
+ */
+export function fusionar(partes, quien = 'miradorAndino') {
+  const buenas = partes
+    .filter(Boolean)
+    .map((p) => {
+      const plana = p.index ? p.toNonIndexed() : p;
+      if (plana !== p) p.dispose();
+      // Sin texturas no hay uv: descartarlo uniforma los atributos (una parte
+      // CON uv y otra SIN uv también producen el null silencioso).
+      plana.deleteAttribute('uv');
+      plana.deleteAttribute('uv1');
+      plana.deleteAttribute('uv2');
+      return plana;
+    });
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error(
+      `${quien}: mergeGeometries devolvió null — atributos incompatibles entre partes`,
+    );
+  }
+  buenas.forEach((p) => p.dispose());
+  return g;
+}
+
+/**
+ * Hornea un color plano en todos los vértices (atributo `color`).
+ * @param {THREE.BufferGeometry} geo
+ * @param {THREE.Color|string} color
+ */
+export function pintar(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/**
+ * Hornea color POR VÉRTICE con una función (x,y,z,i) → THREE.Color.
+ * La base del sombreado sin texturas del DR: gradientes de altura, AO fingido
+ * y parches de ruido viven aquí.
+ * @param {THREE.BufferGeometry} geo
+ * @param {(x:number,y:number,z:number,i:number) => THREE.Color} fn
+ */
+export function pintarPorVertice(geo, fn) {
+  const pos = geo.attributes.position;
+  const arr = new Float32Array(pos.count * 3);
+  for (let i = 0; i < pos.count; i++) {
+    const c = fn(pos.getX(i), pos.getY(i), pos.getZ(i), i);
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/**
+ * Coloca una geometría (posición/rotación/escala aplicadas a los vértices).
+ * @param {THREE.BufferGeometry} geo
+ * @param {[number,number,number]} [pos]
+ * @param {[number,number,number]} [rot]
+ * @param {[number,number,number]} [scale]
+ */
+export function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/** Variación determinista de un color base (bosque no plano — DR §2). */
+export function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
+}
+
+/* Ruido de valor 1D/2D determinista y barato (sin libs): interpola hashes. */
+function hash1(n) {
+  const s = Math.sin(n * 127.1 + 311.7) * 43758.5453;
+  return s - Math.floor(s);
+}
+
+/** Ruido de valor 1D suavizado en [0,1]. */
+export function ruido1D(x, seed = 0) {
+  const i = Math.floor(x);
+  const f = x - i;
+  const u = f * f * (3 - 2 * f);
+  return hash1(i + seed * 57.31) * (1 - u) + hash1(i + 1 + seed * 57.31) * u;
+}
+
+/** fbm 1D: 3 octavas de ruido de valor, [0,1]. */
+export function fbm1D(x, seed = 0) {
+  return (
+    ruido1D(x, seed) * 0.55 +
+    ruido1D(x * 2.13, seed + 7) * 0.3 +
+    ruido1D(x * 4.7, seed + 13) * 0.15
+  );
+}
+
+/** Ruido de valor 2D suavizado en [0,1]. */
+export function ruido2D(x, z, seed = 0) {
+  const xi = Math.floor(x);
+  const zi = Math.floor(z);
+  const xf = x - xi;
+  const zf = z - zi;
+  const u = xf * xf * (3 - 2 * xf);
+  const v = zf * zf * (3 - 2 * zf);
+  const h = (a, b) => hash1(a * 157.7 + b * 311.3 + seed * 53.7);
+  const a = h(xi, zi) * (1 - u) + h(xi + 1, zi) * u;
+  const b = h(xi, zi + 1) * (1 - u) + h(xi + 1, zi + 1) * u;
+  return a * (1 - v) + b * v;
+}
+
+/** fbm 2D: 3 octavas, [0,1]. */
+export function fbm2D(x, z, seed = 0) {
+  return (
+    ruido2D(x, z, seed) * 0.55 +
+    ruido2D(x * 2.17, z * 2.17, seed + 5) * 0.3 +
+    ruido2D(x * 4.9, z * 4.9, seed + 11) * 0.15
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  CIELO — domo con gradiente vertical horneado                               */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Media esfera vista desde adentro. El gradiente horneado (horizonte cálido →
+ * cénit azul) reemplaza el `<color attach="background">` plano: la mitad del
+ * encuadre es cielo, y un cielo con gradiente es el salto de realismo más
+ * barato que existe (1 draw-call, MeshBasic, sin luz ni fog).
+ */
+export function geomCieloDomo(radio = 60) {
+  const geo = new THREE.SphereGeometry(radio, 28, 14, 0, Math.PI * 2, 0, Math.PI * 0.62);
+  const cenit = new THREE.Color(PALM.cieloCenit);
+  const medio = new THREE.Color(PALM.cieloMedio);
+  const horiz = new THREE.Color(PALM.cieloHorizonte);
+  pintarPorVertice(geo, (x, y) => {
+    const t = THREE.MathUtils.clamp(y / (radio * 0.85), 0, 1);
+    const c = new THREE.Color();
+    if (t < 0.28) c.lerpColors(horiz, medio, t / 0.28);
+    else c.lerpColors(medio, cenit, (t - 0.28) / 0.72);
+    return c;
+  });
+  return geo;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  CORDILLERAS — crestas fractales con perspectiva atmosférica                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Una banda de cordillera: franja cilíndrica alrededor de la escena cuya
+ * arista superior sigue un perfil fbm (picos y portezuelos reales, no lomas
+ * de esfera). Color horneado por capa: cuanto más lejos, más se funde con el
+ * cielo (perspectiva atmosférica); la capa lejana lleva nieve en las cumbres.
+ * Las TRES capas se fusionan en UNA geometría → 1 draw-call.
+ */
+export function geomCordilleras(seed = 21) {
+  const capas = [
+    { radio: 22, base: PALM.cordCerca, hMin: 2.2, hMax: 6.0, haz: 0.12, nieve: false, freq: 1.35 },
+    { radio: 32, base: PALM.cordMedia, hMin: 4.0, hMax: 9.5, haz: 0.34, nieve: false, freq: 1.0 },
+    { radio: 44, base: PALM.cordLejos, hMin: 6.5, hMax: 14.5, haz: 0.52, nieve: true, freq: 0.75 },
+  ];
+  // La recesión atmosférica va hacia el AZUL-GRIS de la bruma de distancia;
+  // solo el pie de monte se funde al ámbar del horizonte (lerp abajo).
+  const bruma = new THREE.Color('#b3c0cc');
+  const cielo = new THREE.Color(PALM.cieloHorizonte);
+  const nieve = new THREE.Color(PALM.nieve);
+  const partes = capas.map((capa, ci) => {
+    const N = 96;
+    // Solo el arco que la cámara ve (la cámara vive en z≈+13 mirando a -z):
+    // θ ∈ [-140°, 140°] alrededor de -z. Cerrar el círculo detrás de la cámara
+    // desperdiciaría vértices que jamás entran al encuadre.
+    const a0 = -Math.PI * 0.78;
+    const a1 = Math.PI * 0.78;
+    const posiciones = [];
+    const colores = [];
+    const base = new THREE.Color(capa.base).lerp(bruma, capa.haz);
+    const sombraLadera = base.clone().multiplyScalar(0.82);
+    for (let i = 0; i < N; i++) {
+      const t0 = i / N;
+      const t1 = (i + 1) / N;
+      const perfil = (t) => {
+        const h = fbm1D(t * 14 * capa.freq, seed + ci * 31);
+        // picos más marcados: eleva el contraste del fbm
+        const k = Math.pow(h, 1.4);
+        return capa.hMin + k * (capa.hMax - capa.hMin);
+      };
+      const punto = (t, y) => {
+        const a = a0 + (a1 - a0) * t;
+        return [Math.sin(a) * capa.radio, y, -Math.cos(a) * capa.radio];
+      };
+      const h0 = perfil(t0);
+      const h1 = perfil(t1);
+      const p00 = punto(t0, -1.5);
+      const p01 = punto(t0, h0);
+      const p10 = punto(t1, -1.5);
+      const p11 = punto(t1, h1);
+      // dos triángulos por segmento
+      posiciones.push(...p00, ...p10, ...p01, ...p01, ...p10, ...p11);
+      // color por vértice: base abajo (fundida a bruma), ladera con leve
+      // variación, nieve encima del umbral en la capa lejana
+      const colorEn = (y, t) => {
+        const c = base.clone();
+        // laderas: variación sutil por segmento (rompe lo plano)
+        c.lerp(sombraLadera, ruido1D(t * 23, seed + 77) * 0.5);
+        // pie de monte fundido a la bruma del horizonte
+        const pie = THREE.MathUtils.clamp(1 - y / 3.2, 0, 1);
+        c.lerp(cielo, pie * 0.55);
+        if (capa.nieve && y > capa.hMax * 0.58) {
+          const s = THREE.MathUtils.clamp((y - capa.hMax * 0.58) / (capa.hMax * 0.16), 0, 1);
+          c.lerp(nieve, s * 0.95);
+        }
+        return c;
+      };
+      const cs = [colorEn(-1.5, t0), colorEn(-1.5, t1), colorEn(h0, t0), colorEn(h0, t0), colorEn(-1.5, t1), colorEn(h1, t1)];
+      cs.forEach((c) => colores.push(c.r, c.g, c.b));
+    }
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.BufferAttribute(new Float32Array(posiciones), 3));
+    g.setAttribute('color', new THREE.BufferAttribute(new Float32Array(colores), 3));
+    g.computeVertexNormals();
+    return g;
+  });
+  return fusionar(partes, 'geomCordilleras');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  TERRENO — pradera continua ondulada con color por vértice                  */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * El claro del mirador: un plano desplazado por fbm — casi llano en la plaza
+ * de los portales, ondulado afuera y trepando hacia el pie de las cordilleras.
+ * El color por vértice rompe el "verde plano de cancha": parches secos y
+ * húmedos por ruido, tierra pisada en la plaza y el sendero de entrada, y
+ * orillas húmedas donde corre la quebrada.
+ */
+/**
+ * Altura del terreno en (x,z) — la MISMA fórmula que hornea geomTerreno, para
+ * que árboles, lomitas y umbrales se siembren A NIVEL (nada flotando).
+ * @param {number} x
+ * @param {number} z
+ * @param {number} [seed]
+ */
+export function alturaTerreno(x, z, seed = 33) {
+  const r = Math.hypot(x, z);
+  const onda = (fbm2D(x * 0.09, z * 0.09, seed) - 0.5) * 2; // [-1,1]
+  const plaza = THREE.MathUtils.smoothstep(r, 9, 17); // 0 adentro → 1 afuera
+  const falda = THREE.MathUtils.smoothstep(r, 18, 30); // trepa al pie del monte
+  return onda * (0.05 + plaza * 0.6) + falda * 2.2 + onda * falda * 0.8;
+}
+
+export function geomTerreno({ segmentos = 56 } = {}, seed = 33) {
+  const L = 64;
+  const geo = new THREE.PlaneGeometry(L, L, segmentos, segmentos);
+  geo.rotateX(-Math.PI / 2);
+  const pos = geo.attributes.position;
+
+  const pastoBase = new THREE.Color(PALM.pastoBase);
+  const pastoSeco = new THREE.Color(PALM.pastoSeco);
+  const pastoHumedo = new THREE.Color(PALM.pastoHumedo);
+  const tierra = new THREE.Color(PALM.tierraPisada);
+  const tierraHumeda = new THREE.Color(PALM.tierraHumeda);
+
+  // 1) Desplazamiento: plaza llana (r<11), ondulación creciente afuera.
+  for (let i = 0; i < pos.count; i++) {
+    pos.setY(i, alturaTerreno(pos.getX(i), pos.getZ(i), seed));
+  }
+  geo.computeVertexNormals();
+
+  // 2) Color por vértice: parches + plaza y sendero de tierra + orilla húmeda.
+  pintarPorVertice(geo, (x, y, z) => {
+    const c = pastoBase.clone();
+    // parches secos / húmedos por ruido (dos escalas)
+    const seco = fbm2D(x * 0.16 + 40, z * 0.16, seed + 3);
+    const humedo = fbm2D(x * 0.07 - 21, z * 0.07 + 13, seed + 9);
+    c.lerp(pastoSeco, THREE.MathUtils.smoothstep(seco, 0.55, 0.85) * 0.7);
+    c.lerp(pastoHumedo, THREE.MathUtils.smoothstep(humedo, 0.58, 0.85) * 0.6);
+    // la plaza de los portales: pasto pisado que abre a tierra
+    const r = Math.hypot(x, z);
+    const pisada = 1 - THREE.MathUtils.smoothstep(r, 4.5, 9.5);
+    c.lerp(tierra, pisada * 0.45);
+    // el sendero de entrada (viene de la cámara, x≈0, z>0), con borde ruidoso
+    const borde = (fbm1D(z * 0.7, seed + 17) - 0.5) * 1.1;
+    const dx = Math.abs(x - borde);
+    if (z > 2 && z < 20) {
+      const sendero = 1 - THREE.MathUtils.smoothstep(dx, 0.7, 1.7);
+      c.lerp(tierra, sendero * 0.55);
+    }
+    // orilla húmeda de la quebrada (cauce aproximado: diagonal x≈2.2−0.28·z)
+    const dQ = Math.abs(x - (2.2 - z * 0.28));
+    if (z > -12 && z < 14) {
+      const orilla = 1 - THREE.MathUtils.smoothstep(dQ, 0.8, 2.4);
+      c.lerp(tierraHumeda, orilla * 0.35);
+    }
+    // leve gradiente de altura (lo alto, más dorado por el sol rasante)
+    c.lerp(pastoSeco, THREE.MathUtils.clamp(y * 0.16, 0, 0.35));
+    return c;
+  });
+  return geo;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  QUEBRADA — cinta de agua que baja al reflejo del cielo                     */
+/* -------------------------------------------------------------------------- */
+
+/** El cauce de la quebrada como puntos [x,z] (de lejos-atrás a cerca-frente). */
+export const CAUCE_QUEBRADA = [
+  [-1.4, -13.5],
+  [0.2, -9.5],
+  [1.0, -5.5],
+  [1.6, -1.5],
+  [2.0, 2.5],
+  [2.6, 6.5],
+  [3.4, 10.5],
+];
+
+/*
+ * Cinta de agua siguiendo el cauce, con color horneado: centro hondo oscuro,
+ * orillas claras (el reflejo rasante del cielo) y motas de espuma junto a las
+ * piedras. Una geometría; los destellos animados van aparte (points).
+ */
+export function geomQuebrada(seed = 55) {
+  /** @type {THREE.BufferGeometry[]} */
+  const partes = [];
+  const honda = new THREE.Color(PALM.aguaHonda);
+  const clara = new THREE.Color(PALM.agua);
+  const cieloRef = new THREE.Color(PALM.cieloHorizonte);
+
+  const ancho = 0.68;
+  for (let s = 0; s < CAUCE_QUEBRADA.length - 1; s++) {
+    const [x0, z0] = CAUCE_QUEBRADA[s];
+    const [x1, z1] = CAUCE_QUEBRADA[s + 1];
+    const dx = x1 - x0;
+    const dz = z1 - z0;
+    const largo = Math.hypot(dx, dz) + 0.5;
+    const rotY = Math.atan2(dx, dz);
+    const g = new THREE.PlaneGeometry(ancho, largo, 4, 6);
+    g.rotateX(-Math.PI / 2);
+    // color: centro hondo → orilla clara con destello de cielo
+    pintarPorVertice(g, (x, _y, z) => {
+      const t = Math.abs(x) / (ancho / 2);
+      const c = honda.clone().lerp(clara, Math.pow(t, 1.5));
+      c.lerp(cieloRef, Math.max(0, t - 0.8) * 0.5);
+      // chispas de corriente horneadas (varían a lo largo)
+      const chispa = ruido2D(x * 6 + 9, z * 2.2, seed + s);
+      if (chispa > 0.9) c.lerp(new THREE.Color(PALM.espuma), 0.4);
+      return c;
+    });
+    poner(g, [(x0 + x1) / 2, 0.035, (z0 + z1) / 2], [0, rotY, 0]);
+    partes.push(g);
+  }
+  return fusionar(partes, 'geomQuebrada');
+}
+
+/** Piedras de orilla a lo largo del cauce (fusionadas, color variado). */
+export function geomPiedrasQuebrada(seed = 66) {
+  const r = rng(seed);
+  /** @type {THREE.BufferGeometry[]} */
+  const partes = [];
+  for (let s = 0; s < CAUCE_QUEBRADA.length - 1; s++) {
+    const [x0, z0] = CAUCE_QUEBRADA[s];
+    const n = 2 + Math.floor(r() * 2);
+    for (let i = 0; i < n; i++) {
+      const lado = r() > 0.5 ? 1 : -1;
+      const p = new THREE.DodecahedronGeometry(0.1 + r() * 0.14, 0);
+      poner(
+        p,
+        [x0 + lado * (0.55 + r() * 0.5), 0.03 + r() * 0.04, z0 + r() * 2.4],
+        [r() * 0.6, r() * Math.PI, r() * 0.5],
+        [1, 0.65 + r() * 0.3, 1],
+      );
+      pintar(p, variar(PALM.piedra, r, 0.12));
+      partes.push(p);
+    }
+  }
+  return fusionar(partes, 'geomPiedrasQuebrada');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  ARCO DE PIEDRA SECA — el portal campesino                                  */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Arco de mampostería de piedra seca (lenguaje de camino real): dovelas
+ * individuales con jitter determinista de tamaño/giro, jambas más gordas en la
+ * base, color de piedra variado por bloque, AO radial horneado (la cara que
+ * mira a la boca del arco queda en sombra) y musgo/líquen en las juntas altas.
+ * UNA geometría → un InstancedMesh la repite en los 12 portales.
+ */
+export function geomArcoPiedra({ q = 1 } = {}, seed = 88) {
+  const r = rng(seed);
+  /** @type {THREE.BufferGeometry[]} */
+  const partes = [];
+  const R = 0.98; // radio del anillo de dovelas
+  const nBloques = Math.max(10, Math.round(15 * q));
+  // El arco abre abajo (el umbral es el suelo): θ recorre -122°..122° desde
+  // el cénit del aro.
+  const a0 = THREE.MathUtils.degToRad(-122);
+  const a1 = THREE.MathUtils.degToRad(122);
+
+  const piedras = [PALM.piedra, PALM.piedraClara, PALM.piedraOscura];
+  for (let i = 0; i < nBloques; i++) {
+    const t = i / (nBloques - 1);
+    const a = a0 + (a1 - a0) * t;
+    const esClave = Math.abs(a) < 0.14; // la dovela clave, arriba
+    const esJamba = t < 0.09 || t > 0.91; // las jambas de la base
+    const ancho = (esClave ? 0.4 : esJamba ? 0.42 : 0.33) * (0.92 + r() * 0.16);
+    const alto = (esJamba ? 0.34 : 0.26) * (0.9 + r() * 0.2);
+    const fondo = 0.34 * (0.9 + r() * 0.2);
+    const bloque = new THREE.BoxGeometry(ancho, alto, fondo);
+    // orientar la dovela tangente al aro + jitter de giro
+    const x = Math.sin(a) * R;
+    const y = Math.cos(a) * R;
+    poner(
+      bloque,
+      [x + (r() - 0.5) * 0.03, y + (r() - 0.5) * 0.03, (r() - 0.5) * 0.04],
+      [(r() - 0.5) * 0.08, (r() - 0.5) * 0.08, -a + (r() - 0.5) * 0.07],
+    );
+    // color por bloque + AO radial horneado: los vértices que miran a la boca
+    // (radio menor) se oscurecen — la sombra de la garganta sin costo.
+    const base = variar(piedras[Math.floor(r() * piedras.length)], r, 0.09);
+    const conLiquen = r() > 0.72;
+    const liquen = new THREE.Color(PALM.liquen);
+    pintarPorVertice(bloque, (vx, vy) => {
+      const rad = Math.hypot(vx, vy);
+      const ao = THREE.MathUtils.clamp((rad - (R - 0.22)) / 0.42, 0, 1); // 0 = cara interior
+      const c = base.clone().multiplyScalar(0.74 + ao * 0.3);
+      if (conLiquen) {
+        const mancha = ruido2D(vx * 9, vy * 9, seed + i);
+        if (mancha > 0.78) c.lerp(liquen, 0.5);
+      }
+      return c;
+    });
+    partes.push(bloque);
+  }
+
+  // Musgo en las juntas altas (el páramo se trepa a la piedra).
+  const nMusgo = Math.max(2, Math.round(4 * q));
+  for (let i = 0; i < nMusgo; i++) {
+    const a = (r() - 0.5) * 1.6;
+    const m = new THREE.IcosahedronGeometry(0.05 + r() * 0.035, 0);
+    poner(m, [Math.sin(a) * (R + 0.12), Math.cos(a) * (R + 0.12), (r() - 0.5) * 0.18], [0, 0, 0], [1, 0.6, 1]);
+    pintar(m, variar(PALM.musgoPiedra, r, 0.15));
+    partes.push(m);
+  }
+
+  // Umbral: laja de piso + dos piedras de pie de jamba.
+  const laja = new THREE.BoxGeometry(2.3, 0.09, 0.9);
+  poner(laja, [0, -R - 0.16, 0.18], [0, 0, (r() - 0.5) * 0.02]);
+  pintarPorVertice(laja, (vx) => variar(PALM.piedraOscura, r, 0.05).multiplyScalar(0.9 + Math.abs(vx) * 0.06));
+  partes.push(laja);
+  for (const lado of [-1, 1]) {
+    const pie = new THREE.DodecahedronGeometry(0.16, 0);
+    poner(pie, [lado * (R + 0.18), -R + 0.02, 0.22], [r(), r(), 0], [1, 0.7, 1]);
+    pintar(pie, variar(PALM.piedra, r, 0.1));
+    partes.push(pie);
+  }
+
+  return fusionar(partes, 'geomArcoPiedra');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LAJAS DEL SENDERO — piedras pisables hacia la plaza                        */
+/* -------------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------------- */
+/*  LOMITAS — los asientos de pasto de la fila de atrás                        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Lomas suaves de pasto donde se asienta la terraza de atrás, con la misma
+ * variación de color del terreno (nunca un verde plano). UNA geometría.
+ * @param {Array<[number,number,number]>} centros — [x, y, z] del centro de cada loma
+ * @param {number} seed
+ */
+export function geomLomitas(centros, seed = 44) {
+  const pastoBase = new THREE.Color(PALM.pastoBase);
+  const pastoSeco = new THREE.Color(PALM.pastoSeco);
+  const pastoHumedo = new THREE.Color(PALM.pastoHumedo);
+  const partes = centros.map(([cx, cy, cz], i) => {
+    const g = new THREE.SphereGeometry(1.7, 14, 10);
+    // ondular apenas el perfil para que no se lea "esfera"
+    const pos = g.attributes.position;
+    for (let v = 0; v < pos.count; v++) {
+      const n = 1 + (ruido2D(pos.getX(v) * 1.7 + i * 9, pos.getZ(v) * 1.7, seed) - 0.5) * 0.22;
+      pos.setXYZ(v, pos.getX(v) * n, pos.getY(v), pos.getZ(v) * n);
+    }
+    pintarPorVertice(g, (x, y, z) => {
+      const c = pastoBase.clone();
+      c.lerp(pastoSeco, ruido2D(x * 3 + i * 7, z * 3, seed + 5) * 0.55 + Math.max(0, y) * 0.14);
+      c.lerp(pastoHumedo, ruido2D(x * 1.3 - 4, z * 1.3 + i, seed + 11) * 0.4);
+      return c;
+    });
+    poner(g, [cx, cy, cz], [0, 0, 0], [1.3, 0.75, 1.15]);
+    return g;
+  });
+  return fusionar(partes, 'geomLomitas');
+}
+
+export function geomLajasSendero(seed = 99) {
+  const r = rng(seed);
+  /** @type {THREE.BufferGeometry[]} */
+  const partes = [];
+  for (let i = 0; i < 9; i++) {
+    const z = 11.5 - i * 1.15;
+    const x = (fbm1D(z * 0.7, seed + 17) - 0.5) * 1.1 + (r() - 0.5) * 0.4;
+    const laja = new THREE.CylinderGeometry(0.32 + r() * 0.16, 0.36 + r() * 0.16, 0.05, 7);
+    poner(laja, [x, 0.03, z], [0, r() * Math.PI, 0], [1, 1, 0.8 + r() * 0.3]);
+    pintar(laja, variar(PALM.piedraClara, r, 0.1));
+    partes.push(laja);
+  }
+  return fusionar(partes, 'geomLajasSendero');
+}

--- a/src/visual/mundo3d/vitrina/vinetasMundos.geom.js
+++ b/src/visual/mundo3d/vitrina/vinetasMundos.geom.js
@@ -1,0 +1,949 @@
+/*
+ * vinetasMundos.geom — los DOCE DIORAMAS que viven dentro de los arcos de la
+ * Vitrina Maestra.
+ *
+ * Cada viñeta es una MINIATURA REALISTA del mundo al que abre el arco (registro
+ * visual: los mundos van realistas): el cafetal es una ladera con surcos y
+ * matas con granos; el páramo son frailejones de verdad en su pajonal; la
+ * sierra es una cresta nevada sobre su laguna. La persona SABE a dónde entra
+ * antes de tocar — sin íconos, sin caricatura.
+ *
+ * TÉCNICA (DR realismo-3d-vegetacion): cada viñeta se HORNEA en UNA geometría
+ * fusionada con vertexColors — fondo con gradiente de cielo propio, terreno con
+ * parches de ruido, y el motivo con variación determinista de color/escala/giro
+ * por elemento (nada de copias idénticas). 12 viñetas = 12 draw-calls estáticas:
+ * cero useFrame por viñeta (la vida de la vitrina va en el paisaje, no en un
+ * temblequeo de juguete).
+ *
+ * Contrato: la viñeta se ve desde +z, llena un círculo de radio ~0.72 en XY
+ * y ocupa z ∈ [-0.38, 0.08]. Corre headless (testeable sin WebGL).
+ */
+import * as THREE from 'three';
+import {
+  fusionar,
+  pintar,
+  pintarPorVertice,
+  poner,
+  variar,
+  ruido2D,
+  fbm1D,
+} from './miradorAndino.geom.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* Radio útil de la boca del arco. */
+const RADIO = 0.72;
+
+/* -------------------------------------------------------------------------- */
+/*  Piezas compartidas                                                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * El lienzo del círculo: cielo con gradiente vertical + media luna de suelo
+ * con parches de ruido + lomas de bruma opcionales. Devuelve PARTES (no
+ * fusiona): la viñeta las junta con su motivo en una sola geometría.
+ * @param {{cieloAlto:string, cieloBajo:string, suelo:string, sueloVar?:string, lomas?:string[]}} p
+ * @param {number} seed
+ */
+/** Sube saturación y baja apenas la luz: los pasteles puros se lavaban. */
+function conCuerpo(color, dS = 0.14, dL = -0.03) {
+  const c = new THREE.Color(color);
+  const hsl = { h: 0, s: 0, l: 0 };
+  c.getHSL(hsl);
+  c.setHSL(hsl.h, THREE.MathUtils.clamp(hsl.s + dS, 0, 1), THREE.MathUtils.clamp(hsl.l + dL, 0, 1));
+  return c;
+}
+
+function fondo(p, seed = 1) {
+  /** @type {THREE.BufferGeometry[]} */
+  const partes = [];
+  const alto = conCuerpo(p.cieloAlto);
+  const bajo = conCuerpo(p.cieloBajo, 0.12, -0.02);
+
+  const cielo = new THREE.CircleGeometry(RADIO + 0.05, 28);
+  pintarPorVertice(cielo, (_x, y) => {
+    const t = THREE.MathUtils.clamp((y + RADIO) / (2 * RADIO), 0, 1);
+    return bajo.clone().lerp(alto, Math.pow(t, 1.15));
+  });
+  poner(cielo, [0, 0, -0.37]);
+  partes.push(cielo);
+
+  // lomas lejanas fundidas al cielo (perspectiva atmosférica en miniatura)
+  (p.lomas || []).forEach((colorLoma, i) => {
+    const loma = new THREE.CircleGeometry(0.46 - i * 0.06, 16);
+    const c = new THREE.Color(colorLoma).lerp(bajo, 0.35 + i * 0.2);
+    pintar(loma, c);
+    poner(loma, [(i % 2 ? -1 : 1) * (0.16 + i * 0.1), -0.02 - i * 0.03, -0.362 + i * 0.004], [0, 0, 0], [1.25, 0.4 - i * 0.06, 1]);
+    partes.push(loma);
+  });
+
+  // media luna de suelo con parches (nunca un verde plano)
+  const suelo = new THREE.CircleGeometry(RADIO + 0.02, 26, Math.PI, Math.PI);
+  const base = conCuerpo(p.suelo, 0.12, -0.05);
+  const varTono = conCuerpo(p.sueloVar || p.suelo, 0.1, -0.02);
+  pintarPorVertice(suelo, (x, y) => {
+    const c = base.clone();
+    c.lerp(varTono, ruido2D(x * 7 + 3, y * 7, seed) * 0.55);
+    // el borde alto del suelo (horizonte) se aclara contra el cielo
+    c.lerp(bajo, THREE.MathUtils.clamp((y + 0.1) * 2.2, 0, 0.4));
+    return c;
+  });
+  poner(suelo, [0, 0, -0.35]);
+  partes.push(suelo);
+
+  return partes;
+}
+
+/**
+ * Arbolito realista en miniatura (DR: tronco cónico inclinado + copa de blobs
+ * IRREGULARES con huecos + gradiente de altura + color variado por blob).
+ * @param {ReturnType<typeof rng>} r
+ * @param {{x:number,y:number,z:number, s?:number, tronco?:string, copa?:string, copaClara?:string}} o
+ */
+function arbolito(r, o) {
+  /** @type {THREE.BufferGeometry[]} */
+  const partes = [];
+  const s = o.s ?? 1;
+  const tr = new THREE.CylinderGeometry(0.012 * s, 0.028 * s, 0.16 * s, 5);
+  poner(tr, [o.x, o.y + 0.07 * s, o.z], [0, 0, (r() - 0.5) * 0.24]);
+  pintar(tr, variar(o.tronco || '#6a5844', r, 0.1));
+  partes.push(tr);
+  const copa = new THREE.Color(o.copa || '#3f5a35');
+  const copaClara = new THREE.Color(o.copaClara || '#5c7a46');
+  const nBlobs = 4;
+  for (let i = 0; i < nBlobs; i++) {
+    const ang = r() * Math.PI * 2;
+    const rad = (0.02 + r() * 0.045) * s;
+    const alturaBlob = (0.15 + r() * 0.1) * s;
+    const blob = new THREE.IcosahedronGeometry((0.045 + r() * 0.035) * s, 0);
+    poner(
+      blob,
+      [o.x + Math.cos(ang) * rad, o.y + alturaBlob, o.z + Math.sin(ang) * rad * 0.5],
+      [r(), r(), r()],
+      [1, 0.75 + r() * 0.3, 1],
+    );
+    // gradiente de altura: blobs bajos más oscuros (AO fingido del DR)
+    const t = (alturaBlob / s - 0.15) / 0.1;
+    pintar(blob, copa.clone().lerp(copaClara, THREE.MathUtils.clamp(t, 0, 1) * (0.4 + r() * 0.4)));
+    partes.push(blob);
+  }
+  return partes;
+}
+
+/** Mata baja de blobs (arbusto/cultivo) con variación. */
+function mata(r, x, y, z, s, oscuro, claro, blobs = 3) {
+  /** @type {THREE.BufferGeometry[]} */
+  const partes = [];
+  const cOsc = new THREE.Color(oscuro);
+  const cCla = new THREE.Color(claro);
+  for (let i = 0; i < blobs; i++) {
+    const b = new THREE.IcosahedronGeometry((0.045 + r() * 0.03) * s, 0);
+    poner(
+      b,
+      [x + (r() - 0.5) * 0.09 * s, y + 0.03 * s + r() * 0.05 * s, z + (r() - 0.5) * 0.04],
+      [r(), r(), r()],
+      [1, 0.7 + r() * 0.35, 1],
+    );
+    pintar(b, cOsc.clone().lerp(cCla, r() * 0.55));
+    partes.push(b);
+  }
+  return partes;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LAS DOCE VIÑETAS                                                           */
+/* -------------------------------------------------------------------------- */
+
+/** 🏡 El valle: la casita campesina encalada en su loma, con su camino. */
+export function vinetaValle({ q = 1 } = {}, seed = 101) {
+  const r = rng(seed);
+  const partes = fondo(
+    { cieloAlto: '#9db8cc', cieloBajo: '#f0d8a4', suelo: '#5d7241', sueloVar: '#7d8c4e', lomas: ['#55704a', '#6a7d62'] },
+    seed,
+  );
+
+  // la loma de la casa
+  const loma = new THREE.SphereGeometry(0.34, 12, 8);
+  pintarPorVertice(loma, (x, y) => {
+    const c = new THREE.Color('#5d7241');
+    c.lerp(new THREE.Color('#8a9155'), ruido2D(x * 8, y * 8, seed) * 0.5 + Math.max(0, y) * 0.4);
+    return c;
+  });
+  poner(loma, [0.06, -0.32, -0.3], [0, 0, 0], [1.5, 0.62, 1]);
+  partes.push(loma);
+
+  // la casita: muros encalados, techo de teja a dos aguas, puerta y ventana
+  const cx = 0.1;
+  const cy = -0.1;
+  const muro = new THREE.BoxGeometry(0.3, 0.18, 0.2);
+  poner(muro, [cx, cy, -0.26]);
+  pintarPorVertice(muro, (_x, y) => new THREE.Color('#efe6d4').multiplyScalar(0.86 + (y - cy + 0.09) * 0.9));
+  partes.push(muro);
+  for (const lado of [-1, 1]) {
+    const agua = new THREE.BoxGeometry(0.2, 0.02, 0.24);
+    poner(agua, [cx + lado * 0.083, cy + 0.14, -0.26], [0, 0, lado * 0.6]);
+    pintar(agua, variar('#9a5a38', r, 0.08));
+    partes.push(agua);
+  }
+  const caballete = new THREE.CylinderGeometry(0.014, 0.014, 0.24, 4);
+  poner(caballete, [cx, cy + 0.185, -0.26], [Math.PI / 2, 0, 0]);
+  pintar(caballete, '#7a4530');
+  partes.push(caballete);
+  const puerta = new THREE.PlaneGeometry(0.055, 0.1);
+  poner(puerta, [cx - 0.05, cy - 0.04, -0.155]);
+  pintar(puerta, '#4a3520');
+  partes.push(puerta);
+  const ventana = new THREE.PlaneGeometry(0.05, 0.05);
+  poner(ventana, [cx + 0.07, cy - 0.01, -0.155]);
+  pintar(ventana, '#35506a');
+  partes.push(ventana);
+
+  // el camino de tierra que baja serpenteando (menos tramos en tier frugal)
+  for (let i = 0; i < Math.max(2, Math.round(4 * q)); i++) {
+    const tramo = new THREE.PlaneGeometry(0.075, 0.16);
+    poner(tramo, [cx - 0.1 - i * 0.07 + (i % 2) * 0.03, -0.26 - i * 0.09, -0.29 + i * 0.006], [0, 0, 0.5 + (i % 2) * 0.3]);
+    pintar(tramo, variar('#9a8054', r, 0.08));
+    partes.push(tramo);
+  }
+
+  // árboles que arropan la casa
+  partes.push(...arbolito(r, { x: -0.32, y: -0.3, z: -0.24, s: 1.35 }));
+  partes.push(...arbolito(r, { x: 0.44, y: -0.26, z: -0.26, s: 0.95, copa: '#4a6238' }));
+  return fusionar(partes, 'vinetaValle');
+}
+
+/** ☕ El café: la ladera con surcos, matas con granos rojos y su sombrío. */
+export function vinetaCafe({ q = 1 } = {}, seed = 102) {
+  const r = rng(seed);
+  const partes = fondo(
+    { cieloAlto: '#b8c8c2', cieloBajo: '#f2d8a2', suelo: '#6b5638', sueloVar: '#84643e', lomas: ['#4f6844'] },
+    seed,
+  );
+
+  // la ladera en diagonal con SURCOS horneados (bandas de tierra/verde)
+  const ladera = new THREE.PlaneGeometry(1.5, 0.72, 10, 8);
+  pintarPorVertice(ladera, (x, y) => {
+    const banda = Math.sin(y * 26 + x * 3);
+    const c = new THREE.Color('#7a5c38');
+    c.lerp(new THREE.Color('#55703f'), THREE.MathUtils.smoothstep(banda, -0.1, 0.6) * 0.7);
+    c.lerp(new THREE.Color('#8a6a42'), ruido2D(x * 6, y * 6, seed) * 0.3);
+    return c;
+  });
+  poner(ladera, [0, -0.18, -0.32], [0, 0, 0.34]);
+  partes.push(ladera);
+
+  // matas de café en surco: blobs oscuros lustrosos + granos rojos
+  const nMatas = Math.max(4, Math.round(6 * q));
+  for (let i = 0; i < nMatas; i++) {
+    const t = i / (nMatas - 1);
+    const x = -0.44 + t * 0.9 + (r() - 0.5) * 0.06;
+    const y = 0.08 - t * 0.44 + (r() - 0.5) * 0.04;
+    const s = 0.9 + r() * 0.45;
+    partes.push(...mata(r, x, y, -0.27, s, '#2c452a', '#446b36', 3));
+    // granos: racimos rojos y uno pintón (verde-amarillo)
+    const nG = 3;
+    for (let g = 0; g < nG; g++) {
+      const grano = new THREE.IcosahedronGeometry(0.014 + r() * 0.007, 0);
+      poner(grano, [x + (r() - 0.5) * 0.1 * s, y + 0.04 + r() * 0.06 * s, -0.22]);
+      pintar(grano, g === 2 && r() > 0.5 ? '#b8a03a' : variar('#a52c22', r, 0.15));
+      partes.push(grano);
+    }
+  }
+
+  // el guamo de sombrío: alto, copa ancha y rala
+  const tronco = new THREE.CylinderGeometry(0.016, 0.03, 0.42, 5);
+  poner(tronco, [-0.4, -0.02, -0.3], [0, 0, 0.12]);
+  pintar(tronco, '#6a5844');
+  partes.push(tronco);
+  for (let i = 0; i < 4; i++) {
+    const b = new THREE.IcosahedronGeometry(0.06 + r() * 0.05, 0);
+    poner(b, [-0.46 + i * 0.09 + (r() - 0.5) * 0.05, 0.22 + (r() - 0.5) * 0.08, -0.3], [r(), r(), r()], [1.25, 0.55, 1]);
+    pintar(b, variar('#4a6238', r, 0.14));
+    partes.push(b);
+  }
+
+  // el canasto recolector al pie
+  const canasto = new THREE.CylinderGeometry(0.055, 0.04, 0.07, 8, 1, true);
+  poner(canasto, [0.3, -0.5, -0.2]);
+  pintar(canasto, '#a9825a');
+  partes.push(canasto);
+  return fusionar(partes, 'vinetaCafe');
+}
+
+/** 💧 El agua: la quebrada de montaña bajando entre piedras. */
+export function vinetaAgua({ q = 1 } = {}, seed = 103) {
+  const r = rng(seed);
+  const partes = fondo(
+    { cieloAlto: '#a9c4cc', cieloBajo: '#e2e0c2', suelo: '#4c6238', sueloVar: '#5f7a44', lomas: ['#48604a'] },
+    seed,
+  );
+
+  // el cauce baja en S CONTINUA (una cinta, no esquirlas): franja construida
+  // punto a punto con centro hondo y orillas claras
+  {
+    const curso = [
+      [-0.34, 0.44], [-0.18, 0.24], [-0.02, 0.06], [0.14, -0.12], [0.18, -0.32], [0.1, -0.52], [-0.02, -0.66],
+    ];
+    const posiciones = [];
+    const colores = [];
+    const honda = new THREE.Color('#39616e');
+    const clara = new THREE.Color('#7fa8b2');
+    const colorOrilla = (t) => honda.clone().lerp(clara, Math.pow(Math.abs(t), 1.2));
+    for (let s = 0; s < curso.length - 1; s++) {
+      const [x0, y0] = curso[s];
+      const [x1, y1] = curso[s + 1];
+      // normal del tramo (perpendicular en el plano XY)
+      const dx = x1 - x0;
+      const dy = y1 - y0;
+      const L = Math.hypot(dx, dy) || 1;
+      const nx = (-dy / L) * 0.085;
+      const ny = (dx / L) * 0.085;
+      const z = -0.3;
+      // dos triángulos entre las orillas de este tramo
+      const v = [
+        [x0 - nx, y0 - ny, -1], [x0 + nx, y0 + ny, 1], [x1 - nx, y1 - ny, -1],
+        [x1 - nx, y1 - ny, -1], [x0 + nx, y0 + ny, 1], [x1 + nx, y1 + ny, 1],
+      ];
+      for (const [vx, vy, lado] of v) {
+        posiciones.push(vx, vy, z);
+        const c = colorOrilla(lado);
+        if (ruido2D(vx * 20, vy * 9, seed) > 0.82) c.lerp(new THREE.Color('#e4efe9'), 0.5);
+        colores.push(c.r, c.g, c.b);
+      }
+    }
+    const cinta = new THREE.BufferGeometry();
+    cinta.setAttribute('position', new THREE.BufferAttribute(new Float32Array(posiciones), 3));
+    cinta.setAttribute('color', new THREE.BufferAttribute(new Float32Array(colores), 3));
+    cinta.computeVertexNormals();
+    partes.push(cinta);
+  }
+
+  // piedras a la ORILLA del cauce (siguen el curso, no regadas al azar)
+  const orillaCurso = [
+    [-0.28, 0.3], [-0.06, 0.1], [0.22, -0.18], [0.24, -0.4], [0.02, -0.58],
+  ];
+  for (let i = 0; i < Math.min(orillaCurso.length, Math.max(3, Math.round(5 * q))); i++) {
+    const lado = i % 2 ? 1 : -1;
+    const [cx, cy] = orillaCurso[i];
+    const p = new THREE.DodecahedronGeometry(0.04 + r() * 0.04, 0);
+    poner(p, [cx + lado * 0.11, cy, -0.27], [r(), r() * 3, r()], [1, 0.75, 1]);
+    pintar(p, variar('#7d786c', r, 0.14));
+    partes.push(p);
+    const espuma = new THREE.IcosahedronGeometry(0.016, 0);
+    poner(espuma, [cx + lado * 0.07, cy - 0.02, -0.26], [0, 0, 0], [1.5, 0.5, 1]);
+    pintar(espuma, '#e4efe9');
+    partes.push(espuma);
+  }
+
+  // juncos de orilla
+  for (let i = 0; i < 5; i++) {
+    const lado = i % 2 ? 1 : -1;
+    const junco = new THREE.CylinderGeometry(0.005, 0.009, 0.2 + r() * 0.12, 4);
+    poner(junco, [lado * (0.3 + r() * 0.14), -0.24 - r() * 0.18, -0.25], [0, 0, (r() - 0.5) * 0.3]);
+    pintar(junco, variar('#5f7a44', r, 0.2));
+    partes.push(junco);
+  }
+  partes.push(...arbolito(r, { x: 0.42, y: -0.2, z: -0.3, s: 0.9, copa: '#3c5836' }));
+  return fusionar(partes, 'vinetaAgua');
+}
+
+/** 🐞 La sanidad: la hoja sana con su mariquita — control biológico. */
+export function vinetaSanidad({ q = 1 } = {}, seed = 104) {
+  const r = rng(seed);
+  const partes = fondo(
+    { cieloAlto: '#b4ccb2', cieloBajo: '#eee4b4', suelo: '#55703f', sueloVar: '#6d8448', lomas: [] },
+    seed,
+  );
+
+  // la mata vigilada (cultivo sano con frutos)
+  partes.push(...mata(r, -0.3, -0.3, -0.28, 1.8, '#375231', '#55793c', 4));
+  for (let i = 0; i < 3; i++) {
+    const fruto = new THREE.IcosahedronGeometry(0.022, 0);
+    poner(fruto, [-0.34 + r() * 0.14, -0.24 + r() * 0.12, -0.23]);
+    pintar(fruto, variar('#b03426', r, 0.1));
+    partes.push(fruto);
+  }
+
+  // LA HOJA protagonista con su vena central
+  const hoja = new THREE.CircleGeometry(0.3, 14);
+  pintarPorVertice(hoja, (x, y) => {
+    const c = new THREE.Color('#5c8a44');
+    c.lerp(new THREE.Color('#3f6234'), Math.abs(y) * 2 + ruido2D(x * 9, y * 9, seed) * 0.3);
+    if (Math.abs(y) < 0.016) c.set('#48703a');
+    return c;
+  });
+  poner(hoja, [0.14, 0.02, -0.26], [0, 0, 0.35], [1, 0.55, 1]);
+  partes.push(hoja);
+  const tallo = new THREE.CylinderGeometry(0.008, 0.012, 0.34, 4);
+  poner(tallo, [0.02, -0.26, -0.27], [0, 0, 0.45]);
+  pintar(tallo, '#48703a');
+  partes.push(tallo);
+
+  // la mariquita: élitros rojos partidos, puntos y cabeza negra
+  const mx = 0.18;
+  const my = 0.07;
+  const cuerpo = new THREE.SphereGeometry(0.05, 10, 7);
+  poner(cuerpo, [mx, my, -0.24], [0.3, 0, 0.35], [1.15, 0.7, 1]);
+  pintarPorVertice(cuerpo, (x) => (Math.abs(x - mx) < 0.004 ? new THREE.Color('#2a1c14') : new THREE.Color('#b8281c')));
+  partes.push(cuerpo);
+  const cabeza = new THREE.SphereGeometry(0.024, 8, 6);
+  poner(cabeza, [mx + 0.05, my + 0.008, -0.24]);
+  pintar(cabeza, '#241a12');
+  partes.push(cabeza);
+  for (const [px, py] of [[-0.022, 0.02], [0.012, -0.022], [-0.004, 0.035]]) {
+    const punto = new THREE.IcosahedronGeometry(0.009, 0);
+    poner(punto, [mx + px, my + py, -0.215]);
+    pintar(punto, '#241a12');
+    partes.push(punto);
+  }
+
+  // flores de acompañante (las que llaman a los benéficos)
+  for (let i = 0; i < Math.max(2, Math.round(3 * q)); i++) {
+    const fx = 0.4 + (r() - 0.5) * 0.14;
+    const fy = -0.34 - r() * 0.14;
+    const talloF = new THREE.CylinderGeometry(0.005, 0.007, 0.14, 4);
+    poner(talloF, [fx, fy, -0.27], [0, 0, (r() - 0.5) * 0.3]);
+    pintar(talloF, '#5f7a44');
+    partes.push(talloF);
+    const flor = new THREE.IcosahedronGeometry(0.022, 0);
+    poner(flor, [fx, fy + 0.08, -0.26], [0, 0, 0], [1.3, 0.6, 1]);
+    pintar(flor, i % 2 ? '#e8d968' : '#eeeadd');
+    partes.push(flor);
+  }
+  return fusionar(partes, 'vinetaSanidad');
+}
+
+/** 🧺 El mercado: el puesto de plaza con toldo y la cosecha en canastos. */
+export function vinetaMercado({ q = 1 } = {}, seed = 105) {
+  const r = rng(seed);
+  const partes = fondo(
+    { cieloAlto: '#b6c4c8', cieloBajo: '#f2dcae', suelo: '#9a8054', sueloVar: '#b09468', lomas: [] },
+    seed,
+  );
+
+  // postes de madera
+  for (const x of [-0.3, 0.3]) {
+    const poste = new THREE.CylinderGeometry(0.014, 0.018, 0.56, 5);
+    poner(poste, [x, -0.1, -0.28], [0, 0, (r() - 0.5) * 0.06]);
+    pintar(poste, variar('#7a5c3c', r, 0.12));
+    partes.push(poste);
+  }
+  // el toldo de lona con RAYAS horneadas y caída real (dos aguas suaves)
+  for (const lado of [-1, 1]) {
+    const lona = new THREE.PlaneGeometry(0.76, 0.17, 8, 2);
+    pintarPorVertice(lona, (x) => {
+      const raya = Math.sin(x * 42) > 0.15;
+      return new THREE.Color(raya ? '#c26136' : '#efe2c8');
+    });
+    poner(lona, [0, 0.245 + 0.02 * lado, -0.26 + lado * 0.055], [lado * 0.5 - 0.5, 0, 0]);
+    partes.push(lona);
+  }
+
+  // el mesón con su mantel
+  const meson = new THREE.BoxGeometry(0.62, 0.05, 0.2);
+  poner(meson, [0, -0.2, -0.24]);
+  pintar(meson, '#8a6a46');
+  partes.push(meson);
+
+  // canastos con la cosecha apilada (papa, tomate, aguacate)
+  const productos = ['#c8a03c', '#b03426', '#4c6238'];
+  for (let k = 0; k < 3; k++) {
+    const cx = -0.2 + k * 0.2;
+    const canasto = new THREE.CylinderGeometry(0.075, 0.055, 0.075, 9, 1, true);
+    poner(canasto, [cx, -0.14, -0.22]);
+    pintar(canasto, variar('#a9825a', r, 0.1));
+    partes.push(canasto);
+    for (let i = 0; i < Math.max(3, Math.round(4 * q)); i++) {
+      const fruto = new THREE.IcosahedronGeometry(0.02 + r() * 0.008, 0);
+      poner(fruto, [cx + (r() - 0.5) * 0.08, -0.1 + r() * 0.025, -0.21 + (r() - 0.5) * 0.03]);
+      pintar(fruto, variar(productos[k], r, 0.12));
+      partes.push(fruto);
+    }
+  }
+  // bultos al pie del puesto
+  for (const [bx, by] of [[-0.4, -0.42], [0.42, -0.44]]) {
+    const bulto = new THREE.SphereGeometry(0.07, 8, 6);
+    poner(bulto, [bx, by, -0.24], [0, 0, 0], [1, 1.15, 0.9]);
+    pintar(bulto, variar('#cbb489', r, 0.1));
+    partes.push(bulto);
+  }
+  return fusionar(partes, 'vinetaMercado');
+}
+
+/** 🐔 Los animales: la gallina campesina picoteando junto a su cerca. */
+export function vinetaAnimales({ q = 1 } = {}, seed = 106) {
+  const r = rng(seed);
+  const partes = fondo(
+    { cieloAlto: '#b3c6c0', cieloBajo: '#f0dcae', suelo: '#8a7248', sueloVar: '#a08a58', lomas: ['#55704a'] },
+    seed,
+  );
+
+  // la cerca rústica (postes torcidos + dos largueros)
+  for (const x of [-0.4, -0.02, 0.38]) {
+    const poste = new THREE.CylinderGeometry(0.014, 0.02, 0.34, 5);
+    poner(poste, [x + (r() - 0.5) * 0.03, 0.02, -0.3], [0, 0, (r() - 0.5) * 0.16]);
+    pintar(poste, variar('#6a5238', r, 0.14));
+    partes.push(poste);
+  }
+  for (const y of [0.1, -0.04]) {
+    const larguero = new THREE.CylinderGeometry(0.011, 0.011, 0.92, 4);
+    poner(larguero, [0, y, -0.29], [0, 0, Math.PI / 2 + (r() - 0.5) * 0.05]);
+    pintar(larguero, variar('#7a5c3c', r, 0.1));
+    partes.push(larguero);
+  }
+
+  // la gallina: cuerpo criollo pardo, cola, ala, cabeza con cresta
+  const gx = -0.12;
+  const gy = -0.26;
+  const cuerpo = new THREE.SphereGeometry(0.1, 10, 8);
+  poner(cuerpo, [gx, gy, -0.24], [0, 0, 0.14], [1.3, 0.92, 1]);
+  pintarPorVertice(cuerpo, (x, y) => {
+    const c = new THREE.Color('#8a5c38');
+    c.lerp(new THREE.Color('#c8a888'), THREE.MathUtils.clamp((y - gy) * 6 + 0.3, 0, 0.7));
+    c.lerp(new THREE.Color('#5a3c26'), ruido2D(x * 30, y * 30, seed) * 0.35);
+    return c;
+  });
+  partes.push(cuerpo);
+  const cola = new THREE.ConeGeometry(0.045, 0.12, 6);
+  poner(cola, [gx - 0.12, gy + 0.07, -0.24], [0, 0, 2.2], [1, 1, 0.5]);
+  pintar(cola, '#4a3020');
+  partes.push(cola);
+  const cabeza = new THREE.SphereGeometry(0.042, 8, 6);
+  poner(cabeza, [gx + 0.12, gy + 0.1, -0.24]);
+  pintar(cabeza, '#9a6a42');
+  partes.push(cabeza);
+  const cresta = new THREE.ConeGeometry(0.016, 0.035, 4);
+  poner(cresta, [gx + 0.12, gy + 0.15, -0.24]);
+  pintar(cresta, '#b8281c');
+  partes.push(cresta);
+  const pico = new THREE.ConeGeometry(0.012, 0.035, 4);
+  poner(pico, [gx + 0.165, gy + 0.09, -0.24], [0, 0, -Math.PI / 2]);
+  pintar(pico, '#d8a83c');
+  partes.push(pico);
+
+  // pollitos
+  for (let i = 0; i < 2; i++) {
+    const px = 0.16 + i * 0.14 + (r() - 0.5) * 0.04;
+    const cuerpoP = new THREE.SphereGeometry(0.032, 7, 5);
+    poner(cuerpoP, [px, -0.34, -0.22]);
+    pintar(cuerpoP, variar('#d8bc5c', r, 0.1));
+    partes.push(cuerpoP);
+    const cabezaP = new THREE.SphereGeometry(0.02, 6, 5);
+    poner(cabezaP, [px + 0.02, -0.3, -0.22]);
+    pintar(cabezaP, variar('#e0c868', r, 0.1));
+    partes.push(cabezaP);
+  }
+  // maíz regado
+  for (let i = 0; i < Math.max(3, Math.round(5 * q)); i++) {
+    const grano = new THREE.IcosahedronGeometry(0.008, 0);
+    poner(grano, [(r() - 0.5) * 0.5, -0.42 - r() * 0.12, -0.22]);
+    pintar(grano, '#d8b23c');
+    partes.push(grano);
+  }
+  return fusionar(partes, 'vinetaAnimales');
+}
+
+/** 🌱 El semillero: camas de guadua con brotes en oleada y su túnel. */
+export function vinetaSemillero({ q = 1 } = {}, seed = 107) {
+  const r = rng(seed);
+  const partes = fondo(
+    { cieloAlto: '#b8ccb8', cieloBajo: '#eee6bc', suelo: '#6b5638', sueloVar: '#84643e', lomas: [] },
+    seed,
+  );
+
+  const filas = [
+    { y: -0.14, z: -0.3, ancho: 0.72 },
+    { y: -0.36, z: -0.24, ancho: 0.92 },
+  ];
+  filas.forEach((f, fi) => {
+    // marco de guadua
+    const marco = new THREE.BoxGeometry(f.ancho, 0.05, 0.12);
+    poner(marco, [0, f.y - 0.045, f.z]);
+    pintar(marco, variar('#a09048', r, 0.08));
+    partes.push(marco);
+    // tierra oscura y húmeda
+    const cama = new THREE.BoxGeometry(f.ancho - 0.05, 0.03, 0.1);
+    poner(cama, [0, f.y - 0.02, f.z + 0.004]);
+    pintarPorVertice(cama, (x, y) => new THREE.Color('#3f3222').lerp(new THREE.Color('#5a4830'), ruido2D(x * 20, y * 9, seed + fi) * 0.6));
+    partes.push(cama);
+    // brotes: cotiledones en tamaños escalonados (la oleada, horneada)
+    const nB = Math.max(4, Math.round(7 * q));
+    for (let i = 0; i < nB; i++) {
+      const bx = -f.ancho / 2 + 0.08 + (i / (nB - 1)) * (f.ancho - 0.16);
+      const s = 0.5 + ((i * 2.7 + fi) % 3) * 0.3 + r() * 0.2;
+      const talloB = new THREE.CylinderGeometry(0.004, 0.005, 0.045 * s, 4);
+      poner(talloB, [bx, f.y + 0.02 * s, f.z + 0.01]);
+      pintar(talloB, '#7a9a4c');
+      partes.push(talloB);
+      for (const lado of [-1, 1]) {
+        const cot = new THREE.IcosahedronGeometry(0.013 * s, 0);
+        poner(cot, [bx + lado * 0.014 * s, f.y + 0.045 * s, f.z + 0.01], [0, 0, 0], [1.4, 0.5, 0.8]);
+        pintar(cot, variar('#8ab04e', r, 0.12));
+        partes.push(cot);
+      }
+    }
+  });
+
+  // los arcos del túnel de propagación
+  for (const dz of [0, 0.05]) {
+    const arco = new THREE.TorusGeometry(0.4 + dz * 1.6, 0.011, 4, 12, Math.PI);
+    poner(arco, [0, -0.12, -0.32 + dz]);
+    pintar(arco, '#d8d2be');
+    partes.push(arco);
+  }
+  // la regadera de lata
+  const cuerpoR = new THREE.CylinderGeometry(0.05, 0.055, 0.09, 8);
+  poner(cuerpoR, [0.44, -0.5, -0.22]);
+  pintar(cuerpoR, '#8a9498');
+  partes.push(cuerpoR);
+  const picoR = new THREE.CylinderGeometry(0.008, 0.012, 0.12, 4);
+  poner(picoR, [0.36, -0.48, -0.22], [0, 0, 1.1]);
+  pintar(picoR, '#7a8488');
+  partes.push(picoR);
+  return fusionar(partes, 'vinetaSemillero');
+}
+
+/** 🪱 El suelo vivo: el perfil con sus horizontes, raíces y la lombriz. */
+export function vinetaSuelo({ q = 1 } = {}, seed = 108) {
+  const r = rng(seed);
+  /** @type {THREE.BufferGeometry[]} */
+  const partes = [];
+  // cielo apenas visible arriba
+  const cielo = new THREE.CircleGeometry(RADIO + 0.05, 26);
+  pintarPorVertice(cielo, (_x, y) => new THREE.Color('#e0d5ac').lerp(new THREE.Color('#b0c4c0'), THREE.MathUtils.clamp((y + 0.2) * 2, 0, 1)));
+  poner(cielo, [0, 0, -0.37]);
+  partes.push(cielo);
+
+  // EL PERFIL: horizontes horneados (humus → tierra parda → arcilla → roca)
+  const perfil = new THREE.PlaneGeometry(1.5, 1.1, 12, 16);
+  pintarPorVertice(perfil, (x, y) => {
+    const nivel = y + (ruido2D(x * 4, 7, seed) - 0.5) * 0.08; // horizontes ondulados
+    let c;
+    if (nivel > 0.28) c = new THREE.Color('#2e2418'); // humus negro
+    else if (nivel > 0.02) c = new THREE.Color('#4a3826');
+    else if (nivel > -0.3) c = new THREE.Color('#6b4c2e');
+    else c = new THREE.Color('#7d6a52'); // saprolito
+    c.lerp(new THREE.Color('#8a6a42'), ruido2D(x * 14, y * 14, seed + 3) * 0.25);
+    return c;
+  });
+  poner(perfil, [0, -0.22, -0.34]);
+  partes.push(perfil);
+
+  // la franja de pasto vivo arriba, con sus macollas
+  const franja = new THREE.PlaneGeometry(1.5, 0.09, 8, 1);
+  pintarPorVertice(franja, (x) => new THREE.Color('#55703f').lerp(new THREE.Color('#7d8c4e'), ruido2D(x * 12, 3, seed) * 0.6));
+  poner(franja, [0, 0.155, -0.33]);
+  partes.push(franja);
+  for (let i = 0; i < Math.max(5, Math.round(8 * q)); i++) {
+    const x = -0.55 + (i / 7) * 1.1 + (r() - 0.5) * 0.05;
+    const macolla = new THREE.ConeGeometry(0.02, 0.09 + r() * 0.05, 4);
+    poner(macolla, [x, 0.23, -0.32], [0, 0, (r() - 0.5) * 0.4]);
+    pintar(macolla, variar('#6d8448', r, 0.18));
+    partes.push(macolla);
+  }
+
+  // raíces que bajan ramificándose
+  for (const rx of [-0.3, 0.04, 0.36]) {
+    const raiz = new THREE.CylinderGeometry(0.006, 0.016, 0.34, 4);
+    poner(raiz, [rx, 0.0, -0.3], [0, 0, (r() - 0.5) * 0.3]);
+    pintar(raiz, '#c8b48e');
+    partes.push(raiz);
+    for (const lado of [-1, 1]) {
+      const pelo = new THREE.CylinderGeometry(0.003, 0.007, 0.16, 3);
+      poner(pelo, [rx + lado * 0.05, -0.2 - r() * 0.06, -0.3], [0, 0, lado * (0.5 + r() * 0.3)]);
+      pintar(pelo, '#b8a480');
+      partes.push(pelo);
+    }
+  }
+
+  // LA LOMBRIZ: segmentos en arco con clitelo más claro
+  for (let i = 0; i < 5; i++) {
+    const t = i / 4;
+    const seg = new THREE.SphereGeometry(i === 4 ? 0.024 : 0.03, 7, 5);
+    poner(seg, [-0.14 + t * 0.32, -0.3 + Math.sin(t * Math.PI) * 0.05, -0.26]);
+    pintar(seg, i === 2 ? '#d8a090' : variar('#b06a6a', r, 0.08));
+    partes.push(seg);
+  }
+  // piedras y poros
+  for (let i = 0; i < 4; i++) {
+    const p = new THREE.DodecahedronGeometry(0.02 + r() * 0.025, 0);
+    poner(p, [(r() - 0.5) * 1.0, -0.16 - r() * 0.4, -0.28], [r(), r(), r()]);
+    pintar(p, variar('#7d786c', r, 0.15));
+    partes.push(p);
+  }
+  return fusionar(partes, 'vinetaSuelo');
+}
+
+/** 🏔️ La Sierra: crestas nevadas de verdad sobre su laguna sagrada. */
+export function vinetaSierra({ q = 1 } = {}, seed = 109) {
+  const r = rng(seed);
+  const partes = fondo(
+    { cieloAlto: '#8fb0c8', cieloBajo: '#e8ddba', suelo: '#5c7048', sueloVar: '#748452', lomas: [] },
+    seed,
+  );
+
+  // DOS crestas fractales (la técnica de las cordilleras, en miniatura)
+  const capas = [
+    { y0: -0.12, hMax: 0.5, color: '#46545e', nieve: 0.55, z: -0.34, seedC: 1 },
+    { y0: -0.16, hMax: 0.34, color: '#39493c', nieve: 0.82, z: -0.32, seedC: 2 },
+  ];
+  for (const capa of capas) {
+    const N = 22;
+    const posiciones = [];
+    const colores = [];
+    const base = new THREE.Color(capa.color);
+    const nieve = new THREE.Color('#f2f1e8');
+    for (let i = 0; i < N; i++) {
+      const t0 = i / N;
+      const t1 = (i + 1) / N;
+      const h = (t) => capa.y0 + Math.pow(fbm1D(t * 5.5, seed + capa.seedC * 13), 1.5) * capa.hMax;
+      const X = (t) => -0.66 + t * 1.32;
+      const h0 = h(t0);
+      const h1 = h(t1);
+      posiciones.push(X(t0), capa.y0 - 0.3, capa.z, X(t1), capa.y0 - 0.3, capa.z, X(t0), h0, capa.z);
+      posiciones.push(X(t0), h0, capa.z, X(t1), capa.y0 - 0.3, capa.z, X(t1), h1, capa.z);
+      const colorEn = (y) => {
+        const c = base.clone();
+        const sn = capa.y0 + capa.hMax * capa.nieve;
+        if (y > sn) c.lerp(nieve, THREE.MathUtils.clamp((y - sn) / 0.1, 0, 1));
+        return c;
+      };
+      [capa.y0 - 0.3, capa.y0 - 0.3, h0, h0, capa.y0 - 0.3, h1].forEach((y) => {
+        const c = colorEn(y);
+        colores.push(c.r, c.g, c.b);
+      });
+    }
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.BufferAttribute(new Float32Array(posiciones), 3));
+    g.setAttribute('color', new THREE.BufferAttribute(new Float32Array(colores), 3));
+    g.computeVertexNormals();
+    partes.push(g);
+  }
+
+  // la laguna: espejo del cielo con orilla clara
+  const laguna = new THREE.CircleGeometry(0.4, 18);
+  pintarPorVertice(laguna, (_x, y) => new THREE.Color('#7fb0bd').lerp(new THREE.Color('#cfe0da'), THREE.MathUtils.clamp(-y * 2.4, 0, 0.8)));
+  poner(laguna, [0, -0.44, -0.3], [0, 0, 0], [1.15, 0.4, 1]);
+  partes.push(laguna);
+
+  // frailejones chiquitos de orilla + piedras (uno solo en tier frugal)
+  for (const [fx, fy] of (q < 0.8 ? [[-0.42, -0.3]] : [[-0.42, -0.3], [0.44, -0.34]])) {
+    const talloF = new THREE.CylinderGeometry(0.014, 0.018, 0.07, 5);
+    poner(talloF, [fx, fy, -0.27]);
+    pintar(talloF, '#6f5c40');
+    partes.push(talloF);
+    for (let i = 0; i < 5; i++) {
+      const ang = (i / 5) * Math.PI * 2;
+      const hoja = new THREE.ConeGeometry(0.012, 0.06, 4);
+      poner(hoja, [fx + Math.cos(ang) * 0.016, fy + 0.05, -0.27 + Math.sin(ang) * 0.008], [Math.PI / 3.2 * Math.sin(ang), 0, -Math.PI / 3.2 * Math.cos(ang)]);
+      pintar(hoja, variar('#b9c39c', r, 0.08));
+      partes.push(hoja);
+    }
+  }
+  for (let i = 0; i < 3; i++) {
+    const p = new THREE.DodecahedronGeometry(0.03 + r() * 0.03, 0);
+    poner(p, [(r() - 0.5) * 0.7, -0.5 - r() * 0.08, -0.26], [r(), r(), r()]);
+    pintar(p, variar('#7d786c', r, 0.12));
+    partes.push(p);
+  }
+  return fusionar(partes, 'vinetaSierra');
+}
+
+/** 🌫️ El páramo: frailejones en su pajonal, bruma horneada en el fondo. */
+export function vinetaParamo({ q = 1 } = {}, seed = 110) {
+  const r = rng(seed);
+  const partes = fondo(
+    { cieloAlto: '#b9c6c4', cieloBajo: '#dfe2d2', suelo: '#6d7a4c', sueloVar: '#8a915c', lomas: ['#7d8a74', '#95a08e'] },
+    seed,
+  );
+
+  // pajonal: macollas de paja amarillo-verde por todo el suelo
+  for (let i = 0; i < Math.max(6, Math.round(10 * q)); i++) {
+    const x = (r() - 0.5) * 1.1;
+    const y = -0.2 - r() * 0.34;
+    const macolla = new THREE.ConeGeometry(0.022, 0.1 + r() * 0.07, 4);
+    poner(macolla, [x, y, -0.29], [0, 0, (r() - 0.5) * 0.5]);
+    pintar(macolla, variar('#a3a35c', r, 0.2));
+    partes.push(macolla);
+  }
+
+  // TRES frailejones con enagua y roseta plateada (el ícono, de verdad)
+  const puestos = [
+    { x: -0.26, y: -0.18, s: 1.25 },
+    { x: 0.22, y: -0.32, s: 1.0 },
+    { x: 0.44, y: -0.1, s: 0.7 },
+  ];
+  for (const pu of puestos) {
+    const s = pu.s;
+    const tallo = new THREE.CylinderGeometry(0.02 * s, 0.026 * s, 0.16 * s, 6);
+    poner(tallo, [pu.x, pu.y, -0.27]);
+    pintar(tallo, '#6f5c40');
+    partes.push(tallo);
+    // enagua de hojas muertas colgando
+    for (let i = 0; i < 7; i++) {
+      const ang = (i / 7) * Math.PI * 2;
+      const hoja = new THREE.ConeGeometry(0.012 * s, 0.07 * s, 4);
+      poner(
+        hoja,
+        [pu.x + Math.cos(ang) * 0.024 * s, pu.y - 0.01, -0.27 + Math.sin(ang) * 0.012 * s],
+        [2.4 * Math.sin(ang), 0, -2.4 * Math.cos(ang)],
+      );
+      pintar(hoja, variar('#8a7350', r, 0.14));
+      partes.push(hoja);
+    }
+    // roseta plateada en espiral
+    const GOLDEN = Math.PI * (3 - Math.sqrt(5));
+    for (let i = 0; i < 9; i++) {
+      const ang = i * GOLDEN;
+      const tilt = 0.7 + (i / 9) * 0.5;
+      const hoja = new THREE.ConeGeometry(0.013 * s, 0.09 * s, 4);
+      poner(
+        hoja,
+        [pu.x, pu.y + 0.09 * s, -0.27],
+        [Math.sin(tilt) * Math.sin(ang), 0, -Math.sin(tilt) * Math.cos(ang)],
+      );
+      pintar(hoja, variar('#bcc6ac', r, 0.08));
+      partes.push(hoja);
+    }
+    const corazon = new THREE.IcosahedronGeometry(0.022 * s, 0);
+    poner(corazon, [pu.x, pu.y + 0.1 * s, -0.27], [0, 0, 0], [1, 0.7, 1]);
+    pintar(corazon, '#cfd7c6');
+    partes.push(corazon);
+  }
+
+  // rocas con líquen
+  for (let i = 0; i < 3; i++) {
+    const roca = new THREE.DodecahedronGeometry(0.035 + r() * 0.03, 0);
+    poner(roca, [(r() - 0.5) * 0.9, -0.44 - r() * 0.1, -0.26], [r(), r(), r()], [1, 0.7, 1]);
+    pintarPorVertice(roca, (x, y) => {
+      const c = variar('#7d786c', r, 0.06);
+      if (ruido2D(x * 30, y * 30, seed + i) > 0.75) c.lerp(new THREE.Color('#9aa86a'), 0.5);
+      return c;
+    });
+    partes.push(roca);
+  }
+  return fusionar(partes, 'vinetaParamo');
+}
+
+/** 🌧️ La lluvia: el aguacero de tarde con su nube madre y la cortina. */
+export function vinetaLluvia({ q = 1 } = {}, seed = 111) {
+  const r = rng(seed);
+  const partes = fondo(
+    { cieloAlto: '#8a97a2', cieloBajo: '#b8bfba', suelo: '#465f35', sueloVar: '#587244', lomas: ['#5f6d64'] },
+    seed,
+  );
+
+  // la nube madre: cúmulos grises con panza oscura (gradiente horneado)
+  const blobs = [
+    [-0.26, 0.3, 0.16], [-0.04, 0.36, 0.19], [0.2, 0.31, 0.16], [0.4, 0.28, 0.11], [-0.42, 0.27, 0.1],
+  ];
+  for (const [bx, by, br] of blobs) {
+    const nube = new THREE.SphereGeometry(br, 9, 7);
+    poner(nube, [bx, by, -0.3], [r(), r(), r()], [1.2, 0.72, 1]);
+    pintarPorVertice(nube, (_x, y) => new THREE.Color('#6d7880').lerp(new THREE.Color('#c8cfd2'), THREE.MathUtils.clamp((y - by + br) / (br * 1.6), 0, 1)));
+    partes.push(nube);
+  }
+
+  // la CORTINA de agua: hilos finos ladeados por el viento
+  const nGotas = Math.max(9, Math.round(15 * q));
+  for (let i = 0; i < nGotas; i++) {
+    const x = -0.5 + (i / (nGotas - 1)) * 1.0 + (r() - 0.5) * 0.05;
+    const y = 0.12 - r() * 0.5;
+    const hilo = new THREE.CylinderGeometry(0.0035, 0.0035, 0.1 + r() * 0.08, 3);
+    poner(hilo, [x, y, -0.26], [0, 0, 0.16 + (r() - 0.5) * 0.05]);
+    pintar(hilo, variar('#b8cdd6', r, 0.1));
+    partes.push(hilo);
+  }
+
+  // el charco que recibe (espejo del cielo gris) y su mata agradecida
+  const charco = new THREE.CircleGeometry(0.24, 14);
+  pintarPorVertice(charco, (_x, y) => new THREE.Color('#98acb2').lerp(new THREE.Color('#c8d4d6'), THREE.MathUtils.clamp(-y * 3, 0, 0.8)));
+  poner(charco, [0.12, -0.48, -0.3], [0, 0, 0], [1.3, 0.4, 1]);
+  partes.push(charco);
+  partes.push(...mata(r, -0.3, -0.44, -0.26, 1.5, '#375231', '#55793c', 3));
+  return fusionar(partes, 'vinetaLluvia');
+}
+
+/** 🍂 El compost: la pila caliente por capas con su horqueta clavada. */
+export function vinetaCompost({ q = 1 } = {}, seed = 112) {
+  const r = rng(seed);
+  const partes = fondo(
+    { cieloAlto: '#b6c2b8', cieloBajo: '#eadfb6', suelo: '#6b5638', sueloVar: '#84643e', lomas: [] },
+    seed,
+  );
+
+  // la pila por capas (tierra madura → verde fresco → hojarasca)
+  const capas = [
+    { y: -0.4, rad: 0.4, alto: 0.18, color: '#3f3222', varC: '#54462e' },
+    { y: -0.28, rad: 0.3, alto: 0.15, color: '#4c5c2c', varC: '#65783a' },
+    { y: -0.17, rad: 0.2, alto: 0.13, color: '#7a5c34', varC: '#9a7a44' },
+  ];
+  for (const capa of capas) {
+    const cono = new THREE.ConeGeometry(capa.rad, capa.alto, 12);
+    pintarPorVertice(cono, (x, y) => new THREE.Color(capa.color).lerp(new THREE.Color(capa.varC), ruido2D(x * 16, y * 16, seed) * 0.7));
+    poner(cono, [0, capa.y, -0.28]);
+    partes.push(cono);
+  }
+  // hojarasca y tamo regados en la pila
+  for (let i = 0; i < Math.max(6, Math.round(10 * q)); i++) {
+    const hoja = new THREE.PlaneGeometry(0.03 + r() * 0.02, 0.016);
+    const ang = r() * Math.PI * 2;
+    const rad = r() * 0.32;
+    poner(hoja, [Math.cos(ang) * rad, -0.38 + r() * 0.3 - rad * 0.3, -0.25], [r() * 2, r() * 2, r() * 2]);
+    pintar(hoja, variar(r() > 0.5 ? '#a3763a' : '#b8a04c', r, 0.15));
+    partes.push(hoja);
+  }
+
+  // la horqueta clavada
+  const mango = new THREE.CylinderGeometry(0.01, 0.01, 0.4, 5);
+  poner(mango, [-0.36, -0.22, -0.26], [0, 0, 0.35]);
+  pintar(mango, '#8a6a46');
+  partes.push(mango);
+  for (let i = 0; i < 3; i++) {
+    const diente = new THREE.CylinderGeometry(0.004, 0.006, 0.1, 3);
+    poner(diente, [-0.44 - i * 0.018 + 0.02, -0.4 - i * 0.004, -0.26], [0, 0, 0.5]);
+    pintar(diente, '#6d7880');
+    partes.push(diente);
+  }
+  // la carretilla de tierra lista al lado
+  const balde = new THREE.BoxGeometry(0.14, 0.06, 0.1);
+  poner(balde, [0.42, -0.46, -0.24], [0, 0.3, 0]);
+  pintar(balde, '#7a4530');
+  partes.push(balde);
+  const tierraLista = new THREE.SphereGeometry(0.05, 7, 5);
+  poner(tierraLista, [0.42, -0.42, -0.24], [0, 0, 0], [1.3, 0.5, 1]);
+  pintar(tierraLista, '#3f3222');
+  partes.push(tierraLista);
+  return fusionar(partes, 'vinetaCompost');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Registro                                                                   */
+/* -------------------------------------------------------------------------- */
+
+/** Viñeta por id de mundo (data-driven, mismo espíritu del route-registry). */
+export const VINETAS_GEOM = {
+  valle: vinetaValle,
+  cafe: vinetaCafe,
+  agua: vinetaAgua,
+  sanidad: vinetaSanidad,
+  mercado: vinetaMercado,
+  animales: vinetaAnimales,
+  semillero: vinetaSemillero,
+  suelo: vinetaSuelo,
+  sierra: vinetaSierra,
+  paramo: vinetaParamo,
+  lluvia: vinetaLluvia,
+  compost: vinetaCompost,
+};
+
+/**
+ * Construye la geometría de la viñeta de un mundo. Truena si el id no existe:
+ * un portal sin viñeta es un bug de datos, no un caso silencioso.
+ * @param {string} id
+ * @param {{q?: number}} [opts]
+ */
+export function geomVineta(id, opts = {}) {
+  const fn = VINETAS_GEOM[id];
+  if (!fn) throw new Error(`vinetasMundos: no hay viñeta para el mundo "${id}"`);
+  return fn(opts);
+}


### PR DESCRIPTION
## Reinvención completa de `vitrina_maestra` → El mirador de los mundos

**Feedback (2026-07-14):** *"¿Es 2D? Está feíta, bien feíta, merece una reinvención completa. Lo único que sirve son los efectos de entrada."*

### Qué debe ser (la decisión de diseño)

La vitrina es la **puerta maestra a los 12 mundos** — lo primero que ve el campesino. La definí como un **mirador andino realista a la hora dorada**: un lugar de la cordillera desde donde los doce mundos se ven como ventanas de piedra seca sembradas en el paisaje, cada una con un diorama realista del mundo al que abre. No botones sobre un fondo: un lugar al que dan ganas de entrar.

**Registro visual:** los mundos van REALISTAS (la sierra cayó por caricatura — esta pieza aplica la lección). Los personajes rubber-hose quedan donde corresponde: en el chrome DOM (avatar central, picada del cruce, fauna ambiental, el Ent) y nunca dentro del paisaje.

### Lo conservado (lo único aprobado)

- El **viaje Odyssey** de cámara: dolly a la boca con FOV 46→15 en curva k² (succión), regreso en √k (bocanada). `CamaraVitrina` intacta.
- El **iris** del `TransicionMundoKit` con su contrato `onMitad` (swap bajo el velo, máx un Canvas vivo).
- La **picada del avatar** al centro del portal.
- La máquina de fases `galeria → acercando → mundo → saliendo`.

### Lo reinventado (aplicando el DR realismo-3d-vegetacion 2026-06-19)

| Antes | Ahora |
|---|---|
| Fondo de color plano | **Domo de cielo** con gradiente horneado (horizonte ámbar → cénit azul) |
| Lomas de esfera | **Crestas fbm** en 3 planos con perspectiva atmosférica horneada + nieve lejana |
| Disco verde de cancha | **Pradera continua** ondulada por ruido, parches de color por vértice, plaza pisada, sendero de lajas |
| Cintas azul piscina rotas | **Quebrada** cinta continua: centro hondo, orillas con reflejo, destellos que viajan |
| Conos "árbol de navidad" | **Especies reales** del bosque altoandino (roble, aliso, gaque, encenillo) instanciadas con giro/escala/tinte por instancia, en bosquetes con especie dominante |
| Toros perfectos de parque temático | **Arcos de piedra seca campesina**: dovelas con jitter, AO radial horneado, musgo, umbral de laja — un `InstancedMesh` para los 12 |
| 12 viñetas caricatura con 12 `useFrame` | **12 dioramas realistas horneados** en UNA geometría por mundo — estáticos, 12 draw-calls, CERO loops por viñeta |

Técnica: todo procedural, cero assets/texturas/GLTF, `vertexColors` horneado, patrón `*.geom.js` headless (`src/visual/mundo3d/vitrina/`). Gama baja primero: tier `medio` recorta detalle (q) y cantidades; tier `bajo` NI monta el Canvas (rejilla DOM digna). Portrait adapta la pose de galería (FOV 58 + cámara atrás) para encuadrar el arco completo.

### Dos bugs reales cazados en la verificación

1. **`mergeGeometries` null silencioso (3ª mordida):** icosaedros/dodecaedros vienen sin índice y al fusionarlos con conos/cilindros el merge devuelve `null` sin error → **6 especies del páramo (frailejón, roble, encenillo, aliso, gaque, romerillo) estaban INVISIBLES en `bosque_vivo` hoy**. `fusionar()` ahora desindexa antes y TRUENA si falla. Test de regresión incluido.
2. **Cruce a mundos roto (heredado):** `lazy(() => imp().then(m => m.default || m))` resuelve al componente pelado; React 19 exige `{ default }` → **todo cruce tronaba** con "Lazy element type must resolve to a class or function". Corregido y verificado con viaje redondo real.

### Verificación (síncrona, empírica)

- `npm run build` OK · `npm run tsc:check` **0 errores** · eslint limpio
- 30 tests headless nuevos (`vitrina.geom.test.js`): fusión segura, ruido determinista, contrato de las 12 viñetas (existencia, color horneado, encaje en la boca del arco, tiers), regresión anti-null de las 8 especies.
- **Screenshots reales** (Chromium sistema + swiftshader): antes/después en desktop y phone, tier bajo emulado (4 núcleos → rejilla DOM con 12 tarjetas, sin Canvas), y **viaje redondo completo** galería → dolly → iris → mundo del valle montado → volver → galería. Fotos enviadas por tg-send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
