### PR TITLE
art(valle): portales de luz — fuera aros de follaje, entra el páramo

### DIFF
--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -664,6 +664,42 @@ function LandmarkGeom({ tipo, tinte, reducedMotion, q = 1 }) {
               <meshStandardMaterial color="#4a3a2a" flatShading roughness={1} />
             </mesh>
           </group>
+          {/* LAS CANECAS AZULES DE BIOPREPARADOS sobre su estiba: la seña
+              inconfundible de la biofábrica — el caldo trabajando en sus
+              tanques (nada más en el valle es azul plástico). */}
+          <group position={[0.78, 0, 0.42]} rotation={[0, -0.35, 0]}>
+            {/* la estiba de madera (tarima + dos travesaños que asoman) */}
+            <mesh position={[0, 0.05, 0]} castShadow>
+              <boxGeometry args={[0.66, 0.045, 0.52]} />
+              <meshStandardMaterial color="#8a6a44" flatShading roughness={1} />
+            </mesh>
+            {[-0.2, 0.2].map((dz, i) => (
+              <mesh key={i} position={[0, 0.015, dz]}>
+                <boxGeometry args={[0.7, 0.03, 0.09]} />
+                <meshStandardMaterial color="#6b4a2e" flatShading roughness={1} />
+              </mesh>
+            ))}
+            {/* la caneca grande con su tapa y la mediana */}
+            <mesh position={[-0.16, 0.29, -0.04]} castShadow>
+              <cylinderGeometry args={[0.13, 0.13, 0.42, 9]} />
+              <meshStandardMaterial color="#2f6fa8" flatShading roughness={0.8} />
+            </mesh>
+            <mesh position={[-0.16, 0.52, -0.04]}>
+              <cylinderGeometry args={[0.135, 0.135, 0.035, 9]} />
+              <meshStandardMaterial color="#1f4d78" flatShading roughness={0.8} />
+            </mesh>
+            <mesh position={[0.15, 0.23, 0.05]} castShadow>
+              <cylinderGeometry args={[0.1, 0.1, 0.3, 9]} />
+              <meshStandardMaterial color="#3a86b8" flatShading roughness={0.8} />
+            </mesh>
+            {/* los tarros del biopreparado listos para el lote (en fila) */}
+            {[-0.02, 0.12, 0.26].map((dx, i) => (
+              <mesh key={i} position={[dx, 0.12, 0.28]}>
+                <cylinderGeometry args={[0.045, 0.045, 0.13, 7]} />
+                <meshStandardMaterial color="#e8e0cf" flatShading roughness={1} />
+              </mesh>
+            ))}
+          </group>
         </group>
       );
     case 'saber': // el KIOSCO DEL SABER (portal Aprender): el tablero bajo su
@@ -710,6 +746,51 @@ function LandmarkGeom({ tipo, tinte, reducedMotion, q = 1 }) {
               <meshStandardMaterial color="#f2efe4" flatShading />
             </mesh>
           </group>
+        </group>
+      );
+    case 'frailejonal': // LA PUERTA DEL PÁRAMO: el frailejonal con su niebla
+      // fría — la seña del alto (coherente con MundoParamo3D: frailejones,
+      // piedra y bruma). Tocar aquí sube al mundo del páramo.
+      return (
+        <group>
+          {/* el grupito de frailejones (roseta plateada sobre tronco lanudo) */}
+          {[[-0.5, 0.22, 1], [0.2, -0.3, 0.85], [0.55, 0.35, 0.7], [-0.05, 0.5, 0.6]].map(([x, z, s], i) => (
+            <group key={i} position={[x, 0, z]} scale={s}>
+              <mesh position={[0, 0.45, 0]} castShadow>
+                <cylinderGeometry args={[0.11, 0.14, 0.9, 7]} />
+                <meshStandardMaterial color="#6e6a52" flatShading roughness={1} />
+              </mesh>
+              <mesh position={[0, 0.98, 0]} scale={[1, 0.5, 1]} castShadow>
+                <coneGeometry args={[0.34, 0.5, 8]} />
+                <meshStandardMaterial color={suave} flatShading roughness={1} />
+              </mesh>
+              {/* la flor amarilla del frailejón (la seña de la Espeletia) */}
+              <mesh position={[0.1, 1.16, 0.06]}>
+                <sphereGeometry args={[0.05, 6, 5]} />
+                <meshStandardMaterial color="#e8c94f" flatShading />
+              </mesh>
+            </group>
+          ))}
+          {/* la piedra del alto, con su musgo */}
+          <mesh position={[0.6, 0.12, -0.35]} scale={[1, 0.7, 0.9]} castShadow>
+            <icosahedronGeometry args={[0.22, 0]} />
+            <meshStandardMaterial color="#828b90" flatShading roughness={1} />
+          </mesh>
+          {/* LA NIEBLA FRÍA que arropa el frailejonal (motas traslúcidas que
+              hacen páramo, como el vaho de la pila pero frío) */}
+          {[[-0.35, 0.55, 0.4, 0.3], [0.4, 0.75, 0.1, 0.24], [0, 1.0, -0.25, 0.19]].map(([x, yv, z, r], i) => (
+            <mesh key={i} position={[x, yv, z]}>
+              <sphereGeometry args={[r, 8, 6]} />
+              <meshBasicMaterial color="#dfe8ea" transparent opacity={0.2} depthWrite={false} />
+            </mesh>
+          ))}
+          {/* el hito de piedras apiladas: la seña del sendero de páramo */}
+          {[0.16, 0.11, 0.07].map((r, i) => (
+            <mesh key={i} position={[-0.72, 0.1 + i * 0.17, -0.1]} scale={[1, 0.65, 1]}>
+              <icosahedronGeometry args={[r, 0]} />
+              <meshStandardMaterial color={fuerte} flatShading roughness={1} />
+            </mesh>
+          ))}
         </group>
       );
     case 'hongos': // el suelo vivo: hongos que asoman (el fruto del micelio), con

--- a/src/mockups/valle/composicionValle3D.jsx
+++ b/src/mockups/valle/composicionValle3D.jsx
@@ -11,11 +11,13 @@
  *                        puerta iluminada invita a tocar y lleva a la
  *                        ventana-puerta de los mundos (el host decide a
  *                        dónde). La entrada PRINCIPAL son los portales.
- *   · VentanasVivas    — los 6 portales PRINCIPALES como PAISAJES: un arco
- *                        de vegetación que enmarca una VIÑETA 3D en
- *                        miniatura del mundo de destino (el potrero con sus
- *                        animalitos, la milpa, el puesto del mercado…).
- *                        CERO discos-espejo (fix del operador 2026-07-16).
+ *   · VentanasVivas    — los 6 portales PRINCIPALES como PAISAJES: la
+ *                        VIÑETA 3D en miniatura del mundo de destino (el
+ *                        potrero con sus animalitos, la milpa, el puesto del
+ *                        mercado…) sobre un UMBRAL DE LUZ a ras de suelo.
+ *                        CERO discos-espejo (fix del operador 2026-07-16) y
+ *                        CERO aros de follaje que tapen la entrada (fix del
+ *                        operador 2026-07-18: la entrada se dice con luz).
  *   · PorticosSecundarios — los pórticos de madera SOLO para los lugares
  *                        secundarios de menos uso (eras, huerta, vivero…).
  *   · VistaParamoEnt   — el acceso al páramo: el Ent-queñua MAGNÍFICO parado
@@ -227,18 +229,19 @@ export function CasaCampesina({ alturaDe, perfil, nocturno = false, reducedMotio
    NOTORIOS e inmersivos — y son PAISAJES, no espejos (fix del operador
    2026-07-16: CERO discos translúcidos).
 
-   Cada ventana es un ARCO DE VEGETACIÓN (un anillo vivo brotado de la
-   tierra, con hojas y flores del tinte del mundo) que enmarca una VIÑETA
-   3D en miniatura del mundo de destino: el potrero con su vaca y su cerca,
-   la milpa de tres hermanas, el puesto del mercado con su toldo… Se ve A
-   QUÉ se entra. Se para al borde del patio mirando hacia la casa (de donde
-   llega el sendero) y tocarla ENTRA, igual que el lugar.
+   REDISEÑO 2026-07-18 (fix del operador): los AROS verticales de follaje
+   que envolvían cada viñeta TAPABAN la entrada — bloqueaban la vista del
+   potrero, la milpa, el puesto… Se retiraron. Ahora cada portal es su
+   VIÑETA 3D protagonista (el mundo de destino en miniatura, más grande)
+   sobre un UMBRAL DE LUZ: un halo del tinte del mundo a ras de suelo que
+   respira como la puerta de la casa, y dos faroles bajos de vara
+   flanqueando el paso. El ojo sabe "aquí se entra" por la LUZ, no por un
+   aro que estorba. Tocar el umbral ENTRA, igual que el lugar.
 
    Técnica Android-barata (tier-safe): viñetas low-poly horneadas a mano —
    primitivas + materiales Lambert COMPARTIDOS a nivel de módulo (6 viñetas
-   no pagan 6 shaders), cero texturas, cero render-targets, cero alocación
-   por frame. Presupuesto comparable al arco que ya existía. */
-const MAT_ARCO_VIVO = new THREE.MeshLambertMaterial({ color: '#4f7d3c' });
+   no pagan 6 shaders), cero texturas, cero render-targets, cero pointLights
+   por portal (emisivo + discos meshBasic), cero alocación por frame. */
 
 /* La paleta compartida de las viñetas: UN material por color en todo el
    frente de portales. */
@@ -539,29 +542,24 @@ function sitiosVentanas(mundos) {
   }).filter(Boolean);
 }
 
-/* Las hojas que visten el anillo: puntos sobre la circunferencia (en el
-   plano local x/y del arco), con jitter determinista. */
-const HOJAS_ARCO = Array.from({ length: 10 }, (_, i) => {
-  const a = (i / 10) * Math.PI * 2 + 0.3;
-  const j = Math.sin(i * 12.9898) * 0.5;
-  return { a, r: 0.92 + j * 0.08, s: 0.1 + Math.abs(j) * 0.06, giro: j * 2.4 };
-});
-
 function VentanaViva({ sitio, alturaDe, nocturno, reducedMotion, rico = true, onEntrar }) {
   const y = alturaDe(sitio.x, sitio.z);
-  const brilloRef = useRef(null);
-  // Las flores del arco RESPIRAN (~0.3 Hz, con fase por portal para que el
-  // frente no pulse al unísono): vivo, no intermitente.
+  const haloRef = useRef(null);
+  // El umbral RESPIRA (~0.3 Hz, con fase por portal para que el frente no
+  // pulse al unísono): vivo, no intermitente.
   const fase = useMemo(() => sitio.x * 2.1 + sitio.z * 1.3, [sitio]);
+  const [fuerte] = sitio.tinte;
+  // Los materiales emisivos de los dos faroles del portal, por REF (mismo
+  // patrón que el brillo del arco viejo): el pulso los escribe imperativo.
+  const faroles = useRef([]);
   useFrame((state) => {
     if (reducedMotion) return;
-    const p = (Math.sin(state.clock.elapsedTime * 1.9 + fase) + 1) / 2;
-    if (brilloRef.current) brilloRef.current.emissiveIntensity = 0.5 + p * 0.5;
+    const p = (Math.sin(state.clock.elapsedTime * 1.7 + fase) + 1) / 2;
+    for (const f of faroles.current) {
+      if (f) f.emissiveIntensity = (nocturno ? 0.95 : 0.6) + p * 0.6;
+    }
+    if (haloRef.current) haloRef.current.opacity = (nocturno ? 0.32 : 0.3) + p * 0.18;
   });
-  const [fuerte] = sitio.tinte;
-  // En gama media/baja el arco viste menos hojas; la viñeta SIEMPRE va (ES
-  // el portal: sin ella se vuelve un anillo mudo).
-  const hojas = rico ? HOJAS_ARCO : HOJAS_ARCO.slice(0, 6);
   const Vineta = VINETAS[sitio.mundo.id] || null;
   return (
     <group
@@ -578,53 +576,61 @@ function VentanaViva({ sitio, alturaDe, nocturno, reducedMotion, rico = true, on
       onPointerOver={onEntrar ? alApuntar : undefined}
       onPointerOut={onEntrar ? alSoltar : undefined}
     >
-      {/* el ANILLO VIVO: la enredadera que hace de marco, parada en la tierra */}
-      <mesh position={[0, 1.12, 0]} material={MAT_ARCO_VIVO} castShadow>
-        <torusGeometry args={[0.95, 0.085, 7, 26]} />
+      {/* EL HALO DE ENTRADA a ras de suelo: el anillo de luz del tinte del
+          mundo que respira — "aquí se entra" dicho con luz, sin tapar nada
+          (mismo lenguaje que el charco de la puerta de la casa y el faro). */}
+      <mesh position={[0, 0.06, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[1.02, 1.34, 28]} />
+        <meshBasicMaterial
+          ref={haloRef}
+          color={fuerte}
+          transparent
+          opacity={nocturno ? 0.36 : 0.32}
+          depthWrite={false}
+          side={2}
+        />
       </mesh>
-      {/* las hojas que lo visten (mismo material: 0 draw calls extra de shader) */}
-      {hojas.map((h, i) => (
-        <mesh
-          key={i}
-          material={MAT_ARCO_VIVO}
-          position={[Math.cos(h.a) * h.r, 1.12 + Math.sin(h.a) * h.r, 0.03]}
-          rotation={[0, 0, h.giro]}
-          scale={[h.s * 1.7, h.s, h.s * 0.5]}
-        >
-          <sphereGeometry args={[1, 6, 5]} />
-        </mesh>
-      ))}
-      {/* cuatro flores del tinte del mundo coronando el arco (la seña; de
-          noche brillan más fuerte — la práctica que orienta) */}
-      {[0.6, 1.25, 1.9, 2.55].map((a, i) => (
-        <mesh
-          key={i}
-          position={[Math.cos(a) * 0.98, 1.12 + Math.sin(a) * 0.98, 0.08]}
-        >
-          <sphereGeometry args={[0.065, 6, 5]} />
-          <meshStandardMaterial
-            ref={i === 1 ? brilloRef : undefined}
+      {/* el charco tenue dentro del anillo (solo tier rico: un disco más) */}
+      {rico && (
+        <mesh position={[0, 0.05, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <circleGeometry args={[1.0, 22]} />
+          <meshBasicMaterial
             color={fuerte}
-            emissive={fuerte}
-            emissiveIntensity={nocturno ? 1.0 : 0.7}
-            flatShading
+            transparent
+            opacity={nocturno ? 0.12 : 0.07}
+            depthWrite={false}
           />
         </mesh>
+      )}
+      {/* los DOS FAROLES DE VARA que flanquean el paso: bajitos y a los
+          lados — señalan la entrada sin bloquear la vista de la viñeta */}
+      {[-1.18, 1.18].map((dx, i) => (
+        <group key={i} position={[dx, 0, 0.3]}>
+          <mesh position={[0, 0.27, 0]} material={VIN.madera} castShadow>
+            <cylinderGeometry args={[0.028, 0.04, 0.54, 5]} />
+          </mesh>
+          <mesh position={[0, 0.6, 0]}>
+            <sphereGeometry args={[0.1, 8, 7]} />
+            <meshStandardMaterial
+              ref={(m) => {
+                faroles.current[i] = m;
+              }}
+              color={fuerte}
+              emissive={fuerte}
+              emissiveIntensity={nocturno ? 1.15 : 0.65}
+              flatShading
+            />
+          </mesh>
+        </group>
       ))}
-      {/* LA VIÑETA: el mundo de destino en miniatura, parado DENTRO del arco
-          — se ve a qué se entra. Un paso detrás del plano del anillo para
-          que el marco la abrace (el arco mira hacia la casa). */}
+      {/* LA VIÑETA: el mundo de destino en miniatura — ahora PROTAGONISTA
+          (sin aro que la tape) y más grande: la jerarquía de los 6 portales
+          principales se lee por tamaño y por luz. */}
       {Vineta && (
-        <group position={[0, 0.02, -0.18]}>
+        <group position={[0, 0.02, -0.12]} scale={1.18}>
           <Vineta />
         </group>
       )}
-      {/* los dos raigones donde el anillo agarra la tierra */}
-      {[-0.82, 0.82].map((dx, i) => (
-        <mesh key={i} position={[dx, 0.14, 0]} material={MAT_ARCO_VIVO}>
-          <coneGeometry args={[0.16, 0.5, 5]} />
-        </mesh>
-      ))}
     </group>
   );
 }

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -177,6 +177,23 @@ const LUGARES = [
       tinte: ['#b3771d', '#f2dfae'],
     },
   },
+  // EL PÁRAMO (la puerta de arriba): el frailejonal con su niebla fría en la
+  // zona alta de la cordillera. Antes el páramo se veía (el Ent en el filo)
+  // pero no tenía ENTRADA propia en el valle; este lugar la abre — tocarla
+  // sube al mundo del páramo (MundoParamo3D, vía diorama_paramo). Sin mundo
+  // propio en el manifiesto: trae su identidad de respaldo.
+  {
+    id: 'paramo',
+    pos: [-0.9, 0, -7.6],
+    escala: 0.95,
+    tipo: 'frailejonal',
+    fallbackMundo: {
+      titulo: 'El páramo',
+      emoji: '🏔️',
+      lema: 'El frailejonal que le peina el agua a la niebla y se la guarda a la finca.',
+      tinte: ['#63807a', '#c9d8d2'],
+    },
+  },
 ];
 
 /**
@@ -481,5 +498,5 @@ export const NARRACION = {
   casa:
     'Esta es su casa: el corazón de la finca y la puerta de sus mundos. Toque una de las seis puertas para salir a donde necesite.',
   paramo:
-    'Ahí arriba está el páramo, con su guardián de queñua entre los frailejones. Tóquelo y él le muestra el monte entero.',
+    'El páramo de su finca: los frailejones le peinan el agua a la niebla y se la entregan despacio al suelo. Por eso el páramo se cuida, no se ara. Entre y véalo de cerca.',
 };

--- a/src/prodApp/wire3DNav.js
+++ b/src/prodApp/wire3DNav.js
@@ -33,6 +33,9 @@ export const RUTA_2D_DESDE_3D = {
   // Los hongos no tienen pantalla propia todavía: el mundo subterráneo
   // (subsuelo) es su casa 2D hasta entonces (fix del director, DIRECCION #3).
   micorrizas: 'subsuelo',
+  // La puerta del páramo en el valle (el frailejonal de la zona fría):
+  // abre el mundo del páramo entero.
+  paramo: 'diorama_paramo',
   bosque_vivo: 'bosque_vivo',
 
   // ── Sub-hotspots de cada escena 3D (mundoData.js hotspots con view:) ─


### PR DESCRIPTION
## Rediseño de portales del valle 3D (#/valle3d)

**Qué cambia (aditivo — viñetas, criaturas, terreno y quebrada intactos):**

1. **Fuera los aros verdes**: los anillos verticales de follaje (\`VentanaViva\`, torus + hojas + raigones en \`composicionValle3D.jsx\`) tapaban las entradas de los 6 portales principales. Eliminados.
2. **Umbral de LUZ en su lugar**: halo del tinte del mundo a ras de suelo que respira (fase por portal, respeta \`reducedMotion\`) + dos faroles bajos de vara flanqueando el paso. Cero pointLights por portal — emisivo + meshBasic, tier-safe.
3. **El páramo entra al valle**: lugar nuevo \`paramo\` (frailejonal con niebla fría, piedra, hito de sendero) en la zona alta; tocar abre el panel y su CTA lleva a \`MundoParamo3D\` (\`diorama_paramo\` vía \`wire3DNav\`). Probado con click real en Playwright.
4. **Potrero con cercas vivas**: ya vivía en \`animales.jsx\` (matarratón/nacedero/botón de oro + hato regado) — verificado que renderiza intacto.
5. **Biofábrica reconocible**: canecas azules de biopreparados sobre estiba + tarros — nada más en el valle es azul plástico.
6. **Jerarquía**: los 6 principales más notorios (viñeta ×1.18 + halo + faroles); los secundarios quedan con su pórtico discreto.
7. **Fermentos**: sin marcador suelto en el valle (verificado) — el acceso sigue siendo por la casa (\`ventana_valle\`).

**Verificación**: \`build:prod\` verde · Playwright chromium sistema + swiftshader, \`?ciclo=11#/valle3d\`, 3 tomas + prueba de toque del páramo: sin aros, sin frames negros, sin errores de consola. \`dist-prod/\` restaurado (solo fuentes en el PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)