### PR TITLE
Barrido de controles muertos de prod: 15 clases de tap muerto revividas, 3 crashes de guardado matados

### DIFF
--- a/src/components/FarmMap.jsx
+++ b/src/components/FarmMap.jsx
@@ -93,6 +93,19 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
   const mapRef = useRef(null);
   const featureGroupRef = useRef(null);
 
+  // Fallback sin prop (barrido de controles 2026-07-15): el shell de prod
+  // monta FarmMap SIN onAssetClick → el botón "Ver logs" de cada popup era un
+  // tap muerto. Sin prop: seleccionar el activo en el store y pedir la vista
+  // de activos por el evento global que ambos shells escuchan. El shell viejo
+  // sigue pasando su propio onAssetClick (idéntico comportamiento).
+  const assetClickRef = useRef(/** @type {(id: string) => void} */ ((id) => {
+    try { useAssetStore.getState().setSelectedAsset(id); } catch { /* store no inicializado */ }
+    window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'activos' } }));
+  }));
+  useEffect(() => {
+    if (onAssetClick) assetClickRef.current = /** @type {(id: string) => void} */ (onAssetClick);
+  }, [onAssetClick]);
+
   const plants = useAssetStore((s) => s.plants);
   const structures = useAssetStore((s) => s.structures);
   const lands = useAssetStore((s) => s.lands);
@@ -146,18 +159,19 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
     map.on('moveend', saveViewport);
     map.on('zoomend', saveViewport);
 
-    // Delegación de click para botones "Ver logs →" dentro de popups
-    if (onAssetClick) {
-      map.on('popupopen', (e) => {
-        const btn = e.popup.getElement()?.querySelector('.chagra-popup-logs');
-        if (btn) {
-          btn.addEventListener('click', () => {
-            const assetId = btn.getAttribute('data-asset-id');
-            if (assetId) onAssetClick(assetId);
-          });
-        }
-      });
-    }
+    // Delegación de click para botones "Ver logs →" dentro de popups.
+    // Siempre activa: sin prop onAssetClick usa el fallback del ref (evento
+    // global chagraNavigate) — antes el binding entero se saltaba y el botón
+    // del popup quedaba muerto en prod.
+    map.on('popupopen', (e) => {
+      const btn = e.popup.getElement()?.querySelector('.chagra-popup-logs');
+      if (btn) {
+        btn.addEventListener('click', () => {
+          const assetId = btn.getAttribute('data-asset-id');
+          if (assetId) assetClickRef.current(assetId);
+        });
+      }
+    });
 
     return () => {
       map.remove();

--- a/src/components/GlaciarReporteScreen.jsx
+++ b/src/components/GlaciarReporteScreen.jsx
@@ -95,7 +95,12 @@ function emptyForm() {
   };
 }
 
-export default function GlaciarReporteScreen({ onBack, onVerHistorial = null }) {
+export default function GlaciarReporteScreen({ onBack, onVerHistorial = null, onNavigate = undefined }) {
+  // Fallback sin prop (barrido de controles 2026-07-15): el shell de prod no
+  // pasa onVerHistorial (es una prop específica de esta pantalla) → el botón
+  // "Ver historial" quedaba escondido en prod. Con onNavigate (que el shell
+  // SÍ inyecta) el botón vive; el shell viejo sigue pasando la suya.
+  const verHistorial = onVerHistorial ?? (onNavigate ? () => onNavigate('glaciar_historial') : null);
   const [tab, setTab] = useState('nuevo'); // 'nuevo' | 'lista'
   // U-3: el borrador autosalvado se restaura desde IndexedDB en un efecto al
   // montar (loadDraft es async). Arrancamos en vacío y, si hay borrador, lo
@@ -750,7 +755,7 @@ export default function GlaciarReporteScreen({ onBack, onVerHistorial = null }) 
           loading={loadingList}
           onEliminar={handleEliminar}
           onNuevo={() => setTab('nuevo')}
-          onVerHistorial={onVerHistorial}
+          onVerHistorial={verHistorial}
         />
       )}
     </div>

--- a/src/components/LocationDetectedScreen.jsx
+++ b/src/components/LocationDetectedScreen.jsx
@@ -255,6 +255,8 @@ function ThermalMountain({ altitud, pisoSlug }) {
  * @param {string} [props.initialMunicipio]
  * @param {number|null} [props.altitud]
  * @param {function(Object):void} [props.onConfirm]
+ * @param {Object|string|null} [props.initialData] - datos de navegación del shell de prod ({ coords, altitud, municipio, next }).
+ * @param {(view: string, data?: any) => void} [props.onNavigate] - inyectada por el shell de prod; fallback de onConfirm.
  * @param {function():void} [props.onBack]
  */
 export default function LocationDetectedScreen({
@@ -263,7 +265,20 @@ export default function LocationDetectedScreen({
   altitud = null,
   onConfirm,
   onBack,
+  // Inyectadas por el shell de prod (barrido de controles 2026-07-15): prod
+  // pasa los datos de navegación como `initialData` (no como props sueltas) y
+  // no pasa onConfirm → el botón "Confirmar" del flujo de ubicación era un
+  // tap muerto. El shell viejo sigue pasando sus props directas (ganan ellas).
+  initialData = null,
+  onNavigate = undefined,
 }) {
+  const datos = (initialData && typeof initialData === 'object') ? initialData : {};
+  coords = coords ?? datos.coords ?? null;
+  altitud = altitud ?? datos.altitud ?? null;
+  initialMunicipio = initialMunicipio || datos.municipio || '';
+  const confirmar = onConfirm ?? (onNavigate
+    ? () => onNavigate(typeof datos.next === 'string' ? datos.next : 'dashboard')
+    : undefined);
   const [loc, setLoc] = useState(null);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState(initialMunicipio);
@@ -642,8 +657,8 @@ export default function LocationDetectedScreen({
         /* no-op */
       }
     }
-    if (onConfirm) {
-      onConfirm({
+    if (confirmar) {
+      confirmar({
         ...loc,
         altitud: effectiveAltitud,
         altitud_source: effectiveAltitud != null ? altitudSource : undefined,

--- a/src/components/OnboardingProfile.jsx
+++ b/src/components/OnboardingProfile.jsx
@@ -119,7 +119,37 @@ const EXAMPLE_CHIPS = {
   invernadero_tamano: { values: ['6 x 10 metros', 'Uno pequeño', 'Media hectárea'], append: false },
 };
 
-export default function OnboardingProfile({ onComplete, onClose = undefined, onExplorarEjemplo = undefined }) {
+export default function OnboardingProfile({
+  onComplete,
+  onClose = undefined,
+  onExplorarEjemplo = undefined,
+  // Inyectadas por el shell de prod (barrido de controles 2026-07-15): prod
+  // no pasa onComplete/onClose/onExplorarEjemplo (props específicas del shell
+  // viejo) → "Listo", "Saltar todo", la X de cierre y el SKIP rico eran taps
+  // muertos: terminabas el onboarding y la pantalla no iba a ningún lado.
+  onNavigate = undefined,
+  onBack = undefined,
+}) {
+  // Fallbacks con la MISMA semántica del shell viejo (App.jsx):
+  //   onComplete → confirmar ubicación y seguir al home
+  //   onClose    → atrás
+  //   onExplorarEjemplo → sembrar finca de ejemplo y entrar al home
+  const completar = onComplete ?? (onNavigate
+    ? () => onNavigate('ubicacion-detectada', { next: 'dashboard' })
+    : undefined);
+  const cerrar = onClose ?? onBack;
+  const explorarEjemploFallback = onNavigate
+    ? async () => {
+      try {
+        const { seedExampleFinca } = await import('../services/demoFincaEjemplo');
+        await seedExampleFinca();
+      } catch (err) {
+        console.error('[OnboardingProfile] No se pudo sembrar la finca de ejemplo:', err);
+      }
+      onNavigate('dashboard');
+    }
+    : undefined;
+  const explorarEjemploCb = onExplorarEjemplo ?? explorarEjemploFallback;
   const [answers, setAnswers] = useState(() => getProfile());
   const [index, setIndex] = useState(0);
   const [sembrando, setSembrando] = useState(false);
@@ -153,7 +183,7 @@ export default function OnboardingProfile({ onComplete, onClose = undefined, onE
 
   const goBack = () => {
     if (index > 0) setIndex((i) => i - 1);
-    else if (onClose) onClose();
+    else if (cerrar) cerrar();
   };
 
   const skipQuestion = () => {
@@ -163,13 +193,13 @@ export default function OnboardingProfile({ onComplete, onClose = undefined, onE
   const finish = () => {
     markProfileDone();
     const profile = getProfile();
-    if (onComplete) onComplete(profile);
+    if (completar) completar(profile);
   };
 
   const skipAll = () => {
     markProfileSkipped();
     const profile = getProfile();
-    if (onComplete) onComplete(profile);
+    if (completar) completar(profile);
   };
 
   // SKIP rico: marcar el perfil como saltado, sembrar la finca de ejemplo y
@@ -179,7 +209,7 @@ export default function OnboardingProfile({ onComplete, onClose = undefined, onE
     setSembrando(true);
     markProfileSkipped();
     try {
-      await onExplorarEjemplo?.();
+      await explorarEjemploCb?.();
     } finally {
       setSembrando(false);
     }
@@ -252,7 +282,7 @@ export default function OnboardingProfile({ onComplete, onClose = undefined, onE
         {/* SKIP rico: explorar con la finca de ejemplo ya poblada (demo público).
             No pide llenar nada — entra a una finca completa (multi-piso, con
             historial y problemas reales). */}
-        {typeof onExplorarEjemplo === 'function' && (
+        {typeof explorarEjemploCb === 'function' && (
           <div className="max-w-xl mx-auto mb-2.5">
             <button
               type="button"

--- a/src/components/RegistroVozScreen.jsx
+++ b/src/components/RegistroVozScreen.jsx
@@ -64,7 +64,12 @@ const fmt = (ms) => {
   return `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`;
 };
 
-export default function RegistroVozScreen({ onBack, onSave, onManual = null }) {
+export default function RegistroVozScreen({ onBack, onSave, onManual = null, onNavigate = undefined }) {
+  // Fallback sin prop (barrido de controles 2026-07-15): ningún shell pasaba
+  // onManual → el respaldo "O escríbelo a mano" (clave para quien no puede
+  // usar la voz) estaba escondido en TODOS los shells. Con onNavigate (que el
+  // shell de prod inyecta) lleva al formulario del flujo unificado.
+  const manual = onManual ?? (onNavigate ? () => onNavigate('registro_unificado') : null);
   const { audioLevel, amplitudeHistory, durationMs, start, stop, reset, error: recorderError, hardLimitMs } = useVoiceRecorder();
 
   const [view, setView] = useState(ST.IDLE);
@@ -201,10 +206,10 @@ export default function RegistroVozScreen({ onBack, onSave, onManual = null }) {
             {/* Respaldo manual del flujo unificado (#23): para quien no quiere o
                 no puede usar la voz, un solo formulario adaptativo. Solo se
                 muestra si el contenedor pasó onManual (flujo unificado). */}
-            {onManual && (
+            {manual && (
               <button
                 type="button"
-                onClick={onManual}
+                onClick={manual}
                 className="inline-flex items-center gap-2 px-4 py-2 min-h-[44px] rounded-xl bg-slate-800/70 hover:bg-slate-700 border border-slate-700 text-sm font-semibold text-slate-200"
                 data-testid="registro-manual-cta"
               >

--- a/src/config/rutasProdChagraApp.js
+++ b/src/config/rutasProdChagraApp.js
@@ -89,6 +89,10 @@ export const NUCLEO_3D = [
   // ── Puerta maestra a los 12 mundos ─────────────────────────────
   {
     path: 'vitrina_maestra',
+    // alias mockup_vitrina_maestra: MundosDeMiFinca (dashboard) navega con el
+    // nombre viejo — sin el alias esa tile era un tap muerto en prod
+    // (barrido de controles 2026-07-15).
+    alias: ['mockup_vitrina_maestra'],
     componente: 'VitrinaMaestraMundos',
     importLazy: 'src/mockups/VitrinaMaestraMundos.jsx',
     categoria: '3D',
@@ -153,6 +157,10 @@ export const NUCLEO_3D = [
   },
   {
     path: 'subsuelo',
+    // alias mundo3d_micorrizas: la tile "suelo vivo 3D" de mundosFinca.js usa
+    // el nombre del shell viejo; en prod el mundo micorrízico es el subsuelo
+    // (misma decisión que wire3DNav, PR #2479).
+    alias: ['mundo3d_micorrizas'],
     componente: 'MundoSubsuelo',
     importLazy: 'src/components/juego/MundoSubsuelo.jsx',
     categoria: '3D',
@@ -529,6 +537,17 @@ export const NUCLEO_APP = [
     path: 'milpa_cultivo',
     componente: 'MilpaScreen',
     importLazy: 'src/components/milpa/MilpaScreen.jsx',
+    categoria: '2D-app',
+  },
+  {
+    // Mundo "Quinua y granos andinos" — estaba en el shell viejo (case
+    // 'quinua' + tile en mundosFinca.js) y NO estaba en EXCLUIDO: omisión del
+    // manifiesto, no decisión. Sin esta entrada la tile del hub de cultivos
+    // era un tap muerto en prod (barrido de controles 2026-07-15).
+    path: 'quinua',
+    alias: ['granos-andinos', 'quinoa'],
+    componente: 'QuinuaScreen',
+    importLazy: 'src/components/quinua/QuinuaScreen.jsx',
     categoria: '2D-app',
   },
 
@@ -1006,7 +1025,7 @@ export const EXCLUIDO = [
  * @property {string}  motivo
  */
 
-/** @type {Array<{path:string, componente:string, importLazy:string, decision:null, motivo:string}>} */
+/** @type {Array<{path:string, alias?:string[], componente:string, importLazy:string|null, decision:null, motivo:string}>} */
 export const PENDIENTE_DECISION = [
   // ── Onboarding: ¿Profile o Siembra (mockup)? ──────────────────
   {
@@ -1038,6 +1057,13 @@ export const PENDIENTE_DECISION = [
   },
   {
     path: 'mercados',
+    // alias 'mercado': SIETE superficies de prod (DashboardLive, FiqueScreen,
+    // mundosFinca, pisosTermicos, mundoData, cicloVivoData, FincaVivaHero)
+    // navegan a 'mercado' — y MercadosScreen YA está montada en prod como
+    // #mercados. El alias hace que esos CTAs aterricen en la pantalla que ya
+    // se embarca en vez de morir en el guard. Si el operador decide sacar el
+    // mercado de prod, quitar el alias JUNTO CON la entrada entera.
+    alias: ['mercado'],
     componente: 'MercadosScreen',
     importLazy: 'src/components/MercadosScreen.jsx',
     decision: null,

--- a/src/prodApp/ProdChagraApp.jsx
+++ b/src/prodApp/ProdChagraApp.jsx
@@ -7,7 +7,7 @@
  * Usa import.meta.glob con paths EXACTOS (no wildcard) — Vite los
  * resuelve en build-time sin penalizar el build completo.
  */
-import React, { lazy, Suspense, useState, useEffect, useCallback } from 'react';
+import React, { lazy, Suspense, useState, useEffect, useCallback, useRef } from 'react';
 import { isAuthenticated } from '../services/authService';
 import {
   NUCLEO_3D,
@@ -15,6 +15,15 @@ import {
   PENDIENTE_DECISION,
   EXCLUIDO,
 } from '../config/rutasProdChagraApp.js';
+// Rutas dinámicas 'seguimiento_<key>' (reforestación/silvopastoreo/páramo/
+// cerdos): el shell viejo las parseaba en el switch; sin esto, las tarjetas de
+// seguimiento del dashboard y el enlace de VacasScreen eran taps muertos.
+import { parseSeguimientoView } from '../config/seguimientoProcesos.js';
+// Barra offline/sync (autocontenida, escucha online/offline/syncError/
+// syncComplete). El shell viejo la montaba; prod no — en una app de campo
+// offline-first, quedarse sin la señal de "sin conexión / X por sincronizar"
+// es un bug, no un detalle.
+import NetworkStatusBar from '../components/NetworkStatusBar.jsx';
 
 // Audio cleanup: al cambiar de ruta, detener cualquier voz (Kokoro/Web Speech)
 // que haya quedado sonando de la vista anterior. El loop eterno reportado
@@ -107,6 +116,7 @@ const LAZY_MAP = {
   BoticaScreen: lazy(() => import('../components/botica/BoticaScreen.jsx')),
   FiqueScreen: lazy(() => import('../components/fique/FiqueScreen.jsx')),
   MilpaScreen: lazy(() => import('../components/milpa/MilpaScreen.jsx')),
+  QuinuaScreen: lazy(() => import('../components/quinua/QuinuaScreen.jsx')),
   SanidadSintomaScreen: lazy(() => import('../components/sanidad/SanidadSintomaScreen.jsx')),
   InvasiveObservationLog: lazy(() => import('../components/InvasiveObservationLog.jsx')),
   ToxicologiaScreen: lazy(() => import('../components/ToxicologiaScreen.jsx')),
@@ -215,6 +225,25 @@ function parseHash() {
   return { view: view || 'valle3d', data };
 }
 
+// ── Vistas SIN control de salida propio (verificado archivo por archivo,
+//    barrido de controles 2026-07-15: cero location.hash / chagraNavigate /
+//    onBack / history.back en todo el árbol del componente). En una PWA
+//    instalada (sin barra del navegador) son TRAMPAS: el campesino entra y no
+//    puede volver. Para estas, el shell superpone un botón de casa. Las vistas
+//    con salida propia (valle, mundos con AcompananteMundo, pantallas con
+//    ScreenShell) NO están acá — un segundo botón de casa confundiría.
+const VISTAS_SIN_SALIDA = new Set([
+  'valle3d_noche',
+  'sierra_global', 'sierra', 'vista_sierra',
+  'diorama_abejas', 'diorama_paramo', 'diorama_suelo', 'diorama_compost',
+  'subsuelo', 'mundo3d_micorrizas',
+  'camara_director', 'artesania_andina', 'efectos_funcionales',
+  'catalogo_infra', 'colocar_infra', 'gemelos_2d',
+  'aliados_finca', 'momento_venta',
+  'fermentos', 'asociaciones', 'mapa',
+  'mockup_voz_con_forma', 'mockup_conversacion_voz',
+]);
+
 // ── Componente principal ────────────────────────────────────────
 
 export default function ProdChagraApp() {
@@ -229,12 +258,39 @@ export default function ProdChagraApp() {
   // para sobrevivir recarga y botón atrás del navegador.
   const [navData, setNavData] = useState(null);
 
+  // ── Toast del shell. Dos bocas, misma campana:
+  //    1. prop `onSave` (SeedingLog, TaskScreen, RegistroVoz, invasoras… —
+  //       el shell viejo pasaba onSave={showToast} y prod no pasaba NADA:
+  //       guardabas y no había ninguna confirmación).
+  //    2. CustomEvent 'chagraToast' (7 componentes lo despachan: foto muy
+  //       pesada, plan de alimentación sugerido, reporte registrado…) que NO
+  //       tenía listener en NINGÚN shell — todos esos avisos eran no-ops.
+  const [toast, setToast] = useState(null);
+  const toastTimer = useRef(/** @type {any} */ (null));
+  const mostrarToast = useCallback((message, isError = false) => {
+    if (typeof message !== 'string' || !message) return;
+    setToast({ message, isError: isError === true });
+    clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToast(null), 4000);
+  }, []);
+  useEffect(() => {
+    /** @param {Event & { detail?: any }} e */
+    const onToast = (e) => mostrarToast(e.detail?.message, e.detail?.isError);
+    window.addEventListener('chagraToast', onToast);
+    return () => {
+      window.removeEventListener('chagraToast', onToast);
+      clearTimeout(toastTimer.current);
+    };
+  }, [mostrarToast]);
+
   const navigate = useCallback((view, data = null) => {
     if (!view || view === 'loading') return;
     // Guard de rutas: las pantallas piden vistas que a veces no existen en el
     // manifiesto de prod (ej. tiles legacy del dashboard). Ignorar el toque es
     // mejor que caer al valle "porque sí" (el fallback del router confunde).
-    if (!RUTAS.has(view) && view !== 'login' && view !== 'oauth-callback') return;
+    // Las 'seguimiento_<key>' son rutas paramétricas válidas (no están en el
+    // manifiesto como literales).
+    if (!RUTAS.has(view) && !parseSeguimientoView(view) && view !== 'login' && view !== 'oauth-callback') return;
     // Detener cualquier audio de la vista anterior antes de montar la nueva.
     // El loop eterno reportado ocurre cuando el audio asíncrono resuelve
     // después del desmontaje del componente 3D.
@@ -346,14 +402,20 @@ export default function ProdChagraApp() {
   }
 
   // ── Router data-driven ────────────────────────────────────
-  const ruta = RUTAS.get(currentView);
-  const Componente = ruta ? ruta.Lazy : RUTAS.get('valle3d')?.Lazy;
+  // 'seguimiento_<key>' es paramétrica: no vive en RUTAS como literal.
+  // El path estático 'seguimiento' acepta la key por navData (#seguimiento/"reforestacion").
+  const segKey = parseSeguimientoView(currentView)
+    || (currentView === 'seguimiento' && typeof navData === 'string' ? navData : null);
+  const ruta = segKey ? null : RUTAS.get(currentView);
+  const Componente = segKey
+    ? /** @type {React.ComponentType<any>} */ (LAZY_MAP.SeguimientoProcesoScreen)
+    : (ruta ? ruta.Lazy : RUTAS.get('valle3d')?.Lazy);
 
   if (!Componente) return <ChagraGrowLoader />;
 
   // El HOME (valle 3D) no lleva `onBack`: no hay a dónde volver desde casa
   // (las pantallas esconden/muestran su botón según llegue la prop).
-  const esHome = !ruta || ruta.path === 'valle3d';
+  const esHome = !segKey && (!ruta || ruta.path === 'valle3d');
 
   return (
     <Suspense fallback={<ChagraGrowLoader />}>
@@ -362,15 +424,73 @@ export default function ProdChagraApp() {
           CRASHEABA (onClick={() => onNavigate(...)} sin guard → TypeError →
           ErrorBoundary raíz). Cada componente toma las props que declare e
           ignora el resto (initialContext la usa AgentScreen; initialMundoId,
-          el valle en deep-links `#valle3d/"agua"`). */}
+          el valle en deep-links `#valle3d/"agua"`; procesoKey, el seguimiento
+          de procesos; onSave, las pantallas de registro — el shell viejo
+          pasaba showToast y prod no pasaba nada). */}
       <Componente
         onBack={esHome ? undefined : volverAtras}
         onHome={irAlInicio}
         onNavigate={navigate}
+        onSave={mostrarToast}
         initialData={navData ?? undefined}
         initialContext={navData ?? undefined}
         initialMundoId={esHome && typeof navData === 'string' ? navData : undefined}
+        procesoKey={segKey ?? undefined}
       />
+      {/* Salida para las vistas-trampa: sin esto, en PWA instalada no hay
+          forma de volver (ni barra del navegador ni control propio). */}
+      {!esHome && VISTAS_SIN_SALIDA.has(currentView) && (
+        <button
+          type="button"
+          onClick={irAlInicio}
+          aria-label="Volver al valle"
+          title="Volver al valle"
+          style={{
+            position: 'fixed',
+            top: 'calc(env(safe-area-inset-top, 0px) + 10px)',
+            left: 'calc(env(safe-area-inset-left, 0px) + 10px)',
+            zIndex: 60,
+            width: 42,
+            height: 42,
+            borderRadius: '50%',
+            border: '1px solid rgba(255,255,255,0.3)',
+            background: 'rgba(15,23,42,0.72)',
+            color: '#fff',
+            fontSize: 20,
+            lineHeight: 1,
+            cursor: 'pointer',
+            backdropFilter: 'blur(4px)',
+            WebkitBackdropFilter: 'blur(4px)',
+          }}
+        >
+          🏠
+        </button>
+      )}
+      {/* Toast del shell (onSave + CustomEvent 'chagraToast'). */}
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            position: 'fixed',
+            bottom: 'calc(env(safe-area-inset-bottom, 0px) + 18px)',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 70,
+            maxWidth: 'min(92vw, 480px)',
+            padding: '10px 16px',
+            borderRadius: 12,
+            background: toast.isError ? 'rgba(127,29,29,0.95)' : 'rgba(15,23,42,0.92)',
+            border: `1px solid ${toast.isError ? 'rgba(248,113,113,0.5)' : 'rgba(52,211,153,0.4)'}`,
+            color: '#f8fafc',
+            font: '600 0.85rem/1.35 system-ui, sans-serif',
+            boxShadow: '0 6px 24px rgba(0,0,0,0.45)',
+          }}
+        >
+          {toast.message}
+        </div>
+      )}
+      <NetworkStatusBar />
     </Suspense>
   );
 }

--- a/src/visual/mundo3d/sierra/GaleriaSierraArboles.jsx
+++ b/src/visual/mundo3d/sierra/GaleriaSierraArboles.jsx
@@ -979,6 +979,7 @@ function hexLerp(a, b, t) {
  * @param {string}  [props.pisoUsuario]  piso de la finca a resaltar (opcional).
  * @param {(pisoId:string)=>void} [props.onEntrarPiso]  navegar al mundo del piso.
  * @param {string}  [props.className]
+ * @param {(view: string, data?: any) => void} [props.onNavigate]  inyectada por el shell de prod; fallback de onEntrarPiso.
  */
 export default function GaleriaSierraArboles({
   tier = 'alto',
@@ -986,7 +987,14 @@ export default function GaleriaSierraArboles({
   pisoUsuario,
   onEntrarPiso,
   className = '',
+  // Inyectada por el shell de prod (barrido de controles 2026-07-15): nadie
+  // cableaba onEntrarPiso → los árboles héroe y las bandas de la leyenda eran
+  // taps muertos. Sin prop específica, entrar al piso lleva a la navegación
+  // de mundos por piso térmico (montaña), con el piso tocado como dato.
+  onNavigate = undefined,
 }) {
+  const entrarPiso = onEntrarPiso
+    ?? (onNavigate ? (pisoId) => onNavigate('montana_mundos', { piso: pisoId }) : undefined);
   const [listo, setListo] = useState(false);
   const [clima, setClima] = useState(0);
   const controles = useRef(null);
@@ -1013,7 +1021,7 @@ export default function GaleriaSierraArboles({
           reducedMotion={reducedMotion}
           clima={clima}
           pisoUsuario={pisoUsuario}
-          onEntrarPiso={onEntrarPiso}
+          onEntrarPiso={entrarPiso}
         />
         <OrbitControls
           ref={controles}
@@ -1042,7 +1050,7 @@ export default function GaleriaSierraArboles({
           <small>Del mar Caribe a la nieve: toque el árbol mayor de un piso para entrar a su mundo.</small>
         </h2>
 
-        <LeyendaPisos clima={clima} pisoUsuario={pisoUsuario} onEntrarPiso={onEntrarPiso} />
+        <LeyendaPisos clima={clima} pisoUsuario={pisoUsuario} onEntrarPiso={entrarPiso} />
 
         <div className="gsierra-abajo">
           {/* SLIDER CLIMÁTICO: el corrimiento de los pisos hoy→2050 */}


### PR DESCRIPTION
## Qué es

**Barrido completo de controles muertos de prod.chagra.app** — las ~122 rutas del manifiesto + sus aliases, auditadas estáticamente (script sobre los 756 archivos del grafo de imports de prod) y verificadas con **clicks reales** (chromium+swiftshader sobre `dist-prod`).

**Extiende #2479 (NO lo duplica).** Esta rama nació encima de `fable/direccion-camara-valle`, así que el delta es puro trabajo nuevo: 8 archivos, cero solapamiento con el fix sistémico (listeners + props + guard de rutas) ni con la cámara/composición del valle. #2479 arregló los botones muertos que encontró mirando una pantalla; **este PR barre el resto**. Ya rebasado sobre el `app-3d` de ahora (que incluye #2479 y #2481) y **re-verificado completo sobre esa base** — no confié en el verde anterior.

## Las 5 clases de control muerto encontradas

| Clase | Qué era | Alcance |
|---|---|---|
| A | `navigate()` hacia vistas fuera del manifiesto (el guard de #2479 las traga en silencio) | 8 targets, 10 superficies |
| B | CustomEvents que NINGÚN shell escucha | `chagraToast` (7 componentes), `syncError`/`syncComplete` |
| C | Props callback del shell viejo que prod no inyecta | 6 pantallas, ~12 controles |
| D | Vistas sin NINGÚN control de salida (trampa en PWA instalada) | 20 vistas |
| E | Hash con barra inicial / handlers stub | 0 (limpio) |

**Lo más grave (misma clase que el crash del dashboard de #2479):** `HarvestLog`, `InputLog` y `ObservationScreen` llaman `onSave(...)` **sin guard** en la validación → en prod, guardar con datos incompletos en `#cosechar`/`#insumos`/`#observacion` tiraba `TypeError` → ErrorBoundary raíz → **la app entera se caía**. Reproducido con click real antes del fix (vía `#observacion`, cuyo botón no se deshabilita si falta la ubicación).

## La lista completa (control · ruta · qué hacía · qué hace · estado)

### Arreglados — verificados con clicks reales (15/15 PASS, 0 pageerrors)

| # | Control | Ruta | Antes | Ahora |
|---|---|---|---|---|
| 1 | Guardar registro (validación y éxito) | `observacion`, `cosechar`, `insumos`, `sembrar`, `new_task`, `voz`, `procesos`, `registro_unificado`, `reportar_invasora`, `seguimiento_*` | **CRASH total** (onSave sin guard) o silencio | toast del shell (`onSave={mostrarToast}`, semántica exacta del shell viejo) |
| 2 | Avisos `chagraToast` (foto pesada, plan de alimentación, reporte registrado…) | 7 componentes (Observation, Assets, Bitacora, Maintenance, Evidence, Species, VoiceCapture) | no-op en TODOS los shells | listener + toast en el shell de prod |
| 3 | Tarjetas de seguimiento (reforestación, silvopastoreo, páramo, cerdos) + botón de RestauracionScreen + enlace de VacasScreen | `seguimiento_<key>` | tap muerto (ruta paramétrica no registrada) | rutas dinámicas parseadas como el shell viejo; deep-link también |
| 4 | Tile "Quinua y granos andinos" (hub cultivos, mundosFinca) | `quinua` | tap muerto — **omisión del manifiesto** (tenía case en el shell viejo y NO estaba en EXCLUIDO) | ruta registrada + aliases |
| 5 | Tile "El mercado y la despensa" + CTA de FiqueScreen + 5 superficies más | `mercado` | tap muerto ×7 mientras `#mercados` YA embarcaba en prod | alias `mercado`→MercadosScreen (**reversible**, ver decisiones abajo) |
| 6 | Tile vitrina de mundos (MundosDeMiFinca) | `mockup_vitrina_maestra` | tap muerto (nombre viejo) | alias → `vitrina_maestra` |
| 7 | Tile "suelo vivo 3D" (mundosFinca) | `mundo3d_micorrizas` | tap muerto | alias → `subsuelo` (misma decisión que wire3DNav de #2479) |
| 8 | Salida de 20 vistas-trampa (dioramas, demos 3D, fermentos, asociaciones, mapa, voz…) | ver set `VISTAS_SIN_SALIDA` | **sin retorno en PWA instalada** (0 afordancias, verificado archivo por archivo) | botón casa flotante del shell |
| 9 | Árboles héroe + bandas de leyenda de la Sierra | `sierra_global` | `onEntrarPiso` sin cablear (deuda apuntada por #2479) | → `montana_mundos` con el piso como dato |
| 10 | "Ver logs →" en popups del mapa | `mapa` | botón SIEMPRE visible, binding saltado | selecciona activo + navega a `activos` |
| 11 | "Ver historial completo" del glaciar | `glaciar` | escondido sin `onVerHistorial` | fallback → `glaciar_historial` |
| 12 | "Listo" / "Saltar todo" / cierre / SKIP rico del onboarding | `onboarding-perfil` | taps muertos (terminabas y no ibas a ningún lado) | misma semántica del shell viejo (→ ubicación → home; finca de ejemplo) |
| 13 | "Confirmar" del flujo de ubicación | `ubicacion-detectada` | tap muerto (sin `onConfirm`; datos venían por props que prod no pasa) | adaptador `initialData` + fallback `next` |
| 14 | "O escríbelo a mano" (respaldo sin voz) | `voz` | escondido en TODOS los shells | fallback → `registro_unificado` |
| 15 | Barra offline/sync (`syncError`/`syncComplete`, "X por sincronizar") | global | no existía en prod (app de campo offline-first) | `NetworkStatusBar` montada |

Los fallbacks son **no invasivos**: el shell viejo sigue pasando sus props directas y ganan siempre.

### Declarados, NO arreglados (decisión de producto / fuera de scope)

| Qué | Dónde | Por qué no lo toqué |
|---|---|---|
| Tile "Campo, Javier" | dashboard (solo visible para el operador, gate `esOperadorActual`) | `javier` está en EXCLUIDO con motivo explícito. O se incluye WorkerDashboard en prod o se esconde la tile — decisión del operador. |
| Inclusión definitiva del mercado | PENDIENTE_DECISION | El alias `mercado`→`mercados` es puente a una pantalla que YA embarcaba; si el operador decide "mercado fuera", quitar el alias JUNTO CON la entrada `mercados`. |
| Ruta `seguimiento` pelada (sin key) | manifiesto | Sin `procesoKey` la pantalla queda cargando. Nadie navega ahí hoy; ahora acepta `#seguimiento/"<key>"`. Verruga documentada. |
| `localforage` sin config en prod | `main-prod.jsx` | La config `{name:'Chagra'}` vive en App.jsx que prod no importa → prod usa la DB default. Autoconsistente (funciona), pero migrarla ahora huérfana datos ya guardados de prod. Decisión aparte. |
| `onTaskComplete` de FarmMap | `mapa` | Solo aplica con `showTasks` (prod no lo activa). No es regresión. |
| `PENDIENTE_DECISION` completo se registra en el shell | `ProdChagraApp` | Los "pendientes" (juegos mockup, voz experimental, almanaque…) YA embarcan en prod. Herencia del shell — el operador debería resolver el bloque. |

## Verificación (síncrona, real)

- `npm run tsc:check` **limpio** · `npm run build:prod` **verde** (dist-prod, el build que ES prod — no el clásico)
- **15/15 clicks reales PASS, 0 pageerrors** — chromium sistema + swiftshader sobre `dist-prod` servido estático, login inyectado (DB default de localforage — el seeding contra `Chagra` NO autentica en prod, ver decisiones), rutas `#ruta` sin barra
- Capturas por paso (PASS y estados intermedios): toast de error real tras click en "Guardar Observacion" con app viva; "Saltar todo"→ubicación→cascade municipios→"Confirmar"→dashboard; banda de la Sierra→montaña; overlay casa→valle
- Tests unitarios de los componentes tocados: **59/59** (OnboardingProfile, LocationDetected, Glaciar, RegistroVoz, Restauración, seguimientoProcesos)
- Auditoría estática reproducible: los scripts quedan en scratchpad de la sesión (no van al repo)

## ⚠️ Coordinación

- Base `app-3d` con **#2479 y #2481 ya dentro**; cherry-picks limpios, sin conflictos.
- `GaleriaSierraArboles.jsx` es del frente sierra → commit aparte (`6faef28d`) para cherry-pick fácil, mismo patrón que #2479.
- No toca transiciones, cámara ni composición del valle (#2479 intacto), ni `floraParamo` / la vitrina (#2481, incluido su `dispose()` en `fusionar()`), ni el frente Ent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
