### PR TITLE
art(valle): rediseño mayor — valle grande y regado, casa-puerta, 6 portales, potrero con cercas vivas

### DIFF
--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -58,6 +58,10 @@ import Mundo, {
 } from '../visual/mundo3d/index.js';
 /* Coach-mark del primer ingreso (visual, NO depende de la voz — iOS la muda). */
 import CoachMarkToque from '../visual/mundo3d/CoachMarkToque.jsx';
+/* Los 6 PORTALES del valle (la ley de la composición, datos puros): la puerta
+   de la casa abre este mapa como panel — mis matas · mis animales · el tiempo
+   · vender · aprender · toda mi finca. */
+import { PORTALES_VALLE } from '../visual/mundo3d/direccion/composicionValle.js';
 import { buildSpatialAgentInitialContext } from '../services/spatialAgentContext';
 import { speak, speakKokoro, stop as stopSpeak } from '../services/ttsService.js';
 import { navegarDesde3D, rutaDesdeMundo3D } from '../prodApp/wire3DNav.js';
@@ -370,6 +374,15 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
     decir(COSA_DEL_DIA.vozTexto);
   }, [decir]);
 
+  // ── LA CASA ES LA PUERTA (rediseño §2): tocar la puerta iluminada de la
+  //    casa abre el mapa de los 6 portales — mis matas, mis animales, el
+  //    tiempo, vender, aprender, toda mi finca. Angelita lo narra.
+  const abrirCasa = useCallback(() => {
+    setFocoId(null);
+    setPanel('casa');
+    decir(NARRACION.casa);
+  }, [decir]);
+
   const volverAlValle = useCallback(() => {
     setFocoId(null);
     setPanel(null);
@@ -518,6 +531,8 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
                 energia={companero.energia}
                 onEntrar={entrarMundo}
                 onAlerta={abrirAlerta}
+                onCasa={abrirCasa}
+                onAngelita={preguntarAlAgente}
                 reducedMotion={reducedMotion}
                 tier={equipo.tier}
                 aplanando={!!newDonk && nav.fase === 'viajando'}
@@ -692,6 +707,39 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
             <button type="button" className="valle-ghost" onClick={() => decir(COSA_DEL_DIA.vozTexto)}>
               🔊 Escuchar
             </button>
+          </div>
+        </aside>
+      )}
+
+      {/* ── Panel de LA CASA: el mapa de los 6 portales (rediseño §2). La
+              puerta iluminada de la casa abre estas seis puertas — tocar una
+              enfoca su lugar del valle y abre su panel. ── */}
+      {panel === 'casa' && (
+        <aside className="valle-panel valle-panel--casa" aria-live="polite">
+          <button type="button" className="valle-panel__x" onClick={volverAlValle} aria-label="Cerrar">×</button>
+          <span className="valle-panel__tag">🏡 Su casa</span>
+          <h2>Las puertas de su finca</h2>
+          <p>Desde la casa sale a todo. Toque una puerta para ir a su patio.</p>
+          <div className="valle-puertas">
+            {PORTALES_VALLE.map((p) => {
+              const m = MUNDO_VALLE_BY_ID[p.id];
+              return (
+                <button
+                  key={p.id}
+                  type="button"
+                  className="valle-puerta"
+                  style={{ '--p-tinte': m?.tinte?.[0] }}
+                  onClick={() => entrarMundo(p.id)}
+                  aria-label={`Puerta ${p.nombre}`}
+                >
+                  <span className="valle-puerta__emoji" aria-hidden="true">{p.emoji}</span>
+                  <span>
+                    {p.nombre}
+                    {m?.titulo && m.titulo !== p.nombre && <small>{m.titulo}</small>}
+                  </span>
+                </button>
+              );
+            })}
           </div>
         </aside>
       )}

--- a/src/mockups/entradaValle3D.css
+++ b/src/mockups/entradaValle3D.css
@@ -175,6 +175,29 @@
   transition: transform 0.25s ease; /* voltea hacia donde vuela */
   transform-origin: center;
 }
+/* Angelita TOCABLE (rediseño §6): el billboard central es un botón de verdad
+   — brilla cálido e invita a tocar (tocarla = hablarle a la finca). El brillo
+   es de la ESCENA (este wrapper), no del personaje. */
+.valle-abeja--toque {
+  pointer-events: auto;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  animation: valle-abeja-brilla 3.4s ease-in-out infinite;
+}
+@keyframes valle-abeja-brilla {
+  0%, 100% {
+    filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.4))
+      drop-shadow(0 0 10px rgba(255, 214, 140, 0.45));
+  }
+  50% {
+    filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.4))
+      drop-shadow(0 0 18px rgba(255, 222, 150, 0.8));
+  }
+}
 
 /* ── Criaturas sembradas por el valle (colibrí, mariposas, escarabajo,
       lombriz): billboards reusados de la librería de fauna. Decorativas: no
@@ -396,6 +419,45 @@
 }
 .valle-ghost:hover { background: rgba(255, 255, 255, 0.1); }
 
+/* ── Panel de LA CASA: el mapa de los 6 portales (rediseño §2) ──
+   La puerta de la casa abre estas seis puertas: grilla 2×3 de botones con
+   el tinte de cada mundo — piso táctil generoso, legible de un vistazo. */
+.valle-panel--casa .valle-panel__tag { background: rgba(255, 216, 143, 0.26); color: #ffe2b0; }
+.valle-puertas {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+.valle-puerta {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 56px;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 0.9rem;
+  background: color-mix(in srgb, var(--p-tinte, #7fd08a) 22%, rgba(15, 24, 30, 0.6));
+  color: #fff;
+  font-family: inherit;
+  font-size: 0.98rem;
+  font-weight: 800;
+  line-height: 1.15;
+  text-align: left;
+  cursor: pointer;
+}
+.valle-puerta:hover {
+  background: color-mix(in srgb, var(--p-tinte, #7fd08a) 36%, rgba(15, 24, 30, 0.55));
+  border-color: color-mix(in srgb, var(--p-tinte, #7fd08a) 70%, transparent);
+}
+.valle-puerta__emoji { font-size: 1.35rem; }
+.valle-puerta small {
+  display: block;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.72);
+}
+
 /* ── Barra del agente (abajo, fija) ── */
 .valle-agente {
   position: absolute;
@@ -582,6 +644,12 @@
   .valle2d__cam,
   .valle2d__abeja,
   .valle-abeja__cara { transition: none; }
+  /* Angelita tocable en calma: brillo fijo digno, sin pulso. */
+  .valle-abeja--toque {
+    animation: none;
+    filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.4))
+      drop-shadow(0 0 12px rgba(255, 214, 140, 0.5));
+  }
 }
 
 @media (max-width: 560px) {

--- a/src/mockups/valle/SombrasContacto.jsx
+++ b/src/mockups/valle/SombrasContacto.jsx
@@ -57,25 +57,29 @@ function texturaSombra() {
    (× escala del mundo). Una casa proyecta más que una mata: el corral y el
    mercado pisan ancho; la veleta es un poste y apenas marca su pie. */
 const HUELLAS = {
-  milpa: [0.85, 0.72],
-  cafetal: [0.95, 0.78],
+  milpa: [1.15, 0.95], // la parcela viva pisa ancho (la "granja" AoE)
+  cafetal: [1.0, 0.85], // café + guamo + plátano: el sombrío proyecta
   era: [0.92, 0.78],
   quebrada: [0.8, 0.8],
-  animales: [1.05, 0.85],
+  animales: [1.5, 1.25], // el potrero con sus apartos: la huella mayor
   huerta: [0.85, 0.72],
   mercado: [0.95, 0.8],
   veleta: [0.4, 0.4],
-  semillero: [0.78, 0.85],
+  invernadero: [0.95, 1.0], // el micro-mundo del semillero
   hongos: [0.8, 0.75],
+  compost: [0.85, 0.75], // la biofábrica y su pila
+  saber: [0.85, 0.65], // el kiosco del tablero
 };
 const HUELLA_DEFECTO = [0.8, 0.7];
 
 /* El bosque no es UNA mancha: cada árbol (roble, aliso, gaque — offsets de
-   SITIOS_ARBOLEDA en Valle3D) planta SU propia sombra bajo su copa. */
+   SITIOS_ARBOLEDA en Valle3D, hoy 5 árboles) planta SU sombra bajo su copa. */
 const ARBOLES_BOSQUE = [
-  { dx: -0.55, dz: 0.15, r: 0.62 }, // roble: copa ancha
-  { dx: 0.45, dz: -0.35, r: 0.52 }, // aliso: cónico
-  { dx: 0.2, dz: 0.55, r: 0.58 }, // gaque: domo bajo
+  { dx: -0.6, dz: 0.15, r: 0.64 }, // roble: copa ancha
+  { dx: 0.5, dz: -0.4, r: 0.52 }, // aliso: cónico
+  { dx: 0.2, dz: 0.6, r: 0.58 }, // gaque: domo bajo
+  { dx: 0.85, dz: 0.45, r: 0.46 }, // roble menor
+  { dx: -0.35, dz: -0.7, r: 0.44 }, // aliso menor
 ];
 
 /* Las matas sueltas de los pisos térmicos: sombra leve según su porte. */
@@ -130,9 +134,11 @@ export default function SombrasContacto({ mundos, alturaDe, nocturno = false, fr
   const { fuertes, leves } = useMemo(() => {
     /** @type {Array<{x:number,z:number,rx:number,rz:number,rot?:number}>} */
     const fuertes = [];
-    // La casa-ancla: la sombra más grande del valle (y girada con ella).
+    // La casa-puerta: la sombra más grande del valle (girada con ella y a
+    // la medida de su escala nueva).
     const [cx, cz] = CASA_VALLE.pos;
-    fuertes.push({ x: cx, z: cz, rx: 1.25, rz: 0.95, rot: CASA_VALLE.rotY });
+    const escCasa = CASA_VALLE.escala || 1;
+    fuertes.push({ x: cx, z: cz, rx: 1.25 * escCasa, rz: 0.95 * escCasa, rot: CASA_VALLE.rotY });
     for (const m of mundos) {
       const esc = m.escala || 1;
       const [mx, , mz] = /** @type {[number, number, number]} */ (m.pos);

--- a/src/mockups/valle/Valle2DFallback.jsx
+++ b/src/mockups/valle/Valle2DFallback.jsx
@@ -11,10 +11,12 @@
 import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS } from './valleData';
 import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
 
-/* Proyección isométrica plana de las coordenadas del valle a la lámina SVG. */
+/* Proyección isométrica plana de las coordenadas del valle a la lámina SVG.
+   (Escala al día con el VALLE GRANDE: los lugares viven en x ∈ [-8.6, 8.6],
+   z ∈ [-9.4, 9.6] — la lámina 400×340 los abraza todos con aire.) */
 function iso(x, z) {
-  const cx = 200 + (x - z) * 30;
-  const cy = 150 + (x + z) * 15;
+  const cx = 200 + (x - z) * 10.5;
+  const cy = 155 + (x + z) * 7.5;
   return { cx, cy };
 }
 

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -55,10 +55,12 @@ import { TRANSICION } from '../../visual/mundo3d/cielosHoraData.js';
    vive como datos en visual/mundo3d/direccion; las piezas r3f, al lado. */
 import {
   componerMundos,
+  CASA_VALLE,
   JERARQUIA_PERSONAJES,
 } from '../../visual/mundo3d/direccion/composicionValle.js';
 import {
   CasaCampesina,
+  PorticosPortales,
   SenderosValle,
   PatiosLugares,
   VecinosDelValle,
@@ -87,11 +89,12 @@ const MUNDO_DIR_BY_ID = Object.fromEntries(MUNDOS_DIR.map((m) => [m.id, m]));
    caliente. Así el gradiente de pisos térmicos se LEE como pendiente. La subida
    usa smoothstep (curva suave, sin quiebres) + una ondulación menuda para que
    las lomas se vean redondas, no planas. Determinista → los landmarks se posan
-   encima. */
+   encima. (Rediseño 2026-07: el valle creció a 48×48 — la subida es más larga
+   y un pelo más alta, la ondulación más ancha: lomas de valle grande.) */
 function alturaTerreno(x, z) {
-  const subida = THREE.MathUtils.smoothstep(-z, -8, 11) * 5.4;
-  const ondul = Math.sin(x * 0.42) * 0.14 + Math.cos(z * 0.36 + x * 0.2) * 0.12;
-  const cauce = -0.32 * Math.exp(-((x - 1.2) ** 2) / 6) * Math.exp(-((z + 1) ** 2) / 55);
+  const subida = THREE.MathUtils.smoothstep(-z, -11, 16) * 6.2;
+  const ondul = Math.sin(x * 0.3) * 0.16 + Math.cos(z * 0.27 + x * 0.15) * 0.13;
+  const cauce = -0.36 * Math.exp(-((x - 1.9) ** 2) / 8) * Math.exp(-((z + 1.5) ** 2) / 110);
   return subida + ondul + cauce;
 }
 
@@ -139,7 +142,7 @@ function colorSueloEnZ(z, alto, nocturno, out) {
 function Terreno({ nocturno, innerRef, perfil }) {
   const seg = perfil.segmentosTerreno;
   const geo = useMemo(() => {
-    const g = new THREE.PlaneGeometry(34, 34, seg, seg);
+    const g = new THREE.PlaneGeometry(48, 48, seg, seg);
     g.rotateX(-Math.PI / 2);
     const pos = g.attributes.position;
     const colores = new Float32Array(pos.count * 3);
@@ -149,7 +152,7 @@ function Terreno({ nocturno, innerRef, perfil }) {
       const z = pos.getZ(i);
       const y = alturaTerreno(x, z);
       pos.setY(i, y);
-      const subida = THREE.MathUtils.smoothstep(-z, -8, 11) * 5.4;
+      const subida = THREE.MathUtils.smoothstep(-z, -11, 16) * 6.2;
       const alto = THREE.MathUtils.clamp((y - subida + 0.3) / 0.6, 0, 1);
       colorSueloEnZ(z, alto, nocturno, col);
       colores[i * 3] = col.r;
@@ -177,10 +180,12 @@ function Terreno({ nocturno, innerRef, perfil }) {
       alta (perspectiva aérea). Su base se posa sobre el terreno del páramo
       (que ya subió a ~5) y las cumbres coronan la escena. ── */
 const PICOS_CORDILLERA = [
-  { x: -9, z: -15.5, h: 7, r: 5, base: 4.2 },
-  { x: -2, z: -17, h: 9.5, r: 6, base: 4.6 },
-  { x: 6, z: -16, h: 8, r: 5.2, base: 4.2 },
-  { x: 12, z: -15, h: 6, r: 4.5, base: 4.0 },
+  // (Empujados al fondo del valle grande: z ≤ -21, sobre el páramo que ya
+  //  subió a ~6. Más anchos y altos para coronar el cuadro nuevo.)
+  { x: -13, z: -22, h: 8.5, r: 6.5, base: 5.0 },
+  { x: -3, z: -24, h: 11.5, r: 7.5, base: 5.4 },
+  { x: 8, z: -23, h: 9.5, r: 6.5, base: 5.0 },
+  { x: 17, z: -21, h: 7, r: 5.5, base: 4.8 },
 ];
 
 function Cordillera({ color, innerRef, perfil }) {
@@ -228,16 +233,16 @@ function Quebrada({ color, viva, perfil, nocturno = false }) {
     // Nace arriba (páramo) y BAJA por la ladera hasta la tierra caliente:
     // cada punto se posa sobre el terreno (+un pelo) para leer la pendiente.
     const pts = [
-      [-3.4, -7.2],
-      [-1.2, -4.2],
-      [0.8, -1.4],
-      [1.6, 1.8],
-      [2.6, 5.4],
-      [3.6, 8],
+      [-4.6, -11],
+      [-2.2, -6.4],
+      [0.6, -2.4],
+      [2.2, 1.6],
+      [3.4, 6.4],
+      [4.6, 11.5],
     ].map(([x, z]) => new THREE.Vector3(x, alturaTerreno(x, z) + 0.06, z));
     const curve = new THREE.CatmullRomCurve3(pts);
     // Frugal: menos anillos/segmentos — la cinta se lee igual desde lejos.
-    const g = new THREE.TubeGeometry(curve, rico ? 80 : 48, 0.34, rico ? 7 : 5, false);
+    const g = new THREE.TubeGeometry(curve, rico ? 88 : 52, 0.4, rico ? 7 : 5, false);
     return g;
   }, [rico]);
   return (
@@ -273,9 +278,13 @@ function Quebrada({ color, viva, perfil, nocturno = false }) {
       floraParamo (color horneado por vértice, 1 draw call por árbol); escala
       ~0.5 para el diorama. `q` baja el detalle en perfil frugal. ── */
 const SITIOS_ARBOLEDA = [
-  { geom: geomRoble, args: [-0.55, 0, 0.15], esc: 0.52, rot: 0.8, seed: 91 },
-  { geom: geomAliso, args: [0.45, 0, -0.35], esc: 0.5, rot: 2.1, seed: 92 },
-  { geom: geomGaque, args: [0.2, 0, 0.55], esc: 0.55, rot: 4.4, seed: 93 },
+  // (El monte del portal "toda mi finca" se espesó: 5 árboles, 3 especies —
+  //  dosel multiespecie, no un parche de conos.)
+  { geom: geomRoble, args: [-0.6, 0, 0.15], esc: 0.55, rot: 0.8, seed: 91 },
+  { geom: geomAliso, args: [0.5, 0, -0.4], esc: 0.5, rot: 2.1, seed: 92 },
+  { geom: geomGaque, args: [0.2, 0, 0.6], esc: 0.55, rot: 4.4, seed: 93 },
+  { geom: geomRoble, args: [0.85, 0, 0.45], esc: 0.42, rot: 3.3, seed: 94 },
+  { geom: geomAliso, args: [-0.35, 0, -0.7], esc: 0.44, rot: 5.2, seed: 95 },
 ];
 
 function ArboledaEspecies({ q }) {
@@ -307,45 +316,133 @@ function ArboledaEspecies({ q }) {
 function LandmarkGeom({ tipo, tinte, reducedMotion, q = 1 }) {
   const [fuerte, suave] = tinte;
   switch (tipo) {
-    case 'milpa': // maíz: cañas altas con penacho + hojas
+    case 'milpa': // LA PARCELA VIVA (estilo granja de Age of Empires, en modo
+      // milpa): la tierra labrada como base, y encima las TRES HERMANAS
+      // juntas — maíz (caña con penacho), fríjol (bejuco enroscado a la
+      // caña) y calabaza (frutos naranjas con su hoja ancha tapando el
+      // suelo). Se lee POLICULTIVO de un vistazo: nada de hileras clonadas.
       return (
         <group>
-          {[-0.42, 0.05, 0.42].map((dx, i) => (
-            <group key={i} position={[dx, 0, (i % 2) * 0.36 - 0.18]}>
-              <mesh position={[0, 0.7, 0]} castShadow>
-                <cylinderGeometry args={[0.05, 0.08, 1.4, 6]} />
+          {/* la tierra labrada de la parcela (la "granja" que se lee de lejos) */}
+          <mesh position={[0, 0.045, 0]} receiveShadow>
+            <boxGeometry args={[2.1, 0.09, 1.7]} />
+            <meshStandardMaterial color="#5f4429" flatShading roughness={1} />
+          </mesh>
+          {/* surcos suaves (dos lomos que cruzan la parcela) */}
+          {[-0.45, 0.35].map((dz, i) => (
+            <mesh key={i} position={[0, 0.09, dz]} rotation={[0, 0, Math.PI / 2]}>
+              <capsuleGeometry args={[0.06, 1.85, 3, 6]} />
+              <meshStandardMaterial color="#6b4e30" flatShading roughness={1} />
+            </mesh>
+          ))}
+          {/* el maíz con su fríjol trepado (quincunce, alturas variadas) */}
+          {[
+            [-0.75, -0.5, 1.35], [-0.1, -0.25, 1.5], [0.6, -0.55, 1.25],
+            [-0.45, 0.25, 1.45], [0.3, 0.4, 1.3],
+          ].map(([dx, dz, h], i) => (
+            <group key={i} position={[dx, 0.08, dz]}>
+              <mesh position={[0, h / 2, 0]} castShadow>
+                <cylinderGeometry args={[0.045, 0.075, h, 6]} />
                 <meshStandardMaterial color={fuerte} flatShading roughness={1} />
               </mesh>
-              {/* hojas: conos aplanados que salen de la caña */}
-              <mesh position={[0.16, 0.9, 0]} rotation={[0, 0, -0.7]} scale={[1, 1, 0.3]}>
-                <coneGeometry args={[0.12, 0.5, 4]} />
+              {/* hojas de la caña */}
+              <mesh position={[0.15, h * 0.62, 0]} rotation={[0, 0, -0.7]} scale={[1, 1, 0.3]}>
+                <coneGeometry args={[0.11, 0.46, 4]} />
                 <meshStandardMaterial color={suave} flatShading roughness={1} />
               </mesh>
-              <mesh position={[-0.16, 0.62, 0]} rotation={[0, Math.PI, -0.7]} scale={[1, 1, 0.3]}>
-                <coneGeometry args={[0.12, 0.5, 4]} />
+              <mesh position={[-0.15, h * 0.44, 0]} rotation={[0, Math.PI, -0.7]} scale={[1, 1, 0.3]}>
+                <coneGeometry args={[0.11, 0.46, 4]} />
                 <meshStandardMaterial color={suave} flatShading roughness={1} />
               </mesh>
-              <mesh position={[0, 1.5, 0]}>
-                <coneGeometry args={[0.08, 0.42, 6]} />
+              {/* el penacho */}
+              <mesh position={[0, h + 0.16, 0]}>
+                <coneGeometry args={[0.07, 0.36, 6]} />
                 <meshStandardMaterial color="#e7c96b" flatShading />
+              </mesh>
+              {/* el FRÍJOL enroscado a la caña (dos vueltas del bejuco) */}
+              <mesh position={[0, h * 0.3, 0]} rotation={[Math.PI / 2.3, 0, 0.2]}>
+                <torusGeometry args={[0.1, 0.028, 5, 10]} />
+                <meshStandardMaterial color="#2f6b34" flatShading roughness={1} />
+              </mesh>
+              <mesh position={[0.02, h * 0.55, 0]} rotation={[Math.PI / 1.9, 0, -0.3]}>
+                <torusGeometry args={[0.09, 0.026, 5, 10]} />
+                <meshStandardMaterial color="#2f6b34" flatShading roughness={1} />
+              </mesh>
+            </group>
+          ))}
+          {/* las CALABAZAS tapando el suelo entre matas (fruto + hoja ancha) */}
+          {[[-0.55, 0.75], [0.15, 0.85], [0.75, 0.1], [-0.85, 0.05]].map(([dx, dz], i) => (
+            <group key={i} position={[dx, 0.09, dz]}>
+              <mesh position={[0, 0.09, 0]} scale={[1, 0.72, 1]} castShadow>
+                <sphereGeometry args={[0.14, 9, 7]} />
+                <meshStandardMaterial color="#d98e2b" flatShading roughness={1} />
+              </mesh>
+              <mesh position={[0, 0.16, 0]}>
+                <cylinderGeometry args={[0.018, 0.025, 0.07, 5]} />
+                <meshStandardMaterial color="#4f7a3a" flatShading />
+              </mesh>
+              {/* la hoja ancha que cubre el suelo */}
+              <mesh position={[0.18, 0.06, 0.1]} rotation={[-Math.PI / 2.2, 0, 0.6]} scale={[1, 1, 0.5]}>
+                <circleGeometry args={[0.16, 7]} />
+                <meshStandardMaterial color={suave} flatShading roughness={1} side={2} />
               </mesh>
             </group>
           ))}
         </group>
       );
-    case 'cafetal': // arbustos redondos con frutos, en la ladera
+    case 'cafetal': // café CON SOMBRÍO (policultivo, no hilera): los arbustos
+      // cargados de cereza roja DEBAJO de su guamo de sombra y con una mata
+      // de plátano al lado — el trío clásico del cafetal campesino.
       return (
         <group>
-          {[-0.5, 0.1, 0.55].map((dx, i) => (
-            <group key={i} position={[dx, 0, (i % 2) * 0.42]}>
+          {/* el GUAMO de sombrío: tronco alto + copa ancha y plana encima */}
+          <group position={[-0.15, 0, -0.1]}>
+            <mesh position={[0, 0.8, 0]} castShadow>
+              <cylinderGeometry args={[0.07, 0.1, 1.6, 6]} />
+              <meshStandardMaterial color="#6b4a2e" flatShading roughness={1} />
+            </mesh>
+            <mesh position={[0, 1.7, 0]} scale={[1, 0.34, 1]} castShadow>
+              <sphereGeometry args={[1.05, 10, 8]} />
+              <meshStandardMaterial color="#3f7a38" flatShading roughness={1} />
+            </mesh>
+          </group>
+          {/* la mata de plátano acompañante (pseudotallo + hojas colgantes) */}
+          <group position={[0.85, 0, -0.45]}>
+            <mesh position={[0, 0.5, 0]} castShadow>
+              <cylinderGeometry args={[0.08, 0.12, 1.0, 7]} />
+              <meshStandardMaterial color="#7a9a55" flatShading roughness={1} />
+            </mesh>
+            {[0, 1, 2, 3].map((k) => (
+              <mesh
+                key={k}
+                position={[0, 0.95, 0]}
+                rotation={[0, (k / 4) * Math.PI * 2 + 0.4, -0.9]}
+                scale={[1, 1, 0.28]}
+                castShadow
+              >
+                <coneGeometry args={[0.2, 0.85, 4]} />
+                <meshStandardMaterial color="#4f9a44" flatShading roughness={1} />
+              </mesh>
+            ))}
+          </group>
+          {/* los arbustos de café bajo la sombra, con su cereza roja */}
+          {[[-0.6, 0.35], [0.05, 0.15], [0.5, 0.55], [-0.2, 0.7]].map(([dx, dz], i) => (
+            <group key={i} position={[dx, 0, dz]}>
               <mesh position={[0, 0.16, 0]}>
                 <cylinderGeometry args={[0.05, 0.07, 0.32, 6]} />
                 <meshStandardMaterial color="#6b4a2e" flatShading />
               </mesh>
               <mesh position={[0, 0.44, 0]} castShadow>
-                <sphereGeometry args={[0.32, 10, 9]} />
+                <sphereGeometry args={[0.3, 10, 9]} />
                 <meshStandardMaterial color={fuerte} flatShading roughness={1} />
               </mesh>
+              {/* la cereza madura que pinta el arbusto */}
+              {[[0.16, 0.5, 0.16], [-0.14, 0.42, 0.18], [0.05, 0.6, -0.2]].map(([bx, by, bz], j) => (
+                <mesh key={j} position={[bx, by, bz]}>
+                  <sphereGeometry args={[0.035, 6, 5]} />
+                  <meshBasicMaterial color="#c9392e" />
+                </mesh>
+              ))}
             </group>
           ))}
         </group>
@@ -443,32 +540,170 @@ function LandmarkGeom({ tipo, tinte, reducedMotion, q = 1 }) {
       );
     case 'veleta': // poste con veleta que gira con el viento
       return <Veleta color={fuerte} reducedMotion={reducedMotion} />;
-    case 'semillero': // túnel de media-sombra del vivero: arcos + techo traslúcido + bandeja
+    case 'invernadero': // el MICRO-MUNDO del semillero: un invernadero de
+      // verdad — arcos de madera, el plástico traslúcido que brilla al sol,
+      // la puerta abierta y las mesas de germinación adentro. Se destaca
+      // como pieza propia del valle: la fábrica de la matica.
       return (
         <group>
           {/* los arcos del túnel (medio-toroide de pie), en tono madera */}
-          {[-0.42, 0, 0.42].map((dz, i) => (
+          {[-0.65, -0.22, 0.22, 0.65].map((dz, i) => (
             <mesh key={i} position={[0, 0, dz]}>
-              <torusGeometry args={[0.5, 0.028, 6, 18, Math.PI]} />
+              <torusGeometry args={[0.62, 0.03, 6, 18, Math.PI]} />
               <meshStandardMaterial color="#8a6a44" flatShading roughness={1} />
             </mesh>
           ))}
-          {/* el techo de media-sombra (traslúcido) que cubre los arcos */}
+          {/* la cumbrera que amarra los arcos */}
+          <mesh position={[0, 0.62, 0]} rotation={[Math.PI / 2, 0, 0]}>
+            <cylinderGeometry args={[0.025, 0.025, 1.5, 5]} />
+            <meshStandardMaterial color="#8a6a44" flatShading roughness={1} />
+          </mesh>
+          {/* EL PLÁSTICO: la piel traslúcida que hace invernadero (brilla
+              apenas — de lejos se lee el blanco lechoso característico) */}
           <mesh position={[0, 0, 0]} rotation={[Math.PI / 2, 0, 0]}>
-            <cylinderGeometry args={[0.5, 0.5, 1.0, 16, 1, true, Math.PI, Math.PI]} />
-            <meshStandardMaterial color={suave} transparent opacity={0.4} side={2} roughness={1} />
+            <cylinderGeometry args={[0.63, 0.63, 1.44, 16, 1, true, Math.PI, Math.PI]} />
+            <meshStandardMaterial
+              color="#eef7f2"
+              emissive="#dff0e8"
+              emissiveIntensity={0.12}
+              transparent
+              opacity={0.34}
+              side={2}
+              roughness={0.6}
+            />
           </mesh>
-          {/* la bandeja germinadora adentro, con sus brotecitos */}
-          <mesh position={[0, 0.12, 0]}>
-            <boxGeometry args={[0.5, 0.08, 0.6]} />
-            <meshStandardMaterial color="#5a4326" flatShading roughness={1} />
+          {/* el testero trasero cerrado y el delantero con PUERTA abierta */}
+          <mesh position={[0, 0, -0.72]}>
+            <circleGeometry args={[0.62, 16, 0, Math.PI]} />
+            <meshStandardMaterial color="#eef7f2" transparent opacity={0.3} side={2} roughness={0.6} />
           </mesh>
-          {[[-0.14, -0.18], [0.02, 0], [0.16, 0.2], [-0.06, 0.22], [0.1, -0.2]].map(([bx, bz], i) => (
-            <mesh key={i} position={[bx, 0.24, bz]}>
-              <coneGeometry args={[0.045, 0.16, 5]} />
-              <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+          <mesh position={[-0.3, 0, 0.72]}>
+            <circleGeometry args={[0.62, 16, Math.PI / 2, Math.PI / 2]} />
+            <meshStandardMaterial color="#eef7f2" transparent opacity={0.3} side={2} roughness={0.6} />
+          </mesh>
+          {/* las DOS mesas de germinación con sus brotecitos en fila viva */}
+          {[-0.26, 0.26].map((dx, i) => (
+            <group key={i} position={[dx, 0, 0]}>
+              <mesh position={[0, 0.18, 0]}>
+                <boxGeometry args={[0.34, 0.05, 1.2]} />
+                <meshStandardMaterial color="#5a4326" flatShading roughness={1} />
+              </mesh>
+              {[-0.42, -0.14, 0.14, 0.42].map((bz, j) => (
+                <mesh key={j} position={[(j % 2) * 0.1 - 0.05, 0.27, bz]}>
+                  <coneGeometry args={[0.05, 0.15, 5]} />
+                  <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+                </mesh>
+              ))}
+            </group>
+          ))}
+          {/* el barril de agua junto a la puerta (el riego del vivero) */}
+          <mesh position={[0.62, 0.14, 0.78]} castShadow>
+            <cylinderGeometry args={[0.11, 0.12, 0.28, 9]} />
+            <meshStandardMaterial color={suave} flatShading roughness={1} />
+          </mesh>
+        </group>
+      );
+    case 'compost': // LA BIOFÁBRICA: la pila de compost con apariencia de tal
+      // — el cajón de madera en U, la pila humeante por capas (estiércol
+      // abajo, material fresco, la capa de paja encima) y la horqueta
+      // clavada. El ciclo estiércol→abono, legible.
+      return (
+        <group>
+          {/* el cajón de madera en U que contiene la pila */}
+          {[
+            { p: [0, 0.16, -0.5], s: [1.15, 0.32, 0.08] },
+            { p: [-0.56, 0.16, -0.05], s: [0.08, 0.32, 0.95], r: 0 },
+            { p: [0.56, 0.16, -0.05], s: [0.08, 0.32, 0.95], r: 0 },
+          ].map((w, i) => (
+            <mesh key={i} position={/** @type {any} */ (w.p)} castShadow>
+              <boxGeometry args={/** @type {any} */ (w.s)} />
+              <meshStandardMaterial color="#7a5a38" flatShading roughness={1} />
             </mesh>
           ))}
+          {/* la PILA por capas: estiércol oscuro, compost pardo, paja clara */}
+          <mesh position={[0, 0.14, -0.05]} scale={[1, 0.5, 0.9]} castShadow>
+            <sphereGeometry args={[0.48, 10, 8]} />
+            <meshStandardMaterial color="#3d2b1a" flatShading roughness={1} />
+          </mesh>
+          <mesh position={[0, 0.28, -0.05]} scale={[0.82, 0.45, 0.72]}>
+            <sphereGeometry args={[0.48, 10, 8]} />
+            <meshStandardMaterial color="#5f4429" flatShading roughness={1} />
+          </mesh>
+          <mesh position={[0, 0.4, -0.05]} scale={[0.6, 0.35, 0.52]}>
+            <sphereGeometry args={[0.48, 9, 7]} />
+            <meshStandardMaterial color="#c9a55a" flatShading roughness={1} />
+          </mesh>
+          {/* el vaho tibio de la pila trabajando (dos motas traslúcidas) */}
+          <mesh position={[0.08, 0.68, -0.05]}>
+            <sphereGeometry args={[0.09, 7, 6]} />
+            <meshBasicMaterial color="#f2efe4" transparent opacity={0.32} depthWrite={false} />
+          </mesh>
+          <mesh position={[-0.06, 0.84, 0.02]}>
+            <sphereGeometry args={[0.06, 7, 6]} />
+            <meshBasicMaterial color="#f2efe4" transparent opacity={0.22} depthWrite={false} />
+          </mesh>
+          {/* la horqueta clavada en la pila (aquí se trabaja) */}
+          <mesh position={[0.42, 0.42, 0.32]} rotation={[0.5, 0, -0.35]}>
+            <cylinderGeometry args={[0.022, 0.026, 0.8, 5]} />
+            <meshStandardMaterial color="#8a6a44" flatShading roughness={1} />
+          </mesh>
+          {/* la carretilla del viaje potrero→pila (cajón + rueda) */}
+          <group position={[-0.55, 0, 0.55]} rotation={[0, 0.8, 0]}>
+            <mesh position={[0, 0.18, 0]} castShadow>
+              <boxGeometry args={[0.34, 0.14, 0.22]} />
+              <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+            </mesh>
+            <mesh position={[0.16, 0.09, 0]} rotation={[0, 0, Math.PI / 2]}>
+              <cylinderGeometry args={[0.08, 0.08, 0.04, 10]} />
+              <meshStandardMaterial color="#4a3a2a" flatShading roughness={1} />
+            </mesh>
+          </group>
+        </group>
+      );
+    case 'saber': // el KIOSCO DEL SABER (portal Aprender): el tablero bajo su
+      // techito de paja, la banca de tronco y el libro abierto — la escuelita
+      // de vereda donde la finca enseña y se juega.
+      return (
+        <group>
+          {/* los dos parales y el techito de paja a un agua */}
+          {[-0.5, 0.5].map((dx, i) => (
+            <mesh key={i} position={[dx, 0.55, -0.15]} castShadow>
+              <cylinderGeometry args={[0.04, 0.05, 1.1, 6]} />
+              <meshStandardMaterial color="#8a6a44" flatShading roughness={1} />
+            </mesh>
+          ))}
+          <mesh position={[0, 1.14, -0.05]} rotation={[0.28, 0, 0]} castShadow>
+            <boxGeometry args={[1.3, 0.07, 0.75]} />
+            <meshStandardMaterial color="#c9a55a" flatShading roughness={1} />
+          </mesh>
+          {/* EL TABLERO verde de escuela, colgado entre los parales */}
+          <mesh position={[0, 0.62, -0.14]}>
+            <boxGeometry args={[0.86, 0.5, 0.05]} />
+            <meshStandardMaterial color="#2e5941" flatShading roughness={1} />
+          </mesh>
+          {/* las tres rayitas de tiza del tablero (la lección de hoy) */}
+          {[0.74, 0.62, 0.5].map((y, i) => (
+            <mesh key={i} position={[i * 0.06 - 0.1, y, -0.11]}>
+              <boxGeometry args={[0.42 - i * 0.1, 0.022, 0.01]} />
+              <meshBasicMaterial color="#f2efe4" />
+            </mesh>
+          ))}
+          {/* la banca de tronco donde se sienta el que aprende */}
+          <mesh position={[0.05, 0.12, 0.55]} rotation={[0, 0.2, Math.PI / 2]} castShadow>
+            <cylinderGeometry args={[0.09, 0.09, 0.9, 8]} />
+            <meshStandardMaterial color="#7a5a38" flatShading roughness={1} />
+          </mesh>
+          {/* el libro abierto sobre la banca (dos tapitas en V) */}
+          <group position={[0.15, 0.24, 0.55]} rotation={[0, -0.4, 0]}>
+            <mesh position={[-0.06, 0, 0]} rotation={[0, 0, 0.5]}>
+              <boxGeometry args={[0.14, 0.015, 0.18]} />
+              <meshStandardMaterial color="#f2efe4" flatShading />
+            </mesh>
+            <mesh position={[0.06, 0, 0]} rotation={[0, 0, -0.5]}>
+              <boxGeometry args={[0.14, 0.015, 0.18]} />
+              <meshStandardMaterial color="#f2efe4" flatShading />
+            </mesh>
+          </group>
         </group>
       );
     case 'hongos': // el suelo vivo: hongos que asoman (el fruto del micelio), con
@@ -720,13 +955,14 @@ function Veleta({ color, reducedMotion = false }) {
       eras. Pocas y bien puestas: el valle se siente vivo, no amontonado. Son
       decorativas (aria-hidden) y no capturan toques. ── */
 const CRIATURAS_VALLE = [
-  // (posiciones al día con la DISPOSICIÓN COMPUESTA: la milpa cedió a la
-  //  izquierda y la huerta se arrimó a la casa — sus bichos las siguen.)
-  { crt: 'mariposa', x: -4.8, z: 1.9, dy: 2.0, size: 30, factor: 8 },
-  { crt: 'mariposa', x: -5.6, z: 2.8, dy: 1.5, size: 24, factor: 8 },
-  { crt: 'colibri', x: 3.1, z: 3.9, dy: 1.9, size: 34, factor: 8 },
-  { crt: 'escarabajo', x: 4.7, z: -2.9, dy: 0.5, size: 28, factor: 7 },
-  { crt: 'lombriz', x: -1.2, z: 5.4, dy: 0.28, size: 26, factor: 6.5 },
+  // (posiciones al día con el VALLE GRANDE: las mariposas sobre la milpa,
+  //  el colibrí en la huerta de la casa, el escarabajo en la hojarasca del
+  //  monte, la lombriz asomada en las eras — cada bicho en su nicho.)
+  { crt: 'mariposa', x: -7.6, z: -0.4, dy: 2.2, size: 30, factor: 8 },
+  { crt: 'mariposa', x: -9.2, z: 1.8, dy: 1.7, size: 24, factor: 8 },
+  { crt: 'colibri', x: 2.3, z: 4.6, dy: 1.9, size: 34, factor: 8 },
+  { crt: 'escarabajo', x: 6.4, z: -3.6, dy: 0.5, size: 28, factor: 7 },
+  { crt: 'lombriz', x: -3.0, z: 6.2, dy: 0.28, size: 26, factor: 6.5 },
 ];
 
 function CriaturaSvg({ tipo, size, animated }) {
@@ -1037,15 +1273,26 @@ function Beacon({ onAlerta, reducedMotion, conLuz = true }) {
   );
 }
 
-/* ── El COMPAÑERO-JUGADOR: Angelita, la abeja. Es el avatar que vuela por el
-      valle. Al reposo, ronda sobre el valle con vaivén vivo; cuando se toca un
-      mundo (`entrando`), BAJA y se acerca al lugar — "entra" al mundo, y la
-      cámara la acompaña. Su ánimo/energía (salud real de la finca) tiñen su
-      color, su aura y qué tan vivo es su vuelo. Mira hacia donde viaja. ── */
-function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false, posRef = null, conLuz = false }) {
+/* ── El COMPAÑERO-JUGADOR: Angelita, la abeja — UNA SOLA, la del valle.
+      Rediseño 2026-07 (§6): POSICIÓN DE CALMA — al reposo ya no husmea
+      errática por el valle: flota serena sobre el corredor de la casa (el
+      corazón del cuadro), con un vaivén mínimo de respiración. Es MÁS
+      GRANDE (se veía diminuta) y BRILLA con su luz propia: invita a tocarla
+      — tocarla es hablarle a la finca (`onTocar`). Cuando se toca un mundo
+      (`entrando`), vuela y se acerca al lugar, y la cámara la acompaña. Su
+      ánimo/energía (salud real de la finca) tiñen su color y su vuelo. ── */
+const CALMA_ABEJA = {
+  // Al frente-derecha del corredor, sobre el patio de la casa (no encima del
+  // techo): Angelita ES la anfitriona de la casa-puerta.
+  x: CASA_VALLE.pos[0] + 1.9,
+  z: CASA_VALLE.pos[1] + 2.1,
+};
+
+function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false, posRef = null, conLuz = false, onTocar = null }) {
   const ref = useRef(null);
   const caraRef = useRef(null);
   const prevX = useRef(foco.x);
+  const yCalma = useMemo(() => alturaTerreno(CALMA_ABEJA.x, CALMA_ABEJA.z), []);
   // Reacción al estado REAL de la finca (§5b): mismo repertorio que los mundos.
   // Con estadoFinca manda la reacción; sin él, el contrato viejo (animo/energia).
   const reaccion = useMemo(
@@ -1067,16 +1314,25 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
     const brio = (0.35 + 0.65 * energiaReal) * mVel; // energía y clima animan el vuelo
     const bob = reducedMotion ? 0 : Math.sin(t * (1.6 + brio)) * (0.1 + 0.16 * brio);
     const tembleque = tiembla ? Math.sin(t * 13) * tiembla : 0;
-    // Al reposo deriva en un círculo calmo; al entrar se posa junto al lugar.
-    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.55) * 0.9 * mVagar;
-    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.55) * 0.6 * mVagar;
-    const alto = (entrando ? 1.05 : 2.3) * mAltura;
-    const dest = new THREE.Vector3(
-      foco.x + (entrando ? 0.55 : 0.4 + vagarX) + tembleque,
-      foco.y + alto + bob + tembleque * 0.5,
-      foco.z + (entrando ? 0.7 : 0.6 + vagarZ),
-    );
-    ref.current.position.lerp(dest, (entrando ? 0.05 : 0.045) * mVel);
+    // POSICIÓN DE CALMA (§6): al reposo Angelita ya no ronda el valle en un
+    // círculo errático — flota SERENA sobre el corredor de la casa con una
+    // deriva mínima y lenta (respiración, no husmeo). Al entrar a un mundo
+    // sí vuela y se posa junto al lugar.
+    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.28) * 0.28 * mVagar;
+    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.22) * 0.2 * mVagar;
+    const alto = (entrando ? 1.05 : 2.5) * mAltura;
+    const dest = entrando
+      ? new THREE.Vector3(
+          foco.x + 0.55 + tembleque,
+          foco.y + alto + bob + tembleque * 0.5,
+          foco.z + 0.7,
+        )
+      : new THREE.Vector3(
+          CALMA_ABEJA.x + vagarX + tembleque,
+          yCalma + alto + bob + tembleque * 0.5,
+          CALMA_ABEJA.z + vagarZ,
+        );
+    ref.current.position.lerp(dest, (entrando ? 0.05 : 0.035) * mVel);
     // Comparte su posición viva para que la cámara de director la SIGA (follow
     // con lead): copia dentro del Vector3 compartido (mutación por método sobre
     // un local — no reasigna el prop, como CamaraViajera con controls.current).
@@ -1088,10 +1344,13 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
       prevX.current = ref.current.position.x;
     }
   });
-  const size = 44 + Math.round(energiaReal * 14);
+  // MÁS GRANDE (§6): el px base sube de 44 a la banda de JERARQUIA (58-76) —
+  // en el valle grande la guía se veía diminuta.
+  const [pxMin, pxMax] = JERARQUIA_PERSONAJES.protagonistaPx;
+  const size = pxMin + Math.round(energiaReal * (pxMax - pxMin));
   const luz = JERARQUIA_PERSONAJES.luzProtagonista;
   return (
-    <group ref={ref} position={[foco.x + 0.4, foco.y + 2.3, foco.z + 0.6]}>
+    <group ref={ref} position={[CALMA_ABEJA.x, yCalma + 2.5, CALMA_ABEJA.z]}>
       {/* JERARQUÍA: Angelita es la ÚNICA con luz propia — su calidez baña el
           terreno bajo su vuelo y el ojo la encuentra primero, sobre todo al
           atardecer y de noche. Solo donde el perfil ya paga luces extra. */}
@@ -1103,8 +1362,22 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
           position={[0, -0.2, 0]}
         />
       )}
-      <Html center distanceFactor={9} zIndexRange={[40, 10]}>
-        <div className="valle-abeja" aria-hidden="true">
+      <Html center distanceFactor={15} zIndexRange={[40, 10]}>
+        {/* TOCABLE (§6): Angelita brilla e invita — tocarla es hablarle a la
+            finca (el host abre el agente). Botón real por accesibilidad. */}
+        <button
+          type="button"
+          className="valle-abeja valle-abeja--toque"
+          aria-label="Hable con Angelita, la guía de su finca"
+          onClick={
+            onTocar
+              ? (e) => {
+                  e.stopPropagation();
+                  onTocar();
+                }
+              : undefined
+          }
+        >
           <div ref={caraRef} className="valle-abeja__cara">
             <AbejaAngelita
               size={size}
@@ -1116,7 +1389,7 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
               animated={!reducedMotion}
             />
           </div>
-        </div>
+        </button>
       </Html>
     </group>
   );
@@ -1229,7 +1502,8 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false, 
       const dir = cam.position.clone().sub(c.target);
       // Acercarse al entrar; al volver, abrir hasta el reposo del ASPECTO
       // real (kReposo): en un teléfono parado el valle respira más lejos.
-      const deseada = entrando ? 9 : 18 * kReposo;
+      // (Distancias del valle GRANDE: entrar a 10.5, reposo a ~25.)
+      const deseada = entrando ? 10.5 : 25 * kReposo;
       dir.setLength(THREE.MathUtils.lerp(dir.length(), deseada, k));
       cam.position.copy(c.target.clone().add(dir));
       trans.current = Math.max(0, trans.current - (entrando ? 0.012 : 0.009));
@@ -1246,11 +1520,11 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false, 
          fotograma ya es el encuadre de autor — clave en reduced-motion
          (frameloop demand), donde el lerp por frame gatea. */
       target={miraInicial || undefined}
-      minDistance={7}
+      minDistance={8}
       /* El techo de zoom respeta el reposo del aspecto: si la pose vertical
          vive más lejos, el clamp no pelea contra ella (antes, en teléfono,
          el reposo caía FUERA del techo y los controles daban tirones). */
-      maxDistance={Math.max(28, Math.ceil(20 * kReposo) + 4)}
+      maxDistance={Math.max(38, Math.ceil(27 * kReposo) + 5)}
       minPolarAngle={0.45}
       maxPolarAngle={1.18}
       autoRotate={autoOrbit && !entrando && !tomada}
@@ -1289,7 +1563,9 @@ function estadoAtmosfera(c) {
     niebla: new THREE.Color(c.niebla),
     solPos: new THREE.Vector3(...(c.sol || SOL_DEFECTO)),
     intensidad: c.intensidad,
-    nieblaLejos: c.nieblaLejos + 8,
+    // El valle grande pide más aire antes de la niebla (antes +8): que la
+    // cordillera nueva (z≤-21) se lea, no se coma.
+    nieblaLejos: c.nieblaLejos + 18,
   };
 }
 
@@ -1359,7 +1635,7 @@ function AtmosferaValle({ c, perfil, reducedMotion }) {
       <color ref={fondoRef} attach="background" args={[ini.cielo[1]]} />
       {/* La niebla se paga por fragmento: en perfil 'bajo' se apaga. */}
       {perfil.fog && (
-        <fog ref={fogRef} attach="fog" args={[ini.niebla, 12, ini.nieblaLejos + 8]} />
+        <fog ref={fogRef} attach="fog" args={[ini.niebla, 16, ini.nieblaLejos + 18]} />
       )}
       <hemisphereLight
         ref={hemiRef}
@@ -1399,7 +1675,7 @@ function AtmosferaValle({ c, perfil, reducedMotion }) {
    la luna, como se ve una luna que apenas sale. Verificado contra el terreno:
    el rayo cámara→luna libra la loma (y=6.9 sobre 1.5 en x=-10; 6.2 sobre 3.1
    en el borde x=-17) y la cordillera queda lejos (z≤-15). */
-const POS_LUNA = /** @type {[number, number, number]} */ ([-21, 3.4, -8]);
+const POS_LUNA = /** @type {[number, number, number]} */ ([-28, 4.6, -11]);
 
 function LunaValle({ reducedMotion }) {
   const ref = useRef(null);
@@ -1439,15 +1715,17 @@ function LunaValle({ reducedMotion }) {
 
 /* Caja de las luciérnagas: la tierra baja del frente del valle (referencia
    ESTABLE — ParticulasAmbientales re-siembra si la caja cambia). */
-const AREA_LUCIERNAGAS = /** @type {[number, number, number]} */ ([18, 2.4, 7]);
+const AREA_LUCIERNAGAS = /** @type {[number, number, number]} */ ([26, 2.6, 10]);
 
 /* La pose de cámara del valle: UNA fuente para el Canvas y para el establishing
-   shot de la CámaraDirector (así el dolly aterriza EXACTO donde siempre). */
-const CAMARA_VALLE = { position: /** @type {[number, number, number]} */ ([10.5, 9, 13.5]), fov: 40 };
+   shot de la CámaraDirector (así el dolly aterriza EXACTO donde siempre).
+   REDISEÑO 2026-07: la cámara RETROCEDIÓ con el valle grande (48×48) — el
+   cuadro respira, los lugares regados caben todos y nada queda apeñuscado. */
+const CAMARA_VALLE = { position: /** @type {[number, number, number]} */ ([15.2, 13.4, 19.6]), fov: 40 };
 /* El target de reposo del valle: el corazón del mapa, al que CamaraViajera
-   lleva el target sin foco ((0,1.0,1.4) + 0.6 en y). El establishing del
+   lleva el target sin foco ((0,1.4,2.0) + 0.6 en y). El establishing del
    DirectorValle aterriza EXACTO aquí para no dar ningún salto al soltar. */
-const MIRA_VALLE = [0, 1.6, 1.4];
+const MIRA_VALLE = [0.3, 1.8, 2.6];
 
 /* El REPOSO CONSCIENTE DEL ASPECTO (dirección de cámara): el fov de three es
    VERTICAL — en un teléfono parado (aspecto ~0.46) los 40° dejan un fov
@@ -1470,8 +1748,9 @@ function poseValleParaAspecto(aspect) {
   }
   const cuanVertical = Math.min(1, (0.9 - aspect) / 0.44); // 0 en 0.9 → 1 en ~0.46
   // El PLANO PICADO del teléfono parado (misma acimut de la pose aprobada,
-  // polar ~40°): la cámara sube a 18.7 y la mira avanza a la finca (z 3.2).
-  const PICADO = { position: [9.3, 18.7, 15.1], fov: 58, mira: [-0.5, 0.6, 2.7] };
+  // polar ~40°): la cámara sube y pica para que la ladera del valle GRANDE
+  // corra a lo largo de la pantalla y los lugares respiren en vertical.
+  const PICADO = { position: [13, 26, 21], fov: 58, mira: [-0.6, 0.8, 3.6] };
   const lerp = (a, b) => a + (b - a) * cuanVertical;
   const position = /** @type {[number, number, number]} */ (
     CAMARA_VALLE.position.map((v, i) => lerp(v, PICADO.position[i]))
@@ -1488,7 +1767,7 @@ function poseValleParaAspecto(aspect) {
 }
 
 /* ── Contenido de la escena (dentro del Canvas). ── */
-function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false, aplanando = false, camaraDirector = false, beatsRef = null, portada = false, pose = null }) {
+function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = null, onAngelita = null, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false, aplanando = false, camaraDirector = false, beatsRef = null, portada = false, pose = null }) {
   /* La pose de reposo (aspecto-consciente, viene del host del Canvas). */
   const poseReposo = pose || { position: CAMARA_VALLE.position, fov: CAMARA_VALLE.fov, k: 1, mira: MIRA_VALLE };
   const miraReposo = poseReposo.mira || MIRA_VALLE;
@@ -1563,12 +1842,26 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
       />
       <VegetacionPisos nocturno={nocturno} perfil={perfil} />
 
-      {/* LA DIRECCIÓN DEL CUADRO: la casa-ancla donde descansa el ojo (con su
-          ventana cálida), los senderos de tierra pisada que nacen de ella (el
-          rastro del uso diario: el ojo camina por donde caminan los pies) y
-          los patios bajo cada lugar navegable (afordancia sin UI). */}
-      <CasaCampesina alturaDe={alturaTerreno} perfil={perfil} nocturno={nocturno} />
+      {/* LA DIRECCIÓN DEL CUADRO: la casa-PUERTA donde descansa el ojo (su
+          puerta iluminada abre el mapa de los mundos), los senderos de tierra
+          pisada que nacen de ella (el rastro del uso diario), los PÓRTICOS de
+          los 6 portales (la puerta legible de cada patio) y los patios bajo
+          cada lugar navegable (afordancia sin UI). */}
+      <CasaCampesina
+        alturaDe={alturaTerreno}
+        perfil={perfil}
+        nocturno={nocturno}
+        reducedMotion={reducedMotion}
+        onPuerta={portada ? null : onCasa}
+      />
       <SenderosValle alturaDe={alturaTerreno} perfil={perfil} />
+      <PorticosPortales
+        mundos={MUNDOS_DIR}
+        alturaDe={alturaTerreno}
+        perfil={perfil}
+        nocturno={nocturno}
+        onEntrar={portada ? null : onEntrar}
+      />
       {/* EL PESO DE LAS COSAS: la sombra de contacto que planta cada objeto
           en su loma. Separa la profundidad sin mover nada — la casa, los
           hitos y las matas dejan de flotar. De noche se atenúa, no se va. */}
@@ -1629,6 +1922,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         reducedMotion={reducedMotion}
         posRef={camaraDirector ? avatarRef : null}
         conLuz={perfil.luzBeacon}
+        onTocar={portada ? null : onAngelita}
       />
 
       <CamaraViajera
@@ -1691,6 +1985,12 @@ export default function Valle3D({
   energia = 1,
   onEntrar,
   onAlerta,
+  /* LA CASA ES LA PUERTA (§2): tocar la puerta iluminada de la casa llama
+     aquí — el host abre el mapa de los 6 portales. */
+  onCasa = null,
+  /* ANGELITA INVITA (§6): tocar a la abeja central llama aquí — el host
+     abre la conversación con el agente. */
+  onAngelita = null,
   reducedMotion,
   tier = 'alto',
   /* El estado REAL de la finca (auditoría §5b): Angelita SIEMPRE lo refleja,
@@ -1750,6 +2050,8 @@ export default function Valle3D({
           hayAlerta={hayAlerta}
           onEntrar={onEntrar}
           onAlerta={onAlerta}
+          onCasa={onCasa}
+          onAngelita={onAngelita}
           reducedMotion={reducedMotion}
           perfil={perfil}
           tier={tier}

--- a/src/mockups/valle/animales.jsx
+++ b/src/mockups/valle/animales.jsx
@@ -2,32 +2,30 @@
    compartidos (MATERIAL_FINCA para la arboleda, MATERIAL_HATO para el ganado)
    además del componente. */
 /*
- * Animales de finca del valle — REALISTAS por raza (veredicto del operador:
- * "formas muy geométricas, aún no parecen animales reales" → rehechos).
+ * El POTRERO del valle — animales de finca REALISTAS por raza, regados en
+ * APARTOS divididos por CERCAS VIVAS (rediseño 2026-07, feedback del
+ * operador: "los animales más regados pero más lejos", y el spec del valle:
+ * cercas vivas de matarratón / nacedero / botón de oro — las especies
+ * reales de la cerca viva colombiana, que también son forraje y sombra).
  *
- * Las mallas viven en src/visual/mundo3d/finca/fincaRealista.geom.js: torso
- * como loft orgánico (silueta continua con lomo, grupa y panza reales), AO y
- * luz de cielo HORNEADOS en vertexColors y normales suaves preservadas en la
- * fusión. Cada animal son DOS draw-calls: el cuerpo (una malla) y la cabeza
- * (otra, local al pivote del cuello) para conservar el gesto vivo — la vaca
- * pasta, la gallina picotea, el cerdo hocica, el perro mira. Con
- * `reducedMotion` la escena queda quieta en un fotograma digno. Todo
- * procedural: cero GLTF, cero texturas, offline y liviano.
+ * La escena del aparto:
+ *   · CERCA VIVA 1 (transversal): separa el aparto del fondo (las vacas)
+ *     de los del frente. Con su portillo al centro (la vaca rota de aparto:
+ *     eso ES el pastoreo racional).
+ *   · CERCA VIVA 2 (longitudinal): separa ovejas (izquierda) de cerdos y
+ *     gallinero (derecha).
+ *   · TRANQUERA de madera al oriente (por donde llega el sendero de la casa).
  *
- * El hato del valle (razas reales de Colombia):
- *   · vaca Holstein (la lechera de clima frío) con su ternera criolla
- *   · cerdos que SE DISTINGUEN: zungo negro, duroc colorado y una landrace
- *     rosada larga con sus dos lechones
- *   · ovejas criollas de cara oscura (cada una con su vellón), gallinas
- *     (campesina/negra/blanca) + gallo, y el perro criollo amarillo
- *
- * Los personajes rubber-hose (src/visual/creatures/) NO se tocan: son la fauna
- * con alma. Esto es el ganado, y va realista. Decorativo (aria-hidden): el
- * botón accesible del mundo lo pone MundoLugar.
+ * Las mallas de los animales viven en fincaRealista.geom.js (torso loft
+ * orgánico, AO horneado, cabeza pivotante con gesto vivo). Las cercas vivas
+ * van INSTANCIADAS (troncos + copas + flores = 3-4 draw calls). Todo
+ * procedural: cero GLTF, cero texturas, offline y liviano. Decorativo
+ * (aria-hidden): el botón accesible del mundo lo pone MundoLugar.
  */
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
+import { Instances, Instance } from '@react-three/drei';
 import {
   geomVaca,
   geomCerdo,
@@ -126,9 +124,130 @@ function Comedero({ pos = [0, 0, 0] }) {
   );
 }
 
+/* ── LAS CERCAS VIVAS: matarratón, nacedero y botón de oro ────────────────
+   Las tres especies reales de la cerca viva colombiana, alternadas árbol a
+   árbol para que la cerca se lea VIVA (no un seto clonado):
+     · matarratón (Gliricidia sepium)      — copa verde claro, flor rosada
+     · nacedero  (Trichanthera gigantea)   — copa verde profundo, redonda
+     · botón de oro (Tithonia diversifolia) — mata baja con flores amarillas
+   Cada especie define su silueta; las flores solo en tier rico (q ≥ 1). */
+const ESPECIES_CERCA = [
+  // Copas CHICAS a propósito: de perfil la cerca debe leerse como HILERA de
+  // arbolitos (postes vivos), no como un bosquecito que tape el hato.
+  { copa: '#9fbf6a', flor: '#e8b7c2', rCopa: 0.17, hCopa: 0.24, hTronco: 0.52 }, // matarratón
+  { copa: '#6faa4e', flor: '#f0c02f', rCopa: 0.2, hCopa: 0.2, hTronco: 0.3 }, // botón de oro
+  { copa: '#4e8f4a', flor: null, rCopa: 0.18, hCopa: 0.26, hTronco: 0.44 }, // nacedero
+];
+
+/* Puestos de las dos cercas (coordenadas locales del potrero; el landmark
+   escala el conjunto). Cerca 1 = transversal en z=-0.75 con PORTILLO al
+   centro; cerca 2 = longitudinal en x=0.55, del portillo al frente. */
+function puestosCerca() {
+  const puestos = [];
+  let n = 0;
+  // Cerca 1: de x -2.3 a 2.3, saltando el portillo (-0.35..0.35).
+  for (let x = -2.3; x <= 2.31; x += 0.62) {
+    if (Math.abs(x) < 0.4) continue; // el portillo: por aquí rotan los animales
+    puestos.push({ x, z: -0.75 + Math.sin(n * 3.7) * 0.06, esp: n % 3 });
+    n += 1;
+  }
+  // Cerca 2: de z -0.45 a 2.2 en x=0.55 (separa ovejas de cerdos).
+  for (let z = -0.45; z <= 2.21; z += 0.66) {
+    puestos.push({ x: 0.55 + Math.sin(n * 2.9) * 0.06, z, esp: n % 3 });
+    n += 1;
+  }
+  return puestos;
+}
+
+function CercasVivas({ q = 1 }) {
+  const puestos = useMemo(() => puestosCerca(), []);
+  const conFlor = q >= 1;
+  const flores = conFlor
+    ? puestos.filter((p) => ESPECIES_CERCA[p.esp].flor)
+    : [];
+  return (
+    <group>
+      {/* troncos: 1 draw call */}
+      <Instances limit={puestos.length}>
+        <cylinderGeometry args={[0.03, 0.045, 1, 5]} />
+        <meshLambertMaterial color="#7a5a38" />
+        {puestos.map((p, i) => {
+          const e = ESPECIES_CERCA[p.esp];
+          return (
+            <Instance
+              key={i}
+              position={[p.x, e.hTronco / 2, p.z]}
+              scale={[1, e.hTronco, 1]}
+            />
+          );
+        })}
+      </Instances>
+      {/* copas por especie (color por instancia): 1 draw call */}
+      <Instances limit={puestos.length}>
+        <sphereGeometry args={[1, 8, 7]} />
+        <meshLambertMaterial />
+        {puestos.map((p, i) => {
+          const e = ESPECIES_CERCA[p.esp];
+          return (
+            <Instance
+              key={i}
+              position={[p.x, e.hTronco + e.hCopa * 0.7, p.z]}
+              scale={[e.rCopa, e.hCopa, e.rCopa]}
+              color={e.copa}
+            />
+          );
+        })}
+      </Instances>
+      {/* las flores del matarratón y el botón de oro (solo tier rico) */}
+      {flores.length > 0 && (
+        <Instances limit={flores.length}>
+          <sphereGeometry args={[0.055, 6, 5]} />
+          <meshBasicMaterial />
+          {flores.map((p, i) => {
+            const e = ESPECIES_CERCA[p.esp];
+            return (
+              <Instance
+                key={i}
+                position={[p.x + 0.1, e.hTronco + e.hCopa * 1.15, p.z + 0.08]}
+                color={e.flor}
+              />
+            );
+          })}
+        </Instances>
+      )}
+    </group>
+  );
+}
+
+/* La TRANQUERA de madera al oriente: por donde llega el sendero de la casa.
+   Dos botalones + tres varas — la puerta del potrero, legible de lejos. */
+function Tranquera({ pos = [2.35, 0, 0.6] }) {
+  return (
+    <group position={pos} rotation={[0, Math.PI / 2, 0]}>
+      {[-0.55, 0.55].map((dx, i) => (
+        <mesh key={i} position={[dx, 0.42, 0]} castShadow>
+          <cylinderGeometry args={[0.05, 0.06, 0.84, 6]} />
+          <meshStandardMaterial color="#6b4a2e" flatShading roughness={1} />
+        </mesh>
+      ))}
+      {[0.24, 0.46, 0.68].map((y, i) => (
+        <mesh key={i} position={[0, y, 0]} rotation={[0, 0, Math.PI / 2]}>
+          <cylinderGeometry args={[0.028, 0.028, 1.12, 5]} />
+          <meshStandardMaterial color="#8a6a44" flatShading roughness={1} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
 /*
- * La zona de animales del valle: el hato realista con aire entre animales.
+ * El potrero del valle: apartos con cerca viva y el hato regado.
  * `q` (0..1) baja el detalle geométrico en gama baja (lo pasa el landmark).
+ *
+ *   Aparto del FONDO (z < -0.75): las vacas, a sus anchas.
+ *   Aparto IZQUIERDO del frente:  las ovejas criollas.
+ *   Aparto DERECHO del frente:    los cerdos con sus lechones + el gallinero
+ *                                 suelto junto a la tranquera; el perro vigila.
  */
 export default function AnimalesDeFinca({ reducedMotion = false, q = 1 }) {
   // Las fábricas cachean por args: esto solo compone referencias.
@@ -142,6 +261,7 @@ export default function AnimalesDeFinca({ reducedMotion = false, q = 1 }) {
       lechon: geomLechon({ raza: 'landrace' }),
       oveja1: geomOveja({ q }),
       oveja2: geomOveja({ q }, 67),
+      oveja3: geomOveja({ q }, 71),
       campesina: geomGallina({ tipo: 'campesina', q }),
       negra: geomGallina({ tipo: 'negra', q }, 43),
       blanca: geomGallina({ tipo: 'blanca', q }, 45),
@@ -153,26 +273,36 @@ export default function AnimalesDeFinca({ reducedMotion = false, q = 1 }) {
   const rm = reducedMotion;
   return (
     <group>
-      {/* la Holstein manda el corral; su ternera criolla al lado */}
-      <Animal geom={g.holstein} gesto="pasta" pos={[0.2, 0, -0.4]} giro={-0.5} escala={0.62} reducedMotion={rm} />
-      <Animal geom={g.ternera} gesto="pasta" pos={[0.85, 0, 0.15]} giro={-1.1} escala={0.38} fase={2.2} reducedMotion={rm} />
-      {/* los cerdos POR RAZA: negro zungo, colorado duroc, landrace con cría */}
-      <Animal geom={g.zungo} gesto="hocica" pos={[-1.45, 0, -0.5]} giro={0.3} escala={0.62} reducedMotion={rm} />
-      <Animal geom={g.duroc} gesto="hocica" pos={[-0.95, 0, -1.0]} giro={1.1} escala={0.6} fase={1.9} reducedMotion={rm} />
-      <Animal geom={g.landrace} gesto="hocica" pos={[-1.55, 0, 0.35]} giro={-0.7} escala={0.62} fase={3.4} reducedMotion={rm} />
-      <mesh geometry={g.lechon} material={MATERIAL_HATO} position={[-1.2, 0, 0.62]} rotation={[0, -0.4, 0]} castShadow />
-      <mesh geometry={g.lechon} material={MATERIAL_HATO} position={[-1.75, 0, 0.72]} rotation={[0, 0.9, 0]} scale={0.9} castShadow />
-      {/* las ovejas criollas — vellones DISTINTOS (seed propia) */}
-      <Animal geom={g.oveja1} gesto="tantea" pos={[-0.45, 0, 1.05]} giro={1.4} escala={0.52} fase={1.7} reducedMotion={rm} />
-      <Animal geom={g.oveja2} gesto="tantea" pos={[0.15, 0, 1.35]} giro={0.5} escala={0.48} fase={4.1} reducedMotion={rm} />
-      {/* el gallinero suelto: tres gallinas + el gallo vigilante */}
-      <Animal geom={g.campesina} gesto="picotea" pos={[1.15, 0, 0.6]} giro={2.4} escala={0.8} fase={0.4} reducedMotion={rm} />
-      <Animal geom={g.negra} gesto="picotea" pos={[1.5, 0, 0.05]} giro={-1.2} escala={0.76} fase={2.1} reducedMotion={rm} />
-      <Animal geom={g.blanca} gesto="picotea" pos={[0.7, 0, 1.1]} giro={0.9} escala={0.78} fase={3.6} reducedMotion={rm} />
-      <Animal geom={g.gallo} gesto="picotea" pos={[1.45, 0, 0.95]} giro={-2.2} escala={0.9} fase={5.2} reducedMotion={rm} />
-      {/* el perro criollo, echado el ojo a todo desde su esquina */}
-      <Animal geom={g.perro} gesto="mira" pos={[1.05, 0, -0.85]} giro={-2.6} escala={0.7} fase={1.2} reducedMotion={rm} />
-      <Comedero pos={[1.55, 0.16, -0.45]} />
+      {/* las cercas vivas que dividen los apartos + la tranquera de entrada */}
+      <CercasVivas q={q} />
+      <Tranquera />
+
+      {/* APARTO DEL FONDO: la Holstein manda, su ternera criolla cerca pero
+          no encima — pastan regadas, como en potrero de verdad */}
+      <Animal geom={g.holstein} gesto="pasta" pos={[-1.3, 0, -1.7]} giro={-0.5} escala={0.62} reducedMotion={rm} />
+      <Animal geom={g.ternera} gesto="pasta" pos={[0.4, 0, -1.95]} giro={-1.2} escala={0.38} fase={2.2} reducedMotion={rm} />
+
+      {/* APARTO IZQUIERDO: las ovejas criollas — vellones DISTINTOS (seed propia) */}
+      <Animal geom={g.oveja1} gesto="tantea" pos={[-1.7, 0, 0.4]} giro={1.4} escala={0.52} fase={1.7} reducedMotion={rm} />
+      <Animal geom={g.oveja2} gesto="tantea" pos={[-0.9, 0, 1.4]} giro={0.5} escala={0.48} fase={4.1} reducedMotion={rm} />
+      <Animal geom={g.oveja3} gesto="tantea" pos={[-1.95, 0, 1.6]} giro={-0.9} escala={0.5} fase={5.6} reducedMotion={rm} />
+
+      {/* APARTO DERECHO: los cerdos POR RAZA, con aire entre ellos */}
+      <Animal geom={g.zungo} gesto="hocica" pos={[1.25, 0, 1.15]} giro={0.3} escala={0.62} reducedMotion={rm} />
+      <Animal geom={g.duroc} gesto="hocica" pos={[1.95, 0, 0.55]} giro={1.1} escala={0.6} fase={1.9} reducedMotion={rm} />
+      <Animal geom={g.landrace} gesto="hocica" pos={[1.05, 0, 1.95]} giro={-0.7} escala={0.62} fase={3.4} reducedMotion={rm} />
+      <mesh geometry={g.lechon} material={MATERIAL_HATO} position={[1.5, 0, 1.75]} rotation={[0, -0.4, 0]} castShadow />
+      <mesh geometry={g.lechon} material={MATERIAL_HATO} position={[0.75, 0, 1.55]} rotation={[0, 0.9, 0]} scale={0.9} castShadow />
+
+      {/* el gallinero suelto junto a la tranquera + el gallo vigilante */}
+      <Animal geom={g.campesina} gesto="picotea" pos={[1.75, 0, -0.3]} giro={2.4} escala={0.8} fase={0.4} reducedMotion={rm} />
+      <Animal geom={g.negra} gesto="picotea" pos={[2.05, 0, -0.1]} giro={-1.2} escala={0.76} fase={2.1} reducedMotion={rm} />
+      <Animal geom={g.blanca} gesto="picotea" pos={[1.15, 0, -0.35]} giro={0.9} escala={0.78} fase={3.6} reducedMotion={rm} />
+      <Animal geom={g.gallo} gesto="picotea" pos={[1.45, 0, -0.05]} giro={-2.2} escala={0.9} fase={5.2} reducedMotion={rm} />
+
+      {/* el perro criollo, echado el ojo a todo desde la tranquera */}
+      <Animal geom={g.perro} gesto="mira" pos={[2.15, 0, 0.05]} giro={-2.6} escala={0.7} fase={1.2} reducedMotion={rm} />
+      <Comedero pos={[1.65, 0.16, 0.15]} />
     </group>
   );
 }

--- a/src/mockups/valle/composicionValle3D.jsx
+++ b/src/mockups/valle/composicionValle3D.jsx
@@ -7,17 +7,21 @@
  * frame. Recibe `alturaDe(x, z)` del host (Valle3D es dueño del terreno):
  * nada de aquí importa Valle3D — sin ciclos.
  *
- *   · CasaCampesina    — el ancla del cuadro: encalada, zócalo pintado, teja,
- *                        y la ventana con luz cálida (la casa espera).
+ *   · CasaCampesina    — el corazón del cuadro Y LA PUERTA DE LOS MUNDOS
+ *                        (rediseño 2026-07): la puerta iluminada invita a
+ *                        tocar y abre el mapa de los 6 portales.
+ *   · PorticosPortales — los pórticos de madera de los 6 portales: dos pies
+ *                        derechos + dintel + farolito + tablita con el tinte
+ *                        del mundo. La puerta legible de cada patio.
  *   · SenderosValle    — la tierra pisada que nace de la casa: el rastro del
  *                        uso diario, el ojo camina por donde caminan los pies.
  *   · PatiosLugares    — el suelo desnudo bajo cada lugar navegable: la
  *                        afordancia diegética de "aquí se llega".
- *   · SecundariosDeTierra — los vecinos del monte (el oso, el borugo…) a ras
- *                        de suelo, lejos y chicos: acompañan, no compiten.
- *                        Registro-driven: un slug ausente no monta nada.
+ *   · VecinosDelValle  — los personajes en su casa del valle, registro-driven:
+ *                        un slug ausente no monta nada.
  */
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
 import { Html, Instances, Instance } from '@react-three/drei';
 import * as THREE from 'three';
 import { CREATURES } from '../../visual/creatures/index.js';
@@ -25,6 +29,7 @@ import {
   CASA_VALLE,
   SENDEROS_VALLE,
   PATIO,
+  PORTALES_VALLE,
   JERARQUIA_PERSONAJES,
   VECINOS_VALLE,
 } from '../../visual/mundo3d/direccion/composicionValle.js';
@@ -37,20 +42,60 @@ const CASA = {
   tejaSombra: '#8f4b31',
   madera: '#6b4a2e',
   ventana: '#ffd9a0',
+  puerta: '#ffca7a', // la luz que sale por la puerta abierta: la invitación
 };
 
 /**
- * La casa campesina: ancla de composición, NO navegable (aria nada, cero
- * toques). Modesta a propósito: sostiene el cuadro sin pedir protagonismo.
- * La ventana emisiva es "la casa espera": de día apenas se nota, al
- * atardecer y de noche es el corazón cálido del valle.
+ * La casa campesina: el corazón del cuadro y — rediseño 2026-07 — LA PUERTA
+ * DE LOS MUNDOS. Su puerta está ABIERTA y con luz cálida adentro (la casa
+ * invita), pulsa apenas como el faro del día, y tocarla abre el mapa de los
+ * 6 portales (`onPuerta`). Modesta a propósito en lo demás: sostiene el
+ * cuadro sin pedir espectáculo.
  */
-export function CasaCampesina({ alturaDe, perfil, nocturno = false }) {
+export function CasaCampesina({ alturaDe, perfil, nocturno = false, reducedMotion = false, onPuerta = null }) {
   const [cx, cz] = CASA_VALLE.pos;
+  const esc = CASA_VALLE.escala || 1;
   const y = alturaDe(cx, cz);
   const rico = perfil.materialRico;
+  const puertaRef = useRef(null);
+  const haloRef = useRef(null);
+  // La puerta RESPIRA (brillo que sube y baja, ~0.4 Hz): la afordancia viva
+  // de "toque para entrar". Con reduced-motion queda en su brillo medio.
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const p = (Math.sin(state.clock.elapsedTime * 2.4) + 1) / 2;
+    if (puertaRef.current) puertaRef.current.emissiveIntensity = (nocturno ? 1.5 : 0.85) + p * 0.55;
+    if (haloRef.current) haloRef.current.opacity = 0.16 + p * 0.1;
+  });
   return (
-    <group position={[cx, y, cz]} rotation={[0, CASA_VALLE.rotY, 0]}>
+    <group
+      position={[cx, y, cz]}
+      rotation={[0, CASA_VALLE.rotY, 0]}
+      scale={esc}
+      onClick={
+        onPuerta
+          ? (e) => {
+              e.stopPropagation();
+              onPuerta();
+            }
+          : undefined
+      }
+      onPointerOver={
+        onPuerta
+          ? (e) => {
+              e.stopPropagation();
+              document.body.style.cursor = 'pointer';
+            }
+          : undefined
+      }
+      onPointerOut={
+        onPuerta
+          ? () => {
+              document.body.style.cursor = '';
+            }
+          : undefined
+      }
+    >
       {/* el zócalo pintado (la franja baja de color de toda casa de vereda) */}
       <mesh position={[0, 0.11, 0]} castShadow={perfil.sombras} receiveShadow={perfil.sombras}>
         <boxGeometry args={[1.52, 0.22, 1.06]} />
@@ -74,16 +119,45 @@ export function CasaCampesina({ alturaDe, perfil, nocturno = false }) {
         <boxGeometry args={[0.12, 0.07, 1.3]} />
         <meshStandardMaterial color={CASA.tejaSombra} flatShading roughness={1} />
       </mesh>
-      {/* la puerta de madera, al frente (el lado del corredor) */}
-      <mesh position={[-0.3, 0.42, 0.52]}>
-        <boxGeometry args={[0.3, 0.52, 0.05]} />
+      {/* EL MARCO de la puerta, de madera (la puerta está ABIERTA de par en
+          par: la hoja recostada al muro) */}
+      <mesh position={[-0.48, 0.44, 0.53]}>
+        <boxGeometry args={[0.05, 0.56, 0.05]} />
         <meshStandardMaterial color={CASA.madera} flatShading roughness={1} />
+      </mesh>
+      <mesh position={[-0.12, 0.44, 0.53]}>
+        <boxGeometry args={[0.05, 0.56, 0.05]} />
+        <meshStandardMaterial color={CASA.madera} flatShading roughness={1} />
+      </mesh>
+      <mesh position={[-0.3, 0.7, 0.53]}>
+        <boxGeometry args={[0.42, 0.06, 0.05]} />
+        <meshStandardMaterial color={CASA.madera} flatShading roughness={1} />
+      </mesh>
+      {/* la hoja abierta, recostada hacia afuera */}
+      <mesh position={[-0.58, 0.42, 0.58]} rotation={[0, 0.9, 0]}>
+        <boxGeometry args={[0.3, 0.52, 0.04]} />
+        <meshStandardMaterial color={CASA.madera} flatShading roughness={1} />
+      </mesh>
+      {/* LA LUZ DE LA PUERTA: el vano encendido — la entrada a los mundos.
+          Pulsa apenas (useFrame de arriba): "toque para entrar". */}
+      <mesh position={[-0.3, 0.42, 0.52]}>
+        <boxGeometry args={[0.32, 0.52, 0.03]} />
+        <meshStandardMaterial
+          ref={puertaRef}
+          color={CASA.puerta}
+          emissive={CASA.puerta}
+          emissiveIntensity={nocturno ? 1.6 : 1.0}
+          flatShading
+        />
+      </mesh>
+      {/* el charco de luz que la puerta tira sobre el corredor (afordancia) */}
+      <mesh position={[-0.3, 0.045, 0.92]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[0.55, 18]} />
+        <meshBasicMaterial ref={haloRef} color={CASA.puerta} transparent opacity={0.2} depthWrite={false} />
       </mesh>
       {/* LA VENTANA CON LUZ: la casa espera (emisiva, cálida, chiquita).
           De NOCHE es el FARO del valle (día-por-noche: la práctica que
-          orienta): brilla más fuerte, tira un charco cálido sobre la tierra
-          del corredor, y — solo donde el perfil paga luces — una pointLight
-          ámbar baña la fachada. El punto de referencia para volver a casa. */}
+          orienta). El punto de referencia para volver a casa. */}
       <mesh position={[0.34, 0.56, 0.52]}>
         <boxGeometry args={[0.26, 0.24, 0.04]} />
         <meshStandardMaterial
@@ -134,6 +208,174 @@ export function CasaCampesina({ alturaDe, perfil, nocturno = false }) {
   );
 }
 
+/* ── PÓRTICOS de los 6 portales: la puerta legible de cada patio ─────────
+   Dos pies derechos de madera + dintel + FAROLITO cálido encima + la tablita
+   colgada con el TINTE del mundo: se lee "por aquí se entra" sin leer nada.
+   Cada pórtico mira HACIA LA CASA (de donde llega el sendero) y se para al
+   borde del patio, no encima del landmark. Tocarlo entra al mundo (misma
+   afordancia que el lugar). En perfil frugal los pórticos van instanciados
+   (4 draw calls) y el toque lo sigue dando el landmark. */
+const MAT_PORTICO = new THREE.MeshLambertMaterial({ color: '#7a5a38' });
+const MAT_FAROL = new THREE.MeshStandardMaterial({
+  color: '#ffd88f',
+  emissive: '#ffb24d',
+  emissiveIntensity: 0.9,
+  flatShading: true,
+});
+
+function sitiosPorticos(mundos) {
+  const [cx, cz] = CASA_VALLE.pos;
+  const porId = Object.fromEntries(mundos.map((m) => [m.id, m]));
+  return PORTALES_VALLE.map((p) => {
+    const m = porId[p.id];
+    if (!m) return null;
+    const [x, , z] = m.pos;
+    // Mirar hacia la casa: el pórtico recibe al que llega por el sendero.
+    const rotY = Math.atan2(cx - x, cz - z);
+    const esc = m.escala || 1;
+    // Al borde del patio, del lado de la casa (el umbral, no el centro).
+    const d = PATIO.radioBase * esc + 0.55;
+    const px = x + Math.sin(rotY) * d;
+    const pz = z + Math.cos(rotY) * d;
+    return { portal: p, mundo: m, x: px, z: pz, rotY, tinte: m.tinte };
+  }).filter(Boolean);
+}
+
+function PorticoRico({ sitio, alturaDe, onEntrar, nocturno }) {
+  const y = alturaDe(sitio.x, sitio.z);
+  return (
+    <group
+      position={[sitio.x, y, sitio.z]}
+      rotation={[0, sitio.rotY, 0]}
+      onClick={
+        onEntrar
+          ? (e) => {
+              e.stopPropagation();
+              onEntrar(sitio.mundo.id);
+            }
+          : undefined
+      }
+      onPointerOver={
+        onEntrar
+          ? (e) => {
+              e.stopPropagation();
+              document.body.style.cursor = 'pointer';
+            }
+          : undefined
+      }
+      onPointerOut={
+        onEntrar
+          ? () => {
+              document.body.style.cursor = '';
+            }
+          : undefined
+      }
+    >
+      {/* los dos pies derechos */}
+      <mesh position={[-0.62, 0.72, 0]} material={MAT_PORTICO} castShadow>
+        <cylinderGeometry args={[0.055, 0.07, 1.44, 6]} />
+      </mesh>
+      <mesh position={[0.62, 0.72, 0]} material={MAT_PORTICO} castShadow>
+        <cylinderGeometry args={[0.055, 0.07, 1.44, 6]} />
+      </mesh>
+      {/* el dintel, con su parcito de tejas de remate */}
+      <mesh position={[0, 1.48, 0]} material={MAT_PORTICO} castShadow>
+        <boxGeometry args={[1.52, 0.1, 0.14]} />
+      </mesh>
+      <mesh position={[0, 1.58, 0]} rotation={[0, 0, 0]} castShadow>
+        <boxGeometry args={[1.62, 0.05, 0.24]} />
+        <meshLambertMaterial color="#8f4b31" />
+      </mesh>
+      {/* el farolito: la lucecita que dice "esta puerta está viva" */}
+      <mesh position={[0, 1.72, 0]} material={MAT_FAROL}>
+        <octahedronGeometry args={[0.11, 0]} />
+      </mesh>
+      {/* la tablita colgada con el tinte del mundo (la seña de la puerta) */}
+      <mesh position={[0, 1.22, 0]}>
+        <boxGeometry args={[0.56, 0.3, 0.05]} />
+        <meshLambertMaterial
+          color={sitio.tinte[0]}
+          emissive={nocturno ? sitio.tinte[0] : '#000000'}
+          emissiveIntensity={nocturno ? 0.35 : 0}
+        />
+      </mesh>
+    </group>
+  );
+}
+
+export function PorticosPortales({ mundos, alturaDe, perfil, nocturno = false, onEntrar = null }) {
+  const sitios = useMemo(() => sitiosPorticos(mundos), [mundos]);
+  if (perfil.materialRico) {
+    return (
+      <group>
+        {sitios.map((s) => (
+          <PorticoRico
+            key={s.portal.id}
+            sitio={s}
+            alturaDe={alturaDe}
+            onEntrar={onEntrar}
+            nocturno={nocturno}
+          />
+        ))}
+      </group>
+    );
+  }
+  // Frugal: pies + dintel + tablita + farol en 4 Instances (4 draw calls);
+  // el toque lo captura el landmark del mundo, como siempre.
+  return (
+    <group>
+      <Instances limit={sitios.length * 2}>
+        <cylinderGeometry args={[0.06, 0.07, 1.44, 5]} />
+        <meshLambertMaterial color="#7a5a38" />
+        {sitios.flatMap((s) => {
+          const y = alturaDe(s.x, s.z);
+          const c = Math.cos(s.rotY);
+          const sn = Math.sin(s.rotY);
+          return [-0.62, 0.62].map((dx, i) => (
+            <Instance
+              key={`${s.portal.id}${i}`}
+              position={[s.x + c * dx, y + 0.72, s.z - sn * dx]}
+            />
+          ));
+        })}
+      </Instances>
+      <Instances limit={sitios.length}>
+        <boxGeometry args={[1.56, 0.1, 0.16]} />
+        <meshLambertMaterial color="#7a5a38" />
+        {sitios.map((s) => (
+          <Instance
+            key={s.portal.id}
+            position={[s.x, alturaDe(s.x, s.z) + 1.48, s.z]}
+            rotation={[0, s.rotY, 0]}
+          />
+        ))}
+      </Instances>
+      <Instances limit={sitios.length}>
+        <boxGeometry args={[0.56, 0.3, 0.05]} />
+        <meshLambertMaterial />
+        {sitios.map((s) => (
+          <Instance
+            key={s.portal.id}
+            position={[s.x, alturaDe(s.x, s.z) + 1.22, s.z]}
+            rotation={[0, s.rotY, 0]}
+            color={s.tinte[0]}
+          />
+        ))}
+      </Instances>
+      <Instances limit={sitios.length}>
+        <octahedronGeometry args={[0.11, 0]} />
+        <meshBasicMaterial color="#ffcf87" />
+        {sitios.map((s) => (
+          <Instance
+            key={s.portal.id}
+            position={[s.x, alturaDe(s.x, s.z) + 1.72, s.z]}
+          />
+        ))}
+      </Instances>
+    </group>
+  );
+}
+
 /* ── Senderos: cintas de tierra pisada posadas sobre el terreno ──────────
    Un tubo enterrado a medias por sendero (queda la venita superior visible):
    1 draw call por camino, Lambert (los caminos no piden PBR). En frugal solo
@@ -148,14 +390,14 @@ export function SenderosValle({ alturaDe, perfil }) {
         const pts = s.puntos.map(([x, z]) => new THREE.Vector3(x, alturaDe(x, z) + 0.03, z));
         const curva = new THREE.CatmullRomCurve3(pts);
         // Radio corto y medio hundido: asoma la huella, no un caño.
-        return new THREE.TubeGeometry(curva, s.puntos.length * (rico ? 7 : 5), 0.16, 4, false);
+        return new THREE.TubeGeometry(curva, s.puntos.length * (rico ? 7 : 5), 0.19, 4, false);
       }),
     [alturaDe, rico],
   );
   return (
     <group>
       {geos.map((g, i) => (
-        <mesh key={i} geometry={g} material={MAT_SENDERO} position={[0, -0.07, 0]} />
+        <mesh key={i} geometry={g} material={MAT_SENDERO} position={[0, -0.08, 0]} />
       ))}
     </group>
   );
@@ -201,13 +443,13 @@ export function PatiosLugares({ mundos, alturaDe, nocturno = false }) {
 
 /* ── Los VECINOS del valle: los personajes en su casa ────────────────────
    La puesta en escena de los personajes rubber-hose (feedback del operador:
-   el oso y los demás no pueden ser garnish de la abejita). Cada vecino vive
+   los personajes no pueden ser garnish de la abejita). Cada vecino vive
    en SU rincón (VECINOS_VALLE) con presencia digna, y `franjas` decide
-   cuándo sale — el borugo al caer el sol, el jaguar solo como aparecido.
-   Billboards <Html> aria-hidden, cero toques (JERARQUIA_PERSONAJES): la ley
-   sigue siendo presencia, no interfaz. Un slug que no exista en CREATURES
-   simplemente no monta — las ramas de personajes mejoran el dibujo al
-   mergear sin tocar este mapa. */
+   cuándo sale — el jaguar solo como aparecido. Billboards <Html>
+   aria-hidden, cero toques (JERARQUIA_PERSONAJES): la ley sigue siendo
+   presencia, no interfaz. Un slug que no exista en CREATURES simplemente
+   no monta — las ramas de personajes mejoran el dibujo al mergear sin
+   tocar este mapa. */
 export function VecinosDelValle({ alturaDe, reducedMotion, franja = null }) {
   return (
     <group>

--- a/src/mockups/valle/directorValle.js
+++ b/src/mockups/valle/directorValle.js
@@ -96,12 +96,13 @@ const ANTICIPO = { abre: 0.06 };
 const ZERO3 = Object.freeze(new THREE.Vector3());
 
 /* ── El BARRIDO de presentación ───────────────────────────────────────────
-   Waypoints en unidades de mundo del valle (terreno 34×34; la cordillera al
-   fondo en z≈-15, la quebrada baja de (-3.4,-7.2) a (3.6,8), los mundos entre
-   z -2.5 y 6.5). Arranca ALTO sobre el páramo mirando la ladera, planea sobre
-   la quebrada y los mundos, y cae hacia la pose jugable. El último tramo lo
-   cubre el resorte de asentamiento (por eso la curva termina CERCA del reposo,
-   no encima). El modo sobrio recorta el barrido a un dolly corto en arco. */
+   Waypoints en unidades de mundo del valle (terreno 48×48 tras el rediseño;
+   la cordillera al fondo en z≈-22, la quebrada baja de (-4.6,-11) a
+   (4.6,11.5), los mundos entre z -9.4 y 9.6). Arranca ALTO sobre el páramo
+   mirando la ladera, planea sobre la quebrada y los mundos, y cae hacia la
+   pose jugable. El último tramo lo cubre el resorte de asentamiento (por eso
+   la curva termina CERCA del reposo, no encima). El modo sobrio recorta el
+   barrido a un dolly corto en arco. */
 export function waypointsPresentacion(modo, reposo, mira) {
   const [rx, ry, rz] = reposo;
   const [mx, my, mz] = mira;
@@ -122,15 +123,15 @@ export function waypointsPresentacion(modo, reposo, mira) {
   }
   return {
     pos: [
-      [-13, 15.5, -6], // alto sobre el páramo: la ladera entera y el río de lado
-      [-14.5, 11, 6], // planeo por el costado: la quebrada baja en cuadro
-      [-4, 8.6, 15], // frente del valle: los mundos y la fauna, de cerca
+      [-18, 20, -9], // alto sobre el páramo: la ladera entera y el río de lado
+      [-20, 15, 9], // planeo por el costado: la quebrada baja en cuadro
+      [-6, 11.5, 21], // frente del valle: la casa-puerta, los pórticos, la fauna
       [rx * 0.86, ry * 1.06, rz * 0.94], // casi la pose jugable (remata el resorte)
     ],
     mira: [
-      [1.5, 2.6, 2.5],
-      [0.5, 1.6, 0.8],
-      [0.2, 1.2, 0.6],
+      [2, 3.2, 3.2],
+      [0.7, 2.2, 1.2],
+      [0.2, 1.6, 1.0],
       [mx, my + 0.1, mz - 0.1],
     ],
     fovDesde: 46,

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -35,13 +35,15 @@ import { horaDeReloj } from '../../visual/mundo3d/cielosHoraData.js';
  * cálido) hacia arriba (fondo, páramo).
  */
 export const PISOS_TERMICOS = [
+  // (Franjas ESCALADAS al valle grande — terreno 48×48, rediseño 2026-07:
+  //  el valle respira y cada piso ocupa más ladera.)
   {
     id: 'calido',
     nombre: 'Tierra caliente',
     msnm: '0–1000 m',
     tempC: '> 24 °C',
-    z0: 3.4, // borde frontal de la franja (bajo, cerca de la cámara)
-    z1: 8.5, // borde trasero
+    z0: 4.9, // borde frontal de la franja (bajo, cerca de la cámara)
+    z1: 12.4, // borde trasero
     color: '#84a83f', // verde cálido amarillento
     cresta: '#afc85a',
     vegetacion: 'platano',
@@ -52,8 +54,8 @@ export const PISOS_TERMICOS = [
     nombre: 'Clima medio',
     msnm: '1000–2000 m',
     tempC: '18–24 °C',
-    z0: -0.6,
-    z1: 3.4,
+    z0: -0.9,
+    z1: 4.9,
     color: '#4e9143', // verde vivo
     cresta: '#77b256',
     vegetacion: 'cafe',
@@ -64,8 +66,8 @@ export const PISOS_TERMICOS = [
     nombre: 'Clima frío',
     msnm: '2000–3000 m',
     tempC: '12–18 °C',
-    z0: -5.2,
-    z1: -0.6,
+    z0: -7.6,
+    z1: -0.9,
     color: '#3c7f64', // verde-azulado
     cresta: '#5fa07f',
     vegetacion: 'papa',
@@ -76,8 +78,8 @@ export const PISOS_TERMICOS = [
     nombre: 'Páramo',
     msnm: '> 3000 m',
     tempC: '< 12 °C',
-    z0: -11,
-    z1: -5.2,
+    z0: -16,
+    z1: -7.6,
     color: '#63807a', // frío grisáceo del alto andino
     cresta: '#8ba597',
     vegetacion: 'frailejon',
@@ -98,15 +100,24 @@ export function pisoEnZ(z) {
  * el centro y hacen legible el cambio de vegetación por altura). Cada una trae
  * el `tipo` que su piso siembra — la geometría la resuelve la escena. */
 export const VEGETACION_PISOS = [
-  { piso: 'paramo', pos: [-5.6, -7.8] },
-  { piso: 'paramo', pos: [1.4, -8.4] },
-  { piso: 'paramo', pos: [4.8, -6.6] },
-  { piso: 'frio', pos: [-6.0, -3.6] },
-  { piso: 'frio', pos: [3.0, -4.4] },
-  { piso: 'templado', pos: [-2.4, 1.0] },
-  { piso: 'templado', pos: [6.2, 2.6] },
-  { piso: 'calido', pos: [-6.4, 6.4] },
-  { piso: 'calido', pos: [5.8, 6.0] },
+  // (Regadas por el valle grande: más matas, más aire entre ellas.)
+  { piso: 'paramo', pos: [-8.2, -11.4] },
+  { piso: 'paramo', pos: [-1.6, -12.6] },
+  { piso: 'paramo', pos: [2.4, -12.0] },
+  { piso: 'paramo', pos: [7.0, -9.6] },
+  { piso: 'paramo', pos: [-11.4, -9.0] },
+  { piso: 'frio', pos: [-8.8, -5.2] },
+  { piso: 'frio', pos: [-1.8, -5.6] },
+  { piso: 'frio', pos: [4.2, -6.6] },
+  { piso: 'frio', pos: [10.2, -3.6] },
+  { piso: 'templado', pos: [-11.0, 2.4] },
+  { piso: 'templado', pos: [-3.2, 0.2] },
+  { piso: 'templado', pos: [9.6, 1.6] },
+  { piso: 'templado', pos: [4.4, 2.6] },
+  { piso: 'calido', pos: [-11.2, 7.6] },
+  { piso: 'calido', pos: [-1.4, 9.2] },
+  { piso: 'calido', pos: [5.6, 10.8] },
+  { piso: 'calido', pos: [10.8, 6.4] },
 ].map((v) => {
   const piso = PISOS_TERMICOS.find((p) => p.id === v.piso);
   return { ...v, tipo: piso ? piso.vegetacion : 'platano' };
@@ -124,33 +135,59 @@ export const VEGETACION_PISOS = [
  * semillero abajo en la tierra caliente. Pocos y separados > muchos amontonados.
  */
 const LUGARES = [
-  { id: 'agua', pos: [1.4, 0, -0.2], escala: 1, tipo: 'quebrada' },
-  { id: 'cafe', pos: [4.4, 0, 1.0], escala: 1, tipo: 'cafetal' },
-  { id: 'cultivos', pos: [-4.4, 0, 2.4], escala: 1.15, tipo: 'milpa' },
-  { id: 'suelo', pos: [-1.4, 0, 4.8], escala: 1, tipo: 'era' },
-  { id: 'sanidad', pos: [3.8, 0, 4.9], escala: 0.95, tipo: 'huerta' },
-  { id: 'animales', pos: [-5.0, 0, 5.4], escala: 1, tipo: 'animales' },
-  { id: 'disenio', pos: [5.2, 0, -3.4], escala: 1.1, tipo: 'bosque' },
-  { id: 'clima', pos: [-3.2, 0, -6.0], escala: 1, tipo: 'veleta' },
-  // El mercado, abajo en la tierra caliente, cerca de la salida a la plaza: el
-  // puesto con su toldo donde la cosecha de la finca sale a venderse.
-  { id: 'mercado', pos: [1.2, 0, 6.6], escala: 1, tipo: 'mercado' },
-  // El semillero, abajo cerca de la casa: el túnel de media-sombra donde nace y
-  // se cría la matica antes de salir al lote. (anti-conflicto: lugar nuevo al final.)
-  { id: 'semillero', pos: [-2.6, 0, 6.2], escala: 1, tipo: 'semillero' },
-  // El suelo vivo / red micorrízica, en el corazón cultivado (entre el suelo y
-  // los cultivos): unos hongos que asoman = el fruto de la red bajo tierra. Toque
-  // ahí para BAJAR al mundo subterráneo. (anti-conflicto: lugar nuevo al final.)
-  { id: 'micorrizas', pos: [-2.7, 0, 3.3], escala: 1, tipo: 'hongos' },
+  // (Las posiciones finales las manda COMPOSICION_LUGARES — la capa del
+  //  director en visual/mundo3d/direccion; estas son el respaldo crudo.)
+  { id: 'agua', pos: [1.0, 0, -2.0], escala: 1, tipo: 'quebrada' },
+  // El cafetal CON SOMBRÍO: café bajo guamo y plátano — policultivo, no hilera.
+  { id: 'cafe', pos: [6.0, 0, 0.6], escala: 1.1, tipo: 'cafetal' },
+  // La milpa-PARCELA (portal MIS MATAS): maíz + fríjol + calabaza juntos,
+  // leída como granja viva de Age of Empires — jamás monocultivo.
+  { id: 'cultivos', pos: [-8.4, 0, 0.8], escala: 1.3, tipo: 'milpa' },
+  { id: 'suelo', pos: [-3.6, 0, 6.8], escala: 1, tipo: 'era' },
+  { id: 'sanidad', pos: [2.8, 0, 5.6], escala: 0.95, tipo: 'huerta' },
+  // El POTRERO (portal MIS ANIMALES): apartos divididos por cercas vivas de
+  // matarratón, nacedero y botón de oro; los animales regados, no amontonados.
+  { id: 'animales', pos: [-8.6, 0, 8.6], escala: 1.35, tipo: 'animales' },
+  { id: 'disenio', pos: [7.2, 0, -4.4], escala: 1.25, tipo: 'bosque' },
+  { id: 'clima', pos: [-5.0, 0, -9.4], escala: 1.05, tipo: 'veleta' },
+  // El mercado (portal VENDER), abajo en la tierra caliente, la salida a la
+  // plaza: el puesto con su toldo donde la cosecha sale a venderse.
+  { id: 'mercado', pos: [8.6, 0, 9.0], escala: 1.05, tipo: 'mercado' },
+  // El INVERNADERO (micro-mundo del semillero): arcos y plástico donde nace
+  // y se cría la matica antes de salir al lote.
+  { id: 'semillero', pos: [-6.8, 0, 6.6], escala: 1.25, tipo: 'invernadero' },
+  // El suelo vivo / red micorrízica: unos hongos que asoman = el fruto de la
+  // red bajo tierra. Toque ahí para BAJAR al mundo subterráneo.
+  { id: 'micorrizas', pos: [-5.2, 0, 1.6], escala: 1, tipo: 'hongos' },
+  // La BIOFÁBRICA (mundo real 'abono'): la pila de compost cerca del potrero
+  // pero diferenciada — el ciclo estiércol→abono legible en el mapa.
+  { id: 'abono', pos: [-4.9, 0, 9.6], escala: 1, tipo: 'compost' },
+  // El KIOSCO DEL SABER (portal APRENDER): el tablero bajo techito de paja a
+  // la vera del camino de la plaza. Aún sin mundo propio en el manifiesto:
+  // trae su identidad de respaldo (fallbackMundo) mientras el hub de juegos
+  // abre su puerta (otro frente lo construye).
+  {
+    id: 'aprender',
+    pos: [7.4, 0, 4.2],
+    escala: 1.05,
+    tipo: 'saber',
+    fallbackMundo: {
+      titulo: 'Aprender',
+      emoji: '📖',
+      lema: 'Los juegos y saberes de la finca, reunidos en un solo patio.',
+      tinte: ['#b3771d', '#f2dfae'],
+    },
+  },
 ];
 
 /**
  * Mundos del valle, ya resueltos contra el manifiesto real. Cada uno trae su
- * `titulo`, `emoji` y `tinte` verdaderos + la geometría de su lugar.
+ * `titulo`, `emoji` y `tinte` verdaderos + la geometría de su lugar. Un lugar
+ * sin mundo en el manifiesto (el kiosco de aprender) usa su `fallbackMundo`.
  */
 export const MUNDOS_VALLE = LUGARES.map((l) => {
   /** @type {{ titulo?: string, emoji?: string, lema?: string, tinte?: string[] }} */
-  const real = MUNDO_BY_ID[l.id] || {};
+  const real = MUNDO_BY_ID[l.id] || l.fallbackMundo || {};
   return {
     ...l,
     titulo: real.titulo || l.id,
@@ -426,7 +463,8 @@ export const NARRACION = {
   cafe: 'El cafetal bajo sombra. El café vive debajo del guamo, cargado de cereza roja. De ahí sale el grano: cereza, pergamino y oro. En la finca no se tuesta.',
   suelo: 'Las eras y el semillero. La tierra de aquí es la que pide cuidado esta noche.',
   agua: 'La quebrada que baja del monte. De aquí sale el agua para toda la finca.',
-  animales: 'El corral. Las gallinas y el ganado que cierran el ciclo del abono.',
+  animales:
+    'El potrero, dividido en apartos por cercas vivas de matarratón, nacedero y botón de oro: la cerca que también es comida y sombra. Los animales andan regados, cada grupo en su aparto.',
   sanidad:
     'La huerta de la casa. Aquí es donde primero se ven las plagas, para atajarlas a tiempo.',
   disenio: 'El monte y los árboles que sembró. La finca también es el bosque que la abraza.',
@@ -436,5 +474,11 @@ export const NARRACION = {
   pisos:
     'Suba por la montaña: del cálido al páramo, cada piso con lo suyo. Arriba manda el frailejón, que le peina el agua a la niebla y la entrega despacio al suelo. Por eso el páramo se cuida, no se ara.',
   semillero:
-    'El semillero, bajo su túnel de media-sombra. Aquí nace la matica: la semilla despierta en la bandeja, se repica a la bolsa y se endurece al sol antes de irse al campo. Del grano fuerte sale la finca fuerte.',
+    'El invernadero: el micro-mundo donde nace la matica. La semilla despierta en la bandeja bajo el plástico, se repica a la bolsa y se endurece al sol antes de irse al campo. Del grano fuerte sale la finca fuerte.',
+  abono:
+    'La biofábrica. Del potrero sale el estiércol, aquí se vuelve abono: la pila trabaja sola, con su calorcito y sus lombrices. El ciclo que no bota nada.',
+  aprender:
+    'El kiosco del saber: el tablero donde la finca enseña. Aquí van llegando los juegos y las lecciones del monte.',
+  casa:
+    'Esta es su casa: el corazón de la finca y la puerta de sus mundos. Toque una de las seis puertas para salir a donde necesite.',
 };

--- a/src/visual/mundo3d/GemeloValle2D.jsx
+++ b/src/visual/mundo3d/GemeloValle2D.jsx
@@ -37,7 +37,9 @@ import './GemeloValle2D.css';
 const VB_W = 480;
 const VB_H = 360;
 function iso(x, z) {
-  return { cx: 240 + (x - z) * 26, cy: 200 + (x + z) * 11 };
+  // (Escala al día con el VALLE GRANDE del rediseño 2026-07: los lugares
+  //  viven en x ∈ [-8.6, 8.6], z ∈ [-9.4, 9.6].)
+  return { cx: 240 + (x - z) * 12, cy: 200 + (x + z) * 8 };
 }
 function pct(x, z) {
   const { cx, cy } = iso(x, z);

--- a/src/visual/mundo3d/direccion/composicionValle.js
+++ b/src/visual/mundo3d/direccion/composicionValle.js
@@ -7,65 +7,89 @@
  * acompaña, por dónde camina el ojo. Valle3D lo consume como capa de
  * composición ENCIMA de valleData (que no se toca: otros frentes viven ahí).
  *
+ * ── REDISEÑO 2026-07 (feedback del operador) ─────────────────────────────
+ * "Todo muy pegado; aprovechar mejor el espacio; los animales más regados
+ * pero más lejos; nada se vea monocultivo; la casa no se ve como la entrada
+ * a los mundos." De ahí las cuatro leyes nuevas de esta composición:
+ *
+ *   1. EL VALLE RESPIRA: terreno jugable 48×48 (antes 34×34), aire mínimo
+ *      ~3 u entre lugares vecinos (antes ~2), cámara de reposo más lejos.
+ *   2. LA CASA ES LA PUERTA: deja de ser solo ancla — su puerta iluminada
+ *      ABRE el mapa de los mundos (los 6 portales). El corazón Y la boca.
+ *   3. SEIS PORTALES LEGIBLES: mis matas · mis animales · el tiempo ·
+ *      vender · aprender · toda mi finca — cada uno con su pórtico de
+ *      madera, su patio de tierra y su sendero desde la casa.
+ *   4. LA FINCA ES POLICULTIVO: potrero con cercas vivas, biofábrica con su
+ *      pila (el ciclo estiércol→abono legible), invernadero como micro-mundo,
+ *      milpa como parcela viva estilo "granja de Age of Empires".
+ *
  * ── LOS TRES CRITERIOS DEL ENCUADRE ──────────────────────────────────────
- * La cámara de reposo mira desde [10.5, 9, 13.5] hacia [0, 1.6, 1.4]:
+ * La cámara de reposo mira desde [14.6, 12.2, 18.8] hacia [0, 2.0, 2.0]:
  * el frente (+z, tierra caliente) queda CERCA y abajo; la ladera trepa al
  * páramo (-z) al fondo. De ahí las tres franjas de dirección:
  *
  *   1. LO DIARIO, A LA MANO (frente, cerca de la casa): lo que el campesino
- *      toca todos los días — el corral, las eras, el semillero, la huerta.
- *      La finca real es así: el trajín vive alrededor de la casa.
- *   2. LO SEMANAL, A MEDIA LADERA: la milpa, el cafetal, el agua. Se sube
- *      a ellos; el ojo los alcanza sin estorbar el frente.
+ *      toca todos los días — las eras, el invernadero, la huerta.
+ *   2. LO SEMANAL, A MEDIA LADERA: la milpa, el cafetal, el agua, y el
+ *      potrero de los animales (más lejos, con su propio aire).
  *   3. LO CONTEMPLATIVO, AL FONDO: el monte, la veleta en el filo del
  *      páramo. Son horizonte: se miran más de lo que se tocan.
- *
- * ── EL ANCLA: LA CASA ────────────────────────────────────────────────────
- * Toda finca se organiza alrededor de su casa, y el valle no tenía una: el
- * ojo descansaba en pasto vacío. La casa campesina (encalada, zócalo pintado,
- * techo de teja, la ventana con luz cálida) va donde la mirada de reposo
- * aterriza — no es un mundo navegable, es el HOGAR: el punto de silencio
- * del cuadro. Los senderos nacen de ella: el camino dice qué se usa.
  */
 
-/* ── 1. LA CASA (ancla de composición, no navegable) ─────────────────────
-   Apenas a la izquierda del punto de mira de reposo ([0, 1.6, 1.4]) para
-   componer por tercios: la casa descansa, la quebrada brilla a su derecha,
-   y el faro de la alerta queda con aire propio al frente. */
+/* ── 1. LA CASA (el corazón Y la puerta de los mundos) ───────────────────
+   Apenas a la izquierda del punto de mira de reposo ([0, 2.0, 2.0]) para
+   componer por tercios: la casa descansa, la quebrada brilla a su derecha.
+   Ya NO es solo ancla: su puerta iluminada es NAVEGABLE — tocarla abre el
+   mapa de los 6 portales. `escala` la agranda a la medida del valle nuevo. */
 export const CASA_VALLE = {
-  pos: [-0.9, 2.6], // [x, z] — la y la da el terreno
+  pos: [-1.4, 3.0], // [x, z] — la y la da el terreno
   rotY: 0.42, // el corredor mira hacia la cámara de reposo (suroriente)
+  escala: 1.3, // la casa creció con el valle: sigue mandando el cuadro
 };
 
 /* ── 2. DISPOSICIÓN COMPUESTA de los lugares ─────────────────────────────
-   Override de posición [x, z] por id de mundo. Solo se mueven los que
-   estaban puestos sin componer; los bien contados (agua sobre la quebrada,
-   la veleta en el filo del páramo, el bosque trepando al frío, el cafetal
-   en su piso) se quedan. Reglas duras que cumplen estas coordenadas:
-     · aire mínimo ~2 u entre lugares vecinos (los rótulos ya anti-colisionan
-       en pantalla; esto compone la GEOMETRÍA, no las etiquetas);
-     · cada lugar respeta su piso térmico (valleData.PISOS_TERMICOS);
-     · lo diario rodea la casa; las salidas (mercado) van al borde del cuadro. */
+   Override de posición [x, z] por id de mundo — EL MAPA COMPLETO del valle
+   grande. Reglas duras que cumplen estas coordenadas:
+     · aire mínimo ~3 u entre lugares vecinos (el valle regado que pidió el
+       operador — antes era ~2 u y todo se leía apeñuscado);
+     · cada lugar respeta su piso térmico (valleData.PISOS_TERMICOS, ya
+       escalados al terreno 48×48);
+     · lo diario rodea la casa; el potrero va lejos con su propio llano; las
+       salidas (mercado) van al borde del cuadro; el páramo manda arriba. */
 export const COMPOSICION_LUGARES = {
-  // El corral cierra la esquina izquierda del frente: lo diario, con aire.
-  animales: [-5.4, 5.8],
-  // El semillero entre el corral y las eras, un paso adelante (se cría cerca).
-  semillero: [-3.5, 6.5],
+  // La milpa-parcela (portal MIS MATAS): media ladera izquierda, clima medio.
+  cultivos: [-8.4, 0.8],
+  // El potrero (portal MIS ANIMALES): el llano frontal-izquierdo, LEJOS y
+  // ancho — los animales regados en sus apartos de cerca viva.
+  animales: [-8.6, 8.6],
+  // La biofábrica (pila de compost): CERCA del potrero pero DIFERENCIADA —
+  // el viaje del estiércol a la pila se lee en un sendero corto.
+  abono: [-4.9, 9.6],
   // Las eras al frente-izquierda de la casa: donde el faro del día se lee solo.
-  // (Un paso más allá de la casa: la píldora de la alerta — anclada aquí —
-  //  pisaba el techo desde la cámara de reposo; ahora el faro respira solo.)
-  suelo: [-2.3, 5.5],
-  // La huerta ES "la huerta de la casa" (su propia narración): pegada a ella.
-  sanidad: [3.4, 4.4],
-  // El mercado es LA SALIDA a la plaza: borde derecho-frontal, el camino que
-  // se va del cuadro. Antes tapaba el centro-bajo del encuadre.
-  mercado: [4.9, 6.3],
+  suelo: [-3.6, 6.8],
+  // El invernadero (micro-mundo del semillero): entre las eras y el potrero,
+  // a la mano de la casa — la matica se cría cerca y el túnel SE VE (corrido
+  // del frente de la píldora de la alerta, que le tapaba los arcos).
+  semillero: [-6.8, 6.6],
   // Los hongos en el corazón cultivado, con aire de la casa y de la milpa.
-  // (Corridos un paso al monte: desde la cámara de reposo quedaban justo
-  //  DETRÁS de la píldora de la alerta y su chip nunca se veía.)
-  micorrizas: [-3.8, 3.9],
-  // La milpa cede un paso a la izquierda para darle aire a los hongos.
-  cultivos: [-5.2, 2.2],
+  micorrizas: [-5.2, 1.6],
+  // La huerta ES "la huerta de la casa": pegada a ella, del lado del sol.
+  sanidad: [2.8, 5.6],
+  // El mercado (portal VENDER) es LA SALIDA a la plaza: borde derecho-frontal,
+  // el camino que se va del cuadro.
+  mercado: [8.6, 9.0],
+  // El kiosco del saber (portal APRENDER): a la vera del camino de la plaza —
+  // el tablero bajo el árbol donde se aprende y se juega.
+  aprender: [7.4, 4.2],
+  // El cafetal con sombrío: clima medio, subiendo hacia el monte.
+  cafe: [6.0, 0.6],
+  // El monte (portal TODA MI FINCA): la arboleda trepando al clima frío.
+  disenio: [7.2, -4.4],
+  // La toma de agua sobre la quebrada, donde el cauce cruza el clima frío.
+  agua: [1.0, -2.0],
+  // La veleta (portal EL TIEMPO): arriba en el filo del páramo, donde se lee
+  // el cielo. Sola, con el horizonte entero para ella.
+  clima: [-5.0, -9.4],
 };
 
 /**
@@ -84,94 +108,122 @@ export function componerMundos(mundos) {
   });
 }
 
-/* ── 3. LOS SENDEROS (la mano del campesino sobre el terreno) ────────────
+/* ── 3. LOS 6 PORTALES (las puertas de la finca) ─────────────────────────
+   La promesa del valle en seis puertas legibles: cada portal es un LUGAR
+   con pórtico de madera (dos pies derechos + dintel + farolito), su patio
+   de tierra pisada y su sendero desde la casa. La puerta de la casa abre
+   este mismo mapa como panel. `id` = el mundo del valle que surte el portal. */
+export const PORTALES_VALLE = [
+  { id: 'cultivos', nombre: 'Mis matas', emoji: '🌱' },
+  { id: 'animales', nombre: 'Mis animales', emoji: '🐄' },
+  { id: 'clima', nombre: 'El tiempo', emoji: '⛅' },
+  { id: 'mercado', nombre: 'Vender', emoji: '🧺' },
+  { id: 'aprender', nombre: 'Aprender', emoji: '📖' },
+  { id: 'disenio', nombre: 'Toda mi finca', emoji: '🌳' },
+];
+
+/* ── 4. LOS SENDEROS (la mano del campesino sobre el terreno) ────────────
    Caminos de tierra pisada que NACEN de la casa: el rastro honesto del uso
-   diario. No son UI — son el valle contando qué se camina. Waypoints [x, z];
+   diario. Cada PORTAL tiene su sendero (la puerta se camina, no se adivina);
+   el ramal potrero→pila cuenta el ciclo estiércol→abono. Waypoints [x, z];
    la y la posa el terreno. `frugal: true` = también en gama media/baja
-   (los principales); el resto solo donde sobra GPU. */
+   (los seis del portal + el ciclo del abono); el resto solo donde sobra GPU. */
 export const SENDEROS_VALLE = [
   {
-    id: 'trajin', // casa → eras → semillero → corral: el circuito de la mañana
-    puntos: [[-0.9, 3.0], [-2.0, 5.1], [-3.3, 6.1], [-5.0, 5.9]],
+    id: 'trajin', // casa → eras → invernadero → potrero: el circuito de la mañana
+    puntos: [[-1.4, 3.4], [-3.4, 6.4], [-6.2, 6.4], [-7.8, 7.6], [-8.4, 8.4]],
     frugal: true,
   },
   {
-    id: 'plaza', // casa → huerta → mercado → y SALE del cuadro (a la vereda)
-    puntos: [[-0.4, 2.9], [1.4, 4.0], [3.2, 4.7], [4.8, 6.2], [6.6, 7.8]],
+    id: 'abono', // potrero → la pila: el viaje del estiércol al abono
+    puntos: [[-7.4, 9.0], [-6.2, 9.5], [-5.2, 9.6]],
+    frugal: true,
+  },
+  {
+    id: 'plaza', // casa → huerta → el kiosco → mercado → y SALE del cuadro
+    puntos: [[-0.9, 3.3], [1.2, 4.4], [2.8, 5.2], [5.2, 4.8], [7.3, 5.4], [8.4, 8.6], [9.6, 11.8]],
     frugal: true,
   },
   {
     id: 'milpa', // casa → los hongos → la milpa (la subida del lote)
-    puntos: [[-1.3, 2.5], [-3.6, 3.7], [-5.0, 2.4]],
-    frugal: false,
+    puntos: [[-1.9, 2.9], [-4.6, 1.8], [-6.8, 1.0], [-8.2, 0.8]],
+    frugal: true,
+  },
+  {
+    id: 'monte', // casa → cafetal → el monte (toda mi finca)
+    puntos: [[-1.0, 2.4], [2.0, 1.4], [5.4, 0.6], [6.8, -2.2], [7.2, -4.2]],
+    frugal: true,
+  },
+  {
+    id: 'paramo', // casa → la veleta: la subida al filo donde se lee el cielo
+    puntos: [[-1.8, 2.4], [-3.0, -1.0], [-3.8, -4.6], [-4.6, -7.6], [-5.0, -9.2]],
+    frugal: true,
   },
   {
     id: 'agua', // casa → la toma de la quebrada (el viaje del balde)
-    puntos: [[-0.5, 2.2], [0.5, 1.0], [1.3, 0.1]],
+    puntos: [[-0.8, 2.2], [0.2, 0.4], [0.9, -1.6]],
     frugal: false,
   },
 ];
 
-/* ── 4. LOS PATIOS (tierra pisada bajo cada lugar navegable) ─────────────
+/* ── 5. LOS PATIOS (tierra pisada bajo cada lugar navegable) ─────────────
    El suelo desnudo donde se trabaja: la señal diegética de "aquí se llega"
    — el sendero desemboca en un patio, el patio sostiene el lugar. Afordancia
    sin UI: se entiende sin leer nada. */
 export const PATIO = {
-  radioBase: 0.92, // × escala del lugar
+  radioBase: 1.0, // × escala del lugar (creció con el valle)
   color: '#96703f', // tierra pisada: más clara que el pasto, más viva que el barro
   opacidad: 0.42,
 };
 
-/* ── 5. JERARQUÍA DE PERSONAJES (la ley, en números) ─────────────────────
-   ANGELITA GUÍA. Es la cara de la IA y la compañera de viaje: vuela en
-   primer plano, la cámara la sigue (DirectorValle.follow) y es la única con
-   luz propia. Pero el valle NO es solo suyo — feedback del operador
-   (2026-07-14): "los personajes como el oso y demás aparecen como
-   secundarias a la abejita". Los demás son VECINOS con casa propia: cada uno
-   vive en su rincón del valle con presencia digna (escala real, no garnish
-   de 30px), y la puesta en escena — no el tamaño de Angelita — dice quién
-   guía. Ninguno captura toques: presencia, no interfaz. */
+/* ── 6. JERARQUÍA DE PERSONAJES (la ley, en números) ─────────────────────
+   ANGELITA GUÍA — y es UNA SOLA (feedback 2026-07-16: se veían tres
+   abejitas; las laterales las quita el dueño del dashboard). La del valle
+   es la central: MÁS GRANDE que antes (se veía diminuta), en POSICIÓN DE
+   CALMA sobre el corredor de la casa (no husmeando errática), con su luz
+   propia que invita a tocarla. Los demás son VECINOS con casa propia: cada
+   uno vive en su rincón del valle con presencia digna, y la puesta en
+   escena — no el tamaño de Angelita — dice quién guía. */
 export const JERARQUIA_PERSONAJES = {
   /** La guía del valle: la única con follow de cámara y luz propia. */
   protagonista: 'abeja-angelita',
-  /** Tamaño vivo de Angelita (px del billboard; crece con su energía). */
-  protagonistaPx: [44, 58],
+  /** Tamaño vivo de Angelita (px del billboard; crece con su energía).
+      Subido de [44,58]: en el valle grande se leía diminuta. */
+  protagonistaPx: [58, 76],
   /** La luz cálida que la sigue: SOLO ella ilumina (perfil.luzBeacon). */
-  luzProtagonista: { color: '#ffdda6', intensidad: 0.85, alcance: 3.6 },
-  /** Techo de un vecino (px): puede igualar el piso de Angelita (el oso es
-      el mayor de los vecinos), nunca su tamaño pleno ni su primer plano. */
+  luzProtagonista: { color: '#ffdda6', intensidad: 1.0, alcance: 4.2 },
+  /** Techo de un vecino (px): nunca el tamaño pleno ni el primer plano
+      de Angelita. */
   vecinoMaxPx: 44,
   /** Los vecinos viven en SUS lugares (monte, quebrada, matorral), nunca en
       el centro del encuadre (radio en unidades de mundo alrededor de la mira). */
-  radioSagradoCentro: 3.2,
-  /** Los vecinos jamás capturan toques ni voz: presencia, no interfaz. */
+  radioSagradoCentro: 4.0,
+  /** Los vecinos jamás capturan toques ni voz: presencia, no interfaz.
+      (Angelita SÍ: tocarla es hablarle a la finca — ella es la interfaz.) */
   interactivos: false,
 };
 
-/* ── 6. LOS VECINOS DEL VALLE (la puesta en escena de los personajes) ─────
-   Personajes rubber-hose, cada uno EN SU CASA del valle: el oso en el borde
-   del monte, la rana en la quebrada, el perezoso en la arboleda. Data-driven
+/* ── 7. LOS VECINOS DEL VALLE (la puesta en escena de los personajes) ─────
+   Personajes rubber-hose, cada uno EN SU CASA del valle: la rana en la
+   quebrada, el perezoso en la arboleda, el jaguar en el filo. Data-driven
    contra CREATURES: un slug ausente no monta nada (las ramas de personajes
    mejoran el dibujo al mergear y este mapa ni se entera).
 
-   `franjas` = cuándo sale (null = siempre): el borugo es crepuscular y el
-   jaguar es un aparecido del amanecer, el atardecer y la niebla — verlo es
-   un premio, no un mueble. Eso también es jerarquía: la frecuencia cuenta.
+   `franjas` = cuándo sale (null = siempre): el jaguar es un aparecido del
+   amanecer, el atardecer y la niebla — verlo es un premio, no un mueble.
 
-   Ubicaciones verificadas contra la cámara de reposo ([10.5,9,13.5] →
-   [0,1.6,1.4], fov 40): todas a la vista, ninguna detrás de la cordillera
-   (los picos viven en z≤-15) ni tapada por un lugar compuesto (aire ≥2u del
-   mapa COMPOSICION_LUGARES). El precedente de la sierra (3 de 4 árboles
-   ocultos tras el macizo) no se repite acá. */
+   Ubicaciones al día con el VALLE GRANDE (cámara de reposo [14.6,12.2,18.8]
+   → [0,2,2], fov 40): todas a la vista, ninguna detrás de la cordillera
+   (los picos viven en z≤-21) ni pisando un lugar compuesto (aire ≥3 u del
+   mapa COMPOSICION_LUGARES). */
 export const VECINOS_VALLE = [
-  // NOTA (rediseño 2026-07): el oso rubber-hose café (`oso-andino`, paleta
-  // parda #3b2a1e) se RETIRA del valle por decisión del operador — la
-  // caricatura quedó fea. El oso NEGRO bueno (biopunk) vive en el selector de
-  // guardián del home (GuardianEspiritu). Este slot de ancla ([5.4,-1.2],
-  // px≈44) queda reservado para el CÓNDOR (por crear en el pase de arte).
+  // NOTA (rediseño 2026-07): el oso rubber-hose café se RETIRÓ del valle por
+  // decisión del operador. Este slot de ancla ([7.8, -2.0], px≈44) queda
+  // reservado para el CÓNDOR (Vultur gryphus, en curso en el pase de arte):
+  // planea alto sobre el filo — presencia diurna del páramo.
   {
     slug: 'perezoso',
-    punto: [3.1, -2.2], // colgado a la falda de la arboleda, detrás del oso
+    punto: [4.8, -3.2], // colgado a la falda de la arboleda del monte
     px: 30,
     factor: 8,
     dy: 1.5, // vive arriba, en las ramas
@@ -179,7 +231,7 @@ export const VECINOS_VALLE = [
   },
   {
     slug: 'ardilla',
-    punto: [3.2, -1.2], // entre el cafetal y el monte, siempre de paso
+    punto: [4.4, -1.4], // entre el cafetal y el monte, siempre de paso
     px: 26,
     factor: 7.5,
     dy: 0.25,
@@ -187,7 +239,7 @@ export const VECINOS_VALLE = [
   },
   {
     slug: 'rana-andina',
-    punto: [2.4, 2.8], // la orilla baja de la quebrada (el agua es su casa)
+    punto: [3.4, 3.0], // la orilla baja de la quebrada (el agua es su casa)
     px: 22,
     factor: 6.5,
     dy: 0.18,
@@ -195,7 +247,7 @@ export const VECINOS_VALLE = [
   },
   {
     slug: 'morrocoy',
-    punto: [3.2, 6.8], // la tierra caliente del frente, a paso lento
+    punto: [4.8, 8.2], // la tierra caliente del frente, a paso lento
     px: 26,
     factor: 7,
     dy: 0.2,
@@ -203,7 +255,7 @@ export const VECINOS_VALLE = [
   },
   {
     slug: 'jaguar',
-    punto: [-5.8, -4.6], // el filo del páramo, lejos, del lado de la veleta: el místico
+    punto: [-8.6, -7.2], // el filo del páramo, lejos, del lado de la veleta: el místico
     px: 40,
     factor: 10, // lejos pero con silueta: verlo tiene que sentirse
     dy: 0.3,


### PR DESCRIPTION
## Qué cambia

Rediseño de la ESCENA DEL VALLE (la casa de Chagra, lo primero que ve el campesino) según el spec de auditoría del 2026-07-16 (§1, §2, §4, §6).

### El valle respira (§4)
- Terreno 34×34 → **48×48**; aire mínimo entre lugares ~2u → **~3u+**; cámara de reposo alejada (`[15.2,13.4,19.6]`, mira `[0.3,1.8,2.6]`); pisos térmicos, quebrada, cordillera, vegetación, niebla, luna y pose vertical de teléfono re-escalados.
- Gemelo 2D y fallback dibujado re-proyectados al mapa grande (misma geografía en todas las vistas).

### La casa = puerta a los mundos (§2)
- La puerta de la casa queda **abierta e iluminada** (pulsa, charco de luz, cursor) y es **navegable**: tocarla abre el panel **“Las puertas de su finca”** con los 6 portales.

### 6 portales legibles (§1)
- `PORTALES_VALLE` (mis matas · mis animales · el tiempo · vender · aprender · toda mi finca), cada uno con **pórtico de madera** (pies derechos + dintel + farolito + tablita con el tinte del mundo, mirando a la casa), patio y **sendero desde la casa** (6 senderos frugales + ramal potrero→pila).
- Portal *aprender* nuevo: **kiosco del saber** (tablero de escuela, banca de tronco, libro abierto) con identidad de respaldo hasta que exista su mundo.

### La finca se lee agroecológica
- **Potrero con cercas vivas** (matarratón / nacedero / botón de oro, instanciadas) dividiendo apartos: vacas al fondo, ovejas y cerdos regados, gallinero junto a la tranquera, portillo de rotación.
- **Biofábrica** (mundo real `abono`): cajón en U + pila por capas (estiércol→compost→paja) con vaho, horqueta y carretilla, cerca del potrero pero diferenciada — el ciclo estiércol→abono legible.
- **Invernadero micro-mundo** (semillero): arcos, plástico traslúcido, mesas de germinación, barril de riego.
- **Milpa estilo AoE**: parcela de tierra labrada + las tres hermanas (maíz con fríjol enroscado + calabazas tapando el suelo). **Cafetal con sombrío** (guamo + plátano + cereza roja). Monte espesado a 5 árboles/3 especies.

### Angelita central (§6)
- UNA sola abeja en el valle, en **posición de calma** sobre el patio de la casa (deriva mínima, no husmeo errático), **más grande** (58–76 px) y **tocable**: brilla cálido e invita — tocarla abre el agente. (El personaje/entrada Miss Minutes los lleva otro frente: aquí solo la escena.)

## Rendimiento
Todo procedural, cero assets remotos; cercas y pórticos frugales instanciados (3–4 draw calls); niebla/estrellas/luciérnagas por tier intactos. Android barato respetado.

## Verificación
- `npm run build:prod` VERDE.
- Tests del valle: `directorValle` y `EntradaValle3D.tts` verdes; `entradaValle3D.nav` falla **igual en el commit base** (preexistente en la rama, verificado con control por stash).
- Capturas (chromium + swiftshader sobre dev server): reposo día, atardecer, noche (luna + quebrada luminosa + ventana-faro), panel de la casa con las 6 puertas, vertical de teléfono, y paneo del director.

🤖 Generated with [Claude Code](https://claude.com/claude-code)