### PR TITLE
feat(sierra): montaña 3D navegable para sierra_global — macizo real, no lámina

### DIFF
--- a/src/config/rutasProdChagraApp.js
+++ b/src/config/rutasProdChagraApp.js
@@ -60,13 +60,23 @@ export const NUCLEO_3D = [
     categoria: '3D',
   },
 
-  // ── Vista global (Sierra Nevada) — la montaña cortada por la mitad ────
-  // Lámina estática: los pisos térmicos del mar a la nieve, cada banda entra a
-  // su mundo. Reemplaza la galería en 3/4 (compleja, no se entendía). La galería
-  // vieja (GaleriaSierraArboles.jsx) queda en el repo, sin cablear.
+  // ── Vista global (Sierra Nevada) — la MONTAÑA 3D que se orbita ────────
+  // Macizo con relieve real: los pisos como terreno (color por altura + veg
+  // instanciada), la cámara la recorre girando, y tocar una zona entra a su
+  // mundo. Reemplaza el corte vertical (que se lee como lámina; se GUARDA en
+  // `sierra_corte` como vista-mapa por si se quiere comparar).
   {
     path: 'sierra_global',
     alias: ['sierra', 'vista_sierra'],
+    componente: 'SierraMonte3D',
+    importLazy: 'src/visual/mundo3d/sierra/SierraMonte3D.jsx',
+    categoria: '3D',
+  },
+  // El corte vertical, GUARDADO y accesible: la vista-mapa estática de la
+  // geografía (SierraMonte3D enlaza aquí con "Ver el corte de geografía").
+  {
+    path: 'sierra_corte',
+    alias: ['sierra_lamina', 'vista_sierra_corte'],
     componente: 'SierraCorteVertical',
     importLazy: 'src/visual/mundo3d/sierra/SierraCorteVertical.jsx',
     categoria: '3D',

--- a/src/prodApp/ProdChagraApp.jsx
+++ b/src/prodApp/ProdChagraApp.jsx
@@ -50,6 +50,7 @@ const LAZY_MAP = {
   VentanaValle3D: lazy(() => import('../components/VentanaValle3D.jsx')),
   VistaGlobalSierra: lazy(() => import('../visual/mundo3d/VistaGlobalSierra.jsx')),
   GaleriaSierraArboles: lazy(() => import('../visual/mundo3d/sierra/GaleriaSierraArboles.jsx')),
+  SierraMonte3D: lazy(() => import('../visual/mundo3d/sierra/SierraMonte3D.jsx')),
   SierraCorteVertical: lazy(() => import('../visual/mundo3d/sierra/SierraCorteVertical.jsx')),
   MundoEntBosque: lazy(() => import('../visual/mundo3d/bosque/MundoEntBosque.jsx')),
   MontanaMundosCampesino: lazy(() => import('../mockups/MontanaMundosCampesino.jsx')),
@@ -236,6 +237,7 @@ function parseHash() {
 const VISTAS_SIN_SALIDA = new Set([
   'valle3d_noche',
   'sierra_global', 'sierra', 'vista_sierra',
+  'sierra_corte', 'sierra_lamina', 'vista_sierra_corte',
   'diorama_abejas', 'diorama_paramo', 'diorama_suelo', 'diorama_compost',
   'subsuelo', 'mundo3d_micorrizas',
   'camara_director', 'artesania_andina', 'efectos_funcionales',

--- a/src/visual/mundo3d/sierra/SierraMonte3D.jsx
+++ b/src/visual/mundo3d/sierra/SierraMonte3D.jsx
@@ -1,0 +1,580 @@
+/*
+ * SierraMonte3D — LA VISTA GLOBAL de la Sierra como MONTAÑA 3D DE VERDAD: un
+ * macizo con volumen que se ORBITA, no una lámina vista de frente.
+ *
+ * ── POR QUÉ ESTO Y NO EL CORTE ──────────────────────────────────────────────
+ * El corte vertical (`SierraCorteVertical`, que se GUARDA — es la vista-mapa,
+ * estática a propósito) se lee como una página de libro: 3D técnicamente, pero
+ * compuesto como diagrama. El operador pidió otra cosa: una montaña que se
+ * SIENTA un lugar. Aquí el relieve es geometría real —cara, laderas, quebradas,
+ * contrafuertes—, la cámara la recorre girando, y la luz direccional MODELA la
+ * ladera (eso que un triángulo pintado no puede). Referente: Alto's Odyssey,
+ * Journey, Sable. Anti-referente: la montaña-de-los-mundos (parallax 2D).
+ *
+ * ── LOS PISOS SIGUEN, PERO COMO TERRENO ─────────────────────────────────────
+ * No hay franjas de color planas: la base cálida es ancha junto al mar, y
+ * subiendo el terreno pasa por templado, frío, páramo y la corona de roca y
+ * nieve. El color cae en su banda climática por ALTURA real (cima=5 775 m), y la
+ * vegetación instanciada cambia con la altitud: palma abajo, café, bosque de
+ * niebla, frailejón, y roca/nieve arriba. Tocar una zona de la montaña —o su
+ * hotspot— entra a ese piso; los mundos cuelgan de su altura real en la ladera.
+ *
+ * ── EL PÁRAMO ES ESPECIAL ───────────────────────────────────────────────────
+ * De su banda BAJA el agua (una quebrada que sigue el relieve hasta el mar) y lo
+ * corona un velo de bruma. Su hotspot NO invita a "entrar a sembrar" como los de
+ * abajo: dice "se cuida, no se siembra". (El grafo aún no tiene la norma legal;
+ * la protección se sostiene por diseño.)
+ *
+ * ── RESPETO ─────────────────────────────────────────────────────────────────
+ * La Sierra es territorio sagrado y habitado (Kogui, Arhuaco/Iku, Wiwa,
+ * Kankuamo — el Corazón del Mundo, dentro de la Línea Negra). Se acredita
+ * siempre; cero iconografía ceremonial.
+ *
+ * ── RENDIMIENTO ─────────────────────────────────────────────────────────────
+ * Terreno = UNA malla (rejilla polar, densidad por tier). Vegetación = un
+ * InstancedMesh por especie. Todo procedural, color horneado en vertexColors,
+ * geometría fusionada con `fusionarSeguro`. En 'bajo' el macizo va simplificado
+ * (baja resolución, poca vegetación, sin agua ni bruma, cámara quieta). Corre en
+ * Android barato y Quadro M6000, gateado por `deviceTier`.
+ *
+ * Importa three/@react-three → montar SOLO perezosa (lazy) desde el shell.
+ */
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr, Html } from '@react-three/drei';
+import { ATMOSFERA } from '../atmosferaMadre.js';
+import { decidirTier, perfilDeTier } from '../deviceTier.js';
+import { PISOS_TERMICOS } from '../pisosTermicos.js';
+import {
+  R_MONTE, H_PICO, Y_MAR,
+  geometriaMonte,
+  geomPalmera, geomCafeto, geomNiebla, geomFrailejon,
+  vegDeTier, calidadVeg, distribuirVegetacion,
+  curvaQuebrada, puntoEnLadera, metrosDeY, yDeMetros,
+} from './sierraMonte.geom.js';
+
+/* Las cuatro bandas navegables, del grafo (pisosTermicos.js). `azimut` reparte
+   sus hotspots alrededor del macizo para que orbitar los descubra. */
+const IDS = ['calido', 'templado', 'frio', 'paramo'];
+/* Repartidos ~90° alrededor del macizo: al orbitar siempre asoman un par. */
+const AZIMUT = { calido: 0.5, templado: 2.05, frio: -2.6, paramo: -1.05 };
+const MUNDO_ANCLA = {
+  calido: 'La milpa, los frutales y el corral',
+  templado: 'El café bajo sombra y el semillero',
+  frio: 'La papa, la huerta y el bosque de niebla',
+  paramo: 'La queñua y los frailejones',
+};
+const BANDAS = IDS.map((id) => {
+  const p = PISOS_TERMICOS.find((x) => x.id === id);
+  return {
+    id, nombre: p.nombre, min: p.min, max: p.max, cultivable: p.cultivable,
+    color: p.color, medio: (p.min + p.max) / 2, azimut: AZIMUT[id],
+  };
+});
+/** Banda cuyo rango contiene esa altitud (o null si es corona/mar). */
+function bandaDeMetros(m) {
+  return BANDAS.find((b) => m >= b.min && m < b.max) || null;
+}
+
+/* ── Un banco de matas de UNA especie: una geometría fusionada, N instancias
+      (patrón de FloraParamo). El color va horneado en la geo; `tint` lo varía
+      apenas por instancia. ── */
+function Especie({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh ref={ref} args={[geo, mat, items.length]} frustumCulled={false} castShadow={castShadow} />
+  );
+}
+
+/* ── El MACIZO: la malla del terreno con color horneado + la vegetación
+      instanciada por banda. Clicable: el punto tocado decide su piso. ── */
+function Macizo({ tier, onEntrar }) {
+  const perfil = perfilDeTier(tier);
+  const q = calidadVeg(tier);
+  const conteos = vegDeTier(tier);
+
+  const geoTerreno = useMemo(() => {
+    const g = geometriaMonte(perfil.segmentosTerreno);
+    return perfil.flatShading ? g.toNonIndexed() : g;
+  }, [perfil.segmentosTerreno, perfil.flatShading]);
+
+  const geos = useMemo(() => ({
+    palmera: geomPalmera(q, 9),
+    cafeto: geomCafeto(q, 3),
+    niebla: geomNiebla(q, 5),
+    frailejon: geomFrailejon(q, 11),
+  }), [q]);
+
+  const dist = useMemo(() => distribuirVegetacion(conteos, 707), [conteos]);
+
+  const matTerreno = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.97, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  const matVeg = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.9, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  useEffect(() => () => {
+    geoTerreno.dispose();
+    Object.values(geos).forEach((g) => g && g.dispose());
+    matTerreno.dispose();
+    matVeg.dispose();
+  }, [geoTerreno, geos, matTerreno, matVeg]);
+
+  const alSuelo = (e) => {
+    e.stopPropagation();
+    const m = metrosDeY(e.point.y);
+    const b = bandaDeMetros(m);
+    if (b) onEntrar?.(b.id);
+  };
+
+  const sombra = perfil.sombras;
+  return (
+    <group>
+      <mesh
+        geometry={geoTerreno}
+        material={matTerreno}
+        receiveShadow={sombra}
+        onClick={alSuelo}
+        onPointerOver={() => { document.body.style.cursor = 'pointer'; }}
+        onPointerOut={() => { document.body.style.cursor = ''; }}
+      />
+      <Especie geo={geos.palmera} mat={matVeg} items={dist.palmera} castShadow={sombra} />
+      <Especie geo={geos.cafeto} mat={matVeg} items={dist.cafeto} castShadow={sombra} />
+      <Especie geo={geos.niebla} mat={matVeg} items={dist.niebla} castShadow={sombra} />
+      <Especie geo={geos.frailejon} mat={matVeg} items={dist.frailejon} />
+    </group>
+  );
+}
+
+/* ── El mar Caribe al pie: la Sierra es la montaña litoral más alta del mundo, y
+      ese contraste ES su silueta. Un disco de agua con degradado por vértice. ── */
+function Mar() {
+  const geo = useMemo(() => {
+    const g = new THREE.CircleGeometry(R_MONTE * 6, 64);
+    g.rotateX(-Math.PI / 2);
+    const pos = g.getAttribute('position');
+    const col = new Float32Array(pos.count * 3);
+    const hondo = new THREE.Color('#3f7a86');
+    const orilla = new THREE.Color('#8fbcae');
+    const c = new THREE.Color();
+    for (let i = 0; i < pos.count; i++) {
+      const r = Math.hypot(pos.getX(i), pos.getZ(i));
+      const t = 1 - Math.min(1, r / (R_MONTE * 1.25));
+      c.lerpColors(hondo, orilla, t * t);
+      col[i * 3] = c.r; col[i * 3 + 1] = c.g; col[i * 3 + 2] = c.b;
+    }
+    g.setAttribute('color', new THREE.BufferAttribute(col, 3));
+    return g;
+  }, []);
+  useEffect(() => () => geo.dispose(), [geo]);
+  return (
+    <group>
+      <mesh geometry={geo} position={[0, Y_MAR + 0.02, 0]}>
+        <meshBasicMaterial vertexColors />
+      </mesh>
+      {/* línea de espuma en la orilla: separa la tierra del agua (si no, el
+          faldón bajo y el mar se leen como una sola plataforma). */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, Y_MAR + 0.06, 0]}>
+        <ringGeometry args={[R_MONTE * 0.9, R_MONTE * 1.02, 72]} />
+        <meshBasicMaterial color="#f2ecd8" transparent opacity={0.72} depthWrite={false} />
+      </mesh>
+    </group>
+  );
+}
+
+/* ── El AGUA que baja del páramo: una quebrada que sigue el relieve, con su
+      nacedero. Alma de la pieza y firma del piso protegido. ── */
+function Quebrada({ tier, reducedMotion }) {
+  const curva = useMemo(() => curvaQuebrada(-0.7), []);
+  const geoCauce = useMemo(() => new THREE.TubeGeometry(curva, 60, 0.05, 5, false), [curva]);
+  useEffect(() => () => geoCauce.dispose(), [geoCauce]);
+  const nacedero = curva.getPointAt(0);
+
+  const nGotas = tier === 'alto' ? 6 : 3;
+  const gotas = useRef(null);
+  const fases = useMemo(() => Array.from({ length: nGotas }, (_, i) => i / nGotas), [nGotas]);
+  useFrame((st) => {
+    if (reducedMotion || !gotas.current) return;
+    const t = st.clock.elapsedTime;
+    gotas.current.children.forEach((ch, i) => {
+      const u = (fases[i] + t * 0.12) % 1;
+      const p = curva.getPointAt(u);
+      ch.position.set(p.x, p.y + 0.04, p.z);
+    });
+  });
+  return (
+    <group>
+      <mesh position={[nacedero.x, nacedero.y + 0.03, nacedero.z]}>
+        <sphereGeometry args={[0.14, 12, 10]} />
+        <meshBasicMaterial color="#cfeaf0" transparent opacity={0.9} />
+      </mesh>
+      <mesh geometry={geoCauce}>
+        <meshBasicMaterial color="#7cc3d6" transparent opacity={0.9} />
+      </mesh>
+      <group ref={gotas}>
+        {fases.map((_, i) => (
+          <mesh key={i} position={[nacedero.x, nacedero.y, nacedero.z]}>
+            <sphereGeometry args={[0.06, 7, 6]} />
+            <meshBasicMaterial color="#eaffff" transparent opacity={0.95} />
+          </mesh>
+        ))}
+      </group>
+    </group>
+  );
+}
+
+/* Textura radial suave para la bruma, generada en runtime (sin assets). */
+function texturaVaho() {
+  const s = 128;
+  const cv = document.createElement('canvas');
+  cv.width = cv.height = s;
+  const ctx = cv.getContext('2d');
+  const g = ctx.createRadialGradient(s / 2, s / 2, 0, s / 2, s / 2, s / 2);
+  g.addColorStop(0, 'rgba(255,255,255,0.95)');
+  g.addColorStop(0.5, 'rgba(238,245,246,0.32)');
+  g.addColorStop(1, 'rgba(238,245,246,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, s, s);
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+/* ── El VELO del páramo: bancos de bruma BLANDA (textura radial, no cajas) que
+      coronan la banda protegida. No es otra franja: es luz y silencio. Encaran a
+      la cámara; derivan despacio. ── */
+function VeloParamo({ tier, reducedMotion }) {
+  const { camera } = useThree();
+  const grupo = useRef(null);
+  const n = tier === 'alto' ? 8 : 5;
+  const tex = useMemo(() => texturaVaho(), []);
+  const mat = useMemo(
+    () => new THREE.MeshBasicMaterial({ map: tex, transparent: true, opacity: 0.2, depthWrite: false, fog: false }),
+    [tex],
+  );
+  const geo = useMemo(() => new THREE.PlaneGeometry(4.2, 2.1), []);
+  const bancos = useMemo(() => {
+    const yc = yDeMetros(3450);
+    const arr = [];
+    for (let i = 0; i < n; i++) {
+      const a = (i / n) * Math.PI * 2 + i * 0.7;
+      const rn = 0.28 + (i % 3) * 0.05;
+      arr.push({
+        base: [Math.cos(a) * rn * R_MONTE, yc + 0.35 + (i % 2) * 0.35, Math.sin(a) * rn * R_MONTE],
+        fase: i * 1.7,
+      });
+    }
+    return arr;
+  }, [n]);
+  useEffect(() => () => { tex.dispose(); mat.dispose(); geo.dispose(); }, [tex, mat, geo]);
+  useFrame((st) => {
+    const g = grupo.current;
+    if (!g) return;
+    const t = st.clock.elapsedTime;
+    g.children.forEach((ch, i) => {
+      const b = bancos[i];
+      if (!reducedMotion) {
+        ch.position.x = b.base[0] + Math.sin(t * 0.06 + b.fase) * 0.7;
+        ch.material.opacity = 0.16 + Math.sin(t * 0.1 + b.fase) * 0.06;
+      }
+      ch.quaternion.copy(camera.quaternion);
+    });
+  });
+  return (
+    <group ref={grupo}>
+      {bancos.map((b, i) => (
+        <mesh key={i} geometry={geo} material={mat} position={/** @type {[number,number,number]} */ (b.base)} />
+      ))}
+    </group>
+  );
+}
+
+/* ── Los HOTSPOTS de piso: un pin que cuelga de la altura REAL de su banda en la
+      ladera. Toque = entra a ese mundo. El páramo va aparte (frío, "se cuida"). ── */
+function HotspotsPisos({ onEntrar }) {
+  return (
+    <>
+      {BANDAS.map((b) => {
+        const pos = puntoEnLadera(b.medio, b.azimut);
+        const protegido = !b.cultivable;
+        return (
+          <group key={b.id} position={[pos[0], pos[1] + 0.35, pos[2]]}>
+            <mesh>
+              <sphereGeometry args={[0.16, 12, 10]} />
+              <meshBasicMaterial color={protegido ? '#bfe3ea' : '#ffd679'} transparent opacity={0.95} />
+            </mesh>
+            <Html center distanceFactor={30} zIndexRange={[20, 0]} occlude>
+
+              <button
+                type="button"
+                className={`smonte-pin${protegido ? ' smonte-pin--paramo' : ''}`}
+                onClick={(ev) => { ev.stopPropagation(); onEntrar?.(b.id); }}
+              >
+                <span className="smonte-pin__nom">{b.nombre}</span>
+                <span className="smonte-pin__cota">{b.min}–{b.max} m</span>
+                <span className="smonte-pin__cta">{protegido ? 'Se cuida' : 'Entrar'}</span>
+              </button>
+            </Html>
+          </group>
+        );
+      })}
+    </>
+  );
+}
+
+/* Cielo cálido de fondo (degradado por vértice, cero textura). */
+function CieloFondo() {
+  const geo = useMemo(() => {
+    const g = new THREE.SphereGeometry(90, 20, 12);
+    const pos = g.getAttribute('position');
+    const col = new Float32Array(pos.count * 3);
+    const alto = new THREE.Color('#9cb7c8');
+    const bajo = new THREE.Color('#f6ead2');
+    const c = new THREE.Color();
+    for (let i = 0; i < pos.count; i++) {
+      const t = Math.min(1, Math.max(0, pos.getY(i) / 90 + 0.25));
+      c.lerpColors(bajo, alto, t);
+      col[i * 3] = c.r; col[i * 3 + 1] = c.g; col[i * 3 + 2] = c.b;
+    }
+    g.setAttribute('color', new THREE.BufferAttribute(col, 3));
+    return g;
+  }, []);
+  useEffect(() => () => geo.dispose(), [geo]);
+  return (
+    <mesh geometry={geo}>
+      <meshBasicMaterial vertexColors side={THREE.BackSide} fog={false} depthWrite={false} />
+    </mesh>
+  );
+}
+
+/* Luz de hora dorada que MODELA el relieve: un sol bajo direccional (la clave de
+   que la ladera se lea 3D y no plana), relleno frío opuesto y hemisférico. */
+function LucesMonte({ tier }) {
+  const perfil = perfilDeTier(tier);
+  return (
+    <>
+      <hemisphereLight intensity={0.88} color={ATMOSFERA.cielo} groundColor={ATMOSFERA.suelo} />
+      <ambientLight intensity={0.4} color="#fff2d8" />
+      <directionalLight
+        position={[-R_MONTE * 0.9, H_PICO * 1.5, R_MONTE * 0.7]}
+        intensity={1.25}
+        color={ATMOSFERA.luz}
+        castShadow={perfil.sombras}
+        shadow-mapSize-width={1024}
+        shadow-mapSize-height={1024}
+        shadow-camera-near={1}
+        shadow-camera-far={60}
+        shadow-camera-left={-R_MONTE}
+        shadow-camera-right={R_MONTE}
+        shadow-camera-top={R_MONTE}
+        shadow-camera-bottom={-R_MONTE}
+      />
+      <directionalLight position={[R_MONTE, H_PICO, -R_MONTE]} intensity={0.4} color={ATMOSFERA.relleno} />
+    </>
+  );
+}
+
+/**
+ * La escena del macizo (grupo r3f). Cielo, mar, montaña con vegetación por piso,
+ * agua del páramo, velo de bruma, hotspots navegables y la cámara que orbita.
+ * @param {{tier:'alto'|'medio'|'bajo', reducedMotion:boolean, onEntrarPiso?:(id:string)=>void}} props
+ */
+function EscenaMonte({ tier, reducedMotion, onEntrarPiso }) {
+  const perfil = perfilDeTier(tier);
+  const agua = tier !== 'bajo';
+  return (
+    <>
+      <color attach="background" args={[ATMOSFERA.fondo]} />
+      {perfil.fog && <fog attach="fog" args={[ATMOSFERA.niebla, R_MONTE * 3.0, R_MONTE * 6.2]} />}
+      <LucesMonte tier={tier} />
+      <CieloFondo />
+      <Mar />
+      <Macizo tier={tier} onEntrar={onEntrarPiso} />
+      {agua && <Quebrada tier={tier} reducedMotion={reducedMotion} />}
+      {agua && <VeloParamo tier={tier} reducedMotion={reducedMotion} />}
+      <HotspotsPisos onEntrar={onEntrarPiso} />
+      <OrbitControls
+        makeDefault
+        target={[0, H_PICO * 0.66, 0]}
+        enablePan={false}
+        enableZoom
+        minDistance={R_MONTE * 1.25}
+        maxDistance={R_MONTE * 2.4}
+        minPolarAngle={0.62}
+        maxPolarAngle={1.6}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.32}
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+const CSS = `
+.smonte-root { position: relative; width: 100%; height: 100dvh; min-height: 360px; overflow: hidden; background: ${ATMOSFERA.fondo}; }
+.smonte-canvas { position: absolute; inset: 0; opacity: 0; transition: opacity 0.7s ease; }
+.smonte-canvas--lista { opacity: 1; }
+.smonte-vineta { position: absolute; inset: 0; pointer-events: none; background: radial-gradient(130% 110% at 44% 40%, transparent 58%, rgba(40,30,16,0.28) 100%); }
+.smonte-chrome { position: absolute; inset: 0; pointer-events: none; }
+.smonte-titulo { position: absolute; top: 0; left: 0; margin: 0; padding: 0.9rem 1rem 0; color: #2c1f0e; text-shadow: 0 1px 5px rgba(255,246,224,0.8); font: 700 clamp(1.1rem, 3.3vw, 1.44rem)/1.2 system-ui, sans-serif; }
+.smonte-titulo__cejilla { display: block; font: 600 0.64rem/1 system-ui, sans-serif; text-transform: uppercase; letter-spacing: 0.16em; color: #8a5a1f; margin-bottom: 0.3rem; }
+.smonte-titulo small { display: block; font: 500 0.8rem/1.35 system-ui, sans-serif; opacity: 0.82; margin-top: 0.18rem; max-width: 24rem; }
+
+/* pin flotante de piso (Html sobre la ladera) */
+.smonte-pin { display: flex; flex-direction: column; align-items: flex-start; gap: 0.05rem; border: none; cursor: pointer; padding: 0.32rem 0.5rem; border-radius: 0.55rem; background: rgba(255,248,233,0.94); box-shadow: 0 3px 12px rgba(50,34,18,0.34); border-left: 3px solid #b5763a; transform: translateY(-0.4rem); transition: transform 0.15s ease, box-shadow 0.15s ease; white-space: nowrap; }
+.smonte-pin:hover { transform: translateY(-0.6rem) scale(1.04); box-shadow: 0 6px 18px rgba(50,34,18,0.44); }
+.smonte-pin__nom { font: 700 0.8rem/1.05 system-ui, sans-serif; color: #33240f; }
+.smonte-pin__cota { font: 600 0.6rem/1 system-ui, sans-serif; color: #8a6a3a; font-variant-numeric: tabular-nums; }
+.smonte-pin__cta { margin-top: 0.15rem; font: 700 0.56rem/1 system-ui, sans-serif; text-transform: uppercase; letter-spacing: 0.06em; color: #fff8e9; background: #b5763a; padding: 0.16rem 0.4rem; border-radius: 99px; }
+.smonte-pin--paramo { border-left-color: #7fa6b2; background: linear-gradient(180deg, rgba(233,244,247,0.97), rgba(255,248,233,0.92)); }
+.smonte-pin--paramo .smonte-pin__cta { background: #6f97a3; }
+
+/* fila compacta de pisos abajo (a11y + gama baja): entran sin acertarle al pin */
+.smonte-fila { position: absolute; left: 50%; bottom: 4.6rem; transform: translateX(-50%); display: flex; flex-wrap: wrap; justify-content: center; gap: 0.4rem; padding: 0 0.6rem; pointer-events: auto; }
+.smonte-chip { display: flex; flex-direction: column; align-items: center; gap: 0.02rem; border: none; cursor: pointer; padding: 0.32rem 0.62rem; border-radius: 0.6rem; background: rgba(255,248,233,0.92); box-shadow: 0 2px 8px rgba(60,42,24,0.24); border-bottom: 3px solid var(--c, #b5763a); transition: transform 0.15s ease, box-shadow 0.15s ease; }
+.smonte-chip:hover, .smonte-chip:focus-visible { outline: none; transform: translateY(-2px); box-shadow: 0 6px 16px rgba(60,42,24,0.32); }
+.smonte-chip__nom { font: 700 0.78rem/1.05 system-ui, sans-serif; color: #33240f; }
+.smonte-chip__cota { font: 600 0.58rem/1 system-ui, sans-serif; color: #8a6a3a; font-variant-numeric: tabular-nums; }
+.smonte-chip--paramo { background: linear-gradient(180deg, rgba(233,244,247,0.96), rgba(255,248,233,0.92)); border-bottom-color: #7fa6b2; }
+
+.smonte-pie { position: absolute; bottom: 0; left: 0; right: 0; display: flex; flex-direction: column; align-items: center; gap: 0.4rem; padding: 0 0.85rem 0.7rem; pointer-events: none; }
+.smonte-corte { pointer-events: auto; border: none; cursor: pointer; font: 600 0.66rem/1 system-ui, sans-serif; color: #f4ecdd; background: rgba(24,16,7,0.55); padding: 0.4rem 0.75rem; border-radius: 99px; backdrop-filter: blur(3px); }
+.smonte-pie p { margin: 0; max-width: 40rem; text-align: center; padding: 0.4rem 0.85rem; border-radius: 0.7rem; background: rgba(24,16,7,0.5); backdrop-filter: blur(3px); color: #f4ecdd; font: 500 0.7rem/1.4 system-ui, sans-serif; }
+@media (max-width: 560px) {
+  .smonte-fila { bottom: 4.4rem; gap: 0.3rem; }
+  .smonte-chip { padding: 0.28rem 0.5rem; }
+}
+@media (prefers-reduced-motion: reduce) { .smonte-canvas { transition: none; } }
+`;
+
+/**
+ * SierraMonte3D — la vista global montable con su propio <Canvas>: la Sierra
+ * como macizo 3D que se orbita, con sus pisos como terreno y sus mundos colgando
+ * de la altura real. Decide su `tier` sola (override por prop).
+ *
+ * @param {object} props
+ * @param {'alto'|'medio'|'bajo'} [props.tier]        override; si no, `decidirTier`.
+ * @param {boolean} [props.reducedMotion]             override de calma.
+ * @param {(pisoId:string)=>void} [props.onEntrarPiso]
+ * @param {string}  [props.className]
+ * @param {(view:string, data?:any)=>void} [props.onNavigate] inyectada por el shell.
+ */
+export default function SierraMonte3D({
+  tier: tierProp,
+  reducedMotion: rmProp,
+  onEntrarPiso,
+  className = '',
+  onNavigate = undefined,
+}) {
+  const decidido = useMemo(() => decidirTier(), []);
+  const tier = tierProp || decidido.tier;
+  const reducedMotion = rmProp != null ? rmProp : decidido.reducedMotion;
+  const perfil = perfilDeTier(tier);
+
+  const entrarPiso = onEntrarPiso
+    ?? (onNavigate ? (pisoId) => onNavigate('montana_mundos', { piso: pisoId }) : undefined);
+  const verCorte = onNavigate ? () => onNavigate('sierra_corte') : undefined;
+
+  const [listo, setListo] = useState(false);
+
+  return (
+    <section
+      className={`smonte-root${className ? ` ${className}` : ''}`}
+      data-tier={tier}
+      aria-label="La Sierra Nevada como montaña 3D: gírela y toque un piso para entrar a su mundo"
+    >
+      <style>{CSS}</style>
+      <Canvas
+        className={`smonte-canvas${listo ? ' smonte-canvas--lista' : ''}`}
+        dpr={perfil.dpr}
+        gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+        shadows={perfil.sombras ? 'soft' : false}
+        camera={{ position: [R_MONTE * 0.06, H_PICO * 0.42, R_MONTE * 1.6], fov: 44 }}
+        frameloop={reducedMotion ? 'demand' : 'always'}
+        onCreated={() => setListo(true)}
+      >
+        <EscenaMonte tier={tier} reducedMotion={reducedMotion} onEntrarPiso={entrarPiso} />
+      </Canvas>
+      <div className="smonte-vineta" aria-hidden="true" />
+
+      <div className="smonte-chrome">
+        <h2 className="smonte-titulo">
+          <span className="smonte-titulo__cejilla">Sierra Nevada de Santa Marta</span>
+          La Sierra, del mar a la nieve
+          <small>Gire la montaña. Toque un piso para entrar a su mundo.</small>
+        </h2>
+
+        {/* Fila compacta de pisos abajo: acceso garantizado en móvil/gama baja
+            sin tapar la montaña (los pines flotantes son la vía 3D-nativa; esto
+            es la red de seguridad para dedos y lectores de pantalla). */}
+        <div className="smonte-fila" role="group" aria-label="Pisos térmicos, del mar al páramo">
+          {BANDAS.map((b) => {
+            const protegido = !b.cultivable;
+            return (
+              <button
+                key={b.id}
+                type="button"
+                className={`smonte-chip${protegido ? ' smonte-chip--paramo' : ''}`}
+                style={{ '--c': b.color }}
+                onClick={() => entrarPiso?.(b.id)}
+                title={MUNDO_ANCLA[b.id]}
+                aria-label={`Entrar al piso ${b.nombre}, ${b.min} a ${b.max} metros${protegido ? ', páramo protegido: se cuida, no se siembra' : ''}`}
+              >
+                <span className="smonte-chip__nom">{b.nombre}</span>
+                <span className="smonte-chip__cota">{b.min}–{b.max} m</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="smonte-pie">
+          {verCorte && (
+            <button type="button" className="smonte-corte" onClick={verCorte}>
+              Ver el corte de geografía (la vista-mapa)
+            </button>
+          )}
+          <p role="contentinfo">
+            Territorio ancestral y sagrado de los pueblos Kogui, Arhuaco (Iku),
+            Wiwa y Kankuamo — el Corazón del Mundo, dentro de la Línea Negra.
+            Representado con respeto.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/visual/mundo3d/sierra/sierraMonte.geom.js
+++ b/src/visual/mundo3d/sierra/sierraMonte.geom.js
@@ -1,0 +1,532 @@
+/*
+ * sierraMonte.geom — la GEOMETRÍA de la Sierra como MACIZO 3D DE VERDAD.
+ *
+ * A diferencia de `SierraCorteVertical` (un corte plano visto de frente — se
+ * lee como lámina de geografía, y ESO se guarda), aquí la montaña es un RELIEVE
+ * con volumen: un heightfield radial con crestas, contrafuertes y quebradas, que
+ * se ORBITA. Tiene cara, laderas y profundidad; la luz modela el relieve. El
+ * referente es Alto's Odyssey / Journey / Sable: terreno low-poly que se siente
+ * un LUGAR con presupuesto de teléfono barato.
+ *
+ * Cero three de render aquí: solo three-core (geometría + color por vértice) —
+ * corre headless y no toca WebGL. Lo consume `SierraMonte3D.jsx`.
+ *
+ * ── LOS DATOS SON DEL GRAFO (IDEAM/IGAC, 1093 aristas GROWS_IN) ──────────────
+ * Las cuatro bandas navegables salen de `pisosTermicos.js`:
+ *     cálido    0–1000 m     templado 1000–2000 m
+ *     frío      2000–3000 m  páramo   3000–4000 m
+ * Encima, la corona (superpáramo + nival, hasta 5 775 m) es roca y hielo: se
+ * mira, no se navega. La altura del terreno mapea a metros REALES (cima=5 775 m),
+ * así el color por vértice cae en su banda climática y la vegetación instanciada
+ * cambia con la altura: palma abajo, café, bosque de niebla, frailejón, y roca
+ * y nieve arriba.
+ *
+ * ── PRESUPUESTO (Android barato + Quadro M6000, gateado por tier) ────────────
+ * El terreno es UNA malla (rejilla polar, densidad por tier). La vegetación es
+ * un InstancedMesh por especie (una draw-call por especie por más matas que
+ * haya), con geometría FUSIONADA vía `fusionarSeguro` (la trampa del null
+ * silencioso queda cerrada). Color 100% horneado en vertexColors; cero texturas,
+ * cero DEM, cero GLTF.
+ */
+import * as THREE from 'three';
+import { CUMBRE_SIERRA_M } from '../pisosTermicos.js';
+import {
+  rng,
+  ruido3D,
+  ruidoFbm,
+  fusionarSeguro,
+  poner,
+  tuboOrganico,
+  taperLineal,
+  taperTronco,
+  curvaTronco,
+  hornearFollaje,
+  hornearCorteza,
+  sembrarFollaje,
+  matojoHoja,
+  pintarPlano,
+  pintarPorVertice,
+} from '../bosque/sombreadoVegetal.js';
+
+/* ── Dimensiones del macizo (unidades de mundo). El pie es ancho (cálido junto
+      al mar); la cima, fina y nevada. ── */
+export const R_MONTE = 11.5; // radio de la base al nivel del mar
+export const H_PICO = 10.5; // altura de la cima (alta y empinada: macizo imponente)
+export const Y_MAR = 0; // el mar al pie
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+const lerp = (a, b, t) => a + (b - a) * t;
+
+/** Altura de mundo → altitud en metros (proporción real: cima = 5 775 m). */
+export const metrosDeY = (y) => (clamp(y, 0, H_PICO) / H_PICO) * CUMBRE_SIERRA_M;
+/** Altitud en metros → altura de mundo. */
+export const yDeMetros = (m) => (clamp(m, 0, CUMBRE_SIERRA_M) / CUMBRE_SIERRA_M) * H_PICO;
+
+/* Silueta radial del macizo: cóncava (cae del pico al mar) con un ensanche de
+   falda en el pie —las estribaciones que tocan el Caribe—. */
+function perfilRadial(rn) {
+  const cuerpo = Math.pow(1 - rn, 1.05); // casi lineal: cuerpo lleno, no cinta fina
+  const falda = Math.exp(-rn * 9) * 0.05; // faldón corto: la montaña sube del mar sin plano vasto
+  return cuerpo + falda;
+}
+
+/**
+ * La ALTURA del terreno en (x, z). Determinista. Es el corazón de "montaña de
+ * verdad": sobre la silueta cóncava monta contrafuertes radiales (5 espolones
+ * que bajan por los flancos), quebradas talladas por ruido con cresta, y una
+ * asimetría de baja frecuencia para que NO sea un cono perfecto. Todo el
+ * relieve fino se amortigua con `damp` (0 en la cima y en el borde, máximo a
+ * media ladera) para que la cumbre quede limpia y la base se funda con el mar.
+ */
+export function alturaTerreno(x, z) {
+  const r = Math.hypot(x, z);
+  const rn = clamp(r / R_MONTE, 0, 1);
+  const ang = Math.atan2(z, x);
+  const damp = Math.sin(rn * Math.PI); // 0 en cima y borde, máx a media ladera
+
+  let h = perfilRadial(rn);
+  // Contrafuertes radiales: 5 espolones que bajan por las laderas.
+  const spur = Math.pow(Math.max(0, Math.cos(ang * 5 + Math.sin(rn * 4))), 1.5);
+  h += spur * 0.2 * damp;
+  // Quebradas y hombros: ruido con cresta (ridged) talla surcos y sub-cumbres.
+  const n = ruidoFbm(x * 0.16 + 3.3, 0, z * 0.16 - 1.7);
+  const ridged = 1 - Math.abs(n * 2 - 1);
+  h += (ridged - 0.4) * 0.16 * damp;
+  // Asimetría de baja frecuencia: rompe el cono (un flanco más lleno + un hombro
+  // lateral) — para que se lea macizo, no triángulo.
+  h += Math.cos(ang) * 0.09 * damp;
+  h += Math.cos(ang * 2 + 1.1) * 0.05 * damp;
+  // Rugosidad fina.
+  h += (ruido3D(x * 0.6 + 9, 2, z * 0.6) - 0.5) * 0.03 * damp;
+
+  h = Math.max(0, h);
+  h *= smoothstep(1.0, 0.82, rn); // se funde con el mar en el borde
+  return H_PICO * h;
+}
+
+/** Pendiente aproximada en (x,z): 0 llano, 1 vertical. Diferencias finitas. */
+export function pendienteTerreno(x, z, e = 0.35) {
+  const hx = alturaTerreno(x + e, z) - alturaTerreno(x - e, z);
+  const hz = alturaTerreno(x, z + e) - alturaTerreno(x, z - e);
+  const g = Math.hypot(hx, hz) / (2 * e);
+  return clamp(g / (g + 1.2), 0, 1);
+}
+
+/* ── Paleta de biomas del terreno (colores del SUELO/dosel bajo; los árboles
+      instanciados ponen el dosel alto encima). Cálido→frío→roca→nieve. ── */
+const COL = {
+  arena: new THREE.Color('#cdb98a'),
+  calido: new THREE.Color('#93813f'),
+  calidoV: new THREE.Color('#7c9646'),
+  templado: new THREE.Color('#5a8a3d'),
+  frio: new THREE.Color('#3c7b5f'),
+  paramo: new THREE.Color('#a89a63'), // pajonal pajizo-dorado (claro, se distingue)
+  paramoAlt: new THREE.Color('#8f978c'), // gris frío claro hacia la roca
+  roca: new THREE.Color('#726456'),
+  rocaAlt: new THREE.Color('#544a40'),
+  nieve: new THREE.Color('#f1f6f8'),
+  hielo: new THREE.Color('#d3e2e8'),
+};
+
+/* Rampa de bioma por altitud (metros → color base del suelo). */
+const RAMPA = [
+  { m: 0, c: COL.arena },
+  { m: 120, c: COL.calidoV },
+  { m: 1000, c: COL.calido },
+  { m: 1400, c: COL.templado },
+  { m: 2200, c: COL.frio },
+  { m: 3000, c: COL.paramo },
+  { m: 3700, c: COL.paramoAlt },
+  { m: 4100, c: COL.roca },
+  { m: 4700, c: COL.hielo },
+  { m: 5100, c: COL.nieve },
+];
+
+const _cr = new THREE.Color();
+function colorBioma(m) {
+  if (m <= RAMPA[0].m) return _cr.copy(RAMPA[0].c);
+  for (let i = 1; i < RAMPA.length; i++) {
+    if (m <= RAMPA[i].m) {
+      const a = RAMPA[i - 1];
+      const b = RAMPA[i];
+      const t = smoothstep(a.m, b.m, m);
+      return _cr.copy(a.c).lerp(b.c, t);
+    }
+  }
+  return _cr.copy(RAMPA[RAMPA.length - 1].c);
+}
+
+/**
+ * Construye la malla del macizo: rejilla polar (anillos × sectores) desplazada
+ * por `alturaTerreno`, con color por vértice horneado (bioma por altitud +
+ * roca en las pendientes fuertes + nieve arriba, modelada por la altura y la
+ * pendiente). Indexada; el llamador la desindexa si su tier hace flatShading.
+ *
+ * @param {number} anillos  resolución radial (perfil.segmentosTerreno).
+ * @param {number} [sectores]
+ */
+export function geometriaMonte(anillos = 48, sectores = 0) {
+  const RN = Math.max(10, anillos);
+  const SN = Math.max(16, sectores || Math.round(RN * 1.4));
+  const nV = (RN + 1) * (SN + 1);
+  const posArr = new Float32Array(nV * 3);
+  const uvArr = new Float32Array(nV * 2);
+
+  let p = 0;
+  let u = 0;
+  for (let i = 0; i <= RN; i++) {
+    const r = (i / RN) * R_MONTE;
+    for (let j = 0; j <= SN; j++) {
+      const a = (j / SN) * Math.PI * 2;
+      const x = Math.cos(a) * r;
+      const z = Math.sin(a) * r;
+      const y = alturaTerreno(x, z);
+      posArr[p++] = x;
+      posArr[p++] = y;
+      posArr[p++] = z;
+      uvArr[u++] = j / SN;
+      uvArr[u++] = i / RN;
+    }
+  }
+
+  const index = [];
+  const row = SN + 1;
+  for (let i = 0; i < RN; i++) {
+    for (let j = 0; j < SN; j++) {
+      const a = i * row + j;
+      const b = a + 1;
+      const c = (i + 1) * row + j;
+      const d = c + 1;
+      index.push(a, c, b, b, c, d);
+    }
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(posArr, 3));
+  geo.setAttribute('uv', new THREE.BufferAttribute(uvArr, 2));
+  geo.setIndex(index);
+  geo.computeVertexNormals();
+
+  // ── Color por vértice: bioma + roca por pendiente + nieve por altura/llano ──
+  const nrm = geo.getAttribute('normal');
+  const tmp = new THREE.Color();
+  pintarPorVertice(geo, (x, y, z, i) => {
+    const m = metrosDeY(y);
+    tmp.copy(colorBioma(m));
+    const pend = clamp(1 - nrm.getY(i), 0, 1); // 0 llano, 1 pared
+    // Roca desnuda en pendientes fuertes: fuerte solo arriba (peñascos del
+    // páramo/roca); abajo apenas un roce, para que los pisos verdes NO se
+    // embarren de marrón y el gradiente térmico se lea.
+    if (m < 4000) {
+      const roca = smoothstep(0.54, 0.86, pend);
+      tmp.lerp(m > 3400 ? COL.rocaAlt : COL.roca, roca * (m > 2900 ? 0.5 : 0.14));
+    }
+    // Nieve: corona la Sierra. Empieza abajo y cuaja fuerte; el tercio alto es
+    // blanco franco aunque la pared sea empinada (es "del mar a la NIEVE").
+    const alta = smoothstep(3400, 4100, m);
+    if (alta > 0) {
+      const cuaja = alta * (0.9 + 0.1 * (1 - pend));
+      tmp.lerp(m > 4300 ? COL.nieve : COL.hielo, clamp(cuaja, 0, 1));
+      if (m > 3900) tmp.lerp(COL.nieve, smoothstep(3900, 4800, m));
+    }
+    // Grano fino de color para que la ladera no sea plana.
+    const g = ruidoFbm(x * 0.5 + 21, y * 0.5, z * 0.5);
+    tmp.multiplyScalar(0.92 + g * 0.16);
+    return tmp;
+  });
+
+  return geo;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  VEGETACIÓN — una geometría fusionada por especie, luego instanciada         */
+/* -------------------------------------------------------------------------- */
+
+/* Cuántas matas de cada especie por tier. Son INSTANCIAS (no draw-calls: cada
+   especie es un solo InstancedMesh). 'bajo' deja lo mínimo que aún lee "montaña
+   con pisos". */
+export const VEG_TIER = {
+  alto: { palmera: 70, cafeto: 95, niebla: 85, frailejon: 70 },
+  medio: { palmera: 40, cafeto: 52, niebla: 46, frailejon: 40 },
+  bajo: { palmera: 12, cafeto: 16, niebla: 14, frailejon: 18 },
+};
+export const vegDeTier = (tier) => VEG_TIER[tier] || VEG_TIER.medio;
+
+/* Factor de detalle geométrico por tier (menos blobs/segmentos en gama baja). */
+export const CALIDAD_VEG = { alto: 1, medio: 0.66, bajo: 0.45 };
+export const calidadVeg = (tier) => CALIDAD_VEG[tier] ?? CALIDAD_VEG.medio;
+
+/* ── Un árbol frondoso genérico (café de sombra / árbol de niebla): tronco con
+      curva + corteza horneada, y una copa de matojos con sombreado de follaje
+      (AO + gradiente + contraluz). ── */
+function arbolFrondoso({ altura, radioCopa, base, sol, luz, corteza, nBlobs, q }, seed) {
+  const partes = [];
+  const curva = curvaTronco({ altura, inclina: 0.06, sinuoso: 0.08, giro: seed }, seed);
+  const tronco = tuboOrganico(curva, {
+    tubular: Math.max(4, Math.round(6 * q)),
+    radial: 5,
+    taper: taperTronco(altura * 0.06, altura * 0.02, 0.3),
+    arruga: 0.14,
+    semilla: seed,
+  });
+  hornearCorteza(tronco, { grieta: corteza.g, cuerpo: corteza.c, cresta: corteza.k });
+  partes.push(tronco);
+
+  const nb = Math.max(2, Math.round(nBlobs * q));
+  const cen = [0, altura * 0.92, 0];
+  const puntos = sembrarFollaje({
+    centro: cen, radio: radioCopa, achatado: 0.82, n: nb,
+    semilla: seed + 7, huecos: 0.36, mordida: 0.34, distMin: radioCopa * 0.42,
+  });
+  for (const pt of puntos) {
+    const rad = radioCopa * (0.42 + 0.3 * pt.esc);
+    const hoja = matojoHoja(rad, seed + Math.round(pt.pos[0] * 40) + 3, 0.4);
+    poner(hoja, pt.pos, pt.giro, [1, 1, 1]);
+    hornearFollaje(hoja, {
+      base, sol, luz, centro: pt.pos, radio: rad * 1.15,
+      yMin: altura * 0.5, yMax: altura + radioCopa, ao: 0.6, manchas: 0.14,
+    });
+    partes.push(hoja);
+  }
+  return fusionarSeguro(partes, 'arbol-frondoso');
+}
+
+/** Café / árbol de sombra (templado): bajo, copa redonda verde media. */
+export function geomCafeto(q = 1, seed = 3) {
+  return arbolFrondoso({
+    altura: 0.9, radioCopa: 0.42,
+    base: '#375f2c', sol: '#79a34a', luz: '#c8d888',
+    corteza: { g: '#3c2c1c', c: '#6a4d31', k: '#8a6942' },
+    nBlobs: 5, q,
+  }, seed);
+}
+
+/** Árbol de niebla / roble andino (frío): más alto, copa densa verde-hondo. */
+export function geomNiebla(q = 1, seed = 5) {
+  return arbolFrondoso({
+    altura: 1.35, radioCopa: 0.55,
+    base: '#264a34', sol: '#4f7d47', luz: '#a9c479',
+    corteza: { g: '#2a2016', c: '#4f3a26', k: '#6e5238' },
+    nBlobs: 7, q,
+  }, seed);
+}
+
+/* ── La palma de tierra caliente (cálido): estípite curvo alto y una corona de
+      hojas pinnadas que caen. Se lee "trópico" de un vistazo. ── */
+export function geomPalmera(q = 1, seed = 9) {
+  const partes = [];
+  const altura = 1.5;
+  const curva = curvaTronco({ altura, inclina: 0.16, sinuoso: 0.05, giro: seed }, seed);
+  const estipite = tuboOrganico(curva, {
+    tubular: Math.max(5, Math.round(7 * q)),
+    radial: 5,
+    taper: taperLineal(0.06, 0.045),
+    arruga: 0.16,
+    semilla: seed,
+  });
+  hornearCorteza(estipite, { grieta: '#5a4326', cuerpo: '#8a6a44', cresta: '#a98a5c', escalaGrano: 8 });
+  partes.push(estipite);
+
+  const cima = curva.getPointAt(1);
+  const nHojas = Math.max(4, Math.round(8 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const a = (i / nHojas) * Math.PI * 2 + seed;
+    // Hoja pinnada: un cono aplastado que cae, radiando de la corona.
+    const hoja = new THREE.ConeGeometry(0.12, 0.62, 4, 1, true);
+    hoja.scale(1, 1, 0.28); // aplastada: fronda, no pincho
+    hoja.translate(0, 0.31, 0);
+    const droop = 0.7 + (i % 3) * 0.12;
+    poner(
+      hoja,
+      [cima.x + Math.cos(a) * 0.16, cima.y + 0.02, cima.z + Math.sin(a) * 0.16],
+      [Math.PI / 2 - droop, -a, 0],
+    );
+    pintarPorVertice(hoja, (x, y) => {
+      // gradiente base→punta a lo largo de la fronda
+      const t = clamp((y - cima.y) / 0.7, 0, 1);
+      return _cr.copy(new THREE.Color('#3f6a2f')).lerp(new THREE.Color('#7fae4a'), t);
+    });
+    partes.push(hoja);
+  }
+  // cogollo central
+  const cogollo = matojoHoja(0.12, seed + 1, 0.3);
+  poner(cogollo, [cima.x, cima.y + 0.08, cima.z], [0, 0, 0]);
+  pintarPlano(cogollo, '#6a9a3f');
+  partes.push(cogollo);
+  return fusionarSeguro(partes, 'palmera');
+}
+
+/* ── El frailejón que GUARDA el páramo (Espeletia): tronco columnar con enagua
+      de hojas muertas, roseta lanuda plateada y flor. La firma del piso
+      protegido. ── */
+export function geomFrailejon(q = 1, seed = 11) {
+  const partes = [];
+  const altura = 0.6;
+  const curva = curvaTronco({ altura, inclina: 0.04, sinuoso: 0.03, giro: seed }, seed);
+  const tallo = tuboOrganico(curva, {
+    tubular: Math.max(3, Math.round(5 * q)),
+    radial: 6,
+    taper: taperLineal(0.07, 0.06),
+    arruga: 0.08,
+    semilla: seed,
+  });
+  hornearCorteza(tallo, { grieta: '#4a3a26', cuerpo: '#6f5c40', cresta: '#8a7350' });
+  partes.push(tallo);
+  // enagua: cono invertido de hojas secas alrededor del tallo
+  const enagua = new THREE.ConeGeometry(0.13, altura * 0.9, 8, 1, true);
+  enagua.translate(0, altura * 0.45, 0);
+  pintarPlano(enagua, '#7a6440');
+  partes.push(enagua);
+  // roseta lanuda plateada
+  const roseta = matojoHoja(0.15, seed + 2, 0.34);
+  roseta.scale(1, 0.62, 1);
+  poner(roseta, [0, altura + 0.02, 0], [0, 0, 0]);
+  hornearFollaje(roseta, {
+    base: '#8f9a7a', sol: '#c2ccb0', luz: '#dfe6cf',
+    centro: [0, altura + 0.02, 0], radio: 0.2, ao: 0.4, manchas: 0.1,
+  });
+  partes.push(roseta);
+  // flor
+  const flor = new THREE.SphereGeometry(0.05, 6, 5);
+  flor.translate(0, altura + 0.12, 0);
+  pintarPlano(flor, '#e8c53a');
+  partes.push(flor);
+  return fusionarSeguro(partes, 'frailejon');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Distribución biogeográfica: sembrar cada especie en SU banda de altitud     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Reparte las matas sobre la superficie del macizo, cada especie en la banda
+ * climática que le toca (palma <1000 m, café 1000–2000, niebla 2000–3000,
+ * frailejón 3000–4000). Evita las paredes muy empinadas y la corona nevada.
+ * Devuelve, por especie, los items {pos, rotY, escala, tint} que consume el
+ * InstancedMesh.
+ *
+ * @param {{palmera:number,cafeto:number,niebla:number,frailejon:number}} conteos
+ * @param {number} [seed]
+ */
+export function distribuirVegetacion(conteos, seed = 707) {
+  const r = rng(seed);
+  const out = { palmera: [], cafeto: [], niebla: [], frailejon: [] };
+  const cap = {
+    palmera: conteos.palmera || 0,
+    cafeto: conteos.cafeto || 0,
+    niebla: conteos.niebla || 0,
+    frailejon: conteos.frailejon || 0,
+  };
+  const total = cap.palmera + cap.cafeto + cap.niebla + cap.frailejon;
+  // Escalas PEQUEÑAS a propósito: la vegetación es textura de ladera, no
+  // protagonista — el macizo debe leerse como el gran landform. Un árbol ronda
+  // 0.3–0.6 unidades sobre una montaña de ~9.
+  const escalas = { palmera: [0.26, 0.42], cafeto: [0.22, 0.36], niebla: [0.26, 0.44], frailejon: [0.2, 0.36] };
+
+  const lleno = () =>
+    out.palmera.length >= cap.palmera &&
+    out.cafeto.length >= cap.cafeto &&
+    out.niebla.length >= cap.niebla &&
+    out.frailejon.length >= cap.frailejon;
+
+  let intentos = 0;
+  const maxIntentos = total * 40 + 200;
+  while (!lleno() && intentos < maxIntentos) {
+    intentos++;
+    const ang = r() * Math.PI * 2;
+    // radio en el CUERPO de la montaña (ni el pico, ni el faldón raso del mar)
+    const rn = 0.18 + Math.sqrt(r()) * 0.62;
+    const rad = rn * R_MONTE;
+    const x = Math.cos(ang) * rad;
+    const z = Math.sin(ang) * rad;
+    const y = alturaTerreno(x, z);
+    const m = metrosDeY(y);
+    if (m < 620 || m > 4000) continue; // arriba de la orilla; bajo la corona
+    if (pendienteTerreno(x, z) > 0.62) continue; // no en las paredes
+
+    let esp = null;
+    if (m < 1000) esp = 'palmera';
+    else if (m < 2000) esp = 'cafeto';
+    else if (m < 3000) esp = 'niebla';
+    else esp = 'frailejon';
+    if (out[esp].length >= cap[esp]) continue;
+
+    const [e0, e1] = escalas[esp];
+    out[esp].push({
+      pos: [x, y - 0.03, z],
+      rotY: r() * Math.PI * 2,
+      escala: e0 + r() * (e1 - e0),
+      tint: [0.9 + r() * 0.18, 0.92 + r() * 0.14, 0.9 + r() * 0.16],
+    });
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  El AGUA que baja del páramo: una quebrada que sigue el relieve real         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Traza una quebrada desde la banda de páramo (~3400 m) hasta el mar por un
+ * flanco, siguiendo la altura REAL del terreno (se apoya sobre el relieve, con
+ * un dedo de holgura). Es "de aquí baja el agua" hecho visible, sin cartel.
+ *
+ * @param {number} [azimut]  el flanco por el que baja (rad).
+ * @returns {THREE.CatmullRomCurve3}
+ */
+export function curvaQuebrada(azimut = -0.7) {
+  const pts = [];
+  const n = 24;
+  const yTop = yDeMetros(3400);
+  const rnTop = alturaARadio(yTop);
+  for (let i = 0; i <= n; i++) {
+    const t = i / n;
+    // baja de la cota del páramo al mar; serpentea de flanco
+    const rn = lerp(rnTop, 0.99, t);
+    const ang = azimut + Math.sin(t * Math.PI * 2.4) * 0.28 * (1 - t * 0.5);
+    const rad = rn * R_MONTE;
+    const x = Math.cos(ang) * rad;
+    const z = Math.sin(ang) * rad;
+    const y = alturaTerreno(x, z) + 0.06;
+    pts.push(new THREE.Vector3(x, y, z));
+  }
+  return new THREE.CatmullRomCurve3(pts);
+}
+
+/* Radio normalizado aproximado para una altura dada de la ladera (invierte el
+   perfil por muestreo: barato y suficiente para colgar el nacedero del agua). */
+function alturaARadio(yObjetivo) {
+  let mejor = 0.5;
+  let dif = Infinity;
+  for (let k = 6; k <= 60; k++) {
+    const rn = k / 60;
+    const y = alturaTerreno(Math.cos(0) * rn * R_MONTE, Math.sin(0) * rn * R_MONTE);
+    const d = Math.abs(y - yObjetivo);
+    if (d < dif) {
+      dif = d;
+      mejor = rn;
+    }
+  }
+  return mejor;
+}
+
+/**
+ * Punto de mundo sobre la superficie del macizo para colgar un hotspot de piso:
+ * a la cota media de la banda, en el azimut dado, un dedo sobre el terreno.
+ *
+ * @param {number} metros  altitud de la banda (m).
+ * @param {number} azimut  rad.
+ * @returns {[number,number,number]}
+ */
+export function puntoEnLadera(metros, azimut) {
+  const rn = alturaARadio(yDeMetros(metros));
+  const rad = rn * R_MONTE;
+  const x = Math.cos(azimut) * rad;
+  const z = Math.sin(azimut) * rad;
+  const y = alturaTerreno(x, z);
+  return [x, y, z];
+}


### PR DESCRIPTION
Reemplaza `sierra_global` por **SierraMonte3D**: un macizo 3D con relieve real (heightfield radial con crestas/contrafuertes/quebradas) que se **orbita**, con los pisos térmicos como terreno (color por altitud real + vegetación instanciada que cambia con la altura: palma → café → bosque de niebla → frailejón → roca y nieve), agua que baja del páramo, y hotspots + terreno clicable que entran a cada piso.

El corte vertical (`SierraCorteVertical`) se **guarda intacto** en la ruta secundaria `sierra_corte` (vista-mapa, comparable desde un enlace en la nueva vista). Procedural, geometría fusionada con `fusionarSeguro`, vertexColors, `InstancedMesh`, gateado por tier (`bajo` simplificado: baja resolución, poca vegetación, sin agua/bruma, cámara quieta).

Gates: `build:prod` verde · `tsc:check` 0 errores · eslint limpio. Capturas desde 3 ángulos confirman que se lee como montaña 3D de verdad, no dibujo plano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)