### PR TITLE
art(subsuelo): el subsuelo vivo y conectado — red micorrizica + Lombricita guia

### DIFF
--- a/scripts/diag/verify-subsuelo.mjs
+++ b/scripts/diag/verify-subsuelo.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/*
+ * verify-subsuelo — captura la escena del Mundo Subsuelo enriquecida en 3
+ * estados de vida del suelo (base, suelo vivo, suelo cansado) para revisar la
+ * red micorrízica, la Lombricita protagonista, raíces con nódulos, agua y
+ * minerales. Sin negro, con animación real (no virtual-time-budget).
+ *
+ * Auto-contenido: stubbea la red y siembra el token de auth (el juego no
+ * necesita datos de finca), así la vista con auth `#subsuelo` monta directo.
+ */
+import { mkdirSync } from 'node:fs';
+import { execSync, spawn } from 'node:child_process';
+import { chromium } from 'playwright';
+
+const PORT = process.env.PORT || '5178';
+const BASE = `http://127.0.0.1:${PORT}`;
+const OUT = process.env.OUT_DIR || '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/subsuelo-shots';
+const FIXED_MS = new Date('2026-06-17T10:30:00-05:00').getTime();
+
+function resolveChromium() {
+  if (process.env.PLAYWRIGHT_CHROMIUM_PATH) return process.env.PLAYWRIGHT_CHROMIUM_PATH;
+  try {
+    const w = execSync('which chromium 2>/dev/null', { encoding: 'utf8' }).trim();
+    if (w) return w;
+  } catch { /* fall back to bundled */ }
+  return undefined;
+}
+
+async function waitForServer(url, child) {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (child?.exitCode != null) throw new Error(`server died code=${child.exitCode}`);
+    try {
+      const r = await fetch(url, { signal: AbortSignal.timeout(2000) });
+      if (r.ok || r.status >= 400) return;
+    } catch { /* retry */ }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error('timeout waiting server');
+}
+
+async function ensureServer() {
+  try {
+    const r = await fetch(BASE, { signal: AbortSignal.timeout(1500) });
+    if (r.ok || r.status >= 400) return null;
+  } catch { /* start one */ }
+  const child = spawn('npm', ['run', 'dev', '--', '--host', '127.0.0.1', '--port', PORT, '--strictPort'], {
+    cwd: process.cwd(),
+    stdio: 'inherit',
+    env: { ...process.env, VITE_FARMOS_URL: '', VITE_FARMOS_CLIENT_ID: 'farm', VITE_OPERATOR_USERNAME: 'op-test' },
+  });
+  await waitForServer(BASE, child);
+  return child;
+}
+
+async function stubRed(context) {
+  await context.route('**/*', async (route) => {
+    const req = route.request();
+    const url = new URL(req.url());
+    if (url.pathname.endsWith('/oauth/token')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ access_token: 'tk', refresh_token: 'rf', expires_in: 3600, token_type: 'Bearer' }),
+      });
+    }
+    if (url.origin === BASE) return route.continue();
+    if (url.pathname.includes('/api/') || url.pathname.includes('/jsonapi/') || url.pathname.includes('/oauth/')
+      || url.hostname.includes('open-meteo') || url.hostname.includes('ollama')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
+  });
+}
+
+async function seedProfileAndAuth(page) {
+  await page.addInitScript((fixedMs) => {
+    window.localStorage.setItem('chagra:profile:done:v1', '1');
+    window.localStorage.setItem('chagra:onboarding:done', '1');
+    window.localStorage.setItem('chagra:active_tenant_id', 'op-test');
+  }, FIXED_MS);
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle', { timeout: 20_000 }).catch(() => {});
+  // token de auth en la DB 'Chagra' (syncQueue), igual que isAuthenticated() espera
+  await page.evaluate(async (fixedMs) => {
+    function open(version) {
+      return new Promise((resolve, reject) => {
+        const req = indexedDB.open('Chagra', version);
+        req.onupgradeneeded = () => {
+          if (!req.result.objectStoreNames.contains('syncQueue')) req.result.createObjectStore('syncQueue');
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+      });
+    }
+    let db = await open();
+    if (!db.objectStoreNames.contains('syncQueue')) {
+      const v = db.version + 1; db.close(); db = await open(v);
+    }
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction('syncQueue', 'readwrite');
+      const s = tx.objectStore('syncQueue');
+      s.put('tk', 'farmos_access_token');
+      s.put('rf', 'farmos_refresh_token');
+      s.put(fixedMs + 3600_000, 'farmos_token_expiry');
+      tx.oncomplete = resolve; tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+  }, FIXED_MS);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle', { timeout: 20_000 }).catch(() => {});
+}
+
+async function clickCarta(page, nombre, veces = 1) {
+  for (let i = 0; i < veces; i++) {
+    await page.getByRole('button', { name: new RegExp(nombre, 'i') }).first().click();
+    await page.waitForTimeout(450);
+  }
+}
+
+async function run() {
+  mkdirSync(OUT, { recursive: true });
+  const server = await ensureServer();
+  const browser = await chromium.launch({
+    executablePath: resolveChromium(),
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  });
+  const context = await browser.newContext({
+    baseURL: BASE,
+    viewport: { width: 900, height: 1200 },
+    deviceScaleFactor: 2,
+    locale: 'es-CO',
+  });
+  const page = await context.newPage();
+  page.setDefaultTimeout(60_000);
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+
+  try {
+    await stubRed(context);
+    await seedProfileAndAuth(page);
+
+    // Navegar al Mundo Subsuelo (vista con auth) por el evento de navegación.
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'subsuelo' } })));
+    await page.getByTestId('mundo-subsuelo-escena').waitFor({ state: 'visible', timeout: 30_000 });
+    await page.waitForTimeout(11_000); // dejar correr la red micorrízica y la Lombricita
+
+    const escena = page.getByTestId('mundo-subsuelo-escena');
+    const box0 = await escena.boundingBox();
+    if (!box0 || box0.width < 60 || box0.height < 60) throw new Error('escena vacía/negra en base');
+    const life0 = await escena.getAttribute('data-soil-life');
+    await page.screenshot({ path: `${OUT}/01-base-${life0}.png`, fullPage: true });
+
+    // Suelo VIVO: compost + micorriza suben la vida por encima de 75.
+    await clickCarta(page, 'Compost y bocashi', 2);
+    await clickCarta(page, 'Inocular micorriza', 1);
+    await page.waitForTimeout(3_000);
+    const life1 = await escena.getAttribute('data-soil-life');
+    const stage1 = await escena.getAttribute('data-stage');
+    await page.screenshot({ path: `${OUT}/02-vivo-${life1}-${stage1}.png`, fullPage: true });
+
+    // Suelo CANSADO: labranza intensa + exceso químico rompen la red.
+    await clickCarta(page, 'Labranza intensa', 2);
+    await clickCarta(page, 'Exceso quimico', 2);
+    await page.waitForTimeout(2_500);
+    const life2 = await escena.getAttribute('data-soil-life');
+    const stage2 = await escena.getAttribute('data-stage');
+    await page.screenshot({ path: `${OUT}/03-cansado-${life2}-${stage2}.png`, fullPage: true });
+
+    const sparks = await page.getByTestId('nutrient-spark').count();
+    console.log(`[verify-subsuelo] OK base=${life0} vivo=${life1}(${stage1}) cansado=${life2}(${stage2}) sparks(cansado)=${sparks}`);
+    if (errors.length) throw new Error(`errores de página: ${errors[0]}`);
+    console.log(`[verify-subsuelo] capturas → ${OUT}`);
+  } finally {
+    await context.close().catch(() => {});
+    await browser.close().catch(() => {});
+    if (server) server.kill('SIGTERM');
+  }
+}
+
+run().catch((e) => {
+  console.error(e instanceof Error ? e.message : String(e));
+  process.exitCode = 1;
+});

--- a/src/components/juego/MundoSubsuelo.jsx
+++ b/src/components/juego/MundoSubsuelo.jsx
@@ -5,6 +5,7 @@ import { fvhSkinClass } from '../../config/fvhSkin';
 import { fincaVivaHomePerfilActivo } from '../../config/fincaVivaHomeFlag';
 import { evaluarSubsuelo, mensajeMeta } from '../../services/mundoSubsueloEngine';
 import { Lombriz } from '../../visual/creatures/index.js';
+import { construirSubsuelo } from './subsueloRedGeom';
 import './mundo-subsuelo.css';
 
 function clamp(value, min = 0, max = 100) {
@@ -65,11 +66,48 @@ function Mascot({ name, title, children, active }) {
 
 function SoilScene({ soilLife, activeDecision }) {
   const stage = getSoilStage(soilLife);
-  const rootDepth = 38 + soilLife * 0.7;
-  const hifaCount = Math.max(2, Math.round(soilLife / 12));
-  const wormCount = Math.max(1, Math.round(soilLife / 22));
-  const sparkCount = Math.max(0, Math.round((soilLife - 40) / 10));
   const isTired = soilLife < 35;
+
+  // TODA la geometría del subsuelo (raíces, red micorrízica, nódulos, agua,
+  // minerales) sale de un módulo PURO y determinista; solo depende de la vida
+  // del suelo, así que memoiza por valor y se re-teje cuando la tierra cambia.
+  const sub = useMemo(() => construirSubsuelo(soilLife), [soilLife]);
+  const { raices, nodulos, nodos, hilos, gotas, minerales, vida } = sub;
+
+  // Cuántos hilos de la red se ven encendidos: tierra cansada = pocos y
+  // apagados; tierra viva = casi toda la malla brilla. Los PUENTES (el reparto
+  // entre matas) van siempre de primeros: son la lección.
+  const hilosOrdenados = useMemo(() => {
+    const puentes = hilos.filter((h) => h.puente);
+    const resto = hilos.filter((h) => !h.puente);
+    return [...puentes, ...resto];
+  }, [hilos]);
+  const hilosVisibles = Math.max(
+    hilosOrdenados.filter((h) => h.puente).length,
+    Math.round(hilosOrdenados.length * (0.35 + vida * 0.65)),
+  );
+
+  // Chispas de nutriente que viajan por la red (los pulsos): más vida = más
+  // pulsos. Se paran sobre los PUENTES primero (ahí se lee el intercambio).
+  // Tierra muy cansada = red muda (sin pulsos), como el suelo real sin vida.
+  const sparkCount = Math.max(0, Math.round((soilLife - 40) / 8));
+  const chispas = useMemo(() => {
+    const base = hilosOrdenados.slice(0, Math.max(1, hilosVisibles));
+    return Array.from({ length: sparkCount }, (_, i) => {
+      const h = base[(i * 3 + 1) % base.length] || base[0];
+      // punto sobre la Bézier del hilo (t variado por chispa) — el pulso viaja
+      const t = 0.3 + ((i * 0.27) % 0.4);
+      const u = 1 - t;
+      const cx = u * u * h.a.x + 2 * u * t * h.mid.x + t * t * h.b.x;
+      const cy = u * u * h.a.y + 2 * u * t * h.mid.y + t * t * h.b.y;
+      return { cx, cy, puente: h.puente, i };
+    });
+  }, [hilosOrdenados, hilosVisibles, sparkCount]);
+
+  // La Lombricita protagonista: su galería (un túnel curvo excavado) cruza el
+  // corte y ella va acostada adentro, grande y viva. Más lombricitas menudas
+  // aparecen cuando la tierra despierta (suelo vivo = más fauna).
+  const wormCount = Math.max(1, Math.round(soilLife / 26));
 
   return (
     <div
@@ -78,7 +116,7 @@ function SoilScene({ soilLife, activeDecision }) {
       data-stage={stage}
       className={fvhSkinClass('ms-vinneta overflow-hidden rounded-3xl border border-amber-200 bg-[#f6efe1] shadow-[0_24px_70px_rgba(60,46,26,0.16)]')}
     >
-      <svg viewBox="0 0 760 430" role="img" aria-label="Corte transversal del suelo con raices, hongos, agua y lombrices" className="block h-auto w-full">
+      <svg viewBox="0 0 760 430" role="img" aria-label="Corte transversal del suelo con raices, red de hongos micorrizicos, nodulos, agua que se infiltra y lombrices" className="block h-auto w-full">
         <defs>
           <linearGradient id="ms-sky" x1="0" x2="1" y1="0" y2="1">
             <stop offset="0%" stopColor="#b9f3ff" />
@@ -86,8 +124,14 @@ function SoilScene({ soilLife, activeDecision }) {
           </linearGradient>
           <linearGradient id="ms-soil" x1="0" x2="0" y1="0" y2="1">
             <stop offset="0%" stopColor={isTired ? '#b88452' : '#8a5a32'} />
-            <stop offset="100%" stopColor={isTired ? '#7a5236' : '#3f2d20'} />
+            <stop offset="55%" stopColor={isTired ? '#8a5f3d' : '#5a3d28'} />
+            <stop offset="100%" stopColor={isTired ? '#6b4a30' : '#2c1e15'} />
           </linearGradient>
+          <radialGradient id="ms-nodo" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="#e9fffb" />
+            <stop offset="55%" stopColor="#9df5da" />
+            <stop offset="100%" stopColor="#37d6b0" stopOpacity="0" />
+          </radialGradient>
           <filter id="ms-glow">
             <feGaussianBlur stdDeviation="3" result="blur" />
             <feMerge>
@@ -173,75 +217,167 @@ function SoilScene({ soilLife, activeDecision }) {
           </g>
         ))}
 
-        {/* Raíces: crecen con un pop suave cada vez que ganan profundidad. */}
-        <g key={`raices-${rootDepth}`} className="msx-raices">
-          {[92, 265, 438, 608].map((x, index) => (
-            <g key={x}>
-              <path d={`M${x + 29} 153v${rootDepth}`} stroke="#f5e8b7" strokeWidth="7" strokeLinecap="round" />
-              <path d={`M${x + 29} 205c-${18 + index * 4} 16-${28 + index * 3} 31-${38 + index * 2} 49`} stroke="#f5e8b7" strokeWidth="4" fill="none" strokeLinecap="round" />
-              <path d={`M${x + 29} 224c${18 + index * 3} 17 ${31 + index * 2} 34 ${42 + index * 2} 58`} stroke="#f5e8b7" strokeWidth="4" fill="none" strokeLinecap="round" />
+        {/* AGUA que se infiltra: canales ondulados que bajan desde la superficie
+            (percolación) con su gotica al final. Tierra viva y esponjosa = más
+            infiltración. Va detrás de las raíces (es el telón húmedo). */}
+        <g aria-hidden="true">
+          {gotas.map((g, index) => (
+            <g key={`agua-${index}`}>
+              <path d={g.d} stroke="#7dd3fc" strokeWidth="2" fill="none" strokeLinecap="round" opacity={0.18 + vida * 0.22} />
+              <circle
+                className="msx-gota"
+                style={{ animationDelay: `${g.delay}s` }}
+                cx={g.cx}
+                cy={g.cy}
+                r="3.4"
+                fill="#38bdf8"
+                opacity="0.85"
+              />
             </g>
           ))}
         </g>
 
-        {/* La firma: nutrientes viajando por el internet de los hongos. */}
-        {Array.from({ length: hifaCount }).map((_, index) => {
-          const y = 245 + (index % 4) * 35;
-          const start = 92 + index * 82;
-          return (
-            <path
-              key={`hifa-${index}`}
-              className="msx-hifa"
-              style={{ animationDelay: `${index * 0.45}s` }}
-              d={`M${start} ${y} C${start + 42} ${y - 30}, ${start + 96} ${y + 28}, ${start + 148} ${y - 6}`}
-              stroke="#67e8f9"
-              strokeWidth={soilLife > 70 ? 5 : 3}
-              fill="none"
-              strokeLinecap="round"
-              opacity={isTired ? 0.24 : 0.78}
-              filter={soilLife > 55 ? 'url(#ms-glow)' : undefined}
-            />
-          );
-        })}
+        {/* RAÍCES profundas: trazo cálido con un realce claro encima (da volumen,
+            la punta que busca). Crecen con un pop suave al ganar vida. */}
+        <g key={`raices-${soilLife}`} className="msx-raices" aria-hidden="true">
+          {raices.map((rz, index) => (
+            <g key={`raiz-${index}`}>
+              <path d={rz.d} stroke="#8a5f36" strokeWidth={rz.ancho} fill="none" strokeLinecap="round" />
+              <path d={rz.d} stroke="#e7cf9a" strokeWidth={rz.ancho * 0.5} fill="none" strokeLinecap="round" opacity="0.9" />
+            </g>
+          ))}
+          {/* NÓDULOS del fríjol: bolitas donde las bacterias fijan el nitrógeno
+              del aire (la leguminosa que abona la tierra). Un realce rosado. */}
+          {nodulos.map((nd, index) => (
+            <g key={`nodulo-${index}`}>
+              <circle cx={nd.x} cy={nd.y} r={nd.r} fill="#f9a8d4" opacity="0.92" />
+              <circle cx={nd.x - nd.r * 0.3} cy={nd.y - nd.r * 0.3} r={nd.r * 0.4} fill="#fce7f3" opacity="0.9" />
+            </g>
+          ))}
+        </g>
 
-        {Array.from({ length: sparkCount }).map((_, index) => (
+        {/* MINERALES suspendidos (fósforo ámbar, nitrógeno azul, potasio malva):
+            los que están junto a una punta de raíz brillan y suben — el uptake
+            que la red hace posible. */}
+        <g aria-hidden="true">
+          {minerales.map((m, index) => (
+            <circle
+              key={`min-${index}`}
+              className={m.uptake ? 'msx-mineral' : undefined}
+              style={m.uptake ? { animationDelay: `${m.delay}s` } : undefined}
+              cx={m.x}
+              cy={m.y}
+              r={m.r}
+              fill={m.color}
+              opacity={m.uptake ? 0.95 : 0.5 + vida * 0.2}
+              filter={m.uptake ? 'url(#ms-glow)' : undefined}
+            />
+          ))}
+        </g>
+
+        {/* LA RED MICORRÍZICA — la firma del mundo: hifas turquesa que enlazan las
+            puntas de raíz entre sí (el "wood wide web"). Los PUENTES entre matas
+            distintas van más gruesos y claros: ahí se reparte el alimento. El
+            flujo (dash animado) hace correr el nutriente por los hilos. */}
+        <g fill="none" strokeLinecap="round">
+          {hilosOrdenados.slice(0, hilosVisibles).map((h, index) => (
+            <path
+              key={`hilo-${h.k}`}
+              className="msx-hifa"
+              style={{ animationDelay: `${(index % 8) * 0.35}s` }}
+              d={h.d}
+              stroke={h.puente ? '#a7f3d0' : '#5eead4'}
+              strokeWidth={h.puente ? 3 : 1.6}
+              opacity={isTired ? 0.3 : h.puente ? 0.95 : 0.6 + vida * 0.3}
+              filter={!isTired && (h.puente || vida > 0.6) ? 'url(#ms-glow)' : undefined}
+            />
+          ))}
+        </g>
+
+        {/* NODOS de la red: puntas de raíz (intercambio, cálido), uniones del
+            micelio (verde-blanco que respira) y esporas (perla malva, la memoria
+            del suelo). Solo se dibujan los que cuelgan de hilos visibles. */}
+        <g aria-hidden="true">
+          {nodos.map((nd, index) => {
+            const esRaiz = nd.tipo === 'raiz';
+            const esEspora = nd.tipo === 'espora';
+            const apagado = isTired && !esRaiz;
+            const fill = esRaiz ? '#ffd27a' : esEspora ? '#d8b4fe' : 'url(#ms-nodo)';
+            return (
+              <g key={`nodo-${index}`}>
+                {!esRaiz && !apagado && vida > 0.35 && (
+                  <circle
+                    className="msx-nodo"
+                    style={{ animationDelay: `${(index % 6) * 0.4}s` }}
+                    cx={nd.x}
+                    cy={nd.y}
+                    r={esEspora ? 5 : 6}
+                    fill="url(#ms-nodo)"
+                    opacity="0.55"
+                  />
+                )}
+                <circle cx={nd.x} cy={nd.y} r={esRaiz ? 3.4 : 2.6} fill={fill} opacity={apagado ? 0.35 : 0.95} />
+              </g>
+            );
+          })}
+        </g>
+
+        {/* Los PULSOS de nutriente que corren por la red (chispas). Sobre los
+            puentes cuentan la lección: fósforo/azúcar viajando de mata a mata. */}
+        {chispas.map((c) => (
           <circle
-            key={`spark-${index}`}
+            key={`spark-${c.i}`}
             data-testid="nutrient-spark"
             className="msx-chispa"
-            style={{ animationDelay: `${index * 0.35}s` }}
-            cx={132 + index * 92}
-            cy={238 + (index % 3) * 46}
-            r="6"
-            fill={index % 2 ? '#fef08a' : '#22d3ee'}
+            style={{ animationDelay: `${c.i * 0.3}s` }}
+            cx={c.cx}
+            cy={c.cy}
+            r={c.puente ? 6 : 4.5}
+            fill={c.i % 2 ? '#fde68a' : '#5eead4'}
             filter="url(#ms-glow)"
           />
         ))}
 
-        {/* Lombrices = la Lombriz rubber-hose de la casa, meneándose en su
-            galería (spec belleza-juegos: la protagonista viva de la red del
-            suelo, no un trazo con puntico). Inline dentro del corte, escalada y
-            un poco rotada para acostarse en su galería del suelo. */}
+        {/* LA LOMBRICITA protagonista — la Lombriz rubber-hose de la casa — en su
+            galería excavada (el túnel claro que cruza el corte). Grande y viva,
+            con su sombra sobre la tierra; es la guía del mundo, no un puntico. */}
+        <g aria-hidden="true">
+          <path
+            d="M96 372c48-26 108-14 168-30 58-16 118-8 180-2"
+            stroke="#caa06c"
+            strokeWidth="18"
+            fill="none"
+            strokeLinecap="round"
+            opacity="0.32"
+          />
+          <path
+            d="M96 372c48-26 108-14 168-30 58-16 118-8 180-2"
+            stroke="#3a281a"
+            strokeWidth="20"
+            fill="none"
+            strokeLinecap="round"
+            opacity="0.16"
+          />
+        </g>
+        <g className="msx-lombriz" style={{ animationDelay: '0s' }}>
+          <g transform="translate(150 352) scale(3) rotate(-18)">
+            <Lombriz inline animated title="Lombricita, guia del suelo" />
+          </g>
+        </g>
+
+        {/* Lombricitas menudas que aparecen cuando la tierra despierta. */}
         {Array.from({ length: wormCount }).map((_, index) => {
-          const wx = 112 + index * 178;
-          const wy = 345 - (index % 2) * 34;
-          const rot = index % 2 === 0 ? 26 : -14;
+          const wx = 430 + index * 120;
+          const wy = 360 - (index % 2) * 46;
+          const rot = index % 2 === 0 ? 24 : -16;
           return (
-            <g key={`worm-${index}`} className="msx-lombriz" style={{ animationDelay: `${index * 0.6}s` }}>
-              <g transform={`translate(${wx + 26} ${wy - 30}) scale(1.75) rotate(${rot})`}>
+            <g key={`worm-${index}`} className="msx-lombriz" style={{ animationDelay: `${index * 0.6 + 0.3}s` }} aria-hidden="true">
+              <g transform={`translate(${wx} ${wy}) scale(1.5) rotate(${rot})`}>
                 <Lombriz inline animated title="Lombriz" />
               </g>
             </g>
           );
         })}
-
-        {soilLife >= 55 && (
-          <g fill="#38bdf8" opacity="0.82">
-            <path className="msx-agua" d="M641 161c-22 47-24 78-2 116 22-38 21-69 2-116Z" />
-            <path className="msx-agua" style={{ animationDelay: '0.8s' }} d="M688 154c-18 37-20 62-1 92 18-30 17-56 1-92Z" />
-            <path className="msx-agua" style={{ animationDelay: '1.5s' }} d="M595 164c-15 33-17 54-1 81 15-27 14-49 1-81Z" />
-          </g>
-        )}
 
         {isTired && (
           <g>

--- a/src/components/juego/mundo-subsuelo.css
+++ b/src/components/juego/mundo-subsuelo.css
@@ -100,6 +100,42 @@
   100% { transform: translateY(12px); opacity: 0.15; }
 }
 
+/* La gotica de infiltración baja por su canal y desaparece al fondo. */
+.msx-gota {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: msx-gotear 2.6s ease-in infinite;
+}
+@keyframes msx-gotear {
+  0% { transform: translateY(-42px) scale(0.7); opacity: 0; }
+  25% { opacity: 0.9; }
+  85% { opacity: 0.9; }
+  100% { transform: translateY(6px) scale(1); opacity: 0; }
+}
+
+/* El mineral que la red sube a la mata: asciende y titila (uptake). */
+.msx-mineral {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: msx-uptake 3.4s ease-in-out infinite;
+}
+@keyframes msx-uptake {
+  0% { transform: translateY(6px); opacity: 0.4; }
+  50% { transform: translateY(-6px); opacity: 1; }
+  100% { transform: translateY(6px); opacity: 0.4; }
+}
+
+/* Las uniones del micelio respiran (halo que late suave). */
+.msx-nodo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: msx-nodo-latir 3s ease-in-out infinite;
+}
+@keyframes msx-nodo-latir {
+  0%, 100% { transform: scale(0.85); opacity: 0.35; }
+  50% { transform: scale(1.15); opacity: 0.7; }
+}
+
 /* ── HUD: medidor y puntaje con feedback ─────────────────────────────── */
 
 /* La barra se desliza suave hacia su nuevo valor. */
@@ -199,6 +235,9 @@
   .msx-lombriz,
   .msx-chispa,
   .msx-agua,
+  .msx-gota,
+  .msx-mineral,
+  .msx-nodo,
   .msx-meter-fill::after,
   .msx-punch,
   .msx-entra,

--- a/src/components/juego/subsueloRedGeom.js
+++ b/src/components/juego/subsueloRedGeom.js
@@ -1,0 +1,320 @@
+/*
+ * subsueloRedGeom — la GEOMETRÍA (2D, SVG) del subsuelo vivo del juego "Mundo
+ * Subsuelo": la RED MICORRÍZICA que enlaza las raíces (el "wood wide web"), las
+ * raíces profundas con sus NÓDULOS de fijación, el AGUA que se infiltra y los
+ * MINERALES que suben a la mata. Todo en funciones PURAS y deterministas —
+ * cero azar por frame, cero libs, corre headless y es testeable — que devuelven
+ * cadenas `d` de path y puntos listos para pintar en el `<svg>` de la escena.
+ *
+ * ── LA BIOLOGÍA QUE ENSEÑA (grounded) ──────────────────────────────────────
+ * Los hongos micorrízicos se enredan en las puntas de las raíces: la mata les
+ * entrega AZÚCARES (carbono de la fotosíntesis) y ellos le devuelven FÓSFORO y
+ * AGUA que su micelio busca lejos, donde la raíz sola no llega. Ese micelio no
+ * se queda en una sola mata: CONECTA plantas distintas bajo tierra y REPARTE
+ * nutrientes entre ellas — por eso el maíz, el fríjol y la ahuyama se ayudan por
+ * debajo. Las leguminosas (el fríjol) suman NÓDULOS en sus raíces: bolitas donde
+ * viven bacterias (Rhizobium) que fijan el nitrógeno del aire. La red se DAÑA
+ * con la quema y la labranza que la parte; se CUIDA con coberturas y compost.
+ *
+ * ── EL MODELO ───────────────────────────────────────────────────────────────
+ * El suelo es un GRAFO: NODOS (puntas de raíz donde ocurre el intercambio,
+ * uniones del micelio y esporas) unidos por HILOS (hifas). Los hilos que cruzan
+ * de una planta a OTRA son PUENTES: ahí se lee el reparto. La densidad de la red
+ * crece con la VIDA del suelo (0–100): tierra cansada = pocos hilos apagados;
+ * tierra viva = malla densa que respira.
+ *
+ * El sistema de coordenadas es el del viewBox de la escena (0..760 x 0..430),
+ * con la superficie del suelo en y≈SUP y lo profundo hacia abajo (y creciente).
+ */
+
+/* PRNG determinista (mismo subsuelo en cada carga; nada de Math.random). */
+export function rng(seed) {
+  let s = (seed >>> 0) || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+/* Geometría de la vitrina de tierra (coords del viewBox de la escena). */
+export const SUP = 155; // línea de la superficie del suelo
+export const FONDO = 424; // fondo del corte
+export const ANCHO = 760;
+
+/*
+ * LAS MATAS de la chagra, ancladas en la superficie. `x` es el pie del tallo;
+ * `hondo` hasta dónde bajan las raíces; `raices` cuántas puntas principales.
+ * `leguminosa` marca al fríjol (raíces con nódulos que fijan nitrógeno).
+ * Alineadas con las matas verdes que la escena dibuja arriba.
+ */
+export const MATAS = [
+  { id: 'maiz', x: 121, hondo: 232, raices: 3, esparce: 1.05, leguminosa: false },
+  { id: 'frijol', x: 294, hondo: 196, raices: 3, esparce: 0.9, leguminosa: true },
+  { id: 'ahuyama', x: 467, hondo: 176, raices: 3, esparce: 1.25, leguminosa: false },
+  { id: 'arbol', x: 637, hondo: 258, raices: 4, esparce: 1.3, leguminosa: false },
+];
+
+/* Vida (0..100) → factor 0..1, saturado. */
+export function vidaFactor(soilLife) {
+  return Math.max(0, Math.min(1, soilLife / 100));
+}
+
+/*
+ * SISTEMA DE RAÍCES de una mata: una raíz-madre que baja curvándose y se afina,
+ * con raicillas laterales. Devuelve los `d` de path (para pintar el trazo) y las
+ * PUNTAS (nodos de intercambio de la red micorrízica). Determinista por semilla.
+ */
+export function raicesDeMata(mata, seed) {
+  const r = rng(seed);
+  const bx = mata.x;
+  const by = SUP + 2;
+  const trazos = [];
+  const puntas = [];
+  const n = mata.raices;
+  const anclaLateral = mata.leguminosa ? [] : null; // sitios para nódulos
+
+  for (let i = 0; i < n; i++) {
+    // cada raíz se abre a un lado; el árbol reparte más ancho
+    const t = n === 1 ? 0 : i / (n - 1) - 0.5; // -0.5..0.5
+    const spread = mata.esparce * (18 + r() * 10);
+    const largo = mata.hondo * (0.72 + r() * 0.32);
+    const dx = t * spread * 2 + (r() - 0.5) * 10;
+    const x1 = bx + dx * 0.35;
+    const y1 = by + largo * 0.42;
+    const x2 = bx + dx * 0.85;
+    const y2 = by + largo * 0.78;
+    const xf = bx + dx + (r() - 0.5) * 14;
+    const yf = by + largo;
+    const ancho = mata.id === 'arbol' ? 7.5 : 5.5;
+    trazos.push({
+      d: `M${bx.toFixed(1)} ${by.toFixed(1)} C${x1.toFixed(1)} ${y1.toFixed(1)}, ${x2.toFixed(1)} ${y2.toFixed(1)}, ${xf.toFixed(1)} ${yf.toFixed(1)}`,
+      ancho,
+    });
+    puntas.push({ x: xf, y: yf, tipo: 'raiz', mata: mata.id, arbol: mata.id === 'arbol' });
+
+    // una raicilla intermedia con su puntita (más sitios de intercambio)
+    if (r() > 0.28) {
+      const tm = 0.55 + r() * 0.15;
+      // punto sobre la curva madre (Bézier cúbica aproximada por el medio)
+      const mx = bx + dx * (0.55 * tm + 0.2);
+      const my = by + largo * tm;
+      const lx = mx + (t >= 0 ? 1 : -1) * (16 + r() * 20);
+      const ly = my + 20 + r() * 22;
+      trazos.push({
+        d: `M${mx.toFixed(1)} ${my.toFixed(1)} Q${((mx + lx) / 2 + (r() - 0.5) * 10).toFixed(1)} ${((my + ly) / 2).toFixed(1)}, ${lx.toFixed(1)} ${ly.toFixed(1)}`,
+        ancho: ancho * 0.5,
+      });
+      puntas.push({ x: lx, y: ly, tipo: 'raiz', mata: mata.id, arbol: mata.id === 'arbol' });
+    }
+
+    // guardamos anclas para los nódulos de la leguminosa (a lo largo de la madre)
+    if (anclaLateral) {
+      for (let k = 1; k <= 3; k++) {
+        const tt = 0.3 + k * 0.18;
+        anclaLateral.push({
+          x: bx + dx * (0.5 * tt + 0.25) + (r() - 0.5) * 6,
+          y: by + largo * tt,
+        });
+      }
+    }
+  }
+  return { trazos, puntas, nodulos: anclaLateral || [] };
+}
+
+/* Todas las raíces + puntas + nódulos de la chagra. */
+export function sistemaRaices(seed = 11) {
+  const trazos = [];
+  const puntasRaiz = [];
+  const nodulos = [];
+  MATAS.forEach((m, i) => {
+    const { trazos: t, puntas, nodulos: nod } = raicesDeMata(m, seed + i * 37);
+    trazos.push(...t);
+    puntasRaiz.push(...puntas);
+    nod.forEach((p) => nodulos.push({ ...p, r: 2.6 + ((i * 7 + p.x) % 3) * 0.7 }));
+  });
+  return { trazos, puntasRaiz, nodulos };
+}
+
+/*
+ * NODOS LIBRES del micelio: uniones de hifas repartidas en el volumen ENTRE las
+ * raíces (donde el hongo explora la tierra). Sesgo hacia la franja viva (ni muy
+ * arriba ni muy al fondo). Algunas son ESPORAS (memoria del suelo). `n` escala
+ * con la vida del suelo.
+ */
+export function nodosLibres(n, seed = 23) {
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const x = 46 + r() * (ANCHO - 92);
+    const y = SUP + 44 + r() * (FONDO - SUP - 80);
+    out.push({ x, y, tipo: r() > 0.82 ? 'espora' : 'micelio', mata: null });
+  }
+  return out;
+}
+
+/* Distancia al cuadrado (barata, para vecindad). */
+function d2(a, b) {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return dx * dx + dy * dy;
+}
+
+/*
+ * CONSTRUYE LA RED: dados los nodos (puntas de raíz + libres), teje los HILOS con
+ * estructura legible (no un amasijo):
+ *   1) cada nodo se une a sus `vecinos` más cercanos (grafo k-vecinos, dedup);
+ *   2) se AÑADEN puentes explícitos entre matas vecinas (la punta de una mata ↔
+ *      la punta más cercana de OTRA mata): son la lección (el reparto), y se
+ *      marcan `puente` para brillar más.
+ * Los hilos largísimos se descartan (evita cruces que ensucian la lectura).
+ * Cada hilo trae su `d` (Bézier cuadrática con caída suave, orgánica).
+ */
+export function construirRed(puntasRaiz, libres, { vecinos = 2 } = {}, seed = 37) {
+  const r = rng(seed);
+  const nodos = [...puntasRaiz, ...libres];
+  const maxLargo2 = 210 * 210;
+  const clave = (i, j) => (i < j ? `${i}-${j}` : `${j}-${i}`);
+  const vistos = new Set();
+  const hilos = [];
+
+  const empujar = (i, j, puente) => {
+    if (i === j) return;
+    const k = clave(i, j);
+    if (vistos.has(k)) {
+      if (puente) {
+        const h = hilos.find((x) => x.k === k);
+        if (h) h.puente = true;
+      }
+      return;
+    }
+    const a = nodos[i];
+    const b = nodos[j];
+    if (!puente && d2(a, b) > maxLargo2) return;
+    vistos.add(k);
+    // punto medio con caída (la hifa cuelga un poco) y ruido determinista
+    const largo = Math.sqrt(d2(a, b));
+    const mx = (a.x + b.x) / 2 + (r() - 0.5) * largo * 0.22;
+    const my = (a.y + b.y) / 2 + largo * (0.05 + r() * 0.08);
+    hilos.push({
+      k,
+      d: `M${a.x.toFixed(1)} ${a.y.toFixed(1)} Q${mx.toFixed(1)} ${my.toFixed(1)}, ${b.x.toFixed(1)} ${b.y.toFixed(1)}`,
+      a,
+      b,
+      mid: { x: mx, y: my },
+      puente: !!puente,
+    });
+  };
+
+  // 1) k-vecinos: cada nodo con sus más cercanos
+  for (let i = 0; i < nodos.length; i++) {
+    const orden = [];
+    for (let j = 0; j < nodos.length; j++) if (j !== i) orden.push([j, d2(nodos[i], nodos[j])]);
+    orden.sort((p, q) => p[1] - q[1]);
+    for (let v = 0; v < Math.min(vecinos, orden.length); v++) empujar(i, orden[v][0], false);
+  }
+
+  // 2) PUENTES entre matas vecinas: por cada par contiguo, une la punta de una
+  //    con la punta más cercana de la otra (el reparto entre plantas distintas).
+  const porMata = new Map();
+  puntasRaiz.forEach((p, idx) => {
+    if (!porMata.has(p.mata)) porMata.set(p.mata, []);
+    porMata.get(p.mata).push(idx);
+  });
+  const matas = [...porMata.keys()];
+  for (let pi = 0; pi < matas.length - 1; pi++) {
+    const a = porMata.get(matas[pi]);
+    const b = porMata.get(matas[pi + 1]);
+    let mejor = null;
+    let md = Infinity;
+    for (const i of a) for (const j of b) {
+      const dd = d2(nodos[i], nodos[j]);
+      if (dd < md) { md = dd; mejor = [i, j]; }
+    }
+    if (mejor) empujar(mejor[0], mejor[1], true);
+  }
+
+  return { nodos, hilos };
+}
+
+/*
+ * GOTAS DE AGUA que se infiltran: canales verticales ondulados desde la
+ * superficie hacia abajo (percolación). Cada una trae su `d`, un `delay` para
+ * escalonar la animación y su x/y de arranque. La cantidad escala con la vida
+ * del suelo (tierra viva y esponjosa = más infiltración; tierra apretada, poca).
+ */
+export function gotasAgua(soilLife, seed = 53) {
+  const r = rng(seed);
+  const n = Math.max(2, Math.round(3 + vidaFactor(soilLife) * 6));
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const x0 = 60 + (i + r() * 0.6) * ((ANCHO - 120) / n);
+    const y0 = SUP + 4;
+    const largo = 60 + r() * 120;
+    // canal ondulado: dos curvas encadenadas que serpentean al bajar
+    const x1 = x0 + (r() - 0.5) * 26;
+    const y1 = y0 + largo * 0.5;
+    const x2 = x0 + (r() - 0.5) * 30;
+    const y2 = y0 + largo;
+    out.push({
+      d: `M${x0.toFixed(1)} ${y0.toFixed(1)} Q${(x0 + (r() - 0.5) * 20).toFixed(1)} ${(y0 + largo * 0.25).toFixed(1)}, ${x1.toFixed(1)} ${y1.toFixed(1)} T${x2.toFixed(1)} ${y2.toFixed(1)}`,
+      cx: x2,
+      cy: y2,
+      delay: (i * 0.42).toFixed(2),
+    });
+  }
+  return out;
+}
+
+/*
+ * MINERALES del suelo: granitos de nutriente suspendidos que la red sube a las
+ * matas. Se colorean por tipo (fósforo ámbar, nitrógeno azul, potasio malva) y
+ * los que están cerca de una punta de raíz brillan (uptake). `n` escala con la
+ * vida del suelo. Puro y determinista.
+ */
+const MINERAL_COLORES = [
+  { tipo: 'fosforo', color: '#fcd34d' },
+  { tipo: 'nitrogeno', color: '#93c5fd' },
+  { tipo: 'potasio', color: '#d8b4fe' },
+];
+export function mineralesDelSuelo(soilLife, puntasRaiz, seed = 71) {
+  const r = rng(seed);
+  const vida = vidaFactor(soilLife);
+  const n = Math.round(10 + vida * 18);
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const x = 40 + r() * (ANCHO - 80);
+    const y = SUP + 40 + r() * (FONDO - SUP - 70);
+    const mineral = MINERAL_COLORES[i % MINERAL_COLORES.length];
+    // ¿cerca de una punta de raíz? entonces está siendo tomado (brilla)
+    let cerca = false;
+    for (const p of puntasRaiz) {
+      if (d2({ x, y }, p) < 34 * 34) { cerca = true; break; }
+    }
+    out.push({
+      x,
+      y,
+      r: 1.6 + r() * 1.8,
+      color: mineral.color,
+      tipo: mineral.tipo,
+      uptake: cerca && vida > 0.4,
+      delay: (i * 0.19).toFixed(2),
+    });
+  }
+  return out;
+}
+
+/*
+ * Construye TODO el subsuelo de un tirón, listo para pintar. Es la única función
+ * que la escena necesita llamar; memoiza bien porque solo depende de `soilLife`
+ * (la estructura de raíces es fija; la densidad de red/agua/minerales escala).
+ */
+export function construirSubsuelo(soilLife) {
+  const vida = vidaFactor(soilLife);
+  const { trazos: raices, puntasRaiz, nodulos } = sistemaRaices(11);
+  const nLibres = Math.round(6 + vida * 16); // 6..22
+  const libres = nodosLibres(nLibres, 23);
+  const { nodos, hilos } = construirRed(puntasRaiz, libres, { vecinos: 2 }, 37);
+  const gotas = gotasAgua(soilLife, 53);
+  const minerales = mineralesDelSuelo(soilLife, puntasRaiz, 71);
+  return { raices, puntasRaiz, nodulos, nodos, hilos, gotas, minerales, vida };
+}


### PR DESCRIPTION
## Que
Enriquece la escena 2D del **Mundo Subsuelo** (`MundoSubsuelo`) para volverla un mundo bajo tierra **vivo y conectado**, tejido desde un modulo de geometria PURA y determinista (`subsueloRedGeom.js`).

## Lo nuevo
- **Red micorrizica (el "wood wide web")**: grafo de nodos (puntas de raiz, uniones del micelio, esporas) unidos por hifas turquesa que fluyen. Los **PUENTES** entre matas distintas van mas gruesos y brillantes — ahi se lee el reparto de alimento entre plantas.
- **Lombricita protagonista**: la `Lombriz` de la casa (reusada, no un puntico), grande y viva, acostada en su **galeria excavada**; mas lombricitas menudas aparecen cuando la tierra despierta.
- **Raices profundas con NODULOS** de fijacion en la leguminosa (el frijol y su Rhizobium que abona la tierra).
- **Agua que se infiltra** por canales ondulados (percolacion) y **minerales** (fosforo ambar / nitrogeno azul / potasio malva) que **suben** a la mata cerca de las puntas de raiz (uptake).

La densidad de la red, el agua y los minerales **escala con la vida del suelo**: tierra viva = malla densa que respira; tierra cansada = red muda y rota (0 pulsos). Todo grounded en la biologia real.

## Alcance
Solo toca `MundoSubsuelo` + geometria nueva. No toca valle/bosque/paramo/suelo3d/compost/fermentos.

## Verificacion
- Tests de `MundoSubsuelo` + temas-fase2 verdes (16/16).
- `build:prod` verde.
- ESLint limpio.
- Playwright (`scripts/diag/verify-subsuelo.mjs`, animacion real, 11s, 3 tomas, sin negro): base=48 (en cuidado), vivo=88 (vivo, red densa + pulsos), cansado=20 (cansado, red rota + 0 pulsos). Respeta `prefers-reduced-motion`.