### PR TITLE
art(bosque+paramo): bosque de biodiversidad multiespecie + paramo con el Ent-frailejon maestro

### DIFF
--- a/src/mockups/MundoParamo3D.jsx
+++ b/src/mockups/MundoParamo3D.jsx
@@ -656,6 +656,306 @@ function AvePosada() {
   );
 }
 
+/* ── EL ENT-FRAILEJÓN: el GUARDIÁN-MAESTRO del páramo ──────────────────────
+      Un frailejón MONUMENTAL (Espeletia hecha anciano) que se alza sobre el
+      frailejonal y enseña: columna velluda vestida de enagua marcescente, un
+      ROSTRO sereno que emerge del tallo (ojos ámbar hundidos bajo cejas
+      afelpadas, boca-grieta amable) y la gran ROSETA plateada por corona. Un
+      brazo florido (escapo de capítulos amarillos) que hace ademán de señalar,
+      y un halo de páramo a sus pies. Es el par del Ent-queñua del bosque: aquí,
+      arriba, el maestro es el frailejón. Digno, quieto, sabio. ── */
+function EntFrailejonMaestro({ pos, esc = 1, reducedMotion }) {
+  const cuerpo = useRef(null);
+  const brazo = useRef(null);
+  const halo = useRef(null);
+  useFrame(({ clock }) => {
+    const t = clock.elapsedTime;
+    // respira/mece apenas (anciano sereno, no bailarín)
+    if (!reducedMotion) {
+      if (cuerpo.current) cuerpo.current.rotation.z = Math.sin(t * 0.4) * 0.02;
+      if (brazo.current) brazo.current.rotation.z = -0.5 + Math.sin(t * 0.6) * 0.06;
+    }
+    if (halo.current) {
+      const pulso = reducedMotion ? 1 : 0.72 + 0.28 * Math.sin(t * 0.9);
+      halo.current.material.opacity = 0.16 * pulso;
+    }
+  });
+
+  // La enagua: anillos de hojas secas colgantes (conos abiertos) a lo largo del
+  // tallo — le da CUERPO de fraile, no palo. Recientes arriba, curtidas abajo.
+  const enagua = useMemo(() => {
+    const arr = [];
+    const n = 6;
+    for (let i = 0; i < n; i++) {
+      const f = i / (n - 1); // 0 base(vieja) → 1 arriba(reciente)
+      arr.push({
+        y: 0.5 + f * 1.7,
+        r: 0.44 - f * 0.06,
+        col: f < 0.4 ? P.frailejonTallo : mezclar(P.frailejonTallo, TINTE, 0.3),
+      });
+    }
+    return arr;
+  }, []);
+
+  // La roseta: un POMPÓN plateado pleno — TRES coronas de hojas anchas y
+  // afelpadas sobre un domo pálido, para que se lea como la roseta gorda del
+  // frailejón (no un mohawk) y RESALTE como el punto más claro del oro.
+  const hojasRoseta = useMemo(() => {
+    const rng = crearRng(707);
+    const corona = (n, incMin, incSpan, largoMin, largoSpan, ancho, claroMin, fase) =>
+      Array.from({ length: n }, (_, i) => ({
+        ang: (i / n) * Math.PI * 2 + fase + rng() * 0.12,
+        inc: incMin + rng() * incSpan,
+        largo: largoMin + rng() * largoSpan,
+        ancho,
+        claro: claroMin + rng() * 0.35,
+      }));
+    return [
+      // externa: ancha y arqueada afuera (el faldón de la roseta)
+      ...corona(20, 1.0, 0.28, 0.62, 0.2, 0.19, 0.1, 0),
+      // media: intermedia
+      ...corona(16, 0.6, 0.3, 0.52, 0.18, 0.17, 0.4, 0.4),
+      // interna: corta y erguida (el cogollo, la más pálida)
+      ...corona(10, 0.2, 0.24, 0.34, 0.14, 0.14, 0.7, 0.8),
+    ];
+  }, []);
+
+  // Colores plateados de la roseta: brillan claro para RESALTAR en la niebla
+  // dorada (la firma plateada del frailejón, el punto más luminoso de la escena).
+  const PLATA = mezclar('#c3ceb0', TINTE, 0.12);
+  const PLATA_CLARO = mezclar('#e4ead8', TINTE, 0.08);
+
+  return (
+    <group position={pos} scale={esc}>
+      {/* halo de maestro a los pies (aditivo, respira) */}
+      <mesh ref={halo} position={[0, 0.06, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[0.7, 1.5, 32]} />
+        <meshBasicMaterial color="#f2e6c4" transparent opacity={0.16} depthWrite={false} blending={THREE.AdditiveBlending} side={THREE.DoubleSide} />
+      </mesh>
+
+      <group ref={cuerpo}>
+        {/* el TALLO velludo, grueso y alto */}
+        <mesh position={[0, 1.2, 0]} castShadow>
+          <cylinderGeometry args={[0.34, 0.44, 2.4, 11]} />
+          <meshLambertMaterial color={P.frailejonTallo} flatShading />
+        </mesh>
+        {/* la enagua de hojas muertas (marcescentes) por anillos */}
+        {enagua.map((e, i) => (
+          <mesh key={i} position={[0, e.y, 0]}>
+            <coneGeometry args={[e.r, 0.5, 11, 1, true]} />
+            <meshLambertMaterial color={e.col} flatShading side={THREE.DoubleSide} />
+          </mesh>
+        ))}
+
+        {/* ── EL ROSTRO que emerge del tallo (a ~1.6 de alto) ── */}
+        <group position={[0, 1.62, 0.28]}>
+          {/* frente/mejilla: una cáscara suave sobre el tallo (más clara) */}
+          <mesh position={[0, 0.05, -0.06]} scale={[1, 1.1, 0.7]}>
+            <sphereGeometry args={[0.3, 14, 12]} />
+            <meshLambertMaterial color={mezclar(P.frailejonTallo, '#c8b483', 0.35)} flatShading />
+          </mesh>
+          {/* cejas afelpadas (dos tufos claros sobre los ojos) */}
+          {[-1, 1].map((s) => (
+            <mesh key={s} position={[s * 0.12, 0.13, 0.16]} rotation={[0, 0, -s * 0.3]} scale={[1.2, 0.5, 0.6]}>
+              <sphereGeometry args={[0.08, 8, 6]} />
+              <meshLambertMaterial color={P.frailejonHoja} flatShading />
+            </mesh>
+          ))}
+          {/* ojos: cuenca honda + iris ámbar-miel que asoma de la sombra */}
+          {[-1, 1].map((s) => (
+            <group key={s} position={[s * 0.12, 0.0, 0.18]}>
+              <mesh position={[0, 0, -0.02]} scale={[1, 1.05, 0.8]}>
+                <sphereGeometry args={[0.075, 12, 10]} />
+                <meshLambertMaterial color="#4a3115" flatShading />
+              </mesh>
+              <mesh position={[0, 0, 0.03]}>
+                <sphereGeometry args={[0.05, 12, 10]} />
+                <meshLambertMaterial color="#e0ad4c" emissive="#a5702a" emissiveIntensity={0.35} flatShading />
+              </mesh>
+              <mesh position={[0, 0, 0.06]}>
+                <sphereGeometry args={[0.02, 8, 8]} />
+                <meshLambertMaterial color="#2a1c0a" flatShading />
+              </mesh>
+              <mesh position={[s * 0.015, 0.02, 0.075]}>
+                <sphereGeometry args={[0.008, 6, 6]} />
+                <meshBasicMaterial color="#fff6e2" />
+              </mesh>
+            </group>
+          ))}
+          {/* nariz de nudo */}
+          <mesh position={[0, -0.1, 0.2]} scale={[0.8, 1.1, 0.9]}>
+            <sphereGeometry args={[0.06, 8, 7]} />
+            <meshLambertMaterial color={mezclar(P.frailejonTallo, '#8a6a44', 0.4)} flatShading />
+          </mesh>
+          {/* boca-grieta amable (leve arco) */}
+          <mesh position={[0, -0.22, 0.17]} rotation={[0.2, 0, 0]} scale={[1.5, 0.32, 0.5]}>
+            <sphereGeometry args={[0.09, 10, 6]} />
+            <meshLambertMaterial color="#3a2712" flatShading />
+          </mesh>
+        </group>
+
+        {/* ── LA ROSETA plateada: pompón pleno de tres coronas sobre un domo ── */}
+        <group position={[0, 2.4, 0]}>
+          {/* domo pálido: el cuerpo de la roseta bajo las hojas (le da bulto) */}
+          <mesh position={[0, 0.12, 0]} scale={[1, 0.72, 1]}>
+            <sphereGeometry args={[0.42, 14, 10]} />
+            <meshLambertMaterial color={mezclar('#cdd6bd', TINTE, 0.12)} flatShading />
+          </mesh>
+          {hojasRoseta.map((h, i) => (
+            <mesh
+              key={i}
+              position={[Math.cos(h.ang) * 0.2, 0.06, Math.sin(h.ang) * 0.2]}
+              rotation={[h.inc, -h.ang, 0]}
+              castShadow
+            >
+              <coneGeometry args={[h.ancho, h.largo, 4]} />
+              <meshLambertMaterial color={new THREE.Color(PLATA).lerp(new THREE.Color(PLATA_CLARO), h.claro)} flatShading />
+            </mesh>
+          ))}
+          {/* cogollo velloso central (el punto más pálido, el corazón afelpado) */}
+          <mesh position={[0, 0.2, 0]}>
+            <sphereGeometry args={[0.16, 12, 9]} />
+            <meshLambertMaterial color={mezclar('#eef2e6', TINTE, 0.08)} flatShading />
+          </mesh>
+        </group>
+
+        {/* ── EL BRAZO florido: escapo que sale del costado y hace ademán de
+             señalar (el maestro que enseña) con capítulos amarillos ── */}
+        <group ref={brazo} position={[0.4, 1.8, 0.12]} rotation={[0, 0, -0.5]}>
+          <mesh position={[0, 0.45, 0]}>
+            <cylinderGeometry args={[0.03, 0.045, 0.95, 6]} />
+            <meshLambertMaterial color={P.frailejonHoja} flatShading />
+          </mesh>
+          {[[0, 0.92, 0.05], [0.09, 0.86, -0.03], [-0.07, 0.84, 0.05], [0.03, 0.98, -0.02]].map((f, i) => (
+            <mesh key={i} position={/** @type {[number, number, number]} */ (f)}>
+              <sphereGeometry args={[0.07, 8, 6]} />
+              <meshLambertMaterial color={P.frailejonFlor} emissive="#7a5e18" emissiveIntensity={0.2} flatShading />
+            </mesh>
+          ))}
+        </group>
+      </group>
+    </group>
+  );
+}
+
+/* ── CHUSQUE (Chusquea, el bambú del páramo): macollas de culmos finos y
+      ARQUEADOS que se doblan con el viento. Cero copa: es fino y plumoso. ── */
+function Chusque({ pos, esc = 1, seed = 5 }) {
+  const rng = useMemo(() => crearRng(seed), [seed]);
+  const culmos = useMemo(
+    () => Array.from({ length: 7 }, () => ({
+      ang: rng() * Math.PI * 2,
+      inc: 0.2 + rng() * 0.35,
+      alto: 0.9 + rng() * 0.7,
+      verde: rng(),
+    })),
+    [rng],
+  );
+  return (
+    <group position={pos} scale={esc}>
+      {culmos.map((c, i) => (
+        <group key={i} rotation={[Math.cos(c.ang) * c.inc, 0, Math.sin(c.ang) * c.inc]}>
+          <mesh position={[0, c.alto / 2, 0]}>
+            <cylinderGeometry args={[0.012, 0.02, c.alto, 4]} />
+            <meshLambertMaterial color={mezclar('#8a9a55', TINTE, 0.25 + c.verde * 0.15)} flatShading />
+          </mesh>
+          {/* penacho de hoja fina arriba */}
+          <mesh position={[0, c.alto + 0.06, 0]}>
+            <coneGeometry args={[0.07, 0.28, 4]} />
+            <meshLambertMaterial color={mezclar('#9caf5f', TINTE, 0.28)} flatShading />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}
+
+/* ── CARDÓN (Puya, la bromelia gigante del páramo): roseta de hojas duras
+      espinosas en corona baja y, a veces, una vara-inflorescencia alta. ── */
+function Cardon({ pos, esc = 1, vara = true, seed = 9 }) {
+  const rng = useMemo(() => crearRng(seed), [seed]);
+  const hojas = useMemo(
+    () => Array.from({ length: 14 }, (_, i) => ({
+      ang: (i / 14) * Math.PI * 2 + rng() * 0.2,
+      inc: 0.7 + rng() * 0.4,
+      largo: 0.4 + rng() * 0.2,
+    })),
+    [rng],
+  );
+  return (
+    <group position={pos} scale={esc}>
+      {hojas.map((h, i) => (
+        <mesh
+          key={i}
+          position={[Math.cos(h.ang) * 0.06, 0.06, Math.sin(h.ang) * 0.06]}
+          rotation={[h.inc, -h.ang, 0]}
+        >
+          <coneGeometry args={[0.05, h.largo, 3]} />
+          <meshLambertMaterial color={mezclar('#7e9a58', TINTE, 0.32)} flatShading />
+        </mesh>
+      ))}
+      {vara && (
+        <group position={[0, 0.1, 0]}>
+          <mesh position={[0, 0.65, 0]}>
+            <cylinderGeometry args={[0.03, 0.05, 1.3, 6]} />
+            <meshLambertMaterial color={mezclar('#9a8a5a', TINTE, 0.3)} flatShading />
+          </mesh>
+          <mesh position={[0, 1.35, 0]}>
+            <sphereGeometry args={[0.16, 8, 7]} />
+            <meshLambertMaterial color={mezclar('#5f7d4a', TINTE, 0.28)} flatShading />
+          </mesh>
+        </group>
+      )}
+    </group>
+  );
+}
+
+/* ── ROMERO DE PÁRAMO (Diplostephium): arbustillo bajo, denso y aromático, de
+      follaje fino gris-verde. El sotobosque leñoso del moor, instanciado. ── */
+function RomeroParamo({ n }) {
+  const ref = useRef(null);
+  const sitios = useMemo(() => {
+    const rng = crearRng(163);
+    const lista = [];
+    let intentos = 0;
+    while (lista.length < n && intentos < n * 10) {
+      intentos += 1;
+      const wx = (rng() - 0.5) * (ANCHO - 8);
+      const wz = (rng() - 0.5) * (FONDO - 10);
+      if (humedad(wx, wz) > 0.5) continue;
+      const y = alturaParamo(wx, wz);
+      if (y > 3.4) continue;
+      lista.push({ wx, wz, y, esc: 0.5 + rng() * 0.6, giro: rng() * Math.PI, verde: rng() });
+    }
+    return lista;
+  }, [n]);
+  useEffect(() => {
+    const m = ref.current;
+    if (!m) return;
+    const dummy = new THREE.Object3D();
+    const tinte = new THREE.Color();
+    const base = new THREE.Color(mezclar('#6f8a52', TINTE, 0.3));
+    const claro = new THREE.Color(mezclar('#8aa565', TINTE, 0.28));
+    sitios.forEach((s, i) => {
+      dummy.position.set(s.wx, s.y + 0.16 * s.esc, s.wz);
+      dummy.rotation.set(0, s.giro, 0);
+      dummy.scale.set(s.esc, s.esc * 1.15, s.esc);
+      dummy.updateMatrix();
+      m.setMatrixAt(i, dummy.matrix);
+      tinte.copy(base).lerp(claro, s.verde);
+      m.setColorAt(i, tinte);
+    });
+    m.instanceMatrix.needsUpdate = true;
+    if (m.instanceColor) m.instanceColor.needsUpdate = true;
+  }, [sitios]);
+  return (
+    <instancedMesh ref={ref} args={[undefined, undefined, sitios.length]} frustumCulled={false}>
+      <dodecahedronGeometry args={[0.26]} />
+      <meshLambertMaterial flatShading />
+    </instancedMesh>
+  );
+}
+
 /* La escena completa (grupo r3f interno; el default la monta en su Canvas). */
 function EscenaParamo({ tier, reducedMotion, fabrica }) {
   const perfil = perfilDeTier(tier);
@@ -666,11 +966,12 @@ function EscenaParamo({ tier, reducedMotion, fabrica }) {
   useEffect(() => () => geo.dispose(), [geo]);
 
   // presupuestos de la colonia por tier
-  const nFrailejones = tier === 'alto' ? 16 : 10;
+  const nFrailejones = tier === 'alto' ? 18 : 11;
   const nPaja = tier === 'alto' ? 150 : 90;
   const nMusgo = tier === 'alto' ? 46 : 28;
   const nNiebla = tier === 'alto' ? 9 : 6;
   const nAves = tier === 'alto' ? 3 : 2;
+  const nRomero = tier === 'alto' ? 22 : 12;
 
   /* `color`/`fog` se adjuntan a la ESCENA: hijos directos, nunca en <group>. */
   return (
@@ -685,10 +986,27 @@ function EscenaParamo({ tier, reducedMotion, fabrica }) {
       </mesh>
 
       <NacimientoAgua reducedMotion={reducedMotion} fabrica={fabrica} />
-      <FrailejonHeroe pos={[-2.2, alturaParamo(-2.2, 2.4), 2.4]} reducedMotion={reducedMotion} />
+
+      {/* ══ EL GUARDIÁN-MAESTRO ══ el Ent-frailejón monumental que se alza sobre
+          el frailejonal y enseña. Elevado y adelantado a la izquierda para que
+          domine el cuadro sin tapar el nacimiento del agua. */}
+      <EntFrailejonMaestro pos={[-1.9, alturaParamo(-1.9, 1.4) - 0.1, 1.4]} esc={1.6} reducedMotion={reducedMotion} />
+
+      {/* el frailejón "de detalle" pasa a acompañante, más al costado */}
+      <FrailejonHeroe pos={[2.6, alturaParamo(2.6, 1.4), 1.4]} reducedMotion={reducedMotion} />
       <FrailejonalInstanciado n={nFrailejones} />
       <Pajonal n={nPaja} />
       <CojinesMusgo n={nMusgo} />
+      <RomeroParamo n={nRomero} />
+
+      {/* chusque (bambú del páramo) en macollas en las faldas húmedas */}
+      <Chusque pos={[-5.4, alturaParamo(-5.4, 3.2), 3.2]} esc={1.1} seed={5} />
+      <Chusque pos={[4.6, alturaParamo(4.6, -3.4), -3.4]} esc={0.95} seed={13} />
+      {tier === 'alto' && <Chusque pos={[-6.8, alturaParamo(-6.8, -1.2), -1.2]} esc={1.0} seed={21} />}
+
+      {/* cardón (Puya) — la bromelia gigante del páramo, roseta espinosa + vara */}
+      <Cardon pos={[3.4, alturaParamo(3.4, 3.6), 3.6]} esc={1.0} vara seed={9} />
+      <Cardon pos={[-4.2, alturaParamo(-4.2, 5.2), 5.2]} esc={0.85} vara={false} seed={31} />
 
       {/* quenuas dispersas en las faldas; la niebla se les engancha */}
       <Quenua pos={[-8.2, alturaParamo(-8.2, -4.5), -4.5]} esc={1.25} />
@@ -738,7 +1056,7 @@ const CSS_PARAMO = `
 
 /* La copia didáctica: en calma, la invitación; en modo fábrica, cómo nace. */
 const COPY_CALMA =
-  'El páramo es la fábrica de agua. Toque el botón para ver de dónde nace el agua que baja a las veredas.';
+  'Este es el páramo, la fábrica de agua, y su guardián: el frailejón-maestro que enseña a cuidarlo. Toque el botón para ver de dónde nace el agua que baja a las veredas.';
 const COPY_FABRICA =
   'Los frailejones peinan la niebla con sus hojas velludas; el musgo y la turba la guardan como una esponja. Del hondón, gota a gota, nace el agua. Por eso el páramo se cuida: si se seca, se seca el río.';
 
@@ -798,7 +1116,7 @@ export default function MundoParamo3D() {
       <div className="paramo-chrome">
         <h2 className="paramo-titulo">
           El páramo: la fábrica de agua
-          <small>Bosque altoandino de niebla — frailejones, musgo y el nacimiento del agua</small>
+          <small>El frailejón-maestro, el frailejonal, el chusque y el nacimiento del agua</small>
         </h2>
         <div className="paramo-pie">
           <button

--- a/src/visual/mundo3d/bosque/DoselBiodiverso.jsx
+++ b/src/visual/mundo3d/bosque/DoselBiodiverso.jsx
@@ -1,0 +1,143 @@
+/*
+ * DoselBiodiverso — la CAPA de dosel multiespecie del bosque andino colombiano.
+ *
+ * Monta el bosque VARIADO alrededor del claro del Ent: emergentes al fondo
+ * (guadua, nogal cafetero, cedro), el color del dosel florecido (cámbulo rojo,
+ * gualanday morado, siete cueros magenta), el sotobosque de niebla (helecho
+ * arbóreo, heliconia) y las epífitas (quiche) al pie de todo. Con esto el claro
+ * deja de ser "un árbol solo" y se lee como un BOSQUE de tres estratos.
+ *
+ * Tier-safe (idéntico a FloraParamo): cada especie es UN InstancedMesh de una
+ * geometría fusionada con color horneado → una draw-call por especie. La flora
+ * es PAISAJE: monta QUIETA (el foco animado es el Ent y la fauna). Todo
+ * procedural: cero CDN/imágenes.
+ *
+ * Componente r3f: montar dentro del <Canvas> de EscenaBosqueVivo.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import {
+  doselDeTier,
+  calidadDosel,
+  distribucionDosel,
+  geomGuadua,
+  geomNogal,
+  geomCedro,
+  geomCambulo,
+  geomGualanday,
+  geomSieteCueros,
+  geomHelecho,
+  geomHeliconia,
+  geomQuiche,
+} from './doselBiodiverso.geom.js';
+
+/* Un banco de matas de UNA especie: una geometría, un material, N instancias.
+   (Mismo patrón que FloraParamo/Especie — tint por instancia, pose sobre el
+   relieve, sin animación.) */
+function Especie({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+    />
+  );
+}
+
+/**
+ * La capa de dosel biodiverso del bosque. Montar dentro del <Canvas>.
+ * `alturaDe(x,z)` POSA cada mata sobre el relieve del terreno.
+ * @param {{tier?: 'alto'|'medio'|'bajo', alturaDe?: ((x:number,z:number)=>number)|null}} props
+ */
+export default function DoselBiodiverso({ tier = 'alto', alturaDe = null }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = doselDeTier(tier);
+  const q = calidadDosel(tier);
+
+  // Geometrías fusionadas (una vez por tier). Solo lo que tenga matas.
+  const geos = useMemo(() => {
+    const g = {};
+    if (conteos.guadua) g.guadua = geomGuadua({ q }, 2);
+    if (conteos.nogal) g.nogal = geomNogal({ q }, 3);
+    if (conteos.cedro) g.cedro = geomCedro({ q }, 4);
+    if (conteos.cambulo) g.cambulo = geomCambulo({ q }, 5);
+    if (conteos.gualanday) g.gualanday = geomGualanday({ q }, 6);
+    if (conteos.sieteCueros) g.sieteCueros = geomSieteCueros({ q }, 7);
+    if (conteos.helecho) g.helecho = geomHelecho({ q }, 8);
+    if (conteos.heliconia) g.heliconia = geomHeliconia({ q }, 9);
+    if (conteos.quiche) g.quiche = geomQuiche({ q }, 10);
+    return g;
+  }, [conteos, q]);
+
+  // Material único con vertexColors (cada geometría trae su color horneado).
+  const mat = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.9, metalness: 0.0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  // Distribución por estratos, posada en el relieve.
+  const dist = useMemo(() => {
+    const d = distribucionDosel(conteos, 909);
+    if (!alturaDe) return d;
+    const posar = (items) => items.map((it) => ({
+      ...it,
+      pos: [it.pos[0], alturaDe(it.pos[0], it.pos[2]) + (it.pos[1] || 0), it.pos[2]],
+    }));
+    return Object.fromEntries(Object.entries(d).map(([k, v]) => [k, posar(v)]));
+  }, [conteos, alturaDe]);
+
+  useLayoutEffect(() => () => {
+    Object.values(geos).forEach((gg) => gg && gg.dispose());
+    mat.dispose();
+  }, [geos, mat]);
+
+  const sombra = perfil.sombras;
+
+  return (
+    <group>
+      {/* Epífitas y sotobosque primero (cerca del claro). */}
+      <Especie geo={geos.quiche} mat={mat} items={dist.quiche} />
+      <Especie geo={geos.heliconia} mat={mat} items={dist.heliconia} />
+      <Especie geo={geos.helecho} mat={mat} items={dist.helecho} />
+
+      {/* Dosel florecido (el color, anillo medio). */}
+      <Especie geo={geos.sieteCueros} mat={mat} items={dist.sieteCueros} castShadow={sombra} />
+      <Especie geo={geos.cambulo} mat={mat} items={dist.cambulo} castShadow={sombra} />
+      <Especie geo={geos.gualanday} mat={mat} items={dist.gualanday} castShadow={sombra} />
+
+      {/* Emergentes (la pared verde del fondo). */}
+      <Especie geo={geos.cedro} mat={mat} items={dist.cedro} castShadow={sombra} />
+      <Especie geo={geos.nogal} mat={mat} items={dist.nogal} castShadow={sombra} />
+      <Especie geo={geos.guadua} mat={mat} items={dist.guadua} castShadow={sombra} />
+    </group>
+  );
+}

--- a/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
+++ b/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
@@ -37,6 +37,7 @@ import { SombraContacto } from '../escenas/SombraContacto.jsx';
 import SueloRico from '../terreno/SueloRico.jsx';
 import EntQuenua from './EntQuenua.jsx';
 import FloraParamo from './FloraParamo.jsx';
+import DoselBiodiverso from './DoselBiodiverso.jsx';
 import FaunaBosque from './FaunaBosque.jsx';
 import {
   alturaBosque,
@@ -627,6 +628,13 @@ function Diorama({ tier, reducedMotion, pose }) {
       {/* El ECOSISTEMA de páramo (frailejonar, sotobosque, árboles vecinos),
           POSADO sobre el relieve con alturaDe. */}
       <FloraParamo tier={tier} reducedMotion={reducedMotion} alturaDe={alturaBosque} />
+
+      {/* EL DOSEL BIODIVERSO: la variedad andina/subandina colombiana que
+          TRIPLICA los árboles — emergentes (guadua, nogal cafetero, cedro),
+          dosel florecido (cámbulo rojo, gualanday morado, siete cueros magenta),
+          sotobosque (helecho arbóreo, heliconia) y epífitas (quiche). Con esto
+          el claro se lee como BOSQUE de tres estratos, no un árbol solo. */}
+      <DoselBiodiverso tier={tier} alturaDe={alturaBosque} />
 
       {/* LA VIDA: cóndor, vecinos rubber-hose, mariposas, luciérnagas. */}
       <FaunaBosque tier={tier} reducedMotion={reducedMotion} />

--- a/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
+++ b/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
@@ -314,8 +314,8 @@ const AZ_CAMARA = 0.61;
 const ANCLAS_VECINOS = [[-3.7, 3.0], [3.1, 3.2], [-4.9, 4.4], [3.0, 2.1]];
 
 const CUPO_QUENUAL = {
-  alto: { cerca: 7, lejos: 9 },
-  medio: { cerca: 5, lejos: 5 },
+  alto: { cerca: 8, lejos: 12 },
+  medio: { cerca: 5, lejos: 6 },
   bajo: { cerca: 3, lejos: 0 },
 };
 

--- a/src/visual/mundo3d/bosque/doselBiodiverso.geom.js
+++ b/src/visual/mundo3d/bosque/doselBiodiverso.geom.js
@@ -1,0 +1,709 @@
+/*
+ * doselBiodiverso.geom — el DOSEL MULTIESPECIE del bosque andino/subandino
+ * colombiano. La capa que convierte el claro del Ent en un BOSQUE de verdad:
+ * triplica los árboles y mete VARIEDAD real —cada especie con su silueta y su
+ * color inequívocos, por piso térmico— para que nada se lea a monocultivo.
+ *
+ * Especies (todas reales de Colombia, ordenadas por estrato del bosque):
+ *
+ *   DOSEL / EMERGENTES (la pared verde del fondo)
+ *   · Guadua (Guadua angustifolia) — la caña brava: culmos altos anillados
+ *     verde-dorados en macolla, penacho plumoso arriba. La silueta más nuestra.
+ *   · Nogal cafetero (Cordia alliodora) — fuste recto y limpio, ramas en piso
+ *     (verticilos) y copa clara: el árbol de sombrío y madera del cafetal.
+ *   · Cedro (Cedrela odorata) — bole recto y copa ancha y aparasolada.
+ *
+ *   DOSEL FLORECIDO (el color que rompe el verde)
+ *   · Cámbulo / búcaro (Erythrina fusca) — copa abierta encendida en ROJO-naranja.
+ *   · Gualanday (Jacaranda caucana) — nube MORADA-lila sobre fuste gris.
+ *   · Siete cueros (Tibouchina lepidota) — arbolito andino de flor MAGENTA.
+ *
+ *   SOTOBOSQUE (la penumbra viva bajo el dosel)
+ *   · Helecho arbóreo (Cyathea) — el ícono del bosque de niebla: fuste fibroso
+ *     y corona de frondas arqueadas.
+ *   · Heliconia / platanillo (Heliconia) — remos anchos y la bráctea ROJA.
+ *
+ *   EPÍFITAS (la vida colgada, la firma del bosque húmedo)
+ *   · Quiche / bromelia (Tillandsia/Guzmania) — rosetas que viven SOBRE el suelo
+ *     y en tocones: manchas de color en la penumbra.
+ *
+ * TÉCNICA (idéntica a floraParamo/queñual, tier-safe): cada especie se FUSIONA
+ * en UNA geometría con color horneado (vertexColors) y se dibuja con UN
+ * InstancedMesh → una draw-call por banco por más matas que haya. Todo pasa por
+ * el TALLER compartido `sombreadoVegetal` (fusionarSeguro es la única fusión;
+ * copas = masa de hojas con huecos y normales radiales, nada de icosaedros
+ * literales). Cero assets: procedural y determinista, corre headless.
+ *
+ * El componente r3f (`DoselBiodiverso.jsx`) instancia, ubica sobre el relieve
+ * (alturaDe) y le pone luz. Aquí viven SOLO los datos y las mallas.
+ */
+import * as THREE from 'three';
+import {
+  rng,
+  fusionarSeguro,
+  poner,
+  apuntar,
+  pintarPlano,
+  pintarPorVertice,
+  hornearFollaje,
+  hornearCorteza,
+  tuboOrganico,
+  taperTronco,
+  taperLineal,
+  curvaTronco,
+  sembrarFollaje,
+  matojoNube,
+} from './sombreadoVegetal.js';
+
+/* -------------------------------------------------------------------------- */
+/*  Presupuesto por tier (instancias, no draw-calls)                           */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * 'alto' arma un bosque pleno de tres estratos; 'medio' lo raciona; 'bajo' deja
+ * lo justo para que AÚN lea "bosque variado" (unos emergentes, algo de color,
+ * unos helechos). Junto al queñual y la FloraParamo, esto TRIPLICA los árboles.
+ */
+export const DOSEL_TIER = {
+  alto: {
+    guadua: 9, nogal: 6, cedro: 5,
+    cambulo: 4, gualanday: 4, sieteCueros: 6,
+    helecho: 14, heliconia: 16, quiche: 20,
+  },
+  medio: {
+    guadua: 5, nogal: 3, cedro: 3,
+    cambulo: 2, gualanday: 2, sieteCueros: 3,
+    helecho: 7, heliconia: 8, quiche: 10,
+  },
+  bajo: {
+    guadua: 3, nogal: 2, cedro: 1,
+    cambulo: 1, gualanday: 1, sieteCueros: 1,
+    helecho: 3, heliconia: 3, quiche: 4,
+  },
+};
+export const doselDeTier = (tier) => DOSEL_TIER[tier] || DOSEL_TIER.medio;
+
+export const CALIDAD_DOSEL = { alto: 1, medio: 0.62, bajo: 0.42 };
+export const calidadDosel = (tier) => CALIDAD_DOSEL[tier] ?? CALIDAD_DOSEL.medio;
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta (colores horneados en vertexColors)                                 */
+/* -------------------------------------------------------------------------- */
+
+const PB = {
+  // Guadua — caña verde-dorada anillada
+  guaduaCana: '#9caf57',
+  guaduaCanaSol: '#c4c968',
+  guaduaNudo: '#6f7d3c',
+  guaduaHojaBase: '#3c5a34',
+  guaduaHojaSol: '#78994c',
+  guaduaHojaLuz: '#c6d585',
+
+  // Nogal cafetero — fuste claro, copa fresca
+  nogalTronco: '#8a7f68',
+  nogalGrieta: '#5c5240',
+  nogalCresta: '#a89a7e',
+  nogalHoja: '#3f5a37',
+  nogalHojaSol: '#6f9150',
+  nogalHojaLuz: '#bccf80',
+  nogalFlor: '#e6e3cf', // panículas blanco-crema
+
+  // Cedro — bole recto, copa ancha
+  cedroTronco: '#736150',
+  cedroGrieta: '#463a2c',
+  cedroCresta: '#8f7a62',
+  cedroHoja: '#40563a',
+  cedroHojaSol: '#688a4c',
+  cedroHojaLuz: '#aec27a',
+
+  // Cámbulo — copa encendida ROJO-naranja
+  cambuloTronco: '#7c6a54',
+  cambuloGrieta: '#4d4030',
+  cambuloCresta: '#98846a',
+  cambuloHoja: '#41603d',
+  cambuloHojaSol: '#6a9150',
+  cambuloHojaLuz: '#b6cd7c',
+  cambuloFlor: '#d94a2b', // rojo-bermellón
+  cambuloFlor2: '#e8722f', // naranja de borde
+
+  // Gualanday — nube MORADA-lila
+  gualandayTronco: '#8c8577',
+  gualandayGrieta: '#5f594c',
+  gualandayCresta: '#a49c8c',
+  gualandayHoja: '#4b6144',
+  gualandayHojaSol: '#6f8c56',
+  gualandayFlor: '#7a5ab0', // lila-morado
+  gualandayFlor2: '#9a7fce', // lila claro
+
+  // Siete cueros — flor MAGENTA
+  sieteTronco: '#6f5a48',
+  sieteGrieta: '#463628',
+  sieteCresta: '#8a725c',
+  sieteHoja: '#3c5636',
+  sieteHojaSol: '#5f8148',
+  sieteHojaLuz: '#a6bf74',
+  sieteFlor: '#b0348a', // magenta-violeta
+  sieteFlor2: '#cf5fa9',
+
+  // Helecho arbóreo — fuste fibroso + frondas
+  helechoTronco: '#5a4a38',
+  helechoTronco2: '#463a2b',
+  helechoFronda: '#3f5e35',
+  helechoFrondaSol: '#6f9448',
+  helechoFrondaLuz: '#bcd082',
+
+  // Heliconia — remos + bráctea roja
+  heliconiaHoja: '#3f6238',
+  heliconiaHojaSol: '#63924a',
+  heliconiaHojaLuz: '#b2cd7a',
+  heliconiaBractea: '#d63f2c', // bráctea roja
+  heliconiaBractea2: '#e8a52f', // punta amarilla
+
+  // Quiche / bromelia — rosetas epífitas de color
+  quicheHoja: '#5a7b45',
+  quicheHojaSol: '#83a656',
+  quicheCentro: '#c34a3a', // el corazón encendido (rojo/coral)
+  quicheCentro2: '#dc7a3f',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Utilidades locales (compactas, autocontenidas)                             */
+/* -------------------------------------------------------------------------- */
+
+const pintar = pintarPlano;
+const fusionar = (partes, etiqueta = 'dosel') =>
+  fusionarSeguro(partes, etiqueta, { preservarNormales: true });
+
+function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
+}
+
+/* Tronco orgánico horneado (curva + tubo cónico arrugado + corteza). */
+function troncoHorneado(
+  { H, r0, r1, inclina = 0.08, sinuoso = 0.08, giro = 0, arruga = 0.14, raigon = 0.42, q = 1, corteza, hastaLiquen = 0.4, liquen = '#9aa86a' },
+  seed,
+) {
+  const curva = curvaTronco({ altura: H, inclina, sinuoso, giro }, seed);
+  const geo = tuboOrganico(curva, {
+    tubular: Math.max(8, Math.round(15 * q)),
+    radial: Math.max(6, Math.round(8 * q)),
+    taper: taperTronco(r0, r1, raigon),
+    arruga,
+    semilla: seed * 3.1,
+  });
+  hornearCorteza(geo, {
+    grieta: corteza.grieta,
+    cuerpo: corteza.cuerpo,
+    cresta: corteza.cresta,
+    liquen,
+    escalaGrano: corteza.escalaGrano ?? 4.2,
+    hastaLiquen,
+  });
+  return { geo, curva };
+}
+
+/* Copa-masa: la técnica del queñual (matojos-nube con huecos + horneado). */
+function copaMasa(lobulos, o) {
+  const { base, sol, luz, q = 1, seed = 1, achatado = 0.76, huecos = 0.42, mordida = 0.36, ao = 0.63, manchas = 0.14, densidad = 10 } = o;
+  const copas = [];
+  for (let i = 0; i < lobulos.length; i++) {
+    const lb = lobulos[i];
+    const puntos = sembrarFollaje({
+      centro: lb.c,
+      radio: lb.radio,
+      achatado,
+      n: Math.max(4, Math.round(densidad * q * lb.radio)),
+      semilla: seed * 13 + i * 3,
+      huecos,
+      mordida,
+      distMin: 0.3 * lb.radio,
+    });
+    const matojos = puntos.map((p, k) => {
+      const m = matojoNube((0.27 + 0.16 * p.esc) * lb.radio, seed * 17 + i * 5 + k, 0.5);
+      poner(m, p.pos, p.giro, [1, 0.82, 1]);
+      return m;
+    });
+    if (!matojos.length) {
+      const m = matojoNube(lb.radio * 0.7, seed * 17 + i * 5, 0.5);
+      poner(m, lb.c, [0, 0, 0], [1, 0.82, 1]);
+      matojos.push(m);
+    }
+    const copa = fusionar(matojos, 'copa-masa');
+    hornearFollaje(copa, { base, sol, luz, centro: lb.c, radio: lb.radio * 1.2, ao, manchas });
+    copas.push(copa);
+  }
+  return copas;
+}
+
+/* Puñado de FLOR: matojos-nube pequeños teñidos plano (rojo/morado/magenta),
+   sembrados en la piel de la copa para que el color asome sobre el verde. */
+function floresEnCopa(lobulos, o) {
+  const { colorA, colorB, q = 1, seed = 5, densidad = 5, escala = 0.5 } = o;
+  const r = rng(seed * 2.7);
+  const partes = [];
+  for (let i = 0; i < lobulos.length; i++) {
+    const lb = lobulos[i];
+    const puntos = sembrarFollaje({
+      centro: lb.c,
+      radio: lb.radio * 0.98,
+      achatado: 0.7,
+      n: Math.max(2, Math.round(densidad * q * lb.radio)),
+      semilla: seed * 19 + i * 7,
+      huecos: 0.2,
+      mordida: 0.3,
+      distMin: 0.42 * lb.radio,
+    });
+    for (const p of puntos) {
+      const m = matojoNube(escala * (0.22 + 0.14 * p.esc) * lb.radio, seed * 23 + i * 11, 0.42);
+      poner(m, [p.pos[0], p.pos[1] + lb.radio * 0.12, p.pos[2]], p.giro, [1, 0.85, 1]);
+      partes.push(pintar(m, r() > 0.5 ? variar(colorA, r, 0.12) : variar(colorB, r, 0.12)));
+    }
+  }
+  return partes;
+}
+
+/* Una hoja lanceolada carnosa (elipsoide) que nace en su base y se orienta. */
+function hojaLanza(ancho, largo, grosor, wSeg = 5, hSeg = 3) {
+  const g = new THREE.SphereGeometry(1, wSeg, hSeg);
+  poner(g, [0, largo / 2, 0], [0, 0, 0], [ancho, largo / 2, grosor]);
+  return g;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  GUADUA (Guadua angustifolia) — la caña brava, la firma de Colombia         */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Una MACOLLA de guadua: varios culmos altos, rectos y anillados (nudos) que
+ * abren apenas en abanico, verde-dorados, rematados en un penacho de hoja fina.
+ * Cero copa-globo: la guadua es vertical y plumosa. Un banco = una macolla.
+ */
+export function geomGuadua({ q = 1 } = {}, seed = 2) {
+  const r = rng(seed);
+  const partes = [];
+  const nCulmos = Math.max(3, Math.round(6 * q));
+  for (let c = 0; c < nCulmos; c++) {
+    const H = 3.6 + r() * 2.6;
+    const giro = r() * Math.PI * 2;
+    const rad = 0.15 + r() * 0.55; // separación en la macolla
+    const off = [Math.cos(giro) * rad, 0, Math.sin(giro) * rad];
+    const curva = curvaTronco({ altura: H, inclina: 0.04 + r() * 0.06, sinuoso: 0.03, giro }, seed + c);
+    const culmo = tuboOrganico(curva, {
+      tubular: Math.max(9, Math.round(16 * q)),
+      radial: Math.max(5, Math.round(6 * q)),
+      taper: taperLineal(0.075 + r() * 0.02, 0.03),
+      arruga: 0.05,
+      semilla: seed + c * 2,
+    });
+    poner(culmo, off);
+    // Color de la caña: verde-dorado con NUDOS oscuros marcados por bandas Y.
+    const cana = new THREE.Color(PB.guaduaCana);
+    const canaSol = new THREE.Color(PB.guaduaCanaSol);
+    const nudo = new THREE.Color(PB.guaduaNudo);
+    const tmp = new THREE.Color();
+    pintarPorVertice(culmo, (x, y) => {
+      const t = Math.min(1, Math.max(0, y / H));
+      tmp.copy(cana).lerp(canaSol, t * 0.7);
+      // nudos: anillos oscuros cada ~0.55 de altura
+      const band = Math.abs(((y / 0.55) % 1) - 0.5);
+      if (band > 0.42) tmp.lerp(nudo, (band - 0.42) / 0.08 * 0.8);
+      return tmp;
+    });
+    partes.push(culmo);
+
+    // Penacho de hoja fina en el tercio superior (conos planos apuntando afuera).
+    const punta = curva.getPointAt(1);
+    const nHoja = Math.max(3, Math.round(6 * q));
+    for (let i = 0; i < nHoja; i++) {
+      const t = 0.62 + r() * 0.35;
+      const p = curva.getPointAt(t);
+      const ang = r() * Math.PI * 2;
+      const largo = 0.45 + r() * 0.4;
+      const hoja = new THREE.ConeGeometry(0.06, largo, 4, 1);
+      apuntar(
+        hoja,
+        [off[0] + p.x + Math.cos(ang) * 0.12, p.y + 0.05, off[2] + p.z + Math.sin(ang) * 0.12],
+        [Math.cos(ang) * 0.8, 0.5 + r() * 0.5, Math.sin(ang) * 0.8],
+        [1, 1, 0.5],
+      );
+      const cc = new THREE.Color(PB.guaduaHojaBase).lerp(new THREE.Color(PB.guaduaHojaSol), r());
+      partes.push(pintar(hoja, cc));
+    }
+    // remate plumoso en la punta
+    const pen = new THREE.ConeGeometry(0.16, 0.5 + r() * 0.3, 5, 1);
+    apuntar(pen, [off[0] + punta.x, punta.y + 0.2, off[2] + punta.z], [0.1, 1, 0.1], [1, 1, 0.6]);
+    partes.push(pintar(pen, variar(PB.guaduaHojaLuz, r, 0.1)));
+  }
+  return fusionar(partes, 'guadua');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  NOGAL CAFETERO (Cordia alliodora) — sombrío y madera del cafetal           */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Fuste RECTO y limpio, ramas en pisos (verticilos), copa clara y aireada con
+ * panículas blanco-crema. El árbol alto y ordenado del sombrío de café.
+ */
+export function geomNogal({ q = 1 } = {}, seed = 3) {
+  const r = rng(seed);
+  const partes = [];
+  const H = 4.2 + r() * 0.8;
+  const { geo, curva } = troncoHorneado(
+    { H, r0: 0.16, r1: 0.06, inclina: 0.03, sinuoso: 0.05, giro: r() * 6, arruga: 0.1, raigon: 0.4, q, hastaLiquen: 0.5,
+      corteza: { grieta: PB.nogalGrieta, cuerpo: PB.nogalTronco, cresta: PB.nogalCresta, escalaGrano: 3.6 } },
+    seed + 1,
+  );
+  partes.push(geo);
+  const top = curva.getPointAt(1);
+
+  // Ramas en dos pisos (verticilos) que abren la copa.
+  const lobs = [{ c: [top.x, top.y + 0.5, top.z], radio: 0.82 }];
+  for (let piso = 0; piso < 2; piso++) {
+    const yr = H - 0.9 - piso * 0.85;
+    const p = curva.getPointAt(Math.max(0, (yr / H)));
+    const nR = Math.max(3, Math.round((4 - piso) * q));
+    for (let i = 0; i < nR; i++) {
+      const ang = (i / nR) * Math.PI * 2 + piso * 0.7 + r() * 0.3;
+      const largo = 0.85 + r() * 0.35;
+      const rama = new THREE.CylinderGeometry(0.03, 0.055, largo, 5, 1);
+      apuntar(rama, [p.x + Math.cos(ang) * 0.2, p.y + 0.1, p.z + Math.sin(ang) * 0.2], [Math.cos(ang), 0.35, Math.sin(ang)]);
+      partes.push(pintar(rama, PB.nogalCresta));
+      lobs.push({ c: [Math.cos(ang) * (largo + 0.2), yr + 0.35 + r() * 0.3, Math.sin(ang) * (largo + 0.2)], radio: 0.5 + r() * 0.28 });
+    }
+  }
+  copaMasa(lobs, { base: PB.nogalHoja, sol: PB.nogalHojaSol, luz: PB.nogalHojaLuz, q, seed: seed + 7, achatado: 0.72, huecos: 0.5, mordida: 0.42, ao: 0.6 }).forEach((cc) => partes.push(cc));
+
+  // Panículas crema salpicadas (flor del nogal).
+  if (q > 0.5) {
+    for (const lb of lobs) {
+      const nF = Math.max(1, Math.round(3 * q));
+      for (let i = 0; i < nF; i++) {
+        const ang = r() * Math.PI * 2;
+        const rr = lb.radio * (0.5 + r() * 0.5);
+        const puff = matojoNube(0.1 + r() * 0.06, seed * 31 + i, 0.4);
+        poner(puff, [lb.c[0] + Math.cos(ang) * rr, lb.c[1] + lb.radio * 0.2, lb.c[2] + Math.sin(ang) * rr]);
+        partes.push(pintar(puff, variar(PB.nogalFlor, r, 0.06)));
+      }
+    }
+  }
+  return fusionar(partes, 'nogal');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  CEDRO (Cedrela odorata) — bole recto, copa ancha aparasolada               */
+/* -------------------------------------------------------------------------- */
+
+export function geomCedro({ q = 1 } = {}, seed = 4) {
+  const r = rng(seed);
+  const partes = [];
+  const H = 3.6 + r() * 0.7;
+  const { geo, curva } = troncoHorneado(
+    { H, r0: 0.2, r1: 0.08, inclina: 0.04, sinuoso: 0.06, giro: r() * 6, arruga: 0.16, raigon: 0.55, q, hastaLiquen: 0.6,
+      corteza: { grieta: PB.cedroGrieta, cuerpo: PB.cedroTronco, cresta: PB.cedroCresta, escalaGrano: 4.6 } },
+    seed + 1,
+  );
+  partes.push(geo);
+  const top = curva.getPointAt(1);
+
+  // Copa ANCHA aparasolada: domo aplanado + lóbulos horizontales.
+  const lobs = [{ c: [top.x, top.y + 0.35, top.z], radio: 1.05 }];
+  const nL = Math.max(4, Math.round(6 * q));
+  for (let i = 0; i < nL; i++) {
+    const ang = (i / nL) * Math.PI * 2 + r() * 0.5;
+    const rad = 0.85 + r() * 0.5;
+    const rama = new THREE.CylinderGeometry(0.04, 0.07, rad + 0.2, 5, 1);
+    apuntar(rama, [top.x + Math.cos(ang) * 0.2, H - 0.4, top.z + Math.sin(ang) * 0.2], [Math.cos(ang), 0.18, Math.sin(ang)]);
+    partes.push(pintar(rama, PB.cedroCresta));
+    lobs.push({ c: [Math.cos(ang) * rad, H + 0.0 + r() * 0.4, Math.sin(ang) * rad], radio: 0.62 + r() * 0.3 });
+  }
+  copaMasa(lobs, { base: PB.cedroHoja, sol: PB.cedroHojaSol, luz: PB.cedroHojaLuz, q, seed: seed + 9, achatado: 0.62, huecos: 0.46, mordida: 0.4, ao: 0.64 }).forEach((cc) => partes.push(cc));
+  return fusionar(partes, 'cedro');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  CÁMBULO (Erythrina) — la copa encendida en ROJO-naranja                     */
+/* -------------------------------------------------------------------------- */
+
+export function geomCambulo({ q = 1 } = {}, seed = 5) {
+  const r = rng(seed);
+  const partes = [];
+  const H = 3.0 + r() * 0.6;
+  const { geo, curva } = troncoHorneado(
+    { H, r0: 0.18, r1: 0.08, inclina: 0.09, sinuoso: 0.12, giro: r() * 6, arruga: 0.16, raigon: 0.45, q,
+      corteza: { grieta: PB.cambuloGrieta, cuerpo: PB.cambuloTronco, cresta: PB.cambuloCresta, escalaGrano: 4.2 } },
+    seed + 1,
+  );
+  partes.push(geo);
+  const top = curva.getPointAt(1);
+  // Copa ABIERTA (ramas que suben-abren) + flores rojas.
+  const lobs = [{ c: [top.x, top.y + 0.4, top.z], radio: 0.78 }];
+  const nL = Math.max(3, Math.round(5 * q));
+  for (let i = 0; i < nL; i++) {
+    const ang = (i / nL) * Math.PI * 2 + r() * 0.5;
+    const rad = 0.7 + r() * 0.5;
+    const rama = new THREE.CylinderGeometry(0.035, 0.06, rad + 0.3, 5, 1);
+    apuntar(rama, [top.x + Math.cos(ang) * 0.15, H - 0.5, top.z + Math.sin(ang) * 0.15], [Math.cos(ang), 0.7, Math.sin(ang)]);
+    partes.push(pintar(rama, PB.cambuloCresta));
+    lobs.push({ c: [Math.cos(ang) * rad, H + 0.3 + r() * 0.4, Math.sin(ang) * rad], radio: 0.5 + r() * 0.26 });
+  }
+  copaMasa(lobs, { base: PB.cambuloHoja, sol: PB.cambuloHojaSol, luz: PB.cambuloHojaLuz, q, seed: seed + 7, achatado: 0.72, huecos: 0.5, mordida: 0.44, ao: 0.6 }).forEach((cc) => partes.push(cc));
+  floresEnCopa(lobs, { colorA: PB.cambuloFlor, colorB: PB.cambuloFlor2, q, seed: seed + 3, densidad: 6, escala: 0.55 }).forEach((f) => partes.push(f));
+  return fusionar(partes, 'cambulo');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  GUALANDAY (Jacaranda) — la nube MORADA-lila                                 */
+/* -------------------------------------------------------------------------- */
+
+export function geomGualanday({ q = 1 } = {}, seed = 6) {
+  const r = rng(seed);
+  const partes = [];
+  const H = 3.2 + r() * 0.6;
+  const { geo, curva } = troncoHorneado(
+    { H, r0: 0.15, r1: 0.06, inclina: 0.06, sinuoso: 0.09, giro: r() * 6, arruga: 0.1, raigon: 0.4, q, hastaLiquen: 0.5,
+      corteza: { grieta: PB.gualandayGrieta, cuerpo: PB.gualandayTronco, cresta: PB.gualandayCresta, escalaGrano: 3.4 } },
+    seed + 1,
+  );
+  partes.push(geo);
+  const top = curva.getPointAt(1);
+  const lobs = [{ c: [top.x, top.y + 0.45, top.z], radio: 0.85 }];
+  const nL = Math.max(3, Math.round(5 * q));
+  for (let i = 0; i < nL; i++) {
+    const ang = (i / nL) * Math.PI * 2 + r() * 0.6;
+    const rad = 0.65 + r() * 0.45;
+    lobs.push({ c: [Math.cos(ang) * rad, H + 0.15 + r() * 0.5, Math.sin(ang) * rad], radio: 0.52 + r() * 0.28 });
+  }
+  // La copa lleva MENOS verde y MÁS flor (Jacaranda florece casi sin hoja).
+  copaMasa(lobs, { base: PB.gualandayHoja, sol: PB.gualandayHojaSol, luz: PB.gualandayFlor2, q, seed: seed + 7, achatado: 0.74, huecos: 0.56, mordida: 0.44, ao: 0.58 }).forEach((cc) => partes.push(cc));
+  floresEnCopa(lobs, { colorA: PB.gualandayFlor, colorB: PB.gualandayFlor2, q, seed: seed + 4, densidad: 8, escala: 0.66 }).forEach((f) => partes.push(f));
+  return fusionar(partes, 'gualanday');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  SIETE CUEROS (Tibouchina lepidota) — arbolito andino de flor MAGENTA        */
+/* -------------------------------------------------------------------------- */
+
+export function geomSieteCueros({ q = 1 } = {}, seed = 7) {
+  const r = rng(seed);
+  const partes = [];
+  const H = 2.1 + r() * 0.5;
+  const { geo, curva } = troncoHorneado(
+    { H, r0: 0.1, r1: 0.045, inclina: 0.12, sinuoso: 0.14, giro: r() * 6, arruga: 0.18, raigon: 0.35, q, hastaLiquen: 0.7, liquen: PB.sieteCresta,
+      corteza: { grieta: PB.sieteGrieta, cuerpo: PB.sieteTronco, cresta: PB.sieteCresta, escalaGrano: 4.8 } },
+    seed + 1,
+  );
+  partes.push(geo);
+  const top = curva.getPointAt(1);
+  const lobs = [{ c: [top.x, top.y + 0.3, top.z], radio: 0.6 }];
+  const nL = Math.max(2, Math.round(3 * q));
+  for (let i = 0; i < nL; i++) {
+    const ang = (i / nL) * Math.PI * 2 + r() * 0.7;
+    const rad = 0.4 + r() * 0.35;
+    lobs.push({ c: [Math.cos(ang) * rad, H + 0.05 + r() * 0.35, Math.sin(ang) * rad], radio: 0.4 + r() * 0.22 });
+  }
+  copaMasa(lobs, { base: PB.sieteHoja, sol: PB.sieteHojaSol, luz: PB.sieteHojaLuz, q, seed: seed + 7, achatado: 0.78, huecos: 0.44, mordida: 0.4, ao: 0.62 }).forEach((cc) => partes.push(cc));
+  floresEnCopa(lobs, { colorA: PB.sieteFlor, colorB: PB.sieteFlor2, q, seed: seed + 5, densidad: 7, escala: 0.5 }).forEach((f) => partes.push(f));
+  return fusionar(partes, 'siete-cueros');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  HELECHO ARBÓREO (Cyathea) — el ícono del sotobosque de niebla               */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Fuste fibroso esbelto rematado por una CORONA de frondas arqueadas (planos
+ * alargados que caen en abanico). La silueta más de bosque de niebla que hay.
+ */
+export function geomHelecho({ q = 1 } = {}, seed = 8) {
+  const r = rng(seed);
+  const partes = [];
+  const H = 1.5 + r() * 0.9;
+  // Fuste fibroso: cilindro cónico arrugado, oscuro.
+  const curva = curvaTronco({ altura: H, inclina: 0.05, sinuoso: 0.06, giro: r() * 6 }, seed + 1);
+  const fuste = tuboOrganico(curva, {
+    tubular: Math.max(7, Math.round(12 * q)),
+    radial: Math.max(5, Math.round(6 * q)),
+    taper: taperLineal(0.08, 0.05),
+    arruga: 0.22,
+    semilla: seed * 3,
+  });
+  const tmp = new THREE.Color();
+  const t1 = new THREE.Color(PB.helechoTronco);
+  const t2 = new THREE.Color(PB.helechoTronco2);
+  pintarPorVertice(fuste, (x, y, z) => tmp.copy(t1).lerp(t2, (Math.sin(x * 9 + z * 9 + y * 3) * 0.5 + 0.5) * 0.7));
+  partes.push(fuste);
+
+  // Corona de frondas: planos largos que arquean hacia afuera-abajo.
+  const top = curva.getPointAt(1);
+  const nF = Math.max(5, Math.round(9 * q));
+  for (let i = 0; i < nF; i++) {
+    const ang = (i / nF) * Math.PI * 2 + r() * 0.3;
+    const largo = 0.9 + r() * 0.6;
+    const fronda = new THREE.ConeGeometry(0.14, largo, 4, 1);
+    // arquea: apunta hacia afuera y algo arriba, luego cae (leve inclinación)
+    apuntar(
+      fronda,
+      [top.x + Math.cos(ang) * largo * 0.35, top.y + 0.12 + r() * 0.06, top.z + Math.sin(ang) * largo * 0.35],
+      [Math.cos(ang) * 0.9, 0.35 - r() * 0.3, Math.sin(ang) * 0.9],
+      [1, 1, 0.28],
+    );
+    const cc = new THREE.Color(PB.helechoFronda).lerp(new THREE.Color(PB.helechoFrondaSol), r());
+    partes.push(pintar(fronda, cc));
+  }
+  // cogollo tierno (crozier) más claro en el centro
+  const cogollo = matojoNube(0.16 + r() * 0.06, seed * 5, 0.4);
+  poner(cogollo, [top.x, top.y + 0.14, top.z]);
+  partes.push(pintar(cogollo, PB.helechoFrondaLuz));
+  return fusionar(partes, 'helecho');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  HELICONIA / PLATANILLO — remos anchos + bráctea ROJA                         */
+/* -------------------------------------------------------------------------- */
+
+export function geomHeliconia({ q = 1 } = {}, seed = 9) {
+  const r = rng(seed);
+  const partes = [];
+  const nHojas = Math.max(3, Math.round(5 * q));
+  // Remos: planos anchos alargados que salen de la base y se abren.
+  for (let i = 0; i < nHojas; i++) {
+    const ang = (i / nHojas) * Math.PI * 2 + r() * 0.4;
+    const H = 0.9 + r() * 0.7;
+    const remo = hojaLanza(0.16, H, 0.03, 5, 2);
+    apuntar(
+      remo,
+      [Math.cos(ang) * 0.06, 0.05, Math.sin(ang) * 0.06],
+      [Math.cos(ang) * 0.5, 1, Math.sin(ang) * 0.5],
+      [1, 1, 0.2],
+    );
+    const cc = new THREE.Color(PB.heliconiaHoja).lerp(new THREE.Color(PB.heliconiaHojaSol), r());
+    partes.push(pintar(remo, cc));
+  }
+  // La inflorescencia: zig-zag de brácteas rojas con punta amarilla.
+  const nB = Math.max(2, Math.round(4 * q));
+  const tallo = new THREE.CylinderGeometry(0.02, 0.03, 0.5, 5, 1);
+  poner(tallo, [0.04, 0.3, 0], [0, 0, 0.15]);
+  partes.push(pintar(tallo, PB.heliconiaHojaSol));
+  for (let i = 0; i < nB; i++) {
+    const y = 0.35 + i * 0.14;
+    const lado = i % 2 === 0 ? 1 : -1;
+    const bract = new THREE.ConeGeometry(0.06, 0.28, 4, 1);
+    apuntar(bract, [0.04 + lado * 0.05, y, lado * 0.03], [lado * 0.8, 0.4, 0.2], [1, 1, 0.5]);
+    partes.push(pintar(bract, i === nB - 1 ? PB.heliconiaBractea2 : variar(PB.heliconiaBractea, r, 0.08)));
+  }
+  return fusionar(partes, 'heliconia');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  QUICHE / BROMELIA (Tillandsia/Guzmania) — rosetas epífitas de color         */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Roseta de hojas duras que se abren en copa, con el CORAZÓN encendido
+ * (rojo/coral: la inflorescencia). Vive sobre el suelo, en tocones y horquetas.
+ */
+export function geomQuiche({ q = 1 } = {}, seed = 10) {
+  const r = rng(seed);
+  const partes = [];
+  const nHojas = Math.max(6, Math.round(10 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const ang = (i / nHojas) * Math.PI * 2 + r() * 0.2;
+    const inc = 0.5 + r() * 0.35;
+    const largo = 0.24 + r() * 0.14;
+    const hoja = hojaLanza(0.05, largo, 0.02, 4, 2);
+    apuntar(
+      hoja,
+      [Math.cos(ang) * 0.04, 0.02, Math.sin(ang) * 0.04],
+      [Math.cos(ang) * Math.sin(inc), Math.cos(inc), Math.sin(ang) * Math.sin(inc)],
+      [1, 1, 0.5],
+    );
+    const cc = new THREE.Color(PB.quicheHoja).lerp(new THREE.Color(PB.quicheHojaSol), r());
+    partes.push(pintar(hoja, cc));
+  }
+  // El corazón encendido: un cono corto rojo/coral al centro.
+  const centro = new THREE.ConeGeometry(0.06, 0.18, 6, 1);
+  poner(centro, [0, 0.12, 0]);
+  partes.push(pintar(centro, r() > 0.5 ? PB.quicheCentro : PB.quicheCentro2));
+  return fusionar(partes, 'quiche');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  DISTRIBUCIÓN — dónde crece cada estrato (el Ent en 0,0,0; la cámara orbita) */
+/* -------------------------------------------------------------------------- */
+
+/* El corredor de cámara (mira al Ent desde az≈0.61): los emergentes cercanos no
+   se plantan de frente para no tapar al guardián. */
+const AZ_CAM = 0.61;
+/* xArroyo aproximado (el hilo de agua baja por el flanco derecho, x≈4.7). */
+const xArroyoAprox = (z) => 4.7 + Math.sin(z * 0.24 + 1.3) * 1.5;
+
+function tinte(r, amt) {
+  const f = 1 + (r() - 0.5) * amt;
+  const h = (r() - 0.5) * amt * 0.4;
+  const cl = (v) => Math.max(0.72, Math.min(1.16, v));
+  return [cl(f + h), cl(f), cl(f - h * 0.6)];
+}
+
+/*
+ * Siembra en un anillo. `evitaFrente` deja libre el corredor de cámara (para
+ * emergentes altos); `evitaAgua` no pisa el arroyo. `agrupa` da ángulo aleatorio
+ * (sotobosque/epífitas = manchones); si no, reparto parejo (dosel de fondo).
+ */
+function sembrar(n, rMin, rMax, r, o = {}) {
+  const arr = [];
+  const eMin = o.eMin ?? 0.9;
+  const eMax = o.eMax ?? 1.15;
+  let intentos = 0;
+  while (arr.length < n && intentos++ < n * 20) {
+    const ang = o.agrupa
+      ? r() * Math.PI * 2
+      : (arr.length / Math.max(1, n)) * Math.PI * 2 + (r() - 0.5) * 0.8;
+    if (o.evitaFrente) {
+      const d = Math.atan2(Math.sin(ang - AZ_CAM), Math.cos(ang - AZ_CAM));
+      if (Math.abs(d) < 0.42) continue; // deja el encuadre del Ent libre
+    }
+    const rad = rMin + (rMax - rMin) * (o.haciaAfuera ? Math.sqrt(r()) : r());
+    const x = Math.cos(ang) * rad;
+    const z = Math.sin(ang) * rad;
+    if (o.evitaAgua && z > -13 && Math.abs(x - xArroyoAprox(z)) < 1.3) continue;
+    arr.push({
+      pos: [x, 0, z],
+      rotY: r() * Math.PI * 2,
+      escala: eMin + r() * (eMax - eMin),
+      tint: tinte(r, o.varia ?? 0.1),
+    });
+  }
+  return arr;
+}
+
+/**
+ * Todas las instancias del dosel biodiverso para unos conteos dados.
+ * Estratos:
+ *   · emergentes (guadua/nogal/cedro) → anillo LEJANO, reparto parejo: la pared
+ *     verde del fondo que hace ver hondo el bosque;
+ *   · florecidos (cámbulo/gualanday/siete cueros) → anillo medio, salpicados:
+ *     el color que rompe el verde;
+ *   · sotobosque (helecho/heliconia) → anillo interior-medio, agrupado;
+ *   · epífitas (quiche) → cerca del claro, agrupadas al pie de los árboles.
+ */
+export function distribucionDosel(conteos, seed = 909) {
+  const c = conteos;
+  return {
+    // Emergentes: pared del fondo, altos, reparto parejo, velados por niebla.
+    guadua: sembrar(c.guadua, 11, 22, rng(seed + 1), { eMin: 0.95, eMax: 1.35, varia: 0.08, evitaFrente: true, evitaAgua: true }),
+    nogal: sembrar(c.nogal, 12, 23, rng(seed + 2), { eMin: 0.95, eMax: 1.2, varia: 0.07, evitaFrente: true, evitaAgua: true }),
+    cedro: sembrar(c.cedro, 13, 24, rng(seed + 3), { eMin: 0.95, eMax: 1.2, varia: 0.08, evitaFrente: true, evitaAgua: true }),
+    // Dosel florecido: anillo medio, salpicado (color).
+    cambulo: sembrar(c.cambulo, 9, 18, rng(seed + 4), { eMin: 0.9, eMax: 1.15, varia: 0.08, evitaAgua: true }),
+    gualanday: sembrar(c.gualanday, 9, 18, rng(seed + 5), { eMin: 0.9, eMax: 1.15, varia: 0.08, evitaAgua: true }),
+    sieteCueros: sembrar(c.sieteCueros, 6, 15, rng(seed + 6), { eMin: 0.85, eMax: 1.2, varia: 0.1, agrupa: true, evitaAgua: true }),
+    // Sotobosque: interior-medio, agrupado (manchones).
+    helecho: sembrar(c.helecho, 5, 13, rng(seed + 7), { eMin: 0.8, eMax: 1.3, varia: 0.12, agrupa: true, evitaAgua: true }),
+    heliconia: sembrar(c.heliconia, 4.5, 12, rng(seed + 8), { eMin: 0.85, eMax: 1.25, varia: 0.12, agrupa: true, evitaAgua: true }),
+    // Epífitas: rosetas cerca del claro, agrupadas.
+    quiche: sembrar(c.quiche, 3.6, 11, rng(seed + 9), { eMin: 0.8, eMax: 1.4, varia: 0.12, agrupa: true }),
+  };
+}

--- a/src/visual/mundo3d/bosque/floraParamo.geom.js
+++ b/src/visual/mundo3d/bosque/floraParamo.geom.js
@@ -69,21 +69,30 @@ import {
  * frailejonal viene por EDADES (tres bancos + el que florece) para que el
  * paisaje tenga gradiente de edad, no clones.
  */
+/*
+ * NOTA (rediseño 2026-07-16, dos-mundos): el frailejón es la firma del PÁRAMO
+ * (mundo aparte). Aquí, en el BOSQUE andino/subandino de biodiversidad, queda
+ * solo como un ACENTO raro del filo alto (la transición hacia el páramo de
+ * arriba) — el grueso de la variedad lo llevan los árboles nativos (yarumo,
+ * roble, encenillo, aliso, gaque) MÁS el dosel multiespecie (DoselBiodiverso:
+ * guadua, nogal, cedro, cámbulo, gualanday, siete cueros, helecho, heliconia,
+ * quiche). Por eso se subieron los árboles y se bajaron los frailejones.
+ */
 export const FLORA_TIER = {
   alto: {
-    frailejonJoven: 12, frailejon: 14, frailejonViejo: 7, frailejonFlor: 5,
-    yarumo: 3, roble: 3, encenillo: 4,
-    aliso: 3, gaque: 2, mortino: 10, romerillo: 12, roca: 9, musgo: 12, niebla: 3,
+    frailejonJoven: 4, frailejon: 4, frailejonViejo: 2, frailejonFlor: 2,
+    yarumo: 5, roble: 5, encenillo: 6,
+    aliso: 5, gaque: 4, mortino: 14, romerillo: 14, roca: 9, musgo: 12, niebla: 3,
   },
   medio: {
-    frailejonJoven: 7, frailejon: 8, frailejonViejo: 4, frailejonFlor: 3,
-    yarumo: 2, roble: 2, encenillo: 2,
-    aliso: 2, gaque: 1, mortino: 6, romerillo: 7, roca: 5, musgo: 6, niebla: 0,
+    frailejonJoven: 2, frailejon: 3, frailejonViejo: 1, frailejonFlor: 1,
+    yarumo: 3, roble: 3, encenillo: 3,
+    aliso: 3, gaque: 2, mortino: 8, romerillo: 8, roca: 5, musgo: 6, niebla: 0,
   },
   bajo: {
-    frailejonJoven: 3, frailejon: 4, frailejonViejo: 0, frailejonFlor: 0,
-    yarumo: 1, roble: 1, encenillo: 0,
-    aliso: 0, gaque: 0, mortino: 2, romerillo: 3, roca: 2, musgo: 3, niebla: 0,
+    frailejonJoven: 1, frailejon: 2, frailejonViejo: 0, frailejonFlor: 0,
+    yarumo: 2, roble: 2, encenillo: 1,
+    aliso: 1, gaque: 0, mortino: 3, romerillo: 3, roca: 2, musgo: 3, niebla: 0,
   },
 };
 


### PR DESCRIPTION
## Dos mundos 3D distintos, biodiversidad colombiana real

Rediseño de **dos mundos separados** (decisión del operador: bosque y páramo son mundos aparte), con especies reales de Colombia como regla dura y el taller compartido (`sombreadoVegetal`/kit) para congruencia visual.

### 1. Bosque de biodiversidad — `EscenaBosqueVivo` (ruta `bosque_vivo`)
- **Nuevo `DoselBiodiverso`** (geom + componente): dosel multiespecie andino/subandino por estratos.
  - Emergentes: **guadua** (caña anillada), **nogal cafetero** (Cordia), **cedro**.
  - Dosel florecido: **cámbulo** (rojo), **gualanday** (morado), **siete cueros** (magenta).
  - Sotobosque: **helecho arbóreo** (Cyathea), **heliconia**.
  - Epífitas: **quiche/bromelia**.
  - Cada especie = 1 `InstancedMesh` con color horneado (tier-safe).
- **Triplica los árboles**: DoselBiodiverso + más queñual + más árboles nativos (yarumo, roble, encenillo, aliso, gaque).
- **El frailejón se retira del bosque** (queda como acento raro del filo alto): su firma es del páramo. Se bajaron sus conteos y se subieron los nativos → el bosque lee como bosque, no como páramo.

### 2. Páramo con el Ent — `MundoParamo3D` (ruta `mundo-paramo-3d`)
- **Ent-frailejón maestro** monumental y **visible**: columna velluda con enagua marcescente, **rostro sereno** (ojos ámbar hundidos, cejas afelpadas, boca amable), **roseta plateada plena** (pompón de tres coronas + domo pálido) por corona, **brazo florido** que hace ademán de enseñar, y un halo de páramo a los pies. Es el par del Ent-queñua del bosque, arriba.
- **Nueva flora de páramo**: **chusque** (bambú), **cardón/Puya**, **romero de páramo** (Diplostephium), sobre el frailejonal, pajonal, musgo y el nacimiento del agua ya existentes.
- Título/copia actualizados para nombrar al guardián-maestro.

### Propiedad de archivos (anti-conflicto)
Solo se tocan las escenas + flora de estos dos mundos:
- `src/visual/mundo3d/bosque/{doselBiodiverso.geom.js, DoselBiodiverso.jsx, EscenaBosqueVivo.jsx, bosqueTakeA.geom.js, floraParamo.geom.js}`
- `src/mockups/MundoParamo3D.jsx`

No se tocó `composicionValle*`, `DashboardLive.jsx`, `registry.js` ni `creatures/*`.

### Verificación
- `npm run build:prod` **verde**.
- Capturas de ambos mundos (día, tarde, órbita, teléfono) adjuntas al reporte al operador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
