### PR TITLE
feat(home): el umbral del valle — portada finca-viva a máximo nivel

### DIFF
--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -51,6 +51,12 @@ import PanelVitalidadEspiritu from './PanelVitalidadEspiritu';
 import SceneFincaNature from './SceneFincaNature';
 import SceneHuertoVivo from './SceneHuertoVivo';
 import SceneTrazoMinimal from './SceneTrazoMinimal';
+// EL UMBRAL DEL VALLE + LAS PUERTAS COMO CARTAS (encargo FABLE_50 §A6,
+// "home máximo" 2026-07-16): la vista viva que ES la puerta cinematográfica
+// al valle 3D, y las puertas pintadas como cartas en la mano. Los destinos
+// siguen saliendo de buildPuertas (fuente única); solo cambió la piel.
+import UmbralValle from './UmbralValle';
+import PortalesMano from './PortalesMano';
 import './scene-finca-organismo.css';
 import './scene-finca-nature.css';
 import './scene-huerto-vivo.css';
@@ -764,29 +770,20 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, on
           </div>
         </main>
 
-        {/* ── LAS 6 PUERTAS (usabilidad campesina #5) ─────────────────────────
-            Antes: 4 portales con descripción + ~20 tarjetas + ~35 chips abajo.
-            Ahora: SEIS puertas de una-dos palabras, dibujo grande + palabra
-            grande, targets ≥96px (#8). Cada una enruta a un mundo/vista que YA
-            existe (nada nuevo que mantener). "Toda mi finca" abre los mundos
-            completos en la hoja de abajo. */}
+        {/* ── EL UMBRAL DEL VALLE (encargo "home máximo" 2026-07-16) ──────────
+            La vista viva del valle andino a la hora real — y LA PUERTA GRANDE:
+            tocarla inunda la pantalla con el cielo de la franja y aterriza en
+            el valle 3D ('valle3d', existe en ambos shells). Solo con finca
+            propia: la RED institucional del extensionista no es un valle. */}
+        {tieneFincaPropia && <UmbralValle onNavigate={onNavigate} />}
+
+        {/* ── LAS 6 PUERTAS como CARTAS EN LA MANO (usabilidad campesina #5 +
+            FABLE_50 §A6). Antes: tarjetas planas con emoji. Ahora: viñetas de
+            autor sobre el cielo vivo, palabra grande + a dónde abre, targets
+            ≥96px. Cada una enruta a un mundo/vista que YA existe; los destinos
+            salen de buildPuertas (fuente única, tests intactos). */}
         <div className="fvh-portales-tit">¿A dónde va? <span /></div>
-        <nav className="fvh-puertas" aria-label="Puertas de su finca" data-testid="finca-viva-puertas">
-          {buildPuertas({ onNavigate, irATodaMiFinca, mostrarAnimales }).map((p, i) => (
-            <button
-              key={p.id}
-              type="button"
-              className={`fvh-puerta t-${p.tinte}`}
-              data-testid={`puerta-${p.id}`}
-              onClick={p.onClick}
-              style={{ animationDelay: `${0.08 + i * 0.06}s` }}
-              aria-label={`${p.nombre}: abre ${p.abre}`}
-            >
-              <span className="fvh-puerta-emoji" aria-hidden="true">{p.emoji}</span>
-              <span className="fvh-puerta-nombre">{p.nombre}</span>
-            </button>
-          ))}
-        </nav>
+        <PortalesMano puertas={buildPuertas({ onNavigate, irATodaMiFinca, mostrarAnimales })} />
 
         <div className="fvh-fill" />
         <p className="fvh-titulo-sr">{titulo || 'Mi finca viva'}</p>

--- a/src/components/dashboard/PortalesMano.jsx
+++ b/src/components/dashboard/PortalesMano.jsx
@@ -1,0 +1,305 @@
+/**
+ * PortalesMano — LAS PUERTAS del home como CARTAS EN LA MANO (encargo
+ * FABLE_50 §A6: "los 4 portales 'la mano' claros, vivos y bien dispuestos").
+ *
+ * Antes: tarjetas planas con un emoji del sistema. Ahora cada puerta es una
+ * CARTA PINTADA: una viñeta SVG de autor (rubber-hose, tinta cálida, paleta
+ * madre) sobre el cielo VIVO de la hora real — el mismo cielo del umbral del
+ * valle, para que toda la portada respire la misma hora. En pantalla ancha
+ * las cartas se ABREN EN ABANICO como una mano de cartas (la "mano").
+ *
+ * CONTRATO INTACTO (tests FincaVivaHero.portales): el nav conserva
+ * data-testid="finca-viva-puertas", cada botón conserva `puerta-<id>`,
+ * su aria-label "<nombre>: abre <abre>" y su onClick — aquí solo cambia la
+ * PIEL. Los datos siguen saliendo de buildPuertas (fuente única del hero).
+ *
+ * PERF: SVG estático por carta (cero animación por frame, cero imágenes);
+ * la única animación es la entrada escalonada que ya existía (CSS `brota`).
+ * Español de Colombia (usted), sin voseo.
+ */
+import { useMemo } from 'react';
+import useCicloDia from '../../visual/mundo3d/useCicloDia.js';
+import { mezclaHex } from '../../visual/mundo3d/cielosHoraData.js';
+import { CLIMAS } from '../../mockups/valle/valleData';
+import './portales-mano.css';
+
+/* Paleta madre citada (el barrel paleta/ arrastra three; ver UmbralValle). */
+const TINTA = '#2c241c';
+const VERDE_LADERA = '#4e9143'; // VERDES.templadoVivo
+const VERDE_BROTE = '#7a9a3f'; // VERDES.brote
+const VERDE_MONTE = '#3f6f3a'; // VERDES.monte
+const VERDE_FRIO = '#3c7f64'; // VERDES.frioVivo
+const TIERRA_ARCILLA = '#8a5636'; // TIERRAS.arcilla
+const TIERRA_CAMINO = '#8a6a44'; // TIERRAS.camino
+const BEJUCO = '#a9713c'; // CASA.bejuco (el canasto de cosecha)
+const CEREZA = '#c1553f'; // ACENTOS cochinilla/café cereza (fruto, no alarma)
+const MAIZ = '#e9b84a'; // ACENTOS maíz
+const ENCALADO = '#f3ecdc'; // CASA.encalado
+const TEJA = '#b0603f'; // CASA.teja
+const TEJA_SOMBRA = '#8f4b31'; // CASA.tejaSombra
+const MADERA = '#6b4a2e'; // CASA.madera
+const VENTANA = '#ffd9a0'; // CASA.ventana
+const AGUA = '#5f9ec4'; // AGUAS (el único azul con permiso)
+const CARPINTERIA = '#44685a'; // CASA.carpinteria
+
+/* ── Las viñetas de autor, una por puerta (viewBox 120×64, cielo del card
+      detrás — el SVG pinta solo terreno y sujeto). Trazos gordos, curvas
+      rubber-hose, siluetas que se leen a un vistazo. ── */
+
+function VinetaMatas() {
+  return (
+    <svg viewBox="0 0 120 64" preserveAspectRatio="xMidYMax slice" aria-hidden="true">
+      {/* la ladera con surcos */}
+      <path d="M0,64 L0,40 Q30,30 60,36 Q90,42 120,34 L120,64 Z" fill={VERDE_LADERA} />
+      <g stroke={mezclaHex(VERDE_LADERA, TINTA, 0.35)} strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.6">
+        <path d="M8,52 Q34,46 60,50 Q86,54 112,48" />
+        <path d="M4,59 Q34,53 62,57 Q90,61 116,55" />
+      </g>
+      {/* LA MATA: el brote gordo y vivo, protagonista */}
+      <path d="M60,52 L60,30" fill="none" stroke={TINTA} strokeWidth="3.2" strokeLinecap="round" />
+      {/* hoja izquierda: cotiledón carnoso */}
+      <path
+        d="M59,38 C46,40 36,33 35,21 C48,18 58,26 60,36 Z"
+        fill={VERDE_BROTE}
+        stroke={TINTA}
+        strokeWidth="2.4"
+        strokeLinejoin="round"
+      />
+      {/* hoja derecha */}
+      <path
+        d="M61,38 C74,40 84,33 85,21 C72,18 62,26 60,36 Z"
+        fill={VERDE_MONTE}
+        stroke={TINTA}
+        strokeWidth="2.4"
+        strokeLinejoin="round"
+      />
+      {/* el cogollo nuevo arriba */}
+      <path
+        d="M60,30 C55,24 56,14 62,10 C68,15 67,26 60,30 Z"
+        fill={mezclaHex(VERDE_BROTE, '#e9b84a', 0.25)}
+        stroke={TINTA}
+        strokeWidth="2.4"
+        strokeLinejoin="round"
+      />
+      {/* venas de las hojas */}
+      <g stroke={TINTA} strokeWidth="1.3" strokeLinecap="round" fill="none" opacity="0.55">
+        <path d="M57,36 Q47,32 42,25" />
+        <path d="M63,36 Q73,32 78,25" />
+      </g>
+    </svg>
+  );
+}
+
+function VinetaAnimales() {
+  return (
+    <svg viewBox="0 0 120 64" preserveAspectRatio="xMidYMax slice" aria-hidden="true">
+      {/* el patio de tierra */}
+      <path d="M0,64 L0,44 Q40,36 74,42 Q100,46 120,42 L120,64 Z" fill={TIERRA_ARCILLA} />
+      {/* la cerca del corral */}
+      <g stroke={MADERA} strokeWidth="3.4" strokeLinecap="round">
+        <path d="M14,48 L14,30 M38,46 L38,28" />
+        <path d="M8,36 L46,33" />
+      </g>
+      {/* LA GALLINA rubber-hose: cuerpo gordo, cabeza clara, cresta arriba */}
+      <g stroke={TINTA} strokeWidth="2.4" strokeLinejoin="round">
+        {/* plumas de la cola, en abanico atrás */}
+        <path d="M64,40 Q54,30 58,22 Q66,28 68,36 Z" fill={mezclaHex(ENCALADO, TINTA, 0.16)} />
+        <path d="M62,42 Q50,38 48,30 Q58,32 64,39 Z" fill={ENCALADO} />
+        {/* cuerpo */}
+        <path d="M62,49 Q60,33 78,31 Q95,29 96,42 Q96,51 82,52 Q68,53 62,49 Z" fill={ENCALADO} />
+        {/* cabeza redonda */}
+        <circle cx="95" cy="29" r="7.4" fill={ENCALADO} />
+        {/* cresta: tres bultos ROJOS bien puestos sobre la coronilla */}
+        <path d="M89,25 Q89,19 93,21 Q94,16 98,19 Q101,15 102,21 Q99,24 92,25 Z" fill={CEREZA} />
+        {/* barbilla bajo el pico */}
+        <path d="M99,35 Q99,40 96,39 Q95,36 97,34 Z" fill={CEREZA} />
+        {/* pico */}
+        <path d="M102,28 L110,30.5 L102,33 Z" fill={MAIZ} />
+        {/* ala */}
+        <path d="M70,38 Q82,34 87,42 Q79,48 69,44 Z" fill={mezclaHex(ENCALADO, TINTA, 0.12)} />
+      </g>
+      <circle cx="96" cy="28" r="1.7" fill={TINTA} />
+      <g stroke={MAIZ} strokeWidth="2.6" strokeLinecap="round" fill="none">
+        <path d="M76,52 L76,59 M73,59 L79,59" />
+        <path d="M86,52 L86,59 M83,59 L89,59" />
+      </g>
+      {/* maíz regado */}
+      <g fill={MAIZ}>
+        <circle cx="52" cy="55" r="1.7" /><circle cx="58" cy="59" r="1.5" /><circle cx="47" cy="60" r="1.5" />
+      </g>
+    </svg>
+  );
+}
+
+function VinetaTiempo() {
+  return (
+    <svg viewBox="0 0 120 64" preserveAspectRatio="xMidYMax slice" aria-hidden="true">
+      {/* loma fría al fondo */}
+      <path d="M0,64 L0,50 Q40,40 80,48 Q102,52 120,48 L120,64 Z" fill={VERDE_FRIO} />
+      {/* el sol que asoma */}
+      <circle cx="86" cy="22" r="11" fill={MAIZ} stroke={TINTA} strokeWidth="2.2" />
+      <g stroke={TINTA} strokeWidth="2.2" strokeLinecap="round">
+        <path d="M86,6 L86,10 M102,22 L106,22 M97,11 L100,8 M97,33 L100,36" />
+      </g>
+      {/* LA NUBE gorda de vereda */}
+      <path
+        d="M18,34 Q18,24 29,24 Q32,15 43,17 Q53,12 58,21 Q68,21 67,31 Q66,39 55,39 L28,39 Q19,39 18,34 Z"
+        fill={ENCALADO}
+        stroke={TINTA}
+        strokeWidth="2.4"
+        strokeLinejoin="round"
+      />
+      {/* las gotas */}
+      <g fill={AGUA} stroke={TINTA} strokeWidth="1.6">
+        <path d="M31,46 q-3.4,5 0,7 q3.4,-2 0,-7 Z" />
+        <path d="M44,50 q-3.4,5 0,7 q3.4,-2 0,-7 Z" />
+        <path d="M57,45 q-3.4,5 0,7 q3.4,-2 0,-7 Z" />
+      </g>
+    </svg>
+  );
+}
+
+function VinetaVender() {
+  return (
+    <svg viewBox="0 0 120 64" preserveAspectRatio="xMidYMax slice" aria-hidden="true">
+      {/* la mesa del mercado */}
+      <path d="M0,64 L0,46 L120,46 L120,64 Z" fill={TIERRA_CAMINO} />
+      <path d="M6,46 L114,46" stroke={mezclaHex(TIERRA_CAMINO, TINTA, 0.3)} strokeWidth="2.4" strokeLinecap="round" />
+      {/* EL CANASTO de bejuco con cosecha */}
+      <path d="M38,32 L82,32 L76,52 L44,52 Z" fill={BEJUCO} stroke={TINTA} strokeWidth="2.4" strokeLinejoin="round" />
+      <g stroke={mezclaHex(BEJUCO, TINTA, 0.35)} strokeWidth="1.6" fill="none" opacity="0.8">
+        <path d="M41,38 L79,38 M43,44 L77,44" />
+        <path d="M50,32 L52,52 M60,32 L60,52 M70,32 L68,52" />
+      </g>
+      {/* frutos: café cereza, maíz, aguacate */}
+      <g stroke={TINTA} strokeWidth="1.8">
+        <circle cx="47" cy="29" r="4.6" fill={CEREZA} />
+        <circle cx="57" cy="26" r="4.6" fill={CEREZA} />
+        <ellipse cx="68" cy="27" rx="5" ry="6" fill={VERDE_MONTE} />
+        <circle cx="77" cy="30" r="4.2" fill={MAIZ} />
+      </g>
+      {/* las monedas de la venta: pila + una parada */}
+      <g stroke={TINTA} strokeWidth="2">
+        <ellipse cx="99" cy="44" rx="8.5" ry="3.4" fill={MAIZ} />
+        <ellipse cx="99" cy="39.5" rx="8.5" ry="3.4" fill={mezclaHex(MAIZ, '#ffffff', 0.25)} />
+        <circle cx="99" cy="26" r="7" fill={MAIZ} />
+        <circle cx="99" cy="26" r="4" fill="none" opacity="0.6" />
+      </g>
+    </svg>
+  );
+}
+
+function VinetaAprender() {
+  return (
+    <svg viewBox="0 0 120 64" preserveAspectRatio="xMidYMax slice" aria-hidden="true">
+      {/* la loma del saber, al fondo */}
+      <path d="M0,64 L0,52 Q46,42 90,50 Q106,52 120,50 L120,64 Z" fill={VERDE_LADERA} />
+      {/* EL LIBRO abierto del que brota una mata */}
+      <g stroke={TINTA} strokeWidth="2.4" strokeLinejoin="round">
+        <path d="M28,52 Q44,44 60,50 Q76,44 92,52 L92,32 Q76,24 60,30 Q44,24 28,32 Z" fill={ENCALADO} />
+        <path d="M60,30 L60,50" />
+      </g>
+      <g stroke={mezclaHex(ENCALADO, TINTA, 0.4)} strokeWidth="1.6" strokeLinecap="round" opacity="0.75">
+        <path d="M36,36 Q48,31 54,34 M36,42 Q48,37 54,40" />
+        <path d="M66,34 Q72,31 84,36 M66,40 Q72,37 84,42" />
+      </g>
+      {/* la mata que brota de la página */}
+      <g fill="none" stroke={TINTA} strokeWidth="2.6" strokeLinecap="round">
+        <path d="M60,30 Q60,20 60,14" />
+        <path d="M60,22 Q53,21 50,14" />
+      </g>
+      <path d="M50,14 Q46,6 54,4 Q59,9 50,14 Z" fill={VERDE_BROTE} stroke={TINTA} strokeWidth="2" strokeLinejoin="round" />
+      <path d="M60,14 Q57,4 64,2 Q70,8 60,14 Z" fill={VERDE_MONTE} stroke={TINTA} strokeWidth="2" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function VinetaFinca() {
+  return (
+    <svg viewBox="0 0 120 64" preserveAspectRatio="xMidYMax slice" aria-hidden="true">
+      {/* dos lomas, el valle chiquito */}
+      <path d="M0,64 L0,40 Q30,28 62,38 Q94,48 120,38 L120,64 Z" fill={VERDE_LADERA} />
+      <path d="M0,64 L0,52 Q40,44 80,52 Q102,56 120,52 L120,64 Z" fill={mezclaHex(VERDE_LADERA, VERDE_BROTE, 0.5)} />
+      {/* el sendero a la casa */}
+      <path d="M28,64 Q42,54 56,48" fill="none" stroke={TIERRA_CAMINO} strokeWidth="5" strokeLinecap="round" opacity="0.7" />
+      {/* LA CASA-ANCLA (la misma del valle) */}
+      <g stroke={TINTA} strokeWidth="2.2" strokeLinejoin="round">
+        <rect x="54" y="30" width="30" height="20" rx="1.5" fill={ENCALADO} />
+        <rect x="54" y="45" width="30" height="5" fill={TEJA_SOMBRA} stroke="none" />
+        <path d="M50,32 L69,18 L88,32 Z" fill={TEJA} />
+        <rect x="59" y="36" width="7" height="14" rx="1" fill={MADERA} />
+        <rect x="72" y="35" width="8" height="8" rx="1" fill={VENTANA} />
+      </g>
+      {/* el arbolito y las matas de la huerta */}
+      <rect x="94" y="36" width="3.2" height="13" rx="1.5" fill={MADERA} />
+      <ellipse cx="95.5" cy="30" rx="9" ry="8.5" fill={VERDE_MONTE} stroke={TINTA} strokeWidth="2" />
+      <g fill={CARPINTERIA}>
+        <ellipse cx="22" cy="56" rx="5" ry="3.4" />
+        <ellipse cx="36" cy="59" rx="4.4" ry="3" />
+      </g>
+    </svg>
+  );
+}
+
+const VINETAS = {
+  matas: VinetaMatas,
+  animales: VinetaAnimales,
+  tiempo: VinetaTiempo,
+  vender: VinetaVender,
+  aprender: VinetaAprender,
+  finca: VinetaFinca,
+};
+
+/**
+ * @param {Object} props
+ * @param {Array<{id: string, nombre: string, tinte: string, abre: string,
+ *   onClick: Function, emoji?: string}>} props.puertas — buildPuertas del hero
+ *   (fuente única de destinos; aquí solo se pinta).
+ */
+export default function PortalesMano({ puertas }) {
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  /* El MISMO reloj del umbral: toda la portada respira la misma hora. */
+  const { franja } = useCicloDia({ reducedMotion });
+  const clima = CLIMAS[franja] || CLIMAS.tarde;
+
+  return (
+    <nav
+      className="fvh-puertas fvh-puertas--mano"
+      aria-label="Puertas de su finca"
+      data-testid="finca-viva-puertas"
+      style={{
+        '--pm-cielo-a': clima.cielo[0],
+        '--pm-cielo-b': clima.cielo[1],
+      }}
+    >
+      {puertas.map((p, i) => {
+        const Vineta = VINETAS[p.id] || null;
+        return (
+          <button
+            key={p.id}
+            type="button"
+            className={`fvh-puerta pm-carta t-${p.tinte}`}
+            data-testid={`puerta-${p.id}`}
+            onClick={p.onClick}
+            style={{ animationDelay: `${0.08 + i * 0.06}s` }}
+            aria-label={`${p.nombre}: abre ${p.abre}`}
+          >
+            <span className="pm-vineta" aria-hidden="true">
+              {Vineta ? <Vineta /> : <span className="fvh-puerta-emoji">{p.emoji}</span>}
+            </span>
+            <span className="pm-rotulo">
+              <span className="fvh-puerta-nombre">{p.nombre}</span>
+              <span className="pm-abre">{p.abre}</span>
+            </span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/dashboard/UmbralValle.jsx
+++ b/src/components/dashboard/UmbralValle.jsx
@@ -1,0 +1,419 @@
+/**
+ * UmbralValle — LA PUERTA GRANDE del home al VALLE 3D (portada finca-viva).
+ *
+ * Encargo del operador (FABLE_50 §A6 + dirección "home máximo" 2026-07-16):
+ * la portada necesita una escena de entrada MÁGICA y un paso home→valle que
+ * se sienta de juego, no un hash que corta en seco. Este componente es las
+ * dos cosas a la vez: una VISTA VIVA del valle andino (la misma familia
+ * visual del valle 3D aprobado) que además ES la puerta — tocarla inunda la
+ * pantalla con la luz del cielo de la hora y aterriza en `valle3d`.
+ *
+ * POR QUÉ SE VE COMO SE VE (cero color inventado):
+ *   · El CIELO y la luz salen de CLIMAS (valleData) vía useCicloDia — la
+ *     MISMA fuente que pinta el valle 3D y su placeholder CargandoValle.
+ *     Eso hace la transición casi invisible: el velo con que cubrimos la
+ *     pantalla es el mismo gradiente con que el valle recibe.
+ *   · Las montañas son los 4 PISOS TÉRMICOS del valle (PISOS_TERMICOS de
+ *     valleData: cálido → templado → frío → páramo) con perspectiva
+ *     atmosférica real: a más lejos, más mezcla con el color de la niebla
+ *     de la franja (mezclaHex de cielosHoraData, aritmética pura).
+ *   · La casa campesina usa los tokens CASA de la paleta madre (encalado,
+ *     zócalo, teja, ventana cálida) — es la MISMA casa-ancla del valle.
+ *   · El colibrí es el BARBUDITO ilustrado (Barbudito.jsx), la criatura
+ *     insignia, sobrevolando el umbral como guía.
+ *
+ * PERF (Android barato, es la portada): DOM + SVG + CSS puros — CERO three,
+ * cero imágenes, cero blur. Animaciones solo transform/opacity, apagadas con
+ * prefers-reduced-motion. El chunk de la entrada 3D se PRECARGA al tocar
+ * (import() fire-and-forget) para que el swap bajo el velo no muestre carga.
+ *
+ * NAVEGACIÓN: `onNavigate('valle3d')` — la vista existe en el shell clásico
+ * (App.jsx case 'valle3d') y en prod (rutasProdChagraApp). Sin la prop, cae
+ * al evento global `chagraNavigate` que ambos shells escuchan.
+ *
+ * Español de Colombia (usted), sin voseo.
+ */
+import { useCallback, useMemo, useState } from 'react';
+import useCicloDia from '../../visual/mundo3d/useCicloDia.js';
+import { mezclaHex } from '../../visual/mundo3d/cielosHoraData.js';
+import { CLIMAS } from '../../mockups/valle/valleData';
+import { BarbuditoIlustrado } from '../colibri/Barbudito';
+import './umbral-valle.css';
+
+/* ── Paleta madre (hex citados de paletaMadre.js / valleData.js; el barrel
+      src/visual/mundo3d/paleta arrastra three vía atmosferaMadre, así que en
+      el home DOM se citan los valores con su fuente — no se inventa color). */
+const PISO = {
+  calido: '#84a83f', // valleData PISOS_TERMICOS.calido (VERDES.calidoVivo)
+  templado: '#4e9143', // PISOS_TERMICOS.templado (VERDES.templadoVivo)
+  frio: '#3c7f64', // PISOS_TERMICOS.frio (VERDES.frioVivo)
+  paramo: '#a5975c', // EJE_TERMICO paramo (TIERRAS.pajonal)
+};
+const CASA = {
+  encalado: '#f3ecdc',
+  zocalo: '#a35a3c',
+  teja: '#b0603f',
+  tejaSombra: '#8f4b31',
+  madera: '#6b4a2e',
+  ventana: '#ffd9a0',
+  carpinteria: '#44685a',
+}; // paletaMadre.CASA — la casa campesina canónica del valle
+const CAMINO = '#8a6a44'; // TIERRAS.camino
+const MONTE = '#3f6f3a'; // VERDES.monte (copa en sombra)
+const TINTA = '#2c241c'; // tinta rubber-hose cálida (fauna tokens)
+
+/* Sombra nocturna del terreno: índigo del keyframe noche de la bóveda
+   (cielosHoraData noche '#26325a'), NO un negro plano. */
+const NOCHE_TIERRA = '#22304f';
+const SOMBRA_CREPUSCULO = '#4a3450';
+
+/* Cuánto se oscurece el terreno por franja (el día no se toca). */
+const OSCURECER = {
+  amanecer: { hacia: SOMBRA_CREPUSCULO, t: 0.22 },
+  atardecer: { hacia: SOMBRA_CREPUSCULO, t: 0.28 },
+  noche: { hacia: NOCHE_TIERRA, t: 0.58 },
+};
+
+/* Posición del sol/la luna en el lienzo (viewBox 360×210) por franja: el arco
+   del día de oriente (derecha) a occidente (izquierda), como CLIMAS.sol. */
+const ASTRO = {
+  amanecer: { cx: 306, cy: 86, r: 17 },
+  manana: { cx: 264, cy: 58, r: 15 },
+  mediodia: { cx: 180, cy: 34, r: 14 },
+  tarde: { cx: 104, cy: 54, r: 15 },
+  atardecer: { cx: 54, cy: 88, r: 18 },
+  noche: { cx: 288, cy: 44, r: 12 },
+};
+
+/* Estrellas fijas (x, y, radio) — pocas y bien puestas, no confeti. */
+const ESTRELLAS = [
+  [22, 26, 1.4], [58, 14, 1], [96, 38, 1.2], [140, 18, 1], [172, 46, 1.3],
+  [214, 12, 1], [246, 34, 1.4], [312, 22, 1], [338, 44, 1.2], [76, 58, 1],
+];
+
+/* Luciérnagas (posición base; el vuelo lo hace el CSS). */
+const LUCIERNAGAS = [
+  [96, 168], [150, 182], [228, 172], [296, 184],
+];
+
+/**
+ * @param {Object} props
+ * @param {(view: string, data?: any) => void} [props.onNavigate] navegación
+ *   real de la app (DashboardLive la pasa). Sin ella, cae al evento global.
+ */
+export default function UmbralValle({ onNavigate }) {
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+
+  /* La franja REAL del día (amanecer→noche) — el mismo reloj del valle 3D. */
+  const { franja } = useCicloDia({ reducedMotion });
+  const clima = CLIMAS[franja] || CLIMAS.tarde;
+
+  /* Colores derivados de la franja (mezclas puras, memoizadas). */
+  const v = useMemo(() => {
+    const osc = OSCURECER[franja] || null;
+    const tinte = (hex, lejosT) => {
+      /* perspectiva atmosférica: lejos = más niebla de la franja */
+      let c = mezclaHex(hex, clima.niebla, lejosT);
+      if (osc) c = mezclaHex(c, osc.hacia, osc.t);
+      return c;
+    };
+    const esNoche = franja === 'noche';
+    return {
+      cielo0: clima.cielo[0],
+      cielo1: clima.cielo[1],
+      luz: clima.luz,
+      paramo: tinte(PISO.paramo, 0.58),
+      frio: tinte(PISO.frio, 0.38),
+      templado: tinte(PISO.templado, 0.18),
+      calido: tinte(PISO.calido, 0.05),
+      monte: tinte(MONTE, 0.12),
+      camino: tinte(CAMINO, 0.08),
+      astro: esNoche ? '#e3e9f4' : clima.luz,
+      haloAstro: esNoche ? 'rgba(214,224,246,0.35)' : `${'rgba(255,226,160,0.4)'}`,
+      estrellas: (clima.estrellas || 0) > 0,
+      luciernagas: (clima.luciernagas || 0) > 0,
+      /* la ventana espera encendida del atardecer al amanecer */
+      ventanaPrendida: esNoche || franja === 'atardecer' || franja === 'amanecer',
+      nieblaOp: clima.nieblaLejos <= 26 ? 0.5 : clima.nieblaLejos <= 36 ? 0.32 : 0.18,
+    };
+  }, [franja, clima]);
+
+  /* ── El DESPEGUE (home→valle cinematográfico): un velo con el cielo de la
+        hora cubre la pantalla, la navegación corre DEBAJO y el velo se
+        desvanece sobre el valle que recibe. CLAVE: el velo es un nodo
+        imperativo colgado de document.body — un overlay React moriría con el
+        swap de vista (verificado 2026-07-16: se veía el loader oscuro del
+        shell a mitad de viaje) y este SOBREVIVE al desmontaje del dashboard.
+        Su CSS (.uv-despegue) vive en el bundle global, así que sigue animando
+        después del swap; se autodestruye a los 2.1 s. ── */
+  const [despegando, setDespegando] = useState(false);
+
+  const navegarAlValle = useCallback(() => {
+    if (onNavigate) onNavigate('valle3d');
+    else if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'valle3d' } }));
+    }
+  }, [onNavigate]);
+
+  const entrar = useCallback(() => {
+    if (despegando) return;
+    /* Precalentar el chunk de la entrada 3D bajo el velo (fire-and-forget). */
+    try { import('../../mockups/EntradaValle3D.jsx').catch(() => {}); } catch (_) { /* opcional */ }
+    if (reducedMotion || typeof document === 'undefined') {
+      navegarAlValle();
+      return;
+    }
+    setDespegando(true);
+    const velo = document.createElement('div');
+    velo.className = 'uv-despegue';
+    velo.setAttribute('aria-hidden', 'true');
+    velo.style.setProperty('--uv-cielo-a', v.cielo0);
+    velo.style.setProperty('--uv-cielo-b', v.cielo1);
+    velo.style.setProperty('--uv-luz', v.luz);
+    document.body.appendChild(velo);
+    /* Los timers NO se atan al ciclo de vida del componente: el desmontaje
+       del dashboard a mitad de viaje es lo esperado, y el velo debe seguir. */
+    setTimeout(navegarAlValle, 620);
+    setTimeout(() => { velo.remove(); }, 2100);
+  }, [despegando, reducedMotion, navegarAlValle, v]);
+
+  return (
+    <section className="uv" aria-label="Su valle vivo" data-franja={franja}>
+      <button
+        type="button"
+        className={`uv-puerta${despegando ? ' uv-puerta--despega' : ''}`}
+        data-testid="fvh-umbral-valle"
+        aria-label={`Entrar a su valle en 3D. Ahora es ${clima.etiqueta.toLowerCase()} en la vereda.`}
+        onClick={entrar}
+        style={{
+          '--uv-cielo-a': v.cielo0,
+          '--uv-cielo-b': v.cielo1,
+          '--uv-luz': v.luz,
+        }}
+      >
+        {/* ── LA VISTA: el valle andino de la finca, a la hora real.
+              El LIENZO es panorámico (720×210): el ARTE PRINCIPAL (casa,
+              sendero, milpa, astro) vive en la mitad DERECHA (grupo
+              translate(360)) y el terreno se EXTIENDE hacia la izquierda.
+              Con xMaxYMax slice, el móvil muestra la mitad derecha (idéntico
+              al diseño base) y el desktop abre el panorama completo sin
+              recortar el cielo (el CSS capa el ancho al aspecto del lienzo). */}
+        <svg
+          className="uv-vista"
+          viewBox="0 0 720 210"
+          preserveAspectRatio="xMaxYMax slice"
+          aria-hidden="true"
+        >
+          {/* resplandor del horizonte, de lado a lado (cero blur) */}
+          <rect x="0" y="52" width="720" height="52" fill={v.luz} opacity="0.22" />
+
+          {/* estrellas de la mitad izquierda (solo la ve el desktop) */}
+          {v.estrellas && (
+            <g className="uv-estrellas">
+              {ESTRELLAS.map(([x, y, r], i) => (
+                <circle key={`ext-${i}`} cx={x * 0.94 + 8} cy={y + 4} r={r} fill="#f2f5ff" className={`uv-estrella uv-estrella--${(i + 1) % 3}`} />
+              ))}
+            </g>
+          )}
+          {/* un ave más, lejana, en el panorama ancho */}
+          <g className="uv-aves" stroke={mezclaHex(TINTA, v.cielo0, 0.35)} strokeWidth="1.6" strokeLinecap="round" fill="none" opacity="0.6">
+            <path d="M84,40 q4,-5 8,0 M92,40 q4,-5 8,0" />
+          </g>
+
+          {/* ── EXTENSIÓN IZQUIERDA del terreno (x 0..362) ── */}
+          <path
+            d="M0,104 L0,78 L36,60 L64,74 L96,54 L128,70 L162,58 L196,72 L228,52 L262,70 L298,62 L330,74 L362,84 L362,104 Z"
+            fill={v.paramo}
+          />
+          <path
+            d="M0,126 L0,96 L40,86 L78,100 L112,84 L150,98 L184,88 L222,100 L258,88 L296,102 L330,92 L362,100 L362,126 Z"
+            fill={v.frio}
+          />
+          <path
+            d="M0,154 L0,118 Q60,106 120,116 Q200,128 270,112 Q330,103 362,122 L362,154 Z"
+            fill={v.templado}
+          />
+          <g fill={v.monte}>
+            <ellipse cx="46" cy="120" rx="8" ry="5.5" />
+            <ellipse cx="72" cy="126" rx="7" ry="5" />
+            <ellipse cx="122" cy="118" rx="8" ry="5.5" />
+            <ellipse cx="172" cy="124" rx="7" ry="4.6" />
+            <ellipse cx="232" cy="114" rx="8" ry="5" />
+            <ellipse cx="300" cy="110" rx="7" ry="4.6" />
+          </g>
+          <path
+            d="M0,210 L0,148 Q80,138 160,146 Q260,156 362,152 L362,210 Z"
+            fill={v.calido}
+          />
+
+          {/* ── EL ARTE PRINCIPAL, anclado a la derecha (la vista del móvil) ── */}
+          <g transform="translate(360,0)">
+          {/* astro: el sol en su arco (o la luna plata de la noche) */}
+          <g className="uv-astro">
+            <circle cx={ASTRO[franja].cx} cy={ASTRO[franja].cy} r={ASTRO[franja].r * 2.6} fill={v.haloAstro} opacity="0.5" />
+            <circle cx={ASTRO[franja].cx} cy={ASTRO[franja].cy} r={ASTRO[franja].r} fill={v.astro} />
+            {franja === 'noche' && (
+              /* el mordisco de la luna: mismo índigo del cielo alto */
+              <circle cx={ASTRO.noche.cx + 5} cy={ASTRO.noche.cy - 4} r={ASTRO.noche.r * 0.82} fill={v.cielo0} />
+            )}
+          </g>
+
+          {/* estrellas (solo cuando la franja las trae) */}
+          {v.estrellas && (
+            <g className="uv-estrellas">
+              {ESTRELLAS.map(([x, y, r], i) => (
+                <circle key={i} cx={x} cy={y} r={r} fill="#f2f5ff" className={`uv-estrella uv-estrella--${i % 3}`} />
+              ))}
+            </g>
+          )}
+
+          {/* pajaritos lejanos cruzando el cielo */}
+          <g className="uv-aves" stroke={mezclaHex(TINTA, v.cielo0, 0.35)} strokeWidth="1.6" strokeLinecap="round" fill="none" opacity="0.7">
+            <path d="M120,44 q4,-5 8,0 M128,44 q4,-5 8,0" />
+            <path d="M158,56 q3.4,-4 7,0 M165,56 q3.4,-4 7,0" />
+          </g>
+
+          {/* ── LA CORDILLERA: los 4 pisos térmicos, del páramo al cálido.
+                Crestas con carácter andino (picos, no lomas de nube); a más
+                lejos, más niebla de la franja encima del color del piso. ── */}
+          {/* páramo, lejísimos: la línea de picos altos */}
+          <path
+            d="M0,104 L0,84 L34,62 L58,76 L88,54 L118,72 L146,50 L176,68 L206,58 L238,74 L266,48 L300,68 L328,58 L360,76 L360,104 Z"
+            fill={v.paramo}
+          />
+          {/* frío: la segunda línea, más cerca y más firme */}
+          <path
+            d="M0,126 L0,100 L36,88 L72,102 L104,84 L140,100 L172,88 L210,102 L244,86 L282,100 L318,90 L360,102 L360,126 Z"
+            fill={v.frio}
+          />
+          {/* banco de niebla que se acuesta entre el frío y el templado
+              (las puntas se AFILAN a la izquierda: sin borde vertical duro) */}
+          <g className="uv-niebla" opacity={v.nieblaOp}>
+            <path d="M-16,114 Q80,96 170,106 Q270,114 380,104 L380,120 Q270,128 170,120 Q80,116 -16,114 Z" fill={clima.niebla} />
+            <path d="M44,122 Q150,112 250,118 Q310,121 400,116 L400,128 Q310,132 230,128 Q130,126 44,122 Z" fill={clima.niebla} opacity="0.7" />
+          </g>
+          {/* templado: la ladera trabajada, lomas suaves de cafetal */}
+          <path
+            d="M0,154 L0,122 Q44,108 90,118 Q136,128 180,114 Q226,102 270,116 Q316,130 360,118 L360,154 Z"
+            fill={v.templado}
+          />
+          {/* cafetal del templado: hileras de matas de sombra */}
+          <g fill={v.monte}>
+            <ellipse cx="34" cy="126" rx="8" ry="5.5" />
+            <ellipse cx="56" cy="131" rx="7" ry="5" />
+            <ellipse cx="80" cy="127" rx="8" ry="5.5" />
+            <ellipse cx="104" cy="132" rx="7" ry="4.6" />
+            <ellipse cx="150" cy="122" rx="7" ry="5" />
+            <ellipse cx="196" cy="118" rx="8" ry="5" />
+            <ellipse cx="240" cy="122" rx="7" ry="4.6" />
+          </g>
+          {/* cálido: el primer plano tibio donde vive la casa */}
+          <path
+            d="M0,210 L0,152 Q56,140 116,148 Q178,156 238,146 Q300,136 360,148 L360,210 Z"
+            fill={v.calido}
+          />
+          {/* el sendero que sube a la puerta de la casa (la invitación) */}
+          <path
+            d="M226,210 C244,196 268,186 288,176 C298,171 302,168 304,164"
+            fill="none"
+            stroke={v.camino}
+            strokeWidth="11"
+            strokeLinecap="round"
+            opacity="0.55"
+          />
+          <path
+            d="M226,210 C244,196 268,186 288,176 C298,171 302,168 304,164"
+            fill="none"
+            stroke={v.camino}
+            strokeWidth="4.5"
+            strokeLinecap="round"
+            strokeDasharray="1 9"
+          />
+
+          {/* ── LA CASA-ANCLA, protagonista a la derecha (tokens CASA) ── */}
+          <g className="uv-casa">
+            {/* muro encalado + zócalo pintado */}
+            <rect x="286" y="140" width="42" height="28" rx="2" fill={CASA.encalado} />
+            <rect x="286" y="161" width="42" height="7" fill={CASA.zocalo} />
+            {/* faldón de teja a dos aguas (sol y sombra) + alero */}
+            <path d="M280,142 L307,122 L334,142 Z" fill={CASA.teja} />
+            <path d="M307,122 L334,142 L340,140 L310,118.5 Z" fill={CASA.tejaSombra} />
+            <path d="M280,142 L274,140 L304,118.5 L310,118.5 Z" fill={CASA.teja} />
+            {/* puerta de madera + ventana que espera */}
+            <rect x="292" y="150" width="10" height="18" rx="1.2" fill={CASA.madera} />
+            <rect
+              x="309"
+              y="147"
+              width="11"
+              height="11"
+              rx="1.2"
+              fill={v.ventanaPrendida ? CASA.ventana : CASA.carpinteria}
+              className={v.ventanaPrendida ? 'uv-ventana-prendida' : undefined}
+            />
+            {v.ventanaPrendida && (
+              /* el halo tibio de la ventana: "la casa espera" */
+              <circle cx="314.5" cy="152.5" r="14" fill={CASA.ventana} opacity="0.22" />
+            )}
+            {/* el árbol guardián junto a la casa */}
+            <rect x="270" y="146" width="4" height="18" rx="1.8" fill={CASA.madera} />
+            <ellipse cx="272" cy="138" rx="11" ry="10" fill={v.monte} />
+            <ellipse cx="266" cy="142" rx="6" ry="5" fill={mezclaHex(v.monte, v.luz, 0.18)} />
+          </g>
+
+          {/* la cerca de madera del potrero, a la izquierda del sendero */}
+          <g stroke={mezclaHex(CASA.madera, v.calido, 0.2)} strokeWidth="3.4" strokeLinecap="round" fill="none">
+            <path d="M150,170 L150,152 M186,166 L186,148 M222,163 L222,146" />
+            <path d="M144,158 L228,151 M144,166 L228,158" />
+          </g>
+          {/* matas de café flanqueando el sendero del frente */}
+          <g fill={mezclaHex(v.monte, v.calido, 0.2)}>
+            <ellipse cx="248" cy="172" rx="10" ry="7" />
+            <ellipse cx="338" cy="176" rx="11" ry="8" />
+            <ellipse cx="316" cy="184" rx="9" ry="6.5" />
+          </g>
+
+          {/* luciérnagas del anochecer */}
+          {v.luciernagas && (
+            <g className="uv-luciernagas">
+              {LUCIERNAGAS.map(([x, y], i) => (
+                <circle key={i} cx={x} cy={y} r="1.8" fill="#ffe9a8" className={`uv-luciernaga uv-luciernaga--${i}`} />
+              ))}
+            </g>
+          )}
+          </g>
+        </svg>
+
+        {/* el barbudito de páramo, el guía que sobrevuela el umbral */}
+        <span className="uv-colibri" aria-hidden="true">
+          <BarbuditoIlustrado size={78} />
+        </span>
+
+        {/* eyebrow + hora viva */}
+        <span className="uv-eyebrow" aria-hidden="true">Su valle vivo</span>
+        <span className="uv-hora" aria-hidden="true">{clima.etiqueta}</span>
+
+        {/* ── LA INVITACIÓN ── */}
+        <span className="uv-cta" aria-hidden="true">
+          <span className="uv-cta-txt">
+            <b>Entrar a mi valle</b>
+            <small>Camine su finca en 3D</small>
+          </span>
+          <span className="uv-cta-flecha">
+            <svg viewBox="0 0 24 24" width="22" height="22" fill="none">
+              <path d="M5 12h13M13 6.5 18.5 12 13 17.5" stroke={TINTA} strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </span>
+        </span>
+      </button>
+
+      {/* El velo del viaje NO se renderiza aquí: es un nodo imperativo en
+          document.body (ver `entrar`) para sobrevivir al swap de vista. */}
+    </section>
+  );
+}

--- a/src/components/dashboard/portales-mano.css
+++ b/src/components/dashboard/portales-mano.css
@@ -1,0 +1,112 @@
+/*
+ * portales-mano.css — las puertas del home como CARTAS EN LA MANO
+ * (PortalesMano.jsx). Hereda la base .fvh-puertas/.fvh-puerta del hero
+ * (grid, focus, active, animación brota, tintes de borde) y encima pinta
+ * la carta: viñeta de autor sobre el cielo vivo + rótulo en papel.
+ *
+ * "La mano": en móvil las cartas se ladean apenas (como recién puestas
+ * sobre la mesa); en pantalla ancha la fila se abre en abanico. Todo
+ * transform estático (cero animación por frame).
+ */
+
+.fvh-puertas.fvh-puertas--mano {
+  gap: 14px;
+  /* aire para que el abanico no se corte */
+  padding-bottom: 6px;
+}
+
+.fvh-puertas--mano .pm-carta {
+  position: relative;
+  min-height: 132px;
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
+  justify-content: flex-end;
+  /* el cielo de la hora detrás de la viñeta */
+  background: linear-gradient(180deg, var(--pm-cielo-a), var(--pm-cielo-b) 82%);
+  border-width: 2px;
+  box-shadow:
+    0 12px 26px rgba(20, 30, 20, 0.28),
+    inset 0 0 0 1.5px rgba(255, 255, 255, 0.22);
+}
+
+/* la mano que las puso: ladeadas apenas, alternando. OJO: la animación
+   `fvh-puerta-brota` del hero termina en translateY(0) con fill both y
+   PISA cualquier transform estático — por eso el ladeo viaja en una
+   variable y la carta trae SU animación de brote que termina en él. */
+.fvh-puertas--mano .pm-carta {
+  animation-name: pm-brota;
+  --pm-tilt: none;
+}
+.fvh-puertas--mano .pm-carta:nth-child(odd) { --pm-tilt: rotate(-1.1deg); }
+.fvh-puertas--mano .pm-carta:nth-child(even) { --pm-tilt: rotate(1.1deg) translateY(3px); }
+@keyframes pm-brota {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: var(--pm-tilt, none); }
+}
+/* el toque: la variable cambia y el keyframe lleno la re-resuelve en vivo */
+.fvh-puertas--mano .pm-carta:active { --pm-tilt: scale(0.97); }
+
+.pm-vineta {
+  display: block;
+  width: 100%;
+  height: 72px;
+  flex: none;
+}
+.pm-vineta svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* el rótulo en papel: palabra grande + a dónde abre, legible SIEMPRE */
+.pm-rotulo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  width: 100%;
+  padding: 8px 10px 10px;
+  background: var(--fvh-card-bg);
+  border-top: 2px solid var(--fvh-p-borde, var(--fvh-card-border));
+}
+.fvh-puertas--mano .fvh-puerta-nombre {
+  font-size: 18px;
+  color: var(--fvh-card-tinta);
+}
+.pm-abre {
+  font: 700 11.5px/1.25 var(--fvh-body, 'Nunito', system-ui, sans-serif);
+  color: var(--fvh-card-tinta-suave, var(--fvh-card-tinta));
+  text-align: center;
+  opacity: 0.9;
+}
+
+/* ── EL ABANICO en pantalla ancha: la mano abierta de cartas ── */
+@media (min-width: 1080px) {
+  .fvh-puertas.fvh-puertas--mano {
+    grid-template-columns: repeat(6, 1fr);
+    gap: 10px;
+    padding-top: 10px;
+  }
+  .fvh-puertas--mano .pm-carta { min-height: 148px; }
+  .fvh-puertas--mano .pm-carta:nth-child(1) { --pm-tilt: rotate(-4.5deg) translateY(16px); }
+  .fvh-puertas--mano .pm-carta:nth-child(2) { --pm-tilt: rotate(-2.5deg) translateY(6px); }
+  .fvh-puertas--mano .pm-carta:nth-child(3) { --pm-tilt: rotate(-0.8deg); }
+  .fvh-puertas--mano .pm-carta:nth-child(4) { --pm-tilt: rotate(0.8deg); }
+  .fvh-puertas--mano .pm-carta:nth-child(5) { --pm-tilt: rotate(2.5deg) translateY(6px); }
+  .fvh-puertas--mano .pm-carta:nth-child(6) { --pm-tilt: rotate(4.5deg) translateY(16px); }
+  .fvh-puertas--mano .pm-carta:hover { --pm-tilt: translateY(-6px); }
+  .fvh-puertas--mano .pm-carta:active { --pm-tilt: scale(0.97); }
+}
+
+/* reduced-motion: cartas derechas y quietas, sin brote */
+@media (prefers-reduced-motion: reduce) {
+  .fvh-puertas--mano .pm-carta,
+  .fvh-puertas--mano .pm-carta:nth-child(odd),
+  .fvh-puertas--mano .pm-carta:nth-child(even) {
+    --pm-tilt: none;
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/src/components/dashboard/umbral-valle.css
+++ b/src/components/dashboard/umbral-valle.css
@@ -1,0 +1,235 @@
+/*
+ * umbral-valle.css — la puerta grande del home al valle 3D (UmbralValle.jsx).
+ *
+ * Reglas de la casa: animaciones SOLO transform/opacity (Android barato),
+ * cero blur/filter costoso, prefers-reduced-motion congela todo en un
+ * fotograma digno. Los colores vivos llegan por variables (--uv-*) desde el
+ * componente (cielo/luz de la franja real del día).
+ */
+
+.uv {
+  padding: 4px 16px 0;
+}
+
+/* ── LA PUERTA: una carta grande con la vista viva adentro ── */
+.uv-puerta {
+  position: relative;
+  display: block;
+  width: 100%;
+  min-height: 200px;
+  border: 0;
+  border-radius: 26px;
+  padding: 0;
+  overflow: hidden;
+  cursor: pointer;
+  /* el cielo de la hora ES el fondo; la vista SVG apoya el terreno encima */
+  background: linear-gradient(180deg, var(--uv-cielo-a), var(--uv-cielo-b) 78%);
+  box-shadow:
+    0 18px 38px rgba(18, 26, 18, 0.35),
+    inset 0 0 0 2px rgba(255, 255, 255, 0.16),
+    inset 0 -26px 40px rgba(24, 20, 14, 0.22);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.uv-puerta:active { transform: scale(0.985); }
+.uv-puerta:focus-visible {
+  outline: 3px solid var(--fvh-lima, #a3e635);
+  outline-offset: 3px;
+}
+@media (min-width: 720px) {
+  /* el panorama completo del lienzo (720×210): el ancho se capa a su
+     aspecto para que el cielo y las crestas nunca se recorten */
+  .uv-puerta {
+    min-height: 280px;
+    max-width: 960px;
+    margin-inline: auto;
+  }
+  .uv-puerta:hover {
+    transform: translateY(-2px);
+    box-shadow:
+      0 24px 46px rgba(18, 26, 18, 0.4),
+      inset 0 0 0 2px rgba(255, 255, 255, 0.2),
+      inset 0 -26px 40px rgba(24, 20, 14, 0.22);
+  }
+}
+
+.uv-vista {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* ── vida sutil de la vista (todo transform/opacity) ── */
+.uv-niebla { animation: uv-niebla-deriva 46s ease-in-out infinite alternate; }
+@keyframes uv-niebla-deriva {
+  from { transform: translateX(-14px); }
+  to { transform: translateX(14px); }
+}
+
+.uv-astro { animation: uv-astro-respira 7s ease-in-out infinite alternate; transform-origin: center; }
+@keyframes uv-astro-respira {
+  from { opacity: 0.92; }
+  to { opacity: 1; }
+}
+
+.uv-estrella { animation: uv-titila 3.2s ease-in-out infinite alternate; }
+.uv-estrella--1 { animation-delay: 1.1s; }
+.uv-estrella--2 { animation-delay: 2.2s; }
+@keyframes uv-titila {
+  from { opacity: 0.35; }
+  to { opacity: 1; }
+}
+
+.uv-ventana-prendida { animation: uv-titila 5s ease-in-out infinite alternate; }
+
+.uv-luciernaga { animation: uv-vuela 6.5s ease-in-out infinite alternate; }
+.uv-luciernaga--1 { animation-delay: 1.6s; animation-duration: 7.4s; }
+.uv-luciernaga--2 { animation-delay: 3.1s; animation-duration: 5.8s; }
+.uv-luciernaga--3 { animation-delay: 4.4s; }
+@keyframes uv-vuela {
+  0% { transform: translate(0, 0); opacity: 0.25; }
+  40% { opacity: 1; }
+  100% { transform: translate(9px, -14px); opacity: 0.35; }
+}
+
+/* ── el barbudito guía, sobrevolando el umbral ── */
+.uv-colibri {
+  position: absolute;
+  top: 25%;
+  left: 58%;
+  animation: uv-colibri-flota 5.4s ease-in-out infinite alternate;
+  pointer-events: none;
+}
+@keyframes uv-colibri-flota {
+  from { transform: translateY(0) rotate(-2deg); }
+  to { transform: translateY(-9px) rotate(2.5deg); }
+}
+
+/* ── rótulos sobre el cielo ── */
+.uv-eyebrow,
+.uv-hora {
+  position: absolute;
+  top: 12px;
+  font: 800 11px/1 var(--fvh-body, 'Nunito', system-ui, sans-serif);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(30, 26, 18, 0.78);
+  background: rgba(255, 252, 240, 0.72);
+  padding: 6px 10px;
+  border-radius: 999px;
+  pointer-events: none;
+}
+.uv-eyebrow { right: 12px; }
+.uv-hora { left: 12px; }
+
+/* ── la invitación (CTA dentro de la puerta) ── */
+.uv-cta {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  max-width: min(248px, 68%);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 58px;
+  padding: 8px 10px 8px 16px;
+  border-radius: 18px;
+  background: rgba(255, 252, 240, 0.9);
+  box-shadow: 0 8px 18px rgba(24, 20, 14, 0.28);
+  pointer-events: none;
+}
+.uv-cta-txt {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  text-align: left;
+}
+.uv-cta-txt b {
+  font-family: var(--fvh-display, 'Baloo 2', system-ui, sans-serif);
+  font-size: 19px;
+  font-weight: 700;
+  line-height: 1.05;
+  color: #23301b;
+}
+.uv-cta-txt small {
+  font: 700 12.5px/1.2 var(--fvh-body, 'Nunito', system-ui, sans-serif);
+  color: #55613f;
+}
+.uv-cta-flecha {
+  flex: none;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--uv-luz, #ffd98f);
+  box-shadow: inset 0 0 0 2px rgba(44, 36, 28, 0.28);
+  animation: uv-flecha-invita 2.6s ease-in-out infinite;
+}
+@keyframes uv-flecha-invita {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(4px); }
+}
+
+/* ── EL DESPEGUE: el cielo de la hora inunda la pantalla (velo del viaje).
+      Es un nodo imperativo en <body> (sobrevive al swap de vista): cubre en
+      0.62s, la navegación corre debajo, SOSTIENE la meseta y se desvanece
+      sobre el valle que recibe. Tres actos, dos animaciones. ── */
+.uv-despegue {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  pointer-events: none;
+  background: linear-gradient(180deg, var(--uv-cielo-a), var(--uv-cielo-b));
+  opacity: 0;
+  animation:
+    uv-despega 0.62s ease-in forwards,
+    uv-desvanece 0.55s ease-out 1.35s forwards;
+}
+.uv-despegue::after {
+  /* el estallido de luz del centro: la puerta que se abre */
+  content: '';
+  position: absolute;
+  inset: -30%;
+  background: radial-gradient(circle at 50% 62%, var(--uv-luz) 0%, transparent 52%);
+  opacity: 0;
+  transform: scale(0.6);
+  animation: uv-despega-luz 0.62s ease-out forwards;
+}
+@keyframes uv-despega {
+  0% { opacity: 0; }
+  55% { opacity: 1; }
+  100% { opacity: 1; }
+}
+@keyframes uv-despega-luz {
+  0% { opacity: 0; transform: scale(0.6); }
+  45% { opacity: 0.9; }
+  100% { opacity: 0.55; transform: scale(1.15); }
+}
+@keyframes uv-desvanece {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+.uv-puerta--despega { transform: scale(1.02); }
+
+/* ── reduced-motion: un fotograma digno, cero vaivén ── */
+@media (prefers-reduced-motion: reduce) {
+  .uv-niebla,
+  .uv-astro,
+  .uv-estrella,
+  .uv-ventana-prendida,
+  .uv-luciernaga,
+  .uv-colibri,
+  .uv-cta-flecha,
+  .uv-despegue,
+  .uv-despegue::after {
+    animation: none !important;
+  }
+  .uv-puerta,
+  .uv-puerta:active,
+  .uv-puerta--despega { transition: none; transform: none; }
+}


### PR DESCRIPTION
## El encargo (FABLE_50 §A6 + dirección "home máximo")
> "Home/portada finca-viva — pulir la escena de entrada + los 4 portales 'la mano' + colibrí a nivel demo (es lo PRIMERO que ve el piloto)" — con las 3 prioridades JUNTAS: portales claros, escena de entrada mágica, y transición al valle 3D cinematográfica.

**Antes**: 6 tarjetas planas (emoji del sistema sobre fondo crema), sin ninguna puerta al valle 3D desde el home, y el paso a cualquier vista era un corte seco de hash.

## Qué trae

### 1. El UMBRAL DEL VALLE (`UmbralValle.jsx` + `umbral-valle.css`)
La escena de entrada nueva: una vista viva del valle andino que ES la puerta grande al valle 3D.
- **Vive con la hora real de la vereda**: cielo/luz/estrellas/luciérnagas salen de `CLIMAS` + `useCicloDia` — la MISMA fuente del valle 3D. Amanece, atardece y anochece solo (`?ciclo=` para QA).
- **Cordillera de 4 pisos térmicos** (colores de `PISOS_TERMICOS`/paleta madre) con perspectiva atmosférica real (`mezclaHex` hacia la niebla de la franja) y oscurecimiento crepuscular/nocturno.
- **Casa-ancla** con tokens `CASA` de la paleta madre — la ventana se enciende del atardecer al amanecer ("la casa espera") — sendero, cerca, cafetal, aves, y el **barbudito ilustrado** (el colibrí insignia) sobrevolando.
- **Lienzo panorámico 720×210 anclado a la derecha** (`xMaxYMax slice`): el móvil ve la escena íntima (casa protagonista) y el desktop abre el panorama completo sin recortar cielo ni crestas (CSS capa el ancho al aspecto del lienzo).

### 2. La TRANSICIÓN home→valle (cinematográfica)
- Tocar el umbral **inunda la pantalla con el cielo de la hora** + estallido de luz, navega a `valle3d` bajo la meseta cubierta, sostiene, y se **desvanece sobre el valle que recibe con ese mismo cielo** (`CargandoValle` pinta el mismo gradiente → el corte del shell no se ve).
- **Detalle clave**: el velo es un nodo imperativo en `document.body` — un overlay React moría con el swap de vista y se veía el loader oscuro (verificado empíricamente). Se autodestruye a los 2.1 s.
- El chunk de `EntradaValle3D` se **precarga al tocar**. `prefers-reduced-motion`: corte directo digno. Sin `onNavigate` cae al evento global `chagraNavigate`.

### 3. Las puertas como CARTAS EN LA MANO (`PortalesMano.jsx` + `portales-mano.css`)
- Cada puerta deja el emoji plano y pasa a ser una **carta pintada**: viñeta SVG de autor (rubber-hose, tinta cálida, paleta madre citada) sobre el **cielo vivo de la misma hora del umbral** — toda la portada respira la misma hora.
- Palabra grande + "a dónde abre" debajo (se entiende de un vistazo), targets ≥96px intactos.
- En pantalla ancha la fila se **abre en abanico** como una mano de cartas (la "mano"); el ladeo viaja en `--pm-tilt` dentro del keyframe (la animación `brota` con `fill both` pisaba cualquier transform estático).
- **CONTRATO INTACTO**: mismos `data-testid`, aria-labels y destinos — `buildPuertas` del hero sigue siendo la fuente única.

## Perf (Android barato — es la portada)
DOM+SVG+CSS puros: **cero three en el home**, cero imágenes, cero blur; animaciones solo transform/opacity; todo congelado con `prefers-reduced-motion`.

## Verificación (síncrona)
- `npm run build:prod` **VERDE** (exit 0).
- **29 tests del hero verdes** (portales 15/15 — ruteo de las 6 puertas intacto —, estructura, theme). Los 4 fallos de `ClimaStrip`/`glaciarBanner` en la suite dashboard son **pre-existentes** (fallan igual sin este cambio, verificado con stash).
- `tsc:check`: 22 errores **pre-existentes** en `src/visual/mundo3d/terreno/` (idéntico a `origin/app-3d`, PR #2512); estos archivos suman 0.
- **Transición end-to-end verificada con Playwright**: tap en el umbral → velo del cielo → aterrizaje en el valle 3D al mismo atardecer (capturas `transicion-*.png`).
- **Capturas** (Playwright + swiftshader, móvil 390×844 y desktop 1280×800): mediodía, atardecer, noche y amanecer del umbral + cartas + abanico desktop + frames de la transición. Las adjunta el operador/orquestador al hilo (scratchpad `shots/`): `home-ANTES-top.png`, `home-ANTES-puertas.png`, `umbral-FINAL3-movil.png`, `umbral-FINAL-noche.png`, `umbral-v3-amanecer.png`, `umbral-FINAL3-desktop.png`, `transicion-valle.png`.

## Notas de coordinación
- **Regresión visual**: los baselines de `finca-viva-temas` cambiarán (es el punto del PR) — regenerar con el workflow `visual-regression` (dispatch `update_snapshots=true`) tras el merge.
- **Worktree compartido**: este PR toca SOLO 5 archivos propios (`FincaVivaHero.jsx` + 4 nuevos). El WIP del carril cóndor (`creatures.css`, `Condor*.jsx`, `registry.js`) quedó fuera del commit a propósito.
- El umbral solo se monta con finca propia (`tieneFincaPropia`): la RED institucional del extensionista no lo lleva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)