### PR TITLE
fix(valle): reconstruir sobre la base v2 cercana — ventanas vivas, Ent del páramo, oso negro, cóndor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2229,6 +2229,9 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Criaturas nocturnas">
               <CriaturasNocturnasMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
       case 'mockup_angelita_viva':
         // Angelita al máximo (#/mockups/angelita-viva): la entrada teatral
         // (asoma pequeñita → gafas si hace sol → crece con overshoot) y el

--- a/src/components/dashboard/GuardianEspiritu.jsx
+++ b/src/components/dashboard/GuardianEspiritu.jsx
@@ -211,8 +211,10 @@ const AVATAR = {
   danta: AvatarDanta,
 };
 
-/** Un avatar aislado dibujado en su propio SVG (para chips y héroe). */
-function GuardianAvatar({ id, size = 46 }) {
+/** Un avatar aislado dibujado en su propio SVG (para chips y héroe).
+    Exportado: el valle 3D monta el oso negro biopunk como vecino del monte
+    (decisión del operador — este es EL oso, no el rubber-hose café). */
+export function GuardianAvatar({ id, size = 46 }) {
   const Cuerpo = AVATAR[id] || AvatarAbeja;
   return (
     <svg viewBox="-26 -24 52 46" width={size} height={size} aria-hidden="true" focusable="false">

--- a/src/mockups/valle/Valle2DFallback.jsx
+++ b/src/mockups/valle/Valle2DFallback.jsx
@@ -12,11 +12,12 @@ import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS } from './valleDa
 import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
 
 /* Proyección isométrica plana de las coordenadas del valle a la lámina SVG.
-   (Escala al día con el VALLE GRANDE: los lugares viven en x ∈ [-8.6, 8.6],
-   z ∈ [-9.4, 9.6] — la lámina 400×340 los abraza todos con aire.) */
+   (Escala ajustada para que TODA la finca quepa en la lámina 400×340: con el
+   potrero y la biofábrica el rango (x−z) llega a ±11.5 — a 30 px/u el corral
+   caía fuera del cuadro.) */
 function iso(x, z) {
-  const cx = 200 + (x - z) * 10.5;
-  const cy = 155 + (x + z) * 7.5;
+  const cx = 222 + (x - z) * 16;
+  const cy = 148 + (x + z) * 8;
   return { cx, cy };
 }
 

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -60,11 +60,20 @@ import {
 } from '../../visual/mundo3d/direccion/composicionValle.js';
 import {
   CasaCampesina,
-  PorticosPortales,
+  VentanasVivas,
+  PorticosSecundarios,
+  VistaParamoEnt,
   SenderosValle,
   PatiosLugares,
   VecinosDelValle,
+  OsoNegroDelMonte,
 } from './composicionValle3D.jsx';
+/* El cóndor de los Andes planeando su térmica sobre el páramo: el vecino de
+   AIRE del valle (billboard SVG, un solo <Html>, matemática O(1)/frame). */
+import CondorBillboard from '../../visual/mundo3d/CondorBillboard.jsx';
+/* La silueta biopunk del cóndor (pase de criaturas): la usa el rato en que
+   se POSA en el pico de la cordillera — el vigía alterna vuelo y percha. */
+import { CriaturaNocturnaAvatar } from '../../components/dashboard/CriaturasNocturnas.jsx';
 /* El ANCLAJE: la sombra de contacto bajo cada landmark (casa, lugares,
    árboles, matas, vecinos) — sin ella los objetos flotan sobre la loma.
    2 draw calls instanciados, textura radial pre-horneada, cero costo/frame. */
@@ -89,12 +98,11 @@ const MUNDO_DIR_BY_ID = Object.fromEntries(MUNDOS_DIR.map((m) => [m.id, m]));
    caliente. Así el gradiente de pisos térmicos se LEE como pendiente. La subida
    usa smoothstep (curva suave, sin quiebres) + una ondulación menuda para que
    las lomas se vean redondas, no planas. Determinista → los landmarks se posan
-   encima. (Rediseño 2026-07: el valle creció a 48×48 — la subida es más larga
-   y un pelo más alta, la ondulación más ancha: lomas de valle grande.) */
+   encima. */
 function alturaTerreno(x, z) {
-  const subida = THREE.MathUtils.smoothstep(-z, -11, 16) * 6.2;
-  const ondul = Math.sin(x * 0.3) * 0.16 + Math.cos(z * 0.27 + x * 0.15) * 0.13;
-  const cauce = -0.36 * Math.exp(-((x - 1.9) ** 2) / 8) * Math.exp(-((z + 1.5) ** 2) / 110);
+  const subida = THREE.MathUtils.smoothstep(-z, -8, 11) * 5.4;
+  const ondul = Math.sin(x * 0.42) * 0.14 + Math.cos(z * 0.36 + x * 0.2) * 0.12;
+  const cauce = -0.32 * Math.exp(-((x - 1.2) ** 2) / 6) * Math.exp(-((z + 1) ** 2) / 55);
   return subida + ondul + cauce;
 }
 
@@ -142,7 +150,7 @@ function colorSueloEnZ(z, alto, nocturno, out) {
 function Terreno({ nocturno, innerRef, perfil }) {
   const seg = perfil.segmentosTerreno;
   const geo = useMemo(() => {
-    const g = new THREE.PlaneGeometry(48, 48, seg, seg);
+    const g = new THREE.PlaneGeometry(34, 34, seg, seg);
     g.rotateX(-Math.PI / 2);
     const pos = g.attributes.position;
     const colores = new Float32Array(pos.count * 3);
@@ -152,7 +160,7 @@ function Terreno({ nocturno, innerRef, perfil }) {
       const z = pos.getZ(i);
       const y = alturaTerreno(x, z);
       pos.setY(i, y);
-      const subida = THREE.MathUtils.smoothstep(-z, -11, 16) * 6.2;
+      const subida = THREE.MathUtils.smoothstep(-z, -8, 11) * 5.4;
       const alto = THREE.MathUtils.clamp((y - subida + 0.3) / 0.6, 0, 1);
       colorSueloEnZ(z, alto, nocturno, col);
       colores[i * 3] = col.r;
@@ -180,12 +188,10 @@ function Terreno({ nocturno, innerRef, perfil }) {
       alta (perspectiva aérea). Su base se posa sobre el terreno del páramo
       (que ya subió a ~5) y las cumbres coronan la escena. ── */
 const PICOS_CORDILLERA = [
-  // (Empujados al fondo del valle grande: z ≤ -21, sobre el páramo que ya
-  //  subió a ~6. Más anchos y altos para coronar el cuadro nuevo.)
-  { x: -13, z: -22, h: 8.5, r: 6.5, base: 5.0 },
-  { x: -3, z: -24, h: 11.5, r: 7.5, base: 5.4 },
-  { x: 8, z: -23, h: 9.5, r: 6.5, base: 5.0 },
-  { x: 17, z: -21, h: 7, r: 5.5, base: 4.8 },
+  { x: -9, z: -15.5, h: 7, r: 5, base: 4.2 },
+  { x: -2, z: -17, h: 9.5, r: 6, base: 4.6 },
+  { x: 6, z: -16, h: 8, r: 5.2, base: 4.2 },
+  { x: 12, z: -15, h: 6, r: 4.5, base: 4.0 },
 ];
 
 function Cordillera({ color, innerRef, perfil }) {
@@ -233,16 +239,16 @@ function Quebrada({ color, viva, perfil, nocturno = false }) {
     // Nace arriba (páramo) y BAJA por la ladera hasta la tierra caliente:
     // cada punto se posa sobre el terreno (+un pelo) para leer la pendiente.
     const pts = [
-      [-4.6, -11],
-      [-2.2, -6.4],
-      [0.6, -2.4],
-      [2.2, 1.6],
-      [3.4, 6.4],
-      [4.6, 11.5],
+      [-3.4, -7.2],
+      [-1.2, -4.2],
+      [0.8, -1.4],
+      [1.6, 1.8],
+      [2.6, 5.4],
+      [3.6, 8],
     ].map(([x, z]) => new THREE.Vector3(x, alturaTerreno(x, z) + 0.06, z));
     const curve = new THREE.CatmullRomCurve3(pts);
     // Frugal: menos anillos/segmentos — la cinta se lee igual desde lejos.
-    const g = new THREE.TubeGeometry(curve, rico ? 88 : 52, 0.4, rico ? 7 : 5, false);
+    const g = new THREE.TubeGeometry(curve, rico ? 80 : 48, 0.34, rico ? 7 : 5, false);
     return g;
   }, [rico]);
   return (
@@ -612,8 +618,8 @@ function LandmarkGeom({ tipo, tinte, reducedMotion, q = 1 }) {
           {/* el cajón de madera en U que contiene la pila */}
           {[
             { p: [0, 0.16, -0.5], s: [1.15, 0.32, 0.08] },
-            { p: [-0.56, 0.16, -0.05], s: [0.08, 0.32, 0.95], r: 0 },
-            { p: [0.56, 0.16, -0.05], s: [0.08, 0.32, 0.95], r: 0 },
+            { p: [-0.56, 0.16, -0.05], s: [0.08, 0.32, 0.95] },
+            { p: [0.56, 0.16, -0.05], s: [0.08, 0.32, 0.95] },
           ].map((w, i) => (
             <mesh key={i} position={/** @type {any} */ (w.p)} castShadow>
               <boxGeometry args={/** @type {any} */ (w.s)} />
@@ -955,14 +961,13 @@ function Veleta({ color, reducedMotion = false }) {
       eras. Pocas y bien puestas: el valle se siente vivo, no amontonado. Son
       decorativas (aria-hidden) y no capturan toques. ── */
 const CRIATURAS_VALLE = [
-  // (posiciones al día con el VALLE GRANDE: las mariposas sobre la milpa,
-  //  el colibrí en la huerta de la casa, el escarabajo en la hojarasca del
-  //  monte, la lombriz asomada en las eras — cada bicho en su nicho.)
-  { crt: 'mariposa', x: -7.6, z: -0.4, dy: 2.2, size: 30, factor: 8 },
-  { crt: 'mariposa', x: -9.2, z: 1.8, dy: 1.7, size: 24, factor: 8 },
-  { crt: 'colibri', x: 2.3, z: 4.6, dy: 1.9, size: 34, factor: 8 },
-  { crt: 'escarabajo', x: 6.4, z: -3.6, dy: 0.5, size: 28, factor: 7 },
-  { crt: 'lombriz', x: -3.0, z: 6.2, dy: 0.28, size: 26, factor: 6.5 },
+  // (posiciones al día con la DISPOSICIÓN COMPUESTA: la milpa cedió a la
+  //  izquierda y la huerta se arrimó a la casa — sus bichos las siguen.)
+  { crt: 'mariposa', x: -4.8, z: 1.9, dy: 2.0, size: 30, factor: 8 },
+  { crt: 'mariposa', x: -5.6, z: 2.8, dy: 1.5, size: 24, factor: 8 },
+  { crt: 'colibri', x: 3.1, z: 3.9, dy: 1.9, size: 34, factor: 8 },
+  { crt: 'escarabajo', x: 4.7, z: -2.9, dy: 0.5, size: 28, factor: 7 },
+  { crt: 'lombriz', x: -1.2, z: 5.4, dy: 0.28, size: 26, factor: 6.5 },
 ];
 
 function CriaturaSvg({ tipo, size, animated }) {
@@ -994,10 +999,48 @@ function CriaturasValle({ reducedMotion, cupo }) {
   );
 }
 
+/* ── EL CÓNDOR DEL VALLE: planea Y se posa (alterna) ─────────────────────
+      El vigía del páramo vive dos ratos: la TÉRMICA (CondorBillboard en
+      órbita paciente sobre el filo) y la PERCHA (posado en el pico de la
+      cordillera, quieto — la silueta biopunk del pase de criaturas). El
+      cambio es lento (~45 s volando, ~16 s posado): verlo aterrizar es un
+      premio, no un tic. reduced-motion: queda volando fijo, digno. ── */
+const PERCHA_CONDOR = /** @type {[number, number, number]} */ ([-9, 11.6, -15.5]);
+
+function CondorDelValle({ reducedMotion, tier }) {
+  const [posado, setPosado] = useState(false);
+  useEffect(() => {
+    if (reducedMotion) return undefined;
+    const t = setTimeout(() => setPosado((p) => !p), posado ? 16000 : 45000);
+    return () => clearTimeout(t);
+  }, [posado, reducedMotion]);
+  if (posado) {
+    return (
+      <group position={PERCHA_CONDOR}>
+        <Html center distanceFactor={16} zIndexRange={[6, 0]} pointerEvents="none">
+          <div className="valle-critter" data-vecino="condor-posado" aria-hidden="true">
+            <CriaturaNocturnaAvatar id="condor" size={48} />
+          </div>
+        </Html>
+      </group>
+    );
+  }
+  return (
+    <CondorBillboard
+      centro={[-2, 10.5, -7]}
+      radio={9}
+      px={58}
+      factor={13}
+      animated={!reducedMotion}
+      tier={tier}
+    />
+  );
+}
+
 /* ── Proxy LOD de un landmark (perfil frugal): a distancia, el lugar es una
       silueta de UNA malla con su tinte — el rótulo con emoji ya lo nombra.
       Los tipos que suben (milpa, bosque, veleta) son cono; el resto, domo. ── */
-const PROXY_CONO = new Set(['milpa', 'bosque', 'veleta']);
+const PROXY_CONO = new Set(['milpa', 'bosque', 'veleta', 'saber']);
 
 function ProxyLandmark({ tipo, tinte }) {
   const cono = PROXY_CONO.has(tipo);
@@ -1274,18 +1317,17 @@ function Beacon({ onAlerta, reducedMotion, conLuz = true }) {
 }
 
 /* ── El COMPAÑERO-JUGADOR: Angelita, la abeja — UNA SOLA, la del valle.
-      Rediseño 2026-07 (§6): POSICIÓN DE CALMA — al reposo ya no husmea
-      errática por el valle: flota serena sobre el corredor de la casa (el
-      corazón del cuadro), con un vaivén mínimo de respiración. Es MÁS
-      GRANDE (se veía diminuta) y BRILLA con su luz propia: invita a tocarla
-      — tocarla es hablarle a la finca (`onTocar`). Cuando se toca un mundo
+      POSICIÓN DE CALMA (feedback del operador): al reposo ya no husmea
+      errática por el valle — flota SERENA sobre el patio de la casa (el
+      corazón del cuadro), con un vaivén mínimo de respiración, y BRILLA:
+      tocarla es hablarle a la finca (`onTocar`). Cuando se toca un mundo
       (`entrando`), vuela y se acerca al lugar, y la cámara la acompaña. Su
       ánimo/energía (salud real de la finca) tiñen su color y su vuelo. ── */
 const CALMA_ABEJA = {
   // Al frente-derecha del corredor, sobre el patio de la casa (no encima del
   // techo): Angelita ES la anfitriona de la casa-puerta.
-  x: CASA_VALLE.pos[0] + 1.9,
-  z: CASA_VALLE.pos[1] + 2.1,
+  x: CASA_VALLE.pos[0] + 1.3,
+  z: CASA_VALLE.pos[1] + 1.5,
 };
 
 function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false, posRef = null, conLuz = false, onTocar = null }) {
@@ -1314,13 +1356,13 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
     const brio = (0.35 + 0.65 * energiaReal) * mVel; // energía y clima animan el vuelo
     const bob = reducedMotion ? 0 : Math.sin(t * (1.6 + brio)) * (0.1 + 0.16 * brio);
     const tembleque = tiembla ? Math.sin(t * 13) * tiembla : 0;
-    // POSICIÓN DE CALMA (§6): al reposo Angelita ya no ronda el valle en un
-    // círculo errático — flota SERENA sobre el corredor de la casa con una
+    // POSICIÓN DE CALMA: al reposo Angelita ya no ronda el valle en un
+    // círculo errático — flota serena sobre el patio de la casa con una
     // deriva mínima y lenta (respiración, no husmeo). Al entrar a un mundo
     // sí vuela y se posa junto al lugar.
-    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.28) * 0.28 * mVagar;
-    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.22) * 0.2 * mVagar;
-    const alto = (entrando ? 1.05 : 2.5) * mAltura;
+    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.28) * 0.26 * mVagar;
+    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.22) * 0.18 * mVagar;
+    const alto = (entrando ? 1.05 : 2.2) * mAltura;
     const dest = entrando
       ? new THREE.Vector3(
           foco.x + 0.55 + tembleque,
@@ -1344,13 +1386,12 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
       prevX.current = ref.current.position.x;
     }
   });
-  // MÁS GRANDE (§6): el px base sube de 44 a la banda de JERARQUIA (58-76) —
-  // en el valle grande la guía se veía diminuta.
+  // Más grande que antes: la anfitriona de la casa-puerta se veía tímida.
   const [pxMin, pxMax] = JERARQUIA_PERSONAJES.protagonistaPx;
   const size = pxMin + Math.round(energiaReal * (pxMax - pxMin));
   const luz = JERARQUIA_PERSONAJES.luzProtagonista;
   return (
-    <group ref={ref} position={[CALMA_ABEJA.x, yCalma + 2.5, CALMA_ABEJA.z]}>
+    <group ref={ref} position={[CALMA_ABEJA.x, yCalma + 2.2, CALMA_ABEJA.z]}>
       {/* JERARQUÍA: Angelita es la ÚNICA con luz propia — su calidez baña el
           terreno bajo su vuelo y el ojo la encuentra primero, sobre todo al
           atardecer y de noche. Solo donde el perfil ya paga luces extra. */}
@@ -1362,8 +1403,8 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
           position={[0, -0.2, 0]}
         />
       )}
-      <Html center distanceFactor={15} zIndexRange={[40, 10]}>
-        {/* TOCABLE (§6): Angelita brilla e invita — tocarla es hablarle a la
+      <Html center distanceFactor={9} zIndexRange={[40, 10]}>
+        {/* TOCABLE: Angelita brilla e invita — tocarla es hablarle a la
             finca (el host abre el agente). Botón real por accesibilidad. */}
         <button
           type="button"
@@ -1494,16 +1535,16 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false, 
     }
     /* ASIMETRÍA DEL VIAJE (dirección): ENTRAR es decidido (el toque pide ir
        ya); VOLVER es una exhalación — más lento, el valle se abre con calma y
-       llegar a casa se siente distinto a salir de ella. */
-    const k = entrando ? 0.07 : 0.042;
+       llegar a casa se siente distinto a salir de ella. (El regreso subió de
+       0.042: la exhalación se sentía LENTITUD, feedback del operador.) */
+    const k = entrando ? 0.07 : 0.052;
     c.target.lerp(new THREE.Vector3(foco.x, foco.y + 0.6, foco.z), k);
     if (trans.current > 0) {
       const cam = c.object;
       const dir = cam.position.clone().sub(c.target);
       // Acercarse al entrar; al volver, abrir hasta el reposo del ASPECTO
       // real (kReposo): en un teléfono parado el valle respira más lejos.
-      // (Distancias del valle GRANDE: entrar a 10.5, reposo a ~25.)
-      const deseada = entrando ? 10.5 : 25 * kReposo;
+      const deseada = entrando ? 9 : 18 * kReposo;
       dir.setLength(THREE.MathUtils.lerp(dir.length(), deseada, k));
       cam.position.copy(c.target.clone().add(dir));
       trans.current = Math.max(0, trans.current - (entrando ? 0.012 : 0.009));
@@ -1520,11 +1561,11 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false, 
          fotograma ya es el encuadre de autor — clave en reduced-motion
          (frameloop demand), donde el lerp por frame gatea. */
       target={miraInicial || undefined}
-      minDistance={8}
+      minDistance={7}
       /* El techo de zoom respeta el reposo del aspecto: si la pose vertical
          vive más lejos, el clamp no pelea contra ella (antes, en teléfono,
          el reposo caía FUERA del techo y los controles daban tirones). */
-      maxDistance={Math.max(38, Math.ceil(27 * kReposo) + 5)}
+      maxDistance={Math.max(28, Math.ceil(20 * kReposo) + 4)}
       minPolarAngle={0.45}
       maxPolarAngle={1.18}
       autoRotate={autoOrbit && !entrando && !tomada}
@@ -1534,7 +1575,9 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false, 
          y la atmósfera, no el tiovivo. */
       autoRotateSpeed={0.12}
       enableDamping
-      dampingFactor={0.08}
+      /* 0.08 → 0.12: el paneo respondía con manteca de más ("algo de
+         lentitud", feedback del operador) — sigue suave pero obedece. */
+      dampingFactor={0.12}
       onStart={tomada ? undefined : () => setTomada(true)}
     />
   );
@@ -1563,9 +1606,7 @@ function estadoAtmosfera(c) {
     niebla: new THREE.Color(c.niebla),
     solPos: new THREE.Vector3(...(c.sol || SOL_DEFECTO)),
     intensidad: c.intensidad,
-    // El valle grande pide más aire antes de la niebla (antes +8): que la
-    // cordillera nueva (z≤-21) se lea, no se coma.
-    nieblaLejos: c.nieblaLejos + 18,
+    nieblaLejos: c.nieblaLejos + 8,
   };
 }
 
@@ -1635,7 +1676,7 @@ function AtmosferaValle({ c, perfil, reducedMotion }) {
       <color ref={fondoRef} attach="background" args={[ini.cielo[1]]} />
       {/* La niebla se paga por fragmento: en perfil 'bajo' se apaga. */}
       {perfil.fog && (
-        <fog ref={fogRef} attach="fog" args={[ini.niebla, 16, ini.nieblaLejos + 18]} />
+        <fog ref={fogRef} attach="fog" args={[ini.niebla, 12, ini.nieblaLejos + 8]} />
       )}
       <hemisphereLight
         ref={hemiRef}
@@ -1675,7 +1716,7 @@ function AtmosferaValle({ c, perfil, reducedMotion }) {
    la luna, como se ve una luna que apenas sale. Verificado contra el terreno:
    el rayo cámara→luna libra la loma (y=6.9 sobre 1.5 en x=-10; 6.2 sobre 3.1
    en el borde x=-17) y la cordillera queda lejos (z≤-15). */
-const POS_LUNA = /** @type {[number, number, number]} */ ([-28, 4.6, -11]);
+const POS_LUNA = /** @type {[number, number, number]} */ ([-21, 3.4, -8]);
 
 function LunaValle({ reducedMotion }) {
   const ref = useRef(null);
@@ -1715,17 +1756,15 @@ function LunaValle({ reducedMotion }) {
 
 /* Caja de las luciérnagas: la tierra baja del frente del valle (referencia
    ESTABLE — ParticulasAmbientales re-siembra si la caja cambia). */
-const AREA_LUCIERNAGAS = /** @type {[number, number, number]} */ ([26, 2.6, 10]);
+const AREA_LUCIERNAGAS = /** @type {[number, number, number]} */ ([18, 2.4, 7]);
 
 /* La pose de cámara del valle: UNA fuente para el Canvas y para el establishing
-   shot de la CámaraDirector (así el dolly aterriza EXACTO donde siempre).
-   REDISEÑO 2026-07: la cámara RETROCEDIÓ con el valle grande (48×48) — el
-   cuadro respira, los lugares regados caben todos y nada queda apeñuscado. */
-const CAMARA_VALLE = { position: /** @type {[number, number, number]} */ ([15.2, 13.4, 19.6]), fov: 40 };
+   shot de la CámaraDirector (así el dolly aterriza EXACTO donde siempre). */
+const CAMARA_VALLE = { position: /** @type {[number, number, number]} */ ([10.5, 9, 13.5]), fov: 40 };
 /* El target de reposo del valle: el corazón del mapa, al que CamaraViajera
-   lleva el target sin foco ((0,1.4,2.0) + 0.6 en y). El establishing del
+   lleva el target sin foco ((0,1.0,1.4) + 0.6 en y). El establishing del
    DirectorValle aterriza EXACTO aquí para no dar ningún salto al soltar. */
-const MIRA_VALLE = [0.3, 1.8, 2.6];
+const MIRA_VALLE = [0, 1.6, 1.4];
 
 /* El REPOSO CONSCIENTE DEL ASPECTO (dirección de cámara): el fov de three es
    VERTICAL — en un teléfono parado (aspecto ~0.46) los 40° dejan un fov
@@ -1748,9 +1787,8 @@ function poseValleParaAspecto(aspect) {
   }
   const cuanVertical = Math.min(1, (0.9 - aspect) / 0.44); // 0 en 0.9 → 1 en ~0.46
   // El PLANO PICADO del teléfono parado (misma acimut de la pose aprobada,
-  // polar ~40°): la cámara sube y pica para que la ladera del valle GRANDE
-  // corra a lo largo de la pantalla y los lugares respiren en vertical.
-  const PICADO = { position: [13, 26, 21], fov: 58, mira: [-0.6, 0.8, 3.6] };
+  // polar ~40°): la cámara sube a 18.7 y la mira avanza a la finca (z 3.2).
+  const PICADO = { position: [9.3, 18.7, 15.1], fov: 58, mira: [-0.5, 0.6, 2.7] };
   const lerp = (a, b) => a + (b - a) * cuanVertical;
   const position = /** @type {[number, number, number]} */ (
     CAMARA_VALLE.position.map((v, i) => lerp(v, PICADO.position[i]))
@@ -1843,10 +1881,10 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = nu
       <VegetacionPisos nocturno={nocturno} perfil={perfil} />
 
       {/* LA DIRECCIÓN DEL CUADRO: la casa-PUERTA donde descansa el ojo (su
-          puerta iluminada abre el mapa de los mundos), los senderos de tierra
-          pisada que nacen de ella (el rastro del uso diario), los PÓRTICOS de
-          los 6 portales (la puerta legible de cada patio) y los patios bajo
-          cada lugar navegable (afordancia sin UI). */}
+          puerta iluminada abre el mapa de los 6 portales), los senderos de
+          tierra pisada que nacen de ella, las VENTANAS VIVAS de los portales
+          principales, los pórticos humildes de lo secundario, la vista del
+          páramo con su Ent, y los patios bajo cada lugar (afordancia sin UI). */}
       <CasaCampesina
         alturaDe={alturaTerreno}
         perfil={perfil}
@@ -1855,13 +1893,29 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = nu
         onPuerta={portada ? null : onCasa}
       />
       <SenderosValle alturaDe={alturaTerreno} perfil={perfil} />
-      <PorticosPortales
+      {/* JERARQUÍA DE PORTALES (regla del operador): los 6 grandes son
+          ventanas VIVAS al mundo — notorias, inmersivas; los toris de madera
+          quedan SOLO para los lugares secundarios de menos uso. */}
+      <VentanasVivas
         mundos={MUNDOS_DIR}
         alturaDe={alturaTerreno}
-        perfil={perfil}
         nocturno={nocturno}
+        reducedMotion={reducedMotion}
         onEntrar={portada ? null : onEntrar}
       />
+      <PorticosSecundarios mundos={MUNDOS_DIR} alturaDe={alturaTerreno} />
+      {/* EL ACCESO AL PÁRAMO: el páramo VISIBLE — el Ent-queñua magnífico
+          parado en el filo entre frailejones. Tocarlo entra al monte. */}
+      <VistaParamoEnt
+        alturaDe={alturaTerreno}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        onEntrar={portada ? null : onEntrar}
+      />
+      {/* El cóndor: planea su térmica sobre el filo del páramo y a ratos se
+          POSA en el pico de la cordillera, de día (de noche duerme en la
+          peña). Un billboard: vive en todos los tiers. */}
+      {!nocturno && <CondorDelValle reducedMotion={reducedMotion} tier={tier} />}
       {/* EL PESO DE LAS COSAS: la sombra de contacto que planta cada objeto
           en su loma. Separa la profundidad sin mover nada — la casa, los
           hitos y las matas dejan de flotar. De noche se atenúa, no se va. */}
@@ -1895,6 +1949,9 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = nu
         reducedMotion={reducedMotion}
         franja={clima}
       />
+      {/* EL OSO NEGRO del monte (biopunk, decisión del operador): el mayor
+          de los vecinos de tierra, visible en el borde del bosque. */}
+      <OsoNegroDelMonte alturaDe={alturaTerreno} />
       {/* MODO PORTADA (la cara de prod.chagra.app): el valle es ATMÓSFERA de
           la entrada — sin rótulos que compitan con el formulario ni faro que
           pida un toque que aún no puede darse. La vida (criaturas, Angelita,
@@ -1985,11 +2042,9 @@ export default function Valle3D({
   energia = 1,
   onEntrar,
   onAlerta,
-  /* LA CASA ES LA PUERTA (§2): tocar la puerta iluminada de la casa llama
-     aquí — el host abre el mapa de los 6 portales. */
+  /* Tocar la puerta iluminada de la casa: abre el mapa de los 6 portales. */
   onCasa = null,
-  /* ANGELITA INVITA (§6): tocar a la abeja central llama aquí — el host
-     abre la conversación con el agente. */
+  /* Tocar a Angelita: hablarle a la finca (el host abre el agente). */
   onAngelita = null,
   reducedMotion,
   tier = 'alto',

--- a/src/mockups/valle/composicionValle3D.jsx
+++ b/src/mockups/valle/composicionValle3D.jsx
@@ -7,12 +7,17 @@
  * frame. Recibe `alturaDe(x, z)` del host (Valle3D es dueño del terreno):
  * nada de aquí importa Valle3D — sin ciclos.
  *
- *   · CasaCampesina    — el corazón del cuadro Y LA PUERTA DE LOS MUNDOS
- *                        (rediseño 2026-07): la puerta iluminada invita a
- *                        tocar y abre el mapa de los 6 portales.
- *   · PorticosPortales — los pórticos de madera de los 6 portales: dos pies
- *                        derechos + dintel + farolito + tablita con el tinte
- *                        del mundo. La puerta legible de cada patio.
+ *   · CasaCampesina    — el corazón del cuadro Y LA PUERTA DE LOS MUNDOS:
+ *                        la puerta iluminada invita a tocar y abre el mapa
+ *                        de los 6 portales.
+ *   · VentanasVivas    — los 6 portales PRINCIPALES como ventanas VIVAS al
+ *                        mundo: un arco de vegetación con el lente del mundo
+ *                        brillando adentro (jerarquía del operador: notorios
+ *                        e inmersivos, nada de toris para lo principal).
+ *   · PorticosSecundarios — los pórticos de madera SOLO para los lugares
+ *                        secundarios de menos uso (eras, huerta, vivero…).
+ *   · VistaParamoEnt   — el acceso al páramo: el Ent-queñua MAGNÍFICO parado
+ *                        en el filo entre frailejones. El páramo se VE.
  *   · SenderosValle    — la tierra pisada que nace de la casa: el rastro del
  *                        uso diario, el ojo camina por donde caminan los pies.
  *   · PatiosLugares    — el suelo desnudo bajo cada lugar navegable: la
@@ -25,14 +30,30 @@ import { useFrame } from '@react-three/fiber';
 import { Html, Instances, Instance } from '@react-three/drei';
 import * as THREE from 'three';
 import { CREATURES } from '../../visual/creatures/index.js';
+/* El OSO NEGRO biopunk del GuardianEspiritu (decisión del operador: este es
+   EL oso del valle — cuerpo casi negro, contorno neón teal, anteojos crema;
+   el rubber-hose café quedó retirado). SVG puro: billboard barato. */
+import { GuardianAvatar } from '../../components/dashboard/GuardianEspiritu.jsx';
+import EntQuenua from '../../visual/mundo3d/bosque/EntQuenua.jsx';
 import {
   CASA_VALLE,
   SENDEROS_VALLE,
   PATIO,
   PORTALES_VALLE,
+  PORTICOS_SECUNDARIOS,
+  VISTA_PARAMO,
   JERARQUIA_PERSONAJES,
   VECINOS_VALLE,
 } from '../../visual/mundo3d/direccion/composicionValle.js';
+
+/* Cursor-mano compartido por todo lo tocable de la composición. */
+const alApuntar = (e) => {
+  e.stopPropagation();
+  document.body.style.cursor = 'pointer';
+};
+const alSoltar = () => {
+  document.body.style.cursor = '';
+};
 
 /* ── Paleta de la casa campesina (tapia encalada + zócalo + teja) ────────── */
 const CASA = {
@@ -46,11 +67,10 @@ const CASA = {
 };
 
 /**
- * La casa campesina: el corazón del cuadro y — rediseño 2026-07 — LA PUERTA
- * DE LOS MUNDOS. Su puerta está ABIERTA y con luz cálida adentro (la casa
- * invita), pulsa apenas como el faro del día, y tocarla abre el mapa de los
- * 6 portales (`onPuerta`). Modesta a propósito en lo demás: sostiene el
- * cuadro sin pedir espectáculo.
+ * La casa campesina: el corazón del cuadro y LA PUERTA DE LOS MUNDOS. Su
+ * puerta está ABIERTA y con luz cálida adentro (la casa invita), pulsa apenas
+ * como el faro del día, y tocarla abre el mapa de los 6 portales (`onPuerta`).
+ * Modesta a propósito en lo demás: sostiene el cuadro sin pedir espectáculo.
  */
 export function CasaCampesina({ alturaDe, perfil, nocturno = false, reducedMotion = false, onPuerta = null }) {
   const [cx, cz] = CASA_VALLE.pos;
@@ -80,21 +100,8 @@ export function CasaCampesina({ alturaDe, perfil, nocturno = false, reducedMotio
             }
           : undefined
       }
-      onPointerOver={
-        onPuerta
-          ? (e) => {
-              e.stopPropagation();
-              document.body.style.cursor = 'pointer';
-            }
-          : undefined
-      }
-      onPointerOut={
-        onPuerta
-          ? () => {
-              document.body.style.cursor = '';
-            }
-          : undefined
-      }
+      onPointerOver={onPuerta ? alApuntar : undefined}
+      onPointerOut={onPuerta ? alSoltar : undefined}
     >
       {/* el zócalo pintado (la franja baja de color de toda casa de vereda) */}
       <mesh position={[0, 0.11, 0]} castShadow={perfil.sombras} receiveShadow={perfil.sombras}>
@@ -157,7 +164,9 @@ export function CasaCampesina({ alturaDe, perfil, nocturno = false, reducedMotio
       </mesh>
       {/* LA VENTANA CON LUZ: la casa espera (emisiva, cálida, chiquita).
           De NOCHE es el FARO del valle (día-por-noche: la práctica que
-          orienta). El punto de referencia para volver a casa. */}
+          orienta): brilla más fuerte, tira un charco cálido sobre la tierra
+          del corredor, y — solo donde el perfil paga luces — una pointLight
+          ámbar baña la fachada. El punto de referencia para volver a casa. */}
       <mesh position={[0.34, 0.56, 0.52]}>
         <boxGeometry args={[0.26, 0.24, 0.04]} />
         <meshStandardMaterial
@@ -208,41 +217,64 @@ export function CasaCampesina({ alturaDe, perfil, nocturno = false, reducedMotio
   );
 }
 
-/* ── PÓRTICOS de los 6 portales: la puerta legible de cada patio ─────────
-   Dos pies derechos de madera + dintel + FAROLITO cálido encima + la tablita
-   colgada con el TINTE del mundo: se lee "por aquí se entra" sin leer nada.
-   Cada pórtico mira HACIA LA CASA (de donde llega el sendero) y se para al
-   borde del patio, no encima del landmark. Tocarlo entra al mundo (misma
-   afordancia que el lugar). En perfil frugal los pórticos van instanciados
-   (4 draw calls) y el toque lo sigue dando el landmark. */
-const MAT_PORTICO = new THREE.MeshLambertMaterial({ color: '#7a5a38' });
-const MAT_FAROL = new THREE.MeshStandardMaterial({
-  color: '#ffd88f',
-  emissive: '#ffb24d',
-  emissiveIntensity: 0.9,
-  flatShading: true,
-});
+/* ── VENTANAS VIVAS: los 6 portales principales ──────────────────────────
+   Jerarquía del operador (2026-07-16): los portales grandes (mis matas ·
+   mis animales · el tiempo · vender · aprender · toda mi finca) son
+   NOTORIOS e inmersivos — ventanas VIVAS al mundo, no toris de madera.
 
-function sitiosPorticos(mundos) {
+   Cada ventana es un ARCO DE VEGETACIÓN (un anillo vivo brotado de la
+   tierra, con hojas y flores del tinte del mundo) con el LENTE del mundo
+   brillando adentro: un velo de color que respira — se ve el mundo del otro
+   lado. Se para al borde del patio mirando hacia la casa (de donde llega el
+   sendero) y tocarla ENTRA, igual que el lugar. Cero texturas: anillo,
+   discos y esferitas. */
+const MAT_ARCO_VIVO = new THREE.MeshLambertMaterial({ color: '#4f7d3c' });
+
+function sitiosVentanas(mundos) {
   const [cx, cz] = CASA_VALLE.pos;
   const porId = Object.fromEntries(mundos.map((m) => [m.id, m]));
   return PORTALES_VALLE.map((p) => {
     const m = porId[p.id];
     if (!m) return null;
     const [x, , z] = m.pos;
-    // Mirar hacia la casa: el pórtico recibe al que llega por el sendero.
+    // Mirar hacia la casa: la ventana recibe al que llega por el sendero.
     const rotY = Math.atan2(cx - x, cz - z);
     const esc = m.escala || 1;
     // Al borde del patio, del lado de la casa (el umbral, no el centro).
-    const d = PATIO.radioBase * esc + 0.55;
-    const px = x + Math.sin(rotY) * d;
-    const pz = z + Math.cos(rotY) * d;
-    return { portal: p, mundo: m, x: px, z: pz, rotY, tinte: m.tinte };
+    const d = PATIO.radioBase * esc + 0.7;
+    return {
+      portal: p,
+      mundo: m,
+      x: x + Math.sin(rotY) * d,
+      z: z + Math.cos(rotY) * d,
+      rotY,
+      tinte: m.tinte,
+    };
   }).filter(Boolean);
 }
 
-function PorticoRico({ sitio, alturaDe, onEntrar, nocturno }) {
+/* Las hojas que visten el anillo: puntos sobre la circunferencia (en el
+   plano local x/y del arco), con jitter determinista. */
+const HOJAS_ARCO = Array.from({ length: 10 }, (_, i) => {
+  const a = (i / 10) * Math.PI * 2 + 0.3;
+  const j = Math.sin(i * 12.9898) * 0.5;
+  return { a, r: 0.92 + j * 0.08, s: 0.1 + Math.abs(j) * 0.06, giro: j * 2.4 };
+});
+
+function VentanaViva({ sitio, alturaDe, nocturno, reducedMotion, onEntrar }) {
   const y = alturaDe(sitio.x, sitio.z);
+  const lenteRef = useRef(null);
+  const brilloRef = useRef(null);
+  // El lente RESPIRA (el velo del mundo ondea, ~0.3 Hz, con fase por portal
+  // para que el frente no pulse al unísono): vivo, no intermitente.
+  const fase = useMemo(() => sitio.x * 2.1 + sitio.z * 1.3, [sitio]);
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const p = (Math.sin(state.clock.elapsedTime * 1.9 + fase) + 1) / 2;
+    if (lenteRef.current) lenteRef.current.opacity = 0.34 + p * 0.18;
+    if (brilloRef.current) brilloRef.current.emissiveIntensity = 0.5 + p * 0.5;
+  });
+  const [fuerte, suave] = sitio.tinte;
   return (
     <group
       position={[sitio.x, y, sitio.z]}
@@ -255,123 +287,200 @@ function PorticoRico({ sitio, alturaDe, onEntrar, nocturno }) {
             }
           : undefined
       }
-      onPointerOver={
-        onEntrar
-          ? (e) => {
-              e.stopPropagation();
-              document.body.style.cursor = 'pointer';
-            }
-          : undefined
-      }
-      onPointerOut={
-        onEntrar
-          ? () => {
-              document.body.style.cursor = '';
-            }
-          : undefined
-      }
+      onPointerOver={onEntrar ? alApuntar : undefined}
+      onPointerOut={onEntrar ? alSoltar : undefined}
     >
-      {/* los dos pies derechos */}
-      <mesh position={[-0.62, 0.72, 0]} material={MAT_PORTICO} castShadow>
-        <cylinderGeometry args={[0.055, 0.07, 1.44, 6]} />
+      {/* el ANILLO VIVO: la enredadera que hace de marco, parada en la tierra */}
+      <mesh position={[0, 1.12, 0]} material={MAT_ARCO_VIVO} castShadow>
+        <torusGeometry args={[0.95, 0.085, 7, 26]} />
       </mesh>
-      <mesh position={[0.62, 0.72, 0]} material={MAT_PORTICO} castShadow>
-        <cylinderGeometry args={[0.055, 0.07, 1.44, 6]} />
-      </mesh>
-      {/* el dintel, con su parcito de tejas de remate */}
-      <mesh position={[0, 1.48, 0]} material={MAT_PORTICO} castShadow>
-        <boxGeometry args={[1.52, 0.1, 0.14]} />
-      </mesh>
-      <mesh position={[0, 1.58, 0]} rotation={[0, 0, 0]} castShadow>
-        <boxGeometry args={[1.62, 0.05, 0.24]} />
-        <meshLambertMaterial color="#8f4b31" />
-      </mesh>
-      {/* el farolito: la lucecita que dice "esta puerta está viva" */}
-      <mesh position={[0, 1.72, 0]} material={MAT_FAROL}>
-        <octahedronGeometry args={[0.11, 0]} />
-      </mesh>
-      {/* la tablita colgada con el tinte del mundo (la seña de la puerta) */}
-      <mesh position={[0, 1.22, 0]}>
-        <boxGeometry args={[0.56, 0.3, 0.05]} />
-        <meshLambertMaterial
-          color={sitio.tinte[0]}
-          emissive={nocturno ? sitio.tinte[0] : '#000000'}
-          emissiveIntensity={nocturno ? 0.35 : 0}
+      {/* las hojas que lo visten (mismo material: 0 draw calls extra de shader) */}
+      {HOJAS_ARCO.map((h, i) => (
+        <mesh
+          key={i}
+          material={MAT_ARCO_VIVO}
+          position={[Math.cos(h.a) * h.r, 1.12 + Math.sin(h.a) * h.r, 0.03]}
+          rotation={[0, 0, h.giro]}
+          scale={[h.s * 1.7, h.s, h.s * 0.5]}
+        >
+          <sphereGeometry args={[1, 6, 5]} />
+        </mesh>
+      ))}
+      {/* cuatro flores del tinte del mundo coronando el arco (la seña) */}
+      {[0.6, 1.25, 1.9, 2.55].map((a, i) => (
+        <mesh
+          key={i}
+          position={[Math.cos(a) * 0.98, 1.12 + Math.sin(a) * 0.98, 0.08]}
+        >
+          <sphereGeometry args={[0.065, 6, 5]} />
+          <meshStandardMaterial
+            ref={i === 1 ? brilloRef : undefined}
+            color={fuerte}
+            emissive={fuerte}
+            emissiveIntensity={0.7}
+            flatShading
+          />
+        </mesh>
+      ))}
+      {/* EL LENTE: el velo del mundo — se ve "el otro lado" en su color */}
+      <mesh position={[0, 1.12, 0]}>
+        <circleGeometry args={[0.88, 24]} />
+        <meshBasicMaterial
+          ref={lenteRef}
+          color={suave}
+          transparent
+          opacity={0.4}
+          side={2}
+          depthWrite={false}
         />
       </mesh>
+      <mesh position={[0, 1.12, -0.02]}>
+        <circleGeometry args={[0.55, 20]} />
+        <meshBasicMaterial color={fuerte} transparent opacity={0.3} side={2} depthWrite={false} />
+      </mesh>
+      {/* los dos raigones donde el anillo agarra la tierra */}
+      {[-0.82, 0.82].map((dx, i) => (
+        <mesh key={i} position={[dx, 0.14, 0]} material={MAT_ARCO_VIVO}>
+          <coneGeometry args={[0.16, 0.5, 5]} />
+        </mesh>
+      ))}
+      {/* de noche el lente ES una práctica: un brillo que orienta */}
+      {nocturno && (
+        <mesh position={[0, 1.12, 0.02]}>
+          <circleGeometry args={[0.88, 24]} />
+          <meshBasicMaterial color={fuerte} transparent opacity={0.18} side={2} depthWrite={false} />
+        </mesh>
+      )}
     </group>
   );
 }
 
-export function PorticosPortales({ mundos, alturaDe, perfil, nocturno = false, onEntrar = null }) {
+export function VentanasVivas({ mundos, alturaDe, nocturno = false, reducedMotion = false, onEntrar = null }) {
+  const sitios = useMemo(() => sitiosVentanas(mundos), [mundos]);
+  return (
+    <group>
+      {sitios.map((s) => (
+        <VentanaViva
+          key={s.portal.id}
+          sitio={s}
+          alturaDe={alturaDe}
+          nocturno={nocturno}
+          reducedMotion={reducedMotion}
+          onEntrar={onEntrar}
+        />
+      ))}
+    </group>
+  );
+}
+
+/* ── PÓRTICOS de madera: SOLO los lugares secundarios ────────────────────
+   La puerta humilde del patio de trabajo (dos pies derechos + dintel +
+   farolito + tablita con el tinte): para las eras, la huerta, el vivero, la
+   pila y la toma de agua. Los 6 portales grandes NO llevan pórtico (tienen
+   ventana viva) ni el páramo (tiene su vista con el Ent). Instanciados en
+   4 draw calls; el toque lo captura el landmark del mundo, como siempre. */
+function sitiosPorticos(mundos) {
+  const [cx, cz] = CASA_VALLE.pos;
+  return mundos
+    .filter((m) => PORTICOS_SECUNDARIOS.includes(m.id))
+    .map((m) => {
+      const [x, , z] = m.pos;
+      const rotY = Math.atan2(cx - x, cz - z);
+      const esc = m.escala || 1;
+      const d = PATIO.radioBase * esc + 0.5;
+      return {
+        id: m.id,
+        x: x + Math.sin(rotY) * d,
+        z: z + Math.cos(rotY) * d,
+        rotY,
+        tinte: m.tinte,
+      };
+    });
+}
+
+export function PorticosSecundarios({ mundos, alturaDe }) {
   const sitios = useMemo(() => sitiosPorticos(mundos), [mundos]);
-  if (perfil.materialRico) {
-    return (
-      <group>
-        {sitios.map((s) => (
-          <PorticoRico
-            key={s.portal.id}
-            sitio={s}
-            alturaDe={alturaDe}
-            onEntrar={onEntrar}
-            nocturno={nocturno}
-          />
-        ))}
-      </group>
-    );
-  }
-  // Frugal: pies + dintel + tablita + farol en 4 Instances (4 draw calls);
-  // el toque lo captura el landmark del mundo, como siempre.
   return (
     <group>
       <Instances limit={sitios.length * 2}>
-        <cylinderGeometry args={[0.06, 0.07, 1.44, 5]} />
+        <cylinderGeometry args={[0.045, 0.055, 1.16, 5]} />
         <meshLambertMaterial color="#7a5a38" />
         {sitios.flatMap((s) => {
           const y = alturaDe(s.x, s.z);
           const c = Math.cos(s.rotY);
           const sn = Math.sin(s.rotY);
-          return [-0.62, 0.62].map((dx, i) => (
+          return [-0.5, 0.5].map((dx, i) => (
             <Instance
-              key={`${s.portal.id}${i}`}
-              position={[s.x + c * dx, y + 0.72, s.z - sn * dx]}
+              key={`${s.id}${i}`}
+              position={[s.x + c * dx, y + 0.58, s.z - sn * dx]}
             />
           ));
         })}
       </Instances>
       <Instances limit={sitios.length}>
-        <boxGeometry args={[1.56, 0.1, 0.16]} />
+        <boxGeometry args={[1.26, 0.08, 0.13]} />
         <meshLambertMaterial color="#7a5a38" />
         {sitios.map((s) => (
           <Instance
-            key={s.portal.id}
-            position={[s.x, alturaDe(s.x, s.z) + 1.48, s.z]}
+            key={s.id}
+            position={[s.x, alturaDe(s.x, s.z) + 1.2, s.z]}
             rotation={[0, s.rotY, 0]}
           />
         ))}
       </Instances>
       <Instances limit={sitios.length}>
-        <boxGeometry args={[0.56, 0.3, 0.05]} />
+        <boxGeometry args={[0.46, 0.24, 0.04]} />
         <meshLambertMaterial />
         {sitios.map((s) => (
           <Instance
-            key={s.portal.id}
-            position={[s.x, alturaDe(s.x, s.z) + 1.22, s.z]}
+            key={s.id}
+            position={[s.x, alturaDe(s.x, s.z) + 0.98, s.z]}
             rotation={[0, s.rotY, 0]}
             color={s.tinte[0]}
           />
         ))}
       </Instances>
       <Instances limit={sitios.length}>
-        <octahedronGeometry args={[0.11, 0]} />
+        <octahedronGeometry args={[0.09, 0]} />
         <meshBasicMaterial color="#ffcf87" />
         {sitios.map((s) => (
           <Instance
-            key={s.portal.id}
-            position={[s.x, alturaDe(s.x, s.z) + 1.72, s.z]}
+            key={s.id}
+            position={[s.x, alturaDe(s.x, s.z) + 1.38, s.z]}
           />
         ))}
       </Instances>
+    </group>
+  );
+}
+
+/* ── LA VISTA DEL PÁRAMO: el Ent-queñua magnífico en el filo ─────────────
+   Regla del operador: el acceso al páramo ES el páramo visible — arriba, el
+   Ent (queñua/Polylepis, mallas reales de EntQuenua) parado entre los
+   frailejones, meciéndose con el viento del páramo. Tocarlo entra al mundo
+   del monte. El detalle va con techo 'medio' (el 'alto' pleno es para SU
+   mundo; aquí es un habitante del fondo, no la escena entera). */
+export function VistaParamoEnt({ alturaDe, tier = 'alto', reducedMotion = false, onEntrar = null }) {
+  const [x, z] = VISTA_PARAMO.punto;
+  const y = alturaDe(x, z);
+  const tierEnt = tier === 'bajo' ? 'bajo' : 'medio';
+  return (
+    <group
+      position={[x, y, z]}
+      rotation={[0, 0.5, 0]}
+      scale={VISTA_PARAMO.escala}
+      onClick={
+        onEntrar
+          ? (e) => {
+              e.stopPropagation();
+              onEntrar(VISTA_PARAMO.mundoId);
+            }
+          : undefined
+      }
+      onPointerOver={onEntrar ? alApuntar : undefined}
+      onPointerOut={onEntrar ? alSoltar : undefined}
+    >
+      <EntQuenua tier={tierEnt} reducedMotion={reducedMotion} />
     </group>
   );
 }
@@ -390,14 +499,14 @@ export function SenderosValle({ alturaDe, perfil }) {
         const pts = s.puntos.map(([x, z]) => new THREE.Vector3(x, alturaDe(x, z) + 0.03, z));
         const curva = new THREE.CatmullRomCurve3(pts);
         // Radio corto y medio hundido: asoma la huella, no un caño.
-        return new THREE.TubeGeometry(curva, s.puntos.length * (rico ? 7 : 5), 0.19, 4, false);
+        return new THREE.TubeGeometry(curva, s.puntos.length * (rico ? 7 : 5), 0.16, 4, false);
       }),
     [alturaDe, rico],
   );
   return (
     <group>
       {geos.map((g, i) => (
-        <mesh key={i} geometry={g} material={MAT_SENDERO} position={[0, -0.08, 0]} />
+        <mesh key={i} geometry={g} material={MAT_SENDERO} position={[0, -0.07, 0]} />
       ))}
     </group>
   );
@@ -441,15 +550,37 @@ export function PatiosLugares({ mundos, alturaDe, nocturno = false }) {
   );
 }
 
+/* ── EL OSO NEGRO DEL MONTE (Tremarctos ornatus en clave biopunk) ────────
+   El operador retiró el oso rubber-hose café y pidió VER el oso bueno: el
+   negro del GuardianEspiritu, con su contorno neón y sus anteojos crema (el
+   "de anteojos" literal). Vive en el borde del monte — el slot de ancla que
+   quedó reservado — con presencia clara: es el mayor de los vecinos de
+   tierra. Billboard aria-hidden, cero toques (presencia, no interfaz). */
+const OSO_MONTE = { punto: [5.4, -1.2], px: 52, factor: 11, dy: 0.46 };
+
+export function OsoNegroDelMonte({ alturaDe }) {
+  const [x, z] = OSO_MONTE.punto;
+  const y = alturaDe(x, z) + OSO_MONTE.dy;
+  return (
+    <group position={[x, y, z]}>
+      <Html center distanceFactor={OSO_MONTE.factor} zIndexRange={[6, 0]} pointerEvents="none">
+        <div className="valle-critter" data-vecino="oso-negro" aria-hidden="true">
+          <GuardianAvatar id="oso" size={OSO_MONTE.px} />
+        </div>
+      </Html>
+    </group>
+  );
+}
+
 /* ── Los VECINOS del valle: los personajes en su casa ────────────────────
    La puesta en escena de los personajes rubber-hose (feedback del operador:
-   los personajes no pueden ser garnish de la abejita). Cada vecino vive
+   el oso y los demás no pueden ser garnish de la abejita). Cada vecino vive
    en SU rincón (VECINOS_VALLE) con presencia digna, y `franjas` decide
-   cuándo sale — el jaguar solo como aparecido. Billboards <Html>
-   aria-hidden, cero toques (JERARQUIA_PERSONAJES): la ley sigue siendo
-   presencia, no interfaz. Un slug que no exista en CREATURES simplemente
-   no monta — las ramas de personajes mejoran el dibujo al mergear sin
-   tocar este mapa. */
+   cuándo sale — el borugo al caer el sol, el jaguar solo como aparecido.
+   Billboards <Html> aria-hidden, cero toques (JERARQUIA_PERSONAJES): la ley
+   sigue siendo presencia, no interfaz. Un slug que no exista en CREATURES
+   simplemente no monta — las ramas de personajes mejoran el dibujo al
+   mergear sin tocar este mapa. */
 export function VecinosDelValle({ alturaDe, reducedMotion, franja = null }) {
   return (
     <group>

--- a/src/mockups/valle/directorValle.js
+++ b/src/mockups/valle/directorValle.js
@@ -96,13 +96,12 @@ const ANTICIPO = { abre: 0.06 };
 const ZERO3 = Object.freeze(new THREE.Vector3());
 
 /* ── El BARRIDO de presentación ───────────────────────────────────────────
-   Waypoints en unidades de mundo del valle (terreno 48×48 tras el rediseño;
-   la cordillera al fondo en z≈-22, la quebrada baja de (-4.6,-11) a
-   (4.6,11.5), los mundos entre z -9.4 y 9.6). Arranca ALTO sobre el páramo
-   mirando la ladera, planea sobre la quebrada y los mundos, y cae hacia la
-   pose jugable. El último tramo lo cubre el resorte de asentamiento (por eso
-   la curva termina CERCA del reposo, no encima). El modo sobrio recorta el
-   barrido a un dolly corto en arco. */
+   Waypoints en unidades de mundo del valle (terreno 34×34; la cordillera al
+   fondo en z≈-15, la quebrada baja de (-3.4,-7.2) a (3.6,8), los mundos entre
+   z -2.5 y 6.5). Arranca ALTO sobre el páramo mirando la ladera, planea sobre
+   la quebrada y los mundos, y cae hacia la pose jugable. El último tramo lo
+   cubre el resorte de asentamiento (por eso la curva termina CERCA del reposo,
+   no encima). El modo sobrio recorta el barrido a un dolly corto en arco. */
 export function waypointsPresentacion(modo, reposo, mira) {
   const [rx, ry, rz] = reposo;
   const [mx, my, mz] = mira;
@@ -123,15 +122,15 @@ export function waypointsPresentacion(modo, reposo, mira) {
   }
   return {
     pos: [
-      [-18, 20, -9], // alto sobre el páramo: la ladera entera y el río de lado
-      [-20, 15, 9], // planeo por el costado: la quebrada baja en cuadro
-      [-6, 11.5, 21], // frente del valle: la casa-puerta, los pórticos, la fauna
+      [-13, 15.5, -6], // alto sobre el páramo: la ladera entera y el río de lado
+      [-14.5, 11, 6], // planeo por el costado: la quebrada baja en cuadro
+      [-4, 8.6, 15], // frente del valle: los mundos y la fauna, de cerca
       [rx * 0.86, ry * 1.06, rz * 0.94], // casi la pose jugable (remata el resorte)
     ],
     mira: [
-      [2, 3.2, 3.2],
-      [0.7, 2.2, 1.2],
-      [0.2, 1.6, 1.0],
+      [1.5, 2.6, 2.5],
+      [0.5, 1.6, 0.8],
+      [0.2, 1.2, 0.6],
       [mx, my + 0.1, mz - 0.1],
     ],
     fovDesde: 46,

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -35,15 +35,13 @@ import { horaDeReloj } from '../../visual/mundo3d/cielosHoraData.js';
  * cálido) hacia arriba (fondo, páramo).
  */
 export const PISOS_TERMICOS = [
-  // (Franjas ESCALADAS al valle grande — terreno 48×48, rediseño 2026-07:
-  //  el valle respira y cada piso ocupa más ladera.)
   {
     id: 'calido',
     nombre: 'Tierra caliente',
     msnm: '0–1000 m',
     tempC: '> 24 °C',
-    z0: 4.9, // borde frontal de la franja (bajo, cerca de la cámara)
-    z1: 12.4, // borde trasero
+    z0: 3.4, // borde frontal de la franja (bajo, cerca de la cámara)
+    z1: 8.5, // borde trasero
     color: '#84a83f', // verde cálido amarillento
     cresta: '#afc85a',
     vegetacion: 'platano',
@@ -54,8 +52,8 @@ export const PISOS_TERMICOS = [
     nombre: 'Clima medio',
     msnm: '1000–2000 m',
     tempC: '18–24 °C',
-    z0: -0.9,
-    z1: 4.9,
+    z0: -0.6,
+    z1: 3.4,
     color: '#4e9143', // verde vivo
     cresta: '#77b256',
     vegetacion: 'cafe',
@@ -66,8 +64,8 @@ export const PISOS_TERMICOS = [
     nombre: 'Clima frío',
     msnm: '2000–3000 m',
     tempC: '12–18 °C',
-    z0: -7.6,
-    z1: -0.9,
+    z0: -5.2,
+    z1: -0.6,
     color: '#3c7f64', // verde-azulado
     cresta: '#5fa07f',
     vegetacion: 'papa',
@@ -78,8 +76,8 @@ export const PISOS_TERMICOS = [
     nombre: 'Páramo',
     msnm: '> 3000 m',
     tempC: '< 12 °C',
-    z0: -16,
-    z1: -7.6,
+    z0: -11,
+    z1: -5.2,
     color: '#63807a', // frío grisáceo del alto andino
     cresta: '#8ba597',
     vegetacion: 'frailejon',
@@ -100,24 +98,23 @@ export function pisoEnZ(z) {
  * el centro y hacen legible el cambio de vegetación por altura). Cada una trae
  * el `tipo` que su piso siembra — la geometría la resuelve la escena. */
 export const VEGETACION_PISOS = [
-  // (Regadas por el valle grande: más matas, más aire entre ellas.)
-  { piso: 'paramo', pos: [-8.2, -11.4] },
-  { piso: 'paramo', pos: [-1.6, -12.6] },
-  { piso: 'paramo', pos: [2.4, -12.0] },
-  { piso: 'paramo', pos: [7.0, -9.6] },
-  { piso: 'paramo', pos: [-11.4, -9.0] },
-  { piso: 'frio', pos: [-8.8, -5.2] },
-  { piso: 'frio', pos: [-1.8, -5.6] },
-  { piso: 'frio', pos: [4.2, -6.6] },
-  { piso: 'frio', pos: [10.2, -3.6] },
-  { piso: 'templado', pos: [-11.0, 2.4] },
-  { piso: 'templado', pos: [-3.2, 0.2] },
-  { piso: 'templado', pos: [9.6, 1.6] },
-  { piso: 'templado', pos: [4.4, 2.6] },
-  { piso: 'calido', pos: [-11.2, 7.6] },
-  { piso: 'calido', pos: [-1.4, 9.2] },
-  { piso: 'calido', pos: [5.6, 10.8] },
-  { piso: 'calido', pos: [10.8, 6.4] },
+  { piso: 'paramo', pos: [-5.6, -7.8] },
+  { piso: 'paramo', pos: [1.2, -8.3] },
+  { piso: 'paramo', pos: [4.8, -6.6] },
+  // Los frailejones que ARROPAN al Ent de la vista del páramo (VISTA_PARAMO
+  // en [2.2, -7.4]): el filo se lee páramo de verdad, no un solo mojón.
+  { piso: 'paramo', pos: [3.3, -7.9] },
+  { piso: 'paramo', pos: [2.9, -6.6] },
+  { piso: 'paramo', pos: [-7.4, -6.9] },
+  { piso: 'frio', pos: [-6.0, -3.6] },
+  { piso: 'frio', pos: [3.0, -4.4] },
+  { piso: 'frio', pos: [-7.6, -2.4] },
+  { piso: 'templado', pos: [-2.4, 1.0] },
+  { piso: 'templado', pos: [6.2, 2.6] },
+  { piso: 'templado', pos: [-7.4, 1.2] },
+  { piso: 'calido', pos: [-7.9, 8.3] }, // corrida: su puesto viejo quedó dentro del potrero
+  { piso: 'calido', pos: [7.4, 7.2] },
+  { piso: 'calido', pos: [0.9, 8.0] },
 ].map((v) => {
   const piso = PISOS_TERMICOS.find((p) => p.id === v.piso);
   return { ...v, tipo: piso ? piso.vegetacion : 'platano' };
@@ -137,39 +134,41 @@ export const VEGETACION_PISOS = [
 const LUGARES = [
   // (Las posiciones finales las manda COMPOSICION_LUGARES — la capa del
   //  director en visual/mundo3d/direccion; estas son el respaldo crudo.)
-  { id: 'agua', pos: [1.0, 0, -2.0], escala: 1, tipo: 'quebrada' },
+  { id: 'agua', pos: [1.4, 0, -0.2], escala: 1, tipo: 'quebrada' },
   // El cafetal CON SOMBRÍO: café bajo guamo y plátano — policultivo, no hilera.
-  { id: 'cafe', pos: [6.0, 0, 0.6], escala: 1.1, tipo: 'cafetal' },
+  { id: 'cafe', pos: [4.4, 0, 1.0], escala: 1.05, tipo: 'cafetal' },
   // La milpa-PARCELA (portal MIS MATAS): maíz + fríjol + calabaza juntos,
   // leída como granja viva de Age of Empires — jamás monocultivo.
-  { id: 'cultivos', pos: [-8.4, 0, 0.8], escala: 1.3, tipo: 'milpa' },
-  { id: 'suelo', pos: [-3.6, 0, 6.8], escala: 1, tipo: 'era' },
-  { id: 'sanidad', pos: [2.8, 0, 5.6], escala: 0.95, tipo: 'huerta' },
+  { id: 'cultivos', pos: [-4.4, 0, 2.4], escala: 1.15, tipo: 'milpa' },
+  { id: 'suelo', pos: [-1.4, 0, 4.8], escala: 1, tipo: 'era' },
+  { id: 'sanidad', pos: [3.8, 0, 4.9], escala: 0.95, tipo: 'huerta' },
   // El POTRERO (portal MIS ANIMALES): apartos divididos por cercas vivas de
   // matarratón, nacedero y botón de oro; los animales regados, no amontonados.
-  { id: 'animales', pos: [-8.6, 0, 8.6], escala: 1.35, tipo: 'animales' },
-  { id: 'disenio', pos: [7.2, 0, -4.4], escala: 1.25, tipo: 'bosque' },
-  { id: 'clima', pos: [-5.0, 0, -9.4], escala: 1.05, tipo: 'veleta' },
-  // El mercado (portal VENDER), abajo en la tierra caliente, la salida a la
-  // plaza: el puesto con su toldo donde la cosecha sale a venderse.
-  { id: 'mercado', pos: [8.6, 0, 9.0], escala: 1.05, tipo: 'mercado' },
-  // El INVERNADERO (micro-mundo del semillero): arcos y plástico donde nace
-  // y se cría la matica antes de salir al lote.
-  { id: 'semillero', pos: [-6.8, 0, 6.6], escala: 1.25, tipo: 'invernadero' },
-  // El suelo vivo / red micorrízica: unos hongos que asoman = el fruto de la
-  // red bajo tierra. Toque ahí para BAJAR al mundo subterráneo.
-  { id: 'micorrizas', pos: [-5.2, 0, 1.6], escala: 1, tipo: 'hongos' },
+  // (Escala contenida: el valle cercano de la v2 no aguanta el llano de 48×48.)
+  { id: 'animales', pos: [-5.0, 0, 5.4], escala: 0.82, tipo: 'animales' },
+  { id: 'disenio', pos: [5.2, 0, -3.4], escala: 1.1, tipo: 'bosque' },
+  { id: 'clima', pos: [-3.2, 0, -6.0], escala: 1, tipo: 'veleta' },
+  // El mercado (portal VENDER), abajo en la tierra caliente, cerca de la salida
+  // a la plaza: el puesto con su toldo donde la cosecha sale a venderse.
+  { id: 'mercado', pos: [1.2, 0, 6.6], escala: 1, tipo: 'mercado' },
+  // El INVERNADERO (micro-mundo del semillero): arcos, plástico lechoso y sus
+  // mesas de germinación — donde nace y se cría la matica antes del lote.
+  { id: 'semillero', pos: [-2.6, 0, 6.2], escala: 0.9, tipo: 'invernadero' },
+  // El suelo vivo / red micorrízica, en el corazón cultivado (entre el suelo y
+  // los cultivos): unos hongos que asoman = el fruto de la red bajo tierra. Toque
+  // ahí para BAJAR al mundo subterráneo. (anti-conflicto: lugar nuevo al final.)
+  { id: 'micorrizas', pos: [-2.7, 0, 3.3], escala: 1, tipo: 'hongos' },
   // La BIOFÁBRICA (mundo real 'abono'): la pila de compost cerca del potrero
   // pero diferenciada — el ciclo estiércol→abono legible en el mapa.
-  { id: 'abono', pos: [-4.9, 0, 9.6], escala: 1, tipo: 'compost' },
+  { id: 'abono', pos: [-3.3, 0, 8.1], escala: 0.85, tipo: 'compost' },
   // El KIOSCO DEL SABER (portal APRENDER): el tablero bajo techito de paja a
   // la vera del camino de la plaza. Aún sin mundo propio en el manifiesto:
   // trae su identidad de respaldo (fallbackMundo) mientras el hub de juegos
   // abre su puerta (otro frente lo construye).
   {
     id: 'aprender',
-    pos: [7.4, 0, 4.2],
-    escala: 1.05,
+    pos: [6.4, 0, 4.6],
+    escala: 0.9,
     tipo: 'saber',
     fallbackMundo: {
       titulo: 'Aprender',
@@ -481,4 +480,6 @@ export const NARRACION = {
     'El kiosco del saber: el tablero donde la finca enseña. Aquí van llegando los juegos y las lecciones del monte.',
   casa:
     'Esta es su casa: el corazón de la finca y la puerta de sus mundos. Toque una de las seis puertas para salir a donde necesite.',
+  paramo:
+    'Ahí arriba está el páramo, con su guardián de queñua entre los frailejones. Tóquelo y él le muestra el monte entero.',
 };

--- a/src/visual/mundo3d/direccion/composicionValle.js
+++ b/src/visual/mundo3d/direccion/composicionValle.js
@@ -7,89 +7,93 @@
  * acompaña, por dónde camina el ojo. Valle3D lo consume como capa de
  * composición ENCIMA de valleData (que no se toca: otros frentes viven ahí).
  *
- * ── REDISEÑO 2026-07 (feedback del operador) ─────────────────────────────
- * "Todo muy pegado; aprovechar mejor el espacio; los animales más regados
- * pero más lejos; nada se vea monocultivo; la casa no se ve como la entrada
- * a los mundos." De ahí las cuatro leyes nuevas de esta composición:
- *
- *   1. EL VALLE RESPIRA: terreno jugable 48×48 (antes 34×34), aire mínimo
- *      ~3 u entre lugares vecinos (antes ~2), cámara de reposo más lejos.
- *   2. LA CASA ES LA PUERTA: deja de ser solo ancla — su puerta iluminada
- *      ABRE el mapa de los mundos (los 6 portales). El corazón Y la boca.
- *   3. SEIS PORTALES LEGIBLES: mis matas · mis animales · el tiempo ·
- *      vender · aprender · toda mi finca — cada uno con su pórtico de
- *      madera, su patio de tierra y su sendero desde la casa.
+ * ── REDISEÑO 2026-07 SOBRE LA BASE CERCANA (feedback del operador) ────────
+ * La cámara INMERSIVA y el paisaje denso de la v2 son sagrados: el rediseño
+ * anterior alejó la cámara y el valle quedó lejano y vacío. Esta pasada
+ * reconstruye ENCIMA de la v2 lo que sí funcionó del rediseño:
+ *   1. LA CASA ES LA PUERTA: su puerta iluminada abre el mapa de los 6
+ *      portales. El corazón Y la boca.
+ *   2. JERARQUÍA DE PORTALES: los 6 principales son VENTANAS VIVAS al mundo
+ *      (notorias, inmersivas — ver VentanasVivas); los pórticos de madera
+ *      quedan SOLO para los lugares secundarios de menos uso.
+ *   3. EL PÁRAMO SE VE: el acceso al páramo es el páramo MISMO, arriba, con
+ *      el Ent-queñua magnífico — una vista al mundo, no un letrero.
  *   4. LA FINCA ES POLICULTIVO: potrero con cercas vivas, biofábrica con su
- *      pila (el ciclo estiércol→abono legible), invernadero como micro-mundo,
- *      milpa como parcela viva estilo "granja de Age of Empires".
+ *      pila, invernadero como micro-mundo, milpa de tres hermanas y cafetal
+ *      con sombrío. Nada se lee monocultivo.
  *
  * ── LOS TRES CRITERIOS DEL ENCUADRE ──────────────────────────────────────
- * La cámara de reposo mira desde [14.6, 12.2, 18.8] hacia [0, 2.0, 2.0]:
+ * La cámara de reposo mira desde [10.5, 9, 13.5] hacia [0, 1.6, 1.4]:
  * el frente (+z, tierra caliente) queda CERCA y abajo; la ladera trepa al
  * páramo (-z) al fondo. De ahí las tres franjas de dirección:
  *
  *   1. LO DIARIO, A LA MANO (frente, cerca de la casa): lo que el campesino
- *      toca todos los días — las eras, el invernadero, la huerta.
- *   2. LO SEMANAL, A MEDIA LADERA: la milpa, el cafetal, el agua, y el
- *      potrero de los animales (más lejos, con su propio aire).
+ *      toca todos los días — el corral, las eras, el semillero, la huerta.
+ *      La finca real es así: el trajín vive alrededor de la casa.
+ *   2. LO SEMANAL, A MEDIA LADERA: la milpa, el cafetal, el agua. Se sube
+ *      a ellos; el ojo los alcanza sin estorbar el frente.
  *   3. LO CONTEMPLATIVO, AL FONDO: el monte, la veleta en el filo del
  *      páramo. Son horizonte: se miran más de lo que se tocan.
+ *
+ * ── EL ANCLA: LA CASA ────────────────────────────────────────────────────
+ * Toda finca se organiza alrededor de su casa, y el valle no tenía una: el
+ * ojo descansaba en pasto vacío. La casa campesina (encalada, zócalo pintado,
+ * techo de teja, la ventana con luz cálida) va donde la mirada de reposo
+ * aterriza — no es un mundo navegable, es el HOGAR: el punto de silencio
+ * del cuadro. Los senderos nacen de ella: el camino dice qué se usa.
  */
 
-/* ── 1. LA CASA (el corazón Y la puerta de los mundos) ───────────────────
-   Apenas a la izquierda del punto de mira de reposo ([0, 2.0, 2.0]) para
-   componer por tercios: la casa descansa, la quebrada brilla a su derecha.
-   Ya NO es solo ancla: su puerta iluminada es NAVEGABLE — tocarla abre el
-   mapa de los 6 portales. `escala` la agranda a la medida del valle nuevo. */
+/* ── 1. LA CASA (ancla de composición, no navegable) ─────────────────────
+   Apenas a la izquierda del punto de mira de reposo ([0, 1.6, 1.4]) para
+   componer por tercios: la casa descansa, la quebrada brilla a su derecha,
+   y el faro de la alerta queda con aire propio al frente. */
 export const CASA_VALLE = {
-  pos: [-1.4, 3.0], // [x, z] — la y la da el terreno
+  pos: [-0.9, 2.6], // [x, z] — la y la da el terreno
   rotY: 0.42, // el corredor mira hacia la cámara de reposo (suroriente)
-  escala: 1.3, // la casa creció con el valle: sigue mandando el cuadro
+  // La casa creció un pelo (es la puerta de los mundos, tiene que mandar el
+  // cuadro) sin robarle aire al valle cercano de la v2.
+  escala: 1.12,
 };
 
 /* ── 2. DISPOSICIÓN COMPUESTA de los lugares ─────────────────────────────
-   Override de posición [x, z] por id de mundo — EL MAPA COMPLETO del valle
-   grande. Reglas duras que cumplen estas coordenadas:
-     · aire mínimo ~3 u entre lugares vecinos (el valle regado que pidió el
-       operador — antes era ~2 u y todo se leía apeñuscado);
-     · cada lugar respeta su piso térmico (valleData.PISOS_TERMICOS, ya
-       escalados al terreno 48×48);
-     · lo diario rodea la casa; el potrero va lejos con su propio llano; las
-       salidas (mercado) van al borde del cuadro; el páramo manda arriba. */
+   Override de posición [x, z] por id de mundo. Solo se mueven los que
+   estaban puestos sin componer; los bien contados (agua sobre la quebrada,
+   la veleta en el filo del páramo, el bosque trepando al frío, el cafetal
+   en su piso) se quedan. Reglas duras que cumplen estas coordenadas:
+     · aire mínimo ~2 u entre lugares vecinos (los rótulos ya anti-colisionan
+       en pantalla; esto compone la GEOMETRÍA, no las etiquetas);
+     · cada lugar respeta su piso térmico (valleData.PISOS_TERMICOS);
+     · lo diario rodea la casa; las salidas (mercado) van al borde del cuadro. */
 export const COMPOSICION_LUGARES = {
-  // La milpa-parcela (portal MIS MATAS): media ladera izquierda, clima medio.
-  cultivos: [-8.4, 0.8],
-  // El potrero (portal MIS ANIMALES): el llano frontal-izquierdo, LEJOS y
-  // ancho — los animales regados en sus apartos de cerca viva.
-  animales: [-8.6, 8.6],
-  // La biofábrica (pila de compost): CERCA del potrero pero DIFERENCIADA —
-  // el viaje del estiércol a la pila se lee en un sendero corto.
-  abono: [-4.9, 9.6],
+  // El POTRERO (portal MIS ANIMALES) cierra la esquina izquierda del frente:
+  // apartos con cerca viva y el hato regado — pisa ancho, por eso gana medio
+  // paso de aire respecto al corral viejo.
+  animales: [-5.7, 6.1],
+  // La BIOFÁBRICA (pila de compost): detrás del potrero hacia el frente,
+  // CERCA de los animales pero diferenciada — el viaje del estiércol a la
+  // pila se lee en un ramal corto de sendero.
+  abono: [-3.3, 8.1],
+  // El INVERNADERO (micro-mundo del semillero): al frente de la casa, a la
+  // mano — la matica se cría cerca. (Cedió su puesto viejo al potrero.)
+  semillero: [-0.6, 6.6],
   // Las eras al frente-izquierda de la casa: donde el faro del día se lee solo.
-  suelo: [-3.6, 6.8],
-  // El invernadero (micro-mundo del semillero): entre las eras y el potrero,
-  // a la mano de la casa — la matica se cría cerca y el túnel SE VE (corrido
-  // del frente de la píldora de la alerta, que le tapaba los arcos).
-  semillero: [-6.8, 6.6],
+  // (Un paso más allá de la casa: la píldora de la alerta — anclada aquí —
+  //  pisaba el techo desde la cámara de reposo; ahora el faro respira solo.)
+  suelo: [-2.3, 5.5],
+  // La huerta ES "la huerta de la casa" (su propia narración): pegada a ella.
+  sanidad: [3.4, 4.4],
+  // El mercado es LA SALIDA a la plaza: borde derecho-frontal, el camino que
+  // se va del cuadro. Antes tapaba el centro-bajo del encuadre.
+  mercado: [4.9, 6.3],
+  // El KIOSCO DEL SABER (portal APRENDER): a la vera del camino de la plaza,
+  // el tablero bajo techito de paja donde la finca enseña.
+  aprender: [6.4, 4.6],
   // Los hongos en el corazón cultivado, con aire de la casa y de la milpa.
-  micorrizas: [-5.2, 1.6],
-  // La huerta ES "la huerta de la casa": pegada a ella, del lado del sol.
-  sanidad: [2.8, 5.6],
-  // El mercado (portal VENDER) es LA SALIDA a la plaza: borde derecho-frontal,
-  // el camino que se va del cuadro.
-  mercado: [8.6, 9.0],
-  // El kiosco del saber (portal APRENDER): a la vera del camino de la plaza —
-  // el tablero bajo el árbol donde se aprende y se juega.
-  aprender: [7.4, 4.2],
-  // El cafetal con sombrío: clima medio, subiendo hacia el monte.
-  cafe: [6.0, 0.6],
-  // El monte (portal TODA MI FINCA): la arboleda trepando al clima frío.
-  disenio: [7.2, -4.4],
-  // La toma de agua sobre la quebrada, donde el cauce cruza el clima frío.
-  agua: [1.0, -2.0],
-  // La veleta (portal EL TIEMPO): arriba en el filo del páramo, donde se lee
-  // el cielo. Sola, con el horizonte entero para ella.
-  clima: [-5.0, -9.4],
+  // (Corridos un paso al monte: desde la cámara de reposo quedaban justo
+  //  DETRÁS de la píldora de la alerta y su chip nunca se veía.)
+  micorrizas: [-3.8, 3.9],
+  // La milpa cede un paso a la izquierda para darle aire a los hongos.
+  cultivos: [-5.2, 2.2],
 };
 
 /**
@@ -108,11 +112,13 @@ export function componerMundos(mundos) {
   });
 }
 
-/* ── 3. LOS 6 PORTALES (las puertas de la finca) ─────────────────────────
-   La promesa del valle en seis puertas legibles: cada portal es un LUGAR
-   con pórtico de madera (dos pies derechos + dintel + farolito), su patio
-   de tierra pisada y su sendero desde la casa. La puerta de la casa abre
-   este mismo mapa como panel. `id` = el mundo del valle que surte el portal. */
+/* ── 3. LOS 6 PORTALES (las puertas grandes de la finca) ─────────────────
+   La promesa del valle en seis puertas legibles: mis matas · mis animales ·
+   el tiempo · vender · aprender · toda mi finca. La puerta de la casa abre
+   este mapa como panel, y en la ESCENA cada portal es una VENTANA VIVA al
+   mundo (jerarquía del operador: notorios e inmersivos — los pórticos de
+   madera quedan solo para lo secundario). `id` = el mundo que surte el
+   portal. */
 export const PORTALES_VALLE = [
   { id: 'cultivos', nombre: 'Mis matas', emoji: '🌱' },
   { id: 'animales', nombre: 'Mis animales', emoji: '🐄' },
@@ -122,108 +128,126 @@ export const PORTALES_VALLE = [
   { id: 'disenio', nombre: 'Toda mi finca', emoji: '🌳' },
 ];
 
+/* Los lugares SECUNDARIOS que sí llevan pórtico de madera (la puerta humilde
+   del patio de trabajo): lo de menos uso. Los 6 principales NO van aquí —
+   ellos tienen ventana viva — ni el páramo, que se accede por su propia
+   vista (el Ent magnífico arriba). */
+export const PORTICOS_SECUNDARIOS = ['suelo', 'sanidad', 'semillero', 'abono', 'agua', 'micorrizas'];
+
+/* ── 3b. LA VISTA DEL PÁRAMO (el acceso de arriba) ───────────────────────
+   Regla del operador: el acceso al páramo ES el páramo visible — el
+   Ent-queñua MAGNÍFICO parado en el filo, rodeado de frailejones, no un
+   torii. Tocarlo entra al mundo del monte ('disenio': toda mi finca, de
+   donde se cuida el páramo). */
+export const VISTA_PARAMO = {
+  punto: [2.2, -7.4], // el filo alto, a la derecha de la veleta: se ve entero
+  escala: 0.62, // el Ent mide ~6 u a escala 1: aquí corona sin tapar el cielo
+  mundoId: 'disenio',
+};
+
 /* ── 4. LOS SENDEROS (la mano del campesino sobre el terreno) ────────────
    Caminos de tierra pisada que NACEN de la casa: el rastro honesto del uso
-   diario. Cada PORTAL tiene su sendero (la puerta se camina, no se adivina);
-   el ramal potrero→pila cuenta el ciclo estiércol→abono. Waypoints [x, z];
+   diario. No son UI — son el valle contando qué se camina. Waypoints [x, z];
    la y la posa el terreno. `frugal: true` = también en gama media/baja
-   (los seis del portal + el ciclo del abono); el resto solo donde sobra GPU. */
+   (los principales); el resto solo donde sobra GPU. */
 export const SENDEROS_VALLE = [
   {
-    id: 'trajin', // casa → eras → invernadero → potrero: el circuito de la mañana
-    puntos: [[-1.4, 3.4], [-3.4, 6.4], [-6.2, 6.4], [-7.8, 7.6], [-8.4, 8.4]],
+    id: 'trajin', // casa → eras → la tranquera del potrero: el circuito de la mañana
+    puntos: [[-0.9, 3.0], [-2.0, 5.1], [-3.0, 5.9], [-3.6, 6.4]],
     frugal: true,
   },
   {
-    id: 'abono', // potrero → la pila: el viaje del estiércol al abono
-    puntos: [[-7.4, 9.0], [-6.2, 9.5], [-5.2, 9.6]],
+    id: 'abono', // la tranquera → la pila: el viaje del estiércol al abono
+    puntos: [[-3.6, 6.7], [-3.4, 7.4], [-3.3, 8.0]],
     frugal: true,
   },
   {
-    id: 'plaza', // casa → huerta → el kiosco → mercado → y SALE del cuadro
-    puntos: [[-0.9, 3.3], [1.2, 4.4], [2.8, 5.2], [5.2, 4.8], [7.3, 5.4], [8.4, 8.6], [9.6, 11.8]],
+    id: 'vivero', // eras → el invernadero (la matica se cría al lado)
+    puntos: [[-1.9, 5.6], [-1.2, 6.1], [-0.7, 6.5]],
+    frugal: false,
+  },
+  {
+    id: 'plaza', // casa → huerta → mercado → y SALE del cuadro (a la vereda)
+    puntos: [[-0.4, 2.9], [1.4, 4.0], [3.2, 4.7], [4.8, 6.2], [6.6, 7.8]],
     frugal: true,
+  },
+  {
+    id: 'saber', // el desvío de la plaza al kiosco del tablero
+    puntos: [[3.4, 4.8], [4.9, 4.6], [6.2, 4.6]],
+    frugal: false,
   },
   {
     id: 'milpa', // casa → los hongos → la milpa (la subida del lote)
-    puntos: [[-1.9, 2.9], [-4.6, 1.8], [-6.8, 1.0], [-8.2, 0.8]],
-    frugal: true,
-  },
-  {
-    id: 'monte', // casa → cafetal → el monte (toda mi finca)
-    puntos: [[-1.0, 2.4], [2.0, 1.4], [5.4, 0.6], [6.8, -2.2], [7.2, -4.2]],
-    frugal: true,
-  },
-  {
-    id: 'paramo', // casa → la veleta: la subida al filo donde se lee el cielo
-    puntos: [[-1.8, 2.4], [-3.0, -1.0], [-3.8, -4.6], [-4.6, -7.6], [-5.0, -9.2]],
-    frugal: true,
+    puntos: [[-1.3, 2.5], [-3.6, 3.7], [-5.0, 2.4]],
+    frugal: false,
   },
   {
     id: 'agua', // casa → la toma de la quebrada (el viaje del balde)
-    puntos: [[-0.8, 2.2], [0.2, 0.4], [0.9, -1.6]],
+    puntos: [[-0.5, 2.2], [0.5, 1.0], [1.3, 0.1]],
     frugal: false,
   },
 ];
 
-/* ── 5. LOS PATIOS (tierra pisada bajo cada lugar navegable) ─────────────
+/* ── 4. LOS PATIOS (tierra pisada bajo cada lugar navegable) ─────────────
    El suelo desnudo donde se trabaja: la señal diegética de "aquí se llega"
    — el sendero desemboca en un patio, el patio sostiene el lugar. Afordancia
    sin UI: se entiende sin leer nada. */
 export const PATIO = {
-  radioBase: 1.0, // × escala del lugar (creció con el valle)
+  radioBase: 0.92, // × escala del lugar
   color: '#96703f', // tierra pisada: más clara que el pasto, más viva que el barro
   opacidad: 0.42,
 };
 
-/* ── 6. JERARQUÍA DE PERSONAJES (la ley, en números) ─────────────────────
+/* ── 5. JERARQUÍA DE PERSONAJES (la ley, en números) ─────────────────────
    ANGELITA GUÍA — y es UNA SOLA (feedback 2026-07-16: se veían tres
    abejitas; las laterales las quita el dueño del dashboard). La del valle
-   es la central: MÁS GRANDE que antes (se veía diminuta), en POSICIÓN DE
-   CALMA sobre el corredor de la casa (no husmeando errática), con su luz
-   propia que invita a tocarla. Los demás son VECINOS con casa propia: cada
-   uno vive en su rincón del valle con presencia digna, y la puesta en
-   escena — no el tamaño de Angelita — dice quién guía. */
+   es la central: en POSICIÓN DE CALMA sobre el patio de la casa (no
+   husmeando errática), algo más grande, con su luz propia que invita a
+   tocarla — tocarla es hablarle a la finca. Los demás son VECINOS con casa
+   propia: cada uno vive en su rincón del valle con presencia digna, y la
+   puesta en escena — no el tamaño de Angelita — dice quién guía. */
 export const JERARQUIA_PERSONAJES = {
   /** La guía del valle: la única con follow de cámara y luz propia. */
   protagonista: 'abeja-angelita',
   /** Tamaño vivo de Angelita (px del billboard; crece con su energía).
-      Subido de [44,58]: en el valle grande se leía diminuta. */
-  protagonistaPx: [58, 76],
+      Subido de [44,58]: la anfitriona de la casa-puerta se veía tímida. */
+  protagonistaPx: [50, 66],
   /** La luz cálida que la sigue: SOLO ella ilumina (perfil.luzBeacon). */
-  luzProtagonista: { color: '#ffdda6', intensidad: 1.0, alcance: 4.2 },
-  /** Techo de un vecino (px): nunca el tamaño pleno ni el primer plano
-      de Angelita. */
+  luzProtagonista: { color: '#ffdda6', intensidad: 1.0, alcance: 4.0 },
+  /** Techo de un vecino (px): nunca el tamaño pleno de Angelita ni su
+      primer plano. */
   vecinoMaxPx: 44,
   /** Los vecinos viven en SUS lugares (monte, quebrada, matorral), nunca en
       el centro del encuadre (radio en unidades de mundo alrededor de la mira). */
-  radioSagradoCentro: 4.0,
-  /** Los vecinos jamás capturan toques ni voz: presencia, no interfaz.
-      (Angelita SÍ: tocarla es hablarle a la finca — ella es la interfaz.) */
+  radioSagradoCentro: 3.2,
+  /** Los vecinos jamás capturan toques ni voz: presencia, no interfaz. */
   interactivos: false,
 };
 
-/* ── 7. LOS VECINOS DEL VALLE (la puesta en escena de los personajes) ─────
+/* ── 6. LOS VECINOS DEL VALLE (la puesta en escena de los personajes) ─────
    Personajes rubber-hose, cada uno EN SU CASA del valle: la rana en la
    quebrada, el perezoso en la arboleda, el jaguar en el filo. Data-driven
    contra CREATURES: un slug ausente no monta nada (las ramas de personajes
    mejoran el dibujo al mergear y este mapa ni se entera).
 
-   `franjas` = cuándo sale (null = siempre): el jaguar es un aparecido del
-   amanecer, el atardecer y la niebla — verlo es un premio, no un mueble.
+   `franjas` = cuándo sale (null = siempre): el borugo es crepuscular y el
+   jaguar es un aparecido del amanecer, el atardecer y la niebla — verlo es
+   un premio, no un mueble. Eso también es jerarquía: la frecuencia cuenta.
 
-   Ubicaciones al día con el VALLE GRANDE (cámara de reposo [14.6,12.2,18.8]
-   → [0,2,2], fov 40): todas a la vista, ninguna detrás de la cordillera
-   (los picos viven en z≤-21) ni pisando un lugar compuesto (aire ≥3 u del
-   mapa COMPOSICION_LUGARES). */
+   Ubicaciones verificadas contra la cámara de reposo ([10.5,9,13.5] →
+   [0,1.6,1.4], fov 40): todas a la vista, ninguna detrás de la cordillera
+   (los picos viven en z≤-15) ni tapada por un lugar compuesto (aire ≥2u del
+   mapa COMPOSICION_LUGARES). El precedente de la sierra (3 de 4 árboles
+   ocultos tras el macizo) no se repite aquí. */
 export const VECINOS_VALLE = [
   // NOTA (rediseño 2026-07): el oso rubber-hose café se RETIRÓ del valle por
-  // decisión del operador. Este slot de ancla ([7.8, -2.0], px≈44) queda
-  // reservado para el CÓNDOR (Vultur gryphus, en curso en el pase de arte):
-  // planea alto sobre el filo — presencia diurna del páramo.
+  // decisión del operador. Su presencia mayor la toma el CÓNDOR (Vultur
+  // gryphus), que no vive aquí sino en el CIELO: CondorBillboard en órbita
+  // térmica sobre el páramo (lo monta Valle3D — un vecino de aire, no de
+  // suelo).
   {
     slug: 'perezoso',
-    punto: [4.8, -3.2], // colgado a la falda de la arboleda del monte
+    punto: [3.1, -2.2], // colgado a la falda de la arboleda, detrás del oso
     px: 30,
     factor: 8,
     dy: 1.5, // vive arriba, en las ramas
@@ -231,7 +255,7 @@ export const VECINOS_VALLE = [
   },
   {
     slug: 'ardilla',
-    punto: [4.4, -1.4], // entre el cafetal y el monte, siempre de paso
+    punto: [3.2, -1.2], // entre el cafetal y el monte, siempre de paso
     px: 26,
     factor: 7.5,
     dy: 0.25,
@@ -239,7 +263,7 @@ export const VECINOS_VALLE = [
   },
   {
     slug: 'rana-andina',
-    punto: [3.4, 3.0], // la orilla baja de la quebrada (el agua es su casa)
+    punto: [2.4, 2.8], // la orilla baja de la quebrada (el agua es su casa)
     px: 22,
     factor: 6.5,
     dy: 0.18,
@@ -247,7 +271,7 @@ export const VECINOS_VALLE = [
   },
   {
     slug: 'morrocoy',
-    punto: [4.8, 8.2], // la tierra caliente del frente, a paso lento
+    punto: [3.2, 6.8], // la tierra caliente del frente, a paso lento
     px: 26,
     factor: 7,
     dy: 0.2,
@@ -255,7 +279,7 @@ export const VECINOS_VALLE = [
   },
   {
     slug: 'jaguar',
-    punto: [-8.6, -7.2], // el filo del páramo, lejos, del lado de la veleta: el místico
+    punto: [-5.8, -4.6], // el filo del páramo, lejos, del lado de la veleta: el místico
     px: 40,
     factor: 10, // lejos pero con silueta: verlo tiene que sentirse
     dy: 0.3,


### PR DESCRIPTION
## Qué hace

El rediseño anterior del valle (#2529) alejó la cámara y re-autoró el terreno a 48×48: el valle quedó lejano/vacío. Esta rama **restaura la escena v2 buena** (`6f7f839b`: cámara cercana e inmersiva `[10.5,9,13.5]→[0,1.6,1.4]`, terreno 34×34, paisaje denso) y **re-aplica encima solo lo bueno** del rediseño.

### Restaurado a v2
Terreno, pose de cámara, pisos térmicos, barrido del director, senderos/patios/vecinos.

### Re-aplicado sobre v2 (recompuesto al mapa 34×34)
- **Potrero** con cercas vivas (matarratón/nacedero/botón de oro) + hato regado por apartos, escala contenida.
- **Biofábrica** (pila por capas + carretilla) cerca del potrero pero diferenciada; ramal de sendero tranquera→pila.
- **Invernadero** micro-mundo (plástico lechoso, mesas de germinación).
- **Milpa** tres-hermanas estilo parcela AoE + **cafetal con sombrío** (guamo+plátano) — cero monocultivo.
- **Kiosco del saber** (portal Aprender) a la vera del camino de la plaza.
- **Una sola Angelita**, en calma sobre el patio de la casa, tocable (= hablarle a la finca).
- **La casa abre el panel de los 6 portales** (verificado con captura).

### Jerarquía de portales (regla nueva del operador)
- Los **6 principales** (mis matas · mis animales · el tiempo · vender · aprender · toda mi finca) = **VENTANAS VIVAS**: arco de vegetación con el lente del mundo respirando adentro. Notorios e inmersivos, tocables.
- **Pórticos de madera SOLO** en lo secundario (eras, huerta, vivero, pila, agua, hongos). El reparto fino queda para la auditoría multi-experto.
- **El acceso al páramo = el páramo VISIBLE**: el Ent-queñua magnífico (mallas reales de EntQuenua, tier-gated) parado entre frailejones en el filo; tocarlo entra al monte.

### Fauna nueva
- **Oso NEGRO biopunk** (GuardianEspiritu) visible en el borde del monte — el rubber-hose café queda retirado (decisión previa del operador).
- **Cóndor** que alterna: térmica en vuelo (~45 s) y percha en el pico de la cordillera (~16 s).

### Paneo
La lentitud reportada de la v2: damping 0.08→0.12, regreso 0.042→0.052.

### Fix de integra
`src/App.jsx` tenía el case `mockup_criaturas_nocturnas` con JSX sin cerrar (cicatriz de merge): **App.jsx no parseaba y el dev renderizaba negro**. Cerrado.

## Verificación
- `npm run build:prod` VERDE · eslint limpio · 23/23 tests del valle.
- **Capturas VIVAS de DÍA** (dev + chromium del sistema + swiftshader, hora forzada 11:00): valle CERCANO y POBLADO en desktop y móvil; panel de 6 puertas abre al tocar la casa (probe programático sobre `.valle-panel--casa`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)