### PR TITLE
fix(rag): index short climate fields in flattenDoc

### DIFF
--- a/src/services/__tests__/ragRetriever.test.js
+++ b/src/services/__tests__/ragRetriever.test.js
@@ -139,6 +139,25 @@ describe('ragRetriever — corpus extendido v2', () => {
     });
   });
 
+  it('flattenDoc indexa campos cortos de clima y numericos con contexto', async () => {
+    const { flattenDoc } = await import('../ragRetriever.js');
+    const passages = flattenDoc({
+      species_slug: 'clima_test',
+      clima: 'frio',
+      ph: 5.8,
+      altitud_msnm: 1850,
+      temperatura: 18,
+      humedad: 82,
+      dosis: '2 ml',
+      distancia: '30 cm',
+    });
+
+    expect(passages.length).toBeGreaterThan(0);
+    expect(passages.some((p) => p.text.includes('clima'))).toBe(true);
+    expect(passages.some((p) => p.text.includes('5.8'))).toBe(true);
+    expect(passages.some((p) => p.text.includes('1850'))).toBe(true);
+  });
+
   it('retrieve("plan alimentación fresa") devuelve passage con "### Plan de alimentación"', async () => {
     const { retrieve } = await import('../ragRetriever.js');
     const hits = await retrieve('plan alimentación fresa bocashi humus', 5);

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -203,22 +203,55 @@ function resolveSpeciesSlug(doc, speciesSlug = null) {
   return '';
 }
 
+function normalizeKey(key) {
+  return String(key)
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+}
+
+function formatKeyLabel(key) {
+  return String(key)
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .trim();
+}
+
+function isContextualField(key, val) {
+  if (typeof val === 'number' && Number.isFinite(val)) return true;
+  const normalizedKey = normalizeKey(key);
+  return /(^|[^a-z0-9])(clima|ph|altitud|temperatura|dosis|humedad|distancia|msnm)([^a-z0-9]|$)/.test(normalizedKey);
+}
+
+function buildContextualText(key, val) {
+  const label = formatKeyLabel(key);
+  const value = typeof val === 'string' ? val.trim() : String(val);
+  return label ? `${label} ${value}` : value;
+}
+
 export function flattenDoc(doc, prefix = '', speciesSlug = null) {
   const slug = resolveSpeciesSlug(doc, speciesSlug);
   const passages = [];
+  const fieldLabel = (key) => formatKeyLabel(`${prefix}${key}`.replace(/\.$/, ''));
   const addPassage = (key, val) => {
-    if (typeof val === 'string' && val.length > 20) {
-      passages.push({ key: `${prefix}${key}`, text: val, species: slug });
+    const path = `${prefix}${key}`;
+    if (isContextualField(path, val) && (typeof val === 'string' || typeof val === 'number')) {
+      passages.push({ key: path, text: buildContextualText(fieldLabel(key), val), species: slug });
+    } else if (typeof val === 'string' && val.length > 20) {
+      passages.push({ key: path, text: val, species: slug });
     } else if (Array.isArray(val)) {
       val.forEach((item, i) => {
-        if (typeof item === 'string' && item.length > 20) {
-          passages.push({ key: `${prefix}${key}[${i}]`, text: item, species: slug });
+        const itemPath = `${path}[${i}]`;
+        if (isContextualField(itemPath, item) && (typeof item === 'string' || typeof item === 'number')) {
+          passages.push({ key: itemPath, text: buildContextualText(formatKeyLabel(itemPath), item), species: slug });
+        } else if (typeof item === 'string' && item.length > 20) {
+          passages.push({ key: itemPath, text: item, species: slug });
         } else if (typeof item === 'object' && item !== null) {
-          flattenDoc(item, `${prefix}${key}[${i}].`, slug).forEach((p) => passages.push(p));
+          flattenDoc(item, `${path}[${i}].`, slug).forEach((p) => passages.push(p));
         }
       });
     } else if (typeof val === 'object' && val !== null) {
-      flattenDoc(val, `${prefix}${key}.`, slug).forEach((p) => passages.push(p));
+      flattenDoc(val, `${path}.`, slug).forEach((p) => passages.push(p));
     }
   };
 


### PR DESCRIPTION
## Summary
- Fix flattenDoc so numeric and known context fields like clima, ph, altitud, temperatura, dosis, humedad, and distancia are indexed even when their values are short.
- Keep the long-string filter only for unqualified text fields.
- Add a regression test covering a climate-only document with short fields.

## Test plan
- npx vitest run src/services/__tests__/ragRetriever.test.js
- npx eslint src/services/ragRetriever.js src/services/__tests__/ragRetriever.test.js --max-warnings=0
- npm run build
- npx eslint . --max-warnings=0 was attempted, but Node ran out of heap in this environment.
