### PR TITLE
feat(ent): cara y barba del Ent — mirada ámbar y barba de usnea

### DIFF
--- a/src/visual/mundo3d/bosque/EntQuenua.jsx
+++ b/src/visual/mundo3d/bosque/EntQuenua.jsx
@@ -35,6 +35,7 @@ import {
   factorHabla,
   factorSonrisa,
   specsBarba,
+  geometriaHebraBarba,
   BARBA,
   CORTEZA,
 } from './entQuenua.geom.js';
@@ -83,11 +84,64 @@ function ClusterHojas({ cluster, geo, mat, reducedMotion, fase }) {
   );
 }
 
+/* UN OJO del Ent (a nivel de módulo, no se crea en render): recoveco de sombra +
+   globo con iris ÁMBAR-MIEL grande que casi cubre el ojo (nada de pozo negro) +
+   pupila y dos chispas de húmedo + párpado inferior cálido. El blink escala solo
+   el globo; la mirada deriva en gazeRef. `flip` (-1/1) da una leve asimetría. */
+function Ojo({ x, frente, blinkRef, gazeRef, flip, matGrieta, matOjo, matIris, matBrillo, matCresta }) {
+  return (
+    <group position={[x, 0.02, frente - 0.02]}>
+      {/* recoveco de sombra donde SE ASIENTA el ojo (nudo de la corteza): marrón
+          muy oscuro, pequeño — el ojo lo llena casi todo, NO es un agujero negro */}
+      <mesh position={[0, -0.005, -0.02]} scale={[1.06, 1.14, 0.4]}>
+        <sphereGeometry args={[0.115, 12, 10]} />
+        <primitive object={matGrieta} attach="material" />
+      </mesh>
+      {/* el OJO que parpadea (globo + iris): el blink escala solo esto */}
+      <group ref={blinkRef}>
+        {/* globo oscuro: solo asoma como fino borde húmedo del ojo */}
+        <mesh position={[0, 0, 0.055]}>
+          <sphereGeometry args={[0.097, 16, 14]} />
+          <primitive object={matOjo} attach="material" />
+        </mesh>
+        {/* LA MIRADA: iris ÁMBAR-MIEL GRANDE que casi cubre el globo → el ojo se
+            lee CÁLIDO y vivo (no un pozo negro). Pupila y dos chispas de húmedo. */}
+        <group ref={gazeRef} position={[0, -0.004, 0.072]}>
+          <mesh>
+            <sphereGeometry args={[0.085, 18, 16]} />
+            <primitive object={matIris} attach="material" />
+          </mesh>
+          {/* pupila: pozo oscuro en el centro del iris */}
+          <mesh position={[0, 0, 0.046]}>
+            <sphereGeometry args={[0.038, 12, 10]} />
+            <primitive object={matGrieta} attach="material" />
+          </mesh>
+          {/* chispa mayor (catchlight): arriba a un lado — la vida del ojo */}
+          <mesh position={[0.028, 0.033, 0.064]}>
+            <sphereGeometry args={[0.014, 10, 10]} />
+            <primitive object={matBrillo} attach="material" />
+          </mesh>
+          {/* chispa menor abajo: el húmedo del ojo vivo (truco de animación) */}
+          <mesh position={[-0.022, -0.028, 0.06]}>
+            <sphereGeometry args={[0.006, 8, 8]} />
+            <primitive object={matBrillo} attach="material" />
+          </mesh>
+        </group>
+      </group>
+      {/* párpado inferior: reborde cálido y fino que asienta el ojo (edad, bondad) */}
+      <mesh position={[0, -0.082, 0.05]} rotation={[-0.28, 0, -flip * 0.14]} scale={[1.0, 0.36, 0.52]}>
+        <sphereGeometry args={[0.1, 12, 8]} />
+        <primitive object={matCresta} attach="material" />
+      </mesh>
+    </group>
+  );
+}
+
 /* El rostro tallado: ojos hundidos con MIRADA viva (iris + pupila que se mueven),
    cejas de corteza que fruncen el ceño (ánimo legible) y boca-grieta que murmura
    (habla despacio con la tierra). Los gestos son sutiles y ancestrales, nunca de
    caricatura; con reducedMotion el rostro queda quieto y sereno. */
-function Rostro({ matOjo, matBrillo, matIris, matCorteza, matGrieta, reducedMotion, blinkRefs }) {
+function Rostro({ matOjo, matBrillo, matIris, matCorteza, matGrieta, matPliegue, matCresta, reducedMotion, blinkRefs }) {
   const { centro, radio } = useMemo(() => anclaRostro(7), []);
   // Superficie frontal del tronco a la altura de la mirada (mira al +Z).
   const frente = radio * 0.9;
@@ -115,12 +169,12 @@ function Rostro({ matOjo, matBrillo, matIris, matCorteza, matGrieta, reducedMoti
     const frunce = Math.max(0, ceno);
     const alza = Math.max(0, -ceno);
     if (cejaIzq.current) {
-      cejaIzq.current.position.y = 0.24 + alza * 0.03 - frunce * 0.015;
-      cejaIzq.current.rotation.z = -0.34 - frunce * 0.18;
+      cejaIzq.current.position.y = 0.14 + alza * 0.04 - frunce * 0.025;
+      cejaIzq.current.rotation.z = -0.11 - frunce * 0.16;
     }
     if (cejaDer.current) {
-      cejaDer.current.position.y = 0.24 + alza * 0.03 - frunce * 0.015;
-      cejaDer.current.rotation.z = 0.34 + frunce * 0.18;
+      cejaDer.current.position.y = 0.15 + alza * 0.04 - frunce * 0.025;
+      cejaDer.current.rotation.z = 0.13 + frunce * 0.16;
     }
     // BOCA: HABLA con articulaciones claras (sílabas) y SONRÍE apenas. La
     // mandíbula baja SIEMPRE hacia abajo (nunca invade la nariz); las comisuras
@@ -141,76 +195,82 @@ function Rostro({ matOjo, matBrillo, matIris, matCorteza, matGrieta, reducedMoti
     }
   });
 
-  const Ojo = ({ x, refKey, gazeRef }) => (
-    <group position={[x, 0.06, frente - 0.05]} ref={blinkRefs[refKey]}>
-      {/* cuenca hundida: gran cavidad oscura empotrada en la corteza */}
-      <mesh position={[0, 0, -0.03]} scale={[1.3, 1.5, 0.55]}>
-        <sphereGeometry args={[0.15, 16, 14]} />
-        <primitive object={matGrieta} attach="material" />
-      </mesh>
-      {/* globo del ojo: oscuro, con brillo húmedo */}
-      <mesh position={[0, 0, 0.05]}>
-        <sphereGeometry args={[0.115, 18, 16]} />
-        <primitive object={matOjo} attach="material" />
-      </mesh>
-      {/* LA MIRADA: iris cálido + pupila + chispa, en un grupo que deriva lento
-          (el ojo "mira" alrededor). Es el mayor salto de personalidad del rostro. */}
-      <group ref={gazeRef} position={[0, 0, 0.12]}>
-        <mesh>
-          <sphereGeometry args={[0.052, 14, 12]} />
-          <primitive object={matIris} attach="material" />
-        </mesh>
-        {/* pupila: pozo oscuro en el centro del iris */}
-        <mesh position={[0, 0, 0.032]}>
-          <sphereGeometry args={[0.03, 12, 10]} />
-          <primitive object={matGrieta} attach="material" />
-        </mesh>
-        {/* la chispa de vida (catchlight): arriba a un lado */}
-        <mesh position={[0.022, 0.03, 0.05]}>
-          <sphereGeometry args={[0.02, 10, 10]} />
-          <primitive object={matBrillo} attach="material" />
-        </mesh>
-      </group>
-    </group>
-  );
+  const ojoMats = { matGrieta, matOjo, matIris, matBrillo, matCresta };
 
   return (
     <group position={[centro.x, centro.y, centro.z]} scale={[1.5, 1.55, 1.15]}>
-      <Ojo x={-0.24} refKey="izq" gazeRef={gazeIzq} />
-      <Ojo x={0.24} refKey="der" gazeRef={gazeDer} />
+      <Ojo x={-0.24} frente={frente} blinkRef={blinkRefs.izq} gazeRef={gazeIzq} flip={-1} {...ojoMats} />
+      <Ojo x={0.24} frente={frente} blinkRef={blinkRefs.der} gazeRef={gazeDer} flip={1} {...ojoMats} />
 
-      {/* cejas de corteza: crestas gruesas e inclinadas, ceño sabio/severo que
-          se mueve (fruncir/alzar) = el ánimo del guardián, legible a distancia */}
-      <mesh ref={cejaIzq} position={[-0.24, 0.24, frente + 0.01]} rotation={[0, 0, -0.34]}>
-        <boxGeometry args={[0.34, 0.085, 0.13]} />
+      {/* CEJAS: crestas de corteza REDONDEADAS que sobresalen y ensombrecen los
+          ojos (frente pesada de guardián), no tablas pegadas. Una chispa de
+          corteza pelada corona cada una. Se mueven (fruncir/alzar) = el ánimo.
+          Ligera asimetría izq/der para que no sea un molde. */}
+      <group ref={cejaIzq} position={[-0.265, 0.14, frente + 0.055]} rotation={[0, 0, -0.11]}>
+        <mesh scale={[1.75, 0.6, 1.0]}>
+          <sphereGeometry args={[0.17, 14, 10]} />
+          <primitive object={matCorteza} attach="material" />
+        </mesh>
+        <mesh position={[0, 0.07, 0.05]} scale={[1.5, 0.22, 0.5]}>
+          <sphereGeometry args={[0.13, 10, 8]} />
+          <primitive object={matCresta} attach="material" />
+        </mesh>
+      </group>
+      <group ref={cejaDer} position={[0.265, 0.15, frente + 0.055]} rotation={[0, 0, 0.13]}>
+        <mesh scale={[1.75, 0.6, 1.0]}>
+          <sphereGeometry args={[0.17, 14, 10]} />
+          <primitive object={matCorteza} attach="material" />
+        </mesh>
+        <mesh position={[0, 0.07, 0.05]} scale={[1.5, 0.22, 0.5]}>
+          <sphereGeometry args={[0.13, 10, 8]} />
+          <primitive object={matCresta} attach="material" />
+        </mesh>
+      </group>
+      {/* SURCO del entrecejo: la arruga fina del pensamiento (guardián que medita) */}
+      <mesh position={[0.01, 0.13, frente + 0.05]} rotation={[0, 0, 0.06]}>
+        <boxGeometry args={[0.035, 0.16, 0.04]} />
+        <primitive object={matPliegue} attach="material" />
+      </mesh>
+
+      {/* NARIZ: un LOMO redondeado de corteza que baja del entrecejo — no un cajón
+          pegado, sino un nudo de la madera que crece de la cara. Deja filtrum limpio
+          hasta los labios para que la boca se lea sola. */}
+      <mesh position={[0, 0.0, frente + 0.05]} rotation={[0.16, 0, 0]} scale={[0.92, 2.0, 0.92]}>
+        <sphereGeometry args={[0.072, 12, 12]} />
         <primitive object={matCorteza} attach="material" />
       </mesh>
-      <mesh ref={cejaDer} position={[0.24, 0.24, frente + 0.01]} rotation={[0, 0, 0.34]}>
-        <boxGeometry args={[0.34, 0.085, 0.13]} />
-        <primitive object={matCorteza} attach="material" />
-      </mesh>
-
-      {/* caballete de la nariz: nudo vertical entre los ojos. MÁS CORTO que antes
-          (terminaba encima de la boca): ahora deja un surco/filtrum limpio hasta
-          los labios para que la boca se lea sola y no choque con la nariz. */}
-      <mesh position={[0, 0.0, frente + 0.04]} rotation={[0.18, 0, 0]}>
-        <boxGeometry args={[0.1, 0.28, 0.12]} />
-        <primitive object={matCorteza} attach="material" />
+      {/* cresta iluminada del caballete (corteza pelada sobre el lomo de la nariz) */}
+      <mesh position={[0, 0.01, frente + 0.105]} scale={[0.9, 1.8, 0.9]}>
+        <sphereGeometry args={[0.018, 8, 10]} />
+        <primitive object={matCresta} attach="material" />
       </mesh>
       {/* base/punta de la nariz: nudo redondeado donde termina el caballete */}
-      <mesh position={[0, -0.17, frente + 0.05]}>
-        <sphereGeometry args={[0.075, 10, 8]} />
+      <mesh position={[0, -0.155, frente + 0.06]} scale={[1.05, 0.9, 1]}>
+        <sphereGeometry args={[0.07, 10, 8]} />
         <primitive object={matCorteza} attach="material" />
       </mesh>
-      {/* pómulos/bolsas bajo los ojos: dan edad y peso al rostro */}
-      <mesh position={[-0.24, -0.12, frente]} rotation={[0, 0, 0.2]}>
-        <boxGeometry args={[0.26, 0.07, 0.1]} />
-        <primitive object={matCorteza} attach="material" />
-      </mesh>
-      <mesh position={[0.24, -0.12, frente]} rotation={[0, 0, -0.2]}>
-        <boxGeometry args={[0.26, 0.07, 0.1]} />
-        <primitive object={matCorteza} attach="material" />
-      </mesh>
+      {/* fosas nasales: dos recovecos oscuros bajo la punta (DR: sugerir, no tallar) */}
+      {[-0.04, 0.04].map((nx) => (
+        <mesh key={nx} position={[nx, -0.185, frente + 0.08]} scale={[0.7, 0.9, 0.7]}>
+          <sphereGeometry args={[0.022, 8, 8]} />
+          <primitive object={matGrieta} attach="material" />
+        </mesh>
+      ))}
+
+      {/* PÓMULOS: nudos redondeados y cálidos que pegan la luz — la calidez del
+          oso de anteojos. Cada uno con una chispa de corteza pelada arriba. */}
+      {[-1, 1].map((s) => (
+        <group key={`pom-${s}`}>
+          <mesh position={[s * 0.3, -0.13, frente - 0.02]} scale={[1.5, 1.0, 0.8]}>
+            <sphereGeometry args={[0.1, 12, 10]} />
+            <primitive object={matCorteza} attach="material" />
+          </mesh>
+          <mesh position={[s * 0.32, -0.07, frente + 0.04]} scale={[1.25, 0.4, 0.55]}>
+            <sphereGeometry args={[0.058, 10, 8]} />
+            <primitive object={matCresta} attach="material" />
+          </mesh>
+        </group>
+      ))}
 
       {/* LA BOCA — rehecha: dos LABIOS de corteza (arriba fijo, abajo en la
           MANDÍBULA que baja) con una cavidad oscura detrás. Va BIEN bajo la nariz
@@ -254,44 +314,92 @@ function Rostro({ matOjo, matBrillo, matIris, matCorteza, matGrieta, reducedMoti
   );
 }
 
-/* La BARBA de árbol-anciano (Bárbol): cortinas de musgo que cuelgan de la
-   mandíbula, raicillas leñosas en el mentón y matas de liquen a los lados. Enmarca
-   la boca sin taparla y se mece despacio (un Ent sabio y muy viejo). */
-function Barba({ ancla, matMusgo, matMusgoClaro, matRaiz, matLiquen, matLiquenAzul, reducedMotion }) {
+/* La BARBA de LÍQUEN (Usnea, "barba de viejo"): una cortina DENSA de mechones
+   finos que cuelgan del mentón en tres capas de volumen, con gradiente raíz→punta
+   (sombra→plata), más matas de liquen foliáceo prendidas arriba. Instanciada
+   (2 draw-calls) para poder ser densa y barata; se mece despacio. */
+function Barba({ ancla, matHebra, matTuft, densidad = 1, reducedMotion }) {
   const { centro, radio } = ancla;
   const frente = radio * 0.9;
-  const { mechones, raicillas, liquenes } = useMemo(() => specsBarba(91), []);
+  const { hebras, tufts } = useMemo(() => specsBarba(91), []);
+  // Recorte por tier (densidad): menos hebras en gama baja, pero la SILUETA se
+  // conserva (las capas se recortan por igual porque van intercaladas por seed).
+  const hb = useMemo(
+    () => hebras.slice(0, Math.max(10, Math.round(hebras.length * densidad))),
+    [hebras, densidad],
+  );
+  const tf = useMemo(
+    () => tufts.slice(0, Math.max(5, Math.round(tufts.length * densidad))),
+    [tufts, densidad],
+  );
+  const hebraGeo = useMemo(() => geometriaHebraBarba(), []);
+  const tuftGeo = useMemo(() => new THREE.IcosahedronGeometry(1, 1), []);
+  useLayoutEffect(() => () => { hebraGeo.dispose(); tuftGeo.dispose(); }, [hebraGeo, tuftGeo]);
+
+  const hebraRef = useRef(null);
+  const tuftRef = useRef(null);
   const grupoRef = useRef(null);
+
+  useLayoutEffect(() => {
+    const mesh = hebraRef.current;
+    if (mesh) {
+      const m = new THREE.Matrix4();
+      const q = new THREE.Quaternion();
+      const e = new THREE.Euler();
+      const p = new THREE.Vector3();
+      const s = new THREE.Vector3();
+      const col = new THREE.Color();
+      for (let i = 0; i < hb.length; i++) {
+        const h = hb[i];
+        p.set(h.pos[0], h.pos[1], h.pos[2]);
+        e.set(h.lean, h.yaw, h.tilt);
+        q.setFromEuler(e);
+        s.set(h.grosor, h.len, h.grosor);
+        m.compose(p, q, s);
+        mesh.setMatrixAt(i, m);
+        // tinte por instancia = TONO de usnea (sage↔plateado, o leñosa). La
+        // geometría trae la rampa de luminancia raíz→punta; el tono la colorea →
+        // mechón pálido y plateado, más oscuro donde nace del mentón.
+        if (h.woody) col.copy(BARBA.raicilla);
+        else col.copy(BARBA.usnea).lerp(BARBA.usneaGris, h.tono);
+        mesh.setColorAt(i, col);
+      }
+      mesh.instanceMatrix.needsUpdate = true;
+      if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+    }
+    const tmesh = tuftRef.current;
+    if (tmesh) {
+      const m = new THREE.Matrix4();
+      const q = new THREE.Quaternion();
+      const p = new THREE.Vector3();
+      const s = new THREE.Vector3();
+      const col = new THREE.Color();
+      for (let i = 0; i < tf.length; i++) {
+        const l = tf[i];
+        p.set(l.pos[0], l.pos[1], l.pos[2]);
+        s.set(l.esc * 1.6, l.esc * 0.7, l.esc * 1.1);
+        m.compose(p, q, s);
+        tmesh.setMatrixAt(i, m);
+        col.copy(l.azul ? BARBA.liquenAzul : BARBA.liquen);
+        tmesh.setColorAt(i, col);
+      }
+      tmesh.instanceMatrix.needsUpdate = true;
+      if (tmesh.instanceColor) tmesh.instanceColor.needsUpdate = true;
+    }
+  }, [hb, tf]);
+
   useFrame((st) => {
     if (reducedMotion || !grupoRef.current) return;
     const t = st.clock.elapsedTime;
     grupoRef.current.rotation.z = Math.sin(t * 0.5) * 0.02;
     grupoRef.current.rotation.x = 0.04 + Math.sin(t * 0.4 + 1) * 0.015;
   });
+
   return (
     <group position={[centro.x, centro.y, centro.z]} scale={[1.5, 1.55, 1.15]}>
       <group ref={grupoRef} position={[0, 0, frente]}>
-        {/* mechones de musgo (cortina de la barba). Cono con la punta hacia ABAJO. */}
-        {mechones.map((m, i) => (
-          <mesh key={`mb-${i}`} position={[m.x, m.yTop - m.len / 2, m.z]} rotation={[Math.PI, 0, m.tilt]}>
-            <coneGeometry args={[m.grosor, m.len, 5]} />
-            <primitive object={m.claro ? matMusgoClaro : matMusgo} attach="material" />
-          </mesh>
-        ))}
-        {/* raicillas leñosas: hebras largas en el centro del mentón */}
-        {raicillas.map((m, i) => (
-          <mesh key={`rc-${i}`} position={[m.x, m.yTop - m.len / 2, m.z]} rotation={[Math.PI, 0, m.tilt]}>
-            <coneGeometry args={[m.grosor, m.len, 5]} />
-            <primitive object={matRaiz} attach="material" />
-          </mesh>
-        ))}
-        {/* matas de liquen prendidas a los lados de la boca */}
-        {liquenes.map((l, i) => (
-          <mesh key={`lq-${i}`} position={/** @type {[number, number, number]} */ (l.pos)} scale={[l.esc * 1.5, l.esc * 0.55, l.esc]}>
-            <icosahedronGeometry args={[1, 0]} />
-            <primitive object={l.azul ? matLiquenAzul : matLiquen} attach="material" />
-          </mesh>
-        ))}
+        <instancedMesh ref={hebraRef} args={[hebraGeo, matHebra, hb.length]} frustumCulled={false} />
+        <instancedMesh ref={tuftRef} args={[tuftGeo, matTuft, tf.length]} frustumCulled={false} />
       </group>
     </group>
   );
@@ -433,6 +541,22 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
       : new THREE.MeshLambertMaterial({ color: '#20130d' })),
     [P.materialRico],
   );
+  // Tallado del rostro por VALOR (receta del DR): matPliegue oscurece los surcos
+  // (entrecejo, nasolabiales) y matCresta ilumina los cantos (cejas, caballete,
+  // pómulos) con el tono de la corteza PELADA de la queñua → la cara se esculpe
+  // con luz y sombra, no queda como una careta plana pegada al tronco.
+  const matPliegue = useMemo(
+    () => (P.materialRico
+      ? new THREE.MeshStandardMaterial({ color: CORTEZA.valle, roughness: 0.95 })
+      : new THREE.MeshLambertMaterial({ color: CORTEZA.valle })),
+    [P.materialRico],
+  );
+  const matCresta = useMemo(
+    () => (P.materialRico
+      ? new THREE.MeshStandardMaterial({ color: CORTEZA.papel, roughness: 0.85 })
+      : new THREE.MeshLambertMaterial({ color: CORTEZA.papel })),
+    [P.materialRico],
+  );
   const matOjo = useMemo(
     () => (P.materialRico
       ? new THREE.MeshStandardMaterial({ color: '#120d0a', roughness: 0.18, metalness: 0.1 })
@@ -445,8 +569,8 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
   // le puede seguir el gesto). Rico = emisivo real; frugal = básico constante.
   const matIris = useMemo(
     () => (P.materialRico
-      ? new THREE.MeshStandardMaterial({ color: '#c98a3a', emissive: '#7a4616', emissiveIntensity: 0.7, roughness: 0.35, metalness: 0.05 })
-      : new THREE.MeshBasicMaterial({ color: '#d69a48' })),
+      ? new THREE.MeshStandardMaterial({ color: '#a86c2c', emissive: '#5a3210', emissiveIntensity: 0.3, roughness: 0.45, metalness: 0.05 })
+      : new THREE.MeshBasicMaterial({ color: '#a97636' })),
     [P.materialRico],
   );
   const matHoja = useMemo(
@@ -457,13 +581,11 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
   );
   const hojaGeo = useMemo(() => new THREE.IcosahedronGeometry(1, 0), []);
 
-  // Materiales de la BARBA (musgo/liquen/raicilla): Lambert siempre (baratos y
-  // pequeños; el musgo no pide PBR). El ancla del rostro sitúa la barba en el mentón.
-  const matMusgo = useMemo(() => new THREE.MeshLambertMaterial({ color: BARBA.musgo }), []);
-  const matMusgoClaro = useMemo(() => new THREE.MeshLambertMaterial({ color: BARBA.musgoClaro }), []);
-  const matBarbaRaiz = useMemo(() => new THREE.MeshLambertMaterial({ color: BARBA.raicilla }), []);
-  const matLiquen = useMemo(() => new THREE.MeshLambertMaterial({ color: BARBA.liquen }), []);
-  const matLiquenAzul = useMemo(() => new THREE.MeshLambertMaterial({ color: BARBA.liquenAzul }), []);
+  // Materiales de la BARBA de usnea: Lambert siempre (baratos; el líquen no pide
+  // PBR). La hebra usa vertexColors (gradiente raíz→punta HORNEADO en la geometría)
+  // y el instanceColor tinta cada mechón; el tuft tinta por instancia sobre blanco.
+  const matHebra = useMemo(() => new THREE.MeshLambertMaterial({ vertexColors: true }), []);
+  const matTuft = useMemo(() => new THREE.MeshLambertMaterial({ color: '#ffffff' }), []);
   const ancla = useMemo(() => anclaRostro(7), []);
 
   // Liberar GPU al desmontar (geometrías y materiales procedurales).
@@ -472,10 +594,10 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
     ramasGeo.forEach((g) => g.dispose());
     raicesGeo.forEach((g) => g.dispose());
     hojaGeo.dispose();
-    [matCorteza, matCortezaLisa, matGrieta, matOjo, matBrillo, matIris, matHoja,
-      matMusgo, matMusgoClaro, matBarbaRaiz, matLiquen, matLiquenAzul].forEach((m) => m.dispose());
-  }, [troncoGeo, ramasGeo, raicesGeo, hojaGeo, matCorteza, matCortezaLisa, matGrieta, matOjo, matBrillo, matIris, matHoja,
-    matMusgo, matMusgoClaro, matBarbaRaiz, matLiquen, matLiquenAzul]);
+    [matCorteza, matCortezaLisa, matGrieta, matPliegue, matCresta, matOjo, matBrillo, matIris, matHoja,
+      matHebra, matTuft].forEach((m) => m.dispose());
+  }, [troncoGeo, ramasGeo, raicesGeo, hojaGeo, matCorteza, matCortezaLisa, matGrieta, matPliegue, matCresta, matOjo, matBrillo, matIris, matHoja,
+    matHebra, matTuft]);
 
   // --- Vida: balanceo pesado + parpadeo lento ---
   useFrame((state) => {
@@ -510,18 +632,18 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
           matIris={matIris}
           matCorteza={matCortezaLisa}
           matGrieta={matGrieta}
+          matPliegue={matPliegue}
+          matCresta={matCresta}
           reducedMotion={reducedMotion}
           blinkRefs={{ izq: ojoIzq, der: ojoDer }}
         />
 
-        {/* la BARBA de árbol-anciano (siempre): musgo, liquen y raicillas */}
+        {/* la BARBA de usnea (siempre): cortina densa de líquen colgante */}
         <Barba
           ancla={ancla}
-          matMusgo={matMusgo}
-          matMusgoClaro={matMusgoClaro}
-          matRaiz={matBarbaRaiz}
-          matLiquen={matLiquen}
-          matLiquenAzul={matLiquenAzul}
+          matHebra={matHebra}
+          matTuft={matTuft}
+          densidad={P.barbaDens}
           reducedMotion={reducedMotion}
         />
 

--- a/src/visual/mundo3d/bosque/entQuenua.geom.js
+++ b/src/visual/mundo3d/bosque/entQuenua.geom.js
@@ -32,14 +32,17 @@ export const PARAMS_TIER = {
   alto: {
     tubular: 124, radial: 16, hojas: 680, clusters: 9, ramas: 5, raices: 6,
     frailejones: 5, materialRico: true, flatShading: true, fog: true,
+    barbaDens: 1,
   },
   medio: {
     tubular: 76, radial: 10, hojas: 340, clusters: 7, ramas: 5, raices: 5,
     frailejones: 4, materialRico: false, flatShading: false, fog: true,
+    barbaDens: 0.62,
   },
   bajo: {
     tubular: 44, radial: 8, hojas: 120, clusters: 4, ramas: 3, raices: 4,
     frailejones: 0, materialRico: false, flatShading: false, fog: false,
+    barbaDens: 0.34,
   },
 };
 
@@ -369,68 +372,141 @@ export function factorSonrisa(t) {
   return Math.max(0, s); // solo sonríe (nunca "amarga" la boca)
 }
 
-/* ── BARBA de árbol-anciano (referente: Bárbol / Treebeard). Cortinas de MUSGO
-      que cuelgan de la mandíbula, RAICILLAS leñosas más largas en el mentón y
-      matas de LIQUEN prendidas a los lados. Todo procedural, cuelga y se mece. ── */
+/* ── BARBA de líquen del páramo (Usnea, "barba de viejo"): NO es musgo verde
+      plano, es líquen colgante FIBROSO de tono verde-gris PLATEADO. La barba se
+      arma como una CORTINA DENSA de mechones finos, en capas para dar volumen,
+      con gradiente raíz-en-sombra → punta-plateada. Referente: Bárbol/WETA. ── */
 export const BARBA = {
-  musgo: new THREE.Color('#5f6f42'), // musgo del páramo, verde apagado
-  musgoClaro: new THREE.Color('#879463'), // mechón más claro (variedad)
-  raicilla: new THREE.Color('#5a3b2b'), // raicilla leñosa colgante (marrón)
-  liquen: new THREE.Color('#aeb890'), // liquen foliáceo pálido (sage)
-  liquenAzul: new THREE.Color('#93a89a'), // liquen azul-grisáceo
+  usnea: new THREE.Color('#aebb96'), // cuerpo del líquen: verde-gris PÁLIDO (sage)
+  usneaGris: new THREE.Color('#c3cab4'), // mechón más plateado (variedad)
+  raicilla: new THREE.Color('#725036'), // pocas hebras leñosas marrones (contraste)
+  liquen: new THREE.Color('#c7d0b6'), // mata de liquen foliáceo pálido (plata-sage)
+  liquenAzul: new THREE.Color('#b4c1b4'), // liquen azul-grisáceo (variedad)
 };
 
 /*
+ * Geometría de UN mechón de usnea (líquen colgante): un tubo FINO y tapereado
+ * que nace en el mentón (y=0) y CAE con una leve enroscadura hacia el frente,
+ * como hilo de barba de viejo. Trae horneado el gradiente de color a lo largo:
+ * raíz en sombra → punta plateada (la receta del DR: oscuro en la base, claro en
+ * la punta). Una sola geometría compartida por TODOS los mechones (InstancedMesh,
+ * 1 draw-call); la variedad de largo/grosor/color va por instancia.
+ */
+export function geometriaHebraBarba(segmentos = 6, radial = 4) {
+  const pts = [
+    new THREE.Vector3(0.0, 0.0, 0.0),
+    new THREE.Vector3(0.02, -0.28, 0.05),
+    new THREE.Vector3(-0.02, -0.58, 0.06),
+    new THREE.Vector3(0.03, -0.84, 0.02),
+    new THREE.Vector3(0.0, -1.0, -0.03),
+  ];
+  const curva = new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
+  const geo = new THREE.TubeGeometry(curva, segmentos, 1, radial, false);
+  const pos = geo.attributes.position;
+  const nAnillo = radial + 1;
+  const centros = [];
+  for (let i = 0; i <= segmentos; i++) centros.push(curva.getPointAt(i / segmentos));
+  const colores = new Float32Array(pos.count * 3);
+  const v = new THREE.Vector3();
+  const off = new THREE.Vector3();
+  // El color va como RAMPA DE LUMINANCIA (raíz en sombra → punta encendida); el
+  // TONO real de usnea lo pone el instanceColor. Así el mechón queda pálido y
+  // plateado (multiplicar dos verdes medios lo ensuciaba a oliva-espagueti).
+  const lumRaiz = 0.5;
+  const lumPunta = 1.0;
+  for (let k = 0; k < pos.count; k++) {
+    const anillo = Math.floor(k / nAnillo);
+    const t = Math.min(1, anillo / segmentos); // 0 raíz → 1 punta
+    const radio = 0.03 * (1 - t) + 0.006; // fino, más fino aún en la punta
+    const cen = centros[Math.min(anillo, centros.length - 1)];
+    v.fromBufferAttribute(pos, k);
+    off.subVectors(v, cen).multiplyScalar(radio); // offset unitario → grosor real
+    v.copy(cen).add(off);
+    pos.setXYZ(k, v.x, v.y, v.z);
+    const lum = lumRaiz + (lumPunta - lumRaiz) * Math.min(1, t * 1.1);
+    colores[k * 3] = lum;
+    colores[k * 3 + 1] = lum;
+    colores[k * 3 + 2] = lum * 0.97; // punta apenas cálida
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(colores, 3));
+  pos.needsUpdate = true;
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/*
  * Mechones de la barba en coords del rostro (0,0,0 = ancla del mentón; -y cuelga,
- * +z al frente). Forma de barba: larga en el centro (mentón), corta en las
- * mejillas; enmarca la boca SIN taparla (arranca por debajo del labio).
+ * +z al frente). Forma de barba REAL: densa, larga en el centro (mentón), corta y
+ * dispersa hacia las mejillas, en TRES CAPAS de profundidad para que tenga
+ * VOLUMEN (no un plano de cuatro hebras). Devuelve transformaciones por instancia.
  */
 export function specsBarba(seed = 91) {
   const r = rng(seed);
-  const mechones = [];
-  const N = 15;
-  for (let i = 0; i < N; i++) {
-    const f = i / (N - 1); // 0..1 de mejilla izq a der
-    const x = (f - 0.5) * 0.94; // a lo ancho de la mandíbula
-    const centro = Math.max(0, 1 - Math.abs(f - 0.5) * 1.7); // largo hacia el mentón
-    const len = 0.44 + centro * 0.78 + r() * 0.16;
-    mechones.push({
-      x,
-      yTop: -0.56 - Math.abs(f - 0.5) * 0.1, // bajo la boca, sube por las mejillas
-      z: 0.02 + r() * 0.05,
-      len,
-      tilt: (f - 0.5) * 0.7 + (r() - 0.5) * 0.2, // se abren hacia afuera
-      grosor: 0.05 + r() * 0.03,
-      claro: r() > 0.62,
-      fase: i * 1.3,
+  const hebras = [];
+  // Capas: fondo (volumen), medio y frente (las más largas y visibles). El
+  // solape entre capas es lo que hace que se lea como BARBA con cuerpo. Densa y
+  // con el CENTRO lleno (el mentón de Bárbol), no cuatro hebras a los lados.
+  const capas = [
+    { z: -0.04, lenMul: 0.86, n: 22 },
+    { z: 0.03, lenMul: 1.0, n: 28 },
+    { z: 0.1, lenMul: 1.12, n: 22 },
+  ];
+  for (const capa of capas) {
+    for (let i = 0; i < capa.n; i++) {
+      // sesgo al centro: raíz cuadrada empuja las muestras hacia el mentón para
+      // que la barba tenga cuerpo en el medio y se disperse hacia las mejillas.
+      const u = (i + r() * 0.8) / capa.n; // 0..1 crudo
+      const f = 0.5 + (u - 0.5) * Math.sqrt(Math.abs(u - 0.5) * 2) * 1.15;
+      const x = (f - 0.5) * 1.02; // a lo ancho de la mandíbula
+      const centro = Math.max(0, 1 - Math.abs(f - 0.5) * 1.7); // 1 en el mentón
+      // arranca BAJO la boca (deja ver los labios) y cuelga largo desde el mentón
+      const yTop = -0.47 - centro * 0.06 - Math.abs(f - 0.5) * 0.02;
+      const len = (0.6 + centro * 1.15 + r() * 0.3) * capa.lenMul; // barba LARGA
+      hebras.push({
+        pos: [x + (r() - 0.5) * 0.05, yTop, capa.z + (r() - 0.5) * 0.02],
+        len,
+        grosor: 0.5 + r() * 0.5, // fino (hilo de usnea), varía
+        tilt: (f - 0.5) * 0.28 + (r() - 0.5) * 0.24, // cuelgan casi rectos, poco abanico
+        lean: 0.04 + r() * 0.16, // caen hacia el frente
+        yaw: (r() - 0.5) * 0.5,
+        tono: r(), // 0 usnea sage → 1 plateado
+        woody: r() > 0.9, // muy pocas hebras leñosas marrones (contraste)
+      });
+    }
+  }
+  // COLUMNA CENTRAL del mentón: mechones largos que cuelgan RECTOS en el eje para
+  // que la barba no se parta en dos y tape el surco vertical del tronco (el mentón
+  // macizo de Bárbol). Es lo que une la cortina en una sola barba.
+  const CENTRO = 20;
+  for (let i = 0; i < CENTRO; i++) {
+    // arrancan JUSTO bajo el labio y cuelgan rectos, adelantados para tapar el
+    // surco vertical del tronco → una sola barba maciza, sin raya al medio.
+    hebras.push({
+      pos: [(r() - 0.5) * 0.28, -0.44 - r() * 0.1, 0.09 + r() * 0.05],
+      len: 1.2 + r() * 0.55, // las más largas (el chorro central del mentón)
+      grosor: 0.6 + r() * 0.5,
+      tilt: (r() - 0.5) * 0.14, // casi vertical
+      lean: 0.03 + r() * 0.12,
+      yaw: (r() - 0.5) * 0.4,
+      tono: r(),
+      woody: r() > 0.9,
     });
   }
-  // raicillas leñosas: más largas, en el centro (el mentón de Bárbol)
-  const raicillas = [];
-  const M = 4;
-  for (let i = 0; i < M; i++) {
-    raicillas.push({
-      x: (r() - 0.5) * 0.34,
-      yTop: -0.62,
-      z: 0.0 + r() * 0.04,
-      len: 0.98 + r() * 0.6,
-      tilt: (r() - 0.5) * 0.28,
-      grosor: 0.036 + r() * 0.02,
-      fase: i * 2.1,
-    });
-  }
-  // matas de liquen prendidas a lo alto de la barba, a los lados de la boca
-  const liquenes = [];
-  const L = 9;
+  // matas de liquen foliáceo: acentos PEQUEÑOS del enredo de usnea, prendidos al
+  // borde superior de la barba y trepando por las patillas (mejillas). Chicos y
+  // numerosos: dan textura sin tapar la boca ni verse como piedras.
+  const tufts = [];
+  const L = 22;
   for (let i = 0; i < L; i++) {
     const f = i / (L - 1);
-    liquenes.push({
-      pos: [(f - 0.5) * 0.9, -0.5 - r() * 0.28, 0.05 + r() * 0.05],
-      esc: 0.06 + r() * 0.055,
+    const lado = Math.abs(f - 0.5) * 2; // 0 centro → 1 mejilla
+    tufts.push({
+      pos: [(f - 0.5) * 1.02, -0.5 - r() * 0.22 + lado * 0.16, 0.05 + r() * 0.07],
+      esc: 0.028 + r() * 0.03, // MUCHO más chicos que antes
       azul: r() > 0.6,
     });
   }
-  return { mechones, raicillas, liquenes };
+  return { hebras, tufts };
 }
 
 /*


### PR DESCRIPTION
Quirúrgico: solo `EntQuenua.jsx` + `entQuenua.geom.js`. Parte de la versión de 443 líneas que sí tenía cara y la mejora — no la reemplaza.

- **Cara**: ojos ámbar-miel hundidos y encapuchados por cejas pesadas de corteza (mirada de guardián viejo, no dos puntos); tallado por valor con crestas de corteza pelada (iluminan) y surcos (ensombrecen); nariz de lomo redondeado con fosas; pómulos cálidos.
- **Barba**: usnea "barba de viejo" instanciada — cortina densa en 3 capas con gradiente raíz→punta y matas de liquen pálido, reemplaza los conos verde-espagueti. Densidad por tier (`barbaDens`).

Verde: `build:prod` + `tsc` + eslint + test geom (22/22). La prueba es visual (captura de cerca en la sesión). Honesto: el surco vertical del tronco aún asoma apenas al centro del mentón; la barba lo cubre casi del todo.