### PR TITLE
fix(agente): buildFallbackResponse chequeaba shapes de tools stale (nunca extraía datos)

### DIFF
--- a/src/services/__tests__/buildFallbackResponse.test.js
+++ b/src/services/__tests__/buildFallbackResponse.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { buildFallbackResponse } from '../agentService';
+
+// Shapes de tools VERIFICADAS contra el sidecar 2026-07-18. Antes buildFallbackResponse
+// chequeaba species_name/controls/recipes (stale) → nunca hacía match y todo caía en
+// el genérico "obtuve información útil". Estos tests fijan las shapes reales.
+const ev = (tool, result) => ({ tool, result });
+
+describe('buildFallbackResponse', () => {
+  it('passthrough: si el LLM respondió, devuelve su texto tal cual', () => {
+    expect(buildFallbackResponse('respuesta real del LLM', null)).toBe('respuesta real del LLM');
+  });
+
+  it('get_species: extrae el nombre desde result.species (no species_name)', () => {
+    const out = buildFallbackResponse('', ev('get_species', { found: true, species: { nombre_comun: 'Papa parda', viabilidad: 'viable' } }));
+    expect(out).toContain('Papa parda');
+    expect(out).toContain('viable');
+  });
+
+  it('get_pest_controllers: cuenta desde matches_count (no controls)', () => {
+    const out = buildFallbackResponse('', ev('get_pest_controllers', { matches_count: 3, matches: [1, 2, 3] }));
+    expect(out).toContain('3 control');
+  });
+
+  it('get_biopreparados: cuenta desde matches_count (no recipes)', () => {
+    const out = buildFallbackResponse('', ev('get_biopreparados', { matches_count: 2, matches: [1, 2] }));
+    expect(out).toContain('2 receta');
+  });
+
+  it('get_folk_sintoma: mapea el síntoma folk a su plaga', () => {
+    const out = buildFallbackResponse('', ev('get_folk_sintoma', { query: 'gota', resultados: [{ sintoma_folk: 'gota', mapea_a: 'Phytophthora infestans' }] }));
+    expect(out).toContain('gota');
+    expect(out).toContain('Phytophthora infestans');
+  });
+
+  it('get_aporte_nutricional: arma la línea de nutrientes', () => {
+    const out = buildFallbackResponse('', ev('get_aporte_nutricional', { nombre_comun: 'Papa', unidad: '100 g', nutrientes: { energia_kcal: 93, proteina_g: 1.9, hierro_mg: 1.1 } }));
+    expect(out).toContain('93 kcal');
+    expect(out).toContain('1.9 g proteína');
+    expect(out).toContain('1.1 mg hierro');
+  });
+
+  it('get_suelo: reporta pH óptimo y corrección', () => {
+    const out = buildFallbackResponse('', ev('get_suelo', { nombre_comun: 'Aguacate', ph_optimo: '5.5-6.5', correccion_suelo: 'encalado' }));
+    expect(out).toContain('5.5-6.5');
+    expect(out).toContain('encalado');
+  });
+
+  it('genérico: un tool sin caso propio igual reporta el conteo (no "información útil")', () => {
+    const out = buildFallbackResponse('', ev('get_practicas_agua', { resultados_count: 5, resultados: [1, 2, 3, 4, 5] }));
+    expect(out).toContain('5 resultado');
+    expect(out).not.toContain('obtuve información útil');
+  });
+
+  it('tool no disponible: lo marca como fallo, no como dato', () => {
+    const out = buildFallbackResponse('', ev('get_precio_sipsa', { available: false }));
+    expect(out).toContain('No pude obtener datos');
+  });
+
+  it('sin toolEvidence pero con entidades: al menos dice qué mencionó', () => {
+    const out = buildFallbackResponse('', null, [{ nombre_comun: 'lulo' }]);
+    expect(out).toContain('lulo');
+  });
+
+  it('nada de nada: mensaje honesto sin inventar', () => {
+    const out = buildFallbackResponse('', null, null);
+    expect(out).toContain('No pude completar la consulta');
+    expect(out).toContain('¿Quieres preguntar otra cosa?');
+  });
+});

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -1935,6 +1935,25 @@ REGLA DE MÁXIMA PRIORIDAD (CASO B obligatorio):
  * @param {Array|null} resolvedEntities - Entidades resueltas por el sidecar.
  * @returns {string} - rawResponse si es válida, o fallback estructurado.
  */
+/**
+ * _countFromResult — cuenta genérica de resultados de un tool, cubriendo las
+ * shapes comunes (`*_count` o un array `matches`/`resultados`/`canales`/...).
+ * Así CUALQUIER tool aporta "encontré N" en el fallback, no solo los que tienen
+ * caso explícito abajo. Devuelve null si no hay conteo reconocible.
+ * @param {object} result
+ * @returns {number|null}
+ */
+function _countFromResult(result) {
+  if (!result || typeof result !== 'object') return null;
+  for (const k of ['matches_count', 'resultados_count', 'canales_count', 'controls_count', 'count']) {
+    if (Number.isFinite(result[k])) return result[k];
+  }
+  for (const k of ['matches', 'resultados', 'canales', 'controls', 'controladores', 'companions', 'recipes', 'items']) {
+    if (Array.isArray(result[k])) return result[k].length;
+  }
+  return null;
+}
+
 export function buildFallbackResponse(rawResponse, toolEvidence = null, resolvedEntities = null) {
   if (rawResponse && typeof rawResponse === 'string' && rawResponse.trim().length > 0) {
     return rawResponse;
@@ -1957,24 +1976,44 @@ export function buildFallbackResponse(rawResponse, toolEvidence = null, resolved
         continue;
       }
 
-      // Extraer info relevante del resultado (según el tool)
-      if (toolName === 'get_species' && result.species_name) {
-        knownFacts.push(`La especie que mencionaste es ${result.species_name}.`);
-        if (result.viabilidad) {
-          knownFacts.push(`En tu zona es ${result.viabilidad === 'viable' ? 'viable' : result.viabilidad === 'marginal' ? 'marginal' : 'no viable'} para sembrar.`);
+      // Extraer info relevante del resultado. Shapes VERIFICADAS contra el
+      // sidecar 2026-07-18 (las viejas —species_name/controls/recipes— estaban
+      // stale y nunca hacían match → el fallback caía siempre en el genérico).
+      const sp = result.species;
+      if (toolName === 'get_species' && sp && typeof sp === 'object') {
+        const nombre = sp.nombre_comun || sp.nombre_cientifico || sp.id;
+        if (nombre) knownFacts.push(`La especie que mencionaste es ${nombre}.`);
+        const via = sp.viabilidad || result.viabilidad;
+        if (via) {
+          knownFacts.push(`En tu zona es ${via === 'viable' ? 'viable' : via === 'marginal' ? 'marginal' : 'no viable'} para sembrar.`);
         }
-      } else if (toolName === 'get_pest_controllers' && result.controls) {
-        const controls = Array.isArray(result.controls) ? result.controls : [];
-        if (controls.length > 0) {
-          knownFacts.push(`Encontré ${controls.length} control(es) para esa plaga.`);
-        }
-      } else if (toolName === 'get_biopreparados' && result.recipes) {
-        const recipes = Array.isArray(result.recipes) ? result.recipes : [];
-        if (recipes.length > 0) {
-          knownFacts.push(`Encontré ${recipes.length} receta(s) de biopreparados.`);
-        }
+      } else if (toolName === 'get_pest_controllers' && Number.isFinite(result.matches_count)) {
+        if (result.matches_count > 0) knownFacts.push(`Encontré ${result.matches_count} control(es) para esa plaga.`);
+      } else if (toolName === 'get_biopreparados' && Number.isFinite(result.matches_count)) {
+        if (result.matches_count > 0) knownFacts.push(`Encontré ${result.matches_count} receta(s) de biopreparados.`);
+      } else if (toolName === 'get_folk_sintoma' && Array.isArray(result.resultados) && result.resultados.length) {
+        const r0 = result.resultados[0];
+        if (r0 && r0.mapea_a) knownFacts.push(`"${result.query || r0.sintoma_folk}" corresponde a ${r0.mapea_a}.`);
+      } else if (toolName === 'get_aporte_nutricional' && result.nutrientes && typeof result.nutrientes === 'object') {
+        const n = result.nutrientes;
+        const bits = [];
+        if (Number.isFinite(n.energia_kcal)) bits.push(`${n.energia_kcal} kcal`);
+        if (Number.isFinite(n.proteina_g)) bits.push(`${n.proteina_g} g proteína`);
+        if (Number.isFinite(n.hierro_mg)) bits.push(`${n.hierro_mg} mg hierro`);
+        if (bits.length) knownFacts.push(`${result.nombre_comun || 'La especie'}: ${bits.join(', ')} por ${result.unidad || '100 g'}.`);
+      } else if (toolName === 'get_suelo' && result.ph_optimo) {
+        knownFacts.push(`${result.nombre_comun || 'La especie'}: pH óptimo ${result.ph_optimo}${result.correccion_suelo ? `; corrección de suelo: ${result.correccion_suelo}` : ''}.`);
+      } else if (toolName === 'get_canales_comercializacion' && Number.isFinite(result.canales_count)) {
+        if (result.canales_count > 0) knownFacts.push(`Encontré ${result.canales_count} canal(es) de comercialización.`);
       } else {
-        knownFacts.push(`Consulté "${toolName}" y obtuve información útil.`);
+        // Genérico: cualquier tool con un conteo/array reconocible aporta algo
+        // útil, no el vago "obtuve información útil".
+        const n = _countFromResult(result);
+        if (Number.isFinite(n) && n > 0) {
+          knownFacts.push(`Consulté "${toolName}" y encontré ${n} resultado(s).`);
+        } else {
+          knownFacts.push(`Consulté "${toolName}" y obtuve información.`);
+        }
       }
     }
   }


### PR DESCRIPTION
Parte del #12. Cuando el LLM cae (timeout/OOM), `buildFallbackResponse` debe armar una respuesta con lo que trajeron los tools. **Bug:** chequeaba `result.species_name`/`result.controls`/`result.recipes` — shapes que **ningún tool devuelve** (verificado vs sidecar: son `species`/`matches`/`matches`). Las 3 cases 'específicas' nunca matcheaban → **todo** caía en el vago "obtuve información útil" aun teniendo los datos.

Fix: shapes verificadas + casos para get_folk_sintoma/get_aporte_nutricional/get_suelo/get_canales_comercializacion + conteo **genérico** (`_countFromResult`) para que cualquier tool aporte 'encontré N'. **+11 tests** (antes había 0, solo un mock).