### PR TITLE
fix(canary): B0b sube la foto por el camino que corre el usuario real (/api/file/upload)

### DIFF
--- a/scripts/lib/canary-modules.mjs
+++ b/scripts/lib/canary-modules.mjs
@@ -380,22 +380,28 @@ async function runPlantaFoto(ctx) {
   if (!created.ok && rels.location) { delete rels.location; created = await farmosWrite(base, token, '/api/asset/plant', { data: { type: 'asset--plant', attributes: { name: `CANARIO planta ${target} ${stamp}`, status: 'active' }, relationships: rels } }); }
   const plantId = created.ok ? created.json?.data?.id : null;
 
-  // Subir la foto al campo `image` de la planta por el flujo NATIVO de farmOS 4.x /
-  // Drupal 10 — el MISMO que usa el cliente real (uploadBinaryToFarmOS en
-  // src/services/apiService.js). Es en DOS pasos:
-  //   A) POST /api/{entity}/{bundle}/{field} (octet-stream) crea un file--file NUEVO
-  //      y devuelve su UUID. OJO: la forma con el UUID en la ruta
-  //      (/api/asset/plant/{id}/image) NO EXISTE en este farmOS (404 sin auth → 500
-  //      con token; verificado 2026-07-11) y ningún código de producción la usa.
+  // Subir la foto por el MISMO camino que corre el usuario real: `POST
+  // /api/file/upload` con FormData. Son los dos únicos sitios que suben binarios a
+  // farmOS en producción: uploadToFarmOS (src/services/operatorPhotoService.js) y
+  // el sync de evidencia (src/services/syncManager.js). En DOS pasos:
+  //   A) POST /api/file/upload (multipart) crea un file--file y devuelve su UUID.
   //   B) PATCH del plant relacionando el file, para que persista (un file--file sin
   //      referencia queda temporal y el cron de Drupal lo borra ~6 h).
+  // NO volver a la forma JSON:API de campo (POST /api/{entity}/{bundle}/{field},
+  // octet-stream): ningún código de producción la usa, así que probarla no dice
+  // nada sobre lo que le pasa al usuario. Se intentó dos veces y el farmOS real la
+  // rechazó — 500 con el UUID en la ruta (2026-07-11) y 403 sin él (2026-07-16).
+  // Content-Type se OMITE a propósito: lo pone fetch con el boundary multipart,
+  // igual que fetchFromFarmOS, que borra el header cuando el body es FormData.
   let fileId = null; let uploadStatus = null;
   if (plantId) {
     const bytes = Buffer.from(CANARY_JPEG_B64, 'base64');
-    const up = await httpFetch(`${base}/api/asset/plant/image`, {
+    const form = new FormData();
+    form.append('file', new Blob([bytes], { type: 'image/jpeg' }), `CANARIO-${target}-${dateStr}.jpg`);
+    const up = await httpFetch(`${base}/api/file/upload`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/octet-stream', 'Content-Disposition': `file; filename="CANARIO-${target}-${dateStr}.jpg"`, Accept: 'application/vnd.api+json' },
-      body: bytes, timeoutMs: 45000,
+      headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.api+json' },
+      body: form, timeoutMs: 45000,
     });
     uploadStatus = up.status;
     if (up.ok && up.json?.data?.id) {


### PR DESCRIPTION
**DRAFT — no mergear todavía. Espera verificación contra el farmOS real (ver abajo).**

## Qué pasa

B0b falla desde el 2026-07-08 y ya se "arregló" dos veces apuntando a rutas que **ningún código de producción usa**:

| cuándo | ruta | resultado |
|---|---|---|
| hasta 2026-07-11 | `POST /api/asset/plant/{id}/image` | HTTP 500 |
| b38844b0 (#2328) | `POST /api/asset/plant/image` | HTTP 403 (2026-07-16) |

#2328 justificó el cambio citando `uploadBinaryToFarmOS` en `src/services/apiService.js` como "el flujo del cliente real". **Esa función no existe en el repo** — la única ocurrencia del nombre es el comentario que la cita:

```
$ grep -rn "uploadBinaryToFarmOS" . --include=*.js --include=*.mjs | grep -v node_modules
scripts/lib/canary-modules.mjs:384:  // Drupal 10 — el MISMO que usa el cliente real (uploadBinaryToFarmOS en
```

La premisa era fabricada, así que el fix cambió una ruta que farmOS rechaza por otra que también rechaza. Anoche B0b fue `SKIP` (login falló) y nadie lo notó; hoy corrió por primera vez con token y salió el 403.

## El camino real

Los dos únicos sitios que suben binarios a farmOS en producción — `uploadToFarmOS` (`operatorPhotoService.js:311`) y el sync de evidencia (`syncManager.js:486`) — hacen `POST /api/file/upload` con FormData y **sin** `Content-Type` (lo pone fetch con el boundary; `fetchFromFarmOS` borra el header cuando el body es FormData). El paso B (PATCH relacionando el file) ya estaba bien y no cambia.

## Verificación hecha

Contra un farmOS simulado, en Node puro (como corre el canario de noche):

```
RESULTADO B0b: pass | planta=sí, foto=persiste
data: {"fileId":"3333…","verified":true,"photoOk":true,"uploadStatus":201}
¿llamó /api/file/upload? true
  content-type: multipart/form-data; boundary=----formdata-undici-
  tiene filename: true
  viajó el JPEG: true
¿PATCH adjuntando el file? true {"image":{"data":[{"type":"file--file","id":"3333…"}]}}
¿tocó la ruta 403 vieja? false
```

## Verificación que FALTA (por qué es draft)

Esto prueba la **forma** del request, no el contrato con el farmOS real: el origen está caído desde ~01:44 y no hay contra qué correrlo. Exactamente así se coló #2328 — se mergeó sin poder ejercitar B0b y salió mal. **No repetir el patrón.**

Cuando el origen vuelva:

```
node scripts/nightly-canary.mjs --target dev --only login,B0b
```

Esperado: `B0b PASS · planta=sí, foto=persiste`. Si vuelve a dar 403 con `/api/file/upload`, entonces es permisos del usuario de pruebas (no la ruta) y hay que mirar el rol en farmOS, no seguir rotando rutas a ciegas.

## Nota de test

No dejé test de vitest: la suite corre en `environment: jsdom`, que pisa `FormData`/`Blob` con versiones que el `fetch` de Node no acepta, y la petición se cuelga hasta el timeout. Correrlo en `environment: node` choca con `tests/unit/setup.js`, que asume `window`. Dejarlo cubierto pide un proyecto vitest aparte para tests de ops — vale la pena, pero no de madrugada y no mezclado con este fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)