### PR TITLE
art(cacao): el mundo del cacao — cacaotal bajo sombra navegable (piso cálido)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -156,6 +156,12 @@ const BosqueVivo3DMockup = lazy(() => import('./mockups/BosqueVivo3D'));
 // de guamos y nogales, y la casa-beneficiadero en la bruma. Device-tiering
 // real. Ruta #/mockups/cafetal-vivo-3d, sin auth.
 const CafetalVivo3DMockup = lazy(() => import('./mockups/CafetalVivo3D'));
+// 3D: el MUNDO DEL CACAO — el cacaotal bajo sombra del piso cálido: la vega
+// sembrada a distancia pareja, la MAZORCA pegada del tronco (caulifloria)
+// madurando verde→amarillo→rojo-marrón por instancia, el sombrío de guamos con
+// plátano, y la casa con su cajón de fermentar y su pasera. Device-tiering
+// real. Ruta #/mockups/cacao-vivo-3d, sin auth.
+const CacaoVivo3DMockup = lazy(() => import('./mockups/CacaoVivo3D'));
 // 3D: el MUNDO SUELO VIVO — la RED MICORRÍZICA bajo tierra (el wood-wide web):
 // la red de hongos bioluminiscente que enlaza las raíces y reparte nutrientes,
 // con pulsos corriendo por los hilos y el Ent asomando. Device-tiering real.
@@ -576,6 +582,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo3d-bosque': 'mockup_mundo3d_bosque',
   'mockups/bosque-vivo-3d': 'mockup_bosque_vivo_3d',
   'mockups/cafetal-vivo-3d': 'mockup_cafetal_vivo_3d',
+  'mockups/cacao-vivo-3d': 'mockup_cacao_vivo_3d',
   'mockups/mundo3d-clima': 'mockup_mundo3d_clima',
   'mockups/voz-con-forma': 'mockup_voz_con_forma',
   'mockups/conversacion-voz': 'mockup_conversacion_voz',
@@ -1568,6 +1575,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del café">
               <CafetalVivo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_cacao_vivo_3d':
+        // Vitrina pública del MUNDO DEL CACAO: el cacaotal bajo sombra del
+        // piso cálido en 3D REAL — la mazorca pegada del tronco (caulifloria)
+        // madurando verde→amarillo→rojo-marrón por instancia, el sombrío de
+        // guamos con su luz colada, el plátano intercalado y la casa con el
+        // cajón de fermentar y la pasera. Cuatro pasos didácticos. En equipo
+        // humilde muestra la ficha. Ruta #/mockups/cacao-vivo-3d.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo del cacao">
+              <CacaoVivo3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/CacaoVivo3D.css
+++ b/src/mockups/CacaoVivo3D.css
@@ -1,0 +1,242 @@
+/*
+ * CacaoVivo3D.css — vitrina del mundo del cacao (#/mockups/cacao-vivo-3d).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Paleta de piso cálido: verde de vega, calina dorada y el cobre de la
+ * mazorca madura. Solo opacity/transform se animan.
+ */
+
+.kviva {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background: linear-gradient(180deg, #e2e6c2 0%, #e8e3c4 44%, #efe3c6 100%);
+  color: #322c20;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.kviva__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.kviva__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8a4a20;
+}
+.kviva__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #3c3a22;
+}
+.kviva__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 40rem;
+}
+
+.kviva__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+.kviva__lienzo {
+  position: relative;
+  height: min(66vh, 32rem);
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(138, 74, 32, 0.25);
+  box-shadow: 0 12px 30px rgba(58, 50, 32, 0.16);
+  background: radial-gradient(120% 90% at 50% 20%, #dee4ba 0%, #b8bd8c 100%);
+}
+.kviva__lienzo canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+  touch-action: none;
+}
+.cacao-canvas {
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.cacao-canvas--lista {
+  opacity: 1;
+}
+
+.kviva__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  color: #4a4430;
+  opacity: 0.85;
+}
+
+.kviva__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.kviva__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.kviva__toggle {
+  border: 1.5px solid #8a4a20;
+  background: #fff;
+  color: #8a4a20;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.kviva__toggle:hover,
+.kviva__toggle:focus-visible {
+  background: #8a4a20;
+  color: #fff;
+  outline-offset: 2px;
+}
+
+/* ---- Ficha 2D (fallback digno, sin GPU) ---- */
+.kviva__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  background: radial-gradient(120% 90% at 50% 25%, #dfe0b8 0%, #adad84 100%);
+}
+.kviva__estampa {
+  position: relative;
+  width: 190px;
+  height: 180px;
+  margin-bottom: 0.4rem;
+}
+/* el guamo del sombrío, detrás y bien alto */
+.kviva__guamo {
+  position: absolute;
+  top: 0;
+  left: 8px;
+  width: 145px;
+  height: 60px;
+  border-radius: 56% 44% 60% 40% / 70% 74% 26% 30%;
+  background: radial-gradient(circle at 42% 30%, #68984a77 0%, #4a7c38 65%, #3c662c 100%);
+  box-shadow: inset -8px -6px 14px rgba(0, 0, 0, 0.16);
+}
+.kviva__guamo-tronco {
+  position: absolute;
+  top: 46px;
+  left: 72px;
+  width: 13px;
+  height: 90px;
+  border-radius: 40%;
+  background: linear-gradient(90deg, #4f3c28 0%, #6b533a 55%, #4a3a26 100%);
+}
+/* la copa del cacao, ancha y baja */
+.kviva__copa {
+  position: absolute;
+  top: 62px;
+  left: 42px;
+  width: 108px;
+  height: 52px;
+  border-radius: 48% 52% 44% 56% / 62% 58% 42% 38%;
+  background: radial-gradient(circle at 38% 32%, #4f8340 0%, #33642f 70%, #27522a 100%);
+  box-shadow: inset -7px -6px 12px rgba(0, 0, 0, 0.2);
+}
+/* el TRONCO del cacao — de él cuelgan las mazorcas (caulifloria) */
+.kviva__tronco {
+  position: absolute;
+  top: 100px;
+  left: 88px;
+  width: 16px;
+  height: 80px;
+  border-radius: 38%;
+  background: linear-gradient(90deg, #40301e 0%, #54402c 55%, #3c2e1c 100%);
+}
+.kviva__mazorca {
+  position: absolute;
+  width: 15px;
+  height: 24px;
+  border-radius: 50% 50% 46% 46% / 42% 42% 58% 58%;
+  box-shadow: inset -2px -3px 4px rgba(0, 0, 0, 0.28);
+}
+.kviva__mazorca--verde { top: 8px; left: -13px; background: #6da03f; transform: rotate(-10deg); }
+.kviva__mazorca--amarilla { top: 30px; left: 13px; background: #dcae3a; transform: rotate(9deg); }
+.kviva__mazorca--roja { top: 44px; left: -11px; background: #9c4523; transform: rotate(-6deg); }
+.kviva__ficha-nombre {
+  margin: 0;
+  font-weight: 800;
+  font-size: 1rem;
+  color: #3c3a22;
+}
+.kviva__ficha-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #5a5238;
+}
+
+/* ---- Saberes ---- */
+.kviva__saberes {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.kviva__saberes h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #3c3a22;
+}
+.kviva__saberes ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .kviva__saberes ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.kviva__saberes li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(138, 74, 32, 0.16);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.kviva__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.kviva__saberes b {
+  display: block;
+  font-size: 0.92rem;
+  color: #3c3a22;
+}
+.kviva__saberes li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.kviva__cierre {
+  margin: 0.9rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #4a4430;
+  max-width: 42rem;
+}

--- a/src/mockups/CacaoVivo3D.jsx
+++ b/src/mockups/CacaoVivo3D.jsx
@@ -1,0 +1,163 @@
+/*
+ * CacaoVivo3D — vitrina pública del MUNDO DEL CACAO: el cacaotal bajo sombra
+ * del piso cálido (0–1.200 m). Ruta #/mockups/cacao-vivo-3d, sin auth.
+ *
+ * El cacao es el cultivo de paz de la tierra caliente, y aquí se muestra como
+ * es de verdad en la vega: una siembra navegable a distancia pareja, las matas
+ * de cacao con sus MAZORCAS pegadas del tronco (caulifloria) pintando del
+ * verde al rojo cobrizo, y ARRIBA el SOMBRÍO — guamos que le hacen techo al
+ * cultivo — con el plátano intercalado y la casa con su cajón de fermentar y
+ * su pasera asomando en la calina del fondo. Cuatro pasos cortos recorren la
+ * lección: qué es la mazorca, por qué el cacao va bajo sombra, el grano con su
+ * baba (la fermentación) y el rumbo al secado.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el mundo 3D (chunk
+ * perezoso `vendor-three`); en equipo humilde, ahorro de datos o sin-WebGL se
+ * ve la ficha del cacaotal, digna y sin sudar la GPU. Copy en español de
+ * Colombia, en "usted". Autocontenida: cero CDN/imágenes externas.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import './CacaoVivo3D.css';
+
+const MundoCacao = lazy(() => import('../visual/mundo3d/cacao/MundoCacao.jsx'));
+
+/* Lo que enseña el cacaotal (verificado, en "usted"). */
+const SABERES = [
+  {
+    emoji: '🌳',
+    titulo: 'La mazorca nace del tronco',
+    texto:
+      'El cacao da su fruto donde nadie lo espera: pegado del tronco y de las ramas gruesas. A eso se le dice caulifloria, y es la firma del árbol. La mazorca pinta del verde al amarillo y al rojo cobrizo cuando está de coger.',
+  },
+  {
+    emoji: '🌴',
+    titulo: 'Mata de monte: quiere sombra',
+    texto:
+      'El cacao nació bajo los árboles grandes de la selva y así quiere vivir. El guamo y el plátano le bajan el sol quemante, le guardan la humedad, y su hoja caída se vuelve el abono que lo alimenta sin costar un peso.',
+  },
+  {
+    emoji: '🍯',
+    titulo: 'La baba no se bota: fermenta',
+    texto:
+      'Dentro de la mazorca vienen los granos envueltos en una baba blanca y dulce. En el cajón de madera, tapada con hoja de plátano, esa baba fermenta los granos unos días — ahí, y no en la fábrica, nace el sabor a chocolate.',
+  },
+  {
+    emoji: '☀️',
+    titulo: 'Del cajón a la pasera',
+    texto:
+      'Fermentado el grano, se extiende en la pasera y se voltea a mano hasta quedar seco y sonando a cascajo. Ese grano seco es el que la familia vende. El cacao bien fermentado y bien secado se paga mejor: la paciencia es plata.',
+  },
+];
+
+export default function CacaoVivo3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  return (
+    <main className="kviva">
+      <header className="kviva__head">
+        <p className="kviva__kicker">El mundo del cacao · vitrina</p>
+        <h1>El cacaotal bajo sombra</h1>
+        <p className="kviva__lema">
+          La vega de tierra caliente como es de verdad: las matas de cacao con
+          la mazorca pegada del tronco, el sombrío tendiéndoles techo y la casa
+          con su cajón y su pasera al fondo. Recórrala con el dedo y siga los
+          cuatro pasos de la lección.
+        </p>
+      </header>
+
+      <section className="kviva__escena" aria-label="El cacaotal bajo sombra en 3D">
+        <div className="kviva__lienzo">
+          {mostrar3D ? (
+            <Suspense
+              fallback={
+                <div className="kviva__cargando" role="status">
+                  Bajando a la vega…
+                </div>
+              }
+            >
+              <MundoCacao tier={tier} reducedMotion={reducedMotion} />
+            </Suspense>
+          ) : (
+            <FichaCacaotal />
+          )}
+        </div>
+
+        <div className="kviva__barra">
+          <p className="kviva__tier">
+            {mostrar3D
+              ? 'Está viendo el cacaotal en 3D. Gírelo con el dedo o el mouse y siga los pasos.'
+              : puede3D
+                ? 'Está viendo la ficha del cacaotal.'
+                : 'Su equipo ve la ficha del cacaotal (va parejo en cualquier teléfono).'}
+          </p>
+          {puede3D && (
+            <button type="button" className="kviva__toggle" onClick={() => setVer2d((v) => !v)}>
+              {ver2d ? 'Ver el cacaotal en 3D' : 'Ver la ficha'}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <section className="kviva__saberes" aria-label="Lo que enseña el cacaotal">
+        <h2>Lo que le enseña este cacaotal</h2>
+        <ol>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span className="kviva__emoji" aria-hidden="true">
+                {s.emoji}
+              </span>
+              <div>
+                <b>{s.titulo}</b>
+                <p>{s.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="kviva__cierre">
+          El cacao es cultivo de paz: donde se siembra cacao con sombrío vuelve
+          el monte, vuelve el agua y vuelve la familia a la tierra. Un cacaotal
+          bien llevado es medio bosque que da chocolate — y eso no cuesta
+          cemento.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+/* La ficha del cacaotal: el fallback digno para equipo humilde / sin-WebGL.
+   Una mata de cacao CSS con sus mazorcas PEGADAS del tronco y el guamo del
+   sombrío detrás — cero GPU. */
+function FichaCacaotal() {
+  return (
+    <div
+      className="kviva__ficha"
+      role="img"
+      aria-label="El cacaotal bajo sombra: mata de cacao con mazorcas pegadas del tronco y su árbol de sombrío"
+    >
+      <div className="kviva__estampa" aria-hidden="true">
+        <span className="kviva__guamo" />
+        <span className="kviva__guamo-tronco" />
+        <span className="kviva__copa" />
+        <span className="kviva__tronco">
+          <span className="kviva__mazorca kviva__mazorca--verde" />
+          <span className="kviva__mazorca kviva__mazorca--amarilla" />
+          <span className="kviva__mazorca kviva__mazorca--roja" />
+        </span>
+      </div>
+      <p className="kviva__ficha-nombre">El cacaotal bajo sombra</p>
+      <p className="kviva__ficha-sub">Piso cálido · el cultivo de paz de la tierra caliente</p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
+++ b/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
@@ -1,0 +1,367 @@
+/*
+ * EscenaCacaoVivo — el MUNDO donde vive el cacao (piso cálido, 0–1.200 m).
+ *
+ * Una VEGA de tierra caliente a media mañana: luz dorada y pesada, el aire
+ * húmedo que empaña el fondo, y el cultivo contado como es — las matas de
+ * cacao sembradas a distancia pareja con sus MAZORCAS pegadas del tronco
+ * (caulifloria), el SOMBRÍO de guamos tendiéndoles techo, el plátano
+ * intercalado, y en la lomita del fondo la casa campesina con su cajón de
+ * fermentar y la pasera donde el grano se seca al sol. La cámara mira la vega
+ * desde el camino, como quien llega; se puede girar con el dedo.
+ *
+ * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`: 'alto' con
+ * sombras + bruma + luz colada; 'medio' frugal; 'bajo' mínimo. Con
+ * `reducedMotion` el mundo monta QUIETO (frameloop a demanda). La fauna son los
+ * SVG rubber-hose de la casa como billboards (`Fauna` de FaunaEscena):
+ * mariposas revoloteando y el escarabajo reptando en la hojarasca — la vida que
+ * el cacao bajo sombra sí recibe.
+ *
+ * `foco` (opcional): un punto [x,y,z] que el paso didáctico del host señala con
+ * un anillo que respira. Importa three/@react-three → montar SOLO perezosa.
+ */
+import { useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { perfilDeTier } from '../deviceTier.js';
+import { Fauna } from '../escenas/FaunaEscena.jsx';
+import FloraCacao from './FloraCacao.jsx';
+import { ANCHO, FONDO, alturaVega, SITIO_CASA } from './floraCacao.geom.js';
+
+/* La atmósfera del piso cálido: cielo lechoso de calor y bruma húmeda dorada. */
+const CALIDO = {
+  fondo: '#dce4bd',
+  bruma: '#e0e4ba',
+  sol: '#ffeaa4',
+  cielo: '#f4eecc',
+  suelo: '#5a4630',
+};
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
+    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
+    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
+  );
+}
+
+/* La malla de la vega con colores por vértice: el mantillo pardo de hojarasca
+   que domina bajo el cacao, pasto en los claros, tierra oscura húmeda a
+   manchas y el caminito por donde se llega. */
+function construirVega(seg, plano) {
+  const nx = seg + 1;
+  const nz = seg + 1;
+  const pos = new Float32Array(nx * nz * 3);
+  const col = new Float32Array(nx * nz * 3);
+  const cMantillo = new THREE.Color('#7d6038');
+  const cMantillo2 = new THREE.Color('#6b5230');
+  const cPasto = new THREE.Color('#7fa04e');
+  const cTierra = new THREE.Color('#54402e');
+  const cCamino = new THREE.Color('#b08a58');
+  const c = new THREE.Color();
+  let p = 0;
+  for (let iz = 0; iz < nz; iz++) {
+    const wz = -FONDO / 2 + (FONDO * iz) / seg;
+    for (let ix = 0; ix < nx; ix++) {
+      const wx = -ANCHO / 2 + (ANCHO * ix) / seg;
+      pos[p] = wx;
+      pos[p + 1] = alturaVega(wx, wz);
+      pos[p + 2] = wz;
+      const adentro = smoothstep(8, 0, Math.abs(wx)) * smoothstep(6, -2, wz) * 0.5 + 0.5;
+      // el mantillo de hojarasca manda bajo el cultivo
+      c.lerpColors(cMantillo, cMantillo2, 0.5 + 0.5 * ruido(wx * 0.9, wz * 0.7));
+      // el pasto asoma en los claros y hacia el frente
+      c.lerp(cPasto, smoothstep(0.15, 0.9, ruido(wx * 1.1 + 3, wz * 0.9)) * 0.5 * (1.3 - adentro));
+      // la tierra oscura y húmeda a manchas
+      c.lerp(cTierra, smoothstep(0.1, 0.9, ruido(wx * 1.5 + 7, wz * 1.3 + 2)) * 0.3);
+      // el caminito por donde se llega a la casa
+      c.lerp(cCamino, smoothstep(1.3, 0, Math.abs(wx - 3 - Math.sin(wz * 0.32) * 2.4)) * smoothstep(8, -12, -wz) * 0.9);
+      col[p] = c.r;
+      col[p + 1] = c.g;
+      col[p + 2] = c.b;
+      p += 3;
+    }
+  }
+  const idx = [];
+  for (let iz = 0; iz < seg; iz++) {
+    for (let ix = 0; ix < seg; ix++) {
+      const a = iz * nx + ix;
+      const b = a + 1;
+      const d = a + nx;
+      const e = d + 1;
+      idx.push(a, d, b, b, d, e);
+    }
+  }
+  let geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  geo.setIndex(idx);
+  if (plano) geo = geo.toNonIndexed();
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/* La casa campesina de tierra caliente con su BENEFICIO de cacao: el CAJÓN de
+   madera donde el grano fermenta en su baba, y la PASERA — la cama elevada
+   donde el grano se seca al sol con su techito corredizo. */
+function CasaSecadero({ pos }) {
+  return (
+    <group position={pos} rotation={[0, -0.4, 0]}>
+      {/* la casa: paredes encaladas y zócalo ocre, techo de teja */}
+      <mesh position={[0, 0.72, 0]}>
+        <boxGeometry args={[2.6, 1.44, 1.9]} />
+        <meshLambertMaterial color="#f0e9d6" flatShading />
+      </mesh>
+      <mesh position={[0, 0.18, 0]}>
+        <boxGeometry args={[2.64, 0.36, 1.94]} />
+        <meshLambertMaterial color="#a06a2e" flatShading />
+      </mesh>
+      {/* la puerta y una ventana (maderas verdes, como se pintan allá) */}
+      <mesh position={[0.5, 0.62, 0.96]}>
+        <boxGeometry args={[0.44, 0.95, 0.06]} />
+        <meshLambertMaterial color="#4a6b3f" flatShading />
+      </mesh>
+      <mesh position={[-0.6, 0.86, 0.96]}>
+        <boxGeometry args={[0.5, 0.44, 0.06]} />
+        <meshLambertMaterial color="#4a6b3f" flatShading />
+      </mesh>
+      {/* techo a dos aguas de teja */}
+      <mesh position={[0, 1.62, -0.62]} rotation={[-0.62, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.5]} />
+        <meshLambertMaterial color="#9c4a30" flatShading />
+      </mesh>
+      <mesh position={[0, 1.62, 0.62]} rotation={[0.62, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.5]} />
+        <meshLambertMaterial color="#a85236" flatShading />
+      </mesh>
+
+      {/* el CAJÓN DE FERMENTAR, al pie de la casa: madera gruesa, tapa de
+          hoja de plátano y el grano en su baba asomando */}
+      <group position={[-2.2, 0, 0.7]}>
+        <mesh position={[0, 0.32, 0]}>
+          <boxGeometry args={[0.95, 0.64, 0.7]} />
+          <meshLambertMaterial color="#7a5a38" flatShading />
+        </mesh>
+        <mesh position={[0, 0.66, 0]}>
+          <boxGeometry args={[0.82, 0.06, 0.58]} />
+          <meshLambertMaterial color="#8f6a3c" flatShading />
+        </mesh>
+        {/* la hoja de plátano que tapa la fermentación */}
+        <mesh position={[0.1, 0.71, 0.05]} rotation={[0, 0.4, 0.06]}>
+          <boxGeometry args={[0.7, 0.03, 0.4]} />
+          <meshLambertMaterial color="#579440" flatShading />
+        </mesh>
+      </group>
+
+      {/* la PASERA de secado: patas + cama con el grano marrón extendido +
+          techito translúcido corredizo (la señal del secado) */}
+      <group position={[2.6, 0, 0.4]}>
+        {[[-1.0, -0.55], [1.0, -0.55], [-1.0, 0.55], [1.0, 0.55]].map((q, i) => (
+          <mesh key={i} position={[q[0], 0.35, q[1]]}>
+            <boxGeometry args={[0.09, 0.7, 0.09]} />
+            <meshLambertMaterial color="#6b533a" flatShading />
+          </mesh>
+        ))}
+        <mesh position={[0, 0.72, 0]}>
+          <boxGeometry args={[2.2, 0.07, 1.3]} />
+          <meshLambertMaterial color="#b99a68" flatShading />
+        </mesh>
+        {/* el grano de cacao extendido secándose al sol */}
+        <mesh position={[0, 0.77, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[2.0, 1.1]} />
+          <meshLambertMaterial color="#6f4626" flatShading />
+        </mesh>
+        {[[-1.05, -0.62], [1.05, -0.62], [-1.05, 0.62], [1.05, 0.62]].map((q, i) => (
+          <mesh key={`p${i}`} position={[q[0], 1.15, q[1]]}>
+            <boxGeometry args={[0.06, 0.85, 0.06]} />
+            <meshLambertMaterial color="#6b533a" flatShading />
+          </mesh>
+        ))}
+        <mesh position={[0, 1.62, -0.36]} rotation={[-0.5, 0, 0]}>
+          <planeGeometry args={[2.4, 0.95]} />
+          <meshBasicMaterial color="#fbf3da" transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+        </mesh>
+        <mesh position={[0, 1.62, 0.36]} rotation={[0.5, 0, 0]}>
+          <planeGeometry args={[2.4, 0.95]} />
+          <meshBasicMaterial color="#fbf3da" transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+        </mesh>
+      </group>
+
+      {/* el canasto de cosecha en el patio, con dos mazorcas recién bajadas */}
+      <group position={[-1.5, 0, 1.3]}>
+        <mesh position={[0, 0.18, 0]}>
+          <cylinderGeometry args={[0.24, 0.17, 0.36, 9, 1, true]} />
+          <meshLambertMaterial color="#a9713c" flatShading side={THREE.DoubleSide} />
+        </mesh>
+        <mesh position={[-0.05, 0.4, 0.02]} scale={[0.72, 1.4, 0.72]}>
+          <sphereGeometry args={[0.13, 7, 6]} />
+          <meshLambertMaterial color="#dcae3a" flatShading />
+        </mesh>
+        <mesh position={[0.12, 0.38, -0.06]} rotation={[0, 0, 0.5]} scale={[0.72, 1.4, 0.72]}>
+          <sphereGeometry args={[0.13, 7, 6]} />
+          <meshLambertMaterial color="#9c4523" flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* El anillo del paso didáctico: respira sobre el punto que la lección señala.
+   Con reducedMotion queda quieto (presencia sin parpadeo). */
+function FocoPaso({ foco, reducedMotion }) {
+  const anillo = useRef(null);
+  useFrame(({ clock }) => {
+    const m = anillo.current;
+    if (!m) return;
+    if (reducedMotion) {
+      m.material.opacity = 0.42;
+      return;
+    }
+    const t = clock.elapsedTime;
+    m.material.opacity = 0.3 + 0.2 * Math.sin(t * 1.8);
+    m.scale.setScalar(1 + 0.06 * Math.sin(t * 1.8));
+  });
+  if (!foco) return null;
+  return (
+    <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+      <ringGeometry args={[1.25, 1.65, 32]} />
+      <meshBasicMaterial
+        color="#ffd98e"
+        transparent
+        opacity={0.4}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+/* La fauna del cacaotal: los SVG rubber-hose de la casa como billboards
+   (contrato del operador: el bicho pone el cuerpo, la escena la coreografía).
+   Mariposas en el aire caliente y el escarabajo reptando en la hojarasca —
+   el descomponedor que la hoja del cacao alimenta. */
+const FAUNA_CACAOTAL = [
+  { tipo: 'mariposa', base: [-3.5, 3.4, 2.4], patron: 'revoloteo', size: 27, fase: 0.6, df: 9 },
+  { tipo: 'mariposa', base: [6.2, 2.0, 3.6], patron: 'revoloteo', size: 23, fase: 2.4, df: 9 },
+  { tipo: 'escarabajo', base: [-1.2, 0.5, 6.2], patron: 'reptar', size: 22, fase: 1.2, df: 8 },
+];
+
+function Diorama({ tier, reducedMotion, foco }) {
+  const perfil = perfilDeTier(tier);
+
+  const geoVega = useMemo(
+    () => construirVega(perfil.segmentosTerreno, perfil.flatShading),
+    [perfil.segmentosTerreno, perfil.flatShading],
+  );
+
+  const fauna = useMemo(
+    () => (tier === 'alto' ? FAUNA_CACAOTAL : FAUNA_CACAOTAL.slice(0, 2)),
+    [tier],
+  );
+
+  const casaY = alturaVega(SITIO_CASA[0], SITIO_CASA[1]);
+
+  return (
+    <>
+      <color attach="background" args={[CALIDO.fondo]} />
+      {perfil.fog && <fog attach="fog" args={[CALIDO.bruma, 14, 44]} />}
+
+      {/* la luz de tierra caliente: cielo lechoso, sol dorado pesado, calina */}
+      <hemisphereLight intensity={0.95} color={CALIDO.cielo} groundColor={CALIDO.suelo} />
+      <ambientLight intensity={0.34} color="#f6ecc8" />
+      <directionalLight
+        position={[7, 13, 4]}
+        intensity={1.3}
+        color={CALIDO.sol}
+        castShadow={perfil.sombras}
+        shadow-mapSize-width={1024}
+        shadow-mapSize-height={1024}
+        shadow-camera-near={1}
+        shadow-camera-far={40}
+        shadow-camera-left={-16}
+        shadow-camera-right={16}
+        shadow-camera-top={16}
+        shadow-camera-bottom={-6}
+      />
+      {/* contraluz verdoso que separa el sombrío de la calina */}
+      <directionalLight position={[-6, 5, -7]} intensity={0.32} color="#d8e0b8" />
+
+      {/* LA VEGA (recibe la sombra del sombrío en gama alta) */}
+      <mesh geometry={geoVega} receiveShadow={perfil.sombras}>
+        <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
+      </mesh>
+
+      {/* las lomas calientes del fondo, comidas por la calina */}
+      <mesh position={[-14, 1.4, -20]} scale={[10, 3.2, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color="#6d8a4c" />
+      </mesh>
+      <mesh position={[8, 1.8, -23]} scale={[12, 4.0, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color="#647f48" />
+      </mesh>
+      <mesh position={[21, 1.2, -19]} scale={[8, 2.6, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color="#75904f" />
+      </mesh>
+
+      {/* EL CACAOTAL: matas, mazorcas, sombrío, plátano, luz colada */}
+      <FloraCacao tier={tier} reducedMotion={reducedMotion} />
+
+      {/* la casa con su cajón de fermentar y la pasera, en la lomita */}
+      <CasaSecadero pos={[SITIO_CASA[0], casaY, SITIO_CASA[1]]} />
+
+      {/* LA VIDA que la sombra trae: mariposas y el escarabajo del mantillo */}
+      {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
+
+      {/* el anillo del paso didáctico (lo maneja el host) */}
+      <FocoPaso foco={foco} reducedMotion={reducedMotion} />
+
+      <OrbitControls
+        makeDefault
+        target={[0, 1.2, -4]}
+        enablePan={false}
+        enableZoom
+        minDistance={8}
+        maxDistance={26}
+        minPolarAngle={0.5}
+        maxPolarAngle={1.45}
+        minAzimuthAngle={-1.1}
+        maxAzimuthAngle={1.1}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.12}
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * El mundo del cacaotal bajo sombra. Montar SOLO perezosa (lazy).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, foco?: number[]|null}} props
+ */
+export default function EscenaCacaoVivo({ tier = 'alto', reducedMotion = false, foco = null }) {
+  const perfil = perfilDeTier(tier);
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`cacao-canvas${listo ? ' cacao-canvas--lista' : ''}`}
+      dpr={perfil.dpr}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      shadows={perfil.sombras ? 'soft' : false}
+      camera={{ position: [2.5, 7.4, 16.5], fov: 46 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Diorama tier={tier} reducedMotion={reducedMotion} foco={foco} />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/cacao/FloraCacao.jsx
+++ b/src/visual/mundo3d/cacao/FloraCacao.jsx
@@ -1,0 +1,200 @@
+/*
+ * FloraCacao — el CACAOTAL BAJO SOMBRA sembrado en la vega caliente.
+ *
+ * Consume `floraCacao.geom.js`: cada especie es UN InstancedMesh de una
+ * geometría fusionada (una draw-call por especie, por más matas que haya) —
+ * mismo contrato tier-safe que `FloraCafetal` del mundo del café. La MAZORCA
+ * lleva color POR INSTANCIA (verde → amarillo → rojo-marrón): un solo
+ * InstancedMesh cuenta todos los estados de maduración del fruto, colgado del
+ * tronco de su mata (caulifloria).
+ *
+ * En 'alto' se suma la LUZ COLADA: dapples dorados que respiran en el suelo
+ * bajo las copas del sombrío — el sol de tierra caliente filtrándose entre las
+ * hojas del guamo. `reducedMotion` los deja quietos.
+ *
+ * Componente r3f: montar dentro del <Canvas> de EscenaCacaoVivo.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import {
+  cacaotalDeTier,
+  calidadCacao,
+  distribucionCacaotal,
+  centrosSombrio,
+  alturaVega,
+  geomCacao,
+  geomMazorca,
+  geomGuamo,
+  geomPlatano,
+  geomTroncoCaido,
+  geomHojarasca,
+  geomPiedra,
+} from './floraCacao.geom.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* Un banco de matas de UNA especie: una geometría, un material, N instancias.
+   (Mismo patrón que `Especie` de FloraCafetal — el molde de la casa.) */
+function Especie({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+    />
+  );
+}
+
+/*
+ * La LUZ COLADA bajo el sombrío: discos dorados aditivos sobre el suelo, que
+ * respiran apenas (el sol de tierra caliente entre las hojas del guamo). Solo
+ * 'alto'; con reducedMotion quedan quietos (presencia sin parpadeo).
+ */
+function LuzColada({ centros, reducedMotion }) {
+  const grupo = useRef(null);
+  const manchas = useMemo(() => {
+    const r = rng(131);
+    const lista = [];
+    centros.forEach((c) => {
+      const n = 3 + Math.floor(r() * 3);
+      for (let i = 0; i < n; i++) {
+        const x = c[0] + (r() - 0.5) * 4.0;
+        const z = c[2] + (r() - 0.5) * 4.0;
+        lista.push({
+          pos: /** @type {[number, number, number]} */ ([x, alturaVega(x, z) + 0.05, z]),
+          r: 0.5 + r() * 0.7,
+          fase: r() * Math.PI * 2,
+          op: 0.1 + r() * 0.07,
+        });
+      }
+    });
+    return lista;
+  }, [centros]);
+
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (reducedMotion || !g) return;
+    const t = clock.elapsedTime;
+    for (let i = 0; i < g.children.length; i++) {
+      const m = g.children[i];
+      const d = manchas[i];
+      m.material.opacity = d.op * (0.55 + 0.45 * Math.sin(t * 0.7 + d.fase));
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {manchas.map((d, i) => (
+        <mesh key={i} position={d.pos} rotation={[-Math.PI / 2, 0, 0]}>
+          <circleGeometry args={[d.r, 14]} />
+          <meshBasicMaterial
+            color="#ffe6a6"
+            transparent
+            opacity={d.op}
+            depthWrite={false}
+            blending={THREE.AdditiveBlending}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/**
+ * La capa viva del cacaotal. Montar dentro del <Canvas>.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function FloraCacao({ tier = 'alto', reducedMotion = false }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = cacaotalDeTier(tier);
+  const q = calidadCacao(tier);
+
+  // Geometrías fusionadas (una vez por tier).
+  const geos = useMemo(
+    () => ({
+      cacao: geomCacao({ q }, 31),
+      mazorca: geomMazorca(),
+      guamo: conteos.guamo ? geomGuamo({ q }, 32) : null,
+      platano: conteos.platano ? geomPlatano({ q }, 33) : null,
+      tronco: conteos.tronco ? geomTroncoCaido(34) : null,
+      hojarasca: conteos.hojarasca ? geomHojarasca(35) : null,
+      piedra: conteos.piedra ? geomPiedra(36) : null,
+    }),
+    [conteos, q],
+  );
+
+  // Material único con vertexColors (el color viene horneado por especie y el
+  // tinte por instancia lo multiplica — en la mazorca el tinte ES el color).
+  const mat = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.85, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  // Distribución determinista (una vez por tier).
+  const dist = useMemo(() => distribucionCacaotal(conteos, 417), [conteos]);
+  const centros = useMemo(() => centrosSombrio(conteos), [conteos]);
+
+  // Liberar GPU al desmontar.
+  useLayoutEffect(
+    () => () => {
+      Object.values(geos).forEach((g) => g && g.dispose());
+      mat.dispose();
+    },
+    [geos, mat],
+  );
+
+  const sombra = perfil.sombras; // solo el sombrío proyecta sombra en 'alto'
+
+  return (
+    <group>
+      {/* El suelo del cacaotal: hojarasca gruesa, tronco caído, piedras. */}
+      <Especie geo={geos.hojarasca} mat={mat} items={dist.hojarasca} />
+      <Especie geo={geos.tronco} mat={mat} items={dist.tronco} />
+      <Especie geo={geos.piedra} mat={mat} items={dist.piedra} />
+
+      {/* EL CULTIVO: las matas de cacao y sus mazorcas pegadas del tronco. */}
+      <Especie geo={geos.cacao} mat={mat} items={dist.cacao} />
+      <Especie geo={geos.mazorca} mat={mat} items={dist.mazorca} />
+
+      {/* EL SOMBRÍO: guamos que le hacen techo al cacao. */}
+      <Especie geo={geos.guamo} mat={mat} items={dist.guamo} castShadow={sombra} />
+
+      {/* El plátano intercalado del cacaotal campesino. */}
+      <Especie geo={geos.platano} mat={mat} items={dist.platano} castShadow={sombra} />
+
+      {/* La luz que se cuela entre las hojas del sombrío (solo gama alta). */}
+      {tier === 'alto' && <LuzColada centros={centros} reducedMotion={reducedMotion} />}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/cacao/MundoCacao.jsx
+++ b/src/visual/mundo3d/cacao/MundoCacao.jsx
@@ -1,0 +1,144 @@
+/*
+ * MundoCacao — el MUNDO DEL CACAO completo: la vega navegable + la lección.
+ *
+ * Mismo contrato de host que MundoCafetal: acepta `{tier, reducedMotion}` (o
+ * auto-detecta con decidirTier si se monta suelto), llena a su padre y guarda
+ * su estado local. Sobre la escena viven los PASOS: cuatro lecciones cortas
+ * que recorren lo que este mundo enseña — qué es la mazorca y de dónde nace,
+ * por qué el cacao va bajo sombra, el grano con su baba y la fermentación, y
+ * el rumbo al secado — y cada paso señala SU lugar en la vega con un anillo
+ * que respira (el `foco` que la escena dibuja). Copy en español de Colombia,
+ * en "usted".
+ *
+ * Importa three/@react-three (vía la escena) → montar SOLO perezoso (lazy).
+ */
+import { useMemo, useState } from 'react';
+import EscenaCacaoVivo from './EscenaCacaoVivo.jsx';
+import { decidirTier, permite3D } from '../deviceTier.js';
+import { alturaVega } from './floraCacao.geom.js';
+
+/* Los cuatro pasos de la lección. Cada `foco` es el punto de la vega que el
+   anillo señala mientras se lee (coordenadas del mundo, y sobre el terreno). */
+const enSuelo = (x, z) => [x, alturaVega(x, z), z];
+const PASOS = [
+  {
+    id: 'mazorca',
+    kicker: 'Paso 1 de 4 · La mazorca',
+    texto:
+      'El fruto del cacao es la MAZORCA, y nace donde nadie la espera: pegada del tronco y de las ramas gruesas, no en la punta de las ramitas. Pinta del verde al amarillo y al rojo cobrizo cuando está de coger.',
+    foco: enSuelo(-2.0, 1.6),
+  },
+  {
+    id: 'sombra',
+    kicker: 'Paso 2 de 4 · ¿Por qué bajo sombra?',
+    texto:
+      'El cacao es mata de monte: nació bajo los árboles grandes y así quiere vivir. El guamo y el plátano le bajan el sol quemante, le guardan la humedad, y su hoja caída se vuelve el abono que lo alimenta.',
+    foco: enSuelo(3.5, -8.0),
+  },
+  {
+    id: 'grano',
+    kicker: 'Paso 3 de 4 · El grano y la baba',
+    texto:
+      'Dentro de la mazorca vienen los granos envueltos en una baba blanca y dulce. Esa baba no se lava: en el cajón de madera, tapada con hoja de plátano, FERMENTA los granos unos días — ahí nace el sabor a chocolate.',
+    foco: enSuelo(9.5, -12.2),
+  },
+  {
+    id: 'secado',
+    kicker: 'Paso 4 de 4 · Rumbo al secado',
+    texto:
+      'Fermentado el grano, sube a la pasera: la cama donde se extiende al sol y se voltea a mano hasta quedar seco y sonando a cascajo. Ese grano seco es el que la familia vende — y del que sale el chocolate que usted se toma.',
+    foco: enSuelo(13.5, -12.6),
+  },
+];
+
+const CSS = `
+.mcacao { position: relative; width: 100%; height: 100%; overflow: hidden; background: #dce4bd; }
+.mcacao canvas { opacity: 0; transition: opacity 0.9s ease; }
+.mcacao .cacao-canvas--lista canvas, .mcacao canvas.cacao-canvas--lista { opacity: 1; }
+.mcacao__panel {
+  position: absolute; left: 50%; bottom: max(0.9rem, env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  width: min(26rem, calc(100% - 1.6rem));
+  padding: 0.8rem 0.95rem 0.85rem;
+  border-radius: 1rem;
+  background: rgba(30, 20, 10, 0.68);
+  box-shadow: inset 0 0 0 1px rgba(216, 174, 116, 0.3), 0 6px 24px rgba(16, 12, 6, 0.35);
+  backdrop-filter: blur(6px);
+  color: #f4ecda;
+}
+.mcacao__kicker { margin: 0 0 0.15rem; font: 600 0.68rem/1.2 system-ui, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: #dcb478; }
+.mcacao__texto { margin: 0 0 0.6rem; font: 500 0.85rem/1.38 system-ui, sans-serif; color: #f0e6cd; }
+.mcacao__nav { display: flex; align-items: center; gap: 0.55rem; }
+.mcacao__btn {
+  min-height: 2.5rem; min-width: 2.9rem; padding: 0 0.8rem;
+  border: 0; border-radius: 0.7rem; cursor: pointer;
+  background: linear-gradient(180deg, rgba(224, 168, 74, 0.95), rgba(176, 118, 40, 0.95));
+  color: #241503; font: 700 0.9rem/1 system-ui, sans-serif;
+  transition: transform 0.15s ease;
+}
+.mcacao__btn:active { transform: scale(0.96); }
+.mcacao__btn[disabled] { opacity: 0.35; cursor: default; }
+.mcacao__puntos { display: flex; gap: 0.35rem; margin: 0 auto; }
+.mcacao__punto { width: 0.5rem; height: 0.5rem; border-radius: 999px; background: rgba(233, 218, 186, 0.32); }
+.mcacao__punto--activo { background: #e0a84a; box-shadow: 0 0 8px 1px rgba(224, 168, 74, 0.5); }
+@media (prefers-reduced-motion: reduce) {
+  .mcacao canvas { transition: none; }
+  .mcacao__btn { transition: none; }
+}
+`;
+
+/**
+ * El mundo del cacaotal bajo sombra, completo: escena + pasos didácticos.
+ * Montar SOLO perezoso (lazy); llena a su contenedor.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function MundoCacao({ tier: tierProp, reducedMotion: rmProp } = {}) {
+  // Contrato de mundos: props del host si llegan; si se monta suelto,
+  // auto-detección del equipo (no matar la gama baja).
+  const auto = useMemo(() => decidirTier(), []);
+  const tier = tierProp ?? (permite3D(auto.tier) ? auto.tier : 'bajo');
+  const reducedMotion = rmProp ?? auto.reducedMotion;
+  const [paso, setPaso] = useState(0);
+
+  const actual = PASOS[paso];
+
+  return (
+    <div className="mcacao">
+      <style>{CSS}</style>
+      <EscenaCacaoVivo tier={tier} reducedMotion={reducedMotion} foco={actual.foco} />
+
+      <div className="mcacao__panel" role="group" aria-label="La lección del cacaotal">
+        <p className="mcacao__kicker">{actual.kicker}</p>
+        <p className="mcacao__texto">{actual.texto}</p>
+        <div className="mcacao__nav">
+          <button
+            type="button"
+            className="mcacao__btn"
+            onClick={() => setPaso((p) => Math.max(0, p - 1))}
+            disabled={paso === 0}
+            aria-label="Paso anterior"
+          >
+            ←
+          </button>
+          <span className="mcacao__puntos" aria-hidden="true">
+            {PASOS.map((p, i) => (
+              <span
+                key={p.id}
+                className={`mcacao__punto${i === paso ? ' mcacao__punto--activo' : ''}`}
+              />
+            ))}
+          </span>
+          <button
+            type="button"
+            className="mcacao__btn"
+            onClick={() => setPaso((p) => Math.min(PASOS.length - 1, p + 1))}
+            disabled={paso === PASOS.length - 1}
+            aria-label="Paso siguiente"
+          >
+            →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/cacao/floraCacao.geom.js
+++ b/src/visual/mundo3d/cacao/floraCacao.geom.js
@@ -1,0 +1,532 @@
+/*
+ * floraCacao.geom — la GEOMETRÍA del CACAOTAL BAJO SOMBRA (piso cálido).
+ *
+ * El cacao es el cultivo de paz de la tierra caliente y aquí se cuenta como es
+ * de verdad en la vega: un plano caliente y húmedo sembrado a distancia pareja,
+ * con los árboles de cacao ABAJO y el SOMBRÍO arriba — guamos que le hacen
+ * techo de hojas y el plátano que acompaña casi todo cacaotal campesino. Cada
+ * especie con su identidad inequívoca:
+ *
+ *   · Cacao (Theobroma cacao)  — árbol bajito de HORQUETA: el tronco se abre en
+ *                                ramas gruesas a la altura del pecho, copa ancha
+ *                                de hoja grande y el brote nuevo COBRIZO.
+ *   · Mazorca de cacao         — el fruto, INSTANCIADO APARTE con color por
+ *                                instancia: verde → amarillo → rojo-marrón. Y
+ *                                nace del TRONCO y de las ramas gruesas
+ *                                (caulifloria — la firma del cacao).
+ *   · Guamo (Inga)             — el sombrío clásico: tronco que se bifurca y
+ *                                copa ANCHA y plana, un parasol alto.
+ *   · Plátano intercalado      — pseudotallo claro y hojas enormes arqueadas.
+ *   · Tronco caído + hojarasca — el mantillo grueso que el cacaotal deja en el
+ *                                suelo (la hoja del cacao no se barre: abona).
+ *
+ * TÉCNICA tier-safe (mismo contrato que floraCafetal.geom): cada especie se
+ * FUSIONA en UNA geometría con color horneado en vertexColors y se dibuja con
+ * UN InstancedMesh → una draw-call por especie. La MAZORCA se pinta BLANCA en
+ * la geometría para que el color POR INSTANCIA (setColorAt) sea el color real
+ * del fruto — así el mismo InstancedMesh lleva mazorcas verdes, amarillas y
+ * rojas-marrón.
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO si se mezclan geometrías
+ * indexadas con no-indexadas (ya mordió 3 veces): aquí TODO se desindexa antes
+ * de fusionar y se TRUENA si aun así falla.
+ *
+ * Aquí viven SOLO los datos y las mallas (nada de WebGL): corre headless.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* -------------------------------------------------------------------------- */
+/*  La vega cacaotera (la geografía del mundo, determinista)                   */
+/* -------------------------------------------------------------------------- */
+
+export const ANCHO = 40; // x: -20 … 20
+export const FONDO = 34; // z: -17 (el fondo, la lomita) … 17 (el frente)
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+
+/* Ruido determinista (hash de senos): misma vega siempre, sin Math.random. */
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
+    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
+    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
+  );
+}
+
+/**
+ * La altura de la vega en un punto: casi plana (el cacao es de tierra baja),
+ * con una lomita suave al fondo donde vive la casa y ondulación natural.
+ */
+export function alturaVega(wx, wz) {
+  const sub = smoothstep(2, -15, wz); // 0 al frente, 1 a la lomita del fondo
+  let h = 0.1;
+  h += sub * 1.7; // la vega apenas se levanta hacia atrás
+  h += ruido(wx * 0.45, wz * 0.45) * 0.28 * (0.5 + sub * 0.5); // ondulación
+  return h;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Presupuesto por tier                                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Instancias por especie. 'alto' puebla el cacaotal pleno; 'medio' es frugal;
+ * 'bajo' deja lo mínimo para que AÚN se lea "cacaotal con sombrío". La mazorca
+ * es el conteo del InstancedMesh de frutos (colgados del tronco y las ramas de
+ * las matas cargadas).
+ */
+export const FLORA_CACAO = {
+  alto: { cacao: 90, mazorca: 300, guamo: 6, platano: 8, tronco: 3, hojarasca: 18, piedra: 4 },
+  medio: { cacao: 55, mazorca: 170, guamo: 4, platano: 5, tronco: 2, hojarasca: 10, piedra: 3 },
+  bajo: { cacao: 24, mazorca: 70, guamo: 2, platano: 3, tronco: 1, hojarasca: 5, piedra: 2 },
+};
+
+/** Conteos para un tier (desconocido → frugal, nunca el más caro). */
+export const cacaotalDeTier = (tier) => FLORA_CACAO[tier] || FLORA_CACAO.medio;
+
+/** Factor de detalle geométrico por tier (menos blobs/hojas en gama baja). */
+export const CALIDAD_CACAO = { alto: 1, medio: 0.62, bajo: 0.42 };
+export const calidadCacao = (tier) => CALIDAD_CACAO[tier] ?? CALIDAD_CACAO.medio;
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del cacaotal (colores horneados en vertexColors)                    */
+/* -------------------------------------------------------------------------- */
+
+export const PAL = {
+  // Cacao
+  cacaoTronco: '#54402c', // corteza parda del tronco y la horqueta
+  cacaoHoja: '#33642f', // hoja grande verde oscura
+  cacaoHojaSol: '#4f8340', // la cara de la copa que da al sol
+  cacaoBrote: '#b06a3f', // el brote nuevo COBRIZO (la hoja tierna del cacao)
+
+  // Los tres estados de la mazorca (van POR INSTANCIA, no aquí; referencia):
+  mazorcaVerde: '#6da03f',
+  mazorcaAmarilla: '#dcae3a',
+  mazorcaRoja: '#9c4523', // rojo-marrón de mazorca madura
+
+  // Guamo (Inga) — el parasol del sombrío
+  guamoTronco: '#6b533a',
+  guamoCopa: '#4a7c38',
+  guamoCopaSol: '#68984a',
+
+  // Plátano intercalado
+  platanoTallo: '#a8b06c',
+  platanoHoja: '#579440',
+  platanoHojaSol: '#77ac4e',
+  platanoHojaSeca: '#a5924c',
+
+  // Suelo de tierra caliente
+  hojarasca: '#8a6a3e',
+  hojarasca2: '#6f5530',
+  troncoCaido: '#6f5138',
+  musgo: '#7a8a4a',
+  piedra: '#8b8578',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Utilidades (fusión desindexada + colocación + color horneado)              */
+/* -------------------------------------------------------------------------- */
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+/** Hornea un color plano en TODOS los vértices (atributo `color`). */
+function pintar(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Coloca una geometría (posición/rotación/escala) transformando vértices. */
+function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/** Orienta el +Y de la geometría hacia `dir` y la ubica en `pos` (ramas/hojas). */
+function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    q,
+    new THREE.Vector3(esc[0], esc[1], esc[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/**
+ * Fusiona partes (ya coloreadas) en UNA geometría. Se DESINDEXA todo antes de
+ * fusionar y se TRUENA si falla: mejor un error de build que una especie
+ * invisible en producción (mordida conocida de mergeGeometries).
+ */
+function fusionar(partes) {
+  const buenas = partes.filter(Boolean).map((p) => {
+    const plana = p.index ? p.toNonIndexed() : p;
+    if (plana !== p) p.dispose();
+    return plana;
+  });
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error('floraCacao: mergeGeometries devolvió null — atributos incompatibles entre partes');
+  }
+  return g;
+}
+
+/** Pequeña variación determinista de color (que el cacaotal no sea plano). */
+function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  CACAO (Theobroma cacao) — el cultivo                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * El porte del cacao es inconfundible: un tronco corto que a la altura del
+ * pecho se abre en HORQUETA — 3-4 ramas gruesas que suben abiertas — y encima
+ * una copa ancha y baja de hoja GRANDE, con el brote nuevo cobrizo asomando.
+ * Las MAZORCAS no van aquí: son un InstancedMesh aparte con color por
+ * instancia, colgadas del tronco y las ramas (caulifloria).
+ */
+export function geomCacao({ q = 1 } = {}, seed = 1) {
+  const r = rng(seed);
+  const partes = [];
+
+  // El tronco corto (con AIRE debajo de la copa: ahí cuelga la mazorca).
+  const tronco = new THREE.CylinderGeometry(0.06, 0.095, 1.5, 6, 1);
+  poner(tronco, [0, 0.75, 0]);
+  partes.push(pintar(tronco, PAL.cacaoTronco));
+
+  // La HORQUETA: las ramas gruesas que se abren a la altura del pecho.
+  const nRamas = q < 0.5 ? 3 : 4;
+  const dirRamas = [];
+  for (let i = 0; i < nRamas; i++) {
+    const a = (i / nRamas) * Math.PI * 2 + r() * 0.8;
+    const abierta = 0.75 + r() * 0.35; // qué tan abierta sube la rama
+    const dir = [Math.cos(a) * abierta, 1, Math.sin(a) * abierta];
+    dirRamas.push({ a, abierta });
+    const rama = new THREE.CylinderGeometry(0.028, 0.05, 1.05, 5, 1);
+    apuntar(rama, [Math.cos(a) * 0.32, 1.8, Math.sin(a) * 0.32], dir);
+    partes.push(pintar(rama, PAL.cacaoTronco));
+  }
+
+  // La copa ancha de hoja grande, una masa por rama + el centro — recogida
+  // (que entre ella y el suelo quede el aire donde se ve la caulifloria).
+  const nMasas = Math.max(3, Math.round((nRamas + 1) * Math.min(1, q + 0.25)));
+  for (let i = 0; i < nMasas; i++) {
+    const centro = i === 0;
+    const d = dirRamas[(i - 1 + dirRamas.length) % dirRamas.length];
+    const rad = centro ? 0 : 0.56 + r() * 0.22;
+    const masa = new THREE.IcosahedronGeometry(centro ? 0.56 : 0.44 + r() * 0.14, 1);
+    poner(
+      masa,
+      [Math.cos(d.a) * rad, (centro ? 2.5 : 2.28) + (r() - 0.5) * 0.22, Math.sin(d.a) * rad],
+      [0, r() * Math.PI, 0],
+      [1.42, 0.62, 1.42],
+    );
+    partes.push(pintar(masa, variar(i % 2 ? PAL.cacaoHojaSol : PAL.cacaoHoja, r, 0.05)));
+  }
+
+  // El brote nuevo COBRIZO: la hoja tierna del cacao asoma rojiza, discreta y
+  // ANIDADA al borde de la copa (que no parezca fruto en las ramitas: la
+  // mazorca va en el tronco, y este mundo no puede contradecirse).
+  const brote = new THREE.IcosahedronGeometry(0.11, 0);
+  const ab = r() * Math.PI * 2;
+  poner(brote, [Math.cos(ab) * 0.68, 2.42, Math.sin(ab) * 0.68], [0, r() * Math.PI, 0], [1.1, 0.6, 1.1]);
+  partes.push(pintar(brote, variar(PAL.cacaoBrote, r, 0.08)));
+
+  return fusionar(partes);
+}
+
+/**
+ * La MAZORCA del cacao: una vaina alargada y panzona que cuelga pegada del
+ * tronco. Se pinta BLANCA — el color real (verde → amarillo → rojo-marrón) va
+ * POR INSTANCIA.
+ */
+export function geomMazorca() {
+  const g = new THREE.SphereGeometry(0.115, 7, 6);
+  poner(g, [0, 0, 0], [0, 0, 0], [0.72, 1.5, 0.72]); // alargada, panzona
+  return pintar(g.index ? g.toNonIndexed() : g, '#ffffff');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  GUAMO (Inga) — el parasol del sombrío                                      */
+/* -------------------------------------------------------------------------- */
+
+export function geomGuamo({ q = 1 } = {}, seed = 2) {
+  const r = rng(seed);
+  const partes = [];
+
+  // Tronco alto que se abre en ramas maestras (más alto que en el cafetal:
+  // en tierra caliente el sombrío del cacao tiende techo bien arriba, un piso
+  // entero por encima del dosel del cultivo).
+  const tronco = new THREE.CylinderGeometry(0.15, 0.26, 4.4, 7, 1);
+  poner(tronco, [0, 2.2, 0]);
+  partes.push(pintar(tronco, PAL.guamoTronco));
+  const nRamas = Math.max(2, Math.round(3 * q));
+  for (let i = 0; i < nRamas; i++) {
+    const a = (i / nRamas) * Math.PI * 2 + r();
+    const rama = new THREE.CylinderGeometry(0.05, 0.1, 1.6, 5, 1);
+    apuntar(rama, [Math.cos(a) * 0.6, 4.7, Math.sin(a) * 0.6], [Math.cos(a) * 0.9, 1, Math.sin(a) * 0.9]);
+    partes.push(pintar(rama, PAL.guamoTronco));
+  }
+
+  // La copa ANCHA y plana: el techo de hojas sobre el cacaotal.
+  const nMasas = Math.max(3, Math.round(5 * q));
+  for (let i = 0; i < nMasas; i++) {
+    const a = (i / nMasas) * Math.PI * 2 + 0.7;
+    const rad = i === 0 ? 0 : 1.15 + r() * 0.45;
+    const masa = new THREE.IcosahedronGeometry(i === 0 ? 1.35 : 1.0 + r() * 0.28, 1);
+    poner(
+      masa,
+      [Math.cos(a) * rad, 5.35 + (r() - 0.5) * 0.4, Math.sin(a) * rad],
+      [0, r() * Math.PI, 0],
+      [1.8, 0.72, 1.8],
+    );
+    partes.push(pintar(masa, variar(i % 2 ? PAL.guamoCopaSol : PAL.guamoCopa, r, 0.06)));
+  }
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  PLÁTANO intercalado — el hermano de sombra del cacao joven                 */
+/* -------------------------------------------------------------------------- */
+
+export function geomPlatano({ q = 1 } = {}, seed = 4) {
+  const r = rng(seed);
+  const partes = [];
+
+  // Pseudotallo claro (en tierra caliente el plátano se da grande y asoma
+  // POR ENCIMA del dosel del cacao).
+  const tallo = new THREE.CylinderGeometry(0.1, 0.17, 3.1, 6, 1);
+  poner(tallo, [0, 1.55, 0]);
+  partes.push(pintar(tallo, PAL.platanoTallo));
+
+  // Las hojas enormes, arqueadas hacia afuera y abajo.
+  const nHojas = Math.max(4, Math.round(6 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const a = (i / nHojas) * Math.PI * 2 + r() * 0.5;
+    const caida = 0.55 + r() * 0.4; // cuánto se arquea
+    const hoja = new THREE.SphereGeometry(1, 7, 5);
+    const seca = r() > 0.82; // alguna hoja vieja amarillea
+    apuntar(
+      hoja,
+      [Math.cos(a) * 0.55, 3.15, Math.sin(a) * 0.55],
+      [Math.cos(a), 1 - caida, Math.sin(a)],
+      [0.16, 1.0, 0.36],
+    );
+    partes.push(pintar(hoja, variar(seca ? PAL.platanoHojaSeca : i % 2 ? PAL.platanoHojaSol : PAL.platanoHoja, r, 0.05)));
+  }
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Suelo: tronco caído, hojarasca y piedra                                    */
+/* -------------------------------------------------------------------------- */
+
+/** Un tronco caído con su musgo: la madera que se queda abonando la vega. */
+export function geomTroncoCaido(seed = 7) {
+  const r = rng(seed);
+  const partes = [];
+  const palo = new THREE.CylinderGeometry(0.13, 0.17, 1.9, 6, 1);
+  poner(palo, [0, 0.15, 0], [0, 0, Math.PI / 2 + (r() - 0.5) * 0.2]);
+  partes.push(pintar(palo, PAL.troncoCaido));
+  const capa = new THREE.IcosahedronGeometry(0.16, 0);
+  poner(capa, [0.35, 0.27, 0.02], [0, r() * Math.PI, 0], [1.4, 0.5, 1]);
+  partes.push(pintar(capa, PAL.musgo));
+  return fusionar(partes);
+}
+
+export function geomHojarasca(seed = 5) {
+  const r = rng(seed);
+  const partes = [];
+  for (let i = 0; i < 3; i++) {
+    const mancha = new THREE.CylinderGeometry(0.36 + r() * 0.32, 0.46 + r() * 0.34, 0.035, 7, 1);
+    poner(mancha, [(r() - 0.5) * 0.55, 0.02 + i * 0.012, (r() - 0.5) * 0.55], [0, r() * Math.PI, 0]);
+    partes.push(pintar(mancha, i % 2 ? PAL.hojarasca2 : PAL.hojarasca));
+  }
+  return fusionar(partes);
+}
+
+export function geomPiedra(seed = 6) {
+  const r = rng(seed);
+  const roca = new THREE.DodecahedronGeometry(0.3, 0);
+  poner(roca, [0, 0.13, 0], [r() * 0.6, r() * Math.PI, r() * 0.6], [1.25, 0.7, 1]);
+  const capa = new THREE.DodecahedronGeometry(0.17, 0);
+  poner(capa, [0.11, 0.22, 0.05], [0, r() * Math.PI, 0], [1, 0.55, 1]);
+  return fusionar([pintar(roca, PAL.piedra), pintar(capa, PAL.musgo)]);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Distribución: siembra a distancia pareja + sombrío disperso                */
+/* -------------------------------------------------------------------------- */
+
+/* El sombrío vive FIJO en la vega (posiciones compuestas a mano para que el
+   techo de sombra cubra el cultivo sin taparlo todo). Se recortan por tier. */
+const SITIOS_GUAMO = [
+  [-7.5, -4.5], [3.5, -8.0], [10.5, -3.0], [-13.0, -9.5], [-1.5, -1.0], [7.0, -12.0],
+];
+const SITIOS_PLATANO = [
+  [-11.0, -2.0], [5.5, -4.5], [-4.0, -10.5], [13.5, -8.5], [-15.5, -6.0], [9.5, 0.5], [-8.0, -13.0], [1.5, 2.8],
+];
+const SITIOS_TRONCO = [
+  [-5.5, 3.5], [8.5, -6.5], [-12.0, -12.5],
+];
+
+/* La casa con el cajón de fermentar y la pasera vive en la lomita del fondo. */
+export const SITIO_CASA = /** @type {[number, number]} */ ([11.5, -13.0]);
+
+/** ¿Qué tan madura pinta la mazorca en esta mata? Varía mata a mata. */
+function madurezEn(wx, wz, r) {
+  const base = 0.5 + 0.5 * ruido(wx * 0.35 + 9, wz * 0.35 + 4); // parches de cosecha
+  return clamp(base * 0.85 + (r() - 0.5) * 0.4, 0, 1);
+}
+
+/**
+ * Siembra determinista del cacaotal completo. Devuelve items por especie:
+ * `{pos, rotY, escala, tint}` (contrato del componente `Especie`), y para la
+ * mazorca el `tint` ES el color del fruto (verde → amarillo → rojo-marrón por
+ * instancia). Las mazorcas van PEGADAS del tronco de su mata (caulifloria).
+ */
+export function distribucionCacaotal(conteos, seed = 417) {
+  const c = conteos;
+  const rCac = rng(seed + 1);
+  const rMaz = rng(seed + 2);
+  const rSue = rng(seed + 3);
+
+  // --- La siembra a distancia pareja (el cacao se planta a 3x3, tresbolillo).
+  //     ABIERTA: entre copa y copa queda aire — se ve el tronco y su mazorca. ---
+  const sitios = [];
+  const filasZ = [4.2, 2.0, -0.2, -2.4, -4.6, -6.8, -9.0, -11.2, -13.2];
+  filasZ.forEach((z0, fila) => {
+    const corrimiento = fila % 2 ? 1.15 : 0; // tresbolillo
+    for (let wx = -17; wx <= 17; wx += 2.3) {
+      const px = wx + corrimiento + (rCac() - 0.5) * 0.6;
+      const pz = z0 + (rCac() - 0.5) * 0.55;
+      // respetar el patio de la casa y su secadero
+      const dx = px - SITIO_CASA[0];
+      const dz = pz - SITIO_CASA[1];
+      if (dx * dx + dz * dz < 20) continue;
+      sitios.push({
+        px, pz,
+        esc: 0.82 + rCac() * 0.42,
+        rotY: rCac() * Math.PI * 2,
+        maduro: madurezEn(px, pz, rCac),
+        carga: rCac(), // qué tan cargada de mazorca está la mata
+      });
+    }
+  });
+  // recorte determinista al presupuesto del tier (salto parejo, no los primeros N)
+  const paso = Math.max(1, Math.floor(sitios.length / Math.max(1, c.cacao)));
+  const matas = [];
+  for (let i = 0; i < sitios.length && matas.length < c.cacao; i += paso) matas.push(sitios[i]);
+
+  const cacao = matas.map((s) => ({
+    pos: [s.px, alturaVega(s.px, s.pz), s.pz],
+    rotY: s.rotY,
+    escala: s.esc,
+    tint: [0.92 + rCac() * 0.16, 0.92 + rCac() * 0.16, 0.92 + rCac() * 0.16],
+  }));
+
+  // --- Las mazorcas: PEGADAS del tronco y las ramas bajas (caulifloria). ---
+  const verde = new THREE.Color(PAL.mazorcaVerde);
+  const amarilla = new THREE.Color(PAL.mazorcaAmarilla);
+  const roja = new THREE.Color(PAL.mazorcaRoja);
+  const col = new THREE.Color();
+  const mazorca = [];
+  const cargadas = matas.filter((s) => s.carga > 0.25);
+  let gi = 0;
+  while (mazorca.length < c.mazorca && cargadas.length > 0) {
+    const s = cargadas[gi % cargadas.length];
+    gi += 1;
+    if (gi > cargadas.length * 9) break;
+    const baseY = alturaVega(s.px, s.pz);
+    const cuantas = 2 + Math.floor(rMaz() * 3);
+    for (let k = 0; k < cuantas && mazorca.length < c.mazorca; k++) {
+      const a = rMaz() * Math.PI * 2;
+      const enRama = rMaz() > 0.78; // unas pocas suben a la horqueta
+      // pegada del tronco: radio apenas mayor que la corteza
+      const rad = (enRama ? 0.32 + rMaz() * 0.18 : 0.13 + rMaz() * 0.035) * s.esc;
+      const y = (enRama ? 1.5 + rMaz() * 0.35 : 0.35 + rMaz() * 1.0) * s.esc;
+      // el estado del fruto: la madurez de la mata + su propio azar
+      const m = clamp(s.maduro + (rMaz() - 0.5) * 0.5, 0, 1);
+      if (m < 0.5) col.lerpColors(verde, amarilla, m * 2);
+      else col.lerpColors(amarilla, roja, (m - 0.5) * 2);
+      col.multiplyScalar(0.92 + rMaz() * 0.16);
+      mazorca.push({
+        pos: [s.px + Math.cos(a) * rad, baseY + y, s.pz + Math.sin(a) * rad],
+        rotY: rMaz() * Math.PI,
+        escala: (0.8 + rMaz() * 0.5) * s.esc,
+        tint: [col.r, col.g, col.b],
+      });
+    }
+  }
+
+  // --- El sombrío y el plátano (sitios fijos recortados por tier). ---
+  const enVega = (p, esc, rr) => ({
+    pos: [p[0], alturaVega(p[0], p[1]), p[1]],
+    rotY: rr() * Math.PI * 2,
+    escala: esc,
+    tint: [0.94 + rr() * 0.12, 0.94 + rr() * 0.12, 0.94 + rr() * 0.12],
+  });
+  const rArb = rng(seed + 4);
+  const guamo = SITIOS_GUAMO.slice(0, c.guamo).map((p) => enVega(p, 0.95 + rArb() * 0.35, rArb));
+  const platano = SITIOS_PLATANO.slice(0, c.platano).map((p) => enVega(p, 0.85 + rArb() * 0.3, rArb));
+  const tronco = SITIOS_TRONCO.slice(0, c.tronco).map((p) => enVega(p, 0.85 + rArb() * 0.4, rArb));
+
+  // --- El suelo: hojarasca gruesa por todo el cacaotal, piedras sueltas. ---
+  const hojarasca = [];
+  for (let i = 0; i < c.hojarasca; i++) {
+    const x = -16 + rSue() * 32;
+    const z = -13 + rSue() * 27;
+    hojarasca.push({
+      pos: [x, alturaVega(x, z) + 0.01, z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.85 + rSue() * 0.75,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+  const piedra = [];
+  for (let i = 0; i < c.piedra; i++) {
+    const x = -17 + rSue() * 34;
+    const z = -13 + rSue() * 27;
+    piedra.push({
+      pos: [x, alturaVega(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.7 + rSue() * 0.9,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+
+  return { cacao, mazorca, guamo, platano, tronco, hojarasca, piedra };
+}
+
+/** Los centros del sombrío del tier (para la luz colada bajo las copas). */
+export function centrosSombrio(conteos) {
+  return SITIOS_GUAMO.slice(0, conteos.guamo).map(
+    ([x, z]) => /** @type {[number, number, number]} */ ([x, alturaVega(x, z), z]),
+  );
+}


### PR DESCRIPTION
## El mundo del cacao

El cultivo de paz de la tierra caliente con su mundo 3D propio, hermano del café (molde exacto del PR #2500, `src/visual/mundo3d/cafetal/`).

**Qué se ve**
- La **vega de tierra caliente** casi plana con su lomita al fondo (heightfield con vertexColors: mantillo de hojarasca, pasto en los claros, tierra húmeda, caminito a la casa).
- Los **árboles de cacao** con su porte inconfundible: tronco corto que se abre en **HORQUETA**, copa ancha de hoja grande y el **brote nuevo cobrizo** anidado al borde.
- Las **MAZORCAS pegadas del tronco y las ramas gruesas (caulifloria — la firma del cacao)**, madurando **verde → amarillo → rojo-marrón POR INSTANCIA**: un solo InstancedMesh lleva todos los estados.
- El **sombrío**: guamos-parasol que tienden techo un piso por encima del dosel del cultivo, con **luz colada** (dapples dorados que respiran) en gama alta.
- El **plátano intercalado** asomando por encima del dosel del cacao.
- La **casa con el cajón de fermentar** (tapado con hoja de plátano) **y la pasera** de secado con el grano extendido, en la calina del fondo, con canasto y mazorcas cosechadas en el patio.
- **Fauna SVG rubber-hose** de la casa como billboards: dos mariposas revoloteando y el **escarabajo reptando en la hojarasca** (el descomponedor que la hoja del cacao alimenta).
- **Cuatro pasos didácticos** (la mazorca, por qué bajo sombra, el grano y la baba/fermentación, rumbo al secado) con anillo-foco que respira sobre el lugar de cada lección.

**Rendimiento (contrato de la casa)**
- Una draw-call por especie: geometría FUSIONADA (desindexada antes de `mergeGeometries`, truena si da null — mordida conocida) + `InstancedMesh` con color por instancia.
- Presupuestos por tier (`FLORA_CACAO`), detalle geométrico escalado (`CALIDAD_CACAO`), `perfilDeTier` para sombras/fog/DPR.
- Gama baja / sin WebGL / ahorro de datos → **ficha 2D digna** (mata de cacao CSS con las mazorcas colgadas del tronco y el guamo detrás, cero GPU).
- `reducedMotion` → mundo quieto, frameloop a demanda.

**Cómo se accede**
- Ruta pública sin auth: `#/mockups/cacao-vivo-3d` (registrada en `MOCKUP_HASH_ROUTES` + switch de App.jsx, los 3 puntos exactos del patrón cafetal).

**Archivos**
- `src/visual/mundo3d/cacao/floraCacao.geom.js` — geometrías + distribución determinista (tresbolillo abierto: se ve el tronco y su mazorca)
- `src/visual/mundo3d/cacao/FloraCacao.jsx` — capa instanciada + luz colada
- `src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx` — escena (vega, luz cálida, casa-secadero, fauna, foco)
- `src/visual/mundo3d/cacao/MundoCacao.jsx` — host con los 4 pasos
- `src/mockups/CacaoVivo3D.jsx` + `.css` — vitrina + ficha 2D
- `src/App.jsx` — registro de ruta (3 puntos, patrón cafetal)

**Verificación**
- `npm run tsc:check` limpio · `npm run build:prod` verde.
- Capturas reales navegando (chromium + swiftshader, dev server): entrada, dos ángulos girados con arrastre, los 4 pasos, la ficha 2D y desktop (390×844 y 1280×800). Iterado 2 veces sobre captura: cámara elevada sobre el dosel, siembra abierta para que la caulifloria SE VEA, y brote cobrizo discreto para no contradecir la lección del paso 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)