### PR TITLE
feat(mercado): sitio demo público standalone (mercado.chagra.bio)

### DIFF
--- a/mercado.html
+++ b/mercado.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#0f172a" />
+    <title>Mercado Chagra — mercado campesino de procedencia</title>
+    <meta
+      name="description"
+      content="Mercado campesino honesto: cada producto ubicado en la montaña por su altitud y piso térmico, con la cara de quien lo sembró, su finca y su vereda. Galería de muestra."
+    />
+    <!-- Página estática de galería (datos de muestra, sin auth, sin sqlite-wasm
+         ni service worker): CSP mínima, no necesita 'wasm-unsafe-eval'. -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'"
+    />
+    <style>
+      html, body { background: #020617; margin: 0; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/entries/mercado.jsx"></script>
+  </body>
+</html>

--- a/src/entries/mercado.jsx
+++ b/src/entries/mercado.jsx
@@ -1,0 +1,29 @@
+/*
+ * Entry standalone del mockup Mercado → destino público mercado.chagra.bio.
+ *
+ * Monta SOLO <Mercado/> sin el shell de la PWA (sin auth, sin capa de datos
+ * sqlite-wasm, sin service worker): es una galería pública de diseño con datos
+ * de MUESTRA (src/mockups/mercado/datos.js). Sirve como "sitio demo" autónomo
+ * en la raíz de un host, en vez de la ruta interna #/mockups/mercado.
+ *
+ * Reusa la MISMA cadena de CSS global que src/main.jsx para paridad visual
+ * con la vista embebida en la app. onBack se omite: en standalone no hay
+ * dashboard al que volver (el botón "volver" se oculta solo cuando onBack es
+ * undefined — ver Mercado.jsx).
+ */
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import '../index.css';
+import '../styles/themes.css';
+import '../styles/motion.css';
+import '../styles/temas-fase2.css';
+import '../styles/clima-atmosfera.css';
+import '../styles/sello-confianza.css';
+import '../styles/panel-procedencia.css';
+import Mercado from '../mockups/Mercado.jsx';
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <Mercado />
+  </StrictMode>,
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -76,6 +76,12 @@ export default defineConfig({
   build: {
     target: 'es2022',
     rolldownOptions: {
+      // Multi-página: la PWA (index.html) + el mockup público del mercado
+      // (mercado.html → mercado.chagra.bio) se emiten en el mismo build.
+      input: {
+        main: resolve(import.meta.dirname, 'index.html'),
+        mercado: resolve(import.meta.dirname, 'mercado.html'),
+      },
       output: {
         manualChunks(id) {
           if (id.includes('node_modules/react-dom') || id.includes('node_modules/react/')) {


### PR DESCRIPTION
## Qué

Agrega un **entry standalone** para el mockup `Mercado` (`src/mockups/Mercado.jsx`) para que pueda servirse como **sitio demo público en la raíz de un host** — destino `mercado.chagra.bio` — en vez de solo la ruta hash interna `#/mockups/mercado` dentro de la PWA.

## Por qué

`mercado.chagra.bio` estaba **caído** porque nunca se provisionó: no tiene registro DNS y no existía ningún deploy propio del mercado (el nombre solo vivía como branding en el docstring de `Mercado.jsx`). El demo sí renderiza hoy embebido en `chagra.guatoc.co/#/mockups/mercado`, pero no como sitio autónomo.

## Cómo

- `mercado.html` (nuevo): página raíz mínima, CSP reducida (galería estática, sin sqlite-wasm ni SW).
- `src/entries/mercado.jsx` (nuevo): monta solo `<Mercado/>` sin el shell de la app; reusa la **misma cadena de CSS global** que `src/main.jsx` para paridad visual. `onBack` omitido (el botón volver se auto-oculta).
- `vite.config.js`: build **multipágina** vía `rolldownOptions.input` (`main` + `mercado`).

Verificado: `npm run build` OK (7.9s), emite `dist/mercado.html` cableado a su chunk + `Mercado.css` + creatures. eslint limpio.

## Falta (fuera de este PR, requiere Cloudflare del operador)

Apuntar el subdominio `mercado.chagra.bio` a esta página (registro DNS + custom domain/redirect en Cloudflare). Runbook aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)