### PR TITLE
art(bosque): rostro creíble del Ent-bárbol + frondosidad

### DIFF
--- a/src/visual/mundo3d/bosque/EntQuenua.jsx
+++ b/src/visual/mundo3d/bosque/EntQuenua.jsx
@@ -101,58 +101,64 @@ function MasaFollaje({ cluster, matMasa, hojaGeo, matHoja, detalle, reducedMotio
 }
 
 /* UN OJO del árbol-guardián viejo: HUNDIDO en su cuenca, en sombra bajo la cornisa
-   de la ceja. No es una canica que sobresale: es un iris ÁMBAR-MIEL que asoma
-   desde la oscuridad del pozo, con una sola chispa húmeda de vida. Almendrado
-   (aplanado en z) y encapotado por un párpado grueso de corteza arriba y un
-   reborde abajo → mirada honda, sabia, viva. El blink baja el párpado superior;
-   la mirada deriva en gazeRef. `flip` (-1/1) da una leve asimetría de madera. */
-function Ojo({ x, frente, blinkRef, gazeRef, flip, matGrieta, matOjo, matIris, matBrillo, matCresta }) {
+   de la ceja. La lección del rechazo anterior: el ojo NO puede ser un disco
+   naranja con reborde (goggles de caricatura). Aquí el globo es madera húmeda
+   oscura, el IRIS ámbar-miel es CHICO (asoma desde la sombra, no llena el ojo),
+   la pupila es amplia y ambos párpados son de CORTEZA — el mismo palo que el
+   rostro, entrecerrados con el peso sereno de la edad. Una sola chispa húmeda da
+   la vida. El blink baja el párpado; la mirada deriva en gazeRef. `flip` (-1/1)
+   da la leve asimetría de la madera viva. */
+function Ojo({ x, frente, blinkRef, gazeRef, flip, matGrieta, matOjo, matIris, matBrillo, matParpado }) {
   return (
-    <group position={[x, -0.035, frente - 0.32]} scale={[1.04, 0.98, 0.62]}>
+    <group position={[x, -0.035, frente - 0.34]} scale={[0.94, 0.86, 0.6]}>
       {/* el POZO de la cuenca: oscuridad honda en la que se asienta el ojo. Amplio
           y profundo → el ojo vive DENTRO, no encima de la cara */}
-      <mesh position={[0, -0.01, -0.02]} scale={[1.15, 1.24, 1.3]}>
+      <mesh position={[0, -0.005, -0.03]} scale={[1.26, 1.2, 1.24]}>
         <sphereGeometry args={[0.115, 14, 12]} />
         <primitive object={matGrieta} attach="material" />
       </mesh>
-      {/* el GLOBO: apenas un reborde húmedo oscuro alrededor del iris (mate, sin
-          brillo de canica). Nace hundido: solo la cara frontal del ojo asoma. */}
+      {/* el GLOBO: madera húmeda oscura, mate (sin brillo de canica). Nace
+          hundido: solo la cara frontal del ojo asoma desde el pozo.
+          GEOMETRÍA DEL APILADO (no romperla): el frente del iris DEBE quedar
+          por delante del frente del globo Y del frente del pozo — si no, el
+          ámbar queda literalmente DENTRO de las esferas oscuras y el ojo se ve
+          como cuenca vacía de calavera (pasó: v1 de esta talla). Frentes hoy:
+          pozo ≈ 0.113, globo ≈ 0.130, iris ≈ 0.145, pupila ≈ 0.153. */}
       <group ref={blinkRef}>
-        <mesh position={[0, 0, 0.055]}>
-          <sphereGeometry args={[0.096, 16, 14]} />
+        <mesh position={[0, 0, 0.04]}>
+          <sphereGeometry args={[0.09, 16, 14]} />
           <primitive object={matOjo} attach="material" />
         </mesh>
-        {/* LA MIRADA: iris ÁMBAR-MIEL grande que llena el ojo y BRILLA cálido desde
-            la sombra de la cuenca (linterna de ámbar del guardián) — nunca un pozo
-            negro. Sale hacia la luz. Pupila + una chispa de húmedo. */}
-        <group ref={gazeRef} position={[0, 0.004, 0.092]}>
-          <mesh scale={[1, 1, 0.86]}>
-            <sphereGeometry args={[0.097, 18, 16]} />
+        {/* LA MIRADA: un iris ámbar-miel DISCRETO que asoma desde la sombra —
+            rescoldo de fogón, no farol. Pupila amplia + una chispa de húmedo. */}
+        <group ref={gazeRef} position={[0, 0.004, 0.105]}>
+          <mesh scale={[1, 1, 0.65]}>
+            <sphereGeometry args={[0.062, 16, 14]} />
             <primitive object={matIris} attach="material" />
           </mesh>
-          {/* pupila: pozo hondo en el centro del iris */}
-          <mesh position={[0, 0, 0.04]}>
-            <sphereGeometry args={[0.04, 12, 10]} />
+          {/* pupila: pozo hondo y AMPLIO en el centro del iris (mirada mansa) */}
+          <mesh position={[0, 0, 0.026]} scale={[1, 1, 0.7]}>
+            <sphereGeometry args={[0.031, 12, 10]} />
             <primitive object={matGrieta} attach="material" />
           </mesh>
-          {/* chispa de húmedo (catchlight): pequeña, arriba a un lado — la vida */}
-          <mesh position={[flip * 0.03, 0.036, 0.066]}>
-            <sphereGeometry args={[0.011, 10, 10]} />
+          {/* chispa de húmedo (catchlight): mínima, arriba a un lado — la vida */}
+          <mesh position={[flip * 0.021, 0.025, 0.044]}>
+            <sphereGeometry args={[0.008, 8, 8]} />
             <primitive object={matBrillo} attach="material" />
           </mesh>
         </group>
       </group>
-      {/* PÁRPADO SUPERIOR grueso de corteza: encapota el ojo desde arriba (el peso
-          del alero de la ceja) → la parte alta del iris queda en sombra, mirada
-          honda, pero el ámbar asoma. Es la gravedad sabia del guardián. */}
-      <mesh position={[0, 0.088, 0.052]} rotation={[0.62, 0, flip * 0.1]} scale={[1.16, 0.42, 0.62]}>
-        <sphereGeometry args={[0.11, 14, 10]} />
-        <primitive object={matOjo} attach="material" />
+      {/* PÁRPADO SUPERIOR de CORTEZA: pesado, entrecerrado — cubre el tercio alto
+          del ojo (la gravedad sabia del guardián). Del MISMO tono de madera que
+          el rostro: un pliegue del árbol, no una pieza pegada. */}
+      <mesh position={[0, 0.082, 0.032]} rotation={[0.7, 0, flip * 0.08]} scale={[1.24, 0.52, 0.7]}>
+        <sphereGeometry args={[0.104, 14, 10]} />
+        <primitive object={matParpado} attach="material" />
       </mesh>
-      {/* párpado inferior: reborde cálido y fino que asienta el ojo (edad, bondad) */}
-      <mesh position={[0, -0.088, 0.05]} rotation={[-0.32, 0, -flip * 0.14]} scale={[1.05, 0.4, 0.55]}>
-        <sphereGeometry args={[0.1, 12, 8]} />
-        <primitive object={matCresta} attach="material" />
+      {/* párpado inferior: reborde discreto de la misma corteza (edad, bondad) */}
+      <mesh position={[0, -0.08, 0.028]} rotation={[-0.35, 0, -flip * 0.1]} scale={[1.08, 0.4, 0.6]}>
+        <sphereGeometry args={[0.095, 12, 8]} />
+        <primitive object={matParpado} attach="material" />
       </mesh>
     </group>
   );
@@ -166,7 +172,7 @@ function Ojo({ x, frente, blinkRef, gazeRef, flip, matGrieta, matOjo, matIris, m
    por la cornisa. La mandíbula es la parte baja de la misma cáscara y pivota
    apenas al murmurar. Gestos mínimos y con peso: un ser ancestral, no caricatura;
    con reducedMotion queda quieto y sereno. */
-function Rostro({ P, matCorteza, matOjo, matBrillo, matIris, matGrieta, matCresta, reducedMotion, blinkRefs }) {
+function Rostro({ P, matCorteza, matOjo, matBrillo, matIris, matGrieta, matParpado, reducedMotion, blinkRefs }) {
   const { centro, radio } = useMemo(() => anclaRostro(7), []);
   // Superficie frontal del tronco a la altura de la mirada (mira al +Z).
   const frente = radio * 0.9;
@@ -186,20 +192,25 @@ function Rostro({ P, matCorteza, matOjo, matBrillo, matIris, matGrieta, matCrest
     // MIRADA: deriva lenta (recorre, se detiene, vuelve). Ambos ojos juntos.
     const gx = Math.sin(t * 0.24) * 0.03 + Math.sin(t * 0.09 + 1.1) * 0.015;
     const gy = Math.sin(t * 0.17 + 0.6) * 0.018;
-    if (gazeIzq.current) gazeIzq.current.position.set(gx, gy - 0.004, 0.072);
-    if (gazeDer.current) gazeDer.current.position.set(gx, gy - 0.004, 0.072);
+    // OJO con la z: 0.105 es la MISMA z base del grupo de la mirada en <Ojo>.
+    // Antes este frame escribía 0.072 (< frente del globo) y con la animación
+    // encendida el iris se HUNDÍA dentro de la esfera oscura: ojos de calavera
+    // solo en vivo, nunca en la captura con reducedMotion. Bug silencioso.
+    if (gazeIzq.current) gazeIzq.current.position.set(gx, gy - 0.004, 0.105);
+    if (gazeDer.current) gazeDer.current.position.set(gx, gy - 0.004, 0.105);
     // HABLA: la mandíbula de madera pivota despacio — murmullo de árbol viejo,
     // nunca un chasquido. La grieta se abre y asoma la cavidad oscura.
     const abre = factorHabla(t);
     if (mandibulaRef.current) mandibulaRef.current.rotation.x = 0.015 + abre * 0.11;
   });
 
-  const ojoMats = { matGrieta, matOjo, matIris, matBrillo, matCresta };
+  const ojoMats = { matGrieta, matOjo, matIris, matBrillo, matParpado };
 
   return (
     <group position={[centro.x, centro.y, centro.z]} scale={ROSTRO_ESCALA}>
-      {/* la cavidad oscura tras la boca-grieta: al abrirse se ve hondura, no tronco */}
-      <mesh position={[0, ROSTRO_BOCA_Y - 0.02, frente - 0.16]} scale={[0.34, 0.12, 0.14]}>
+      {/* la cavidad oscura tras la boca-grieta: al abrirse se ve hondura, no tronco.
+          Discreta — si se agranda vuelve la franja negra de teatro bajo la nariz */}
+      <mesh position={[0, ROSTRO_BOCA_Y - 0.02, frente - 0.16]} scale={[0.29, 0.1, 0.13]}>
         <sphereGeometry args={[1, 14, 12]} />
         <primitive object={matGrieta} attach="material" />
       </mesh>
@@ -231,10 +242,14 @@ function Barba({ ancla, matHebra, matTuft, densidad = 1, reducedMotion }) {
     () => hebras.slice(0, Math.max(10, Math.round(hebras.length * densidad))),
     [hebras, densidad],
   );
-  const tf = useMemo(
-    () => tufts.slice(0, Math.max(5, Math.round(tufts.length * densidad))),
-    [tufts, densidad],
-  );
+  // El musgo de las cejas NO se recorta por tier (va al final de la lista y un
+  // slice ciego lo borraría entero): las cejas de musgo son un rasgo del rostro,
+  // no relleno. Solo el liquen de la barba se adelgaza en gama baja.
+  const tf = useMemo(() => {
+    const liquen = tufts.filter((t) => !t.musgo);
+    const musgo = tufts.filter((t) => t.musgo);
+    return [...liquen.slice(0, Math.max(5, Math.round(liquen.length * densidad))), ...musgo];
+  }, [tufts, densidad]);
   const hebraGeo = useMemo(() => geometriaHebraBarba(), []);
   const tuftGeo = useMemo(() => new THREE.IcosahedronGeometry(1, 1), []);
   useLayoutEffect(() => () => { hebraGeo.dispose(); tuftGeo.dispose(); }, [hebraGeo, tuftGeo]);
@@ -283,7 +298,7 @@ function Barba({ ancla, matHebra, matTuft, densidad = 1, reducedMotion }) {
         s.set(l.esc * 1.6, l.esc * 0.7, l.esc * 1.1);
         m.compose(p, q, s);
         tmesh.setMatrixAt(i, m);
-        col.copy(l.azul ? BARBA.liquenAzul : BARBA.liquen);
+        col.copy(l.musgo ? BARBA.musgoCeja : (l.azul ? BARBA.liquenAzul : BARBA.liquen));
         tmesh.setColorAt(i, col);
       }
       tmesh.instanceMatrix.needsUpdate = true;
@@ -336,24 +351,25 @@ function Brazos({ P, matCorteza, matCortezaLisa, reducedMotion }) {
       {brazos.map((b, i) => (
         <group key={`brazo-${i}`}>
           <mesh geometry={geos[i]} material={matCorteza} castShadow receiveShadow />
-          {/* la MANO: nudo de muñeca + dedos-ramita que cuelgan hacia la tierra */}
+          {/* la MANO: nudo de muñeca + dedos-ramita RECOGIDOS hacia la tierra.
+              Cortos y juntos: una mano de madera en reposo. (Los dedos largos y
+              abiertos de antes leían como garra de espanto junto al rostro.) */}
           <group position={[b.muneca.x, b.muneca.y, b.muneca.z]}>
-            <mesh scale={[1.15, 0.9, 1.05]}>
-              <sphereGeometry args={[0.13, 10, 8]} />
+            <mesh scale={[1.1, 0.92, 1.0]}>
+              <sphereGeometry args={[0.12, 10, 8]} />
               <primitive object={matCortezaLisa} attach="material" />
             </mesh>
             {[
-              [-0.08, -0.17, 0.03, 0.3],
-              [0.0, -0.2, 0.08, 0.38],
-              [0.08, -0.16, 0.01, 0.28],
-              [b.s * 0.11, -0.1, -0.07, 0.22],
+              [-0.06, -0.14, 0.02, 0.2],
+              [0.0, -0.16, 0.05, 0.24],
+              [0.06, -0.13, 0.0, 0.19],
             ].map(([dx, dy, dz, len], j) => (
               <mesh
                 key={`dedo-${j}`}
                 position={[dx, dy, dz]}
-                rotation={[Math.PI - 0.22 + j * 0.09, 0, dx * 2.1]}
+                rotation={[Math.PI - 0.12 + j * 0.06, 0, dx * 1.2]}
               >
-                <coneGeometry args={[0.034, len, 5]} />
+                <coneGeometry args={[0.032, len, 5]} />
                 <primitive object={matCortezaLisa} attach="material" />
               </mesh>
             ))}
@@ -489,10 +505,12 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
       : new THREE.MeshLambertMaterial(base);
   }, [P.materialRico, P.flatShading]);
 
+  // Un punto más OSCURA que la corteza del fuste: manos y dedos no deben pegar
+  // en salmón contra el tronco (leían como garras rosadas).
   const matCortezaLisa = useMemo(
     () => (P.materialRico
-      ? new THREE.MeshStandardMaterial({ color: CORTEZA.cuerpo, roughness: 0.9 })
-      : new THREE.MeshLambertMaterial({ color: CORTEZA.cuerpo })),
+      ? new THREE.MeshStandardMaterial({ color: '#71402d', roughness: 0.9 })
+      : new THREE.MeshLambertMaterial({ color: '#71402d' })),
     [P.materialRico],
   );
   const matGrieta = useMemo(
@@ -501,12 +519,13 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
       : new THREE.MeshLambertMaterial({ color: '#20130d' })),
     [P.materialRico],
   );
-  // matCresta ilumina los cantos con el tono de la corteza PELADA de la queñua
-  // (lo usa el párpado del ojo; el tallado del rostro va horneado en la cáscara).
-  const matCresta = useMemo(
+  // matParpado: los párpados de CORTEZA oscura (madera del rostro, un pelo más
+  // honda que el cuerpo) — el ojo queda enmarcado por el mismo palo, nunca por
+  // rebordes claros que lo recorten como goggles.
+  const matParpado = useMemo(
     () => (P.materialRico
-      ? new THREE.MeshStandardMaterial({ color: CORTEZA.papel, roughness: 0.85 })
-      : new THREE.MeshLambertMaterial({ color: CORTEZA.papel })),
+      ? new THREE.MeshStandardMaterial({ color: '#5d3424', roughness: 0.92 })
+      : new THREE.MeshLambertMaterial({ color: '#5d3424' })),
     [P.materialRico],
   );
   const matOjo = useMemo(
@@ -515,22 +534,25 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
       : new THREE.MeshLambertMaterial({ color: '#1a120d' })),
     [P.materialRico],
   );
-  const matBrillo = useMemo(() => new THREE.MeshBasicMaterial({ color: '#eef4e8' }), []);
-  // Iris cálido y VIVO: el glow ámbar que hace que el rostro MIRE (antes el ojo
-  // era una bola oscura con una chispa; con iris + pupila la mirada se lee y se
-  // le puede seguir el gesto). Rico = emisivo real; frugal = básico constante.
+  const matBrillo = useMemo(() => new THREE.MeshBasicMaterial({ color: '#e6ecdd' }), []);
+  // Iris ámbar-miel DISCRETO: rescoldo cálido que asoma desde la sombra de la
+  // cuenca — se le sigue la mirada sin que sea un farol naranja (ese farol era
+  // caricatura). En frugal va Lambert CON emisivo (nunca Basic plano: el disco
+  // naranja sin sombreado era el peor de los goggles).
   const matIris = useMemo(
     () => (P.materialRico
-      ? new THREE.MeshStandardMaterial({ color: '#c08a3e', emissive: '#7a4718', emissiveIntensity: 0.62, roughness: 0.4, metalness: 0.05 })
-      : new THREE.MeshBasicMaterial({ color: '#bd8846' })),
+      ? new THREE.MeshStandardMaterial({ color: '#b08137', emissive: '#6b4514', emissiveIntensity: 0.5, roughness: 0.55, metalness: 0.05 })
+      : new THREE.MeshLambertMaterial({ color: '#b08137', emissive: '#6b4514', emissiveIntensity: 0.55 })),
     [P.materialRico],
   );
   // La MASA de follaje: facetada (flatShading) con su color por cara horneado —
   // el cúmulo de hojas con huecos que se lee como copa de juego de consola.
+  // El facetado va TAMBIÉN en frugal: sin él la copa era una bola de plastilina
+  // lisa (Lambert soporta flatShading y no cuesta nada).
   const matMasa = useMemo(
     () => (P.materialRico
       ? new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.85, metalness: 0.0, flatShading: true })
-      : new THREE.MeshLambertMaterial({ vertexColors: true })),
+      : new THREE.MeshLambertMaterial({ vertexColors: true, flatShading: true })),
     [P.materialRico],
   );
   // El FLECO: hojitas-plano sueltas sobre la masa (rompen la silueta). Lambert
@@ -554,9 +576,9 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
     ramasGeo.forEach((g) => g.dispose());
     raicesGeo.forEach((g) => g.dispose());
     hojaGeo.dispose();
-    [matCorteza, matCortezaLisa, matGrieta, matCresta, matOjo, matBrillo, matIris, matMasa, matHoja,
+    [matCorteza, matCortezaLisa, matGrieta, matParpado, matOjo, matBrillo, matIris, matMasa, matHoja,
       matHebra, matTuft].forEach((m) => m.dispose());
-  }, [troncoGeo, ramasGeo, raicesGeo, hojaGeo, matCorteza, matCortezaLisa, matGrieta, matCresta, matOjo, matBrillo, matIris, matMasa, matHoja,
+  }, [troncoGeo, ramasGeo, raicesGeo, hojaGeo, matCorteza, matCortezaLisa, matGrieta, matParpado, matOjo, matBrillo, matIris, matMasa, matHoja,
     matHebra, matTuft]);
 
   // --- Vida: balanceo pesado + parpadeo lento ---
@@ -593,7 +615,7 @@ export default function EntQuenua({ tier = 'alto', reducedMotion = false, señal
           matIris={matIris}
           matCorteza={matCorteza}
           matGrieta={matGrieta}
-          matCresta={matCresta}
+          matParpado={matParpado}
           reducedMotion={reducedMotion}
           blinkRefs={{ izq: ojoIzq, der: ojoDer }}
         />

--- a/src/visual/mundo3d/bosque/entQuenua.geom.js
+++ b/src/visual/mundo3d/bosque/entQuenua.geom.js
@@ -30,19 +30,19 @@ export function rng(seed) {
  */
 export const PARAMS_TIER = {
   alto: {
-    tubular: 124, radial: 16, hojas: 680, clusters: 9, ramas: 5, raices: 6,
+    tubular: 124, radial: 16, hojas: 960, clusters: 11, ramas: 5, raices: 6,
     frailejones: 5, materialRico: true, flatShading: true, fog: true,
     barbaDens: 1, segRostro: [56, 62], detalleMasa: 2,
   },
   medio: {
-    tubular: 76, radial: 10, hojas: 340, clusters: 7, ramas: 5, raices: 5,
+    tubular: 76, radial: 10, hojas: 520, clusters: 9, ramas: 5, raices: 5,
     frailejones: 4, materialRico: false, flatShading: false, fog: true,
-    barbaDens: 0.62, segRostro: [40, 44], detalleMasa: 2,
+    barbaDens: 0.72, segRostro: [40, 44], detalleMasa: 2,
   },
   bajo: {
-    tubular: 44, radial: 8, hojas: 120, clusters: 4, ramas: 3, raices: 4,
+    tubular: 44, radial: 8, hojas: 170, clusters: 5, ramas: 3, raices: 4,
     frailejones: 0, materialRico: false, flatShading: false, fog: false,
-    barbaDens: 0.34, segRostro: [26, 30], detalleMasa: 1,
+    barbaDens: 0.4, segRostro: [26, 30], detalleMasa: 1,
   },
 };
 
@@ -283,20 +283,22 @@ export function clustersCopa(puntasRama, { clusters, hojas }, seed = 51) {
   const r = rng(seed);
   const curva = curvaTronco(7);
   const centros = [];
-  // La corona: encima de la punta del tronco.
-  centros.push({ center: curva.getPointAt(1).clone().add(new THREE.Vector3(0.1, 0.5, 0)), radio: 1.25 });
+  // La corona: encima de la punta del tronco, GENEROSA (la frondosidad manda:
+  // el guardián se lee primero por su copa, después por su rostro).
+  centros.push({ center: curva.getPointAt(1).clone().add(new THREE.Vector3(0.1, 0.55, 0)), radio: 1.5 });
   // Una copa por punta de rama (hasta llenar `clusters`).
   for (const p of puntasRama) {
     if (centros.length >= clusters) break;
-    centros.push({ center: p.clone().add(new THREE.Vector3(0, 0.2, 0)), radio: 0.82 + r() * 0.3 });
+    centros.push({ center: p.clone().add(new THREE.Vector3(0, 0.24, 0)), radio: 0.95 + r() * 0.35 });
   }
-  // Si faltan clusters (pocas ramas), rellena alrededor de la corona.
+  // Si faltan clusters (pocas ramas), rellena alrededor de la corona: cierran los
+  // huecos de cielo entre ramas y la copa se vuelve UN dosel, no bolas sueltas.
   while (centros.length < clusters) {
     const a = r() * Math.PI * 2;
-    const rad = 0.7 + r() * 0.6;
+    const rad = 0.75 + r() * 0.7;
     centros.push({
-      center: curva.getPointAt(0.9).clone().add(new THREE.Vector3(Math.cos(a) * rad, 0.3 + r() * 0.5, Math.sin(a) * rad)),
-      radio: 0.55 + r() * 0.25,
+      center: curva.getPointAt(0.88).clone().add(new THREE.Vector3(Math.cos(a) * rad, 0.35 + r() * 0.7, Math.sin(a) * rad)),
+      radio: 0.68 + r() * 0.3,
     });
   }
   const porCluster = Math.max(8, Math.floor(hojas / centros.length));
@@ -391,46 +393,64 @@ export function campoRostro(x, y) {
   // PANEL FACIAL: la cara vive sobre un plano frontal REHUNDIDO en el tronco (así
   // Bárbol: la madera se aplana y retrocede, y los rasgos se tallan sobre ese
   // panel). Sin esto la suma de rasgos abomba toda la cara como una cúpula pegada.
-  const panel = g2(x, y, 0, -0.06, 0.46, 0.6);
-  d -= 0.13 * panel;
-  // FRENTE: apenas se recupera del panel (superficie sobre la que cuelga la cornisa)
-  d += 0.05 * g2(x, y, 0, 0.36, 0.5, 0.26);
-  // CEJAS-CORNISA: los aleros pesados de corteza que SOBRESALEN y encapuchan los
-  // ojos. Fuertes hacia afuera, con leve asimetría (madera viva).
-  d += 0.2 * g2(x, y, -0.235, 0.13, 0.21, 0.07);
-  d += 0.2 * g2(x, y, 0.245, 0.145, 0.22, 0.075);
-  // el HUECO de sombra justo bajo la cornisa (el párpado hundido) — carga el
-  // encapuchado que hace la mirada sabia
-  d -= 0.14 * (g2(x, y, -0.235, 0.03, 0.17, 0.06) + g2(x, y, 0.245, 0.04, 0.18, 0.065));
-  // entrecejo: el surco vertical del pensamiento, hondo entre las cejas
-  d -= 0.11 * g2(x, y, 0, 0.15, 0.05, 0.14);
-  // CUENCAS: pozos HONDOS donde se hunden los ojos ámbar (sombra que los encapucha)
-  const cuencas = g2(x, y, -0.235, -0.03, 0.15, 0.12) + g2(x, y, 0.245, -0.02, 0.155, 0.125);
-  d -= 0.44 * cuencas;
-  // NARIZ: lomo ANCHO de madera que baja del entrecejo, se ensancha y termina en
-  // nudo — sobresale de verdad (el rasgo más prominente de la cara).
-  const caida = Math.min(1, Math.max(0, (0.14 - y) / 0.3)); // 0 arriba → 1 punta
-  d += (0.12 + 0.16 * caida) * g2(x, 0, 0, 0, 0.09 + 0.05 * caida, 1) * g2(0, y, 0, -0.04, 1, 0.22);
-  d += 0.17 * g2(x, y, 0, -0.17, 0.12, 0.08); // el nudo de la punta
-  const fosas = g2(x, y, -0.07, -0.235, 0.045, 0.035) + g2(x, y, 0.07, -0.235, 0.045, 0.035);
-  d -= 0.12 * fosas;
-  // PÓMULOS anchos que pegan la luz + surcos nasolabiales hondos (la vejez del árbol)
-  d += 0.09 * (g2(x, y, -0.42, -0.16, 0.19, 0.16) + g2(x, y, 0.42, -0.15, 0.19, 0.16));
-  d -= 0.08 * (g2(x, y, -0.2, -0.32, 0.055, 0.13) + g2(x, y, 0.2, -0.32, 0.055, 0.13));
-  // bolsas bajo los ojos (peso de los años)
-  d += 0.05 * (g2(x, y, -0.235, -0.16, 0.13, 0.05) + g2(x, y, 0.245, -0.15, 0.13, 0.05));
+  const panel = g2(x, y, 0, -0.06, 0.5, 0.62);
+  d -= 0.11 * panel;
+  // FRENTE: bóveda amplia y serena que se recupera del panel — la superficie
+  // sobre la que corren los pliegues y de la que cuelga el alero de las cejas.
+  d += 0.07 * g2(x, y, 0, 0.42, 0.52, 0.3);
+  // ARCO SUPERCILIAR: UN alero continuo de madera, ancho y BAJO, con un arco por
+  // ojo y el puente unido sobre el entrecejo. (Las dos cejas-salchicha sueltas de
+  // antes eran la mitad de la caricatura: mucho bulto, poca anchura.) Leve
+  // asimetría de madera viva: la derecha apenas más alzada.
+  const cejaI = g2(x, y, -0.24, 0.135, 0.3, 0.062);
+  const cejaD = g2(x, y, 0.25, 0.152, 0.31, 0.066);
+  d += 0.115 * cejaI + 0.125 * cejaD;
+  d += 0.06 * g2(x, y, 0, 0.16, 0.13, 0.052); // el puente del ceño
+  // la sombra justo bajo el alero (el párpado hundido que encapucha la mirada)
+  d -= 0.1 * (g2(x, y, -0.24, 0.042, 0.19, 0.055) + g2(x, y, 0.25, 0.052, 0.2, 0.058));
+  // entrecejo: el surco vertical del pensamiento (discreto — el ceño de un sabio,
+  // no el de un ogro)
+  d -= 0.07 * g2(x, y, 0, 0.21, 0.045, 0.11);
+  // CUENCAS: pozos hondos donde viven los ojos, EN SOMBRA bajo la cornisa
+  const cuencas = g2(x, y, -0.24, -0.03, 0.145, 0.115) + g2(x, y, 0.25, -0.02, 0.15, 0.12);
+  d -= 0.4 * cuencas;
+  // NARIZ: un caballete ANGOSTO de madera que baja del entrecejo y apenas se
+  // ensancha; la punta es un nudo discreto. (El bulbo-payaso de antes, fuera.)
+  const caida = Math.min(1, Math.max(0, (0.16 - y) / 0.34)); // 0 arriba → 1 punta
+  d += (0.1 + 0.1 * caida) * g2(x, 0, 0, 0, 0.075 + 0.035 * caida, 1) * g2(0, y, 0, -0.03, 1, 0.24);
+  d += 0.09 * g2(x, y, 0, -0.185, 0.1, 0.075); // el nudo de la punta
+  const fosas = g2(x, y, -0.065, -0.24, 0.04, 0.03) + g2(x, y, 0.065, -0.24, 0.04, 0.03);
+  d -= 0.09 * fosas;
+  // PÓMULOS anchos que pegan la luz + surcos nasolabiales (la vejez del árbol)
+  d += 0.07 * (g2(x, y, -0.43, -0.17, 0.2, 0.17) + g2(x, y, 0.43, -0.16, 0.2, 0.17));
+  d -= 0.06 * (g2(x, y, -0.2, -0.33, 0.05, 0.12) + g2(x, y, 0.2, -0.33, 0.05, 0.12));
+  // bolsas bajo los ojos (peso de los años, muy leves)
+  d += 0.04 * (g2(x, y, -0.24, -0.155, 0.12, 0.05) + g2(x, y, 0.25, -0.15, 0.12, 0.05));
   // BOCA: labios de corteza alrededor de la grieta (la grieta es un pozo hondo)
-  d += 0.08 * g2(x, y, 0, -0.375, 0.28, 0.055); // labio superior
-  d += 0.1 * g2(x, y, 0, -0.53, 0.25, 0.065); // labio inferior
-  const grieta = g2(x, y, 0, ROSTRO_BOCA_Y, 0.32, 0.05);
-  d -= 0.36 * grieta;
+  d += 0.06 * g2(x, y, 0, -0.375, 0.26, 0.05); // labio superior
+  d += 0.08 * g2(x, y, 0, -0.53, 0.24, 0.06); // labio inferior
+  const grieta = g2(x, y, 0, ROSTRO_BOCA_Y, 0.3, 0.046);
+  d -= 0.32 * grieta;
   // MENTÓN macizo (el peso del árbol viejo; la barba lo enmarca)
-  d += 0.12 * g2(x, y, 0, -0.68, 0.22, 0.14);
-  // ARRUGAS de madera: grano fino que cruza el rostro (leve — sigue siendo corteza)
-  d += 0.02 * Math.sin(x * 30 + y * 6) + 0.017 * Math.sin(y * 24 + x * 4);
-  d -= 0.03 * Math.sin(y * 30) * g2(x, y, 0, 0.4, 0.44, 0.22); // pliegues de la frente
-  const sombra = Math.min(1, cuencas * 1.0 + grieta * 1.15 + fosas * 0.8 + panel * 0.12);
-  return { d, sombra };
+  d += 0.1 * g2(x, y, 0, -0.68, 0.22, 0.14);
+  // VETAS: el grano vertical de la corteza SIGUE DE LARGO por la frente, las
+  // sienes y las mejillas (crestas anchas tanh, las mismas del fuste) y solo se
+  // calma sobre ojos, fosas y boca. Es lo que hace que el rostro sea EL MISMO
+  // palo y no una careta lijada puesta encima.
+  const rasgos = Math.min(1, cuencas * 1.4 + grieta * 1.4 + fosas);
+  const veta = 0.032 * Math.tanh(Math.sin(x * 13 + Math.sin(y * 3.1) * 1.5 + 0.7) * 2.1);
+  d += veta * (1 - rasgos);
+  // pliegues horizontales de la frente (edad serena, no ceño bravo)
+  d -= 0.022 * Math.sin(y * 24 + 0.8) * g2(x, y, 0, 0.45, 0.42, 0.2);
+  // grano fino de madera (leve — la aspereza de cerca)
+  d += 0.013 * Math.sin(x * 31 + y * 7) + 0.011 * Math.sin(y * 23 + x * 5);
+  // MUSGO: dónde se posa el verde de páramo — sobre el lomo de las cejas y en el
+  // filo alto de los pómulos (donde la humedad se queda). Va al COLOR, no al
+  // relieve: pátina viva sobre la madera.
+  const musgo = 0.55 * (g2(x, y, -0.26, 0.2, 0.24, 0.05) + g2(x, y, 0.27, 0.22, 0.25, 0.05))
+    + 0.3 * (g2(x, y, -0.46, -0.1, 0.14, 0.12) + g2(x, y, 0.46, -0.09, 0.14, 0.12));
+  const sombra = Math.min(1, cuencas * 1.1 + grieta * 1.2 + fosas * 0.8 + panel * 0.1);
+  return { d, sombra, musgo };
 }
 
 /*
@@ -475,7 +495,7 @@ export function mallaRostro({ segRostro = [48, 54] } = {}, seed = 7) {
         const uN = iu / segU;
         const ang = (uN * 2 - 1) * angMax;
         const xl = (Math.sin(ang) * R) / ROSTRO_ESCALA[0]; // lateral local sobre la superficie
-        const { d, sombra } = campoRostro(xl, y);
+        const { d, sombra, musgo } = campoRostro(xl, y);
         // máscara del óvalo: adentro manda la talla; afuera, la corteza normal
         const m = Math.exp(-((xl / 0.56) ** 2 + ((y + 0.08) / 0.66) ** 2));
         const bark = desplazamientoCorteza(t, ang + 0.6) * (0.35 + 0.65 * (1 - m));
@@ -491,10 +511,13 @@ export function mallaRostro({ segRostro = [48, 54] } = {}, seed = 7) {
         pos[k] = (Math.sin(ang) * R * f) / ROSTRO_ESCALA[0] + offX;
         pos[k + 1] = y - pivotY;
         pos[k + 2] = (Math.cos(ang) * R * f) / ROSTRO_ESCALA[2] + offZ;
-        // color: corteza + pátina clara de madera vieja + cresta pelada + sombra
+        // color: corteza + pátina clara de madera vieja + cresta pelada DISCRETA
+        // (el resalte fuerte de antes recortaba cada rasgo como sticker) + el
+        // musgo del páramo posado en cejas y pómulos + la sombra tallada
         c.copy(colorCorteza(bark + d * 0.9, t));
-        if (m > 0.2) c.lerp(CORTEZA.papel, m * 0.14);
-        if (d > 0.1) c.lerp(CORTEZA.papel, Math.min(0.45, (d - 0.1) * 1.9));
+        if (m > 0.2) c.lerp(CORTEZA.papel, m * 0.12);
+        if (d > 0.12) c.lerp(CORTEZA.papel, Math.min(0.28, (d - 0.12) * 1.4));
+        if (musgo > 0.03) c.lerp(CORTEZA.liquen, Math.min(0.55, musgo) * m);
         c.multiplyScalar(1 - 0.6 * sombra * (1 - borde));
         col[k] = c.r;
         col[k + 1] = c.g;
@@ -679,11 +702,14 @@ export function factorSonrisa(t) {
       arma como una CORTINA DENSA de mechones finos, en capas para dar volumen,
       con gradiente raíz-en-sombra → punta-plateada. Referente: Bárbol/WETA. ── */
 export const BARBA = {
-  usnea: new THREE.Color('#aebb96'), // cuerpo del líquen: verde-gris PÁLIDO (sage)
-  usneaGris: new THREE.Color('#c3cab4'), // mechón más plateado (variedad)
+  // Tonos un punto MÁS HONDOS que la usnea real: sobre la boca-grieta oscura la
+  // versión pálida leía como tiras de papel blanco rasgado, no como líquen.
+  usnea: new THREE.Color('#93a17b'), // cuerpo del líquen: verde-gris sage
+  usneaGris: new THREE.Color('#adb598'), // mechón más plateado (variedad)
   raicilla: new THREE.Color('#725036'), // pocas hebras leñosas marrones (contraste)
   liquen: new THREE.Color('#8f9c7a'), // mata de liquen foliáceo (sage apagado, NO blanco)
   liquenAzul: new THREE.Color('#828f7e'), // liquen gris-verdoso (variedad)
+  musgoCeja: new THREE.Color('#5e7244'), // musgo VIVO de las cejas (verde páramo hondo)
 };
 
 /*
@@ -749,9 +775,9 @@ export function specsBarba(seed = 91) {
   // solape entre capas es lo que hace que se lea como BARBA con cuerpo. Densa y
   // con el CENTRO lleno (el mentón de Bárbol), no cuatro hebras a los lados.
   const capas = [
-    { z: -0.03, lenMul: 0.72, n: 34 },
-    { z: 0.05, lenMul: 0.86, n: 40 },
-    { z: 0.12, lenMul: 0.98, n: 34 },
+    { z: -0.04, lenMul: 0.64, n: 46 },
+    { z: 0.04, lenMul: 0.8, n: 54 },
+    { z: 0.115, lenMul: 0.94, n: 46 },
   ];
   for (const capa of capas) {
     for (let i = 0; i < capa.n; i++) {
@@ -763,11 +789,11 @@ export function specsBarba(seed = 91) {
       const centro = Math.max(0, 1 - Math.abs(f - 0.5) * 1.7); // 1 en el mentón
       // arranca BAJO la boca (deja ver los labios) y cuelga desde el mentón
       const yTop = -0.5 - centro * 0.05 - Math.abs(f - 0.5) * 0.03;
-      const len = (0.4 + centro * 0.6 + r() * 0.22) * capa.lenMul; // barba CORTA y tupida
+      const len = (0.36 + centro * 0.52 + r() * 0.18) * capa.lenMul; // corta y TUPIDA
       hebras.push({
         pos: [x + (r() - 0.5) * 0.045, yTop, capa.z + (r() - 0.5) * 0.02],
         len,
-        grosor: 0.8 + r() * 0.7, // más gruesa: mechones tupidos, no hilo suelto
+        grosor: 0.9 + r() * 0.6, // mechones con cuerpo, no espagueti (ni cinta)
         tilt: (f - 0.5) * 0.22 + (r() - 0.5) * 0.18, // cuelgan casi rectos
         lean: 0.05 + r() * 0.14, // caen hacia el frente
         yaw: (r() - 0.5) * 0.4,
@@ -779,14 +805,14 @@ export function specsBarba(seed = 91) {
   // COLUMNA CENTRAL del mentón: mechones que cuelgan RECTOS en el eje para que la
   // barba no se parta en dos y tape el surco vertical del tronco (el mentón macizo
   // de un árbol viejo). Es lo que une la cortina en una sola barba maciza.
-  const CENTRO = 30;
+  const CENTRO = 38;
   for (let i = 0; i < CENTRO; i++) {
     // arrancan JUSTO bajo el labio y cuelgan rectos, adelantados para tapar el
     // surco vertical del tronco → una sola barba maciza, sin raya al medio.
     hebras.push({
-      pos: [(r() - 0.5) * 0.3, -0.48 - r() * 0.08, 0.1 + r() * 0.05],
-      len: 0.7 + r() * 0.4, // el chorro central del mentón (corto y denso)
-      grosor: 0.9 + r() * 0.6,
+      pos: [(r() - 0.5) * 0.32, -0.48 - r() * 0.08, 0.1 + r() * 0.05],
+      len: 0.62 + r() * 0.34, // el chorro central del mentón (corto y denso)
+      grosor: 1.0 + r() * 0.7,
       tilt: (r() - 0.5) * 0.12, // casi vertical
       lean: 0.04 + r() * 0.1,
       yaw: (r() - 0.5) * 0.35,
@@ -796,12 +822,12 @@ export function specsBarba(seed = 91) {
   }
   // BIGOTE / patillas cortas: mechones cortos prendidos a las mejillas justo bajo
   // los pómulos, que cierran el marco de la cara (barba que sube por las patillas).
-  for (let i = 0; i < 16; i++) {
-    const s = i < 8 ? -1 : 1;
+  for (let i = 0; i < 20; i++) {
+    const s = i < 10 ? -1 : 1;
     hebras.push({
       pos: [s * (0.28 + r() * 0.14), -0.34 - r() * 0.14, 0.06 + r() * 0.05],
-      len: 0.24 + r() * 0.2,
-      grosor: 0.7 + r() * 0.5,
+      len: 0.22 + r() * 0.18,
+      grosor: 0.8 + r() * 0.5,
       tilt: s * (0.12 + r() * 0.1),
       lean: 0.05 + r() * 0.12,
       yaw: (r() - 0.5) * 0.4,
@@ -809,18 +835,37 @@ export function specsBarba(seed = 91) {
       woody: r() > 0.9,
     });
   }
-  // matas de liquen foliáceo: acentos MINÚSCULOS del enredo de usnea, prendidos al
-  // borde de la barba y trepando por las patillas. Chicos, planos y sage-apagado
-  // para que se lean como líquen enredado — NUNCA como sombreros de hongo blancos.
+  // matas de liquen foliáceo: acentos MINÚSCULOS del enredo de usnea, METIDOS
+  // entre las raíces de los mechones (no encima: encima leían como sombreros de
+  // hongo). Chicos, planos y sage-apagado — textura del enredo, nada más.
   const tufts = [];
-  const L = 16;
+  const L = 12;
   for (let i = 0; i < L; i++) {
     const f = i / (L - 1);
     const lado = Math.abs(f - 0.5) * 2; // 0 centro → 1 mejilla
     tufts.push({
-      pos: [(f - 0.5) * 0.94, -0.52 - r() * 0.2 + lado * 0.18, 0.05 + r() * 0.06],
-      esc: 0.016 + r() * 0.018, // minúsculos: textura, no piedras/hongos
+      pos: [(f - 0.5) * 0.9, -0.56 - r() * 0.16 + lado * 0.12, 0.03 + r() * 0.04],
+      esc: 0.01 + r() * 0.012, // minúsculos: textura, no piedras/hongos
       azul: r() > 0.6,
+      musgo: false,
+    });
+  }
+  // MUSGO DE LAS CEJAS: matas pequeñas posadas SOBRE el lomo del alero (donde el
+  // campo del rostro ya pinta su pátina verde) — las cejas del viejo son musgo
+  // vivo, no madera pelada. Siguen el arco de cada ceja con temblor natural.
+  for (let i = 0; i < 22; i++) {
+    const s = i % 2 ? 1 : -1;
+    const u = r();
+    const bx = s * (0.1 + u * 0.3);
+    const arco = Math.sin(Math.min(1, (Math.abs(bx) - 0.06) / 0.36) * Math.PI) * 0.05;
+    tufts.push({
+      // z relativo al frente del grupo de la barba: el lomo de la ceja queda
+      // unos 0.05-0.1 DETRÁS del plano frontal (la cara es curva) → se hunden
+      // apenas en la madera y se leen prendidas, no flotando.
+      pos: [bx + (r() - 0.5) * 0.035, 0.185 + arco + (r() - 0.5) * 0.03, -0.09 + r() * 0.06],
+      esc: 0.011 + r() * 0.013,
+      azul: false,
+      musgo: true,
     });
   }
   return { hebras, tufts };


### PR DESCRIPTION
## Qué cambia

Retallado del Ent de la queñua (`src/visual/mundo3d/bosque/`) tras el rechazo de la cara anterior por caricaturesca.

### Rostro
- **Alero superciliar continuo y bajo** en `campoRostro` (antes: dos cejas-salchicha sueltas), nariz de caballete angosto con nudo discreto (antes: bola), vetas verticales del fuste que cruzan la cara — el rostro es el mismo palo, no una careta pegada.
- **Ojos**: iris ámbar-miel discreto que asoma desde la sombra de la cuenca, pupila amplia, párpados de corteza. Incluye fix de un bug silencioso: el `useFrame` de la mirada escribía una z vieja que hundía el iris dentro de la esfera oscura del globo — en vivo los ojos quedaban como cuencas vacías.
- **Cejas de musgo vivo** que siguen el arco del alero + pátina verde en cejas y pómulos horneada en el vertex color.
- **Barba de usnea con cuerpo**: tres capas más densas y cortas, tonos sage más hondos, liquen minúsculo metido entre las raíces de los mechones (antes leían como sombreros de hongo blancos).
- **Manos en reposo**: dedos cortos y recogidos en tono hondo (las garras abiertas salmón junto al rostro leían como espanto).

### Frondosidad
- +40% de hojas y más clusters por tier, corona más generosa que cierra los huecos entre ramas.
- La masa de follaje va facetada también en gama frugal (Lambert `flatShading`).

## Verificación
- 3 tomas playwright con `?ciclo=11` (entrada, retrato del rostro, microsuelo), sin pantalla negra — capturas enviadas al operador.
- `npm run build:prod` verde.
- `entQuenua.geom.test.js` 22/22 en verde. (Los fallos de `bosqueRealismo.test.js` son pre-existentes en la base: ese archivo referencia una API vieja del geom — `tDeAltura`, `desplazamientoRostro` — que no existe en esta rama.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)