### PR TITLE
fix(bosque): la red micorrízica estaba ENTERRADA — desenterrarla, no iluminarla

### DIFF
--- a/src/visual/mundo3d/__tests__/corteSuelo.test.js
+++ b/src/visual/mundo3d/__tests__/corteSuelo.test.js
@@ -1,0 +1,328 @@
+/*
+ * Invariantes de la VITRINA DE TIERRA del Ent maestro (la lección del subsuelo).
+ *
+ * Estos tests existen por UNA razón concreta, y no es teórica: la pasada 2 dejó
+ * escrito que "la banda de micorrizas se lee oscura y la red se ve más como
+ * brillo que como red". Las dos frases describían el mismo fallo, y era
+ * aritmético: la red se sembraba en z ∈ [0.05, 0.80] y la cara del bloque de
+ * tierra estaba en z = 0.85 → LA RED ENTERA VIVÍA DENTRO DEL LADRILLO OPACO.
+ * Cero píxeles, cero errores, cero forma de enterarse sin mirar una captura.
+ *
+ * Es la MISMA familia del bug de la barba (que colgaba dentro del fuste). Ya van
+ * dos veces que una geometría correcta desaparece dentro de otra sin un solo
+ * síntoma. Estos tests convierten ese fallo silencioso en un test rojo.
+ */
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import {
+  ANCHO_CUT,
+  CARA,
+  CAPAS,
+  ALTO_CORTE,
+  HUECO,
+  ANCLAS,
+  centrosCapas,
+  zFrenteDe,
+  puntaDeAncla,
+  colorHorizonte,
+  construirTierra,
+  construirRaicesBanda,
+  construirRaicesZona,
+  esqueletoRed,
+  geometriaRedBanda,
+  muestrasDeLuz,
+  nodosDeRed,
+  pulsosDeBanda,
+  construirTerreno,
+} from '../bosque/corteSuelo.geom.js';
+
+const banda = CAPAS.find((c) => c.id === 'micorrizas');
+const zona = CAPAS.find((c) => c.id === 'raices');
+const TIERS = /** @type {const} */ (['alto', 'medio', 'bajo']);
+
+const bbox = (geo) => {
+  geo.computeBoundingBox();
+  return geo.boundingBox;
+};
+const lum = (r, g, b) => 0.2126 * r + 0.7152 * g + 0.0722 * b;
+
+describe('LA RED NO ESTÁ ENTERRADA (el bug que costó la tercera pasada)', () => {
+  it.each(TIERS)('en tier %s todo filamento está DELANTE de la cara de la tierra', (tier) => {
+    const { hilos } = esqueletoRed(banda.alto, tier);
+    const geo = geometriaRedBanda(hilos, tier);
+    const bb = bbox(geo);
+    // zFrenteDe('micorrizas') es la cara de la tierra: por detrás no se ve NADA
+    expect(bb.min.z).toBeGreaterThan(zFrenteDe('micorrizas'));
+  });
+
+  it.each(TIERS)('en tier %s la red no se sale del bloque hacia la cámara', (tier) => {
+    const { hilos } = esqueletoRed(banda.alto, tier);
+    const bb = bbox(geometriaRedBanda(hilos, tier));
+    expect(bb.max.z).toBeLessThan(CARA);
+  });
+
+  it.each(TIERS)('en tier %s las raíces de la banda también están a la vista', (tier) => {
+    const bb = bbox(construirRaicesBanda(banda.alto, tier));
+    expect(bb.min.z).toBeGreaterThan(zFrenteDe('micorrizas'));
+  });
+
+  it('las raíces de la zona de raíces están delante de SU cara (alcoba propia)', () => {
+    const bb = bbox(construirRaicesZona(zona.alto, banda.alto, 'alto'));
+    expect(bb.min.z).toBeGreaterThan(zFrenteDe('raices'));
+  });
+
+  it('la alcoba de micorrizas es la más abierta: es la lección', () => {
+    expect(HUECO.micorrizas).toBeGreaterThan(HUECO.raices);
+    expect(HUECO.raices).toBeGreaterThan(HUECO.hojarasca);
+  });
+
+  it('ninguna alcoba se come el bloque entero', () => {
+    for (const c of CAPAS) expect(zFrenteDe(c.id)).toBeGreaterThan(-CARA);
+  });
+});
+
+describe('LA RED SE LEE COMO RED (no como un resplandor)', () => {
+  it('conecta RAÍCES: cada ancla tiene un filamento naciendo en su punta', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'alto');
+    for (const a of ANCLAS) {
+      const punta = puntaDeAncla(a, banda.alto);
+      const tocado = hilos.some((h) => h.nivel === 0
+        && (h.curva.getPoint(0).distanceTo(punta) < 1e-6
+          || h.curva.getPoint(1).distanceTo(punta) < 1e-6));
+      expect(tocado, `la raíz "${a.id}" no está conectada a la red`).toBe(true);
+    }
+  });
+
+  it('hay JERARQUÍA de verdad: rizomorfo → secundaria → punta, y adelgazan', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'alto');
+    const r = (n) => hilos.filter((h) => h.nivel === n);
+    expect(r(0).length).toBeGreaterThan(0);
+    expect(r(1).length).toBeGreaterThan(0);
+    expect(r(2).length).toBeGreaterThan(0);
+    // cada nivel es más fino que el anterior (si no, no hay jerarquía visible)
+    const grosor = (n) => Math.max(...r(n).map((h) => h.r0));
+    expect(grosor(0)).toBeGreaterThan(grosor(1));
+    expect(grosor(1)).toBeGreaterThan(grosor(2));
+  });
+
+  it('todo filamento tiene CONICIDAD (r1 < r0): ninguno es un tubo parejo', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'alto');
+    for (const h of hilos) expect(h.r1).toBeLessThan(h.r0);
+  });
+
+  it('la red OCUPA la banda: no es un collar en el tercio bajo', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'alto');
+    const bb = bbox(geometriaRedBanda(hilos, 'alto'));
+    expect((bb.max.y - bb.min.y) / banda.alto).toBeGreaterThan(0.6);
+    expect((bb.max.x - bb.min.x) / ANCHO_CUT).toBeGreaterThan(0.5);
+  });
+
+  it('la red se queda DENTRO de su banda (no invade las capas vecinas)', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'alto');
+    const bb = bbox(geometriaRedBanda(hilos, 'alto'));
+    const media = banda.alto / 2;
+    expect(bb.min.y).toBeGreaterThanOrEqual(-media - 1e-6);
+    expect(bb.max.y).toBeLessThanOrEqual(media + 1e-6);
+  });
+
+  it('la raíz de la QUEÑUA MADRE es la más gruesa: la lección se lee sin texto', () => {
+    const madre = ANCLAS.find((a) => a.madre);
+    const otras = ANCLAS.filter((a) => !a.madre);
+    for (const o of otras) expect(madre.r0).toBeGreaterThan(o.r0);
+  });
+
+  it('los nodos brillan en las uniones y el de la madre es el mayor', () => {
+    const nodos = nodosDeRed(banda.alto);
+    expect(nodos.length).toBe(ANCLAS.length + 3);
+    const madre = nodos[ANCLAS.findIndex((a) => a.madre)];
+    expect(madre.esc).toBe(Math.max(...nodos.map((n) => n.esc)));
+  });
+
+  it('los pulsos corren SOLO por los rizomorfos (por la lección, no al azar)', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'alto');
+    const pulsos = pulsosDeBanda(hilos, 26);
+    expect(pulsos.length).toBe(26);
+    for (const p of pulsos) expect(hilos[p.hilo].nivel).toBe(0);
+    // en los DOS sentidos: el mineral sube y el azúcar baja
+    expect(pulsos.some((p) => p.dir === 1)).toBe(true);
+    expect(pulsos.some((p) => p.dir === -1)).toBe(true);
+  });
+
+  it('tier bajo: sin pulsos, pero el espinazo de la lección sigue estando', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'bajo');
+    expect(pulsosDeBanda(hilos, 0)).toEqual([]);
+    expect(hilos.filter((h) => h.nivel === 0).length).toBeGreaterThan(0);
+  });
+
+  it('es UN draw-call por pieza: la geometría viene fusionada', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'alto');
+    for (const g of [
+      geometriaRedBanda(hilos, 'alto'),
+      construirRaicesBanda(banda.alto, 'alto'),
+      construirTerreno({ x: 2.5, z: 1.9 }, { tier: 'alto' }),
+    ]) {
+      expect(g).toBeInstanceOf(THREE.BufferGeometry);
+      expect(g.attributes.position.count).toBeGreaterThan(0);
+      expect(g.attributes.color).toBeTruthy();
+    }
+  });
+});
+
+describe('LA BANDA DE MICORRIZAS YA NO SE LEE OSCURA', () => {
+  /* Sin subir un lift plano: la RED le hornea la luz encima. Un lift plano
+     arreglaría la banda y lavaría el filamento — los dos males tiran en
+     direcciones opuestas y por eso la luz tiene que ser LOCAL. */
+  const caraDeLaBanda = (geo) => {
+    const c = geo.attributes.color;
+    const p = geo.attributes.position;
+    const zF = zFrenteDe('micorrizas');
+    const out = [];
+    for (let i = 0; i < c.count; i++) {
+      if (p.getZ(i) < zF - 0.02) continue;
+      out.push(lum(c.getX(i), c.getY(i), c.getZ(i)));
+    }
+    return out;
+  };
+
+  it('la luz de la red levanta la banda respecto a la tierra sin red', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'alto');
+    const sin = caraDeLaBanda(construirTierra(banda, { tier: 'alto', luces: [] }));
+    const con = caraDeLaBanda(construirTierra(banda, { tier: 'alto', luces: muestrasDeLuz(hilos) }));
+    const media = (a) => a.reduce((s, v) => s + v, 0) / a.length;
+    expect(media(con)).toBeGreaterThan(media(sin) * 1.5);
+  });
+
+  it('la luz es LOCAL, no un lift plano: hay rango dinámico dentro de la banda', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'alto');
+    const l = caraDeLaBanda(construirTierra(banda, { tier: 'alto', luces: muestrasDeLuz(hilos) }));
+    // cerca del filamento se enciende; en los huecos se queda oscura → contraste
+    expect(Math.max(...l) / Math.max(1e-6, Math.min(...l))).toBeGreaterThan(5);
+  });
+
+  it('la banda sigue siendo la tierra más oscura: la red tiene contra qué resaltar', () => {
+    const parda = ['hojarasca', 'humus', 'raices'].map(
+      (id) => new THREE.Color(CAPAS.find((c) => c.id === id).color),
+    );
+    const mic = new THREE.Color(banda.color);
+    for (const p of parda) {
+      expect(lum(mic.r, mic.g, mic.b)).toBeLessThan(lum(p.r, p.g, p.b));
+    }
+  });
+
+  it('ninguna tierra cae a NEGRO (el agujero negro de la primera versión)', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'alto');
+    for (const c of centrosCapas()) {
+      const geo = construirTierra(c, {
+        tier: 'alto',
+        luces: c.id === 'micorrizas' ? muestrasDeLuz(hilos) : [],
+      });
+      const col = geo.attributes.color;
+      let mx = 0;
+      for (let i = 0; i < col.count; i++) {
+        mx = Math.max(mx, lum(col.getX(i), col.getY(i), col.getZ(i)));
+      }
+      expect(mx, `la capa "${c.id}" no tiene un solo vértice con luz`).toBeGreaterThan(0.01);
+    }
+  });
+
+  it('la tierra lleva información horneada: no es un color plano', () => {
+    const geo = construirTierra(zona, { tier: 'alto', luces: [] });
+    const c = geo.attributes.color;
+    const vals = [];
+    for (let i = 0; i < c.count; i++) vals.push(lum(c.getX(i), c.getY(i), c.getZ(i)));
+    expect(new Set(vals.map((v) => v.toFixed(4))).size).toBeGreaterThan(20);
+  });
+
+  it('las muestras de luz salen del espinazo, no de las puntas', () => {
+    const { hilos } = esqueletoRed(banda.alto, 'alto');
+    const m = muestrasDeLuz(hilos);
+    expect(m.length).toBeGreaterThan(0);
+    expect(m.some((x) => x.fuerza === 1)).toBe(true);
+    expect(m.every((x) => x.fuerza > 0)).toBe(true);
+  });
+});
+
+describe('EL AIRE MUERTO: el corte ya no flota en el cielo', () => {
+  const terreno = construirTerreno({ x: 2.5, z: 1.9 }, { tier: 'alto' });
+
+  it('el macizo llega HASTA la cara del corte y tapa por detrás', () => {
+    const bb = bbox(terreno);
+    expect(bb.max.z).toBeCloseTo(1.9 + CARA, 5);
+    // sin la caja de DETRÁS se veía el cielo por encima del bloque
+    expect(bb.min.z).toBeLessThan(1.9 - CARA);
+  });
+
+  it('el macizo baja MÁS que el corte: no se le ve el fondo', () => {
+    expect(bbox(terreno).min.y).toBeLessThan(-ALTO_CORTE);
+  });
+
+  it('el macizo no invade la huella del corte por delante (nada de z-fighting)', () => {
+    const p = terreno.attributes.position;
+    const x0 = 2.5 - ANCHO_CUT / 2;
+    const x1 = 2.5 + ANCHO_CUT / 2;
+    const zCara = 1.9 + CARA;
+    for (let i = 0; i < p.count; i++) {
+      const x = p.getX(i);
+      const y = p.getY(i);
+      const z = p.getZ(i);
+      const dentro = x > x0 + 1e-6 && x < x1 - 1e-6
+        && y > -ALTO_CORTE + 1e-6 && y < -1e-6
+        && z > 1.9 - CARA + 1e-6;
+      expect(dentro && Math.abs(z - zCara) < 1e-6).toBe(false);
+    }
+  });
+
+  it('el macizo enseña LOS MISMOS horizontes del corte', () => {
+    for (const c of centrosCapas()) {
+      const medio = (c.top + c.bottom) / 2;
+      expect(colorHorizonte(medio).getHexString()).toBe(
+        new THREE.Color(c.color).getHexString(),
+      );
+    }
+  });
+
+  it('por debajo del corte la roca madre sigue: la tierra no se acaba en la vitrina', () => {
+    const roca = new THREE.Color(CAPAS[CAPAS.length - 1].color).getHexString();
+    expect(colorHorizonte(-ALTO_CORTE - 3).getHexString()).toBe(roca);
+  });
+
+  it('la superficie es musgo de páramo, no tierra', () => {
+    const c = terreno.attributes.color;
+    const p = terreno.attributes.position;
+    let verdes = 0;
+    for (let i = 0; i < p.count; i++) {
+      if (p.getY(i) > -1e-6 && c.getY(i) > c.getX(i) && c.getY(i) > c.getZ(i)) verdes++;
+    }
+    expect(verdes).toBeGreaterThan(0);
+  });
+
+  it('tier bajo: el macizo sigue existiendo pero mucho más barato', () => {
+    const bajo = construirTerreno({ x: 2.5, z: 1.9 }, { tier: 'bajo' });
+    expect(bajo.attributes.position.count).toBeGreaterThan(0);
+    expect(bajo.attributes.position.count).toBeLessThan(terreno.attributes.position.count / 2);
+  });
+});
+
+describe('Presupuesto tier-safe (el equipo humilde no se muere)', () => {
+  it.each(TIERS)('tier %s: la red cabe en el presupuesto', (tier) => {
+    const { hilos } = esqueletoRed(banda.alto, tier);
+    const tris = geometriaRedBanda(hilos, tier).attributes.position.count / 3;
+    const techo = tier === 'alto' ? 9000 : tier === 'medio' ? 4000 : 1500;
+    expect(tris).toBeLessThan(techo);
+  });
+
+  it('el tier alto tiene más red que el bajo (si no, el tier no sirve de nada)', () => {
+    const n = (t) => esqueletoRed(banda.alto, t).hilos.length;
+    expect(n('alto')).toBeGreaterThan(n('medio'));
+    expect(n('medio')).toBeGreaterThan(n('bajo'));
+  });
+
+  it('es determinista: el mismo suelo en cada carga', () => {
+    const a = esqueletoRed(banda.alto, 'alto').hilos;
+    const b = esqueletoRed(banda.alto, 'alto').hilos;
+    expect(a.length).toBe(b.length);
+    for (let i = 0; i < a.length; i++) {
+      expect(a[i].curva.getPoint(0.5).toArray()).toEqual(b[i].curva.getPoint(0.5).toArray());
+    }
+  });
+});

--- a/src/visual/mundo3d/bosque/EscenaEntMaestro.jsx
+++ b/src/visual/mundo3d/bosque/EscenaEntMaestro.jsx
@@ -8,8 +8,10 @@
  * cada una: hojarasca → humus → zona de raíces → red micorrízica (el wood-wide
  * web) → roca madre. Una lección viaja de arriba abajo (la capa que el Ent
  * "explica" se enciende y su nombre resalta), y en la banda de las micorrizas
- * corre la red bioluminiscente con sus pulsos de nutrientes (reusa el módulo de
- * micorrizas — no se rehace, se ENCHUFA aquí).
+ * corre la red bioluminiscente con sus pulsos de nutrientes.
+ *
+ * La geometría de la vitrina vive en `corteSuelo.geom.js` (puro three-core,
+ * testeable headless). Acá solo se monta, se ilumina y se le da vida.
  *
  * Todo procedural (cero CDN/imágenes). Tier-safe: 'alto' pleno (red densa,
  * pulsos, brazo, sombras); 'medio' frugal; 'bajo' mínimo digno. Con
@@ -23,13 +25,26 @@ import { OrbitControls, AdaptiveDpr, Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { perfilDeTier } from '../deviceTier.js';
 import EntQuenua from './EntQuenua.jsx';
+import FloraParamo from './FloraParamo.jsx';
+import { PALETA } from '../micorrizas/micorrizas.geom.js';
 import {
-  PALETA,
-  construirRed,
-  geometriaRed,
-  curvaHilo,
-  pulsosDeRed,
-} from '../micorrizas/micorrizas.geom.js';
+  ANCHO_CUT,
+  PROF_CUT,
+  CARA,
+  CAPAS,
+  ALTO_CORTE,
+  centrosCapas,
+  zFrenteDe,
+  construirTierra,
+  construirRaicesBanda,
+  construirRaicesZona,
+  esqueletoRed,
+  geometriaRedBanda,
+  muestrasDeLuz,
+  nodosDeRed,
+  pulsosDeBanda,
+  construirTerreno,
+} from './corteSuelo.geom.js';
 
 /* CSS del lienzo + de los rótulos de cada capa (self-contained). */
 const CSS = `
@@ -45,43 +60,34 @@ const CSS = `
 `;
 
 /* Cielo del páramo (mismo aire que el Bosque Vivo, para que el Ent se lea igual). */
-const PARAMO = { fondo: '#c3cfce', niebla: '#c9d3d1', musgo: '#5c6844' };
-
-/* Geometría del CORTE: ancho/prof del bloque de suelo (la vitrina de tierra). */
-const ANCHO_CUT = 3.2;
-const PROF_CUT = 1.7;
-const CARA = PROF_CUT / 2; // el plano frontal expuesto del corte
+const PARAMO = { fondo: '#c3cfce', niebla: '#c9d3d1' };
 
 /* Dónde se planta la vitrina de suelo, al lado del Ent (donde apunta su mano). */
 const CORTE_POS = /** @type {[number, number, number]} */ ([2.5, 0, 1.9]);
 
-/*
- * LAS CAPAS del suelo, de arriba abajo — la lección. `alto` en metros-escena,
- * `color` de la tierra, `nombre` + `hint` para el rótulo que el Ent enseña.
- * (Grounded: hojarasca que abriga, humus vivo, zona de raíces, la red de hongos
- * que reparte, y la roca madre de donde nace la tierra.)
- */
-/*
- * OJO CON LOS COLORES: la primera versión pintaba el humus '#241611' y las
- * micorrizas '#140f0c' — casi negro puro. Con la luz del páramo (cenital y
- * difusa) la cara frontal del corte no recibe casi nada, y la vitrina entera se
- * veía como un AGUJERO NEGRO: la lección existía y era imposible de leer. Ese
- * era, literalmente, el *"no veo la lección del subsuelo"* del operador.
- *
- * La tierra real, iluminada, NO es negra: es parda. Estos tonos siguen siendo
- * oscuros y siguen dejando brillar la red micorrízica, pero se VEN. Y la banda
- * de las micorrizas se mantiene la más oscura a propósito, para que el
- * bioluminiscente resalte contra ella.
- */
-const CAPAS = [
-  { id: 'hojarasca', nombre: 'Hojarasca', alto: 0.42, color: '#8a6038', hint: 'Las hojas caídas que abrigan y alimentan el suelo.' },
-  { id: 'humus', nombre: 'Humus', alto: 0.95, color: '#4a3325', hint: 'Tierra negra viva: lombrices y bacterias hacen el alimento.' },
-  { id: 'raices', nombre: 'Zona de raíces', alto: 1.15, color: '#63492f', hint: 'Aquí las matas beben agua y minerales.' },
-  { id: 'micorrizas', nombre: 'Red micorrízica', alto: 1.35, color: '#33261c', hint: 'El internet de hongos: reparte comida entre las plantas.' },
-  { id: 'roca', nombre: 'Roca madre', alto: 0.92, color: '#6d6b78', hint: 'La piedra de donde, poco a poco, nace la tierra.' },
-];
-
 const DUR_CAPA = 3.6; // segundos que el Ent "enseña" cada capa
+
+/*
+ * QUÉ FLORA SE QUITA en este encuadre — y por qué el páramo tiene que estar.
+ *
+ * En la entrada el Ent vive en un frailejonar; al bajar al microsuelo el páramo
+ * desaparecía y el guardián se quedaba parado en un césped pelado. Es el MISMO
+ * sitio: la lección no ocurre en otro planeta. Ese césped era la mitad del "aire
+ * muerto" que quedaba en el encuadre.
+ *
+ * Pero acá la cámara mira el corte de frente y de cerca, así que:
+ *   · toda mata con z > 2.5 se para ENTRE la cámara y la vitrina → tapa la
+ *     lección (y además se saldría del macizo, cuya cara llega a z = 2.75);
+ *   · toda mata sobre la huella del corte (con margen) quedaría plantada en el
+ *     borde del tajo o encima de él.
+ * El resto del páramo se queda: puebla el fondo y devuelve la continuidad.
+ */
+const CORTE_X0 = CORTE_POS[0] - ANCHO_CUT / 2 - 0.6;
+const CORTE_X1 = CORTE_POS[0] + ANCHO_CUT / 2 + 0.6;
+/** @type {(pos: number[]) => boolean} */
+const floraEstorba = ([x, , z]) => (
+  z > 2.5 || (x > CORTE_X0 && x < CORTE_X1 && z > CORTE_POS[2] - CARA - 0.45)
+);
 
 /* PRNG determinista local (mismo corte siempre). */
 function rng(seed) {
@@ -92,72 +98,47 @@ function rng(seed) {
   };
 }
 
-/* Alturas acumuladas: y del centro de cada capa (la cima del corte en y=0). */
-function centrosCapas() {
-  let top = 0;
-  return CAPAS.map((c) => {
-    const cy = top - c.alto / 2;
-    top -= c.alto;
-    return { ...c, cy, top: top + c.alto, bottom: top };
-  });
+/* ── La RED de micelio de la banda de micorrizas ───────────────────────────── */
+
+/*
+ * LA MALLA DE LA RED — y por qué ya NO es aditiva.
+ *
+ * Antes: MeshBasicMaterial aditivo, depthWrite:false, opacity respirando entre
+ * 0.84 y 0.94. Tres decisiones que, juntas, garantizan un resplandor: el aditivo
+ * ACUMULA donde los hilos se cruzan (y en una red se cruzan siempre), sin
+ * depthWrite nada ocluye a nada, y la opacidad pulsante lo vuelve niebla que
+ * respira. Aunque la red no hubiera estado enterrada, ese material la habría
+ * leído como brillo.
+ *
+ * Ahora: material OPACO con vertexColors. Los filamentos se ocluyen entre sí →
+ * hay profundidad, hay delante y detrás, hay RED. El aditivo se reserva para lo
+ * que sí es luz puntual: los nodos y los pulsos. El resplandor no se pierde: se
+ * hornea en la tierra de alrededor (`hornearTierra`), que es donde la luz de una
+ * red bioluminiscente iría a caer de verdad.
+ */
+function RedMicelio({ geo }) {
+  const mat = useMemo(() => new THREE.MeshBasicMaterial({ vertexColors: true }), []);
+  useLayoutEffect(() => () => mat.dispose(), [mat]);
+  if (!geo) return null;
+  return <mesh geometry={geo} material={mat} />;
 }
 
-/* ── La RED de micelio confinada a la BANDA de la capa "micorrizas": reusa la
-      maquinaria del módulo de micorrizas (construirRed + geometriaRed + pulsos),
-      solo que sembrada dentro de esta franja del corte. ── */
-function redDeBanda(alto, tier) {
-  const r = rng(41);
-  const plantas = ['maiz', 'frijol', 'ahuyama'];
-  const puntasRaiz = [];
-  const libres = [];
-  const nZ = CARA - 0.15;
-  // puntas de raíz entrando por lo alto de la banda (con planta → hacen PUENTES)
-  for (let i = 0; i < 6; i++) {
-    puntasRaiz.push({
-      pos: new THREE.Vector3((r() - 0.5) * (ANCHO_CUT - 0.7), alto / 2 - 0.12 - r() * 0.3, 0.1 + r() * nZ),
-      tipo: 'raiz', planta: plantas[i % 3], arbol: false,
-    });
-  }
-  const nLibres = tier === 'alto' ? 16 : tier === 'medio' ? 10 : 6;
-  for (let i = 0; i < nLibres; i++) {
-    const espora = r() > 0.82;
-    libres.push({
-      pos: new THREE.Vector3((r() - 0.5) * (ANCHO_CUT - 0.45), (r() - 0.5) * (alto - 0.3), 0.05 + r() * nZ),
-      tipo: espora ? 'espora' : 'nodo', planta: null,
-    });
-  }
-  const { nodos, hilos } = construirRed(puntasRaiz, libres, { vecinos: tier === 'alto' ? 2 : 1 }, 41);
-  const geo = geometriaRed(hilos, { tubK: tier === 'alto' ? 14 : 10, tubM: 5, radioHilo: 0.02 });
-  const curvas = hilos.map(curvaHilo);
-  const pulsos = pulsosDeRed(hilos, tier === 'alto' ? 70 : tier === 'medio' ? 30 : 0, 53);
-  return { nodos, geo, curvas, pulsos };
-}
-
-/* La malla de la red (un draw-call, aditiva, respira). */
-function RedMicelio({ geo, reducedMotion }) {
-  const meshRef = useRef(null);
+/* Las RAÍCES de la banda: materia, no luz → lambert, reciben la luz de vitrina. */
+function RaicesBanda({ geo }) {
   const mat = useMemo(
-    () => new THREE.MeshBasicMaterial({
-      vertexColors: true, transparent: true, opacity: 0.92,
-      blending: THREE.AdditiveBlending, depthWrite: false,
-    }),
+    () => new THREE.MeshLambertMaterial({ vertexColors: true, flatShading: true }),
     [],
   );
   useLayoutEffect(() => () => mat.dispose(), [mat]);
-  useFrame((st) => {
-    if (reducedMotion || !meshRef.current) return;
-    // Vía el ref de la malla: mutar el material del useMemo directamente está
-    // prohibido (valor capturado), y por el ref es el mismo objeto.
-    meshRef.current.material.opacity = 0.84 + Math.sin(st.clock.elapsedTime * 0.9) * 0.1;
-  });
   if (!geo) return null;
-  return <mesh ref={meshRef} geometry={geo} material={mat} frustumCulled={false} />;
+  return <mesh geometry={geo} material={mat} />;
 }
 
-/* Los NODOS del micelio (arbúsculos/nodos/esporas), instanciados. */
+/* Los NODOS del micelio (arbúsculos y uniones), instanciados. Estos SÍ aditivos:
+   son los puntos de intercambio, lo único que de verdad es una lucecita. */
 function NodosRed({ nodos }) {
   const ref = useRef(null);
-  const geo = useMemo(() => new THREE.OctahedronGeometry(0.055, 0), []);
+  const geo = useMemo(() => new THREE.OctahedronGeometry(0.038, 0), []);
   const mat = useMemo(
     () => new THREE.MeshBasicMaterial({ transparent: true, opacity: 0.95, blending: THREE.AdditiveBlending, depthWrite: false }),
     [],
@@ -168,15 +149,12 @@ function NodosRed({ nodos }) {
     const m = new THREE.Matrix4();
     const q = new THREE.Quaternion();
     const s = new THREE.Vector3();
-    const p = new THREE.Vector3();
     for (let i = 0; i < nodos.length; i++) {
       const n = nodos[i];
-      const esc = n.tipo === 'raiz' ? 1.5 : n.tipo === 'espora' ? 1.25 : 0.9;
-      p.copy(n.pos); s.setScalar(esc);
-      m.compose(p, q, s);
+      s.setScalar(n.esc);
+      m.compose(n.pos, q, s);
       mesh.setMatrixAt(i, m);
-      const col = n.tipo === 'raiz' ? PALETA.arbusculo : n.tipo === 'espora' ? PALETA.espora : PALETA.nodo;
-      mesh.setColorAt(i, col);
+      mesh.setColorAt(i, n.color);
     }
     mesh.instanceMatrix.needsUpdate = true;
     if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
@@ -186,10 +164,10 @@ function NodosRed({ nodos }) {
   return <instancedMesh ref={ref} args={[geo, mat, nodos.length]} frustumCulled={false} />;
 }
 
-/* Los PULSOS de nutrientes que corren por los hilos (instanciados). */
+/* Los PULSOS de nutrientes que corren por los RIZOMORFOS (instanciados). */
 function Pulsos({ curvas, pulsos, reducedMotion }) {
   const ref = useRef(null);
-  const geo = useMemo(() => new THREE.SphereGeometry(0.05, 7, 6), []);
+  const geo = useMemo(() => new THREE.SphereGeometry(0.038, 7, 6), []);
   const mat = useMemo(
     () => new THREE.MeshBasicMaterial({ transparent: true, opacity: 0.95, blending: THREE.AdditiveBlending, depthWrite: false }),
     [],
@@ -237,40 +215,28 @@ function Terron({ pos, r, color }) {
   );
 }
 
-/* Una raíz que baja por la cara del corte (cono principal + raicillas). */
-function Raiz({ pos, largo }) {
-  return (
-    <group position={pos}>
-      <mesh position={[0, -largo / 2, 0]} rotation={[Math.PI, 0, 0]}>
-        <coneGeometry args={[0.05, largo, 6]} />
-        <meshLambertMaterial color="#c9a86a" flatShading />
-      </mesh>
-      <mesh position={[0.07, -largo * 0.5, 0]} rotation={[Math.PI, 0, -0.7]}>
-        <coneGeometry args={[0.022, largo * 0.5, 5]} />
-        <meshLambertMaterial color="#bd9a5a" flatShading />
-      </mesh>
-    </group>
-  );
-}
-
-/* El detalle propio de cada capa (la vida que la hace legible). */
-function DetalleCapa({ capa, alto, red, reducedMotion }) {
+/* El detalle propio de cada capa (la vida que la hace legible).
+   OJO: todo detalle se ancla a `zFrenteDe(capa)`, la cara REAL de la capa una vez
+   descontada su alcoba. Anclarlo a CARA a secas —como antes— lo entierra en las
+   capas excavadas, que es como la red entera acabó dentro del ladrillo. */
+function DetalleCapa({ capa, alto, red, tier, reducedMotion }) {
   const r = useMemo(() => rng(capa.id.length * 131 + 7), [capa.id]);
+  const zCara = zFrenteDe(capa.id);
   // grumos en la cara del corte (siempre; textura de tierra)
   const terrones = useMemo(() => {
     const n = 3 + Math.round(alto * 2);
     return Array.from({ length: n }, (_, i) => ({
       key: i,
-      pos: [(r() - 0.5) * (ANCHO_CUT - 0.5), (r() - 0.5) * alto * 0.7, CARA - 0.04],
+      pos: /** @type {[number, number, number]} */ ([(r() - 0.5) * (ANCHO_CUT - 0.5), (r() - 0.5) * alto * 0.7, zCara - 0.04]),
       rr: 0.08 + r() * 0.08,
     }));
-  }, [alto, r]);
+  }, [alto, r, zCara]);
 
   if (capa.id === 'hojarasca') {
     // hojitas caídas sobre la cara (flecos ocres)
     const hojas = Array.from({ length: 10 }, (_, i) => ({
       key: i,
-      pos: /** @type {[number, number, number]} */ ([(r() - 0.5) * (ANCHO_CUT - 0.4), (r() - 0.5) * alto * 0.6, CARA - 0.02]),
+      pos: /** @type {[number, number, number]} */ ([(r() - 0.5) * (ANCHO_CUT - 0.4), (r() - 0.5) * alto * 0.6, zCara - 0.02]),
       giro: r() * Math.PI,
     }));
     return (
@@ -291,7 +257,7 @@ function DetalleCapa({ capa, alto, red, reducedMotion }) {
     return (
       <group>
         {terrones.map((t) => <Terron key={t.key} pos={t.pos} r={t.rr} color={t.key % 2 ? '#1c120c' : capa.color} />)}
-        <mesh position={[-0.4, -alto * 0.1, CARA - 0.02]} rotation={[0, 0, 0.5]}>
+        <mesh position={[-0.4, -alto * 0.1, zCara - 0.02]} rotation={[0, 0, 0.5]}>
           <capsuleGeometry args={[0.05, 0.34, 4, 8]} />
           <meshLambertMaterial color="#c98a8f" flatShading />
         </mesh>
@@ -300,23 +266,23 @@ function DetalleCapa({ capa, alto, red, reducedMotion }) {
   }
 
   if (capa.id === 'raices') {
-    // raíces que descienden (y siguen hacia la red, abajo)
-    const raices = Array.from({ length: 5 }, (_, i) => ({
-      key: i, pos: [(r() - 0.5) * (ANCHO_CUT - 0.8), alto * 0.35, CARA - 0.05 - r() * 0.1], largo: 0.5 + r() * (alto * 0.8),
-    }));
+    // las MISMAS raíces que abajo agarra el micelio: bajan, cruzan el piso de la
+    // capa y entran a la alcoba de micorrizas. Antes cada capa sorteaba las suyas
+    // y no empataban: la lección se cortaba justo en la juntura.
     return (
       <group>
         {terrones.map((t) => <Terron key={t.key} pos={t.pos} r={t.rr} color={capa.color} />)}
-        {raices.map((ra) => <Raiz key={ra.key} pos={ra.pos} largo={ra.largo} />)}
+        {red?.raicesZona && <RaicesBanda geo={red.raicesZona} />}
       </group>
     );
   }
 
   if (capa.id === 'micorrizas' && red) {
-    // ¡la estrella! la red micorrízica bioluminiscente + sus pulsos
+    // ¡la estrella! las raíces que bajan + la red que las conecta + los pulsos
     return (
       <group>
-        <RedMicelio geo={red.geo} reducedMotion={reducedMotion} />
+        <RaicesBanda geo={red.raices} />
+        <RedMicelio geo={red.geo} />
         <NodosRed nodos={red.nodos} />
         <Pulsos curvas={red.curvas} pulsos={red.pulsos} reducedMotion={reducedMotion} />
       </group>
@@ -327,7 +293,7 @@ function DetalleCapa({ capa, alto, red, reducedMotion }) {
     // roca madre: pedruscos facetados grises embebidos
     const rocas = Array.from({ length: 6 }, (_, i) => ({
       key: i,
-      pos: /** @type {[number, number, number]} */ ([(r() - 0.5) * (ANCHO_CUT - 0.4), (r() - 0.5) * alto * 0.7, CARA - 0.05]),
+      pos: /** @type {[number, number, number]} */ ([(r() - 0.5) * (ANCHO_CUT - 0.4), (r() - 0.5) * alto * 0.7, zCara - 0.05]),
       esc: 0.14 + r() * 0.16,
     }));
     return (
@@ -342,32 +308,31 @@ function DetalleCapa({ capa, alto, red, reducedMotion }) {
     );
   }
 
+  void tier;
   return <group>{terrones.map((t) => <Terron key={t.key} pos={t.pos} r={t.rr} color={capa.color} />)}</group>;
 }
 
-/* Una CAPA del corte: el bloque de tierra + su detalle + su rótulo. El rótulo se
-   enciende cuando es la capa que el Ent está enseñando (activa). */
-function Capa({ capa, activa, red, reducedMotion }) {
+/* Una CAPA del corte: el bloque de tierra horneado + su detalle + su rótulo. */
+function Capa({ capa, geo, activa, red, tier, reducedMotion }) {
+  const zCara = zFrenteDe(capa.id);
+  const mat = useMemo(() => new THREE.MeshLambertMaterial({ vertexColors: true }), []);
+  useLayoutEffect(() => () => mat.dispose(), [mat]);
   return (
     <group position={[0, capa.cy, 0]}>
-      {/* el bloque de tierra (cara frontal = el corte) */}
-      <mesh>
-        <boxGeometry args={[ANCHO_CUT, capa.alto, PROF_CUT]} />
-        <meshLambertMaterial color={capa.color} flatShading />
-      </mesh>
-      <DetalleCapa capa={capa} alto={capa.alto} red={red} reducedMotion={reducedMotion} />
+      <mesh geometry={geo} material={mat} castShadow={false} receiveShadow />
+      <DetalleCapa capa={capa} alto={capa.alto} red={red} tier={tier} reducedMotion={reducedMotion} />
 
       {/* marca de ATENCIÓN cuando el Ent enseña esta capa: barra que brilla en la
           arista frontal + el rótulo resaltado */}
       {activa && (
-        <mesh position={[0, -capa.alto / 2 + 0.02, CARA + 0.01]}>
+        <mesh position={[0, -capa.alto / 2 + 0.02, zCara + 0.01]}>
           <boxGeometry args={[ANCHO_CUT, 0.04, 0.04]} />
           <meshBasicMaterial color="#7ef0c8" transparent opacity={0.9} blending={THREE.AdditiveBlending} depthWrite={false} />
         </mesh>
       )}
 
       {/* el rótulo (nombre + hint) al costado derecho de la capa */}
-      <Html position={[ANCHO_CUT / 2 + 0.18, 0, CARA - 0.1]} className="entm-rot" zIndexRange={[30, 10]}>
+      <Html position={[ANCHO_CUT / 2 + 0.18, 0, zCara - 0.1]} className="entm-rot" zIndexRange={[30, 10]}>
         <div className={`entm-rot__caja${activa ? ' entm-rot__caja--activa' : ''}`}>
           <span className="entm-rot__n">{capa.nombre}</span>
           <span className="entm-rot__h">{capa.hint}</span>
@@ -379,10 +344,42 @@ function Capa({ capa, activa, red, reducedMotion }) {
 
 /* La VITRINA de suelo completa + la LECCIÓN (qué capa está enseñando el Ent). */
 function CorteSuelo({ tier, reducedMotion }) {
-  const capas = useMemo(() => centrosCapas(), []);
-  const bandaMic = useMemo(() => capas.find((c) => c.id === 'micorrizas'), [capas]);
-  const red = useMemo(() => redDeBanda(bandaMic.alto, tier), [bandaMic.alto, tier]);
-  useLayoutEffect(() => () => red.geo?.dispose(), [red]);
+  /*
+   * Orden OBLIGATORIO: primero la red, porque la tierra de la banda se hornea
+   * CON la luz de la red (las `muestras`). Es lo que deja la banda legible sin
+   * lavar el filamento — un lift plano arreglaría 1 y rompería 2.
+   */
+  const { capas, red } = useMemo(() => {
+    const cs = centrosCapas();
+    const banda = cs.find((c) => c.id === 'micorrizas');
+    const zona = cs.find((c) => c.id === 'raices');
+
+    const { hilos } = esqueletoRed(banda.alto, tier);
+    const luces = muestrasDeLuz(hilos);
+    const nPulsos = tier === 'alto' ? 26 : tier === 'medio' ? 12 : 0;
+
+    const redOut = {
+      geo: geometriaRedBanda(hilos, tier),
+      raices: construirRaicesBanda(banda.alto, tier),
+      raicesZona: construirRaicesZona(zona.alto, banda.alto, tier),
+      nodos: nodosDeRed(banda.alto),
+      curvas: hilos.map((h) => h.curva),
+      pulsos: pulsosDeBanda(hilos, nPulsos),
+    };
+
+    const conGeo = cs.map((c) => ({
+      ...c,
+      geo: construirTierra(c, { tier, luces: c.id === 'micorrizas' ? luces : [] }),
+    }));
+    return { capas: conGeo, red: redOut };
+  }, [tier]);
+
+  useLayoutEffect(() => () => {
+    capas.forEach((c) => c.geo?.dispose());
+    red.geo?.dispose();
+    red.raices?.dispose();
+    red.raicesZona?.dispose();
+  }, [capas, red]);
 
   const [activa, setActiva] = useState(0);
   useFrame((st) => {
@@ -393,16 +390,37 @@ function CorteSuelo({ tier, reducedMotion }) {
 
   return (
     <group position={CORTE_POS}>
-      {/* borde de pasto que corona el corte (la tierra "sigue" arriba) */}
-      <mesh position={[0, 0.04, 0]}>
-        <boxGeometry args={[ANCHO_CUT, 0.08, PROF_CUT]} />
-        <meshLambertMaterial color="#6f9a45" flatShading />
+      {/* Borde de pasto que corona el corte. Va ENRASADO con el terreno (de -0.04
+          a 0) y con el musgo del páramo: antes sobresalía 0.08 en un verde
+          distinto y se leía como el bordillo de una maceta. */}
+      <mesh position={[0, -0.02, 0]}>
+        <boxGeometry args={[ANCHO_CUT, 0.04, PROF_CUT]} />
+        <meshLambertMaterial color="#66754c" flatShading />
       </mesh>
       {capas.map((c, i) => (
-        <Capa key={c.id} capa={c} red={c.id === 'micorrizas' ? red : null} activa={i === activa} reducedMotion={reducedMotion} />
+        <Capa
+          key={c.id}
+          capa={c}
+          geo={c.geo}
+          red={c.id === 'micorrizas' || c.id === 'raices' ? red : null}
+          activa={i === activa}
+          tier={tier}
+          reducedMotion={reducedMotion}
+        />
       ))}
     </group>
   );
+}
+
+/* EL TERRENO que rodea la vitrina — lo que mata el aire muerto. */
+function Terreno({ tier }) {
+  const geo = useMemo(
+    () => construirTerreno({ x: CORTE_POS[0], z: CORTE_POS[2] }, { tier }),
+    [tier],
+  );
+  const mat = useMemo(() => new THREE.MeshLambertMaterial({ vertexColors: true }), []);
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+  return <mesh geometry={geo} material={mat} receiveShadow />;
 }
 
 function Diorama({ tier, reducedMotion }) {
@@ -410,7 +428,7 @@ function Diorama({ tier, reducedMotion }) {
   return (
     <>
       <color attach="background" args={[PARAMO.fondo]} />
-      {perfil.fog && <fog attach="fog" args={[PARAMO.niebla, 12, 40]} />}
+      {perfil.fog && <fog attach="fog" args={[PARAMO.niebla, 14, 44]} />}
 
       {/* luz de páramo (misma que el Bosque, para que el Ent se lea igual) */}
       <hemisphereLight intensity={0.92} color="#d7e2e4" groundColor="#3a3a2c" />
@@ -442,21 +460,24 @@ function Diorama({ tier, reducedMotion }) {
         intensity={1.05}
         color="#f0ead8"
       />
-      {/* relleno cálido bajo tierra: da cuerpo a la red y a las capas */}
-      <pointLight position={[CORTE_POS[0], -1.6, CORTE_POS[2] + 1]} intensity={0.6} color="#37d6b0" distance={9} decay={2} />
-      {/* segundo relleno abajo del todo: la roca madre no puede caer a negro */}
-      <pointLight position={[CORTE_POS[0], -4.2, CORTE_POS[2] + 2.5]} intensity={0.5} color="#cfd6dd" distance={7} decay={2} />
+      {/*
+        NO va acá el pointLight turquesa de relleno que había antes en
+        [x, -1.6, z+1]. Estaba DELANTE de la cara del corte y lo que hacía era
+        pintarle un halo verde al barro plano: ESE era el "brillo" que se veía en
+        vez de la red (la red estaba enterrada y no aportaba un solo píxel).
+        Ahora la luz que la red echa sobre la tierra va HORNEADA por vértice en
+        `hornearTierra`, que además cuesta cero en runtime y cae solo donde hay
+        filamento — no en una bola difusa en el centro de la capa.
+      */}
+      {/* relleno frío abajo del todo: la roca madre no puede caer a negro */}
+      <pointLight position={[CORTE_POS[0], -4.4, CORTE_POS[2] + 2.5]} intensity={0.45} color="#cfd6dd" distance={7} decay={2} />
 
-      {/* parche de musgo del páramo bajo el Ent */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.01, 0]} receiveShadow>
-        <circleGeometry args={[4.2, 32]} />
-        <meshLambertMaterial color={PARAMO.musgo} />
-      </mesh>
-      {/* apron de tierra que lleva del musgo a la vitrina de suelo */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[CORTE_POS[0] * 0.6, -0.02, CORTE_POS[2] * 0.6]}>
-        <planeGeometry args={[5, 4]} />
-        <meshLambertMaterial color="#4a4030" />
-      </mesh>
+      {/* EL TERRENO: el macizo de tierra del que se sacó la vitrina */}
+      <Terreno tier={tier} />
+
+      {/* EL PÁRAMO: el mismo frailejonar de la entrada, menos lo que taparía la
+          lección. La lección pasa DONDE vive el Ent, no en un potrero. */}
+      <FloraParamo tier={tier} reducedMotion={reducedMotion} excluir={floraEstorba} />
 
       {/* EL GUARDIÁN, con el BRAZO que señala y enseña el suelo */}
       <EntQuenua tier={tier} reducedMotion={reducedMotion} señala />
@@ -464,19 +485,30 @@ function Diorama({ tier, reducedMotion }) {
       {/* LA VITRINA de suelo con sus capas + la red micorrízica */}
       <CorteSuelo tier={tier} reducedMotion={reducedMotion} />
 
+      {/*
+        ENCUADRE sobre la unidad pedagógica: rostro + brazo que señala + capas.
+        La cámara estaba a 13.7 y el corte —la lección— ocupaba una quinta parte
+        del ancho: todo lo demás era cielo gris. Pero el aire muerto NO se cura
+        acercando la cámara; se curó poblando (el macizo de tierra). Con la tierra
+        puesta, bajo el horizonte ya no hay vacío, y entonces sí se puede encuadrar
+        a 11: el rostro del Ent (y=2.09) entra justo por arriba, el corte llena
+        ~54% del alto y el brazo cruza el tercio izquierdo hacia la vitrina.
+      */}
       <OrbitControls
         makeDefault
-        target={[1.5, -1.5, 1.1]}
+        target={[1.9, -1.6, 1.75]}
         enablePan={false}
         enableZoom
-        minDistance={9}
-        maxDistance={26}
+        minDistance={6}
+        maxDistance={20}
         minPolarAngle={0.5}
         maxPolarAngle={1.52}
         enableDamping
         dampingFactor={0.08}
         autoRotate={!reducedMotion}
-        autoRotateSpeed={0.12}
+        // muy lento: a 0.12 la cara del corte se iba de perfil en un minuto y la
+        // lección dejaba de leerse. Esto es deriva, no rotación.
+        autoRotateSpeed={0.06}
       />
       <AdaptiveDpr pixelated />
     </>
@@ -499,7 +531,7 @@ export default function EscenaEntMaestro({ tier = 'alto', reducedMotion = false 
         dpr={perfil.dpr}
         gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
         shadows={perfil.sombras ? 'soft' : false}
-        camera={{ position: [3.4, 0.2, 14.6], fov: 46 }}
+        camera={{ position: [3.96, 1.65, 12.59], fov: 44 }}
         frameloop={reducedMotion ? 'demand' : 'always'}
         onCreated={() => setListo(true)}
       >
@@ -508,3 +540,6 @@ export default function EscenaEntMaestro({ tier = 'alto', reducedMotion = false 
     </>
   );
 }
+
+/* Reexport para los tests de encuadre (invariantes de composición). */
+export { ALTO_CORTE, CARA, CORTE_POS, PALETA };

--- a/src/visual/mundo3d/bosque/FloraParamo.jsx
+++ b/src/visual/mundo3d/bosque/FloraParamo.jsx
@@ -171,9 +171,26 @@ function NieblaRasante({ n, reducedMotion }) {
 
 /**
  * La capa de flora del páramo alrededor del Ent. Montar dentro del <Canvas>.
- * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ *
+ * `excluir` deja sembrar el MISMO páramo en encuadres distintos. El microsuelo lo
+ * necesita: allí la cámara mira el corte de frente y de cerca, así que cualquier
+ * mata sembrada entre la cámara y la vitrina TAPA la lección, y el frailejonar
+ * (que arranca a radio 3.4) cae justo sobre el corte (que está a 3.14 del Ent).
+ * Sin esto, la única salida era dejar al guardián parado en un césped pelado —
+ * que es de donde venía el "aire muerto".
+ *
+ * `excluir` recibe la posición `[x, y, z]` de la mata y devuelve `true` para
+ * quitarla. DEBE ser estable entre renders (una constante de módulo): va en las
+ * dependencias del useMemo de la distribución, y una lambda en línea re-filtraría
+ * el páramo entero en cada frame.
+ *
+ * @param {{
+ *   tier?: 'alto'|'medio'|'bajo',
+ *   reducedMotion?: boolean,
+ *   excluir?: (pos: number[]) => boolean,
+ * }} props
  */
-export default function FloraParamo({ tier = 'alto', reducedMotion = false }) {
+export default function FloraParamo({ tier = 'alto', reducedMotion = false, excluir }) {
   const perfil = perfilDeTier(tier);
   const conteos = floraDeTier(tier);
   const q = calidadDeTier(tier);
@@ -205,7 +222,20 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false }) {
   }, [perfil.materialRico]);
 
   // --- Distribución en bosquetes (una vez por tier). ---
-  const dist = useMemo(() => distribucionFlora(conteos, 707), [conteos]);
+  // El filtro se aplica DESPUÉS de sembrar, nunca antes: la siembra es
+  // determinista (bosquetes, claros, distancia mínima) y re-sembrar con otro
+  // dominio movería el páramo entero. Filtrando, el bosque es EL MISMO en la
+  // entrada y en el microsuelo — solo que allí se quitan las matas que estorban.
+  const dist = useMemo(() => {
+    const d = distribucionFlora(conteos, 707);
+    if (!excluir) return d;
+    return Object.fromEntries(
+      Object.entries(d).map(([k, items]) => [
+        k,
+        Array.isArray(items) ? items.filter((it) => !excluir(it.pos)) : items,
+      ]),
+    );
+  }, [conteos, excluir]);
 
   // Liberar GPU al desmontar.
   useLayoutEffect(() => () => {

--- a/src/visual/mundo3d/bosque/corteSuelo.geom.js
+++ b/src/visual/mundo3d/bosque/corteSuelo.geom.js
@@ -1,0 +1,693 @@
+/*
+ * corteSuelo.geom — la VITRINA DE TIERRA que el Ent abre y enseña, en funciones
+ * PURAS (three-core, corren headless: cero contexto GL, cero azar por frame).
+ *
+ * ── POR QUÉ EXISTE ESTE MÓDULO (la tercera pasada) ──────────────────────────
+ *
+ * La pasada 2 dejó escrito que "la banda de micorrizas se lee oscura y la red se
+ * ve más como brillo que como red". Las dos frases describían el MISMO bug, y no
+ * era de acabado: era aritmético.
+ *
+ *   · La cara del corte está en z = CARA = PROF_CUT/2 = 0.85.
+ *   · La red se sembraba en z ∈ [0.05, 0.80] (nZ = CARA - 0.15).
+ *   · El bloque de tierra era un box de profundidad PROF_CUT → OPACO hasta 0.85.
+ *
+ * → La red entera vivía DENTRO del ladrillo de tierra. Cero píxeles, sin un solo
+ *   error. Es la misma familia del bug de la barba de la pasada 1 (el fuste se la
+ *   tragaba): la geometría estaba bien y algo sólido se la comía.
+ *
+ * → Y el "brillo" que sí se veía era el pointLight turquesa de relleno pegando
+ *   sobre la cara plana del barro. Literalmente "más brillo que red": lo único
+ *   que había EN PANTALLA era un brillo.
+ *
+ * La cura no es iluminar la red. Es DESENTERRARLA:
+ *
+ *   1. HUECO — la tierra se retira por capa (una alcoba excavada). La franja de
+ *      micorrizas es la más abierta porque es la estrella; las de arriba se
+ *      escalonan hacia ella y la roca madre hace de repisa. La biología vive en
+ *      la alcoba, DELANTE de la tierra, no dentro.
+ *   2. RAÍCES VISIBLES que bajan de la zona de raíces y entran a la alcoba: sin
+ *      raíces a la vista, unos filamentos flotando no son una red — son un
+ *      adorno. La lección es "reparte entre plantas", y eso exige ver las puntas.
+ *   3. JERARQUÍA (DR §"Ausencia de jerarquía de ramas"): rizomorfo troncal →
+ *      secundaria → punta, con conicidad real (DR §"Conicidad real y nudos").
+ *      El DR es taxativo: "más ramas" no arregla nada; la estructura sí.
+ *   4. HUECOS (DR §"Importancia de los huecos"): el DR pide ver el cielo ENTRE
+ *      las hojas. Acá es al revés y es lo mismo: hay que ver la tierra oscura
+ *      ENTRE las hifas. El vacío es lo que define la red.
+ *
+ * ── EL CONFLICTO 1↔2, RESUELTO ──────────────────────────────────────────────
+ * "Aclarar la banda" y "que la red resalte" tiran en direcciones opuestas: subir
+ * el brillo del fondo lava el filamento. Por eso NO se sube un `lift` plano. Se
+ * hornea luz DESDE LA RED sobre la tierra (`hornearTierra` recibe las muestras de
+ * las hifas): la tierra se enciende CERCA de los filamentos y se queda oscura en
+ * los huecos. La banda deja de leerse negra, la red gana contraste local, y de
+ * paso el resplandor queda justificado — la red ilumina lo que la rodea.
+ * Es la receta de translucidez/contraluz del DR, con la red de fuente.
+ */
+import * as THREE from 'three';
+import {
+  rng,
+  ruidoFbm,
+  pintarPorVertice,
+  fusionarSeguro,
+  tuboOrganico,
+} from './sombreadoVegetal.js';
+import { PALETA } from '../micorrizas/micorrizas.geom.js';
+
+/* Geometría del bloque de suelo (la vitrina de tierra). */
+export const ANCHO_CUT = 3.2;
+export const PROF_CUT = 1.7;
+export const CARA = PROF_CUT / 2; // el plano frontal expuesto del corte
+
+/*
+ * CUÁNTA TIERRA se retira por capa (la alcoba excavada). 0 = bloque macizo, la
+ * cara queda en CARA. La franja de micorrizas es la más abierta: es la lección.
+ * Las de encima se escalonan hacia ella para que la excavación se lea como un
+ * scoop y no como un error de modelado, y la roca madre vuelve a salir haciendo
+ * de repisa que enmarca la alcoba por abajo.
+ */
+export const HUECO = {
+  hojarasca: 0,
+  humus: 0.1,
+  raices: 0.34,
+  micorrizas: 0.62,
+  roca: 0.28,
+};
+
+/** z de la cara frontal expuesta de una capa (ya descontada su alcoba). */
+export const zFrenteDe = (id) => CARA - (HUECO[id] ?? 0);
+
+/*
+ * LAS CAPAS del suelo, de arriba abajo — la lección.
+ *
+ * OJO CON LOS COLORES: la primera versión pintaba el humus '#241611' y las
+ * micorrizas '#140f0c' — casi negro puro, y la vitrina entera se leía como un
+ * agujero. La pasada 2 los subió a tierra parda de verdad. Esta pasada NO los
+ * vuelve a subir: la banda de micorrizas sigue siendo la más oscura A PROPÓSITO
+ * (es el fondo contra el que resalta el bioluminiscente). Lo que cambia es que
+ * ahora la tierra tiene INFORMACIÓN — grano, oclusión en las interfaces,
+ * profundidad de alcoba y la luz que la red le echa encima. El DR lo dice
+ * exacto: la oscuridad tiene que ser LOCAL (grietas/depresiones), nunca global.
+ */
+export const CAPAS = [
+  { id: 'hojarasca', nombre: 'Hojarasca', alto: 0.42, color: '#8a6038', hint: 'Las hojas caídas que abrigan y alimentan el suelo.' },
+  { id: 'humus', nombre: 'Humus', alto: 0.95, color: '#4a3325', hint: 'Tierra negra viva: lombrices y bacterias hacen el alimento.' },
+  { id: 'raices', nombre: 'Zona de raíces', alto: 1.15, color: '#63492f', hint: 'Aquí las matas beben agua y minerales.' },
+  { id: 'micorrizas', nombre: 'Red micorrízica', alto: 1.35, color: '#33261c', hint: 'El internet de hongos: reparte comida entre las plantas.' },
+  // La roca iba en '#6d6b78': era LO MÁS CLARO del corte y le robaba el ojo a la
+  // red, que es la lección. Sigue siendo gris de piedra y sigue sin caer a negro
+  // (tiene su relleno frío), pero deja de competir.
+  { id: 'roca', nombre: 'Roca madre', alto: 0.92, color: '#514f5a', hint: 'La piedra de donde, poco a poco, nace la tierra.' },
+];
+
+/** Alturas acumuladas: y del centro de cada capa (la cima del corte en y=0). */
+export function centrosCapas() {
+  let top = 0;
+  return CAPAS.map((c) => {
+    const cy = top - c.alto / 2;
+    top -= c.alto;
+    return { ...c, cy, top: top + c.alto, bottom: top };
+  });
+}
+
+/** Alto total del corte (para encuadrar la cámara sobre la unidad pedagógica). */
+export const ALTO_CORTE = CAPAS.reduce((s, c) => s + c.alto, 0);
+
+/* Los horizontes precalculados como THREE.Color (parsear '#hex' por vértice
+   sería tirar el tiempo: son decenas de miles de vértices). */
+const HORIZONTES = (() => {
+  let top = 0;
+  return CAPAS.map((c) => {
+    const bottom = top - c.alto;
+    const h = { top, bottom, color: new THREE.Color(c.color) };
+    top = bottom;
+    return h;
+  });
+})();
+
+/**
+ * El color del horizonte de suelo a una profundidad `y`. Por debajo del corte
+ * sigue la roca madre: la tierra no se acaba donde acaba la vitrina.
+ * @param {number} y  profundidad de mundo (0 = superficie, negativo = abajo).
+ */
+export function colorHorizonte(y) {
+  for (let i = 0; i < HORIZONTES.length; i++) {
+    const h = HORIZONTES[i];
+    if (y <= h.top && y > h.bottom) return h.color;
+  }
+  return HORIZONTES[HORIZONTES.length - 1].color;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Las RAÍCES que la red conecta — las ANCLAS de la lección                   */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Las cuatro raíces que bajan a la banda. NO son decorado: son lo que la red
+ * conecta, y sin ellas unos filamentos sueltos no enseñan nada.
+ *
+ * La primera es la RAÍZ DEL ENT (la queñua madre): gruesa, entra por la
+ * izquierda —el lado donde el guardián está parado— y baja más hondo que
+ * ninguna. Las otras tres son maticas. Esa asimetría ES la lección del árbol
+ * madre que alimenta a las chiquitas por debajo: se lee en el grosor, sin texto.
+ *
+ * `z` las pone DELANTE de la cara de las dos capas que atraviesan (raíces 0.51 y
+ * micorrizas 0.23), que es exactamente lo que la versión anterior no hacía.
+ */
+export const ANCLAS = [
+  { id: 'ent', x: -1.16, z: 0.64, r0: 0.055, drift: -0.1, hondo: 0.78, madre: true },
+  { id: 'mata1', x: -0.28, z: 0.7, r0: 0.026, drift: 0.12, hondo: 0.34 },
+  { id: 'mata2', x: 0.64, z: 0.6, r0: 0.024, drift: -0.08, hondo: 0.52 },
+  { id: 'mata3', x: 1.34, z: 0.68, r0: 0.021, drift: 0.1, hondo: 0.26 },
+];
+
+/** La punta (nodo de intercambio) de un ancla dentro de la banda de micorrizas. */
+export function puntaDeAncla(ancla, alto) {
+  const media = alto / 2;
+  return new THREE.Vector3(
+    ancla.x + ancla.drift,
+    media - ancla.hondo * alto,
+    ancla.z - 0.06,
+  );
+}
+
+/** La curva de una raíz: entra por arriba de la banda y baja hasta su punta. */
+function curvaDeAncla(ancla, alto, desdeArriba = 0.08) {
+  const media = alto / 2;
+  const p0 = new THREE.Vector3(ancla.x, media + desdeArriba, ancla.z);
+  const fin = puntaDeAncla(ancla, alto);
+  const p1 = new THREE.Vector3(
+    ancla.x + ancla.drift * 0.25,
+    media - ancla.hondo * alto * 0.45,
+    ancla.z + 0.03,
+  );
+  return new THREE.CatmullRomCurve3([p0, p1, fin], false, 'catmullrom', 0.5);
+}
+
+/*
+ * GEOMETRÍA de las raíces de la banda: tubos con conicidad real (gruesa arriba,
+ * puntita que busca abajo) y color de raíz viva → punta clara. Van con material
+ * LAMBERT (no aditivo): la raíz es MATERIA y tiene que recibir la luz de la
+ * vitrina. Ese contraste contra el micelio autoiluminado es el que hace legible
+ * la lección: la raíz es cosa, la red es luz.
+ */
+export function construirRaicesBanda(alto, tier = 'alto') {
+  const radial = tier === 'alto' ? 7 : 5;
+  const tubular = tier === 'alto' ? 14 : 8;
+  const partes = ANCLAS.map((a) => {
+    const geo = tuboOrganico(curvaDeAncla(a, alto), {
+      tubular,
+      radial,
+      taper: (t) => a.r0 * (1 - 0.72 * t),
+      arruga: 0.16,
+      semilla: a.x * 7,
+      minRadio: 0.006,
+    });
+    const media = alto / 2;
+    return pintarPorVertice(geo, (x, y, z, i, c) => {
+      const t = Math.min(1, Math.max(0, (media + 0.08 - y) / (alto * a.hondo + 0.08)));
+      c.copy(PALETA.raiz).lerp(PALETA.raizPunta, t);
+      // grano de raíz + oclusión: la cara que mira a la tierra queda en penumbra
+      const n = ruidoFbm(x * 9 + 3, y * 9, z * 9);
+      c.multiplyScalar(0.78 + n * 0.3);
+      return c;
+    });
+  });
+  return fusionarSeguro(partes, 'raices-banda-micorrizas');
+}
+
+/*
+ * Las raíces vistas en la CAPA DE ARRIBA ("zona de raíces"), nacidas de las
+ * MISMAS anclas: así una raíz baja, cruza la frontera entre capas y entra a la
+ * alcoba donde el micelio la agarra. Antes cada capa sorteaba sus raíces por su
+ * cuenta y no empataban — la lección se cortaba justo en la juntura.
+ */
+export function construirRaicesZona(altoZona, altoBanda, tier = 'alto') {
+  const radial = tier === 'alto' ? 7 : 5;
+  const media = altoZona / 2;
+  const partes = ANCLAS.map((a) => {
+    // baja desde lo alto de la capa hasta cruzar por completo su piso
+    const p0 = new THREE.Vector3(a.x - a.drift * 0.4, media * 0.92, a.z + 0.02);
+    const p1 = new THREE.Vector3(a.x - a.drift * 0.1, 0, a.z);
+    const p2 = new THREE.Vector3(a.x, -media - 0.02, a.z);
+    const curva = new THREE.CatmullRomCurve3([p0, p1, p2], false, 'catmullrom', 0.5);
+    const geo = tuboOrganico(curva, {
+      tubular: tier === 'alto' ? 12 : 7,
+      radial,
+      // llega al piso con el mismo grosor con el que arranca abajo → sin escalón
+      taper: (t) => a.r0 * (1.35 - 0.35 * t),
+      arruga: 0.18,
+      semilla: a.x * 11,
+      minRadio: 0.006,
+    });
+    return pintarPorVertice(geo, (x, y, z, i, c) => {
+      const t = Math.min(1, Math.max(0, (media - y) / altoZona));
+      c.copy(PALETA.raiz).lerp(PALETA.raizPunta, t * 0.45);
+      const n = ruidoFbm(x * 9 + 17, y * 9, z * 9);
+      c.multiplyScalar(0.74 + n * 0.32);
+      return c;
+    });
+  });
+  void altoBanda;
+  return fusionarSeguro(partes, 'raices-zona');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LA RED: rizomorfo → secundaria → punta (jerarquía, no maraña)              */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Los HUBS del micelio: las uniones donde el rizomorfo se reparte.
+ *
+ * Van a ALTURAS MUY DISTINTAS a propósito. Con los tres a la misma hondura el
+ * espinazo salía horizontal y la red entera se leía como un COLLAR colgado en el
+ * tercio bajo de la banda: se veían las conexiones, sí, pero no OCUPABA el suelo.
+ * Escalonados, el rizomorfo zigzaguea y la red llena la franja.
+ */
+function hubsDeBanda(alto) {
+  const media = alto / 2;
+  return [
+    new THREE.Vector3(-0.72, media - alto * 0.58, 0.48),
+    new THREE.Vector3(0.2, media - alto * 0.86, 0.62),
+    new THREE.Vector3(1.05, media - alto * 0.5, 0.42),
+  ];
+}
+
+/** Curva de una hifa: cuelga un poco (sag) y serpentea. Nunca un palo recto. */
+function curvaHifa(a, b, r, sag = 0.1) {
+  const mid = a.clone().add(b).multiplyScalar(0.5);
+  const largo = a.distanceTo(b);
+  mid.y -= largo * sag;
+  mid.x += (r() - 0.5) * largo * 0.2;
+  mid.z += (r() - 0.5) * largo * 0.24;
+  return new THREE.QuadraticBezierCurve3(a.clone(), mid, b.clone());
+}
+
+/*
+ * EL ESQUELETO de la red. Devuelve los hilos con su NIVEL, que es lo que la hace
+ * legible como grafo y no como niebla:
+ *
+ *   nivel 0 — RIZOMORFO: el cordón troncal. Va de punta de raíz a punta de raíz
+ *             pasando por hubs. ES la lección (el reparto), y por eso es el más
+ *             grueso y el más claro, y es el único que lleva pulsos de nutriente.
+ *   nivel 1 — SECUNDARIA: se desprende del rizomorfo a explorar la tierra.
+ *   nivel 2 — PUNTA: la hifa fina que busca. Casi no se ve, y por eso da escala.
+ *
+ * La cadena de rizomorfos se arma A MANO, no por k-vecinos. El grafo k-vecinos
+ * de la versión anterior unía cada nodo con su más cercano: eso da una malla
+ * pareja sin dirección, que es precisamente lo que se lee como resplandor. Una
+ * cadena explícita raíz→hub→raíz se lee como CAMINO, y un camino sí cuenta algo.
+ */
+export function esqueletoRed(alto, tier = 'alto') {
+  const r = rng(41);
+  const puntas = ANCLAS.map((a) => puntaDeAncla(a, alto));
+  const hubs = hubsDeBanda(alto);
+  const hilos = [];
+
+  /* nivel 0 — la columna vertebral: raíz → hub → raíz, de punta a punta */
+  const cadena = [
+    [puntas[0], hubs[0]],
+    [hubs[0], puntas[1]],
+    [hubs[0], hubs[1]],
+    [hubs[1], puntas[2]],
+    [hubs[1], hubs[2]],
+    [hubs[2], puntas[3]],
+    // la queñua madre alcanza lejos: su raíz llega hasta el hub del centro
+    [puntas[0], hubs[1]],
+  ];
+  for (const [a, b] of cadena) {
+    // sag corto: el rizomorfo es un cordón TENSO entre dos raíces, no una guirnalda
+    hilos.push({ nivel: 0, curva: curvaHifa(a, b, r, 0.05), r0: 0.026, r1: 0.019 });
+  }
+
+  if (tier === 'bajo') return { hilos, puntas, hubs };
+
+  /* nivel 1 — secundarias: nacen del rizomorfo y salen a explorar */
+  const nSec = tier === 'alto' ? 3 : 2;
+  const troncales = hilos.slice();
+  for (const h of troncales) {
+    for (let k = 0; k < nSec; k++) {
+      const t = 0.24 + r() * 0.54;
+      const a = h.curva.getPoint(t);
+      // en los DOS sentidos: antes toda secundaria salía hacia abajo
+      // (-0.1 - r()*0.34) y el micelio se apelotonaba contra el piso de la banda
+      // dejando muerta la mitad de arriba. El hongo explora en todas direcciones.
+      const b = a.clone().add(new THREE.Vector3(
+        (r() - 0.5) * 0.78,
+        (r() - 0.5) * 0.62,
+        (r() - 0.5) * 0.4,
+      ));
+      // que no se salga de la alcoba ni del bloque
+      b.z = Math.min(0.77, Math.max(0.31, b.z));
+      b.x = Math.min(ANCHO_CUT / 2 - 0.14, Math.max(-ANCHO_CUT / 2 + 0.14, b.x));
+      b.y = Math.min(alto / 2 - 0.06, Math.max(-alto / 2 + 0.06, b.y));
+      hilos.push({ nivel: 1, curva: curvaHifa(a, b, r, 0.14), r0: 0.013, r1: 0.006 });
+    }
+  }
+
+  if (tier !== 'alto') return { hilos, puntas, hubs };
+
+  /* nivel 2 — puntas: la hifa fina que busca. Dan escala y textura de red. */
+  const secundarias = hilos.filter((h) => h.nivel === 1);
+  for (const h of secundarias) {
+    if (r() > 0.62) continue;
+    const a = h.curva.getPoint(0.62 + r() * 0.3);
+    const b = a.clone().add(new THREE.Vector3(
+      (r() - 0.5) * 0.34,
+      (r() - 0.5) * 0.3,
+      (r() - 0.5) * 0.22,
+    ));
+    b.z = Math.min(0.77, Math.max(0.31, b.z));
+    b.y = Math.min(alto / 2 - 0.04, Math.max(-alto / 2 + 0.04, b.y));
+    hilos.push({ nivel: 2, curva: curvaHifa(a, b, r, 0.2), r0: 0.006, r1: 0.002 });
+  }
+
+  return { hilos, puntas, hubs };
+}
+
+/* Brillo por nivel: el rizomorfo manda, la punta se apaga. */
+const COLOR_NIVEL = [PALETA.puente, PALETA.micelio, PALETA.micelioTenue];
+
+/*
+ * GEOMETRÍA de la red, en UNA malla (un draw-call).
+ *
+ * El horneado hace tres cosas que convierten resplandor en RED:
+ *   · CORDÓN: el vértice que mira a la cámara brilla y el del canto se apaga →
+ *     el tubo se lee como filamento redondo y no como cinta plana.
+ *   · PROFUNDIDAD (depth cueing): la hifa del fondo de la alcoba se apaga. Antes
+ *     TODAS brillaban igual sin importar la hondura, y una maraña de líneas con
+ *     brillo uniforme es, literalmente, una nube. Esto la separa en planos.
+ *   · NIVEL: rizomorfo claro → punta tenue. La jerarquía se ve.
+ */
+export function geometriaRedBanda(hilos, tier = 'alto') {
+  const radial = tier === 'alto' ? 6 : 4;
+  const zFondo = zFrenteDe('micorrizas');
+  const rango = Math.max(0.001, CARA - zFondo);
+  const partes = hilos.map((h) => {
+    const tub = h.nivel === 0 ? (tier === 'alto' ? 20 : 12) : tier === 'alto' ? 10 : 6;
+    const geo = tuboOrganico(h.curva, {
+      tubular: tub,
+      radial,
+      taper: (t) => h.r0 * (1 - t) + h.r1 * t,
+      // arruga 0: a 1-3 px de ancho no se ve, y con radial=4..6 las frecuencias
+      // del surco caerían por debajo de Nyquist y aliasarían (la misma trampa
+      // que convertía la corteza del Ent en "chocolate de plástico").
+      arruga: 0,
+      minRadio: 0.0015,
+    });
+    const base = COLOR_NIVEL[h.nivel] ?? PALETA.micelio;
+    const nrm = geo.attributes.normal;
+    return pintarPorVertice(geo, (x, y, z, i, c) => {
+      c.copy(base);
+      // cordón: la normal que mira a la cámara (+z) es la que brilla
+      const nz = nrm.getZ(i);
+      c.multiplyScalar(0.5 + 0.5 * Math.max(0, nz));
+      // depth cueing dentro de la alcoba
+      const prof = Math.min(1, Math.max(0, (z - zFondo) / rango));
+      c.multiplyScalar(0.42 + 0.58 * prof);
+      return c;
+    });
+  });
+  return fusionarSeguro(partes, 'red-micorrizas');
+}
+
+/*
+ * MUESTRAS de la red para hornearle luz a la tierra: puntos a lo largo de los
+ * rizomorfos y secundarias, con la fuerza con que iluminan. Es lo que resuelve el
+ * conflicto "banda oscura" ↔ "red que resalta" sin subir un lift plano.
+ */
+export function muestrasDeLuz(hilos) {
+  const out = [];
+  for (const h of hilos) {
+    if (h.nivel > 1) continue; // las puntas no alumbran
+    const n = h.nivel === 0 ? 9 : 4;
+    const fuerza = h.nivel === 0 ? 1 : 0.45;
+    for (let i = 0; i <= n; i++) {
+      const p = h.curva.getPoint(i / n);
+      out.push({ x: p.x, y: p.y, z: p.z, fuerza });
+    }
+  }
+  return out;
+}
+
+/*
+ * NODOS del micelio: los puntos donde el rizomorfo se une a una raíz o a otro
+ * rizomorfo. El DR hornea oclusión en las uniones de rama (se OSCURECEN); acá el
+ * signo se invierte: en una red viva la unión es el sitio de intercambio y tiene
+ * que ser lo más brillante. Son los nodos los que hacen que una maraña se lea
+ * como GRAFO — sin ellos hay líneas, pero no hay red.
+ */
+export function nodosDeRed(alto) {
+  const puntas = ANCLAS.map((a) => puntaDeAncla(a, alto));
+  const hubs = hubsDeBanda(alto);
+  return [
+    ...puntas.map((pos, i) => ({
+      pos,
+      tipo: 'arbusculo',
+      esc: ANCLAS[i].madre ? 1.9 : 1.35,
+      color: PALETA.arbusculo,
+    })),
+    ...hubs.map((pos) => ({ pos, tipo: 'nodo', esc: 1.1, color: PALETA.nodo })),
+  ];
+}
+
+/*
+ * PULSOS de nutrientes, SOLO por los rizomorfos. En la versión anterior los
+ * pulsos se repartían por hilos al azar de una malla k-vecinos: puntos de luz
+ * yendo a cualquier lado = ruido, y el ruido de luz sobre fondo oscuro es
+ * exactamente lo que se lee como "brillo". Corriendo por la columna vertebral,
+ * de raíz a raíz, el pulso hace visible la DIRECCIÓN del reparto — que es la
+ * frase entera del wood-wide web en una animación barata.
+ */
+export function pulsosDeBanda(hilos, total, seed = 53) {
+  if (!total) return [];
+  const r = rng(seed);
+  const troncales = [];
+  hilos.forEach((h, i) => { if (h.nivel === 0) troncales.push(i); });
+  if (!troncales.length) return [];
+  const out = [];
+  let k = 0;
+  while (out.length < total) {
+    const i = troncales[k % troncales.length];
+    k++;
+    const moneda = r();
+    // el mineral sube a la mata; el azúcar baja al hongo. Los dos sentidos.
+    const sube = moneda > 0.5;
+    out.push({
+      hilo: i,
+      t0: r(),
+      vel: 0.1 + r() * 0.06,
+      dir: sube ? -1 : 1,
+      color: sube ? (r() > 0.5 ? PALETA.fosforo : PALETA.agua) : PALETA.carbono,
+      tam: 0.9 + r() * 0.5,
+    });
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LA TIERRA — con información, no un color plano                             */
+/* -------------------------------------------------------------------------- */
+
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+
+/*
+ * El BLOQUE de tierra de una capa, con su alcoba ya descontada y el sombreado
+ * horneado por vértice (DR: "AO por vértice horneado ... añade profundidad sin
+ * costo de rendimiento en tiempo real").
+ *
+ * Va segmentado a propósito: un box de 24 vértices no puede llevar un gradiente
+ * ni una oclusión: el horneado no tendría dónde ocurrir y la tierra volvería a
+ * ser un color plano.
+ */
+export function construirTierra(capa, { luces = [], tier = 'alto' } = {}) {
+  const hueco = HUECO[capa.id] ?? 0;
+  const prof = PROF_CUT - hueco;
+  const segX = tier === 'alto' ? 20 : 10;
+  const segY = Math.max(3, Math.round(capa.alto * (tier === 'alto' ? 9 : 5)));
+  const segZ = tier === 'alto' ? 4 : 2;
+  const geo = new THREE.BoxGeometry(ANCHO_CUT, capa.alto, prof, segX, segY, segZ);
+  // la alcoba se abre por delante: el fondo del bloque no se mueve
+  geo.translate(0, 0, -hueco / 2);
+  return hornearTierra(geo, capa, { luces });
+}
+
+/**
+ * Hornea la tierra de una capa: grano, oclusión en las interfaces, caída hacia
+ * el fondo de la alcoba y —la clave— la LUZ QUE LA RED le echa encima.
+ *
+ * @param {THREE.BufferGeometry} geo
+ * @param {{id:string, alto:number, color:string}} capa
+ * @param {{luces?: Array<{x:number,y:number,z:number,fuerza:number}>}} o
+ */
+export function hornearTierra(geo, capa, { luces = [] } = {}) {
+  const base = new THREE.Color(capa.color);
+  const grieta = base.clone().multiplyScalar(0.42);
+  const cresta = base.clone().lerp(new THREE.Color('#c9ac82'), 0.22);
+  const brillo = new THREE.Color(PALETA.micelio);
+  const media = capa.alto / 2;
+  const zFrente = zFrenteDe(capa.id);
+  const RADIO_LUZ = 0.62;
+  const tmp = new THREE.Color();
+
+  return pintarPorVertice(geo, (x, y, z) => {
+    /* grano de tierra: la oscuridad es LOCAL (grieta) y no global */
+    const n = ruidoFbm(x * 3.1 + 13, y * 3.1, z * 3.1);
+    tmp.copy(grieta).lerp(base, clamp01(n * 1.45));
+    if (n > 0.66) tmp.lerp(cresta, clamp01((n - 0.66) / 0.34) * 0.7);
+
+    /* oclusión en las interfaces entre capas: la tierra se comprime arriba y
+       abajo. Es donde el ojo lee "profundidad de suelo". Nunca a 0. */
+    const juntura = 1 - clamp01((media - Math.abs(y)) / 0.16);
+    tmp.multiplyScalar(1 - 0.3 * juntura);
+
+    /* profundidad de alcoba: la luz de vitrina no llega al fondo del hueco */
+    const prof = clamp01((z + CARA) / PROF_CUT);
+    tmp.multiplyScalar(0.46 + 0.54 * prof);
+
+    /* la RED alumbra la tierra que la rodea. Cerca del filamento la tierra se
+       enciende; en los huecos se queda oscura → la banda se ve Y la red resalta.
+       Solo sobre la cara expuesta: dentro del bloque no hay nada que alumbrar. */
+    if (luces.length && z > zFrente - 0.12) {
+      let maxCae = 0;
+      for (let i = 0; i < luces.length; i++) {
+        const l = luces[i];
+        const dx = x - l.x;
+        const dy = y - l.y;
+        const dz = z - l.z;
+        const d = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        const cae = (1 - clamp01(d / RADIO_LUZ)) * l.fuerza;
+        if (cae > maxCae) maxCae = cae;
+      }
+      if (maxCae > 0) tmp.lerp(brillo, maxCae * maxCae * 0.5);
+    }
+    return tmp;
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL TERRENO — matar el aire muerto                                          */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * EL AIRE MUERTO, y por qué no se arregla solo moviendo la cámara.
+ *
+ * En la captura de la pasada 2 el corte FLOTA en cielo gris: un bloque de tierra
+ * colgado en el aire con vacío por los cuatro costados. No es que "sobre encuadre"
+ * — es que bajo la línea del pasto NO HAY MUNDO. El suelo era un disco de musgo
+ * de radio 4.2 visto casi de canto (la cámara está a y=0.2), o sea una rayita
+ * verde, y de ahí para abajo, nada.
+ *
+ * Acercar la cámara sin más solo agranda el bloque flotando. Lo que mata el aire
+ * muerto es POBLAR: un macizo de tierra que rodea la vitrina y explica de dónde
+ * se sacó el bloque. Con eso, bajo el horizonte todo es tierra y el corte pasa a
+ * ser lo que siempre debió ser: una VENTANA a la tierra, no un ladrillo en el
+ * cielo. Es la receta del DR de sotobosque/borde y de "claros" — el vacío tiene
+ * que ser compuesto, nunca residual.
+ *
+ * Se arma con CUATRO cajas alrededor de la huella del corte y nunca ENCIMA:
+ * coplanares pero sin solaparse, así que no hay z-fighting con la cara del corte.
+ *
+ *   izquierda · derecha · debajo · DETRÁS
+ *
+ * La de DETRÁS no es un detalle. El corte solo ocupa z ∈ [1.05, 2.75]; sin ella,
+ * la región x∈[0.9,4.1] · y∈[0,-4.79] · z<1.05 queda hueca y la cámara ve el
+ * CIELO por encima del bloque, justo detrás del pasto. Se veía en la primera
+ * captura de esta pasada: un boquete azul en plena tierra.
+ *
+ * El viñeteo se apaga al alejarse del corte → la vitrina queda iluminada y el
+ * entorno cae en penumbra, que es lo que lleva el ojo a la lección. Va SUAVE
+ * (0.3): a 0.55 el macizo se volvía un campo negro y el aire muerto gris
+ * simplemente pasaba a ser aire muerto negro.
+ *
+ * @param {{x:number, z:number}} corte  dónde está plantada la vitrina (mundo).
+ */
+export function construirTerreno(corte, { tier = 'alto' } = {}) {
+  const x0 = corte.x - ANCHO_CUT / 2;
+  const x1 = corte.x + ANCHO_CUT / 2;
+  const zF = corte.z + CARA; // la cara del corte: el terreno llega hasta acá
+  const zAtrasCorte = corte.z - CARA; // el fondo del bloque de la vitrina
+  const ATRAS = 15;
+  const HONDO = 9.5;
+  const LADO = 15;
+  const alto = tier === 'alto';
+
+  /*
+   * RESOLUCIÓN VERTICAL. La franja de arriba (la que enseña los horizontes) va
+   * densa: los horizontes se pintan POR VÉRTICE, así que un horizonte más
+   * delgado que el segmento sencillamente no existe. La hojarasca mide 0.42 →
+   * con 32 segmentos sobre 4.79 el paso es 0.15 y se resuelve. La franja de
+   * abajo es roca madre pareja: no necesita resolución y no la gasta.
+   */
+  const SEG_SUP = alto ? 32 : 14;
+  const SEG_INF = alto ? 8 : 3;
+  const PASO_Z = alto ? 1.5 : 4;
+
+  const piel = new THREE.Color('#5c6844'); // musgo del páramo
+  const pielSol = new THREE.Color('#7d9153');
+  const tmp = new THREE.Color();
+
+  /** Una caja del macizo, ya horneada. Coords de MUNDO. `segY` explícito. */
+  const caja = (bx0, bx1, by0, by1, bz0, bz1, segY) => {
+    const w = bx1 - bx0;
+    const h = by1 - by0;
+    const d = bz1 - bz0;
+    const geo = new THREE.BoxGeometry(
+      w, h, d,
+      Math.max(2, Math.min(16, Math.round(w * 0.8))),
+      segY,
+      Math.max(2, Math.round(d / PASO_Z)),
+    );
+    geo.translate((bx0 + bx1) / 2, (by0 + by1) / 2, (bz0 + bz1) / 2);
+    return pintarPorVertice(geo, (x, y, z) => {
+      /*
+       * RUIDO DE BAJA FRECUENCIA — no es gusto, es una COSTURA.
+       *
+       * Las cajas del macizo se hornean por vértice, y una función que salta
+       * (los horizontes) interpolada sobre rejillas distintas delata la arista
+       * que comparten: sale una línea vertical en plena tierra. Por eso las
+       * cajas que comparten arista llevan el MISMO `segY` (se parten todas en
+       * y=-ALTO_CORTE) y el ruido va a escala 0.16, lento frente al segmento.
+       */
+      const n = ruidoFbm(x * 0.16 + 5, y * 0.16, z * 0.16);
+      if (y > -0.06) {
+        // la piel del páramo: musgo, no tierra
+        tmp.copy(piel).lerp(pielSol, n);
+      } else {
+        /*
+         * LOS MISMOS HORIZONTES DEL CORTE, ondulados y en penumbra.
+         *
+         * Antes esto era un marrón liso, y un marrón liso gigante es aire muerto
+         * igual que el gris: solo cambia de color. Con los horizontes, el macizo
+         * deja de ser relleno y pasa a ser la lección: el suelo entero está en
+         * capas y el bloque es apenas la VENTANA por donde se ven. La onda evita
+         * que los horizontes salgan a nivel de albañil.
+         */
+        const onda = (ruidoFbm(x * 0.42 + 21, 0, z * 0.42) - 0.5) * 0.55;
+        tmp.copy(colorHorizonte(y + onda));
+        // penumbra: lo iluminado es la vitrina. Acá afuera la luz no entra.
+        tmp.multiplyScalar(0.5 + n * 0.26);
+      }
+      /* VIÑETEO suave: lejos del corte, penumbra. El ojo va a la vitrina. */
+      const d2 = Math.sqrt((x - corte.x) ** 2 + (z - corte.z) ** 2);
+      tmp.multiplyScalar(1 - 0.3 * clamp01((d2 - 2.6) / 10));
+      return tmp;
+    });
+  };
+
+  const yc = -ALTO_CORTE;
+  return fusionarSeguro(
+    [
+      // franja de los horizontes (la que se ve): todas parten en y=-ALTO_CORTE
+      caja(corte.x - LADO, x0, yc, 0, -ATRAS, zF, SEG_SUP), // izquierda (bajo el Ent)
+      caja(x1, corte.x + LADO, yc, 0, -ATRAS, zF, SEG_SUP), // derecha
+      caja(x0, x1, yc, 0, -ATRAS, zAtrasCorte, SEG_SUP), // DETRÁS (tapa el boquete)
+      // franja de roca madre, pareja: comparten segY → aristas casadas
+      caja(corte.x - LADO, x0, -HONDO, yc, -ATRAS, zF, SEG_INF),
+      caja(x1, corte.x + LADO, -HONDO, yc, -ATRAS, zF, SEG_INF),
+      caja(x0, x1, -HONDO, yc, -ATRAS, zF, SEG_INF), // debajo del corte
+    ],
+    'terreno-microsuelo',
+  );
+}

--- a/src/visual/mundo3d/bosque/sombreadoVegetal.js
+++ b/src/visual/mundo3d/bosque/sombreadoVegetal.js
@@ -299,11 +299,17 @@ export function hornearCorteza(geo, o) {
  * @param {(t:number)=>number} o.taper  radio-mundo en t∈[0,1].
  * @param {number} [o.arruga]  amplitud relativa del relieve de corteza.
  * @param {number} [o.semilla] desfase del relieve (para que no se repita).
+ * @param {number} [o.minRadio] piso del radio. Por defecto 0.02, que es lo que
+ *   quiere un TRONCO (nunca degenera a un hilo). Pero una HIFA micorrízica vive
+ *   entre 0.002 y 0.03: con el piso de tronco toda la jerarquía (rizomorfo →
+ *   secundaria → punta) se aplasta a un mismo grosor y la red vuelve a leerse
+ *   como una maraña pareja. Los llamadores finos lo bajan.
  */
 export function tuboOrganico(curva, o) {
   const { tubular, radial, taper } = o;
   const arruga = o.arruga ?? 0.12;
   const semilla = o.semilla ?? 0;
+  const minRadio = o.minRadio ?? 0.02;
   const geo = new THREE.TubeGeometry(curva, tubular, 1, radial, false);
   const pos = geo.attributes.position;
   const nAnillo = radial + 1;
@@ -327,7 +333,7 @@ export function tuboOrganico(curva, o) {
       + Math.sin(ang * 15 - semilla * 2 + t * 3) * 0.25
       + (ruido3D(Math.cos(ang) * 3 + semilla, t * 9, Math.sin(ang) * 3) - 0.5) * 1.4;
     const disp = 1 + surco * arruga * (1 + (1 - t) * 0.5);
-    v.copy(centro).addScaledVector(off, Math.max(0.02, taper(t) * disp));
+    v.copy(centro).addScaledVector(off, Math.max(minRadio, taper(t) * disp));
     pos.setXYZ(k, v.x, v.y, v.z);
   }
   pos.needsUpdate = true;


### PR DESCRIPTION
Tercera pasada sobre el Bosque Vivo. Base: `dev`. El #2480 se mergeó (squash) mientras esta pasada estaba en curso, así que esto va rebasado encima y aporta **un solo commit**.

El PR #2480 se cerró con esta frase:

> *"Mejora clara y medible en los tres frentes, pero no está 'terminado': la banda de micorrizas sigue leyéndose oscura y la red se ve más como brillo que como red, y la composición del microsuelo tiene aire muerto."*

Las dos primeras no eran dos cosas. Eran la misma, y no era acabado.

## La red estaba ENTERRADA

```
cara del corte          z = CARA = PROF_CUT/2   = 0.85
red (puntas de raíz)    z ∈ [0.05, 0.80]        (nZ = CARA - 0.15)
bloque de tierra        box de profundidad PROF_CUT → OPACO hasta 0.85
```

**La red entera vivía dentro del ladrillo de tierra.** Cero píxeles, cero errores, cero forma de enterarse sin mirar una captura. Es la misma familia del bug de la barba de la pasada 1 (colgaba dentro del fuste): la geometría estaba perfectamente construida y algo sólido se la comía.

Y el "brillo" que sí se veía **era el `pointLight` turquesa de relleno** pegando sobre la cara plana del barro — estaba delante del corte. Literalmente *"más brillo que red"*: lo único que había en pantalla ERA un brillo. La red no aportaba un píxel.

Las raíces de la capa de arriba llegaban a `0.85` exacto: tangentes a la cara, invisibles también. Los terrones se veían solo porque son esferas de radio 0.08–0.16 que asoman.

La cura no es iluminar la red. Es desenterrarla.

## Desenterrarla

- **`HUECO`** — la tierra se retira por capa (una alcoba excavada). La franja de micorrizas es la más abierta porque es la lección; las de arriba se escalonan hacia ella y la roca madre hace de repisa. La biología vive **delante** de la tierra.
- **Raíces visibles** que bajan de la zona de raíces y entran a la alcoba, nacidas de las **mismas anclas**: una raíz baja, cruza la frontera entre capas y el micelio la agarra. Antes cada capa sorteaba las suyas por su cuenta y no empataban — la lección se cortaba en la juntura. Sin raíces a la vista, unos filamentos flotando no son una red.
- **Jerarquía** (DR §*"Ausencia de jerarquía de ramas"*): rizomorfo → secundaria → punta, con **conicidad real** (DR §*"Conicidad real y nudos"*). La cadena raíz→hub→raíz se arma **a mano**: el grafo k-vecinos anterior unía cada nodo con su más cercano, y eso da una malla pareja **sin dirección** — que es exactamente lo que se lee como resplandor. Una cadena explícita se lee como *camino*, y un camino cuenta algo.
- **El material deja de ser aditivo.** El aditivo **acumula** donde los hilos se cruzan (en una red, siempre), sin `depthWrite` nada ocluye a nada, y la opacidad pulsante (0.84↔0.94) lo volvía niebla que respira. Aunque la red no hubiera estado enterrada, ese material la habría leído como brillo. Ahora es opaco con `vertexColors`: los filamentos se ocluyen entre sí → hay delante y detrás → hay red. El aditivo se reserva para nodos y pulsos, que sí son luz puntual.
- **Depth cueing** horneado: la hifa del fondo de la alcoba se apaga. Antes todas brillaban igual sin importar la hondura, y una maraña de líneas con brillo uniforme es una nube.
- **Pulsos solo por los rizomorfos**, de raíz a raíz: se ve la *dirección* del reparto. Antes iban por hilos al azar de la malla = ruido, y ruido de luz sobre fondo oscuro es, otra vez, "brillo".

## La banda oscura, sin lavar la red

Los dos males tiran en direcciones opuestas: subir el brillo del fondo lava el filamento. Por eso **no se sube un lift plano**. La luz se hornea **desde la red** sobre la tierra (`hornearTierra` recibe las muestras de las hifas): se enciende cerca del filamento y se queda oscura en los huecos. Es la receta de contraluz del DR con la red de fuente, y de paso el resplandor queda justificado — la red ilumina lo que la rodea.

Medido en espacio **lineal** sobre la cara de la banda (la primera medición que hice estaba mal: comparaba sRGB contra lineal):

| | L media | cerca del filamento | rango dinámico |
|---|---|---|---|
| antes (color plano `#33261c`) | 0.0217 | — | **x1.0** (era plano) |
| ahora | 0.0383 (**x1.76**) | 0.1296 (**x5.96**) | **x17.5** |

La banda **sigue siendo la tierra más oscura a propósito** — es el fondo contra el que resalta el bioluminiscente. Lo que cambia es que ahora tiene información. El DR es exacto: la oscuridad tiene que ser **local**, nunca global.

## El aire muerto

**No se cura acercando la cámara.** El corte *flotaba en cielo gris* porque bajo la línea del pasto no había mundo: el suelo era un disco de musgo de radio 4.2 visto casi de canto (una rayita verde) y de ahí para abajo, nada. Acercarse solo agranda un bloque flotando.

- **Terreno**: un macizo de tierra alrededor de la vitrina que enseña **los mismos horizontes del corte**. El suelo se lee continuo y el bloque pasa a ser lo que siempre debió ser: una **ventana iluminada** en la tierra. Convertir el relleno en la lección misma es lo que evita que sea aire muerto marrón en vez de gris.
- **La caja de DETRÁS**: sin ella se veía el **cielo por encima del bloque** (el corte solo ocupa `z ∈ [1.05, 2.75]`; la franja detrás quedaba hueca). Salió en la primera captura de esta pasada: un boquete azul en plena tierra.
- **El páramo vuelve al microsuelo.** En la entrada el Ent vive en un frailejonar; al bajar, el páramo desaparecía y el guardián quedaba parado en un **césped pelado**. Es el mismo sitio. `FloraParamo` gana `excluir` (opt-in, `undefined` por defecto → los llamadores actuales no cambian) para quitar lo que taparía la lección: acá la cámara mira el corte de frente y de cerca, y el frailejonar (radio 3.4) cae justo sobre el corte (a 3.14 del Ent). Se filtra **después** de sembrar: el bosque es el mismo en los dos encuadres.
- **Encuadre a 11** — con la tierra puesta ya se puede: rostro (`y=2.09`) + brazo + capas, y el corte llena ~54% del alto. `autoRotate` 0.12 → 0.06: a 0.12 la cara del corte se iba de perfil en un minuto y la lección dejaba de leerse.
- **Costura**: las cajas del macizo no compartían rejilla (5 vs 9 segmentos en Y) → el ruido se interpolaba distinto a cada lado de la arista y salía una línea vertical en plena tierra. Ahora todas parten en `y=-ALTO_CORTE` con el mismo `segY` y el ruido va a escala 0.16.

## Taller (no uno paralelo)

`tuboOrganico` gana `minRadio` — default **0.02**, que es el piso que quiere un *tronco*, así que los llamadores actuales no cambian ni un píxel. Una hifa vive entre 0.002 y 0.03: con el piso de tronco toda la jerarquía se aplastaba a un mismo grosor. Todo lo demás (`pintarPorVertice`, `fusionarSeguro`, `ruidoFbm`, `tuboOrganico`) es el taller de siempre. `arruga: 0` en las hifas: a 1-3 px de ancho no se ve, y con `radial=4..6` las frecuencias del surco caerían bajo Nyquist y aliasarían — la misma trampa que volvía la corteza del Ent "chocolate de plástico".

## Red de seguridad

**40 tests nuevos.** El primero es el que faltaba: que ningún filamento quede detrás de la cara de la tierra, en los 3 tiers.

Verificado **contra un control**: al devolver la alcoba a 0 (el estado de #2480) se ponen **rojos 7 tests**, justo los de "la red está delante de la tierra". El fallo que hoy solo se veía mirando una captura ahora es un test rojo.

## Presupuesto

| | alto | medio | bajo |
|---|---|---|---|
| red (tris) | 6120 | ~2.3k | ~700 |
| terreno (tris) | 12020 | — | 3316 |

Una draw-call por pieza (geometría fusionada + vertexColors horneados). Cero assets externos.

## Verificación

- `npm run build:prod` **verde** · eslint **limpio**.
- `tsc`: base **465** → con estos cambios **465**, y **0 en `bosque/`**. Delta **cero**, medido con `stash` contra la rama base, no estimado. (Ojo: `tail` me ocultó el exit code real en el primer intento; el segundo destapó 1 error mío, que está corregido.)
- **112 tests verdes** (40 nuevos + 63 del bosque + smoke).
- Los 2 rojos de `mundo3d` (`hiloVidaVista`, `useAudioMundo`) **fallan igual en la rama base** — verificado con stash. No los toca este PR.
- Capturas reales antes/después (chromium del sistema + swiftshader).
- **Entrada del bosque sin regresión** pese a tocar el taller.

## Honestidad sobre lo que queda

- Los campos de tierra a izquierda y derecha son grandes y oscuros. Tienen los horizontes y ya no son un vacío, pero siguen siendo superficie de poca información: ~35% del encuadre.
- El rostro del Ent entra justo por arriba, con poco aire sobre las cejas. Meter más cabeza le cobra tamaño al corte, y el corte es la lección — es una decisión, no un descuido. La rueda llega al rostro (`maxDistance` 20).
- Los tres frentes que #2480 dejó abiertos están cerrados y **medidos**, pero el juicio de si el nivel de acabado alcanza es del operador, no mío.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
