### PR TITLE
art(lecheria): mundo 3D de la cadena láctea — potrero silvopastoril + quesera + ciclo del abono

### DIFF
--- a/src/mockups/LecheriaViva3D.css
+++ b/src/mockups/LecheriaViva3D.css
@@ -1,0 +1,261 @@
+/*
+ * LecheriaViva3D.css — vitrina del mundo de la cadena láctea
+ * (#/mockups/lecheria-viva-3d). Autocontenida: sin fuentes/imágenes externas.
+ * Móvil-first desde 320px. Paleta de potrero: verde de pasto, bruma clara, la
+ * crema del queso y el pardo del abono. Solo opacity/transform se animan.
+ */
+
+.lviva {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background: linear-gradient(180deg, #dfe6cd 0%, #e7e6c9 44%, #eee7cd 100%);
+  color: #2b3226;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.lviva__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.lviva__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #5f7a30;
+}
+.lviva__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #2e402e;
+}
+.lviva__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 40rem;
+}
+
+.lviva__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+.lviva__lienzo {
+  position: relative;
+  height: min(66vh, 32rem);
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(95, 122, 48, 0.28);
+  box-shadow: 0 12px 30px rgba(44, 54, 40, 0.16);
+  background: radial-gradient(120% 90% at 50% 20%, #cadfc8 0%, #a6c09c 100%);
+}
+.lviva__lienzo canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+  touch-action: none;
+}
+.lecheria-canvas {
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.lecheria-canvas--lista {
+  opacity: 1;
+}
+
+.lviva__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  color: #3c4a38;
+  opacity: 0.85;
+}
+
+.lviva__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.lviva__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.lviva__toggle {
+  border: 1.5px solid #5f7a30;
+  background: #fff;
+  color: #4f671f;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.lviva__toggle:hover,
+.lviva__toggle:focus-visible {
+  background: #5f7a30;
+  color: #fff;
+  outline-offset: 2px;
+}
+
+/* ---- Ficha 2D (fallback digno, sin GPU) ---- */
+.lviva__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  background: radial-gradient(120% 90% at 50% 25%, #cfdcc3 0%, #a2b393 100%);
+}
+.lviva__estampa {
+  position: relative;
+  width: 200px;
+  height: 175px;
+  margin-bottom: 0.4rem;
+}
+/* el árbol forrajero, detrás y más alto (el banco de sombra) */
+.lviva__arbol {
+  position: absolute;
+  top: 0;
+  left: 96px;
+  width: 118px;
+  height: 70px;
+  border-radius: 56% 44% 60% 40% / 70% 74% 26% 30%;
+  background: radial-gradient(circle at 42% 30%, #68a54877 0%, #4e8a3e 65%, #3a6c34 100%);
+  box-shadow: inset -8px -6px 14px rgba(0, 0, 0, 0.16);
+}
+.lviva__arbol-tronco {
+  position: absolute;
+  top: 56px;
+  left: 148px;
+  width: 13px;
+  height: 74px;
+  border-radius: 40%;
+  background: linear-gradient(90deg, #4f3c28 0%, #6a5c4a 55%, #4a3a26 100%);
+}
+/* la vaca al frente, cuerpo capsular con manchas */
+.lviva__vaca {
+  position: absolute;
+  bottom: 22px;
+  left: 20px;
+  width: 118px;
+  height: 66px;
+  border-radius: 44% 46% 42% 44% / 58% 58% 42% 42%;
+  background: radial-gradient(circle at 40% 34%, #ffffff 0%, #efe8dc 72%, #ddd4c4 100%);
+  box-shadow: inset -6px -6px 12px rgba(0, 0, 0, 0.12);
+}
+.lviva__vaca::after {
+  /* la ubre — la señal de la vaca de leche */
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  left: 40px;
+  width: 22px;
+  height: 16px;
+  border-radius: 50% 50% 46% 46%;
+  background: #e7b6a6;
+}
+.lviva__vaca-mancha {
+  position: absolute;
+  border-radius: 48% 52% 46% 54%;
+  background: #2a241c;
+}
+.lviva__vaca-mancha--a { top: 10px; left: 22px; width: 30px; height: 24px; }
+.lviva__vaca-mancha--b { top: 26px; left: 66px; width: 24px; height: 20px; }
+.lviva__vaca-cabeza {
+  position: absolute;
+  top: 4px;
+  left: -14px;
+  width: 34px;
+  height: 30px;
+  border-radius: 50% 44% 46% 52%;
+  background: #efe8dc;
+  box-shadow: inset -3px -3px 6px rgba(0, 0, 0, 0.12);
+}
+/* la rueda de queso al pie */
+.lviva__queso {
+  position: absolute;
+  bottom: 6px;
+  left: 150px;
+  width: 40px;
+  height: 26px;
+  border-radius: 50% 50% 44% 44% / 60% 60% 40% 40%;
+  background: linear-gradient(180deg, #f7efd9 0%, #ecdcb2 100%);
+  box-shadow: inset -3px -3px 6px rgba(0, 0, 0, 0.14);
+}
+.lviva__ficha-nombre {
+  margin: 0;
+  font-weight: 800;
+  font-size: 1rem;
+  color: #2e402e;
+}
+.lviva__ficha-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4c5a44;
+}
+
+/* ---- Saberes ---- */
+.lviva__saberes {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.lviva__saberes h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #2e402e;
+}
+.lviva__saberes ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .lviva__saberes ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.lviva__saberes li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(95, 122, 48, 0.16);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.lviva__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.lviva__saberes b {
+  display: block;
+  font-size: 0.92rem;
+  color: #2e402e;
+}
+.lviva__saberes li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.lviva__cierre {
+  margin: 0.9rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #3c4a38;
+  max-width: 42rem;
+}

--- a/src/mockups/LecheriaViva3D.jsx
+++ b/src/mockups/LecheriaViva3D.jsx
@@ -1,0 +1,159 @@
+/*
+ * LecheriaViva3D — vitrina pública del MUNDO DE LA CADENA LÁCTEA campesina: el
+ * potrero silvopastoril, la quesera de la finca y el ciclo del estiércol al
+ * abono. Ruta #/mockups/lecheria-viva-3d, sin auth.
+ *
+ * La lechería agroecológica como es de verdad: un potrero navegable con el hato
+ * (Holstein, Normando, criolla, cruce con cebú) pastando bajo el banco forrajero
+ * de nacedero, matarratón, leucaena y botón de oro; la quesera donde la leche se
+ * hace queso, cuajada, kumis, yogur y arequipe; y el biodigestor que vuelve el
+ * estiércol en biogás y abono. Cuatro pasos cortos recorren la lección.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el mundo 3D (chunk
+ * perezoso `vendor-three`); en equipo humilde, ahorro de datos o sin-WebGL se ve
+ * la ficha, digna y sin sudar la GPU. Copy en español de Colombia, en "usted".
+ * Autocontenida: cero CDN/imágenes externas.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import './LecheriaViva3D.css';
+
+const MundoLecheria = lazy(() => import('../visual/mundo3d/lecheria/MundoLecheria.jsx'));
+
+/* Lo que enseña la lechería (verificado en el DR de la cadena láctea, en "usted"). */
+const SABERES = [
+  {
+    emoji: '🌳',
+    titulo: 'El potrero se siembra con árboles',
+    texto:
+      'Nacedero, matarratón, leucaena y el arbusto botón de oro se siembran entre el pasto. Dan sombra a la vaca, forraje con proteína y fijan nitrógeno que abona el suelo. Con sombra la vaca sufre menos calor y da más leche.',
+  },
+  {
+    emoji: '🐄',
+    titulo: 'Cada vaca según su clima',
+    texto:
+      'En tierra fría van la Holstein y la Normando, de buena leche; en tierra caliente, la criolla y el cruce con cebú (el de la giba), que aguantan el calor y las garrapatas. Y se rota el potrero para que el pasto descanse y se recupere.',
+  },
+  {
+    emoji: '🧀',
+    titulo: 'La leche se transforma en la finca',
+    texto:
+      'Vender la leche cruda deja poco. En la quesera salen la cuajada y el queso campesino, el doble crema, el kumis, el yogur y el arequipe en la olla de cobre. Transformar en finca es donde el campesino de verdad gana.',
+  },
+  {
+    emoji: '♻️',
+    titulo: 'El estiércol no se bota',
+    texto:
+      'La boñiga entra al biodigestor y da biogás para cocinar y biol para abonar; lo demás va al montón de abono. Del potrero a la leche y de vuelta al potrero: el ciclo se cierra sin comprar químicos ni quemar leña.',
+  },
+];
+
+export default function LecheriaViva3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  return (
+    <main className="lviva">
+      <header className="lviva__head">
+        <p className="lviva__kicker">La cadena láctea · vitrina</p>
+        <h1>El potrero, la quesera y el ciclo</h1>
+        <p className="lviva__lema">
+          La lechería campesina como es de verdad: el hato pastando bajo los
+          árboles forrajeros, la quesera donde la leche se hace queso y el
+          biodigestor que vuelve el estiércol en abono. Recórrala con el dedo y
+          siga los cuatro pasos de la lección.
+        </p>
+      </header>
+
+      <section className="lviva__escena" aria-label="La cadena láctea campesina en 3D">
+        <div className="lviva__lienzo">
+          {mostrar3D ? (
+            <Suspense
+              fallback={
+                <div className="lviva__cargando" role="status">
+                  Saliendo al potrero…
+                </div>
+              }
+            >
+              <MundoLecheria tier={tier} reducedMotion={reducedMotion} />
+            </Suspense>
+          ) : (
+            <FichaLecheria />
+          )}
+        </div>
+
+        <div className="lviva__barra">
+          <p className="lviva__tier">
+            {mostrar3D
+              ? 'Está viendo el potrero en 3D. Gírelo con el dedo o el mouse y siga los pasos.'
+              : puede3D
+                ? 'Está viendo la ficha de la lechería.'
+                : 'Su equipo ve la ficha de la lechería (va parejo en cualquier teléfono).'}
+          </p>
+          {puede3D && (
+            <button type="button" className="lviva__toggle" onClick={() => setVer2d((v) => !v)}>
+              {ver2d ? 'Ver el potrero en 3D' : 'Ver la ficha'}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <section className="lviva__saberes" aria-label="Lo que enseña la lechería">
+        <h2>Lo que le enseña esta lechería</h2>
+        <ol>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span className="lviva__emoji" aria-hidden="true">
+                {s.emoji}
+              </span>
+              <div>
+                <b>{s.titulo}</b>
+                <p>{s.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="lviva__cierre">
+          La leche buena no sale de potrero pelado ni de vender crudo y barato:
+          sale de un potrero con árboles, de una vaca con sombra y de una finca
+          que transforma lo suyo y no bota nada. Eso no cuesta cemento.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+/* La ficha de la lechería: el fallback digno para equipo humilde / sin-WebGL.
+   Una vaca CSS bajo su árbol forrajero, con la rueda de queso al pie — cero GPU. */
+function FichaLecheria() {
+  return (
+    <div
+      className="lviva__ficha"
+      role="img"
+      aria-label="La lechería campesina: una vaca bajo el árbol forrajero, con la rueda de queso"
+    >
+      <div className="lviva__estampa" aria-hidden="true">
+        <span className="lviva__arbol" />
+        <span className="lviva__arbol-tronco" />
+        <span className="lviva__vaca">
+          <span className="lviva__vaca-mancha lviva__vaca-mancha--a" />
+          <span className="lviva__vaca-mancha lviva__vaca-mancha--b" />
+          <span className="lviva__vaca-cabeza" />
+        </span>
+        <span className="lviva__queso" />
+      </div>
+      <p className="lviva__ficha-nombre">El potrero, la quesera y el ciclo</p>
+      <p className="lviva__ficha-sub">La cadena láctea campesina · silvopastoril</p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/lecheria/EscenaLecheriaViva.jsx
+++ b/src/visual/mundo3d/lecheria/EscenaLecheriaViva.jsx
@@ -1,0 +1,542 @@
+/*
+ * EscenaLecheriaViva — el MUNDO de la CADENA LÁCTEA campesina: el potrero
+ * silvopastoril, la quesera de la finca y el ciclo del estiércol al abono.
+ *
+ * Un POTRERO en la hora viva del valle (atmósfera del kit, familia `corral`) que
+ * cuenta la lechería agroecológica COMPLETA, como es de verdad (grounded en el
+ * DR de la cadena láctea):
+ *
+ *   · el SISTEMA SILVOPASTORIL — el hato lechero (Holstein, Normando, criolla y
+ *     el cruce con cebú) pastando bajo el banco forrajero de nacedero,
+ *     matarratón, leucaena y botón de oro, con su cerca VIVA de matarratón y el
+ *     bebedero. No es potrero pelado: es sombra, forraje y flor (FloraLecheria +
+ *     GanadoLechero);
+ *   · la QUESERA de la finca — la enramada donde la leche se hace queso: las
+ *     cantinas, la mesa con la cuajada y el cincho, y la olla de cobre del
+ *     arequipe. La TRANSFORMACIÓN en finca, que es donde el campesino gana;
+ *   · el CICLO — el estiércol no se bota: entra al biodigestor (biogás para la
+ *     quesera + biol para abonar) y al montón de abono. Nada se pierde.
+ *
+ * En clave de la TOMA B (estilizada Switch/BOTW): domo de gradiente con el glow
+ * del sol (`DomoCielo`), terreno y cerros por BANDAS toon y silueta fuerte. La
+ * cámara LLEGA (CamaraDirector) y se gira con el dedo.
+ *
+ * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`. Con
+ * `reducedMotion` monta QUIETO. Importa three/@react-three → montar SOLO perezosa.
+ *
+ * `foco` (opcional): el punto [x,y,z] que el paso didáctico señala con un anillo.
+ */
+import { useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { perfilDeTier } from '../deviceTier.js';
+import { Fauna } from '../escenas/FaunaEscena.jsx';
+import FloraLecheria from './FloraLecheria.jsx';
+import GanadoLechero from './GanadoLechero.jsx';
+import {
+  ANCHO,
+  FONDO,
+  alturaPotrero,
+  SITIO_QUESERA,
+  SITIO_BIODIGESTOR,
+  SITIO_ABONO,
+  SITIO_BEBEDERO,
+  LINEA_CERCA,
+} from './floraLecheria.geom.js';
+import {
+  AtmosferaMundo,
+  DomoCielo,
+  useAtmosferaMundo,
+  useGradienteBandas,
+  construirTerreno,
+  ruidoTerreno,
+  smoothstep,
+  CamaraDirector,
+} from '../kit/index.js';
+import { mezclar, VERDES, TIERRAS, PALETA, CORTEZAS, ACENTOS, LUCES, NIEBLAS, AGUAS, NEUTROS } from '../paleta/index.js';
+
+/* La familia del valle para el potrero: `corral` (tarde de finca). */
+const FAMILIA_LECHERIA = 'corral';
+const RADIO_LECHERIA = 12;
+const SOMBRA_LECHERIA = { left: -18, right: 18, top: 16, bottom: -8, far: 46 };
+
+/* El potrero: heightfield del KIT con la pintura PROPIA del pasto — verde de
+   trabajo al sol, oliva hacia lo seco, tierra pisada en los caminos del ganado
+   y el pardo del pie de monte al fondo. */
+function construirPotrero(seg, plano) {
+  const cPasto = new THREE.Color(VERDES.trabajo);
+  const cPastoSol = new THREE.Color(VERDES.brote);
+  const cSeco = new THREE.Color(VERDES.calido);
+  const cTierra = new THREE.Color(TIERRAS.camino);
+  const cMonte = new THREE.Color(mezclar(VERDES.monte, TIERRAS.siembra, 0.25));
+  return construirTerreno({
+    ancho: ANCHO,
+    fondo: FONDO,
+    seg,
+    plano,
+    altura: alturaPotrero,
+    pintar: (wx, wz, alt, c) => {
+      c.lerpColors(cPasto, cPastoSol, 0.45 + 0.5 * ruidoTerreno(wx * 0.7, wz * 0.6));
+      // manchas de pasto seco/oliva
+      c.lerp(cSeco, smoothstep(0.1, 0.85, ruidoTerreno(wx * 1.2, wz * 1.0)) * 0.3);
+      // los caminos pisados del ganado (serpentean por el potrero)
+      const camino = smoothstep(1.0, 0, Math.abs(wx - Math.sin(wz * 0.35) * 4.5 + 2)) * smoothstep(-12, 4, wz);
+      c.lerp(cTierra, camino * 0.6);
+      // el pie de monte pardo hacia el fondo
+      c.lerp(cMonte, smoothstep(-9, -18, wz) * 0.5);
+    },
+  });
+}
+
+/* ── LA QUESERA de la finca: la enramada de la transformación ─────────────── */
+function Quesera({ pos }) {
+  const madera = PALETA.madera;
+  const maderaClara = PALETA.maderaClara;
+  const zinc = PALETA.lamina;
+  const cobre = CORTEZAS.sieteCueros; // la olla de cobre del arequipe
+  const cobreBrillo = CORTEZAS.sieteCuerosClaro;
+  const quesoColor = '#f4ecd6';
+  const leche = NEUTROS.hueso;
+  return (
+    <group position={pos} rotation={[0, -0.55, 0]}>
+      {/* piso de tabla (una plancha limpia, la quesera se lava) */}
+      <mesh position={[0, 0.04, 0]}>
+        <boxGeometry args={[3.4, 0.08, 2.8]} />
+        <meshLambertMaterial color={mezclar(PALETA.concreto, NEUTROS.cal, 0.5)} flatShading />
+      </mesh>
+      {/* postes de la enramada */}
+      {[[-1.5, -1.2], [1.5, -1.2], [-1.5, 1.2], [1.5, 1.2]].map((q, i) => (
+        <mesh key={i} position={[q[0], 1.05, q[1]]}>
+          <cylinderGeometry args={[0.08, 0.1, 2.1, 6]} />
+          <meshLambertMaterial color={madera} flatShading />
+        </mesh>
+      ))}
+      {/* techo de zinc a un agua (la lámina entibiada bajo el sol andino) */}
+      <mesh position={[0, 2.28, 0]} rotation={[0.28, 0, 0]}>
+        <boxGeometry args={[3.8, 0.08, 3.2]} />
+        <meshLambertMaterial color={zinc} flatShading />
+      </mesh>
+      {/* media pared al fondo (donde cuelga el estante) */}
+      <mesh position={[0, 1.0, -1.25]}>
+        <boxGeometry args={[3.1, 1.5, 0.08]} />
+        <meshLambertMaterial color={mezclar(NEUTROS.cal, PALETA.concreto, 0.3)} flatShading />
+      </mesh>
+
+      {/* LAS CANTINAS de leche (metálicas, cuello angosto + tapa) */}
+      {[[-1.0, 0.9], [-0.55, 1.0], [-1.35, 0.55]].map((q, i) => (
+        <group key={`c${i}`} position={[q[0], 0.08, q[1]]}>
+          <mesh position={[0, 0.34, 0]}>
+            <cylinderGeometry args={[0.19, 0.2, 0.62, 12]} />
+            <meshStandardMaterial color={zinc} roughness={0.45} metalness={0.5} flatShading />
+          </mesh>
+          <mesh position={[0, 0.7, 0]}>
+            <cylinderGeometry args={[0.1, 0.16, 0.16, 12]} />
+            <meshStandardMaterial color={zinc} roughness={0.45} metalness={0.5} flatShading />
+          </mesh>
+          <mesh position={[0, 0.8, 0]}>
+            <cylinderGeometry args={[0.11, 0.11, 0.05, 12]} />
+            <meshStandardMaterial color={mezclar(zinc, NEUTROS.tinta, 0.2)} roughness={0.4} metalness={0.5} flatShading />
+          </mesh>
+        </group>
+      ))}
+
+      {/* LA MESA de la quesera con la cuajada, el cincho y el queso prensado */}
+      <group position={[0.9, 0, 0.1]}>
+        <mesh position={[0, 0.72, 0]}>
+          <boxGeometry args={[1.5, 0.07, 0.9]} />
+          <meshLambertMaterial color={maderaClara} flatShading />
+        </mesh>
+        {[[-0.65, -0.35], [0.65, -0.35], [-0.65, 0.35], [0.65, 0.35]].map((q, i) => (
+          <mesh key={i} position={[q[0], 0.36, q[1]]}>
+            <boxGeometry args={[0.07, 0.72, 0.07]} />
+            <meshLambertMaterial color={madera} flatShading />
+          </mesh>
+        ))}
+        {/* el queso prensado (rueda) */}
+        <mesh position={[-0.4, 0.82, 0]}>
+          <cylinderGeometry args={[0.22, 0.22, 0.14, 16]} />
+          <meshLambertMaterial color={quesoColor} flatShading />
+        </mesh>
+        {/* el cincho (molde-aro) con la cuajada adentro */}
+        <mesh position={[0.2, 0.82, 0.15]}>
+          <cylinderGeometry args={[0.17, 0.17, 0.12, 14, 1, true]} />
+          <meshLambertMaterial color={maderaClara} flatShading side={THREE.DoubleSide} />
+        </mesh>
+        <mesh position={[0.2, 0.8, 0.15]}>
+          <cylinderGeometry args={[0.15, 0.15, 0.08, 14]} />
+          <meshLambertMaterial color={mezclar(quesoColor, leche, 0.5)} flatShading />
+        </mesh>
+        {/* bloques de cuajada escurriendo */}
+        {[[0.5, -0.2], [0.35, -0.28]].map((q, i) => (
+          <mesh key={i} position={[q[0], 0.8, q[1]]}>
+            <boxGeometry args={[0.16, 0.1, 0.16]} />
+            <meshLambertMaterial color={leche} flatShading />
+          </mesh>
+        ))}
+      </group>
+
+      {/* LA OLLA DE COBRE del arequipe, sobre el fogón (con su rescoldo) */}
+      <group position={[1.15, 0.08, -0.85]}>
+        <mesh position={[0, 0.24, 0]}>
+          <cylinderGeometry args={[0.28, 0.24, 0.4, 12]} />
+          <meshLambertMaterial color={mezclar(PALETA.piedra, NEUTROS.tinta, 0.25)} flatShading />
+        </mesh>
+        {/* el rescoldo del fogón */}
+        <mesh position={[0, 0.06, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <circleGeometry args={[0.2, 10]} />
+          <meshBasicMaterial color={LUCES.candela} transparent opacity={0.7} depthWrite={false} />
+        </mesh>
+        {/* la olla de cobre */}
+        <mesh position={[0, 0.5, 0]}>
+          <cylinderGeometry args={[0.3, 0.22, 0.26, 16]} />
+          <meshStandardMaterial color={cobre} roughness={0.35} metalness={0.7} flatShading />
+        </mesh>
+        <mesh position={[0, 0.63, 0]}>
+          <torusGeometry args={[0.29, 0.03, 6, 16]} />
+          <meshStandardMaterial color={cobreBrillo} roughness={0.3} metalness={0.7} flatShading />
+        </mesh>
+        {/* el arequipe adentro */}
+        <mesh position={[0, 0.62, 0]}>
+          <cylinderGeometry args={[0.26, 0.26, 0.04, 16]} />
+          <meshLambertMaterial color={ACENTOS.ambar} flatShading />
+        </mesh>
+      </group>
+
+      {/* el ESTANTE con los frascos de kumis y yogur (contra la media pared) */}
+      <group position={[-1.1, 0, -1.1]}>
+        <mesh position={[0, 1.05, 0]}>
+          <boxGeometry args={[1.3, 0.05, 0.3]} />
+          <meshLambertMaterial color={maderaClara} flatShading />
+        </mesh>
+        {[-0.45, -0.15, 0.15, 0.45].map((x, i) => (
+          <group key={i} position={[x, 1.08, 0]}>
+            <mesh position={[0, 0.11, 0]}>
+              <cylinderGeometry args={[0.08, 0.08, 0.22, 10]} />
+              <meshLambertMaterial color={mezclar(leche, i % 2 ? ACENTOS.ambar : NIEBLAS.lechosa, 0.25)} flatShading transparent opacity={0.92} />
+            </mesh>
+            <mesh position={[0, 0.23, 0]}>
+              <cylinderGeometry args={[0.06, 0.08, 0.04, 10]} />
+              <meshLambertMaterial color={PALETA.madera} flatShading />
+            </mesh>
+          </group>
+        ))}
+      </group>
+    </group>
+  );
+}
+
+/* ── EL CICLO: biodigestor tubular + bolsa de gas + montón de abono ────────── */
+function CicloAbono({ pos, posAbono, reducedMotion }) {
+  const bolsa = useRef(null);
+  useFrame(({ clock }) => {
+    const b = bolsa.current;
+    if (reducedMotion || !b) return;
+    // la bolsa de gas respira apenas (se llena y se vacía con el biogás)
+    const s = 1 + Math.sin(clock.elapsedTime * 0.5) * 0.05;
+    b.scale.set(1, s, 1);
+  });
+  return (
+    <group>
+      {/* EL BIODIGESTOR TUBULAR (polietileno de bajo costo, medio enterrado) */}
+      <group position={pos} rotation={[0, 0.6, 0]}>
+        {/* la zanja poco profunda */}
+        <mesh position={[0, -0.02, 0]}>
+          <boxGeometry args={[3.2, 0.2, 1.1]} />
+          <meshLambertMaterial color={TIERRAS.siembra} flatShading />
+        </mesh>
+        {/* el tubo de polietileno (semicilindro tendido) */}
+        <mesh position={[0, 0.12, 0]} rotation={[0, 0, Math.PI / 2]}>
+          <cylinderGeometry args={[0.42, 0.42, 2.9, 14, 1, false, 0, Math.PI]} />
+          <meshStandardMaterial color={mezclar(NEUTROS.cal, VERDES.calido, 0.15)} roughness={0.6} metalness={0.05} transparent opacity={0.85} side={THREE.DoubleSide} flatShading />
+        </mesh>
+        {/* la BOLSA de gas encima (se infla con el biogás) */}
+        <group ref={bolsa} position={[0, 0.42, 0]}>
+          <mesh scale={[1, 1, 1]}>
+            <sphereGeometry args={[0.55, 14, 8, 0, Math.PI * 2, 0, Math.PI / 2]} />
+            <meshStandardMaterial color={NIEBLAS.lechosa} roughness={0.5} transparent opacity={0.55} side={THREE.DoubleSide} flatShading />
+          </mesh>
+        </group>
+        {/* la caja de CARGA (donde entra el estiércol) */}
+        <mesh position={[-1.75, 0.14, 0]}>
+          <boxGeometry args={[0.55, 0.5, 0.7]} />
+          <meshLambertMaterial color={mezclar(TIERRAS.turba, TIERRAS.siembra, 0.4)} flatShading />
+        </mesh>
+        {/* la salida del BIOL (fertilizante líquido) */}
+        <mesh position={[1.75, 0.1, 0]}>
+          <boxGeometry args={[0.5, 0.36, 0.6]} />
+          <meshLambertMaterial color={mezclar(VERDES.monte, TIERRAS.turba, 0.4)} flatShading />
+        </mesh>
+        {/* el TUBO de biogás que sube y va hacia la quesera (la energía) */}
+        <mesh position={[0.1, 1.0, 0]}>
+          <cylinderGeometry args={[0.03, 0.03, 1.2, 6]} />
+          <meshLambertMaterial color={PALETA.lamina} flatShading />
+        </mesh>
+        <mesh position={[1.0, 1.55, 0]} rotation={[0, 0, Math.PI / 2]}>
+          <cylinderGeometry args={[0.03, 0.03, 2.0, 6]} />
+          <meshLambertMaterial color={PALETA.lamina} flatShading />
+        </mesh>
+      </group>
+
+      {/* EL MONTÓN DE ABONO (compost / bioabono), con su horqueta clavada */}
+      <group position={posAbono}>
+        <mesh position={[0, 0.35, 0]} scale={[1.3, 1, 1.3]}>
+          <sphereGeometry args={[0.7, 12, 8, 0, Math.PI * 2, 0, Math.PI / 2]} />
+          <meshLambertMaterial color={mezclar(TIERRAS.turba, TIERRAS.cacao, 0.4)} flatShading />
+        </mesh>
+        <mesh position={[0.15, 0.5, 0.1]} scale={[1, 0.8, 1]}>
+          <sphereGeometry args={[0.5, 10, 6, 0, Math.PI * 2, 0, Math.PI / 2]} />
+          <meshLambertMaterial color={mezclar(TIERRAS.siembra, VERDES.monte, 0.2)} flatShading />
+        </mesh>
+        {/* la horqueta (mango + dientes) */}
+        <group position={[-0.5, 0, 0.3]} rotation={[0, 0, 0.35]}>
+          <mesh position={[0, 0.7, 0]}>
+            <cylinderGeometry args={[0.028, 0.028, 1.4, 6]} />
+            <meshLambertMaterial color={PALETA.madera} flatShading />
+          </mesh>
+          {[-0.06, 0, 0.06].map((z, i) => (
+            <mesh key={i} position={[0, 0.05, z]}>
+              <cylinderGeometry args={[0.014, 0.014, 0.3, 5]} />
+              <meshStandardMaterial color={PALETA.lamina} roughness={0.5} metalness={0.5} flatShading />
+            </mesh>
+          ))}
+        </group>
+      </group>
+    </group>
+  );
+}
+
+/* ── EL BEBEDERO del ganado ───────────────────────────────────────────────── */
+function Bebedero({ pos }) {
+  return (
+    <group position={pos} rotation={[0, 0.4, 0]}>
+      {[[-1.05, 0], [1.05, 0], [0, -0.45], [0, 0.45]].map((q, i) => (
+        <mesh key={i} position={[q[0], 0.18, q[1]]}>
+          <boxGeometry args={[Math.abs(q[0]) > 0.5 ? 0.12 : 2.1, 0.36, Math.abs(q[1]) > 0.2 ? 0.12 : 0.9]} />
+          <meshLambertMaterial color={PALETA.concreto} flatShading />
+        </mesh>
+      ))}
+      <mesh position={[0, 0.06, 0]}>
+        <boxGeometry args={[2.0, 0.3, 0.8]} />
+        <meshLambertMaterial color={mezclar(PALETA.concreto, NEUTROS.tinta, 0.2)} flatShading />
+      </mesh>
+      {/* el agua */}
+      <mesh position={[0, 0.3, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[1.9, 0.72]} />
+        <meshStandardMaterial color={AGUAS.viva} roughness={0.2} metalness={0.1} transparent opacity={0.85} />
+      </mesh>
+    </group>
+  );
+}
+
+/* ── LA CERCA VIVA de matarratón (postes vivos + alambre) ─────────────────── */
+function CercaViva({ puntos }) {
+  const postes = useMemo(
+    () => puntos.map(([x, z]) => /** @type {[number, number, number]} */ ([x, alturaPotrero(x, z), z])),
+    [puntos],
+  );
+  return (
+    <group>
+      {postes.map((p, i) => (
+        <group key={i} position={p}>
+          {/* el poste vivo (tronquito de matarratón que rebrota) */}
+          <mesh position={[0, 0.55, 0]}>
+            <cylinderGeometry args={[0.07, 0.09, 1.1, 6]} />
+            <meshLambertMaterial color={CORTEZAS.aliso} flatShading />
+          </mesh>
+          {/* el rebrote verde en la cabeza del poste (por eso es "vivo") */}
+          <mesh position={[0, 1.2, 0]}>
+            <icosahedronGeometry args={[0.22, 0]} />
+            <meshLambertMaterial color={VERDES.brote} flatShading />
+          </mesh>
+        </group>
+      ))}
+      {/* los alambres entre postes */}
+      {postes.slice(0, -1).map((p, i) => {
+        const q = postes[i + 1];
+        const mid = [(p[0] + q[0]) / 2, 0, (p[2] + q[2]) / 2];
+        const dx = q[0] - p[0];
+        const dz = q[2] - p[2];
+        const len = Math.hypot(dx, dz);
+        const ang = Math.atan2(dz, dx);
+        return [0.5, 0.8].map((h, k) => (
+          <mesh
+            key={`${i}-${k}`}
+            position={[mid[0], (p[1] + q[1]) / 2 + h, mid[2]]}
+            rotation={[0, -ang, Math.PI / 2]}
+          >
+            <cylinderGeometry args={[0.008, 0.008, len, 4]} />
+            <meshLambertMaterial color={PALETA.lamina} flatShading />
+          </mesh>
+        ));
+      })}
+    </group>
+  );
+}
+
+/* El anillo del paso didáctico (lo mismo que en cafetal). */
+function FocoPaso({ foco, reducedMotion }) {
+  const anillo = useRef(null);
+  useFrame(({ clock }) => {
+    const m = anillo.current;
+    if (!m) return;
+    if (reducedMotion) {
+      m.material.opacity = 0.42;
+      return;
+    }
+    const t = clock.elapsedTime;
+    m.material.opacity = 0.3 + 0.2 * Math.sin(t * 1.8);
+    m.scale.setScalar(1 + 0.06 * Math.sin(t * 1.8));
+  });
+  if (!foco) return null;
+  return (
+    <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+      <ringGeometry args={[1.25, 1.65, 32]} />
+      <meshBasicMaterial
+        color={LUCES.candela}
+        transparent
+        opacity={0.4}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+/* La vida que traen las flores del banco forrajero (matarratón y botón de oro):
+   mariposas y el colibrí — los SVG rubber-hose de la casa como billboards. */
+const FAUNA_LECHERIA = [
+  { tipo: 'mariposa', base: [-15.5, 1.5, 4.0], patron: 'revoloteo', size: 24, fase: 0.6, df: 9 },
+  { tipo: 'colibri', base: [12.0, 2.2, -3.2], patron: 'revoloteo', size: 30, fase: 1.8, df: 10 },
+  { tipo: 'mariposa', base: [6.0, 1.6, -9.0], patron: 'revoloteo', size: 22, fase: 2.7, df: 9 },
+];
+
+function Diorama({ tier, reducedMotion, foco }) {
+  const perfil = perfilDeTier(tier);
+  const atm = useAtmosferaMundo({ familia: FAMILIA_LECHERIA, reducedMotion });
+  const bandas = useGradienteBandas();
+
+  const geoPotrero = useMemo(
+    () => construirPotrero(perfil.segmentosTerreno, perfil.flatShading),
+    [perfil.segmentosTerreno, perfil.flatShading],
+  );
+
+  const montes = useMemo(
+    () => ({
+      cerca: mezclar(VERDES.monte, atm.niebla, 0.2),
+      media: mezclar(VERDES.frio, atm.niebla, 0.3),
+      lejos: mezclar(VERDES.frio, atm.niebla, 0.42),
+    }),
+    [atm.niebla],
+  );
+
+  const fauna = useMemo(
+    () => (tier === 'alto' ? FAUNA_LECHERIA : FAUNA_LECHERIA.slice(0, 2)),
+    [tier],
+  );
+
+  const controls = useRef(null);
+  const gY = (p) => /** @type {[number, number, number]} */ ([p[0], alturaPotrero(p[0], p[1]), p[1]]);
+
+  return (
+    <>
+      <AtmosferaMundo
+        familia={FAMILIA_LECHERIA}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        radio={RADIO_LECHERIA}
+        conSuelo={false}
+        sombra={SOMBRA_LECHERIA}
+      />
+      <DomoCielo atm={atm} radio={70} />
+
+      {/* EL POTRERO por bandas toon (recibe la sombra del banco forrajero). */}
+      <mesh geometry={geoPotrero} receiveShadow={perfil.sombras}>
+        <meshToonMaterial vertexColors gradientMap={bandas} />
+      </mesh>
+
+      {/* los cerros del fondo, comidos por la niebla de la hora */}
+      <mesh position={[-15, 2.4, -22]} scale={[10, 4.6, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.media} gradientMap={bandas} />
+      </mesh>
+      <mesh position={[8, 3.0, -25]} scale={[12, 5.8, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.lejos} gradientMap={bandas} />
+      </mesh>
+      <mesh position={[23, 1.8, -20]} scale={[9, 3.6, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.cerca} gradientMap={bandas} />
+      </mesh>
+
+      {/* EL BANCO FORRAJERO + el hato lechero pastando */}
+      <FloraLecheria tier={tier} reducedMotion={reducedMotion} />
+      <GanadoLechero tier={tier} reducedMotion={reducedMotion} />
+
+      {/* la cerca viva, el bebedero */}
+      <CercaViva puntos={LINEA_CERCA} />
+      <Bebedero pos={gY(SITIO_BEBEDERO)} />
+
+      {/* LA QUESERA de la finca (la transformación) */}
+      <Quesera pos={gY(SITIO_QUESERA)} />
+
+      {/* EL CICLO del estiércol al abono (biodigestor + montón de abono) */}
+      <CicloAbono pos={gY(SITIO_BIODIGESTOR)} posAbono={gY(SITIO_ABONO)} reducedMotion={reducedMotion} />
+
+      {/* la vida que traen las flores del banco forrajero */}
+      {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
+
+      <FocoPaso foco={foco} reducedMotion={reducedMotion} />
+
+      <OrbitControls
+        ref={controls}
+        makeDefault
+        target={[0, 2.2, -3]}
+        enablePan={false}
+        enableZoom
+        minDistance={9}
+        maxDistance={28}
+        minPolarAngle={0.5}
+        maxPolarAngle={1.46}
+        minAzimuthAngle={-1.15}
+        maxAzimuthAngle={1.15}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.1}
+      />
+      <CamaraDirector
+        controls={controls}
+        reposo={[1.5, 5.0, 16.0]}
+        mirada={[0, 3.0, -3]}
+        respiro={0.04}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="mundoLecheria"
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * El mundo de la cadena láctea campesina. Montar SOLO perezosa (lazy).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, foco?: number[]|null}} props
+ */
+export default function EscenaLecheriaViva({ tier = 'alto', reducedMotion = false, foco = null }) {
+  const perfil = perfilDeTier(tier);
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`lecheria-canvas${listo ? ' lecheria-canvas--lista' : ''}`}
+      dpr={perfil.dpr}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      shadows={perfil.sombras ? 'soft' : false}
+      camera={{ position: [1.5, 5.0, 16.0], fov: 46 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Diorama tier={tier} reducedMotion={reducedMotion} foco={foco} />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/lecheria/FloraLecheria.jsx
+++ b/src/visual/mundo3d/lecheria/FloraLecheria.jsx
@@ -1,0 +1,187 @@
+/*
+ * FloraLecheria — el POTRERO SILVOPASTORIL sembrado: el banco forrajero vivo.
+ *
+ * Consume `floraLecheria.geom.js`: cada especie forrajera es UN InstancedMesh de
+ * una geometría fusionada (una draw-call por especie, por más matas que haya) —
+ * mismo contrato tier-safe que `FloraCafetal`. La flor va HORNEADA en la
+ * geometría de cada especie (la rosada del matarratón, la amarilla del botón de
+ * oro), así el potrero se lee a golpe de vista: no es pasto pelado, es sombra,
+ * forraje y flor.
+ *
+ * En 'alto' se suma la LUZ COLADA bajo el banco forrajero (el sol entre las
+ * copas del nacedero y la leucaena) — con `reducedMotion` queda quieta.
+ *
+ * Componente r3f: montar dentro del <Canvas> de EscenaLecheriaViva.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import {
+  lecheriaDeTier,
+  calidadLecheria,
+  distribucionLecheria,
+  centrosSombra,
+  alturaPotrero,
+  geomNacedero,
+  geomMatarraton,
+  geomLeucaena,
+  geomBotonDeOro,
+  geomPasto,
+  geomBoniga,
+} from './floraLecheria.geom.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* Un banco de matas de UNA especie: una geometría, un material, N instancias.
+   (Mismo molde que `Especie` de FloraCafetal.) */
+function Especie({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+    />
+  );
+}
+
+/*
+ * La LUZ COLADA bajo el banco forrajero: discos dorados aditivos sobre el pasto,
+ * que respiran apenas (el sol moviéndose entre las hojas del nacedero y la
+ * leucaena). Solo 'alto'; con reducedMotion quedan quietos.
+ */
+function LuzColada({ centros, reducedMotion }) {
+  const grupo = useRef(null);
+  const manchas = useMemo(() => {
+    const r = rng(131);
+    const lista = [];
+    centros.forEach((c) => {
+      const n = 3 + Math.floor(r() * 3);
+      for (let i = 0; i < n; i++) {
+        const x = c[0] + (r() - 0.5) * 3.4;
+        const z = c[2] + (r() - 0.5) * 3.4;
+        lista.push({
+          pos: /** @type {[number, number, number]} */ ([x, alturaPotrero(x, z) + 0.05, z]),
+          r: 0.42 + r() * 0.6,
+          fase: r() * Math.PI * 2,
+          op: 0.08 + r() * 0.06,
+        });
+      }
+    });
+    return lista;
+  }, [centros]);
+
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (reducedMotion || !g) return;
+    const t = clock.elapsedTime;
+    for (let i = 0; i < g.children.length; i++) {
+      const m = g.children[i];
+      const d = manchas[i];
+      m.material.opacity = d.op * (0.55 + 0.45 * Math.sin(t * 0.7 + d.fase));
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {manchas.map((d, i) => (
+        <mesh key={i} position={d.pos} rotation={[-Math.PI / 2, 0, 0]}>
+          <circleGeometry args={[d.r, 14]} />
+          <meshBasicMaterial
+            color="#ffe9b8"
+            transparent
+            opacity={d.op}
+            depthWrite={false}
+            blending={THREE.AdditiveBlending}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/**
+ * La capa viva del potrero silvopastoril. Montar dentro del <Canvas>.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function FloraLecheria({ tier = 'alto', reducedMotion = false }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = lecheriaDeTier(tier);
+  const q = calidadLecheria(tier);
+
+  const geos = useMemo(
+    () => ({
+      nacedero: conteos.nacedero ? geomNacedero({ q }, 41) : null,
+      matarraton: conteos.matarraton ? geomMatarraton({ q }, 42) : null,
+      leucaena: conteos.leucaena ? geomLeucaena({ q }, 43) : null,
+      botonDeOro: conteos.botonDeOro ? geomBotonDeOro({ q }, 44) : null,
+      pasto: conteos.pasto ? geomPasto({ q }, 45) : null,
+      boniga: conteos.boniga ? geomBoniga(46) : null,
+    }),
+    [conteos, q],
+  );
+
+  const mat = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.9, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  const dist = useMemo(() => distribucionLecheria(conteos, 707), [conteos]);
+  const centros = useMemo(() => centrosSombra(conteos), [conteos]);
+
+  useLayoutEffect(
+    () => () => {
+      Object.values(geos).forEach((g) => g && g.dispose());
+      mat.dispose();
+    },
+    [geos, mat],
+  );
+
+  const sombra = perfil.sombras;
+
+  return (
+    <group>
+      {/* El suelo del potrero: las boñigas (materia prima del ciclo) y el pasto. */}
+      <Especie geo={geos.boniga} mat={mat} items={dist.boniga} />
+      <Especie geo={geos.pasto} mat={mat} items={dist.pasto} />
+
+      {/* EL BANCO FORRAJERO: los árboles y arbustos que hacen el silvopastoril. */}
+      <Especie geo={geos.nacedero} mat={mat} items={dist.nacedero} castShadow={sombra} />
+      <Especie geo={geos.matarraton} mat={mat} items={dist.matarraton} castShadow={sombra} />
+      <Especie geo={geos.leucaena} mat={mat} items={dist.leucaena} castShadow={sombra} />
+      <Especie geo={geos.botonDeOro} mat={mat} items={dist.botonDeOro} />
+
+      {/* La luz que se cuela entre las copas del banco forrajero (gama alta). */}
+      {tier === 'alto' && <LuzColada centros={centros} reducedMotion={reducedMotion} />}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/lecheria/GanadoLechero.jsx
+++ b/src/visual/mundo3d/lecheria/GanadoLechero.jsx
@@ -1,0 +1,217 @@
+/*
+ * GanadoLechero — EL HATO LECHERO pastando en el potrero silvopastoril.
+ *
+ * Estiliza la silueta de VACA ya validada del corral de la finca (CorralVivo:
+ * cuerpo capsular, cabeza con hocico, orejas, cuernos, cola y cuatro patas) y le
+ * suma lo que la vuelve LECHERA y la cuenta por piso térmico (grounded en el DR
+ * de la cadena láctea):
+ *
+ *   · la UBRE — la señal inequívoca de la vaca de leche, bajo el vientre atrás;
+ *   · las RAZAS por piso: Holstein y Normando (la vaca mejorada del clima FRÍO),
+ *     la CRIOLLA baya y el CRUCE CON CEBÚ (giba + papada, la del clima CÁLIDO).
+ *
+ * Cada vaca PASTA: baja la cabeza al pasto en un ciclo lento y propio, respira y
+ * mueve la cola — vida, no espectáculo. Todo gateado por reduced-motion Y
+ * device-tier ('bajo' las deja quietas y sin cuernos/cola fina).
+ *
+ * Pocas y por criterio (≈6): un hato campesino de finca, no un feedlot.
+ * Componente r3f: montar dentro del <Canvas> de EscenaLecheriaViva.
+ */
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { alturaPotrero } from './floraLecheria.geom.js';
+
+/* ── Pelajes por raza (grounded en las razas del DR por piso térmico) ─────── */
+const RAZAS = {
+  holstein: { cuerpo: '#f2ede2', mancha: '#2a241c', cuernos: false, giba: false, manchada: true },
+  normando: { cuerpo: '#e9ddc6', mancha: '#8a5a3c', cuernos: true, giba: false, manchada: true },
+  criolla: { cuerpo: '#c08a52', mancha: '#9a6a3c', cuernos: true, giba: false, manchada: false },
+  cebu: { cuerpo: '#d0c9bb', mancha: '#b6ad9c', cuernos: true, giba: true, manchada: false },
+};
+const HOCICO = '#7a5c50';
+const HUESO = '#d8cba8';
+const PEZUNA = '#4a3a30';
+const UBRE = '#e7b6a6';
+
+/* Manchas deterministas sobre el lomo/flancos (Holstein/Normando). */
+function manchasDe(fase) {
+  const s = (k) => (Math.sin((fase + 1) * k) * 43758.5453) % 1;
+  const puntos = [];
+  const n = 4;
+  for (let i = 0; i < n; i++) {
+    const a = Math.abs(s(12.9 + i * 3.1));
+    const b = Math.abs(s(78.2 + i * 5.7));
+    puntos.push({
+      pos: [-0.28 + a * 0.62, 0.56 + (b - 0.5) * 0.24, (Math.abs(s(3.3 + i)) - 0.5) * 0.42],
+      r: 0.12 + Math.abs(s(9.1 + i)) * 0.1,
+    });
+  }
+  return puntos;
+}
+
+/**
+ * UNA vaca lechera, estilizada de la silueta del corral. Mira a +x.
+ * @param {{raza:string, escala?:number, fase?:number, animar?:boolean, fina?:boolean}} p
+ */
+function Vaca({ raza, escala = 1, fase = 0, animar = true, fina = true }) {
+  const pelaje = RAZAS[raza] || RAZAS.criolla;
+  const cabeza = useRef(null);
+  const cola = useRef(null);
+  const cuerpo = useRef(null);
+  const manchas = useMemo(() => (pelaje.manchada ? manchasDe(fase) : []), [pelaje.manchada, fase]);
+
+  useFrame(({ clock }) => {
+    if (!animar) return;
+    const t = clock.elapsedTime;
+    // pastar: la cabeza baja al pasto en un ciclo lento (agacha y vuelve a mirar)
+    if (cabeza.current) {
+      const p = 0.5 - 0.5 * Math.cos(t * 0.55 + fase); // 0 arriba, 1 abajo
+      const agacha = p * p; // se demora abajo pastando
+      cabeza.current.rotation.z = -agacha * 0.95;
+    }
+    // respirar (el flanco sube apenas)
+    if (cuerpo.current) cuerpo.current.scale.y = 1 + Math.sin(t * 0.9 + fase) * 0.02;
+    // la cola espanta moscas
+    if (cola.current) cola.current.rotation.x = Math.sin(t * 1.6 + fase) * 0.35;
+  });
+
+  const reposoCabeza = animar ? 0 : -0.5; // quieta: pose de pastar sereno
+
+  return (
+    <group scale={escala}>
+      {/* patas (siempre plantadas) */}
+      {[[0.3, 0.16], [0.3, -0.16], [-0.3, 0.16], [-0.3, -0.16]].map((q, i) => (
+        <group key={i} position={[q[0], 0, q[1]]}>
+          <mesh position={[0, 0.24, 0]}>
+            <cylinderGeometry args={[0.052, 0.046, 0.48, 6]} />
+            <meshLambertMaterial color={pelaje.cuerpo} flatShading />
+          </mesh>
+          <mesh position={[0, 0.02, 0]}>
+            <cylinderGeometry args={[0.055, 0.05, 0.06, 6]} />
+            <meshLambertMaterial color={PEZUNA} flatShading />
+          </mesh>
+        </group>
+      ))}
+
+      {/* cuerpo (capsular, respira) */}
+      <group ref={cuerpo}>
+        <mesh position={[0, 0.56, 0]} rotation={[0, 0, Math.PI / 2]}>
+          <capsuleGeometry args={[0.26, 0.5, 4, 10]} />
+          <meshLambertMaterial color={pelaje.cuerpo} flatShading />
+        </mesh>
+
+        {/* la giba del cebú (el cruce del clima cálido) */}
+        {pelaje.giba && (
+          <mesh position={[0.16, 0.78, 0]} scale={[0.9, 1, 0.8]}>
+            <sphereGeometry args={[0.17, 10, 8]} />
+            <meshLambertMaterial color={pelaje.mancha} flatShading />
+          </mesh>
+        )}
+
+        {/* manchas de la Holstein / Normando (sobre el lomo y flancos) */}
+        {manchas.map((m, i) => (
+          <mesh key={i} position={m.pos} scale={[1, 0.55, 0.9]}>
+            <sphereGeometry args={[m.r, 8, 6]} />
+            <meshLambertMaterial color={pelaje.mancha} flatShading />
+          </mesh>
+        ))}
+
+        {/* LA UBRE — la vaca es de leche (bajo el vientre, atrás) */}
+        <mesh position={[-0.16, 0.32, 0]} scale={[1.1, 0.85, 1.25]}>
+          <sphereGeometry args={[0.13, 10, 8]} />
+          <meshLambertMaterial color={UBRE} flatShading />
+        </mesh>
+      </group>
+
+      {/* cabeza + cuello (pivote en la base del cuello: pasta agachándose) */}
+      <group ref={cabeza} position={[0.34, 0.54, 0]} rotation={[0, 0, reposoCabeza]}>
+        {/* cuello */}
+        <mesh position={[0.12, 0.04, 0]} rotation={[0, 0, -0.5]}>
+          <cylinderGeometry args={[0.12, 0.16, 0.34, 7]} />
+          <meshLambertMaterial color={pelaje.cuerpo} flatShading />
+        </mesh>
+        {/* la papada del cebú */}
+        {pelaje.giba && (
+          <mesh position={[0.18, -0.14, 0]} rotation={[0, 0, 0.3]} scale={[1, 1.4, 0.5]}>
+            <coneGeometry args={[0.1, 0.34, 6]} />
+            <meshLambertMaterial color={pelaje.cuerpo} flatShading />
+          </mesh>
+        )}
+        {/* cráneo */}
+        <mesh position={[0.3, 0.05, 0]}>
+          <sphereGeometry args={[0.16, 10, 8]} />
+          <meshLambertMaterial color={pelaje.cuerpo} flatShading />
+        </mesh>
+        {/* hocico */}
+        <mesh position={[0.44, -0.02, 0]} scale={[1, 0.85, 0.9]}>
+          <sphereGeometry args={[0.1, 9, 7]} />
+          <meshLambertMaterial color={HOCICO} flatShading />
+        </mesh>
+        {/* orejas */}
+        {fina &&
+          [0.15, -0.15].map((z) => (
+            <mesh key={z} position={[0.24, 0.14, z]} rotation={[z > 0 ? 0.6 : -0.6, 0, 0.4]}>
+              <coneGeometry args={[0.055, 0.16, 5]} />
+              <meshLambertMaterial color={pelaje.cuerpo} flatShading />
+            </mesh>
+          ))}
+        {/* cuernos (criolla / normando / cebú) */}
+        {fina &&
+          pelaje.cuernos &&
+          [0.08, -0.08].map((z) => (
+            <mesh key={z} position={[0.32, 0.16, z]} rotation={[z > 0 ? 0.5 : -0.5, 0, -0.5]}>
+              <coneGeometry args={[0.032, 0.16, 5]} />
+              <meshLambertMaterial color={HUESO} flatShading />
+            </mesh>
+          ))}
+      </group>
+
+      {/* cola (espanta moscas) */}
+      {fina && (
+        <group ref={cola} position={[-0.5, 0.5, 0]}>
+          <mesh position={[0, -0.22, 0]} rotation={[0, 0, 0.15]}>
+            <cylinderGeometry args={[0.018, 0.028, 0.5, 5]} />
+            <meshLambertMaterial color={pelaje.cuerpo} flatShading />
+          </mesh>
+          <mesh position={[0.02, -0.46, 0]}>
+            <sphereGeometry args={[0.05, 7, 6]} />
+            <meshLambertMaterial color={pelaje.mancha} flatShading />
+          </mesh>
+        </group>
+      )}
+    </group>
+  );
+}
+
+/* El hato de la finca: un puñado de vacas, la mezcla real de un potrero
+   campesino (la mejorada de leche + la criolla + el cruce con cebú). Posiciones
+   sobre el potrero (centro-izquierda, donde también quedan las boñigas). */
+const HATO = [
+  { raza: 'holstein', p: [-5.5, -3.2], giro: 2.4, escala: 1.7, fase: 0.0 },
+  { raza: 'normando', p: [-8.2, -5.6], giro: 1.1, escala: 1.65, fase: 1.3 },
+  { raza: 'criolla', p: [-2.4, -6.0], giro: 3.5, escala: 1.55, fase: 2.1 },
+  { raza: 'cebu', p: [-9.6, -2.2], giro: 0.5, escala: 1.75, fase: 0.7 },
+  { raza: 'holstein', p: [0.6, -4.2], giro: 4.0, escala: 1.6, fase: 2.8 },
+  { raza: 'criolla', p: [-4.6, -7.4], giro: 2.0, escala: 1.5, fase: 1.7 },
+];
+
+/**
+ * El hato lechero pastando. Montar dentro del <Canvas>.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function GanadoLechero({ tier = 'alto', reducedMotion = false }) {
+  const animar = !reducedMotion && tier !== 'bajo';
+  const fina = tier !== 'bajo';
+  // gama baja: un hato más corto (siluetas legibles, sin pagar de más)
+  const hato = tier === 'bajo' ? HATO.slice(0, 4) : HATO;
+
+  return (
+    <group>
+      {hato.map((v, i) => (
+        <group key={i} position={[v.p[0], alturaPotrero(v.p[0], v.p[1]), v.p[1]]} rotation={[0, v.giro, 0]}>
+          <Vaca raza={v.raza} escala={v.escala} fase={v.fase} animar={animar} fina={fina} />
+        </group>
+      ))}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/lecheria/MundoLecheria.jsx
+++ b/src/visual/mundo3d/lecheria/MundoLecheria.jsx
@@ -1,0 +1,141 @@
+/*
+ * MundoLecheria — el MUNDO DE LA CADENA LÁCTEA completo: el potrero navegable +
+ * la lección. Mismo contrato de host que MundoCafetal: acepta `{tier,
+ * reducedMotion}` (o auto-detecta con decidirTier si se monta suelto), llena a su
+ * padre y guarda su estado local. Sobre la escena viven los PASOS: cuatro
+ * lecciones cortas — el silvopastoril, el hato por piso térmico, la quesera de
+ * la finca y el ciclo del estiércol al abono — y cada paso señala SU lugar en el
+ * potrero con un anillo que respira. Copy en español de Colombia, en "usted".
+ *
+ * Importa three/@react-three (vía la escena) → montar SOLO perezoso (lazy).
+ */
+import { useMemo, useState } from 'react';
+import EscenaLecheriaViva from './EscenaLecheriaViva.jsx';
+import { decidirTier, permite3D } from '../deviceTier.js';
+import {
+  alturaPotrero,
+  SITIO_QUESERA,
+  SITIO_BIODIGESTOR,
+} from './floraLecheria.geom.js';
+
+const enSuelo = (x, z) => [x, alturaPotrero(x, z), z];
+const PASOS = [
+  {
+    id: 'silvopastoril',
+    kicker: 'Paso 1 de 4 · El potrero con árboles',
+    texto:
+      'Esto no es potrero pelado: es un sistema SILVOPASTORIL. Entre el pasto se siembran árboles forrajeros —nacedero, matarratón, leucaena y el arbusto botón de oro—: dan sombra, forraje con proteína y fijan nitrógeno que abona el suelo.',
+    foco: enSuelo(-6.5, -1.5),
+  },
+  {
+    id: 'hato',
+    kicker: 'Paso 2 de 4 · El hato por piso',
+    texto:
+      'La vaca se escoge según el clima: en tierra fría, la Holstein y la Normando de buena leche; en tierra caliente, la criolla y el cruce con cebú (el de la giba), que aguanta el calor y las garrapatas. Se pastorea rotando el potrero para que el pasto descanse.',
+    foco: enSuelo(-5.5, -3.2),
+  },
+  {
+    id: 'quesera',
+    kicker: 'Paso 3 de 4 · La quesera de la finca',
+    texto:
+      'La leche no se vende cruda y barata: se TRANSFORMA en la finca. En la quesera salen la cuajada y el queso campesino, el doble crema, el kumis y el yogur, y en la olla de cobre el arequipe. Ahí es donde el trabajo del campesino se paga.',
+    foco: enSuelo(SITIO_QUESERA[0], SITIO_QUESERA[1]),
+  },
+  {
+    id: 'ciclo',
+    kicker: 'Paso 4 de 4 · Nada se pierde',
+    texto:
+      'El estiércol no es basura: entra al biodigestor y da BIOGÁS para cocinar en la quesera y BIOL para abonar el pasto; lo demás va al montón de abono. Así se cierra el ciclo —del potrero a la leche y de vuelta al potrero— sin comprar químicos.',
+    foco: enSuelo(SITIO_BIODIGESTOR[0], SITIO_BIODIGESTOR[1]),
+  },
+];
+
+const CSS = `
+.mlecheria { position: relative; width: 100%; height: 100%; overflow: hidden; background: #cfe0cf; }
+.mlecheria canvas { opacity: 0; transition: opacity 0.9s ease; }
+.mlecheria .lecheria-canvas--lista canvas, .mlecheria canvas.lecheria-canvas--lista { opacity: 1; }
+.mlecheria__panel {
+  position: absolute; left: 50%; bottom: max(0.9rem, env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  width: min(26rem, calc(100% - 1.6rem));
+  padding: 0.8rem 0.95rem 0.85rem;
+  border-radius: 1rem;
+  background: rgba(22, 28, 18, 0.68);
+  box-shadow: inset 0 0 0 1px rgba(180, 206, 150, 0.3), 0 6px 24px rgba(12, 14, 8, 0.35);
+  backdrop-filter: blur(6px);
+  color: #f0f3e8;
+}
+.mlecheria__kicker { margin: 0 0 0.15rem; font: 600 0.68rem/1.2 system-ui, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; color: #b9d68f; }
+.mlecheria__texto { margin: 0 0 0.6rem; font: 500 0.85rem/1.38 system-ui, sans-serif; color: #e9efdb; }
+.mlecheria__nav { display: flex; align-items: center; gap: 0.55rem; }
+.mlecheria__btn {
+  min-height: 2.5rem; min-width: 2.9rem; padding: 0 0.8rem;
+  border: 0; border-radius: 0.7rem; cursor: pointer;
+  background: linear-gradient(180deg, rgba(150, 186, 96, 0.95), rgba(102, 140, 58, 0.95));
+  color: #17230b; font: 700 0.9rem/1 system-ui, sans-serif;
+  transition: transform 0.15s ease;
+}
+.mlecheria__btn:active { transform: scale(0.96); }
+.mlecheria__btn[disabled] { opacity: 0.35; cursor: default; }
+.mlecheria__puntos { display: flex; gap: 0.35rem; margin: 0 auto; }
+.mlecheria__punto { width: 0.5rem; height: 0.5rem; border-radius: 999px; background: rgba(233, 239, 219, 0.32); }
+.mlecheria__punto--activo { background: #96ba60; box-shadow: 0 0 8px 1px rgba(150, 186, 96, 0.5); }
+@media (prefers-reduced-motion: reduce) {
+  .mlecheria canvas { transition: none; }
+  .mlecheria__btn { transition: none; }
+}
+`;
+
+/**
+ * El mundo de la cadena láctea campesina, completo: escena + pasos didácticos.
+ * Montar SOLO perezoso (lazy); llena a su contenedor.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function MundoLecheria({ tier: tierProp, reducedMotion: rmProp } = {}) {
+  const auto = useMemo(() => decidirTier(), []);
+  const tier = tierProp ?? (permite3D(auto.tier) ? auto.tier : 'bajo');
+  const reducedMotion = rmProp ?? auto.reducedMotion;
+  const [paso, setPaso] = useState(0);
+
+  const actual = PASOS[paso];
+
+  return (
+    <div className="mlecheria">
+      <style>{CSS}</style>
+      <EscenaLecheriaViva tier={tier} reducedMotion={reducedMotion} foco={actual.foco} />
+
+      <div className="mlecheria__panel" role="group" aria-label="La lección de la cadena láctea">
+        <p className="mlecheria__kicker">{actual.kicker}</p>
+        <p className="mlecheria__texto">{actual.texto}</p>
+        <div className="mlecheria__nav">
+          <button
+            type="button"
+            className="mlecheria__btn"
+            onClick={() => setPaso((p) => Math.max(0, p - 1))}
+            disabled={paso === 0}
+            aria-label="Paso anterior"
+          >
+            ←
+          </button>
+          <span className="mlecheria__puntos" aria-hidden="true">
+            {PASOS.map((p, i) => (
+              <span
+                key={p.id}
+                className={`mlecheria__punto${i === paso ? ' mlecheria__punto--activo' : ''}`}
+              />
+            ))}
+          </span>
+          <button
+            type="button"
+            className="mlecheria__btn"
+            onClick={() => setPaso((p) => Math.min(PASOS.length - 1, p + 1))}
+            disabled={paso === PASOS.length - 1}
+            aria-label="Paso siguiente"
+          >
+            →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/lecheria/floraLecheria.geom.js
+++ b/src/visual/mundo3d/lecheria/floraLecheria.geom.js
@@ -1,0 +1,564 @@
+/*
+ * floraLecheria.geom — la GEOMETRÍA del POTRERO SILVOPASTORIL de la lechería
+ * campesina (piso templado, la lechería tropical de altura media de Colombia).
+ *
+ * La ganadería agroecológica no es potrero pelado a pleno sol: es un SISTEMA
+ * SILVOPASTORIL — árboles y arbustos forrajeros REALES sembrados entre el pasto,
+ * que dan sombra, forraje de alta proteína, fijan nitrógeno y traen de vuelta la
+ * vida. Cada especie con su identidad inequívoca (todas verificadas en el DR de
+ * la cadena láctea, confirmadas por gemini Y glm):
+ *
+ *   · Nacedero / quiebrabarrigo   — Trichanthera gigantea. Arbolito de HOJA
+ *     (Trichanthera gigantea)       GRANDE y copa densa; fija nitrógeno, forraje
+ *                                   de alta calidad. La columna del banco forrajero.
+ *   · Matarratón                  — Gliricidia sepium. Copa abierta y aireada con
+ *     (Gliricidia sepium)           FLOR ROSADA-LILA (su firma); follaje muy
+ *                                   nutritivo, antiparasitario, y el poste vivo
+ *                                   por excelencia de la cerca viva.
+ *   · Leucaena                    — Leucaena leucocephala. El "árbol insignia" de
+ *     (Leucaena leucocephala)       los SSP: alto, follaje FINO y plumoso, vainas
+ *                                   y flores en pompón crema. Alto aporte de proteína.
+ *   · Botón de oro                — Tithonia diversifolia. ARBUSTO de FLOR AMARILLA
+ *     (Tithonia diversifolia)       intensa (16–28% de proteína); el banco forrajero
+ *                                   que además alimenta polinizadores.
+ *   · Macolla de pasto            — el pasto de piso (kikuyo/estrella según el
+ *                                   clima); la cobertura viva del potrero.
+ *   · Boñiga                      — la plasta de estiércol en el potrero: el
+ *                                   principio del ciclo (estiércol → abono/biogás).
+ *
+ * TÉCNICA tier-safe (mismo contrato que floraCafetal.geom): cada especie se
+ * FUSIONA en UNA geometría con color horneado en vertexColors y se dibuja con UN
+ * InstancedMesh → una draw-call por especie. La FLOR (rosada del matarratón,
+ * amarilla del botón de oro) va HORNEADA en la geometría de su especie.
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO si se mezclan geometrías indexadas
+ * con no-indexadas (ya mordió 3 veces): aquí TODO se desindexa antes de fusionar
+ * y se TRUENA si aun así falla.
+ *
+ * Aquí viven SOLO los datos y las mallas (nada de WebGL): corre headless.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* -------------------------------------------------------------------------- */
+/*  El potrero (la geografía del mundo, determinista)                          */
+/* -------------------------------------------------------------------------- */
+
+export const ANCHO = 42; // x: -21 … 21
+export const FONDO = 40; // z: -20 (los cerros, al fondo) … 20 (el frente)
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+
+/* Ruido determinista (hash de senos): mismo potrero siempre, sin Math.random. */
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.7 + wz * 0.5) * 0.5 +
+    Math.sin(wx * 1.7 - wz * 1.3 + 2.1) * 0.3 +
+    Math.sin(wx * 3.0 + wz * 2.4 + 4.7) * 0.2
+  );
+}
+
+/**
+ * La altura del potrero: casi PLANO al frente (donde pastan las vacas y está la
+ * quesera), con ondulación suave de loma, y SUBE hacia el fondo a encontrarse
+ * con los cerros. Un potrero no es una ladera empinada como el cafetal.
+ */
+export function alturaPotrero(wx, wz) {
+  const alFondo = smoothstep(-6, -19, wz); // 0 al frente, 1 contra los cerros
+  let h = 0.08;
+  h += alFondo * 3.2; // el pie de monte al fondo
+  h += ruido(wx * 0.35, wz * 0.32) * 0.45 * (0.4 + alFondo); // el rolar del potrero
+  return h;
+}
+
+/* Los SITIOS de lo construido (la escena los posa sobre el terreno). */
+export const SITIO_QUESERA = /** @type {[number, number]} */ ([8.2, 3.4]);
+export const SITIO_BIODIGESTOR = /** @type {[number, number]} */ ([3.6, 5.6]);
+export const SITIO_ABONO = /** @type {[number, number]} */ ([0.4, 6.4]);
+export const SITIO_BEBEDERO = /** @type {[number, number]} */ ([-3.0, -2.4]);
+
+/* -------------------------------------------------------------------------- */
+/*  Presupuesto por tier                                                       */
+/* -------------------------------------------------------------------------- */
+
+export const FLORA_LECHERIA = {
+  alto: { nacedero: 5, matarraton: 6, leucaena: 4, botonDeOro: 16, pasto: 96, boniga: 12 },
+  medio: { nacedero: 3, matarraton: 4, leucaena: 2, botonDeOro: 9, pasto: 54, boniga: 7 },
+  bajo: { nacedero: 2, matarraton: 2, leucaena: 1, botonDeOro: 4, pasto: 22, boniga: 3 },
+};
+export const lecheriaDeTier = (tier) => FLORA_LECHERIA[tier] || FLORA_LECHERIA.medio;
+
+export const CALIDAD_LECHERIA = { alto: 1, medio: 0.62, bajo: 0.42 };
+export const calidadLecheria = (tier) => CALIDAD_LECHERIA[tier] ?? CALIDAD_LECHERIA.medio;
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del potrero (colores horneados en vertexColors)                     */
+/* -------------------------------------------------------------------------- */
+
+export const PAL = {
+  // Nacedero (Trichanthera) — hoja grande, verde franco
+  nacederoTronco: '#6a5c4a',
+  nacederoHoja: '#4e8a3e',
+  nacederoHojaSol: '#68a548',
+  nacederoHojaSombra: '#3a6c34',
+
+  // Matarratón (Gliricidia) — copa aireada + flor rosada-lila (LA firma)
+  matarratonTronco: '#9a9a8f',
+  matarratonHoja: '#7a9a45',
+  matarratonHojaSol: '#95b45a',
+  matarratonFlor: '#e46b9b', // la flor rosada del matarratón (ACENTOS.florDeMonte)
+  matarratonFlorPalo: '#d98fb0',
+
+  // Leucaena — follaje fino plumoso azul-verdoso + pompón crema
+  leucaenaTronco: '#7a6a52',
+  leucaenaHoja: '#5c8a5e',
+  leucaenaHojaSol: '#79a56e',
+  leucaenaPompon: '#f2ead3', // la flor crema en pompón
+  leucaenaVaina: '#9a7c46', // la vaina parda
+
+  // Botón de oro (Tithonia) — arbusto verde + FLOR AMARILLA intensa
+  botonHoja: '#5f8a3f',
+  botonHojaSol: '#7a9a3f',
+  botonFlor: '#f2c33a', // el amarillo botón de oro (ACENTOS.guayacan)
+  botonFlorCentro: '#c98a2a',
+
+  // Pasto y suelo
+  pasto: '#5f8a3f',
+  pastoSol: '#7a9a3f',
+  pastoSeco: '#a5975c',
+  boniga: '#5a3d28', // la plasta fresca-parda del estiércol (TIERRAS.turba)
+  bonigaBorde: '#6b4a2e',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Utilidades (fusión desindexada + colocación + color horneado)              */
+/* -------------------------------------------------------------------------- */
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+function pintar(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    q,
+    new THREE.Vector3(esc[0], esc[1], esc[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/**
+ * Fusiona partes (ya coloreadas) en UNA geometría. Se DESINDEXA todo antes de
+ * fusionar y se TRUENA si falla: mejor un error de build que una especie
+ * invisible en producción (mordida conocida de mergeGeometries).
+ */
+function fusionar(partes, etiqueta) {
+  const buenas = partes.filter(Boolean).map((p) => {
+    const plana = p.index ? p.toNonIndexed() : p;
+    if (plana !== p) p.dispose();
+    return plana;
+  });
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error(`floraLecheria: mergeGeometries devolvió null en "${etiqueta}" — atributos incompatibles`);
+  }
+  return g;
+}
+
+function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  NACEDERO (Trichanthera gigantea) — la columna del banco forrajero          */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Arbolito de HOJA GRANDE: tronco corto que se abre en pocas ramas maestras y
+ * una copa densa, redondeada, de masas anchas — con unas hojas gigantes
+ * insinuadas como paletas planas (su firma: la hoja de quiebrabarrigo).
+ */
+export function geomNacedero({ q = 1 } = {}, seed = 2) {
+  const r = rng(seed);
+  const partes = [];
+
+  const tronco = new THREE.CylinderGeometry(0.1, 0.17, 2.2, 6, 1);
+  poner(tronco, [0, 1.1, 0]);
+  partes.push(pintar(tronco, PAL.nacederoTronco));
+
+  const nRamas = Math.max(2, Math.round(3 * q));
+  for (let i = 0; i < nRamas; i++) {
+    const a = (i / nRamas) * Math.PI * 2 + r();
+    const rama = new THREE.CylinderGeometry(0.05, 0.08, 1.1, 5, 1);
+    apuntar(rama, [Math.cos(a) * 0.35, 2.2, Math.sin(a) * 0.35], [Math.cos(a) * 0.7, 1, Math.sin(a) * 0.7]);
+    partes.push(pintar(rama, PAL.nacederoTronco));
+  }
+
+  // La copa densa y redonda: masas anchas de hoja grande.
+  const nMasas = Math.max(3, Math.round(6 * q));
+  for (let i = 0; i < nMasas; i++) {
+    const a = (i / nMasas) * Math.PI * 2 + 0.5;
+    const rad = i === 0 ? 0 : 0.55 + r() * 0.35;
+    const masa = new THREE.IcosahedronGeometry(i === 0 ? 1.05 : 0.72 + r() * 0.22, 1);
+    poner(
+      masa,
+      [Math.cos(a) * rad, 2.7 + (r() - 0.5) * 0.4, Math.sin(a) * rad],
+      [0, r() * Math.PI, 0],
+      [1.25, 1.0, 1.25],
+    );
+    partes.push(pintar(masa, variar(i % 2 ? PAL.nacederoHojaSol : PAL.nacederoHoja, r, 0.06)));
+  }
+
+  // Unas hojas GIGANTES asomando (la firma del nacedero): paletas planas anchas.
+  const nHojas = q < 0.5 ? 2 : Math.round(5 * q);
+  for (let i = 0; i < nHojas; i++) {
+    const a = r() * Math.PI * 2;
+    const hoja = new THREE.SphereGeometry(1, 6, 4);
+    apuntar(
+      hoja,
+      [Math.cos(a) * 0.95, 2.55 + r() * 0.5, Math.sin(a) * 0.95],
+      [Math.cos(a), 0.35, Math.sin(a)],
+      [0.34, 0.05, 0.5],
+    );
+    partes.push(pintar(hoja, i % 2 ? PAL.nacederoHojaSol : PAL.nacederoHojaSombra));
+  }
+
+  return fusionar(partes, 'nacedero');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  MATARRATÓN (Gliricidia sepium) — copa aireada + flor rosada (su firma)     */
+/* -------------------------------------------------------------------------- */
+
+export function geomMatarraton({ q = 1 } = {}, seed = 3) {
+  const r = rng(seed);
+  const partes = [];
+
+  // Tronco esbelto que se inclina y bifurca (el árbol de cerca viva).
+  const tronco = new THREE.CylinderGeometry(0.09, 0.15, 3.0, 6, 1);
+  poner(tronco, [0, 1.5, 0], [0, 0, 0.08]);
+  partes.push(pintar(tronco, PAL.matarratonTronco));
+  const nRamas = Math.max(2, Math.round(3 * q));
+  for (let i = 0; i < nRamas; i++) {
+    const a = (i / nRamas) * Math.PI * 2 + r();
+    const rama = new THREE.CylinderGeometry(0.04, 0.07, 1.4, 5, 1);
+    apuntar(rama, [Math.cos(a) * 0.5, 3.05, Math.sin(a) * 0.5], [Math.cos(a) * 1.1, 1, Math.sin(a) * 1.1]);
+    partes.push(pintar(rama, PAL.matarratonTronco));
+  }
+
+  // Copa AIREADA: masas más chicas y separadas (deja pasar la luz).
+  const nMasas = Math.max(4, Math.round(7 * q));
+  const centros = [];
+  for (let i = 0; i < nMasas; i++) {
+    const a = (i / nMasas) * Math.PI * 2 + 0.3;
+    const rad = i === 0 ? 0.2 : 0.9 + r() * 0.5;
+    const cx = Math.cos(a) * rad;
+    const cy = 3.5 + (r() - 0.5) * 0.6;
+    const cz = Math.sin(a) * rad;
+    centros.push([cx, cy, cz]);
+    const masa = new THREE.IcosahedronGeometry(0.55 + r() * 0.22, 1);
+    poner(masa, [cx, cy, cz], [0, r() * Math.PI, 0], [1.15, 0.78, 1.15]);
+    partes.push(pintar(masa, variar(i % 2 ? PAL.matarratonHojaSol : PAL.matarratonHoja, r, 0.06)));
+  }
+
+  // LA FLOR ROSADA-LILA: racimos de bolitas rosadas por la copa (su identidad).
+  const nFlores = q < 0.5 ? 4 : Math.round(12 * q);
+  for (let i = 0; i < nFlores; i++) {
+    const c = centros[i % centros.length];
+    const flor = new THREE.IcosahedronGeometry(0.11 + r() * 0.05, 0);
+    poner(flor, [c[0] + (r() - 0.5) * 0.7, c[1] + (r() - 0.5) * 0.5, c[2] + (r() - 0.5) * 0.7]);
+    partes.push(pintar(flor, i % 3 ? PAL.matarratonFlor : PAL.matarratonFlorPalo));
+  }
+
+  return fusionar(partes, 'matarraton');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LEUCAENA (Leucaena leucocephala) — el árbol insignia del SSP, follaje fino */
+/* -------------------------------------------------------------------------- */
+
+export function geomLeucaena({ q = 1 } = {}, seed = 4) {
+  const r = rng(seed);
+  const partes = [];
+
+  // Tronco recto y alto (crece más que sus vecinos del banco).
+  const tronco = new THREE.CylinderGeometry(0.08, 0.14, 3.9, 6, 1);
+  poner(tronco, [0, 1.95, 0]);
+  partes.push(pintar(tronco, PAL.leucaenaTronco));
+
+  // Copa FINA y plumosa: muchas masas chicas, verde-azuloso claro.
+  const nMasas = Math.max(5, Math.round(9 * q));
+  const centros = [];
+  for (let i = 0; i < nMasas; i++) {
+    const a = i * 2.2 + 0.4;
+    const rad = i === 0 ? 0 : 0.5 + r() * 0.45;
+    const cx = Math.cos(a) * rad;
+    const cy = 3.9 + i * 0.16 + (r() - 0.5) * 0.4;
+    const cz = Math.sin(a) * rad;
+    centros.push([cx, cy, cz]);
+    const masa = new THREE.IcosahedronGeometry(0.42 + r() * 0.2, 1);
+    poner(masa, [cx, cy, cz], [0, r() * Math.PI, 0], [1.2, 0.72, 1.2]);
+    partes.push(pintar(masa, variar(i % 2 ? PAL.leucaenaHojaSol : PAL.leucaenaHoja, r, 0.06)));
+  }
+
+  // Los pompones crema (la flor) y alguna vaina parda colgando.
+  const nPom = q < 0.5 ? 3 : Math.round(7 * q);
+  for (let i = 0; i < nPom; i++) {
+    const c = centros[i % centros.length];
+    const pom = new THREE.IcosahedronGeometry(0.08 + r() * 0.03, 0);
+    poner(pom, [c[0] + (r() - 0.5) * 0.6, c[1] + 0.2 + r() * 0.2, c[2] + (r() - 0.5) * 0.6]);
+    partes.push(pintar(pom, PAL.leucaenaPompon));
+  }
+  const nVainas = q < 0.5 ? 0 : Math.round(4 * q);
+  for (let i = 0; i < nVainas; i++) {
+    const c = centros[(i + 2) % centros.length];
+    const vaina = new THREE.BoxGeometry(0.03, 0.4, 0.09);
+    poner(vaina, [c[0] + (r() - 0.5) * 0.5, c[1] - 0.35, c[2] + (r() - 0.5) * 0.5], [0, r() * Math.PI, 0.1]);
+    partes.push(pintar(vaina, PAL.leucaenaVaina));
+  }
+
+  return fusionar(partes, 'leucaena');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  BOTÓN DE ORO (Tithonia diversifolia) — el arbusto de flor amarilla         */
+/* -------------------------------------------------------------------------- */
+
+export function geomBotonDeOro({ q = 1 } = {}, seed = 5) {
+  const r = rng(seed);
+  const partes = [];
+
+  // Varios tallos delgados desde la base (mata arbustiva).
+  const nTallos = Math.max(2, Math.round(4 * q));
+  const cimas = [];
+  for (let i = 0; i < nTallos; i++) {
+    const a = (i / nTallos) * Math.PI * 2 + r();
+    const incl = 0.12 + r() * 0.14;
+    const cx = Math.cos(a) * 0.24;
+    const cz = Math.sin(a) * 0.24;
+    const tallo = new THREE.CylinderGeometry(0.02, 0.03, 1.35, 4, 1);
+    poner(tallo, [cx, 0.68, cz], [Math.sin(a) * incl, 0, -Math.cos(a) * incl]);
+    partes.push(pintar(tallo, '#6f7d3a'));
+    cimas.push([cx + Math.sin(a) * incl * 0.7, 1.3, cz - Math.cos(a) * incl * 0.7]);
+  }
+
+  // La mata verde (masas bajas y anchas).
+  const nMasas = Math.max(2, Math.round(4 * q));
+  for (let i = 0; i < nMasas; i++) {
+    const a = r() * Math.PI * 2;
+    const masa = new THREE.IcosahedronGeometry(0.36 + r() * 0.16, 1);
+    poner(masa, [Math.cos(a) * 0.3, 0.85 + r() * 0.45, Math.sin(a) * 0.3], [0, r() * Math.PI, 0], [1.15, 0.85, 1.15]);
+    partes.push(pintar(masa, variar(i % 2 ? PAL.botonHojaSol : PAL.botonHoja, r, 0.06)));
+  }
+
+  // LA FLOR AMARILLA (el "botón de oro"): discos amarillos con centro anaranjado.
+  const nFlores = Math.max(2, Math.round(6 * q));
+  for (let i = 0; i < nFlores; i++) {
+    const c = cimas[i % Math.max(1, cimas.length)] || [0, 1.3, 0];
+    const dx = (r() - 0.5) * 0.4;
+    const dz = (r() - 0.5) * 0.4;
+    const petalos = new THREE.CylinderGeometry(0.16, 0.16, 0.035, 8, 1);
+    poner(petalos, [c[0] + dx, c[1] + r() * 0.2, c[2] + dz], [0, r() * Math.PI, 0]);
+    partes.push(pintar(petalos, PAL.botonFlor));
+    const centro = new THREE.IcosahedronGeometry(0.06, 0);
+    poner(centro, [c[0] + dx, c[1] + 0.03 + r() * 0.2, c[2] + dz]);
+    partes.push(pintar(centro, PAL.botonFlorCentro));
+  }
+
+  return fusionar(partes, 'botonDeOro');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  MACOLLA DE PASTO — la cobertura viva del potrero                           */
+/* -------------------------------------------------------------------------- */
+
+export function geomPasto({ q = 1 } = {}, seed = 6) {
+  const r = rng(seed);
+  const partes = [];
+  const nHojas = q < 0.5 ? 4 : Math.round(9 * q);
+  for (let i = 0; i < nHojas; i++) {
+    const a = r() * Math.PI * 2;
+    const incl = 0.2 + r() * 0.35;
+    const alto = 0.22 + r() * 0.26;
+    const hoja = new THREE.ConeGeometry(0.03, alto, 3, 1);
+    poner(
+      hoja,
+      [Math.cos(a) * 0.06, alto * 0.45, Math.sin(a) * 0.06],
+      [Math.sin(a) * incl, 0, -Math.cos(a) * incl],
+    );
+    partes.push(pintar(hoja, i % 2 ? PAL.pastoSol : PAL.pasto));
+  }
+  return fusionar(partes, 'pasto');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  BOÑIGA — la plasta de estiércol: el principio del ciclo del abono          */
+/* -------------------------------------------------------------------------- */
+
+export function geomBoniga(seed = 7) {
+  const r = rng(seed);
+  const base = new THREE.CylinderGeometry(0.24 + r() * 0.08, 0.3 + r() * 0.08, 0.05, 9, 1);
+  poner(base, [0, 0.025, 0]);
+  const cupula = new THREE.SphereGeometry(0.16, 8, 4, 0, Math.PI * 2, 0, Math.PI / 2);
+  poner(cupula, [(r() - 0.5) * 0.05, 0.05, (r() - 0.5) * 0.05], [0, 0, 0], [1.2, 0.55, 1.2]);
+  return fusionar([pintar(base, PAL.bonigaBorde), pintar(cupula, PAL.boniga)], 'boniga');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Distribución del potrero silvopastoril                                     */
+/* -------------------------------------------------------------------------- */
+
+/* Los árboles del banco forrajero viven en sitios FIJOS (compuestos a mano para
+   que den sombra al potrero sin taparlo). Se recortan por tier. */
+const SITIOS_NACEDERO = [
+  [-9.5, -4.5], [-2.5, -8.0], [6.0, -9.5], [-13.0, -9.0], [11.5, -5.5],
+];
+const SITIOS_MATARRATON = [
+  [-6.5, -1.5], [3.0, -3.5], [-11.0, -1.0], [9.5, -1.5], [-4.0, -11.5], [13.0, -10.5],
+];
+const SITIOS_LEUCAENA = [
+  [-8.0, -13.5], [1.5, -14.5], [8.5, -13.0], [-14.5, -5.5],
+];
+
+/** Sitios de la cerca viva de matarratón (postes vivos), en línea al frente-izq. */
+export const LINEA_CERCA = (() => {
+  const pts = [];
+  for (let i = 0; i <= 8; i++) {
+    const t = i / 8;
+    const wx = -19 + t * 12; // de -19 a -7
+    const wz = 9.5 - t * 2.2; // baja apenas hacia el centro
+    pts.push([wx, wz]);
+  }
+  return pts;
+})();
+
+/**
+ * Siembra determinista del potrero. Devuelve items por especie
+ * (`{pos, rotY, escala, tint}` — contrato del componente `Especie`).
+ */
+export function distribucionLecheria(conteos, seed = 707) {
+  const c = conteos;
+  const rArb = rng(seed + 1);
+  const rPas = rng(seed + 2);
+  const rBon = rng(seed + 3);
+
+  const enSuelo = (p, esc, rr) => ({
+    pos: /** @type {[number, number, number]} */ ([p[0], alturaPotrero(p[0], p[1]), p[1]]),
+    rotY: rr() * Math.PI * 2,
+    escala: esc,
+    tint: /** @type {[number, number, number]} */ ([
+      0.94 + rr() * 0.12,
+      0.94 + rr() * 0.12,
+      0.94 + rr() * 0.12,
+    ]),
+  });
+
+  const nacedero = SITIOS_NACEDERO.slice(0, c.nacedero).map((p) => enSuelo(p, 0.95 + rArb() * 0.3, rArb));
+  const matarraton = SITIOS_MATARRATON.slice(0, c.matarraton).map((p) => enSuelo(p, 0.95 + rArb() * 0.3, rArb));
+  const leucaena = SITIOS_LEUCAENA.slice(0, c.leucaena).map((p) => enSuelo(p, 0.95 + rArb() * 0.25, rArb));
+
+  // Botón de oro: en RACIMOS (el banco forrajero) al borde del potrero y bajo
+  // los árboles — junto a la cerca y en manchas sueltas.
+  const botonDeOro = [];
+  const focos = [[-16, 6.5], [-15, 2.0], [12.5, -3.5], [-9.5, -4.5], [6.0, -9.5], [10.0, 2.5]];
+  let fi = 0;
+  while (botonDeOro.length < c.botonDeOro) {
+    const f = focos[fi % focos.length];
+    fi += 1;
+    if (fi > focos.length * 6) break;
+    const cuantas = 2 + Math.floor(rArb() * 2);
+    for (let k = 0; k < cuantas && botonDeOro.length < c.botonDeOro; k++) {
+      const x = f[0] + (rArb() - 0.5) * 3.4;
+      const z = f[1] + (rArb() - 0.5) * 3.0;
+      botonDeOro.push({
+        pos: [x, alturaPotrero(x, z), z],
+        rotY: rArb() * Math.PI * 2,
+        escala: 0.82 + rArb() * 0.5,
+        tint: [0.94 + rArb() * 0.12, 0.96 + rArb() * 0.08, 0.94 + rArb() * 0.12],
+      });
+    }
+  }
+
+  // Pasto: repartido por el potrero, RALO cerca de lo construido (quesera, ciclo,
+  // bebedero) y sin invadir el frente por donde entra la cámara.
+  const evitar = [SITIO_QUESERA, SITIO_BIODIGESTOR, SITIO_ABONO, SITIO_BEBEDERO];
+  const pasto = [];
+  let intentos = 0;
+  while (pasto.length < c.pasto && intentos < c.pasto * 8) {
+    intentos += 1;
+    const x = -20 + rPas() * 40;
+    const z = -18 + rPas() * 34;
+    // dejar despejado el proscenio (muy al frente y centrado)
+    if (z > 8.5 && Math.abs(x) < 6) continue;
+    let choca = false;
+    for (const e of evitar) {
+      if ((x - e[0]) ** 2 + (z - e[1]) ** 2 < 5) {
+        choca = true;
+        break;
+      }
+    }
+    if (choca) continue;
+    pasto.push({
+      pos: [x, alturaPotrero(x, z), z],
+      rotY: rPas() * Math.PI * 2,
+      escala: 0.7 + rPas() * 0.8,
+      tint: [0.92 + rPas() * 0.16, 0.94 + rPas() * 0.14, 0.9 + rPas() * 0.14],
+    });
+  }
+
+  // Boñigas: donde pastan las vacas (el centro-izquierda del potrero) — la
+  // materia prima del ciclo del abono.
+  const boniga = [];
+  for (let i = 0; i < c.boniga; i++) {
+    const x = -9 + rBon() * 12;
+    const z = -8 + rBon() * 8;
+    boniga.push({
+      pos: [x, alturaPotrero(x, z) + 0.01, z],
+      rotY: rBon() * Math.PI * 2,
+      escala: 0.8 + rBon() * 0.6,
+      tint: [0.9 + rBon() * 0.14, 0.9 + rBon() * 0.12, 0.9 + rBon() * 0.12],
+    });
+  }
+
+  return { nacedero, matarraton, leucaena, botonDeOro, pasto, boniga };
+}
+
+/** Los centros de sombra del banco forrajero (para posar la luz colada). */
+export function centrosSombra(conteos) {
+  return [
+    ...SITIOS_NACEDERO.slice(0, conteos.nacedero),
+    ...SITIOS_MATARRATON.slice(0, conteos.matarraton),
+    ...SITIOS_LEUCAENA.slice(0, conteos.leucaena),
+  ].map(([x, z]) => /** @type {[number, number, number]} */ ([x, alturaPotrero(x, z), z]));
+}


### PR DESCRIPTION
## Qué es
Un **mundo 3D nuevo y autocontenido**: la **cadena láctea campesina** (lechería silvopastoril + quesos/derivados + ciclo del estiércol al abono) — la brecha que el operador marcó ("faltan leche, quesos y derivados"). Congruente con el kit (`AtmosferaMundo` familia `corral`, `DomoCielo` + bandas toon, `construirTerreno`, paleta madre, luz colada, `CamaraDirector`).

## Grounding (DR cadena láctea, solo lo confirmado por gemini Y glm)
- **Silvopastoril** — banco forrajero real: **nacedero** (*Trichanthera gigantea*, hoja grande, fija N), **matarratón** (*Gliricidia sepium*, flor rosada, poste vivo), **leucaena** (*Leucaena leucocephala*, el "árbol insignia" del SSP), **botón de oro** (*Tithonia diversifolia*, arbusto de flor amarilla, 16–28% proteína) + **cerca viva** de matarratón y bebedero.
- **Razas por piso** — Holstein/Normando (frío), criolla y **cruce con cebú** (giba + papada, cálido). Vacas con **ubre** (señal de lechería); idle de pastar.
- **Transformación en finca** — la **quesera**: cantinas, mesa con **cuajada** y **cincho**, **olla de cobre** del **arequipe**, estante de **kumis/yogur**; queso campesino/doble crema en el copy.
- **Ciclo** — **estiércol → biodigestor tubular** (biogás a la quesera + biol) + **montón de abono**; boñigas en el potrero.

*(glm inventó fuentes/DOIs — descartadas; me quedé con gemini + lo que ambos confirman.)*

## Archivos (todos NUEVOS)
- `src/visual/mundo3d/lecheria/floraLecheria.geom.js` — terreno del potrero + geom de las 4 especies forrajeras + pasto + boñiga + distribución.
- `src/visual/mundo3d/lecheria/FloraLecheria.jsx` — banco forrajero instanciado (una draw-call por especie) + luz colada.
- `src/visual/mundo3d/lecheria/GanadoLechero.jsx` — el hato (estiliza la silueta `vaca` de `CorralVivo`) con ubre y razas.
- `src/visual/mundo3d/lecheria/EscenaLecheriaViva.jsx` — la escena (quesera, biodigestor, abono, bebedero, cerca viva inline).
- `src/visual/mundo3d/lecheria/MundoLecheria.jsx` — wrapper con 4 pasos didácticos (usted, es-CO).
- `src/mockups/LecheriaViva3D.jsx` + `.css` — vitrina pública con ficha 2D de fallback (sin GPU).

## Cableado sugerido (NO tocado aquí — lo cablea el operador)
En `src/config/rutasProdChagraApp.js`, junto a cafetal/cacao/papa:
```js
{
  path: 'lecheria_viva',
  alias: ['lecheria', 'mundo_leche', 'lecheria-viva-3d', 'quesos', 'lacteos'],
  componente: 'LecheriaViva3D',
  importLazy: 'src/mockups/LecheriaViva3D.jsx',
  categoria: '3D',
},
```
Ruta: `#/mockups/lecheria-viva-3d`. (Para capturas por hora, agregar `['lecheria', '/mockups/lecheria-viva-3d']` a `scripts/diag/shot-pisos-termicos.mjs`.)

## Verificación
- `npm run build:prod` **verde** (el mundo va lazy en `vendor-three`; `dist-prod/` NO tocado en el commit).
- `eslint` limpio sobre los archivos nuevos.
- **Capturas** (chromium sistema + swiftshader, arnés diag temporal ya retirado): mañana / atardecer / medio-tier — canvas OK, sin `pageerror`.
- Tier-safe (alto/medio/bajo), reduced-motion, español de Colombia sin voseo, cero política/nombres reales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)