### PR TITLE
feat(agente): Angelita la abeja ES el agente — jubila el colibrí

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1074,7 +1074,7 @@ export default function App() {
   const [currentViewData, setCurrentViewData] = useState(null);
   const [toast, setToast] = useState(null);
   const [lastLogMessage, setLastLogMessage] = useState('');
-  // Transición colibrí (home→conversación): se activa al pasar de la portada
+  // Transición Angelita (home→conversación): se activa al pasar de la portada
   // (dashboard, donde vive el AgentHero) al agente. El overlay va ENCIMA y la
   // conversación monta detrás; al terminar, queda la conversación limpia.
   const [colibriTransition, setColibriTransition] = useState(false);
@@ -1084,7 +1084,7 @@ export default function App() {
   // dashboard → vista_con_initialData → dashboard → misma_vista_otra_vez
   // reusaba el initialData stale (bug latente de UX).
   const navigate = useCallback((view, initialData = null) => {
-    // Transición colibrí solo en home→conversación (la portada con el hero del
+    // Transición Angelita solo en home→conversación (la portada con el hero del
     // agente → el agente). Otras entradas al agente (FAB, tile, notificación)
     // conservan la entrada suave estándar del AgentScreen, sin video.
     if (view === 'agente' && currentView === 'dashboard') {
@@ -3714,7 +3714,7 @@ export default function App() {
 
   return (
     <>
-      {/* Transición colibrí home→conversación (~2s). Encima de todo (z alto);
+      {/* Transición Angelita home→conversación (~2s). Encima de todo (z alto);
           la conversación monta detrás y queda limpia al terminar. */}
       <ColibriTransition active={colibriTransition} onDone={() => setColibriTransition(false)} />
       <NetworkStatusBar />

--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -106,8 +106,8 @@ export default function AgentFab({ onNavigate, pantalla = null }) {
         position: 'fixed',
         bottom: 'max(90px, calc(env(safe-area-inset-bottom) + 90px))',
         right: 14,
-        width: 64,
-        height: 64,
+        width: 84,
+        height: 84,
         borderRadius: '50%',
         // Angelita vuela LIBRE: sin plinto ni borde — una abeja en la esquina,
         // no un icono enfrascado. La legibilidad sobre cualquier fondo la pone
@@ -137,7 +137,7 @@ export default function AgentFab({ onNavigate, pantalla = null }) {
       <span style={{ pointerEvents: 'none', display: 'flex' }} aria-hidden="true">
         <Angelita
           estado={estado}
-          size={62}
+          size={82}
           direccion="izquierda"
           className={responseReady ? 'agt-avatar-glow' : undefined}
           title="Angelita, la asistente de Chagra"

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3595,7 +3595,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             Angelita, "jubila el colibrí" — operador). */}
         <ChagraAgentAvatar
           state={state === STATE_RECORDING ? 'listening' : (state === STATE_THINKING || isVoicePlaying) ? 'thinking' : 'idle'}
-          size={36}
+          size={52}
           onDoubleClick={async () => {
             if (isSpeaking() || ttsEnabled) {
               stop(); setTtsEnabled(false); agentSounds.cancel(); return;
@@ -4096,7 +4096,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               }}
             >
               <ChagraAgentAvatar
-                size={38}
+                size={46}
                 state={state === STATE_THINKING ? 'thinking' : 'idle'}
                 ariaLabel="Enviar al agente"
               />

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -466,7 +466,7 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
       {!isUser && (
         <div className="v3-byline" aria-hidden="true">
           <span className={`v3-byline-avatar${isStreaming ? ' is-streaming' : ''}`}>
-            <ChagraAgentAvatar state={agentState} size={22} ariaLabel="Chagra IA" />
+            <ChagraAgentAvatar state={agentState} size={30} ariaLabel="Chagra IA" />
           </span>
           <span>Chagra</span>
         </div>

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -281,7 +281,7 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
             <span className="v3-byline-avatar is-streaming">
               <ChagraAgentAvatar
                 state="thinking"
-                size={22}
+                size={30}
                 ariaLabel={MSG.agente.pensandoAria}
               />
             </span>

--- a/src/components/Aprende/InsightProactivoCard.jsx
+++ b/src/components/Aprende/InsightProactivoCard.jsx
@@ -72,7 +72,7 @@ function ChagraInsightFrame({ children, titulo }) {
             className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center bg-slate-900/70"
             style={{ border: '1px solid rgba(var(--t-accent-rgb),0.5)' }}
           >
-            <ChagraAgentAvatar state="idle" size={22} ariaLabel="Chagra" />
+            <ChagraAgentAvatar state="idle" size={28} ariaLabel="Chagra" />
           </span>
           {/* Glifo de la mano de Chagra — hereda el acento del tema */}
           <span

--- a/src/components/BienvenidaFinca.jsx
+++ b/src/components/BienvenidaFinca.jsx
@@ -3,7 +3,7 @@
    exportarse junto al componente (mismo patrón que NotifPermissionPrompt). */
 import React, { useEffect, useRef, useState } from 'react';
 import { Mic, Camera, BadgeCheck, MapPin, ArrowRight, Volume2, Sparkles, Glasses, Share, Download, WifiOff, Save, Smartphone, Check } from 'lucide-react';
-import ChagraAgentAvatarColibri from './ChagraAgentAvatarColibri';
+import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
 import usePwaInstall from '../hooks/usePwaInstall';
 import { MSG } from '../config/messages.js';
 
@@ -260,7 +260,7 @@ export default function BienvenidaFinca({ onUbicar, onClose, onExplorarEjemplo =
         {paso === 0 && (
           <>
             <div className="bienvenida-item bienvenida-flotar" style={{ '--bv-delay': '0ms' }}>
-              <ChagraAgentAvatarColibri size={152} state="idle" ariaLabel="Colibrí de Chagra" />
+              <ChagraAgentAvatarAngelita size={188} state="idle" ariaLabel="Angelita, la abeja de Chagra" />
             </div>
             <div className="bienvenida-item flex flex-col gap-3" style={{ '--bv-delay': '120ms' }}>
               <p className="text-xs font-bold uppercase tracking-[0.2em] text-emerald-400">

--- a/src/components/ChagraAgentAvatar.jsx
+++ b/src/components/ChagraAgentAvatar.jsx
@@ -1,4 +1,3 @@
-import ChagraAgentAvatarColibri from './ChagraAgentAvatarColibri';
 import ChagraAgentAvatarMaiz from './ChagraAgentAvatarMaiz';
 import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
 import useAgentAvatarType from '../hooks/useAgentAvatarType';
@@ -9,23 +8,24 @@ import useAgentAvatarType from '../hooks/useAgentAvatarType';
  * los call-sites siguen usando `<ChagraAgentAvatar .../>` sin cambios.
  *
  * Decisiones del operador:
- *   - 2026-05-27: usuario debe poder elegir entre colibrí o maíz.
- *   - 2026-05-28: reemplazar el R3F que "desatina con todo lo que ya está".
+ *   - 2026-05-27: usuario debe poder elegir avatar.
  *   - 2026-07-16: "Angelita como el agente, jubila el colibrí". La cara del
  *     agente pasa a ser Angelita (la abeja angelita, con idle-cerebro, mirada
- *     y lip-sync). El slug guardado 'colibri' (el default histórico) delega en
- *     ella sin migración; el colibrí NO sale del código: sigue de polinizador
- *     decorativo en los mundos 3D y como preferencia explícita 'colibri_svg'.
+ *     y lip-sync).
+ *   - 2026-07-18: el colibrí sale TAMBIÉN de las opciones ("solo abejita").
+ *     Los slugs viejos 'colibri'/'colibri_svg' migran a Angelita en el hook,
+ *     sin acción del usuario. El colibrí queda de fauna decorativa en los
+ *     mundos 3D — nunca como cara del agente.
  *
  * UI de cambio vive en ProfileScreen → Apariencia → Avatar del agente.
  *
  * Mismas props que los avatares hijos: state, size, withLabel, onClick,
- * onDoubleClick, glow, className, ariaLabel.
+ * onDoubleClick, glow, className, ariaLabel (+ visema/confianza que
+ * Angelita entiende y el maíz ignora).
  */
 export default function ChagraAgentAvatar(props) {
     const [type] = useAgentAvatarType();
     if (type === 'maiz') return <ChagraAgentAvatarMaiz {...props} />;
-    if (type === 'colibri_svg') return <ChagraAgentAvatarColibri {...props} />;
-    // default (+ slug histórico 'colibri') → Angelita, el agente de Chagra.
+    // default → Angelita, el agente de Chagra.
     return <ChagraAgentAvatarAngelita {...props} />;
 }

--- a/src/components/ChagraAgentAvatarAngelita.jsx
+++ b/src/components/ChagraAgentAvatarAngelita.jsx
@@ -36,12 +36,19 @@ export default function ChagraAgentAvatarAngelita({
     glow = false,
     className = '',
     ariaLabel = 'Chagra IA',
+    // Extras que solo Angelita entiende (los avatares hermanos los ignoran):
+    // visema 'V1'..'V4' de useLipSync (lip-sync al hablar) y confianza del
+    // modo científico (0..1 o 'alta'|'media'|'baja' → anillo de certeza).
+    visema = null,
+    confianza = null,
 }) {
     const estado = ESTADO_DE_STATE[state] || 'acompana';
     const abeja = (
         <Angelita
             estado={estado}
             size={size}
+            visema={visema}
+            confianza={confianza}
             className={`${glow ? 'agt-avatar-glow ' : ''}${className}`.trim() || undefined}
             title={ariaLabel}
         />

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -6,7 +6,7 @@ import { setCurrentOperator } from '../services/operatorIdentityService';
 import { setActiveTenantId } from '../services/tenantContext';
 import { version as APP_VERSION } from '../../package.json';
 import ChagraGrowLoader from './ChagraGrowLoader';
-import ChagraAgentAvatarColibri from './ChagraAgentAvatarColibri';
+import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
 import LegalLinks from './LegalLinks';
 import WelcomeStatsHero from './WelcomeStatsHero';
 import useOllamaWarmStore from '../store/useOllamaWarmStore';
@@ -196,10 +196,10 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
               aria-hidden="true"
               className="absolute inset-0 rounded-full ring-1 ring-muzo/20 animate-pulse"
             />
-            <ChagraAgentAvatarColibri
+            <ChagraAgentAvatarAngelita
               state="idle"
-              size={92}
-              ariaLabel="Colibrí Barbudito, símbolo de Chagra"
+              size={108}
+              ariaLabel="Angelita, la abeja de Chagra"
             />
           </div>
 

--- a/src/components/OnboardingCondensado.jsx
+++ b/src/components/OnboardingCondensado.jsx
@@ -13,7 +13,7 @@ import {
   AlertCircle,
   SkipForward,
 } from 'lucide-react';
-import ChagraAgentAvatarColibri from './ChagraAgentAvatarColibri';
+import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
 import AvatarSelector from './Settings/AvatarSelector';
 import { useGeolocation } from '../hooks/useGeolocation';
 import {
@@ -550,7 +550,7 @@ export default function OnboardingCondensado({
           <>
             <div className="flex items-center gap-4">
               <div className="shrink-0">
-                <ChagraAgentAvatarColibri size={72} state="idle" ariaLabel="Colibrí de Chagra" />
+                <ChagraAgentAvatarAngelita size={96} state="idle" ariaLabel="Angelita, la abeja de Chagra" />
               </div>
               <div className="min-w-0">
                 <h1 className="text-2xl font-black leading-tight text-slate-100">
@@ -934,7 +934,7 @@ export default function OnboardingCondensado({
         {/* ═══ LISTO ═══ */}
         {paso === 3 && (
           <div className="flex-1 flex flex-col items-center justify-center text-center gap-5">
-            <ChagraAgentAvatarColibri size={132} state="speaking" ariaLabel="Colibrí de Chagra" />
+            <ChagraAgentAvatarAngelita size={168} state="speaking" ariaLabel="Angelita, la abeja de Chagra" />
             <div className="flex flex-col gap-2">
               <h1 className="text-3xl font-black leading-tight text-slate-100">
                 Su finca está lista 🌱

--- a/src/components/Settings/AgentAvatarSelector.jsx
+++ b/src/components/Settings/AgentAvatarSelector.jsx
@@ -1,38 +1,29 @@
 import { Check } from 'lucide-react';
 import useAgentAvatarType from '../../hooks/useAgentAvatarType';
-import ChagraAgentAvatarColibri from '../ChagraAgentAvatarColibri';
 import ChagraAgentAvatarAngelita from '../ChagraAgentAvatarAngelita';
 import ChagraAgentAvatarMaiz from '../ChagraAgentAvatarMaiz';
 
 /**
  * AgentAvatarSelector — selector visual para el avatar del agente IA.
  *
- * 3 opciones: Angelita la abeja (default), colibrí ilustrado SVG, o planta
- * de maíz. Persiste vía useAgentAvatarType (localStorage
- * `chagra:agent-avatar-type`). Cambio inmediato — afecta a todas las
- * instancias del avatar en la app.
+ * 2 opciones: Angelita la abeja (default) o planta de maíz. Persiste vía
+ * useAgentAvatarType (localStorage `chagra:agent-avatar-type`). Cambio
+ * inmediato — afecta a todas las instancias del avatar en la app.
  *
- * 2026-07-16 (operador): "Angelita como el agente, jubila el colibrí". La
- * opción default pasa a ser Angelita; conserva el slug guardado 'colibri'
- * (default histórico) para que nadie necesite migración. El colibrí
- * ilustrado sigue disponible como preferencia explícita.
+ * 2026-07-16 (operador): "Angelita como el agente, jubila el colibrí".
+ * 2026-07-18 (operador): el colibrí sale también de las opciones — "solo
+ * abejita". Los slugs viejos 'colibri'/'colibri_svg' migran a 'angelita'
+ * en el hook, sin acción del usuario.
  */
 export default function AgentAvatarSelector() {
     const [type, setType] = useAgentAvatarType();
 
     const OPTIONS = [
         {
-            // Slug histórico 'colibri' = el default de siempre; hoy es Angelita.
-            id: 'colibri',
+            id: 'angelita',
             label: 'Angelita, la abeja',
             sub: 'La vecina que sabe de finca (recomendado)',
             Component: ChagraAgentAvatarAngelita,
-        },
-        {
-            id: 'colibri_svg',
-            label: 'Colibrí ilustrado',
-            sub: 'SVG botánico animado',
-            Component: ChagraAgentAvatarColibri,
         },
         {
             id: 'maiz',
@@ -50,7 +41,7 @@ export default function AgentAvatarSelector() {
                     Elige cómo se ve la IA en la app. Cambio inmediato.
                 </p>
             </div>
-            <div className="grid grid-cols-3 gap-2.5">
+            <div className="grid grid-cols-2 gap-2.5">
                 {OPTIONS.map((opt) => {
                     const selected = type === opt.id;
                     return (
@@ -70,7 +61,7 @@ export default function AgentAvatarSelector() {
                                     <Check size={12} strokeWidth={3} aria-hidden="true" />
                                 </span>
                             )}
-                            <opt.Component state={selected ? 'thinking' : 'idle'} size={60} onDoubleClick={() => {}} ariaLabel={opt.label} />
+                            <opt.Component state={selected ? 'thinking' : 'idle'} size={84} onDoubleClick={() => {}} ariaLabel={opt.label} />
                             <div className="text-center">
                                 <p className="text-xs sm:text-sm font-bold text-slate-100 leading-tight">{opt.label}</p>
                                 <p className="text-[10px] text-slate-500 mt-0.5 leading-tight">{opt.sub}</p>

--- a/src/components/Settings/__tests__/AgentAvatarSelector.smoke.test.jsx
+++ b/src/components/Settings/__tests__/AgentAvatarSelector.smoke.test.jsx
@@ -7,17 +7,17 @@ describe('AgentAvatarSelector smoke', () => {
         localStorage.clear();
     });
 
-    it('renderiza 3 opciones angelita + colibri-svg + maiz', () => {
+    it('renderiza 2 opciones: angelita + maiz (el colibrí jubiló)', () => {
         render(<AgentAvatarSelector />);
         expect(screen.getByText('Angelita, la abeja', { selector: 'p' })).toBeInTheDocument();
-        expect(screen.getByText('Colibrí ilustrado')).toBeInTheDocument();
         expect(screen.getByText('Planta de maíz')).toBeInTheDocument();
+        expect(screen.queryByText(/colibrí/i)).toBeNull();
     });
 
-    it('angelita (slug historico colibri) seleccionada por default', () => {
+    it('angelita seleccionada por default', () => {
         render(<AgentAvatarSelector />);
-        const colibriBtn = screen.getByText('Angelita, la abeja', { selector: 'p' }).closest('button');
-        expect(colibriBtn).toHaveAttribute('aria-pressed', 'true');
+        const angelitaBtn = screen.getByText('Angelita, la abeja', { selector: 'p' }).closest('button');
+        expect(angelitaBtn).toHaveAttribute('aria-pressed', 'true');
     });
 
     it('click en maiz cambia la preferencia y persiste en localStorage', () => {
@@ -26,16 +26,8 @@ describe('AgentAvatarSelector smoke', () => {
         fireEvent.click(maizBtn);
         expect(maizBtn).toHaveAttribute('aria-pressed', 'true');
         expect(localStorage.getItem('chagra:agent-avatar-type')).toBe('maiz');
-        const colibriBtn = screen.getByText('Angelita, la abeja', { selector: 'p' }).closest('button');
-        expect(colibriBtn).toHaveAttribute('aria-pressed', 'false');
-    });
-
-    it('click en colibri-svg cambia la preferencia y persiste', () => {
-        render(<AgentAvatarSelector />);
-        const svgBtn = screen.getByText('Colibrí ilustrado').closest('button');
-        fireEvent.click(svgBtn);
-        expect(svgBtn).toHaveAttribute('aria-pressed', 'true');
-        expect(localStorage.getItem('chagra:agent-avatar-type')).toBe('colibri_svg');
+        const angelitaBtn = screen.getByText('Angelita, la abeja', { selector: 'p' }).closest('button');
+        expect(angelitaBtn).toHaveAttribute('aria-pressed', 'false');
     });
 
     it('localStorage maiz preselecciona maiz al montar', () => {
@@ -45,10 +37,17 @@ describe('AgentAvatarSelector smoke', () => {
         expect(maizBtn).toHaveAttribute('aria-pressed', 'true');
     });
 
-    it('localStorage colibri_svg preselecciona el ilustrado al montar', () => {
+    it('slug legacy colibri_svg en localStorage migra a angelita seleccionada', () => {
         localStorage.setItem('chagra:agent-avatar-type', 'colibri_svg');
         render(<AgentAvatarSelector />);
-        const svgBtn = screen.getByText('Colibrí ilustrado').closest('button');
-        expect(svgBtn).toHaveAttribute('aria-pressed', 'true');
+        const angelitaBtn = screen.getByText('Angelita, la abeja', { selector: 'p' }).closest('button');
+        expect(angelitaBtn).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('slug legacy colibri en localStorage migra a angelita seleccionada', () => {
+        localStorage.setItem('chagra:agent-avatar-type', 'colibri');
+        render(<AgentAvatarSelector />);
+        const angelitaBtn = screen.getByText('Angelita, la abeja', { selector: 'p' }).closest('button');
+        expect(angelitaBtn).toHaveAttribute('aria-pressed', 'true');
     });
 });

--- a/src/components/WelcomeStatsHero.jsx
+++ b/src/components/WelcomeStatsHero.jsx
@@ -202,8 +202,8 @@ const TONE_CLASSES = {
 };
 
 /**
- * AgentColibriChip — colibri clickable que abre el agente desde el home.
- * Default idle (vuelo estacionario), hover thinking (libando), click navega.
+ * AgentAngelitaChip — Angelita clickable que abre el agente desde el home.
+ * Default idle (vuelo estacionario), hover thinking, click navega.
  * Se anima en mouse over para invitar al click y en touch press en mobile.
  *
  * Bug móvil "Abrir Chagra IA no abre el overlay" (2026-06-20): el botón solo
@@ -217,7 +217,7 @@ const TONE_CLASSES = {
  * para suprimir el ghost-click, deduplicando con `navigatedByTouchRef` para que
  * el click sintético —si igual llega— no navegue dos veces.
  */
-function AgentColibriChip({ onNavigate, size = 26 }) {
+function AgentAngelitaChip({ onNavigate, size = 36 }) {
   const [hover, setHover] = useState(false);
   const [pressed, setPressed] = useState(false);
   const interactive = typeof onNavigate === 'function';
@@ -447,12 +447,12 @@ export default function WelcomeStatsHero({ mode = 'post-login', onNavigate = und
         aria-label="Impacto de Chagra"
       >
         <div className="flex items-center justify-between gap-2 px-1">
-          {/* Header con colibri clickable → abre el agente desde el home.
-              Hover anima a state thinking (libando), click navega y muestra el
+          {/* Header con Angelita clickable → abre el agente desde el home.
+              Hover anima a state thinking, click navega y muestra el
               tap feedback con scale. Si no hay onNavigate, queda inerte como
               header decorativo (ej. en pre-login). */}
           <h2 className="flex items-center gap-2 text-[10px] sm:text-xs font-black uppercase tracking-[0.2em] text-slate-400 min-w-0">
-            <AgentColibriChip onNavigate={onNavigate} size={collapsed ? 20 : 26} />
+            <AgentAngelitaChip onNavigate={onNavigate} size={collapsed ? 28 : 36} />
             <span className="truncate">Chagra · impacto</span>
           </h2>
           <div className="flex items-center gap-2 shrink-0">
@@ -609,7 +609,7 @@ export default function WelcomeStatsHero({ mode = 'post-login', onNavigate = und
             <div className="flex items-center justify-between gap-2 pt-4">
               <div>
                 <h2 className="flex items-center gap-2.5 text-base sm:text-lg font-black uppercase tracking-wider text-slate-200">
-                  <AgentColibriChip onNavigate={onNavigate} size={38} />
+                  <AgentAngelitaChip onNavigate={onNavigate} size={48} />
                   Chagra · impacto
                 </h2>
                 {isPreLogin && (

--- a/src/components/__tests__/ChagraAgentAvatar.test.jsx
+++ b/src/components/__tests__/ChagraAgentAvatar.test.jsx
@@ -1,43 +1,50 @@
 /**
- * ChagraAgentAvatar — task #122.
+ * ChagraAgentAvatar — task #122 + "solo abejita" (2026-07-18).
  *
- * Cubre las extensiones añadidas para el sistema global de notificaciones:
- *   - `glow` prop agrega la clase `chagra-glow` al SVG raíz.
+ * Cubre las extensiones del sistema global de notificaciones sobre el avatar
+ * default del wrapper, que hoy es ANGELITA (la abeja agente):
+ *   - `glow` prop agrega la clase `agt-avatar-glow` al SVG de Angelita.
  *   - `onDoubleClick` se invoca al doble-click del wrapper button.
  *   - a11y: aria-label custom + role="img" + tooltip title presente cuando
  *     hay onDoubleClick.
- *
- * 2026-05-28: el avatar default del wrapper cambió a la foto-realista
- * (ChagraAgentAvatarColibriPhoto). Estos tests verifican la rama SVG, así
- * que el beforeEach fuerza `colibri_svg` en localStorage. La rama foto
- * tiene su propio smoke test (ChagraAgentAvatarColibriPhoto si se añade).
+ *   - migración: los slugs viejos 'colibri'/'colibri_svg' en localStorage
+ *     renderizan Angelita (el colibrí jubiló del rol de agente).
  */
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, test, expect, vi, afterEach } from 'vitest';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import ChagraAgentAvatarMaiz from '../ChagraAgentAvatarMaiz';
 
-describe('ChagraAgentAvatar — task #122 glow + double-click', () => {
-  beforeEach(() => {
-    localStorage.setItem('chagra:agent-avatar-type', 'colibri_svg');
-  });
+describe('ChagraAgentAvatar — Angelita default: glow + double-click + migración', () => {
   afterEach(() => {
     localStorage.clear();
   });
-  test('por defecto NO incluye clase chagra-glow', () => {
+  test('por defecto renderiza Angelita SIN clase agt-avatar-glow', () => {
     const { container } = render(<ChagraAgentAvatar state="idle" />);
-    const svg = container.querySelector('svg.chagra-agent-avatar');
+    const svg = container.querySelector('svg.agt-angelita');
     expect(svg).toBeInTheDocument();
-    expect(svg.classList.contains('chagra-glow')).toBe(false);
+    expect(svg.classList.contains('agt-avatar-glow')).toBe(false);
   });
 
-  test('con prop glow={true} agrega clase chagra-glow al SVG', () => {
+  test('con prop glow={true} agrega clase agt-avatar-glow al SVG', () => {
     const { container } = render(<ChagraAgentAvatar state="idle" glow />);
-    const svg = container.querySelector('svg.chagra-agent-avatar');
+    const svg = container.querySelector('svg.agt-angelita');
     expect(svg).toBeInTheDocument();
-    expect(svg.classList.contains('chagra-glow')).toBe(true);
+    expect(svg.classList.contains('agt-avatar-glow')).toBe(true);
+  });
+
+  test('slug legacy colibri_svg en localStorage TAMBIÉN renderiza Angelita', () => {
+    localStorage.setItem('chagra:agent-avatar-type', 'colibri_svg');
+    const { container } = render(<ChagraAgentAvatar state="idle" />);
+    expect(container.querySelector('svg.agt-angelita')).toBeInTheDocument();
+  });
+
+  test('slug legacy colibri en localStorage TAMBIÉN renderiza Angelita', () => {
+    localStorage.setItem('chagra:agent-avatar-type', 'colibri');
+    const { container } = render(<ChagraAgentAvatar state="idle" />);
+    expect(container.querySelector('svg.agt-angelita')).toBeInTheDocument();
   });
 
   test('sin onClick ni onDoubleClick renderiza solo el SVG (no button)', () => {
@@ -79,28 +86,42 @@ describe('ChagraAgentAvatar — task #122 glow + double-click', () => {
     ).toBeInTheDocument();
   });
 
-  test('a11y: tooltip title aparece cuando hay onDoubleClick', () => {
-    render(<ChagraAgentAvatar state="idle" onDoubleClick={() => {}} />);
+  test('a11y: tooltip title del button refleja el ariaLabel', () => {
+    render(
+      <ChagraAgentAvatar
+        state="idle"
+        onDoubleClick={() => {}}
+        ariaLabel="Chagra IA — doble click silencia la voz"
+      />,
+    );
     const btn = screen.getByRole('button');
     expect(btn).toHaveAttribute('title', expect.stringMatching(/doble click/i));
   });
 
-  test('SVG aplica la clase de estado correspondiente', () => {
+  test('el state del agente se mapea al estado de Angelita (data-agt-estado)', () => {
     const { container, rerender } = render(<ChagraAgentAvatar state="thinking" />);
     expect(
-      container.querySelector('svg.chagra-state-thinking'),
+      container.querySelector('svg[data-agt-estado="pensando"]'),
     ).toBeInTheDocument();
     rerender(<ChagraAgentAvatar state="listening" />);
     expect(
-      container.querySelector('svg.chagra-state-listening'),
+      container.querySelector('svg[data-agt-estado="escuchando"]'),
+    ).toBeInTheDocument();
+    rerender(<ChagraAgentAvatar state="speaking" />);
+    expect(
+      container.querySelector('svg[data-agt-estado="respondiendo"]'),
+    ).toBeInTheDocument();
+    rerender(<ChagraAgentAvatar state="idle" />);
+    expect(
+      container.querySelector('svg[data-agt-estado="acompana"]'),
     ).toBeInTheDocument();
   });
 
   test('glow + state coexisten sin conflicto', () => {
     const { container } = render(<ChagraAgentAvatar state="speaking" glow />);
-    const svg = container.querySelector('svg.chagra-agent-avatar');
-    expect(svg.classList.contains('chagra-state-speaking')).toBe(true);
-    expect(svg.classList.contains('chagra-glow')).toBe(true);
+    const svg = container.querySelector('svg.agt-angelita');
+    expect(svg.getAttribute('data-agt-estado')).toBe('respondiendo');
+    expect(svg.classList.contains('agt-avatar-glow')).toBe(true);
   });
 });
 

--- a/src/components/agent/ColibriTransition.jsx
+++ b/src/components/agent/ColibriTransition.jsx
@@ -1,49 +1,39 @@
 import { useEffect, useRef, useState } from 'react';
-import { colibriRealActivo } from '../../config/colibriFlag';
-import { BarbuditoFlor } from '../colibri/Barbudito';
+import Angelita from '../../visual/agente/Angelita';
 
 /**
- * ColibriTransition — transición HIPER LINDA pero LIMPIA del home a la
- * conversación (~2–3s).
+ * Transición home → conversación (~2s): ANGELITA, la abeja agente.
  *
  * Al enviar desde el hero del home, en vez de un corte seco hacia AgentScreen,
- * aparece a pantalla completa sobre un fondo oscuro suave, y se desvanece
- * dejando la conversación montada detrás. Llama la atención sin saltos ni flash.
+ * Angelita aparece a pantalla completa sobre un fondo oscuro suave — grande,
+ * invitándolo a la conversación ('invita': se inclina y hace "venga" con la
+ * manita) — y el overlay se desvanece dejando la conversación montada detrás.
  *
- * DOS modos (según la flag VITE_COLIBRI, dev-only):
- *   - Flag ON (colibrí REAL): el CLIP DE LA FLOR del frailejón (~2.5s,
- *     `flower-transition.mp4`, H.264 SIN alpha → corre en TODO navegador incl.
- *     iOS), centrado y grande, con el barbudito tomando néctar; el video trae su
- *     propio fade in/out y el overlay hace además un fade suave hacia la pantalla
- *     del agente. El operador rechazó el recuadro de la flor en el HOME, pero lo
- *     quiere AQUÍ, en la transición, donde se ve claro y entero.
- *   - Flag OFF (default, prod): el colibrí entra en VIDEO
- *     (`/avatar/colibri-transition.webm`) como hasta ahora; si el video falla
- *     o no soporta WebM, cae al still.
+ * 2026-07-18 (operador): "solo abejita". Este overlay mostraba el VIDEO del
+ * colibrí (webm foto-realista) como cara del agente; el colibrí queda jubilado
+ * del rol de asistente (fauna decorativa en los mundos 3D, nada más) y la
+ * transición pasa a ser Angelita — la misma del FAB, el chat y el hero.
+ * El archivo conserva su nombre para no mover imports; el componente exportado
+ * mantiene el contrato de siempre.
  *
- * Contrato común:
+ * Contrato:
  *   - Duración total acotada: tras `HOLD_MS` el overlay hace fade-out
  *     (`FADE_MS`) y se desmonta.
- *   - prefers-reduced-motion → SIN animación pesada: solo un fade corto.
- *   - No bloquea el montaje de la conversación: el overlay va ENCIMA; cuando se
- *     va, la conversación ya está lista detrás (cero parpadeo).
+ *   - prefers-reduced-motion → SIN animación pesada: fade corto y Angelita
+ *     quieta (fotograma digno, animated=false).
+ *   - No bloquea el montaje de la conversación: el overlay va ENCIMA; cuando
+ *     se va, la conversación ya está lista detrás (cero parpadeo).
  *   - Cleanup total de timers al desmontar.
+ *   - Frugal: SVG + CSS, cero video, cero red.
  *
  * Exportadas las duraciones para tests y para sincronizar la navegación.
  */
 
-export const COLIBRI_TRANSITION_HOLD_MS = 1500; // video visible antes del fade
+export const COLIBRI_TRANSITION_HOLD_MS = 1500; // Angelita visible antes del fade
 export const COLIBRI_TRANSITION_FADE_MS = 480; // fade-out suave
 export const COLIBRI_TRANSITION_TOTAL_MS = COLIBRI_TRANSITION_HOLD_MS + COLIBRI_TRANSITION_FADE_MS;
 // Reduced-motion: transición mínima y sobria, sin animación.
 export const COLIBRI_TRANSITION_REDUCED_MS = 360;
-// Clip de la FLOR (flag ON): el mp4 dura ~2.5s con su propio fade in/out.
-// Lo dejamos correr casi entero (2.4s) y luego el overlay hace su fade-out.
-export const COLIBRI_TRANSITION_FLOR_HOLD_MS = 2400;
-
-// ¿Transición con el clip de la FLOR del frailejón (barbudito libando néctar)?
-// Gateado por VITE_COLIBRI (dev-only). Se evalúa una sola vez (flag de build).
-const COLIBRI_REAL = colibriRealActivo();
 
 function prefersReducedMotion() {
   return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
@@ -52,64 +42,42 @@ function prefersReducedMotion() {
 }
 
 const CSS = `
-  .colibri-tx {
+  .agente-tx {
     position: fixed; inset: 0; z-index: 9999;
-    display: flex; align-items: center; justify-content: center;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 14px;
     background: radial-gradient(120% 120% at 50% 45%, #0e2a2e 0%, #0a1118 55%, #070b10 100%);
     transition: opacity ${COLIBRI_TRANSITION_FADE_MS}ms cubic-bezier(0.22,0.61,0.36,1);
     opacity: 1; pointer-events: none;
   }
-  .colibri-tx.is-leaving { opacity: 0; }
-  .colibri-tx-video {
-    width: min(72vw, 360px); height: min(72vw, 360px);
-    max-width: 80vh; max-height: 80vh;
-    border-radius: 50%; object-fit: cover; object-position: center 45%;
-    box-shadow: 0 0 70px 8px rgba(25,201,154,0.35), 0 0 0 2px rgba(25,201,154,0.45);
-    animation: colibri-tx-in 0.5s cubic-bezier(0.22,0.61,0.36,1) both;
-    background: #0f172a;
+  .agente-tx.is-leaving { opacity: 0; }
+  .agente-tx-abeja {
+    animation: agente-tx-in 0.5s cubic-bezier(0.34,1.56,0.64,1) both;
+    filter: drop-shadow(0 0 44px rgba(240,178,60,0.32)) drop-shadow(0 6px 14px rgba(7,11,16,0.6));
+    line-height: 0;
   }
-  /* Fallback (sin video / reduced-motion): orbe sobrio con el still del colibrí */
-  .colibri-tx-still {
-    width: min(58vw, 240px); height: min(58vw, 240px);
-    border-radius: 50%; object-fit: cover; object-position: center 42%;
-    box-shadow: 0 0 50px 4px rgba(25,201,154,0.28), 0 0 0 2px rgba(25,201,154,0.4);
-    background: #0f172a;
+  .agente-tx-nombre {
+    font: 800 0.82rem/1 system-ui, sans-serif;
+    letter-spacing: 0.22em; text-transform: uppercase;
+    color: rgba(240, 216, 160, 0.85);
+    animation: agente-tx-in 0.6s 0.12s cubic-bezier(0.22,0.61,0.36,1) both;
   }
-  @keyframes colibri-tx-in {
-    from { opacity: 0; transform: scale(0.82); }
-    to   { opacity: 1; transform: scale(1); }
-  }
-  /* Clip de la FLOR (flag ON): grande y centrado, casi cubriendo, con esquinas
-     redondeadas y una viñeta suave que funde sus bordes con el fondo oscuro. El
-     video trae su propio fade interno; aquí lo asentamos. */
-  .colibri-tx-flor {
-    width: min(86vw, 560px); height: min(86vw, 560px);
-    max-width: 92vh; max-height: 92vh;
-    border-radius: 28px; object-fit: cover; object-position: center 50%;
-    box-shadow: 0 18px 60px rgba(0,0,0,0.5), 0 0 0 1px rgba(190,242,100,0.18);
-    animation: colibri-tx-in 0.55s cubic-bezier(0.22,0.61,0.36,1) both;
-    background: #0d1f17;
-  }
-  .colibri-tx-flor-wrap { position: relative; line-height: 0; }
-  /* viñeta para fundir el clip con el fondo (no un recuadro duro) */
-  .colibri-tx-flor-wrap::after {
-    content: ''; position: absolute; inset: 0; pointer-events: none;
-    border-radius: 28px;
-    box-shadow: inset 0 0 60px 16px rgba(7,11,16,0.55);
+  @keyframes agente-tx-in {
+    from { opacity: 0; transform: scale(0.78) translateY(10px); }
+    to   { opacity: 1; transform: scale(1) translateY(0); }
   }
   @media (prefers-reduced-motion: reduce) {
-    .colibri-tx-video, .colibri-tx-still, .colibri-tx-flor { animation: none !important; }
-    .colibri-tx { transition: opacity ${COLIBRI_TRANSITION_REDUCED_MS}ms linear; }
+    .agente-tx-abeja, .agente-tx-nombre { animation: none !important; }
+    .agente-tx { transition: opacity ${COLIBRI_TRANSITION_REDUCED_MS}ms linear; }
   }
 `;
 
 /**
- * Overlay interno. Se monta/desmonta por `active` desde el padre, así su estado
- * (leaving/videoFailed) arranca limpio en cada transición sin resets manuales.
+ * Overlay interno. Se monta/desmonta por `active` desde el padre, así su
+ * estado (leaving) arranca limpio en cada transición sin resets manuales.
  */
-function ColibriOverlay({ onDone }) {
+function AngelitaOverlay({ onDone }) {
   const [leaving, setLeaving] = useState(false);
-  const [videoFailed, setVideoFailed] = useState(false);
   const doneRef = useRef(null);
 
   // ref-latest del callback fuera de render (react-hooks/refs).
@@ -119,13 +87,9 @@ function ColibriOverlay({ onDone }) {
     const reduce = prefersReducedMotion();
     const timers = [];
     if (reduce) {
-      // Fade simple y corto, sin video ni cruce.
+      // Fade simple y corto, sin coreografía.
       timers.push(setTimeout(() => setLeaving(true), 40));
       timers.push(setTimeout(() => doneRef.current?.(), COLIBRI_TRANSITION_REDUCED_MS + 60));
-    } else if (COLIBRI_REAL) {
-      // Clip de la flor: lo dejamos correr casi entero (~2.4s) y luego el fade.
-      timers.push(setTimeout(() => setLeaving(true), COLIBRI_TRANSITION_FLOR_HOLD_MS));
-      timers.push(setTimeout(() => doneRef.current?.(), COLIBRI_TRANSITION_FLOR_HOLD_MS + COLIBRI_TRANSITION_FADE_MS));
     } else {
       timers.push(setTimeout(() => setLeaving(true), COLIBRI_TRANSITION_HOLD_MS));
       timers.push(setTimeout(() => doneRef.current?.(), COLIBRI_TRANSITION_TOTAL_MS));
@@ -134,38 +98,26 @@ function ColibriOverlay({ onDone }) {
   }, []);
 
   const reduce = prefersReducedMotion();
-  const showVideo = !COLIBRI_REAL && !reduce && !videoFailed;
 
   return (
     <div
-      className={`colibri-tx${leaving ? ' is-leaving' : ''}`}
+      className={`agente-tx${leaving ? ' is-leaving' : ''}`}
       aria-hidden="true"
-      data-testid="colibri-transition"
+      data-testid="agente-transition"
     >
       <style>{CSS}</style>
-      {COLIBRI_REAL && !reduce ? (
-        // Clip de la FLOR del frailejón: el barbudito tomando néctar, grande y
-        // centrado, con fade suave. H.264 sin alpha → universal (incl. iOS).
-        <span className="colibri-tx-flor-wrap">
-          <BarbuditoFlor className="colibri-tx-flor" />
-        </span>
-      ) : showVideo ? (
-        <video
-          className="colibri-tx-video"
-          autoPlay
-          muted
-          playsInline
-          preload="auto"
-          onError={() => setVideoFailed(true)}
-        >
-          <source src="/avatar/colibri-transition.webm" type="video/webm" />
-        </video>
-      ) : COLIBRI_REAL ? (
-        // Flag ON + reduced-motion: el póster del barbudito, sin cruce.
-        <img className="colibri-tx-still" src="/colibri/barbudito-poster.png" alt="" draggable={false} />
-      ) : (
-        <img className="colibri-tx-still" src="/avatar/colibri-hero-still.jpg" alt="" draggable={false} />
-      )}
+      <span className="agente-tx-abeja">
+        <Angelita
+          estado="invita"
+          size={Math.round(Math.min(
+            typeof window !== 'undefined' ? window.innerWidth * 0.62 : 280,
+            300,
+          ))}
+          animated={!reduce}
+          title="Angelita lo lleva a la conversación"
+        />
+      </span>
+      <span className="agente-tx-nombre">Angelita</span>
     </div>
   );
 }
@@ -177,5 +129,5 @@ function ColibriOverlay({ onDone }) {
  */
 export default function ColibriTransition({ active, onDone }) {
   if (!active) return null;
-  return <ColibriOverlay onDone={onDone} />;
+  return <AngelitaOverlay onDone={onDone} />;
 }

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -21,6 +21,7 @@ import { buildCropSuggestions } from '../../data/cropSuggestions';
 import { syncManager } from '../../services/syncManager';
 import { iconForTheme } from './themeIcon';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
+import Angelita from '../../visual/agente/Angelita';
 import { lunarPhase, solarTimes, moonPathD } from '../../utils/skyEphemeris';
 import { resolveClimaLocation, getCachedClimaSnapshot } from '../../services/climaService';
 import {
@@ -237,34 +238,6 @@ function SkyAstro({ night, condition, moonFraction }) {
     );
 }
 
-// Colibrí 2D del demo (SVG .hummer). Se usa tanto en la escena ambiente (vuela)
-// como DENTRO del botón de enviar (operador 2026-06-06: "el colibrí es enviar").
-// Se factoriza para que ambos usos compartan exactamente el mismo trazo.
-function HummerSvg({ width = 62, height = 46, flap = true }) {
-    return (
-        <svg width={width} height={height} viewBox="0 0 62 46" aria-hidden="true">
-            {/* cuerpo */}
-            <ellipse cx="34" cy="28" rx="11" ry="6.5" fill="#2f7d6b" />
-            <ellipse cx="34" cy="27" rx="9" ry="4.2" fill="#3fa489" />
-            {/* cabeza */}
-            <circle cx="46" cy="24" r="6" fill="#2a6f60" />
-            <circle cx="48.5" cy="22.5" r="1.4" fill="#11332c" />
-            {/* gorguera roja */}
-            <path d="M44 28 q5 2 8 0 q-3 4 -8 3 z" fill="#d05038" />
-            {/* pico largo */}
-            <path d="M52 24 L62 19" stroke="#3a2a18" strokeWidth="2" strokeLinecap="round" />
-            {/* cola */}
-            <path d="M23 28 L8 22 M23 30 L8 32" stroke="#256155" strokeWidth="3" strokeLinecap="round" />
-            {/* ala (animada solo cuando vuela en la escena) */}
-            <g className={flap ? 'wing' : undefined}>
-                <path d="M30 24 C18 6 6 8 2 16 C12 18 22 24 30 30 Z" fill="#4fb89a" opacity=".9" />
-            </g>
-        </svg>
-    );
-}
-
-// Saludos por hora del día. En modo "experto" (nivel detallado) el demo abre
-// con "Hola." en vez de "Buenos días." (COPY.experto.greetHi). Replicamos.
 function greetingForNow(nivel) {
     if (nivel === 'detallado') return 'Hola.';
     const h = typeof Date !== 'undefined' ? new Date().getHours() : 9;
@@ -1007,8 +980,8 @@ export default function AgentHero({ onNavigate }) {
                     transform-origin: center; will-change: transform;
                 }
                 .agentport-hummer svg { display: block; filter: drop-shadow(0 6px 6px rgba(90,60,20,.18)); }
-                /* bio-punk = tema base (sin data-theme): glow neón teal */
-                .agentport-hummer svg { filter: drop-shadow(0 0 8px rgba(25,201,154,.7)) drop-shadow(0 0 16px rgba(25,240,192,.35)); }
+                /* bio-punk = tema base (sin data-theme): glow de miel (ámbar) */
+                .agentport-hummer svg { filter: drop-shadow(0 0 8px rgba(240,178,60,.6)) drop-shadow(0 0 16px rgba(240,200,120,.3)); }
                 [data-theme="nature"] .agentport-hummer svg { filter: drop-shadow(0 6px 6px rgba(90,60,20,.18)); }
                 /* minimalista: SIN colibrí (escena limpia del demo). */
                 [data-theme="minimalista"] .agentport-hummer { display: none !important; }
@@ -1103,7 +1076,7 @@ export default function AgentHero({ onNavigate }) {
                 /* "Abrir Chagra IA" — botón redondo con el avatar del agente.
                    Entrada explícita al overlay desde la portada (tarea #51). */
                 .agentport-open {
-                    width: 38px; height: 38px; flex: none; border-radius: 50%;
+                    width: 52px; height: 52px; flex: none; border-radius: 50%;
                     display: inline-flex; align-items: center; justify-content: center;
                     overflow: hidden; padding: 0; cursor: pointer;
                     background: rgb(var(--c-surface-card) / 0.65);
@@ -1725,11 +1698,12 @@ export default function AgentHero({ onNavigate }) {
                     <div className="agentport-horizon" />
                 </div>
 
-                {/* — COLIBRÍ 2D — vuela en bio-punk y nature (SVG del demo
-                     nature). En minimalista se oculta vía CSS: el demo limpio no
-                     lleva colibrí. — */}
+                {/* — ANGELITA — la abeja agente vuela en bio-punk y nature
+                     ("solo abejita", operador 2026-07-18: el colibrí jubiló).
+                     En minimalista se oculta vía CSS: el demo limpio no lleva
+                     fauna. — */}
                 <div className="agentport-hummer">
-                    <HummerSvg />
+                    <Angelita estado="acompana" size={68} title="Angelita acompaña la portada" />
                 </div>
             </div>
 
@@ -1762,7 +1736,7 @@ export default function AgentHero({ onNavigate }) {
                         title="Abrir Chagra IA"
                         className="agentport-open"
                     >
-                        <ChagraAgentAvatar size={26} state="idle" ariaLabel="Chagra IA" />
+                        <ChagraAgentAvatar size={48} state="idle" ariaLabel="Chagra IA" />
                     </button>
 
                     <div className="agentport-mode" role="tablist" aria-label="Nivel de respuestas">
@@ -2129,7 +2103,7 @@ export default function AgentHero({ onNavigate }) {
                             }}
                         >
                             <div style={{ width: '100%', height: '100%', position: 'relative' }}>
-                              <ChagraAgentAvatar size={38} state={canSend ? 'idle' : 'listening'} ariaLabel="Enviar al agente" />
+                              <ChagraAgentAvatar size={44} state={canSend ? 'idle' : 'listening'} ariaLabel="Enviar al agente" />
                             </div>
                         </button>
                     </div>

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -23,6 +23,7 @@ import { useTheme, resolveAutoTheme } from '../../hooks/useTheme';
 import { iconForTheme } from './themeIcon';
 import { colibriRealActivo } from '../../config/colibriFlag';
 import { BarbuditoIlustrado, BarbuditoRealLoop } from '../colibri/Barbudito';
+import Angelita from '../../visual/agente/Angelita';
 // Campana de notificaciones en el header F2 (regresión 2026-07-04): con la flag
 // F2 ON el TopBar legacy (que la montaba) NO se renderiza, así que el home se
 // quedó sin campana. `variant="f2"` es la misma píldora redonda que ya usa
@@ -617,23 +618,20 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, on
                     )
                   )}
 
-                  {/* fauna sobre la escena. El COLIBRÍ (criatura insignia del
-                      agente) vuela SIEMPRE — es el guía, no ganado; acompaña
-                      también la finca recién empezada. La mariposa y la abeja
-                      (fauna que prospera) sólo aparecen cuando la finca está
-                      poblada. Con una ESCENA VIVA de tema activa NO se
-                      superpone fauna: cada escena trae su PROPIO colibrí y su
-                      fauna (el emoji 🦋/🐝 y el colibrí 2D duplicados rompían
-                      la clave del arte de cada tema). */}
+                  {/* fauna sobre la escena. ANGELITA (la abeja agente) vuela
+                      SIEMPRE — es la guía, no ganado; acompaña también la
+                      finca recién empezada ("solo abejita", operador
+                      2026-07-18: el colibrí jubiló del rol de insignia del
+                      agente). La mariposa y la abeja emoji (fauna que
+                      prospera) sólo aparecen cuando la finca está poblada.
+                      Con una ESCENA VIVA de tema activa NO se superpone
+                      fauna: cada escena trae la suya. */}
                   {!escenaVivaActiva && (
                   <div className="fvh-bichos" aria-hidden="true">
-                    {/* COLIBRÍ insignia. Con la flag VITE_COLIBRI ON (dev) =
-                        modo A/B TEMPORAL: dos barbuditos de páramo, uno a cada
-                        costado, para que el operador elija. IZQUIERDA el
-                        ILUSTRADO (SVG/CSS dibujado); DERECHA el REAL recortado
-                        (sprite en loop, sin recuadro). Cada uno con su etiquetita
-                        ("ilustrado"/"real"). Con la flag OFF (prod), el colibrí
-                        SVG 2D `ColibriVuela` de siempre. */}
+                    {/* Con la flag VITE_COLIBRI ON (dev) = modo A/B TEMPORAL
+                        de barbuditos de páramo (fauna decorativa, no el
+                        agente). Con la flag OFF (prod), ANGELITA volando —
+                        idle vivo 'acompana' con su cerebro de micro-gestos. */}
                     {COLIBRI_REAL ? (
                       <>
                         <span className="fvh-bicho fvh-colibri-ab fvh-colibri-ab-izq" style={{ left: '4%', top: '12%' }}>
@@ -646,8 +644,8 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, on
                         </span>
                       </>
                     ) : (
-                      <span className="fvh-bicho fvh-colibri-vuela" style={{ left: '66%', top: '20%' }}>
-                        <ColibriVuela />
+                      <span className="fvh-bicho fvh-colibri-vuela" style={{ left: '60%', top: '14%' }}>
+                        <Angelita estado="acompana" size={72} title="Angelita acompaña la finca" />
                       </span>
                     )}
                     {poblada && (
@@ -1164,55 +1162,6 @@ function WashSolBajo({ cielo, w = 390, h = 360 }) {
       opacity={tono === 'atardecer' ? 0.9 : 0.7}
       pointerEvents="none"
     />
-  );
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-//  COLIBRÍ DE VERDAD (feedback #5) — pico largo, alas, iridiscencia.
-//  Inspirado en ChagraAgentAvatarColibri (mismo plumaje turquesa→violeta).
-// ════════════════════════════════════════════════════════════════════════════
-
-/** Colibrí que vuela estacionario sobre la escena (criatura insignia). */
-function ColibriVuela() {
-  return (
-    <svg viewBox="0 0 64 48" width="44" height="33" aria-hidden="true" className="fvh-colibri-svg">
-      <defs>
-        <linearGradient id="fvh-colibri-plum" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0" stopColor="#34d399" />
-          <stop offset="40%" stopColor="#10b981" />
-          <stop offset="72%" stopColor="#06b6d4" />
-          <stop offset="100%" stopColor="#8b5cf6" />
-        </linearGradient>
-        <radialGradient id="fvh-colibri-gorget" cx="50%" cy="50%" r="50%">
-          <stop offset="0" stopColor="#fde68a" />
-          <stop offset="45%" stopColor="#f59e0b" />
-          <stop offset="100%" stopColor="#dc2626" />
-        </radialGradient>
-      </defs>
-      {/* cola en abanico */}
-      <path d="M10 28 L1 24 L6 30 L0 35 L8 33 L5 40 L14 32 Z" fill="url(#fvh-colibri-plum)" opacity="0.9" />
-      {/* ala trasera (batiendo) */}
-      <g className="fvh-ala-tras" style={{ transformOrigin: '24px 24px' }}>
-        <path d="M24 24 Q12 16 4 24 Q12 32 24 28 Z" fill="url(#fvh-colibri-plum)" opacity="0.55" />
-      </g>
-      {/* cuerpo */}
-      <ellipse cx="26" cy="27" rx="13" ry="7.5" fill="url(#fvh-colibri-plum)" transform="rotate(-16 26 27)" />
-      {/* vientre claro */}
-      <ellipse cx="25" cy="30" rx="8" ry="3.4" fill="#fef3c7" opacity="0.5" transform="rotate(-16 25 30)" />
-      {/* cabeza */}
-      <circle cx="40" cy="22" r="6.4" fill="url(#fvh-colibri-plum)" />
-      {/* garganta iridiscente (gorget) */}
-      <ellipse cx="41" cy="26" rx="3.6" ry="2.4" fill="url(#fvh-colibri-gorget)" opacity="0.92" />
-      {/* ojo */}
-      <circle cx="41.5" cy="20.6" r="1.5" fill="#0c0a09" />
-      <circle cx="41" cy="20.1" r="0.5" fill="#fff" opacity="0.95" />
-      {/* PICO LARGO característico del colibrí */}
-      <path d="M46 22 Q58 24 63 30" fill="none" stroke="#26201b" strokeWidth="1.7" strokeLinecap="round" />
-      {/* ala frontal (batiendo, sobre el cuerpo) */}
-      <g className="fvh-ala-fron" style={{ transformOrigin: '28px 23px' }}>
-        <path d="M28 23 Q16 6 2 12 Q14 26 30 21 Z" fill="url(#fvh-colibri-plum)" opacity="0.78" />
-      </g>
-    </svg>
   );
 }
 

--- a/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
@@ -164,8 +164,9 @@ describe('AgentHero — integración post-pulido (task #TEST-int)', () => {
       const avatar = sendBtn.querySelector('[data-testid="avatar"]');
       expect(avatar).toBeTruthy();
 
-      // Verifica que tiene los atributos correctos
-      expect(avatar).toHaveAttribute('data-size', '38');
+      // Verifica que tiene los atributos correctos (44: protagonismo de
+      // Angelita — el avatar llena el botón de 44px, 2026-07-18)
+      expect(avatar).toHaveAttribute('data-size', '44');
       expect(avatar).toHaveAttribute('data-state', 'listening');
     });
 

--- a/src/hooks/useAgentAvatarType.js
+++ b/src/hooks/useAgentAvatarType.js
@@ -2,23 +2,25 @@ import { useEffect, useState, useCallback } from 'react';
 
 const STORAGE_KEY = 'chagra:agent-avatar-type';
 
-// 'colibri' = avatar foto-realista (foto biopunk Lili). Es el nuevo
-// default 2026-05-28 ("reemplazar el 3D R3F" — operador). Los usuarios
-// que ya tenían 'colibri' en localStorage automáticamente ven la foto
-// sin migration (mismo slug, distinta implementación).
-//
-// 'colibri_svg' = ilustración SVG (Amazilia libando del abutilón). Antes
-// era el componente detrás de 'colibri'; ahora vive bajo su propio slug
-// para quien prefiera estilo botánico ilustrado.
+// 'angelita' = Angelita, la abeja angelita (Tetragonisca angustula). ES el
+// agente de Chagra desde 2026-07-16 ("Angelita como el agente, jubila el
+// colibrí" — operador; 2026-07-18: el colibrí sale también de las opciones —
+// "solo abejita"). El colibrí queda de fauna decorativa en los mundos 3D,
+// nunca como cara del agente.
 //
 // 'maiz' = planta de maíz, alternativa cultural ancestral.
-export const AVATAR_TYPES = ['colibri', 'colibri_svg', 'maiz'];
-export const DEFAULT_AVATAR_TYPE = 'colibri';
+export const AVATAR_TYPES = ['angelita', 'maiz'];
+export const DEFAULT_AVATAR_TYPE = 'angelita';
+
+// Slugs históricos guardados en localStorage de instalaciones viejas:
+// ambos colibríes migran a Angelita sin que el usuario haga nada.
+const LEGACY_TYPES = { colibri: 'angelita', colibri_svg: 'angelita' };
 
 function readPref() {
     try {
         const raw = localStorage.getItem(STORAGE_KEY);
         if (raw && AVATAR_TYPES.includes(raw)) return raw;
+        if (raw && LEGACY_TYPES[raw]) return LEGACY_TYPES[raw];
     } catch {
         // private mode / quota → fallback
     }


### PR DESCRIPTION
## Qué hace

Decisión del operador: **la abejita Angelita reemplaza al colibrí como avatar del agente IA en toda la app, con más protagonismo y más grande.**

### Cableado
- `ChagraAgentAvatar` (router): default → `ChagraAgentAvatarAngelita`; las ramas `colibri`/`colibri_svg` desaparecen. Solo quedan `angelita` (default) y `maiz`.
- Slugs viejos en localStorage (`colibri`, `colibri_svg`) **migran a `angelita`** en `useAgentAvatarType` sin acción del usuario.
- Estados del agente → estados de Angelita: `idle→acompana`, `thinking→pensando`, `speaking→respondiendo`, `listening→escuchando` (vía `estadoCanonico`). El adaptador ahora acepta `visema` (lip-sync) y `confianza` (anillo de certeza) como passthrough para cuando el host los tenga.

### El colibrí fuera de todos los puntos reales
- Selector de Perfil: 2 opciones (sin colibrí).
- LoginScreen, BienvenidaFinca, OnboardingCondensado (x2): renders directos del colibrí → Angelita.
- Transición home→conversación: del video webm del colibrí → **Angelita 'invita' a pantalla completa** con su nombre (SVG puro, cero video, reduced-motion respetado).
- Fauna insignia de los heroes (AgentHero `agentport-hummer`, FincaVivaHero): ahora vuela Angelita 'acompana' con glow de miel. `HummerSvg` y `ColibriVuela` removidos (huérfanos).
- El colibrí queda solo como fauna decorativa de los mundos 3D y bajo la flag dev `VITE_COLIBRI` (A/B de barbuditos) — nunca como cara del agente.

### Protagonismo (tamaños)
| Punto | Antes | Ahora |
|---|---|---|
| Header del chat | 36 | **52** |
| Enviar (chat) | 38 | **46** (llena el `.as-send`) |
| Botón portada (`agentport-open`) | 38px/26 | **52px/48** |
| Enviar (hero) | 38 | **44** |
| FAB global | 64/62 | **84/82** |
| Chips home (WelcomeStatsHero) | 20/26/38 | 28/36/48 |
| Bylines chat / insight | 22 | 30 / 28 |

### Verificación (capturas sobre la app real, chromium del sistema + swiftshader)
- Home, chat, transición, perfil y login: **solo la abejita** — 0 avatares colibrí en el DOM (verificado por locator).
- Chat funcional: enviar → burbuja usuario → respuesta → feedback; aria-labels intactos.
- `npm run build:prod` verde; `dist-prod/` sin tocar (regenerable).
- Tests: suite avatar 23/23, AgentHero 50/50, selector smoke verde (con tests nuevos de migración legacy). Fallos de ClimaStrip/DashboardLive.glaciar preexistentes en la base (verificado con stash).

Capturas de verificación en el scratchpad de la sesión (`abejita-agente-*.png`): login, home con Angelita en el cielo + chip + enviar, transición con Angelita gigante, chat con header/byline/enviar, perfil con FAB 84px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)