### PR TITLE
rescate(bosque): el boton del microsuelo era un @keyframes inexistente

### DIFF
--- a/src/visual/mundo3d/bosque/MundoEntBosque.jsx
+++ b/src/visual/mundo3d/bosque/MundoEntBosque.jsx
@@ -23,9 +23,20 @@ import EscenaBosqueVivo from './EscenaBosqueVivo.jsx';
 import EscenaEntMaestro from './EscenaEntMaestro.jsx';
 import { decidirTier, permite3D } from '../deviceTier.js';
 
-/* La invitación aparece cuando la cámara ya llegó al claro (~5.2s de caminata). */
+/* La invitación aparece a los ~2s (antes eran 5.6s: el operador la perdía de
+   vista buscando la lección). Mientras tanto, una pista discreta abajo avisa
+   que algo viene — para que la espera no se sienta como una pantalla muda. */
 const CSS = `
 .entb { position: relative; width: 100%; height: 100%; overflow: hidden; background: #c3cfce; }
+.entb__pista {
+  position: absolute; left: 50%; bottom: max(1.3rem, env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  width: 0.55rem; height: 0.55rem; border-radius: 999px;
+  background: rgba(55, 214, 176, 0.85);
+  box-shadow: 0 0 10px 3px rgba(55, 214, 176, 0.45);
+  opacity: 0;
+  animation: entb-pista 2s ease forwards;
+}
 .entb__panel {
   position: absolute; left: 50%; bottom: max(0.9rem, env(safe-area-inset-bottom));
   transform: translateX(-50%);
@@ -37,7 +48,7 @@ const CSS = `
   backdrop-filter: blur(6px);
   color: #e9efdd;
   opacity: 0;
-  animation: entb-aparece 0.9s ease 5.6s forwards;
+  animation: entb-aparece 0.9s ease 2s forwards;
 }
 .entb__panel--ya { opacity: 1; animation: none; }
 .entb__kicker { margin: 0 0 0.15rem; font: 600 0.68rem/1.2 system-ui, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: #aebd97; }
@@ -61,7 +72,18 @@ const CSS = `
   backdrop-filter: blur(6px);
 }
 .entb__volver:active { transform: scale(0.97); }
+@keyframes entb-pista {
+  0% { opacity: 0; transform: translateX(-50%) scale(0.6); }
+  15% { opacity: 1; transform: translateX(-50%) scale(1); }
+  80% { opacity: 1; transform: translateX(-50%) scale(1); }
+  100% { opacity: 0; transform: translateX(-50%) scale(1); }
+}
+@keyframes entb-aparece {
+  from { opacity: 0; transform: translateX(-50%) translateY(0.6rem); }
+  to { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
 @media (prefers-reduced-motion: reduce) {
+  .entb__pista { display: none; }
   .entb__panel { opacity: 1; animation: none; }
   .entb__bajar, .entb__volver { transition: none; }
 }
@@ -88,6 +110,10 @@ export default function MundoEntBosque({ tier: tierProp, reducedMotion: rmProp }
       {modo === 'entrada' ? (
         <>
           <EscenaBosqueVivo tier={tier} reducedMotion={reducedMotion} />
+          {/* Pista discreta: avisa desde el primer fotograma que algo va a
+              aparecer abajo, mientras el panel real hace su fade-in (~2s). Sin
+              esto la espera se sentía como pantalla muda. */}
+          {!reducedMotion && <div className="entb__pista" aria-hidden="true" />}
           <div className={`entb__panel${reducedMotion ? ' entb__panel--ya' : ''}`}>
             <p className="entb__kicker">El guardián del páramo</p>
             <p className="entb__texto">


### PR DESCRIPTION
Cherry-pick de `4c181901`, rescatado del PR #2478 antes de descartarlo.

## Qué arregla

El botón "Bajar al microsuelo" de `MundoEntBosque` **no se demoraba: nunca aparecía**. La animación llamaba a un `@keyframes` **que no existe**, así que el panel se quedaba en `opacity: 0` **para siempre**.

Es el mismo patrón que apareció nueve veces en 24 horas: **código escrito, correcto y que nadie ejecuta** — como la barba del Ent enterrada en su propio tronco, la red micorrízica sepultada bajo el bloque de tierra, o los gestos del oso que ningún componente disparaba.

## De los 4 commits huérfanos de #2478, solo este entra limpio

| commit | estado |
|---|---|
| `4c181901` botón del microsuelo | ✅ **este PR** |
| `06278aac` desconectar grafo+atmosfera | ❌ choca — **pero ya no hace falta**: verificado que en `app-3d` ambas rutas ya están fuera (0 entradas en el manifest, 0 en el LAZY_MAP) |
| `a7684093` cablear 6 módulos sin ruta | ❌ choca con #2479 — pendiente, va aparte |
| `a8df2b90` poblar el corral | ❌ choca — pendiente, va aparte |

## Hallazgo al verificar (no lo arregla este PR)

**`restauracion` sirve la pantalla 2D (`RestauracionScreen`) y el mundo 3D de restauración no tiene ruta en `app-3d`.** El código existe (`EscenaRestauracion.jsx`, `AguaQueVuelve.jsx`, `AvesQueVuelven.jsx`) y **nada lo alcanza**. `restauracion_3d` solo existía en #2478, que queda descartado. Es el noveno caso del patrón y necesita decisión: o se cablea o se declara en el allowlist de `ops/integraciones-no-consumidas.json` (PR #2475).

`build:prod` verde.