### PR TITLE
feat(creatures): los 8 bichos al nivel de Angelita — idle-cerebro, ritmo propio y mirada

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-prod
 dist-ssr
 *.local
 

--- a/scripts/diag/captura-bichos-shot.mjs
+++ b/scripts/diag/captura-bichos-shot.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/*
+ * captura-bichos-shot — toma la SECUENCIA de capturas de movimiento del arnés
+ * captura-bichos.html (diagnóstico de la vida de los 9 rubber-hose).
+ * Requiere `npm run dev` corriendo. Chromium del sistema (NixOS) + playwright.
+ *
+ * Uso: node scripts/diag/captura-bichos-shot.mjs <dirSalida> [prefijo] [baseUrl]
+ * Saca: <prefijo>-t02s.png, -t12s.png, -t22s.png, -t32s.png (página completa).
+ */
+import { mkdirSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { chromium } from 'playwright';
+
+const [dir = './capturas-bichos', prefijo = 'bichos', base = 'http://127.0.0.1:5173'] = process.argv.slice(2);
+mkdirSync(dir, { recursive: true });
+
+function chromiumPath() {
+  if (process.env.PLAYWRIGHT_CHROMIUM_PATH) return process.env.PLAYWRIGHT_CHROMIUM_PATH;
+  try { return execSync('which chromium', { encoding: 'utf8' }).trim() || undefined; } catch { return undefined; }
+}
+
+const browser = await chromium.launch({
+  executablePath: chromiumPath(),
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--no-sandbox'],
+});
+const page = await browser.newPage({ viewport: { width: 1180, height: 900 } });
+// waitUntil 'load' (no 'networkidle': el websocket de HMR de vite nunca calla).
+await page.goto(`${base}/scripts/diag/captura-bichos.html?gesto=1`, { waitUntil: 'load' });
+await page.waitForSelector('svg[data-creature]', { timeout: 30_000 });
+
+const t0 = Date.now();
+for (const marca of [2, 12, 22, 32]) {
+  const espera = t0 + marca * 1000 - Date.now();
+  if (espera > 0) await new Promise((r) => setTimeout(r, espera));
+  await page.screenshot({ path: `${dir}/${prefijo}-t${String(marca).padStart(2, '0')}s.png`, fullPage: true });
+  console.log(`shot t=${marca}s`);
+}
+await browser.close();
+console.log(`OK → ${dir}`);

--- a/scripts/diag/captura-bichos.html
+++ b/scripts/diag/captura-bichos.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <title>Diag — vida de los bichos rubber-hose</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body { margin: 0; background: #f6efe2; font-family: system-ui, sans-serif; }
+    #raiz { padding: 12px; }
+  </style>
+</head>
+<body>
+  <div id="raiz"></div>
+  <script type="module" src="/scripts/diag/captura-bichos.jsx"></script>
+</body>
+</html>

--- a/scripts/diag/captura-bichos.jsx
+++ b/scripts/diag/captura-bichos.jsx
@@ -1,0 +1,73 @@
+/*
+ * captura-bichos — ARNÉS DE DIAGNÓSTICO VISUAL (scripts/diag, regla de la casa:
+ * scripts versionados, no pegotes por SSH). Sirve para VER y CAPTURAR la vida
+ * de los 9 personajes rubber-hose lado a lado, con la etiqueta VIVA de qué
+ * momento del idle-cerebro corre en cada uno (data-vida / data-pose).
+ *
+ * Uso (vite dev):  npm run dev  →  http://127.0.0.1:5173/scripts/diag/captura-bichos.html
+ * Query params:
+ *   ?gesto=1   además de la fila viva, una fila por bicho con sus gestos-firma
+ *              FORZADOS por props (frames garantizados para captura).
+ * NO va al bundle de prod: nada lo importa desde src/.
+ */
+import { createElement as h, useEffect, useRef, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import {
+  AbejaAngelita, OsoAndino, Colibri, RanaAndina, Perezoso,
+  Ardilla, Jaguar, Morrocoy, Borugo,
+} from '../../src/visual/creatures/index.js';
+
+const BICHOS = [
+  ['abeja-angelita', AbejaAngelita, 'Angelita (vara)', {}],
+  ['oso-andino', OsoAndino, 'Oso andino', { gestos: ['resopla', 'rasca'] }],
+  ['colibri', Colibri, 'Colibrí', { gestos: ['acicala', 'vibra'] }],
+  ['rana-andina', RanaAndina, 'Rana arlequín', { gestos: ['croa', 'medita'] }],
+  ['perezoso', Perezoso, 'Perezoso', { gestos: ['dormita', 'estira'] }],
+  ['ardilla', Ardilla, 'Ardilla', { gestos: ['inspecciona', 'roe'] }],
+  ['jaguar', Jaguar, 'Jaguar', { gestos: ['ruge', 'acecha'] }],
+  ['morrocoy', Morrocoy, 'Morrocoy', { gestos: ['seRetrae', 'asiente'] }],
+  ['borugo', Borugo, 'Borugo', { gestos: ['olfatea', 'acurruca'] }],
+];
+
+/* Tarjeta con etiqueta VIVA: un MutationObserver lee data-vida/data-pose del
+   svg del bicho y lo pinta debajo — así el screenshot PRUEBA qué momento del
+   cerebro corría en el instante de la captura. */
+function Tarjeta({ nombre, children }) {
+  const ref = useRef(null);
+  const [estado, setEstado] = useState('—');
+  useEffect(() => {
+    const svg = ref.current?.querySelector('svg[data-creature]');
+    if (!svg) return undefined;
+    const leer = () => setEstado(
+      svg.getAttribute('data-vida') || svg.getAttribute('data-pose') || 'base',
+    );
+    leer();
+    const mo = new MutationObserver(leer);
+    mo.observe(svg, { attributes: true, attributeFilter: ['data-vida', 'data-pose'] });
+    return () => mo.disconnect();
+  }, []);
+  return h('figure', { style: { margin: 4, textAlign: 'center', width: 150 } },
+    h('div', { ref }, children),
+    h('figcaption', { style: { fontSize: 13 } },
+      h('strong', null, nombre), h('br'),
+      h('code', { style: { fontSize: 12, color: '#7a4a12' } }, estado)));
+}
+
+function Grilla() {
+  const conGestos = new URLSearchParams(window.location.search).has('gesto');
+  return h('div', null,
+    h('h3', { style: { margin: '4px 8px' } }, 'Fila viva — idle-cerebro solo (data-vida en vivo)'),
+    h('div', { style: { display: 'flex', flexWrap: 'wrap' } },
+      BICHOS.map(([slug, Comp, nombre]) =>
+        h(Tarjeta, { key: slug, nombre },
+          h(Comp, { size: 132, animated: true })))),
+    conGestos && h('div', null,
+      h('h3', { style: { margin: '10px 8px 4px' } }, 'Gestos-firma FORZADOS por props (frames garantizados)'),
+      h('div', { style: { display: 'flex', flexWrap: 'wrap' } },
+        BICHOS.filter(([, , , x]) => x.gestos).flatMap(([slug, Comp, nombre, x]) =>
+          x.gestos.map((g) =>
+            h(Tarjeta, { key: `${slug}-${g}`, nombre: `${nombre} · ${g}` },
+              h(Comp, { size: 110, animated: true, vida: false, [g]: true })))))));
+}
+
+createRoot(document.getElementById('raiz')).render(h(Grilla));

--- a/src/visual/creatures/Ardilla.jsx
+++ b/src/visual/creatures/Ardilla.jsx
@@ -1,5 +1,6 @@
-import { useId } from 'react';
+import { useId, useRef } from 'react';
 import './creatures.css';
+import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
 import { CreatureFilters } from './_filters.jsx';
 import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, RH_INK } from './_rubberhose.jsx';
 import { ARDILLA_PALETA, ARDILLA_PROPORCION } from './faunaAndina.js';
@@ -66,6 +67,14 @@ export function Ardilla({
      OPT-IN: la ardilla sostiene una bellota y la ROE a mordiscos rápidos (los
      incisivos castañetean, olfateo veloz). Default false. */
   roe = false,
+  /* ── VIDA PROPIA (idle-cerebro v2 — la vara de Angelita) ───────────────────
+     Default ON: un reloj con jitter hojea el repertorio de la especie
+     (vidaEstados.js) — el bicho EXISTE aunque nadie le hable. Cada instancia
+     parpadea a SU aire (ritmo propio) y sus pupilas SIGUEN su puntero/dedo
+     cuando anda cerca. El cerebro CEDE ante el host (cualquier gesto manual
+     lo apaga); animated=false, tier 'bajo' y reduced-motion lo apagan entero.
+     vida={false} = el bicho de antes, idéntico. */
+  vida = true,
   /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
      pleno; 'bajo' apaga el idle continuo (boil + cola + olfateo) y deja los
      estados reactivos. Sin prop (standalone) = pleno. */
@@ -95,6 +104,19 @@ export function Ardilla({
   const vivo = animated;
   const auraOp = Math.max(0.14, Math.min(0.44, 0.18 + 0.28 * (energia ?? 1)));
   const auraR = 7.8 + 1.5 * (energia ?? 1);
+
+  // ═══ VIDA PROPIA (idle-cerebro + ritmo propio + mirada — vara Angelita v2).
+  // El cerebro solo manda cuando el host no dirige (pose base, sin gestos
+  // manuales ni lip-sync); sus momentos se funden con los props opt-in para
+  // reusar TODO el CSS existente de los gestos-firma.
+  const raizRef = useRef(null);
+  const ritmoPropio = useRitmoPropio();
+  const enBase = pose === 'anda' && !inspecciona && !roe && !visema;
+  const momento = useVidaIdle('ardilla', vida && vivo && tier !== 'bajo' && enBase);
+  useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
+  const inspeccionaFx = inspecciona || momento === 'inspecciona';
+  const roeFx = roe || momento === 'roe';
+  const poseFx = momento === 'reposo' ? 'reposo' : pose;
   const P = ARDILLA_PROPORCION;
   const C = ARDILLA_PALETA;
 
@@ -128,7 +150,7 @@ export function Ardilla({
   ) : null;
 
   // La BELLOTA que roe (solo con roe): entre las patitas, a la altura de la boca.
-  const bellota = roe ? (
+  const bellota = roeFx ? (
     <g className="ardilla-bellota" aria-hidden="true">
       <ellipse cx="0" cy="0.6" rx="1.7" ry="2.0" fill={C.bellota} stroke={RH_INK} strokeWidth="0.7" />
       <path d="M-1.7,-0.6 A1.7,1.4 0 0 1 1.7,-0.6 Z" fill="#5f3a17" stroke={RH_INK} strokeWidth="0.5" />
@@ -268,29 +290,33 @@ export function Ardilla({
 
   const estadoAttrs = {
     'data-creature': 'ardilla',
-    'data-pose': vivo ? pose : undefined,
+    'data-pose': vivo ? poseFx : undefined,
     'data-animo': animo,
     'data-tier': tier || undefined,
     'data-visema': visema || undefined,
     'data-ruana': ropa?.ruana ? '1' : undefined,
     'data-mojado': ropa?.mojado ? '1' : undefined,
-    'data-inspecciona': inspecciona ? '1' : undefined,
-    'data-roe': roe ? '1' : undefined,
+    'data-inspecciona': inspeccionaFx ? '1' : undefined,
+    'data-roe': roeFx ? '1' : undefined,
+    'data-vida': momento || undefined,
     'data-lineboil': lineBoil ? '1' : undefined,
     'data-prop': mundoId || undefined,
   };
 
+  // El ritmo propio (parpadeo/dardeo por instancia) viaja como vars CSS.
+  const estiloRaiz = { ...ritmoPropio, ...estiloClima };
+
   if (inline) {
     // En modo inline el power-up lo pone el host DOM; acá solo marcamos data-poder.
     return (
-      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+      <g ref={raizRef} className={className} style={estiloRaiz} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
         {defs}
         {cuerpoVivo}
       </g>
     );
   }
   const svg = (
-    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+    <svg ref={raizRef} viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloRaiz}
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}

--- a/src/visual/creatures/Borugo.jsx
+++ b/src/visual/creatures/Borugo.jsx
@@ -1,5 +1,6 @@
-import { useId } from 'react';
+import { useId, useRef } from 'react';
 import './creatures.css';
+import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
 import { CreatureFilters } from './_filters.jsx';
 import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, RH_INK } from './_rubberhose.jsx';
 import { BORUGO_PALETA, BORUGO_PROPORCION, BORUGO_SLUG, PERFIL_BORUGO } from './borugoIdentidad.js';
@@ -99,6 +100,14 @@ export function Borugo({
      protegido, digno y tranquilo). Su otra reacción-firma, el corazón emotivo
      del cierre. Default false. */
   acurruca = false,
+  /* ── VIDA PROPIA (idle-cerebro v2 — la vara de Angelita) ───────────────────
+     Default ON: un reloj con jitter hojea el repertorio de la especie
+     (vidaEstados.js) — el bicho EXISTE aunque nadie le hable. Cada instancia
+     parpadea a SU aire (ritmo propio) y sus pupilas SIGUEN su puntero/dedo
+     cuando anda cerca. El cerebro CEDE ante el host (cualquier gesto manual
+     lo apaga); animated=false, tier 'bajo' y reduced-motion lo apagan entero.
+     vida={false} = el bicho de antes, idéntico. */
+  vida = true,
   /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
      pleno; 'bajo' apaga el idle continuo (boil + olfateo + bigotes + brillo
      lunar) y deja los estados reactivos. Sin prop (standalone: avatares,
@@ -133,6 +142,19 @@ export function Borugo({
   const vivo = animated;
   const auraOp = Math.max(0.14, Math.min(0.4, 0.16 + 0.24 * (energia ?? 1)));
   const auraR = 8.2 + 1.5 * (energia ?? 1);
+
+  // ═══ VIDA PROPIA (idle-cerebro + ritmo propio + mirada — vara Angelita v2).
+  // El cerebro solo manda cuando el host no dirige (pose base, sin gestos
+  // manuales ni lip-sync); sus momentos se funden con los props opt-in para
+  // reusar TODO el CSS existente de los gestos-firma.
+  const raizRef = useRef(null);
+  const ritmoPropio = useRitmoPropio();
+  const enBase = pose === 'anda' && !olfatea && !acurruca && !visema;
+  const momento = useVidaIdle('borugo', vida && vivo && tier !== 'bajo' && enBase);
+  useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
+  const olfateaFx = olfatea || momento === 'olfatea';
+  const acurrucaFx = acurruca || momento === 'acurruca';
+  const poseFx = momento === 'reposo' ? 'reposo' : pose;
 
   // CLIMA → cuerpo (determinista, una vez por render): tinte + opacidad al
   // contorno. El borugo no tiene alas (velocidadAlas siempre 1: no se usa).
@@ -305,30 +327,34 @@ export function Borugo({
 
   const estadoAttrs = {
     'data-creature': BORUGO_SLUG,
-    'data-pose': vivo ? pose : undefined,
+    'data-pose': vivo ? poseFx : undefined,
     'data-animo': animo,
     'data-tier': tier || undefined,
     'data-visema': visema || undefined,
     'data-ruana': ropa?.ruana ? '1' : undefined,
     'data-mojado': ropa?.mojado ? '1' : undefined,
-    'data-olfatea': olfatea ? '1' : undefined,
-    'data-acurruca': acurruca ? '1' : undefined,
+    'data-olfatea': olfateaFx ? '1' : undefined,
+    'data-acurruca': acurrucaFx ? '1' : undefined,
+    'data-vida': momento || undefined,
     'data-lineboil': lineBoil ? '1' : undefined,
     'data-prop': mundoId || undefined,
   };
+
+  // El ritmo propio (parpadeo/dardeo por instancia) viaja como vars CSS.
+  const estiloRaiz = { ...ritmoPropio, ...estiloClima };
 
   if (inline) {
     // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
     // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
     return (
-      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+      <g ref={raizRef} className={className} style={estiloRaiz} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
         {defs}
         {cuerpoVivo}
       </g>
     );
   }
   const svg = (
-    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+    <svg ref={raizRef} viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloRaiz}
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}

--- a/src/visual/creatures/Colibri.jsx
+++ b/src/visual/creatures/Colibri.jsx
@@ -1,5 +1,6 @@
-import { useId } from 'react';
+import { useId, useRef } from 'react';
 import './creatures.css';
+import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
 import { CreatureFilters } from './_filters.jsx';
 import { OjosRubber, Cachetes, Sonrisa, RH_INK, RH_BOCA } from './_rubberhose.jsx';
 import { COLIBRI_PALETA, COLIBRI_PROPORCION } from './faunaAndina.js';
@@ -102,6 +103,23 @@ export function Colibri({
      estelas={false} las apaga (hosts que quieran al colibrí sobrio). Con
      animated=false / reduced-motion / tier bajo no existen o quedan ocultas. */
   estelas = true,
+  /* ── ACICALA (aseo de ave — gesto-firma NUEVO, vida v2) ────────────────────
+     OPT-IN: el pico baja al ala trasera y la peina con dos pasadas (el aseo
+     que toda ave real hace a cada rato). Dardo y estelas se pausan: nadie se
+     asea dardeando. Default false. */
+  acicala = false,
+  /* ── VIBRA (burst staccato — gesto-firma NUEVO, vida v2) ───────────────────
+     OPT-IN: la emoción que no cabe — jitter veloz con squash&stretch y el
+     aleteo a más revoluciones (olla a presión, puro hiperactivo). Default
+     false. */
+  vibra = false,
+  /* ── VIDA PROPIA (idle-cerebro v2 — la vara de Angelita) ───────────────────
+     Default ON: un reloj con jitter hojea el repertorio del colibrí (acicala,
+     vibra, se posa) — el hiperactivo EXISTE aunque nadie le hable. Cada
+     instancia parpadea a SU aire y sus pupilas SIGUEN su puntero/dedo cerca.
+     El cerebro CEDE ante el host; animated=false, tier 'bajo' y
+     reduced-motion lo apagan entero. vida={false} = el colibrí de antes. */
+  vida = true,
   /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
      pleno; 'bajo' apaga lo continuo (dardo + estelas + boil) y deja aleteo y
      estados reactivos. Sin prop (standalone: avatares, catálogo) = pleno. */
@@ -136,6 +154,16 @@ export function Colibri({
   const auraOp = Math.max(0.16, Math.min(0.5, 0.2 + 0.3 * (energia ?? 1)));
   const auraR = 5.2 + 1.2 * (energia ?? 1);
   const estelasOn = vivo && !!estelas;
+
+  // ═══ VIDA PROPIA (idle-cerebro + ritmo propio + mirada — vara Angelita v2).
+  const raizRef = useRef(null);
+  const ritmoPropio = useRitmoPropio();
+  const enBase = pose === 'vuela' && !acicala && !vibra && !visema;
+  const momento = useVidaIdle('colibri', vida && vivo && tier !== 'bajo' && enBase);
+  useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
+  const acicalaFx = acicala || momento === 'acicala';
+  const vibraFx = vibra || momento === 'vibra';
+  const poseFx = momento === 'reposo' ? 'reposo' : pose;
 
   // CLIMA → cuerpo (perfil colibrí). El aleteo base HIPERVELOZ (0.11s, en el
   // CSS del bloque colibrí) se apura (dorada) o pesa (lluvia) escalando por
@@ -287,29 +315,35 @@ export function Colibri({
 
   const estadoAttrs = {
     'data-creature': 'colibri',
-    'data-pose': vivo ? pose : undefined,
+    'data-pose': vivo ? poseFx : undefined,
     'data-animo': animo,
     'data-tier': tier || undefined,
     'data-visema': visema || undefined,
     'data-ruana': ropa?.ruana ? '1' : undefined,
     'data-mojado': ropa?.mojado ? '1' : undefined,
     'data-estelas': estelasOn ? '1' : undefined,
+    'data-acicala': acicalaFx ? '1' : undefined,
+    'data-vibra': vibraFx ? '1' : undefined,
+    'data-vida': momento || undefined,
     'data-lineboil': lineBoil ? '1' : undefined,
     'data-prop': mundoId || undefined,
   };
+
+  // El ritmo propio (parpadeo/dardeo por instancia) viaja como vars CSS.
+  const estiloRaiz = { ...ritmoPropio, ...estiloClima };
 
   if (inline) {
     // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
     // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
     return (
-      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+      <g ref={raizRef} className={className} style={estiloRaiz} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
         {defs}
         {cuerpoVivo}
       </g>
     );
   }
   const svg = (
-    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+    <svg ref={raizRef} viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloRaiz}
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}

--- a/src/visual/creatures/Jaguar.jsx
+++ b/src/visual/creatures/Jaguar.jsx
@@ -1,5 +1,6 @@
-import { useId } from 'react';
+import { useId, useRef } from 'react';
 import './creatures.css';
+import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
 import { CreatureFilters } from './_filters.jsx';
 import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, RH_INK, RH_BOCA } from './_rubberhose.jsx';
 import { JAGUAR_PALETA, JAGUAR_PROPORCION, JAGUAR_SLUG, PERFIL_JAGUAR } from './jaguarIdentidad.js';
@@ -122,6 +123,14 @@ export function Jaguar({
      OPT-IN: los omóplatos SUBEN, la cabeza BAJA y el cuerpo avanza lento y
      controlado (el acecho felino). Su otra reacción-firma. Default false. */
   acecha = false,
+  /* ── VIDA PROPIA (idle-cerebro v2 — la vara de Angelita) ───────────────────
+     Default ON: un reloj con jitter hojea el repertorio de la especie
+     (vidaEstados.js) — el bicho EXISTE aunque nadie le hable. Cada instancia
+     parpadea a SU aire (ritmo propio) y sus pupilas SIGUEN su puntero/dedo
+     cuando anda cerca. El cerebro CEDE ante el host (cualquier gesto manual
+     lo apaga); animated=false, tier 'bajo' y reduced-motion lo apagan entero.
+     vida={false} = el bicho de antes, idéntico. */
+  vida = true,
   /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
      pleno; 'bajo' apaga el idle continuo (boil + acecho de hombros + cola) y
      deja los estados reactivos. Sin prop (standalone: avatares, catálogo) = pleno. */
@@ -156,6 +165,19 @@ export function Jaguar({
   const vivo = animated;
   const auraOp = Math.max(0.14, Math.min(0.42, 0.18 + 0.26 * (energia ?? 1)));
   const auraR = 8.5 + 1.6 * (energia ?? 1);
+
+  // ═══ VIDA PROPIA (idle-cerebro + ritmo propio + mirada — vara Angelita v2).
+  // El cerebro solo manda cuando el host no dirige (pose base, sin gestos
+  // manuales ni lip-sync); sus momentos se funden con los props opt-in para
+  // reusar TODO el CSS existente de los gestos-firma.
+  const raizRef = useRef(null);
+  const ritmoPropio = useRitmoPropio();
+  const enBase = pose === 'anda' && !ruge && !acecha && !visema;
+  const momento = useVidaIdle('jaguar', vida && vivo && tier !== 'bajo' && enBase);
+  useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
+  const rugeFx = ruge || momento === 'ruge';
+  const acechaFx = acecha || momento === 'acecha';
+  const poseFx = momento === 'reposo' ? 'reposo' : pose;
 
   // CLIMA → cuerpo (determinista, una vez por render): tinte + opacidad al
   // contorno. El jaguar no tiene alas (velocidadAlas siempre 1: no se usa).
@@ -192,7 +214,7 @@ export function Jaguar({
   // BOCA: precedencia RUGIDO > visema > sonrisa. La fiera que ruge abre las
   // fauces con colmillos + garganta (no articula fonemas); si narra sin rugir,
   // el visema; en reposo, la sonrisa de goma de siempre.
-  const boca = ruge ? (
+  const boca = rugeFx ? (
     <g className="jaguar-rugido-boca" aria-hidden="true">
       <ellipse cx="0" cy="-2.9" rx="2.5" ry="2.1" fill={RH_BOCA} stroke={RH_INK} strokeWidth="0.9" />
       {/* colmillos superiores (el rugido) */}
@@ -382,30 +404,34 @@ export function Jaguar({
 
   const estadoAttrs = {
     'data-creature': JAGUAR_SLUG,
-    'data-pose': vivo ? pose : undefined,
+    'data-pose': vivo ? poseFx : undefined,
     'data-animo': animo,
     'data-tier': tier || undefined,
     'data-visema': visema || undefined,
     'data-ruana': ropa?.ruana ? '1' : undefined,
     'data-mojado': ropa?.mojado ? '1' : undefined,
-    'data-ruge': ruge ? '1' : undefined,
-    'data-acecha': acecha ? '1' : undefined,
+    'data-ruge': rugeFx ? '1' : undefined,
+    'data-acecha': acechaFx ? '1' : undefined,
+    'data-vida': momento || undefined,
     'data-lineboil': lineBoil ? '1' : undefined,
     'data-prop': mundoId || undefined,
   };
+
+  // El ritmo propio (parpadeo/dardeo por instancia) viaja como vars CSS.
+  const estiloRaiz = { ...ritmoPropio, ...estiloClima };
 
   if (inline) {
     // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
     // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
     return (
-      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+      <g ref={raizRef} className={className} style={estiloRaiz} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
         {defs}
         {cuerpoVivo}
       </g>
     );
   }
   const svg = (
-    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+    <svg ref={raizRef} viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloRaiz}
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}

--- a/src/visual/creatures/Morrocoy.jsx
+++ b/src/visual/creatures/Morrocoy.jsx
@@ -1,5 +1,6 @@
-import { useId } from 'react';
+import { useId, useRef } from 'react';
 import './creatures.css';
+import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
 import { CreatureFilters } from './_filters.jsx';
 import { OjosRubber, Cachetes, Sonrisa, BocaVisema, RH_INK, RH_BOCA } from './_rubberhose.jsx';
 import { MORROCOY_PALETA, MORROCOY_PROPORCION, MORROCOY_SLUG, PERFIL_MORROCOY } from './morrocoyIdentidad.js';
@@ -122,6 +123,14 @@ export function Morrocoy({
      OPT-IN: la testa cabecea lento y firme ("sí, mijo, con paciencia"). Su otra
      reacción-firma. Default false. */
   asiente = false,
+  /* ── VIDA PROPIA (idle-cerebro v2 — la vara de Angelita) ───────────────────
+     Default ON: un reloj con jitter hojea el repertorio de la especie
+     (vidaEstados.js) — el bicho EXISTE aunque nadie le hable. Cada instancia
+     parpadea a SU aire (ritmo propio) y sus pupilas SIGUEN su puntero/dedo
+     cuando anda cerca. El cerebro CEDE ante el host (cualquier gesto manual
+     lo apaga); animated=false, tier 'bajo' y reduced-motion lo apagan entero.
+     vida={false} = el bicho de antes, idéntico. */
+  vida = true,
   /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
      pleno; 'bajo' apaga el idle continuo (boil + respiración del domo + shimmer)
      y deja los estados reactivos. Sin prop (standalone: avatares, catálogo) = pleno. */
@@ -156,6 +165,19 @@ export function Morrocoy({
   const vivo = animated;
   const auraOp = Math.max(0.14, Math.min(0.42, 0.18 + 0.26 * (energia ?? 1)));
   const auraR = 9.0 + 1.6 * (energia ?? 1);
+
+  // ═══ VIDA PROPIA (idle-cerebro + ritmo propio + mirada — vara Angelita v2).
+  // El cerebro solo manda cuando el host no dirige (pose base, sin gestos
+  // manuales ni lip-sync); sus momentos se funden con los props opt-in para
+  // reusar TODO el CSS existente de los gestos-firma.
+  const raizRef = useRef(null);
+  const ritmoPropio = useRitmoPropio();
+  const enBase = pose === 'anda' && !seRetrae && !asiente && !visema;
+  const momento = useVidaIdle('morrocoy', vida && vivo && tier !== 'bajo' && enBase);
+  useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
+  const seRetraeFx = seRetrae || momento === 'seRetrae';
+  const asienteFx = asiente || momento === 'asiente';
+  const poseFx = momento === 'reposo' ? 'reposo' : pose;
 
   // CLIMA → cuerpo (determinista, una vez por render): tinte + opacidad al
   // contorno. El morrocoy no tiene alas (velocidadAlas siempre 1: no se usa).
@@ -343,30 +365,34 @@ export function Morrocoy({
 
   const estadoAttrs = {
     'data-creature': MORROCOY_SLUG,
-    'data-pose': vivo ? pose : undefined,
+    'data-pose': vivo ? poseFx : undefined,
     'data-animo': animo,
     'data-tier': tier || undefined,
     'data-visema': visema || undefined,
     'data-ruana': ropa?.ruana ? '1' : undefined,
     'data-mojado': ropa?.mojado ? '1' : undefined,
-    'data-retrae': seRetrae ? '1' : undefined,
-    'data-asiente': asiente ? '1' : undefined,
+    'data-retrae': seRetraeFx ? '1' : undefined,
+    'data-asiente': asienteFx ? '1' : undefined,
+    'data-vida': momento || undefined,
     'data-lineboil': lineBoil ? '1' : undefined,
     'data-prop': mundoId || undefined,
   };
+
+  // El ritmo propio (parpadeo/dardeo por instancia) viaja como vars CSS.
+  const estiloRaiz = { ...ritmoPropio, ...estiloClima };
 
   if (inline) {
     // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
     // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
     return (
-      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+      <g ref={raizRef} className={className} style={estiloRaiz} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
         {defs}
         {cuerpoVivo}
       </g>
     );
   }
   const svg = (
-    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+    <svg ref={raizRef} viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloRaiz}
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}

--- a/src/visual/creatures/OsoAndino.jsx
+++ b/src/visual/creatures/OsoAndino.jsx
@@ -1,5 +1,6 @@
-import { useId } from 'react';
+import { useId, useRef } from 'react';
 import './creatures.css';
+import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
 import { CreatureFilters } from './_filters.jsx';
 import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, RH_INK } from './_rubberhose.jsx';
 import { OSO_PALETA, OSO_PROPORCION } from './faunaAndina.js';
@@ -66,6 +67,15 @@ export function OsoAndino({
      OPT-IN: el oso se rasca la panza con la zarpa derecha (gesto de oso, pausado
      y entrañable). Default false. */
   rasca = false,
+  /* ── VIDA PROPIA (idle-cerebro v2 — la vara de Angelita) ───────────────────
+     Default ON: un reloj con jitter hojea el repertorio del oso (resopla,
+     rasca, se sienta a respirar) — el guardián EXISTE aunque nadie le hable.
+     Además cada instancia parpadea a SU aire (ritmo propio) y sus pupilas
+     SIGUEN su puntero/dedo cuando anda cerca. El cerebro CEDE ante el host:
+     cualquier gesto manual (resopla/rasca/pose/visema) lo apaga. Gates de la
+     casa: animated=false, tier 'bajo' y reduced-motion lo apagan entero.
+     vida={false} = el oso de antes, idéntico. */
+  vida = true,
   /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
      pleno; 'bajo' apaga el idle continuo (boil + follow-through) y deja los
      estados reactivos. Sin prop (standalone: avatares, catálogo) = pleno. */
@@ -100,6 +110,19 @@ export function OsoAndino({
   const auraOp = Math.max(0.14, Math.min(0.42, 0.18 + 0.26 * (energia ?? 1)));
   const auraR = 8.5 + 1.6 * (energia ?? 1);
 
+  // ═══ VIDA PROPIA (idle-cerebro + ritmo propio + mirada — vara Angelita v2).
+  // El cerebro solo manda cuando el host no está dirigiendo (pose base, sin
+  // gestos manuales ni lip-sync); sus momentos se funden con los props opt-in
+  // (`resoplaFx = resopla || momento`) para reusar TODO el CSS existente.
+  const raizRef = useRef(null);
+  const ritmoPropio = useRitmoPropio();
+  const enBase = pose === 'anda' && !resopla && !rasca && !visema;
+  const momento = useVidaIdle('oso-andino', vida && vivo && tier !== 'bajo' && enBase);
+  useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
+  const resoplaFx = resopla || momento === 'resopla';
+  const rascaFx = rasca || momento === 'rasca';
+  const poseFx = momento === 'reposo' ? 'reposo' : pose;
+
   // CLIMA → cuerpo (determinista, una vez por render): tinte + opacidad al
   // contorno. El oso no tiene alas (velocidadAlas siempre 1: no se usa).
   const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: PERFIL_OSO });
@@ -125,7 +148,7 @@ export function OsoAndino({
   // VAHO del resoplido: dos motas claras que salen de la trufa y se disuelven
   // (el oso resopla — su gruñido corporal). CSS (crt-vaho-mota) las anima; con
   // animated=false / RM quedan colgando dignas. Opt-in (resopla).
-  const vaho = resopla ? (
+  const vaho = resoplaFx ? (
     <g className="crt-vaho" fill={OSO_PALETA.cremaClara} aria-hidden="true" opacity="0.7">
       <circle className={vivo ? 'crt-vaho-mota' : undefined} cx="2.6" cy="-4.4" r="1.1" />
       <circle className={vivo ? 'crt-vaho-mota' : undefined} style={{ animationDelay: '-0.7s' }} cx="3.6" cy="-3.2" r="0.85" />
@@ -267,30 +290,33 @@ export function OsoAndino({
 
   const estadoAttrs = {
     'data-creature': 'oso-andino',
-    'data-pose': vivo ? pose : undefined,
+    'data-pose': vivo ? poseFx : undefined,
     'data-animo': animo,
     'data-tier': tier || undefined,
     'data-visema': visema || undefined,
     'data-ruana': ropa?.ruana ? '1' : undefined,
     'data-mojado': ropa?.mojado ? '1' : undefined,
-    'data-resopla': resopla ? '1' : undefined,
-    'data-rasca': rasca ? '1' : undefined,
+    'data-resopla': resoplaFx ? '1' : undefined,
+    'data-rasca': rascaFx ? '1' : undefined,
+    'data-vida': momento || undefined,
     'data-lineboil': lineBoil ? '1' : undefined,
     'data-prop': mundoId || undefined,
   };
+  // El ritmo propio (parpadeo/dardeo por instancia) viaja como vars CSS.
+  const estiloRaiz = { ...ritmoPropio, ...estiloClima };
 
   if (inline) {
     // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
     // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
     return (
-      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+      <g ref={raizRef} className={className} style={estiloRaiz} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
         {defs}
         {cuerpoVivo}
       </g>
     );
   }
   const svg = (
-    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+    <svg ref={raizRef} viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloRaiz}
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}

--- a/src/visual/creatures/Perezoso.jsx
+++ b/src/visual/creatures/Perezoso.jsx
@@ -1,5 +1,6 @@
-import { useId } from 'react';
+import { useId, useRef } from 'react';
 import './creatures.css';
+import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
 import { CreatureFilters } from './_filters.jsx';
 import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, RH_INK } from './_rubberhose.jsx';
 import { cuerpoDeClima, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
@@ -101,6 +102,14 @@ export function Perezoso({
      OPT-IN: el cuerpo se ALARGA despacio y SOSTIENE el estirón (el clásico
      bostezo-estiramiento del perezoso, lentísimo). Default false. */
   estira = false,
+  /* ── VIDA PROPIA (idle-cerebro v2 — la vara de Angelita) ───────────────────
+     Default ON: un reloj con jitter hojea el repertorio de la especie
+     (vidaEstados.js) — el bicho EXISTE aunque nadie le hable. Cada instancia
+     parpadea a SU aire (ritmo propio) y sus pupilas SIGUEN su puntero/dedo
+     cuando anda cerca. El cerebro CEDE ante el host (cualquier gesto manual
+     lo apaga); animated=false, tier 'bajo' y reduced-motion lo apagan entero.
+     vida={false} = el bicho de antes, idéntico. */
+  vida = true,
   /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
      pleno; 'bajo' apaga el idle continuo (boil + mecerse) y deja los estados
      reactivos. Sin prop (standalone: avatares, catálogo) = pleno. */
@@ -133,6 +142,19 @@ export function Perezoso({
   const auraOp = Math.max(0.14, Math.min(0.4, 0.16 + 0.24 * (energia ?? 1)));
   const auraR = 8.2 + 1.5 * (energia ?? 1);
 
+  // ═══ VIDA PROPIA (idle-cerebro + ritmo propio + mirada — vara Angelita v2).
+  // El cerebro solo manda cuando el host no dirige (pose base, sin gestos
+  // manuales ni lip-sync); sus momentos se funden con los props opt-in para
+  // reusar TODO el CSS existente de los gestos-firma.
+  const raizRef = useRef(null);
+  const ritmoPropio = useRitmoPropio();
+  const enBase = pose === 'anda' && !dormita && !estira && !visema;
+  const momento = useVidaIdle('perezoso', vida && vivo && tier !== 'bajo' && enBase);
+  useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
+  const dormitaFx = dormita || momento === 'dormita';
+  const estiraFx = estira || momento === 'estira';
+  const poseFx = momento === 'reposo' ? 'reposo' : pose;
+
   // CLIMA → cuerpo (determinista, una vez por render): tinte + opacidad al
   // contorno. El perezoso no tiene alas (velocidadAlas siempre 1: no se usa).
   const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: PERFIL_PEREZOSO });
@@ -157,7 +179,7 @@ export function Perezoso({
   // "Z" del sueño: tres zetas que flotan LENTO y se disuelven (el perezoso
   // dormita). CSS (perezoso-zzz-mota) las anima; con animated=false / RM quedan
   // colgando dignas. Opt-in (dormita).
-  const zzz = dormita ? (
+  const zzz = dormitaFx ? (
     <g className="perezoso-zzz" fill="none" stroke={RH_INK} strokeWidth="0.9"
       strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" opacity="0.75">
       <path className={vivo ? 'perezoso-zzz-mota' : undefined} d="M2,-12 h2 l-2,2 h2" />
@@ -297,23 +319,27 @@ export function Perezoso({
 
   const estadoAttrs = {
     'data-creature': 'perezoso',
-    'data-pose': vivo ? pose : undefined,
+    'data-pose': vivo ? poseFx : undefined,
     'data-animo': animo,
     'data-tier': tier || undefined,
     'data-visema': visema || undefined,
     'data-ruana': ropa?.ruana ? '1' : undefined,
     'data-mojado': ropa?.mojado ? '1' : undefined,
-    'data-dormita': dormita ? '1' : undefined,
-    'data-estira': estira ? '1' : undefined,
+    'data-dormita': dormitaFx ? '1' : undefined,
+    'data-estira': estiraFx ? '1' : undefined,
+    'data-vida': momento || undefined,
     'data-lineboil': lineBoil ? '1' : undefined,
     'data-prop': mundoId || undefined,
   };
+
+  // El ritmo propio (parpadeo/dardeo por instancia) viaja como vars CSS.
+  const estiloRaiz = { ...ritmoPropio, ...estiloClima };
 
   if (inline) {
     // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
     // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
     return (
-      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+      <g ref={raizRef} className={className} style={estiloRaiz} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
         {defs}
         {rama}
         {cuerpoVivo}
@@ -321,7 +347,7 @@ export function Perezoso({
     );
   }
   const svg = (
-    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+    <svg ref={raizRef} viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloRaiz}
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}

--- a/src/visual/creatures/RanaAndina.jsx
+++ b/src/visual/creatures/RanaAndina.jsx
@@ -1,5 +1,6 @@
-import { useId } from 'react';
+import { useId, useRef } from 'react';
 import './creatures.css';
+import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
 import { CreatureFilters } from './_filters.jsx';
 import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, RH_INK } from './_rubberhose.jsx';
 import { RANA_PALETA, RANA_PROPORCION } from './faunaAndina.js';
@@ -65,6 +66,23 @@ export function RanaAndina({
      piel de cuerpoDeClima. tempC afina frío/calor. */
   vestuario = false,
   tempC = undefined,
+  /* ── CROA (el canto — gesto-firma NUEVO, vida v2) ──────────────────────────
+     OPT-IN: la garganta que ya late se INFLA grande dos veces con el compás
+     del canto y el cuerpo acompaña con squash de esfuerzo. La rana canta
+     plantada (el salto espera). Default false. */
+  croa = false,
+  /* ── MEDITA (zen hondo — gesto-firma NUEVO, vida v2) ───────────────────────
+     OPT-IN: los párpados caen despacio y se quedan caídos, la respiración se
+     vuelve honda y lenta — la paciente-MUY-inteligente se va para adentro.
+     Default false. */
+  medita = false,
+  /* ── VIDA PROPIA (idle-cerebro v2 — la vara de Angelita) ───────────────────
+     Default ON: un reloj con jitter hojea el repertorio de la rana (croa,
+     medita, reposa) — la sabia del agua EXISTE aunque nadie le hable. Cada
+     instancia parpadea a SU aire y sus pupilas SIGUEN su puntero/dedo cerca.
+     El cerebro CEDE ante el host; animated=false, tier 'bajo' y
+     reduced-motion lo apagan entero. vida={false} = la rana de antes. */
+  vida = true,
   /* Device-tier: 'alto'|'medio' corren la cadencia zen plena; 'bajo' apaga lo
      continuo (boil + garganta + salto + follow-through) y deja los estados
      reactivos. Sin prop (standalone: avatares, catálogo) = pleno. El CSS gatea
@@ -98,6 +116,16 @@ export function RanaAndina({
   const vivo = animated;
   const auraOp = Math.max(0.14, Math.min(0.44, 0.18 + 0.28 * (energia ?? 1)));
   const auraR = 7.6 + 1.4 * (energia ?? 1);
+
+  // ═══ VIDA PROPIA (idle-cerebro + ritmo propio + mirada — vara Angelita v2).
+  const raizRef = useRef(null);
+  const ritmoPropio = useRitmoPropio();
+  const enBase = pose === 'anda' && !croa && !medita && !visema;
+  const momento = useVidaIdle('rana-andina', vida && vivo && tier !== 'bajo' && enBase);
+  useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
+  const croaFx = croa || momento === 'croa';
+  const meditaFx = medita || momento === 'medita';
+  const poseFx = momento === 'reposo' ? 'reposo' : pose;
 
   // CLIMA → cuerpo (perfil rana). Sin clima = neutro digno.
   const cuerpoClima = cuerpoDeClima(clima, { enso, tier, perfil: PERFIL_RANA });
@@ -213,29 +241,35 @@ export function RanaAndina({
 
   const estadoAttrs = {
     'data-creature': 'rana-andina',
-    'data-pose': vivo ? pose : undefined,
+    'data-pose': vivo ? poseFx : undefined,
     'data-animo': animo,
     'data-tier': tier || undefined,
     'data-visema': visema || undefined,
     'data-ruana': ropa?.ruana ? '1' : undefined,
     'data-sombrero': ropa?.sombrero ? '1' : undefined,
     'data-sudor': ropa?.sudor ? '1' : undefined,
+    'data-croa': croaFx ? '1' : undefined,
+    'data-medita': meditaFx ? '1' : undefined,
+    'data-vida': momento || undefined,
     'data-lineboil': lineBoil ? '1' : undefined,
     'data-prop': mundoId || undefined,
   };
+
+  // El ritmo propio (parpadeo/dardeo por instancia) viaja como vars CSS.
+  const estiloRaiz = { ...ritmoPropio, ...estiloClima };
 
   if (inline) {
     // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
     // aplican a SVG); acá solo marcamos data-poder por si el host lo consulta.
     return (
-      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+      <g ref={raizRef} className={className} style={estiloRaiz} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
         {defs}
         {cuerpoVivo}
       </g>
     );
   }
   const svg = (
-    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+    <svg ref={raizRef} viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloRaiz}
       role="img" aria-label={title} {...estadoAttrs} {...rest}>
       <title>{title}</title>
       {defs}

--- a/src/visual/creatures/__tests__/vidaEstados.test.js
+++ b/src/visual/creatures/__tests__/vidaEstados.test.js
@@ -1,0 +1,119 @@
+/**
+ * vidaEstados.test.js — la LÓGICA PURA del idle-cerebro de los 8 bichos
+ * (la vara de Angelita v2 species-agnostic). Verifica:
+ *   1. El repertorio cubre EXACTO a los 8 bichos rubber-hose del registro
+ *      (ni especies fantasma ni bichos huérfanos de vida).
+ *   2. elegirMomentoVida: pondera, NUNCA repite el gesto anterior, azar
+ *      inyectable (determinista en test).
+ *   3. duracionDeMomentoVida/duracionDeDescanso: duraciones del contrato
+ *      (múltiplos del loop CSS) y jitter dentro del rango del temperamento.
+ *   4. crearRitmoPropio: vars CSS de parpadeo/dardeo con fase propia.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  VIDA_REPERTORIO,
+  elegirMomentoVida,
+  duracionDeMomentoVida,
+  duracionDeDescanso,
+  crearRitmoPropio,
+} from '../vidaEstados.js';
+import { CREATURES } from '../index.js';
+
+/* Los 8 con vida propia: todos los personajes del registro menos la abeja
+   (su cerebro v2 vive en el agente — es la vara), la microfauna decorativa
+   y el Ent (árbol-maestro, otro compás). */
+const CON_VIDA = Object.keys(CREATURES).filter(
+  (s) => !['abeja-angelita', 'lombriz', 'mariposa', 'escarabajo', 'ent-frailejon'].includes(s),
+);
+
+describe('1. El repertorio cubre exacto a los 8 bichos', () => {
+  it('cada bicho del registro (menos abeja/microfauna/Ent) tiene repertorio', () => {
+    expect(Object.keys(VIDA_REPERTORIO).sort()).toEqual(CON_VIDA.sort());
+    expect(CON_VIDA).toHaveLength(8);
+  });
+
+  it('cada repertorio trae descanso [min,max] y ≥2 gestos con peso > 0', () => {
+    for (const [slug, r] of Object.entries(VIDA_REPERTORIO)) {
+      expect(r.descanso[0], slug).toBeGreaterThan(0);
+      expect(r.descanso[1], slug).toBeGreaterThan(r.descanso[0]);
+      const conPeso = Object.values(r.momentos).filter((m) => m.peso > 0);
+      expect(conPeso.length, slug).toBeGreaterThanOrEqual(2);
+      for (const m of Object.values(r.momentos)) expect(m.dur, slug).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('2. elegirMomentoVida — azar ponderado sin repetir', () => {
+  it('nunca repite el gesto anterior (criatura viva, no GIF)', () => {
+    for (const slug of Object.keys(VIDA_REPERTORIO)) {
+      let previo = null;
+      for (let i = 0; i < 60; i += 1) {
+        const m = elegirMomentoVida(slug, previo);
+        expect(m, slug).not.toBe(previo);
+        expect(VIDA_REPERTORIO[slug].momentos[m], `${slug}:${m}`).toBeTruthy();
+        previo = m;
+      }
+    }
+  });
+
+  it('el azar se inyecta: rand=0 da siempre el primer candidato (determinista)', () => {
+    const a = elegirMomentoVida('oso-andino', null, () => 0);
+    const b = elegirMomentoVida('oso-andino', null, () => 0);
+    expect(a).toBe(b);
+  });
+
+  it('especie sin repertorio → null (identidad para siempre, sin romper)', () => {
+    expect(elegirMomentoVida('lombriz')).toBeNull();
+    expect(elegirMomentoVida('no-existe')).toBeNull();
+  });
+});
+
+describe('3. Duraciones — el contrato con el CSS', () => {
+  it('duracionDeMomentoVida devuelve el dur del repertorio (0 si no existe)', () => {
+    expect(duracionDeMomentoVida('oso-andino', 'resopla')).toBe(4500);
+    expect(duracionDeMomentoVida('oso-andino', 'nada')).toBe(0);
+    expect(duracionDeMomentoVida('nadie', 'resopla')).toBe(0);
+  });
+
+  it('la REGLA DURA anotada: durs múltiplos limpios de décimas de segundo', () => {
+    // El empalme en identidad exige durs múltiplos exactos del loop CSS; como
+    // mínimo, ninguno puede ser un número "raro" que delate un cálculo roto.
+    for (const [slug, r] of Object.entries(VIDA_REPERTORIO)) {
+      for (const [nombre, m] of Object.entries(r.momentos)) {
+        expect(m.dur % 10, `${slug}:${nombre}`).toBe(0);
+      }
+    }
+  });
+
+  it('duracionDeDescanso respeta el rango del temperamento (jitter inyectable)', () => {
+    for (const [slug, r] of Object.entries(VIDA_REPERTORIO)) {
+      expect(duracionDeDescanso(slug, () => 0)).toBe(r.descanso[0]);
+      expect(duracionDeDescanso(slug, () => 1)).toBe(r.descanso[1]);
+      const d = duracionDeDescanso(slug);
+      expect(d).toBeGreaterThanOrEqual(r.descanso[0]);
+      expect(d).toBeLessThanOrEqual(r.descanso[1]);
+    }
+    expect(duracionDeDescanso('nadie')).toBe(6000); // fallback digno
+  });
+});
+
+describe('4. crearRitmoPropio — el fix del metrónomo', () => {
+  it('devuelve las 3 vars CSS con unidades y rangos del contrato', () => {
+    const r = crearRitmoPropio(() => 0.5);
+    expect(r['--rh-blink-dur']).toMatch(/^\d+\.\d{2}s$/);
+    expect(r['--rh-blink-delay']).toMatch(/^-\d+\.\d{2}s$/);
+    expect(r['--rh-mirada-delay']).toMatch(/^-\d+\.\d{2}s$/);
+    const dur = parseFloat(r['--rh-blink-dur']);
+    expect(dur).toBeGreaterThanOrEqual(4.9);
+    expect(dur).toBeLessThanOrEqual(6.6);
+  });
+
+  it('dos instancias con azar real casi nunca comparten fase (anti-metrónomo)', () => {
+    const a = crearRitmoPropio();
+    const b = crearRitmoPropio();
+    // Con 2 decimales de resolución la colisión total es despreciable; si este
+    // test parpadea, el azar está roto de verdad.
+    expect(`${a['--rh-blink-dur']}${a['--rh-blink-delay']}`)
+      .not.toBe(`${b['--rh-blink-dur']}${b['--rh-blink-delay']}`);
+  });
+});

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -281,7 +281,11 @@
 .rh-blink {
   transform-box: fill-box;
   transform-origin: center;
-  animation: rh-blink 5.6s linear infinite;
+  /* RITMO PROPIO (vida v2): cada instancia trae su duración y su fase por
+     vars (useRitmoPropio) — dos bichos jamás parpadean al tiempo. Sin vars
+     (consumidores viejos) queda el compás clásico de 5.6s. */
+  animation: rh-blink var(--rh-blink-dur, 5.6s) linear infinite;
+  animation-delay: var(--rh-blink-delay, 0s);
 }
 @keyframes rh-blink {
   0%, 36%, 40%, 74%, 78%, 82%, 86%, 100% { transform: scaleY(1); }
@@ -297,6 +301,8 @@
    loop). Amplitudes en unidades del viewBox (≈2px en un avatar de 64). */
 .rh-mirada {
   animation: rh-mirada 7.9s ease-in-out infinite;
+  /* Fase propia por instancia (vida v2): los dardeos tampoco son de metrónomo. */
+  animation-delay: var(--rh-mirada-delay, 0s);
 }
 @keyframes rh-mirada {
   0%, 20%, 47%, 58%, 76%, 100% { transform: translate(0, 0); }
@@ -1206,7 +1212,9 @@
 }
 [data-creature='jaguar'][data-ruge='1'] .jaguar-cejas,
 [data-creature='jaguar'][data-acecha='1'] .jaguar-cejas {
-  animation: jaguar-cejas-frunce 1.1s ease-in-out infinite;
+  /* 1.6s divide exacto el rugido (1.6s) y el acecho (3.2s): el idle-cerebro
+     suelta el gesto en identidad sin que las cejas queden a mitad de fruncido. */
+  animation: jaguar-cejas-frunce 1.6s ease-in-out infinite;
 }
 @keyframes jaguar-cejas-frunce {
   0%, 100% { transform: translateY(0) scaleX(1); }
@@ -1623,7 +1631,9 @@
   50%      { transform: scaleX(1.14) rotate(1.2deg); }  /* los bigotes se abren */
 }
 [data-creature='borugo'][data-olfatea='1'] .borugo-orejas {
-  animation: borugo-orejas-perk 0.9s ease-in-out infinite;
+  /* 1.1s = 1/3 del olfateo del cerebro (3.3s = 6× nariz 0.55s): las orejitas
+     cierran en identidad exacto cuando el idle-cerebro suelta el gesto. */
+  animation: borugo-orejas-perk 1.1s ease-in-out infinite;
 }
 @keyframes borugo-orejas-perk {
   0%, 100% { transform: translateY(-0.3px) scaleY(1.06); }
@@ -1861,4 +1871,139 @@
   /* la roseta-guardián queda abierta y digna, sin latir */
   .ent-poder .ent-roseta,
   [data-creature='ent-frailejon'][data-poder='1'] .ent-roseta { transform: scale(1.06); }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   VIDA v2 — LA VARA DE ANGELITA APLICADA A LOS 8 BICHOS (idle-cerebro +
+   mirada que reconoce + gestos-firma nuevos de colibrí y rana).
+   El reloj vive en useVidaIdle.js; el repertorio en vidaEstados.js. Aquí:
+     1. La MIRADA QUE LO RECONOCE — data-rh-mira='usted' pisa el dardeo
+        natural y las pupilas siguen su puntero (vars --rh-mx/--rh-my).
+     2. COLIBRÍ: acicala (pico al ala) + vibra (burst staccato de emoción).
+     3. RANA: croa (la garganta canta) + medita (zen hondo, ojos que caen).
+   Todo transform/opacity (GPU, Android gama baja), RM-safe, tier-safe.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ── LA MIRADA QUE LO RECONOCE (species-agnostic) ────────────────────────────
+   Cuando el bicho "se da cuenta" de usted (useMiradaUsted pone el attr en el
+   nodo raíz), las pupilas dejan su dardeo y lo SIGUEN con un empalme suave.
+   Al soltarlo (~2s quieto) vuelven a su dardeo natural. Al final del archivo
+   para ganar la cascada sobre .rh-mirada. */
+[data-rh-mira='usted'] .rh-mirada {
+  animation: none;
+  transform: translate(var(--rh-mx, 0px), var(--rh-my, 0px));
+  transition: transform 0.16s ease-out;
+}
+
+/* ── COLIBRÍ · ACICALA (aseo de ave: el pico peina el ala) ───────────────────
+   El cuerpo entero pica hacia el ala trasera (transform-origin al centro),
+   da DOS pasadas de peine y vuelve con overshoot. 2.6s = un loop exacto del
+   compás del cerebro. El dardo y las estelas se pausan (nadie se asea
+   dardeando); los antics ceden como en todos los gestos de la casa. */
+[data-creature='colibri'][data-acicala='1'] .crt-body {
+  animation: colibri-acicala 2.6s cubic-bezier(0.4, 0, 0.3, 1.3) infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+@keyframes colibri-acicala {
+  0%, 100% { transform: rotate(0deg) translateY(0); }
+  16%      { transform: rotate(-26deg) translateY(0.7px); } /* baja el pico al ala */
+  30%      { transform: rotate(-19deg) translateY(0.5px); } /* pasada 1 */
+  44%      { transform: rotate(-27deg) translateY(0.7px); } /* pasada 2 */
+  58%      { transform: rotate(-18deg) translateY(0.4px); }
+  82%      { transform: rotate(5deg) translateY(-0.2px); }  /* overshoot al volver */
+}
+[data-creature='colibri'][data-acicala='1'] .colibri-estela { opacity: 0; }
+[data-creature='colibri'][data-acicala='1'] .colibri-dardo,
+[data-creature='colibri'][data-vibra='1'] .colibri-dardo { animation: none; }
+
+/* ── COLIBRÍ · VIBRA (el burst staccato: la emoción que no cabe) ─────────────
+   Jitter chiquito y VELOZ con squash&stretch — el hiperactivo vibra en el
+   sitio como olla a presión. 0.45s por loop; el cerebro lo sostiene 4 loops. */
+[data-creature='colibri'][data-vibra='1'] .crt-body {
+  animation: colibri-vibra 0.45s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+@keyframes colibri-vibra {
+  0%, 100% { transform: translate(0, 0) scale(1, 1); }
+  25%      { transform: translate(0.3px, -0.5px) scale(1.04, 0.95); }
+  50%      { transform: translate(-0.25px, 0.2px) scale(0.96, 1.05); }
+  75%      { transform: translate(0.25px, 0.3px) scale(1.03, 0.97); }
+}
+/* el aleteo se apura durante el burst (la emoción sube las revoluciones) */
+[data-creature='colibri'][data-vibra='1'] .crt-wing { animation-duration: 0.07s; }
+
+/* ── RANA · CROA (el canto: la garganta se INFLA y suelta) ───────────────────
+   La papada que ya late (crt-garganta) se hincha GRANDE dos veces con el
+   compás del canto; el cuerpo acompaña con squash de esfuerzo. La rana canta
+   PLANTADA: el salto espera a que termine. 2.4s = un loop del cerebro. */
+[data-creature='rana-andina'][data-croa='1'] .crt-garganta {
+  animation: rana-croa-garganta 2.4s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+}
+@keyframes rana-croa-garganta {
+  0%, 100% { transform: scale(1, 1); }
+  20%      { transform: scale(1.55, 1.75); } /* se INFLA — el globo del croar */
+  36%      { transform: scale(1.1, 1.14); }  /* suelta el canto */
+  56%      { transform: scale(1.48, 1.65); } /* segundo croar */
+  78%      { transform: scale(0.95, 0.92); } /* exhala, vacía */
+}
+[data-creature='rana-andina'][data-croa='1'] .crt-body {
+  animation: rana-croa-cuerpo 2.4s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes rana-croa-cuerpo {
+  0%, 100% { transform: scale(1, 1); }
+  20%      { transform: scale(1.06, 0.93); } /* el esfuerzo del canto (squash) */
+  56%      { transform: scale(1.05, 0.94); }
+}
+
+/* ── RANA · MEDITA (zen hondo — paciente pero MUY inteligente) ───────────────
+   Los párpados CAEN despacio y se quedan caídos casi todo el rato (pisa el
+   parpadeo normal), la respiración se vuelve honda y lenta. La quietud como
+   gesto: la sabia del agua se va para adentro. 4.8s = un loop del cerebro. */
+[data-creature='rana-andina'][data-medita='1'] .rh-blink {
+  animation: rana-medita-ojos 4.8s ease-in-out infinite;
+}
+@keyframes rana-medita-ojos {
+  0%, 100%  { transform: scaleY(1); }
+  16%, 84%  { transform: scaleY(0.12); } /* párpados caídos, serena */
+}
+[data-creature='rana-andina'][data-medita='1'] .crt-body {
+  animation: rana-medita-respira 4.8s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+@keyframes rana-medita-respira {
+  0%, 100% { transform: scale(1, 1) translateY(0); }
+  45%      { transform: scale(1.05, 1.07) translateY(-0.35px); } /* inhala hondo */
+  72%      { transform: scale(0.985, 0.965) translateY(0.1px); } /* suelta despacio */
+}
+/* la rana ni salta ni dardea la mirada mientras canta o medita */
+[data-creature='rana-andina'][data-croa='1'] .rana-salto,
+[data-creature='rana-andina'][data-medita='1'] .rana-salto,
+[data-creature='rana-andina'][data-medita='1'] .rh-mirada { animation: none; }
+
+/* Los ANTICS ceden durante los gestos nuevos (patrón de toda la casa: un
+   gesto a la vez — la vuelta de campana no interrumpe el canto). */
+[data-creature='colibri'][data-acicala='1'] .rh-antic,
+[data-creature='colibri'][data-acicala='1'] .rh-travieso,
+[data-creature='colibri'][data-vibra='1'] .rh-antic,
+[data-creature='colibri'][data-vibra='1'] .rh-travieso,
+[data-creature='rana-andina'][data-croa='1'] .rh-antic,
+[data-creature='rana-andina'][data-croa='1'] .rh-travieso,
+[data-creature='rana-andina'][data-medita='1'] .rh-antic,
+[data-creature='rana-andina'][data-medita='1'] .rh-travieso { animation: none; }
+
+/* Cinturón y tirantes: quietud pedida = fotograma digno (los gestos nuevos
+   quedan estáticos; la mirada-que-sigue ni se activa — el JS ya no corre). */
+@media (prefers-reduced-motion: reduce) {
+  [data-creature='colibri'][data-acicala='1'] .crt-body,
+  [data-creature='colibri'][data-vibra='1'] .crt-body,
+  [data-creature='rana-andina'][data-croa='1'] .crt-garganta,
+  [data-creature='rana-andina'][data-croa='1'] .crt-body,
+  [data-creature='rana-andina'][data-medita='1'] .rh-blink,
+  [data-creature='rana-andina'][data-medita='1'] .crt-body { animation: none !important; }
+  [data-rh-mira='usted'] .rh-mirada { transition: none !important; }
 }

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -93,6 +93,14 @@ export {
 export { AccesoriosClima } from './AccesoriosClima.jsx';
 // Line-boil (contorno que vibra, años 30).
 export { LineBoilFilter, BOIL_SEEDS } from './LineBoilFilter.jsx';
+// VIDA v2 (la vara de Angelita en los 8): idle-cerebro species-agnostic +
+// ritmo propio de parpadeo + la mirada que reconoce. Los bichos ya la traen
+// por dentro (default ON); se exporta para hosts que quieran dirigirla.
+export {
+  VIDA_REPERTORIO, MOMENTO_POSE,
+  elegirMomentoVida, duracionDeMomentoVida, duracionDeDescanso, crearRitmoPropio,
+} from './vidaEstados.js';
+export { useVidaIdle, useRitmoPropio, useMiradaUsted, prefiereQuietud } from './useVidaIdle.js';
 
 import AbejaAngelita from './AbejaAngelita.jsx';
 import Colibri from './Colibri.jsx';

--- a/src/visual/creatures/useVidaIdle.js
+++ b/src/visual/creatures/useVidaIdle.js
@@ -1,0 +1,149 @@
+/*
+ * useVidaIdle — el IDLE-CEREBRO species-agnostic de la familia rubber-hose
+ * (la vara de Angelita v2, `agente/Angelita.jsx`, aplicada a los 8 bichos).
+ *
+ * Lo que separa una criatura de un logo es que EXISTE aunque nadie le hable:
+ * un reloj con jitter hojea el repertorio de su especie (vidaEstados.js) —
+ * el oso resopla y se rasca, el jaguar acecha, la ardilla se cuelga de cabeza,
+ * el morrocoy asiente, el borugo olfatea, la rana croa, el colibrí se acicala,
+ * el perezoso dormita — y entre gesto y gesto vuelve a su identidad serena.
+ * Nunca repite el mismo gesto dos veces seguidas.
+ *
+ * TRES herramientas, mismas garantías que Angelita v2:
+ *   useVidaIdle(slug, activo)   → el momento vigente (null = identidad).
+ *   useRitmoPropio()            → vars CSS de parpadeo/dardeo con fase propia
+ *                                 por instancia (mata el metrónomo del robot).
+ *   useMiradaUsted(ref, activo) → las pupilas SIGUEN su puntero/dedo cuando
+ *                                 anda cerca y lo sueltan a los ~2s.
+ *
+ * GATES (los de la casa, sin excepción): `activo=false` (animated=false, tier
+ * 'bajo', gesto manual del host) apaga todo; prefers-reduced-motion apaga el
+ * JS entero (la dignidad de la calma es de TODO el cuerpo, timers incluidos).
+ * Costo: UN setTimeout vivo por instancia activa; la mirada es un listener
+ * passive + rAF-throttle con DOM directo (cero re-renders por mover el mouse).
+ */
+import { useEffect, useRef, useState } from 'react';
+import {
+  elegirMomentoVida,
+  duracionDeMomentoVida,
+  duracionDeDescanso,
+  crearRitmoPropio,
+} from './vidaEstados.js';
+
+/* ¿El usuario pidió quietud? Los sistemas JS se apagan igual que el CSS. */
+export function prefiereQuietud() {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * El IDLE-CEREBRO: descanso (identidad) → gesto → descanso → otro gesto…
+ * Arranca SIEMPRE descansando (el primer render es idéntico al de antes: los
+ * consumidores y tests existentes no ven nada nuevo hasta el primer compás).
+ *
+ * @param {string} slug  especie (clave de VIDA_REPERTORIO).
+ * @param {boolean} activo  el gate ya resuelto por el bicho (vivo && tier
+ *   !== 'bajo' && sin gesto manual del host).
+ * @returns {string|null} el momento vigente ('resopla', 'reposo'…) o null.
+ */
+export function useVidaIdle(slug, activo) {
+  const [momento, setMomento] = useState(/** @type {string|null} */ (null));
+  useEffect(() => {
+    if (!activo || prefiereQuietud()) return undefined;
+    let timer = 0;
+    let ultimo = /** @type {string|null} */ (null);
+    const descansa = () => {
+      setMomento(null);
+      timer = window.setTimeout(gesticula, duracionDeDescanso(slug));
+    };
+    const gesticula = () => {
+      ultimo = elegirMomentoVida(slug, ultimo);
+      if (!ultimo) return; // especie sin repertorio: identidad para siempre
+      setMomento(ultimo);
+      timer = window.setTimeout(descansa, duracionDeMomentoVida(slug, ultimo));
+    };
+    // Arranca al próximo tick (nunca setState síncrono dentro del effect) y
+    // SIEMPRE desde el descanso: nadie gesticula nada más nacer.
+    timer = window.setTimeout(descansa, 0);
+    return () => {
+      window.clearTimeout(timer);
+      setMomento(null); // al apagar el gate, el gesto no queda colgado
+    };
+  }, [slug, activo]);
+  return momento;
+}
+
+/**
+ * RITMO PROPIO de parpadeo/dardeo — una vez al montar: duración y fase con
+ * azar para que cada instancia parpadee a SU aire (dos bichos en la misma
+ * pantalla jamás parpadean al tiempo). El CSS las consume como vars en
+ * `.rh-blink` / `.rh-mirada` (creatures.css).
+ * @returns {Record<string, string>} vars CSS para el style del nodo raíz.
+ */
+export function useRitmoPropio() {
+  const [ritmo] = useState(crearRitmoPropio);
+  return ritmo;
+}
+
+/* Hasta dónde "se da cuenta" del puntero (px) y cuánto sostiene la mirada
+   después del último movimiento antes de soltarlo (ms) — mismos compases que
+   Angelita v2. La deflexión satura a ~150px (más lejos ya es "hacia allá"). */
+const RADIO_DE_ATENCION = 340;
+const SUELTA_MIRADA_MS = 1900;
+
+/**
+ * LA MIRADA QUE LO RECONOCE — si su puntero/dedo anda cerca, las pupilas lo
+ * siguen (data-rh-mira='usted' + vars --rh-mx/--rh-my sobre el nodo raíz; la
+ * regla CSS vive en creatures.css y pisa el dardeo natural). Al quedarse
+ * quieto ~2s lo suelta. DOM directo vía ref (React no administra estos
+ * attrs): cero re-renders por mover el mouse.
+ *
+ * @param {{ current: Element|null }} ref  el nodo raíz del bicho (svg o g).
+ * @param {boolean} activo  gate ya resuelto (vivo && tier !== 'bajo').
+ */
+export function useMiradaUsted(ref, activo) {
+  useEffect(() => {
+    const raiz = ref.current;
+    if (!activo || !raiz || prefiereQuietud()) return undefined;
+    let raf = 0;
+    let soltar = 0;
+    let px = 0;
+    let py = 0;
+    const liberar = () => raiz.removeAttribute('data-rh-mira');
+    const mirar = () => {
+      raf = 0;
+      const r = raiz.getBoundingClientRect();
+      if (!r.width) return;
+      // Sus ojos viven arriba del centro del dibujo (la cabeza, no el tronco).
+      const dx = px - (r.left + r.width / 2);
+      const dy = py - (r.top + r.height * 0.4);
+      if (Math.hypot(dx, dy) > RADIO_DE_ATENCION) { liberar(); return; }
+      // Deflexión de pupila en unidades del viewBox (la misma amplitud ~0.55
+      // del dardeo natural de rh-mirada).
+      const mx = Math.max(-1, Math.min(1, dx / 150)) * 0.55;
+      const my = Math.max(-1, Math.min(1, dy / 150)) * 0.42;
+      raiz.style.setProperty('--rh-mx', `${mx.toFixed(3)}px`);
+      raiz.style.setProperty('--rh-my', `${my.toFixed(3)}px`);
+      raiz.setAttribute('data-rh-mira', 'usted');
+      window.clearTimeout(soltar);
+      soltar = window.setTimeout(liberar, SUELTA_MIRADA_MS);
+    };
+    const onMove = (ev) => {
+      px = ev.clientX;
+      py = ev.clientY;
+      if (!raf) raf = window.requestAnimationFrame(mirar);
+    };
+    window.addEventListener('pointermove', onMove, { passive: true });
+    window.addEventListener('pointerdown', onMove, { passive: true });
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerdown', onMove);
+      if (raf) window.cancelAnimationFrame(raf);
+      window.clearTimeout(soltar);
+      liberar();
+      raiz.style.removeProperty('--rh-mx');
+      raiz.style.removeProperty('--rh-my');
+    };
+  }, [ref, activo]);
+}

--- a/src/visual/creatures/vidaEstados.js
+++ b/src/visual/creatures/vidaEstados.js
@@ -1,0 +1,177 @@
+/*
+ * vidaEstados — el REPERTORIO DEL IDLE VIVO de los 8 bichos rubber-hose,
+ * como SOLO DATOS + funciones puras (cero React, cero DOM, cero azar oculto).
+ *
+ * Es la MISMA vara que Angelita v2 (`agente/angelitaEstados.js` →
+ * MOMENTOS_IDLE + elegirMomentoIdle), extendida species-agnostic: una criatura
+ * de verdad EXISTE aunque nadie le hable — entre ratos de identidad serena se
+ * rasca, resopla, olfatea, se retrae, croa o se acuesta un rato… cada especie
+ * con SU repertorio y SU compás (la ardilla no descansa lo que descansa el
+ * morrocoy). `useVidaIdle` (el reloj con jitter) hojea este repertorio; la
+ * CADENCIA de cada momento ya vive en `creatures.css` como los gestos-firma
+ * opt-in de cada bicho (data-resopla, data-acecha, data-olfatea…) — este
+ * módulo solo decide CUÁNDO y CUÁL.
+ *
+ * REGLA DURA (la misma de Angelita v2): `dur` (ms) debe ser MÚLTIPLO EXACTO
+ * de la duración del keyframe-loop CSS del elemento DOMINANTE del gesto — el
+ * scheduler suelta el atributo justo cuando el loop cierra en identidad y el
+ * empalme no salta. Los múltiplos están anotados momento a momento.
+ *
+ * `peso` = probabilidad relativa al elegir. El gesto elegido NUNCA repite el
+ * anterior (una criatura viva no se rasca dos veces seguidas como un GIF).
+ *
+ * REGLA DE ORO (la de abejaIdentidad.js): SOLO datos y funciones puras. La
+ * CADENCIA vive en `creatures.css`; el RELOJ en `useVidaIdle.js`; el DIBUJO
+ * en cada bicho.
+ */
+
+/* ── EL REPERTORIO POR ESPECIE ───────────────────────────────────────────────
+   momento → { dur, peso }. El nombre del momento ES el nombre del gesto-firma
+   del bicho ('resopla' → data-resopla) o la pose species-agnostic 'reposo'
+   (data-pose='reposo', rh-g-reposo 4.4s). `descanso` = [min,max] ms del rato
+   de identidad serena entre gestos (con jitter: el reloj de una criatura viva
+   no es de cuarzo). El TEMPERAMENTO va en el compás: los nerviosos (ardilla,
+   colibrí) gesticulan seguido; los lentos (morrocoy, perezoso) casi nunca. */
+export const VIDA_REPERTORIO = {
+  'oso-andino': {
+    descanso: [4200, 9800],
+    momentos: {
+      resopla: { dur: 4500, peso: 2 }, // 3× oso-resoplido 1.5s · 5× oso-cejas-frunce 0.9s
+      rasca: { dur: 3000, peso: 2 }, // 3× oso-rasca-cuerpo 1.0s · 6× oso-rasca 0.5s
+      reposo: { dur: 8800, peso: 1 }, // 2× rh-g-reposo 4.4s — el guardián se sienta
+    },
+  },
+  colibri: {
+    descanso: [2600, 6400], // hiperactivo: casi no se queda quieto
+    momentos: {
+      acicala: { dur: 2600, peso: 2 }, // 1× colibri-acicala 2.6s — pico al ala
+      vibra: { dur: 1800, peso: 2 }, // 4× colibri-vibra 0.45s — burst staccato
+      reposo: { dur: 8800, peso: 0.8 }, // 2× rh-g-reposo — el ÚNICO momento quieto
+    },
+  },
+  'rana-andina': {
+    descanso: [4200, 9800],
+    momentos: {
+      croa: { dur: 2400, peso: 2 }, // 1× rana-croa-garganta 2.4s — el canto
+      medita: { dur: 4800, peso: 1.5 }, // 1× rana-medita-respira 4.8s — zen hondo
+      reposo: { dur: 8800, peso: 1 }, // 2× rh-g-reposo
+    },
+  },
+  perezoso: {
+    descanso: [6400, 13200], // lentísimo: la tensión cómica es la espera
+    momentos: {
+      estira: { dur: 5200, peso: 2 }, // 1× perezoso-estira 5.2s
+      dormita: { dur: 8400, peso: 2 }, // 2× perezoso-zzz 4.2s — se le van las luces
+      reposo: { dur: 8800, peso: 1 }, // 2× rh-g-reposo
+    },
+  },
+  ardilla: {
+    descanso: [2600, 6400], // inquieta: pizpireta, no para
+    momentos: {
+      inspecciona: { dur: 3400, peso: 2 }, // 1× ardilla-invierte 3.4s — su firma
+      roe: { dur: 3060, peso: 2 }, // 9× ardilla-roe 0.34s
+      reposo: { dur: 4400, peso: 0.6 }, // 1× rh-g-reposo — descansa POCO
+    },
+  },
+  jaguar: {
+    descanso: [4200, 9800],
+    momentos: {
+      acecha: { dur: 6400, peso: 2 }, // 2× jaguar-acecho 3.2s · 4× cejas 1.6s
+      ruge: { dur: 3200, peso: 1 }, // 2× jaguar-rugido 1.6s — raro e imponente
+      reposo: { dur: 8800, peso: 1 }, // 2× rh-g-reposo
+    },
+  },
+  morrocoy: {
+    descanso: [6400, 13200], // ancestral: la sabiduría no corre
+    momentos: {
+      asiente: { dur: 5600, peso: 2 }, // 2× morrocoy-asiente 2.8s — el sabio asiente
+      seRetrae: { dur: 4600, peso: 1 }, // 1× morrocoy-retrae 4.6s — su firma elástica
+      reposo: { dur: 8800, peso: 1.5 }, // 2× rh-g-reposo — descansar es lo suyo
+    },
+  },
+  borugo: {
+    descanso: [4200, 9800],
+    momentos: {
+      olfatea: { dur: 3300, peso: 2.5 }, // 6× borugo-olfateo 0.55s · 3× orejas 1.1s
+      acurruca: { dur: 4600, peso: 1 }, // 1× borugo-acurruca 4.6s — el corazón del cierre
+      reposo: { dur: 4400, peso: 1 }, // 1× rh-g-reposo
+    },
+  },
+};
+
+/* El nombre de momento que significa "pose species-agnostic", no gesto-firma:
+   el bicho lo traduce a data-pose='reposo' en vez de a un data-attr propio. */
+export const MOMENTO_POSE = 'reposo';
+
+/* Gestos elegibles por especie (peso > 0), congelados una vez. */
+const GESTOS_DE = Object.fromEntries(
+  Object.entries(VIDA_REPERTORIO).map(([slug, r]) => [
+    slug,
+    Object.keys(r.momentos).filter((m) => r.momentos[m].peso > 0),
+  ]),
+);
+
+/**
+ * Elige el próximo micro-gesto del idle de una especie: azar ponderado que
+ * NUNCA repite el anterior. Pura y testeable: el azar se inyecta.
+ * @param {string} slug  especie (clave de VIDA_REPERTORIO).
+ * @param {string|null} [previo]  el último gesto hecho (se excluye).
+ * @param {() => number} [rand]  fuente de azar 0..1 (default Math.random).
+ * @returns {string|null} nombre del momento elegido (null si la especie no
+ *   tiene repertorio — el bicho queda en su identidad de siempre, sin romper).
+ */
+export function elegirMomentoVida(slug, previo = null, rand = Math.random) {
+  const gestos = GESTOS_DE[slug];
+  if (!gestos || gestos.length === 0) return null;
+  const candidatos = gestos.length > 1 ? gestos.filter((m) => m !== previo) : gestos;
+  const momentos = VIDA_REPERTORIO[slug].momentos;
+  const total = candidatos.reduce((s, m) => s + momentos[m].peso, 0);
+  let bola = rand() * total;
+  for (const m of candidatos) {
+    bola -= momentos[m].peso;
+    if (bola <= 0) return m;
+  }
+  return candidatos[candidatos.length - 1];
+}
+
+/**
+ * Duración en ms de un momento (el tiempo que el scheduler sostiene el gesto
+ * — múltiplo exacto del loop CSS, ver REGLA DURA arriba).
+ * @param {string} slug @param {string} momento
+ * @returns {number}
+ */
+export function duracionDeMomentoVida(slug, momento) {
+  const m = VIDA_REPERTORIO[slug]?.momentos?.[momento];
+  return m ? m.dur : 0;
+}
+
+/**
+ * Duración en ms del próximo rato de identidad serena (descanso entre gestos),
+ * con jitter dentro del rango del temperamento de la especie.
+ * @param {string} slug
+ * @param {() => number} [rand]
+ * @returns {number}
+ */
+export function duracionDeDescanso(slug, rand = Math.random) {
+  const d = VIDA_REPERTORIO[slug]?.descanso;
+  if (!d) return 6000;
+  return Math.round(d[0] + rand() * (d[1] - d[0]));
+}
+
+/**
+ * RITMO PROPIO por instancia — el fix del metrónomo: `.rh-blink` corría con
+ * la MISMA duración y fase en todas las instancias, así que todos los bichos
+ * de una pantalla parpadeaban al tiempo (el robot delatado — mismo hallazgo
+ * de Angelita v2). Estas vars CSS le dan a CADA instancia su propia duración
+ * y fase de parpadeo y su propia fase de dardeo de pupilas. Pura: el azar se
+ * inyecta (default Math.random, una vez al montar).
+ * @param {() => number} [rand]
+ * @returns {Record<string, string>} vars CSS para el style del nodo raíz.
+ */
+export function crearRitmoPropio(rand = Math.random) {
+  return {
+    '--rh-blink-dur': `${(4.9 + rand() * 1.7).toFixed(2)}s`,
+    '--rh-blink-delay': `${(-rand() * 5).toFixed(2)}s`,
+    '--rh-mirada-delay': `${(-rand() * 7.9).toFixed(2)}s`,
+  };
+}


### PR DESCRIPTION
## Los 8 bichos al nivel de Angelita — vida v2 species-agnostic

**El diagnóstico**: Angelita v2 (`fable/angelita-v2-vida`) tiene idle-cerebro, ritmo propio y mirada que reconoce. Los otros 8 tenían TODOS sus gestos-firma como props opt-in que **nadie disparaba jamás**: en escena quedaban en loop de boil eterno. Además `.rh-blink` corría con la misma duración y fase en todas las instancias — todos los bichos parpadeaban al unísono (el metrónomo que delata al robot). Y colibrí y rana **no tenían ningún gesto-firma**.

**La solución** (misma vara, species-agnostic, patrón de la casa motor+perfil):
- `vidaEstados.js` — repertorio por especie (SOLO datos): momentos, pesos, descansos por temperamento. Durs = múltiplos exactos del loop CSS (el cerebro suelta el gesto en identidad, sin salto).
- `useVidaIdle.js` — el idle-cerebro (reloj con jitter, azar ponderado que nunca repite), `useRitmoPropio` (vars de parpadeo/dardeo por instancia) y `useMiradaUsted` (las pupilas siguen su puntero/dedo y lo sueltan a los ~2s — DOM directo vía rAF, cero re-renders).
- `creatures.css` — vars de ritmo en `rh-blink`/`rh-mirada`, la mirada-que-sigue (`data-rh-mira`), y los gestos NUEVOS de colibrí (`acicala`, `vibra`) y rana (`croa`, `medita`).
- Los 8 componentes: cerebro **default ON**; CEDE ante cualquier dirección manual del host (gesto/pose/visema). `vida={false}` = el bicho de antes, idéntico.

## Cuadro comparativo por bicho

| Bicho | Qué tiene Angelita (vara v2) | Qué le faltaba | Qué se le puso |
|---|---|---|---|
| **Oso andino** 🐻 | idle-cerebro, ritmo propio, mirada | `resopla`/`rasca` existían pero nadie los disparaba; parpadeo en metrónomo; pupilas fijas | cerebro (resopla·rasca·reposo, compás pesado 4.2–9.8s), ritmo propio, mirada-que-sigue |
| **Colibrí** 🐦 | ídem | **CERO gestos-firma** (solo dardo continuo); metrónomo; pupilas fijas | 2 gestos NUEVOS (`acicala`: pico al ala con 2 pasadas · `vibra`: burst staccato + aleteo a 0.07s), cerebro nervioso (2.6–6.4s), ritmo, mirada |
| **Rana arlequín** 🐸 | ídem | **CERO gestos-firma** (solo garganta que late); metrónomo; pupilas fijas | 2 gestos NUEVOS (`croa`: garganta inflada ×2 + squash de esfuerzo · `medita`: párpados caídos + respiración honda), cerebro, ritmo, mirada |
| **Perezoso** 🦥 | ídem | `dormita`/`estira` sin disparador; metrónomo | cerebro lentísimo (6.4–13.2s de descanso — la tensión cómica es la espera), ritmo, mirada |
| **Ardilla** 🐿️ | ídem | `inspecciona`/`roe` sin disparador; metrónomo | cerebro inquieto (2.6–6.4s, casi no reposa), ritmo, mirada |
| **Jaguar** 🐆 | ídem | `ruge`/`acecha` sin disparador; metrónomo; cejas 1.1s desfasaban el cierre | cerebro (acecha frecuente, ruge raro e imponente), cejas a 1.6s (divisor exacto), ritmo, mirada |
| **Morrocoy** 🐢 | ídem | `seRetrae`/`asiente` sin disparador; metrónomo | cerebro ancestral (asiente seguido, retracción rara, mucho reposo), ritmo, mirada |
| **Borugo** 🦫 | ídem | `olfatea`/`acurruca` sin disparador; metrónomo; orejas 0.9s desfasaban | cerebro tierno (olfateo frecuente, acurruca de vez en cuando), orejas a 1.1s, ritmo, mirada |
| Angelita 🐝 | — es la vara — | — | **no se tocó** (su v2 vive en `agente/`) |

## Verificación (síncrona, capturas reales)

Arnés versionado `scripts/diag/captura-bichos.{html,jsx}` + `captura-bichos-shot.mjs` (chromium sistema + playwright, secuencia t=2/12/22/32s):

- **ANTES (origin/dev)**: fila viva clavada en pose base en los 4 tiempos — nadie hace nada, nunca. Gestos forzados de colibrí/rana = idénticos al base (no existían).
- **DESPUÉS**: t=12s el oso se rasca solo y la ardilla cuelga de cabeza; t=32s el oso resopla, la rana reposa y el perezoso se estira — rotación sin repetir, etiqueta `data-vida` en vivo en cada frame.
- **Mirada/ritmo (playwright)**: `data-rh-mira="usted"` + `--rh-mx` al acercar el puntero, suelta a los ~2s; blink-delay oso −4.13s vs jaguar −3.30s (metrónomo muerto).
- `npm run build:prod` ✅ · `npm run tsc:check` ✅ limpio · vitest creatures **275/275** ✅ + AvatarSelector 9/9 ✅ (contratos viejos intactos: el cerebro arranca descansando — primer render idéntico).

## Presupuesto (Android barato)

Cabe en tier bajo **porque ahí no corre**: mismos gates que Angelita v2 — `tier='bajo'` apaga cerebro+mirada (quedan los estados reactivos), `prefers-reduced-motion` apaga hasta el JS, `animated=false` (LOD de FaunaAmbiental) = cero timers. En tier alto/medio el costo es 1 setTimeout vivo por instancia + gestos CSS que **ya existían** (solo que ahora se disparan) + un listener passive de puntero con rAF-throttle.

## Notas

- El registro visual no se mezcla: esto es SOLO el carril rubber-hose (personajes). Flora/fauna secundaria/mundos realistas no se tocan.
- `.gitignore`: se agrega `dist-prod` (el build de prod se colaba como untracked).
- Follow-up sugerido (no en este PR): en `FaunaAmbiental` los vecinos lejanos van con `animated=false` (LOD deliberado) — si se quiere que el oso del valle gesticule de verdad en tier alto, es un cambio de una línea sobre la fase `gesto`, pero toca una decisión de perf que prefiero dejar explícita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
