### PR TITLE
feat(angelita): motor de comportamiento e inteligencia de notificaciones

### DIFF
--- a/src/services/__tests__/angelitaInteligencia.test.js
+++ b/src/services/__tests__/angelitaInteligencia.test.js
@@ -1,0 +1,310 @@
+/**
+ * angelitaInteligencia — el MOTOR de comportamiento de Angelita.
+ *
+ * Contratos que cuidamos:
+ *   - los 4 estados de comportamiento y su mapeo al vocabulario VISUAL real.
+ *   - ruteo pantalla → mundo.
+ *   - comentario por mundo GROUNDED (usa datos reales; si no hay, acompaña
+ *     honesto — nunca inventa cifras).
+ *   - notificaciones priorizadas + severidad.
+ *   - anti-molestia (lección Clippy): cooldown, no interrumpir a mitad de tarea,
+ *     silencio, y que la urgencia alta sí pueda interrumpir.
+ *   - arbitraje del resolvedor (aviso urgente > celebra > husmea; veto → calma).
+ *   - tono: usted, SIN voseo (ni "vos", ni "tenés/querés/podés"), nunca tuteo.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ESTADOS_COMPORTAMIENTO,
+  MUNDOS,
+  estadoVisualDeComportamiento,
+  ariaDeComportamiento,
+  mundoDePantalla,
+  comentarioDeMundo,
+  notificacionesInteligentes,
+  debeHablar,
+  resolverComportamiento,
+  llaveDeDecision,
+  COOLDOWN_MS,
+} from '../angelitaInteligencia';
+// Contrato con la CARA: los estados visuales canónicos que el dibujo entiende.
+import { ESTADOS_ANGELITA } from '../../visual/agente/angelitaEstados';
+
+const MINUTO = 60 * 1000;
+const sinVoseo = (s) => expect(s).not.toMatch(/\bvos\b|tenés|querés|podés|\btú\b/i);
+
+describe('estados de comportamiento', () => {
+  it('expone los cuatro estados canónicos', () => {
+    expect(ESTADOS_COMPORTAMIENTO).toEqual(['calma', 'aviso', 'celebra', 'husmea']);
+  });
+
+  it('mapea cada estado a vocabulario VISUAL conocido (contrato con la cara)', () => {
+    for (const e of ESTADOS_COMPORTAMIENTO) {
+      const v = estadoVisualDeComportamiento(e);
+      expect(ESTADOS_ANGELITA).toContain(v);
+    }
+    // aviso urgente vs tranquilo → dos poses visuales distintas y válidas.
+    const urgente = estadoVisualDeComportamiento('aviso', { severidad: 'alta' });
+    const tranquilo = estadoVisualDeComportamiento('aviso', { severidad: 'media' });
+    expect(urgente).toBe('preocupada');
+    expect(tranquilo).toBe('invita');
+    expect(ESTADOS_ANGELITA).toContain(urgente);
+    expect(ESTADOS_ANGELITA).toContain(tranquilo);
+  });
+
+  it('calma es el default seguro ante estado desconocido', () => {
+    expect(estadoVisualDeComportamiento('calma')).toBe('acompana');
+    expect(estadoVisualDeComportamiento('inventado_xyz')).toBe('acompana');
+  });
+
+  it('celebra y husmea tienen su pose', () => {
+    expect(estadoVisualDeComportamiento('celebra')).toBe('contenta');
+    expect(estadoVisualDeComportamiento('husmea')).toBe('senala');
+  });
+
+  it('aria narra en usted, sin voseo', () => {
+    for (const e of ESTADOS_COMPORTAMIENTO) sinVoseo(ariaDeComportamiento(e));
+  });
+});
+
+describe('mundoDePantalla', () => {
+  it('rutea pantallas conocidas a su mundo', () => {
+    expect(mundoDePantalla('animales_gallinas')).toBe('mis_animales');
+    expect(mundoDePantalla('clima_boletin')).toBe('clima');
+    expect(mundoDePantalla('mercado')).toBe('vender');
+    expect(mundoDePantalla('aprende')).toBe('aprender');
+    expect(mundoDePantalla('bosque_vivo')).toBe('bosque');
+    expect(mundoDePantalla('glaciar')).toBe('paramo');
+    expect(mundoDePantalla('valle3d')).toBe('finca');
+  });
+
+  it('los cultivos con mundo propio caen en mis_matas', () => {
+    expect(mundoDePantalla('cafe')).toBe('mis_matas');
+    expect(mundoDePantalla('papa')).toBe('mis_matas');
+    expect(mundoDePantalla('uchuva')).toBe('mis_matas');
+  });
+
+  it('prefijos paramétricos caen a su mundo', () => {
+    expect(mundoDePantalla('animales_lo_que_sea')).toBe('mis_animales');
+    expect(mundoDePantalla('seguimiento_reforestacion')).toBe('mis_matas');
+    expect(mundoDePantalla('valle3d_lluvia')).toBe('clima'); // mapeo explícito gana
+  });
+
+  it('desconocida / vacía / no-string → null', () => {
+    expect(mundoDePantalla('pantalla_inventada')).toBeNull();
+    expect(mundoDePantalla('')).toBeNull();
+    expect(mundoDePantalla(null)).toBeNull();
+    expect(mundoDePantalla(42)).toBeNull();
+  });
+
+  it('todo destino de PANTALLA_A_MUNDO es un mundo válido', () => {
+    const muestras = ['activos', 'animales', 'agua', 'mercados', 'curso', 'restauracion', 'diorama_paramo', 'dashboard'];
+    for (const p of muestras) {
+      const m = mundoDePantalla(p);
+      expect(MUNDOS).toContain(m);
+    }
+  });
+});
+
+describe('comentarioDeMundo — grounded + honesto', () => {
+  it('mis_matas: usa el inventario REAL cuando lo hay', () => {
+    const s = comentarioDeMundo('mis_matas', { cultivos: [{ name: 'Café #01', count: 12 }, { name: 'Fríjol', count: 3 }] });
+    expect(s).toMatch(/café/i);
+    expect(s).toMatch(/12/);
+    sinVoseo(s);
+  });
+
+  it('mis_matas: sin datos → acompañamiento honesto, SIN cifras inventadas', () => {
+    const s = comentarioDeMundo('mis_matas', { cultivos: [] });
+    expect(s).toMatch(/todavía no me ha contado/i);
+    expect(s).not.toMatch(/\d/); // no inventa números
+    sinVoseo(s);
+  });
+
+  it('mis_animales: cuenta real o fallback honesto', () => {
+    expect(comentarioDeMundo('mis_animales', { total: 5 })).toMatch(/5 animales/i);
+    expect(comentarioDeMundo('mis_animales', {})).toMatch(/cuando anote los suyos/i);
+  });
+
+  it('clima: prioriza alertas reales, luego fase, luego honestidad', () => {
+    const conAlerta = comentarioDeMundo('clima', { snapshot: { alertas_locales: [{}, {}] } });
+    expect(conAlerta).toMatch(/2 avisos/i);
+    const conFase = comentarioDeMundo('clima', {
+      snapshot: { enso_status: { phase: 'nina_fuerte' } },
+      describirFase: (p) => (p === 'nina_fuerte' ? 'La Niña fuerte — mucha lluvia' : 'Estado del clima desconocido'),
+    });
+    expect(conFase).toMatch(/niña fuerte/i);
+    const sinDato = comentarioDeMundo('clima', {});
+    expect(sinDato).toMatch(/no tengo el parte del clima/i);
+  });
+
+  it('vender: NUNCA inventa precios', () => {
+    const s = comentarioDeMundo('vender', { cultivos: [{ name: 'Aguacate', count: 4 }] });
+    expect(s).toMatch(/aguacate/i);
+    expect(s).not.toMatch(/\$|peso|precio de|a \d/i);
+    sinVoseo(s);
+  });
+
+  it('aprender / bosque / páramo: acompañamiento en pregunta, sin dato de la finca', () => {
+    for (const m of ['aprender', 'bosque', 'paramo']) {
+      const s = comentarioDeMundo(m, {});
+      expect(s).toBeTruthy();
+      sinVoseo(s);
+    }
+    expect(comentarioDeMundo('paramo', {})).toMatch(/agua/i);
+  });
+
+  it('mundo inexistente → null', () => {
+    expect(comentarioDeMundo('mundo_fantasma', {})).toBeNull();
+  });
+
+  it('todos los mundos comentan en usted sin voseo', () => {
+    for (const m of MUNDOS) {
+      const s = comentarioDeMundo(m, {});
+      expect(s).toBeTruthy();
+      sinVoseo(s);
+    }
+  });
+});
+
+describe('notificacionesInteligentes', () => {
+  const helada = { type: 'helada', severity: 'danger', title: 'Helada esta noche' };
+  const tareaHoy = { name: 'Regar el semillero', timestamp: Math.floor(Date.now() / 1000) };
+
+  it('sin alertas ni tareas → calma, sin severidad', () => {
+    const n = notificacionesInteligentes({ activeAlerts: [], pendingTasks: [] });
+    expect(n.hay).toBe(false);
+    expect(n.estado).toBe('calma');
+    expect(n.severidad).toBeNull();
+    expect(n.prioridad).toBe(0);
+  });
+
+  it('alerta danger → aviso severidad alta y prioridad máxima', () => {
+    const n = notificacionesInteligentes({ activeAlerts: [helada], pendingTasks: [] });
+    expect(n.hay).toBe(true);
+    expect(n.estado).toBe('aviso');
+    expect(n.severidad).toBe('alta');
+    expect(n.prioridad).toBe(100);
+    expect(n.lead).toBeTruthy();
+    expect(n.items.length).toBeGreaterThan(0);
+  });
+
+  it('tarea de hoy sin alertas → aviso severidad baja/media', () => {
+    const n = notificacionesInteligentes({ activeAlerts: [], pendingTasks: [tareaHoy] });
+    expect(n.hay).toBe(true);
+    expect(['media', 'baja']).toContain(n.severidad);
+  });
+});
+
+describe('debeHablar — anti-molestia', () => {
+  const ahora = 1_000_000_000;
+
+  it('silenciado → nunca habla', () => {
+    expect(debeHablar({ estado: 'aviso', severidad: 'alta', silenciado: true, ahoraMs: ahora })).toBe(false);
+  });
+
+  it('calma → nunca "habla" (reposa)', () => {
+    expect(debeHablar({ estado: 'calma', ahoraMs: ahora })).toBe(false);
+  });
+
+  it('no interrumpe a mitad de tarea… salvo aviso URGENTE', () => {
+    expect(debeHablar({ estado: 'husmea', ocupado: true, ahoraMs: ahora })).toBe(false);
+    expect(debeHablar({ estado: 'celebra', ocupado: true, ahoraMs: ahora })).toBe(false);
+    expect(debeHablar({ estado: 'aviso', severidad: 'media', ocupado: true, ahoraMs: ahora })).toBe(false);
+    // urgente sí puede interrumpir
+    expect(debeHablar({ estado: 'aviso', severidad: 'alta', ocupado: true, ahoraMs: ahora })).toBe(true);
+  });
+
+  it('respeta el cooldown por tipo', () => {
+    // husmea recién habló → aún no
+    expect(debeHablar({ estado: 'husmea', ahoraMs: ahora, ultimaMs: ahora - 5 * MINUTO })).toBe(false);
+    // pasado el cooldown → sí
+    expect(debeHablar({ estado: 'husmea', ahoraMs: ahora, ultimaMs: ahora - (COOLDOWN_MS.husmea + MINUTO) })).toBe(true);
+  });
+
+  it('aviso urgente ignora el cooldown (cooldown 0)', () => {
+    expect(COOLDOWN_MS.aviso_alta).toBe(0);
+    expect(debeHablar({ estado: 'aviso', severidad: 'alta', ahoraMs: ahora, ultimaMs: ahora - 1000 })).toBe(true);
+  });
+});
+
+describe('resolverComportamiento — arbitraje', () => {
+  const ahora = 2_000_000_000;
+  const avisoAlto = notificacionesInteligentes({ activeAlerts: [{ type: 'helada', severity: 'danger', title: 'Helada' }], pendingTasks: [] });
+
+  it('sin nada → calma silenciosa', () => {
+    const d = resolverComportamiento({ ahoraMs: ahora });
+    expect(d.estado).toBe('calma');
+    expect(d.mensaje).toBeNull();
+    expect(d.interrumpe).toBe(false);
+    expect(d.visualEstado).toBe('acompana');
+  });
+
+  it('aviso urgente le gana a celebrar y a husmear', () => {
+    const d = resolverComportamiento({
+      ahoraMs: ahora,
+      notificaciones: avisoAlto,
+      logro: { id: 'l1', texto: '¡Registró su cosecha!' },
+      mundo: 'mis_matas',
+      datosMundo: { cultivos: [{ name: 'Café', count: 9 }] },
+    });
+    expect(d.estado).toBe('aviso');
+    expect(d.severidad).toBe('alta');
+    expect(d.visualEstado).toBe('preocupada');
+    expect(d.interrumpe).toBe(true);
+    expect(d.mensaje).toBeTruthy();
+  });
+
+  it('celebra un logro real (dedup por id)', () => {
+    const ctx = { ahoraMs: ahora, logro: { id: 'cosecha-42', texto: '¡Buena cosecha!' } };
+    const d1 = resolverComportamiento(ctx);
+    expect(d1.estado).toBe('celebra');
+    expect(d1.visualEstado).toBe('contenta');
+    expect(d1.logroId).toBe('cosecha-42');
+    // ya celebrado → no repite
+    const d2 = resolverComportamiento({ ...ctx, ultimoLogroId: 'cosecha-42' });
+    expect(d2.estado).toBe('calma');
+  });
+
+  it('husmea un mundo con comentario grounded', () => {
+    const d = resolverComportamiento({
+      ahoraMs: ahora,
+      mundo: 'mis_animales',
+      datosMundo: { total: 8 },
+    });
+    expect(d.estado).toBe('husmea');
+    expect(d.visualEstado).toBe('senala');
+    expect(d.mensaje).toMatch(/8 animales/i);
+    expect(d.interrumpe).toBe(true);
+  });
+
+  it('husmea respeta cooldown POR MUNDO → si ya comentó ese mundo, calla', () => {
+    const llave = 'husmea:mis_matas';
+    const d = resolverComportamiento({
+      ahoraMs: ahora,
+      mundo: 'mis_matas',
+      datosMundo: { cultivos: [{ name: 'Café', count: 3 }] },
+      ultimaHablaPorLlave: { [llave]: ahora - 60 * 1000 }, // habló hace 1 min
+    });
+    expect(d.estado).toBe('calma'); // vetado por cooldown de mundo
+  });
+
+  it('no interrumpe a mitad de tarea (ocupado) salvo urgencia', () => {
+    const husmeando = resolverComportamiento({
+      ahoraMs: ahora, ocupado: true, mundo: 'mis_matas', datosMundo: { cultivos: [{ name: 'Papa', count: 2 }] },
+    });
+    expect(husmeando.estado).toBe('calma');
+    const urgente = resolverComportamiento({ ahoraMs: ahora, ocupado: true, notificaciones: avisoAlto });
+    expect(urgente.estado).toBe('aviso');
+  });
+
+  it('silenciado → siempre calma', () => {
+    const d = resolverComportamiento({ ahoraMs: ahora, notificaciones: avisoAlto, silenciado: true });
+    expect(d.estado).toBe('calma');
+  });
+
+  it('llaveDeDecision devuelve la llave correcta para el cooldown', () => {
+    expect(llaveDeDecision({ estado: 'calma' })).toBeNull();
+    expect(llaveDeDecision({ estado: 'husmea' }, 'clima')).toBe('husmea:clima');
+    expect(llaveDeDecision({ estado: 'aviso', severidad: 'media' })).toBe('aviso_media');
+  });
+});

--- a/src/services/angelitaInteligencia.js
+++ b/src/services/angelitaInteligencia.js
@@ -1,0 +1,595 @@
+/*
+ * angelitaInteligencia — EL MOTOR DE COMPORTAMIENTO DE ANGELITA.
+ *
+ * Angelita (Tetragonisca angustula, la abeja sin aguijón) es la compañera IA de
+ * Chagra. Este módulo es su CABEZA, no su cara: decide QUÉ hacer y QUÉ decir a
+ * partir de lo que de verdad pasa en la finca — sin dibujar nada, sin React, sin
+ * red. La cara (Angelita.jsx / angelitaEstados.js) consume esta decisión; el
+ * shell (AgentScreen / AgentFab / el store useAngelitaStore) le pasa los datos.
+ *
+ * La meta, en una línea: que Angelita se sienta una vecina VIVA que sabe dónde
+ * está usted y qué le conviene, NUNCA un Clippy que interrumpe a lo bruto.
+ *
+ * CUATRO ESTADOS DE COMPORTAMIENTO (la API que consume la cara):
+ *   - calma   → default, en reposo, acompaña e invita a tocar. No habla sola.
+ *   - aviso   → hay algo que atender (helada, riego, tarea vencida, alerta). Lo
+ *               DICE, priorizado, 1–2 cosas, sin gritar.
+ *   - celebra → un logro REAL del campesino (cosecha registrada, racha, meta).
+ *   - husmea  → curiosea el mundo donde entró y comenta algo con valor,
+ *               GROUNDED en los datos reales de ese mundo.
+ *
+ * REGLAS DE LA CASA (inviolables):
+ *   1. CERO invención de datos agronómicos. Si no hay dato real, se usa un
+ *      mensaje de acompañamiento honesto y genérico (una pregunta, una
+ *      invitación) — nunca una cifra, dosis, precio o pronóstico inventado.
+ *   2. Español de Colombia, USTED cálido. Nunca voseo (ni "vos", ni "tenés").
+ *   3. Anti-molestia (lección Clippy): frecuencia y timing con criterio; nunca
+ *      interrumpe a mitad de una tarea salvo urgencia real; local-first, todo
+ *      funciona offline (este módulo NO hace red).
+ *
+ * DEUDA CONOCIDA (2º pase): al arrancar no había salida del DR de UX de
+ * asistentes-IA y notificaciones contextuales en deepresearch/DR-FANOUT. Los
+ * cooldowns y las plantillas se fijaron con criterio; cuando llegue el DR,
+ * revisar cadencias y copy aquí.
+ *
+ * SOLO datos + funciones puras (testeables sin montar nada). El estado en vivo
+ * (qué está diciendo ahora, cuándo habló por última vez) vive en el store
+ * useAngelitaStore, que llama a estas funciones.
+ */
+
+import { buildProactiveGreeting, saludoPorHora } from './proactiveGreeting';
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * 1. LOS ESTADOS DE COMPORTAMIENTO — el vocabulario de la API.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** Los cuatro estados canónicos del comportamiento de Angelita. */
+export const ESTADOS_COMPORTAMIENTO = /** @type {const} */ ([
+  'calma',
+  'aviso',
+  'celebra',
+  'husmea',
+]);
+
+/**
+ * Contrato con la CARA (src/visual/agente/angelitaEstados.js): cada estado de
+ * comportamiento se traduce a un estado VISUAL canónico que el dibujo entiende.
+ * Se deja HARDCODEADO a propósito (no importamos del paquete visual) para que
+ * este motor quede desacoplado de la cara — el test `mapea a vocabulario visual
+ * conocido` cuida que estos destinos sigan siendo válidos.
+ *
+ *   calma   → 'acompana'   (idle vivo: flota, respira, presente sin hablar)
+ *   aviso   → 'preocupada' si es urgente; 'invita' si es un aviso tranquilo
+ *   celebra → 'contenta'   (brinquito de celebración)
+ *   husmea  → 'senala'     (se inclina y apunta a lo que mira del mundo)
+ */
+const VISUAL_CALMA = 'acompana';
+const VISUAL_AVISO_URGENTE = 'preocupada';
+const VISUAL_AVISO_TRANQUILO = 'invita';
+const VISUAL_CELEBRA = 'contenta';
+const VISUAL_HUSMEA = 'senala';
+
+/** Narración para lectores de pantalla — usted, cercano, sin tecnicismos. */
+const ARIA_COMPORTAMIENTO = {
+  calma: 'Angelita la acompaña, tranquila',
+  aviso: 'Angelita tiene algo importante que contarle',
+  celebra: 'Angelita está contenta por usted',
+  husmea: 'Angelita curiosea y le comenta algo de este mundo',
+};
+
+/**
+ * Traduce un estado de comportamiento al estado VISUAL que consume la cara.
+ * @param {string} estado — uno de ESTADOS_COMPORTAMIENTO.
+ * @param {{ severidad?: ('alta'|'media'|'baja'|null) }} [opts]
+ * @returns {string} estado visual canónico (angelitaEstados.js).
+ */
+export function estadoVisualDeComportamiento(estado, opts = {}) {
+  switch (estado) {
+    case 'aviso':
+      return opts.severidad === 'alta' ? VISUAL_AVISO_URGENTE : VISUAL_AVISO_TRANQUILO;
+    case 'celebra':
+      return VISUAL_CELEBRA;
+    case 'husmea':
+      return VISUAL_HUSMEA;
+    case 'calma':
+    default:
+      return VISUAL_CALMA;
+  }
+}
+
+/** Narración ARIA de un estado de comportamiento (usted). */
+export function ariaDeComportamiento(estado) {
+  return ARIA_COMPORTAMIENTO[estado] || ARIA_COMPORTAMIENTO.calma;
+}
+
+/* Prioridad de arbitraje entre comportamientos que compiten en un mismo
+   momento. Mayor = manda. La severidad del aviso ajusta su prioridad. */
+const PRIORIDAD = {
+  aviso_alta: 100,
+  aviso_media: 70,
+  celebra: 60,
+  aviso_baja: 45,
+  husmea: 20,
+  calma: 0,
+};
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * 2. LOS MUNDOS — taxonomía y ruteo pantalla → mundo.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** Los mundos reales de la app, como los nombra el operador. */
+export const MUNDOS = /** @type {const} */ ([
+  'mis_matas',
+  'mis_animales',
+  'clima',
+  'vender',
+  'aprender',
+  'bosque',
+  'paramo',
+  'finca',
+]);
+
+/* Pantallas (rutas #sin-barra de rutasProdChagraApp) que caen en cada mundo.
+   No es exhaustivo: lo que no cuadre → null, y el shell puede pasar el mundo
+   explícito. Los cultivos concretos (café, papa…) caen en mis_matas. */
+const PANTALLA_A_MUNDO = {
+  // ── mis matas ──
+  activos: 'mis_matas', mundo_cultivos: 'mis_matas', mundo: 'mis_matas',
+  semilla: 'mis_matas', germinacion: 'mis_matas', sembrar: 'mis_matas',
+  ciclo: 'mis_matas', ciclo_vivo: 'mis_matas', cosechar: 'mis_matas',
+  mi_cosecha: 'mis_matas', poscosecha: 'mis_matas', nutricion: 'mis_matas',
+  sanidad_sintoma: 'mis_matas', seguimiento: 'mis_matas',
+  // ── mis animales ──
+  animales: 'mis_animales', animales_gallinas: 'mis_animales',
+  animales_abejas: 'mis_animales', animales_vacas: 'mis_animales',
+  animales_conejos: 'mis_animales', animales_caprinos: 'mis_animales',
+  diorama_gallinero: 'mis_animales', diorama_abejas: 'mis_animales',
+  // ── el tiempo / clima ──
+  clima_boletin: 'clima', agua: 'clima', valle3d_lluvia: 'clima',
+  diorama_agua: 'clima',
+  // ── vender ──
+  mercado: 'vender', mercados: 'vender', momento_venta: 'vender',
+  // ── aprender ──
+  aprende: 'aprender', curso: 'aprender', faq: 'aprender',
+  extensionista: 'aprender', casos: 'aprender',
+  // ── bosque ──
+  bosque_vivo: 'bosque', bosque: 'bosque', restauracion: 'bosque',
+  biodiversidad: 'bosque', aliados_finca: 'bosque',
+  // ── páramo ──
+  glaciar: 'paramo', glaciar_historial: 'paramo', diorama_paramo: 'paramo',
+  // ── la finca (home / valle) ──
+  valle3d: 'finca', valle3d_noche: 'finca', ventana_valle: 'finca',
+  dashboard: 'finca', hoy_finca: 'finca', montana_mundos: 'finca',
+};
+
+/* Cultivos con mundo propio (rutasProdChagraApp): todos caen en mis_matas. */
+const CULTIVOS_MUNDO = new Set([
+  'cafe', 'cacao', 'papa', 'platano', 'aguacate', 'citricos', 'cana', 'mango',
+  'uchuva', 'frutales', 'hortalizas', 'tuberculos', 'aromaticas', 'botica',
+  'fique', 'quinua', 'milpa_cultivo', 'maiz', 'frijol',
+]);
+
+/**
+ * Resuelve el mundo al que pertenece una pantalla (currentView del shell).
+ * @param {string|null|undefined} pantalla
+ * @returns {string|null} uno de MUNDOS, o null si la pantalla no mapea.
+ */
+export function mundoDePantalla(pantalla) {
+  if (!pantalla || typeof pantalla !== 'string') return null;
+  const p = pantalla.trim().toLowerCase();
+  if (!p) return null;
+  if (PANTALLA_A_MUNDO[p]) return PANTALLA_A_MUNDO[p];
+  if (CULTIVOS_MUNDO.has(p)) return 'mis_matas';
+  if (p.startsWith('animales')) return 'mis_animales';
+  if (p.startsWith('seguimiento')) return 'mis_matas';
+  if (p.startsWith('glaciar')) return 'paramo';
+  if (p.startsWith('valle3d')) return 'finca';
+  return null;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * 3. COMENTARIO POR MUNDO — grounded en datos reales, con fallback honesto.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** Un dato "real" de inventario: array no vacío de { name, count>0 }. */
+function inventarioReal(lista) {
+  return Array.isArray(lista) && lista.some((x) => x && x.name && Number(x.count) > 0);
+}
+
+/** El ítem de inventario más numeroso (para aterrizar el comentario). */
+function masNumeroso(lista) {
+  if (!inventarioReal(lista)) return null;
+  return [...lista]
+    .filter((x) => x && x.name && Number(x.count) > 0)
+    .sort((a, b) => Number(b.count) - Number(a.count))[0];
+}
+
+/** Limpia el "#03" del nombre y lo deja en minúscula amable. */
+function nombreLimpio(name) {
+  return String(name || '').replace(/\s*#\d+\s*$/, '').trim().toLowerCase();
+}
+
+/* Cada mundo sabe comentar CON los datos que tenga, y sabe callar honesto
+   cuando no los tiene. `datos` es lo que el shell alcanzó a reunir localmente;
+   ningún builder inventa cifras — sólo lee lo que le pasan. */
+const COMENTARISTA_MUNDO = {
+  mis_matas(datos = {}) {
+    const top = masNumeroso(datos.cultivos);
+    if (top) {
+      const n = Number(top.count);
+      const nombre = nombreLimpio(top.name);
+      return n > 1
+        ? `De sus matas, la que más tiene es ${nombre} — ${n} registradas. ¿Le hacemos seguimiento?`
+        : `Tiene ${nombre} registrado en su finca. ¿Le echamos un ojo a cómo va?`;
+    }
+    return 'Todavía no me ha contado qué tiene sembrado. Cuando registre sus matas, le sigo el rastro a cada una.';
+  },
+
+  mis_animales(datos = {}) {
+    const top = masNumeroso(datos.especies);
+    const total = Number(datos.total);
+    if (top) {
+      const nombre = nombreLimpio(top.name);
+      return `De sus animales, lo que más tiene es ${nombre}. ¿Revisamos cómo van?`;
+    }
+    if (Number.isFinite(total) && total > 0) {
+      return `Tiene ${total} ${total === 1 ? 'animal anotado' : 'animales anotados'}. ¿Los repasamos?`;
+    }
+    return 'Aquí llevamos sus animales. Cuando anote los suyos, le ayudo con la cría, el alimento y la sanidad.';
+  },
+
+  clima(datos = {}) {
+    const snap = datos.snapshot;
+    const alertas = Array.isArray(snap?.alertas_locales) ? snap.alertas_locales.length : 0;
+    if (alertas > 0) {
+      return `El parte del clima trae ${alertas} ${alertas === 1 ? 'aviso' : 'avisos'} para su zona. ¿Se los muestro?`;
+    }
+    const fase = snap?.enso_status?.phase;
+    if (fase && typeof datos.describirFase === 'function') {
+      const desc = datos.describirFase(fase);
+      if (desc && desc !== 'Estado del clima desconocido') {
+        return `Por temporada, ${String(desc).toLowerCase()}. El clima del día en su finca manda; ¿le ayudo a leerlo?`;
+      }
+    }
+    return 'No tengo el parte del clima a la mano ahora. Cuando haya señal se lo traigo — y el cielo de su finca siempre manda.';
+  },
+
+  vender(datos = {}) {
+    // NUNCA inventamos precios. Sólo ofrecemos acompañar la venta.
+    const top = masNumeroso(datos.cultivos);
+    if (top) {
+      const nombre = nombreLimpio(top.name);
+      return `Cuando quiera vender, le ayudo a sacar cuentas y a presentar bien su ${nombre}. ¿Empezamos por ahí?`;
+    }
+    return 'Cuando tenga algo para vender, le ayudo a sacar cuentas y a presentarlo bien. Sin afán.';
+  },
+
+  aprender() {
+    return '¿Qué quiere aprender hoy? Aquí estoy sin afán — pregúnteme sin pena.';
+  },
+
+  bosque() {
+    // Verdad general, en pregunta (no es un dato de SU finca).
+    return 'El bosque se recupera con paciencia. ¿Le muestro cómo un rastrojo vuelve a ser monte?';
+  },
+
+  paramo() {
+    // Verdad geográfica segura: del páramo baja el agua de la finca andina.
+    return 'Del páramo baja el agua de su finca. ¿Le cuento cómo se cuida ese nacimiento?';
+  },
+
+  finca(datos = {}) {
+    const top = masNumeroso(datos.cultivos);
+    if (top) {
+      return 'Aquí está su finca. Toque el mundo que quiera revisar y yo le acompaño.';
+    }
+    return 'Aquí está su finca. Empecemos por registrar lo que tiene sembrado, y yo le sigo el rastro.';
+  },
+};
+
+/**
+ * Comentario de Angelita al entrar/pasar por un mundo. GROUNDED: usa sólo los
+ * datos reales que le pasen; si faltan, cae a un acompañamiento honesto (nunca
+ * inventa una cifra ni un dato agronómico).
+ *
+ * @param {string} mundo — uno de MUNDOS.
+ * @param {Object} [datos] — datos reales locales del mundo:
+ *   - mis_matas / vender / finca: { cultivos: Array<{name,count}> }
+ *   - mis_animales: { especies: Array<{name,count}>, total?: number }
+ *   - clima: { snapshot, describirFase?: (phase)=>string }
+ * @returns {string|null} el comentario en usted, o null si el mundo no existe.
+ */
+export function comentarioDeMundo(mundo, datos = {}) {
+  const fn = COMENTARISTA_MUNDO[mundo];
+  if (!fn) return null;
+  return fn(datos);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * 4. NOTIFICACIONES INTELIGENTES — qué atender hoy, priorizado y sin ruido.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+const SEVERITY_RANK = { danger: 0, warning: 1, info: 2 };
+
+/**
+ * Severidad máxima del momento a partir de las entradas crudas. Local, sin red.
+ * 'alta' = alguna alerta danger; 'media' = warning o tarea vencida; 'baja' =
+ * hay algo pero leve; null = nada que atender.
+ */
+function severidadDelMomento(activeAlerts, pendingTasks, date) {
+  const alertsArr = Array.isArray(activeAlerts)
+    ? activeAlerts
+    : (activeAlerts instanceof Map ? Array.from(activeAlerts.values()) : []);
+  let peor = null; // menor rank = peor
+  for (const a of alertsArr) {
+    const r = SEVERITY_RANK[a?.severity];
+    if (r != null && (peor == null || r < peor)) peor = r;
+  }
+  let tareaVencida = false;
+  if (Array.isArray(pendingTasks)) {
+    const now = date instanceof Date ? date.getTime() : Date.now();
+    for (const t of pendingTasks) {
+      let dueMs = null;
+      if (Number.isFinite(t?.timestamp)) dueMs = t.timestamp > 1e12 ? t.timestamp : t.timestamp * 1000;
+      else if (t?.due || t?.date || t?.due_date) {
+        const parsed = Date.parse(t.due || t.date || t.due_date);
+        if (Number.isFinite(parsed)) dueMs = parsed;
+      }
+      if (dueMs != null && Math.floor((now - dueMs) / 86400000) > 0) tareaVencida = true;
+    }
+  }
+  const hayAlerta = peor != null;
+  const hayTarea = Array.isArray(pendingTasks) && pendingTasks.length > 0;
+  if (!hayAlerta && !hayTarea) return null;
+  if (peor === SEVERITY_RANK.danger) return 'alta';
+  if (peor === SEVERITY_RANK.warning || tareaVencida) return 'media';
+  return 'baja';
+}
+
+/**
+ * Decide QUÉ atender hoy, priorizado. Reutiliza buildProactiveGreeting (misma
+ * lógica de ranking del saludo proactivo) y le añade la severidad y el estado
+ * de comportamiento que la cara necesita.
+ *
+ * @param {Object} input — ver buildProactiveGreeting (activeAlerts, pendingTasks,
+ *   cultivos, altitud, ensoOutlook, date, maxItems).
+ * @returns {{ hay: boolean, estado: ('aviso'|'calma'), severidad: ('alta'|'media'|'baja'|null),
+ *   hi: string, lead: string, items: Array, restCount: number, prompt: (string|null),
+ *   prioridad: number }}
+ */
+export function notificacionesInteligentes(input = {}) {
+  const { activeAlerts = [], pendingTasks = [], date = new Date() } = input;
+  const greeting = buildProactiveGreeting(input);
+  const severidad = severidadDelMomento(activeAlerts, pendingTasks, date);
+  const hay = greeting.state === 'pending' && severidad != null;
+  return {
+    hay,
+    estado: hay ? 'aviso' : 'calma',
+    severidad: hay ? severidad : null,
+    hi: greeting.hi || saludoPorHora(date instanceof Date ? date : new Date()),
+    lead: greeting.lead,
+    items: greeting.items,
+    restCount: greeting.restCount,
+    prompt: greeting.prompt,
+    prioridad: hay
+      ? (severidad === 'alta' ? PRIORIDAD.aviso_alta
+        : severidad === 'media' ? PRIORIDAD.aviso_media
+          : PRIORIDAD.aviso_baja)
+      : PRIORIDAD.calma,
+  };
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * 5. ANTI-MOLESTIA — la lección Clippy hecha código.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+const MINUTO = 60 * 1000;
+
+/**
+ * Cuánto debe callar Angelita entre mensajes del mismo tipo, para no volverse
+ * un Clippy. La urgencia alta puede hablar siempre; lo demás respira.
+ */
+export const COOLDOWN_MS = {
+  aviso_alta: 0,            // urgente: puede surgir siempre (pero ver `ocupado`)
+  aviso_media: 20 * MINUTO,
+  aviso_baja: 45 * MINUTO,
+  celebra: 0,              // se dedup por logro.id, no por reloj
+  husmea: 20 * MINUTO,     // no comenta el mismo mundo cada vez que pasa
+  calma: 0,
+};
+
+/** La llave de cooldown de un comportamiento (aviso se afina por severidad). */
+function llaveCooldown(estado, severidad) {
+  if (estado === 'aviso') {
+    if (severidad === 'alta') return 'aviso_alta';
+    if (severidad === 'media') return 'aviso_media';
+    return 'aviso_baja';
+  }
+  return estado;
+}
+
+/**
+ * ¿Debe Angelita SURGIR con un mensaje ahora, o quedarse tranquila? Pura y con
+ * reloj inyectable. La regla de oro: nunca interrumpe a mitad de una tarea
+ * (`ocupado`) salvo un aviso URGENTE; respeta el silencio; y respeta el cooldown
+ * de su tipo de mensaje.
+ *
+ * @param {Object} p
+ * @param {string} p.estado — comportamiento candidato ('aviso'|'celebra'|'husmea'|'calma').
+ * @param {('alta'|'media'|'baja'|null)} [p.severidad]
+ * @param {number} [p.ahoraMs]
+ * @param {number|null} [p.ultimaMs] — cuándo surgió por última vez ESE tipo.
+ * @param {boolean} [p.ocupado] — el campesino está a mitad de algo (escribiendo, grabando…).
+ * @param {boolean} [p.silenciado] — el usuario pidió silencio a Angelita.
+ * @returns {boolean}
+ */
+export function debeHablar({
+  estado,
+  severidad = null,
+  ahoraMs = Date.now(),
+  ultimaMs = null,
+  ocupado = false,
+  silenciado = false,
+} = {}) {
+  if (silenciado) return false;
+  if (estado === 'calma' || !estado) return false;
+  const urgente = estado === 'aviso' && severidad === 'alta';
+  // Nunca interrumpe a mitad de una tarea, salvo urgencia real.
+  if (ocupado && !urgente) return false;
+  const requerido = COOLDOWN_MS[llaveCooldown(estado, severidad)] ?? 0;
+  if (requerido > 0) {
+    if (ultimaMs != null && ahoraMs - ultimaMs < requerido) return false;
+  }
+  return true;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * 6. EL RESOLVEDOR — arbitra los cuatro comportamientos y arma la decisión.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * @typedef {Object} DecisionAngelita
+ * @property {('calma'|'aviso'|'celebra'|'husmea')} estado — comportamiento elegido.
+ * @property {string} visualEstado — estado visual canónico para la cara.
+ * @property {string|null} mensaje — lo que dice (null si se queda en calma).
+ * @property {string} aria — narración para lector de pantalla.
+ * @property {('alta'|'media'|'baja'|null)} severidad
+ * @property {number} prioridad
+ * @property {boolean} interrumpe — si de verdad debe surgir el mensaje ahora.
+ * @property {string|null} prompt — prompt sugerido para sembrar al agente.
+ * @property {string|null} logroId — id del logro celebrado (para no repetir).
+ */
+
+/** La decisión de reposo: Angelita tranquila, sin mensaje. */
+function decisionCalma() {
+  return {
+    estado: 'calma',
+    visualEstado: VISUAL_CALMA,
+    mensaje: null,
+    aria: ARIA_COMPORTAMIENTO.calma,
+    severidad: null,
+    prioridad: PRIORIDAD.calma,
+    interrumpe: false,
+    prompt: null,
+    logroId: null,
+  };
+}
+
+/**
+ * Decide el comportamiento de Angelita en este momento, dado TODO el contexto.
+ * Arbitra por prioridad (aviso urgente > celebra > aviso normal > husmea) y
+ * luego deja que la anti-molestia decida si de verdad surge el mensaje. Si la
+ * anti-molestia veta al ganador, Angelita se queda en CALMA (conservador:
+ * mejor callar que molestar).
+ *
+ * @param {Object} ctx
+ * @param {ReturnType<typeof notificacionesInteligentes>|null} [ctx.notificaciones]
+ * @param {{ id:string, texto:string }|null} [ctx.logro] — logro REAL a celebrar.
+ * @param {string|null} [ctx.ultimoLogroId] — último logro ya celebrado (dedup).
+ * @param {string|null} [ctx.mundo] — mundo actual (para husmear).
+ * @param {Object} [ctx.datosMundo] — datos reales del mundo (ver comentarioDeMundo).
+ * @param {number} [ctx.ahoraMs]
+ * @param {Object} [ctx.ultimaHablaPorLlave] — { [llaveCooldown]: ms } de la última vez.
+ * @param {boolean} [ctx.ocupado]
+ * @param {boolean} [ctx.silenciado]
+ * @returns {DecisionAngelita}
+ */
+export function resolverComportamiento(ctx = {}) {
+  const {
+    notificaciones = null,
+    logro = null,
+    ultimoLogroId = null,
+    mundo = null,
+    datosMundo = {},
+    ahoraMs = Date.now(),
+    ultimaHablaPorLlave = {},
+    ocupado = false,
+    silenciado = false,
+  } = ctx;
+
+  /** @type {Array<{estado:string, prioridad:number, severidad:any, mensaje:string, prompt:string|null, logroId:string|null}>} */
+  const candidatos = [];
+
+  // Aviso — algo que atender.
+  if (notificaciones && notificaciones.hay && notificaciones.lead) {
+    candidatos.push({
+      estado: 'aviso',
+      prioridad: notificaciones.prioridad,
+      severidad: notificaciones.severidad,
+      mensaje: notificaciones.lead,
+      prompt: notificaciones.prompt || null,
+      logroId: null,
+    });
+  }
+
+  // Celebra — un logro real que aún no hemos celebrado.
+  if (logro && logro.id && logro.texto && logro.id !== ultimoLogroId) {
+    candidatos.push({
+      estado: 'celebra',
+      prioridad: PRIORIDAD.celebra,
+      severidad: null,
+      mensaje: logro.texto,
+      prompt: null,
+      logroId: logro.id,
+    });
+  }
+
+  // Husmea — comentario grounded del mundo donde entró.
+  if (mundo) {
+    const comentario = comentarioDeMundo(mundo, datosMundo);
+    if (comentario) {
+      candidatos.push({
+        estado: 'husmea',
+        prioridad: PRIORIDAD.husmea,
+        severidad: null,
+        mensaje: comentario,
+        prompt: null,
+        logroId: null,
+      });
+    }
+  }
+
+  if (candidatos.length === 0) return decisionCalma();
+
+  // Gana la prioridad más alta.
+  const ganador = candidatos.sort((a, b) => b.prioridad - a.prioridad)[0];
+
+  // Para husmea el cooldown es POR MUNDO (no comentar el mismo mundo seguido);
+  // para el resto, por tipo/severidad.
+  const llave = ganador.estado === 'husmea'
+    ? `husmea:${mundo}`
+    : llaveCooldown(ganador.estado, ganador.severidad);
+  const cooldownEstado = ganador.estado === 'husmea' ? 'husmea' : ganador.estado;
+
+  const surge = debeHablar({
+    estado: cooldownEstado,
+    severidad: ganador.severidad,
+    ahoraMs,
+    ultimaMs: ultimaHablaPorLlave[llave] ?? null,
+    ocupado,
+    silenciado,
+  });
+
+  if (!surge) return decisionCalma();
+
+  return {
+    estado: /** @type {any} */ (ganador.estado),
+    visualEstado: estadoVisualDeComportamiento(ganador.estado, { severidad: ganador.severidad }),
+    mensaje: ganador.mensaje,
+    aria: ariaDeComportamiento(ganador.estado),
+    severidad: ganador.severidad,
+    prioridad: ganador.prioridad,
+    interrumpe: true,
+    prompt: ganador.prompt,
+    logroId: ganador.logroId,
+  };
+}
+
+/** La llave de cooldown que corresponde a una decisión (para registrar la hora). */
+export function llaveDeDecision(decision, mundo = null) {
+  if (!decision || decision.estado === 'calma') return null;
+  if (decision.estado === 'husmea') return `husmea:${mundo}`;
+  return llaveCooldown(decision.estado, decision.severidad);
+}
+
+export default resolverComportamiento;

--- a/src/store/__tests__/useAngelitaStore.test.js
+++ b/src/store/__tests__/useAngelitaStore.test.js
@@ -1,0 +1,81 @@
+/**
+ * useAngelitaStore — la API en vivo del comportamiento de Angelita.
+ *
+ * Smoke tests del store: que el motor puro quede bien conectado al estado vivo,
+ * que la anti-molestia (cooldown por mundo) funcione entre llamadas sucesivas,
+ * que el dedup de logro persista, y que el silencio la deje en calma.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import useAngelitaStore from '../useAngelitaStore';
+
+// El store persiste en localStorage; lo reseteamos entre pruebas.
+const reset = () => {
+  useAngelitaStore.setState({
+    estado: 'calma',
+    visualEstado: 'acompana',
+    mensaje: null,
+    aria: null,
+    severidad: null,
+    prioridad: 0,
+    prompt: null,
+    mundoActual: null,
+    ultimaHablaPorLlave: {},
+    ultimoLogroId: null,
+    silenciado: false,
+  });
+};
+
+describe('useAngelitaStore', () => {
+  beforeEach(reset);
+
+  it('arranca en calma', () => {
+    const s = useAngelitaStore.getState();
+    expect(s.estado).toBe('calma');
+    expect(s.visualEstado).toBe('acompana');
+    expect(s.mensaje).toBeNull();
+  });
+
+  it('entrarMundo husmea con comentario grounded', () => {
+    useAngelitaStore.getState().entrarMundo('mis_animales', { total: 6 });
+    const s = useAngelitaStore.getState();
+    expect(s.estado).toBe('husmea');
+    expect(s.visualEstado).toBe('senala');
+    expect(s.mensaje).toMatch(/6 animales/i);
+  });
+
+  it('anti-molestia: no re-comenta el MISMO mundo enseguida', () => {
+    const api = useAngelitaStore.getState();
+    api.entrarMundo('mis_matas', { cultivos: [{ name: 'Café', count: 4 }] });
+    expect(useAngelitaStore.getState().estado).toBe('husmea');
+    // segunda entrada inmediata al mismo mundo → cooldown → calma
+    useAngelitaStore.getState().entrarMundo('mis_matas', { cultivos: [{ name: 'Café', count: 4 }] });
+    expect(useAngelitaStore.getState().estado).toBe('calma');
+  });
+
+  it('celebrar un logro real, con dedup por id', () => {
+    useAngelitaStore.getState().celebrar({ id: 'racha-3', texto: '¡Tres días seguidos anotando!' });
+    expect(useAngelitaStore.getState().estado).toBe('celebra');
+    useAngelitaStore.getState().reposar();
+    // mismo logro → ya no se celebra
+    useAngelitaStore.getState().celebrar({ id: 'racha-3', texto: '¡Tres días seguidos anotando!' });
+    expect(useAngelitaStore.getState().estado).toBe('calma');
+  });
+
+  it('silenciar la deja en calma y no habla', () => {
+    useAngelitaStore.getState().silenciar(true);
+    useAngelitaStore.getState().entrarMundo('clima', { snapshot: { alertas_locales: [{}] } });
+    expect(useAngelitaStore.getState().estado).toBe('calma');
+    expect(useAngelitaStore.getState().mensaje).toBeNull();
+  });
+
+  it('reposar vuelve a calma sin borrar la memoria anti-molestia', () => {
+    const api = useAngelitaStore.getState();
+    api.entrarMundo('mis_matas', { cultivos: [{ name: 'Papa', count: 2 }] });
+    const memoriaAntes = useAngelitaStore.getState().ultimaHablaPorLlave;
+    expect(Object.keys(memoriaAntes)).toContain('husmea:mis_matas');
+    useAngelitaStore.getState().reposar();
+    expect(useAngelitaStore.getState().estado).toBe('calma');
+    // la memoria del cooldown NO se borra al reposar
+    expect(useAngelitaStore.getState().ultimaHablaPorLlave).toEqual(memoriaAntes);
+  });
+});

--- a/src/store/useAngelitaStore.js
+++ b/src/store/useAngelitaStore.js
@@ -1,0 +1,150 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import {
+  resolverComportamiento,
+  llaveDeDecision,
+  estadoVisualDeComportamiento,
+} from '../services/angelitaInteligencia';
+
+/**
+ * useAngelitaStore — LA API EN VIVO del comportamiento de Angelita.
+ *
+ * Es la superficie que consume la CARA (src/visual/agente/Angelita.jsx via
+ * AgentFab) y las notificaciones: un store desacoplado, sin cablearse a la
+ * fuerza en los archivos de nadie. El motor (angelitaInteligencia.js) es la
+ * cabeza pura; este store la pone en el tiempo real de la app.
+ *
+ * Lo que expone para leer (selectores):
+ *   - estado        → comportamiento actual: 'calma'|'aviso'|'celebra'|'husmea'.
+ *   - visualEstado  → estado visual canónico que la cara pinta directamente.
+ *   - mensaje       → lo que Angelita dice ahora (null en calma).
+ *   - aria          → narración para lector de pantalla.
+ *   - prompt        → prompt sugerido para sembrar al agente al tocarla.
+ *
+ * Lo que expone para actuar:
+ *   - evaluar(ctx)  → corre el motor con el contexto en vivo y actualiza estado.
+ *   - entrarMundo(mundo, datos) → husmear un mundo (comentario grounded).
+ *   - celebrar(logro)           → celebrar un logro REAL (dedup por id).
+ *   - reposar()                 → volver a la calma (default).
+ *   - silenciar(bool)           → el usuario pide/quita silencio.
+ *
+ * ANTI-MOLESTIA + LOCAL-FIRST: los cooldowns (`ultimaHablaPorLlave`) y el flag
+ * de silencio se PERSISTEN en localStorage — para que la cadencia sobreviva
+ * recargas y Angelita no repita lo mismo al volver. Cero red: todo funciona
+ * offline. Sólo persistimos lo mínimo (cooldowns + silencio); el mensaje en
+ * curso es efímero por sesión.
+ */
+
+const inicial = {
+  estado: 'calma',
+  visualEstado: estadoVisualDeComportamiento('calma'),
+  mensaje: null,
+  aria: null,
+  severidad: null,
+  prioridad: 0,
+  prompt: null,
+  mundoActual: null,
+};
+
+const useAngelitaStore = create(
+  persist(
+    (set, get) => ({
+      ...inicial,
+
+      // Persistidos (anti-molestia). NO se limpian al reposar.
+      ultimaHablaPorLlave: /** @type {Record<string, number>} */ ({}),
+      ultimoLogroId: /** @type {string|null} */ (null),
+      silenciado: false,
+
+      /**
+       * Aplica una decisión del motor al estado vivo, y si de verdad surge un
+       * mensaje (interrumpe), registra la hora para el cooldown.
+       * @param {import('../services/angelitaInteligencia').DecisionAngelita} decision
+       * @param {string|null} [mundo]
+       */
+      _aplicar: (decision, mundo = null) => {
+        if (!decision || !decision.interrumpe) {
+          // La anti-molestia vetó (o nada que decir): Angelita reposa.
+          set({ ...inicial, silenciado: get().silenciado, mundoActual: mundo });
+          return;
+        }
+        const llave = llaveDeDecision(decision, mundo);
+        const ahora = Date.now();
+        set((s) => ({
+          estado: decision.estado,
+          visualEstado: decision.visualEstado,
+          mensaje: decision.mensaje,
+          aria: decision.aria,
+          severidad: decision.severidad,
+          prioridad: decision.prioridad,
+          prompt: decision.prompt,
+          mundoActual: mundo ?? s.mundoActual,
+          ultimoLogroId: decision.logroId || s.ultimoLogroId,
+          ultimaHablaPorLlave: llave
+            ? { ...s.ultimaHablaPorLlave, [llave]: ahora }
+            : s.ultimaHablaPorLlave,
+        }));
+      },
+
+      /**
+       * Corre el motor con el contexto en vivo. El shell arma `ctx` con lo que
+       * tenga localmente (notificaciones, logro, mundo+datos, ocupado…); el
+       * store inyecta la memoria anti-molestia y el silencio.
+       * @param {Object} ctx — ver resolverComportamiento (sin la parte de memoria).
+       */
+      evaluar: (ctx = {}) => {
+        const { ultimaHablaPorLlave, ultimoLogroId, silenciado } = get();
+        const decision = resolverComportamiento({
+          ...ctx,
+          ahoraMs: ctx.ahoraMs ?? Date.now(),
+          ultimaHablaPorLlave,
+          ultimoLogroId,
+          silenciado,
+        });
+        get()._aplicar(decision, ctx.mundo ?? get().mundoActual);
+        return decision;
+      },
+
+      /**
+       * Husmear un mundo: comentario grounded al entrar. Atajo de evaluar()
+       * para el caso más común (navegación entre mundos).
+       * @param {string} mundo
+       * @param {Object} [datos] — datos reales del mundo (ver comentarioDeMundo).
+       * @param {{ ocupado?: boolean, ahoraMs?: number }} [opts]
+       */
+      entrarMundo: (mundo, datos = {}, opts = {}) =>
+        get().evaluar({ mundo, datosMundo: datos, ocupado: opts.ocupado, ahoraMs: opts.ahoraMs }),
+
+      /**
+       * Celebrar un logro REAL (cosecha registrada, racha, meta). Dedup por id:
+       * el mismo logro no se celebra dos veces.
+       * @param {{ id: string, texto: string }} logro
+       * @param {{ ocupado?: boolean }} [opts]
+       */
+      celebrar: (logro, opts = {}) =>
+        get().evaluar({ logro, ocupado: opts.ocupado }),
+
+      /** Volver a la calma (default). No borra la memoria anti-molestia. */
+      reposar: () =>
+        set((s) => ({ ...inicial, silenciado: s.silenciado, mundoActual: s.mundoActual })),
+
+      /** El usuario pide (o quita) silencio a Angelita. */
+      silenciar: (flag = true) => {
+        set({ silenciado: Boolean(flag) });
+        if (flag) get().reposar();
+      },
+    }),
+    {
+      name: 'chagra:angelita:antimolestia',
+      storage: createJSONStorage(() => localStorage),
+      // Sólo la memoria anti-molestia sobrevive recargas — el mensaje en curso no.
+      partialize: (s) => ({
+        ultimaHablaPorLlave: s.ultimaHablaPorLlave,
+        ultimoLogroId: s.ultimoLogroId,
+        silenciado: s.silenciado,
+      }),
+    },
+  ),
+);
+
+export default useAngelitaStore;


### PR DESCRIPTION
## Qué es

La **CABEZA** de Angelita (la abeja compañera IA): un motor que decide qué hacer y qué decir según lo que de verdad pasa en la finca. La deja sentir una vecina viva estilo narradora-compañera, no un Clippy. Solo la capa de LÓGICA — la cara (Angelita.jsx), el valle, los FABs y los mundos 3D los llevan otros frentes; este PR expone la **API** para que la consuman.

## Archivos (4, todos nuevos)

- `src/services/angelitaInteligencia.js` — el motor PURO (cero React, cero red).
- `src/store/useAngelitaStore.js` — la API en vivo (store zustand desacoplado, cooldowns persistidos local-first).
- tests de ambos (`src/services/__tests__/`, `src/store/__tests__/`) — 40 casos.

## La API que expongo (para la cara / notificaciones)

**Cuatro estados de comportamiento** → mapeados al vocabulario visual canónico (`angelitaEstados.js`) vía `estadoVisualDeComportamiento()`:

| comportamiento | cuándo | estado visual |
|---|---|---|
| `calma` | reposo, default, invita a tocar | `acompana` |
| `aviso` | algo que atender (severidad alta/media/baja) | `preocupada` (urgente) / `invita` |
| `celebra` | un logro REAL (dedup por id) | `contenta` |
| `husmea` | curiosea el mundo donde entró | `senala` |

- `resolverComportamiento(ctx)` — el cerebro: arbitra los cuatro por prioridad (aviso urgente > celebra > aviso normal > husmea) y deja que la anti-molestia decida si de verdad surge el mensaje.
- `comentarioDeMundo(mundo, datos)` — comentario por mundo (mis matas, animales, clima, vender, aprender, bosque, páramo, finca).
- `notificacionesInteligentes(...)` — qué atender hoy, priorizado (reutiliza el ranking del saludo proactivo).
- `mundoDePantalla(pantalla)` — rutea una ruta a su mundo.
- Store: `entrarMundo(mundo, datos)`, `celebrar(logro)`, `evaluar(ctx)`, `reposar()`, `silenciar(bool)`; selectores `estado` / `visualEstado` / `mensaje` / `aria` / `prompt`.

**Consumo (una línea, sin tocar archivos ajenos):**
```js
useAngelitaStore.getState().entrarMundo(mundoDePantalla(currentView), { cultivos, snapshot, ... });
const estadoVisual = useAngelitaStore(s => s.visualEstado); // la cara pinta esto
```

## Reglas de la casa respetadas

- **Grounded**: los comentarios usan SOLO datos reales que le pasan; si faltan → acompañamiento honesto (una pregunta, una invitación). **Cero cifras / precios / pronósticos inventados** (test lo cuida).
- **Anti-molestia (Clippy)**: cooldown por tipo y por mundo; nunca interrumpe a mitad de tarea salvo urgencia real; respeta silencio; **local-first** (cero red, cooldowns persistidos, funciona offline).
- **Tono**: español Colombia, usted cálido, **sin voseo** (test barre todos los mensajes).

## Verificación

- `npm run build:prod` → **verde** (built in 1m 53s).
- 40 tests nuevos verdes; regresión de `saludoPantalla` verde.

## Pendiente (2º pase)

Al arrancar no había salida del DR de UX de asistentes-IA en `deepresearch/DR-FANOUT`. Cadencias y copy se fijaron con criterio; cuando llegue el DR, revisar cooldowns y plantillas (marcado en la cabecera del motor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)