### PR TITLE
art(bosque): el bosque de niebla ~3x más grande y grandioso

### DIFF
--- a/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
+++ b/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
@@ -76,8 +76,8 @@ function presetBosque(franja) {
     sol: p.sol,
     rellenoInt: p.rellenoInt,
     solPos: p.solPos,
-    nieblaCerca: Math.max(5, p.nieblaCerca * 0.6),
-    nieblaLejos: 14 + p.nieblaLejos * 0.5,
+    nieblaCerca: Math.max(6, p.nieblaCerca * 0.72),
+    nieblaLejos: 26 + p.nieblaLejos * 0.7,
     estrellas: Number(p.estrellas) || 0,
   };
 }
@@ -196,11 +196,11 @@ function AtmosferaBosque({ franja, perfil, reducedMotion }) {
         castShadow={perfil.sombras}
         shadow-mapSize={[1024, 1024]}
         shadow-camera-near={1}
-        shadow-camera-far={60}
-        shadow-camera-left={-15}
-        shadow-camera-right={15}
-        shadow-camera-top={15}
-        shadow-camera-bottom={-15}
+        shadow-camera-far={88}
+        shadow-camera-left={-20}
+        shadow-camera-right={20}
+        shadow-camera-top={20}
+        shadow-camera-bottom={-20}
       />
       {/* contraluz frío opuesto al sol: separa las copas de la niebla */}
       <directionalLight
@@ -388,11 +388,11 @@ function texturaRayo() {
 }
 
 const LAMINAS_RAYO = [
-  { ox: -2.6, oz: 1.2, w: 0.9, l: 11, giro: 0.3 },
-  { ox: -0.8, oz: -1.8, w: 1.4, l: 12.5, giro: 1.2 },
-  { ox: 1.4, oz: 0.6, w: 0.7, l: 10, giro: 2.1 },
-  { ox: 3.1, oz: -1.1, w: 1.1, l: 12, giro: 0.8 },
-  { ox: -4.4, oz: -0.4, w: 0.8, l: 10.5, giro: 1.7 },
+  { ox: -3.4, oz: 1.6, w: 1.3, l: 18, giro: 0.3 },
+  { ox: -1.0, oz: -2.4, w: 2.0, l: 21, giro: 1.2 },
+  { ox: 1.8, oz: 0.8, w: 1.0, l: 16, giro: 2.1 },
+  { ox: 4.0, oz: -1.4, w: 1.6, l: 20, giro: 0.8 },
+  { ox: -5.6, oz: -0.5, w: 1.1, l: 17, giro: 1.7 },
 ];
 
 const _UP = new THREE.Vector3(0, 1, 0);
@@ -468,10 +468,11 @@ function RayosDeSol({ franja, reducedMotion }) {
       deslizan a velocidades distintas y el bosque gana profundidad física.
       La franja pesa: más bruma al amanecer y de noche. */
 const CAPAS_BRUMA = [
-  { rad: 13.5, y: 2.3, w: 24, h: 5.5, op: 0.16, vel: 0.011, fase: 0 },
-  { rad: 17, y: 3.1, w: 32, h: 7, op: 0.14, vel: -0.008, fase: 2.2 },
-  { rad: 21.5, y: 4.2, w: 42, h: 9, op: 0.12, vel: 0.006, fase: 4.1 },
-  { rad: 26, y: 5.6, w: 54, h: 11, op: 0.1, vel: -0.004, fase: 1.3 },
+  { rad: 13.5, y: 2.6, w: 26, h: 6.5, op: 0.16, vel: 0.011, fase: 0 },
+  { rad: 18, y: 4.0, w: 36, h: 9, op: 0.15, vel: -0.008, fase: 2.2 },
+  { rad: 23, y: 6.0, w: 48, h: 12, op: 0.13, vel: 0.006, fase: 4.1 },
+  { rad: 29, y: 8.5, w: 62, h: 15, op: 0.12, vel: -0.004, fase: 1.3 },
+  { rad: 36, y: 12, w: 84, h: 20, op: 0.1, vel: 0.003, fase: 5.5 },
 ];
 const PESO_BRUMA = {
   amanecer: 1.4, manana: 1.0, mediodia: 0.65, tarde: 0.9, atardecer: 1.25, noche: 1.15,
@@ -564,16 +565,20 @@ function BrumaParallax({ franja, reducedMotion }) {
       guardián, el arroyo entrando por la derecha del cuadro). En un teléfono
       parado la cámara retrocede y sube apenas: el fov vertical alcanza y el
       Ent respira sin perder el queñual de los flancos. */
-const POSE_BOSQUE = { position: [8.0, 2.55, 11.6], fov: 42, mira: [0, 3.0, 0] };
+/* El guardián creció 1.4× (mount-ent scale): para conservar EXACTO el encuadre
+   héroe aprobado (leve contrapicado, el rostro tallado legible), el rig de
+   cámara se escala con él — misma proporción árbol/cuadro que el original, solo
+   que 1.4× más grande y con el bosque catedral abriéndose alrededor. */
+const POSE_BOSQUE = { position: [11.2, 3.6, 16.2], fov: 42, mira: [0, 4.2, 0] };
 
 /* Anclas de sombra de contacto que la escena le pasa a SueloRico: el claro del
    guardián (el Ent es el objeto mayor y necesita el AO ancho que lo planta). */
-const ANCLAS_SUELO = [{ x: 0, z: 0, radio: 1.7 }];
+const ANCLAS_SUELO = [{ x: 0, z: 0, radio: 2.7 }];
 
 function poseBosqueParaAspecto(aspect) {
   if (!aspect || aspect >= 0.9) return { ...POSE_BOSQUE, k: 1 };
   const t = Math.min(1, (0.9 - aspect) / 0.44);
-  const B = { position: [10.6, 4.4, 15.4], fov: 56, mira: [0, 2.7, 0] };
+  const B = { position: [14.8, 6.2, 21.6], fov: 56, mira: [0, 3.8, 0] };
   const lerp = (a, b) => a + (b - a) * t;
   const position = POSE_BOSQUE.position.map((v, i) => lerp(v, B.position[i]));
   const mira = POSE_BOSQUE.mira.map((v, i) => lerp(v, B.mira[i]));
@@ -600,8 +605,8 @@ function Diorama({ tier, reducedMotion, pose }) {
       <AtmosferaBosque franja={franja} perfil={perfil} reducedMotion={reducedMotion} />
       {fracEstrellas > 0 && perfil.estrellas > 0 && (
         <Stars
-          radius={44}
-          depth={22}
+          radius={60}
+          depth={26}
           count={Math.max(24, Math.round(perfil.estrellas * fracEstrellas))}
           factor={3}
           fade
@@ -649,13 +654,13 @@ function Diorama({ tier, reducedMotion, pose }) {
           de la escena); en 'bajo' SueloRico no dibuja sombras, así que el kit la
           planta acá para que el Ent no flote. */}
       {!perfil.sombrasContacto && (
-        <SombraContacto pos={[0, 0.04, 0]} radio={1.6} color="#20281c" opacidad={0.34} orden={2} />
+        <SombraContacto pos={[0, 0.04, 0]} radio={2.6} color="#20281c" opacidad={0.34} orden={2} />
       )}
 
-      {/* ══ MOUNT DEL ENT ══ El guardián vive AQUÍ (origen del claro). Otra
-          rama lo eleva de calibre: inyectar el Ent nuevo en este group sin
-          tocar el resto del escenario. */}
-      <group name="mount-ent">
+      {/* ══ MOUNT DEL ENT ══ El guardián vive AQUÍ (origen del claro). Crece con
+          la grandeza del bosque (scale) SIN tocar su geometría ni su rostro
+          refinado — el corazón acompaña la escala catedral, no la pierde. */}
+      <group name="mount-ent" scale={1.4}>
         <EntQuenua tier={tier} reducedMotion={reducedMotion} />
       </group>
 
@@ -665,10 +670,10 @@ function Diorama({ tier, reducedMotion, pose }) {
         target={pose.mira}
         enablePan={false}
         enableZoom
-        minDistance={6}
-        maxDistance={Math.max(20, Math.ceil(16 * pose.k) + 5)}
+        minDistance={7}
+        maxDistance={Math.max(30, Math.ceil(22 * pose.k) + 6)}
         minPolarAngle={0.5}
-        maxPolarAngle={1.42}
+        maxPolarAngle={1.5}
         enableDamping
         dampingFactor={0.08}
         autoRotate={!reducedMotion}
@@ -679,9 +684,9 @@ function Diorama({ tier, reducedMotion, pose }) {
       <CamaraDirector
         controls={controls}
         reposo={pose.position}
-        mirada={[0, 4.6, 0]}
-        duracion={2.6}
-        amplio={1.35}
+        mirada={[0, 6.4, 0]}
+        duracion={3.0}
+        amplio={1.6}
         respiro={0.045}
         activa={!reducedMotion && tier !== 'bajo'}
         unaVezClave="bosqueTakeA"

--- a/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
+++ b/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
@@ -68,9 +68,9 @@ function extraAnfiteatro(x, z) {
   const cresta = 1 + 0.34 * Math.sin(ang * 3 + 1.2)
     + 0.2 * Math.sin(ang * 7 - 0.7)
     + 0.12 * Math.sin(ang * 13 + 2.3);
-  const pared = ss(r, 12.5, 30) ** 1.25 * 4.8 * cresta;
+  const pared = ss(r, 14, 40) ** 1.2 * 7.4 * cresta;
   const dx = x - xArroyo(z);
-  const canada = -0.4 * Math.exp(-(dx * dx) / 1.15) * ss(z, -13, -6) * (1 - ss(r, 20, 28));
+  const canada = -0.4 * Math.exp(-(dx * dx) / 1.15) * ss(z, -13, -6) * (1 - ss(r, 28, 40));
   return pared + canada;
 }
 
@@ -329,8 +329,9 @@ function tinteInstancia(r, amt = 0.1) {
 /**
  * Sitios del queñual para un tier: anillo HÉROE (r 6.4–10.6, enmarca el claro
  * sin tapar el corredor de cámara ni el arroyo ni a los vecinos) + anillo
- * LEJANO (r 12.5–19.5, sobre la falda de la pared, velado por la niebla, con
- * escala mayor: siluetas que dan fondo). Determinista.
+ * LEJANO (r 15–28, sobre la falda de la pared del anfiteatro, velado por la
+ * niebla, con escala 1.5–2.4×: siluetas COLOSALES que dan fondo catedral).
+ * Determinista.
  */
 export function sitiosQuenual(tier = 'alto') {
   const cupo = CUPO_QUENUAL[tier] || CUPO_QUENUAL.medio;
@@ -359,11 +360,11 @@ export function sitiosQuenual(tier = 'alto') {
     const x = Math.cos(ang) * rad;
     const z = Math.sin(ang) * rad;
     if (z > -13 && Math.abs(x - xArroyo(z)) < 1.4) continue; // no pisar el agua
-    if (!cabe(x, z, 2.6)) continue;
+    if (!cabe(x, z, 2.8)) continue;
     sitios.push({
       pos: [x, alturaBosque(x, z) - 0.06, z],
       rotY: r() * Math.PI * 2,
-      esc: 0.92 + r() * 0.35,
+      esc: 1.02 + r() * 0.42,
       variante: sitios.length % 3,
       tinte: tinteInstancia(r),
     });
@@ -376,15 +377,15 @@ export function sitiosQuenual(tier = 'alto') {
     const ang = r() * Math.PI * 2;
     const d = Math.atan2(Math.sin(ang - AZ_CAMARA), Math.cos(ang - AZ_CAMARA));
     if (Math.abs(d) < 0.22) continue; // ni las lejanas tapan al Ent de frente
-    const rad = 12.5 + r() * 7;
+    const rad = 15 + r() * 13;
     const x = Math.cos(ang) * rad;
     const z = Math.sin(ang) * rad;
     if (z > -13 && Math.abs(x - xArroyo(z)) < 1.6) continue;
-    if (!cabe(x, z, 3.1)) continue;
+    if (!cabe(x, z, 3.6)) continue;
     sitios.push({
       pos: [x, alturaBosque(x, z) - 0.1, z],
       rotY: r() * Math.PI * 2,
-      esc: 1.15 + r() * 0.5,
+      esc: 1.5 + r() * 0.95,
       variante: sitios.length % 3,
       tinte: tinteInstancia(r, 0.14),
     });

--- a/src/visual/mundo3d/bosque/doselBiodiverso.geom.js
+++ b/src/visual/mundo3d/bosque/doselBiodiverso.geom.js
@@ -328,7 +328,7 @@ export function geomGuadua({ q = 1 } = {}, seed = 2) {
   const partes = [];
   const nCulmos = Math.max(3, Math.round(6 * q));
   for (let c = 0; c < nCulmos; c++) {
-    const H = 3.6 + r() * 2.6;
+    const H = 4.8 + r() * 3.6;
     const giro = r() * Math.PI * 2;
     const rad = 0.15 + r() * 0.55; // separación en la macolla
     const off = [Math.cos(giro) * rad, 0, Math.sin(giro) * rad];
@@ -336,7 +336,7 @@ export function geomGuadua({ q = 1 } = {}, seed = 2) {
     const culmo = tuboOrganico(curva, {
       tubular: Math.max(9, Math.round(16 * q)),
       radial: Math.max(5, Math.round(6 * q)),
-      taper: taperLineal(0.075 + r() * 0.02, 0.03),
+      taper: taperLineal(0.088 + r() * 0.024, 0.032),
       arruga: 0.05,
       semilla: seed + c * 2,
     });
@@ -393,9 +393,9 @@ export function geomGuadua({ q = 1 } = {}, seed = 2) {
 export function geomNogal({ q = 1 } = {}, seed = 3) {
   const r = rng(seed);
   const partes = [];
-  const H = 4.2 + r() * 0.8;
+  const H = 5.8 + r() * 1.5;
   const { geo, curva } = troncoHorneado(
-    { H, r0: 0.16, r1: 0.06, inclina: 0.03, sinuoso: 0.05, giro: r() * 6, arruga: 0.1, raigon: 0.4, q, hastaLiquen: 0.5,
+    { H, r0: 0.2, r1: 0.075, inclina: 0.03, sinuoso: 0.05, giro: r() * 6, arruga: 0.1, raigon: 0.4, q, hastaLiquen: 0.5,
       corteza: { grieta: PB.nogalGrieta, cuerpo: PB.nogalTronco, cresta: PB.nogalCresta, escalaGrano: 3.6 } },
     seed + 1,
   );
@@ -442,9 +442,9 @@ export function geomNogal({ q = 1 } = {}, seed = 3) {
 export function geomCedro({ q = 1 } = {}, seed = 4) {
   const r = rng(seed);
   const partes = [];
-  const H = 3.6 + r() * 0.7;
+  const H = 5.0 + r() * 1.3;
   const { geo, curva } = troncoHorneado(
-    { H, r0: 0.2, r1: 0.08, inclina: 0.04, sinuoso: 0.06, giro: r() * 6, arruga: 0.16, raigon: 0.55, q, hastaLiquen: 0.6,
+    { H, r0: 0.25, r1: 0.1, inclina: 0.04, sinuoso: 0.06, giro: r() * 6, arruga: 0.16, raigon: 0.55, q, hastaLiquen: 0.6,
       corteza: { grieta: PB.cedroGrieta, cuerpo: PB.cedroTronco, cresta: PB.cedroCresta, escalaGrano: 4.6 } },
     seed + 1,
   );
@@ -688,13 +688,13 @@ export function geomQuiche({ q = 1 } = {}, seed = 10) {
 export function geomYarumo({ q = 1 } = {}, seed = 11) {
   const r = rng(seed);
   const partes = [];
-  const H = 4.4 + r() * 1.3;
+  const H = 6.2 + r() * 2.2;
   // Fuste pálido, recto y liso, con anillos oscuros (cicatrices de hoja).
   const curva = curvaTronco({ altura: H, inclina: 0.03, sinuoso: 0.04, giro: r() * 6 }, seed + 1);
   const fuste = tuboOrganico(curva, {
     tubular: Math.max(9, Math.round(16 * q)),
     radial: Math.max(6, Math.round(7 * q)),
-    taper: taperTronco(0.13, 0.05, 0.35),
+    taper: taperTronco(0.155, 0.06, 0.35),
     arruga: 0.05,
     semilla: seed * 3,
   });
@@ -767,9 +767,9 @@ export function geomYarumo({ q = 1 } = {}, seed = 11) {
 export function geomAliso({ q = 1 } = {}, seed = 12) {
   const r = rng(seed);
   const partes = [];
-  const H = 3.8 + r() * 1.0;
+  const H = 5.4 + r() * 1.6;
   const { geo, curva } = troncoHorneado(
-    { H, r0: 0.16, r1: 0.055, inclina: 0.03, sinuoso: 0.05, giro: r() * 6, arruga: 0.12, raigon: 0.4, q, hastaLiquen: 0.55, liquen: '#8f9a5e',
+    { H, r0: 0.2, r1: 0.07, inclina: 0.03, sinuoso: 0.05, giro: r() * 6, arruga: 0.12, raigon: 0.4, q, hastaLiquen: 0.55, liquen: '#8f9a5e',
       corteza: { grieta: PB.alisoGrieta, cuerpo: PB.alisoTronco, cresta: PB.alisoCresta, escalaGrano: 4.0 } },
     seed + 1,
   );
@@ -939,26 +939,30 @@ function sembrar(n, rMin, rMax, r, o = {}) {
 export function distribucionDosel(conteos, seed = 909) {
   const c = conteos;
   return {
-    // Emergentes: pared del fondo, altos, reparto parejo, velados por niebla.
-    // Anillos ANCHOS y solapados (10→27) para que el dosel se cierre denso y
-    // gane profundidad — el bosque se lee como muralla de árboles, no como fila.
-    guadua: sembrar(c.guadua, 10, 26, rng(seed + 1), { eMin: 0.95, eMax: 1.4, varia: 0.08, evitaFrente: true, evitaAgua: true }),
-    nogal: sembrar(c.nogal, 11, 26, rng(seed + 2), { eMin: 0.95, eMax: 1.25, varia: 0.07, evitaFrente: true, evitaAgua: true }),
-    cedro: sembrar(c.cedro, 12, 27, rng(seed + 3), { eMin: 0.95, eMax: 1.25, varia: 0.08, evitaFrente: true, evitaAgua: true }),
-    // Yarumo: emergente pionero, disperso y alto, entra hasta el anillo medio.
-    yarumo: sembrar(c.yarumo, 10, 25, rng(seed + 10), { eMin: 1.0, eMax: 1.35, varia: 0.06, evitaFrente: true, evitaAgua: true }),
+    // Emergentes: la MURALLA CATEDRAL del fondo. Anillos anchos empujados hacia
+    // afuera (12→31, sobre el mismo plano-terreno de 64) CON sesgo `haciaAfuera`
+    // (sqrt): el grueso se apila LEJOS y trepa la pared del anfiteatro, y la
+    // escala de instancia sube hasta ~2× (los más altos se salen del cuadro).
+    // Un bosque que RECEDE en profundidad y ABRUMA hacia arriba, no una fila.
+    guadua: sembrar(c.guadua, 12, 30, rng(seed + 1), { eMin: 1.1, eMax: 2.05, varia: 0.08, evitaFrente: true, evitaAgua: true, haciaAfuera: true }),
+    nogal: sembrar(c.nogal, 13, 30, rng(seed + 2), { eMin: 1.1, eMax: 1.85, varia: 0.07, evitaFrente: true, evitaAgua: true, haciaAfuera: true }),
+    cedro: sembrar(c.cedro, 14, 31, rng(seed + 3), { eMin: 1.1, eMax: 1.85, varia: 0.08, evitaFrente: true, evitaAgua: true, haciaAfuera: true }),
+    // Yarumo: emergente pionero, pálido y ALTÍSIMO, disperso hacia el fondo.
+    yarumo: sembrar(c.yarumo, 12, 30, rng(seed + 10), { eMin: 1.15, eMax: 2.1, varia: 0.06, evitaFrente: true, evitaAgua: true, haciaAfuera: true }),
     // Aliso: árbol de AGUA — se le deja pisar cerca del arroyo (sin evitaAgua).
-    aliso: sembrar(c.aliso, 8, 22, rng(seed + 11), { eMin: 0.95, eMax: 1.3, varia: 0.07, evitaFrente: true }),
+    aliso: sembrar(c.aliso, 11, 28, rng(seed + 11), { eMin: 1.1, eMax: 1.9, varia: 0.07, evitaFrente: true, haciaAfuera: true }),
     // Dosel florecido y de sombra: anillo medio, salpicado (color y textura).
-    guacimo: sembrar(c.guacimo, 8, 18, rng(seed + 12), { eMin: 0.9, eMax: 1.2, varia: 0.08, evitaAgua: true }),
-    cambulo: sembrar(c.cambulo, 8, 18, rng(seed + 4), { eMin: 0.9, eMax: 1.2, varia: 0.08, evitaAgua: true }),
-    gualanday: sembrar(c.gualanday, 8, 18, rng(seed + 5), { eMin: 0.9, eMax: 1.2, varia: 0.08, evitaAgua: true }),
-    sieteCueros: sembrar(c.sieteCueros, 6, 16, rng(seed + 6), { eMin: 0.85, eMax: 1.2, varia: 0.1, agrupa: true, evitaAgua: true }),
-    chachafruto: sembrar(c.chachafruto, 7, 17, rng(seed + 13), { eMin: 0.9, eMax: 1.2, varia: 0.09, evitaAgua: true }),
+    // Con `evitaFrente`: dejan LIBRE el corredor de cámara para que el rostro del
+    // Ent (el coloso central) nunca quede tapado por una copa de flor de enfrente.
+    guacimo: sembrar(c.guacimo, 9, 22, rng(seed + 12), { eMin: 0.95, eMax: 1.45, varia: 0.08, evitaAgua: true, evitaFrente: true }),
+    cambulo: sembrar(c.cambulo, 9, 22, rng(seed + 4), { eMin: 0.95, eMax: 1.45, varia: 0.08, evitaAgua: true, evitaFrente: true }),
+    gualanday: sembrar(c.gualanday, 9, 22, rng(seed + 5), { eMin: 0.95, eMax: 1.45, varia: 0.08, evitaAgua: true, evitaFrente: true }),
+    sieteCueros: sembrar(c.sieteCueros, 7, 19, rng(seed + 6), { eMin: 0.9, eMax: 1.35, varia: 0.1, agrupa: true, evitaAgua: true, evitaFrente: true }),
+    chachafruto: sembrar(c.chachafruto, 8, 20, rng(seed + 13), { eMin: 0.95, eMax: 1.4, varia: 0.09, evitaAgua: true, evitaFrente: true }),
     // Sotobosque: interior-medio, agrupado (manchones espesos).
-    helecho: sembrar(c.helecho, 4.5, 14, rng(seed + 7), { eMin: 0.8, eMax: 1.35, varia: 0.12, agrupa: true, evitaAgua: true }),
-    heliconia: sembrar(c.heliconia, 4, 13, rng(seed + 8), { eMin: 0.85, eMax: 1.3, varia: 0.12, agrupa: true, evitaAgua: true }),
+    helecho: sembrar(c.helecho, 4.5, 16, rng(seed + 7), { eMin: 0.85, eMax: 1.45, varia: 0.12, agrupa: true, evitaAgua: true }),
+    heliconia: sembrar(c.heliconia, 4, 15, rng(seed + 8), { eMin: 0.9, eMax: 1.4, varia: 0.12, agrupa: true, evitaAgua: true }),
     // Epífitas: rosetas cerca del claro, agrupadas al pie de todo.
-    quiche: sembrar(c.quiche, 3.4, 12, rng(seed + 9), { eMin: 0.8, eMax: 1.45, varia: 0.12, agrupa: true }),
+    quiche: sembrar(c.quiche, 3.4, 13, rng(seed + 9), { eMin: 0.85, eMax: 1.5, varia: 0.12, agrupa: true }),
   };
 }


### PR DESCRIPTION
## Qué

El **mundo del bosque** (`EscenaBosqueVivo`, ruta `#/mockups/bosque-vivo-3d`) escalado a **~3× más grande y grandioso**: un bosque andino de niebla que abruma hacia arriba y recede en profundidad, con el Ent-Bárbol maestro como coloso central. Es cuestión de **escala y composición**, no de densidad: se mantienen las 13 especies y **una draw-call por especie** (subí tamaño/altura de instancias, no el conteo).

## Qué escalé (antes → después)

**`doselBiodiverso.geom.js`** — emergentes catedral:
- Alturas de fuste: guadua `3.6–6.2 → 4.8–8.4`, nogal `4.2–5.0 → 5.8–7.3`, cedro `3.6–4.3 → 5.0–6.3`, yarumo `4.4–5.7 → 6.2–8.4`, aliso `3.8–4.8 → 5.4–7.0` (grosor de fuste proporcional para que lean altos).
- Escala de instancia de emergentes hasta `~2.05×` (variación: los más altos **se salen del encuadre**).
- Anillos empujados hacia afuera con sesgo `haciaAfuera`: emergentes `10–27 → 12–31`, florecidos `8–18 → 9–22`, sotobosque/epífitas extendidos. Florecidos ahora con `evitaFrente` para no tapar el rostro del guardián.

**`bosqueTakeA.geom.js`** — anfiteatro y queñual:
- Muro del anfiteatro `ss(12.5,30)*4.8 → ss(14,40)*7.4` (más alto y ancho, cuenco que la niebla se come al fondo).
- Queñuas lejanas colosales: anillo `12.5–19.5 → 15–28`, escala `1.15–1.65 → 1.5–2.4`.

**`EscenaBosqueVivo.jsx`** — atmósfera aérea + cámara:
- Niebla lejana `14 → 26` base (el bosque grande respira y recede en perspectiva aérea).
- 5ª banda de bruma alta (`y 12`, `84×20`) para escala entre estratos; rayos de sol más largos (`l 11 → 18–21`); estrellas radio `44 → 60`; sombra `far 60 → 88`, bounds `±15 → ±20`.
- El guardián acompaña la grandeza: `mount-ent scale 1.4` **sin tocar su geometría ni su rostro** (#2554). El **rig de cámara se escala 1.4×** para conservar EXACTO el encuadre héroe aprobado; el dolly de llegada arranca alto (revela la altura) y baja al rostro.

## Restricciones respetadas
- Solo archivos del bosque (`src/visual/mundo3d/bosque/*`). No se tocó valle, otros mundos, ni `App.jsx`.
- Frugal/low-poly, instancing intacto (una draw-call por especie), procedural, offline, sin assets nuevos. `dist-prod/` restaurado (PR solo con fuentes).
- Español Colombia "usted"; sin nombres reales/persona.

## Verificación
- `npm run build:prod` verde (gate de compilación).
- Captura con Playwright + chromium del sistema (swiftshader), ruta `?ciclo=11#/mockups/bosque-vivo-3d`. **Nota:** la ruta del mockup vive en la app estándar (`main.jsx` → `App.jsx`); `dist-prod` monta `ProdChagraApp` (3D-first) que no la incluye, así que la verificación visual se hizo contra el `vite build` estándar.
- 3 tomas: héroe (Ent centrado con su rostro + emergentes altísimos), gran angular (copa biodiversa + dosel en niebla), portrait (altura catedral con rayos de sol). Sin negro, sin crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)