### PR TITLE
feat(bosque): TAKE A — el bosque de niebla al calibre del valle

### DIFF
--- a/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
+++ b/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
@@ -1,146 +1,690 @@
 /*
- * EscenaBosqueVivo — el MUNDO donde vive el Ent de la queñua.
+ * EscenaBosqueVivo — el MUNDO donde vive el Ent de la queñua (TAKE A).
  *
- * Un claro del páramo alto: luz fría y difusa, niebla que come el fondo, suelo
- * de musgo y todo un ECOSISTEMA altoandino alrededor (frailejonar al frente,
- * árboles de niebla al fondo — ver `FloraParamo`) que sitúa el lugar SIN robarle
- * el foco al guardián: la queñua sigue siendo EL árbol mayor. La cámara mira al
- * árbol un poco DESDE ABAJO para que se lea imponente. Se puede girar con el dedo.
+ * Un anfiteatro de bosque de niebla altoandino con el calibre del VALLE:
+ *   · TERRENO con relieve real (heightfield determinista, vertexColors):
+ *     el claro del guardián, lomos de musgo, la cañada del arroyo y la
+ *     pared del anfiteatro que la niebla se come al fondo.
+ *   · EL QUEÑUAL: queñuas (Polylepis) de tronco retorcido rojizo que se
+ *     despapela y copas que son MASA de hojas con huecos (matojos-nube con
+ *     normales radiales — nada de poliedros literales). Anillo héroe que
+ *     enmarca al Ent + anillo lejano de siluetas veladas.
+ *   · CICLO DE DÍA real (useCicloDia + CIELOS_HORA sesgados a bosque de
+ *     niebla): la atmósfera se AMORTIGUA entre franjas (mismo patrón que
+ *     AtmosferaValle) — amanece y anochece, no se teletransporta.
+ *   · RAYOS DE SOL colados (godrays baratos: planos aditivos con textura
+ *     canvas), BRUMA por capas con parallax entre los árboles y estrellas
+ *     de noche.
+ *   · CÁMARA consciente del aspecto + CamaraDirector (la llegada con dolly).
  *
- * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`: 'alto' con
- * sombras + niebla + facetado; 'medio' frugal; 'bajo' mínimo. Con `reducedMotion`
- * el mundo monta QUIETO (frameloop a demanda).
+ * El guardián (EntQuenua) vive en el MOUNT del centro — otra rama lo eleva
+ * de calibre; aquí solo se le prepara el escenario. La fauna es la de
+ * FaunaBosque (SVG rubber-hose, el estándar de la casa). Tier-safe vía
+ * perfilDeTier; reducedMotion monta QUIETO (frameloop a demanda).
  *
- * Importa three/@react-three → montar SOLO perezosa (lazy) desde el host.
+ * Todo procedural (cero CDN/imágenes). Importa three/@react-three → montar
+ * SOLO perezosa (lazy) desde el host.
  */
-import { useMemo, useState } from 'react';
-import { Canvas } from '@react-three/fiber';
-import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { Suspense, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr, Stars } from '@react-three/drei';
+import * as THREE from 'three';
 import { perfilDeTier } from '../deviceTier.js';
+import useCicloDia from '../useCicloDia.js';
+import { CIELOS_HORA, TRANSICION, mezclaHex } from '../cielosHoraData.js';
+import CamaraDirector from '../escenas/CamaraDirector.jsx';
 import EntQuenua from './EntQuenua.jsx';
 import FloraParamo from './FloraParamo.jsx';
 import FaunaBosque from './FaunaBosque.jsx';
+import {
+  alturaBosque,
+  geomTerrenoBosque,
+  geomQuenua,
+  sitiosQuenual,
+  geomLosetaHojarasca,
+  sitiosHojarasca,
+  geomTroncosCaidos,
+  curvaArroyo,
+} from './bosqueTakeA.geom.js';
 
-/* Cielo del páramo: gris-azul frío, alto y húmedo. */
-const PARAMO = { fondo: '#c3cfce', niebla: '#c9d3d1', suelo: '#4b5340', musgo: '#5c6844' };
+/* ── LA ATMÓSFERA DEL BOSQUE DE NIEBLA ─────────────────────────────────────
+      Los presets del día salen de CIELOS_HORA (la misma familia del valle:
+      el bosque amanece y anochece CON el valle) pero sesgados a bosque de
+      niebla: colores más fríos y lechosos, el suelo más verde, y el fog
+      MUCHO más cerca — aquí la niebla es la protagonista que come el fondo. */
+const BRUMA = { fondo: '#c2cecb', suelo: '#3c4634', niebla: '#c6d1ce' };
 
-function rng(seed) {
-  let s = (seed >>> 0) || 1;
-  return () => {
-    s = (s * 1664525 + 1013904223) >>> 0;
-    return s / 4294967296;
+function presetBosque(franja) {
+  const p = CIELOS_HORA[franja] || CIELOS_HORA.manana;
+  // De noche la bruma lechosa CEDE: el índigo del cine (día por noche) manda
+  // y la niebla apenas azulea — sin esto la noche quedaba gris-lavada.
+  const kBruma = franja === 'noche' ? 0.28 : 0.55;
+  const kFondo = franja === 'noche' ? 0.3 : 0.5;
+  return {
+    fondo: mezclaHex(p.fondo, BRUMA.fondo, kFondo),
+    cielo: mezclaHex(p.cielo, BRUMA.fondo, 0.35),
+    suelo: mezclaHex(p.suelo, BRUMA.suelo, 0.5),
+    luz: p.luz,
+    relleno: p.relleno,
+    niebla: mezclaHex(p.niebla, BRUMA.niebla, kBruma),
+    intensidad: p.intensidad * 0.95,
+    hemisferio: p.hemisferio,
+    ambiente: p.ambiente,
+    sol: p.sol,
+    rellenoInt: p.rellenoInt,
+    solPos: p.solPos,
+    nieblaCerca: Math.max(5, p.nieblaCerca * 0.6),
+    nieblaLejos: 14 + p.nieblaLejos * 0.5,
+    estrellas: Number(p.estrellas) || 0,
   };
 }
 
-/* Mata de paja del páramo: unos conos finos dorado-verdosos. */
-function Paja({ pos }) {
+function estadoAtmosfera(p) {
+  return {
+    fondo: new THREE.Color(p.fondo),
+    domo: new THREE.Color(p.cielo),
+    suelo: new THREE.Color(p.suelo),
+    luz: new THREE.Color(p.luz),
+    relleno: new THREE.Color(p.relleno),
+    niebla: new THREE.Color(p.niebla),
+    solPos: new THREE.Vector3(p.solPos[0], p.solPos[1], p.solPos[2]),
+    intensidad: p.intensidad,
+    hemisferio: p.hemisferio,
+    ambiente: p.ambiente,
+    sol: p.sol,
+    rellenoInt: p.rellenoInt,
+    nieblaCerca: p.nieblaCerca,
+    nieblaLejos: p.nieblaLejos,
+  };
+}
+
+function amortiguar(a, o, k) {
+  a.fondo.lerp(o.fondo, k);
+  a.domo.lerp(o.domo, k);
+  a.suelo.lerp(o.suelo, k);
+  a.luz.lerp(o.luz, k);
+  a.relleno.lerp(o.relleno, k);
+  a.niebla.lerp(o.niebla, k);
+  a.solPos.lerp(o.solPos, k);
+  a.intensidad += (o.intensidad - a.intensidad) * k;
+  a.hemisferio += (o.hemisferio - a.hemisferio) * k;
+  a.ambiente += (o.ambiente - a.ambiente) * k;
+  a.sol += (o.sol - a.sol) * k;
+  a.rellenoInt += (o.rellenoInt - a.rellenoInt) * k;
+  a.nieblaCerca += (o.nieblaCerca - a.nieblaCerca) * k;
+  a.nieblaLejos += (o.nieblaLejos - a.nieblaLejos) * k;
+}
+
+/* Mismo patrón que AtmosferaValle: los props declarativos usan la piel del
+   PRIMER montaje; todo lo vivo se escribe imperativo por refs (cero setState
+   por frame, cero alocación — colores/vec3 mutados in-place). */
+function AtmosferaBosque({ franja, perfil, reducedMotion }) {
+  const objetivo = useMemo(() => estadoAtmosfera(presetBosque(franja)), [franja]);
+  const [ini] = useState(() => presetBosque(franja));
+  const [actual] = useState(() => estadoAtmosfera(ini));
+
+  const fondoRef = useRef(null);
+  const fogRef = useRef(null);
+  const hemiRef = useRef(null);
+  const ambRef = useRef(null);
+  const solRef = useRef(null);
+  const rellenoRef = useRef(null);
+
+  const pintar = (e) => {
+    if (fondoRef.current) fondoRef.current.copy(e.fondo);
+    if (fogRef.current) {
+      fogRef.current.color.copy(e.niebla);
+      fogRef.current.near = e.nieblaCerca;
+      fogRef.current.far = e.nieblaLejos;
+    }
+    if (hemiRef.current) {
+      hemiRef.current.intensity = e.intensidad * e.hemisferio * 1.7;
+      hemiRef.current.color.copy(e.domo);
+      hemiRef.current.groundColor.copy(e.suelo);
+    }
+    if (ambRef.current) {
+      ambRef.current.intensity = e.intensidad * e.ambiente * 1.3;
+      ambRef.current.color.copy(e.luz);
+    }
+    if (solRef.current) {
+      solRef.current.intensity = e.intensidad * e.sol * 1.25;
+      solRef.current.color.copy(e.luz);
+      solRef.current.position.set(e.solPos.x * 1.8, e.solPos.y * 1.8, e.solPos.z * 1.8);
+    }
+    if (rellenoRef.current) {
+      rellenoRef.current.intensity = e.intensidad * e.rellenoInt * 1.4;
+      rellenoRef.current.color.copy(e.relleno);
+      rellenoRef.current.position.set(-e.solPos.x, Math.max(3, e.solPos.y * 0.6), -e.solPos.z);
+    }
+  };
+
+  // Calma pedida → snap directo a la franja (frameloop 'demand').
+  useLayoutEffect(() => {
+    if (!reducedMotion) return;
+    amortiguar(actual, objetivo, 1);
+    pintar(actual);
+  });
+
+  useFrame((_, dt) => {
+    if (reducedMotion) return;
+    const k = 1 - Math.exp((-3 / TRANSICION.duracion) * Math.min(dt, 0.1));
+    amortiguar(actual, objetivo, k);
+    pintar(actual);
+  });
+
   return (
-    <group position={pos}>
-      {[0, 1, 2, 3].map((i) => (
-        <mesh key={i} position={[(i - 1.5) * 0.05, 0.2, 0]} rotation={[0, 0, (i - 1.5) * 0.12]}>
-          <coneGeometry args={[0.03, 0.42, 4]} />
-          <meshLambertMaterial color={i % 2 ? '#8a7d47' : '#6f7c48'} />
-        </mesh>
+    <>
+      <color ref={fondoRef} attach="background" args={[ini.fondo]} />
+      {perfil.fog && (
+        <fog ref={fogRef} attach="fog" args={[ini.niebla, ini.nieblaCerca, ini.nieblaLejos]} />
+      )}
+      <hemisphereLight
+        ref={hemiRef}
+        intensity={ini.intensidad * ini.hemisferio * 1.7}
+        color={ini.cielo}
+        groundColor={ini.suelo}
+      />
+      <ambientLight ref={ambRef} intensity={ini.intensidad * ini.ambiente * 1.3} color={ini.luz} />
+      <directionalLight
+        ref={solRef}
+        position={[ini.solPos[0] * 1.8, ini.solPos[1] * 1.8, ini.solPos[2] * 1.8]}
+        intensity={ini.intensidad * ini.sol * 1.25}
+        color={ini.luz}
+        castShadow={perfil.sombras}
+        shadow-mapSize={[1024, 1024]}
+        shadow-camera-near={1}
+        shadow-camera-far={60}
+        shadow-camera-left={-15}
+        shadow-camera-right={15}
+        shadow-camera-top={15}
+        shadow-camera-bottom={-15}
+      />
+      {/* contraluz frío opuesto al sol: separa las copas de la niebla */}
+      <directionalLight
+        ref={rellenoRef}
+        position={[-ini.solPos[0], Math.max(3, ini.solPos[1] * 0.6), -ini.solPos[2]]}
+        intensity={ini.intensidad * ini.rellenoInt * 1.4}
+        color={ini.relleno}
+      />
+    </>
+  );
+}
+
+/* ── EL TERRENO ──────────────────────────────────────────────────────────── */
+function TerrenoBosque({ nocturno, perfil }) {
+  const seg = Math.round(perfil.segmentosTerreno * 1.6);
+  const geo = useMemo(() => geomTerrenoBosque({ seg, nocturno }), [seg, nocturno]);
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  return (
+    <mesh geometry={geo} receiveShadow={perfil.sombras}>
+      {perfil.materialRico ? (
+        <meshStandardMaterial vertexColors roughness={1} metalness={0} />
+      ) : (
+        <meshLambertMaterial vertexColors />
+      )}
+    </mesh>
+  );
+}
+
+/* ── EL QUEÑUAL (instanciado: 3 variantes → 3 draw-calls) ────────────────── */
+function BancoInstancias({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.esc);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tinte[0], it.tinte[1], it.tinte[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+      receiveShadow={castShadow}
+    />
+  );
+}
+
+function Quenual({ tier, perfil }) {
+  const q = tier === 'alto' ? 1 : tier === 'medio' ? 0.62 : 0.45;
+  const sitios = useMemo(() => sitiosQuenual(tier), [tier]);
+  const variantes = useMemo(
+    () => [geomQuenua({ q }, 21), geomQuenua({ q }, 57), geomQuenua({ q }, 83)],
+    [q],
+  );
+  const mat = useMemo(
+    () => (perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.92, metalness: 0 })
+      : new THREE.MeshLambertMaterial({ vertexColors: true })),
+    [perfil.materialRico],
+  );
+  useLayoutEffect(() => () => {
+    variantes.forEach((g) => g.dispose());
+    mat.dispose();
+  }, [variantes, mat]);
+  return (
+    <group>
+      {[0, 1, 2].map((v) => (
+        <BancoInstancias
+          key={v}
+          geo={variantes[v]}
+          mat={mat}
+          items={sitios.filter((s) => s.variante === v)}
+          castShadow={perfil.sombras}
+        />
       ))}
     </group>
   );
 }
 
-function Diorama({ tier, reducedMotion }) {
-  const perfil = perfilDeTier(tier);
+/* ── HOJARASCA + TRONCOS CAÍDOS ──────────────────────────────────────────── */
+function Hojarasca({ tier }) {
+  const n = tier === 'alto' ? 150 : tier === 'medio' ? 80 : 0;
+  const items = useMemo(() => sitiosHojarasca(n), [n]);
+  const geo = useMemo(() => geomLosetaHojarasca(), []);
+  const mat = useMemo(() => new THREE.MeshLambertMaterial({ color: '#ffffff' }), []);
+  useLayoutEffect(() => () => {
+    geo.dispose();
+    mat.dispose();
+  }, [geo, mat]);
+  if (!n) return null;
+  return <BancoInstancias geo={geo} mat={mat} items={items} />;
+}
 
-  const pajas = useMemo(() => {
-    if (tier === 'bajo') return [];
-    const r = rng(202);
-    const n = tier === 'alto' ? 26 : 14;
-    return Array.from({ length: n }, (_, i) => {
-      const a = r() * Math.PI * 2;
-      const rad = 1.6 + r() * 4;
-      return { key: `pj-${i}`, pos: [Math.cos(a) * rad, 0, Math.sin(a) * rad] };
-    });
-  }, [tier]);
+function TroncosCaidos({ tier, perfil }) {
+  const q = tier === 'alto' ? 1 : 0.62;
+  const geo = useMemo(() => geomTroncosCaidos(q), [q]);
+  const mat = useMemo(
+    () => (perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.95, metalness: 0 })
+      : new THREE.MeshLambertMaterial({ vertexColors: true })),
+    [perfil.materialRico],
+  );
+  useLayoutEffect(() => () => {
+    geo.dispose();
+    mat.dispose();
+  }, [geo, mat]);
+  return <mesh geometry={geo} material={mat} castShadow={perfil.sombras} receiveShadow={perfil.sombras} />;
+}
+
+/* ── EL ARROYO — el hilo de agua que baja de la niebla ───────────────────── */
+function Arroyo({ nocturno, perfil }) {
+  const rico = perfil.materialRico;
+  const ref = useRef(null);
+  const geo = useMemo(
+    () => new THREE.TubeGeometry(curvaArroyo(), rico ? 72 : 44, 0.21, rico ? 6 : 5, false),
+    [rico],
+  );
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  useFrame((state) => {
+    if (ref.current) {
+      ref.current.opacity = 0.72 + Math.sin(state.clock.elapsedTime * 1.7) * 0.06;
+    }
+  });
+  return (
+    <mesh geometry={geo}>
+      {rico ? (
+        <meshStandardMaterial
+          ref={ref}
+          color="#5fa8bd"
+          emissive={nocturno ? '#3f6f9e' : '#000000'}
+          emissiveIntensity={nocturno ? 0.42 : 0}
+          transparent
+          opacity={0.75}
+          roughness={0.25}
+          metalness={0.3}
+        />
+      ) : (
+        <meshLambertMaterial
+          ref={ref}
+          color="#5fa8bd"
+          emissive={nocturno ? '#3f6f9e' : '#000000'}
+          emissiveIntensity={nocturno ? 0.42 : 0}
+          transparent
+          opacity={0.75}
+        />
+      )}
+    </mesh>
+  );
+}
+
+/* ── RAYOS DE SOL COLADOS (godrays baratos) ────────────────────────────────
+      Láminas aditivas con textura canvas (gradiente que se apaga hacia el
+      suelo), orientadas HACIA el sol de la franja. Fuertes al amanecer y la
+      tarde, tímidos al mediodía, apagados de noche. Solo tier alto. */
+const OPACIDAD_RAYOS = {
+  amanecer: 0.3, manana: 0.22, mediodia: 0.08, tarde: 0.22, atardecer: 0.28, noche: 0,
+};
+
+function texturaRayo() {
+  const cv = document.createElement('canvas');
+  cv.width = 64;
+  cv.height = 256;
+  const ctx = cv.getContext('2d');
+  const g = ctx.createLinearGradient(0, 0, 0, 256);
+  g.addColorStop(0, 'rgba(255,244,214,0.85)');
+  g.addColorStop(0.55, 'rgba(255,240,200,0.3)');
+  g.addColorStop(1, 'rgba(255,240,200,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, 64, 256);
+  // Bordes laterales suaves (destination-in recorta con un gradiente horizontal).
+  const h = ctx.createLinearGradient(0, 0, 64, 0);
+  h.addColorStop(0, 'rgba(0,0,0,0)');
+  h.addColorStop(0.25, 'rgba(0,0,0,1)');
+  h.addColorStop(0.75, 'rgba(0,0,0,1)');
+  h.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.globalCompositeOperation = 'destination-in';
+  ctx.fillStyle = h;
+  ctx.fillRect(0, 0, 64, 256);
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+const LAMINAS_RAYO = [
+  { ox: -2.6, oz: 1.2, w: 0.9, l: 11, giro: 0.3 },
+  { ox: -0.8, oz: -1.8, w: 1.4, l: 12.5, giro: 1.2 },
+  { ox: 1.4, oz: 0.6, w: 0.7, l: 10, giro: 2.1 },
+  { ox: 3.1, oz: -1.1, w: 1.1, l: 12, giro: 0.8 },
+  { ox: -4.4, oz: -0.4, w: 0.8, l: 10.5, giro: 1.7 },
+];
+
+const _UP = new THREE.Vector3(0, 1, 0);
+
+function RayosDeSol({ franja, reducedMotion }) {
+  const grupo = useRef(null);
+  const tex = useMemo(() => texturaRayo(), []);
+  const mat = useMemo(
+    () => new THREE.MeshBasicMaterial({
+      map: tex,
+      transparent: true,
+      opacity: 0,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      fog: false,
+    }),
+    [tex],
+  );
+  // Lámina con el pivote en la punta de abajo (crece hacia el sol).
+  const geo = useMemo(() => {
+    const g = new THREE.PlaneGeometry(1, 1);
+    g.translate(0, 0.5, 0);
+    return g;
+  }, []);
+  useLayoutEffect(() => () => {
+    tex.dispose();
+    mat.dispose();
+    geo.dispose();
+  }, [tex, mat, geo]);
+
+  const objetivo = useMemo(() => {
+    const p = presetBosque(franja);
+    const d = new THREE.Vector3(p.solPos[0], p.solPos[1], p.solPos[2]).normalize();
+    // Elevación mínima: aunque el sol esté rasante, la luz colada cae en
+    // DIAGONAL entre las copas (sin esto, al amanecer las láminas se tienden
+    // horizontales y se delatan como bandas planas cruzando el cielo).
+    d.y = Math.max(d.y, 0.6);
+    d.normalize();
+    return {
+      op: OPACIDAD_RAYOS[franja] ?? 0.2,
+      quat: new THREE.Quaternion().setFromUnitVectors(_UP, d),
+    };
+  }, [franja]);
+
+  useFrame((state, dt) => {
+    const g = grupo.current;
+    if (!g) return;
+    const k = reducedMotion ? 1 : 1 - Math.exp(-1.2 * Math.min(dt, 0.1));
+    g.quaternion.slerp(objetivo.quat, k);
+    const t = state.clock.elapsedTime;
+    const pulso = reducedMotion ? 1 : 0.85 + 0.15 * Math.sin(t * 0.23);
+    // El material se alcanza por el grafo (todas las láminas lo comparten):
+    // mismo patrón que NieblaRasante — cero setState, cero alocación.
+    const m = g.children[0]?.children[0]?.material;
+    if (m) m.opacity += (objetivo.op * pulso - m.opacity) * k;
+  });
+
+  return (
+    <group ref={grupo} position={[0, 0.2, 0]}>
+      {LAMINAS_RAYO.map((l, i) => (
+        <group key={i} position={[l.ox, 0, l.oz]} rotation={[0, l.giro, 0]}>
+          <mesh geometry={geo} material={mat} scale={[l.w, l.l, 1]} />
+          <mesh geometry={geo} material={mat} scale={[l.w, l.l, 1]} rotation={[0, Math.PI / 2, 0]} />
+        </group>
+      ))}
+    </group>
+  );
+}
+
+/* ── BRUMA POR CAPAS (la niebla volumétrica falsa con parallax) ────────────
+      Cartas grandes billboard a radios crecientes: al orbitar, las capas se
+      deslizan a velocidades distintas y el bosque gana profundidad física.
+      La franja pesa: más bruma al amanecer y de noche. */
+const CAPAS_BRUMA = [
+  { rad: 13.5, y: 2.3, w: 24, h: 5.5, op: 0.16, vel: 0.011, fase: 0 },
+  { rad: 17, y: 3.1, w: 32, h: 7, op: 0.14, vel: -0.008, fase: 2.2 },
+  { rad: 21.5, y: 4.2, w: 42, h: 9, op: 0.12, vel: 0.006, fase: 4.1 },
+  { rad: 26, y: 5.6, w: 54, h: 11, op: 0.1, vel: -0.004, fase: 1.3 },
+];
+const PESO_BRUMA = {
+  amanecer: 1.4, manana: 1.0, mediodia: 0.65, tarde: 0.9, atardecer: 1.25, noche: 1.15,
+};
+
+function texturaBruma(seed = 7) {
+  const cv = document.createElement('canvas');
+  cv.width = 256;
+  cv.height = 128;
+  const ctx = cv.getContext('2d');
+  let s = seed;
+  const r = () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+  for (let i = 0; i < 10; i++) {
+    const x = 20 + r() * 216;
+    const y = 30 + r() * 68;
+    const rad = 28 + r() * 55;
+    const a = 0.16 + r() * 0.2;
+    const g = ctx.createRadialGradient(x, y, 0, x, y, rad);
+    g.addColorStop(0, `rgba(238,244,242,${a})`);
+    g.addColorStop(1, 'rgba(238,244,242,0)');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 256, 128);
+  }
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+function BrumaParallax({ franja, reducedMotion }) {
+  const grupo = useRef(null);
+  const peso = useRef(1);
+  const tex = useMemo(() => texturaBruma(), []);
+  const mats = useMemo(
+    () => CAPAS_BRUMA.flatMap((c) => [0, 1].map(() => new THREE.MeshBasicMaterial({
+      map: tex,
+      transparent: true,
+      opacity: c.op,
+      depthWrite: false,
+      fog: false,
+    }))),
+    [tex],
+  );
+  useLayoutEffect(() => () => {
+    tex.dispose();
+    mats.forEach((m) => m.dispose());
+  }, [tex, mats]);
+
+  useFrame((state, dt) => {
+    const g = grupo.current;
+    if (!g) return;
+    const t = state.clock.elapsedTime;
+    const k = reducedMotion ? 1 : 1 - Math.exp(-0.8 * Math.min(dt, 0.1));
+    peso.current += ((PESO_BRUMA[franja] ?? 1) - peso.current) * k;
+    let idx = 0;
+    for (let c = 0; c < CAPAS_BRUMA.length; c++) {
+      const capa = CAPAS_BRUMA[c];
+      for (let lado = 0; lado < 2; lado++) {
+        const carta = g.children[idx];
+        if (!carta) break;
+        const az = capa.fase + lado * Math.PI + (reducedMotion ? 0 : t * capa.vel);
+        carta.position.set(
+          Math.cos(az) * capa.rad,
+          capa.y + (reducedMotion ? 0 : Math.sin(t * 0.05 + capa.fase + lado) * 0.25),
+          Math.sin(az) * capa.rad,
+        );
+        carta.quaternion.copy(state.camera.quaternion);
+        carta.material.opacity = capa.op * peso.current
+          * (reducedMotion ? 1 : 0.9 + 0.1 * Math.sin(t * 0.07 + capa.fase * 2 + lado * 3));
+        idx++;
+      }
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {CAPAS_BRUMA.flatMap((c, ci) => [0, 1].map((lado) => (
+        <mesh key={`${ci}-${lado}`} material={mats[ci * 2 + lado]}>
+          <planeGeometry args={[c.w, c.h]} />
+        </mesh>
+      )))}
+    </group>
+  );
+}
+
+/* ── LA CÁMARA: pose de reposo consciente del ASPECTO ──────────────────────
+      En landscape la pose aprobada (leve contrapicado que hace imponente al
+      guardián, el arroyo entrando por la derecha del cuadro). En un teléfono
+      parado la cámara retrocede y sube apenas: el fov vertical alcanza y el
+      Ent respira sin perder el queñual de los flancos. */
+const POSE_BOSQUE = { position: [8.0, 2.55, 11.6], fov: 42, mira: [0, 3.0, 0] };
+
+function poseBosqueParaAspecto(aspect) {
+  if (!aspect || aspect >= 0.9) return { ...POSE_BOSQUE, k: 1 };
+  const t = Math.min(1, (0.9 - aspect) / 0.44);
+  const B = { position: [10.6, 4.4, 15.4], fov: 56, mira: [0, 2.7, 0] };
+  const lerp = (a, b) => a + (b - a) * t;
+  const position = POSE_BOSQUE.position.map((v, i) => lerp(v, B.position[i]));
+  const mira = POSE_BOSQUE.mira.map((v, i) => lerp(v, B.mira[i]));
+  const dist = (p, m) => Math.hypot(p[0] - m[0], p[1] - m[1], p[2] - m[2]);
+  return {
+    position,
+    fov: Math.round(lerp(POSE_BOSQUE.fov, B.fov)),
+    mira,
+    k: dist(position, mira) / dist(POSE_BOSQUE.position, POSE_BOSQUE.mira),
+  };
+}
+
+/* ── EL DIORAMA ──────────────────────────────────────────────────────────── */
+function Diorama({ tier, reducedMotion, pose }) {
+  const perfil = perfilDeTier(tier);
+  const controls = useRef(null);
+  const { franja } = useCicloDia({ reducedMotion });
+  const nocturno = franja === 'noche';
+  const fracEstrellas = presetBosque(franja).estrellas;
 
   return (
     <>
-      <color attach="background" args={[PARAMO.fondo]} />
-      {perfil.fog && <fog attach="fog" args={[PARAMO.niebla, 9, 34]} />}
+      {/* Atmósfera del ciclo de día: fondo + niebla + las cuatro luces. */}
+      <AtmosferaBosque franja={franja} perfil={perfil} reducedMotion={reducedMotion} />
+      {fracEstrellas > 0 && perfil.estrellas > 0 && (
+        <Stars
+          radius={44}
+          depth={22}
+          count={Math.max(24, Math.round(perfil.estrellas * fracEstrellas))}
+          factor={3}
+          fade
+          speed={reducedMotion ? 0 : 1}
+        />
+      )}
 
-      {/* luz de páramo: cielo frío, sol tenue y velado */}
-      <hemisphereLight intensity={0.95} color="#d7e2e4" groundColor="#3a3a2c" />
-      <ambientLight intensity={0.35} color="#cdd7da" />
-      <directionalLight
-        position={[6, 11, 5]}
-        intensity={1.15}
-        color="#eef3f0"
-        castShadow={perfil.sombras}
-        shadow-mapSize-width={1024}
-        shadow-mapSize-height={1024}
-        shadow-camera-near={1}
-        shadow-camera-far={30}
-        shadow-camera-left={-8}
-        shadow-camera-right={8}
-        shadow-camera-top={10}
-        shadow-camera-bottom={-4}
-      />
-      {/* contraluz frío que separa la copa de la niebla */}
-      <directionalLight position={[-5, 6, -6]} intensity={0.4} color="#b9cdd6" />
+      {/* El anfiteatro: terreno con relieve, pintado por vértice. */}
+      <TerrenoBosque nocturno={nocturno} perfil={perfil} />
 
-      {/* suelo de musgo del páramo */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]} receiveShadow>
-        <circleGeometry args={[32, 40]} />
-        <meshLambertMaterial color={PARAMO.suelo} />
-      </mesh>
-      {/* parche de musgo húmedo bajo el árbol */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.01, 0]}>
-        <circleGeometry args={[3.4, 28]} />
-        <meshLambertMaterial color={PARAMO.musgo} />
-      </mesh>
-      {/* sombra de contacto suave (barata, en todos los tiers) */}
+      {/* El queñual: héroes que enmarcan + siluetas lejanas en la niebla. */}
+      <Quenual tier={tier} perfil={perfil} />
+
+      {/* El suelo vivido: hojarasca y madera muerta con musgo. */}
+      <Hojarasca tier={tier} />
+      <TroncosCaidos tier={tier} perfil={perfil} />
+
+      {/* El arroyo que baja de la niebla (de noche, lo que más brilla). */}
+      {tier !== 'bajo' && <Arroyo nocturno={nocturno} perfil={perfil} />}
+
+      {/* El ECOSISTEMA de páramo (frailejonar, sotobosque, árboles vecinos),
+          POSADO sobre el relieve con alturaDe. */}
+      <FloraParamo tier={tier} reducedMotion={reducedMotion} alturaDe={alturaBosque} />
+
+      {/* LA VIDA: cóndor, vecinos rubber-hose, mariposas, luciérnagas. */}
+      <FaunaBosque tier={tier} reducedMotion={reducedMotion} />
+
+      {/* Luz que se cuela entre las copas (solo donde sobra GPU). */}
+      {perfil.materialRico && <RayosDeSol franja={franja} reducedMotion={reducedMotion} />}
+
+      {/* La bruma con parallax que da profundidad física al orbitar. */}
+      {perfil.fog && <BrumaParallax franja={franja} reducedMotion={reducedMotion} />}
+
+      {/* Sombra de contacto del guardián (todos los tiers: lo planta). */}
       {perfil.sombrasContacto && (
-        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.02, 0]}>
-          <circleGeometry args={[1.6, 24]} />
-          <meshBasicMaterial color="#2c3324" transparent opacity={0.4} />
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.03, 0]}>
+          <circleGeometry args={[1.7, 24]} />
+          <meshBasicMaterial color="#20281c" transparent opacity={0.38} />
         </mesh>
       )}
 
-      {/* colinas lejanas que se pierden en la niebla */}
-      <mesh position={[-9, 0.5, -12]} scale={[6, 2.4, 4]}>
-        <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#59654b" />
-      </mesh>
-      <mesh position={[10, 0.4, -14]} scale={[7, 2.1, 4]}>
-        <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#515e46" />
-      </mesh>
-
-      {pajas.map((p) => (
-        <Paja key={p.key} pos={p.pos} />
-      ))}
-
-      {/* EL ECOSISTEMA de páramo: frailejonar, sotobosque, árboles de niebla,
-          rocas, musgo y vaho. Alrededor del guardián, sin taparlo. */}
-      <FloraParamo tier={tier} reducedMotion={reducedMotion} />
-
-      {/* LA VIDA: el cóndor arriba, los vecinos en su casa, mariposas y
-          abejas sobre el frailejonar. Un bosque sin bichos es un decorado. */}
-      <FaunaBosque tier={tier} reducedMotion={reducedMotion} />
-
-      {/* EL GUARDIÁN */}
-      <EntQuenua tier={tier} reducedMotion={reducedMotion} />
+      {/* ══ MOUNT DEL ENT ══ El guardián vive AQUÍ (origen del claro). Otra
+          rama lo eleva de calibre: inyectar el Ent nuevo en este group sin
+          tocar el resto del escenario. */}
+      <group name="mount-ent">
+        <EntQuenua tier={tier} reducedMotion={reducedMotion} />
+      </group>
 
       <OrbitControls
+        ref={controls}
         makeDefault
-        target={[0, 3.2, 0]}
+        target={pose.mira}
         enablePan={false}
         enableZoom
-        minDistance={7}
-        maxDistance={20}
-        minPolarAngle={0.55}
-        maxPolarAngle={1.5}
+        minDistance={6}
+        maxDistance={Math.max(20, Math.ceil(16 * pose.k) + 5)}
+        minPolarAngle={0.5}
+        maxPolarAngle={1.42}
         enableDamping
         dampingFactor={0.08}
         autoRotate={!reducedMotion}
-        autoRotateSpeed={0.16}
+        autoRotateSpeed={0.1}
+      />
+      {/* La LLEGADA: dolly de establecimiento (una vez por sesión) — la
+          cámara arranca mirando al dosel y baja al rostro del guardián. */}
+      <CamaraDirector
+        controls={controls}
+        reposo={pose.position}
+        mirada={[0, 4.6, 0]}
+        duracion={2.6}
+        amplio={1.35}
+        respiro={0.045}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="bosqueTakeA"
       />
       <AdaptiveDpr pixelated />
     </>
@@ -148,23 +692,33 @@ function Diorama({ tier, reducedMotion }) {
 }
 
 /**
- * El mundo Bosque Vivo con el Ent de la queñua. Montar SOLO perezosa.
+ * El mundo Bosque Vivo con el Ent de la queñua (TAKE A). Montar SOLO perezosa.
  * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
  */
 export default function EscenaBosqueVivo({ tier = 'alto', reducedMotion = false }) {
   const perfil = perfilDeTier(tier);
   const [listo, setListo] = useState(false);
+  const pose = useMemo(
+    () => poseBosqueParaAspecto(
+      typeof window !== 'undefined' && window.innerHeight > 0
+        ? window.innerWidth / window.innerHeight
+        : 1,
+    ),
+    [],
+  );
   return (
     <Canvas
       className={`bviva-canvas${listo ? ' bviva-canvas--lista' : ''}`}
       dpr={perfil.dpr}
       gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
       shadows={perfil.sombras ? 'soft' : false}
-      camera={{ position: [1.5, 2.3, 12.5], fov: 44 }}
+      camera={/** @type {any} */ ({ position: pose.position, fov: pose.fov })}
       frameloop={reducedMotion ? 'demand' : 'always'}
       onCreated={() => setListo(true)}
     >
-      <Diorama tier={tier} reducedMotion={reducedMotion} />
+      <Suspense fallback={null}>
+        <Diorama tier={tier} reducedMotion={reducedMotion} pose={pose} />
+      </Suspense>
     </Canvas>
   );
 }

--- a/src/visual/mundo3d/bosque/FloraParamo.jsx
+++ b/src/visual/mundo3d/bosque/FloraParamo.jsx
@@ -160,9 +160,11 @@ function NieblaRasante({ n, reducedMotion }) {
 
 /**
  * La capa de flora del páramo alrededor del Ent. Montar dentro del <Canvas>.
- * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ * `alturaDe(x,z)` (opcional) POSA cada mata sobre el relieve del terreno:
+ * sin ella la siembra queda en y=0 (el claro plano de siempre).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, alturaDe?: ((x:number,z:number)=>number)|null}} props
  */
-export default function FloraParamo({ tier = 'alto', reducedMotion = false }) {
+export default function FloraParamo({ tier = 'alto', reducedMotion = false, alturaDe = null }) {
   const perfil = perfilDeTier(tier);
   const conteos = floraDeTier(tier);
   const q = calidadDeTier(tier);
@@ -192,8 +194,16 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false }) {
       : new THREE.MeshLambertMaterial(base);
   }, [perfil.materialRico, perfil.flatShading]);
 
-  // --- Distribución biogeográfica (una vez por tier). ---
-  const dist = useMemo(() => distribucionFlora(conteos, 707), [conteos]);
+  // --- Distribución biogeográfica (una vez por tier), posada en el relieve. ---
+  const dist = useMemo(() => {
+    const d = distribucionFlora(conteos, 707);
+    if (!alturaDe) return d;
+    const posar = (items) => items.map((it) => ({
+      ...it,
+      pos: [it.pos[0], alturaDe(it.pos[0], it.pos[2]) + (it.pos[1] || 0), it.pos[2]],
+    }));
+    return Object.fromEntries(Object.entries(d).map(([k, v]) => [k, posar(v)]));
+  }, [conteos, alturaDe]);
 
   // Liberar GPU al desmontar.
   useLayoutEffect(() => () => {

--- a/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
+++ b/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
@@ -1,0 +1,574 @@
+/*
+ * bosqueTakeA.geom — la GEOMETRÍA del bosque de niebla TAKE A (naturalista).
+ *
+ * El claro del guardián deja de ser un plato verde: aquí vive el RELIEVE del
+ * anfiteatro altoandino (heightfield determinista), el QUEÑUAL de troncos
+ * retorcidos con copas que son MASA de hojas (nubes deformadas con normales
+ * radiales — nada de poliedros literales), la hojarasca del suelo, los troncos
+ * caídos con musgo y el arroyo que baja de la niebla.
+ *
+ * Reglas de la casa:
+ *   · Todo procedural y determinista (rng con semilla): el mismo bosque en
+ *     cada carga, cero assets externos.
+ *   · Color HORNEADO por vértice (hornearCorteza/hornearFollaje del taller
+ *     sombreadoVegetal) → un material con vertexColors por banco.
+ *   · mergeGeometries devuelve NULL EN SILENCIO si se mezclan indexadas con
+ *     no-indexadas (ya mordió 3 veces): aquí TODO se desindexa y se TRUENA si
+ *     el merge falla — pero SIN recomputar normales (las copas traen normales
+ *     radiales a propósito: así la nube de hojas se sombrea suave).
+ *   · three core puro: corre headless, sin contexto GL.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import {
+  rng,
+  ruidoFbm,
+  desindexar,
+  poner,
+  apuntar,
+  pintarPlano,
+  hornearFollaje,
+  hornearCorteza,
+  tuboOrganico,
+  taperTronco,
+  taperLineal,
+  curvaTronco,
+  sembrarFollaje,
+} from './sombreadoVegetal.js';
+
+const ss = THREE.MathUtils.smoothstep;
+
+/* -------------------------------------------------------------------------- */
+/*  Fusión que PRESERVA normales                                               */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * fusionarSeguro (del taller) recalcula normales al final — correcto para la
+ * flora facetada, letal para las copas-nube: sus normales RADIALES (puestas a
+ * mano) son lo que las hace leerse como masa suave de hojas y no como
+ * icosaedros. Esta variante desindexa, truena si el merge da null, y respeta
+ * las normales que cada parte ya trae.
+ */
+function fusionarConNormales(partes, etiqueta = 'sin-nombre') {
+  const buenas = partes.filter(Boolean).map(desindexar);
+  if (!buenas.length) {
+    throw new Error(`[bosqueTakeA] "${etiqueta}": no hay partes que fusionar.`);
+  }
+  const refAttrs = Object.keys(buenas[0].attributes).sort().join(',');
+  for (let i = 0; i < buenas.length; i++) {
+    const attrs = Object.keys(buenas[i].attributes).sort().join(',');
+    if (attrs !== refAttrs) {
+      throw new Error(
+        `[bosqueTakeA] "${etiqueta}": la parte ${i} tiene atributos [${attrs}] `
+        + `pero se esperaba [${refAttrs}] — mergeGeometries devolvería null.`,
+      );
+    }
+  }
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error(
+      `[bosqueTakeA] "${etiqueta}": mergeGeometries devolvió NULL — la pieza `
+      + 'habría quedado invisible sin error.',
+    );
+  }
+  return g;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL TERRENO — el anfiteatro del bosque de niebla                            */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Altura del terreno en (x,z). La composición:
+ *   · CLARO central plano (r<3.2): el Ent y los vecinos viven en y≈0 — la
+ *     fauna billboard y las raíces del guardián no flotan ni se entierran.
+ *   · ONDULACIÓN media (r 3.2→9.5): lomos suaves de musgo, el microrelieve
+ *     que hace que el suelo deje de ser una mesa.
+ *   · PARED del anfiteatro (r>12.5): la ladera trepa hasta ~6 con crestas
+ *     irregulares por ángulo — el cuenco que la niebla se come al fondo.
+ *   · CAÑADA del arroyo: una vaguada honda que baja del fondo brumoso y
+ *     cruza el flanco derecho del claro.
+ * Determinista y barata: los objetos se POSAN encima con esta misma función.
+ */
+export function xArroyo(z) {
+  return 4.7 + Math.sin(z * 0.24 + 1.3) * 1.5;
+}
+
+export function alturaBosque(x, z) {
+  const r = Math.hypot(x, z);
+  const ang = Math.atan2(z, x);
+  const onda = (Math.sin(x * 0.52 + 1.7) * Math.cos(z * 0.47 - 0.6) * 0.36
+    + Math.sin(x * 1.25 - z * 0.85 + 2.1) * 0.13) * ss(r, 3.2, 9.5);
+  const micro = (Math.sin(x * 2.6 + z * 1.9) * 0.04
+    + Math.cos(x * 1.7 - z * 2.8) * 0.035) * ss(r, 2.2, 5);
+  const cresta = 1 + 0.34 * Math.sin(ang * 3 + 1.2)
+    + 0.2 * Math.sin(ang * 7 - 0.7)
+    + 0.12 * Math.sin(ang * 13 + 2.3);
+  const pared = ss(r, 12.5, 30) ** 1.25 * 4.8 * cresta;
+  const dx = x - xArroyo(z);
+  const canada = -0.4 * Math.exp(-(dx * dx) / 1.15) * ss(z, -13, -6) * (1 - ss(r, 20, 28));
+  return onda + micro + pared + canada;
+}
+
+/* Paleta del suelo (musgo, hojarasca, tierra pisada, humedad, roca). */
+const SUELO = {
+  musgoOscuro: new THREE.Color('#3d4b2c'),
+  musgoClaro: new THREE.Color('#5a6b3a'),
+  hojarasca: new THREE.Color('#6e5838'),
+  hojarasca2: new THREE.Color('#7d6a44'),
+  tierra: new THREE.Color('#5c4a33'),
+  humedo: new THREE.Color('#2f3d2b'),
+  roca: new THREE.Color('#7b8074'),
+  rocaOscura: new THREE.Color('#5d6156'),
+  noche: new THREE.Color('#243349'),
+};
+
+export const LADO_TERRENO = 64;
+
+/*
+ * La malla del terreno, PINTADA por vértice: musgo moteado de base, parches de
+ * hojarasca bajo el anillo de árboles, el patio de tierra pisada del Ent, la
+ * humedad oscura de la cañada y la roca pálida asomando en lo alto de la
+ * pared. De noche todo se enfría hacia el azul-luna (día por noche del cine).
+ */
+export function geomTerrenoBosque({ seg = 90, nocturno = false } = {}) {
+  const g = new THREE.PlaneGeometry(LADO_TERRENO, LADO_TERRENO, seg, seg);
+  g.rotateX(-Math.PI / 2);
+  const pos = g.attributes.position;
+  const colores = new Float32Array(pos.count * 3);
+  const col = new THREE.Color();
+  for (let i = 0; i < pos.count; i++) {
+    const x = pos.getX(i);
+    const z = pos.getZ(i);
+    const y = alturaBosque(x, z);
+    pos.setY(i, y);
+    const r = Math.hypot(x, z);
+
+    // Musgo moteado (dos verdes que el ruido mezcla en nubes grandes).
+    const mote = ruidoFbm(x * 0.33 + 3, 0, z * 0.33);
+    col.copy(SUELO.musgoOscuro).lerp(SUELO.musgoClaro, mote);
+
+    // Hojarasca bajo el anillo del queñual (parches, no alfombra).
+    const mHoja = ruidoFbm(x * 0.21 + 9, 0, z * 0.21);
+    if (r > 4 && r < 18 && mHoja > 0.55) {
+      const t = ss(mHoja, 0.55, 0.82) * 0.85;
+      col.lerp(mHoja > 0.7 ? SUELO.hojarasca2 : SUELO.hojarasca, t);
+    }
+
+    // El patio de tierra pisada bajo el guardián (afordancia sin UI).
+    const patio = 1 - ss(r, 1.5, 2.8);
+    if (patio > 0) col.lerp(SUELO.tierra, patio * 0.75);
+
+    // La humedad de la cañada (el suelo oscuro y mojado junto al agua).
+    const dxA = x - xArroyo(z);
+    const fCa = Math.exp(-(dxA * dxA) / 1.6) * ss(z, -13, -6) * (1 - ss(r, 20, 28));
+    if (fCa > 0.02) col.lerp(SUELO.humedo, fCa * 0.7);
+
+    // Roca asomando en lo alto de la pared del anfiteatro.
+    const fR = ss(y, 2.0, 4.8);
+    if (fR > 0) {
+      const veta = ruidoFbm(x * 0.5, y * 0.5, z * 0.5);
+      col.lerp(veta > 0.5 ? SUELO.roca : SUELO.rocaOscura, fR * 0.75);
+    }
+
+    if (nocturno) col.lerp(SUELO.noche, 0.55);
+    colores[i * 3] = col.r;
+    colores[i * 3 + 1] = col.g;
+    colores[i * 3 + 2] = col.b;
+  }
+  g.setAttribute('color', new THREE.BufferAttribute(colores, 3));
+  g.computeVertexNormals(); // indexada → normales SUAVES (lomas redondas)
+  return g;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LA QUEÑUA (Polylepis) — el árbol del bosque de niebla                      */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Nube de follaje SUAVE: un icosaedro subdividido, deformado con ruido y con
+ * NORMALES RADIALES puestas a mano — así el matojo se sombrea como una masa
+ * redonda de hojas (Ori/BOTW), no como un poliedro facetado. Es la pieza que
+ * mata el "icosaedro literal" que el operador odia.
+ */
+function matojoNube(radio, semilla = 1, deform = 0.5) {
+  const g = new THREE.IcosahedronGeometry(radio, 1);
+  const pos = g.attributes.position;
+  const v = new THREE.Vector3();
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i);
+    const n = ruidoFbm(v.x * 2.2 + semilla, v.y * 2.2, v.z * 2.2) - 0.5;
+    v.multiplyScalar(1 + n * deform * 2);
+    pos.setXYZ(i, v.x, v.y, v.z);
+  }
+  pos.needsUpdate = true;
+  const nor = new Float32Array(pos.count * 3);
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i).normalize();
+    nor[i * 3] = v.x;
+    nor[i * 3 + 1] = v.y;
+    nor[i * 3 + 2] = v.z;
+  }
+  g.setAttribute('normal', new THREE.BufferAttribute(nor, 3));
+  return g;
+}
+
+/* Paleta Polylepis: corteza roja que se despapela + hoja menuda verde-gris. */
+const QUENUA = {
+  grieta: '#3a231a',
+  cuerpo: '#82503a',
+  papel: '#cf9068', // la lámina que se desprende (la firma de la queñua)
+  liquen: '#94a56b',
+  hojaBase: '#2c4531',
+  hojaSol: '#6f9150',
+  hojaLuz: '#c3cf7e',
+  barba: '#93a877', // musgo/usnea colgando en el bosque de niebla
+};
+
+/*
+ * UNA queñua completa, fusionada en UNA geometría con color horneado:
+ *   · fuste principal retorcido (curva + conicidad + arruga de corteza) y un
+ *     segundo fuste bajo — Polylepis crece en macolla, nunca es un palo recto;
+ *   · ramas que suben en busca de luz, cada una rematada en un LÓBULO de copa;
+ *   · cada lóbulo es un puñado de matojos-nube sembrados con huecos y borde
+ *     mordido (el cielo se ve a través) + AO/gradiente/contraluz horneados;
+ *   · barbas de musgo colgando del borde inferior (el velo del bosque de niebla).
+ * `q` escala el detalle (tier); `seed` da variantes distintas.
+ */
+export function geomQuenua({ q = 1 } = {}, seed = 21) {
+  const r = rng(seed);
+  const partesCorteza = [];
+  const copas = [];
+  const H = 3.3 + r() * 1.2;
+
+  // Fuste principal: pelea con el viento (inclinación + sinuosidad + torsión).
+  const curva = curvaTronco(
+    { altura: H, inclina: 0.14 + r() * 0.14, sinuoso: 0.15 + r() * 0.12, giro: r() * Math.PI * 2 },
+    seed + 1,
+  );
+  partesCorteza.push(tuboOrganico(curva, {
+    tubular: Math.max(10, Math.round(20 * q)),
+    radial: Math.max(6, Math.round(8 * q)),
+    taper: taperTronco(0.24 + r() * 0.07, 0.085, 0.55),
+    arruga: 0.16,
+    semilla: seed * 3.1,
+  }));
+
+  // Segundo fuste (la macolla): más bajo, más recostado.
+  const giro2 = r() * Math.PI * 2;
+  const off2 = [Math.cos(giro2) * 0.3, 0, Math.sin(giro2) * 0.3];
+  const curva2 = curvaTronco(
+    { altura: H * (0.45 + r() * 0.2), inclina: 0.34 + r() * 0.2, sinuoso: 0.22, giro: giro2 },
+    seed + 2,
+  );
+  const fuste2 = tuboOrganico(curva2, {
+    tubular: Math.max(8, Math.round(12 * q)),
+    radial: Math.max(5, Math.round(7 * q)),
+    taper: taperTronco(0.13 + r() * 0.04, 0.05, 0.5),
+    arruga: 0.18,
+    semilla: seed * 5.7,
+  });
+  poner(fuste2, off2);
+  partesCorteza.push(fuste2);
+
+  // Lóbulos de copa: la corona del fuste + la punta de cada rama + la macolla.
+  const lobulos = [];
+  const puntaP = curva.getPointAt(1);
+  lobulos.push({ c: [puntaP.x, puntaP.y + 0.42, puntaP.z], radio: 0.95 + r() * 0.3 });
+
+  const nRamas = Math.max(2, Math.round(3 * q));
+  for (let i = 0; i < nRamas; i++) {
+    const t0 = Math.min(0.9, 0.55 + i * (0.32 / nRamas) + r() * 0.05);
+    const pIni = curva.getPointAt(t0);
+    const ang = r() * Math.PI * 2;
+    const alcance = 0.9 + r() * 0.7;
+    const pFin = new THREE.Vector3(
+      pIni.x + Math.cos(ang) * alcance,
+      pIni.y + 0.55 + r() * 0.5,
+      pIni.z + Math.sin(ang) * alcance,
+    );
+    const pMed = pIni.clone().lerp(pFin, 0.5);
+    pMed.y += 0.18;
+    partesCorteza.push(tuboOrganico(new THREE.CatmullRomCurve3([pIni, pMed, pFin]), {
+      tubular: Math.max(6, Math.round(9 * q)),
+      radial: Math.max(5, Math.round(6 * q)),
+      taper: taperLineal(0.085, 0.03),
+      arruga: 0.12,
+      semilla: seed * 7 + i,
+    }));
+    lobulos.push({ c: [pFin.x, pFin.y + 0.3, pFin.z], radio: 0.68 + r() * 0.35 });
+  }
+  const punta2 = curva2.getPointAt(1);
+  lobulos.push({
+    c: [punta2.x + off2[0], punta2.y + 0.26, punta2.z + off2[2]],
+    radio: 0.52 + r() * 0.25,
+  });
+
+  // Corteza horneada: grieta/cuerpo/papel rojizo + líquen trepando el pie.
+  const corteza = fusionarConNormales(partesCorteza, 'quenua-corteza');
+  hornearCorteza(corteza, {
+    grieta: QUENUA.grieta,
+    cuerpo: QUENUA.cuerpo,
+    cresta: QUENUA.papel,
+    liquen: QUENUA.liquen,
+    escalaGrano: 4.2,
+    hastaLiquen: 0.85,
+  });
+
+  // Copas: matojos-nube con huecos, borde mordido y sombreado horneado.
+  const varia = (hex, amt) => {
+    const c = new THREE.Color(hex);
+    c.multiplyScalar(1 + (r() - 0.5) * amt);
+    return c;
+  };
+  for (let i = 0; i < lobulos.length; i++) {
+    const lb = lobulos[i];
+    const puntos = sembrarFollaje({
+      centro: lb.c,
+      radio: lb.radio,
+      achatado: 0.72,
+      n: Math.max(5, Math.round(11 * q * lb.radio)),
+      semilla: seed * 13 + i * 3,
+      huecos: 0.46,
+      mordida: 0.38,
+      distMin: lb.radio * 0.3,
+    });
+    const matojos = puntos.map((p, k) => {
+      const m = matojoNube((0.26 + 0.16 * p.esc) * lb.radio, seed * 17 + i * 5 + k, 0.5);
+      poner(m, p.pos, p.giro, [1, 0.82, 1]);
+      return m;
+    });
+    if (!matojos.length) {
+      const m = matojoNube(lb.radio * 0.7, seed * 17 + i * 5, 0.5);
+      poner(m, lb.c, [0, 0, 0], [1, 0.82, 1]);
+      matojos.push(m);
+    }
+    const copa = fusionarConNormales(matojos, 'quenua-copa');
+    hornearFollaje(copa, {
+      base: varia(QUENUA.hojaBase, 0.1),
+      sol: varia(QUENUA.hojaSol, 0.12),
+      luz: QUENUA.hojaLuz,
+      centro: lb.c,
+      radio: lb.radio * 1.2,
+      ao: 0.66,
+      manchas: 0.16,
+    });
+    copas.push(copa);
+  }
+
+  // Barbas de musgo colgando del borde inferior de los lóbulos.
+  const barbas = [];
+  const nBarbas = Math.max(2, Math.round(5 * q));
+  for (let i = 0; i < nBarbas; i++) {
+    const lb = lobulos[i % lobulos.length];
+    const ang = r() * Math.PI * 2;
+    const largo = 0.3 + r() * 0.35;
+    const barba = new THREE.ConeGeometry(0.045, largo, 4, 1);
+    apuntar(
+      barba,
+      [
+        lb.c[0] + Math.cos(ang) * lb.radio * 0.55,
+        lb.c[1] - lb.radio * 0.5 - largo * 0.35,
+        lb.c[2] + Math.sin(ang) * lb.radio * 0.55,
+      ],
+      [Math.cos(ang) * 0.12, -1, Math.sin(ang) * 0.12],
+    );
+    barbas.push(pintarPlano(barba, varia(QUENUA.barba, 0.14)));
+  }
+
+  return fusionarConNormales([corteza, ...copas, ...barbas], 'quenua');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL QUEÑUAL — dónde vive cada queñua                                        */
+/* -------------------------------------------------------------------------- */
+
+/* El corredor de cámara (la vista de reposo mira al Ent desde ~az 0.61): las
+   queñuas HÉROE no se paran en el encuadre; las lejanas sí pueden velarse. */
+const AZ_CAMARA = 0.61;
+/* Los vecinos rubber-hose viven en estas anclas (FaunaBosque): despejarlas. */
+const ANCLAS_VECINOS = [[-3.7, 3.0], [3.1, 3.2], [-4.9, 4.4], [3.0, 2.1]];
+
+const CUPO_QUENUAL = {
+  alto: { cerca: 7, lejos: 9 },
+  medio: { cerca: 5, lejos: 5 },
+  bajo: { cerca: 3, lejos: 0 },
+};
+
+function tinteInstancia(r, amt = 0.1) {
+  const f = 1 + (r() - 0.5) * amt;
+  const h = (r() - 0.5) * amt * 0.5;
+  const cl = (v) => Math.max(0.75, Math.min(1.14, v));
+  return [cl(f + h), cl(f), cl(f - h * 0.6)];
+}
+
+/**
+ * Sitios del queñual para un tier: anillo HÉROE (r 6.4–10.6, enmarca el claro
+ * sin tapar el corredor de cámara ni el arroyo ni a los vecinos) + anillo
+ * LEJANO (r 12.5–19.5, sobre la falda de la pared, velado por la niebla, con
+ * escala mayor: siluetas que dan fondo). Determinista.
+ */
+export function sitiosQuenual(tier = 'alto') {
+  const cupo = CUPO_QUENUAL[tier] || CUPO_QUENUAL.medio;
+  const r = rng(929);
+  const sitios = [];
+
+  const cabe = (x, z, minSep) => {
+    for (const s of sitios) {
+      if ((s.pos[0] - x) ** 2 + (s.pos[2] - z) ** 2 < minSep * minSep) return false;
+    }
+    for (const [ax, az] of ANCLAS_VECINOS) {
+      if ((ax - x) ** 2 + (az - z) ** 2 < 1.8 * 1.8) return false;
+    }
+    return true;
+  };
+
+  let cerca = 0;
+  let intentos = 0;
+  while (cerca < cupo.cerca && intentos++ < 300) {
+    const ang = r() * Math.PI * 2;
+    const d = Math.atan2(Math.sin(ang - AZ_CAMARA), Math.cos(ang - AZ_CAMARA));
+    if (Math.abs(d) < 0.55) continue; // el encuadre del guardián queda libre
+    const rad = 6.4 + r() * 4.2;
+    const x = Math.cos(ang) * rad;
+    const z = Math.sin(ang) * rad;
+    if (z > -13 && Math.abs(x - xArroyo(z)) < 1.4) continue; // no pisar el agua
+    if (!cabe(x, z, 2.6)) continue;
+    sitios.push({
+      pos: [x, alturaBosque(x, z) - 0.06, z],
+      rotY: r() * Math.PI * 2,
+      esc: 0.92 + r() * 0.35,
+      variante: sitios.length % 3,
+      tinte: tinteInstancia(r),
+    });
+    cerca++;
+  }
+
+  let lejos = 0;
+  intentos = 0;
+  while (lejos < cupo.lejos && intentos++ < 300) {
+    const ang = r() * Math.PI * 2;
+    const d = Math.atan2(Math.sin(ang - AZ_CAMARA), Math.cos(ang - AZ_CAMARA));
+    if (Math.abs(d) < 0.22) continue; // ni las lejanas tapan al Ent de frente
+    const rad = 12.5 + r() * 7;
+    const x = Math.cos(ang) * rad;
+    const z = Math.sin(ang) * rad;
+    if (z > -13 && Math.abs(x - xArroyo(z)) < 1.6) continue;
+    if (!cabe(x, z, 3.1)) continue;
+    sitios.push({
+      pos: [x, alturaBosque(x, z) - 0.1, z],
+      rotY: r() * Math.PI * 2,
+      esc: 1.15 + r() * 0.5,
+      variante: sitios.length % 3,
+      tinte: tinteInstancia(r, 0.14),
+    });
+    lejos++;
+  }
+
+  return sitios;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  HOJARASCA — el suelo del bosque no está barrido                            */
+/* -------------------------------------------------------------------------- */
+
+/** Loseta de hojarasca: disco bajo de borde irregular (se instancia). */
+export function geomLosetaHojarasca(seed = 5) {
+  const r = rng(seed);
+  const g = new THREE.CircleGeometry(1, 7);
+  const pos = g.attributes.position;
+  const v = new THREE.Vector2();
+  for (let i = 1; i < pos.count; i++) { // el vértice 0 es el centro
+    v.set(pos.getX(i), pos.getY(i));
+    const f = 0.72 + r() * 0.5;
+    pos.setXY(i, v.x * f, v.y * f);
+  }
+  g.rotateX(-Math.PI / 2);
+  return g;
+}
+
+const TINTES_HOJARASCA = ['#6e5838', '#7d6a44', '#5c4a30', '#87724d', '#4f4a2c', '#75543a'];
+
+/** Siembra de hojarasca: parches bajo el anillo de árboles, no alfombra. */
+export function sitiosHojarasca(n, seed = 31) {
+  const r = rng(seed);
+  const arr = [];
+  for (let i = 0; i < n; i++) {
+    const ang = r() * Math.PI * 2;
+    const rad = 2.6 + Math.sqrt(r()) * 13;
+    const x = Math.cos(ang) * rad;
+    const z = Math.sin(ang) * rad;
+    arr.push({
+      pos: [x, alturaBosque(x, z) + 0.02, z],
+      rotY: r() * Math.PI * 2,
+      esc: 0.07 + r() * (r() > 0.85 ? 0.24 : 0.12),
+      tinte: TINTES_HOJARASCA[Math.floor(r() * TINTES_HOJARASCA.length)],
+    });
+  }
+  return arr;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  TRONCOS CAÍDOS — la madera muerta que hace bosque viejo                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Dos troncos caídos con musgo encima, posados sobre el relieve. UNA geometría
+ * (color horneado) → un draw-call.
+ */
+export function geomTroncosCaidos(q = 1) {
+  const partes = [];
+  const domos = [];
+  const caido = (x0, z0, x1, z1, grosor, seed) => {
+    const y0 = alturaBosque(x0, z0);
+    const y1 = alturaBosque(x1, z1);
+    const curva = new THREE.CatmullRomCurve3([
+      new THREE.Vector3(x0, y0 + grosor * 0.55, z0),
+      new THREE.Vector3((x0 + x1) / 2, Math.max(y0, y1) + grosor * 0.9, (z0 + z1) / 2),
+      new THREE.Vector3(x1, y1 + grosor * 0.5, z1),
+    ]);
+    partes.push(tuboOrganico(curva, {
+      tubular: Math.max(8, Math.round(12 * q)),
+      radial: Math.max(5, Math.round(7 * q)),
+      taper: taperLineal(grosor, grosor * 0.62),
+      arruga: 0.2,
+      semilla: seed,
+    }));
+    // Musgo encima (domos bajos, el lado que mira al cielo húmedo).
+    const rD = rng(seed * 3);
+    for (let i = 0; i < Math.max(2, Math.round(4 * q)); i++) {
+      const t = 0.2 + rD() * 0.6;
+      const p = curva.getPointAt(t);
+      const domo = new THREE.SphereGeometry(grosor * (0.5 + rD() * 0.4), 7, 5, 0, Math.PI * 2, 0, Math.PI * 0.5);
+      poner(domo, [p.x, p.y + grosor * 0.5, p.z], [0, rD() * Math.PI, 0], [1.4, 0.5, 1]);
+      domos.push(pintarPlano(domo, new THREE.Color(rD() > 0.5 ? '#4c5c34' : '#5a6a3e')));
+    }
+  };
+  caido(-6.8, 4.6, -4.0, 6.6, 0.2, 41);
+  caido(6.4, -5.2, 8.6, -3.2, 0.17, 43);
+
+  const madera = fusionarConNormales(partes, 'troncos-caidos');
+  hornearCorteza(madera, {
+    grieta: '#33261d',
+    cuerpo: '#6b503b',
+    cresta: '#8a6d4f',
+    liquen: '#94a56b',
+    escalaGrano: 3.6,
+    hastaLiquen: 1.4,
+  });
+  return fusionarConNormales([madera, ...domos], 'troncos-caidos-musgo');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL ARROYO — el hilo de agua que baja de la niebla                          */
+/* -------------------------------------------------------------------------- */
+
+/** La curva del arroyo, posada sobre su cañada (para TubeGeometry). */
+export function curvaArroyo() {
+  const pts = [];
+  for (let z = -12; z <= 15; z += 3) {
+    const x = xArroyo(z);
+    pts.push(new THREE.Vector3(x, alturaBosque(x, z) + 0.05, z));
+  }
+  return new THREE.CatmullRomCurve3(pts);
+}


### PR DESCRIPTION
## El Bosque Vivo — TAKE A (naturalista, bosque de niebla andino)

Rehace la **escena completa** del Bosque Vivo al calibre del valle. El plato verde con dos esferas de fondo se retiró; ahora el guardián vive en un **anfiteatro de bosque de niebla** real.

### Qué trae

- **Terreno con relieve real** (`bosqueTakeA.geom.js`): heightfield determinista con el claro del Ent, lomos de musgo, microrelieve, la **cañada del arroyo** y la pared del anfiteatro con crestas que la niebla se come. Pintado por vértice: musgo moteado, parches de hojarasca, patio de tierra pisada, humedad junto al agua, roca en lo alto. De noche se enfría al azul del cine.
- **El queñual** (Polylepis): fuste principal + macolla retorcidos (tubo orgánico con arruga de corteza), corteza horneada grieta/cuerpo/**papel rojizo** con líquen trepando; copas por lóbulos de **matojos-nube con normales radiales** — masa de hojas suave con huecos y borde mordido, cero icosaedros literales; barbas de musgo colgando. 3 variantes instanciadas (3 draw-calls), anillo héroe que enmarca sin tapar el encuadre + anillo lejano de siluetas veladas.
- **Ciclo de día real**: `useCicloDia` + `CIELOS_HORA` sesgados a bosque de niebla, **amortiguados** entre franjas (patrón AtmosferaValle): amanece, atardece y anochece con el valle. Estrellas de noche, el arroyo brilla azul-luna.
- **Rayos de sol colados** (godrays baratos: láminas aditivas con textura canvas, elevación mínima para caer siempre en diagonal) + **bruma por capas con parallax** (8 cartas billboard a 4 radios: el fondo se desliza distinto al orbitar).
- **Suelo vivido**: hojarasca instanciada (1 draw-call) y troncos caídos con musgo.
- **Cámara**: pose consciente del aspecto (contrapicado en landscape, retroceso en teléfono parado) + `CamaraDirector` (llegada con dolly, una vez por sesión).
- **FloraParamo** ahora acepta `alturaDe(x,z)` y posa el frailejonar/sotobosque/árboles sobre el relieve (cambio mínimo, prop opcional — sin `alturaDe` queda igual que antes).
- **Mount del Ent** claro (`<group name="mount-ent">`): la rama del Ent de alto calibre lo inyecta ahí sin tocar el escenario. FaunaBosque (SVG rubber-hose) intacta.

### Verificación

- `npm run build:prod` VERDE · `tsc:check` limpio · ESLint limpio en los archivos tocados.
- Smoke headless del kit geométrico (fusiones sin null, conteos por tier, claro en y=0).
- Tier-gating real: alto (sombras+rayos+bruma), medio (frugal, sin sombras), bajo (3 queñuas, sin fog/arroyo/hojarasca).
- Capturas reales en los comentarios (franjas + órbita + vertical).
