### PR TITLE
art(juegos): criaturas rubber-hose como protagonistas (hub + subsuelo)

### DIFF
--- a/scripts/diag/cap-juegos.mjs
+++ b/scripts/diag/cap-juegos.mjs
@@ -1,0 +1,167 @@
+// Capturas de los JUEGOS en el ProdChagraApp (dist-prod servido por vite preview).
+// Navega por hash (#juego, #defensores, …) + siembra datos en IDB para el estado
+// próspero del hub. Uso: node cap-juegos.mjs <baseURL> <outPrefix>
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+
+const BASE = process.argv[2] || 'http://127.0.0.1:4178';
+const PREFIX = process.argv[3] || 'antes';
+const OUT_DIR = '/tmp/caps';
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const CHROMIUM = process.env.CHROMIUM_PATH
+  || '/nix/store/r7ifk1v95jfl02775kgbrd61dyr1rfsx-chromium-148.0.7778.178/bin/chromium';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function seedData() {
+  const slugs = ['coffea_arabica', 'theobroma_cacao', 'musa_paradisiaca', 'persea_americana',
+    'phaseolus_vulgaris', 'zea_mays', 'inga_edulis', 'citrus_limon'];
+  const now = Date.now();
+  const processes = slugs.map((slug, i) => ({
+    process_id: `seed-p${i}`,
+    type: 'farm_process',
+    attributes: {
+      process_type: i % 2 === 0 ? 'sowing' : 'agroforestry',
+      subject_kind: 'aggregate', subject_slug: slug, subject_label: slug,
+      quantity: 10, unit: 'plantas', location_land_asset_id: 'land-1',
+      status: 'active', current_stage: ['vegetative', 'flowering', 'fruiting', 'mature'][i % 4],
+      created_at: now, updated_at: now, companions: i < 3 ? ['inga_edulis'] : [],
+    },
+  }));
+  const events = [];
+  processes.forEach((p, i) => {
+    events.push({ event_id: `seed-e-h-${i}`, type: 'farm_process_event',
+      attributes: { process_id: p.process_id, event_type: 'harvest_confirmed', occurred_at: now, payload: { quantity: 10 + i } } });
+    events.push({ event_id: `seed-e-p-${i}`, type: 'farm_process_event',
+      attributes: { process_id: p.process_id, event_type: 'pest_management_confirmed', occurred_at: now, payload: { method: 'biopreparado bio' } } });
+  });
+  return { processes, events };
+}
+
+async function stubAuth(page) {
+  await page.evaluate(() => new Promise((resolve, reject) => {
+    const put = (db) => {
+      const tx = db.transaction('syncQueue', 'readwrite');
+      const s = tx.objectStore('syncQueue');
+      s.put('stub-token-for-ui-screenshot', 'farmos_access_token');
+      s.put(Date.now() + 3600e3, 'farmos_token_expiry');
+      tx.oncomplete = () => { db.close(); resolve('ok'); };
+      tx.onerror = () => reject(tx.error);
+    };
+    const o = indexedDB.open('Chagra');
+    o.onupgradeneeded = () => { try { o.result.createObjectStore('syncQueue'); } catch { /* */ } };
+    o.onerror = () => reject(o.error);
+    o.onsuccess = () => {
+      const db = o.result;
+      if (db.objectStoreNames.contains('syncQueue')) return put(db);
+      const v = db.version + 1; db.close();
+      const up = indexedDB.open('Chagra', v);
+      up.onupgradeneeded = () => up.result.createObjectStore('syncQueue');
+      up.onsuccess = () => put(up.result);
+      up.onerror = () => reject(up.error);
+    };
+  }));
+}
+
+async function seedFarm(page, data) {
+  await page.evaluate(({ processes, events }) => new Promise((resolve, reject) => {
+    const o = indexedDB.open('ChagraDB');
+    o.onerror = () => reject(o.error);
+    o.onsuccess = () => {
+      const db = o.result;
+      if (!db.objectStoreNames.contains('farm_processes')) { db.close(); return resolve('no-store'); }
+      const tx = db.transaction(['farm_processes', 'farm_process_events'], 'readwrite');
+      const ps = tx.objectStore('farm_processes');
+      const es = tx.objectStore('farm_process_events');
+      processes.forEach((p) => ps.put(p));
+      events.forEach((e) => es.put(e));
+      tx.oncomplete = () => { db.close(); resolve('ok'); };
+      tx.onerror = () => { db.close(); reject(tx.error); };
+    };
+  }), data);
+}
+
+async function nav(page, view) {
+  await page.evaluate((v) => { window.location.hash = '#' + v; }, view);
+  await sleep(300);
+  await page.evaluate((v) => window.dispatchEvent(new CustomEvent('chagra:nav', { detail: v })), view);
+}
+
+(async () => {
+  const browser = await chromium.launch({
+    executablePath: CHROMIUM, headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-gl=swiftshader',
+      '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'],
+  });
+  const ctx = await browser.newContext({ viewport: { width: 412, height: 915 }, locale: 'es-CO', deviceScaleFactor: 2, isMobile: true });
+  await ctx.route('**/*', (route) => {
+    const u = route.request().url().replace(BASE, '');
+    if (/\/(jsonapi|api|sites|oauth|fincas)(\/|$|\?)/.test(u)) {
+      const isJsonApi = /jsonapi/.test(u);
+      return route.fulfill({ status: 200, contentType: isJsonApi ? 'application/vnd.api+json' : 'application/json',
+        body: JSON.stringify(isJsonApi ? { data: [], meta: {}, links: {} } : {}) });
+    }
+    return route.continue();
+  });
+  const page = await ctx.newPage();
+  page.setDefaultTimeout(60000);
+  const errs = [];
+  page.on('pageerror', (e) => errs.push(`[pageerror] ${e.message}`));
+  page.on('console', (m) => { if (m.type() === 'error') errs.push(`[console] ${m.text().slice(0, 200)}`); });
+
+  const shot = async (name) => {
+    const p = `${OUT_DIR}/${PREFIX}-${name}.png`;
+    await page.screenshot({ path: p, fullPage: true });
+    console.log(`  saved ${p}`);
+  };
+
+  try {
+    await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded', timeout: 40000 });
+    await stubAuth(page);
+    await seedFarm(page, seedData());
+    await page.evaluate(() => { try { localStorage.setItem('chagra:juego-finca:default', JSON.stringify({ lastLevel: 4, misionesHechas: [] })); } catch { /* */ } });
+    await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded', timeout: 40000 });
+    await sleep(1500);
+
+    // HUB próspero (mi-finca-viva) — el objetivo principal
+    console.log('[hub] mi finca viva (próspera)');
+    await nav(page, 'juego');
+    try { await page.waitForSelector('[data-testid="mi-finca-viva-screen"]', { timeout: 30000 }); } catch { console.log('  (hub no montó)'); }
+    await sleep(1800);
+    await shot('hub-prospera');
+
+    // Colección de criaturas — scroll hasta ella para primer plano
+    try {
+      await page.evaluate(() => document.querySelector('[data-testid="criatura-collection"]')?.scrollIntoView({ block: 'center' }));
+      await sleep(700);
+      const col = await page.$('[data-testid="criatura-collection"]');
+      if (col) { await col.screenshot({ path: `${OUT_DIR}/${PREFIX}-coleccion.png` }); console.log('  saved coleccion'); }
+      const scene = await page.$('[data-testid="finca-world-scene"]');
+      if (scene) { await scene.screenshot({ path: `${OUT_DIR}/${PREFIX}-mundo.png` }); console.log('  saved mundo'); }
+    } catch (e) { console.log('  colección/mundo shot fail:', e.message); }
+
+    // Otros juegos (vista de entrada)
+    for (const [view, sel, name] of [
+      ['defensores', '[data-testid="defensores-finca-screen"]', 'defensores'],
+      ['milpa', '[data-testid="milpa-simulator"]', 'milpa'],
+      ['subsuelo', '[data-testid="mundo-subsuelo"]', 'subsuelo'],
+    ]) {
+      try {
+        console.log(`[juego] ${name}`);
+        await nav(page, view);
+        try { await page.waitForSelector(sel, { timeout: 8000 }); } catch { /* captura igual */ }
+        await sleep(1400);
+        await shot(name);
+      } catch (e) { console.log(`  ${name} fail:`, e.message); }
+    }
+
+    console.log('\n=== page errors ===');
+    console.log(errs.length ? [...new Set(errs)].slice(0, 15).join('\n') : '(ninguno)');
+  } catch (e) {
+    console.error('FALLO:', e.message);
+    try { await shot('ERROR'); } catch { /* */ }
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+})();

--- a/src/components/juego/CriaturaCollection.jsx
+++ b/src/components/juego/CriaturaCollection.jsx
@@ -1,4 +1,5 @@
 import { Volume2 } from 'lucide-react';
+import { CriaturaFinca } from './CriaturaFinca.jsx';
 
 /**
  * CriaturaCollection — la galería de criaturas coleccionables.
@@ -56,11 +57,14 @@ export default function CriaturaCollection({ criaturas = [], vivas = 0, total = 
                 : `${c.nombre}: bloqueada. Pista: ${c.pista}`
             }
           >
-            <span
-              className={c.desbloqueada ? 'text-4xl' : 'text-4xl grayscale opacity-30'}
-              aria-hidden="true"
-            >
-              {c.desbloqueada ? c.emoji : '❔'}
+            <span className="flex items-center justify-center h-[52px]" aria-hidden="true">
+              <CriaturaFinca
+                id={c.id}
+                emoji={c.emoji}
+                nombre={c.nombre}
+                size={52}
+                fantasma={!c.desbloqueada}
+              />
             </span>
             <span
               className={[

--- a/src/components/juego/CriaturaFinca.jsx
+++ b/src/components/juego/CriaturaFinca.jsx
@@ -1,0 +1,89 @@
+import {
+  AbejaAngelita, Colibri, RanaAndina, Lombriz, Mariposa,
+} from '../../visual/creatures/index.js';
+
+/**
+ * CriaturaFinca — hace que las criaturas del juego "Mi Finca Viva" sean sus
+ * PERSONAJES rubber-hose de verdad, no emojis de adorno (spec belleza-juegos,
+ * regla de oro #1: los actores animados como protagonistas).
+ *
+ * Mapea la criatura del JUEGO (fincaGameService CREATURES, referida por `id`)
+ * a su personaje rubber-hose de la casa (src/visual/creatures). Solo mapeos
+ * FIELES — una lombriz ES la Lombriz, una abeja ES Angelita. Las que aún no
+ * tienen un SVG fiel de la casa (mariquita, quetzal) caen a su emoji: honestidad
+ * visual, jamás un bicho disfrazado de otro (verify-before-claim, también en arte).
+ *
+ * Cero three, cero geometría nueva: reusa los SVG ya aprobados (memoria
+ * feedback-svg-rubberhose-en-mundos-3d). Cada personaje trae por dentro su
+ * vida idle (aleteo, parpadeo, line-boil) cuando `animated`.
+ */
+export const CRIATURA_JUEGO_SVG = Object.freeze({
+  lombriz: Lombriz,
+  mariposa: Mariposa,
+  abeja: AbejaAngelita,
+  rana: RanaAndina,
+  colibri: Colibri,
+});
+
+/** ¿La criatura del juego tiene un personaje rubber-hose fiel? */
+export function criaturaTieneSvg(id) {
+  return Boolean(CRIATURA_JUEGO_SVG[id]);
+}
+
+/**
+ * Dibuja UNA criatura del juego como su personaje rubber-hose (protagonista),
+ * con respaldo a emoji para las que aún no tienen SVG fiel.
+ *
+ * @param {Object} props
+ * @param {string} props.id        id de la criatura del juego (lombriz, abeja, …)
+ * @param {string} [props.emoji]   emoji de respaldo (para las sin SVG fiel)
+ * @param {string} [props.nombre]  nombre accesible
+ * @param {number} [props.size]    px del personaje
+ * @param {boolean} [props.fantasma]  silueta "aún no desbloqueada" (gris, tenue)
+ * @param {boolean} [props.animated]  vida idle (default true; off si fantasma)
+ * @param {string} [props.className]
+ */
+export function CriaturaFinca({
+  id,
+  emoji,
+  nombre,
+  size = 44,
+  fantasma = false,
+  animated = true,
+  className = '',
+}) {
+  const Comp = CRIATURA_JUEGO_SVG[id];
+  const estiloFantasma = fantasma
+    ? { filter: 'grayscale(1) brightness(0.62) contrast(0.9)', opacity: 0.34 }
+    : undefined;
+
+  if (!Comp) {
+    // Sin personaje fiel → emoji (honesto). Bloqueada = interrogante tenue.
+    return (
+      <span
+        aria-hidden="true"
+        className={className}
+        style={{
+          fontSize: `${Math.round(size * 0.82)}px`,
+          lineHeight: 1,
+          display: 'inline-flex',
+          ...(fantasma ? { filter: 'grayscale(1)', opacity: 0.3 } : null),
+        }}
+      >
+        {fantasma ? '❔' : emoji}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className={className}
+      style={{ display: 'inline-flex', lineHeight: 0, ...estiloFantasma }}
+    >
+      <Comp size={size} animated={animated && !fantasma} title={nombre || id} />
+    </span>
+  );
+}
+
+export default CriaturaFinca;

--- a/src/components/juego/FincaWorldScene.jsx
+++ b/src/components/juego/FincaWorldScene.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { fvhSkinClass } from '../../config/fvhSkin';
+import { CriaturaFinca, criaturaTieneSvg } from './CriaturaFinca.jsx';
 
 /**
  * FincaWorldScene — el MUNDO ilustrado de "Mi Finca Viva".
@@ -289,12 +290,31 @@ export default function FincaWorldScene({
         )}
       </svg>
 
-      {/* Criaturas vivas — emojis flotando sobre el mundo (modo juego) */}
+      {/* Criaturas vivas — sus PERSONAJES rubber-hose viviendo sobre el mundo
+          (spec belleza-juegos: actores como protagonistas, no emojis de adorno).
+          Cada bicho reconocido es su SVG de la casa con su vida idle; los que aún
+          no tienen SVG fiel (mariquita, quetzal) caen a su emoji, honesto. La
+          altura respeta su hábitat: voladores arriba (cielo), suelo abajo. */}
       {!modoRico && !vacia && criaturasVivas.length > 0 && (
         <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
           {criaturasVivas.map((c, i) => {
-            const left = 12 + ((i * 31) % 70);
-            const top = 12 + ((i * 19) % 42);
+            const svg = criaturaTieneSvg(c.id);
+            const n = criaturasVivas.length;
+            // Reparto horizontal parejo, legible (composición estilo Age of
+            // Empires: actores separados, nada amontonado) evitando la esquina
+            // del sol (arriba-derecha). Franja 8%–70% del ancho.
+            const left = n <= 1 ? 40 : Math.round(8 + (i * 62) / (n - 1));
+            // Banda de hábitat: voladores (colibrí/mariposa/abeja) alto en el
+            // cielo; suelo (lombriz) abajo; resto al medio. Jitter determinista
+            // por índice para que no queden en fila rígida.
+            const volador = c.id === 'colibri' || c.id === 'mariposa' || c.id === 'abeja';
+            const suelo = c.id === 'lombriz';
+            const jitter = (i % 2 === 0 ? 0 : 6);
+            const top = suelo
+              ? 62 + jitter
+              : volador
+                ? 10 + ((i * 5) % 14) + jitter
+                : 38 + jitter;
             return (
               <span
                 key={c.id}
@@ -302,11 +322,16 @@ export default function FincaWorldScene({
                 style={{
                   left: `${left}%`,
                   top: `${top}%`,
-                  fontSize: '1.7rem',
+                  fontSize: svg ? undefined : '1.7rem',
+                  filter: 'drop-shadow(0 3px 4px rgba(20,30,22,0.28))',
                   animationDelay: `${i * 0.5}s`,
                 }}
               >
-                {c.emoji}
+                {svg ? (
+                  <CriaturaFinca id={c.id} emoji={c.emoji} nombre={c.nombre} size={46} />
+                ) : (
+                  c.emoji
+                )}
               </span>
             );
           })}

--- a/src/components/juego/MundoSubsuelo.jsx
+++ b/src/components/juego/MundoSubsuelo.jsx
@@ -4,6 +4,7 @@ import { recordGameStart, recordGameComplete } from '../../services/usageTelemet
 import { fvhSkinClass } from '../../config/fvhSkin';
 import { fincaVivaHomePerfilActivo } from '../../config/fincaVivaHomeFlag';
 import { evaluarSubsuelo, mensajeMeta } from '../../services/mundoSubsueloEngine';
+import { Lombriz } from '../../visual/creatures/index.js';
 import './mundo-subsuelo.css';
 
 function clamp(value, min = 0, max = 100) {
@@ -36,25 +37,21 @@ function Mascot({ name, title, children, active }) {
           aria-hidden="true"
           className={`msx-avatar grid h-12 w-12 shrink-0 place-items-center rounded-2xl ${name === 'Miquito' ? 'bg-cyan-200' : 'bg-amber-200'}`}
         >
-          <svg viewBox="0 0 48 48" className="h-10 w-10" role="img" aria-label={name}>
-            {name === 'Miquito' ? (
-              <>
-                <path d="M12 23c1-9 7-15 15-15s13 6 14 15H12Z" fill="#38bdf8" />
-                <path d="M18 23h17l-3 15H21l-3-15Z" fill="#f8fafc" />
-                <circle cx="22" cy="18" r="2.5" fill="#f0fdfa" />
-                <circle cx="31" cy="17" r="2" fill="#f0fdfa" />
-                <path d="M22 31c3 2 6 2 9 0" stroke="#164e63" strokeWidth="2" fill="none" strokeLinecap="round" />
-              </>
-            ) : (
-              <>
-                <path d="M9 28c8-12 23-13 31-2 2 3 0 8-5 9-9 2-20 1-26-7Z" fill="#d97706" />
-                <circle cx="25" cy="23" r="9" fill="#fbbf24" />
-                <circle cx="22" cy="22" r="1.7" fill="#422006" />
-                <circle cx="29" cy="22" r="1.7" fill="#422006" />
-                <path d="M22 27c3 2 6 2 8 0" stroke="#422006" strokeWidth="2" fill="none" strokeLinecap="round" />
-              </>
-            )}
-          </svg>
+          {name === 'Miquito' ? (
+            <svg viewBox="0 0 48 48" className="h-10 w-10" role="img" aria-label={name}>
+              <path d="M12 23c1-9 7-15 15-15s13 6 14 15H12Z" fill="#38bdf8" />
+              <path d="M18 23h17l-3 15H21l-3-15Z" fill="#f8fafc" />
+              <circle cx="22" cy="18" r="2.5" fill="#f0fdfa" />
+              <circle cx="31" cy="17" r="2" fill="#f0fdfa" />
+              <path d="M22 31c3 2 6 2 9 0" stroke="#164e63" strokeWidth="2" fill="none" strokeLinecap="round" />
+            </svg>
+          ) : (
+            /* Lombricita = la Lombriz rubber-hose de la casa, no una carita
+               genérica (spec belleza-juegos: la guía-protagonista de verdad).
+               El contenedor ya es aria-hidden; el título del SVG es descriptivo
+               y distinto del nombre (para no duplicar el texto "Lombricita"). */
+            <Lombriz size={40} title="Lombriz de tierra" animated={active} />
+          )}
         </div>
         <div>
           <h3 className="text-base font-black text-stone-950">{name}</h3>
@@ -221,21 +218,19 @@ function SoilScene({ soilLife, activeDecision }) {
           />
         ))}
 
-        {/* Lombrices meneándose, con carita para la niña que juega. */}
+        {/* Lombrices = la Lombriz rubber-hose de la casa, meneándose en su
+            galería (spec belleza-juegos: la protagonista viva de la red del
+            suelo, no un trazo con puntico). Inline dentro del corte, escalada y
+            un poco rotada para acostarse en su galería del suelo. */}
         {Array.from({ length: wormCount }).map((_, index) => {
           const wx = 112 + index * 178;
           const wy = 345 - (index % 2) * 34;
+          const rot = index % 2 === 0 ? 26 : -14;
           return (
             <g key={`worm-${index}`} className="msx-lombriz" style={{ animationDelay: `${index * 0.6}s` }}>
-              <path
-                d={`M${wx} ${wy}c20-18 45 16 68-4`}
-                stroke="#f59e0b"
-                strokeWidth="10"
-                fill="none"
-                strokeLinecap="round"
-              />
-              <circle cx={wx + 68} cy={wy - 4} r="6.5" fill="#d97706" />
-              <circle cx={wx + 70} cy={wy - 6} r="1.5" fill="#451a03" />
+              <g transform={`translate(${wx + 26} ${wy - 30}) scale(1.75) rotate(${rot})`}>
+                <Lombriz inline animated title="Lombriz" />
+              </g>
             </g>
           );
         })}


### PR DESCRIPTION
## Pase de belleza de los juegos cableados — actores animados como protagonistas

Primer pase (con dos pasadas en el hub) del spec *belleza-juegos-maximo-esfuerzo*: los
personajes rubber-hose de la casa (`src/visual/creatures`) pasan de ser emojis de adorno a
**protagonistas** de los juegos. Solo VISUAL — no toca mecánica ni datos.

### Qué cambió
- **`CriaturaFinca`** (nuevo): mapea la criatura del juego (`fincaGameService`) a su personaje
  rubber-hose fiel — `lombriz→Lombriz`, `mariposa→Mariposa`, `abeja→Angelita`, `rana→RanaAndina`,
  `colibri→Colibri`. Las que aún no tienen un SVG fiel (`mariquita`, `quetzal`) caen a su emoji:
  honestidad visual, jamás un bicho disfrazado de otro. Cero `three`, reusa los SVG aprobados
  (billboards, sin geometría nueva — memoria `feedback-svg-rubberhose-en-mundos-3d`).
- **Mi Finca Viva (hub)** — *pasada 1 y 2*:
  - La galería `CriaturaCollection` muestra los personajes rubber-hose con su vida idle
    (bloqueadas = silueta tenue).
  - El mundo `FincaWorldScene` los reparte por **hábitat** (voladores en el cielo, lombriz en el
    suelo) y **espaciados**, despejando la esquina del sol para una composición legible.
- **Mundo Subsuelo** — la **Lombricita** (guía) es la Lombriz real, y las lombrices de la galería
  del suelo son la Lombriz rubber-hose meneándose: la protagonista viva de la red micorrízica.
- `scripts/diag/cap-juegos.mjs`: harness de captura de los juegos sobre el `ProdChagraApp`.

### Alcance / decisiones
- **Defensores** y **Milpa** se dejaron como están en cuanto a fauna: sus actores (Crisopa,
  Avispita Trichogramma, sírfido / cultivos) no tienen un SVG fiel en el roster — forzar un
  personaje ajeno sería deshonesto. Candidatos a un pase posterior propio.
- No se cablea `dist-prod` en este PR (artefacto de build; lo regenera el pipeline).

### Verificación
- `npm run build:prod` **verde** (el gate; el hub ya está ruteado en `rutasProdChagraApp`).
- 145 tests de `src/components/juego/` en verde (incluye `MundoSubsuelo`, `MiFincaVivaScreen`,
  `FincaWorldScene`).
- Capturas reales antes/después (chromium headless + swiftshader sobre `vite preview` de
  `dist-prod`): galería, mundo del hub y subsuelo.

> Nota: la app clásica (`vite build` de `index.html`/`App.jsx`) rebota en dev/build regular por
> un quirk de oxc con el comentario `// ...(<1200 msnm)...` en `App.jsx` (preexistente, va en
> `main`). `build:prod` (rolldown, entry `index-prod`) lo compila sin problema — ese es el
> objetivo a prod.