### PR TITLE
art(valle): MinimapaValle — minimapa RTS del valle (AoE del campo)

### DIFF
--- a/src/mockups/valle/MinimapaValle.jsx
+++ b/src/mockups/valle/MinimapaValle.jsx
@@ -1,0 +1,300 @@
+/*
+ * MinimapaValle — el minimapa RTS del valle ("Age of Empires del campo").
+ *
+ * Un overlay 2D de esquina, autocontenido (SVG+CSS, cero assets remotos),
+ * que muestra el valle EN PLANTA como el minimapa de un RTS clásico:
+ *   · el terreno por pisos térmicos (páramo arriba → tierra caliente abajo,
+ *     la MISMA orientación de la escena 3D: -z al fondo, +z al frente);
+ *   · la quebrada bajando la ladera y los senderos del trajín;
+ *   · la casa-ancla (el hogar, no navegable) y la cordillera del fondo;
+ *   · un BLIP por lugar navegable (color del tinte + emoji del mundo);
+ *   · el CONO DE CÁMARA: desde la esquina de la cámara de reposo
+ *     ([10.5, 13.5] en planta) apunta hacia el foco vigente — se lee
+ *     "hacia dónde estoy mirando" como en AoE;
+ *   · TAP-PARA-SALTAR: tocar un blip llama onSaltar(id) — la escena decide
+ *     el viaje. Este componente NO toca la escena: es un mapa, no un mando.
+ *
+ * Geografía por DATOS, no a mano: pisos de valleData.PISOS_TERMICOS, casa y
+ * senderos de direccion/composicionValle — el minimapa es EL MISMO lugar que
+ * el valle 3D. (La quebrada se duplica: la escena la define inline.)
+ *
+ * Colapsable: en teléfono ocupa ~124-148px de esquina y se pliega a un botón.
+ */
+import { useMemo, useState } from 'react';
+import { PISOS_TERMICOS } from './valleData';
+import { CASA_VALLE, SENDEROS_VALLE } from '../../visual/mundo3d/direccion/composicionValle';
+import './minimapaValle.css';
+
+/* ── Proyección mundo→mapa ────────────────────────────────────────────────
+   El valle vive en x∈[-9,9], z∈[-11,9]. Escala UNIFORME (sin deformar la
+   planta): 18 u de ancho → 100 unidades SVG; el fondo (z) da el alto. */
+const X_MIN = -9;
+const Z_MIN = -11;
+const Z_MAX = 9;
+const ESCALA = 100 / 18;
+const ANCHO = 100;
+const ALTO = (Z_MAX - Z_MIN) * ESCALA; // ≈ 111.1
+
+const sx = (x) => (x - X_MIN) * ESCALA;
+const sy = (z) => (z - Z_MIN) * ESCALA;
+
+/* La quebrada: los MISMOS waypoints del tubo 3D (Valle3D.Quebrada los define
+   inline en la escena — si se mueven allá, moverlos acá). Nace en el páramo
+   y baja a la tierra caliente. */
+const QUEBRADA_PTS = [
+  [-3.4, -7.2],
+  [-1.2, -4.2],
+  [0.8, -1.4],
+  [1.6, 1.8],
+  [2.6, 5.4],
+  [3.6, 8],
+];
+
+/* La cámara de reposo de la escena ([10.5, 9, 13.5] mirando a [0, 1.6, 1.4]):
+   en planta cae por fuera de la esquina inferior-derecha del mapa — el cono
+   entra al cuadro desde ahí, como el viewport de un RTS. */
+const CAMARA_PLANTA = [10.5, 13.5];
+const MIRA_REPOSO = [0, 1.4];
+/* Largo del cono: alcanza el punto de mira de reposo desde la cámara. */
+const CONO_LARGO = 95;
+/* Medio-ángulo del cono en el mapa (~fov 40 de la escena, achatado a planta). */
+const CONO_MEDIO_TAN = 0.24;
+
+/** Polyline [x,z] → path SVG suavizado (cuadráticas por punto medio). */
+function pathSuave(puntos) {
+  const p = puntos.map(([x, z]) => [sx(x), sy(z)]);
+  if (p.length < 2) return '';
+  let d = `M ${p[0][0].toFixed(1)} ${p[0][1].toFixed(1)}`;
+  for (let i = 1; i < p.length - 1; i += 1) {
+    const mx = (p[i][0] + p[i + 1][0]) / 2;
+    const my = (p[i][1] + p[i + 1][1]) / 2;
+    d += ` Q ${p[i][0].toFixed(1)} ${p[i][1].toFixed(1)} ${mx.toFixed(1)} ${my.toFixed(1)}`;
+  }
+  const fin = p[p.length - 1];
+  return `${d} L ${fin[0].toFixed(1)} ${fin[1].toFixed(1)}`;
+}
+
+/** Borde ondulado de una franja de piso (4 ondas suaves a lo ancho). */
+function ondaEn(zTop) {
+  const y = sy(zTop);
+  const amp = 1.5;
+  const n = 4;
+  const w = ANCHO / n;
+  let d = `M 0 ${y.toFixed(1)}`;
+  for (let i = 0; i < n; i += 1) {
+    const cy = y + (i % 2 === 0 ? -amp : amp);
+    d += ` Q ${(w * i + w / 2).toFixed(1)} ${cy.toFixed(1)} ${(w * (i + 1)).toFixed(1)} ${y.toFixed(1)}`;
+  }
+  return d;
+}
+
+/* ── Capas estáticas precalculadas (cero costo por render) ──────────────── */
+/* Pisos de atrás (páramo, arriba) hacia delante (cálido, abajo): cada franja
+   pinta de su borde ondulado hasta el fondo del mapa y la siguiente la tapa. */
+const CAPAS_PISOS = [...PISOS_TERMICOS].reverse().map((p, i) => ({
+  id: p.id,
+  color: p.color,
+  cresta: p.cresta,
+  dTop: i === 0 ? null : ondaEn(p.z0),
+  dFill: i === 0
+    ? `M 0 0 H ${ANCHO} V ${(ALTO + 2).toFixed(1)} H 0 Z`
+    : `${ondaEn(p.z0)} L ${ANCHO} ${(ALTO + 2).toFixed(1)} L 0 ${(ALTO + 2).toFixed(1)} Z`,
+}));
+
+const D_QUEBRADA = pathSuave(QUEBRADA_PTS);
+
+/* Solo los senderos frugales (los del uso diario): el minimapa respira. */
+const D_SENDEROS = SENDEROS_VALLE
+  .filter((s) => s.frugal)
+  .map((s) => ({ id: s.id, d: pathSuave(s.puntos) }));
+
+const CASA_XY = [sx(CASA_VALLE.pos[0]), sy(CASA_VALLE.pos[1])];
+const CAM_XY = [sx(CAMARA_PLANTA[0]), sy(CAMARA_PLANTA[1])];
+
+/* La cordillera del fondo (los picos viven en z≤-15, fuera del mapa): unos
+   chevrones en la franja del páramo la sugieren. */
+const CHEVRONES = [
+  'M 10 11 l 4.5 -4.5 l 4.5 4.5',
+  'M 40 8 l 5 -5 l 5 5',
+  'M 74 12 l 4.5 -4.5 l 4.5 4.5',
+];
+
+/**
+ * El minimapa del valle, estilo RTS. Overlay de esquina, colapsable.
+ *
+ * @param {object} props
+ * @param {Array<{id: string, x: number, z: number, emoji: string, tinte: string[]|string}>} props.lugares
+ *   Los lugares navegables del valle en planta. `tinte` acepta el par del
+ *   manifiesto (['#a', '#b'] — usa el primero) o un color suelto.
+ * @param {string|{id: string}|null} [props.foco] El lugar en foco (id o el
+ *   objeto del mundo): su blip pulsa y el cono de cámara lo apunta. null =
+ *   reposo (el cono mira al centro del valle).
+ * @param {(id: string) => void} [props.onSaltar] Tap en un blip → saltar ahí.
+ * @param {'alto'|'medio'|'bajo'} [props.tier] Presupuesto visual del equipo
+ *   (deviceTier): en 'bajo' se apagan pulso, brillos y transiciones.
+ * @param {boolean} [props.reducedMotion] Respeto a "menos movimiento".
+ */
+export default function MinimapaValle({
+  lugares = [],
+  foco = null,
+  onSaltar,
+  tier = 'alto',
+  reducedMotion = false,
+}) {
+  const [abierto, setAbierto] = useState(true);
+  const quieto = reducedMotion || tier === 'bajo';
+  const focoId = typeof foco === 'string' ? foco : (foco && foco.id) || null;
+
+  /* Hacia dónde apunta el cono: el lugar en foco, o la mira de reposo. */
+  const anguloCono = useMemo(() => {
+    const enFoco = focoId && lugares.find((l) => l.id === focoId);
+    const tx = enFoco ? sx(enFoco.x) : sx(MIRA_REPOSO[0]);
+    const ty = enFoco ? sy(enFoco.z) : sy(MIRA_REPOSO[1]);
+    return (Math.atan2(ty - CAM_XY[1], tx - CAM_XY[0]) * 180) / Math.PI;
+  }, [focoId, lugares]);
+
+  const saltar = (id) => {
+    if (onSaltar) onSaltar(id);
+  };
+
+  if (!abierto) {
+    return (
+      <div className="mmv mmv--cerrado">
+        <button
+          type="button"
+          className="mmv-toggle mmv-toggle--abrir"
+          aria-label="Mostrar el minimapa del valle"
+          onClick={() => setAbierto(true)}
+        >
+          <span aria-hidden="true">🗺️</span>
+        </button>
+      </div>
+    );
+  }
+
+  const lado = CONO_LARGO * CONO_MEDIO_TAN;
+
+  return (
+    <div
+      className={`mmv${quieto ? ' mmv--quieto' : ''}`}
+      role="group"
+      aria-label="Minimapa del valle"
+    >
+      <div className="mmv-marco">
+        <span className="mmv-tachuela mmv-tachuela--tl" aria-hidden="true" />
+        <span className="mmv-tachuela mmv-tachuela--tr" aria-hidden="true" />
+        <span className="mmv-tachuela mmv-tachuela--bl" aria-hidden="true" />
+        <span className="mmv-tachuela mmv-tachuela--br" aria-hidden="true" />
+        <button
+          type="button"
+          className="mmv-toggle"
+          aria-label="Ocultar el minimapa"
+          onClick={() => setAbierto(false)}
+        >
+          <span aria-hidden="true">▾</span>
+        </button>
+        <svg
+          className="mmv-mapa"
+          viewBox={`0 0 ${ANCHO} ${ALTO.toFixed(1)}`}
+          role="presentation"
+          focusable="false"
+        >
+          <defs>
+            <radialGradient id="mmv-vineta" cx="50%" cy="46%" r="72%">
+              <stop offset="62%" stopColor="#000" stopOpacity="0" />
+              <stop offset="100%" stopColor="#000" stopOpacity="0.38" />
+            </radialGradient>
+          </defs>
+
+          {/* el terreno: las franjas de los pisos térmicos */}
+          <g className="mmv-terreno">
+            {CAPAS_PISOS.map((p) => (
+              <g key={p.id}>
+                <path d={p.dFill} fill={p.color} />
+                {p.dTop && <path className="mmv-cresta" d={p.dTop} stroke={p.cresta} />}
+              </g>
+            ))}
+          </g>
+
+          {/* la cordillera sugerida en el páramo */}
+          <g className="mmv-cordillera">
+            {CHEVRONES.map((d) => <path key={d} d={d} />)}
+          </g>
+
+          {/* los senderos del trajín */}
+          <g className="mmv-senderos">
+            {D_SENDEROS.map((s) => <path key={s.id} d={s.d} />)}
+          </g>
+
+          {/* la quebrada: brillo + hilo de agua */}
+          <path className="mmv-quebrada-brillo" d={D_QUEBRADA} />
+          <path className="mmv-quebrada" d={D_QUEBRADA} />
+
+          {/* la casa-ancla (el hogar; no navegable, no es blip) */}
+          <g
+            className="mmv-casa"
+            transform={`translate(${CASA_XY[0].toFixed(1)} ${CASA_XY[1].toFixed(1)})`}
+            aria-hidden="true"
+          >
+            <rect x="-2.3" y="-1.3" width="4.6" height="3.2" rx="0.5" />
+            <path className="mmv-casa-techo" d="M -3 -1.1 L 0 -3.6 L 3 -1.1 Z" />
+          </g>
+
+          {/* viñeta de profundidad: bajo el cono y los blips (ellos brillan) */}
+          <rect
+            className="mmv-vineta"
+            x="0"
+            y="0"
+            width={ANCHO}
+            height={ALTO.toFixed(1)}
+            fill="url(#mmv-vineta)"
+          />
+
+          {/* el cono de cámara: desde la esquina de la cámara de reposo hacia
+              el foco — "hacia dónde estoy mirando" (viewport RTS) */}
+          <g
+            className="mmv-cam"
+            style={{ transform: `translate(${CAM_XY[0]}px, ${CAM_XY[1]}px) rotate(${anguloCono.toFixed(1)}deg)` }}
+          >
+            <path
+              className="mmv-cam-cono"
+              d={`M 0 0 L ${(CONO_LARGO - 3).toFixed(1)} ${(-lado).toFixed(1)} A ${CONO_LARGO} ${CONO_LARGO} 0 0 1 ${(CONO_LARGO - 3).toFixed(1)} ${lado.toFixed(1)} Z`}
+            />
+          </g>
+
+          {/* los blips: un lugar navegable por punto, tap para saltar */}
+          <g className="mmv-blips">
+            {lugares.map((l) => {
+              const esFoco = focoId === l.id;
+              const tinte = Array.isArray(l.tinte) ? l.tinte[0] : (l.tinte || '#3f8f4e');
+              return (
+                <g
+                  key={l.id}
+                  className={`mmv-blip${esFoco ? ' mmv-blip--foco' : ''}`}
+                  transform={`translate(${sx(l.x).toFixed(1)} ${sy(l.z).toFixed(1)})`}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Ir a ${l.id}`}
+                  onClick={() => saltar(l.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      saltar(l.id);
+                    }
+                  }}
+                >
+                  {esFoco && <circle className="mmv-blip-aro" r="7.4" />}
+                  <circle className="mmv-blip-tap" r="8.2" />
+                  <circle className="mmv-blip-punto" r="4.6" fill={tinte} />
+                  <text className="mmv-blip-emoji" y="1.9" textAnchor="middle">
+                    {l.emoji}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/mockups/valle/minimapaValle.css
+++ b/src/mockups/valle/minimapaValle.css
@@ -1,0 +1,246 @@
+/*
+ * minimapaValle.css — el minimapa RTS del valle (MinimapaValle.jsx).
+ *
+ * Estética AoE aterrizada a Chagra: marco de madera con tachuelas de latón,
+ * mapa oscuro adentro, blips que brillan, cono de cámara translúcido.
+ * Overlay de esquina inferior-derecha, colapsable, legible en teléfono.
+ * Autocontenido: cero assets, todo CSS/SVG.
+ */
+
+.mmv {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  z-index: 30;
+  width: 152px;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  pointer-events: auto;
+}
+
+/* ── El marco: madera barnizada con bisel, tachuelas de latón ──────────── */
+.mmv-marco {
+  position: relative;
+  padding: 5px;
+  border-radius: 13px;
+  background:
+    linear-gradient(155deg, #8a6733 0%, #5d431d 42%, #7d5c2a 68%, #3c2b11 100%);
+  box-shadow:
+    0 5px 16px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 228, 165, 0.4),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.45);
+}
+
+.mmv-tachuela {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #ffe9b0, #b78a3a 55%, #6d4d1c);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+}
+.mmv-tachuela--tl { top: 3px; left: 3px; }
+.mmv-tachuela--tr { top: 3px; right: 3px; }
+.mmv-tachuela--bl { bottom: 3px; left: 3px; }
+.mmv-tachuela--br { bottom: 3px; right: 3px; }
+
+/* ── El mapa ───────────────────────────────────────────────────────────── */
+.mmv-mapa {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 9px;
+  background: #17231a;
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.55),
+    inset 0 0 14px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+
+.mmv-terreno {
+  filter: brightness(0.88) saturate(0.92);
+}
+
+.mmv-cresta {
+  fill: none;
+  stroke-width: 0.7;
+  opacity: 0.5;
+}
+
+.mmv-cordillera path {
+  fill: none;
+  stroke: #9fb5a8;
+  stroke-width: 1;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.55;
+}
+
+.mmv-senderos path {
+  fill: none;
+  stroke: #cfa268;
+  stroke-width: 0.9;
+  stroke-dasharray: 2 1.7;
+  stroke-linecap: round;
+  opacity: 0.62;
+}
+
+.mmv-quebrada-brillo {
+  fill: none;
+  stroke: #7fd4ff;
+  stroke-width: 3.4;
+  stroke-linecap: round;
+  opacity: 0.22;
+}
+.mmv-quebrada {
+  fill: none;
+  stroke: #a9e2ff;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  opacity: 0.9;
+}
+
+.mmv-casa rect {
+  fill: #f3ead8;
+  stroke: rgba(0, 0, 0, 0.4);
+  stroke-width: 0.4;
+}
+.mmv-casa-techo {
+  fill: #b0582f;
+  stroke: rgba(0, 0, 0, 0.35);
+  stroke-width: 0.4;
+}
+
+.mmv-vineta {
+  pointer-events: none;
+}
+
+/* ── El cono de cámara (viewport RTS) ──────────────────────────────────── */
+.mmv-cam {
+  pointer-events: none;
+  transition: transform 0.7s cubic-bezier(0.33, 1, 0.68, 1);
+}
+.mmv-cam-cono {
+  fill: rgba(255, 255, 255, 0.09);
+  stroke: rgba(255, 255, 255, 0.5);
+  stroke-width: 0.7;
+  stroke-linejoin: round;
+}
+
+/* ── Los blips ─────────────────────────────────────────────────────────── */
+.mmv-blip {
+  cursor: pointer;
+  outline: none;
+}
+.mmv-blip-tap {
+  fill: transparent;
+  pointer-events: all;
+}
+.mmv-blip-punto {
+  stroke: rgba(0, 0, 0, 0.5);
+  stroke-width: 0.7;
+  paint-order: stroke;
+  transition: stroke 0.2s ease;
+}
+.mmv-blip-emoji {
+  font-size: 5px;
+  pointer-events: none;
+  dominant-baseline: middle;
+}
+.mmv-blip:hover .mmv-blip-punto,
+.mmv-blip:focus-visible .mmv-blip-punto {
+  stroke: rgba(255, 255, 255, 0.95);
+  stroke-width: 1.1;
+}
+.mmv-blip--foco .mmv-blip-punto {
+  stroke: #fff;
+  stroke-width: 1.1;
+}
+
+/* el aro que pulsa sobre el lugar en foco */
+.mmv-blip-aro {
+  fill: none;
+  stroke: #ffffff;
+  stroke-width: 1.1;
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: mmv-pulso 1.7s ease-out infinite;
+}
+@keyframes mmv-pulso {
+  0% { transform: scale(0.55); opacity: 0.95; }
+  70% { transform: scale(1.12); opacity: 0.18; }
+  100% { transform: scale(1.2); opacity: 0; }
+}
+
+/* ── Plegar / desplegar ────────────────────────────────────────────────── */
+.mmv-toggle {
+  position: absolute;
+  top: -7px;
+  right: -7px;
+  z-index: 2;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid rgba(0, 0, 0, 0.4);
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #ffe3a0, #b78a3a 60%, #6d4d1c);
+  color: #3c2b11;
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mmv-toggle:focus-visible {
+  outline: 2px solid #ffe9b0;
+  outline-offset: 1px;
+}
+
+.mmv--cerrado {
+  width: auto;
+}
+.mmv-toggle--abrir {
+  position: static;
+  width: 42px;
+  height: 42px;
+  font-size: 20px;
+  border-radius: 50%;
+}
+
+/* ── Presupuesto: tier bajo o "menos movimiento" ───────────────────────── */
+.mmv--quieto .mmv-blip-aro {
+  animation: none;
+  transform: scale(1);
+  opacity: 0.6;
+}
+.mmv--quieto .mmv-cam {
+  transition: none;
+}
+.mmv--quieto .mmv-terreno {
+  filter: none;
+}
+.mmv--quieto .mmv-quebrada-brillo {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mmv .mmv-blip-aro { animation: none; transform: scale(1); opacity: 0.6; }
+  .mmv .mmv-cam { transition: none; }
+}
+
+/* ── Teléfono: más chico, más pegado a la esquina ──────────────────────── */
+@media (max-width: 480px) {
+  .mmv {
+    width: 126px;
+    right: 8px;
+    bottom: 8px;
+  }
+  .mmv-toggle {
+    width: 24px;
+    height: 24px;
+  }
+}


### PR DESCRIPTION
## Qué es

El minimapa 2D del valle estilo Age of Empires: overlay DOM/SVG de esquina, autocontenido (cero assets remotos, cero three), colapsable, legible en teléfono (~126-152px).

- Terreno en planta por pisos térmicos — layout por DATOS (`valleData.PISOS_TERMICOS`), misma orientación de la escena (páramo arriba/fondo, tierra caliente abajo/frente).
- Quebrada (mismos waypoints del tubo 3D), senderos frugales + casa-ancla desde `direccion/composicionValle` → el minimapa es EL MISMO lugar que el valle 3D.
- Un blip por lugar navegable (tinte + emoji del manifiesto); tap/Enter → `onSaltar(id)`.
- Cono de cámara (viewport RTS) desde la planta de la cámara de reposo `[10.5, 13.5]` hacia el foco; aro pulsante en el blip en foco.
- Marco de madera + tachuelas de latón (guiño AoE aterrizado a Chagra).
- `tier: 'bajo'` / `reducedMotion` apagan pulso, brillos y transiciones.

## Alcance

SOLO archivos nuevos: `src/mockups/valle/MinimapaValle.jsx` + `src/mockups/valle/minimapaValle.css`. Cero escena tocada (Valle3D/composicionValle3D/EntradaValle3D intactos) — el cableado lo hace el operador.

## Cableo (para quien lo conecte)

```jsx
import MinimapaValle from './MinimapaValle';
import { MUNDOS_VALLE } from './valleData';
import { componerMundos } from '../../visual/mundo3d/direccion/composicionValle';

const lugares = componerMundos(MUNDOS_VALLE).map((m) => ({
  id: m.id, x: m.pos[0], z: m.pos[2], emoji: m.emoji, tinte: m.tinte,
}));
<MinimapaValle lugares={lugares} foco={focoId} onSaltar={irAMundo} tier={tier} reducedMotion={rm} />
```

Props: `lugares` ({id,x,z,emoji,tinte[]|string}), `foco` (id | {id} | null), `onSaltar(id)`, `tier` ('alto'|'medio'|'bajo'), `reducedMotion` (bool). Root `position:absolute` esquina inferior-derecha: montarlo dentro del contenedor del canvas.

## Verificación

- `npx eslint` limpio · `npm run build:prod` VERDE (31.5s) · dist-prod restaurado.
- Render aislado (react-dom/server + datos reales del valle, 14 blips) capturado con chromium: terreno, quebrada, cono y blips legibles a 126px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)