### PR TITLE
art(fauna): fauna emblemática del piso cálido en cafetal y cacaotal 3D

### DIFF
--- a/src/visual/creatures/Guacamaya.jsx
+++ b/src/visual/creatures/Guacamaya.jsx
@@ -1,0 +1,126 @@
+import { useId } from 'react';
+import './faunaCalido.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/*
+ * Guacamaya — GUACAMAYA BANDERA / guacamayo rojo, Ara macao (Psittacidae).
+ *
+ * La guacamaya insignia del piso cálido-tropical bajo colombiano (0–1.000 msnm):
+ * plumaje ROJO ESCARLATA brillante, con la banda AMARILLA y las puntas AZULES en
+ * las alas y la cola larga, CARA BLANCA desnuda y el pico grande — maxila clara,
+ * mandíbula oscura. Vuela en parejas o bandadas sobre el dosel; dispersora de
+ * semillas. Aquí va EN VUELO con las alas abiertas, cruzando el cielo del
+ * cafetal/cacaotal. Fuente: DR piso-cálido (gemini, GBIF Ara macao 2479361).
+ *
+ * Billboard LIGERO (sin kit rubber-hose). Vista ventral en vuelo. Las alas
+ * aletean (fc-wing--ave). API estable: { size, className, inline, animated, title }.
+ */
+const VIEWBOX = '-42 -26 84 62';
+
+const ROJO = '#e03726';        // escarlata
+const ROJO2 = '#f2513a';       // escarlata con luz
+const AMARILLO = '#f3c024';    // la banda amarilla del ala
+const AZUL = '#2f61c4';        // puntas azules de alas y cola
+const CARA = '#f3ede1';        // cara blanca desnuda
+const PICO_SUP = '#e6ddca';    // maxila clara
+const PICO_INF = '#2a2018';    // mandíbula oscura
+const INK = '#20120c';
+
+/* Un ala escarlata→amarillo→azul (la bandera de la especie), dibujada a la
+   izquierda; el lado derecho la refleja con scale(-1,1). */
+function Ala() {
+  return (
+    <g>
+      {/* pluma coberteras escarlata (hombro) */}
+      <path d="M-3,-6 C-14,-9 -24,-8 -31,-3 C-24,-1 -13,-1 -3,-1 Z" fill={ROJO} stroke={INK} strokeWidth="1.2" strokeLinejoin="round" />
+      {/* banda AMARILLA media */}
+      <path d="M-13,-2.4 C-22,-3 -30,-2.4 -35,0.4 C-29,1.6 -20,1.6 -12,0.8 Z" fill={AMARILLO} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+      {/* rémiges AZULES (puntas) */}
+      <path d="M-24,-0.6 C-31,-0.8 -37,0.4 -40,2.8 C-34,3.6 -27,3 -21,1.6 Z" fill={AZUL} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+      {/* separación de plumas primarias */}
+      <path d="M-27,1 L-33,1.2 M-31,0 L-37,1.6" stroke={INK} strokeWidth="0.6" opacity="0.5" />
+    </g>
+  );
+}
+
+export function Guacamaya({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Guacamaya bandera (Ara macao)',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `fc-glow-${uid}`;
+  const blur = `fc-blur-${uid}`;
+  const alaL = animated ? 'fc-wing-l fc-wing--ave' : undefined;
+  const alaR = animated ? 'fc-wing-r fc-wing--ave' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+
+  const body = (
+    <g className="fc-body" filter={`url(#${glow})`}>
+      {/* COLA larga escarlata con la pluma central azul (cuelga en vuelo) */}
+      <path d="M-3.4,4 C-4,14 -3.4,22 -2,25 C-0.6,22 -0.2,14 -0.6,5 Z" fill={ROJO} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+      <path d="M0.6,5 C0.2,14 0.6,22 2,25 C3.4,22 4,14 3.4,4 Z" fill={ROJO2} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+      <path d="M-1,6 C-1.2,13 -1,20 0,23.5 C1,20 1.2,13 1,6 Z" fill={AZUL} opacity="0.85" />
+
+      {/* ALA izquierda (aletea) */}
+      <g className={alaL}>
+        <Ala />
+      </g>
+      {/* ALA derecha (espejo, aletea) */}
+      <g className={alaR} transform="scale(-1,1)">
+        <Ala />
+      </g>
+
+      {/* patas recogidas bajo el cuerpo */}
+      <path d="M-2,6 C-2.6,8 -2.4,9.4 -1.6,10 M2,6 C2.6,8 2.4,9.4 1.6,10" stroke={PICO_INF} strokeWidth="1.4" fill="none" strokeLinecap="round" />
+
+      {/* CUERPO escarlata (gota) */}
+      <ellipse cx="0" cy="-2" rx="7" ry="9.5" fill={ROJO} stroke={INK} strokeWidth="1.3" />
+      <ellipse cx="-1.6" cy="-4" rx="3.6" ry="5" fill={ROJO2} opacity="0.7" />
+
+      {/* CABEZA con cara blanca y pico ganchudo */}
+      <circle cx="0" cy="-14" r="6.2" fill={ROJO} stroke={INK} strokeWidth="1.2" />
+      {/* cara blanca desnuda (la firma de la bandera) */}
+      <path d="M-5,-15.5 C-5.5,-12 -3,-9.6 0,-9.6 C3,-9.6 5.5,-12 5,-15.5 C3,-16.4 -3,-16.4 -5,-15.5 Z"
+        fill={CARA} stroke="#d9cfbf" strokeWidth="0.8" strokeLinejoin="round" />
+      {/* rayas de plumas finas sobre la cara blanca */}
+      <path d="M-4,-14.5 h3 M-4,-13.2 h4 M1,-14.5 h3 M0,-13.2 h4" stroke={ROJO} strokeWidth="0.5" opacity="0.55" />
+      {/* ojos */}
+      <circle cx="-2.6" cy="-14.6" r="1.3" fill="#1a120c" />
+      <circle cx="2.6" cy="-14.6" r="1.3" fill="#1a120c" />
+      <circle cx="-3" cy="-15.1" r="0.4" fill="#f4f7ff" />
+      <circle cx="2.2" cy="-15.1" r="0.4" fill="#f4f7ff" />
+      {/* PICO ganchudo: maxila clara grande + mandíbula oscura */}
+      <path d="M-3.4,-11.2 C-1.5,-9.4 1.5,-9.4 3.4,-11.2 C2.4,-7 0,-5 -0.2,-5 C-0.4,-5 -2.4,-7 -3.4,-11.2 Z"
+        fill={PICO_SUP} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+      <path d="M-2.2,-8 C-0.8,-6.8 0.8,-6.8 2.2,-8 C1.4,-5.6 0,-4.6 0,-4.6 C0,-4.6 -1.4,-5.6 -2.2,-8 Z" fill={PICO_INF} />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="guacamaya">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="guacamaya" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default Guacamaya;

--- a/src/visual/creatures/Iguana.jsx
+++ b/src/visual/creatures/Iguana.jsx
@@ -1,0 +1,138 @@
+import { useId } from 'react';
+import './faunaCalido.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/*
+ * Iguana — IGUANA VERDE, Iguana iguana (Iguanidae).
+ *
+ * El gran lagarto arbóreo del piso cálido-tropical bajo colombiano (0–1.000
+ * msnm): VERDE brillante, con la PAPADA (gular) prominente bajo la garganta, la
+ * CRESTA de espinas dorsales, el escudo redondo de la mejilla (subtimpánico) y la
+ * COLA larga ANILLADA. Herbívora y dispersora de semillas; suele asolearse en
+ * ramas cerca del agua. Aquí va POSADA a lo largo de una rama, quieta, tomando el
+ * sol, con la papada latiendo. Fuente: DR piso-cálido (gemini, GBIF Iguana
+ * iguana 2470396).
+ *
+ * Billboard LIGERO (sin kit rubber-hose). Perfil lateral mirando a la izquierda.
+ * API estable: { size, className, inline, animated, title }.
+ */
+const VIEWBOX = '-34 -20 68 42';
+
+const VERDE = '#54a13c';       // verde iguana
+const VERDE_LUZ = '#74c257';   // el lomo al sol
+const VERDE_OSC = '#3a7029';   // bandas / sombra
+const PAPADA = '#7cc05a';      // la papada gular
+const MEJILLA = '#d3dd95';     // escudo redondo de la mejilla (subtimpánico)
+const CRESTA = '#35662a';      // espinas dorsales
+const RAMA = '#6b4a30';
+const GARRA = '#241d14';
+const INK = '#152210';
+
+export function Iguana({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Iguana verde (Iguana iguana)',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `fc-glow-${uid}`;
+  const blur = `fc-blur-${uid}`;
+  const papada = animated ? 'fc-dewlap' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+
+  // La rama a lo largo de la que se asolea (estática, bajo la panza).
+  const rama = (
+    <g aria-hidden="true">
+      <path d="M-30,11 C-10,9.6 14,9.6 31,11 C14,12.6 -10,12.6 -30,11 Z"
+        fill={RAMA} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+    </g>
+  );
+
+  // Espinas de la cresta dorsal a lo largo del lomo.
+  const crestaDorsal = (
+    <g fill={CRESTA}>
+      {[[-13, -6.4], [-9, -7.2], [-5, -7.6], [-1, -7.7], [3, -7.4], [7, -6.8], [11, -5.6], [15, -4.2]].map((p, i) => (
+        <path key={i} d={`M${p[0] - 1.1},${p[1] + 1} L${p[0]},${p[1] - 2.2} L${p[0] + 1.1},${p[1] + 1} Z`} />
+      ))}
+    </g>
+  );
+
+  const body = (
+    <g className="fc-body" filter={`url(#${glow})`}>
+      {/* COLA larga ANILLADA (se afila a la derecha) */}
+      <path d="M9,-3 C18,-2.4 26,-0.6 32,2.4 C26,3.2 17,2.6 9,1 Z" fill={VERDE} stroke={INK} strokeWidth="1.2" strokeLinejoin="round" />
+      {/* anillos oscuros de la cola */}
+      <g stroke={VERDE_OSC} strokeWidth="1.4" fill="none" opacity="0.8">
+        <path d="M14,-1.8 L14.6,1.8" />
+        <path d="M19,-1 L19.6,2.2" />
+        <path d="M24,-0.2 L24.4,2.4" />
+        <path d="M28,0.6 L28.2,2.6" />
+      </g>
+
+      {/* patas: trasera y delantera agarrando la rama con garras */}
+      <path d="M6,6 C7.4,9 7,11 5,12" stroke={VERDE} strokeWidth="3.6" fill="none" strokeLinecap="round" />
+      <path d="M4,11.6 l-2,1.4 m2.4,-0.8 l-1.2,1.8 m2,-1.8 l0,2" stroke={GARRA} strokeWidth="0.9" fill="none" strokeLinecap="round" />
+      <path d="M-8,6 C-9,9 -8.6,11 -7,12" stroke={VERDE_LUZ} strokeWidth="3.4" fill="none" strokeLinecap="round" />
+      <path d="M-7.6,11.6 l-2,1.4 m2.4,-0.8 l-1.2,1.8 m2,-1.8 l0,2" stroke={GARRA} strokeWidth="0.9" fill="none" strokeLinecap="round" />
+
+      {/* CUERPO verde alargado */}
+      <path d="M-14,-4 C-8,-8 6,-8 12,-3 C13,0 12,4 8,6 C0,8 -8,7 -13,4 C-16,1 -16,-2 -14,-4 Z"
+        fill={VERDE} stroke={INK} strokeWidth="1.3" strokeLinejoin="round" />
+      {/* lomo al sol */}
+      <path d="M-12,-4.4 C-6,-7 4,-7 10,-3.4 C4,-4.8 -6,-5 -12,-3 Z" fill={VERDE_LUZ} opacity="0.75" />
+      {/* bandas oscuras del cuerpo */}
+      <g stroke={VERDE_OSC} strokeWidth="1.6" fill="none" opacity="0.6" strokeLinecap="round">
+        <path d="M-6,-6 C-6.6,-1 -6,3 -5,6" />
+        <path d="M0,-6.6 C-0.6,-1 0,3.4 1,6.4" />
+        <path d="M6,-5.6 C5.6,-1 6,3 6.6,5.4" />
+      </g>
+      {crestaDorsal}
+
+      {/* PAPADA gular (late suave) — cuelga de la garganta */}
+      <g className={papada}>
+        <path d="M-16,-1 C-18,3 -17.6,7 -14.6,8 C-13,5 -13,1 -13.6,-2 Z" fill={PAPADA} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+      </g>
+
+      {/* CABEZA a la izquierda */}
+      <path d="M-13,-5 C-19,-5.4 -23,-3.6 -23.4,-1 C-23.6,1.4 -21,3 -16,2.6 C-13,2.2 -12,-1 -13,-5 Z"
+        fill={VERDE} stroke={INK} strokeWidth="1.2" strokeLinejoin="round" />
+      {/* escudo redondo de la mejilla (subtimpánico) — la firma */}
+      <circle cx="-16.5" cy="-0.4" r="2.6" fill={MEJILLA} stroke="#b6c473" strokeWidth="0.8" />
+      {/* ojo */}
+      <circle cx="-19.2" cy="-2.4" r="1.5" fill="#1a1a0e" />
+      <circle cx="-19.6" cy="-2.9" r="0.45" fill="#f2f6dd" />
+      {/* boca */}
+      <path d="M-23.2,-0.4 C-21,0.4 -18,0.6 -15.5,0.2" fill="none" stroke={INK} strokeWidth="0.9" strokeLinecap="round" />
+      {/* espinas pequeñas de la nuca */}
+      <path d="M-13.6,-5.2 l0.6,-2 l1,1.8 M-11.6,-5 l0.6,-2 l1,1.8" fill={CRESTA} />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="iguana">
+        {defs}
+        {rama}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="iguana" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {rama}
+      {body}
+    </svg>
+  );
+}
+
+export default Iguana;

--- a/src/visual/creatures/MicoMaicero.jsx
+++ b/src/visual/creatures/MicoMaicero.jsx
@@ -1,0 +1,128 @@
+import { useId } from 'react';
+import './faunaCalido.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/*
+ * MicoMaicero — MICO MAICERO / mono ardilla, Saimiri sciureus (Cebidae).
+ *
+ * El primate ágil del bosque cálido-tropical bajo colombiano (0–1.000 msnm):
+ * pequeño, CUERPO gris-oliva, la MÁSCARA BLANCA alrededor de los ojos con el
+ * hocico negro (su firma), la CORONA oscura, las EXTREMIDADES amarillo-anaranjado
+ * y la COLA larga NO prensil de punta oscura. Frugívoro dispersor de semillas e
+ * insectívoro (control biológico). Aquí va SENTADO en una rama del sombrío,
+ * curioso, con la cola colgando y meciéndose. Fuente: DR piso-cálido (gemini,
+ * GBIF Saimiri sciureus 2436605).
+ *
+ * Billboard LIGERO (sin kit rubber-hose). API estable:
+ * { size, className, inline, animated, title }.
+ */
+const VIEWBOX = '-26 -27 52 55';
+
+const CUERPO = '#948f79';      // gris-oliva
+const CUERPO_LUZ = '#a9a488';  // el lomo con luz
+const NARANJA = '#cf9a4c';     // extremidades amarillo-anaranjado
+const NARANJA2 = '#e0b062';
+const CARA = '#efeade';        // máscara blanca
+const CORONA = '#46433a';      // corona/hocico oscuros
+const HOCICO = '#241f18';      // negro del morro
+const RAMA = '#6b4a30';
+const INK = '#171410';
+
+export function MicoMaicero({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Mico maicero / mono ardilla (Saimiri sciureus)',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `fc-glow-${uid}`;
+  const blur = `fc-blur-${uid}`;
+  const cola = animated ? 'fc-tail fc-tail--der' : undefined;
+  const cabeza = animated ? 'fc-nod' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+
+  // La rama del sombrío (estática, detrás de las patas).
+  const rama = (
+    <g aria-hidden="true">
+      <path d="M-22,17 C-8,15.6 10,15.6 23,17 C10,18.4 -8,18.4 -22,17 Z"
+        fill={RAMA} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+    </g>
+  );
+
+  const body = (
+    <g className="fc-body" filter={`url(#${glow})`}>
+      {/* COLA larga NO prensil, cuelga por la derecha y se enrosca (se mece) */}
+      <g className={cola}>
+        <path d="M7,6 C15,7 20,12 20,18 C20,23 16,26 12,24 C15.4,24.4 17.6,22 17.4,18.4 C17.2,13.6 12.6,9.6 6,8.6 Z"
+          fill={CUERPO} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+        <path d="M13,24 C15.4,24.4 17.6,22 17.4,18.4 C16,21.6 14,23.4 12,23.6 Z" fill={HOCICO} />
+      </g>
+
+      {/* patas traseras dobladas agarrando la rama */}
+      <path d="M-5,9 C-7,12 -6.4,15 -4,16.4" stroke={NARANJA} strokeWidth="3.4" fill="none" strokeLinecap="round" />
+      <path d="M5,9 C7,12 6.4,15 4,16.4" stroke={NARANJA} strokeWidth="3.4" fill="none" strokeLinecap="round" />
+      <path d="M-4.4,16 l-2.2,0.8 M4.4,16 l2.2,0.8" stroke={HOCICO} strokeWidth="1.3" fill="none" strokeLinecap="round" />
+
+      {/* cuerpo gris-oliva sentado */}
+      <ellipse cx="0" cy="3" rx="8" ry="9.5" fill={CUERPO} stroke={INK} strokeWidth="1.3" />
+      <path d="M-4,-3 C1,-1 6,0 7.5,4 C4,2.5 -2,2 -5,4 Z" fill={CUERPO_LUZ} opacity="0.7" />
+      {/* pecho más claro */}
+      <ellipse cx="0" cy="4.5" rx="4.4" ry="6" fill={NARANJA2} opacity="0.35" />
+
+      {/* bracitos amarillos recogidos al pecho (curioso) */}
+      <path d="M-5,-1 C-8,1 -8.4,4 -6.6,6.4 C-5,5 -3.6,3 -3.4,1 Z" fill={NARANJA} stroke={INK} strokeWidth="1" strokeLinejoin="round" />
+      <path d="M5,-1 C8,1 8.4,4 6.6,6.4 C5,5 3.6,3 3.4,1 Z" fill={NARANJA} stroke={INK} strokeWidth="1" strokeLinejoin="round" />
+      <path d="M-6.4,6.2 l-1.4,1.2 m0.6,-2.2 l-1.6,0.8 M6.4,6.2 l1.4,1.2 m-0.6,-2.2 l1.6,0.8" stroke={HOCICO} strokeWidth="0.9" fill="none" strokeLinecap="round" />
+
+      {/* CABEZA (cabecea despacio) */}
+      <g className={cabeza}>
+        {/* corona oscura */}
+        <path d="M-6.6,-9.5 C-6,-13.6 6,-13.6 6.6,-9.5 C4,-11 -4,-11 -6.6,-9.5 Z" fill={CORONA} />
+        {/* cráneo gris */}
+        <circle cx="0" cy="-8.5" r="6.3" fill={CUERPO} stroke={INK} strokeWidth="1.2" />
+        {/* MÁSCARA BLANCA con arcos puntudos sobre los ojos (la firma) */}
+        <path d="M-6,-8.8 C-5.4,-12 -2.4,-12.4 -1.2,-9.6 C-0.4,-11 0.4,-11 1.2,-9.6 C2.4,-12.4 5.4,-12 6,-8.8 C6,-5.6 3.6,-4 0,-4 C-3.6,-4 -6,-5.6 -6,-8.8 Z"
+          fill={CARA} stroke="#ddd8c9" strokeWidth="0.7" strokeLinejoin="round" />
+        {/* orejitas */}
+        <circle cx="-6.2" cy="-9" r="1.8" fill={CUERPO} stroke={INK} strokeWidth="0.9" />
+        <circle cx="6.2" cy="-9" r="1.8" fill={CUERPO} stroke={INK} strokeWidth="0.9" />
+        {/* ojos grandes dentro de la máscara */}
+        <circle cx="-2.5" cy="-8.4" r="1.8" fill={HOCICO} />
+        <circle cx="2.5" cy="-8.4" r="1.8" fill={HOCICO} />
+        <circle cx="-3" cy="-9" r="0.55" fill="#f3f7ff" />
+        <circle cx="2" cy="-9" r="0.55" fill="#f3f7ff" />
+        {/* HOCICO negro (la boca-máscara oscura de Saimiri) */}
+        <ellipse cx="0" cy="-4.4" rx="2.6" ry="2.1" fill={HOCICO} />
+        <path d="M-1.2,-4 C-0.4,-3.2 0.4,-3.2 1.2,-4" fill="none" stroke="#0c0a07" strokeWidth="0.7" strokeLinecap="round" />
+      </g>
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="mico-maicero">
+        {defs}
+        {rama}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="mico-maicero" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {rama}
+      {body}
+    </svg>
+  );
+}
+
+export default MicoMaicero;

--- a/src/visual/creatures/MorphoAzul.jsx
+++ b/src/visual/creatures/MorphoAzul.jsx
@@ -1,0 +1,109 @@
+import { useId } from 'react';
+import './faunaCalido.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/*
+ * MorphoAzul — mariposa MORFO AZUL, Morpho peleides (Nymphalidae).
+ *
+ * La mariposa emblema del bosque húmedo del piso cálido-tropical bajo colombiano
+ * (0–1.400 msnm): alas grandes de un AZUL IRIDISCENTE metálico estructural en la
+ * cara superior, con borde negro ancho, y el envés pardo con ocelos (que apenas
+ * insinuamos). Vuelo lento y ondulante — por eso en la escena deriva ancho y
+ * pausado. Polinizadora/frugívora en el sotobosque del cafetal y el cacaotal.
+ * Fuente: DR piso-cálido (gemini, GBIF Morpho peleides 190872740).
+ *
+ * Hermana LIGERA de la Mariposa pasionaria: NO arrastra el kit rubber-hose
+ * (sin lip-sync/clima/poder) — es un billboard de dosel. Cuatro alas (delanteras
+ * + traseras, izq/der) que abren y cierran (fc-wing), cuerpo, antenas y ocelos.
+ * API estable: { size, className, inline, animated, title }.
+ */
+const VIEWBOX = '-30 -22 60 46';
+
+const AZUL = '#2f6bd6';        // azul morfo iridiscente (cara superior)
+const AZUL_CLARO = '#63a0f2';  // el brillo estructural que corre por el ala
+const BORDE = '#141b2e';       // el borde negro ancho de la especie
+const PARDO = '#5a4632';       // asomo del envés pardo en el borde interno
+const CUERPO = '#241a12';      // cuerpo/antenas
+const OCELO = '#e9eef7';       // punto claro (ocelo insinuado)
+
+export function MorphoAzul({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Morfo azul (Morpho peleides)',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `fc-glow-${uid}`;
+  const blur = `fc-blur-${uid}`;
+  const alaL = animated ? 'fc-wing-l' : undefined;
+  const alaR = animated ? 'fc-wing-r' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+
+  const body = (
+    <g className="fc-body" filter={`url(#${glow})`}>
+      {/* ── ala TRASERA izquierda (lóbulo bajo, con el asomo pardo del envés) ── */}
+      <g className={alaL}>
+        <path d="M0,-1 C-19,-4 -27,7 -22,15 C-16,21 -4,15 0,4 Z" fill={AZUL} />
+        <path d="M0,-1 C-19,-4 -27,7 -22,15 C-16,21 -4,15 0,4 Z" fill="none" stroke={BORDE} strokeWidth="2.2" strokeLinejoin="round" />
+        <path d="M-3,2 C-10,4 -16,8 -19,13" fill="none" stroke={AZUL_CLARO} strokeWidth="1.1" opacity="0.75" />
+        <path d="M-18,15 C-14,17 -8,15 -3,10" fill={PARDO} opacity="0.4" />
+        <circle cx="-16" cy="13" r="1.5" fill={OCELO} opacity="0.7" />
+      </g>
+      {/* ── ala TRASERA derecha ── */}
+      <g className={alaR}>
+        <path d="M0,-1 C19,-4 27,7 22,15 C16,21 4,15 0,4 Z" fill={AZUL} />
+        <path d="M0,-1 C19,-4 27,7 22,15 C16,21 4,15 0,4 Z" fill="none" stroke={BORDE} strokeWidth="2.2" strokeLinejoin="round" />
+        <path d="M3,2 C10,4 16,8 19,13" fill="none" stroke={AZUL_CLARO} strokeWidth="1.1" opacity="0.75" />
+        <path d="M18,15 C14,17 8,15 3,10" fill={PARDO} opacity="0.4" />
+        <circle cx="16" cy="13" r="1.5" fill={OCELO} opacity="0.7" />
+      </g>
+      {/* ── ala DELANTERA izquierda (grande, la firma azul metálico) ── */}
+      <g className={alaL}>
+        <path d="M0,-3 C-15,-19 -29,-16 -27,-4 C-25,5 -11,2 0,0 Z" fill={AZUL} />
+        <path d="M0,-3 C-15,-19 -29,-16 -27,-4 C-25,5 -11,2 0,0 Z" fill="none" stroke={BORDE} strokeWidth="2.4" strokeLinejoin="round" />
+        <path d="M-3,-2 C-11,-6 -19,-9 -25,-8" fill="none" stroke={AZUL_CLARO} strokeWidth="1.4" opacity="0.85" />
+        <path d="M-6,-6 C-12,-10 -18,-12 -23,-11" fill="none" stroke={AZUL_CLARO} strokeWidth="1" opacity="0.6" />
+      </g>
+      {/* ── ala DELANTERA derecha ── */}
+      <g className={alaR}>
+        <path d="M0,-3 C15,-19 29,-16 27,-4 C25,5 11,2 0,0 Z" fill={AZUL} />
+        <path d="M0,-3 C15,-19 29,-16 27,-4 C25,5 11,2 0,0 Z" fill="none" stroke={BORDE} strokeWidth="2.4" strokeLinejoin="round" />
+        <path d="M3,-2 C11,-6 19,-9 25,-8" fill="none" stroke={AZUL_CLARO} strokeWidth="1.4" opacity="0.85" />
+        <path d="M6,-6 C12,-10 18,-12 23,-11" fill="none" stroke={AZUL_CLARO} strokeWidth="1" opacity="0.6" />
+      </g>
+      {/* cuerpo, cabeza y antenas */}
+      <ellipse cx="0" cy="1" rx="2.1" ry="10.5" fill={CUERPO} />
+      <circle cx="0" cy="-10" r="2.2" fill={CUERPO} />
+      <path d="M-1,-11.4 C-3.4,-16 -5,-17.6 -7.2,-17.4 M1,-11.4 C3.4,-16 5,-17.6 7.2,-17.4"
+        stroke={CUERPO} strokeWidth="1" fill="none" strokeLinecap="round" />
+      <circle cx="-7.2" cy="-17.4" r="1.1" fill={CUERPO} />
+      <circle cx="7.2" cy="-17.4" r="1.1" fill={CUERPO} />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="morfo-azul">
+        {defs}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="morfo-azul" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {body}
+    </svg>
+  );
+}
+
+export default MorphoAzul;

--- a/src/visual/creatures/Tucan.jsx
+++ b/src/visual/creatures/Tucan.jsx
@@ -1,0 +1,125 @@
+import { useId } from 'react';
+import './faunaCalido.css';
+import { CreatureFilters } from './_filters.jsx';
+
+/*
+ * Tucan — TUCÁN PECHIBLANCO, Ramphastos tucanus (Ramphastidae).
+ *
+ * El tucán grande del bosque húmedo del piso cálido-tropical bajo colombiano
+ * (0–1.000 msnm): ave robusta de PLUMAJE NEGRO, PECHO amarillo-blanco, banda
+ * roja en el vientre, coberteras supracaudales rojo-anaranjado, y su firma
+ * inconfundible — el PICO enorme, amarillo en el culmen y la base, CELESTE en la
+ * mandíbula inferior, con anillo ocular azul. Dispersor de semillas (frugívoro):
+ * el que siembra el monte tragando fruto y soltando la pepa lejos. Aquí va
+ * POSADO en una rama del sombrío. Fuente: DR piso-cálido (gemini, GBIF
+ * Ramphastos tucanus 2478235).
+ *
+ * Billboard LIGERO (sin kit rubber-hose). Perfil lateral mirando a la izquierda.
+ * API estable: { size, className, inline, animated, title }.
+ */
+const VIEWBOX = '-32 -26 62 54';
+
+const NEGRO = '#1c1c22';       // plumaje negro
+const NEGRO2 = '#2b2b34';      // negro con luz
+const PECHO = '#f4eccf';       // pecho amarillo-blanco (pechiblanco)
+const PECHO_BORDE = '#e9c85a'; // el reborde amarillo del pecho
+const ROJO = '#cf3524';        // banda del vientre + supracaudales
+const PICO_SUP = '#f2b21e';    // pico: culmen y base amarillos
+const PICO_INF = '#7ec7e0';    // pico: mandíbula inferior celeste
+const PICO_PUNTA = '#b8471f';  // ápice rojizo del pico
+const OJO_ANILLO = '#4f9bd6';  // anillo ocular azul
+const RAMA = '#6b4a30';
+const INK = '#141118';
+
+export function Tucan({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Tucán pechiblanco (Ramphastos tucanus)',
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `fc-glow-${uid}`;
+  const blur = `fc-blur-${uid}`;
+  const respira = animated ? 'fc-breathe' : undefined;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+    </defs>
+  );
+
+  // La rama del sombrío de la que se agarra (estática, detrás de las patas).
+  const rama = (
+    <g aria-hidden="true">
+      <path d="M-20,15 C-6,13.4 12,13.4 24,15 C12,16.6 -6,16.6 -20,15 Z"
+        fill={RAMA} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+    </g>
+  );
+
+  const body = (
+    <g className="fc-body" filter={`url(#${glow})`}>
+      {/* patas amarillas agarrando la rama */}
+      <path d="M0,9 L-1.4,14 M0,9 L1.6,14" stroke={PICO_SUP} strokeWidth="1.8" fill="none" strokeLinecap="round" />
+      <path d="M6,9 L4.6,14 M6,9 L7.6,14" stroke={PICO_SUP} strokeWidth="1.8" fill="none" strokeLinecap="round" />
+
+      {/* cola negra cocada hacia arriba-atrás, con las supracaudales rojas */}
+      <path d="M9,-2 C17,-3 22,2 20,10 C17,12 12,9 10,4 Z" fill={NEGRO} stroke={INK} strokeWidth="1.2" strokeLinejoin="round" />
+      <path d="M16,7 C18,8.5 19.4,10 19.6,11.6 C17.6,11 15.6,9.6 14.6,8 Z" fill={ROJO} />
+
+      {/* cuerpo negro (respira) */}
+      <g className={respira}>
+        <ellipse cx="3" cy="1" rx="10" ry="11" fill={NEGRO} stroke={INK} strokeWidth="1.3" />
+        <ellipse cx="0.5" cy="-1.5" rx="6" ry="6.5" fill={NEGRO2} opacity="0.6" />
+        {/* pecho amarillo-blanco al frente (pechiblanco) */}
+        <path d="M-6.5,-6 C-11,-1 -11,7 -5,10 C-1,11.4 2,10 3.6,7 C0,7 -3.4,3 -3.4,-2 C-3.4,-5 -5,-6.4 -6.5,-6 Z"
+          fill={PECHO} stroke={PECHO_BORDE} strokeWidth="1.1" strokeLinejoin="round" />
+        {/* banda roja del vientre */}
+        <path d="M-5,9 C-1.5,11 2,10.4 4,8.4 C1.4,10.8 -3,11 -5.6,9.8 Z" fill={ROJO} />
+      </g>
+
+      {/* cabeza negra */}
+      <circle cx="-4" cy="-6.5" r="6.2" fill={NEGRO} stroke={INK} strokeWidth="1.2" />
+      {/* anillo ocular azul + ojo */}
+      <circle cx="-6.4" cy="-8" r="2.5" fill={OJO_ANILLO} />
+      <circle cx="-6.6" cy="-8" r="1.5" fill="#0c0c12" />
+      <circle cx="-7.2" cy="-8.6" r="0.5" fill="#f3f7ff" />
+
+      {/* EL PICO enorme — la firma. Base en la cara, se afila a la izquierda. */}
+      {/* mandíbula superior (culmen amarillo) */}
+      <path d="M-8,-9.4 C-16,-11 -25,-8.6 -28.6,-5.4 C-24,-5.6 -16,-5.8 -9,-5.6 Z"
+        fill={PICO_SUP} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+      {/* mandíbula inferior (celeste) */}
+      <path d="M-9,-5.2 C-17,-4.8 -24,-4.6 -28.6,-5.2 C-24,-2.6 -16,-1.2 -9,-1.6 Z"
+        fill={PICO_INF} stroke={INK} strokeWidth="1.1" strokeLinejoin="round" />
+      {/* la línea del culmen (borde superior más oscuro) */}
+      <path d="M-8.4,-9.2 C-16,-10.6 -24.4,-8.4 -28.4,-5.5" fill="none" stroke="#c8901a" strokeWidth="1" opacity="0.8" />
+      {/* ápice rojizo del pico */}
+      <path d="M-27,-5.3 C-28.6,-5.4 -29.2,-5.4 -28.9,-5.5 C-28.9,-5.2 -28.2,-4.9 -27,-4.6 Z" fill={PICO_PUNTA} />
+      {/* la comisura donde las mandíbulas se juntan */}
+      <path d="M-8.6,-5.4 L-28.4,-5.3" stroke={INK} strokeWidth="0.7" opacity="0.5" />
+    </g>
+  );
+
+  if (inline) {
+    return (
+      <g className={className} data-creature="tucan">
+        {defs}
+        {rama}
+        {body}
+      </g>
+    );
+  }
+  return (
+    <svg viewBox={VIEWBOX} width={size} height={size} className={className}
+      role="img" aria-label={title} data-creature="tucan" {...rest}>
+      <title>{title}</title>
+      {defs}
+      {rama}
+      {body}
+    </svg>
+  );
+}
+
+export default Tucan;

--- a/src/visual/creatures/faunaCalido.css
+++ b/src/visual/creatures/faunaCalido.css
@@ -1,0 +1,103 @@
+/*
+ * faunaCalido.css — el idle interno de la fauna del PISO CÁLIDO (tucán,
+ * guacamaya, mico, iguana, morfo). Self-contained: keyframes propios con prefijo
+ * `fc-` para no pisar `creatures.css` (el kit rubber-hose de la casa). El
+ * movimiento de POSICIÓN en la escena lo pone el billboard (useFrame); aquí solo
+ * vive el gesto DENTRO del dibujo: aletear, mecer la cola, respirar, la papada.
+ *
+ * Los componentes SOLO montan estas clases con `animated` (billboard vivo). Aun
+ * así el guard de reduced-motion al final las apaga por si alguien las usa de
+ * avatar sin apagar `animated`.
+ */
+
+.fc-billboard {
+  pointer-events: none;
+  will-change: transform;
+  filter: drop-shadow(0 3px 4px rgba(22, 30, 18, 0.34));
+}
+
+/* ── Alas (morfo + guacamaya): abren y cierran desde el cuerpo ─────────────── */
+.fc-wing-l,
+.fc-wing-r {
+  transform-box: fill-box;
+  will-change: transform;
+}
+.fc-wing-l {
+  transform-origin: right center;
+  animation: fc-flutter 0.9s ease-in-out infinite alternate;
+}
+.fc-wing-r {
+  transform-origin: left center;
+  animation: fc-flutter 0.9s ease-in-out infinite alternate;
+}
+@keyframes fc-flutter {
+  from { transform: scaleX(1); }
+  to { transform: scaleX(0.58); }
+}
+/* Aleteo de AVE (guacamaya en vuelo): más rápido y con un empuje vertical. */
+.fc-wing-l.fc-wing--ave,
+.fc-wing-r.fc-wing--ave {
+  animation-duration: 0.62s;
+}
+
+/* ── Cola larga (mico / iguana): se mece pausada ──────────────────────────── */
+.fc-tail {
+  transform-box: fill-box;
+  transform-origin: 0% 50%;
+  will-change: transform;
+  animation: fc-tailsway 2.6s ease-in-out infinite alternate;
+}
+.fc-tail--der {
+  transform-origin: 100% 50%;
+}
+@keyframes fc-tailsway {
+  from { transform: rotate(-5deg); }
+  to { transform: rotate(6deg); }
+}
+
+/* ── Respiración del cuerpo (posado / asoleado): sube y baja el pecho ──────── */
+.fc-breathe {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  will-change: transform;
+  animation: fc-breathe 3.6s ease-in-out infinite alternate;
+}
+@keyframes fc-breathe {
+  from { transform: scaleY(1); }
+  to { transform: scaleY(1.035); }
+}
+
+/* ── Cabeceo (mico curioso): la cabeza inclina despacio ───────────────────── */
+.fc-nod {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  will-change: transform;
+  animation: fc-nod 2.9s ease-in-out infinite alternate;
+}
+@keyframes fc-nod {
+  from { transform: rotate(-4deg); }
+  to { transform: rotate(5deg); }
+}
+
+/* ── Papada de la iguana: late suave (termorregula) ───────────────────────── */
+.fc-dewlap {
+  transform-box: fill-box;
+  transform-origin: top center;
+  will-change: transform;
+  animation: fc-dewlap 4.2s ease-in-out infinite alternate;
+}
+@keyframes fc-dewlap {
+  from { transform: scaleY(1); }
+  to { transform: scaleY(1.12); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fc-wing-l,
+  .fc-wing-r,
+  .fc-tail,
+  .fc-breathe,
+  .fc-nod,
+  .fc-dewlap {
+    animation: none !important;
+  }
+}

--- a/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
+++ b/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
@@ -28,6 +28,7 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import { perfilDeTier } from '../deviceTier.js';
 import { Fauna } from '../escenas/FaunaEscena.jsx';
+import FaunaCalido from '../escenas/FaunaCalido.jsx';
 import FloraCacao from './FloraCacao.jsx';
 import { ANCHO, FONDO, alturaVega, SITIO_CASA } from './floraCacao.geom.js';
 import {
@@ -239,6 +240,22 @@ const FAUNA_CACAOTAL = [
   { tipo: 'escarabajo', base: [-1.2, 0.5, 6.2], patron: 'reptar', size: 22, fase: 1.2, df: 8 },
 ];
 
+/* La FAUNA EMBLEMÁTICA DEL PISO CÁLIDO-TROPICAL BAJO (0–1.200 m): el cacaotal ES
+   tierra caliente y su dosel está lleno de vida. Especies REALES colombianas con
+   su nombre científico, del DR fauna-piso-cálido (gemini, GBIF): la guacamaya
+   bandera que ronda en lo alto, el tucán posado, el perezoso colgado lentísimo,
+   el mico entre las ramas, la iguana asoleándose en el tronco caído y el morfo
+   azul del sotobosque. Billboards SVG con coreografía por nicho (FaunaCalido).
+   Orden = prominencia: el recorte por tier deja siempre lo insignia. */
+const FAUNA_CALIDO_CACAO = [
+  { tipo: 'guacamaya', base: [0, 6.2, -6.5], patron: 'vuela', size: 66, fase: 0.5, df: 13, title: 'Guacamaya bandera (Ara macao)' },
+  { tipo: 'tucan', base: [-3.0, 4.6, -1.0], patron: 'posa', size: 60, fase: 1.4, df: 9, title: 'Tucán pechiblanco (Ramphastos tucanus)' },
+  { tipo: 'perezoso', base: [3.4, 4.2, -0.4], patron: 'cuelga', size: 66, fase: 0.9, df: 9, title: 'Perezoso de tres dedos (Bradypus variegatus)' },
+  { tipo: 'mico', base: [5.6, 3.6, -1.4], patron: 'trepa', size: 54, fase: 2.2, df: 9, title: 'Mico maicero (Saimiri sciureus)' },
+  { tipo: 'iguana', base: [-5.2, 0.9, 3.0], patron: 'asolea', size: 58, fase: 0.3, df: 8.5, title: 'Iguana verde (Iguana iguana)' },
+  { tipo: 'morfo', base: [-1.8, 2.7, 3.0], patron: 'morfo', size: 40, fase: 0.6, df: 9, title: 'Morfo azul (Morpho peleides)' },
+];
+
 function Diorama({ tier, reducedMotion, foco }) {
   const perfil = perfilDeTier(tier);
 
@@ -268,6 +285,13 @@ function Diorama({ tier, reducedMotion, foco }) {
 
   const fauna = useMemo(
     () => (tier === 'alto' ? FAUNA_CACAOTAL : FAUNA_CACAOTAL.slice(0, 2)),
+    [tier],
+  );
+
+  /* La fauna emblemática del cálido: recortada por tier (alto todo el elenco;
+     medio deja lo insignia — guacamaya + tucán + perezoso). */
+  const faunaCalido = useMemo(
+    () => (tier === 'alto' ? FAUNA_CALIDO_CACAO : FAUNA_CALIDO_CACAO.slice(0, 3)),
     [tier],
   );
 
@@ -320,6 +344,10 @@ function Diorama({ tier, reducedMotion, foco }) {
 
       {/* LA VIDA que la sombra trae: mariposas y el escarabajo del mantillo */}
       {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
+
+      {/* LA FAUNA EMBLEMÁTICA DEL CÁLIDO: guacamaya en vuelo, tucán posado,
+          perezoso colgado, mico en las ramas, iguana al sol y el morfo azul. */}
+      {perfil.criaturas > 0 && <FaunaCalido items={faunaCalido} reducedMotion={reducedMotion} />}
 
       {/* el anillo del paso didáctico (lo maneja el host) */}
       <FocoPaso foco={foco} reducedMotion={reducedMotion} />

--- a/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
+++ b/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
@@ -27,6 +27,7 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import { perfilDeTier } from '../deviceTier.js';
 import { Fauna } from '../escenas/FaunaEscena.jsx';
+import FaunaCalido from '../escenas/FaunaCalido.jsx';
 import FloraCafetal from './FloraCafetal.jsx';
 import { ANCHO, FONDO, alturaLadera, SITIO_CASA } from './floraCafetal.geom.js';
 import {
@@ -214,6 +215,20 @@ const FAUNA_CAFETAL = [
   { tipo: 'mariposa', base: [7.2, 1.9, 0.6], patron: 'revoloteo', size: 22, fase: 2.9, df: 9 },
 ];
 
+/* La FAUNA EMBLEMÁTICA DEL PISO CÁLIDO que sube al cinturón cafetero bajo/
+   sub-andino (~1.000–1.400 m, donde el café templado y la tierra caliente se
+   tocan). Especies REALES colombianas con su nombre científico, del DR
+   fauna-piso-cálido (gemini, GBIF): la guacamaya que cruza en lo alto, el tucán
+   posado en el sombrío, el mico entre las ramas y el morfo azul del sotobosque.
+   Billboards SVG con coreografía por nicho (FaunaCalido). Orden = prominencia:
+   el recorte por tier deja siempre lo insignia. */
+const FAUNA_CALIDO_CAFETAL = [
+  { tipo: 'guacamaya', base: [0, 5.6, -6], patron: 'vuela', size: 62, fase: 0.4, df: 12, title: 'Guacamaya bandera (Ara macao)' },
+  { tipo: 'tucan', base: [-5.2, 3.5, -1.2], patron: 'posa', size: 60, fase: 1.1, df: 9, title: 'Tucán pechiblanco (Ramphastos tucanus)' },
+  { tipo: 'mico', base: [5.4, 3.2, -1.6], patron: 'trepa', size: 54, fase: 2.0, df: 9, title: 'Mico maicero (Saimiri sciureus)' },
+  { tipo: 'morfo', base: [-2.6, 2.3, 2.6], patron: 'morfo', size: 40, fase: 0.7, df: 9, title: 'Morfo azul (Morpho peleides)' },
+];
+
 function Diorama({ tier, reducedMotion, foco }) {
   const perfil = perfilDeTier(tier);
 
@@ -243,6 +258,13 @@ function Diorama({ tier, reducedMotion, foco }) {
 
   const fauna = useMemo(
     () => (tier === 'alto' ? FAUNA_CAFETAL : FAUNA_CAFETAL.slice(0, 2)),
+    [tier],
+  );
+
+  /* La fauna del cálido que asoma al café bajo: recortada por tier (alto todo,
+     medio deja lo insignia — guacamaya + tucán). */
+  const faunaCalido = useMemo(
+    () => (tier === 'alto' ? FAUNA_CALIDO_CAFETAL : FAUNA_CALIDO_CAFETAL.slice(0, 2)),
     [tier],
   );
 
@@ -295,6 +317,10 @@ function Diorama({ tier, reducedMotion, foco }) {
 
       {/* LA VIDA que la sombra trae: mariposas y el colibrí */}
       {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
+
+      {/* LA FAUNA DEL CÁLIDO que sube al café bajo: guacamaya en vuelo, tucán
+          posado, mico en las ramas y el morfo azul del sotobosque. */}
+      {perfil.criaturas > 0 && <FaunaCalido items={faunaCalido} reducedMotion={reducedMotion} />}
 
       {/* el anillo del paso didáctico (lo maneja el host) */}
       <FocoPaso foco={foco} reducedMotion={reducedMotion} />

--- a/src/visual/mundo3d/escenas/FaunaCalido.jsx
+++ b/src/visual/mundo3d/escenas/FaunaCalido.jsx
@@ -1,0 +1,151 @@
+/*
+ * FaunaCalido — SEMBRAR los mundos de TIERRA CALIENTE (cafetal, cacaotal) con la
+ * fauna emblemática del piso cálido-tropical bajo colombiano.
+ *
+ * La auditoría 3D marcó que a los mundos cálidos les faltaba SU fauna: el dosel
+ * del sombrío está lleno de vida en la tierra caliente y estaba mudo. Aquí entran
+ * los bichos que de verdad viven ese piso (0–1.000/1.400 msnm), cada uno como
+ * billboard SVG `<Html>` de drei (mismo patrón que FaunaEscena/CondorBillboard) y
+ * con un movimiento DICTADO POR SU NICHO — la creature pone el cuerpo, la escena
+ * pone la coreografía (contrato del DR):
+ *
+ *   · 'vuela'  guacamaya (Ara macao) — ronda el dosel en elipse ancha, banqueando.
+ *   · 'posa'   tucán (Ramphastos tucanus) — posado en la rama, respira, casi quieto.
+ *   · 'trepa'  mico maicero (Saimiri sciureus) — bandazos suaves entre ramas.
+ *   · 'cuelga' perezoso (Bradypus variegatus) — se mece LENTÍSIMO colgado.
+ *   · 'asolea' iguana (Iguana iguana) — quieta al sol, solo la papada late.
+ *   · 'morfo'  morfo azul (Morpho peleides) — deriva ancha y ondulante.
+ *
+ * POCOS y bien puestos por criterio ecológico (nunca un enjambre): son billboards
+ * DOM, así que la regla es la barata — 2–4 por escena, recortados por device-tier
+ * desde la escena. Con reduced-motion la escena corre `frameloop='demand'` y aquí
+ * `animated={false}` congela también el gesto interno del SVG. Importa
+ * three/@react-three → vive en escenas/ (chunk perezoso `vendor-three`).
+ */
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import { Tucan } from '../../creatures/Tucan.jsx';
+import { Guacamaya } from '../../creatures/Guacamaya.jsx';
+import { MicoMaicero } from '../../creatures/MicoMaicero.jsx';
+import { Iguana } from '../../creatures/Iguana.jsx';
+import { MorphoAzul } from '../../creatures/MorphoAzul.jsx';
+import { Perezoso } from '../../creatures/Perezoso.jsx';
+import '../../creatures/faunaCalido.css';
+
+/* La fauna reutilizable del piso cálido (cada clave = `tipo` de un item). */
+const COMPS = {
+  tucan: Tucan,
+  guacamaya: Guacamaya,
+  mico: MicoMaicero,
+  iguana: Iguana,
+  morfo: MorphoAzul,
+  perezoso: Perezoso,
+};
+
+/**
+ * Coreografía por NICHO: el offset [dx, dy, dz] (unidades de escena) respecto del
+ * ancla, dado el tiempo `t` y una `fase` que desincroniza a cada individuo. Pura y
+ * determinista (estable en SSR/tests). Amplitudes a medida: vida, no espectáculo.
+ * @param {'vuela'|'posa'|'trepa'|'cuelga'|'asolea'|'morfo'} patron
+ * @param {number} t
+ * @param {number} [fase]
+ * @returns {[number, number, number]}
+ */
+export function coreoCalido(patron, t, fase = 0) {
+  switch (patron) {
+    case 'vuela': {
+      // guacamaya rondando el dosel: elipse ancha y lenta + deriva de altura.
+      const a = t * 0.16 + fase;
+      return [Math.cos(a) * 3.4, Math.sin(t * 0.22 + fase) * 0.6, Math.sin(a) * 1.8];
+    }
+    case 'posa':
+      // tucán posado: respiro mínimo, presencia sin ruido.
+      return [Math.sin(t * 0.5 + fase) * 0.04, Math.abs(Math.sin(t * 0.8 + fase)) * 0.05, 0];
+    case 'trepa': {
+      // mico entre ramas: bandazos suaves en las tres direcciones.
+      const u = t * 0.3 + fase;
+      return [Math.sin(u) * 0.5, Math.sin(u * 1.7 + 1) * 0.28, Math.cos(u * 0.8) * 0.22];
+    }
+    case 'cuelga':
+      // perezoso: mecerse LENTÍSIMO (su gracia es la quietud).
+      return [Math.sin(t * 0.14 + fase) * 0.06, Math.sin(t * 0.1 + fase) * 0.04, 0];
+    case 'asolea':
+      // iguana asoleándose: casi inmóvil, apenas el fuelle de respirar.
+      return [0, Math.abs(Math.sin(t * 0.3 + fase)) * 0.02, 0];
+    case 'morfo':
+    default:
+      // morfo azul: vuelo lento y ondulante, deriva ancha por el sotobosque.
+      return [
+        Math.sin(t * 0.45 + fase) * 0.42,
+        Math.sin(t * 0.8 + fase) * 0.24,
+        Math.cos(t * 0.4 + fase) * 0.3,
+      ];
+  }
+}
+
+/** El banqueo (grados) del billboard según el nicho: la guacamaya se inclina al
+    girar; el morfo cabecea apenas; el resto va derecho. */
+function bancoCalido(patron, t, fase) {
+  if (patron === 'vuela') return Math.sin(t * 0.16 + fase) * 11;
+  if (patron === 'morfo') return Math.sin(t * 0.8 + fase) * 7;
+  return 0;
+}
+
+/**
+ * Un bicho del piso cálido, posado/volando en la escena como billboard.
+ * @param {object} p
+ * @param {'tucan'|'guacamaya'|'mico'|'iguana'|'morfo'|'perezoso'} p.tipo
+ * @param {[number,number,number]} p.base  ancla en coordenadas de la escena.
+ * @param {'vuela'|'posa'|'trepa'|'cuelga'|'asolea'|'morfo'} p.patron  nicho → gesto.
+ * @param {number} [p.size=64]  tamaño en px del SVG.
+ * @param {number} [p.fase=0]   desfase del vaivén.
+ * @param {number} [p.df=10]    distanceFactor del <Html> (escala en mundo).
+ * @param {string} [p.title]    especie + nombre científico (decorativo).
+ * @param {boolean} [p.reducedMotion=false]
+ */
+export function BichoCalido({
+  tipo, base, patron = 'morfo', size = 64, fase = 0, df = 10, title, reducedMotion = false,
+}) {
+  const grupo = useRef(/** @type {any} */ (null));
+  const capa = useRef(/** @type {HTMLDivElement|null} */ (null));
+  const Comp = COMPS[tipo];
+  useFrame((state) => {
+    if (reducedMotion || !grupo.current) return;
+    const t = state.clock.elapsedTime;
+    const [dx, dy, dz] = coreoCalido(patron, t, fase);
+    grupo.current.position.set(base[0] + dx, base[1] + dy, base[2] + dz);
+    if (capa.current) {
+      const b = bancoCalido(patron, t, fase);
+      capa.current.style.transform = b ? `rotate(${b.toFixed(1)}deg)` : '';
+    }
+  });
+  if (!Comp) return null;
+  return (
+    <group ref={grupo} position={base}>
+      <Html center distanceFactor={df} zIndexRange={[18, 0]} pointerEvents="none">
+        <div ref={capa} className="fc-billboard" aria-hidden="true">
+          <Comp size={size} animated={!reducedMotion} title={title} />
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+/**
+ * Siembra una lista de bichos del piso cálido (una línea por diorama).
+ * @param {object} p
+ * @param {Array<object>} p.items  cada uno = props de `<BichoCalido>`.
+ * @param {boolean} [p.reducedMotion=false]
+ */
+export function FaunaCalido({ items = [], reducedMotion = false }) {
+  return (
+    <group>
+      {items.map((it, i) => (
+        <BichoCalido key={it.key ?? i} reducedMotion={reducedMotion} {...it} />
+      ))}
+    </group>
+  );
+}
+
+export default FaunaCalido;


### PR DESCRIPTION
## Qué

La auditoría 3D marcó que a los mundos de **tierra caliente** (cafetal, cacaotal) les faltaba SU fauna: el dosel del sombrío estaba mudo. Este PR pobla los dos mundos cálidos con la fauna emblemática **real** del piso cálido-tropical bajo colombiano, como billboards SVG rubber-hose (mismo patrón que `FaunaEscena`/`CondorBillboard`) — cada especie en su nicho y con coreografía dictada por su rol.

## Especies (con su respaldo del DR)

Grounding: `DR-FANOUT/fauna-emblematica-del-piso-calido...-gemini` (GBIF/SiB Colombia). Nombre científico obligatorio (regla dura de biodiversidad):

| Especie | Nombre científico | Nicho / gesto | GBIF |
| --- | --- | --- | --- |
| Guacamaya bandera | *Ara macao* | en vuelo, ronda el dosel (banqueando) | 2479361 |
| Tucán pechiblanco | *Ramphastos tucanus* | posado en el sombrío, su pico enorme | 2478235 |
| Mico maicero / mono ardilla | *Saimiri sciureus* | entre las ramas, curioso | 2436605 |
| Perezoso de tres dedos | *Bradypus variegatus* | colgado, mecerse lentísimo (reusa `Perezoso`) | 2436616 |
| Iguana verde | *Iguana iguana* | asoleándose en el tronco, papada latiendo | 2470396 |
| Morfo azul | *Morpho peleides* | vuelo lento y ondulante por el sotobosque | 190872740 |

El cacaotal (0–1.200 m) lleva el elenco completo; el cafetal (cinturón bajo/sub-andino ~1.000–1.400 m) lleva las que suben a ese piso (guacamaya, tucán, mico, morfo).

## Alcance

- **Solo archivos nuevos + los dos mundos cálidos.** No toca el valle (ya arreglado), ni bosque/agua/juegos.
- Nuevos: `MorphoAzul/Tucan/Guacamaya/MicoMaicero/Iguana.jsx` + `faunaCalido.css` (creatures) y `escenas/FaunaCalido.jsx` (billboard + coreografía por nicho).
- Cableado en `EscenaCafetalVivo.jsx` y `EscenaCacaoVivo.jsx`.
- Se recorta por `device-tier` (alto/medio) y se congela con `reduced-motion` (billboards DOM, pocos y bien puestos).

## Verificación

- `npm run build:prod` **verde**.
- Playwright (chromium del sistema + swiftshader, sin `--virtual-time-budget`): las seis especies renderizan en su nicho en ambos mundos, **cero pantallas negras** (negro ~0% en 8 tomas). Español Colombia en "usted".

🤖 Generated with [Claude Code](https://claude.com/claude-code)