### PR TITLE
art(paramo): la danta de paramo pastando entre los frailejones (billboard rubber-hose)

### DIFF
--- a/scripts/diag/shot-danta-paramo.mjs
+++ b/scripts/diag/shot-danta-paramo.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/* Captura de LA DANTA DE PÁRAMO en su casa (#/mockups/mundo-paramo-3d):
+   toma ancha, órbita al costado de la danta y vertical de teléfono. */
+import { mkdirSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { chromium } from 'playwright';
+
+const BASE = process.env.BASE_URL || 'http://127.0.0.1:5322';
+const OUT = process.env.OUT_DIR || '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad';
+mkdirSync(OUT, { recursive: true });
+
+function chromiumPath() {
+  if (process.env.PLAYWRIGHT_CHROMIUM_PATH) return process.env.PLAYWRIGHT_CHROMIUM_PATH;
+  try {
+    const w = execSync('which chromium 2>/dev/null', { encoding: 'utf8' }).trim();
+    if (w) return w;
+  } catch { /* sigue */ }
+  return undefined;
+}
+
+/* Browser FRESCO por toma: chromium+swiftshader se cae de a ratos en tomas
+   largas; aislar cada toma en su browser evita que una caída tumbe la tanda. */
+function lanzar() {
+  return chromium.launch({
+    executablePath: chromiumPath(),
+    args: [
+      '--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage',
+      '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader',
+      '--ignore-gpu-blocklist',
+    ],
+  });
+}
+
+async function drag(page, x0, y0, x1, y1, pasos = 24) {
+  await page.mouse.move(x0, y0);
+  await page.mouse.down();
+  for (let i = 1; i <= pasos; i++) {
+    await page.mouse.move(x0 + ((x1 - x0) * i) / pasos, y0 + ((y1 - y0) * i) / pasos);
+    await page.waitForTimeout(16);
+  }
+  await page.mouse.up();
+}
+
+async function shot({ nombre, vw = 1160, vh = 720, orbita = null, esperar = 12000 }) {
+  const browser = await lanzar();
+  const page = await browser.newPage({ viewport: { width: vw, height: vh }, deviceScaleFactor: 1.4 });
+  page.on('pageerror', (e) => console.log(`[${nombre}] pageerror:`, e.message));
+  page.on('console', (m) => {
+    if (m.type() === 'error') console.log(`[${nombre}] console.error:`, m.text().slice(0, 220));
+  });
+  await page.goto(`${BASE}/?ciclo=11#/mockups/mundo-paramo-3d`, { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await page.waitForSelector('canvas', { timeout: 90000 });
+  await page.waitForTimeout(esperar);
+  if (orbita) {
+    await drag(page, vw / 2, vh / 2, vw / 2 + orbita[0], vh / 2 + orbita[1]);
+    await page.waitForTimeout(1800);
+  }
+  await page.screenshot({ path: `${OUT}/${nombre}.png`, timeout: 120000 });
+  console.log('ok', nombre);
+  await browser.close();
+}
+
+async function conReintento(cfg) {
+  try {
+    await shot(cfg);
+  } catch (e) {
+    console.log(`[${cfg.nombre}] cayó (${String(e.message).slice(0, 80)}), reintento…`);
+    await shot(cfg);
+  }
+}
+
+await conReintento({ nombre: 'danta-01-ancha' });
+await conReintento({ nombre: 'danta-02-orbita-der', orbita: [-260, 20] });
+await conReintento({ nombre: 'danta-03-vertical', vw: 390, vh: 844 });
+console.log('LISTO', OUT);

--- a/src/mockups/MundoParamo3D.jsx
+++ b/src/mockups/MundoParamo3D.jsx
@@ -36,6 +36,10 @@
  *     cielo, piedras y un halo que respira. El botón didáctico lo enciende.
  *   - Aves         : un cóndor que planea alto y aves pequeñas del páramo; una
  *     posada en la piedra para la lectura en calma (reduced-motion no las vuela).
+ *   - Danta        : la danta de páramo (Tapirus pinchaque), la vecina grande
+ *     del frailejonal — el SVG rubber-hose de la casa (Danta.jsx) como
+ *     billboard <Html>, pastando entre los frailejones con su reloj de vida
+ *     (pasea / husmea con la trompa en periscopio / reposa).
  *
  * RENDIMIENTO: frailejones/paja/musgo instanciados (pocos draw calls), un Points
  * para el polen, materiales Lambert sin shadow-map. Presupuestos por
@@ -47,7 +51,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { Canvas, useFrame } from '@react-three/fiber';
-import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { OrbitControls, AdaptiveDpr, Html } from '@react-three/drei';
+import { Danta } from '../visual/creatures/Danta.jsx';
 import { CIELOS_HORA, mezclaHex } from '../visual/mundo3d/cielosHoraData.js';
 import { PALETA, mezclar } from '../visual/mundo3d/atmosferaMadre.js';
 import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
@@ -1066,6 +1071,120 @@ function RocioFrio({ tier, reducedMotion, semilla = 17 }) {
   );
 }
 
+/* ── LA DANTA DE PÁRAMO — Tapirus pinchaque, la vecina grande del frailejonal.
+   El mamífero emblemático del páramo, POR FIN en su casa epónima: el SVG
+   rubber-hose de la casa (Danta.jsx — mole lanuda, trompa que tantea, borde
+   blanco de orejas y labios) como billboard <Html>, igual que los vecinos del
+   Bosque Vivo (FaunaBosque). Nada de low-poly: el estándar es el dibujo.
+
+   Su VIDA es un reloj con jitter (el patrón useVidaIdle, local): PASTA
+   paseando unos pasos entre los frailejones y vuelve (movimiento 3D real del
+   billboard, con el bamboleo del andar pesado y el flip de la vuelta), HUSMEA
+   con la trompa en periscopio (su seña-firma) y REPOSA respirando hondo.
+   Nunca el mismo gesto dos veces seguidas. reduced-motion / tier bajo =
+   quieta y digna en su puesto (el fotograma manda, ni un timer vivo). */
+const DANTA_POS = [4.6, alturaParamo(4.6, 4.2) + 0.85, 4.2]; // el claro del frailejonal, al frente-derecha
+const VIDA_DANTA = {
+  primero: 'pasea', // abre caminando: lo primero que se ve es que VIVE
+  descanso: [6000, 13000],
+  momentos: {
+    pasea: { dur: 11000, props: { pose: 'anda' }, paseo: [-2.0, 0, 0.9] },
+    husmea: { dur: 4600, props: { husmea: true } },
+    reposo: { dur: 6200, props: { pose: 'reposo' } },
+  },
+};
+const ESTILO_DANTA = {
+  filter: 'drop-shadow(0 2px 4px rgba(30, 44, 56, 0.4))',
+  pointerEvents: 'none',
+};
+
+/* El reloj de vida (patrón useRelojDeVida de FaunaBosque, local al mockup):
+   descanso → gesto → descanso → otro gesto… con jitter y sin repetir. Gate
+   activo=false (reduced-motion, tier bajo) = ni un timer vivo. */
+function useRelojDanta(activo) {
+  const [momento, setMomento] = useState(/** @type {string|null} */ (null));
+  useEffect(() => {
+    if (!activo) return undefined;
+    let timer = 0;
+    let ultimo = /** @type {string|null} */ (null);
+    let esPrimera = true;
+    const claves = Object.keys(VIDA_DANTA.momentos);
+    const azarMs = (a, b) => a + Math.random() * (b - a);
+    const descansa = () => {
+      setMomento(null);
+      timer = window.setTimeout(gesticula, azarMs(VIDA_DANTA.descanso[0], VIDA_DANTA.descanso[1]));
+    };
+    const gesticula = () => {
+      let m = esPrimera ? VIDA_DANTA.primero : claves[Math.floor(Math.random() * claves.length)];
+      while (m === ultimo) m = claves[Math.floor(Math.random() * claves.length)];
+      esPrimera = false;
+      ultimo = m;
+      setMomento(m);
+      timer = window.setTimeout(descansa, VIDA_DANTA.momentos[m].dur);
+    };
+    // Arranca pronto: la vida se nota en los primeros segundos, no al minuto.
+    timer = window.setTimeout(gesticula, azarMs(1800, 4200));
+    return () => {
+      window.clearTimeout(timer);
+      setMomento(null);
+    };
+  }, [activo]);
+  return momento;
+}
+
+function DantaDelParamo({ tier, reducedMotion }) {
+  const vivo = !reducedMotion && tier !== 'bajo';
+  const momento = useRelojDanta(vivo);
+  const grupo = useRef(/** @type {any} */ (null));
+  const capa = useRef(/** @type {HTMLDivElement|null} */ (null));
+  const paseo = useRef(/** @type {{t0: number|null, dur: number, rumbo: number[]}|null} */ (null));
+
+  const momentoCfg = momento ? VIDA_DANTA.momentos[momento] : null;
+  useEffect(() => {
+    paseo.current = momentoCfg?.paseo
+      ? { t0: null, dur: momentoCfg.dur / 1000, rumbo: momentoCfg.paseo }
+      : null;
+  }, [momentoCfg]);
+
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (!g || !vivo) return;
+    const pw = paseo.current;
+    if (pw) {
+      const t = clock.getElapsedTime();
+      if (pw.t0 == null) pw.t0 = t;
+      const p = Math.min(1, (t - pw.t0) / pw.dur);
+      const ida = Math.sin(p * Math.PI); // sale y VUELVE, suave en las puntas
+      g.position.set(
+        DANTA_POS[0] + pw.rumbo[0] * ida,
+        DANTA_POS[1] + Math.abs(Math.sin(t * 3.4)) * 0.045 * ida, // el bamboleo del andar pesado
+        DANTA_POS[2] + pw.rumbo[2] * ida,
+      );
+      // A la vuelta, el flip: la mole regresa mirando a su puesto.
+      if (capa.current) capa.current.style.transform = p > 0.5 ? 'scaleX(-1)' : '';
+    } else if (g.position.x !== DANTA_POS[0] || g.position.y !== DANTA_POS[1]) {
+      g.position.set(DANTA_POS[0], DANTA_POS[1], DANTA_POS[2]);
+      if (capa.current) capa.current.style.transform = '';
+    }
+  });
+
+  return (
+    <group ref={grupo} position={/** @type {[number, number, number]} */ (DANTA_POS)}>
+      <Html center distanceFactor={13} zIndexRange={[6, 0]} pointerEvents="none">
+        <div
+          ref={capa}
+          aria-hidden="true"
+          data-vecino="danta"
+          data-momento={momento ?? undefined}
+          style={ESTILO_DANTA}
+        >
+          <Danta size={78} animated={vivo} {...(momentoCfg?.props ?? null)} />
+        </div>
+      </Html>
+    </group>
+  );
+}
+
 /* La escena completa (grupo r3f interno; el default la monta en su Canvas). */
 function EscenaParamo({ tier, reducedMotion, fabrica }) {
   const perfil = perfilDeTier(tier);
@@ -1129,6 +1248,12 @@ function EscenaParamo({ tier, reducedMotion, fabrica }) {
       <Quenua pos={[-9.4, alturaParamo(-9.4, 1.6), 1.6]} esc={1.0} />
 
       <NieblaEnganchada n={nNiebla} reducedMotion={reducedMotion} />
+
+      {/* ══ LA DANTA DE PÁRAMO ══ Tapirus pinchaque pastando entre los
+          frailejones: el SVG rubber-hose de la casa como billboard, con su
+          reloj de vida (pasea / husmea / reposa). Su casa epónima. */}
+      <DantaDelParamo tier={tier} reducedMotion={reducedMotion} />
+
       <AvePosada />
       {!reducedMotion && <AvesParamo n={nAves} />}
 
@@ -1143,7 +1268,7 @@ const CSS_PARAMO = `
 .paramo-root { position: relative; width: 100%; height: 100dvh; min-height: 320px; overflow: hidden; background: ${ATMO.fondo}; }
 .paramo-canvas { position: absolute; inset: 0; opacity: 0; transition: opacity 0.9s ease; }
 .paramo-canvas--lista { opacity: 1; }
-.paramo-chrome { position: absolute; inset: 0; pointer-events: none; display: flex; flex-direction: column; justify-content: space-between; }
+.paramo-chrome { position: absolute; inset: 0; z-index: 7; pointer-events: none; display: flex; flex-direction: column; justify-content: space-between; }
 .paramo-titulo { margin: 0; padding: 0.9rem 1rem 0; color: #22303c; text-shadow: 0 1px 8px rgba(226,238,245,0.75); font: 700 1.18rem/1.2 system-ui, sans-serif; letter-spacing: 0.01em; }
 .paramo-titulo small { display: block; font: 500 0.8rem/1.3 system-ui, sans-serif; opacity: 0.84; margin-top: 0.15rem; }
 .paramo-pie { padding: 0 1rem 0.9rem; display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 0.6rem; }


### PR DESCRIPTION
## Que hace

La danta de paramo (*Tapirus pinchaque*) ya tenia su SVG rubber-hose de la casa (`Danta.jsx`, mergeado antes) y su puesto en el Bosque Vivo — pero faltaba en el PARAMO, su habitat eponimo. Este PR la pone a pastar entre los frailejones de `MundoParamo3D`:

- **Billboard `<Html>`** con el SVG existente (el estandar de la casa: dibujo, no low-poly), `distanceFactor` 13, sombra suave.
- **Reloj de vida propio** (patron `useRelojDeVida` de FaunaBosque, local al mockup): *pasea* unos pasos entre los frailejones y vuelve (movimiento 3D real con bamboleo de andar pesado y flip a la vuelta), *husmea* con la trompa en periscopio (su sena-firma), *reposa*. Nunca el mismo gesto dos veces seguidas.
- **reduced-motion / tier bajo** = quieta y digna en su puesto, ni un timer vivo.
- **Fix de capas**: `.paramo-chrome` sube a `z-index: 7` — el boton y la carta didactica siempre pintan sobre los billboards `<Html>` (antes la danta podia taparlos al orbitar).
- Script de captura versionado: `scripts/diag/shot-danta-paramo.mjs` (browser fresco por toma + reintento; swiftshader se cae en tandas largas).

## Verificacion (con los ojos)

- `npm run build:prod` verde (1m11s) y `npm run build` verde (chunk `MundoParamo3D` 29 kB / 8.6 kB gzip). Nota: los mockups NO entran al bundle de `build:prod` (entry `index-prod.html`), asi que la captura se hizo contra la app normal.
- Playwright + chromium del sistema + swiftshader, `?ciclo=11#/mockups/mundo-paramo-3d`, 3 tomas (ancha, orbita, vertical) + zoom al billboard: la danta se ve rubber-hose plena — mole lanuda cafe-oscuro, orejas de borde blanco, ojos de goma con catchlight, cachetes, trompa con puntita palida y naricitas sobre el morro de labios blancos — pastando entre cojines de musgo y frailejones, en momento `pasea`. Sin negro, sin crash, chrome DOM por encima.
- `dist-prod/` restaurado: PR solo fuentes (2 archivos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)