### PR TITLE
art(angelita): entrada/salida con squash&stretch (rh-entra/rh-sale)

### DIFF
--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -122,6 +122,19 @@ export function AbejaAngelita({
      'vivas' (con eyebrow-flash al hablar) | 'fruncidas' (concentrada). El
      agente las deriva por estado; cualquier host puede pedirlas directo. */
   cejas = null,
+  /* ── ENTRADA / SALIDA de escena (squash-&-stretch, rh-entra/rh-sale) ───────
+     El pop COTIDIANO (no el número teatral de AngelitaEntrada): aparecer en un
+     diálogo, un panel, una percha — y, sobre todo, DESPEDIRSE (la salida no
+     existía en ningún lado). One-shot con anticipación + overshoot elástico:
+       entrando → brota de la nada: se aplasta cogiendo impulso, estira al
+                  salir, rebasa, rebota y asienta en identidad (0.9s, se queda).
+       saliendo → el reverso: se agacha (anticipación), estira al despegar y
+                  se esfuma chiquita hacia arriba (0.62s; el host desmonta
+                  después, ~0.65s). Si ambos llegan true, gana entrando.
+     Default false ambos → cero cambio para consumidores. Con animated=false o
+     reduced-motion no hay teatro: aparece/desaparece en fotograma digno. */
+  entrando = false,
+  saliendo = false,
   ...rest
 }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
@@ -315,7 +328,14 @@ export function AbejaAngelita({
   // El line-boil (contorno que hierve) envuelve TODO el dibujo cuando se pide:
   // el feDisplacementMap desplaza el trazo entero (Cuphead). Grupo aparte para
   // no colisionar con el glow del `.crt-body` (dos filtros, nodos distintos).
-  const cuerpoVivo = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
+  const conBoil = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
+  // ENTRADA/SALIDA (rh-entra/rh-sale): wrapper EXTERNO a todo (antic, boil,
+  // line-boil) — su transform one-shot no pisa ninguna capa del idle. Solo se
+  // monta cuando hace falta y cuando la creature está viva (animated); con
+  // animated=false no hay teatro y el CSS de RM lo congela por su lado.
+  const cuerpoVivo = (vivo && (entrando || saliendo)) ? (
+    <g className={entrando ? 'rh-entra' : 'rh-sale'}>{conBoil}</g>
+  ) : conBoil;
 
   // data-estado agrupa la reacción para el CSS (brillo mojado, jadeo, mordisco).
   // data-pose SOLO cuando está viva: así los gestos (celebra/reposo/señala) no

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -399,8 +399,45 @@
   50%      { transform: scaleX(1.3) skewX(-6deg); }
 }
 
+/* ENTRADA / SALIDA de escena con squash-&-stretch (12 principios) — el POP
+   cotidiano species-agnostic del KIT: aparecer/desaparecer de un diálogo, un
+   panel, una percha. One-shot con `both` (rh-entra termina en identidad y ahí
+   se queda; rh-sale termina invisible — el host desmonta después, ~0.65s).
+   NO compite con la ENTRADA TEATRAL de Angelita (.ang-entrada, el número
+   heroico con gafas y aro): esto es el gesto barato de todos los días.
+   Va en un wrapper EXTERNO al antic/boil: capas de transform que no se pisan. */
+.rh-entra {
+  transform-box: fill-box;
+  transform-origin: center;
+  will-change: transform, opacity;
+  animation: rh-entra 0.9s cubic-bezier(0.36, 1.4, 0.5, 1) both;
+}
+@keyframes rh-entra {
+  0%   { transform: scale(0.001); opacity: 0; }
+  18%  { transform: translateY(1.5px) scale(0.3, 0.12); opacity: 1; }  /* anticipación: aplastada, coge impulso */
+  40%  { transform: translateY(-1.2px) scale(0.72, 1.35); }            /* ¡el estirón al brotar! */
+  62%  { transform: translateY(0.3px) scale(1.16, 0.86); }             /* overshoot squash */
+  78%  { transform: scale(0.94, 1.07); }                               /* rebote elástico */
+  90%  { transform: scale(1.03, 0.98); }
+  100% { transform: scale(1); }                                        /* asentada */
+}
+.rh-sale {
+  transform-box: fill-box;
+  transform-origin: center;
+  will-change: transform, opacity;
+  animation: rh-sale 0.62s cubic-bezier(0.5, 0, 0.75, 0.4) both;
+}
+@keyframes rh-sale {
+  0%   { transform: scale(1); opacity: 1; }
+  22%  { transform: translateY(1.2px) scale(1.14, 0.8); }    /* anticipación: se agacha */
+  42%  { transform: translateY(-2px) scale(0.8, 1.3); }      /* ¡estira al despegar! */
+  70%  { transform: translateY(-3.5px) scale(0.4, 0.62); opacity: 1; }
+  100% { transform: translateY(-5px) scale(0.001); opacity: 0; }  /* se esfumó */
+}
+
 /* device-tier 'bajo': corta lo continuo (ahorro gama baja). Los estados
-   reactivos siguen (feedback importante) por su mayor especificidad. */
+   reactivos siguen (feedback importante) por su mayor especificidad.
+   rh-entra/rh-sale QUEDAN: son one-shot baratos y son feedback de presencia. */
 [data-tier='bajo'] .rh-boil,
 [data-tier='bajo'] .rh-sway,
 [data-tier='bajo'] .rh-antic,
@@ -415,7 +452,10 @@
      (bracitos colgando, cuerpo neutro, sonriendo). */
   [data-pose='celebra'] .crt-body, [data-pose='celebra'] .crt-brazo-l, [data-pose='celebra'] .crt-brazo-r,
   [data-pose='reposo'] .crt-body,
-  [data-pose='señala'] .crt-body, [data-pose='señala'] .crt-brazo-r { animation: none !important; }
+  [data-pose='señala'] .crt-body, [data-pose='señala'] .crt-brazo-r,
+  /* Entrada/salida sin teatro: aparece YA (identidad) / se va YA (abajo). */
+  .rh-entra, .rh-sale { animation: none !important; }
+  .rh-sale { opacity: 0; }  /* saliendo bajo RM = ya no está (el host desmonta) */
 }
 
 /* ── REACCIÓN AL ESTADO REAL DE LA FINCA (auditoría §5b) ──────────────────────


### PR DESCRIPTION
## Hallazgo primero (importante para el que cablea)

La tarea pedía subir a Angelita al nivel Miss-Minutes (visemas, cejas, parpadeo, estados, entrada/salida). Al auditar la base `integra/todo-3d-a-prod` resultó que **casi todo YA existe aquí, y mejor hecho**:

- **Visemas**: `BocaVisema` (V1..V4) en `_rubberhose.jsx` + `useLipSync` (RMS del TTS, con `visemaFallback` sin audio — nunca queda muda). Prop `visema` en `AbejaAngelita`.
- **Cejas**: `CejasRubber` ('alegres'|'altas'|'vivas'|'fruncidas') + `CEJAS_DE_ESTADO` derivadas por estado.
- **Parpadeo**: `rh-blink` irregular (blink + blink-blink) de siempre.
- **Estados legibles**: `src/visual/agente/Angelita.jsx` con 10 estados canónicos (`angelitaEstados.js`): escuchando (se posa y ladea, ondas), pensando (burbuja con recuerdos + manita al mentón), respondiendo (visemas + gesticula), preocupada/alerta (aro + sudor), contenta/celebra, husmea, señala, invita, no-sé.
- **Entrada teatral**: `AngelitaEntrada.jsx` (asoma → gafas si hay sol → crece con overshoot + aro).

**Lo ÚNICO que no existía en ningún archivo: la SALIDA.** Y un pop de entrada barato species-level para hosts que no montan el número teatral completo.

## Qué agrega este PR (aditivo, 2 archivos, 63 líneas)

- `creatures.css`: keyframes one-shot `rh-entra` (anticipación aplastada → estirón → overshoot → rebote → asentada, 0.9s) y `rh-sale` (se agacha → estira al despegar → se esfuma hacia arriba, 0.62s). Species-agnostic en el KIT: cualquier bicho rubber-hose lo hereda. RM = sin teatro (fotograma digno); tier bajo lo conserva (one-shot barato).
- `AbejaAngelita.jsx`: props `entrando` / `saliendo` (default `false` → cero cambio para consumidores). Wrapper EXTERNO a antic/boil/line-boil — no pisa ninguna capa del idle. Solo con `animated`.

## Para cablear CompaneroAbeja

- Estados de compañera: montar `<Angelita estado='escuchando'|'pensando'|'respondiendo'|'contenta'|'preocupada'|...>` (acepta alias: 'hablando', 'alerta', 'celebra'). NO recablear `AbejaAngelita` cruda.
- Boca al hablar: `useLipSync` → prop `visema`; el agente ya lo hace solo.
- Despedida: `saliendo={true}` y desmontar a los ~650ms.

Verificado: transform oxc + lightningcss limpios sobre ambos archivos; cero colisiones de nombres `rh-entra`/`rh-sale` en el repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)