### PR TITLE
fix(rag): indexar clima y altitud — un umbral de 20 chars botaba el 62% del saber

### DIFF
--- a/src/services/__tests__/ragClima.test.js
+++ b/src/services/__tests__/ragClima.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import { flattenDoc } from '../ragRetriever.js';
+
+// Regresión del hallazgo 2026-07-15: flattenDoc solo indexaba strings >20 chars.
+// Medido: 6.042 de 9.671 valores (62%) invisibles al BM25 — incluidos
+// thermal_zones:'calido' (6 chars) y altitud_msnm:0 (número). El campesino
+// pregunta "¿esto se me da a mí?" y la recuperación no veía ni la zona térmica
+// ni la altitud.
+describe('flattenDoc indexa clima y altitud', () => {
+  const doc = {
+    slug: 'coffea_arabica',
+    thermal_zones: ['templado', 'frio'],
+    requirements: { altitud_msnm: { optimo_min: 1200, optimo_max: 1800 }, temp_min: 12 },
+    valor_pedagogico: 'El cafe necesita sombra y una altura que le de acidez a la taza.',
+    id: 42,
+    version: 3,
+  };
+
+  it('indexa las zonas termicas (strings cortos que antes se caian)', () => {
+    const t = flattenDoc(doc).map((p) => p.text.toLowerCase());
+    expect(t.some((x) => x.includes('templado'))).toBe(true);
+    expect(t.some((x) => x.includes('frio'))).toBe(true);
+  });
+
+  it('indexa la altitud (numeros que antes se caian)', () => {
+    const t = flattenDoc(doc).map((p) => p.text);
+    expect(t.some((x) => x.includes('1200'))).toBe(true);
+    expect(t.some((x) => x.includes('1800'))).toBe(true);
+  });
+
+  it('el dato corto lleva su clave: "calido" suelto no dice nada', () => {
+    const p = flattenDoc(doc).find((x) => x.text.includes('templado'));
+    expect(p.text).toMatch(/thermal.?zones/i);
+  });
+
+  it('NO indexa plumbing (id/slug/version) — diluiria el IDF', () => {
+    const claves = flattenDoc(doc).map((p) => p.key);
+    expect(claves).not.toContain('id');
+    expect(claves).not.toContain('slug');
+    expect(claves).not.toContain('version');
+  });
+
+  it('no rompe lo que ya funcionaba: los textos largos siguen enteros', () => {
+    const p = flattenDoc(doc).find((x) => x.key === 'valor_pedagogico');
+    expect(p.text).toBe(doc.valor_pedagogico);
+  });
+
+  it('sobre las fichas reales, recupera clima donde antes habia cero', () => {
+    const dir = 'public/cycle-content';
+    const fs_ = fs.readdirSync(dir).filter((f) => f.endsWith('.json') && f !== 'manifest.json').slice(0, 50);
+    let clima = 0;
+    for (const f of fs_) {
+      const d = JSON.parse(fs.readFileSync(`${dir}/${f}`, 'utf8'));
+      clima += flattenDoc(d).filter((p) => /therm|altitud|temp/i.test(p.key)).length;
+    }
+    expect(clima).toBeGreaterThan(0);
+  });
+});

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -203,16 +203,55 @@ function resolveSpeciesSlug(doc, speciesSlug = null) {
   return '';
 }
 
+/**
+ * Claves que NO se indexan como dato corto: son identificadores/plumbing y
+ * solo diluirían el IDF del BM25 sin responder ninguna pregunta del campesino.
+ * Se comparan contra el ÚLTIMO segmento de la clave (`requirements.id` → `id`).
+ */
+const CLAVES_RUIDO = new Set([
+  'id', 'slug', 'uuid', '_id', 'key', 'ref', 'url', 'href', 'src', 'icon',
+  'version', 'schema_version', 'orden', 'order', 'index', 'idx', 'color', 'hex',
+]);
+
+/** true si la clave es plumbing y su valor corto no aporta recuperación. */
+function esClaveRuido(clavePlana) {
+  const ultimo = String(clavePlana).split('.').pop().replace(/\[\d+\]$/, '');
+  return CLAVES_RUIDO.has(ultimo.toLowerCase());
+}
+
 export function flattenDoc(doc, prefix = '', speciesSlug = null) {
   const slug = resolveSpeciesSlug(doc, speciesSlug);
   const passages = [];
+
+  // Un dato corto sin su clave es inservible: "calido" suelto no dice nada, y
+  // "0" menos. Se indexa `clave: valor` para que la clave aporte la semántica y
+  // el BM25 pueda casar "zona termica calido" contra `thermal_zones: calido`.
+  const addDatoCorto = (key, val) => {
+    const clave = `${prefix}${key}`;
+    if (esClaveRuido(clave)) return;
+    const legible = String(key).replace(/[_.]/g, ' ').trim();
+    passages.push({ key: clave, text: `${legible}: ${val}`, species: slug });
+  };
+
   const addPassage = (key, val) => {
     if (typeof val === 'string' && val.length > 20) {
       passages.push({ key: `${prefix}${key}`, text: val, species: slug });
+    } else if (typeof val === 'string' && val.trim()) {
+      // ANTES se caían en silencio: `thermal_zones: 'calido'` (6 chars),
+      // `piso: 'frio'` (4). Medido 2026-07-15: 4.272 de 9.671 valores.
+      addDatoCorto(key, val.trim());
+    } else if (typeof val === 'number' && Number.isFinite(val)) {
+      // ANTES se caían en silencio: `altitud_msnm.optimo_min: 1800`,
+      // `temp_min: 12`. Medido 2026-07-15: 1.770 de 9.671 valores.
+      addDatoCorto(key, val);
     } else if (Array.isArray(val)) {
       val.forEach((item, i) => {
         if (typeof item === 'string' && item.length > 20) {
           passages.push({ key: `${prefix}${key}[${i}]`, text: item, species: slug });
+        } else if (typeof item === 'string' && item.trim()) {
+          addDatoCorto(`${key}[${i}]`, item.trim());
+        } else if (typeof item === 'number' && Number.isFinite(item)) {
+          addDatoCorto(`${key}[${i}]`, item);
         } else if (typeof item === 'object' && item !== null) {
           flattenDoc(item, `${prefix}${key}[${i}].`, slug).forEach((p) => passages.push(p));
         }


### PR DESCRIPTION
## Problema

`flattenDoc` en `src/services/ragRetriever.js` solo indexaba strings de **>20 caracteres**:

```js
if (typeof val === 'string' && val.length > 20) { ... }
```

Esto tiraba en silencio los strings cortos y **todos los números**. Medido sobre las fichas reales: **6.042 de 9.671 valores (62%) invisibles al BM25** — incluyendo justo lo que pregunta el campesino:
- `thermal_zones: 'calido'` (6 chars) → botado
- `requirements.altitud_msnm.optimo_min: 1800` (número) → botado
- `temp_min: 12` → botado

El agente no podía responder "¿esto se me da a mí?" porque la recuperación no veía ni la zona térmica ni la altitud.

## Fix

`flattenDoc` ahora indexa los datos cortos y numéricos como `clave: valor` (para que la clave aporte la semántica al BM25: `thermal zones: calido`), con una lista `CLAVES_RUIDO` que salta plumbing (`id`, `slug`, `uuid`, `version`, `color`…) para no diluir el IDF.

**Es aditivo:** solo agrega pasajes, nunca quita ni modifica los existentes → el recall no puede regresar; el único vector de riesgo (precisión) queda acotado por `CLAVES_RUIDO` + el peso IDF de BM25.

## Evidencia

- `src/services/__tests__/ragClima.test.js` (nuevo, **6/6 verde**): valida que indexa `thermal_zones`/altitud (antes 0), que el dato corto lleva su clave, que NO indexa plumbing, que los textos largos siguen enteros, y **sobre las fichas reales de `public/cycle-content` confirma que recupera clima donde antes había cero**.
- El delta de recall@k del gold set corre en el suite de CI (`bench-rag-retrieve`, requiere el corpus servido).

## Notas

Cherry-pick quirúrgico de `7a68e610` sobre `main` actual (la rama origen `fix/rag-indexa-clima` traía ~65k líneas ajenas de otro trabajo; acá va solo el fix + su test).