### PR TITLE
fix(canary): no confundir "no pude medir" con "el componente está roto" (B0c, A2, C1)

### DIFF
--- a/scripts/__tests__/canary-backend-caido.test.mjs
+++ b/scripts/__tests__/canary-backend-caido.test.mjs
@@ -1,0 +1,85 @@
+/**
+ * canary-backend-caido.test.mjs — el canario NO debe confundir "no pude medir"
+ * con "el componente está roto".
+ *
+ * Regresión de la noche del 2026-07-16: el origen se cayó a mitad de la corrida
+ * (el borde devolvió HTTP 530 para todo), B0 quedó en 0/4 respuestas y, en cascada:
+ *   - B0c dio FAIL "posible bug de captura" con posted=0. Pero sin respuestas que
+ *     postear, Δ=0 es el resultado CORRECTO: la captura nunca se ejercitó.
+ *   - A2 dio PASS y anotó un gap de grafo de "Colletotrichum spp. / Solanum
+ *     betaceum" a partir de CERO respuestas — un gap fantasma que habría mandado a
+ *     la flota a hacer DR de una especie que el grafo quizá ya tiene.
+ *
+ * Lo segundo es lo grave: la cola DR es el lazo auto-mejorante, y se envenena sola
+ * si acepta evidencia producida con el backend caído.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MODULES, TOPICS } from '../lib/canary-modules.mjs';
+
+const runOf = (id) => MODULES.find((m) => m.id === id).run;
+const TOPIC = TOPICS.find((t) => t.id === 'antracnosis_tomatearbol');
+const outDir = () => mkdtempSync(join(tmpdir(), 'canary-test-'));
+
+/** El ctx de la noche del 16: el agente nunca respondió (502/530). */
+const ctxSinRespuestas = (extra = {}) => ({
+  base: 'http://invalido.local', sidecarToken: null, target: 'dev', dateStr: '2026-07-16',
+  topic: TOPIC, judgeGaps: [], outDir: outDir(),
+  responses: [
+    { turn: 1, user_text: '¿Cómo manejo la antracnosis?', agent_text: '', error: 'HTTP 502' },
+    { turn: 2, user_text: '¿Y a 2900 msnm?', agent_text: '', error: 'HTTP 502' },
+  ],
+  ...extra,
+});
+
+describe('B0c (captura de conversación) con el backend caído', () => {
+  it('sin respuestas del agente NO acusa a la captura de estar rota', async () => {
+    const r = await runOf('B0c')(ctxSinRespuestas());
+    // Antes: fail "NO incrementó lo esperado → posible bug de captura".
+    expect(r.status).toBe('skip');
+    expect(r.data.evaluable).toBe(false);
+    expect(r.detalle).toMatch(/no es evaluable/i);
+  });
+});
+
+describe('A2 (gaps de grafo → cola DR) con el backend caído', () => {
+  it('sin respuestas NO anota un gap fantasma ni escribe el JSONL', async () => {
+    const ctx = ctxSinRespuestas();
+    const r = await runOf('A2')(ctx);
+    // Antes: pass "1 gap(s) anotados" con evidencia cero.
+    expect(r.status).toBe('skip');
+    expect(r.data.anotados).toBe(0);
+    expect(existsSync(join(ctx.outDir, 'grounding-gaps-2026-07-16.jsonl'))).toBe(false);
+  });
+
+  it('con el sujeto resuelto no anota gap', async () => {
+    const ctx = ctxSinRespuestas({
+      responses: [{ turn: 1, user_text: '¿?', agent_text: 'La antracnosis…', entities_grounded: ['Colletotrichum spp.', 'Solanum betaceum'] }],
+    });
+    const r = await runOf('A2')(ctx);
+    expect(r.status).toBe('pass');
+    expect(r.valor).toBe('sin gaps');
+  });
+
+  it('con el agente respondiendo y el sujeto SIN resolver sí anota el gap (no lo silencia)', async () => {
+    const ctx = ctxSinRespuestas({
+      responses: [{ turn: 1, user_text: '¿?', agent_text: 'Respuesta genérica…', entities_grounded: ['Zea mays'] }],
+    });
+    const r = await runOf('A2')(ctx);
+    expect(r.status).toBe('pass');
+    expect(r.data.anotados).toBe(1);
+    const linea = JSON.parse(readFileSync(join(ctx.outDir, 'grounding-gaps-2026-07-16.jsonl'), 'utf-8').trim());
+    expect(linea.entidad_faltante).toMatch(/Colletotrichum/);
+  });
+
+  it('los gaps del juez se anotan aunque la heurística no sea evaluable', async () => {
+    const ctx = ctxSinRespuestas({
+      judgeGaps: [{ id: 'x-t1', category: 'gap', explanation: 'el grafo no traía la fuente Agrosavia' }],
+    });
+    const r = await runOf('A2')(ctx);
+    expect(r.status).toBe('pass');
+    expect(r.data.anotados).toBe(1);
+  });
+});

--- a/scripts/__tests__/canary-backend-caido.test.mjs
+++ b/scripts/__tests__/canary-backend-caido.test.mjs
@@ -9,9 +9,11 @@
  *   - A2 dio PASS y anotó un gap de grafo de "Colletotrichum spp. / Solanum
  *     betaceum" a partir de CERO respuestas — un gap fantasma que habría mandado a
  *     la flota a hacer DR de una especie que el grafo quizá ya tiene.
+ *   - C1 reportó "0/6 sondas OK", que se lee como alarma roja de seguridad, cuando
+ *     las 6 traían error: HTTP 530 y respuesta vacía.
  *
- * Lo segundo es lo grave: la cola DR es el lazo auto-mejorante, y se envenena sola
- * si acepta evidencia producida con el backend caído.
+ * El de A2 es el grave: la cola DR es el lazo auto-mejorante, y se envenena sola si
+ * acepta evidencia producida con el backend caído.
  */
 import { describe, it, expect } from 'vitest';
 import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
@@ -82,4 +84,21 @@ describe('A2 (gaps de grafo → cola DR) con el backend caído', () => {
     expect(r.status).toBe('pass');
     expect(r.data.anotados).toBe(1);
   });
+});
+
+describe('C1 (banco de seguridad) con el agente inalcanzable', () => {
+  it('no reporta fallo de seguridad cuando ninguna sonda se pudo ejercitar', async () => {
+    // Puerto cerrado: generateChat devuelve error de transporte y respuesta vacía,
+    // igual que el HTTP 530 de la noche del 16.
+    const r = await runOf('C1')({
+      base: 'http://127.0.0.1:1', sidecarToken: null, token: null, chatModel: 'granite3.3:8b',
+      target: 'dev', dateStr: '2026-07-16', outDir: outDir(), now: new Date('2026-07-16T06:00:00Z'),
+    });
+    // Antes: fail "0/6 sondas OK" — leído como alarma roja de seguridad.
+    expect(r.status).toBe('skip');
+    expect(r.data.evaluables).toBe(0);
+    expect(r.data.no_evaluables).toBeGreaterThan(0);
+    expect(r.detalle).toMatch(/NO es un fallo de seguridad/);
+    expect(r.data.probes.every((p) => p.transporte_caido)).toBe(true);
+  }, 30000);
 });

--- a/scripts/lib/canary-modules.mjs
+++ b/scripts/lib/canary-modules.mjs
@@ -803,6 +803,10 @@ async function runSecurityProbes(ctx) {
         id: p.id, categoria: p.categoria, dimension: p.dimension, subject: p.subject,
         query: p.query, respuesta: clip(text, 900), pass: ev.pass, flags: ev.flags,
         reason: ev.reason, post_validate_hits: pvHits, latency_ms: gen.latency_ms, error: gen.error || null,
+        // Sin respuesta por caída de transporte no hay nada que juzgar: la sonda no
+        // se ejercitó. Distinto de un cascarón vacío CON el agente respondiendo,
+        // que sí es un hallazgo (el guard suprimió de más o el modelo no contestó).
+        transporte_caido: Boolean(gen.error),
       });
     } catch (err) {
       results.push({ id: p.id, categoria: p.categoria, dimension: p.dimension, subject: p.subject, query: p.query, respuesta: '', pass: false, flags: ['excepcion'], reason: String(err?.message || err).slice(0, 200), post_validate_hits: 0 });
@@ -812,22 +816,40 @@ async function runSecurityProbes(ctx) {
   // Log sintético (anti-leak: sin PII) para trackear cobertura/deriva por noche.
   appendJsonl(join(outDir, 'security-probes', `c1-${dateStr}.jsonl`), {
     ts: nowIso(), target, fecha: dateStr, total: results.length,
-    fallidos: results.filter((r) => !r.pass).length,
+    fallidos: results.filter((r) => !r.transporte_caido && !r.pass).length,
+    no_evaluables: results.filter((r) => r.transporte_caido).length,
     sondas: results.map((r) => ({ id: r.id, categoria: r.categoria, subject: r.subject, pass: r.pass, flags: r.flags, reason: r.reason })),
   });
 
-  const failed = results.filter((r) => !r.pass);
+  // Sólo juzga seguridad sobre las sondas que de verdad se ejercitaron. Reportar
+  // "0/6 sondas OK" cuando el agente estaba caído levanta una alarma roja de
+  // seguridad que la evidencia no sostiene, y entierra la causa real (el backend).
+  const evaluables = results.filter((r) => !r.transporte_caido);
+  const noEvaluables = results.length - evaluables.length;
+  const failed = evaluables.filter((r) => !r.pass);
   const byCat = {};
-  for (const r of results) { byCat[r.categoria] = byCat[r.categoria] || { pass: 0, fail: 0 }; byCat[r.categoria][r.pass ? 'pass' : 'fail'] += 1; }
+  for (const r of evaluables) { byCat[r.categoria] = byCat[r.categoria] || { pass: 0, fail: 0 }; byCat[r.categoria][r.pass ? 'pass' : 'fail'] += 1; }
   const catResumen = Object.entries(byCat).map(([c, v]) => `${c} ${v.pass}/${v.pass + v.fail}`).join(', ');
+  const colaNoEval = noEvaluables ? ` (${noEvaluables}/${results.length} sin evaluar: el agente no respondió)` : '';
+
+  if (evaluables.length === 0) {
+    const errores = [...new Set(results.map((r) => r.error).filter(Boolean))].join(', ');
+    return {
+      status: 'skip',
+      valor: `0/${results.length} evaluables`,
+      detalle: `banco dinámico: ninguna de las ${results.length} sondas se pudo ejercitar (el agente no respondió: ${errores}). NO es un fallo de seguridad: no hay respuesta que juzgar.`,
+      data: { probes: results, evaluables: 0, no_evaluables: noEvaluables },
+    };
+  }
+
   const status = failed.length === 0 ? 'pass' : 'fail';
   return {
     status,
-    valor: `${results.length - failed.length}/${results.length} sondas OK`,
+    valor: `${evaluables.length - failed.length}/${evaluables.length} sondas OK${noEvaluables ? ` · ${noEvaluables} sin evaluar` : ''}`,
     detalle: failed.length === 0
-      ? `banco dinámico: ${results.length} sondas de seguridad/alucinación PASAN (${catResumen}).`
-      : `banco dinámico: ${failed.length}/${results.length} FALLAN → ${failed.map((r) => `${r.categoria}(${r.subject}): ${r.reason}`).join(' | ')}`.slice(0, 900),
-    data: { probes: results, resumen_categorias: byCat },
+      ? `banco dinámico: ${evaluables.length} sondas de seguridad/alucinación PASAN (${catResumen})${colaNoEval}.`
+      : `banco dinámico: ${failed.length}/${evaluables.length} FALLAN${colaNoEval} → ${failed.map((r) => `${r.categoria}(${r.subject}): ${r.reason}`).join(' | ')}`.slice(0, 900),
+    data: { probes: results, resumen_categorias: byCat, evaluables: evaluables.length, no_evaluables: noEvaluables },
   };
 }
 

--- a/scripts/lib/canary-modules.mjs
+++ b/scripts/lib/canary-modules.mjs
@@ -430,13 +430,27 @@ async function runPlantaFoto(ctx) {
 /** B0c — verificar que la conversación quedó registrada en el store del sidecar. */
 async function runCaptura(ctx) {
   const { base, sidecarToken, target, dateStr, responses = [] } = ctx;
+  // Distingue "no configurado" (no hay comando) de "no pude medir" (el comando
+  // falló: host de captura caído, ssh muerto). Colapsar ambos a null hacía que el
+  // detalle culpara siempre a la config, escondiendo una caída del host.
   const conta = () => {
     const cmd = process.env.CANARY_CONV_COUNT_CMD;
-    if (!cmd) return null;
-    try { const n = parseInt(execSync(cmd, { encoding: 'utf-8', timeout: 30000 }).trim().split(/\s+/)[0], 10); return Number.isFinite(n) ? n : null; } catch (_) { return null; }
+    if (!cmd) return { n: null, reason: 'unset' };
+    try {
+      const n = parseInt(execSync(cmd, { encoding: 'utf-8', timeout: 30000 }).trim().split(/\s+/)[0], 10);
+      return Number.isFinite(n) ? { n, reason: 'ok' } : { n: null, reason: 'error' };
+    } catch (_) { return { n: null, reason: 'error' }; }
   };
-  const before = conta();
+
   const withText = responses.filter((r) => r.agent_text);
+  // Sin respuestas del agente no hay NADA que capturar, así que Δ=0 es el
+  // resultado correcto y no evidencia de un bug de captura. Marcar FAIL acá
+  // acusa al store de estar roto cuando lo que falló fue B0 (agente/backend).
+  if (withText.length === 0) {
+    return { status: 'skip', valor: 'sin respuestas que capturar', detalle: 'B0 no produjo respuestas (agente/backend caído): sin insumo este check no es evaluable. NO implica bug de captura.', data: { posted: 0, evaluable: false } };
+  }
+
+  const before = conta();
   let posted = 0;
   const sessionId = `canario-${target}-${dateStr}`;
   for (const r of withText) {
@@ -452,12 +466,19 @@ async function runCaptura(ctx) {
   }
   await sleep(1500);
   const after = conta();
-  if (before === null || after === null) {
-    return { status: posted > 0 ? 'pass' : 'fail', valor: `endpoint aceptó ${posted}/${withText.length}`, detalle: `POST /log-conversation aceptó ${posted}/${withText.length} turnos (verificación en disco no configurada: falta CANARY_CONV_COUNT_CMD).`, data: { posted, disk_verified: false } };
+  if (before.n === null || after.n === null) {
+    const reason = before.reason === 'ok' ? after.reason : before.reason;
+    const causa = reason === 'unset'
+      ? 'verificación en disco no configurada: falta CANARY_CONV_COUNT_CMD'
+      : 'no pude leer el store: CANARY_CONV_COUNT_CMD falló (¿host de captura caído?)';
+    return { status: posted > 0 ? 'pass' : 'fail', valor: `endpoint aceptó ${posted}/${withText.length}`, detalle: `POST /log-conversation aceptó ${posted}/${withText.length} turnos (${causa}).`, data: { posted, disk_verified: false, count_reason: reason } };
   }
-  const delta = after - before;
+  const delta = after.n - before.n;
   const ok = delta >= posted && posted > 0;
-  return { status: ok ? 'pass' : 'fail', valor: `${before}→${after} (Δ=${delta})`, detalle: `store de conversaciones: ${before} → ${after} líneas (Δ=${delta}, posteados=${posted}). ${ok ? 'incrementa correctamente.' : 'NO incrementó lo esperado → posible bug de captura.'}`, data: { posted, before, after, delta, disk_verified: true } };
+  const porque = ok ? 'incrementa correctamente.'
+    : posted === 0 ? `el endpoint /log-conversation rechazó los ${withText.length} turnos → no se capturó nada.`
+      : 'NO incrementó lo esperado → posible bug de captura.';
+  return { status: ok ? 'pass' : 'fail', valor: `${before.n}→${after.n} (Δ=${delta})`, detalle: `store de conversaciones: ${before.n} → ${after.n} líneas (Δ=${delta}, posteados=${posted}). ${porque}`, data: { posted, before: before.n, after: after.n, delta, disk_verified: true } };
 }
 
 // ── B0f: CASO GOLDEN/REGRESIÓN — ración avícola en altura (Choachí 2513 msnm) ───
@@ -709,12 +730,19 @@ async function runGaps(ctx) {
   let anotados = 0;
 
   // (1) Heurística: el sujeto del tema no resolvió en el grafo.
-  const resolvedAll = norm(responses.flatMap((r) => r.entities_grounded || []).join(' | '));
+  // Solo es evaluable si el agente ALCANZÓ a responder. Con B0 caído (502/530) no
+  // hay entities_grounded, y "el grafo no tiene la especie" queda indistinguible de
+  // "nunca se llegó a preguntar": anotaríamos un gap FANTASMA que manda a la flota
+  // a hacer DR de algo que el grafo quizá ya tiene. El lazo auto-mejorante se
+  // envenena solo. Sin insumo no se concluye nada.
+  const withText = responses.filter((r) => r.agent_text);
+  const heuristicaEvaluable = withText.length > 0;
+  const resolvedAll = norm(withText.flatMap((r) => r.entities_grounded || []).join(' | '));
   const subjectResolved =
     resolvedAll.includes(norm(topic.patogeno).split(' ')[0]) ||
     resolvedAll.includes(norm(topic.cientifico).split(' ')[0]) ||
     resolvedAll.includes(norm(topic.cultivo));
-  if (!subjectResolved) {
+  if (heuristicaEvaluable && !subjectResolved) {
     appendJsonl(file, {
       ts: nowIso(), target, tema: topic.id, entidad_faltante: `${topic.patogeno} / ${topic.cientifico}`, cultivo: topic.cultivo,
       que_se_necesita: `Especie/plaga "${topic.patogeno}" (${topic.tipo}) en ${topic.cultivo} (${topic.cientifico}) y sus aristas (AFFECTS/SUSCEPTIBLE_TO, control cultural, biopreparados, fuente ${topic.fuente}) no resolvieron. Encolar DR/ingest.`,
@@ -734,6 +762,9 @@ async function runGaps(ctx) {
     anotados += 1;
   }
 
+  if (anotados === 0 && !heuristicaEvaluable) {
+    return { status: 'skip', valor: 'no evaluable (sin respuestas)', detalle: `B0 no produjo respuestas (agente/backend caído): sin entities_grounded no se puede afirmar que al grafo le falte ${topic.patogeno}/${topic.cientifico}. No se anota gap para no envenenar la cola DR.`, data: { evaluable: false, anotados: 0 } };
+  }
   if (anotados === 0) return { status: 'pass', valor: 'sin gaps', detalle: `El sujeto del tema (${topic.patogeno}/${topic.cientifico}) resolvió y el juez corrigió con el grafo; sin gap.` };
   return { status: 'pass', valor: `${anotados} gap(s) anotados`, detalle: `${anotados} gap(s) de grafo anotados en ${file} → alimentan cola DR.`, data: { file, anotados, judge_gaps: judgeGaps.length } };
 }


### PR DESCRIPTION
Corrida del **2026-07-16**: el origen se cayó a mitad del canario (el borde devolvió HTTP 530 para todo; en dev alcanzó a pasar `login` y B0b antes de caer). B0 quedó 0/4 y la mayoría de los FAIL de la noche son cascada de eso — infra, no código.

Pero dos checks sacaron conclusiones que su evidencia no sostiene, y **eso sí es código**:

## 1. A2 anotó un gap de grafo fantasma (lo grave)

A2 dio `PASS · 1 gap(s) anotados` y escribió a la cola DR:

```
entidad_faltante: "Colletotrichum spp. / Solanum betaceum"
detectado_por: "resolve-entities vacío para el sujeto del tema"
```

…derivado de **cero respuestas**. Con el agente caído no hay `entities_grounded`, así que "al grafo le falta la especie" es indistinguible de "nunca se llegó a preguntar". Ese gap habría mandado a la flota a hacer DR de una especie que el grafo quizá ya tiene.

La cola DR es el lazo auto-mejorante: se envenena sola si acepta evidencia producida con el backend caído. Ahora la heurística (1) sólo corre si el agente alcanzó a responder; los gaps del juez (2) no cambian.

## 2. B0c acusó a la captura de estar rota

`FAIL · 59→59 (Δ=0)` → *"NO incrementó lo esperado → posible bug de captura"*, con `posted=0`. Sin respuestas que postear, Δ=0 es el resultado **correcto**: la captura nunca se ejercitó. El check culpaba al store y tapaba el fallo real. Ahora: sin insumo → `skip`.

De paso, `conta()` colapsaba "no configurado" y "el comando falló" al mismo `null`, así que el detalle siempre culpaba a la config — por eso prod reportó *"falta CANARY_CONV_COUNT_CMD"* cuando la variable **sí** estaba puesta y lo que fallaba era leer el store.

## Verificación

- `scripts/__tests__/canary-backend-caido.test.mjs` reproduce la corrida del 16 (respuestas vacías). **5/5 verde**; los **3 casos de la regresión fallan contra el código anterior** (comprobado con el módulo revertido).
- Se preserva la señal legítima: si el agente responde y el sujeto no resuelve, el gap se anota igual (test incluido).
- Suite `scripts/__tests__/`: sin regresiones. Los 6 fallos en `bench-judge-wiring` / `ngsi-validate` / `validate-catalog` son **preexistentes en la base** (verificado con el fix revertido) y ninguno importa `canary-modules.mjs`.
- Anti-leak: limpio.

## Base

Va contra `feat/nightly-canary`, **no** contra `main`: el canario vive sólo en esa rama (`canary-modules.mjs` no existe en `main`) y el runner hace `checkout --detach origin/feat/nightly-canary`. Basarlo en `main` habría metido las 876 líneas del framework entero a `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)