### PR TITLE
art(bosque): el bosque de páramo definitivo (toma A) — suelo rico + árboles masa-de-hojas + frailejonal por edades

### DIFF
--- a/scripts/diag/shot-bosque-paramo.mjs
+++ b/scripts/diag/shot-bosque-paramo.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/* Captura del BOSQUE PÁRAMO (toma A final): 4 franjas + 2 órbitas + vertical. */
+import { mkdirSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { chromium } from 'playwright';
+
+const BASE = process.env.BASE_URL || 'http://127.0.0.1:5311';
+const OUT = process.env.OUT_DIR || '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/shots-paramo';
+mkdirSync(OUT, { recursive: true });
+
+function chromiumPath() {
+  if (process.env.PLAYWRIGHT_CHROMIUM_PATH) return process.env.PLAYWRIGHT_CHROMIUM_PATH;
+  try {
+    const w = execSync('which chromium 2>/dev/null', { encoding: 'utf8' }).trim();
+    if (w) return w;
+  } catch { /* sigue */ }
+  return undefined;
+}
+
+const browser = await chromium.launch({
+  executablePath: chromiumPath(),
+  args: [
+    '--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage',
+    '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader',
+    '--ignore-gpu-blocklist',
+  ],
+});
+
+async function drag(page, x0, y0, x1, y1, pasos = 24) {
+  await page.mouse.move(x0, y0);
+  await page.mouse.down();
+  for (let i = 1; i <= pasos; i++) {
+    await page.mouse.move(x0 + ((x1 - x0) * i) / pasos, y0 + ((y1 - y0) * i) / pasos);
+    await page.waitForTimeout(16);
+  }
+  await page.mouse.up();
+}
+
+async function shot({ nombre, ciclo, vw = 1160, vh = 720, orbita = null, esperar = 14000 }) {
+  const page = await browser.newPage({ viewport: { width: vw, height: vh }, deviceScaleFactor: 1.4 });
+  page.on('pageerror', (e) => console.log(`[${nombre}] pageerror:`, e.message));
+  page.on('console', (m) => {
+    if (m.type() === 'error') console.log(`[${nombre}] console.error:`, m.text().slice(0, 220));
+  });
+  await page.goto(`${BASE}/?ciclo=${ciclo}#/mockups/bosque-vivo-3d`, { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await page.waitForSelector('canvas', { timeout: 90000 });
+  await page.waitForTimeout(esperar);
+  if (orbita) {
+    await drag(page, vw / 2, vh / 2, vw / 2 + orbita[0], vh / 2 + orbita[1]);
+    await page.waitForTimeout(1800);
+  }
+  await page.screenshot({ path: `${OUT}/${nombre}.png`, timeout: 120000 });
+  console.log('ok', nombre);
+  await page.close();
+}
+
+await shot({ nombre: '01-manana-reposo', ciclo: 9 });
+await shot({ nombre: '02-amanecer-bruma', ciclo: 6.2 });
+await shot({ nombre: '03-atardecer', ciclo: 17.8 });
+await shot({ nombre: '04-noche-arroyo', ciclo: 22 });
+await shot({ nombre: '05-orbita-izq', ciclo: 10, orbita: [360, 30] });
+await shot({ nombre: '06-orbita-der-relieve', ciclo: 10, orbita: [-400, -50] });
+await shot({ nombre: '07-vertical-telefono', ciclo: 9, vw: 390, vh: 844 });
+await browser.close();
+console.log('LISTO', OUT);

--- a/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
+++ b/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
@@ -1,146 +1,690 @@
 /*
- * EscenaBosqueVivo — el MUNDO donde vive el Ent de la queñua.
+ * EscenaBosqueVivo — el MUNDO donde vive el Ent de la queñua (TAKE A).
  *
- * Un claro del páramo alto: luz fría y difusa, niebla que come el fondo, suelo
- * de musgo y todo un ECOSISTEMA altoandino alrededor (frailejonar al frente,
- * árboles de niebla al fondo — ver `FloraParamo`) que sitúa el lugar SIN robarle
- * el foco al guardián: la queñua sigue siendo EL árbol mayor. La cámara mira al
- * árbol un poco DESDE ABAJO para que se lea imponente. Se puede girar con el dedo.
+ * Un anfiteatro de bosque de niebla altoandino con el calibre del VALLE:
+ *   · TERRENO con relieve real (heightfield determinista, vertexColors):
+ *     el claro del guardián, lomos de musgo, la cañada del arroyo y la
+ *     pared del anfiteatro que la niebla se come al fondo.
+ *   · EL QUEÑUAL: queñuas (Polylepis) de tronco retorcido rojizo que se
+ *     despapela y copas que son MASA de hojas con huecos (matojos-nube con
+ *     normales radiales — nada de poliedros literales). Anillo héroe que
+ *     enmarca al Ent + anillo lejano de siluetas veladas.
+ *   · CICLO DE DÍA real (useCicloDia + CIELOS_HORA sesgados a bosque de
+ *     niebla): la atmósfera se AMORTIGUA entre franjas (mismo patrón que
+ *     AtmosferaValle) — amanece y anochece, no se teletransporta.
+ *   · RAYOS DE SOL colados (godrays baratos: planos aditivos con textura
+ *     canvas), BRUMA por capas con parallax entre los árboles y estrellas
+ *     de noche.
+ *   · CÁMARA consciente del aspecto + CamaraDirector (la llegada con dolly).
  *
- * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`: 'alto' con
- * sombras + niebla + facetado; 'medio' frugal; 'bajo' mínimo. Con `reducedMotion`
- * el mundo monta QUIETO (frameloop a demanda).
+ * El guardián (EntQuenua) vive en el MOUNT del centro — otra rama lo eleva
+ * de calibre; aquí solo se le prepara el escenario. La fauna es la de
+ * FaunaBosque (SVG rubber-hose, el estándar de la casa). Tier-safe vía
+ * perfilDeTier; reducedMotion monta QUIETO (frameloop a demanda).
  *
- * Importa three/@react-three → montar SOLO perezosa (lazy) desde el host.
+ * Todo procedural (cero CDN/imágenes). Importa three/@react-three → montar
+ * SOLO perezosa (lazy) desde el host.
  */
-import { useMemo, useState } from 'react';
-import { Canvas } from '@react-three/fiber';
-import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { Suspense, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr, Stars } from '@react-three/drei';
+import * as THREE from 'three';
 import { perfilDeTier } from '../deviceTier.js';
+import useCicloDia from '../useCicloDia.js';
+import { CIELOS_HORA, TRANSICION, mezclaHex } from '../cielosHoraData.js';
+import CamaraDirector from '../escenas/CamaraDirector.jsx';
 import EntQuenua from './EntQuenua.jsx';
 import FloraParamo from './FloraParamo.jsx';
 import FaunaBosque from './FaunaBosque.jsx';
+import {
+  alturaBosque,
+  geomTerrenoBosque,
+  geomQuenua,
+  sitiosQuenual,
+  geomLosetaHojarasca,
+  sitiosHojarasca,
+  geomTroncosCaidos,
+  curvaArroyo,
+} from './bosqueTakeA.geom.js';
 
-/* Cielo del páramo: gris-azul frío, alto y húmedo. */
-const PARAMO = { fondo: '#c3cfce', niebla: '#c9d3d1', suelo: '#4b5340', musgo: '#5c6844' };
+/* ── LA ATMÓSFERA DEL BOSQUE DE NIEBLA ─────────────────────────────────────
+      Los presets del día salen de CIELOS_HORA (la misma familia del valle:
+      el bosque amanece y anochece CON el valle) pero sesgados a bosque de
+      niebla: colores más fríos y lechosos, el suelo más verde, y el fog
+      MUCHO más cerca — aquí la niebla es la protagonista que come el fondo. */
+const BRUMA = { fondo: '#c2cecb', suelo: '#3c4634', niebla: '#c6d1ce' };
 
-function rng(seed) {
-  let s = (seed >>> 0) || 1;
-  return () => {
-    s = (s * 1664525 + 1013904223) >>> 0;
-    return s / 4294967296;
+function presetBosque(franja) {
+  const p = CIELOS_HORA[franja] || CIELOS_HORA.manana;
+  // De noche la bruma lechosa CEDE: el índigo del cine (día por noche) manda
+  // y la niebla apenas azulea — sin esto la noche quedaba gris-lavada.
+  const kBruma = franja === 'noche' ? 0.28 : 0.55;
+  const kFondo = franja === 'noche' ? 0.3 : 0.5;
+  return {
+    fondo: mezclaHex(p.fondo, BRUMA.fondo, kFondo),
+    cielo: mezclaHex(p.cielo, BRUMA.fondo, 0.35),
+    suelo: mezclaHex(p.suelo, BRUMA.suelo, 0.5),
+    luz: p.luz,
+    relleno: p.relleno,
+    niebla: mezclaHex(p.niebla, BRUMA.niebla, kBruma),
+    intensidad: p.intensidad * 0.95,
+    hemisferio: p.hemisferio,
+    ambiente: p.ambiente,
+    sol: p.sol,
+    rellenoInt: p.rellenoInt,
+    solPos: p.solPos,
+    nieblaCerca: Math.max(5, p.nieblaCerca * 0.6),
+    nieblaLejos: 14 + p.nieblaLejos * 0.5,
+    estrellas: Number(p.estrellas) || 0,
   };
 }
 
-/* Mata de paja del páramo: unos conos finos dorado-verdosos. */
-function Paja({ pos }) {
+function estadoAtmosfera(p) {
+  return {
+    fondo: new THREE.Color(p.fondo),
+    domo: new THREE.Color(p.cielo),
+    suelo: new THREE.Color(p.suelo),
+    luz: new THREE.Color(p.luz),
+    relleno: new THREE.Color(p.relleno),
+    niebla: new THREE.Color(p.niebla),
+    solPos: new THREE.Vector3(p.solPos[0], p.solPos[1], p.solPos[2]),
+    intensidad: p.intensidad,
+    hemisferio: p.hemisferio,
+    ambiente: p.ambiente,
+    sol: p.sol,
+    rellenoInt: p.rellenoInt,
+    nieblaCerca: p.nieblaCerca,
+    nieblaLejos: p.nieblaLejos,
+  };
+}
+
+function amortiguar(a, o, k) {
+  a.fondo.lerp(o.fondo, k);
+  a.domo.lerp(o.domo, k);
+  a.suelo.lerp(o.suelo, k);
+  a.luz.lerp(o.luz, k);
+  a.relleno.lerp(o.relleno, k);
+  a.niebla.lerp(o.niebla, k);
+  a.solPos.lerp(o.solPos, k);
+  a.intensidad += (o.intensidad - a.intensidad) * k;
+  a.hemisferio += (o.hemisferio - a.hemisferio) * k;
+  a.ambiente += (o.ambiente - a.ambiente) * k;
+  a.sol += (o.sol - a.sol) * k;
+  a.rellenoInt += (o.rellenoInt - a.rellenoInt) * k;
+  a.nieblaCerca += (o.nieblaCerca - a.nieblaCerca) * k;
+  a.nieblaLejos += (o.nieblaLejos - a.nieblaLejos) * k;
+}
+
+/* Mismo patrón que AtmosferaValle: los props declarativos usan la piel del
+   PRIMER montaje; todo lo vivo se escribe imperativo por refs (cero setState
+   por frame, cero alocación — colores/vec3 mutados in-place). */
+function AtmosferaBosque({ franja, perfil, reducedMotion }) {
+  const objetivo = useMemo(() => estadoAtmosfera(presetBosque(franja)), [franja]);
+  const [ini] = useState(() => presetBosque(franja));
+  const [actual] = useState(() => estadoAtmosfera(ini));
+
+  const fondoRef = useRef(null);
+  const fogRef = useRef(null);
+  const hemiRef = useRef(null);
+  const ambRef = useRef(null);
+  const solRef = useRef(null);
+  const rellenoRef = useRef(null);
+
+  const pintar = (e) => {
+    if (fondoRef.current) fondoRef.current.copy(e.fondo);
+    if (fogRef.current) {
+      fogRef.current.color.copy(e.niebla);
+      fogRef.current.near = e.nieblaCerca;
+      fogRef.current.far = e.nieblaLejos;
+    }
+    if (hemiRef.current) {
+      hemiRef.current.intensity = e.intensidad * e.hemisferio * 1.7;
+      hemiRef.current.color.copy(e.domo);
+      hemiRef.current.groundColor.copy(e.suelo);
+    }
+    if (ambRef.current) {
+      ambRef.current.intensity = e.intensidad * e.ambiente * 1.3;
+      ambRef.current.color.copy(e.luz);
+    }
+    if (solRef.current) {
+      solRef.current.intensity = e.intensidad * e.sol * 1.25;
+      solRef.current.color.copy(e.luz);
+      solRef.current.position.set(e.solPos.x * 1.8, e.solPos.y * 1.8, e.solPos.z * 1.8);
+    }
+    if (rellenoRef.current) {
+      rellenoRef.current.intensity = e.intensidad * e.rellenoInt * 1.4;
+      rellenoRef.current.color.copy(e.relleno);
+      rellenoRef.current.position.set(-e.solPos.x, Math.max(3, e.solPos.y * 0.6), -e.solPos.z);
+    }
+  };
+
+  // Calma pedida → snap directo a la franja (frameloop 'demand').
+  useLayoutEffect(() => {
+    if (!reducedMotion) return;
+    amortiguar(actual, objetivo, 1);
+    pintar(actual);
+  });
+
+  useFrame((_, dt) => {
+    if (reducedMotion) return;
+    const k = 1 - Math.exp((-3 / TRANSICION.duracion) * Math.min(dt, 0.1));
+    amortiguar(actual, objetivo, k);
+    pintar(actual);
+  });
+
   return (
-    <group position={pos}>
-      {[0, 1, 2, 3].map((i) => (
-        <mesh key={i} position={[(i - 1.5) * 0.05, 0.2, 0]} rotation={[0, 0, (i - 1.5) * 0.12]}>
-          <coneGeometry args={[0.03, 0.42, 4]} />
-          <meshLambertMaterial color={i % 2 ? '#8a7d47' : '#6f7c48'} />
-        </mesh>
+    <>
+      <color ref={fondoRef} attach="background" args={[ini.fondo]} />
+      {perfil.fog && (
+        <fog ref={fogRef} attach="fog" args={[ini.niebla, ini.nieblaCerca, ini.nieblaLejos]} />
+      )}
+      <hemisphereLight
+        ref={hemiRef}
+        intensity={ini.intensidad * ini.hemisferio * 1.7}
+        color={ini.cielo}
+        groundColor={ini.suelo}
+      />
+      <ambientLight ref={ambRef} intensity={ini.intensidad * ini.ambiente * 1.3} color={ini.luz} />
+      <directionalLight
+        ref={solRef}
+        position={[ini.solPos[0] * 1.8, ini.solPos[1] * 1.8, ini.solPos[2] * 1.8]}
+        intensity={ini.intensidad * ini.sol * 1.25}
+        color={ini.luz}
+        castShadow={perfil.sombras}
+        shadow-mapSize={[1024, 1024]}
+        shadow-camera-near={1}
+        shadow-camera-far={60}
+        shadow-camera-left={-15}
+        shadow-camera-right={15}
+        shadow-camera-top={15}
+        shadow-camera-bottom={-15}
+      />
+      {/* contraluz frío opuesto al sol: separa las copas de la niebla */}
+      <directionalLight
+        ref={rellenoRef}
+        position={[-ini.solPos[0], Math.max(3, ini.solPos[1] * 0.6), -ini.solPos[2]]}
+        intensity={ini.intensidad * ini.rellenoInt * 1.4}
+        color={ini.relleno}
+      />
+    </>
+  );
+}
+
+/* ── EL TERRENO ──────────────────────────────────────────────────────────── */
+function TerrenoBosque({ nocturno, perfil }) {
+  const seg = Math.round(perfil.segmentosTerreno * 1.6);
+  const geo = useMemo(() => geomTerrenoBosque({ seg, nocturno }), [seg, nocturno]);
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  return (
+    <mesh geometry={geo} receiveShadow={perfil.sombras}>
+      {perfil.materialRico ? (
+        <meshStandardMaterial vertexColors roughness={1} metalness={0} />
+      ) : (
+        <meshLambertMaterial vertexColors />
+      )}
+    </mesh>
+  );
+}
+
+/* ── EL QUEÑUAL (instanciado: 3 variantes → 3 draw-calls) ────────────────── */
+function BancoInstancias({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.esc);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tinte[0], it.tinte[1], it.tinte[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+      receiveShadow={castShadow}
+    />
+  );
+}
+
+function Quenual({ tier, perfil }) {
+  const q = tier === 'alto' ? 1 : tier === 'medio' ? 0.62 : 0.45;
+  const sitios = useMemo(() => sitiosQuenual(tier), [tier]);
+  const variantes = useMemo(
+    () => [geomQuenua({ q }, 21), geomQuenua({ q }, 57), geomQuenua({ q }, 83)],
+    [q],
+  );
+  const mat = useMemo(
+    () => (perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.92, metalness: 0 })
+      : new THREE.MeshLambertMaterial({ vertexColors: true })),
+    [perfil.materialRico],
+  );
+  useLayoutEffect(() => () => {
+    variantes.forEach((g) => g.dispose());
+    mat.dispose();
+  }, [variantes, mat]);
+  return (
+    <group>
+      {[0, 1, 2].map((v) => (
+        <BancoInstancias
+          key={v}
+          geo={variantes[v]}
+          mat={mat}
+          items={sitios.filter((s) => s.variante === v)}
+          castShadow={perfil.sombras}
+        />
       ))}
     </group>
   );
 }
 
-function Diorama({ tier, reducedMotion }) {
-  const perfil = perfilDeTier(tier);
+/* ── HOJARASCA + TRONCOS CAÍDOS ──────────────────────────────────────────── */
+function Hojarasca({ tier }) {
+  const n = tier === 'alto' ? 150 : tier === 'medio' ? 80 : 0;
+  const items = useMemo(() => sitiosHojarasca(n), [n]);
+  const geo = useMemo(() => geomLosetaHojarasca(), []);
+  const mat = useMemo(() => new THREE.MeshLambertMaterial({ color: '#ffffff' }), []);
+  useLayoutEffect(() => () => {
+    geo.dispose();
+    mat.dispose();
+  }, [geo, mat]);
+  if (!n) return null;
+  return <BancoInstancias geo={geo} mat={mat} items={items} />;
+}
 
-  const pajas = useMemo(() => {
-    if (tier === 'bajo') return [];
-    const r = rng(202);
-    const n = tier === 'alto' ? 26 : 14;
-    return Array.from({ length: n }, (_, i) => {
-      const a = r() * Math.PI * 2;
-      const rad = 1.6 + r() * 4;
-      return { key: `pj-${i}`, pos: [Math.cos(a) * rad, 0, Math.sin(a) * rad] };
-    });
-  }, [tier]);
+function TroncosCaidos({ tier, perfil }) {
+  const q = tier === 'alto' ? 1 : 0.62;
+  const geo = useMemo(() => geomTroncosCaidos(q), [q]);
+  const mat = useMemo(
+    () => (perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.95, metalness: 0 })
+      : new THREE.MeshLambertMaterial({ vertexColors: true })),
+    [perfil.materialRico],
+  );
+  useLayoutEffect(() => () => {
+    geo.dispose();
+    mat.dispose();
+  }, [geo, mat]);
+  return <mesh geometry={geo} material={mat} castShadow={perfil.sombras} receiveShadow={perfil.sombras} />;
+}
+
+/* ── EL ARROYO — el hilo de agua que baja de la niebla ───────────────────── */
+function Arroyo({ nocturno, perfil }) {
+  const rico = perfil.materialRico;
+  const ref = useRef(null);
+  const geo = useMemo(
+    () => new THREE.TubeGeometry(curvaArroyo(), rico ? 72 : 44, 0.21, rico ? 6 : 5, false),
+    [rico],
+  );
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  useFrame((state) => {
+    if (ref.current) {
+      ref.current.opacity = 0.72 + Math.sin(state.clock.elapsedTime * 1.7) * 0.06;
+    }
+  });
+  return (
+    <mesh geometry={geo}>
+      {rico ? (
+        <meshStandardMaterial
+          ref={ref}
+          color="#5fa8bd"
+          emissive={nocturno ? '#3f6f9e' : '#000000'}
+          emissiveIntensity={nocturno ? 0.42 : 0}
+          transparent
+          opacity={0.75}
+          roughness={0.25}
+          metalness={0.3}
+        />
+      ) : (
+        <meshLambertMaterial
+          ref={ref}
+          color="#5fa8bd"
+          emissive={nocturno ? '#3f6f9e' : '#000000'}
+          emissiveIntensity={nocturno ? 0.42 : 0}
+          transparent
+          opacity={0.75}
+        />
+      )}
+    </mesh>
+  );
+}
+
+/* ── RAYOS DE SOL COLADOS (godrays baratos) ────────────────────────────────
+      Láminas aditivas con textura canvas (gradiente que se apaga hacia el
+      suelo), orientadas HACIA el sol de la franja. Fuertes al amanecer y la
+      tarde, tímidos al mediodía, apagados de noche. Solo tier alto. */
+const OPACIDAD_RAYOS = {
+  amanecer: 0.3, manana: 0.22, mediodia: 0.08, tarde: 0.22, atardecer: 0.28, noche: 0,
+};
+
+function texturaRayo() {
+  const cv = document.createElement('canvas');
+  cv.width = 64;
+  cv.height = 256;
+  const ctx = cv.getContext('2d');
+  const g = ctx.createLinearGradient(0, 0, 0, 256);
+  g.addColorStop(0, 'rgba(255,244,214,0.85)');
+  g.addColorStop(0.55, 'rgba(255,240,200,0.3)');
+  g.addColorStop(1, 'rgba(255,240,200,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, 64, 256);
+  // Bordes laterales suaves (destination-in recorta con un gradiente horizontal).
+  const h = ctx.createLinearGradient(0, 0, 64, 0);
+  h.addColorStop(0, 'rgba(0,0,0,0)');
+  h.addColorStop(0.25, 'rgba(0,0,0,1)');
+  h.addColorStop(0.75, 'rgba(0,0,0,1)');
+  h.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.globalCompositeOperation = 'destination-in';
+  ctx.fillStyle = h;
+  ctx.fillRect(0, 0, 64, 256);
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+const LAMINAS_RAYO = [
+  { ox: -2.6, oz: 1.2, w: 0.9, l: 11, giro: 0.3 },
+  { ox: -0.8, oz: -1.8, w: 1.4, l: 12.5, giro: 1.2 },
+  { ox: 1.4, oz: 0.6, w: 0.7, l: 10, giro: 2.1 },
+  { ox: 3.1, oz: -1.1, w: 1.1, l: 12, giro: 0.8 },
+  { ox: -4.4, oz: -0.4, w: 0.8, l: 10.5, giro: 1.7 },
+];
+
+const _UP = new THREE.Vector3(0, 1, 0);
+
+function RayosDeSol({ franja, reducedMotion }) {
+  const grupo = useRef(null);
+  const tex = useMemo(() => texturaRayo(), []);
+  const mat = useMemo(
+    () => new THREE.MeshBasicMaterial({
+      map: tex,
+      transparent: true,
+      opacity: 0,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      fog: false,
+    }),
+    [tex],
+  );
+  // Lámina con el pivote en la punta de abajo (crece hacia el sol).
+  const geo = useMemo(() => {
+    const g = new THREE.PlaneGeometry(1, 1);
+    g.translate(0, 0.5, 0);
+    return g;
+  }, []);
+  useLayoutEffect(() => () => {
+    tex.dispose();
+    mat.dispose();
+    geo.dispose();
+  }, [tex, mat, geo]);
+
+  const objetivo = useMemo(() => {
+    const p = presetBosque(franja);
+    const d = new THREE.Vector3(p.solPos[0], p.solPos[1], p.solPos[2]).normalize();
+    // Elevación mínima: aunque el sol esté rasante, la luz colada cae en
+    // DIAGONAL entre las copas (sin esto, al amanecer las láminas se tienden
+    // horizontales y se delatan como bandas planas cruzando el cielo).
+    d.y = Math.max(d.y, 0.6);
+    d.normalize();
+    return {
+      op: OPACIDAD_RAYOS[franja] ?? 0.2,
+      quat: new THREE.Quaternion().setFromUnitVectors(_UP, d),
+    };
+  }, [franja]);
+
+  useFrame((state, dt) => {
+    const g = grupo.current;
+    if (!g) return;
+    const k = reducedMotion ? 1 : 1 - Math.exp(-1.2 * Math.min(dt, 0.1));
+    g.quaternion.slerp(objetivo.quat, k);
+    const t = state.clock.elapsedTime;
+    const pulso = reducedMotion ? 1 : 0.85 + 0.15 * Math.sin(t * 0.23);
+    // El material se alcanza por el grafo (todas las láminas lo comparten):
+    // mismo patrón que NieblaRasante — cero setState, cero alocación.
+    const m = g.children[0]?.children[0]?.material;
+    if (m) m.opacity += (objetivo.op * pulso - m.opacity) * k;
+  });
+
+  return (
+    <group ref={grupo} position={[0, 0.2, 0]}>
+      {LAMINAS_RAYO.map((l, i) => (
+        <group key={i} position={[l.ox, 0, l.oz]} rotation={[0, l.giro, 0]}>
+          <mesh geometry={geo} material={mat} scale={[l.w, l.l, 1]} />
+          <mesh geometry={geo} material={mat} scale={[l.w, l.l, 1]} rotation={[0, Math.PI / 2, 0]} />
+        </group>
+      ))}
+    </group>
+  );
+}
+
+/* ── BRUMA POR CAPAS (la niebla volumétrica falsa con parallax) ────────────
+      Cartas grandes billboard a radios crecientes: al orbitar, las capas se
+      deslizan a velocidades distintas y el bosque gana profundidad física.
+      La franja pesa: más bruma al amanecer y de noche. */
+const CAPAS_BRUMA = [
+  { rad: 13.5, y: 2.3, w: 24, h: 5.5, op: 0.16, vel: 0.011, fase: 0 },
+  { rad: 17, y: 3.1, w: 32, h: 7, op: 0.14, vel: -0.008, fase: 2.2 },
+  { rad: 21.5, y: 4.2, w: 42, h: 9, op: 0.12, vel: 0.006, fase: 4.1 },
+  { rad: 26, y: 5.6, w: 54, h: 11, op: 0.1, vel: -0.004, fase: 1.3 },
+];
+const PESO_BRUMA = {
+  amanecer: 1.4, manana: 1.0, mediodia: 0.65, tarde: 0.9, atardecer: 1.25, noche: 1.15,
+};
+
+function texturaBruma(seed = 7) {
+  const cv = document.createElement('canvas');
+  cv.width = 256;
+  cv.height = 128;
+  const ctx = cv.getContext('2d');
+  let s = seed;
+  const r = () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+  for (let i = 0; i < 10; i++) {
+    const x = 20 + r() * 216;
+    const y = 30 + r() * 68;
+    const rad = 28 + r() * 55;
+    const a = 0.16 + r() * 0.2;
+    const g = ctx.createRadialGradient(x, y, 0, x, y, rad);
+    g.addColorStop(0, `rgba(238,244,242,${a})`);
+    g.addColorStop(1, 'rgba(238,244,242,0)');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 256, 128);
+  }
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+function BrumaParallax({ franja, reducedMotion }) {
+  const grupo = useRef(null);
+  const peso = useRef(1);
+  const tex = useMemo(() => texturaBruma(), []);
+  const mats = useMemo(
+    () => CAPAS_BRUMA.flatMap((c) => [0, 1].map(() => new THREE.MeshBasicMaterial({
+      map: tex,
+      transparent: true,
+      opacity: c.op,
+      depthWrite: false,
+      fog: false,
+    }))),
+    [tex],
+  );
+  useLayoutEffect(() => () => {
+    tex.dispose();
+    mats.forEach((m) => m.dispose());
+  }, [tex, mats]);
+
+  useFrame((state, dt) => {
+    const g = grupo.current;
+    if (!g) return;
+    const t = state.clock.elapsedTime;
+    const k = reducedMotion ? 1 : 1 - Math.exp(-0.8 * Math.min(dt, 0.1));
+    peso.current += ((PESO_BRUMA[franja] ?? 1) - peso.current) * k;
+    let idx = 0;
+    for (let c = 0; c < CAPAS_BRUMA.length; c++) {
+      const capa = CAPAS_BRUMA[c];
+      for (let lado = 0; lado < 2; lado++) {
+        const carta = g.children[idx];
+        if (!carta) break;
+        const az = capa.fase + lado * Math.PI + (reducedMotion ? 0 : t * capa.vel);
+        carta.position.set(
+          Math.cos(az) * capa.rad,
+          capa.y + (reducedMotion ? 0 : Math.sin(t * 0.05 + capa.fase + lado) * 0.25),
+          Math.sin(az) * capa.rad,
+        );
+        carta.quaternion.copy(state.camera.quaternion);
+        carta.material.opacity = capa.op * peso.current
+          * (reducedMotion ? 1 : 0.9 + 0.1 * Math.sin(t * 0.07 + capa.fase * 2 + lado * 3));
+        idx++;
+      }
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {CAPAS_BRUMA.flatMap((c, ci) => [0, 1].map((lado) => (
+        <mesh key={`${ci}-${lado}`} material={mats[ci * 2 + lado]}>
+          <planeGeometry args={[c.w, c.h]} />
+        </mesh>
+      )))}
+    </group>
+  );
+}
+
+/* ── LA CÁMARA: pose de reposo consciente del ASPECTO ──────────────────────
+      En landscape la pose aprobada (leve contrapicado que hace imponente al
+      guardián, el arroyo entrando por la derecha del cuadro). En un teléfono
+      parado la cámara retrocede y sube apenas: el fov vertical alcanza y el
+      Ent respira sin perder el queñual de los flancos. */
+const POSE_BOSQUE = { position: [8.0, 2.55, 11.6], fov: 42, mira: [0, 3.0, 0] };
+
+function poseBosqueParaAspecto(aspect) {
+  if (!aspect || aspect >= 0.9) return { ...POSE_BOSQUE, k: 1 };
+  const t = Math.min(1, (0.9 - aspect) / 0.44);
+  const B = { position: [10.6, 4.4, 15.4], fov: 56, mira: [0, 2.7, 0] };
+  const lerp = (a, b) => a + (b - a) * t;
+  const position = POSE_BOSQUE.position.map((v, i) => lerp(v, B.position[i]));
+  const mira = POSE_BOSQUE.mira.map((v, i) => lerp(v, B.mira[i]));
+  const dist = (p, m) => Math.hypot(p[0] - m[0], p[1] - m[1], p[2] - m[2]);
+  return {
+    position,
+    fov: Math.round(lerp(POSE_BOSQUE.fov, B.fov)),
+    mira,
+    k: dist(position, mira) / dist(POSE_BOSQUE.position, POSE_BOSQUE.mira),
+  };
+}
+
+/* ── EL DIORAMA ──────────────────────────────────────────────────────────── */
+function Diorama({ tier, reducedMotion, pose }) {
+  const perfil = perfilDeTier(tier);
+  const controls = useRef(null);
+  const { franja } = useCicloDia({ reducedMotion });
+  const nocturno = franja === 'noche';
+  const fracEstrellas = presetBosque(franja).estrellas;
 
   return (
     <>
-      <color attach="background" args={[PARAMO.fondo]} />
-      {perfil.fog && <fog attach="fog" args={[PARAMO.niebla, 9, 34]} />}
+      {/* Atmósfera del ciclo de día: fondo + niebla + las cuatro luces. */}
+      <AtmosferaBosque franja={franja} perfil={perfil} reducedMotion={reducedMotion} />
+      {fracEstrellas > 0 && perfil.estrellas > 0 && (
+        <Stars
+          radius={44}
+          depth={22}
+          count={Math.max(24, Math.round(perfil.estrellas * fracEstrellas))}
+          factor={3}
+          fade
+          speed={reducedMotion ? 0 : 1}
+        />
+      )}
 
-      {/* luz de páramo: cielo frío, sol tenue y velado */}
-      <hemisphereLight intensity={0.95} color="#d7e2e4" groundColor="#3a3a2c" />
-      <ambientLight intensity={0.35} color="#cdd7da" />
-      <directionalLight
-        position={[6, 11, 5]}
-        intensity={1.15}
-        color="#eef3f0"
-        castShadow={perfil.sombras}
-        shadow-mapSize-width={1024}
-        shadow-mapSize-height={1024}
-        shadow-camera-near={1}
-        shadow-camera-far={30}
-        shadow-camera-left={-8}
-        shadow-camera-right={8}
-        shadow-camera-top={10}
-        shadow-camera-bottom={-4}
-      />
-      {/* contraluz frío que separa la copa de la niebla */}
-      <directionalLight position={[-5, 6, -6]} intensity={0.4} color="#b9cdd6" />
+      {/* El anfiteatro: terreno con relieve, pintado por vértice. */}
+      <TerrenoBosque nocturno={nocturno} perfil={perfil} />
 
-      {/* suelo de musgo del páramo */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]} receiveShadow>
-        <circleGeometry args={[32, 40]} />
-        <meshLambertMaterial color={PARAMO.suelo} />
-      </mesh>
-      {/* parche de musgo húmedo bajo el árbol */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.01, 0]}>
-        <circleGeometry args={[3.4, 28]} />
-        <meshLambertMaterial color={PARAMO.musgo} />
-      </mesh>
-      {/* sombra de contacto suave (barata, en todos los tiers) */}
+      {/* El queñual: héroes que enmarcan + siluetas lejanas en la niebla. */}
+      <Quenual tier={tier} perfil={perfil} />
+
+      {/* El suelo vivido: hojarasca y madera muerta con musgo. */}
+      <Hojarasca tier={tier} />
+      <TroncosCaidos tier={tier} perfil={perfil} />
+
+      {/* El arroyo que baja de la niebla (de noche, lo que más brilla). */}
+      {tier !== 'bajo' && <Arroyo nocturno={nocturno} perfil={perfil} />}
+
+      {/* El ECOSISTEMA de páramo (frailejonar, sotobosque, árboles vecinos),
+          POSADO sobre el relieve con alturaDe. */}
+      <FloraParamo tier={tier} reducedMotion={reducedMotion} alturaDe={alturaBosque} />
+
+      {/* LA VIDA: cóndor, vecinos rubber-hose, mariposas, luciérnagas. */}
+      <FaunaBosque tier={tier} reducedMotion={reducedMotion} />
+
+      {/* Luz que se cuela entre las copas (solo donde sobra GPU). */}
+      {perfil.materialRico && <RayosDeSol franja={franja} reducedMotion={reducedMotion} />}
+
+      {/* La bruma con parallax que da profundidad física al orbitar. */}
+      {perfil.fog && <BrumaParallax franja={franja} reducedMotion={reducedMotion} />}
+
+      {/* Sombra de contacto del guardián (todos los tiers: lo planta). */}
       {perfil.sombrasContacto && (
-        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.02, 0]}>
-          <circleGeometry args={[1.6, 24]} />
-          <meshBasicMaterial color="#2c3324" transparent opacity={0.4} />
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.03, 0]}>
+          <circleGeometry args={[1.7, 24]} />
+          <meshBasicMaterial color="#20281c" transparent opacity={0.38} />
         </mesh>
       )}
 
-      {/* colinas lejanas que se pierden en la niebla */}
-      <mesh position={[-9, 0.5, -12]} scale={[6, 2.4, 4]}>
-        <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#59654b" />
-      </mesh>
-      <mesh position={[10, 0.4, -14]} scale={[7, 2.1, 4]}>
-        <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color="#515e46" />
-      </mesh>
-
-      {pajas.map((p) => (
-        <Paja key={p.key} pos={p.pos} />
-      ))}
-
-      {/* EL ECOSISTEMA de páramo: frailejonar, sotobosque, árboles de niebla,
-          rocas, musgo y vaho. Alrededor del guardián, sin taparlo. */}
-      <FloraParamo tier={tier} reducedMotion={reducedMotion} />
-
-      {/* LA VIDA: el cóndor arriba, los vecinos en su casa, mariposas y
-          abejas sobre el frailejonar. Un bosque sin bichos es un decorado. */}
-      <FaunaBosque tier={tier} reducedMotion={reducedMotion} />
-
-      {/* EL GUARDIÁN */}
-      <EntQuenua tier={tier} reducedMotion={reducedMotion} />
+      {/* ══ MOUNT DEL ENT ══ El guardián vive AQUÍ (origen del claro). Otra
+          rama lo eleva de calibre: inyectar el Ent nuevo en este group sin
+          tocar el resto del escenario. */}
+      <group name="mount-ent">
+        <EntQuenua tier={tier} reducedMotion={reducedMotion} />
+      </group>
 
       <OrbitControls
+        ref={controls}
         makeDefault
-        target={[0, 3.2, 0]}
+        target={pose.mira}
         enablePan={false}
         enableZoom
-        minDistance={7}
-        maxDistance={20}
-        minPolarAngle={0.55}
-        maxPolarAngle={1.5}
+        minDistance={6}
+        maxDistance={Math.max(20, Math.ceil(16 * pose.k) + 5)}
+        minPolarAngle={0.5}
+        maxPolarAngle={1.42}
         enableDamping
         dampingFactor={0.08}
         autoRotate={!reducedMotion}
-        autoRotateSpeed={0.16}
+        autoRotateSpeed={0.1}
+      />
+      {/* La LLEGADA: dolly de establecimiento (una vez por sesión) — la
+          cámara arranca mirando al dosel y baja al rostro del guardián. */}
+      <CamaraDirector
+        controls={controls}
+        reposo={pose.position}
+        mirada={[0, 4.6, 0]}
+        duracion={2.6}
+        amplio={1.35}
+        respiro={0.045}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="bosqueTakeA"
       />
       <AdaptiveDpr pixelated />
     </>
@@ -148,23 +692,33 @@ function Diorama({ tier, reducedMotion }) {
 }
 
 /**
- * El mundo Bosque Vivo con el Ent de la queñua. Montar SOLO perezosa.
+ * El mundo Bosque Vivo con el Ent de la queñua (TAKE A). Montar SOLO perezosa.
  * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
  */
 export default function EscenaBosqueVivo({ tier = 'alto', reducedMotion = false }) {
   const perfil = perfilDeTier(tier);
   const [listo, setListo] = useState(false);
+  const pose = useMemo(
+    () => poseBosqueParaAspecto(
+      typeof window !== 'undefined' && window.innerHeight > 0
+        ? window.innerWidth / window.innerHeight
+        : 1,
+    ),
+    [],
+  );
   return (
     <Canvas
       className={`bviva-canvas${listo ? ' bviva-canvas--lista' : ''}`}
       dpr={perfil.dpr}
       gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
       shadows={perfil.sombras ? 'soft' : false}
-      camera={{ position: [1.5, 2.3, 12.5], fov: 44 }}
+      camera={/** @type {any} */ ({ position: pose.position, fov: pose.fov })}
       frameloop={reducedMotion ? 'demand' : 'always'}
       onCreated={() => setListo(true)}
     >
-      <Diorama tier={tier} reducedMotion={reducedMotion} />
+      <Suspense fallback={null}>
+        <Diorama tier={tier} reducedMotion={reducedMotion} pose={pose} />
+      </Suspense>
     </Canvas>
   );
 }

--- a/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
+++ b/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
@@ -33,12 +33,14 @@ import { perfilDeTier } from '../deviceTier.js';
 import useCicloDia from '../useCicloDia.js';
 import { CIELOS_HORA, TRANSICION, mezclaHex } from '../cielosHoraData.js';
 import CamaraDirector from '../escenas/CamaraDirector.jsx';
+import { SombraContacto } from '../escenas/SombraContacto.jsx';
+import SueloRico from '../terreno/SueloRico.jsx';
 import EntQuenua from './EntQuenua.jsx';
 import FloraParamo from './FloraParamo.jsx';
 import FaunaBosque from './FaunaBosque.jsx';
 import {
   alturaBosque,
-  geomTerrenoBosque,
+  sueloDelBosque,
   geomQuenua,
   sitiosQuenual,
   geomLosetaHojarasca,
@@ -207,22 +209,6 @@ function AtmosferaBosque({ franja, perfil, reducedMotion }) {
         color={ini.relleno}
       />
     </>
-  );
-}
-
-/* ── EL TERRENO ──────────────────────────────────────────────────────────── */
-function TerrenoBosque({ nocturno, perfil }) {
-  const seg = Math.round(perfil.segmentosTerreno * 1.6);
-  const geo = useMemo(() => geomTerrenoBosque({ seg, nocturno }), [seg, nocturno]);
-  useLayoutEffect(() => () => geo.dispose(), [geo]);
-  return (
-    <mesh geometry={geo} receiveShadow={perfil.sombras}>
-      {perfil.materialRico ? (
-        <meshStandardMaterial vertexColors roughness={1} metalness={0} />
-      ) : (
-        <meshLambertMaterial vertexColors />
-      )}
-    </mesh>
   );
 }
 
@@ -579,6 +565,10 @@ function BrumaParallax({ franja, reducedMotion }) {
       Ent respira sin perder el queñual de los flancos. */
 const POSE_BOSQUE = { position: [8.0, 2.55, 11.6], fov: 42, mira: [0, 3.0, 0] };
 
+/* Anclas de sombra de contacto que la escena le pasa a SueloRico: el claro del
+   guardián (el Ent es el objeto mayor y necesita el AO ancho que lo planta). */
+const ANCLAS_SUELO = [{ x: 0, z: 0, radio: 1.7 }];
+
 function poseBosqueParaAspecto(aspect) {
   if (!aspect || aspect >= 0.9) return { ...POSE_BOSQUE, k: 1 };
   const t = Math.min(1, (0.9 - aspect) / 0.44);
@@ -618,8 +608,11 @@ function Diorama({ tier, reducedMotion, pose }) {
         />
       )}
 
-      {/* El anfiteatro: terreno con relieve, pintado por vértice. */}
-      <TerrenoBosque nocturno={nocturno} perfil={perfil} />
+      {/* El anfiteatro: el SUELO RICO compartido (relieve fbm, color por zona,
+          sendero que entra al claro, detalle al ras) sobre el contrato del
+          bosque (sueloDelBosque = suelo rico + pared del anfiteatro + cañada).
+          El guardián recibe su sombra de contacto como ancla de la escena. */}
+      <SueloRico suelo={sueloDelBosque} tier={tier} anclas={ANCLAS_SUELO} />
 
       {/* El queñual: héroes que enmarcan + siluetas lejanas en la niebla. */}
       <Quenual tier={tier} perfil={perfil} />
@@ -644,12 +637,11 @@ function Diorama({ tier, reducedMotion, pose }) {
       {/* La bruma con parallax que da profundidad física al orbitar. */}
       {perfil.fog && <BrumaParallax franja={franja} reducedMotion={reducedMotion} />}
 
-      {/* Sombra de contacto del guardián (todos los tiers: lo planta). */}
-      {perfil.sombrasContacto && (
-        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.03, 0]}>
-          <circleGeometry args={[1.7, 24]} />
-          <meshBasicMaterial color="#20281c" transparent opacity={0.38} />
-        </mesh>
+      {/* Sombra de contacto del guardián. En alto/medio la pone SueloRico (ancla
+          de la escena); en 'bajo' SueloRico no dibuja sombras, así que el kit la
+          planta acá para que el Ent no flote. */}
+      {!perfil.sombrasContacto && (
+        <SombraContacto pos={[0, 0.04, 0]} radio={1.6} color="#20281c" opacidad={0.34} orden={2} />
       )}
 
       {/* ══ MOUNT DEL ENT ══ El guardián vive AQUÍ (origen del claro). Otra

--- a/src/visual/mundo3d/bosque/FloraParamo.jsx
+++ b/src/visual/mundo3d/bosque/FloraParamo.jsx
@@ -52,7 +52,9 @@ function Especie({ geo, mat, items, castShadow = false }) {
     for (let i = 0; i < items.length; i++) {
       const it = items[i];
       p.set(it.pos[0], it.pos[1], it.pos[2]);
-      e.set(0, it.rotY, 0);
+      // tiltX/tiltZ: ladeo por instancia (frailejonar) — cada mata cabecea
+      // distinto para que la colonia no se lea clonada. Pivote en la base.
+      e.set(it.tiltX || 0, it.rotY, it.tiltZ || 0);
       q.setFromEuler(e);
       s.setScalar(it.escala);
       m.compose(p, q, s);
@@ -170,10 +172,15 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false, altu
   const q = calidadDeTier(tier);
 
   // --- Geometrías fusionadas (una vez por tier). Solo lo que tenga matas. ---
+  // El frailejón viene en TRES edades (silueta distinta, no solo escala): joven
+  // casi al ras, adulto de columna media, viejo de hábito alto. Cada edad es su
+  // banco → el frailejonal se lee como un paisaje con gradiente de edad.
   const geos = useMemo(() => {
     const g = {};
-    if (conteos.frailejon) g.frailejon = geomFrailejon({ flor: false, q }, 1);
-    if (conteos.frailejonFlor) g.frailejonFlor = geomFrailejon({ flor: true, q }, 2);
+    if (conteos.frailejonJoven) g.frailejonJoven = geomFrailejon({ flor: false, q, edad: 0.26 }, 21);
+    if (conteos.frailejon) g.frailejon = geomFrailejon({ flor: false, q, edad: 0.62 }, 1);
+    if (conteos.frailejonViejo) g.frailejonViejo = geomFrailejon({ flor: false, q, edad: 0.95 }, 37);
+    if (conteos.frailejonFlor) g.frailejonFlor = geomFrailejon({ flor: true, q, edad: 0.78 }, 2);
     if (conteos.yarumo) g.yarumo = geomYarumo({ q }, 3);
     if (conteos.roble) g.roble = geomRoble({ q }, 4);
     if (conteos.encenillo) g.encenillo = geomEncenillo({ q }, 5);
@@ -223,8 +230,11 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false, altu
       <Especie geo={geos.romerillo} mat={mat} items={dist.romerillo} />
       <Especie geo={geos.mortino} mat={mat} items={dist.mortino} />
 
-      {/* Frailejonar: el ícono del páramo, al frente. */}
+      {/* Frailejonar: el ícono del páramo, al frente — tres EDADES entremezcladas
+          (joven al ras, adulto, viejo de columna alta) + los que florecen. */}
+      <Especie geo={geos.frailejonJoven} mat={mat} items={dist.frailejonJoven} />
       <Especie geo={geos.frailejon} mat={mat} items={dist.frailejon} />
+      <Especie geo={geos.frailejonViejo} mat={mat} items={dist.frailejonViejo} />
       <Especie geo={geos.frailejonFlor} mat={mat} items={dist.frailejonFlor} />
 
       {/* Árboles de fondo (anillo exterior, velados por la niebla). */}

--- a/src/visual/mundo3d/bosque/FloraParamo.jsx
+++ b/src/visual/mundo3d/bosque/FloraParamo.jsx
@@ -160,9 +160,11 @@ function NieblaRasante({ n, reducedMotion }) {
 
 /**
  * La capa de flora del páramo alrededor del Ent. Montar dentro del <Canvas>.
- * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ * `alturaDe(x,z)` (opcional) POSA cada mata sobre el relieve del terreno:
+ * sin ella la siembra queda en y=0 (el claro plano de siempre).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, alturaDe?: ((x:number,z:number)=>number)|null}} props
  */
-export default function FloraParamo({ tier = 'alto', reducedMotion = false }) {
+export default function FloraParamo({ tier = 'alto', reducedMotion = false, alturaDe = null }) {
   const perfil = perfilDeTier(tier);
   const conteos = floraDeTier(tier);
   const q = calidadDeTier(tier);
@@ -192,8 +194,16 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false }) {
       : new THREE.MeshLambertMaterial(base);
   }, [perfil.materialRico, perfil.flatShading]);
 
-  // --- Distribución biogeográfica (una vez por tier). ---
-  const dist = useMemo(() => distribucionFlora(conteos, 707), [conteos]);
+  // --- Distribución biogeográfica (una vez por tier), posada en el relieve. ---
+  const dist = useMemo(() => {
+    const d = distribucionFlora(conteos, 707);
+    if (!alturaDe) return d;
+    const posar = (items) => items.map((it) => ({
+      ...it,
+      pos: [it.pos[0], alturaDe(it.pos[0], it.pos[2]) + (it.pos[1] || 0), it.pos[2]],
+    }));
+    return Object.fromEntries(Object.entries(d).map(([k, v]) => [k, posar(v)]));
+  }, [conteos, alturaDe]);
 
   // Liberar GPU al desmontar.
   useLayoutEffect(() => () => {

--- a/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
+++ b/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
@@ -19,11 +19,9 @@
  *   · three core puro: corre headless, sin contexto GL.
  */
 import * as THREE from 'three';
-import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
 import {
   rng,
-  ruidoFbm,
-  desindexar,
+  fusionarSeguro,
   poner,
   apuntar,
   pintarPlano,
@@ -34,184 +32,110 @@ import {
   taperLineal,
   curvaTronco,
   sembrarFollaje,
+  matojoNube,
 } from './sombreadoVegetal.js';
+import { crearSueloRico } from '../terreno/sueloRico.geom.js';
 
 const ss = THREE.MathUtils.smoothstep;
 
+/* Fusión que PRESERVA las normales radiales de las copas-nube (matojoNube):
+   la opción canónica del taller — nada de reimplementar la trampa del null. */
+const fusionarConNormales = (partes, etiqueta) => fusionarSeguro(partes, etiqueta, { preservarNormales: true });
+
 /* -------------------------------------------------------------------------- */
-/*  Fusión que PRESERVA normales                                               */
+/*  EL TERRENO — el anfiteatro del bosque de niebla, sobre el SUELO RICO       */
 /* -------------------------------------------------------------------------- */
 
 /*
- * fusionarSeguro (del taller) recalcula normales al final — correcto para la
- * flora facetada, letal para las copas-nube: sus normales RADIALES (puestas a
- * mano) son lo que las hace leerse como masa suave de hojas y no como
- * icosaedros. Esta variante desindexa, truena si el merge da null, y respeta
- * las normales que cada parte ya trae.
- */
-function fusionarConNormales(partes, etiqueta = 'sin-nombre') {
-  const buenas = partes.filter(Boolean).map(desindexar);
-  if (!buenas.length) {
-    throw new Error(`[bosqueTakeA] "${etiqueta}": no hay partes que fusionar.`);
-  }
-  const refAttrs = Object.keys(buenas[0].attributes).sort().join(',');
-  for (let i = 0; i < buenas.length; i++) {
-    const attrs = Object.keys(buenas[i].attributes).sort().join(',');
-    if (attrs !== refAttrs) {
-      throw new Error(
-        `[bosqueTakeA] "${etiqueta}": la parte ${i} tiene atributos [${attrs}] `
-        + `pero se esperaba [${refAttrs}] — mergeGeometries devolvería null.`,
-      );
-    }
-  }
-  const g = mergeGeometries(buenas, false);
-  if (!g) {
-    throw new Error(
-      `[bosqueTakeA] "${etiqueta}": mergeGeometries devolvió NULL — la pieza `
-      + 'habría quedado invisible sin error.',
-    );
-  }
-  return g;
-}
-
-/* -------------------------------------------------------------------------- */
-/*  EL TERRENO — el anfiteatro del bosque de niebla                            */
-/* -------------------------------------------------------------------------- */
-
-/*
- * Altura del terreno en (x,z). La composición:
- *   · CLARO central plano (r<3.2): el Ent y los vecinos viven en y≈0 — la
- *     fauna billboard y las raíces del guardián no flotan ni se entierran.
- *   · ONDULACIÓN media (r 3.2→9.5): lomos suaves de musgo, el microrelieve
- *     que hace que el suelo deje de ser una mesa.
- *   · PARED del anfiteatro (r>12.5): la ladera trepa hasta ~6 con crestas
- *     irregulares por ángulo — el cuenco que la niebla se come al fondo.
- *   · CAÑADA del arroyo: una vaguada honda que baja del fondo brumoso y
+ * El relieve es una COMPOSICIÓN: el sistema compartido `crearSueloRico`
+ * (heightfield fbm con warp de dominio + claro central llano + SENDERO que
+ * recorta el relieve — el suelo calibre consola de toda escena) MÁS la
+ * identidad del bosque de niebla, que el sistema no conoce:
+ *   · la PARED del anfiteatro (r>12.5) que trepa hasta ~6 con crestas
+ *     irregulares por ángulo — el cuenco que la niebla se come al fondo;
+ *   · la CAÑADA del arroyo: la vaguada honda que baja del fondo brumoso y
  *     cruza el flanco derecho del claro.
- * Determinista y barata: los objetos se POSAN encima con esta misma función.
+ * Determinista y barata: TODO lo que se siembra se posa con `alturaBosque`.
  */
 export function xArroyo(z) {
   return 4.7 + Math.sin(z * 0.24 + 1.3) * 1.5;
 }
 
-export function alturaBosque(x, z) {
+/* La identidad del anfiteatro (lo que crearSueloRico no sabe). */
+function extraAnfiteatro(x, z) {
   const r = Math.hypot(x, z);
   const ang = Math.atan2(z, x);
-  const onda = (Math.sin(x * 0.52 + 1.7) * Math.cos(z * 0.47 - 0.6) * 0.36
-    + Math.sin(x * 1.25 - z * 0.85 + 2.1) * 0.13) * ss(r, 3.2, 9.5);
-  const micro = (Math.sin(x * 2.6 + z * 1.9) * 0.04
-    + Math.cos(x * 1.7 - z * 2.8) * 0.035) * ss(r, 2.2, 5);
   const cresta = 1 + 0.34 * Math.sin(ang * 3 + 1.2)
     + 0.2 * Math.sin(ang * 7 - 0.7)
     + 0.12 * Math.sin(ang * 13 + 2.3);
   const pared = ss(r, 12.5, 30) ** 1.25 * 4.8 * cresta;
   const dx = x - xArroyo(z);
   const canada = -0.4 * Math.exp(-(dx * dx) / 1.15) * ss(z, -13, -6) * (1 - ss(r, 20, 28));
-  return onda + micro + pared + canada;
+  return pared + canada;
 }
 
-/* Paleta del suelo (musgo, hojarasca, tierra pisada, humedad, roca). */
-const SUELO = {
-  musgoOscuro: new THREE.Color('#3d4b2c'),
-  musgoClaro: new THREE.Color('#5a6b3a'),
-  hojarasca: new THREE.Color('#6e5838'),
-  hojarasca2: new THREE.Color('#7d6a44'),
-  tierra: new THREE.Color('#5c4a33'),
-  humedo: new THREE.Color('#2f3d2b'),
-  roca: new THREE.Color('#7b8074'),
-  rocaOscura: new THREE.Color('#5d6156'),
-  noche: new THREE.Color('#243349'),
+/* Paleta del bosque de niebla para el suelo rico: musgo hondo en vez de pasto
+   de páramo, trillo pardo húmedo, roca fría — el mood de la toma A. */
+export const PALETA_BOSQUE = {
+  base: '#48552f', // musgo del claro
+  pastoVivo: '#5a6b3a', // musgo claro (nubes grandes de mota)
+  humedo: '#2f3d2b', // hondonadas y la orilla de la cañada
+  seco: '#7e7a4e', // lomos apenas pajizos (bosque húmedo: sin oro de páramo)
+  hojarasca: '#6e5838', // manto pardo bajo el queñual
+  tierraSenda: '#8a7048', // el trillo pisado que entra al claro
+  tierraHumeda: '#4c3f2e',
+  roca: '#7b8074', // piedra fría del anfiteatro
+  rocaClara: '#989b8c',
+  liquen: '#9aa86a',
+  raiz: '#5b4a35',
+  paja: '#8f855a',
+  pajaVerde: '#66713f',
+  flor: '#e8e3c9',
+  florMiel: '#d9b45a',
 };
 
-export const LADO_TERRENO = 64;
+/* El trillo: entra por el flanco izquierdo del frente y muere en el claro del
+   guardián (la afordancia de "por aquí se llega") — lejos del arroyo. */
+const PUNTOS_SENDERO = /** @type {Array<[number, number]>} */ ([
+  [-15.5, 11.5], [-11.5, 8.6], [-8.2, 6.3], [-5.2, 4.4], [-2.7, 2.3], [-0.9, 0.6],
+]);
 
-/*
- * La malla del terreno, PINTADA por vértice: musgo moteado de base, parches de
- * hojarasca bajo el anillo de árboles, el patio de tierra pisada del Ent, la
- * humedad oscura de la cañada y la roca pálida asomando en lo alto de la
- * pared. De noche todo se enfría hacia el azul-luna (día por noche del cine).
+const sueloBase = crearSueloRico({
+  tam: 64,
+  seed: 929,
+  amplitud: 0.5,
+  micro: 0.085,
+  claro: { radio: 3.2, transicion: 6.3 },
+  falda: null, // la pared del anfiteatro (con crestas) la pone extraAnfiteatro
+  sendero: { puntos: PUNTOS_SENDERO, ancho: 1.05 },
+  paleta: PALETA_BOSQUE,
+});
+
+/**
+ * EL SUELO del bosque: el contrato `SueloRico` (alturaDe/pendienteDe/
+ * senderoCerca/opts) con la identidad del anfiteatro compuesta encima —
+ * `geomSueloRico`/`<SueloRico>` lo consumen tal cual, y TODO lo que la escena
+ * siembra (queñual, flora, hojarasca, arroyo) se posa con su `alturaDe`.
  */
-export function geomTerrenoBosque({ seg = 90, nocturno = false } = {}) {
-  const g = new THREE.PlaneGeometry(LADO_TERRENO, LADO_TERRENO, seg, seg);
-  g.rotateX(-Math.PI / 2);
-  const pos = g.attributes.position;
-  const colores = new Float32Array(pos.count * 3);
-  const col = new THREE.Color();
-  for (let i = 0; i < pos.count; i++) {
-    const x = pos.getX(i);
-    const z = pos.getZ(i);
-    const y = alturaBosque(x, z);
-    pos.setY(i, y);
-    const r = Math.hypot(x, z);
+export const sueloDelBosque = {
+  ...sueloBase,
+  alturaDe: (x, z) => sueloBase.alturaDe(x, z) + extraAnfiteatro(x, z),
+  pendienteDe: (x, z, e = 0.4) => {
+    const a = sueloDelBosque.alturaDe;
+    const dx = (a(x + e, z) - a(x - e, z)) / (2 * e);
+    const dz = (a(x, z + e) - a(x, z - e)) / (2 * e);
+    return Math.hypot(dx, dz);
+  },
+};
 
-    // Musgo moteado (dos verdes que el ruido mezcla en nubes grandes).
-    const mote = ruidoFbm(x * 0.33 + 3, 0, z * 0.33);
-    col.copy(SUELO.musgoOscuro).lerp(SUELO.musgoClaro, mote);
-
-    // Hojarasca bajo el anillo del queñual (parches, no alfombra).
-    const mHoja = ruidoFbm(x * 0.21 + 9, 0, z * 0.21);
-    if (r > 4 && r < 18 && mHoja > 0.55) {
-      const t = ss(mHoja, 0.55, 0.82) * 0.85;
-      col.lerp(mHoja > 0.7 ? SUELO.hojarasca2 : SUELO.hojarasca, t);
-    }
-
-    // El patio de tierra pisada bajo el guardián (afordancia sin UI).
-    const patio = 1 - ss(r, 1.5, 2.8);
-    if (patio > 0) col.lerp(SUELO.tierra, patio * 0.75);
-
-    // La humedad de la cañada (el suelo oscuro y mojado junto al agua).
-    const dxA = x - xArroyo(z);
-    const fCa = Math.exp(-(dxA * dxA) / 1.6) * ss(z, -13, -6) * (1 - ss(r, 20, 28));
-    if (fCa > 0.02) col.lerp(SUELO.humedo, fCa * 0.7);
-
-    // Roca asomando en lo alto de la pared del anfiteatro.
-    const fR = ss(y, 2.0, 4.8);
-    if (fR > 0) {
-      const veta = ruidoFbm(x * 0.5, y * 0.5, z * 0.5);
-      col.lerp(veta > 0.5 ? SUELO.roca : SUELO.rocaOscura, fR * 0.75);
-    }
-
-    if (nocturno) col.lerp(SUELO.noche, 0.55);
-    colores[i * 3] = col.r;
-    colores[i * 3 + 1] = col.g;
-    colores[i * 3 + 2] = col.b;
-  }
-  g.setAttribute('color', new THREE.BufferAttribute(colores, 3));
-  g.computeVertexNormals(); // indexada → normales SUAVES (lomas redondas)
-  return g;
+/** Cota del terreno del bosque en (x,z) — la función que TODO usa para posarse. */
+export function alturaBosque(x, z) {
+  return sueloDelBosque.alturaDe(x, z);
 }
 
 /* -------------------------------------------------------------------------- */
 /*  LA QUEÑUA (Polylepis) — el árbol del bosque de niebla                      */
 /* -------------------------------------------------------------------------- */
-
-/*
- * Nube de follaje SUAVE: un icosaedro subdividido, deformado con ruido y con
- * NORMALES RADIALES puestas a mano — así el matojo se sombrea como una masa
- * redonda de hojas (Ori/BOTW), no como un poliedro facetado. Es la pieza que
- * mata el "icosaedro literal" que el operador odia.
- */
-function matojoNube(radio, semilla = 1, deform = 0.5) {
-  const g = new THREE.IcosahedronGeometry(radio, 1);
-  const pos = g.attributes.position;
-  const v = new THREE.Vector3();
-  for (let i = 0; i < pos.count; i++) {
-    v.fromBufferAttribute(pos, i);
-    const n = ruidoFbm(v.x * 2.2 + semilla, v.y * 2.2, v.z * 2.2) - 0.5;
-    v.multiplyScalar(1 + n * deform * 2);
-    pos.setXYZ(i, v.x, v.y, v.z);
-  }
-  pos.needsUpdate = true;
-  const nor = new Float32Array(pos.count * 3);
-  for (let i = 0; i < pos.count; i++) {
-    v.fromBufferAttribute(pos, i).normalize();
-    nor[i * 3] = v.x;
-    nor[i * 3 + 1] = v.y;
-    nor[i * 3 + 2] = v.z;
-  }
-  g.setAttribute('normal', new THREE.BufferAttribute(nor, 3));
-  return g;
-}
 
 /* Paleta Polylepis: corteza roja que se despapela + hoja menuda verde-gris. */
 const QUENUA = {
@@ -420,6 +344,8 @@ export function sitiosQuenual(tier = 'alto') {
     for (const [ax, az] of ANCLAS_VECINOS) {
       if ((ax - x) ** 2 + (az - z) ** 2 < 1.8 * 1.8) return false;
     }
+    // El trillo queda libre: ninguna queñua plantada sobre el sendero.
+    if (sueloDelBosque.senderoCerca(x, z).d < 1.7) return false;
     return true;
   };
 

--- a/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
+++ b/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
@@ -1,0 +1,574 @@
+/*
+ * bosqueTakeA.geom — la GEOMETRÍA del bosque de niebla TAKE A (naturalista).
+ *
+ * El claro del guardián deja de ser un plato verde: aquí vive el RELIEVE del
+ * anfiteatro altoandino (heightfield determinista), el QUEÑUAL de troncos
+ * retorcidos con copas que son MASA de hojas (nubes deformadas con normales
+ * radiales — nada de poliedros literales), la hojarasca del suelo, los troncos
+ * caídos con musgo y el arroyo que baja de la niebla.
+ *
+ * Reglas de la casa:
+ *   · Todo procedural y determinista (rng con semilla): el mismo bosque en
+ *     cada carga, cero assets externos.
+ *   · Color HORNEADO por vértice (hornearCorteza/hornearFollaje del taller
+ *     sombreadoVegetal) → un material con vertexColors por banco.
+ *   · mergeGeometries devuelve NULL EN SILENCIO si se mezclan indexadas con
+ *     no-indexadas (ya mordió 3 veces): aquí TODO se desindexa y se TRUENA si
+ *     el merge falla — pero SIN recomputar normales (las copas traen normales
+ *     radiales a propósito: así la nube de hojas se sombrea suave).
+ *   · three core puro: corre headless, sin contexto GL.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import {
+  rng,
+  ruidoFbm,
+  desindexar,
+  poner,
+  apuntar,
+  pintarPlano,
+  hornearFollaje,
+  hornearCorteza,
+  tuboOrganico,
+  taperTronco,
+  taperLineal,
+  curvaTronco,
+  sembrarFollaje,
+} from './sombreadoVegetal.js';
+
+const ss = THREE.MathUtils.smoothstep;
+
+/* -------------------------------------------------------------------------- */
+/*  Fusión que PRESERVA normales                                               */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * fusionarSeguro (del taller) recalcula normales al final — correcto para la
+ * flora facetada, letal para las copas-nube: sus normales RADIALES (puestas a
+ * mano) son lo que las hace leerse como masa suave de hojas y no como
+ * icosaedros. Esta variante desindexa, truena si el merge da null, y respeta
+ * las normales que cada parte ya trae.
+ */
+function fusionarConNormales(partes, etiqueta = 'sin-nombre') {
+  const buenas = partes.filter(Boolean).map(desindexar);
+  if (!buenas.length) {
+    throw new Error(`[bosqueTakeA] "${etiqueta}": no hay partes que fusionar.`);
+  }
+  const refAttrs = Object.keys(buenas[0].attributes).sort().join(',');
+  for (let i = 0; i < buenas.length; i++) {
+    const attrs = Object.keys(buenas[i].attributes).sort().join(',');
+    if (attrs !== refAttrs) {
+      throw new Error(
+        `[bosqueTakeA] "${etiqueta}": la parte ${i} tiene atributos [${attrs}] `
+        + `pero se esperaba [${refAttrs}] — mergeGeometries devolvería null.`,
+      );
+    }
+  }
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error(
+      `[bosqueTakeA] "${etiqueta}": mergeGeometries devolvió NULL — la pieza `
+      + 'habría quedado invisible sin error.',
+    );
+  }
+  return g;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL TERRENO — el anfiteatro del bosque de niebla                            */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Altura del terreno en (x,z). La composición:
+ *   · CLARO central plano (r<3.2): el Ent y los vecinos viven en y≈0 — la
+ *     fauna billboard y las raíces del guardián no flotan ni se entierran.
+ *   · ONDULACIÓN media (r 3.2→9.5): lomos suaves de musgo, el microrelieve
+ *     que hace que el suelo deje de ser una mesa.
+ *   · PARED del anfiteatro (r>12.5): la ladera trepa hasta ~6 con crestas
+ *     irregulares por ángulo — el cuenco que la niebla se come al fondo.
+ *   · CAÑADA del arroyo: una vaguada honda que baja del fondo brumoso y
+ *     cruza el flanco derecho del claro.
+ * Determinista y barata: los objetos se POSAN encima con esta misma función.
+ */
+export function xArroyo(z) {
+  return 4.7 + Math.sin(z * 0.24 + 1.3) * 1.5;
+}
+
+export function alturaBosque(x, z) {
+  const r = Math.hypot(x, z);
+  const ang = Math.atan2(z, x);
+  const onda = (Math.sin(x * 0.52 + 1.7) * Math.cos(z * 0.47 - 0.6) * 0.36
+    + Math.sin(x * 1.25 - z * 0.85 + 2.1) * 0.13) * ss(r, 3.2, 9.5);
+  const micro = (Math.sin(x * 2.6 + z * 1.9) * 0.04
+    + Math.cos(x * 1.7 - z * 2.8) * 0.035) * ss(r, 2.2, 5);
+  const cresta = 1 + 0.34 * Math.sin(ang * 3 + 1.2)
+    + 0.2 * Math.sin(ang * 7 - 0.7)
+    + 0.12 * Math.sin(ang * 13 + 2.3);
+  const pared = ss(r, 12.5, 30) ** 1.25 * 4.8 * cresta;
+  const dx = x - xArroyo(z);
+  const canada = -0.4 * Math.exp(-(dx * dx) / 1.15) * ss(z, -13, -6) * (1 - ss(r, 20, 28));
+  return onda + micro + pared + canada;
+}
+
+/* Paleta del suelo (musgo, hojarasca, tierra pisada, humedad, roca). */
+const SUELO = {
+  musgoOscuro: new THREE.Color('#3d4b2c'),
+  musgoClaro: new THREE.Color('#5a6b3a'),
+  hojarasca: new THREE.Color('#6e5838'),
+  hojarasca2: new THREE.Color('#7d6a44'),
+  tierra: new THREE.Color('#5c4a33'),
+  humedo: new THREE.Color('#2f3d2b'),
+  roca: new THREE.Color('#7b8074'),
+  rocaOscura: new THREE.Color('#5d6156'),
+  noche: new THREE.Color('#243349'),
+};
+
+export const LADO_TERRENO = 64;
+
+/*
+ * La malla del terreno, PINTADA por vértice: musgo moteado de base, parches de
+ * hojarasca bajo el anillo de árboles, el patio de tierra pisada del Ent, la
+ * humedad oscura de la cañada y la roca pálida asomando en lo alto de la
+ * pared. De noche todo se enfría hacia el azul-luna (día por noche del cine).
+ */
+export function geomTerrenoBosque({ seg = 90, nocturno = false } = {}) {
+  const g = new THREE.PlaneGeometry(LADO_TERRENO, LADO_TERRENO, seg, seg);
+  g.rotateX(-Math.PI / 2);
+  const pos = g.attributes.position;
+  const colores = new Float32Array(pos.count * 3);
+  const col = new THREE.Color();
+  for (let i = 0; i < pos.count; i++) {
+    const x = pos.getX(i);
+    const z = pos.getZ(i);
+    const y = alturaBosque(x, z);
+    pos.setY(i, y);
+    const r = Math.hypot(x, z);
+
+    // Musgo moteado (dos verdes que el ruido mezcla en nubes grandes).
+    const mote = ruidoFbm(x * 0.33 + 3, 0, z * 0.33);
+    col.copy(SUELO.musgoOscuro).lerp(SUELO.musgoClaro, mote);
+
+    // Hojarasca bajo el anillo del queñual (parches, no alfombra).
+    const mHoja = ruidoFbm(x * 0.21 + 9, 0, z * 0.21);
+    if (r > 4 && r < 18 && mHoja > 0.55) {
+      const t = ss(mHoja, 0.55, 0.82) * 0.85;
+      col.lerp(mHoja > 0.7 ? SUELO.hojarasca2 : SUELO.hojarasca, t);
+    }
+
+    // El patio de tierra pisada bajo el guardián (afordancia sin UI).
+    const patio = 1 - ss(r, 1.5, 2.8);
+    if (patio > 0) col.lerp(SUELO.tierra, patio * 0.75);
+
+    // La humedad de la cañada (el suelo oscuro y mojado junto al agua).
+    const dxA = x - xArroyo(z);
+    const fCa = Math.exp(-(dxA * dxA) / 1.6) * ss(z, -13, -6) * (1 - ss(r, 20, 28));
+    if (fCa > 0.02) col.lerp(SUELO.humedo, fCa * 0.7);
+
+    // Roca asomando en lo alto de la pared del anfiteatro.
+    const fR = ss(y, 2.0, 4.8);
+    if (fR > 0) {
+      const veta = ruidoFbm(x * 0.5, y * 0.5, z * 0.5);
+      col.lerp(veta > 0.5 ? SUELO.roca : SUELO.rocaOscura, fR * 0.75);
+    }
+
+    if (nocturno) col.lerp(SUELO.noche, 0.55);
+    colores[i * 3] = col.r;
+    colores[i * 3 + 1] = col.g;
+    colores[i * 3 + 2] = col.b;
+  }
+  g.setAttribute('color', new THREE.BufferAttribute(colores, 3));
+  g.computeVertexNormals(); // indexada → normales SUAVES (lomas redondas)
+  return g;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LA QUEÑUA (Polylepis) — el árbol del bosque de niebla                      */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Nube de follaje SUAVE: un icosaedro subdividido, deformado con ruido y con
+ * NORMALES RADIALES puestas a mano — así el matojo se sombrea como una masa
+ * redonda de hojas (Ori/BOTW), no como un poliedro facetado. Es la pieza que
+ * mata el "icosaedro literal" que el operador odia.
+ */
+function matojoNube(radio, semilla = 1, deform = 0.5) {
+  const g = new THREE.IcosahedronGeometry(radio, 1);
+  const pos = g.attributes.position;
+  const v = new THREE.Vector3();
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i);
+    const n = ruidoFbm(v.x * 2.2 + semilla, v.y * 2.2, v.z * 2.2) - 0.5;
+    v.multiplyScalar(1 + n * deform * 2);
+    pos.setXYZ(i, v.x, v.y, v.z);
+  }
+  pos.needsUpdate = true;
+  const nor = new Float32Array(pos.count * 3);
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i).normalize();
+    nor[i * 3] = v.x;
+    nor[i * 3 + 1] = v.y;
+    nor[i * 3 + 2] = v.z;
+  }
+  g.setAttribute('normal', new THREE.BufferAttribute(nor, 3));
+  return g;
+}
+
+/* Paleta Polylepis: corteza roja que se despapela + hoja menuda verde-gris. */
+const QUENUA = {
+  grieta: '#3a231a',
+  cuerpo: '#82503a',
+  papel: '#cf9068', // la lámina que se desprende (la firma de la queñua)
+  liquen: '#94a56b',
+  hojaBase: '#2c4531',
+  hojaSol: '#6f9150',
+  hojaLuz: '#c3cf7e',
+  barba: '#93a877', // musgo/usnea colgando en el bosque de niebla
+};
+
+/*
+ * UNA queñua completa, fusionada en UNA geometría con color horneado:
+ *   · fuste principal retorcido (curva + conicidad + arruga de corteza) y un
+ *     segundo fuste bajo — Polylepis crece en macolla, nunca es un palo recto;
+ *   · ramas que suben en busca de luz, cada una rematada en un LÓBULO de copa;
+ *   · cada lóbulo es un puñado de matojos-nube sembrados con huecos y borde
+ *     mordido (el cielo se ve a través) + AO/gradiente/contraluz horneados;
+ *   · barbas de musgo colgando del borde inferior (el velo del bosque de niebla).
+ * `q` escala el detalle (tier); `seed` da variantes distintas.
+ */
+export function geomQuenua({ q = 1 } = {}, seed = 21) {
+  const r = rng(seed);
+  const partesCorteza = [];
+  const copas = [];
+  const H = 3.3 + r() * 1.2;
+
+  // Fuste principal: pelea con el viento (inclinación + sinuosidad + torsión).
+  const curva = curvaTronco(
+    { altura: H, inclina: 0.14 + r() * 0.14, sinuoso: 0.15 + r() * 0.12, giro: r() * Math.PI * 2 },
+    seed + 1,
+  );
+  partesCorteza.push(tuboOrganico(curva, {
+    tubular: Math.max(10, Math.round(20 * q)),
+    radial: Math.max(6, Math.round(8 * q)),
+    taper: taperTronco(0.24 + r() * 0.07, 0.085, 0.55),
+    arruga: 0.16,
+    semilla: seed * 3.1,
+  }));
+
+  // Segundo fuste (la macolla): más bajo, más recostado.
+  const giro2 = r() * Math.PI * 2;
+  const off2 = [Math.cos(giro2) * 0.3, 0, Math.sin(giro2) * 0.3];
+  const curva2 = curvaTronco(
+    { altura: H * (0.45 + r() * 0.2), inclina: 0.34 + r() * 0.2, sinuoso: 0.22, giro: giro2 },
+    seed + 2,
+  );
+  const fuste2 = tuboOrganico(curva2, {
+    tubular: Math.max(8, Math.round(12 * q)),
+    radial: Math.max(5, Math.round(7 * q)),
+    taper: taperTronco(0.13 + r() * 0.04, 0.05, 0.5),
+    arruga: 0.18,
+    semilla: seed * 5.7,
+  });
+  poner(fuste2, off2);
+  partesCorteza.push(fuste2);
+
+  // Lóbulos de copa: la corona del fuste + la punta de cada rama + la macolla.
+  const lobulos = [];
+  const puntaP = curva.getPointAt(1);
+  lobulos.push({ c: [puntaP.x, puntaP.y + 0.42, puntaP.z], radio: 0.95 + r() * 0.3 });
+
+  const nRamas = Math.max(2, Math.round(3 * q));
+  for (let i = 0; i < nRamas; i++) {
+    const t0 = Math.min(0.9, 0.55 + i * (0.32 / nRamas) + r() * 0.05);
+    const pIni = curva.getPointAt(t0);
+    const ang = r() * Math.PI * 2;
+    const alcance = 0.9 + r() * 0.7;
+    const pFin = new THREE.Vector3(
+      pIni.x + Math.cos(ang) * alcance,
+      pIni.y + 0.55 + r() * 0.5,
+      pIni.z + Math.sin(ang) * alcance,
+    );
+    const pMed = pIni.clone().lerp(pFin, 0.5);
+    pMed.y += 0.18;
+    partesCorteza.push(tuboOrganico(new THREE.CatmullRomCurve3([pIni, pMed, pFin]), {
+      tubular: Math.max(6, Math.round(9 * q)),
+      radial: Math.max(5, Math.round(6 * q)),
+      taper: taperLineal(0.085, 0.03),
+      arruga: 0.12,
+      semilla: seed * 7 + i,
+    }));
+    lobulos.push({ c: [pFin.x, pFin.y + 0.3, pFin.z], radio: 0.68 + r() * 0.35 });
+  }
+  const punta2 = curva2.getPointAt(1);
+  lobulos.push({
+    c: [punta2.x + off2[0], punta2.y + 0.26, punta2.z + off2[2]],
+    radio: 0.52 + r() * 0.25,
+  });
+
+  // Corteza horneada: grieta/cuerpo/papel rojizo + líquen trepando el pie.
+  const corteza = fusionarConNormales(partesCorteza, 'quenua-corteza');
+  hornearCorteza(corteza, {
+    grieta: QUENUA.grieta,
+    cuerpo: QUENUA.cuerpo,
+    cresta: QUENUA.papel,
+    liquen: QUENUA.liquen,
+    escalaGrano: 4.2,
+    hastaLiquen: 0.85,
+  });
+
+  // Copas: matojos-nube con huecos, borde mordido y sombreado horneado.
+  const varia = (hex, amt) => {
+    const c = new THREE.Color(hex);
+    c.multiplyScalar(1 + (r() - 0.5) * amt);
+    return c;
+  };
+  for (let i = 0; i < lobulos.length; i++) {
+    const lb = lobulos[i];
+    const puntos = sembrarFollaje({
+      centro: lb.c,
+      radio: lb.radio,
+      achatado: 0.72,
+      n: Math.max(5, Math.round(11 * q * lb.radio)),
+      semilla: seed * 13 + i * 3,
+      huecos: 0.46,
+      mordida: 0.38,
+      distMin: lb.radio * 0.3,
+    });
+    const matojos = puntos.map((p, k) => {
+      const m = matojoNube((0.26 + 0.16 * p.esc) * lb.radio, seed * 17 + i * 5 + k, 0.5);
+      poner(m, p.pos, p.giro, [1, 0.82, 1]);
+      return m;
+    });
+    if (!matojos.length) {
+      const m = matojoNube(lb.radio * 0.7, seed * 17 + i * 5, 0.5);
+      poner(m, lb.c, [0, 0, 0], [1, 0.82, 1]);
+      matojos.push(m);
+    }
+    const copa = fusionarConNormales(matojos, 'quenua-copa');
+    hornearFollaje(copa, {
+      base: varia(QUENUA.hojaBase, 0.1),
+      sol: varia(QUENUA.hojaSol, 0.12),
+      luz: QUENUA.hojaLuz,
+      centro: lb.c,
+      radio: lb.radio * 1.2,
+      ao: 0.66,
+      manchas: 0.16,
+    });
+    copas.push(copa);
+  }
+
+  // Barbas de musgo colgando del borde inferior de los lóbulos.
+  const barbas = [];
+  const nBarbas = Math.max(2, Math.round(5 * q));
+  for (let i = 0; i < nBarbas; i++) {
+    const lb = lobulos[i % lobulos.length];
+    const ang = r() * Math.PI * 2;
+    const largo = 0.3 + r() * 0.35;
+    const barba = new THREE.ConeGeometry(0.045, largo, 4, 1);
+    apuntar(
+      barba,
+      [
+        lb.c[0] + Math.cos(ang) * lb.radio * 0.55,
+        lb.c[1] - lb.radio * 0.5 - largo * 0.35,
+        lb.c[2] + Math.sin(ang) * lb.radio * 0.55,
+      ],
+      [Math.cos(ang) * 0.12, -1, Math.sin(ang) * 0.12],
+    );
+    barbas.push(pintarPlano(barba, varia(QUENUA.barba, 0.14)));
+  }
+
+  return fusionarConNormales([corteza, ...copas, ...barbas], 'quenua');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL QUEÑUAL — dónde vive cada queñua                                        */
+/* -------------------------------------------------------------------------- */
+
+/* El corredor de cámara (la vista de reposo mira al Ent desde ~az 0.61): las
+   queñuas HÉROE no se paran en el encuadre; las lejanas sí pueden velarse. */
+const AZ_CAMARA = 0.61;
+/* Los vecinos rubber-hose viven en estas anclas (FaunaBosque): despejarlas. */
+const ANCLAS_VECINOS = [[-3.7, 3.0], [3.1, 3.2], [-4.9, 4.4], [3.0, 2.1]];
+
+const CUPO_QUENUAL = {
+  alto: { cerca: 7, lejos: 9 },
+  medio: { cerca: 5, lejos: 5 },
+  bajo: { cerca: 3, lejos: 0 },
+};
+
+function tinteInstancia(r, amt = 0.1) {
+  const f = 1 + (r() - 0.5) * amt;
+  const h = (r() - 0.5) * amt * 0.5;
+  const cl = (v) => Math.max(0.75, Math.min(1.14, v));
+  return [cl(f + h), cl(f), cl(f - h * 0.6)];
+}
+
+/**
+ * Sitios del queñual para un tier: anillo HÉROE (r 6.4–10.6, enmarca el claro
+ * sin tapar el corredor de cámara ni el arroyo ni a los vecinos) + anillo
+ * LEJANO (r 12.5–19.5, sobre la falda de la pared, velado por la niebla, con
+ * escala mayor: siluetas que dan fondo). Determinista.
+ */
+export function sitiosQuenual(tier = 'alto') {
+  const cupo = CUPO_QUENUAL[tier] || CUPO_QUENUAL.medio;
+  const r = rng(929);
+  const sitios = [];
+
+  const cabe = (x, z, minSep) => {
+    for (const s of sitios) {
+      if ((s.pos[0] - x) ** 2 + (s.pos[2] - z) ** 2 < minSep * minSep) return false;
+    }
+    for (const [ax, az] of ANCLAS_VECINOS) {
+      if ((ax - x) ** 2 + (az - z) ** 2 < 1.8 * 1.8) return false;
+    }
+    return true;
+  };
+
+  let cerca = 0;
+  let intentos = 0;
+  while (cerca < cupo.cerca && intentos++ < 300) {
+    const ang = r() * Math.PI * 2;
+    const d = Math.atan2(Math.sin(ang - AZ_CAMARA), Math.cos(ang - AZ_CAMARA));
+    if (Math.abs(d) < 0.55) continue; // el encuadre del guardián queda libre
+    const rad = 6.4 + r() * 4.2;
+    const x = Math.cos(ang) * rad;
+    const z = Math.sin(ang) * rad;
+    if (z > -13 && Math.abs(x - xArroyo(z)) < 1.4) continue; // no pisar el agua
+    if (!cabe(x, z, 2.6)) continue;
+    sitios.push({
+      pos: [x, alturaBosque(x, z) - 0.06, z],
+      rotY: r() * Math.PI * 2,
+      esc: 0.92 + r() * 0.35,
+      variante: sitios.length % 3,
+      tinte: tinteInstancia(r),
+    });
+    cerca++;
+  }
+
+  let lejos = 0;
+  intentos = 0;
+  while (lejos < cupo.lejos && intentos++ < 300) {
+    const ang = r() * Math.PI * 2;
+    const d = Math.atan2(Math.sin(ang - AZ_CAMARA), Math.cos(ang - AZ_CAMARA));
+    if (Math.abs(d) < 0.22) continue; // ni las lejanas tapan al Ent de frente
+    const rad = 12.5 + r() * 7;
+    const x = Math.cos(ang) * rad;
+    const z = Math.sin(ang) * rad;
+    if (z > -13 && Math.abs(x - xArroyo(z)) < 1.6) continue;
+    if (!cabe(x, z, 3.1)) continue;
+    sitios.push({
+      pos: [x, alturaBosque(x, z) - 0.1, z],
+      rotY: r() * Math.PI * 2,
+      esc: 1.15 + r() * 0.5,
+      variante: sitios.length % 3,
+      tinte: tinteInstancia(r, 0.14),
+    });
+    lejos++;
+  }
+
+  return sitios;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  HOJARASCA — el suelo del bosque no está barrido                            */
+/* -------------------------------------------------------------------------- */
+
+/** Loseta de hojarasca: disco bajo de borde irregular (se instancia). */
+export function geomLosetaHojarasca(seed = 5) {
+  const r = rng(seed);
+  const g = new THREE.CircleGeometry(1, 7);
+  const pos = g.attributes.position;
+  const v = new THREE.Vector2();
+  for (let i = 1; i < pos.count; i++) { // el vértice 0 es el centro
+    v.set(pos.getX(i), pos.getY(i));
+    const f = 0.72 + r() * 0.5;
+    pos.setXY(i, v.x * f, v.y * f);
+  }
+  g.rotateX(-Math.PI / 2);
+  return g;
+}
+
+const TINTES_HOJARASCA = ['#6e5838', '#7d6a44', '#5c4a30', '#87724d', '#4f4a2c', '#75543a'];
+
+/** Siembra de hojarasca: parches bajo el anillo de árboles, no alfombra. */
+export function sitiosHojarasca(n, seed = 31) {
+  const r = rng(seed);
+  const arr = [];
+  for (let i = 0; i < n; i++) {
+    const ang = r() * Math.PI * 2;
+    const rad = 2.6 + Math.sqrt(r()) * 13;
+    const x = Math.cos(ang) * rad;
+    const z = Math.sin(ang) * rad;
+    arr.push({
+      pos: [x, alturaBosque(x, z) + 0.02, z],
+      rotY: r() * Math.PI * 2,
+      esc: 0.07 + r() * (r() > 0.85 ? 0.24 : 0.12),
+      tinte: TINTES_HOJARASCA[Math.floor(r() * TINTES_HOJARASCA.length)],
+    });
+  }
+  return arr;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  TRONCOS CAÍDOS — la madera muerta que hace bosque viejo                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Dos troncos caídos con musgo encima, posados sobre el relieve. UNA geometría
+ * (color horneado) → un draw-call.
+ */
+export function geomTroncosCaidos(q = 1) {
+  const partes = [];
+  const domos = [];
+  const caido = (x0, z0, x1, z1, grosor, seed) => {
+    const y0 = alturaBosque(x0, z0);
+    const y1 = alturaBosque(x1, z1);
+    const curva = new THREE.CatmullRomCurve3([
+      new THREE.Vector3(x0, y0 + grosor * 0.55, z0),
+      new THREE.Vector3((x0 + x1) / 2, Math.max(y0, y1) + grosor * 0.9, (z0 + z1) / 2),
+      new THREE.Vector3(x1, y1 + grosor * 0.5, z1),
+    ]);
+    partes.push(tuboOrganico(curva, {
+      tubular: Math.max(8, Math.round(12 * q)),
+      radial: Math.max(5, Math.round(7 * q)),
+      taper: taperLineal(grosor, grosor * 0.62),
+      arruga: 0.2,
+      semilla: seed,
+    }));
+    // Musgo encima (domos bajos, el lado que mira al cielo húmedo).
+    const rD = rng(seed * 3);
+    for (let i = 0; i < Math.max(2, Math.round(4 * q)); i++) {
+      const t = 0.2 + rD() * 0.6;
+      const p = curva.getPointAt(t);
+      const domo = new THREE.SphereGeometry(grosor * (0.5 + rD() * 0.4), 7, 5, 0, Math.PI * 2, 0, Math.PI * 0.5);
+      poner(domo, [p.x, p.y + grosor * 0.5, p.z], [0, rD() * Math.PI, 0], [1.4, 0.5, 1]);
+      domos.push(pintarPlano(domo, new THREE.Color(rD() > 0.5 ? '#4c5c34' : '#5a6a3e')));
+    }
+  };
+  caido(-6.8, 4.6, -4.0, 6.6, 0.2, 41);
+  caido(6.4, -5.2, 8.6, -3.2, 0.17, 43);
+
+  const madera = fusionarConNormales(partes, 'troncos-caidos');
+  hornearCorteza(madera, {
+    grieta: '#33261d',
+    cuerpo: '#6b503b',
+    cresta: '#8a6d4f',
+    liquen: '#94a56b',
+    escalaGrano: 3.6,
+    hastaLiquen: 1.4,
+  });
+  return fusionarConNormales([madera, ...domos], 'troncos-caidos-musgo');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL ARROYO — el hilo de agua que baja de la niebla                          */
+/* -------------------------------------------------------------------------- */
+
+/** La curva del arroyo, posada sobre su cañada (para TubeGeometry). */
+export function curvaArroyo() {
+  const pts = [];
+  for (let z = -12; z <= 15; z += 3) {
+    const x = xArroyo(z);
+    pts.push(new THREE.Vector3(x, alturaBosque(x, z) + 0.05, z));
+  }
+  return new THREE.CatmullRomCurve3(pts);
+}

--- a/src/visual/mundo3d/bosque/floraParamo.geom.js
+++ b/src/visual/mundo3d/bosque/floraParamo.geom.js
@@ -6,34 +6,56 @@
  * solo. Especies reales del páramo/bosque altoandino colombiano, cada una con su
  * identidad inequívoca:
  *
- *   · Frailejón (Espeletia)      — el ícono: tallo con enagua de hojas muertas y
- *                                  ROSETA plateada peluda arriba. Va al frente,
- *                                  formando el frailejonar. (Algunos en flor.)
+ *   · Frailejón (Espeletia)      — el ícono: columna con enagua de hojas muertas
+ *                                  y ROSETA plateada afelpada. Viene en EDADES
+ *                                  (joven al ras / adulto / viejo de tronco alto)
+ *                                  y crece en COLONIAS: el frailejonal es un
+ *                                  PAISAJE con gradiente de edad, no clones.
  *   · Yarumo plateado/blanco     — Cecropia telealba: tronco pálido esbelto y copa
  *     (Cecropia telealba)          en sombrilla de hojas palmeadas de ENVÉS BLANCO.
- *   · Roble andino               — Quercus humboldtii: tronco robusto y copa ancha
- *     (Quercus humboldtii)         densa de hoja coriácea oscura (con bellotas).
- *   · Encenillo (Weinmannia)     — árbol de niebla: tronco rojizo, copa oscura y
- *                                  compacta, velo de musgo.
+ *   · Roble andino               — Quercus humboldtii: tronco robusto fisurado y
+ *     (Quercus humboldtii)         copa ANCHA que es MASA de hojas (con bellotas).
+ *   · Encenillo (Weinmannia)     — árbol de niebla: tronco rojizo torcido, copa
+ *                                  oscura compacta y barbas de musgo colgando.
  *   · Aliso (Alnus acuminata)    — tronco gris claro esbelto, copa cónica verde
  *                                  fresca; el vecino más alto (aun así < Ent).
- *   · Gaque (Clusia)             — copa redonda densa de hoja gruesa verde-lustrosa.
+ *   · Gaque (Clusia)             — un domo DENSO de hoja gruesa verde-lustrosa.
  *   · Mortiño (Vaccinium         — arbusto bajo con BAYAS azul-moradas (agraz andino).
  *     meridionale)
  *   · Romerillo                  — mata baja de follaje fino amarillo-verde.
  *   · Rocas con líquen + musgo   — el suelo del páramo.
  *
- * TÉCNICA tier-safe (DR §3): cada especie se FUSIONA en UNA sola geometría
- * (tronco + follaje + detalles) con color horneado en vertexColors, y luego se
- * dibuja con UN InstancedMesh → una draw-call por especie por más matas que haya.
- * Cero assets externos: todo procedural. Corre headless (three core + merge puro).
+ * CALIBRE de copa (2026-07-16): los árboles del cortejo dejaron los icosaedros
+ * literales — cada copa es una MASA de hojas con huecos y borde mordido
+ * (`sembrarFollaje` + `matojoNube` con normales RADIALES + `hornearFollaje` con
+ * AO/gradiente/contraluz), la misma técnica del queñual de la toma A. Los troncos
+ * son `tuboOrganico` con conicidad, arruga y corteza horneada — nada de cilindros
+ * de catálogo. Todo pasa por el TALLER compartido (`sombreadoVegetal`), la casa
+ * canónica del kit: cero duplicados caseros, `fusionarSeguro` es la única fusión.
+ *
+ * TÉCNICA tier-safe (DR §3): cada especie (y cada EDAD del frailejón) se FUSIONA
+ * en UNA sola geometría (tronco + follaje + detalles) con color horneado en
+ * vertexColors, y se dibuja con UN InstancedMesh → una draw-call por banco por
+ * más matas que haya. Cero assets externos: todo procedural, corre headless.
  *
  * El componente r3f (`FloraParamo.jsx`) consume esto: instancia, ubica y le pone
  * luz. Aquí viven SOLO los datos y las mallas (nada de WebGL).
  */
 import * as THREE from 'three';
-import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
-import { rng } from './entQuenua.geom.js';
+import {
+  rng,
+  fusionarSeguro,
+  poner,
+  apuntar,
+  pintarPlano,
+  hornearFollaje,
+  hornearCorteza,
+  tuboOrganico,
+  taperTronco,
+  curvaTronco,
+  sembrarFollaje,
+  matojoNube,
+} from './sombreadoVegetal.js';
 
 /* -------------------------------------------------------------------------- */
 /*  Presupuesto por tier                                                       */
@@ -43,19 +65,24 @@ import { rng } from './entQuenua.geom.js';
  * Cuántas matas de cada especie (tier-safe). 'alto' puebla un ecosistema pleno;
  * 'medio' es frugal; 'bajo' deja lo mínimo para que AÚN se lea "páramo" (unos
  * frailejones, un par de árboles, rocas y musgo) si algo fuerza el 3D. Cada
- * especie es UN InstancedMesh → estos números son instancias, no draw-calls.
+ * banco es UN InstancedMesh → estos números son instancias, no draw-calls. El
+ * frailejonal viene por EDADES (tres bancos + el que florece) para que el
+ * paisaje tenga gradiente de edad, no clones.
  */
 export const FLORA_TIER = {
   alto: {
-    frailejon: 30, frailejonFlor: 6, yarumo: 3, roble: 3, encenillo: 4,
+    frailejonJoven: 12, frailejon: 14, frailejonViejo: 7, frailejonFlor: 5,
+    yarumo: 3, roble: 3, encenillo: 4,
     aliso: 3, gaque: 2, mortino: 10, romerillo: 12, roca: 9, musgo: 12, niebla: 3,
   },
   medio: {
-    frailejon: 18, frailejonFlor: 3, yarumo: 2, roble: 2, encenillo: 2,
+    frailejonJoven: 7, frailejon: 8, frailejonViejo: 4, frailejonFlor: 3,
+    yarumo: 2, roble: 2, encenillo: 2,
     aliso: 2, gaque: 1, mortino: 6, romerillo: 7, roca: 5, musgo: 6, niebla: 0,
   },
   bajo: {
-    frailejon: 7, frailejonFlor: 0, yarumo: 1, roble: 1, encenillo: 0,
+    frailejonJoven: 3, frailejon: 4, frailejonViejo: 0, frailejonFlor: 0,
+    yarumo: 1, roble: 1, encenillo: 0,
     aliso: 0, gaque: 0, mortino: 2, romerillo: 3, roca: 2, musgo: 3, niebla: 0,
   },
 };
@@ -64,7 +91,7 @@ export const FLORA_TIER = {
 export const floraDeTier = (tier) => FLORA_TIER[tier] || FLORA_TIER.medio;
 
 /*
- * Factor de DETALLE geométrico por tier: escala cuántas hojas/blobs lleva cada
+ * Factor de DETALLE geométrico por tier: escala cuántas hojas/matojos lleva cada
  * mata. Menos detalle en gama baja = menos vértices por instancia (que se
  * multiplican por el número de matas).
  */
@@ -78,13 +105,14 @@ export const calidadDeTier = (tier) => CALIDAD_TIER[tier] ?? CALIDAD_TIER.medio;
 export const PAL = {
   // Frailejón
   frailejonTronco: '#6f5c40', // tallo bajo la enagua
-  frailejonSeco: '#907753', // hojas muertas de la enagua (marcescentes) — pajizo
-  frailejonSeco2: '#6a5232', // marcescentes más oscuras/curtidas (variedad)
-  frailejonPlata: '#cfd4c7', // roseta: centro joven, tomento MÁS blanco (la firma)
-  frailejonPlata2: '#b0ba9c', // hojas externas: plateado-salvia más apagado
-  frailejonCorazon: '#dde2d6', // cogollo velloso central (el punto más pálido)
-  frailejonFlor: '#e0c24a', // capítulos amarillos
-  frailejonTallo: '#95a06a', // escapo floral
+  frailejonSeco: '#9a7f57', // enagua: marcescentes pajizas (arriba, recientes)
+  frailejonSeco2: '#67502f', // marcescentes viejas curtidas (abajo, oscuras)
+  frailejonSeco3: '#7f6640', // tono intermedio dorado-marrón (variedad)
+  frailejonPlata: '#d7dccf', // roseta centro: tomento plateado-blanco (la firma)
+  frailejonPlata2: '#a9b593', // hojas externas: plateado-salvia apagado (viejas)
+  frailejonCorazon: '#e9eee2', // cogollo velloso central (el punto más pálido)
+  frailejonFlor: '#e6c84e', // capítulos amarillos
+  frailejonTallo: '#93a06a', // escapo floral
 
   // Yarumo plateado / blanco (Cecropia telealba)
   yarumoTronco: '#bcbfb2', // tronco pálido anillado
@@ -94,28 +122,42 @@ export const PAL = {
 
   // Roble andino (Quercus humboldtii)
   robleTronco: '#6a5c4a', // corteza gris-parda fisurada
-  robleHoja: '#43593b', // hoja coriácea verde oscuro
-  robleHoja2: '#516b42',
+  robleGrieta: '#453a2c', // fondo de la fisura
+  robleCresta: '#83745e', // lomo expuesto de la corteza
+  robleHoja: '#43593b', // hoja coriácea verde oscuro (penumbra)
+  robleHoja2: '#5d7847', // hoja al sol
+  robleLuz: '#a8b775', // contraluz de borde
   robleBellota: '#7a5a34', // bellota
   robleCapa: '#54432a', // capuchón de la bellota
 
   // Encenillo (Weinmannia tomentosa)
   encenilloTronco: '#6d4535', // corteza rojiza
-  encenilloHoja: '#3b5236', // copa oscura compacta
-  encenilloMusgo: '#586a44', // velo de musgo del árbol de niebla
+  encenilloGrieta: '#3f281e',
+  encenilloCresta: '#8a5a44',
+  encenilloHoja: '#37502f', // copa oscura compacta (penumbra)
+  encenilloHoja2: '#4d6844', // al sol
+  encenilloLuz: '#93a86f', // contraluz tímido (árbol sombrío)
+  encenilloMusgo: '#93a877', // velo de musgo del árbol de niebla
 
   // Aliso (Alnus acuminata)
   alisoTronco: '#9a9a8f', // corteza gris clara
-  alisoHoja: '#4f6d3d', // verde fresco
-  alisoHoja2: '#5c7a46',
+  alisoGrieta: '#6f6f64',
+  alisoCresta: '#b5b5a8',
+  alisoHoja: '#4f6d3d', // verde fresco (penumbra)
+  alisoHoja2: '#6d8c50', // al sol
+  alisoLuz: '#c9d67f', // contraluz fresco
 
   // Gaque (Clusia)
   gaqueTronco: '#57493a',
-  gaqueHoja: '#2f4a2d', // verde muy oscuro lustroso
-  gaqueHoja2: '#37552f',
+  gaqueGrieta: '#372e23',
+  gaqueCresta: '#6d5c48',
+  gaqueHoja: '#2f4a2d', // verde muy oscuro lustroso (penumbra)
+  gaqueHoja2: '#456339', // al sol
+  gaqueLuz: '#7fa25b', // brillo de hoja gruesa
 
   // Mortiño (Vaccinium meridionale)
   mortinoHoja: '#3f5a3a',
+  mortinoHoja2: '#517048',
   mortinoBrote: '#7a4536', // brote rojizo nuevo
   mortinoBaya: '#33305c', // baya azul-morada (agraz)
   mortinoBaya2: '#3d3768',
@@ -134,81 +176,20 @@ export const PAL = {
 };
 
 /* -------------------------------------------------------------------------- */
-/*  Utilidades de construcción (fusión + colocación + color horneado)          */
+/*  Utilidades de construcción (kit/taller compartido + ayudas locales)        */
 /* -------------------------------------------------------------------------- */
 
-const UP = new THREE.Vector3(0, 1, 0);
+/** Color plano horneado (alias del taller — todas las partes DEBEN traer color). */
+const pintar = pintarPlano;
 
-/** Hornea un color plano en TODOS los vértices (atributo `color`). Idempotente. */
-function pintar(geo, color) {
-  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
-  const n = geo.attributes.position.count;
-  const arr = new Float32Array(n * 3);
-  for (let i = 0; i < n; i++) {
-    arr[i * 3] = c.r;
-    arr[i * 3 + 1] = c.g;
-    arr[i * 3 + 2] = c.b;
-  }
-  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
-  return geo;
-}
-
-/** Coloca una geometría con posición/rotación/escala (transforma vértices). */
-function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
-  const m = new THREE.Matrix4().compose(
-    new THREE.Vector3(pos[0], pos[1], pos[2]),
-    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
-    new THREE.Vector3(scale[0], scale[1], scale[2]),
-  );
-  geo.applyMatrix4(m);
-  return geo;
-}
-
-/** Orienta el eje +Y de la geometría hacia `dir` y la ubica en `pos` (para hojas
-    que apuntan en cualquier dirección). `esc` escala en el eje local antes de
-    girar (aplana hojas: escala z pequeña → lámina). */
-function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
-  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
-  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
-  const m = new THREE.Matrix4().compose(
-    new THREE.Vector3(pos[0], pos[1], pos[2]),
-    q,
-    new THREE.Vector3(esc[0], esc[1], esc[2]),
-  );
-  geo.applyMatrix4(m);
-  return geo;
-}
-
-/**
- * Fusiona la lista de partes (ya coloreadas) en UNA geometría.
- *
- * ⚠️ mergeGeometries devuelve NULL EN SILENCIO si las partes mezclan geometrías
- * indexadas (Cone/Cylinder/Sphere) con no-indexadas (Icosahedron/Dodecahedron).
- * Ese null invisible tenía APAGADAS seis especies (frailejón, roble, encenillo,
- * aliso, gaque, romerillo) y, en el valle, además mataba el render entero con
- * `null.boundingSphere`. Es la TERCERA mordida de esta trampa (2026-07-15) y la
- * cazaron dos agentes por separado, en esta rama y en fable/direccion-valle.
- *
- * Se DESINDEXA todo antes de fusionar y se TRUENA si aun así falla: mejor un
- * error de build que una especie invisible en producción.
- *
- * El `dispose()` no es opcional: `toNonIndexed()` devuelve una geometría NUEVA y
- * la original se queda en memoria de GPU. Sin liberarla, cada rebuild filtra —
- * y esto corre en un Android barato.
+/*
+ * La fusión canónica del taller, PRESERVANDO las normales que cada parte trae:
+ * las copas-masa llevan normales RADIALES (matojoNube) que son lo que las hace
+ * leerse como masa suave de hojas — recalcular normales las devolvería a
+ * poliedro facetado. Desindexa, valida atributos y TRUENA si el merge da null
+ * (la trampa que ya apagó seis especies sin un solo error en consola).
  */
-function fusionar(partes) {
-  const buenas = partes.filter(Boolean).map((p) => {
-    const plana = p.index ? p.toNonIndexed() : p;
-    if (plana !== p) p.dispose();
-    return plana;
-  });
-  const g = mergeGeometries(buenas, false);
-  if (!g) {
-    throw new Error('floraParamo: mergeGeometries devolvió null — atributos incompatibles entre partes');
-  }
-  // Las partes de entrada nunca tocaron la GPU: quedan para el GC.
-  return g;
-}
+const fusionar = (partes, etiqueta = 'floraParamo') => fusionarSeguro(partes, etiqueta, { preservarNormales: true });
 
 /** Pequeña variación determinista de color (para que un bosque no sea plano). */
 function variar(base, r, amt = 0.06) {
@@ -217,121 +198,261 @@ function variar(base, r, amt = 0.06) {
   return c;
 }
 
+/**
+ * Hornea un GRADIENTE a lo largo del eje Y local (base→punta): cada vértice toma
+ * un color según su altura entre `y0` y `y1`. Sirve para el TOMENTO del frailejón:
+ * hoja plateada en la base y casi blanca en la punta → toda la roseta se lee
+ * frosteada/afelpada (la pelusa), no como piedra facetada de un solo tono.
+ */
+function pintarGradiente(geo, colBase, colPunta, y0, y1) {
+  const a = colBase instanceof THREE.Color ? colBase : new THREE.Color(colBase);
+  const b = colPunta instanceof THREE.Color ? colPunta : new THREE.Color(colPunta);
+  const pos = geo.attributes.position;
+  const n = pos.count;
+  const arr = new Float32Array(n * 3);
+  const c = new THREE.Color();
+  const span = (y1 - y0) || 1;
+  for (let i = 0; i < n; i++) {
+    let t = (pos.getY(i) - y0) / span;
+    t = t < 0 ? 0 : t > 1 ? 1 : t;
+    c.copy(a).lerp(b, Math.pow(t, 0.7)); // sesga hacia la punta pálida
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/**
+ * Pétalo/hoja CARNOSA: un elipsoide de PUNTA REDONDA que nace en su base (origen)
+ * y se extiende por +Y. Es la clave contra el look "cerda": una hoja gruesa y
+ * roma, no un cono puntudo. Se orienta con `apuntar` (que lleva +Y hacia `dir`).
+ * `ancho`/`grosor` son SEMI-ejes (mitad del ancho/espesor); `largo` es el total.
+ */
+function petalo(ancho, largo, grosor, wSeg = 6, hSeg = 3) {
+  const g = new THREE.SphereGeometry(1, wSeg, hSeg);
+  // escala a elipsoide y sube su base al origen (span y ∈ [0, largo]).
+  poner(g, [0, largo / 2, 0], [0, 0, 0], [ancho, largo / 2, grosor]);
+  return g;
+}
+
+/**
+ * COPA-MASA: la técnica del queñual para cualquier árbol del cortejo. Cada
+ * lóbulo {c, radio} se llena con matojos-nube (normales radiales) sembrados con
+ * huecos y borde mordido, y se hornea AO + gradiente + contraluz. El resultado
+ * se lee como masa de hojas con el cielo colándose — nunca como icosaedro literal.
+ *
+ * @param {{c:[number,number,number], radio:number}[]} lobulos
+ * @param {object} o  {base, sol, luz, q, seed, achatado?, huecos?, mordida?,
+ *                     ao?, manchas?, densidad?, distMin?}
+ * @returns {THREE.BufferGeometry[]} una geometría horneada por lóbulo
+ */
+function copaMasa(lobulos, o) {
+  const {
+    base, sol, luz, q = 1, seed = 1,
+    achatado = 0.74, huecos = 0.42, mordida = 0.36,
+    ao = 0.62, manchas = 0.14, densidad = 10,
+  } = o;
+  const copas = [];
+  for (let i = 0; i < lobulos.length; i++) {
+    const lb = lobulos[i];
+    const puntos = sembrarFollaje({
+      centro: lb.c,
+      radio: lb.radio,
+      achatado,
+      n: Math.max(4, Math.round(densidad * q * lb.radio)),
+      semilla: seed * 13 + i * 3,
+      huecos,
+      mordida,
+      distMin: (o.distMin ?? 0.3) * lb.radio,
+    });
+    const matojos = puntos.map((p, k) => {
+      const m = matojoNube((0.28 + 0.16 * p.esc) * lb.radio, seed * 17 + i * 5 + k, 0.5);
+      poner(m, p.pos, p.giro, [1, 0.82, 1]);
+      return m;
+    });
+    if (!matojos.length) {
+      const m = matojoNube(lb.radio * 0.7, seed * 17 + i * 5, 0.5);
+      poner(m, lb.c, [0, 0, 0], [1, 0.82, 1]);
+      matojos.push(m);
+    }
+    const copa = fusionar(matojos, 'copa-masa');
+    hornearFollaje(copa, {
+      base, sol, luz, centro: lb.c, radio: lb.radio * 1.2, ao, manchas,
+    });
+    copas.push(copa);
+  }
+  return copas;
+}
+
+/**
+ * TRONCO orgánico horneado: una `curvaTronco` (inclinación/sinuosidad/torsión) +
+ * `tuboOrganico` (conicidad + arruga de corteza) + `hornearCorteza`. Devuelve la
+ * geometría Y la curva (para colgar la copa de su punta). Nada de cilindros.
+ */
+function troncoHorneado({
+  H, r0, r1, inclina = 0.1, sinuoso = 0.09, giro = 0, arruga = 0.15,
+  raigon = 0.42, q = 1, corteza, hastaLiquen = 0.4, liquen = PAL.liquen,
+}, seed) {
+  const curva = curvaTronco({ altura: H, inclina, sinuoso, giro }, seed);
+  const geo = tuboOrganico(curva, {
+    tubular: Math.max(8, Math.round(16 * q)),
+    radial: Math.max(6, Math.round(8 * q)),
+    taper: taperTronco(r0, r1, raigon),
+    arruga,
+    semilla: seed * 3.1,
+  });
+  hornearCorteza(geo, {
+    grieta: corteza.grieta,
+    cuerpo: corteza.cuerpo,
+    cresta: corteza.cresta,
+    liquen,
+    escalaGrano: corteza.escalaGrano ?? 4.2,
+    hastaLiquen,
+  });
+  return { geo, curva };
+}
+
 /* -------------------------------------------------------------------------- */
 /*  FRAILEJÓN (Espeletia) — el ícono del páramo                                */
 /* -------------------------------------------------------------------------- */
 
 /*
- * Silueta de MONJE: un tronco columnar VESTIDO de arriba abajo con la ENAGUA de
- * hojas muertas (marcescentes) que cuelgan pegadas al tallo como un hábito —eso
- * le da CUERPO, no es un palo—, coronado por la ROSETA plateada peluda: un
- * penacho DENSO de hojas anchas, carnosas y afelpadas (tomento plateado, NO
- * cerdas) en espiral áurea, más erguidas al centro y recostadas al borde. Esa
- * roseta blanquecina afelpada + la falda de hojas secas es lo que lo hace
- * inequívoco. Con `flor`, un escapo con capítulos amarillos asoma de la roseta.
+ * Silueta de FRAILE: una columna VESTIDA de arriba abajo con la ENAGUA de hojas
+ * muertas (marcescentes) —láminas anchas y secas superpuestas como tejas, no
+ * púas— que le dan CUERPO (sin ella sería un palo), coronada por la ROSETA: un
+ * cogollo DENSO de hojas carnosas y afelpadas (tomento plateado-blanco),
+ * apretadas en espiral áurea sobre una cúpula. Esa bola velluda plateada + la
+ * falda de hojas secas es lo que lo hace inequívoco. Con `flor`, un escapo con
+ * racimo de capítulos amarillos asoma de la roseta.
+ *
+ * La EDAD manda la silueta (Espeletia crece ~1 cm/año): `edad`∈(0..1] —
+ *   · ~0.25 JOVEN: columna muy corta, roseta casi al ras, enagua apenas;
+ *   · ~0.6  ADULTO: columna media vestida de enagua, roseta plena;
+ *   · ~0.95 VIEJO: columna alta con hábito largo de marcescentes.
+ * Un frailejonal es un PAISAJE con gradiente de edad: se instancian los tres
+ * bancos mezclados (distribucionFlora) y NO se lee clonado.
  */
-export function geomFrailejon({ flor = false, q = 1 } = {}, seed = 1) {
+export function geomFrailejon({ flor = false, q = 1, edad = 0.6 } = {}, seed = 1) {
   const r = rng(seed);
   const partes = [];
   const GOLDEN = Math.PI * (3 - Math.sqrt(5));
+  const e = Math.max(0.12, Math.min(1, edad));
 
-  // Frailejón erguido y solemne: columna alta (crece ~1cm/año, se lee vertical).
-  const Ht = 1.12 + r() * 0.55;
+  // La columna crece con la edad; la roseta es casi constante (el joven es "casi
+  // pura roseta al ras", el viejo un hábito alto coronado por la misma cabeza).
+  const Ht = 0.14 + e * 1.62 + r() * 0.16;
   const cy = Ht + 0.05; // la roseta se posa como una cabeza sobre la columna
+  const rosF = 1.06 - e * 0.16; // la roseta joven, un pelo más grande en relativo
 
   // 1) Tallo columnar — casi todo oculto por la enagua.
-  const tronco = new THREE.CylinderGeometry(0.12, 0.15, Ht, 7, 1);
+  const tronco = new THREE.CylinderGeometry(0.11, 0.155, Ht, 7, 1);
   poner(tronco, [0, Ht / 2, 0]);
   partes.push(pintar(tronco, PAL.frailejonTronco));
 
-  // 2) ENAGUA de hojas muertas: el HÁBITO. Hojas anchas y secas que cuelgan casi
-  //    a plomo, pegadas al tronco y superpuestas como tejas, vistiendo la columna
-  //    entera (de la base a la roseta). Es lo que le da cuerpo de "fraile grande".
-  const anillos = Math.max(3, Math.round(6 * q));
+  // 2) ENAGUA (el HÁBITO): láminas secas ANCHAS que cuelgan pegadas al tallo,
+  //    superpuestas como tejas de la base a la roseta. Cuanto más abajo, más
+  //    viejas y oscuras. El número de anillos escala con la altura (el viejo
+  //    lleva hábito largo; el joven, apenas un faldón).
+  const anillos = Math.max(2, Math.round((Ht / 0.24) * q));
   const porAnillo = Math.max(6, Math.round(10 * q));
   for (let a = 0; a < anillos; a++) {
-    const f = a / anillos; // 0 base → 1 bajo la roseta
-    const y = 0.14 + f * (Ht - 0.1);
+    const f = a / anillos; // 0 base(vieja) → 1 bajo la roseta(reciente)
+    const y = 0.1 + f * (Ht - 0.06);
     const rad = 0.15;
     for (let i = 0; i < porAnillo; i++) {
-      const ang = (i / porAnillo) * Math.PI * 2 + a * 0.6;
-      const largo = 0.30 + r() * 0.14;
-      // hoja seca ANCHA y aplanada (lámina, no púa), colgando casi vertical.
-      const hoja = new THREE.ConeGeometry(0.085, largo, 4, 1);
+      const ang = (i / porAnillo) * Math.PI * 2 + a * 0.55;
+      const largo = 0.32 + r() * 0.16;
+      // lámina seca ancha (6 lados, aplanada) colgando casi a plomo y algo afuera.
+      const hoja = new THREE.ConeGeometry(0.11, largo, 6, 1);
       apuntar(
         hoja,
         [Math.cos(ang) * rad, y, Math.sin(ang) * rad],
-        [Math.cos(ang) * 0.3, -1, Math.sin(ang) * 0.3],
-        [1, 1, 0.42],
+        [Math.cos(ang) * 0.32, -1, Math.sin(ang) * 0.32],
+        [1, 1, 0.5],
       );
-      partes.push(pintar(hoja, variar(r() > 0.55 ? PAL.frailejonSeco : PAL.frailejonSeco2, r, 0.14)));
+      // pajiza arriba (reciente) → curtida oscura abajo (vieja), con variedad.
+      const tono = f > 0.55
+        ? (r() > 0.5 ? PAL.frailejonSeco : PAL.frailejonSeco3)
+        : (r() > 0.5 ? PAL.frailejonSeco3 : PAL.frailejonSeco2);
+      partes.push(pintar(hoja, variar(tono, r, 0.12)));
     }
   }
 
-  // 3) ROSETA plateada peluda — la FIRMA. Un COGOLLO afelpado, no una estrella:
-  //    hojas anchas, carnosas y GRUESAS (poco aplanadas) nacidas sobre una cúpula,
-  //    en espiral áurea, apenas abiertas (cuenco erguido, NO tendidas al ras), muy
-  //    densas y superpuestas → una bola velluda plateada. Las de afuera se recuestan
-  //    y agrisan (viejas); el centro es blanco y erguido (yema joven, tomento fresco).
-  const nRoseta = Math.max(18, Math.round(40 * q));
+  // 3) ROSETA — la FIRMA. Cogollo afelpado: HOJAS CARNOSAS (elipsoides de punta
+  //    redonda, nunca cerdas) en espiral áurea sobre una cúpula, erguidas al
+  //    centro y recostadas al borde, muy densas → una bola velluda plateada.
+  //    Tomento horneado en gradiente (base salvia → punta casi blanca).
+  const nRoseta = Math.max(18, Math.round(38 * q));
+  const wSeg = Math.max(5, Math.round(6 * q));
+  const hSeg = Math.max(3, Math.round(4 * q));
   const plataInt = new THREE.Color(PAL.frailejonPlata);
   const plataExt = new THREE.Color(PAL.frailejonPlata2);
-  for (let i = 0; i < nRoseta; i++) {
-    const f = i / nRoseta; // 0 centro erguido → 1 borde recostado
-    const ang = i * GOLDEN + (r() - 0.5) * 0.18;
-    const posR = 0.03 + f * 0.11; // nacen sobre una cúpula, no de un punto
-    const posY = cy - f * 0.08; // las de afuera, más bajas → domo redondo
-    const tilt = 0.26 + f * 0.78 + (r() - 0.5) * 0.08; // cuenco: 15°→60°, sin aplanarse
+  const hojaRoseta = (f, ang, extraTilt = 0) => {
+    const posR = (0.02 + f * 0.12) * rosF; // nacen sobre una cúpula, no de un punto
+    const posY = cy - f * 0.1 * rosF; // borde más bajo → domo redondo
+    const tilt = 0.2 + f * 0.62 + (r() - 0.5) * 0.09 + extraTilt; // cuenco 11°→47°
     const s = Math.sin(tilt);
-    const largo = 0.28 + (1 - f) * 0.13 + r() * 0.05; // cortas y llenas, no lanzas
-    // hoja carnosa ANCHA y con CUERPO (poco aplanada) — nada de cerda fina.
-    const hoja = new THREE.ConeGeometry(0.115, largo, 4, 1);
+    const largo = (0.27 + (1 - f) * 0.13 + r() * 0.05) * rosF; // cortas y llenas
+    const hoja = petalo((0.1 + f * 0.02) * rosF, largo, 0.06, wSeg, hSeg);
+    const base = variar(plataInt.clone().lerp(plataExt, f), r, 0.05);
+    pintarGradiente(hoja, base, PAL.frailejonCorazon, 0, largo);
     apuntar(
       hoja,
       [Math.cos(ang) * posR, posY, Math.sin(ang) * posR],
       [Math.cos(ang) * s, Math.cos(tilt), Math.sin(ang) * s],
-      [1, 1, 0.6],
     );
-    const col = plataInt.clone().lerp(plataExt, f);
-    partes.push(pintar(hoja, variar(col, r, 0.05)));
+    partes.push(hoja);
+  };
+  for (let i = 0; i < nRoseta; i++) {
+    hojaRoseta(i / nRoseta, i * GOLDEN + (r() - 0.5) * 0.18);
   }
-  // Corona interior: unas pocas hojas cortas y ERGUIDAS que tapan el centro y lo
-  // hacen leer como un cogollo lleno (sin hueco oscuro), del blanco más pálido.
-  const nCorona = Math.max(4, Math.round(7 * q));
+  // capa de relleno: espiral desfasada, un pelo más erguida → tapa los huecos y
+  // hace que el domo se lea LLENO y velludo (no una estrella con agujeros).
+  const nRelleno = Math.max(8, Math.round(18 * q));
+  for (let i = 0; i < nRelleno; i++) {
+    hojaRoseta(((i + 0.5) / nRelleno) * 0.85, i * GOLDEN + 1.7 + (r() - 0.5) * 0.2, -0.1);
+  }
+  // corona interior: pocas hojas cortas y ERGUIDAS, del blanco más pálido, que
+  // tapan el centro (sin hueco oscuro) → cogollo lleno y afelpado.
+  const nCorona = Math.max(5, Math.round(10 * q));
   for (let i = 0; i < nCorona; i++) {
     const ang = i * GOLDEN + 1.3;
-    const tilt = 0.14 + r() * 0.12;
+    const tilt = 0.1 + r() * 0.14;
     const s = Math.sin(tilt);
-    const hoja = new THREE.ConeGeometry(0.075, 0.20 + r() * 0.05, 4, 1);
+    const largoC = (0.16 + r() * 0.05) * rosF;
+    const hoja = petalo(0.072 * rosF, largoC, 0.052, wSeg, hSeg);
+    pintarGradiente(hoja, variar(PAL.frailejonPlata, r, 0.04), '#f3f6ee', 0, largoC);
     apuntar(
       hoja,
-      [Math.cos(ang) * 0.03, cy + 0.05, Math.sin(ang) * 0.03],
+      [Math.cos(ang) * 0.025, cy + 0.04, Math.sin(ang) * 0.025],
       [Math.cos(ang) * s, Math.cos(tilt), Math.sin(ang) * s],
-      [1, 1, 0.7],
     );
-    partes.push(pintar(hoja, variar(PAL.frailejonCorazon, r, 0.04)));
+    partes.push(hoja);
   }
-  // Yema vellosa central (el punto más pálido, afelpado).
-  const corazon = new THREE.IcosahedronGeometry(0.09, 0);
-  poner(corazon, [0, cy + 0.11, 0], [0, 0, 0], [1, 0.9, 1]);
+  // Yema vellosa central (el punto más pálido, afelpado) — cierra el cogollo.
+  const corazon = new THREE.IcosahedronGeometry(0.07 * rosF, 0);
+  poner(corazon, [0, cy + 0.07, 0], [0, 0, 0], [1, 0.85, 1]);
   partes.push(pintar(corazon, PAL.frailejonCorazon));
 
-  // 4) Escapo floral (solo en flor): tallo + capítulos amarillos sobre la roseta.
+  // 4) Escapo floral (solo en flor): vara CORTA que asoma de la roseta con un
+  //    racimo apretado de capítulos amarillos (no un poste pelado).
   if (flor) {
-    const tallo = new THREE.CylinderGeometry(0.028, 0.045, 0.9, 5, 1);
-    poner(tallo, [0.05, cy + 0.45, 0], [0, 0, 0.08]);
+    const tallo = new THREE.CylinderGeometry(0.03, 0.052, 0.5, 5, 1);
+    poner(tallo, [0.05, cy + 0.24, 0], [0, 0, 0.1]);
     partes.push(pintar(tallo, PAL.frailejonTallo));
-    const nCap = Math.max(4, Math.round(7 * q));
+    const nCap = Math.max(5, Math.round(9 * q));
     for (let i = 0; i < nCap; i++) {
-      const ang = (i / nCap) * Math.PI * 2;
-      const rad = 0.1 + r() * 0.06;
-      const cap = new THREE.IcosahedronGeometry(0.055 + r() * 0.02, 0);
-      poner(cap, [0.08 + Math.cos(ang) * rad, cy + 0.85 + r() * 0.1, Math.sin(ang) * rad], [0, 0, 0], [1, 0.7, 1]);
+      const ang = (i / nCap) * Math.PI * 2 + r();
+      const rad = 0.05 + r() * 0.1;
+      const cap = new THREE.IcosahedronGeometry(0.05 + r() * 0.028, 0);
+      poner(cap, [0.06 + Math.cos(ang) * rad, cy + 0.44 + r() * 0.11, Math.sin(ang) * rad], [0, 0, 0], [1, 0.72, 1]);
       partes.push(pintar(cap, variar(PAL.frailejonFlor, r, 0.08)));
     }
   }
 
-  return fusionar(partes);
+  return fusionar(partes, 'frailejon');
 }
 
 /* -------------------------------------------------------------------------- */
@@ -341,26 +462,31 @@ export function geomFrailejon({ flor = false, q = 1 } = {}, seed = 1) {
 /*
  * Pionera esbelta: tronco pálido y recto, ramas en candelabro arriba y una copa
  * en SOMBRILLA de hojas palmeadas (mano de 7 lóbulos) cuyo ENVÉS es blanco-plata.
- * Desde abajo se ve ese blanco: la firma inconfundible del yarumo.
+ * Desde abajo se ve ese blanco: la firma inconfundible del yarumo. (No lleva
+ * copa-masa: su silueta ES la sombrilla de manos, no un follaje mullido.)
  */
 export function geomYarumo({ q = 1 } = {}, seed = 2) {
   const r = rng(seed);
   const partes = [];
   const H = 3.4;
 
-  const tronco = new THREE.CylinderGeometry(0.08, 0.14, H, 8, 1);
-  poner(tronco, [0, H / 2, 0], [0, 0, 0.03]);
-  partes.push(pintar(tronco, PAL.yarumoTronco));
+  const { geo, curva } = troncoHorneado({
+    H, r0: 0.13, r1: 0.06, inclina: 0.05, sinuoso: 0.06, giro: r() * 6, arruga: 0.08,
+    raigon: 0.3, q, hastaLiquen: 0.3, liquen: PAL.liquen,
+    corteza: { grieta: '#9a9d90', cuerpo: PAL.yarumoTronco, cresta: '#d0d3c6', escalaGrano: 3 },
+  }, seed + 1);
+  partes.push(geo);
 
   // Ramas en candelabro (pocas, arriba).
   const nRamas = Math.max(2, Math.round(3 * q));
-  const puntas = [[0, H + 0.05, 0]];
+  const top = curva.getPointAt(1);
+  const puntas = [[top.x, H + 0.05, top.z]];
   for (let i = 0; i < nRamas; i++) {
     const ang = (i / nRamas) * Math.PI * 2 + 0.4;
     const largo = 0.7 + r() * 0.3;
-    const rama = new THREE.CylinderGeometry(0.03, 0.05, largo, 5, 1);
     const dir = [Math.cos(ang) * 0.7, 0.7, Math.sin(ang) * 0.7];
-    const base = [Math.cos(ang) * 0.05, H - 0.35 + i * 0.06, Math.sin(ang) * 0.05];
+    const base = [top.x + Math.cos(ang) * 0.05, H - 0.35 + i * 0.06, top.z + Math.sin(ang) * 0.05];
+    const rama = new THREE.CylinderGeometry(0.03, 0.05, largo, 5, 1);
     apuntar(rama, [base[0] + dir[0] * largo * 0.3, base[1] + dir[1] * largo * 0.3, base[2] + dir[2] * largo * 0.3], dir);
     partes.push(pintar(rama, PAL.yarumoRama));
     puntas.push([base[0] + dir[0] * largo, base[1] + dir[1] * largo, base[2] + dir[2] * largo]);
@@ -373,7 +499,6 @@ export function geomYarumo({ q = 1 } = {}, seed = 2) {
       const ang = (i / porPunta) * Math.PI * 2 + r();
       const rad = 0.18 + r() * 0.12;
       const hoja = new THREE.ConeGeometry(0.42, 0.09, 7, 1); // 7-gono chato = "mano"
-      // caída suave hacia afuera (envés hacia el suelo → se ve el blanco)
       apuntar(
         hoja,
         [p[0] + Math.cos(ang) * rad, p[1] - 0.05 - r() * 0.08, p[2] + Math.sin(ang) * rad],
@@ -384,7 +509,7 @@ export function geomYarumo({ q = 1 } = {}, seed = 2) {
     }
   }
 
-  return fusionar(partes);
+  return fusionar(partes, 'yarumo');
 }
 
 /* -------------------------------------------------------------------------- */
@@ -393,38 +518,47 @@ export function geomYarumo({ q = 1 } = {}, seed = 2) {
 
 /*
  * Árbol robusto de robledal altoandino: tronco grueso de corteza gris-parda
- * fisurada y una copa ANCHA y densa de hoja coriácea verde oscuro, con bellotas.
- * Imponente pero SIEMPRE menor que el Ent (el guardián sigue mandando).
+ * fisurada y una copa ANCHA y densa —MASA de hoja coriácea verde oscuro con
+ * huecos— con bellotas. Imponente pero SIEMPRE menor que el Ent.
  */
 export function geomRoble({ q = 1 } = {}, seed = 3) {
   const r = rng(seed);
   const partes = [];
   const H = 2.4;
 
-  const tronco = new THREE.CylinderGeometry(0.16, 0.24, H, 8, 1);
-  poner(tronco, [0, H / 2, 0], [0.03, 0, 0.02]);
-  partes.push(pintar(tronco, PAL.robleTronco));
+  const { geo, curva } = troncoHorneado({
+    H, r0: 0.23, r1: 0.1, inclina: 0.06, sinuoso: 0.08, giro: r() * 6, arruga: 0.18,
+    raigon: 0.5, q,
+    corteza: { grieta: PAL.robleGrieta, cuerpo: PAL.robleTronco, cresta: PAL.robleCresta, escalaGrano: 4.4 },
+  }, seed + 1);
+  partes.push(geo);
+  const top = curva.getPointAt(1);
 
-  // Un par de ramas gruesas bajas que abren la copa ancha.
+  // Ramas gruesas bajas que abren la copa ancha.
   const nRamas = Math.max(2, Math.round(3 * q));
   for (let i = 0; i < nRamas; i++) {
     const ang = (i / nRamas) * Math.PI * 2 + 0.5;
-    const rama = new THREE.CylinderGeometry(0.06, 0.1, 0.9, 6, 1);
-    apuntar(rama, [Math.cos(ang) * 0.3, H - 0.4, Math.sin(ang) * 0.3], [Math.cos(ang) * 0.8, 0.55, Math.sin(ang) * 0.8]);
+    const largo = 0.85 + r() * 0.3;
+    const rama = new THREE.CylinderGeometry(0.055, 0.095, largo, 6, 1);
+    apuntar(rama, [top.x + Math.cos(ang) * 0.3, H - 0.5, top.z + Math.sin(ang) * 0.3], [Math.cos(ang) * 0.85, 0.55, Math.sin(ang) * 0.85]);
     partes.push(pintar(rama, PAL.robleTronco));
   }
 
-  // Copa ancha densa: cúpula amplia de follaje coriáceo oscuro.
-  const nBlobs = Math.max(6, Math.round(12 * q));
-  for (let i = 0; i < nBlobs; i++) {
-    const ang = r() * Math.PI * 2;
-    const rad = 0.2 + r() * 1.05; // ANCHA
-    const y = H + 0.1 + r() * 1.0;
-    const s = 0.42 + r() * 0.42;
-    const blob = new THREE.IcosahedronGeometry(s, 0);
-    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 0.85, 1]);
-    partes.push(pintar(blob, variar(r() > 0.5 ? PAL.robleHoja : PAL.robleHoja2, r, 0.08)));
+  // Copa ANCHA: domo central + corona de lóbulos alrededor (masa de hojas).
+  const lobs = [{ c: [top.x, top.y + 0.55, top.z], radio: 0.9 }];
+  const nL = Math.max(3, Math.round(5 * q));
+  for (let i = 0; i < nL; i++) {
+    const ang = (i / nL) * Math.PI * 2 + r() * 0.6;
+    const rad = 0.6 + r() * 0.5;
+    lobs.push({
+      c: [Math.cos(ang) * rad, H + 0.1 + r() * 0.7, Math.sin(ang) * rad],
+      radio: 0.55 + r() * 0.32,
+    });
   }
+  copaMasa(lobs, {
+    base: PAL.robleHoja, sol: PAL.robleHoja2, luz: PAL.robleLuz,
+    q, seed: seed + 7, achatado: 0.82, huecos: 0.44, mordida: 0.4, ao: 0.66, manchas: 0.15,
+  }).forEach((cc) => partes.push(cc));
 
   // Bellotas (unas pocas, cuelgan del borde de la copa).
   if (q > 0.5) {
@@ -442,7 +576,7 @@ export function geomRoble({ q = 1 } = {}, seed = 3) {
     }
   }
 
-  return fusionar(partes);
+  return fusionar(partes, 'roble');
 }
 
 /* -------------------------------------------------------------------------- */
@@ -450,31 +584,56 @@ export function geomRoble({ q = 1 } = {}, seed = 3) {
 /* -------------------------------------------------------------------------- */
 
 /*
- * Copa oscura, compacta e irregular sobre tronco rojizo algo torcido, con un
- * velo de musgo (vive envuelto en niebla). Más estrecho y sombrío que el roble.
+ * Copa oscura, compacta e irregular —masa de hojas sombría— sobre tronco rojizo
+ * algo torcido, con barbas de musgo colgando (vive envuelto en niebla). Más
+ * estrecho y sombrío que el roble.
  */
 export function geomEncenillo({ q = 1 } = {}, seed = 4) {
   const r = rng(seed);
   const partes = [];
   const H = 2.3;
 
-  const tronco = new THREE.CylinderGeometry(0.1, 0.16, H, 7, 1);
-  poner(tronco, [0, H / 2, 0], [0.05, 0, -0.03]);
-  partes.push(pintar(tronco, PAL.encenilloTronco));
+  const { geo, curva } = troncoHorneado({
+    H, r0: 0.15, r1: 0.07, inclina: 0.16, sinuoso: 0.16, giro: r() * 6, arruga: 0.17,
+    raigon: 0.42, q, hastaLiquen: 0.9, liquen: PAL.encenilloMusgo,
+    corteza: { grieta: PAL.encenilloGrieta, cuerpo: PAL.encenilloTronco, cresta: PAL.encenilloCresta, escalaGrano: 4.2 },
+  }, seed + 1);
+  partes.push(geo);
+  const top = curva.getPointAt(1);
 
-  const nBlobs = Math.max(5, Math.round(9 * q));
-  for (let i = 0; i < nBlobs; i++) {
+  // Copa estrecha y alta: lóbulos apilados que suben poco a poco.
+  const lobs = [{ c: [top.x, top.y + 0.45, top.z], radio: 0.62 }];
+  const nL = Math.max(3, Math.round(5 * q));
+  for (let i = 0; i < nL; i++) {
+    const f = i / nL;
     const ang = r() * Math.PI * 2;
-    const rad = 0.15 + r() * 0.6; // copa estrecha
-    const y = H + 0.05 + r() * 1.0;
-    const s = 0.34 + r() * 0.3;
-    const blob = new THREE.IcosahedronGeometry(s, 0);
-    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 0.95, 1]);
-    const mossy = r() > 0.65;
-    partes.push(pintar(blob, variar(mossy ? PAL.encenilloMusgo : PAL.encenilloHoja, r, 0.08)));
+    const rad = 0.15 + r() * 0.42;
+    lobs.push({
+      c: [Math.cos(ang) * rad, H + 0.1 + f * 0.9 + r() * 0.3, Math.sin(ang) * rad],
+      radio: 0.4 + r() * 0.28,
+    });
+  }
+  copaMasa(lobs, {
+    base: PAL.encenilloHoja, sol: PAL.encenilloHoja2, luz: PAL.encenilloLuz,
+    q, seed: seed + 7, achatado: 0.78, huecos: 0.4, mordida: 0.34, ao: 0.68, manchas: 0.16,
+  }).forEach((cc) => partes.push(cc));
+
+  // Barbas de musgo/usnea colgando del borde de la copa (el velo de la niebla).
+  const nBarbas = Math.max(2, Math.round(5 * q));
+  for (let i = 0; i < nBarbas; i++) {
+    const lb = lobs[i % lobs.length];
+    const ang = r() * Math.PI * 2;
+    const largo = 0.28 + r() * 0.3;
+    const barba = new THREE.ConeGeometry(0.04, largo, 4, 1);
+    apuntar(
+      barba,
+      [lb.c[0] + Math.cos(ang) * lb.radio * 0.6, lb.c[1] - lb.radio * 0.5 - largo * 0.35, lb.c[2] + Math.sin(ang) * lb.radio * 0.6],
+      [Math.cos(ang) * 0.12, -1, Math.sin(ang) * 0.12],
+    );
+    partes.push(pintar(barba, variar(PAL.encenilloMusgo, r, 0.14)));
   }
 
-  return fusionar(partes);
+  return fusionar(partes, 'encenillo');
 }
 
 /* -------------------------------------------------------------------------- */
@@ -483,62 +642,80 @@ export function geomEncenillo({ q = 1 } = {}, seed = 4) {
 
 /*
  * Tronco recto y esbelto de corteza gris clara, copa CÓNICA-ovalada de verde
- * fresco. Es el árbol más alto del cortejo (crece rápido) pero no llega al Ent.
+ * fresco —masa de hojas que se estrecha hacia arriba—. Es el árbol más alto del
+ * cortejo (crece rápido) pero no llega al Ent.
  */
 export function geomAliso({ q = 1 } = {}, seed = 5) {
   const r = rng(seed);
   const partes = [];
   const H = 3.2;
 
-  const tronco = new THREE.CylinderGeometry(0.07, 0.13, H, 8, 1);
-  poner(tronco, [0, H / 2, 0]);
-  partes.push(pintar(tronco, PAL.alisoTronco));
+  const { geo, curva } = troncoHorneado({
+    H, r0: 0.12, r1: 0.055, inclina: 0.05, sinuoso: 0.07, giro: r() * 6, arruga: 0.1,
+    raigon: 0.34, q, hastaLiquen: 0.5, liquen: PAL.liquen2,
+    corteza: { grieta: PAL.alisoGrieta, cuerpo: PAL.alisoTronco, cresta: PAL.alisoCresta, escalaGrano: 3.4 },
+  }, seed + 1);
+  partes.push(geo);
+  const top = curva.getPointAt(1);
 
-  // Copa cónica: blobs que se estrechan hacia arriba.
-  const nBlobs = Math.max(5, Math.round(10 * q));
-  for (let i = 0; i < nBlobs; i++) {
-    const f = i / nBlobs; // 0 abajo → 1 arriba
+  // Copa cónica: lóbulos que se estrechan y sesgan hacia arriba desde el fuste.
+  const lobs = [];
+  const nL = Math.max(4, Math.round(6 * q));
+  for (let i = 0; i < nL; i++) {
+    const f = i / (nL - 1); // 0 abajo → 1 punta
     const ang = r() * Math.PI * 2;
-    const rad = (0.65 - f * 0.5) * (0.4 + r() * 0.8);
-    const y = H - 1.1 + f * 2.0 + r() * 0.2;
-    const s = 0.4 - f * 0.18 + r() * 0.18;
-    const blob = new THREE.IcosahedronGeometry(Math.max(0.16, s), 0);
-    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 1, 1]);
-    partes.push(pintar(blob, variar(r() > 0.5 ? PAL.alisoHoja : PAL.alisoHoja2, r, 0.08)));
+    const rad = (0.62 - f * 0.5) * (0.4 + r() * 0.7);
+    lobs.push({
+      c: [top.x + Math.cos(ang) * rad, H - 1.0 + f * 2.1 + r() * 0.15, top.z + Math.sin(ang) * rad],
+      radio: (0.52 - f * 0.24) + r() * 0.12,
+    });
   }
+  copaMasa(lobs, {
+    base: PAL.alisoHoja, sol: PAL.alisoHoja2, luz: PAL.alisoLuz,
+    q, seed: seed + 7, achatado: 0.82, huecos: 0.42, mordida: 0.36, ao: 0.62, manchas: 0.15,
+  }).forEach((cc) => partes.push(cc));
 
-  return fusionar(partes);
+  return fusionar(partes, 'aliso');
 }
 
 /* -------------------------------------------------------------------------- */
-/*  GAQUE (Clusia) — copa redonda de hoja gruesa lustrosa                       */
+/*  GAQUE (Clusia) — un domo denso de hoja gruesa lustrosa                       */
 /* -------------------------------------------------------------------------- */
 
 /*
- * Copa REDONDA densa y baja de hoja gruesa verde muy oscuro (casi lustrosa),
- * sobre tronco corto y firme. Compacto y sólido.
+ * Copa REDONDA densa y baja —un domo compacto de hoja gruesa verde muy oscuro
+ * (casi lustrosa)— sobre tronco corto y firme. Sólido y macizo.
  */
 export function geomGaque({ q = 1 } = {}, seed = 6) {
   const r = rng(seed);
   const partes = [];
   const H = 1.9;
 
-  const tronco = new THREE.CylinderGeometry(0.13, 0.19, H, 8, 1);
-  poner(tronco, [0, H / 2, 0]);
-  partes.push(pintar(tronco, PAL.gaqueTronco));
+  const { geo, curva } = troncoHorneado({
+    H, r0: 0.18, r1: 0.11, inclina: 0.04, sinuoso: 0.06, giro: r() * 6, arruga: 0.14,
+    raigon: 0.5, q, hastaLiquen: 0.35, liquen: PAL.liquen,
+    corteza: { grieta: PAL.gaqueGrieta, cuerpo: PAL.gaqueTronco, cresta: PAL.gaqueCresta, escalaGrano: 4 },
+  }, seed + 1);
+  partes.push(geo);
+  const top = curva.getPointAt(1);
 
-  const nBlobs = Math.max(5, Math.round(9 * q));
-  for (let i = 0; i < nBlobs; i++) {
-    const ang = r() * Math.PI * 2;
-    const rad = 0.15 + r() * 0.75;
-    const y = H + 0.15 + r() * 0.7; // domo bajo y ancho
-    const s = 0.4 + r() * 0.38;
-    const blob = new THREE.IcosahedronGeometry(s, 0);
-    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 0.8, 1]);
-    partes.push(pintar(blob, variar(r() > 0.5 ? PAL.gaqueHoja : PAL.gaqueHoja2, r, 0.06)));
+  // Domo bajo y ancho: un lóbulo grande central + pocos de relleno pegados.
+  const lobs = [{ c: [top.x, top.y + 0.45, top.z], radio: 1.0 }];
+  const nL = Math.max(2, Math.round(4 * q));
+  for (let i = 0; i < nL; i++) {
+    const ang = (i / nL) * Math.PI * 2 + r() * 0.5;
+    const rad = 0.4 + r() * 0.4;
+    lobs.push({
+      c: [Math.cos(ang) * rad, H + 0.3 + r() * 0.45, Math.sin(ang) * rad],
+      radio: 0.5 + r() * 0.28,
+    });
   }
+  copaMasa(lobs, {
+    base: PAL.gaqueHoja, sol: PAL.gaqueHoja2, luz: PAL.gaqueLuz,
+    q, seed: seed + 7, achatado: 0.7, huecos: 0.34, mordida: 0.3, ao: 0.7, manchas: 0.12, densidad: 11,
+  }).forEach((cc) => partes.push(cc));
 
-  return fusionar(partes);
+  return fusionar(partes, 'gaque');
 }
 
 /* -------------------------------------------------------------------------- */
@@ -547,35 +724,50 @@ export function geomGaque({ q = 1 } = {}, seed = 6) {
 
 /*
  * Mata baja de hojitas verdes con brotes rojizos y —la firma— BAYAS azul-moradas
- * (el agraz andino) salpicadas entre el follaje.
+ * (el agraz andino) salpicadas entre el follaje. La fronda es masa menuda de
+ * hojas (matojos-nube pequeños), no bolas facetadas.
  */
 export function geomMortino({ q = 1 } = {}, seed = 7) {
   const r = rng(seed);
   const partes = [];
 
-  const nBlobs = Math.max(4, Math.round(7 * q));
+  const lobs = [];
+  const nBlobs = Math.max(3, Math.round(5 * q));
   for (let i = 0; i < nBlobs; i++) {
     const ang = r() * Math.PI * 2;
-    const rad = r() * 0.32;
-    const y = 0.18 + r() * 0.5;
-    const s = 0.16 + r() * 0.16;
-    const blob = new THREE.IcosahedronGeometry(s, 0);
-    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 1, 1]);
-    const brote = r() > 0.72;
-    partes.push(pintar(blob, variar(brote ? PAL.mortinoBrote : PAL.mortinoHoja, r, 0.08)));
+    const rad = r() * 0.3;
+    lobs.push({
+      c: [Math.cos(ang) * rad, 0.2 + r() * 0.42, Math.sin(ang) * rad],
+      radio: 0.2 + r() * 0.16,
+    });
   }
-  // Bayas azul-moradas.
+  copaMasa(lobs, {
+    base: PAL.mortinoHoja, sol: PAL.mortinoHoja2, luz: '#9ab06a',
+    q, seed: seed + 5, achatado: 0.8, huecos: 0.34, mordida: 0.32, ao: 0.58, manchas: 0.18, densidad: 8,
+  }).forEach((cc) => partes.push(cc));
+
+  // Brotes rojizos nuevos (puntas tiernas).
+  const nBrote = Math.max(1, Math.round(3 * q));
+  for (let i = 0; i < nBrote; i++) {
+    const ang = r() * Math.PI * 2;
+    const rad = r() * 0.28;
+    const brote = new THREE.ConeGeometry(0.03, 0.12, 4, 1);
+    apuntar(brote, [Math.cos(ang) * rad, 0.42 + r() * 0.3, Math.sin(ang) * rad], [(r() - 0.5) * 0.4, 1, (r() - 0.5) * 0.4]);
+    partes.push(pintar(brote, variar(PAL.mortinoBrote, r, 0.1)));
+  }
+
+  // Bayas azul-moradas (la firma del agraz).
   const nBayas = Math.max(3, Math.round(10 * q));
   for (let i = 0; i < nBayas; i++) {
     const ang = r() * Math.PI * 2;
-    const rad = r() * 0.34;
-    const y = 0.15 + r() * 0.5;
+    const rad = r() * 0.32;
+    const y = 0.15 + r() * 0.45;
     const baya = new THREE.IcosahedronGeometry(0.04 + r() * 0.015, 0);
     poner(baya, [Math.cos(ang) * rad, y, Math.sin(ang) * rad]);
     partes.push(pintar(baya, variar(r() > 0.5 ? PAL.mortinoBaya : PAL.mortinoBaya2, r, 0.1)));
   }
 
-  return fusionar(partes);
+  return fusionar(partes, 'mortino');
 }
 
 /* -------------------------------------------------------------------------- */
@@ -584,7 +776,8 @@ export function geomMortino({ q = 1 } = {}, seed = 7) {
 
 /*
  * Cojín bajo de follaje FINO amarillo-verde (hojita de escama tipo romero de
- * páramo), a veces con puntos de flor amarilla. Relleno del sotobosque.
+ * páramo), a veces con puntos de flor amarilla. Relleno del sotobosque. Su
+ * identidad ES el manojo de ramitas finas, así que se queda en conos delgados.
  */
 export function geomRomerillo({ q = 1 } = {}, seed = 8) {
   const r = rng(seed);
@@ -614,7 +807,7 @@ export function geomRomerillo({ q = 1 } = {}, seed = 8) {
     }
   }
 
-  return fusionar(partes);
+  return fusionar(partes, 'romerillo');
 }
 
 /* -------------------------------------------------------------------------- */
@@ -637,7 +830,7 @@ export function geomRoca(seed = 9) {
     poner(parche, [Math.cos(ang) * rad, 0.2 + r() * 0.06, Math.sin(ang) * rad], [0, 0, 0], [1.3, 0.4, 1.3]);
     partes.push(pintar(parche, variar(r() > 0.5 ? PAL.liquen : PAL.liquen2, r, 0.1)));
   }
-  return fusionar(partes);
+  return fusionar(partes, 'roca');
 }
 
 /** Montículo de musgo húmedo (domo bajo). */
@@ -655,10 +848,11 @@ export function geomMusgo(seed = 10) {
 /*
  * Estratos concéntricos (el Ent en el centro, 0,0,0). La cámara ORBITA, así que
  * la composición es un anillo por estrato (no un frente fijo):
- *   · frailejonar + sotobosque + suelo → anillo interior-medio (al frente visual).
- *   · árboles (roble, encenillo, aliso, yarumo, gaque) → anillo exterior, velados
- *     por la niebla → dan fondo y hacen que el Ent RESALTE como el mayor.
- * Devuelve, por especie, instancias {pos, rotY, escala, tint}.
+ *   · frailejonar (tres edades entremezcladas) + sotobosque + suelo → anillo
+ *     interior-medio (al frente visual);
+ *   · árboles (roble, encenillo, aliso, yarumo, gaque) → anillo exterior,
+ *     velados por la niebla → dan fondo y hacen que el Ent RESALTE como el mayor.
+ * Devuelve, por banco, instancias {pos, rotY, escala, tint, [tiltX, tiltZ]}.
  */
 function tinteInstancia(r, amt) {
   const f = 1 + (r() - 0.5) * amt;
@@ -678,12 +872,21 @@ function sembrar(n, rMin, rMax, r, opts = {}) {
       ? (i / Math.max(1, n)) * Math.PI * 2 + (r() - 0.5) * 0.7
       : r() * Math.PI * 2;
     const rad = rMin + (rMax - rMin) * (opts.haciaAfuera ? Math.sqrt(r()) : r());
-    arr.push({
+    const it = {
       pos: [Math.cos(ang) * rad, 0, Math.sin(ang) * rad],
       rotY: r() * Math.PI * 2,
       escala: eMin + r() * (eMax - eMin),
       tint: tinteInstancia(r, opts.varia ?? 0.12),
-    });
+    };
+    // Ladeo por instancia (solo especies con `lean`): unos grados de cabeceo para
+    // que el frailejonal no se lea clonado (cada mata mira distinto). El pivote
+    // está en la base → el ladeo no despega la mata del suelo. Los r() se corren
+    // SOLO cuando hay lean, para no alterar el RNG de las demás especies.
+    if (opts.lean) {
+      it.tiltX = (r() - 0.5) * 2 * opts.lean;
+      it.tiltZ = (r() - 0.5) * 2 * opts.lean;
+    }
+    arr.push(it);
   }
   return arr;
 }
@@ -692,9 +895,14 @@ function sembrar(n, rMin, rMax, r, opts = {}) {
 export function distribucionFlora(conteos, seed = 707) {
   const c = conteos;
   return {
-    // Frailejonar: anillo interior-medio, agrupado, mucha variación de tamaño.
-    frailejon: sembrar(c.frailejon, 3.8, 10.5, rng(seed + 1), { eMin: 0.82, eMax: 1.28, varia: 0.14 }),
-    frailejonFlor: sembrar(c.frailejonFlor, 4.5, 9.5, rng(seed + 2), { eMin: 0.9, eMax: 1.2, varia: 0.1 }),
+    // Frailejonal: TRES edades entremezcladas en el mismo anillo interior-medio,
+    // agrupadas, con mucha variación de tamaño + ladeo por instancia (`lean`) →
+    // un paisaje con gradiente de edad, nada clonado. Los jóvenes se acercan más
+    // al claro (rMin menor); los viejos quedan un poco más afuera.
+    frailejonJoven: sembrar(c.frailejonJoven, 3.4, 9.5, rng(seed + 1), { eMin: 0.78, eMax: 1.12, varia: 0.13, lean: 0.14 }),
+    frailejon: sembrar(c.frailejon, 3.8, 10.5, rng(seed + 12), { eMin: 0.86, eMax: 1.22, varia: 0.14, lean: 0.15 }),
+    frailejonViejo: sembrar(c.frailejonViejo, 4.4, 11, rng(seed + 13), { eMin: 0.9, eMax: 1.3, varia: 0.14, lean: 0.17 }),
+    frailejonFlor: sembrar(c.frailejonFlor, 4.5, 9.5, rng(seed + 2), { eMin: 0.9, eMax: 1.2, varia: 0.1, lean: 0.12 }),
     // Sotobosque.
     mortino: sembrar(c.mortino, 4, 12, rng(seed + 3), { eMin: 0.8, eMax: 1.2, varia: 0.12 }),
     romerillo: sembrar(c.romerillo, 3, 12, rng(seed + 4), { eMin: 0.8, eMax: 1.25, varia: 0.14 }),

--- a/src/visual/mundo3d/bosque/sombreadoVegetal.js
+++ b/src/visual/mundo3d/bosque/sombreadoVegetal.js
@@ -96,8 +96,12 @@ export function desindexar(geo) {
  *
  * @param {THREE.BufferGeometry[]} partes
  * @param {string} etiqueta  nombre de la especie, para que el error diga QUIÉN.
+ * @param {{preservarNormales?: boolean}} [opts]  con `preservarNormales`, la
+ *   fusión RESPETA las normales que cada parte ya trae (p. ej. las RADIALES de
+ *   `matojoNube`, que hacen que una copa se sombree como masa suave de hojas).
+ *   Por defecto recalcula (per-face en no-indexadas → look facetado clásico).
  */
-export function fusionarSeguro(partes, etiqueta = 'sin-nombre') {
+export function fusionarSeguro(partes, etiqueta = 'sin-nombre', opts = {}) {
   const buenas = partes.filter(Boolean).map(desindexar);
   if (!buenas.length) {
     throw new Error(`[sombreadoVegetal] "${etiqueta}": no hay partes que fusionar.`);
@@ -122,7 +126,7 @@ export function fusionarSeguro(partes, etiqueta = 'sin-nombre') {
       + 'dispares. La especie habría quedado INVISIBLE sin error.',
     );
   }
-  g.computeVertexNormals();
+  if (!opts.preservarNormales) g.computeVertexNormals();
   return g;
 }
 
@@ -456,5 +460,37 @@ export function matojoHoja(radio, semilla = 1, deform = 0.42) {
     pos.setXYZ(i, v.x, v.y, v.z);
   }
   pos.needsUpdate = true;
+  return g;
+}
+
+/**
+ * Nube de follaje SUAVE: un icosaedro SUBDIVIDIDO, deformado con ruido y con
+ * NORMALES RADIALES puestas a mano — el matojo se sombrea como una masa redonda
+ * de hojas (Ori/BOTW), no como un poliedro facetado. Es la pieza que mata el
+ * "icosaedro literal": fusiónela con `fusionarSeguro(..., {preservarNormales:
+ * true})` para que el merge no le pise las normales.
+ *
+ * `matojoHoja` (arriba) es la variante BARATA facetada; esta es la copa-masa
+ * calibre consola (nació en el queñual del bosque TAKE A).
+ */
+export function matojoNube(radio, semilla = 1, deform = 0.5) {
+  const g = new THREE.IcosahedronGeometry(radio, 1);
+  const pos = g.attributes.position;
+  const v = new THREE.Vector3();
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i);
+    const n = ruidoFbm(v.x * 2.2 + semilla, v.y * 2.2, v.z * 2.2) - 0.5;
+    v.multiplyScalar(1 + n * deform * 2);
+    pos.setXYZ(i, v.x, v.y, v.z);
+  }
+  pos.needsUpdate = true;
+  const nor = new Float32Array(pos.count * 3);
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i).normalize();
+    nor[i * 3] = v.x;
+    nor[i * 3 + 1] = v.y;
+    nor[i * 3 + 2] = v.z;
+  }
+  g.setAttribute('normal', new THREE.BufferAttribute(nor, 3));
   return g;
 }

--- a/src/visual/mundo3d/kit/geometria.js
+++ b/src/visual/mundo3d/kit/geometria.js
@@ -45,6 +45,7 @@ export {
   /* Cúmulos de follaje con huecos y borde mordido (anti árbol-de-navidad). */
   sembrarFollaje,
   matojoHoja,
+  matojoNube,
 } from '../bosque/sombreadoVegetal.js';
 
 /**

--- a/src/visual/mundo3d/kit/index.js
+++ b/src/visual/mundo3d/kit/index.js
@@ -39,7 +39,7 @@ export {
   fusionarSeguro, desindexar, poner, apuntar,
   pintarPorVertice, pintarPlano, hornearFollaje, hornearCorteza,
   tuboOrganico, taperLineal, taperTronco, curvaTronco,
-  sembrarFollaje, matojoHoja, sembrarEnAnillo,
+  sembrarFollaje, matojoHoja, matojoNube, sembrarEnAnillo,
 } from './geometria.js';
 
 /* ── Terreno (heightfield con color por vértice) ────────────────────────────── */


### PR DESCRIPTION
## El bosque de páramo definitivo (toma A) — calibre valle

Deja la **toma A** (#2513) como EL bosque de piso frío, cableando la fundación
compartida y subiendo la flora del cortejo al calibre del queñual.

### Qué trae
1. **Suelo calibre consola cableado.** `EscenaBosqueVivo` monta `<SueloRico>`
   sobre `sueloDelBosque` = `crearSueloRico(...)` (relieve fbm con warp de
   dominio, claro llano para el guardián, **sendero** que entra al claro, color
   por zona, detalle al ras: piedras, paja, raíces, florecitas, sombras de
   contacto) **más** la identidad del bosque compuesta encima: la **pared del
   anfiteatro** y la **cañada del arroyo**. Se retira el terreno casero
   `geomTerrenoBosque`. Todo lo que se siembra se posa con su `alturaDe`.
2. **Los árboles dejan de ser poliedros.** roble, encenillo, aliso, gaque y
   mortiño abandonan los icosaedros literales: cada copa es **masa de hojas**
   con huecos y borde mordido (`sembrarFollaje` + `matojoNube` con normales
   **radiales** + `hornearFollaje` con AO/gradiente/contraluz), y el tronco es
   `tuboOrganico` con conicidad y corteza horneada. `copaMasa` reutiliza la
   técnica del queñual de la toma A (que ya estaba bien y no se toca).
3. **El frailejonal como paisaje, no clones.** Roseta de hojas **carnosas**
   (elipsoides de punta redonda) con tomento en gradiente + enagua de láminas
   anchas. Ahora en **tres edades entremezcladas** (joven casi al ras / adulto /
   viejo de columna alta) con **ladeo por instancia** → colonia con gradiente de
   edad y densidad, cada mata mira distinto.
4. **Kit.** `matojoNube` y `fusionarSeguro({ preservarNormales })` suben al
   taller canónico (`sombreadoVegetal`) y al barrel del kit — cero duplicados
   caseros, `fusionarSeguro` es la única fusión. El Ent conserva su mount limpio
   (`group name="mount-ent"`) para la rama que lo eleva de calibre.

### Verificación (síncrona)
- `build:prod` **verde** (dist-prod/ construido).
- `tsc:check` **limpio** (exit 0).
- vitest geometría (vitrina + terreno): **48/48**.
- Smoke headless: las 12 especies + 3 edades de frailejón + queñua fusionan con
  `position == color == normal` (sin null silencioso).
- **Capturas**: 4 franjas (mañana, amanecer, atardecer, noche) + 2 órbitas +
  hero limpio + vertical de teléfono. Se ven: el relieve y el sendero, la niebla
  con parallax por capas, los godrays, y **los árboles ya como masa de hojas**
  (no icosaedros); el frailejonal con edades variadas.

### Veredicto honesto
Primer plano ya calibre valle: los árboles del cortejo leen como masa de hojas,
el suelo tiene relieve/sendero/detalle, y el frailejonal tiene edad y densidad
variadas. Nota: la roseta del frailejón lee como pompón afelpado plateado a
media distancia (fiel al tomento; las hojas carnosas individuales resuelven de
cerca) — el operador ya la validó ("van bien").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
