### PR TITLE
fix(tsc): cerrar JSX del case cacao en App.jsx (merge tangle) + tupla Vitrina

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1595,6 +1595,9 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del cacao">
               <CacaoVivo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
       case 'mockup_papa_viva_3d':
         // Vitrina pública del MUNDO DE LA PAPA: el papal en surcos de la tierra
         // fría en 3D REAL — caballones de tierra negra horneados en el relieve

--- a/src/mockups/VitrinaMaestraMundos.jsx
+++ b/src/mockups/VitrinaMaestraMundos.jsx
@@ -448,7 +448,7 @@ function PaisajeMirador({ tier }) {
       lajas: geomLajasSendero(),
       /* los andenes de la montaña + las lomitas que rematan sus cortes */
       bancales: geomBancales(FILAS_BANCAL),
-      lomitas: geomLomitas(LOMITAS_REMATE),
+      lomitas: geomLomitas(/** @type {[number, number, number][]} */ (LOMITAS_REMATE)),
     }),
     [tier],
   );


### PR DESCRIPTION
El auto-merge de los 3 mundos de cultivo dejó el `case 'mockup_cacao_...'` de App.jsx sin sus tags de cierre → 23 errores tsc en cascada + shell clásico (chagra-dev) roto. build:prod no lo veía (prod entra por ProdChagraApp.jsx). Fix: cerrar el JSX + tupla en Vitrina. **tsc:check VERDE, build:prod verde.**

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>