### PR TITLE
art(angelita): la compañera al máximo — gafas de sol, entrada teatral, cejas y husmea

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -227,6 +227,9 @@ const MundoMercado3DMockup = lazy(() => import('./mockups/MundoMercado3D'));
 // fondo → velo dorado del cruce → el valle como HOME (EntradaValle3D).
 const CaraProd3DMockup = lazy(() => import('./mockups/CaraProd3D'));
 const SueloDemo3DMockup = lazy(() => import('./mockups/SueloDemo3D'));
+// Angelita al máximo: la entrada teatral (gafas + crecimiento) y el repertorio
+// completo de estados del agente, uno al lado del otro.
+const AngelitaVivaMockup = lazy(() => import('./mockups/AngelitaViva'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
@@ -659,6 +662,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo-mercado-3d': 'mockup_mundo_mercado_3d',
   'mockups/cara-prod': 'mockup_cara_prod',
   'mockups/suelo-demo-3d': 'mockup_suelo_demo_3d',
+  'mockups/angelita-viva': 'mockup_angelita_viva',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -2213,6 +2217,17 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El suelo del páramo">
               <SueloDemo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_angelita_viva':
+        // Angelita al máximo (#/mockups/angelita-viva): la entrada teatral
+        // (asoma pequeñita → gafas si hace sol → crece con overshoot) y el
+        // repertorio de estados del agente. ?estado=<nombre> agranda uno.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Angelita, la compañera viva">
+              <AngelitaVivaMockup onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/AngelitaViva.jsx
+++ b/src/mockups/AngelitaViva.jsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from 'react';
+import { AngelitaEntrada } from '../visual/agente/AngelitaEntrada.jsx';
+import { Angelita } from '../visual/agente/Angelita.jsx';
+
+/*
+ * AngelitaViva — vitrina de LA COMPAÑERA al máximo (#/mockups/angelita-viva).
+ *
+ * Dos actos, sin auth (vitrina de discovery como las demás):
+ *   1. LA ENTRADA TEATRAL — el número completo tras el paneo: asoma pequeñita,
+ *      si hace sol se pone las gafas (caída + destello) y CRECE con overshoot
+ *      a asistente. Botones para repetirla soleada o nublada.
+ *   2. EL REPERTORIO — los estados del agente uno al lado del otro (calma,
+ *      escucha, piensa, habla con lip-sync, celebra, aviso, no-sé, señala,
+ *      invita y el nuevo HUSMEA), cada uno actuando con cuerpo, ojos y cejas.
+ *
+ * ?estado=<nombre> agranda ese estado (deep-link para revisión/capturas) y
+ * ?solo=entrada|estados aísla un acto (más liviano para revisar la entrada:
+ * el grid completo son ~12 cuerpos con filtros vivos).
+ */
+
+const ESTADOS_VITRINA = [
+  ['calma', 'acompana', 'Acompaña: flota viva, mira, se acicala'],
+  ['escucha', 'escuchando', 'Se posa y ladea la cabeza hacia usted'],
+  ['piensa', 'pensando', 'Hojea su memoria de la finca'],
+  ['habla', 'respondiendo', 'Lip-sync + gestos + cejas vivas'],
+  ['celebra', 'contenta', 'Brinca con chispas y ojos de dicha'],
+  ['aviso', 'preocupada', 'Alerta honesta: cejas, sudor, aro'],
+  ['no sabe', 'no-se', 'Se encoge de hombros y lo dice'],
+  ['señala', 'senala', 'Se inclina y apunta al lugar'],
+  ['invita', 'invita', 'Venga, le muestro'],
+  ['husmea', 'husmea', 'Fisgonea el rastro, cejas fruncidas'],
+];
+
+/* Visemas en bucle para que la boquita HABLE en la vitrina (sin TTS real). */
+const CICLO_VISEMAS = ['V3', 'V2', 'V1', 'V3', 'V4', 'V2', 'V3', 'V1'];
+
+export default function AngelitaViva({ onBack }) {
+  const [replay, setReplay] = useState(0);
+  const [soleado, setSoleado] = useState(true);
+  const [visema, setVisema] = useState('V3');
+  const params = typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search)
+    : null;
+  const estadoGrande = params?.get('estado') || null;
+  const solo = params?.get('solo') || null;
+
+  useEffect(() => {
+    let i = 0;
+    const t = setInterval(() => {
+      i = (i + 1) % CICLO_VISEMAS.length;
+      setVisema(CICLO_VISEMAS[i]);
+    }, 210);
+    return () => clearInterval(t);
+  }, []);
+
+  const cielo = soleado
+    ? 'linear-gradient(180deg, #aee3ff 0%, #dff4ff 55%, #f4ead0 100%)'
+    : 'linear-gradient(180deg, #b9c6cc 0%, #d8dfe2 55%, #e9e4d4 100%)';
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: '#fdf6e3',
+      color: '#2a1a0c',
+      fontFamily: 'system-ui, sans-serif',
+      padding: '16px 14px 48px',
+    }}>
+      <header style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            style={{
+              border: '2px solid #2a1a0c', background: '#fffaf0', borderRadius: 10,
+              padding: '6px 12px', fontWeight: 700, cursor: 'pointer',
+            }}
+          >
+            ← Volver
+          </button>
+        )}
+        <div>
+          <h1 style={{ margin: 0, fontSize: 22 }}>Angelita, la compañera viva</h1>
+          <p style={{ margin: '2px 0 0', fontSize: 13, opacity: 0.75 }}>
+            La entrada teatral y el repertorio completo del agente
+          </p>
+        </div>
+      </header>
+
+      {/* ── ACTO 1: LA ENTRADA ─────────────────────────────────────────────── */}
+      {solo !== 'estados' && (
+      <section
+        data-vitrina="entrada"
+        style={{
+          border: '2.5px solid #2a1a0c', borderRadius: 18, overflow: 'hidden',
+          marginBottom: 22, background: '#fffaf0',
+        }}
+      >
+        <div style={{
+          background: cielo, minHeight: 300, display: 'flex',
+          alignItems: 'center', justifyContent: 'center', position: 'relative',
+        }}>
+          {soleado && (
+            <div aria-hidden style={{
+              position: 'absolute', top: 18, right: 26, width: 54, height: 54,
+              borderRadius: '50%', background: '#ffd76a',
+              boxShadow: '0 0 34px 12px rgba(255, 215, 106, 0.75)',
+            }} />
+          )}
+          <AngelitaEntrada
+            key={`${replay}-${soleado}`}
+            activa
+            conGafas={soleado}
+            clima={soleado ? 'soleado' : null}
+            size={190}
+            retrasoMs={400}
+          />
+        </div>
+        <div style={{ display: 'flex', gap: 8, padding: '10px 12px', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            onClick={() => { setSoleado(true); setReplay((n) => n + 1); }}
+            style={{
+              border: '2px solid #2a1a0c', background: '#ffd76a', borderRadius: 10,
+              padding: '8px 14px', fontWeight: 700, cursor: 'pointer',
+            }}
+          >
+            Repetir con sol (se pone las gafas)
+          </button>
+          <button
+            type="button"
+            onClick={() => { setSoleado(false); setReplay((n) => n + 1); }}
+            style={{
+              border: '2px solid #2a1a0c', background: '#dfe7ea', borderRadius: 10,
+              padding: '8px 14px', fontWeight: 700, cursor: 'pointer',
+            }}
+          >
+            Repetir nublado (sin gafas)
+          </button>
+        </div>
+      </section>
+      )}
+
+      {/* ── ACTO 2: EL REPERTORIO ──────────────────────────────────────────── */}
+      {solo !== 'entrada' && (
+      <section data-vitrina="estados">
+        <h2 style={{ fontSize: 17, margin: '0 0 10px' }}>El repertorio del agente</h2>
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(168px, 1fr))',
+          gap: 12,
+        }}>
+          {ESTADOS_VITRINA.map(([nombre, estado, nota]) => {
+            const grande = estadoGrande === estado || estadoGrande === nombre;
+            return (
+              <figure
+                key={estado}
+                data-estado={estado}
+                style={{
+                  margin: 0, border: '2px solid #2a1a0c', borderRadius: 14,
+                  background: '#fffaf0', padding: '10px 8px 8px', textAlign: 'center',
+                  gridColumn: grande ? '1 / -1' : undefined,
+                }}
+              >
+                <Angelita
+                  estado={estado}
+                  size={grande ? 260 : 148}
+                  visema={estado === 'respondiendo' ? visema : null}
+                  confianza={estado === 'respondiendo' ? 'alta' : null}
+                />
+                <figcaption style={{ fontSize: 13 }}>
+                  <strong style={{ textTransform: 'capitalize' }}>{nombre}</strong>
+                  <div style={{ fontSize: 11.5, opacity: 0.7, marginTop: 2 }}>{nota}</div>
+                </figcaption>
+              </figure>
+            );
+          })}
+          {/* bonus: la de gafas puestas, quieta, para verla de asistente al sol */}
+          <figure
+            data-estado="gafas"
+            style={{
+              margin: 0, border: '2px solid #2a1a0c', borderRadius: 14,
+              background: 'linear-gradient(180deg, #dff4ff, #fffaf0)', padding: '10px 8px 8px',
+              textAlign: 'center',
+            }}
+          >
+            <Angelita estado="acompana" size={148} gafas />
+            <figcaption style={{ fontSize: 13 }}>
+              <strong>Con gafas</strong>
+              <div style={{ fontSize: 11.5, opacity: 0.7, marginTop: 2 }}>Día soleado: quedan puestas</div>
+            </figcaption>
+          </figure>
+        </div>
+      </section>
+      )}
+    </div>
+  );
+}

--- a/src/visual/agente/Angelita.jsx
+++ b/src/visual/agente/Angelita.jsx
@@ -7,6 +7,7 @@ import {
   estadoCanonico,
   POSE_DE_ESTADO,
   ARIA_DE_ESTADO,
+  CEJAS_DE_ESTADO,
   nivelDeConfianza,
   elegirMomentoIdle,
   duracionDeMomento,
@@ -214,6 +215,12 @@ export function Angelita({
   energia = 1,
   mundoId = null,
   lineBoil = false,
+  /* Gafas de sol (día soleado / entrada teatral): passthrough al cuerpo.
+     false | true | 'poniendose' (la caída one-shot). */
+  gafas = false,
+  /* Cejas: si el host no manda, cada estado actúa con las SUYAS
+     (CEJAS_DE_ESTADO — el que habla hace eyebrow-flash, la contenta arquea). */
+  cejas = undefined,
   title = undefined,
   ...rest
 }) {
@@ -311,6 +318,9 @@ export function Angelita({
   // El estado tiñe el ánimo del cuerpo base (aura/antics) salvo que el host
   // mande el suyo: contenta brilla 'pleno', preocupada se pone 'atento'.
   const animoDelEstado = animo ?? (e === 'contenta' ? 'pleno' : e === 'preocupada' ? 'atento' : 'sereno');
+  // Y actúa con las CEJAS (salvo que el host mande las suyas): eyebrow-flash
+  // al hablar, arqueadas de dicha, fruncidas de concentración fisgona.
+  const cejasDelEstado = cejas !== undefined ? cejas : CEJAS_DE_ESTADO[e] ?? null;
   const aria = title ?? (ARIA_DE_ESTADO[e] + (nivel === 'baja' ? ' (con dudas)' : ''));
   // Clase de animación solo cuando está viva; quieta = opacidad digna inline.
   const cls = (c) => (vivo ? c : undefined);
@@ -480,6 +490,22 @@ export function Angelita({
       <path d={CHISPA_D} fill={COLOR_CERTEZA} stroke={RH_INK} strokeWidth="0.35" />
     </g>
   ) : null;
+  // HUSMEA — las virutas de olor que entran hacia su nariz (la carita vive a
+  // la derecha, x≈13): tres hilitos serpenteantes desfasados que ella persigue
+  // inclinada (el cuerpo lo pone el CSS agm-husmea-cuerpo).
+  const virutasOlor = e === 'husmea' ? (
+    <g stroke={RH_INK} strokeWidth="0.6" strokeLinecap="round" fill="none" aria-hidden="true">
+      {[[15.2, 0.6, 0], [17.1, -1.4, -0.7], [15.9, 2.8, -1.4]].map(([x, y, d], i) => (
+        <path
+          key={i}
+          className={cls('agm-olor')}
+          style={vivo ? { animationDelay: `${d}s` } : undefined}
+          opacity={vivo ? undefined : 0.55}
+          d={`M${x},${y} q1.1,-0.7 2.2,0 q1.1,0.7 2.2,0`}
+        />
+      ))}
+    </g>
+  ) : null;
   // INVITA — estelas del "venga": arcos que viajan HACIA ella.
   const estelasInvita = e === 'invita' ? (
     <g stroke={COLOR_VOZ_MIEL} strokeWidth="0.95" strokeLinecap="round" fill="none" aria-hidden="true">
@@ -541,6 +567,8 @@ export function Angelita({
             energia={energia}
             mundoId={mundoId}
             lineBoil={lineBoil}
+            gafas={gafas}
+            cejas={cejasDelEstado}
           />
           {caraPreocupada}
           {caraNoSe}
@@ -553,6 +581,7 @@ export function Angelita({
       {signoNoSe}
       {destelloPoi}
       {estelasInvita}
+      {virutasOlor}
       {mota}
     </svg>
   );

--- a/src/visual/agente/AngelitaEntrada.jsx
+++ b/src/visual/agente/AngelitaEntrada.jsx
@@ -1,0 +1,162 @@
+/* eslint-disable react-refresh/only-export-components -- `esDiaSoleado` es el
+   criterio del número de gafas y viaja JUNTO a la entrada a propósito (una
+   sola verdad); el componente se importa perezoso, no es hot-reload-sensible. */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import '../creatures/angelita-missminutes.css';
+import { Angelita } from './Angelita.jsx';
+
+/*
+ * AngelitaEntrada — LA ENTRADA TEATRAL de la compañera de Chagra.
+ *
+ * Después del paneo de cámara del host (el valle terminó de presentarse), la
+ * abejita hace su aparición de estrella de cartoon años 30:
+ *
+ *   1. ASOMA pequeñita — pop elástico a escala chiquita, curiosa, aleteando.
+ *   2. Si es de DÍA y hace SOL (clima 'soleado'/'dorada'): SE PONE LAS GAFAS —
+ *      caen giradas desde arriba, rebasan la carita, rebotan y asientan, con
+ *      el destello que barre el lente (AngelitaGafas + angelita-missminutes).
+ *   3. CRECE — anticipa (se agacha a coger impulso), se estira con OVERSHOOT
+ *      hasta su tamaño de asistente, squash de aterrizaje, rebotico, y el aro
+ *      de energía ámbar revienta al llegar: ya está aquí la compañera viva.
+ *
+ * El JS solo es el METRÓNOMO de fases (clases .ang-entrada--*); el timing y
+ * las curvas viven en el CSS. Contratos de la casa:
+ *   · reduced-motion (o animated=false) NO hace teatro: aparece YA en tamaño
+ *     final, con las gafas puestas si corresponde — fotograma digno.
+ *   · El line-boil (capa cara) se enciende SOLO durante el número (asoma →
+ *     crece) y en tier alto/medio: es su momento heroico, no un loop eterno.
+ *   · Al terminar queda una <Angelita> normal (estadoFinal) y el host sigue
+ *     mandando con sus props de siempre; `onLista` avisa el fin del show.
+ *
+ * USO (el host del valle, tras su paneo):
+ *   <AngelitaEntrada activa={paneoTermino} clima={clima} size={96} />
+ */
+
+/* Duraciones de fase (ms) — deben COINCIDIR con los keyframes one-shot del CSS
+   (regla dura de la casa: el metrónomo suelta la clase cuando el gesto terminó
+   en identidad, y el empalme no salta). */
+const DUR_ASOMA = 900;    // = ang-asoma
+const DUR_GAFAS = 1650;   // = agz-ponerse (950) + destello (500 desde 0.9s) + respiro
+const DUR_CRECE = 1300;   // = ang-crece
+
+/** ¿Es un momento de gafas? Día con sol en el vocabulario canónico del valle
+ *  ('dorada' | 'soleado' | 'niebla' | 'lluvia' | 'noche'). */
+export function esDiaSoleado(clima) {
+  return clima === 'soleado' || clima === 'dorada';
+}
+
+function prefiereQuietud() {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * @param {Object} props
+ * @param {boolean} [props.activa=true]  dispara la secuencia (el host la pone
+ *   en true cuando su paneo de cámara terminó). Mientras sea false, espera
+ *   invisible. Una vez corrida no se repite (remontar con key para repetir).
+ * @param {string|null} [props.clima=null]  clima canónico del valle: con
+ *   'soleado'/'dorada' la entrada incluye el número de las gafas (que quedan
+ *   puestas). Puede pisarse con `conGafas`.
+ * @param {boolean} [props.conGafas]  fuerza el número de gafas (pisa clima).
+ * @param {number} [props.retrasoMs=0]  espera extra tras `activa` (afinar el
+ *   empalme con el final del paneo).
+ * @param {string} [props.estadoFinal='acompana']  estado del agente al quedar
+ *   de asistente.
+ * @param {number} [props.size=96]
+ * @param {boolean} [props.animated=true]
+ * @param {string} [props.tier]  'bajo' apaga line-boil del número (el show
+ *   sigue: es feedback de llegada, no decoración).
+ * @param {() => void} [props.onLista]  el show terminó: ya es la asistente.
+ *   El resto de props (enso, energia, confianza, …) pasan a <Angelita>.
+ */
+export function AngelitaEntrada({
+  activa = true,
+  clima = null,
+  conGafas = undefined,
+  retrasoMs = 0,
+  estadoFinal = 'acompana',
+  size = 96,
+  animated = true,
+  tier = undefined,
+  onLista = undefined,
+  className = '',
+  ...rest
+}) {
+  const soleado = conGafas ?? esDiaSoleado(clima);
+  // Sin teatro (RM / animated=false): directo a 'lista', digna y completa.
+  const sinTeatro = !animated || prefiereQuietud();
+  const [fase, setFase] = useState(sinTeatro ? 'lista' : 'espera');
+  const onListaRef = useRef(onLista);
+  useEffect(() => { onListaRef.current = onLista; });
+
+  useEffect(() => {
+    if (!activa || sinTeatro) return undefined;
+    let timer = 0;
+    const paso = (f, dur, siguiente) => {
+      setFase(f);
+      timer = window.setTimeout(siguiente, dur);
+    };
+    timer = window.setTimeout(() => {
+      paso('asoma', DUR_ASOMA + 350, () => {
+        if (soleado) {
+          paso('gafas', DUR_GAFAS, () => {
+            paso('crece', DUR_CRECE, () => setFase('lista'));
+          });
+        } else {
+          paso('crece', DUR_CRECE, () => setFase('lista'));
+        }
+      });
+    }, retrasoMs);
+    return () => window.clearTimeout(timer);
+  }, [activa, sinTeatro, soleado, retrasoMs]);
+
+  // Avisar al host UNA vez cuando el show termina.
+  const avisado = useRef(false);
+  useEffect(() => {
+    if (fase === 'lista' && !avisado.current) {
+      avisado.current = true;
+      onListaRef.current?.();
+    }
+  }, [fase]);
+
+  // Las gafas: caen en la fase 'gafas' (one-shot) y QUEDAN puestas después.
+  const gafas = useMemo(() => {
+    if (!soleado) return false;
+    if (sinTeatro) return true;
+    if (fase === 'gafas') return 'poniendose';
+    return (fase === 'crece' || fase === 'lista') ? true : false;
+  }, [soleado, sinTeatro, fase]);
+
+  // Estado del agente por fase: curiosa mientras asoma/se viste, CONTENTA en
+  // el estirón (brinca celebrando mientras crece — puro cartoon), y al quedar
+  // lista, lo que el host pida.
+  const estado = fase === 'crece' ? 'contenta' : fase === 'lista' ? estadoFinal : 'acompana';
+  // Su momento heroico: line-boil solo durante el número (y no en gama baja).
+  const heroica = !sinTeatro && fase !== 'lista' && fase !== 'espera' && tier !== 'bajo';
+
+  return (
+    <span
+      className={`ang-entrada ang-entrada--${fase}${className ? ` ${className}` : ''}`}
+      style={{ width: size, height: size }}
+      data-sol={soleado ? '1' : undefined}
+    >
+      <span className="ang-entrada__escala">
+        <Angelita
+          estado={estado}
+          size={size}
+          animated={animated}
+          tier={tier}
+          gafas={gafas}
+          lineBoil={heroica}
+          clima={clima}
+          {...rest}
+        />
+      </span>
+      <span className="ang-entrada__aro" aria-hidden="true" />
+    </span>
+  );
+}
+
+export default AngelitaEntrada;

--- a/src/visual/agente/angelitaEstados.js
+++ b/src/visual/agente/angelitaEstados.js
@@ -35,6 +35,7 @@ export const ESTADOS_ANGELITA = [
   'no-se',        // honesta: se encoge de hombros — no sabe y LO DICE
   'senala',       // guía: se inclina y apunta al POI, con destello donde señala
   'invita',       // guía: hace "venga" con la manita, acercándose
+  'husmea',       // fisgona: se inclina a olfatear el rastro (revisa la finca)
 ];
 
 /* Sinónimos amables → canónico. El host escribe como piensa; el cuerpo entiende. */
@@ -56,6 +57,10 @@ const ALIAS = {
   guia: 'senala',
   'guía': 'senala',
   ven: 'invita',
+  calma: 'acompana',
+  aviso: 'preocupada',
+  husmeando: 'husmea',
+  fisgonea: 'husmea',
 };
 
 /**
@@ -84,6 +89,24 @@ export const POSE_DE_ESTADO = {
   'no-se': 'vuela',
   senala: 'señala',       // el gesto afinado que ya vive en creatures.css
   invita: 'vuela',
+  husmea: 'vuela',        // la inclinación fisgona la pone el CSS del estado
+};
+
+/* Cada estado ACTÚA también con las CEJAS (CejasRubber, opt-in del cuerpo):
+   el que habla hace eyebrow-flash, la contenta las arquea, la que escucha las
+   levanta, la fisgona las frunce de concentración. null = la carita de siempre
+   (preocupada y no-se conservan SUS cejas dibujadas por el agente). */
+export const CEJAS_DE_ESTADO = {
+  acompana: null,
+  escuchando: 'altas',
+  pensando: null,
+  respondiendo: 'vivas',
+  contenta: 'alegres',
+  preocupada: null,
+  'no-se': null,
+  senala: 'fruncidas',
+  invita: 'altas',
+  husmea: 'fruncidas',
 };
 
 /* Narración para lectores de pantalla — usted, cercano, sin tecnicismos. */
@@ -97,6 +120,7 @@ export const ARIA_DE_ESTADO = {
   'no-se': 'Angelita no sabe la respuesta, y se lo dice con honestidad',
   senala: 'Angelita le está señalando algo',
   invita: 'Angelita lo invita a acercarse',
+  husmea: 'Angelita está husmeando: revisa la finca con cuidado',
 };
 
 /* ── EL REPERTORIO DEL IDLE VIVO (estado acompana) ───────────────────────────

--- a/src/visual/agente/index.js
+++ b/src/visual/agente/index.js
@@ -9,11 +9,13 @@
  *   <Angelita estado="pensando" confianza={0.8} />
  */
 export { Angelita, default } from './Angelita.jsx';
+export { AngelitaEntrada, esDiaSoleado } from './AngelitaEntrada.jsx';
 export {
   ESTADOS_ANGELITA,
   NIVELES_CONFIANZA,
   POSE_DE_ESTADO,
   ARIA_DE_ESTADO,
+  CEJAS_DE_ESTADO,
   MOMENTOS_IDLE,
   estadoCanonico,
   nivelDeConfianza,

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -1,7 +1,9 @@
 import { useId } from 'react';
 import './creatures.css';
+import './angelita-missminutes.css';
 import { CreatureFilters } from './_filters.jsx';
 import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, AntenaRubber, RH_INK } from './_rubberhose.jsx';
+import { GafasSol, CejasRubber } from './AngelitaGafas.jsx';
 import { ABEJA_PALETA, ABEJA_PROPORCION } from './abejaIdentidad.js';
 import { cuerpoDeClima, PERFIL_ABEJA, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
 import { AccesoriosClima } from './AccesoriosClima.jsx';
@@ -109,6 +111,17 @@ export function AbejaAngelita({
      mundoId (o mundo sin prop) entra con las manos libres. Va en su manita
      izquierda (el lado libre; la carita vive a la derecha). */
   mundoId = null,
+  /* ── GAFAS DE SOL (AngelitaGafas) ──────────────────────────────────────────
+     OPT-IN: false (default, nada cambia) | true (puestas sobre los ojitos) |
+     'poniendose' (reproduce UNA vez la caída teatral: baja girada, rebasa,
+     rebota y asienta — su entrada de día soleado). La cadencia vive en
+     angelita-missminutes.css gateada por data-gafas; RM = puestas quietas. */
+  gafas = false,
+  /* ── CEJAS EXPRESIVAS (AngelitaGafas.CejasRubber) ──────────────────────────
+     OPT-IN: null (default: la carita de siempre) | 'alegres' | 'altas' |
+     'vivas' (con eyebrow-flash al hablar) | 'fruncidas' (concentrada). El
+     agente las deriva por estado; cualquier host puede pedirlas directo. */
+  cejas = null,
   ...rest
 }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
@@ -265,9 +278,14 @@ export function AbejaAngelita({
         mirar={[0.3, 0.34]}
         parpadea={vivo}
       />
+      {/* cejas expresivas (opt-in): el rasgo que actúa alegría/atención/foco */}
+      {cejas && <CejasRubber estilo={cejas} />}
       {/* antenas con bombillo que se mecen (secondary motion) */}
       <AntenaRubber d="M7.7,-4.7 C6.7,-7.3 7.0,-9.3 8.3,-10.1" bulbo={[8.3, -10.3]} sway={vivo} delay={0} />
       <AntenaRubber d="M9.7,-4.6 C11.0,-6.7 11.3,-8.7 10.5,-10.3" bulbo={[10.5, -10.5]} sway={vivo} delay={-0.3} />
+      {/* gafas de sol (opt-in): por ENCIMA de ojos y cejas — con 'poniendose'
+          caen desde arriba con overshoot y el destello barre el lente */}
+      {gafas && <GafasSol puesta={gafas === 'poniendose' ? 'poniendose' : 'puesta'} animated={vivo} />}
 
       {/* Vestuario por clima+hora (ruana/sombrero/sudor) — solo con vestuario=true. */}
       {ropa && (
@@ -318,6 +336,8 @@ export function AbejaAngelita({
     'data-lineboil': lineBoil ? '1' : undefined,
     'data-polen': polen ? '1' : undefined,
     'data-prop': mundoId || undefined,
+    'data-gafas': gafas ? (gafas === 'poniendose' && vivo ? 'poniendose' : '1') : undefined,
+    'data-cejas': cejas || undefined,
   };
 
   if (inline) {

--- a/src/visual/creatures/AngelitaGafas.jsx
+++ b/src/visual/creatures/AngelitaGafas.jsx
@@ -1,0 +1,129 @@
+/*
+ * AngelitaGafas — las GAFAS DE SOL de Angelita + las CEJAS expresivas.
+ *
+ * Dos piezas de CARA para subir la expresividad del cuerpo rubber-hose al
+ * máximo (años 30: la cara ES el personaje):
+ *
+ *   <GafasSol />    → gafas redondas de tinta con destello ámbar/cielo, en
+ *                     perspectiva 3/4 (el lente lejano asoma detrás del
+ *                     cercano). Su momento estelar: `puesta='poniendose'`
+ *                     reproduce UNA vez la caída teatral sobre los ojitos —
+ *                     baja girada desde arriba, rebasa, rebota y asienta
+ *                     (timing + overshoot), y el destello barre el lente.
+ *   <CejasRubber /> → cejas de goma por ESTILO ('alegres'|'altas'|'vivas'|
+ *                     'fruncidas'): el rasgo que le faltaba a la carita para
+ *                     actuar de verdad (alegría, atención, concentración).
+ *
+ * Ambas viven en el espacio de la CABEZA de Angelita (cabeza en (8.6,-1) r4.4;
+ * ojos en (10.1,-1.9) y (7.4,-2.2) — abejaIdentidad/AbejaAngelita). La CADENCIA
+ * (caída, rebote, destello, vida de cejas) vive en `angelita-missminutes.css`
+ * gateada por data-attrs del cuerpo (data-gafas / data-cejas) con las reglas de
+ * la casa: reduced-motion congela en fotograma digno, tier 'bajo' corta lo
+ * decorativo continuo. Cero dependencias nuevas; transform/opacity friendly.
+ */
+import { RH_INK } from './_rubberhose.jsx';
+import { ABEJA_PALETA } from './abejaIdentidad.js';
+
+/* El vidrio oscuro cálido (tinta quemada, no negro industrial) y sus reflejos:
+   el cielo de las alas de tul arriba, la chispa crema del catchlight cruzada. */
+const LENTE = '#221106';
+const REFLEJO_CIELO = ABEJA_PALETA.alaTul;
+const CHISPA = '#fff3d8';
+
+/* Geometría 3/4 sobre los ojos reales: lente CERCANO (ojo derecho, grande) por
+   delante; lente LEJANO (ojo izquierdo) asoma detrás — como la cara misma. */
+const CERCA = { cx: 10.15, cy: -1.95, r: 2.3 };
+const LEJOS = { cx: 7.3, cy: -2.25, r: 1.8 };
+
+/**
+ * Las gafas de sol rubber-hose. El grupo entero anima según `puesta`:
+ *   'puesta'      → quietas sobre los ojos (default).
+ *   'poniendose'  → la caída teatral one-shot (CSS `agz-ponerse`), con el
+ *                   destello que barre el lente al aterrizar.
+ * El gate vive en el CSS por [data-gafas] del cuerpo; este componente solo
+ * dibuja y pone clases. `animated=false` (o RM) = fotograma digno: puestas.
+ *
+ * @param {Object} props
+ * @param {'puesta'|'poniendose'} [props.puesta='puesta']
+ * @param {boolean} [props.animated=true]
+ * @param {string} [props.ink=RH_INK]
+ */
+export function GafasSol({ puesta = 'puesta', animated = true, ink = RH_INK }) {
+  const cayendo = animated && puesta === 'poniendose';
+  return (
+    <g
+      className={`agz-gafas${cayendo ? ' agz-cae' : ''}`}
+      style={{ transformBox: 'fill-box', transformOrigin: 'center' }}
+      aria-hidden="true"
+    >
+      {/* lente LEJANO (detrás): asoma por la izquierda del cercano */}
+      <circle cx={LEJOS.cx} cy={LEJOS.cy} r={LEJOS.r} fill={LENTE} stroke={ink} strokeWidth="0.6" />
+      <path
+        d={`M${LEJOS.cx - 1.15},${LEJOS.cy - 0.95} Q${LEJOS.cx - 0.1},${LEJOS.cy - 1.55} ${LEJOS.cx + 0.85},${LEJOS.cy - 1.05}`}
+        stroke={REFLEJO_CIELO} strokeWidth="0.42" fill="none" strokeLinecap="round" opacity="0.55"
+      />
+      {/* patica de la gafa hacia la oreja (borde de la cabeza, lado lejano) */}
+      <path
+        d={`M${LEJOS.cx - LEJOS.r + 0.25},${LEJOS.cy - 0.3} C4.9,-2.3 4.5,-1.95 4.35,-1.5`}
+        stroke={ink} strokeWidth="0.7" fill="none" strokeLinecap="round"
+      />
+      {/* puentecito sobre la nariz (une los aros por arriba) */}
+      <path
+        d={`M${LEJOS.cx + 1.0},${LEJOS.cy - 1.5} Q8.9,-4.15 ${CERCA.cx - 1.4},${CERCA.cy - 1.7}`}
+        stroke={ink} strokeWidth="0.75" fill="none" strokeLinecap="round"
+      />
+      {/* lente CERCANO (delante, el protagonista) */}
+      <circle cx={CERCA.cx} cy={CERCA.cy} r={CERCA.r} fill={LENTE} stroke={ink} strokeWidth="0.7" />
+      {/* reflejo de cielo en el arco superior */}
+      <path
+        d={`M${CERCA.cx - 1.5},${CERCA.cy - 1.15} Q${CERCA.cx},${CERCA.cy - 1.95} ${CERCA.cx + 1.35},${CERCA.cy - 1.0}`}
+        stroke={REFLEJO_CIELO} strokeWidth="0.5" fill="none" strokeLinecap="round" opacity="0.6"
+      />
+      {/* la CHISPA diagonal (dos trazos paralelos, cartoon clásico) — con
+          'poniendose' el CSS la barre por el vidrio al aterrizar */}
+      <g className="agz-chispa" stroke={CHISPA} strokeLinecap="round" opacity="0.85">
+        <path d={`M${CERCA.cx - 1.0},${CERCA.cy + 1.1} L${CERCA.cx + 0.6},${CERCA.cy - 0.9}`} strokeWidth="0.5" />
+        <path d={`M${CERCA.cx - 0.1},${CERCA.cy + 1.3} L${CERCA.cx + 1.0},${CERCA.cy - 0.1}`} strokeWidth="0.32" />
+      </g>
+    </g>
+  );
+}
+
+/* ── CEJAS de goma por estilo — coordenadas sobre los ojos reales ────────────
+   (ojo derecho arriba en y≈-3.85; izquierdo en y≈-3.65; las cejas van un pelo
+   más arriba para no chocar con los aros de las gafas cuando conviven). Cada
+   estilo son DOS paths [cejaDerecha, cejaIzquierda] en el trazo de la casa. */
+const CEJAS_D = {
+  /* arqueadas de dicha — acompañan sonrisa/celebración */
+  alegres: ['M9.0,-4.65 Q10.25,-5.5 11.45,-4.75', 'M6.4,-4.55 Q7.35,-5.25 8.3,-4.7'],
+  /* levantadas de atención — escuchar, sorpresa amable */
+  altas: ['M8.95,-5.2 Q10.25,-6.1 11.5,-5.3', 'M6.35,-5.1 Q7.3,-5.8 8.25,-5.2'],
+  /* como alegres pero VIVAS: el CSS les da el eyebrow-flash del que habla */
+  vivas: ['M9.0,-4.65 Q10.25,-5.5 11.45,-4.75', 'M6.4,-4.55 Q7.35,-5.25 8.3,-4.7'],
+  /* fruncidas de concentración (husmear, señalar) — decididas, no bravas */
+  fruncidas: ['M9.2,-5.0 L11.35,-4.35', 'M6.35,-4.4 L8.25,-4.95'],
+};
+
+/**
+ * Cejas expresivas. Opt-in: sin `estilo` (o desconocido) no dibuja nada — las
+ * caras existentes no cambian. La vida ('vivas', flash al hablar) es del CSS.
+ *
+ * @param {Object} props
+ * @param {'alegres'|'altas'|'vivas'|'fruncidas'|null} [props.estilo]
+ * @param {string} [props.ink=RH_INK]
+ */
+export function CejasRubber({ estilo = null, ink = RH_INK }) {
+  const par = estilo ? CEJAS_D[estilo] : null;
+  if (!par) return null;
+  return (
+    <g
+      className="rh-cejas"
+      stroke={ink} strokeWidth="0.85" fill="none" strokeLinecap="round"
+      style={{ transformBox: 'fill-box', transformOrigin: 'center bottom' }}
+      aria-hidden="true"
+    >
+      <path className="rh-ceja" d={par[0]} />
+      <path className="rh-ceja" d={par[1]} />
+    </g>
+  );
+}

--- a/src/visual/creatures/angelita-missminutes.css
+++ b/src/visual/creatures/angelita-missminutes.css
@@ -1,0 +1,259 @@
+/* ─── ANGELITA AL MÁXIMO — cadencia nueva de la compañera viva ───────────────
+ *
+ * La capa de animación que sube a Angelita a su tope de carisma rubber-hose:
+ *
+ *   1. GAFAS DE SOL (data-gafas)     — la caída teatral one-shot al ponérselas
+ *                                      (baja girada, rebasa, rebota, asienta) +
+ *                                      el destello que barre el lente + el
+ *                                      recoil del cuerpito al aterrizarle.
+ *   2. CEJAS (data-cejas)            — vida de cejas: el eyebrow-flash del que
+ *                                      habla, el temblor de concentración.
+ *   3. HUSMEA (data-agt-estado)      — el estado nuevo del agente: se inclina
+ *                                      a fisgonear, la mirada barre el piso,
+ *                                      las antenas apuntan, y las virutas de
+ *                                      olor entran hacia su nariz.
+ *   4. ENTRADA TEATRAL (.ang-entrada)— asoma pequeñita → (si hace sol) se pone
+ *                                      las gafas → anticipa y CRECE con
+ *                                      overshoot a tamaño de asistente, con su
+ *                                      aro de energía. Timing de cartoon puro.
+ *
+ * REGLAS DE LA CASA (las mismas de creatures.css / angelita-agente.css):
+ *   · Solo transform/opacity (GPU, gama baja).
+ *   · prefers-reduced-motion congela TODO en fotograma digno (gafas puestas,
+ *     tamaño final, cejas quietas).
+ *   · [data-tier='bajo'] corta lo continuo decorativo; conserva los one-shot
+ *     de estado (la entrada sí se ve — es feedback, no decoración).
+ */
+
+/* ═══ 1. LAS GAFAS DE SOL ════════════════════════════════════════════════════ */
+
+/* La CAÍDA teatral (one-shot): baja girada desde arriba de la cabeza, REBASA
+   la cara (slam), rebota dos veces decreciente y asienta. Curvas por tramo:
+   la entrada es rápida (gravedad), el asentado elástico. */
+.agz-cae {
+  animation: agz-ponerse 0.95s cubic-bezier(0.3, 0.9, 0.4, 1) both;
+}
+@keyframes agz-ponerse {
+  0% { transform: translate(1.6px, -10.5px) rotate(-24deg); opacity: 0; }
+  10% { opacity: 1; }
+  52% { transform: translate(0.2px, 0.95px) rotate(5deg); }
+  70% { transform: translate(0, -0.55px) rotate(-2.2deg); }
+  85% { transform: translate(0, 0.2px) rotate(0.8deg); }
+  100% { transform: none; }
+}
+/* El DESTELLO que barre el vidrio justo al aterrizar (delay = el slam). */
+.agz-cae .agz-chispa {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: agz-destello 0.7s 0.5s cubic-bezier(0.2, 0.7, 0.3, 1) both;
+}
+@keyframes agz-destello {
+  0% { transform: translate(-2.1px, 2.1px); opacity: 0; }
+  35% { opacity: 1; }
+  100% { transform: none; opacity: 0.85; }
+}
+/* El cuerpito ACUSA el golpecito: squash de recoil cuando las gafas tocan cara
+   (mismo delay del slam). Pisa el boil idle ese instante y se lo devuelve. */
+[data-gafas='poniendose'] .crt-body {
+  animation: agz-recoil 0.5s 0.48s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+@keyframes agz-recoil {
+  0% { transform: none; }
+  30% { transform: scale(1.06, 0.9) translateY(0.6px); }
+  65% { transform: scale(0.97, 1.04); }
+  100% { transform: none; }
+}
+/* Con las gafas PUESTAS al sol, un brillito perezoso recorre el lente cada
+   tanto (continuo decorativo: se corta en tier bajo). */
+[data-gafas='1'] .agz-chispa {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: agz-brilla 7.3s ease-in-out infinite;
+}
+@keyframes agz-brilla {
+  0%, 86%, 100% { transform: none; opacity: 0.85; }
+  90% { transform: translate(-0.9px, 0.9px); opacity: 0.4; }
+  95% { transform: translate(0.5px, -0.5px); opacity: 1; }
+}
+
+/* ═══ 2. VIDA DE CEJAS ═══════════════════════════════════════════════════════ */
+
+/* El EYEBROW-FLASH del que habla (cejas 'vivas'): suben un pelo con el énfasis
+   y bajan — período co-primo con la gesticulación de brazos (1.7/1.55s). */
+[data-cejas='vivas'] .rh-cejas {
+  animation: rh-cejas-flash 2.3s ease-in-out infinite;
+}
+@keyframes rh-cejas-flash {
+  0%, 100% { transform: none; }
+  12% { transform: translateY(-0.75px); }
+  22% { transform: translateY(0.1px); }
+  58% { transform: translateY(-0.45px); }
+  70% { transform: none; }
+}
+/* Concentración (fruncidas): micro-temblor de esfuerzo, casi subliminal. */
+[data-cejas='fruncidas'] .rh-cejas {
+  animation: rh-cejas-esfuerzo 3.7s ease-in-out infinite;
+}
+@keyframes rh-cejas-esfuerzo {
+  0%, 100% { transform: none; }
+  45% { transform: translateY(0.3px); }
+  55% { transform: translateY(0.15px); }
+}
+/* Atención (altas): respiran arriba — sostener la sorpresa cuesta. */
+[data-cejas='altas'] .rh-cejas {
+  animation: rh-cejas-altas 4.1s ease-in-out infinite;
+}
+@keyframes rh-cejas-altas {
+  0%, 100% { transform: none; }
+  50% { transform: translateY(0.45px); }
+}
+
+/* ═══ 3. HUSMEA — el estado fisgón del agente ════════════════════════════════
+   La abeja detective: se inclina hacia adelante-abajo (fisgonea el piso),
+   cabecea siguiendo el rastro, la mirada barre, y las virutas de olor entran
+   hacia su nariz. Selectores en el espacio del agente (angelita-agente.css). */
+[data-agt-vivo='1'][data-agt-estado='husmea'] .agt-cuerpo {
+  animation: agm-husmea-cuerpo 2.8s cubic-bezier(0.45, 0, 0.3, 1.25) infinite;
+}
+@keyframes agm-husmea-cuerpo {
+  0%, 100% { transform: rotate(4deg) translate(0.6px, 0.8px); }
+  22% { transform: rotate(9deg) translate(1.4px, 2.2px); }
+  38% { transform: rotate(7deg) translate(1.1px, 1.6px); }
+  60% { transform: rotate(11deg) translate(1.8px, 2.8px); }
+  78% { transform: rotate(5deg) translate(0.8px, 1.1px); }
+}
+/* Quieta (fotograma digno): inclinada fisgoneando, sin loop. */
+[data-agt-estado='husmea'] .agt-cuerpo {
+  transform: rotate(7deg) translate(1.2px, 1.8px);
+}
+/* La mirada BARRE el rastro (abajo, de lado a lado) — pisa el dardeo neutro. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='husmea'] .rh-mirada {
+  animation: agm-husmea-mirada 2.8s ease-in-out infinite;
+}
+@keyframes agm-husmea-mirada {
+  0%, 100% { transform: translate(0.35px, 0.55px); }
+  30% { transform: translate(-0.35px, 0.6px); }
+  55% { transform: translate(0.5px, 0.7px); }
+  80% { transform: translate(-0.2px, 0.5px); }
+}
+/* Las VIRUTAS DE OLOR (markup del agente): entran serpenteando hacia la nariz
+   y se disuelven — tres, desfasadas por delay inline. */
+.agm-olor {
+  transform-box: fill-box;
+  transform-origin: center;
+  opacity: 0;
+}
+[data-agt-vivo='1'] .agm-olor {
+  animation: agm-olor 2.1s ease-in-out infinite;
+}
+@keyframes agm-olor {
+  0% { transform: translate(3.4px, 1.4px); opacity: 0; }
+  30% { opacity: 0.75; }
+  70% { opacity: 0.5; }
+  100% { transform: translate(-1.6px, -0.6px); opacity: 0; }
+}
+
+/* ═══ 4. LA ENTRADA TEATRAL (.ang-entrada) ═══════════════════════════════════
+   Después del paneo del host: asoma PEQUEÑITA (pop elástico) → si hace sol se
+   pone las gafas (fase quieta a escala chiquita: el show es de las gafas) →
+   anticipa (se recoge) y CRECE con overshoot a su tamaño de asistente, con el
+   aro de energía que revienta al llegar. El JS (AngelitaEntrada.jsx) solo
+   cambia la clase de fase; el timing vive aquí. */
+.ang-entrada {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.ang-entrada__escala {
+  display: inline-flex;
+  transform-origin: 50% 78%; /* crece desde su base: brota, no infla */
+  will-change: transform;
+}
+/* espera: todavía nada (el paneo del host sigue andando) */
+.ang-entrada--espera .ang-entrada__escala { transform: scale(0.36); opacity: 0; }
+/* asoma: pop elástico a tamaño pequeñito */
+.ang-entrada--asoma .ang-entrada__escala {
+  animation: ang-asoma 0.9s cubic-bezier(0.3, 1.4, 0.5, 1) both;
+}
+@keyframes ang-asoma {
+  0% { transform: scale(0.1); opacity: 0; }
+  18% { opacity: 1; }
+  62% { transform: scale(0.44); }
+  82% { transform: scale(0.33); }
+  100% { transform: scale(0.36); opacity: 1; }
+}
+/* gafas: quieta a escala chica (el one-shot de las gafas manda) */
+.ang-entrada--gafas .ang-entrada__escala { transform: scale(0.36); }
+/* crece: anticipación (se agacha y recoge) → estirón con overshoot → asienta */
+.ang-entrada--crece .ang-entrada__escala {
+  animation: ang-crece 1.3s cubic-bezier(0.3, 0.9, 0.35, 1) both;
+}
+@keyframes ang-crece {
+  0% { transform: scale(0.36); }
+  16% { transform: scale(0.42, 0.28) translateY(3%); }  /* se agacha: coge impulso */
+  30% { transform: scale(0.3, 0.5) translateY(-1%); }   /* se estira hacia arriba */
+  58% { transform: scale(1.14, 1.22) translateY(-2%); } /* el estirón — REBASA */
+  74% { transform: scale(0.94, 0.9) translateY(0.5%); } /* squash de aterrizaje */
+  88% { transform: scale(1.04, 1.05); }                 /* rebotico */
+  100% { transform: none; }
+}
+.ang-entrada--lista .ang-entrada__escala { transform: none; }
+
+/* El ARO DE ENERGÍA que revienta cuando alcanza su tamaño (delay = el pico del
+   estirón). Un anillo ámbar que se expande y disuelve — llegó la compañera. */
+.ang-entrada__aro {
+  position: absolute;
+  inset: 12%;
+  border: 2.5px solid rgba(255, 181, 79, 0.9);
+  border-radius: 50%;
+  pointer-events: none;
+  opacity: 0;
+  transform: scale(0.4);
+}
+/* forwards (no both): antes del delay el aro queda en su base (opacity 0) —
+   con both se veía el 0% congelado desde el arranque del crecimiento. */
+.ang-entrada--crece .ang-entrada__aro {
+  animation: ang-aro 0.85s 0.55s cubic-bezier(0.2, 0.7, 0.3, 1) forwards;
+}
+@keyframes ang-aro {
+  0% { transform: scale(0.4); opacity: 0.9; }
+  100% { transform: scale(1.5); opacity: 0; }
+}
+
+/* ═══ GATES DE LA CASA ═══════════════════════════════════════════════════════ */
+
+/* Tier bajo: fuera lo continuo decorativo (brillito de lente, vida de cejas,
+   virutas — el estado husmea conserva SU cuerpo, que es feedback). El one-shot
+   de gafas y la entrada quedan: son momentos, no loops. */
+[data-tier='bajo'] .agz-chispa,
+[data-tier='bajo'] .rh-cejas,
+[data-tier='bajo'] .agm-olor {
+  animation: none;
+}
+
+/* Reduced-motion: TODO congela en su fotograma digno — gafas puestas, cejas
+   quietas, husmeo inclinado estático, entrada YA en tamaño final (el JS de
+   AngelitaEntrada además salta directo a 'lista'; esto es el cinturón). */
+@media (prefers-reduced-motion: reduce) {
+  .agz-cae,
+  .agz-cae .agz-chispa,
+  [data-gafas='poniendose'] .crt-body,
+  [data-gafas='1'] .agz-chispa,
+  .rh-cejas,
+  [data-agt-estado='husmea'] .agt-cuerpo,
+  [data-agente='angelita'][data-agt-estado='husmea'] .rh-mirada,
+  .agm-olor,
+  .ang-entrada__escala,
+  .ang-entrada__aro {
+    animation: none !important;
+  }
+  .ang-entrada--espera .ang-entrada__escala,
+  .ang-entrada--asoma .ang-entrada__escala,
+  .ang-entrada--gafas .ang-entrada__escala,
+  .ang-entrada--crece .ang-entrada__escala {
+    transform: none;
+    opacity: 1;
+  }
+  .agm-olor { opacity: 0.55; }
+}


### PR DESCRIPTION
## Qué hace

Sube a Angelita (la cara de la IA) a su tope de carisma rubber-hose años 30. Todo **opt-in**: los consumidores existentes no cambian un pixel.

### Piezas nuevas
- **`AngelitaGafas.jsx`** — `GafasSol` (gafas redondas de tinta, perspectiva 3/4, reflejo de cielo + chispa; caída teatral one-shot con overshoot, destello que barre el lente y recoil del cuerpito) y `CejasRubber` (cejas por estilo: alegres/altas/vivas/fruncidas).
- **`AngelitaEntrada.jsx`** — la entrada teatral tras el paneo del host: asoma pequeñita (pop elástico) → si es de DÍA y hace SOL se pone las gafas → anticipa y CRECE con overshoot a tamaño de asistente, con aro de energía. `esDiaSoleado(clima)` decide con el vocabulario canónico ('soleado'/'dorada'). `onLista` avisa el fin del show.
- **`angelita-missminutes.css`** — toda la cadencia nueva (transform/opacity; gates reduced-motion + tier de la casa).
- **Estado `husmea`** — la fisgona: se inclina a olfatear, la mirada barre el piso, virutas de olor entran a su nariz, cejas fruncidas.
- **Cejas por estado** (`CEJAS_DE_ESTADO`): eyebrow-flash al hablar, arqueadas de dicha al celebrar, altas al escuchar.
- **Vitrina** `#/mockups/angelita-viva`: entrada repetible (sol/nublado) + repertorio completo. `?estado=` agranda uno, `?solo=entrada|estados` aísla acto.

### Compatibilidad con el cerebro (PR #2524)
El vocabulario que mapea `angelitaInteligencia` queda cubierto y con cara: `acompana`/`preocupada`/`invita`/`contenta`/`senala` ya existían y ahora actúan también con cejas; además alias `calma→acompana`, `aviso→preocupada` y el canónico nuevo `husmea`. `<Angelita estado=… gafas=… />` sigue siendo la única API.

### Cableado pendiente (consolidación)
La entrada está lista para el host del valle: `<AngelitaEntrada activa={paneoTermino} clima={clima} onLista=… />` (no toqué la escena del valle ni los FABs — propiedad de otro frente). `dist-prod/` no se regeneró en este PR (solo fuente).

### Verificación
- `npm run build:prod` VERDE (1m). Lint limpio en archivos tocados. Tests de render de AbejaAngelita verdes (el fallo de `vidaEstados.test.js` ya existía en la base).
- Capturas de la secuencia completa y del repertorio adjuntas por el operador (evidencia visual del arte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)