### PR TITLE
feat(aprender): la sala de juegos visible + una sola abeja Angelita

### DIFF
--- a/src/components/Aprende/AprenderConAgente.jsx
+++ b/src/components/Aprende/AprenderConAgente.jsx
@@ -30,6 +30,7 @@ import {
 
 import lecciones from '../../data/agro-lecciones.json';
 import todasLasCards from '../../data/agro-insight-cards.json';
+import { SalaJuegosBanner } from '../juego/HubJuegos.jsx';
 import InsightCard from './InsightCard.jsx';
 import ManoChagraGlyph from '../dashboard/ManoChagraGlyph.jsx';
 import LessonInfographic from '../LessonInfographic.jsx';
@@ -442,6 +443,13 @@ export default function AprenderConAgente({ onBack, onAskAgent, initialSlug, onN
       </div>
 
       <main className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+        {/* LA SALA DE JUEGOS — primero y bien visible (feedback del operador
+            2026-07-16: "no veo los juegos"): el toldo de feria abre el hub
+            con los 9 juegos (#juegos). Jugar también es aprender. */}
+        {typeof onNavigate === 'function' && (
+          <SalaJuegosBanner onNavigate={onNavigate} />
+        )}
+
         {/* ¿Nuevo en Chagra? El curso guiado enseña a USAR la app (video +
             lección + probar), del primer registro a la venta. Va arriba de las
             lecciones sueltas: es el camino para volverse autónomo. */}

--- a/src/components/juego/HubJuegos.jsx
+++ b/src/components/juego/HubJuegos.jsx
@@ -1,0 +1,169 @@
+/*
+ * HubJuegos — LA SALA DE JUEGOS de Chagra (feedback del operador 2026-07-16:
+ * "no veo los juegos"). Una sola puerta hermosa para TODOS los juegos de la
+ * finca, cableada al portal Aprender.
+ *
+ * Dirección de arte: cartel de FERIA DE PUEBLO campesina — un toldo de carpa
+ * (festones ámbar/crema), y cada juego como un cartel serigrafiado con su
+ * criatura rubber-hose de PROTAGONISTA (viva: flota/respira, con su sombra de
+ * contacto). Cada cartel lleva el tinte del juego y un letrero claro de QUÉ
+ * PRÁCTICA REAL enseña — jugar también es cultivar.
+ *
+ * El catálogo (rutas reales + criaturas + tintes) vive en hubJuegosData.js;
+ * este archivo solo dibuja. Cero lógica de juego aquí.
+ *
+ * i18n: pantalla servida solo en es-CO (mismo criterio que los juegos que
+ * enlaza); el copy vive en hubJuegosData.js.
+ */
+import { useMemo } from 'react';
+import { ChevronLeft, ChevronRight, Play } from 'lucide-react';
+import { JUEGOS_CHAGRA, PORTEROS_SALA } from './hubJuegosData.js';
+import './hub-juegos.css';
+
+/** ¿El equipo pidió calma? Se decide una vez por montaje. */
+function usarCalma() {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+/* Los obreros del suelo asomados al mostrador del toldo (hero y banner). */
+function Porteros({ className, calma }) {
+  return (
+    <span className={className} aria-hidden="true">
+      {PORTEROS_SALA.map((p, i) => (
+        <span className="hj-portero" style={{ '--hj-orden': i }} key={i}>
+          <p.Criatura size={p.size} animated={!calma} />
+          <i className="hj-portero__sombra" />
+        </span>
+      ))}
+    </span>
+  );
+}
+
+/**
+ * Un cartel de la feria: la criatura protagonista + qué enseña + jugar.
+ */
+function CartelJuego({ juego, indice, animado, onJugar }) {
+  const { titulo, ensena, detalle, tinte } = juego;
+  return (
+    <button
+      type="button"
+      data-testid={`hub-juego-${juego.id}`}
+      className="hj-cartel"
+      style={{ '--hj-tinte': tinte, '--hj-orden': indice }}
+      onClick={() => onJugar(juego.view)}
+      aria-label={`Jugar ${titulo} — ${ensena}`}
+    >
+      <span className="hj-medallon" aria-hidden="true">
+        <juego.Criatura size={58} animated={animado} />
+        <i className="hj-medallon__sombra" />
+      </span>
+      <span className="hj-cartel__cuerpo">
+        <span className="hj-cartel__ensena">{ensena}</span>
+        <span className="hj-cartel__titulo">{titulo}</span>
+        <span className="hj-cartel__detalle">{detalle}</span>
+      </span>
+      <span className="hj-cartel__jugar" aria-hidden="true">
+        <Play size={15} strokeWidth={2.6} />
+        <span>Jugar</span>
+      </span>
+    </button>
+  );
+}
+
+/**
+ * SalaJuegosBanner — la ENTRADA de la sala desde el portal Aprender: un
+ * pedazo del toldo de feria con los porteros asomados. Un solo toque abre
+ * el hub completo (#juegos).
+ *
+ * @param {{ onNavigate: (view: string) => void }} props
+ */
+export function SalaJuegosBanner({ onNavigate }) {
+  const calma = useMemo(() => usarCalma(), []);
+  return (
+    <button
+      type="button"
+      data-testid="sala-juegos-banner"
+      className="hj-banner"
+      onClick={() => onNavigate('juegos')}
+      aria-label="Abrir la sala de juegos: nueve juegos para aprender jugando"
+    >
+      <i className="hj-toldo hj-toldo--banner" aria-hidden="true" />
+      <span className="hj-banner__fila">
+        <Porteros className="hj-banner__porteros" calma={calma} />
+        <span className="hj-banner__texto">
+          <span className="hj-banner__eyebrow">Aprender jugando</span>
+          <span className="hj-banner__titulo">La sala de juegos</span>
+          <span className="hj-banner__sub">
+            Nueve juegos que enseñan prácticas reales: control biológico, suelo
+            vivo, milpa, restauración…
+          </span>
+        </span>
+        <ChevronRight size={22} className="hj-banner__flecha" aria-hidden="true" />
+      </span>
+    </button>
+  );
+}
+
+/**
+ * HubJuegos — la pantalla completa de la sala.
+ *
+ * @param {Object} props
+ * @param {() => void} [props.onBack]
+ * @param {(view: string, data?: any) => void} [props.onNavigate]
+ */
+export default function HubJuegos({ onBack, onNavigate }) {
+  const calma = useMemo(() => usarCalma(), []);
+  const jugar = (view) => {
+    if (typeof onNavigate === 'function') onNavigate(view);
+  };
+
+  return (
+    <div className="hj-root" data-testid="hub-juegos">
+      {/* El toldo de la carpa: la sala se anuncia como feria de pueblo. */}
+      <i className="hj-toldo" aria-hidden="true" />
+
+      <header className="hj-header">
+        {onBack && (
+          <button
+            type="button"
+            className="hj-volver"
+            onClick={onBack}
+            aria-label="Volver"
+          >
+            <ChevronLeft size={22} />
+          </button>
+        )}
+        <div className="hj-header__texto">
+          <p className="hj-eyebrow">Aprender jugando</p>
+          <h1 className="hj-titulo">La sala de juegos</h1>
+          <p className="hj-lema">
+            Jugar también es cultivar: cada juego enseña una práctica real de la
+            finca.
+          </p>
+        </div>
+        <Porteros className="hj-porteros" calma={calma} />
+      </header>
+
+      <main className="hj-feria">
+        {JUEGOS_CHAGRA.map((juego, i) => (
+          <CartelJuego
+            key={juego.id}
+            juego={juego}
+            indice={i}
+            animado={!calma}
+            onJugar={jugar}
+          />
+        ))}
+      </main>
+
+      <p className="hj-pie">
+        Todos los juegos usan datos y prácticas verificadas — y funcionan sin
+        internet.
+      </p>
+    </div>
+  );
+}

--- a/src/components/juego/hub-juegos.css
+++ b/src/components/juego/hub-juegos.css
@@ -1,0 +1,385 @@
+/* ── LA SALA DE JUEGOS — feria de pueblo campesina ──────────────────────────
+   Tokens de la sala:
+     tinta        #f2ead8  (crema serigrafiada)
+     noche        #0a1410 → #0e1a13 (verde-noche de vereda)
+     toldo A      #e9b44c  (ámbar de carpa)
+     toldo B      #f2ead8  (crema de carpa)
+     cada cartel  --hj-tinte (triplete RGB propio del juego)
+   Firma visual: el TOLDO de festones arriba + la criatura rubber-hose viva
+   en su medallón de luz con sombra de contacto que late. */
+
+.hj-root {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(120% 55% at 50% -8%, rgba(233, 180, 76, 0.14), transparent 60%),
+    linear-gradient(178deg, #0e1a13 0%, #0a1410 46%, #081009 100%);
+  color: #f2ead8;
+  overflow-x: hidden;
+  padding-bottom: max(env(safe-area-inset-bottom, 0px), 12px);
+}
+
+/* ── El toldo: festones de carpa alternando ámbar/crema ── */
+.hj-toldo {
+  display: block;
+  flex: 0 0 auto;
+  height: 30px;
+  background:
+    /* festones (dos capas intercaladas) */
+    radial-gradient(circle at 14px 10px, #e9b44c 0 12px, transparent 13px) 0 8px / 56px 30px repeat-x,
+    radial-gradient(circle at 14px 10px, #caa14e 0 12px, transparent 13px) 28px 8px / 56px 30px repeat-x,
+    /* la banda rayada de la carpa */
+    repeating-linear-gradient(90deg, #e9b44c 0 28px, #b3873c 28px 56px);
+  background-color: transparent;
+  filter: drop-shadow(0 3px 5px rgba(0, 0, 0, 0.35));
+}
+
+/* ── Encabezado de la sala ── */
+.hj-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.9rem clamp(0.9rem, 4vw, 1.6rem) 0.4rem;
+  max-width: 46rem;
+  width: 100%;
+  margin: 0 auto;
+}
+.hj-volver {
+  align-self: start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 42px;
+  min-height: 42px;
+  border-radius: 12px;
+  border: 1px solid rgba(242, 234, 216, 0.22);
+  background: rgba(242, 234, 216, 0.06);
+  color: #f2ead8;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.hj-volver:hover { background: rgba(242, 234, 216, 0.14); }
+.hj-header__texto { min-width: 0; }
+.hj-eyebrow {
+  margin: 0;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(233, 180, 76, 0.92);
+}
+.hj-titulo {
+  margin: 0.1rem 0 0;
+  font-size: clamp(1.6rem, 6.5vw, 2.2rem);
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  line-height: 1.02;
+  color: #f2ead8;
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.35);
+}
+.hj-lema {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: rgba(242, 234, 216, 0.68);
+  max-width: 30rem;
+}
+
+/* Los porteros del mostrador: los obreros del suelo, asomados y vivos. */
+.hj-porteros,
+.hj-banner__porteros {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.15rem;
+}
+.hj-portero {
+  position: relative;
+  display: inline-flex;
+  padding-bottom: 6px;
+  animation: hj-portero-flota 3.6s ease-in-out calc(var(--hj-orden, 0) * -1.2s) infinite;
+}
+.hj-portero__sombra {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  width: 20px;
+  height: 5px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.5), transparent 70%);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+@keyframes hj-portero-flota {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+@media (max-width: 430px) {
+  .hj-porteros { display: none; } /* en tela angosta manda el título */
+}
+
+/* ── La feria: la grilla de carteles ── */
+.hj-feria {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.7rem;
+  padding: 0.9rem clamp(0.9rem, 4vw, 1.6rem) 0.4rem;
+  max-width: 46rem;
+  width: 100%;
+  margin: 0 auto;
+}
+@media (min-width: 640px) {
+  .hj-feria { grid-template-columns: 1fr 1fr; }
+}
+
+/* ── El cartel serigrafiado de cada juego ── */
+.hj-cartel {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-areas:
+    'medallon cuerpo'
+    'medallon jugar';
+  align-items: center;
+  column-gap: 0.8rem;
+  row-gap: 0.4rem;
+  text-align: left;
+  padding: 0.9rem 0.95rem 0.8rem;
+  min-height: 118px;
+  border-radius: 20px;
+  border: 2px solid rgba(var(--hj-tinte), 0.42);
+  background:
+    radial-gradient(90% 120% at 12% 0%, rgba(var(--hj-tinte), 0.2), transparent 55%),
+    linear-gradient(165deg, rgba(var(--hj-tinte), 0.1), rgba(8, 14, 11, 0.2) 55%),
+    #101c15;
+  /* doble filete de afiche serigrafiado */
+  box-shadow:
+    inset 0 0 0 1px rgba(6, 10, 8, 0.9),
+    inset 0 0 0 3px rgba(var(--hj-tinte), 0.16),
+    0 8px 22px rgba(0, 0, 0, 0.38);
+  color: #f2ead8;
+  cursor: pointer;
+  animation: hj-cartel-entra 0.45s cubic-bezier(0.2, 0.9, 0.3, 1.2) both;
+  animation-delay: calc(var(--hj-orden, 0) * 60ms);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+.hj-cartel:hover {
+  transform: translateY(-3px);
+  border-color: rgba(var(--hj-tinte), 0.75);
+  box-shadow:
+    inset 0 0 0 1px rgba(6, 10, 8, 0.9),
+    inset 0 0 0 3px rgba(var(--hj-tinte), 0.22),
+    0 14px 30px rgba(0, 0, 0, 0.5),
+    0 0 24px rgba(var(--hj-tinte), 0.18);
+}
+.hj-cartel:active { transform: translateY(-1px) scale(0.988); }
+.hj-cartel:focus-visible {
+  outline: 3px solid rgba(var(--hj-tinte), 0.9);
+  outline-offset: 2px;
+}
+@keyframes hj-cartel-entra {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* El medallón de luz: la criatura protagonista, viva, con piso propio. */
+.hj-medallon {
+  grid-area: medallon;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 74px;
+  height: 74px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 42%, rgba(var(--hj-tinte), 0.3), rgba(var(--hj-tinte), 0.08) 62%, transparent 75%);
+  box-shadow: inset 0 0 0 1.5px rgba(var(--hj-tinte), 0.35);
+}
+.hj-medallon > :first-child {
+  animation: hj-portero-flota 3.4s ease-in-out infinite;
+}
+.hj-medallon__sombra {
+  position: absolute;
+  left: 50%;
+  bottom: 7px;
+  width: 26px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.5), transparent 70%);
+  transform: translateX(-50%);
+  animation: hj-sombra-late 3.4s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes hj-sombra-late {
+  0%, 100% { transform: translateX(-50%) scaleX(1); opacity: 0.55; }
+  50% { transform: translateX(-50%) scaleX(0.72); opacity: 0.3; }
+}
+
+.hj-cartel__cuerpo {
+  grid-area: cuerpo;
+  display: block;
+  min-width: 0;
+}
+.hj-cartel__ensena {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(var(--hj-tinte), 0.95);
+}
+.hj-cartel__ensena::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgb(var(--hj-tinte));
+  box-shadow: 0 0 6px rgba(var(--hj-tinte), 0.8);
+}
+.hj-cartel__titulo {
+  display: block;
+  margin-top: 0.18rem;
+  font-size: 1.08rem;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  line-height: 1.12;
+  color: #f7f1e1;
+}
+.hj-cartel__detalle {
+  display: block;
+  margin-top: 0.28rem;
+  font-size: 0.8rem;
+  line-height: 1.42;
+  color: rgba(242, 234, 216, 0.7);
+}
+
+/* El botón-señal de jugar (todo el cartel es tocable; esto es la señal). */
+.hj-cartel__jugar {
+  grid-area: jugar;
+  justify-self: end;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
+  padding: 0.28rem 0.7rem;
+  border-radius: 999px;
+  border: 1.5px solid rgba(var(--hj-tinte), 0.55);
+  background: rgba(var(--hj-tinte), 0.14);
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgb(var(--hj-tinte));
+  transition: background 0.15s ease;
+}
+.hj-cartel:hover .hj-cartel__jugar {
+  background: rgba(var(--hj-tinte), 0.26);
+}
+
+.hj-pie {
+  margin: 0.6rem auto 0;
+  padding: 0 1.2rem 0.8rem;
+  max-width: 46rem;
+  font-size: 0.72rem;
+  line-height: 1.5;
+  text-align: center;
+  color: rgba(242, 234, 216, 0.45);
+}
+
+/* ── El banner de entrada (vive dentro de Aprender) ─────────────────────── */
+.hj-banner {
+  position: relative;
+  display: block;
+  width: 100%;
+  text-align: left;
+  border-radius: 20px;
+  border: 2px solid rgba(233, 180, 76, 0.45);
+  background:
+    radial-gradient(110% 130% at 15% 0%, rgba(233, 180, 76, 0.18), transparent 55%),
+    linear-gradient(170deg, #14211a 0%, #0c1611 70%);
+  box-shadow:
+    inset 0 0 0 1px rgba(6, 10, 8, 0.9),
+    inset 0 0 0 3px rgba(233, 180, 76, 0.14),
+    0 8px 22px rgba(0, 0, 0, 0.38);
+  color: #f2ead8;
+  cursor: pointer;
+  overflow: hidden;
+  padding: 0;
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+.hj-banner:hover {
+  transform: translateY(-2px);
+  border-color: rgba(233, 180, 76, 0.75);
+  box-shadow:
+    inset 0 0 0 1px rgba(6, 10, 8, 0.9),
+    inset 0 0 0 3px rgba(233, 180, 76, 0.2),
+    0 12px 28px rgba(0, 0, 0, 0.5),
+    0 0 24px rgba(233, 180, 76, 0.16);
+}
+.hj-banner:active { transform: scale(0.988); }
+.hj-banner:focus-visible {
+  outline: 3px solid rgba(233, 180, 76, 0.9);
+  outline-offset: 2px;
+}
+.hj-toldo--banner {
+  height: 16px;
+  background:
+    radial-gradient(circle at 9px 5px, #e9b44c 0 7px, transparent 8px) 0 4px / 36px 16px repeat-x,
+    radial-gradient(circle at 9px 5px, #caa14e 0 7px, transparent 8px) 18px 4px / 36px 16px repeat-x,
+    repeating-linear-gradient(90deg, #e9b44c 0 18px, #b3873c 18px 36px);
+  filter: none;
+}
+.hj-banner__fila {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0.9rem 0.85rem;
+}
+.hj-banner__porteros { flex: 0 0 auto; }
+.hj-banner__texto { flex: 1; min-width: 0; }
+.hj-banner__eyebrow {
+  display: block;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(233, 180, 76, 0.92);
+}
+.hj-banner__titulo {
+  display: block;
+  margin-top: 0.12rem;
+  font-size: 1.2rem;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  line-height: 1.08;
+  color: #f7f1e1;
+}
+.hj-banner__sub {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.76rem;
+  line-height: 1.4;
+  color: rgba(242, 234, 216, 0.68);
+}
+.hj-banner__flecha {
+  flex: 0 0 auto;
+  color: rgba(233, 180, 76, 0.9);
+}
+@media (max-width: 380px) {
+  .hj-banner__porteros { display: none; }
+}
+
+/* ── Calma: sin flotes, sin entradas, sin latidos ── */
+@media (prefers-reduced-motion: reduce) {
+  .hj-cartel { animation: none; transition: none; }
+  .hj-cartel:hover { transform: none; }
+  .hj-portero,
+  .hj-medallon > :first-child { animation: none; }
+  .hj-medallon__sombra { animation: none; }
+  .hj-banner { transition: none; }
+  .hj-banner:hover { transform: none; }
+}

--- a/src/components/juego/hubJuegosData.js
+++ b/src/components/juego/hubJuegosData.js
@@ -1,0 +1,128 @@
+/*
+ * hubJuegosData — el CATÁLOGO de la sala de juegos (HubJuegos).
+ *
+ * Cada juego es una ruta REAL del manifiesto de prod (rutasProdChagraApp.js);
+ * aquí solo vive su cartel: título, práctica agroecológica que enseña
+ * (`ensena`, el letrero pedagógico — no decoración), detalle corto en usted,
+ * la criatura rubber-hose protagonista y el tinte RGB del cartel.
+ *
+ * Vive aparte del componente por la regla react-refresh (un archivo de
+ * componentes no exporta constantes) y para que el catálogo sea testeable.
+ *
+ * i18n: copy servido solo en es-CO (mismo criterio que los juegos que nombra).
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+import { Colibri } from '../../visual/creatures/Colibri.jsx';
+import { Escarabajo } from '../../visual/creatures/Escarabajo.jsx';
+import { Lombriz } from '../../visual/creatures/Lombriz.jsx';
+import { RanaAndina } from '../../visual/creatures/RanaAndina.jsx';
+import { Jaguar } from '../../visual/creatures/Jaguar.jsx';
+import { Morrocoy } from '../../visual/creatures/Morrocoy.jsx';
+import { Danta } from '../../visual/creatures/Danta.jsx';
+import { Perezoso } from '../../visual/creatures/Perezoso.jsx';
+import { Ardilla } from '../../visual/creatures/Ardilla.jsx';
+
+/**
+ * @type {Array<{id: string, view: string, titulo: string, ensena: string,
+ *   detalle: string, Criatura: (props: any) => any, tinte: string}>}
+ */
+export const JUEGOS_CHAGRA = [
+  {
+    id: 'mi-finca-viva',
+    view: 'juego',
+    titulo: 'Mi Finca Viva',
+    ensena: 'La finca que evoluciona',
+    detalle:
+      'Su finca de verdad se vuelve un mundo que florece: criaturas, misiones e insignias que salen de sus propios registros.',
+    Criatura: Colibri,
+    tinte: '52, 211, 153',
+  },
+  {
+    id: 'defensores',
+    view: 'defensores',
+    titulo: 'Defensores de la Finca',
+    ensena: 'Control biológico',
+    detalle:
+      'Corra y salte por la ladera soltando los bichos buenos que controlan a las plagas, sin un solo veneno.',
+    Criatura: Escarabajo,
+    tinte: '45, 212, 191',
+  },
+  {
+    id: 'milpa',
+    view: 'milpa',
+    titulo: 'La Milpa',
+    ensena: 'Asociaciones de cultivo',
+    detalle:
+      'Siembre maíz, fríjol y ahuyama juntos — las tres hermanas — y mire cómo rinden más que cada uno por su lado.',
+    Criatura: Ardilla,
+    tinte: '163, 230, 53',
+  },
+  {
+    id: 'doom-finca',
+    view: 'doom_finca',
+    titulo: 'Doom de la Finca',
+    ensena: 'Manejo de plagas',
+    detalle:
+      'Recorra el invernadero en primera persona, identifique la plaga y lance el controlador biológico correcto.',
+    Criatura: RanaAndina,
+    tinte: '251, 146, 60',
+  },
+  {
+    id: 'subsuelo',
+    view: 'subsuelo',
+    titulo: 'Mundo Subsuelo',
+    ensena: 'Suelo vivo',
+    detalle:
+      'Baje bajo sus botas: alimente la tierra con compost, conecte raíces con hongos y despierte a las lombrices.',
+    Criatura: Lombriz,
+    tinte: '34, 211, 238',
+  },
+  {
+    id: 'finca-odyssey',
+    view: 'finca_odyssey',
+    titulo: 'Mi finca en 3D',
+    ensena: 'Riego y cuidado',
+    detalle:
+      'Cruce el túnel mágico a su finca en tres dimensiones y aterrice en el huerto a cuidar el riego y las abejas.',
+    Criatura: Danta,
+    tinte: '129, 140, 248',
+  },
+  {
+    id: 'rescate-ladera',
+    view: 'metal_slug_campo',
+    titulo: 'Rescate en la ladera',
+    ensena: 'Plagas y fauna silvestre',
+    detalle:
+      'Acción de plataforma: controle plagas reales con el organismo benéfico correcto y libere la fauna cazada.',
+    Criatura: Jaguar,
+    tinte: '245, 158, 11',
+  },
+  {
+    id: 'mono-vs-poli',
+    view: 'mono_vs_poli',
+    titulo: '¿Mono o poli?',
+    ensena: 'Datos con fuente',
+    detalle:
+      'Compare monocultivo contra policultivo con cifras medidas de verdad: rendimiento, nitrógeno y control de plaga.',
+    Criatura: Morrocoy,
+    tinte: '167, 139, 250',
+  },
+  {
+    id: 'monte-vuelve',
+    view: 'monte_vuelve',
+    titulo: 'El monte vuelve',
+    ensena: 'Restauración ecológica',
+    detalle:
+      'Camine los años de un potrero que vuelve a ser monte: qué llega primero, qué llega después y por qué.',
+    Criatura: Perezoso,
+    tinte: '74, 222, 128',
+  },
+];
+
+/* Las criaturas del mostrador del toldo (hero y banner) — los obreros del
+   suelo, asomados y vivos. */
+export const PORTEROS_SALA = [
+  { Criatura: Escarabajo, size: 44 },
+  { Criatura: Lombriz, size: 40 },
+  { Criatura: RanaAndina, size: 46 },
+];

--- a/src/config/rutasProdChagraApp.js
+++ b/src/config/rutasProdChagraApp.js
@@ -880,6 +880,16 @@ export const NUCLEO_APP = [
 
   // ── Juegos (promovidos de PENDIENTE, smoke-test OK 2026-07-14) ─
   {
+    // LA SALA DE JUEGOS — el hub que hace VISIBLES los 9 juegos (feedback del
+    // operador 2026-07-16: "no veo los juegos"). Enlazado desde Aprender
+    // (SalaJuegosBanner) y con deep-link directo #juegos.
+    path: 'juegos',
+    alias: ['sala_juegos', 'hub_juegos'],
+    componente: 'HubJuegos',
+    importLazy: 'src/components/juego/HubJuegos.jsx',
+    categoria: '2D-app',
+  },
+  {
     path: 'juego',
     componente: 'MiFincaVivaScreen',
     importLazy: 'src/components/juego/MiFincaVivaScreen.jsx',

--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -43,7 +43,6 @@ import {
 import useCicloDia from '../visual/mundo3d/useCicloDia.js';
 import Valle2DFallback from './valle/Valle2DFallback';
 import AbejaTransicion, { AlMontarEscena } from '../visual/creatures/AbejaTransicion.jsx';
-import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
 /* El framework de MUNDOS (three-free en el barrel; los dioramas 3D bajan
    perezosos en `vendor-three`): tocar un lugar del valle ENTRA de verdad. */
 import Mundo, {
@@ -645,38 +644,19 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
         </p>
       )}
 
-      {/* ── El compañero: Angelita en una sola línea puntual (imagen-first).
-              Es el ser al que se cuida; su cara refleja el ánimo real. Se
-              esconde si hay un panel abierto — una cosa clara a la vez.
-              DENTRO de un mundo sigue presente y HABLA: narra el lugar y
-              nombra las puertas. Lo que dice (`dicho`) va SIEMPRE en su
-              burbuja de texto (aria-live) — si la voz falta o está apagada,
-              la burbuja es la voz. ── */}
-      {(dicho || (!panel && !nav.enMundo)) && (
+      {/* ── La burbuja de voz de Angelita (aria-live): lo que ella DICE va
+              SIEMPRE en texto — si la voz falta o está apagada, la burbuja ES
+              la voz. Angelita VIVE en la ESCENA del valle (UNA sola abeja —
+              feedback del operador 2026-07-16: "se ven 3 abejitas"): este chip
+              ya no lleva su cara 2D ni la frase fija de ánimo; aparece solo
+              mientras ella habla. ── */}
+      {dicho && (
         <div
           className={`valle-companero${nav.enMundo ? ' valle-companero--mundo' : ''}`}
-          data-gesto={gesto || undefined}
           role="status"
           aria-live="polite"
         >
-          {/* DENTRO de un mundo Angelita vive en la ESCENA (una sola compañera,
-              no dos abejas): aquí el chip queda solo como su burbuja de voz. En
-              el valle sí lleva su cara (la tarjeta puntual imagen-first). */}
-          {!nav.enMundo && (
-            <span className="valle-companero__cara" aria-hidden="true">
-              <AbejaAngelita
-                size={34}
-                pose={gesto || 'vuela'}
-                animo={companero.animo}
-                energia={companero.energia}
-                animated={!reducedMotion}
-              />
-              <i className="valle-companero__sombra" />
-            </span>
-          )}
-          {(dicho || !nav.enMundo) && (
-            <span className="valle-companero__txt">{dicho || companero.frase}</span>
-          )}
+          <span className="valle-companero__txt">{dicho}</span>
         </div>
       )}
 

--- a/src/mockups/__tests__/entradaValle3D.nav.test.jsx
+++ b/src/mockups/__tests__/entradaValle3D.nav.test.jsx
@@ -114,7 +114,10 @@ describe('entrada-3d — voz con respaldo visible', () => {
     const { container } = render(<EntradaValle3D onBack={() => {}} />);
 
     act(() => vi.advanceTimersByTime(1000));
-    expect(container.querySelector('.valle-companero')).not.toHaveTextContent(/Bienvenido/i);
+    // Antes del primer gesto Angelita no ha dicho nada: la burbuja de voz ni
+    // se monta (el chip ya no lleva frase fija de ánimo — una sola abeja, la
+    // de la escena).
+    expect(container.querySelector('.valle-companero')).toBeNull();
 
     fireEvent.pointerDown(container.querySelector('.valle-root'));
     expect(container.querySelector('.valle-companero')).toHaveTextContent(/Bienvenido/i);

--- a/src/mockups/entradaValle3D.css
+++ b/src/mockups/entradaValle3D.css
@@ -185,8 +185,9 @@
   will-change: transform;
 }
 
-/* ── El compañero como TARJETA puntual (imagen-first, una sola línea) ──
-      El ser al que se cuida vive también en el DOM: su cara refleja el ánimo. */
+/* ── La BURBUJA DE VOZ de Angelita (solo texto, mientras habla) ──
+      La abeja vive en la ESCENA del valle — una sola. Este chip es su voz
+      escrita (aria-live): aparece con lo dicho y se va solo. */
 .valle-companero {
   position: absolute;
   left: 1.1rem;
@@ -196,7 +197,7 @@
   align-items: center;
   gap: 0.5rem;
   max-width: min(74vw, 22rem);
-  padding: 0.35rem 0.8rem 0.35rem 0.4rem;
+  padding: 0.45rem 0.85rem;
   border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 999px;
   background: rgba(15, 24, 30, 0.7);
@@ -271,7 +272,7 @@
 .valle-companero--mundo {
   z-index: 35;
   bottom: 4.9rem;
-  padding: 0.3rem 0.75rem 0.3rem 0.4rem;
+  padding: 0.4rem 0.8rem;
   background: rgba(15, 24, 30, 0.62);
 }
 

--- a/src/prodApp/ProdChagraApp.jsx
+++ b/src/prodApp/ProdChagraApp.jsx
@@ -175,6 +175,13 @@ const LAZY_MAP = {
   // ── PENDIENTE_DECISION (operador dijo "nada afuera") ────────────
   OnboardingCondensado: lazy(() => import('../components/OnboardingCondensado.jsx')),
   OnboardingSiembra: lazy(() => import('../mockups/OnboardingSiembra.jsx')),
+  // La sala de juegos: el hub que hace VISIBLES los juegos (#juegos) desde
+  // Aprender. Los dos de abajo estaban en el manifiesto SIN entrada aquí →
+  // rutas muertas en prod ("construido pero no cableado"): sus tarjetas del
+  // hub no abrían nada.
+  HubJuegos: lazy(() => import('../components/juego/HubJuegos.jsx')),
+  JuegoMiFincaOdyssey: lazy(() => import('../mockups/JuegoMiFincaOdyssey.jsx')),
+  MonoVsPoliSimulator: lazy(() => import('../components/juego/MonoVsPoliSimulator.jsx')),
   MiFincaVivaScreen: lazy(() => import('../components/juego/MiFincaVivaScreen.jsx')),
   DefensoresFincaScreen: lazy(() => import('../components/juego/DefensoresFincaScreen.jsx')),
   MilpaSimulator: lazy(() => import('../components/juego/MilpaSimulator.jsx')),
@@ -258,6 +265,10 @@ const VISTAS_SIN_SALIDA = new Set([
   'aliados_finca', 'momento_venta',
   'fermentos', 'asociaciones', 'mapa',
   'mockup_voz_con_forma', 'mockup_conversacion_voz',
+  // Juegos sin control de salida propio (verificado componente por
+  // componente): el comparador mono-vs-poli y la ladera 3D de restauración
+  // no traen onBack ni ScreenShell — sin el botón de casa serían trampas.
+  'mono_vs_poli', 'monte_vuelve', 'restaurar',
 ]);
 
 // ── Componente principal ────────────────────────────────────────
@@ -539,8 +550,12 @@ export default function ProdChagraApp() {
           sea sobre ESA pantalla (saludoPantalla.js). Se oculta solo donde
           estorba: cargando (parpadeo de auth), el propio agente (ya está
           ella en grande), la escucha de voz, los mockups de diseño y el
-          onboarding guiado — mismo criterio del shell clásico (App.jsx). */}
-      {currentView !== 'loading'
+          onboarding guiado — mismo criterio del shell clásico (App.jsx).
+          EN EL VALLE (home) NO se monta: allá Angelita YA vive en la escena
+          (una sola abeja — feedback del operador 2026-07-16: "se ven 3
+          abejitas") y la barra "Pregúntele a su finca…" abre el agente. */}
+      {!esHome
+        && currentView !== 'loading'
         && currentView !== 'agente'
         && currentView !== 'voz'
         && !currentView.startsWith('mockup_')


### PR DESCRIPTION
## Qué hace

Dos feedbacks del operador (2026-07-16), spec §6 y §7 del audit del valle:

### 1. "No veo los juegos" → LA SALA DE JUEGOS (`#juegos`)
- **Hub nuevo** (`src/components/juego/HubJuegos.jsx` + `hub-juegos.css` + `hubJuegosData.js`): los 9 juegos como **carteles de feria de pueblo** — toldo de festones ámbar/crema, cada cartel con su **criatura rubber-hose protagonista viva** (colibrí, escarabajo, ardilla, rana, lombriz, danta, jaguar, morrocoy, perezoso) en un medallón de luz con sombra de contacto, tinte propio por juego y letrero de **qué práctica real enseña** (control biológico, suelo vivo, asociaciones, restauración…).
- **Cableado al portal Aprender**: `SalaJuegosBanner` de primera en `AprenderConAgente` (el toldo con los porteros asomados) → abre el hub.
- Ruta `juegos` (alias `sala_juegos`, `hub_juegos`) en el manifiesto, dentro de la sección de juegos de `NUCLEO_APP`.
- De paso: `JuegoMiFincaOdyssey` y `MonoVsPoliSimulator` estaban en el manifiesto **sin entrada en el LAZY_MAP de prod** (rutas muertas, "construido pero no cableado") — cableados; y `mono_vs_poli` / `monte_vuelve` / `restaurar` entran a `VISTAS_SIN_SALIDA` (no traen salida propia).

### 2. "Se ven 3 abejitas" → UNA sola Angelita
- **FAB fuera del valle (home)**: en `ProdChagraApp` el `AgentFab` ya no se monta cuando `esHome` — allá Angelita **vive en la escena** y la barra "Pregúntele a su finca…" abre el agente. En el resto de pantallas el FAB sigue siendo la única abeja.
- **Chip "anda pendiente" sin abeja**: el `valle-companero` de `EntradaValle3D` pierde la cara 2D (`AbejaAngelita` 34px) y la frase fija de ánimo; queda **solo como burbuja de voz** (aria-live) mientras ella habla. La abeja central de la escena NO se tocó.

## Verificación
- `npm run build:prod` **verde**.
- Capturas headless (chromium + swiftshader, 390×844) sobre `dist-prod`:
  - hub: 9 carteles, 9 criaturas SVG montadas;
  - Aprender: banner de la sala de primera;
  - valle: **1 sola abeja** (la de la escena), `.chagra-fab` = 0, chip = 0.
- Lint limpio en los archivos tocados; `AprenderConAgente` y `MiFincaVivaScreen` suites verdes. Las 4 fallas de `entradaValle3D.nav.test` ("Viajar al mundo…") **pre-existen en la base** (verificado con stash sobre `d9e46776`).

## No tocado (propiedad de otros frentes)
`composicionValle*`, escena/terreno del valle, `src/visual/creatures/*`, `src/visual/registry.js`, `saludoPantalla.js`, lógica de notificaciones de Angelita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)