### PR TITLE
fix(ci): los gates no corrian en dev ni app-3d — todo el 3D entraba a ciegas

### DIFF
--- a/.github/workflows/perf-budget.yml
+++ b/.github/workflows/perf-budget.yml
@@ -8,7 +8,7 @@ name: Performance Budget
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev, app-3d]
   push:
     branches: [main, feat/**, fix/**, chore/**]
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,7 +2,7 @@ name: Playwright E2E
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev, app-3d]
   push:
     branches: [main]
 

--- a/.github/workflows/tsc-gate.yml
+++ b/.github/workflows/tsc-gate.yml
@@ -11,7 +11,7 @@ name: TSC Gate (anti-regresión)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev, app-3d]
   push:
     branches: [main, feat/**, fix/**, chore/**]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ name: Unit Tests (vitest)
 # estabilizar esos 2 tests; ver el cuerpo del PR para el detalle.
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev, app-3d]
   push:
     branches: [main]
 


### PR DESCRIPTION
## El hallazgo

Los 5 gates de CI filtran `pull_request: branches: [main]`. **Todo lo que va a `dev` o `app-3d` se mergea sin una sola verificación.**

Medido, no supuesto:

| PR | base | checks que corrieron |
|---|---|---|
| #2482 | `dev` | **solo CLAAssistant** |
| #2475 | `main` | CodeQL ✓ · bundle sizes ✓ · Offline-first E2E ✓ · audit-integraciones ✓ · Playwright |

**Hoy se mergearon 8 PRs a `dev`/`app-3d` así**, razonando "CLAAssistant es ruido, lo demás está bien" — cuando **no había un lo demás**. Y hay **11 PRs abiertos más** apuntando a esas ramas.

> No es que el verde mienta: **es que no hay verde.**

Es el **décimo caso** del patrón que apareció nueve veces en 24 horas: algo construido, documentado, con comentarios que explican su política — **y que no corre donde ocurre el trabajo**. Los gates tienen headers explicando su criterio anti-regresión. Nunca se ejecutaron sobre el 3D.

## El cambio

`dev` y `app-3d` agregados a: **tsc-gate**, **unit-tests**, **playwright**, **perf-budget**. Los cuatro corren en `ubuntu-latest` → siempre disponibles.

## Lo que queda fuera A PROPÓSITO

**`llm-local-review` corre en `[self-hosted, alpha]`.** Meterlo en `dev` **colgaría cada PR cada vez que alpha esté apagada** — y la apagamos a diario para cambiar la GPU. Se queda en `main`.

## Verificación

YAML parseado con `js-yaml`, no revisado a ojo — hoy se rechazó el PR #2461 justo por romper un YAML con indentación inválida:
```
tsc-gate     OK  branches: ["main","dev","app-3d"]
unit-tests   OK  branches: ["main","dev","app-3d"]
playwright   OK  branches: ["main","dev","app-3d"]
perf-budget  OK  branches: ["main","dev","app-3d"]
```

## Efecto secundario esperado, y es bueno

Los **11 PRs abiertos a `dev`/`app-3d` van a empezar a mostrar checks reales**. Es probable que varios salgan rojos — esa es exactamente la información que hoy no teníamos.