### PR TITLE
feat(finca): animales del corral rehechos — anatomía real, sombreado horneado, razas

### DIFF
--- a/scripts/diag/hato-main.jsx
+++ b/scripts/diag/hato-main.jsx
@@ -1,0 +1,40 @@
+/*
+ * Arnés diag del hato: monta AnimalesDeFinca solo, con luz tipo valle y cámara
+ * cercana por query (?vista=...&q=0.42). Para capturas antes/después.
+ */
+import { createRoot } from 'react-dom/client';
+import { Canvas } from '@react-three/fiber';
+import AnimalesDeFinca from '/src/mockups/valle/animales.jsx';
+
+const params = new URLSearchParams(location.search);
+const vista = params.get('vista') || 'general';
+const q = params.has('q') ? Number(params.get('q')) : 1;
+
+/* Encuadres: [posición cámara], [mira a]. El corral vive en ~[-1.8..1.6]². */
+const VISTAS = {
+  general: { pos: [2.6, 2.2, 3.2], mira: [-0.1, 0.35, 0] },
+  vaca: { pos: [1.55, 0.85, 1.15], mira: [0.35, 0.55, -0.3] },
+  cerdos: { pos: [-2.6, 0.75, 0.85], mira: [-1.25, 0.3, -0.25] },
+  ovejas: { pos: [0.9, 0.7, 2.5], mira: [-0.15, 0.3, 1.2] },
+  gallinas: { pos: [2.2, 0.55, 1.6], mira: [1.15, 0.2, 0.55] },
+  perro: { pos: [1.9, 0.7, -1.7], mira: [1.05, 0.3, -0.85] },
+};
+const V = VISTAS[vista] || VISTAS.general;
+
+createRoot(document.getElementById('root')).render(
+  <Canvas
+    shadows
+    dpr={2}
+    camera={{ position: V.pos, fov: 42 }}
+    onCreated={({ camera }) => camera.lookAt(V.mira[0], V.mira[1], V.mira[2])}
+  >
+    <ambientLight intensity={0.55} />
+    <hemisphereLight args={['#cfe6ff', '#5a7a4a', 0.5]} />
+    <directionalLight position={[4, 6, 3]} intensity={1.25} castShadow />
+    <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+      <circleGeometry args={[6, 32]} />
+      <meshLambertMaterial color="#7fa055" />
+    </mesh>
+    <AnimalesDeFinca reducedMotion q={q} />
+  </Canvas>,
+);

--- a/scripts/diag/hato.html
+++ b/scripts/diag/hato.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<!-- Arnés de diagnóstico VISUAL del hato (solo dev, nunca entra al build de prod):
+     sirve con `vite dev` y monta ÚNICAMENTE AnimalesDeFinca con cámara cercana
+     parametrizable (?vista=vaca|cerdos|ovejas|gallinas|perro|general) para
+     capturas antes/después de cada animal. -->
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>diag: hato de la finca</title>
+    <style>
+      html, body, #root { margin: 0; width: 100%; height: 100%; overflow: hidden; background: #87b5d8; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/scripts/diag/hato-main.jsx"></script>
+  </body>
+</html>

--- a/scripts/diag/shot-hato.mjs
+++ b/scripts/diag/shot-hato.mjs
@@ -1,0 +1,46 @@
+// Capturas del arnés diag del hato (scripts/diag/hato.html) con chromium del
+// sistema + swiftshader, sirviendo ESTE worktree con `vite dev`.
+// Uso: node scripts/diag/shot-hato.mjs <etiqueta> [vista...]
+import { chromium } from 'playwright';
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const PORT = 5199;
+const BASE = `http://127.0.0.1:${PORT}`;
+const [etiqueta = 'x', ...vistasArg] = process.argv.slice(2);
+const VISTAS = vistasArg.length ? vistasArg : ['general', 'vaca', 'cerdos', 'ovejas', 'gallinas', 'perro'];
+
+const srv = spawn('npx', ['vite', '--port', String(PORT), '--host', '127.0.0.1', '--strictPort'], {
+  cwd: REPO, stdio: 'ignore', env: { ...process.env, BROWSER: 'none' },
+});
+let up = false;
+for (let i = 0; i < 60; i++) {
+  try { await fetch(BASE + '/'); up = true; break; } catch { /* aún no */ }
+  await sleep(1000);
+}
+if (!up) { console.log('SERVER_FAIL'); srv.kill('SIGKILL'); process.exit(1); }
+await sleep(1500);
+
+const browser = await chromium.launch({
+  executablePath: '/run/current-system/sw/bin/chromium',
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage',
+    '--enable-unsafe-swiftshader', '--use-gl=angle', '--use-angle=swiftshader', '--ignore-gpu-blocklist'],
+});
+const page = await browser.newPage({ viewport: { width: 640, height: 640 }, deviceScaleFactor: 2 });
+page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE_ERR:', m.text().slice(0, 300)); });
+page.on('pageerror', (e) => console.log('PAGE_ERR:', String(e).slice(0, 300)));
+for (const vista of VISTAS) {
+  try {
+    await page.goto(`${BASE}/scripts/diag/hato.html?vista=${vista}`, { waitUntil: 'load', timeout: 40000 });
+    await sleep(5000);
+    const f = `/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/hato-${etiqueta}-${vista}.png`;
+    await page.screenshot({ path: f, timeout: 60000 });
+    console.log('OK', vista, f);
+  } catch (e) { console.log('FAIL', vista, String(e).slice(0, 120)); }
+}
+await browser.close();
+srv.kill('SIGKILL');
+console.log('DONE');

--- a/scripts/diag/shot-valle.mjs
+++ b/scripts/diag/shot-valle.mjs
@@ -1,0 +1,20 @@
+import { chromium } from 'playwright';
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+const REPO = '/home/kortux/Workspace/chagra/.claude/worktrees/agent-acc693963161d0026';
+const PORT = 5201;
+const BASE = `http://127.0.0.1:${PORT}`;
+const srv = spawn('npx', ['vite', '--port', String(PORT), '--host', '127.0.0.1', '--strictPort'], { cwd: REPO, stdio: 'ignore' });
+let up = false;
+for (let i = 0; i < 60; i++) { try { await fetch(BASE + '/'); up = true; break; } catch {} await sleep(1000); }
+if (!up) { console.log('SERVER_FAIL'); srv.kill('SIGKILL'); process.exit(1); }
+const browser = await chromium.launch({ executablePath: '/run/current-system/sw/bin/chromium',
+  args: ['--no-sandbox', '--disable-dev-shm-usage', '--enable-unsafe-swiftshader', '--use-gl=angle', '--use-angle=swiftshader'] });
+const page = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 2 });
+page.on('pageerror', (e) => console.log('PAGE_ERR:', String(e).slice(0, 300)));
+await page.goto(BASE + '/#/mockups/entrada-3d', { waitUntil: 'load', timeout: 40000 });
+await sleep(9000);
+await page.screenshot({ path: '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/valle-integracion.png' });
+console.log('OK');
+await browser.close();
+srv.kill('SIGKILL');

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -368,7 +368,7 @@ function LandmarkGeom({ tipo, tinte, reducedMotion, q = 1 }) {
         </group>
       );
     case 'animales': // los animales de la finca (reemplaza la vieja casita)
-      return <AnimalesDeFinca reducedMotion={reducedMotion} />;
+      return <AnimalesDeFinca reducedMotion={reducedMotion} q={q} />;
     case 'huerta': // camas de la huerta: lomos redondeados con matas
       return (
         <group>

--- a/src/mockups/valle/animales.jsx
+++ b/src/mockups/valle/animales.jsx
@@ -1,248 +1,125 @@
-/* eslint-disable react-refresh/only-export-components -- exporta MATERIAL_FINCA
-   (constante compartida de las mallas horneadas) además del componente. */
+/* eslint-disable react-refresh/only-export-components -- exporta los materiales
+   compartidos (MATERIAL_FINCA para la arboleda, MATERIAL_HATO para el ganado)
+   además del componente. */
 /*
- * Animales de finca del valle — el mundo 'animales' (antes una casita muda).
+ * Animales de finca del valle — REALISTAS por raza (veredicto del operador:
+ * "formas muy geométricas, aún no parecen animales reales" → rehechos).
  *
- * Cría campesina de verdad: una vaca, ovejas, gallinas y un cerdo, low-poly de
- * PRIMITIVAS redondeadas (cápsulas, esferas, conos) — nada de cajas. Cada uno
- * tiene un micro-movimiento suave (la vaca pasta, la gallina picotea, la oveja
- * y el cerdo respiran); con `reducedMotion` la escena queda quieta en un
- * fotograma digno. Todo procedural: cero GLTF, offline y liviano.
+ * Las mallas viven en src/visual/mundo3d/finca/fincaRealista.geom.js: torso
+ * como loft orgánico (silueta continua con lomo, grupa y panza reales), AO y
+ * luz de cielo HORNEADOS en vertexColors y normales suaves preservadas en la
+ * fusión. Cada animal son DOS draw-calls: el cuerpo (una malla) y la cabeza
+ * (otra, local al pivote del cuello) para conservar el gesto vivo — la vaca
+ * pasta, la gallina picotea, el cerdo hocica, el perro mira. Con
+ * `reducedMotion` la escena queda quieta en un fotograma digno. Todo
+ * procedural: cero GLTF, cero texturas, offline y liviano.
  *
- * Las criaturas de src/visual/creatures/ son FAUNA menuda (abeja, colibrí,
- * mariposa, escarabajo, lombriz) — no hay animales de corral aptos allí, así
- * que estos se arman con geometría de three. Son decorativos (aria-hidden): el
+ * El hato del valle (razas reales de Colombia):
+ *   · vaca Holstein (la lechera de clima frío) con su ternera criolla
+ *   · cerdos que SE DISTINGUEN: zungo negro, duroc colorado y una landrace
+ *     rosada larga con sus dos lechones
+ *   · ovejas criollas de cara oscura (cada una con su vellón), gallinas
+ *     (campesina/negra/blanca) + gallo, y el perro criollo amarillo
+ *
+ * Los personajes rubber-hose (src/visual/creatures/) NO se tocan: son la fauna
+ * con alma. Esto es el ganado, y va realista. Decorativo (aria-hidden): el
  * botón accesible del mundo lo pone MundoLugar.
  */
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
+import {
+  geomVaca,
+  geomCerdo,
+  geomLechon,
+  geomGallina,
+  geomPerro,
+  geomOveja,
+} from '../../visual/mundo3d/finca/fincaRealista.geom.js';
 
-/* El material COMPARTIDO de las mallas fusionadas con color horneado por
-   vértice (arboleda por especie hoy; el hato realista de finca-realismo-d1
-   cuando mergee — mismo export, cero conflicto). UNO para todas: cada malla
-   fusionada es 1 draw call. */
+/* El material de las mallas fusionadas con color horneado por vértice que usa
+   la ARBOLEDA por especie. flatShading le da carácter a un tronco — pero a un
+   lomo de vaca lo delata como poliedro, por eso el hato NO lo comparte. */
 export const MATERIAL_FINCA = new THREE.MeshLambertMaterial({
   vertexColors: true,
   flatShading: true,
 });
 
-/* Patas: cuatro cilindros finos y cortos, iguales para todos los cuadrúpedos. */
-function Patas({ x = 0.28, z = 0.16, alto = 0.26, r = 0.05, color }) {
-  const spots = [
-    [x, z],
-    [-x, z],
-    [x, -z],
-    [-x, -z],
-  ];
-  return (
-    <group>
-      {spots.map(([px, pz], i) => (
-        <mesh key={i} position={[px, alto / 2, pz]} castShadow>
-          <cylinderGeometry args={[r * 0.8, r, alto, 6]} />
-          <meshStandardMaterial color={color} flatShading roughness={1} />
-        </mesh>
-      ))}
-    </group>
-  );
-}
+/* El material del HATO: mismo Lambert + vertexColors (el sombreado viene
+   horneado en la geometría), pero con normales SUAVES — carne curva, no
+   facetas. Uno solo para todos los animales: un programa, 2 draw-calls por
+   animal. */
+export const MATERIAL_HATO = new THREE.MeshLambertMaterial({
+  vertexColors: true,
+});
 
-/* Vaca — cuerpo de cápsula con manchas, cabeza que baja a pastar y cuernitos. */
-function Vaca({ pos = [0, 0, 0], giro = 0, reducedMotion }) {
+/* Los GESTOS de idle: reescriben solo la rotación del grupo-cabeza (el cuerpo
+   queda plantado). Amplitudes chicas: vida, no espectáculo. */
+const GESTOS = {
+  // La vaca pasta: baja el hocico al pasto con calma y lo sube a rumiar.
+  pasta: (g, t, fase) => {
+    g.rotation.z = -0.15 - (Math.sin(t * 0.55 + fase) * 0.5 + 0.5) * 0.55;
+  },
+  // La gallina picotea: golpes secos con pausas.
+  picotea: (g, t, fase) => {
+    const c = (Math.sin(t * 2.4 + fase) + 1) / 2;
+    g.rotation.z = -Math.pow(c, 4) * 0.9;
+  },
+  // El cerdo hocica el suelo: empuja el morro hacia abajo-adelante.
+  hocica: (g, t, fase) => {
+    const c = Math.max(0, Math.sin(t * 1.1 + fase));
+    g.rotation.z = -(c ** 4) * 0.35;
+  },
+  // El perro mira: barre el paisaje con la cabeza, a veces la ladea.
+  mira: (g, t, fase) => {
+    g.rotation.y = Math.sin(t * 0.4 + fase) * 0.45;
+    g.rotation.x = Math.sin(t * 0.23 + fase * 2) * 0.1;
+  },
+  // La oveja tantea el pasto, más tímida que la vaca.
+  tantea: (g, t, fase) => {
+    g.rotation.z = -0.1 - (Math.sin(t * 0.7 + fase) * 0.5 + 0.5) * 0.35;
+  },
+};
+
+/*
+ * Un animal realista: cuerpo + cabeza pivotante. `geom` es el resultado de la
+ * fábrica ({cuerpo, cabeza, pivote}); `gesto` elige el idle de la cabeza.
+ * El jitter determinista por instancia (escala no uniforme + inclinación
+ * mínima, sembrado por `fase`) evita que dos animales de la misma raza sean
+ * clones — la repetición evidente mata la escena (DR §1).
+ */
+function Animal({ geom, gesto, pos = [0, 0, 0], giro = 0, escala = 1, fase = 0, reducedMotion }) {
   const cabeza = useRef(null);
   useFrame((state) => {
     if (reducedMotion || !cabeza.current) return;
-    // Pasta: baja y sube la cabeza con calma.
-    const t = state.clock.elapsedTime * 0.6;
-    cabeza.current.rotation.x = -0.15 + (Math.sin(t) * 0.5 + 0.5) * 0.6;
+    const mueve = GESTOS[gesto];
+    if (mueve) mueve(cabeza.current, state.clock.elapsedTime, fase);
   });
+  const jitter = useMemo(() => {
+    const j = (k) => Math.sin(fase * 12.9898 + k * 78.233) * 0.5; // determinista
+    return {
+      esc: [escala * (1 + j(1) * 0.07), escala * (1 + j(2) * 0.05), escala * (1 + j(3) * 0.07)],
+      rot: [j(4) * 0.03, giro, j(5) * 0.035],
+    };
+  }, [escala, giro, fase]);
   return (
-    <group position={[pos[0], pos[1], pos[2]]} rotation={[0, giro, 0]} scale={0.9}>
-      <Patas x={0.34} z={0.2} alto={0.34} r={0.06} color="#6b5744" />
-      {/* lomo */}
-      <mesh position={[0, 0.62, 0]} rotation={[0, 0, Math.PI / 2]} castShadow>
-        <capsuleGeometry args={[0.28, 0.7, 4, 10]} />
-        <meshStandardMaterial color="#f2ebde" flatShading roughness={1} />
-      </mesh>
-      {/* manchas */}
-      <mesh position={[0.18, 0.78, 0.16]} castShadow>
-        <sphereGeometry args={[0.16, 8, 8]} />
-        <meshStandardMaterial color="#5a4632" flatShading roughness={1} />
-      </mesh>
-      <mesh position={[-0.24, 0.6, -0.16]} castShadow>
-        <sphereGeometry args={[0.13, 8, 8]} />
-        <meshStandardMaterial color="#5a4632" flatShading roughness={1} />
-      </mesh>
-      {/* cabeza (pivota para pastar) */}
-      <group ref={cabeza} position={[0.55, 0.62, 0]}>
-        <mesh position={[0.12, -0.04, 0]} castShadow>
-          <sphereGeometry args={[0.19, 10, 10]} />
-          <meshStandardMaterial color="#ece1cf" flatShading roughness={1} />
-        </mesh>
-        <mesh position={[0.28, -0.08, 0]} castShadow>
-          <capsuleGeometry args={[0.1, 0.08, 3, 8]} />
-          <meshStandardMaterial color="#d7a79a" flatShading roughness={1} />
-        </mesh>
-        {/* cuernitos */}
-        <mesh position={[0.06, 0.12, 0.1]} rotation={[0.4, 0, 0.3]}>
-          <coneGeometry args={[0.035, 0.14, 6]} />
-          <meshStandardMaterial color="#d8cbb0" flatShading />
-        </mesh>
-        <mesh position={[0.06, 0.12, -0.1]} rotation={[-0.4, 0, 0.3]}>
-          <coneGeometry args={[0.035, 0.14, 6]} />
-          <meshStandardMaterial color="#d8cbb0" flatShading />
-        </mesh>
-      </group>
-      {/* cola */}
-      <mesh position={[-0.5, 0.5, 0]} rotation={[0, 0, 0.5]}>
-        <cylinderGeometry args={[0.02, 0.03, 0.4, 5]} />
-        <meshStandardMaterial color="#e0d6c6" flatShading />
-      </mesh>
-    </group>
-  );
-}
-
-/* Oveja — vellón de esferas apiladas, cabeza oscura, respiración leve. */
-function Oveja({ pos = [0, 0, 0], giro = 0, fase = 0, reducedMotion }) {
-  const cuerpo = useRef(null);
-  useFrame((state) => {
-    if (reducedMotion || !cuerpo.current) return;
-    const s = 1 + Math.sin(state.clock.elapsedTime * 1.4 + fase) * 0.02;
-    cuerpo.current.scale.set(s, s, s);
-  });
-  return (
-    <group position={[pos[0], pos[1], pos[2]]} rotation={[0, giro, 0]} scale={0.5}>
-      <Patas x={0.22} z={0.14} alto={0.24} r={0.045} color="#3c3a3a" />
-      {/* vellón: varias esferas para una silueta esponjosa */}
-      <group ref={cuerpo} position={[0, 0.42, 0]}>
-        <mesh castShadow>
-          <sphereGeometry args={[0.32, 10, 10]} />
-          <meshStandardMaterial color="#efeee9" flatShading roughness={1} />
-        </mesh>
-        <mesh position={[0.2, 0.06, 0.12]} castShadow>
-          <sphereGeometry args={[0.2, 9, 9]} />
-          <meshStandardMaterial color="#f4f3ee" flatShading roughness={1} />
-        </mesh>
-        <mesh position={[-0.18, 0.04, -0.12]} castShadow>
-          <sphereGeometry args={[0.2, 9, 9]} />
-          <meshStandardMaterial color="#e7e6e0" flatShading roughness={1} />
-        </mesh>
-      </group>
-      {/* cabeza */}
-      <mesh position={[0.36, 0.44, 0]} castShadow>
-        <sphereGeometry args={[0.15, 9, 9]} />
-        <meshStandardMaterial color="#3c3a3a" flatShading roughness={1} />
-      </mesh>
-      {/* orejitas */}
-      <mesh position={[0.34, 0.5, 0.14]} rotation={[0.3, 0, -0.4]}>
-        <coneGeometry args={[0.05, 0.12, 5]} />
-        <meshStandardMaterial color="#332f2f" flatShading />
-      </mesh>
-      <mesh position={[0.34, 0.5, -0.14]} rotation={[-0.3, 0, -0.4]}>
-        <coneGeometry args={[0.05, 0.12, 5]} />
-        <meshStandardMaterial color="#332f2f" flatShading />
-      </mesh>
-    </group>
-  );
-}
-
-/* Gallina — cuerpo ovoide, cresta y pico, cola en cuña; picotea el suelo. */
-function Gallina({ pos = [0, 0, 0], giro = 0, fase = 0, color = '#e8e2d6', reducedMotion }) {
-  const cuello = useRef(null);
-  useFrame((state) => {
-    if (reducedMotion || !cuello.current) return;
-    // Picoteo: baja de golpe y vuelve, con pausas.
-    const c = (Math.sin(state.clock.elapsedTime * 2.4 + fase) + 1) / 2;
-    cuello.current.rotation.z = -Math.pow(c, 4) * 0.9;
-  });
-  return (
-    <group position={[pos[0], pos[1], pos[2]]} rotation={[0, giro, 0]} scale={0.34}>
-      {/* patitas */}
-      {[0.1, -0.1].map((pz, i) => (
-        <mesh key={i} position={[0.02, 0.14, pz]}>
-          <cylinderGeometry args={[0.02, 0.02, 0.28, 5]} />
-          <meshStandardMaterial color="#e6a53c" flatShading />
-        </mesh>
-      ))}
-      {/* cuerpo */}
-      <mesh position={[0, 0.44, 0]} rotation={[0, 0, 0.2]} castShadow>
-        <sphereGeometry args={[0.3, 10, 10]} />
-        <meshStandardMaterial color={color} flatShading roughness={1} />
-      </mesh>
-      {/* cola en cuña */}
-      <mesh position={[-0.28, 0.6, 0]} rotation={[0, 0, 0.8]}>
-        <coneGeometry args={[0.16, 0.34, 5]} />
-        <meshStandardMaterial color={color} flatShading roughness={1} />
-      </mesh>
-      {/* cuello + cabeza (pivota al picotear) */}
-      <group ref={cuello} position={[0.24, 0.56, 0]}>
-        <mesh position={[0.06, 0.14, 0]} castShadow>
-          <sphereGeometry args={[0.15, 9, 9]} />
-          <meshStandardMaterial color={color} flatShading roughness={1} />
-        </mesh>
-        {/* cresta */}
-        <mesh position={[0.06, 0.3, 0]}>
-          <coneGeometry args={[0.06, 0.14, 5]} />
-          <meshStandardMaterial color="#d64b3a" flatShading />
-        </mesh>
-        {/* pico */}
-        <mesh position={[0.2, 0.12, 0]} rotation={[0, 0, -Math.PI / 2]}>
-          <coneGeometry args={[0.05, 0.12, 5]} />
-          <meshStandardMaterial color="#e6a53c" flatShading />
-        </mesh>
+    <group
+      position={[pos[0], pos[1], pos[2]]}
+      rotation={/** @type {[number, number, number]} */ (jitter.rot)}
+      scale={/** @type {[number, number, number]} */ (jitter.esc)}
+    >
+      <mesh geometry={geom.cuerpo} material={MATERIAL_HATO} castShadow />
+      <group ref={cabeza} position={geom.pivote}>
+        <mesh geometry={geom.cabeza} material={MATERIAL_HATO} castShadow />
       </group>
     </group>
   );
 }
 
-/* Cerdo — cápsula rosada, hocico chato, orejas caídas; respira despacio. */
-function Cerdo({ pos = [0, 0, 0], giro = 0, reducedMotion }) {
-  const cuerpo = useRef(null);
-  useFrame((state) => {
-    if (reducedMotion || !cuerpo.current) return;
-    cuerpo.current.position.y = 0.4 + Math.sin(state.clock.elapsedTime * 1.1) * 0.015;
-  });
-  return (
-    <group position={[pos[0], pos[1], pos[2]]} rotation={[0, giro, 0]} scale={0.52}>
-      <Patas x={0.24} z={0.16} alto={0.2} r={0.05} color="#c98a86" />
-      <group ref={cuerpo} position={[0, 0.4, 0]}>
-        <mesh rotation={[0, 0, Math.PI / 2]} castShadow>
-          <capsuleGeometry args={[0.26, 0.42, 4, 10]} />
-          <meshStandardMaterial color="#e6a6a2" flatShading roughness={1} />
-        </mesh>
-        {/* cabeza */}
-        <mesh position={[0.42, -0.02, 0]} castShadow>
-          <sphereGeometry args={[0.2, 10, 10]} />
-          <meshStandardMaterial color="#e6a6a2" flatShading roughness={1} />
-        </mesh>
-        {/* hocico */}
-        <mesh position={[0.58, -0.04, 0]} rotation={[0, 0, Math.PI / 2]}>
-          <cylinderGeometry args={[0.1, 0.1, 0.08, 10]} />
-          <meshStandardMaterial color="#d98d88" flatShading />
-        </mesh>
-        {/* orejas */}
-        <mesh position={[0.34, 0.14, 0.12]} rotation={[0.4, 0, 0.6]}>
-          <coneGeometry args={[0.07, 0.14, 5]} />
-          <meshStandardMaterial color="#d98d88" flatShading />
-        </mesh>
-        <mesh position={[0.34, 0.14, -0.12]} rotation={[-0.4, 0, 0.6]}>
-          <coneGeometry args={[0.07, 0.14, 5]} />
-          <meshStandardMaterial color="#d98d88" flatShading />
-        </mesh>
-        {/* colita */}
-        <mesh position={[-0.42, 0.06, 0]}>
-          <torusGeometry args={[0.06, 0.02, 6, 10]} />
-          <meshStandardMaterial color="#d98d88" flatShading />
-        </mesh>
-      </group>
-    </group>
-  );
-}
-
-/* Comedero: un medio-cilindro (canoa), redondeado, en vez de un cajón. */
+/* Comedero: la canoa de madera de siempre (medio cilindro). */
 function Comedero({ pos = [0, 0, 0] }) {
   return (
-    <mesh position={[pos[0], pos[1], pos[2]]} rotation={[0, 0, 0]} castShadow receiveShadow>
+    <mesh position={[pos[0], pos[1], pos[2]]} castShadow receiveShadow>
       <cylinderGeometry args={[0.16, 0.16, 0.7, 10, 1, false, 0, Math.PI]} />
       <meshStandardMaterial color="#8a6a44" flatShading roughness={1} side={2} />
     </mesh>
@@ -250,20 +127,52 @@ function Comedero({ pos = [0, 0, 0] }) {
 }
 
 /*
- * La zona de animales: varios animales pastando/picoteando, con aire entre
- * ellos (no amontonados). Reemplaza por completo a la casita anterior.
+ * La zona de animales del valle: el hato realista con aire entre animales.
+ * `q` (0..1) baja el detalle geométrico en gama baja (lo pasa el landmark).
  */
-export default function AnimalesDeFinca({ reducedMotion = false }) {
+export default function AnimalesDeFinca({ reducedMotion = false, q = 1 }) {
+  // Las fábricas cachean por args: esto solo compone referencias.
+  const g = useMemo(
+    () => ({
+      holstein: geomVaca({ raza: 'holstein', q }),
+      ternera: geomVaca({ raza: 'criolla', ubre: false, cuerno: 0, q }, 23),
+      zungo: geomCerdo({ raza: 'zungo', q }),
+      duroc: geomCerdo({ raza: 'duroc', q }, 33),
+      landrace: geomCerdo({ raza: 'landrace', q }, 35),
+      lechon: geomLechon({ raza: 'landrace' }),
+      oveja1: geomOveja({ q }),
+      oveja2: geomOveja({ q }, 67),
+      campesina: geomGallina({ tipo: 'campesina', q }),
+      negra: geomGallina({ tipo: 'negra', q }, 43),
+      blanca: geomGallina({ tipo: 'blanca', q }, 45),
+      gallo: geomGallina({ tipo: 'gallo', q }, 47),
+      perro: geomPerro({ q }),
+    }),
+    [q],
+  );
+  const rm = reducedMotion;
   return (
     <group>
-      <Vaca pos={[0.15, 0, -0.35]} giro={-0.5} reducedMotion={reducedMotion} />
-      <Oveja pos={[-1.0, 0, 0.45]} giro={0.6} fase={0} reducedMotion={reducedMotion} />
-      <Oveja pos={[-0.35, 0, 1.0]} giro={1.4} fase={1.7} reducedMotion={reducedMotion} />
-      <Cerdo pos={[-1.45, 0, -0.5]} giro={0.2} reducedMotion={reducedMotion} />
-      <Gallina pos={[1.15, 0, 0.6]} giro={2.4} fase={0.4} color="#e8e2d6" reducedMotion={reducedMotion} />
-      <Gallina pos={[1.5, 0, 0.05]} giro={-1.2} fase={2.1} color="#c98a4a" reducedMotion={reducedMotion} />
-      <Gallina pos={[0.7, 0, 1.15]} giro={0.9} fase={3.6} color="#dcd2c2" reducedMotion={reducedMotion} />
-      <Comedero pos={[1.25, 0.16, -0.7]} />
+      {/* la Holstein manda el corral; su ternera criolla al lado */}
+      <Animal geom={g.holstein} gesto="pasta" pos={[0.2, 0, -0.4]} giro={-0.5} escala={0.62} reducedMotion={rm} />
+      <Animal geom={g.ternera} gesto="pasta" pos={[0.85, 0, 0.15]} giro={-1.1} escala={0.38} fase={2.2} reducedMotion={rm} />
+      {/* los cerdos POR RAZA: negro zungo, colorado duroc, landrace con cría */}
+      <Animal geom={g.zungo} gesto="hocica" pos={[-1.45, 0, -0.5]} giro={0.3} escala={0.62} reducedMotion={rm} />
+      <Animal geom={g.duroc} gesto="hocica" pos={[-0.95, 0, -1.0]} giro={1.1} escala={0.6} fase={1.9} reducedMotion={rm} />
+      <Animal geom={g.landrace} gesto="hocica" pos={[-1.55, 0, 0.35]} giro={-0.7} escala={0.62} fase={3.4} reducedMotion={rm} />
+      <mesh geometry={g.lechon} material={MATERIAL_HATO} position={[-1.2, 0, 0.62]} rotation={[0, -0.4, 0]} castShadow />
+      <mesh geometry={g.lechon} material={MATERIAL_HATO} position={[-1.75, 0, 0.72]} rotation={[0, 0.9, 0]} scale={0.9} castShadow />
+      {/* las ovejas criollas — vellones DISTINTOS (seed propia) */}
+      <Animal geom={g.oveja1} gesto="tantea" pos={[-0.45, 0, 1.05]} giro={1.4} escala={0.52} fase={1.7} reducedMotion={rm} />
+      <Animal geom={g.oveja2} gesto="tantea" pos={[0.15, 0, 1.35]} giro={0.5} escala={0.48} fase={4.1} reducedMotion={rm} />
+      {/* el gallinero suelto: tres gallinas + el gallo vigilante */}
+      <Animal geom={g.campesina} gesto="picotea" pos={[1.15, 0, 0.6]} giro={2.4} escala={0.8} fase={0.4} reducedMotion={rm} />
+      <Animal geom={g.negra} gesto="picotea" pos={[1.5, 0, 0.05]} giro={-1.2} escala={0.76} fase={2.1} reducedMotion={rm} />
+      <Animal geom={g.blanca} gesto="picotea" pos={[0.7, 0, 1.1]} giro={0.9} escala={0.78} fase={3.6} reducedMotion={rm} />
+      <Animal geom={g.gallo} gesto="picotea" pos={[1.45, 0, 0.95]} giro={-2.2} escala={0.9} fase={5.2} reducedMotion={rm} />
+      {/* el perro criollo, echado el ojo a todo desde su esquina */}
+      <Animal geom={g.perro} gesto="mira" pos={[1.05, 0, -0.85]} giro={-2.6} escala={0.7} fase={1.2} reducedMotion={rm} />
+      <Comedero pos={[1.55, 0.16, -0.45]} />
     </group>
   );
 }

--- a/src/visual/mundo3d/bosque/sombreadoVegetal.js
+++ b/src/visual/mundo3d/bosque/sombreadoVegetal.js
@@ -1,0 +1,460 @@
+/*
+ * sombreadoVegetal — el TALLER común de la vegetación procedural del páramo.
+ *
+ * Aquí vive lo que el DR de realismo-3d-vegetacion (2026-06-19) identifica como
+ * el mayor retorno visual por costo, y que la primera versión de la flora NO
+ * tenía. El diagnóstico del DR era exacto: un cono/esfera de follaje sobre un
+ * cilindro, con UN color plano horneado por parte, se lee como "árbol de navidad".
+ *
+ * Las cuatro recetas que aplicamos aquí (DR §2 y §"Entregable"):
+ *
+ *   1. SOMBREADO con profundidad (§1 "Sombreado plano"): en vez de un color
+ *      plano, cada vértice recibe oclusión ambiental horneada (qué tan hundido
+ *      está en la masa de follaje) + gradiente de altura (el sol pega arriba) +
+ *      un dejo de translucidez en el borde de la copa (la hoja a contraluz).
+ *      Es gratis en runtime: viaja en el atributo `color`.
+ *   2. SILUETA irregular (§1 "Silueta irreal"): el borde de la copa se modula
+ *      con ruido y los cúmulos se siembran con huecos → el cielo se ve a través.
+ *   3. JERARQUÍA de ramas (§1 "Ausencia de jerarquía"): troncos con curva y
+ *      conicidad reales, ramas que nacen en ángulo áureo y se subdividen.
+ *   4. FUSIÓN SEGURA: `mergeGeometries` devuelve **null en silencio** si se
+ *      mezclan geometrías indexadas con no-indexadas → r3f hace `if(!geo) return
+ *      null` y la especie NO SE DIBUJA sin un solo error en consola. Ya mordió
+ *      dos veces. Aquí se desindexa TODO y se truena fuerte si el retorno es null.
+ *
+ * Todo es three core puro: corre headless (sin contexto GL) y es testeable.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+
+/* PRNG determinista (LCG): el mismo bosque en cada carga, nunca azar por frame. */
+export function rng(seed) {
+  let s = (seed >>> 0) || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+/* -------------------------------------------------------------------------- */
+/*  Ruido determinista (sin dependencias)                                      */
+/* -------------------------------------------------------------------------- */
+
+/** Hash escalar estable → [0,1). Base del ruido de valor. */
+function hash3(x, y, z) {
+  let h = Math.sin(x * 127.1 + y * 311.7 + z * 74.7) * 43758.5453;
+  h -= Math.floor(h);
+  return h;
+}
+
+const suave = (t) => t * t * (3 - 2 * t); // smoothstep
+
+/**
+ * Ruido de valor 3D en [0,1], continuo y determinista. Sirve para romper la
+ * perfección geométrica: arruga la corteza, muerde el borde de la copa, mancha
+ * el color. Barato: se evalúa en tiempo de construcción, nunca por frame.
+ */
+export function ruido3D(x, y, z) {
+  const xi = Math.floor(x);
+  const yi = Math.floor(y);
+  const zi = Math.floor(z);
+  const xf = suave(x - xi);
+  const yf = suave(y - yi);
+  const zf = suave(z - zi);
+  const lerp = (a, b, t) => a + (b - a) * t;
+  const c = (dx, dy, dz) => hash3(xi + dx, yi + dy, zi + dz);
+  const x00 = lerp(c(0, 0, 0), c(1, 0, 0), xf);
+  const x10 = lerp(c(0, 1, 0), c(1, 1, 0), xf);
+  const x01 = lerp(c(0, 0, 1), c(1, 0, 1), xf);
+  const x11 = lerp(c(0, 1, 1), c(1, 1, 1), xf);
+  return lerp(lerp(x00, x10, yf), lerp(x01, x11, yf), zf);
+}
+
+/** Ruido fractal (2 octavas): detalle grueso + fino. Devuelve [0,1]. */
+export function ruidoFbm(x, y, z) {
+  return ruido3D(x, y, z) * 0.65 + ruido3D(x * 2.3, y * 2.3, z * 2.3) * 0.35;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Fusión segura (la trampa del null silencioso)                              */
+/* -------------------------------------------------------------------------- */
+
+/** Desindexa si hace falta. Uniformar índice es lo que evita el merge → null. */
+export function desindexar(geo) {
+  return geo.index ? geo.toNonIndexed() : geo;
+}
+
+/**
+ * Fusiona partes en UNA geometría (1 draw-call por especie).
+ *
+ * TRUENA si el merge devuelve null en vez de dejar la especie invisible: ese
+ * fallo silencioso ya costó dos depuraciones largas. Todas las partes se
+ * desindexan primero (poliedros vienen no-indexados y cilindros/conos sí →
+ * mezclarlos es exactamente lo que devuelve null).
+ *
+ * @param {THREE.BufferGeometry[]} partes
+ * @param {string} etiqueta  nombre de la especie, para que el error diga QUIÉN.
+ */
+export function fusionarSeguro(partes, etiqueta = 'sin-nombre') {
+  const buenas = partes.filter(Boolean).map(desindexar);
+  if (!buenas.length) {
+    throw new Error(`[sombreadoVegetal] "${etiqueta}": no hay partes que fusionar.`);
+  }
+  // Todas deben declarar los MISMOS atributos o el merge devuelve null.
+  const refAttrs = Object.keys(buenas[0].attributes).sort().join(',');
+  for (let i = 0; i < buenas.length; i++) {
+    const attrs = Object.keys(buenas[i].attributes).sort().join(',');
+    if (attrs !== refAttrs) {
+      throw new Error(
+        `[sombreadoVegetal] "${etiqueta}": la parte ${i} tiene atributos [${attrs}] `
+        + `pero se esperaba [${refAttrs}]. mergeGeometries devolvería null y la `
+        + 'especie no se dibujaría. Revise que TODAS las partes pasen por pintar*().',
+      );
+    }
+  }
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error(
+      `[sombreadoVegetal] "${etiqueta}": mergeGeometries devolvió NULL. `
+      + 'Causa típica: mezcla de geometrías indexadas y no-indexadas, o atributos '
+      + 'dispares. La especie habría quedado INVISIBLE sin error.',
+    );
+  }
+  g.computeVertexNormals();
+  return g;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Colocación                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/** Coloca una geometría (transforma sus vértices) con pos/rot/escala. */
+export function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/** Orienta el eje +Y de la geometría hacia `dir` y la ubica en `pos`. */
+export function apuntar(geo, pos, dir, esc = [1, 1, 1], giro = 0) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
+  if (giro) q.multiply(new THREE.Quaternion().setFromAxisAngle(UP, giro));
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    q,
+    new THREE.Vector3(esc[0], esc[1], esc[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Horneado de color por vértice — el corazón del realismo (DR §"mayor        */
+/*  retorno": AO + gradiente + translucidez + variación)                       */
+/* -------------------------------------------------------------------------- */
+
+/** Aplica un color por vértice calculado por `fn(x, y, z, i) → THREE.Color`. */
+export function pintarPorVertice(geo, fn) {
+  const pos = geo.attributes.position;
+  const arr = new Float32Array(pos.count * 3);
+  const c = new THREE.Color();
+  for (let i = 0; i < pos.count; i++) {
+    const col = fn(pos.getX(i), pos.getY(i), pos.getZ(i), i, c);
+    arr[i * 3] = col.r;
+    arr[i * 3 + 1] = col.g;
+    arr[i * 3 + 2] = col.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Color plano en todos los vértices. Para piezas pequeñas (bayas, flores). */
+export function pintarPlano(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  return pintarPorVertice(geo, () => c);
+}
+
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+
+/**
+ * Hornea el sombreado de un CÚMULO DE FOLLAJE (la receta #1 del DR).
+ *
+ * Tres capas que, juntas, sacan a la copa de "masa sólida verde":
+ *   · AO: el vértice se oscurece según lo HUNDIDO que está en la masa de la
+ *     copa (distancia al centro del cúmulo, normalizada por su radio). El
+ *     interior queda en penumbra y el borde se enciende → volumen real.
+ *   · Gradiente de altura: arriba pega el sol, abajo queda en sombra propia.
+ *   · Translucidez de borde: en la piel exterior la hoja se lee a contraluz →
+ *     se mezcla un verde más claro y amarillento (la falsa SSS del DR, pero
+ *     horneada: cero costo de shader, corre en Android barato).
+ *
+ * @param {THREE.BufferGeometry} geo  geometría YA colocada en coords del árbol.
+ * @param {object} o
+ * @param {THREE.Color|string} o.base    verde de la hoja en penumbra.
+ * @param {THREE.Color|string} o.sol     verde iluminado (arriba/afuera).
+ * @param {THREE.Color|string} [o.luz]   tinte de contraluz (hoja translúcida).
+ * @param {[number,number,number]} o.centro  centro del cúmulo (coords del árbol).
+ * @param {number} o.radio               radio del cúmulo.
+ * @param {number} [o.yMin]   base del rango de altura del gradiente.
+ * @param {number} [o.yMax]   tope del rango de altura del gradiente.
+ * @param {number} [o.ao]                fuerza de la oclusión (0..1).
+ * @param {number} [o.manchas]           variación de ruido por vértice.
+ */
+export function hornearFollaje(geo, o) {
+  const base = new THREE.Color(o.base);
+  const sol = new THREE.Color(o.sol);
+  const luz = new THREE.Color(o.luz ?? '#cfd98a');
+  const [cx, cy, cz] = o.centro;
+  const radio = Math.max(0.001, o.radio);
+  const yMin = o.yMin ?? cy - radio;
+  const yMax = o.yMax ?? cy + radio;
+  const aoK = o.ao ?? 0.62;
+  const manchas = o.manchas ?? 0.1;
+  const tmp = new THREE.Color();
+
+  return pintarPorVertice(geo, (x, y, z) => {
+    // Profundidad dentro del cúmulo: 0 en el corazón → 1 en la piel exterior.
+    const d = Math.sqrt((x - cx) ** 2 + (y - cy) ** 2 + (z - cz) ** 2) / radio;
+    const piel = clamp01(d);
+    // AO: el corazón de la copa queda oscuro; la piel, expuesta.
+    const ao = 1 - aoK * (1 - piel * piel);
+    // Gradiente de altura: el sol viene de arriba.
+    const alt = clamp01((y - yMin) / Math.max(0.001, yMax - yMin));
+    tmp.copy(base).lerp(sol, alt * 0.75 + piel * 0.25);
+    // Contraluz: solo en la piel exterior, y más arriba que abajo.
+    const contra = clamp01((piel - 0.72) / 0.28) * (0.35 + alt * 0.4);
+    if (contra > 0) tmp.lerp(luz, contra * 0.45);
+    tmp.multiplyScalar(ao);
+    // Manchas: rompe el plano uniforme (nubes de hoja más clara/oscura).
+    if (manchas > 0) {
+      const n = ruidoFbm(x * 1.7 + 11, y * 1.7, z * 1.7);
+      tmp.multiplyScalar(1 + (n - 0.5) * manchas * 2);
+    }
+    return tmp;
+  });
+}
+
+/**
+ * Hornea el sombreado de CORTEZA: grieta oscura / cresta clara, oclusión de
+ * contacto contra el suelo y velo de líquen abajo (DR §"Corteza sin textura").
+ *
+ * @param {THREE.BufferGeometry} geo  tronco/rama YA colocado.
+ * @param {object} o
+ * @param {THREE.Color|string} o.grieta  fondo de la fisura.
+ * @param {THREE.Color|string} o.cuerpo  corteza madura.
+ * @param {THREE.Color|string} [o.cresta] lámina expuesta (papel del Polylepis).
+ * @param {THREE.Color|string} [o.liquen] líquen que trepa el pie.
+ * @param {number} [o.escalaGrano]  frecuencia del grano de corteza.
+ * @param {number} [o.hastaLiquen]  altura hasta donde trepa el líquen.
+ */
+export function hornearCorteza(geo, o) {
+  const grieta = new THREE.Color(o.grieta);
+  const cuerpo = new THREE.Color(o.cuerpo);
+  const cresta = new THREE.Color(o.cresta ?? o.cuerpo);
+  const liquen = o.liquen ? new THREE.Color(o.liquen) : null;
+  const grano = o.escalaGrano ?? 5.5;
+  const hastaLiquen = o.hastaLiquen ?? 0;
+  const tmp = new THREE.Color();
+
+  return pintarPorVertice(geo, (x, y, z) => {
+    // Grano de corteza: fibras verticales (mucha frecuencia en el plano XZ,
+    // poca en Y → la veta corre a lo largo del tronco, como en la madera real).
+    const v = ruidoFbm(x * grano * 2.2, y * grano * 0.5, z * grano * 2.2);
+    tmp.copy(grieta).lerp(cuerpo, clamp01(v * 1.5));
+    if (v > 0.62) tmp.lerp(cresta, clamp01((v - 0.62) / 0.38) * 0.8);
+    // Oclusión de contacto: el pie del árbol vive en penumbra.
+    const pie = clamp01(y / 1.1);
+    tmp.multiplyScalar(0.55 + 0.45 * pie);
+    // Líquen del páramo trepando la base (mancha, no capa uniforme).
+    if (liquen && y < hastaLiquen) {
+      const m = ruidoFbm(x * 3.1 + 5, y * 3.1, z * 3.1 + 5);
+      const cuanto = clamp01((hastaLiquen - y) / hastaLiquen) * clamp01((m - 0.42) / 0.58);
+      tmp.lerp(liquen, cuanto * 0.75);
+    }
+    return tmp;
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Geometría orgánica: troncos y ramas con conicidad y arruga reales          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Tubo orgánico sobre una curva: conicidad real + arruga de corteza en la
+ * geometría (no un normal-map). Es la pieza con la que se hacen troncos, ramas
+ * y raíces. El DR insiste: un cilindro perfecto se delata; la conicidad y la
+ * irregularidad son baratas y valen mucho.
+ *
+ * @param {THREE.Curve} curva
+ * @param {object} o
+ * @param {number} o.tubular  segmentos a lo largo.
+ * @param {number} o.radial   segmentos alrededor.
+ * @param {(t:number)=>number} o.taper  radio-mundo en t∈[0,1].
+ * @param {number} [o.arruga]  amplitud relativa del relieve de corteza.
+ * @param {number} [o.semilla] desfase del relieve (para que no se repita).
+ * @param {number} [o.minRadio] piso del radio. Por defecto 0.02, que es lo que
+ *   quiere un TRONCO (nunca degenera a un hilo). Pero una HIFA micorrízica vive
+ *   entre 0.002 y 0.03: con el piso de tronco toda la jerarquía (rizomorfo →
+ *   secundaria → punta) se aplasta a un mismo grosor y la red vuelve a leerse
+ *   como una maraña pareja. Los llamadores finos lo bajan.
+ */
+export function tuboOrganico(curva, o) {
+  const { tubular, radial, taper } = o;
+  const arruga = o.arruga ?? 0.12;
+  const semilla = o.semilla ?? 0;
+  const minRadio = o.minRadio ?? 0.02;
+  const geo = new THREE.TubeGeometry(curva, tubular, 1, radial, false);
+  const pos = geo.attributes.position;
+  const nAnillo = radial + 1;
+
+  const centros = [];
+  for (let i = 0; i <= tubular; i++) centros.push(curva.getPointAt(i / tubular));
+
+  const v = new THREE.Vector3();
+  const off = new THREE.Vector3();
+  for (let k = 0; k < pos.count; k++) {
+    const anillo = Math.floor(k / nAnillo);
+    const j = k % nAnillo;
+    const t = anillo / tubular;
+    const ang = (j / radial) * Math.PI * 2;
+    const centro = centros[Math.min(anillo, centros.length - 1)];
+
+    v.fromBufferAttribute(pos, k);
+    off.subVectors(v, centro);
+    // Arruga: surcos que corren a lo largo + grano fino, más marcados abajo.
+    const surco = Math.sin(ang * 7 + semilla + t * 1.6) * 0.55
+      + Math.sin(ang * 15 - semilla * 2 + t * 3) * 0.25
+      + (ruido3D(Math.cos(ang) * 3 + semilla, t * 9, Math.sin(ang) * 3) - 0.5) * 1.4;
+    const disp = 1 + surco * arruga * (1 + (1 - t) * 0.5);
+    v.copy(centro).addScaledVector(off, Math.max(minRadio, taper(t) * disp));
+    pos.setXYZ(k, v.x, v.y, v.z);
+  }
+  pos.needsUpdate = true;
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/** Taper lineal de r0 (base) a r1 (punta). */
+export const taperLineal = (r0, r1 = 0.02) => (t) => Math.max(0.012, r0 * (1 - t) + r1 * t);
+
+/**
+ * Taper de TRONCO: raigón ensanchado al pie (contrafuertes), adelgazamiento
+ * potencial hacia la copa y pulsos de nudo. Nada de conos.
+ */
+export function taperTronco(r0, r1, raigon = 0.35) {
+  return (t) => {
+    const base = (r0 - r1) * Math.pow(Math.max(0, 1 - t), 1.4) + r1;
+    const pie = r0 * raigon * Math.exp(-t * 8);
+    const nudo = r0 * 0.06 * Math.sin(t * 6.5) * Math.sin(t * Math.PI);
+    return Math.max(0.015, base + pie + nudo);
+  };
+}
+
+/**
+ * Curva de tronco con inclinación, curvatura y torsión deterministas. Un árbol
+ * real pelea con el viento: no es un eje recto.
+ */
+export function curvaTronco({ altura, inclina = 0.1, sinuoso = 0.12, giro = 0 }, seed = 1) {
+  const r = rng(seed);
+  const n = 5;
+  const pts = [];
+  for (let i = 0; i <= n; i++) {
+    const t = i / n;
+    const y = altura * t;
+    // La inclinación crece con la altura; la sinuosidad serpentea alrededor.
+    const lean = inclina * altura * t * t;
+    const ang = giro + t * Math.PI * 1.3;
+    const s = sinuoso * altura * (0.25 + t * 0.75);
+    pts.push(new THREE.Vector3(
+      Math.cos(giro) * lean + Math.cos(ang) * s * (r() * 0.6 + 0.2),
+      y,
+      Math.sin(giro) * lean + Math.sin(ang) * s * (r() * 0.6 + 0.2),
+    ));
+  }
+  return new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Cúmulos de follaje con HUECOS y borde irregular (anti árbol-de-navidad)    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Siembra puntos de hoja dentro de un elipsoide, PERO:
+ *   · con rechazo por distancia mínima (Poisson pobre) → no se apelmazan;
+ *   · con huecos: el ruido decide dónde NO hay hoja → el cielo entra;
+ *   · con borde mordido: el radio se modula por dirección → silueta irregular.
+ *
+ * Esto es, literalmente, lo que separa una copa creíble de una bola de helado.
+ *
+ * @returns {{pos:[number,number,number], esc:number, giro:[number,number,number]}[]}
+ */
+export function sembrarFollaje({
+  centro, radio, achatado = 0.78, n, semilla = 1,
+  huecos = 0.42, mordida = 0.34, distMin = 0.34,
+}) {
+  const r = rng(semilla);
+  const puntos = [];
+  const intentos = n * 14;
+  for (let i = 0; i < intentos && puntos.length < n; i++) {
+    // Dirección uniforme en la esfera.
+    const u = r() * 2 - 1;
+    const th = r() * Math.PI * 2;
+    const s = Math.sqrt(1 - u * u);
+    const dx = s * Math.cos(th);
+    const dy = u;
+    const dz = s * Math.sin(th);
+    // Borde mordido: el radio útil depende de la dirección (ruido) → la copa
+    // deja de ser una esfera y adquiere bultos y entrantes.
+    const muerde = 1 - mordida * ruidoFbm(dx * 2 + semilla, dy * 2, dz * 2);
+    const rad = radio * muerde * Math.cbrt(r());
+    const p = [
+      centro[0] + dx * rad,
+      centro[1] + dy * rad * achatado,
+      centro[2] + dz * rad,
+    ];
+    // Huecos: el ruido apaga regiones enteras → claros dentro de la copa.
+    if (huecos > 0 && ruidoFbm(p[0] * 1.15 + 31, p[1] * 1.15, p[2] * 1.15) < huecos * 0.55) continue;
+    // Rechazo por cercanía: nada de grumos apelmazados.
+    let choca = false;
+    for (let k = 0; k < puntos.length; k++) {
+      const q = puntos[k].pos;
+      if ((q[0] - p[0]) ** 2 + (q[1] - p[1]) ** 2 + (q[2] - p[2]) ** 2 < distMin * distMin) {
+        choca = true;
+        break;
+      }
+    }
+    if (choca) continue;
+    puntos.push({
+      pos: /** @type {[number, number, number]} */ (p),
+      esc: 0.62 + r() * 0.55,
+      giro: /** @type {[number, number, number]} */ ([r() * Math.PI, r() * Math.PI, r() * Math.PI]),
+    });
+  }
+  return puntos;
+}
+
+/**
+ * Un "matojo" de hoja: poliedro achatado y deformado con ruido. No es una
+ * esfera — es un manojo irregular. Con `hornearFollaje` encima, se lee como
+ * masa de hojas y no como bola.
+ */
+export function matojoHoja(radio, semilla = 1, deform = 0.42) {
+  const g = new THREE.IcosahedronGeometry(radio, 0);
+  const pos = g.attributes.position;
+  const v = new THREE.Vector3();
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i);
+    const n = ruidoFbm(v.x * 2.6 + semilla, v.y * 2.6, v.z * 2.6) - 0.5;
+    v.multiplyScalar(1 + n * deform * 2);
+    pos.setXYZ(i, v.x, v.y, v.z);
+  }
+  pos.needsUpdate = true;
+  return g;
+}

--- a/src/visual/mundo3d/finca/fincaRealista.geom.js
+++ b/src/visual/mundo3d/finca/fincaRealista.geom.js
@@ -1,0 +1,948 @@
+/*
+ * fincaRealista.geom — los ANIMALES del corral, con anatomía y sombreado reales.
+ *
+ * Veredicto del operador (dos veces): "formas muy geométricas, aún no parecen
+ * animales reales". El diagnóstico del DR realismo-3d (2026-06-19) aplica
+ * palabra por palabra al hato:
+ *
+ *   1. SILUETA: un animal armado como unión de cápsulas y esferas perfectas se
+ *      lee como juguete — el contorno es lo primero que el ojo evalúa. Aquí el
+ *      torso es UN loft orgánico (`cuerpoOrganico`): secciones elípticas sobre
+ *      una espina dorsal curva, con cruz, caída de lomo, grupa y panza
+ *      descolgada continuas + ruido determinista que rompe la perfección.
+ *   2. SOMBREADO: el color plano por pieza delata el poliedro. `hornearPelaje`
+ *      hornea en vertexColors (gratis en runtime, corre en Android barato) la
+ *      luz de cielo arriba, la oclusión de panza/entre-patas abajo y un moteado
+ *      sutil de pelaje. Las MANCHAS de capa (holstein, pietrain) van PINTADAS
+ *      por vértice con ruido — parches de piel, no pelotas pegadas que abultan
+ *      la silueta.
+ *   3. NORMALES SUAVES — la trampa fina: `computeVertexNormals()` sobre una
+ *      geometría DESINDEXADA calcula normales POR CARA → flat shading aunque el
+ *      material sea suave. Por eso `fusionarHato` NO recalcula normales: las
+ *      partes llegan con sus normales suaves (primitivas o loft indexado) y la
+ *      fusión las preserva. El material del hato (animales.jsx) va sin
+ *      flatShading — a diferencia de MATERIAL_FINCA, que la arboleda necesita.
+ *   4. REPETICIÓN: cada fábrica acepta `seed` (dos ovejas ≠ la misma oveja) y
+ *      el consumidor añade jitter determinista por instancia.
+ *
+ * Las señas POR RAZA (pedido explícito del operador — él tiene cerdos):
+ *   · VACA Holstein (manchas negras de capa, ubre llena, MOCHA — sin cuernos),
+ *     criolla (caramelo, cuernos en lira) y cebú/Brahman (giba, papada,
+ *     orejones caídos).
+ *   · CERDO zungo (negro, panza baja), san pedreño (calcetines claros), duroc
+ *     (colorado, dorso arqueado), landrace (rosado LARGO, orejas tapaojos) y
+ *     pietrain (blanco manchado, jamones) + lechones.
+ *   · GALLINA campesina/negra/blanca + gallo de cola en hoz verde tornasol.
+ *   · PERRO criollo amarillo y OVEJA criolla de vellón por mechones.
+ *
+ * TÉCNICA tier-safe: cada animal se FUSIONA en cuerpo (una malla) + cabeza
+ * (otra, local al pivote del cuello para conservar el gesto vivo) → 2 draw
+ * calls por animal con UN material compartido. Cero assets, cero texturas,
+ * corre headless (three core + merge).
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import {
+  rng,
+  ruidoFbm,
+  poner,
+  apuntar,
+  pintarPorVertice,
+  pintarPlano,
+  desindexar,
+} from '../bosque/sombreadoVegetal.js';
+
+/* -------------------------------------------------------------------------- */
+/*  Fusión + horneado del hato                                                 */
+/* -------------------------------------------------------------------------- */
+
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+
+/**
+ * Fusiona las partes de un animal en UNA geometría, con las mismas garantías
+ * anti-null de `fusionarSeguro` (desindexar TODO + validar atributos + tronar
+ * fuerte) pero SIN recalcular normales: sobre geometría desindexada,
+ * `computeVertexNormals` produce normales por-cara y el animal vuelve a ser un
+ * poliedro por más suave que sea el material. Las normales suaves que traen
+ * las primitivas y el loft SE PRESERVAN. El `uv` se descarta (el material del
+ * hato no usa mapas) para que primitivas-con-uv y loft-sin-uv fusionen parejo.
+ */
+function fusionarHato(partes, etiqueta) {
+  const buenas = partes.filter(Boolean).map((g) => {
+    const geo = desindexar(g);
+    if (geo.attributes.uv) geo.deleteAttribute('uv');
+    return geo;
+  });
+  if (!buenas.length) throw new Error(`[fincaRealista] "${etiqueta}": sin partes que fusionar.`);
+  const ref = Object.keys(buenas[0].attributes).sort().join(',');
+  for (let i = 0; i < buenas.length; i++) {
+    const attrs = Object.keys(buenas[i].attributes).sort().join(',');
+    if (attrs !== ref) {
+      throw new Error(
+        `[fincaRealista] "${etiqueta}": la parte ${i} tiene atributos [${attrs}], se esperaba `
+        + `[${ref}]. mergeGeometries devolvería null y el animal quedaría INVISIBLE sin error.`,
+      );
+    }
+  }
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error(
+      `[fincaRealista] "${etiqueta}": mergeGeometries devolvió NULL (mezcla indexada/no-indexada `
+      + 'o atributos dispares). El animal habría quedado invisible.',
+    );
+  }
+  return g;
+}
+
+/**
+ * Hornea el sombreado del animal SOBRE la malla ya fusionada (posiciones y
+ * normales finales): multiplica el color de cada vértice por
+ *   · luz de cielo (las superficies que miran arriba se encienden),
+ *   · oclusión de panza (gradiente de altura: entre las patas y bajo el vientre
+ *     vive la penumbra — el AO barato que separa un bicho de un juguete),
+ *   · sombra propia de las caras que miran al suelo,
+ *   · moteado sutil de pelaje (ruido determinista, nunca por frame).
+ */
+function hornearPelaje(geo, { yBajo = 0.05, yAlto = 0.9, ao = 0.38, moteado = 0.07, semilla = 1 } = {}) {
+  const pos = geo.attributes.position;
+  const nor = geo.attributes.normal;
+  const col = geo.attributes.color;
+  for (let i = 0; i < pos.count; i++) {
+    const x = pos.getX(i);
+    const y = pos.getY(i);
+    const z = pos.getZ(i);
+    const ny = nor.getY(i);
+    const cielo = 0.82 + 0.18 * Math.max(0, ny);
+    const alt = clamp01((y - yBajo) / Math.max(0.001, yAlto - yBajo));
+    let oc = 1 - ao + ao * alt;
+    if (ny < 0) oc *= 1 + ny * 0.16; // la cara que mira al piso, en sombra propia
+    const mota = 1 + (ruidoFbm(x * 2.7 + semilla, y * 2.7, z * 2.7) - 0.5) * moteado * 2;
+    const f = cielo * oc * mota;
+    col.setXYZ(i, col.getX(i) * f, col.getY(i) * f, col.getZ(i) * f);
+  }
+  return geo;
+}
+
+/** Pequeña variación determinista de color (que un hato no sea plano). */
+function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
+}
+
+/**
+ * MANCHAS DE CAPA pintadas por vértice: el ruido decide dónde la piel es
+ * mancha y dónde es fondo. Como se evalúa en coordenadas del ANIMAL ya armado,
+ * el parche continúa sin costura de una pieza a la vecina (torso → cuello).
+ * Cero geometría extra: la silueta queda limpia (una mancha de vaca es piel,
+ * no una piedra pegada).
+ */
+function pintarManchas(geo, base, mancha, { escala = 1.6, umbral = 0.58, semilla = 1 } = {}) {
+  const cb = new THREE.Color(base);
+  const cm = new THREE.Color(mancha);
+  const tmp = new THREE.Color();
+  const banda = 0.05; // borde suave: sin esto el umbral duro serrucha el parche
+  return pintarPorVertice(geo, (x, y, z) => {
+    const n = ruidoFbm(x * escala + semilla * 7.31, y * escala + semilla * 1.7, z * escala);
+    const mezcla = clamp01((n - (umbral - banda)) / (banda * 2));
+    return tmp.copy(cb).lerp(cm, mezcla);
+  });
+}
+
+/** MECHÓN de lana SUAVE: esfera deformada con ruido, indexada, con normales
+    recalculadas ANTES de fusionar — bulto blando, no roca facetada (el
+    matojoHoja del bosque es no-indexado y se lee cristal en un vellón). */
+function mechonLana(radio, semilla = 1, deform = 0.3) {
+  const g = new THREE.SphereGeometry(radio, 9, 7);
+  const pos = g.attributes.position;
+  const v = new THREE.Vector3();
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i);
+    const n = ruidoFbm(v.x * 2.4 + semilla, v.y * 2.4, v.z * 2.4) - 0.5;
+    v.multiplyScalar(1 + n * deform * 2);
+    pos.setXYZ(i, v.x, v.y, v.z);
+  }
+  pos.needsUpdate = true;
+  g.computeVertexNormals();
+  return g;
+}
+
+/** Un cono ANCLADO por su base (cuernos, plumas, picos): el centro se corre
+    medio largo hacia `dir`. */
+function brote(attach, dir, radio, largo, escZ, segs = 5) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const hoja = new THREE.ConeGeometry(radio, largo, segs, 1);
+  apuntar(
+    hoja,
+    [attach[0] + d.x * largo * 0.5, attach[1] + d.y * largo * 0.5, attach[2] + d.z * largo * 0.5],
+    dir,
+    [1, 1, escZ],
+  );
+  return hoja;
+}
+
+/** OREJA de pétalo: esfera aplastada orientada hacia `dir` — punta REDONDA.
+    Un cono en la cabeza se lee como púa; una oreja real es una hoja carnosa. */
+function orejaPetalo(attach, dir, largo, ancho, grosor = 0.3) {
+  const g = new THREE.SphereGeometry(0.5, 9, 7);
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  apuntar(
+    g,
+    [attach[0] + d.x * largo * 0.42, attach[1] + d.y * largo * 0.42, attach[2] + d.z * largo * 0.42],
+    dir,
+    [ancho, largo, ancho * grosor],
+  );
+  return g;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  El torso orgánico — la silueta es lo que el ojo lee primero                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Loft de TORSO: anillos elípticos a lo largo del eje X (cola en t=0, pecho en
+ * t=1) sobre una espina dorsal con altura variable. Radios independientes
+ * hacia arriba (lomo), abajo (panza descolgada) y los lados, más ruido
+ * orgánico determinista. INDEXADO → `computeVertexNormals` da normales suaves
+ * reales (se llama aquí, ANTES de desindexar en la fusión).
+ *
+ * @param {object} o
+ * @param {number} o.largo           largo total en X.
+ * @param {(t:number)=>number} o.espina  altura del eje en t.
+ * @param {(t:number)=>number} o.arriba  radio del lomo (espina → arriba).
+ * @param {(t:number)=>number} o.abajo   radio de la panza (espina → abajo).
+ * @param {(t:number)=>number} o.lado    medio-ancho.
+ * @param {number} [o.nSeg] anillos a lo largo.  @param {number} [o.nRad] vértices por anillo.
+ * @param {number} [o.ruido] amplitud relativa del relieve orgánico.
+ * @param {number} [o.semilla] desfase del ruido.
+ */
+function cuerpoOrganico({ largo, espina, arriba, abajo, lado, nSeg = 16, nRad = 12, ruido = 0.025, semilla = 1 }) {
+  const pos = [];
+  const idx = [];
+  for (let i = 0; i <= nSeg; i++) {
+    const t = i / nSeg;
+    const x = -largo / 2 + t * largo;
+    const cy = espina(t);
+    for (let j = 0; j < nRad; j++) {
+      const a = (j / nRad) * Math.PI * 2;
+      const s = Math.sin(a);
+      const c = Math.cos(a);
+      const n = (ruidoFbm(x * 3.1 + semilla, s * 1.9 + semilla, c * 1.9) - 0.5) * 2 * ruido;
+      const ry = (s >= 0 ? arriba(t) : abajo(t)) * (1 + n);
+      pos.push(x, cy + s * ry, c * lado(t) * (1 + n));
+    }
+  }
+  for (let i = 0; i < nSeg; i++) {
+    for (let j = 0; j < nRad; j++) {
+      const a = i * nRad + j;
+      const b = i * nRad + ((j + 1) % nRad);
+      const c = (i + 1) * nRad + j;
+      const d = (i + 1) * nRad + ((j + 1) % nRad);
+      idx.push(a, c, b, b, c, d);
+    }
+  }
+  // Tapas (los perfiles ya llegan angostos a las puntas → remate redondeado).
+  const iCola = pos.length / 3;
+  pos.push(-largo / 2 - largo * 0.02, espina(0), 0);
+  const iPecho = pos.length / 3;
+  pos.push(largo / 2 + largo * 0.02, espina(1), 0);
+  for (let j = 0; j < nRad; j++) {
+    idx.push(iCola, j, (j + 1) % nRad);
+    const base = nSeg * nRad;
+    idx.push(iPecho, base + ((j + 1) % nRad), base + j);
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(pos), 3));
+  geo.setIndex(idx);
+  geo.computeVertexNormals(); // indexado → suaves de verdad
+  return geo;
+}
+
+/** Campana suave 0→1→0 centrada en `c` con ancho `w` (perfiles de panza/giba). */
+const campana = (t, c, w) => {
+  const u = clamp01(1 - Math.abs(t - c) / w);
+  return u * u * (3 - 2 * u);
+};
+
+/** Remate de puntas: 1 en el centro, cae a `min` en t=0 y t=1 (que el loft
+    cierre redondeado, no en tubo cortado). */
+const remate = (t, min = 0.35) => min + (1 - min) * Math.sin(Math.PI * clamp01(t)) ** 0.6;
+
+/* Patas de cuadrúpedo: muslo carnoso ANCHO ARRIBA que nace dentro de la masa
+   del cuerpo (nada de postes desconectados), caña fina, pezuña oscura.
+   Jitter determinista por pata: ningún animal para perfectamente cuadrado. */
+function pataCuadrupedo(p, { x, z, yCadera, rMuslo, rCana, pelaje, pezuna, r, atras = false, pintor = null }) {
+  const j = () => (r() - 0.5) * 0.02;
+  const dx = x + j();
+  const dz = z + j();
+  const pinta = pintor || ((g, c) => pintarPlano(g, c));
+  const muslo = new THREE.CylinderGeometry(rMuslo, rCana * 1.1, yCadera * 0.55, 8, 2);
+  poner(muslo, [dx, yCadera * 0.66, dz], [j() * 3, 0, (atras ? -0.05 : 0.03) + j() * 2]);
+  p.push(pinta(muslo, variar(pelaje, r, 0.05)));
+  const cana = new THREE.CylinderGeometry(rCana, rCana * 0.88, yCadera * 0.42, 7, 1);
+  poner(cana, [dx + (atras ? -0.012 : 0.006), yCadera * 0.22, dz], [0, 0, j() * 2]);
+  p.push(pinta(cana, variar(pelaje, r, 0.06)));
+  const casco = new THREE.CylinderGeometry(rCana * 1.02, rCana * 1.12, yCadera * 0.09, 7, 1);
+  poner(casco, [dx + (atras ? -0.012 : 0.006), yCadera * 0.045, dz]);
+  p.push(pintarPlano(casco, pezuna));
+}
+
+/* Caché de geometrías (mismas args → misma malla; nada se reconstruye al
+   re-montar la escena). Chico: unas decenas de mallas menudas. */
+const _cache = new Map();
+function memo(clave, crear) {
+  if (!_cache.has(clave)) _cache.set(clave, crear());
+  return _cache.get(clave);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  VACA — Holstein / criolla / cebú (Brahman)                                 */
+/* -------------------------------------------------------------------------- */
+
+export const RAZAS_VACA = {
+  holstein: {
+    pelaje: '#f2ecdf', manchas: '#26211d', hocico: '#c39793', ubre: '#e2ab9e',
+    cuerno: 0, orejas: 'lado', giba: false, papada: false,
+  },
+  criolla: {
+    pelaje: '#a5652f', manchas: null, hocico: '#7c5138', ubre: '#cf9c82',
+    cuerno: 0.9, orejas: 'lado', giba: false, papada: true,
+  },
+  cebu: {
+    pelaje: '#d9d5c7', manchas: null, hocico: '#524b44', ubre: '#d8b3a4',
+    cuerno: 0.8, orejas: 'caida', giba: true, papada: true,
+  },
+};
+
+/**
+ * La vaca anatómica. Mira a +X, patas en y=0, cruz a ~1.1.
+ * `cuerno` (opcional) escala los cuernos por encima de la raza — la ternera va
+ * mocha aunque sea criolla.
+ * @returns {{cuerpo: THREE.BufferGeometry, cabeza: THREE.BufferGeometry, pivote: [number,number,number]}}
+ */
+export function geomVaca({ raza = 'holstein', ubre = true, cuerno = null, q = 1 } = {}, seed = 21) {
+  return memo(`vaca|${raza}|${ubre}|${cuerno}|${q}|${seed}`, () => {
+    const R = RAZAS_VACA[raza] || RAZAS_VACA.holstein;
+    const r = rng(seed);
+    const p = [];
+    const nSeg = Math.max(14, Math.round(20 * q));
+    const nRad = Math.max(11, Math.round(15 * q));
+    const escCuerno = cuerno ?? R.cuerno;
+    // El pintor de pelaje: manchas de capa pintadas (holstein) o color pleno.
+    const pinta = R.manchas
+      ? (g, c) => pintarManchas(g, c, R.manchas, { escala: 1.5, umbral: 0.56, semilla: seed })
+      : (g, c) => pintarPlano(g, c);
+
+    // ── El torso ES UNA silueta: grupa alta y huesuda, lomo que cae apenas,
+    //    cruz marcada, pecho hondo y la panza de vaca descolgada al medio ──
+    const torso = cuerpoOrganico({
+      largo: 1.32,
+      nSeg,
+      nRad,
+      semilla: seed,
+      ruido: 0.02,
+      espina: (t) => 0.9 + 0.05 * campana(t, 0.08, 0.22) - 0.035 * campana(t, 0.45, 0.35) + 0.04 * campana(t, 0.9, 0.2),
+      arriba: (t) => (0.17 + 0.02 * campana(t, 0.1, 0.3)) * remate(t, 0.3),
+      abajo: (t) => (0.24 + 0.17 * campana(t, 0.42, 0.5) + 0.05 * campana(t, 0.92, 0.25)) * remate(t, 0.42),
+      lado: (t) => (0.27 + 0.02 * campana(t, 0.15, 0.3) - 0.02 * campana(t, 0.75, 0.3)) * remate(t, 0.4),
+    });
+    p.push(pinta(torso, R.pelaje));
+    // Huesos de cadera marcados (lo huesudo de una vaca real).
+    for (const dz of [0.16, -0.16]) {
+      const hueso = new THREE.SphereGeometry(0.07, 9, 7);
+      poner(hueso, [-0.52, 1.0, dz], [0, 0, 0], [1.15, 0.75, 0.75]);
+      p.push(pinta(hueso, variar(R.pelaje, r, 0.04)));
+    }
+
+    // ── Cuello macizo y CORTO del pecho al pivote de la cabeza (las manchas
+    //    pintadas continúan del torso al cuello sin costura) ──
+    const cuello = new THREE.CylinderGeometry(0.13, 0.23, 0.42, 10, 3);
+    apuntar(cuello, [0.66, 0.94, 0], [0.66, 0.5, 0], [1, 1, 0.7]);
+    p.push(pinta(cuello, R.pelaje));
+
+    // ── Giba y papada (cebú); papada leve en la criolla ──
+    if (R.giba) {
+      const giba = new THREE.SphereGeometry(0.14, 10, 8);
+      poner(giba, [0.4, 1.12, 0], [0, 0, 0.15], [0.9, 1.1, 0.7]);
+      p.push(pintarPlano(giba, variar(R.pelaje, r, 0.05)));
+    }
+    if (R.papada) {
+      const papada = new THREE.CapsuleGeometry(0.06, R.giba ? 0.44 : 0.3, 4, 8);
+      apuntar(papada, [0.62, 0.6, 0], [0.45, -1, 0], [1, 1, 0.45]);
+      p.push(pintarPlano(papada, variar(R.pelaje, r, 0.06)));
+    }
+
+    // ── Patas nacidas de la masa (muslo→caña→pezuña, con jitter) ──
+    for (const [px, pz, atras] of /** @type {[number, number, boolean][]} */ ([[0.44, 0.17, false], [0.44, -0.17, false], [-0.46, 0.18, true], [-0.46, -0.18, true]])) {
+      pataCuadrupedo(p, {
+        x: px, z: pz, yCadera: 0.72, rMuslo: 0.1, rCana: 0.046,
+        pelaje: R.pelaje, pezuna: '#3c352d', r, atras, pintor: pinta,
+      });
+    }
+
+    // ── Ubre con tetillas (la seña de la lechera) ──
+    if (ubre) {
+      const bolsa = new THREE.SphereGeometry(0.155, 11, 9);
+      poner(bolsa, [-0.28, 0.52, 0], [0, 0, 0], [1.2, 0.95, 1.0]);
+      p.push(pintarPlano(bolsa, R.ubre));
+      for (const [tx, tz] of [[-0.2, 0.07], [-0.2, -0.07], [-0.37, 0.07], [-0.37, -0.07]]) {
+        const teta = new THREE.CylinderGeometry(0.016, 0.021, 0.09, 6, 1);
+        poner(teta, [tx, 0.42, tz]);
+        p.push(pintarPlano(teta, variar(R.ubre, r, 0.06)));
+      }
+    }
+
+    // ── Cola con borla ──
+    const cola = new THREE.CylinderGeometry(0.015, 0.028, 0.52, 6, 2);
+    apuntar(cola, [-0.66, 0.82, 0.02], [-0.2, -1, 0.08]);
+    p.push(pintarPlano(cola, variar(R.pelaje, r, 0.05)));
+    const borla = new THREE.ConeGeometry(0.032, 0.1, 6, 1);
+    apuntar(borla, [-0.75, 0.56, 0.05], [-0.2, -1, 0.08]);
+    p.push(pintarPlano(borla, R.manchas || '#3c352d'));
+
+    const cuerpo = hornearPelaje(fusionarHato(p, `vaca-${raza}`), {
+      yBajo: 0.04, yAlto: 1.0, ao: 0.42, moteado: 0.06, semilla: seed,
+    });
+
+    // ── La CABEZA (local al pivote del cuello): cráneo ancho, testuz recta,
+    //    morro REDONDEADO — la cabeza de vaca, no una pelota con un tubo ──
+    const c = [];
+    const pintaCara = R.manchas
+      ? (g, col) => pintarManchas(g, col, R.manchas, { escala: 2.4, umbral: 0.55, semilla: seed + 11 })
+      : (g, col) => pintarPlano(g, col);
+    const craneo = new THREE.SphereGeometry(0.15, 13, 11);
+    poner(craneo, [0.06, 0.0, 0], [0, 0, -0.1], [1.25, 1.02, 0.82]);
+    c.push(pintaCara(craneo, R.pelaje));
+    const testuz = new THREE.SphereGeometry(0.115, 11, 9);
+    poner(testuz, [0.24, -0.06, 0], [0, 0, -0.35], [1.35, 0.85, 0.72]);
+    c.push(pintaCara(testuz, R.pelaje));
+    const morro = new THREE.SphereGeometry(0.098, 11, 9);
+    poner(morro, [0.37, -0.115, 0], [0, 0, -0.3], [1.05, 0.75, 0.8]);
+    c.push(pintarPlano(morro, R.hocico));
+    for (const oz of [0.045, -0.045]) {
+      const ollar = new THREE.SphereGeometry(0.015, 6, 5);
+      poner(ollar, [0.43, -0.1, oz], [0, 0, 0], [1, 0.65, 1]);
+      c.push(pintarPlano(ollar, '#2c2521'));
+    }
+    for (const oz of [0.108, -0.108]) {
+      const ojo = new THREE.SphereGeometry(0.024, 7, 6);
+      poner(ojo, [0.14, 0.045, oz]);
+      c.push(pintarPlano(ojo, '#241d18'));
+    }
+    // Orejas de pétalo: horizontales y ligeramente caídas (grandes en el cebú).
+    // En la holstein van del color de la mancha de cabeza — la clásica.
+    const caida = R.orejas === 'caida';
+    const colorOreja = R.manchas ? variar(R.manchas, r, 0.08) : variar(R.pelaje, r, 0.07);
+    for (const lado of [1, -1]) {
+      const oreja = orejaPetalo(
+        [0.0, caida ? 0.04 : 0.06, lado * 0.125],
+        caida ? [0.1, -0.55, lado * 0.85] : [0.02, -0.12, lado],
+        caida ? 0.2 : 0.14,
+        caida ? 0.1 : 0.085,
+        0.28,
+      );
+      c.push(pintarPlano(oreja, colorOreja));
+    }
+    if (escCuerno > 0.2) {
+      for (const lado of [1, -1]) {
+        const cuerno1 = brote([0.0, 0.115, lado * 0.065], [-0.08, 0.9, lado * 0.5], 0.024, 0.16 * escCuerno, 1, 6);
+        c.push(pintarPlano(cuerno1, '#d9cdb2'));
+      }
+    }
+    const cabeza = hornearPelaje(fusionarHato(c, `cabeza-vaca-${raza}`), {
+      yBajo: -0.2, yAlto: 0.15, ao: 0.3, moteado: 0.05, semilla: seed + 3,
+    });
+
+    return { cuerpo, cabeza, pivote: [0.82, 1.08, 0] };
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  CERDO — por RAZA (pedido explícito: que se distingan)                      */
+/* -------------------------------------------------------------------------- */
+
+export const RAZAS_CERDO = {
+  zungo: {
+    pelaje: '#2e2926', trompa: '#4c423c', panza: 1.35, largo: 0.95,
+    orejas: 'caida', arco: 0, jamon: 1, manchas: null, calcetin: null,
+  },
+  sanpedreno: {
+    pelaje: '#332b26', trompa: '#c9a58e', panza: 1.15, largo: 0.98,
+    orejas: 'caida', arco: 0, jamon: 1, manchas: null, calcetin: '#d8cec0',
+  },
+  duroc: {
+    pelaje: '#8e4a2b', trompa: '#7c4630', panza: 1, largo: 1.02,
+    orejas: 'gacha', arco: 1, jamon: 1.08, manchas: null, calcetin: null,
+  },
+  landrace: {
+    pelaje: '#e5b6a3', trompa: '#d89a88', panza: 1.05, largo: 1.24,
+    orejas: 'tapaojos', arco: 0, jamon: 1, manchas: null, calcetin: null,
+  },
+  pietrain: {
+    pelaje: '#e4ded3', trompa: '#cfa290', panza: 0.95, largo: 1.0,
+    orejas: 'parada', arco: 0, jamon: 1.28, manchas: '#37312d', calcetin: null,
+  },
+};
+
+/**
+ * El cerdo por raza. Mira a +X, patas en y=0, lomo a ~0.62.
+ * @returns {{cuerpo: THREE.BufferGeometry, cabeza: THREE.BufferGeometry, pivote: [number,number,number]}}
+ */
+export function geomCerdo({ raza = 'zungo', q = 1 } = {}, seed = 31) {
+  return memo(`cerdo|${raza}|${q}|${seed}`, () => {
+    const R = RAZAS_CERDO[raza] || RAZAS_CERDO.zungo;
+    const r = rng(seed);
+    const L = R.largo;
+    const p = [];
+    const nSeg = Math.max(13, Math.round(17 * q));
+    const nRad = Math.max(11, Math.round(14 * q));
+    const pinta = R.manchas
+      ? (g, c) => pintarManchas(g, c, R.manchas, { escala: 2.4, umbral: 0.6, semilla: seed })
+      : (g, c) => pintarPlano(g, c);
+
+    // ── El torso cilíndrico-macizo del cerdo: lomo casi recto (arqueado en el
+    //    duroc), panza que en el zungo casi barre el piso, jamones atrás ──
+    const torso = cuerpoOrganico({
+      largo: 0.92 * L,
+      nSeg,
+      nRad,
+      semilla: seed,
+      ruido: 0.02,
+      espina: (t) => 0.42 + (R.arco ? 0.05 * campana(t, 0.5, 0.5) : 0.012 * campana(t, 0.55, 0.45)),
+      arriba: (t) => (0.155 + 0.012 * campana(t, 0.45, 0.4)) * remate(t, 0.42),
+      abajo: (t) => (0.17 + 0.1 * R.panza * campana(t, 0.48, 0.52)) * remate(t, 0.48),
+      lado: (t) => (0.185 + 0.02 * campana(t, 0.2, 0.35)) * remate(t, 0.5),
+    });
+    p.push(pinta(torso, R.pelaje));
+    for (const lado of [1, -1]) {
+      const jamon = new THREE.SphereGeometry(0.145 * R.jamon, 11, 9);
+      poner(jamon, [-0.32 * L, 0.4, lado * 0.09], [0, 0, 0.1], [1.05, 1.15, 0.85]);
+      p.push(pinta(jamon, variar(R.pelaje, r, 0.05)));
+      const paleta = new THREE.SphereGeometry(0.115 * (R.jamon > 1.1 ? 1.15 : 1), 10, 8);
+      poner(paleta, [0.26 * L, 0.45, lado * 0.095], [0, 0, 0], [1, 1.1, 0.8]);
+      p.push(pinta(paleta, variar(R.pelaje, r, 0.05)));
+    }
+
+    // ── Patas cortas con pezuña (calcetines claros si la raza los trae) ──
+    for (const [px, pz, atras] of /** @type {[number, number, boolean][]} */ ([[0.28 * L, 0.12, false], [0.28 * L, -0.12, false], [-0.31 * L, 0.13, true], [-0.31 * L, -0.13, true]])) {
+      const j = () => (r() - 0.5) * 0.015;
+      const pata = new THREE.CylinderGeometry(0.052, 0.04, 0.24, 8, 1);
+      poner(pata, [px + j(), 0.15, pz + j()], [j() * 2, 0, (atras ? -0.04 : 0.03) + j() * 2]);
+      p.push(pintarPlano(pata, R.calcetin || variar(R.pelaje, r, 0.04)));
+      const pezuna = new THREE.CylinderGeometry(0.042, 0.048, 0.06, 7, 1);
+      poner(pezuna, [px, 0.03, pz]);
+      p.push(pintarPlano(pezuna, '#332c26'));
+    }
+
+    // ── La colita en tirabuzón, chiquita y pegada al jamón ──
+    const cola = new THREE.TorusGeometry(0.032, 0.011, 6, 12);
+    poner(cola, [-0.47 * L, 0.5, 0], [0.35, Math.PI / 2, 0.4]);
+    p.push(pintarPlano(cola, variar(R.pelaje, r, 0.06)));
+
+    const cuerpo = hornearPelaje(fusionarHato(p, `cerdo-${raza}`), {
+      yBajo: 0.02, yAlto: 0.58, ao: 0.4, moteado: 0.07, semilla: seed,
+    });
+
+    // ── CABEZA (pivote al frente): hocica el suelo ──
+    const c = [];
+    const craneo = new THREE.SphereGeometry(0.14, 12, 10);
+    poner(craneo, [0.06, -0.02, 0], [0, 0, -0.12], [1.28, 1, 0.92]);
+    c.push(pinta(craneo, R.pelaje));
+    const papadita = new THREE.SphereGeometry(0.088, 9, 8);
+    poner(papadita, [0.07, -0.115, 0], [0, 0, 0], [1.15, 0.7, 0.85]);
+    c.push(pintarPlano(papadita, variar(R.pelaje, r, 0.05)));
+    const trompa = new THREE.CylinderGeometry(0.058, 0.078, 0.16, 10, 2);
+    poner(trompa, [0.23, -0.06, 0], [0, 0, Math.PI / 2 + 0.22], [1, 1, 0.88]);
+    c.push(pintarPlano(trompa, R.pelaje));
+    // El disco del morro (la nariz de cerdo, inconfundible) + ollares.
+    const disco = new THREE.CylinderGeometry(0.06, 0.06, 0.032, 11, 1);
+    poner(disco, [0.315, -0.08, 0], [0, 0, Math.PI / 2 + 0.22]);
+    c.push(pintarPlano(disco, R.trompa));
+    for (const oz of [0.024, -0.024]) {
+      const ollar = new THREE.SphereGeometry(0.011, 5, 4);
+      poner(ollar, [0.333, -0.076, oz]);
+      c.push(pintarPlano(ollar, '#241f1b'));
+    }
+    for (const oz of [0.095, -0.095]) {
+      const ojo = new THREE.SphereGeometry(0.018, 6, 5);
+      poner(ojo, [0.125, 0.05, oz]);
+      c.push(pintarPlano(ojo, '#1f1a16'));
+    }
+    // Orejas de pétalo: la firma de cada raza.
+    const OREJAS = {
+      caida: { dir: (l) => [0.4, -0.45, l * 0.75], largo: 0.16, ancho: 0.1 },
+      gacha: { dir: (l) => [0.65, -0.2, l * 0.55], largo: 0.15, ancho: 0.095 },
+      tapaojos: { dir: (l) => [0.8, -0.5, l * 0.3], largo: 0.2, ancho: 0.13 },
+      parada: { dir: (l) => [0.15, 0.85, l * 0.45], largo: 0.13, ancho: 0.085 },
+    };
+    const O = OREJAS[R.orejas] || OREJAS.caida;
+    for (const lado of [1, -1]) {
+      const oreja = orejaPetalo([0.05, 0.09, lado * 0.09], O.dir(lado), O.largo, O.ancho, 0.3);
+      c.push(pintarPlano(oreja, variar(R.pelaje, r, 0.07)));
+    }
+    const cabeza = hornearPelaje(fusionarHato(c, `cabeza-cerdo-${raza}`), {
+      yBajo: -0.18, yAlto: 0.12, ao: 0.28, moteado: 0.06, semilla: seed + 3,
+    });
+
+    return { cuerpo, cabeza, pivote: [0.42 * L, 0.5, 0] };
+  });
+}
+
+/**
+ * Lechón: la cría en UNA sola malla (no pivota la cabeza — trota detrás de la
+ * marrana). Hereda el pelaje de su raza.
+ */
+export function geomLechon({ raza = 'landrace' } = {}, seed = 37) {
+  return memo(`lechon|${raza}|${seed}`, () => {
+    const R = RAZAS_CERDO[raza] || RAZAS_CERDO.landrace;
+    const r = rng(seed);
+    const p = [];
+    const torso = cuerpoOrganico({
+      largo: 0.3,
+      nSeg: 10,
+      nRad: 9,
+      semilla: seed,
+      ruido: 0.03,
+      espina: () => 0.155,
+      arriba: (t) => 0.07 * remate(t, 0.45),
+      abajo: (t) => (0.075 + 0.025 * campana(t, 0.5, 0.5)) * remate(t, 0.5),
+      lado: (t) => 0.068 * remate(t, 0.5),
+    });
+    p.push(pintarPlano(torso, variar(R.pelaje, r, 0.05)));
+    const cabeza = new THREE.SphereGeometry(0.058, 10, 8);
+    poner(cabeza, [0.155, 0.165, 0], [0, 0, -0.15], [1.2, 1, 0.9]);
+    p.push(pintarPlano(cabeza, R.pelaje));
+    const trompita = new THREE.CylinderGeometry(0.024, 0.03, 0.05, 8, 1);
+    poner(trompita, [0.215, 0.15, 0], [0, 0, Math.PI / 2 + 0.2]);
+    p.push(pintarPlano(trompita, R.trompa));
+    for (const lado of [1, -1]) {
+      const oreja = orejaPetalo([0.17, 0.2, lado * 0.035], [0.35, 0.3, lado * 0.7], 0.05, 0.034, 0.3);
+      p.push(pintarPlano(oreja, variar(R.pelaje, r, 0.08)));
+      for (const px of [0.1, -0.09]) {
+        const pata = new THREE.CylinderGeometry(0.017, 0.014, 0.1, 6, 1);
+        poner(pata, [px + (r() - 0.5) * 0.012, 0.05, lado * 0.045]);
+        p.push(pintarPlano(pata, variar(R.pelaje, r, 0.05)));
+      }
+    }
+    const colita = new THREE.TorusGeometry(0.015, 0.005, 5, 9);
+    poner(colita, [-0.16, 0.18, 0], [0.3, Math.PI / 2, 0]);
+    p.push(pintarPlano(colita, R.pelaje));
+    return hornearPelaje(fusionarHato(p, `lechon-${raza}`), {
+      yBajo: 0.01, yAlto: 0.24, ao: 0.35, moteado: 0.06, semilla: seed,
+    });
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  GALLINA / GALLO                                                            */
+/* -------------------------------------------------------------------------- */
+
+export const TIPOS_GALLINA = {
+  campesina: { plumas: '#9a5a2e', pecho: '#7c4524', cola: '#5e3a20', cresta: 0.8, gallo: false },
+  negra: { plumas: '#2c2825', pecho: '#3a332e', cola: '#232019', cresta: 0.8, gallo: false },
+  blanca: { plumas: '#e9e3d4', pecho: '#ddd5c2', cola: '#cfc6b0', cresta: 0.9, gallo: false },
+  gallo: { plumas: '#a34f22', pecho: '#3a2c20', cola: '#1f3a2c', cresta: 1.15, gallo: true },
+};
+
+/**
+ * Gallina de verdad: pechuga baja, rabadilla alzada, abanico de cola, alas
+ * plegadas, cresta y barbillas. El gallo lleva cola verde tornasol en hoz.
+ * Mira a +X. @returns {{cuerpo, cabeza, pivote}}
+ */
+export function geomGallina({ tipo = 'campesina', q = 1 } = {}, seed = 41) {
+  return memo(`gallina|${tipo}|${q}|${seed}`, () => {
+    const T = TIPOS_GALLINA[tipo] || TIPOS_GALLINA.campesina;
+    const r = rng(seed);
+    const p = [];
+
+    // Cuerpo en gota: pechuga adelante-abajo, rabadilla arriba-atrás — un loft
+    // inclinado, no una esfera escalada.
+    const alza = T.gallo ? 0.05 : 0; // el gallo anda más erguido que las gallinas
+    const torso = cuerpoOrganico({
+      largo: 0.4,
+      nSeg: 12,
+      nRad: 11,
+      semilla: seed,
+      ruido: 0.035,
+      espina: (t) => 0.22 + alza + 0.14 * (1 - t) - 0.03 * campana(t, 0.7, 0.4),
+      arriba: (t) => (0.1 + 0.03 * campana(t, 0.35, 0.5)) * remate(t, 0.35),
+      abajo: (t) => (0.09 + 0.075 * campana(t, 0.62, 0.45)) * remate(t, 0.4),
+      lado: (t) => (0.105 + 0.01 * campana(t, 0.5, 0.4)) * remate(t, 0.4),
+    });
+    p.push(pintarPlano(torso, T.plumas));
+    const pechuga = new THREE.SphereGeometry(0.095, 10, 8);
+    poner(pechuga, [0.1, 0.2, 0], [0, 0, 0.3], [1.1, 1, 0.8]);
+    p.push(pintarPlano(pechuga, T.pecho));
+    // Alas plegadas HUNDIDAS en el flanco (parche de pluma, no globo aparte).
+    for (const lado of [1, -1]) {
+      const ala = new THREE.SphereGeometry(0.1, 10, 8);
+      poner(ala, [-0.03, 0.28, lado * 0.082], [0.15 * lado, 0, 0.55], [1.3, 0.62, 0.26]);
+      p.push(pintarPlano(ala, variar(T.plumas, r, 0.1)));
+    }
+    // La cola: la gallina un abanico corto alzado; el gallo HOCES que arquean
+    // de verdad — cadena de 3 tramos encadenados punta-a-base, cada uno girando
+    // hacia abajo (la curva de la pluma, no una cuchilla recta).
+    if (T.gallo) {
+      // Base: abanico corto de pluma oscura en la rabadilla (masa de cola).
+      for (let i = 0; i < 3; i++) {
+        const abre = (i - 1) * 0.3;
+        const pluma = brote([-0.14, 0.42, 0], [-0.8, 0.65, abre * 0.5], 0.05, 0.16, 0.3, 5);
+        p.push(pintarPlano(pluma, variar('#4a2c18', r, 0.12)));
+      }
+      // Las HOCES: arcos de toro finos (curva LISA — la pluma que sube y cae),
+      // cada una con su radio y su apertura lateral.
+      const nHoces = 4;
+      for (let i = 0; i < nHoces; i++) {
+        const abre = (i - (nHoces - 1) / 2) * 0.5;
+        const radio = 0.13 + (1 - Math.abs(abre)) * 0.05 + r() * 0.015;
+        const hoz = new THREE.TorusGeometry(radio, 0.013, 6, 14, Math.PI * 0.85);
+        // El arco vive en el plano XY; se planta en la rabadilla, girado para
+        // que suba por detrás y caiga, con apertura lateral por pluma.
+        poner(
+          hoz,
+          [-0.16, 0.3 + radio * 0.35, abre * 0.05],
+          [abre * 0.55, abre * 0.35, 0.55 - Math.abs(abre) * 0.2],
+        );
+        p.push(pintarPlano(hoz, variar(T.cola, r, 0.16)));
+      }
+    } else {
+      for (let i = 0; i < 3; i++) {
+        const abre = (i - 1) * 0.32;
+        const largo = 0.22 * (1 - Math.abs(abre) * 0.35);
+        const pluma = brote([-0.16, 0.37, 0], [-0.85, 0.75, abre * 0.5], 0.058, largo, 0.28, 5);
+        p.push(pintarPlano(pluma, variar(T.cola, r, 0.14)));
+      }
+    }
+    // Muslos emplumados + patas + dedos.
+    for (const lado of [1, -1]) {
+      const muslo = new THREE.SphereGeometry(0.055, 8, 7);
+      poner(muslo, [0.02, 0.16, lado * 0.055]);
+      p.push(pintarPlano(muslo, variar(T.plumas, r, 0.08)));
+      const pata = new THREE.CylinderGeometry(0.011, 0.013, 0.13, 6, 1);
+      poner(pata, [0.03 + (r() - 0.5) * 0.01, 0.065, lado * 0.05]);
+      p.push(pintarPlano(pata, '#caa03c'));
+      if (q > 0.5) {
+        for (const dd of [-0.35, 0, 0.35]) {
+          const dedo = brote([0.03, 0.008, lado * 0.05], [1, 0.05, dd], 0.008, 0.05, 1, 4);
+          p.push(pintarPlano(dedo, '#caa03c'));
+        }
+      }
+    }
+
+    const cuerpo = hornearPelaje(fusionarHato(p, `gallina-${tipo}`), {
+      yBajo: 0.02, yAlto: 0.4, ao: 0.32, moteado: 0.09, semilla: seed,
+    });
+
+    // ── CABEZA + CUELLO (pivotan juntos: el picoteo) ──
+    const c = [];
+    const cuello = new THREE.CylinderGeometry(0.036, 0.055, 0.17, 9, 2);
+    apuntar(cuello, [0.035, 0.075, 0], [0.45, 1, 0]);
+    c.push(pintarPlano(cuello, T.plumas));
+    const cabeza = new THREE.SphereGeometry(0.065, 10, 8);
+    poner(cabeza, [0.085, 0.16, 0], [0, 0, -0.1], [1.15, 1, 0.85]);
+    c.push(pintarPlano(cabeza, T.plumas));
+    const pico = brote([0.14, 0.15, 0], [1, -0.12, 0], 0.019, 0.065, 1, 5);
+    c.push(pintarPlano(pico, '#d8a03c'));
+    // Cresta dentada (2-3 pinchos) + barbillas colgantes.
+    const nCresta = T.gallo ? 3 : 2;
+    for (let i = 0; i < nCresta; i++) {
+      const pincho = brote(
+        [0.055 + i * 0.035, 0.213, 0],
+        [0.15 - i * 0.15, 1, 0],
+        0.02 * T.cresta,
+        0.055 * T.cresta,
+        0.5,
+        5,
+      );
+      c.push(pintarPlano(pincho, '#c8352a'));
+    }
+    for (const lado of [1, -1]) {
+      const barbilla = new THREE.SphereGeometry(0.019 * T.cresta, 6, 5);
+      poner(barbilla, [0.115, 0.1, lado * 0.018], [0, 0, 0], [1, 1.45, 0.65]);
+      c.push(pintarPlano(barbilla, '#c8352a'));
+      const ojo = new THREE.SphereGeometry(0.013, 5, 4);
+      poner(ojo, [0.1, 0.17, lado * 0.052]);
+      c.push(pintarPlano(ojo, '#1f1a14'));
+    }
+    const cabezaGeo = hornearPelaje(fusionarHato(c, `cabeza-gallina-${tipo}`), {
+      yBajo: -0.02, yAlto: 0.2, ao: 0.22, moteado: 0.07, semilla: seed + 3,
+    });
+
+    return { cuerpo, cabeza: cabezaGeo, pivote: [0.11, 0.3 + alza, 0] };
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  PERRO criollo                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * El perro criollo amarillo que no falta en ninguna finca: pecho hondo,
+ * cintura recogida, orejas a media asta y la cola enroscada sobre el lomo.
+ * Mira a +X. @returns {{cuerpo, cabeza, pivote}}
+ */
+export function geomPerro({ q = 1 } = {}, seed = 51) {
+  return memo(`perro|${q}|${seed}`, () => {
+    const PELAJE = '#c08b4d';
+    const CREMA = '#e2c9a0';
+    const r = rng(seed);
+    const p = [];
+    const nSeg = Math.max(11, Math.round(15 * q));
+    const nRad = Math.max(10, Math.round(12 * q));
+
+    // Torso HORIZONTAL de perro flaco de finca: pecho hondo tras los hombros,
+    // cintura recogida, grupa que cae apenas.
+    const torso = cuerpoOrganico({
+      largo: 0.6,
+      nSeg,
+      nRad,
+      semilla: seed,
+      ruido: 0.025,
+      espina: (t) => 0.37 + 0.035 * campana(t, 0.82, 0.35) - 0.008 * campana(t, 0.3, 0.35),
+      arriba: (t) => (0.08 + 0.015 * campana(t, 0.8, 0.35)) * remate(t, 0.42),
+      abajo: (t) => (0.065 + 0.085 * campana(t, 0.72, 0.4) - 0.015 * campana(t, 0.22, 0.28)) * remate(t, 0.48),
+      lado: (t) => (0.09 + 0.018 * campana(t, 0.78, 0.35)) * remate(t, 0.48),
+    });
+    p.push(pintarPlano(torso, PELAJE));
+    // Pechera crema HUNDIDA en el pecho (parche de pelo, no una pelota).
+    const pechera = new THREE.SphereGeometry(0.062, 9, 7);
+    poner(pechera, [0.27, 0.31, 0], [0, 0, 0.5], [0.75, 1.05, 0.62]);
+    p.push(pintarPlano(pechera, CREMA));
+    const anca = new THREE.SphereGeometry(0.08, 10, 8);
+    poner(anca, [-0.2, 0.37, 0], [0, 0, 0.15], [1, 1.02, 0.82]);
+    p.push(pintarPlano(anca, variar(PELAJE, r, 0.05)));
+    // Patas finas y CONECTADAS: la caña nace DENTRO del muslo (solapadas),
+    // nada de huesos partidos con tapa a la vista.
+    for (const [px, pz, atras] of /** @type {[number, number, boolean][]} */ ([[0.21, 0.06, false], [0.21, -0.06, false], [-0.19, 0.07, true], [-0.19, -0.07, true]])) {
+      const j = () => (r() - 0.5) * 0.012;
+      const dx = px + j();
+      const dz = pz + j();
+      const muslo = new THREE.CylinderGeometry(0.046, 0.023, 0.22, 7, 1);
+      poner(muslo, [dx, 0.26, dz], [0, 0, (atras ? -0.09 : 0.04) + j() * 3]);
+      p.push(pintarPlano(muslo, variar(PELAJE, r, 0.06)));
+      const bajaX = dx + (atras ? -0.021 : 0.009);
+      const cana = new THREE.CylinderGeometry(0.02, 0.017, 0.17, 6, 1);
+      poner(cana, [bajaX, 0.1, dz], [0, 0, j() * 2]);
+      p.push(pintarPlano(cana, variar(PELAJE, r, 0.07)));
+      const garra = new THREE.SphereGeometry(0.024, 7, 5);
+      poner(garra, [bajaX + 0.012, 0.02, dz], [0, 0, 0], [1.3, 0.65, 1]);
+      p.push(pintarPlano(garra, CREMA));
+    }
+    // La cola del criollo: ARCO carnoso enroscado sobre el lomo.
+    const cola = new THREE.TorusGeometry(0.088, 0.024, 7, 12, Math.PI * 1.2);
+    poner(cola, [-0.27, 0.47, 0.03], [0.35, 0.3, -0.6]);
+    p.push(pintarPlano(cola, variar(PELAJE, r, 0.05)));
+    // Cuello corto y macizo que sube al pivote.
+    const cuello = new THREE.CylinderGeometry(0.06, 0.095, 0.17, 9, 2);
+    apuntar(cuello, [0.28, 0.44, 0], [0.75, 0.65, 0], [1, 1, 0.82]);
+    p.push(pintarPlano(cuello, PELAJE));
+
+    const cuerpo = hornearPelaje(fusionarHato(p, 'perro'), {
+      yBajo: 0.015, yAlto: 0.46, ao: 0.36, moteado: 0.07, semilla: seed,
+    });
+
+    // ── CABEZA (pivote: mira/ladea): cráneo redondo, hocico que AFINA, orejas
+    //    de pétalo a media asta — perro criollo, no zorro de palo ──
+    const c = [];
+    const craneo = new THREE.SphereGeometry(0.088, 11, 9);
+    poner(craneo, [0.02, 0.01, 0], [0, 0, -0.08], [1.15, 0.98, 0.86]);
+    c.push(pintarPlano(craneo, PELAJE));
+    // Hocico LARGO que afina — perro criollo, no osezno.
+    const hocico = new THREE.SphereGeometry(0.05, 9, 7);
+    poner(hocico, [0.14, -0.025, 0], [0, 0, -0.3], [1.7, 0.68, 0.66]);
+    c.push(pintarPlano(hocico, variar(PELAJE, r, 0.08)));
+    const nariz = new THREE.SphereGeometry(0.018, 6, 5);
+    poner(nariz, [0.215, -0.012, 0]);
+    c.push(pintarPlano(nariz, '#241d18'));
+    for (const lado of [1, -1]) {
+      // Orejas a media asta que CAEN a los lados (la punta quebrada del criollo).
+      const oreja = orejaPetalo([0.0, 0.068, lado * 0.055], [-0.08, 0.28, lado * 0.95], 0.105, 0.06, 0.3);
+      c.push(pintarPlano(oreja, variar('#8a5f33', r, 0.06)));
+      const ojo = new THREE.SphereGeometry(0.014, 5, 4);
+      poner(ojo, [0.085, 0.033, lado * 0.052]);
+      c.push(pintarPlano(ojo, '#1f1a14'));
+    }
+    const cabeza = hornearPelaje(fusionarHato(c, 'cabeza-perro'), {
+      yBajo: -0.1, yAlto: 0.1, ao: 0.25, moteado: 0.06, semilla: seed + 3,
+    });
+
+    return { cuerpo, cabeza, pivote: [0.38, 0.55, 0] };
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  OVEJA criolla                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Oveja criolla: vellón crema por MECHONES (matojos deformados con ruido — lana
+ * de verdad, no una bola), cara y patas oscuras, copete. Mira a +X.
+ * @returns {{cuerpo, cabeza, pivote}}
+ */
+export function geomOveja({ q = 1 } = {}, seed = 61) {
+  return memo(`oveja|${q}|${seed}`, () => {
+    const LANA = '#e9e4d6';
+    const OSCURO = '#4a4038';
+    const r = rng(seed);
+    const p = [];
+
+    // La masa del vellón: un loft rechoncho…
+    const torso = cuerpoOrganico({
+      largo: 0.62,
+      nSeg: 12,
+      nRad: 10,
+      semilla: seed,
+      ruido: 0.06,
+      espina: (t) => 0.46 + 0.02 * campana(t, 0.3, 0.4),
+      arriba: (t) => (0.19 + 0.02 * campana(t, 0.4, 0.5)) * remate(t, 0.45),
+      abajo: (t) => (0.17 + 0.03 * campana(t, 0.5, 0.5)) * remate(t, 0.5),
+      lado: (t) => 0.2 * remate(t, 0.5),
+    });
+    p.push(pintarPlano(torso, LANA));
+    // …más MECHONES SUAVES que rompen la silueta (deterministas por seed).
+    const nBorlas = Math.max(5, Math.round(9 * q));
+    for (let i = 0; i < nBorlas; i++) {
+      const ang = (i / nBorlas) * Math.PI * 2 + r() * 0.6;
+      const borla = mechonLana(0.09 + r() * 0.05, seed + i * 3, 0.28);
+      poner(borla, [
+        Math.cos(ang) * (0.2 + r() * 0.08),
+        0.5 + (r() - 0.4) * 0.14,
+        Math.sin(ang) * (0.13 + r() * 0.05),
+      ]);
+      p.push(pintarPlano(borla, variar(LANA, r, 0.07)));
+    }
+    for (const [px, pz] of [[0.18, 0.09], [0.18, -0.09], [-0.18, 0.1], [-0.18, -0.1]]) {
+      const j = (r() - 0.5) * 0.015;
+      const pata = new THREE.CylinderGeometry(0.026, 0.028, 0.3, 6, 1);
+      poner(pata, [px + j, 0.15, pz + j], [0, 0, j * 4]);
+      p.push(pintarPlano(pata, OSCURO));
+    }
+    const colita = new THREE.ConeGeometry(0.042, 0.13, 6, 1);
+    apuntar(colita, [-0.34, 0.44, 0], [-0.5, -1, 0]);
+    p.push(pintarPlano(colita, variar(LANA, r, 0.06)));
+
+    const cuerpo = hornearPelaje(fusionarHato(p, 'oveja'), {
+      yBajo: 0.03, yAlto: 0.62, ao: 0.4, moteado: 0.08, semilla: seed,
+    });
+
+    const c = [];
+    const cara = new THREE.SphereGeometry(0.088, 10, 8);
+    poner(cara, [0.05, -0.01, 0], [0, 0, -0.15], [1.25, 1, 0.8]);
+    c.push(pintarPlano(cara, OSCURO));
+    const copete = mechonLana(0.06, seed + 7, 0.28);
+    poner(copete, [0.0, 0.07, 0], [0, 0, 0], [1.15, 0.8, 1.05]);
+    c.push(pintarPlano(copete, LANA));
+    for (const lado of [1, -1]) {
+      const oreja = orejaPetalo([0.02, 0.03, lado * 0.07], [0.12, -0.2, lado], 0.085, 0.05, 0.3);
+      c.push(pintarPlano(oreja, variar(OSCURO, r, 0.08)));
+      const ojo = new THREE.SphereGeometry(0.014, 5, 4);
+      poner(ojo, [0.1, 0.025, lado * 0.058]);
+      c.push(pintarPlano(ojo, '#171310'));
+    }
+    const cabeza = hornearPelaje(fusionarHato(c, 'cabeza-oveja'), {
+      yBajo: -0.08, yAlto: 0.1, ao: 0.25, moteado: 0.06, semilla: seed + 3,
+    });
+
+    return { cuerpo, cabeza, pivote: [0.32, 0.5, 0] };
+  });
+}


### PR DESCRIPTION
## Qué cambió
Los animales del corral (rechazados por el operador: "formas muy geométricas, aún no parecen animales reales") se rehicieron desde la silueta: torso como loft orgánico (espina curva, cruz, grupa, panza descolgada), AO+luz de cielo+moteado horneados en vertexColors, manchas de capa pintadas por ruido (no esferas pegadas), material propio del hato SIN flatShading (la arboleda conserva MATERIAL_FINCA intacto), razas reales (Holstein mocha con ubre + ternera criolla, zungo/duroc/landrace + lechones, ovejas con vellón blando distinto por seed, gallinas + gallo de hoces en arco, perro criollo de cola enroscada).

## Cómo se ve
Verificado por captura de cerca en 6 encuadres, antes/después, con el arnés `scripts/diag/hato.html` + `shot-hato.mjs` (chromium+swiftshader). La vaca lee Holstein a primera vista, los cerdos se distinguen por raza, el gallo tiene cola de gallo fino. El valle completo monta sin errores. `build:prod` verde, `tsc:check` 0 errores.

## Qué falta (juicio honesto)
- El **perro** es el más débil del lote: ya lee perro (hocico largo, orejas caídas, cola enroscada) pero de espaldas conserva un aire rígido de madera; una pasada más de grupa/hombros lo cerraría.
- La **ternera criolla** de frente roza lo equino; de perfil funciona.
- El quiebre muslo→caña en patas finas (perro) muestra la juntura si se mira a menos de ~1m de escena.
- La cresta del gallo sigue siendo 3 conos — funciona a distancia de valle, no en primerísimo plano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)