### PR TITLE
feat(mundos): café, cacao y papa respiran la hora del valle — migración al kit + estilo por piso térmico

### DIFF
--- a/scripts/diag/shot-pisos-termicos.mjs
+++ b/scripts/diag/shot-pisos-termicos.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/*
+ * shot-pisos-termicos — capturas de los TRES mundos de cultivo (café, cacao,
+ * papa) en varias horas del ciclo (?ciclo=), para el ANTES/DESPUÉS de la
+ * migración al kit por piso térmico. Calca el patrón de shot3d-ruta.mjs
+ * (chromium del sistema + swiftshader) y además siembra la bienvenida vista
+ * (localStorage) para que el onboarding no intercepte la ruta del mockup.
+ *
+ * Uso: node scripts/diag/shot-pisos-termicos.mjs <outdir> [--base URL] [--pre prefijo]
+ */
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+const outdir = args[0];
+const getFlag = (n, d) => {
+  const i = args.indexOf(`--${n}`);
+  return i === -1 ? d : args[i + 1];
+};
+const base = getFlag('base', 'http://127.0.0.1:5273');
+const pre = getFlag('pre', 'despues');
+const wait = Number(getFlag('wait', 15000));
+mkdirSync(outdir, { recursive: true });
+
+/* Las tomas: cada mundo en la mañana, el atardecer (el vendedor de la toma B)
+   y la noche (la prueba de que el ciclo vive). */
+const MUNDOS = [
+  ['cafetal', '/mockups/cafetal-vivo-3d'],
+  ['cacao', '/mockups/cacao-vivo-3d'],
+  ['papa', '/mockups/papa-viva-3d'],
+];
+const HORAS = [
+  ['manana', '10'],
+  ['atardecer', '17.6'],
+  ['noche', '21'],
+];
+
+const chromiumPath = execSync('which chromium', { encoding: 'utf8' }).trim();
+const browser = await chromium.launch({
+  executablePath: chromiumPath,
+  args: [
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--disable-dev-shm-usage',
+    '--use-gl=angle',
+    '--use-angle=swiftshader',
+    '--enable-unsafe-swiftshader',
+    '--ignore-gpu-blocklist',
+  ],
+});
+
+for (const [mundo, ruta] of MUNDOS) {
+  for (const [hora, ciclo] of HORAS) {
+    const ctx = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      deviceScaleFactor: 1,
+      locale: 'es-CO',
+    });
+    const page = await ctx.newPage();
+    const errores = [];
+    page.on('pageerror', (e) => errores.push(`[pageerror] ${e.message}`));
+    await page.addInitScript(() => {
+      // la bienvenida ya se vio: que el onboarding no intercepte el mockup
+      window.localStorage.setItem('chagra:bienvenida-vista:v1', '1');
+      // sesión falsa (mismo sembrado que shot3d-ruta.mjs)
+      const sembrar = (db, store) =>
+        new Promise((res) => {
+          const req = indexedDB.open(db, 2);
+          req.onupgradeneeded = () => {
+            try { req.result.createObjectStore(store); } catch { /* ya existe */ }
+          };
+          req.onsuccess = () => {
+            try {
+              const tx = req.result.transaction(store, 'readwrite');
+              const st = tx.objectStore(store);
+              st.put('shot-diag-token', 'farmos_access_token');
+              st.put(Date.now() + 86400000, 'farmos_token_expiry');
+              tx.oncomplete = () => res(undefined);
+              tx.onerror = () => res(undefined);
+            } catch { res(undefined); }
+          };
+          req.onerror = () => res(undefined);
+        });
+      sembrar('localforage', 'keyvaluepairs');
+      sembrar('Chagra', 'syncQueue');
+    });
+    // `ciclo` va en el SEARCH (antes del #): el router de App matchea el hash
+    // EXACTO contra MOCKUP_HASH_ROUTES, y useCicloDia lee hash O search.
+    const url = `${base}/index.html?ciclo=${ciclo}#${ruta}`;
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(wait);
+    const out = `${outdir}/${pre}-${mundo}-${hora}.png`;
+    await page.screenshot({ path: out, timeout: 120000, animations: 'disabled' });
+    const canvas = await page.evaluate(() => !!document.querySelector('canvas'));
+    console.log(`[shot] ${pre} ${mundo} ${hora} canvas=${canvas} → ${out}`);
+    if (errores.length) console.log(`  ERRORES: ${errores.slice(0, 4).join(' | ')}`);
+    await ctx.close();
+  }
+}
+await browser.close();

--- a/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
+++ b/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
@@ -291,9 +291,11 @@ function Diorama({ tier, reducedMotion, foco }) {
           de tierra caliente — el atardecer del piso cálido es el cartel. */}
       <DomoCielo atm={atm} radio={64} />
 
-      {/* LA VEGA por bandas (recibe la sombra del sombrío en gama alta) */}
+      {/* LA VEGA por bandas (recibe la sombra del sombrío en gama alta).
+          El look facetado no necesita flag: con perfil.flatShading el terreno
+          ya viene DESINDEXADO con normales planas horneadas (construirTerreno). */}
       <mesh geometry={geoVega} receiveShadow={perfil.sombras}>
-        <meshToonMaterial vertexColors gradientMap={bandas} flatShading={perfil.flatShading} />
+        <meshToonMaterial vertexColors gradientMap={bandas} />
       </mesh>
 
       {/* las lomas calientes del fondo, comidas por la calina de la hora */}

--- a/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
+++ b/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
@@ -1,13 +1,16 @@
 /*
  * EscenaCacaoVivo — el MUNDO donde vive el cacao (piso cálido, 0–1.200 m).
  *
- * Una VEGA de tierra caliente a media mañana: luz dorada y pesada, el aire
- * húmedo que empaña el fondo, y el cultivo contado como es — las matas de
- * cacao sembradas a distancia pareja con sus MAZORCAS pegadas del tronco
- * (caulifloria), el SOMBRÍO de guamos tendiéndoles techo, el plátano
- * intercalado, y en la lomita del fondo la casa campesina con su cajón de
- * fermentar y la pasera donde el grano se seca al sol. La cámara mira la vega
- * desde el camino, como quien llega; se puede girar con el dedo.
+ * Una VEGA de tierra caliente EN LA HORA VIVA DEL VALLE: la atmósfera ya no es
+ * un cielo clavado sino la del kit compartido (`AtmosferaMundo`, familia
+ * `sotobosque`) — el cacaotal amanece, dora y anochece CON el valle. Y en
+ * clave de la TOMA B (estilizada Switch/BOTW, decisión por piso térmico):
+ * domo de gradiente con el glow del sol pesado (`DomoCielo`), terreno y lomas
+ * por BANDAS (`useGradienteBandas` + toon), luz dorada dramática de la franja
+ * y silueta fuerte. El cultivo se cuenta como es — las matas de cacao con sus
+ * MAZORCAS pegadas del tronco (caulifloria), el SOMBRÍO de guamos, el plátano
+ * intercalado, y en la lomita la casa con su cajón de fermentar y la pasera.
+ * La cámara LLEGA (CamaraDirector) y se puede girar con el dedo.
  *
  * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`: 'alto' con
  * sombras + bruma + luz colada; 'medio' frugal; 'bajo' mínimo. Con
@@ -28,8 +31,16 @@ import { Fauna } from '../escenas/FaunaEscena.jsx';
 import FloraCacao from './FloraCacao.jsx';
 import { ANCHO, FONDO, alturaVega, SITIO_CASA } from './floraCacao.geom.js';
 import {
-  CIELOS,
-  mezclarCielo,
+  AtmosferaMundo,
+  DomoCielo,
+  useAtmosferaMundo,
+  useGradienteBandas,
+  construirTerreno,
+  ruidoTerreno,
+  smoothstep,
+  CamaraDirector,
+} from '../kit/index.js';
+import {
   mezclar,
   VERDES,
   TIERRAS,
@@ -39,89 +50,47 @@ import {
   LUCES,
   NIEBLAS,
   PALETA,
-  LuzMadre,
 } from '../paleta/index.js';
 
-/* La atmósfera del piso cálido, DERIVADA de la madre: la familia `sotobosque`
-   (verde hondo bajo techo de hojas) mezclada 60% hacia la hora dorada — la
-   misma ley de EscenaBase3D. El cacaotal deja de inventar su cielo. */
-const CALIDO = mezclarCielo(CIELOS.sotobosque);
+/* La identidad del piso cálido dentro de la familia del valle: `sotobosque`
+   (verde hondo bajo techo de hojas). El 60% restante lo pone la HORA. */
+const FAMILIA_CACAOTAL = 'sotobosque';
 
-/* Las lomas calientes del fondo: el verde de trabajo comido por la calina
-   dorada (perspectiva aérea con los MISMOS tokens de la casa). */
-const LOMAS = {
-  cerca: mezclar(VERDES.trabajo, CALIDO.niebla, 0.22),
-  media: mezclar(VERDES.trabajo, CALIDO.niebla, 0.3),
-  lejos: mezclar(VERDES.trabajo, CALIDO.niebla, 0.4),
-};
+/* Escala de la escena para el kit (cámara↔centro ~16.5): la niebla del kit cae
+   a radio*1.4→radio*4.6 ≈ el 14→44 que este mundo ya calibró. */
+const RADIO_CACAOTAL = 10;
 
-const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
-const smoothstep = (a, b, x) => {
-  const t = clamp((x - a) / (b - a), 0, 1);
-  return t * t * (3 - 2 * t);
-};
-function ruido(wx, wz) {
-  return (
-    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
-    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
-    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
-  );
-}
+/* El frustum de sombra a medida de la vega (la luz colada del sombrío). */
+const SOMBRA_CACAOTAL = { left: -16, right: 16, top: 16, bottom: -6, far: 40 };
 
-/* La malla de la vega con colores por vértice: el mantillo pardo de hojarasca
-   que domina bajo el cacao, pasto en los claros, tierra oscura húmeda a
-   manchas y el caminito por donde se llega. */
+/* La malla de la vega — el heightfield del KIT (mismo andamiaje que todos los
+   mundos) con la pintura PROPIA del piso cálido: el mantillo pardo de
+   hojarasca que domina bajo el cacao, pasto en los claros, tierra oscura
+   húmeda a manchas y el caminito por donde se llega. */
 function construirVega(seg, plano) {
-  const nx = seg + 1;
-  const nz = seg + 1;
-  const pos = new Float32Array(nx * nz * 3);
-  const col = new Float32Array(nx * nz * 3);
   const cMantillo = new THREE.Color(TIERRAS.mantillo); // la hojarasca manda
   const cMantillo2 = new THREE.Color(TIERRAS.mantilloSombra);
   const cPasto = new THREE.Color(VERDES.calidoVivo); // el pasto del piso cálido
   const cTierra = new THREE.Color(TIERRAS.turba); // tierra oscura y húmeda
   const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.arenaOrilla, 0.35));
-  const c = new THREE.Color();
-  let p = 0;
-  for (let iz = 0; iz < nz; iz++) {
-    const wz = -FONDO / 2 + (FONDO * iz) / seg;
-    for (let ix = 0; ix < nx; ix++) {
-      const wx = -ANCHO / 2 + (ANCHO * ix) / seg;
-      pos[p] = wx;
-      pos[p + 1] = alturaVega(wx, wz);
-      pos[p + 2] = wz;
+  return construirTerreno({
+    ancho: ANCHO,
+    fondo: FONDO,
+    seg,
+    plano,
+    altura: alturaVega,
+    pintar: (wx, wz, alt, c) => {
       const adentro = smoothstep(8, 0, Math.abs(wx)) * smoothstep(6, -2, wz) * 0.5 + 0.5;
       // el mantillo de hojarasca manda bajo el cultivo
-      c.lerpColors(cMantillo, cMantillo2, 0.5 + 0.5 * ruido(wx * 0.9, wz * 0.7));
+      c.lerpColors(cMantillo, cMantillo2, 0.5 + 0.5 * ruidoTerreno(wx * 0.9, wz * 0.7));
       // el pasto asoma en los claros y hacia el frente
-      c.lerp(cPasto, smoothstep(0.15, 0.9, ruido(wx * 1.1 + 3, wz * 0.9)) * 0.5 * (1.3 - adentro));
+      c.lerp(cPasto, smoothstep(0.15, 0.9, ruidoTerreno(wx * 1.1 + 3, wz * 0.9)) * 0.5 * (1.3 - adentro));
       // la tierra oscura y húmeda a manchas
-      c.lerp(cTierra, smoothstep(0.1, 0.9, ruido(wx * 1.5 + 7, wz * 1.3 + 2)) * 0.3);
+      c.lerp(cTierra, smoothstep(0.1, 0.9, ruidoTerreno(wx * 1.5 + 7, wz * 1.3 + 2)) * 0.3);
       // el caminito por donde se llega a la casa
       c.lerp(cCamino, smoothstep(1.3, 0, Math.abs(wx - 3 - Math.sin(wz * 0.32) * 2.4)) * smoothstep(8, -12, -wz) * 0.9);
-      col[p] = c.r;
-      col[p + 1] = c.g;
-      col[p + 2] = c.b;
-      p += 3;
-    }
-  }
-  const idx = [];
-  for (let iz = 0; iz < seg; iz++) {
-    for (let ix = 0; ix < seg; ix++) {
-      const a = iz * nx + ix;
-      const b = a + 1;
-      const d = a + nx;
-      const e = d + 1;
-      idx.push(a, d, b, b, d, e);
-    }
-  }
-  let geo = new THREE.BufferGeometry();
-  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
-  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
-  geo.setIndex(idx);
-  if (plano) geo = geo.toNonIndexed();
-  geo.computeVertexNormals();
-  return geo;
+    },
+  });
 }
 
 /* La casa campesina de tierra caliente con su BENEFICIO de cacao: el CAJÓN de
@@ -273,9 +242,28 @@ const FAUNA_CACAOTAL = [
 function Diorama({ tier, reducedMotion, foco }) {
   const perfil = perfilDeTier(tier);
 
+  /* La atmósfera VIVA (misma resolución que monta AtmosferaMundo: barata,
+     cambia por franja) — alimenta el domo y la perspectiva aérea del fondo. */
+  const atm = useAtmosferaMundo({ familia: FAMILIA_CACAOTAL, reducedMotion });
+
+  /* EL gradiente de bandas de la escena (toma B): terreno y lomas comparten
+     los mismos escalones de luz — ilustración en movimiento. */
+  const bandas = useGradienteBandas();
+
   const geoVega = useMemo(
     () => construirVega(perfil.segmentosTerreno, perfil.flatShading),
     [perfil.segmentosTerreno, perfil.flatShading],
+  );
+
+  /* Las lomas calientes del fondo, comidas por la calina DE LA HORA
+     (perspectiva aérea viva: la calina se dora y se apaga con el valle). */
+  const lomas = useMemo(
+    () => ({
+      cerca: mezclar(VERDES.trabajo, atm.niebla, 0.22),
+      media: mezclar(VERDES.trabajo, atm.niebla, 0.3),
+      lejos: mezclar(VERDES.trabajo, atm.niebla, 0.4),
+    }),
+    [atm.niebla],
   );
 
   const fauna = useMemo(
@@ -283,39 +271,43 @@ function Diorama({ tier, reducedMotion, foco }) {
     [tier],
   );
 
+  const controls = useRef(null);
   const casaY = alturaVega(SITIO_CASA[0], SITIO_CASA[1]);
 
   return (
     <>
-      <color attach="background" args={[CALIDO.fondo]} />
-      {perfil.fog && <fog attach="fog" args={[CALIDO.niebla, 14, 44]} />}
-
-      {/* LA LUZ DE LA CASA: la receta madre con el tinte del sotobosque.
-          El sol pesado de tierra caliente y el frustum a medida de la vega. */}
-      <LuzMadre
-        cielo={CIELOS.sotobosque}
-        perfil={perfil}
-        solPos={[7, 13, 4]}
-        sombra={{ left: -16, right: 16, top: 16, bottom: -6, far: 40 }}
+      {/* LA ATMÓSFERA DEL KIT: fondo, niebla, luces y estrellas de LA HORA DEL
+          VALLE (familia sotobosque), con el shadow-map del sombrío en alta. */}
+      <AtmosferaMundo
+        familia={FAMILIA_CACAOTAL}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        radio={RADIO_CACAOTAL}
+        conSuelo={false}
+        sombra={SOMBRA_CACAOTAL}
       />
 
-      {/* LA VEGA (recibe la sombra del sombrío en gama alta) */}
+      {/* El DOMO de la toma B: gradiente cenit→horizonte + glow del sol pesado
+          de tierra caliente — el atardecer del piso cálido es el cartel. */}
+      <DomoCielo atm={atm} radio={64} />
+
+      {/* LA VEGA por bandas (recibe la sombra del sombrío en gama alta) */}
       <mesh geometry={geoVega} receiveShadow={perfil.sombras}>
-        <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
+        <meshToonMaterial vertexColors gradientMap={bandas} flatShading={perfil.flatShading} />
       </mesh>
 
-      {/* las lomas calientes del fondo, comidas por la calina dorada */}
+      {/* las lomas calientes del fondo, comidas por la calina de la hora */}
       <mesh position={[-14, 1.4, -20]} scale={[10, 3.2, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color={LOMAS.media} />
+        <meshToonMaterial color={lomas.media} gradientMap={bandas} />
       </mesh>
       <mesh position={[8, 1.8, -23]} scale={[12, 4.0, 6]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color={LOMAS.lejos} />
+        <meshToonMaterial color={lomas.lejos} gradientMap={bandas} />
       </mesh>
       <mesh position={[21, 1.2, -19]} scale={[8, 2.6, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color={LOMAS.cerca} />
+        <meshToonMaterial color={lomas.cerca} gradientMap={bandas} />
       </mesh>
 
       {/* EL CACAOTAL: matas, mazorcas, sombrío, plátano, luz colada */}
@@ -331,6 +323,7 @@ function Diorama({ tier, reducedMotion, foco }) {
       <FocoPaso foco={foco} reducedMotion={reducedMotion} />
 
       <OrbitControls
+        ref={controls}
         makeDefault
         target={[0, 1.2, -4]}
         enablePan={false}
@@ -345,6 +338,16 @@ function Diorama({ tier, reducedMotion, foco }) {
         dampingFactor={0.08}
         autoRotate={!reducedMotion}
         autoRotateSpeed={0.12}
+      />
+      {/* La LLEGADA del kit: dolly de establishing con tilt-down suave — entrar
+          a la vega se siente como llegar por el camino, una vez por sesión. */}
+      <CamaraDirector
+        controls={controls}
+        reposo={[2.5, 7.4, 16.5]}
+        mirada={[0, 2.2, -4]}
+        respiro={0.04}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="mundoCacaotal"
       />
       <AdaptiveDpr pixelated />
     </>

--- a/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
+++ b/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
@@ -1,13 +1,16 @@
 /*
  * EscenaCafetalVivo — el MUNDO donde vive el café (piso templado, 1.000–2.000 m).
  *
- * Una LADERA de la montaña cafetera al final de la mañana: luz tibia de media
- * montaña, bruma que se come el valle del fondo, y el cultivo contado como es —
- * los surcos de cafetos a curva de nivel ABAJO, el SOMBRÍO de guamos y nogales
- * ARRIBA tendiéndoles techo, el plátano intercalado, y al fondo, medio velada
- * por la bruma, la casa campesina con su beneficiadero y la marquesina de secar.
- * La cámara mira la ladera desde abajo, como quien llega subiendo; se puede
- * girar con el dedo.
+ * Una LADERA de la montaña cafetera EN LA HORA VIVA DEL VALLE: la atmósfera ya
+ * no es un cielo clavado sino la del kit compartido (`AtmosferaMundo`, familia
+ * `corral`) — el cafetal amanece, dora y anochece CON el valle. Y en clave de
+ * la TOMA B (estilizada Switch/BOTW, decisión por piso térmico): domo de
+ * gradiente con el glow del sol (`DomoCielo`), terreno y montes por BANDAS
+ * (`useGradienteBandas` + toon), luz dorada dramática de la franja y silueta
+ * fuerte. El cultivo se cuenta como es — los surcos de cafetos a curva de nivel
+ * ABAJO, el SOMBRÍO de guamos y nogales ARRIBA tendiéndoles techo, el plátano
+ * intercalado y la casa-beneficiadero medio velada al fondo. La cámara LLEGA
+ * (CamaraDirector, dolly de establishing) y se puede girar con el dedo.
  *
  * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`: 'alto' con
  * sombras + bruma + luz colada; 'medio' frugal; 'bajo' mínimo. Con
@@ -27,8 +30,16 @@ import { Fauna } from '../escenas/FaunaEscena.jsx';
 import FloraCafetal from './FloraCafetal.jsx';
 import { ANCHO, FONDO, alturaLadera, SITIO_CASA } from './floraCafetal.geom.js';
 import {
-  CIELOS,
-  mezclarCielo,
+  AtmosferaMundo,
+  DomoCielo,
+  useAtmosferaMundo,
+  useGradienteBandas,
+  construirTerreno,
+  ruidoTerreno,
+  smoothstep,
+  CamaraDirector,
+} from '../kit/index.js';
+import {
   mezclar,
   VERDES,
   TIERRAS,
@@ -37,87 +48,45 @@ import {
   LUCES,
   NIEBLAS,
   PALETA,
-  LuzMadre,
 } from '../paleta/index.js';
 
-/* La atmósfera del piso templado, DERIVADA de la madre: la familia `corral`
-   ("corral y cafetal: tarde de finca") mezclada 60% hacia la hora dorada —
-   la misma ley de EscenaBase3D. El cafetal deja de inventar su cielo. */
-const TEMPLADO = mezclarCielo(CIELOS.corral);
+/* La identidad del piso templado dentro de la familia del valle: `corral`
+   ("corral y cafetal: tarde de finca"). El 60% restante lo pone la HORA. */
+const FAMILIA_CAFETAL = 'corral';
 
-/* Las montañas del fondo: el monte templado comido por la niebla dorada
-   (perspectiva aérea con los MISMOS tokens, no tres verdes sueltos). */
-const MONTES = {
-  cerca: mezclar(VERDES.monte, TEMPLADO.niebla, 0.2),
-  media: mezclar(VERDES.monte, TEMPLADO.niebla, 0.28),
-  lejos: mezclar(VERDES.monte, TEMPLADO.niebla, 0.38),
-};
+/* Escala de la escena para el kit (cámara↔centro ~14.5): la niebla del kit cae
+   a radio*1.4→radio*4.6 ≈ el 16→46 que este mundo ya calibró. */
+const RADIO_CAFETAL = 11;
 
-const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
-const smoothstep = (a, b, x) => {
-  const t = clamp((x - a) / (b - a), 0, 1);
-  return t * t * (3 - 2 * t);
-};
-function ruido(wx, wz) {
-  return (
-    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
-    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
-    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
-  );
-}
+/* El frustum de sombra a medida de la ladera (la luz colada del sombrío). */
+const SOMBRA_CAFETAL = { left: -16, right: 16, top: 16, bottom: -6, far: 40 };
 
-/* La malla de la ladera con colores por vértice: arvenses verdes (cobertura
+/* La malla de la ladera — el heightfield del KIT (mismo andamiaje que todos los
+   mundos) con la pintura PROPIA del piso templado: arvenses verdes (cobertura
    viva), tierra roja andina asomando y el mantillo pardo hacia la sombra. */
 function construirLadera(seg, plano) {
-  const nx = seg + 1;
-  const nz = seg + 1;
-  const pos = new Float32Array(nx * nz * 3);
-  const col = new Float32Array(nx * nz * 3);
   const cPasto = new THREE.Color(VERDES.brote); // pasto al sol del piso templado
   const cPasto2 = new THREE.Color(VERDES.calido); // el oliva que asoma hacia lo seco
   const cTierra = new THREE.Color(TIERRAS.arcilla); // la tierra roja cafetera
   const cMantillo = new THREE.Color(TIERRAS.mantillo); // hojarasca bajo el sombrío
   const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.4));
-  const c = new THREE.Color();
-  let p = 0;
-  for (let iz = 0; iz < nz; iz++) {
-    const wz = -FONDO / 2 + (FONDO * iz) / seg;
-    for (let ix = 0; ix < nx; ix++) {
-      const wx = -ANCHO / 2 + (ANCHO * ix) / seg;
-      pos[p] = wx;
-      pos[p + 1] = alturaLadera(wx, wz);
-      pos[p + 2] = wz;
+  return construirTerreno({
+    ancho: ANCHO,
+    fondo: FONDO,
+    seg,
+    plano,
+    altura: alturaLadera,
+    pintar: (wx, wz, alt, c) => {
       const enLoma = smoothstep(5, -8, wz);
-      c.lerpColors(cPasto, cPasto2, 0.5 + 0.5 * ruido(wx * 0.9, wz * 0.7));
+      c.lerpColors(cPasto, cPasto2, 0.5 + 0.5 * ruidoTerreno(wx * 0.9, wz * 0.7));
       // la tierra roja asoma a manchas entre los surcos
-      c.lerp(cTierra, smoothstep(-0.1, 0.85, ruido(wx * 1.3, wz * 1.1)) * 0.45 * enLoma);
+      c.lerp(cTierra, smoothstep(-0.1, 0.85, ruidoTerreno(wx * 1.3, wz * 1.1)) * 0.45 * enLoma);
       // el mantillo pardo gana hacia lo alto (más sombrío, más hojarasca)
       c.lerp(cMantillo, enLoma * 0.22);
       // el caminito seco del frente, por donde se llega
       c.lerp(cCamino, smoothstep(1.2, 0, Math.abs(wx - Math.sin(wz * 0.4) * 2.2)) * smoothstep(2, 12, wz));
-      col[p] = c.r;
-      col[p + 1] = c.g;
-      col[p + 2] = c.b;
-      p += 3;
-    }
-  }
-  const idx = [];
-  for (let iz = 0; iz < seg; iz++) {
-    for (let ix = 0; ix < seg; ix++) {
-      const a = iz * nx + ix;
-      const b = a + 1;
-      const d = a + nx;
-      const e = d + 1;
-      idx.push(a, d, b, b, d, e);
-    }
-  }
-  let geo = new THREE.BufferGeometry();
-  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
-  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
-  geo.setIndex(idx);
-  if (plano) geo = geo.toNonIndexed();
-  geo.computeVertexNormals();
-  return geo;
+    },
+  });
 }
 
 /* La casa campesina con su BENEFICIADERO, arriba al fondo: paredes encaladas,
@@ -248,9 +217,28 @@ const FAUNA_CAFETAL = [
 function Diorama({ tier, reducedMotion, foco }) {
   const perfil = perfilDeTier(tier);
 
+  /* La atmósfera VIVA (misma resolución que monta AtmosferaMundo: barata,
+     cambia por franja) — alimenta el domo y la perspectiva aérea del fondo. */
+  const atm = useAtmosferaMundo({ familia: FAMILIA_CAFETAL, reducedMotion });
+
+  /* EL gradiente de bandas de la escena (toma B): terreno y montes comparten
+     los mismos escalones de luz — ilustración en movimiento. */
+  const bandas = useGradienteBandas();
+
   const geoLadera = useMemo(
     () => construirLadera(perfil.segmentosTerreno, perfil.flatShading),
     [perfil.segmentosTerreno, perfil.flatShading],
+  );
+
+  /* Las montañas del fondo, comidas por la niebla DE LA HORA (perspectiva
+     aérea viva: al atardecer se doran, de noche se apagan con el valle). */
+  const montes = useMemo(
+    () => ({
+      cerca: mezclar(VERDES.monte, atm.niebla, 0.2),
+      media: mezclar(VERDES.monte, atm.niebla, 0.28),
+      lejos: mezclar(VERDES.monte, atm.niebla, 0.38),
+    }),
+    [atm.niebla],
   );
 
   const fauna = useMemo(
@@ -258,39 +246,43 @@ function Diorama({ tier, reducedMotion, foco }) {
     [tier],
   );
 
+  const controls = useRef(null);
   const casaY = alturaLadera(SITIO_CASA[0], SITIO_CASA[1]);
 
   return (
     <>
-      <color attach="background" args={[TEMPLADO.fondo]} />
-      {perfil.fog && <fog attach="fog" args={[TEMPLADO.niebla, 16, 46]} />}
-
-      {/* LA LUZ DE LA CASA: la receta madre con el tinte de la familia corral.
-          El sol alto de la composición y el frustum a medida de la ladera. */}
-      <LuzMadre
-        cielo={CIELOS.corral}
-        perfil={perfil}
-        solPos={[8, 12, 5]}
-        sombra={{ left: -16, right: 16, top: 16, bottom: -6, far: 40 }}
+      {/* LA ATMÓSFERA DEL KIT: fondo, niebla, luces y estrellas de LA HORA DEL
+          VALLE (familia corral), con el shadow-map del sombrío en gama alta. */}
+      <AtmosferaMundo
+        familia={FAMILIA_CAFETAL}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        radio={RADIO_CAFETAL}
+        conSuelo={false}
+        sombra={SOMBRA_CAFETAL}
       />
 
-      {/* LA LADERA (recibe la sombra del sombrío en gama alta) */}
+      {/* El DOMO de la toma B: gradiente cenit→horizonte + glow del sol de la
+          franja — el atardecer del piso templado es el cartel. */}
+      <DomoCielo atm={atm} radio={64} />
+
+      {/* LA LADERA por bandas (recibe la sombra del sombrío en gama alta) */}
       <mesh geometry={geoLadera} receiveShadow={perfil.sombras}>
-        <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
+        <meshToonMaterial vertexColors gradientMap={bandas} flatShading={perfil.flatShading} />
       </mesh>
 
-      {/* las montañas cafeteras del fondo, comidas por la niebla dorada */}
+      {/* las montañas cafeteras del fondo, comidas por la niebla de la hora */}
       <mesh position={[-13, 2.2, -21]} scale={[9, 4.2, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color={MONTES.media} />
+        <meshToonMaterial color={montes.media} gradientMap={bandas} />
       </mesh>
       <mesh position={[9, 2.6, -24]} scale={[11, 5.4, 6]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color={MONTES.lejos} />
+        <meshToonMaterial color={montes.lejos} gradientMap={bandas} />
       </mesh>
       <mesh position={[22, 1.6, -20]} scale={[8, 3.4, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color={MONTES.cerca} />
+        <meshToonMaterial color={montes.cerca} gradientMap={bandas} />
       </mesh>
 
       {/* EL CAFETAL: surcos, cerezas, sombrío, plátano, luz colada */}
@@ -306,6 +298,7 @@ function Diorama({ tier, reducedMotion, foco }) {
       <FocoPaso foco={foco} reducedMotion={reducedMotion} />
 
       <OrbitControls
+        ref={controls}
         makeDefault
         target={[0, 2.6, -3]}
         enablePan={false}
@@ -320,6 +313,16 @@ function Diorama({ tier, reducedMotion, foco }) {
         dampingFactor={0.08}
         autoRotate={!reducedMotion}
         autoRotateSpeed={0.12}
+      />
+      {/* La LLEGADA del kit: dolly de establishing con tilt-down suave — entrar
+          al cafetal se siente como llegar subiendo, una vez por sesión. */}
+      <CamaraDirector
+        controls={controls}
+        reposo={[1.5, 4.6, 14.5]}
+        mirada={[0, 3.6, -3]}
+        respiro={0.04}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="mundoCafetal"
       />
       <AdaptiveDpr pixelated />
     </>

--- a/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
+++ b/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
@@ -266,9 +266,11 @@ function Diorama({ tier, reducedMotion, foco }) {
           franja — el atardecer del piso templado es el cartel. */}
       <DomoCielo atm={atm} radio={64} />
 
-      {/* LA LADERA por bandas (recibe la sombra del sombrío en gama alta) */}
+      {/* LA LADERA por bandas (recibe la sombra del sombrío en gama alta).
+          El look facetado no necesita flag: con perfil.flatShading el terreno
+          ya viene DESINDEXADO con normales planas horneadas (construirTerreno). */}
       <mesh geometry={geoLadera} receiveShadow={perfil.sombras}>
-        <meshToonMaterial vertexColors gradientMap={bandas} flatShading={perfil.flatShading} />
+        <meshToonMaterial vertexColors gradientMap={bandas} />
       </mesh>
 
       {/* las montañas cafeteras del fondo, comidas por la niebla de la hora */}

--- a/src/visual/mundo3d/kit/AtmosferaMundo.jsx
+++ b/src/visual/mundo3d/kit/AtmosferaMundo.jsx
@@ -37,6 +37,12 @@ import { useAtmosferaMundo } from './atmosfera.js';
  *   "posan" el diorama. Póngalo en false si la escena ya trae su propio suelo.
  * @param {boolean} [props.conNiebla=true]  monta la niebla de profundidad.
  * @param {boolean} [props.conEstrellas=true]  deja asomar las estrellas de noche.
+ * @param {{left:number,right:number,top:number,bottom:number,far:number}|null}
+ *   [props.sombra=null]  frustum de sombra a medida de la escena (el contrato de
+ *   LuzMadre): cuando viene Y el tier lo permite (perfil.sombras, solo 'alto'),
+ *   el sol de la franja proyecta shadow-map real — la luz colada del sombrío que
+ *   los mundos de cultivo no pueden perder. Sin `sombra`, cero shadow-map (el
+ *   costo de siempre).
  */
 export default function AtmosferaMundo({
   familia = 'neutro',
@@ -47,10 +53,12 @@ export default function AtmosferaMundo({
   conSuelo = true,
   conNiebla = true,
   conEstrellas = true,
+  sombra = null,
 }) {
   const atm = useAtmosferaMundo({ familia, reducedMotion });
   const frugal = tier === 'bajo';
   const perfil = perfilDeTier(tier);
+  const conSombra = !!(sombra && perfil.sombras);
 
   return (
     <>
@@ -62,8 +70,23 @@ export default function AtmosferaMundo({
       <ambientLight intensity={0.28 * atm.intensidad} color={atm.luz} />
       {/* El sol de la franja — mismo arco que el valle (rasante al amanecer,
           cenital al mediodía, luna de noche): el lenguaje de sombreado no cambia
-          al entrar al mundo. */}
-      <directionalLight position={atm.solPos} intensity={0.9 * atm.intensidad} color={atm.luz} />
+          al entrar al mundo. Con `sombra` (y tier alto) proyecta shadow-map. */}
+      <directionalLight
+        position={atm.solPos}
+        intensity={0.9 * atm.intensidad}
+        color={atm.luz}
+        castShadow={conSombra}
+        {...(conSombra
+          ? {
+              'shadow-mapSize': [1024, 1024],
+              'shadow-camera-far': sombra.far ?? 30,
+              'shadow-camera-left': sombra.left ?? -12,
+              'shadow-camera-right': sombra.right ?? 12,
+              'shadow-camera-top': sombra.top ?? 12,
+              'shadow-camera-bottom': sombra.bottom ?? -12,
+            }
+          : null)}
+      />
       {/* Relleno frío tenue desde el lado opuesto: despega los volúmenes del
           fondo cálido sin matar el contraste (clave del look claymation). */}
       <directionalLight position={[-5, 4, -6]} intensity={0.22} color={atm.relleno} />

--- a/src/visual/mundo3d/kit/DomoCielo.jsx
+++ b/src/visual/mundo3d/kit/DomoCielo.jsx
@@ -1,0 +1,117 @@
+/*
+ * DomoCielo — el CIELO CON DOMO de la toma B (estilizada Switch/BOTW), como
+ * pieza del kit para cualquier "mundo vivo".
+ *
+ * El fondo plano (`<color attach="background">`) cuenta la hora pero no VENDE:
+ * la toma B del bosque (#2510) demostró que un domo de gradiente
+ * cenit→horizonte con el glow del sol es lo que vuelve el atardecer un
+ * cartel. Este componente saca ese shader (mínimo: 2 mix y un pow, corre en
+ * Android barato) del take y lo alimenta con la MISMA atmósfera viva del kit
+ * (`useAtmosferaMundo`): el domo amanece, dora y anochece con el valle, sin
+ * tablas propias de color.
+ *
+ * Derivación (cero fuentes nuevas de verdad):
+ *   · horizonte = atm.niebla  → el domo EMPATA con el fog que come el fondo.
+ *   · cenit     = atm.cielo   → la bóveda del hemisferio de la familia.
+ *   · glow      = atm.luz     → el halo alrededor del sol/luna de la franja.
+ *   · dirección = atm.solPos  → el mismo arco del día del valle.
+ * La FUERZA del glow sí es capa gráfica por franja (el atardecer vende, el
+ * mediodía apenas insinúa): tabla GLOW_FRANJA, calcada de la toma B.
+ *
+ * Uso (dentro del Canvas, junto a <AtmosferaMundo>):
+ *   const atm = useAtmosferaMundo({ familia, reducedMotion });
+ *   <DomoCielo atm={atm} radio={60} />
+ *
+ * El material NO escribe depth (todo lo demás pinta encima) y va BackSide
+ * (la cámara vive adentro). Importa three → solo para archivos de escena.
+ */
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+
+/* La capa gráfica por franja: cuánto vende el halo del astro (toma B). */
+const GLOW_FRANJA = {
+  amanecer: 0.55,
+  manana: 0.3,
+  mediodia: 0.22,
+  tarde: 0.32,
+  atardecer: 0.75,
+  noche: 0.32,
+};
+
+const VERT = /* glsl */ `
+  varying vec3 vPos;
+  void main() {
+    vPos = position;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+const FRAG = /* glsl */ `
+  varying vec3 vPos;
+  uniform vec3 uCenit;
+  uniform vec3 uHorizonte;
+  uniform vec3 uAstro;
+  uniform vec3 uSolDir;
+  uniform float uGlow;
+  void main() {
+    vec3 dir = normalize(vPos);
+    float h = clamp(dir.y, 0.0, 1.0);
+    vec3 col = mix(uHorizonte, uCenit, pow(h, 0.58));
+    float s = pow(max(dot(dir, normalize(uSolDir)), 0.0), 5.0);
+    col += uAstro * s * uGlow;
+    gl_FragColor = vec4(col, 1.0);
+  }
+`;
+
+/**
+ * @param {object} props
+ * @param {import('./atmosfera.js').AtmosferaMundo} props.atm  la atmósfera viva
+ *   resuelta (de `useAtmosferaMundo`) — el domo hereda sus colores y su sol.
+ * @param {number} [props.radio=60]  radio del domo; MÁS GRANDE que el far de la
+ *   niebla de la escena, para que el fog nunca lo recorte raro.
+ * @param {number|null} [props.glow=null]  fuerza del halo; null → la tabla por
+ *   franja de la toma B (el atardecer vende).
+ */
+export default function DomoCielo({ atm, radio = 60, glow = null }) {
+  const meshRef = useRef(null);
+  const material = useMemo(
+    () =>
+      new THREE.ShaderMaterial({
+        vertexShader: VERT,
+        fragmentShader: FRAG,
+        uniforms: {
+          uCenit: { value: new THREE.Color('#6fb0dd') },
+          uHorizonte: { value: new THREE.Color('#eae9c0') },
+          uAstro: { value: new THREE.Color('#fff3cf') },
+          uSolDir: { value: new THREE.Vector3(6, 9, 4) },
+          uGlow: { value: 0.3 },
+        },
+        side: THREE.BackSide,
+        depthWrite: false,
+        fog: false,
+      }),
+    [],
+  );
+  useEffect(() => () => material.dispose(), [material]);
+
+  /* La franja cambia unas pocas veces al día: escribir uniforms ahí es gratis
+     (mismo contrato de snap que AtmosferaMundo — el velo Odyssey cubre a los
+     mundos al entrar; dentro, la franja rara vez cruza en cámara). Escritura
+     imperativa a través del REF del mesh (el patrón de la casa), en
+     layout-effect: antes del primer frame pintado. */
+  useLayoutEffect(() => {
+    const m = meshRef.current;
+    if (!m) return;
+    const u = m.material.uniforms;
+    u.uCenit.value.set(atm.cielo);
+    u.uHorizonte.value.set(atm.niebla);
+    u.uAstro.value.set(atm.luz);
+    u.uSolDir.value.set(atm.solPos[0], atm.solPos[1], atm.solPos[2]);
+    u.uGlow.value = glow ?? GLOW_FRANJA[atm.franja] ?? 0.3;
+  }, [atm, glow]);
+
+  return (
+    <mesh ref={meshRef} material={material} renderOrder={-10} frustumCulled={false}>
+      <sphereGeometry args={[radio, 24, 12]} />
+    </mesh>
+  );
+}

--- a/src/visual/mundo3d/kit/DomoCielo.jsx
+++ b/src/visual/mundo3d/kit/DomoCielo.jsx
@@ -102,8 +102,13 @@ export default function DomoCielo({ atm, radio = 60, glow = null }) {
     const m = meshRef.current;
     if (!m) return;
     const u = m.material.uniforms;
-    u.uCenit.value.set(atm.cielo);
-    u.uHorizonte.value.set(atm.niebla);
+    /* La NOCHE apaga el domo: las familias cálidas (corral, sotobosque)
+       aportan su 40% claro a la mezcla y sin esto el cielo nocturno queda
+       gris-lavado. `intensidad` ya ES "cuánto baja la hora" (noche 0.55,
+       día ≥0.9): se reusa como atenuador — de día no muerde (clamp a 1). */
+    const kNoche = Math.min(1, 0.22 + 0.78 * atm.intensidad);
+    u.uCenit.value.set(atm.cielo).multiplyScalar(kNoche);
+    u.uHorizonte.value.set(atm.niebla).multiplyScalar(kNoche);
     u.uAstro.value.set(atm.luz);
     u.uSolDir.value.set(atm.solPos[0], atm.solPos[1], atm.solPos[2]);
     u.uGlow.value = glow ?? GLOW_FRANJA[atm.franja] ?? 0.3;

--- a/src/visual/mundo3d/kit/bandas.js
+++ b/src/visual/mundo3d/kit/bandas.js
@@ -1,0 +1,61 @@
+/*
+ * kit/bandas — el COLOR POR BANDAS de la toma B (toon de N pasos), compartido.
+ *
+ * La toma B del bosque (#2510) probó la clave estilizada Switch/BOTW: UN
+ * gradientMap escalonado (NearestFilter) compartido por todos los materiales
+ * toon de la escena — las bandas de luz + el color por vértice = ilustración
+ * en movimiento, silueta fuerte, cero texturas externas. Aquí vive la textura
+ * canónica para que cafetal, cacaotal y quien venga bandeen IGUAL (mismos
+ * escalones = misma familia visual), en vez de que cada escena hornee la suya.
+ *
+ * Uso (en la escena, con material JSX de r3f — r3f ya gestiona el dispose):
+ *   const bandas = useGradienteBandas();
+ *   <meshToonMaterial vertexColors gradientMap={bandas} />
+ *
+ * Importa three (DataTexture) → solo para archivos de escena (chunk
+ * vendor-three), como el resto del kit.
+ */
+import { useEffect, useMemo } from 'react';
+import * as THREE from 'three';
+
+/* Los escalones canónicos de la toma B: 4 pasos, del hueco de sombra (70) al
+   plano al sol (255). Menos pasos = más cartel; más pasos = más suave. */
+const PASOS_TAKE_B = [70, 128, 192, 255];
+
+/**
+ * Crea el gradientMap escalonado (pura, three-core; el llamador es dueño de la
+ * textura y de su dispose). Con `pasos` distinto de 4 interpola linealmente
+ * entre los extremos canónicos.
+ *
+ * @param {number} [pasos=4]  número de bandas de luz.
+ * @returns {THREE.DataTexture} textura 1×N lista como `gradientMap`.
+ */
+export function crearGradienteBandas(pasos = 4) {
+  const datos =
+    pasos === PASOS_TAKE_B.length
+      ? new Uint8Array(PASOS_TAKE_B)
+      : new Uint8Array(
+          Array.from({ length: pasos }, (_, i) =>
+            Math.round(70 + (185 * i) / Math.max(1, pasos - 1)),
+          ),
+        );
+  const tex = new THREE.DataTexture(datos, pasos, 1, THREE.RedFormat);
+  tex.minFilter = THREE.NearestFilter;
+  tex.magFilter = THREE.NearestFilter;
+  tex.needsUpdate = true;
+  return tex;
+}
+
+/**
+ * Hook: EL gradiente de bandas de la escena, memoizado y con dispose al
+ * desmontar. Compártalo entre TODOS los `<meshToonMaterial>` de la escena
+ * (esa unidad es el look).
+ *
+ * @param {number} [pasos=4]
+ * @returns {THREE.DataTexture}
+ */
+export function useGradienteBandas(pasos = 4) {
+  const tex = useMemo(() => crearGradienteBandas(pasos), [pasos]);
+  useEffect(() => () => tex.dispose(), [tex]);
+  return tex;
+}

--- a/src/visual/mundo3d/kit/index.js
+++ b/src/visual/mundo3d/kit/index.js
@@ -49,6 +49,10 @@ export { construirTerreno } from './terreno.js';
 export { atmosferaDeFamilia, useAtmosferaMundo } from './atmosfera.js';
 export { default as AtmosferaMundo } from './AtmosferaMundo.jsx';
 
+/* ── Cielo con domo + color por bandas (la clave estilizada de la toma B) ────── */
+export { default as DomoCielo } from './DomoCielo.jsx';
+export { crearGradienteBandas, useGradienteBandas } from './bandas.js';
+
 /* ── Paleta madre + cielos por hora (dirección de arte central) ─────────────── */
 export { ATMOSFERA, PALETA, CIELOS, BLOOM, mezclar, mezclarCielo } from '../atmosferaMadre.js';
 export {

--- a/src/visual/mundo3d/papa/EscenaPapaVivo.jsx
+++ b/src/visual/mundo3d/papa/EscenaPapaVivo.jsx
@@ -1,15 +1,18 @@
 /*
  * EscenaPapaVivo — el MUNDO donde vive la papa (piso frío, 2.000–3.200 m).
  *
- * Una LADERA de tierra fría a media mañana: cielo despejado y azul de montaña
- * alta, luz blanca y dura (a esa altura el sol no perdona), y el cultivo
- * contado como es — los SURCOS: caballones de tierra negra amontonada a curva
- * de nivel, con la mata de papa aporcada encima de cada lomo. El caballón va
- * horneado EN EL RELIEVE del terreno (se lee la tierra alzada, no una raya
- * pintada). Alrededor el pajonal amarillo del frío, al fondo la loma alta con
- * frailejones en silueta (el páramo queda ahí no más), la casita campesina con
- * sus costales, y en un claro la COSECHA: la tierra abierta y las papas
- * criollas destapadas — amarillas, rojas y moradas.
+ * Una LADERA de tierra fría EN LA HORA VIVA DEL VALLE: la atmósfera ya no es
+ * un cielo clavado sino la del kit compartido (`AtmosferaMundo`, familia
+ * `ladera`) — el papal amanece, aclara y anochece CON el valle. Y en clave de
+ * la TOMA A (naturalista, decisión por piso térmico): la NIEBLA es la
+ * protagonista — bruma lechosa verde-plata que se acerca y se come los cerros
+ * (la misma BRUMA que ganó en el bosque #2513) — y una luz fría de altura que
+ * platea sin dorar. El cultivo se cuenta como es — los SURCOS: caballones de
+ * tierra negra amontonada a curva de nivel, con la mata de papa aporcada
+ * encima de cada lomo, horneados EN EL RELIEVE del terreno. Alrededor el
+ * pajonal amarillo del frío, la loma alta con frailejones en silueta, la
+ * casita campesina con sus costales y el claro de la COSECHA con las papas
+ * criollas destapadas. La cámara LLEGA (CamaraDirector) y se gira con el dedo.
  *
  * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`: 'alto' con
  * sombras + vaho; 'medio' frugal; 'bajo' mínimo. Con `reducedMotion` el mundo
@@ -36,8 +39,14 @@ import {
   SITIO_COSECHA,
 } from './floraPapa.geom.js';
 import {
-  CIELOS,
-  mezclarCielo,
+  AtmosferaMundo,
+  useAtmosferaMundo,
+  construirTerreno,
+  ruidoTerreno,
+  smoothstep,
+  CamaraDirector,
+} from '../kit/index.js';
+import {
   mezclar,
   VERDES,
   TIERRAS,
@@ -45,46 +54,31 @@ import {
   ACENTOS,
   LUCES,
   NEUTROS,
-  LuzMadre,
 } from '../paleta/index.js';
 
-/* La atmósfera del piso frío, DERIVADA de la madre: la familia `ladera`
-   ("bruma sí, pero verde-plata, no celeste frío") mezclada 60% hacia la hora
-   dorada — la misma ley de EscenaBase3D. El cielo azul de postal se va: el
-   frío se cuenta con los verdes callados y la bruma, no con otro sol. */
-const FRIO = mezclarCielo(CIELOS.ladera);
+/* La identidad del piso frío dentro de la familia del valle: `ladera`
+   ("bruma sí, pero verde-plata, no celeste frío"). La HORA pone el resto. */
+const FAMILIA_PAPAL = 'ladera';
 
-/* Los cerros del fondo, ya con cara de páramo: la hoja coriácea comida por
-   la bruma dorada (perspectiva aérea con los MISMOS tokens de la casa). */
-const CERROS = {
-  cerca: mezclar(VERDES.paramoHoja, FRIO.niebla, 0.22),
-  media: mezclar(VERDES.paramoHoja, FRIO.niebla, 0.3),
-  lejos: mezclar(VERDES.paramoHoja, FRIO.niebla, 0.4),
-  filo: mezclar(TIERRAS.rocaParamo, FRIO.niebla, 0.45),
-};
+/* Escala de la escena para el kit (cámara↔centro ~15.5). La niebla NO la pone
+   el kit aquí (conNiebla={false}): en la toma A la bruma es la protagonista y
+   este mundo la monta más CERCA y más lechosa (abajo, BRUMA_FRIA). */
+const RADIO_PAPAL = 12;
 
-const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
-const smoothstep = (a, b, x) => {
-  const t = clamp((x - a) / (b - a), 0, 1);
-  return t * t * (3 - 2 * t);
-};
-function ruido(wx, wz) {
-  return (
-    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
-    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
-    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
-  );
-}
+/* La bruma verde-plata de la toma A (#2513, la que ganó en el bosque): el fog
+   de la hora se sesga hacia esta leche fría — de noche la bruma CEDE y el
+   índigo del cine manda (sin esto la noche queda gris-lavada). */
+const BRUMA_FRIA = '#c6d1ce';
 
-/* La malla de la ladera con colores por vértice: el LOMO del caballón en tierra
-   negra recién aporcada, el surco hondo entre lomos más húmedo y oscuro, y
-   afuera del lote el pajonal amarillo-verde del frío. Los caballones van en la
-   ALTURA (alturaLadera ya los trae horneados): el relieve se lee de verdad. */
+/* El frustum de sombra a medida del papal (el sol duro de la altura). */
+const SOMBRA_PAPAL = { left: -17, right: 17, top: 17, bottom: -7, far: 44 };
+
+/* La malla de la ladera — el heightfield del KIT (mismo andamiaje que todos
+   los mundos) con la pintura PROPIA del piso frío: el LOMO del caballón en
+   tierra negra recién aporcada, el surco hondo entre lomos más húmedo y
+   oscuro, y afuera del lote el pajonal amarillo-verde del frío. Los caballones
+   van en la ALTURA (alturaLadera ya los trae horneados): relieve de verdad. */
 function construirLadera(seg, plano) {
-  const nx = seg + 1;
-  const nz = seg + 1;
-  const pos = new Float32Array(nx * nz * 3);
-  const col = new Float32Array(nx * nz * 3);
   const cPajonal = new THREE.Color(mezclar(TIERRAS.pajonal, VERDES.paramoLiquen, 0.5));
   const cPajonal2 = new THREE.Color(VERDES.paramoLiquen);
   const cLomo = new THREE.Color(mezclar(TIERRAS.turba, NEUTROS.tinta, 0.3)); // tierra negra del caballón
@@ -92,20 +86,17 @@ function construirLadera(seg, plano) {
   const cSurco = new THREE.Color(mezclar(TIERRAS.turba, NEUTROS.tinta, 0.65)); // el fondo húmedo entre lomos
   const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.25));
   const cLoma = new THREE.Color(mezclar(VERDES.paramoLiquen, VERDES.paramoMusgo, 0.4)); // la loma alta, parda de frío
-  const c = new THREE.Color();
-  let p = 0;
-  for (let iz = 0; iz < nz; iz++) {
-    const wz = -FONDO / 2 + (FONDO * iz) / seg;
-    for (let ix = 0; ix < nx; ix++) {
-      const wx = -ANCHO / 2 + (ANCHO * ix) / seg;
-      pos[p] = wx;
-      pos[p + 1] = alturaLadera(wx, wz);
-      pos[p + 2] = wz;
-
+  return construirTerreno({
+    ancho: ANCHO,
+    fondo: FONDO,
+    seg,
+    plano,
+    altura: alturaLadera,
+    pintar: (wx, wz, alt, c) => {
       const s = reliefSurco(wx, wz);
       const enLoma = smoothstep(-8, -17, wz);
       // base: pajonal con manchas, y hacia la loma alta se apaga de frío
-      c.lerpColors(cPajonal, cPajonal2, 0.5 + 0.5 * ruido(wx * 0.9, wz * 0.7));
+      c.lerpColors(cPajonal, cPajonal2, 0.5 + 0.5 * ruidoTerreno(wx * 0.9, wz * 0.7));
       c.lerp(cLoma, enLoma * 0.55);
       // dentro del lote: el surco húmedo de fondo…
       c.lerp(cSurco, s.lote * 0.85);
@@ -122,29 +113,8 @@ function construirLadera(seg, plano) {
         cCamino,
         smoothstep(1.3, 0, Math.abs(wx - 4 - Math.sin(wz * 0.35) * 2.4)) * smoothstep(4, 14, wz),
       );
-      col[p] = c.r;
-      col[p + 1] = c.g;
-      col[p + 2] = c.b;
-      p += 3;
-    }
-  }
-  const idx = [];
-  for (let iz = 0; iz < seg; iz++) {
-    for (let ix = 0; ix < seg; ix++) {
-      const a = iz * nx + ix;
-      const b = a + 1;
-      const d = a + nx;
-      const e = d + 1;
-      idx.push(a, d, b, b, d, e);
-    }
-  }
-  let geo = new THREE.BufferGeometry();
-  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
-  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
-  geo.setIndex(idx);
-  if (plano) geo = geo.toNonIndexed();
-  geo.computeVertexNormals();
-  return geo;
+    },
+  });
 }
 
 /* La casita campesina de tierra fría, arriba al fondo: paredes de adobe
@@ -296,9 +266,33 @@ const FAUNA_PAPAL = [
 function Diorama({ tier, reducedMotion, foco }) {
   const perfil = perfilDeTier(tier);
 
+  /* La atmósfera VIVA (misma resolución que monta AtmosferaMundo: barata,
+     cambia por franja) — alimenta la bruma propia y los cerros del fondo. */
+  const atm = useAtmosferaMundo({ familia: FAMILIA_PAPAL, reducedMotion });
+
+  /* La NIEBLA PROTAGONISTA de la toma A: el fog de la hora sesgado a la leche
+     verde-plata, y MÁS CERCA que en los pisos calientes (aquí la bruma manda).
+     De noche la bruma cede al índigo del cine (kFria baja). */
+  const nieblaFria = useMemo(
+    () => mezclar(atm.niebla, BRUMA_FRIA, atm.franja === 'noche' ? 0.25 : 0.5),
+    [atm.niebla, atm.franja],
+  );
+
   const geoLadera = useMemo(
     () => construirLadera(perfil.segmentosTerreno, perfil.flatShading),
     [perfil.segmentosTerreno, perfil.flatShading],
+  );
+
+  /* Los cerros del fondo, comidos por la bruma DE LA HORA (perspectiva aérea
+     viva: platean de día, azulean de noche, con el valle). */
+  const cerros = useMemo(
+    () => ({
+      cerca: mezclar(VERDES.paramoHoja, nieblaFria, 0.22),
+      media: mezclar(VERDES.paramoHoja, nieblaFria, 0.3),
+      lejos: mezclar(VERDES.paramoHoja, nieblaFria, 0.4),
+      filo: mezclar(TIERRAS.rocaParamo, nieblaFria, 0.45),
+    }),
+    [nieblaFria],
   );
 
   const fauna = useMemo(
@@ -306,45 +300,52 @@ function Diorama({ tier, reducedMotion, foco }) {
     [tier],
   );
 
+  const controls = useRef(null);
   const casaY = alturaLadera(SITIO_CASA[0], SITIO_CASA[1]);
   const cosechaY = alturaLadera(SITIO_COSECHA[0], SITIO_COSECHA[1]);
 
   return (
     <>
-      <color attach="background" args={[FRIO.fondo]} />
-      {perfil.fog && <fog attach="fog" args={[FRIO.niebla, 22, 58]} />}
-
-      {/* LA LUZ DE LA CASA: la receta madre con el tinte de la ladera de
-          páramo. El sol alto del frío y el frustum a medida del papal. */}
-      <LuzMadre
-        cielo={CIELOS.ladera}
-        perfil={perfil}
-        solPos={[9, 14, 6]}
-        sombra={{ left: -17, right: 17, top: 17, bottom: -7, far: 44 }}
+      {/* LA ATMÓSFERA DEL KIT: fondo, luces y estrellas de LA HORA DEL VALLE
+          (familia ladera), con el shadow-map del sol duro en gama alta. La
+          niebla va aparte (protagonista, abajo). */}
+      <AtmosferaMundo
+        familia={FAMILIA_PAPAL}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        radio={RADIO_PAPAL}
+        conSuelo={false}
+        conNiebla={false}
+        sombra={SOMBRA_PAPAL}
       />
+      {/* La bruma lechosa de la toma A: cerca y espesa — se come los cerros. */}
+      {perfil.fog && <fog attach="fog" args={[nieblaFria, 14, 46]} />}
+      {/* La luz FRÍA de la altura: un relleno plata desde arriba que platea
+          los lomos sin dorarlos (el toque naturalista del piso frío). */}
+      <directionalLight position={[-4, 10, -2]} intensity={0.18} color="#cfe0e4" />
 
       {/* LA LADERA con sus caballones horneados en el relieve */}
       <mesh geometry={geoLadera} receiveShadow={perfil.sombras}>
         <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
       </mesh>
 
-      {/* los cerros fríos del fondo, ya con cara de páramo */}
+      {/* los cerros fríos del fondo, comidos por la bruma de la hora */}
       <mesh position={[-14, 4.2, -24]} scale={[10, 5.6, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color={CERROS.media} />
+        <meshLambertMaterial color={cerros.media} />
       </mesh>
       <mesh position={[6, 5.2, -27]} scale={[12, 7, 6]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color={CERROS.lejos} />
+        <meshLambertMaterial color={cerros.lejos} />
       </mesh>
       <mesh position={[21, 3.4, -23]} scale={[8, 4.6, 5]}>
         <sphereGeometry args={[1, 12, 8]} />
-        <meshLambertMaterial color={CERROS.cerca} />
+        <meshLambertMaterial color={cerros.cerca} />
       </mesh>
       {/* y detrasito, el filo pelado con su neblina pegada */}
       <mesh position={[-3, 7.8, -31]} scale={[16, 5, 5]}>
         <sphereGeometry args={[1, 10, 7]} />
-        <meshLambertMaterial color={CERROS.filo} />
+        <meshLambertMaterial color={cerros.filo} />
       </mesh>
 
       {/* EL PAPAL: matas en surcos, flores, cosecha, pajonal, frailejones */}
@@ -363,6 +364,7 @@ function Diorama({ tier, reducedMotion, foco }) {
       <FocoPaso foco={foco} reducedMotion={reducedMotion} />
 
       <OrbitControls
+        ref={controls}
         makeDefault
         target={[0, 2.8, -3]}
         enablePan={false}
@@ -377,6 +379,16 @@ function Diorama({ tier, reducedMotion, foco }) {
         dampingFactor={0.08}
         autoRotate={!reducedMotion}
         autoRotateSpeed={0.12}
+      />
+      {/* La LLEGADA del kit: dolly de establishing con tilt-down suave — entrar
+          al papal se siente como subir a la tierra fría, una vez por sesión. */}
+      <CamaraDirector
+        controls={controls}
+        reposo={[2, 5.4, 15.5]}
+        mirada={[0, 3.8, -3]}
+        respiro={0.04}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="mundoPapal"
       />
       <AdaptiveDpr pixelated />
     </>


### PR DESCRIPTION
## Qué hace

Los tres mundos de cultivo (cafetal, cacaotal, papal) montaban su propio Canvas con **cielo clavado y luz casera** — la "familia viva desconectada" del hallazgo del toolkit (#2511). Este PR los migra a la fundación compartida y aplica la decisión del operador de **estilo por piso térmico**:

### Café y cacao (templado/caliente) → clave TOMA B (#2510, estilizada Switch/BOTW)
- **`DomoCielo` (nuevo en el kit)**: domo de gradiente cenit→horizonte + glow del sol de la franja — el shader de la toma B, alimentado por la atmósfera viva del kit (cero tablas nuevas de color). El atardecer es el cartel.
- **Color por BANDAS (`kit/bandas.js`, nuevo)**: el gradientMap toon de 4 pasos canónico de la toma B, compartido por terreno y montes — silueta fuerte, ilustración en movimiento.
- Perspectiva aérea VIVA: los montes del fondo se mezclan con la niebla DE LA HORA (se doran al atardecer, se apagan de noche).

### Papa (frío) → clave TOMA A (#2513, naturalista)
- **La NIEBLA protagonista**: bruma lechosa verde-plata (la BRUMA que ganó en el bosque), más cerca que en los pisos calientes; de noche cede al índigo del cine.
- **Luz fría de altura**: relleno plata desde arriba que platea sin dorar. Lambert intacto (naturalista).

### Común a los tres (la migración al kit)
- `AtmosferaMundo` en el Canvas: fondo, niebla, luces y estrellas de **la hora viva del valle** (+ familia propia: corral / sotobosque / ladera). Los mundos amanecen, doran y anochecen CON el valle.
- Terreno migrado a `construirTerreno` + `ruidoTerreno` del kit — **borradas 3 copias** del heightfield y del ruido byte-a-byte; cada escena conserva solo su pintura propia.
- `CamaraDirector`: la llegada con dolly de establishing, una vez por sesión.
- Nuevo prop `sombra` en `AtmosferaMundo` (contrato de LuzMadre): el sol de la franja proyecta shadow-map real en tier alto — la luz colada del sombrío no se pierde.
- **La geometría de las matas NO se tocó** (café, cacao y papa aprobados).

## Verificación (síncrona, con capturas)
- `build:prod` VERDE (exit 0) · `tsc:check` — **0 errores en archivos tocados** (quedan ~20 pre-existentes de la base en `sueloRico.geom.js`/`LuzMadre.jsx`, de #2512/#2509, no de este PR).
- Tests: `kit` + `transicionMundoKit` + `mundo.smoke` → 27/27 verdes. Los 3 fallos de `mundo3d` (hiloVida, navegación, audio) **fallan igual en la base** — pre-existentes.
- Capturas 390×844 (Android barato), 3 mundos × 3 horas, ANTES vs DESPUÉS: en el antes las tres horas son **idénticas** (cielo clavado); en el después la mañana dora, el atardecer es cartel naranja con montes en silueta y la noche oscurece con estrellas. Pliego comparativo enviado por Telegram.
- Script de capturas versionado: `scripts/diag/shot-pisos-termicos.mjs`.

## Veredicto honesto
Café y cacao **ya parecen el mismo juego que el valle** — mismo reloj, misma paleta madre, y el domo+bandas les da el empaque Switch que la toma B probó en el bosque. La papa quedó deliberadamente en otra temperatura (naturalista, niebla protagonista) pero con el MISMO reloj y la misma familia de paleta: se siente el mismo mundo, otro piso. Lo más flojo: la noche del papal queda lechosa-clara (niebla de luna) — es defendible como alta montaña, pero si el operador la quiere más índigo es un número (`kFria` nocturno) en `EscenaPapaVivo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)