### PR TITLE
fix: crash React #306 al recorrer en 3D

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -560,16 +560,35 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
           style={{ '--vm-tinte': tinteDeMundo(nav.mundoId)[0] }}
           aria-label={`Mundo ${tituloDeMundo(nav.mundoId)}`}
         >
-          <Mundo
-            mundoId={nav.mundoId}
-            tier={equipo.tier}
-            reducedMotion={reducedMotion}
-            onHotspot={onPuertaMundo}
-            onSalir={salirDelMundo}
-            animo={companero.animo}
-            energia={companero.energia}
-            hablando={!!dicho}
-          />
+          {/* DEFENSA EN PROFUNDIDAD: si un mundo falla al montar (p. ej. una
+              escena que no resuelve), el error queda ACOTADO al mundo — se
+              muestra una salida digna y se vuelve al valle, en vez de tumbar
+              toda la app. La causa raíz (React #306 por el lazy sin `default`)
+              queda arreglada en Mundo.jsx; esto es el cinturón de seguridad. */}
+          <Valle3DGuard
+            key={nav.mundoId}
+            fallback={(
+              <div className="mundo-caida" role="status" style={{ '--m-tinte': tinteDeMundo(nav.mundoId)[0] }}>
+                <p className="mundo-caida__txt">
+                  Este mundo no abrió bien. Su finca sigue completa; vuelva al valle e inténtelo de nuevo.
+                </p>
+                <button type="button" className="mundo-caida__btn" onClick={salirDelMundo}>
+                  ‹ El valle
+                </button>
+              </div>
+            )}
+          >
+            <Mundo
+              mundoId={nav.mundoId}
+              tier={equipo.tier}
+              reducedMotion={reducedMotion}
+              onHotspot={onPuertaMundo}
+              onSalir={salirDelMundo}
+              animo={companero.animo}
+              energia={companero.energia}
+              hablando={!!dicho}
+            />
+          </Valle3DGuard>
         </section>
       )}
 

--- a/src/visual/mundo3d/Mundo.jsx
+++ b/src/visual/mundo3d/Mundo.jsx
@@ -48,8 +48,13 @@ const IMPORTA_ESCENA = {
   // propio, atmósfera subterránea), fuera de escenas/ pero con el mismo contrato.
   micorrizas: () => import('./micorrizas/EscenaMicorrizas.jsx'),
 };
+/* React.lazy EXIGE que la promesa resuelva a `{ default: Componente }`. El
+   `importa().then(m => m.default || m)` resolvía al COMPONENTE pelado, así que
+   React leía `Componente.default` → `undefined` → crash #306 al entrar a
+   CUALQUIER mundo 3D (todas las escenas exportan default). Se envuelve en
+   `{ default: … }` — el mismo contrato que ya usa VitrinaMaestraMundos. */
 const ESCENAS_3D = Object.fromEntries(
-  Object.entries(IMPORTA_ESCENA).map(([k, importa]) => [k, lazy(() => importa().then(m => (/** @type {any} */ (m)).default || m))]),
+  Object.entries(IMPORTA_ESCENA).map(([k, importa]) => [k, lazy(() => importa().then(m => ({ default: (/** @type {any} */ (m)).default || m })))]),
 );
 
 /* Cuánto esperamos el chunk 3D antes de la CAÍDA DIGNA al 2D. Con señal


### PR DESCRIPTION
## Qué

Al tocar **"Recorrer en 3D"** (o "Entrar a este mundo") en el valle, la app tumbaba con **Minified React error #306** ("Element type is invalid: got undefined"). Crashea al entrar a **cualquier** mundo 3D.

## Causa raíz (verificada empíricamente en el bundle de prod)

`src/visual/mundo3d/Mundo.jsx` cargaba las escenas así:

```js
lazy(() => importa().then(m => m.default || m))
```

`m.default || m` resuelve al **componente pelado**. Pero `React.lazy` exige que la promesa resuelva a `{ default: Componente }`; React entonces lee `.default` del valor resuelto → `Componente.default` → **`undefined`** → #306. Como todas las escenas exportan `default`, rompía en **todos** los mundos.

Prueba: cargando el bundle de prod en Chromium (swiftshader) y tocando "Recorrer en 3D", el stack de React apunta al `Lazy` dentro de `<Mundo>`; sondeando el módulo, `import(EscenaFlujo)` = `{ default: fn }`, pero `(m.default||m).default` = `undefined`. El hermano `VitrinaMaestraMundos.jsx` ya usaba la forma correcta `({ default: m.default || m })`.

## Arreglo

- **Raíz**: envolver en `{ default: … }` (mismo contrato que la Vitrina).
- **Defensa en profundidad**: `<Mundo>` en `EntradaValle3D` queda acotado por un `ErrorBoundary` (Valle3DGuard) → si una escena falla, muestra una salida digna "vuelva al valle" en vez de tumbar toda la app.

## Verificación

- Repro en Chromium/swiftshader sobre `dist-prod`: **antes** = "Algo falló" (#306); **después** = entra normal ("Angelita lo lleva a El agua…"), sin errores de consola, app intacta.
- `npm run build:prod` **verde**.
- Tests relacionados (mundo/vitrina/tts) verdes (11/11).

## Nota

Las 4 fallas de `entradaValle3D.nav.test.jsx` ("Viajar al mundo…") **pre-existen** en la base y son un tema aparte de _timing_ del `Valle3D` lazy en jsdom (el valle no cae al 2D síncrono sin WebGL); no son este #306 ni las introduce este cambio.