### PR TITLE
fix(bench): el gate no debe tratar conteos crudos como porcentajes

### DIFF
--- a/bench/__tests__/gate.test.mjs
+++ b/bench/__tests__/gate.test.mjs
@@ -32,6 +32,15 @@ describe('classifyMetric', () => {
     expect(classifyMetric('cold_load_ms')).toBe('latency');
     expect(classifyMetric('recall1_bm25')).toBe('other');
   });
+  it('los CONTEOS crudos NO son familia hallucination (no llevan umbral pp)', () => {
+    // Bug 2026-07-18: subspecies_disconnections (256) tratado como % daba
+    // "+212pp" -> RED falso. Los conteos caen a 'other' (info, no votan).
+    expect(classifyMetric('subspecies_disconnections')).toBe('other');
+    expect(classifyMetric('hallucinations')).toBe('other');
+    // las TASAS si son gate real:
+    expect(classifyMetric('ah_pct')).toBe('hallucination');
+    expect(classifyMetric('hallucination_rate')).toBe('hallucination');
+  });
 });
 
 describe('regressionAmount', () => {
@@ -123,6 +132,15 @@ describe('diffRecords - veredicto global', () => {
     );
     expect(d.verdict).toBe('GREEN');
     expect(d.unmatched.map((u) => u.name)).toContain('nueva_metrica');
+  });
+  it('un salto grande de CONTEO no bloquea (info-only, reproduce el bug 2026-07-18)', () => {
+    const d = diffRecords(
+      rec({ ah_pct: 10, subspecies_disconnections: 256 }),
+      rec({ ah_pct: 10, subspecies_disconnections: 468 }), // +212 en conteo
+    );
+    expect(d.verdict).toBe('GREEN'); // antes daba RED por "+212pp"
+    expect(d.blockers).toHaveLength(0);
+    expect(d.metrics.find((m) => m.name === 'subspecies_disconnections').severity).toBe('info');
   });
   it('anota advertencia si la config es cruda (no producto)', () => {
     const d = diffRecords(

--- a/bench/gate.mjs
+++ b/bench/gate.mjs
@@ -61,9 +61,14 @@ const ACCURACY_METRICS = new Set([
   'subspecies_ok_pct', 'score_global', 'factualidad', 'promedio',
   'normalized_score', 'lift_pp',
 ]);
+// SOLO tasas/porcentajes (0-100). Los CONTEOS crudos (hallucinations,
+// subspecies_disconnections) NO van aca: aplicarles un umbral en pp es un bug
+// -- un conteo 256->468 es +82% relativo, no "+212pp". Caen a 'other' (info):
+// se reportan pero NO votan, para que un gate que BLOQUEA merges no de
+// falsos-RED por la varianza natural de un conteo. El gate vota sobre las TASAS
+// (ah_pct / hallucination_rate / rejection_rate), que es lo que el spec define.
 const HALLUC_METRICS = new Set([
-  'ah_pct', 'hallucination_rate', 'hallucinations', 'rejection_rate',
-  'subspecies_disconnections',
+  'ah_pct', 'hallucination_rate', 'rejection_rate',
 ]);
 
 /**


### PR DESCRIPTION
Follow-up de #2580 (bench-gate CI). **El propio run del gate cazó el bug:** `subspecies_disconnections` (un conteo, 256) caía en la familia `hallucination` con umbral en pp, así que 256→468 se reportaba como `+212pp` → **RED falso**.

Los conteos crudos no son porcentajes. Fix: sacar `hallucinations` y `subspecies_disconnections` de `HALLUC_METRICS` → caen a `other` (info: se reportan pero **no votan**), para que un gate que bloquea merges no dé falsos-RED por la varianza natural de un conteo. El gate sigue votando sobre las **tasas** (`ah_pct`/`hallucination_rate`/`rejection_rate`) que es lo que el spec define.

+2 tests (22/22): clasificación de conteos + un salto grande de conteo no bloquea (reproduce el bug). eslint limpio.