### PR TITLE
feat(valle): re-aplica abeja inteligente + acceso al páramo sobre v2 limpio

### DIFF
--- a/scripts/diag/valle-fino-click-paramo.mjs
+++ b/scripts/diag/valle-fino-click-paramo.mjs
@@ -1,0 +1,38 @@
+import { chromium } from 'playwright';
+
+const OUT = '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad';
+const URL = 'http://localhost:4183/?ciclo=11#/valle3d';
+
+async function main() {
+  const browser = await chromium.launch({
+    executablePath: '/run/current-system/sw/bin/chromium',
+    args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--no-sandbox'],
+  });
+  const page = await browser.newPage({ viewport: { width: 1350, height: 900 } });
+  const errors = [];
+  page.on('pageerror', (err) => errors.push('pageerror: ' + err.message));
+
+  await page.goto(URL, { waitUntil: 'commit' });
+  await page.waitForTimeout(9000);
+
+  // El rótulo del páramo (chip con el emoji de montaña) — buscar el botón cuyo texto/aria mencione "páramo".
+  const boton = page.locator('[class*="valle-poi"]', { hasText: /p.ramo/i }).first();
+  const existe = await boton.count();
+  console.log('boton paramo encontrado (por texto):', existe);
+
+  // Fallback: cualquier v3d-poi con emoji de montaña 🏔️
+  const porEmoji = page.getByText('🏔️').first();
+  const existeEmoji = await porEmoji.count();
+  console.log('emoji montaña encontrado:', existeEmoji);
+
+  const target = existe ? boton : porEmoji;
+  await target.click({ force: true, timeout: 5000 }).catch((e) => console.log('click fallo:', e.message));
+  await page.waitForTimeout(2500);
+  await page.screenshot({ path: `${OUT}/valle-fino-paramo-click.png` });
+  console.log('screenshot tras click listo');
+  console.log('ERRORS:', JSON.stringify(errors, null, 2));
+
+  await browser.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/diag/valle-fino-verify.mjs
+++ b/scripts/diag/valle-fino-verify.mjs
@@ -1,0 +1,44 @@
+import { chromium } from 'playwright';
+
+const OUT = '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad';
+const URL = 'http://localhost:4183/?ciclo=11#/valle3d';
+
+async function main() {
+  const browser = await chromium.launch({
+    executablePath: '/run/current-system/sw/bin/chromium',
+    args: [
+      '--use-gl=angle',
+      '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader',
+      '--no-sandbox',
+    ],
+  });
+  const page = await browser.newPage({ viewport: { width: 1350, height: 900 } });
+  const consoleErrors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', (err) => consoleErrors.push('pageerror: ' + err.message));
+
+  console.log('goto...');
+  await page.goto(URL, { waitUntil: 'commit' });
+  await page.waitForTimeout(11000);
+
+  await page.screenshot({ path: `${OUT}/valle-fino-panoramica.png` });
+  console.log('shot 1 done');
+
+  await page.waitForTimeout(6000); // dar tiempo a que el primer husmeo (5.2s) muestre burbuja
+  await page.screenshot({ path: `${OUT}/valle-fino-husmeo.png` });
+  console.log('shot 2 done');
+
+  await page.setViewportSize({ width: 480, height: 900 });
+  await page.waitForTimeout(1500);
+  await page.screenshot({ path: `${OUT}/valle-fino-retrato.png` });
+  console.log('shot 3 done');
+
+  console.log('CONSOLE ERRORS:', JSON.stringify(consoleErrors.slice(0, 20), null, 2));
+
+  await browser.close();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -36,6 +36,12 @@ import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
 /* La CAPA DE ESTADO de Angelita (auditoría §5b): módulo puro, sin three — el
    mismo repertorio (mojada/sed/comiendo/vuelo) que usan los mundos 3D. */
 import { reaccionDeFinca, ESTADO_FINCA_MUESTRA } from '../../visual/mundo3d/escenas/reaccionFinca.js';
+/* EL CEREBRO DE ANGELITA (re-aplicado tras el rollback a v2, 2026-07-18):
+   estaba construido y DESCONECTADO del valle — ningún componente vivo lo
+   consumía. La abeja del valle (CompaneroAbeja) lo usa para husmear con
+   criterio: comentarios grounded por mundo, con la anti-molestia (cooldowns)
+   resuelta adentro del store. */
+import useAngelitaStore from '../../store/useAngelitaStore';
 import { Colibri } from '../../visual/creatures/Colibri.jsx';
 import { Mariposa } from '../../visual/creatures/Mariposa.jsx';
 import { Escarabajo } from '../../visual/creatures/Escarabajo.jsx';
@@ -81,6 +87,37 @@ import {
       escena entera consume ESTA lista — geometría, rótulos, faro y foco. ── */
 const MUNDOS_DIR = componerMundos(MUNDOS_VALLE);
 const MUNDO_DIR_BY_ID = Object.fromEntries(MUNDOS_DIR.map((m) => [m.id, m]));
+
+/* ── EL VOCABULARIO DE ANGELITA: los lugares del valle (valleData.js LUGARES)
+      tienen SU PROPIO id ('cafe', 'cultivos', 'micorrizas'…); el motor
+      (angelitaInteligencia.MUNDOS) habla en un vocabulario más ancho
+      ('mis_matas', 'mis_animales', 'clima', 'vender', 'aprender', 'bosque',
+      'paramo', 'finca'). Esta tabla traduce uno al otro para que
+      `comentarioDeMundo`/`entrarMundo` sepan qué decir de cada lugar
+      tocado. Solo trae los ids que hoy existen en LUGARES — nada muerto. ── */
+const LUGAR_A_MUNDO_ANGELITA = {
+  cultivos: 'mis_matas',
+  cafe: 'mis_matas',
+  suelo: 'mis_matas',
+  sanidad: 'mis_matas',
+  semillero: 'mis_matas',
+  micorrizas: 'bosque',
+  animales: 'mis_animales',
+  agua: 'clima',
+  clima: 'clima',
+  mercado: 'vender',
+  disenio: 'bosque',
+  paramo: 'paramo',
+};
+
+/* Los lugares que Angelita husmea SOLA en reposo — rotan uno a la vez,
+   espaciados por HUSMEO_CADA_MS; el propio store (cooldown de 20 min por
+   mundo) decide si de verdad vale la pena interrumpir. Nunca a mitad de un
+   viaje real, nunca con reduced-motion. */
+const HUSMEO_LUGARES = ['cultivos', 'animales', 'clima', 'mercado', 'disenio', 'paramo'];
+const HUSMEO_PRIMERO_MS = 5200; // el primer husmeo llega pronto: se ve viva al cargar
+const HUSMEO_CADA_MS = 40000; // cadencia entre intentos de husmeo autónomo
+const HUSMEO_VISIBLE_MS = 7200; // cuánto dura el comentario antes de volver a calma
 
 /* Altura del terreno por (x,z): la LADERA ANDINA. El eje z es la montaña — al
    fondo (z negativo) trepa al páramo alto, al frente (z positivo) baja a tierra
@@ -1042,7 +1079,7 @@ function Beacon({ onAlerta, reducedMotion, conLuz = true }) {
       mundo (`entrando`), BAJA y se acerca al lugar — "entra" al mundo, y la
       cámara la acompaña. Su ánimo/energía (salud real de la finca) tiñen su
       color, su aura y qué tan vivo es su vuelo. Mira hacia donde viaja. ── */
-function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false, posRef = null, conLuz = false }) {
+function CompaneroAbeja({ foco, focoId = null, entrando, animo, energia, reducedMotion, estadoFinca = null, hayAlerta = false, posRef = null, conLuz = false }) {
   const ref = useRef(null);
   const caraRef = useRef(null);
   const prevX = useRef(foco.x);
@@ -1055,6 +1092,71 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
   const animoReal = reaccion?.animo ?? animo;
   const energiaReal = reaccion?.energia ?? energia;
   const vuelo = reaccion?.vuelo;
+
+  // ── EL CEREBRO (re-aplicado 2026-07-18 tras el rollback a v2): dos
+  //    disparadores alimentan el MISMO store — un solo `estado`/`mensaje` en
+  //    vivo, arbitrado por angelitaInteligencia con su anti-molestia:
+  //      1) NAVEGACIÓN REAL: al entrar a un mundo de verdad (focoId), un
+  //         comentario grounded de ESE mundo.
+  //      2) HUSMEO AUTÓNOMO: en reposo, cada tanto se acerca sola a un
+  //         portal y comenta — el store decide si de verdad interrumpe.
+  const estadoAngelita = useAngelitaStore((s) => s.estado);
+  const mensajeAngelita = useAngelitaStore((s) => s.mensaje);
+  const entrarMundoAngelita = useAngelitaStore((s) => s.entrarMundo);
+  const reposarAngelita = useAngelitaStore((s) => s.reposar);
+
+  // 1) Navegación real: al entrar/salir de un mundo de verdad, la abeja
+  //    husmea ese lugar (o vuelve a calma al salir).
+  const focoIdPrevio = useRef(focoId);
+  useEffect(() => {
+    if (focoId && focoId !== focoIdPrevio.current) {
+      entrarMundoAngelita(LUGAR_A_MUNDO_ANGELITA[focoId] || 'finca', {});
+    } else if (!focoId && focoIdPrevio.current) {
+      reposarAngelita();
+    }
+    focoIdPrevio.current = focoId;
+  }, [focoId, entrarMundoAngelita, reposarAngelita]);
+
+  // 2) Husmeo autónomo: nunca a mitad de un viaje real (entrandoRef, para que
+  //    un viaje NO reinicie la cadencia), nunca con reduced-motion. El lugar
+  //    que autónomamente mira ahora vive en un ref — no repinta el árbol.
+  const entrandoRef = useRef(entrando);
+  useEffect(() => { entrandoRef.current = entrando; }, [entrando]);
+  const husmeoIdx = useRef(0);
+  const husmeoLugarRef = useRef(null);
+  useEffect(() => {
+    if (reducedMotion) return undefined;
+    let vivo = true;
+    let temporizador = null;
+    let ocultarTimer = null;
+    const tick = () => {
+      if (!vivo) return;
+      if (!entrandoRef.current) {
+        const lugar = HUSMEO_LUGARES[husmeoIdx.current % HUSMEO_LUGARES.length];
+        husmeoIdx.current += 1;
+        const mundo = LUGAR_A_MUNDO_ANGELITA[lugar];
+        const decision = mundo ? entrarMundoAngelita(mundo, {}) : null;
+        if (decision?.interrumpe) {
+          husmeoLugarRef.current = lugar;
+          if (ocultarTimer) clearTimeout(ocultarTimer);
+          ocultarTimer = setTimeout(() => {
+            husmeoLugarRef.current = null;
+            reposarAngelita();
+          }, HUSMEO_VISIBLE_MS);
+        }
+      }
+      temporizador = setTimeout(tick, HUSMEO_CADA_MS);
+    };
+    temporizador = setTimeout(tick, HUSMEO_PRIMERO_MS);
+    return () => {
+      vivo = false;
+      if (temporizador) clearTimeout(temporizador);
+      if (ocultarTimer) clearTimeout(ocultarTimer);
+    };
+    // `entrando` vive en entrandoRef a propósito: un viaje real no debe
+    // reiniciar la cadencia del husmeo autónomo.
+  }, [reducedMotion, entrarMundoAngelita, reposarAngelita]);
+
   useFrame((state) => {
     if (!ref.current) return;
     const t = state.clock.elapsedTime;
@@ -1067,16 +1169,27 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
     const brio = (0.35 + 0.65 * energiaReal) * mVel; // energía y clima animan el vuelo
     const bob = reducedMotion ? 0 : Math.sin(t * (1.6 + brio)) * (0.1 + 0.16 * brio);
     const tembleque = tiembla ? Math.sin(t * 13) * tiembla : 0;
-    // Al reposo deriva en un círculo calmo; al entrar se posa junto al lugar.
-    const vagarX = reducedMotion || entrando ? 0 : Math.sin(t * 0.55) * 0.9 * mVagar;
-    const vagarZ = reducedMotion || entrando ? 0 : Math.cos(t * 0.55) * 0.6 * mVagar;
-    const alto = (entrando ? 1.05 : 2.3) * mAltura;
+    // HUSMEO AUTÓNOMO: mientras no hay viaje real, el lugar que el store
+    // aceptó (husmeoLugarRef) manda un ancla temporal — un solo lugar a la
+    // vez, nunca un círculo errático. Nunca pisa una navegación real.
+    const lugarHusmeo = !entrando ? husmeoLugarRef.current : null;
+    const mundoHusmeo = lugarHusmeo ? MUNDO_DIR_BY_ID[lugarHusmeo] : null;
+    const ancla = mundoHusmeo
+      ? { x: mundoHusmeo.pos[0], y: alturaTerreno(mundoHusmeo.pos[0], mundoHusmeo.pos[2]), z: mundoHusmeo.pos[2] }
+      : foco;
+    // Al reposo deriva en un círculo calmo; al entrar (real o husmeado) se
+    // posa junto al lugar.
+    const vagarX = reducedMotion || entrando || mundoHusmeo ? 0 : Math.sin(t * 0.55) * 0.9 * mVagar;
+    const vagarZ = reducedMotion || entrando || mundoHusmeo ? 0 : Math.cos(t * 0.55) * 0.6 * mVagar;
+    const alto = (entrando ? 1.05 : mundoHusmeo ? 1.6 : 2.3) * mAltura;
     const dest = new THREE.Vector3(
-      foco.x + (entrando ? 0.55 : 0.4 + vagarX) + tembleque,
-      foco.y + alto + bob + tembleque * 0.5,
-      foco.z + (entrando ? 0.7 : 0.6 + vagarZ),
+      ancla.x + (entrando ? 0.55 : 0.4 + vagarX) + tembleque,
+      ancla.y + alto + bob + tembleque * 0.5,
+      ancla.z + (entrando ? 0.7 : 0.6 + vagarZ),
     );
-    ref.current.position.lerp(dest, (entrando ? 0.05 : 0.045) * mVel);
+    // El husmeo autónomo vuela más SUAVE que una entrada real decidida.
+    const kVuelo = entrando ? 0.05 : mundoHusmeo ? 0.035 : 0.045;
+    ref.current.position.lerp(dest, kVuelo * mVel);
     // Comparte su posición viva para que la cámara de director la SIGA (follow
     // con lead): copia dentro del Vector3 compartido (mutación por método sobre
     // un local — no reasigna el prop, como CamaraViajera con controls.current).
@@ -1118,6 +1231,20 @@ function CompaneroAbeja({ foco, entrando, animo, energia, reducedMotion, estadoF
           </div>
         </div>
       </Html>
+      {/* EL CEREBRO SE VE: cuando Angelita husmea (sola o de verdad) o avisa
+          algo, lo dice en una burbuja — nunca queda muda. aria-live para que
+          también se narre a lectores de pantalla. */}
+      {mensajeAngelita && (
+        <Html center position={[0, 1.3, 0]} distanceFactor={9} zIndexRange={[45, 20]} style={{ pointerEvents: 'none' }}>
+          <div
+            className={`valle-abeja__burbuja valle-abeja__burbuja--${estadoAngelita}`}
+            role="status"
+            aria-live="polite"
+          >
+            {mensajeAngelita}
+          </div>
+        </Html>
+      )}
     </group>
   );
 }
@@ -1621,6 +1748,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
       )}
       <CompaneroAbeja
         foco={foco}
+        focoId={focoId}
         entrando={entrando}
         animo={animo}
         energia={energia}

--- a/src/mockups/valle/rotulosValle3D.css
+++ b/src/mockups/valle/rotulosValle3D.css
@@ -81,8 +81,37 @@
   min-height: 48px;
 }
 
+/* ── La BURBUJA DEL CEREBRO: lo que Angelita dice cuando husmea o avisa
+      (CompaneroAbeja, Valle3D.jsx) — un <Html> anclado a su vuelo dentro de
+      la escena, no un overlay de pantalla. Misma familia visual que
+      .valle-companero de la entrada (pastilla oscura translúcida, texto
+      blanco): consistente con el valle limpio, sin halos ni marcos nuevos. */
+.valle-abeja__burbuja {
+  max-width: 15rem;
+  padding: 0.4rem 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(15, 24, 30, 0.78);
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 0.82rem;
+  line-height: 1.25;
+  text-align: center;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.32);
+  animation: valle-abeja-burbuja-in 0.35s ease both;
+}
+.valle-abeja__burbuja--aviso {
+  border-color: rgba(255, 190, 120, 0.4);
+}
+@keyframes valle-abeja-burbuja-in {
+  from { opacity: 0; transform: translateY(4px) scale(0.94); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .v3d-poi {
     transition: none;
+  }
+  .valle-abeja__burbuja {
+    animation: none;
   }
 }

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -142,15 +142,34 @@ const LUGARES = [
   // los cultivos): unos hongos que asoman = el fruto de la red bajo tierra. Toque
   // ahí para BAJAR al mundo subterráneo. (anti-conflicto: lugar nuevo al final.)
   { id: 'micorrizas', pos: [-2.7, 0, 3.3], escala: 1, tipo: 'hongos' },
+  // EL PÁRAMO (la puerta de arriba): el acceso al alto andino, en el filo frío
+  // del valle (piso 'paramo', ver PISOS_TERMICOS). Tocarlo sube a MundoParamo3D
+  // (wire3DNav `paramo: 'diorama_paramo'`). Ícono simple — SIN Ent-queñua ni
+  // frailejones amontonados alrededor (eso fue el clutter de la v1 descartada):
+  // un portal limpio, igual que los demás lugares del valle. Sin mundo propio
+  // en el manifiesto real: trae su identidad de respaldo (`fallbackMundo`).
+  {
+    id: 'paramo',
+    pos: [-0.9, 0, -7.6],
+    escala: 0.95,
+    tipo: 'frailejonal',
+    fallbackMundo: {
+      titulo: 'El páramo',
+      emoji: '🏔️',
+      lema: 'El frailejonal que le peina el agua a la niebla y se la guarda a la finca.',
+      tinte: ['#63807a', '#c9d8d2'],
+    },
+  },
 ];
 
 /**
  * Mundos del valle, ya resueltos contra el manifiesto real. Cada uno trae su
- * `titulo`, `emoji` y `tinte` verdaderos + la geometría de su lugar.
+ * `titulo`, `emoji` y `tinte` verdaderos + la geometría de su lugar. Un lugar
+ * sin mundo en el manifiesto (ej. el páramo) usa su `fallbackMundo`.
  */
 export const MUNDOS_VALLE = LUGARES.map((l) => {
   /** @type {{ titulo?: string, emoji?: string, lema?: string, tinte?: string[] }} */
-  const real = MUNDO_BY_ID[l.id] || {};
+  const real = MUNDO_BY_ID[l.id] || l.fallbackMundo || {};
   return {
     ...l,
     titulo: real.titulo || l.id,


### PR DESCRIPTION
## Resumen

Tras el rollback del valle a v2 (`6f7f839b`), 3 features se habían perdido. Se re-aplican de forma **aditiva mínima** sobre el v2 limpio actual (referencia: `ops/valle-comparacion-evidencia/v2-panoramica.png`).

- **Abeja inteligente**: `CompaneroAbeja` (`src/mockups/valle/Valle3D.jsx`) ahora consume `useAngelitaStore` — husmea con COOLDOWN un portal a la vez en reposo (nunca a mitad de un viaje real, nunca con `reducedMotion`) y también al entrar/salir de un mundo de verdad, mostrando una burbuja `<Html>` con el comentario grounded del motor (`angelitaInteligencia`). `AgentFab.jsx` **ya tenía** `notificacionesInteligentes()` cableada — sobrevivió al rollback porque el revert no tocó ese archivo.
- **Casa → mirador de mundos**: `wire3DNav.js` `casa: 'vitrina_maestra'` **ya estaba** — tampoco fue tocado por el revert.
- **Acceso al páramo**: nuevo lugar `id:'paramo'` en `valleData.js` LUGARES — ícono simple (cae al `default` de `LandmarkGeom`, un icosaedro chico), **sin** Ent-queñua ni frailejones amontonados (eso fue el clutter de la v1 descartada). Sube a `MundoParamo3D` vía `wire3DNav` (`paramo: 'diorama_paramo'`, ya existente). `MUNDOS_VALLE` ahora soporta `fallbackMundo` para lugares sin mundo propio en el manifiesto real.

`composicionValle3D.jsx` **no se tocó** — sigue en 235 líneas, v2 intacto.

## Verificación

- `npm run build:prod` verde.
- Playwright (chromium del sistema, `--use-gl=angle --use-angle=swiftshader --enable-unsafe-swiftshader --no-sandbox`, `waitUntil:'commit'`) sobre `vite preview --outDir dist-prod`:
  - Panorámica del valle: sin aros/halos/discos/faroles, igual de limpio que `v2-panoramica.png`.
  - La abeja mostró su burbuja de húsmeo con texto grounded real (`COMENTARISTA_MUNDO.mis_matas()`).
  - Click en el portal del páramo abrió su card ("El páramo — El frailejonal que le peina el agua a la niebla...") sin clutter, sin errores de consola.
- `dist-prod/` restaurado a HEAD antes de commitear (no es parte de este diff).

## Test plan

- [ ] Revisar capturas del PR / correr `node scripts/diag/valle-fino-verify.mjs` y `node scripts/diag/valle-fino-click-paramo.mjs` contra un `vite preview --outDir dist-prod`.
- [ ] Confirmar visualmente que el valle sigue viéndose v2 (sin clutter) en `#/valle3d`.
- [ ] Confirmar que el portal del páramo navega a `MundoParamo3D` en el shell de prod (`diorama_paramo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)