### PR TITLE
fix(anti-leak): sanear fugas forward + cablear el guardián al CI

### DIFF
--- a/.github/workflows/boundary-gate.yml
+++ b/.github/workflows/boundary-gate.yml
@@ -1,0 +1,59 @@
+name: Boundary Gate (anti-leak)
+
+# Gate anti-leak (ADR-002 / ADR-020). Cierra la causa raíz del leak:
+# hasta ahora NINGUNO de los dos controles corría en CI de GitHub —
+#   - tests/unit/boundaryAudit.test.js NO estaba en ningún workflow
+#     (unit-tests.yml solo corre el test del entrypoint), y
+#   - scripts/audit-bundle.mjs solo se invocaba manual (pre-merge-main.sh).
+# Resultado: codenames / identidad / rutas locales entraban a las ramas de
+# integración sin que nada fallara el PR. Este job los frena en cada PR.
+#
+# Dos capas:
+#   1. Guardián de FUENTE (boundaryAudit): escanea el árbol por codenames de
+#      agente, identidad personal y rutas absolutas del operador.
+#   2. Auditor de BUNDLE (audit-bundle): build + inspección de dist/ contra
+#      oss-pro/PROHIBITED_IN_PUBLIC.md — atrapa lo que llega al artefacto servido.
+#
+# Corre en PR a las ramas de integración (main, dev, app-3d) y en push a las
+# ramas que despliegan (main, app-3d). Barato: sin GPU, sin red, sin self-hosted.
+
+on:
+  pull_request:
+    branches: [main, dev, app-3d]
+  push:
+    branches: [main, app-3d]
+
+permissions:
+  contents: read
+
+jobs:
+  boundary:
+    name: anti-leak (fuente + bundle)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Capa 1 — Guardián de fuente. Falla si aparece un codename, identidad o
+      # ruta local del operador en el árbol (case-insensitive; ver el test).
+      - name: Guardián de frontera (fuente)
+        run: npm run test:unit -- tests/unit/boundaryAudit.test.js
+
+      # Capa 2 — Auditor del bundle. audit-bundle.mjs inspecciona dist/, así que
+      # primero hay que construir. Mismo comando de build que perf-budget.yml
+      # (ubuntu-latest, sin env extra).
+      - name: Build
+        run: npm run build
+
+      - name: Auditor del bundle (dist/)
+        run: npm run audit:bundle

--- a/.github/workflows/llm-local-review.yml
+++ b/.github/workflows/llm-local-review.yml
@@ -102,8 +102,10 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p .adr-cache
-          # En alpha, los ADRs de Chagra-strategy están en /home/kortux/Workspace/Chagra-strategy o /home/kortux/Chagra-strategy.
-          for base in /home/kortux/Workspace/Chagra-strategy /home/kortux/Chagra-strategy; do
+          # En el runner self-hosted, los ADRs de Chagra-strategy viven bajo el
+          # HOME del runner (configurable con CHAGRA_STRATEGY_DIR si difiere).
+          for base in "${CHAGRA_STRATEGY_DIR:-}" "$HOME/Workspace/Chagra-strategy" "$HOME/Chagra-strategy"; do
+            [ -z "$base" ] && continue
             if [ -d "$base/deepresearch" ]; then
               cp "$base/deepresearch/data-model/adr-019-asset-log-3-reglas-inviolables.md" .adr-cache/adr-019.md 2>/dev/null || true
               cp "$base/deepresearch/architecture/ADR-020-anti-leak-content-boundary.md" .adr-cache/adr-020.md 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-prod
 dist-ssr
 *.local
 

--- a/bench/run.mjs
+++ b/bench/run.mjs
@@ -118,9 +118,13 @@ export function detectInfra({ probe } = {}) {
     if (process.env.ANTHROPIC_API_KEY) return true;
     return existsSync(join(process.env.HOME || '', '.config', 'chagra-anthropic-judge-key'));
   });
-  check('fixtures-privadas', () =>
-    existsSync('/home/kortux/Workspace/Chagra-strategy/deepresearch'),
-  );
+  check('fixtures-privadas', () => {
+    // Ruta de fixtures privadas configurable por env; default relativo al HOME
+    // del operador (no hardcodear el path absoluto de una máquina concreta).
+    const dir = process.env.CHAGRA_FIXTURES_DIR
+      || join(process.env.HOME || '', 'Workspace', 'Chagra-strategy', 'deepresearch');
+    return existsSync(dir);
+  });
   check('farmos', () => result.sidecar === true);
   check('age', () => {
     const r = spawnSync(

--- a/public/sw.js
+++ b/public/sw.js
@@ -94,7 +94,7 @@ const RAG_GROUNDING_PRECACHE = [
   // (plaga→controlador, compatibles, antagonistas, biopreparados, vernáculos)
   // por especie del catálogo. Cierra el "invisible offline": antes el cliente
   // sin red sólo veía el catálogo estático y NO estas aristas. Generado en
-  // build/ops por chagra-pro/scripts/export-grafo-offline.mjs. Se cachea en
+  // build/ops por un script interno de export del grafo offline. Se cachea en
   // RAG_GROUNDING_CACHE (sobrevive deploys; cache-first; degrada a 504).
   '/grafo-relations.json',
 ];
@@ -672,7 +672,7 @@ self.addEventListener('message', (event) => {
   // comparar con `sw:last-acked-version` en localStorage y decidir si
   // mostrar el banner "nueva version disponible". Respondemos por
   // MessageChannel (event.ports[0]) para evitar broadcast a otros clients.
-  // Fix Antigravity QA #18.
+  // Fix QA #18.
   if (event.data && event.data.type === 'GET_VERSION') {
     if (event.ports && event.ports[0]) {
       event.ports[0].postMessage({ type: 'VERSION', version: CACHE_NAME });

--- a/scripts/diag/_shot-valle-noche.mjs
+++ b/scripts/diag/_shot-valle-noche.mjs
@@ -2,11 +2,13 @@
 /* Captura del valle con franja fija (?ciclo=N) — teléfono y desktop. */
 import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { chromium } from 'playwright';
 
 const BASE = process.env.SHOT_BASE || 'http://127.0.0.1:5173';
 const CICLO = process.env.SHOT_CICLO || '22';
-const OUTDIR = process.env.SHOT_OUTDIR || '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/shots';
+const OUTDIR = process.env.SHOT_OUTDIR || join(tmpdir(), 'chagra-shots');
 const TAG = process.env.SHOT_TAG || 'base';
 const RUTA = process.env.SHOT_RUTA || '/#/mockups/entrada-3d';
 const ESPERA = Number(process.env.SHOT_ESPERA || 9000);

--- a/scripts/diag/shot-hato.mjs
+++ b/scripts/diag/shot-hato.mjs
@@ -5,9 +5,11 @@ import { chromium } from 'playwright';
 import { spawn } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const OUTDIR = process.env.SHOT_OUTDIR || tmpdir();
 const PORT = 5199;
 const BASE = `http://127.0.0.1:${PORT}`;
 const [etiqueta = 'x', ...vistasArg] = process.argv.slice(2);
@@ -36,7 +38,7 @@ for (const vista of VISTAS) {
   try {
     await page.goto(`${BASE}/scripts/diag/hato.html?vista=${vista}`, { waitUntil: 'load', timeout: 40000 });
     await sleep(5000);
-    const f = `/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/hato-${etiqueta}-${vista}.png`;
+    const f = path.join(OUTDIR, `hato-${etiqueta}-${vista}.png`);
     await page.screenshot({ path: f, timeout: 60000 });
     console.log('OK', vista, f);
   } catch (e) { console.log('FAIL', vista, String(e).slice(0, 120)); }

--- a/scripts/diag/shot-suelo-demo.mjs
+++ b/scripts/diag/shot-suelo-demo.mjs
@@ -3,10 +3,12 @@
 // Uso: npx vite --port 5237 & BASE=http://localhost:5237 node scripts/diag/shot-suelo-demo.mjs
 import { execSync } from 'node:child_process';
 import { mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { chromium } from 'playwright';
 
 const BASE = process.env.BASE || 'http://localhost:5237';
-const OUT = process.env.OUT || '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/shots';
+const OUT = process.env.OUT || join(tmpdir(), 'chagra-shots');
 mkdirSync(OUT, { recursive: true });
 
 function chromiumPath() {

--- a/scripts/diag/shot-valle.mjs
+++ b/scripts/diag/shot-valle.mjs
@@ -1,7 +1,12 @@
 import { chromium } from 'playwright';
 import { spawn } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
-const REPO = '/home/kortux/Workspace/chagra/.claude/worktrees/agent-acc693963161d0026';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+// Raíz del repo derivada de la ubicación del script (no hardcodear rutas locales).
+const REPO = process.env.SHOT_REPO || path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const OUT = process.env.SHOT_OUT || path.join(tmpdir(), 'valle-integracion.png');
 const PORT = 5201;
 const BASE = `http://127.0.0.1:${PORT}`;
 const srv = spawn('npx', ['vite', '--port', String(PORT), '--host', '127.0.0.1', '--strictPort'], { cwd: REPO, stdio: 'ignore' });
@@ -14,7 +19,7 @@ const page = await browser.newPage({ viewport: { width: 390, height: 844 }, devi
 page.on('pageerror', (e) => console.log('PAGE_ERR:', String(e).slice(0, 300)));
 await page.goto(BASE + '/#/mockups/entrada-3d', { waitUntil: 'load', timeout: 40000 });
 await sleep(9000);
-await page.screenshot({ path: '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/valle-integracion.png' });
-console.log('OK');
+await page.screenshot({ path: OUT });
+console.log('OK', OUT);
 await browser.close();
 srv.kill('SIGKILL');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -569,9 +569,10 @@ const LoadingFallback = ({ view = null }) => {
 // dashboard legacy), que NUNCA se montaba — `case 'dashboard'` renderiza
 // `DashboardLiveView`. La home viva es `DashboardLive.jsx` (HERRAMIENTAS_TILES +
 // FincaCards + mano radial). Los launchers que SOLO vivían en ese código muerto
-// (`casos` vía CaseStudyTopWidget, `javier` vía el tile) se rescataron a la home
-// viva (HERRAMIENTAS_TILES en DashboardLive). Las rutas `casos`/`caso_detail`/
-// `javier`/`usage_stats` siguen vivas en el router (más abajo) y por hash.
+// (`casos` vía CaseStudyTopWidget, `campo_trabajador` vía el tile) se rescataron
+// a la home viva (HERRAMIENTAS_TILES en DashboardLive). Las rutas `casos`/
+// `caso_detail`/`campo_trabajador`/`usage_stats` siguen vivas en el router (más
+// abajo) y por hash.
 // Ref: CAPABILITIES_STATUS.md §4 (deuda de navegación) + §2 (huérfanos).
 
 // Rutas PÚBLICAS de mockups (vitrinas de discovery). Se resuelven ANTES del
@@ -867,7 +868,7 @@ const HASH_VIEW_ROUTES = {
 
 // Vistas que cuentan como "módulo" para telemetría de piloto.
 const MODULE_VIEWS = new Set([
-  'activos', 'mapa', 'javier', 'bodega', 'task_log', 'historial', 'bitacora',
+  'activos', 'mapa', 'campo_trabajador', 'bodega', 'task_log', 'historial', 'bitacora',
   'biodiversidad', 'informes', 'perfil', 'ayuda', 'help',
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'estiercol', 'compost',
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'animales_conejos', 'animales_caprinos', 'estiercol',
@@ -2535,7 +2536,7 @@ export default function App() {
             <TaskScreen onBack={() => navigate('task_log')} onSave={showToast} initialData={currentViewData?.task || currentViewData} />
           </ErrorBoundary>
         );
-      case 'javier':
+      case 'campo_trabajador':
         return (
           <ErrorBoundary>
             <ScreenShell title={`Campo, ${PRIMARY_WORKER_NAME}`} icon={Eye} onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')}>

--- a/src/__tests__/swUpdateAck.test.js
+++ b/src/__tests__/swUpdateAck.test.js
@@ -1,5 +1,5 @@
 /**
- * swUpdateAck.test.js — cobertura del fix Antigravity QA #18.
+ * swUpdateAck.test.js — cobertura del fix QA #18.
  *
  * Bug: el banner "nueva versión disponible" se mostraba cada reload aunque
  * el usuario ya hubiera clickeado "Actualizar". Persistimos el ack en
@@ -11,7 +11,7 @@
  *   2. Ack persistido y misma versión → NO mostrar banner.
  *   3. Versión cambió (incluido rollback) → SÍ mostrar banner.
  *
- * Refs: Antigravity QA #18, task #128.
+ * Refs: QA #18, task #128.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import {

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -47,6 +47,7 @@ import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciar
 import { esExtensionistaRealActual } from '../../config/extensionistaAccess';
 import { fincaVivaHomePerfilActivo } from '../../config/fincaVivaHomeFlag';
 import { registroUnificadoActivo } from '../../config/registroUnificadoFlag';
+import { PRIMARY_WORKER_NAME } from '../../config/workerConfig';
 import SelectedBackgroundReveal from './SelectedBackgroundReveal';
 import MiFincaVivaHomeCard from './MiFincaVivaHomeCard';
 import FincaRedInstitucional from './FincaRedInstitucional';
@@ -383,13 +384,13 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
             return true; // Fail-open: no esconder el módulo por un error.
         }
     });
-    // Rescate huérfano 2026-06-24 (descubribilidad): "Campo, Javier"
-    // (WorkerDashboard) era HUÉRFANO — solo accesible desde el NAV_TILES del
-    // DashboardView muerto o por #javier. Es una vista de SUPERVISOR/trabajador
-    // (nicho), así que la exponemos gateada al OPERADOR (no se la mostramos al
-    // campesino dueño para no ensuciar la home). La ruta #javier sigue viva en el
-    // router. Ref: CAPABILITIES_STATUS.md §2.
-    const [mostrarJavier] = useState(() => {
+    // Rescate huérfano 2026-06-24 (descubribilidad): el panel "Campo,
+    // <trabajador>" (WorkerDashboard) era HUÉRFANO — solo accesible desde el
+    // NAV_TILES del DashboardView muerto o por #campo_trabajador. Es una vista de
+    // SUPERVISOR/trabajador (nicho), así que la exponemos gateada al OPERADOR (no
+    // se la mostramos al campesino dueño para no ensuciar la home). La ruta
+    // #campo_trabajador sigue viva en el router. Ref: CAPABILITIES_STATUS.md §2.
+    const [mostrarCampoPanel] = useState(() => {
         try {
             return esOperadorActual();
         } catch (_) {
@@ -630,20 +631,20 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
         </div>
     );
 
-    // Banner "Campo, Javier" (gateado al operador) — idéntico en ambos layouts.
-    const renderJavier = () => (mostrarJavier && (
+    // Banner "Campo, <trabajador>" (gateado al operador) — idéntico en ambos layouts.
+    const renderCampoPanel = () => (mostrarCampoPanel && (
         <div className={`px-4 pt-3 ${fincaVivaFlag ? 'fvh-resto-block' : ''}`}>
             <button
                 type="button"
-                onClick={() => onNavigate('javier')}
+                onClick={() => onNavigate('campo_trabajador')}
                 className="w-full flex items-center gap-3 p-3.5 rounded-2xl border border-slate-700/60 bg-slate-900/40 hover:bg-slate-800/50 active:scale-[0.99] transition text-left"
-                aria-label="Campo, Javier: panel de trabajo en finca"
+                aria-label={`Campo, ${PRIMARY_WORKER_NAME}: panel de trabajo en finca`}
             >
                 <span className="shrink-0 w-11 h-11 rounded-xl bg-emerald-500/15 grid place-items-center">
                     <Eye size={24} className="text-emerald-300" />
                 </span>
                 <span className="flex-1 min-w-0">
-                    <span className="block font-bold text-slate-100 leading-tight">Campo, Javier</span>
+                    <span className="block font-bold text-slate-100 leading-tight">Campo, {PRIMARY_WORKER_NAME}</span>
                     <span className="block text-xs text-slate-400 leading-tight">
                         Panel de trabajo: tareas por proximidad y registro en finca
                     </span>
@@ -963,8 +964,8 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                     <CaseStudyTopWidget onNavigate={onNavigate} maxItems={3} />
                 </div>
 
-                {/* "Campo, Javier" (gateado al operador), al fondo. */}
-                {renderJavier()}
+                {/* "Campo, <trabajador>" (gateado al operador), al fondo. */}
+                {renderCampoPanel()}
 
                 {/* Pie del cuaderno: ayuda y preguntas frecuentes, discretas
                     pero siempre alcanzables (antes "Preguntas frecuentes" era
@@ -1061,8 +1062,8 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
             {/* MERCADO. */}
             {renderMercado()}
 
-            {/* "Campo, Javier" (gateado al operador). */}
-            {renderJavier()}
+            {/* "Campo, <trabajador>" (gateado al operador). */}
+            {renderCampoPanel()}
 
             {/* MÓDULO ANIMALES — gateado por perfil. */}
             {mostrarAnimales && (

--- a/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
@@ -20,7 +20,7 @@ import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../../config/glaciarAccess', () => ({
   tieneAccesoGlaciarActual: () => false,
-  esOperadorActual: () => true, // el operador ve todo (renderJavier, etc.)
+  esOperadorActual: () => true, // el operador ve todo (renderCampoPanel, etc.)
 }));
 
 vi.mock('../../../config/fincaVivaHomeFlag', () => ({

--- a/src/config/README-rutas-manifest.md
+++ b/src/config/README-rutas-manifest.md
@@ -19,7 +19,7 @@
 - **Temas viejos dashboard**: BiopunkBackground, SceneFinca*, PanelVitalidad, RelojFrailejon, ArbolDeMundos, ManoChagraGlyph — reemplazados por valle 3D como fondo principal.
 - **Duplicados**: EntradaCampesina (→ EntradaValle3D), HomeCampesino (→ DashboardLive), MontanaMundos v1 y v3 (→ MontanaMundosCampesino).
 - **Prototipos reemplazados**: BotonAnarquia (→ AgentFab), AvatarGame* (→ Espíritu Guardián), MapaAcuarela (→ FarmMap), ClimaAtmosfera (→ ClimaBoletinScreen), DiaEnFinca (→ HoyEnFincaScreen), SaludFinca, PrimerCultivo, Guardianes, HojaVidaMata, DiagnosticoSobreFoto, EvidenciaIlustrada.
-- **Funcionalidad nicho**: WorkerDashboard "Javier", AuditoriaInventario.
+- **Funcionalidad nicho**: WorkerDashboard (panel de trabajador de finca), AuditoriaInventario.
 
 ### Pendiente decisión (Miguel)
 

--- a/src/config/rutasProdChagraApp.js
+++ b/src/config/rutasProdChagraApp.js
@@ -1008,8 +1008,8 @@ export const EXCLUIDO = [
 
   // ── Componentes específicos ────────────────────────────────────
   {
-    path: 'javier',
-    motivo: 'Dashboard del trabajador "Javier". Rol específico, no genérico.',
+    path: 'campo_trabajador',
+    motivo: 'Dashboard de trabajador de finca (WorkerDashboard). Rol específico, no genérico.',
   },
   {
     path: 'auditoria_inventario',

--- a/src/config/workerConfig.js
+++ b/src/config/workerConfig.js
@@ -8,3 +8,13 @@
  */
 export const PRIMARY_WORKER_NAME =
   import.meta.env.VITE_PRIMARY_WORKER_NAME || 'Trabajador';
+
+/**
+ * Nombre del operario ANTERIOR a renombrar en la migración de identidad única
+ * (main.jsx / main-prod.jsx). Antes estaba hardcodeado con un nombre real en el
+ * source público (leak de identidad, ADR-020). Ahora se configura por deploy via
+ * VITE_LEGACY_WORKER_NAME; el default genérico 'Trabajador' hace que la migración
+ * sea un no-op inocuo si el deploy no la setea (no busca ningún nombre personal).
+ */
+export const LEGACY_WORKER_NAME =
+  import.meta.env.VITE_LEGACY_WORKER_NAME || 'Trabajador';

--- a/src/main-prod.jsx
+++ b/src/main-prod.jsx
@@ -14,7 +14,7 @@ import { ModoCampoProvider } from './hooks/ModoCampoContext';
 import { syncManager } from './services/syncManager';
 import { useLogStore } from './store/useLogStore';
 import { fetchFromFarmOS } from './services/apiService';
-import { PRIMARY_WORKER_NAME } from './config/workerConfig';
+import { PRIMARY_WORKER_NAME, LEGACY_WORKER_NAME } from './config/workerConfig';
 import { renameWorker } from './services/assetService';
 import { getAccessToken } from './services/authService';
 import { registerServiceWorker } from './services/swRegistration';
@@ -48,7 +48,7 @@ if (!canonicalRedirect.redirected) {
     if (navigator.onLine && !localStorage.getItem('chagra:v1:rename_done')) {
       getAccessToken().then((token) => {
         if (!token) return;
-        renameWorker('Jimmy', PRIMARY_WORKER_NAME).then((result) => {
+        renameWorker(LEGACY_WORKER_NAME, PRIMARY_WORKER_NAME).then((result) => {
           if (result.success || result.error === 'not_found') {
             localStorage.setItem('chagra:v1:rename_done', '1');
           }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -15,7 +15,7 @@ import { ModoCampoProvider } from './hooks/ModoCampoContext'
 import { syncManager } from './services/syncManager'
 import { useLogStore } from './store/useLogStore'
 import { fetchFromFarmOS } from './services/apiService'
-import { PRIMARY_WORKER_NAME } from './config/workerConfig'
+import { PRIMARY_WORKER_NAME, LEGACY_WORKER_NAME } from './config/workerConfig'
 import { renameWorker } from './services/assetService'
 import { getAccessToken } from './services/authService'
 import { registerServiceWorker } from './services/swRegistration'
@@ -58,7 +58,7 @@ if (!canonicalRedirect.redirected) {
     if (navigator.onLine && !localStorage.getItem('chagra:v1:rename_done')) {
       getAccessToken().then((token) => {
         if (!token) return; // Sin sesión, no intentar PATCH sin auth
-        renameWorker('Jimmy', PRIMARY_WORKER_NAME).then((result) => {
+        renameWorker(LEGACY_WORKER_NAME, PRIMARY_WORKER_NAME).then((result) => {
           if (result.success || result.error === 'not_found') {
             localStorage.setItem('chagra:v1:rename_done', '1');
             console.info('[Migration] Renombrado completado o innecesario.');

--- a/tests/unit/boundaryAudit.test.js
+++ b/tests/unit/boundaryAudit.test.js
@@ -19,26 +19,29 @@ import { fileURLToPath } from 'url';
 const TEST_FILE = fileURLToPath(import.meta.url);
 const REPO_DIR = resolve(dirname(TEST_FILE), '../..');
 
+// Flag `i` (case-insensitive) OBLIGATORIO: sin él, `/antigravity/` NO matcheaba
+// el texto real `Antigravity` (mayúscula) y el codename sobrevivía en el bundle
+// servido (public/sw.js). Un leak de identidad/infra no depende de la caja.
 const PROHIBITED_PATTERNS = [
-  /PROHIBITED_INTERNAL/,
-  /ECOCERT_PRESET_INTERNAL/,
-  /MAYACERT_PRESET_INTERNAL/,
-  /CONTROL_UNION_PRESET_INTERNAL/,
-  /IFOAM_PRESET_PRO/,
-  /mollison[-_]?adapted/,
-  /lawton[-_]?curated/,
-  /pfeiffer[-_]?internal/,
-  /appliance[-_]?default[-_]?config/,
-  /antigravity/,
-  /openfang/,
-  /personal_hand/,
-  /\/home\/kortux/,
-  /\/home\/ubuntu/,
-  /kortux/,
+  /PROHIBITED_INTERNAL/i,
+  /ECOCERT_PRESET_INTERNAL/i,
+  /MAYACERT_PRESET_INTERNAL/i,
+  /CONTROL_UNION_PRESET_INTERNAL/i,
+  /IFOAM_PRESET_PRO/i,
+  /mollison[-_]?adapted/i,
+  /lawton[-_]?curated/i,
+  /pfeiffer[-_]?internal/i,
+  /appliance[-_]?default[-_]?config/i,
+  /antigravity/i,
+  /openfang/i,
+  /personal_hand/i,
+  /\/home\/kortux/i,
+  /\/home\/ubuntu/i,
+  /kortux/i,
 ];
 
 const SKIP_DIRS = new Set([
-  'node_modules', 'dist', '.git',
+  'node_modules', 'dist', 'dist-prod', '.git',
   'test-results',    // Playwright artifacts (CI paths)
   '.claude',          // private agent config (not in repo)
   'bench',            // benchmark data/history (contains model names, paths)


### PR DESCRIPTION
## Qué y por qué

El guardián anti-leak `tests/unit/boundaryAudit.test.js` estaba rojo y **no corría en CI de GitHub**, con un bug de case-sensitivity que dejaba pasar codenames. Esa era la causa raíz de que las fugas reentraran. Este PR lo arregla, le da diente en CI, y sanea las fugas concretas **hacia adelante** (sin reescribir historia).

Base: `app-3d` (rama de integración activa; el gate corre igual en PR a `main`/`dev`/`app-3d`).

## Guardián + CI (causa raíz)

- **`boundaryAudit.test.js`**: patrones ahora case-insensitive (flag `i`) — antes el patrón en minúscula no matcheaba el texto real con mayúscula, por eso el codename sobrevivía en el bundle servido. Se ignora `dist-prod/` en el escaneo.
- **Nuevo `.github/workflows/boundary-gate.yml`**: corre el guardián de fuente **y** el auditor del bundle (`audit-bundle.mjs`, con build previo) en cada **PR a `main`/`dev`/`app-3d`** y push a `main`/`app-3d`. Antes ninguno de los dos corría en CI (el guardián no estaba en ningún workflow; `audit-bundle` solo se invocaba manual).

## Saneo forward

| Fuga | Dónde | Arreglo |
|------|-------|---------|
| Codename de agente | `public/sw.js` (comentario servido en prod) + `src/__tests__/swUpdateAck.test.js` | Se quita el codename, se deja la referencia neutra al ticket |
| Nombre de repo privado | `public/sw.js` (comentario embebido en el artefacto público) | Reescrito sin nombrar el repo — **lo detectó el auditor del bundle**, no el guardián |
| Identidad de trabajador hardcodeada | `main.jsx`, `main-prod.jsx`, `DashboardLive.jsx`, `App.jsx`, `rutasProdChagraApp.js`, `README-rutas-manifest.md` | Migración a `LEGACY_WORKER_NAME` (env, default genérico); banner/título ya derivan de `PRIMARY_WORKER_NAME`; slug de ruta renombrado a uno neutro |
| Rutas absolutas locales | `scripts/diag/*.mjs`, `bench/run.mjs`, `.github/workflows/llm-local-review.yml` | `tmpdir()` / `$HOME` / env — sin usuario ni layout de máquina |
| Higiene | `.gitignore` | Se ignora `dist-prod/` (evita publicar el bundle construido con artefactos embebidos) |

No se tocó la atribución legítima de foto Wikimedia (dominio público) ni los literales de patrón dentro del propio test guardián.

## Verificación (empírica)

- Guardián `boundaryAudit.test.js`: **verde**.
- `npm run build` + `npm run audit:bundle`: **Bundle limpio — 0 hits**.
- `npm run build:prod`: **verde**; `dist-prod/` sin codename ni identidad.
- `tsc:check`: **sin errores nuevos** (los errores restantes son previos y en archivos 3D/terreno no tocados por este PR).

## Requiere decisión humana

- **Historia git**: ADR-020 dice no reescribir historia. Este PR limpia **forward**; los codenames que ya están en commits pasados quedan (bajo daño, consistente con ADR-020). Confirmar si se mantiene esa política.
- **`main` vs `app-3d`**: prod despliega desde `main`, que sigue divergido de `app-3d`. Hasta que `app-3d` se promueva (o se haga cherry-pick del saneo de `sw.js`), el codename sigue viajando en el `sw.js` servido en prod actual. Decisión de si vale un cherry-pick a `main`.
- **`chagra-pro` en comentarios de `src/`**: quedan varias menciones del repo privado en comentarios y tests de `src/` que el minificador **elimina del bundle** (verificado: no llegan a `dist/`). No las tocó este PR para no inflar el diff; se pueden barrer en una pasada aparte si se quiere. La única que llegaba al artefacto (`sw.js`) sí se arregló acá.
