### PR TITLE
art(papa): el mundo de la papa — el papal en surcos de la tierra fría, navegable

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -156,6 +156,11 @@ const BosqueVivo3DMockup = lazy(() => import('./mockups/BosqueVivo3D'));
 // de guamos y nogales, y la casa-beneficiadero en la bruma. Device-tiering
 // real. Ruta #/mockups/cafetal-vivo-3d, sin auth.
 const CafetalVivo3DMockup = lazy(() => import('./mockups/CafetalVivo3D'));
+// 3D: el MUNDO DE LA PAPA — el papal en surcos de la tierra fría: caballones
+// horneados en el relieve a curva de nivel, la mata aporcada con su flor lila/
+// blanca por instancia, la cosecha de criollas (amarilla/roja/morada) y los
+// frailejones en silueta. Device-tiering real. Ruta #/mockups/papa-viva-3d, sin auth.
+const PapaVivo3DMockup = lazy(() => import('./mockups/PapaVivo3D'));
 // 3D: el MUNDO SUELO VIVO — la RED MICORRÍZICA bajo tierra (el wood-wide web):
 // la red de hongos bioluminiscente que enlaza las raíces y reparte nutrientes,
 // con pulsos corriendo por los hilos y el Ent asomando. Device-tiering real.
@@ -576,6 +581,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo3d-bosque': 'mockup_mundo3d_bosque',
   'mockups/bosque-vivo-3d': 'mockup_bosque_vivo_3d',
   'mockups/cafetal-vivo-3d': 'mockup_cafetal_vivo_3d',
+  'mockups/papa-viva-3d': 'mockup_papa_viva_3d',
   'mockups/mundo3d-clima': 'mockup_mundo3d_clima',
   'mockups/voz-con-forma': 'mockup_voz_con_forma',
   'mockups/conversacion-voz': 'mockup_conversacion_voz',
@@ -1568,6 +1574,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del café">
               <CafetalVivo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_papa_viva_3d':
+        // Vitrina pública del MUNDO DE LA PAPA: el papal en surcos de la tierra
+        // fría en 3D REAL — caballones de tierra negra horneados en el relieve
+        // a curva de nivel, la mata aporcada con su flor lila/blanca, el
+        // pajonal, los frailejones en silueta y la cosecha de criollas
+        // destapada (amarilla/roja/morada). Cuatro pasos didácticos. En equipo
+        // humilde muestra la ficha del corte. Ruta #/mockups/papa-viva-3d.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo de la papa">
+              <PapaVivo3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/PapaVivo3D.css
+++ b/src/mockups/PapaVivo3D.css
@@ -1,0 +1,246 @@
+/*
+ * PapaVivo3D.css — vitrina del mundo de la papa (#/mockups/papa-viva-3d).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Paleta de piso frío: cielo azul de altura, pajonal amarillo, tierra negra
+ * del caballón y el amarillo criollo del tubérculo. Solo opacity/transform.
+ */
+
+.pviva {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background: linear-gradient(180deg, #c8dcea 0%, #d9e2cf 46%, #e9e4cb 100%);
+  color: #2c3128;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.pviva__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.pviva__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7a5a94;
+}
+.pviva__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #2f3d2f;
+}
+.pviva__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 40rem;
+}
+
+.pviva__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+.pviva__lienzo {
+  position: relative;
+  height: min(66vh, 32rem);
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(122, 90, 148, 0.25);
+  box-shadow: 0 12px 30px rgba(42, 52, 44, 0.16);
+  background: radial-gradient(120% 90% at 50% 20%, #c2d8e8 0%, #a4b79e 100%);
+}
+.pviva__lienzo canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+  touch-action: none;
+}
+.papal-canvas {
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.papal-canvas--lista {
+  opacity: 1;
+}
+
+.pviva__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  color: #3a4838;
+  opacity: 0.85;
+}
+
+.pviva__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.pviva__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.pviva__toggle {
+  border: 1.5px solid #7a5a94;
+  background: #fff;
+  color: #7a5a94;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.pviva__toggle:hover,
+.pviva__toggle:focus-visible {
+  background: #7a5a94;
+  color: #fff;
+  outline-offset: 2px;
+}
+
+/* ---- Ficha 2D (fallback digno, sin GPU): el surco en CORTE ---- */
+.pviva__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  background: linear-gradient(180deg, #c5daea 0%, #cfd8b8 58%, #b9c49e 100%);
+}
+.pviva__estampa {
+  position: relative;
+  width: 190px;
+  height: 185px;
+  margin-bottom: 0.4rem;
+}
+/* la mata de papa, tupida y bajita, sobre el lomo */
+.pviva__mata {
+  position: absolute;
+  top: 12px;
+  left: 52px;
+  width: 88px;
+  height: 62px;
+  border-radius: 48% 52% 44% 56% / 64% 58% 42% 36%;
+  background: radial-gradient(circle at 38% 30%, #699344 0%, #4d7a35 68%, #3d642c 100%);
+  box-shadow: inset -7px -6px 12px rgba(0, 0, 0, 0.2);
+}
+.pviva__flor {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  box-shadow: inset -2px -2px 3px rgba(0, 0, 0, 0.18);
+}
+.pviva__flor--lila { top: -6px; left: 20px; background: #b28cd6; }
+.pviva__flor--blanca { top: -2px; left: 52px; background: #f3eef8; }
+.pviva__flor--lila2 { top: 12px; left: 68px; background: #9a72c4; }
+/* el CABALLÓN: el lomo de tierra amontonada donde la mata va aporcada */
+.pviva__caballon {
+  position: absolute;
+  top: 62px;
+  left: 26px;
+  width: 140px;
+  height: 40px;
+  border-radius: 50% 50% 8% 8% / 100% 100% 10% 10%;
+  background: linear-gradient(180deg, #5c4936 0%, #4a3a2b 55%, #3d2f22 100%);
+  box-shadow: inset -8px -5px 12px rgba(0, 0, 0, 0.22);
+}
+/* el corte de tierra: lo que pasa abajo, donde engorda la papa */
+.pviva__tierra {
+  position: absolute;
+  top: 100px;
+  left: 10px;
+  width: 172px;
+  height: 74px;
+  border-radius: 6px 6px 12px 12px;
+  background: linear-gradient(180deg, #43352a 0%, #382c21 60%, #2f251c 100%);
+  box-shadow: inset 0 4px 8px rgba(0, 0, 0, 0.25);
+}
+.pviva__papa {
+  position: absolute;
+  width: 22px;
+  height: 17px;
+  border-radius: 50%;
+  box-shadow: inset -3px -3px 4px rgba(0, 0, 0, 0.3);
+}
+.pviva__papa--criolla { top: 14px; left: 58px; background: #e5b93c; }
+.pviva__papa--criolla2 { top: 34px; left: 86px; background: #d4a52f; }
+.pviva__papa--roja { top: 40px; left: 34px; background: #a4503a; }
+.pviva__papa--morada { top: 16px; left: 112px; background: #5c3a66; }
+.pviva__papa--criolla3 { top: 44px; left: 128px; width: 16px; height: 13px; background: #e0b23a; }
+.pviva__ficha-nombre {
+  margin: 0;
+  font-weight: 800;
+  font-size: 1rem;
+  color: #2f3d2f;
+}
+.pviva__ficha-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4a5844;
+}
+
+/* ---- Saberes ---- */
+.pviva__saberes {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.pviva__saberes h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #2f3d2f;
+}
+.pviva__saberes ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .pviva__saberes ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.pviva__saberes li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(122, 90, 148, 0.16);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.pviva__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.pviva__saberes b {
+  display: block;
+  font-size: 0.92rem;
+  color: #2f3d2f;
+}
+.pviva__saberes li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.pviva__cierre {
+  margin: 0.9rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #3a4838;
+  max-width: 42rem;
+}

--- a/src/mockups/PapaVivo3D.jsx
+++ b/src/mockups/PapaVivo3D.jsx
@@ -1,0 +1,169 @@
+/*
+ * PapaVivo3D — vitrina pública del MUNDO DE LA PAPA: el papal en surcos de la
+ * tierra fría (piso frío, 2.000–3.200 m). Ruta #/mockups/papa-viva-3d, sin auth.
+ *
+ * La papa criolla es el cultivo de la montaña alta, y aquí se muestra como es
+ * de verdad: una ladera navegable con los SURCOS horneados en el relieve —
+ * caballones de tierra negra a curva de nivel con la mata aporcada encima —,
+ * la flor lila y blanca avisando que abajo hay tubérculo, el pajonal del frío
+ * rodeando el lote, los frailejones en silueta al fondo y el rincón de cosecha
+ * con la diversidad andina destapada: criolla amarilla, roja y morada. Cuatro
+ * pasos cortos recorren la lección: el surco y por qué, la mata y su flor, la
+ * papa criolla y la cosecha.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el mundo 3D (chunk
+ * perezoso `vendor-three`); en equipo humilde, ahorro de datos o sin-WebGL se
+ * ve la ficha del papal — con su corte de tierra y las papas abajo — digna y
+ * sin sudar la GPU. Copy en español de Colombia, en "usted". Autocontenida:
+ * cero CDN/imágenes externas.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import './PapaVivo3D.css';
+
+const MundoPapa = lazy(() => import('../visual/mundo3d/papa/MundoPapa.jsx'));
+
+/* Lo que enseña el papal (verificado, en "usted"). */
+const SABERES = [
+  {
+    emoji: '⛰️',
+    titulo: 'El surco abriga y escurre',
+    texto:
+      'La papa se siembra en caballones: tierra amontonada a curva de nivel. Ese lomo abriga la semilla del frío de la madrugada, escurre el agua lluvia para que el tubérculo no se pudra y le da campo para engordar.',
+  },
+  {
+    emoji: '🌼',
+    titulo: 'La flor avisa lo de abajo',
+    texto:
+      'Cuando el papal florece — lila o blanco, según la variedad — la mata está avisando que abajo ya se forma la papa. Al aporcar se le arrima más tierra al tallo, y la mata responde echando más tubérculo.',
+  },
+  {
+    emoji: '🥔',
+    titulo: 'La criolla no está sola',
+    texto:
+      'La criolla amarilla es la reina de la tierra fría colombiana, pero los Andes guardan cientos de variedades: rojas, moradas, pintadas. Esa diversidad es semilla campesina de generaciones y un seguro contra plagas y heladas.',
+  },
+  {
+    emoji: '🧺',
+    titulo: 'Se cosecha con cuidado',
+    texto:
+      'A los cinco o seis meses la mata amarillea: es la seña. El caballón se abre con azadón sin lastimar la papa, se aparta la saca por tamaños, se cose el costal de fique y la cosecha arranca pal mercado.',
+  },
+];
+
+export default function PapaVivo3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  return (
+    <main className="pviva">
+      <header className="pviva__head">
+        <p className="pviva__kicker">El mundo de la papa · vitrina</p>
+        <h1>El papal en surcos de la tierra fría</h1>
+        <p className="pviva__lema">
+          La ladera papera como es de verdad: los caballones de tierra negra a
+          curva de nivel, la mata aporcada con su flor lila y blanca, y en el
+          claro la cosecha destapada — criolla amarilla, roja y morada. Recórrala
+          con el dedo y siga los cuatro pasos de la lección.
+        </p>
+      </header>
+
+      <section className="pviva__escena" aria-label="El papal en surcos en 3D">
+        <div className="pviva__lienzo">
+          {mostrar3D ? (
+            <Suspense
+              fallback={
+                <div className="pviva__cargando" role="status">
+                  Subiendo a la tierra fría…
+                </div>
+              }
+            >
+              <MundoPapa tier={tier} reducedMotion={reducedMotion} />
+            </Suspense>
+          ) : (
+            <FichaPapal />
+          )}
+        </div>
+
+        <div className="pviva__barra">
+          <p className="pviva__tier">
+            {mostrar3D
+              ? 'Está viendo el papal en 3D. Gírelo con el dedo o el mouse y siga los pasos.'
+              : puede3D
+                ? 'Está viendo la ficha del papal.'
+                : 'Su equipo ve la ficha del papal (va parejo en cualquier teléfono).'}
+          </p>
+          {puede3D && (
+            <button type="button" className="pviva__toggle" onClick={() => setVer2d((v) => !v)}>
+              {ver2d ? 'Ver el papal en 3D' : 'Ver la ficha'}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <section className="pviva__saberes" aria-label="Lo que enseña el papal">
+        <h2>Lo que le enseña este papal</h2>
+        <ol>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span className="pviva__emoji" aria-hidden="true">
+                {s.emoji}
+              </span>
+              <div>
+                <b>{s.titulo}</b>
+                <p>{s.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="pviva__cierre">
+          La papa no es solo un bulto en la plaza: es el cultivo que domesticaron
+          los Andes y el que sostiene la mesa de la tierra fría. Donde hay surco
+          bien hecho y semilla propia hay comida segura — y eso se cuida
+          sembrando de todas, no de una sola.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+/* La ficha del papal: el fallback digno para equipo humilde / sin-WebGL.
+   El corte del caballón en CSS: la mata con sus flores arriba y, bajo la
+   línea de tierra, las papas criollas engordando — cero GPU. */
+function FichaPapal() {
+  return (
+    <div
+      className="pviva__ficha"
+      role="img"
+      aria-label="El surco de papa en corte: la mata con su flor arriba y las papas criollas bajo la tierra"
+    >
+      <div className="pviva__estampa" aria-hidden="true">
+        <span className="pviva__mata">
+          <span className="pviva__flor pviva__flor--lila" />
+          <span className="pviva__flor pviva__flor--blanca" />
+          <span className="pviva__flor pviva__flor--lila2" />
+        </span>
+        <span className="pviva__caballon" />
+        <span className="pviva__tierra">
+          <span className="pviva__papa pviva__papa--criolla" />
+          <span className="pviva__papa pviva__papa--criolla2" />
+          <span className="pviva__papa pviva__papa--roja" />
+          <span className="pviva__papa pviva__papa--morada" />
+          <span className="pviva__papa pviva__papa--criolla3" />
+        </span>
+      </div>
+      <p className="pviva__ficha-nombre">El surco de papa, en corte</p>
+      <p className="pviva__ficha-sub">Piso frío · el cultivo que domesticaron los Andes</p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/papa/EscenaPapaVivo.jsx
+++ b/src/visual/mundo3d/papa/EscenaPapaVivo.jsx
@@ -1,0 +1,399 @@
+/*
+ * EscenaPapaVivo — el MUNDO donde vive la papa (piso frío, 2.000–3.200 m).
+ *
+ * Una LADERA de tierra fría a media mañana: cielo despejado y azul de montaña
+ * alta, luz blanca y dura (a esa altura el sol no perdona), y el cultivo
+ * contado como es — los SURCOS: caballones de tierra negra amontonada a curva
+ * de nivel, con la mata de papa aporcada encima de cada lomo. El caballón va
+ * horneado EN EL RELIEVE del terreno (se lee la tierra alzada, no una raya
+ * pintada). Alrededor el pajonal amarillo del frío, al fondo la loma alta con
+ * frailejones en silueta (el páramo queda ahí no más), la casita campesina con
+ * sus costales, y en un claro la COSECHA: la tierra abierta y las papas
+ * criollas destapadas — amarillas, rojas y moradas.
+ *
+ * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`: 'alto' con
+ * sombras + vaho; 'medio' frugal; 'bajo' mínimo. Con `reducedMotion` el mundo
+ * monta QUIETO (frameloop a demanda). La fauna son los SVG rubber-hose de la
+ * casa como billboards (`Fauna` de FaunaEscena): la mariposa y el colibrí
+ * chillón que la flor de papa sí convoca.
+ *
+ * `foco` (opcional): un punto [x,y,z] que el paso didáctico del host señala con
+ * un anillo que respira. Importa three/@react-three → montar SOLO perezosa.
+ */
+import { useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { perfilDeTier } from '../deviceTier.js';
+import { Fauna } from '../escenas/FaunaEscena.jsx';
+import FloraPapa from './FloraPapa.jsx';
+import {
+  ANCHO,
+  FONDO,
+  alturaLadera,
+  reliefSurco,
+  SITIO_CASA,
+  SITIO_COSECHA,
+} from './floraPapa.geom.js';
+
+/* La atmósfera del piso frío: cielo azul limpio y luz dura de montaña alta. */
+const FRIO = {
+  fondo: '#b7d2e4',
+  bruma: '#c9dce8',
+  sol: '#fff8e6',
+  cielo: '#ddeaf4',
+  suelo: '#3b3226',
+};
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
+    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
+    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
+  );
+}
+
+/* La malla de la ladera con colores por vértice: el LOMO del caballón en tierra
+   negra recién aporcada, el surco hondo entre lomos más húmedo y oscuro, y
+   afuera del lote el pajonal amarillo-verde del frío. Los caballones van en la
+   ALTURA (alturaLadera ya los trae horneados): el relieve se lee de verdad. */
+function construirLadera(seg, plano) {
+  const nx = seg + 1;
+  const nz = seg + 1;
+  const pos = new Float32Array(nx * nz * 3);
+  const col = new Float32Array(nx * nz * 3);
+  const cPajonal = new THREE.Color('#9aa056');
+  const cPajonal2 = new THREE.Color('#aab061');
+  const cLomo = new THREE.Color('#4a3a2b'); // la tierra negra del caballón
+  const cLomoSeco = new THREE.Color('#5c4936'); // la cresta que el sol ya secó
+  const cSurco = new THREE.Color('#332920'); // el fondo húmedo entre lomos
+  const cCamino = new THREE.Color('#8d7a58');
+  const cLoma = new THREE.Color('#7f8a52'); // la loma alta, más parda de frío
+  const c = new THREE.Color();
+  let p = 0;
+  for (let iz = 0; iz < nz; iz++) {
+    const wz = -FONDO / 2 + (FONDO * iz) / seg;
+    for (let ix = 0; ix < nx; ix++) {
+      const wx = -ANCHO / 2 + (ANCHO * ix) / seg;
+      pos[p] = wx;
+      pos[p + 1] = alturaLadera(wx, wz);
+      pos[p + 2] = wz;
+
+      const s = reliefSurco(wx, wz);
+      const enLoma = smoothstep(-8, -17, wz);
+      // base: pajonal con manchas, y hacia la loma alta se apaga de frío
+      c.lerpColors(cPajonal, cPajonal2, 0.5 + 0.5 * ruido(wx * 0.9, wz * 0.7));
+      c.lerp(cLoma, enLoma * 0.55);
+      // dentro del lote: el surco húmedo de fondo…
+      c.lerp(cSurco, s.lote * 0.85);
+      // …y el LOMO del caballón encima, tierra negra con la cresta seca
+      const lomo = smoothstep(0.2, 0.8, s.lomo);
+      c.lerp(cLomo, lomo);
+      c.lerp(cLomoSeco, smoothstep(0.62, 1, s.lomo) * 0.85);
+      // el claro de la COSECHA: tierra abierta, ya sin surco
+      const dCx = wx - SITIO_COSECHA[0];
+      const dCz = wz - SITIO_COSECHA[1];
+      c.lerp(cLomo, smoothstep(9, 2.5, dCx * dCx + dCz * dCz) * 0.8);
+      // el caminito por donde se entra al lote, al frente
+      c.lerp(
+        cCamino,
+        smoothstep(1.3, 0, Math.abs(wx - 4 - Math.sin(wz * 0.35) * 2.4)) * smoothstep(4, 14, wz),
+      );
+      col[p] = c.r;
+      col[p + 1] = c.g;
+      col[p + 2] = c.b;
+      p += 3;
+    }
+  }
+  const idx = [];
+  for (let iz = 0; iz < seg; iz++) {
+    for (let ix = 0; ix < seg; ix++) {
+      const a = iz * nx + ix;
+      const b = a + 1;
+      const d = a + nx;
+      const e = d + 1;
+      idx.push(a, d, b, b, d, e);
+    }
+  }
+  let geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  geo.setIndex(idx);
+  if (plano) geo = geo.toNonIndexed();
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/* La casita campesina de tierra fría, arriba al fondo: paredes de adobe
+   encalado, techo de teja, la ruana colgada — y en el patio los COSTALES de
+   papa cosidos, listos pal mercado. Insinuada, que el mundo es el surco. */
+function CasaFria({ pos }) {
+  return (
+    <group position={pos} rotation={[0, 0.4, 0]}>
+      {/* la casa: adobe encalado con zócalo de tierra */}
+      <mesh position={[0, 0.7, 0]}>
+        <boxGeometry args={[2.4, 1.4, 1.8]} />
+        <meshLambertMaterial color="#ece4d2" flatShading />
+      </mesh>
+      <mesh position={[0, 0.17, 0]}>
+        <boxGeometry args={[2.44, 0.34, 1.84]} />
+        <meshLambertMaterial color="#7a5a3c" flatShading />
+      </mesh>
+      {/* la puerta y la ventanita (maderas verdes de tierra fría) */}
+      <mesh position={[0.42, 0.6, 0.91]}>
+        <boxGeometry args={[0.42, 0.92, 0.06]} />
+        <meshLambertMaterial color="#3e5c40" flatShading />
+      </mesh>
+      <mesh position={[-0.55, 0.84, 0.91]}>
+        <boxGeometry args={[0.46, 0.4, 0.06]} />
+        <meshLambertMaterial color="#3e5c40" flatShading />
+      </mesh>
+      {/* techo a dos aguas de teja */}
+      <mesh position={[0, 1.56, -0.58]} rotation={[-0.6, 0, 0]}>
+        <boxGeometry args={[2.8, 0.08, 1.42]} />
+        <meshLambertMaterial color="#96482f" flatShading />
+      </mesh>
+      <mesh position={[0, 1.56, 0.58]} rotation={[0.6, 0, 0]}>
+        <boxGeometry args={[2.8, 0.08, 1.42]} />
+        <meshLambertMaterial color="#a25136" flatShading />
+      </mesh>
+      {/* la chimenea de fogón de leña (en el frío se cocina con candela) */}
+      <mesh position={[-0.85, 1.85, -0.3]}>
+        <boxGeometry args={[0.24, 0.6, 0.24]} />
+        <meshLambertMaterial color="#8a8074" flatShading />
+      </mesh>
+
+      {/* los COSTALES de papa cosidos en el patio, la cosecha que ya subió */}
+      {[
+        [1.7, 0.55, 0], [2.15, 0.75, 0.18], [1.9, 0.15, -0.55],
+      ].map((q, i) => (
+        <group key={`s${i}`} position={[q[0], 0, q[1] ?? 0]} rotation={[0, q[2] ?? 0, 0]}>
+          <mesh position={[0, 0.34, 0]}>
+            <cylinderGeometry args={[0.24, 0.28, 0.68, 8, 1]} />
+            <meshLambertMaterial color="#c8b184" flatShading />
+          </mesh>
+          <mesh position={[0, 0.7, 0]} scale={[1, 0.5, 1]}>
+            <sphereGeometry args={[0.2, 7, 5]} />
+            <meshLambertMaterial color="#b49c6e" flatShading />
+          </mesh>
+        </group>
+      ))}
+
+      {/* el azadón recostado a la pared (la herramienta del surco) */}
+      <group position={[-1.28, 0, 0.72]} rotation={[0, 0, 0.35]}>
+        <mesh position={[0, 0.6, 0]}>
+          <cylinderGeometry args={[0.03, 0.03, 1.2, 5, 1]} />
+          <meshLambertMaterial color="#8a6c48" flatShading />
+        </mesh>
+        <mesh position={[0.1, 0.06, 0]} rotation={[0, 0, -1.2]}>
+          <boxGeometry args={[0.3, 0.14, 0.05]} />
+          <meshLambertMaterial color="#6e6a62" flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* El rincón de COSECHA: el canasto con papas y la manta con la saca tendida —
+   los tubérculos instanciados de FloraPapa ya ponen la diversidad al piso. */
+function RinconCosecha({ pos }) {
+  return (
+    <group position={pos}>
+      {/* el canasto de bejuco con su papa adentro */}
+      <group position={[0.6, 0, -1.2]}>
+        <mesh position={[0, 0.2, 0]}>
+          <cylinderGeometry args={[0.3, 0.22, 0.4, 9, 1, true]} />
+          <meshLambertMaterial color="#a9713c" flatShading side={THREE.DoubleSide} />
+        </mesh>
+        <mesh position={[0, 0.4, 0]} scale={[1, 0.45, 1]}>
+          <sphereGeometry args={[0.26, 8, 5]} />
+          <meshLambertMaterial color="#dfb43a" flatShading />
+        </mesh>
+      </group>
+      {/* la manta tendida donde se aparta la saca por tamaños */}
+      <mesh position={[-0.9, 0.03, 0.9]} rotation={[-Math.PI / 2, 0, 0.4]}>
+        <planeGeometry args={[1.7, 1.2]} />
+        <meshLambertMaterial color="#cbbfa4" flatShading side={THREE.DoubleSide} />
+      </mesh>
+      {/* el azadón clavado en el montículo, en plena faena */}
+      <group position={[1.3, 0, 0.6]} rotation={[0.5, 0.6, -0.35]}>
+        <mesh position={[0, 0.62, 0]}>
+          <cylinderGeometry args={[0.03, 0.03, 1.24, 5, 1]} />
+          <meshLambertMaterial color="#8a6c48" flatShading />
+        </mesh>
+        <mesh position={[0.1, 0.04, 0]} rotation={[0, 0, -1.2]}>
+          <boxGeometry args={[0.3, 0.15, 0.05]} />
+          <meshLambertMaterial color="#6e6a62" flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* El anillo del paso didáctico: respira sobre el punto que la lección señala.
+   Con reducedMotion queda quieto (presencia sin parpadeo). */
+function FocoPaso({ foco, reducedMotion }) {
+  const anillo = useRef(null);
+  useFrame(({ clock }) => {
+    const m = anillo.current;
+    if (!m) return;
+    if (reducedMotion) {
+      m.material.opacity = 0.42;
+      return;
+    }
+    const t = clock.elapsedTime;
+    m.material.opacity = 0.3 + 0.2 * Math.sin(t * 1.8);
+    m.scale.setScalar(1 + 0.06 * Math.sin(t * 1.8));
+  });
+  if (!foco) return null;
+  return (
+    <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+      <ringGeometry args={[1.25, 1.65, 32]} />
+      <meshBasicMaterial
+        color="#ffe9ae"
+        transparent
+        opacity={0.4}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+/* La fauna del papal en flor: los SVG rubber-hose de la casa como billboards
+   (contrato del operador: el bicho pone el cuerpo, la escena la coreografía).
+   Pocas y por criterio: la flor de papa sí convoca su visita. */
+const FAUNA_PAPAL = [
+  { tipo: 'mariposa', base: [-3.5, 1.5, 2.4], patron: 'revoloteo', size: 26, fase: 0.6, df: 9 },
+  { tipo: 'colibri', base: [3.8, 2.2, -1.8], patron: 'revoloteo', size: 30, fase: 1.8, df: 10 },
+  { tipo: 'mariposa', base: [7.5, 1.7, 3.2], patron: 'revoloteo', size: 22, fase: 2.7, df: 9 },
+];
+
+function Diorama({ tier, reducedMotion, foco }) {
+  const perfil = perfilDeTier(tier);
+
+  const geoLadera = useMemo(
+    () => construirLadera(perfil.segmentosTerreno, perfil.flatShading),
+    [perfil.segmentosTerreno, perfil.flatShading],
+  );
+
+  const fauna = useMemo(
+    () => (tier === 'alto' ? FAUNA_PAPAL : FAUNA_PAPAL.slice(0, 2)),
+    [tier],
+  );
+
+  const casaY = alturaLadera(SITIO_CASA[0], SITIO_CASA[1]);
+  const cosechaY = alturaLadera(SITIO_COSECHA[0], SITIO_COSECHA[1]);
+
+  return (
+    <>
+      <color attach="background" args={[FRIO.fondo]} />
+      {perfil.fog && <fog attach="fog" args={[FRIO.bruma, 22, 58]} />}
+
+      {/* la luz de montaña alta: cielo azul limpio, sol blanco y duro */}
+      <hemisphereLight intensity={0.95} color={FRIO.cielo} groundColor={FRIO.suelo} />
+      <ambientLight intensity={0.3} color="#e8eef4" />
+      <directionalLight
+        position={[9, 14, 6]}
+        intensity={1.35}
+        color={FRIO.sol}
+        castShadow={perfil.sombras}
+        shadow-mapSize-width={1024}
+        shadow-mapSize-height={1024}
+        shadow-camera-near={1}
+        shadow-camera-far={44}
+        shadow-camera-left={-17}
+        shadow-camera-right={17}
+        shadow-camera-top={17}
+        shadow-camera-bottom={-7}
+      />
+      {/* contraluz azulado que enfría las sombras (el frío se ve) */}
+      <directionalLight position={[-7, 6, -8]} intensity={0.38} color="#b8cede" />
+
+      {/* LA LADERA con sus caballones horneados en el relieve */}
+      <mesh geometry={geoLadera} receiveShadow={perfil.sombras}>
+        <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
+      </mesh>
+
+      {/* los cerros fríos del fondo, ya con cara de páramo */}
+      <mesh position={[-14, 4.2, -24]} scale={[10, 5.6, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color="#6d7c54" />
+      </mesh>
+      <mesh position={[6, 5.2, -27]} scale={[12, 7, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color="#66755a" />
+      </mesh>
+      <mesh position={[21, 3.4, -23]} scale={[8, 4.6, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color="#75825a" />
+      </mesh>
+      {/* y detrasito, el filo pelado con su neblina pegada */}
+      <mesh position={[-3, 7.8, -31]} scale={[16, 5, 5]}>
+        <sphereGeometry args={[1, 10, 7]} />
+        <meshLambertMaterial color="#8b95a0" />
+      </mesh>
+
+      {/* EL PAPAL: matas en surcos, flores, cosecha, pajonal, frailejones */}
+      <FloraPapa tier={tier} reducedMotion={reducedMotion} />
+
+      {/* la casita de tierra fría con sus costales, arriba al fondo */}
+      <CasaFria pos={[SITIO_CASA[0], casaY, SITIO_CASA[1]]} />
+
+      {/* el rincón de la cosecha: canasto, manta y azadón en faena */}
+      <RinconCosecha pos={[SITIO_COSECHA[0], cosechaY, SITIO_COSECHA[1]]} />
+
+      {/* LA VIDA que la flor convoca: mariposas y el colibrí */}
+      {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
+
+      {/* el anillo del paso didáctico (lo maneja el host) */}
+      <FocoPaso foco={foco} reducedMotion={reducedMotion} />
+
+      <OrbitControls
+        makeDefault
+        target={[0, 2.8, -3]}
+        enablePan={false}
+        enableZoom
+        minDistance={8}
+        maxDistance={26}
+        minPolarAngle={0.5}
+        maxPolarAngle={1.45}
+        minAzimuthAngle={-1.1}
+        maxAzimuthAngle={1.1}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.12}
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * El mundo del papal de tierra fría. Montar SOLO perezosa (lazy).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, foco?: number[]|null}} props
+ */
+export default function EscenaPapaVivo({ tier = 'alto', reducedMotion = false, foco = null }) {
+  const perfil = perfilDeTier(tier);
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`papal-canvas${listo ? ' papal-canvas--lista' : ''}`}
+      dpr={perfil.dpr}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      shadows={perfil.sombras ? 'soft' : false}
+      camera={{ position: [2, 5.4, 15.5], fov: 46 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Diorama tier={tier} reducedMotion={reducedMotion} foco={foco} />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/papa/FloraPapa.jsx
+++ b/src/visual/mundo3d/papa/FloraPapa.jsx
@@ -1,0 +1,198 @@
+/*
+ * FloraPapa — el PAPAL de tierra fría sembrado sobre sus caballones.
+ *
+ * Consume `floraPapa.geom.js`: cada especie es UN InstancedMesh de una
+ * geometría fusionada (una draw-call por especie, por más matas que haya) —
+ * mismo contrato tier-safe que FloraCafetal. La FLOR lleva color POR INSTANCIA
+ * (lila o blanca, la variedad de cada mata) y la PAPA también (amarilla criolla,
+ * roja, morada — la diversidad andina destapada en el rincón de cosecha).
+ *
+ * En 'alto' se suma el VAHO DE FLORACIÓN: puntitos de polen/luz fría que
+ * flotan apenas sobre el lote florecido — el aire delgado de la montaña alta
+ * haciéndose visible. `reducedMotion` los deja quietos.
+ *
+ * Componente r3f: montar dentro del <Canvas> de EscenaPapaVivo.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import {
+  papalDeTier,
+  calidadPapa,
+  distribucionPapal,
+  alturaLadera,
+  geomMataPapa,
+  geomFlorPapa,
+  geomPapa,
+  geomPaja,
+  geomFrailejon,
+  geomMonticulo,
+  geomPiedra,
+} from './floraPapa.geom.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* Un banco de matas de UNA especie: una geometría, un material, N instancias.
+   (Mismo patrón que `Especie` de FloraCafetal — el molde de la casa.) */
+function Especie({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+    />
+  );
+}
+
+/*
+ * El VAHO de floración: puntitos fríos que flotan despacito sobre el lote
+ * florecido — polen y aire delgado de montaña alta. Solo 'alto'; con
+ * reducedMotion quedan quietos (presencia sin parpadeo).
+ */
+function VahoFloracion({ reducedMotion }) {
+  const puntos = useRef(null);
+  const datos = useMemo(() => {
+    const r = rng(131);
+    const n = 42;
+    const pos = new Float32Array(n * 3);
+    const fase = new Float32Array(n);
+    for (let i = 0; i < n; i++) {
+      const x = -13 + r() * 26;
+      const z = -9 + r() * 16;
+      pos[i * 3] = x;
+      pos[i * 3 + 1] = alturaLadera(x, z) + 0.5 + r() * 1.1;
+      pos[i * 3 + 2] = z;
+      fase[i] = r() * Math.PI * 2;
+    }
+    return { pos, fase, n };
+  }, []);
+
+  const geo = useMemo(() => {
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.BufferAttribute(datos.pos.slice(), 3));
+    return g;
+  }, [datos]);
+
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+
+  useFrame(({ clock }) => {
+    const p = puntos.current;
+    if (reducedMotion || !p) return;
+    const t = clock.elapsedTime;
+    const arr = p.geometry.attributes.position.array;
+    for (let i = 0; i < datos.n; i++) {
+      arr[i * 3 + 1] = datos.pos[i * 3 + 1] + Math.sin(t * 0.45 + datos.fase[i]) * 0.16;
+    }
+    p.geometry.attributes.position.needsUpdate = true;
+  });
+
+  return (
+    <points ref={puntos} geometry={geo}>
+      <pointsMaterial
+        color="#f0ead8"
+        size={0.09}
+        sizeAttenuation
+        transparent
+        opacity={0.5}
+        depthWrite={false}
+      />
+    </points>
+  );
+}
+
+/**
+ * La capa viva del papal. Montar dentro del <Canvas>.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function FloraPapa({ tier = 'alto', reducedMotion = false }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = papalDeTier(tier);
+  const q = calidadPapa(tier);
+
+  // Geometrías fusionadas (una vez por tier).
+  const geos = useMemo(
+    () => ({
+      mata: geomMataPapa({ q }, 31),
+      flor: geomFlorPapa(),
+      papa: geomPapa(),
+      paja: conteos.paja ? geomPaja({ q }, 33) : null,
+      frailejon: conteos.frailejon ? geomFrailejon({ q }, 34) : null,
+      monticulo: conteos.monticulo ? geomMonticulo(35) : null,
+      piedra: conteos.piedra ? geomPiedra(36) : null,
+    }),
+    [conteos, q],
+  );
+
+  // Material único con vertexColors (el color viene horneado por especie y el
+  // tinte por instancia lo multiplica — en flor y papa el tinte ES el color).
+  const mat = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.88, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  // Distribución determinista (una vez por tier).
+  const dist = useMemo(() => distribucionPapal(conteos, 419), [conteos]);
+
+  // Liberar GPU al desmontar.
+  useLayoutEffect(
+    () => () => {
+      Object.values(geos).forEach((g) => g && g.dispose());
+      mat.dispose();
+    },
+    [geos, mat],
+  );
+
+  const sombra = perfil.sombras; // solo lo que abulta proyecta sombra en 'alto'
+
+  return (
+    <group>
+      {/* El pajonal y la piedra: la tierra alta rodeando el lote. */}
+      <Especie geo={geos.paja} mat={mat} items={dist.paja} />
+      <Especie geo={geos.piedra} mat={mat} items={dist.piedra} />
+
+      {/* EL CULTIVO: las matas sobre el lomo del caballón y su flor. */}
+      <Especie geo={geos.mata} mat={mat} items={dist.mata} castShadow={sombra} />
+      <Especie geo={geos.flor} mat={mat} items={dist.flor} />
+
+      {/* LA COSECHA: la tierra abierta y las papas destapadas (variedades). */}
+      <Especie geo={geos.monticulo} mat={mat} items={dist.monticulo} />
+      <Especie geo={geos.papa} mat={mat} items={dist.papa} />
+
+      {/* Los frailejones LEJANOS: el páramo asomado en la loma del fondo. */}
+      <Especie geo={geos.frailejon} mat={mat} items={dist.frailejon} castShadow={sombra} />
+
+      {/* El vaho frío sobre el lote florecido (solo gama alta). */}
+      {tier === 'alto' && <VahoFloracion reducedMotion={reducedMotion} />}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/papa/MundoPapa.jsx
+++ b/src/visual/mundo3d/papa/MundoPapa.jsx
@@ -1,0 +1,143 @@
+/*
+ * MundoPapa — el MUNDO DE LA PAPA completo: la ladera navegable + la lección.
+ *
+ * Mismo contrato de host que MundoCafetal: acepta `{tier, reducedMotion}` (o
+ * auto-detecta con decidirTier si se monta suelto), llena a su padre y guarda
+ * su estado local. Sobre la escena viven los PASOS: cuatro lecciones cortas que
+ * recorren lo que este mundo enseña — el surco y por qué se amontona la tierra,
+ * la mata y su flor, la papa criolla y sus variedades andinas, y la cosecha —
+ * y cada paso señala SU lugar en la ladera con un anillo que respira (el
+ * `foco` que la escena dibuja). Copy en español de Colombia, en "usted".
+ *
+ * Importa three/@react-three (vía la escena) → montar SOLO perezoso (lazy).
+ */
+import { useMemo, useState } from 'react';
+import EscenaPapaVivo from './EscenaPapaVivo.jsx';
+import { decidirTier, permite3D } from '../deviceTier.js';
+import { alturaLadera, SITIO_COSECHA } from './floraPapa.geom.js';
+
+/* Los cuatro pasos de la lección. Cada `foco` es el punto de la ladera que el
+   anillo señala mientras se lee (coordenadas del mundo, y sobre el terreno). */
+const enSuelo = (x, z) => [x, alturaLadera(x, z), z];
+const PASOS = [
+  {
+    id: 'surco',
+    kicker: 'Paso 1 de 4 · El surco',
+    texto:
+      'Mire el relieve: la papa no se siembra a ras, se siembra en SURCOS — caballones de tierra amontonada a curva de nivel. Esa tierra alzada abriga la semilla del frío, escurre el agua lluvia y le da campo al tubérculo para engordar.',
+    foco: enSuelo(-1.0, 2.6),
+  },
+  {
+    id: 'mata',
+    kicker: 'Paso 2 de 4 · La mata y su flor',
+    texto:
+      'Encima de cada lomo va la mata: bajita, tupida, aporcada — se le arrima tierra al tallo para que eche más papa. Y cuando el papal florece, lila y blanco según la variedad, la mata le está avisando: abajo ya hay tubérculo formándose.',
+    foco: enSuelo(-3.2, -0.6),
+  },
+  {
+    id: 'criolla',
+    kicker: 'Paso 3 de 4 · La papa criolla',
+    texto:
+      'La criolla amarilla es la reina de la tierra fría colombiana, pero no está sola: en los Andes hay cientos de variedades — rojas, moradas, pintadas. Esa diversidad es semilla guardada por generaciones campesinas, y es un seguro contra plagas y heladas.',
+    foco: enSuelo(SITIO_COSECHA[0] + 0.6, SITIO_COSECHA[1] + 0.4),
+  },
+  {
+    id: 'cosecha',
+    kicker: 'Paso 4 de 4 · La cosecha',
+    texto:
+      'A los cinco o seis meses la mata se agacha y amarillea: es la seña. Se abre el caballón con azadón — con cuidado, que la papa se ofende — y la tierra entrega lo guardado. Se aparta la saca por tamaños, se cose el costal y arranca pal mercado.',
+    foco: enSuelo(SITIO_COSECHA[0] - 1.2, SITIO_COSECHA[1] + 1.2),
+  },
+];
+
+const CSS = `
+.mpapal { position: relative; width: 100%; height: 100%; overflow: hidden; background: #b7d2e4; }
+.mpapal canvas { opacity: 0; transition: opacity 0.9s ease; }
+.mpapal .papal-canvas--lista canvas, .mpapal canvas.papal-canvas--lista { opacity: 1; }
+.mpapal__panel {
+  position: absolute; left: 50%; bottom: max(0.9rem, env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  width: min(26rem, calc(100% - 1.6rem));
+  padding: 0.8rem 0.95rem 0.85rem;
+  border-radius: 1rem;
+  background: rgba(18, 22, 14, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(196, 208, 150, 0.3), 0 6px 24px rgba(10, 14, 10, 0.35);
+  backdrop-filter: blur(6px);
+  color: #eef1e2;
+}
+.mpapal__kicker { margin: 0 0 0.15rem; font: 600 0.68rem/1.2 system-ui, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: #cdd88f; }
+.mpapal__texto { margin: 0 0 0.6rem; font: 500 0.85rem/1.38 system-ui, sans-serif; color: #e9edd8; }
+.mpapal__nav { display: flex; align-items: center; gap: 0.55rem; }
+.mpapal__btn {
+  min-height: 2.5rem; min-width: 2.9rem; padding: 0 0.8rem;
+  border: 0; border-radius: 0.7rem; cursor: pointer;
+  background: linear-gradient(180deg, rgba(214, 196, 92, 0.95), rgba(164, 146, 52, 0.95));
+  color: #221d05; font: 700 0.9rem/1 system-ui, sans-serif;
+  transition: transform 0.15s ease;
+}
+.mpapal__btn:active { transform: scale(0.96); }
+.mpapal__btn[disabled] { opacity: 0.35; cursor: default; }
+.mpapal__puntos { display: flex; gap: 0.35rem; margin: 0 auto; }
+.mpapal__punto { width: 0.5rem; height: 0.5rem; border-radius: 999px; background: rgba(230, 234, 210, 0.32); }
+.mpapal__punto--activo { background: #d6c45c; box-shadow: 0 0 8px 1px rgba(214, 196, 92, 0.5); }
+@media (prefers-reduced-motion: reduce) {
+  .mpapal canvas { transition: none; }
+  .mpapal__btn { transition: none; }
+}
+`;
+
+/**
+ * El mundo de la papa de tierra fría, completo: escena + pasos didácticos.
+ * Montar SOLO perezoso (lazy); llena a su contenedor.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function MundoPapa({ tier: tierProp, reducedMotion: rmProp } = {}) {
+  // Contrato de mundos: props del host si llegan; si se monta suelto,
+  // auto-detección del equipo (no matar la gama baja).
+  const auto = useMemo(() => decidirTier(), []);
+  const tier = tierProp ?? (permite3D(auto.tier) ? auto.tier : 'bajo');
+  const reducedMotion = rmProp ?? auto.reducedMotion;
+  const [paso, setPaso] = useState(0);
+
+  const actual = PASOS[paso];
+
+  return (
+    <div className="mpapal">
+      <style>{CSS}</style>
+      <EscenaPapaVivo tier={tier} reducedMotion={reducedMotion} foco={actual.foco} />
+
+      <div className="mpapal__panel" role="group" aria-label="La lección del papal">
+        <p className="mpapal__kicker">{actual.kicker}</p>
+        <p className="mpapal__texto">{actual.texto}</p>
+        <div className="mpapal__nav">
+          <button
+            type="button"
+            className="mpapal__btn"
+            onClick={() => setPaso((p) => Math.max(0, p - 1))}
+            disabled={paso === 0}
+            aria-label="Paso anterior"
+          >
+            ←
+          </button>
+          <span className="mpapal__puntos" aria-hidden="true">
+            {PASOS.map((p, i) => (
+              <span
+                key={p.id}
+                className={`mpapal__punto${i === paso ? ' mpapal__punto--activo' : ''}`}
+              />
+            ))}
+          </span>
+          <button
+            type="button"
+            className="mpapal__btn"
+            onClick={() => setPaso((p) => Math.min(PASOS.length - 1, p + 1))}
+            disabled={paso === PASOS.length - 1}
+            aria-label="Paso siguiente"
+          >
+            →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/papa/floraPapa.geom.js
+++ b/src/visual/mundo3d/papa/floraPapa.geom.js
@@ -1,0 +1,624 @@
+/*
+ * floraPapa.geom — la GEOMETRÍA del PAPAL de tierra fría (piso frío, 2.000–3.200 m).
+ *
+ * La papa criolla es EL cultivo del frío: la montaña alta, el aire delgado y la
+ * tierra negra. Y su firma visual es el SURCO — el caballón de tierra amontonada
+ * a curva de nivel donde la mata se aporca. Aquí el caballón va HORNEADO EN EL
+ * RELIEVE del terreno (no es utilería: es la geografía), y encima de cada lomo
+ * va sembrada la mata. Cada especie con su identidad inequívoca:
+ *
+ *   · Mata de papa (Solanum       — mata baja y tupida de follaje verde medio,
+ *     phureja, la criolla)          amontonada sobre el caballón.
+ *   · Flor de papa                — INSTANCIADA APARTE con color por instancia:
+ *                                   LILA o BLANCA (así florece la papa andina,
+ *                                   según la variedad de cada mata).
+ *   · Papa criolla (tubérculo)    — instanciada con color por instancia en el
+ *                                   rincón de COSECHA: amarilla criolla en su
+ *                                   mayoría, con rojas y moradas — la diversidad
+ *                                   de variedades andinas a la vista.
+ *   · Paja de pajonal             — los macollos amarillos del frío rodeando
+ *                                   el lote (la tierra alta se anuncia sola).
+ *   · Frailejón lejano            — SILUETA al fondo, en la loma alta: la seña
+ *                                   de que el páramo queda ahí no más.
+ *   · Montículo de cosecha        — la tierra abierta con azadón, destapada.
+ *   · Piedra                      — la piedra suelta de la montaña.
+ *
+ * TÉCNICA tier-safe (mismo contrato que floraCafetal.geom): cada especie se
+ * FUSIONA en UNA geometría con color horneado en vertexColors y se dibuja con
+ * UN InstancedMesh → una draw-call por especie. FLOR y PAPA se pintan BLANCAS
+ * en la geometría para que el color POR INSTANCIA (setColorAt) sea el real.
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO si se mezclan geometrías
+ * indexadas con no-indexadas (ya mordió varias veces): aquí TODO se desindexa
+ * antes de fusionar y se TRUENA si aun así falla.
+ *
+ * Aquí viven SOLO los datos y las mallas (nada de WebGL): corre headless.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* -------------------------------------------------------------------------- */
+/*  La ladera fría (la geografía del mundo, determinista)                      */
+/* -------------------------------------------------------------------------- */
+
+export const ANCHO = 40; // x: -20 … 20
+export const FONDO = 38; // z: -19 (la loma alta, arriba) … 19 (el frente, abajo)
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+
+/* Ruido determinista (hash de senos): misma ladera siempre, sin Math.random. */
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
+    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
+    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
+  );
+}
+
+/** La altura BASE de la ladera (sin surcos): sube fuerte hacia el fondo. */
+export function alturaBase(wx, wz) {
+  const sub = smoothstep(8, -17, wz); // 0 al frente (bajo), 1 en la loma alta
+  let h = 0.15;
+  h += sub * sub * 7.2; // la tierra fría es de pendiente brava
+  h += ruido(wx * 0.45, wz * 0.45) * 0.4 * (0.3 + sub); // ondulación natural
+  return h;
+}
+
+/* --- Los SURCOS: caballones a curva de nivel, horneados en el relieve. ----- */
+
+/* Las filas del lote (z del centro de cada caballón) y su curva de nivel. */
+export const FILAS_SURCO = [7.2, 5.6, 4.0, 2.4, 0.8, -0.8, -2.4, -4.0, -5.6, -7.2, -8.8, -10.4];
+
+/** La curva de nivel del surco: el caballón serpentea con la ladera. */
+export function curvaSurco(wx, fila) {
+  return Math.sin(wx * 0.11 + fila * 0.55) * 1.05;
+}
+
+/* El lote sembrado (dónde hay caballones) y los claros que el lote respeta. */
+export const SITIO_CASA = /** @type {[number, number]} */ ([-11.5, -13.2]);
+export const SITIO_COSECHA = /** @type {[number, number]} */ ([6.8, 4.6]);
+
+/** Máscara 0…1 del lote sembrado (dentro hay caballones; fuera, pajonal). */
+export function dentroLote(wx, wz) {
+  let m =
+    smoothstep(-17, -14.5, wx) *
+    smoothstep(17, 14.5, wx) *
+    smoothstep(9.4, 7.6, wz) *
+    smoothstep(-13.2, -11.0, wz);
+  // el claro de la cosecha (la tierra ya destapada) y el patio de la casa
+  const dCx = wx - SITIO_COSECHA[0];
+  const dCz = wz - SITIO_COSECHA[1];
+  m *= smoothstep(6.5, 13.5, dCx * dCx + dCz * dCz);
+  const dHx = wx - SITIO_CASA[0];
+  const dHz = wz - SITIO_CASA[1];
+  m *= smoothstep(9, 20, dHx * dHx + dHz * dHz);
+  return m;
+}
+
+/**
+ * El RELIEVE del caballón en un punto: la campana de tierra amontonada de la
+ * fila más cercana, solo dentro del lote. Devuelve también qué tan "encima del
+ * lomo" está el punto (para pintar la tierra en el terreno).
+ */
+export function reliefSurco(wx, wz) {
+  const lote = dentroLote(wx, wz);
+  if (lote <= 0.001) return { alza: 0, lomo: 0, lote: 0 };
+  let mejor = 1e9;
+  for (let i = 0; i < FILAS_SURCO.length; i++) {
+    const zc = FILAS_SURCO[i] + curvaSurco(wx, i);
+    const d = wz - zc;
+    const d2 = d * d;
+    if (d2 < mejor) mejor = d2;
+  }
+  // campana del caballón: ~0.9 de ancho, 0.42 de alto de tierra aporcada
+  const perfil = Math.exp(-mejor / 0.2);
+  return { alza: perfil * 0.42 * lote, lomo: perfil * lote, lote };
+}
+
+/** La altura FINAL de la ladera con los surcos horneados. */
+export function alturaLadera(wx, wz) {
+  return alturaBase(wx, wz) + reliefSurco(wx, wz).alza;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Presupuesto por tier                                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Instancias por especie. 'alto' puebla el papal pleno; 'medio' es frugal;
+ * 'bajo' deja lo mínimo para que AÚN se lea "papal en surcos con pajonal". La
+ * flor es el conteo del InstancedMesh de flores (repartidas entre las matas) y
+ * la papa el de tubérculos destapados en el rincón de cosecha.
+ */
+export const FLORA_PAPA = {
+  alto: { mata: 130, flor: 300, papa: 44, paja: 90, frailejon: 9, monticulo: 3, piedra: 7 },
+  medio: { mata: 78, flor: 160, papa: 26, paja: 52, frailejon: 5, monticulo: 2, piedra: 4 },
+  bajo: { mata: 36, flor: 66, papa: 12, paja: 24, frailejon: 3, monticulo: 1, piedra: 2 },
+};
+
+/** Conteos para un tier (desconocido → frugal, nunca el más caro). */
+export const papalDeTier = (tier) => FLORA_PAPA[tier] || FLORA_PAPA.medio;
+
+/** Factor de detalle geométrico por tier (menos blobs/hojas en gama baja). */
+export const CALIDAD_PAPA = { alto: 1, medio: 0.62, bajo: 0.42 };
+export const calidadPapa = (tier) => CALIDAD_PAPA[tier] ?? CALIDAD_PAPA.medio;
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del papal (colores horneados en vertexColors)                       */
+/* -------------------------------------------------------------------------- */
+
+export const PAL = {
+  // Mata de papa (la criolla): follaje verde medio, un pelo amarilloso
+  mataTallo: '#5d7038',
+  mataHoja: '#4d7a35',
+  mataHojaSol: '#699344',
+  mataBrote: '#86a84e',
+
+  // Las flores van POR INSTANCIA (referencia): lila y blanca
+  florLila: '#b28cd6',
+  florLila2: '#9a72c4',
+  florBlanca: '#f3eef8',
+
+  // El tubérculo va POR INSTANCIA (referencia): la diversidad andina
+  papaCriolla: '#e5b93c', // la amarilla, la reina
+  papaCriolla2: '#d4a52f',
+  papaRoja: '#a4503a', // la pastusa roja
+  papaMorada: '#5c3a66', // la morada andina
+
+  // Pajonal (los macollos del frío)
+  paja: '#b3a95e',
+  pajaSeca: '#c2b476',
+  pajaVerde: '#8f9a52',
+
+  // Frailejón lejano (silueta, no protagonista): la roseta plateada manda
+  frailejonTronco: '#7a6648',
+  frailejonHoja: '#aebe9a',
+  frailejonHojaSeca: '#bcae84',
+
+  // Tierra y piedra
+  tierraNegra: '#43352a',
+  tierraAbierta: '#382c21',
+  piedra: '#8d8a80',
+  liquen: '#a5a986',
+
+  // El costal de fique de la cosecha
+  costal: '#c8b184',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Utilidades (fusión desindexada + colocación + color horneado)              */
+/* -------------------------------------------------------------------------- */
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+/** Hornea un color plano en TODOS los vértices (atributo `color`). */
+function pintar(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Coloca una geometría (posición/rotación/escala) transformando vértices. */
+function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/** Orienta el +Y de la geometría hacia `dir` y la ubica en `pos` (hojas). */
+function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    q,
+    new THREE.Vector3(esc[0], esc[1], esc[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/**
+ * Fusiona partes (ya coloreadas) en UNA geometría. Se DESINDEXA todo antes de
+ * fusionar y se TRUENA si falla: mejor un error de build que una especie
+ * invisible en producción (mordida conocida de mergeGeometries).
+ */
+function fusionar(partes) {
+  const buenas = partes.filter(Boolean).map((p) => {
+    const plana = p.index ? p.toNonIndexed() : p;
+    if (plana !== p) p.dispose();
+    return plana;
+  });
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error('floraPapa: mergeGeometries devolvió null — atributos incompatibles entre partes');
+  }
+  return g;
+}
+
+/** Pequeña variación determinista de color (que el papal no sea plano). */
+function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  MATA DE PAPA (Solanum phureja, la criolla) — el cultivo                    */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Mata BAJA y tupida, amontonada sobre el caballón: tallos cortos que apenas
+ * asoman y 3–4 masas de follaje anchas y pegadas al lomo de tierra. Las FLORES
+ * no van aquí: son un InstancedMesh aparte con color por instancia (lila o
+ * blanca, según la variedad de la mata).
+ */
+export function geomMataPapa({ q = 1 } = {}, seed = 1) {
+  const r = rng(seed);
+  const partes = [];
+
+  // Los tallitos que asoman entre el follaje.
+  const nTallos = q < 0.5 ? 2 : 3;
+  for (let i = 0; i < nTallos; i++) {
+    const a = (i / nTallos) * Math.PI * 2 + r();
+    const tallo = new THREE.CylinderGeometry(0.014, 0.022, 0.34, 4, 1);
+    apuntar(tallo, [Math.cos(a) * 0.1, 0.16, Math.sin(a) * 0.1], [Math.cos(a) * 0.35, 1, Math.sin(a) * 0.35]);
+    partes.push(pintar(tallo, PAL.mataTallo));
+  }
+
+  // Las masas de follaje: anchas, bajas, amontonadas (la mata aporcada).
+  const masas = [
+    { x: 0, z: 0, y: 0.2, rad: 0.3, cara: false },
+    { x: 0.2, z: 0.14, y: 0.16, rad: 0.24, cara: true },
+    { x: -0.2, z: -0.1, y: 0.17, rad: 0.25, cara: false },
+    { x: -0.02, z: 0.18, y: 0.28, rad: 0.2, cara: true },
+  ];
+  const nMasas = q < 0.5 ? 3 : 4;
+  for (let i = 0; i < nMasas; i++) {
+    const m = masas[i];
+    const masa = new THREE.IcosahedronGeometry(m.rad, 1); // detail 1: mata tupida
+    poner(
+      masa,
+      [m.x + (r() - 0.5) * 0.06, m.y, m.z + (r() - 0.5) * 0.06],
+      [0, r() * Math.PI, 0],
+      [1.35, 0.72, 1.35],
+    );
+    partes.push(pintar(masa, variar(m.cara ? PAL.mataHojaSol : PAL.mataHoja, r, 0.05)));
+  }
+
+  // El cogollo tierno del centro.
+  const brote = new THREE.IcosahedronGeometry(0.09, 0);
+  poner(brote, [0.02, 0.38, 0.02], [0, r() * Math.PI, 0], [1, 0.75, 1]);
+  partes.push(pintar(brote, PAL.mataBrote));
+
+  return fusionar(partes);
+}
+
+/** La flor de papa: un ramito blanco — el color real (lila/blanca) va POR INSTANCIA. */
+export function geomFlorPapa() {
+  const partes = [];
+  // tres florecitas apiñadas (el racimo terminal de la papa)
+  const puntos = [
+    [0, 0.045, 0],
+    [0.055, 0.01, 0.02],
+    [-0.04, 0.005, -0.045],
+  ];
+  for (const p of puntos) {
+    const flor = new THREE.IcosahedronGeometry(0.042, 0);
+    poner(flor, p);
+    partes.push(pintar(flor, '#ffffff'));
+  }
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  PAPA CRIOLLA (el tubérculo destapado) — color por instancia                */
+/* -------------------------------------------------------------------------- */
+
+/** El tubérculo: bolita apenas ovalada, blanca — el color va POR INSTANCIA. */
+export function geomPapa() {
+  const g = new THREE.IcosahedronGeometry(0.085, 1);
+  poner(g, [0, 0, 0], [0, 0, 0.35], [1.25, 0.85, 0.95]);
+  return pintar(g.index ? g.toNonIndexed() : g, '#ffffff');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  PAJA DE PAJONAL — los macollos amarillos del frío                          */
+/* -------------------------------------------------------------------------- */
+
+export function geomPaja({ q = 1 } = {}, seed = 7) {
+  const r = rng(seed);
+  const partes = [];
+  const nHojas = Math.max(4, Math.round(7 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const a = (i / nHojas) * Math.PI * 2 + r() * 0.6;
+    const inclina = 0.25 + r() * 0.4;
+    const alto = 0.5 + r() * 0.35;
+    const hoja = new THREE.ConeGeometry(0.035, alto, 4, 1);
+    apuntar(
+      hoja,
+      [Math.cos(a) * 0.07, alto * 0.42, Math.sin(a) * 0.07],
+      [Math.cos(a) * inclina, 1, Math.sin(a) * inclina],
+    );
+    const tono = r();
+    partes.push(pintar(hoja, variar(tono > 0.6 ? PAL.pajaSeca : tono > 0.25 ? PAL.paja : PAL.pajaVerde, r, 0.06)));
+  }
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  FRAILEJÓN LEJANO — la silueta del páramo al fondo (no protagonista)        */
+/* -------------------------------------------------------------------------- */
+
+export function geomFrailejon({ q = 1 } = {}, seed = 8) {
+  const r = rng(seed);
+  const partes = [];
+
+  // El tronco lanudo, CORTO (las hojas viejas que lo abrigan): que la
+  // silueta que mande sea la roseta, no un palo pelado.
+  const tronco = new THREE.CylinderGeometry(0.17, 0.21, 0.72, 6, 1);
+  poner(tronco, [0, 0.36, 0]);
+  partes.push(pintar(tronco, PAL.frailejonTronco));
+
+  // La roseta plateada: dos coronas de hojas anchas — la de abajo abierta,
+  // la de arriba parada — y el cogollo del centro apuntando al cielo.
+  const nHojas = Math.max(7, Math.round(10 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const a = (i / nHojas) * Math.PI * 2 + r() * 0.4;
+    const abre = 0.55 + r() * 0.35;
+    const hoja = new THREE.ConeGeometry(0.12, 0.66, 4, 1);
+    apuntar(
+      hoja,
+      [Math.cos(a) * 0.16, 0.82, Math.sin(a) * 0.16],
+      [Math.cos(a) * abre, 1, Math.sin(a) * abre],
+    );
+    partes.push(pintar(hoja, variar(i % 3 === 2 ? PAL.frailejonHojaSeca : PAL.frailejonHoja, r, 0.06)));
+  }
+  const nAltas = Math.max(4, Math.round(6 * q));
+  for (let i = 0; i < nAltas; i++) {
+    const a = (i / nAltas) * Math.PI * 2 + 0.5 + r() * 0.4;
+    const abre = 0.18 + r() * 0.2;
+    const hoja = new THREE.ConeGeometry(0.1, 0.56, 4, 1);
+    apuntar(
+      hoja,
+      [Math.cos(a) * 0.07, 0.98, Math.sin(a) * 0.07],
+      [Math.cos(a) * abre, 1, Math.sin(a) * abre],
+    );
+    partes.push(pintar(hoja, variar(PAL.frailejonHoja, r, 0.05)));
+  }
+  const cogollo = new THREE.ConeGeometry(0.09, 0.4, 4, 1);
+  poner(cogollo, [0, 1.14, 0]);
+  partes.push(pintar(cogollo, variar(PAL.frailejonHoja, r, 0.04)));
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  MONTÍCULO de cosecha — la tierra abierta con el azadón                     */
+/* -------------------------------------------------------------------------- */
+
+export function geomMonticulo(seed = 9) {
+  const r = rng(seed);
+  const partes = [];
+  // la tierra volteada: dos terrones grandes y uno chico
+  const t1 = new THREE.DodecahedronGeometry(0.42, 0);
+  poner(t1, [0, 0.1, 0], [r() * 0.5, r() * Math.PI, r() * 0.5], [1.4, 0.5, 1.1]);
+  partes.push(pintar(t1, PAL.tierraAbierta));
+  const t2 = new THREE.DodecahedronGeometry(0.3, 0);
+  poner(t2, [0.42, 0.08, 0.2], [r() * 0.5, r() * Math.PI, r() * 0.5], [1.2, 0.5, 1]);
+  partes.push(pintar(t2, PAL.tierraNegra));
+  const t3 = new THREE.DodecahedronGeometry(0.18, 0);
+  poner(t3, [-0.36, 0.06, -0.2], [r() * 0.6, r() * Math.PI, 0], [1.1, 0.55, 1]);
+  partes.push(pintar(t3, PAL.tierraAbierta));
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  PIEDRA — la piedra suelta de la montaña                                    */
+/* -------------------------------------------------------------------------- */
+
+export function geomPiedra(seed = 6) {
+  const r = rng(seed);
+  const roca = new THREE.DodecahedronGeometry(0.34, 0);
+  poner(roca, [0, 0.14, 0], [r() * 0.6, r() * Math.PI, r() * 0.6], [1.25, 0.68, 1]);
+  const capa = new THREE.DodecahedronGeometry(0.18, 0);
+  poner(capa, [0.12, 0.24, 0.05], [0, r() * Math.PI, 0], [1, 0.55, 1]);
+  return fusionar([pintar(roca, PAL.piedra), pintar(capa, PAL.liquen)]);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Distribución: las matas SOBRE el lomo del caballón + el resto del mundo    */
+/* -------------------------------------------------------------------------- */
+
+/** ¿Qué tan florecida está la mata? El centro del lote florece más parejo. */
+function floracionEn(wz, r) {
+  const base = smoothstep(-11, 1.5, wz) * smoothstep(8.5, 0, wz);
+  return clamp(0.3 + base * 0.55 + (r() - 0.5) * 0.3, 0, 1);
+}
+
+/**
+ * Siembra determinista del papal completo. Devuelve items por especie:
+ * `{pos, rotY, escala, tint}` (contrato del componente `Especie`); para la FLOR
+ * el `tint` ES el color (lila/blanca por mata) y para la PAPA es la variedad
+ * (amarilla criolla / roja / morada).
+ */
+export function distribucionPapal(conteos, seed = 419) {
+  const c = conteos;
+  const rMat = rng(seed + 1);
+  const rFlo = rng(seed + 2);
+  const rSue = rng(seed + 3);
+
+  // --- Las matas SOBRE el lomo de cada caballón (la siembra aporcada). ------
+  const sitios = [];
+  FILAS_SURCO.forEach((z0, fila) => {
+    for (let wx = -14.5; wx <= 14.5; wx += 1.05) {
+      const px = wx + (rMat() - 0.5) * 0.3;
+      const pz = z0 + curvaSurco(px, fila) + (rMat() - 0.5) * 0.16;
+      if (dentroLote(px, pz) < 0.55) continue; // fuera del lote o en un claro
+      sitios.push({
+        px, pz,
+        esc: 0.8 + rMat() * 0.5,
+        rotY: rMat() * Math.PI * 2,
+        florece: floracionEn(pz, rMat),
+        lila: rMat() > 0.38, // la variedad de la mata decide el color de su flor
+      });
+    }
+  });
+  // recorte determinista al presupuesto del tier (salto parejo, no los primeros N)
+  const paso = Math.max(1, Math.floor(sitios.length / Math.max(1, c.mata)));
+  const matas = [];
+  for (let i = 0; i < sitios.length && matas.length < c.mata; i += paso) matas.push(sitios[i]);
+
+  const mata = matas.map((s) => ({
+    pos: [s.px, alturaLadera(s.px, s.pz), s.pz],
+    rotY: s.rotY,
+    escala: s.esc,
+    tint: [0.92 + rMat() * 0.16, 0.92 + rMat() * 0.16, 0.92 + rMat() * 0.16],
+  }));
+
+  // --- Las flores: ramitos sobre las matas que están floreciendo. -----------
+  const lila = new THREE.Color(PAL.florLila);
+  const lila2 = new THREE.Color(PAL.florLila2);
+  const blanca = new THREE.Color(PAL.florBlanca);
+  const col = new THREE.Color();
+  const flor = [];
+  const floridas = matas.filter((s) => s.florece > 0.35);
+  let gi = 0;
+  while (flor.length < c.flor && floridas.length > 0) {
+    const s = floridas[gi % floridas.length];
+    gi += 1;
+    if (gi > floridas.length * 8) break;
+    const cuantas = 1 + Math.floor(rFlo() * 3);
+    for (let k = 0; k < cuantas && flor.length < c.flor; k++) {
+      const a = rFlo() * Math.PI * 2;
+      const rad = (0.12 + rFlo() * 0.2) * s.esc;
+      if (s.lila) col.lerpColors(lila, lila2, rFlo());
+      else col.copy(blanca);
+      col.multiplyScalar(0.94 + rFlo() * 0.12);
+      flor.push({
+        pos: [
+          s.px + Math.cos(a) * rad,
+          alturaLadera(s.px, s.pz) + (0.34 + rFlo() * 0.12) * s.esc,
+          s.pz + Math.sin(a) * rad,
+        ],
+        rotY: rFlo() * Math.PI,
+        escala: 0.85 + rFlo() * 0.4,
+        tint: [col.r, col.g, col.b],
+      });
+    }
+  }
+
+  // --- La cosecha: papas destapadas en el claro (la diversidad andina). -----
+  const criolla = new THREE.Color(PAL.papaCriolla);
+  const criolla2 = new THREE.Color(PAL.papaCriolla2);
+  const roja = new THREE.Color(PAL.papaRoja);
+  const morada = new THREE.Color(PAL.papaMorada);
+  const papa = [];
+  for (let i = 0; i < c.papa; i++) {
+    const a = rSue() * Math.PI * 2;
+    const rad = Math.sqrt(rSue()) * 2.1;
+    const x = SITIO_COSECHA[0] + Math.cos(a) * rad;
+    const z = SITIO_COSECHA[1] + Math.sin(a) * rad * 0.8;
+    // la mayoría criolla amarilla; unas rojas y unas moradas (variedades)
+    const v = rSue();
+    if (v > 0.86) col.copy(morada);
+    else if (v > 0.7) col.copy(roja);
+    else col.lerpColors(criolla, criolla2, rSue());
+    col.multiplyScalar(0.92 + rSue() * 0.16);
+    papa.push({
+      pos: [x, alturaLadera(x, z) + 0.06, z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.8 + rSue() * 0.55,
+      tint: [col.r, col.g, col.b],
+    });
+  }
+
+  // --- Los montículos de tierra abierta del claro de cosecha. ---------------
+  const monticulo = [];
+  const sitiosMont = [
+    [SITIO_COSECHA[0] - 1.3, SITIO_COSECHA[1] + 0.4],
+    [SITIO_COSECHA[0] + 1.1, SITIO_COSECHA[1] - 0.9],
+    [SITIO_COSECHA[0] + 0.2, SITIO_COSECHA[1] + 1.5],
+  ];
+  for (let i = 0; i < Math.min(c.monticulo, sitiosMont.length); i++) {
+    const [x, z] = sitiosMont[i];
+    monticulo.push({
+      pos: [x, alturaLadera(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.85 + rSue() * 0.4,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+
+  // --- El pajonal: macollos rodeando el lote y subiendo a la loma. -----------
+  const paja = [];
+  let intentosPaja = 0;
+  while (paja.length < c.paja && intentosPaja < c.paja * 14) {
+    intentosPaja += 1;
+    const x = -19 + rSue() * 38;
+    const z = -18 + rSue() * 36;
+    if (dentroLote(x, z) > 0.25) continue; // el pajonal NO invade el lote
+    const dCx = x - SITIO_COSECHA[0];
+    const dCz = z - SITIO_COSECHA[1];
+    if (dCx * dCx + dCz * dCz < 7) continue; // ni el claro de cosecha
+    const dHx = x - SITIO_CASA[0];
+    const dHz = z - SITIO_CASA[1];
+    if (dHx * dHx + dHz * dHz < 8) continue; // ni el patio de la casa
+    paja.push({
+      pos: [x, alturaLadera(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.7 + rSue() * 0.8,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+
+  // --- Los frailejones LEJANOS: la loma alta del fondo, silueta del páramo. --
+  const frailejon = [];
+  const sitiosFrail = [
+    [-15.5, -16.5], [-11, -17.5], [-6, -16.8], [-1, -17.6], [4, -16.9],
+    [9, -17.4], [13.5, -16.6], [16.5, -17.2], [-18, -15.8],
+  ];
+  for (let i = 0; i < Math.min(c.frailejon, sitiosFrail.length); i++) {
+    const [x, z] = sitiosFrail[i];
+    frailejon.push({
+      pos: [x, alturaLadera(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 1.25 + rSue() * 0.6,
+      tint: [0.92 + rSue() * 0.12, 0.92 + rSue() * 0.12, 0.92 + rSue() * 0.12],
+    });
+  }
+
+  // --- Las piedras sueltas (fuera del lote, que el azadón ya las sacó). ------
+  const piedra = [];
+  let intentosPiedra = 0;
+  while (piedra.length < c.piedra && intentosPiedra < c.piedra * 14) {
+    intentosPiedra += 1;
+    const x = -18 + rSue() * 36;
+    const z = -16 + rSue() * 32;
+    if (dentroLote(x, z) > 0.25) continue;
+    piedra.push({
+      pos: [x, alturaLadera(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.7 + rSue() * 0.9,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+
+  return { mata, flor, papa, paja, frailejon, monticulo, piedra };
+}


### PR DESCRIPTION
## El mundo de la papa (piso frío)

Mundo 3D navegable nuevo, calcado del molde del MUNDO DEL CAFÉ (#2500). La papa criolla contada como es: en SURCOS.

### La firma visual: el caballón
- Los surcos van **horneados en el relieve del terreno** (heightfield): campana de tierra amontonada a curva de nivel, cresta seca más clara y fondo de surco húmedo más oscuro en vertexColors. Se lee la tierra alzada de verdad, no una raya pintada.
- La mata de papa va **aporcada encima de cada lomo** (siembra determinista sobre el centro del caballón).

### Especies (una draw-call por especie, InstancedMesh)
- **Mata de papa criolla**: baja, tupida, con cogollo.
- **Flor de papa**: color POR INSTANCIA — lila o blanca según la variedad de cada mata.
- **Papa criolla destapada**: color POR INSTANCIA en el rincón de cosecha — amarilla criolla (mayoría), roja y morada: la diversidad andina a la vista.
- **Pajonal** rodeando el lote, **frailejones en silueta** en la loma del fondo (el páramo queda ahí no más), montículos de tierra abierta y piedra.
- Geometrías fusionadas **desindexadas antes de fusionar** y error duro si `mergeGeometries` devuelve null (mordida conocida).

### Escena
- Luz dura y fría de montaña alta, cielo azul limpio, contraluz azulado.
- Casita de tierra fría con costales de papa cosidos y azadón; rincón de cosecha con canasto, manta y azadón en faena.
- Fauna rubber-hose de la casa (mariposa + colibrí) como billboards.
- 4 pasos didácticos con anillo-foco: el surco y por qué / la mata y su flor / la papa criolla (variedades) / la cosecha. Copy en usted.

### Tier-safe
- `FLORA_PAPA` alto/medio/bajo + `calidadPapa` (menos blobs en gama baja). Vaho de floración y sombras solo en 'alto'. `reducedMotion` = mundo quieto (frameloop demand).
- Vitrina `#/mockups/papa-viva-3d` con **ficha 2D del surco en corte** (CSS puro: mata + flores + caballón + las papas bajo tierra) para equipo humilde / sin WebGL.

### Verificación
- `npm run build:prod` VERDE · `npm run tsc:check` limpio.
- Capturado navegando en 390×844 y 1280×800: vista general, 2 ángulos por drag (OrbitControls), los 4 pasos y la ficha 2D.

### Archivos
- `src/visual/mundo3d/papa/floraPapa.geom.js` (nuevo)
- `src/visual/mundo3d/papa/FloraPapa.jsx` (nuevo)
- `src/visual/mundo3d/papa/EscenaPapaVivo.jsx` (nuevo)
- `src/visual/mundo3d/papa/MundoPapa.jsx` (nuevo)
- `src/mockups/PapaVivo3D.jsx` + `.css` (nuevos)
- `src/App.jsx` (lazy import + ruta + case, los 3 puntos del patrón café)

🤖 Generated with [Claude Code](https://claude.com/claude-code)