### PR TITLE
art(criaturas): trío de control biológico rubber-hose en Defensores y Milpa

### DIFF
--- a/src/components/juego/DefensoresFincaScreen.jsx
+++ b/src/components/juego/DefensoresFincaScreen.jsx
@@ -36,6 +36,21 @@ import {
 import { fincaVivaHomePerfilActivo } from '../../config/fincaVivaHomeFlag';
 import { agentSounds, isSoundEnabled } from '../../services/agentSoundService';
 import { recordGameStart, recordGameComplete } from '../../services/usageTelemetryService';
+import { Crisopa } from '../../visual/creatures/Crisopa.jsx';
+import { Trichogramma } from '../../visual/creatures/Trichogramma.jsx';
+import { Sirfido } from '../../visual/creatures/Sirfido.jsx';
+
+/**
+ * Los aliados de control biológico que ya tienen su criatura rubber-hose fiel:
+ * en el selector de benéficos se dibujan de verdad (protagonistas), en vez del
+ * emoji genérico. Solo visual — el id y la mecánica del par no cambian.
+ * El resto de benéficos conserva su emoji hasta que tengan su propio dibujo.
+ */
+const CRIATURA_BENEFICO = {
+  crisopa: Crisopa,
+  trichogramma: Trichogramma,
+  sirfido: Sirfido,
+};
 
 // Dimensiones lógicas del LIENZO visible (la cámara recorta el mundo a esto).
 const VIEW_W = 720;
@@ -1054,6 +1069,7 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
           const ayuda = plagaQueControla
             ? `${b.nombre}: controla al ${plagaQueControla.toLowerCase()}`
             : b.nombre;
+          const Criatura = CRIATURA_BENEFICO[b.id];
           return (
             <button
               key={b.id}
@@ -1066,7 +1082,9 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
               title={ayuda}
               className="df-beneficio"
             >
-              <span className="df-beneficio-emoji" aria-hidden="true">{b.emoji}</span>
+              <span className="df-beneficio-emoji" aria-hidden="true">
+                {Criatura ? <Criatura size={38} title="" /> : b.emoji}
+              </span>
               <span className="df-beneficio-nombre">{b.nombre}</span>
             </button>
           );

--- a/src/components/juego/MilpaSimulator.jsx
+++ b/src/components/juego/MilpaSimulator.jsx
@@ -56,7 +56,47 @@ import { recordGameStart, recordGameComplete } from '../../services/usageTelemet
 // No se reescribe ninguna mecánica: es cableado/composición.
 import JuegoLaMilpa from '../../mockups/JuegoLaMilpa';
 
+import { Crisopa } from '../../visual/creatures/Crisopa.jsx';
+import { Trichogramma } from '../../visual/creatures/Trichogramma.jsx';
+import { Sirfido } from '../../visual/creatures/Sirfido.jsx';
+
 import './milpa.css';
+
+/**
+ * Los aliados naturales que llegan SOLOS cuando la finca tiene variedad: la
+ * crisopa y el sírfido se comen los áfidos, la avispita Trichogramma parasita
+ * los huevos de las plagas. Es control biológico REAL — un policultivo diverso
+ * les da flores y refugio, y ellos hacen la vigilancia gratis. Puro visual y
+ * educativo; no toca la mecánica del simulador.
+ */
+const ALIADOS_BIOLOGICOS = [
+  { Criatura: Sirfido, nombre: 'Sírfido', hace: 'come áfidos y poliniza' },
+  { Criatura: Crisopa, nombre: 'Crisopa', hace: 'caza mosca blanca y pulgón' },
+  { Criatura: Trichogramma, nombre: 'Avispita', hace: 'ataca el huevo de la plaga' },
+];
+
+/** Tira de los aliados de control biológico que atrae el policultivo. */
+function AliadosNaturales() {
+  return (
+    <div
+      className="rounded-3xl border border-lime-300/25 bg-emerald-950/40 p-3 milpa-fade-in"
+      data-testid="milpa-aliados-naturales"
+    >
+      <p className="mb-2 text-center text-[11px] font-black uppercase tracking-wide text-lime-300/90">
+        Cuando hay variedad, llegan solos los aliados
+      </p>
+      <div className="flex items-start justify-around gap-2">
+        {ALIADOS_BIOLOGICOS.map(({ Criatura, nombre, hace }) => (
+          <div key={nombre} className="flex flex-1 flex-col items-center gap-1 text-center">
+            <Criatura size={52} title={nombre} className="milpa-brota" />
+            <span className="text-[11px] font-black text-emerald-100">{nombre}</span>
+            <span className="text-[9px] leading-tight text-emerald-300/80">{hace}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 /** Acentos por color de cultivo (estética Chagra). */
 const ACENTO = {
@@ -501,6 +541,8 @@ export default function MilpaSimulator({ onBack, onHome }) {
                 Jugar «Las tres hermanas» (modo ilustrado)
               </button>
             </header>
+
+            <AliadosNaturales />
 
             <section className="grid grid-cols-1 gap-3">
               <h3 className="text-sm font-black text-emerald-200">Sistemas</h3>

--- a/src/visual/creatures/Crisopa.jsx
+++ b/src/visual/creatures/Crisopa.jsx
@@ -1,0 +1,119 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+import { RH_INK, Sonrisa } from './_rubberhose.jsx';
+
+/* Crisopa — Chrysoperla externa (Chrysopidae, "león de los áfidos"). El
+   depredador de ALAS VERDES TRANSLÚCIDAS: dos pares de alas de encaje que
+   guarda a dos aguas sobre el cuerpo esbelto, y sus OJOS DORADOS metálicos —
+   la firma de la crisopa. Su larva atrapa mosca blanca y pulgones con las
+   mandíbulas curvas; el adulto vuela liviano entre las hojas. Controlador
+   biológico real de la agroecología colombiana. Rubber-hose de la casa.
+
+   Vista 3/4 desde arriba: cabeza arriba (ojos dorados), cuerpo esbelto hacia
+   abajo, y las cuatro alas de encaje abiertas hacia atrás como una carpa. */
+const VIEWBOX = '-30 -20 60 44';
+
+/* Un ala de encaje (translúcida y venada). El grupo EXTERNO hace el espejo
+   estático (scaleX según `lado`); el grupo INTERNO lleva la cadencia crt-fwing
+   (que anima su propio scaleX al plegarse) sin pelear con el espejo. `sombra`
+   la tinta un punto más oscura (el par trasero, al fondo). */
+function AlaEncaje({ animated, lado = 1, sombra = false, larga = true }) {
+  const verde = sombra ? '#7fbf50' : '#b6ea7c';
+  const L = larga ? 1 : 0.78;
+  const clase = animated ? 'crt-fwing' : undefined;
+  // Ala dibujada hacia la derecha; el grupo externo la espeja para el lado izq.
+  const d = `M0,-2 C${9 * L},-6 ${20 * L},-3 ${24 * L},4 C${22 * L},9 ${10 * L},7 0,3 Z`;
+  return (
+    <g style={{ transform: `scaleX(${lado})` }}>
+      <g className={clase} style={{ transformBox: 'fill-box', transformOrigin: 'left center' }}>
+        <path d={d} fill={verde} opacity={sombra ? 0.5 : 0.6} stroke="#5f9b39" strokeWidth="0.7" />
+        {/* venación de encaje: nervaduras + cruces finas */}
+        <g fill="none" stroke="#4d8a2c" strokeWidth="0.5" opacity="0.7">
+          <path d={`M1,-1 C${8 * L},-3 ${16 * L},-2 ${22 * L},2`} />
+          <path d={`M1,1.4 C${8 * L},1 ${15 * L},2 ${21 * L},4`} />
+          <path d={`M${5 * L},-2.6 l0.6,3 M${10 * L},-2.2 l0.5,3.4 M${15 * L},-1 l0.4,3.4 M${19 * L},0.6 l0.6,3`} />
+        </g>
+      </g>
+    </g>
+  );
+}
+
+export function Crisopa({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Crisopa',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      {/* patas finas (3 pares) que asoman del cuerpo esbelto */}
+      <g stroke={RH_INK} strokeWidth="0.9" strokeLinecap="round" opacity="0.85">
+        <path d="M-2,2 L-8,5 M-2,6 L-8,9 M2,2 L8,5 M2,6 L8,9" />
+      </g>
+      {/* par de alas TRASERO (al fondo, un punto más oscuro y algo más corto) */}
+      <g transform="translate(0,3)">
+        <AlaEncaje animated={animated} lado={-1} sombra larga={false} />
+        <AlaEncaje animated={animated} lado={1} sombra larga={false} />
+      </g>
+      {/* cuerpo esbelto vertical (abdomen que se afina hacia la cola) */}
+      <path
+        d="M-2.4,-6 C-3.2,0 -2.4,8 0,13 C2.4,8 3.2,0 2.4,-6 Z"
+        fill="#9dd66a"
+        stroke="#5f9b39"
+        strokeWidth="0.6"
+      />
+      <path d="M0,-4 L0,11" stroke="#6fae42" strokeWidth="0.5" opacity="0.6" />
+      {/* par de alas DELANTERO (encima, translúcido claro) */}
+      <AlaEncaje animated={animated} lado={-1} />
+      <AlaEncaje animated={animated} lado={1} />
+      {/* tórax + cabeza (arriba) */}
+      <ellipse cx="0" cy="-6.5" rx="3.4" ry="3" fill="#8fce63" stroke="#5f9b39" strokeWidth="0.6" />
+      <circle cx="0" cy="-11.5" r="4.2" fill="#a7dd77" stroke="#5f9b39" strokeWidth="0.6" />
+      {/* OJOS DORADOS metálicos — la firma de la crisopa (con brillo rubber-hose) */}
+      <circle cx="-2.2" cy="-12" r="2.2" fill="#e8b422" stroke={RH_INK} strokeWidth="0.7" />
+      <circle cx="2.2" cy="-12" r="2.2" fill="#e8b422" stroke={RH_INK} strokeWidth="0.7" />
+      <circle cx="-2.8" cy="-12.8" r="0.75" fill="#fffdf3" />
+      <circle cx="1.6" cy="-12.8" r="0.75" fill="#fffdf3" />
+      {/* sonrisa breve de la casa */}
+      <Sonrisa cx={0} cy={-9} w={3} prof={1.1} ink={RH_INK} />
+      {/* antenas largas, filiformes, hacia arriba con bulbito */}
+      <g fill="none" stroke={RH_INK} strokeWidth="0.8" strokeLinecap="round">
+        <path d="M-2.4,-14.6 C-6,-18 -9,-19 -12,-18.4" />
+        <path d="M2.4,-14.6 C6,-18 9,-19 12,-18.4" />
+      </g>
+      <circle cx="-12" cy="-18.4" r="0.85" fill={RH_INK} />
+      <circle cx="12" cy="-18.4" r="0.85" fill={RH_INK} />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="crisopa">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="crisopa" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Crisopa;

--- a/src/visual/creatures/Sirfido.jsx
+++ b/src/visual/creatures/Sirfido.jsx
@@ -1,0 +1,102 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+import { RH_INK, Sonrisa } from './_rubberhose.jsx';
+
+/* Sírfido / mosca de las flores — Syrphidae. EL IMPOSTOR: se disfraza de abeja
+   con su abdomen de bandas AMARILLAS Y NEGRAS, pero es una MOSCA — y se le nota
+   en tres señas fieles: UN solo par de alas (no dos), OJOS enormes de mosca que
+   le tapan casi toda la cara, y antenitas MINÚSCULAS (la abeja las tiene largas;
+   él no). Doble aliado: la cría se come los áfidos y el adulto poliniza. Queda
+   suspendido en el aire batiendo alas rapidísimo. Controlador biológico real de
+   la agroecología colombiana. Rubber-hose de la casa. */
+const VIEWBOX = '-30 -22 60 44';
+
+export function Sirfido({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Mosca de las flores (sírfido)',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const alaR = animated ? 'crt-wing' : undefined;
+  const alaL = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      {/* patitas cortas colgando (queda suspendido en el aire) */}
+      <g stroke={RH_INK} strokeWidth="1.1" strokeLinecap="round" opacity="0.9">
+        <path d="M-4,10 L-6,15 M0,11 L0,16 M4,10 L6,15" />
+      </g>
+      {/* UN SOLO PAR de alas (seña de mosca), extendidas y translúcidas */}
+      <g className={alaL} style={{ transformOrigin: 'right center' }}>
+        <path d="M-3,-4 C-16,-11 -26,-9 -25,-3 C-24,1 -14,1 -3,-1 Z"
+          fill="#eaf3f7" opacity="0.66" stroke="#9db8c2" strokeWidth="0.7" />
+        <path d="M-6,-3.5 C-14,-6 -20,-6 -23,-4" fill="none" stroke="#b7cdd6" strokeWidth="0.5" opacity="0.8" />
+      </g>
+      <g className={alaR} style={{ transformOrigin: 'left center' }}>
+        <path d="M3,-4 C16,-11 26,-9 25,-3 C24,1 14,1 3,-1 Z"
+          fill="#eaf3f7" opacity="0.66" stroke="#9db8c2" strokeWidth="0.7" />
+        <path d="M6,-3.5 C14,-6 20,-6 23,-4" fill="none" stroke="#b7cdd6" strokeWidth="0.5" opacity="0.8" />
+      </g>
+      {/* abdomen: bandas AMARILLAS Y NEGRAS (disfraz de avispa/abeja) */}
+      <ellipse cx="0" cy="6" rx="7.5" ry="8.5" fill="#f5c542" stroke="#7a5a12" strokeWidth="0.8" />
+      <g fill="#241a0c">
+        <path d="M-7,2.2 C-3,3.6 3,3.6 7,2.2 L7,4 C3,5.4 -3,5.4 -7,4 Z" />
+        <path d="M-7.3,6 C-3,7.2 3,7.2 7.3,6 L7.3,8 C3,9.2 -3,9.2 -7.3,8 Z" />
+        <path d="M-6,10 C-3,11 3,11 6,10 L5.6,12 C2.6,12.9 -2.6,12.9 -5.6,12 Z" />
+      </g>
+      <ellipse cx="-2.4" cy="1" rx="2.6" ry="1.6" fill="#fbe08a" opacity="0.7" />
+      {/* tórax bronce/olivo con brillo */}
+      <ellipse cx="0" cy="-3.5" rx="6" ry="5" fill="#8a7d3c" stroke="#5f5626" strokeWidth="0.8" />
+      <ellipse cx="-2" cy="-5" rx="2.4" ry="1.6" fill="#b6a75a" opacity="0.7" />
+      {/* cabeza: OJOS ENORMES de mosca que se juntan arriba */}
+      <circle cx="0" cy="-11" r="6.6" fill="#7a5236" stroke={RH_INK} strokeWidth="0.7" />
+      <ellipse cx="-3" cy="-11.5" rx="3.9" ry="4.6" fill="#a8514a" stroke={RH_INK} strokeWidth="0.8" />
+      <ellipse cx="3" cy="-11.5" rx="3.9" ry="4.6" fill="#a8514a" stroke={RH_INK} strokeWidth="0.8" />
+      {/* facetas tenues del ojo compuesto */}
+      <g fill="#8f3f39" opacity="0.5">
+        <circle cx="-3.4" cy="-10.4" r="0.5" /><circle cx="-1.8" cy="-12.2" r="0.5" />
+        <circle cx="3.4" cy="-10.4" r="0.5" /><circle cx="1.8" cy="-12.2" r="0.5" />
+      </g>
+      {/* brillo grande (chispa rubber-hose) en cada ojo */}
+      <circle cx="-4.2" cy="-13.2" r="1.4" fill="#ffe9e4" opacity="0.92" />
+      <circle cx="1.8" cy="-13.2" r="1.4" fill="#ffe9e4" opacity="0.92" />
+      {/* sonrisita cómplice del impostor, entre los ojos */}
+      <Sonrisa cx={0} cy={-6.4} w={3.4} prof={1.2} ink={RH_INK} />
+      {/* antenitas MINÚSCULAS (la seña de que es mosca, no abeja) */}
+      <g fill={RH_INK}>
+        <ellipse cx="-1.8" cy="-16.6" rx="1" ry="1.5" />
+        <ellipse cx="1.8" cy="-16.6" rx="1" ry="1.5" />
+      </g>
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="sirfido">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="sirfido" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Sirfido;

--- a/src/visual/creatures/Trichogramma.jsx
+++ b/src/visual/creatures/Trichogramma.jsx
@@ -1,0 +1,106 @@
+import { useId } from 'react';
+import './creatures.css';
+import { CreatureFilters } from './_filters.jsx';
+import { RH_INK, Sonrisa } from './_rubberhose.jsx';
+
+/* Avispita Trichogramma — Trichogramma (Trichogrammatidae). La DIMINUTA:
+   la avispa parásita más pequeña de la finca (menos de un milímetro), pero la
+   más brava — pone su huevo DENTRO del huevo del cogollero y la plaga nunca
+   nace. Rasgos fieles: cuerpo ámbar rechoncho, OJOS ROJOS, y las alas con
+   FLECOS de pelitos en el borde (la seña de su familia). Aquí va de gigante y
+   tierna para que se vea; en la vida real cabría en la cabeza de un alfiler.
+   Controlador biológico real de la agroecología colombiana. Rubber-hose. */
+const VIEWBOX = '-24 -20 48 40';
+
+/* Ala con FLECOS: lámina translúcida + pelitos radiales en el borde (la marca
+   de los Trichogrammatidae). Se agita con la cadencia rápida crt-wing. */
+function AlaFleco({ clase, lado = 1 }) {
+  // lado: 1 = derecha, -1 = izquierda (espejo por scaleX en el grupo).
+  return (
+    <g className={clase} style={{ transformOrigin: `${lado < 0 ? 'right' : 'left'} center` }}>
+      <path
+        d="M0,-1 C7,-8 15,-8 18,-3 C15,0 7,1 0,2 Z"
+        fill="#f2ede0"
+        opacity="0.72"
+        stroke="#b9a98a"
+        strokeWidth="0.6"
+      />
+      {/* flecos: pelitos cortos que salen del borde */}
+      <g stroke="#9b8a6a" strokeWidth="0.5" strokeLinecap="round" opacity="0.85">
+        <path d="M6,-6.6 L6.6,-8.4 M9.5,-6.7 L10.2,-8.6 M12.6,-6 L13.4,-7.8 M15.5,-4.4 L16.6,-5.8" />
+        <path d="M5,1.6 L5.4,3.2 M8.5,1.2 L9,2.9 M12,0.4 L12.7,2 M15,-0.6 L16,0.8" />
+      </g>
+    </g>
+  );
+}
+
+export function Trichogramma({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Avispita Trichogramma',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const alaR = animated ? 'crt-wing' : undefined;
+  const alaL = animated ? 'crt-wing' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+  const body = (
+    <g className="crt-body" filter={`url(#${glow})`}>
+      {/* patitas (3 pares), cortas y oscuras */}
+      <g stroke={RH_INK} strokeWidth="1" strokeLinecap="round">
+        <path d="M-3,6 L-6,11 M0,6.5 L-1,12 M3,6 L5,11" />
+      </g>
+      {/* alas con flecos, una a cada lado (la izquierda se espeja) */}
+      <g transform="translate(2,-2)"><AlaFleco clase={alaR} lado={1} /></g>
+      <g transform="translate(-2,-2) scale(-1,1)"><AlaFleco clase={alaL} lado={-1} /></g>
+      {/* abdomen ámbar rechoncho */}
+      <ellipse cx="0" cy="4" rx="6.5" ry="6" fill="#e0a52e" stroke="#a9741a" strokeWidth="0.8" />
+      <path d="M-4.5,2.5 C-2,4 2,4 4.5,2.5" fill="none" stroke="#c8871a" strokeWidth="0.7" opacity="0.7" />
+      <ellipse cx="-2" cy="1.6" rx="2.4" ry="1.5" fill="#f2c463" opacity="0.6" />
+      {/* tórax */}
+      <ellipse cx="0" cy="-2.2" rx="4.4" ry="3.6" fill="#c8871a" stroke="#a9741a" strokeWidth="0.7" />
+      {/* cabeza + OJOS ROJOS grandes (rubber-hose: brillo y sonrisa) */}
+      <circle cx="0" cy="-8" r="5" fill="#d99a2c" stroke="#a9741a" strokeWidth="0.7" />
+      <circle cx="-2.2" cy="-8.6" r="2.1" fill="#d6392b" stroke={RH_INK} strokeWidth="0.6" />
+      <circle cx="2.2" cy="-8.6" r="2.1" fill="#d6392b" stroke={RH_INK} strokeWidth="0.6" />
+      <circle cx="-2.8" cy="-9.4" r="0.7" fill="#fff2ef" />
+      <circle cx="1.6" cy="-9.4" r="0.7" fill="#fff2ef" />
+      <Sonrisa cx={0} cy={-5.6} w={3} prof={1.1} ink={RH_INK} />
+      {/* antenas cortas acodadas con clava (avispita) */}
+      <g fill="none" stroke={RH_INK} strokeWidth="1" strokeLinecap="round">
+        <path d="M-2.6,-11.6 C-5,-14 -7,-14.5 -8.6,-13.4" />
+        <path d="M2.6,-11.6 C5,-14 7,-14.5 8.6,-13.4" />
+      </g>
+      <circle cx="-8.6" cy="-13.4" r="1.3" fill={RH_INK} />
+      <circle cx="8.6" cy="-13.4" r="1.3" fill={RH_INK} />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="trichogramma">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="trichogramma" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Trichogramma;

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -67,6 +67,15 @@ export { Perezoso, PEREZOSO_PALETA, PEREZOSO_PROPORCION } from './Perezoso.jsx';
 export { Lombriz } from './Lombriz.jsx';
 export { Mariposa } from './Mariposa.jsx';
 export { Escarabajo } from './Escarabajo.jsx';
+/* EL TRÍO DE CONTROL BIOLÓGICO — los aliados reales de la agroecología que los
+   juegos Defensores y Milpa necesitaban como protagonistas: la crisopa (alas
+   verdes translúcidas, ojos dorados), la avispita Trichogramma (diminuta pero
+   brava, ojos rojos, alas con flecos) y el sírfido (mosca que imita abeja: un
+   par de alas, ojos enormes, antenitas mínimas). Fauna benéfica REAL con
+   binomio verificado — misma fundación rubber-hose que Mariposa/Escarabajo. */
+export { Crisopa } from './Crisopa.jsx';
+export { Trichogramma } from './Trichogramma.jsx';
+export { Sirfido } from './Sirfido.jsx';
 /* EL ENT DEL PÁRAMO — el árbol-guardián que enseña (frailejón gigante). NO es un
    bicho: es el corazón del "Bosque Vivo". Hereda la MISMA fundación transversal
    (line-boil, lip-sync, modo-poder=guardián, clima) adaptada a su escala y su
@@ -128,6 +137,9 @@ import Condor from './Condor.jsx';
 import Lombriz from './Lombriz.jsx';
 import Mariposa from './Mariposa.jsx';
 import Escarabajo from './Escarabajo.jsx';
+import Crisopa from './Crisopa.jsx';
+import Trichogramma from './Trichogramma.jsx';
+import Sirfido from './Sirfido.jsx';
 import EntFrailejon from './EntFrailejon.jsx';
 
 /* Registro consultable: slug → componente + binomio verificado. */
@@ -146,6 +158,10 @@ export const CREATURES = {
   lombriz: { Component: Lombriz, nombre: 'Lombriz de tierra', cientifico: 'Martiodrilus crassus' },
   mariposa: { Component: Mariposa, nombre: 'Mariposa pasionaria', cientifico: 'Dione juno' },
   escarabajo: { Component: Escarabajo, nombre: 'Escarabajo estercolero', cientifico: 'Dichotomius belus' },
+  // El trío de control biológico (aliados reales de Defensores y Milpa).
+  crisopa: { Component: Crisopa, nombre: 'Crisopa', cientifico: 'Chrysoperla externa' },
+  trichogramma: { Component: Trichogramma, nombre: 'Avispita Trichogramma', cientifico: 'Trichogramma' },
+  sirfido: { Component: Sirfido, nombre: 'Mosca de las flores (sírfido)', cientifico: 'Syrphidae' },
   // El árbol-maestro del Bosque Vivo (flora, no fauna): el frailejón guardián.
   'ent-frailejon': { Component: EntFrailejon, nombre: 'El Ent del páramo', cientifico: 'Espeletia sp.' },
 };


### PR DESCRIPTION
## Qué

El pase de belleza de juegos dejó **Defensores** y **Milpa** sin sus actores fieles porque no existía SVG de los controladores biológicos reales. Este PR dibuja las 3 criaturas que faltaban en el lenguaje **rubber-hose** de la casa y las aplica como **protagonistas** (solo visual, sin tocar mecánica ni datos).

## Criaturas nuevas (`src/visual/creatures/`)

- **Crisopa** — *Chrysoperla externa*: alas verdes translúcidas de encaje (con venación) + **ojos dorados metálicos** (su firma) + antenas filiformes largas.
- **Avispita Trichogramma** — *Trichogramma*: la **diminuta pero brava**, cuerpo ámbar rechoncho, **ojos rojos** y alas con **flecos** (la seña de los Trichogrammatidae).
- **Sírfido / mosca de las flores** — *Syrphidae*: **imita abeja pero es mosca** — un solo par de alas, ojos enormes y antenitas mínimas; abdomen a bandas amarillas y negras.

Cada una sigue el patrón existente (Mariposa/Escarabajo): `CreatureFilters`, `Sonrisa`, clases `crt-*`, modos `standalone`/`inline`, y el gate `reduced-motion` heredado de `creatures.css`.

## Cableado (solo visual)

- **Barrel** `creatures/index.js`: `export` + registro `CREATURES` con binomio verificado → se publican solas en el registro visual y el avatar-selector.
- **Defensores** (`DefensoresFincaScreen`): el selector de benéficos dibuja la criatura real en vez del emoji para `crisopa`/`trichogramma`/`sirfido` (mapa `CRIATURA_BENEFICO`). El resto de benéficos mantiene su emoji. El `id` y la mecánica del par no cambian.
- **Milpa** (`MilpaSimulator`): tira **"Cuando hay variedad, llegan solos los aliados"** en la fase de selección — control biológico que atrae el policultivo diverso (depredador de áfidos, parásito de huevos, polinizador+depredador). Educativo y veraz.

## Verificación

- `npm run build:prod` **verde**.
- Capturas headless (harness aislado por un error pre-existente de oxc en `App.jsx` en modo dev, ajeno a este PR): el trío, el selector de Defensores y la tira de Milpa renderizan correctamente. Rutas en el reporte al operador.
- Fauna benéfica **REAL** con nombre científico correcto (regla dura de biodiversidad). Español Colombia sin voseo. Anti-leak: limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)