### PR TITLE
feat(juegos): destapar las joyas escondidas y dejar el hub Mi Finca Viva listo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -481,6 +481,10 @@ const DefensoresFincaScreen = lazy(() => import('./components/juego/DefensoresFi
 const MilpaSimulator = lazy(() => import('./components/juego/MilpaSimulator'));
 const DoomFincaScreen = lazy(() => import('./components/juego/DoomFincaScreen'));
 const MundoSubsuelo = lazy(() => import('./components/juego/MundoSubsuelo'));
+// MonoVsPoli: comparador monocultivo↔policultivo (LER/N/insumos/plaga) grounded
+// en asociaciones-comparativa.json. Rescatado de "construido-pero-no-cableado"
+// (audit juegos 2026-07-16): existía exportado en juego/index.js pero sin ruta.
+const MonoVsPoliSimulator = lazy(() => import('./components/juego/MonoVsPoliSimulator'));
 // Modo extensionista (panel supervisor multi-finca, ADR-048 MVP). Gateado por
 // feature flag VITE_FEATURE_EXTENSIONISTA + rol (ver config/extensionistaAccess).
 const ExtensionistaScreen = lazy(() => import('./components/ExtensionistaScreen'));
@@ -713,6 +717,12 @@ const HASH_VIEW_ROUTES = {
   'doom-finca': 'doom_finca',
   subsuelo: 'subsuelo',
   'mundo-subsuelo': 'subsuelo',
+  // Juegos promovidos de URL-only / huérfanos a ruta de primera clase
+  // (audit juegos 2026-07-16): Odyssey (túnel 2D↔3D) y el comparador mono/poli.
+  'finca-odyssey': 'finca_odyssey',
+  'mi-finca-odyssey': 'finca_odyssey',
+  'mono-vs-poli': 'mono_vs_poli',
+  'monocultivo-policultivo': 'mono_vs_poli',
   toxicologia: 'toxicologia',
   suelo: 'suelo',
   agua: 'agua',
@@ -871,7 +881,7 @@ const MODULE_VIEWS = new Set([
   'biodiversidad', 'informes', 'perfil', 'ayuda', 'help',
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'estiercol', 'compost',
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'animales_conejos', 'animales_caprinos', 'estiercol',
-  'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'sembrar', 'cosechar', 'mi_cosecha', 'insumos', 'biopreparados',
+  'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'finca_odyssey', 'mono_vs_poli', 'sembrar', 'cosechar', 'mi_cosecha', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'sanidad_sintoma', 'mantenimiento', 'new_task',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'aromaticas', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'cafe', 'uchuva', 'frutales', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
@@ -2405,6 +2415,30 @@ export default function App() {
             <ErrorFallback moduleName="Mundo Subsuelo">
               <ScreenShell title="Mundo Subsuelo" onBack={() => navigate('juego')} onHome={() => navigate('dashboard')}>
                 <MundoSubsuelo />
+              </ScreenShell>
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'finca_odyssey':
+        // Ruta de PRIMERA CLASE para el cruce túnel Odyssey 2D↔3D (antes solo
+        // alcanzable por #/mockups/juego-mi-finca). Enlazado desde el hub
+        // MiFincaViva; onBack regresa al hub. Misma implementación jugable.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Mi finca (túnel Odyssey)">
+              <JuegoMiFincaMockup onBack={() => navigate('juego')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mono_vs_poli':
+        // Comparador monocultivo↔policultivo (rescatado de huérfano, audit
+        // 2026-07-16). No trae navegación propia → lo envolvemos en ScreenShell
+        // (como 'subsuelo') para dar Volver/Inicio.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Monocultivo vs Policultivo">
+              <ScreenShell title="Mono vs Poli" onBack={() => navigate('juego')} onHome={() => navigate('dashboard')}>
+                <MonoVsPoliSimulator />
               </ScreenShell>
             </ErrorFallback>
           </ErrorBoundary>

--- a/src/components/juego/MiFincaVivaScreen.jsx
+++ b/src/components/juego/MiFincaVivaScreen.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Sparkles, Volume2, VolumeX, Trophy, Sprout, Crosshair } from 'lucide-react';
+import { Sparkles, Volume2, VolumeX, Trophy, Sprout, Crosshair, Mountain, Scale } from 'lucide-react';
 import { ScreenShell } from '../common/ScreenShell';
 import FincaWorldScene from './FincaWorldScene';
 import CriaturaCollection from './CriaturaCollection';
@@ -300,6 +300,46 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
             </span>
           </span>
           <Sparkles size={22} className="text-cyan-200 shrink-0" aria-hidden="true" />
+        </button>
+
+        {/* Mi finca (túnel Odyssey): el cruce mágico 2D↔3D. Antes era una joya
+            escondida (solo URL #/mockups/juego-mi-finca); promovido a ruta de
+            primera clase y enlazado aquí (audit juegos 2026-07-16). */}
+        <button
+          type="button"
+          data-testid="entrada-finca-odyssey"
+          onClick={() => irAccion('finca_odyssey')}
+          className="jp-mfv-entrada w-full text-left rounded-2xl p-4 bg-gradient-to-br from-indigo-600/40 to-emerald-800/40 border-2 border-indigo-400/40 hover:border-indigo-300/60 active:scale-[0.99] transition flex items-center gap-3"
+        >
+          <span className="text-4xl shrink-0" aria-hidden="true">🏔️</span>
+          <span className="flex-1 min-w-0">
+            <span className="jp-tinta block text-base font-black text-white">Mi finca en 3D</span>
+            <span className="jp-tinta-suave block text-sm text-indigo-100/90 leading-snug">
+              Entra por el túnel a tu finca en tres dimensiones y aterriza en el
+              huerto para cuidar el riego, las tres hermanas y las abejitas.
+            </span>
+          </span>
+          <Mountain size={22} className="text-indigo-200 shrink-0" aria-hidden="true" />
+        </button>
+
+        {/* Mono vs Poli: comparador de decisión (rendimiento/LER, nitrógeno,
+            ahorro de insumos, control de plaga) con cifras reales y fuente.
+            Rescatado de huérfano total sin ruta (audit juegos 2026-07-16). */}
+        <button
+          type="button"
+          data-testid="entrada-mono-vs-poli"
+          onClick={() => irAccion('mono_vs_poli')}
+          className="jp-mfv-entrada w-full text-left rounded-2xl p-4 bg-gradient-to-br from-amber-600/40 to-emerald-800/40 border-2 border-amber-400/40 hover:border-amber-300/60 active:scale-[0.99] transition flex items-center gap-3"
+        >
+          <span className="text-4xl shrink-0" aria-hidden="true">⚖️</span>
+          <span className="flex-1 min-w-0">
+            <span className="jp-tinta block text-base font-black text-white">Uno solo o varios juntos</span>
+            <span className="jp-tinta-suave block text-sm text-amber-100/90 leading-snug">
+              Compara sembrar un solo cultivo contra varios juntos y mira, con
+              cifras de verdad, cuánto rinde más y ahorra la asociación.
+            </span>
+          </span>
+          <Scale size={22} className="text-amber-200 shrink-0" aria-hidden="true" />
         </button>
 
         {/* Barra de progreso del mundo (alegre, pero honesta: % real) */}

--- a/src/components/juego/MilpaSimulator.jsx
+++ b/src/components/juego/MilpaSimulator.jsx
@@ -49,6 +49,13 @@ import { agentSounds, isSoundEnabled, setSoundEnabled } from '../../services/age
 import { speak, stop as stopSpeak, isSupported as ttsSupported } from '../../services/ttsService';
 import { recordGameStart, recordGameComplete } from '../../services/usageTelemetryService';
 
+// FUSIÓN MILPA (audit juegos 2026-07-16): "La milpa: las tres hermanas" (mockup
+// SVG pulido, antes URL-only #/mockups/juego-la-milpa) se pliega DENTRO de este
+// simulador como su "modo ilustrado". Una sola entrada en el hub → el simulador
+// hondo (5 sistemas, LER/N/carbono) con un botón para el juego bonito de intro.
+// No se reescribe ninguna mecánica: es cableado/composición.
+import JuegoLaMilpa from '../../mockups/JuegoLaMilpa';
+
 import './milpa.css';
 
 /** Acentos por color de cultivo (estética Chagra). */
@@ -196,6 +203,9 @@ export default function MilpaSimulator({ onBack, onHome }) {
   const [consejoVisible, setConsejoVisible] = useState({});
   const [resultadosTemporadas, setResultadosTemporadas] = useState([]);
   const [medallasObtenidas, setMedallasObtenidas] = useState([]);
+  // Modo de vista de la Milpa fusionada: 'simulador' (hondo, por defecto) vs
+  // 'ilustrado' (el mini-juego SVG "tres hermanas"). Una sola entrada, dos caras.
+  const [modoVista, setModoVista] = useState('simulador');
 
   // Telemetría de uso ANÓNIMA: inicio del juego al montar (una vez).
   useEffect(() => { recordGameStart('milpa'); }, []);
@@ -416,6 +426,13 @@ export default function MilpaSimulator({ onBack, onHome }) {
     return asoc.cultivos.map((id) => CULTIVO_POR_ID[id]).filter(Boolean);
   }, [sistemaActivo]);
 
+  // Modo ilustrado (juego SVG "las tres hermanas"). Se monta como pantalla
+  // completa; su "Salir" regresa al simulador hondo. El early-return va DESPUÉS
+  // de todos los hooks para no violar las reglas de hooks.
+  if (modoVista === 'ilustrado') {
+    return <JuegoLaMilpa onBack={() => setModoVista('simulador')} />;
+  }
+
   return (
     <ScreenShell
       title="Asociaciones"
@@ -471,6 +488,18 @@ export default function MilpaSimulator({ onBack, onHome }) {
                 Las plantas se ayudan cuando crecen juntas. Elige una asociación
                 y descubre cómo rinde más que sembrar cada cultivo solo.
               </p>
+              {/* Puente a la "cara bonita" de la Milpa: el mini-juego SVG de las
+                  tres hermanas (fusión audit 2026-07-16). Misma Milpa, modo
+                  ilustrado para entrar jugando. */}
+              <button
+                type="button"
+                data-testid="milpa-modo-ilustrado"
+                onClick={() => setModoVista('ilustrado')}
+                className="mt-3 inline-flex items-center gap-2 rounded-2xl border-2 border-lime-300/50 bg-lime-500/15 px-4 py-2.5 text-sm font-black text-lime-100 hover:bg-lime-500/25 active:scale-[0.98] transition"
+              >
+                <Sparkles size={18} aria-hidden="true" />
+                Jugar «Las tres hermanas» (modo ilustrado)
+              </button>
             </header>
 
             <section className="grid grid-cols-1 gap-3">

--- a/src/components/juego/__tests__/MiFincaVivaScreen.test.jsx
+++ b/src/components/juego/__tests__/MiFincaVivaScreen.test.jsx
@@ -107,6 +107,24 @@ describe('MiFincaVivaScreen', () => {
     expect(onNavigate).toHaveBeenCalledWith('subsuelo');
   });
 
+  it('expone la entrada a Mi finca en 3D (Odyssey) y navega a finca_odyssey', async () => {
+    const onNavigate = vi.fn();
+    render(<MiFincaVivaScreen onNavigate={onNavigate} />);
+    const entrada = await screen.findByTestId('entrada-finca-odyssey');
+    expect(entrada).toBeTruthy();
+    fireEvent.click(entrada);
+    expect(onNavigate).toHaveBeenCalledWith('finca_odyssey');
+  });
+
+  it('expone la entrada a Mono vs Poli y navega a mono_vs_poli (rescate huérfano)', async () => {
+    const onNavigate = vi.fn();
+    render(<MiFincaVivaScreen onNavigate={onNavigate} />);
+    const entrada = await screen.findByTestId('entrada-mono-vs-poli');
+    expect(entrada).toBeTruthy();
+    fireEvent.click(entrada);
+    expect(onNavigate).toHaveBeenCalledWith('mono_vs_poli');
+  });
+
   it('siempre muestra la galería de criaturas (con siluetas si vacía)', async () => {
     render(<MiFincaVivaScreen />);
     expect(await screen.findByTestId('criatura-collection')).toBeTruthy();

--- a/src/components/juego/__tests__/MilpaSimulator.test.jsx
+++ b/src/components/juego/__tests__/MilpaSimulator.test.jsx
@@ -91,6 +91,19 @@ describe('MilpaSimulator', () => {
     expect(within(resultado).getByText(/La ahuyama cuida el suelo/)).toBeInTheDocument();
   });
 
+  it('fusión: el modo ilustrado abre «Las tres hermanas» y Salir vuelve al simulador', () => {
+    render(<MilpaSimulator />);
+    // La entrada única de la Milpa ofrece el juego ilustrado (fusión audit 2026-07-16).
+    const irIlustrado = screen.getByTestId('milpa-modo-ilustrado');
+    fireEvent.click(irIlustrado);
+    // Ahora se ve el mini-juego SVG de las tres hermanas (intro con su CTA propio).
+    expect(screen.getByText('Empezar a sembrar')).toBeInTheDocument();
+    expect(screen.getAllByText('La milpa: las tres hermanas').length).toBeGreaterThan(0);
+    // Y su «Salir» regresa al simulador hondo (una sola Milpa, dos caras).
+    fireEvent.click(screen.getByRole('button', { name: /Salir/ }));
+    expect(screen.getByText('¿Qué quieres sembrar hoy?')).toBeInTheDocument();
+  });
+
   it('permite pasar a la siguiente temporada con parcelas vacías', () => {
     render(<MilpaSimulator />);
     elegirMilpa();

--- a/src/config/rutasProdChagraApp.js
+++ b/src/config/rutasProdChagraApp.js
@@ -857,10 +857,29 @@ export const NUCLEO_APP = [
     categoria: '2D-app',
   },
   {
+    // Fusionado DENTRO de MilpaSimulator como "modo ilustrado" (audit juegos
+    // 2026-07-16). Se mantiene la ruta/alias para el deep-link directo, pero el
+    // hub MiFincaViva ya no lo lista como entrada aparte (una sola Milpa).
     path: 'juego_la_milpa',
     alias: ['mockup_juego_la_milpa'],
     componente: 'JuegoLaMilpa',
     importLazy: 'src/mockups/JuegoLaMilpa.jsx',
+    categoria: '2D-app',
+  },
+  {
+    // Promovido de URL-only (#/mockups/juego-mi-finca) a ruta de primera clase
+    // + enlace desde el hub (audit juegos 2026-07-16). La joya 2D↔3D Odyssey.
+    path: 'finca_odyssey',
+    alias: ['mockup_juego_mi_finca'],
+    componente: 'JuegoMiFincaOdyssey',
+    importLazy: 'src/mockups/JuegoMiFincaOdyssey.jsx',
+    categoria: '2D-app',
+  },
+  {
+    // Rescatado de huérfano total sin ruta (audit juegos 2026-07-16). AGR 9.
+    path: 'mono_vs_poli',
+    componente: 'MonoVsPoliSimulator',
+    importLazy: 'src/components/juego/MonoVsPoliSimulator.jsx',
     categoria: '2D-app',
   },
 


### PR DESCRIPTION
## Qué hace

Cableado/integración de los juegos huérfanos o URL-only al hub **Mi Finca Viva** (`src/components/juego/MiFincaVivaScreen.jsx`), **sin reescribir mecánicas**. Fuente: `ops/AUDIT-JUEGOS-2026-07-16.md`.

### 1. Odyssey — de joya escondida a ruta de primera clase
`JuegoMiFincaOdyssey` (el cruce 2D↔3D, ESP 9) era solo alcanzable escribiendo `#/mockups/juego-mi-finca`. Ahora:
- Ruta de primera clase `finca_odyssey` (+ alias hash `finca-odyssey` / `mi-finca-odyssey`), `onBack` regresa al hub.
- Tarjeta **"Mi finca en 3D"** en el hub.
- Registrado en `rutasProdChagraApp.js` (NUCLEO_APP, categoría `2D-app`).

### 2. MonoVsPoli — revivido de huérfano total
`MonoVsPoliSimulator` (AGR 9, testeado) estaba **sin ninguna ruta** (solo `export`). Ahora:
- Ruta `mono_vs_poli` envuelta en `ScreenShell` (como `subsuelo`, ya que no trae navegación propia).
- Tarjeta **"Uno solo o varios juntos"** en el hub + entrada en el manifiesto prod.

### 3. Milpa — fusionada en UNA
`JuegoLaMilpa` (mockup SVG pulido, URL-only) se **pliega DENTRO de `MilpaSimulator`** como **"modo ilustrado"**: un botón en la intro del simulador abre el mini-juego de las tres hermanas; su "Salir" vuelve al simulador hondo. **Una sola entrada en el hub** (`milpa` → el simulador profundo, con la cara bonita como intro jugable). No se reescribió ninguna mecánica: es composición. Se conserva el deep-link directo del mockup.

### 4. Hub coherente
`MiFincaViva` ahora lista todos los juegos cableados: Defensores · Milpa (fusionada) · Doom · Subsuelo · **Mi finca en 3D (Odyssey)** · **Mono vs Poli**.

## Verificación
- `build:prod` **verde** (✓ built ~29s).
- `tsc:check`: **sin errores nuevos** (20 pre-existentes ajenos intactos: sueloRico/SueloRico/LuzMadre/SueloDemo3D/AgentAvatarSelector/saludoPantalla).
- Tests: **26 verdes** (+2 entradas del hub que navegan a `finca_odyssey` / `mono_vs_poli`, +1 de la fusión Milpa que abre "Las tres hermanas" y vuelve).
- `eslint` limpio en los archivos tocados.

## TODO / seguimiento
- **MetalSlugCampo**: sigue URL-only e **inconcluso** (solo nivel 1; faltan niveles 2-4 + jefes en el JSX). No se promovió a propósito — necesita terminarse antes.
- **AvatarGame ×3**: quedan EXCLUIDO (mockups sin datos reales; el concepto vive en Espíritu Guardián).
- **Fusión Milpa más profunda** (opcional): hoy es "dos caras, una entrada" (toggle simulador ↔ ilustrado). Una fusión total (vestir el motor hondo con el arte SVG de LaMilpa) sería un rediseño mayor, fuera del alcance de cableado.
- Captura del hub: verificada por tests (assert de las tarjetas + navegación); pendiente captura viva en dev/stg si se quiere para el registro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)