### PR TITLE
art(sierra): biodiversidad real por piso + fauna altoandina (SierraMonte3D)

### DIFF
--- a/src/visual/mundo3d/sierra/SierraMonte3D.jsx
+++ b/src/visual/mundo3d/sierra/SierraMonte3D.jsx
@@ -49,10 +49,14 @@ import { PISOS_TERMICOS } from '../pisosTermicos.js';
 import {
   R_MONTE, H_PICO, Y_MAR,
   geometriaMonte,
-  geomPalmera, geomCafeto, geomNiebla, geomFrailejon,
-  vegDeTier, calidadVeg, distribuirVegetacion,
   curvaQuebrada, puntoEnLadera, metrosDeY, yDeMetros,
 } from './sierraMonte.geom.js';
+import {
+  geomsEspeciesSierra, vegSierraDeTier, calidadSierra, distribuirEspeciesReales,
+  geomVenadoCuerpo, geomVenadoPata, geomAguilaCuerpo, geomAguilaAla,
+} from './sierraBiodiversa.geom.js';
+import CondorBillboard from '../CondorBillboard.jsx';
+import { OsoAndino } from '../../creatures/index.js';
 
 /* Las cuatro bandas navegables, del grafo (pisosTermicos.js). `azimut` reparte
    sus hotspots alrededor del macizo para que orbitar los descubra. */
@@ -115,22 +119,19 @@ function Especie({ geo, mat, items, castShadow = false }) {
       instanciada por banda. Clicable: el punto tocado decide su piso. ── */
 function Macizo({ tier, onEntrar }) {
   const perfil = perfilDeTier(tier);
-  const q = calidadVeg(tier);
-  const conteos = vegDeTier(tier);
+  const q = calidadSierra(tier);
+  const conteos = vegSierraDeTier(tier);
 
   const geoTerreno = useMemo(() => {
     const g = geometriaMonte(perfil.segmentosTerreno);
     return perfil.flatShading ? g.toNonIndexed() : g;
   }, [perfil.segmentosTerreno, perfil.flatShading]);
 
-  const geos = useMemo(() => ({
-    palmera: geomPalmera(q, 9),
-    cafeto: geomCafeto(q, 3),
-    niebla: geomNiebla(q, 5),
-    frailejon: geomFrailejon(q, 11),
-  }), [q]);
+  // Cinco especies REALES, una por piso (ceiba/guayacán/roble/queñua) + frailejón
+  // coronando el páramo. Reusan la geometría de arbolMayor.geom / sierraMonte.geom.
+  const geos = useMemo(() => geomsEspeciesSierra(q), [q]);
 
-  const dist = useMemo(() => distribuirVegetacion(conteos, 707), [conteos]);
+  const dist = useMemo(() => distribuirEspeciesReales(conteos, 909), [conteos]);
 
   const matTerreno = useMemo(() => {
     const base = { vertexColors: true, flatShading: perfil.flatShading };
@@ -171,9 +172,13 @@ function Macizo({ tier, onEntrar }) {
         onPointerOver={() => { document.body.style.cursor = 'pointer'; }}
         onPointerOut={() => { document.body.style.cursor = ''; }}
       />
-      <Especie geo={geos.palmera} mat={matVeg} items={dist.palmera} castShadow={sombra} />
-      <Especie geo={geos.cafeto} mat={matVeg} items={dist.cafeto} castShadow={sombra} />
-      <Especie geo={geos.niebla} mat={matVeg} items={dist.niebla} castShadow={sombra} />
+      {/* ceiba (cálido), guayacán (templado), roble (frío) y queñua (filo del
+          páramo): las cuatro especies mayores reales, cada una en su piso. */}
+      <Especie geo={geos.ceiba} mat={matVeg} items={dist.ceiba} castShadow={sombra} />
+      <Especie geo={geos.guayacan} mat={matVeg} items={dist.guayacan} castShadow={sombra} />
+      <Especie geo={geos.roble} mat={matVeg} items={dist.roble} castShadow={sombra} />
+      <Especie geo={geos.quenua} mat={matVeg} items={dist.quenua} castShadow={sombra} />
+      {/* el frailejonar corona el páramo abierto, sobre la queñua */}
       <Especie geo={geos.frailejon} mat={matVeg} items={dist.frailejon} />
     </group>
   );
@@ -322,6 +327,179 @@ function VeloParamo({ tier, reducedMotion }) {
   );
 }
 
+/* ── FAUNA ALTOANDINA — la vida REAL de la Sierra, que faltaba ────────────────
+   La Sierra Nevada es LA sede simbólica del cóndor en el imaginario colombiano y
+   hábitat del oso de anteojos, el venado coliblanco y el águila mora. Cóndor y
+   oso reusan los SVG rubber-hose de la casa como billboards (el estándar de
+   calidad); el venado y el águila van en geometría procedural mínima
+   (`sierraBiodiversa.geom`). Todo gateado por tier/reducedMotion: en calma queda
+   quieto y digno. ── */
+const ESTILO_BICHO = {
+  filter: 'drop-shadow(0 2px 3px rgba(25, 32, 28, 0.32))',
+  pointerEvents: 'none',
+};
+
+/* El OSO DE ANTEOJOS (Tremarctos ornatus, el único oso de Suramérica) en el
+   bosque de niebla (piso frío): SVG de la casa como billboard que encara la
+   cámara. `occlude`: se esconde tras el macizo cuando la órbita lo deja detrás. */
+function OsoDeAnteojos({ pos, tier, animated, px = 56, factor = 15 }) {
+  return (
+    <group position={/** @type {[number,number,number]} */ (pos)}>
+      <Html center distanceFactor={factor} zIndexRange={[12, 0]} occlude pointerEvents="none">
+        <div aria-hidden="true" data-vecino="oso-andino" style={ESTILO_BICHO}>
+          <OsoAndino size={px} animated={animated} tier={tier} />
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+/* El VENADO COLIBLANCO ANDINO (Odocoileus goudotii, la subespecie de páramo):
+   pace alerta en el frío/páramo. Cuerpo tostado fusionado + cuatro patas + la
+   COLA BLANCA en alto (su firma). Idle sutil: mecido de peso y coleteo. */
+function VenadoSierra({ pos, escala = 0.3, giro = 0, reducedMotion }) {
+  const grupo = useRef(null);
+  const cola = useRef(null);
+  const geoCuerpo = useMemo(() => geomVenadoCuerpo(), []);
+  const geoPata = useMemo(() => geomVenadoPata(), []);
+  const matCafe = useMemo(() => new THREE.MeshLambertMaterial({ vertexColors: true }), []);
+  const matPata = useMemo(() => new THREE.MeshLambertMaterial({ color: '#5d4530' }), []);
+  const matBlanco = useMemo(() => new THREE.MeshLambertMaterial({ color: '#f3efe2' }), []);
+  useEffect(
+    () => () => {
+      geoCuerpo.dispose();
+      geoPata.dispose();
+      matCafe.dispose();
+      matPata.dispose();
+      matBlanco.dispose();
+    },
+    [geoCuerpo, geoPata, matCafe, matPata, matBlanco],
+  );
+  useFrame(({ clock }) => {
+    if (reducedMotion || !grupo.current) return;
+    const t = clock.getElapsedTime();
+    grupo.current.rotation.z = Math.sin(t * 0.5 + pos[0]) * 0.03; // mecido de peso
+    if (cola.current) cola.current.rotation.x = Math.max(0, Math.sin(t * 1.3 + pos[2])) * 0.5; // coleteo
+  });
+  return (
+    <group ref={grupo} position={/** @type {[number,number,number]} */ (pos)} rotation={[0, giro, 0]} scale={escala}>
+      <mesh geometry={geoCuerpo} material={matCafe} />
+      {[[0.42, 0.16], [0.42, -0.16], [-0.5, 0.16], [-0.5, -0.16]].map(([px, pz], i) => (
+        <mesh key={i} geometry={geoPata} material={matPata} position={[px, 0.74, pz]} />
+      ))}
+      {/* la cola blanca en alto (Odocoileus la levanta como bandera) */}
+      <group ref={cola} position={[-0.66, 1.04, 0]}>
+        <mesh material={matBlanco} position={[-0.04, 0.06, 0]} scale={[0.9, 1.5, 0.7]}>
+          <sphereGeometry args={[0.1, 6, 5]} />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* El ÁGUILA MORA (Geranoaetus melanoleucus, águila real de páramo): planea en
+   círculos los altos de la Sierra, bajo el cóndor. Cuerpo oscuro fuselado + dos
+   alas anchas que baten a rachas + cola corta en cuña (su firma frente al
+   cóndor). El cuerpo mira +z (rumbo); la órbita lo rota a la tangente. */
+function AguilaSierra({ centro = [0, H_PICO * 0.62, 0], radio = R_MONTE * 0.46, fase = 0, reducedMotion }) {
+  const ave = useRef(null);
+  const alaIzq = useRef(null);
+  const alaDer = useRef(null);
+  const geoCuerpo = useMemo(() => geomAguilaCuerpo(), []);
+  const geoAlaD = useMemo(() => geomAguilaAla(1), []);
+  const geoAlaI = useMemo(() => geomAguilaAla(-1), []);
+  const mat = useMemo(() => new THREE.MeshLambertMaterial({ vertexColors: true, side: THREE.DoubleSide }), []);
+  useEffect(
+    () => () => {
+      geoCuerpo.dispose();
+      geoAlaD.dispose();
+      geoAlaI.dispose();
+      mat.dispose();
+    },
+    [geoCuerpo, geoAlaD, geoAlaI, mat],
+  );
+  useFrame(({ clock }) => {
+    const g = ave.current;
+    if (!g) return;
+    if (reducedMotion) {
+      g.position.set(centro[0] + radio, centro[1], centro[2]);
+      return;
+    }
+    const t = clock.getElapsedTime();
+    const a = t * 0.16 + fase; // una vuelta cada ~40 s (más nerviosa que el cóndor)
+    const r = radio + Math.sin(t * 0.07) * radio * 0.12;
+    g.position.set(
+      centro[0] + Math.cos(a) * r,
+      centro[1] + Math.sin(t * 0.3 + fase) * 0.6,
+      centro[2] + Math.sin(a) * r,
+    );
+    g.rotation.y = -a; // el cuerpo (+z) apunta a la tangente del giro
+    g.rotation.z = 0.12 + Math.sin(t * 0.5) * 0.06; // banqueo hacia adentro
+    // aletea a rachas: dos golpes cada tanto, el resto plancha
+    const rafaga = Math.max(0, Math.sin(t * 0.4 + fase) - 0.78) * 6;
+    const flap = Math.sin(t * 7) * 0.4 * rafaga;
+    const base = 0.16; // diedro leve en reposo
+    if (alaDer.current) alaDer.current.rotation.z = base + flap;
+    if (alaIzq.current) alaIzq.current.rotation.z = -(base + flap);
+  });
+  return (
+    <group ref={ave} position={/** @type {[number,number,number]} */ (centro)}>
+      <mesh geometry={geoCuerpo} material={mat} />
+      <mesh ref={alaDer} geometry={geoAlaD} material={mat} />
+      <mesh ref={alaIzq} geometry={geoAlaI} material={mat} />
+    </group>
+  );
+}
+
+/* Toda la fauna altoandina de la Sierra, gateada por tier/reducedMotion. */
+function FaunaSierra({ tier, reducedMotion }) {
+  const animado = !reducedMotion && tier !== 'bajo';
+  const nCondor = tier === 'alto' ? 2 : 1;
+  const hayAguila = tier !== 'bajo';
+  const nVenado = tier === 'alto' ? 2 : tier === 'medio' ? 1 : 0;
+
+  const osoPos = useMemo(() => {
+    const p = puntoEnLadera(2450, -2.15); // el bosque de niebla, piso frío
+    return [p[0], p[1] + 0.02, p[2]];
+  }, []);
+  const venados = useMemo(
+    () =>
+      [
+        { pos: puntoEnLadera(2900, 1.35), giro: 2.1, escala: 0.3 },
+        { pos: puntoEnLadera(3200, -0.5), giro: -1.2, escala: 0.27 },
+      ].slice(0, nVenado),
+    [nVenado],
+  );
+
+  return (
+    <group>
+      {/* El cóndor de los Andes (Vultur gryphus): planea alto sobre la nieve. */}
+      {Array.from({ length: nCondor }).map((_, i) => (
+        <CondorBillboard
+          key={i}
+          centro={[0, H_PICO * (0.92 + i * 0.06), 0]}
+          radio={R_MONTE * (0.7 + i * 0.18)}
+          velocidad={0.075}
+          px={tier === 'alto' ? 60 : 48}
+          factor={22}
+          animated={animado}
+          tier={tier}
+        />
+      ))}
+      {/* El águila mora (Geranoaetus melanoleucus): círculos más bajos y nerviosos. */}
+      {hayAguila && (
+        <AguilaSierra centro={[0, H_PICO * 0.62, 0]} radio={R_MONTE * 0.46} reducedMotion={!animado} />
+      )}
+      {/* El oso de anteojos (Tremarctos ornatus) en el bosque de niebla. */}
+      <OsoDeAnteojos pos={osoPos} tier={tier} animated={animado} />
+      {/* El venado coliblanco andino (Odocoileus goudotii) paciendo en el frío/páramo. */}
+      {venados.map((v, i) => (
+        <VenadoSierra key={i} pos={v.pos} giro={v.giro} escala={v.escala} reducedMotion={!animado} />
+      ))}
+    </group>
+  );
+}
+
 /* ── Los HOTSPOTS de piso: un pin que cuelga de la altura REAL de su banda en la
       ladera. Toque = entra a ese mundo. El páramo va aparte (frío, "se cuida"). ── */
 function HotspotsPisos({ onEntrar }) {
@@ -425,6 +603,7 @@ function EscenaMonte({ tier, reducedMotion, onEntrarPiso }) {
       <Macizo tier={tier} onEntrar={onEntrarPiso} />
       {agua && <Quebrada tier={tier} reducedMotion={reducedMotion} />}
       {agua && <VeloParamo tier={tier} reducedMotion={reducedMotion} />}
+      <FaunaSierra tier={tier} reducedMotion={reducedMotion} />
       <HotspotsPisos onEntrar={onEntrarPiso} />
       <OrbitControls
         makeDefault

--- a/src/visual/mundo3d/sierra/sierraBiodiversa.geom.js
+++ b/src/visual/mundo3d/sierra/sierraBiodiversa.geom.js
@@ -1,0 +1,326 @@
+/*
+ * sierraBiodiversa.geom — la BIODIVERSIDAD REAL del macizo de la Sierra 3D.
+ *
+ * ── POR QUÉ ESTE ARCHIVO ─────────────────────────────────────────────────────
+ * La vista global cableada (`SierraMonte3D`, ruta `sierra_global`) sembraba la
+ * ladera con TRES formas genéricas —"árbol frondoso genérico"— para cuatro pisos
+ * térmicos completos, y CERO fauna. La auditoría de biodiversidad (2026-07-16) lo
+ * marcó: baja fidelidad pese al volumen, y sin el cóndor —la especie más asociada
+ * a la Sierra Nevada—. Este módulo trae la variedad REAL, reusando lo que el repo
+ * ya modeló con nombre científico:
+ *
+ *   · Los CUATRO árboles mayores de `arbolMayor.geom.js` (los mismos de la
+ *     galería huérfana `GaleriaSierraArboles`), cada uno en SU piso:
+ *        ceiba/Ceiba pentandra ....... cálido   (<1000 m) — raíces tablares
+ *        guayacán/Handroanthus ....... templado (1000–2000 m) — florece de oro
+ *        roble andino/Quercus ........ frío     (2000–3000 m) — copa ancha
+ *        queñua/Polylepis quadrijuga . filo del páramo — el bosque más alto
+ *   · El FRAILEJÓN/Espeletia (roseta plateada + enagua) de `sierraMonte.geom.js`,
+ *     coronando el páramo abierto, arriba de la queñua.
+ *   · FAUNA ALTOANDINA REAL como billboards/geometría (la del imaginario de la
+ *     Sierra): cóndor y oso de anteojos reusan los SVG rubber-hose de la casa
+ *     (los monta `SierraMonte3D`); el VENADO (Odocoileus goudotii, venado
+ *     coliblanco andino) y el ÁGUILA MORA (Geranoaetus melanoleucus, la rapaz
+ *     que planea los páramos) van en geometría procedural mínima, aquí.
+ *
+ * ── CERO three-de-pantalla, cero React ──────────────────────────────────────
+ * Solo three-core (geometría + color por vértice). Corre headless y lo consume
+ * `SierraMonte3D.jsx`. Geometría FUSIONADA con `fusionarSeguro` (cierra la trampa
+ * del null silencioso de mergeGeometries). Los conteos de vegetación se instancian
+ * (un InstancedMesh por especie): densidad sin multiplicar draw-calls.
+ *
+ * ── REGLA DURA (biodiversidad) ───────────────────────────────────────────────
+ * Especies REALES colombianas por piso térmico. Nada inventado: cada una lleva su
+ * binomio y sale de un DR o de un módulo del repo con respaldo. La Sierra es
+ * territorio sagrado y habitado (Kogui, Arhuaco/Iku, Wiwa, Kankuamo); la fauna se
+ * representa con sobriedad, sin iconografía ceremonial.
+ */
+import * as THREE from 'three';
+import {
+  R_MONTE,
+  alturaTerreno,
+  pendienteTerreno,
+  metrosDeY,
+  geomFrailejon,
+} from './sierraMonte.geom.js';
+import { geomArbol } from './arbolMayor.geom.js';
+import { rng, fusionarSeguro } from '../bosque/sombreadoVegetal.js';
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+
+/* -------------------------------------------------------------------------- */
+/*  VEGETACIÓN — cinco especies reales, una geometría fusionada por especie     */
+/* -------------------------------------------------------------------------- */
+
+/* Cuántas matas de cada especie por tier. Son INSTANCIAS (cada especie es un
+   solo InstancedMesh, una draw-call por más matas que haya). Los árboles reusan
+   la geometría de `arbolMayor` con calidad de LOD (baja): de lejos, sobre el
+   macizo, lo único que se lee es la silueta — el detalle fino sería plata tirada.
+   'bajo' deja lo mínimo que aún lee "montaña con pisos". */
+export const VEG_SIERRA_TIER = {
+  alto: { ceiba: 30, guayacan: 52, roble: 66, quenua: 44, frailejon: 84 },
+  medio: { ceiba: 16, guayacan: 28, roble: 36, quenua: 24, frailejon: 46 },
+  bajo: { ceiba: 5, guayacan: 9, roble: 12, quenua: 9, frailejon: 18 },
+};
+export const vegSierraDeTier = (tier) => VEG_SIERRA_TIER[tier] || VEG_SIERRA_TIER.medio;
+
+/* Detalle geométrico por tier. Se mapea a la `q` de arbolMayor/frailejón, pero
+   TOPADO bajo: estos árboles son textura de ladera vistos de lejos, no héroes. */
+export const CALIDAD_SIERRA = { alto: 0.5, medio: 0.42, bajo: 0.34 };
+export const calidadSierra = (tier) => CALIDAD_SIERRA[tier] ?? CALIDAD_SIERRA.medio;
+
+/**
+ * Las cinco geometrías (una por especie), ya fusionadas y con color horneado.
+ * Los cuatro árboles salen de `geomArbol` con `sss:false` (contraluz apagada):
+ * las instancias giran libremente en Y y una luz horneada direccional mentiría
+ * (§ROTACIÓN de arbolMayor.geom). El frailejón trae su propia roseta plateada.
+ *
+ * @param {number} q  calidad geométrica (calidadSierra(tier)).
+ * @returns {{ceiba,guayacan,roble,quenua,frailejon: THREE.BufferGeometry}}
+ */
+export function geomsEspeciesSierra(q = 0.5) {
+  return {
+    ceiba: geomArbol('ceiba', { q, variante: 0, sss: false }),
+    guayacan: geomArbol('guayacan', { q, variante: 1, sss: false }),
+    roble: geomArbol('roble', { q, variante: 0, sss: false }),
+    quenua: geomArbol('quenua', { q, variante: 2, sss: false }),
+    frailejon: geomFrailejon(q, 11),
+  };
+}
+
+/* Banda de altitud REAL de cada especie (metros). La queñua y el frailejón se
+   solapan a propósito (3150–3650): en el páramo real los bosquecillos de
+   Polylepis salpican el frailejonal — no son bandas limpias. */
+const BANDA_ESP = {
+  ceiba: [640, 1000],
+  guayacan: [1000, 2000],
+  roble: [2000, 3050],
+  quenua: [3050, 3650], // el filo: el bosque más alto del mundo
+  frailejon: [3150, 3900], // el páramo abierto, coronando la queñua
+};
+
+/* Escala por especie: la geometría de arbolMayor mide 1.5–3.2 en su espacio
+   local; aquí todo aterriza en ~0.3–0.5 unidades de mundo — la vegetación es
+   textura de un macizo de ~10, no protagonista. La ceiba y el roble, emergentes,
+   salen un pelo más grandes; la queñua, achaparrada por el viento del filo. */
+const ESCALA_ESP = {
+  ceiba: [0.13, 0.18],
+  guayacan: [0.14, 0.2],
+  roble: [0.14, 0.2],
+  quenua: [0.19, 0.28],
+  frailejon: [0.24, 0.4],
+};
+
+const CLAVES_ESP = ['ceiba', 'guayacan', 'roble', 'quenua', 'frailejon'];
+
+/**
+ * Reparte las matas sobre la superficie del macizo por RECHAZO, cada especie en
+ * su banda de altitud real. Como la ladera tiene relieve, el bosque se acomoda
+ * siguiendo las curvas de nivel (sube por vaguadas, se corta en los filos): nadie
+ * dibuja ese contorno, sale de cruzar la banda con el terreno. Evita las paredes
+ * empinadas, la orilla del mar y la corona nevada. Donde dos especies aceptan la
+ * misma altura (queñua/frailejón), se sortea entre ellas: quedan entreveradas.
+ *
+ * @param {{ceiba,guayacan,roble,quenua,frailejon:number}} conteos
+ * @param {number} [seed]
+ * @returns {Record<string, Array<{pos:number[],rotY:number,escala:number,tint:number[]}>>}
+ */
+export function distribuirEspeciesReales(conteos, seed = 909) {
+  const r = rng(seed);
+  const out = {};
+  const cap = {};
+  for (const k of CLAVES_ESP) {
+    out[k] = [];
+    cap[k] = conteos[k] || 0;
+  }
+  const total = CLAVES_ESP.reduce((s, k) => s + cap[k], 0);
+  const lleno = () => CLAVES_ESP.every((k) => out[k].length >= cap[k]);
+
+  let intentos = 0;
+  const maxIntentos = total * 60 + 400;
+  while (!lleno() && intentos < maxIntentos) {
+    intentos++;
+    const ang = r() * Math.PI * 2;
+    // radio en el CUERPO del macizo (ni el pico, ni el faldón raso del mar)
+    const rn = 0.16 + Math.sqrt(r()) * 0.66;
+    const rad = rn * R_MONTE;
+    const x = Math.cos(ang) * rad;
+    const z = Math.sin(ang) * rad;
+    const y = alturaTerreno(x, z);
+    const m = metrosDeY(y);
+    if (m < 620 || m > 3950) continue; // sobre la orilla, bajo la corona
+    if (pendienteTerreno(x, z) > 0.6) continue; // no en las paredes
+
+    // ¿qué especies (con cupo libre) aceptan esta altura?
+    const candidatas = CLAVES_ESP.filter(
+      (k) => out[k].length < cap[k] && m >= BANDA_ESP[k][0] && m < BANDA_ESP[k][1],
+    );
+    if (!candidatas.length) continue;
+    const esp = candidatas[Math.floor(r() * candidatas.length) % candidatas.length];
+
+    const [e0, e1] = ESCALA_ESP[esp];
+    out[esp].push({
+      pos: [x, y - 0.03, z],
+      rotY: r() * Math.PI * 2,
+      escala: e0 + r() * (e1 - e0),
+      // variación de color por instancia (que no haya dos matas iguales)
+      tint: [0.88 + r() * 0.2, 0.9 + r() * 0.16, 0.88 + r() * 0.18],
+    });
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  FAUNA ALTOANDINA — geometría procedural mínima                              */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * El VENADO COLIBLANCO ANDINO (Odocoileus goudotii, la subespecie de páramo del
+ * venado de cola blanca). Pace en el frío/páramo. Cuerpo tostado, vientre y cara
+ * claros; la firma es la COLA BLANCA (va como pieza aparte, en el render). El
+ * cuerpo entero es UNA geometría fusionada (fusionarSeguro); las patas van aparte
+ * en el render porque se mecen al pacer. Mira hacia +x.
+ */
+export function geomVenadoCuerpo() {
+  const tostado = new THREE.Color('#8a6a44');
+  const partes = [];
+  const push = (g, c) => {
+    const col = c || tostado;
+    const arr = new Float32Array(g.getAttribute('position').count * 3);
+    for (let i = 0; i < arr.length; i += 3) {
+      arr[i] = col.r;
+      arr[i + 1] = col.g;
+      arr[i + 2] = col.b;
+    }
+    g.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+    partes.push(g);
+  };
+
+  const cuerpo = new THREE.SphereGeometry(0.4, 9, 7);
+  cuerpo.scale(1.5, 0.95, 0.72);
+  cuerpo.translate(0, 0.98, 0);
+  push(cuerpo);
+
+  const grupa = new THREE.SphereGeometry(0.32, 8, 6);
+  grupa.scale(1.05, 1, 0.9);
+  grupa.translate(-0.5, 1.0, 0);
+  push(grupa);
+
+  const cuello = new THREE.CylinderGeometry(0.1, 0.16, 0.64, 7);
+  cuello.rotateZ(-0.72);
+  cuello.translate(0.62, 1.4, 0);
+  push(cuello);
+
+  const cabeza = new THREE.SphereGeometry(0.15, 8, 6);
+  cabeza.scale(1.3, 1, 0.85);
+  cabeza.translate(0.86, 1.68, 0);
+  push(cabeza);
+
+  // hocico y cara claros (la máscara pálida del coliblanco)
+  const claro = new THREE.Color('#c9ad82');
+  const hocico = new THREE.ConeGeometry(0.075, 0.26, 6);
+  hocico.rotateZ(-Math.PI / 2);
+  hocico.translate(1.08, 1.62, 0);
+  push(hocico, claro);
+
+  // orejas grandes (venado alerta)
+  const orejaIzq = new THREE.ConeGeometry(0.055, 0.24, 5);
+  orejaIzq.rotateZ(0.4);
+  orejaIzq.translate(0.76, 1.9, 0.1);
+  push(orejaIzq);
+  const orejaDer = orejaIzq.clone();
+  orejaDer.translate(0, 0, -0.2);
+  push(orejaDer);
+
+  return fusionarSeguro(partes, 'venado-cuerpo');
+}
+
+/** Una pata del venado, con el pivote arriba (en la cadera) para que columpie. */
+export function geomVenadoPata() {
+  const g = new THREE.CylinderGeometry(0.042, 0.03, 0.74, 5);
+  g.translate(0, -0.37, 0);
+  return g;
+}
+
+/*
+ * El ÁGUILA MORA (Geranoaetus melanoleucus, águila real de páramo): la rapaz que
+ * planea en círculos los altos de la Sierra. Silueta oscura de alas anchas y cola
+ * corta en cuña (distinta del cóndor: sin gorguera blanca, más pequeña, cola
+ * corta). Cuerpo + cabeza fusionados; las alas van aparte en el render (baten de
+ * tanto en tanto). Mira hacia +x (rumbo del vuelo).
+ */
+export function geomAguilaCuerpo() {
+  const oscuro = new THREE.Color('#3a3d42');
+  const partes = [];
+  const push = (g, c) => {
+    const col = c || oscuro;
+    const arr = new Float32Array(g.getAttribute('position').count * 3);
+    for (let i = 0; i < arr.length; i += 3) {
+      arr[i] = col.r;
+      arr[i + 1] = col.g;
+      arr[i + 2] = col.b;
+    }
+    g.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+    partes.push(g);
+  };
+
+  const cuerpo = new THREE.SphereGeometry(0.16, 8, 6);
+  cuerpo.scale(0.9, 0.85, 2.3); // fuselado a lo largo del vuelo (+z local → giro en render)
+  push(cuerpo);
+
+  const cabeza = new THREE.SphereGeometry(0.1, 7, 6);
+  cabeza.translate(0, 0.02, 0.34);
+  push(cabeza);
+
+  // pico corto y ganchudo
+  const pico = new THREE.ConeGeometry(0.04, 0.12, 5);
+  pico.rotateX(Math.PI / 2);
+  pico.translate(0, 0, 0.44);
+  push(pico, new THREE.Color('#d8b23a'));
+
+  // cola corta en cuña (la firma que la separa del cóndor)
+  const cola = new THREE.ConeGeometry(0.14, 0.4, 4);
+  cola.rotateX(-Math.PI / 2);
+  cola.translate(0, 0, -0.44);
+  push(cola);
+
+  return fusionarSeguro(partes, 'aguila-cuerpo');
+}
+
+/**
+ * Un ala del águila: plano barrido con la punta digitada (las primarias abiertas
+ * como dedos de rapaz). Va acostada, con el pivote en el hombro (x=0) para batir
+ * desde el cuerpo. `lado` = +1 ala derecha (se extiende hacia +x), −1 izquierda
+ * (espejo hacia −x). Devuelve una geometría plana pintada (se aclara a la punta).
+ *
+ * @param {1|-1} [lado]
+ */
+export function geomAguilaAla(lado = 1) {
+  const oscuro = new THREE.Color('#33363b');
+  const claro = new THREE.Color('#6b6a5e'); // el pálido de la cubierta alar
+  // trapecio barrido: ancho en el hombro, angosto y retrasado en la punta
+  const forma = new THREE.Shape();
+  forma.moveTo(0, 0.14);
+  forma.lineTo(0, -0.14);
+  forma.lineTo(0.92, -0.34);
+  forma.lineTo(1.02, -0.24);
+  forma.lineTo(0.98, -0.12); // muescas de las primarias digitadas
+  forma.lineTo(1.04, -0.04);
+  forma.lineTo(0.9, 0.06);
+  forma.closePath();
+  const g = new THREE.ShapeGeometry(forma);
+  g.rotateX(-Math.PI / 2); // acostada (plano del vuelo)
+  if (lado < 0) g.scale(-1, 1, 1); // ala izquierda: espejo (side:DoubleSide la salva)
+  const pos = g.getAttribute('position');
+  const arr = new Float32Array(pos.count * 3);
+  const tmp = new THREE.Color();
+  for (let i = 0; i < pos.count; i++) {
+    const x = Math.abs(pos.getX(i));
+    tmp.copy(oscuro).lerp(claro, clamp(x, 0, 1) * 0.5); // se aclara hacia la punta
+    arr[i * 3] = tmp.r;
+    arr[i * 3 + 1] = tmp.g;
+    arr[i * 3 + 2] = tmp.b;
+  }
+  g.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return g;
+}


### PR DESCRIPTION
## Qué

Enriquece la **Sierra activa** (`SierraMonte3D`, ruta `sierra_global`) con variedad de **especies REALES por piso térmico** + **fauna altoandina real**. Cierra el hallazgo 4a de `ops/AUDIT-3D-BIODIVERSIDAD-2026-07-16.md`: la vista cableada sembraba 3 formas genéricas ("árbol frondoso genérico") para 4 pisos y **cero fauna**, pese a que la Sierra Nevada es la sede simbólica del cóndor.

## Flora — 5 especies reales, una por piso

Reusa la geometría que el repo YA modeló con nombre científico (`arbolMayor.geom.js` + `sierraMonte.geom.js`), distribuida por banda de altitud real:

| Especie | Binomio | Piso | Firma |
|---|---|---|---|
| Ceiba | *Ceiba pentandra* | cálido (<1000 m) | raíces tablares |
| Guayacán amarillo | *Handroanthus chrysanthus* | templado (1000–2000 m) | florece de oro |
| Roble andino | *Quercus humboldtii* | frío (2000–3000 m) | copa ancha |
| Queñua | *Polylepis quadrijuga* | filo del páramo | el bosque más alto del mundo |
| Frailejón | *Espeletia* | corona el páramo abierto | roseta plateada + enagua |

## Fauna altoandina real (gateada por tier / reducedMotion)

| Especie | Binomio | Cómo |
|---|---|---|
| Cóndor de los Andes | *Vultur gryphus* | reusa el SVG `CondorBillboard` (planea alto sobre la nieve) |
| Oso de anteojos | *Tremarctos ornatus* | reusa el SVG `OsoAndino` (billboard, bosque de niebla) |
| Venado coliblanco andino | *Odocoileus goudotii* | geometría procedural (pace en el frío/páramo) |
| Águila mora | *Geranoaetus melanoleucus* | geometría procedural (círculos más bajos que el cóndor) |

## Alcance

- **Nuevo:** `src/visual/mundo3d/sierra/sierraBiodiversa.geom.js` — geometría (three-core, `fusionarSeguro`), distribución por altitud real y cuerpos procedurales de venado/águila.
- **Editado:** `src/visual/mundo3d/sierra/SierraMonte3D.jsx` — cablea las especies reales y la fauna.
- No se tocó valle / agua / cultivos / juegos ni ningún otro geom.

## Verificación

- `npm run build:prod` **verde**.
- Playwright (chromium + swiftshader, `?ciclo=11#sierra_global`): 4 tomas, **tier alto**, canvas pintando, **sin frames negros**. DOM confirma **2 cóndores + 1 oso** billboards montados + águila/venado procedurales visibles.

Especies con respaldo: cada binomio sale de un módulo con DR del repo (`arbolMayor.geom.js`, `floraParamo.geom`, `faunaAndina.js`, `condorIdentidad`) o es fauna altoandina real de la SNSM.