### PR TITLE
feat(agente): Angelita es el agente vivo en toda pantalla — y saluda según dónde ande usted

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3571,7 +3571,7 @@ export default function App() {
           CTA "Explorar con finca de ejemplo" del footer y la usuaria nueva aún
           no conoce al agente — ruido en su primer flujo. */}
       <Suspense fallback={null}>
-        {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && !currentView.startsWith('mockup_') && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && <AgentFab onNavigate={navigate} />}
+        {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && !currentView.startsWith('mockup_') && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && currentView !== 'onboarding-perfil' && currentView !== 'onboarding-perfil-clasico' && <AgentFab onNavigate={navigate} pantalla={currentView} />}
       </Suspense>
       {/* Escucha manos libres (operador 2026-07-05, caso guantes/manos
           embarradas). Abre el widget "Chagra está escuchando" que navega o

--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -129,13 +129,20 @@ export default function AgentFab({ onNavigate, pantalla = null }) {
         transition: 'transform .18s cubic-bezier(.34,1.56,.64,1), filter .25s ease',
       }}
     >
-      <Angelita
-        estado={estado}
-        size={62}
-        direccion="izquierda"
-        className={responseReady ? 'agt-avatar-glow' : undefined}
-        title="Angelita, la asistente de Chagra"
-      />
+      {/* pointer-events:none — CRÍTICO: el click debe caer en el BOTÓN, nunca
+          en el SVG. Angelita se REMONTA al cambiar de estado (key=estado en su
+          .agt-vuelo) y hover/pressed cambian el estado: si el mousedown cae en
+          un nodo del dibujo que se desconecta antes del mouseup, el navegador
+          se traga el click (verificado con playwright 2026-07-16). */}
+      <span style={{ pointerEvents: 'none', display: 'flex' }} aria-hidden="true">
+        <Angelita
+          estado={estado}
+          size={62}
+          direccion="izquierda"
+          className={responseReady ? 'agt-avatar-glow' : undefined}
+          title="Angelita, la asistente de Chagra"
+        />
+      </span>
     </button>
   );
 }

--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -1,42 +1,37 @@
 import React, { useState, useCallback } from 'react';
-import ChagraAgentAvatar from './ChagraAgentAvatar';
+import Angelita from '../visual/agente/Angelita';
 import useAgentNotificationStore from '../store/useAgentNotificationStore';
 import usePrefsStore from '../store/usePrefsStore';
 import { isSpeaking, stop, replayLast, isKokoroAvailable } from '../services/ttsService';
 import { agentSounds } from '../services/agentSoundService';
 import { fvhSkinClass } from '../config/fvhSkin';
-import { colibriRealActivo } from '../config/colibriFlag';
-import { BarbuditoPosado } from './colibri/Barbudito';
 import './agent-fab-skin.css';
 
-// ¿Avatar del FAB = colibrí REAL (barbudito posado)? Gateado por VITE_COLIBRI
-// (dev-only). Con la flag OFF (prod) el FAB conserva su avatar actual
-// (ChagraAgentAvatar). Se evalúa una sola vez (flag de build).
-const COLIBRI_REAL = colibriRealActivo();
-
 /**
- * AgentFab — Floating Action Button para abrir el agente Chagra IA.
+ * AgentFab — Angelita, el agente vivo presente en TODA pantalla.
  *
- * Operator 2026-05-19:
- *   - default state idle (alas batiendo suave, vuelo estacionario).
- *   - mouse over → estado `thinking` (colibri se acerca a libar la flor).
- *   - mouse down / pulsacion → estado `speaking` mas breve para sentir el feedback.
- *   - touch (mobile) → estado `thinking` mientras se mantiene el toque.
+ * Decisión del operador (2026-07-16): "Angelita como el agente, jubila el
+ * colibrí". El FAB deja de ser un porthole con foto de colibrí: es Angelita
+ * volando libre en la esquina — compañía, no interrupción. El colibrí
+ * (barbudito) se retira del rol de asistente y queda de decoración en los
+ * mundos 3D (faunaFuncional, rol polinizador).
  *
- * Task #122 (2026-05-23): el FAB ahora es el avatar global. Lee de
- * `useAgentNotificationStore`:
- *   - `responseReady` → glow drop-shadow amber para anunciar "respuesta lista"
- *     mientras el operador está en otra pantalla.
- * Double-click handler:
- *   - Si TTS está reproduciendo → stop() inmediato + ttsEnabled=false.
- *   - Si TTS OFF y hay último mensaje → replayLast() + ttsEnabled=true.
- *   - Si no hay nada que reproducir, no-op (sin error visible).
- * Single click → abrir AgentScreen (comportamiento previo).
+ * Sus tres momentos (rubber-hose, angelitaEstados.js):
+ *   - default        → 'acompana': idle-cerebro vivo (flota, se acicala, se
+ *                      posa a descansar) — presente sin hablar sola.
+ *   - hover / focus  → 'escuchando': se posa y ladea la cabeza hacia usted.
+ *   - tap / pressed  → 'contenta': brinquito de celebración al tocarla.
+ *   - respuesta lista→ 'invita' + glow ámbar: "venga, le tengo algo".
  *
- * El FAB tambien escala 1.06x al hover/active para feedback claro de boton
- * sin perder el sello visual del colibri.
+ * CONTEXTUAL POR PANTALLA: si el shell le pasa `pantalla` (currentView), al
+ * tocarla navega al agente con `{ desdePantalla, spatialContext.pantalla }` —
+ * AgentScreen saluda sobre ESA pantalla (saludoPantalla.js) y el LLM recibe
+ * la pantalla en el pin espacial (spatialAgentContext.js).
+ *
+ * Double-click (Task #122, sin cambios): TTS hablando → stop + mute; TTS OFF
+ * con último mensaje → replay + unmute.
  */
-export default function AgentFab({ onNavigate }) {
+export default function AgentFab({ onNavigate, pantalla = null }) {
   const [hover, setHover] = useState(false);
   const [pressed, setPressed] = useState(false);
 
@@ -45,11 +40,14 @@ export default function AgentFab({ onNavigate }) {
   const ttsEnabled = usePrefsStore((s) => s.ttsEnabled);
   const setTtsEnabled = usePrefsStore((s) => s.setTtsEnabled);
 
-  // Estado del avatar:
-  // - pressed -> 'speaking' (cuerpo bob, plumaje pulsa) durante el tap
-  // - hover -> 'thinking' (sip motion hacia la flor)
-  // - default -> 'idle'
-  const state = pressed ? 'speaking' : hover ? 'thinking' : 'idle';
+  // Estado de Angelita: el tacto manda sobre el aviso, y el aviso sobre el idle.
+  const estado = pressed
+    ? 'contenta'
+    : hover
+      ? 'escuchando'
+      : responseReady
+        ? 'invita'
+        : 'acompana';
 
   const handleEnter = () => setHover(true);
   const handleLeave = () => { setHover(false); setPressed(false); };
@@ -57,32 +55,29 @@ export default function AgentFab({ onNavigate }) {
   const handleUp = () => setPressed(false);
 
   const handleClick = () => {
-    onNavigate('agente');
+    // El shell prod pasa `pantalla` (currentView): viaja como initialContext
+    // para que el saludo y el pin espacial sean sobre la pantalla de origen.
+    onNavigate('agente', pantalla
+      ? { desdePantalla: pantalla, spatialContext: { pantalla } }
+      : undefined);
   };
 
   // Task #122: double-click toggle silencia/reactiva audio global.
-  // - Si está hablando (Kokoro o Web Speech) → stop() + ttsEnabled OFF.
-  // - Si silenciado y hay last message → replayLast() + ttsEnabled ON.
-  // - Sin último mensaje: feedback sutil (cancel sound) y no-op de TTS.
   const handleDoubleClick = useCallback(async (e) => {
     e.stopPropagation();
     e.preventDefault();
     if (isSpeaking() || ttsEnabled) {
-      // Cualquier playback activo OR estado "enabled" lo apagamos
       stop();
       setTtsEnabled(false);
       agentSounds.cancel();
       return;
     }
-    // TTS OFF: reactivar + replay si hay algo cacheado
     if (lastAssistantMessage) {
       setTtsEnabled(true);
       const kokoroReady = await isKokoroAvailable();
       await replayLast({ useKokoro: kokoroReady });
       agentSounds.chime();
     } else {
-      // No hay nada que reproducir. Reactivamos el toggle igual para que
-      // futuras respuestas suenen, pero sin chime engañoso.
       setTtsEnabled(true);
     }
   }, [ttsEnabled, lastAssistantMessage, setTtsEnabled]);
@@ -91,11 +86,11 @@ export default function AgentFab({ onNavigate }) {
     <button
       type="button"
       className={fvhSkinClass(`chagra-fab${hover ? ' is-hover' : ''}${responseReady ? ' is-ready' : ''}`)}
-      aria-label={responseReady ? 'Chagra IA tiene respuesta nueva' : 'Asistente Chagra IA'}
+      aria-label={responseReady ? 'Angelita (Chagra IA) tiene respuesta nueva' : 'Angelita, la asistente Chagra IA'}
       title={
         responseReady
-          ? 'Chagra IA tiene respuesta nueva. Doble click silencia o reactiva la voz'
-          : 'Hablar con Chagra IA. Doble click silencia o reactiva la voz'
+          ? 'Angelita tiene respuesta nueva. Doble click silencia o reactiva la voz'
+          : 'Hablar con Angelita. Doble click silencia o reactiva la voz'
       }
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
@@ -110,38 +105,37 @@ export default function AgentFab({ onNavigate }) {
       style={{
         position: 'fixed',
         bottom: 'max(90px, calc(env(safe-area-inset-bottom) + 90px))',
-        right: 18,
-        width: 56,
-        height: 56,
+        right: 14,
+        width: 64,
+        height: 64,
         borderRadius: '50%',
-        border: responseReady
-          ? '2px solid rgba(255,183,0,.7)'
-          : '2px solid rgba(16,185,129,.55)',
-        background: hover
-          ? 'radial-gradient(circle at 30% 25%, #1e3a2f 0%, #0a1320 70%)'
-          : 'radial-gradient(circle at 30% 25%, #1e293b 0%, #0f172a 70%)',
+        // Angelita vuela LIBRE: sin plinto ni borde — una abeja en la esquina,
+        // no un icono enfrascado. La legibilidad sobre cualquier fondo la pone
+        // el drop-shadow de tinta; el aviso "respuesta lista", el glow ámbar
+        // (.agt-avatar-glow via Angelita className + anillo .is-ready de
+        // motion.css sobre el círculo táctil).
+        border: 'none',
+        background: 'transparent',
         color: 'white',
         cursor: 'pointer',
-        boxShadow: hover
-          ? '0 6px 22px rgba(0,0,0,0.5), 0 0 22px rgba(16,185,129,.65), 0 0 6px rgba(6,182,212,.45) inset'
-          : '0 4px 16px rgba(0,0,0,0.4), 0 0 14px rgba(16,185,129,.35)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         zIndex: 40,
         padding: 0,
-        overflow: 'hidden',
-        transform: pressed ? 'scale(0.95)' : hover ? 'scale(1.06)' : 'scale(1)',
-        transition: 'transform .18s cubic-bezier(.34,1.56,.64,1), box-shadow .25s ease, background .25s ease, border-color .25s ease',
+        overflow: 'visible',
+        filter: 'drop-shadow(0 3px 6px rgba(10, 15, 26, 0.45))',
+        transform: pressed ? 'scale(0.94)' : hover ? 'scale(1.08)' : 'scale(1)',
+        transition: 'transform .18s cubic-bezier(.34,1.56,.64,1), filter .25s ease',
       }}
     >
-      {COLIBRI_REAL ? (
-        // Colibrí REAL (barbudito POSADO recortado), con un leve flotar. El
-        // botón ya es circular y recorta (overflow:hidden).
-        <BarbuditoPosado size={46} ariaLabel="Chagra IA" />
-      ) : (
-        <ChagraAgentAvatar state={state} size={48} ariaLabel="Chagra IA" glow={responseReady} />
-      )}
+      <Angelita
+        estado={estado}
+        size={62}
+        direccion="izquierda"
+        className={responseReady ? 'agt-avatar-glow' : undefined}
+        title="Angelita, la asistente de Chagra"
+      />
     </button>
   );
 }

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -139,7 +139,6 @@ import ChatHistory from './ChatHistory';
 import ActionConfirmModal from '../ActionConfirmModal';
 import FeedbackConsentModal from '../FeedbackConsentModal';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
-import ChagraAgentAvatarColibriPhoto from '../ChagraAgentAvatarColibriPhoto';
 import { AgentManoOverlay } from '../agent/AgentShell';
 import { mapCapabilityPick } from '../agent/capabilityRouting';
 import { agentSounds } from '../../services/agentSoundService';
@@ -3591,8 +3590,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         >
           <Home size={20} />
         </button>
-        {/* Avatar + título */}
-        <ChagraAgentAvatarColibriPhoto
+        {/* Avatar + título. 2026-07-16: iba directo a la foto del colibrí
+            saltándose el wrapper — ahora respeta la preferencia (default
+            Angelita, "jubila el colibrí" — operador). */}
+        <ChagraAgentAvatar
           state={state === STATE_RECORDING ? 'listening' : (state === STATE_THINKING || isVoicePlaying) ? 'thinking' : 'idle'}
           size={36}
           onDoubleClick={async () => {

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -120,7 +120,8 @@ import { prependCorrectionBlock } from './responseGuards';
 // idea contextual (cultivo/clima/temporada) sin inventar alarmas. Lógica pura
 // y testeable extraída a proactiveGreeting; aquí solo la hidratamos desde los
 // stores en vivo y la pintamos en el empty-state del chat.
-import { resolveProactiveGreeting } from '../../services/proactiveGreeting';
+import { resolveProactiveGreeting, saludoPorHora } from '../../services/proactiveGreeting';
+import { saludoDePantalla } from '../../services/saludoPantalla';
 import useLogStore from '../../store/useLogStore';
 // Bug UX 2026-05-30: preservar respuesta parcial ante abort/timeout/cancel.
 // La lógica pura del merge del estado final vive en agentPartialMerge (testeable
@@ -574,6 +575,19 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         ensoOutlook = getEnsoOutlook({ phase, region, probabilities: probs });
       }
     } catch (_) { /* sin ENSO no pasa nada — la idea cae a temporada/piso */ }
+    // SALUDO CONTEXTUAL POR PANTALLA (2026-07-16): si el operador tocó a
+    // Angelita desde una pantalla mapeada (AgentFab pasa `desdePantalla`),
+    // ella saluda sobre ESO — "¿le ayudo con la germinación?" en #semilla.
+    // Los pendientes URGENTES siguen mandando (una alerta de plaga le gana
+    // a la cortesía); el saludo de pantalla solo reemplaza la idea genérica.
+    const saludoPantalla = saludoDePantalla(initialContext?.desdePantalla);
+    const greetingDePantalla = (hi) => ({
+      state: 'idea',
+      hi: hi || saludoPorHora(),
+      lead: saludoPantalla,
+      items: [],
+      restCount: 0,
+    });
     resolveProactiveGreeting({
       activeAlerts,
       getPendingTasks: () => useLogStore.getState().getPendingTasks(),
@@ -581,8 +595,17 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       altitud: finca?.altitud != null ? Number(finca.altitud) : null,
       ensoOutlook,
     }).then((g) => {
-      if (alive) setProactiveGreeting(g);
-    }).catch(() => { /* degrada silencioso al copy estático */ });
+      if (!alive) return;
+      if (saludoPantalla && (!g || g.state !== 'pending')) {
+        setProactiveGreeting(greetingDePantalla(g?.hi));
+      } else {
+        setProactiveGreeting(g);
+      }
+    }).catch(() => {
+      // Degrada silencioso: con saludo de pantalla lo usamos igual; sin él,
+      // cae al copy estático de siempre.
+      if (alive && saludoPantalla) setProactiveGreeting(greetingDePantalla());
+    });
     return () => { alive = false; };
     // Solo al montar: el saludo es la primera impresión, no debe re-evaluarse en
     // cada cambio de inventario/alerta mientras el operador ya está leyéndolo.

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -139,9 +139,9 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
                 className="text-slate-200 text-xl mb-2"
                 style={{ fontFamily: "'Baloo 2', 'Nunito', system-ui, sans-serif", fontWeight: 700, letterSpacing: '-0.3px' }}
               >
-                ¡Hola! Soy tu asistente agroecológico.
+                ¡Hola! Soy Angelita, su asistente agroecológica.
               </p>
-              <p className="text-slate-500 text-xs">Puedes hablarme o escribirme sobre tus plantas.</p>
+              <p className="text-slate-500 text-xs">Puede hablarme o escribirme sobre sus plantas.</p>
             </>
           )}
         </div>
@@ -348,7 +348,9 @@ function ProactiveGreeting({ greeting }) {
         className="text-slate-200 text-xl mb-1.5"
         style={{ fontFamily: "'Baloo 2', 'Nunito', system-ui, sans-serif", fontWeight: 700, letterSpacing: '-0.3px' }}
       >
-        {hi}. Soy <span className="text-emerald-300">Chagra</span>.
+        {/* 2026-07-16: el agente ES Angelita (la abeja) — el texto acompaña
+            a la cara que el operador ya ve arriba. */}
+        {hi}. Soy <span className="text-emerald-300">Angelita</span>, de Chagra.
       </p>
       <p
         className="text-slate-300 text-sm leading-relaxed mb-3"

--- a/src/components/AgentScreen/__tests__/ChatHistory.greeting.test.jsx
+++ b/src/components/AgentScreen/__tests__/ChatHistory.greeting.test.jsx
@@ -68,6 +68,6 @@ describe('ChatHistory — saludo proactivo (empty state)', () => {
   it('sin saludo resuelto → copy estático de siempre (backward compat)', () => {
     render(<ChatHistory messages={[]} proactiveGreeting={null} />);
     expect(screen.queryByTestId('proactive-greeting')).toBeNull();
-    expect(screen.getByText(/Soy tu asistente agroecológico/i)).toBeInTheDocument();
+    expect(screen.getByText(/Soy Angelita, su asistente agroecológica/i)).toBeInTheDocument();
   });
 });

--- a/src/components/ChagraAgentAvatar.jsx
+++ b/src/components/ChagraAgentAvatar.jsx
@@ -1,6 +1,6 @@
 import ChagraAgentAvatarColibri from './ChagraAgentAvatarColibri';
-import ChagraAgentAvatarColibriPhoto from './ChagraAgentAvatarColibriPhoto';
 import ChagraAgentAvatarMaiz from './ChagraAgentAvatarMaiz';
+import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
 import useAgentAvatarType from '../hooks/useAgentAvatarType';
 
 /**
@@ -11,9 +11,11 @@ import useAgentAvatarType from '../hooks/useAgentAvatarType';
  * Decisiones del operador:
  *   - 2026-05-27: usuario debe poder elegir entre colibrí o maíz.
  *   - 2026-05-28: reemplazar el R3F que "desatina con todo lo que ya está".
- *     El default 'colibri' ahora apunta al avatar foto-realista (foto
- *     biopunk Lili). El SVG ilustrado vive bajo 'colibri_svg' para quien
- *     prefiera el estilo botánico anterior.
+ *   - 2026-07-16: "Angelita como el agente, jubila el colibrí". La cara del
+ *     agente pasa a ser Angelita (la abeja angelita, con idle-cerebro, mirada
+ *     y lip-sync). El slug guardado 'colibri' (el default histórico) delega en
+ *     ella sin migración; el colibrí NO sale del código: sigue de polinizador
+ *     decorativo en los mundos 3D y como preferencia explícita 'colibri_svg'.
  *
  * UI de cambio vive en ProfileScreen → Apariencia → Avatar del agente.
  *
@@ -24,6 +26,6 @@ export default function ChagraAgentAvatar(props) {
     const [type] = useAgentAvatarType();
     if (type === 'maiz') return <ChagraAgentAvatarMaiz {...props} />;
     if (type === 'colibri_svg') return <ChagraAgentAvatarColibri {...props} />;
-    // default + 'colibri' → avatar foto-realista (reemplaza el R3F).
-    return <ChagraAgentAvatarColibriPhoto {...props} />;
+    // default (+ slug histórico 'colibri') → Angelita, el agente de Chagra.
+    return <ChagraAgentAvatarAngelita {...props} />;
 }

--- a/src/components/ChagraAgentAvatarAngelita.jsx
+++ b/src/components/ChagraAgentAvatarAngelita.jsx
@@ -1,0 +1,76 @@
+import Angelita from '../visual/agente/Angelita';
+
+/**
+ * ChagraAgentAvatarAngelita — Angelita (la abeja angelita, Tetragonisca
+ * angustula) como CARA del agente de Chagra en todos los call-sites del
+ * avatar (FAB, chat, header, hero).
+ *
+ * Decisión del operador (2026-07-16): "Angelita como el agente, jubila el
+ * colibrí". El colibrí NO desaparece del código — sigue de decoración
+ * (polinizador en los mundos 3D, `colibri_svg` como preferencia explícita) —
+ * pero deja de ser el asistente.
+ *
+ * Adaptador puro: traduce la API histórica del avatar del agente
+ * (state 'idle'|'thinking'|'speaking'|'listening', glow, withLabel,
+ * onClick/onDoubleClick) al vocabulario de estados de Angelita
+ * (angelitaEstados.js). Cero lógica nueva de agente.
+ *
+ * Español de Colombia (usted), sin voseo. SVG + CSS: liviano, sin three.
+ */
+
+/* API histórica → estados conversacionales de Angelita. Un state desconocido
+   cae a 'acompana' (estadoCanonico ya es tolerante, esto solo documenta). */
+const ESTADO_DE_STATE = {
+    idle: 'acompana',
+    thinking: 'pensando',
+    speaking: 'respondiendo',
+    listening: 'escuchando',
+};
+
+export default function ChagraAgentAvatarAngelita({
+    state = 'idle',
+    size = 48,
+    withLabel = false,
+    onClick,
+    onDoubleClick,
+    glow = false,
+    className = '',
+    ariaLabel = 'Chagra IA',
+}) {
+    const estado = ESTADO_DE_STATE[state] || 'acompana';
+    const abeja = (
+        <Angelita
+            estado={estado}
+            size={size}
+            className={`${glow ? 'agt-avatar-glow ' : ''}${className}`.trim() || undefined}
+            title={ariaLabel}
+        />
+    );
+
+    const contenido = withLabel ? (
+        <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+            {abeja}
+            <span style={{ font: '600 0.7rem/1 system-ui, sans-serif', color: '#94a3b8' }}>
+                Angelita
+            </span>
+        </span>
+    ) : abeja;
+
+    // Paridad con los avatares hermanos: con handlers, botón real (teclado +
+    // lector de pantalla); sin handlers, solo el dibujo.
+    if (onClick || onDoubleClick) {
+        return (
+            <button
+                type="button"
+                onClick={onClick}
+                onDoubleClick={onDoubleClick}
+                aria-label={ariaLabel}
+                title={ariaLabel}
+                style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', lineHeight: 0 }}
+            >
+                {contenido}
+            </button>
+        );
+    }
+    return contenido;
+}

--- a/src/components/Settings/AgentAvatarSelector.jsx
+++ b/src/components/Settings/AgentAvatarSelector.jsx
@@ -1,30 +1,32 @@
 import { Check } from 'lucide-react';
 import useAgentAvatarType from '../../hooks/useAgentAvatarType';
 import ChagraAgentAvatarColibri from '../ChagraAgentAvatarColibri';
-import ChagraAgentAvatarColibriPhoto from '../ChagraAgentAvatarColibriPhoto';
+import ChagraAgentAvatarAngelita from '../ChagraAgentAvatarAngelita';
 import ChagraAgentAvatarMaiz from '../ChagraAgentAvatarMaiz';
 
 /**
  * AgentAvatarSelector — selector visual para el avatar del agente IA.
  *
- * 3 opciones: colibrí foto-realista (default), colibrí ilustrado SVG,
- * o planta de maíz. Persiste vía useAgentAvatarType (localStorage
+ * 3 opciones: Angelita la abeja (default), colibrí ilustrado SVG, o planta
+ * de maíz. Persiste vía useAgentAvatarType (localStorage
  * `chagra:agent-avatar-type`). Cambio inmediato — afecta a todas las
  * instancias del avatar en la app.
  *
- * 2026-05-28: la opción 'colibri' foto-realista reemplaza al R3F que
- * el operador rechazó. La ilustración SVG sigue accesible bajo
- * 'colibri_svg' para quien prefiera el estilo botánico anterior.
+ * 2026-07-16 (operador): "Angelita como el agente, jubila el colibrí". La
+ * opción default pasa a ser Angelita; conserva el slug guardado 'colibri'
+ * (default histórico) para que nadie necesite migración. El colibrí
+ * ilustrado sigue disponible como preferencia explícita.
  */
 export default function AgentAvatarSelector() {
     const [type, setType] = useAgentAvatarType();
 
     const OPTIONS = [
         {
+            // Slug histórico 'colibri' = el default de siempre; hoy es Angelita.
             id: 'colibri',
-            label: 'Colibrí real',
-            sub: 'Foto biopunk (recomendado)',
-            Component: ChagraAgentAvatarColibriPhoto,
+            label: 'Angelita, la abeja',
+            sub: 'La vecina que sabe de finca (recomendado)',
+            Component: ChagraAgentAvatarAngelita,
         },
         {
             id: 'colibri_svg',

--- a/src/components/Settings/__tests__/AgentAvatarSelector.smoke.test.jsx
+++ b/src/components/Settings/__tests__/AgentAvatarSelector.smoke.test.jsx
@@ -7,16 +7,16 @@ describe('AgentAvatarSelector smoke', () => {
         localStorage.clear();
     });
 
-    it('renderiza 3 opciones colibri-real + colibri-svg + maiz', () => {
+    it('renderiza 3 opciones angelita + colibri-svg + maiz', () => {
         render(<AgentAvatarSelector />);
-        expect(screen.getByText('Colibrí real')).toBeInTheDocument();
+        expect(screen.getByText('Angelita, la abeja', { selector: 'p' })).toBeInTheDocument();
         expect(screen.getByText('Colibrí ilustrado')).toBeInTheDocument();
         expect(screen.getByText('Planta de maíz')).toBeInTheDocument();
     });
 
-    it('colibri-real seleccionado por default', () => {
+    it('angelita (slug historico colibri) seleccionada por default', () => {
         render(<AgentAvatarSelector />);
-        const colibriBtn = screen.getByText('Colibrí real').closest('button');
+        const colibriBtn = screen.getByText('Angelita, la abeja', { selector: 'p' }).closest('button');
         expect(colibriBtn).toHaveAttribute('aria-pressed', 'true');
     });
 
@@ -26,7 +26,7 @@ describe('AgentAvatarSelector smoke', () => {
         fireEvent.click(maizBtn);
         expect(maizBtn).toHaveAttribute('aria-pressed', 'true');
         expect(localStorage.getItem('chagra:agent-avatar-type')).toBe('maiz');
-        const colibriBtn = screen.getByText('Colibrí real').closest('button');
+        const colibriBtn = screen.getByText('Angelita, la abeja', { selector: 'p' }).closest('button');
         expect(colibriBtn).toHaveAttribute('aria-pressed', 'false');
     });
 

--- a/src/components/__tests__/AgentFab.temas-fase2.test.jsx
+++ b/src/components/__tests__/AgentFab.temas-fase2.test.jsx
@@ -17,10 +17,12 @@ vi.mock('../../config/fincaVivaHomeFlag', () => ({
   fincaVivaHomePerfilActivo: () => flagOn,
 }));
 
-// El avatar es pesado (foto/video/stores). Lo stubbeamos: solo nos importa la
-// CHROME del botón (piel por tema), no el contenido del avatar.
-vi.mock('../ChagraAgentAvatar', () => ({
+// El avatar (Angelita, 2026-07-16: "jubila el colibrí") arrastra el kit
+// rubber-hose completo. Lo stubbeamos: solo nos importa la CHROME del botón
+// (piel por tema), no el contenido del avatar.
+vi.mock('../../visual/agente/Angelita', () => ({
   default: () => <span data-testid="avatar-stub" />,
+  Angelita: () => <span data-testid="avatar-stub" />,
 }));
 
 import AgentFab from '../AgentFab';

--- a/src/prodApp/ProdChagraApp.jsx
+++ b/src/prodApp/ProdChagraApp.jsx
@@ -495,13 +495,20 @@ export default function ProdChagraApp() {
           {toast.message}
         </div>
       )}
-      {/* Angelita — asistente vivo en TODA pantalla, igual que el shell clasico
-          (App.jsx:3574). Se oculta solo donde estorbaria: loading, login y el
-          callback de oauth. */}
-      {/* En TODAS las pantallas (orden del operador). Solo se oculta mientras
-          el estado de auth aun no se resolvio, para no parpadear al arrancar. */}
-      {currentView !== 'loading' && (
-        <AgentFab onNavigate={navigate} />
+      {/* Angelita — el agente vivo en TODA pantalla (orden del operador
+          2026-07-16: "Angelita como el agente, jubila el colibrí"). Recibe
+          `pantalla` (currentView) para que al tocarla el saludo del agente
+          sea sobre ESA pantalla (saludoPantalla.js). Se oculta solo donde
+          estorba: cargando (parpadeo de auth), el propio agente (ya está
+          ella en grande), la escucha de voz, los mockups de diseño y el
+          onboarding guiado — mismo criterio del shell clásico (App.jsx). */}
+      {currentView !== 'loading'
+        && currentView !== 'agente'
+        && currentView !== 'voz'
+        && !currentView.startsWith('mockup_')
+        && !currentView.startsWith('onboarding')
+        && (
+        <AgentFab onNavigate={navigate} pantalla={currentView} />
       )}
       <NetworkStatusBar />
     </Suspense>

--- a/src/prodApp/ProdChagraApp.jsx
+++ b/src/prodApp/ProdChagraApp.jsx
@@ -33,6 +33,10 @@ import { stop as stopAllAudio } from '../services/ttsService.js';
 
 import ChagraGrowLoader from '../components/ChagraGrowLoader';
 const LoginScreen = lazy(() => import('../components/LoginScreen.jsx'));
+// Angelita viva en TODA pantalla: App.jsx la monta global y prod nunca lo hizo.
+// El asistente existia, con idle-cerebro, ritmo propio, mirada y lip-sync — y en
+// produccion no aparecia en ninguna de las 48 pantallas.
+const AgentFab = lazy(() => import('../components/AgentFab.jsx'));
 const OAuthCallback = lazy(() => import('../components/OAuthCallback.jsx'));
 
 // ── Mapa de lazy components (generado del manifiesto) ─────────────
@@ -490,6 +494,14 @@ export default function ProdChagraApp() {
         >
           {toast.message}
         </div>
+      )}
+      {/* Angelita — asistente vivo en TODA pantalla, igual que el shell clasico
+          (App.jsx:3574). Se oculta solo donde estorbaria: loading, login y el
+          callback de oauth. */}
+      {/* En TODAS las pantallas (orden del operador). Solo se oculta mientras
+          el estado de auth aun no se resolvio, para no parpadear al arrancar. */}
+      {currentView !== 'loading' && (
+        <AgentFab onNavigate={navigate} />
       )}
       <NetworkStatusBar />
     </Suspense>

--- a/src/services/__tests__/saludoPantalla.test.js
+++ b/src/services/__tests__/saludoPantalla.test.js
@@ -1,0 +1,48 @@
+/**
+ * saludoPantalla — el saludo contextual de Angelita por pantalla.
+ *
+ * Contratos:
+ *   - pantalla mapeada → saludo en usted, terminado en pregunta o invitación.
+ *   - mundos de cultivo comparten plantilla (cambia la mata).
+ *   - seguimiento_* paramétrico cae al saludo de seguimiento.
+ *   - pantalla desconocida / vacía / no-string → null (el greeting de siempre
+ *     sigue mandando — cero regresión para rutas sin saludo propio).
+ *   - tono: nunca voseo (ni "vos", ni "tenés"), nunca tuteo en los saludos.
+ */
+import { describe, it, expect } from 'vitest';
+import { saludoDePantalla } from '../saludoPantalla';
+
+describe('saludoDePantalla', () => {
+  it('pantallas clave tienen saludo propio', () => {
+    expect(saludoDePantalla('semilla')).toMatch(/semillas/i);
+    expect(saludoDePantalla('sierra_global')).toMatch(/altura/i);
+    expect(saludoDePantalla('compost')).toMatch(/compostera/i);
+    expect(saludoDePantalla('valle3d')).toMatch(/finca/i);
+  });
+
+  it('mundos de cultivo usan la plantilla con su mata', () => {
+    expect(saludoDePantalla('cafe')).toMatch(/el café/);
+    expect(saludoDePantalla('uchuva')).toMatch(/la uchuva/);
+  });
+
+  it('seguimiento paramétrico cae al saludo de proceso', () => {
+    expect(saludoDePantalla('seguimiento_reforestacion')).toBe(saludoDePantalla('seguimiento'));
+  });
+
+  it('desconocida, vacía o no-string → null (sin regresión)', () => {
+    expect(saludoDePantalla('pantalla_inventada_xyz')).toBeNull();
+    expect(saludoDePantalla('')).toBeNull();
+    expect(saludoDePantalla(null)).toBeNull();
+    expect(saludoDePantalla(undefined)).toBeNull();
+    expect(saludoDePantalla(42)).toBeNull();
+  });
+
+  it('tono: usted, sin voseo ni tuteo', () => {
+    const rutas = ['semilla', 'cafe', 'compost', 'agua', 'animales_gallinas', 'valle3d', 'sierra_global'];
+    for (const r of rutas) {
+      const s = saludoDePantalla(r);
+      expect(s).toBeTruthy();
+      expect(s).not.toMatch(/\bvos\b|tenés|querés|podés|\btu\b|\bte\b/i);
+    }
+  });
+});

--- a/src/services/proactiveGreeting.js
+++ b/src/services/proactiveGreeting.js
@@ -50,7 +50,7 @@ const HORAS = {
   night: 'Buenas noches',
 };
 
-function saludoPorHora(date = new Date()) {
+export function saludoPorHora(date = new Date()) {
   const h = date.getHours();
   if (h >= 5 && h < 12) return HORAS.morning;
   if (h >= 12 && h < 18) return HORAS.afternoon;

--- a/src/services/saludoPantalla.js
+++ b/src/services/saludoPantalla.js
@@ -1,0 +1,158 @@
+/*
+ * saludoPantalla — el saludo CONTEXTUAL de Angelita según la pantalla.
+ *
+ * Cuando el campesino toca a Angelita (AgentFab) estando en una pantalla,
+ * ella no saluda genérico: pregunta por LO QUE ESTÁ VIENDO. En #semilla
+ * ofrece ayuda con la germinación; en el mundo del café, con el café; en la
+ * sierra, con lo que se da a su altura. Compañía que entiende dónde está.
+ *
+ * SOLO datos + un resolver puro (testeable, cero react). El shell prod pasa
+ * `currentView` al FAB; el FAB lo manda como `initialContext.desdePantalla`;
+ * AgentScreen resuelve aquí el saludo y lo pinta como greeting de entrada.
+ * Pantalla no mapeada → null → el flujo de saludo de siempre (pendientes /
+ * idea contextual) queda intacto.
+ *
+ * TONO (regla de la casa): español de Colombia, USTED, campesino, corto y
+ * en pregunta — invita a hablar, no sermonea. Nunca voseo.
+ */
+
+/* Mundos de cultivo: comparten plantilla — cambia la mata. */
+const CULTIVOS = {
+  cafe: 'el café',
+  cacao: 'el cacao',
+  platano: 'el plátano y el banano',
+  aguacate: 'el aguacate',
+  citricos: 'los cítricos',
+  cana: 'la caña',
+  mango: 'el mango',
+  uchuva: 'la uchuva',
+  frutales: 'los frutales',
+  hortalizas: 'las hortalizas',
+  tuberculos: 'los tubérculos',
+  aromaticas: 'las aromáticas',
+  botica: 'las plantas de botica',
+  fique: 'el fique',
+  quinua: 'la quinua',
+  milpa_cultivo: 'la milpa',
+};
+
+/* Saludos por ruta exacta (rutasProdChagraApp.js — rutas #sin-barra). */
+const SALUDOS = {
+  // ── El valle (home) y las vistas 3D ──
+  valle3d: '¿Qué quiere revisar de su finca hoy? Cuénteme qué vio.',
+  valle3d_noche: '¿Pendiente de la finca a esta hora? Cuénteme qué necesita.',
+  valle3d_lluvia: '¿Lo cogió la lluvia? Si quiere miramos qué le conviene al cultivo con esta agua.',
+  ventana_valle: '¿Qué quiere revisar de su finca hoy? Cuénteme qué vio.',
+  sierra_global: '¿Le cuento qué se da bien a la altura de su finca?',
+  bosque_vivo: '¿Hablamos del bosque? Le puedo contar cómo se recupera un rastrojo.',
+  montana_mundos: '¿Para cuál mundo va? Si duda, dígame qué cultiva y le señalo el camino.',
+  mundo_cultivos: '¿De cuál cultivo quiere hablar? Dígame cuál tiene sembrado.',
+
+  // ── Semillas, siembra y ciclos ──
+  semilla: '¿Le ayudo con sus semillas? Germinación, selección o cómo guardarlas.',
+  germinacion: '¿Cómo van sus germinados? Si algo no le nace, miramos por qué.',
+  sembrar: '¿Qué está pensando sembrar? Le ayudo a escoger el momento y el lugar.',
+  ciclo: '¿Le explico el ciclo de la mata? Pregúnteme por la etapa que quiera.',
+  ciclo_vivo: '¿Le explico el ciclo de la mata? Pregúnteme por la etapa que quiera.',
+  ciclo_nutrientes: '¿Hablamos de cómo circulan los nutrientes en su finca?',
+  calendario_finca: '¿Miramos qué le toca hacer en la finca por estas fechas?',
+  ano_finca: '¿Miramos cómo va el año de su finca? Le cuento qué viene.',
+  almanaque: '¿Consultamos el almanaque? Luna, siembra y cosecha por estas fechas.',
+
+  // ── Cosecha y venta ──
+  cosechar: '¿Cómo le fue con la cosecha? Si quiere la registramos juntos.',
+  mi_cosecha: '¿Revisamos su cosecha? Le ayudo a sacarle cuentas.',
+  poscosecha: '¿Le ayudo con el manejo después de la cosecha, para que no se le dañe?',
+  almacenamiento: '¿Hablamos de cómo guardar bien lo cosechado?',
+  momento_venta: '¿Le ayudo con la venta? Precios, presentación o a quién ofrecerle.',
+  mercado: '¿Le ayudo con el mercado? Qué llevar, cómo presentarlo, a cómo venderlo.',
+  mercados: '¿Buscando dónde vender? Miramos juntos las opciones.',
+
+  // ── Agua, suelo y abonos ──
+  agua: '¿Le ayudo con el agua de su finca? Riego, reservorios o la lluvia que viene.',
+  diorama_agua: '¿Le cuento cómo camina el agua por su finca?',
+  suelo: '¿Hablamos de su suelo? Cuénteme cómo lo ve, o qué le preocupa.',
+  salud_suelo: '¿Revisamos la salud de su suelo? Dígame qué síntomas le ve.',
+  diorama_suelo: '¿Le cuento qué vive dentro de su suelo?',
+  cromatografia: '¿Le explico qué dice la cromatografía de su suelo?',
+  subsuelo: '¿Hablamos de la vida de abajo? Lombrices, hongos y raíces.',
+  diorama_microfauna: '¿Le presento los bichitos que le trabajan el suelo gratis?',
+  compost: '¿Cómo va su compostera? Si huele feo o no calienta, lo revisamos.',
+  diorama_compost: '¿Le explico cómo se cocina un buen compost?',
+  estiercol: '¿Le ayudo a aprovechar el estiércol de sus animales?',
+  biopreparados: '¿Preparamos algo? Dígame qué quiere controlar o nutrir y le doy la receta.',
+  fermentos: '¿Le ayudo con sus fermentos? Dosis, tiempos o cómo saber si quedó bueno.',
+  diorama_fermentos: '¿Le explico cómo trabajan los fermentos? Pregunte sin pena.',
+  nutricion: '¿Hablamos de la comida de sus matas? Abonos, deficiencias y remedios.',
+
+  // ── Animales ──
+  animales: '¿Hablamos de sus animales? Cuénteme cómo los ve.',
+  animales_gallinas: '¿Algo de sus gallinas? Postura, alimento o salud.',
+  diorama_gallinero: '¿Le ayudo con el gallinero? Manejo, postura o sanidad.',
+  animales_abejas: '¿Hablamos de abejas? De eso sí le sé — soy una angelita.',
+  diorama_abejas: '¿Hablamos de abejas? De eso sí le sé — soy una angelita.',
+  animales_vacas: '¿Algo de su ganado? Pastos, ordeño o sanidad.',
+  animales_conejos: '¿Algo de sus conejos? Manejo, cría o alimento.',
+  animales_caprinos: '¿Algo de sus cabras? Manejo, leche o sanidad.',
+
+  // ── Sanidad y clima ──
+  sanidad_sintoma: '¿Vio algo raro en una mata? Descríbamelo y miramos qué puede ser.',
+  reportar_invasora: '¿Vio una planta que no cuadra? Le ayudo a identificarla.',
+  toxicologia: '¿Duda con algún producto? Miramos si es seguro y cómo se usa.',
+  clima_boletin: '¿Le explico el boletín del clima y qué significa para su finca?',
+
+  // ── Páramo, bosque y biodiversidad ──
+  glaciar: '¿Le cuento cómo va el páramo y por qué importa para su agua?',
+  glaciar_historial: '¿Miramos cómo ha cambiado el glaciar con los años?',
+  diorama_paramo: '¿Le cuento del páramo? De allá baja el agua de su finca.',
+  restauracion: '¿Hablamos de restaurar? Le cuento por dónde se empieza.',
+  biodiversidad: '¿Le cuento qué aliados viven en su finca sin cobrarle?',
+  asociaciones: '¿Le ayudo a escoger qué sembrar junto a qué? Hay matas que se cuidan entre ellas.',
+  aliados_finca: '¿Le presento los aliados de su finca? Cada uno le trabaja gratis.',
+
+  // ── Registro y seguimiento ──
+  bitacora: '¿Le ayudo a apuntar lo que vio hoy en la finca?',
+  observacion: '¿Qué observó? Cuéntemelo y lo dejamos anotado.',
+  registro_unificado: '¿Qué quiere registrar? Yo le ayudo a dejarlo bien apuntado.',
+  hoy_finca: '¿Repasamos lo de hoy en su finca? Le cuento qué hay pendiente.',
+  seguimiento: '¿Miramos cómo va su proceso? Le ayudo con el paso que sigue.',
+  procesos: '¿Le ayudo con alguno de sus procesos? Dígame cuál.',
+  activos: '¿Buscamos algo de sus matas o animales? Dígame cuál.',
+  bodega: '¿Revisamos su bodega? Insumos, herramientas o lo cosechado.',
+  insumos: '¿Le ayudo con los insumos? Qué le falta o qué puede preparar usted mismo.',
+  mantenimiento: '¿Qué toca mantener? Le ayudo a organizar la tarea.',
+
+  // ── Aprender y acompañamiento ──
+  aprende: '¿Qué quiere aprender hoy? Pregúnteme sin pena.',
+  curso: '¿Le ayudo con el curso? Si algo no quedó claro, lo repasamos.',
+  faq: '¿No encuentra la respuesta? Pregúnteme directo, para eso estoy.',
+  extensionista: '¿Le ayudo con sus casos de campo? Dígame cuál lo tiene pensando.',
+  casos: '¿Revisamos sus casos? Le ayudo a priorizar.',
+  dashboard: '¿Miramos cómo va su finca? Le cuento qué veo en los números.',
+  evolucion: '¿Le cuento cómo ha evolucionado su finca? Los números hablan.',
+  informes: '¿Le ayudo a leer sus informes? Le traduzco los números a decisiones.',
+  mapa: '¿Miramos el mapa? Le ayudo a ubicar lotes, aguas o siembras.',
+};
+
+/**
+ * Saludo contextual de Angelita para una pantalla dada.
+ *
+ * @param {string|null|undefined} pantalla — currentView del shell (ruta #sin-barra).
+ * @returns {string|null} el saludo en usted, o null si la pantalla no tiene
+ *   saludo propio (el greeting de siempre sigue mandando).
+ */
+export function saludoDePantalla(pantalla) {
+  if (!pantalla || typeof pantalla !== 'string') return null;
+  const p = pantalla.trim().toLowerCase();
+  if (!p) return null;
+  if (SALUDOS[p]) return SALUDOS[p];
+  // Mundos de cultivo: misma plantilla, cambia la mata.
+  if (CULTIVOS[p]) return `¿Algo sobre ${CULTIVOS[p]}? Siembra, plagas, cosecha — lo que necesite.`;
+  // Seguimientos paramétricos (seguimiento_reforestacion, …) — genérico de proceso.
+  if (p.startsWith('seguimiento')) return SALUDOS.seguimiento;
+  // Mundo genérico (ruta 'mundo' con data) — ofrezca el cultivo en general.
+  if (p === 'mundo') return SALUDOS.mundo_cultivos;
+  return null;
+}
+
+export default saludoDePantalla;

--- a/src/services/spatialAgentContext.js
+++ b/src/services/spatialAgentContext.js
@@ -58,6 +58,9 @@ export function buildSpatialContextPin(spatialContext) {
     mundoId: cleanText(spatialContext.mundoId, 80),
     hotspotActivo: cleanText(spatialContext.hotspotActivo),
     clima: cleanText(spatialContext.clima, 40),
+    // Pantalla 2D de origen (AgentFab → currentView): el agente sabe DESDE
+    // dónde le hablan aunque no venga de un mundo 3D (p. ej. '#semilla').
+    pantalla: cleanText(spatialContext.pantalla, 60),
     estadoFinca: cleanEstadoFinca(spatialContext.estadoFinca),
   };
 

--- a/src/visual/agente/Angelita.jsx
+++ b/src/visual/agente/Angelita.jsx
@@ -1,0 +1,561 @@
+import { useEffect, useRef, useState } from 'react';
+import './angelita-agente.css';
+import { AbejaAngelita } from '../creatures/AbejaAngelita.jsx';
+import { RH_INK, RH_CHEEK } from '../creatures/_rubberhose.jsx';
+import { ABEJA_PALETA } from '../creatures/abejaIdentidad.js';
+import {
+  estadoCanonico,
+  POSE_DE_ESTADO,
+  ARIA_DE_ESTADO,
+  nivelDeConfianza,
+  elegirMomentoIdle,
+  duracionDeMomento,
+} from './angelitaEstados.js';
+
+/*
+ * ANGELITA — EL CUERPO DEL AGENTE DE CHAGRA.
+ *
+ * La inteligencia que le responde al campesino deja de ser texto: es Angelita,
+ * la abeja angelita (Tetragonisca angustula, meliponino nativo SIN aguijón) —
+ * noble, sabia, cercana, campesina. NO mascota corporativa: una vecina que
+ * sabe de la finca, que se posa a escuchar, que piensa buscando en su memoria,
+ * que gesticula al responder y que DICE cuando no sabe (Chagra valora la
+ * honestidad sobre la alucinación).
+ *
+ * Este componente es SOLO el cuerpo con su API de estados — cero lógica de
+ * agente. El host (chat, voz, tutorial) le dice qué está pasando y ella lo
+ * ENCARNA:
+ *
+ *   <Angelita estado="pensando" />
+ *   <Angelita estado="respondiendo" visema={visema} confianza={0.9} />
+ *   <Angelita estado="no-se" confianza="baja" />
+ *
+ * ESTADOS (angelitaEstados.js — acepta sinónimos):
+ *   acompana     → idle VIVO: flota, respira (boil), mira alrededor, antics.
+ *                  Es la AbejaAngelita de siempre: viva aunque nadie hable.
+ *   escuchando   → se posa (reposo), ladea la cabeza hacia usted; la voz
+ *                  humana entra en ondas de tinta.
+ *   pensando     → burbuja de pensamiento con recuerdos de la finca (hoja,
+ *                  gota, flor) que hojea; bracito a la barbilla; mirada arriba.
+ *   respondiendo → habla (lip-sync por `visema` de useLipSync) y gesticula;
+ *                  su voz sale en ondas de MIEL (ámbar).
+ *   contenta     → brinca celebrando (pose celebra) con chispas doradas.
+ *   preocupada   → alerta honesta: cejas fruncidas, gota de sudor, aro coral
+ *                  que late, vibración inquieta. Para plaga/sequía/riesgo.
+ *   no-se        → LA HONESTA: se encoge de hombros con las palmas arriba y
+ *                  un "?" dibujado a mano. Sonríe: no saber no la avergüenza.
+ *   senala       → guía: se inclina y apunta (pose señala) con destello en
+ *                  el punto señalado.
+ *   invita       → guía: se inclina hacia usted y hace "venga" con la manita.
+ *
+ * CONFIANZA (modo científico): `confianza` acepta 0..1 o 'alta'|'media'|'baja'.
+ * Se dibuja como ANILLO DE CERTEZA alrededor del cuerpo: continuo y sereno si
+ * está segura; punteado girando si es parcial; entrecortado, titilante y con
+ * puntos suspensivos si duda. null (default) = sin anillo — nada cambia para
+ * quien no maneja confianza.
+ *
+ * REUTILIZA, NO REDIBUJA: el cuerpo es la AbejaAngelita aprobada (inline) con
+ * su identidad (abejaIdentidad.js), su kit rubber-hose y sus poses; las capas
+ * del agente (halo, burbuja, ondas, cejas, chispas, signos) se dibujan ALREDEDOR
+ * en el mismo lenguaje: tinta cálida RH_INK, squash & stretch, overshoot,
+ * follow-through. La cadencia vive en `angelita-agente.css` (clases agt-*) con
+ * los gates de la casa: reduced-motion congela en fotograma digno; tier 'bajo'
+ * corta lo continuo decorativo y conserva el feedback de estado.
+ *
+ * ═══ V2 — LA VIDA (lo que separa una vecina de un logo) ═════════════════════
+ *
+ * 1. IDLE-CEREBRO (solo en acompana): un reloj con jitter hojea el repertorio
+ *    de MOMENTOS_IDLE — mira alrededor, sigue una mota de vilano que pasa, se
+ *    acicala la antena, se rasca, sacude las alas, y de vez en cuando SE POSA
+ *    (aterriza con peso, respira plegadita, despega con impulso). Nunca repite
+ *    el mismo gesto dos veces; entre gesto y gesto vuelve al vuelo sereno.
+ *    Los micro-gestos son la vida: existe aunque nadie le hable.
+ *
+ * 2. FÍSICA DE VUELO: el wrapper `.agt-vuelo` deriva en figura-8 con banqueo
+ *    (la abeja se ladea hacia donde va y el cuerpo la sigue con retraso —
+ *    inercia, no flotador); el aterrizaje ANTICIPA, cae con peso y amortigua
+ *    con squash; el despegue se agacha para coger impulso. Las alas llevan un
+ *    velo de motion-blur (solo tier alto/medio).
+ *
+ * 3. LA MIRADA: las pupilas SIGUEN el puntero/dedo de usted cuando anda cerca
+ *    (data-agt-mira='usted', vars --agt-mx/--agt-my puestas por rAF) y lo
+ *    sueltan a los ~2s para volver a sus dardeos naturales. El parpadeo lleva
+ *    ritmo PROPIO por instancia (duración y fase con azar al montar: dos
+ *    Angelitas jamás parpadean al tiempo — el metrónomo delataba al robot).
+ *    Además cada estado ACTÚA con los ojos: contacto visual franco en no-sé,
+ *    ojos clavados en el POI (con chequeo a usted) en senala, buscar la
+ *    palabra arriba al responder, achinaditos de dicha en contenta.
+ *
+ * 4. TRANSICIONES: al cambiar de estado el wrapper se remonta (key=estado) y
+ *    reproduce UNA anticipación (se recoge con squash, rebasa, asienta) antes
+ *    del loop del estado — los cambios fluyen, no saltan. La burbuja del
+ *    pensar nace elástica desde su colita y el "?" del no-sé se dibuja a mano.
+ *
+ * Todos los sistemas nuevos respetan los gates: animated=false los apaga,
+ * prefers-reduced-motion los apaga (JS incluido), tier 'bajo' apaga scheduler,
+ * seguimiento de mirada, deriva y blur — el feedback de estado permanece.
+ *
+ * Tier-safe: SVG + CSS transform/opacity, cero deps nuevas, cero three.
+ */
+
+/* El escenario del agente: la abeja (viewBox propio '-15 -15 32 30') más aire
+   arriba para la burbuja de pensamiento y alrededor para halo/ondas/destellos. */
+const VIEWBOX = '-23 -30 46 46';
+
+/* La voz de cada quien tiene su color: la de USTED llega en tinta (línea), la
+   de ANGELITA sale en miel (ámbar). Detalle que se lee sin explicarse. */
+const COLOR_VOZ_HUMANA = RH_INK;
+const COLOR_VOZ_MIEL = ABEJA_PALETA.cuerpo;
+const COLOR_CERTEZA = ABEJA_PALETA.cabeza;   // el dorado claro de su cabeza
+const COLOR_ALERTA = '#e0745a';              // coral de alerta (pariente del RH_CHEEK)
+const CREMA_PAPEL = '#fffaf0';               // el papel de la burbuja (blanco de ojo)
+
+/* Gotita (sudor de preocupación / recuerdo de agua) — lágrima rubber-hose. */
+const GOTA_D = 'M0,-1.1 C0.75,-0.15 0.75,0.55 0,1.05 C-0.75,0.55 -0.75,-0.15 0,-1.1 Z';
+/* Chispa de 4 puntas (polen dorado que estalla cuando celebra / destello POI). */
+const CHISPA_D = 'M0,-2 L0.55,-0.55 L2,0 L0.55,0.55 L0,2 L-0.55,0.55 L-2,0 L-0.55,-0.55 Z';
+
+/* ── Recuerdos de la finca (lo que hojea al PENSAR): hoja, agua, flor ────────
+   Mini-íconos en el mismo trazo de la familia; viven dentro de la burbuja. */
+function RecuerdoHoja() {
+  return (
+    <g transform="rotate(-26)">
+      <ellipse rx="1.7" ry="0.95" fill="#6a994e" stroke={RH_INK} strokeWidth="0.4" />
+      <path d="M-1.4,0 L1.4,0" stroke="#3f5d33" strokeWidth="0.35" strokeLinecap="round" />
+    </g>
+  );
+}
+function RecuerdoGota() {
+  return <path d={GOTA_D} transform="scale(1.35)" fill={ABEJA_PALETA.gota} stroke={RH_INK} strokeWidth="0.32" />;
+}
+function RecuerdoFlor() {
+  const petalos = [[0, -0.95], [0.9, -0.29], [0.56, 0.77], [-0.56, 0.77], [-0.9, -0.29]];
+  return (
+    <g>
+      {petalos.map(([x, y], i) => (
+        <circle key={i} cx={x * 1.15} cy={y * 1.15} r="0.68" fill={RH_CHEEK} stroke={RH_INK} strokeWidth="0.3" />
+      ))}
+      <circle r="0.62" fill={COLOR_CERTEZA} stroke={RH_INK} strokeWidth="0.3" />
+    </g>
+  );
+}
+const RECUERDOS = [RecuerdoHoja, RecuerdoGota, RecuerdoFlor];
+
+/* ── La VIDA: helpers del idle-cerebro y de la mirada ───────────────────────── */
+
+/* ¿El usuario pidió quietud? Los sistemas JS (scheduler, seguimiento) se apagan
+   igual que las animaciones CSS — la dignidad de la calma es de TODO el cuerpo. */
+function prefiereQuietud() {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/* Estados en los que Angelita LO MIRA a usted si su puntero/dedo anda cerca.
+   En pensando manda su mirada pensativa; en preocupada/no-se/senala, la
+   actuación del estado (el problema, sus ojos francos, el POI). */
+const ESTADOS_QUE_LO_MIRAN = new Set(['acompana', 'escuchando', 'respondiendo', 'invita']);
+
+/* Hasta dónde "se da cuenta" del puntero (px) y cuánto sostiene la mirada
+   después del último movimiento antes de soltarlo (ms). */
+const RADIO_DE_ATENCION = 340;
+const SUELTA_MIRADA_MS = 1900;
+
+/* Mota de vilano (semillita voladora) — lo que la distrae en el momento
+   'distraida': una pelusa que cruza el aire y ella despide con los ojos.
+   El viaje lo pone el CSS (.agt-mota); aquí solo el dibujo, en el trazo de
+   la casa: tinta cálida, tres pelitos y su semilla. */
+function MotaDeVilano() {
+  return (
+    <g className="agt-mota" aria-hidden="true">
+      <path
+        d="M0,0 L-1.15,-1.7 M0,0 L0.1,-2 M0,0 L1.2,-1.55"
+        stroke={RH_INK} strokeWidth="0.28" strokeLinecap="round" opacity="0.7"
+      />
+      <circle r="0.5" fill={RH_INK} opacity="0.62" />
+    </g>
+  );
+}
+
+/**
+ * Angelita — el cuerpo visible del agente de Chagra. Solo arte: el host cablea
+ * la inteligencia y este componente la ENCARNA por estados.
+ *
+ * @param {Object} props
+ * @param {string} [props.estado='acompana']  estado conversacional (o sinónimo).
+ * @param {number|string|null} [props.confianza=null]  0..1 o 'alta'|'media'|'baja'.
+ * @param {'derecha'|'izquierda'} [props.direccion='derecha']  hacia dónde mira/
+ *   señala/invita (izquierda = espejo del dibujo completo).
+ * @param {number} [props.size=96]
+ * @param {string} [props.className]
+ * @param {boolean} [props.animated=true]  false = fotograma digno.
+ * @param {string|null} [props.visema]  'V1'..'V4' de useLipSync (respondiendo).
+ * @param {string} [props.tier]  'alto'|'medio'|'bajo' (gama baja recorta).
+ * @param {Object|null} [props.clima]  passthrough al cuerpo (clima real).
+ * @param {string} [props.enso]
+ * @param {string} [props.animo]  pisa el ánimo derivado del estado.
+ * @param {number} [props.energia]
+ * @param {string|null} [props.mundoId]  su herramienta por mundo (PropEnMano).
+ * @param {boolean} [props.lineBoil]  contorno que hierve (momentos heroicos).
+ * @param {string} [props.title]  pisa la narración aria derivada del estado.
+ */
+export function Angelita({
+  estado = 'acompana',
+  confianza = null,
+  direccion = 'derecha',
+  size = 96,
+  className = '',
+  animated = true,
+  visema = null,
+  tier = undefined,
+  clima = null,
+  enso = 'neutro',
+  animo = undefined,
+  energia = 1,
+  mundoId = null,
+  lineBoil = false,
+  title = undefined,
+  ...rest
+}) {
+  const e = estadoCanonico(estado);
+  const vivo = animated;
+  const nivel = nivelDeConfianza(confianza);
+  const pose = POSE_DE_ESTADO[e];
+  const svgRef = useRef(null);
+
+  /* ═══ RITMO PROPIO DE PARPADEO — una vez al montar: duración y fase con azar
+     para que cada instancia parpadee a SU aire (CSS las consume como vars). */
+  const [ritmoPropio] = useState(() => ({
+    '--agt-blink-dur': `${(4.9 + Math.random() * 1.7).toFixed(2)}s`,
+    '--agt-blink-delay': `${(-Math.random() * 5).toFixed(2)}s`,
+  }));
+
+  /* ═══ IDLE-CEREBRO (solo acompana) — el reloj con jitter que hojea el
+     repertorio de micro-gestos. flota → gesto → flota…; posa encadena
+     posada → despega. Gates: animated, estado, tier bajo, reduced-motion. */
+  const idleActivo = vivo && e === 'acompana' && tier !== 'bajo';
+  const [momento, setMomento] = useState('flota');
+  useEffect(() => {
+    if (!idleActivo || prefiereQuietud()) return undefined;
+    let timer = 0;
+    let ultimoGesto = null;
+    const programar = (nombre) => {
+      setMomento(nombre);
+      timer = window.setTimeout(() => {
+        if (nombre === 'posa') { programar('posada'); return; }
+        if (nombre === 'posada') { programar('despega'); return; }
+        if (nombre === 'flota') {
+          ultimoGesto = elegirMomentoIdle(ultimoGesto);
+          programar(ultimoGesto);
+          return;
+        }
+        programar('flota'); // todo gesto vuelve al vuelo sereno
+      }, duracionDeMomento(nombre));
+    };
+    // Arranca al próximo tick (nunca setState síncrono dentro del effect);
+    // siempre desde el vuelo sereno, por si quedó un momento viejo colgado.
+    timer = window.setTimeout(() => programar('flota'), 0);
+    return () => window.clearTimeout(timer);
+  }, [idleActivo]);
+
+  /* ═══ LA MIRADA QUE LO RECONOCE — si su puntero/dedo anda cerca, las pupilas
+     lo siguen (data-agt-mira='usted' + vars --agt-mx/--agt-my); al quedarse
+     quieto ~2s lo suelta y vuelve a sus dardeos naturales. DOM directo vía ref
+     (React no administra estos attrs): cero re-renders por mover el mouse. */
+  const sigueUsted = vivo && tier !== 'bajo' && ESTADOS_QUE_LO_MIRAN.has(e);
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!sigueUsted || !svg || prefiereQuietud()) return undefined;
+    let raf = 0;
+    let soltar = 0;
+    let px = 0;
+    let py = 0;
+    const signo = direccion === 'izquierda' ? -1 : 1; // el espejo voltea la x
+    const liberar = () => svg.removeAttribute('data-agt-mira');
+    const mirar = () => {
+      raf = 0;
+      const r = svg.getBoundingClientRect();
+      if (!r.width) return;
+      // Sus ojos viven arriba del centro del lienzo (la cabeza, no el tronco).
+      const dx = px - (r.left + r.width / 2);
+      const dy = py - (r.top + r.height * 0.4);
+      if (Math.hypot(dx, dy) > RADIO_DE_ATENCION) { liberar(); return; }
+      // Deflexión de pupila en unidades del viewBox (misma amplitud ~0.55 del
+      // dardeo natural); saturada a ~150px — más lejos ya es "mirar hacia allá".
+      const mx = Math.max(-1, Math.min(1, dx / 150)) * 0.55 * signo;
+      const my = Math.max(-1, Math.min(1, dy / 150)) * 0.42;
+      svg.style.setProperty('--agt-mx', `${mx.toFixed(3)}px`);
+      svg.style.setProperty('--agt-my', `${my.toFixed(3)}px`);
+      svg.setAttribute('data-agt-mira', 'usted');
+      window.clearTimeout(soltar);
+      soltar = window.setTimeout(liberar, SUELTA_MIRADA_MS);
+    };
+    const onMove = (ev) => {
+      px = ev.clientX;
+      py = ev.clientY;
+      if (!raf) raf = window.requestAnimationFrame(mirar);
+    };
+    window.addEventListener('pointermove', onMove, { passive: true });
+    window.addEventListener('pointerdown', onMove, { passive: true });
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerdown', onMove);
+      if (raf) window.cancelAnimationFrame(raf);
+      window.clearTimeout(soltar);
+      liberar();
+      svg.style.removeProperty('--agt-mx');
+      svg.style.removeProperty('--agt-my');
+    };
+  }, [sigueUsted, direccion]);
+
+  // El estado tiñe el ánimo del cuerpo base (aura/antics) salvo que el host
+  // mande el suyo: contenta brilla 'pleno', preocupada se pone 'atento'.
+  const animoDelEstado = animo ?? (e === 'contenta' ? 'pleno' : e === 'preocupada' ? 'atento' : 'sereno');
+  const aria = title ?? (ARIA_DE_ESTADO[e] + (nivel === 'baja' ? ' (con dudas)' : ''));
+  // Clase de animación solo cuando está viva; quieta = opacidad digna inline.
+  const cls = (c) => (vivo ? c : undefined);
+
+  /* ═══ CAPA FONDO: el anillo de certeza (confianza) + aro de alerta ═══════ */
+  const halo = nivel ? (
+    <g aria-hidden="true">
+      <circle
+        className={`agt-halo-${nivel}`}
+        cx="1" cy="-1" r="15"
+        fill="none"
+        stroke={COLOR_CERTEZA}
+        strokeWidth="1"
+        strokeLinecap="round"
+        strokeDasharray={nivel === 'media' ? '4.6 3' : nivel === 'baja' ? '1.8 4' : undefined}
+        opacity={nivel === 'baja' ? 0.45 : 0.55}
+      />
+      {/* La duda también se dice: puntos suspensivos junto a su cabeza. */}
+      {nivel === 'baja' && (
+        <g fill={RH_INK} opacity="0.75">
+          <circle className={cls('agt-duda-punto')} cx="15" cy="-7.8" r="0.7" />
+          <circle className={cls('agt-duda-punto')} style={{ animationDelay: '-0.7s' }} cx="16.8" cy="-9.4" r="0.6" />
+          <circle className={cls('agt-duda-punto')} style={{ animationDelay: '-1.4s' }} cx="18.3" cy="-11.2" r="0.5" />
+        </g>
+      )}
+    </g>
+  ) : null;
+  // Preocupada: un aro coral late detrás del cuerpo — alerta que se siente,
+  // no sirena. (Detrás: nunca compite con la carita.)
+  const aroAlerta = e === 'preocupada' ? (
+    <circle
+      className={cls('agt-alerta')}
+      cx="1" cy="-1" r="12.4"
+      fill="none" stroke={COLOR_ALERTA} strokeWidth="1.1"
+      opacity={vivo ? undefined : 0.3}
+      aria-hidden="true"
+    />
+  ) : null;
+
+  /* ═══ SEÑALES DE CARA (dentro de .agt-cuerpo: se mueven CON ella) ════════
+     Coordenadas en el espacio de la abeja: cabeza (8.6,-1) r4.4; ojos en
+     (10.1,-1.9) y (7.4,-2.2); las cejas van justo encima. */
+  const caraPreocupada = e === 'preocupada' ? (
+    <g aria-hidden="true">
+      {/* cejas fruncidas: las puntas internas suben — preocupación, no rabia */}
+      <g stroke={RH_INK} strokeWidth="0.85" strokeLinecap="round" fill="none">
+        <path d="M6.1,-4.5 L8,-5.2" />
+        <path d="M9.1,-5.3 L11.4,-4.5" />
+      </g>
+      {/* gota de sudor que brota de la sien y escurre */}
+      <g transform="translate(5.1 -4.4)">
+        <path
+          className={cls('agt-sudor')}
+          d={GOTA_D}
+          fill={ABEJA_PALETA.gota}
+          stroke={RH_INK}
+          strokeWidth="0.35"
+          opacity={vivo ? undefined : 0.85}
+        />
+      </g>
+    </g>
+  ) : null;
+  const caraNoSe = e === 'no-se' ? (
+    <g stroke={RH_INK} strokeWidth="0.8" strokeLinecap="round" fill="none" aria-hidden="true">
+      {/* una ceja arqueada y la otra tranquila: honestidad curiosa, sin pena */}
+      <path d="M5.9,-5.2 Q7.3,-6.1 8.6,-5.3" />
+      <path d="M9.5,-4.8 L11.3,-4.7" />
+    </g>
+  ) : null;
+
+  /* ═══ CAPA AIRE: lo que flota alrededor (burbuja, ondas, signos) ═════════ */
+  // PENSANDO — burbuja de pensamiento con colita, tres puntos que laten y los
+  // recuerdos de la finca que va hojeando (quieta u en tier bajo: solo el 1º).
+  const recuerdosVisibles = vivo ? RECUERDOS : RECUERDOS.slice(0, 1);
+  const burbuja = e === 'pensando' ? (
+    <g className={cls('agt-burbuja')} aria-hidden="true">
+      <circle cx="10.8" cy="-11.6" r="0.85" fill={CREMA_PAPEL} stroke={RH_INK} strokeWidth="0.7" />
+      <circle cx="12.2" cy="-14.6" r="1.35" fill={CREMA_PAPEL} stroke={RH_INK} strokeWidth="0.8" />
+      <ellipse cx="13.6" cy="-21.4" rx="7" ry="5.6" fill={CREMA_PAPEL} stroke={RH_INK} strokeWidth="1.1" />
+      {/* lo que está repasando: la mata, el agua, la flor */}
+      <g transform="translate(13.6 -22.8)">
+        {recuerdosVisibles.map((Recuerdo, i) => (
+          <g key={i} className={cls('agt-recuerdo')} style={vivo ? { animationDelay: `${i * -1.8}s` } : undefined}>
+            <Recuerdo />
+          </g>
+        ))}
+      </g>
+      {/* el latido del pensar */}
+      <g fill={RH_INK}>
+        <circle className={cls('agt-piensa-punto')} cx="10.9" cy="-18.4" r="1" />
+        <circle className={cls('agt-piensa-punto')} style={{ animationDelay: '0.22s' }} cx="13.6" cy="-18.4" r="1" />
+        <circle className={cls('agt-piensa-punto')} style={{ animationDelay: '0.44s' }} cx="16.3" cy="-18.4" r="1" />
+      </g>
+    </g>
+  ) : null;
+  // ESCUCHANDO — la voz de usted entra en ondas de tinta, hacia ella.
+  const ondasIn = e === 'escuchando' ? (
+    <g stroke={COLOR_VOZ_HUMANA} strokeWidth="1" strokeLinecap="round" fill="none" aria-hidden="true">
+      {[0, -2.8, -5.4].map((dx, i) => (
+        <path
+          key={i}
+          className={cls('agt-onda-in')}
+          style={vivo ? { animationDelay: `${i * -0.63}s` } : undefined}
+          opacity={vivo ? undefined : 0.4}
+          d={`M${-15.8 + dx},-6.4 q2.8,4.9 0,10.6`}
+        />
+      ))}
+    </g>
+  ) : null;
+  // RESPONDIENDO — su voz sale en ondas de miel, desde la boquita.
+  const ondasOut = e === 'respondiendo' ? (
+    <g stroke={COLOR_VOZ_MIEL} strokeWidth="1.05" strokeLinecap="round" fill="none" aria-hidden="true">
+      {[0, 2.3, 4.6].map((dx, i) => (
+        <path
+          key={i}
+          className={cls('agt-onda-out')}
+          style={vivo ? { animationDelay: `${i * -0.53}s` } : undefined}
+          opacity={vivo ? undefined : 0.4}
+          d={`M${14.4 + dx},-2.4 q2.9,4 0,8.2`}
+        />
+      ))}
+    </g>
+  ) : null;
+  // CONTENTA — chispas de polen dorado que estallan al compás del brinco.
+  const CHISPAS_POS = [[-11.5, -8.5], [13, -12], [16.5, 2.5], [-13.5, 3.5], [-3, -13.5], [9.5, 11.5]];
+  const chispas = e === 'contenta' ? (
+    <g fill={COLOR_CERTEZA} stroke={RH_INK} strokeWidth="0.3" aria-hidden="true">
+      {CHISPAS_POS.map(([x, y], i) => (
+        <path
+          key={i}
+          className={cls('agt-chispa')}
+          style={vivo ? { animationDelay: `${i * -0.19}s` } : undefined}
+          opacity={vivo ? undefined : 0.55}
+          transform={`translate(${x} ${y}) scale(${0.8 + (i % 3) * 0.25})`}
+          d={CHISPA_D}
+        />
+      ))}
+    </g>
+  ) : null;
+  // NO-SÉ — el "?" dibujado a mano, con wobble de line-boil (steps, no péndulo).
+  // Al entrar al estado se DIBUJA de un trazo (pathLength=1 + dashoffset en el
+  // CSS) y el puntico cae al final — honestidad que se escribe delante de usted.
+  const signoNoSe = e === 'no-se' ? (
+    <g className={cls('agt-nose-signo')} aria-hidden="true">
+      <path
+        pathLength="1"
+        d="M11.8,-19.2 Q11.7,-22 14.3,-21.8 Q16.6,-21.5 15.9,-19.3 Q15.5,-18 14.2,-17.4 Q13.5,-17 13.5,-15.9"
+        stroke={RH_INK} strokeWidth="1.25" fill="none" strokeLinecap="round"
+      />
+      <circle cx="13.5" cy="-13.8" r="0.85" fill={RH_INK} />
+    </g>
+  ) : null;
+  // La MOTA DE VILANO que la distrae (momento 'distraida' del idle): cruza el
+  // aire una sola vez y Angelita la despide con los ojos y la cabeza (CSS).
+  const mota = (vivo && e === 'acompana' && momento === 'distraida')
+    ? <MotaDeVilano />
+    : null;
+  // SEÑALA — el destello donde apunta (abajo-derecha, donde cae su bracito).
+  const destelloPoi = e === 'senala' ? (
+    <g
+      className={cls('agt-poi')}
+      transform="translate(16 10.5)"
+      opacity={vivo ? undefined : 0.7}
+      aria-hidden="true"
+    >
+      <circle r="2.9" fill="none" stroke={COLOR_CERTEZA} strokeWidth="0.7" opacity="0.7" />
+      <path d={CHISPA_D} fill={COLOR_CERTEZA} stroke={RH_INK} strokeWidth="0.35" />
+    </g>
+  ) : null;
+  // INVITA — estelas del "venga": arcos que viajan HACIA ella.
+  const estelasInvita = e === 'invita' ? (
+    <g stroke={COLOR_VOZ_MIEL} strokeWidth="0.95" strokeLinecap="round" fill="none" aria-hidden="true">
+      {[0, 2.4].map((dx, i) => (
+        <path
+          key={i}
+          className={cls('agt-venga-onda')}
+          style={vivo ? { animationDelay: `${i * -0.7}s` } : undefined}
+          opacity={vivo ? undefined : 0.4}
+          d={`M${16.4 + dx},-3.2 q-2.2,3.4 0,6.6`}
+        />
+      ))}
+    </g>
+  ) : null;
+
+  /* ═══ MONTAJE ═════════════════════════════════════════════════════════════
+     fondo (halo/alerta) → vuelo (la física: deriva, aterrizaje, entrada de
+     estado) → cuerpo (abeja + señales de cara, UN wrapper que los estados
+     mueven junto) → aire (burbuja, ondas, chispas, signos, la mota).
+     `.agt-vuelo` va con key=estado: al cambiar de estado se REMONTA y su
+     animación de entrada (anticipación → overshoot → asienta) vuelve a correr
+     — la transición fluye en vez de saltar. direccion 'izquierda' espeja TODO
+     el dibujo (señala/invita hacia el otro lado); el ritmo propio de parpadeo
+     viaja como CSS vars. */
+  const espejo = direccion === 'izquierda' ? { transform: 'scaleX(-1)' } : null;
+  const estilo = { ...ritmoPropio, ...espejo };
+  return (
+    <svg
+      ref={svgRef}
+      viewBox={VIEWBOX}
+      width={size}
+      height={size}
+      className={className ? `agt-angelita ${className}` : 'agt-angelita'}
+      style={estilo}
+      role="img"
+      aria-label={aria}
+      data-agente="angelita"
+      data-agt-estado={e}
+      data-agt-vivo={vivo ? '1' : undefined}
+      data-agt-idle={idleActivo ? momento : undefined}
+      data-agt-confianza={nivel || undefined}
+      data-tier={tier || undefined}
+      {...rest}
+    >
+      <title>{aria}</title>
+      {halo}
+      {aroAlerta}
+      <g className="agt-vuelo" key={e}>
+        <g className="agt-cuerpo">
+          <AbejaAngelita
+            inline
+            animated={vivo}
+            pose={pose}
+            visema={visema}
+            tier={tier}
+            clima={clima}
+            enso={enso}
+            animo={animoDelEstado}
+            energia={energia}
+            mundoId={mundoId}
+            lineBoil={lineBoil}
+          />
+          {caraPreocupada}
+          {caraNoSe}
+        </g>
+      </g>
+      {burbuja}
+      {ondasIn}
+      {ondasOut}
+      {chispas}
+      {signoNoSe}
+      {destelloPoi}
+      {estelasInvita}
+      {mota}
+    </svg>
+  );
+}
+
+export default Angelita;

--- a/src/visual/agente/angelita-agente.css
+++ b/src/visual/agente/angelita-agente.css
@@ -889,3 +889,19 @@
     transition: none;
   }
 }
+
+/* ═══ GLOW "RESPUESTA LISTA" (avatar del agente, task #122) ═══════════════════
+   El aviso ámbar que antes ponía el porthole del FAB ahora vive en el propio
+   cuerpo: drop-shadow que late, mismo ámbar #FFB700 de la campana. Con
+   reduced-motion queda el aviso FIJO (visible, sin latido). */
+.agt-avatar-glow {
+  filter: drop-shadow(0 0 7px rgb(255 183 0 / 0.75));
+  animation: agt-avatar-glow-late 2.6s ease-in-out infinite;
+}
+@keyframes agt-avatar-glow-late {
+  0%, 100% { filter: drop-shadow(0 0 5px rgb(255 183 0 / 0.55)); }
+  50% { filter: drop-shadow(0 0 11px rgb(255 183 0 / 0.9)); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .agt-avatar-glow { animation: none; }
+}

--- a/src/visual/agente/angelita-agente.css
+++ b/src/visual/agente/angelita-agente.css
@@ -1,0 +1,891 @@
+/* ─── ANGELITA, EL CUERPO DEL AGENTE — cadencia de sus estados conversacionales.
+   SVG + CSS puros, solo transform/opacity (GPU, Android gama baja), misma
+   gramática rubber-hose de creatures.css (anticipación, overshoot, follow-
+   through, nada lineal). El DIBUJO vive en Angelita.jsx; aquí SOLO el tiempo.
+
+   CONTRATO DE GATES (idéntico al de la familia):
+   - Las capas del agente animan solo con [data-agt-vivo='1'] (animated).
+   - reduced-motion congela TODO en fotograma digno (las señales de estado
+     — cejas, burbuja, ondas, halo — quedan visibles, quietas).
+   - [data-tier='bajo'] corta lo continuo decorativo (halo girando, recuerdos,
+     gesticulación) y CONSERVA el feedback de estado (ondas, chispas, gestos).
+
+   Los overrides a piezas internas de la abeja (.crt-brazo-*, .rh-mirada) van
+   SIEMPRE detrás de [data-agente='angelita'][data-agt-vivo='1'] — dos atributos
+   de especificidad: pisan el sway/mirada base del kit sin tocar creatures.css.
+
+   V2 — LA VIDA. Tres sistemas nuevos, todos gateados igual que el resto:
+   · `.agt-vuelo` (física): entrada de estado con anticipación (one-shot que se
+     replaya porque el wrapper se remonta con key=estado), deriva en figura-8
+     con banqueo e inercia en acompana, aterrizaje/despegue con peso.
+   · [data-agt-idle=…] (idle-cerebro): los micro-gestos del repertorio
+     MOMENTOS_IDLE — las duraciones de estos one-shot deben COINCIDIR con las
+     de angelitaEstados.js (el scheduler suelta el atributo cuando el gesto
+     cierra en identidad).
+   · [data-agt-mira='usted'] (la mirada): las pupilas siguen el puntero vía
+     vars --agt-mx/--agt-my; la regla vive al FINAL del archivo para ganar el
+     empate de especificidad contra la actuación de mirada por estado. */
+
+/* ═══ EL CUERPO (wrapper que carga abeja + señales de cara) ══════════════════
+   Las señales pegadas a la cara (cejas, gota de sudor) viven DENTRO de
+   .agt-cuerpo: cuando el estado mueve el cuerpo, mueve TAMBIÉN sus señales
+   (nunca cejas flotando despegadas). En esos estados el CSS apaga el boil/
+   antics internos y la emoción la pone este wrapper. */
+.agt-cuerpo {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+
+/* ═══ EL VUELO (física: entrada, deriva con inercia, peso) ═══════════════════
+   `.agt-vuelo` envuelve a `.agt-cuerpo`: capa de POSICIÓN (dónde está en el
+   aire), separada de la capa de GESTO (qué hace el cuerpo). Así la deriva, el
+   aterrizaje y la entrada de estado componen con los gestos sin pisarse. */
+.agt-vuelo {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+
+/* ENTRADA DE ESTADO — cada cambio de estado remonta el wrapper (key=estado) y
+   esta anticipación corre UNA vez: se recoge (squash), rebasa hacia el gesto
+   nuevo y asienta. Las transiciones fluyen; nada aparece en seco. */
+[data-agt-vivo='1'] .agt-vuelo {
+  animation: agt-entra 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) 1;
+}
+@keyframes agt-entra {
+  0%   { transform: translateY(0) scale(1, 1); }
+  30%  { transform: translateY(0.85px) scale(1.06, 0.91); }  /* anticipa: se recoge */
+  68%  { transform: translateY(-0.7px) scale(0.965, 1.05); } /* rebasa hacia el gesto */
+  100% { transform: translateY(0) scale(1, 1); }
+}
+
+/* DERIVA (solo acompana) — vuelo con INERCIA: figura-8 lenta con banqueo (se
+   ladea hacia donde va) y bolsillos de gravedad (cae un pelo al cambiar de
+   rumbo — el aire pesa, no es un flotador). Arranca después de la entrada. */
+[data-agt-vivo='1'][data-agt-estado='acompana'] .agt-vuelo {
+  animation:
+    agt-entra 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) 1,
+    agt-deriva 13s ease-in-out 0.5s infinite;
+}
+@keyframes agt-deriva {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  12%  { transform: translate(0.8px, -0.7px) rotate(2.2deg); }    /* rumbo derecha: banquea */
+  25%  { transform: translate(1.2px, 0.15px) rotate(0.6deg); }    /* bolsillo: cae un pelo */
+  38%  { transform: translate(0.3px, -1.1px) rotate(-1.6deg); }   /* remonta a la izquierda */
+  52%  { transform: translate(-0.9px, -0.5px) rotate(-2.5deg); }  /* banquea al otro lado */
+  64%  { transform: translate(-1.25px, 0.35px) rotate(-0.7deg); } /* deja caer el peso */
+  78%  { transform: translate(-0.5px, -0.9px) rotate(1.5deg); }   /* retoma altura */
+  90%  { transform: translate(0.2px, -0.35px) rotate(1.1deg); }
+}
+/* El cuerpo SIGUE al vuelo con retraso (follow-through): mismo período que la
+   deriva pero contra-rotación suave y 0.7s tarde — la cabeza dirige, el cuerpo
+   la alcanza. Solo en el vuelo sereno (flota); los momentos ponen el suyo. */
+[data-agt-vivo='1'][data-agt-estado='acompana'][data-agt-idle='flota'] .agt-cuerpo {
+  animation: agt-cuerpo-sigue 13s ease-in-out 1.2s infinite;
+}
+@keyframes agt-cuerpo-sigue {
+  0%, 100% { transform: rotate(0deg); }
+  12%  { transform: rotate(-1.3deg); }
+  25%  { transform: rotate(-0.2deg); }
+  38%  { transform: rotate(0.9deg); }
+  52%  { transform: rotate(1.5deg); }
+  64%  { transform: rotate(0.4deg); }
+  78%  { transform: rotate(-1deg); }
+  90%  { transform: rotate(-0.6deg); }
+}
+
+/* Las alitas de tul BORRONEAN de verdad: un velo de motion-blur (unidades del
+   viewBox: ~0.5px de pantalla en un avatar de 96). Es la única capa raster del
+   agente; tier bajo la corta al final del archivo, y posada la apaga (alas
+   plegadas y quietas se ven nítidas). */
+[data-agente='angelita'][data-agt-vivo='1'] .crt-wing {
+  filter: blur(0.24px);
+}
+/* Plegadas no borronean: en escuchando (pose reposo) el tul se ve nítido —
+   el blur es firma de VELOCIDAD, no maquillaje. (posada lo apaga más abajo.) */
+[data-agente='angelita'][data-agt-estado='escuchando'] .crt-wing {
+  filter: none;
+}
+
+/* El parpadeo lleva RITMO PROPIO por instancia (vars con azar que estampa
+   Angelita.jsx al montar): dos Angelitas jamás parpadean al tiempo, y ninguna
+   parpadea como metrónomo entre sesiones. */
+[data-agente='angelita'] .rh-blink {
+  animation-duration: var(--agt-blink-dur, 5.6s);
+  animation-delay: var(--agt-blink-delay, 0s);
+}
+
+/* ═══ EL IDLE VIVO — los micro-gestos del acompana ([data-agt-idle]) ══════════
+   Una criatura que EXISTE aunque nadie le hable. El scheduler pone el atributo
+   el tiempo exacto del one-shot; cada gesto cierra en identidad para que el
+   empalme con el vuelo sereno no salte. Mientras hay gesto, los antics del kit
+   (vuelta de campana, saltitos) callan: el gesto lee limpio. */
+[data-agente='angelita'][data-agt-idle]:not([data-agt-idle='flota']) .rh-antic,
+[data-agente='angelita'][data-agt-idle]:not([data-agt-idle='flota']) .rh-travieso {
+  animation: none;
+}
+
+/* MIRA ALREDEDOR — curiosa: los ojos van PRIMERO (¿allá?… ¿o allá?) y la
+   cabeza los sigue con retraso — las pupilas anticipan el movimiento. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='mira'] .rh-mirada {
+  animation: agt-idle-mira 2.6s ease-in-out 1;
+}
+@keyframes agt-idle-mira {
+  0%, 100% { transform: translate(0, 0); }
+  10%, 30% { transform: translate(-0.6px, -0.1px); }   /* ojos: ¿qué hay allá? */
+  42%, 66% { transform: translate(0.55px, -0.25px); }  /* …¿y allá? */
+  80%  { transform: translate(-0.15px, 0.05px); }
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='mira'] .agt-cuerpo {
+  animation: agt-idle-mira-cuerpo 2.6s ease-in-out 1;
+}
+@keyframes agt-idle-mira-cuerpo {
+  0%, 100% { transform: rotate(0deg); }
+  18%, 34% { transform: rotate(-2.6deg); }  /* la cabeza alcanza a los ojos */
+  50%, 70% { transform: rotate(2.2deg); }
+  84%  { transform: rotate(-0.6deg); }
+}
+
+/* SE DISTRAE — pasa una mota de vilano y la despide con los ojos; la cabeza
+   gira detrás (otra vez: pupilas anticipan, cuerpo sigue). La mota cruza UNA
+   vez y se va con el viento. */
+.agt-mota {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+}
+[data-agt-vivo='1'] .agt-mota {
+  animation: agt-mota-cruza 3.6s ease-in-out 1;
+}
+@keyframes agt-mota-cruza {
+  0%   { transform: translate(-19px, -6px) rotate(0deg); opacity: 0; }
+  12%  { opacity: 0.65; }
+  30%  { transform: translate(-8px, -9.5px) rotate(50deg); }
+  55%  { transform: translate(3px, -6px) rotate(105deg); opacity: 0.6; }
+  80%  { transform: translate(13px, -10.5px) rotate(160deg); opacity: 0.5; }
+  100% { transform: translate(20px, -13.5px) rotate(200deg); opacity: 0; }
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='distraida'] .rh-mirada {
+  animation: agt-sigue-mota 3.6s ease-in-out 1;
+}
+@keyframes agt-sigue-mota {
+  0%   { transform: translate(0, 0); }
+  14%  { transform: translate(-0.65px, -0.15px); }  /* la pilla entrando */
+  55%  { transform: translate(0.1px, -0.35px); }    /* la acompaña de largo */
+  85%  { transform: translate(0.6px, -0.5px); }     /* la despide arriba-derecha */
+  100% { transform: translate(0, 0); }
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='distraida'] .agt-cuerpo {
+  animation: agt-sigue-mota-cuerpo 3.6s ease-in-out 1;
+}
+@keyframes agt-sigue-mota-cuerpo {
+  0%, 100% { transform: rotate(0deg); }
+  26%  { transform: rotate(-2.2deg); }  /* gira tarde hacia donde ya miró */
+  62%  { transform: rotate(1.4deg); }
+  86%  { transform: rotate(2deg); }     /* la sigue con la cabeza al salir */
+}
+
+/* SE ACICALA — aseo de abeja: la manita derecha sube a la antena (rebasa),
+   da dos pasaditas y recoge; la cabeza se agacha hacia la manita y los ojos
+   se van bizcos arriba, mirándose la antena. Vecina, no logo. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='acicala'] .crt-brazo-r {
+  animation: agt-acicala-brazo 3s cubic-bezier(0.4, 0, 0.3, 1.3) 1;
+}
+@keyframes agt-acicala-brazo {
+  0%, 100% { transform: rotate(0deg); }
+  16%  { transform: rotate(-160deg); }  /* sube junto a la antena (rebasa) */
+  24%  { transform: rotate(-147deg); }  /* asienta al borde de la cabecita */
+  34%  { transform: rotate(-156deg); }  /* pasadita 1 */
+  46%  { transform: rotate(-144deg); }
+  56%  { transform: rotate(-154deg); }  /* pasadita 2 */
+  66%  { transform: rotate(-146deg); }
+  86%  { transform: rotate(-4deg); }    /* recoge con follow-through */
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='acicala'] .agt-cuerpo {
+  animation: agt-acicala-cuerpo 3s ease-in-out 1;
+}
+@keyframes agt-acicala-cuerpo {
+  0%, 100% { transform: rotate(0deg) translateY(0); }
+  20%, 64% { transform: rotate(3deg) translateY(0.3px); }  /* agacha la cabeza a la manita */
+  82%  { transform: rotate(-0.8deg) translateY(0); }       /* rebote al soltar */
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='acicala'] .rh-mirada {
+  animation: none;
+  transform: translate(0.4px, -0.45px);  /* bizca, mirándose la antena */
+}
+
+/* SE RASCA — la manita izquierda a la barriguita: ras-ras-ras y suelta con
+   rebote; el cuerpo se recuesta al gusto (squash de satisfacción). */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='rasca'] .crt-brazo-l {
+  animation: agt-rasca-brazo 2.4s cubic-bezier(0.4, 0, 0.3, 1.3) 1;
+}
+@keyframes agt-rasca-brazo {
+  0%, 100% { transform: rotate(0deg); }
+  14%  { transform: rotate(-62deg); }  /* llega a la barriguita (rebasa) */
+  22%  { transform: rotate(-52deg); }
+  30%  { transform: rotate(-60deg); }  /* ras… */
+  38%  { transform: rotate(-51deg); }
+  46%  { transform: rotate(-59deg); }  /* …ras… */
+  54%  { transform: rotate(-52deg); }
+  66%  { transform: rotate(-56deg); }  /* …ras (más lento: qué rico) */
+  88%  { transform: rotate(3deg); }    /* suelta con rebote */
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='rasca'] .agt-cuerpo {
+  animation: agt-rasca-cuerpo 2.4s ease-in-out 1;
+}
+@keyframes agt-rasca-cuerpo {
+  0%, 100% { transform: rotate(0deg) scale(1, 1); }
+  18%, 60% { transform: rotate(-2deg) scale(1.02, 0.97); }  /* se recuesta al gusto */
+  78%  { transform: rotate(0.6deg) scale(0.995, 1.01); }
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='rasca'] .rh-mirada {
+  animation: none;
+  transform: translate(-0.35px, 0.45px);  /* mira lo que se rasca */
+}
+
+/* SACUDE LAS ALAS — escalofrío alegre: se infla, tiembla en ráfaga corta con
+   el aleteo a tope (blur extra) y queda esponjada. Ventana breve, no epilepsia. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='sacude'] .agt-cuerpo {
+  animation: agt-sacude 1.5s ease-in-out 1;
+}
+@keyframes agt-sacude {
+  0%, 100% { transform: rotate(0deg) scale(1, 1); }
+  12%  { transform: rotate(-2deg) scale(0.97, 1.05); }   /* se infla: prepara */
+  20%  { transform: rotate(4deg) scale(1.03, 0.97); }
+  28%  { transform: rotate(-4.5deg) scale(1, 1); }
+  36%  { transform: rotate(4.5deg) scale(1, 1); }
+  44%  { transform: rotate(-3.5deg) scale(1, 1); }
+  52%  { transform: rotate(2.5deg) scale(1, 1); }
+  60%  { transform: rotate(-1.2deg) scale(1, 1); }
+  74%  { transform: rotate(0.4deg) scale(0.99, 1.02); }  /* queda esponjada */
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='sacude'] .crt-wing {
+  animation-duration: 0.06s;
+  filter: blur(0.42px);
+}
+
+/* SE POSA — aterrizar CUESTA: se alza un pelo eligiendo el sitio, baja con
+   peso (ease-in), amortigua con squash y queda abajo (fill forwards empalma
+   con la quietud de 'posada'). Las alitas siguen frenando en el aire. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='posa'] .agt-vuelo {
+  animation: agt-aterriza 1.15s cubic-bezier(0.55, 0, 0.65, 1) 1 forwards;
+}
+@keyframes agt-aterriza {
+  0%   { transform: translateY(0); }
+  18%  { transform: translateY(-1.2px); }  /* se alza: elige el sitio */
+  70%  { transform: translateY(5.9px); }   /* baja con peso */
+  84%  { transform: translateY(5.3px); }   /* amortigua */
+  100% { transform: translateY(5.6px); }
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='posa'] .agt-cuerpo {
+  animation: agt-aterriza-cuerpo 1.15s ease-in-out 1;
+}
+@keyframes agt-aterriza-cuerpo {
+  0%, 45% { transform: scale(1, 1); }
+  62%  { transform: scale(0.955, 1.06); }  /* se estira mientras cae */
+  76%  { transform: scale(1.1, 0.88); }    /* squash del impacto */
+  88%  { transform: scale(0.98, 1.03); }   /* rebote */
+  100% { transform: scale(1, 1); }
+}
+
+/* POSADA — descansa: quieta abajo (transform estático que empalma con el
+   forwards del aterrizaje), alitas PLEGADAS que respiran (reusa el keyframe
+   del kit) y respiración honda de cuerpo. Nítida: sin blur de alas. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='posada'] .agt-vuelo {
+  animation: none;
+  transform: translateY(5.6px);
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='posada'] .agt-cuerpo {
+  animation: agt-posada-respira 4.2s ease-in-out infinite;
+}
+@keyframes agt-posada-respira {
+  0%, 100% { transform: translateY(0) scale(1, 1); }
+  50%  { transform: translateY(-0.35px) scale(0.985, 1.035); }  /* respira hondo */
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='posada'] .crt-wing {
+  animation: crt-wing-reposo 3.6s ease-in-out infinite alternate;
+  filter: none;
+}
+
+/* DESPEGA — coger vuelo cuesta también: se agacha (squash de impulso), salta
+   al aire con stretch, rebasa la altura y asienta en el vuelo sereno. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='despega'] .agt-vuelo {
+  animation: agt-despega 0.95s cubic-bezier(0.34, 1.56, 0.64, 1) 1;
+}
+@keyframes agt-despega {
+  0%   { transform: translateY(5.6px); }
+  22%  { transform: translateY(6.6px); }   /* se agacha: coge impulso */
+  60%  { transform: translateY(-1.6px); }  /* ¡al aire! (rebasa) */
+  80%  { transform: translateY(0.5px); }
+  100% { transform: translateY(0); }
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='despega'] .agt-cuerpo {
+  animation: agt-despega-cuerpo 0.95s cubic-bezier(0.34, 1.56, 0.64, 1) 1;
+}
+@keyframes agt-despega-cuerpo {
+  0%   { transform: scale(1, 1); }
+  22%  { transform: scale(1.1, 0.86); }   /* squash del impulso */
+  55%  { transform: scale(0.9, 1.12); }   /* stretch de subida */
+  80%  { transform: scale(1.02, 0.97); }
+  100% { transform: scale(1, 1); }
+}
+
+/* ── ESCUCHANDO — se posa (pose reposo la pliega) y LADEA la cabeza hacia
+   usted, sosteniendo la atención con un vaivén mínimo (escucha activa, no
+   estatua). El transform base queda como regla: si tier/RM apagan la
+   animación, el ladeo digno permanece. */
+[data-agt-estado='escuchando'] .agt-cuerpo {
+  transform: rotate(-5deg);
+}
+[data-agt-vivo='1'][data-agt-estado='escuchando'] .agt-cuerpo {
+  animation: agt-ladea 4.6s ease-in-out infinite;
+}
+@keyframes agt-ladea {
+  0%, 100% { transform: rotate(-5deg); }
+  12%      { transform: rotate(-6.8deg); }  /* se inclina un pelo más: "ajá…" */
+  22%      { transform: rotate(-4.6deg); }
+  58%      { transform: rotate(-5.6deg); }  /* micro-asentimiento */
+  66%      { transform: rotate(-4.8deg); }
+}
+/* Ondas de la voz humana ENTRANDO (tinta — la voz de usted llega en línea):
+   tres arcos que avanzan hacia ella y se disuelven, escalonados. */
+.agt-onda-in {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+  animation: agt-onda-in 1.9s ease-out infinite;
+}
+@keyframes agt-onda-in {
+  0%   { transform: translateX(0); opacity: 0; }
+  22%  { opacity: 0.55; }
+  70%  { transform: translateX(3.2px); opacity: 0.2; }
+  100% { transform: translateX(4px); opacity: 0; }
+}
+
+/* ── PENSANDO — busca en su memoria. La burbuja flota con bob propio (los
+   globos de pensamiento van despegados del cuerpo, como en los cómics);
+   adentro laten tres puntos y pasan RECUERDOS de la finca (hoja, gota, flor).
+   El bracito derecho sube a la barbilla con overshoot y da golpecitos "hmm";
+   las pupilas se van arriba-derecha, a donde uno mira cuando recuerda.
+   La burbuja NACE elástica desde su colita (el estado la monta al entrar:
+   pop de anticipación una vez) y después flota con su bob. */
+[data-agt-vivo='1'] .agt-burbuja {
+  transform-box: fill-box;
+  transform-origin: 20% 92%;  /* la colita: el pensamiento brota de ella */
+  animation:
+    agt-burbuja-nace 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) 1,
+    agt-burbuja-bob 3.7s ease-in-out 0.5s infinite;
+}
+@keyframes agt-burbuja-nace {
+  0%   { transform: scale(0); opacity: 0; }
+  55%  { transform: scale(1.08); opacity: 1; }  /* brota y rebasa */
+  100% { transform: scale(1); opacity: 1; }
+}
+@keyframes agt-burbuja-bob {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  50%      { transform: translateY(-0.8px) rotate(1.2deg); }
+}
+.agt-piensa-punto {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: agt-piensa-punto 1.35s ease-in-out infinite;
+}
+@keyframes agt-piensa-punto {
+  0%, 100% { transform: scale(0.75); opacity: 0.35; }
+  35%      { transform: scale(1.15); opacity: 1; }   /* late con overshoot */
+  50%      { transform: scale(0.95); opacity: 0.9; }
+}
+/* Recuerdos que se hojean: cada uno visible ~1/3 del ciclo, con una entradita
+   elástica (aparece chiquito, rebasa, asienta) — está REPASANDO, no decorando. */
+.agt-recuerdo {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+  animation: agt-recuerdo 5.4s ease-in-out infinite;
+}
+@keyframes agt-recuerdo {
+  0%   { transform: scale(0.4) rotate(-8deg); opacity: 0; }
+  5%   { transform: scale(1.12) rotate(3deg); opacity: 1; }  /* pop elástico */
+  9%   { transform: scale(0.97) rotate(0deg); opacity: 1; }
+  26%  { transform: scale(1) rotate(0deg); opacity: 1; }     /* lo sostiene, lo mira */
+  32%, 100% { transform: scale(0.5) rotate(6deg); opacity: 0; }
+}
+/* Bracito derecho a la barbilla: sube con overshoot, sostiene y da dos
+   golpecitos pensativos antes de recoger (el gesto universal del "mmm…"). */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='pensando'] .crt-brazo-r {
+  animation: agt-barbilla 4.8s cubic-bezier(0.4, 0, 0.3, 1.3) infinite;
+}
+@keyframes agt-barbilla {
+  0%, 100% { transform: rotate(0deg); }
+  12%  { transform: rotate(-108deg); }  /* sube a la barbilla (rebasa) */
+  19%  { transform: rotate(-96deg); }   /* asienta */
+  40%  { transform: rotate(-96deg); }
+  45%  { transform: rotate(-103deg); }  /* golpecito "hmm" */
+  50%  { transform: rotate(-96deg); }
+  56%  { transform: rotate(-102deg); }  /* segundo golpecito */
+  61%, 84% { transform: rotate(-96deg); } /* sostiene pensando */
+  94%  { transform: rotate(-4deg); }    /* recoge con follow-through */
+}
+/* Pupilas arriba-derecha (recordando), con un chequeo breve al centro — lo
+   mira a usted un instante ("ya casi") y vuelve a su memoria. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='pensando'] .rh-mirada {
+  animation: agt-mirada-pensativa 3.8s ease-in-out infinite;
+}
+@keyframes agt-mirada-pensativa {
+  0%, 12% { transform: translate(0.55px, -0.5px); }
+  48%     { transform: translate(0.4px, -0.55px); }   /* deriva suave: repasa */
+  58%, 66% { transform: translate(0, 0); }            /* lo mira: "ya casi" */
+  78%, 100% { transform: translate(0.55px, -0.5px); }
+}
+
+/* ── RESPONDIENDO — habla (el visema mueve la boquita; lo pone useLipSync) y
+   GESTICULA con las manitas como buena conversadora campesina; el cuerpo
+   marca el énfasis con un bob suave. Su voz sale en ondas de MIEL (ámbar). */
+[data-agt-vivo='1'][data-agt-estado='respondiendo'] .agt-cuerpo {
+  animation: agt-enfasis 2.1s ease-in-out infinite;
+}
+@keyframes agt-enfasis {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  30%      { transform: translateY(-0.55px) rotate(1.4deg); }  /* se alza en el énfasis */
+  62%      { transform: translateY(0.25px) rotate(-0.6deg); }
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='respondiendo'] .crt-brazo-l {
+  animation: agt-gesticula-l 1.7s ease-in-out infinite;
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='respondiendo'] .crt-brazo-r {
+  animation: agt-gesticula-r 1.55s ease-in-out infinite;
+}
+/* Períodos co-primos (1.7 / 1.55): las manitas nunca caen en el mismo compás
+   — conversación viva, no marioneta. */
+@keyframes agt-gesticula-l {
+  0%, 100% { transform: rotate(0deg); }
+  38%      { transform: rotate(16deg); }   /* abre la manita: "vea…" */
+  55%      { transform: rotate(11deg); }   /* asienta (follow-through) */
+  78%      { transform: rotate(14deg); }
+}
+@keyframes agt-gesticula-r {
+  0%, 100% { transform: rotate(0deg); }
+  42%      { transform: rotate(-14deg); }  /* remata la idea */
+  60%      { transform: rotate(-9deg); }
+}
+.agt-onda-out {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+  animation: agt-onda-out 1.6s ease-out infinite;
+}
+@keyframes agt-onda-out {
+  0%   { transform: translateX(0) scale(0.85); opacity: 0; }
+  18%  { opacity: 0.7; }
+  70%  { transform: translateX(3px) scale(1.05); opacity: 0.25; }
+  100% { transform: translateX(3.8px) scale(1.1); opacity: 0; }
+}
+
+/* ── CONTENTA — la pose 'celebra' de la abeja ya brinca (anticipa, salta,
+   aterriza elástica); aquí solo estallan CHISPAS de polen dorado alrededor,
+   sincronizadas con el ciclo del salto (1.15s). */
+.agt-chispa {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+  animation: agt-chispa 1.15s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+}
+@keyframes agt-chispa {
+  0%, 34% { transform: scale(0) rotate(0deg); opacity: 0; }
+  46%  { transform: scale(1.2) rotate(45deg) translateY(-0.8px); opacity: 1; }  /* estalla en el salto */
+  60%  { transform: scale(0.95) rotate(70deg) translateY(-1.6px); opacity: 0.9; }
+  88%, 100% { transform: scale(0.2) rotate(100deg) translateY(-2.6px); opacity: 0; }
+}
+
+/* ── PREOCUPADA — alerta honesta, no pánico: cejas fruncidas y gota de sudor
+   (van DENTRO de .agt-cuerpo: se mueven con ella), un aro coral que pulsa
+   como latido, y una vibración inquieta con ventanas de calma (no epilepsia).
+   El boil/antics internos se apagan (abajo) para que las cejas no se
+   despeguen: la inquietud completa la pone el wrapper. */
+[data-agt-vivo='1'][data-agt-estado='preocupada'] .agt-cuerpo {
+  animation: agt-inquieta 2.6s ease-in-out infinite;
+}
+@keyframes agt-inquieta {
+  0%, 24%, 52%, 100% { transform: translateX(0) rotate(0deg); }
+  28% { transform: translateX(-0.5px) rotate(-1.6deg); }  /* sacudida corta */
+  32% { transform: translateX(0.5px) rotate(1.4deg); }
+  36% { transform: translateX(-0.35px) rotate(-1deg); }
+  40% { transform: translateX(0) rotate(0deg); }          /* …y vuelve la calma */
+  60% { transform: translateY(0.5px) rotate(0.8deg); }    /* se hunde un pelo: pesa */
+  68% { transform: translateY(0) rotate(0deg); }
+}
+.agt-sudor {
+  transform-box: fill-box;
+  transform-origin: center top;
+  animation: agt-sudor 2.2s cubic-bezier(0.5, 0, 0.7, 1) infinite;
+}
+@keyframes agt-sudor {
+  0%   { transform: translateY(0) scale(0.6); opacity: 0; }
+  18%  { transform: translateY(0.2px) scale(1.05); opacity: 0.95; }  /* brota */
+  70%  { transform: translateY(2.4px) scale(1); opacity: 0.8; }      /* escurre */
+  100% { transform: translateY(3.4px) scale(0.4); opacity: 0; }
+}
+.agt-alerta {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: agt-alerta 1.6s ease-in-out infinite;
+}
+@keyframes agt-alerta {
+  0%, 100% { transform: scale(0.97); opacity: 0.18; }
+  38%      { transform: scale(1.02); opacity: 0.5; }   /* latido de alerta */
+}
+
+/* ── NO-SÉ — la honestidad hecha gesto: encoge los hombros (squash del cuerpo
+   hacia arriba) mientras ambas manitas se abren palmas-arriba con overshoot,
+   sostiene el "pues no sé, vea" y suelta. El signo ? flota arriba con line-boil
+   de baja cadencia (steps — dibujado a mano, no péndulo). La sonrisa se queda:
+   no saber NO la avergüenza. */
+[data-agt-vivo='1'][data-agt-estado='no-se'] .agt-cuerpo {
+  animation: agt-encoge 3.6s cubic-bezier(0.4, 0, 0.3, 1.35) infinite;
+}
+@keyframes agt-encoge {
+  0%, 100% { transform: scale(1, 1) translateY(0) rotate(0deg); }
+  18%  { transform: scale(1.05, 0.92) translateY(0.7px) rotate(-1.6deg); }   /* hombros ARRIBA (squash) */
+  26%  { transform: scale(1.02, 0.96) translateY(0.4px) rotate(-2.8deg); }   /* asienta encogida, LADEA la cabeza */
+  68%  { transform: scale(1.02, 0.96) translateY(0.4px) rotate(-2.8deg); }   /* sostiene: "pues no sé, vea…" */
+  82%  { transform: scale(0.985, 1.03) translateY(-0.3px) rotate(0.8deg); }  /* suelta con rebote */
+}
+/* La honestidad se ESCRIBE delante de usted: el "?" se dibuja de un trazo
+   (pathLength=1 en el JSX) y el puntico cae al final, como tiza en tablero. */
+[data-agt-vivo='1'] .agt-nose-signo path {
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  animation: agt-nose-dibuja 0.55s ease-out 0.12s forwards;
+}
+@keyframes agt-nose-dibuja {
+  to { stroke-dashoffset: 0; }
+}
+[data-agt-vivo='1'] .agt-nose-signo circle {
+  opacity: 0;
+  animation: agt-nose-punto 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) 0.66s forwards;
+}
+@keyframes agt-nose-punto {
+  from { opacity: 0; transform: translateY(-0.8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+/* Y las chapetas se quedan ENCENDIDAS: no saber no la avergüenza — sonríe. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='no-se'] .rh-rubor {
+  animation: none;
+  opacity: 0.92;
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='no-se'] .crt-brazo-l {
+  animation: agt-shrug-l 3.6s cubic-bezier(0.4, 0, 0.3, 1.35) infinite;
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='no-se'] .crt-brazo-r {
+  animation: agt-shrug-r 3.6s cubic-bezier(0.4, 0, 0.3, 1.35) infinite;
+}
+@keyframes agt-shrug-l {
+  0%, 100% { transform: rotate(0deg); }
+  18%  { transform: rotate(104deg); }   /* palma arriba (rebasa) */
+  26%  { transform: rotate(91deg); }    /* asienta abierta */
+  68%  { transform: rotate(94deg); }    /* sostiene el gesto */
+  86%  { transform: rotate(-5deg); }    /* recoge (follow-through) */
+}
+@keyframes agt-shrug-r {
+  0%, 100% { transform: rotate(0deg); }
+  18%  { transform: rotate(-96deg); }   /* la otra palma (bajo la carita) */
+  26%  { transform: rotate(-83deg); }
+  68%  { transform: rotate(-86deg); }
+  86%  { transform: rotate(4deg); }
+}
+.agt-nose-signo {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: agt-nose-signo 1.1s steps(2, jump-none) infinite;
+}
+@keyframes agt-nose-signo {
+  0%, 100% { transform: rotate(-3deg) translateY(0); }
+  50%      { transform: rotate(3.5deg) translateY(-0.4px); }
+}
+
+/* ── SEÑALA — la pose 'señala' afinada de la abeja manda (creatures.css);
+   aquí solo se enciende el DESTELLO donde apunta, sincronizado con su ciclo
+   (2.9s): aparece cuando el bracito asienta (~30%) y se apaga al recoger. */
+.agt-poi {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+  animation: agt-poi 2.9s cubic-bezier(0.5, 0, 0.25, 1.4) infinite;
+}
+@keyframes agt-poi {
+  0%, 26% { transform: scale(0) rotate(0deg); opacity: 0; }
+  34%  { transform: scale(1.25) rotate(20deg); opacity: 0.95; }  /* pop al asentar el brazo */
+  42%  { transform: scale(0.95) rotate(28deg); opacity: 0.9; }
+  70%  { transform: scale(1) rotate(40deg); opacity: 0.85; }     /* sostiene con el gesto */
+  84%, 100% { transform: scale(0.3) rotate(55deg); opacity: 0; }
+}
+
+/* ── INVITA — se inclina hacia usted (base como regla: queda aún sin animación)
+   y la manita derecha hace "venga, acérquese" tres veces con overshoot, con
+   estelas que van hacia ella marcando la dirección del convite. */
+[data-agt-estado='invita'] .agt-cuerpo {
+  transform: rotate(3.5deg);
+}
+[data-agt-vivo='1'][data-agt-estado='invita'] .agt-cuerpo {
+  animation: agt-invita-cuerpo 2.8s ease-in-out infinite;
+}
+@keyframes agt-invita-cuerpo {
+  0%, 100% { transform: rotate(0deg); }
+  14%      { transform: rotate(4.6deg); }   /* se inclina invitando (rebasa) */
+  22%, 74% { transform: rotate(3.5deg); }   /* sostiene la inclinación */
+  88%      { transform: rotate(-0.8deg); }  /* rebote al enderezar */
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='invita'] .crt-brazo-r {
+  animation: agt-venga 2.8s cubic-bezier(0.4, 0, 0.3, 1.3) infinite;
+}
+@keyframes agt-venga {
+  0%, 100% { transform: rotate(0deg); }
+  13%  { transform: rotate(-92deg); }   /* alza la manita (rebasa) */
+  20%  { transform: rotate(-74deg); }   /* venga…       */
+  30%  { transform: rotate(-90deg); }
+  38%  { transform: rotate(-74deg); }   /* …venga…      */
+  48%  { transform: rotate(-88deg); }
+  56%  { transform: rotate(-76deg); }   /* …acérquese   */
+  72%  { transform: rotate(-80deg); }   /* sostiene abierta */
+  90%  { transform: rotate(-4deg); }    /* recoge (follow-through) */
+}
+.agt-venga-onda {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+  animation: agt-venga-onda 1.4s ease-in-out infinite;
+}
+@keyframes agt-venga-onda {
+  0%   { transform: translateX(0); opacity: 0; }
+  25%  { opacity: 0.6; }
+  100% { transform: translateX(-3px); opacity: 0; }
+}
+
+/* ═══ HALO DE CONFIANZA (modo científico) ════════════════════════════════════
+   El anillo de certeza alrededor del cuerpo. Que se NOTE cuándo está segura y
+   cuándo duda — honestidad visible, sin leer una cifra:
+   alta  → anillo continuo que respira lento (firme, sereno).
+   media → anillo punteado que gira despacio (evidencia parcial).
+   baja  → anillo entrecortado que titila + puntos suspensivos de duda. */
+[data-agt-vivo='1'] .agt-halo-alta {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: agt-halo-respira 5.2s ease-in-out infinite;
+}
+@keyframes agt-halo-respira {
+  0%, 100% { transform: scale(1); opacity: 0.5; }
+  50%      { transform: scale(1.015); opacity: 0.65; }
+}
+[data-agt-vivo='1'] .agt-halo-media {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: agt-halo-gira 26s linear infinite;
+}
+@keyframes agt-halo-gira {
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+[data-agt-vivo='1'] .agt-halo-baja {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: agt-halo-duda 3.1s ease-in-out infinite;
+}
+@keyframes agt-halo-duda {
+  0%, 100% { transform: rotate(0deg); opacity: 0.5; }
+  22% { transform: rotate(9deg); opacity: 0.2; }      /* titila: no está segura */
+  30% { transform: rotate(6deg); opacity: 0.45; }
+  58% { transform: rotate(-5deg); opacity: 0.25; }    /* vacila al otro lado */
+  70% { transform: rotate(-2deg); opacity: 0.5; }
+}
+.agt-duda-punto {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: agt-duda-punto 2.1s ease-in-out infinite;
+}
+@keyframes agt-duda-punto {
+  0%, 100% { transform: scale(0.7); opacity: 0.25; }
+  40%      { transform: scale(1.1); opacity: 0.85; }
+}
+
+/* ═══ ACTUACIÓN DE MIRADA — los ojos son lo que más humaniza ═════════════════
+   Cada estado actúa TAMBIÉN con las pupilas, sincronizadas al ciclo del gesto
+   del estado (mismo período): la mirada y el cuerpo cuentan una sola cosa. */
+
+/* ESCUCHANDO — lo mira a USTED (la voz entra por la izquierda) sosteniendo el
+   contacto; a mitad del ciclo se le van los ojos un instante (procesa) y
+   vuelven. Período 4.6s = el del ladeo de cabeza. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='escuchando'] .rh-mirada {
+  animation: agt-mirada-escucha 4.6s ease-in-out infinite;
+}
+@keyframes agt-mirada-escucha {
+  0%, 44%, 100% { transform: translate(-0.5px, 0.12px); }  /* en sus ojos: lo escucha */
+  12%  { transform: translate(-0.55px, 0.22px); }          /* micro-asentimiento */
+  52%, 60% { transform: translate(-0.28px, -0.18px); }     /* procesa un instante */
+  68%  { transform: translate(-0.5px, 0.12px); }
+}
+
+/* RESPONDIENDO — conversa con los ojos: lo mira al hablar, busca la palabra
+   arriba un momento (como hace la gente) y vuelve para el remate. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='respondiendo'] .rh-mirada {
+  animation: agt-mirada-habla 3.4s ease-in-out infinite;
+}
+@keyframes agt-mirada-habla {
+  0%, 30%, 100% { transform: translate(-0.42px, 0.1px); }  /* le habla mirándolo */
+  40%, 52% { transform: translate(0.3px, -0.42px); }       /* busca la palabra arriba */
+  62%  { transform: translate(-0.42px, 0.1px); }           /* vuelve para el remate */
+  78%, 86% { transform: translate(-0.5px, 0.18px); }       /* énfasis: se acerca con los ojos */
+}
+
+/* CONTENTA — ojos achinaditos de dicha (el squint vale más que mil chispas),
+   sincronizados con el brinco (1.15s): se cierran en el salto y respiran al
+   caer. Las chapetas encendidas. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='contenta'] .rh-blink {
+  animation: agt-ojos-felices 1.15s ease-in-out infinite;
+}
+@keyframes agt-ojos-felices {
+  0%, 100% { transform: scaleY(0.72); }  /* achinaditos */
+  40%  { transform: scaleY(0.52); }      /* en el salto casi se cierran */
+  62%  { transform: scaleY(0.8); }
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='contenta'] .rh-rubor {
+  animation: none;
+  opacity: 0.95;
+}
+
+/* PREOCUPADA — los ojos van del problema (abajo, la finca) a usted: "¿vio?".
+   La preocupación honesta COMPARTE, no se aísla. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='preocupada'] .rh-mirada {
+  animation: agt-mirada-preocupa 3.9s ease-in-out infinite;
+}
+@keyframes agt-mirada-preocupa {
+  0%, 26%, 100% { transform: translate(0.32px, 0.5px); }  /* mira el problema */
+  36%, 46% { transform: translate(-0.5px, 0.1px); }       /* lo busca a usted: "¿vio?" */
+  56%, 84% { transform: translate(0.35px, 0.48px); }      /* vuelve al problema */
+}
+
+/* NO-SÉ — lo mira DE FRENTE mientras se encoge de hombros: la honestidad
+   sostiene la mirada, no la esquiva. Período 3.6s = el del encogimiento. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='no-se'] .rh-mirada {
+  animation: agt-mirada-nose 3.6s ease-in-out infinite;
+}
+@keyframes agt-mirada-nose {
+  0%, 8% { transform: translate(0, 0); }
+  16%, 72% { transform: translate(-0.5px, 0.15px); }  /* a sus ojos, franca, sin pena */
+  84%, 100% { transform: translate(-0.15px, 0.05px); }
+}
+
+/* SEÑALA — clava los ojos donde apunta el bracito y CHEQUEA con usted a mitad
+   del gesto ("¿sí lo ve?") — la guía de verdad confirma. Período 2.9s. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='senala'] .rh-mirada {
+  animation: agt-mirada-senala 2.9s ease-in-out infinite;
+}
+@keyframes agt-mirada-senala {
+  0%, 100% { transform: translate(0, 0); }
+  16%, 44% { transform: translate(0.6px, 0.55px); }   /* los ojos al punto señalado */
+  54%, 62% { transform: translate(-0.45px, 0.1px); }  /* chequea: "¿sí lo ve?" */
+  70%, 82% { transform: translate(0.6px, 0.55px); }   /* y de vuelta al punto */
+}
+
+/* INVITA — lo mira a usted mientras hace "venga": el convite es de frente.
+   Período 2.8s = el del gesto de la manita. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='invita'] .rh-mirada {
+  animation: agt-mirada-invita 2.8s ease-in-out infinite;
+}
+@keyframes agt-mirada-invita {
+  0%, 100% { transform: translate(-0.2px, 0.05px); }
+  12%, 64% { transform: translate(-0.55px, 0.2px); }  /* en sus ojos: "venga" */
+  78%  { transform: translate(-0.35px, 0.1px); }
+}
+
+/* ═══ LIMPIEZA DE GESTO — los estados del agente PISAN los antics internos ═══
+   Una abeja pensando/preocupada/encogida no da además vueltas de campana ni
+   saltitos traviesos: el gesto lee limpio (mismo criterio de creatures.css con
+   mojada/sed/poses). En preocupada y no-sé se apaga TAMBIÉN el boil: sus
+   señales de cara (cejas, sudor) van pegadas al cuerpo y el wrapper .agt-cuerpo
+   ya pone la emoción — nada se despega. (La mirada de preocupada ya no se
+   apaga: ahora ACTÚA — va del problema a usted, arriba.) */
+[data-agt-estado='pensando'] .rh-antic, [data-agt-estado='pensando'] .rh-travieso,
+[data-agt-estado='respondiendo'] .rh-antic, [data-agt-estado='respondiendo'] .rh-travieso,
+[data-agt-estado='preocupada'] .rh-antic, [data-agt-estado='preocupada'] .rh-travieso,
+[data-agt-estado='no-se'] .rh-antic, [data-agt-estado='no-se'] .rh-travieso,
+[data-agt-estado='invita'] .rh-antic, [data-agt-estado='invita'] .rh-travieso { animation: none; }
+[data-agt-estado='preocupada'] .rh-boil,
+[data-agt-estado='no-se'] .rh-boil { animation: none; }
+
+/* ═══ LA MIRADA QUE LO RECONOCE ([data-agt-mira='usted']) ════════════════════
+   Cuando su puntero/dedo anda cerca, Angelita LO MIRA: las pupilas siguen las
+   vars --agt-mx/--agt-my que estampa el JSX (rAF) con una sacadita elástica
+   (transition con rebase corto — ojo vivo, no cursor). Vive AL FINAL de las
+   reglas de mirada: a igual especificidad, reconocerlo a usted gana sobre la
+   actuación del estado. El JSX solo la activa en estados que lo miran
+   (acompana, escuchando, respondiendo, invita) y la suelta a los ~2s. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-mira='usted'] .rh-mirada {
+  animation: none;
+  transform: translate(var(--agt-mx, 0px), var(--agt-my, 0px));
+  transition: transform 0.16s cubic-bezier(0.3, 1.5, 0.55, 1);
+}
+
+/* ═══ GATES ══════════════════════════════════════════════════════════════════
+   device-tier 'bajo': fuera lo continuo decorativo (halo animado, recuerdos,
+   bob de burbuja, gesticulación, mirada pensativa, vaivén de escucha). El
+   FEEDBACK de estado queda: ondas, puntos del pensar, chispas, gestos de
+   brazo, sudor, alerta, destello POI — el campesino sigue viendo QUÉ hace
+   Angelita, solo que más quieta. */
+[data-tier='bajo'] .agt-halo-alta,
+[data-tier='bajo'] .agt-halo-media,
+[data-tier='bajo'] .agt-halo-baja,
+[data-tier='bajo'] .agt-recuerdo,
+[data-tier='bajo'] .agt-burbuja,
+[data-tier='bajo'][data-agt-estado='escuchando'] .agt-cuerpo,
+[data-tier='bajo'][data-agt-estado='respondiendo'] .agt-cuerpo,
+[data-tier='bajo'][data-agt-estado='respondiendo'] .crt-brazo-l,
+[data-tier='bajo'][data-agt-estado='respondiendo'] .crt-brazo-r,
+[data-tier='bajo'][data-agt-estado='pensando'] .rh-mirada { animation: none; }
+/* Los recuerdos en tier bajo no se hojean: se quedan en el primero, visible. */
+[data-tier='bajo'] .agt-recuerdo { opacity: 0; }
+[data-tier='bajo'] .agt-recuerdo:first-of-type { opacity: 1; }
+/* V2 en tier bajo: fuera la física continua (entrada+deriva del vuelo, la
+   mirada por estado) y el blur de alas (raster). El idle-cerebro y el
+   seguimiento de mirada ya se apagan solos en el JS con el mismo gate. */
+[data-tier='bajo'][data-agt-vivo='1'] .agt-vuelo,
+[data-tier='bajo'] .agt-mota,
+[data-tier='bajo'][data-agente='angelita'][data-agt-vivo='1'] .rh-mirada { animation: none; }
+[data-agente='angelita'][data-tier='bajo'] .crt-wing { filter: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  /* Fotograma digno: TODAS las señales del agente visibles pero quietas. Las
+     capas que nacen invisibles (ondas, chispas, POI) quedan a media luz para
+     que el estado se lea aún sin movimiento. */
+  .agt-cuerpo, .agt-burbuja, .agt-piensa-punto, .agt-recuerdo,
+  .agt-onda-in, .agt-onda-out, .agt-chispa, .agt-sudor, .agt-alerta,
+  .agt-nose-signo, .agt-poi, .agt-venga-onda,
+  .agt-halo-alta, .agt-halo-media, .agt-halo-baja, .agt-duda-punto,
+  .agt-vuelo, .agt-mota,
+  [data-agente='angelita'] .crt-brazo-l,
+  [data-agente='angelita'] .crt-brazo-r,
+  [data-agente='angelita'] .rh-blink,
+  [data-agente='angelita'] .rh-mirada { animation: none !important; }
+  .agt-onda-in, .agt-onda-out, .agt-venga-onda { opacity: 0.45; }
+  .agt-chispa { opacity: 0.7; transform: scale(1); }
+  .agt-poi { opacity: 0.7; transform: scale(1); }
+  .agt-recuerdo { opacity: 0; }
+  .agt-recuerdo:first-of-type { opacity: 1; }
+  /* V2 quieta: la mota ni aparece; las alas nítidas (sin blur); el "?" del
+     no-sé ya dibujado (sin trazo animado, el signo completo y digno). El
+     idle-cerebro y el seguimiento de puntero se apagan en el JS con el mismo
+     matchMedia — aquí solo el seguro de la capa CSS. */
+  .agt-mota { opacity: 0; }
+  [data-agente='angelita'][data-agt-vivo='1'] .crt-wing { filter: none; }
+  [data-agt-vivo='1'] .agt-nose-signo path {
+    animation: none !important;
+    stroke-dasharray: none;
+    stroke-dashoffset: 0;
+  }
+  [data-agt-vivo='1'] .agt-nose-signo circle {
+    animation: none !important;
+    opacity: 1;
+  }
+  [data-agente='angelita'][data-agt-vivo='1'][data-agt-mira='usted'] .rh-mirada {
+    transform: none;
+    transition: none;
+  }
+}

--- a/src/visual/agente/angelitaEstados.js
+++ b/src/visual/agente/angelitaEstados.js
@@ -1,0 +1,190 @@
+/*
+ * angelitaEstados — EL REPERTORIO DEL AGENTE, COMO DATOS.
+ *
+ * Angelita (Tetragonisca angustula, la abeja angelita sin aguijón) es LA CARA
+ * de la inteligencia de Chagra: cuando el campesino le habla a la app, quien
+ * escucha, piensa y responde es ella. Este módulo define — como datos puros,
+ * cero react/three — el vocabulario de esa conversación:
+ *
+ *   ESTADOS_ANGELITA   → los estados conversacionales canónicos del agente.
+ *   POSE_DE_ESTADO     → qué pose del dibujo base (AbejaAngelita) sostiene
+ *                        cada estado — el agente REUTILIZA el cuerpo aprobado,
+ *                        no dibuja otra abeja.
+ *   ARIA_DE_ESTADO     → cómo se narra cada estado a lectores de pantalla
+ *                        (usted, colombiano — nunca "tú").
+ *   nivelDeConfianza   → normaliza la confianza del modo científico
+ *                        (número 0..1 o etiqueta) a 'alta'|'media'|'baja'.
+ *   MOMENTOS_IDLE      → el repertorio del idle VIVO (acompana): los micro-
+ *                        gestos de criatura que existe aunque nadie le hable.
+ *   elegirMomentoIdle  → el azar ponderado (sin repetir) con el que Angelita
+ *                        decide qué hacer en el próximo rato de vuelo.
+ *
+ * REGLA DE ORO (la misma de abejaIdentidad.js): SOLO datos. La CADENCIA vive
+ * en `angelita-agente.css`; el DIBUJO en `Angelita.jsx`.
+ */
+
+/* Los estados canónicos del cuerpo del agente. En ASCII (sin ñ/tildes) porque
+   viajan como valores de atributo data-* que el CSS selecciona. */
+export const ESTADOS_ANGELITA = [
+  'acompana',     // idle vivo: flota, respira, mira alrededor — presente sin hablar
+  'escuchando',   // se posa y ladea la cabeza hacia usted; ondas de voz entrando
+  'pensando',     // busca en su memoria de la finca (burbuja con recuerdos)
+  'respondiendo', // habla (lip-sync por visema) y gesticula; su voz sale en miel
+  'contenta',     // acertó / buena noticia: brinca celebrando con chispas
+  'preocupada',   // alerta (plaga, sequía, riesgo): cejas, sudor, aro de alerta
+  'no-se',        // honesta: se encoge de hombros — no sabe y LO DICE
+  'senala',       // guía: se inclina y apunta al POI, con destello donde señala
+  'invita',       // guía: hace "venga" con la manita, acercándose
+];
+
+/* Sinónimos amables → canónico. El host escribe como piensa; el cuerpo entiende. */
+const ALIAS = {
+  idle: 'acompana',
+  acompaña: 'acompana',
+  escucha: 'escuchando',
+  piensa: 'pensando',
+  buscando: 'pensando',
+  habla: 'respondiendo',
+  hablando: 'respondiendo',
+  celebra: 'contenta',
+  alerta: 'preocupada',
+  nose: 'no-se',
+  'no-sé': 'no-se',
+  'nosé': 'no-se',
+  duda: 'no-se',
+  'señala': 'senala',
+  guia: 'senala',
+  'guía': 'senala',
+  ven: 'invita',
+};
+
+/**
+ * Devuelve el estado canónico (o 'acompana' si no se reconoce: el agente
+ * nunca se rompe por un estado desconocido — se queda acompañando, digno).
+ * @param {string} [estado]
+ * @returns {string}
+ */
+export function estadoCanonico(estado) {
+  if (!estado) return 'acompana';
+  const e = String(estado).toLowerCase().trim();
+  if (ESTADOS_ANGELITA.includes(e)) return e;
+  return ALIAS[e] || 'acompana';
+}
+
+/* Cada estado del agente sostiene UNA pose del dibujo base (AbejaAngelita:
+   'vuela'|'reposo'|'celebra'|'señala'). El resto del carácter (ondas, burbuja,
+   cejas, shrug) lo ponen las capas del agente encima. */
+export const POSE_DE_ESTADO = {
+  acompana: 'vuela',
+  escuchando: 'reposo',   // se posa a escuchar — atención de verdad, no vuelo
+  pensando: 'vuela',
+  respondiendo: 'vuela',
+  contenta: 'celebra',
+  preocupada: 'vuela',
+  'no-se': 'vuela',
+  senala: 'señala',       // el gesto afinado que ya vive en creatures.css
+  invita: 'vuela',
+};
+
+/* Narración para lectores de pantalla — usted, cercano, sin tecnicismos. */
+export const ARIA_DE_ESTADO = {
+  acompana: 'Angelita la abeja lo acompaña',
+  escuchando: 'Angelita lo está escuchando con atención',
+  pensando: 'Angelita está pensando, buscando en su memoria de la finca',
+  respondiendo: 'Angelita le está respondiendo',
+  contenta: 'Angelita está contenta',
+  preocupada: 'Angelita está preocupada: hay algo que conviene revisar',
+  'no-se': 'Angelita no sabe la respuesta, y se lo dice con honestidad',
+  senala: 'Angelita le está señalando algo',
+  invita: 'Angelita lo invita a acercarse',
+};
+
+/* ── EL REPERTORIO DEL IDLE VIVO (estado acompana) ───────────────────────────
+   Una vecina de verdad EXISTE aunque nadie le hable: entre ratos de vuelo
+   sereno ('flota') se distrae con una mota que pasa, mira alrededor, se
+   acicala las antenas con la manita, se rasca la barriguita, sacude las alas
+   y — de vez en cuando — SE POSA a descansar (aterriza con peso, respira
+   plegadita y vuelve a despegar). Angelita.jsx hojea este repertorio con un
+   reloj de jitter (nunca metrónomo); la CADENCIA de cada momento vive en
+   angelita-agente.css bajo [data-agt-idle=…].
+
+   REGLA DURA: `dur` (ms) debe COINCIDIR con la duración del keyframe one-shot
+   del CSS de ese momento — el scheduler suelta el atributo exactamente cuando
+   el gesto termina en identidad, y así el empalme no salta.
+   `peso` = probabilidad relativa al elegir (0 = no se elige por azar: son los
+   momentos de secuencia — flota es el "entre-gestos"; posada/despega los
+   encadena el propio scheduler después de posa). */
+export const MOMENTOS_IDLE = {
+  flota: { dur: [3200, 8600], peso: 0 },  // vuelo sereno entre gestos (dur al azar)
+  mira: { dur: 2600, peso: 3 },       // mira alrededor, curiosa (ojos primero, cabeza después)
+  distraida: { dur: 3600, peso: 2 },  // pasa una mota de vilano y la sigue con los ojos
+  acicala: { dur: 3000, peso: 2 },    // se acicala la antena con la manita (aseo de abeja)
+  rasca: { dur: 2400, peso: 1.5 },    // se rasca la barriguita, satisfecha
+  sacude: { dur: 1500, peso: 1.5 },   // sacudón de alas: escalofrío alegre que la esponja
+  posa: { dur: 1150, peso: 2 },       // aterriza con peso (→ posada → despega)
+  posada: { dur: [3400, 5200], peso: 0 }, // descansa posada: alitas plegadas, respira hondo
+  despega: { dur: 950, peso: 0 },     // se agacha, coge impulso y vuelve al aire
+};
+
+/* Los momentos elegibles por azar (peso > 0), congelados una vez. */
+const GESTOS_IDLE = Object.keys(MOMENTOS_IDLE).filter((m) => MOMENTOS_IDLE[m].peso > 0);
+
+/**
+ * Elige el próximo micro-gesto del idle: azar ponderado que NUNCA repite el
+ * anterior (una criatura viva no se rasca dos veces seguidas como un GIF).
+ * Pura y testeable: el azar se inyecta.
+ * @param {string|null} [previo]  el último gesto hecho (se excluye).
+ * @param {() => number} [rand]  fuente de azar 0..1 (default Math.random).
+ * @returns {string} nombre del momento elegido.
+ */
+export function elegirMomentoIdle(previo = null, rand = Math.random) {
+  const candidatos = GESTOS_IDLE.filter((m) => m !== previo);
+  const total = candidatos.reduce((s, m) => s + MOMENTOS_IDLE[m].peso, 0);
+  let bola = rand() * total;
+  for (const m of candidatos) {
+    bola -= MOMENTOS_IDLE[m].peso;
+    if (bola <= 0) return m;
+  }
+  return candidatos[candidatos.length - 1];
+}
+
+/**
+ * Duración en ms de un momento del idle; los rangos [min,max] salen con
+ * jitter (el reloj de una criatura viva no es de cuarzo).
+ * @param {string} momento
+ * @param {() => number} [rand]
+ * @returns {number}
+ */
+export function duracionDeMomento(momento, rand = Math.random) {
+  const m = MOMENTOS_IDLE[momento] || MOMENTOS_IDLE.flota;
+  return Array.isArray(m.dur) ? Math.round(m.dur[0] + rand() * (m.dur[1] - m.dur[0])) : m.dur;
+}
+
+/* ── CONFIANZA (modo científico) ─────────────────────────────────────────────
+   Chagra valora la honestidad sobre la alucinación: cuando el agente responde
+   con evidencia firme se NOTA, y cuando duda TAMBIÉN se nota. El cuerpo lo
+   dibuja como un anillo de certeza (halo): firme si está segura, punteado si
+   es regular, titilante y con puntos suspensivos si duda. */
+export const NIVELES_CONFIANZA = ['alta', 'media', 'baja'];
+
+/**
+ * Normaliza la confianza que entrega el host: acepta número 0..1 (score del
+ * modo científico) o etiqueta directa. null/undefined = sin marca (el halo no
+ * se dibuja; consumidores que no manejan confianza no ven nada nuevo).
+ * @param {number|string|null|undefined} confianza
+ * @returns {'alta'|'media'|'baja'|null}
+ */
+export function nivelDeConfianza(confianza) {
+  if (confianza === null || confianza === undefined || confianza === '') return null;
+  if (typeof confianza === 'string') {
+    const c = confianza.toLowerCase().trim();
+    if (c === 'segura') return 'alta';
+    if (c === 'duda' || c === 'dudosa') return 'baja';
+    return NIVELES_CONFIANZA.includes(/** @type {any} */ (c)) ? /** @type {any} */ (c) : null;
+  }
+  const n = Number(confianza);
+  if (Number.isNaN(n)) return null;
+  if (n >= 0.75) return 'alta';
+  if (n >= 0.4) return 'media';
+  return 'baja';
+}

--- a/src/visual/agente/index.js
+++ b/src/visual/agente/index.js
@@ -1,0 +1,22 @@
+/*
+ * src/visual/agente — EL CUERPO VISIBLE DE LA INTELIGENCIA DE CHAGRA.
+ *
+ * Angelita, la abeja angelita, es la cara del agente que le responde al
+ * campesino. Aquí vive SOLO su arte (cuerpo + estados + cadencia); la
+ * inteligencia la cablea el host donde viva la conversación (chat, voz).
+ *
+ *   import { Angelita } from 'src/visual/agente';
+ *   <Angelita estado="pensando" confianza={0.8} />
+ */
+export { Angelita, default } from './Angelita.jsx';
+export {
+  ESTADOS_ANGELITA,
+  NIVELES_CONFIANZA,
+  POSE_DE_ESTADO,
+  ARIA_DE_ESTADO,
+  MOMENTOS_IDLE,
+  estadoCanonico,
+  nivelDeConfianza,
+  elegirMomentoIdle,
+  duracionDeMomento,
+} from './angelitaEstados.js';


### PR DESCRIPTION
Angelita pasa a ser la cara del agente en TODA pantalla de prod: el FAB es la abeja volando libre (idle-cerebro, se posa al hover, glow ámbar con respuesta lista) y el chat entero (header, empty-state, saludo) habla como ella; el colibrí queda jubilado de asistente (sigue de polinizador decorativo en los mundos 3D y como preferencia explícita `colibri_svg`).

Contextual por pantalla: el shell pasa `currentView` al FAB → al tocarla, AgentScreen saluda sobre ESA pantalla (`saludoPantalla.js`: ~80 rutas + familia de cultivos, usted campesino) y el pin espacial lleva `pantalla` al LLM; los pendientes urgentes siguen mandando sobre la cortesía.

Verificado cargando el dist-prod real: **#semilla** → "¿Le ayudo con sus semillas? Germinación, selección o cómo guardarlas." · **#cafe** → "¿Algo sobre el café? Siembra, plagas, cosecha — lo que necesite." · **valle3d** → "¿Qué quiere revisar de su finca hoy? Cuénteme qué vio." — build:prod verde, tsc limpio, 30 tests del área en verde. De paso cayó un bug real: el tap al FAB se tragaba el click (remount del SVG entre mousedown/mouseup) — arreglado con pointer-events. Nota honesta: en el valle conviven su acompañante propio y el FAB (dos Angelitas); si molesta, se decide aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)