### PR TITLE
art(3d): mundo leguminosas y raíces DENSO — frijolar, milpa, quinua, yuca

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -262,6 +262,11 @@ const MundoBoticaCana3DMockup = lazy(() => import('./mockups/MundoBoticaCana3D')
 // cítricos, guayabo, papayo, injerto con tutor, plateo y cosecha a mano).
 // Standalone tipo botica: no monta el sistema MUNDO ni toca EscenaBase3D.
 const MundoFrutales3DMockup = lazy(() => import('./mockups/MundoFrutales3D'));
+// 3D: el LOTE DE LEGUMINOSAS Y RAÍCES ANDINAS, denso (frijolar de vara con
+// nódulos de Rhizobium en el corte del subsuelo, milpa de las tres hermanas —
+// maíz + fríjol + calabaza —, quinua en grupo con panojas de color, yucas
+// frondosas). Standalone tipo botica: no monta el sistema MUNDO ni EscenaBase3D.
+const MundoLeguminosas3DMockup = lazy(() => import('./mockups/MundoLeguminosas3D'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
@@ -701,6 +706,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo-polinizadores-3d': 'mockup_mundo_polinizadores_3d',
   'mockups/mundo-botica-cana-3d': 'mockup_mundo_botica_cana_3d',
   'mockups/mundo-frutales-3d': 'mockup_mundo_frutales_3d',
+  'mockups/mundo-leguminosas-3d': 'mockup_mundo_leguminosas_3d',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -2399,6 +2405,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El huerto de frutales">
               <MundoFrutales3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_mundo_leguminosas_3d':
+        // El lote de leguminosas y raíces andinas, denso: el frijolar de vara
+        // en hileras (con la mata héroe que abre el corte del subsuelo y los
+        // nódulos rosados de Rhizobium — el nitrógeno que se ve), la milpa de
+        // las tres hermanas (maíz + fríjol + calabaza), la quinua en grupo con
+        // panojas rojas/doradas/moradas y las yucas frondosas de raíz tuberosa.
+        // Botón «ver el saber bajo tierra». Ruta #/mockups/mundo-leguminosas-3d.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El lote de leguminosas y raíces">
+              <MundoLeguminosas3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/MundoLeguminosas3D.jsx
+++ b/src/mockups/MundoLeguminosas3D.jsx
@@ -1,15 +1,23 @@
 /*
- * MundoLeguminosas3D — el MUNDO DE LEGUMINOSAS Y RAÍCES ANDINAS en 3D.
+ * MundoLeguminosas3D — el MUNDO DE LEGUMINOSAS Y RAÍCES ANDINAS en 3D, DENSO.
  *
- * Tres matas que le dan de comer a la familia Y a la tierra, en hora dorada:
- *   - FRÍJOL (leguminosa trepadora): sube por su estaca con hojas y VAINAS, y a
- *     un lado, en un CORTE del subsuelo, se ven los NÓDULOS ROSADOS de Rhizobium
- *     en la raíz — las fábricas de nitrógeno, el abono gratis del aire. Es el
- *     saber agroecológico clave: por eso el fríjol se asocia con el maíz.
- *   - YUCA (arbusto de raíz tuberosa): tallo leñoso nudoso, hoja palmada de
- *     dedos y las raíces tuberosas asomando en la base. Aguanta el suelo pobre.
- *   - QUINUA (pseudocereal andino): tallos altos rematados en PANOJAS densas —
- *     rojas, doradas y moradas. El color es su firma. Proteína de la altura.
+ * No una muestra suelta de cuatro matas en tierra pelada, sino un LOTE VIVO —
+ * "el campo hasta donde alcanza la vista": hileras y parcelas sembradas de un
+ * lado a otro, en hora dorada, con la milpa de las tres hermanas al fondo.
+ *
+ *   - FRÍJOL DE VARA (leguminosa trepadora): HILERAS de estacas con la vid
+ *     helicoidal subiendo, hojas trifoliadas y vainas. Al frente, una mata
+ *     HÉROE abre un CORTE del subsuelo: los NÓDULOS ROSADOS de Rhizobium en la
+ *     raíz — las fábricas de nitrógeno, el abono gratis del aire. Es el saber
+ *     agroecológico clave, por eso el fríjol se asocia con el maíz.
+ *   - MILPA / TRES HERMANAS: el maíz da la vara, el fríjol trepa por él y le
+ *     abona la tierra, y la calabaza rastrera tapa el suelo y guarda la humedad.
+ *   - QUINUA (pseudocereal andino) en GRUPO: una parcela de tallos rematados en
+ *     PANOJAS densas — rojas, doradas y moradas. El color es su firma.
+ *   - YUCA (arbusto de raíz tuberosa): tallo leñoso nudoso, hoja palmada y las
+ *     raíces tuberosas asomando en la base. Frondosa, aguanta el suelo pobre.
+ *   - COBERTURA del suelo: pasto y piedritas instanciadas — la chagra no es
+ *     tierra pelada.
  *
  * DIRECCIÓN DE ARTE (todo dentro del framework, nada inventado por fuera):
  *   - La atmósfera es la MISMA hora dorada del valle: preset `CIELOS_HORA.dorada`
@@ -18,15 +26,17 @@
  *   - Los materiales salen tinteados hacia la niebla dorada con `mezclar` (la ley
  *     de coherencia), conservando la identidad de cada mata (el rosado del nódulo,
  *     el rojo/dorado/morado de la panoja).
- *   - La fauna es la del kit (`FaunaEscena`/creatures): pocos billboards SVG bien
- *     puestos por rol ecológico (colibrí y mariposa polinizando, escarabajo a
+ *   - La fauna es la del kit (`Bicho`/creatures): billboards SVG bien puestos por
+ *     rol ecológico (colibrí y mariposas polinizando, escarabajo y lombriz a
  *     ras). El polen en suspensión son las `ParticulasAmbientales` (tipo=polen).
  *
- * RENDIMIENTO: cobertura vegetal y granos de panoja instanciados (pocos draw
- * calls), materiales Lambert sin shadow-map, geometrías compartidas por mata.
- * Presupuestos por `perfilDeTier`; `reducedMotion` congela el vaivén, apaga la
- * fauna animada y pasa el frameloop a demanda. Gama baja cae al 2D digno antes de
- * montar esto. Autocontenida: cero CDN/imágenes externas.
+ * RENDIMIENTO: DENSO pero barato. Todo lo repetido va INSTANCIADO (pocos draw
+ * calls): las estacas, las vides helicoidales (una geometría compartida), las
+ * hojas, las vainas, los tallos y hojas de maíz y quinua, los granos de panoja,
+ * la cobertura y las piedritas. Materiales Lambert sin shadow-map, geometrías
+ * compartidas. Presupuestos por `perfilDeTier`; `reducedMotion` congela el
+ * vaivén, apaga la fauna animada y pasa el frameloop a demanda. Autocontenida:
+ * cero CDN/imágenes externas.
  *
  * Ruta mockup: #/mockups/mundo-leguminosas-3d (cableada en App.jsx, sin auth).
  * Copy en español de Colombia, en "usted".
@@ -40,7 +50,7 @@ import { mezclar } from '../visual/mundo3d/atmosferaMadre.js';
 import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
 import { ParticulasAmbientales } from '../visual/mundo3d/ParticulasAmbientales.jsx';
 import { crearRng } from '../visual/mundo3d/particulasData.js';
-import { Fauna } from '../visual/mundo3d/escenas/FaunaEscena.jsx';
+import { Bicho } from '../visual/mundo3d/escenas/FaunaEscena.jsx';
 
 /* La hora dorada canónica (espejo de ATMOSFERA): única fuente de la atmósfera. */
 const DORADA = CIELOS_HORA.dorada;
@@ -54,8 +64,12 @@ const P = {
   sueloSeco: mezclar('#8f7248', TINTE, 0.3),
   sueloCorte: mezclar('#402d1b', TINTE, 0.12), // el perfil oscuro del corte
   topsoil: mezclar('#5e4530', TINTE, 0.2), // la capa fértil arriba del corte
+  surco: mezclar('#6e4f31', TINTE, 0.22), // la tierra labrada de las hileras
   pasto: mezclar('#6f9448', TINTE, 0.3), // cobertura verde
+  pastoClaro: mezclar('#86a94f', TINTE, 0.28),
   pastoSeco: mezclar('#a7a862', TINTE, 0.3),
+  piedra: mezclar('#9a9285', TINTE, 0.34),
+  piedraClara: mezclar('#b6ad9c', TINTE, 0.34),
 
   // fríjol
   estaca: mezclar('#8a6a44', TINTE, 0.3), // la vara/tutor
@@ -63,10 +77,25 @@ const P = {
   frijolHoja: mezclar('#4e8b3c', TINTE, 0.3), // hoja trifoliada
   frijolHojaClara: mezclar('#71a851', TINTE, 0.28),
   frijolVaina: mezclar('#7cae54', TINTE, 0.26), // la vaina verde
+  frijolVainaSeca: mezclar('#c9b25e', TINTE, 0.2), // vaina que va secando
   frijolFlor: mezclar('#ece4f0', TINTE, 0.12), // florecita lila pálida
   raiz: mezclar('#e7dab9', TINTE, 0.18), // la raíz clara
   nodulo: mezclar('#e386a6', TINTE, 0.06), // NÓDULO de Rhizobium (rosado)
   noduloClaro: mezclar('#f4abc6', TINTE, 0.06),
+
+  // maíz (la vara de la milpa)
+  maizTallo: mezclar('#9fae4f', TINTE, 0.22),
+  maizHoja: mezclar('#7fa53e', TINTE, 0.26),
+  maizHojaClara: mezclar('#a6c057', TINTE, 0.24),
+  maizPanocha: mezclar('#d9c24f', TINTE, 0.14), // la espiga (tassel)
+  maizMazorca: mezclar('#e7c65a', TINTE, 0.12), // el grano de la mazorca
+  maizCapacho: mezclar('#b9c069', TINTE, 0.2), // la hoja que envuelve
+
+  // calabaza rastrera (la tercera hermana)
+  calabazaHoja: mezclar('#4b7c3a', TINTE, 0.28),
+  calabazaHojaClara: mezclar('#6a9a48', TINTE, 0.26),
+  calabazaFruto: mezclar('#d98b2c', TINTE, 0.1), // el zapallo naranja
+  calabazaFrutoV: mezclar('#8ca444', TINTE, 0.18), // fruto todavía verde
 
   // yuca
   yucaTallo: mezclar('#7c5330', TINTE, 0.26), // tallo leñoso
@@ -79,9 +108,9 @@ const P = {
   // quinua
   quinuaTallo: mezclar('#7ea24a', TINTE, 0.28),
   quinuaHoja: mezclar('#5f9146', TINTE, 0.28),
-  quinuaRojo: mezclar('#c1343a', TINTE, 0.08), // panoja roja
-  quinuaDorado: mezclar('#e0a52a', TINTE, 0.1), // panoja dorada
-  quinuaMorado: mezclar('#933f8a', TINTE, 0.08), // panoja morada
+  quinuaRojo: '#c1343a', // panoja roja (sin tinte: su color ES el saber)
+  quinuaDorado: '#e0a52a', // panoja dorada
+  quinuaMorado: '#933f8a', // panoja morada
 };
 
 const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
@@ -102,26 +131,27 @@ function ruido(wx, wz) {
   );
 }
 
-/* La geografía: una parcela de finca (chagra) casi plana, con leves lomas de
-   siembra bajo cada mata y una suave ondulación general. */
-const ANCHO = 26;
-const FONDO = 26;
+/* La geografía: un LOTE de finca amplio, casi plano, con leves camas de siembra
+   y una suave ondulación general (la milpa siembra sobre una cama al fondo). */
+const ANCHO = 34;
+const FONDO = 32;
 function alturaCampo(wx, wz) {
-  let h = 0.05 + ruido(wx * 0.4, wz * 0.4) * 0.16; // ondulación suave del terreno
-  h += gauss(wx, wz, 3.6, -0.6, 1.8, 1.8) * 0.28; // loma de la yuca
-  h += gauss(wx, wz, 0.4, -2.8, 2.2, 1.8) * 0.22; // cama de la quinua
+  let h = 0.05 + ruido(wx * 0.36, wz * 0.36) * 0.14; // ondulación suave
+  h += gauss(wx, wz, 2.0, -6.5, 6.0, 2.2) * 0.32; // cama alta de la milpa (fondo)
+  h += gauss(wx, wz, 7.0, 1.2, 2.4, 2.2) * 0.24; // loma de la yuca
+  h += gauss(wx, wz, -1.5, -3.5, 3.2, 2.0) * 0.18; // cama de la quinua
   return Math.max(0, h);
 }
 
-/* Malla de la parcela con colores por vértice: pasto verde con motas secas y
-   surcos de tierra labrada (la chagra sembrada, no un potrero). */
+/* Malla del lote con colores por vértice: pasto verde con motas secas y surcos
+   de tierra labrada corriendo en hileras (la chagra sembrada, no un potrero). */
 function construirCampo(seg, plano) {
   const nx = seg + 1, nz = seg + 1;
   const pos = new Float32Array(nx * nz * 3);
   const col = new Float32Array(nx * nz * 3);
   const cPasto = new THREE.Color(P.pasto);
   const cPastoSeco = new THREE.Color(P.pastoSeco);
-  const cSuelo = new THREE.Color(P.suelo);
+  const cSurco = new THREE.Color(P.surco);
   const c = new THREE.Color();
   let p = 0;
   for (let iz = 0; iz < nz; iz++) {
@@ -131,9 +161,9 @@ function construirCampo(seg, plano) {
       const y = alturaCampo(wx, wz);
       pos[p] = wx; pos[p + 1] = y; pos[p + 2] = wz;
       c.lerpColors(cPasto, cPastoSeco, smoothstep(-0.5, 0.9, ruido(wx * 1.2, wz * 1.2)));
-      // surcos de tierra: bandas labradas donde se sembró
-      const surco = Math.abs(Math.sin(wx * 0.85 + wz * 0.12));
-      c.lerp(cSuelo, smoothstep(0.72, 0.98, surco) * 0.55);
+      // surcos de tierra: bandas labradas donde se sembró, corriendo N-S
+      const surco = Math.abs(Math.sin(wx * 0.9 + wz * 0.05));
+      c.lerp(cSurco, smoothstep(0.74, 0.99, surco) * 0.6);
       col[p] = c.r; col[p + 1] = c.g; col[p + 2] = c.b;
       p += 3;
     }
@@ -154,6 +184,20 @@ function construirCampo(seg, plano) {
   return geo;
 }
 
+/* La curva de una vid de fríjol: helicoidal, sube por su tutor. Compartida por
+   TODAS las estacas (una sola geometría, instanciada) → pocos draw calls. */
+function curvaVid(vueltas, alto, r0) {
+  const pts = [];
+  const N = 40;
+  for (let i = 0; i <= N; i++) {
+    const t = i / N;
+    const a = t * vueltas * Math.PI * 2;
+    const r = r0 * (1 - 0.18 * t);
+    pts.push(new THREE.Vector3(Math.cos(a) * r, t * alto, Math.sin(a) * r));
+  }
+  return new THREE.CatmullRomCurve3(pts);
+}
+
 /* Las luces de la hora dorada del kit: hemisferio cálido, ambiente suave, el sol
    bajo como direccional principal y un relleno frío opuesto (cielo abierto). */
 function LucesDoradas() {
@@ -171,24 +215,24 @@ function LucesDoradas() {
    encargan las luces); es el ancla visual de la hora. */
 function SolBajo() {
   return (
-    <group position={[9, 7, -14]}>
+    <group position={[11, 7, -15]}>
       <mesh>
-        <circleGeometry args={[1.5, 40]} />
+        <circleGeometry args={[1.6, 40]} />
         <meshBasicMaterial color="#fff0cf" transparent opacity={0.95} depthWrite={false} side={THREE.DoubleSide} />
       </mesh>
       <mesh position={[0, 0, -0.05]}>
-        <circleGeometry args={[2.9, 40]} />
+        <circleGeometry args={[3.1, 40]} />
         <meshBasicMaterial color={DORADA.luz} transparent opacity={0.22} depthWrite={false} side={THREE.DoubleSide} />
       </mesh>
       <mesh position={[0, 0, -0.1]}>
-        <circleGeometry args={[5.0, 40]} />
+        <circleGeometry args={[5.4, 40]} />
         <meshBasicMaterial color={DORADA.cielo} transparent opacity={0.13} depthWrite={false} side={THREE.DoubleSide} />
       </mesh>
     </group>
   );
 }
 
-/* ── Cobertura vegetal: matas bajas de pasto instanciadas (1 draw call), la
+/* ── COBERTURA del suelo: matas bajas de pasto instanciadas (1 draw call), la
       chagra no es tierra pelada. Poco dobladas, tinte verde variado. ── */
 function Cobertura({ n }) {
   const ref = useRef(null);
@@ -198,10 +242,10 @@ function Cobertura({ n }) {
     let intentos = 0;
     while (lista.length < n && intentos < n * 8) {
       intentos += 1;
-      const wx = (rng() - 0.5) * (ANCHO - 6);
-      const wz = (rng() - 0.5) * (FONDO - 6);
+      const wx = (rng() - 0.5) * (ANCHO - 4);
+      const wz = (rng() - 0.5) * (FONDO - 4);
       const y = alturaCampo(wx, wz);
-      lista.push({ wx, wz, y, esc: 0.4 + rng() * 0.6, giro: rng() * Math.PI, ladeo: (rng() - 0.5) * 0.35 });
+      lista.push({ wx, wz, y, esc: 0.4 + rng() * 0.7, giro: rng() * Math.PI, ladeo: (rng() - 0.5) * 0.4 });
     }
     return lista;
   }, [n]);
@@ -210,7 +254,7 @@ function Cobertura({ n }) {
     if (!m) return;
     const dummy = new THREE.Object3D();
     const tinte = new THREE.Color();
-    const base = new THREE.Color(P.pasto);
+    const base = new THREE.Color(P.pastoClaro);
     const seco = new THREE.Color(P.pastoSeco);
     sitios.forEach((s, i) => {
       dummy.position.set(s.wx, s.y + 0.11 * s.esc, s.wz);
@@ -226,95 +270,253 @@ function Cobertura({ n }) {
   }, [sitios]);
   return (
     <instancedMesh ref={ref} args={[undefined, undefined, sitios.length]} frustumCulled={false}>
-      <coneGeometry args={[0.13, 0.42, 4]} />
+      <coneGeometry args={[0.13, 0.44, 4]} />
       <meshLambertMaterial flatShading />
     </instancedMesh>
   );
 }
 
-/* Una hoja trifoliada de fríjol: tres foliolos (elipsoides aplanados) que radian
-   desde un peciolo corto. La firma de la leguminosa. */
-function HojaTrifoliada({ pos, giro = 0, esc = 1, claro = false }) {
-  const color = claro ? P.frijolHojaClara : P.frijolHoja;
+/* ── PIEDRITAS de cobertura instanciadas (1 draw call): el suelo con su textura,
+      cantos rodados grisáceos entre las matas. ── */
+function Piedritas({ n }) {
+  const ref = useRef(null);
+  const sitios = useMemo(() => {
+    const rng = crearRng(73);
+    return Array.from({ length: n }, () => {
+      const wx = (rng() - 0.5) * (ANCHO - 3);
+      const wz = (rng() - 0.5) * (FONDO - 3);
+      return {
+        wx, wz, y: alturaCampo(wx, wz),
+        esc: 0.05 + rng() * 0.11,
+        rx: rng() * Math.PI, ry: rng() * Math.PI, rz: rng() * Math.PI,
+        clara: rng() > 0.5,
+      };
+    });
+  }, [n]);
+  useEffect(() => {
+    const m = ref.current;
+    if (!m) return;
+    const dummy = new THREE.Object3D();
+    const tinte = new THREE.Color();
+    sitios.forEach((s, i) => {
+      dummy.position.set(s.wx, s.y + s.esc * 0.4, s.wz);
+      dummy.rotation.set(s.rx, s.ry, s.rz);
+      dummy.scale.set(s.esc, s.esc * 0.7, s.esc);
+      dummy.updateMatrix();
+      m.setMatrixAt(i, dummy.matrix);
+      tinte.set(s.clara ? P.piedraClara : P.piedra);
+      m.setColorAt(i, tinte);
+    });
+    m.instanceMatrix.needsUpdate = true;
+    if (m.instanceColor) m.instanceColor.needsUpdate = true;
+  }, [sitios]);
   return (
-    <group position={pos} rotation={[0, giro, 0]} scale={esc}>
-      {[0, 2.2, -2.2].map((a, i) => (
-        <mesh key={i} position={[Math.sin(a) * 0.12, 0.02 * i, Math.cos(a) * 0.12 + 0.05]} rotation={[-0.5, a, 0]} scale={[0.13, 0.02, 0.18]}>
-          <sphereGeometry args={[1, 7, 5]} />
-          <meshLambertMaterial color={color} flatShading />
-        </mesh>
-      ))}
+    <instancedMesh ref={ref} args={[undefined, undefined, sitios.length]} frustumCulled={false}>
+      <dodecahedronGeometry args={[1, 0]} />
+      <meshLambertMaterial flatShading />
+    </instancedMesh>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   EL FRIJOLAR: hileras de estacas con la vid trepando, y los ÓRGANOS de la mata
+   (hojas trifoliadas, vainas) instanciados a lo largo de todas las vides.
+   Todo dividido en pocos InstancedMesh para que el lote lea DENSO y sea barato.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Genera la disposición de un frijolar: estacas en hileras + los sitios de sus
+   hojas/vainas/flores repartidos alrededor de cada vid (determinista). */
+function sembrarFrijolar(seed, filas, porFila, cx, cz, paso, altoVar) {
+  const rng = crearRng(seed);
+  const estacas = [];
+  const hojas = [];
+  const vainas = [];
+  const flores = [];
+  for (let f = 0; f < filas; f++) {
+    for (let k = 0; k < porFila; k++) {
+      const jitterX = (rng() - 0.5) * 0.35;
+      const jitterZ = (rng() - 0.5) * 0.35;
+      const wx = cx + (k - (porFila - 1) / 2) * paso + jitterX;
+      const wz = cz + (f - (filas - 1) / 2) * paso * 1.15 + jitterZ;
+      const y = alturaCampo(wx, wz);
+      const alto = altoVar * (0.85 + rng() * 0.3);
+      const giro = rng() * Math.PI * 2;
+      estacas.push({ wx, wz, y, alto, giro, esc: 0.9 + rng() * 0.25 });
+      // hojas trifoliadas subiendo alrededor de la vid
+      const nH = 5 + Math.floor(rng() * 3);
+      for (let h = 0; h < nH; h++) {
+        const t = 0.12 + (h / nH) * 0.8;
+        const a = giro + t * 3.2 * Math.PI * 2 + rng() * 0.6;
+        const r = 0.26 * (1 - t * 0.15);
+        hojas.push({
+          x: wx + Math.cos(a) * r,
+          y: y + t * alto,
+          z: wz + Math.sin(a) * r,
+          giro: a,
+          esc: (0.85 - t * 0.2) * (0.9 + rng() * 0.3),
+          clara: h % 2 === 0,
+        });
+      }
+      // vainas colgando en la mitad alta
+      const nV = 3 + Math.floor(rng() * 3);
+      for (let v = 0; v < nV; v++) {
+        const t = 0.4 + rng() * 0.4;
+        const a = giro + t * 3.2 * Math.PI * 2 + rng() * 0.8;
+        const r = 0.28;
+        vainas.push({
+          x: wx + Math.cos(a) * r,
+          y: y + t * alto,
+          z: wz + Math.sin(a) * r,
+          giro: a,
+          esc: 0.85 + rng() * 0.4,
+          seca: rng() > 0.7,
+        });
+      }
+      // una florecita lila cerca de la copa
+      if (rng() > 0.35) {
+        flores.push({ x: wx + (rng() - 0.5) * 0.2, y: y + alto * (0.85 + rng() * 0.12), z: wz + (rng() - 0.5) * 0.2 });
+      }
+    }
+  }
+  return { estacas, hojas, vainas, flores };
+}
+
+function Frijolar({ plan, vineGeo }) {
+  const estacasRef = useRef(null);
+  const vidRef = useRef(null);
+  const hojasRef = useRef(null);
+  const vainasRef = useRef(null);
+  const floresRef = useRef(null);
+  const { estacas, hojas, vainas, flores } = plan;
+
+  useEffect(() => {
+    const d = new THREE.Object3D();
+    // estacas (tutores)
+    if (estacasRef.current) {
+      estacas.forEach((s, i) => {
+        d.position.set(s.wx, s.y + s.alto * 0.5, s.wz);
+        d.rotation.set(0, s.giro, (i % 2 ? 0.03 : -0.03));
+        d.scale.set(1, s.alto / 2.2, 1);
+        d.updateMatrix();
+        estacasRef.current.setMatrixAt(i, d.matrix);
+      });
+      estacasRef.current.instanceMatrix.needsUpdate = true;
+    }
+    // vides helicoidales (misma geometría, escalada por altura)
+    if (vidRef.current) {
+      estacas.forEach((s, i) => {
+        d.position.set(s.wx, s.y, s.wz);
+        d.rotation.set(0, s.giro, 0);
+        d.scale.set(1.5 * s.esc, s.alto / 2.0, 1.5 * s.esc);
+        d.updateMatrix();
+        vidRef.current.setMatrixAt(i, d.matrix);
+      });
+      vidRef.current.instanceMatrix.needsUpdate = true;
+    }
+    // hojas
+    if (hojasRef.current) {
+      const col = new THREE.Color();
+      hojas.forEach((h, i) => {
+        d.position.set(h.x, h.y, h.z);
+        d.rotation.set(-0.5, h.giro, 0.2);
+        d.scale.set(0.19 * h.esc, 0.04 * h.esc, 0.24 * h.esc);
+        d.updateMatrix();
+        hojasRef.current.setMatrixAt(i, d.matrix);
+        col.set(h.clara ? P.frijolHojaClara : P.frijolHoja);
+        hojasRef.current.setColorAt(i, col);
+      });
+      hojasRef.current.instanceMatrix.needsUpdate = true;
+      if (hojasRef.current.instanceColor) hojasRef.current.instanceColor.needsUpdate = true;
+    }
+    // vainas
+    if (vainasRef.current) {
+      const col = new THREE.Color();
+      vainas.forEach((v, i) => {
+        d.position.set(v.x, v.y, v.z);
+        d.rotation.set(0.3, v.giro, 0.35);
+        d.scale.set(0.05 * v.esc, 0.19 * v.esc, 0.05 * v.esc);
+        d.updateMatrix();
+        vainasRef.current.setMatrixAt(i, d.matrix);
+        col.set(v.seca ? P.frijolVainaSeca : P.frijolVaina);
+        vainasRef.current.setColorAt(i, col);
+      });
+      vainasRef.current.instanceMatrix.needsUpdate = true;
+      if (vainasRef.current.instanceColor) vainasRef.current.instanceColor.needsUpdate = true;
+    }
+    // flores
+    if (floresRef.current) {
+      flores.forEach((fl, i) => {
+        d.position.set(fl.x, fl.y, fl.z);
+        d.rotation.set(0, 0, 0);
+        d.scale.setScalar(1);
+        d.updateMatrix();
+        floresRef.current.setMatrixAt(i, d.matrix);
+      });
+      floresRef.current.instanceMatrix.needsUpdate = true;
+    }
+  }, [estacas, hojas, vainas, flores]);
+
+  return (
+    <group>
+      <instancedMesh ref={estacasRef} args={[undefined, undefined, estacas.length]} frustumCulled={false}>
+        <cylinderGeometry args={[0.03, 0.045, 2.2, 6]} />
+        <meshLambertMaterial color={P.estaca} flatShading />
+      </instancedMesh>
+      <instancedMesh ref={vidRef} args={[vineGeo, undefined, estacas.length]} frustumCulled={false}>
+        <meshLambertMaterial color={P.frijolTallo} flatShading />
+      </instancedMesh>
+      <instancedMesh ref={hojasRef} args={[undefined, undefined, hojas.length]} frustumCulled={false}>
+        <sphereGeometry args={[1, 6, 5]} />
+        <meshLambertMaterial flatShading />
+      </instancedMesh>
+      <instancedMesh ref={vainasRef} args={[undefined, undefined, vainas.length]} frustumCulled={false}>
+        <sphereGeometry args={[1, 6, 6]} />
+        <meshLambertMaterial flatShading />
+      </instancedMesh>
+      <instancedMesh ref={floresRef} args={[undefined, undefined, Math.max(1, flores.length)]} frustumCulled={false}>
+        <sphereGeometry args={[0.05, 6, 5]} />
+        <meshLambertMaterial color={P.frijolFlor} flatShading />
+      </instancedMesh>
     </group>
   );
 }
 
-/* Una vaina de fríjol: dos segmentos aplanados que le dan una curva de banana. */
-function Vaina({ pos, giro = 0, incl = 0 }) {
-  return (
-    <group position={pos} rotation={[incl, giro, 0.2]}>
-      <mesh position={[0, -0.11, 0]} scale={[0.045, 0.16, 0.045]}>
-        <sphereGeometry args={[1, 7, 6]} />
-        <meshLambertMaterial color={P.frijolVaina} flatShading />
-      </mesh>
-      <mesh position={[0.03, -0.28, 0]} rotation={[0, 0, 0.35]} scale={[0.04, 0.12, 0.04]}>
-        <sphereGeometry args={[1, 7, 6]} />
-        <meshLambertMaterial color={P.frijolVaina} flatShading />
-      </mesh>
-    </group>
-  );
-}
-
-/* ── EL FRÍJOL: la mata trepadora + el CORTE del subsuelo con los nódulos.
+/* ── LA MATA HÉROE: el fríjol con el CORTE del subsuelo y los NÓDULOS ROSADOS.
       Anclada en la CIMA de un monolito de suelo (y=0 = la superficie): arriba la
       enredadera con vainas; abajo, en la cara frontal del corte, la raíz con los
       nódulos rosados de Rhizobium — el nitrógeno que no se ve, hecho visible. ── */
-function MataFrijol({ pos, reducedMotion, saber }) {
+function MataFrijolHeroe({ pos, reducedMotion, saber, vineGeo }) {
   const flor = useRef(null);
   const halo = useRef(null);
   const nodulos = useRef(null);
+  const vid = useMemo(() => curvaVid(3.2, 2.0, 0.18), []);
 
-  // la enredadera como un tubo helicoidal que sube por la estaca (1 mesh).
-  const curvaVid = useMemo(() => {
-    const pts = [];
-    const vueltas = 3.2, alto = 2.0, r0 = 0.18;
-    const N = 44;
-    for (let i = 0; i <= N; i++) {
-      const t = i / N;
-      const a = t * vueltas * Math.PI * 2;
-      const r = r0 * (1 - 0.18 * t);
-      pts.push(new THREE.Vector3(Math.cos(a) * r, t * alto, Math.sin(a) * r));
-    }
-    return new THREE.CatmullRomCurve3(pts);
-  }, []);
-
-  // hojas y vainas repartidas a lo largo de la enredadera.
   const hojas = useMemo(
     () => [0.16, 0.34, 0.52, 0.68, 0.84].map((t, i) => {
-      const p = curvaVid.getPoint(t);
+      const p = vid.getPoint(t);
       return { pos: [p.x * 1.5, p.y, p.z * 1.5], giro: i * 1.7, esc: 1 - t * 0.25, claro: i % 2 === 0 };
     }),
-    [curvaVid],
+    [vid],
   );
   const vainas = useMemo(
     () => [0.44, 0.58, 0.66, 0.78].map((t, i) => {
-      const p = curvaVid.getPoint(t);
+      const p = vid.getPoint(t);
       return { pos: [p.x * 1.7, p.y + 0.02, p.z * 1.7 + 0.04], giro: i * 2.1, incl: 0.1 + i * 0.05 };
     }),
-    [curvaVid],
+    [vid],
   );
 
-  // los nódulos: puntos sobre la raíz principal y las laterales (cara frontal).
   const puntosNodulo = useMemo(() => {
     const rng = crearRng(19);
     const lista = [];
-    for (let i = 0; i < 11; i++) {
-      const t = 0.12 + rng() * 0.8; // profundidad
-      const lado = (rng() - 0.5); // izquierda/derecha
+    for (let i = 0; i < 15; i++) {
+      const t = 0.12 + rng() * 0.82;
+      const lado = (rng() - 0.5);
       lista.push({
-        x: lado * (0.1 + t * 0.5),
+        x: lado * (0.1 + t * 0.55),
         y: -0.12 - t * 1.05,
         z: 0.2 + rng() * 0.05,
-        r: 0.05 + rng() * 0.035,
+        r: 0.05 + rng() * 0.04,
         claro: i % 3 === 0,
       });
     }
@@ -331,13 +533,13 @@ function MataFrijol({ pos, reducedMotion, saber }) {
       halo.current.visible = saber;
     }
     if (nodulos.current) {
-      const s = saber ? 1.28 : 1;
+      const s = saber ? 1.3 : 1;
       nodulos.current.scale.setScalar(reducedMotion ? s : s * (0.98 + 0.02 * Math.sin(t * 1.6)));
     }
   });
 
   const groundY = alturaCampo(pos[0], pos[2]);
-  const ALTO_CORTE = 1.3; // el monolito sube esto sobre el terreno; y=0 = superficie
+  const ALTO_CORTE = 1.3;
 
   return (
     <group position={[pos[0], groundY + ALTO_CORTE, pos[2]]}>
@@ -350,7 +552,6 @@ function MataFrijol({ pos, reducedMotion, saber }) {
         <boxGeometry args={[1.52, 0.14, 0.44]} />
         <meshLambertMaterial color={P.topsoil} flatShading />
       </mesh>
-      {/* pastico en la cima del corte, para que lea "superficie" */}
       {[-0.5, -0.15, 0.2, 0.55].map((x, i) => (
         <mesh key={i} position={[x, 0.06, 0.12]} rotation={[0.1, i, 0.1]}>
           <coneGeometry args={[0.08, 0.22, 4]} />
@@ -388,23 +589,35 @@ function MataFrijol({ pos, reducedMotion, saber }) {
       </mesh>
 
       {/* ── LA MATA TREPADORA (sobre la superficie) ── */}
-      {/* la estaca / tutor */}
       <mesh position={[0, 1.1, 0]} rotation={[0, 0, 0.02]}>
         <cylinderGeometry args={[0.035, 0.05, 2.25, 6]} />
         <meshLambertMaterial color={P.estaca} flatShading />
       </mesh>
-      {/* la enredadera helicoidal */}
-      <mesh scale={[1.5, 1, 1.5]}>
-        <tubeGeometry args={[curvaVid, 46, 0.032, 6, false]} />
+      <mesh scale={[1.5, 1, 1.5]} geometry={vineGeo}>
         <meshLambertMaterial color={P.frijolTallo} flatShading />
       </mesh>
       {hojas.map((h, i) => (
-        <HojaTrifoliada key={i} pos={h.pos} giro={h.giro} esc={h.esc} claro={h.claro} />
+        <group key={i} position={h.pos} rotation={[0, h.giro, 0]} scale={h.esc}>
+          {[0, 2.2, -2.2].map((a, j) => (
+            <mesh key={j} position={[Math.sin(a) * 0.12, 0.02 * j, Math.cos(a) * 0.12 + 0.05]} rotation={[-0.5, a, 0]} scale={[0.13, 0.02, 0.18]}>
+              <sphereGeometry args={[1, 7, 5]} />
+              <meshLambertMaterial color={h.claro ? P.frijolHojaClara : P.frijolHoja} flatShading />
+            </mesh>
+          ))}
+        </group>
       ))}
       {vainas.map((v, i) => (
-        <Vaina key={i} pos={v.pos} giro={v.giro} incl={v.incl} />
+        <group key={i} position={v.pos} rotation={[v.incl, v.giro, 0.2]}>
+          <mesh position={[0, -0.11, 0]} scale={[0.045, 0.16, 0.045]}>
+            <sphereGeometry args={[1, 7, 6]} />
+            <meshLambertMaterial color={P.frijolVaina} flatShading />
+          </mesh>
+          <mesh position={[0.03, -0.28, 0]} rotation={[0, 0, 0.35]} scale={[0.04, 0.12, 0.04]}>
+            <sphereGeometry args={[1, 7, 6]} />
+            <meshLambertMaterial color={P.frijolVaina} flatShading />
+          </mesh>
+        </group>
       ))}
-      {/* unas florecitas lila cerca de la copa */}
       <group ref={flor} position={[0.16, 1.7, 0.1]}>
         {[[0, 0, 0], [0.12, 0.08, -0.05], [-0.08, 0.12, 0.06]].map((f, i) => (
           <mesh key={i} position={f}>
@@ -417,7 +630,200 @@ function MataFrijol({ pos, reducedMotion, saber }) {
   );
 }
 
-/* Una hoja palmada de yuca: peciolo + 5 foliolos (dedos) en abanico. */
+/* ═══════════════════════════════════════════════════════════════════════════
+   LA MILPA — LAS TRES HERMANAS: el maíz da la vara, el fríjol trepa por él, la
+   calabaza rastrera tapa el suelo. Maíz y sus hojas instanciados; el fríjol
+   reusa la vid helicoidal; la calabaza pone hojas grandes y frutos a ras.
+   ═══════════════════════════════════════════════════════════════════════════ */
+function sembrarMilpa(seed, filas, porFila, cx, cz, paso) {
+  const rng = crearRng(seed);
+  const golpes = []; // cada "golpe" de siembra: maíz + fríjol + calabaza
+  for (let f = 0; f < filas; f++) {
+    for (let k = 0; k < porFila; k++) {
+      const wx = cx + (k - (porFila - 1) / 2) * paso + (rng() - 0.5) * 0.3;
+      const wz = cz + (f - (filas - 1) / 2) * paso + (rng() - 0.5) * 0.3;
+      golpes.push({
+        wx, wz, y: alturaCampo(wx, wz),
+        alto: 2.5 + rng() * 0.6,
+        giro: rng() * Math.PI * 2,
+        conCalabaza: rng() > 0.4,
+      });
+    }
+  }
+  return golpes;
+}
+
+function Milpa({ golpes, vineGeo }) {
+  const tallosRef = useRef(null);
+  const hojasRef = useRef(null);
+  const espigasRef = useRef(null);
+  const vidRef = useRef(null);
+  const calRef = useRef(null);
+  const frutoRef = useRef(null);
+
+  // pre-cálculo de hojas de maíz (largas, drapeadas) por golpe
+  const hojasMaiz = useMemo(() => {
+    const rng = crearRng(555);
+    const lista = [];
+    golpes.forEach((g) => {
+      const n = 5;
+      for (let i = 0; i < n; i++) {
+        const t = 0.35 + (i / n) * 0.55;
+        const a = g.giro + i * 2.4 + rng() * 0.4;
+        lista.push({
+          x: g.wx, y: g.y + t * g.alto, z: g.wz,
+          giro: a, incl: 0.5 + rng() * 0.3, esc: (1 - t * 0.3),
+          clara: i % 2 === 0,
+        });
+      }
+    });
+    return lista;
+  }, [golpes]);
+
+  const frutos = useMemo(() => {
+    const rng = crearRng(777);
+    const lista = [];
+    golpes.forEach((g) => {
+      if (!g.conCalabaza) return;
+      const a = g.giro + 1.2;
+      const d = 0.9 + rng() * 0.5;
+      lista.push({
+        x: g.wx + Math.cos(a) * d, z: g.wz + Math.sin(a) * d, y: g.y,
+        esc: 0.28 + rng() * 0.16, verde: rng() > 0.6,
+      });
+    });
+    return lista;
+  }, [golpes]);
+
+  const hojasCal = useMemo(() => {
+    const rng = crearRng(888);
+    const lista = [];
+    golpes.forEach((g) => {
+      if (!g.conCalabaza) return;
+      const n = 4 + Math.floor(rng() * 3);
+      for (let i = 0; i < n; i++) {
+        const a = rng() * Math.PI * 2;
+        const d = 0.5 + rng() * 1.1;
+        lista.push({
+          x: g.wx + Math.cos(a) * d, z: g.wz + Math.sin(a) * d, y: g.y + 0.08,
+          giro: rng() * Math.PI, esc: 0.7 + rng() * 0.5, clara: i % 2 === 0,
+        });
+      }
+    });
+    return lista;
+  }, [golpes]);
+
+  useEffect(() => {
+    const d = new THREE.Object3D();
+    const col = new THREE.Color();
+    if (tallosRef.current) {
+      golpes.forEach((g, i) => {
+        d.position.set(g.wx, g.y + g.alto * 0.5, g.wz);
+        d.rotation.set(0, g.giro, 0);
+        d.scale.set(1, g.alto / 2.5, 1);
+        d.updateMatrix();
+        tallosRef.current.setMatrixAt(i, d.matrix);
+      });
+      tallosRef.current.instanceMatrix.needsUpdate = true;
+    }
+    if (espigasRef.current) {
+      golpes.forEach((g, i) => {
+        d.position.set(g.wx, g.y + g.alto + 0.18, g.wz);
+        d.rotation.set(0, g.giro, 0);
+        d.scale.setScalar(1);
+        d.updateMatrix();
+        espigasRef.current.setMatrixAt(i, d.matrix);
+      });
+      espigasRef.current.instanceMatrix.needsUpdate = true;
+    }
+    if (vidRef.current) {
+      golpes.forEach((g, i) => {
+        d.position.set(g.wx + 0.12, g.y, g.wz + 0.12);
+        d.rotation.set(0, g.giro + 1, 0);
+        d.scale.set(0.9, (g.alto * 0.82) / 2.0, 0.9);
+        d.updateMatrix();
+        vidRef.current.setMatrixAt(i, d.matrix);
+      });
+      vidRef.current.instanceMatrix.needsUpdate = true;
+    }
+    if (hojasRef.current) {
+      hojasMaiz.forEach((h, i) => {
+        d.position.set(h.x, h.y, h.z);
+        d.rotation.set(h.incl, h.giro, 0.1);
+        d.scale.set(0.09 * h.esc, 0.02, 0.7 * h.esc);
+        d.updateMatrix();
+        hojasRef.current.setMatrixAt(i, d.matrix);
+        col.set(h.clara ? P.maizHojaClara : P.maizHoja);
+        hojasRef.current.setColorAt(i, col);
+      });
+      hojasRef.current.instanceMatrix.needsUpdate = true;
+      if (hojasRef.current.instanceColor) hojasRef.current.instanceColor.needsUpdate = true;
+    }
+    if (calRef.current) {
+      hojasCal.forEach((h, i) => {
+        d.position.set(h.x, h.y, h.z);
+        d.rotation.set(-1.3, h.giro, 0);
+        d.scale.set(0.3 * h.esc, 0.02, 0.3 * h.esc);
+        d.updateMatrix();
+        calRef.current.setMatrixAt(i, d.matrix);
+        col.set(h.clara ? P.calabazaHojaClara : P.calabazaHoja);
+        calRef.current.setColorAt(i, col);
+      });
+      calRef.current.instanceMatrix.needsUpdate = true;
+      if (calRef.current.instanceColor) calRef.current.instanceColor.needsUpdate = true;
+    }
+    if (frutoRef.current) {
+      frutos.forEach((fr, i) => {
+        d.position.set(fr.x, fr.y + fr.esc * 0.6, fr.z);
+        d.rotation.set(0, i, 0);
+        d.scale.set(fr.esc, fr.esc * 0.8, fr.esc);
+        d.updateMatrix();
+        frutoRef.current.setMatrixAt(i, d.matrix);
+        col.set(fr.verde ? P.calabazaFrutoV : P.calabazaFruto);
+        frutoRef.current.setColorAt(i, col);
+      });
+      frutoRef.current.instanceMatrix.needsUpdate = true;
+      if (frutoRef.current.instanceColor) frutoRef.current.instanceColor.needsUpdate = true;
+    }
+  }, [golpes, hojasMaiz, hojasCal, frutos]);
+
+  return (
+    <group>
+      {/* tallos de maíz */}
+      <instancedMesh ref={tallosRef} args={[undefined, undefined, golpes.length]} frustumCulled={false}>
+        <cylinderGeometry args={[0.045, 0.08, 2.5, 6]} />
+        <meshLambertMaterial color={P.maizTallo} flatShading />
+      </instancedMesh>
+      {/* espigas (tassel) en la punta */}
+      <instancedMesh ref={espigasRef} args={[undefined, undefined, golpes.length]} frustumCulled={false}>
+        <coneGeometry args={[0.09, 0.5, 5]} />
+        <meshLambertMaterial color={P.maizPanocha} flatShading />
+      </instancedMesh>
+      {/* el fríjol trepando el maíz (vid helicoidal compartida) */}
+      <instancedMesh ref={vidRef} args={[vineGeo, undefined, golpes.length]} frustumCulled={false}>
+        <meshLambertMaterial color={P.frijolTallo} flatShading />
+      </instancedMesh>
+      {/* hojas largas del maíz */}
+      <instancedMesh ref={hojasRef} args={[undefined, undefined, hojasMaiz.length]} frustumCulled={false}>
+        <sphereGeometry args={[1, 5, 4]} />
+        <meshLambertMaterial flatShading />
+      </instancedMesh>
+      {/* hojas grandes de la calabaza rastrera */}
+      <instancedMesh ref={calRef} args={[undefined, undefined, Math.max(1, hojasCal.length)]} frustumCulled={false}>
+        <circleGeometry args={[1, 6]} />
+        <meshLambertMaterial flatShading side={THREE.DoubleSide} />
+      </instancedMesh>
+      {/* los zapallos a ras */}
+      <instancedMesh ref={frutoRef} args={[undefined, undefined, Math.max(1, frutos.length)]} frustumCulled={false}>
+        <sphereGeometry args={[1, 8, 7]} />
+        <meshLambertMaterial flatShading />
+      </instancedMesh>
+    </group>
+  );
+}
+
+/* ── LA YUCA: arbusto de tallo leñoso nudoso, copa de hojas palmadas frondosa y
+      las raíces tuberosas asomando en la base. Aguanta el suelo pobre. ── */
 function HojaPalmada({ pos, giro = 0, incl = 0, esc = 1 }) {
   return (
     <group position={pos} rotation={[incl, giro, 0]} scale={esc}>
@@ -437,23 +843,24 @@ function HojaPalmada({ pos, giro = 0, incl = 0, esc = 1 }) {
   );
 }
 
-/* ── LA YUCA: arbusto de tallo leñoso nudoso, copa de hojas palmadas y las
-      raíces tuberosas asomando en la base. Aguanta el suelo pobre. ── */
-function MataYuca({ pos }) {
+function MataYuca({ pos, esc = 1, semilla = 3 }) {
   const groundY = alturaCampo(pos[0], pos[2]);
-  // el tallo leñoso: tres tramos que zig-zaguean en los nudos (como la yuca).
+  const giroBase = useMemo(() => crearRng(semilla)() * Math.PI, [semilla]);
   const tramos = [
-    { y: 0.35, x: 0, incl: 0.05, h: 0.7 },
-    { y: 0.98, x: 0.08, incl: -0.12, h: 0.62 },
-    { y: 1.52, x: 0.02, incl: 0.08, h: 0.5 },
+    { y: 0.35 * esc, x: 0, incl: 0.05, h: 0.7 * esc },
+    { y: 0.98 * esc, x: 0.08, incl: -0.12, h: 0.62 * esc },
+    { y: 1.52 * esc, x: 0.02, incl: 0.08, h: 0.5 * esc },
   ];
-  const hojas = [
-    { pos: [0.1, 1.78, 0.05], giro: 0.2, incl: -0.2, esc: 1.05 },
-    { pos: [0.0, 1.72, 0.0], giro: 2.1, incl: -0.1, esc: 1.0 },
-    { pos: [-0.05, 1.8, -0.02], giro: 4.0, incl: -0.25, esc: 0.95 },
-    { pos: [0.15, 1.68, -0.08], giro: 5.4, incl: -0.05, esc: 0.9 },
-  ];
-  // tubérculos radiando de la base, medio enterrados (asomando).
+  // copa frondosa: más hojas palmadas que la vieja
+  const hojas = useMemo(() => {
+    const r = crearRng(semilla + 100);
+    return Array.from({ length: 8 }, (_, i) => ({
+      pos: [Math.sin(i * 2.1) * 0.14, (1.6 + Math.cos(i) * 0.18) * esc, Math.cos(i * 2.1) * 0.14],
+      giro: i * 1.6 + r(),
+      incl: -0.05 - r() * 0.3,
+      esc: (0.9 + r() * 0.35) * esc,
+    }));
+  }, [esc, semilla]);
   const tuberculos = [
     { ang: 0.4, largo: 0.62, baja: 0.28 },
     { ang: 1.9, largo: 0.55, baja: 0.24 },
@@ -462,34 +869,29 @@ function MataYuca({ pos }) {
     { ang: 5.6, largo: 0.58, baja: 0.26 },
   ];
   return (
-    <group position={[pos[0], groundY, pos[2]]}>
-      {/* raíces tuberosas asomando en la base */}
+    <group position={[pos[0], groundY, pos[2]]} rotation={[0, giroBase, 0]}>
       {tuberculos.map((tb, i) => (
         <group key={i} rotation={[0, tb.ang, 0]}>
-          <group position={[0.28, 0.02, 0]} rotation={[0, 0, -1.05]}>
-            {/* piel */}
-            <mesh position={[0, -tb.baja * 0.4, 0]} scale={[0.11, tb.largo, 0.11]}>
+          <group position={[0.28 * esc, 0.02, 0]} rotation={[0, 0, -1.05]}>
+            <mesh position={[0, -tb.baja * 0.4, 0]} scale={[0.11 * esc, tb.largo * esc, 0.11 * esc]}>
               <sphereGeometry args={[1, 8, 6]} />
               <meshLambertMaterial color={P.yucaTuberPiel} flatShading />
             </mesh>
-            {/* la punta clara (pulpa asomando por el corte natural) */}
-            <mesh position={[0, -tb.baja * 0.4 - tb.largo * 0.75, 0]} scale={[0.08, 0.1, 0.08]}>
+            <mesh position={[0, -tb.baja * 0.4 - tb.largo * 0.75 * esc, 0]} scale={[0.08 * esc, 0.1 * esc, 0.08 * esc]}>
               <sphereGeometry args={[1, 7, 6]} />
               <meshLambertMaterial color={P.yucaTuber} flatShading />
             </mesh>
           </group>
         </group>
       ))}
-      {/* el tallo leñoso con nudos */}
       {tramos.map((tr, i) => (
         <group key={i}>
           <mesh position={[tr.x, tr.y, 0]} rotation={[0, 0, tr.incl]}>
-            <cylinderGeometry args={[0.07 - i * 0.012, 0.085 - i * 0.012, tr.h, 7]} />
+            <cylinderGeometry args={[(0.07 - i * 0.012) * esc, (0.085 - i * 0.012) * esc, tr.h, 7]} />
             <meshLambertMaterial color={P.yucaTallo} flatShading />
           </mesh>
-          {/* nudo (cicatriz de hoja) */}
           <mesh position={[tr.x, tr.y + tr.h * 0.5, 0]}>
-            <sphereGeometry args={[0.08 - i * 0.012, 7, 5]} />
+            <sphereGeometry args={[(0.08 - i * 0.012) * esc, 7, 5]} />
             <meshLambertMaterial color={P.yucaNudo} flatShading />
           </mesh>
         </group>
@@ -501,85 +903,137 @@ function MataYuca({ pos }) {
   );
 }
 
-/* La PANOJA: la firma de la quinua. Granos diminutos instanciados (1 draw call),
-   apretados en un volumen cónico-alargado, coloreados alrededor del tono base
-   (rojo / dorado / morado) con leve variación. */
-function Panoja({ baseHex, alto, radio, n }) {
-  const ref = useRef(null);
-  const granos = useMemo(() => {
-    const rng = crearRng(Math.round(alto * 1000) + n);
-    return Array.from({ length: n }, () => {
-      const t = rng(); // 0 abajo, 1 arriba de la panoja
-      const rad = radio * (1 - t * 0.75) * (0.35 + rng() * 0.65);
-      const ang = rng() * Math.PI * 2;
-      return {
-        x: Math.cos(ang) * rad,
-        y: t * alto,
-        z: Math.sin(ang) * rad,
-        s: 0.03 + rng() * 0.03,
-        tono: (rng() - 0.5),
-      };
-    });
-  }, [alto, radio, n]);
-  useEffect(() => {
-    const m = ref.current;
-    if (!m) return;
-    const dummy = new THREE.Object3D();
-    const tinte = new THREE.Color();
-    granos.forEach((g, i) => {
-      dummy.position.set(g.x, g.y, g.z);
-      dummy.scale.setScalar(g.s);
-      dummy.updateMatrix();
-      m.setMatrixAt(i, dummy.matrix);
-      tinte.set(baseHex).offsetHSL(g.tono * 0.03, g.tono * 0.1, g.tono * 0.12);
-      m.setColorAt(i, tinte);
-    });
-    m.instanceMatrix.needsUpdate = true;
-    if (m.instanceColor) m.instanceColor.needsUpdate = true;
-  }, [granos, baseHex]);
-  return (
-    <instancedMesh ref={ref} args={[undefined, undefined, granos.length]} frustumCulled={false}>
-      <sphereGeometry args={[1, 6, 5]} />
-      <meshLambertMaterial flatShading />
-    </instancedMesh>
-  );
+/* ═══════════════════════════════════════════════════════════════════════════
+   LA QUINUA EN GRUPO: una parcela de tallos con hojas de pata de ganso y las
+   PANOJAS densas de color arriba (rojas / doradas / moradas). Tallos y hojas
+   instanciados; TODOS los granos de TODAS las panojas en UN InstancedMesh.
+   ═══════════════════════════════════════════════════════════════════════════ */
+function sembrarQuinuar(seed, filas, porFila, cx, cz, paso) {
+  const rng = crearRng(seed);
+  const colores = [P.quinuaRojo, P.quinuaDorado, P.quinuaMorado];
+  const plantas = [];
+  for (let f = 0; f < filas; f++) {
+    for (let k = 0; k < porFila; k++) {
+      const wx = cx + (k - (porFila - 1) / 2) * paso + (rng() - 0.5) * 0.35;
+      const wz = cz + (f - (filas - 1) / 2) * paso + (rng() - 0.5) * 0.35;
+      plantas.push({
+        wx, wz, y: alturaCampo(wx, wz),
+        alto: 1.05 + rng() * 0.7,
+        giro: rng() * Math.PI * 2,
+        color: colores[Math.floor(rng() * colores.length)],
+        semilla: Math.floor(rng() * 9999),
+      });
+    }
+  }
+  return plantas;
 }
 
-/* ── LA QUINUA: tallo alto con hojas de pata de ganso y la PANOJA densa de color
-      arriba. Proteína de la altura. Distintas alturas/edades por instancia. ── */
-function MataQuinua({ pos, esc = 1, colorHex, reducedMotion, semilla, granos }) {
-  const cabeza = useRef(null);
-  const altoTallo = 1.15 * esc;
+function Quinuar({ plantas, granosPorPanoja, reducedMotion }) {
+  const tallosRef = useRef(null);
+  const hojasRef = useRef(null);
+  const granosRef = useRef(null);
+  const cabezasRef = useRef(null); // grupo que mece las panojas
+
   const hojas = useMemo(() => {
-    const rng = crearRng(semilla);
-    return Array.from({ length: 6 }, (_, i) => ({
-      y: 0.3 + (i / 6) * altoTallo * 0.8,
-      giro: i * 1.9 + rng(),
-      esc: (0.9 - i * 0.08) * esc,
-    }));
-  }, [altoTallo, esc, semilla]);
+    const rng = crearRng(321);
+    const lista = [];
+    plantas.forEach((p) => {
+      const n = 6;
+      for (let i = 0; i < n; i++) {
+        const t = 0.25 + (i / n) * 0.6;
+        const a = p.giro + i * 1.9 + rng();
+        lista.push({
+          x: p.wx + Math.sin(a) * 0.1, y: p.y + t * p.alto, z: p.wz + Math.cos(a) * 0.1,
+          giro: a, esc: 0.85 - i * 0.06,
+        });
+      }
+    });
+    return lista;
+  }, [plantas]);
+
+  // granos: todos los de todas las panojas, con su color por instancia
+  const granos = useMemo(() => {
+    const lista = [];
+    plantas.forEach((p) => {
+      const rng = crearRng(p.semilla);
+      const baseCol = new THREE.Color(p.color);
+      const altoP = 0.65 + p.alto * 0.12;
+      const radioP = 0.19;
+      for (let i = 0; i < granosPorPanoja; i++) {
+        const t = rng();
+        const rad = radioP * (1 - t * 0.72) * (0.35 + rng() * 0.65);
+        const ang = rng() * Math.PI * 2;
+        const c = baseCol.clone().offsetHSL((rng() - 0.5) * 0.03, (rng() - 0.5) * 0.1, (rng() - 0.5) * 0.14);
+        lista.push({
+          x: p.wx + Math.cos(ang) * rad,
+          y: p.y + p.alto + t * altoP,
+          z: p.wz + Math.sin(ang) * rad,
+          s: 0.032 + rng() * 0.03,
+          col: c,
+        });
+      }
+    });
+    return lista;
+  }, [plantas, granosPorPanoja]);
+
+  useEffect(() => {
+    const d = new THREE.Object3D();
+    const col = new THREE.Color();
+    if (tallosRef.current) {
+      plantas.forEach((p, i) => {
+        d.position.set(p.wx, p.y + p.alto * 0.5, p.wz);
+        d.rotation.set(0, p.giro, 0);
+        d.scale.set(1, p.alto / 1.1, 1);
+        d.updateMatrix();
+        tallosRef.current.setMatrixAt(i, d.matrix);
+      });
+      tallosRef.current.instanceMatrix.needsUpdate = true;
+    }
+    if (hojasRef.current) {
+      hojas.forEach((h, i) => {
+        d.position.set(h.x, h.y, h.z);
+        d.rotation.set(-0.5, h.giro, 0.3);
+        d.scale.set(0.13 * h.esc, 0.02, 0.15 * h.esc);
+        d.updateMatrix();
+        hojasRef.current.setMatrixAt(i, d.matrix);
+      });
+      hojasRef.current.instanceMatrix.needsUpdate = true;
+    }
+    if (granosRef.current) {
+      granos.forEach((g, i) => {
+        d.position.set(g.x, g.y, g.z);
+        d.rotation.set(0, 0, 0);
+        d.scale.setScalar(g.s);
+        d.updateMatrix();
+        granosRef.current.setMatrixAt(i, d.matrix);
+        col.copy(g.col);
+        granosRef.current.setColorAt(i, col);
+      });
+      granosRef.current.instanceMatrix.needsUpdate = true;
+      if (granosRef.current.instanceColor) granosRef.current.instanceColor.needsUpdate = true;
+    }
+  }, [plantas, hojas, granos]);
+
   useFrame(({ clock }) => {
-    if (reducedMotion || !cabeza.current) return;
-    cabeza.current.rotation.z = Math.sin(clock.elapsedTime * 0.9 + semilla) * 0.05;
+    if (reducedMotion || !cabezasRef.current) return;
+    cabezasRef.current.rotation.z = Math.sin(clock.elapsedTime * 0.8) * 0.02;
   });
-  const groundY = alturaCampo(pos[0], pos[2]);
+
   return (
-    <group position={[pos[0], groundY, pos[2]]}>
-      {/* el tallo */}
-      <mesh position={[0, altoTallo / 2, 0]}>
-        <cylinderGeometry args={[0.03 * esc, 0.055 * esc, altoTallo, 6]} />
+    <group>
+      <instancedMesh ref={tallosRef} args={[undefined, undefined, plantas.length]} frustumCulled={false}>
+        <cylinderGeometry args={[0.03, 0.055, 1.1, 6]} />
         <meshLambertMaterial color={P.quinuaTallo} flatShading />
-      </mesh>
-      {/* hojas de pata de ganso a lo largo del tallo */}
-      {hojas.map((h, i) => (
-        <mesh key={i} position={[Math.sin(h.giro) * 0.1, h.y, Math.cos(h.giro) * 0.1]} rotation={[-0.5, h.giro, 0.3]} scale={[0.12 * h.esc, 0.02, 0.14 * h.esc]}>
+      </instancedMesh>
+      <instancedMesh ref={hojasRef} args={[undefined, undefined, hojas.length]} frustumCulled={false}>
+        <sphereGeometry args={[1, 6, 5]} />
+        <meshLambertMaterial color={P.quinuaHoja} flatShading />
+      </instancedMesh>
+      <group ref={cabezasRef}>
+        <instancedMesh ref={granosRef} args={[undefined, undefined, granos.length]} frustumCulled={false}>
           <sphereGeometry args={[1, 6, 5]} />
-          <meshLambertMaterial color={P.quinuaHoja} flatShading />
-        </mesh>
-      ))}
-      {/* la PANOJA de color, meciéndose apenas */}
-      <group ref={cabeza} position={[0, altoTallo, 0]}>
-        <Panoja baseHex={colorHex} alto={0.7 * esc} radio={0.2 * esc} n={granos} />
+          <meshLambertMaterial flatShading />
+        </instancedMesh>
       </group>
     </group>
   );
@@ -594,21 +1048,45 @@ function EscenaLeguminosas({ tier, reducedMotion, saber }) {
   );
   useEffect(() => () => geo.dispose(), [geo]);
 
-  const nCobertura = tier === 'alto' ? 90 : tier === 'medio' ? 55 : 24;
-  const granosPanoja = tier === 'alto' ? 60 : tier === 'medio' ? 40 : 22;
+  // geometría de vid compartida por TODO el fríjol (frijolar + milpa + héroe)
+  const vineGeo = useMemo(
+    () => new THREE.TubeGeometry(curvaVid(3.2, 2.0, 0.18), 40, 0.03, 5, false),
+    [],
+  );
+  useEffect(() => () => vineGeo.dispose(), [vineGeo]);
+
+  // presupuestos por tier (denso arriba, digno abajo)
+  const denso = tier === 'alto' ? 1 : tier === 'medio' ? 0.62 : 0.4;
+  const nCobertura = tier === 'alto' ? 150 : tier === 'medio' ? 90 : 45;
+  const nPiedras = tier === 'alto' ? 120 : tier === 'medio' ? 70 : 30;
+  const granosPanoja = tier === 'alto' ? 55 : tier === 'medio' ? 36 : 20;
+  const filasFrijol = tier === 'bajo' ? 2 : 3;
+  const porFilaFrijol = tier === 'alto' ? 6 : tier === 'medio' ? 5 : 4;
+  const filasMilpa = tier === 'bajo' ? 2 : 3;
+  const porFilaMilpa = tier === 'alto' ? 5 : 4;
+  const filasQuinua = tier === 'bajo' ? 2 : 3;
+  const porFilaQuinua = tier === 'alto' ? 5 : 4;
+
+  // siembras deterministas
+  const frijolarA = useMemo(() => sembrarFrijolar(11, filasFrijol, porFilaFrijol, -7.5, 2.2, 1.5, 2.2), [filasFrijol, porFilaFrijol]);
+  const frijolarB = useMemo(() => sembrarFrijolar(29, filasFrijol, porFilaFrijol - 1, -8.5, 7.0, 1.5, 2.0), [filasFrijol, porFilaFrijol]);
+  const milpa = useMemo(() => sembrarMilpa(43, filasMilpa, porFilaMilpa, 2.0, -7.0, 1.9), [filasMilpa, porFilaMilpa]);
+  const quinuar = useMemo(() => sembrarQuinuar(61, filasQuinua, porFilaQuinua, -1.5, -3.0, 1.35), [filasQuinua, porFilaQuinua]);
 
   // Fauna del kit (billboards SVG), por rol ecológico. Recortada al presupuesto.
   const faunaItems = [
-    { tipo: 'mariposa', rol: 'polinizador', base: [0.6, 1.7, -2.4], size: 30, fase: 0.4, title: 'Mariposa polinizando las panojas' },
-    { tipo: 'colibri', rol: 'polinizador', base: [-2.4, 2.3, 3.9], size: 32, fase: 1.6, title: 'Colibrí en las flores del fríjol' },
-    { tipo: 'escarabajo', rol: 'descomponedor', base: [3.6, 0.2, 0.4], size: 26, fase: 2.4, title: 'Escarabajo cerrando el ciclo del abono' },
+    { tipo: 'mariposa', rol: 'polinizador', base: [-6.5, 1.9, 3.6], size: 30, fase: 0.4, title: 'Mariposa polinizando el fríjol' },
+    { tipo: 'colibri', rol: 'polinizador', base: [1.5, 2.4, -2.6], size: 32, fase: 1.6, title: 'Colibrí en las flores de la milpa' },
+    { tipo: 'mariposa', rol: 'polinizador', base: [-1.0, 1.6, -1.4], size: 26, fase: 2.9, title: 'Mariposa entre las panojas de quinua' },
+    { tipo: 'escarabajo', rol: 'descomponedor', base: [4.2, 0.2, 1.6], size: 26, fase: 2.4, title: 'Escarabajo cerrando el ciclo del abono' },
+    { tipo: 'lombriz', rol: 'descomponedor', base: [-4.0, 0.12, 5.6], size: 24, fase: 0.9, title: 'Lombriz aireando la tierra' },
   ].slice(0, perfil.criaturas);
 
   /* `color`/`fog` se adjuntan a la ESCENA: hijos directos, nunca en <group>. */
   return (
     <>
       <color attach="background" args={[DORADA.fondo]} />
-      {perfil.fog && <fog attach="fog" args={[DORADA.niebla, DORADA.nieblaCerca + 4, DORADA.nieblaLejos]} />}
+      {perfil.fog && <fog attach="fog" args={[DORADA.niebla, DORADA.nieblaCerca + 6, DORADA.nieblaLejos]} />}
       <LucesDoradas />
       <SolBajo />
 
@@ -617,19 +1095,34 @@ function EscenaLeguminosas({ tier, reducedMotion, saber }) {
       </mesh>
 
       <Cobertura n={nCobertura} />
+      <Piedritas n={nPiedras} />
 
-      {/* Las tres matas, a distinta altura/edad, NO en fila. */}
-      <MataFrijol pos={[-2.4, 0, 3.5]} reducedMotion={reducedMotion} saber={saber} />
-      <MataYuca pos={[3.6, 0, -0.6]} />
-      <MataQuinua pos={[0.2, 0, -2.9]} esc={1.35} colorHex={P.quinuaDorado} reducedMotion={reducedMotion} semilla={5} granos={granosPanoja} />
-      <MataQuinua pos={[2.0, 0, -2.0]} esc={1.0} colorHex={P.quinuaRojo} reducedMotion={reducedMotion} semilla={11} granos={granosPanoja} />
-      <MataQuinua pos={[-1.9, 0, -1.6]} esc={0.82} colorHex={P.quinuaMorado} reducedMotion={reducedMotion} semilla={17} granos={granosPanoja} />
+      {/* EL FRIJOLAR: dos parcelas de hileras a la izquierda del lote */}
+      <Frijolar plan={frijolarA} vineGeo={vineGeo} />
+      <Frijolar plan={frijolarB} vineGeo={vineGeo} />
 
-      {perfil.criaturas > 0 && <Fauna items={faunaItems} reducedMotion={reducedMotion} />}
+      {/* LA MATA HÉROE: el corte con los nódulos, al frente e izquierda */}
+      <MataFrijolHeroe pos={[-6.0, 0, 5.6]} reducedMotion={reducedMotion} saber={saber} vineGeo={vineGeo} />
+
+      {/* LA MILPA de las tres hermanas, al fondo-centro */}
+      <Milpa golpes={milpa} vineGeo={vineGeo} />
+
+      {/* LA QUINUA en grupo, centro */}
+      <Quinuar plantas={quinuar} granosPorPanoja={granosPanoja} reducedMotion={reducedMotion} />
+
+      {/* LAS YUCAS frondosas, a la derecha */}
+      <MataYuca pos={[6.6, 0, 1.4]} esc={1.15} semilla={3} />
+      <MataYuca pos={[8.4, 0, -1.2]} esc={0.95} semilla={7} />
+      {denso > 0.5 && <MataYuca pos={[5.2, 0, 4.4]} esc={0.85} semilla={13} />}
+
+      {perfil.criaturas > 0 && faunaItems.map((it, i) => (
+        <Bicho key={i} {...it} reducedMotion={reducedMotion} />
+      ))}
 
       {/* el polen dorado en suspensión (kit de partículas) */}
-      <ParticulasAmbientales tipo="polen" tier={tier} reducedMotion={reducedMotion} position={[0, 0.8, 0]} semilla={23} />
-      <ParticulasAmbientales tipo="polen" densidad={0.6} tier={tier} reducedMotion={reducedMotion} position={[-3, 1.0, 2]} semilla={31} />
+      <ParticulasAmbientales tipo="polen" tier={tier} reducedMotion={reducedMotion} position={[-3, 1.1, 2]} semilla={23} />
+      <ParticulasAmbientales tipo="polen" densidad={0.7} tier={tier} reducedMotion={reducedMotion} position={[2, 1.4, -4]} semilla={31} />
+      <ParticulasAmbientales tipo="polen" densidad={0.5} tier={tier} reducedMotion={reducedMotion} position={[6, 1.0, 1]} semilla={47} />
     </>
   );
 }
@@ -644,7 +1137,7 @@ const CSS_LEGUM = `
 .legum-titulo small { display: block; font: 500 0.8rem/1.3 system-ui, sans-serif; opacity: 0.82; margin-top: 0.15rem; }
 .legum-pie { padding: 0 1rem 0.9rem; display: flex; flex-direction: column; align-items: center; gap: 0.55rem; }
 .legum-carta { margin: 0; max-width: 34rem; text-align: center; padding: 0.5rem 0.95rem; border-radius: 0.7rem; background: rgba(74,52,24,0.62); backdrop-filter: blur(3px); color: #fbf3e2; font: 500 0.8rem/1.5 system-ui, sans-serif; }
-.legum-chips { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.4rem; max-width: 36rem; }
+.legum-chips { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.4rem; max-width: 38rem; }
 .legum-chip { padding: 0.28rem 0.7rem; border-radius: 999px; background: rgba(255,247,228,0.86); color: #5a3f1c; font: 600 0.72rem/1.2 system-ui, sans-serif; }
 .legum-chip b { color: #7a2f4c; }
 .legum-boton { pointer-events: auto; appearance: none; border: 1px solid rgba(74,52,24,0.35); border-radius: 999px; padding: 0.44rem 1rem; background: rgba(255,247,228,0.82); color: #5a3f1c; font: 600 0.8rem/1.1 system-ui, sans-serif; cursor: pointer; backdrop-filter: blur(3px); transition: background 0.2s ease, border-color 0.2s ease; }
@@ -656,21 +1149,22 @@ const CSS_LEGUM = `
 
 /* La copia didáctica: en calma, la invitación; con el saber encendido, los nódulos. */
 const COPY_CALMA =
-  'El fríjol, la yuca y la quinua: tres matas que le dan de comer a la familia y a la tierra. Toque el botón para ver, bajo el fríjol, los nódulos rosados que fijan el nitrógeno.';
+  'El frijolar, la milpa, la quinua y la yuca: un lote que le da de comer a la familia y a la tierra. Toque el botón para ver, bajo el fríjol de adelante, los nódulos rosados que fijan el nitrógeno.';
 const COPY_SABER =
-  'Esas pelotitas rosadas en la raíz del fríjol son fábricas de nitrógeno (bacterias Rhizobium): abono gratis del aire. Por eso conviene asociar el fríjol con el maíz — el maíz da la vara y el fríjol le abona la tierra.';
+  'Esas pelotitas rosadas en la raíz del fríjol son fábricas de nitrógeno (bacterias Rhizobium): abono gratis del aire. Por eso siembre la milpa: el maíz da la vara, el fríjol le abona la tierra y la calabaza le tapa el suelo.';
 
 const CHIPS = [
-  { emoji: '🫘', txt: <>Fríjol: <b>fija nitrógeno gratis</b> (asócielo con maíz)</> },
-  { emoji: '🌿', txt: <>Yuca: <b>aguanta el suelo pobre</b></> },
+  { emoji: '🫘', txt: <>Fríjol: <b>fija nitrógeno gratis</b></> },
+  { emoji: '🌽', txt: <>Milpa: <b>maíz + fríjol + calabaza</b></> },
   { emoji: '🌾', txt: <>Quinua: <b>proteína de la altura</b></> },
+  { emoji: '🌿', txt: <>Yuca: <b>aguanta el suelo pobre</b></> },
 ];
 
 /**
- * MundoLeguminosas3D — el mundo de leguminosas y raíces andinas, montable con su
- * propio `<Canvas>`. Sin lógica de negocio: es una vitrina
+ * MundoLeguminosas3D — el mundo de leguminosas y raíces andinas, DENSO, montable
+ * con su propio `<Canvas>`. Sin lógica de negocio: es una vitrina
  * (#/mockups/mundo-leguminosas-3d). El tier y reduced-motion se detectan aquí
- * (mockup standalone), igual que sus pares (MundoParamo3D).
+ * (mockup standalone), igual que sus pares (MundoBoticaCana3D).
  */
 export default function MundoLeguminosas3D() {
   const [listo, setListo] = useState(false);
@@ -689,14 +1183,14 @@ export default function MundoLeguminosas3D() {
     <section
       className="legum-root"
       data-tier={tier}
-      aria-label="El mundo de leguminosas y raíces andinas: fríjol con nódulos, yuca y quinua"
+      aria-label="El lote de leguminosas y raíces andinas: frijolar, milpa, quinua y yuca, con los nódulos del fríjol"
     >
       <style>{CSS_LEGUM}</style>
       <Canvas
         className={`legum-canvas${listo ? ' legum-canvas--lista' : ''}`}
         dpr={perfil.dpr}
         gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
-        camera={{ position: [0.5, 4.2, 12], fov: 44 }}
+        camera={{ position: [2.5, 4.6, 13.5], fov: 46 }}
         frameloop={reducedMotion ? 'demand' : 'always'}
         onCreated={() => setListo(true)}
       >
@@ -705,13 +1199,13 @@ export default function MundoLeguminosas3D() {
           makeDefault
           enablePan={false}
           enableZoom
-          minDistance={6}
-          maxDistance={18}
-          target={[-0.3, 1.4, 0.6]}
-          minPolarAngle={0.45}
-          maxPolarAngle={1.42}
-          minAzimuthAngle={-0.6}
-          maxAzimuthAngle={0.7}
+          minDistance={7}
+          maxDistance={22}
+          target={[-1.5, 1.3, 0.4]}
+          minPolarAngle={0.4}
+          maxPolarAngle={1.44}
+          minAzimuthAngle={-0.75}
+          maxAzimuthAngle={0.75}
           enableDamping
           dampingFactor={0.08}
           autoRotate={!reducedMotion}
@@ -723,7 +1217,7 @@ export default function MundoLeguminosas3D() {
       <div className="legum-chrome">
         <h2 className="legum-titulo">
           Leguminosas y raíces andinas
-          <small>Fríjol que abona · yuca que aguanta · quinua que alimenta</small>
+          <small>Frijolar que abona · milpa de tres hermanas · quinua · yuca</small>
         </h2>
         <div className="legum-pie">
           <div className="legum-chips">


### PR DESCRIPTION
## Qué

Densifica el mundo **leguminosas y raíces andinas** 3D: de ~4 matas sueltas en terreno vacío a un **LOTE VIVO** ("AoE del campo") en hora dorada. Todo lo repetido va **instanciado** (pocos draw calls) para densidad sin costo.

## Norte de densidad (cumplido)
- **Frijolar en hileras**: dos parcelas de estacas con la vid helicoidal trepando (geometría de vid **compartida e instanciada**); hojas trifoliadas y vainas instanciadas.
- **Milpa / tres hermanas**: maíz de vara con espiga + fríjol trepando por él + calabaza rastrera (hojas grandes y zapallos a ras).
- **Quinua en grupo**: parcela con panojas rojas/doradas/moradas; todos los granos en **un solo InstancedMesh** coloreado por instancia.
- **Yucas frondosas** de raíz tuberosa; cobertura de pasto + piedritas instanciadas; más fauna del kit (mariposas, colibrí, escarabajo, lombriz) + polen.

## Lección conservada
La **mata héroe** mantiene el corte del subsuelo con los **NÓDULOS ROSADOS de Rhizobium** y el halo del saber (botón «ver el saber bajo tierra»). Copy en "usted".

## Archivos (cero valle / framework / auth)
- `src/mockups/MundoLeguminosas3D.jsx` — reescrito, denso, standalone (patrón botica).
- `src/App.jsx` — ruta dev `#/mockups/mundo-leguminosas-3d` (lazy import + hash route + case). Prod `diorama_leguminosas` ya venía cableado desde la base (rutasProdChagraApp.js + ProdChagraApp.jsx sin cambios).

NO se tocó: `src/mockups/valle/**`, `mundoData.js`, `arquetipos.js`, `EscenaBase3D.jsx`, `Mundo.jsx`, servicios, CI ni auth.

## Verificación
- `npm run build:prod` **verde** (22s); `dist-prod/` restaurado (sin artefactos en el diff).
- eslint limpio en los archivos tocados.
- Captura chromium sistema + swiftshader en `#diorama_leguminosas` (`waitUntil:'commit'` + 11s, 3 tomas): escena **densa, sin negro**, con frijolar + milpa + quinua + yuca + nódulos rosados visibles. La 3ª toma muestra el halo del saber encendido.

## Comparativa honesta (densidad)
| | vieja (`art/mundo-leguminosas-tuberculos`) | esta v2 |
|---|---|---|
| matas | 1 fríjol héroe + 1 yuca + 3 quinuas = ~5, terreno vacío | frijolar (2 parcelas de hileras) + milpa (parcela) + quinuar (grupo) + 3 yucas + héroe |
| técnica | matas sueltas a mano | siembras deterministas instanciadas (estacas/vides/hojas/vainas/granos/cobertura) |
| tres hermanas | no | sí (maíz + fríjol + calabaza) |
| cobertura | 90 conos pasto | pasto + piedritas |

🤖 Generated with [Claude Code](https://claude.com/claude-code)