### PR TITLE
art(mundo): leguminosas y raíces andinas 3D — fríjol con nódulos, yuca, quinua

### DIFF
--- a/scripts/diag/_shot-valle-noche.mjs
+++ b/scripts/diag/_shot-valle-noche.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/* Captura del valle con franja fija (?ciclo=N) — teléfono y desktop. */
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { chromium } from 'playwright';
+
+const BASE = process.env.SHOT_BASE || 'http://127.0.0.1:5173';
+const CICLO = process.env.SHOT_CICLO || '22';
+const OUTDIR = process.env.SHOT_OUTDIR || '/tmp/claude-1000/-home-kortux/93695a3d-dc16-45f5-8c0e-608e6e767ffd/scratchpad/shots';
+const TAG = process.env.SHOT_TAG || 'base';
+const RUTA = process.env.SHOT_RUTA || '/#/mockups/entrada-3d';
+const ESPERA = Number(process.env.SHOT_ESPERA || 9000);
+
+function chromiumPath() {
+  if (process.env.PLAYWRIGHT_CHROMIUM_PATH) return process.env.PLAYWRIGHT_CHROMIUM_PATH;
+  try {
+    const w = execSync('which chromium 2>/dev/null', { encoding: 'utf8' }).trim();
+    if (w) return w;
+  } catch { /* noop */ }
+  return undefined;
+}
+
+mkdirSync(OUTDIR, { recursive: true });
+
+const browser = await chromium.launch({
+  ...(chromiumPath() ? { executablePath: chromiumPath() } : {}),
+  args: [
+    '--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage',
+    ...(process.env.SHOT_GL ? process.env.SHOT_GL.split(' ') : []),
+  ],
+});
+
+const vistas = [
+  { nombre: 'tel', viewport: { width: 390, height: 844 }, mobile: true },
+  { nombre: 'desk', viewport: { width: 1366, height: 768 }, mobile: false },
+];
+
+for (const v of vistas) {
+  const ctx = await browser.newContext({
+    viewport: v.viewport,
+    isMobile: v.mobile,
+    hasTouch: v.mobile,
+    deviceScaleFactor: v.mobile ? 2 : 1,
+    locale: 'es-CO',
+    ...(process.env.SHOT_CALMA ? { reducedMotion: 'reduce' } : {}),
+  });
+  const page = await ctx.newPage();
+  const errores = [];
+  page.on('pageerror', (e) => errores.push(e.message));
+  const url = `${BASE}${RUTA}?ciclo=${CICLO}`;
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForTimeout(ESPERA);
+  const out = `${OUTDIR}/valle-${TAG}-c${CICLO}-${v.nombre}.png`;
+  await page.screenshot({ path: out });
+  const cam = await page.evaluate(() => JSON.stringify(window.__valleCam || null));
+  console.log(`[shot] ${out} cam=${cam} ${errores.length ? 'ERRORES: ' + errores.slice(0, 3).join(' | ') : 'ok'}`);
+  await ctx.close();
+}
+await browser.close();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -199,6 +199,10 @@ const JuegoLaMilpaMockup = lazy(() => import('./mockups/JuegoLaMilpa'));
 // 3D: el PÁRAMO altoandino — el ecosistema de la niebla (frailejones, musgo,
 // quenuas, aves) y el NACIMIENTO del agua. Didáctico: la fábrica de agua.
 const MundoParamo3DMockup = lazy(() => import('./mockups/MundoParamo3D'));
+// 3D: LEGUMINOSAS y RAÍCES ANDINAS — fríjol trepador con el CORTE de raíz y los
+// nódulos rosados de Rhizobium (nitrógeno gratis), yuca de raíz tuberosa y
+// quinua con panojas rojas/doradas/moradas. Didáctico, hora dorada.
+const MundoLeguminosas3DMockup = lazy(() => import('./mockups/MundoLeguminosas3D'));
 const CamaraDirectorDemoMockup = lazy(() => import('./mockups/CamaraDirectorDemo'));
 const MomentoVentaMercado3DMockup = lazy(() => import('./mockups/MomentoVentaMercado3D'));
 const ArtesaniaAndinaDemoMockup = lazy(() => import('./mockups/ArtesaniaAndinaDemo'));
@@ -625,6 +629,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/valle-noche-3d': 'mockup_valle_noche_3d',
   'mockups/juego-la-milpa': 'mockup_juego_la_milpa',
   'mockups/mundo-paramo-3d': 'mockup_mundo_paramo_3d',
+  'mockups/mundo-leguminosas-3d': 'mockup_mundo_leguminosas_3d',
   'mockups/camara-director': 'mockup_camara_director',
   'mockups/momento-venta-mercado-3d': 'mockup_momento_venta_mercado_3d',
   'mockups/artesania-andina': 'mockup_artesania_andina',
@@ -1402,7 +1407,16 @@ export default function App() {
   // (const en TDZ si el effect se declarara antes).
   useEffect(() => {
     const handler = () => {
-      if (currentView === 'login' || currentView === 'loading' || currentView === 'oauth-callback') {
+      // Los mockups públicos (#/mockups/*) son vitrinas SIN sesión: no deben
+      // rebotar a login por un 'session-expired' fantasma (p.ej. una llamada de
+      // fondo a farmOS que 401ea). Sin este exento, cualquier vitrina 3D pública
+      // se caía a login apenas fallaba una petición de API en segundo plano.
+      if (
+        currentView === 'login' ||
+        currentView === 'loading' ||
+        currentView === 'oauth-callback' ||
+        currentView.startsWith('mockup_')
+      ) {
         return;
       }
       logoutUser().catch(() => { /* tokens podrían persistir; getAccessToken igual da null */ });
@@ -2184,6 +2198,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El páramo altoandino">
               <MundoParamo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo_leguminosas_3d':
+        // Leguminosas y raíces andinas en 3D: el fríjol trepador con el CORTE de
+        // raíz que muestra los nódulos rosados de Rhizobium (fijación de N,
+        // abono gratis — asociar con maíz), la yuca de raíz tuberosa que aguanta
+        // el suelo pobre y la quinua con panojas rojas/doradas/moradas (proteína
+        // de altura). Hora dorada, fauna del kit. Ruta
+        // #/mockups/mundo-leguminosas-3d, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Leguminosas y raíces andinas">
+              <MundoLeguminosas3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/MundoLeguminosas3D.jsx
+++ b/src/mockups/MundoLeguminosas3D.jsx
@@ -1,0 +1,752 @@
+/*
+ * MundoLeguminosas3D — el MUNDO DE LEGUMINOSAS Y RAÍCES ANDINAS en 3D.
+ *
+ * Tres matas que le dan de comer a la familia Y a la tierra, en hora dorada:
+ *   - FRÍJOL (leguminosa trepadora): sube por su estaca con hojas y VAINAS, y a
+ *     un lado, en un CORTE del subsuelo, se ven los NÓDULOS ROSADOS de Rhizobium
+ *     en la raíz — las fábricas de nitrógeno, el abono gratis del aire. Es el
+ *     saber agroecológico clave: por eso el fríjol se asocia con el maíz.
+ *   - YUCA (arbusto de raíz tuberosa): tallo leñoso nudoso, hoja palmada de
+ *     dedos y las raíces tuberosas asomando en la base. Aguanta el suelo pobre.
+ *   - QUINUA (pseudocereal andino): tallos altos rematados en PANOJAS densas —
+ *     rojas, doradas y moradas. El color es su firma. Proteína de la altura.
+ *
+ * DIRECCIÓN DE ARTE (todo dentro del framework, nada inventado por fuera):
+ *   - La atmósfera es la MISMA hora dorada del valle: preset `CIELOS_HORA.dorada`
+ *     (espejo de `ATMOSFERA` / atmosferaMadre). Entrar a la chagra se siente como
+ *     acercarse dentro del mismo atardecer, no como abrir otra app.
+ *   - Los materiales salen tinteados hacia la niebla dorada con `mezclar` (la ley
+ *     de coherencia), conservando la identidad de cada mata (el rosado del nódulo,
+ *     el rojo/dorado/morado de la panoja).
+ *   - La fauna es la del kit (`FaunaEscena`/creatures): pocos billboards SVG bien
+ *     puestos por rol ecológico (colibrí y mariposa polinizando, escarabajo a
+ *     ras). El polen en suspensión son las `ParticulasAmbientales` (tipo=polen).
+ *
+ * RENDIMIENTO: cobertura vegetal y granos de panoja instanciados (pocos draw
+ * calls), materiales Lambert sin shadow-map, geometrías compartidas por mata.
+ * Presupuestos por `perfilDeTier`; `reducedMotion` congela el vaivén, apaga la
+ * fauna animada y pasa el frameloop a demanda. Gama baja cae al 2D digno antes de
+ * montar esto. Autocontenida: cero CDN/imágenes externas.
+ *
+ * Ruta mockup: #/mockups/mundo-leguminosas-3d (cableada en App.jsx, sin auth).
+ * Copy en español de Colombia, en "usted".
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { CIELOS_HORA } from '../visual/mundo3d/cielosHoraData.js';
+import { mezclar } from '../visual/mundo3d/atmosferaMadre.js';
+import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
+import { ParticulasAmbientales } from '../visual/mundo3d/ParticulasAmbientales.jsx';
+import { crearRng } from '../visual/mundo3d/particulasData.js';
+import { Fauna } from '../visual/mundo3d/escenas/FaunaEscena.jsx';
+
+/* La hora dorada canónica (espejo de ATMOSFERA): única fuente de la atmósfera. */
+const DORADA = CIELOS_HORA.dorada;
+const TINTE = DORADA.niebla; // tinta cálida común: "el mismo atardecer"
+
+/* La paleta de la chagra, tinteada hacia la hora dorada. Cada mata conserva su
+   identidad; los nódulos rosados y las panojas de color se dejan casi puros
+   (poco tinte) porque su color ES el saber que hay que ver. */
+const P = {
+  suelo: mezclar('#7a5a3a', TINTE, 0.28), // loam de la finca
+  sueloSeco: mezclar('#8f7248', TINTE, 0.3),
+  sueloCorte: mezclar('#402d1b', TINTE, 0.12), // el perfil oscuro del corte
+  topsoil: mezclar('#5e4530', TINTE, 0.2), // la capa fértil arriba del corte
+  pasto: mezclar('#6f9448', TINTE, 0.3), // cobertura verde
+  pastoSeco: mezclar('#a7a862', TINTE, 0.3),
+
+  // fríjol
+  estaca: mezclar('#8a6a44', TINTE, 0.3), // la vara/tutor
+  frijolTallo: mezclar('#5c8f43', TINTE, 0.28), // la enredadera
+  frijolHoja: mezclar('#4e8b3c', TINTE, 0.3), // hoja trifoliada
+  frijolHojaClara: mezclar('#71a851', TINTE, 0.28),
+  frijolVaina: mezclar('#7cae54', TINTE, 0.26), // la vaina verde
+  frijolFlor: mezclar('#ece4f0', TINTE, 0.12), // florecita lila pálida
+  raiz: mezclar('#e7dab9', TINTE, 0.18), // la raíz clara
+  nodulo: mezclar('#e386a6', TINTE, 0.06), // NÓDULO de Rhizobium (rosado)
+  noduloClaro: mezclar('#f4abc6', TINTE, 0.06),
+
+  // yuca
+  yucaTallo: mezclar('#7c5330', TINTE, 0.26), // tallo leñoso
+  yucaNudo: mezclar('#5c3c22', TINTE, 0.2), // cicatriz de hoja (nudo)
+  yucaHoja: mezclar('#3f7f39', TINTE, 0.3), // hoja palmada
+  yucaHojaClara: mezclar('#5a9a4a', TINTE, 0.28),
+  yucaTuber: mezclar('#d8b788', TINTE, 0.2), // pulpa del tubérculo
+  yucaTuberPiel: mezclar('#a67a4c', TINTE, 0.2), // piel del tubérculo
+
+  // quinua
+  quinuaTallo: mezclar('#7ea24a', TINTE, 0.28),
+  quinuaHoja: mezclar('#5f9146', TINTE, 0.28),
+  quinuaRojo: mezclar('#c1343a', TINTE, 0.08), // panoja roja
+  quinuaDorado: mezclar('#e0a52a', TINTE, 0.1), // panoja dorada
+  quinuaMorado: mezclar('#933f8a', TINTE, 0.08), // panoja morada
+};
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+function gauss(wx, wz, cx, cz, sx, sz) {
+  const dx = wx - cx, dz = wz - cz;
+  return Math.exp(-((dx * dx) / (2 * sx * sx) + (dz * dz) / (2 * sz * sz)));
+}
+/* Ruido determinista (hash de senos): misma chagra siempre, sin Math.random. */
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
+    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
+    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
+  );
+}
+
+/* La geografía: una parcela de finca (chagra) casi plana, con leves lomas de
+   siembra bajo cada mata y una suave ondulación general. */
+const ANCHO = 26;
+const FONDO = 26;
+function alturaCampo(wx, wz) {
+  let h = 0.05 + ruido(wx * 0.4, wz * 0.4) * 0.16; // ondulación suave del terreno
+  h += gauss(wx, wz, 3.6, -0.6, 1.8, 1.8) * 0.28; // loma de la yuca
+  h += gauss(wx, wz, 0.4, -2.8, 2.2, 1.8) * 0.22; // cama de la quinua
+  return Math.max(0, h);
+}
+
+/* Malla de la parcela con colores por vértice: pasto verde con motas secas y
+   surcos de tierra labrada (la chagra sembrada, no un potrero). */
+function construirCampo(seg, plano) {
+  const nx = seg + 1, nz = seg + 1;
+  const pos = new Float32Array(nx * nz * 3);
+  const col = new Float32Array(nx * nz * 3);
+  const cPasto = new THREE.Color(P.pasto);
+  const cPastoSeco = new THREE.Color(P.pastoSeco);
+  const cSuelo = new THREE.Color(P.suelo);
+  const c = new THREE.Color();
+  let p = 0;
+  for (let iz = 0; iz < nz; iz++) {
+    const wz = -FONDO / 2 + (FONDO * iz) / seg;
+    for (let ix = 0; ix < nx; ix++) {
+      const wx = -ANCHO / 2 + (ANCHO * ix) / seg;
+      const y = alturaCampo(wx, wz);
+      pos[p] = wx; pos[p + 1] = y; pos[p + 2] = wz;
+      c.lerpColors(cPasto, cPastoSeco, smoothstep(-0.5, 0.9, ruido(wx * 1.2, wz * 1.2)));
+      // surcos de tierra: bandas labradas donde se sembró
+      const surco = Math.abs(Math.sin(wx * 0.85 + wz * 0.12));
+      c.lerp(cSuelo, smoothstep(0.72, 0.98, surco) * 0.55);
+      col[p] = c.r; col[p + 1] = c.g; col[p + 2] = c.b;
+      p += 3;
+    }
+  }
+  const idx = [];
+  for (let iz = 0; iz < seg; iz++) {
+    for (let ix = 0; ix < seg; ix++) {
+      const a = iz * nx + ix, b = a + 1, d = a + nx, e = d + 1;
+      idx.push(a, d, b, b, d, e);
+    }
+  }
+  let geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  geo.setIndex(idx);
+  if (plano) geo = geo.toNonIndexed();
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/* Las luces de la hora dorada del kit: hemisferio cálido, ambiente suave, el sol
+   bajo como direccional principal y un relleno frío opuesto (cielo abierto). */
+function LucesDoradas() {
+  return (
+    <>
+      <hemisphereLight intensity={DORADA.hemisferio} color={DORADA.cielo} groundColor={DORADA.suelo} />
+      <ambientLight intensity={DORADA.ambiente} color={DORADA.luz} />
+      <directionalLight position={DORADA.solPos} intensity={DORADA.sol} color={DORADA.luz} />
+      <directionalLight position={[-6, 4, -7]} intensity={DORADA.rellenoInt} color={DORADA.relleno} />
+    </>
+  );
+}
+
+/* El sol bajo del atardecer: un disco tibio con halo. No ilumina (de eso se
+   encargan las luces); es el ancla visual de la hora. */
+function SolBajo() {
+  return (
+    <group position={[9, 7, -14]}>
+      <mesh>
+        <circleGeometry args={[1.5, 40]} />
+        <meshBasicMaterial color="#fff0cf" transparent opacity={0.95} depthWrite={false} side={THREE.DoubleSide} />
+      </mesh>
+      <mesh position={[0, 0, -0.05]}>
+        <circleGeometry args={[2.9, 40]} />
+        <meshBasicMaterial color={DORADA.luz} transparent opacity={0.22} depthWrite={false} side={THREE.DoubleSide} />
+      </mesh>
+      <mesh position={[0, 0, -0.1]}>
+        <circleGeometry args={[5.0, 40]} />
+        <meshBasicMaterial color={DORADA.cielo} transparent opacity={0.13} depthWrite={false} side={THREE.DoubleSide} />
+      </mesh>
+    </group>
+  );
+}
+
+/* ── Cobertura vegetal: matas bajas de pasto instanciadas (1 draw call), la
+      chagra no es tierra pelada. Poco dobladas, tinte verde variado. ── */
+function Cobertura({ n }) {
+  const ref = useRef(null);
+  const sitios = useMemo(() => {
+    const rng = crearRng(41);
+    const lista = [];
+    let intentos = 0;
+    while (lista.length < n && intentos < n * 8) {
+      intentos += 1;
+      const wx = (rng() - 0.5) * (ANCHO - 6);
+      const wz = (rng() - 0.5) * (FONDO - 6);
+      const y = alturaCampo(wx, wz);
+      lista.push({ wx, wz, y, esc: 0.4 + rng() * 0.6, giro: rng() * Math.PI, ladeo: (rng() - 0.5) * 0.35 });
+    }
+    return lista;
+  }, [n]);
+  useEffect(() => {
+    const m = ref.current;
+    if (!m) return;
+    const dummy = new THREE.Object3D();
+    const tinte = new THREE.Color();
+    const base = new THREE.Color(P.pasto);
+    const seco = new THREE.Color(P.pastoSeco);
+    sitios.forEach((s, i) => {
+      dummy.position.set(s.wx, s.y + 0.11 * s.esc, s.wz);
+      dummy.rotation.set(s.ladeo, s.giro, s.ladeo * 0.5);
+      dummy.scale.set(s.esc, s.esc, s.esc);
+      dummy.updateMatrix();
+      m.setMatrixAt(i, dummy.matrix);
+      tinte.copy(base).lerp(seco, (i % 6) / 6);
+      m.setColorAt(i, tinte);
+    });
+    m.instanceMatrix.needsUpdate = true;
+    if (m.instanceColor) m.instanceColor.needsUpdate = true;
+  }, [sitios]);
+  return (
+    <instancedMesh ref={ref} args={[undefined, undefined, sitios.length]} frustumCulled={false}>
+      <coneGeometry args={[0.13, 0.42, 4]} />
+      <meshLambertMaterial flatShading />
+    </instancedMesh>
+  );
+}
+
+/* Una hoja trifoliada de fríjol: tres foliolos (elipsoides aplanados) que radian
+   desde un peciolo corto. La firma de la leguminosa. */
+function HojaTrifoliada({ pos, giro = 0, esc = 1, claro = false }) {
+  const color = claro ? P.frijolHojaClara : P.frijolHoja;
+  return (
+    <group position={pos} rotation={[0, giro, 0]} scale={esc}>
+      {[0, 2.2, -2.2].map((a, i) => (
+        <mesh key={i} position={[Math.sin(a) * 0.12, 0.02 * i, Math.cos(a) * 0.12 + 0.05]} rotation={[-0.5, a, 0]} scale={[0.13, 0.02, 0.18]}>
+          <sphereGeometry args={[1, 7, 5]} />
+          <meshLambertMaterial color={color} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* Una vaina de fríjol: dos segmentos aplanados que le dan una curva de banana. */
+function Vaina({ pos, giro = 0, incl = 0 }) {
+  return (
+    <group position={pos} rotation={[incl, giro, 0.2]}>
+      <mesh position={[0, -0.11, 0]} scale={[0.045, 0.16, 0.045]}>
+        <sphereGeometry args={[1, 7, 6]} />
+        <meshLambertMaterial color={P.frijolVaina} flatShading />
+      </mesh>
+      <mesh position={[0.03, -0.28, 0]} rotation={[0, 0, 0.35]} scale={[0.04, 0.12, 0.04]}>
+        <sphereGeometry args={[1, 7, 6]} />
+        <meshLambertMaterial color={P.frijolVaina} flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/* ── EL FRÍJOL: la mata trepadora + el CORTE del subsuelo con los nódulos.
+      Anclada en la CIMA de un monolito de suelo (y=0 = la superficie): arriba la
+      enredadera con vainas; abajo, en la cara frontal del corte, la raíz con los
+      nódulos rosados de Rhizobium — el nitrógeno que no se ve, hecho visible. ── */
+function MataFrijol({ pos, reducedMotion, saber }) {
+  const flor = useRef(null);
+  const halo = useRef(null);
+  const nodulos = useRef(null);
+
+  // la enredadera como un tubo helicoidal que sube por la estaca (1 mesh).
+  const curvaVid = useMemo(() => {
+    const pts = [];
+    const vueltas = 3.2, alto = 2.0, r0 = 0.18;
+    const N = 44;
+    for (let i = 0; i <= N; i++) {
+      const t = i / N;
+      const a = t * vueltas * Math.PI * 2;
+      const r = r0 * (1 - 0.18 * t);
+      pts.push(new THREE.Vector3(Math.cos(a) * r, t * alto, Math.sin(a) * r));
+    }
+    return new THREE.CatmullRomCurve3(pts);
+  }, []);
+
+  // hojas y vainas repartidas a lo largo de la enredadera.
+  const hojas = useMemo(
+    () => [0.16, 0.34, 0.52, 0.68, 0.84].map((t, i) => {
+      const p = curvaVid.getPoint(t);
+      return { pos: [p.x * 1.5, p.y, p.z * 1.5], giro: i * 1.7, esc: 1 - t * 0.25, claro: i % 2 === 0 };
+    }),
+    [curvaVid],
+  );
+  const vainas = useMemo(
+    () => [0.44, 0.58, 0.66, 0.78].map((t, i) => {
+      const p = curvaVid.getPoint(t);
+      return { pos: [p.x * 1.7, p.y + 0.02, p.z * 1.7 + 0.04], giro: i * 2.1, incl: 0.1 + i * 0.05 };
+    }),
+    [curvaVid],
+  );
+
+  // los nódulos: puntos sobre la raíz principal y las laterales (cara frontal).
+  const puntosNodulo = useMemo(() => {
+    const rng = crearRng(19);
+    const lista = [];
+    for (let i = 0; i < 11; i++) {
+      const t = 0.12 + rng() * 0.8; // profundidad
+      const lado = (rng() - 0.5); // izquierda/derecha
+      lista.push({
+        x: lado * (0.1 + t * 0.5),
+        y: -0.12 - t * 1.05,
+        z: 0.2 + rng() * 0.05,
+        r: 0.05 + rng() * 0.035,
+        claro: i % 3 === 0,
+      });
+    }
+    return lista;
+  }, []);
+
+  useFrame(({ clock }) => {
+    const t = clock.elapsedTime;
+    if (!reducedMotion && flor.current) flor.current.rotation.z = Math.sin(t * 0.8) * 0.06;
+    if (halo.current) {
+      const objetivo = saber ? 0.5 : 0.0;
+      const pulso = reducedMotion ? 1 : 0.7 + 0.3 * Math.sin(t * 1.6);
+      halo.current.material.opacity = objetivo * pulso;
+      halo.current.visible = saber;
+    }
+    if (nodulos.current) {
+      const s = saber ? 1.28 : 1;
+      nodulos.current.scale.setScalar(reducedMotion ? s : s * (0.98 + 0.02 * Math.sin(t * 1.6)));
+    }
+  });
+
+  const groundY = alturaCampo(pos[0], pos[2]);
+  const ALTO_CORTE = 1.3; // el monolito sube esto sobre el terreno; y=0 = superficie
+
+  return (
+    <group position={[pos[0], groundY + ALTO_CORTE, pos[2]]}>
+      {/* ── EL CORTE DEL SUBSUELO (monolito): perfil oscuro + capa fértil arriba ── */}
+      <mesh position={[0, -ALTO_CORTE / 2, 0]}>
+        <boxGeometry args={[1.5, ALTO_CORTE, 0.42]} />
+        <meshLambertMaterial color={P.sueloCorte} flatShading />
+      </mesh>
+      <mesh position={[0, -0.06, 0]}>
+        <boxGeometry args={[1.52, 0.14, 0.44]} />
+        <meshLambertMaterial color={P.topsoil} flatShading />
+      </mesh>
+      {/* pastico en la cima del corte, para que lea "superficie" */}
+      {[-0.5, -0.15, 0.2, 0.55].map((x, i) => (
+        <mesh key={i} position={[x, 0.06, 0.12]} rotation={[0.1, i, 0.1]}>
+          <coneGeometry args={[0.08, 0.22, 4]} />
+          <meshLambertMaterial color={P.pasto} flatShading />
+        </mesh>
+      ))}
+
+      {/* ── LA RAÍZ en la cara frontal del corte ── */}
+      <mesh position={[0.02, -0.62, 0.19]} rotation={[0, 0, 0.06]}>
+        <coneGeometry args={[0.07, 1.15, 6]} />
+        <meshLambertMaterial color={P.raiz} flatShading />
+      </mesh>
+      {[
+        [0.16, -0.42, 0.9], [-0.2, -0.55, -1.1], [0.26, -0.78, 0.7],
+        [-0.24, -0.9, -0.8], [0.1, -1.05, 0.5],
+      ].map((r, i) => (
+        <mesh key={i} position={[r[0], r[1], 0.18]} rotation={[0, 0, r[2]]}>
+          <cylinderGeometry args={[0.012, 0.03, 0.5, 5]} />
+          <meshLambertMaterial color={P.raiz} flatShading />
+        </mesh>
+      ))}
+      {/* ── LOS NÓDULOS ROSADOS (Rhizobium): el nitrógeno que se ve ── */}
+      <group ref={nodulos}>
+        {puntosNodulo.map((nd, i) => (
+          <mesh key={i} position={[nd.x, nd.y, nd.z]}>
+            <sphereGeometry args={[nd.r, 8, 7]} />
+            <meshLambertMaterial color={nd.claro ? P.noduloClaro : P.nodulo} flatShading emissive={nd.claro ? P.noduloClaro : P.nodulo} emissiveIntensity={saber ? 0.35 : 0.12} />
+          </mesh>
+        ))}
+      </group>
+      {/* halo del saber: un resplandor rosado que enciende el botón didáctico */}
+      <mesh ref={halo} position={[0, -0.7, 0.24]} visible={false}>
+        <circleGeometry args={[0.62, 32]} />
+        <meshBasicMaterial color="#ffc3da" transparent opacity={0} depthWrite={false} blending={THREE.AdditiveBlending} />
+      </mesh>
+
+      {/* ── LA MATA TREPADORA (sobre la superficie) ── */}
+      {/* la estaca / tutor */}
+      <mesh position={[0, 1.1, 0]} rotation={[0, 0, 0.02]}>
+        <cylinderGeometry args={[0.035, 0.05, 2.25, 6]} />
+        <meshLambertMaterial color={P.estaca} flatShading />
+      </mesh>
+      {/* la enredadera helicoidal */}
+      <mesh scale={[1.5, 1, 1.5]}>
+        <tubeGeometry args={[curvaVid, 46, 0.032, 6, false]} />
+        <meshLambertMaterial color={P.frijolTallo} flatShading />
+      </mesh>
+      {hojas.map((h, i) => (
+        <HojaTrifoliada key={i} pos={h.pos} giro={h.giro} esc={h.esc} claro={h.claro} />
+      ))}
+      {vainas.map((v, i) => (
+        <Vaina key={i} pos={v.pos} giro={v.giro} incl={v.incl} />
+      ))}
+      {/* unas florecitas lila cerca de la copa */}
+      <group ref={flor} position={[0.16, 1.7, 0.1]}>
+        {[[0, 0, 0], [0.12, 0.08, -0.05], [-0.08, 0.12, 0.06]].map((f, i) => (
+          <mesh key={i} position={f}>
+            <sphereGeometry args={[0.045, 6, 5]} />
+            <meshLambertMaterial color={P.frijolFlor} flatShading />
+          </mesh>
+        ))}
+      </group>
+    </group>
+  );
+}
+
+/* Una hoja palmada de yuca: peciolo + 5 foliolos (dedos) en abanico. */
+function HojaPalmada({ pos, giro = 0, incl = 0, esc = 1 }) {
+  return (
+    <group position={pos} rotation={[incl, giro, 0]} scale={esc}>
+      <mesh position={[0, 0, 0.14]} rotation={[1.1, 0, 0]}>
+        <cylinderGeometry args={[0.014, 0.02, 0.32, 5]} />
+        <meshLambertMaterial color={P.yucaTallo} flatShading />
+      </mesh>
+      <group position={[0, 0.02, 0.3]}>
+        {[-0.9, -0.45, 0, 0.45, 0.9].map((a, i) => (
+          <mesh key={i} position={[Math.sin(a) * 0.16, 0, Math.cos(a) * 0.08 + 0.1]} rotation={[-0.4, a, 0]} scale={[0.05, 0.02, 0.26]}>
+            <sphereGeometry args={[1, 6, 5]} />
+            <meshLambertMaterial color={i % 2 ? P.yucaHojaClara : P.yucaHoja} flatShading />
+          </mesh>
+        ))}
+      </group>
+    </group>
+  );
+}
+
+/* ── LA YUCA: arbusto de tallo leñoso nudoso, copa de hojas palmadas y las
+      raíces tuberosas asomando en la base. Aguanta el suelo pobre. ── */
+function MataYuca({ pos }) {
+  const groundY = alturaCampo(pos[0], pos[2]);
+  // el tallo leñoso: tres tramos que zig-zaguean en los nudos (como la yuca).
+  const tramos = [
+    { y: 0.35, x: 0, incl: 0.05, h: 0.7 },
+    { y: 0.98, x: 0.08, incl: -0.12, h: 0.62 },
+    { y: 1.52, x: 0.02, incl: 0.08, h: 0.5 },
+  ];
+  const hojas = [
+    { pos: [0.1, 1.78, 0.05], giro: 0.2, incl: -0.2, esc: 1.05 },
+    { pos: [0.0, 1.72, 0.0], giro: 2.1, incl: -0.1, esc: 1.0 },
+    { pos: [-0.05, 1.8, -0.02], giro: 4.0, incl: -0.25, esc: 0.95 },
+    { pos: [0.15, 1.68, -0.08], giro: 5.4, incl: -0.05, esc: 0.9 },
+  ];
+  // tubérculos radiando de la base, medio enterrados (asomando).
+  const tuberculos = [
+    { ang: 0.4, largo: 0.62, baja: 0.28 },
+    { ang: 1.9, largo: 0.55, baja: 0.24 },
+    { ang: 3.3, largo: 0.66, baja: 0.3 },
+    { ang: 4.7, largo: 0.5, baja: 0.22 },
+    { ang: 5.6, largo: 0.58, baja: 0.26 },
+  ];
+  return (
+    <group position={[pos[0], groundY, pos[2]]}>
+      {/* raíces tuberosas asomando en la base */}
+      {tuberculos.map((tb, i) => (
+        <group key={i} rotation={[0, tb.ang, 0]}>
+          <group position={[0.28, 0.02, 0]} rotation={[0, 0, -1.05]}>
+            {/* piel */}
+            <mesh position={[0, -tb.baja * 0.4, 0]} scale={[0.11, tb.largo, 0.11]}>
+              <sphereGeometry args={[1, 8, 6]} />
+              <meshLambertMaterial color={P.yucaTuberPiel} flatShading />
+            </mesh>
+            {/* la punta clara (pulpa asomando por el corte natural) */}
+            <mesh position={[0, -tb.baja * 0.4 - tb.largo * 0.75, 0]} scale={[0.08, 0.1, 0.08]}>
+              <sphereGeometry args={[1, 7, 6]} />
+              <meshLambertMaterial color={P.yucaTuber} flatShading />
+            </mesh>
+          </group>
+        </group>
+      ))}
+      {/* el tallo leñoso con nudos */}
+      {tramos.map((tr, i) => (
+        <group key={i}>
+          <mesh position={[tr.x, tr.y, 0]} rotation={[0, 0, tr.incl]}>
+            <cylinderGeometry args={[0.07 - i * 0.012, 0.085 - i * 0.012, tr.h, 7]} />
+            <meshLambertMaterial color={P.yucaTallo} flatShading />
+          </mesh>
+          {/* nudo (cicatriz de hoja) */}
+          <mesh position={[tr.x, tr.y + tr.h * 0.5, 0]}>
+            <sphereGeometry args={[0.08 - i * 0.012, 7, 5]} />
+            <meshLambertMaterial color={P.yucaNudo} flatShading />
+          </mesh>
+        </group>
+      ))}
+      {hojas.map((h, i) => (
+        <HojaPalmada key={i} pos={h.pos} giro={h.giro} incl={h.incl} esc={h.esc} />
+      ))}
+    </group>
+  );
+}
+
+/* La PANOJA: la firma de la quinua. Granos diminutos instanciados (1 draw call),
+   apretados en un volumen cónico-alargado, coloreados alrededor del tono base
+   (rojo / dorado / morado) con leve variación. */
+function Panoja({ baseHex, alto, radio, n }) {
+  const ref = useRef(null);
+  const granos = useMemo(() => {
+    const rng = crearRng(Math.round(alto * 1000) + n);
+    return Array.from({ length: n }, () => {
+      const t = rng(); // 0 abajo, 1 arriba de la panoja
+      const rad = radio * (1 - t * 0.75) * (0.35 + rng() * 0.65);
+      const ang = rng() * Math.PI * 2;
+      return {
+        x: Math.cos(ang) * rad,
+        y: t * alto,
+        z: Math.sin(ang) * rad,
+        s: 0.03 + rng() * 0.03,
+        tono: (rng() - 0.5),
+      };
+    });
+  }, [alto, radio, n]);
+  useEffect(() => {
+    const m = ref.current;
+    if (!m) return;
+    const dummy = new THREE.Object3D();
+    const tinte = new THREE.Color();
+    granos.forEach((g, i) => {
+      dummy.position.set(g.x, g.y, g.z);
+      dummy.scale.setScalar(g.s);
+      dummy.updateMatrix();
+      m.setMatrixAt(i, dummy.matrix);
+      tinte.set(baseHex).offsetHSL(g.tono * 0.03, g.tono * 0.1, g.tono * 0.12);
+      m.setColorAt(i, tinte);
+    });
+    m.instanceMatrix.needsUpdate = true;
+    if (m.instanceColor) m.instanceColor.needsUpdate = true;
+  }, [granos, baseHex]);
+  return (
+    <instancedMesh ref={ref} args={[undefined, undefined, granos.length]} frustumCulled={false}>
+      <sphereGeometry args={[1, 6, 5]} />
+      <meshLambertMaterial flatShading />
+    </instancedMesh>
+  );
+}
+
+/* ── LA QUINUA: tallo alto con hojas de pata de ganso y la PANOJA densa de color
+      arriba. Proteína de la altura. Distintas alturas/edades por instancia. ── */
+function MataQuinua({ pos, esc = 1, colorHex, reducedMotion, semilla, granos }) {
+  const cabeza = useRef(null);
+  const altoTallo = 1.15 * esc;
+  const hojas = useMemo(() => {
+    const rng = crearRng(semilla);
+    return Array.from({ length: 6 }, (_, i) => ({
+      y: 0.3 + (i / 6) * altoTallo * 0.8,
+      giro: i * 1.9 + rng(),
+      esc: (0.9 - i * 0.08) * esc,
+    }));
+  }, [altoTallo, esc, semilla]);
+  useFrame(({ clock }) => {
+    if (reducedMotion || !cabeza.current) return;
+    cabeza.current.rotation.z = Math.sin(clock.elapsedTime * 0.9 + semilla) * 0.05;
+  });
+  const groundY = alturaCampo(pos[0], pos[2]);
+  return (
+    <group position={[pos[0], groundY, pos[2]]}>
+      {/* el tallo */}
+      <mesh position={[0, altoTallo / 2, 0]}>
+        <cylinderGeometry args={[0.03 * esc, 0.055 * esc, altoTallo, 6]} />
+        <meshLambertMaterial color={P.quinuaTallo} flatShading />
+      </mesh>
+      {/* hojas de pata de ganso a lo largo del tallo */}
+      {hojas.map((h, i) => (
+        <mesh key={i} position={[Math.sin(h.giro) * 0.1, h.y, Math.cos(h.giro) * 0.1]} rotation={[-0.5, h.giro, 0.3]} scale={[0.12 * h.esc, 0.02, 0.14 * h.esc]}>
+          <sphereGeometry args={[1, 6, 5]} />
+          <meshLambertMaterial color={P.quinuaHoja} flatShading />
+        </mesh>
+      ))}
+      {/* la PANOJA de color, meciéndose apenas */}
+      <group ref={cabeza} position={[0, altoTallo, 0]}>
+        <Panoja baseHex={colorHex} alto={0.7 * esc} radio={0.2 * esc} n={granos} />
+      </group>
+    </group>
+  );
+}
+
+/* La escena completa (grupo r3f interno; el default la monta en su Canvas). */
+function EscenaLeguminosas({ tier, reducedMotion, saber }) {
+  const perfil = perfilDeTier(tier);
+  const geo = useMemo(
+    () => construirCampo(perfil.segmentosTerreno, perfil.flatShading),
+    [perfil.segmentosTerreno, perfil.flatShading],
+  );
+  useEffect(() => () => geo.dispose(), [geo]);
+
+  const nCobertura = tier === 'alto' ? 90 : tier === 'medio' ? 55 : 24;
+  const granosPanoja = tier === 'alto' ? 60 : tier === 'medio' ? 40 : 22;
+
+  // Fauna del kit (billboards SVG), por rol ecológico. Recortada al presupuesto.
+  const faunaItems = [
+    { tipo: 'mariposa', rol: 'polinizador', base: [0.6, 1.7, -2.4], size: 30, fase: 0.4, title: 'Mariposa polinizando las panojas' },
+    { tipo: 'colibri', rol: 'polinizador', base: [-2.4, 2.3, 3.9], size: 32, fase: 1.6, title: 'Colibrí en las flores del fríjol' },
+    { tipo: 'escarabajo', rol: 'descomponedor', base: [3.6, 0.2, 0.4], size: 26, fase: 2.4, title: 'Escarabajo cerrando el ciclo del abono' },
+  ].slice(0, perfil.criaturas);
+
+  /* `color`/`fog` se adjuntan a la ESCENA: hijos directos, nunca en <group>. */
+  return (
+    <>
+      <color attach="background" args={[DORADA.fondo]} />
+      {perfil.fog && <fog attach="fog" args={[DORADA.niebla, DORADA.nieblaCerca + 4, DORADA.nieblaLejos]} />}
+      <LucesDoradas />
+      <SolBajo />
+
+      <mesh geometry={geo}>
+        <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
+      </mesh>
+
+      <Cobertura n={nCobertura} />
+
+      {/* Las tres matas, a distinta altura/edad, NO en fila. */}
+      <MataFrijol pos={[-2.4, 0, 3.5]} reducedMotion={reducedMotion} saber={saber} />
+      <MataYuca pos={[3.6, 0, -0.6]} />
+      <MataQuinua pos={[0.2, 0, -2.9]} esc={1.35} colorHex={P.quinuaDorado} reducedMotion={reducedMotion} semilla={5} granos={granosPanoja} />
+      <MataQuinua pos={[2.0, 0, -2.0]} esc={1.0} colorHex={P.quinuaRojo} reducedMotion={reducedMotion} semilla={11} granos={granosPanoja} />
+      <MataQuinua pos={[-1.9, 0, -1.6]} esc={0.82} colorHex={P.quinuaMorado} reducedMotion={reducedMotion} semilla={17} granos={granosPanoja} />
+
+      {perfil.criaturas > 0 && <Fauna items={faunaItems} reducedMotion={reducedMotion} />}
+
+      {/* el polen dorado en suspensión (kit de partículas) */}
+      <ParticulasAmbientales tipo="polen" tier={tier} reducedMotion={reducedMotion} position={[0, 0.8, 0]} semilla={23} />
+      <ParticulasAmbientales tipo="polen" densidad={0.6} tier={tier} reducedMotion={reducedMotion} position={[-3, 1.0, 2]} semilla={31} />
+    </>
+  );
+}
+
+/* Estilos de ESTA escena (chrome DOM sobre el Canvas). */
+const CSS_LEGUM = `
+.legum-root { position: relative; width: 100%; height: 100dvh; min-height: 320px; overflow: hidden; background: ${DORADA.fondo}; }
+.legum-canvas { position: absolute; inset: 0; opacity: 0; transition: opacity 0.9s ease; }
+.legum-canvas--lista { opacity: 1; }
+.legum-chrome { position: absolute; inset: 0; pointer-events: none; display: flex; flex-direction: column; justify-content: space-between; }
+.legum-titulo { margin: 0; padding: 0.9rem 1rem 0; color: #4a3418; text-shadow: 0 1px 8px rgba(255,244,214,0.7); font: 700 1.18rem/1.2 system-ui, sans-serif; letter-spacing: 0.01em; }
+.legum-titulo small { display: block; font: 500 0.8rem/1.3 system-ui, sans-serif; opacity: 0.82; margin-top: 0.15rem; }
+.legum-pie { padding: 0 1rem 0.9rem; display: flex; flex-direction: column; align-items: center; gap: 0.55rem; }
+.legum-carta { margin: 0; max-width: 34rem; text-align: center; padding: 0.5rem 0.95rem; border-radius: 0.7rem; background: rgba(74,52,24,0.62); backdrop-filter: blur(3px); color: #fbf3e2; font: 500 0.8rem/1.5 system-ui, sans-serif; }
+.legum-chips { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.4rem; max-width: 36rem; }
+.legum-chip { padding: 0.28rem 0.7rem; border-radius: 999px; background: rgba(255,247,228,0.86); color: #5a3f1c; font: 600 0.72rem/1.2 system-ui, sans-serif; }
+.legum-chip b { color: #7a2f4c; }
+.legum-boton { pointer-events: auto; appearance: none; border: 1px solid rgba(74,52,24,0.35); border-radius: 999px; padding: 0.44rem 1rem; background: rgba(255,247,228,0.82); color: #5a3f1c; font: 600 0.8rem/1.1 system-ui, sans-serif; cursor: pointer; backdrop-filter: blur(3px); transition: background 0.2s ease, border-color 0.2s ease; }
+.legum-boton:hover, .legum-boton:focus-visible { background: rgba(255,255,255,0.95); border-color: rgba(74,52,24,0.6); outline: none; }
+.legum-boton[aria-pressed='true'] { background: #ffd9e6; border-color: rgba(122,47,76,0.6); color: #7a2f4c; }
+.mundo-fauna { will-change: transform; }
+@media (prefers-reduced-motion: reduce) { .legum-canvas { transition: none; } }
+`;
+
+/* La copia didáctica: en calma, la invitación; con el saber encendido, los nódulos. */
+const COPY_CALMA =
+  'El fríjol, la yuca y la quinua: tres matas que le dan de comer a la familia y a la tierra. Toque el botón para ver, bajo el fríjol, los nódulos rosados que fijan el nitrógeno.';
+const COPY_SABER =
+  'Esas pelotitas rosadas en la raíz del fríjol son fábricas de nitrógeno (bacterias Rhizobium): abono gratis del aire. Por eso conviene asociar el fríjol con el maíz — el maíz da la vara y el fríjol le abona la tierra.';
+
+const CHIPS = [
+  { emoji: '🫘', txt: <>Fríjol: <b>fija nitrógeno gratis</b> (asócielo con maíz)</> },
+  { emoji: '🌿', txt: <>Yuca: <b>aguanta el suelo pobre</b></> },
+  { emoji: '🌾', txt: <>Quinua: <b>proteína de la altura</b></> },
+];
+
+/**
+ * MundoLeguminosas3D — el mundo de leguminosas y raíces andinas, montable con su
+ * propio `<Canvas>`. Sin lógica de negocio: es una vitrina
+ * (#/mockups/mundo-leguminosas-3d). El tier y reduced-motion se detectan aquí
+ * (mockup standalone), igual que sus pares (MundoParamo3D).
+ */
+export default function MundoLeguminosas3D() {
+  const [listo, setListo] = useState(false);
+  const [saber, setSaber] = useState(false);
+  const tier = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const perfil = perfilDeTier(tier);
+
+  return (
+    <section
+      className="legum-root"
+      data-tier={tier}
+      aria-label="El mundo de leguminosas y raíces andinas: fríjol con nódulos, yuca y quinua"
+    >
+      <style>{CSS_LEGUM}</style>
+      <Canvas
+        className={`legum-canvas${listo ? ' legum-canvas--lista' : ''}`}
+        dpr={perfil.dpr}
+        gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+        camera={{ position: [0.5, 4.2, 12], fov: 44 }}
+        frameloop={reducedMotion ? 'demand' : 'always'}
+        onCreated={() => setListo(true)}
+      >
+        <EscenaLeguminosas tier={tier} reducedMotion={reducedMotion} saber={saber} />
+        <OrbitControls
+          makeDefault
+          enablePan={false}
+          enableZoom
+          minDistance={6}
+          maxDistance={18}
+          target={[-0.3, 1.4, 0.6]}
+          minPolarAngle={0.45}
+          maxPolarAngle={1.42}
+          minAzimuthAngle={-0.6}
+          maxAzimuthAngle={0.7}
+          enableDamping
+          dampingFactor={0.08}
+          autoRotate={!reducedMotion}
+          autoRotateSpeed={0.12}
+        />
+        <AdaptiveDpr pixelated />
+      </Canvas>
+
+      <div className="legum-chrome">
+        <h2 className="legum-titulo">
+          Leguminosas y raíces andinas
+          <small>Fríjol que abona · yuca que aguanta · quinua que alimenta</small>
+        </h2>
+        <div className="legum-pie">
+          <div className="legum-chips">
+            {CHIPS.map((c) => (
+              <span key={c.emoji} className="legum-chip">
+                <span aria-hidden="true">{c.emoji} </span>
+                {c.txt}
+              </span>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="legum-boton"
+            aria-pressed={saber}
+            onClick={() => setSaber((v) => !v)}
+          >
+            {saber ? 'Ver la mata completa' : 'Ver el saber bajo tierra'}
+          </button>
+          <p className="legum-carta" role="status">
+            {saber ? COPY_SABER : COPY_CALMA}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -100,7 +100,10 @@ const _centrosPiso = PISOS_TERMICOS.map((p) => ({
   color: new THREE.Color(p.color),
   cresta: new THREE.Color(p.cresta),
 }));
-const _colNoche = new THREE.Color('#1f3a2c');
+/* La noche del cine es AZUL, no negra (día por noche): el suelo se enfría
+   hacia un azul-luna y solo 45% — las franjas de pisos térmicos siguen
+   leyéndose como bandas de altitud, apagadas pero presentes. */
+const _colNoche = new THREE.Color('#2c4560');
 
 function colorSueloEnZ(z, alto, nocturno, out) {
   // Buscar los dos centros de piso que rodean a z e interpolar.
@@ -121,7 +124,7 @@ function colorSueloEnZ(z, alto, nocturno, out) {
   out.copy(lo.color).lerp(hi.color, t);
   // Relieve: las crestas más claras; los vallecitos, el color base.
   out.lerp(lo.cresta.clone().lerp(hi.cresta, t), THREE.MathUtils.clamp(alto, 0, 1) * 0.35);
-  if (nocturno) out.lerp(_colNoche, 0.62);
+  if (nocturno) out.lerp(_colNoche, 0.56);
   return out;
 }
 
@@ -204,8 +207,11 @@ function Cordillera({ color, innerRef, perfil }) {
   );
 }
 
-/* ── La quebrada: una cinta de agua que serpentea por el cauce. ── */
-function Quebrada({ color, viva, perfil }) {
+/* ── La quebrada: una cinta de agua que serpentea por el cauce. De noche es
+      LO QUE MÁS BRILLA del suelo (el reflejo de la luna sobre el agua, la
+      firma del día-por-noche): emissive tenue que además guía el ojo ladera
+      abajo — el agua se vuelve el sendero luminoso del valle dormido. ── */
+function Quebrada({ color, viva, perfil, nocturno = false }) {
   const ref = useRef(null);
   useFrame((state) => {
     // `ref` apunta al material (no al mesh): animar su opacidad directamente.
@@ -236,13 +242,22 @@ function Quebrada({ color, viva, perfil }) {
         <meshStandardMaterial
           ref={ref}
           color={color}
+          emissive={nocturno ? '#3f6f9e' : '#000000'}
+          emissiveIntensity={nocturno ? 0.42 : 0}
           transparent
           opacity={0.78}
           roughness={0.25}
           metalness={0.35}
         />
       ) : (
-        <meshLambertMaterial ref={ref} color={color} transparent opacity={0.78} />
+        <meshLambertMaterial
+          ref={ref}
+          color={color}
+          emissive={nocturno ? '#3f6f9e' : '#000000'}
+          emissiveIntensity={nocturno ? 0.42 : 0}
+          transparent
+          opacity={0.78}
+        />
       )}
     </mesh>
   );
@@ -1183,10 +1198,16 @@ function AplaneNewDonk({ foco, aplanando }) {
       suelta el control para que el usuario siga haciendo zoom a mano). Durante
       el APLANE New Donk cede TODO el control a AplaneNewDonk (early-return): no
       mueve target ni zoom para no pelear con la caída. ── */
-function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false, kReposo = 1 }) {
+function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false, kReposo = 1, miraInicial = null }) {
   const trans = useRef(0);
   const prevKey = useRef(focoKey);
   const entrando = focoKey !== 'valle';
+  /* LA CÁMARA ES DEL USUARIO DESDE QUE LA TOCA: la deriva de reposo
+     (autoRotate) es bienvenida mientras nadie maneja, pero girar el valle
+     BAJO el dedo que está apuntando a un lugar era el "difícil de manejar a
+     ratos" — el chip se corría del toque. El primer gesto de órbita apaga la
+     deriva por el resto de la sesión del valle. */
+  const [tomada, setTomada] = useState(false);
   useFrame(() => {
     if (!controls.current || aplanando) return;
     const c = controls.current;
@@ -1217,14 +1238,26 @@ function CamaraViajera({ foco, focoKey, controls, autoOrbit, aplanando = false, 
       makeDefault
       enablePan={false}
       enableZoom
+      /* El target ARRANCA en la mira de reposo (no en el origen): el primer
+         fotograma ya es el encuadre de autor — clave en reduced-motion
+         (frameloop demand), donde el lerp por frame gatea. */
+      target={miraInicial || undefined}
       minDistance={7}
-      maxDistance={28}
+      /* El techo de zoom respeta el reposo del aspecto: si la pose vertical
+         vive más lejos, el clamp no pelea contra ella (antes, en teléfono,
+         el reposo caía FUERA del techo y los controles daban tirones). */
+      maxDistance={Math.max(28, Math.ceil(20 * kReposo) + 4)}
       minPolarAngle={0.45}
       maxPolarAngle={1.18}
-      autoRotate={autoOrbit && !entrando}
-      autoRotateSpeed={0.35}
+      autoRotate={autoOrbit && !entrando && !tomada}
+      /* Deriva de reposo APENAS perceptible (~0.7°/s): a 0.35 el valle giraba
+         ~2°/s y en un minuto la composición de autor ya no estaba en pantalla
+         — y el chip apuntado se corría del dedo. La vida la ponen los bichos
+         y la atmósfera, no el tiovivo. */
+      autoRotateSpeed={0.12}
       enableDamping
       dampingFactor={0.08}
+      onStart={tomada ? undefined : () => setTomada(true)}
     />
   );
 }
@@ -1350,6 +1383,56 @@ function AtmosferaValle({ c, perfil, reducedMotion }) {
   );
 }
 
+/* ── LA LUNA DEL VALLE: el disco de plata que AUTORIZA la luz nocturna ──────
+      La noche del cine tiene autora: la direccional fría sale de aquí
+      (CLIMAS.noche.sol apunta desde -x,-z) y verla en el cielo hace legible
+      el contraluz. Discos meshBasic (5 planos transparentes, cero luces
+      extra): corre en TODOS los tiers. Se orienta a la cámara con lookAt
+      (~2 veces/s alcanza — la luna está lejos y el orbit es lento). ── */
+/* La LUNA SALIENDO tras el filo del páramo (izquierda-fondo, baja sobre el
+   horizonte): la pose de reposo pica 23° hacia abajo, así que el único cielo
+   del cuadro es la franja rasante sobre la silueta de la ladera — ahí vive
+   la luna, como se ve una luna que apenas sale. Verificado contra el terreno:
+   el rayo cámara→luna libra la loma (y=6.9 sobre 1.5 en x=-10; 6.2 sobre 3.1
+   en el borde x=-17) y la cordillera queda lejos (z≤-15). */
+const POS_LUNA = /** @type {[number, number, number]} */ ([-21, 3.4, -8]);
+
+function LunaValle({ reducedMotion }) {
+  const ref = useRef(null);
+  const tick = useRef(0);
+  useFrame(({ camera }) => {
+    if (!ref.current) return;
+    if (tick.current++ % 30 !== 0 && !reducedMotion) return;
+    ref.current.lookAt(camera.position);
+  });
+  return (
+    <group ref={ref} position={POS_LUNA} scale={1.1}>
+      <mesh>
+        <circleGeometry args={[1.15, 36]} />
+        <meshBasicMaterial color="#f2f0e2" transparent opacity={0.98} depthWrite={false} fog={false} />
+      </mesh>
+      {/* mares: sombras suaves que hacen luna, no plato */}
+      <mesh position={[-0.3, 0.26, 0.01]}>
+        <circleGeometry args={[0.3, 18]} />
+        <meshBasicMaterial color="#d4d2c2" transparent opacity={0.5} depthWrite={false} fog={false} />
+      </mesh>
+      <mesh position={[0.34, -0.28, 0.01]}>
+        <circleGeometry args={[0.19, 16]} />
+        <meshBasicMaterial color="#d9d7c6" transparent opacity={0.45} depthWrite={false} fog={false} />
+      </mesh>
+      {/* halo doble: el velo húmedo del páramo alrededor de la luna */}
+      <mesh position={[0, 0, -0.05]}>
+        <circleGeometry args={[2.1, 36]} />
+        <meshBasicMaterial color="#b3cdf0" transparent opacity={0.18} depthWrite={false} fog={false} />
+      </mesh>
+      <mesh position={[0, 0, -0.1]}>
+        <circleGeometry args={[3.6, 36]} />
+        <meshBasicMaterial color="#3d5178" transparent opacity={0.12} depthWrite={false} fog={false} />
+      </mesh>
+    </group>
+  );
+}
+
 /* Caja de las luciérnagas: la tierra baja del frente del valle (referencia
    ESTABLE — ParticulasAmbientales re-siembra si la caja cambia). */
 const AREA_LUCIERNAGAS = /** @type {[number, number, number]} */ ([18, 2.4, 7]);
@@ -1367,24 +1450,44 @@ const MIRA_VALLE = [0, 1.6, 1.4];
    horizontal de ~19° y la composición entera (lugares en x ∈ [-7.5, 7.5], el
    oso en el borde del monte) queda FUERA del cuadro: medio valle existía y
    nadie lo veía (la misma clase de fallo que los árboles tras el macizo de la
-   sierra). En pantallas angostas la cámara retrocede y abre un poco el fov —
-   con techo, para no caer en ojo de pez — y el valle entero vuelve al cuadro.
+   sierra).
+
+   EL PLANO VERTICAL ES OTRO PLANO (no el mismo, más lejos): retroceder a lo
+   ancho regalaba el 40% del cuadro al cielo vacío y apeñuscaba la finca abajo
+   — los rótulos colisionaban todos y la anti-colisión escondía la mayoría (el
+   "difícil de manejar" del operador). En vertical la cámara SUBE y PICA: la
+   ladera entera (tierra caliente → páramo, 16 u de fondo) corre a lo LARGO de
+   la pantalla, los lugares se separan en vertical y cada rótulo respira. La
+   mira baja y avanza (la finca al centro, el cielo de remate arriba).
    En landscape (aspecto ≥ 0.9) la pose aprobada queda EXACTA. */
 function poseValleParaAspecto(aspect) {
-  if (!aspect || aspect >= 0.9) return { position: CAMARA_VALLE.position, fov: CAMARA_VALLE.fov, k: 1 };
-  const k = Math.min(1.6, Math.pow(0.9 / aspect, 0.62));
-  const fov = Math.min(54, Math.round(CAMARA_VALLE.fov * Math.pow(0.9 / aspect, 0.4)));
-  return {
-    position: /** @type {[number, number, number]} */ (CAMARA_VALLE.position.map((v) => v * k)),
-    fov,
-    k,
-  };
+  if (!aspect || aspect >= 0.9) {
+    return { position: CAMARA_VALLE.position, fov: CAMARA_VALLE.fov, k: 1, mira: MIRA_VALLE };
+  }
+  const cuanVertical = Math.min(1, (0.9 - aspect) / 0.44); // 0 en 0.9 → 1 en ~0.46
+  // El PLANO PICADO del teléfono parado (misma acimut de la pose aprobada,
+  // polar ~40°): la cámara sube a 18.7 y la mira avanza a la finca (z 3.2).
+  const PICADO = { position: [9.3, 18.7, 15.1], fov: 58, mira: [-0.5, 0.6, 2.7] };
+  const lerp = (a, b) => a + (b - a) * cuanVertical;
+  const position = /** @type {[number, number, number]} */ (
+    CAMARA_VALLE.position.map((v, i) => lerp(v, PICADO.position[i]))
+  );
+  const mira = /** @type {[number, number, number]} */ (
+    MIRA_VALLE.map((v, i) => lerp(v, PICADO.mira[i]))
+  );
+  const fov = Math.round(lerp(CAMARA_VALLE.fov, PICADO.fov));
+  // k = razón de distancia (cámara→mira) contra la pose landscape: gobierna
+  // el zoom de reposo de CamaraViajera y el techo de los controles.
+  const dist = (p, m) => Math.hypot(p[0] - m[0], p[1] - m[1], p[2] - m[2]);
+  const k = dist(position, mira) / dist(CAMARA_VALLE.position, MIRA_VALLE);
+  return { position, fov, k, mira };
 }
 
 /* ── Contenido de la escena (dentro del Canvas). ── */
 function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false, aplanando = false, camaraDirector = false, beatsRef = null, portada = false, pose = null }) {
   /* La pose de reposo (aspecto-consciente, viene del host del Canvas). */
-  const poseReposo = pose || { position: CAMARA_VALLE.position, fov: CAMARA_VALLE.fov, k: 1 };
+  const poseReposo = pose || { position: CAMARA_VALLE.position, fov: CAMARA_VALLE.fov, k: 1, mira: MIRA_VALLE };
+  const miraReposo = poseReposo.mira || MIRA_VALLE;
   const controls = useRef(null);
   /* La cámara de director (FASE 4, flag `camaraDirector`) se monta DESPUÉS de
      CamaraViajera y gana por orden de frame durante su barrido. `avatarRef`
@@ -1399,11 +1502,12 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
   const foco = useMemo(() => {
     const m = focoId ? MUNDO_DIR_BY_ID[focoId] : null;
     // Sin foco, la cámara encuadra el corazón del valle (algo hacia el frente,
-    // regla de tercios) para dar aire y leer la ladera que sube al fondo.
-    if (!m) return new THREE.Vector3(0, 1.0, 1.4);
+    // regla de tercios) — la mira de reposo es ASPECTO-CONSCIENTE: en vertical
+    // baja y avanza hacia la finca (CamaraViajera le suma 0.6 en y).
+    if (!m) return new THREE.Vector3(miraReposo[0], miraReposo[1] - 0.6, miraReposo[2]);
     const y = alturaTerreno(m.pos[0], m.pos[2]);
     return new THREE.Vector3(m.pos[0], y, m.pos[2]);
-  }, [focoId]);
+  }, [focoId, miraReposo]);
   const autoOrbit = !reducedMotion && !focoId;
   const entrando = !!focoId;
   const nocturno = clima === 'noche';
@@ -1442,18 +1546,28 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         />
       )}
 
+      {/* La LUNA: la autora de la luz nocturna. Verla ancla el contraluz. */}
+      {nocturno && <LunaValle reducedMotion={reducedMotion} />}
+
       <Terreno nocturno={nocturno} innerRef={terrenoRef} perfil={perfil} />
-      <Cordillera color={nocturno ? '#3a4a63' : c.niebla} innerRef={cordilleraRef} perfil={perfil} />
-      <Quebrada color={nocturno ? '#2a4a6a' : '#5fb2c9'} viva={c.lluviaViva} perfil={perfil} />
+      <Cordillera color={nocturno ? '#48598a' : c.niebla} innerRef={cordilleraRef} perfil={perfil} />
+      <Quebrada
+        color={nocturno ? '#7fb3d9' : '#5fb2c9'}
+        viva={c.lluviaViva}
+        perfil={perfil}
+        nocturno={nocturno}
+      />
       <VegetacionPisos nocturno={nocturno} perfil={perfil} />
 
       {/* LA DIRECCIÓN DEL CUADRO: la casa-ancla donde descansa el ojo (con su
           ventana cálida), los senderos de tierra pisada que nacen de ella (el
           rastro del uso diario: el ojo camina por donde caminan los pies) y
           los patios bajo cada lugar navegable (afordancia sin UI). */}
-      <CasaCampesina alturaDe={alturaTerreno} perfil={perfil} />
+      <CasaCampesina alturaDe={alturaTerreno} perfil={perfil} nocturno={nocturno} />
       <SenderosValle alturaDe={alturaTerreno} perfil={perfil} />
-      {!portada && <PatiosLugares mundos={MUNDOS_DIR} alturaDe={alturaTerreno} />}
+      {!portada && (
+        <PatiosLugares mundos={MUNDOS_DIR} alturaDe={alturaTerreno} nocturno={nocturno} />
+      )}
 
       {MUNDOS_DIR.map((m) => (
         <MundoLugar
@@ -1511,6 +1625,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         autoOrbit={autoOrbit}
         aplanando={aplanando}
         kReposo={poseReposo.k}
+        miraInicial={miraReposo}
       />
       {/* La CÁMARA DE DIRECTOR (FASE 4). Con el flag `camaraDirector`:
           DirectorValle (establishing + follow + beats), montado DESPUÉS de
@@ -1521,7 +1636,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, reducedMoti
         <DirectorValle
           controls={controls}
           reposo={poseReposo.position}
-          mira={MIRA_VALLE}
+          mira={miraReposo}
           fov={poseReposo.fov}
           foco={foco}
           avatarRef={avatarRef}

--- a/src/mockups/valle/composicionValle3D.jsx
+++ b/src/mockups/valle/composicionValle3D.jsx
@@ -45,7 +45,7 @@ const CASA = {
  * La ventana emisiva es "la casa espera": de día apenas se nota, al
  * atardecer y de noche es el corazón cálido del valle.
  */
-export function CasaCampesina({ alturaDe, perfil }) {
+export function CasaCampesina({ alturaDe, perfil, nocturno = false }) {
   const [cx, cz] = CASA_VALLE.pos;
   const y = alturaDe(cx, cz);
   const rico = perfil.materialRico;
@@ -79,16 +79,42 @@ export function CasaCampesina({ alturaDe, perfil }) {
         <boxGeometry args={[0.3, 0.52, 0.05]} />
         <meshStandardMaterial color={CASA.madera} flatShading roughness={1} />
       </mesh>
-      {/* LA VENTANA CON LUZ: la casa espera (emisiva, cálida, chiquita) */}
+      {/* LA VENTANA CON LUZ: la casa espera (emisiva, cálida, chiquita).
+          De NOCHE es el FARO del valle (día-por-noche: la práctica que
+          orienta): brilla más fuerte, tira un charco cálido sobre la tierra
+          del corredor, y — solo donde el perfil paga luces — una pointLight
+          ámbar baña la fachada. El punto de referencia para volver a casa. */}
       <mesh position={[0.34, 0.56, 0.52]}>
         <boxGeometry args={[0.26, 0.24, 0.04]} />
         <meshStandardMaterial
           color={CASA.ventana}
           emissive={CASA.ventana}
-          emissiveIntensity={0.8}
+          emissiveIntensity={nocturno ? 1.8 : 0.8}
           flatShading
         />
       </mesh>
+      {nocturno && (
+        <>
+          {/* el charco de luz de la ventana (todos los tiers: es un disco) */}
+          <mesh position={[0.4, 0.05, 0.95]} rotation={[-Math.PI / 2, 0, 0]}>
+            <circleGeometry args={[0.85, 20]} />
+            <meshBasicMaterial
+              color={CASA.ventana}
+              transparent
+              opacity={0.2}
+              depthWrite={false}
+            />
+          </mesh>
+          {perfil.luzBeacon && (
+            <pointLight
+              color={CASA.ventana}
+              intensity={1.1}
+              distance={5.2}
+              position={[0.38, 0.7, 0.9]}
+            />
+          )}
+        </>
+      )}
       {/* el corredor: dos pies derechos y su tramo de techo (solo tier alto) */}
       {rico && (
         <group>
@@ -138,7 +164,7 @@ export function SenderosValle({ alturaDe, perfil }) {
 /* ── Patios de tierra pisada bajo los lugares navegables ─────────────────
    Todos en UNA InstancedMesh (1 draw call). Círculo plano apenas levantado;
    depthWrite off para no pelear con la ondulación del terreno. */
-export function PatiosLugares({ mundos, alturaDe }) {
+export function PatiosLugares({ mundos, alturaDe, nocturno = false }) {
   const sitios = useMemo(
     () =>
       mundos.map((m) => ({
@@ -152,10 +178,13 @@ export function PatiosLugares({ mundos, alturaDe }) {
   return (
     <Instances limit={sitios.length}>
       <circleGeometry args={[1, 22]} />
+      {/* De noche la tierra pisada AGARRA la luna (emisivo leve): los claros
+          se leen como lugares a los que se llega, no como huecos negros. */}
       <meshLambertMaterial
-        color={PATIO.color}
+        color={nocturno ? '#8a9bb8' : PATIO.color}
+        emissive={nocturno ? '#1b2940' : '#000000'}
         transparent
-        opacity={PATIO.opacidad}
+        opacity={nocturno ? 0.26 : PATIO.opacidad}
         depthWrite={false}
       />
       {sitios.map((s, i) => (

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -380,14 +380,18 @@ export const CLIMAS = {
     luciernagas: 0,
   },
   noche: {
+    /* DÍA POR NOCHE (dirección de fotografía): nadie filma la noche a oscuras.
+       Azul índigo levantado (se VE), luz de luna plateada con intensidad de
+       contraluz, y la niebla abierta para que la ladera entera se lea. Las
+       prácticas (ventana de la casa, luciérnagas, el faro) hacen el resto. */
     etiqueta: 'Noche',
     grade: 'vfx-grade--glacial',
-    cielo: ['#0b1830', '#132a4e'],
-    luz: '#9fc2e8',
-    ambiente: '#26364f',
-    niebla: '#13203a',
-    nieblaLejos: 22,
-    intensidad: 0.5,
+    cielo: ['#152a52', '#1e3d6e'],
+    luz: '#b3cdf0',
+    ambiente: '#35486b',
+    niebla: '#1d3153',
+    nieblaLejos: 30,
+    intensidad: 0.72,
     estrellas: true,
     sol: [-6, 7, -4],
     luciernagas: 1,

--- a/src/visual/mundo3d/bosque/floraParamo.geom.js
+++ b/src/visual/mundo3d/bosque/floraParamo.geom.js
@@ -1,683 +1,337 @@
 /*
- * floraParamo.geom — el BOSQUE ALTOANDINO que rodea al Ent de la queñua.
+ * floraParamo.geom — la GEOMETRÍA del ECOSISTEMA que rodea al Ent de la queñua.
  *
- * REHECHO tras el rechazo del operador: *"las matas alrededor ni se diga,
- * parecen más árboles de navidad que matas"*. Tenía toda la razón, y el DR de
- * realismo-3d-vegetacion nombra el fallo exacto que teníamos:
+ * El Ent (queñua) es EL árbol mayor y sigue siendo el foco; esto es el páramo que
+ * lo acompaña para que el claro se sienta un bosque altoandino VIVO y no un árbol
+ * solo. Especies reales del páramo/bosque altoandino colombiano, cada una con su
+ * identidad inequívoca:
  *
- *   ANTES: `CylinderGeometry` recto + un puñado de `IcosahedronGeometry` regados
- *   en un domo, cada parte con UN color plano horneado (`pintar`). Es la
- *   definición literal del "cono/esfera de follaje sobre un cilindro" del DR:
- *   sin conicidad, sin jerarquía de ramas, sin huecos, sin AO, sin gradiente.
- *   El aliso incluso construía la copa como un CONO explícito. Árbol de navidad.
- *
- *   AHORA: todas las especies leñosas salen de `construirArbol`, que aplica las
- *   recetas del DR por orden de retorno visual:
- *     · tronco con CURVA, conicidad real, raigón y arruga en la geometría;
- *     · JERARQUÍA de ramas (primarias en ángulo áureo → secundarias);
- *     · copas sembradas en los EXTREMOS de rama, con HUECOS y borde MORDIDO
- *       (el cielo se ve a través → se acabó la masa sólida);
- *     · sombreado horneado por vértice: AO + gradiente de altura + contraluz;
- *     · variación determinista por instancia (rotación/escala/inclinación/tinte).
- *
- * Cada especie conserva lo que la hace INCONFUNDIBLE (si se ven genéricas,
- * fallamos):
- *   · Frailejón (Espeletia)      — roseta vellosa plateada + enagua de hojas
- *                                  muertas marcescentes. El ícono del páramo.
- *   · Queñua (Polylepis)         — tronco retorcido + corteza rojiza que se
- *                                  descama en LÁMINAS DE PAPEL (geometría real).
- *   · Encenillo (Weinmannia)     — árbol de niebla: tronco rojizo, copa oscura
+ *   · Frailejón (Espeletia)      — el ícono: tallo con enagua de hojas muertas y
+ *                                  ROSETA plateada peluda arriba. Va al frente,
+ *                                  formando el frailejonar. (Algunos en flor.)
+ *   · Yarumo plateado/blanco     — Cecropia telealba: tronco pálido esbelto y copa
+ *     (Cecropia telealba)          en sombrilla de hojas palmeadas de ENVÉS BLANCO.
+ *   · Roble andino               — Quercus humboldtii: tronco robusto y copa ancha
+ *     (Quercus humboldtii)         densa de hoja coriácea oscura (con bellotas).
+ *   · Encenillo (Weinmannia)     — árbol de niebla: tronco rojizo, copa oscura y
  *                                  compacta, velo de musgo.
- *   · Aliso (Alnus acuminata)    — tronco gris claro esbelto, copa alta y fresca
- *                                  (alargada e IRREGULAR, nunca un cono).
- *   · Gaque (Clusia)             — copa redonda densa de hoja gruesa lustrosa.
- *   · Mortiño (Vaccinium)        — arbusto bajo con bayas azul-moradas (agraz).
- *   · Romerillo, rocas con líquen, musgo — el suelo y el sotobosque.
+ *   · Aliso (Alnus acuminata)    — tronco gris claro esbelto, copa cónica verde
+ *                                  fresca; el vecino más alto (aun así < Ent).
+ *   · Gaque (Clusia)             — copa redonda densa de hoja gruesa verde-lustrosa.
+ *   · Mortiño (Vaccinium         — arbusto bajo con BAYAS azul-moradas (agraz andino).
+ *     meridionale)
+ *   · Romerillo                  — mata baja de follaje fino amarillo-verde.
+ *   · Rocas con líquen + musgo   — el suelo del páramo.
  *
- * TÉCNICA tier-safe: cada especie se fusiona en UNA geometría con el color ya
- * horneado → UN InstancedMesh → una draw-call por especie por más matas que
- * haya. Cero assets externos. Corre headless (three core puro).
+ * TÉCNICA tier-safe (DR §3): cada especie se FUSIONA en UNA sola geometría
+ * (tronco + follaje + detalles) con color horneado en vertexColors, y luego se
+ * dibuja con UN InstancedMesh → una draw-call por especie por más matas que haya.
+ * Cero assets externos: todo procedural. Corre headless (three core + merge puro).
+ *
+ * El componente r3f (`FloraParamo.jsx`) consume esto: instancia, ubica y le pone
+ * luz. Aquí viven SOLO los datos y las mallas (nada de WebGL).
  */
 import * as THREE from 'three';
-import {
-  rng,
-  ruidoFbm,
-  fusionarSeguro,
-  poner,
-  apuntar,
-  pintarPlano,
-  hornearFollaje,
-  hornearCorteza,
-  tuboOrganico,
-  taperLineal,
-  taperTronco,
-  curvaTronco,
-  sembrarFollaje,
-  matojoHoja,
-} from './sombreadoVegetal.js';
-
-export { rng };
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from './entQuenua.geom.js';
 
 /* -------------------------------------------------------------------------- */
 /*  Presupuesto por tier                                                       */
 /* -------------------------------------------------------------------------- */
 
 /*
- * Cuántas matas de cada especie. 'alto' puebla un bosque pleno; 'medio' es
- * frugal; 'bajo' deja lo mínimo para que AÚN se lea "páramo". Cada especie es
- * UN InstancedMesh → estos números son instancias, no draw-calls.
+ * Cuántas matas de cada especie (tier-safe). 'alto' puebla un ecosistema pleno;
+ * 'medio' es frugal; 'bajo' deja lo mínimo para que AÚN se lea "páramo" (unos
+ * frailejones, un par de árboles, rocas y musgo) si algo fuerza el 3D. Cada
+ * especie es UN InstancedMesh → estos números son instancias, no draw-calls.
  */
 export const FLORA_TIER = {
   alto: {
-    frailejon: 34, frailejonFlor: 7, quenua: 5, encenillo: 5, aliso: 4,
-    gaque: 3, mortino: 12, romerillo: 14, roca: 10, musgo: 14, niebla: 3,
+    frailejon: 30, frailejonFlor: 6, yarumo: 3, roble: 3, encenillo: 4,
+    aliso: 3, gaque: 2, mortino: 10, romerillo: 12, roca: 9, musgo: 12, niebla: 3,
   },
   medio: {
-    frailejon: 20, frailejonFlor: 4, quenua: 3, encenillo: 3, aliso: 2,
-    gaque: 2, mortino: 7, romerillo: 8, roca: 6, musgo: 7, niebla: 0,
+    frailejon: 18, frailejonFlor: 3, yarumo: 2, roble: 2, encenillo: 2,
+    aliso: 2, gaque: 1, mortino: 6, romerillo: 7, roca: 5, musgo: 6, niebla: 0,
   },
   bajo: {
-    frailejon: 8, frailejonFlor: 0, quenua: 2, encenillo: 0, aliso: 0,
-    gaque: 0, mortino: 3, romerillo: 3, roca: 2, musgo: 3, niebla: 0,
+    frailejon: 7, frailejonFlor: 0, yarumo: 1, roble: 1, encenillo: 0,
+    aliso: 0, gaque: 0, mortino: 2, romerillo: 3, roca: 2, musgo: 3, niebla: 0,
   },
 };
 
 /** Conteos de flora para un tier (desconocido → frugal, nunca el más caro). */
 export const floraDeTier = (tier) => FLORA_TIER[tier] || FLORA_TIER.medio;
 
-/* Factor de DETALLE geométrico por tier: escala hojas/ramas por mata. */
-export const CALIDAD_TIER = { alto: 1, medio: 0.6, bajo: 0.4 };
+/*
+ * Factor de DETALLE geométrico por tier: escala cuántas hojas/blobs lleva cada
+ * mata. Menos detalle en gama baja = menos vértices por instancia (que se
+ * multiplican por el número de matas).
+ */
+export const CALIDAD_TIER = { alto: 1, medio: 0.62, bajo: 0.42 };
 export const calidadDeTier = (tier) => CALIDAD_TIER[tier] ?? CALIDAD_TIER.medio;
 
 /* -------------------------------------------------------------------------- */
-/*  Paleta del páramo (horneada en vertexColors)                               */
+/*  Paleta del páramo (colores horneados en vertexColors)                      */
 /* -------------------------------------------------------------------------- */
 
 export const PAL = {
-  // Frailejón — la roseta plateada vellosa es la firma.
-  frailejonTronco: '#5f4e36',
-  frailejonSeco: '#7d6544', // enagua de hojas muertas marcescentes
-  frailejonSeco2: '#93794f',
-  frailejonPlata: '#a8b79a', // roseta: verde-plata vellosa (NO blanco tiza)
-  frailejonPlataSol: '#c8d3b6',
-  frailejonCorazon: '#b9c4a4',
-  frailejonFlor: '#dcbc46',
-  frailejonTallo: '#8d9866',
+  // Frailejón
+  frailejonTronco: '#6f5c40', // tallo bajo la enagua
+  frailejonSeco: '#907753', // hojas muertas de la enagua (marcescentes) — pajizo
+  frailejonSeco2: '#6a5232', // marcescentes más oscuras/curtidas (variedad)
+  frailejonPlata: '#cfd4c7', // roseta: centro joven, tomento MÁS blanco (la firma)
+  frailejonPlata2: '#b0ba9c', // hojas externas: plateado-salvia más apagado
+  frailejonCorazon: '#dde2d6', // cogollo velloso central (el punto más pálido)
+  frailejonFlor: '#e0c24a', // capítulos amarillos
+  frailejonTallo: '#95a06a', // escapo floral
 
-  // Queñua (Polylepis) — corteza rojiza en láminas de papel.
-  quenuaGrieta: '#4a2a20',
-  quenuaCuerpo: '#8a4a33',
-  quenuaPapel: '#cf9166',
-  quenuaLamina: '#b9744c',
-  quenuaHoja: '#4e6640',
-  quenuaHojaSol: '#8ba06d',
-
-  // Encenillo (Weinmannia) — el árbol de la niebla.
-  encenilloGrieta: '#3d2419',
-  encenilloTronco: '#6d4535',
-  encenilloHoja: '#31462d',
-  encenilloHojaSol: '#5c7a4c',
-  encenilloMusgo: '#6b7d4c',
-
-  // Aliso (Alnus acuminata) — corteza gris clara.
-  alisoGrieta: '#5f6156',
-  alisoTronco: '#9a9a8f',
-  alisoLenticela: '#c2c2b4',
-  alisoHoja: '#415c30',
-  alisoHojaSol: '#83a05a',
-
-  // Gaque (Clusia) — hoja gruesa verde muy oscuro lustrosa.
-  gaqueGrieta: '#33291f',
-  gaqueTronco: '#57493a',
-  gaqueHoja: '#263d24',
-  gaqueHojaSol: '#4e6f43',
-
-  // Mortiño (Vaccinium meridionale) — agraz andino.
-  mortinoRama: '#5a4030',
-  mortinoHoja: '#37502f',
-  mortinoHojaSol: '#6a8248',
-  mortinoBrote: '#7a4536',
-  mortinoBaya: '#33305c',
-  mortinoBaya2: '#454078',
-
-  // Roble andino (Quercus humboldtii) — no es de páramo; lo usan la ladera de
-  // restauración y el valle. Copa ancha de hoja coriácea oscura + bellotas.
-  robleTronco: '#6a5c4a',
-  robleHoja: '#3a4f32',
-  robleHojaSol: '#6d8a4e',
-  robleBellota: '#7a5a34',
-  robleCapa: '#54432a',
-
-  // Yarumo plateado (Cecropia telealba) — tampoco es de páramo; ladera + valle.
-  // Su firma: el ENVÉS BLANCO de la hoja palmeada.
-  yarumoTronco: '#bcbfb2',
+  // Yarumo plateado / blanco (Cecropia telealba)
+  yarumoTronco: '#bcbfb2', // tronco pálido anillado
   yarumoRama: '#a9ac9f',
-  yarumoEnves: '#e2e7dc',
-  yarumoHaz: '#7f9070',
+  yarumoEnves: '#e2e7dc', // envés BLANCO de la hoja palmeada (la firma)
+  yarumoHaz: '#7f9070', // dejo verde del haz
 
-  // Romerillo.
-  romerilloHoja: '#65763a',
-  romerilloHojaSol: '#98a85c',
+  // Roble andino (Quercus humboldtii)
+  robleTronco: '#6a5c4a', // corteza gris-parda fisurada
+  robleHoja: '#43593b', // hoja coriácea verde oscuro
+  robleHoja2: '#516b42',
+  robleBellota: '#7a5a34', // bellota
+  robleCapa: '#54432a', // capuchón de la bellota
+
+  // Encenillo (Weinmannia tomentosa)
+  encenilloTronco: '#6d4535', // corteza rojiza
+  encenilloHoja: '#3b5236', // copa oscura compacta
+  encenilloMusgo: '#586a44', // velo de musgo del árbol de niebla
+
+  // Aliso (Alnus acuminata)
+  alisoTronco: '#9a9a8f', // corteza gris clara
+  alisoHoja: '#4f6d3d', // verde fresco
+  alisoHoja2: '#5c7a46',
+
+  // Gaque (Clusia)
+  gaqueTronco: '#57493a',
+  gaqueHoja: '#2f4a2d', // verde muy oscuro lustroso
+  gaqueHoja2: '#37552f',
+
+  // Mortiño (Vaccinium meridionale)
+  mortinoHoja: '#3f5a3a',
+  mortinoBrote: '#7a4536', // brote rojizo nuevo
+  mortinoBaya: '#33305c', // baya azul-morada (agraz)
+  mortinoBaya2: '#3d3768',
+
+  // Romerillo
+  romerilloHoja: '#79883f',
+  romerilloHoja2: '#8a9a4e',
   romerilloFlor: '#d8c24a',
 
-  // Suelo.
-  roca: '#77776b',
-  rocaSol: '#9b9b8d',
-  liquen: '#9aa86a',
+  // Suelo
+  roca: '#7c7c70',
+  liquen: '#9aa86a', // líquen pálido sobre la piedra
   liquen2: '#b7c08a',
-  musgo: '#46562f',
-  musgoSol: '#6d8049',
+  musgo: '#4c5c34',
+  musgo2: '#5a6a3e',
 };
 
-/* Líquen del páramo que trepa el pie de todo lo leñoso. */
-const LIQUEN_PIE = '#7c8a5e';
-
 /* -------------------------------------------------------------------------- */
-/*  El constructor de ÁRBOLES (jerarquía de ramas + copas con huecos)          */
+/*  Utilidades de construcción (fusión + colocación + color horneado)          */
 /* -------------------------------------------------------------------------- */
 
-const AUREO = Math.PI * (3 - Math.sqrt(5)); // ángulo áureo: filotaxia real
+const UP = new THREE.Vector3(0, 1, 0);
+
+/** Hornea un color plano en TODOS los vértices (atributo `color`). Idempotente. */
+function pintar(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Coloca una geometría con posición/rotación/escala (transforma vértices). */
+function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/** Orienta el eje +Y de la geometría hacia `dir` y la ubica en `pos` (para hojas
+    que apuntan en cualquier dirección). `esc` escala en el eje local antes de
+    girar (aplana hojas: escala z pequeña → lámina). */
+function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    q,
+    new THREE.Vector3(esc[0], esc[1], esc[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
 
 /**
- * Construye un árbol procedural completo y lo devuelve FUSIONADO (1 draw-call).
+ * Fusiona la lista de partes (ya coloreadas) en UNA geometría.
  *
- * Sigue la receta del DR en orden de retorno: silueta y jerarquía primero,
- * sombreado horneado encima. Las copas NO son un domo relleno: se siembran
- * cúmulos en las PUNTAS DE RAMA, cada uno con huecos y borde mordido.
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO si las partes mezclan geometrías
+ * indexadas (Cone/Cylinder/Sphere) con no-indexadas (Icosahedron/Dodecahedron).
+ * Ese null invisible tenía APAGADAS seis especies (frailejón, roble, encenillo,
+ * aliso, gaque, romerillo) y, en el valle, además mataba el render entero con
+ * `null.boundingSphere`. Es la TERCERA mordida de esta trampa (2026-07-15) y la
+ * cazaron dos agentes por separado, en esta rama y en fable/direccion-valle.
  *
- * @param {object} o
- * @param {string} o.nombre        etiqueta (para que un merge nulo diga quién).
- * @param {number} o.altura        altura del fuste.
- * @param {number} o.r0            radio en la base.
- * @param {number} o.r1            radio en la punta.
- * @param {number} [o.inclina]     cuánto se inclina el fuste con la altura.
- * @param {number} [o.sinuoso]     cuánto serpentea alrededor de su eje.
- * @param {number} [o.raigon]      ensanche del pie (contrafuertes).
- * @param {number} [o.arruga]      amplitud del relieve de corteza.
- * @param {object} o.corteza       paleta de corteza (ver hornearCorteza).
- * @param {object} o.copa          { inicio, ramas, largo, alza, sub, subLargo }
- * @param {object} o.follaje       { base, sol, luz, radio, hojas, achatado, ... }
- * @param {number} o.q             calidad (tier): escala el detalle.
- * @param {number} o.semilla
- * @param {(partes:THREE.BufferGeometry[], ctx:object)=>void} [o.firma]
- *        gancho para el rasgo INCONFUNDIBLE de la especie (láminas de papel del
- *        Polylepis, lenticelas del aliso, musgo del encenillo, bayas…).
+ * Se DESINDEXA todo antes de fusionar y se TRUENA si aun así falla: mejor un
+ * error de build que una especie invisible en producción.
+ *
+ * El `dispose()` no es opcional: `toNonIndexed()` devuelve una geometría NUEVA y
+ * la original se queda en memoria de GPU. Sin liberarla, cada rebuild filtra —
+ * y esto corre en un Android barato.
  */
-export function construirArbol(o) {
-  const {
-    nombre, altura, r0, r1, corteza, copa, follaje, q = 1, semilla = 1,
-    inclina = 0.08, sinuoso = 0.1, raigon = 0.35, arruga = 0.13,
-  } = o;
-  const r = rng(semilla);
-  const partes = [];
-
-  // 1) El FUSTE: curva sinuosa + conicidad con raigón + arruga en la malla.
-  const giro = r() * Math.PI * 2;
-  const curva = curvaTronco({ altura, inclina, sinuoso, giro }, semilla);
-  const taper = taperTronco(r0, r1, raigon);
-  const tronco = tuboOrganico(curva, {
-    tubular: Math.max(9, Math.round(16 * q)),
-    radial: Math.max(5, Math.round(9 * q)),
-    taper,
-    arruga,
-    semilla: semilla * 3,
+function fusionar(partes) {
+  const buenas = partes.filter(Boolean).map((p) => {
+    const plana = p.index ? p.toNonIndexed() : p;
+    if (plana !== p) p.dispose();
+    return plana;
   });
-  hornearCorteza(tronco, {
-    ...corteza,
-    hastaLiquen: corteza.hastaLiquen ?? altura * 0.3,
-    liquen: corteza.liquen ?? LIQUEN_PIE,
-  });
-  partes.push(tronco);
-
-  // 2) RAMAS PRIMARIAS: nacen del tercio alto, en ángulo áureo (filotaxia real,
-  //    no un reparto regular que se lee como radios de rueda).
-  const nRamas = Math.max(2, Math.round(copa.ramas * q));
-  const puntas = [];
-  const ramaGeos = [];
-  for (let i = 0; i < nRamas; i++) {
-    const f = nRamas === 1 ? 0.5 : i / (nRamas - 1);
-    const tBase = copa.inicio + f * (0.94 - copa.inicio);
-    const base = curva.getPointAt(tBase);
-    const ang = i * AUREO + giro;
-    // Las ramas de abajo son más largas y abiertas; las de arriba, cortas y
-    // erguidas → la copa se estrecha sola, sin ser un cono.
-    const largo = copa.largo * (1.15 - f * 0.5) * (0.8 + r() * 0.4);
-    const alza = copa.alza * (0.7 + f * 0.7);
-    const dirX = Math.cos(ang);
-    const dirZ = Math.sin(ang);
-    const pts = [
-      base.clone(),
-      base.clone().add(new THREE.Vector3(dirX * largo * 0.34, alza * 0.3 + (r() - 0.5) * 0.1, dirZ * largo * 0.34)),
-      base.clone().add(new THREE.Vector3(dirX * largo * 0.72 + (r() - 0.5) * 0.2, alza * 0.68, dirZ * largo * 0.72 + (r() - 0.5) * 0.2)),
-      base.clone().add(new THREE.Vector3(dirX * largo, alza, dirZ * largo)),
-    ];
-    const cRama = new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
-    const rBase = Math.max(0.02, taper(tBase) * 0.4);
-    const g = tuboOrganico(cRama, {
-      tubular: Math.max(5, Math.round(9 * q)),
-      radial: Math.max(4, Math.round(6 * q)),
-      taper: taperLineal(rBase, rBase * 0.28),
-      arruga: arruga * 0.7,
-      semilla: semilla + i * 7,
-    });
-    ramaGeos.push(g);
-    puntas.push({ p: pts[3].clone(), rBase, dir: [dirX, dirZ], nivel: 1 });
-
-    // 3) RAMAS SECUNDARIAS: la jerarquía que el DR pide. Nacen a media rama y
-    //    se abren en otro plano → la silueta deja de ser una estrella plana.
-    const nSub = Math.max(0, Math.round((copa.sub ?? 2) * q));
-    for (let k = 0; k < nSub; k++) {
-      const tk = 0.42 + (k / Math.max(1, nSub)) * 0.45;
-      const bk = cRama.getPointAt(tk);
-      const desvio = ang + (k % 2 ? 1 : -1) * (0.6 + r() * 0.5);
-      const lk = (copa.subLargo ?? largo * 0.5) * (0.7 + r() * 0.5);
-      const pk = [
-        bk.clone(),
-        bk.clone().add(new THREE.Vector3(Math.cos(desvio) * lk * 0.5, alza * 0.22 + r() * 0.12, Math.sin(desvio) * lk * 0.5)),
-        bk.clone().add(new THREE.Vector3(Math.cos(desvio) * lk, alza * 0.42 + r() * 0.16, Math.sin(desvio) * lk)),
-      ];
-      const cSub = new THREE.CatmullRomCurve3(pk, false, 'catmullrom', 0.5);
-      const rk = rBase * 0.5;
-      ramaGeos.push(tuboOrganico(cSub, {
-        tubular: Math.max(4, Math.round(6 * q)),
-        radial: 4,
-        taper: taperLineal(rk, rk * 0.3),
-        arruga: arruga * 0.5,
-        semilla: semilla + i * 13 + k,
-      }));
-      puntas.push({ p: pk[2].clone(), rBase: rk, dir: [Math.cos(desvio), Math.sin(desvio)], nivel: 2 });
-    }
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error('floraParamo: mergeGeometries devolvió null — atributos incompatibles entre partes');
   }
-  for (const g of ramaGeos) {
-    hornearCorteza(g, { ...corteza, hastaLiquen: 0, liquen: null });
-    partes.push(g);
-  }
+  // Las partes de entrada nunca tocaron la GPU: quedan para el GC.
+  return g;
+}
 
-  // 4) LA COPA: un cúmulo por punta de rama. Cada cúmulo trae huecos y borde
-  //    mordido; juntos forman una masa irregular por la que entra el cielo.
-  const cima = curva.getPointAt(1);
-  const centros = puntas.map((pt) => ({
-    centro: /** @type {[number, number, number]} */ ([pt.p.x, pt.p.y + follaje.radio * 0.25, pt.p.z]),
-    radio: follaje.radio * (pt.nivel === 1 ? 1 : 0.66) * (0.75 + r() * 0.5),
-  }));
-  // La corona: remata el fuste para que la copa no se vea "colgada" de ramas.
-  centros.push({ centro: /** @type {[number, number, number]} */ ([cima.x, cima.y + follaje.radio * 0.35, cima.z]), radio: follaje.radio * 0.95 });
-
-  const totalHojas = Math.max(6, Math.round(follaje.hojas * q));
-  const porCumulo = Math.max(2, Math.floor(totalHojas / centros.length));
-  const yTope = cima.y + follaje.radio * 1.3;
-  const yPie = copa.inicio * altura;
-
-  centros.forEach((c, i) => {
-    const puntos = sembrarFollaje({
-      centro: c.centro,
-      radio: c.radio,
-      achatado: follaje.achatado ?? 0.8,
-      n: porCumulo,
-      semilla: semilla * 31 + i * 17,
-      huecos: follaje.huecos ?? 0.42,
-      mordida: follaje.mordida ?? 0.34,
-      distMin: c.radio * (follaje.distMin ?? 0.38),
-    });
-    for (let k = 0; k < puntos.length; k++) {
-      const h = puntos[k];
-      const tam = c.radio * (follaje.escHoja ?? 0.34) * h.esc;
-      const g = matojoHoja(tam, semilla + i * 5 + k, follaje.deform ?? 0.42);
-      poner(g, h.pos, h.giro, [1, follaje.aplana ?? 0.72, 1]);
-      // El sombreado se hornea contra el CÚMULO (AO local) pero con el rango de
-      // altura del ÁRBOL entero → la copa tiene sol arriba y penumbra abajo.
-      hornearFollaje(g, {
-        base: follaje.base,
-        sol: follaje.sol,
-        luz: follaje.luz,
-        centro: c.centro,
-        radio: c.radio * 1.15,
-        yMin: yPie,
-        yMax: yTope,
-        ao: follaje.ao ?? 0.6,
-        manchas: follaje.manchas ?? 0.1,
-      });
-      partes.push(g);
-    }
-  });
-
-  // 5) La FIRMA de la especie (lo que la hace inconfundible).
-  if (o.firma) o.firma(partes, { r, curva, taper, altura, puntas, q, centros });
-
-  return fusionarSeguro(partes, nombre);
+/** Pequeña variación determinista de color (para que un bosque no sea plano). */
+function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
 }
 
 /* -------------------------------------------------------------------------- */
-/*  FRAILEJÓN (Espeletia) — el ícono, y el más difícil                         */
+/*  FRAILEJÓN (Espeletia) — el ícono del páramo                                */
 /* -------------------------------------------------------------------------- */
 
 /*
- * Dos rasgos lo hacen inconfundible y los dos son geometría, no color:
- *   · la ENAGUA: el tallo va vestido con las hojas MUERTAS de toda su vida, que
- *     no se caen (marcescencia) — se apelmazan hacia abajo contra el tallo y lo
- *     engordan. Es lo que le da su silueta de columna peluda.
- *   · la ROSETA: hojas lanceoladas, gruesas y VELLOSAS, en espiral áurea,
- *     apretadas y erguidas formando una copa compacta — no un erizo de púas.
- *
- * La versión anterior fallaba justo aquí: pocas hojas, muy separadas, muy
- * blancas y muy abiertas → parecía un erizo blanco clavado en un palo.
+ * Silueta de MONJE: un tronco columnar VESTIDO de arriba abajo con la ENAGUA de
+ * hojas muertas (marcescentes) que cuelgan pegadas al tallo como un hábito —eso
+ * le da CUERPO, no es un palo—, coronado por la ROSETA plateada peluda: un
+ * penacho DENSO de hojas anchas, carnosas y afelpadas (tomento plateado, NO
+ * cerdas) en espiral áurea, más erguidas al centro y recostadas al borde. Esa
+ * roseta blanquecina afelpada + la falda de hojas secas es lo que lo hace
+ * inequívoco. Con `flor`, un escapo con capítulos amarillos asoma de la roseta.
  */
 export function geomFrailejon({ flor = false, q = 1 } = {}, seed = 1) {
   const r = rng(seed);
   const partes = [];
-  const H = 1.0; // alto del tallo vestido
+  const GOLDEN = Math.PI * (3 - Math.sqrt(5));
 
-  // 1) Tallo columnar (casi todo oculto por la enagua).
-  const tallo = new THREE.CylinderGeometry(0.1, 0.13, H, 7, 1);
-  poner(tallo, [0, H / 2, 0]);
-  hornearCorteza(tallo, {
-    grieta: '#3f3324', cuerpo: PAL.frailejonTronco, cresta: '#7d6a4c',
-    liquen: null, hastaLiquen: 0, escalaGrano: 9,
-  });
-  partes.push(tallo);
+  // Frailejón erguido y solemne: columna alta (crece ~1cm/año, se lee vertical).
+  const Ht = 1.12 + r() * 0.55;
+  const cy = Ht + 0.05; // la roseta se posa como una cabeza sobre la columna
 
-  // 2) ENAGUA: anillos densos de hojas muertas pegadas al tallo, apuntando
-  //    abajo-afuera. Muchas y solapadas: es un manto, no un fleco.
-  const anillos = Math.max(4, Math.round(7 * q));
+  // 1) Tallo columnar — casi todo oculto por la enagua.
+  const tronco = new THREE.CylinderGeometry(0.12, 0.15, Ht, 7, 1);
+  poner(tronco, [0, Ht / 2, 0]);
+  partes.push(pintar(tronco, PAL.frailejonTronco));
+
+  // 2) ENAGUA de hojas muertas: el HÁBITO. Hojas anchas y secas que cuelgan casi
+  //    a plomo, pegadas al tronco y superpuestas como tejas, vistiendo la columna
+  //    entera (de la base a la roseta). Es lo que le da cuerpo de "fraile grande".
+  const anillos = Math.max(3, Math.round(6 * q));
   const porAnillo = Math.max(6, Math.round(10 * q));
   for (let a = 0; a < anillos; a++) {
-    const f = a / anillos;
-    const y = 0.1 + f * (H - 0.06);
-    const rad = 0.13 - f * 0.015;
+    const f = a / anillos; // 0 base → 1 bajo la roseta
+    const y = 0.14 + f * (Ht - 0.1);
+    const rad = 0.15;
     for (let i = 0; i < porAnillo; i++) {
-      const ang = (i / porAnillo) * Math.PI * 2 + a * 0.71 + r() * 0.16;
-      const largo = 0.3 + r() * 0.1;
-      const hoja = new THREE.ConeGeometry(0.055, largo, 4, 1);
-      // Cuelgan pegadas: casi verticales hacia abajo, apenas abiertas.
+      const ang = (i / porAnillo) * Math.PI * 2 + a * 0.6;
+      const largo = 0.30 + r() * 0.14;
+      // hoja seca ANCHA y aplanada (lámina, no púa), colgando casi vertical.
+      const hoja = new THREE.ConeGeometry(0.085, largo, 4, 1);
       apuntar(
         hoja,
         [Math.cos(ang) * rad, y, Math.sin(ang) * rad],
-        [Math.cos(ang) * 0.45, -0.9, Math.sin(ang) * 0.45],
+        [Math.cos(ang) * 0.3, -1, Math.sin(ang) * 0.3],
         [1, 1, 0.42],
       );
-      const seca = r() > 0.5 ? PAL.frailejonSeco : PAL.frailejonSeco2;
-      hornearFollaje(hoja, {
-        base: '#4a3a26', sol: seca, luz: '#a98d5e',
-        centro: [0, y, 0], radio: 0.4, yMin: 0, yMax: H, ao: 0.42, manchas: 0.14,
-      });
-      partes.push(hoja);
+      partes.push(pintar(hoja, variar(r() > 0.55 ? PAL.frailejonSeco : PAL.frailejonSeco2, r, 0.14)));
     }
   }
 
-  // 3) ROSETA: hojas lanceoladas apretadas en espiral áurea. Las de afuera se
-  //    abren; las del centro van casi verticales → cogollo compacto y velloso.
-  const nRoseta = Math.max(16, Math.round(34 * q));
-  const cy = H + 0.02;
+  // 3) ROSETA plateada peluda — la FIRMA. Un COGOLLO afelpado, no una estrella:
+  //    hojas anchas, carnosas y GRUESAS (poco aplanadas) nacidas sobre una cúpula,
+  //    en espiral áurea, apenas abiertas (cuenco erguido, NO tendidas al ras), muy
+  //    densas y superpuestas → una bola velluda plateada. Las de afuera se recuestan
+  //    y agrisan (viejas); el centro es blanco y erguido (yema joven, tomento fresco).
+  const nRoseta = Math.max(18, Math.round(40 * q));
+  const plataInt = new THREE.Color(PAL.frailejonPlata);
+  const plataExt = new THREE.Color(PAL.frailejonPlata2);
   for (let i = 0; i < nRoseta; i++) {
-    const f = i / nRoseta; // 0 = exterior (vieja) → 1 = centro (nueva)
-    const ang = i * AUREO;
-    // Las viejas se tumban (casi horizontales), las nuevas se yerguen.
-    const tilt = 0.85 - f * 0.62 + (r() - 0.5) * 0.08;
+    const f = i / nRoseta; // 0 centro erguido → 1 borde recostado
+    const ang = i * GOLDEN + (r() - 0.5) * 0.18;
+    const posR = 0.03 + f * 0.11; // nacen sobre una cúpula, no de un punto
+    const posY = cy - f * 0.08; // las de afuera, más bajas → domo redondo
+    const tilt = 0.26 + f * 0.78 + (r() - 0.5) * 0.08; // cuenco: 15°→60°, sin aplanarse
     const s = Math.sin(tilt);
-    const largo = 0.32 - f * 0.1;
-    // ANCHA y CORTA: una hoja de frailejón es una lengua carnosa, no una púa.
-    // La versión anterior usaba conos largos y finos (r=0.062, l=0.5) muy
-    // separados → el conjunto se leía como un ERIZO blanco clavado en un palo,
-    // que es justo lo que el operador rechazó. Ancho ×2 y largo ×0.8, más
-    // hojas y menos abiertas → roseta compacta y vellosa.
-    const hoja = new THREE.ConeGeometry(0.135, largo, 6, 1);
+    const largo = 0.28 + (1 - f) * 0.13 + r() * 0.05; // cortas y llenas, no lanzas
+    // hoja carnosa ANCHA y con CUERPO (poco aplanada) — nada de cerda fina.
+    const hoja = new THREE.ConeGeometry(0.115, largo, 4, 1);
     apuntar(
       hoja,
-      [Math.cos(ang) * 0.03, cy + f * 0.045, Math.sin(ang) * 0.03],
+      [Math.cos(ang) * posR, posY, Math.sin(ang) * posR],
       [Math.cos(ang) * s, Math.cos(tilt), Math.sin(ang) * s],
-      [1, 1, 0.5], // lanceolada: carnosa. Aplanarla a 0.3 la volvía una púa.
+      [1, 1, 0.6],
     );
-    // Vellosa: verde-plata MATE. Nada de blanco tiza (eso la volvía un erizo de
-    // nieve); el frailejón es verde grisáceo con pelusa que apenas aclara.
-    hornearFollaje(hoja, {
-      base: '#5e6d4e', sol: PAL.frailejonPlata, luz: '#c2cdb0',
-      centro: [0, cy, 0], radio: 0.5, yMin: cy - 0.2, yMax: cy + 0.38,
-      ao: 0.5, manchas: 0.1,
-    });
-    partes.push(hoja);
+    const col = plataInt.clone().lerp(plataExt, f);
+    partes.push(pintar(hoja, variar(col, r, 0.05)));
   }
-  // Cogollo velloso: el corazón apretado de la roseta.
-  const corazon = matojoHoja(0.11, seed + 3, 0.3);
-  poner(corazon, [0, cy + 0.08, 0], [0, 0, 0], [1, 0.8, 1]);
-  hornearFollaje(corazon, {
-    base: '#8e9a7c', sol: PAL.frailejonCorazon, luz: '#e2e8d6',
-    centro: [0, cy + 0.08, 0], radio: 0.13, ao: 0.3, manchas: 0.06,
-  });
-  partes.push(corazon);
+  // Corona interior: unas pocas hojas cortas y ERGUIDAS que tapan el centro y lo
+  // hacen leer como un cogollo lleno (sin hueco oscuro), del blanco más pálido.
+  const nCorona = Math.max(4, Math.round(7 * q));
+  for (let i = 0; i < nCorona; i++) {
+    const ang = i * GOLDEN + 1.3;
+    const tilt = 0.14 + r() * 0.12;
+    const s = Math.sin(tilt);
+    const hoja = new THREE.ConeGeometry(0.075, 0.20 + r() * 0.05, 4, 1);
+    apuntar(
+      hoja,
+      [Math.cos(ang) * 0.03, cy + 0.05, Math.sin(ang) * 0.03],
+      [Math.cos(ang) * s, Math.cos(tilt), Math.sin(ang) * s],
+      [1, 1, 0.7],
+    );
+    partes.push(pintar(hoja, variar(PAL.frailejonCorazon, r, 0.04)));
+  }
+  // Yema vellosa central (el punto más pálido, afelpado).
+  const corazon = new THREE.IcosahedronGeometry(0.09, 0);
+  poner(corazon, [0, cy + 0.11, 0], [0, 0, 0], [1, 0.9, 1]);
+  partes.push(pintar(corazon, PAL.frailejonCorazon));
 
-  // 4) Escapo floral (solo en flor): capítulos amarillos sobre tallo velloso.
+  // 4) Escapo floral (solo en flor): tallo + capítulos amarillos sobre la roseta.
   if (flor) {
-    const tf = new THREE.CylinderGeometry(0.026, 0.038, 0.9, 5, 1);
-    poner(tf, [0.04, cy + 0.44, 0], [0, 0, 0.07]);
-    partes.push(pintarPlano(tf, PAL.frailejonTallo));
-    const nCap = Math.max(4, Math.round(8 * q));
+    const tallo = new THREE.CylinderGeometry(0.028, 0.045, 0.9, 5, 1);
+    poner(tallo, [0.05, cy + 0.45, 0], [0, 0, 0.08]);
+    partes.push(pintar(tallo, PAL.frailejonTallo));
+    const nCap = Math.max(4, Math.round(7 * q));
     for (let i = 0; i < nCap; i++) {
-      const ang = i * AUREO;
-      const rad = 0.09 + r() * 0.07;
-      const cap = matojoHoja(0.05 + r() * 0.018, seed + i, 0.24);
-      poner(cap, [0.07 + Math.cos(ang) * rad, cy + 0.86 + r() * 0.1, Math.sin(ang) * rad], [0, 0, 0], [1, 0.72, 1]);
-      hornearFollaje(cap, {
-        base: '#9b8420', sol: PAL.frailejonFlor, luz: '#f3e08a',
-        centro: [0.07, cy + 0.9, 0], radio: 0.2, ao: 0.3, manchas: 0.05,
-      });
-      partes.push(cap);
+      const ang = (i / nCap) * Math.PI * 2;
+      const rad = 0.1 + r() * 0.06;
+      const cap = new THREE.IcosahedronGeometry(0.055 + r() * 0.02, 0);
+      poner(cap, [0.08 + Math.cos(ang) * rad, cy + 0.85 + r() * 0.1, Math.sin(ang) * rad], [0, 0, 0], [1, 0.7, 1]);
+      partes.push(pintar(cap, variar(PAL.frailejonFlor, r, 0.08)));
     }
   }
 
-  return fusionarSeguro(partes, flor ? 'frailejon-flor' : 'frailejon');
-}
-
-/* -------------------------------------------------------------------------- */
-/*  QUEÑUA / Polylepis — la corteza de papel                                    */
-/* -------------------------------------------------------------------------- */
-
-/*
- * La misma especie del Ent, pero de porte normal: un cortejo de queñuas
- * jóvenes alrededor del guardián (una familia, no un solitario). Su firma es la
- * corteza rojiza que se DESCAMA en láminas de papel: se modela con geometría
- * (anillos de lámina despegada), que es lo único que la lee de verdad.
- */
-export function geomQuenua({ q = 1 } = {}, seed = 2) {
-  return construirArbol({
-    nombre: 'quenua',
-    altura: 2.3, r0: 0.17, r1: 0.05,
-    inclina: 0.2, sinuoso: 0.2, raigon: 0.4, arruga: 0.16, // retorcida
-    corteza: {
-      grieta: PAL.quenuaGrieta, cuerpo: PAL.quenuaCuerpo, cresta: PAL.quenuaPapel,
-      liquen: LIQUEN_PIE, escalaGrano: 4.5,
-    },
-    copa: { inicio: 0.4, ramas: 5, largo: 0.62, alza: 0.62, sub: 2, subLargo: 0.34 },
-    follaje: {
-      base: '#33452a', sol: PAL.quenuaHojaSol, luz: '#cdd58e',
-      radio: 0.5, hojas: 46, achatado: 0.8, huecos: 0.46, mordida: 0.4,
-      escHoja: 0.36, aplana: 0.7, ao: 0.62, manchas: 0.12,
-    },
-    q,
-    semilla: seed,
-    // FIRMA: las láminas de papel que se despegan del tronco.
-    firma: (partes, { r, curva, taper, q: qq }) => {
-      const n = Math.max(5, Math.round(14 * qq));
-      for (let i = 0; i < n; i++) {
-        const t = 0.06 + r() * 0.72;
-        const c = curva.getPointAt(t);
-        const ang = r() * Math.PI * 2;
-        const rad = taper(t);
-        // Cada lámina es un casquete fino, despegado y curvado hacia afuera.
-        const lam = new THREE.CylinderGeometry(
-          rad * 1.12, rad * 1.2, 0.1 + r() * 0.14, 7, 1, true,
-          ang, 0.7 + r() * 0.9,
-        );
-        poner(lam, [c.x, c.y, c.z], [(r() - 0.5) * 0.3, 0, (r() - 0.5) * 0.3]);
-        hornearFollaje(lam, {
-          base: '#6d3b28', sol: PAL.quenuaPapel, luz: '#e9c2a0',
-          centro: [c.x, c.y, c.z], radio: rad * 1.6,
-          yMin: 0, yMax: 2.3, ao: 0.3, manchas: 0.16,
-        });
-        partes.push(lam);
-      }
-    },
-  });
-}
-
-/* -------------------------------------------------------------------------- */
-/*  ENCENILLO (Weinmannia tomentosa) — el árbol de la niebla                   */
-/* -------------------------------------------------------------------------- */
-
-export function geomEncenillo({ q = 1 } = {}, seed = 3) {
-  return construirArbol({
-    nombre: 'encenillo',
-    altura: 2.6, r0: 0.15, r1: 0.045,
-    inclina: 0.1, sinuoso: 0.13, arruga: 0.14,
-    corteza: {
-      grieta: PAL.encenilloGrieta, cuerpo: PAL.encenilloTronco, cresta: '#8a5c46',
-      liquen: '#6f8055', escalaGrano: 6,
-    },
-    // Copa compacta y estrecha: vive apretado en el bosque de niebla.
-    copa: { inicio: 0.46, ramas: 5, largo: 0.5, alza: 0.66, sub: 2, subLargo: 0.3 },
-    follaje: {
-      base: '#22331f', sol: PAL.encenilloHojaSol, luz: '#adc07e',
-      radio: 0.46, hojas: 52, achatado: 0.92, huecos: 0.36, mordida: 0.3,
-      escHoja: 0.36, aplana: 0.8, ao: 0.68, manchas: 0.1,
-    },
-    q,
-    semilla: seed,
-    // FIRMA: el velo de MUSGO que lo cubre (vive envuelto en niebla).
-    firma: (partes, { r, curva, taper, q: qq }) => {
-      const n = Math.max(4, Math.round(11 * qq));
-      for (let i = 0; i < n; i++) {
-        const t = 0.12 + r() * 0.7;
-        const c = curva.getPointAt(t);
-        const ang = r() * Math.PI * 2;
-        const rad = taper(t) * 1.05;
-        const m = matojoHoja(0.1 + r() * 0.07, seed + i * 3, 0.5);
-        poner(m, [c.x + Math.cos(ang) * rad, c.y, c.z + Math.sin(ang) * rad], [r(), r(), r()], [1.3, 0.9, 1.3]);
-        hornearFollaje(m, {
-          base: '#3d4a2a', sol: PAL.encenilloMusgo, luz: '#c2cf94',
-          centro: [c.x, c.y, c.z], radio: 0.4, yMin: 0, yMax: 2.6, ao: 0.4, manchas: 0.2,
-        });
-        partes.push(m);
-      }
-    },
-  });
-}
-
-/* -------------------------------------------------------------------------- */
-/*  ALISO (Alnus acuminata) — el vecino esbelto de corteza clara               */
-/* -------------------------------------------------------------------------- */
-
-/*
- * OJO: la versión anterior construía su copa como un CONO explícito ("copa
- * cónica: blobs que se estrechan hacia arriba") — el árbol de navidad literal.
- * Ahora la copa es alta y ovalada pero IRREGULAR: se estrecha porque las ramas
- * de arriba son cortas, no porque la dibujemos como un cono.
- */
-export function geomAliso({ q = 1 } = {}, seed = 4) {
-  return construirArbol({
-    nombre: 'aliso',
-    altura: 3.3, r0: 0.13, r1: 0.04,
-    inclina: 0.06, sinuoso: 0.08, raigon: 0.28, arruga: 0.08, // recto y esbelto
-    corteza: {
-      grieta: PAL.alisoGrieta, cuerpo: PAL.alisoTronco, cresta: PAL.alisoLenticela,
-      liquen: '#8a9668', escalaGrano: 7,
-    },
-    copa: { inicio: 0.42, ramas: 6, largo: 0.6, alza: 0.72, sub: 2, subLargo: 0.32 },
-    follaje: {
-      base: '#2c4020', sol: PAL.alisoHojaSol, luz: '#d2dc8e',
-      radio: 0.5, hojas: 56, achatado: 0.86, huecos: 0.5, mordida: 0.42,
-      escHoja: 0.34, aplana: 0.7, ao: 0.58, manchas: 0.12,
-    },
-    q,
-    semilla: seed,
-    // FIRMA: las LENTICELAS: las rayitas claras horizontales de su corteza gris.
-    firma: (partes, { r, curva, taper, q: qq }) => {
-      const n = Math.max(6, Math.round(16 * qq));
-      for (let i = 0; i < n; i++) {
-        const t = 0.06 + r() * 0.68;
-        const c = curva.getPointAt(t);
-        const ang = r() * Math.PI * 2;
-        const rad = taper(t);
-        const len = new THREE.BoxGeometry(0.07 + r() * 0.06, 0.014, 0.03);
-        poner(
-          len,
-          [c.x + Math.cos(ang) * rad * 0.98, c.y, c.z + Math.sin(ang) * rad * 0.98],
-          [0, -ang, 0],
-        );
-        partes.push(pintarPlano(len, PAL.alisoLenticela));
-      }
-    },
-  });
-}
-
-/* -------------------------------------------------------------------------- */
-/*  GAQUE (Clusia) — copa redonda densa de hoja gruesa lustrosa                */
-/* -------------------------------------------------------------------------- */
-
-export function geomGaque({ q = 1 } = {}, seed = 5) {
-  return construirArbol({
-    nombre: 'gaque',
-    altura: 1.9, r0: 0.17, r1: 0.06,
-    inclina: 0.1, sinuoso: 0.1, arruga: 0.1,
-    corteza: {
-      grieta: PAL.gaqueGrieta, cuerpo: PAL.gaqueTronco, cresta: '#75664f',
-      liquen: LIQUEN_PIE, escalaGrano: 6.5,
-    },
-    // Ramas cortas y muy abiertas → domo bajo, ancho y macizo.
-    copa: { inicio: 0.4, ramas: 6, largo: 0.72, alza: 0.34, sub: 2, subLargo: 0.36 },
-    follaje: {
-      base: '#182a17', sol: PAL.gaqueHojaSol, luz: '#9ab97e',
-      radio: 0.56, hojas: 58, achatado: 0.72, huecos: 0.3, mordida: 0.26,
-      escHoja: 0.4, aplana: 0.66, ao: 0.7, manchas: 0.08,
-    },
-    q,
-    semilla: seed,
-  });
-}
-
-/* -------------------------------------------------------------------------- */
-/*  ROBLE ANDINO (Quercus humboldtii) — el único roble nativo de Colombia      */
-/* -------------------------------------------------------------------------- */
-
-/*
- * No es de páramo (es del robledal andino, más abajo), así que NO entra en el
- * cortejo del Ent — pero lo usan la ladera de restauración y el valle, y esos
- * mundos también merecen dejar de tener bombones. Su firma: tronco grueso y
- * copa ANCHA y densa de hoja coriácea oscura, con bellotas.
- */
-export function geomRoble({ q = 1 } = {}, seed = 11) {
-  return construirArbol({
-    nombre: 'roble',
-    altura: 2.5, r0: 0.26, r1: 0.08,
-    inclina: 0.07, sinuoso: 0.1, raigon: 0.42, arruga: 0.15,
-    corteza: {
-      grieta: '#3b3126', cuerpo: PAL.robleTronco, cresta: '#8a7a63',
-      liquen: LIQUEN_PIE, escalaGrano: 5,
-    },
-    // Ramas largas y poco alzadas → la copa se va a lo ANCHO, que es su sello.
-    copa: { inicio: 0.38, ramas: 6, largo: 1.0, alza: 0.5, sub: 2, subLargo: 0.5 },
-    follaje: {
-      base: '#1e2f1a', sol: PAL.robleHojaSol, luz: '#a8bd76',
-      radio: 0.62, hojas: 66, achatado: 0.74, huecos: 0.34, mordida: 0.3,
-      escHoja: 0.38, aplana: 0.7, ao: 0.68, manchas: 0.1,
-    },
-    q,
-    semilla: seed,
-    // FIRMA: las bellotas colgando del borde de la copa.
-    firma: (partes, { r, q: qq, centros }) => {
-      const n = Math.max(2, Math.round(5 * qq));
-      for (let i = 0; i < n; i++) {
-        const c = centros[Math.floor(r() * centros.length) % centros.length];
-        const ang = r() * Math.PI * 2;
-        const rad = c.radio * (0.4 + r() * 0.5);
-        const p = [c.centro[0] + Math.cos(ang) * rad, c.centro[1] - c.radio * 0.5, c.centro[2] + Math.sin(ang) * rad];
-        const bellota = new THREE.IcosahedronGeometry(0.055, 0);
-        poner(bellota, p, [0, 0, 0], [1, 1.45, 1]);
-        partes.push(pintarPlano(bellota, PAL.robleBellota));
-        const capa = new THREE.SphereGeometry(0.048, 6, 4, 0, Math.PI * 2, 0, Math.PI * 0.5);
-        poner(capa, [p[0], p[1] + 0.06, p[2]]);
-        partes.push(pintarPlano(capa, PAL.robleCapa));
-      }
-    },
-  });
+  return fusionar(partes);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -685,304 +339,348 @@ export function geomRoble({ q = 1 } = {}, seed = 11) {
 /* -------------------------------------------------------------------------- */
 
 /*
- * Tampoco es de páramo (es pionera de bosque andino) pero la usan la ladera y
- * el valle. Su firma es única y no pasa por el constructor genérico: pocas
- * ramas en candelabro y una copa en SOMBRILLA de hojas palmeadas grandes cuyo
- * ENVÉS es blanco-plata — desde abajo se ve ese blanco, y eso es el yarumo.
+ * Pionera esbelta: tronco pálido y recto, ramas en candelabro arriba y una copa
+ * en SOMBRILLA de hojas palmeadas (mano de 7 lóbulos) cuyo ENVÉS es blanco-plata.
+ * Desde abajo se ve ese blanco: la firma inconfundible del yarumo.
  */
-export function geomYarumo({ q = 1 } = {}, seed = 12) {
+export function geomYarumo({ q = 1 } = {}, seed = 2) {
   const r = rng(seed);
   const partes = [];
   const H = 3.4;
 
-  // Tronco pálido, esbelto y anillado.
-  const curva = curvaTronco({ altura: H, inclina: 0.07, sinuoso: 0.06, giro: r() * 6.28 }, seed);
-  const taper = taperTronco(0.14, 0.06, 0.2);
-  const tronco = tuboOrganico(curva, {
-    tubular: Math.max(8, Math.round(14 * q)), radial: Math.max(5, Math.round(8 * q)),
-    taper, arruga: 0.05, semilla: seed * 3,
-  });
-  hornearCorteza(tronco, {
-    grieta: '#8e9186', cuerpo: PAL.yarumoTronco, cresta: '#d6d9cc',
-    liquen: LIQUEN_PIE, hastaLiquen: H * 0.18, escalaGrano: 3,
-  });
-  partes.push(tronco);
+  const tronco = new THREE.CylinderGeometry(0.08, 0.14, H, 8, 1);
+  poner(tronco, [0, H / 2, 0], [0, 0, 0.03]);
+  partes.push(pintar(tronco, PAL.yarumoTronco));
 
-  // Anillos: las cicatrices de hoja caída que le marcan el tronco.
-  const nAnillos = Math.max(3, Math.round(8 * q));
-  for (let i = 0; i < nAnillos; i++) {
-    const t = 0.12 + (i / nAnillos) * 0.72;
-    const c = curva.getPointAt(t);
-    const rad = taper(t);
-    const anillo = new THREE.TorusGeometry(rad * 1.02, 0.012, 4, 9);
-    poner(anillo, [c.x, c.y, c.z], [Math.PI / 2, 0, 0]);
-    partes.push(pintarPlano(anillo, '#9fa294'));
-  }
-
-  // Ramas en candelabro: pocas, arriba, muy abiertas.
-  const nRamas = Math.max(2, Math.round(4 * q));
-  const puntas = [curva.getPointAt(1).clone()];
+  // Ramas en candelabro (pocas, arriba).
+  const nRamas = Math.max(2, Math.round(3 * q));
+  const puntas = [[0, H + 0.05, 0]];
   for (let i = 0; i < nRamas; i++) {
-    const ang = i * AUREO + r() * 0.4;
-    const largo = 0.72 + r() * 0.3;
-    const base = curva.getPointAt(0.86 + (i / nRamas) * 0.1);
-    const fin = base.clone().add(new THREE.Vector3(Math.cos(ang) * largo, 0.66 + r() * 0.2, Math.sin(ang) * largo));
-    const cR = new THREE.CatmullRomCurve3([
-      base.clone(),
-      base.clone().lerp(fin, 0.55).add(new THREE.Vector3(0, 0.1, 0)),
-      fin.clone(),
-    ], false, 'catmullrom', 0.5);
-    const g = tuboOrganico(cR, {
-      tubular: 5, radial: 4, taper: taperLineal(0.045, 0.022), arruga: 0.05, semilla: seed + i,
-    });
-    hornearCorteza(g, { grieta: '#8a8d82', cuerpo: PAL.yarumoRama, cresta: '#c8cbbe', liquen: null, hastaLiquen: 0, escalaGrano: 4 });
-    partes.push(g);
-    puntas.push(fin);
+    const ang = (i / nRamas) * Math.PI * 2 + 0.4;
+    const largo = 0.7 + r() * 0.3;
+    const rama = new THREE.CylinderGeometry(0.03, 0.05, largo, 5, 1);
+    const dir = [Math.cos(ang) * 0.7, 0.7, Math.sin(ang) * 0.7];
+    const base = [Math.cos(ang) * 0.05, H - 0.35 + i * 0.06, Math.sin(ang) * 0.05];
+    apuntar(rama, [base[0] + dir[0] * largo * 0.3, base[1] + dir[1] * largo * 0.3, base[2] + dir[2] * largo * 0.3], dir);
+    partes.push(pintar(rama, PAL.yarumoRama));
+    puntas.push([base[0] + dir[0] * largo, base[1] + dir[1] * largo, base[2] + dir[2] * largo]);
   }
 
-  // Las HOJAS palmeadas: discos grandes de 7 lóbulos, casi horizontales, con el
-  // envés blanco mirando al suelo. Es la sombrilla del yarumo.
+  // Hojas palmeadas: discos aplanados de 7 lóbulos, envés blanco, colgando.
   const porPunta = Math.max(2, Math.round(3 * q));
   for (const p of puntas) {
     for (let i = 0; i < porPunta; i++) {
-      const ang = i * AUREO + r() * 1.2;
-      const rad = 0.2 + r() * 0.14;
-      const hoja = new THREE.ConeGeometry(0.44, 0.08, 7, 1); // heptágono chato = "mano"
-      const pos = /** @type {[number, number, number]} */ ([p.x + Math.cos(ang) * rad, p.y - 0.04 - r() * 0.08, p.z + Math.sin(ang) * rad]);
-      apuntar(hoja, pos, [Math.cos(ang) * 0.34, 0.94, Math.sin(ang) * 0.34], [1, 0.5, 1]);
-      // El haz apenas verdea; el envés (abajo) es blanco-plata: el gradiente de
-      // altura de hornearFollaje hace justo eso si le damos un rango corto.
-      hornearFollaje(hoja, {
-        base: PAL.yarumoEnves, sol: PAL.yarumoHaz, luz: '#f2f6ee',
-        centro: pos, radio: 0.5, yMin: pos[1] - 0.06, yMax: pos[1] + 0.06,
-        ao: 0.18, manchas: 0.05,
-      });
-      partes.push(hoja);
+      const ang = (i / porPunta) * Math.PI * 2 + r();
+      const rad = 0.18 + r() * 0.12;
+      const hoja = new THREE.ConeGeometry(0.42, 0.09, 7, 1); // 7-gono chato = "mano"
+      // caída suave hacia afuera (envés hacia el suelo → se ve el blanco)
+      apuntar(
+        hoja,
+        [p[0] + Math.cos(ang) * rad, p[1] - 0.05 - r() * 0.08, p[2] + Math.sin(ang) * rad],
+        [Math.cos(ang) * 0.4, 0.9, Math.sin(ang) * 0.4],
+        [1, 0.5, 1],
+      );
+      partes.push(pintar(hoja, variar(PAL.yarumoEnves, r, 0.05)));
     }
   }
 
-  return fusionarSeguro(partes, 'yarumo');
+  return fusionar(partes);
 }
 
 /* -------------------------------------------------------------------------- */
-/*  MORTIÑO (Vaccinium meridionale) — el agraz andino                          */
+/*  ROBLE ANDINO (Quercus humboldtii) — el único roble nativo de Colombia      */
 /* -------------------------------------------------------------------------- */
 
 /*
- * Arbusto bajo y ramoso. No pasa por `construirArbol` (no tiene fuste): es una
- * mata de varitas que salen del suelo, con hojita menuda y —la firma— BAYAS
- * azul-moradas salpicadas.
+ * Árbol robusto de robledal altoandino: tronco grueso de corteza gris-parda
+ * fisurada y una copa ANCHA y densa de hoja coriácea verde oscuro, con bellotas.
+ * Imponente pero SIEMPRE menor que el Ent (el guardián sigue mandando).
  */
-export function geomMortino({ q = 1 } = {}, seed = 6) {
+export function geomRoble({ q = 1 } = {}, seed = 3) {
   const r = rng(seed);
   const partes = [];
+  const H = 2.4;
 
-  // Varitas desde la base (mata ramosa).
-  const nVaras = Math.max(3, Math.round(6 * q));
-  const puntas = [];
-  for (let i = 0; i < nVaras; i++) {
-    const ang = i * AUREO + r() * 0.5;
-    const alto = 0.42 + r() * 0.3;
-    const abre = 0.12 + r() * 0.16;
-    const pts = [
-      new THREE.Vector3(0, 0, 0),
-      new THREE.Vector3(Math.cos(ang) * abre * 0.5, alto * 0.5, Math.sin(ang) * abre * 0.5),
-      new THREE.Vector3(Math.cos(ang) * abre, alto, Math.sin(ang) * abre),
-    ];
-    const c = new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
-    const g = tuboOrganico(c, {
-      tubular: 4, radial: 4, taper: taperLineal(0.022, 0.01), arruga: 0.1, semilla: seed + i,
-    });
-    hornearCorteza(g, { grieta: '#38271c', cuerpo: PAL.mortinoRama, cresta: '#7a5a44', liquen: null, hastaLiquen: 0, escalaGrano: 10 });
-    partes.push(g);
-    puntas.push(pts[2]);
+  const tronco = new THREE.CylinderGeometry(0.16, 0.24, H, 8, 1);
+  poner(tronco, [0, H / 2, 0], [0.03, 0, 0.02]);
+  partes.push(pintar(tronco, PAL.robleTronco));
+
+  // Un par de ramas gruesas bajas que abren la copa ancha.
+  const nRamas = Math.max(2, Math.round(3 * q));
+  for (let i = 0; i < nRamas; i++) {
+    const ang = (i / nRamas) * Math.PI * 2 + 0.5;
+    const rama = new THREE.CylinderGeometry(0.06, 0.1, 0.9, 6, 1);
+    apuntar(rama, [Math.cos(ang) * 0.3, H - 0.4, Math.sin(ang) * 0.3], [Math.cos(ang) * 0.8, 0.55, Math.sin(ang) * 0.8]);
+    partes.push(pintar(rama, PAL.robleTronco));
   }
 
-  // Hojita menuda alrededor de las varitas.
-  const nHojas = Math.max(6, Math.round(16 * q));
-  for (let i = 0; i < nHojas; i++) {
-    const p = puntas[i % puntas.length];
+  // Copa ancha densa: cúpula amplia de follaje coriáceo oscuro.
+  const nBlobs = Math.max(6, Math.round(12 * q));
+  for (let i = 0; i < nBlobs; i++) {
     const ang = r() * Math.PI * 2;
-    const rad = 0.06 + r() * 0.16;
-    const pos = [p.x + Math.cos(ang) * rad, 0.16 + r() * 0.42, p.z + Math.sin(ang) * rad];
-    const h = matojoHoja(0.08 + r() * 0.05, seed + i * 3, 0.4);
-    poner(h, pos, [r(), r(), r()], [1, 0.6, 1]);
-    hornearFollaje(h, {
-      base: '#25361f', sol: r() > 0.78 ? PAL.mortinoBrote : PAL.mortinoHojaSol, luz: '#b6c883',
-      centro: [0, 0.4, 0], radio: 0.5, yMin: 0, yMax: 0.8, ao: 0.5, manchas: 0.14,
-    });
-    partes.push(h);
+    const rad = 0.2 + r() * 1.05; // ANCHA
+    const y = H + 0.1 + r() * 1.0;
+    const s = 0.42 + r() * 0.42;
+    const blob = new THREE.IcosahedronGeometry(s, 0);
+    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 0.85, 1]);
+    partes.push(pintar(blob, variar(r() > 0.5 ? PAL.robleHoja : PAL.robleHoja2, r, 0.08)));
   }
 
-  // FIRMA: las bayas de agraz, azul-moradas con su punto de brillo.
-  const nBayas = Math.max(3, Math.round(9 * q));
-  for (let i = 0; i < nBayas; i++) {
-    const ang = r() * Math.PI * 2;
-    const rad = r() * 0.3;
-    const baya = new THREE.IcosahedronGeometry(0.038 + r() * 0.014, 0);
-    poner(baya, [Math.cos(ang) * rad, 0.16 + r() * 0.42, Math.sin(ang) * rad]);
-    hornearFollaje(baya, {
-      base: '#1d1b38', sol: r() > 0.5 ? PAL.mortinoBaya : PAL.mortinoBaya2, luz: '#8f88d0',
-      centro: [Math.cos(ang) * rad, 0.3, Math.sin(ang) * rad], radio: 0.05, ao: 0.3, manchas: 0,
-    });
-    partes.push(baya);
+  // Bellotas (unas pocas, cuelgan del borde de la copa).
+  if (q > 0.5) {
+    const nBel = Math.max(2, Math.round(4 * q));
+    for (let i = 0; i < nBel; i++) {
+      const ang = r() * Math.PI * 2;
+      const rad = 0.7 + r() * 0.5;
+      const y = H + 0.2 + r() * 0.5;
+      const bellota = new THREE.IcosahedronGeometry(0.06, 0);
+      poner(bellota, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [0, 0, 0], [1, 1.4, 1]);
+      partes.push(pintar(bellota, PAL.robleBellota));
+      const capa = new THREE.SphereGeometry(0.05, 6, 4, 0, Math.PI * 2, 0, Math.PI * 0.5);
+      poner(capa, [Math.cos(ang) * rad, y + 0.07, Math.sin(ang) * rad]);
+      partes.push(pintar(capa, PAL.robleCapa));
+    }
   }
 
-  return fusionarSeguro(partes, 'mortino');
+  return fusionar(partes);
 }
 
 /* -------------------------------------------------------------------------- */
-/*  ROMERILLO — cojín bajo de follaje fino                                      */
+/*  ENCENILLO (Weinmannia tomentosa) — el árbol de la niebla                   */
 /* -------------------------------------------------------------------------- */
 
-export function geomRomerillo({ q = 1 } = {}, seed = 7) {
+/*
+ * Copa oscura, compacta e irregular sobre tronco rojizo algo torcido, con un
+ * velo de musgo (vive envuelto en niebla). Más estrecho y sombrío que el roble.
+ */
+export function geomEncenillo({ q = 1 } = {}, seed = 4) {
   const r = rng(seed);
   const partes = [];
-  const nRamitas = Math.max(6, Math.round(16 * q));
+  const H = 2.3;
+
+  const tronco = new THREE.CylinderGeometry(0.1, 0.16, H, 7, 1);
+  poner(tronco, [0, H / 2, 0], [0.05, 0, -0.03]);
+  partes.push(pintar(tronco, PAL.encenilloTronco));
+
+  const nBlobs = Math.max(5, Math.round(9 * q));
+  for (let i = 0; i < nBlobs; i++) {
+    const ang = r() * Math.PI * 2;
+    const rad = 0.15 + r() * 0.6; // copa estrecha
+    const y = H + 0.05 + r() * 1.0;
+    const s = 0.34 + r() * 0.3;
+    const blob = new THREE.IcosahedronGeometry(s, 0);
+    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 0.95, 1]);
+    const mossy = r() > 0.65;
+    partes.push(pintar(blob, variar(mossy ? PAL.encenilloMusgo : PAL.encenilloHoja, r, 0.08)));
+  }
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  ALISO (Alnus acuminata) — el vecino alto de corteza clara                  */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Tronco recto y esbelto de corteza gris clara, copa CÓNICA-ovalada de verde
+ * fresco. Es el árbol más alto del cortejo (crece rápido) pero no llega al Ent.
+ */
+export function geomAliso({ q = 1 } = {}, seed = 5) {
+  const r = rng(seed);
+  const partes = [];
+  const H = 3.2;
+
+  const tronco = new THREE.CylinderGeometry(0.07, 0.13, H, 8, 1);
+  poner(tronco, [0, H / 2, 0]);
+  partes.push(pintar(tronco, PAL.alisoTronco));
+
+  // Copa cónica: blobs que se estrechan hacia arriba.
+  const nBlobs = Math.max(5, Math.round(10 * q));
+  for (let i = 0; i < nBlobs; i++) {
+    const f = i / nBlobs; // 0 abajo → 1 arriba
+    const ang = r() * Math.PI * 2;
+    const rad = (0.65 - f * 0.5) * (0.4 + r() * 0.8);
+    const y = H - 1.1 + f * 2.0 + r() * 0.2;
+    const s = 0.4 - f * 0.18 + r() * 0.18;
+    const blob = new THREE.IcosahedronGeometry(Math.max(0.16, s), 0);
+    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 1, 1]);
+    partes.push(pintar(blob, variar(r() > 0.5 ? PAL.alisoHoja : PAL.alisoHoja2, r, 0.08)));
+  }
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  GAQUE (Clusia) — copa redonda de hoja gruesa lustrosa                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Copa REDONDA densa y baja de hoja gruesa verde muy oscuro (casi lustrosa),
+ * sobre tronco corto y firme. Compacto y sólido.
+ */
+export function geomGaque({ q = 1 } = {}, seed = 6) {
+  const r = rng(seed);
+  const partes = [];
+  const H = 1.9;
+
+  const tronco = new THREE.CylinderGeometry(0.13, 0.19, H, 8, 1);
+  poner(tronco, [0, H / 2, 0]);
+  partes.push(pintar(tronco, PAL.gaqueTronco));
+
+  const nBlobs = Math.max(5, Math.round(9 * q));
+  for (let i = 0; i < nBlobs; i++) {
+    const ang = r() * Math.PI * 2;
+    const rad = 0.15 + r() * 0.75;
+    const y = H + 0.15 + r() * 0.7; // domo bajo y ancho
+    const s = 0.4 + r() * 0.38;
+    const blob = new THREE.IcosahedronGeometry(s, 0);
+    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 0.8, 1]);
+    partes.push(pintar(blob, variar(r() > 0.5 ? PAL.gaqueHoja : PAL.gaqueHoja2, r, 0.06)));
+  }
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  MORTIÑO (Vaccinium meridionale) — arbusto de agraz con bayas azules         */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Mata baja de hojitas verdes con brotes rojizos y —la firma— BAYAS azul-moradas
+ * (el agraz andino) salpicadas entre el follaje.
+ */
+export function geomMortino({ q = 1 } = {}, seed = 7) {
+  const r = rng(seed);
+  const partes = [];
+
+  const nBlobs = Math.max(4, Math.round(7 * q));
+  for (let i = 0; i < nBlobs; i++) {
+    const ang = r() * Math.PI * 2;
+    const rad = r() * 0.32;
+    const y = 0.18 + r() * 0.5;
+    const s = 0.16 + r() * 0.16;
+    const blob = new THREE.IcosahedronGeometry(s, 0);
+    poner(blob, [Math.cos(ang) * rad, y, Math.sin(ang) * rad], [r(), r(), r()], [1, 1, 1]);
+    const brote = r() > 0.72;
+    partes.push(pintar(blob, variar(brote ? PAL.mortinoBrote : PAL.mortinoHoja, r, 0.08)));
+  }
+  // Bayas azul-moradas.
+  const nBayas = Math.max(3, Math.round(10 * q));
+  for (let i = 0; i < nBayas; i++) {
+    const ang = r() * Math.PI * 2;
+    const rad = r() * 0.34;
+    const y = 0.15 + r() * 0.5;
+    const baya = new THREE.IcosahedronGeometry(0.04 + r() * 0.015, 0);
+    poner(baya, [Math.cos(ang) * rad, y, Math.sin(ang) * rad]);
+    partes.push(pintar(baya, variar(r() > 0.5 ? PAL.mortinoBaya : PAL.mortinoBaya2, r, 0.1)));
+  }
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  ROMERILLO — mata baja de follaje fino                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Cojín bajo de follaje FINO amarillo-verde (hojita de escama tipo romero de
+ * páramo), a veces con puntos de flor amarilla. Relleno del sotobosque.
+ */
+export function geomRomerillo({ q = 1 } = {}, seed = 8) {
+  const r = rng(seed);
+  const partes = [];
+
+  const nRamitas = Math.max(6, Math.round(14 * q));
   for (let i = 0; i < nRamitas; i++) {
-    const ang = i * AUREO;
-    const rad = r() * 0.26;
-    const largo = 0.26 + r() * 0.3;
-    const ramita = new THREE.ConeGeometry(0.045, largo, 4, 1);
+    const ang = r() * Math.PI * 2;
+    const rad = r() * 0.28;
+    const largo = 0.28 + r() * 0.32;
+    const ramita = new THREE.ConeGeometry(0.05, largo, 4, 1);
     apuntar(
       ramita,
-      [Math.cos(ang) * rad, largo * 0.42, Math.sin(ang) * rad],
-      [Math.cos(ang) * 0.32 + (r() - 0.5) * 0.28, 1, Math.sin(ang) * 0.32 + (r() - 0.5) * 0.28],
+      [Math.cos(ang) * rad, largo * 0.4, Math.sin(ang) * rad],
+      [Math.cos(ang) * 0.35 + (r() - 0.5) * 0.3, 1, Math.sin(ang) * 0.35 + (r() - 0.5) * 0.3],
     );
-    hornearFollaje(ramita, {
-      base: '#3f4a20', sol: PAL.romerilloHojaSol, luz: '#d8e08e',
-      centro: [0, 0.3, 0], radio: 0.45, yMin: 0, yMax: 0.62, ao: 0.5, manchas: 0.16,
-    });
-    partes.push(ramita);
+    partes.push(pintar(ramita, variar(r() > 0.5 ? PAL.romerilloHoja : PAL.romerilloHoja2, r, 0.1)));
   }
   if (q > 0.5) {
     const nFlor = Math.max(2, Math.round(5 * q));
     for (let i = 0; i < nFlor; i++) {
       const ang = r() * Math.PI * 2;
-      const rad = r() * 0.24;
-      const flor = new THREE.IcosahedronGeometry(0.032, 0);
-      poner(flor, [Math.cos(ang) * rad, 0.34 + r() * 0.28, Math.sin(ang) * rad]);
-      partes.push(pintarPlano(flor, PAL.romerilloFlor));
+      const rad = r() * 0.26;
+      const flor = new THREE.IcosahedronGeometry(0.035, 0);
+      poner(flor, [Math.cos(ang) * rad, 0.35 + r() * 0.3, Math.sin(ang) * rad]);
+      partes.push(pintar(flor, PAL.romerilloFlor));
     }
   }
-  return fusionarSeguro(partes, 'romerillo');
+
+  return fusionar(partes);
 }
 
 /* -------------------------------------------------------------------------- */
 /*  SUELO — rocas con líquen + montículos de musgo                              */
 /* -------------------------------------------------------------------------- */
 
-/** Roca del páramo: pedrusco irregular con parches de líquen. */
-export function geomRoca(seed = 8) {
+/** Roca baja gris con parches de líquen pálido (piedra del páramo). */
+export function geomRoca(seed = 9) {
   const r = rng(seed);
   const partes = [];
-  const piedra = matojoHoja(0.3, seed, 0.34);
-  poner(piedra, [0, 0.1, 0], [r(), r(), r()], [1 + r() * 0.4, 0.5 + r() * 0.2, 1 + r() * 0.4]);
-  hornearFollaje(piedra, {
-    base: '#4a4a42', sol: PAL.rocaSol, luz: '#c4c4b4',
-    centro: [0, 0.05, 0], radio: 0.4, yMin: 0, yMax: 0.32, ao: 0.5, manchas: 0.14,
-  });
-  partes.push(piedra);
+  const piedra = new THREE.IcosahedronGeometry(0.3, 0);
+  poner(piedra, [0, 0.12, 0], [r(), r(), r()], [1 + r() * 0.4, 0.55 + r() * 0.2, 1 + r() * 0.4]);
+  partes.push(pintar(piedra, variar(PAL.roca, r, 0.08)));
+  // Líquen encima.
   const nLiquen = 2 + Math.round(r() * 2);
   for (let i = 0; i < nLiquen; i++) {
     const ang = r() * Math.PI * 2;
-    const rad = r() * 0.2;
-    const parche = matojoHoja(0.07 + r() * 0.05, seed + i * 7, 0.5);
-    poner(parche, [Math.cos(ang) * rad, 0.17 + r() * 0.05, Math.sin(ang) * rad], [0, 0, 0], [1.4, 0.35, 1.4]);
-    hornearFollaje(parche, {
-      base: '#6a7844', sol: r() > 0.5 ? PAL.liquen : PAL.liquen2, luz: '#dfe6b4',
-      centro: [0, 0.2, 0], radio: 0.3, ao: 0.3, manchas: 0.2,
-    });
-    partes.push(parche);
+    const rad = r() * 0.22;
+    const parche = new THREE.IcosahedronGeometry(0.07 + r() * 0.05, 0);
+    poner(parche, [Math.cos(ang) * rad, 0.2 + r() * 0.06, Math.sin(ang) * rad], [0, 0, 0], [1.3, 0.4, 1.3]);
+    partes.push(pintar(parche, variar(r() > 0.5 ? PAL.liquen : PAL.liquen2, r, 0.1)));
   }
-  return fusionarSeguro(partes, 'roca');
+  return fusionar(partes);
 }
 
-/** Montículo de musgo húmedo (domo bajo e irregular). */
-export function geomMusgo(seed = 9) {
+/** Montículo de musgo húmedo (domo bajo). */
+export function geomMusgo(seed = 10) {
   const r = rng(seed);
-  const domo = matojoHoja(0.28, seed, 0.3);
-  poner(domo, [0, 0.02, 0], [0, 0, 0], [1 + r() * 0.5, 0.4 + r() * 0.18, 1 + r() * 0.5]);
-  hornearFollaje(domo, {
-    base: '#2b3a1c', sol: PAL.musgoSol, luz: '#b6c886',
-    centro: [0, 0, 0], radio: 0.32, yMin: 0, yMax: 0.22, ao: 0.45, manchas: 0.22,
-  });
-  return fusionarSeguro([domo], 'musgo');
+  const domo = new THREE.SphereGeometry(0.28, 8, 5, 0, Math.PI * 2, 0, Math.PI * 0.5);
+  poner(domo, [0, 0, 0], [0, 0, 0], [1 + r() * 0.5, 0.45 + r() * 0.2, 1 + r() * 0.5]);
+  return pintar(domo, variar(r() > 0.5 ? PAL.musgo : PAL.musgo2, r, 0.1));
 }
 
 /* -------------------------------------------------------------------------- */
-/*  DISTRIBUCIÓN — bosquetes, claros, sotobosque y borde (NO una grilla)       */
+/*  DISTRIBUCIÓN biogeográfica alrededor del Ent                               */
 /* -------------------------------------------------------------------------- */
 
 /*
- * El DR §"La disposición" es tajante: los árboles no crecen en cuadrícula NI en
- * anillos regulares. La versión anterior sembraba cada especie en un ANILLO
- * concéntrico con reparto angular parejo (`uniforme: true`) → se leía como un
- * decorado de teatro alrededor del Ent.
- *
- * Ahora: BOSQUETES. Cada especie elige unos pocos núcleos alrededor del claro y
- * sus matas caen cerca de ellos (dispersión gaussiana). Un campo de ruido decide
- * la densidad → aparecen claros de verdad. El sotobosque se agolpa en el BORDE
- * de los bosquetes, que es donde crece en el bosque real.
+ * Estratos concéntricos (el Ent en el centro, 0,0,0). La cámara ORBITA, así que
+ * la composición es un anillo por estrato (no un frente fijo):
+ *   · frailejonar + sotobosque + suelo → anillo interior-medio (al frente visual).
+ *   · árboles (roble, encenillo, aliso, yarumo, gaque) → anillo exterior, velados
+ *     por la niebla → dan fondo y hacen que el Ent RESALTE como el mayor.
+ * Devuelve, por especie, instancias {pos, rotY, escala, tint}.
  */
-
 function tinteInstancia(r, amt) {
   const f = 1 + (r() - 0.5) * amt;
   const h = (r() - 0.5) * amt * 0.4;
-  const cl = (v) => Math.max(0.72, Math.min(1.16, v));
+  const cl = (v) => Math.max(0.7, Math.min(1.16, v));
   return [cl(f + h), cl(f), cl(f - h * 0.6)];
 }
 
-/** Gaussiana estándar por Box-Muller (para dispersar alrededor de un núcleo). */
-function gauss(r) {
-  const u = Math.max(1e-6, r());
-  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * r());
-}
-
-/**
- * Siembra `n` matas en BOSQUETES dentro del anillo [rMin, rMax] alrededor del
- * Ent, respetando los claros del campo de ruido y una distancia mínima entre
- * matas (nada de matas encajadas unas en otras).
- */
-function sembrarBosquete(n, rMin, rMax, r, opts = {}) {
-  if (n <= 0) return [];
-  const nucleos = Math.max(1, opts.nucleos ?? Math.ceil(n / 5));
-  const disper = opts.disper ?? 1.5;
-  const distMin = opts.distMin ?? 0.7;
-  const eMin = opts.eMin ?? 0.85;
-  const eMax = opts.eMax ?? 1.2;
-  const claros = opts.claros ?? 0.35;
-
-  // Núcleos de bosquete: repartidos con jitter fuerte (no equiespaciados).
-  const centros = [];
-  for (let i = 0; i < nucleos; i++) {
-    const ang = (i / nucleos) * Math.PI * 2 + (r() - 0.5) * 1.9;
-    const rad = rMin + (rMax - rMin) * (0.25 + r() * 0.6);
-    centros.push([Math.cos(ang) * rad, Math.sin(ang) * rad]);
-  }
-
+function sembrar(n, rMin, rMax, r, opts = {}) {
   const arr = [];
-  const intentos = n * 26;
-  for (let i = 0; i < intentos && arr.length < n; i++) {
-    const c = centros[Math.floor(r() * centros.length) % centros.length];
-    const x = c[0] + gauss(r) * disper;
-    const z = c[1] + gauss(r) * disper;
-    const rad = Math.hypot(x, z);
-    if (rad < rMin || rad > rMax) continue;
-    // Claros: el campo de ruido apaga zonas → el bosque respira.
-    if (ruidoFbm(x * 0.16 + 40, 0, z * 0.16 + 40) < claros * 0.55) continue;
-    // Distancia mínima: nada de matas incrustadas.
-    let choca = false;
-    for (let k = 0; k < arr.length; k++) {
-      const q = arr[k].pos;
-      if ((q[0] - x) ** 2 + (q[2] - z) ** 2 < distMin * distMin) { choca = true; break; }
-    }
-    if (choca) continue;
+  const eMin = opts.eMin ?? 0.9;
+  const eMax = opts.eMax ?? 1.15;
+  for (let i = 0; i < n; i++) {
+    // Árboles (uniforme): reparto angular parejo + leve jitter → no se solapan.
+    // Sotobosque/frailejonar (agrupado): ángulo aleatorio → matorral natural.
+    const ang = opts.uniforme
+      ? (i / Math.max(1, n)) * Math.PI * 2 + (r() - 0.5) * 0.7
+      : r() * Math.PI * 2;
+    const rad = rMin + (rMax - rMin) * (opts.haciaAfuera ? Math.sqrt(r()) : r());
     arr.push({
-      pos: [x, 0, z],
+      pos: [Math.cos(ang) * rad, 0, Math.sin(ang) * rad],
       rotY: r() * Math.PI * 2,
-      // Inclinación sutil por instancia: ningún árbol real está a plomo.
-      inclina: [(r() - 0.5) * (opts.inclina ?? 0.1), (r() - 0.5) * (opts.inclina ?? 0.1)],
       escala: eMin + r() * (eMax - eMin),
       tint: tinteInstancia(r, opts.varia ?? 0.12),
     });
@@ -990,48 +688,24 @@ function sembrarBosquete(n, rMin, rMax, r, opts = {}) {
   return arr;
 }
 
-/**
- * Todas las instancias de flora. El Ent manda en el centro: nada se le encima
- * y los árboles del cortejo quedan más lejos y más bajos que él.
- */
+/** Todas las instancias de flora para unos conteos dados. */
 export function distribucionFlora(conteos, seed = 707) {
   const c = conteos;
   return {
-    // Frailejonar: bosquetes densos en el anillo interior-medio. Es lo primero
-    // que se ve y lo que dice "esto es páramo".
-    frailejon: sembrarBosquete(c.frailejon, 3.4, 11, rng(seed + 1), {
-      nucleos: 5, disper: 1.7, distMin: 0.78, eMin: 0.78, eMax: 1.34, varia: 0.15, claros: 0.3, inclina: 0.14,
-    }),
-    frailejonFlor: sembrarBosquete(c.frailejonFlor, 4, 10, rng(seed + 2), {
-      nucleos: 3, disper: 1.9, distMin: 0.9, eMin: 0.9, eMax: 1.22, varia: 0.1, claros: 0.3, inclina: 0.12,
-    }),
-    // Sotobosque: se agolpa en el borde de los bosquetes.
-    mortino: sembrarBosquete(c.mortino, 3, 12.5, rng(seed + 3), {
-      nucleos: 4, disper: 1.8, distMin: 0.7, eMin: 0.78, eMax: 1.25, varia: 0.14, claros: 0.4,
-    }),
-    romerillo: sembrarBosquete(c.romerillo, 2.6, 12.5, rng(seed + 4), {
-      nucleos: 5, disper: 1.9, distMin: 0.62, eMin: 0.75, eMax: 1.3, varia: 0.16, claros: 0.42,
-    }),
+    // Frailejonar: anillo interior-medio, agrupado, mucha variación de tamaño.
+    frailejon: sembrar(c.frailejon, 3.8, 10.5, rng(seed + 1), { eMin: 0.82, eMax: 1.28, varia: 0.14 }),
+    frailejonFlor: sembrar(c.frailejonFlor, 4.5, 9.5, rng(seed + 2), { eMin: 0.9, eMax: 1.2, varia: 0.1 }),
+    // Sotobosque.
+    mortino: sembrar(c.mortino, 4, 12, rng(seed + 3), { eMin: 0.8, eMax: 1.2, varia: 0.12 }),
+    romerillo: sembrar(c.romerillo, 3, 12, rng(seed + 4), { eMin: 0.8, eMax: 1.25, varia: 0.14 }),
     // Suelo.
-    roca: sembrarBosquete(c.roca, 1.8, 12, rng(seed + 5), {
-      nucleos: 4, disper: 2.4, distMin: 0.85, eMin: 0.65, eMax: 1.6, varia: 0.12, claros: 0.25,
-    }),
-    musgo: sembrarBosquete(c.musgo, 1.1, 10, rng(seed + 6), {
-      nucleos: 4, disper: 2.2, distMin: 0.6, eMin: 0.7, eMax: 1.7, varia: 0.14, claros: 0.2,
-    }),
-    // El cortejo leñoso: bosquetes en el anillo exterior, velados por la niebla.
-    // Cada especie tiene SU rincón (no se mezclan parejo) → se lee agrupamiento.
-    quenua: sembrarBosquete(c.quenua, 6.5, 13, rng(seed + 7), {
-      nucleos: 2, disper: 1.9, distMin: 2.0, eMin: 0.85, eMax: 1.2, varia: 0.1, claros: 0.2, inclina: 0.12,
-    }),
-    gaque: sembrarBosquete(c.gaque, 8, 14, rng(seed + 8), {
-      nucleos: 2, disper: 1.6, distMin: 2.2, eMin: 0.9, eMax: 1.12, varia: 0.08, claros: 0.2,
-    }),
-    encenillo: sembrarBosquete(c.encenillo, 9, 16, rng(seed + 9), {
-      nucleos: 2, disper: 2.1, distMin: 2.1, eMin: 0.85, eMax: 1.12, varia: 0.09, claros: 0.2, inclina: 0.1,
-    }),
-    aliso: sembrarBosquete(c.aliso, 10, 17.5, rng(seed + 10), {
-      nucleos: 2, disper: 2.2, distMin: 2.3, eMin: 0.9, eMax: 1.14, varia: 0.09, claros: 0.2,
-    }),
+    roca: sembrar(c.roca, 2, 11, rng(seed + 5), { eMin: 0.7, eMax: 1.5, varia: 0.1 }),
+    musgo: sembrar(c.musgo, 1.2, 9, rng(seed + 6), { eMin: 0.7, eMax: 1.6, varia: 0.12 }),
+    // Árboles de fondo (anillo exterior, reparto parejo, velados por niebla).
+    gaque: sembrar(c.gaque, 8.5, 14, rng(seed + 7), { eMin: 0.9, eMax: 1.1, uniforme: true, varia: 0.08 }),
+    roble: sembrar(c.roble, 9.5, 16, rng(seed + 8), { eMin: 0.92, eMax: 1.15, uniforme: true, varia: 0.08 }),
+    encenillo: sembrar(c.encenillo, 10, 17, rng(seed + 9), { eMin: 0.85, eMax: 1.1, uniforme: true, varia: 0.08 }),
+    yarumo: sembrar(c.yarumo, 10, 17, rng(seed + 10), { eMin: 0.9, eMax: 1.15, uniforme: true, varia: 0.06 }),
+    aliso: sembrar(c.aliso, 11, 19, rng(seed + 11), { eMin: 0.9, eMax: 1.12, uniforme: true, varia: 0.08 }),
   };
 }

--- a/src/visual/mundo3d/direccion/composicionValle.js
+++ b/src/visual/mundo3d/direccion/composicionValle.js
@@ -52,14 +52,18 @@ export const COMPOSICION_LUGARES = {
   // El semillero entre el corral y las eras, un paso adelante (se cría cerca).
   semillero: [-3.5, 6.5],
   // Las eras al frente-izquierda de la casa: donde el faro del día se lee solo.
-  suelo: [-1.6, 5.0],
+  // (Un paso más allá de la casa: la píldora de la alerta — anclada aquí —
+  //  pisaba el techo desde la cámara de reposo; ahora el faro respira solo.)
+  suelo: [-2.3, 5.5],
   // La huerta ES "la huerta de la casa" (su propia narración): pegada a ella.
   sanidad: [3.4, 4.4],
   // El mercado es LA SALIDA a la plaza: borde derecho-frontal, el camino que
   // se va del cuadro. Antes tapaba el centro-bajo del encuadre.
   mercado: [4.9, 6.3],
   // Los hongos en el corazón cultivado, con aire de la casa y de la milpa.
-  micorrizas: [-3.2, 3.7],
+  // (Corridos un paso al monte: desde la cámara de reposo quedaban justo
+  //  DETRÁS de la píldora de la alerta y su chip nunca se veía.)
+  micorrizas: [-3.8, 3.9],
   // La milpa cede un paso a la izquierda para darle aire a los hongos.
   cultivos: [-5.2, 2.2],
 };
@@ -88,7 +92,7 @@ export function componerMundos(mundos) {
 export const SENDEROS_VALLE = [
   {
     id: 'trajin', // casa → eras → semillero → corral: el circuito de la mañana
-    puntos: [[-0.9, 3.0], [-1.6, 4.6], [-3.3, 6.1], [-5.0, 5.9]],
+    puntos: [[-0.9, 3.0], [-2.0, 5.1], [-3.3, 6.1], [-5.0, 5.9]],
     frugal: true,
   },
   {
@@ -98,7 +102,7 @@ export const SENDEROS_VALLE = [
   },
   {
     id: 'milpa', // casa → los hongos → la milpa (la subida del lote)
-    puntos: [[-1.3, 2.5], [-3.0, 3.4], [-5.0, 2.4]],
+    puntos: [[-1.3, 2.5], [-3.6, 3.7], [-5.0, 2.4]],
     frugal: false,
   },
   {


### PR DESCRIPTION
## Mundo 3D de leguminosas y raíces andinas

Nuevo mundo vitrina público **`#/mockups/mundo-leguminosas-3d`** — escena react-three-fiber autocontenida en hora dorada, modelada sobre `MundoParamo3D` (device-tiering real, instancing, `meshLambertMaterial` compartido, `reduced-motion`, offline, cero CDN/imágenes externas).

### Las tres matas (distinta altura/edad, no en fila)
- 🫘 **Fríjol** — mata trepadora en su estaca (vid helicoidal `TubeGeometry` + hojas trifoliadas + vainas) y un **CORTE del subsuelo** con los **NÓDULOS ROSADOS de Rhizobium** en la raíz: la fijación de nitrógeno hecha visible. Botón «ver el saber bajo tierra» → enciende un halo rosado sobre los nódulos.
- 🌿 **Yuca** — arbusto de tallo leñoso nudoso, hojas palmadas de dedos y las **raíces tuberosas asomando** en la base.
- 🌾 **Quinua** — tres matas con **panojas densas instanciadas** rojas / doradas / moradas (el color es su firma).
- Fauna del kit (`FaunaEscena`/creatures) como billboards por rol ecológico (colibrí, mariposa, escarabajo) + polen (`ParticulasAmbientales`).

Copy didáctica (español Colombia, usted): el fríjol **fija nitrógeno gratis** (asociar con maíz), la yuca **aguanta el suelo pobre**, la quinua es **proteína de altura**.

### Cableado
`App.jsx`: lazy import + `MOCKUP_HASH_ROUTES` + `case 'mockup_mundo_leguminosas_3d'`.

### Fix incluido (necesario)
Los mockups públicos `#/mockups/*` quedan **exentos del rebote a login por `session-expired` fantasma**: sin sesión, una llamada de fondo a farmOS que 401ea disparaba `chagra:session-expired` y tumbaba *cualquier* vitrina 3D pública a login. Guard con `startsWith('mockup_')`, idéntico patrón al resto del archivo.

### Verificación
- `vite build --outDir dist-prod` **verde** (chunk `MundoLeguminosas3D` ~18.8 kB), con mi código compilando limpio sobre la base integra.
- Prueba visual fuerte con **chromium del sistema + swiftshader** (`--use-angle=swiftshader --enable-unsafe-swiftshader`), `waitUntil:'commit'`, `waitForTimeout(11000)`, 3 tomas: fríjol con nódulos (halo en modo saber), yuca (hojas palmadas + tubérculos), quinua con panojas rojas/doradas/moradas. Sin negro/crash.

### ⚠️ Blocker de la base (NO es de este PR)
La punta de `integra/todo-3d-a-prod` **no compila** por un bug pre-existente en el mundo del bosque: `src/visual/mundo3d/bosque/FloraParamo.jsx` importa y usa `geomQuenua` (líneas 32/203/264) pero `floraParamo.geom.js` ya no lo exporta (renombrado a `geomYarumo`). Mi build verde se obtuvo con un shim temporal NO commiteado; el fix real del bosque (quenua↔yarumo) es decisión del dueño de ese mundo. Draft hasta que se resuelva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)