### PR TITLE
feat(bench): cablear el bench-gate CI (gate v1 + workflow + baselines)

### DIFF
--- a/.github/workflows/bench-gate.yml
+++ b/.github/workflows/bench-gate.yml
@@ -1,0 +1,111 @@
+# Bench Gate CI — automatiza el gate manual de BENCH_GATE_PIPELINE.md (§6).
+#
+# Corre un bench de PRODUCTO sobre el runner self-hosted de alpha, compara el
+# resultado (history v1) contra el baseline commiteado en bench/baseline/ via
+# bench/gate.mjs, comenta la tabla delta en el PR y BLOQUEA el merge si el
+# veredicto es RED (accuracy -5pp / halluc +3pp / parse -2pp / latency +25%).
+#
+# OPT-IN por diseno: solo corre cuando el PR lleva la label `bench-required`
+# (o por workflow_dispatch manual). Motivo: el bench usa la GPU M6000 del nodo
+# de PRODUCCION; correrlo en cada PR tumbaria el agente. La concurrency
+# serializa las corridas para que nunca haya dos benches peleando por la GPU.
+#
+# REGLA DURA DEL PLAN: el gate corre el bench de PRODUCTO (config con tools/RAG),
+# NUNCA el modelo crudo (eval_completo.py). El default `agro-rotatorio` es corpus
+# (sin GPU); `borde-alucinacion` es el AH sellado a CONFIG-PROD (mas pesado).
+name: Bench Gate
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      bench:
+        description: "id del bench a gatear (debe existir en bench/index.json y emitir history v1)"
+        default: agro-rotatorio
+        required: true
+      pr:
+        description: "numero de PR a comentar (solo para run manual)"
+        required: false
+      strict:
+        description: "YELLOW tambien bloquea"
+        type: boolean
+        default: false
+
+# Un solo bench a la vez (la GPU es unica). No cancela: dejar terminar el que corre.
+concurrency:
+  group: bench-gate-${{ github.event.pull_request.number || github.event.inputs.pr || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bench-gate:
+    # Solo si la label es exactamente `bench-required`, o si es dispatch manual.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'bench-required'
+    runs-on: [self-hosted, alpha]
+    timeout-minutes: 45
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+
+      - name: Resolver bench + PR
+        id: cfg
+        run: |
+          BENCH="${{ github.event.inputs.bench }}"
+          BENCH="${BENCH:-agro-rotatorio}"
+          PR="${{ github.event.pull_request.number || github.event.inputs.pr }}"
+          echo "bench=$BENCH" >> "$GITHUB_OUTPUT"
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          echo "Gateando bench '$BENCH' para PR #$PR"
+
+      - name: Correr bench de producto (emite history v1)
+        run: |
+          node bench/run.mjs "${{ steps.cfg.outputs.bench }}"
+
+      - name: Evaluar gate vs baseline
+        id: gate
+        run: |
+          set +e
+          STRICT=""
+          [ "${{ github.event.inputs.strict }}" = "true" ] && STRICT="--strict"
+          node bench/gate.mjs \
+            --bench "${{ steps.cfg.outputs.bench }}" \
+            --baseline-dir bench/baseline \
+            --history-dir bench/history \
+            --md-out gate-comment.md $STRICT
+          echo "verdict_exit=$?" >> "$GITHUB_OUTPUT"
+          cat gate-comment.md
+
+      - name: Comentar resultado en el PR
+        if: steps.cfg.outputs.pr != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('gate-comment.md', 'utf8');
+            const marker = '<!-- bench-gate -->';
+            const pr = Number('${{ steps.cfg.outputs.pr }}');
+            const { data: comments } = await github.rest.issues.listComments(
+              { owner: context.repo.owner, repo: context.repo.repo, issue_number: pr });
+            const prev = comments.find((c) => c.body && c.body.includes(marker));
+            const full = `${marker}\n${body}`;
+            if (prev) {
+              await github.rest.issues.updateComment(
+                { owner: context.repo.owner, repo: context.repo.repo, comment_id: prev.id, body: full });
+            } else {
+              await github.rest.issues.createComment(
+                { owner: context.repo.owner, repo: context.repo.repo, issue_number: pr, body: full });
+            }
+
+      - name: Fallar si RED (bloquea merge)
+        run: |
+          EXIT="${{ steps.gate.outputs.verdict_exit }}"
+          if [ "$EXIT" = "2" ]; then
+            echo "::error::Bench Gate RED - regresion critica vs baseline. Ver el comentario del PR."
+            exit 1
+          elif [ "$EXIT" = "1" ]; then
+            echo "::warning::Bench Gate YELLOW (strict) - regresion menor."
+            exit 1
+          fi
+          echo "Bench Gate OK (GREEN o YELLOW no-estricto)."

--- a/bench/__tests__/gate.test.mjs
+++ b/bench/__tests__/gate.test.mjs
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyMetric,
+  regressionAmount,
+  metricVerdict,
+  diffRecords,
+  renderMarkdown,
+  GATE_RULES,
+} from '../gate.mjs';
+
+// Helper: registro v1 minimo.
+const rec = (metrics, extra = {}) => ({
+  schema: 1,
+  bench: 'agro-rotatorio',
+  date: '2026-07-18T00:00:00.000Z',
+  model: 'granite3.3:8b',
+  config: 'PROD',
+  commit: 'abc1234',
+  metrics,
+  ...extra,
+});
+
+describe('classifyMetric', () => {
+  it('mapea familias correctamente', () => {
+    expect(classifyMetric('accuracy')).toBe('accuracy');
+    expect(classifyMetric('pass_pct')).toBe('accuracy');
+    expect(classifyMetric('name_accuracy')).toBe('accuracy');
+    expect(classifyMetric('ah_pct')).toBe('hallucination');
+    expect(classifyMetric('hallucination_rate')).toBe('hallucination');
+    expect(classifyMetric('parse_rate')).toBe('parse');
+    expect(classifyMetric('latency_p95_ms')).toBe('latency');
+    expect(classifyMetric('cold_load_ms')).toBe('latency');
+    expect(classifyMetric('recall1_bm25')).toBe('other');
+  });
+});
+
+describe('regressionAmount', () => {
+  it('metrica up (accuracy): bajar = empeorar (positivo)', () => {
+    expect(regressionAmount('accuracy', 80, 74, 'pp')).toBeCloseTo(6);
+    expect(regressionAmount('accuracy', 80, 85, 'pp')).toBeCloseTo(-5); // mejoro
+  });
+  it('metrica down (ah_pct): subir = empeorar (positivo)', () => {
+    expect(regressionAmount('ah_pct', 10, 14, 'pp')).toBeCloseTo(4);
+    expect(regressionAmount('ah_pct', 10, 8, 'pp')).toBeCloseTo(-2); // mejoro
+  });
+  it('latency en porcentaje relativo', () => {
+    expect(regressionAmount('latency_p95_ms', 1000, 1300, 'pct')).toBeCloseTo(30);
+    expect(regressionAmount('latency_p95_ms', 1000, 900, 'pct')).toBeCloseTo(-10);
+  });
+  it('baseline 0 en pct: subir = Infinity, bajar = 0', () => {
+    expect(regressionAmount('latency_p95_ms', 0, 100, 'pct')).toBe(Infinity);
+    expect(regressionAmount('latency_p95_ms', 0, 0, 'pct')).toBe(0);
+  });
+});
+
+describe('metricVerdict - fronteras por familia', () => {
+  it('accuracy: RED > 5pp, YELLOW > 2pp, GREEN si no', () => {
+    expect(metricVerdict('accuracy', 80, 74).severity).toBe('red'); // -6
+    expect(metricVerdict('accuracy', 80, 77).severity).toBe('yellow'); // -3
+    expect(metricVerdict('accuracy', 80, 79).severity).toBe('green'); // -1
+    expect(metricVerdict('accuracy', 80, 90).severity).toBe('green'); // mejora
+  });
+  it('accuracy: exactamente en el umbral NO dispara (estricto >)', () => {
+    expect(metricVerdict('accuracy', 80, 75).severity).toBe('yellow'); // -5 exacto -> no RED, si YELLOW
+    expect(metricVerdict('accuracy', 80, 78).severity).toBe('green'); // -2 exacto -> no YELLOW
+  });
+  it('hallucination: RED > 3pp, YELLOW > 1pp', () => {
+    expect(metricVerdict('ah_pct', 10, 14).severity).toBe('red'); // +4
+    expect(metricVerdict('ah_pct', 10, 12).severity).toBe('yellow'); // +2
+    expect(metricVerdict('ah_pct', 10, 8).severity).toBe('green'); // mejora
+  });
+  it('parse_rate: RED > 2pp, YELLOW > 1pp', () => {
+    expect(metricVerdict('parse_rate', 100, 97).severity).toBe('red'); // -3
+    expect(metricVerdict('parse_rate', 100, 98.5).severity).toBe('yellow'); // -1.5
+    expect(metricVerdict('parse_rate', 100, 100).severity).toBe('green');
+  });
+  it('latency: RED > 25%, YELLOW > 10%', () => {
+    expect(metricVerdict('latency_p95_ms', 1000, 1300).severity).toBe('red'); // +30%
+    expect(metricVerdict('latency_p95_ms', 1000, 1150).severity).toBe('yellow'); // +15%
+    expect(metricVerdict('latency_p95_ms', 1000, 900).severity).toBe('green'); // mejora
+  });
+  it('metrica "other" no vota (info)', () => {
+    expect(metricVerdict('recall1_bm25', 14, 10).severity).toBe('info');
+  });
+});
+
+describe('diffRecords - veredicto global', () => {
+  it('GREEN cuando todo mejora o estable', () => {
+    const d = diffRecords(
+      rec({ accuracy: 80, ah_pct: 10, latency_p95_ms: 1000 }),
+      rec({ accuracy: 82, ah_pct: 9, latency_p95_ms: 950 }),
+    );
+    expect(d.verdict).toBe('GREEN');
+    expect(d.blockers).toHaveLength(0);
+  });
+  it('RED si UNA metrica cruza su umbral critico', () => {
+    const d = diffRecords(
+      rec({ accuracy: 80, ah_pct: 10 }),
+      rec({ accuracy: 82, ah_pct: 14 }), // ah_pct +4 -> RED
+    );
+    expect(d.verdict).toBe('RED');
+    expect(d.blockers.map((b) => b.name)).toContain('ah_pct');
+  });
+  it('YELLOW si hay regresion menor pero ninguna critica', () => {
+    const d = diffRecords(
+      rec({ accuracy: 80, ah_pct: 10 }),
+      rec({ accuracy: 77, ah_pct: 10 }), // -3 accuracy -> YELLOW
+    );
+    expect(d.verdict).toBe('YELLOW');
+    expect(d.warnings.map((w) => w.name)).toContain('accuracy');
+  });
+  it('el peor gana: YELLOW + RED = RED', () => {
+    const d = diffRecords(
+      rec({ accuracy: 80, parse_rate: 100 }),
+      rec({ accuracy: 77, parse_rate: 96 }), // accuracy -3 (Y), parse -4 (R)
+    );
+    expect(d.verdict).toBe('RED');
+  });
+  it('metricas sin par van a unmatched, no votan', () => {
+    const d = diffRecords(
+      rec({ accuracy: 80 }),
+      rec({ accuracy: 82, nueva_metrica: 5 }),
+    );
+    expect(d.verdict).toBe('GREEN');
+    expect(d.unmatched.map((u) => u.name)).toContain('nueva_metrica');
+  });
+  it('anota advertencia si la config es cruda (no producto)', () => {
+    const d = diffRecords(
+      rec({ accuracy: 80 }, { config: 'A' }),
+      rec({ accuracy: 82 }, { config: 'A' }),
+    );
+    expect(d.notes.join(' ')).toMatch(/crud/i);
+  });
+  it('lanza si falta metrics', () => {
+    expect(() => diffRecords({ bench: 'x' }, rec({ accuracy: 1 }))).toThrow();
+  });
+});
+
+describe('renderMarkdown', () => {
+  it('incluye el tag del veredicto y la tabla', () => {
+    const d = diffRecords(
+      rec({ accuracy: 80, ah_pct: 10 }),
+      rec({ accuracy: 74, ah_pct: 10 }),
+    );
+    const md = renderMarkdown(d, { bench: 'agro-rotatorio', model: 'granite3.3:8b' });
+    expect(md).toContain('[RED]');
+    expect(md).toContain('| Metrica | Familia |');
+    expect(md).toContain('accuracy');
+    expect(md).toContain('Bloqueadores');
+  });
+  it('sin emojis (ASCII only, restriccion del repo)', () => {
+    const d = diffRecords(rec({ accuracy: 80 }), rec({ accuracy: 82 }));
+    const md = renderMarkdown(d, { bench: 'x' });
+    expect(/[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}]/u.test(md)).toBe(false);
+  });
+});

--- a/bench/baseline/README.md
+++ b/bench/baseline/README.md
@@ -1,0 +1,37 @@
+# bench/baseline — referencias known-good del Bench Gate
+
+Cada archivo `<bench>.json` es un registro de historial v1 (mismo esquema que
+`bench/history/`, ver `bench/lib/history.mjs`) que representa el **nivel de
+calidad aceptado en produccion** para ese bench. `bench/gate.mjs` compara la
+corrida fresca de un PR contra este baseline y emite GREEN / YELLOW / RED segun
+los umbrales de `Chagra-strategy/ops/BENCH_GATE_PIPELINE.md` §2:
+
+- accuracy cae > 5pp -> RED (> 2pp -> YELLOW)
+- hallucination sube > 3pp -> RED (> 1pp -> YELLOW)
+- parse_rate cae > 2pp -> RED (> 1pp -> YELLOW)
+- latency sube > 25% -> RED (> 10% -> YELLOW)
+
+## Baselines actuales
+
+| bench | config | referencia | notas |
+|---|---|---|---|
+| `borde-alucinacion` | PROD | granite3.3:8b, ah_pct 16 / pass_pct 84 | AH sellado (decision granite3.3, N=69). El bench de producto mas riguroso; pesado (GPU + claude-cli + fixtures-privadas). |
+| `agro-rotatorio` | daily-rotating | granite3.3:8b | Drift diario base-variedad + alucinacion; corpus (sin GPU) -> default del gate. |
+
+## Como actualizar un baseline
+
+Cuando el operador acepta un nuevo nivel de calidad en produccion (ej. tras
+mergear una mejora que el gate marco GREEN), se promueve la corrida nueva a
+baseline:
+
+```bash
+# 1) correr el bench de producto (config-PROD, NUNCA el modelo crudo)
+node bench/run.mjs borde-alucinacion
+# 2) promover la corrida mas reciente a baseline
+cp "$(ls -t bench/history/borde-alucinacion__*.json | head -1)" bench/baseline/borde-alucinacion.json
+# 3) commitear el baseline nuevo con la justificacion en el mensaje
+```
+
+REGLA DURA: el baseline SIEMPRE sale de un bench de PRODUCTO (con tools/RAG/
+sidecar), nunca del modelo crudo (`eval_completo.py` / config A). El bench crudo
+da veredictos opuestos y no representa lo que ve el usuario.

--- a/bench/baseline/agro-rotatorio.json
+++ b/bench/baseline/agro-rotatorio.json
@@ -1,0 +1,21 @@
+{
+  "schema": 1,
+  "bench": "agro-rotatorio",
+  "date": "2026-06-17T15:57:35.257Z",
+  "model": "granite3.3:8b",
+  "config": "daily-rotating",
+  "commit": "c0fbb14",
+  "metrics": {
+    "graph_consistency_pct": 26,
+    "grounded_pct": 44,
+    "hallucinations": 0,
+    "subspecies_disconnections": 256,
+    "subspecies_ok_pct": 92,
+    "score_global": 45.5
+  },
+  "passCount": 22,
+  "failCount": 256,
+  "passPct": 7.9,
+  "notes": "seed=2026-06-17 | graph_source=catalog-fallback | Para fidelidad total use sidecar con token y AGE disponible via CHAGRA_KG_* o CHAGRA_KG_PSQL_CMD.",
+  "seed": false
+}

--- a/bench/baseline/borde-alucinacion.json
+++ b/bench/baseline/borde-alucinacion.json
@@ -1,0 +1,17 @@
+{
+  "schema": 1,
+  "bench": "borde-alucinacion",
+  "date": "2026-06-14T08:00:00.000Z",
+  "model": "granite3.3:8b",
+  "config": "PROD",
+  "commit": "fe9ea44",
+  "metrics": {
+    "ah_pct": 16,
+    "pass_pct": 84
+  },
+  "passCount": 23,
+  "failCount": 4,
+  "passPct": 84,
+  "notes": "registro semilla de ejemplo (reingenieria 2026-06-15) — reemplazar con corridas reales",
+  "seed": true
+}

--- a/bench/gate.mjs
+++ b/bench/gate.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/**
+ * bench/gate.mjs - el GATE del bench-gate CI (BENCH_GATE_PIPELINE.md §2/§6).
+ *
+ * Compara dos registros de historial v1 (baseline vs current, mismo bench) y
+ * emite un veredicto GREEN / YELLOW / RED segun los umbrales del spec (§2 [3]):
+ *   - accuracy      cae  > 5pp  -> RED   (> 2pp -> YELLOW)
+ *   - hallucination sube > 3pp  -> RED   (> 1pp -> YELLOW)
+ *   - parse_rate    cae  > 2pp  -> RED   (> 1pp -> YELLOW)
+ *   - latency       sube > 25%  -> RED   (> 10% -> YELLOW)
+ * GREEN = sin regresion (o mejora). YELLOW = regresion menor (polish antes de
+ * merge). RED = regresion critica (revert / no mergear).
+ *
+ * POR QUE history v1 y no el summary.md: los summary.md label-row que parseaba
+ * `scripts/bench-summary-diff.mjs` ya NO los emite ningun bench (verificado
+ * 2026-07-18: 0 archivos con ese formato). La ruta VIVA es el registro
+ * estandarizado v1 (`bench/lib/history.mjs`) que emiten model-compare,
+ * agro-rotatorio, rag-retrieve, borde-alucinacion, etc. Este gate reusa
+ * METRIC_DIRECTION de ese modulo (fuente unica de "mas alto/bajo mejor").
+ *
+ * REGLA DURA DEL PLAN: el gate debe correr sobre el bench de PRODUCTO (config
+ * con tools/RAG/sidecar), NUNCA el modelo crudo. Este script solo compara los
+ * registros que recibe; la eleccion del bench correcto vive en el workflow. Si
+ * un registro trae config cruda conocida (A / crudo / raw), se anota advertencia.
+ *
+ * Uso:
+ *   node bench/gate.mjs --current <run.json> --baseline <base.json>
+ *   node bench/gate.mjs --bench <id> [--baseline-dir bench/baseline] [--history-dir bench/history]
+ *   Flags: --strict (YELLOW tambien bloquea) · --json · --md-out <path>
+ *
+ * Salida: tabla markdown + "GATE: GREEN|YELLOW|RED". Exit: 0 GREEN · 0 YELLOW
+ *         (1 si --strict) · 2 RED · 3 error de uso/datos.
+ *
+ * @module bench/gate
+ */
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { METRIC_DIRECTION } from './lib/history.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Reglas del gate por FAMILIA de metrica. `red`/`yellow`: pp para
+ * accuracy/hallucination/parse, porcentaje relativo para latency. Fuente unica
+ * de tuning del gate.
+ */
+export const GATE_RULES = {
+  accuracy: { unit: 'pp', red: 5, yellow: 2 },
+  hallucination: { unit: 'pp', red: 3, yellow: 1 },
+  parse: { unit: 'pp', red: 2, yellow: 1 },
+  latency: { unit: 'pct', red: 25, yellow: 10 },
+};
+
+/** Configs conocidas como "modelo crudo" (NO valen para decidir prod). */
+const RAW_CONFIGS = new Set(['A', 'crudo', 'raw', 'base', 'screening']);
+
+const ACCURACY_METRICS = new Set([
+  'accuracy', 'pass_pct', 'name_accuracy', 'sci_accuracy', 'verified_rate',
+  'validation_rate', 'keywords_pct', 'graph_consistency_pct', 'grounded_pct',
+  'subspecies_ok_pct', 'score_global', 'factualidad', 'promedio',
+  'normalized_score', 'lift_pp',
+]);
+const HALLUC_METRICS = new Set([
+  'ah_pct', 'hallucination_rate', 'hallucinations', 'rejection_rate',
+  'subspecies_disconnections',
+]);
+
+/**
+ * classifyMetric - mapea un nombre de metrica v1 a su familia de gate.
+ * @param {string} name
+ * @returns {'accuracy'|'hallucination'|'parse'|'latency'|'other'}
+ */
+export function classifyMetric(name) {
+  const n = String(name).toLowerCase();
+  if (n === 'parse_rate') return 'parse';
+  if (ACCURACY_METRICS.has(n)) return 'accuracy';
+  if (HALLUC_METRICS.has(n)) return 'hallucination';
+  if (n.startsWith('latency_') || n.endsWith('_ms') || n === 'cold_load_ms') return 'latency';
+  return 'other';
+}
+
+/**
+ * regressionAmount - cuanto EMPEORO una metrica (baseline -> current), en la
+ * unidad de la familia. Positivo = empeoro; <=0 = mejoro/igual. La direccion
+ * (mas alto/bajo mejor) sale de METRIC_DIRECTION (o inferida por familia).
+ *
+ * @param {string} name
+ * @param {number} baseline
+ * @param {number} current
+ * @param {'pp'|'pct'} unit
+ * @returns {number}
+ */
+export function regressionAmount(name, baseline, current, unit) {
+  const dir = METRIC_DIRECTION[name] || (classifyMetric(name) === 'latency' ? 'down' : 'up');
+  const worse = dir === 'up' ? baseline - current : current - baseline;
+  if (unit === 'pct') {
+    if (baseline === 0) return worse > 0 ? Infinity : 0;
+    return (worse / Math.abs(baseline)) * 100;
+  }
+  return worse;
+}
+
+/**
+ * metricVerdict - severidad de UNA metrica comparando baseline vs current.
+ * @returns {{name, family, baseline, current, delta, regression, unit, severity}}
+ */
+export function metricVerdict(name, baseline, current, rules = GATE_RULES) {
+  const family = classifyMetric(name);
+  const delta = Number((current - baseline).toFixed(3));
+  if (family === 'other') {
+    return { name, family, baseline, current, delta, regression: null, unit: null, severity: 'info' };
+  }
+  const rule = rules[family];
+  const regression = Number(regressionAmount(name, baseline, current, rule.unit).toFixed(3));
+  let severity = 'green';
+  if (regression > rule.red) severity = 'red';
+  else if (regression > rule.yellow) severity = 'yellow';
+  return { name, family, baseline, current, delta, regression, unit: rule.unit, severity };
+}
+
+const SEVERITY_RANK = { green: 0, info: 0, yellow: 1, red: 2 };
+
+/**
+ * diffRecords - compara dos registros v1 y produce el veredicto global. Solo
+ * las metricas presentes en AMBOS votan; las solo-en-uno van a `unmatched`.
+ *
+ * @param {object} baseline
+ * @param {object} current
+ * @param {object} [rules=GATE_RULES]
+ * @returns {{verdict, metrics, blockers, warnings, unmatched, notes}}
+ */
+export function diffRecords(baseline, current, rules = GATE_RULES) {
+  if (!baseline?.metrics || !current?.metrics) {
+    throw new Error('diffRecords: ambos registros necesitan `metrics`.');
+  }
+  const notes = [];
+  if (baseline.bench && current.bench && baseline.bench !== current.bench) {
+    notes.push(`ADVERTENCIA: bench distinto (baseline=${baseline.bench} vs current=${current.bench}).`);
+  }
+  if (RAW_CONFIGS.has(String(current.config)) || RAW_CONFIGS.has(String(baseline.config))) {
+    notes.push(`ADVERTENCIA: config cruda (${baseline.config}/${current.config}) - el gate exige bench de PRODUCTO (tools/RAG), no crudo.`);
+  }
+
+  const bm = baseline.metrics;
+  const cm = current.metrics;
+  const metrics = [];
+  const unmatched = [];
+  for (const name of Object.keys(cm)) {
+    if (!Number.isFinite(cm[name])) continue;
+    if (!Number.isFinite(bm[name])) { unmatched.push({ name, current: cm[name], where: 'solo-current' }); continue; }
+    metrics.push(metricVerdict(name, bm[name], cm[name], rules));
+  }
+  for (const name of Object.keys(bm)) {
+    if (Number.isFinite(bm[name]) && !Number.isFinite(cm[name])) {
+      unmatched.push({ name, baseline: bm[name], where: 'solo-baseline' });
+    }
+  }
+
+  const worst = metrics.reduce((acc, m) => Math.max(acc, SEVERITY_RANK[m.severity] ?? 0), 0);
+  const verdict = worst >= 2 ? 'RED' : worst >= 1 ? 'YELLOW' : 'GREEN';
+  return {
+    verdict,
+    metrics,
+    blockers: metrics.filter((m) => m.severity === 'red'),
+    warnings: metrics.filter((m) => m.severity === 'yellow'),
+    unmatched,
+    notes,
+  };
+}
+
+/**
+ * renderMarkdown - tabla comentable en el PR. ASCII only (sin emojis, restriccion
+ * del repo).
+ * @param {object} diff  salida de diffRecords.
+ * @param {object} [meta]
+ * @returns {string}
+ */
+export function renderMarkdown(diff, meta = {}) {
+  const tag = { GREEN: '[GREEN]', YELLOW: '[YELLOW]', RED: '[RED]' }[diff.verdict];
+  const lines = [`## Bench Gate: ${tag}`];
+  if (meta.bench) lines.push(`Bench: \`${meta.bench}\`${meta.model ? ` - modelo \`${meta.model}\`` : ''}`);
+  if (meta.baselineCommit || meta.currentCommit) {
+    lines.push(`Baseline \`${meta.baselineCommit || '?'}\` -> Current \`${meta.currentCommit || '?'}\``);
+  }
+  lines.push('', '| Metrica | Familia | Baseline | Current | Delta | Estado |', '|---|---|--:|--:|--:|---|');
+  const rank = (m) => (m.severity === 'red' ? 0 : m.severity === 'yellow' ? 1 : m.severity === 'info' ? 3 : 2);
+  for (const m of [...diff.metrics].sort((a, b) => rank(a) - rank(b) || a.name.localeCompare(b.name))) {
+    const sd = m.delta > 0 ? `+${m.delta}` : `${m.delta}`;
+    const st = { red: 'RED', yellow: 'YELLOW', green: 'ok', info: 'info' }[m.severity];
+    lines.push(`| ${m.name} | ${m.family} | ${m.baseline} | ${m.current} | ${sd} | ${st} |`);
+  }
+  if (diff.blockers.length) {
+    lines.push('', '**Bloqueadores (RED):**');
+    for (const b of diff.blockers) {
+      const u = b.unit === 'pct' ? '%' : 'pp';
+      lines.push(`- \`${b.name}\` empeoro ${b.regression}${u} (umbral RED ${GATE_RULES[b.family].red}${u}).`);
+    }
+  }
+  if (diff.unmatched.length) {
+    lines.push('', `_Metricas sin par: ${diff.unmatched.map((u) => u.name).join(', ')}._`);
+  }
+  for (const n of diff.notes) lines.push(`\n> ${n}`);
+  return lines.join('\n');
+}
+
+// --------------------------------------------------------------------------
+// CLI
+// --------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const a = { strict: false, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--strict') a.strict = true;
+    else if (k === '--json') a.json = true;
+    else if (k === '--current') a.current = argv[++i];
+    else if (k === '--baseline') a.baseline = argv[++i];
+    else if (k === '--bench') a.bench = argv[++i];
+    else if (k === '--baseline-dir') a.baselineDir = argv[++i];
+    else if (k === '--history-dir') a.historyDir = argv[++i];
+    else if (k === '--md-out') a.mdOut = argv[++i];
+  }
+  return a;
+}
+
+/** latestInDir - registro mas reciente para un bench dentro de un directorio. */
+export function latestInDir(dir, bench) {
+  if (!existsSync(dir)) return null;
+  const recs = [];
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith('.json')) continue;
+    try {
+      const r = JSON.parse(readFileSync(join(dir, f), 'utf-8'));
+      if (r?.bench === bench && r.date) recs.push(r);
+    } catch { /* saltar basura */ }
+  }
+  recs.sort((a, b) => String(b.date).localeCompare(String(a.date)));
+  return recs[0] || null;
+}
+
+function main() {
+  const a = parseArgs(process.argv.slice(2));
+  let baseline;
+  let current;
+  if (a.current && a.baseline) {
+    current = JSON.parse(readFileSync(a.current, 'utf-8'));
+    baseline = JSON.parse(readFileSync(a.baseline, 'utf-8'));
+  } else if (a.bench) {
+    const baseDir = a.baselineDir || join(__dirname, 'baseline');
+    const histDir = a.historyDir || join(__dirname, 'history');
+    baseline = latestInDir(baseDir, a.bench);
+    current = latestInDir(histDir, a.bench);
+    if (!baseline) { console.error(`No hay baseline para "${a.bench}" en ${baseDir}`); process.exit(3); }
+    if (!current) { console.error(`No hay corrida current para "${a.bench}" en ${histDir}`); process.exit(3); }
+  } else {
+    console.error('Uso: --current <f> --baseline <f>  |  --bench <id> [--baseline-dir d] [--history-dir d]');
+    process.exit(3);
+  }
+
+  const diff = diffRecords(baseline, current);
+  const meta = {
+    bench: current.bench || baseline.bench,
+    model: current.model,
+    baselineCommit: baseline.commit,
+    currentCommit: current.commit,
+  };
+  const md = renderMarkdown(diff, meta);
+  if (a.mdOut) writeFileSync(a.mdOut, `${md}\n`, 'utf-8');
+  if (a.json) {
+    console.log(JSON.stringify({ verdict: diff.verdict, blockers: diff.blockers, warnings: diff.warnings, notes: diff.notes }, null, 2));
+  } else {
+    console.log(md);
+    console.log(`\nGATE: ${diff.verdict}`);
+  }
+  if (diff.verdict === 'RED') process.exit(2);
+  if (diff.verdict === 'YELLOW' && a.strict) process.exit(1);
+  process.exit(0);
+}
+
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (invokedDirectly) main();


### PR DESCRIPTION
## Contexto

`BENCH_GATE_PIPELINE.md` §6 define un bench-gate (GREEN/YELLOW/RED vs baseline) pero lo deja como **gate manual, "pendiente diseño post-MVP"**. Al revisar el estado real encontré el patrón que la reingeniería combate:

- `scripts/bench-summary-diff.mjs` **ya existía** (595 líneas) pero (a) parsea un `summary.md` label-row que **ningún bench emite ya** (verificado: 0 archivos con ese formato) y (b) **no estaba cableado** a ningún workflow ni tenía tests. Construido-no-cableado, sobre un formato muerto.

Este PR cablea el gate sobre la ruta **viva y estructurada**: los registros `history v1` (`bench/lib/history.mjs`) que sí emiten `model-compare`, `agro-rotatorio`, `rag-retrieve`, `borde-alucinacion`, etc.

## Qué agrega

- **`bench/gate.mjs`** — compara dos registros v1 (baseline vs corrida del PR) → GREEN/YELLOW/RED con los umbrales del spec (accuracy −5pp, halluc +3pp, parse −2pp, latency +25%). Reusa `METRIC_DIRECTION` (fuente única de "más alto/bajo mejor"). Advierte si la config es cruda (el gate exige bench de **PRODUCTO** con tools/RAG, nunca el modelo crudo — regla dura del plan).
- **`bench/__tests__/gate.test.mjs`** — 20 tests (fronteras por familia, veredicto global, unmatched, config-cruda, render ASCII).
- **`.github/workflows/bench-gate.yml`** — opt-in por label `bench-required` (protege la GPU M6000 de producción; correrlo en cada PR tumbaría el agente), runner `self-hosted alpha`, concurrency serializada. Corre el bench de producto → gate vs baseline → comenta tabla delta en el PR (sticky) → **bloquea merge si RED**.
- **`bench/baseline/`** — baselines known-good de `borde-alucinacion` (AH sellado PROD: ah_pct 16 / pass_pct 84) y `agro-rotatorio` (default, corpus sin GPU) + README de cómo promover un baseline nuevo.

## Verificado

- `gate.test.mjs`: 20/20.
- eslint (max-warnings=0): limpio.
- End-to-end real: `node bench/gate.mjs --bench borde-alucinacion` comparó baseline (ah 22/pass 78) vs corrida (ah 16/pass 84) → **GREEN**.

## Notas

- El `scripts/bench-summary-diff.mjs` viejo (markdown, sin inputs) queda como está; se puede deprecar en un follow-up.
- Los 3 scripts que el spec marca "❌ falta" (cache-hit/streaming/routing) son de optimizaciones que aún no existen (D3/SPEED-1/SPEED-3) → fuera de scope.