### PR TITLE
art(cafe): el mundo del café — cafetal bajo sombra navegable (piso templado)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -151,6 +151,11 @@ const VitrinaCriaturasMockup = lazy(() => import('./mockups/vitrina3d/VitrinaCri
 // Polylepis) — mallas three reales (tronco retorcido con rostro tallado, copa
 // instanciada), device-tiering real. Ruta #/mockups/bosque-vivo-3d, sin auth.
 const BosqueVivo3DMockup = lazy(() => import('./mockups/BosqueVivo3D'));
+// 3D: el MUNDO DEL CAFÉ — el cafetal bajo sombra del piso templado: surcos a
+// curva de nivel, cereza madurando verde→pintón→rojo por instancia, el sombrío
+// de guamos y nogales, y la casa-beneficiadero en la bruma. Device-tiering
+// real. Ruta #/mockups/cafetal-vivo-3d, sin auth.
+const CafetalVivo3DMockup = lazy(() => import('./mockups/CafetalVivo3D'));
 // 3D: el MUNDO SUELO VIVO — la RED MICORRÍZICA bajo tierra (el wood-wide web):
 // la red de hongos bioluminiscente que enlaza las raíces y reparte nutrientes,
 // con pulsos corriendo por los hilos y el Ent asomando. Device-tiering real.
@@ -570,6 +575,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo3d-milpa': 'mockup_mundo3d_milpa',
   'mockups/mundo3d-bosque': 'mockup_mundo3d_bosque',
   'mockups/bosque-vivo-3d': 'mockup_bosque_vivo_3d',
+  'mockups/cafetal-vivo-3d': 'mockup_cafetal_vivo_3d',
   'mockups/mundo3d-clima': 'mockup_mundo3d_clima',
   'mockups/voz-con-forma': 'mockup_voz_con_forma',
   'mockups/conversacion-voz': 'mockup_conversacion_voz',
@@ -1549,6 +1555,19 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El bosque vivo">
               <BosqueVivo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_cafetal_vivo_3d':
+        // Vitrina pública del MUNDO DEL CAFÉ: el cafetal bajo sombra del piso
+        // templado en 3D REAL — surcos a curva de nivel, cereza verde→pintón→
+        // rojo por instancia, el sombrío de guamos y nogales con su luz colada,
+        // y la casa-beneficiadero en la bruma. Cuatro pasos didácticos. En
+        // equipo humilde muestra la ficha. Ruta #/mockups/cafetal-vivo-3d.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo del café">
+              <CafetalVivo3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/CafetalVivo3D.css
+++ b/src/mockups/CafetalVivo3D.css
@@ -1,0 +1,233 @@
+/*
+ * CafetalVivo3D.css — vitrina del mundo del café (#/mockups/cafetal-vivo-3d).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Paleta de piso templado: verde cafetal, bruma clara y el rojo de la cereza.
+ * Solo opacity/transform se animan.
+ */
+
+.cviva {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background: linear-gradient(180deg, #cfe0d5 0%, #dde6d6 44%, #ece7d2 100%);
+  color: #2b3226;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.cviva__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.cviva__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8e3f2c;
+}
+.cviva__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #2e402e;
+}
+.cviva__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 40rem;
+}
+
+.cviva__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+.cviva__lienzo {
+  position: relative;
+  height: min(66vh, 32rem);
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(142, 63, 44, 0.25);
+  box-shadow: 0 12px 30px rgba(44, 54, 40, 0.16);
+  background: radial-gradient(120% 90% at 50% 20%, #c6dcd0 0%, #a8bfa8 100%);
+}
+.cviva__lienzo canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+  touch-action: none;
+}
+.cafetal-canvas {
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.cafetal-canvas--lista {
+  opacity: 1;
+}
+
+.cviva__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  color: #3c4a38;
+  opacity: 0.85;
+}
+
+.cviva__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.cviva__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.cviva__toggle {
+  border: 1.5px solid #8e3f2c;
+  background: #fff;
+  color: #8e3f2c;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.cviva__toggle:hover,
+.cviva__toggle:focus-visible {
+  background: #8e3f2c;
+  color: #fff;
+  outline-offset: 2px;
+}
+
+/* ---- Ficha 2D (fallback digno, sin GPU) ---- */
+.cviva__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  background: radial-gradient(120% 90% at 50% 25%, #d2ddc9 0%, #a3b295 100%);
+}
+.cviva__estampa {
+  position: relative;
+  width: 180px;
+  height: 175px;
+  margin-bottom: 0.4rem;
+}
+/* el guamo del sombrío, detrás y más alto */
+.cviva__guamo {
+  position: absolute;
+  top: 0;
+  left: 18px;
+  width: 130px;
+  height: 62px;
+  border-radius: 56% 44% 60% 40% / 70% 74% 26% 30%;
+  background: radial-gradient(circle at 42% 30%, #74995177 0%, #4b7c3a 65%, #3d6630 100%);
+  box-shadow: inset -8px -6px 14px rgba(0, 0, 0, 0.16);
+}
+.cviva__guamo-tronco {
+  position: absolute;
+  top: 48px;
+  left: 76px;
+  width: 14px;
+  height: 78px;
+  border-radius: 40%;
+  background: linear-gradient(90deg, #4f3c28 0%, #6b533a 55%, #4a3a26 100%);
+}
+/* el cafeto abajo, tupido y cargado */
+.cviva__cafeto {
+  position: absolute;
+  bottom: 0;
+  left: 50px;
+  width: 92px;
+  height: 78px;
+  border-radius: 48% 52% 44% 56% / 62% 58% 42% 38%;
+  background: radial-gradient(circle at 38% 32%, #477a3d 0%, #2e5c33 70%, #234b28 100%);
+  box-shadow: inset -7px -6px 12px rgba(0, 0, 0, 0.2);
+}
+.cviva__cereza {
+  position: absolute;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  box-shadow: inset -2px -2px 3px rgba(0, 0, 0, 0.28);
+}
+.cviva__cereza--verde { top: 18px; left: 14px; background: #6f9e3c; }
+.cviva__cereza--pinton { top: 40px; left: 60px; background: #dca63c; }
+.cviva__cereza--roja { top: 30px; left: 38px; background: #c1301f; }
+.cviva__cereza--roja2 { top: 52px; left: 26px; background: #a82818; }
+.cviva__ficha-nombre {
+  margin: 0;
+  font-weight: 800;
+  font-size: 1rem;
+  color: #2e402e;
+}
+.cviva__ficha-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4c5a44;
+}
+
+/* ---- Saberes ---- */
+.cviva__saberes {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.cviva__saberes h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #2e402e;
+}
+.cviva__saberes ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .cviva__saberes ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.cviva__saberes li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(142, 63, 44, 0.16);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.cviva__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.cviva__saberes b {
+  display: block;
+  font-size: 0.92rem;
+  color: #2e402e;
+}
+.cviva__saberes li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.cviva__cierre {
+  margin: 0.9rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #3c4a38;
+  max-width: 42rem;
+}

--- a/src/mockups/CafetalVivo3D.jsx
+++ b/src/mockups/CafetalVivo3D.jsx
@@ -1,0 +1,155 @@
+/*
+ * CafetalVivo3D — vitrina pública del MUNDO DEL CAFÉ: el cafetal bajo sombra
+ * del piso templado (1.000–2.000 m). Ruta #/mockups/cafetal-vivo-3d, sin auth.
+ *
+ * El café es EL cultivo del campesino colombiano, y aquí se muestra como es de
+ * verdad en la montaña: una ladera navegable sembrada en surcos a curva de
+ * nivel, los cafetos con su cereza madurando del verde al rojo, y ARRIBA el
+ * SOMBRÍO — guamos y nogales cafeteros que le hacen techo al cultivo — con el
+ * plátano intercalado y la casa-beneficiadero asomando en la bruma del fondo.
+ * Cuatro pasos cortos recorren la lección: qué es el sombrío, por qué el café
+ * va bajo sombra, cómo madura la cereza y a dónde va el grano.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el mundo 3D (chunk
+ * perezoso `vendor-three`); en equipo humilde, ahorro de datos o sin-WebGL se
+ * ve la ficha del cafetal, digna y sin sudar la GPU. Copy en español de
+ * Colombia, en "usted". Autocontenida: cero CDN/imágenes externas.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import './CafetalVivo3D.css';
+
+const MundoCafetal = lazy(() => import('../visual/mundo3d/cafetal/MundoCafetal.jsx'));
+
+/* Lo que enseña el cafetal (verificado, en "usted"). */
+const SABERES = [
+  {
+    emoji: '🌳',
+    titulo: 'El sombrío no estorba: trabaja',
+    texto:
+      'Guamos y nogales cafeteros se siembran a propósito entre el café. Su techo de hojas baja el sol quemante, guarda la humedad y la hoja que cae abona el suelo sin costar un peso.',
+  },
+  {
+    emoji: '🐦',
+    titulo: 'Café con sombra es café con vida',
+    texto:
+      'Bajo el sombrío vuelven las aves, las mariposas y los polinizadores que el café a pleno sol espanta. Un cafetal con sombra es medio bosque: produce café y cuida el monte a la vez.',
+  },
+  {
+    emoji: '🍒',
+    titulo: 'La cereza se coge roja, a mano',
+    texto:
+      'El fruto nace verde, pinta amarillo y madura rojo cereza. A la sombra madura despacio, y grano que madura despacio da taza más dulce. Por eso se cosecha grano a grano, solo el maduro.',
+  },
+  {
+    emoji: '🏡',
+    titulo: 'Del cerezo al pergamino',
+    texto:
+      'La cereza cogida se despulpa, se lava y se seca en la marquesina de la casa hasta volverse café pergamino: el grano que la familia vende. El tueste ya es del otro lado, no del campo.',
+  },
+];
+
+export default function CafetalVivo3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  return (
+    <main className="cviva">
+      <header className="cviva__head">
+        <p className="cviva__kicker">El mundo del café · vitrina</p>
+        <h1>El cafetal bajo sombra</h1>
+        <p className="cviva__lema">
+          La ladera cafetera como es de verdad: los surcos a curva de nivel, la
+          cereza pintando del verde al rojo y el sombrío tendiéndole techo al
+          cultivo. Recórrala con el dedo y siga los cuatro pasos de la lección.
+        </p>
+      </header>
+
+      <section className="cviva__escena" aria-label="El cafetal bajo sombra en 3D">
+        <div className="cviva__lienzo">
+          {mostrar3D ? (
+            <Suspense
+              fallback={
+                <div className="cviva__cargando" role="status">
+                  Subiendo a la ladera…
+                </div>
+              }
+            >
+              <MundoCafetal tier={tier} reducedMotion={reducedMotion} />
+            </Suspense>
+          ) : (
+            <FichaCafetal />
+          )}
+        </div>
+
+        <div className="cviva__barra">
+          <p className="cviva__tier">
+            {mostrar3D
+              ? 'Está viendo el cafetal en 3D. Gírelo con el dedo o el mouse y siga los pasos.'
+              : puede3D
+                ? 'Está viendo la ficha del cafetal.'
+                : 'Su equipo ve la ficha del cafetal (va parejo en cualquier teléfono).'}
+          </p>
+          {puede3D && (
+            <button type="button" className="cviva__toggle" onClick={() => setVer2d((v) => !v)}>
+              {ver2d ? 'Ver el cafetal en 3D' : 'Ver la ficha'}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <section className="cviva__saberes" aria-label="Lo que enseña el cafetal">
+        <h2>Lo que le enseña este cafetal</h2>
+        <ol>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span className="cviva__emoji" aria-hidden="true">
+                {s.emoji}
+              </span>
+              <div>
+                <b>{s.titulo}</b>
+                <p>{s.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="cviva__cierre">
+          El café no es una plantación a pleno sol: es un cultivo de montaña que
+          vive mejor acompañado. Donde hay sombrío hay suelo vivo, hay pájaros y
+          hay taza dulce — y eso no cuesta cemento.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+/* La ficha del cafetal: el fallback digno para equipo humilde / sin-WebGL.
+   Un cafeto CSS con sus cerezas y el guamo detrás — cero GPU. */
+function FichaCafetal() {
+  return (
+    <div className="cviva__ficha" role="img" aria-label="El cafetal bajo sombra: cafeto con cerezas y su árbol de sombrío">
+      <div className="cviva__estampa" aria-hidden="true">
+        <span className="cviva__guamo" />
+        <span className="cviva__guamo-tronco" />
+        <span className="cviva__cafeto">
+          <span className="cviva__cereza cviva__cereza--verde" />
+          <span className="cviva__cereza cviva__cereza--pinton" />
+          <span className="cviva__cereza cviva__cereza--roja" />
+          <span className="cviva__cereza cviva__cereza--roja2" />
+        </span>
+      </div>
+      <p className="cviva__ficha-nombre">El cafetal bajo sombra</p>
+      <p className="cviva__ficha-sub">Piso templado · el cultivo bandera del campesino</p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
+++ b/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
@@ -1,0 +1,343 @@
+/*
+ * EscenaCafetalVivo — el MUNDO donde vive el café (piso templado, 1.000–2.000 m).
+ *
+ * Una LADERA de la montaña cafetera al final de la mañana: luz tibia de media
+ * montaña, bruma que se come el valle del fondo, y el cultivo contado como es —
+ * los surcos de cafetos a curva de nivel ABAJO, el SOMBRÍO de guamos y nogales
+ * ARRIBA tendiéndoles techo, el plátano intercalado, y al fondo, medio velada
+ * por la bruma, la casa campesina con su beneficiadero y la marquesina de secar.
+ * La cámara mira la ladera desde abajo, como quien llega subiendo; se puede
+ * girar con el dedo.
+ *
+ * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`: 'alto' con
+ * sombras + bruma + luz colada; 'medio' frugal; 'bajo' mínimo. Con
+ * `reducedMotion` el mundo monta QUIETO (frameloop a demanda). La fauna son los
+ * SVG rubber-hose de la casa como billboards (`Fauna` de FaunaEscena): mariposa
+ * y colibrí — la vida que el café de sombra sí recibe y el de sol espanta.
+ *
+ * `foco` (opcional): un punto [x,y,z] que el paso didáctico del host señala con
+ * un anillo que respira. Importa three/@react-three → montar SOLO perezosa.
+ */
+import { useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { perfilDeTier } from '../deviceTier.js';
+import { Fauna } from '../escenas/FaunaEscena.jsx';
+import FloraCafetal from './FloraCafetal.jsx';
+import { ANCHO, FONDO, alturaLadera, SITIO_CASA } from './floraCafetal.geom.js';
+
+/* La atmósfera del piso templado: cielo claro con bruma tibia de media montaña. */
+const TEMPLADO = {
+  fondo: '#c3dcd2',
+  bruma: '#cde2d6',
+  sol: '#fff0c8',
+  cielo: '#e6f2e2',
+  suelo: '#4f4030',
+};
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
+    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
+    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
+  );
+}
+
+/* La malla de la ladera con colores por vértice: arvenses verdes (cobertura
+   viva), tierra roja andina asomando y el mantillo pardo hacia la sombra. */
+function construirLadera(seg, plano) {
+  const nx = seg + 1;
+  const nz = seg + 1;
+  const pos = new Float32Array(nx * nz * 3);
+  const col = new Float32Array(nx * nz * 3);
+  const cPasto = new THREE.Color('#79994b');
+  const cPasto2 = new THREE.Color('#8aa855');
+  const cTierra = new THREE.Color('#8a5636');
+  const cMantillo = new THREE.Color('#7d6540');
+  const cCamino = new THREE.Color('#a9825a');
+  const c = new THREE.Color();
+  let p = 0;
+  for (let iz = 0; iz < nz; iz++) {
+    const wz = -FONDO / 2 + (FONDO * iz) / seg;
+    for (let ix = 0; ix < nx; ix++) {
+      const wx = -ANCHO / 2 + (ANCHO * ix) / seg;
+      pos[p] = wx;
+      pos[p + 1] = alturaLadera(wx, wz);
+      pos[p + 2] = wz;
+      const enLoma = smoothstep(5, -8, wz);
+      c.lerpColors(cPasto, cPasto2, 0.5 + 0.5 * ruido(wx * 0.9, wz * 0.7));
+      // la tierra roja asoma a manchas entre los surcos
+      c.lerp(cTierra, smoothstep(-0.1, 0.85, ruido(wx * 1.3, wz * 1.1)) * 0.45 * enLoma);
+      // el mantillo pardo gana hacia lo alto (más sombrío, más hojarasca)
+      c.lerp(cMantillo, enLoma * 0.22);
+      // el caminito seco del frente, por donde se llega
+      c.lerp(cCamino, smoothstep(1.2, 0, Math.abs(wx - Math.sin(wz * 0.4) * 2.2)) * smoothstep(2, 12, wz));
+      col[p] = c.r;
+      col[p + 1] = c.g;
+      col[p + 2] = c.b;
+      p += 3;
+    }
+  }
+  const idx = [];
+  for (let iz = 0; iz < seg; iz++) {
+    for (let ix = 0; ix < seg; ix++) {
+      const a = iz * nx + ix;
+      const b = a + 1;
+      const d = a + nx;
+      const e = d + 1;
+      idx.push(a, d, b, b, d, e);
+    }
+  }
+  let geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  geo.setIndex(idx);
+  if (plano) geo = geo.toNonIndexed();
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/* La casa campesina con su BENEFICIADERO, arriba al fondo: paredes encaladas,
+   techo de teja, y al lado la marquesina — la cama elevada bajo plástico donde
+   el café pergamino se seca al sol. Insinuada, medio velada por la bruma. */
+function CasaBeneficio({ pos }) {
+  return (
+    <group position={pos} rotation={[0, -0.35, 0]}>
+      {/* la casa: paredes encaladas y zócalo rojo de finca cafetera */}
+      <mesh position={[0, 0.72, 0]}>
+        <boxGeometry args={[2.6, 1.44, 1.9]} />
+        <meshLambertMaterial color="#efe8d8" flatShading />
+      </mesh>
+      <mesh position={[0, 0.18, 0]}>
+        <boxGeometry args={[2.64, 0.36, 1.94]} />
+        <meshLambertMaterial color="#8e3f2c" flatShading />
+      </mesh>
+      {/* la puerta y una ventana (maderas de colores, como se pintan allá) */}
+      <mesh position={[0.5, 0.62, 0.96]}>
+        <boxGeometry args={[0.44, 0.95, 0.06]} />
+        <meshLambertMaterial color="#3f6b6e" flatShading />
+      </mesh>
+      <mesh position={[-0.6, 0.86, 0.96]}>
+        <boxGeometry args={[0.5, 0.44, 0.06]} />
+        <meshLambertMaterial color="#3f6b6e" flatShading />
+      </mesh>
+      {/* techo a dos aguas de teja */}
+      <mesh position={[0, 1.62, -0.62]} rotation={[-0.62, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.5]} />
+        <meshLambertMaterial color="#9c4a30" flatShading />
+      </mesh>
+      <mesh position={[0, 1.62, 0.62]} rotation={[0.62, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.5]} />
+        <meshLambertMaterial color="#a85236" flatShading />
+      </mesh>
+
+      {/* la MARQUESINA de secado, al lado: patas + cama de pergamino + techo
+          translúcido a dos aguas (la señal del beneficio) */}
+      <group position={[2.6, 0, 0.4]}>
+        {[[-1.0, -0.55], [1.0, -0.55], [-1.0, 0.55], [1.0, 0.55]].map((q, i) => (
+          <mesh key={i} position={[q[0], 0.35, q[1]]}>
+            <boxGeometry args={[0.09, 0.7, 0.09]} />
+            <meshLambertMaterial color="#6b533a" flatShading />
+          </mesh>
+        ))}
+        <mesh position={[0, 0.72, 0]}>
+          <boxGeometry args={[2.2, 0.07, 1.3]} />
+          <meshLambertMaterial color="#b99a68" flatShading />
+        </mesh>
+        {/* el café pergamino extendido secándose al sol */}
+        <mesh position={[0, 0.77, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[2.0, 1.1]} />
+          <meshLambertMaterial color="#dcc494" flatShading />
+        </mesh>
+        {[[-1.05, -0.62], [1.05, -0.62], [-1.05, 0.62], [1.05, 0.62]].map((q, i) => (
+          <mesh key={`p${i}`} position={[q[0], 1.15, q[1]]}>
+            <boxGeometry args={[0.06, 0.85, 0.06]} />
+            <meshLambertMaterial color="#6b533a" flatShading />
+          </mesh>
+        ))}
+        <mesh position={[0, 1.62, -0.36]} rotation={[-0.5, 0, 0]}>
+          <planeGeometry args={[2.4, 0.95]} />
+          <meshBasicMaterial color="#fbf3da" transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+        </mesh>
+        <mesh position={[0, 1.62, 0.36]} rotation={[0.5, 0, 0]}>
+          <planeGeometry args={[2.4, 0.95]} />
+          <meshBasicMaterial color="#fbf3da" transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+        </mesh>
+      </group>
+
+      {/* dos canastos de cosecha esperando en el patio */}
+      {[[-1.8, 0.6], [-1.35, 0.9]].map((q, i) => (
+        <group key={`c${i}`} position={[q[0], 0, q[1]]}>
+          <mesh position={[0, 0.18, 0]}>
+            <cylinderGeometry args={[0.24, 0.17, 0.36, 9, 1, true]} />
+            <meshLambertMaterial color="#a9713c" flatShading side={THREE.DoubleSide} />
+          </mesh>
+          <mesh position={[0, 0.36, 0]} scale={[1, 0.4, 1]}>
+            <sphereGeometry args={[0.2, 8, 5]} />
+            <meshLambertMaterial color="#c1301f" flatShading />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}
+
+/* El anillo del paso didáctico: respira sobre el punto que la lección señala.
+   Con reducedMotion queda quieto (presencia sin parpadeo). */
+function FocoPaso({ foco, reducedMotion }) {
+  const anillo = useRef(null);
+  useFrame(({ clock }) => {
+    const m = anillo.current;
+    if (!m) return;
+    if (reducedMotion) {
+      m.material.opacity = 0.42;
+      return;
+    }
+    const t = clock.elapsedTime;
+    m.material.opacity = 0.3 + 0.2 * Math.sin(t * 1.8);
+    m.scale.setScalar(1 + 0.06 * Math.sin(t * 1.8));
+  });
+  if (!foco) return null;
+  return (
+    <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+      <ringGeometry args={[1.25, 1.65, 32]} />
+      <meshBasicMaterial
+        color="#ffdf9e"
+        transparent
+        opacity={0.4}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+/* La fauna del café de sombra: los SVG rubber-hose de la casa como billboards
+   (contrato del operador: el bicho pone el cuerpo, la escena la coreografía).
+   Pocas y por criterio: la sombra ES el hábitat que las trae. */
+const FAUNA_CAFETAL = [
+  { tipo: 'mariposa', base: [-3.2, 1.7, 2.2], patron: 'revoloteo', size: 26, fase: 0.7, df: 9 },
+  { tipo: 'colibri', base: [4.2, 2.6, -2.6], patron: 'revoloteo', size: 30, fase: 1.9, df: 10 },
+  { tipo: 'mariposa', base: [7.2, 1.9, 0.6], patron: 'revoloteo', size: 22, fase: 2.9, df: 9 },
+];
+
+function Diorama({ tier, reducedMotion, foco }) {
+  const perfil = perfilDeTier(tier);
+
+  const geoLadera = useMemo(
+    () => construirLadera(perfil.segmentosTerreno, perfil.flatShading),
+    [perfil.segmentosTerreno, perfil.flatShading],
+  );
+
+  const fauna = useMemo(
+    () => (tier === 'alto' ? FAUNA_CAFETAL : FAUNA_CAFETAL.slice(0, 2)),
+    [tier],
+  );
+
+  const casaY = alturaLadera(SITIO_CASA[0], SITIO_CASA[1]);
+
+  return (
+    <>
+      <color attach="background" args={[TEMPLADO.fondo]} />
+      {perfil.fog && <fog attach="fog" args={[TEMPLADO.bruma, 16, 46]} />}
+
+      {/* la luz templada de media montaña: cielo claro, sol tibio, bruma */}
+      <hemisphereLight intensity={0.9} color={TEMPLADO.cielo} groundColor={TEMPLADO.suelo} />
+      <ambientLight intensity={0.32} color="#f2ecd6" />
+      <directionalLight
+        position={[8, 12, 5]}
+        intensity={1.2}
+        color={TEMPLADO.sol}
+        castShadow={perfil.sombras}
+        shadow-mapSize-width={1024}
+        shadow-mapSize-height={1024}
+        shadow-camera-near={1}
+        shadow-camera-far={40}
+        shadow-camera-left={-16}
+        shadow-camera-right={16}
+        shadow-camera-top={16}
+        shadow-camera-bottom={-6}
+      />
+      {/* contraluz fresco que separa el sombrío de la bruma */}
+      <directionalLight position={[-6, 6, -7]} intensity={0.35} color="#cfe0dc" />
+
+      {/* LA LADERA (recibe la sombra del sombrío en gama alta) */}
+      <mesh geometry={geoLadera} receiveShadow={perfil.sombras}>
+        <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
+      </mesh>
+
+      {/* las montañas cafeteras del fondo, comidas por la bruma */}
+      <mesh position={[-13, 2.2, -21]} scale={[9, 4.2, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color="#5d7a4e" />
+      </mesh>
+      <mesh position={[9, 2.6, -24]} scale={[11, 5.4, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color="#54704b" />
+      </mesh>
+      <mesh position={[22, 1.6, -20]} scale={[8, 3.4, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color="#647f52" />
+      </mesh>
+
+      {/* EL CAFETAL: surcos, cerezas, sombrío, plátano, luz colada */}
+      <FloraCafetal tier={tier} reducedMotion={reducedMotion} />
+
+      {/* la casa con su beneficiadero, arriba al fondo */}
+      <CasaBeneficio pos={[SITIO_CASA[0], casaY, SITIO_CASA[1]]} />
+
+      {/* LA VIDA que la sombra trae: mariposas y el colibrí */}
+      {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
+
+      {/* el anillo del paso didáctico (lo maneja el host) */}
+      <FocoPaso foco={foco} reducedMotion={reducedMotion} />
+
+      <OrbitControls
+        makeDefault
+        target={[0, 2.6, -3]}
+        enablePan={false}
+        enableZoom
+        minDistance={8}
+        maxDistance={24}
+        minPolarAngle={0.5}
+        maxPolarAngle={1.45}
+        minAzimuthAngle={-1.1}
+        maxAzimuthAngle={1.1}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.12}
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * El mundo del cafetal bajo sombra. Montar SOLO perezosa (lazy).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, foco?: number[]|null}} props
+ */
+export default function EscenaCafetalVivo({ tier = 'alto', reducedMotion = false, foco = null }) {
+  const perfil = perfilDeTier(tier);
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`cafetal-canvas${listo ? ' cafetal-canvas--lista' : ''}`}
+      dpr={perfil.dpr}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      shadows={perfil.sombras ? 'soft' : false}
+      camera={{ position: [1.5, 4.6, 14.5], fov: 46 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Diorama tier={tier} reducedMotion={reducedMotion} foco={foco} />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/cafetal/FloraCafetal.jsx
+++ b/src/visual/mundo3d/cafetal/FloraCafetal.jsx
@@ -1,0 +1,199 @@
+/*
+ * FloraCafetal — el CAFETAL BAJO SOMBRA sembrado en la ladera.
+ *
+ * Consume `floraCafetal.geom.js`: cada especie es UN InstancedMesh de una
+ * geometría fusionada (una draw-call por especie, por más matas que haya) —
+ * mismo contrato tier-safe que `FloraParamo` del bosque. La CEREZA lleva color
+ * POR INSTANCIA (verde → pintón → rojo): un solo InstancedMesh cuenta todos los
+ * estados de maduración del grano.
+ *
+ * En 'alto' se suma la LUZ COLADA: dapples dorados que respiran en el suelo
+ * bajo las copas del sombrío — el sol filtrándose entre las hojas del guamo,
+ * la imagen que explica el mundo entero. `reducedMotion` los deja quietos.
+ *
+ * Componente r3f: montar dentro del <Canvas> de EscenaCafetalVivo.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import {
+  cafetalDeTier,
+  calidadCafetal,
+  distribucionCafetal,
+  centrosSombrio,
+  alturaLadera,
+  geomCafeto,
+  geomCereza,
+  geomGuamo,
+  geomNogal,
+  geomPlatano,
+  geomHojarasca,
+  geomPiedra,
+} from './floraCafetal.geom.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* Un banco de matas de UNA especie: una geometría, un material, N instancias.
+   (Mismo patrón que `Especie` de FloraParamo — el molde de la casa.) */
+function Especie({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+    />
+  );
+}
+
+/*
+ * La LUZ COLADA bajo el sombrío: discos dorados aditivos sobre el suelo, que
+ * respiran apenas (el sol moviéndose entre las hojas). Solo 'alto'; con
+ * reducedMotion quedan quietos (presencia sin parpadeo).
+ */
+function LuzColada({ centros, reducedMotion }) {
+  const grupo = useRef(null);
+  const manchas = useMemo(() => {
+    const r = rng(97);
+    const lista = [];
+    centros.forEach((c) => {
+      const n = 3 + Math.floor(r() * 3);
+      for (let i = 0; i < n; i++) {
+        const x = c[0] + (r() - 0.5) * 3.6;
+        const z = c[2] + (r() - 0.5) * 3.6;
+        lista.push({
+          pos: /** @type {[number, number, number]} */ ([x, alturaLadera(x, z) + 0.05, z]),
+          r: 0.45 + r() * 0.65,
+          fase: r() * Math.PI * 2,
+          op: 0.09 + r() * 0.06,
+        });
+      }
+    });
+    return lista;
+  }, [centros]);
+
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (reducedMotion || !g) return;
+    const t = clock.elapsedTime;
+    for (let i = 0; i < g.children.length; i++) {
+      const m = g.children[i];
+      const d = manchas[i];
+      m.material.opacity = d.op * (0.55 + 0.45 * Math.sin(t * 0.7 + d.fase));
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {manchas.map((d, i) => (
+        <mesh key={i} position={d.pos} rotation={[-Math.PI / 2, 0, 0]}>
+          <circleGeometry args={[d.r, 14]} />
+          <meshBasicMaterial
+            color="#ffe9b8"
+            transparent
+            opacity={d.op}
+            depthWrite={false}
+            blending={THREE.AdditiveBlending}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/**
+ * La capa viva del cafetal. Montar dentro del <Canvas>.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function FloraCafetal({ tier = 'alto', reducedMotion = false }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = cafetalDeTier(tier);
+  const q = calidadCafetal(tier);
+
+  // Geometrías fusionadas (una vez por tier).
+  const geos = useMemo(
+    () => ({
+      cafeto: geomCafeto({ q }, 21),
+      cereza: geomCereza(),
+      guamo: conteos.guamo ? geomGuamo({ q }, 22) : null,
+      nogal: conteos.nogal ? geomNogal({ q }, 23) : null,
+      platano: conteos.platano ? geomPlatano({ q }, 24) : null,
+      hojarasca: conteos.hojarasca ? geomHojarasca(25) : null,
+      piedra: conteos.piedra ? geomPiedra(26) : null,
+    }),
+    [conteos, q],
+  );
+
+  // Material único con vertexColors (el color viene horneado por especie y el
+  // tinte por instancia lo multiplica — en la cereza el tinte ES el color).
+  const mat = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.85, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  // Distribución determinista (una vez por tier).
+  const dist = useMemo(() => distribucionCafetal(conteos, 311), [conteos]);
+  const centros = useMemo(() => centrosSombrio(conteos), [conteos]);
+
+  // Liberar GPU al desmontar.
+  useLayoutEffect(
+    () => () => {
+      Object.values(geos).forEach((g) => g && g.dispose());
+      mat.dispose();
+    },
+    [geos, mat],
+  );
+
+  const sombra = perfil.sombras; // solo el sombrío proyecta sombra en 'alto'
+
+  return (
+    <group>
+      {/* El suelo del cafetal: hojarasca bajo el sombrío, piedras. */}
+      <Especie geo={geos.hojarasca} mat={mat} items={dist.hojarasca} />
+      <Especie geo={geos.piedra} mat={mat} items={dist.piedra} />
+
+      {/* EL CULTIVO: los surcos de cafetos y sus cerezas (verde→pintón→rojo). */}
+      <Especie geo={geos.cafeto} mat={mat} items={dist.cafeto} />
+      <Especie geo={geos.cereza} mat={mat} items={dist.cereza} />
+
+      {/* EL SOMBRÍO: guamos y nogales que le hacen techo al café. */}
+      <Especie geo={geos.guamo} mat={mat} items={dist.guamo} castShadow={sombra} />
+      <Especie geo={geos.nogal} mat={mat} items={dist.nogal} castShadow={sombra} />
+
+      {/* El plátano intercalado del cafetal campesino. */}
+      <Especie geo={geos.platano} mat={mat} items={dist.platano} castShadow={sombra} />
+
+      {/* La luz que se cuela entre las hojas del sombrío (solo gama alta). */}
+      {tier === 'alto' && <LuzColada centros={centros} reducedMotion={reducedMotion} />}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/cafetal/MundoCafetal.jsx
+++ b/src/visual/mundo3d/cafetal/MundoCafetal.jsx
@@ -1,0 +1,143 @@
+/*
+ * MundoCafetal — el MUNDO DEL CAFÉ completo: la ladera navegable + la lección.
+ *
+ * Mismo contrato de host que MundoEntBosque: acepta `{tier, reducedMotion}` (o
+ * auto-detecta con decidirTier si se monta suelto), llena a su padre y guarda
+ * su estado local. Sobre la escena viven los PASOS: cuatro lecciones cortas que
+ * recorren lo que este mundo enseña — qué es el sombrío, por qué el café va
+ * bajo sombra, cómo madura la cereza y a dónde va el grano — y cada paso
+ * señala SU lugar en la ladera con un anillo que respira (el `foco` que la
+ * escena dibuja). Copy en español de Colombia, en "usted".
+ *
+ * Importa three/@react-three (vía la escena) → montar SOLO perezoso (lazy).
+ */
+import { useMemo, useState } from 'react';
+import EscenaCafetalVivo from './EscenaCafetalVivo.jsx';
+import { decidirTier, permite3D } from '../deviceTier.js';
+import { alturaLadera } from './floraCafetal.geom.js';
+
+/* Los cuatro pasos de la lección. Cada `foco` es el punto de la ladera que el
+   anillo señala mientras se lee (coordenadas del mundo, y sobre el terreno). */
+const enSuelo = (x, z) => [x, alturaLadera(x, z), z];
+const PASOS = [
+  {
+    id: 'sombrio',
+    kicker: 'Paso 1 de 4 · El sombrío',
+    texto:
+      'Los árboles altos que ve entre el café no estorban: son el SOMBRÍO. Guamos y nogales cafeteros sembrados a propósito, que le tienden un techo de hojas al cultivo.',
+    foco: enSuelo(-1.5, -8.5),
+  },
+  {
+    id: 'sombra',
+    kicker: 'Paso 2 de 4 · ¿Por qué bajo sombra?',
+    texto:
+      'La sombra baja el sol quemante, guarda la humedad y su hoja caída abona el suelo. Un cafetal con sombrío es café con vida: vuelven las aves y las mariposas que el café a pleno sol espanta.',
+    foco: enSuelo(0.5, -5.2),
+  },
+  {
+    id: 'cereza',
+    kicker: 'Paso 3 de 4 · La cereza',
+    texto:
+      'El fruto del café es la CEREZA: nace verde, pinta amarillo y madura ROJO. A la sombra madura despacio — y grano que madura despacio da taza más dulce. Se coge solo la roja, a mano, grano a grano.',
+    foco: enSuelo(-2.8, 1.6),
+  },
+  {
+    id: 'beneficio',
+    kicker: 'Paso 4 de 4 · Rumbo al beneficio',
+    texto:
+      'La cereza cogida sube a la casa: allá se despulpa, se lava y se seca en la marquesina hasta volverse café pergamino, el grano que se vende. De esa paciencia sale el café que usted se toma.',
+    foco: enSuelo(9.0, -12.2),
+  },
+];
+
+const CSS = `
+.mcafetal { position: relative; width: 100%; height: 100%; overflow: hidden; background: #c3dcd2; }
+.mcafetal canvas { opacity: 0; transition: opacity 0.9s ease; }
+.mcafetal .cafetal-canvas--lista canvas, .mcafetal canvas.cafetal-canvas--lista { opacity: 1; }
+.mcafetal__panel {
+  position: absolute; left: 50%; bottom: max(0.9rem, env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  width: min(26rem, calc(100% - 1.6rem));
+  padding: 0.8rem 0.95rem 0.85rem;
+  border-radius: 1rem;
+  background: rgba(26, 20, 10, 0.68);
+  box-shadow: inset 0 0 0 1px rgba(214, 188, 130, 0.3), 0 6px 24px rgba(14, 12, 8, 0.35);
+  backdrop-filter: blur(6px);
+  color: #f3ecda;
+}
+.mcafetal__kicker { margin: 0 0 0.15rem; font: 600 0.68rem/1.2 system-ui, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: #d9be85; }
+.mcafetal__texto { margin: 0 0 0.6rem; font: 500 0.85rem/1.38 system-ui, sans-serif; color: #efe6cf; }
+.mcafetal__nav { display: flex; align-items: center; gap: 0.55rem; }
+.mcafetal__btn {
+  min-height: 2.5rem; min-width: 2.9rem; padding: 0 0.8rem;
+  border: 0; border-radius: 0.7rem; cursor: pointer;
+  background: linear-gradient(180deg, rgba(226, 178, 82, 0.95), rgba(186, 132, 45, 0.95));
+  color: #241703; font: 700 0.9rem/1 system-ui, sans-serif;
+  transition: transform 0.15s ease;
+}
+.mcafetal__btn:active { transform: scale(0.96); }
+.mcafetal__btn[disabled] { opacity: 0.35; cursor: default; }
+.mcafetal__puntos { display: flex; gap: 0.35rem; margin: 0 auto; }
+.mcafetal__punto { width: 0.5rem; height: 0.5rem; border-radius: 999px; background: rgba(233, 220, 190, 0.32); }
+.mcafetal__punto--activo { background: #e2b252; box-shadow: 0 0 8px 1px rgba(226, 178, 82, 0.5); }
+@media (prefers-reduced-motion: reduce) {
+  .mcafetal canvas { transition: none; }
+  .mcafetal__btn { transition: none; }
+}
+`;
+
+/**
+ * El mundo del cafetal bajo sombra, completo: escena + pasos didácticos.
+ * Montar SOLO perezoso (lazy); llena a su contenedor.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function MundoCafetal({ tier: tierProp, reducedMotion: rmProp } = {}) {
+  // Contrato de mundos: props del host si llegan; si se monta suelto,
+  // auto-detección del equipo (no matar la gama baja).
+  const auto = useMemo(() => decidirTier(), []);
+  const tier = tierProp ?? (permite3D(auto.tier) ? auto.tier : 'bajo');
+  const reducedMotion = rmProp ?? auto.reducedMotion;
+  const [paso, setPaso] = useState(0);
+
+  const actual = PASOS[paso];
+
+  return (
+    <div className="mcafetal">
+      <style>{CSS}</style>
+      <EscenaCafetalVivo tier={tier} reducedMotion={reducedMotion} foco={actual.foco} />
+
+      <div className="mcafetal__panel" role="group" aria-label="La lección del cafetal">
+        <p className="mcafetal__kicker">{actual.kicker}</p>
+        <p className="mcafetal__texto">{actual.texto}</p>
+        <div className="mcafetal__nav">
+          <button
+            type="button"
+            className="mcafetal__btn"
+            onClick={() => setPaso((p) => Math.max(0, p - 1))}
+            disabled={paso === 0}
+            aria-label="Paso anterior"
+          >
+            ←
+          </button>
+          <span className="mcafetal__puntos" aria-hidden="true">
+            {PASOS.map((p, i) => (
+              <span
+                key={p.id}
+                className={`mcafetal__punto${i === paso ? ' mcafetal__punto--activo' : ''}`}
+              />
+            ))}
+          </span>
+          <button
+            type="button"
+            className="mcafetal__btn"
+            onClick={() => setPaso((p) => Math.min(PASOS.length - 1, p + 1))}
+            disabled={paso === PASOS.length - 1}
+            aria-label="Paso siguiente"
+          >
+            →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/cafetal/floraCafetal.geom.js
+++ b/src/visual/mundo3d/cafetal/floraCafetal.geom.js
@@ -1,0 +1,520 @@
+/*
+ * floraCafetal.geom — la GEOMETRÍA del CAFETAL BAJO SOMBRA (piso templado).
+ *
+ * El café es EL cultivo del campesino colombiano y aquí se cuenta como es de
+ * verdad en la montaña: una LADERA sembrada en surcos a curva de nivel, con los
+ * cafetos ABAJO y el SOMBRÍO arriba — guamos y nogales cafeteros que le hacen
+ * techo de hojas al cultivo — y el plátano intercalado que acompaña casi todo
+ * cafetal campesino. Cada especie con su identidad inequívoca:
+ *
+ *   · Cafeto (Coffea arabica)   — arbusto de porte columnar con PISOS de ramas
+ *                                 horizontales y hoja verde oscura lustrosa.
+ *   · Cereza de café            — el fruto, INSTANCIADO APARTE con color por
+ *                                 instancia: verde → pintón amarillo → ROJO
+ *                                 cereza (el estado de maduración varía por mata).
+ *   · Guamo (Inga)              — el árbol de sombrío clásico: tronco que se
+ *                                 bifurca y copa ANCHA y plana, un parasol.
+ *   · Nogal cafetero            — el otro sombrío: tronco recto y alto, copa
+ *     (Cordia alliodora)          más recogida y elevada.
+ *   · Plátano intercalado       — pseudotallo claro y hojas enormes arqueadas.
+ *   · Hojarasca + piedra        — el mantillo que la sombra deja en el suelo.
+ *
+ * TÉCNICA tier-safe (mismo contrato que floraParamo.geom): cada especie se
+ * FUSIONA en UNA geometría con color horneado en vertexColors y se dibuja con
+ * UN InstancedMesh → una draw-call por especie. La CEREZA se pinta BLANCA en la
+ * geometría para que el color POR INSTANCIA (setColorAt) sea el color real del
+ * fruto — así el mismo InstancedMesh lleva cerezas verdes, pintonas y rojas.
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO si se mezclan geometrías
+ * indexadas con no-indexadas (ya mordió 3 veces): aquí TODO se desindexa antes
+ * de fusionar y se TRUENA si aun así falla.
+ *
+ * Aquí viven SOLO los datos y las mallas (nada de WebGL): corre headless.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* -------------------------------------------------------------------------- */
+/*  La ladera cafetera (la geografía del mundo, determinista)                  */
+/* -------------------------------------------------------------------------- */
+
+export const ANCHO = 38; // x: -19 … 19
+export const FONDO = 36; // z: -18 (la loma, arriba) … 18 (el frente, abajo)
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+
+/* Ruido determinista (hash de senos): misma ladera siempre, sin Math.random. */
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
+    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
+    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
+  );
+}
+
+/** La altura de la ladera en un punto: sube hacia el fondo (el café es de montaña). */
+export function alturaLadera(wx, wz) {
+  const sub = smoothstep(6, -16, wz); // 0 al frente (bajo), 1 al fondo (la loma)
+  let h = 0.12;
+  h += sub * 5.4; // la ladera cafetera gana altura hacia atrás
+  h += ruido(wx * 0.5, wz * 0.5) * 0.35 * (0.3 + sub); // ondulación natural
+  return h;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Presupuesto por tier                                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Instancias por especie. 'alto' puebla el cafetal pleno; 'medio' es frugal;
+ * 'bajo' deja lo mínimo para que AÚN se lea "cafetal con sombrío". La cereza es
+ * el conteo del InstancedMesh de frutos (repartidos entre las matas cargadas).
+ */
+export const FLORA_CAFETAL = {
+  alto: { cafeto: 120, cereza: 360, guamo: 7, nogal: 3, platano: 6, hojarasca: 14, piedra: 6 },
+  medio: { cafeto: 70, cereza: 190, guamo: 5, nogal: 2, platano: 4, hojarasca: 8, piedra: 4 },
+  bajo: { cafeto: 30, cereza: 80, guamo: 3, nogal: 1, platano: 2, hojarasca: 4, piedra: 2 },
+};
+
+/** Conteos para un tier (desconocido → frugal, nunca el más caro). */
+export const cafetalDeTier = (tier) => FLORA_CAFETAL[tier] || FLORA_CAFETAL.medio;
+
+/** Factor de detalle geométrico por tier (menos blobs/hojas en gama baja). */
+export const CALIDAD_CAFETAL = { alto: 1, medio: 0.62, bajo: 0.42 };
+export const calidadCafetal = (tier) => CALIDAD_CAFETAL[tier] ?? CALIDAD_CAFETAL.medio;
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del cafetal (colores horneados en vertexColors)                     */
+/* -------------------------------------------------------------------------- */
+
+export const PAL = {
+  // Cafeto
+  cafetoTallo: '#5a4430', // tallo leñoso delgado
+  cafetoHoja: '#2e5c33', // hoja verde oscura lustrosa (la firma del café)
+  cafetoHojaSol: '#477a3d', // la cara del piso que da al sol
+  cafetoBrote: '#7fa24c', // cogollo tierno arriba
+
+  // Los tres estados de la cereza (van POR INSTANCIA, no aquí; referencia):
+  cerezaVerde: '#6f9e3c',
+  cerezaPinton: '#dca63c',
+  cerezaRoja: '#c1301f',
+
+  // Guamo (Inga) — el parasol del sombrío
+  guamoTronco: '#6b533a',
+  guamoCopa: '#4b7c3a',
+  guamoCopaSol: '#699a48',
+
+  // Nogal cafetero (Cordia alliodora) — el sombrío alto y recto
+  nogalTronco: '#8a8274',
+  nogalCopa: '#527a40',
+  nogalCopaSol: '#6c9450',
+
+  // Plátano intercalado
+  platanoTallo: '#a8b06c',
+  platanoHoja: '#5d9440',
+  platanoHojaSol: '#7cb04e',
+  platanoHojaSeca: '#a5924c',
+
+  // Suelo
+  hojarasca: '#8a6c42',
+  hojarasca2: '#75592f',
+  piedra: '#8b8578',
+  liquen: '#a3a878',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Utilidades (fusión desindexada + colocación + color horneado)              */
+/* -------------------------------------------------------------------------- */
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+/** Hornea un color plano en TODOS los vértices (atributo `color`). */
+function pintar(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Coloca una geometría (posición/rotación/escala) transformando vértices. */
+function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/** Orienta el +Y de la geometría hacia `dir` y la ubica en `pos` (hojas). */
+function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    q,
+    new THREE.Vector3(esc[0], esc[1], esc[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/**
+ * Fusiona partes (ya coloreadas) en UNA geometría. Se DESINDEXA todo antes de
+ * fusionar y se TRUENA si falla: mejor un error de build que una especie
+ * invisible en producción (mordida conocida de mergeGeometries).
+ */
+function fusionar(partes) {
+  const buenas = partes.filter(Boolean).map((p) => {
+    const plana = p.index ? p.toNonIndexed() : p;
+    if (plana !== p) p.dispose();
+    return plana;
+  });
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error('floraCafetal: mergeGeometries devolvió null — atributos incompatibles entre partes');
+  }
+  return g;
+}
+
+/** Pequeña variación determinista de color (que el cafetal no sea plano). */
+function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  CAFETO (Coffea arabica) — el cultivo                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Porte columnar con PISOS: un tallo leñoso central y 3 pisos de follaje
+ * anchos y bajos (las ramas horizontales del café leídas como masas), hoja
+ * oscura abajo y cara al sol arriba, cogollo tierno en la punta. Las CEREZAS
+ * no van aquí: son un InstancedMesh aparte con color por instancia.
+ */
+export function geomCafeto({ q = 1 } = {}, seed = 1) {
+  const r = rng(seed);
+  const partes = [];
+
+  // El tallo leñoso central.
+  const tallo = new THREE.CylinderGeometry(0.035, 0.06, 1.2, 5, 1);
+  poner(tallo, [0, 0.6, 0]);
+  partes.push(pintar(tallo, PAL.cafetoTallo));
+
+  // Los PISOS de follaje: anchos abajo, angostos arriba (el porte del café).
+  const pisos = [
+    { y: 0.46, rad: 0.44, cara: false },
+    { y: 0.78, rad: 0.37, cara: true },
+    { y: 1.06, rad: 0.28, cara: true },
+  ];
+  const nPisos = q < 0.5 ? 2 : 3;
+  for (let i = 0; i < nPisos; i++) {
+    const p = pisos[i];
+    const masa = new THREE.IcosahedronGeometry(p.rad, 1); // detail 1: la mata tupida
+    poner(masa, [(r() - 0.5) * 0.08, p.y, (r() - 0.5) * 0.08], [0, r() * Math.PI, 0], [1.35, 0.6, 1.35]);
+    partes.push(pintar(masa, variar(p.cara ? PAL.cafetoHojaSol : PAL.cafetoHoja, r, 0.05)));
+  }
+
+  // El cogollo tierno de la punta.
+  const brote = new THREE.IcosahedronGeometry(0.12, 0);
+  poner(brote, [0, 1.24, 0], [0, r() * Math.PI, 0], [1, 0.8, 1]);
+  partes.push(pintar(brote, PAL.cafetoBrote));
+
+  return fusionar(partes);
+}
+
+/** La cereza del café: UNA bolita blanca — el color real va POR INSTANCIA. */
+export function geomCereza() {
+  const g = new THREE.IcosahedronGeometry(0.07, 0);
+  return pintar(g.index ? g.toNonIndexed() : g, '#ffffff');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  GUAMO (Inga) — el parasol del sombrío                                      */
+/* -------------------------------------------------------------------------- */
+
+export function geomGuamo({ q = 1 } = {}, seed = 2) {
+  const r = rng(seed);
+  const partes = [];
+
+  // Tronco que se abre en ramas maestras.
+  const tronco = new THREE.CylinderGeometry(0.14, 0.24, 2.9, 7, 1);
+  poner(tronco, [0, 1.45, 0]);
+  partes.push(pintar(tronco, PAL.guamoTronco));
+  const nRamas = Math.max(2, Math.round(3 * q));
+  for (let i = 0; i < nRamas; i++) {
+    const a = (i / nRamas) * Math.PI * 2 + r();
+    const rama = new THREE.CylinderGeometry(0.05, 0.09, 1.3, 5, 1);
+    apuntar(rama, [Math.cos(a) * 0.55, 3.1, Math.sin(a) * 0.55], [Math.cos(a) * 0.9, 1, Math.sin(a) * 0.9]);
+    partes.push(pintar(rama, PAL.guamoTronco));
+  }
+
+  // La copa ANCHA y plana: el techo de hojas sobre el cafetal.
+  const nMasas = Math.max(3, Math.round(5 * q));
+  for (let i = 0; i < nMasas; i++) {
+    const a = (i / nMasas) * Math.PI * 2 + 0.7;
+    const rad = i === 0 ? 0 : 1.0 + r() * 0.4;
+    const masa = new THREE.IcosahedronGeometry(i === 0 ? 1.25 : 0.95 + r() * 0.25, 1);
+    poner(
+      masa,
+      [Math.cos(a) * rad, 3.55 + (r() - 0.5) * 0.35, Math.sin(a) * rad],
+      [0, r() * Math.PI, 0],
+      [1.7, 0.74, 1.7],
+    );
+    partes.push(pintar(masa, variar(i % 2 ? PAL.guamoCopaSol : PAL.guamoCopa, r, 0.06)));
+  }
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  NOGAL CAFETERO (Cordia alliodora) — el sombrío alto y recto                */
+/* -------------------------------------------------------------------------- */
+
+export function geomNogal({ q = 1 } = {}, seed = 3) {
+  const r = rng(seed);
+  const partes = [];
+
+  // Tronco recto y alto (madera fina de la finca cafetera).
+  const tronco = new THREE.CylinderGeometry(0.1, 0.17, 4.1, 7, 1);
+  poner(tronco, [0, 2.05, 0]);
+  partes.push(pintar(tronco, PAL.nogalTronco));
+
+  // Copa recogida y elevada, por pisos cortos (silueta de nogal).
+  const nMasas = Math.max(3, Math.round(4 * q));
+  for (let i = 0; i < nMasas; i++) {
+    const a = i * 2.1 + 0.5;
+    const rad = i === 0 ? 0 : 0.55 + r() * 0.3;
+    const masa = new THREE.IcosahedronGeometry(0.75 + r() * 0.2, 1);
+    poner(
+      masa,
+      [Math.cos(a) * rad, 4.15 + i * 0.32, Math.sin(a) * rad],
+      [0, r() * Math.PI, 0],
+      [1.15, 0.8, 1.15],
+    );
+    partes.push(pintar(masa, variar(i % 2 ? PAL.nogalCopaSol : PAL.nogalCopa, r, 0.06)));
+  }
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  PLÁTANO intercalado — el acompañante de casi todo cafetal campesino        */
+/* -------------------------------------------------------------------------- */
+
+export function geomPlatano({ q = 1 } = {}, seed = 4) {
+  const r = rng(seed);
+  const partes = [];
+
+  // Pseudotallo claro.
+  const tallo = new THREE.CylinderGeometry(0.09, 0.14, 1.9, 6, 1);
+  poner(tallo, [0, 0.95, 0]);
+  partes.push(pintar(tallo, PAL.platanoTallo));
+
+  // Las hojas enormes, arqueadas hacia afuera y abajo.
+  const nHojas = Math.max(4, Math.round(6 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const a = (i / nHojas) * Math.PI * 2 + r() * 0.5;
+    const caida = 0.55 + r() * 0.4; // cuánto se arquea
+    const hoja = new THREE.SphereGeometry(1, 7, 5);
+    const seca = r() > 0.82; // alguna hoja vieja amarillea
+    apuntar(
+      hoja,
+      [Math.cos(a) * 0.5, 1.95, Math.sin(a) * 0.5],
+      [Math.cos(a), 1 - caida, Math.sin(a)],
+      [0.14, 0.85, 0.32],
+    );
+    partes.push(pintar(hoja, variar(seca ? PAL.platanoHojaSeca : i % 2 ? PAL.platanoHojaSol : PAL.platanoHoja, r, 0.05)));
+  }
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Suelo: hojarasca y piedra                                                  */
+/* -------------------------------------------------------------------------- */
+
+export function geomHojarasca(seed = 5) {
+  const r = rng(seed);
+  const partes = [];
+  for (let i = 0; i < 3; i++) {
+    const mancha = new THREE.CylinderGeometry(0.34 + r() * 0.3, 0.42 + r() * 0.32, 0.035, 7, 1);
+    poner(mancha, [(r() - 0.5) * 0.5, 0.02 + i * 0.012, (r() - 0.5) * 0.5], [0, r() * Math.PI, 0]);
+    partes.push(pintar(mancha, i % 2 ? PAL.hojarasca2 : PAL.hojarasca));
+  }
+  return fusionar(partes);
+}
+
+export function geomPiedra(seed = 6) {
+  const r = rng(seed);
+  const roca = new THREE.DodecahedronGeometry(0.32, 0);
+  poner(roca, [0, 0.14, 0], [r() * 0.6, r() * Math.PI, r() * 0.6], [1.25, 0.7, 1]);
+  const capa = new THREE.DodecahedronGeometry(0.18, 0);
+  poner(capa, [0.12, 0.24, 0.05], [0, r() * Math.PI, 0], [1, 0.55, 1]);
+  return fusionar([pintar(roca, PAL.piedra), pintar(capa, PAL.liquen)]);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Distribución: surcos a curva de nivel + sombrío disperso                   */
+/* -------------------------------------------------------------------------- */
+
+/* El sombrío vive FIJO en la ladera (posiciones compuestas a mano para que el
+   techo de sombra cubra el cultivo sin taparlo todo). Se recortan por tier. */
+const SITIOS_GUAMO = [
+  [-8.5, -5.5], [-1.5, -8.5], [6.5, -6.0], [11.0, -2.5], [-12.5, -10.0], [2.5, -12.5], [-4.5, -2.0],
+];
+const SITIOS_NOGAL = [
+  [9.5, -10.5], [-6.5, -13.0], [14.0, -7.5],
+];
+const SITIOS_PLATANO = [
+  [-11.5, -3.0], [4.0, -3.8], [-3.0, -11.0], [12.5, -12.0], [-14.5, -7.0], [8.0, -1.2],
+];
+
+/* La casa/beneficiadero vive arriba al fondo; los surcos la respetan. */
+export const SITIO_CASA = /** @type {[number, number]} */ ([9.0, -14.6]);
+
+/** ¿Qué tan maduro está el café en esta franja? Abajo (más caliente) más rojo. */
+function madurezEn(wz, r) {
+  const base = smoothstep(-13.5, 3.0, wz); // el frente de la ladera pinta primero
+  return clamp(base + (r() - 0.5) * 0.35, 0, 1);
+}
+
+/**
+ * Siembra determinista del cafetal completo. Devuelve items por especie:
+ * `{pos, rotY, escala, tint}` (contrato del componente `Especie`), y para la
+ * cereza el `tint` ES el color del fruto (verde → pintón → rojo por instancia).
+ */
+export function distribucionCafetal(conteos, seed = 311) {
+  const c = conteos;
+  const rCaf = rng(seed + 1);
+  const rCer = rng(seed + 2);
+  const rSue = rng(seed + 3);
+
+  // --- Los surcos a curva de nivel (el café nunca se siembra ladera abajo). ---
+  const sitios = [];
+  const filasZ = [2.6, 1.0, -0.6, -2.2, -3.8, -5.4, -7.0, -8.6, -10.2, -11.8, -13.4];
+  filasZ.forEach((z0, fila) => {
+    for (let wx = -15; wx <= 15; wx += 1.35) {
+      const jx = (rCaf() - 0.5) * 0.5;
+      const curva = Math.sin(wx * 0.13 + fila * 0.45) * 0.9; // la curva del surco
+      const px = wx + jx;
+      const pz = z0 + curva + (rCaf() - 0.5) * 0.3;
+      // respetar el patio de la casa/beneficiadero
+      const dx = px - SITIO_CASA[0];
+      const dz = pz - SITIO_CASA[1];
+      if (dx * dx + dz * dz < 16) continue;
+      sitios.push({
+        px, pz,
+        esc: 0.8 + rCaf() * 0.45,
+        rotY: rCaf() * Math.PI * 2,
+        maduro: madurezEn(pz, rCaf),
+        carga: rCaf(), // qué tan cargada de fruto está la mata
+      });
+    }
+  });
+  // recorte determinista al presupuesto del tier (salto parejo, no los primeros N)
+  const paso = Math.max(1, Math.floor(sitios.length / Math.max(1, c.cafeto)));
+  const matas = [];
+  for (let i = 0; i < sitios.length && matas.length < c.cafeto; i += paso) matas.push(sitios[i]);
+
+  const cafeto = matas.map((s) => ({
+    pos: [s.px, alturaLadera(s.px, s.pz), s.pz],
+    rotY: s.rotY,
+    escala: s.esc,
+    tint: [0.92 + rCaf() * 0.16, 0.92 + rCaf() * 0.16, 0.92 + rCaf() * 0.16],
+  }));
+
+  // --- Las cerezas: racimos alrededor de los pisos de las matas cargadas. ---
+  const verde = new THREE.Color(PAL.cerezaVerde);
+  const pinton = new THREE.Color(PAL.cerezaPinton);
+  const roja = new THREE.Color(PAL.cerezaRoja);
+  const col = new THREE.Color();
+  const cereza = [];
+  const cargadas = matas.filter((s) => s.carga > 0.3);
+  let gi = 0;
+  while (cereza.length < c.cereza && cargadas.length > 0) {
+    const s = cargadas[gi % cargadas.length];
+    gi += 1;
+    if (gi > cargadas.length * 9) break;
+    const cuantas = 2 + Math.floor(rCer() * 3);
+    for (let k = 0; k < cuantas && cereza.length < c.cereza; k++) {
+      const a = rCer() * Math.PI * 2;
+      const nivel = rCer();
+      const rad = (0.3 + nivel * -0.08 + rCer() * 0.16) * s.esc * 1.2;
+      const y = (0.42 + nivel * 0.6) * s.esc;
+      // el estado del fruto: la madurez de la mata + su propio azar
+      const m = clamp(s.maduro + (rCer() - 0.5) * 0.5, 0, 1);
+      if (m < 0.5) col.lerpColors(verde, pinton, m * 2);
+      else col.lerpColors(pinton, roja, (m - 0.5) * 2);
+      col.multiplyScalar(0.92 + rCer() * 0.16);
+      cereza.push({
+        pos: [s.px + Math.cos(a) * rad, alturaLadera(s.px, s.pz) + y, s.pz + Math.sin(a) * rad],
+        rotY: rCer() * Math.PI,
+        escala: 0.85 + rCer() * 0.4,
+        tint: [col.r, col.g, col.b],
+      });
+    }
+  }
+
+  // --- El sombrío y el plátano (sitios fijos recortados por tier). ---
+  const enLadera = (p, esc, rr) => ({
+    pos: [p[0], alturaLadera(p[0], p[1]), p[1]],
+    rotY: rr() * Math.PI * 2,
+    escala: esc,
+    tint: [0.94 + rr() * 0.12, 0.94 + rr() * 0.12, 0.94 + rr() * 0.12],
+  });
+  const rArb = rng(seed + 4);
+  const guamo = SITIOS_GUAMO.slice(0, c.guamo).map((p) => enLadera(p, 0.95 + rArb() * 0.35, rArb));
+  const nogal = SITIOS_NOGAL.slice(0, c.nogal).map((p) => enLadera(p, 0.95 + rArb() * 0.25, rArb));
+  const platano = SITIOS_PLATANO.slice(0, c.platano).map((p) => enLadera(p, 0.85 + rArb() * 0.3, rArb));
+
+  // --- El suelo: hojarasca bajo el sombrío, piedras sueltas. ---
+  const hojarasca = [];
+  const bajoSombra = [...SITIOS_GUAMO.slice(0, c.guamo), ...SITIOS_NOGAL.slice(0, c.nogal)];
+  for (let i = 0; i < c.hojarasca; i++) {
+    const s = bajoSombra[i % Math.max(1, bajoSombra.length)] || [0, -6];
+    const x = s[0] + (rSue() - 0.5) * 3.2;
+    const z = s[1] + (rSue() - 0.5) * 3.2;
+    hojarasca.push({
+      pos: [x, alturaLadera(x, z) + 0.01, z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.8 + rSue() * 0.7,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+  const piedra = [];
+  for (let i = 0; i < c.piedra; i++) {
+    const x = -16 + rSue() * 32;
+    const z = -14 + rSue() * 28;
+    piedra.push({
+      pos: [x, alturaLadera(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.7 + rSue() * 0.9,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+
+  return { cafeto, cereza, guamo, nogal, platano, hojarasca, piedra };
+}
+
+/** Los centros del sombrío del tier (para la luz colada bajo las copas). */
+export function centrosSombrio(conteos) {
+  return [
+    ...SITIOS_GUAMO.slice(0, conteos.guamo),
+    ...SITIOS_NOGAL.slice(0, conteos.nogal),
+  ].map(([x, z]) => /** @type {[number, number, number]} */ ([x, alturaLadera(x, z), z]));
+}


### PR DESCRIPTION
## El mundo del café

El cultivo bandera del campesino colombiano con su mundo 3D propio, siguiendo el molde del Bosque Vivo (`src/visual/mundo3d/bosque/`).

**Qué se ve**
- La **ladera cafetera** en surcos a curva de nivel (heightfield con vertexColors: arvenses, tierra roja, mantillo, caminito de entrada).
- Los **cafetos** de porte columnar con su **cereza madurando verde → pintón → rojo POR INSTANCIA** (un solo InstancedMesh lleva todos los estados; las filas de abajo, más calientes, pintan primero).
- El **sombrío**: guamos de copa-parasol y nogales cafeteros altos, con **luz colada** (dapples dorados que respiran) bajo las copas en gama alta.
- El **plátano intercalado** del cafetal campesino.
- La **casa con beneficiadero y marquesina** de secado, arriba en la bruma, con canastos de cosecha.
- **Fauna SVG rubber-hose** de la casa como billboards (mariposa Morpho y colibrí) — cero fauna procedural fea.
- **Cuatro pasos didácticos** (qué es el sombrío, por qué bajo sombra, la cereza, rumbo al beneficio) con anillo-foco que respira sobre el lugar de cada lección.

**Rendimiento (contrato de la casa)**
- Una draw-call por especie: geometría FUSIONADA (desindexada antes de `mergeGeometries`, truena si da null) + `InstancedMesh` con color por instancia.
- Presupuestos por tier (`FLORA_CAFETAL`), detalle geométrico escalado (`CALIDAD_CAFETAL`), `perfilDeTier` para sombras/fog/DPR.
- Gama baja / sin WebGL / ahorro de datos → **ficha 2D digna** (cafeto CSS con cerezas y guamo, cero GPU).
- `reducedMotion` → mundo quieto, frameloop a demanda.

**Cómo se accede**
- Ruta pública sin auth: `#/mockups/cafetal-vivo-3d` (registrada en `MOCKUP_HASH_ROUTES` + switch de App.jsx, patrón exacto de `bosque-vivo-3d`).

**Archivos**
- `src/visual/mundo3d/cafetal/floraCafetal.geom.js` — geometrías + distribución determinista
- `src/visual/mundo3d/cafetal/FloraCafetal.jsx` — capa instanciada + luz colada
- `src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx` — escena (ladera, luz templada, casa, fauna, foco)
- `src/visual/mundo3d/cafetal/MundoCafetal.jsx` — host con los 4 pasos
- `src/mockups/CafetalVivo3D.jsx` + `.css` — vitrina + ficha 2D
- `src/App.jsx` — registro de ruta (3 puntos, patrón bosque)

**Verificación**
- `npm run tsc:check` limpio · `npm run build:prod` verde.
- Capturas reales navegando (chromium + swiftshader, dev server): entrada, girado, acercamiento y los 4 pasos, en teléfono (390×844) y desktop (1280×800).

🤖 Generated with [Claude Code](https://claude.com/claude-code)