### PR TITLE
feat(mundo3d): kit 3D compartido — fundación de la congruencia visual

### DIFF
--- a/ops/TOOLKIT-3D-INVENTARIO-2026-07-16.md
+++ b/ops/TOOLKIT-3D-INVENTARIO-2026-07-16.md
@@ -1,0 +1,212 @@
+# Inventario del Toolkit 3D — congruencia entre escenas
+
+**Fecha:** 2026-07-16 · **Rama base:** `app-3d` · **Rama:** `feat/toolkit-3d-congruencia`
+
+Objetivo: que las ~15 escenas 3D (`src/visual/mundo3d/**` + `src/mockups/*3D*`) se
+vean como **un solo juego de Switch**. Hoy no: cada escena reinventó terreno,
+niebla, luz, instancing y materiales. Este documento inventaria lo que existe,
+dónde está **duplicado**, **qué escena usa qué**, y los **GAPS**. La Fase 2
+(el módulo `src/visual/mundo3d/kit/`) ya consolida lo señalado aquí.
+
+---
+
+## 1. El hallazgo central: DOS familias de escena
+
+| Familia | Andamiaje | Atmósfera | Ciclo día | Sombra contacto | Cámara | Veredicto |
+|---|---|---|---|---|---|---|
+| **Dioramas** (`escenas/*`) | `EscenaBase3D` | hereda `atmosferaMadre` (mezcla 60% → hora madre) | **sí** (`useCicloDia`) | **sí** (`SombraContacto`) | `CamaraDirector` (establishing shot) | **coherente** |
+| **Mundos vivos** (`bosque/`, `cacao/`, `cafetal/`, `papa/`, `sierra/`) | `<Canvas>` propio | **cielo estático clavado** por escena | **no** | círculo plano a mano | `OrbitControls` pelón | **dispar** |
+
+La familia diorama ya está congruente porque **todo** (Canvas, luz, atmósfera de
+la hora, cámara, sombras) lo hereda de `EscenaBase3D`. La familia "mundo vivo"
+monta su propio Canvas y **reinventa cada pieza** — por eso se ven de otro juego.
+Cerrar esta brecha es el 80% de la congruencia.
+
+Ejemplo (`bosque/EscenaBosqueVivo.jsx`): define su propio `PARAMO` gris, su
+`rng` local, su niebla `[9,34]` fija, su sombra de contacto como `circleGeometry`
+plano, luces `directionalLight` estáticas — **no** cambia con la hora ni conversa
+con el valle. `cafetal/EscenaCafetalVivo.jsx` idem con su `TEMPLADO`.
+
+---
+
+## 2. Inventario por dimensión
+
+### 2.1 Terreno / heightfield
+- **Patrón repetido:** doble bucle nx×nz → `y = altura(wx,wz)` → color por vértice
+  (pasto/tierra/mantillo según altura+ruido) → índices → `toNonIndexed()` si
+  facetado → `computeVertexNormals`.
+- **Reimplementado en:** `cafetal/EscenaCafetalVivo.jsx` (`construirLadera`),
+  `cacao/EscenaCacaoVivo.jsx`, `papa/EscenaPapaVivo.jsx`, y mockups
+  (`MundoCafe3D`, `MundoParamo3D`, `ValleNoche3D`, `MomentoVentaMercado3D`,
+  `valle/Valle3D.jsx`).
+- Las funciones de altura propias (`alturaLadera`, `alturaTerreno`) SÍ son
+  identidad de cada escena y deben quedarse; lo duplicado es el **andamiaje**.
+- **→ kit:** `construirTerreno({ancho, fondo, seg, altura, pintar, plano})`.
+
+### 2.2 Atmósfera (cielo / niebla / luz)
+- **Canónico:** `atmosferaMadre.js` (`ATMOSFERA`, `CIELOS` por familia,
+  `mezclarCielo` receta 60%→madre, `BLOOM`, `PALETA`) + `cielosHoraData.js`
+  (`CIELOS_HORA` por franja, `presetDeHora`, `franjaDeHoraDecimal`).
+- `EscenaBase3D` los aplica (color de fondo + fog + hemisphere + ambient + sol de
+  la franja + relleno frío + estrellas). **Los mundos vivos NO** — clavan un
+  objeto de cielo local (`PARAMO`, `TEMPLADO`, etc.) estático.
+- **→ kit:** `atmosferaDeFamilia(familia, franja)` + `useAtmosferaMundo(...)` +
+  `<AtmosferaMundo>` (drop-in que replica el bloque de `EscenaBase3D`).
+
+### 2.3 Ciclo de día — `useCicloDia.js`
+- Reloj compartido, three-free, con override `?ciclo=demo|<hora>`.
+- **Usan:** `EscenaBase3D`, `mockups/EntradaValle3D`, `mockups/CaraProd3D`,
+  `bosque/FaunaBosque`. **NO usan:** las 4 escenas de mundo vivo (su Canvas
+  propio) → sus mundos no amanecen/anochecen.
+- **→ kit:** re-exportado; `useAtmosferaMundo` lo envuelve para la familia viva.
+
+### 2.4 Instancing / scatter + fusión segura
+- **`fusionarSeguro` / merge anti-null-silencioso — reimplementado en 7 archivos:**
+  | Archivo | Nombre | Nota |
+  |---|---|---|
+  | `bosque/sombreadoVegetal.js` | `fusionarSeguro` | **CANÓNICO** — desindexa + valida atributos + **truena** + `computeVertexNormals` |
+  | `finca/fincaRealista.geom.js` | `fusionarHato` | variante que NO recalcula normales (preserva suaves) + borra `uv` |
+  | `bosque/floraParamo.geom.js` | `fusionar` | con `dispose()`, sin validar atributos |
+  | `cafetal/floraCafetal.geom.js` | inline | copia local |
+  | `papa/floraPapa.geom.js` | inline | copia local |
+  | `cacao/floraCacao.geom.js` | inline | copia local |
+  | `vitrina/miradorAndino.geom.js` | inline | copia local |
+  Es la mordida documentada (`mergeGeometries` mezcla indexada+no-indexada →
+  **null en silencio** → especie invisible sin error). Ya apagó especies 3 veces.
+- **Scatter:** `floraParamo.geom.js` tiene un `sembrar`/`distribucionFlora`
+  genérico y bueno, pero **privado**. cacao/cafetal/papa reparten a mano.
+- **InstancedMesh:** cada `Flora*.jsx` arma su instanciado (1 draw-call/especie);
+  patrón sano pero no factorizado.
+- **→ kit:** `fusionarSeguro` (re-export del canónico, **única fusión permitida**)
+  + `sembrarEnAnillo(...)` (generaliza el `sembrar` de floraParamo).
+
+### 2.5 Ruido y PRNG (el azar determinista)
+- **`ruido(wx,wz)` de terreno — 6 copias byte-a-byte** (`cafetal/EscenaCafetalVivo`
+  + `cafetal/floraCafetal.geom`, `cacao/EscenaCacaoVivo` + `cacao/floraCacao.geom`,
+  `papa/EscenaPapaVivo` + `papa/floraPapa.geom`) + 1 variante (`sierra/…`) +
+  copias en mockups (`MundoCafe3D`, `MundoParamo3D`, `ValleNoche3D`,
+  `MomentoVentaMercado3D`).
+- **`rng(seed)` LCG — ~12 copias locales** (`entQuenua.geom`, `sombreadoVegetal`
+  [export], `EscenaBosqueVivo`, `EscenaEntMaestro`, `CicloMata`, `EscenaCalma3D`,
+  `EscenaCutaway`, `micorrizas.geom`, `MicrofaunaSuelo`, `MundoCompost3D`,
+  `MundoSemillero3D`, `MundoSueloVivo3D`, …).
+- **`crearRng(sem)` mulberry32 — canónico** en `particulasData.js`, importado por
+  ~10 mockups; PERO tiene 2 **copias locales** (`CatalogoInfra3D`, `AliadosFinca3D`).
+- **`ruido3D`/`ruidoFbm`/`hash3`** canónicos en `sombreadoVegetal`; `vitrina`
+  tiene su propio `fbm1D`/`fbm2D`.
+- **→ kit:** `ruidoTerreno` (la copia canónica), `rng` (re-export LCG), `crearRng`
+  (re-export mulberry32), `ruido3D`/`ruidoFbm` (re-export), `smoothstep`.
+
+### 2.6 Materiales / paleta
+- **Canónico:** `atmosferaMadre.PALETA` (madera/tierra/follaje/agua/piedra/… — un
+  solo marrón de madera en todo el juego) + `PAL` por escena (frailejón, café…)
+  para colores de especie. La `PALETA` madre es buena y está adoptada en varias.
+- No hay un "material canónico" (los dioramas usan `MeshLambert + flatShading`;
+  los animales `fincaRealista` van sin flatShading a propósito). Consistente por
+  contrato, no por un componente compartido — aceptable.
+- **→ kit:** `PALETA`, `CIELOS`, `BLOOM`, `mezclarCielo` re-exportados.
+
+### 2.7 Billboards SVG (criaturas rubber-hose como `<Html>`)
+- Las criaturas SVG se montan como billboards en `escenas/FaunaEscena.jsx`
+  (`Fauna`) y `bosque/FaunaBosque.jsx`. Patrón sano (reusa los SVG ya hechos, no
+  geometría procedural fea — memoria `svg-rubberhose-en-mundos-3d`).
+- **No está factorizado** como primitiva del kit → **GAP** (ver §4).
+
+### 2.8 Sombras de contacto / AO barato — `escenas/SombraContacto.jsx`
+- Canónico: `CanvasTexture` radial cacheada, plano transparente. Excelente.
+- **Solo lo usan** `EscenaBase3D` y `useEntradaAbeja`. Los mundos vivos hacen su
+  propio `circleGeometry` plano con `meshBasicMaterial` (aproximación pobre).
+- **→ kit:** re-exportado; `<AtmosferaMundo conSuelo>` lo monta por la familia viva.
+
+### 2.9 Cámara
+- `escenas/CamaraDirector.jsx` — establishing shot (dolly con arco + lente que se
+  asienta) + respiración del encuadre; una vez por sesión. Muy bueno.
+- `camaraDioramas.js` — `ENCUADRES`/`resolverEncuadre` (poses por mundo+tier).
+- **Duplicado:** hay un `CamaraDirector.jsx` en la raíz de `mundo3d/` además del
+  de `escenas/` (revisar cuál es el vivo; el de `escenas/` es el que usa
+  `EscenaBase3D`).
+- La familia viva usa `OrbitControls` pelón → sin establishing shot.
+- **→ kit:** `CamaraDirector` + `resolverEncuadre` re-exportados (migración pend.).
+
+### 2.10 Transiciones (VeloOdyssey / cruce)
+- **Ya consolidado** en `transiciones/` (barrel DOM-safe): `VeloOdyssey`,
+  `useCruceMundo`, `velosData` (`VELOS`, `duracionCruce`, `curvaCruce`…), y
+  `CamaraCruce` (import directo por el chunk three). Buen estado.
+- Además en la raíz: `TransicionMundo`, `TransicionNewDonk`, `TransicionMundoKit`,
+  `TransicionSierraMundo` — algo dispersos pero funcionales.
+- **→ kit:** re-exporta el barrel de `transiciones/`.
+
+### 2.11 device-tier — `deviceTier.js`
+- `decidirTier` (alto/medio/bajo por RAM/núcleos/saveData/webgl/reduced-motion),
+  `permite3D`, `perfilDeTier` (`PERFIL_RENDER`: dpr, sombras, segmentosTerreno,
+  flatShading, estrellas, criaturas, matasInstanciadas, lod, fog, sombrasContacto).
+- **La pieza mejor adoptada:** casi todas las escenas/mockups la usan. Modelo a
+  seguir para el resto del kit.
+- **→ kit:** re-exportado.
+
+---
+
+## 3. Mapa de consumidores (quién usa qué)
+
+- **`EscenaBase3D`** (11 arquetipos + 4 mockups): cutaway, flujo, recinto,
+  estratos, mercado, sanidad, semillero, boveda, cafe, calma, valle +
+  `MundoAgua3D`, `ValleLluvia3D`, `ColocarInfraestructura`, `JuegoMiFincaOdyssey`.
+- **`atmosferaMadre`**: ~45 archivos (paleta/cielos ampliamente adoptados).
+- **`deviceTier`/`perfilDeTier`**: ~universal (~70 archivos).
+- **`useCicloDia`**: `EscenaBase3D`, `EntradaValle3D`, `CaraProd3D`, `FaunaBosque`.
+- **`SombraContacto`**: `EscenaBase3D`, `useEntradaAbeja` (solo).
+- **`sombreadoVegetal`** (taller de geometría): `bosque/FaunaBosque`,
+  `sierra/sierraMonte.geom`, `finca/fincaRealista.geom` (los buenos ciudadanos).
+  cacao/cafetal/papa/vitrina **no** lo importan (reimplementan).
+
+---
+
+## 4. GAPS (lo que faltaba para congruencia)
+
+| # | Gap | Estado tras Fase 2 |
+|---|---|---|
+| G1 | Los mundos vivos no heredan la atmósfera/hora del valle (cielo estático). | **Cerrado por el kit** (`<AtmosferaMundo>` + `useAtmosferaMundo`). Falta *migrar* las 4 escenas. |
+| G2 | `fusionarSeguro` sin casa neutra → copia de la trampa null en 7 archivos. | **Cerrado** (kit re-exporta el canónico como única fusión). Falta migrar los inline. |
+| G3 | Sin constructor de terreno compartido. | **Cerrado** (`construirTerreno`). Falta migrar. |
+| G4 | Ruido de terreno + PRNG duplicados (6 + ~12 copias). | **Cerrado** (`ruidoTerreno`, `rng`, `crearRng`). Falta dedupe local. |
+| G5 | Sin scatter compartido. | **Cerrado** (`sembrarEnAnillo`). |
+| G6 | Cámara director atada a la familia diorama; la viva no la usa. | Re-exportada; **migración pendiente**. |
+| G7 | Billboards SVG de criaturas sin primitiva de kit. | **Abierto** — recomendación: `<BillboardCriatura>` que envuelva el patrón `<Html>` de `FaunaEscena`. |
+| G8 | Sin wrapper de Canvas para la familia viva (equivalente a `EscenaBase3D`). | **Abierto** — recomendación: `EscenaVivaBase` que componga `<AtmosferaMundo>` + `CamaraDirector` + `OrbitControls` + `MonitorRendimiento`. Cambio mayor; diferido. |
+| G9 | `CamaraDirector` duplicado (raíz vs `escenas/`). | **Abierto** — unificar. |
+
+---
+
+## 5. Fase 2 entregada — API del kit
+
+`src/visual/mundo3d/kit/` (ver `kit/README.md`). **Un solo import** para la
+congruencia. El barrel **importa three** → solo para archivos de escena (chunk
+`vendor-three`), nunca el barrel three-free `mundo3d/index.js`.
+
+- `ruido.js` — `rng`, `crearRng`, `ruidoTerreno`, `ruido3D`, `ruidoFbm`, `smoothstep`, `saturar`.
+- `geometria.js` — `fusionarSeguro` (única fusión), `desindexar`, `poner`, `apuntar`,
+  `pintarPorVertice`, `pintarPlano`, `hornearFollaje`, `hornearCorteza`,
+  `tuboOrganico`, `taperTronco`, `curvaTronco`, `sembrarFollaje`, `matojoHoja`, `sembrarEnAnillo`.
+- `terreno.js` — `construirTerreno`.
+- `atmosfera.js` — `atmosferaDeFamilia`, `useAtmosferaMundo`.
+- `AtmosferaMundo.jsx` — drop-in `<color>/<fog>/luces/estrellas/sombras`.
+- `index.js` — barrel + re-exports de paleta madre, cielos por hora, `useCicloDia`,
+  `deviceTier`, `SombraContacto`, `CamaraDirector`/`resolverEncuadre`, transiciones.
+
+**Pruebas:** `kit/__tests__/kit.test.js` (headless) cubre determinismo del ruido,
+`fusionarSeguro` **tronando** ante null/atributos dispares, `construirTerreno`,
+coherencia de `atmosferaDeFamilia` con la hora, y `sembrarEnAnillo` determinista.
+
+### Nota sobre gates
+- `kit/__tests__/kit.test.js`: **11/11 verde**.
+- El diff de esta rama es **solo** `src/visual/mundo3d/kit/` (archivos nuevos, aún
+  sin consumidores) → **no introduce errores de tsc**. `origin/app-3d` ya trae 2
+  errores de tsc **pre-existentes y ajenos** al kit (`AgentAvatarSelector.jsx`,
+  `saludoPantalla.test.js`) — fuera del alcance de este toolkit.
+
+## 6. Siguiente ola (para la reescritura valle/bosque)
+1. Migrar `EscenaBosqueVivo`/`EscenaCacaoVivo`/`EscenaCafetalVivo`/`EscenaPapaVivo`
+   a `<AtmosferaMundo>` + `construirTerreno` + `fusionarSeguro` del kit (G1–G4).
+2. Reemplazar los `rng`/`ruido` locales por los del kit (G4).
+3. Construir `<BillboardCriatura>` (G7) y evaluar `EscenaVivaBase` (G8).
+4. Unificar el `CamaraDirector` duplicado (G9).

--- a/src/visual/mundo3d/kit/AtmosferaMundo.jsx
+++ b/src/visual/mundo3d/kit/AtmosferaMundo.jsx
@@ -1,0 +1,105 @@
+/*
+ * AtmosferaMundo — la ATMÓSFERA compartida como componente DROP-IN para cualquier
+ * `<Canvas>` (no solo los dioramas de EscenaBase3D).
+ *
+ * Pinta EXACTAMENTE los mismos `<color>`, `<fog>`, luces, estrellas y sombras de
+ * contacto que `EscenaBase3D` monta para la familia de dioramas — mismos colores
+ * (mezcla 60% hacia la hora madre del valle), mismos multiplicadores de luz,
+ * mismo bloom de sombra — pero SUELTO, para que las escenas de "mundo vivo"
+ * (bosque, cacao, cafetal, papa, sierra) que arman su propio Canvas dejen de
+ * clavar un cielo estático y HEREDEN el ciclo diurno vivo y la paleta del valle.
+ *
+ * Uso (dentro del `<Canvas>` de la escena, reemplazando su `<color>`/luces):
+ *
+ *   <AtmosferaMundo familia="sotobosque" tier={tier} reducedMotion={rm} radio={7} />
+ *
+ * Tier-safe: en 'bajo' (frugal) apaga niebla, estrellas y alfombras (overdraw) —
+ * el mismo contrato de costo que EscenaBase3D. `radio` es la escala de la escena
+ * (la distancia cámara↔centro): escala el near/far de la niebla y el tamaño de
+ * las alfombras de contacto para que el velo caiga donde debe.
+ */
+import { Stars } from '@react-three/drei';
+import { perfilDeTier } from '../deviceTier.js';
+import { SombraContacto } from '../escenas/SombraContacto.jsx';
+import { useAtmosferaMundo } from './atmosfera.js';
+
+/**
+ * @param {object} props
+ * @param {string} [props.familia='neutro']  clave de CIELOS (atmosferaMadre):
+ *   neutro | agua | tierra | corral | plaza | huerta | sotobosque | ladera | alba.
+ * @param {'alto'|'medio'|'bajo'} [props.tier='alto']  device-tier (presupuesto).
+ * @param {boolean} [props.reducedMotion=false]  quieta (apaga el día acelerado y
+ *   la rotación de estrellas).
+ * @param {number} [props.radio=6.5]  escala de la escena (cámara↔centro); escala
+ *   niebla y alfombras de contacto.
+ * @param {number} [props.piso=0]  altura Y del suelo (posa las alfombras).
+ * @param {boolean} [props.conSuelo=true]  monta las alfombras de contacto que
+ *   "posan" el diorama. Póngalo en false si la escena ya trae su propio suelo.
+ * @param {boolean} [props.conNiebla=true]  monta la niebla de profundidad.
+ * @param {boolean} [props.conEstrellas=true]  deja asomar las estrellas de noche.
+ */
+export default function AtmosferaMundo({
+  familia = 'neutro',
+  tier = 'alto',
+  reducedMotion = false,
+  radio = 6.5,
+  piso = 0,
+  conSuelo = true,
+  conNiebla = true,
+  conEstrellas = true,
+}) {
+  const atm = useAtmosferaMundo({ familia, reducedMotion });
+  const frugal = tier === 'bajo';
+  const perfil = perfilDeTier(tier);
+
+  return (
+    <>
+      <color attach="background" args={[atm.fondo]} />
+      {conNiebla && !frugal && (
+        <fog attach="fog" args={[atm.niebla, radio * 1.4, radio * 4.6]} />
+      )}
+      <hemisphereLight intensity={0.55 * atm.intensidad} color={atm.cielo} groundColor={atm.suelo} />
+      <ambientLight intensity={0.28 * atm.intensidad} color={atm.luz} />
+      {/* El sol de la franja — mismo arco que el valle (rasante al amanecer,
+          cenital al mediodía, luna de noche): el lenguaje de sombreado no cambia
+          al entrar al mundo. */}
+      <directionalLight position={atm.solPos} intensity={0.9 * atm.intensidad} color={atm.luz} />
+      {/* Relleno frío tenue desde el lado opuesto: despega los volúmenes del
+          fondo cálido sin matar el contraste (clave del look claymation). */}
+      <directionalLight position={[-5, 4, -6]} intensity={0.22} color={atm.relleno} />
+
+      {conEstrellas && atm.estrellas > 0 && !frugal && (
+        <Stars
+          radius={radio * 8}
+          depth={30}
+          count={Math.round(perfil.estrellas * atm.estrellas)}
+          factor={3}
+          saturation={0}
+          fade
+          speed={reducedMotion ? 0 : 0.5}
+        />
+      )}
+
+      {conSuelo && !frugal && (
+        <>
+          <SombraContacto
+            refExt={undefined}
+            pos={[0, piso + 0.008, 0]}
+            radio={radio * 0.68}
+            color={atm.alfombra}
+            opacidad={0.5}
+            orden={1}
+          />
+          <SombraContacto
+            refExt={undefined}
+            pos={[0, piso + 0.02, 0]}
+            radio={radio * 0.4}
+            color={atm.sombra}
+            opacidad={0.3}
+            orden={2}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/src/visual/mundo3d/kit/README.md
+++ b/src/visual/mundo3d/kit/README.md
@@ -1,0 +1,91 @@
+# kit — Toolkit 3D compartido de Chagra
+
+La fundación de la **congruencia visual**: todas las escenas 3D deben verse como
+**un solo juego de Switch** (mismo suelo, misma niebla, misma luz de la hora del
+valle, misma paleta madre, misma sombra de contacto, la misma fusión de geometría
+a prueba del *null silencioso*). Antes cada escena reinventaba esas piezas y se
+veían dispares. Este módulo las reúne detrás de **un solo import**.
+
+```js
+import {
+  AtmosferaMundo, useAtmosferaMundo, construirTerreno, ruidoTerreno,
+  fusionarSeguro, poner, apuntar, hornearFollaje, sembrarEnAnillo,
+  PALETA, CIELOS, perfilDeTier, SombraContacto, useCicloDia,
+} from '@/visual/mundo3d/kit';
+```
+
+> ⚠️ **El barrel importa `three`/`@react-three`.** Úselo solo desde archivos de
+> escena (chunk `vendor-three`, montaje perezoso). **No** lo importe desde el
+> barrel three-free `mundo3d/index.js` ni desde el bundle base. Para dato puro
+> three-free (paleta, cielos por hora, device-tier) importe del módulo suelto.
+
+## Qué consolida (y de dónde sale lo canónico)
+
+| Pieza | Casa canónica | Qué resuelve |
+|---|---|---|
+| `rng` (LCG) | `bosque/sombreadoVegetal.js` | PRNG de la línea de geometría — la misma semilla da el mismo árbol en todo el juego. Estaba reimplementado ~12×. |
+| `crearRng` (mulberry32) | `particulasData.js` | PRNG de partículas/dispersión, three-free. |
+| `ruidoTerreno(wx,wz)` | **kit/ruido.js (nuevo)** | El ruido 2D de terreno que estaba **copiado byte-a-byte en 6 escenas**. |
+| `ruido3D` / `ruidoFbm` | `bosque/sombreadoVegetal.js` | Ruido de valor 3D (arruga corteza, muerde copa). |
+| `fusionarSeguro` | `bosque/sombreadoVegetal.js` | **La única fusión permitida**: desindexa, valida atributos y **truena** si `mergeGeometries` da null. La trampa del null silencioso estaba reimplementada en **7 archivos**. |
+| `poner` / `apuntar` / `hornearFollaje` / `hornearCorteza` / `tuboOrganico` / `curvaTronco` / `sembrarFollaje` / `matojoHoja` | `bosque/sombreadoVegetal.js` | Colocación + horneado de color por vértice + geometría orgánica. |
+| `sembrarEnAnillo` | **kit/geometria.js (nuevo)** | Dispersión determinista en anillo (generaliza el `sembrar` privado de `floraParamo`). |
+| `construirTerreno` | **kit/terreno.js (nuevo)** | Heightfield con color por vértice — consolida el `construirLadera`/`construirSuelo` de cafetal/cacao/papa. |
+| `atmosferaDeFamilia` / `useAtmosferaMundo` / `AtmosferaMundo` | **kit/atmosfera(.jsx) (nuevo)** | La hora viva del valle (ciclo diurno + mezcla 60% a la madre) **para cualquier Canvas**, no solo dioramas. |
+| `PALETA` / `CIELOS` / `mezclarCielo` / `BLOOM` | `atmosferaMadre.js` | Paleta y cielos madre. |
+| `CIELOS_HORA` / `presetDeHora` / `franjaDeHoraDecimal` | `cielosHoraData.js` | Presets de luz por franja del día. |
+| `perfilDeTier` / `decidirTier` | `deviceTier.js` | Presupuesto de render por dispositivo (LOD). |
+| `SombraContacto` | `escenas/SombraContacto.jsx` | AO barato (sombra de contacto falsa). |
+| `CamaraDirector` / `resolverEncuadre` | `escenas/CamaraDirector.jsx`, `camaraDioramas.js` | Establishing shot + encuadres por mundo. |
+| `VeloOdyssey` / `useCruceMundo` | `transiciones/` | Transición Odyssey entre mundos. |
+
+**No se movió** el código canónico (evitar churn/roturas en escenas que ya
+importan de su casa). El kit es la **superficie pública** única.
+
+## Receta: hacer congruente un "mundo vivo" (bosque/cacao/cafetal/papa)
+
+Estas escenas montan su propio `<Canvas>` y hoy clavan un cielo estático que ni
+cambia con la hora ni conversa con el valle. Para heredar la hora viva:
+
+```jsx
+import { Canvas } from '@react-three/fiber';
+import { AtmosferaMundo, perfilDeTier, construirTerreno, ruidoTerreno } from '@/visual/mundo3d/kit';
+
+function Diorama({ tier, reducedMotion }) {
+  return (
+    <>
+      {/* reemplaza <color>/<fog>/luces/estrellas/sombras hechas a mano: */}
+      <AtmosferaMundo familia="sotobosque" tier={tier} reducedMotion={reducedMotion} radio={7} />
+      {/* … tu terreno con construirTerreno(...), tu flora con fusionarSeguro(...) … */}
+    </>
+  );
+}
+```
+
+`familia` es una de `CIELOS`: `neutro | agua | tierra | corral | plaza | huerta |
+sotobosque | ladera | alba`. Es el 40% de identidad propia del mundo; el 60%
+restante lo pone la hora madre del valle.
+
+## Terreno
+
+```js
+const geo = construirTerreno({
+  ancho: 20, fondo: 20, seg: perfilDeTier(tier).segmentosTerreno,
+  altura: (wx, wz) => ruidoTerreno(wx * 0.2, wz * 0.2) * 1.5,
+  pintar: (wx, wz, alt, out) => out.lerpColors(cPasto, cTierra, saturar(alt)),
+  plano: perfilDeTier(tier).flatShading,
+});
+```
+
+## Geometría procedural — regla de oro
+
+**Nunca** llame `mergeGeometries` a mano. Siempre `fusionarSeguro(partes, etiqueta)`.
+Desindexa todo, valida que las partes declaren los mismos atributos y truena con
+el nombre de la especie si el merge da null — el fallo que ya apagó especies
+enteras **sin un solo error en consola**, tres veces.
+
+## Estado / GAPS pendientes
+
+Ver `ops/TOOLKIT-3D-INVENTARIO-2026-07-16.md` para el inventario completo, los
+consumidores por escena y los gaps que quedan (migración de las escenas vivas al
+kit, dedupe del PRNG local, terreno de los mockups).

--- a/src/visual/mundo3d/kit/__tests__/kit.test.js
+++ b/src/visual/mundo3d/kit/__tests__/kit.test.js
@@ -1,0 +1,131 @@
+/*
+ * Pruebas del toolkit 3D compartido (parte three-core, headless).
+ *
+ * Cubre lo que garantiza la CONGRUENCIA y lo que ya mordió en producción:
+ *   · ruidoTerreno determinista (dos escenas siembran igual).
+ *   · fusionarSeguro TRUENA en vez de dejar geometría invisible (null silencioso).
+ *   · construirTerreno arma la malla con color por vértice.
+ *   · atmosferaDeFamilia hereda la hora del valle (coherencia de paleta).
+ *   · sembrarEnAnillo es determinista y respeta el anillo.
+ */
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { ruidoTerreno, smoothstep, saturar } from '../ruido.js';
+import { fusionarSeguro, sembrarEnAnillo } from '../geometria.js';
+import { construirTerreno } from '../terreno.js';
+import { atmosferaDeFamilia } from '../atmosfera.js';
+import { rng } from '../ruido.js';
+
+const esHex = (s) => typeof s === 'string' && /^#[0-9a-f]{6}$/i.test(s);
+
+describe('ruido', () => {
+  it('ruidoTerreno es determinista y ~[-1,1]', () => {
+    for (let i = 0; i < 50; i++) {
+      const x = (i - 25) * 0.7;
+      const z = (i * 1.3) % 11;
+      const a = ruidoTerreno(x, z);
+      const b = ruidoTerreno(x, z);
+      expect(a).toBe(b);
+      expect(a).toBeGreaterThanOrEqual(-1.0001);
+      expect(a).toBeLessThanOrEqual(1.0001);
+    }
+  });
+
+  it('smoothstep sube monótono de 0 a 1; saturar recorta', () => {
+    expect(smoothstep(0, 10, -5)).toBe(0);
+    expect(smoothstep(0, 10, 15)).toBe(1);
+    expect(smoothstep(0, 10, 5)).toBeCloseTo(0.5, 5);
+    expect(saturar(-2)).toBe(0);
+    expect(saturar(2)).toBe(1);
+    expect(saturar(0.4)).toBe(0.4);
+  });
+});
+
+describe('fusionarSeguro (anti null silencioso)', () => {
+  it('fusiona partes compatibles en una geometría', () => {
+    const a = new THREE.BoxGeometry(1, 1, 1);
+    const b = new THREE.ConeGeometry(0.5, 1, 6); // indexada; se desindexa dentro
+    const g = fusionarSeguro([a, b], 'test');
+    expect(g).toBeInstanceOf(THREE.BufferGeometry);
+    expect(g.attributes.position.count).toBeGreaterThan(0);
+  });
+
+  it('TRUENA sin partes (no deja geometría vacía silenciosa)', () => {
+    expect(() => fusionarSeguro([], 'vacio')).toThrow(/vacio/);
+  });
+
+  it('TRUENA con atributos dispares (la mordida de mergeGeometries→null)', () => {
+    const a = new THREE.BoxGeometry(1, 1, 1);
+    const b = new THREE.BoxGeometry(1, 1, 1);
+    b.deleteAttribute('uv'); // atributos ya no coinciden con `a`
+    expect(() => fusionarSeguro([a, b], 'dispar')).toThrow(/dispar/);
+  });
+});
+
+describe('construirTerreno', () => {
+  it('arma heightfield con position y color; respeta seg', () => {
+    const seg = 8;
+    const geo = construirTerreno({
+      ancho: 10,
+      fondo: 10,
+      seg,
+      altura: (wx, wz) => ruidoTerreno(wx * 0.3, wz * 0.3) * 0.5,
+      pintar: (wx, wz, alt, out) => out.setRGB(0.4, 0.6, 0.3),
+    });
+    expect(geo.attributes.position.count).toBe((seg + 1) * (seg + 1));
+    expect(geo.attributes.color).toBeTruthy();
+    expect(geo.index).toBeTruthy(); // indexada por defecto
+  });
+
+  it('plano:true desindexa (look facetado)', () => {
+    const geo = construirTerreno({
+      ancho: 4, fondo: 4, seg: 4,
+      altura: () => 0,
+      pintar: (wx, wz, alt, out) => out.setRGB(1, 1, 1),
+      plano: true,
+    });
+    expect(geo.index).toBeNull();
+  });
+});
+
+describe('atmosferaDeFamilia (coherencia con la hora del valle)', () => {
+  it('devuelve colores hex y arco solar por franja', () => {
+    const dorada = atmosferaDeFamilia('sotobosque', 'tarde');
+    expect(esHex(dorada.fondo)).toBe(true);
+    expect(esHex(dorada.niebla)).toBe(true);
+    expect(esHex(dorada.luz)).toBe(true);
+    expect(Array.isArray(dorada.solPos)).toBe(true);
+    expect(dorada.solPos).toHaveLength(3);
+  });
+
+  it('la noche baja intensidad y enciende estrellas; la franja viaja', () => {
+    const noche = atmosferaDeFamilia('sotobosque', 'noche');
+    const mediodia = atmosferaDeFamilia('sotobosque', 'mediodia');
+    expect(noche.estrellas).toBeGreaterThan(0);
+    expect(mediodia.estrellas).toBe(0);
+    expect(noche.intensidad).toBeLessThan(mediodia.intensidad);
+    expect(noche.franja).toBe('noche');
+    expect(noche.fondo).not.toBe(mediodia.fondo);
+  });
+
+  it('familia desconocida cae a neutro sin romper', () => {
+    const x = atmosferaDeFamilia('no-existe', 'mediodia');
+    expect(esHex(x.fondo)).toBe(true);
+  });
+});
+
+describe('sembrarEnAnillo', () => {
+  it('es determinista por semilla y respeta el anillo', () => {
+    const gen = () => sembrarEnAnillo({ n: 12, rMin: 3, rMax: 8, rand: rng(42) });
+    const a = gen();
+    const b = gen();
+    expect(a).toEqual(b);
+    expect(a).toHaveLength(12);
+    for (const it of a) {
+      const rad = Math.hypot(it.pos[0], it.pos[2]);
+      expect(rad).toBeGreaterThanOrEqual(3 - 1e-6);
+      expect(rad).toBeLessThanOrEqual(8 + 1e-6);
+      expect(it.pos[1]).toBe(0);
+    }
+  });
+});

--- a/src/visual/mundo3d/kit/atmosfera.js
+++ b/src/visual/mundo3d/kit/atmosfera.js
@@ -1,0 +1,90 @@
+/*
+ * kit/atmosfera — la ATMÓSFERA RESUELTA de un mundo, lista para cualquier Canvas.
+ *
+ * `EscenaBase3D` ya heredaba la hora del valle (ciclo diurno vivo + mezcla 60%
+ * hacia la madre) para toda la familia de DIORAMAS. Pero las escenas de "mundo
+ * vivo" (bosque, cacao, cafetal, papa, sierra) montan su PROPIO `<Canvas>` y por
+ * eso quedaban fuera: cada una clavaba un cielo estático (el páramo gris del
+ * bosque, el templado del cafetal) que ni cambia con la hora ni conversa con el
+ * valle — entrar a esos mundos se siente como abrir otra app.
+ *
+ * Este módulo saca la RECETA de EscenaBase3D a una función pura y un hook para
+ * que CUALQUIER escena la reciba sin depender del andamiaje de dioramas:
+ *
+ *   const atm = useAtmosferaMundo({ familia: 'sotobosque', reducedMotion });
+ *   // atm.fondo, atm.niebla, atm.cielo, atm.suelo, atm.luz, atm.relleno,
+ *   // atm.solPos, atm.intensidad, atm.estrellas, atm.sombra, atm.alfombra
+ *
+ * Y `<AtmosferaMundo>` (kit/AtmosferaMundo.jsx) lo pinta como los `<color>`,
+ * `<fog>` y luces que EscenaBase3D ya usa — mismos multiplicadores, mismo look.
+ *
+ * `familia` es una de las de `CIELOS` (atmosferaMadre): neutro | agua | tierra |
+ * corral | plaza | huerta | sotobosque | ladera | alba. Es el 40% de identidad
+ * propia del mundo; el 60% restante lo pone la hora madre del valle.
+ */
+import { useMemo } from 'react';
+import { CIELOS, mezclarCielo } from '../atmosferaMadre.js';
+import { presetDeHora } from '../cielosHoraData.js';
+import useCicloDia from '../useCicloDia.js';
+
+/**
+ * @typedef {object} AtmosferaMundo
+ * @property {string} fondo       scene.background.
+ * @property {string} cielo       hemisphereLight (bóveda).
+ * @property {string} suelo       hemisphereLight (rebote de tierra).
+ * @property {string} niebla      color del fog.
+ * @property {string} alfombra    tinte de la alfombra de suelo (sombra ancha).
+ * @property {string} luz         color del sol/luna (direccional principal + ambiente).
+ * @property {string} relleno     color del relleno frío opuesto.
+ * @property {string} sombra      tinte de las sombras de contacto.
+ * @property {[number,number,number]} solPos  posición del sol (el arco del día).
+ * @property {number} intensidad  multiplicador global de la hora (la noche baja todo).
+ * @property {number} estrellas   fracción 0..1 del presupuesto de estrellas del tier.
+ * @property {string} franja      la franja del día que produjo esta atmósfera.
+ */
+
+/**
+ * Resuelve la atmósfera de un mundo para una FRANJA dada del día: el cielo propio
+ * de la `familia` mezclado 60% hacia la hora madre del valle (la misma receta,
+ * `mezclarCielo`, que usa EscenaBase3D) + los campos de LUZ de la hora (sol,
+ * relleno, posición, estrellas). Pura salvo el `THREE.Color` interno de
+ * `mezclarCielo`; memoícela en quien llama (el hook ya lo hace).
+ *
+ * @param {string} familia  clave de CIELOS (atmosferaMadre).
+ * @param {string} franja   'amanecer'|'manana'|'mediodia'|'tarde'|'atardecer'|'noche'.
+ * @returns {AtmosferaMundo}
+ */
+export function atmosferaDeFamilia(familia, franja) {
+  const madre = presetDeHora(franja);
+  const c = mezclarCielo(CIELOS[familia], madre);
+  return {
+    fondo: c.fondo,
+    cielo: c.cielo,
+    suelo: c.suelo,
+    niebla: c.niebla,
+    alfombra: c.alfombra,
+    intensidad: c.intensidad,
+    luz: madre.luz,
+    relleno: madre.relleno,
+    sombra: madre.sombra,
+    solPos: /** @type {[number, number, number]} */ (madre.solPos),
+    estrellas: madre.estrellas,
+    franja,
+  };
+}
+
+/**
+ * Hook: la atmósfera VIVA de un mundo. Envuelve el reloj del ciclo diurno
+ * (`useCicloDia`) y memoíza la resolución por franja — la franja cambia unas
+ * pocas veces al día (en `?ciclo=demo`, cada pocos segundos), así que el costo
+ * es nulo por frame. El mundo amanece, atardece y anochece CON el valle.
+ *
+ * @param {object} o
+ * @param {string} [o.familia='neutro']  clave de CIELOS.
+ * @param {boolean} [o.reducedMotion=false]  apaga el día acelerado del modo demo.
+ * @returns {AtmosferaMundo}
+ */
+export function useAtmosferaMundo({ familia = 'neutro', reducedMotion = false } = {}) {
+  const { franja } = useCicloDia({ reducedMotion });
+  return useMemo(() => atmosferaDeFamilia(familia, franja), [familia, franja]);
+}

--- a/src/visual/mundo3d/kit/geometria.js
+++ b/src/visual/mundo3d/kit/geometria.js
@@ -1,0 +1,90 @@
+/*
+ * kit/geometria — el TALLER de geometría procedural compartido (three-core puro).
+ *
+ * La auditoría de congruencia (2026-07-16) halló la trampa del `mergeGeometries`
+ * → null en silencio REIMPLEMENTADA en siete archivos (floraParamo, floraCafetal,
+ * floraPapa, floraCacao, fincaRealista, miradorAndino y la canónica de
+ * sombreadoVegetal). Esa mordida ya apagó especies enteras sin un solo error en
+ * consola, tres veces. La versión CANÓNICA — la que desindexa TODO, valida que
+ * las partes declaren los mismos atributos y TRUENA si el merge da null — vive en
+ * `sombreadoVegetal.js`. Aquí se re-exporta para que TODA escena nueva la alcance
+ * con un solo import y deje de copiar la trampa:
+ *
+ *   import { fusionarSeguro, poner, apuntar, hornearFollaje } from '.../kit';
+ *
+ * No se MUEVE el código (evitar churn/roturas en las escenas que ya importan de
+ * `sombreadoVegetal`); esto es la SUPERFICIE PÚBLICA única del taller.
+ *
+ * Regla de oro (memoria mergeGeometries-null-silencioso): jamás llamar
+ * `mergeGeometries` a mano en una escena. Siempre `fusionarSeguro(partes, etiqueta)`
+ * — desindexa, valida atributos y truena con el nombre de la especie si falla.
+ */
+
+export {
+  /* PRNG y ruido (también en kit/ruido.js; aquí por conveniencia del taller). */
+  rng,
+  ruido3D,
+  ruidoFbm,
+  /* Fusión SEGURA — la única forma permitida de unir partes. */
+  fusionarSeguro,
+  desindexar,
+  /* Colocación de partes (transforman los vértices en coords del modelo). */
+  poner,
+  apuntar,
+  /* Horneado de color por vértice (AO + gradiente + translucidez, gratis en
+     runtime: viaja en el atributo `color`). */
+  pintarPorVertice,
+  pintarPlano,
+  hornearFollaje,
+  hornearCorteza,
+  /* Geometría orgánica: troncos/ramas con conicidad y arruga reales. */
+  tuboOrganico,
+  taperLineal,
+  taperTronco,
+  curvaTronco,
+  /* Cúmulos de follaje con huecos y borde mordido (anti árbol-de-navidad). */
+  sembrarFollaje,
+  matojoHoja,
+} from '../bosque/sombreadoVegetal.js';
+
+/**
+ * Distribución determinista en ANILLO alrededor del origen (la cámara ORBITA,
+ * así que la composición de un mundo es un anillo por estrato, no un frente).
+ * Es la generalización del `sembrar` que vivía privado en `floraParamo.geom`:
+ * árboles de fondo con reparto angular parejo, sotobosque agrupado al azar.
+ *
+ * @param {object} o
+ * @param {number} o.n           cuántas instancias.
+ * @param {number} o.rMin        radio interior del anillo.
+ * @param {number} o.rMax        radio exterior.
+ * @param {() => number} o.rand  fuente de azar (un `rng(seed)` — determinista).
+ * @param {number} [o.escMin=0.9]   escala mínima por instancia.
+ * @param {number} [o.escMax=1.15]  escala máxima.
+ * @param {boolean} [o.uniforme=false]  reparto angular parejo (árboles) vs
+ *                                       aleatorio (matorral).
+ * @param {boolean} [o.haciaAfuera=false]  sesga el radio hacia el borde (sqrt).
+ * @param {number} [o.varia=0.12]   amplitud del tinte por instancia.
+ * @returns {{pos:[number,number,number], rotY:number, escala:number, tint:[number,number,number]}[]}
+ */
+export function sembrarEnAnillo({
+  n, rMin, rMax, rand, escMin = 0.9, escMax = 1.15,
+  uniforme = false, haciaAfuera = false, varia = 0.12,
+}) {
+  const arr = [];
+  for (let i = 0; i < n; i++) {
+    const ang = uniforme
+      ? (i / Math.max(1, n)) * Math.PI * 2 + (rand() - 0.5) * 0.7
+      : rand() * Math.PI * 2;
+    const rad = rMin + (rMax - rMin) * (haciaAfuera ? Math.sqrt(rand()) : rand());
+    const f = 1 + (rand() - 0.5) * varia;
+    const h = (rand() - 0.5) * varia * 0.4;
+    const cl = (v) => Math.max(0.7, Math.min(1.16, v));
+    arr.push({
+      pos: /** @type {[number, number, number]} */ ([Math.cos(ang) * rad, 0, Math.sin(ang) * rad]),
+      rotY: rand() * Math.PI * 2,
+      escala: escMin + rand() * (escMax - escMin),
+      tint: /** @type {[number, number, number]} */ ([cl(f + h), cl(f), cl(f - h * 0.6)]),
+    });
+  }
+  return arr;
+}

--- a/src/visual/mundo3d/kit/index.js
+++ b/src/visual/mundo3d/kit/index.js
@@ -1,0 +1,78 @@
+/*
+ * kit — EL TOOLKIT 3D COMPARTIDO de Chagra: la superficie única de congruencia.
+ *
+ * Todas las escenas 3D (dioramas de EscenaBase3D y "mundos vivos" con su propio
+ * Canvas) deben verse como UN juego de Switch: mismo suelo, misma niebla, misma
+ * luz de la hora del valle, misma paleta madre, misma sombra de contacto, la
+ * misma fusión de geometría a prueba del null silencioso. Antes cada escena
+ * reinventaba esas piezas y se veían dispares. Este barrel las reúne para que la
+ * próxima escena (y la reescritura del valle/bosque) importe UNA cosa:
+ *
+ *   import {
+ *     AtmosferaMundo, useAtmosferaMundo, construirTerreno, ruidoTerreno,
+ *     fusionarSeguro, poner, apuntar, hornearFollaje, sembrarEnAnillo,
+ *     PALETA, CIELOS, perfilDeTier, SombraContacto, useCicloDia,
+ *   } from '@/visual/mundo3d/kit';
+ *
+ * ⚠️ ESTE BARREL IMPORTA `three`/`@react-three` (vía AtmosferaMundo/SombraContacto/
+ * el taller de geometría). NO lo importe desde el barrel three-free de
+ * `mundo3d/index.js` ni desde el bundle base: es SOLO para archivos de escena que
+ * ya viven en el chunk `vendor-three` (montaje perezoso). Para dato puro
+ * three-free (paleta, cielos por hora, device-tier) importe del módulo suelto.
+ *
+ * Mapa del kit:
+ *   · ruido.js        rng/crearRng + ruidoTerreno + ruido3D/ruidoFbm + smoothstep
+ *   · geometria.js    fusionarSeguro (¡la única fusión!) + colocación + horneado
+ *                     + geometría orgánica + sembrarEnAnillo
+ *   · terreno.js      construirTerreno (heightfield con color por vértice)
+ *   · atmosfera.js    atmosferaDeFamilia + useAtmosferaMundo (hora viva del valle)
+ *   · AtmosferaMundo  el drop-in <color>/<fog>/luces/estrellas/sombras
+ *   + re-exports de las piezas madre ya probadas (paleta, cielos, tier, cámara,
+ *     transiciones, sombra de contacto, ciclo diurno).
+ */
+
+/* ── Azar determinista + ruido ─────────────────────────────────────────────── */
+export { rng, crearRng, ruido3D, ruidoFbm, ruidoTerreno, saturar, smoothstep } from './ruido.js';
+
+/* ── Taller de geometría procedural (three-core; safe-merge + shading) ──────── */
+export {
+  fusionarSeguro, desindexar, poner, apuntar,
+  pintarPorVertice, pintarPlano, hornearFollaje, hornearCorteza,
+  tuboOrganico, taperLineal, taperTronco, curvaTronco,
+  sembrarFollaje, matojoHoja, sembrarEnAnillo,
+} from './geometria.js';
+
+/* ── Terreno (heightfield con color por vértice) ────────────────────────────── */
+export { construirTerreno } from './terreno.js';
+
+/* ── Atmósfera del mundo (hora viva del valle, lista para cualquier Canvas) ──── */
+export { atmosferaDeFamilia, useAtmosferaMundo } from './atmosfera.js';
+export { default as AtmosferaMundo } from './AtmosferaMundo.jsx';
+
+/* ── Paleta madre + cielos por hora (dirección de arte central) ─────────────── */
+export { ATMOSFERA, PALETA, CIELOS, BLOOM, mezclar, mezclarCielo } from '../atmosferaMadre.js';
+export {
+  CIELOS_HORA, HORAS, presetDeHora, franjaDeHoraDecimal, horaDeReloj,
+  mezclaHex, mezclarPresets, TRANSICION,
+} from '../cielosHoraData.js';
+
+/* ── Ciclo diurno vivo (el reloj compartido) ────────────────────────────────── */
+export { default as useCicloDia, horaDecimal, leerCicloParam } from '../useCicloDia.js';
+
+/* ── Device-tier / LOD (el presupuesto por dispositivo) ─────────────────────── */
+export { decidirTier, permite3D, perfilDeTier } from '../deviceTier.js';
+
+/* ── Sombra de contacto / AO barato ─────────────────────────────────────────── */
+export { SombraContacto } from '../escenas/SombraContacto.jsx';
+
+/* ── Cámara (establishing shot + encuadres por mundo) ───────────────────────── */
+export { default as CamaraDirector } from '../escenas/CamaraDirector.jsx';
+export {
+  ENCUADRES, ENCUADRE_IDS, ENCUADRE_DEFECTO, BEAT_DEFECTO, resolverEncuadre,
+} from '../camaraDioramas.js';
+
+/* ── Transiciones Odyssey (barrel DOM-safe; la cámara del cruce va directa) ──── */
+export {
+  VeloOdyssey, useCruceMundo, VELOS, VELO_IDS, familiaDeVelo, veloDeDestino,
+  duracionCruce, momentoCubierto, curvaCruce,
+} from '../transiciones/index.js';

--- a/src/visual/mundo3d/kit/ruido.js
+++ b/src/visual/mundo3d/kit/ruido.js
@@ -1,0 +1,69 @@
+/*
+ * kit/ruido — el RUIDO y el AZAR DETERMINISTA compartidos de los mundos 3D.
+ *
+ * Antes cada escena copiaba su propio `function ruido(wx, wz)` y su propio
+ * `rng(seed)`: la auditoría de congruencia (2026-07-16) encontró la MISMA
+ * función de ruido de terreno copiada byte-a-byte en seis escenas (cafetal,
+ * cacao, papa y sus geom) y el PRNG reimplementado a mano una docena de veces.
+ * Dos matas sembradas con dos copias del mismo ruido NO quedan en el mismo sitio
+ * si una copia deriva: la congruencia se pierde en silencio. Aquí viven las
+ * versiones ÚNICAS.
+ *
+ * Dos azares, dos usos (a propósito):
+ *   · rng(seed)      LCG — el PRNG de la LÍNEA DE GEOMETRÍA (flora/fauna
+ *                    procedural). Es el que ya usa `sombreadoVegetal`; se
+ *                    re-exporta desde su casa canónica para no bifurcar la
+ *                    secuencia (una misma semilla debe dar el MISMO árbol aquí
+ *                    y en el bosque).
+ *   · crearRng(sem)  mulberry32 — el PRNG de PARTÍCULAS/nubes/dispersión, de más
+ *                    calidad estadística; re-exportado de `particulasData` (su
+ *                    casa canónica, three-free) para que los mockups y la capa
+ *                    viva compartan la misma nube en cada montaje/SSR/test.
+ *
+ * Y el ruido:
+ *   · ruidoTerreno(wx, wz)  — el ruido 2D de TERRENO (tres octavas de seno,
+ *                    ~[-1, 1]). Idéntico al que seis escenas tenían copiado;
+ *                    es lo que colorea la ladera y decide dónde asoma la tierra.
+ *   · ruido3D / ruidoFbm    — el ruido de VALOR 3D (para arrugar corteza, morder
+ *                    la copa, manchar color), re-exportado de `sombreadoVegetal`.
+ *
+ * Todo es matemática pura: corre headless (sin contexto GL), es testeable y no
+ * cuesta por frame (se evalúa en tiempo de construcción).
+ */
+
+/* Los azares canónicos, desde sus casas de origen (cero bifurcación). */
+export { rng } from '../bosque/sombreadoVegetal.js';
+export { crearRng } from '../particulasData.js';
+
+/* El ruido de valor 3D (arruga/mordida/mancha), desde su casa canónica. */
+export { ruido3D, ruidoFbm } from '../bosque/sombreadoVegetal.js';
+
+/**
+ * Ruido 2D de TERRENO en coordenadas de mundo (metros): tres octavas de seno
+ * desfasadas. Devuelve aproximadamente [-1, 1], continuo y determinista (no
+ * depende de semilla: el mismo (wx, wz) da siempre el mismo valor, así dos
+ * escenas pintan el suelo coherente). Es la función que estaba copiada literal
+ * en cafetal/cacao/papa (y sus geom): esta es la ÚNICA.
+ *
+ * Barato: se evalúa por vértice EN CONSTRUCCIÓN del terreno, nunca por frame.
+ *
+ * @param {number} wx  coordenada X de mundo.
+ * @param {number} wz  coordenada Z de mundo.
+ * @returns {number} ruido en ~[-1, 1].
+ */
+export function ruidoTerreno(wx, wz) {
+  return (
+    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
+    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
+    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
+  );
+}
+
+/** Recorta a [0, 1]. Útil al normalizar altura/pendiente para gradientes. */
+export const saturar = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+
+/** smoothstep(a, b, x): 0 antes de `a`, 1 después de `b`, curva suave en medio. */
+export function smoothstep(a, b, x) {
+  const t = saturar((x - a) / (b - a || 1e-6));
+  return t * t * (3 - 2 * t);
+}

--- a/src/visual/mundo3d/kit/terreno.js
+++ b/src/visual/mundo3d/kit/terreno.js
@@ -1,0 +1,96 @@
+/*
+ * kit/terreno — el CONSTRUCTOR de heightfields con color por vértice.
+ *
+ * Cada escena de ladera (cafetal, cacao, papa, y varios mockups) reescribía el
+ * MISMO doble bucle: recorrer una rejilla nx×nz, poner `y = altura(wx, wz)`,
+ * hornear un color por vértice (pasto/tierra/mantillo según altura y ruido),
+ * armar los índices de triángulos y —si el look es facetado— desindexar antes de
+ * `computeVertexNormals`. Aquí ese patrón es UNA función; la escena solo aporta
+ * su relieve (`altura`) y su pintura (`pintar`), que es lo único propio de cada
+ * piso térmico. Así dos laderas comparten la malla y solo divergen en lo que
+ * DEBEN divergir (la paleta del piso), no en el andamiaje.
+ *
+ * three-core puro: corre headless (sin GL), es testeable, cero costo por frame
+ * (la malla se construye una vez y se memoiza en quien llama).
+ */
+import * as THREE from 'three';
+
+/**
+ * @callback AlturaFn
+ * @param {number} wx  X de mundo (metros).
+ * @param {number} wz  Z de mundo.
+ * @returns {number}   altura Y del terreno en ese punto.
+ */
+
+/**
+ * @callback PintarFn
+ * @param {number} wx   X de mundo.
+ * @param {number} wz   Z de mundo.
+ * @param {number} alt  la altura ya calculada en (wx, wz).
+ * @param {THREE.Color} out  color a ESCRIBIR (mutar in-place y devolver/no).
+ * @returns {void}
+ */
+
+/**
+ * Construye un terreno rectangular como heightfield con color horneado por
+ * vértice (vertexColors). El terreno se centra en el origen y se extiende
+ * `ancho` en X y `fondo` en Z.
+ *
+ * @param {object} o
+ * @param {number} o.ancho          tamaño en X (metros de mundo).
+ * @param {number} o.fondo          tamaño en Z.
+ * @param {number} o.seg            segmentos por lado (más = más detalle; el
+ *                                  device-tier ya sugiere `segmentosTerreno`).
+ * @param {AlturaFn} o.altura       relieve del terreno.
+ * @param {PintarFn} o.pintar       color por vértice (recibe un `THREE.Color`
+ *                                  reutilizado que debe MUTAR: `out.set(...)` /
+ *                                  `out.lerpColors(...)`).
+ * @param {boolean} [o.plano=false] true → look FACETADO (desindexa antes de
+ *                                  normales; da flat-shading real). false →
+ *                                  malla indexada suave (~4× menos vértices).
+ * @returns {THREE.BufferGeometry}  con atributos `position` y `color`.
+ */
+export function construirTerreno({ ancho, fondo, seg, altura, pintar, plano = false }) {
+  const nx = seg + 1;
+  const nz = seg + 1;
+  const pos = new Float32Array(nx * nz * 3);
+  const col = new Float32Array(nx * nz * 3);
+  const c = new THREE.Color();
+  let p = 0;
+  for (let iz = 0; iz < nz; iz++) {
+    const wz = -fondo / 2 + (fondo * iz) / seg;
+    for (let ix = 0; ix < nx; ix++) {
+      const wx = -ancho / 2 + (ancho * ix) / seg;
+      const y = altura(wx, wz);
+      pos[p] = wx;
+      pos[p + 1] = y;
+      pos[p + 2] = wz;
+      pintar(wx, wz, y, c);
+      col[p] = c.r;
+      col[p + 1] = c.g;
+      col[p + 2] = c.b;
+      p += 3;
+    }
+  }
+  const idx = [];
+  for (let iz = 0; iz < seg; iz++) {
+    for (let ix = 0; ix < seg; ix++) {
+      const a = iz * nx + ix;
+      const b = a + 1;
+      const d = a + nx;
+      const e = d + 1;
+      idx.push(a, d, b, b, d, e);
+    }
+  }
+  let geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  geo.setIndex(idx);
+  if (plano) {
+    const plana = geo.toNonIndexed();
+    geo.dispose(); // la indexada nunca tocó la GPU, pero liberamos igual
+    geo = plana;
+  }
+  geo.computeVertexNormals();
+  return geo;
+}


### PR DESCRIPTION
## Qué

Extrae un **toolkit 3D reutilizable** en `src/visual/mundo3d/kit/` que garantiza **congruencia** entre las ~15 escenas 3D: mismo suelo, misma niebla, misma luz de la hora del valle, misma paleta madre, misma sombra de contacto y la misma fusión de geometría a prueba del *null silencioso*. Es la **fundación** para que las próximas iteraciones (valle, bosque) tengan una sola API en vez de reinventar cada pieza.

**No reescribe ninguna escena** — solo consolida/crea y deja el kit listo (archivos nuevos, aún sin consumidores).

## El hallazgo (ver inventario)

Hay **dos familias** de escena: los **dioramas** (`EscenaBase3D` → ya coherentes) y los **mundos vivos** (`bosque/cacao/cafetal/papa/sierra`, con `<Canvas>` propio → **disparejos**: cielo estático, sin ciclo de día, sombra de contacto pobre). Además, patrones duplicados:
- `fusionarSeguro` / merge anti-null-silencioso reimplementado en **7 archivos**.
- `ruido(wx,wz)` de terreno copiado **byte-a-byte en 6 escenas**.
- `rng` LCG en ~12 copias locales; heightfield reescrito por escena.

## Qué entrega el kit

**Consolida** (re-export, sin mover el código canónico → cero churn):
`fusionarSeguro` (única fusión permitida) + taller de geometría (`poner`/`apuntar`/`hornearFollaje`/`tuboOrganico`/…) + `PALETA`/`CIELOS`/`mezclarCielo` + `useCicloDia` + `perfilDeTier` + `SombraContacto` + `CamaraDirector`/`resolverEncuadre` + transiciones Odyssey.

**Crea lo que faltaba:**
- `ruidoTerreno` + `rng`/`crearRng` + `smoothstep` (`kit/ruido.js`)
- `construirTerreno(...)` heightfield con color por vértice (`kit/terreno.js`)
- `atmosferaDeFamilia` / `useAtmosferaMundo` / `<AtmosferaMundo>` — **la hora viva del valle para cualquier Canvas** (cierra la brecha de la familia de mundos vivos) (`kit/atmosfera*`)
- `sembrarEnAnillo(...)` dispersión determinista (`kit/geometria.js`)

Todo detrás de **un import**: `import { … } from '@/visual/mundo3d/kit'`. El barrel importa `three` → solo para archivos de escena (chunk `vendor-three`), nunca el barrel three-free.

## Gaps que quedan (para la reescritura valle/bosque)
- Migrar las 4 escenas vivas a `<AtmosferaMundo>` + `construirTerreno` + `fusionarSeguro`.
- Dedupe de los `rng`/`ruido` locales.
- Primitiva `<BillboardCriatura>` para los SVG rubber-hose (G7) y evaluar `EscenaVivaBase` (G8).
- Unificar el `CamaraDirector` duplicado (raíz vs `escenas/`) (G9).

## Gates
- **`build:prod` verde** (`✓ built in 29.82s`).
- **`kit/__tests__/kit.test.js`: 11/11** (headless: determinismo del ruido, `fusionarSeguro` tronando ante null/atributos dispares, `construirTerreno`, coherencia de atmósfera por hora, `sembrarEnAnillo`).
- El diff es **solo** `src/visual/mundo3d/kit/` → **cero errores de tsc nuevos**. `app-3d` ya traía 2 errores de tsc **pre-existentes y ajenos** (`AgentAvatarSelector.jsx`, `saludoPantalla.test.js`), fuera del alcance de este toolkit.

Inventario completo, consumidores por escena y gaps: `ops/TOOLKIT-3D-INVENTARIO-2026-07-16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)