### PR TITLE
feat(condor): el cóndor de los Andes — el emblema del páramo en rubber-hose + billboard de cielo (FABLE_50 #21)

### DIFF
--- a/scripts/diag/condor-main.jsx
+++ b/scripts/diag/condor-main.jsx
@@ -1,0 +1,52 @@
+/*
+ * Arnés diag del cóndor: ?vista=grid (las variantes del SVG rubber-hose de
+ * cerca — planeo, otea, celebra en V, lip-sync, line-boil, poder celeste) o
+ * ?vista=cielo (el mockup CondorCielo3D: el billboard planeando en 3D).
+ * Para capturas antes/después con scripts/diag/shot-condor.mjs.
+ */
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Condor } from '/src/visual/creatures/index.js';
+import CondorCielo3D from '/src/mockups/CondorCielo3D.jsx';
+
+const vista = new URLSearchParams(window.location.search).get('vista') || 'grid';
+
+const VARIANTES = [
+  ['planea (idle)', {}],
+  ['otea el valle', { otea: true }],
+  ['celebra (alas en V)', { pose: 'celebra' }],
+  ['reposo', { pose: 'reposo' }],
+  ['habla V3', { visema: 'V3' }],
+  ['línea que hierve', { lineBoil: true }],
+  ['poder celeste', { poder: true }],
+  ['sin animación', { animated: false }],
+];
+
+function Grid() {
+  return (
+    <div style={{
+      minHeight: '100vh', background: 'linear-gradient(#a8cfe4, #d9ebf4)',
+      display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8,
+      alignItems: 'center', justifyItems: 'center', padding: 18, boxSizing: 'border-box',
+      fontFamily: 'system-ui', color: '#1e3442',
+    }}>
+      <div style={{ gridColumn: '1 / -1', textAlign: 'center' }}>
+        <h1 style={{ margin: 0, fontSize: 20 }}>Cóndor de los Andes — Vultur gryphus</h1>
+        <div style={{ fontSize: 12, opacity: 0.75 }}>rubber-hose SVG · arnés diag</div>
+      </div>
+      <div style={{ gridColumn: '1 / -1' }}>
+        <Condor size={340} />
+      </div>
+      {VARIANTES.map(([label, props]) => (
+        <figure key={label} style={{ margin: 0, textAlign: 'center' }}>
+          <Condor size={150} {...props} />
+          <figcaption style={{ fontSize: 11, marginTop: 2 }}>{label}</figcaption>
+        </figure>
+      ))}
+    </div>
+  );
+}
+
+createRoot(document.getElementById('root')).render(
+  <React.StrictMode>{vista === 'cielo' ? <CondorCielo3D /> : <Grid />}</React.StrictMode>,
+);

--- a/scripts/diag/condor.html
+++ b/scripts/diag/condor.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<!-- Arnés de diagnóstico VISUAL del cóndor (solo dev, nunca entra al build de
+     prod): sirve con `vite dev` y monta el cóndor rubber-hose en dos vistas
+     (?vista=grid → variantes del SVG de cerca · ?vista=cielo → el mockup
+     CondorCielo3D con el billboard planeando) para capturas antes/después. -->
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>diag: cóndor de los Andes</title>
+    <style>
+      html, body, #root { margin: 0; width: 100%; height: 100%; background: #a8cfe4; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/scripts/diag/condor-main.jsx"></script>
+  </body>
+</html>

--- a/scripts/diag/shot-condor.mjs
+++ b/scripts/diag/shot-condor.mjs
@@ -1,0 +1,61 @@
+// Capturas del arnés diag del cóndor (scripts/diag/condor.html) con chromium
+// del sistema + swiftshader, sirviendo ESTE worktree con `vite dev`.
+// Uso: node scripts/diag/shot-condor.mjs <etiqueta>
+//   → /tmp/condor-<etiqueta>-grid.png        (las variantes de cerca)
+//   → /tmp/condor-<etiqueta>-cielo-N.png     (móvil 412×892, 3 frames del vuelo)
+//   → /tmp/condor-<etiqueta>-cielo-ancho.png (1280×800, la térmica y el cruce)
+import { chromium } from 'playwright';
+import { execSync, spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const PORT = 5199;
+const BASE = `http://127.0.0.1:${PORT}`;
+const [etiqueta = 'x'] = process.argv.slice(2);
+
+const srv = spawn('npx', ['vite', '--port', String(PORT), '--host', '127.0.0.1', '--strictPort'], {
+  cwd: REPO, stdio: 'ignore', env: { ...process.env, BROWSER: 'none' },
+});
+let up = false;
+for (let i = 0; i < 60; i++) {
+  try { await fetch(BASE + '/'); up = true; break; } catch { /* aún no */ }
+  await sleep(1000);
+}
+if (!up) { console.log('SERVER_FAIL'); srv.kill('SIGKILL'); process.exit(1); }
+await sleep(1500);
+
+const chromiumPath = process.env.PLAYWRIGHT_CHROMIUM_PATH
+  || execSync('which chromium', { encoding: 'utf8' }).trim();
+const browser = await chromium.launch({
+  executablePath: chromiumPath,
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage',
+    '--enable-unsafe-swiftshader', '--use-gl=angle', '--use-angle=swiftshader', '--ignore-gpu-blocklist'],
+});
+
+// 1) EL CÓNDOR DE CERCA: la grilla de variantes
+const g = await browser.newPage({ viewport: { width: 920, height: 1300 }, deviceScaleFactor: 2 });
+g.on('pageerror', (e) => console.log('PAGEERR-grid', String(e).slice(0, 160)));
+await g.goto(`${BASE}/scripts/diag/condor.html?vista=grid`, { waitUntil: 'load', timeout: 40000 });
+await sleep(3600);
+await g.screenshot({ path: `/tmp/condor-${etiqueta}-grid.png` });
+console.log('OK grid');
+
+// 2) PLANEANDO: el mockup 3D — tres frames móviles (la órbita viaja) + ancho
+const p = await browser.newPage({ viewport: { width: 412, height: 892 }, deviceScaleFactor: 2 });
+p.on('pageerror', (e) => console.log('PAGEERR-cielo', String(e).slice(0, 160)));
+await p.goto(`${BASE}/scripts/diag/condor.html?vista=cielo`, { waitUntil: 'load', timeout: 40000 });
+await sleep(6000);
+for (const n of [1, 2, 3]) {
+  await p.screenshot({ path: `/tmp/condor-${etiqueta}-cielo-${n}.png` });
+  console.log('OK cielo', n);
+  await sleep(7000);
+}
+await p.setViewportSize({ width: 1280, height: 800 });
+await sleep(5000);
+await p.screenshot({ path: `/tmp/condor-${etiqueta}-cielo-ancho.png` });
+console.log('OK cielo ancho');
+
+await browser.close();
+srv.kill('SIGKILL');

--- a/src/mockups/CondorCielo3D.jsx
+++ b/src/mockups/CondorCielo3D.jsx
@@ -30,6 +30,7 @@ const NIEBLA = '#c3dbe8';
 
 /* La cordillera de siluetas: picos que se ALEJAN por tono (la atmósfera hace
    la profundidad, no los polígonos). [x, z, radio, alto, color] */
+/** @type {[number, number, number, number, string][]} */
 const PICOS = [
   [-16, -30, 10, 15, '#7fa3b8'],
   [-4, -36, 13, 19, '#8fb2c4'],

--- a/src/mockups/CondorCielo3D.jsx
+++ b/src/mockups/CondorCielo3D.jsx
@@ -1,0 +1,169 @@
+/*
+ * CondorCielo3D — EL CIELO DEL PÁRAMO CON SU CÓNDOR (demo del billboard).
+ *
+ * La demo viva de <CondorBillboard> (src/visual/mundo3d/CondorBillboard.jsx):
+ * el cóndor SVG rubber-hose de la casa (Condor.jsx) planeando un cielo 3D de
+ * altura — farallones al fondo, niebla que come los lejos y DOS cóndores:
+ *   · el PROTAGONISTA en su térmica (modo 'orbita'): círculos pacientes con
+ *     banqueo y deriva de altura, siempre presente;
+ *   · el COMPAÑERO lejano (modo 'cruce'): atraviesa el cielo y se pierde —
+ *     verlo pasar es suerte.
+ *
+ * La escena es un DECORADO MÍNIMO a propósito (conos lambert + fog): el
+ * protagonista es el billboard reutilizable, que cualquier escena real (el
+ * bosque, el valle, la sierra) monta con una línea. NO toca EscenaBosqueVivo
+ * ni las escenas en vuelo: el cableado a los mundos lo hace Opus después.
+ *
+ * RENDIMIENTO: cero texturas, cero shadow-map, geometría de decorado O(10)
+ * meshes. reducedMotion = cóndor fijo y digno + frameloop a demanda.
+ * Archivo nuevo autónomo (su propio <Canvas>). Ruta la cablea Opus (sin auth).
+ */
+import { useMemo, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
+import CondorBillboard from '../visual/mundo3d/CondorBillboard.jsx';
+
+/* La luz del páramo a media mañana: cielo alto frío, picos azulosos. */
+const CIELO = '#a8cfe4';
+const NIEBLA = '#c3dbe8';
+
+/* La cordillera de siluetas: picos que se ALEJAN por tono (la atmósfera hace
+   la profundidad, no los polígonos). [x, z, radio, alto, color] */
+const PICOS = [
+  [-16, -30, 10, 15, '#7fa3b8'],
+  [-4, -36, 13, 19, '#8fb2c4'],
+  [10, -32, 11, 16, '#7fa3b8'],
+  [22, -38, 14, 18, '#97b9ca'],
+  [-26, -34, 12, 14, '#97b9ca'],
+  [2, -24, 8, 11, '#6d94ab'],
+];
+
+function DecoradoParamo() {
+  return (
+    <group>
+      {/* el pajonal: un plano quieto color paja de altura */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
+        <planeGeometry args={[120, 120]} />
+        <meshLambertMaterial color="#8a9a6b" />
+      </mesh>
+      {/* la cordillera al fondo (el fog la funde con el cielo) */}
+      {PICOS.map(([x, z, r, h, color], i) => (
+        <mesh key={i} position={[x, h / 2 - 0.5, z]}>
+          <coneGeometry args={[r, h, 5]} />
+          <meshLambertMaterial color={color} />
+        </mesh>
+      ))}
+      {/* el sol pálido de altura */}
+      <mesh position={[-14, 22, -34]}>
+        <sphereGeometry args={[2.4, 12, 10]} />
+        <meshBasicMaterial color="#fff6dd" />
+      </mesh>
+    </group>
+  );
+}
+
+/**
+ * El mockup standalone: #/mockups/condor-cielo-3d (ruta la cablea Opus).
+ * Tier y reduced-motion se detectan aquí, igual que sus pares.
+ */
+export default function CondorCielo3D() {
+  const [listo, setListo] = useState(false);
+  const { tier, reducedMotion } = useMemo(() => decidirTier(), []);
+  const perfil = perfilDeTier(tier);
+  const vivo = !reducedMotion && tier !== 'bajo';
+
+  return (
+    <section
+      style={{ position: 'fixed', inset: 0, background: CIELO }}
+      data-tier={tier}
+      aria-label="El cóndor de los Andes planeando el cielo del páramo"
+    >
+      <style>{CSS_CONDOR_CIELO}</style>
+      <Canvas
+        className={`cnd-canvas${listo ? ' cnd-canvas--lista' : ''}`}
+        dpr={perfil.dpr}
+        gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+        camera={{ position: [0, 4.5, 20], fov: 50 }}
+        frameloop={reducedMotion ? 'demand' : 'always'}
+        onCreated={({ gl }) => {
+          gl.setClearColor(CIELO);
+          setListo(true);
+        }}
+      >
+        <fog attach="fog" args={[NIEBLA, 26, 68]} />
+        <hemisphereLight args={['#eaf6ff', '#6b7a55', 1.05]} />
+        <directionalLight position={[-8, 14, 6]} intensity={0.7} color="#fff2d8" />
+
+        <DecoradoParamo />
+
+        {/* EL PROTAGONISTA: la térmica sobre el claro, cerca y legible */}
+        <CondorBillboard
+          centro={[0, 9.5, -4]}
+          radio={9}
+          px={96}
+          factor={17}
+          modo="orbita"
+          animated={vivo}
+          tier={tier}
+        />
+        {/* EL COMPAÑERO: cruza altísimo cada tanto y se pierde en la niebla */}
+        {vivo && (
+          <CondorBillboard
+            centro={[0, 16, -18]}
+            radio={26}
+            px={44}
+            factor={26}
+            modo="cruce"
+            animated
+            tier={tier}
+          />
+        )}
+
+        <OrbitControls
+          makeDefault
+          enablePan={false}
+          enableZoom
+          minDistance={10}
+          maxDistance={30}
+          target={[0, 8, -4]}
+          minPolarAngle={0.6}
+          maxPolarAngle={1.65}
+          minAzimuthAngle={-1.2}
+          maxAzimuthAngle={1.2}
+          enableDamping
+          dampingFactor={0.08}
+        />
+        <AdaptiveDpr pixelated />
+      </Canvas>
+
+      <div className="cnd-chrome">
+        <h2 className="cnd-titulo">
+          El cóndor de los Andes
+          <small>
+            Vultur gryphus — el señor del viento. Casi no aletea: planea las térmicas, y verlo
+            cruzar el cielo es saber que el páramo está sano.
+          </small>
+        </h2>
+      </div>
+    </section>
+  );
+}
+
+const CSS_CONDOR_CIELO = `
+.cnd-canvas { opacity: 0; transition: opacity 0.6s ease; }
+.cnd-canvas--lista { opacity: 1; }
+.cnd-chrome {
+  position: absolute; left: 0; right: 0; top: 0;
+  padding: max(14px, env(safe-area-inset-top)) 18px 0;
+  pointer-events: none;
+}
+.cnd-titulo {
+  margin: 0; font-size: 1.15rem; font-weight: 800; color: #1e3442;
+  text-shadow: 0 1px 0 rgba(255,255,255,0.35);
+}
+.cnd-titulo small {
+  display: block; margin-top: 4px; max-width: 34rem;
+  font-size: 0.8rem; font-weight: 500; line-height: 1.45; color: #2c4a5c;
+}
+`;

--- a/src/visual/creatures/Condor.jsx
+++ b/src/visual/creatures/Condor.jsx
@@ -1,0 +1,291 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+import { OjosRubber, Cachetes, Sonrisa, BocaVisema, RH_INK } from './_rubberhose.jsx';
+import { CONDOR_PALETA, CONDOR_PROPORCION, CONDOR_SLUG, PERFIL_CONDOR } from './condorIdentidad.js';
+import { cuerpoDeClima } from './creatureClimaCuerpo.js';
+import { LineBoilFilter } from './LineBoilFilter.jsx';
+import { PropEnMano } from './PropEnMano.jsx';
+import { AuraPoder } from './AuraPoder.jsx';
+import { auraDeBicho } from './transformacion.js';
+
+/* Cóndor de los Andes — Vultur gryphus (el ave voladora más grande del mundo,
+   EL EMBLEMA DEL PÁRAMO: verlo cruzar el cielo es saber que la montaña está
+   sana — el carroñero sagrado que limpia y cierra el ciclo). Hermano
+   rubber-hose de la abeja Angelita, el oso y la danta: compone el MISMO kit
+   `_rubberhose.jsx` (ojos de goma, cachetes, sonrisa) y hereda la MISMA
+   fundación transversal — lip-sync (useLipSync → BocaVisema), modo poder
+   (transformacion, aura CELESTE DE ALTURA), clima→cuerpo (PERFIL_CONDOR) y
+   line-boil (LineBoilFilter) — cero código duplicado. Solo cambia el ANIMAL
+   y su CARÁCTER: MAJESTUOSO e imperturbable, EL SEÑOR DEL VIENTO — su seña de
+   vida es que CASI NO ALETEA: planea con las alas planchadas (banqueo lento de
+   térmica) y solo cada tanto da DOS golpes de ala secos y vuelve a la plancha.
+   Su firma es TRIPLE: las ALAS ENORMES con las plumas primarias abiertas como
+   DEDOS (toda la silueta es ala), el COLLAR BLANCO de plumón (su ruana propia:
+   contrato de altura — JAMÁS vestuario) y la CABEZA PELADA rosada con la
+   carúncula. Su squash&stretch es MÍNIMO y lentísimo (la majestad no rebota).
+   La IDENTIDAD (paleta + proporciones) vive en `condorIdentidad.js`; el
+   CLIMA→cuerpo usa PERFIL_CONDOR (vuela por encima de la lluvia; la niebla sí
+   se lo traga). A diferencia de sus hermanos NO monta `rh-antic`/`rh-travieso`
+   (volteretas y arrebatos): un cóndor no hace travesuras — su vida idle es el
+   PLANEO (.condor-planeo). */
+const VIEWBOX = '-24 -20 48 40';
+
+/* EL ALA — dibujada UNA vez para el lado izquierdo; la derecha la monta el
+   cuerpo con scale(-1,1) en un grupo exterior SIN animación (el CSS transform
+   de `.condor-ala` pisaría el atributo). Hombro en (-2.5,-3.5): ahí pivota
+   (transform-origin right center del fill-box — vale igual espejada). */
+function AlaCondor({ P, vivo }) {
+  return (
+    <g
+      className={vivo ? 'condor-ala' : undefined}
+      style={{ transformBox: 'fill-box', transformOrigin: 'right center' }}
+    >
+      {/* la vela del ala: nace en el hombro y se extiende hasta la punta */}
+      <path
+        d="M-2.4,-4.6 C-8.2,-7.8 -14.6,-8.4 -19.8,-7.3 L-20.6,-6.2
+           C-15.2,-2.6 -8.6,-0.4 -2.0,0.9 C-0.9,-1.0 -1.1,-3.2 -2.4,-4.6 Z"
+        fill={P.ala} stroke={RH_INK} strokeWidth="1.3" strokeLinejoin="round"
+      />
+      {/* la banda PLATEADA de coberteras (el relumbre del adulto al sol) */}
+      <path
+        d="M-3.4,-4.0 C-8.4,-6.8 -13.8,-7.3 -18.4,-6.5
+           C-13.8,-5.0 -8.6,-3.6 -3.6,-2.2 C-3.0,-2.8 -3.0,-3.4 -3.4,-4.0 Z"
+        fill={P.cobertera} opacity="0.9"
+      />
+      {/* LAS PRIMARIAS: las plumas-dedo abiertas de la punta (la firma que
+          hace cóndor a la silueta aun a 40 px). Vibran con el viento. */}
+      <g
+        className={vivo ? 'condor-primarias' : undefined}
+        style={{ transformBox: 'fill-box', transformOrigin: 'right center' }}
+        stroke={P.pluma} strokeWidth="1.5" strokeLinecap="round" fill="none"
+      >
+        <path d="M-18.3,-7.0 L-23.1,-9.6" />
+        <path d="M-19.2,-6.6 L-23.6,-7.2" />
+        <path d="M-19.4,-5.8 L-23.3,-4.6" />
+        <path d="M-19.0,-4.9 L-22.5,-2.4" />
+        <path d="M-18.2,-4.0 L-21.2,-0.6" />
+      </g>
+    </g>
+  );
+}
+
+export function Condor({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Cóndor de los Andes',
+  /* Pose de VIDA (idle-life): 'planea' (base — banqueo de térmica, alas
+     planchadas, dos golpes de ala cada tanto) | 'celebra' (brinca con las ALAS
+     alzadas en V — CSS propio: sin bracitos, celebra con la envergadura) |
+     'reposo' (respira lentísimo, plantado) | 'señala' (se inclina al POI).
+     Solo corren vivas (animated); con animated=false o reduced-motion queda en
+     fotograma digno: la plancha perfecta. */
+  pose = 'planea',
+  animo = 'sereno',
+  energia = 1,
+  /* CLIMA REAL escrito en el cuerpo (perfil cóndor: vuela por encima de la
+     lluvia, la niebla sí se lo traga). Sin clima (avatares, catálogo) = neutro
+     digno. */
+  clima = null,
+  enso = 'neutro',
+  /* ── LIP-SYNC (sistema transversal, useLipSync) ────────────────────────────
+     visema opcional ('V1'..'V4') del RMS del TTS: la boca (bajo el pico) se
+     abre cuando el agente narra y la cabeza pelada se adelanta cortés (CSS por
+     data-visema). Sin visema (o 'V1') = la sonrisa de siempre. */
+  visema = null,
+  /* ── OTEA (la cabeza pelada escanea el valle — su reacción-firma) ───────────
+     OPT-IN: la CABEZA gira a lado y lado con pausa de vigía (el censo del
+     carroñero: nada se le escapa desde arriba) y el collar se esponja. Default
+     false → planeo sereno de siempre. */
+  otea = false,
+  /* Device-tier (DR-3D-PERF-GAMABAJA): 'alto'|'medio' corren el rubber-hose
+     pleno; 'bajo' apaga el idle continuo (planeo + primarias + cola) y deja
+     los estados reactivos. Sin prop (standalone) = pleno. */
+  tier,
+  /* ── LÍNEA QUE RESPIRA (line-boil, Cuphead años 30 — LineBoilFilter) ────────
+     OPT-IN: el CONTORNO vibra escalonado (~8fps). Capa MÁS cara del kit:
+     reservada para su entrada heroica. */
+  lineBoil = false,
+  /* ── MODO PODER (transformación / power-up CELESTE DE ALTURA) ───────────────
+     OPT-IN: aura de 4 capas color cielo de 5000 msnm — su firma cuando "sube
+     de nivel": el señor del viento en pleno. En modo inline el power-up lo
+     pone el host DOM. */
+  poder = false,
+  /* ── PROP POR MUNDO (la herramienta EN LAS GARRAS — propsPorMundo) ──────────
+     mundoId opcional: al entrar a un mundo el cóndor carga su herramienta
+     colgando de las garras recogidas. Sin mundoId entra con las garras libres. */
+  mundoId = null,
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const boil = `crt-boil-${uid}`;
+  const vivo = animated;
+  const auraOp = Math.max(0.12, Math.min(0.34, 0.14 + 0.2 * (energia ?? 1)));
+  const auraR = 8.4 + 1.4 * (energia ?? 1);
+
+  // CLIMA → cuerpo (determinista, una vez por render): tinte + opacidad.
+  // Sin aleteo continuo que acelerar (alas:false — el planeo es imperturbable).
+  const cuerpoClima = cuerpoDeClima(clima, { enso: /** @type {any} */ (enso), tier, perfil: PERFIL_CONDOR });
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
+
+  const P = CONDOR_PALETA;
+  const PR = CONDOR_PROPORCION;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+      {lineBoil && <LineBoilFilter id={boil} animated={vivo} />}
+    </defs>
+  );
+
+  // PROP DEL MUNDO colgando de las garras. Sin mundoId → garras libres.
+  const propMundo = mundoId ? (
+    <PropEnMano mundoId={mundoId} x={-2.6} y={7.4} escala={0.62} ink={RH_INK} animated={vivo} />
+  ) : null;
+
+  // BOCA bajo el pico ganchudo: visema (el agente narra) o la sonrisa serena.
+  const boca = visema
+    ? <BocaVisema cx={0} cy={-10.0} w={2.4} prof={0.9} visema={visema} />
+    : <Sonrisa cx={0} cy={-9.9} w={2.4} prof={0.8} />;
+
+  // ── CUERPO rubber-hose (atrás→adelante): aura, cola-timón, LAS ALAS (la
+  //    silueta manda), garras recogidas, torso, COLLAR de plumón y la CABEZA
+  //    PELADA (carúncula + pico ganchudo + boca + ojos). `.crt-body` respira
+  //    mínimo (condor-boil: la majestad no rebota).
+  const body = (
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* aura viva (la presencia grande y serena) */}
+      <circle cx="0" cy="0" r={auraR} fill={P.cuerpo} opacity={auraOp} filter={`url(#${blur})`} />
+
+      {/* LA COLA-TIMÓN: el abanico corto que corrige el rumbo (grupo propio) */}
+      <g className={vivo ? 'condor-cola' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center top' }}>
+        <path
+          d={`M-2.9,4.6 L-4.4,${4.6 + PR.colaLargo} C-1.5,${6.4 + PR.colaLargo} 1.5,${6.4 + PR.colaLargo} 4.4,${4.6 + PR.colaLargo} L2.9,4.6 Z`}
+          fill={P.cola} stroke={RH_INK} strokeWidth="1.2" strokeLinejoin="round"
+        />
+        <path d={`M-1.4,5.4 L-1.9,${5.2 + PR.colaLargo}`} stroke={RH_INK} strokeWidth="0.6" opacity="0.5" />
+        <path d={`M1.4,5.4 L1.9,${5.2 + PR.colaLargo}`} stroke={RH_INK} strokeWidth="0.6" opacity="0.5" />
+      </g>
+
+      {/* LAS ALAS ENORMES (la firma: toda la silueta es ala). El grupo exterior
+          derecho lleva el espejo SIN animación; la animación vive adentro. */}
+      <g className="condor-ala-mount">
+        <AlaCondor P={P} vivo={vivo} />
+      </g>
+      <g className="condor-ala-mount" transform="scale(-1,1)">
+        <AlaCondor P={P} vivo={vivo} />
+      </g>
+
+      {/* las garras RECOGIDAS del planeo (dos puntitas, casi escondidas) */}
+      <ellipse cx="-1.7" cy="6.3" rx="1.1" ry="0.7" fill={P.pico} stroke={RH_INK} strokeWidth="0.7" />
+      <ellipse cx="1.7" cy="6.3" rx="1.1" ry="0.7" fill={P.pico} stroke={RH_INK} strokeWidth="0.7" />
+
+      {/* el torso compacto negro azabache (todo lo demás es ala) */}
+      <ellipse cx="0" cy="0.5" rx={PR.cuerpoRx} ry={PR.cuerpoRy}
+        fill={P.cuerpo} stroke={RH_INK} strokeWidth="1.4"
+        style={{ filter: `drop-shadow(0 0 6px ${P.cuerpoGlow})` }} />
+      {/* la pechuga un tono más honda (la sombra del planeo) */}
+      <ellipse cx="0" cy="2.6" rx="3.4" ry="3.2" fill={P.ala} opacity="0.7" />
+
+      {/* EL COLLAR BLANCO de plumón (su firma, su ruana propia): la nube
+          esponjosa de la que emerge el cuello pelado. Grupo .condor-collar
+          (se esponja al otear). */}
+      <g className={vivo ? 'condor-collar' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+        <circle cx="-3.2" cy="-6.6" r="1.9" fill={P.collar} stroke={RH_INK} strokeWidth="0.9" />
+        <circle cx="3.2" cy="-6.6" r="1.9" fill={P.collar} stroke={RH_INK} strokeWidth="0.9" />
+        <circle cx="-1.7" cy="-7.5" r="2.0" fill={P.collar} stroke={RH_INK} strokeWidth="0.9" />
+        <circle cx="1.7" cy="-7.5" r="2.0" fill={P.collar} stroke={RH_INK} strokeWidth="0.9" />
+        <circle cx="0" cy="-7.9" r="2.1" fill={P.collar} stroke={RH_INK} strokeWidth="0.9" />
+        {/* la elipse de fusión: borra las costuras internas de la nube */}
+        <ellipse cx="0" cy="-6.8" rx="4.5" ry="2.2" fill={P.collar} />
+      </g>
+
+      {/* LA CABEZA PELADA (grupo propio .condor-cabeza: otea, habla) */}
+      <g className="condor-cabeza" style={{ transformBox: 'fill-box', transformOrigin: 'center bottom' }}>
+        {/* la carúncula (la cresta carnosa del adulto) — detrás de la testa */}
+        <ellipse cx="0.2" cy="-14.9" rx="1.6" ry="1.0" fill={P.caruncula} stroke={RH_INK} strokeWidth="0.9" />
+        {/* la testa pelada rosada-gris (su firma: ni una pluma) */}
+        <circle cx="0" cy="-12" r={PR.cabezaR} fill={P.cabeza} stroke={RH_INK} strokeWidth="1.3" />
+        {/* el rubor sobre la piel pelada (ternura rubber-hose) */}
+        <Cachetes puntos={[{ cx: -2.3, cy: -11.5, r: 0.8 }, { cx: 2.3, cy: -11.5, r: 0.8 }]} color={P.cachete} vivo={vivo} />
+        {/* el pico ganchudo marfil (base + el gancho que cuelga) */}
+        <path
+          d="M-1.0,-11.9 C-1.3,-10.9 -0.7,-10.3 0,-10.3 C0.8,-10.3 1.3,-10.9 1.0,-11.9 C0.4,-12.5 -0.5,-12.5 -1.0,-11.9 Z"
+          fill={P.pico} stroke={RH_INK} strokeWidth="0.9" strokeLinejoin="round"
+        />
+        <path d="M-0.35,-10.35 C-0.3,-9.9 0.1,-9.72 0.5,-9.92"
+          stroke={P.picoPunta} strokeWidth="0.9" strokeLinecap="round" fill="none" />
+        {boca}
+        {/* ojos de goma serenos (la mirada que ve el valle entero) */}
+        <OjosRubber
+          ojos={[{ cx: -1.4, cy: -13.1, r: 1.2 }, { cx: 1.4, cy: -13.1, r: 1.2 }]}
+          mirar={[0, 0.12]}
+          parpadea={vivo}
+        />
+      </g>
+
+      {/* Prop del mundo en las garras (entra con su herramienta colgando). */}
+      {propMundo}
+    </g>
+  );
+
+  // El cóndor NO monta rh-antic/rh-travieso (arrebatos y volteretas): su vida
+  // idle es el PLANEO — banqueo lento de térmica sobre el dibujo entero.
+  const conVida = vivo ? <g className="condor-planeo">{body}</g> : body;
+  // El line-boil (contorno que hierve) envuelve TODO el dibujo cuando se pide.
+  const cuerpoVivo = lineBoil ? <g filter={`url(#${boil})`}>{conVida}</g> : conVida;
+
+  const estadoAttrs = {
+    'data-creature': CONDOR_SLUG,
+    'data-pose': vivo ? pose : undefined,
+    'data-animo': animo,
+    'data-tier': tier || undefined,
+    'data-visema': visema || undefined,
+    'data-otea': otea ? '1' : undefined,
+    'data-lineboil': lineBoil ? '1' : undefined,
+    'data-prop': mundoId || undefined,
+  };
+
+  if (inline) {
+    // En modo inline el power-up lo pone el host DOM (::before/mix-blend no
+    // aplican a SVG); aquí solo marcamos data-poder por si el host lo consulta.
+    return (
+      <g className={className} style={estiloClima} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+        {defs}
+        {cuerpoVivo}
+      </g>
+    );
+  }
+  const svg = (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloClima}
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
+      <title>{title}</title>
+      {defs}
+      {cuerpoVivo}
+    </svg>
+  );
+  // MODO PODER (standalone): el aura CELESTE DE ALTURA de 4 capas
+  // (transformacion.css). El wrapper DOM es lo único que puede llevar
+  // ::before/mix-blend/corrientes.
+  if (poder) {
+    return (
+      <span
+        className="is-powered-up condor-poder"
+        data-creature-poder={CONDOR_SLUG}
+        style={{ '--aura-color': auraDeBicho(CONDOR_SLUG), display: 'inline-flex' }}
+      >
+        {svg}
+        <AuraPoder />
+      </span>
+    );
+  }
+  return svg;
+}
+
+export default Condor;

--- a/src/visual/creatures/condorIdentidad.js
+++ b/src/visual/creatures/condorIdentidad.js
@@ -1,0 +1,87 @@
+/*
+ * condorIdentidad — LA IDENTIDAD VISUAL DEL CÓNDOR, COMO DATOS.
+ *
+ * Hermano de `dantaIdentidad.js` / `borugoIdentidad.js` / `faunaAndina.js`: el
+ * CÓNDOR DE LOS ANDES (Vultur gryphus — el ave voladora más grande del mundo,
+ * el emblema del páramo y del escudo) tiene aquí su silueta canónica.
+ * Rubber-hose (Cuphead + Miss Minutes) con calidez campesina — el MISMO
+ * lenguaje de goma de la abeja, el oso y la danta, otro animal y otro
+ * CARÁCTER: MAJESTUOSO, paciente y de otra altura. EL SEÑOR DEL VIENTO:
+ * casi nunca aletea — se DESLIZA en las térmicas con las alas planchadas,
+ * y verlo cruzar el cielo es saber que el páramo está sano (carroñero
+ * sagrado: limpia la montaña y cierra el ciclo).
+ *
+ * Su firma inconfundible es TRIPLE: las ALAS ENORMES con las plumas
+ * primarias abiertas como DEDOS (hasta 3.3 m reales de envergadura), el
+ * COLLAR BLANCO de plumón esponjoso (su ruana propia — jamás necesita otra)
+ * y la CABEZA PELADA rosada con la cresta carnosa (la carúncula). Su color
+ * de poder es el CELESTE DE ALTURA (el azul del cielo a 5000 msnm, el viento
+ * del glaciar) — distinto de los 10: dorado (abeja), rojo (oso), verde-zen
+ * (rana), iridiscente (colibrí), púrpura (jaguar), ámbar (ardilla), turquesa
+ * (perezoso), bronce (morrocoy), plata lunar (borugo) y verde semilla (danta).
+ *
+ * REGLA DE ORO (idéntica a dantaIdentidad/faunaAndina): SOLO datos. Cero
+ * three, cero react. La creature del bundle base lo importa; jamás debe
+ * arrastrar `vendor-three`. La CADENCIA (animación) vive en `creatures.css`
+ * (clases `rh-*`/`crt-*`/`condor-*`); el DIBUJO compone el KIT
+ * `_rubberhose.jsx`; el CLIMA→cuerpo, en `creatureClimaCuerpo.js` con el
+ * PERFIL_CONDOR de abajo. El aura de poder (celeste de altura) vive en
+ * `transformacion.js` (AURA_POR_BICHO, fila 'condor'). VESTUARIO: el cóndor
+ * NO lleva ruana ni sombrero — su collar de plumón ES su ruana (contrato
+ * de altura: el rey del viento no se abriga, y a 5000 msnm nadie suda).
+ */
+
+/* La tinta cálida del contorno es de TODA la familia rubber-hose. */
+export { RH_INK as CONDOR_TINTA } from './_rubberhose.jsx';
+
+/* Slug estable del cóndor (data-creature, aura, perfiles). */
+export const CONDOR_SLUG = 'condor';
+
+/* ── CÓNDOR — Vultur gryphus (el cóndor de los Andes). Plumaje NEGRO
+   AZABACHE con las coberteras PLATEADAS sobre el ala (la banda clara que
+   relumbra al sol cuando planea), collar de plumón BLANCO, cabeza PELADA
+   rosada-gris con la carúncula carnosa y el pico ganchudo marfil. Alas
+   enormes de puntas digitadas. Paciente, imperturbable, de otra altura. */
+export const CONDOR_PALETA = {
+  cuerpo: '#23262b',        // plumaje negro azabache (con alma azulosa, no negro puro)
+  cuerpoGlow: 'rgba(35,38,43,0.65)',
+  ala: '#1d2023',           // el ala, un tono más honda (la sombra del planeo)
+  cobertera: '#b9c4cc',     // la banda PLATEADA sobre el ala (su relumbre al sol)
+  pluma: '#15181b',         // las primarias digitadas (los dedos del viento)
+  collar: '#f6f1e3',        // el COLLAR BLANCO de plumón (su firma, su ruana propia)
+  cabeza: '#c98d7a',        // la cabeza PELADA rosada-gris (su firma)
+  caruncula: '#a85d4e',     // la cresta carnosa sobre el pico (el macho adulto)
+  pico: '#e8dcc0',          // el pico ganchudo marfil
+  picoPunta: '#8a7a5c',     // la punta del gancho, más honda
+  cola: '#191c1f',          // el abanico corto de la cola
+  cachete: '#b06a58',       // el rubor sobre la piel pelada (ternura rubber-hose)
+  /* ── El señor del viento (el celeste de altura) ── */
+  viento: '#9fd8ff',        // su aura de poder: el cielo a 5000 msnm
+  rafaga: '#e2f3ff',        // el brillo de las corrientes (chispas de aire)
+};
+
+export const CONDOR_PROPORCION = {
+  cuerpoRx: 5.0,            // el torso compacto (todo lo demás es ALA)
+  cuerpoRy: 6.4,
+  cabezaR: 3.0,             // la cabeza pelada, chica sobre el collar
+  alaLargo: 19.5,           // media envergadura (las alas MANDAN en la silueta)
+  primarias: 5,             // las plumas-dedo de cada punta
+  colaLargo: 5.0,           // el abanico corto
+};
+
+/*
+ * PERFIL_CONDOR — el perfil de CLIMA→cuerpo del cóndor para `cuerpoDeClima`
+ * (creatureClimaCuerpo.js). Mismo shape que PERFIL_DANTA — se pasa vía la
+ * opción `perfil`, así NO hay que tocar el archivo compartido (anti-conflicto).
+ *   alas    false → su planeo es IMPERTURBABLE: ningún clima lo apura ni lo
+ *                   frena (no hay aleteo continuo que acelerar — casi no aletea).
+ *   humedad 0.3  → vuela POR ENCIMA de la lluvia: apenas lo salpica.
+ *   difusa  0.6  → ave de lejos: la niebla sí se lo traga (aparece y se pierde).
+ *   sequia  0.25 → planea igual con seca: el viento no se seca.
+ */
+export const PERFIL_CONDOR = Object.freeze({
+  alas: false,
+  humedad: 0.3,
+  difusa: 0.6,
+  sequia: 0.25,
+});

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1969,3 +1969,140 @@
   [data-creature='danta'][data-visema='V3'] .danta-trompa,
   [data-creature='danta'][data-visema='V4'] .danta-trompa { animation: none !important; }
 }
+
+/* ═══ EL CÓNDOR DE LOS ANDES — el señor del viento (Condor.jsx) ══════════════
+   Carácter: MAJESTUOSO e imperturbable. Su vida idle NO es antic/travieso
+   (un cóndor no hace volteretas): es el PLANEO — banqueo lento de térmica
+   (.condor-planeo), alas PLANCHADAS que solo cada tanto dan DOS golpes secos
+   (.condor-ala), las plumas-dedo vibrando al viento (.condor-primarias) y la
+   cola-timón corrigiendo el rumbo (.condor-cola). */
+
+/* BOIL MÍNIMO — el cóndor NO squashea: respira apenas (la majestad no rebota).
+   Reescribe SOLO el boil del cóndor (misma clase, selector más específico). */
+[data-creature='condor'] .rh-boil {
+  animation-name: condor-boil;
+  animation-duration: 5.6s;
+}
+@keyframes condor-boil {
+  0%, 100% { transform: scale(1, 1); }
+  50%      { transform: scale(1.008, 0.992); }   /* la respiración de altura */
+}
+
+/* EL PLANEO — el banqueo de térmica sobre el dibujo entero: se ladea suave a
+   un lado, se endereza, se ladea al otro, y la corriente lo mece en vertical.
+   Período largo y ease amplio: paciencia de cóndor. */
+.condor-planeo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: condor-planeo 8.4s ease-in-out infinite;
+}
+@keyframes condor-planeo {
+  0%, 100% { transform: rotate(2deg) translateY(0.2px); }
+  25%      { transform: rotate(0.4deg) translateY(-0.5px); }  /* remonta la térmica */
+  50%      { transform: rotate(-2.2deg) translateY(0.1px); }
+  75%      { transform: rotate(-0.4deg) translateY(-0.4px); }
+}
+
+/* LAS ALAS PLANCHADAS — el 88% del ciclo, quietas (esa quietud ES el cóndor);
+   al final, DOS golpes de ala secos y de vuelta a la plancha. El origin vive
+   en el hombro (right center del fill-box); el ala derecha va espejada por su
+   grupo exterior (.condor-ala-mount) así que el mismo keyframe sirve. */
+.condor-ala {
+  animation: condor-aleteo 11s ease-in-out infinite;
+}
+@keyframes condor-aleteo {
+  0%, 86%  { transform: rotate(0deg); }
+  89%      { transform: rotate(-10deg); }   /* primer golpe */
+  92%      { transform: rotate(3deg); }
+  95%      { transform: rotate(-6deg); }    /* segundo golpe */
+  98%, 100% { transform: rotate(0deg); }    /* la plancha perfecta */
+}
+
+/* LAS PRIMARIAS — las plumas-dedo tantean el viento: vibración mínima y
+   continua (lo único que nunca para: el aire se toca con los dedos). */
+.condor-primarias {
+  animation: condor-primarias 2.7s ease-in-out infinite;
+}
+@keyframes condor-primarias {
+  0%, 100% { transform: rotate(0deg); }
+  50%      { transform: rotate(1.6deg); }
+}
+
+/* LA COLA-TIMÓN — corrige el rumbo a destiempo del banqueo (períodos
+   co-primos: nunca el mismo compás). */
+.condor-cola {
+  animation: condor-timon 6.5s ease-in-out infinite;
+}
+@keyframes condor-timon {
+  0%, 100% { transform: rotate(-2deg); }
+  50%      { transform: rotate(2.4deg); }
+}
+
+/* OTEA (reacción-firma, opt-in): la cabeza pelada ESCANEA el valle a lado y
+   lado con pausa de vigía — el censo del carroñero: nada se le escapa. El
+   collar se esponja apenas (alerta). */
+[data-creature='condor'][data-otea='1'] .condor-cabeza {
+  animation: condor-otea 3.4s ease-in-out infinite;
+}
+@keyframes condor-otea {
+  0%, 100% { transform: rotate(-11deg); }
+  20%      { transform: rotate(-11deg); }   /* la pausa del vigía */
+  50%      { transform: rotate(12deg); }
+  70%      { transform: rotate(12deg); }
+}
+[data-creature='condor'][data-otea='1'] .condor-collar {
+  animation: condor-collar-esponja 3.4s ease-in-out infinite;
+}
+@keyframes condor-collar-esponja {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.06); }
+}
+
+/* CELEBRA — el cóndor no tiene bracitos: celebra con la ENVERGADURA. Las alas
+   se alzan en V de victoria (con el overshoot elástico de la casa) mientras el
+   cuerpo brinca con el gesto genérico (rh-g-celebra sobre .crt-body). */
+[data-creature='condor'][data-pose='celebra'] .condor-ala {
+  animation: condor-ala-v 1.15s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+}
+@keyframes condor-ala-v {
+  0%, 100% { transform: rotate(0deg); }
+  38%      { transform: rotate(30deg); }    /* la V de victoria (positivo = la punta SUBE) */
+  55%      { transform: rotate(24deg); }    /* el overshoot elástico */
+  75%      { transform: rotate(27deg); }
+}
+
+/* HABLA (lip-sync): la cabeza pelada se adelanta cortés mientras dure el
+   visema (V2..V4; V1 = boca en reposo). */
+[data-creature='condor'][data-visema='V2'] .condor-cabeza,
+[data-creature='condor'][data-visema='V3'] .condor-cabeza,
+[data-creature='condor'][data-visema='V4'] .condor-cabeza {
+  animation: condor-cabeza-habla 1.7s ease-in-out infinite;
+}
+@keyframes condor-cabeza-habla {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(0.4px); }   /* se acerca a quien escucha */
+}
+
+/* El estado otea PISA el planeo del banqueo NO (sigue planeando: un cóndor
+   otea EN vuelo) — pero sí congela la cola para que la mirada mande. */
+[data-creature='condor'][data-otea='1'] .condor-cola { animation: none; }
+
+/* device-tier 'bajo': se corta el idle continuo (planeo + alas + primarias +
+   cola + boil reescrito); los estados reactivos (otea, celebra) siguen
+   contando la verdad. */
+[data-tier='bajo'][data-creature='condor'] .rh-boil,
+[data-tier='bajo'] .condor-planeo,
+[data-tier='bajo'] .condor-ala,
+[data-tier='bajo'] .condor-primarias,
+[data-tier='bajo'] .condor-cola { animation: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  [data-creature='condor'] .rh-boil,
+  .condor-planeo, .condor-ala, .condor-primarias, .condor-cola,
+  [data-creature='condor'][data-otea='1'] .condor-cabeza,
+  [data-creature='condor'][data-otea='1'] .condor-collar,
+  [data-creature='condor'][data-pose='celebra'] .condor-ala,
+  [data-creature='condor'][data-visema='V2'] .condor-cabeza,
+  [data-creature='condor'][data-visema='V3'] .condor-cabeza,
+  [data-creature='condor'][data-visema='V4'] .condor-cabeza { animation: none !important; }
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -49,6 +49,12 @@ export { Danta } from './Danta.jsx';
    bosque — la JARDINERA que siembra al andar. Solo datos: jamás arrastra three
    al bundle base — igual que borugoIdentidad/jaguarIdentidad. */
 export { DANTA_PALETA, DANTA_PROPORCION, DANTA_SLUG, PERFIL_DANTA } from './dantaIdentidad.js';
+export { Condor } from './Condor.jsx';
+/* La IDENTIDAD del cóndor como datos (paleta azabache + coberteras plateadas +
+   collar de plumón, proporciones y su perfil de clima). EL EMBLEMA DEL PÁRAMO —
+   el señor del viento que casi no aletea. Solo datos: jamás arrastra three al
+   bundle base — igual que dantaIdentidad/borugoIdentidad. */
+export { CONDOR_PALETA, CONDOR_PROPORCION, CONDOR_SLUG, PERFIL_CONDOR } from './condorIdentidad.js';
 /* La IDENTIDAD del trío andino como datos (paletas + proporciones). Solo datos:
    jamás arrastra three al bundle base — igual que abejaIdentidad. */
 export {
@@ -110,6 +116,7 @@ import Jaguar from './Jaguar.jsx';
 import Morrocoy from './Morrocoy.jsx';
 import Borugo from './Borugo.jsx';
 import Danta from './Danta.jsx';
+import Condor from './Condor.jsx';
 import Lombriz from './Lombriz.jsx';
 import Mariposa from './Mariposa.jsx';
 import Escarabajo from './Escarabajo.jsx';
@@ -127,6 +134,7 @@ export const CREATURES = {
   morrocoy: { Component: Morrocoy, nombre: 'Morrocoy de patas rojas', cientifico: 'Chelonoidis carbonarius' },
   borugo: { Component: Borugo, nombre: 'Borugo', cientifico: 'Cuniculus taczanowskii' },
   danta: { Component: Danta, nombre: 'Danta de páramo', cientifico: 'Tapirus pinchaque' },
+  condor: { Component: Condor, nombre: 'Cóndor de los Andes', cientifico: 'Vultur gryphus' },
   lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
   mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
   escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },

--- a/src/visual/creatures/transformacion.js
+++ b/src/visual/creatures/transformacion.js
@@ -37,6 +37,7 @@ export const AURA_POR_BICHO = Object.freeze({
   morrocoy: '#ff7a3c',         // caparazón que brilla (ámbar-rojizo)
   borugo: '#dbe8ff',           // PLATA LUNAR / blanco luminoso (nocturno sagrado, el animal de cierre)
   danta: '#a8e05f',            // VERDE SEMILLA (la jardinera del bosque: todo lo que pisa, germina)
+  condor: '#9fd8ff',           // CELESTE DE ALTURA (el señor del viento: el cielo a 5000 msnm)
   'ent-frailejon': '#8fdcae',  // VERDE-PLATEADO del guardián del páramo (modo-guardián: el frailejón se yergue a intervenir)
 });
 

--- a/src/visual/mundo3d/CondorBillboard.jsx
+++ b/src/visual/mundo3d/CondorBillboard.jsx
@@ -1,0 +1,144 @@
+/*
+ * CondorBillboard — EL CÓNDOR PLANEANDO EN CUALQUIER CIELO 3D.
+ *
+ * El emblema del páramo como billboard <Html> del SVG rubber-hose de la casa
+ * (Condor.jsx — el estándar de calidad: el SVG le gana a cualquier low-poly,
+ * decisión del operador en FaunaBosque). REUTILIZABLE: cualquier escena con
+ * <Canvas> lo monta y tiene el cielo vivo — el bosque, el valle, la sierra.
+ *
+ * Dos modos de vuelo (los dos del cóndor real):
+ *   · 'orbita' (default) — la TÉRMICA: círculos amplios y pacientes sobre un
+ *     centro, con deriva de altura (remonta y baja) y banqueo hacia adentro
+ *     del giro. Una vuelta cada ~70 s: paciencia de cóndor, siempre presente.
+ *   · 'cruce'  — EL CRUCE ÉPICO: atraviesa el cielo de lado a lado y se
+ *     pierde; reaparece un buen rato después por donde quiera. La vida es
+ *     aparición y desaparición (patrón VenadoCruzante/QuetzalFugaz).
+ *
+ * El SVG es la vista VENTRAL (alas abiertas, de frente/abajo) — exactamente
+ * como se ve un cóndor planeando desde la finca. El banqueo del vuelo se
+ * escribe como rotate en el div (mutación por ref, cero re-renders, cero
+ * toques al SVG). El aleteo raro, las plumas-dedo y el resto del idle ya
+ * viven DENTRO del componente Condor (creatures.css).
+ *
+ * Tier-safe / reduced-motion: sin animación queda FIJO en un punto alto del
+ * cielo, digno (animated=false también congela el SVG). Android barato: un
+ * solo <Html>, matemática O(1) por frame, cero geometría.
+ *
+ * Importa three/@react-three → montar SOLO dentro de un <Canvas>.
+ */
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import { Condor } from '../creatures/index.js';
+
+const azar = (a, b) => a + Math.random() * (b - a);
+
+const ESTILO_CONDOR = {
+  filter: 'drop-shadow(0 2px 3px rgba(25, 32, 28, 0.3))',
+  pointerEvents: 'none',
+  willChange: 'transform',
+};
+
+/**
+ * @param {Object} props
+ * @param {[number,number,number]} [props.centro=[0,11,0]] centro del vuelo (la térmica u
+ *   origen del cruce). La Y es la altura de crucero.
+ * @param {number} [props.radio=14]   radio de la órbita / media-luz del cruce.
+ * @param {number} [props.velocidad=0.09] rad/s de la órbita (~70 s la vuelta).
+ * @param {number} [props.px=64]      tamaño del SVG en px (nitidez del billboard).
+ * @param {number} [props.factor=16]  distanceFactor del <Html> (escala en mundo).
+ * @param {'orbita'|'cruce'} [props.modo='orbita']
+ * @param {boolean} [props.animated=true] false = fijo y digno (tier bajo / RM).
+ * @param {string}  [props.tier]      device-tier, se pasa al SVG (gates CSS).
+ */
+export default function CondorBillboard({
+  centro = [0, 11, 0],
+  radio = 14,
+  velocidad = 0.09,
+  px = 64,
+  factor = 16,
+  modo = 'orbita',
+  animated = true,
+  tier,
+}) {
+  const grupo = useRef(/** @type {any} */ (null));
+  const capa = useRef(/** @type {HTMLDivElement|null} */ (null));
+  const st = useRef({
+    fase: azar(0, Math.PI * 2),   // cada cóndor arranca en SU punto del giro
+    activo: modo === 'orbita',    // el cruce empieza esperando su momento
+    prox: azar(3, 8),             // primer cruce pronto (la vida se nota)
+    t0: 0,
+    dur: 14,
+    dir: 1,
+  });
+
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (!g || !animated) return;
+    const t = clock.getElapsedTime();
+    const s = st.current;
+
+    if (modo === 'cruce') {
+      // EL CRUCE: aparece por un costado, atraviesa el cielo, se pierde.
+      if (!s.activo) {
+        g.visible = false;
+        if (t >= s.prox) {
+          s.activo = true;
+          s.t0 = t;
+          s.dir = Math.random() < 0.5 ? -1 : 1;
+          s.dur = azar(13, 18);
+        }
+        return;
+      }
+      const p = (t - s.t0) / s.dur;
+      if (p >= 1) {
+        s.activo = false;
+        s.prox = t + azar(30, 75); // no vuelve en un rato: verlo es suerte
+        g.visible = false;
+        return;
+      }
+      g.visible = true;
+      g.position.set(
+        centro[0] + (-radio + 2 * radio * p) * s.dir,
+        centro[1] + Math.sin(p * Math.PI) * 1.6 + Math.sin(t * 0.35) * 0.3,
+        centro[2] + Math.sin(p * Math.PI * 2) * 1.2,
+      );
+      if (capa.current) {
+        // banqueo leve sostenido en el rumbo del cruce
+        const banco = (6 + Math.sin(t * 0.5) * 3) * s.dir;
+        capa.current.style.transform = `rotate(${banco.toFixed(1)}deg)`;
+      }
+      return;
+    }
+
+    // LA TÉRMICA (default): círculos pacientes con deriva de altura.
+    const a = t * velocidad + s.fase;
+    const r = radio + Math.sin(t * 0.05) * radio * 0.14;
+    g.position.set(
+      centro[0] + Math.cos(a) * r,
+      centro[1] + Math.sin(t * 0.21) * 0.8 + Math.sin(t * 0.047) * 1.4, // remonta y baja
+      centro[2] + Math.sin(a) * r,
+    );
+    if (capa.current) {
+      // banqueo hacia ADENTRO del giro (el ala interior baja), respirado
+      const banco = 9 + Math.sin(t * 0.13) * 4;
+      capa.current.style.transform = `rotate(${banco.toFixed(1)}deg)`;
+    }
+  });
+
+  const posInicial = /** @type {[number,number,number]} */ (
+    modo === 'cruce'
+      ? [centro[0], centro[1], centro[2]]
+      : [centro[0] + radio, centro[1], centro[2]]
+  );
+
+  return (
+    <group ref={grupo} position={posInicial} visible={modo === 'orbita' || !animated}>
+      <Html center distanceFactor={factor} zIndexRange={[6, 0]} pointerEvents="none">
+        <div ref={capa} aria-hidden="true" data-vecino="condor" style={ESTILO_CONDOR}>
+          <Condor size={px} animated={animated} tier={tier} />
+        </div>
+      </Html>
+    </group>
+  );
+}

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -203,6 +203,26 @@ const VARIANTES_DANTA = [
   { label: 'sin animación', props: { size: 88, animated: false } },
 ];
 
+/* EL CÓNDOR completo luce la fundación transversal con su carácter de señor
+   del viento: el PLANEO imperturbable (casi no aletea — dos golpes secos cada
+   tanto), las plumas-dedo que tantean el aire, OTEA (la cabeza pelada escanea
+   el valle, su firma), celebra con la ENVERGADURA en V, modo poder CELESTE DE
+   ALTURA y prop en las garras. SIN ruana: su collar de plumón ES su ruana
+   (contrato de altura). */
+const VARIANTES_CONDOR = [
+  { label: '48 px', props: { size: 48 } },
+  { label: 'planea', props: { size: 88 } },
+  { label: 'celebra (alas en V)', props: { size: 88, pose: 'celebra' } },
+  { label: 'reposo', props: { size: 88, pose: 'reposo' } },
+  { label: 'señala', props: { size: 88, pose: 'señala' } },
+  { label: 'otea el valle', props: { size: 88, otea: true } },
+  { label: 'habla (lip-sync)', props: { size: 88, visema: 'V3' } },
+  { label: 'con lupa (suelo)', props: { size: 88, mundoId: 'suelo' } },
+  { label: 'poder CELESTE DE ALTURA', props: { size: 88, poder: true } },
+  { label: 'línea que hierve', props: { size: 88, lineBoil: true } },
+  { label: 'sin animación', props: { size: 88, animated: false } },
+];
+
 /* EL ENT DEL PÁRAMO — el árbol-maestro del Bosque Vivo (NO un bicho). Presencia
    GRANDE e imponente. Luce sus 5 frentes: expresividad de árbol vivo (line-boil
    lento, roseta que se mece, rostro sabio), lip-sync (boca en las grietas),
@@ -232,6 +252,7 @@ const VARIANTES_POR_SLUG = {
   morrocoy: VARIANTES_MORROCOY,
   borugo: VARIANTES_BORUGO,
   danta: VARIANTES_DANTA,
+  condor: VARIANTES_CONDOR,
   'ent-frailejon': VARIANTES_ENT,
 };
 
@@ -248,6 +269,7 @@ const NOTAS_CREATURE = {
   morrocoy: 'Galápago de patas rojas, el anciano ancestral y paciente; caparazón de domo hexagonal (su firma) y patas rojizas, aura bronce. Se retrae elástico a la concha.',
   borugo: 'La paca de montaña andina, roedor nocturno tierno; pardo con hileras de motas crema (su firma), olfateo tímido y aura plata lunar. El animal de cierre — vivo, a salvo y digno.',
   danta: 'El tapir andino, la mole lanuda y mansa del bosque altoandino; trompa corta que husmea en periscopio y borde blanco de orejas y labios (su firma doble). La jardinera del bosque: siembra semillas al andar, aura verde semilla.',
+  condor: 'El ave voladora más grande del mundo, el emblema del páramo; alas enormes de plumas-dedo, collar blanco de plumón y cabeza pelada con carúncula (su firma triple). El señor del viento: casi no aletea — planea las térmicas y verlo es saber que la montaña está sana. Aura celeste de altura.',
   'ent-frailejon': 'El árbol-guardián que enseña: frailejón gigante del páramo, tronco con rostro sabio y faldita de hojas muertas, corona en roseta plateada y flores amarillas. Guardián del agua; anciano sereno y lento. Modo-guardián verde-plateado cuando el páramo peligra.',
   lombriz: 'La ingeniera del suelo; ondula por segmentos con clitelo marcado.',
   mariposa: 'Alas naranjas con venación; poliniza y anuncia buen suelo.',


### PR DESCRIPTION
## Qué llega

**El CÓNDOR de los Andes (Vultur gryphus)** — el emblema del páramo — como criatura SVG rubber-hose de la casa, mismo molde de Danta/OsoAndino, + un **billboard reutilizable** para que planee en cualquier cielo 3D.

### La criatura (`src/visual/creatures/Condor.jsx` + `condorIdentidad.js`)
- **Firma triple**: alas ENORMES con las plumas primarias abiertas como dedos (vibran al viento), collar blanco de plumón (su ruana propia — contrato de altura: JAMÁS vestuario) y cabeza pelada rosada con carúncula.
- **Idle propio = el PLANEO**: banqueo lento de térmica; casi no aletea — dos golpes de ala secos cada 11 s y de vuelta a la plancha. Sin `rh-antic`/`rh-travieso`: un cóndor no hace volteretas.
- **Reacción-firma `otea`**: la cabeza pelada escanea el valle con pausa de vigía. **Celebra con la envergadura** (alas en V, CSS propio — no tiene bracitos).
- Fundación transversal completa: lip-sync (`BocaVisema` bajo el pico ganchudo), line-boil, clima (`PERFIL_CONDOR`: vuela por encima de la lluvia; la niebla sí se lo traga), prop en las garras, modo poder **CELESTE DE ALTURA** (`#9fd8ff`, fila en `AURA_POR_BICHO`).
- Gates de la casa: tier `bajo` apaga el idle continuo; `prefers-reduced-motion` = fotograma digno (la plancha perfecta).

### Registro (data-driven, cero cableado extra)
- `CREATURES['condor']` en el barrel → la **vitrina** `#/mockups/visual-lib` y el **avatar-selector** lo publican solos.
- Variantes + nota de campo en `src/visual/registry.js`.

### El billboard (`src/visual/mundo3d/CondorBillboard.jsx`)
- Patrón `<Html>` de FaunaBosque (el SVG le gana a cualquier low-poly). **Dos modos**: `orbita` (la térmica paciente: círculos con banqueo hacia adentro del giro y deriva de altura) y `cruce` (atraviesa el cielo y se pierde; reaparece cuando quiere — verlo es suerte).
- Android barato: cero geometría, O(1) por frame, banqueo por mutación de ref (cero re-renders).
- **NO se cablea aquí a EscenaBosqueVivo ni a las escenas en vuelo** (encargo explícito): cualquier escena lo monta con una línea — `<CondorBillboard centro={[0,11,0]} radio={14} />`. Nota: el cóndor procedural de 3 cajas de `FaunaBosque.jsx` queda listo para jubilar cuando Opus cablee este billboard.

### La demo (`src/mockups/CondorCielo3D.jsx` + `scripts/diag/`)
- Mockup autónomo (patrón AliadosFinca3D — "ruta la cablea Opus, sin auth"): cordillera mínima + fog + los dos modos de vuelo a la vez.
- Arnés de capturas versionado (patrón hato): `scripts/diag/condor.html` + `condor-main.jsx` + `shot-condor.mjs` (`?vista=grid|cielo`).

## Verificación (síncrona)
- `npm run build:prod` **VERDE** (exit 0) · `npm run tsc:check` **exit 0**.
- **Capturas** (Playwright + chromium sistema + swiftshader, `scripts/diag/shot-condor.mjs`): grid de variantes de cerca (920×1300), cielo móvil 412×892 (3 frames del vuelo) y cielo ancho 1280×800 (la térmica y el cruce a la vez). Enviadas por Telegram al operador.
- **Bug de arte cazado y corregido en la captura**: `celebra` alzaba las alas hacia ABAJO (signo de rotación invertido para el pivote del hombro); ahora la V sube con overshoot — verificado en re-captura.

## Veredicto honesto
- El bicho se LEE como cóndor a 44 px (la silueta de plumas-dedo manda) y es tierno de cerca: collar esponjoso, carita pelada con rubor, banda plateada de coberteras. Sólido.
- El planeo del billboard convence: banqueo + deriva + el aleteo raro. El cruce lejano con fog es puro páramo.
- Mejorable (lo digo yo): el gancho del pico es sutil a tamaños chicos (< 60 px se pierde); la carúncula puede leerse como copete. Si el operador quiere más gancho, es un path de 1 línea.
- Sin test de render (Danta tampoco trae — la prueba del arte es la captura); si se quiere, es un encargo de 10 min para un esclavo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)