### PR TITLE
fix(experimentos): align reindex rag with corpus_chunks schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "leaflet": "^1.9.4",
         "localforage": "^1.10.0",
         "lucide-react": "^0.577.0",
+        "pg": "8.22.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-leaflet": "^5.0.0",
@@ -8040,6 +8041,95 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8284,6 +8374,45 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/potpack": {
       "version": "1.0.2",
@@ -9285,6 +9414,15 @@
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -10958,6 +11096,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "leaflet": "^1.9.4",
     "localforage": "^1.10.0",
     "lucide-react": "^0.577.0",
+    "pg": "8.22.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-leaflet": "^5.0.0",

--- a/scripts/__tests__/reindex-rag.test.mjs
+++ b/scripts/__tests__/reindex-rag.test.mjs
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  buildDocumentChunks,
+  collectMarkdownFiles,
+  hashChunkKey,
+  parseArgs,
+  runReindexRag,
+  sliceWithOverlap,
+  splitMarkdownIntoSections,
+  toCorpusChunkRows,
+} from '../experimentos/reindex-rag.mjs';
+
+let tempRoot;
+
+beforeEach(() => {
+  tempRoot = join(tmpdir(), `reindex-rag-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  mkdirSync(tempRoot, { recursive: true });
+});
+
+afterEach(() => {
+  if (tempRoot) {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+  vi.unstubAllGlobals();
+});
+
+function makeDoc(relPath, content) {
+  const filePath = join(tempRoot, relPath);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, 'utf8');
+  return filePath;
+}
+
+describe('parseArgs', () => {
+  it('lee defaults y flags explicitos', () => {
+    const opts = parseArgs(['--dry-run', '--source-dir', '/x', '--ollama-url', 'http://ollama:11434', '--log-file', '/tmp/out.log', '--schema', 'kg', '--table', 'chunks', '--max-chars', '100', '--overlap-chars', '15']);
+    expect(opts.dryRun).toBe(true);
+    expect(opts.sourceDir).toBe('/x');
+    expect(opts.ollamaUrl).toBe('http://ollama:11434');
+    expect(opts.logFile).toBe('/tmp/out.log');
+    expect(opts.schema).toBe('kg');
+    expect(opts.table).toBe('chunks');
+    expect(opts.maxChars).toBe(100);
+    expect(opts.overlapChars).toBe(15);
+  });
+});
+
+describe('markdown chunking', () => {
+  it('divide por secciones y conserva texto de encabezados', () => {
+    const text = [
+      '# DR demo',
+      '',
+      'Intro.',
+      '',
+      '## Seccion uno',
+      '',
+      'Primer bloque.',
+      '',
+      '### Detalle',
+      '',
+      'Segundo bloque.',
+    ].join('\n');
+
+    const sections = splitMarkdownIntoSections(text, 'demo');
+    expect(sections).toHaveLength(3);
+    expect(sections[0].headingTitle).toBe('DR demo');
+    expect(sections[1].headingTitle).toBe('Seccion uno');
+    expect(sections[2].headingTitle).toBe('Detalle');
+  });
+
+  it('mantiene solape entre slices', () => {
+    const slices = sliceWithOverlap('a'.repeat(120) + 'b'.repeat(120), 100, 20);
+    expect(slices.length).toBeGreaterThan(1);
+    expect(slices[1].startChar).toBeLessThan(slices[0].endChar);
+  });
+
+  it('crea chunks con titulo de seccion', () => {
+    const text = [
+      '# DR demo',
+      '',
+      'Texto muy largo '.repeat(40),
+    ].join('\n');
+    const chunks = buildDocumentChunks(text, 'demo', { maxChars: 180, overlapChars: 20 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks[0].title).toBe('DR demo');
+    expect(chunks[0].content).toContain('# DR demo');
+  });
+});
+
+describe('filesystem helpers', () => {
+  it('recorre markdowns de forma recursiva y ordenada', () => {
+    makeDoc('b/dos.md', '# Dos\nContenido.');
+    makeDoc('a/uno.md', '# Uno\nContenido.');
+    makeDoc('a/ignore.txt', 'x');
+
+    const files = collectMarkdownFiles(tempRoot);
+    expect(files.map((file) => file.endsWith('.md'))).toEqual([true, true]);
+    expect(files[0].endsWith('uno.md')).toBe(true);
+    expect(files[1].endsWith('dos.md')).toBe(true);
+  });
+});
+
+describe('row builder', () => {
+  it('crea rows con el esquema real esperado', () => {
+    const filePath = makeDoc('demo.md', [
+      '# DR demo',
+      '',
+      'Texto base.',
+      '',
+      '## Seccion',
+      '',
+      'Segundo bloque.',
+    ].join('\n'));
+
+    const rows = toCorpusChunkRows({
+      filePath,
+      fileName: 'demo.md',
+      text: readFileSync(filePath, 'utf8'),
+      maxChars: 120,
+      overlapChars: 20,
+    });
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0]).toMatchObject({
+      source_type: 'dr-fanout',
+      graph_node_id: null,
+      title: 'DR demo',
+      source_ids: ['demo'],
+      model: 'nomic-embed-text',
+    });
+    expect(rows[0].chunkKey).toHaveLength(64);
+    expect(hashChunkKey({
+      sourceName: 'demo',
+      chunkIndex: 0,
+      title: rows[0].title,
+      content: rows[0].content,
+    })).toBe(rows[0].chunkKey);
+  });
+});
+
+describe('runReindexRag', () => {
+  it('usa ON CONFLICT cuando detecta indice unico en chunk_key', async () => {
+    makeDoc('demo.md', [
+      '# DR demo',
+      '',
+      'Texto base suficiente para un chunk.',
+    ].join('\n'));
+
+    const queries = [];
+    const pool = {
+      async query(sql, params) {
+        const text = String(sql);
+        queries.push(text);
+        if (text.includes('information_schema.columns')) {
+          return { rows: ['chunk_key', 'content', 'embedding', 'model'].map((column_name) => ({ column_name })) };
+        }
+        if (text.includes('pg_index')) {
+          return { rows: [{ has_unique_chunk_key: true }] };
+        }
+        if (text.includes('INSERT INTO')) {
+          return { rowCount: 1 };
+        }
+        return { rows: [] };
+      },
+      async end() {},
+    };
+
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ embedding: Array.from({ length: 768 }, (_, index) => index / 1000) }),
+    }));
+
+    const result = await runReindexRag({
+      sourceDir: tempRoot,
+      dryRun: false,
+      pool,
+      fetchImpl: globalThis.fetch,
+      logger: {
+        info() {},
+        warn() {},
+        error() {},
+      },
+    });
+
+    expect(result.errors).toBe(0);
+    expect(result.inserted).toBeGreaterThan(0);
+    expect(queries.some((sql) => sql.includes('ON CONFLICT (chunk_key) DO NOTHING'))).toBe(true);
+  });
+
+  it('falla si faltan columnas requeridas', async () => {
+    makeDoc('demo.md', '# DR demo\n\nTexto.');
+
+    const pool = {
+      async query(sql) {
+        const text = String(sql);
+        if (text.includes('information_schema.columns')) {
+          return { rows: [{ column_name: 'chunk_key' }, { column_name: 'content' }, { column_name: 'embedding' }] };
+        }
+        return { rows: [] };
+      },
+      async end() {},
+    };
+
+    await expect(runReindexRag({
+      sourceDir: tempRoot,
+      pool,
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ embedding: Array.from({ length: 768 }, () => 0.1) }),
+      }),
+      logger: { info() {}, warn() {}, error() {} },
+    })).rejects.toThrow(/corpus_chunks no tiene columnas requeridas/);
+  });
+});

--- a/scripts/experimentos/reindex-rag.mjs
+++ b/scripts/experimentos/reindex-rag.mjs
@@ -1,0 +1,668 @@
+#!/usr/bin/env node
+/**
+ * scripts/experimentos/reindex-rag.mjs
+ *
+ * Ingesta de markdowns DR-FANOUT hacia chagra_kg.corpus_chunks.
+ *
+ * Flujo:
+ *   1. Lee cada .md del source dir.
+ *   2. Divide por secciones markdown con solape.
+ *   3. Embebe cada chunk contra Ollama con nomic-embed-text.
+ *   4. Inserta en corpus_chunks con chunk_key estable e idempotencia.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, extname, join, resolve, basename } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createHash } from 'node:crypto';
+import { Pool } from 'pg';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..', '..');
+
+export const SOURCE_TYPE = 'dr-fanout';
+export const DEFAULT_SOURCE_DIR = resolve(ROOT, 'deepresearch', 'DR-FANOUT');
+export const DEFAULT_OLLAMA_URL = process.env.REINDEX_RAG_OLLAMA_URL || 'http://127.0.0.1:11434';
+export const DEFAULT_MODEL = 'nomic-embed-text';
+export const DEFAULT_SCHEMA = 'chagra_kg';
+export const DEFAULT_TABLE = 'corpus_chunks';
+export const DEFAULT_MAX_CHARS = 3200;
+export const DEFAULT_OVERLAP_CHARS = 400;
+const EMBED_DIM = 768;
+const EMBED_TIMEOUT_MS = 60000;
+const REQUIRED_COLUMNS = ['chunk_key', 'content', 'embedding', 'model'];
+
+function ensureDirForFile(filePath) {
+  mkdirSync(dirname(filePath), { recursive: true });
+}
+
+function createLogger(logFile) {
+  if (!logFile) {
+    return {
+      info(message) {
+        console.log(message);
+      },
+      warn(message) {
+        console.warn(message);
+      },
+      error(message) {
+        console.error(message);
+      },
+    };
+  }
+
+  ensureDirForFile(logFile);
+  return {
+    info(message, meta = null) {
+      appendFileSync(logFile, JSON.stringify({ ts: new Date().toISOString(), level: 'info', message, meta }) + '\n', 'utf8');
+      console.log(message);
+    },
+    warn(message, meta = null) {
+      appendFileSync(logFile, JSON.stringify({ ts: new Date().toISOString(), level: 'warn', message, meta }) + '\n', 'utf8');
+      console.warn(message);
+    },
+    error(message, meta = null) {
+      appendFileSync(logFile, JSON.stringify({ ts: new Date().toISOString(), level: 'error', message, meta }) + '\n', 'utf8');
+      console.error(message);
+    },
+  };
+}
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const opts = {
+    dryRun: false,
+    sourceDir: DEFAULT_SOURCE_DIR,
+    ollamaUrl: DEFAULT_OLLAMA_URL,
+    logFile: null,
+    schema: DEFAULT_SCHEMA,
+    table: DEFAULT_TABLE,
+    maxChars: DEFAULT_MAX_CHARS,
+    overlapChars: DEFAULT_OVERLAP_CHARS,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--dry-run') {
+      opts.dryRun = true;
+      continue;
+    }
+    if (arg === '--source-dir') {
+      opts.sourceDir = resolve(argv[++i] || opts.sourceDir);
+      continue;
+    }
+    if (arg === '--ollama-url') {
+      opts.ollamaUrl = argv[++i] || opts.ollamaUrl;
+      continue;
+    }
+    if (arg === '--log-file') {
+      opts.logFile = resolve(argv[++i] || '');
+      continue;
+    }
+    if (arg === '--schema') {
+      opts.schema = argv[++i] || opts.schema;
+      continue;
+    }
+    if (arg === '--table') {
+      opts.table = argv[++i] || opts.table;
+      continue;
+    }
+    if (arg === '--max-chars') {
+      opts.maxChars = Number.parseInt(argv[++i] || String(opts.maxChars), 10);
+      continue;
+    }
+    if (arg === '--overlap-chars') {
+      opts.overlapChars = Number.parseInt(argv[++i] || String(opts.overlapChars), 10);
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      opts.help = true;
+    }
+  }
+
+  return opts;
+}
+
+export function collectMarkdownFiles(rootDir) {
+  const files = [];
+
+  function walk(currentDir) {
+    for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+      const entryPath = join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(entryPath);
+        continue;
+      }
+      if (entry.isFile() && extname(entry.name).toLowerCase() === '.md') {
+        files.push(entryPath);
+      }
+    }
+  }
+
+  walk(rootDir);
+  files.sort((a, b) => a.localeCompare(b));
+  return files;
+}
+
+function normalizeChunkText(text) {
+  return String(text || '')
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .trim();
+}
+
+function isHeadingLine(line) {
+  const match = String(line || '').match(/^(#{1,6})\s+(.*\S)\s*$/);
+  if (!match) return null;
+  return { level: match[1].length, title: match[2].trim() };
+}
+
+function isFenceLine(line) {
+  return /^(```+|~~~+)/.test(String(line || '').trim());
+}
+
+export function splitMarkdownIntoSections(text, sourceName = '') {
+  const lines = String(text || '').replace(/\r\n/g, '\n').split('\n');
+  const sections = [];
+  const stack = [];
+  let current = null;
+  let inFence = false;
+
+  function flushCurrent() {
+    if (!current) return;
+    const body = normalizeChunkText(current.lines.join('\n'));
+    const headingLine = current.headingLine || '';
+    const sectionText = headingLine ? `${headingLine}\n\n${body}`.trim() : body;
+    if (!sectionText) {
+      current = null;
+      return;
+    }
+    sections.push({
+      headingLevel: current.headingLevel,
+      headingTitle: current.headingTitle,
+      headingPath: current.headingPath,
+      headingLine,
+      body,
+      text: sectionText,
+    });
+    current = null;
+  }
+
+  for (const line of lines) {
+    if (isFenceLine(line)) {
+      inFence = !inFence;
+      if (!current) {
+        current = {
+          headingLevel: 0,
+          headingTitle: sourceName,
+          headingPath: [],
+          headingLine: '',
+          lines: [],
+        };
+      }
+      current.lines.push(line);
+      continue;
+    }
+
+    const heading = !inFence ? isHeadingLine(line) : null;
+    if (heading) {
+      flushCurrent();
+      stack.length = Math.max(0, heading.level - 1);
+      stack[heading.level - 1] = heading.title;
+      current = {
+        headingLevel: heading.level,
+        headingTitle: heading.title,
+        headingPath: stack.slice(0, heading.level),
+        headingLine: line.trim(),
+        lines: [],
+      };
+      continue;
+    }
+
+    if (!current) {
+      current = {
+        headingLevel: 0,
+        headingTitle: sourceName,
+        headingPath: [],
+        headingLine: '',
+        lines: [],
+      };
+    }
+    current.lines.push(line);
+  }
+
+  flushCurrent();
+  return sections;
+}
+
+export function sliceWithOverlap(text, maxChars, overlapChars) {
+  const normalized = normalizeChunkText(text);
+  if (!normalized) return [];
+  if (normalized.length <= maxChars) {
+    return [{ text: normalized, startChar: 0, endChar: normalized.length }];
+  }
+
+  const chunks = [];
+  let start = 0;
+  while (start < normalized.length) {
+    const end = Math.min(normalized.length, start + maxChars);
+    const slice = normalizeChunkText(normalized.slice(start, end));
+    if (slice) {
+      chunks.push({ text: slice, startChar: start, endChar: end });
+    }
+
+    if (end >= normalized.length) break;
+    let nextStart = end - overlapChars;
+    if (nextStart <= start) nextStart = end;
+    start = nextStart;
+  }
+
+  return chunks;
+}
+
+export function buildDocumentChunks(text, sourceName, { maxChars = DEFAULT_MAX_CHARS, overlapChars = DEFAULT_OVERLAP_CHARS } = {}) {
+  const sections = splitMarkdownIntoSections(text, sourceName);
+  const chunks = [];
+  let chunkIndex = 0;
+
+  for (const section of sections) {
+    const sectionTitle = section.headingTitle || sourceName;
+    const headingPrefix = section.headingLine ? `${section.headingLine}\n\n` : '';
+    const body = section.body || '';
+    const fullText = section.headingLine ? `${headingPrefix}${body}`.trim() : body;
+    if (!fullText) continue;
+
+    const bodyLimit = Math.max(1, maxChars - headingPrefix.length);
+    const effectiveOverlap = Math.max(0, Math.min(overlapChars, bodyLimit - 1));
+    const bodySlices = body ? sliceWithOverlap(body, bodyLimit, effectiveOverlap) : [{ text: '', startChar: 0, endChar: 0 }];
+
+    if (bodySlices.length === 0) {
+      chunks.push({
+        chunkIndex,
+        title: sectionTitle,
+        content: normalizeChunkText(section.headingLine),
+        section,
+      });
+      chunkIndex += 1;
+      continue;
+    }
+
+    for (const slice of bodySlices) {
+      const content = section.headingLine ? `${headingPrefix}${slice.text}`.trim() : slice.text;
+      if (!content) continue;
+      chunks.push({
+        chunkIndex,
+        title: sectionTitle,
+        content,
+        section,
+      });
+      chunkIndex += 1;
+    }
+  }
+
+  return chunks;
+}
+
+export function hashChunkKey({ sourceName, chunkIndex, title, content }) {
+  return createHash('sha256')
+    .update(`${sourceName}\u0000${chunkIndex}\u0000${title}\u0000${normalizeChunkText(content)}`, 'utf8')
+    .digest('hex');
+}
+
+export function toCorpusChunkRows({ filePath, fileName, text, maxChars = DEFAULT_MAX_CHARS, overlapChars = DEFAULT_OVERLAP_CHARS }) {
+  const sourceName = basename(fileName, extname(fileName));
+  const chunks = buildDocumentChunks(text, sourceName, { maxChars, overlapChars });
+
+  return chunks.map((chunk) => ({
+    filePath,
+    fileName,
+    sourceName,
+    chunkIndex: chunk.chunkIndex,
+    chunkKey: hashChunkKey({
+      sourceName,
+      chunkIndex: chunk.chunkIndex,
+      title: chunk.title,
+      content: chunk.content,
+    }),
+    source_type: SOURCE_TYPE,
+    graph_node_id: null,
+    content: normalizeChunkText(chunk.content),
+    title: chunk.title || sourceName,
+    source_ids: [sourceName],
+    embedding: null,
+    model: DEFAULT_MODEL,
+  }));
+}
+
+async function embedChunkTexts(texts, { ollamaUrl, fetchImpl = globalThis.fetch }) {
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('fetch no esta disponible para consultar Ollama');
+  }
+
+  const url = new URL('/api/embeddings', `${ollamaUrl.replace(/\/$/, '')}/`).toString();
+  const vectors = [];
+
+  for (const text of texts) {
+    const res = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: DEFAULT_MODEL, prompt: text }),
+      signal: AbortSignal.timeout(EMBED_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`Ollama HTTP ${res.status}`);
+    }
+    const data = await res.json();
+    if (!Array.isArray(data.embedding) || data.embedding.length !== EMBED_DIM) {
+      throw new Error(`embedding invalido: se esperaban ${EMBED_DIM} dimensiones`);
+    }
+    vectors.push(data.embedding);
+  }
+
+  return vectors;
+}
+
+function vectorLiteral(values) {
+  if (!Array.isArray(values) || values.length === 0) {
+    throw new Error('embedding vacio');
+  }
+
+  const parts = values.map((value) => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new Error('embedding invalido');
+    }
+    return Number(value).toString();
+  });
+  return `[${parts.join(',')}]`;
+}
+
+async function queryRequiredColumns(client, { schema, table }) {
+  const sql = `
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema = $1
+      AND table_name = $2
+      AND column_name = ANY($3::text[])
+  `;
+  const res = await client.query(sql, [schema, table, REQUIRED_COLUMNS]);
+  const present = new Set(res.rows.map((row) => row.column_name));
+  const missing = REQUIRED_COLUMNS.filter((column) => !present.has(column));
+  if (missing.length > 0) {
+    throw new Error(`corpus_chunks no tiene columnas requeridas: ${missing.join(', ')}`);
+  }
+  return true;
+}
+
+async function hasUniqueChunkKeyIndex(client, { schema, table }) {
+  const sql = `
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_index i
+      JOIN pg_class t ON t.oid = i.indrelid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
+      JOIN pg_attribute a ON a.attrelid = t.oid
+      WHERE n.nspname = $1
+        AND t.relname = $2
+        AND i.indisunique
+        AND i.indnkeyatts = 1
+        AND a.attnum = ANY(i.indkey)
+        AND a.attname = 'chunk_key'
+    ) AS has_unique_chunk_key
+  `;
+  const res = await client.query(sql, [schema, table]);
+  return Boolean(res.rows[0]?.has_unique_chunk_key);
+}
+
+async function queryExistingChunkKeys(client, { schema, table, chunkKeys }) {
+  if (chunkKeys.length === 0) return new Set();
+  const sql = `SELECT chunk_key FROM "${schema}"."${table}" WHERE chunk_key = ANY($1::text[])`;
+  const res = await client.query(sql, [chunkKeys]);
+  return new Set(res.rows.map((row) => row.chunk_key));
+}
+
+function dedupeRows(rows) {
+  const seen = new Set();
+  const out = [];
+  for (const row of rows) {
+    if (seen.has(row.chunkKey)) continue;
+    seen.add(row.chunkKey);
+    out.push(row);
+  }
+  return out;
+}
+
+function buildInsertQuery({ schema, table, rows, useConflict }) {
+  if (rows.length === 0) {
+    return { text: '', values: [] };
+  }
+
+  const values = [];
+  const placeholders = [];
+  let param = 1;
+  for (const row of rows) {
+    placeholders.push(`($${param}, $${param + 1}, $${param + 2}, $${param + 3}, $${param + 4}, $${param + 5}::text[], $${param + 6}::vector, $${param + 7})`);
+    values.push(
+      row.chunkKey,
+      row.source_type,
+      row.graph_node_id,
+      row.content,
+      row.title,
+      row.source_ids,
+      vectorLiteral(row.embedding),
+      row.model,
+    );
+    param += 8;
+  }
+
+  const conflict = useConflict ? ' ON CONFLICT (chunk_key) DO NOTHING' : '';
+  return {
+    text: `
+      INSERT INTO "${schema}"."${table}" (
+        chunk_key,
+        source_type,
+        graph_node_id,
+        content,
+        title,
+        source_ids,
+        embedding,
+        model
+      )
+      VALUES ${placeholders.join(', ')}
+      ${conflict}
+    `,
+    values,
+  };
+}
+
+async function insertRows(client, { schema, table, rows, useConflict }) {
+  const { text, values } = buildInsertQuery({ schema, table, rows, useConflict });
+  if (!text) return 0;
+  const res = await client.query(text, values);
+  return res.rowCount || 0;
+}
+
+async function createPoolFromEnv() {
+  return new Pool();
+}
+
+async function processDocument({ filePath, fileName, text, options, logger, client, useConflict, fetchImpl }) {
+  const rows = toCorpusChunkRows({
+    filePath,
+    fileName,
+    text,
+    maxChars: options.maxChars,
+    overlapChars: options.overlapChars,
+  });
+
+  if (rows.length === 0) {
+    logger.warn(`Documento sin chunks utiles: ${fileName}`);
+    return { chunks: 0, embedded: 0, inserted: 0, skipped: 0 };
+  }
+
+  let pendingRows = dedupeRows(rows);
+  if (!useConflict) {
+    const existing = await queryExistingChunkKeys(client, {
+      schema: options.schema,
+      table: options.table,
+      chunkKeys: pendingRows.map((row) => row.chunkKey),
+    });
+    pendingRows = pendingRows.filter((row) => !existing.has(row.chunkKey));
+  }
+
+  if (pendingRows.length === 0) {
+    logger.info(`Documento ${fileName}: todo ya existia`);
+    return { chunks: rows.length, embedded: 0, inserted: 0, skipped: rows.length };
+  }
+
+  const embeddings = await embedChunkTexts(
+    pendingRows.map((row) => row.content),
+    { ollamaUrl: options.ollamaUrl, fetchImpl },
+  );
+
+  const readyRows = pendingRows.map((row, index) => ({
+    ...row,
+    embedding: embeddings[index],
+  }));
+
+  const inserted = options.dryRun ? 0 : await insertRows(client, {
+    schema: options.schema,
+    table: options.table,
+    rows: readyRows,
+    useConflict,
+  });
+  const skipped = rows.length - inserted;
+
+  logger.info(`Documento ${fileName}: chunks ${rows.length}, insertados ${inserted}, omitidos ${skipped}`);
+
+  return {
+    chunks: rows.length,
+    embedded: readyRows.length,
+    inserted,
+    skipped,
+  };
+}
+
+export async function runReindexRag({
+  sourceDir = DEFAULT_SOURCE_DIR,
+  ollamaUrl = DEFAULT_OLLAMA_URL,
+  logFile = null,
+  schema = DEFAULT_SCHEMA,
+  table = DEFAULT_TABLE,
+  maxChars = DEFAULT_MAX_CHARS,
+  overlapChars = DEFAULT_OVERLAP_CHARS,
+  dryRun = false,
+  pool = null,
+  fetchImpl = globalThis.fetch,
+  logger = null,
+} = {}) {
+  const activeLogger = logger || createLogger(logFile);
+  if (!existsSync(sourceDir)) {
+    throw new Error(`No existe el directorio fuente: ${sourceDir}`);
+  }
+
+  const files = collectMarkdownFiles(sourceDir);
+  activeLogger.info(`Reindexando ${files.length} documentos desde ${sourceDir}`);
+  activeLogger.info(`Destino: ${schema}.${table}`);
+  activeLogger.info(`Modelo: ${DEFAULT_MODEL} en ${ollamaUrl}`);
+
+  if (files.length === 0) {
+    activeLogger.warn('No se encontraron archivos markdown para procesar');
+    return { files: 0, documents: 0, chunks: 0, embedded: 0, inserted: 0, skipped: 0, errors: 0 };
+  }
+
+  const options = {
+    ollamaUrl,
+    schema,
+    table,
+    maxChars,
+    overlapChars,
+    dryRun,
+  };
+
+  let client = null;
+  let useConflict = false;
+  if (!dryRun) {
+    client = pool || await createPoolFromEnv();
+    await queryRequiredColumns(client, { schema, table });
+    useConflict = await hasUniqueChunkKeyIndex(client, { schema, table });
+    activeLogger.info(useConflict ? 'Indice unico en chunk_key detectado, se usara ON CONFLICT' : 'No hay indice unico en chunk_key, se verificara existencia antes de insertar');
+  }
+
+  let documents = 0;
+  let chunks = 0;
+  let embedded = 0;
+  let inserted = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const filePath of files) {
+    const fileName = basename(filePath);
+    try {
+      const text = readFileSync(filePath, 'utf8');
+      const result = await processDocument({
+        filePath,
+        fileName,
+        text,
+        options,
+        logger: activeLogger,
+        client,
+        useConflict,
+        fetchImpl,
+      });
+      documents += 1;
+      chunks += result.chunks;
+      embedded += result.embedded;
+      inserted += result.inserted;
+      skipped += result.skipped;
+    } catch (err) {
+      errors += 1;
+      activeLogger.error(`Error en ${fileName}: ${err.message}`);
+    }
+  }
+
+  if (client && typeof client.end === 'function') {
+    await client.end();
+  }
+
+  activeLogger.info(`Resumen final: documentos ${documents}, chunks ${chunks}, embebidos ${embedded}, insertados ${inserted}, omitidos ${skipped}, errores ${errors}`);
+
+  return {
+    files: files.length,
+    documents,
+    chunks,
+    embedded,
+    inserted,
+    skipped,
+    errors,
+  };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log([
+      'Usage: node scripts/experimentos/reindex-rag.mjs [options]',
+      '',
+      'Options:',
+      '  --dry-run',
+      '  --source-dir PATH',
+      '  --ollama-url URL',
+      '  --log-file PATH',
+      '  --schema NAME',
+      '  --table NAME',
+      '  --max-chars N',
+      '  --overlap-chars N',
+    ].join('\n'));
+    return { help: true };
+  }
+
+  return runReindexRag(args);
+}
+
+const IS_CLI = process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+
+if (IS_CLI) {
+  main().catch((err) => {
+    console.error(`[reindex-rag] ERROR: ${err.message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary\n- Rewrote scripts/experimentos/reindex-rag.mjs to read markdown DR files, split by markdown sections with overlap, embed chunks with nomic-embed-text, and insert into chagra_kg.corpus_chunks using the real schema.\n- Added deterministic chunk keys, source_type dr-fanout, source_ids, and idempotent insert behavior based on the chunk_key unique index or an existence check fallback.\n- Added unit coverage for chunking, chunk key generation, file discovery, schema mapping, and DB path selection.\n\n## Test plan\n- npx vitest run scripts/__tests__/reindex-rag.test.mjs\n- npx eslint scripts/experimentos/reindex-rag.mjs scripts/__tests__/reindex-rag.test.mjs --max-warnings=0\n- npx vitest run (repo-wide, currently fails on pre-existing unrelated tests)\n- npx eslint . --max-warnings=0 (repo-wide, hit OOM in this environment)\n- npm run build