### PR TITLE
feat(paleta): paleta madre — un solo atardecer andino en cafetal, cacaotal y papal

### DIFF
--- a/scripts/diag/shot-paleta-mundos.mjs
+++ b/scripts/diag/shot-paleta-mundos.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/* Captura mundos 3D por ruta hash (mockups sin auth). Uso:
+   node shot-mundos.mjs <baseUrl> <outDir> <sufijo> */
+import { mkdirSync } from 'node:fs';
+import { chromium } from 'playwright';
+
+const base = process.argv[2] || 'http://127.0.0.1:5199';
+const outDir = process.argv[3] || '.';
+const sufijo = process.argv[4] || 'antes';
+mkdirSync(outDir, { recursive: true });
+
+const MUNDOS = [
+  { id: 'cafetal', ruta: '#/mockups/cafetal-vivo-3d' },
+  { id: 'cacao', ruta: '#/mockups/cacao-vivo-3d' },
+  { id: 'papa', ruta: '#/mockups/papa-viva-3d' },
+];
+
+const browser = await chromium.launch({
+  executablePath: process.env.CHROMIUM_PATH || '/run/current-system/sw/bin/chromium',
+  args: [
+    '--use-gl=angle',
+    '--use-angle=swiftshader',
+    '--enable-unsafe-swiftshader',
+    '--no-sandbox',
+    '--disable-dev-shm-usage',
+  ],
+});
+const page = await browser.newPage({ viewport: { width: 900, height: 700 } });
+// Forzar reduced motion NO (queremos el mundo normal) pero congelar tiempo no hace falta:
+// la cámara autoRotate es lenta (0.12) y el diff es de color, no de pose exacta.
+for (const m of MUNDOS) {
+  await page.goto(`${base}/${m.ruta}`, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('canvas', { timeout: 30000 }).catch(() => {});
+  await page.waitForTimeout(9000); // chunk three + primer render swiftshader
+  await page.screenshot({ path: `${outDir}/${m.id}-${sufijo}.png` });
+  console.log(`ok ${m.id}-${sufijo}.png`);
+}
+await browser.close();

--- a/src/mockups/CafetalVivo3D.css
+++ b/src/mockups/CafetalVivo3D.css
@@ -9,7 +9,8 @@
   min-height: 100vh;
   min-height: 100dvh;
   padding: 1rem 0.9rem 2.5rem;
-  background: linear-gradient(180deg, #cfe0d5 0%, #dde6d6 44%, #ece7d2 100%);
+  /* la familia corral bajo la hora dorada (paleta madre): sin menta fría */
+  background: linear-gradient(180deg, #e2e0c9 0%, #e9e2cb 44%, #f0e6cd 100%);
   color: #2b3226;
   font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
 }

--- a/src/mockups/PapaVivo3D.css
+++ b/src/mockups/PapaVivo3D.css
@@ -9,7 +9,8 @@
   min-height: 100vh;
   min-height: 100dvh;
   padding: 1rem 0.9rem 2.5rem;
-  background: linear-gradient(180deg, #c8dcea 0%, #d9e2cf 46%, #e9e4cb 100%);
+  /* la ladera de páramo bajo la hora dorada (paleta madre): verde-plata, no celeste */
+  background: linear-gradient(180deg, #dce0d2 0%, #e4e0c9 46%, #ece4ca 100%);
   color: #2c3128;
   font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
 }

--- a/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
+++ b/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
@@ -27,14 +27,32 @@ import { perfilDeTier } from '../deviceTier.js';
 import { Fauna } from '../escenas/FaunaEscena.jsx';
 import FloraCacao from './FloraCacao.jsx';
 import { ANCHO, FONDO, alturaVega, SITIO_CASA } from './floraCacao.geom.js';
+import {
+  CIELOS,
+  mezclarCielo,
+  mezclar,
+  VERDES,
+  TIERRAS,
+  CORTEZAS,
+  CASA,
+  ACENTOS,
+  LUCES,
+  NIEBLAS,
+  PALETA,
+  LuzMadre,
+} from '../paleta/index.js';
 
-/* La atmósfera del piso cálido: cielo lechoso de calor y bruma húmeda dorada. */
-const CALIDO = {
-  fondo: '#dce4bd',
-  bruma: '#e0e4ba',
-  sol: '#ffeaa4',
-  cielo: '#f4eecc',
-  suelo: '#5a4630',
+/* La atmósfera del piso cálido, DERIVADA de la madre: la familia `sotobosque`
+   (verde hondo bajo techo de hojas) mezclada 60% hacia la hora dorada — la
+   misma ley de EscenaBase3D. El cacaotal deja de inventar su cielo. */
+const CALIDO = mezclarCielo(CIELOS.sotobosque);
+
+/* Las lomas calientes del fondo: el verde de trabajo comido por la calina
+   dorada (perspectiva aérea con los MISMOS tokens de la casa). */
+const LOMAS = {
+  cerca: mezclar(VERDES.trabajo, CALIDO.niebla, 0.22),
+  media: mezclar(VERDES.trabajo, CALIDO.niebla, 0.3),
+  lejos: mezclar(VERDES.trabajo, CALIDO.niebla, 0.4),
 };
 
 const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
@@ -58,11 +76,11 @@ function construirVega(seg, plano) {
   const nz = seg + 1;
   const pos = new Float32Array(nx * nz * 3);
   const col = new Float32Array(nx * nz * 3);
-  const cMantillo = new THREE.Color('#7d6038');
-  const cMantillo2 = new THREE.Color('#6b5230');
-  const cPasto = new THREE.Color('#7fa04e');
-  const cTierra = new THREE.Color('#54402e');
-  const cCamino = new THREE.Color('#b08a58');
+  const cMantillo = new THREE.Color(TIERRAS.mantillo); // la hojarasca manda
+  const cMantillo2 = new THREE.Color(TIERRAS.mantilloSombra);
+  const cPasto = new THREE.Color(VERDES.calidoVivo); // el pasto del piso cálido
+  const cTierra = new THREE.Color(TIERRAS.turba); // tierra oscura y húmeda
+  const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.arenaOrilla, 0.35));
   const c = new THREE.Color();
   let p = 0;
   for (let iz = 0; iz < nz; iz++) {
@@ -112,32 +130,32 @@ function construirVega(seg, plano) {
 function CasaSecadero({ pos }) {
   return (
     <group position={pos} rotation={[0, -0.4, 0]}>
-      {/* la casa: paredes encaladas y zócalo ocre, techo de teja */}
+      {/* la casa: LA casa campesina de la paleta madre (la misma del valle) */}
       <mesh position={[0, 0.72, 0]}>
         <boxGeometry args={[2.6, 1.44, 1.9]} />
-        <meshLambertMaterial color="#f0e9d6" flatShading />
+        <meshLambertMaterial color={CASA.encalado} flatShading />
       </mesh>
       <mesh position={[0, 0.18, 0]}>
         <boxGeometry args={[2.64, 0.36, 1.94]} />
-        <meshLambertMaterial color="#a06a2e" flatShading />
+        <meshLambertMaterial color={CASA.zocalo} flatShading />
       </mesh>
-      {/* la puerta y una ventana (maderas verdes, como se pintan allá) */}
+      {/* la puerta y una ventana (la carpintería pintada de la casa) */}
       <mesh position={[0.5, 0.62, 0.96]}>
         <boxGeometry args={[0.44, 0.95, 0.06]} />
-        <meshLambertMaterial color="#4a6b3f" flatShading />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
       </mesh>
       <mesh position={[-0.6, 0.86, 0.96]}>
         <boxGeometry args={[0.5, 0.44, 0.06]} />
-        <meshLambertMaterial color="#4a6b3f" flatShading />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
       </mesh>
       {/* techo a dos aguas de teja */}
       <mesh position={[0, 1.62, -0.62]} rotation={[-0.62, 0, 0]}>
         <boxGeometry args={[3.0, 0.08, 1.5]} />
-        <meshLambertMaterial color="#9c4a30" flatShading />
+        <meshLambertMaterial color={CASA.tejaSombra} flatShading />
       </mesh>
       <mesh position={[0, 1.62, 0.62]} rotation={[0.62, 0, 0]}>
         <boxGeometry args={[3.0, 0.08, 1.5]} />
-        <meshLambertMaterial color="#a85236" flatShading />
+        <meshLambertMaterial color={CASA.teja} flatShading />
       </mesh>
 
       {/* el CAJÓN DE FERMENTAR, al pie de la casa: madera gruesa, tapa de
@@ -145,16 +163,16 @@ function CasaSecadero({ pos }) {
       <group position={[-2.2, 0, 0.7]}>
         <mesh position={[0, 0.32, 0]}>
           <boxGeometry args={[0.95, 0.64, 0.7]} />
-          <meshLambertMaterial color="#7a5a38" flatShading />
+          <meshLambertMaterial color={PALETA.madera} flatShading />
         </mesh>
         <mesh position={[0, 0.66, 0]}>
           <boxGeometry args={[0.82, 0.06, 0.58]} />
-          <meshLambertMaterial color="#8f6a3c" flatShading />
+          <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaClara, 0.45)} flatShading />
         </mesh>
         {/* la hoja de plátano que tapa la fermentación */}
         <mesh position={[0.1, 0.71, 0.05]} rotation={[0, 0.4, 0.06]}>
           <boxGeometry args={[0.7, 0.03, 0.4]} />
-          <meshLambertMaterial color="#579440" flatShading />
+          <meshLambertMaterial color={VERDES.templadoVivo} flatShading />
         </mesh>
       </group>
 
@@ -164,31 +182,31 @@ function CasaSecadero({ pos }) {
         {[[-1.0, -0.55], [1.0, -0.55], [-1.0, 0.55], [1.0, 0.55]].map((q, i) => (
           <mesh key={i} position={[q[0], 0.35, q[1]]}>
             <boxGeometry args={[0.09, 0.7, 0.09]} />
-            <meshLambertMaterial color="#6b533a" flatShading />
+            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
           </mesh>
         ))}
         <mesh position={[0, 0.72, 0]}>
           <boxGeometry args={[2.2, 0.07, 1.3]} />
-          <meshLambertMaterial color="#b99a68" flatShading />
+          <meshLambertMaterial color={PALETA.maderaClara} flatShading />
         </mesh>
         {/* el grano de cacao extendido secándose al sol */}
         <mesh position={[0, 0.77, 0]} rotation={[-Math.PI / 2, 0, 0]}>
           <planeGeometry args={[2.0, 1.1]} />
-          <meshLambertMaterial color="#6f4626" flatShading />
+          <meshLambertMaterial color={mezclar(TIERRAS.siembra, CORTEZAS.quenual, 0.5)} flatShading />
         </mesh>
         {[[-1.05, -0.62], [1.05, -0.62], [-1.05, 0.62], [1.05, 0.62]].map((q, i) => (
           <mesh key={`p${i}`} position={[q[0], 1.15, q[1]]}>
             <boxGeometry args={[0.06, 0.85, 0.06]} />
-            <meshLambertMaterial color="#6b533a" flatShading />
+            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
           </mesh>
         ))}
         <mesh position={[0, 1.62, -0.36]} rotation={[-0.5, 0, 0]}>
           <planeGeometry args={[2.4, 0.95]} />
-          <meshBasicMaterial color="#fbf3da" transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
         </mesh>
         <mesh position={[0, 1.62, 0.36]} rotation={[0.5, 0, 0]}>
           <planeGeometry args={[2.4, 0.95]} />
-          <meshBasicMaterial color="#fbf3da" transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
         </mesh>
       </group>
 
@@ -196,15 +214,15 @@ function CasaSecadero({ pos }) {
       <group position={[-1.5, 0, 1.3]}>
         <mesh position={[0, 0.18, 0]}>
           <cylinderGeometry args={[0.24, 0.17, 0.36, 9, 1, true]} />
-          <meshLambertMaterial color="#a9713c" flatShading side={THREE.DoubleSide} />
+          <meshLambertMaterial color={CASA.bejuco} flatShading side={THREE.DoubleSide} />
         </mesh>
         <mesh position={[-0.05, 0.4, 0.02]} scale={[0.72, 1.4, 0.72]}>
           <sphereGeometry args={[0.13, 7, 6]} />
-          <meshLambertMaterial color="#dcae3a" flatShading />
+          <meshLambertMaterial color={mezclar(ACENTOS.guayacan, ACENTOS.ambar, 0.5)} flatShading />
         </mesh>
         <mesh position={[0.12, 0.38, -0.06]} rotation={[0, 0, 0.5]} scale={[0.72, 1.4, 0.72]}>
           <sphereGeometry args={[0.13, 7, 6]} />
-          <meshLambertMaterial color="#9c4523" flatShading />
+          <meshLambertMaterial color={mezclar(ACENTOS.cafeCereza, TIERRAS.siembra, 0.45)} flatShading />
         </mesh>
       </group>
     </group>
@@ -231,7 +249,7 @@ function FocoPaso({ foco, reducedMotion }) {
     <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
       <ringGeometry args={[1.25, 1.65, 32]} />
       <meshBasicMaterial
-        color="#ffd98e"
+        color={LUCES.candela}
         transparent
         opacity={0.4}
         depthWrite={false}
@@ -270,45 +288,34 @@ function Diorama({ tier, reducedMotion, foco }) {
   return (
     <>
       <color attach="background" args={[CALIDO.fondo]} />
-      {perfil.fog && <fog attach="fog" args={[CALIDO.bruma, 14, 44]} />}
+      {perfil.fog && <fog attach="fog" args={[CALIDO.niebla, 14, 44]} />}
 
-      {/* la luz de tierra caliente: cielo lechoso, sol dorado pesado, calina */}
-      <hemisphereLight intensity={0.95} color={CALIDO.cielo} groundColor={CALIDO.suelo} />
-      <ambientLight intensity={0.34} color="#f6ecc8" />
-      <directionalLight
-        position={[7, 13, 4]}
-        intensity={1.3}
-        color={CALIDO.sol}
-        castShadow={perfil.sombras}
-        shadow-mapSize-width={1024}
-        shadow-mapSize-height={1024}
-        shadow-camera-near={1}
-        shadow-camera-far={40}
-        shadow-camera-left={-16}
-        shadow-camera-right={16}
-        shadow-camera-top={16}
-        shadow-camera-bottom={-6}
+      {/* LA LUZ DE LA CASA: la receta madre con el tinte del sotobosque.
+          El sol pesado de tierra caliente y el frustum a medida de la vega. */}
+      <LuzMadre
+        cielo={CIELOS.sotobosque}
+        perfil={perfil}
+        solPos={[7, 13, 4]}
+        sombra={{ left: -16, right: 16, top: 16, bottom: -6, far: 40 }}
       />
-      {/* contraluz verdoso que separa el sombrío de la calina */}
-      <directionalLight position={[-6, 5, -7]} intensity={0.32} color="#d8e0b8" />
 
       {/* LA VEGA (recibe la sombra del sombrío en gama alta) */}
       <mesh geometry={geoVega} receiveShadow={perfil.sombras}>
         <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
       </mesh>
 
-      {/* las lomas calientes del fondo, comidas por la calina */}
+      {/* las lomas calientes del fondo, comidas por la calina dorada */}
       <mesh position={[-14, 1.4, -20]} scale={[10, 3.2, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#6d8a4c" />
+        <meshLambertMaterial color={LOMAS.media} />
       </mesh>
       <mesh position={[8, 1.8, -23]} scale={[12, 4.0, 6]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#647f48" />
+        <meshLambertMaterial color={LOMAS.lejos} />
       </mesh>
       <mesh position={[21, 1.2, -19]} scale={[8, 2.6, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#75904f" />
+        <meshLambertMaterial color={LOMAS.cerca} />
       </mesh>
 
       {/* EL CACAOTAL: matas, mazorcas, sombrío, plátano, luz colada */}

--- a/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
+++ b/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
@@ -26,14 +26,31 @@ import { perfilDeTier } from '../deviceTier.js';
 import { Fauna } from '../escenas/FaunaEscena.jsx';
 import FloraCafetal from './FloraCafetal.jsx';
 import { ANCHO, FONDO, alturaLadera, SITIO_CASA } from './floraCafetal.geom.js';
+import {
+  CIELOS,
+  mezclarCielo,
+  mezclar,
+  VERDES,
+  TIERRAS,
+  CASA,
+  ACENTOS,
+  LUCES,
+  NIEBLAS,
+  PALETA,
+  LuzMadre,
+} from '../paleta/index.js';
 
-/* La atmósfera del piso templado: cielo claro con bruma tibia de media montaña. */
-const TEMPLADO = {
-  fondo: '#c3dcd2',
-  bruma: '#cde2d6',
-  sol: '#fff0c8',
-  cielo: '#e6f2e2',
-  suelo: '#4f4030',
+/* La atmósfera del piso templado, DERIVADA de la madre: la familia `corral`
+   ("corral y cafetal: tarde de finca") mezclada 60% hacia la hora dorada —
+   la misma ley de EscenaBase3D. El cafetal deja de inventar su cielo. */
+const TEMPLADO = mezclarCielo(CIELOS.corral);
+
+/* Las montañas del fondo: el monte templado comido por la niebla dorada
+   (perspectiva aérea con los MISMOS tokens, no tres verdes sueltos). */
+const MONTES = {
+  cerca: mezclar(VERDES.monte, TEMPLADO.niebla, 0.2),
+  media: mezclar(VERDES.monte, TEMPLADO.niebla, 0.28),
+  lejos: mezclar(VERDES.monte, TEMPLADO.niebla, 0.38),
 };
 
 const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
@@ -56,11 +73,11 @@ function construirLadera(seg, plano) {
   const nz = seg + 1;
   const pos = new Float32Array(nx * nz * 3);
   const col = new Float32Array(nx * nz * 3);
-  const cPasto = new THREE.Color('#79994b');
-  const cPasto2 = new THREE.Color('#8aa855');
-  const cTierra = new THREE.Color('#8a5636');
-  const cMantillo = new THREE.Color('#7d6540');
-  const cCamino = new THREE.Color('#a9825a');
+  const cPasto = new THREE.Color(VERDES.brote); // pasto al sol del piso templado
+  const cPasto2 = new THREE.Color(VERDES.calido); // el oliva que asoma hacia lo seco
+  const cTierra = new THREE.Color(TIERRAS.arcilla); // la tierra roja cafetera
+  const cMantillo = new THREE.Color(TIERRAS.mantillo); // hojarasca bajo el sombrío
+  const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.4));
   const c = new THREE.Color();
   let p = 0;
   for (let iz = 0; iz < nz; iz++) {
@@ -109,32 +126,32 @@ function construirLadera(seg, plano) {
 function CasaBeneficio({ pos }) {
   return (
     <group position={pos} rotation={[0, -0.35, 0]}>
-      {/* la casa: paredes encaladas y zócalo rojo de finca cafetera */}
+      {/* la casa: LA casa campesina de la paleta madre (la misma del valle) */}
       <mesh position={[0, 0.72, 0]}>
         <boxGeometry args={[2.6, 1.44, 1.9]} />
-        <meshLambertMaterial color="#efe8d8" flatShading />
+        <meshLambertMaterial color={CASA.encalado} flatShading />
       </mesh>
       <mesh position={[0, 0.18, 0]}>
         <boxGeometry args={[2.64, 0.36, 1.94]} />
-        <meshLambertMaterial color="#8e3f2c" flatShading />
+        <meshLambertMaterial color={CASA.zocalo} flatShading />
       </mesh>
-      {/* la puerta y una ventana (maderas de colores, como se pintan allá) */}
+      {/* la puerta y una ventana (la carpintería pintada de la casa) */}
       <mesh position={[0.5, 0.62, 0.96]}>
         <boxGeometry args={[0.44, 0.95, 0.06]} />
-        <meshLambertMaterial color="#3f6b6e" flatShading />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
       </mesh>
       <mesh position={[-0.6, 0.86, 0.96]}>
         <boxGeometry args={[0.5, 0.44, 0.06]} />
-        <meshLambertMaterial color="#3f6b6e" flatShading />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
       </mesh>
       {/* techo a dos aguas de teja */}
       <mesh position={[0, 1.62, -0.62]} rotation={[-0.62, 0, 0]}>
         <boxGeometry args={[3.0, 0.08, 1.5]} />
-        <meshLambertMaterial color="#9c4a30" flatShading />
+        <meshLambertMaterial color={CASA.tejaSombra} flatShading />
       </mesh>
       <mesh position={[0, 1.62, 0.62]} rotation={[0.62, 0, 0]}>
         <boxGeometry args={[3.0, 0.08, 1.5]} />
-        <meshLambertMaterial color="#a85236" flatShading />
+        <meshLambertMaterial color={CASA.teja} flatShading />
       </mesh>
 
       {/* la MARQUESINA de secado, al lado: patas + cama de pergamino + techo
@@ -143,31 +160,31 @@ function CasaBeneficio({ pos }) {
         {[[-1.0, -0.55], [1.0, -0.55], [-1.0, 0.55], [1.0, 0.55]].map((q, i) => (
           <mesh key={i} position={[q[0], 0.35, q[1]]}>
             <boxGeometry args={[0.09, 0.7, 0.09]} />
-            <meshLambertMaterial color="#6b533a" flatShading />
+            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
           </mesh>
         ))}
         <mesh position={[0, 0.72, 0]}>
           <boxGeometry args={[2.2, 0.07, 1.3]} />
-          <meshLambertMaterial color="#b99a68" flatShading />
+          <meshLambertMaterial color={PALETA.maderaClara} flatShading />
         </mesh>
         {/* el café pergamino extendido secándose al sol */}
         <mesh position={[0, 0.77, 0]} rotation={[-Math.PI / 2, 0, 0]}>
           <planeGeometry args={[2.0, 1.1]} />
-          <meshLambertMaterial color="#dcc494" flatShading />
+          <meshLambertMaterial color={mezclar(TIERRAS.arenaOrilla, TIERRAS.camino, 0.2)} flatShading />
         </mesh>
         {[[-1.05, -0.62], [1.05, -0.62], [-1.05, 0.62], [1.05, 0.62]].map((q, i) => (
           <mesh key={`p${i}`} position={[q[0], 1.15, q[1]]}>
             <boxGeometry args={[0.06, 0.85, 0.06]} />
-            <meshLambertMaterial color="#6b533a" flatShading />
+            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
           </mesh>
         ))}
         <mesh position={[0, 1.62, -0.36]} rotation={[-0.5, 0, 0]}>
           <planeGeometry args={[2.4, 0.95]} />
-          <meshBasicMaterial color="#fbf3da" transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
         </mesh>
         <mesh position={[0, 1.62, 0.36]} rotation={[0.5, 0, 0]}>
           <planeGeometry args={[2.4, 0.95]} />
-          <meshBasicMaterial color="#fbf3da" transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
         </mesh>
       </group>
 
@@ -176,11 +193,11 @@ function CasaBeneficio({ pos }) {
         <group key={`c${i}`} position={[q[0], 0, q[1]]}>
           <mesh position={[0, 0.18, 0]}>
             <cylinderGeometry args={[0.24, 0.17, 0.36, 9, 1, true]} />
-            <meshLambertMaterial color="#a9713c" flatShading side={THREE.DoubleSide} />
+            <meshLambertMaterial color={CASA.bejuco} flatShading side={THREE.DoubleSide} />
           </mesh>
           <mesh position={[0, 0.36, 0]} scale={[1, 0.4, 1]}>
             <sphereGeometry args={[0.2, 8, 5]} />
-            <meshLambertMaterial color="#c1301f" flatShading />
+            <meshLambertMaterial color={ACENTOS.cafeCereza} flatShading />
           </mesh>
         </group>
       ))}
@@ -208,7 +225,7 @@ function FocoPaso({ foco, reducedMotion }) {
     <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
       <ringGeometry args={[1.25, 1.65, 32]} />
       <meshBasicMaterial
-        color="#ffdf9e"
+        color={LUCES.candela}
         transparent
         opacity={0.4}
         depthWrite={false}
@@ -246,45 +263,34 @@ function Diorama({ tier, reducedMotion, foco }) {
   return (
     <>
       <color attach="background" args={[TEMPLADO.fondo]} />
-      {perfil.fog && <fog attach="fog" args={[TEMPLADO.bruma, 16, 46]} />}
+      {perfil.fog && <fog attach="fog" args={[TEMPLADO.niebla, 16, 46]} />}
 
-      {/* la luz templada de media montaña: cielo claro, sol tibio, bruma */}
-      <hemisphereLight intensity={0.9} color={TEMPLADO.cielo} groundColor={TEMPLADO.suelo} />
-      <ambientLight intensity={0.32} color="#f2ecd6" />
-      <directionalLight
-        position={[8, 12, 5]}
-        intensity={1.2}
-        color={TEMPLADO.sol}
-        castShadow={perfil.sombras}
-        shadow-mapSize-width={1024}
-        shadow-mapSize-height={1024}
-        shadow-camera-near={1}
-        shadow-camera-far={40}
-        shadow-camera-left={-16}
-        shadow-camera-right={16}
-        shadow-camera-top={16}
-        shadow-camera-bottom={-6}
+      {/* LA LUZ DE LA CASA: la receta madre con el tinte de la familia corral.
+          El sol alto de la composición y el frustum a medida de la ladera. */}
+      <LuzMadre
+        cielo={CIELOS.corral}
+        perfil={perfil}
+        solPos={[8, 12, 5]}
+        sombra={{ left: -16, right: 16, top: 16, bottom: -6, far: 40 }}
       />
-      {/* contraluz fresco que separa el sombrío de la bruma */}
-      <directionalLight position={[-6, 6, -7]} intensity={0.35} color="#cfe0dc" />
 
       {/* LA LADERA (recibe la sombra del sombrío en gama alta) */}
       <mesh geometry={geoLadera} receiveShadow={perfil.sombras}>
         <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
       </mesh>
 
-      {/* las montañas cafeteras del fondo, comidas por la bruma */}
+      {/* las montañas cafeteras del fondo, comidas por la niebla dorada */}
       <mesh position={[-13, 2.2, -21]} scale={[9, 4.2, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#5d7a4e" />
+        <meshLambertMaterial color={MONTES.media} />
       </mesh>
       <mesh position={[9, 2.6, -24]} scale={[11, 5.4, 6]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#54704b" />
+        <meshLambertMaterial color={MONTES.lejos} />
       </mesh>
       <mesh position={[22, 1.6, -20]} scale={[8, 3.4, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#647f52" />
+        <meshLambertMaterial color={MONTES.cerca} />
       </mesh>
 
       {/* EL CAFETAL: surcos, cerezas, sombrío, plátano, luz colada */}

--- a/src/visual/mundo3d/paleta/GUIA.md
+++ b/src/visual/mundo3d/paleta/GUIA.md
@@ -1,0 +1,113 @@
+# Paleta madre — guía de adopción
+
+Chagra tiene valle, bosque, microsuelo, sierra, finca, juegos… y el riesgo
+permanente de que se vean como cinco demos distintos. Este módulo es el alma
+común: **la paleta andina, los materiales canónicos y la luz de la casa**,
+extraídos de los mundos ya aprobados (no inventados). Un mundo nuevo que
+importa de aquí se ve de la misma obra desde el primer commit.
+
+Este módulo **construye encima** de lo que ya es ley — no lo reemplaza:
+
+| Ya existía (no tocar)            | Qué resuelve                                     |
+| -------------------------------- | ------------------------------------------------ |
+| `../atmosferaMadre.js`           | la hora dorada, los cielos por familia, el bloom |
+| `../deviceTier.js`               | el tier y el `perfilDeTier(tier)`                |
+| `../cielosHoraData.js`           | las franjas del día (amanecer→noche)             |
+| `../escenas/EscenaBase3D.jsx`    | el Canvas del framework (ya monta esta luz)      |
+| `../escenas/BloomSutil.jsx`      | el bloom sutil, lazy, SOLO tier alto             |
+
+Lo que este módulo agrega: **los colores con nombre** (`paletaMadre.js`),
+**las recetas de material** (`materialesMadre.js`) y **la luz como
+componente** (`LuzMadre.jsx`) para escenas fuera del framework.
+
+## 1. Colores: nunca un hex nuevo sin preguntarle a la paleta
+
+```js
+import { VERDES, TIERRAS, CORTEZAS, AGUAS, ACENTOS, NEUTROS } from '../paleta';
+```
+
+- **Verdes**: elegí por PISO TÉRMICO, no por gusto. Tierra caliente →
+  `VERDES.calido` (oliva); templado → `VERDES.trabajo`; frío → `VERDES.frio`;
+  páramo → los `paramo*` (apagados, con plata). Rampa completa: `EJE_TERMICO`.
+- **El único azul es el agua** (`AGUAS.*`) y el índigo textil
+  (`ACENTOS.indigo`) como acento. Cielos: los pone la atmósfera, no vos.
+- **Acentos a cucharadas**: `ACENTOS` (cochinilla, maíz, guayacán…) es para
+  una cinta, una baya, una señal — jamás para superficies grandes.
+- **Nada de grises fabriles ni negro puro**: `NEUTROS.lamina/concreto` ya
+  vienen entibiados; la línea oscura es `NEUTROS.tinta` (negro cálido).
+- ¿Falta un color? Primero buscá el pariente más cercano y derivalo con
+  `mezclar(a, b, t)`. Solo si de verdad no existe, se agrega AQUÍ (con
+  fuente y comentario), nunca como hex suelto en el mundo.
+
+## 2. Materiales: la receta decide cómo responde a la luz
+
+```js
+import { crearMaterialMadre, crearMaterialVertexColors } from '../paleta';
+
+// materiales con nombre (memoizar + liberar, como siempre):
+const matFollaje = useMemo(() => crearMaterialMadre('follaje', perfil), [perfil]);
+const matCorteza = useMemo(
+  () => crearMaterialMadre('corteza', perfil, { color: CORTEZAS.quenual }),
+  [perfil],
+);
+useEffect(() => () => { matFollaje.dispose(); matCorteza.dispose(); }, [matFollaje, matCorteza]);
+
+// malla fusionada con color por vértice (patrón floraParamo/fincaRealista):
+const matUnico = useMemo(() => crearMaterialVertexColors(perfil), [perfil]);
+```
+
+Recetas: `follaje`, `corteza`, `tierra`, `roca`, `agua`, `musgo`, `madera`,
+`lamina`, `cal`. Cada una ya sabe:
+
+- **Tier**: `materialRico` → `MeshStandardMaterial` con SU roughness;
+  medio/bajo → `MeshLambertMaterial`. El mundo no escribe ese ternario nunca
+  más.
+- **flatShading**: el follaje/tierra/roca lo siguen del perfil; la corteza
+  orgánica lo apaga (regla EntQuenua: el relieve es geometría, no facetas).
+- **Casos especiales**: `musgo` es Lambert SIEMPRE; `agua` es el único
+  material con transparencia y metalness.
+
+Override legítimo: `extra.color` para la variante de especie
+(`CORTEZAS.quenual` vs `CORTEZAS.roble`). Override sospechoso: cambiar
+roughness/metalness — si lo necesitás, probablemente va una receta nueva acá.
+
+## 3. Luz: dentro del framework no hacés nada; fuera, `<LuzMadre>`
+
+- **Mundo dentro de `EscenaBase3D`** (arquetipos): la luz YA es esta. No
+  montés luces propias; a lo sumo elegí tu `CIELOS.familia`.
+- **Escena standalone** (galería, mockup, preview con su propio `<Canvas>`):
+
+```jsx
+import { LuzMadre, CIELOS, mezclarCielo } from '../paleta';
+
+const c = useMemo(() => mezclarCielo(CIELOS.ladera), []);
+<Canvas>
+  <color attach="background" args={[c.fondo]} />
+  {perfil.fog && <fog attach="fog" args={[c.niebla, 12, 40]} />}
+  <LuzMadre cielo={CIELOS.ladera} perfil={perfil} />
+  {/* …tu mundo… */}
+</Canvas>
+```
+
+`<LuzMadre>` acepta `madre` (un preset de `CIELOS_HORA` para amanecer/noche),
+`cielo` (tu familia), `perfil` (sombras solo tier alto) y `escala`. Cuatro
+luces, cero costo por frame. **No calqués los números a mano**: la deriva de
+calcos es exactamente lo que este componente elimina.
+
+## 4. Bloom: no lo montés vos
+
+El bloom sutil vive en `../escenas/BloomSutil.jsx` como chunk lazy que
+`EscenaBase3D` monta SOLO con `tier === 'alto' && !reducedMotion`. Su receta
+(`BLOOM`: fuerza 0.18, umbral 0.85 — un velo, no discoteca) es dirección de
+arte central. Si tu escena standalone de verdad lo amerita, importalo lazy
+con el mismo gate; jamás un composer propio con números propios.
+
+## 5. Checklist del mundo nuevo
+
+1. Verdes por piso térmico de la paleta; ni un hex inventado.
+2. Materiales por `crearMaterialMadre` / `crearMaterialVertexColors`.
+3. Luz: `EscenaBase3D` (arquetipo) o `<LuzMadre>` (standalone).
+4. Familia de cielo elegida de `CIELOS`, mezclada con `mezclarCielo` (la ley
+   60%-hacia-la-madre), nunca un fondo hex directo.
+5. Acentos con cuentagotas; el drama lo pone la luz dorada, no la saturación.
+6. Tier-safe gratis: si consumiste 1–3, tu mundo ya degrada solo.

--- a/src/visual/mundo3d/paleta/GUIA.md
+++ b/src/visual/mundo3d/paleta/GUIA.md
@@ -33,6 +33,9 @@ import { VERDES, TIERRAS, CORTEZAS, AGUAS, ACENTOS, NEUTROS } from '../paleta';
   (`ACENTOS.indigo`) como acento. Cielos: los pone la atmósfera, no vos.
 - **Acentos a cucharadas**: `ACENTOS` (cochinilla, maíz, guayacán…) es para
   una cinta, una baya, una señal — jamás para superficies grandes.
+- **La casa campesina es UNA**: `CASA` (encalado, zócalo, teja/tejaSombra,
+  carpintería, bejuco) viene del valle — el estándar. Si tu mundo tiene casa,
+  es ESTA casa, en cualquier piso térmico.
 - **Nada de grises fabriles ni negro puro**: `NEUTROS.lamina/concreto` ya
   vienen entibiados; la línea oscura es `NEUTROS.tinta` (negro cálido).
 - ¿Falta un color? Primero buscá el pariente más cercano y derivalo con
@@ -93,6 +96,14 @@ const c = useMemo(() => mezclarCielo(CIELOS.ladera), []);
 `cielo` (tu familia), `perfil` (sombras solo tier alto) y `escala`. Cuatro
 luces, cero costo por frame. **No calqués los números a mano**: la deriva de
 calcos es exactamente lo que este componente elimina.
+
+Si tu composición pide el sol en otro sitio o un frustum de sombra a la
+medida de tu geometría, eso NO es excusa para calcar el rig: pasá `solPos`
+y/o `sombra={{left,right,top,bottom,far}}` — la receta (proporciones, colores,
+mezcla 60%) sigue siendo la de la casa. Adopción de referencia: los mundos
+del cafetal, el cacaotal y el papal (`EscenaCafetalVivo`, `EscenaCacaoVivo`,
+`EscenaPapaVivo`) derivan su atmósfera con `mezclarCielo(CIELOS.corral /
+sotobosque / ladera)` y montan esta luz.
 
 ## 4. Bloom: no lo montés vos
 

--- a/src/visual/mundo3d/paleta/LuzMadre.jsx
+++ b/src/visual/mundo3d/paleta/LuzMadre.jsx
@@ -1,0 +1,98 @@
+/*
+ * LuzMadre — la RECETA DE ILUMINACIÓN de la casa, como componente.
+ *
+ * EscenaBase3D ya monta esta luz para los mundos del framework, pero las
+ * escenas que viven FUERA de la base (la galería de la sierra, un preview,
+ * un mockup nuevo) venían calcando los números a mano — y cada calco deriva
+ * (la sierra hoy ilumina 1.3 donde el valle ilumina 0.9). Este componente es
+ * la receta exportada: cuatro luces, mismas proporciones, misma calidez
+ * andina, en cualquier <Canvas>.
+ *
+ * La receta (proporciones de EscenaBase3D / cielosHoraData.dorada):
+ *   1. hemisferio 0.55 — el domo dorado arriba, el rebote de tierra abajo.
+ *      Es el 60% de la sensación: la luz "viene de un cielo", no de focos.
+ *   2. ambiente   0.28 — un piso tibio para que la sombra nunca sea negra.
+ *   3. sol        0.90 — la CLAVE direccional, dorada, baja ([6,9,4]).
+ *      La única que proyecta sombra, y solo si el perfil lo permite (tier
+ *      alto; en medio/bajo el shadow-map ni existe — DR FIX 1).
+ *   4. relleno    0.22 — el contraluz FRÍO ([-5,4,-6]): el azul del cielo
+ *      abierto que modela el lado en sombra sin aplanarlo.
+ *
+ * `madre` acepta cualquier preset con la forma de ATMOSFERA/CIELOS_HORA
+ * (cielosHoraData): si trae sus propias intensidades por luz (hemisferio,
+ * ambiente, sol, rellenoInt, solPos) se respetan — así la MISMA receta
+ * amanece, dora o anochece sin tocar la escena.
+ *
+ * `cielo` es el tinte de FAMILIA del mundo (CIELOS.huerta, CIELOS.agua…):
+ * se mezcla 60% hacia la madre con la ley de atmosferaMadre, igual que en
+ * EscenaBase3D. Sin `cielo`, luce la madre pura.
+ *
+ * Costo: 4 luces y una mezcla memoizada. Nada por frame. El fondo y la
+ * niebla NO van aquí (son de la escena): ver GUIA.md para el par de líneas.
+ */
+import { useMemo } from 'react';
+import { ATMOSFERA, mezclarCielo } from '../atmosferaMadre.js';
+
+/* Las proporciones de la casa, exportadas como dato (para consumidores no-r3f
+   o para quien necesite leer la receta sin montar luces). */
+export const LUZ_MADRE = {
+  hemisferio: 0.55,
+  ambiente: 0.28,
+  sol: 0.9,
+  relleno: 0.22,
+  solPos: [6, 9, 4], // el sol dorado de la tarde (calca EscenaBase3D)
+  rellenoPos: [-5, 4, -6], // el contraluz frío, opuesto y bajo
+};
+
+/**
+ * @param {object} props
+ * @param {object} [props.madre]   preset de atmósfera (ATMOSFERA o una franja
+ *                                 de CIELOS_HORA). Default: la hora dorada.
+ * @param {object} [props.cielo]   tinte de familia (CIELOS.huerta…); se mezcla
+ *                                 60% hacia la madre. Default: madre pura.
+ * @param {object} [props.perfil]  perfilDeTier(tier); decide castShadow.
+ * @param {number} [props.escala]  atenuador global (1 = receta tal cual).
+ */
+export default function LuzMadre({
+  madre = ATMOSFERA,
+  cielo = null,
+  perfil = null,
+  escala = 1,
+}) {
+  /* La mezcla 60%-hacia-la-madre es la MISMA ley de EscenaBase3D (7 lerps,
+     memoizados aquí): un consumidor standalone pinta IGUAL que el framework. */
+  const c = useMemo(() => mezclarCielo(cielo, madre), [cielo, madre]);
+  const k = (c.intensidad ?? 1) * escala;
+  const sombras = !!(perfil && perfil.sombras);
+
+  return (
+    <>
+      <hemisphereLight
+        intensity={(madre.hemisferio ?? LUZ_MADRE.hemisferio) * k}
+        color={c.cielo}
+        groundColor={c.suelo}
+      />
+      <ambientLight
+        intensity={(madre.ambiente ?? LUZ_MADRE.ambiente) * k}
+        color={madre.luz}
+      />
+      <directionalLight
+        position={madre.solPos ?? LUZ_MADRE.solPos}
+        intensity={(madre.sol ?? LUZ_MADRE.sol) * k}
+        color={madre.luz}
+        castShadow={sombras}
+        shadow-mapSize={[1024, 1024]}
+        shadow-camera-far={30}
+        shadow-camera-left={-12}
+        shadow-camera-right={12}
+        shadow-camera-top={12}
+        shadow-camera-bottom={-12}
+      />
+      <directionalLight
+        position={LUZ_MADRE.rellenoPos}
+        intensity={(madre.rellenoInt ?? LUZ_MADRE.relleno) * escala}
+        color={madre.relleno}
+      />
+    </>
+  );
+}

--- a/src/visual/mundo3d/paleta/LuzMadre.jsx
+++ b/src/visual/mundo3d/paleta/LuzMadre.jsx
@@ -30,6 +30,9 @@
  * Costo: 4 luces y una mezcla memoizada. Nada por frame. El fondo y la
  * niebla NO van aquí (son de la escena): ver GUIA.md para el par de líneas.
  */
+/* eslint-disable react-refresh/only-export-components -- exporta LUZ_MADRE
+   (las proporciones de la receta como dato) junto al componente: es la misma
+   ley en dos formas y separarlas duplicaría la fuente (precedente: CamaraCruce). */
 import { useMemo } from 'react';
 import { ATMOSFERA, mezclarCielo } from '../atmosferaMadre.js';
 
@@ -52,12 +55,19 @@ export const LUZ_MADRE = {
  *                                 60% hacia la madre. Default: madre pura.
  * @param {object} [props.perfil]  perfilDeTier(tier); decide castShadow.
  * @param {number} [props.escala]  atenuador global (1 = receta tal cual).
+ * @param {number[]} [props.solPos] posición del sol si la composición de la
+ *                                 escena pide otro ángulo (misma luz, otro sitio).
+ * @param {object} [props.sombra]  frustum de sombra a medida de la geometría:
+ *                                 {left,right,top,bottom,far}. Default: el de
+ *                                 la casa (±12, far 30).
  */
 export default function LuzMadre({
   madre = ATMOSFERA,
   cielo = null,
   perfil = null,
   escala = 1,
+  solPos = null,
+  sombra = null,
 }) {
   /* La mezcla 60%-hacia-la-madre es la MISMA ley de EscenaBase3D (7 lerps,
      memoizados aquí): un consumidor standalone pinta IGUAL que el framework. */
@@ -77,16 +87,16 @@ export default function LuzMadre({
         color={madre.luz}
       />
       <directionalLight
-        position={madre.solPos ?? LUZ_MADRE.solPos}
+        position={solPos ?? madre.solPos ?? LUZ_MADRE.solPos}
         intensity={(madre.sol ?? LUZ_MADRE.sol) * k}
         color={madre.luz}
         castShadow={sombras}
         shadow-mapSize={[1024, 1024]}
-        shadow-camera-far={30}
-        shadow-camera-left={-12}
-        shadow-camera-right={12}
-        shadow-camera-top={12}
-        shadow-camera-bottom={-12}
+        shadow-camera-far={sombra?.far ?? 30}
+        shadow-camera-left={sombra?.left ?? -12}
+        shadow-camera-right={sombra?.right ?? 12}
+        shadow-camera-top={sombra?.top ?? 12}
+        shadow-camera-bottom={sombra?.bottom ?? -12}
       />
       <directionalLight
         position={LUZ_MADRE.rellenoPos}

--- a/src/visual/mundo3d/paleta/index.js
+++ b/src/visual/mundo3d/paleta/index.js
@@ -34,6 +34,7 @@ export {
   NIEBLAS,
   LUCES,
   ACENTOS,
+  CASA,
   NEUTROS,
 } from './paletaMadre.js';
 

--- a/src/visual/mundo3d/paleta/index.js
+++ b/src/visual/mundo3d/paleta/index.js
@@ -1,0 +1,46 @@
+/*
+ * paleta/ — el SISTEMA VISUAL MADRE de Chagra en una sola puerta.
+ *
+ * Un mundo nuevo importa de aquí y ya habla el idioma de la casa:
+ *
+ *   import {
+ *     VERDES, TIERRAS, CORTEZAS, AGUAS, NIEBLAS, LUCES, ACENTOS, NEUTROS,
+ *     crearMaterialMadre, crearMaterialVertexColors,
+ *     LuzMadre, LUZ_MADRE,
+ *     ATMOSFERA, CIELOS, PALETA, BLOOM, mezclar, mezclarCielo,
+ *   } from '../paleta';
+ *
+ * Cómo adoptar (el detalle y los antipatrones): ./GUIA.md
+ *
+ * El BLOOM sutil del tier alto NO se importa de aquí: es un chunk lazy
+ * (escenas/BloomSutil.jsx) que solo EscenaBase3D monta con
+ * `tier === 'alto' && !reducedMotion` — medio y bajo ni lo descargan.
+ * Aquí solo viaja su receta (BLOOM, de atmosferaMadre).
+ */
+export {
+  /* atmósfera (re-export de atmosferaMadre: la ley no se duplica) */
+  ATMOSFERA,
+  CIELOS,
+  PALETA,
+  BLOOM,
+  mezclar,
+  mezclarCielo,
+  /* la paleta madre andina */
+  VERDES,
+  EJE_TERMICO,
+  TIERRAS,
+  CORTEZAS,
+  AGUAS,
+  NIEBLAS,
+  LUCES,
+  ACENTOS,
+  NEUTROS,
+} from './paletaMadre.js';
+
+export {
+  RECETAS,
+  crearMaterialMadre,
+  crearMaterialVertexColors,
+} from './materialesMadre.js';
+
+export { default as LuzMadre, LUZ_MADRE } from './LuzMadre.jsx';

--- a/src/visual/mundo3d/paleta/materialesMadre.js
+++ b/src/visual/mundo3d/paleta/materialesMadre.js
@@ -1,0 +1,156 @@
+/*
+ * materialesMadre — el SET CANÓNICO de materiales compartidos de los mundos.
+ *
+ * El patrón `perfil.materialRico ? MeshStandard : MeshLambert` ya es ley de
+ * facto (FloraParamo, EntQuenua, Valle3D lo repiten a mano), pero cada mundo
+ * elige SU roughness y SU flatShading — y el ojo lo nota: la madera del valle
+ * no brilla como la de la finca. Este módulo vuelve RECETA esa costumbre:
+ * un solo lugar decide cómo responde a la luz el follaje, la corteza, la
+ * tierra, la roca, el agua, el musgo y la lámina de finca, en TODOS los tiers.
+ *
+ * Contrato tier-safe (deviceTier / DR §6):
+ *   - perfil.materialRico === true  (tier alto)  → MeshStandardMaterial con la
+ *     rugosidad de la receta (PBR mate: metalness 0 salvo agua/lámina).
+ *   - perfil.materialRico === false (medio/bajo) → MeshLambertMaterial, que
+ *     ignora roughness/metalness — la receta degrada SOLA, sin condicionales
+ *     en el mundo.
+ *   - `flatShading` sale de la receta (el follaje low-poly lo pide; la corteza
+ *     orgánica lo apaga como EntQuenua) y respeta el perfil cuando la receta
+ *     lo deja en 'perfil'.
+ *   - El musgo es Lambert SIEMPRE (regla de EntQuenua: barato y se ve igual).
+ *
+ * USO (los creadores son PUROS; la escena memoiza y libera, como ya hace):
+ *   const matFollaje = useMemo(() => crearMaterialMadre('follaje', perfil), [perfil]);
+ *   useEffect(() => () => matFollaje.dispose(), [matFollaje]);
+ *
+ * Para mallas fusionadas con color por vértice (el patrón de floraParamo /
+ * fincaRealista: UNA geometría, UN material blanco):
+ *   const mat = useMemo(() => crearMaterialVertexColors(perfil), [perfil]);
+ *
+ * Nada aquí corre por frame: son fábricas que se llaman una vez por montaje.
+ */
+import * as THREE from 'three';
+import { PALETA } from '../atmosferaMadre.js';
+import { VERDES, TIERRAS, CORTEZAS, AGUAS, NEUTROS } from './paletaMadre.js';
+
+/*
+ * Las recetas. Campos:
+ *   color   — hex de la paleta madre (override con `extra.color` si el mundo
+ *             necesita SU variante: p. ej. corteza de quenual vs de roble).
+ *   flat    — true/false fijo, o 'perfil' (= sigue perfil.flatShading).
+ *   rico    — parámetros SOLO del tier alto (MeshStandard); Lambert los ignora.
+ *   extras  — props comunes a ambos tiers (transparencias del agua).
+ *   siempreLambert — materiales de relleno masivo (musgo) que ni en tier alto
+ *                    ameritan PBR.
+ */
+export const RECETAS = {
+  /* follaje low-poly: mate total, facetado — el verde de trabajo del juego */
+  follaje: {
+    color: VERDES.trabajo,
+    flat: 'perfil',
+    rico: { roughness: 0.9, metalness: 0 },
+  },
+  /* corteza orgánica: SUAVE (el relieve es geometría, no facetas — EntQuenua) */
+  corteza: {
+    color: CORTEZAS.roble,
+    flat: false,
+    rico: { roughness: 0.94, metalness: 0 },
+  },
+  /* tierra de labranza: mate absoluto, facetada como el terreno del valle */
+  tierra: {
+    color: TIERRAS.siembra,
+    flat: 'perfil',
+    rico: { roughness: 1, metalness: 0 },
+  },
+  /* roca de sierra/páramo: mate, facetada — hermana de la tierra */
+  roca: {
+    color: TIERRAS.rocaSierra,
+    flat: 'perfil',
+    rico: { roughness: 1, metalness: 0 },
+  },
+  /* agua viva: el único material con brillo y transparencia (receta Valle3D) */
+  agua: {
+    color: AGUAS.viva,
+    flat: false,
+    rico: { roughness: 0.2, metalness: 0.4 },
+    extras: { transparent: true, opacity: 0.85 },
+  },
+  /* musgo de páramo: relleno masivo → Lambert SIEMPRE (regla EntQuenua) */
+  musgo: {
+    color: VERDES.paramoMusgo,
+    flat: false,
+    siempreLambert: true,
+  },
+  /* madera trabajada de finca: poste, tabla, mango — mate con un dejo de veta */
+  madera: {
+    color: PALETA.madera,
+    flat: 'perfil',
+    rico: { roughness: 0.85, metalness: 0 },
+  },
+  /* lámina/zinc/herraje: el único metal, y aun así tibio y gastado */
+  lamina: {
+    color: NEUTROS.lamina,
+    flat: false,
+    rico: { roughness: 0.5, metalness: 0.25 },
+  },
+  /* pared encalada: mate, casi luz hecha materia */
+  cal: {
+    color: NEUTROS.cal,
+    flat: false,
+    rico: { roughness: 0.95, metalness: 0 },
+  },
+};
+
+/* ¿flatShading efectivo? La receta manda; 'perfil' delega en el tier. */
+function flatDe(receta, perfil) {
+  if (receta.flat === 'perfil') return !!(perfil && perfil.flatShading);
+  return !!receta.flat;
+}
+
+/**
+ * Crea el material canónico `nombre` para el `perfil` de render del tier.
+ * PURO: quien llama memoiza (useMemo) y libera (dispose) al desmontar.
+ *
+ * @param {keyof typeof RECETAS} nombre  receta de la casa ('follaje', 'agua'…)
+ * @param {{ materialRico?: boolean, flatShading?: boolean }} perfil  perfilDeTier(tier)
+ * @param {object} [extra]  overrides finales (p. ej. { color: CORTEZAS.quenual })
+ * @returns {THREE.Material}
+ */
+export function crearMaterialMadre(nombre, perfil, extra = {}) {
+  const receta = RECETAS[nombre];
+  if (!receta) throw new Error(`materialesMadre: receta desconocida '${nombre}'`);
+  const base = {
+    color: receta.color,
+    flatShading: flatDe(receta, perfil),
+    ...(receta.extras || {}),
+  };
+  const rico = !!(perfil && perfil.materialRico) && !receta.siempreLambert;
+  const mat = rico
+    ? new THREE.MeshStandardMaterial({ ...base, ...(receta.rico || {}), ...extra })
+    : new THREE.MeshLambertMaterial({ ...base, ...extra });
+  return mat;
+}
+
+/**
+ * El material ÚNICO para mallas fusionadas con color por vértice — el patrón
+ * de floraParamo/fincaRealista/Valle3D (una geometría merged, un material).
+ * Misma respuesta a la luz que 'follaje' (roughness 0.9), porque eso es lo
+ * que esas mallas ya son: vegetación y finca horneadas.
+ *
+ * @param {{ materialRico?: boolean, flatShading?: boolean }} perfil
+ * @param {{ flatShading?: boolean, roughness?: number }} [opciones]
+ * @returns {THREE.Material}
+ */
+export function crearMaterialVertexColors(perfil, opciones = {}) {
+  const base = {
+    vertexColors: true,
+    flatShading: opciones.flatShading ?? !!(perfil && perfil.flatShading),
+  };
+  return perfil && perfil.materialRico
+    ? new THREE.MeshStandardMaterial({
+        ...base,
+        roughness: opciones.roughness ?? 0.9,
+        metalness: 0,
+      })
+    : new THREE.MeshLambertMaterial(base);
+}

--- a/src/visual/mundo3d/paleta/paletaMadre.js
+++ b/src/visual/mundo3d/paleta/paletaMadre.js
@@ -1,0 +1,187 @@
+/*
+ * paletaMadre — LA PALETA MADRE ANDINA de Chagra, con nombre y apellido.
+ *
+ * atmosferaMadre ya unificó la HORA (la luz dorada, los cielos por familia,
+ * los 14 tonos low-poly). Pero cada mundo siguió inventando sus verdes, sus
+ * cortezas y sus acentos por su cuenta: el bosque tiene ONCE verdes locales,
+ * la sierra SEIS, el valle CUATRO — y ninguno sabe del otro. Este módulo NO
+ * reemplaza nada de eso: lo EXTRAE de lo ya aprobado y lo vuelve vocabulario
+ * común, para que el próximo mundo no invente el verde número treinta y dos.
+ *
+ * De dónde sale cada color (fuentes aprobadas, no gusto propio):
+ *   - bosque/floraParamo.geom.js + entQuenua.geom.js  → verdes de páramo,
+ *     plata de frailejón, cortezas, musgo, líquen.
+ *   - sierra/GaleriaSierraArboles.jsx + arbolesMayores.js → el eje térmico
+ *     cálido→nival, roca, laguna, nieve, guayacán.
+ *   - mockups/valle/valleData.js (PISOS/CLIMAS)       → verdes por piso,
+ *     luces por hora.
+ *   - finca/fincaRealista.geom.js                     → maíz, café, tierras
+ *     de labranza.
+ *   - creatures/_faunaRubberTokens.js                 → los acentos de
+ *     textil andino (cochinilla, maíz, índigo) y la tinta rubber-hose.
+ *   - atmosferaMadre.js                               → sigue siendo la LEY
+ *     de atmósfera; aquí se re-exporta para compra en un solo lugar.
+ *
+ * REGLA DE LA CASA (heredada de atmosferaMadre y ahora explícita):
+ *   1. Los verdes andinos NO son saturados de tech: van del oliva del cálido
+ *      al verde-plata del páramo, siempre con tierra adentro.
+ *   2. El único azul con permiso es el AGUA (y el índigo de mortiño como
+ *      acento textil). Cielos y sombras se resuelven con la atmósfera.
+ *   3. No hay gris fabril puro: bajo el sol andino hasta el zinc se entibia.
+ *   4. El rojo existe como cochinilla/café cereza (textil, fruto), nunca
+ *      como rojo catástrofe de UI.
+ *
+ * Solo constantes y re-exports: cero costo por frame, cero three propio.
+ */
+import {
+  ATMOSFERA,
+  CIELOS,
+  PALETA,
+  BLOOM,
+  mezclar,
+  mezclarCielo,
+} from '../atmosferaMadre.js';
+
+/* Re-export: quien importa la paleta madre tiene TODO el sistema visual en un
+   solo `from './paleta'` (atmósfera, cielos, tonos low-poly, bloom, mezcla). */
+export { ATMOSFERA, CIELOS, PALETA, BLOOM, mezclar, mezclarCielo };
+
+/* ------------------------------------------------------------------ */
+/* VERDES — el eje térmico andino, de la tierra caliente al páramo.    */
+/* La regla: a más altura, menos saturación y más plata/gris adentro   */
+/* (así lo pinta la sierra aprobada y así se ve el páramo real).       */
+/* ------------------------------------------------------------------ */
+export const VERDES = {
+  /* — piso cálido: oliva amarillento, pasto al sol — */
+  calido: '#98ab4b', // sierra, banda del piso cálido
+  calidoVivo: '#84a83f', // valle, piso cálido (verde cálido amarillento)
+
+  /* — piso templado: el verde franco del trabajo — */
+  templado: '#63a447', // sierra, banda templada
+  templadoVivo: '#4e9143', // valle, piso templado (verde vivo)
+  trabajo: '#5f8a3f', // = PALETA.follaje: surco, mata (el default del juego)
+  brote: '#7a9a3f', // = PALETA.follajeClaro: brote, pasto al sol
+  monte: '#3f6f3a', // = PALETA.follajeOscuro: copa en sombra
+
+  /* — piso frío: se apaga hacia el azul-gris, sin volverse azul — */
+  frio: '#3f7358', // sierra, banda fría (verde-azulado)
+  frioVivo: '#3c7f64', // valle, piso frío
+  aliso: '#4f6d3d', // bosque, hoja fresca de aliso
+
+  /* — páramo: los verdes callados de la niebla — */
+  paramoHoja: '#43593b', // bosque, hoja coriácea de roble
+  paramoNiebla: '#3b5236', // bosque, copa oscura de encenillo (árbol de niebla)
+  paramoMusgo: '#4c5c34', // bosque, musgo de piedra
+  paramoMusgoClaro: '#5f6f42', // quenual, mechón de musgo de la barba
+  paramoLiquen: '#9aa86a', // bosque, líquen pálido sobre roca
+  paramoPlata: '#bcc6ac', // bosque, roseta plateada del frailejón (LA firma)
+  paramoSage: '#aeb890', // quenual, liquen foliáceo pálido
+  altoAndino: '#63807a', // valle, frío grisáceo del alto andino
+};
+
+/* El eje térmico como rampa ordenada (cálido → nival), para pintar altura,
+   leyendas o gradientes sin re-inventar las paradas. Colores de la sierra. */
+export const EJE_TERMICO = [
+  { id: 'calido', color: VERDES.calido },
+  { id: 'templado', color: VERDES.templado },
+  { id: 'frio', color: VERDES.frio },
+  { id: 'paramo', color: '#a5975c' }, // pajonal dorado-verdoso
+  { id: 'superparamo', color: '#83836f' }, // roca con vida rala
+  { id: 'nival', color: '#e9eef2' }, // el blanco azulado de la nieve
+];
+
+/* ------------------------------------------------------------------ */
+/* TIERRAS Y ROCAS — el suelo que sostiene todo.                       */
+/* ------------------------------------------------------------------ */
+export const TIERRAS = {
+  cacao: '#4a2a20', // quenual, fondo de grieta (la tierra más honda)
+  siembra: '#6b4a2e', // = PALETA.tierra: cama de siembra, tierra removida
+  camino: '#8a6a44', // = PALETA.tierraClara: suelo seco, camino de finca
+  turba: '#5a3d28', // fauna, el suelo de la lombriz (tierra viva del páramo)
+  pajonal: '#a5975c', // sierra, banda de páramo (paja dorada-verdosa)
+  rocaSierra: '#6f6357', // sierra, el risco que asoma en lo empinado
+  rocaParamo: '#7c7c70', // bosque, piedra con líquen
+  piedra: '#9a8b74', // = PALETA.piedra: tanque, roca de río (gris pardo)
+  vega: '#c9b593', // sierra, tierra clara de la vega baja
+  arenaOrilla: '#e6d2a0', // sierra, playa de la laguna
+};
+
+/* ------------------------------------------------------------------ */
+/* CORTEZAS — los troncos aprobados, por especie insignia.             */
+/* ------------------------------------------------------------------ */
+export const CORTEZAS = {
+  quenual: '#8a4a33', // bosque, corteza rojiza madura del Ent quenual
+  quenualPapel: '#cf9166', // bosque, lámina de papel que se despega (LA firma)
+  sieteCueros: '#a5502e', // sierra, cobre que se descama
+  sieteCuerosClaro: '#c9723f',
+  encenillo: '#6d4535', // bosque, corteza rojiza del árbol de niebla
+  roble: '#6a5c4a', // bosque, corteza gris-parda fisurada (la genérica digna)
+  yarumo: '#bcbfb2', // bosque, tronco pálido anillado
+  aliso: '#9a9a8f', // bosque, corteza gris clara
+  raicilla: '#5a3b2b', // quenual, raicilla leñosa colgante
+  /* madera TRABAJADA (poste, tabla, viga) → PALETA.madera/maderaClara/
+     maderaOscura de atmosferaMadre; corteza VIVA → estas. */
+};
+
+/* ------------------------------------------------------------------ */
+/* AGUAS — el único azul con permiso.                                  */
+/* ------------------------------------------------------------------ */
+export const AGUAS = {
+  viva: '#3f8fb0', // = PALETA.agua: acequia, río (el acento azul del juego)
+  lagunaHonda: '#5d8d97', // sierra, el centro de la laguna de páramo
+  lagunaOrilla: '#a8cbb4', // sierra, la orilla verde-lechosa
+  espuma: '#fdf7e8', // sierra, brillo del agua a contraluz
+};
+
+/* ------------------------------------------------------------------ */
+/* NIEBLAS — la bruma andina por altitud (para fog y veladuras).       */
+/* ------------------------------------------------------------------ */
+export const NIEBLAS = {
+  dorada: '#f0c98d', // = ATMOSFERA.niebla: la niebla madre del valle
+  paramo: '#d6e0d2', // = CIELOS.ladera.fondo: bruma verde-plata, no celeste
+  lechosa: '#fbf3df', // sierra, las veladuras de bruma entre planos
+};
+
+/* ------------------------------------------------------------------ */
+/* LUCES — la luz andina con nombre (los hex que ya usan las escenas). */
+/* Las INTENSIDADES y la receta viven en LuzMadre / cielosHoraData.    */
+/* ------------------------------------------------------------------ */
+export const LUCES = {
+  sol: '#ffd79a', // = ATMOSFERA.luz: el sol bajo, dorado
+  rellenoFrio: '#9db8d9', // = ATMOSFERA.relleno: cielo abierto opuesto al sol
+  ambienteTibio: '#fff1d6', // sierra, el baño ambiente de la galería
+  horizonte: '#ffe6ba', // sierra, el degradé bajo del cielo
+  sombra: '#3a2a18', // = ATMOSFERA.sombra: tinte de sombra de contacto
+  luna: '#b9c6e6', // cielosHora, la luna plata de la noche de páramo
+  fogata: '#6b5638', // cielosHora, el relleno tibio nocturno
+  candela: '#ffd28a', // valle, la pointLight de los hitos encendidos
+};
+
+/* ------------------------------------------------------------------ */
+/* ACENTOS — textil andino y frutos: los ÚNICOS colores que gritan.    */
+/* Se usan a cucharadas (una cinta, una baya, una flor), jamás a balde. */
+/* ------------------------------------------------------------------ */
+export const ACENTOS = {
+  cochinilla: '#d1382b', // fauna, el rojo textil (mariquita)
+  cafeCereza: '#c23227', // finca, la cereza madura del cafeto
+  maizTextil: '#f4c542', // fauna, el rombo/chakana de las guardas
+  maizGrano: '#e2c04c', // finca, el grano de la mazorca
+  guayacan: '#f2c33a', // sierra, la flor dorada maciza del guayacán
+  frailejonFlor: '#e0c24a', // bosque, los capítulos amarillos
+  ambar: '#d9a13b', // = PALETA.ambar: señal, alerta amable (nunca rojo UI)
+  indigo: '#33305c', // bosque, la baya del mortiño (el índigo textil)
+  florDeMonte: '#e46b9b', // fauna, la flor que visita el abejorro
+};
+
+/* ------------------------------------------------------------------ */
+/* NEUTROS — tinta, hueso, cal, nieve: los silencios de la paleta.     */
+/* ------------------------------------------------------------------ */
+export const NEUTROS = {
+  tinta: '#241a10', // rubber-hose INK: negro cálido, nunca negro puro
+  hueso: '#fff8ec', // rubber-hose HUESO: blanco de ojos y brillos
+  cal: '#efe7d8', // = PALETA.cal: pared encalada
+  nieve: '#f4f7fb', // sierra, la corona nival
+  nival: '#e9eef2', // sierra, banda nival del terreno
+  lamina: '#8b8578', // = PALETA.lamina: zinc, barril (gris CÁLIDO)
+  concreto: '#a89a84', // = PALETA.concreto: obra civil entibiada
+};

--- a/src/visual/mundo3d/paleta/paletaMadre.js
+++ b/src/visual/mundo3d/paleta/paletaMadre.js
@@ -98,6 +98,9 @@ export const TIERRAS = {
   siembra: '#6b4a2e', // = PALETA.tierra: cama de siembra, tierra removida
   camino: '#8a6a44', // = PALETA.tierraClara: suelo seco, camino de finca
   turba: '#5a3d28', // fauna, el suelo de la lombriz (tierra viva del páramo)
+  arcilla: '#8a5636', // cafetal, la tierra roja andina que asoma entre surcos
+  mantillo: '#7d6038', // cacaotal, la hojarasca parda bajo el sombrío
+  mantilloSombra: '#6b5230', // cacaotal, el mantillo húmedo hacia la sombra
   pajonal: '#a5975c', // sierra, banda de páramo (paja dorada-verdosa)
   rocaSierra: '#6f6357', // sierra, el risco que asoma en lo empinado
   rocaParamo: '#7c7c70', // bosque, piedra con líquen
@@ -171,6 +174,23 @@ export const ACENTOS = {
   ambar: '#d9a13b', // = PALETA.ambar: señal, alerta amable (nunca rojo UI)
   indigo: '#33305c', // bosque, la baya del mortiño (el índigo textil)
   florDeMonte: '#e46b9b', // fauna, la flor que visita el abejorro
+};
+
+/* ------------------------------------------------------------------ */
+/* CASA — la casa campesina canónica, EXTRAÍDA del valle (el estándar  */
+/* de referencia: composicionValle3D.jsx). Cada mundo venía inventando */
+/* SU teja, SU zócalo y SU carpintería: tres casas que no eran la misma*/
+/* casa. Esta es LA casa — en cualquier piso térmico se reconoce.      */
+/* ------------------------------------------------------------------ */
+export const CASA = {
+  encalado: '#f3ecdc', // valle, el muro de tapia encalada
+  zocalo: '#a35a3c', // valle, la franja pintada de toda casa de vereda
+  teja: '#b0603f', // valle, el faldón de teja al sol
+  tejaSombra: '#8f4b31', // valle, el faldón en sombra y la cumbrera
+  madera: '#6b4a2e', // valle, puerta y marco (= PALETA.tierra, madera curtida)
+  ventana: '#ffd9a0', // valle, la luz cálida de "la casa espera"
+  carpinteria: '#44685a', // puerta/ventana pintadas: el verde-aguamarina campesino
+  bejuco: '#a9713c', // el canasto de cosecha (cafetal/cacaotal/papal, ya idéntico)
 };
 
 /* ------------------------------------------------------------------ */

--- a/src/visual/mundo3d/papa/EscenaPapaVivo.jsx
+++ b/src/visual/mundo3d/papa/EscenaPapaVivo.jsx
@@ -35,14 +35,32 @@ import {
   SITIO_CASA,
   SITIO_COSECHA,
 } from './floraPapa.geom.js';
+import {
+  CIELOS,
+  mezclarCielo,
+  mezclar,
+  VERDES,
+  TIERRAS,
+  CASA,
+  ACENTOS,
+  LUCES,
+  NEUTROS,
+  LuzMadre,
+} from '../paleta/index.js';
 
-/* La atmósfera del piso frío: cielo azul limpio y luz dura de montaña alta. */
-const FRIO = {
-  fondo: '#b7d2e4',
-  bruma: '#c9dce8',
-  sol: '#fff8e6',
-  cielo: '#ddeaf4',
-  suelo: '#3b3226',
+/* La atmósfera del piso frío, DERIVADA de la madre: la familia `ladera`
+   ("bruma sí, pero verde-plata, no celeste frío") mezclada 60% hacia la hora
+   dorada — la misma ley de EscenaBase3D. El cielo azul de postal se va: el
+   frío se cuenta con los verdes callados y la bruma, no con otro sol. */
+const FRIO = mezclarCielo(CIELOS.ladera);
+
+/* Los cerros del fondo, ya con cara de páramo: la hoja coriácea comida por
+   la bruma dorada (perspectiva aérea con los MISMOS tokens de la casa). */
+const CERROS = {
+  cerca: mezclar(VERDES.paramoHoja, FRIO.niebla, 0.22),
+  media: mezclar(VERDES.paramoHoja, FRIO.niebla, 0.3),
+  lejos: mezclar(VERDES.paramoHoja, FRIO.niebla, 0.4),
+  filo: mezclar(TIERRAS.rocaParamo, FRIO.niebla, 0.45),
 };
 
 const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
@@ -67,13 +85,13 @@ function construirLadera(seg, plano) {
   const nz = seg + 1;
   const pos = new Float32Array(nx * nz * 3);
   const col = new Float32Array(nx * nz * 3);
-  const cPajonal = new THREE.Color('#9aa056');
-  const cPajonal2 = new THREE.Color('#aab061');
-  const cLomo = new THREE.Color('#4a3a2b'); // la tierra negra del caballón
-  const cLomoSeco = new THREE.Color('#5c4936'); // la cresta que el sol ya secó
-  const cSurco = new THREE.Color('#332920'); // el fondo húmedo entre lomos
-  const cCamino = new THREE.Color('#8d7a58');
-  const cLoma = new THREE.Color('#7f8a52'); // la loma alta, más parda de frío
+  const cPajonal = new THREE.Color(mezclar(TIERRAS.pajonal, VERDES.paramoLiquen, 0.5));
+  const cPajonal2 = new THREE.Color(VERDES.paramoLiquen);
+  const cLomo = new THREE.Color(mezclar(TIERRAS.turba, NEUTROS.tinta, 0.3)); // tierra negra del caballón
+  const cLomoSeco = new THREE.Color(mezclar(TIERRAS.turba, TIERRAS.camino, 0.25)); // la cresta que el sol secó
+  const cSurco = new THREE.Color(mezclar(TIERRAS.turba, NEUTROS.tinta, 0.65)); // el fondo húmedo entre lomos
+  const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.25));
+  const cLoma = new THREE.Color(mezclar(VERDES.paramoLiquen, VERDES.paramoMusgo, 0.4)); // la loma alta, parda de frío
   const c = new THREE.Color();
   let p = 0;
   for (let iz = 0; iz < nz; iz++) {
@@ -135,37 +153,37 @@ function construirLadera(seg, plano) {
 function CasaFria({ pos }) {
   return (
     <group position={pos} rotation={[0, 0.4, 0]}>
-      {/* la casa: adobe encalado con zócalo de tierra */}
+      {/* la casa: LA casa campesina de la paleta madre (la misma del valle) */}
       <mesh position={[0, 0.7, 0]}>
         <boxGeometry args={[2.4, 1.4, 1.8]} />
-        <meshLambertMaterial color="#ece4d2" flatShading />
+        <meshLambertMaterial color={CASA.encalado} flatShading />
       </mesh>
       <mesh position={[0, 0.17, 0]}>
         <boxGeometry args={[2.44, 0.34, 1.84]} />
-        <meshLambertMaterial color="#7a5a3c" flatShading />
+        <meshLambertMaterial color={CASA.zocalo} flatShading />
       </mesh>
-      {/* la puerta y la ventanita (maderas verdes de tierra fría) */}
+      {/* la puerta y la ventanita (la carpintería pintada de la casa) */}
       <mesh position={[0.42, 0.6, 0.91]}>
         <boxGeometry args={[0.42, 0.92, 0.06]} />
-        <meshLambertMaterial color="#3e5c40" flatShading />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
       </mesh>
       <mesh position={[-0.55, 0.84, 0.91]}>
         <boxGeometry args={[0.46, 0.4, 0.06]} />
-        <meshLambertMaterial color="#3e5c40" flatShading />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
       </mesh>
       {/* techo a dos aguas de teja */}
       <mesh position={[0, 1.56, -0.58]} rotation={[-0.6, 0, 0]}>
         <boxGeometry args={[2.8, 0.08, 1.42]} />
-        <meshLambertMaterial color="#96482f" flatShading />
+        <meshLambertMaterial color={CASA.tejaSombra} flatShading />
       </mesh>
       <mesh position={[0, 1.56, 0.58]} rotation={[0.6, 0, 0]}>
         <boxGeometry args={[2.8, 0.08, 1.42]} />
-        <meshLambertMaterial color="#a25136" flatShading />
+        <meshLambertMaterial color={CASA.teja} flatShading />
       </mesh>
       {/* la chimenea de fogón de leña (en el frío se cocina con candela) */}
       <mesh position={[-0.85, 1.85, -0.3]}>
         <boxGeometry args={[0.24, 0.6, 0.24]} />
-        <meshLambertMaterial color="#8a8074" flatShading />
+        <meshLambertMaterial color={mezclar(NEUTROS.lamina, TIERRAS.rocaParamo, 0.5)} flatShading />
       </mesh>
 
       {/* los COSTALES de papa cosidos en el patio, la cosecha que ya subió */}
@@ -175,11 +193,11 @@ function CasaFria({ pos }) {
         <group key={`s${i}`} position={[q[0], 0, q[1] ?? 0]} rotation={[0, q[2] ?? 0, 0]}>
           <mesh position={[0, 0.34, 0]}>
             <cylinderGeometry args={[0.24, 0.28, 0.68, 8, 1]} />
-            <meshLambertMaterial color="#c8b184" flatShading />
+            <meshLambertMaterial color={TIERRAS.vega} flatShading />
           </mesh>
           <mesh position={[0, 0.7, 0]} scale={[1, 0.5, 1]}>
             <sphereGeometry args={[0.2, 7, 5]} />
-            <meshLambertMaterial color="#b49c6e" flatShading />
+            <meshLambertMaterial color={mezclar(TIERRAS.vega, TIERRAS.camino, 0.35)} flatShading />
           </mesh>
         </group>
       ))}
@@ -188,11 +206,11 @@ function CasaFria({ pos }) {
       <group position={[-1.28, 0, 0.72]} rotation={[0, 0, 0.35]}>
         <mesh position={[0, 0.6, 0]}>
           <cylinderGeometry args={[0.03, 0.03, 1.2, 5, 1]} />
-          <meshLambertMaterial color="#8a6c48" flatShading />
+          <meshLambertMaterial color={TIERRAS.camino} flatShading />
         </mesh>
         <mesh position={[0.1, 0.06, 0]} rotation={[0, 0, -1.2]}>
           <boxGeometry args={[0.3, 0.14, 0.05]} />
-          <meshLambertMaterial color="#6e6a62" flatShading />
+          <meshLambertMaterial color={mezclar(NEUTROS.lamina, NEUTROS.tinta, 0.3)} flatShading />
         </mesh>
       </group>
     </group>
@@ -208,27 +226,27 @@ function RinconCosecha({ pos }) {
       <group position={[0.6, 0, -1.2]}>
         <mesh position={[0, 0.2, 0]}>
           <cylinderGeometry args={[0.3, 0.22, 0.4, 9, 1, true]} />
-          <meshLambertMaterial color="#a9713c" flatShading side={THREE.DoubleSide} />
+          <meshLambertMaterial color={CASA.bejuco} flatShading side={THREE.DoubleSide} />
         </mesh>
         <mesh position={[0, 0.4, 0]} scale={[1, 0.45, 1]}>
           <sphereGeometry args={[0.26, 8, 5]} />
-          <meshLambertMaterial color="#dfb43a" flatShading />
+          <meshLambertMaterial color={mezclar(ACENTOS.guayacan, ACENTOS.ambar, 0.5)} flatShading />
         </mesh>
       </group>
       {/* la manta tendida donde se aparta la saca por tamaños */}
       <mesh position={[-0.9, 0.03, 0.9]} rotation={[-Math.PI / 2, 0, 0.4]}>
         <planeGeometry args={[1.7, 1.2]} />
-        <meshLambertMaterial color="#cbbfa4" flatShading side={THREE.DoubleSide} />
+        <meshLambertMaterial color={mezclar(TIERRAS.vega, NEUTROS.cal, 0.35)} flatShading side={THREE.DoubleSide} />
       </mesh>
       {/* el azadón clavado en el montículo, en plena faena */}
       <group position={[1.3, 0, 0.6]} rotation={[0.5, 0.6, -0.35]}>
         <mesh position={[0, 0.62, 0]}>
           <cylinderGeometry args={[0.03, 0.03, 1.24, 5, 1]} />
-          <meshLambertMaterial color="#8a6c48" flatShading />
+          <meshLambertMaterial color={TIERRAS.camino} flatShading />
         </mesh>
         <mesh position={[0.1, 0.04, 0]} rotation={[0, 0, -1.2]}>
           <boxGeometry args={[0.3, 0.15, 0.05]} />
-          <meshLambertMaterial color="#6e6a62" flatShading />
+          <meshLambertMaterial color={mezclar(NEUTROS.lamina, NEUTROS.tinta, 0.3)} flatShading />
         </mesh>
       </group>
     </group>
@@ -255,7 +273,7 @@ function FocoPaso({ foco, reducedMotion }) {
     <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
       <ringGeometry args={[1.25, 1.65, 32]} />
       <meshBasicMaterial
-        color="#ffe9ae"
+        color={LUCES.candela}
         transparent
         opacity={0.4}
         depthWrite={false}
@@ -294,27 +312,16 @@ function Diorama({ tier, reducedMotion, foco }) {
   return (
     <>
       <color attach="background" args={[FRIO.fondo]} />
-      {perfil.fog && <fog attach="fog" args={[FRIO.bruma, 22, 58]} />}
+      {perfil.fog && <fog attach="fog" args={[FRIO.niebla, 22, 58]} />}
 
-      {/* la luz de montaña alta: cielo azul limpio, sol blanco y duro */}
-      <hemisphereLight intensity={0.95} color={FRIO.cielo} groundColor={FRIO.suelo} />
-      <ambientLight intensity={0.3} color="#e8eef4" />
-      <directionalLight
-        position={[9, 14, 6]}
-        intensity={1.35}
-        color={FRIO.sol}
-        castShadow={perfil.sombras}
-        shadow-mapSize-width={1024}
-        shadow-mapSize-height={1024}
-        shadow-camera-near={1}
-        shadow-camera-far={44}
-        shadow-camera-left={-17}
-        shadow-camera-right={17}
-        shadow-camera-top={17}
-        shadow-camera-bottom={-7}
+      {/* LA LUZ DE LA CASA: la receta madre con el tinte de la ladera de
+          páramo. El sol alto del frío y el frustum a medida del papal. */}
+      <LuzMadre
+        cielo={CIELOS.ladera}
+        perfil={perfil}
+        solPos={[9, 14, 6]}
+        sombra={{ left: -17, right: 17, top: 17, bottom: -7, far: 44 }}
       />
-      {/* contraluz azulado que enfría las sombras (el frío se ve) */}
-      <directionalLight position={[-7, 6, -8]} intensity={0.38} color="#b8cede" />
 
       {/* LA LADERA con sus caballones horneados en el relieve */}
       <mesh geometry={geoLadera} receiveShadow={perfil.sombras}>
@@ -324,20 +331,20 @@ function Diorama({ tier, reducedMotion, foco }) {
       {/* los cerros fríos del fondo, ya con cara de páramo */}
       <mesh position={[-14, 4.2, -24]} scale={[10, 5.6, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#6d7c54" />
+        <meshLambertMaterial color={CERROS.media} />
       </mesh>
       <mesh position={[6, 5.2, -27]} scale={[12, 7, 6]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#66755a" />
+        <meshLambertMaterial color={CERROS.lejos} />
       </mesh>
       <mesh position={[21, 3.4, -23]} scale={[8, 4.6, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#75825a" />
+        <meshLambertMaterial color={CERROS.cerca} />
       </mesh>
       {/* y detrasito, el filo pelado con su neblina pegada */}
       <mesh position={[-3, 7.8, -31]} scale={[16, 5, 5]}>
         <sphereGeometry args={[1, 10, 7]} />
-        <meshLambertMaterial color="#8b95a0" />
+        <meshLambertMaterial color={CERROS.filo} />
       </mesh>
 
       {/* EL PAPAL: matas en surcos, flores, cosecha, pajonal, frailejones */}


### PR DESCRIPTION
## FABLE_50 #7 — PALETA MADRE: coherencia de color entre mundos

Dos piezas en esta rama:

### 1. El módulo madre (`src/visual/mundo3d/paleta/`)
Rescatado de `fable/paleta-madre-a5` (estaba huérfano, sin PR): `paletaMadre.js` (verdes por piso térmico, tierras, cortezas, aguas, nieblas, luces, acentos, neutros — cada hex con fuente anotada), `materialesMadre.js` (recetas tier-safe), `LuzMadre.jsx` (la receta de iluminación de la casa como componente) y `GUIA.md`.

### 2. La ADOPCIÓN (lo nuevo)
Cafetal, cacaotal y papal inventaban cada uno su atmósfera: papal con **cielo celeste de postal alpina**, cafetal **verde-menta**, cacaotal lechoso; rigs de luces calcados con números propios (sol 1.2–1.35 donde el valle ilumina 0.9); y TRES tejas distintas para la misma casa campesina.

- Atmósfera **derivada, no inventada**: `mezclarCielo(CIELOS.corral / sotobosque / ladera)` — la misma ley 60%-hacia-la-madre de `EscenaBase3D`. El VALLE es el estándar; los tres mundos ahora comparten su atardecer dorado.
- `<LuzMadre>` montada en las tres escenas; gana props `solPos` y `sombra` (frustum a medida) para que nadie vuelva a calcar el rig.
- Token nuevo **`CASA`** (extraído de `composicionValle3D`): encalado, zócalo, teja/tejaSombra, carpintería, bejuco — la casa es UNA en todo piso térmico.
- `TIERRAS.arcilla` + `TIERRAS.mantillo/mantilloSombra` (superficies repetidas entre mundos, ahora con nombre).
- Terrenos, cerros de fondo (perspectiva aérea vía `mezclar` hacia la niebla dorada), canastos, herramientas, focos didácticos: **cero hex suelto** en las tres escenas.
- Marcos CSS de las vitrinas cafetal/papa entibiados.
- `scripts/diag/shot-paleta-mundos.mjs`: captura reproducible de los 3 mundos.

### Qué NO se tocó
- Geometría: cero. Solo color/luz/materiales/tokens.
- Los verdes de especie de la flora (`floraCacao.geom.js` etc.): identidad botánica legítima, la luz madre ya los entibia.
- Sierra/bosque/valle: son las FUENTES de la paleta, no destinatarios.
- El mundo del agua no existe en `app-3d` (vive en otra rama); queda para cuando llegue.

### Verificación
- `build:prod` VERDE, `tsc:check` limpio, lefthook completo (eslint/secret-scan/voseo) verde.
- Capturas antes/después de los 3 mundos verificadas en dev server (swiftshader): la comparativa va por Telegram al operador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)