### PR TITLE
art(agua): fauna acuática/ribereña real + vegetación de quebrada en el mundo del agua

### DIFF
--- a/src/mockups/MundoAgua3D.jsx
+++ b/src/mockups/MundoAgua3D.jsx
@@ -34,6 +34,15 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { Html, OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import { ATMOSFERA, CIELOS, PALETA, mezclarCielo } from '../visual/mundo3d/atmosferaMadre.js';
 import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
+import {
+  Cardumen,
+  Garza,
+  MartinPescador,
+  MirlaDeAgua,
+  Libelulas,
+  RanaQuebrada,
+} from '../visual/mundo3d/agua/faunaAcuatica.jsx';
+import { Aliso, VegetacionRibera } from '../visual/mundo3d/agua/vegetacionRibera.jsx';
 
 /* ── El cielo del mundo agua, mezclado hacia la hora dorada (misma receta que
       EscenaBase3D → entrar aquí se siente del MISMO atardecer). Constante de
@@ -411,21 +420,8 @@ function Filtracion({ cuantas, reducedMotion }) {
 
 /* ── Piezas quietas (arquitectura del agua) ───────────────────────────────── */
 
-/* Árbol low-poly: el monte que PROTEGE el nacimiento (ronda hídrica). */
-function Arbol({ pos, esc = 1, tono = PALETA.follajeOscuro }) {
-  return (
-    <group position={pos} scale={esc}>
-      <mesh position={[0, 0.32, 0]}>
-        <cylinderGeometry args={[0.06, 0.09, 0.64, 6]} />
-        <meshLambertMaterial color={PALETA.madera} />
-      </mesh>
-      <mesh position={[0, 0.85, 0]}>
-        <coneGeometry args={[0.42, 0.95, 7]} />
-        <meshLambertMaterial color={tono} flatShading />
-      </mesh>
-    </group>
-  );
-}
+/* El monte que PROTEGE el nacimiento es ahora ALISO real (Alnus acuminata), el
+   árbol de ronda hídrica por excelencia — vive en vegetacionRibera.jsx. */
 
 /* El nacimiento: ojo de agua entre piedras, con su ronda de monte. */
 function Nacimiento() {
@@ -452,7 +448,7 @@ function Nacimiento() {
         </mesh>
       ))}
       {monte.map(([px, py, pz, e], i) => (
-        <Arbol key={`a${i}`} pos={[px, py, pz]} esc={e} />
+        <Aliso key={`a${i}`} pos={[px, py, pz]} esc={e * 0.72} rot={i * 1.7} />
       ))}
     </group>
   );
@@ -531,7 +527,7 @@ function Reservorio({ reducedMotion }) {
           emissive="#2a6a86"
           emissiveIntensity={0.3}
           transparent
-          opacity={0.95}
+          opacity={0.72}
         />
       </mesh>
       <mesh position={[0, 0.09, 0]} rotation={[-Math.PI / 2, 0, 0]}>
@@ -870,6 +866,23 @@ function DioramaAgua({ perfil, tier, reducedMotion, estacion, onSoltar, controle
   const nGoteo = tier === 'alto' ? 20 : tier === 'medio' ? 12 : 8;
   const nFiltra = tier === 'alto' ? 8 : 5;
 
+  /* fauna acuática/ribereña — presupuesto por tier (individuos, no partículas) */
+  const nTrucha = tier === 'alto' ? 8 : tier === 'medio' ? 5 : 3;
+  const nCapitan = tier === 'alto' ? 3 : tier === 'medio' ? 2 : 1;
+  const nSabaleta = tier === 'alto' ? 5 : tier === 'medio' ? 3 : 2;
+  const ySupReservorio = altura(RESERVORIO.x, RESERVORIO.z) + 0.1; // lámina del espejo
+  const anclasLibelulas = useMemo(() => {
+    const base = [
+      [RESERVORIO.x - 0.3, ySupReservorio + 0.5, RESERVORIO.z - 0.2],
+      [-3.0, altura(-3.0, 2.0) + 0.55, 2.0],
+      [-3.3, altura(-3.3, 6.0) + 0.55, 6.0],
+      [RESERVORIO.x + 0.6, ySupReservorio + 0.7, RESERVORIO.z + 0.5],
+      [-3.7, altura(-3.7, -3.6) + 0.55, -3.6],
+    ];
+    const n = tier === 'alto' ? 5 : tier === 'medio' ? 3 : 2;
+    return base.slice(0, n);
+  }, [tier, ySupReservorio]);
+
   return (
     <>
       <color attach="background" args={[CIELO.fondo]} />
@@ -886,8 +899,9 @@ function DioramaAgua({ perfil, tier, reducedMotion, estacion, onSoltar, controle
         <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
       </mesh>
 
-      {/* el agua: quebrada + canal + reservorio, respirando */}
-      <EspejoAgua geometria={geoCintas.quebrada} reducedMotion={reducedMotion} />
+      {/* el agua: quebrada + canal + reservorio, respirando (la quebrada un
+          poco más clara para dejar ver la sabaleta que remonta) */}
+      <EspejoAgua geometria={geoCintas.quebrada} reducedMotion={reducedMotion} opacidad={0.82} />
       <EspejoAgua geometria={geoCintas.canal} reducedMotion={reducedMotion} fase={1.4} />
       <Reservorio reducedMotion={reducedMotion} />
 
@@ -908,6 +922,50 @@ function DioramaAgua({ perfil, tier, reducedMotion, estacion, onSoltar, controle
       <Lluvia cuantas={nLluvia} reducedMotion={reducedMotion} />
       <GoteoRiego cuantas={nGoteo} reducedMotion={reducedMotion} />
       <Filtracion cuantas={nFiltra} reducedMotion={reducedMotion} />
+
+      {/* ── LA VIDA DEL AGUA (fauna real por piso térmico, ver faunaAcuatica) ── */}
+      {/* El reservorio como estanque de aguas frías: trucha (cardumen) y
+          capitán bentónico pegado al fondo. */}
+      <Cardumen
+        modo="estanque"
+        centro={[RESERVORIO.x, 0, RESERVORIO.z]}
+        radio={RESERVORIO.r}
+        superficieY={ySupReservorio}
+        especieId="trucha"
+        cuantas={nTrucha}
+        reducedMotion={reducedMotion}
+      />
+      <Cardumen
+        modo="estanque"
+        centro={[RESERVORIO.x, 0, RESERVORIO.z]}
+        radio={RESERVORIO.r}
+        superficieY={ySupReservorio}
+        especieId="capitan"
+        cuantas={nCapitan}
+        reducedMotion={reducedMotion}
+      />
+      {/* La quebrada viva: sabaleta remontando la corriente */}
+      <Cardumen
+        modo="quebrada"
+        curva={curvas.quebrada}
+        altura={altura}
+        especieId="sabaleta"
+        cuantas={nSabaleta}
+        reducedMotion={reducedMotion}
+      />
+
+      {/* aves de ribera */}
+      <Garza pos={[RESERVORIO.x - 0.1, altura(RESERVORIO.x - 0.1, RESERVORIO.z + 1.55), RESERVORIO.z + 1.55]} rot={Math.PI} reducedMotion={reducedMotion} />
+      <MartinPescador pos={[-2.55, altura(-2.55, 3.7) + 0.45, 3.7]} rot={-0.7} reducedMotion={reducedMotion} />
+      <MirlaDeAgua pos={[-3.2, altura(-3.2, 5.5) + 0.02, 5.5]} rot={0.5} reducedMotion={reducedMotion} />
+      <RanaQuebrada pos={[-3.95, altura(-3.95, -3.1) + 0.02, -3.1]} rot={0.8} reducedMotion={reducedMotion} />
+      <RanaQuebrada pos={[-2.75, altura(-2.75, 4.7) + 0.02, 4.7]} rot={-1.4} reducedMotion={reducedMotion} />
+
+      {/* libélulas (bioindicador de agua limpia) */}
+      <Libelulas anclas={anclasLibelulas} reducedMotion={reducedMotion} />
+
+      {/* vegetación de ribera real: aliso · sauce · guadua a lo largo de la quebrada */}
+      <VegetacionRibera curva={curvas.quebrada} altura={altura} />
 
       {/* rótulos de las estaciones, sobrios */}
       <Rotulo pos={[QUEBRADA_XZ[0][0], altura(...QUEBRADA_XZ[0]) + 1.9, QUEBRADA_XZ[0][1]]} texto="Nacimiento" sub="protegido con monte" />

--- a/src/visual/mundo3d/agua/faunaAcuatica.data.js
+++ b/src/visual/mundo3d/agua/faunaAcuatica.data.js
@@ -1,0 +1,88 @@
+/*
+ * faunaAcuatica.data — registro de especies acuáticas/ribereñas por PISO
+ * TÉRMICO (documental y citable). Separado del .jsx para el fast-refresh.
+ *
+ * Regla dura de biodiversidad: especies REALES colombianas con nombre
+ * científico, por piso térmico. Este mundo es una quebrada-finca ANDINA del
+ * gradiente FRÍO↔TEMPLADO (nacimiento en la loma → vega); el reservorio hace de
+ * estanque de piscicultura de aguas frías. Nada de peces de tierra caliente.
+ *
+ * GROUNDING: DR fauna-acuatica-y-riberea-…-b158c9b7 (gemini grounded — AUNAP,
+ * Instituto Humboldt, U.D.C.A., WWF Colombia, GBIF). El gemelo glm se descartó
+ * (alucinaba filas repetidas). Cada nota visual proviene del DR.
+ */
+
+/** Peces del gradiente frío→templado. Colores derivados de la nota visual DR. */
+export const FAUNA_AGUA_ESPECIES = {
+  trucha: {
+    comun: 'Trucha arcoíris',
+    cientifico: 'Oncorhynchus mykiss',
+    piso: 'frío (2000–3000 m) · piscicultura',
+    grupo: 'pez',
+    grounding: 'DR b158c9b7 (gemini) — piscicultura de aguas frías en Colombia',
+    // Nota visual DR: plateado con franja rosada iridiscente y motas negras.
+    cuerpo: '#c7ced4', vientre: '#eae6db', franja: '#e28aa2', aleta: '#aab3bb',
+  },
+  capitan: {
+    comun: 'Capitán de la sabana',
+    cientifico: 'Eremophilus mutisii',
+    piso: 'frío (2000–3000 m) · endémico altiplano cundiboyacense',
+    grupo: 'pez',
+    grounding: 'DR b158c9b7 (gemini) — U.D.C.A., AUNAP, MinAmbiente',
+    // Nota visual DR: cilíndrico, sin escamas, verde oliva con vermiculado
+    // amarillo; bentónico (vive pegado al fondo), con barbillones.
+    cuerpo: '#7d874c', vientre: '#9aa060', franja: null, aleta: '#69713f',
+    bentonico: true,
+  },
+  sabaleta: {
+    comun: 'Sabaleta',
+    cientifico: 'Brycon henni',
+    piso: 'templado (1000–2000 m)',
+    grupo: 'pez',
+    grounding: 'DR b158c9b7 (gemini) — dispersora de semillas en ríos andinos',
+    // Nota visual DR: plateada, fusiforme, aletas amarillentas/rojizas.
+    cuerpo: '#c0cad0', vientre: '#e8e3d6', franja: null, aleta: '#d8c079',
+  },
+};
+
+/**
+ * Aves de ribera, anfibios e insectos (documental — el .jsx los dibuja por
+ * nombre). Todas del gradiente frío→templado, ver notas visuales del DR.
+ */
+export const FAUNA_AGUA_RIBERA = {
+  garza: {
+    comun: 'Garza real',
+    cientifico: 'Ardea alba',
+    piso: 'cálido→frío · humedales y reservorios andinos',
+    grupo: 'ave',
+    grounding: 'DR b158c9b7 (gemini) — depredador tope, bioindicador',
+  },
+  martin: {
+    comun: 'Martín pescador amazónico',
+    cientifico: 'Chloroceryle amazona',
+    piso: 'templado',
+    grupo: 'ave',
+    grounding: 'DR b158c9b7 (gemini) — bioindicador de ribera sana',
+  },
+  mirla: {
+    comun: 'Mirla de agua',
+    cientifico: 'Cinclus leucocephalus',
+    piso: 'frío · ríos y quebradas de montaña',
+    grupo: 'ave',
+    grounding: 'DR b158c9b7 (gemini) — bioindicador de buena calidad de agua',
+  },
+  rana: {
+    comun: 'Rana de quebrada',
+    cientifico: 'Pristimantis sp.',
+    piso: 'templado→frío · endémicas de los Andes',
+    grupo: 'anfibio',
+    grounding: 'DR b158c9b7 (gemini) — Instituto Humboldt',
+  },
+  libelula: {
+    comun: 'Libélula',
+    cientifico: 'Orden Odonata',
+    piso: 'transversal · adultos sobre la lámina',
+    grupo: 'insecto',
+    grounding: 'DR b158c9b7 (gemini) — bioindicador de agua limpia',
+  },
+};

--- a/src/visual/mundo3d/agua/faunaAcuatica.jsx
+++ b/src/visual/mundo3d/agua/faunaAcuatica.jsx
@@ -1,0 +1,391 @@
+/*
+ * faunaAcuatica — la VIDA del mundo del agua (peces, aves de ribera, libélulas
+ * y ranas de quebrada), low-poly y por PISO TÉRMICO real.
+ *
+ * Regla dura de biodiversidad: especies REALES colombianas, con nombre
+ * científico, ubicadas por su piso térmico. Este mundo es una quebrada-finca
+ * ANDINA que baja del nacimiento (loma, frío) a la vega (templado); su
+ * reservorio hace las veces de estanque de piscicultura de aguas frías. Por eso
+ * el elenco es del gradiente FRÍO↔TEMPLADO, nunca peces de tierra caliente.
+ *
+ * GROUNDING (DR fauna-acuatica-y-riberea-…-b158c9b7, gemini grounded — AUNAP,
+ * Instituto Humboldt, U.D.C.A., WWF Colombia, GBIF; el gemelo glm se descartó
+ * por alucinar filas repetidas). Cada especie lleva su nota visual del DR.
+ *
+ * ESTILO: mismos materiales que MundoAgua3D (MeshLambert/Basic, sin shadow-map),
+ * PALETA madre para los cuerpos y el mismo azul con permiso (PALETA.agua) del
+ * espejo de agua del valle. Todo respeta `reducedMotion` (se congela quieto) y
+ * el presupuesto por `tier` lo decide quien monta (cuenta de individuos).
+ */
+import { useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { useFrame } from '@react-three/fiber';
+import { PALETA } from '../atmosferaMadre.js';
+import { FAUNA_AGUA_ESPECIES } from './faunaAcuatica.data.js';
+
+/* Hash determinista [0,1) a partir de un índice — el cardumen se ve orgánico
+   pero es SIEMPRE el mismo (cero Math.random → cachea limpio, igual que el
+   terreno). */
+const jitter = (i, s) => {
+  const v = Math.sin(i * 12.9898 + s * 78.233) * 43758.5453;
+  return v - Math.floor(v);
+};
+
+/* ── UN PEZ: cuerpo fusiforme + cola que aletea, sumergido ─────────────────── */
+function Pez({ posicionar, fase, velocidad, escala, especie, reducedMotion }) {
+  const g = useRef(null);
+  const cola = useRef(null);
+  useFrame((st) => {
+    if (!g.current) return;
+    const reloj = reducedMotion ? 4.2 + fase * 3.1 : st.clock.elapsedTime;
+    const info = posicionar(fase + reloj * velocidad);
+    g.current.position.set(info.x, info.y, info.z);
+    const wig = reducedMotion ? 0 : Math.sin(reloj * 5.5 + fase * 11);
+    g.current.rotation.y = info.yaw + wig * 0.08; // serpenteo del cuerpo
+    if (cola.current) cola.current.rotation.y = wig * 0.7; // la cola aletea
+  });
+  return (
+    <group ref={g} scale={escala}>
+      {/* cuerpo fusiforme (elipsoide alargado sobre +Z, la marcha del pez) */}
+      <mesh scale={[0.42, 0.5, 1]}>
+        <sphereGeometry args={[0.5, 8, 6]} />
+        <meshLambertMaterial color={especie.cuerpo} flatShading emissive={especie.cuerpo} emissiveIntensity={0.1} />
+      </mesh>
+      {/* vientre más claro (contraluz del agua) */}
+      <mesh position={[0, -0.12, 0.02]} scale={[0.34, 0.3, 0.86]}>
+        <sphereGeometry args={[0.5, 8, 5]} />
+        <meshLambertMaterial color={especie.vientre} flatShading />
+      </mesh>
+      {/* franja lateral iridiscente (solo la trucha) */}
+      {especie.franja ? (
+        <mesh position={[0, 0.02, 0.0]} scale={[0.44, 0.1, 0.9]}>
+          <sphereGeometry args={[0.5, 8, 4]} />
+          <meshBasicMaterial color={especie.franja} transparent opacity={0.85} />
+        </mesh>
+      ) : null}
+      {/* aleta dorsal */}
+      <mesh position={[0, 0.2, 0.02]} rotation={[0.25, 0, 0]}>
+        <coneGeometry args={[0.09, 0.2, 3]} />
+        <meshLambertMaterial color={especie.aleta} flatShading />
+      </mesh>
+      {/* cola: sub-grupo anclado detrás (−Z) que aletea de lado a lado */}
+      <group ref={cola} position={[0, 0, -0.48]}>
+        <mesh rotation={[Math.PI / 2, 0, 0]} scale={[1, 1, 0.32]}>
+          <coneGeometry args={[0.2, 0.36, 4]} />
+          <meshLambertMaterial color={especie.aleta} flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* ── CARDUMEN: N peces de una especie. Dos hábitats:
+      · modo="estanque": giran despacio bajo el espejo del reservorio.
+      · modo="quebrada": remontan la corriente drapeados sobre el lecho. ── */
+export function Cardumen({
+  modo = 'estanque',
+  centro = [0, 0, 0],
+  radio = 1,
+  superficieY = 0,
+  curva = null,
+  altura = null,
+  especieId = 'trucha',
+  cuantas = 6,
+  reducedMotion = false,
+}) {
+  const especie = FAUNA_AGUA_ESPECIES[especieId];
+  const peces = useMemo(() => {
+    const arr = [];
+    const tmp = { p: new THREE.Vector3(), t: new THREE.Vector3() };
+    for (let i = 0; i < cuantas; i++) {
+      const a = jitter(i, 1), b = jitter(i, 2), c = jitter(i, 3);
+      const escala = especie.grupo === 'pez'
+        ? (especie.comun === 'Capitán de la sabana' ? 0.5 : 0.42) * (0.8 + a * 0.5)
+        : 0.4;
+      let posicionar;
+      if (modo === 'estanque') {
+        // anillo dentro del espejo; los bentónicos (capitán) pegados al fondo.
+        // La columna de agua del reservorio es somera (~0.3): el cardumen nada
+        // JUSTO bajo la lámina para verse, y el capitán roza el lecho.
+        const rr = radio * (0.35 + b * 0.5);
+        const prof = especie.bentonico ? 0.2 + c * 0.05 : 0.05 + c * 0.13;
+        const sentido = i % 2 === 0 ? 1 : -1;
+        posicionar = (u) => {
+          const ang = u * Math.PI * 2 * sentido + a * 6.283;
+          const x = centro[0] + Math.cos(ang) * rr;
+          const z = centro[2] + Math.sin(ang) * rr;
+          const y = superficieY - prof + Math.sin(u * 6.283 + a * 9) * 0.03;
+          const yaw = Math.atan2(-Math.sin(ang) * sentido, Math.cos(ang) * sentido);
+          return { x, y, z, yaw };
+        };
+      } else {
+        // a lo largo de la quebrada, a un costado del hilo de agua
+        const lado = i % 2 === 0 ? 1 : -1;
+        const off = (0.05 + b * 0.14) * lado;
+        const prof = 0.02 + c * 0.05; // apenas bajo la lámina (agua somera)
+        posicionar = (u) => {
+          const tt = ((u % 1) + 1) % 1;
+          curva.getPointAt(tt, tmp.p);
+          curva.getTangentAt(tt, tmp.t);
+          const px = -tmp.t.z, pz = tmp.t.x;
+          const L = Math.hypot(px, pz) || 1;
+          const x = tmp.p.x + (px / L) * off;
+          const z = tmp.p.z + (pz / L) * off;
+          const y = (altura ? altura(x, z) : tmp.p.y) + prof;
+          const yaw = Math.atan2(tmp.t.x, tmp.t.z);
+          return { x, y, z, yaw };
+        };
+      }
+      arr.push({
+        key: i,
+        fase: a,
+        velocidad: (modo === 'estanque' ? 0.02 : 0.03) * (0.7 + b * 0.6),
+        escala,
+        posicionar,
+      });
+    }
+    return arr;
+  }, [modo, centro, radio, superficieY, curva, altura, cuantas, especie]);
+
+  return (
+    <group>
+      {peces.map((p) => (
+        <Pez
+          key={p.key}
+          posicionar={p.posicionar}
+          fase={p.fase}
+          velocidad={p.velocidad}
+          escala={p.escala}
+          especie={especie}
+          reducedMotion={reducedMotion}
+        />
+      ))}
+    </group>
+  );
+}
+
+/* ── GARZA REAL (Ardea alba) — depredador tope, bioindicador. Blanca, pico
+      amarillo, patas negras; quieta al acecho en la orilla, con leve vaivén de
+      cuello. Piso: cálido→frío (humedales y reservorios andinos). ── */
+export function Garza({ pos, rot = 0, reducedMotion = false }) {
+  const cuello = useRef(null);
+  useFrame((st) => {
+    if (reducedMotion || !cuello.current) return;
+    cuello.current.rotation.x = -0.5 + Math.sin(st.clock.elapsedTime * 0.5) * 0.16;
+  });
+  const B = '#f3f0e6'; // blanco cálido
+  return (
+    <group position={pos} rotation={[0, rot, 0]}>
+      {/* patas negras */}
+      {[-0.07, 0.07].map((dx, i) => (
+        <mesh key={i} position={[dx, 0.34, 0]}>
+          <cylinderGeometry args={[0.016, 0.016, 0.68, 5]} />
+          <meshLambertMaterial color="#33322c" />
+        </mesh>
+      ))}
+      {/* cuerpo ovoide inclinado */}
+      <mesh position={[0, 0.78, -0.02]} rotation={[0.3, 0, 0]} scale={[0.36, 0.4, 0.6]}>
+        <sphereGeometry args={[0.5, 9, 7]} />
+        <meshLambertMaterial color={B} flatShading />
+      </mesh>
+      {/* cuello + cabeza + pico (sub-grupo que se mece) */}
+      <group ref={cuello} position={[0, 0.92, 0.05]} rotation={[-0.5, 0, 0]}>
+        <mesh position={[0, 0.22, 0.03]}>
+          <cylinderGeometry args={[0.03, 0.045, 0.5, 6]} />
+          <meshLambertMaterial color={B} />
+        </mesh>
+        <mesh position={[0, 0.47, 0.05]}>
+          <sphereGeometry args={[0.075, 8, 6]} />
+          <meshLambertMaterial color={B} flatShading />
+        </mesh>
+        {/* pico amarillo, largo y puntiagudo */}
+        <mesh position={[0, 0.5, 0.2]} rotation={[1.25, 0, 0]}>
+          <coneGeometry args={[0.03, 0.28, 5]} />
+          <meshLambertMaterial color="#e6b23a" flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* ── MARTÍN PESCADOR (Chloroceryle amazona) — dorso verde brillante, vientre
+      blanco, cresta desordenada y pico recto. Posado en una vara sobre el agua.
+      Piso: templado. Bioindicador de presa/ecosistema ribereño sano. ── */
+export function MartinPescador({ pos, rot = 0, reducedMotion = false }) {
+  const cabeza = useRef(null);
+  useFrame((st) => {
+    if (reducedMotion || !cabeza.current) return;
+    cabeza.current.rotation.y = Math.sin(st.clock.elapsedTime * 0.8) * 0.4; // otea el agua
+  });
+  const V = '#2f5d43'; // verde dorso
+  return (
+    <group position={pos} rotation={[0, rot, 0]}>
+      {/* la vara donde se posa (asomando del agua) */}
+      <mesh position={[0, -0.12, 0]} rotation={[0.18, 0, 0.1]}>
+        <cylinderGeometry args={[0.02, 0.025, 0.7, 5]} />
+        <meshLambertMaterial color={PALETA.maderaOscura} />
+      </mesh>
+      {/* cuerpo compacto */}
+      <mesh position={[0, 0.22, 0]} rotation={[0.5, 0, 0]} scale={[0.3, 0.32, 0.5]}>
+        <sphereGeometry args={[0.5, 9, 7]} />
+        <meshLambertMaterial color={V} flatShading />
+      </mesh>
+      {/* vientre blanco */}
+      <mesh position={[0, 0.16, 0.09]} scale={[0.2, 0.2, 0.26]}>
+        <sphereGeometry args={[0.5, 8, 6]} />
+        <meshLambertMaterial color="#efe9db" flatShading />
+      </mesh>
+      {/* cabeza + cresta + pico (sub-grupo que otea) */}
+      <group ref={cabeza} position={[0, 0.34, 0.12]}>
+        <mesh>
+          <sphereGeometry args={[0.11, 9, 7]} />
+          <meshLambertMaterial color={V} flatShading />
+        </mesh>
+        <mesh position={[0, 0.09, -0.03]} rotation={[-0.3, 0, 0]}>
+          <coneGeometry args={[0.06, 0.12, 4]} />
+          <meshLambertMaterial color={V} flatShading />
+        </mesh>
+        {/* pico recto y largo, negro */}
+        <mesh position={[0, 0, 0.14]} rotation={[Math.PI / 2, 0, 0]}>
+          <coneGeometry args={[0.022, 0.22, 5]} />
+          <meshLambertMaterial color="#26251f" flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* ── MIRLA DE AGUA (Cinclus leucocephalus) — el ave de los torrentes: cuerpo
+      pizarra, cabeza y pecho blancos. Se posa en una piedra a media corriente y
+      "cabecea" (dipper). Piso: frío (ríos y quebradas de montaña). ── */
+export function MirlaDeAgua({ pos, rot = 0, reducedMotion = false }) {
+  const ave = useRef(null);
+  useFrame((st) => {
+    if (reducedMotion || !ave.current) return;
+    ave.current.position.y = 0.16 + Math.abs(Math.sin(st.clock.elapsedTime * 2.2)) * 0.05; // el cabeceo
+  });
+  const O = '#4a4f52'; // pizarra
+  const W = '#ece7db';
+  return (
+    <group position={pos} rotation={[0, rot, 0]}>
+      {/* la piedra del torrente */}
+      <mesh position={[0, 0.05, 0]}>
+        <dodecahedronGeometry args={[0.16, 0]} />
+        <meshLambertMaterial color={PALETA.piedra} flatShading />
+      </mesh>
+      <group ref={ave} position={[0, 0.16, 0]}>
+        <mesh rotation={[0.3, 0, 0]} scale={[0.24, 0.26, 0.4]}>
+          <sphereGeometry args={[0.5, 9, 7]} />
+          <meshLambertMaterial color={O} flatShading />
+        </mesh>
+        {/* cabeza y pecho blancos */}
+        <mesh position={[0, 0.13, 0.06]} scale={[0.16, 0.16, 0.18]}>
+          <sphereGeometry args={[0.5, 8, 6]} />
+          <meshLambertMaterial color={W} flatShading />
+        </mesh>
+        {/* colita alzada */}
+        <mesh position={[0, 0.05, -0.14]} rotation={[-0.7, 0, 0]}>
+          <coneGeometry args={[0.05, 0.14, 4]} />
+          <meshLambertMaterial color={O} flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* ── LIBÉLULA (Odonata) — bioindicador de agua limpia. Cuerpo iridiscente,
+      cuatro alas translúcidas; revolotea sobre la lámina. ── */
+function Libelula({ ancla, fase, reducedMotion }) {
+  const g = useRef(null);
+  const alas = useRef(null);
+  useFrame((st) => {
+    if (!g.current) return;
+    const t = reducedMotion ? fase * 6 : st.clock.elapsedTime;
+    // vuelo errático sobre su ancla
+    g.current.position.set(
+      ancla[0] + Math.sin(t * 0.9 + fase * 6) * 0.5,
+      ancla[1] + Math.sin(t * 1.7 + fase * 3) * 0.12,
+      ancla[2] + Math.cos(t * 0.7 + fase * 5) * 0.5,
+    );
+    g.current.rotation.y = Math.sin(t * 0.9 + fase * 6 + Math.PI / 2) * 0.6;
+    if (alas.current && !reducedMotion) alas.current.rotation.x = Math.sin(t * 30) * 0.4;
+  });
+  return (
+    <group ref={g} position={ancla}>
+      {/* abdomen delgado */}
+      <mesh rotation={[Math.PI / 2, 0, 0]} scale={[1, 1, 1]}>
+        <cylinderGeometry args={[0.012, 0.02, 0.34, 5]} />
+        <meshBasicMaterial color="#2fa6a2" />
+      </mesh>
+      <mesh position={[0, 0, 0.18]}>
+        <sphereGeometry args={[0.035, 7, 5]} />
+        <meshBasicMaterial color="#1f7d7a" />
+      </mesh>
+      {/* cuatro alas translúcidas */}
+      <group ref={alas} position={[0, 0.01, 0.06]}>
+        {[[-1, 0.02], [1, 0.02], [-1, -0.06], [1, -0.06]].map(([lado, dz], i) => (
+          <mesh key={i} position={[lado * 0.12, 0, dz]} rotation={[0, 0, lado * 0.2]} scale={[1, 1, 1]}>
+            <boxGeometry args={[0.22, 0.005, 0.07]} />
+            <meshBasicMaterial color="#e2f4f4" transparent opacity={0.5} depthWrite={false} />
+          </mesh>
+        ))}
+      </group>
+    </group>
+  );
+}
+
+export function Libelulas({ anclas = [], reducedMotion = false }) {
+  return (
+    <group>
+      {anclas.map((a, i) => (
+        <Libelula key={i} ancla={a} fase={jitter(i, 7)} reducedMotion={reducedMotion} />
+      ))}
+    </group>
+  );
+}
+
+/* ── RANA DE QUEBRADA (Pristimantis sp.) — control de insectos, endémicas de
+      los Andes. Pequeña, verde-parda, posada en una piedra de la ribera, con
+      pulso del buche. Piso: templado→frío según la especie. ── */
+export function RanaQuebrada({ pos, rot = 0, reducedMotion = false }) {
+  const buche = useRef(null);
+  useFrame((st) => {
+    if (reducedMotion || !buche.current) return;
+    const p = 0.9 + Math.max(0, Math.sin(st.clock.elapsedTime * 1.6)) * 0.5; // canto
+    buche.current.scale.set(p, p, p);
+  });
+  const P = '#6f7d44';
+  return (
+    <group position={pos} rotation={[0, rot, 0]}>
+      {/* piedrita húmeda */}
+      <mesh position={[0, 0.04, 0]} scale={[1.1, 0.6, 1]}>
+        <dodecahedronGeometry args={[0.16, 0]} />
+        <meshLambertMaterial color={PALETA.piedra} flatShading />
+      </mesh>
+      {/* cuerpo rechoncho */}
+      <mesh position={[0, 0.13, 0]} scale={[0.5, 0.34, 0.6]}>
+        <sphereGeometry args={[0.28, 8, 6]} />
+        <meshLambertMaterial color={P} flatShading />
+      </mesh>
+      {/* patas traseras plegadas */}
+      {[-1, 1].map((s) => (
+        <mesh key={s} position={[s * 0.11, 0.09, -0.03]} rotation={[0, 0, s * 0.6]} scale={[0.5, 0.22, 0.4]}>
+          <sphereGeometry args={[0.16, 6, 5]} />
+          <meshLambertMaterial color="#5c6a38" flatShading />
+        </mesh>
+      ))}
+      {/* buche que canta */}
+      <mesh ref={buche} position={[0, 0.09, 0.11]} scale={[1, 1, 1]}>
+        <sphereGeometry args={[0.06, 7, 5]} />
+        <meshLambertMaterial color="#8a944e" flatShading />
+      </mesh>
+      {/* ojos saltones */}
+      {[-1, 1].map((s) => (
+        <mesh key={s} position={[s * 0.07, 0.2, 0.06]}>
+          <sphereGeometry args={[0.032, 6, 5]} />
+          <meshLambertMaterial color="#23281a" emissive="#5a4a10" emissiveIntensity={0.2} />
+        </mesh>
+      ))}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/agua/vegetacionRibera.jsx
+++ b/src/visual/mundo3d/agua/vegetacionRibera.jsx
@@ -1,0 +1,198 @@
+/*
+ * vegetacionRibera — la VEGETACIÓN REAL de quebrada andina que reemplaza al
+ * árbol genérico de ribera del mundo del agua.
+ *
+ * Tres especies del bosque de galería / ronda hídrica colombiana (todas de
+ * clima frío→templado, coherentes con esta quebrada-finca):
+ *
+ *   · Aliso        (Alnus acuminata)      — fija nitrógeno, PROTEGE nacimientos
+ *                                            y estabiliza taludes; el árbol de
+ *                                            ronda hídrica por excelencia.
+ *   · Sauce        (Salix humboldtiana)   — ramas colgantes sobre el agua;
+ *                                            sujeta la orilla.
+ *   · Guadua       (Guadua angustifolia)  — el bambú nativo: macolla de culmos
+ *                                            anillados a la vera de la quebrada,
+ *                                            gran retenedor de suelo y agua.
+ *
+ * GROUNDING: agroforestería/silvopastoril andino y ronda hídrica — Alnus
+ * acuminata y Guadua angustifolia son especies canónicas de ribera en los Andes
+ * colombianos (Instituto Humboldt / Agrosavia; DR agua-manejo-nacional-colombia
+ * y agroforesteria-y-silvopastoril-andino). Reemplaza el cono genérico anterior.
+ *
+ * ESTILO: low-poly MeshLambert, PALETA madre; determinista (cero Math.random).
+ */
+import { useMemo } from 'react';
+import * as THREE from 'three';
+import { PALETA } from '../atmosferaMadre.js';
+
+const jitter = (i, s) => {
+  const v = Math.sin(i * 12.9898 + s * 78.233) * 43758.5453;
+  return v - Math.floor(v);
+};
+
+/* ── ALISO (Alnus acuminata): tronco gris pardo, copa redondeada en verde de
+      trabajo. El guardián del agua. ── */
+export function Aliso({ pos, esc = 1, rot = 0 }) {
+  return (
+    <group position={pos} scale={esc} rotation={[0, rot, 0]}>
+      <mesh position={[0, 0.55, 0]}>
+        <cylinderGeometry args={[0.07, 0.11, 1.1, 6]} />
+        <meshLambertMaterial color="#7c7360" flatShading />
+      </mesh>
+      <mesh position={[0, 1.32, 0]}>
+        <icosahedronGeometry args={[0.62, 0]} />
+        <meshLambertMaterial color={PALETA.follaje} flatShading />
+      </mesh>
+      <mesh position={[0.32, 1.02, 0.12]}>
+        <icosahedronGeometry args={[0.4, 0]} />
+        <meshLambertMaterial color={PALETA.follajeOscuro} flatShading />
+      </mesh>
+      <mesh position={[-0.28, 1.14, -0.15]}>
+        <icosahedronGeometry args={[0.44, 0]} />
+        <meshLambertMaterial color={PALETA.follaje} flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* ── SAUCE (Salix humboldtiana): esbelto, con cortinas de ramas colgantes que
+      rozan el agua (verde claro plateado). ── */
+export function Sauce({ pos, esc = 1, rot = 0 }) {
+  const cortinas = useMemo(() => {
+    const arr = [];
+    const n = 7;
+    for (let i = 0; i < n; i++) {
+      const a = (i / n) * Math.PI * 2;
+      const r = 0.34 + jitter(i, 4) * 0.14;
+      arr.push({
+        pos: [Math.cos(a) * r, 1.15, Math.sin(a) * r],
+        largo: 0.7 + jitter(i, 5) * 0.5,
+        inc: 0.12 + jitter(i, 6) * 0.12,
+        rot: a,
+      });
+    }
+    return arr;
+  }, []);
+  return (
+    <group position={pos} scale={esc} rotation={[0, rot, 0]}>
+      <mesh position={[0, 0.6, 0]} rotation={[0, 0, 0.06]}>
+        <cylinderGeometry args={[0.06, 0.1, 1.25, 6]} />
+        <meshLambertMaterial color={PALETA.madera} flatShading />
+      </mesh>
+      {/* copa alta y las cortinas colgantes */}
+      <mesh position={[0, 1.35, 0]}>
+        <icosahedronGeometry args={[0.42, 0]} />
+        <meshLambertMaterial color="#a8c489" flatShading />
+      </mesh>
+      {cortinas.map((c, i) => (
+        <mesh
+          key={i}
+          position={/** @type {[number,number,number]} */ (c.pos)}
+          rotation={[c.inc * Math.cos(c.rot), 0, -c.inc * Math.sin(c.rot)]}
+        >
+          <coneGeometry args={[0.08, c.largo, 4]} />
+          <meshLambertMaterial color="#9dbb7c" flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* ── GUADUA (Guadua angustifolia): macolla de culmos altos y anillados, con
+      leve arqueo y penachos de hoja arriba. El bambú de la quebrada. ── */
+export function Guadua({ pos, esc = 1, rot = 0 }) {
+  const culmos = useMemo(() => {
+    const arr = [];
+    const n = 6;
+    for (let i = 0; i < n; i++) {
+      const a = jitter(i, 8) * Math.PI * 2;
+      const r = 0.06 + jitter(i, 9) * 0.22;
+      const alto = 2.1 + jitter(i, 10) * 1.1;
+      arr.push({
+        x: Math.cos(a) * r,
+        z: Math.sin(a) * r,
+        alto,
+        inc: (jitter(i, 11) - 0.5) * 0.24, // arqueo
+        dir: a,
+      });
+    }
+    return arr;
+  }, []);
+  const VERDE = '#b7c06a'; // verde-amarillo del culmo
+  return (
+    <group position={pos} scale={esc} rotation={[0, rot, 0]}>
+      {culmos.map((c, i) => {
+        const nudos = Math.max(3, Math.round(c.alto / 0.45));
+        return (
+          <group
+            key={i}
+            position={[c.x, 0, c.z]}
+            rotation={[c.inc * Math.cos(c.dir), 0, -c.inc * Math.sin(c.dir)]}
+          >
+            <mesh position={[0, c.alto / 2, 0]}>
+              <cylinderGeometry args={[0.035, 0.05, c.alto, 6]} />
+              <meshLambertMaterial color={VERDE} flatShading />
+            </mesh>
+            {/* anillos de los nudos */}
+            {Array.from({ length: nudos }, (_, k) => (
+              <mesh key={k} position={[0, ((k + 1) * c.alto) / (nudos + 1), 0]}>
+                <torusGeometry args={[0.05, 0.014, 4, 8]} />
+                <meshLambertMaterial color="#8f9a4a" flatShading />
+              </mesh>
+            ))}
+            {/* penacho de hoja en la punta */}
+            <mesh position={[0, c.alto + 0.12, 0]}>
+              <coneGeometry args={[0.22, 0.5, 5]} />
+              <meshLambertMaterial color={PALETA.follajeClaro} flatShading />
+            </mesh>
+          </group>
+        );
+      })}
+    </group>
+  );
+}
+
+/* ── EL BOSQUE DE GALERÍA: siembra las tres especies a lo largo de la quebrada,
+      alternando orillas. Determinista: la misma ribera siempre. ──
+   @param {THREE.Curve} curva  la quebrada (curva 3D drapeada sobre el terreno)
+   @param {(x:number,z:number)=>number} altura  altura del terreno */
+export function VegetacionRibera({ curva, altura }) {
+  const arboles = useMemo(() => {
+    if (!curva) return [];
+    const arr = [];
+    const p = new THREE.Vector3();
+    const t = new THREE.Vector3();
+    // de aguas abajo del nacimiento hasta la salida, en ambas orillas
+    const tramos = [0.22, 0.34, 0.46, 0.58, 0.7, 0.82, 0.93];
+    const especies = ['aliso', 'guadua', 'sauce', 'aliso', 'guadua', 'sauce', 'aliso'];
+    tramos.forEach((tt, i) => {
+      curva.getPointAt(tt, p);
+      curva.getTangentAt(tt, t);
+      const px = -t.z, pz = t.x;
+      const L = Math.hypot(px, pz) || 1;
+      const lado = i % 2 === 0 ? 1 : -1;
+      const dist = 0.85 + jitter(i, 12) * 0.5;
+      const x = p.x + (px / L) * dist * lado;
+      const z = p.z + (pz / L) * dist * lado;
+      arr.push({
+        key: i,
+        tipo: especies[i],
+        pos: [x, altura ? altura(x, z) : p.y, z],
+        esc: 0.72 + jitter(i, 13) * 0.4,
+        rot: jitter(i, 14) * Math.PI * 2,
+      });
+    });
+    return arr;
+  }, [curva, altura]);
+
+  return (
+    <group>
+      {arboles.map((a) => {
+        const props = { pos: /** @type {[number,number,number]} */ (a.pos), esc: a.esc, rot: a.rot };
+        if (a.tipo === 'sauce') return <Sauce key={a.key} {...props} />;
+        if (a.tipo === 'guadua') return <Guadua key={a.key} {...props} />;
+        return <Aliso key={a.key} {...props} />;
+      })}
+    </group>
+  );
+}


### PR DESCRIPTION
## Qué

El **mundo del agua** (`MundoAgua3D`, ruta prod `diorama_agua`) tenía **cero fauna** y su vegetación de ribera era un **árbol genérico** (auditoría 3D de biodiversidad). Este PR lo puebla con **vida real por piso térmico** — gradiente frío↔templado de una quebrada-finca andina cuyo reservorio hace de estanque de piscicultura de aguas frías.

Regla dura de biodiversidad: **especies reales colombianas, con nombre científico, por piso térmico.**

## Fauna (archivos nuevos, geometría procedural low-poly)

**Peces** — cardúmenes procedurales, cuerpo fusiforme, cola que aletea, sumergidos:
- **Trucha arcoíris** (*Oncorhynchus mykiss*) — cardumen en el reservorio, franja rosada iridiscente
- **Capitán de la sabana** (*Eremophilus mutisii*) — bentónico, roza el fondo (endémico altiplano cundiboyacense)
- **Sabaleta** (*Brycon henni*) — remonta la quebrada

**Aves de ribera:** Garza real (*Ardea alba*), Martín pescador amazónico (*Chloroceryle amazona*), Mirla de agua (*Cinclus leucocephalus*, cabecea como buen dipper).
**Anfibios:** Rana de quebrada (*Pristimantis* sp.) en piedra, con canto del buche.
**Insectos:** libélulas (Odonata) revoloteando — bioindicador de agua limpia.

## Vegetación de ribera (reemplaza el árbol genérico)

- **Aliso** (*Alnus acuminata*) — guardián del nacimiento (ronda hídrica), también en el monte del ojo de agua
- **Sauce** (*Salix humboldtiana*) — ramas colgantes sobre el agua
- **Guadua** (*Guadua angustifolia*) — macolla de culmos anillados a la vera de la quebrada

## Respaldo (grounding)

DR `fauna-acuatica-y-riberea-…-b158c9b7` (gemini grounded — AUNAP, Instituto Humboldt, U.D.C.A., WWF Colombia, GBIF). El gemelo *glm* se descartó por alucinar filas repetidas. Vegetación de ribera: agroforestería/silvopastoril andino y ronda hídrica (Alnus/Guadua canónicas). Cada especie lleva su piso térmico, nota visual y fuente en `faunaAcuatica.data.js`.

## Alcance / cuidados

- **Solo el mundo del agua** + geometría nueva en `src/visual/mundo3d/agua/` (3 archivos nuevos) + wiring en `MundoAgua3D.jsx`. **No toca** valle, bosque ni juegos.
- Reutiliza `PALETA` y el material de agua (`PALETA.agua`); reservorio y quebrada un poco más translúcidos para dejar ver los peces.
- Low-poly (MeshLambert/Basic, sin shadow-maps), determinista (cero `Math.random`), respeta `reducedMotion` y presupuesto por `tier`.

## Verificación

- `npm run build:prod` **verde**.
- `eslint` limpio; test de contrato `mundoAgua.test.jsx` **5/5** (no afectado).
- Verificado con **4 capturas de día seguidas** (render intermitente): todas pintan, **ninguna negra**. Peces visibles bajo la lámina, garza al acecho, libélulas sobre el agua, bosque de galería (aliso/sauce/guadua) a lo largo de la quebrada.