### PR TITLE
feat(capture): modo piloto — captura conversaciones de todos los usuarios

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,6 +113,12 @@ jobs:
           # VITE_CAPTURE_ANONYMIZE); el store cae en /var/lib/agro-mcp/conversations
           # (fuera del rsync --delete del deploy). Habeas Data: Ley 1581.
           VITE_CAPTURE_CONVERSATIONS: "true"
+          # MODO PILOTO 2026-07-18: captura para TODOS los usuarios sin el gate de
+          # consentimiento in-app (auditoría del agente durante pruebas). Default
+          # del código es exigir consentimiento; este flag lo desactiva SOLO en
+          # prod-piloto. Habeas Data Ley 1581: informar a los usuarios del piloto
+          # fuera de la app. Revertir a "true" (o quitar) al cerrar el piloto.
+          VITE_CAPTURE_REQUIRE_CONSENT: "false"
           # Token X-Chagra-Token shared-secret. NOTA: termina en bundle JS
           # publico - defense-in-depth, NO auth real (auth real = nginx CORS
           # lockdown). Sincronizado con SOPS de alpha; rotacion coordinada.

--- a/src/services/__tests__/conversationCaptureService.test.js
+++ b/src/services/__tests__/conversationCaptureService.test.js
@@ -5,7 +5,7 @@
 /* eslint-disable no-undef */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { captureExchange, isCaptureEnabled, shouldAnonymizePII } from '../conversationCaptureService';
+import { captureExchange, isCaptureEnabled, isConsentRequired, shouldAnonymizePII } from '../conversationCaptureService';
 import * as feedbackService from '../feedbackService';
 
 const waitForFetchCalls = async (count) => {
@@ -64,6 +64,24 @@ describe('conversationCaptureService', () => {
     });
   });
 
+  describe('isConsentRequired', () => {
+    it('exige consentimiento por defecto (privacy-first)', () => {
+      expect(isConsentRequired()).toBe(true);
+    });
+
+    it('reconoce false/0/off como NO-exigir (modo piloto)', () => {
+      for (const v of ['false', '0', 'off', 'FALSE', 'Off']) {
+        vi.stubEnv('VITE_CAPTURE_REQUIRE_CONSENT', v);
+        expect(isConsentRequired()).toBe(false);
+      }
+    });
+
+    it('cualquier otro valor sigue exigiendo consentimiento', () => {
+      vi.stubEnv('VITE_CAPTURE_REQUIRE_CONSENT', 'true');
+      expect(isConsentRequired()).toBe(true);
+    });
+  });
+
   describe('captureExchange', () => {
     it('no envía nada cuando la flag está OFF', () => {
       captureExchange({ userText: 'hola', agentText: 'buenas' });
@@ -75,6 +93,15 @@ describe('conversationCaptureService', () => {
       vi.spyOn(feedbackService, 'hasConsent').mockReturnValue(false);
       captureExchange({ userText: 'hola', agentText: 'buenas' });
       expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('MODO PILOTO: con REQUIRE_CONSENT=false captura aunque no haya consentimiento', async () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      vi.stubEnv('VITE_CAPTURE_REQUIRE_CONSENT', 'false');
+      vi.spyOn(feedbackService, 'hasConsent').mockReturnValue(false);
+      captureExchange({ userText: 'hola', agentText: 'buenas' });
+      await waitForFetchCalls(1);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('no envía turnos vacíos aunque la flag esté ON', () => {

--- a/src/services/conversationCaptureService.js
+++ b/src/services/conversationCaptureService.js
@@ -55,6 +55,27 @@ export function isCaptureEnabled() {
   }
 }
 
+/**
+ * ¿Se exige consentimiento por-usuario (hasConsent) para capturar?
+ * Default TRUE (privacy-first). Puesto en `false` vía VITE_CAPTURE_REQUIRE_CONSENT
+ * (build), la captura se aplica a TODOS los usuarios sin el gate de consentimiento
+ * in-app — modo PILOTO para auditar el agente con toda la data (los usuarios del
+ * piloto deben ser informados fuera de la app; Habeas Data Ley 1581).
+ */
+export function isConsentRequired() {
+  try {
+    const raw = import.meta.env?.VITE_CAPTURE_REQUIRE_CONSENT;
+    if (raw === false) return false;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      if (v === 'false' || v === '0' || v === 'off') return false;
+    }
+    return true; // default: exige consentimiento
+  } catch (_) {
+    return true;
+  }
+}
+
 function getBaseUrl() {
   try {
     const raw = import.meta.env?.VITE_SIDECAR_URL;
@@ -124,7 +145,9 @@ function anonymizeIdentity(identity) {
  */
 export function captureExchange({ userText, agentText, identity = {}, meta = {} } = {}) {
   if (!isCaptureEnabled()) return;
-  if (!hasConsent()) return;
+  // Gate de consentimiento: por defecto exigido (privacy-first). En modo PILOTO
+  // (VITE_CAPTURE_REQUIRE_CONSENT=false) se captura a todos los usuarios.
+  if (isConsentRequired() && !hasConsent()) return;
   // No capturamos turnos vacíos (p. ej. abortados sin respuesta).
   if (!userText && !agentText) return;
 


### PR DESCRIPTION
## Qué
Flag de build `VITE_CAPTURE_REQUIRE_CONSENT` (default `true`, privacy-first). En `false` (modo piloto, activado en prod via deploy.yml) la captura de conversaciones se aplica a **todos los usuarios** sin el gate `hasConsent()` in-app.

## Por qué
Durante el piloto, las conversaciones de usuarios reales (Karen, erik_stiven, etc.) NO se estaban capturando (solo el canario), porque el doble-gate exige consentimiento por-usuario. Se necesita esa data para auditar el agente.

## Privacidad (Habeas Data, Ley 1581)
- Default del código sigue exigiendo consentimiento (sin cambios para quien no ponga el flag).
- El bypass es explícito, solo-prod-piloto, y **revertible** (poner `true` o quitar el flag).
- Los usuarios del piloto deben ser informados **fuera de la app** de que sus conversaciones se registran para auditoría de calidad.

## Tests
16/16 pasan (+4 nuevos: `isConsentRequired` default/override + captura en modo piloto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)