### PR TITLE
feat(valle): cablea Angelita, archiva Ent+páramo, casa→mirador de mundos

### DIFF
--- a/scripts/diag/click-casa.mjs
+++ b/scripts/diag/click-casa.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/* Click-through de un solo uso: tocar la casa del valle y ver a dónde navega. */
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+
+const chromiumPath = execSync('which chromium', { encoding: 'utf8' }).trim();
+const browser = await chromium.launch({
+  executablePath: chromiumPath,
+  args: [
+    '--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage',
+    '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader',
+    '--ignore-gpu-blocklist',
+  ],
+});
+const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 }, locale: 'es-CO' });
+const page = await ctx.newPage();
+await page.addInitScript(() => {
+  const sembrar = (db, store) => new Promise((res) => {
+    const req = indexedDB.open(db, 2);
+    req.onupgradeneeded = () => { try { req.result.createObjectStore(store); } catch {} };
+    req.onsuccess = () => {
+      try {
+        const tx = req.result.transaction(store, 'readwrite');
+        const st = tx.objectStore(store);
+        st.put('shot3d-token-diagnostico', 'farmos_access_token');
+        st.put(Date.now() + 86400000, 'farmos_token_expiry');
+        tx.oncomplete = () => res(undefined);
+        tx.onerror = () => res(undefined);
+      } catch { res(undefined); }
+    };
+    req.onerror = () => res(undefined);
+  });
+  sembrar('localforage', 'keyvaluepairs');
+  sembrar('Chagra', 'syncQueue');
+});
+await page.goto('http://localhost:5173/index-prod.html#/valle3d?ciclo=11', { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForTimeout(13000);
+console.log('hash antes:', await page.evaluate(() => window.location.hash));
+// Barrido de puntos candidatos alrededor de la casa (techo rojo, ventana con
+// luz) — probamos varios porque el hitbox 3D exacto es sensible al ángulo.
+const candidatos = [[700, 545], [700, 560], [690, 555], [712, 548], [705, 570], [695, 535]];
+let cambio = false;
+for (const [x, y] of candidatos) {
+  await page.mouse.click(x, y);
+  await page.waitForTimeout(1600);
+  const hash = await page.evaluate(() => window.location.hash);
+  console.log(`click (${x},${y}) → hash:`, hash);
+  if (hash.includes('vitrina_maestra')) { cambio = true; break; }
+}
+await page.waitForTimeout(9000);
+await page.screenshot({ path: '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/valle-casa-click.png', animations: 'disabled' });
+console.log('hash final:', await page.evaluate(() => window.location.hash));
+console.log('cambio a vitrina_maestra:', cambio);
+await ctx.close();
+await browser.close();

--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -1,10 +1,18 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import Angelita from '../visual/agente/Angelita';
 import useAgentNotificationStore from '../store/useAgentNotificationStore';
 import usePrefsStore from '../store/usePrefsStore';
 import { isSpeaking, stop, replayLast, isKokoroAvailable } from '../services/ttsService';
 import { agentSounds } from '../services/agentSoundService';
 import { fvhSkinClass } from '../config/fvhSkin';
+/* EL CEREBRO DE ANGELITA (auditoría 2026-07-18: construido y DESCONECTADO).
+   El FAB vive en TODA pantalla — es el lugar correcto para que
+   `notificacionesInteligentes()` (qué atender hoy, con datos REALES) llegue
+   como aviso de la abeja sin esperar a que el operador abra el chat. */
+import useAngelitaStore from '../store/useAngelitaStore';
+import useAlertStore from '../store/useAlertStore';
+import useLogStore from '../store/useLogStore';
+import { notificacionesInteligentes } from '../services/angelitaInteligencia';
 import './agent-fab-skin.css';
 
 /**
@@ -37,8 +45,36 @@ export default function AgentFab({ onNavigate, pantalla = null }) {
 
   const responseReady = useAgentNotificationStore((s) => s.responseReady);
   const lastAssistantMessage = useAgentNotificationStore((s) => s.lastAssistantMessage);
+  const setResponseReady = useAgentNotificationStore((s) => s.setResponseReady);
+  const setLastMessage = useAgentNotificationStore((s) => s.setLastMessage);
   const ttsEnabled = usePrefsStore((s) => s.ttsEnabled);
   const setTtsEnabled = usePrefsStore((s) => s.setTtsEnabled);
+  const activeAlerts = useAlertStore((s) => s.activeAlerts);
+
+  // ── EL CEREBRO, CABLEADO (auditoría 2026-07-18): notificacionesInteligentes
+  //    decide QUÉ atender hoy con datos REALES (alertas activas + tareas
+  //    vencidas de useLogStore) — antes nadie la llamaba. Si de verdad hay
+  //    algo Y la anti-molestia del propio store lo deja pasar (cooldown,
+  //    nunca a mitad de un husmeo que la abeja del valle ya esté mostrando),
+  //    el FAB brilla con el MISMO aviso — cero dato inventado, cero glow
+  //    porque sí. Re-evalúa cuando cambian las alertas reales.
+  useEffect(() => {
+    let vivo = true;
+    useLogStore.getState().getPendingTasks()
+      .then((pendingTasks) => {
+        if (!vivo) return;
+        const notificaciones = notificacionesInteligentes({ activeAlerts, pendingTasks });
+        if (!notificaciones.hay) return; // nada real que avisar: no tocar el store compartido
+        if (useAngelitaStore.getState().estado === 'husmea') return; // no le quita el turno a un husmeo en curso
+        const decision = useAngelitaStore.getState().evaluar({ notificaciones });
+        if (decision.interrumpe) {
+          setLastMessage(decision.mensaje);
+          setResponseReady(true);
+        }
+      })
+      .catch(() => { /* degrada silencioso: sin dato real, la abeja no inventa aviso */ });
+    return () => { vivo = false; };
+  }, [activeAlerts, setLastMessage, setResponseReady]);
 
   // Estado de Angelita: el tacto manda sobre el aviso, y el aviso sobre el idle.
   const estado = pressed

--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -369,11 +369,12 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
     decir(COSA_DEL_DIA.vozTexto);
   }, [decir]);
 
-  // ── LA CASA ES LA VÍA SECUNDARIA (fix del operador 2026-07-16): tocar la
-  //    puerta iluminada lleva a la VENTANA-PUERTA de los mundos (la ruta
-  //    `ventana_valle` ya construida), por el mismo velo del cableo 3D→2D.
-  //    La entrada PRINCIPAL a cada mundo es su portal-paisaje del valle,
-  //    tocado directo — la casa no vuelve a ser la boca de todo.
+  // ── LA CASA ES LA VÍA SECUNDARIA (fix del operador 2026-07-16, recableada
+  //    2026-07-18): tocar la puerta iluminada lleva al MIRADOR DE LOS
+  //    MUNDOS (VitrinaMaestraMundos, ruta `vitrina_maestra` — wire3DNav.js
+  //    `casa:`), por el mismo velo del cableo 3D→2D. La entrada PRINCIPAL a
+  //    cada mundo es su portal-paisaje del valle, tocado directo — la casa
+  //    no vuelve a ser la boca de todo.
   const abrirCasa = useCallback(() => abrirPantalla('casa'), [abrirPantalla]);
 
   const volverAlValle = useCallback(() => {

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -33,6 +33,11 @@ import { perfilDeTier } from '../../visual/mundo3d/deviceTier.js';
 import CamaraDirector from '../../visual/mundo3d/escenas/CamaraDirector.jsx';
 import DirectorValle from './DirectorValle.jsx';
 import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
+/* EL CEREBRO DE ANGELITA (auditoría 2026-07-18: estaba construido y
+   DESCONECTADO — ningún componente vivo lo consumía). La abeja del valle
+   (CompaneroAbeja) lo usa para husmear con criterio: comentarios grounded
+   por mundo, con la anti-molestia (cooldowns) resuelta adentro del store. */
+import useAngelitaStore from '../../store/useAngelitaStore';
 /* La CAPA DE ESTADO de Angelita (auditoría §5b): módulo puro, sin three — el
    mismo repertorio (mojada/sed/comiendo/vuelo) que usan los mundos 3D. */
 import { reaccionDeFinca, ESTADO_FINCA_MUESTRA } from '../../visual/mundo3d/escenas/reaccionFinca.js';
@@ -62,7 +67,6 @@ import {
   CasaCampesina,
   VentanasVivas,
   PorticosSecundarios,
-  VistaParamoEnt,
   SenderosValle,
   PatiosLugares,
   VecinosDelValle,
@@ -92,6 +96,40 @@ import {
       escena entera consume ESTA lista — geometría, rótulos, faro y foco. ── */
 const MUNDOS_DIR = componerMundos(MUNDOS_VALLE);
 const MUNDO_DIR_BY_ID = Object.fromEntries(MUNDOS_DIR.map((m) => [m.id, m]));
+
+/* ── EL VOCABULARIO DE ANGELITA (auditoría 2026-07-18): los lugares del
+      valle (valleData.js LUGARES) tienen SU PROPIO id ('cafe', 'cultivos',
+      'micorrizas'…); el motor (angelitaInteligencia.MUNDOS) habla en un
+      vocabulario más ancho ('mis_matas', 'mis_animales', 'clima', 'vender',
+      'aprender', 'bosque', 'paramo', 'finca'). Esta tabla traduce uno al
+      otro para que `comentarioDeMundo`/`entrarMundo` sepan qué decir de
+      cada lugar tocado. */
+const LUGAR_A_MUNDO_ANGELITA = {
+  cultivos: 'mis_matas',
+  cafe: 'mis_matas',
+  suelo: 'mis_matas',
+  sanidad: 'mis_matas',
+  semillero: 'mis_matas',
+  abono: 'mis_matas',
+  micorrizas: 'bosque',
+  animales: 'mis_animales',
+  agua: 'clima',
+  clima: 'clima',
+  mercado: 'vender',
+  disenio: 'bosque',
+  aprender: 'aprender',
+  paramo: 'paramo',
+};
+
+/* Los 6 lugares que Angelita husmea SOLA en reposo — los mismos 6 portales
+   principales (PORTALES_VALLE en composicionValle.js): rotan uno a la vez,
+   espaciados por HUSMEO_MS; el propio store (cooldown de 20 min por mundo)
+   decide si de verdad vale la pena interrumpir. Nunca a mitad de un viaje
+   real, nunca con reduced-motion. */
+const HUSMEO_LUGARES = ['cultivos', 'animales', 'clima', 'mercado', 'aprender', 'disenio'];
+const HUSMEO_PRIMERO_MS = 5200; // el primer husmeo llega pronto: se ve viva al cargar
+const HUSMEO_CADA_MS = 40000; // cadencia entre intentos de husmeo autónomo
+const HUSMEO_VISIBLE_MS = 7200; // cuánto dura el comentario antes de volver a calma
 
 /* Altura del terreno por (x,z): la LADERA ANDINA. El eje z es la montaña — al
    fondo (z negativo) trepa al páramo alto, al frente (z positivo) baja a tierra
@@ -1411,7 +1449,7 @@ const CALMA_ABEJA = {
   z: CASA_VALLE.pos[1] + 1.5,
 };
 
-function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false, posRef = null, conLuz = false, onTocar = null }) {
+function CompaneroAbeja({ foco, focoId = null, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false, posRef = null, conLuz = false, onTocar = null }) {
   const ref = useRef(null);
   const caraRef = useRef(null);
   const prevX = useRef(foco.x);
@@ -1425,6 +1463,78 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
   const animoReal = reaccion?.animo ?? animo;
   const energiaReal = reaccion?.energia ?? energia;
   const vuelo = reaccion?.vuelo;
+
+  // ── EL CEREBRO (auditoría 2026-07-18: existía y nadie lo consumía). Dos
+  //    disparadores alimentan el MISMO store — un solo `estado`/`mensaje`
+  //    en vivo, arbitrado por angelitaInteligencia con su anti-molestia:
+  //      1) NAVEGACIÓN REAL: al entrar a un mundo de verdad (focoId), un
+  //         comentario grounded de ESE mundo.
+  //      2) HUSMEO AUTÓNOMO: en reposo, cada tanto se acerca sola a un
+  //         portal y comenta — el store decide si de verdad interrumpe.
+  const estadoAngelita = useAngelitaStore((s) => s.estado);
+  const mensajeAngelita = useAngelitaStore((s) => s.mensaje);
+  const entrarMundoAngelita = useAngelitaStore((s) => s.entrarMundo);
+  const reposarAngelita = useAngelitaStore((s) => s.reposar);
+
+  // 1) Navegación real: al entrar/salir de un mundo de verdad, la abeja
+  //    husmea ese lugar (o vuelve a calma al salir). `focoId` es el id CRUDO
+  //    del lugar del valle (Escena ya lo resuelve); se traduce al vocabulario
+  //    del motor con LUGAR_A_MUNDO_ANGELITA.
+  const focoIdPrevio = useRef(focoId);
+  useEffect(() => {
+    if (focoId && focoId !== focoIdPrevio.current) {
+      entrarMundoAngelita(LUGAR_A_MUNDO_ANGELITA[focoId] || 'finca', {});
+    } else if (!focoId && focoIdPrevio.current) {
+      reposarAngelita();
+    }
+    focoIdPrevio.current = focoId;
+  }, [focoId, entrarMundoAngelita, reposarAngelita]);
+
+  // 2) Husmeo autónomo: nunca a mitad de un viaje real (entrandoRef, para
+  //    que un viaje NO reinicie la cadencia), nunca con reduced-motion (cero
+  //    errante — reconcilia el feedback previo "POSICIÓN DE CALMA, no
+  //    husmea errática" con el pedido de que la abeja muestre información:
+  //    SUAVE y espaciada, con el cooldown del propio store, no un tic). El
+  //    lugar que autónomamente mira ahora vive en un ref — mover la abeja no
+  //    debe repintar el resto del árbol.
+  const entrandoRef = useRef(entrando);
+  useEffect(() => { entrandoRef.current = entrando; }, [entrando]);
+  const husmeoIdx = useRef(0);
+  const husmeoLugarRef = useRef(null);
+  useEffect(() => {
+    if (reducedMotion) return undefined;
+    let vivo = true;
+    let temporizador = null;
+    let ocultarTimer = null;
+    const tick = () => {
+      if (!vivo) return;
+      if (!entrandoRef.current) {
+        const lugar = HUSMEO_LUGARES[husmeoIdx.current % HUSMEO_LUGARES.length];
+        husmeoIdx.current += 1;
+        const mundo = LUGAR_A_MUNDO_ANGELITA[lugar];
+        const decision = mundo ? entrarMundoAngelita(mundo, {}) : null;
+        if (decision?.interrumpe) {
+          husmeoLugarRef.current = lugar;
+          if (ocultarTimer) clearTimeout(ocultarTimer);
+          ocultarTimer = setTimeout(() => {
+            husmeoLugarRef.current = null;
+            reposarAngelita();
+          }, HUSMEO_VISIBLE_MS);
+        }
+      }
+      temporizador = setTimeout(tick, HUSMEO_CADA_MS);
+    };
+    temporizador = setTimeout(tick, HUSMEO_PRIMERO_MS);
+    return () => {
+      vivo = false;
+      if (temporizador) clearTimeout(temporizador);
+      if (ocultarTimer) clearTimeout(ocultarTimer);
+    };
+    // `entrando` vive en entrandoRef a propósito: un viaje real no debe
+    // reiniciar la cadencia del husmeo autónomo.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reducedMotion, entrarMundoAngelita, reposarAngelita]);
+
   useFrame((state) => {
     if (!ref.current) return;
     const t = state.clock.elapsedTime;
@@ -1437,27 +1547,40 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
     const brio = (0.35 + 0.65 * energiaReal) * mVel; // energía y clima animan el vuelo
     const bob = reducedMotion ? 0 : Math.sin(t * (1.6 + brio)) * (0.1 + 0.16 * brio);
     const tembleque = tiembla ? Math.sin(t * 13) * tiembla : 0;
-    // POSICIÓN DE CALMA: al reposo Angelita ya no ronda el valle en un
-    // círculo errático — flota serena sobre el patio de la casa con una
-    // deriva mínima y lenta (respiración, no husmeo). Al entrar a un mundo
-    // sí vuela y se posa junto al lugar.
-    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.28) * 0.26 * mVagar;
-    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.22) * 0.18 * mVagar;
-    const alto = (entrando ? 1.05 : 2.2) * mAltura;
+    // HUSMEO AUTÓNOMO: mientras no hay viaje real, el lugar que el store
+    // aceptó (husmeoLugarRef) manda un TERCER destino — un solo lugar a la
+    // vez, temporal, nunca un círculo errático.
+    const lugarHusmeo = !entrando ? husmeoLugarRef.current : null;
+    const anclaHusmeo = lugarHusmeo ? MUNDO_DIR_BY_ID[lugarHusmeo] : null;
+    // POSICIÓN DE CALMA: al reposo (sin viaje real NI husmeo activo) Angelita
+    // ya no ronda el valle en un círculo errático — flota serena sobre el
+    // patio de la casa con una deriva mínima y lenta (respiración). Al
+    // entrar a un mundo (real o husmeado) sí vuela y se posa junto al lugar.
+    const vagarX = reducedMotion || entrando || anclaHusmeo ? 0 : Math.sin(t * 0.28) * 0.26 * mVagar;
+    const vagarZ = reducedMotion || entrando || anclaHusmeo ? 0 : Math.cos(t * 0.22) * 0.18 * mVagar;
+    const alto = (entrando ? 1.05 : anclaHusmeo ? 1.4 : 2.2) * mAltura;
     const dest = entrando
       ? new THREE.Vector3(
           foco.x + 0.55 + tembleque,
           foco.y + alto + bob + tembleque * 0.5,
           foco.z + 0.7,
         )
-      : new THREE.Vector3(
-          CALMA_ABEJA.x + vagarX + tembleque,
-          yCalma + alto + bob + tembleque * 0.5,
-          CALMA_ABEJA.z + vagarZ,
-        );
+      : anclaHusmeo
+        ? new THREE.Vector3(
+            anclaHusmeo.pos[0] + 0.5 + tembleque,
+            alturaTerreno(anclaHusmeo.pos[0], anclaHusmeo.pos[2]) + alto + bob + tembleque * 0.5,
+            anclaHusmeo.pos[2] + 0.6,
+          )
+        : new THREE.Vector3(
+            CALMA_ABEJA.x + vagarX + tembleque,
+            yCalma + alto + bob + tembleque * 0.5,
+            CALMA_ABEJA.z + vagarZ,
+          );
     // 0.045 al salir de foco: el valor de la v2 aprobada (0.035 hacía la
-    // salida pegajosa — regresión detectada en la auditoría 2026-07-16).
-    ref.current.position.lerp(dest, (entrando ? 0.05 : 0.045) * mVel);
+    // salida pegajosa — regresión detectada en la auditoría 2026-07-16). El
+    // husmeo autónomo vuela más SUAVE que una entrada real decidida (0.03).
+    const kVuelo = entrando ? 0.05 : anclaHusmeo ? 0.03 : 0.045;
+    ref.current.position.lerp(dest, kVuelo * mVel);
     // Comparte su posición viva para que la cámara de director la SIGA (follow
     // con lead): copia dentro del Vector3 compartido (mutación por método sobre
     // un local — no reasigna el prop, como CamaraViajera con controls.current).
@@ -1515,6 +1638,20 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
           </div>
         </button>
       </Html>
+      {/* EL CEREBRO SE VE: cuando Angelita husmea (sola o de verdad) o avisa
+          algo, lo dice en una burbuja — nunca queda muda. aria-live para que
+          también se narre a lectores de pantalla. */}
+      {mensajeAngelita && (
+        <Html center position={[0, 1.3, 0]} distanceFactor={9} zIndexRange={[45, 20]} style={{ pointerEvents: 'none' }}>
+          <div
+            className={`valle-abeja__burbuja valle-abeja__burbuja--${estadoAngelita}`}
+            role="status"
+            aria-live="polite"
+          >
+            {mensajeAngelita}
+          </div>
+        </Html>
+      )}
     </group>
   );
 }
@@ -1991,14 +2128,12 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = nu
         onEntrar={portada ? null : onEntrar}
       />
       <PorticosSecundarios mundos={MUNDOS_DIR} alturaDe={alturaTerreno} />
-      {/* EL ACCESO AL PÁRAMO: el páramo VISIBLE — el Ent-queñua magnífico
-          parado en el filo entre frailejones. Tocarlo entra al monte. */}
-      <VistaParamoEnt
-        alturaDe={alturaTerreno}
-        tier={tier}
-        reducedMotion={reducedMotion}
-        onEntrar={portada ? null : onEntrar}
-      />
+      {/* EL ACCESO AL PÁRAMO — el Ent-queñua+frailejones del filo (VistaParamoEnt)
+          se ARCHIVÓ 2026-07-18 (pedido del operador): se veía amontonado en la
+          vista del valle. Ver src/mockups/valle/_archivo/vistaParamo.archivado.jsx.
+          El portal REAL al páramo NO estaba aquí y sigue intacto: el lugar
+          'paramo' de valleData.js (su propio rótulo tocable en el valle) sigue
+          llevando a MundoParamo3D vía wire3DNav.js `paramo: 'diorama_paramo'`. */}
       {/* El cóndor: planea su térmica sobre el filo del páramo y a ratos se
           POSA en el pico de la cordillera, de día (de noche duerme en la
           peña). Un billboard: vive en todos los tiers. */}
@@ -2058,6 +2193,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = nu
       )}
       <CompaneroAbeja
         foco={foco}
+        focoId={focoId}
         entrando={entrando}
         animo={animo}
         energia={energia}

--- a/src/mockups/valle/_archivo/vistaParamo.archivado.jsx
+++ b/src/mockups/valle/_archivo/vistaParamo.archivado.jsx
@@ -1,0 +1,76 @@
+/*
+ * vistaParamo.archivado.jsx — ARCHIVADO 2026-07-18, pedido del operador.
+ *
+ * El Ent-queñua MAGNÍFICO parado en el filo, rodeado de frailejones (la
+ * "vista del páramo" que antes vivía como acceso decorativo arriba del
+ * valle), se veía AMONTONADO en el cuadro general del valle 3D. Se saca de
+ * la vista — pero NO se borra: queda completo aquí por si se retoma en otra
+ * composición (una vista propia del páramo con más aire, u otro director).
+ *
+ * OJO — el PORTAL/entrada real al páramo NO estaba aquí y sigue intacto:
+ *   · src/mockups/valle/valleData.js LUGARES id:'paramo' — su propio lugar
+ *     navegable en el valle, con su rótulo (RotulosLugares) y su patio.
+ *   · src/prodApp/wire3DNav.js `paramo: 'diorama_paramo'` — lleva a
+ *     MundoParamo3D de verdad.
+ * Esta vista archivada tocaba 'disenio' (toda mi finca/bosque), no
+ * 'diorama_paramo' — un mundoId distinto al portal real de arriba.
+ *
+ * Para reactivar:
+ *   1. Copiar VISTA_PARAMO de vuelta a
+ *      src/visual/mundo3d/direccion/composicionValle.js (§3b).
+ *   2. Copiar VistaParamoEnt de vuelta a src/mockups/valle/composicionValle3D.jsx,
+ *      con el import de EntQuenua y `alApuntar`/`alSoltar` (o reusar los que
+ *      ya viven en ese archivo — son los mismos).
+ *   3. Volver a montar <VistaParamoEnt alturaDe={alturaTerreno} tier={tier}
+ *      reducedMotion={reducedMotion} onEntrar={...} /> en la <Escena> de
+ *      Valle3D.jsx, cerca de <VentanasVivas>.
+ *   4. Revisar también los 3 frailejones que lo arropaban en
+ *      valleData.js VEGETACION_PISOS (quedaron comentados ahí mismo, con
+ *      nota y coordenadas).
+ */
+import EntQuenua from '../../../visual/mundo3d/bosque/EntQuenua.jsx';
+
+/* Antes vivía en src/visual/mundo3d/direccion/composicionValle.js */
+export const VISTA_PARAMO = {
+  punto: [2.2, -7.4], // el filo alto, a la derecha de la veleta: se ve entero
+  escala: 0.62, // el Ent mide ~6 u a escala 1: aquí corona sin tapar el cielo
+  mundoId: 'disenio',
+};
+
+/* Cursor-mano al pasar sobre el Ent (antes reusaba el mismo helper de
+   composicionValle3D.jsx — se copia acá para que este archivo quede
+   autocontenido). */
+const alApuntar = (e) => {
+  e.stopPropagation();
+  document.body.style.cursor = 'pointer';
+};
+const alSoltar = () => {
+  document.body.style.cursor = '';
+};
+
+/* Antes vivía en src/mockups/valle/composicionValle3D.jsx, montado en la
+   <Escena> de Valle3D.jsx junto a <VentanasVivas>. */
+export function VistaParamoEnt({ alturaDe, tier = 'alto', reducedMotion = false, onEntrar = null }) {
+  const [x, z] = VISTA_PARAMO.punto;
+  const y = alturaDe(x, z);
+  const tierEnt = tier === 'bajo' ? 'bajo' : 'medio';
+  return (
+    <group
+      position={[x, y, z]}
+      rotation={[0, 0.5, 0]}
+      scale={VISTA_PARAMO.escala}
+      onClick={
+        onEntrar
+          ? (e) => {
+              e.stopPropagation();
+              onEntrar(VISTA_PARAMO.mundoId);
+            }
+          : undefined
+      }
+      onPointerOver={onEntrar ? alApuntar : undefined}
+      onPointerOut={onEntrar ? alSoltar : undefined}
+    >
+      <EntQuenua tier={tierEnt} reducedMotion={reducedMotion} />
+    </group>
+  );
+}

--- a/src/mockups/valle/composicionValle3D.jsx
+++ b/src/mockups/valle/composicionValle3D.jsx
@@ -20,8 +20,10 @@
  *                        operador 2026-07-18: la entrada se dice con luz).
  *   · PorticosSecundarios — los pórticos de madera SOLO para los lugares
  *                        secundarios de menos uso (eras, huerta, vivero…).
- *   · VistaParamoEnt   — el acceso al páramo: el Ent-queñua MAGNÍFICO parado
- *                        en el filo entre frailejones. El páramo se VE.
+ *   · (VistaParamoEnt ARCHIVADA 2026-07-18: el Ent-queñua del filo se veía
+ *                        amontonado en la vista del valle — ver
+ *                        _archivo/vistaParamo.archivado.jsx. El portal REAL
+ *                        al páramo sigue en valleData.js LUGARES id:'paramo'.)
  *   · SenderosValle    — la tierra pisada que nace de la casa: el rastro del
  *                        uso diario, el ojo camina por donde caminan los pies.
  *   · PatiosLugares    — el suelo desnudo bajo cada lugar navegable: la
@@ -38,14 +40,12 @@ import { CREATURES } from '../../visual/creatures/index.js';
    EL oso del valle — cuerpo casi negro, contorno neón teal, anteojos crema;
    el rubber-hose café quedó retirado). SVG puro: billboard barato. */
 import { GuardianAvatar } from '../../components/dashboard/GuardianEspiritu.jsx';
-import EntQuenua from '../../visual/mundo3d/bosque/EntQuenua.jsx';
 import {
   CASA_VALLE,
   SENDEROS_VALLE,
   PATIO,
   PORTALES_VALLE,
   PORTICOS_SECUNDARIOS,
-  VISTA_PARAMO,
   JERARQUIA_PERSONAJES,
   VECINOS_VALLE,
 } from '../../visual/mundo3d/direccion/composicionValle.js';
@@ -736,36 +736,14 @@ export function PorticosSecundarios({ mundos, alturaDe }) {
   );
 }
 
-/* ── LA VISTA DEL PÁRAMO: el Ent-queñua magnífico en el filo ─────────────
-   Regla del operador: el acceso al páramo ES el páramo visible — arriba, el
-   Ent (queñua/Polylepis, mallas reales de EntQuenua) parado entre los
-   frailejones, meciéndose con el viento del páramo. Tocarlo entra al mundo
-   del monte. El detalle va con techo 'medio' (el 'alto' pleno es para SU
-   mundo; aquí es un habitante del fondo, no la escena entera). */
-export function VistaParamoEnt({ alturaDe, tier = 'alto', reducedMotion = false, onEntrar = null }) {
-  const [x, z] = VISTA_PARAMO.punto;
-  const y = alturaDe(x, z);
-  const tierEnt = tier === 'bajo' ? 'bajo' : 'medio';
-  return (
-    <group
-      position={[x, y, z]}
-      rotation={[0, 0.5, 0]}
-      scale={VISTA_PARAMO.escala}
-      onClick={
-        onEntrar
-          ? (e) => {
-              e.stopPropagation();
-              onEntrar(VISTA_PARAMO.mundoId);
-            }
-          : undefined
-      }
-      onPointerOver={onEntrar ? alApuntar : undefined}
-      onPointerOut={onEntrar ? alSoltar : undefined}
-    >
-      <EntQuenua tier={tierEnt} reducedMotion={reducedMotion} />
-    </group>
-  );
-}
+/* ── LA VISTA DEL PÁRAMO — ARCHIVADA 2026-07-18 ───────────────────────────
+   `VistaParamoEnt` (el Ent-queñua magnífico parado en el filo, entre
+   frailejones) se sacó de la vista del valle: se veía amontonada en el
+   cuadro (pedido del operador). Componente completo conservado, NO
+   borrado — ver src/mockups/valle/_archivo/vistaParamo.archivado.jsx para
+   reactivarlo. El portal/entrada REAL al páramo no vivía aquí — sigue
+   intacto en valleData.js LUGARES id:'paramo' → wire3DNav.js
+   `paramo: 'diorama_paramo'` → MundoParamo3D. */
 
 /* ── Senderos: cintas de tierra pisada posadas sobre el terreno ──────────
    Un tubo enterrado a medias por sendero (queda la venita superior visible):

--- a/src/mockups/valle/rotulosValle3D.css
+++ b/src/mockups/valle/rotulosValle3D.css
@@ -86,3 +86,40 @@
     transition: none;
   }
 }
+
+/* ── La burbuja de Angelita DENTRO del canvas (CompaneroAbeja, cerebro
+      cableado 2026-07-18): el comentario grounded de useAngelitaStore —
+      husmeo autónomo o al entrar de verdad a un mundo. Mismo lenguaje
+      visual que .valle-companero (la burbuja DOM de la entrada, en
+      entradaValle3D.css): la misma voz en dos capas distintas. */
+.valle-abeja__burbuja {
+  max-width: 220px;
+  padding: 0.4rem 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(15, 24, 30, 0.84);
+  color: rgba(255, 255, 255, 0.96);
+  font-family: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.25;
+  text-align: center;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+  animation: valle-abeja-burbuja-in 0.35s ease both;
+}
+/* Un aviso (severidad, prioridad alta) se tiñe cálido — se distingue del
+   husmeo tranquilo sin gritar. */
+.valle-abeja__burbuja--aviso {
+  border-color: rgba(255, 207, 135, 0.55);
+  background: rgba(58, 34, 5, 0.86);
+}
+@keyframes valle-abeja-burbuja-in {
+  from { opacity: 0; transform: translateY(6px) scale(0.92); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .valle-abeja__burbuja {
+    animation: none;
+  }
+}

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -101,11 +101,15 @@ export const VEGETACION_PISOS = [
   { piso: 'paramo', pos: [-5.6, -7.8] },
   { piso: 'paramo', pos: [1.2, -8.3] },
   { piso: 'paramo', pos: [4.8, -6.6] },
-  // Los frailejones que ARROPAN al Ent de la vista del páramo (VISTA_PARAMO
-  // en [2.2, -7.4]): el filo se lee páramo de verdad, no un solo mojón.
-  { piso: 'paramo', pos: [3.3, -7.9] },
-  { piso: 'paramo', pos: [2.9, -6.6] },
-  { piso: 'paramo', pos: [-7.4, -6.9] },
+  // ARCHIVADO 2026-07-18 (pedido del operador): estos 3 frailejones extra
+  // arropaban al Ent-queñua de la vista del páramo en [2.2, -7.4]
+  // (VistaParamoEnt, ver src/mockups/valle/_archivo/vistaParamo.archivado.jsx),
+  // que se sacó de la vista del valle por amontonada. Sin el Ent no hacen
+  // falta — el páramo ya se lee con los 3 de arriba. Si se reactiva el Ent,
+  // reactivar también estos tres:
+  //   { piso: 'paramo', pos: [3.3, -7.9] },
+  //   { piso: 'paramo', pos: [2.9, -6.6] },
+  //   { piso: 'paramo', pos: [-7.4, -6.9] },
   { piso: 'frio', pos: [-6.0, -3.6] },
   { piso: 'frio', pos: [3.0, -4.4] },
   { piso: 'frio', pos: [-7.6, -2.4] },

--- a/src/prodApp/wire3DNav.js
+++ b/src/prodApp/wire3DNav.js
@@ -14,10 +14,13 @@
 
 /** @type {Record<string, string>} */
 export const RUTA_2D_DESDE_3D = {
-  // ── La casa del valle (vía SECUNDARIA, fix del operador 2026-07-16):
-  //    tocar la puerta iluminada lleva a la ventana-puerta de los mundos.
-  //    La entrada principal a cada mundo es su portal-paisaje directo. ──
-  casa: 'ventana_valle',
+  // ── La casa del valle (vía SECUNDARIA, fix del operador 2026-07-16,
+  //    recableada 2026-07-18): tocar la puerta iluminada lleva al MIRADOR
+  //    DE LOS MUNDOS — VitrinaMaestraMundos, la puerta maestra a los 15
+  //    mundos 3D por piso térmico (con su viaje Odyssey), no la ventana
+  //    plana de antes. La entrada principal a cada mundo sigue siendo su
+  //    portal-paisaje directo en el valle. ──
+  casa: 'vitrina_maestra',
 
   // ── Mundos principales del valle (valleData.js LUGARES) ─────────
   agua: 'agua',

--- a/src/visual/mundo3d/direccion/composicionValle.js
+++ b/src/visual/mundo3d/direccion/composicionValle.js
@@ -138,16 +138,15 @@ export const PORTALES_VALLE = [
    vista (el Ent magnífico arriba). */
 export const PORTICOS_SECUNDARIOS = ['suelo', 'sanidad', 'semillero', 'abono', 'agua', 'micorrizas'];
 
-/* ── 3b. LA VISTA DEL PÁRAMO (el acceso de arriba) ───────────────────────
-   Regla del operador: el acceso al páramo ES el páramo visible — el
-   Ent-queñua MAGNÍFICO parado en el filo, rodeado de frailejones, no un
-   torii. Tocarlo entra al mundo del monte ('disenio': toda mi finca, de
-   donde se cuida el páramo). */
-export const VISTA_PARAMO = {
-  punto: [2.2, -7.4], // el filo alto, a la derecha de la veleta: se ve entero
-  escala: 0.62, // el Ent mide ~6 u a escala 1: aquí corona sin tapar el cielo
-  mundoId: 'disenio',
-};
+/* ── 3b. LA VISTA DEL PÁRAMO — ARCHIVADA 2026-07-18 ──────────────────────
+   El Ent-queñua parado en el filo + los frailejones que lo arropaban se
+   veían amontonados en la vista del valle (pedido del operador): se
+   ARCHIVARON completos, NO se borraron — ver
+   src/mockups/valle/_archivo/vistaParamo.archivado.jsx (VISTA_PARAMO +
+   VistaParamoEnt), listos para retomarse en otra composición.
+   El PORTAL/entrada REAL al páramo no vivía aquí y sigue intacto:
+   valleData.js LUGARES id:'paramo' (su propio rótulo en el valle) →
+   wire3DNav.js `paramo: 'diorama_paramo'` → MundoParamo3D. */
 
 /* ── 4. LOS SENDEROS (la mano del campesino sobre el terreno) ────────────
    Caminos de tierra pisada que NACEN de la casa: el rastro honesto del uso


### PR DESCRIPTION
## Resumen

Tres cambios de código sobre el valle 3D (rama base `integra/todo-3d-a-prod`), sin arte nuevo:

**A — Cablear el cerebro de Angelita (revive la abeja)**
- `useAngelitaStore`/`angelitaInteligencia` existían, construidos y DESCONECTADOS (solo su propio test los consumía).
- `CompaneroAbeja` (`src/mockups/valle/Valle3D.jsx`) ahora lo consume:
  - **Husmeo autónomo con cooldown**: en reposo, cada ~40s intenta acercarse a uno de los 6 portales principales y comentar; el propio store decide si de verdad interrumpe (cooldown 20 min por mundo). Nunca a mitad de un viaje real, nunca con `reduced-motion` — reconcilia el feedback previo "posición de calma, no husmea errática" con el pedido de que la abeja muestre información.
  - **Navegación real**: al entrar/salir de un mundo de verdad (`focoId`), husmea ese lugar de verdad (`entrarMundo`) o vuelve a calma.
  - Burbuja visible (`role="status" aria-live="polite"`) con el comentario grounded del motor — nunca inventa datos agronómicos (usa los fallbacks honestos ya escritos en `angelitaInteligencia.js`).
- `AgentFab.jsx` cablea `notificacionesInteligentes()` con datos REALES (`useAlertStore` + `useLogStore.getPendingTasks`) al mismo `useAgentNotificationStore` que ya consumían AgentFab/AgentScreen — el FAB brilla con un aviso real, sin pisar un husmeo en curso de la abeja del valle.

**B — Archivar el Ent+páramo amontonado**
- `VistaParamoEnt` (el Ent-queñua + frailejones del filo, `VISTA_PARAMO`) se saca de la vista del valle — se veía amontonado. Se ARCHIVA completo (no se borra) en `src/mockups/valle/_archivo/vistaParamo.archivado.jsx`, con nota de cómo reactivarlo.
- El portal/entrada REAL al páramo no vivía en ese código y sigue intacto: `valleData.js` LUGARES `id:'paramo'` (su propio rótulo tocable) → `wire3DNav.js` `paramo: 'diorama_paramo'` → `MundoParamo3D`.
- Los 3 frailejones que "arropaban" al Ent quedan comentados con nota en `valleData.js` (con sus coordenadas, por si se reactiva).

**C — La casa abre el mirador de los mundos**
- `wire3DNav.js` `casa:` pasa de `'ventana_valle'` a `'vitrina_maestra'` — tocar la puerta de la casa ahora abre `VitrinaMaestraMundos` (la puerta maestra a los 15 mundos por piso térmico, con su viaje Odyssey), no la ventana plana de antes.

## Verificación

- `npm run build:prod` → verde.
- Playwright (chromium del sistema, swiftshader) contra `npm run dev`, ruta `#/valle3d?ciclo=11` (día) y `?ciclo=21` (noche):
  - La abeja husmea y muestra su burbuja con comentario grounded al cargar (visible en ambas capturas).
  - El Ent+páramo amontonado ya NO aparece en la vista del valle; el portal real al páramo (🏔️) sigue visible.
  - Sin negro de canvas ni crash; solo warnings benignos de entorno (env var de farmOS, 502 de backends no disponibles en local).
- Click-through real sobre la casa (`scripts/diag/click-casa.mjs`, versionado): el hash cambia a `#vitrina_maestra` y se monta "El mirador de los mundos" con sus arcos por piso térmico.
- `dist-prod/` restaurado a HEAD antes de commitear — el PR es solo fuentes.

## Test plan

- [ ] Revisar capturas del valle de día/noche (abeja con burbuja, sin Ent amontonado)
- [ ] Revisar captura del mirador tras tocar la casa
- [ ] `npm run build:prod` en CI