### PR TITLE
feat(polinizadores): cablear el mundo de polinizadores a la ruta de producción

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -181,6 +181,14 @@ const MundoPiscicultura3DMockup = lazy(() => import('./mockups/MundoPiscicultura
 // biodigestor que cierra el ciclo del estiércol. Device-tiering real. Ruta
 // #/mockups/lecheria-viva-3d, sin auth.
 const LecheriaViva3DMockup = lazy(() => import('./mockups/LecheriaViva3D'));
+// 3D: el MUNDO DE LOS POLINIZADORES — la finca completa con la red de polen
+// tejiéndose entre ocho especies (angelita, abeja de miel, abejorro, colibrí,
+// murciélago, mariposa, sírfido, escarabajo) y siete síndromes florales
+// reales, sobre el maracuyá, la ahuyama, el cafetal y la cerca viva. Tres
+// interruptores: el turno día/noche, el ojo de la abeja (guías UV) y la
+// deriva del veneno vecino. Device-tiering real. Ruta
+// #/mockups/mundo-polinizadores-3d, sin auth.
+const MundoPolinizadores3DMockup = lazy(() => import('./mockups/MundoPolinizadores3D'));
 // 3D: el MUNDO SUELO VIVO — la RED MICORRÍZICA bajo tierra (el wood-wide web):
 // la red de hongos bioluminiscente que enlaza las raíces y reparte nutrientes,
 // con pulsos corriendo por los hilos y el Ent asomando. Device-tiering real.
@@ -681,6 +689,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/suelo-demo-3d': 'mockup_suelo_demo_3d',
   'mockups/criaturas-nocturnas': 'mockup_criaturas_nocturnas',
   'mockups/angelita-viva': 'mockup_angelita_viva',
+  'mockups/mundo-polinizadores-3d': 'mockup_mundo_polinizadores_3d',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1670,6 +1679,21 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El potrero, la quesera y el ciclo">
               <LecheriaViva3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo_polinizadores_3d':
+        // Vitrina pública del MUNDO DE LOS POLINIZADORES: la finca completa en
+        // 3D REAL — el rincón de monte donde anidan los silvestres, el
+        // meliponario de la angelita, la cerca viva florida, el maracuyá en
+        // su emparrado, la ahuyama, el cafetal bajo sombrío y el maizal — con
+        // la RED de polen tejiéndose entre ocho especies. Tres interruptores:
+        // el turno día/noche, el ojo de la abeja (guías UV) y la deriva del
+        // veneno vecino. Ruta #/mockups/mundo-polinizadores-3d.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo de los polinizadores">
+              <MundoPolinizadores3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/config/rutasProdChagraApp.js
+++ b/src/config/rutasProdChagraApp.js
@@ -118,6 +118,19 @@ export const NUCLEO_3D = [
     importLazy: 'src/mockups/LecheriaViva3D.jsx',
     categoria: '3D',
   },
+  // El MUNDO DE LOS POLINIZADORES — la finca completa (rincón de monte,
+  // meliponario, cerca viva florida, maracuyá, ahuyama, cafetal y maizal) con
+  // la red de polen tejiéndose entre las ocho especies. El arte estaba
+  // completo en `visual/mundo3d/polinizadores/` pero nada lo montaba (hallazgo
+  // #1 del audit de biodiversidad 3D, 2026-07-16: cero rutas, cero
+  // componentMap).
+  {
+    path: 'mundo_polinizadores',
+    alias: ['polinizadores', 'mundo_polinizadores_3d', 'polinizadores-vivo-3d'],
+    componente: 'MundoPolinizadores3D',
+    importLazy: 'src/mockups/MundoPolinizadores3D.jsx',
+    categoria: '3D',
+  },
 
 
   // ── Arte nuevo — en revisión del operador (2026-07-14) ─────────

--- a/src/mockups/MundoPolinizadores3D.css
+++ b/src/mockups/MundoPolinizadores3D.css
@@ -1,0 +1,291 @@
+/*
+ * MundoPolinizadores3D.css — vitrina del mundo de la red de polinización
+ * (#/mockups/mundo-polinizadores-3d). Autocontenida: sin fuentes/imágenes
+ * externas. Móvil-first desde 320px. Paleta: el ámbar del polen (el mismo de
+ * Angelita) sobre el verde de huerta.
+ */
+
+.mpoliniz {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background: linear-gradient(180deg, #eef0d6 0%, #eaeecb 44%, #f2ecd0 100%);
+  color: #2b3226;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.mpoliniz__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.mpoliniz__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #96631a;
+}
+.mpoliniz__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #2e402e;
+}
+.mpoliniz__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 40rem;
+}
+
+.mpoliniz__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+.mpoliniz__lienzo {
+  position: relative;
+  height: min(66vh, 32rem);
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(150, 99, 26, 0.25);
+  box-shadow: 0 12px 30px rgba(44, 54, 40, 0.16);
+  background: radial-gradient(120% 90% at 50% 20%, #bfe3f2 0%, #9db486 100%);
+}
+.mpoliniz__lienzo canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+  touch-action: none;
+}
+/* El contenedor `.polz-mundo` (de polinizadores.css) vive dentro del lienzo y
+   llena todo el alto disponible; acá solo se ajusta al marco recortado. */
+.mpoliniz__lienzo .polz-mundo {
+  position: absolute;
+  inset: 0;
+}
+
+.mpoliniz__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  color: #3c4a38;
+  opacity: 0.85;
+}
+
+/* ---- Los tres interruptores ---- */
+.mpoliniz__interruptores {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.mpoliniz__switch {
+  border: 1.5px solid #96631a;
+  background: #fff;
+  color: #6b4712;
+  font-weight: 700;
+  font-size: 0.82rem;
+  padding: 0.42rem 0.8rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.mpoliniz__switch:hover,
+.mpoliniz__switch:focus-visible {
+  background: #96631a;
+  color: #fff;
+  outline-offset: 2px;
+}
+.mpoliniz__switch[aria-pressed='true'] {
+  background: #6b4712;
+  color: #fff;
+  border-color: #6b4712;
+}
+.mpoliniz__switch--veneno {
+  border-color: #7a8a63;
+  color: #55622f;
+}
+.mpoliniz__switch--veneno:hover,
+.mpoliniz__switch--veneno:focus-visible {
+  background: #7a8a63;
+  color: #fff;
+}
+.mpoliniz__switch--veneno[aria-pressed='true'] {
+  background: #5c6b3d;
+  border-color: #5c6b3d;
+  color: #fff;
+}
+.mpoliniz__dano {
+  flex: 1 1 100%;
+  margin: 0.1rem 0 0;
+  font-size: 0.82rem;
+  color: #5c6b3d;
+}
+
+.mpoliniz__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.mpoliniz__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.mpoliniz__toggle {
+  border: 1.5px solid #96631a;
+  background: #fff;
+  color: #96631a;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.mpoliniz__toggle:hover,
+.mpoliniz__toggle:focus-visible {
+  background: #96631a;
+  color: #fff;
+  outline-offset: 2px;
+}
+
+/* ---- Ficha 2D (fallback digno, sin GPU) ---- */
+.mpoliniz__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  background: radial-gradient(120% 90% at 50% 25%, #d2ddc9 0%, #a3b295 100%);
+}
+.mpoliniz__estampa {
+  position: relative;
+  width: 180px;
+  height: 160px;
+  margin-bottom: 0.4rem;
+}
+/* la flor amarilla, cartel abierto de la mañana */
+.mpoliniz__flor {
+  position: absolute;
+  bottom: 10px;
+  left: 40px;
+  width: 92px;
+  height: 92px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, #ffe08a 0%, #ffc94a 55%, #e0a52e 100%);
+  box-shadow: inset -6px -6px 12px rgba(0, 0, 0, 0.14);
+}
+.mpoliniz__flor::after {
+  content: '';
+  position: absolute;
+  inset: 30%;
+  border-radius: 50%;
+  background: #c1301f;
+  opacity: 0.55;
+}
+/* el hilo de polen tendido hacia la abeja */
+.mpoliniz__hilo {
+  position: absolute;
+  top: 34px;
+  left: 90px;
+  width: 3px;
+  height: 56px;
+  background: linear-gradient(180deg, #ffc94a 0%, rgba(255, 201, 74, 0.15) 100%);
+  transform: rotate(18deg);
+  border-radius: 2px;
+}
+/* la angelita, chiquita, sobre la flor */
+.mpoliniz__abeja {
+  position: absolute;
+  top: 4px;
+  left: 96px;
+  width: 44px;
+  height: 30px;
+  border-radius: 50% 50% 42% 42% / 58% 58% 42% 42%;
+  background: radial-gradient(circle at 38% 30%, #7a5a2c 0%, #4a3418 70%);
+  box-shadow: inset -5px -4px 8px rgba(0, 0, 0, 0.25);
+}
+.mpoliniz__abeja-banda {
+  position: absolute;
+  top: 6px;
+  left: 14px;
+  width: 8px;
+  height: 20px;
+  border-radius: 4px;
+  background: #ffc94a;
+  opacity: 0.85;
+}
+.mpoliniz__ficha-nombre {
+  margin: 0;
+  font-weight: 800;
+  font-size: 1rem;
+  color: #2e402e;
+}
+.mpoliniz__ficha-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4c5a44;
+}
+
+/* ---- Saberes ---- */
+.mpoliniz__saberes {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.mpoliniz__saberes h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #2e402e;
+}
+.mpoliniz__saberes ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .mpoliniz__saberes ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.mpoliniz__saberes li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(150, 99, 26, 0.16);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.mpoliniz__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.mpoliniz__saberes b {
+  display: block;
+  font-size: 0.92rem;
+  color: #2e402e;
+}
+.mpoliniz__saberes li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.mpoliniz__cierre {
+  margin: 0.9rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #3c4a38;
+  max-width: 42rem;
+}

--- a/src/mockups/MundoPolinizadores3D.jsx
+++ b/src/mockups/MundoPolinizadores3D.jsx
@@ -1,0 +1,221 @@
+/*
+ * MundoPolinizadores3D — vitrina pública del MUNDO DE LA RED QUE DA LA
+ * COSECHA. Ruta #/mockups/mundo-polinizadores-3d, sin auth.
+ *
+ * La tesis, en una línea: SIN ESTOS BICHOS NO HAY COSECHA — y el trabajo que
+ * hacen es invisible, y por invisible es gratis, y por gratis no se cuida.
+ * Este mockup monta la finca completa (`EscenaPolinizadores`, ya armada con
+ * el rincón de monte, el meliponario, la cerca viva florida, el maracuyá, la
+ * ahuyama, el cafetal y el maizal) y le pone ENCIMA los tres interruptores
+ * que enseñan lo que un párrafo no logra:
+ *
+ *   día/noche    la finca cambia de turno (se recogen las abejas, entra el
+ *                murciélago a las flores pálidas del guamo).
+ *   ojo de abeja se apaga la flor roja del colibrí y se encienden las guías
+ *                de néctar ultravioleta.
+ *   la deriva    cruza el veneno del lote vecino: los hilos de polen se van
+ *                en ceniza y el enjambre se calla — distinto de día que de
+ *                noche, porque el veneno no tiene horario y las abejas sí.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el mundo 3D (chunk
+ * perezoso `vendor-three`); en equipo humilde, ahorro de datos o sin-WebGL se
+ * ve la ficha, digna y sin sudar la GPU. Copy en español de Colombia, en
+ * "usted". Autocontenida: cero CDN/imágenes externas.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import '../visual/mundo3d/polinizadores/polinizadores.css';
+import './MundoPolinizadores3D.css';
+
+const EscenaPolinizadores = lazy(() => import('../visual/mundo3d/polinizadores/EscenaPolinizadores.jsx'));
+
+/* Lo que enseña este mundo (verificado en el corpus de campo, en "usted"). */
+const SABERES = [
+  {
+    emoji: '🐝',
+    titulo: 'Ocho bichos, no uno',
+    texto:
+      'Polinizador no es sinónimo de abeja. En esta finca trabajan la angelita y la abeja de miel, el abejorro, el colibrí, el murciélago, la mariposa, el sírfido (una mosca disfrazada de abeja) y el escarabajo. Cada uno hace lo que ningún otro hace igual.',
+  },
+  {
+    emoji: '🌺',
+    titulo: 'Cada flor llama al suyo',
+    texto:
+      'El color, la forma, el olor y hasta la hora de abrirse evolucionaron juntos para llamar a un visitante. La flor roja y tubular llama al colibrí; la blanca grande que huele de noche llama al murciélago; la amarilla abierta de la mañana llama a la abeja.',
+  },
+  {
+    emoji: '👁️',
+    titulo: 'El mundo con el ojo de la abeja',
+    texto:
+      'Las abejas no ven el rojo: ven azul, morado, amarillo y ultravioleta. Donde nosotros vemos una flor pareja, ellas ven guías de néctar que las llevan derecho al premio. Actívelo y va a entender el síndrome floral en un segundo.',
+  },
+  {
+    emoji: '☠️',
+    titulo: 'La deriva tiene horario, la abeja también',
+    texto:
+      'Cuando el veneno del lote vecino cruza de día, se lleva la mayoría del enjambre; de noche el daño es otro, porque las abejas duermen y el murciélago sigue trabajando. La red se recupera si queda monte de dónde volver.',
+  },
+];
+
+export default function MundoPolinizadores3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  const [momento, setMomento] = useState('dia');
+  const [comoAbeja, setComoAbeja] = useState(false);
+  const [veneno, setVeneno] = useState(false);
+  const [diezmado, setDiezmado] = useState(0);
+
+  return (
+    <main className="mpoliniz">
+      <header className="mpoliniz__head">
+        <p className="mpoliniz__kicker">La red que da la cosecha · vitrina</p>
+        <h1>El mundo de los polinizadores</h1>
+        <p className="mpoliniz__lema">
+          Ocho bichos, siete síndromes florales y la red de polen tejiéndose
+          sobre el maracuyá, la ahuyama, el cafetal y la cerca viva. Recórrala
+          con el dedo y pruebe los tres interruptores: el turno, el ojo de la
+          abeja y la deriva del vecino.
+        </p>
+      </header>
+
+      <section className="mpoliniz__escena" aria-label="La red de polinización en 3D">
+        <div className="mpoliniz__lienzo">
+          {mostrar3D ? (
+            <div
+              className="polz-mundo"
+              data-tier={tier}
+              data-momento={momento}
+              data-vision={comoAbeja ? 'abeja' : 'humana'}
+              data-veneno={veneno ? '1' : '0'}
+            >
+              <Suspense
+                fallback={
+                  <div className="mpoliniz__cargando" role="status">
+                    Entrando a la finca…
+                  </div>
+                }
+              >
+                <EscenaPolinizadores
+                  tier={tier}
+                  reducedMotion={reducedMotion}
+                  momento={momento}
+                  comoAbeja={comoAbeja}
+                  veneno={veneno}
+                  onDano={setDiezmado}
+                />
+              </Suspense>
+            </div>
+          ) : (
+            <FichaPolinizadores />
+          )}
+        </div>
+
+        {mostrar3D && (
+          <div className="mpoliniz__interruptores" role="group" aria-label="Los tres interruptores del mundo">
+            <button
+              type="button"
+              className="mpoliniz__switch"
+              aria-pressed={momento === 'noche'}
+              onClick={() => setMomento((m) => (m === 'dia' ? 'noche' : 'dia'))}
+            >
+              {momento === 'dia' ? '🌙 Ver de noche' : '☀️ Ver de día'}
+            </button>
+            <button
+              type="button"
+              className="mpoliniz__switch"
+              aria-pressed={comoAbeja}
+              onClick={() => setComoAbeja((v) => !v)}
+            >
+              {comoAbeja ? '👁️ Ver con ojo humano' : '🐝 Ver con ojo de abeja'}
+            </button>
+            <button
+              type="button"
+              className="mpoliniz__switch mpoliniz__switch--veneno"
+              aria-pressed={veneno}
+              onClick={() => setVeneno((v) => !v)}
+            >
+              {veneno ? '✕ Quitar la deriva' : '☠️ Cruzar la deriva del vecino'}
+            </button>
+            {veneno && diezmado > 0 && (
+              <p className="mpoliniz__dano" role="status">
+                Se fue el {Math.round(diezmado * 100)} % del enjambre
+                {momento === 'noche' ? ' (de noche el daño es menor)' : ''}.
+              </p>
+            )}
+          </div>
+        )}
+
+        <div className="mpoliniz__barra">
+          <p className="mpoliniz__tier">
+            {mostrar3D
+              ? 'Está viendo la finca en 3D. Gírela con el dedo o el mouse.'
+              : puede3D
+                ? 'Está viendo la ficha de la red de polinización.'
+                : 'Su equipo ve la ficha de la red de polinización (va parejo en cualquier teléfono).'}
+          </p>
+          {puede3D && (
+            <button type="button" className="mpoliniz__toggle" onClick={() => setVer2d((v) => !v)}>
+              {ver2d ? 'Ver la finca en 3D' : 'Ver la ficha'}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <section className="mpoliniz__saberes" aria-label="Lo que enseña este mundo">
+        <h2>Lo que le enseña esta red</h2>
+        <ol>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span className="mpoliniz__emoji" aria-hidden="true">
+                {s.emoji}
+              </span>
+              <div>
+                <b>{s.titulo}</b>
+                <p>{s.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="mpoliniz__cierre">
+          El polen que viaja de flor en flor no lo paga nadie y no lo ve
+          nadie: por eso es la primera cosecha que se pierde cuando se acaba
+          el monte o cruza el veneno. Cuidar la red no cuesta cemento — cuesta
+          dejarle un rincón a los bichos.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+/* La ficha de la red: el fallback digno para equipo humilde / sin-WebGL. Una
+   angelita CSS sobre la flor amarilla, con el hilo de polen tendido — cero GPU. */
+function FichaPolinizadores() {
+  return (
+    <div
+      className="mpoliniz__ficha"
+      role="img"
+      aria-label="La red de polinización: la abeja angelita sobre la flor, con el hilo de polen tendido"
+    >
+      <div className="mpoliniz__estampa" aria-hidden="true">
+        <span className="mpoliniz__flor" />
+        <span className="mpoliniz__hilo" />
+        <span className="mpoliniz__abeja">
+          <span className="mpoliniz__abeja-banda" />
+        </span>
+      </div>
+      <p className="mpoliniz__ficha-nombre">El mundo de los polinizadores</p>
+      <p className="mpoliniz__ficha-sub">Ocho bichos, siete flores, una sola red</p>
+    </div>
+  );
+}

--- a/src/prodApp/ProdChagraApp.jsx
+++ b/src/prodApp/ProdChagraApp.jsx
@@ -67,6 +67,7 @@ const LAZY_MAP = {
   PapaVivo3D: lazy(() => import('../mockups/PapaVivo3D.jsx')),
   MundoPiscicultura3D: lazy(() => import('../mockups/MundoPiscicultura3D.jsx')),
   LecheriaViva3D: lazy(() => import('../mockups/LecheriaViva3D.jsx')),
+  MundoPolinizadores3D: lazy(() => import('../mockups/MundoPolinizadores3D.jsx')),
   MundoEntBosque: lazy(() => import('../visual/mundo3d/bosque/MundoEntBosque.jsx')),
   MontanaMundosCampesino: lazy(() => import('../mockups/MontanaMundosCampesino.jsx')),
   VitrinaMaestraMundos: lazy(() => import('../mockups/VitrinaMaestraMundos.jsx')),


### PR DESCRIPTION
## Resumen

- `EscenaPolinizadores.jsx` (la finca completa: rincón de monte, meliponario, cerca viva florida, maracuyá, ahuyama, cafetal, maizal + la RED de polen entre 8 especies y 7 síndromes florales) existía en `src/visual/mundo3d/polinizadores/` pero nada lo montaba: cero rutas en el manifiesto de prod, cero entrada en `App.jsx`, cero componentMap (hallazgo #1 del audit de biodiversidad 3D, 2026-07-16, mayor ROI).
- Se agrega `src/mockups/MundoPolinizadores3D.jsx` (+ `.css`), siguiendo el patrón de `LecheriaViva3D.jsx`/`CafetalVivo3D.jsx` (PR #2545): device-tiering real (`decidirTier`/`permite3D`), ficha 2D de respaldo para equipo humilde/sin-WebGL, y los **tres interruptores** que la escena ya documentaba (turno día/noche, ojo de abeja, deriva del veneno vecino) expuestos como controles reales, con el `diezmado` del enjambre mostrado cuando el veneno está activo.
- Cableado en los tres sitios:
  - `src/config/rutasProdChagraApp.js` — entrada en `NUCLEO_3D` (`path: 'mundo_polinizadores'`, alias, `categoria: '3D'`).
  - `src/App.jsx` — lazy import + `MOCKUP_HASH_ROUTES['mockups/mundo-polinizadores-3d']` + `case 'mockup_mundo_polinizadores_3d'`.
  - `src/prodApp/ProdChagraApp.jsx` — `LAZY_MAP.MundoPolinizadores3D`.

## Verificación

- `npm run build:prod` verde (chunk `EscenaPolinizadores-*.js` ~59 kB emitido, code-split correcto).
- `npm run dev` + Playwright (Chromium sistema + swiftshader) en la ruta clásica `#/mockups/mundo-polinizadores-3d`: el mundo monta, no queda negro (finca completa visible: monte, meliponario, cerca viva, maracuyá, maizal), y el interruptor "Ver de noche" cambia la escena en vivo (cielo lunar, flores nocturnas).
- Control: los console-errors observados (VITE_FARMOS_CLIENT_ID, sqlite-wasm 403/404) aparecen IDÉNTICOS en `#/mockups/cafetal-vivo-3d` (ruta ya en prod) — son ruido preexistente del entorno de dev, no relacionados con este cableado.
- `dist-prod/` (build artifact preexistente, trackeado por herencia) se revirtió antes del commit — no forma parte de este diff.
- Anti-leak: grep limpio sobre los archivos tocados.

## Plan de pruebas

- [x] Build de producción verde
- [x] Montaje verificado en dev vía hash clásico (2 capturas + control)
- [ ] Revisión del operador (Miguel) — mismo flujo que piscicultura/lechería/cafetal