### PR TITLE
art(terreno): el suelo calibre consola — relieve fbm, zonas, sendero de corte y detalle al ras

### DIFF
--- a/scripts/diag/shot-suelo-demo.mjs
+++ b/scripts/diag/shot-suelo-demo.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/* Capturas del SueloDemo3D: varias vistas deterministas, de lejos y al ras. */
+// Uso: npx vite --port 5237 & BASE=http://localhost:5237 node scripts/diag/shot-suelo-demo.mjs
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { chromium } from 'playwright';
+
+const BASE = process.env.BASE || 'http://localhost:5237';
+const OUT = process.env.OUT || '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/shots';
+mkdirSync(OUT, { recursive: true });
+
+function chromiumPath() {
+  try {
+    const p = execSync('which chromium 2>/dev/null', { encoding: 'utf8' }).trim();
+    if (p) return p;
+  } catch { /* nada */ }
+  return undefined;
+}
+
+const VISTAS = ['aerea', 'sendero', 'cerca', 'ladera'];
+
+const browser = await chromium.launch({
+  executablePath: chromiumPath(),
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--no-sandbox'],
+});
+const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+page.on('console', (m) => { if (m.type() === 'error') console.log('[console.error]', m.text()); });
+page.on('pageerror', (e) => console.log('[pageerror]', e.message));
+
+for (const vista of VISTAS) {
+  await page.goto(`${BASE}/?vista=${vista}#/mockups/suelo-demo-3d`, { waitUntil: 'load', timeout: 120000 });
+  await page.waitForSelector('canvas', { timeout: 30000 });
+  await page.waitForTimeout(7000); // que asiente el frame (swiftshader es lento)
+  await page.screenshot({ path: `${OUT}/suelo-${vista}.png` });
+  console.log(`ok ${vista}`);
+}
+// móvil (tier medio aprox por viewport chico no cambia tier, pero muestra encuadre)
+await page.setViewportSize({ width: 390, height: 844 });
+await page.goto(`${BASE}/?vista=sendero#/mockups/suelo-demo-3d`, { waitUntil: 'load', timeout: 120000 });
+await page.waitForSelector('canvas', { timeout: 30000 });
+await page.waitForTimeout(6000);
+await page.screenshot({ path: `${OUT}/suelo-movil.png` });
+console.log('ok movil');
+
+await browser.close();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -226,6 +226,7 @@ const MundoMercado3DMockup = lazy(() => import('./mockups/MundoMercado3D'));
 // La CARA 3D-first de prod.chagra.app: entrada-tranquera con el valle vivo de
 // fondo → velo dorado del cruce → el valle como HOME (EntradaValle3D).
 const CaraProd3DMockup = lazy(() => import('./mockups/CaraProd3D'));
+const SueloDemo3DMockup = lazy(() => import('./mockups/SueloDemo3D'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
@@ -653,6 +654,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo-gallinero-3d': 'mockup_mundo_gallinero_3d',
   'mockups/mundo-mercado-3d': 'mockup_mundo_mercado_3d',
   'mockups/cara-prod': 'mockup_cara_prod',
+  'mockups/suelo-demo-3d': 'mockup_suelo_demo_3d',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -2191,6 +2193,16 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="La cara de Chagra (prod 3D)">
               <CaraProd3DMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_suelo_demo_3d':
+        // El SUELO calibre Switch (#/mockups/suelo-demo-3d): terreno fbm con
+        // color por zona, sendero, detalle al ras. ?vista=aerea|cerca|sendero.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El suelo del páramo">
+              <SueloDemo3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/SueloDemo3D.jsx
+++ b/src/mockups/SueloDemo3D.jsx
@@ -1,0 +1,213 @@
+/*
+ * SueloDemo3D — la escena de prueba del SUELO calibre Switch.
+ *
+ * Un pedazo de páramo a la hora dorada donde el terreno ES el protagonista:
+ * lomos y hondonadas de fbm, color por zona (musgo húmedo abajo, paja dorada
+ * en los lomos, roca asomando en la pendiente), un trillo que serpentea con
+ * lajas, y el detalle al ras (piedras, matas de paja, raíces, florecitas) con
+ * su sombra de contacto. Unos frailejones señalan la escala.
+ *
+ * Ruta #/mockups/suelo-demo-3d, sin auth. Vistas deterministas para capturas
+ * (el parámetro va en el SEARCH, no en el hash — el router de mockups compara
+ * el hash exacto): /?vista=aerea#/mockups/suelo-demo-3d
+ *   vista = paseo (default: la cámara recorre) | aerea | sendero | cerca | ladera
+ *
+ * Tier-safe vía decidirTier/perfilDeTier; con reducedMotion monta quieta.
+ */
+import { useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import * as THREE from 'three';
+import { decidirTier, permite3D, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
+import { crearSueloRico, geomPiedraSuelo, distribuirDetalle } from '../visual/mundo3d/terreno/sueloRico.geom.js';
+import SueloRico, { Instancias } from '../visual/mundo3d/terreno/SueloRico.jsx';
+import { geomCieloDomo } from '../visual/mundo3d/vitrina/miradorAndino.geom.js';
+import { geomFrailejon, calidadDeTier } from '../visual/mundo3d/bosque/floraParamo.geom.js';
+
+/* Luz de páramo a la hora dorada (cielo del domo del mirador). */
+const LUZ = { niebla: '#ddc9a2', sol: '#ffe8bd', cielo: '#dfe6df', suelo: '#4a4634' };
+
+/* Las vistas fijas (para capturas deterministas de cerca y de lejos). */
+const VISTAS = {
+  aerea: { pos: [11, 13, 15], mira: [0, 0, 0] },
+  sendero: { pos: [0.9, 1.9, 13.2], mira: [-0.6, 0.2, 4] },
+  cerca: { pos: [3.1, 1.0, 6.2], mira: [0.9, 0.3, 3.4] },
+  ladera: { pos: [-10, 3.2, 8], mira: [2, 0.6, -4] },
+};
+
+function vistaDeHash() {
+  if (typeof window === 'undefined') return 'paseo';
+  const m = /[?&]vista=([a-z]+)/.exec(window.location.search || '');
+  return m && (VISTAS[m[1]] || m[1] === 'paseo') ? m[1] : 'paseo';
+}
+
+/* El paseo: la cámara sube a ver los lomos y baja al ras del trillo. */
+function CamaraPaseo({ activa }) {
+  const mira = useRef(new THREE.Vector3());
+  useFrame((state) => {
+    if (!activa) return;
+    const t = state.clock.elapsedTime * 0.09;
+    const r = 10.5 + Math.sin(t * 0.63) * 4.6;
+    const y = 1.4 + (Math.sin(t * 1.21) + 1) * 1.9;
+    state.camera.position.set(Math.cos(t) * r, y, Math.sin(t) * r);
+    mira.current.set(Math.cos(t + 1.4) * 1.6, 0.35, Math.sin(t + 1.4) * 1.6);
+    state.camera.lookAt(mira.current);
+  });
+  return null;
+}
+
+function Diorama({ tier, reducedMotion, vista }) {
+  const perfil = perfilDeTier(tier);
+
+  // EL SUELO: trillo en S que baja del lomo, cruza el claro y sigue de largo.
+  const suelo = useMemo(
+    () =>
+      crearSueloRico({
+        tam: 68,
+        seed: 20,
+        amplitud: 1.8,
+        micro: 0.16,
+        claro: { radio: 2.6, transicion: 7 },
+        falda: { inicio: 18, fin: 30, altura: 3.2 },
+        sendero: {
+          puntos: [
+            [1.8, 15],
+            [0.2, 11],
+            [-1.5, 7.5],
+            [-0.4, 4],
+            [0.6, 1.2],
+            [0, -1.8],
+            [-1.9, -5],
+            [-3.4, -9],
+            [-6, -13],
+          ],
+          ancho: 1.15,
+        },
+      }),
+    [],
+  );
+
+  const cielo = useMemo(() => geomCieloDomo(58), []);
+
+  // Frailejones de escala junto al claro, POSADOS en el relieve.
+  const frailejones = useMemo(() => {
+    const geo = geomFrailejon({ flor: true, q: calidadDeTier(tier) }, 12);
+    const lugares = [
+      [2.1, -0.9, 1.15],
+      [-1.7, 1.4, 0.95],
+      [2.9, 2.2, 1.3],
+      [-2.6, -2.1, 1.05],
+      [0.9, -3.1, 0.85],
+      [-4.4, 3.6, 1.2],
+    ];
+    const items = lugares.map(([x, z, escala], i) => ({
+      pos: [x, suelo.alturaDe(x, z), z],
+      rotY: i * 1.7,
+      escala,
+      tint: [1, 1, 1],
+    }));
+    return { geo, items };
+  }, [tier, suelo]);
+
+  const matFrailejon = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.9, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  const anclas = useMemo(
+    () => frailejones.items.map((it) => ({ x: it.pos[0], z: it.pos[2], radio: 0.85 * it.escala })),
+    [frailejones],
+  );
+
+  // Peñas: rocas GRANDES de hito (la silueta que se recorta contra la niebla),
+  // sembradas con la misma API de detalle — prueba de reuso del sistema.
+  const penas = useMemo(() => {
+    const geo = geomPiedraSuelo(suelo.opts.seed + 777, suelo.opts.paleta);
+    const items = distribuirDetalle(suelo, 5, {
+      seed: 99, rMin: 9, rMax: 20, eMin: 2.4, eMax: 4.2, evitaSendero: 1.6, hundir: 0.1,
+    });
+    return { geo, items };
+  }, [suelo]);
+
+  const fija = VISTAS[vista];
+
+  return (
+    <>
+      <color attach="background" args={[LUZ.niebla]} />
+      {perfil.fog && <fog attach="fog" args={[LUZ.niebla, 16, 52]} />}
+
+      <hemisphereLight intensity={0.85} color={LUZ.cielo} groundColor={LUZ.suelo} />
+      <ambientLight intensity={0.28} color="#e8dcc4" />
+      <directionalLight
+        position={[14, 9, 6]}
+        intensity={1.35}
+        color={LUZ.sol}
+        castShadow={perfil.sombras}
+        shadow-mapSize-width={1024}
+        shadow-mapSize-height={1024}
+        shadow-camera-near={1}
+        shadow-camera-far={45}
+        shadow-camera-left={-16}
+        shadow-camera-right={16}
+        shadow-camera-top={16}
+        shadow-camera-bottom={-16}
+      />
+      <directionalLight position={[-8, 5, -7]} intensity={0.3} color="#b9cdd6" />
+
+      <mesh geometry={cielo}>
+        <meshBasicMaterial vertexColors side={THREE.BackSide} fog={false} />
+      </mesh>
+
+      <SueloRico suelo={suelo} tier={tier} anclas={anclas} segmentos={tier === 'alto' ? 96 : undefined} />
+      <Instancias geo={frailejones.geo} mat={matFrailejon} items={frailejones.items} castShadow={perfil.sombras} />
+      <Instancias geo={penas.geo} mat={matFrailejon} items={penas.items} castShadow={perfil.sombras} />
+
+      {vista === 'paseo' && !reducedMotion ? (
+        <CamaraPaseo activa />
+      ) : (
+        <OrbitControls
+          makeDefault
+          target={fija ? fija.mira : [0, 0.4, 0]}
+          enablePan={false}
+          minDistance={2.5}
+          maxDistance={30}
+          maxPolarAngle={1.52}
+          enableDamping
+          dampingFactor={0.08}
+        />
+      )}
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+export default function SueloDemo3D() {
+  const [{ tier, reducedMotion }] = useState(() => decidirTier());
+  const vista = useMemo(() => vistaDeHash(), []);
+  const perfil = perfilDeTier(tier);
+
+  if (!permite3D(tier)) {
+    return (
+      <div style={{ padding: '2rem', textAlign: 'center', color: '#4a4634' }}>
+        <p>Este equipo no alcanza para la demo 3D del suelo.</p>
+      </div>
+    );
+  }
+
+  const fija = VISTAS[vista];
+  return (
+    <div style={{ position: 'fixed', inset: 0 }}>
+      <Canvas
+        dpr={perfil.dpr}
+        gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+        shadows={perfil.sombras ? 'soft' : false}
+        camera={{ position: fija ? fija.pos : [11, 6, 13], fov: 46 }}
+        frameloop={reducedMotion ? 'demand' : 'always'}
+      >
+        <Diorama tier={tier} reducedMotion={reducedMotion} vista={vista} />
+      </Canvas>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/terreno/SueloRico.jsx
+++ b/src/visual/mundo3d/terreno/SueloRico.jsx
@@ -1,0 +1,227 @@
+/*
+ * SueloRico — el componente r3f del suelo calibre Switch.
+ *
+ * Monta la malla del terreno (geomSueloRico) + el detalle cercano instanciado
+ * (piedras, matas de paja, raíces, florecitas — 1 draw-call por tipo) + las
+ * sombras de contacto que anclan cada detalle al piso (misma técnica del valle:
+ * UNA textura radial de canvas + UN InstancedMesh de círculos inclinados a la
+ * normal del terreno — cero costo por frame).
+ *
+ * Contrato: la escena crea el suelo con `crearSueloRico(...)` (useMemo), le
+ * pasa el objeto aquí Y reparte `suelo.alturaDe` a todo lo demás que siembre.
+ * Las `anclas` extra (árboles, casas) reciben su sombra de contacto aquí mismo.
+ *
+ * Tier-safe vía perfilDeTier: segmentos/material/sombras/conteos por gama.
+ * Montar SOLO dentro de un <Canvas> (lazy desde el host).
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import {
+  geomSueloRico,
+  geomPiedraSuelo,
+  geomMataPaja,
+  geomRaizSuelo,
+  geomFlorecitas,
+  geomLajasSendero,
+  distribuirDetalle,
+  detalleDeTier,
+} from './sueloRico.geom.js';
+
+/* Un banco de detalle: una geometría, un material, N instancias (patrón Especie). */
+export function Instancias({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(/** @type {THREE.InstancedMesh|null} */ (null));
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh ref={ref} args={[geo, mat, items.length]} frustumCulled={false} castShadow={castShadow} />
+  );
+}
+
+/* Textura radial compartida para las sombras de contacto (una por sesión). */
+let _texturaSombra = null;
+function texturaSombra() {
+  if (_texturaSombra) return _texturaSombra;
+  const s = 128;
+  const cv = document.createElement('canvas');
+  cv.width = cv.height = s;
+  const ctx = cv.getContext('2d');
+  const g = ctx.createRadialGradient(s / 2, s / 2, 0, s / 2, s / 2, s / 2);
+  g.addColorStop(0, 'rgba(10, 9, 6, 0.85)');
+  g.addColorStop(0.4, 'rgba(10, 9, 6, 0.5)');
+  g.addColorStop(0.75, 'rgba(10, 9, 6, 0.16)');
+  g.addColorStop(1, 'rgba(10, 9, 6, 0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, s, s);
+  _texturaSombra = new THREE.CanvasTexture(cv);
+  return _texturaSombra;
+}
+
+const _EJE_Z = new THREE.Vector3(0, 0, 1);
+
+/*
+ * Sombras de contacto: un InstancedMesh de círculos con gradiente radial,
+ * posados sobre el terreno e inclinados a su normal (gradiente numérico de
+ * alturaDe). Anclan piedras, matas y las anclas que pase la escena.
+ */
+function SombrasContactoSuelo({ suelo, puntos, opacidad = 0.32 }) {
+  const ref = useRef(/** @type {THREE.InstancedMesh|null} */ (null));
+  const tex = useMemo(() => texturaSombra(), []);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !puntos.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const normal = new THREE.Vector3();
+    const e = 0.35;
+    for (let i = 0; i < puntos.length; i++) {
+      const pt = puntos[i];
+      const dx = (suelo.alturaDe(pt.x + e, pt.z) - suelo.alturaDe(pt.x - e, pt.z)) / (2 * e);
+      const dz = (suelo.alturaDe(pt.x, pt.z + e) - suelo.alturaDe(pt.x, pt.z - e)) / (2 * e);
+      normal.set(-dx, 1, -dz).normalize();
+      p.set(pt.x, suelo.alturaDe(pt.x, pt.z) + 0.045, pt.z);
+      q.setFromUnitVectors(_EJE_Z, normal);
+      s.setScalar(pt.radio);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [suelo, puntos]);
+
+  if (!puntos.length) return null;
+  return (
+    <instancedMesh ref={ref} args={[undefined, undefined, puntos.length]} frustumCulled={false} renderOrder={2}>
+      <circleGeometry args={[1, 20]} />
+      <meshBasicMaterial map={tex} transparent opacity={opacidad} depthWrite={false} />
+    </instancedMesh>
+  );
+}
+
+/**
+ * El suelo rico completo: malla + detalle + sombras de contacto.
+ * @param {{
+ *   suelo: import('./sueloRico.geom.js').SueloRico,
+ *   tier?: 'alto'|'medio'|'bajo',
+ *   anclas?: Array<{x:number, z:number, radio:number}>,  — sombras extra de la escena (árboles…)
+ *   detalle?: Partial<ReturnType<typeof detalleDeTier>>, — override de conteos
+ *   rMaxDetalle?: number,
+ *   segmentos?: number, — override de la resolución de la malla (default: perfil del tier)
+ * }} props
+ */
+export default function SueloRico({ suelo, tier = 'alto', anclas = [], detalle, rMaxDetalle, segmentos }) {
+  const perfil = perfilDeTier(tier);
+  const segs = segmentos ?? perfil.segmentosTerreno;
+
+  const geoSuelo = useMemo(() => geomSueloRico(suelo, { segmentos: segs }), [suelo, segs]);
+
+  const geos = useMemo(() => {
+    const seed = suelo.opts.seed;
+    return {
+      piedra: geomPiedraSuelo(seed + 101, suelo.opts.paleta),
+      mata: geomMataPaja(seed + 202, suelo.opts.paleta),
+      raiz: geomRaizSuelo(seed + 303, suelo.opts.paleta),
+      flor: geomFlorecitas(seed + 404, suelo.opts.paleta),
+      lajas: geomLajasSendero(suelo),
+    };
+  }, [suelo]);
+
+  const conteos = useMemo(() => ({ ...detalleDeTier(tier), ...(detalle || {}) }), [tier, detalle]);
+
+  const dist = useMemo(() => {
+    const seed = suelo.opts.seed;
+    const rMax = rMaxDetalle ?? suelo.opts.tam * 0.36;
+    return {
+      // piedras: prefieren el terreno quebrado (pendiente) y respetan el trillo
+      piedra: distribuirDetalle(suelo, conteos.piedras, {
+        seed: seed + 11, rMax, evitaSendero: 0.9, hundir: 0.05, eMin: 0.6, eMax: 1.6,
+      }),
+      // matas de paja: por todas partes menos el trillo y la roca parada
+      mata: distribuirDetalle(suelo, conteos.matas, {
+        seed: seed + 22, rMax, evitaSendero: 1.1, pendienteMax: 0.6, hundir: 0.02, eMin: 0.7, eMax: 1.45, varia: 0.16,
+      }),
+      // raíces: cerca del claro (donde viven los árboles héroe)
+      raiz: distribuirDetalle(suelo, conteos.raices, {
+        seed: seed + 33, rMin: suelo.opts.claro ? suelo.opts.claro.radio * 0.8 : 2,
+        rMax: Math.min(rMax, (suelo.opts.claro ? suelo.opts.claro.radio : 3) + 5),
+        evitaSendero: 1.0, pendienteMax: 0.5, hundir: 0, eMin: 0.8, eMax: 1.3,
+      }),
+      // florecitas: en lo amable, lejos del trillo
+      flor: distribuirDetalle(suelo, conteos.flores, {
+        seed: seed + 44, rMax: rMax * 0.8, evitaSendero: 1.3, pendienteMax: 0.45, hundir: 0.01, eMin: 0.8, eMax: 1.35, varia: 0.2,
+      }),
+    };
+  }, [suelo, conteos, rMaxDetalle]);
+
+  // sombras de contacto: piedras + anclas de la escena. Las matas NO llevan
+  // (su base horneada en sombra ya las ancla; círculos de más = manchones).
+  // Con shadow-map real (tier alto) el círculo es refuerzo suave, no doble sombra.
+  const sombras = useMemo(() => {
+    if (!perfil.sombrasContacto) return [];
+    const pts = [];
+    for (const it of dist.piedra) pts.push({ x: it.pos[0], z: it.pos[2], radio: 0.42 * it.escala });
+    for (const a of anclas) pts.push({ x: a.x, z: a.z, radio: a.radio });
+    return pts;
+  }, [perfil.sombrasContacto, dist, anclas]);
+
+  const matSuelo = useMemo(() => {
+    const base = { vertexColors: true };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, flatShading: perfil.flatShading, roughness: 1, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  const matDetalle = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.95, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  useLayoutEffect(() => () => {
+    geoSuelo.dispose();
+    Object.values(geos).forEach((g) => g && g.dispose());
+    matSuelo.dispose();
+    matDetalle.dispose();
+  }, [geoSuelo, geos, matSuelo, matDetalle]);
+
+  return (
+    <group>
+      <mesh geometry={geoSuelo} material={matSuelo} receiveShadow={perfil.sombras} />
+      {geos.lajas && <mesh geometry={geos.lajas} material={matDetalle} />}
+      <Instancias geo={geos.piedra} mat={matDetalle} items={dist.piedra} castShadow={perfil.sombras} />
+      <Instancias geo={geos.mata} mat={matDetalle} items={dist.mata} />
+      <Instancias geo={geos.raiz} mat={matDetalle} items={dist.raiz} />
+      <Instancias geo={geos.flor} mat={matDetalle} items={dist.flor} />
+      {sombras.length > 0 && (
+        <SombrasContactoSuelo suelo={suelo} puntos={sombras} opacidad={perfil.sombras ? 0.22 : 0.3} />
+      )}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/terreno/__tests__/sueloRico.geom.test.js
+++ b/src/visual/mundo3d/terreno/__tests__/sueloRico.geom.test.js
@@ -1,0 +1,136 @@
+/*
+ * sueloRico.geom — pruebas headless (three core, sin WebGL).
+ *
+ * Lo que NO puede fallar en silencio:
+ *   · mergeGeometries null (indexadas vs no-indexadas) → fusionar TRUENA.
+ *   · el relieve es determinista (misma seed → misma cota).
+ *   · el claro queda llano (el héroe de la escena no flota ni se entierra).
+ *   · el sendero RECORTA el relieve (el trillo queda bajo su orilla).
+ *   · toda geometría sale con color por vértice (el look vive ahí).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  crearSueloRico,
+  geomSueloRico,
+  geomPiedraSuelo,
+  geomMataPaja,
+  geomRaizSuelo,
+  geomFlorecitas,
+  geomLajasSendero,
+  distribuirDetalle,
+  detalleDeTier,
+} from '../sueloRico.geom.js';
+
+const SENDERO = { puntos: [[1.5, 12], [0, 6], [-1, 0], [0, -6]], ancho: 1.1 };
+
+const sueloDePrueba = () =>
+  crearSueloRico({
+    tam: 60,
+    seed: 20,
+    amplitud: 1.6,
+    claro: { radio: 2.5, transicion: 6 },
+    sendero: SENDERO,
+  });
+
+describe('crearSueloRico', () => {
+  it('es determinista: misma seed, misma cota', () => {
+    const a = sueloDePrueba();
+    const b = sueloDePrueba();
+    for (const [x, z] of [[7, 3], [-11, 8], [4.2, -9.7], [0, 15]]) {
+      expect(a.alturaDe(x, z)).toBe(b.alturaDe(x, z));
+    }
+  });
+
+  it('el claro queda llano para el héroe (|cota| chica en el centro)', () => {
+    // sin sendero: el trillo hunde su rasante a propósito (-0.085)
+    const s = crearSueloRico({ tam: 60, seed: 20, amplitud: 1.6, claro: { radio: 2.5, transicion: 6 } });
+    for (const [x, z] of [[0, 0], [1, 1], [-1.5, 0.5]]) {
+      expect(Math.abs(s.alturaDe(x, z))).toBeLessThan(0.08);
+    }
+  });
+
+  it('lejos del claro HAY relieve (esto no es un plano)', () => {
+    const s = sueloDePrueba();
+    let min = Infinity;
+    let max = -Infinity;
+    for (let i = 0; i < 200; i++) {
+      const ang = (i / 200) * Math.PI * 2;
+      const h = s.alturaDe(Math.cos(ang) * 13, Math.sin(ang) * 13);
+      min = Math.min(min, h);
+      max = Math.max(max, h);
+    }
+    expect(max - min).toBeGreaterThan(0.8);
+  });
+
+  it('el sendero recorta: el trillo queda por debajo de su orilla', () => {
+    const s = sueloDePrueba();
+    // punto medio de un tramo del trillo vs su costado (perpendicular)
+    const enTrillo = s.alturaDe(-0.5, 3);
+    const orilla = (s.alturaDe(-0.5 + 2.6, 3) + s.alturaDe(-0.5 - 2.6, 3)) / 2;
+    expect(enTrillo).toBeLessThan(orilla + 0.02);
+    const { d } = s.senderoCerca(-0.5, 3);
+    expect(d).toBeLessThan(SENDERO.ancho);
+  });
+
+  it('pendienteDe devuelve 0..~ y crece donde hay lomo', () => {
+    const s = sueloDePrueba();
+    expect(s.pendienteDe(0, 0)).toBeLessThan(0.15);
+    expect(s.pendienteDe(13, 9)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('geometrías (fusionar truena en vez de null silencioso)', () => {
+  const s = sueloDePrueba();
+
+  it.each([
+    ['geomSueloRico', () => geomSueloRico(s, { segmentos: 24 })],
+    ['geomPiedraSuelo', () => geomPiedraSuelo(7)],
+    ['geomMataPaja', () => geomMataPaja(7)],
+    ['geomRaizSuelo', () => geomRaizSuelo(7)],
+    ['geomFlorecitas', () => geomFlorecitas(7)],
+    ['geomLajasSendero', () => geomLajasSendero(s)],
+  ])('%s sale con posiciones y color por vértice', (_nombre, hacer) => {
+    const g = hacer();
+    expect(g).toBeTruthy();
+    expect(g.attributes.position.count).toBeGreaterThan(0);
+    expect(g.attributes.color).toBeTruthy();
+    expect(g.attributes.color.count).toBe(g.attributes.position.count);
+    g.dispose();
+  });
+
+  it('geomLajasSendero sin sendero devuelve null (no truena)', () => {
+    const sinSenda = crearSueloRico({ seed: 3, sendero: null });
+    expect(geomLajasSendero(sinSenda)).toBeNull();
+  });
+});
+
+describe('distribuirDetalle', () => {
+  const s = sueloDePrueba();
+
+  it('siembra n items POSADOS en el relieve', () => {
+    const items = distribuirDetalle(s, 40, { seed: 9, hundir: 0 });
+    expect(items.length).toBe(40);
+    for (const it of items.slice(0, 10)) {
+      expect(it.pos[1]).toBeCloseTo(s.alturaDe(it.pos[0], it.pos[2]), 5);
+      expect(it.escala).toBeGreaterThan(0);
+      expect(it.tint).toHaveLength(3);
+    }
+  });
+
+  it('respeta el trillo (evitaSendero)', () => {
+    const items = distribuirDetalle(s, 60, { seed: 11, evitaSendero: 1.0 });
+    for (const it of items) {
+      const { d } = s.senderoCerca(it.pos[0], it.pos[2]);
+      expect(d).toBeGreaterThanOrEqual(SENDERO.ancho);
+    }
+  });
+
+  it('detalleDeTier degrada: bajo < medio < alto', () => {
+    const alto = detalleDeTier('alto');
+    const medio = detalleDeTier('medio');
+    const bajo = detalleDeTier('bajo');
+    expect(medio.matas).toBeLessThan(alto.matas);
+    expect(bajo.matas).toBeLessThan(medio.matas);
+    expect(bajo.raices).toBe(0);
+  });
+});

--- a/src/visual/mundo3d/terreno/sueloRico.geom.js
+++ b/src/visual/mundo3d/terreno/sueloRico.geom.js
@@ -1,0 +1,630 @@
+/*
+ * sueloRico.geom — el SUELO de calibre Switch, reutilizable por toda escena 3D.
+ *
+ * Encargo del operador (2026-07-16): que el piso de las escenas deje de ser un
+ * círculo Lambert plano y se lea como terreno de un juego de consola del más
+ * alto calibre — superando al valle. Este módulo es el SISTEMA:
+ *
+ *   · RELIEVE: heightfield por fbm de 4 octavas (ruido de valor con giro entre
+ *     octavas — mata los artefactos alineados al eje) + warp de dominio suave.
+ *     Lomos y hondonadas reales, microrelieve al ras y falda que trepa al
+ *     horizonte. El claro central queda LLANO para el héroe de la escena.
+ *   · SENDERO: una polilínea serpentea el terreno; el relieve se RECORTA hacia
+ *     la cota del camino (corte-y-relleno campesino: el trillo se lee pisado,
+ *     no pintado) y el color abre a tierra con borde ruidoso y orilla húmeda.
+ *   · COLOR POR ZONA (vertexColors, cero texturas): musgo/pasto base, hondonada
+ *     húmeda y oscura, lomo seco pajizo, ROCA que asoma en la pendiente fuerte,
+ *     parches de hojarasca, y AO fingido por concavidad (el laplaciano de la
+ *     altura oscurece los hoyos — la luz no entra a las hondonadas).
+ *   · DETALLE CERCANO: piedras medio enterradas, matas de paja, raíces asomando
+ *     y florecitas — arquetipos fusionados (1 draw-call por tipo vía instancias)
+ *     con AO horneado en la base, distribuidos POR el relieve (nada flota).
+ *
+ * Contrato de reuso: `crearSueloRico(opts)` devuelve { alturaDe, pendienteDe,
+ * … }; la escena reparte ese `alturaDe` a TODO lo que siembre (flora, fauna,
+ * sombras de contacto) — el mismo contrato que el valle usa con sus landmarks.
+ *
+ * Corre headless (three core + merge puro): testeable en vitest sin WebGL.
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO al mezclar indexadas con
+ * no-indexadas. `fusionar()` desindexa TODO y truena si el merge falla.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del suelo de páramo (la escena puede traer la suya)                 */
+/* -------------------------------------------------------------------------- */
+
+export const PALETA_PARAMO = {
+  base: '#5f6d43', // pasto-musgo del claro
+  pastoVivo: '#66784a',
+  humedo: '#44583a', // hondonadas: verde hondo y mojado (rico, no negro)
+  seco: '#99905a', // lomos: paja dorada batida por el viento
+  hojarasca: '#7c6743', // manto de hojas caídas bajo los árboles
+  tierraSenda: '#9b8154', // el trillo pisado
+  tierraHumeda: '#63523a', // orilla del sendero y barro
+  roca: '#867e6d', // el afloramiento en la pendiente (piedra cálida de páramo)
+  rocaClara: '#a89d85',
+  liquen: '#9aa86a',
+  raiz: '#6b5138',
+  paja: '#9a8d56',
+  pajaVerde: '#75824c',
+  flor: '#e8e3c9', // florecita de páramo (blanco hueso)
+  florMiel: '#d9b45a',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Ruido: valor 2D con suavizado quíntico, fbm con giro entre octavas         */
+/* -------------------------------------------------------------------------- */
+
+function hash2(x, z, seed) {
+  const s = Math.sin(x * 127.1 + z * 311.7 + seed * 74.7) * 43758.5453;
+  return s - Math.floor(s);
+}
+
+/** Ruido de valor 2D en [0,1], suavizado quíntico (normales sin quiebres). */
+export function ruidoValor2D(x, z, seed = 0) {
+  const xi = Math.floor(x);
+  const zi = Math.floor(z);
+  const xf = x - xi;
+  const zf = z - zi;
+  // quíntico: 6t⁵−15t⁴+10t³ (derivada continua → computeVertexNormals suave)
+  const u = xf * xf * xf * (xf * (xf * 6 - 15) + 10);
+  const v = zf * zf * zf * (zf * (zf * 6 - 15) + 10);
+  const a = hash2(xi, zi, seed) * (1 - u) + hash2(xi + 1, zi, seed) * u;
+  const b = hash2(xi, zi + 1, seed) * (1 - u) + hash2(xi + 1, zi + 1, seed) * u;
+  return a * (1 - v) + b * v;
+}
+
+/* Giro fijo entre octavas (~37°): rompe la retícula del ruido de valor. */
+const GIRO_C = Math.cos(0.65);
+const GIRO_S = Math.sin(0.65);
+
+/**
+ * fbm de 4 octavas en [0,1] con rotación del dominio entre octavas.
+ * @param {number} x
+ * @param {number} z
+ * @param {number} [seed]
+ * @param {number} [octavas]
+ */
+export function fbmSuelo(x, z, seed = 0, octavas = 4) {
+  let amp = 0.5;
+  let suma = 0;
+  let norm = 0;
+  let px = x;
+  let pz = z;
+  for (let o = 0; o < octavas; o++) {
+    suma += ruidoValor2D(px, pz, seed + o * 13) * amp;
+    norm += amp;
+    const nx = px * GIRO_C - pz * GIRO_S;
+    pz = (px * GIRO_S + pz * GIRO_C) * 2.07;
+    px = nx * 2.07;
+    amp *= 0.5;
+  }
+  return suma / norm;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Fusión segura + horneado (mismas garantías que miradorAndino)              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Fusiona partes en UNA geometría: desindexa todo, borra uv y TRUENA si
+ * mergeGeometries devuelve null (mejor error de build que suelo invisible).
+ * @param {THREE.BufferGeometry[]} partes
+ * @param {string} quien
+ */
+export function fusionar(partes, quien = 'sueloRico') {
+  const buenas = partes.filter(Boolean).map((p) => {
+    const plana = p.index ? p.toNonIndexed() : p;
+    if (plana !== p) p.dispose();
+    plana.deleteAttribute('uv');
+    plana.deleteAttribute('uv1');
+    plana.deleteAttribute('uv2');
+    return plana;
+  });
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error(`${quien}: mergeGeometries devolvió null — atributos incompatibles`);
+  }
+  buenas.forEach((p) => p.dispose());
+  return g;
+}
+
+/**
+ * Hornea color POR VÉRTICE con (x,y,z,i) → THREE.Color.
+ * @param {THREE.BufferGeometry} geo
+ * @param {(x:number,y:number,z:number,i:number) => THREE.Color} fn
+ */
+export function pintarPorVertice(geo, fn) {
+  const pos = geo.attributes.position;
+  const arr = new Float32Array(pos.count * 3);
+  for (let i = 0; i < pos.count; i++) {
+    const c = fn(pos.getX(i), pos.getY(i), pos.getZ(i), i);
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Coloca una geometría (matriz aplicada a los vértices). */
+function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL SUELO — factoría: relieve + sendero como funciones puras                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @typedef {Object} OpcionesSuelo
+ * @property {number} [tam] — lado del terreno (unidades de mundo)
+ * @property {number} [seed]
+ * @property {number} [amplitud] — alto de los lomos grandes
+ * @property {number} [micro] — alto del microrelieve al ras
+ * @property {{radio:number, transicion:number}|null} [claro] — zona llana central (cota 0) para el héroe
+ * @property {{inicio:number, fin:number, altura:number}|null} [falda] — el terreno trepa hacia el borde
+ * @property {{puntos:Array<[number,number]>, ancho:number}|null} [sendero] — trillo [x,z] que corta el relieve
+ * @property {Record<string,string>} [paleta]
+ */
+
+/**
+ * @typedef {Object} SueloRico
+ * @property {(x:number, z:number) => number} alturaDe — cota del terreno (con sendero recortado)
+ * @property {(x:number, z:number) => number} pendienteDe — 0 llano … ~1 vertical
+ * @property {(x:number, z:number) => {d:number, y:number}} senderoCerca — distancia al trillo y cota del trillo
+ * @property {Required<OpcionesSuelo>} opts
+ */
+
+/**
+ * Crea el suelo: devuelve las FUNCIONES (alturaDe/pendienteDe) que la escena
+ * reparte a todo lo que siembre, y que geomSueloRico hornea en la malla.
+ * @param {OpcionesSuelo} [opciones]
+ * @returns {SueloRico}
+ */
+export function crearSueloRico(opciones = {}) {
+  const opts = {
+    tam: 64,
+    seed: 31,
+    amplitud: 1.5,
+    micro: 0.1,
+    claro: { radio: 2.4, transicion: 6.5 },
+    falda: { inicio: 17, fin: 30, altura: 2.6 },
+    sendero: null,
+    paleta: PALETA_PARAMO,
+    ...opciones,
+  };
+  const { seed } = opts;
+
+  /* Cota del trillo por punto (se fija al crear: el carve no es recursivo). */
+  const senda = opts.sendero;
+  const cotas = [];
+
+  /* Relieve SIN sendero: lomos + micro + claro + falda. */
+  const alturaBase = (x, z) => {
+    // warp de dominio suave: los lomos dejan de ser "manchas de ruido"
+    const wx = x + (fbmSuelo(x * 0.05 + 40, z * 0.05, seed + 91, 2) - 0.5) * 5;
+    const wz = z + (fbmSuelo(x * 0.05, z * 0.05 - 27, seed + 47, 2) - 0.5) * 5;
+    let lomas = (fbmSuelo(wx * 0.062, wz * 0.062, seed) - 0.5) * 2; // [-1,1]
+    // el fbm normalizado se apretuja hacia 0: tanh EXPANDE el cuerpo del ruido
+    // (lomos gordos, hondonadas hondas) sin pasarse de ±1
+    lomas = Math.tanh(lomas * 2.2);
+    // crestas un pelo más marcadas, hondonadas anchas (asimetría natural)
+    lomas = Math.sign(lomas) * Math.pow(Math.abs(lomas), 1.12);
+    const micro = (fbmSuelo(x * 0.55, z * 0.55, seed + 7, 3) - 0.5) * 2;
+
+    const r = Math.hypot(x, z);
+    let mask = 1;
+    if (opts.claro) {
+      mask = THREE.MathUtils.smoothstep(r, opts.claro.radio, opts.claro.radio + opts.claro.transicion);
+    }
+    let h = lomas * opts.amplitud * mask + micro * opts.micro * (0.35 + 0.65 * mask);
+    if (opts.falda) {
+      const f = THREE.MathUtils.smoothstep(r, opts.falda.inicio, opts.falda.fin);
+      h += f * opts.falda.altura + f * lomas * opts.amplitud * 0.7;
+    }
+    return h;
+  };
+
+  if (senda && senda.puntos.length >= 2) {
+    for (const [px, pz] of senda.puntos) cotas.push(alturaBase(px, pz));
+  }
+
+  /** Distancia a la polilínea del sendero + cota interpolada del trillo. */
+  const senderoCerca = (x, z) => {
+    if (!senda || senda.puntos.length < 2) return { d: Infinity, y: 0 };
+    let mejorD = Infinity;
+    let mejorY = 0;
+    for (let s = 0; s < senda.puntos.length - 1; s++) {
+      const [ax, az] = senda.puntos[s];
+      const [bx, bz] = senda.puntos[s + 1];
+      const dx = bx - ax;
+      const dz = bz - az;
+      const l2 = dx * dx + dz * dz || 1e-9;
+      const t = THREE.MathUtils.clamp(((x - ax) * dx + (z - az) * dz) / l2, 0, 1);
+      const qx = ax + dx * t;
+      const qz = az + dz * t;
+      const d = Math.hypot(x - qx, z - qz);
+      if (d < mejorD) {
+        mejorD = d;
+        mejorY = cotas[s] + (cotas[s + 1] - cotas[s]) * t;
+      }
+    }
+    return { d: mejorD, y: mejorY };
+  };
+
+  /* Cota final: el sendero RECORTA el relieve hacia su rasante (corte-y-
+     relleno) y se hunde un pelín — el trillo pisado de verdad. */
+  const alturaDe = (x, z) => {
+    let h = alturaBase(x, z);
+    if (senda) {
+      const { d, y } = senderoCerca(x, z);
+      const carve = 1 - THREE.MathUtils.smoothstep(d, senda.ancho * 0.45, senda.ancho * 1.9);
+      if (carve > 0) {
+        // borde con vaivén: el corte no es una zanja recta de máquina
+        const vaiven = (fbmSuelo(x * 0.6 + 9, z * 0.6, seed + 23, 2) - 0.5) * 0.12;
+        h = THREE.MathUtils.lerp(h, y - 0.085 + vaiven, carve * 0.9);
+      }
+    }
+    return h;
+  };
+
+  const pendienteDe = (x, z, e = 0.4) => {
+    const dx = (alturaDe(x + e, z) - alturaDe(x - e, z)) / (2 * e);
+    const dz = (alturaDe(x, z + e) - alturaDe(x, z - e)) / (2 * e);
+    return Math.hypot(dx, dz);
+  };
+
+  return { alturaDe, pendienteDe, senderoCerca, opts };
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LA MALLA — plano desplazado + color por zona                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Hornea la malla del suelo: desplaza el plano con `alturaDe` y pinta POR ZONA
+ * (humedad en hondonadas, paja en lomos, roca en pendiente, hojarasca, trillo,
+ * AO por concavidad). El costo vive en el build de la geometría, no en el frame.
+ * @param {SueloRico} suelo
+ * @param {{segmentos?: number}} [cfg]
+ */
+export function geomSueloRico(suelo, { segmentos = 56 } = {}) {
+  const { alturaDe, pendienteDe, senderoCerca, opts } = suelo;
+  const { seed, tam } = opts;
+  const P = opts.paleta;
+  const geo = new THREE.PlaneGeometry(tam, tam, segmentos, segmentos);
+  geo.rotateX(-Math.PI / 2);
+  const pos = geo.attributes.position;
+  for (let i = 0; i < pos.count; i++) {
+    pos.setY(i, alturaDe(pos.getX(i), pos.getZ(i)));
+  }
+  geo.computeVertexNormals();
+
+  const base = new THREE.Color(P.base);
+  const pastoVivo = new THREE.Color(P.pastoVivo);
+  const humedo = new THREE.Color(P.humedo);
+  const seco = new THREE.Color(P.seco);
+  const hojarasca = new THREE.Color(P.hojarasca);
+  const tierraSenda = new THREE.Color(P.tierraSenda);
+  const tierraHumeda = new THREE.Color(P.tierraHumeda);
+  const roca = new THREE.Color(P.roca);
+  const rocaClara = new THREE.Color(P.rocaClara);
+
+  const e = Math.max(0.6, tam / segmentos); // paso del laplaciano ≈ celda
+  pintarPorVertice(geo, (x, y, z, i) => {
+    const c = base.clone();
+
+    // parches vivos/apagados a dos escalas (nunca un verde de cancha)
+    c.lerp(pastoVivo, THREE.MathUtils.smoothstep(fbmSuelo(x * 0.13 + 60, z * 0.13, seed + 3, 3), 0.48, 0.8) * 0.55);
+
+    // concavidad (laplaciano): >0 hondonada, <0 cresta
+    const lap =
+      (alturaDe(x + e, z) + alturaDe(x - e, z) + alturaDe(x, z + e) + alturaDe(x, z - e) - 4 * y) /
+      (e * e);
+    const hondo = THREE.MathUtils.clamp(lap * 1.4, 0, 1);
+    const cresta = THREE.MathUtils.clamp(-lap * 1.6, 0, 1);
+
+    // HONDONADA: húmeda, verde hondo (nunca un manchón negro: el húmedo es RICO)
+    const charco = fbmSuelo(x * 0.09 - 31, z * 0.09 + 18, seed + 9, 3);
+    c.lerp(humedo, THREE.MathUtils.clamp(hondo * 0.6 + THREE.MathUtils.smoothstep(charco, 0.62, 0.88) * 0.25, 0, 0.75));
+
+    // LOMO: paja seca dorada, más cuanto más alto y convexo — la zona que CANTA
+    const altoRel = THREE.MathUtils.clamp((y - 0.1) / Math.max(0.001, opts.amplitud), 0, 1);
+    c.lerp(seco, THREE.MathUtils.clamp(cresta * 0.65 + altoRel * 0.65, 0, 0.95) * (0.5 + fbmSuelo(x * 0.3, z * 0.3, seed + 15, 2) * 0.5));
+
+    // HOJARASCA: parches pardos donde el terreno es amable (pendiente baja)
+    const pend = pendienteDe(x, z);
+    const mHoja = THREE.MathUtils.smoothstep(fbmSuelo(x * 0.17 + 12, z * 0.17 - 44, seed + 21, 3), 0.55, 0.8);
+    c.lerp(hojarasca, mHoja * (1 - THREE.MathUtils.smoothstep(pend, 0.3, 0.6)) * 0.7);
+
+    // ROCA: aflora en la pendiente fuerte, con umbral ruidoso (vetas, no franja)
+    const veta = (fbmSuelo(x * 0.35 - 8, z * 0.35 + 27, seed + 27, 3) - 0.5) * 0.22;
+    const mRoca = THREE.MathUtils.smoothstep(pend, 0.42 + veta, 0.72 + veta);
+    if (mRoca > 0) {
+      const tRoca = roca.clone().lerp(rocaClara, fbmSuelo(x * 0.8, z * 0.8, seed + 33, 2));
+      c.lerp(tRoca, mRoca * 0.92);
+    }
+
+    // SENDERO: tierra pisada al centro, orilla húmeda al borde (borde ruidoso)
+    if (opts.sendero) {
+      const { d } = senderoCerca(x, z);
+      const borde = (fbmSuelo(x * 0.7 + 3, z * 0.7 - 6, seed + 39, 2) - 0.5) * 0.5;
+      const nucleo = 1 - THREE.MathUtils.smoothstep(d + borde, opts.sendero.ancho * 0.32, opts.sendero.ancho * 0.85);
+      const orilla = 1 - THREE.MathUtils.smoothstep(d + borde, opts.sendero.ancho * 0.7, opts.sendero.ancho * 1.7);
+      c.lerp(tierraHumeda, THREE.MathUtils.clamp(orilla - nucleo, 0, 1) * 0.5);
+      c.lerp(tierraSenda, nucleo * 0.88);
+      // huellas: motas más oscuras dentro del trillo
+      if (nucleo > 0.5 && fbmSuelo(x * 1.6, z * 1.6, seed + 45, 2) > 0.62) {
+        c.lerp(tierraHumeda, 0.35);
+      }
+    }
+
+    // AO fingido: los hoyos comen luz; las crestas la reciben
+    c.multiplyScalar(1 - hondo * 0.18 + cresta * 0.12);
+
+    // jitter por vértice ±4%: mata el banding del lerp
+    c.multiplyScalar(0.96 + hash2(i, i * 0.37, seed + 51) * 0.08);
+    return c;
+  });
+  return geo;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  DETALLE CERCANO — arquetipos fusionados (para instanciar)                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Piedra de páramo: racimo de 2-3 dodecaedros deformados medio enterrados,
+ * luz horneada de arriba (cara superior clara, base oscura = AO de contacto)
+ * y pecas de líquen. El origen queda EN el suelo (y=0 = línea de tierra).
+ * @param {number} [seed]
+ * @param {Record<string,string>} [P]
+ */
+export function geomPiedraSuelo(seed = 101, P = PALETA_PARAMO) {
+  const r = rng(seed);
+  const partes = [];
+  const n = 2 + Math.floor(r() * 2);
+  for (let i = 0; i < n; i++) {
+    const rad = 0.22 + r() * 0.2;
+    const p = new THREE.DodecahedronGeometry(rad, 0);
+    // deformar: que ninguna piedra sea el sólido platónico de catálogo
+    const pp = p.attributes.position;
+    for (let v = 0; v < pp.count; v++) {
+      const k = 1 + (hash2(pp.getX(v) * 7, pp.getZ(v) * 7, seed + i) - 0.5) * 0.34;
+      pp.setXYZ(v, pp.getX(v) * k, pp.getY(v) * k, pp.getZ(v) * k);
+    }
+    poner(
+      p,
+      [(r() - 0.5) * 0.5, rad * (0.22 + r() * 0.2), (r() - 0.5) * 0.5],
+      [r() * 0.7, r() * Math.PI, r() * 0.7],
+      [1, 0.62 + r() * 0.3, 1],
+    );
+    const tone = new THREE.Color(P.roca).lerp(new THREE.Color(P.rocaClara), r());
+    const liquen = new THREE.Color(P.liquen);
+    const conLiquen = r() > 0.4;
+    pintarPorVertice(p, (vx, vy, vz) => {
+      const c = tone.clone().multiplyScalar(0.72 + THREE.MathUtils.clamp(vy * 1.6 + 0.35, 0, 1) * 0.42);
+      if (conLiquen && ruidoValor2D(vx * 8, vz * 8, seed + i * 3) > 0.74) c.lerp(liquen, 0.55);
+      return c;
+    });
+    partes.push(p);
+  }
+  return fusionar(partes, 'geomPiedraSuelo');
+}
+
+/**
+ * Mata de paja de páramo: abanico de conos finos, base oscura (AO) y puntas
+ * doradas encendidas — la "hierba" que rompe la planitud al ras.
+ * @param {number} [seed]
+ * @param {Record<string,string>} [P]
+ */
+export function geomMataPaja(seed = 202, P = PALETA_PARAMO) {
+  const r = rng(seed);
+  const partes = [];
+  const paja = new THREE.Color(P.paja);
+  const verde = new THREE.Color(P.pajaVerde);
+  const punta = new THREE.Color(P.seco);
+  const n = 9 + Math.floor(r() * 4);
+  for (let i = 0; i < n; i++) {
+    const alto = 0.42 + r() * 0.34;
+    const hoja = new THREE.ConeGeometry(0.032 + r() * 0.02, alto, 4);
+    const inclinacion = 0.16 + r() * 0.46;
+    const rumbo = r() * Math.PI * 2;
+    poner(
+      hoja,
+      [Math.cos(rumbo) * 0.09, alto * 0.44, Math.sin(rumbo) * 0.09],
+      [Math.cos(rumbo + Math.PI / 2) * inclinacion, rumbo, Math.sin(rumbo + Math.PI / 2) * inclinacion],
+    );
+    const tono = (r() > 0.4 ? paja : verde).clone().multiplyScalar(1.0 + r() * 0.25);
+    const oscuro = tono.clone().multiplyScalar(0.42);
+    pintarPorVertice(hoja, (_vx, vy) => {
+      const t = THREE.MathUtils.clamp(vy / alto + 0.15, 0, 1);
+      // base en sombra (AO de mata), cuerpo dorado, PUNTA encendida por el sol
+      return oscuro.clone().lerp(tono, Math.pow(t, 0.75)).lerp(punta, Math.max(0, t - 0.62) * 1.9);
+    });
+    partes.push(hoja);
+  }
+  return fusionar(partes, 'geomMataPaja');
+}
+
+/**
+ * Raíz que asoma: dos-tres jorobas de raíz (arcos de toro) medio hundidas,
+ * corteza oscura con lomo pulido por el paso — el detalle que ancla los
+ * árboles al suelo en vez de posarlos encima.
+ * @param {number} [seed]
+ * @param {Record<string,string>} [P]
+ */
+export function geomRaizSuelo(seed = 303, P = PALETA_PARAMO) {
+  const r = rng(seed);
+  const partes = [];
+  const corteza = new THREE.Color(P.raiz);
+  const n = 2 + Math.floor(r() * 2);
+  for (let i = 0; i < n; i++) {
+    const radio = 0.3 + r() * 0.34;
+    const gordo = 0.045 + r() * 0.035;
+    const arco = new THREE.TorusGeometry(radio, gordo, 5, 10, Math.PI * (0.55 + r() * 0.3));
+    poner(
+      arco,
+      [(r() - 0.5) * 0.7, -radio * 0.35, (r() - 0.5) * 0.7],
+      [Math.PI / 2 + (r() - 0.5) * 0.3, 0, r() * Math.PI * 2],
+      [1, 1, 0.8],
+    );
+    // ojo: tras rotar, el "lomo" de la joroba es el y máximo del arco
+    pintarPorVertice(arco, (_vx, vy) => {
+      const t = THREE.MathUtils.clamp(vy * 3 + 0.4, 0, 1);
+      return corteza.clone().multiplyScalar(0.62 + t * 0.55);
+    });
+    partes.push(arco);
+  }
+  return fusionar(partes, 'geomRaizSuelo');
+}
+
+/**
+ * Florecitas de páramo: tallitos con cabeza clara — el acento que hace vivir
+ * el musgo. Baratas: 3 tallos por mata, instanciadas aparte.
+ * @param {number} [seed]
+ * @param {Record<string,string>} [P]
+ */
+export function geomFlorecitas(seed = 404, P = PALETA_PARAMO) {
+  const r = rng(seed);
+  const partes = [];
+  const verde = new THREE.Color(P.pajaVerde);
+  for (let i = 0; i < 3; i++) {
+    const alto = 0.16 + r() * 0.14;
+    const x = (r() - 0.5) * 0.16;
+    const z = (r() - 0.5) * 0.16;
+    const tallo = new THREE.CylinderGeometry(0.006, 0.009, alto, 3);
+    poner(tallo, [x, alto / 2, z], [(r() - 0.5) * 0.3, 0, (r() - 0.5) * 0.3]);
+    pintarPorVertice(tallo, (_vx, vy) => verde.clone().multiplyScalar(0.55 + (vy / alto) * 0.5));
+    partes.push(tallo);
+    const flor = new THREE.IcosahedronGeometry(0.028 + r() * 0.016, 0);
+    poner(flor, [x, alto + 0.015, z], [0, 0, 0], [1, 0.72, 1]);
+    const tono = new THREE.Color(r() > 0.55 ? P.flor : P.florMiel).multiplyScalar(0.92 + r() * 0.16);
+    pintarPorVertice(flor, (_vx, vy) => tono.clone().multiplyScalar(0.8 + THREE.MathUtils.clamp(vy * 8 + 0.5, 0, 1) * 0.25));
+    partes.push(flor);
+  }
+  return fusionar(partes, 'geomFlorecitas');
+}
+
+/**
+ * Lajas del sendero: piedras pisables sembradas SOBRE la rasante del trillo,
+ * hundidas apenas, con vaivén lateral (nadie pone lajas con regla).
+ * @param {SueloRico} suelo
+ * @param {number} [cada] — una laja cada tantas unidades de camino
+ * @param {number} [seed]
+ */
+export function geomLajasSendero(suelo, cada = 1.35, seed = 505) {
+  const senda = suelo.opts.sendero;
+  if (!senda || senda.puntos.length < 2) return null;
+  const P = suelo.opts.paleta;
+  const r = rng(seed);
+  const partes = [];
+  for (let s = 0; s < senda.puntos.length - 1; s++) {
+    const [ax, az] = senda.puntos[s];
+    const [bx, bz] = senda.puntos[s + 1];
+    const largo = Math.hypot(bx - ax, bz - az);
+    const pasos = Math.max(1, Math.round(largo / cada));
+    for (let i = 0; i < pasos; i++) {
+      const t = (i + 0.5) / pasos;
+      const x = ax + (bx - ax) * t + (r() - 0.5) * senda.ancho * 0.5;
+      const z = az + (bz - az) * t + (r() - 0.5) * senda.ancho * 0.5;
+      const laja = new THREE.CylinderGeometry(0.2 + r() * 0.12, 0.24 + r() * 0.12, 0.045, 6);
+      poner(
+        laja,
+        [x, suelo.alturaDe(x, z) + 0.012, z],
+        [(r() - 0.5) * 0.06, r() * Math.PI, (r() - 0.5) * 0.06],
+        [1, 1, 0.72 + r() * 0.4],
+      );
+      // laja cálida y soleada: piedra clara con un beso de la tierra del trillo
+      const tono = new THREE.Color(P.rocaClara)
+        .lerp(new THREE.Color(P.tierraSenda), 0.22)
+        .multiplyScalar(0.98 + r() * 0.18);
+      pintarPorVertice(laja, (_vx, vy) => tono.clone().multiplyScalar(vy > 0 ? 1.06 : 0.74));
+      partes.push(laja);
+    }
+  }
+  return partes.length ? fusionar(partes, 'geomLajasSendero') : null;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  DISTRIBUCIÓN — sembrar detalle POR el relieve                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Siembra `n` puntos de detalle sobre el suelo. Cada item trae pos (con la Y
+ * del terreno), rotY, escala y tint — el formato que ya consumen los
+ * InstancedMesh de flora (FloraParamo.Especie y equivalentes).
+ * @param {SueloRico} suelo
+ * @param {number} n
+ * @param {{
+ *   seed?: number, rMin?: number, rMax?: number,
+ *   eMin?: number, eMax?: number, varia?: number,
+ *   evitaSendero?: number,      — descartar a menos de tantos anchos del trillo
+ *   pendienteMin?: number, pendienteMax?: number,
+ *   hundir?: number,            — enterrar la base (fracción de escala)
+ * }} [o]
+ */
+export function distribuirDetalle(suelo, n, o = {}) {
+  const r = rng(o.seed ?? 606);
+  const rMin = o.rMin ?? (suelo.opts.claro ? suelo.opts.claro.radio * 0.7 : 1);
+  const rMax = o.rMax ?? suelo.opts.tam * 0.42;
+  const eMin = o.eMin ?? 0.8;
+  const eMax = o.eMax ?? 1.3;
+  const items = [];
+  let intentos = 0;
+  while (items.length < n && intentos < n * 14) {
+    intentos++;
+    const ang = r() * Math.PI * 2;
+    const rad = rMin + (rMax - rMin) * Math.sqrt(r());
+    const x = Math.cos(ang) * rad;
+    const z = Math.sin(ang) * rad;
+    if (o.evitaSendero && suelo.opts.sendero) {
+      const { d } = suelo.senderoCerca(x, z);
+      if (d < suelo.opts.sendero.ancho * o.evitaSendero) continue;
+    }
+    const pend = suelo.pendienteDe(x, z);
+    if (o.pendienteMax != null && pend > o.pendienteMax) continue;
+    if (o.pendienteMin != null && pend < o.pendienteMin) continue;
+    const escala = eMin + r() * (eMax - eMin);
+    items.push({
+      pos: [x, suelo.alturaDe(x, z) - (o.hundir ?? 0.03) * escala, z],
+      rotY: r() * Math.PI * 2,
+      escala,
+      tint: tinte(r, o.varia ?? 0.12),
+    });
+  }
+  return items;
+}
+
+/** Tinte por instancia (mismo formato que floraParamo). */
+function tinte(r, amt) {
+  const f = 1 + (r() - 0.5) * amt;
+  const h = (r() - 0.5) * amt * 0.4;
+  const cl = (v) => Math.max(0.7, Math.min(1.16, v));
+  return [cl(f + h), cl(f), cl(f - h * 0.6)];
+}
+
+/* -------------------------------------------------------------------------- */
+/*  PRESUPUESTO por tier — cuánto detalle siembra cada gama                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Conteos de detalle por tier (Android barato = gama baja frugal).
+ * @param {'alto'|'medio'|'bajo'} tier
+ */
+export function detalleDeTier(tier) {
+  if (tier === 'alto') return { piedras: 34, matas: 260, raices: 8, flores: 56 };
+  if (tier === 'medio') return { piedras: 18, matas: 100, raices: 4, flores: 22 };
+  return { piedras: 8, matas: 30, raices: 0, flores: 0 };
+}


### PR DESCRIPTION
## El encargo
> "que el terreno parezca parte de un juego de Switch del más alto calibre, que supere lo que está en el valle"

**Antes**: el suelo de las escenas era un círculo Lambert plano (el bosque de páramo: dos `circleGeometry` verdes) o un heightfield de una sola función seno.

**Ahora**: un SISTEMA de terreno reutilizable en `src/visual/mundo3d/terreno/` — heightfield fbm con zonas de color que CUENTAN el terreno, sendero que corta el relieve y detalle al ras — demostrado en `#/mockups/suelo-demo-3d` (páramo a la hora dorada, cámara que recorre).

## Qué trae
- **`crearSueloRico(opts)` → `{ alturaDe, pendienteDe, senderoCerca }`** — el contrato que la escena reparte a todo lo que siembre (mismo patrón `alturaDe` del valle). Relieve: fbm 4 octavas (suavizado quíntico + giro entre octavas + warp de dominio, cero artefactos de retícula), tanh que engorda lomos y ahonda hondonadas, **claro llano central** para el héroe de la escena, **falda** que trepa al horizonte.
- **Sendero de corte-y-relleno**: la polilínea del trillo RECORTA el relieve hacia su rasante (se lee pisado, no pintado encima), borde con vaivén fbm, lajas sembradas sobre la rasante.
- **Color por vértice POR ZONA** (cero texturas): hondonada húmeda (laplaciano > 0 = el hoyo junta agua), lomo de paja dorada (convexo + alto), **roca que aflora en la pendiente fuerte** con umbral veteado, parches de hojarasca donde el terreno es amable, trillo de tierra con orilla húmeda y huellas, **AO por concavidad** y jitter por vértice anti-banding.
- **Detalle cercano** (1 draw-call por tipo, instanciado): piedras deformadas con líquen y luz-de-arriba horneada, matas de paja (base en sombra = AO propio, punta encendida por el sol), raíces asomando, florecitas, y `distribuirDetalle()` que siembra POR el relieve (respeta el trillo, filtra por pendiente, nada flota).
- **`SueloRico.jsx`** tier-safe: segmentos/material/conteos por `perfilDeTier` (bajo: 20 segmentos, 38 piezas de detalle, sin sombras de contacto) + sombras de contacto instanciadas inclinadas a la normal del terreno (técnica del valle).

## Verificación (síncrona)
- `npm run build:prod` **VERDE** (exit 0) · `npm run tsc:check` **exit 0** · vitest del geom **15/15** (anti-null de `fusionar`, determinismo por seed, claro llano, carve del sendero bajo su orilla, detalle posado en su cota).
- **Capturas en 5 vistas** (Playwright + swiftshader, `scripts/diag/shot-suelo-demo.mjs`): aérea, sendero, cerca (al ras), ladera y móvil 390×844. Vistas deterministas vía `/?vista=aerea#/mockups/suelo-demo-3d`.

## Veredicto honesto (¿supera al valle?)
**Sí en lenguaje de terreno**: el valle tiene UNA función analítica de ladera + bandas de piso térmico; este suelo tiene lomos/hondonadas orgánicos, 7 zonas de material que responden al relieve (humedad abajo, paja arriba, roca en la pendiente), un trillo que corta la ladera y detalle instanciado al ras con su sombra. Lo que el valle sigue teniendo y esto no pretende reemplazar: su composición narrativa (casa, senderos entre lugares, vecinos).

## Nota de coordinación (para el merge)
- **NO cableé `EscenaBosqueVivo`**: hay otro carril activo reescribiéndola (+732 líneas, ramas `fable/bosque-escena-takeB` / `fable/bosque-takeB-ws`, geoms `bosqueTakeA/B`). Cablearla en paralelo era garantía de enredo de merge. El contrato está listo: la escena crea `crearSueloRico({claro: {radio: 7}})` (la fauna del bosque vive a y fijo hasta r≈8.3) y pasa `alturaDe` a flora/fauna. La demo ES páramo (frailejones, paleta) como prueba visual.
- Registro en `App.jsx`: solo las 3 piezas estándar (lazy + ruta al final del bloque + case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)