### PR TITLE
art(bosque): el frailejón deja de ser una escoba — roseta afelpada + hábito

### DIFF
--- a/src/visual/mundo3d/bosque/floraParamo.geom.js
+++ b/src/visual/mundo3d/bosque/floraParamo.geom.js
@@ -78,9 +78,11 @@ export const calidadDeTier = (tier) => CALIDAD_TIER[tier] ?? CALIDAD_TIER.medio;
 export const PAL = {
   // Frailejón
   frailejonTronco: '#6f5c40', // tallo bajo la enagua
-  frailejonSeco: '#8a7350', // hojas muertas de la enagua (marcescentes)
-  frailejonPlata: '#bcc6ac', // roseta plateada peluda (la firma)
-  frailejonCorazon: '#cfd7c6', // centro velloso del cogollo
+  frailejonSeco: '#907753', // hojas muertas de la enagua (marcescentes) — pajizo
+  frailejonSeco2: '#6a5232', // marcescentes más oscuras/curtidas (variedad)
+  frailejonPlata: '#cfd4c7', // roseta: centro joven, tomento MÁS blanco (la firma)
+  frailejonPlata2: '#b0ba9c', // hojas externas: plateado-salvia más apagado
+  frailejonCorazon: '#dde2d6', // cogollo velloso central (el punto más pálido)
   frailejonFlor: '#e0c24a', // capítulos amarillos
   frailejonTallo: '#95a06a', // escapo floral
 
@@ -220,73 +222,111 @@ function variar(base, r, amt = 0.06) {
 /* -------------------------------------------------------------------------- */
 
 /*
- * Tallo columnar vestido con una ENAGUA de hojas muertas (marcescentes) que
- * cuelgan, coronado por una ROSETA de hojas lanceoladas plateadas y peludas que
- * apuntan hacia arriba y afuera en espiral (ángulo áureo). Esa roseta velluda
- * plateada es lo que lo hace inequívoco. Con `flor`, le nace un escapo con
- * capítulos amarillos.
+ * Silueta de MONJE: un tronco columnar VESTIDO de arriba abajo con la ENAGUA de
+ * hojas muertas (marcescentes) que cuelgan pegadas al tallo como un hábito —eso
+ * le da CUERPO, no es un palo—, coronado por la ROSETA plateada peluda: un
+ * penacho DENSO de hojas anchas, carnosas y afelpadas (tomento plateado, NO
+ * cerdas) en espiral áurea, más erguidas al centro y recostadas al borde. Esa
+ * roseta blanquecina afelpada + la falda de hojas secas es lo que lo hace
+ * inequívoco. Con `flor`, un escapo con capítulos amarillos asoma de la roseta.
  */
 export function geomFrailejon({ flor = false, q = 1 } = {}, seed = 1) {
   const r = rng(seed);
   const partes = [];
   const GOLDEN = Math.PI * (3 - Math.sqrt(5));
 
-  // 1) Tallo (mayormente oculto por la enagua).
-  const tronco = new THREE.CylinderGeometry(0.11, 0.14, 1.0, 7, 1);
-  poner(tronco, [0, 0.5, 0]);
+  // Frailejón erguido y solemne: columna alta (crece ~1cm/año, se lee vertical).
+  const Ht = 1.12 + r() * 0.55;
+  const cy = Ht + 0.05; // la roseta se posa como una cabeza sobre la columna
+
+  // 1) Tallo columnar — casi todo oculto por la enagua.
+  const tronco = new THREE.CylinderGeometry(0.12, 0.15, Ht, 7, 1);
+  poner(tronco, [0, Ht / 2, 0]);
   partes.push(pintar(tronco, PAL.frailejonTronco));
 
-  // 2) Enagua de hojas muertas: anillos de hojas que cuelgan hacia abajo-afuera.
-  const anillos = Math.max(2, Math.round(3 * q));
-  const porAnillo = Math.max(5, Math.round(7 * q));
+  // 2) ENAGUA de hojas muertas: el HÁBITO. Hojas anchas y secas que cuelgan casi
+  //    a plomo, pegadas al tronco y superpuestas como tejas, vistiendo la columna
+  //    entera (de la base a la roseta). Es lo que le da cuerpo de "fraile grande".
+  const anillos = Math.max(3, Math.round(6 * q));
+  const porAnillo = Math.max(6, Math.round(10 * q));
   for (let a = 0; a < anillos; a++) {
-    const y = 0.26 + a * (0.72 / anillos);
-    const rad = 0.15 - a * 0.02;
+    const f = a / anillos; // 0 base → 1 bajo la roseta
+    const y = 0.14 + f * (Ht - 0.1);
+    const rad = 0.15;
     for (let i = 0; i < porAnillo; i++) {
-      const ang = (i / porAnillo) * Math.PI * 2 + a * 0.5;
-      const hoja = new THREE.ConeGeometry(0.05, 0.34, 4, 1);
+      const ang = (i / porAnillo) * Math.PI * 2 + a * 0.6;
+      const largo = 0.30 + r() * 0.14;
+      // hoja seca ANCHA y aplanada (lámina, no púa), colgando casi vertical.
+      const hoja = new THREE.ConeGeometry(0.085, largo, 4, 1);
       apuntar(
         hoja,
         [Math.cos(ang) * rad, y, Math.sin(ang) * rad],
-        [Math.cos(ang) * 0.8, -0.7, Math.sin(ang) * 0.8],
-        [1, 1, 0.4],
+        [Math.cos(ang) * 0.3, -1, Math.sin(ang) * 0.3],
+        [1, 1, 0.42],
       );
-      partes.push(pintar(hoja, variar(PAL.frailejonSeco, r, 0.12)));
+      partes.push(pintar(hoja, variar(r() > 0.55 ? PAL.frailejonSeco : PAL.frailejonSeco2, r, 0.14)));
     }
   }
 
-  // 3) Roseta plateada: hojas lanceoladas hacia arriba-afuera, en espiral áurea.
-  const nRoseta = Math.max(8, Math.round(16 * q));
-  const cy = 0.98;
+  // 3) ROSETA plateada peluda — la FIRMA. Un COGOLLO afelpado, no una estrella:
+  //    hojas anchas, carnosas y GRUESAS (poco aplanadas) nacidas sobre una cúpula,
+  //    en espiral áurea, apenas abiertas (cuenco erguido, NO tendidas al ras), muy
+  //    densas y superpuestas → una bola velluda plateada. Las de afuera se recuestan
+  //    y agrisan (viejas); el centro es blanco y erguido (yema joven, tomento fresco).
+  const nRoseta = Math.max(18, Math.round(40 * q));
+  const plataInt = new THREE.Color(PAL.frailejonPlata);
+  const plataExt = new THREE.Color(PAL.frailejonPlata2);
   for (let i = 0; i < nRoseta; i++) {
-    const ang = i * GOLDEN;
-    const tilt = 0.72 + (i / nRoseta) * 0.5 + (r() - 0.5) * 0.12; // afuera al borde
+    const f = i / nRoseta; // 0 centro erguido → 1 borde recostado
+    const ang = i * GOLDEN + (r() - 0.5) * 0.18;
+    const posR = 0.03 + f * 0.11; // nacen sobre una cúpula, no de un punto
+    const posY = cy - f * 0.08; // las de afuera, más bajas → domo redondo
+    const tilt = 0.26 + f * 0.78 + (r() - 0.5) * 0.08; // cuenco: 15°→60°, sin aplanarse
     const s = Math.sin(tilt);
-    const hoja = new THREE.ConeGeometry(0.055, 0.52, 4, 1);
+    const largo = 0.28 + (1 - f) * 0.13 + r() * 0.05; // cortas y llenas, no lanzas
+    // hoja carnosa ANCHA y con CUERPO (poco aplanada) — nada de cerda fina.
+    const hoja = new THREE.ConeGeometry(0.115, largo, 4, 1);
     apuntar(
       hoja,
-      [Math.cos(ang) * 0.04, cy, Math.sin(ang) * 0.04],
+      [Math.cos(ang) * posR, posY, Math.sin(ang) * posR],
       [Math.cos(ang) * s, Math.cos(tilt), Math.sin(ang) * s],
-      [1, 1, 0.42],
+      [1, 1, 0.6],
     );
-    partes.push(pintar(hoja, variar(PAL.frailejonPlata, r, 0.08)));
+    const col = plataInt.clone().lerp(plataExt, f);
+    partes.push(pintar(hoja, variar(col, r, 0.05)));
   }
-  // Cogollo velloso en el centro.
-  const corazon = new THREE.IcosahedronGeometry(0.13, 0);
-  poner(corazon, [0, cy + 0.02, 0], [0, 0, 0], [1, 0.7, 1]);
+  // Corona interior: unas pocas hojas cortas y ERGUIDAS que tapan el centro y lo
+  // hacen leer como un cogollo lleno (sin hueco oscuro), del blanco más pálido.
+  const nCorona = Math.max(4, Math.round(7 * q));
+  for (let i = 0; i < nCorona; i++) {
+    const ang = i * GOLDEN + 1.3;
+    const tilt = 0.14 + r() * 0.12;
+    const s = Math.sin(tilt);
+    const hoja = new THREE.ConeGeometry(0.075, 0.20 + r() * 0.05, 4, 1);
+    apuntar(
+      hoja,
+      [Math.cos(ang) * 0.03, cy + 0.05, Math.sin(ang) * 0.03],
+      [Math.cos(ang) * s, Math.cos(tilt), Math.sin(ang) * s],
+      [1, 1, 0.7],
+    );
+    partes.push(pintar(hoja, variar(PAL.frailejonCorazon, r, 0.04)));
+  }
+  // Yema vellosa central (el punto más pálido, afelpado).
+  const corazon = new THREE.IcosahedronGeometry(0.09, 0);
+  poner(corazon, [0, cy + 0.11, 0], [0, 0, 0], [1, 0.9, 1]);
   partes.push(pintar(corazon, PAL.frailejonCorazon));
 
-  // 4) Escapo floral (solo en flor): tallo + capítulos amarillos.
+  // 4) Escapo floral (solo en flor): tallo + capítulos amarillos sobre la roseta.
   if (flor) {
-    const tallo = new THREE.CylinderGeometry(0.028, 0.04, 0.95, 5, 1);
-    poner(tallo, [0.05, 1.42, 0], [0, 0, 0.08]);
+    const tallo = new THREE.CylinderGeometry(0.028, 0.045, 0.9, 5, 1);
+    poner(tallo, [0.05, cy + 0.45, 0], [0, 0, 0.08]);
     partes.push(pintar(tallo, PAL.frailejonTallo));
     const nCap = Math.max(4, Math.round(7 * q));
     for (let i = 0; i < nCap; i++) {
       const ang = (i / nCap) * Math.PI * 2;
       const rad = 0.1 + r() * 0.06;
       const cap = new THREE.IcosahedronGeometry(0.055 + r() * 0.02, 0);
-      poner(cap, [0.08 + Math.cos(ang) * rad, 1.82 + r() * 0.1, Math.sin(ang) * rad], [0, 0, 0], [1, 0.7, 1]);
+      poner(cap, [0.08 + Math.cos(ang) * rad, cy + 0.85 + r() * 0.1, Math.sin(ang) * rad], [0, 0, 0], [1, 0.7, 1]);
       partes.push(pintar(cap, variar(PAL.frailejonFlor, r, 0.08)));
     }
   }


### PR DESCRIPTION
**Problema:** el frailejón (Espeletia, ícono del páramo) se leía como un palo con cerdas duras — "escoba".

**Cambio (`floraParamo.geom.js`, `geomFrailejon`):** la roseta pasa de conos-cerda finos a un cogollo DENSO de hojas anchas, carnosas y plateadas (tomento) en cuenco cupular + corona interior que tapa el hueco central; el tronco se viste con la enagua de hojas muertas colgando pegadas como un hábito de fraile. Paleta más plateada-blanca (menos verde). Sigue procedural, `fusionar` desindexado (sin null), vertexColors horneado, 1 draw-call por InstancedMesh.

**Prueba:** captura del frailejonar (abajo). `build:prod` verde, eslint verde. Solo toca el frailejón (Ent, fauna y subsuelo intactos).