### PR TITLE
feat(voz): la voz de Angelita — anti-solapamiento + carácter propio

### DIFF
--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -76,6 +76,18 @@ export default function AgentFab({ onNavigate, pantalla = null }) {
     return () => { vivo = false; };
   }, [activeAlerts, setLastMessage, setResponseReady]);
 
+  // ── LA GARGANTA, CABLEADA (2026-07-19): el puente store→voz hace que lo
+  //    que Angelita decide decir SUENE en toda pantalla — con la cola única
+  //    (angelitaVoz) que garantiza que dos audios jamás se pisen. Import
+  //    perezoso (el stack de voz no pesa en el arranque) e idempotente (el
+  //    puente es singleton: montar N FABs instala UNA vez y no se
+  //    desinstala — desinstalarlo con un FAB callaría a los demás).
+  useEffect(() => {
+    import('../services/angelitaVozBridge')
+      .then((m) => m.initAngelitaVozBridge())
+      .catch(() => { /* sin voz no se rompe nada: la burbuja sigue */ });
+  }, []);
+
   // Estado de Angelita: el tacto manda sobre el aviso, y el aviso sobre el idle.
   const estado = pressed
     ? 'contenta'

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -131,7 +131,10 @@ import { mergePartialOnInterruption } from '../../services/agentPartialMerge';
 // comparten el mismo snapshot via `climaService` (cache 30 min).
 import { getCachedClimaSnapshot, fetchClimaSnapshot, resolveClimaLocation } from '../../services/climaService';
 import { FARM_CONFIG } from '../../config/defaults';
-import { speak, speakSentences, stop, init as initTTS, isSupported, isKokoroAvailable, replayLast, isSpeaking, onSpeakingChange, isAudioPlaying, getLastSpoken } from '../../services/ttsService';
+import { stop, init as initTTS, isSupported, isKokoroAvailable, replayLast, isSpeaking, onSpeakingChange, isAudioPlaying, getLastSpoken } from '../../services/ttsService';
+// Garganta única de Angelita (2026-07-19): el habla del personaje pasa por
+// la cola serializada (nunca dos audios pisados) con su carácter de voz.
+import { decir as decirAngelita, PRIORIDAD as PRIORIDAD_VOZ, MOTIVO as MOTIVO_VOZ } from '../../services/angelitaVoz';
 import { executeAction, setActionGateCallback } from '../../services/actionExecutor';
 import { getToolsForLLM } from '../../services/llmTools';
 import { useRotatingTip } from '../../services/tipsService';
@@ -2621,11 +2624,20 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       }
 
       if (ttsEnabled && response) {
-        stop();
-        // TIER 2 #5: degradación amable. Si TODO el stack de voz falla
-        // (Kokoro caído + Web Speech ausente), avisamos en el strip — la
-        // respuesta YA está escrita arriba, nada se rompe ni queda mudo.
-        // Damos 1.2s de gracia porque Web Speech puede demorar el onstart.
+        // GARGANTA ÚNICA (2026-07-19): la respuesta va por la cola de
+        // Angelita con reemplaza:true — la política explícita del chat: una
+        // respuesta nueva deja obsoleta la anterior (la corta y vacía la
+        // cola) en vez del stop() bruto + play suelto que permitía pisones.
+        // El streaming frase-por-frase (latencia kokoro lineal con chars,
+        // 7KB→3s) y el respaldo Web Speech viven DENTRO del motor de la
+        // cola; el rate/voz es el carácter de Angelita (angelitaCaracter).
+        //
+        // TIER 2 #5: degradación amable. Si TODO el stack de voz falla,
+        // avisamos en el strip — la respuesta YA está escrita arriba, nada
+        // se rompe ni queda mudo. decir() nunca rechaza ni cuelga (watchdog
+        // interno), y distingue en `motivo` el fallo real de un corte
+        // legítimo (interrumpida/callada por otra respuesta): solo el fallo
+        // real merece el aviso.
         const warnIfMute = () => {
           setTimeout(() => {
             if (!isAudioPlaying() && !isSpeaking()) {
@@ -2633,18 +2645,16 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             }
           }, 1200);
         };
-        if (kokoroReady) {
-          // Free 7→10 fix-pack #4: streaming frase-por-frase reduce la
-          // latencia hasta-primer-audio de "esperar respuesta entera"
-          // (3-23s) a "esperar primera frase" (<2s). Sin rate hardcodeado:
-          // hereda la velocidad preferida del operador (getPreferredRate).
-          speakSentences(responseBody)
-            .then((ok) => { if (!ok) warnIfMute(); })
-            .catch(() => warnIfMute());
-        } else {
-          const utterance = speak(responseBody, { rate: 0.9, pitch: 1.0 });
-          if (!utterance) warnIfMute();
-        }
+        const FALLOS_REALES = [MOTIVO_VOZ.AUDIO_FALLO, MOTIVO_VOZ.WATCHDOG, MOTIVO_VOZ.SIN_GESTO];
+        decirAngelita(responseBody, {
+          prioridad: PRIORIDAD_VOZ.RESPUESTA,
+          reemplaza: true,
+          origen: 'agente-respuesta',
+        })
+          .then(({ hablado, motivo }) => {
+            if (!hablado && FALLOS_REALES.includes(motivo)) warnIfMute();
+          })
+          .catch(() => warnIfMute());
       }
 
       // 057.4 integration: en lugar de abrir el modal directo, delegamos a
@@ -3485,7 +3495,16 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           ...prev,
           { role: 'assistant', content: rejection, timestamp: Date.now() },
         ]);
-        if (ttsEnabled) { try { speak(rejection, { rate: 0.9, pitch: 1.0 }); } catch (_) { /* noop */ } }
+        // Garganta única: también los rechazos hablan por la cola (voz y
+        // política consistentes; antes era un speak() suelto que podía
+        // pisarse con la respuesta en curso).
+        if (ttsEnabled) {
+          decirAngelita(rejection, {
+            prioridad: PRIORIDAD_VOZ.RESPUESTA,
+            reemplaza: true,
+            origen: 'agente-rechazo-adjunto',
+          }).catch(() => { /* decir() no rechaza; cinturón */ });
+        }
         await outboxMarkAnswered(item.id, { answeredText: rejection });
         return true;
       }

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -4,7 +4,7 @@ import {
   OctagonAlert, SearchX, Wrench, ChevronDown,
 } from 'lucide-react';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
-import { speak, speakKokoro, stop, isSpeaking, isKokoroAvailable } from '../../services/ttsService';
+import { stop, isSpeaking } from '../../services/ttsService';
 import { agentSounds } from '../../services/agentSoundService';
 import usePrefsStore from '../../store/usePrefsStore';
 import FeedbackButtons from '../FeedbackButtons';
@@ -439,13 +439,16 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
       return;
     }
     try {
-      const kokoroReady = await isKokoroAvailable();
-      if (kokoroReady) {
-        // Sin rate hardcodeado: hereda la velocidad preferida del operador.
-        await speakKokoro(message.content);
-      } else {
-        speak(message.content, { rate: 0.9, pitch: 1.0 });
-      }
+      // GARGANTA ÚNICA (2026-07-19): la relectura pasa por la cola de
+      // Angelita (reemplaza: el usuario pidió OÍR ESTO ya) — antes era un
+      // speakKokoro suelto que secuestraba el audio por fuera de la cola.
+      // Voz/ritmo y respaldo Web Speech viven en el motor de la cola.
+      const { decir, PRIORIDAD } = await import('../../services/angelitaVoz');
+      await decir(message.content, {
+        prioridad: PRIORIDAD.RESPUESTA,
+        reemplaza: true,
+        origen: 'chat-releer',
+      });
       agentSounds.chime();
     } catch (_) {
       // No reportar al UI — el TTS es secundario, no debe interrumpir lectura.

--- a/src/components/BienvenidaFinca.jsx
+++ b/src/components/BienvenidaFinca.jsx
@@ -131,11 +131,17 @@ export function marcarBienvenidaVista() {
   }
 }
 
-/** Lee el momento en voz alta. Import perezoso del ttsService (no pesa en el
- * bundle del dashboard) y fail-silent: sin red/voz no rompe nada. */
+/** Lee el momento en voz alta por la GARGANTA ÚNICA de Angelita (cola
+ * serializada, prioridad RESPUESTA — lo pidió el usuario; reemplaza lo que
+ * estuviera sonando). Import perezoso (no pesa en el bundle del dashboard)
+ * y fail-silent: sin red/voz no rompe nada — el texto ya está en pantalla. */
 function escucharTexto(texto) {
-  import('../services/ttsService')
-    .then((m) => m.speakSentences(texto).catch(() => {}))
+  import('../services/angelitaVoz')
+    .then((m) => m.decir(texto, {
+      prioridad: m.PRIORIDAD.RESPUESTA,
+      reemplaza: true,
+      origen: 'bienvenida-finca',
+    }).catch(() => {}))
     .catch(() => {});
 }
 

--- a/src/components/OnboardingCondensado.jsx
+++ b/src/components/OnboardingCondensado.jsx
@@ -119,10 +119,16 @@ const IDENTIDAD_TARJETAS = [
   },
 ];
 
-/** Lee la pantalla en voz alta (TTS kokoro, import perezoso, fail-silent). */
+/** Lee la pantalla en voz alta por la GARGANTA ÚNICA de Angelita (cola
+ * serializada, prioridad RESPUESTA, reemplaza lo que sonara). Import
+ * perezoso, fail-silent: el texto ya está en pantalla. */
 function escucharTexto(texto) {
-  import('../services/ttsService')
-    .then((m) => m.speakSentences(texto).catch(() => {}))
+  import('../services/angelitaVoz')
+    .then((m) => m.decir(texto, {
+      prioridad: m.PRIORIDAD.RESPUESTA,
+      reemplaza: true,
+      origen: 'onboarding',
+    }).catch(() => {}))
     .catch(() => {});
 }
 

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -412,12 +412,23 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, on
   };
   const escuchar = async () => {
     try {
-      const tts = await import('../../services/ttsService');
+      // GARGANTA ÚNICA (2026-07-19): el botón habla por la cola de Angelita
+      // (prioridad RESPUESTA — lo pidió el usuario) en vez del speakSentences
+      // suelto que podía pisarse con otra superficie. El estado "hablando"
+      // sigue viniendo del motor (onSpeakingChange).
+      const [tts, voz] = await Promise.all([
+        import('../../services/ttsService'),
+        import('../../services/angelitaVoz'),
+      ]);
       if (!ttsUnsubRef.current) {
         ttsUnsubRef.current = tts.onSpeakingChange((v) => setHablando(!!v));
       }
-      if (tts.isAudioPlaying()) { tts.stop(); return; }
-      await tts.speakSentences(textoEscuchar());
+      if (tts.isAudioPlaying()) { voz.callar(); return; }
+      await voz.decir(textoEscuchar(), {
+        prioridad: voz.PRIORIDAD.RESPUESTA,
+        reemplaza: true,
+        origen: 'hero-escuchar',
+      });
     } catch (_) { /* sin audio disponible: el botón no rompe el home */ }
   };
 

--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -61,7 +61,10 @@ import Mundo, {
 /* Coach-mark del primer ingreso (visual, NO depende de la voz — iOS la muda). */
 import CoachMarkToque from '../visual/mundo3d/CoachMarkToque.jsx';
 import { buildSpatialAgentInitialContext } from '../services/spatialAgentContext';
-import { speak, speakKokoro, stop as stopSpeak } from '../services/ttsService.js';
+// GARGANTA ÚNICA (2026-07-19): la voz de Angelita en el valle pasa por la
+// cola serializada (angelitaVoz) — nunca dos audios pisados. El respaldo
+// Web Speech y el carácter (voz, ritmo) viven dentro del motor de la cola.
+import { decir as decirVoz, callar as stopSpeak, PRIORIDAD } from '../services/angelitaVoz.js';
 import { navegarDesde3D, rutaDesdeMundo3D } from '../prodApp/wire3DNav.js';
 /* El VELO ODYSSEY (lenguaje de transición aprobado por el operador): cubrir →
    swap en la meseta → revelar, con la identidad del DESTINO y variación por
@@ -278,15 +281,11 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
     vozRef.current = voz;
   }, [voz]);
 
-  const hablar = useCallback((texto) => {
+  const hablar = useCallback((texto, prioridad = PRIORIDAD.RESPUESTA) => {
     if (!vozRef.current || !texto) return;
-    speakKokoro(texto, { lang: 'es', rate: 0.98 })
-      .then((audio) => {
-        if (!audio && vozRef.current) speak(texto, { rate: 0.98, pitch: 1 });
-      })
-      .catch(() => {
-        if (vozRef.current) speak(texto, { rate: 0.98, pitch: 1 });
-      });
+    // decir() nunca rechaza ni cuelga (cola con watchdog + respaldo
+    // interno); la burbuja ya salió — el texto SIEMPRE llega.
+    decirVoz(texto, { prioridad, origen: 'valle-entrada' }).catch(() => {});
   }, []);
 
   // ── Angelita DICE (voz + burbuja): el texto SIEMPRE acompaña a la voz en la
@@ -295,7 +294,7 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
   const [dicho, setDicho] = useState(null);
   const dichoTimer = useRef(null);
   const decir = useCallback(
-    (texto) => {
+    (texto, prioridad = PRIORIDAD.RESPUESTA) => {
       if (!texto) return;
       setDicho(texto);
       if (dichoTimer.current) clearTimeout(dichoTimer.current);
@@ -303,7 +302,7 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
         () => setDicho(null),
         Math.min(14000, 4000 + texto.length * 55),
       );
-      hablar(texto);
+      hablar(texto, prioridad);
     },
     [hablar],
   );
@@ -328,7 +327,9 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
     const saludar = () => {
       if (saludado.current) return;
       saludado.current = true;
-      decir(NARRACION.bienvenida);
+      // Bienvenida espontánea → AMBIENTE: si Angelita ya está hablando en
+      // otra superficie, este saludo se descarta en vez de pisarla.
+      decir(NARRACION.bienvenida, PRIORIDAD.AMBIENTE);
     };
     window.addEventListener('pointerdown', saludar, { once: true, capture: true });
     window.addEventListener('keydown', saludar, { once: true, capture: true });
@@ -465,7 +466,8 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
       MUNDO_VALLE_BY_ID[nav.mundoId]?.lema ||
       `Está en ${tituloDeMundo(nav.mundoId)}.`;
     const t = setTimeout(
-      () => decir(`${texto} Toque un punto para ver a dónde lo lleva.`),
+      // Narración espontánea de entrada → AMBIENTE (no pisa lo que suene).
+      () => decir(`${texto} Toque un punto para ver a dónde lo lleva.`, PRIORIDAD.AMBIENTE),
       700,
     );
     return () => clearTimeout(t);

--- a/src/mockups/valle/AcompananteMundo.jsx
+++ b/src/mockups/valle/AcompananteMundo.jsx
@@ -35,7 +35,11 @@ import { Children, cloneElement, isValidElement, useCallback, useEffect, useMemo
 import { MUNDO, tituloDeMundo, tinteDeMundo } from '../../visual/mundo3d/index.js';
 import { parseComandoMundo, puertasDeMundo } from '../../visual/mundo3d/comandoMundo.js';
 import { NARRACION, MUNDO_VALLE_BY_ID } from './valleData';
-import { speak, speakKokoro, stop as stopSpeak } from '../../services/ttsService.js';
+// GARGANTA ÚNICA (2026-07-19): la voz del acompañante pasa por la cola de
+// Angelita (angelitaVoz) — nunca dos audios pisados entre mundos/pantallas.
+// El respaldo Web Speech y el carácter (voz kokoro, ritmo pausado) viven
+// dentro del motor de la cola, no aquí.
+import { decir as decirVoz, callar as callarVoz, PRIORIDAD } from '../../services/angelitaVoz.js';
 import './acompananteMundo.css';
 
 /* La narración de un mundo, con la MISMA cadena de fallbacks del shell:
@@ -71,23 +75,23 @@ export function useAcompanante(mundoId) {
     vozRef.current = voz;
   }, [voz]);
 
-  const hablar = useCallback((texto) => {
+  const hablar = useCallback((texto, prioridad = PRIORIDAD.RESPUESTA) => {
     if (!vozRef.current || !texto) return;
-    speakKokoro(texto, { lang: 'es', rate: 0.98 })
-      .then((audio) => {
-        if (!audio && vozRef.current) speak(texto, { rate: 0.98, pitch: 1 });
-      })
-      .catch(() => {
-        if (vozRef.current) speak(texto, { rate: 0.98, pitch: 1 });
-      });
-  }, []);
+    // decir() nunca rechaza ni cuelga (cola con watchdog + respaldos
+    // internos); la burbuja ya salió — el texto SIEMPRE llega.
+    decirVoz(texto, { prioridad, origen: `mundo:${mundoId}` }).catch(() => {});
+  }, [mundoId]);
 
   // ── Angelita DICE (voz + burbuja): el texto SIEMPRE va a la burbuja
   //    (aria-live). Sin voz (equipo o toggle), la burbuja es la voz.
+  //    `prioridad`: lo que el usuario PIDIÓ (botón, puerta, comando) entra
+  //    como RESPUESTA; la narración espontánea de entrada, como AMBIENTE —
+  //    si Angelita ya está hablando en otra parte, el comentario de ambiente
+  //    se descarta en vez de pisarla (política de la cola).
   const [dicho, setDicho] = useState(null);
   const dichoTimer = useRef(null);
   const decir = useCallback(
-    (texto) => {
+    (texto, prioridad = PRIORIDAD.RESPUESTA) => {
       if (!texto) return;
       setDicho(texto);
       if (dichoTimer.current) clearTimeout(dichoTimer.current);
@@ -95,14 +99,14 @@ export function useAcompanante(mundoId) {
         () => setDicho(null),
         Math.min(14000, 4000 + texto.length * 55),
       );
-      hablar(texto);
+      hablar(texto, prioridad);
     },
     [hablar],
   );
   useEffect(
     () => () => {
       if (dichoTimer.current) clearTimeout(dichoTimer.current);
-      stopSpeak();
+      callarVoz();
     },
     [],
   );
@@ -114,7 +118,10 @@ export function useAcompanante(mundoId) {
   //    con gesto para oírla.
   useEffect(() => {
     const t = setTimeout(
-      () => decir(`${narracionDeMundo(mundoId)} Toque un punto para ver a dónde lo lleva.`),
+      () => decir(
+        `${narracionDeMundo(mundoId)} Toque un punto para ver a dónde lo lleva.`,
+        PRIORIDAD.AMBIENTE,
+      ),
       900,
     );
     return () => clearTimeout(t);
@@ -266,7 +273,7 @@ export default function AcompananteMundo({ mundoId, acompanante, children }) {
   // App.jsx escucha desde cualquier pantalla.
   const preguntarAlAgente = useCallback(() => {
     if (typeof window === 'undefined') return;
-    stopSpeak();
+    callarVoz();
     window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'agente' } }));
   }, []);
 
@@ -330,7 +337,7 @@ export default function AcompananteMundo({ mundoId, acompanante, children }) {
             onClick={() => {
               const n = !voz;
               setVoz(n);
-              if (!n) stopSpeak();
+              if (!n) callarVoz();
             }}
           >
             {!vozDisponible ? '💬 Texto' : voz ? '🔊 Voz' : '🔇 Voz'}

--- a/src/prodApp/ProdChagraApp.jsx
+++ b/src/prodApp/ProdChagraApp.jsx
@@ -30,6 +30,7 @@ import NetworkStatusBar from '../components/NetworkStatusBar.jsx';
 // por el operador ocurre cuando el fetch asíncrono de speakKokoro resuelve
 // DESPUES de que el componente se desmontó → el audio se reproduce sin dueño.
 import { stop as stopAllAudio } from '../services/ttsService.js';
+import { callar as callarAngelita } from '../services/angelitaVoz.js';
 
 import ChagraGrowLoader from '../components/ChagraGrowLoader';
 const LoginScreen = lazy(() => import('../components/LoginScreen.jsx'));
@@ -339,6 +340,9 @@ export default function ProdChagraApp() {
     // Detener cualquier audio de la vista anterior antes de montar la nueva.
     // El loop eterno reportado ocurre cuando el audio asíncrono resuelve
     // después del desmontaje del componente 3D.
+    // callarAngelita() además vacía la COLA de la garganta única — sin esto,
+    // un mensaje encolado en la vista vieja sonaría recién montada la nueva.
+    try { callarAngelita(); } catch { /* la voz puede no estar cargada */ }
     try { stopAllAudio(); } catch { /* ttsService puede no estar inicializado */ }
     setNavData(data ?? null);
     setCurrentView(view);

--- a/src/services/__tests__/angelitaCaracter.test.js
+++ b/src/services/__tests__/angelitaCaracter.test.js
@@ -1,0 +1,119 @@
+/*
+ * angelitaCaracter.test — el carácter de la voz de Angelita.
+ *
+ * Garantiza que el "aterciopelado" del texto mejora la prosodia SIN tocar
+ * el contenido (cero invención, cero pérdida de palabras), que el ritmo
+ * pausado del personaje cede ante la preferencia explícita del usuario, y
+ * que el override de voz propio valida contra las voces reales.
+ */
+
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+  darCaracter,
+  vozDeAngelita,
+  setVozDeAngelita,
+  rateDeAngelita,
+  opcionesDeVozAngelita,
+  RATE_ANGELITA,
+  VOZ_ANGELITA_KEY,
+} from '../angelitaCaracter.js';
+import { DEFAULT_KOKORO_VOICE } from '../ttsService.js';
+
+afterEach(() => {
+  localStorage.removeItem(VOZ_ANGELITA_KEY);
+  localStorage.removeItem('chagra:tts:rate');
+  localStorage.removeItem('chagra:tts:voice');
+});
+
+describe('darCaracter — aterciopelar sin cambiar el contenido', () => {
+  test('quita emojis (kokoro los deletrea feo)', () => {
+    expect(darCaracter('Su mata va muy bien 🌱🐝')).toBe('Su mata va muy bien.');
+  });
+
+  test('baja los gritos a un solo signo (calidez, no alarma)', () => {
+    expect(darCaracter('¡Qué maravilla!!!')).toBe('¡Qué maravilla!');
+    expect(darCaracter('¿¿Cómo así???')).toBe('¿¿Cómo así?');
+  });
+
+  test('el guion largo con aire se vuelve pausa (coma)', () => {
+    expect(darCaracter('La mata — la que sembró — creció.'))
+      .toBe('La mata, la que sembró, creció.');
+  });
+
+  test('quita comillas angulares y tipográficas, conserva el contenido', () => {
+    expect(darCaracter('«El café» está “muy bueno”.')).toBe('El café está muy bueno.');
+  });
+
+  test('cierra SIEMPRE con puntuación (la entonación no queda colgada)', () => {
+    expect(darCaracter('Buenas, vecina')).toBe('Buenas, vecina.');
+    expect(darCaracter('¿Le ayudo?')).toBe('¿Le ayudo?');
+  });
+
+  test('conserva el usted, las tildes y la eñe intactos', () => {
+    const texto = 'Usted sembró la mañana del miércoles, ¿cierto?';
+    expect(darCaracter(texto)).toBe(texto);
+  });
+
+  test('es idempotente (doble pase = mismo resultado)', () => {
+    const muestras = [
+      'Su mata va muy bien 🌱🐝',
+      '¡Qué maravilla!!!',
+      'La mata — la que sembró — creció',
+      '«El café» está listo',
+      'Buenas, vecina',
+    ];
+    for (const m of muestras) {
+      expect(darCaracter(darCaracter(m))).toBe(darCaracter(m));
+    }
+  });
+
+  test('entradas no-string o vacías pasan sin romper', () => {
+    expect(darCaracter('')).toBe('');
+    expect(darCaracter(null)).toBe(null);
+    expect(darCaracter(undefined)).toBe(undefined);
+  });
+});
+
+describe('vozDeAngelita — una voz consistente', () => {
+  test('sin override usa la voz preferida global (default del sistema)', () => {
+    expect(vozDeAngelita()).toBe(DEFAULT_KOKORO_VOICE);
+  });
+
+  test('el override propio válido gana', () => {
+    expect(setVozDeAngelita('ef_dora')).toBe(true);
+    expect(vozDeAngelita()).toBe('ef_dora');
+  });
+
+  test('un override inválido se rechaza y no cambia nada', () => {
+    expect(setVozDeAngelita('voz_que_no_existe')).toBe(false);
+    expect(vozDeAngelita()).toBe(DEFAULT_KOKORO_VOICE);
+  });
+
+  test('limpiar el override vuelve a la preferida global', () => {
+    setVozDeAngelita('ef_dora');
+    expect(setVozDeAngelita('')).toBe(true);
+    expect(vozDeAngelita()).toBe(DEFAULT_KOKORO_VOICE);
+  });
+});
+
+describe('rateDeAngelita — pausado propio, preferencia del usuario manda', () => {
+  test('sin preferencia del usuario: el ritmo pausado del personaje', () => {
+    expect(rateDeAngelita()).toBe(RATE_ANGELITA);
+  });
+
+  test('con preferencia explícita del usuario, esa gana', () => {
+    localStorage.setItem('chagra:tts:rate', '1.05');
+    expect(rateDeAngelita()).toBe(1.05);
+  });
+});
+
+describe('opcionesDeVozAngelita — listas para el motor', () => {
+  test('trae voz, ritmo y español', () => {
+    const opts = opcionesDeVozAngelita();
+    expect(opts).toEqual({
+      voice: DEFAULT_KOKORO_VOICE,
+      rate: RATE_ANGELITA,
+      lang: 'es',
+    });
+  });
+});

--- a/src/services/__tests__/angelitaVoz.test.js
+++ b/src/services/__tests__/angelitaVoz.test.js
@@ -1,0 +1,323 @@
+/*
+ * angelitaVoz.test — la GARGANTA ÚNICA, probada de verdad (no emergente).
+ *
+ * Lo que estos tests garantizan:
+ *   1. Dos mensajes seguidos JAMÁS suenan a la vez (serialización).
+ *   2. La política de llegada es la documentada: mayor interrumpe, igual
+ *      encola, AMBIENTE se descarta si está ocupada, reemplaza vacía todo.
+ *   3. Un fallo del motor (red caída, kokoro muerto) no cuelga la cola ni
+ *      pierde el mensaje: el TEXTO se emite siempre y decir() resuelve.
+ *   4. El watchdog corta un motor colgado y la cola sigue.
+ *   5. Sin gesto de usuario no se intenta audio (autoplay policy); con
+ *      prefers-reduced-motion lo espontáneo (AMBIENTE) queda en texto.
+ *
+ * El motor es inyectado (cero audio real, cero red): se prueba la
+ * AUTORIDAD, no la síntesis (esa vive en ttsService y sus propios tests).
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  decir,
+  callar,
+  estaHablando,
+  estadoCola,
+  onTexto,
+  politicaLlegada,
+  marcarGesto,
+  setAudioHabilitado,
+  PRIORIDAD,
+  MOTIVO,
+  MAX_COLA,
+  WATCHDOG_BASE_MS,
+  WATCHDOG_POR_CHAR_MS,
+  __resetParaTests,
+} from '../angelitaVoz.js';
+
+/** Motor controlable: cada decir() queda pendiente hasta resolverlo a mano. */
+function motorControlable() {
+  const pendientes = [];
+  const motor = {
+    decir: vi.fn((texto) => new Promise((res, rej) => {
+      pendientes.push({ res, rej, texto });
+    })),
+    parar: vi.fn(),
+  };
+  motor.terminaActual = (sono = true) => { pendientes.shift()?.res(sono); };
+  motor.fallaActual = () => { pendientes.shift()?.rej(new Error('motor caído')); };
+  return motor;
+}
+
+/** Deja correr las microtareas + timers 0 (la cola activa en microtask). */
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+let motor;
+
+beforeEach(() => {
+  motor = motorControlable();
+  __resetParaTests({ motor, gesto: true, audio: true });
+});
+
+afterEach(() => {
+  callar();
+  vi.useRealTimers();
+});
+
+describe('política de llegada (pura)', () => {
+  test('sin nada sonando, reproduce', () => {
+    expect(politicaLlegada({ prioridad: PRIORIDAD.AMBIENTE }, null)).toBe('reproducir');
+  });
+  test('prioridad mayor interrumpe', () => {
+    expect(politicaLlegada(
+      { prioridad: PRIORIDAD.ALERTA },
+      { prioridad: PRIORIDAD.NORMAL },
+    )).toBe('interrumpir');
+  });
+  test('prioridad igual encola', () => {
+    expect(politicaLlegada(
+      { prioridad: PRIORIDAD.RESPUESTA },
+      { prioridad: PRIORIDAD.RESPUESTA },
+    )).toBe('encolar');
+  });
+  test('AMBIENTE con algo sonando se descarta (su momento pasó)', () => {
+    expect(politicaLlegada(
+      { prioridad: PRIORIDAD.AMBIENTE },
+      { prioridad: PRIORIDAD.NORMAL },
+    )).toBe('descartar');
+  });
+  test('menor no-ambiente espera turno', () => {
+    expect(politicaLlegada(
+      { prioridad: PRIORIDAD.NORMAL },
+      { prioridad: PRIORIDAD.RESPUESTA },
+    )).toBe('encolar');
+  });
+});
+
+describe('serialización — nunca dos audios a la vez', () => {
+  test('el segundo mensaje espera a que termine el primero', async () => {
+    const p1 = decir('Primero le cuento esto.', { prioridad: PRIORIDAD.NORMAL });
+    await tick();
+    const p2 = decir('Y después esto otro.', { prioridad: PRIORIDAD.NORMAL });
+    await tick();
+
+    // Con el primero aún sonando, el motor SOLO fue llamado una vez.
+    expect(motor.decir).toHaveBeenCalledTimes(1);
+    expect(estadoCola().pendientes).toHaveLength(1);
+
+    motor.terminaActual(true);
+    await expect(p1).resolves.toEqual({ hablado: true, motivo: MOTIVO.OK });
+    await tick();
+
+    // Solo al terminar el primero arranca el segundo.
+    expect(motor.decir).toHaveBeenCalledTimes(2);
+    expect(motor.decir.mock.calls[1][0]).toMatch(/después esto otro/);
+    motor.terminaActual(true);
+    await expect(p2).resolves.toEqual({ hablado: true, motivo: MOTIVO.OK });
+    expect(estaHablando()).toBe(false);
+  });
+
+  test('mismo texto repetido no se apila (dedup)', async () => {
+    decir('Se repite igualito.', { prioridad: PRIORIDAD.NORMAL });
+    await tick();
+    const res = await decir('Se repite igualito.', { prioridad: PRIORIDAD.NORMAL });
+    expect(res.motivo).toBe(MOTIVO.DUPLICADO);
+    expect(motor.decir).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('interrupción por prioridad', () => {
+  test('una ALERTA corta lo que suena y suena ya', async () => {
+    const pNormal = decir('Aviso tranquilo del día.', { prioridad: PRIORIDAD.NORMAL });
+    await tick();
+    expect(motor.decir).toHaveBeenCalledTimes(1);
+
+    const pAlerta = decir('¡Riesgo de helada esta noche!', { prioridad: PRIORIDAD.ALERTA });
+    // El interrumpido resuelve de una: cortado, no se reanuda.
+    await expect(pNormal).resolves.toEqual({ hablado: false, motivo: MOTIVO.INTERRUMPIDO });
+    expect(motor.parar).toHaveBeenCalled();
+    await tick();
+    expect(motor.decir).toHaveBeenCalledTimes(2);
+    expect(motor.decir.mock.calls[1][0]).toMatch(/helada/);
+
+    // El settle tardío del motor viejo NO rompe ni pisa al nuevo.
+    motor.terminaActual(true); // resuelve la promesa pendiente del viejo
+    await tick();
+    expect(estadoCola().actual?.texto).toMatch(/helada/);
+    motor.terminaActual(true);
+    await expect(pAlerta).resolves.toEqual({ hablado: true, motivo: MOTIVO.OK });
+  });
+
+  test('la interrupción purga lo AMBIENTE encolado', async () => {
+    decir('Respuesta larga del agente.', { prioridad: PRIORIDAD.RESPUESTA });
+    await tick();
+    // NORMAL espera turno; llega ALERTA: interrumpe y el NORMAL sobrevive.
+    const pNormal = decir('Recordatorio de riego.', { prioridad: PRIORIDAD.NORMAL });
+    const pAlerta = decir('¡Alerta seria!', { prioridad: PRIORIDAD.ALERTA });
+    await tick();
+    expect(estadoCola().actual?.texto).toMatch(/Alerta seria/);
+    expect(estadoCola().pendientes.map((m) => m.texto)).toEqual(['Recordatorio de riego.']);
+    motor.terminaActual(true); // settle tardío del interrumpido (no-op)
+    motor.terminaActual(true); // termina la alerta
+    await pAlerta;
+    await tick();
+    motor.terminaActual(true); // termina el normal
+    await expect(pNormal).resolves.toEqual({ hablado: true, motivo: MOTIVO.OK });
+  });
+
+  test('AMBIENTE llegando con la garganta ocupada se descarta', async () => {
+    decir('Estoy contando algo.', { prioridad: PRIORIDAD.NORMAL });
+    await tick();
+    const res = await decir('Mire ese colibrí.', { prioridad: PRIORIDAD.AMBIENTE });
+    expect(res).toEqual({ hablado: false, motivo: MOTIVO.OCUPADA });
+    expect(motor.decir).toHaveBeenCalledTimes(1);
+    expect(estadoCola().pendientes).toHaveLength(0);
+  });
+
+  test('reemplaza:true vacía todo y suena ya (modo chat)', async () => {
+    const pVieja = decir('Respuesta vieja.', { prioridad: PRIORIDAD.RESPUESTA });
+    await tick();
+    const pEncolada = decir('Otra en cola.', { prioridad: PRIORIDAD.RESPUESTA });
+    const pNueva = decir('Respuesta nueva.', { prioridad: PRIORIDAD.RESPUESTA, reemplaza: true });
+    await expect(pVieja).resolves.toEqual({ hablado: false, motivo: MOTIVO.CALLADA });
+    await expect(pEncolada).resolves.toEqual({ hablado: false, motivo: MOTIVO.CALLADA });
+    await tick();
+    expect(estadoCola().actual?.texto).toBe('Respuesta nueva.');
+    motor.terminaActual(true); // settle tardío del viejo
+    motor.terminaActual(true);
+    await expect(pNueva).resolves.toEqual({ hablado: true, motivo: MOTIVO.OK });
+  });
+});
+
+describe('tope de cola', () => {
+  test('con la cola llena, el excedente resuelve cola-llena y nada cuelga', async () => {
+    decir('Sonando.', { prioridad: PRIORIDAD.NORMAL });
+    await tick();
+    for (let i = 0; i < MAX_COLA; i++) {
+      // Las encoladas quedan pendientes; el afterEach (callar) las resuelve.
+      decir(`En cola número ${i}.`, { prioridad: PRIORIDAD.NORMAL });
+    }
+    const excedente = await decir('Yo ya no quepo.', { prioridad: PRIORIDAD.NORMAL });
+    expect(excedente.motivo).toBe(MOTIVO.COLA_LLENA);
+    expect(estadoCola().pendientes).toHaveLength(MAX_COLA);
+  });
+});
+
+describe('degradación digna (offline-first)', () => {
+  test('el texto SIEMPRE llega, aunque el motor falle, y la cola avanza', async () => {
+    const textos = [];
+    onTexto((m) => textos.push(m.texto));
+
+    const p1 = decir('Este audio va a fallar.', { prioridad: PRIORIDAD.NORMAL });
+    await tick();
+    const p2 = decir('Yo sí debo sonar después.', { prioridad: PRIORIDAD.NORMAL });
+
+    motor.fallaActual(); // red caída / kokoro muerto
+    await expect(p1).resolves.toEqual({ hablado: false, motivo: MOTIVO.AUDIO_FALLO });
+    await tick();
+    // La cola NO se colgó: el siguiente arrancó solo.
+    expect(motor.decir).toHaveBeenCalledTimes(2);
+    motor.terminaActual(true);
+    await expect(p2).resolves.toEqual({ hablado: true, motivo: MOTIVO.OK });
+
+    // Ambos textos llegaron a la UI pase lo que pase con el audio.
+    expect(textos).toEqual(['Este audio va a fallar.', 'Yo sí debo sonar después.']);
+  });
+
+  test('motor que devuelve false (nada sonó) resuelve audio-fallo sin colgar', async () => {
+    const p = decir('Nadie me reprodujo.', { prioridad: PRIORIDAD.NORMAL });
+    await tick();
+    motor.terminaActual(false);
+    await expect(p).resolves.toEqual({ hablado: false, motivo: MOTIVO.AUDIO_FALLO });
+    expect(estaHablando()).toBe(false);
+  });
+
+  test('WATCHDOG: un motor colgado se corta y la cola sigue', async () => {
+    vi.useFakeTimers();
+    const colgado = {
+      decir: vi.fn(() => new Promise(() => { /* jamás resuelve */ })),
+      parar: vi.fn(),
+    };
+    __resetParaTests({ motor: colgado, gesto: true });
+
+    const texto = 'Me voy a quedar pegado.';
+    const p1 = decir(texto, { prioridad: PRIORIDAD.NORMAL });
+    const p2 = decir('Yo espero mi turno.', { prioridad: PRIORIDAD.NORMAL });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(colgado.decir).toHaveBeenCalledTimes(1);
+
+    const plazo = WATCHDOG_BASE_MS + texto.length * WATCHDOG_POR_CHAR_MS;
+    await vi.advanceTimersByTimeAsync(plazo + 10);
+
+    expect(colgado.parar).toHaveBeenCalled();
+    await expect(p1).resolves.toEqual({ hablado: false, motivo: MOTIVO.WATCHDOG });
+    // La cola avanzó al siguiente en vez de quedarse rehén.
+    expect(colgado.decir).toHaveBeenCalledTimes(2);
+    callar();
+    await p2;
+  });
+});
+
+describe('autoplay y calma', () => {
+  test('sin gesto del usuario NO se intenta audio, pero el texto llega', async () => {
+    __resetParaTests({ motor, gesto: false });
+    const textos = [];
+    onTexto((m) => textos.push(m.texto));
+
+    const res = await decir('Hola sin gesto.', { prioridad: PRIORIDAD.RESPUESTA });
+    expect(res).toEqual({ hablado: false, motivo: MOTIVO.SIN_GESTO });
+    expect(motor.decir).not.toHaveBeenCalled();
+    expect(textos).toEqual(['Hola sin gesto.']);
+
+    // Tras el gesto, la voz ya puede.
+    marcarGesto();
+    decir('Ahora sí con gesto.', { prioridad: PRIORIDAD.RESPUESTA });
+    await tick();
+    expect(motor.decir).toHaveBeenCalledTimes(1);
+  });
+
+  test('con audio deshabilitado resuelve audio-off y el texto llega', async () => {
+    setAudioHabilitado(false);
+    const textos = [];
+    onTexto((m) => textos.push(m.texto));
+    const res = await decir('Solo texto, por favor.', { prioridad: PRIORIDAD.NORMAL });
+    expect(res).toEqual({ hablado: false, motivo: MOTIVO.AUDIO_OFF });
+    expect(motor.decir).not.toHaveBeenCalled();
+    expect(textos).toEqual(['Solo texto, por favor.']);
+  });
+
+  test('prefers-reduced-motion calla lo espontáneo (AMBIENTE) pero no lo pedido', async () => {
+    const matchMediaOriginal = window.matchMedia;
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+    try {
+      const ambiente = await decir('Comentario espontáneo.', { prioridad: PRIORIDAD.AMBIENTE });
+      expect(ambiente).toEqual({ hablado: false, motivo: MOTIVO.CALMA });
+      expect(motor.decir).not.toHaveBeenCalled();
+
+      decir('Usted me pidió oír esto.', { prioridad: PRIORIDAD.RESPUESTA });
+      await tick();
+      expect(motor.decir).toHaveBeenCalledTimes(1);
+    } finally {
+      window.matchMedia = matchMediaOriginal;
+    }
+  });
+});
+
+describe('callar y entradas inválidas', () => {
+  test('callar() corta lo actual y vacía la cola (todo resuelve callada)', async () => {
+    const p1 = decir('Sonando ahora.', { prioridad: PRIORIDAD.NORMAL });
+    await tick();
+    const p2 = decir('Esperando turno.', { prioridad: PRIORIDAD.NORMAL });
+    callar();
+    await expect(p1).resolves.toEqual({ hablado: false, motivo: MOTIVO.CALLADA });
+    await expect(p2).resolves.toEqual({ hablado: false, motivo: MOTIVO.CALLADA });
+    expect(motor.parar).toHaveBeenCalled();
+    expect(estaHablando()).toBe(false);
+    expect(estadoCola().pendientes).toHaveLength(0);
+  });
+
+  test('texto vacío o no-string resuelve vacio sin tocar el motor', async () => {
+    await expect(decir('')).resolves.toEqual({ hablado: false, motivo: MOTIVO.VACIO });
+    await expect(decir('   ')).resolves.toEqual({ hablado: false, motivo: MOTIVO.VACIO });
+    await expect(decir(null)).resolves.toEqual({ hablado: false, motivo: MOTIVO.VACIO });
+    expect(motor.decir).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/angelitaCaracter.js
+++ b/src/services/angelitaCaracter.js
@@ -1,0 +1,181 @@
+/*
+ * angelitaCaracter — CÓMO SUENA Angelita (la abeja compañera de Chagra).
+ *
+ * Este módulo es el CARÁCTER de la voz, no el motor: decide con qué voz, a
+ * qué ritmo y con qué forma de texto habla Angelita, para que suene como
+ * ELLA en cualquier pantalla de la app. El motor (síntesis kokoro + cola)
+ * vive en ttsService.js / angelitaVoz.js.
+ *
+ * Fuente: DR "diseño de la voz de un personaje companion (abeja Angelita)
+ * para niños y campesinos" (deepresearch/DR-FANOUT, 2026-06-19). Lo que el
+ * DR pide y aquí se aterriza:
+ *
+ *   · RITMO PAUSADO Y MEDIDO — la audiencia es una niña de 11 años y
+ *     campesinos con baja alfabetización digital: necesitan tiempo para
+ *     procesar. Rate por defecto 0.95 (un pelito más lento que neutro),
+ *     salvo que el usuario ya haya elegido su velocidad en Ajustes — la
+ *     preferencia explícita del usuario SIEMPRE gana.
+ *   · CLARIDAD > ADORNO — frases cortas, pronunciación limpia. El texto se
+ *     "aterciopela" antes de sintetizar: fuera emojis (kokoro los deletrea
+ *     o los ignora feo), fuera signos gritados (!!!), guiones largos se
+ *     vuelven pausas (coma), y toda frase cierra con puntuación para que
+ *     la entonación caiga natural y no quede colgada.
+ *   · ESPAÑOL DE COLOMBIA, USTED — el léxico ya lo garantizan el guion
+ *     (angelitaInteligencia, saludoPantalla: usted cálido, nunca voseo) y
+ *     la guarda filterVoseo dentro de ttsService. Aquí NO se re-filtra:
+ *     una sola autoridad por regla.
+ *   · UNA SOLA VOZ CONSISTENTE — Angelita usa la voz kokoro preferida del
+ *     usuario (o la default del sistema). Hay una llave de override propia
+ *     (VOZ_ANGELITA_KEY) para el día que el operador consiga/apruebe una
+ *     voz femenina colombiana real (XTTS con sample colombiano, o una voz
+ *     kokoro nueva); mientras tanto NO forzamos ninguna voz vetada.
+ *   · EL SILENCIO ES PARTE DE LA VOZ — la cadencia anti-molestia (cuándo
+ *     NO hablar) no vive aquí sino en la cola (angelitaVoz: los comentarios
+ *     de ambiente se descartan si ella ya está hablando) y en el motor de
+ *     comportamiento (angelitaInteligencia: cooldowns).
+ *
+ * SOLO funciones puras + lectura de preferencias. Cero red, cero audio.
+ */
+
+import {
+  KOKORO_VOICES,
+  getPreferredVoice,
+  getPreferredRate,
+  KOKORO_RATE_MIN,
+  KOKORO_RATE_MAX,
+} from './ttsService.js';
+
+/**
+ * Override opcional de la voz kokoro de Angelita (localStorage). Vacío o
+ * inválido → se usa la voz preferida global del usuario. Existe para poder
+ * darle a Angelita una voz PROPIA (distinta de la del lector de pantalla
+ * general) el día que haya una voz femenina colombiana aprobada.
+ */
+export const VOZ_ANGELITA_KEY = 'chagra:angelita:voz';
+
+/**
+ * Ritmo por defecto de Angelita: 0.95 — pausado y medido (DR de voz §2:
+ * niños y baja alfabetización necesitan tiempo de proceso), sin sonar
+ * arrastrado. Solo aplica si el usuario NO fijó su propia velocidad.
+ */
+export const RATE_ANGELITA = 0.95;
+
+/* Misma llave que usa ttsService para la velocidad preferida (privada allá;
+ * aquí solo se consulta EXISTENCIA para saber si el usuario eligió algo). */
+const RATE_USUARIO_KEY = 'chagra:tts:rate';
+
+const IDS_VALIDOS = new Set(KOKORO_VOICES.map((v) => v.id));
+
+/**
+ * La voz kokoro con la que habla Angelita.
+ * Prioridad: override propio válido → voz preferida global del usuario.
+ * @returns {string} id de voz kokoro servible.
+ */
+export function vozDeAngelita() {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      const propia = localStorage.getItem(VOZ_ANGELITA_KEY);
+      if (propia && IDS_VALIDOS.has(propia)) return propia;
+    }
+  } catch (_) { /* storage inaccesible: cae a la preferida global */ }
+  return getPreferredVoice();
+}
+
+/**
+ * Fija (o limpia con '' / null) la voz propia de Angelita.
+ * @param {string|null} voiceId - id kokoro válido, o vacío para limpiar.
+ * @returns {boolean} true si persistió el cambio.
+ */
+export function setVozDeAngelita(voiceId) {
+  try {
+    if (typeof localStorage === 'undefined') return false;
+    if (!voiceId) {
+      localStorage.removeItem(VOZ_ANGELITA_KEY);
+      return true;
+    }
+    if (!IDS_VALIDOS.has(voiceId)) return false;
+    localStorage.setItem(VOZ_ANGELITA_KEY, voiceId);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * El ritmo al que habla Angelita. La preferencia explícita del usuario
+ * (Ajustes → velocidad) SIEMPRE gana; sin preferencia, el pausado propio
+ * del personaje (RATE_ANGELITA), clampeado al rango servible.
+ * @returns {number}
+ */
+export function rateDeAngelita() {
+  try {
+    if (typeof localStorage !== 'undefined' && localStorage.getItem(RATE_USUARIO_KEY) !== null) {
+      return getPreferredRate();
+    }
+  } catch (_) { /* storage inaccesible: ritmo propio */ }
+  return Math.min(KOKORO_RATE_MAX, Math.max(KOKORO_RATE_MIN, RATE_ANGELITA));
+}
+
+/**
+ * "Aterciopela" un texto para la GARGANTA de Angelita: mismo contenido,
+ * mejor prosodia. Pensado para correr ANTES de sanitizeForTTS (que quita
+ * markdown) — ambos son idempotentes y componen en cualquier orden.
+ *
+ *   · Emojis fuera — kokoro los deletrea o los traga con glitch.
+ *   · «Comillas angulares» y "tipográficas" fuera (el contenido queda).
+ *   · ¡Gritos!!! → un solo signo (calidez, no alarma — DR §1: sonrisa
+ *     audible, no locutor eufórico).
+ *   · Guion largo con aire ( — ) → coma: pausa natural en la síntesis.
+ *   · Cierre con puntuación SIEMPRE: sin punto final la entonación kokoro
+ *     queda suspendida (suena a robot que se apagó).
+ *
+ * Idempotente: darCaracter(darCaracter(x)) === darCaracter(x).
+ *
+ * @param {string} texto
+ * @returns {string}
+ */
+export function darCaracter(texto) {
+  if (typeof texto !== 'string' || texto.length === 0) return texto;
+  let t = texto
+    // Emojis y pictogramas → espacio (no pegar palabras vecinas).
+    .replace(/\p{Extended_Pictographic}/gu, ' ')
+    // Selectores de variante y zero-width joiners residuales.
+    .replace(/[️‍]/g, '')
+    // Comillas angulares y tipográficas: el contenido se dice, ellas no.
+    .replace(/[«»“”„]/g, '')
+    // Signos repetidos → uno (habla cálida, no gritada).
+    .replace(/!{2,}/g, '!')
+    .replace(/\?{2,}/g, '?')
+    // Guion largo/corto con aire → coma (pausa de respiración).
+    .replace(/\s+[—–]\s+/g, ', ')
+    // Espacios múltiples que dejaron los reemplazos.
+    .replace(/[ \t]{2,}/g, ' ')
+    // Espacio huérfano antes de puntuación ("hola !", "sí .").
+    .replace(/ ([.,;:!?])/g, '$1')
+    .trim();
+  if (t.length > 0 && !/[.!?…:]$/.test(t)) t = `${t}.`;
+  return t;
+}
+
+/**
+ * Las opciones de síntesis con las que Angelita habla, listas para pasarle
+ * al motor (ttsService.speakSentences): su voz, su ritmo, español.
+ * @returns {{ voice: string, rate: number, lang: string }}
+ */
+export function opcionesDeVozAngelita() {
+  return {
+    voice: vozDeAngelita(),
+    rate: rateDeAngelita(),
+    lang: 'es',
+  };
+}
+
+export default {
+  VOZ_ANGELITA_KEY,
+  RATE_ANGELITA,
+  vozDeAngelita,
+  setVozDeAngelita,
+  rateDeAngelita,
+  darCaracter,
+  opcionesDeVozAngelita,
+};

--- a/src/services/angelitaVoz.js
+++ b/src/services/angelitaVoz.js
@@ -1,0 +1,439 @@
+/*
+ * angelitaVoz — LA GARGANTA ÚNICA de Angelita (autoridad de reproducción).
+ *
+ * PROBLEMA QUE RESUELVE (bug "los audios se pisan", 2026-07-19): hasta hoy
+ * cada superficie (AgentScreen, el shell del valle, el hero, onboarding…)
+ * llamaba a ttsService por su cuenta. Dos llamadas cercanas = dos <audio>
+ * sonando encima, o un stop() bruto a mitad de frase. Angelita tenía cuerpo
+ * en toda la app pero garganta repartida.
+ *
+ * ARQUITECTURA (DR "arquitectura de audio para un agente de voz en una PWA
+ * offline-first", deepresearch/DR-FANOUT 2026-06-19): UNA sola autoridad de
+ * reproducción con cola serializada y política EXPLÍCITA de llegada. Nadie
+ * más de la app debe llamar speakKokoro/speakSentences directo para el
+ * habla del personaje — todo pasa por decir().
+ *
+ * POLÍTICA DE LLEGADA (explícita, testeada — no emergente):
+ *   · Nada sonando                  → suena ya.
+ *   · Llega prioridad MAYOR         → INTERRUMPE: corta lo actual (se
+ *     descarta, no se reanuda — retomar a media frase suena a radio dañado),
+ *     purga lo AMBIENTE encolado y suena ya.
+ *   · Llega prioridad IGUAL         → se ENCOLA (FIFO dentro de su nivel).
+ *   · Llega prioridad MENOR         → se encola, SALVO AMBIENTE que se
+ *     DESCARTA: un comentario de ambiente es del momento; decirlo tarde es
+ *     peor que callarlo (anti-molestia, DR de voz §5 "cuándo no hablar").
+ *   · reemplaza:true (opción caller) → vacía todo y suena ya. Es el modo del
+ *     chat: una respuesta nueva del agente deja obsoleta la anterior.
+ *
+ * PRIORIDADES:
+ *   AMBIENTE  (1) — narración espontánea al entrar a un mundo, husmeo.
+ *   NORMAL    (2) — avisos del comportamiento (aviso/celebra del store).
+ *   RESPUESTA (3) — lo que el usuario PIDIÓ oír (respuesta del agente,
+ *                   botón "Escuchar", tocar una puerta).
+ *   ALERTA    (4) — urgencias reales (helada, alerta activa severa).
+ *
+ * LATENCIA kokoro (CPU, lineal con los caracteres: 7KB→3s, 75KB→11s): NO se
+ * recorta la respuesta (política: inteligencia primero). El motor delega en
+ * ttsService.speakSentences, que parte en frases y encadena con prefetch —
+ * el primer audio llega en <2s y el resto fluye. La cola solo gobierna
+ * MENSAJES completos; el encadenado interno de frases ya es serial.
+ *
+ * DEGRADACIÓN DIGNA (offline-first):
+ *   · El TEXTO del mensaje se emite SIEMPRE (onTexto) al activarse, antes
+ *     de intentar audio — sin kokoro, sin red o sin gesto, el mensaje llega
+ *     escrito y la UI nunca queda muda ni colgada.
+ *   · Un fallo del motor NUNCA rechaza hacia el caller: decir() resuelve
+ *     { hablado:false, motivo } y la cola avanza sola.
+ *   · WATCHDOG: si una síntesis/reproducción se queda pegada (backend
+ *     colgado sin timeout), un plazo proporcional al largo del texto corta
+ *     y la cola sigue. La interfaz jamás espera para siempre.
+ *
+ * AUTOPLAY Y CALMA:
+ *   · El audio NUNCA arranca sin un gesto previo del usuario en la sesión
+ *     (pointerdown/keydown global desbloquea — patrón unlock del DR). Antes
+ *     del gesto: solo texto, motivo 'sin-gesto'.
+ *   · prefers-reduced-motion: el habla ESPONTÁNEA (AMBIENTE) se calla y
+ *     queda en texto; lo que el usuario pidió (RESPUESTA) y las urgencias
+ *     (ALERTA/NORMAL) sí suenan — reducir estímulo no es esconder avisos.
+ *
+ * VOZ DEL PERSONAJE: el carácter (voz kokoro, ritmo pausado, texto
+ * aterciopelado) viene de angelitaCaracter.js y se aplica aquí para que
+ * TODAS las superficies suenen a la misma Angelita.
+ */
+
+import { speakSentences, speak, stop as pararMotorTts, isKokoroAvailable } from './ttsService.js';
+import { darCaracter, opcionesDeVozAngelita } from './angelitaCaracter.js';
+
+/** Niveles de prioridad del habla (mayor = más importante). */
+export const PRIORIDAD = Object.freeze({
+  AMBIENTE: 1,
+  NORMAL: 2,
+  RESPUESTA: 3,
+  ALERTA: 4,
+});
+
+/** Motivos con los que resuelve decir() — vocabulario cerrado y testeable. */
+export const MOTIVO = Object.freeze({
+  OK: 'ok',                    // sonó completo
+  VACIO: 'vacio',              // texto vacío/no-string
+  DUPLICADO: 'duplicado',      // mismo texto ya sonando o en cola
+  OCUPADA: 'ocupada',          // AMBIENTE descartado porque ella ya habla
+  COLA_LLENA: 'cola-llena',    // se cayó del tope de la cola
+  INTERRUMPIDO: 'interrumpido',// lo cortó una prioridad mayor
+  CALLADA: 'callada',          // callar() del usuario/caller
+  SIN_GESTO: 'sin-gesto',      // autoplay bloqueado: aún no hubo gesto
+  AUDIO_OFF: 'audio-off',      // audio deshabilitado (toggle voz)
+  CALMA: 'calma',              // prefers-reduced-motion vetó habla espontánea
+  AUDIO_FALLO: 'audio-fallo',  // kokoro y respaldo fallaron (texto ya llegó)
+  WATCHDOG: 'watchdog',        // el motor se colgó; se cortó y se siguió
+});
+
+/** Tope de mensajes esperando turno (además del que suena). */
+export const MAX_COLA = 3;
+
+/* WATCHDOG: plazo = base + porChar·len. kokoro CPU sintetiza ~lineal
+ * (75KB→11s) y la REPRODUCCIÓN dura aprox len/14 chars por segundo; 90ms
+ * por char cubre síntesis+reproducción con holgura amplia sin dejar la UI
+ * rehén de un backend colgado. */
+export const WATCHDOG_BASE_MS = 20000;
+export const WATCHDOG_POR_CHAR_MS = 90;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Motor por defecto: kokoro streaming frase-a-frase; si kokoro NO está
+ * (health check), la voz del navegador como arranque digno (mismo trato
+ * que ya daba AgentScreen). Envuelto en promesa que resuelve al TERMINAR
+ * de sonar — la cola necesita saber cuándo se soltó la garganta.
+ * ──────────────────────────────────────────────────────────────────────── */
+const motorTts = {
+  /**
+   * @param {string} texto - ya aterciopelado (darCaracter).
+   * @param {{voice?: string, rate?: number, lang?: string}} opciones
+   * @returns {Promise<boolean>} true si algo llegó a sonar.
+   */
+  async decir(texto, opciones) {
+    let kokoro = false;
+    try { kokoro = await isKokoroAvailable(); } catch (_) { kokoro = false; }
+    if (kokoro) {
+      // speakSentences resuelve cuando TODA la cadena de frases terminó (o
+      // false si nada sonó). Reintentos y política anti-cambio-de-voz viven
+      // adentro (ttsService).
+      return !!(await speakSentences(texto, opciones));
+    }
+    // Sin kokoro (offline / backend caído de raíz): Web Speech si existe.
+    // pitch apenas arriba de neutro — registro medio-agudo de abeja (DR de
+    // voz §1) sin caer en caricatura.
+    return await new Promise((resolver) => {
+      let utterance = null;
+      try {
+        utterance = speak(texto, { rate: opciones?.rate ?? 0.95, pitch: 1.1 });
+      } catch (_) { utterance = null; }
+      if (!utterance) { resolver(false); return; }
+      // addEventListener y NO .onend: ttsService ya usa .onend para su
+      // estado observable (notifySpeaking) — no se lo pisamos.
+      utterance.addEventListener('end', () => resolver(true));
+      utterance.addEventListener('error', () => resolver(false));
+    });
+  },
+  parar() {
+    try { pararMotorTts(); } catch (_) { /* nunca romper por parar */ }
+  },
+};
+
+/* ── Estado de la autoridad (módulo singleton) ─────────────────────────── */
+let motor = motorTts;
+let actual = null;             // mensaje activo (sonando o entregándose)
+let cola = [];                 // mensajes esperando turno (orden de salida)
+let contadorId = 0;
+let desbloqueada = false;      // ¿ya hubo gesto del usuario en la sesión?
+let audioHabilitado = true;    // toggle global de la garganta (texto sigue)
+const oyentesTexto = new Set();
+
+/* ── Desbloqueo por gesto (autoplay policy) ────────────────────────────── */
+function instalarDesbloqueoPorGesto() {
+  if (typeof document === 'undefined') return;
+  const desbloquear = () => {
+    desbloqueada = true;
+    document.removeEventListener('pointerdown', desbloquear);
+    document.removeEventListener('keydown', desbloquear);
+  };
+  try {
+    document.addEventListener('pointerdown', desbloquear, { passive: true });
+    document.addEventListener('keydown', desbloquear);
+  } catch (_) { /* entorno sin DOM events: quedará bloqueada (solo texto) */ }
+}
+instalarDesbloqueoPorGesto();
+
+/** Marca explícitamente que hubo gesto (para callers que ya lo saben). */
+export function marcarGesto() { desbloqueada = true; }
+
+/** ¿Ya hubo un gesto que desbloquee audio en esta sesión? */
+export function hayGesto() { return desbloqueada; }
+
+/** Prende/apaga la garganta globalmente (el texto SIEMPRE sigue llegando). */
+export function setAudioHabilitado(v) { audioHabilitado = !!v; }
+
+/** ¿prefers-reduced-motion? Guardado — jsdom y browsers viejos no lo traen. */
+function prefiereCalma() {
+  try {
+    return typeof window !== 'undefined'
+      && typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch (_) {
+    return false;
+  }
+}
+
+/* ── La política de llegada, PURA y exportada (testeable sin audio) ────── */
+/**
+ * Decide qué pasa cuando llega un mensaje nuevo estando (o no) otra cosa
+ * sonando. Ver tabla en el encabezado del módulo.
+ * @param {{prioridad: number}} nuevo
+ * @param {{prioridad: number}|null} enCurso
+ * @returns {'reproducir'|'interrumpir'|'encolar'|'descartar'}
+ */
+export function politicaLlegada(nuevo, enCurso) {
+  if (!enCurso) return 'reproducir';
+  if (nuevo.prioridad > enCurso.prioridad) return 'interrumpir';
+  if (nuevo.prioridad === enCurso.prioridad) return 'encolar';
+  return nuevo.prioridad <= PRIORIDAD.AMBIENTE ? 'descartar' : 'encolar';
+}
+
+/* ── Suscripción al texto (la burbuja/UI que quiera oír a Angelita) ────── */
+/**
+ * Cada mensaje ACEPTADO emite su texto al activarse — ANTES de intentar
+ * audio. Es la garantía "el texto siempre llega aunque el audio no".
+ * @param {(msg: {id: string, texto: string, prioridad: number, origen: string}) => void} cb
+ * @returns {() => void} unsubscribe
+ */
+export function onTexto(cb) {
+  if (typeof cb !== 'function') return () => {};
+  oyentesTexto.add(cb);
+  return () => oyentesTexto.delete(cb);
+}
+
+function emitirTexto(msg) {
+  for (const cb of oyentesTexto) {
+    try { cb({ id: msg.id, texto: msg.texto, prioridad: msg.prioridad, origen: msg.origen }); }
+    catch (_) { /* un oyente roto no calla a Angelita */ }
+  }
+}
+
+/* ── El corazón: activar, sonar con guardia, avanzar ───────────────────── */
+
+function resolverMsg(msg, resultado) {
+  if (msg.resuelto) return;
+  msg.resuelto = true;
+  try { msg.resolver(resultado); } catch (_) { /* noop */ }
+}
+
+function terminar(msg, resultado) {
+  resolverMsg(msg, resultado);
+  if (actual === msg) {
+    actual = null;
+    const siguiente = cola.shift();
+    if (siguiente) activar(siguiente);
+  }
+}
+
+function puedeSonar(msg) {
+  if (!audioHabilitado) return { ok: false, motivo: MOTIVO.AUDIO_OFF };
+  if (!desbloqueada) return { ok: false, motivo: MOTIVO.SIN_GESTO };
+  if (msg.prioridad <= PRIORIDAD.AMBIENTE && prefiereCalma()) {
+    return { ok: false, motivo: MOTIVO.CALMA };
+  }
+  return { ok: true };
+}
+
+function activar(msg) {
+  actual = msg;
+  emitirTexto(msg); // el texto llega SIEMPRE, pase lo que pase con el audio
+  const paso = puedeSonar(msg);
+  if (!paso.ok) {
+    terminar(msg, { hablado: false, motivo: paso.motivo });
+    return;
+  }
+  sonarConGuardia(msg);
+}
+
+function sonarConGuardia(msg) {
+  const plazoMs = WATCHDOG_BASE_MS + msg.texto.length * WATCHDOG_POR_CHAR_MS;
+  let cerrado = false;
+  const timer = setTimeout(() => {
+    // El motor se colgó (síntesis o reproducción sin fin): cortar y seguir.
+    motor.parar();
+    cerrar({ hablado: false, motivo: MOTIVO.WATCHDOG });
+  }, plazoMs);
+  const cerrar = (resultado) => {
+    if (cerrado) return;
+    cerrado = true;
+    clearTimeout(timer);
+    if (!msg.vivo) return; // interrumpido/callado: otro camino ya resolvió
+    terminar(msg, resultado);
+  };
+  // Si interrumpen/callan este mensaje, la guardia se desarma (que el timer
+  // viejo no le corte el audio al mensaje NUEVO).
+  msg.desarmarGuardia = () => {
+    cerrado = true;
+    clearTimeout(timer);
+  };
+  Promise.resolve()
+    .then(() => motor.decir(msg.textoVoz, msg.opcionesVoz))
+    .then((sono) => cerrar({ hablado: !!sono, motivo: sono ? MOTIVO.OK : MOTIVO.AUDIO_FALLO }))
+    .catch(() => cerrar({ hablado: false, motivo: MOTIVO.AUDIO_FALLO }));
+}
+
+function cortarActual(motivo) {
+  const cortado = actual;
+  if (!cortado) return;
+  cortado.vivo = false;
+  if (cortado.desarmarGuardia) cortado.desarmarGuardia();
+  actual = null;
+  motor.parar();
+  resolverMsg(cortado, { hablado: false, motivo });
+}
+
+function encolar(msg) {
+  // Inserta manteniendo prioridad (desc); FIFO dentro del mismo nivel.
+  let idx = cola.length;
+  for (let i = 0; i < cola.length; i++) {
+    if (msg.prioridad > cola[i].prioridad) { idx = i; break; }
+  }
+  cola.splice(idx, 0, msg);
+  // Tope: se cae el de MENOR prioridad más al fondo (puede ser el recién
+  // llegado). Resuelve 'cola-llena' — nunca cuelga al caller.
+  if (cola.length > MAX_COLA) {
+    let peor = cola.length - 1;
+    for (let i = cola.length - 1; i >= 0; i--) {
+      if (cola[i].prioridad < cola[peor].prioridad) peor = i;
+    }
+    const [caido] = cola.splice(peor, 1);
+    resolverMsg(caido, { hablado: false, motivo: MOTIVO.COLA_LLENA });
+  }
+}
+
+/* ── API pública ───────────────────────────────────────────────────────── */
+
+/**
+ * Angelita DICE algo — la única puerta de entrada del habla del personaje.
+ *
+ * Nunca rechaza: siempre resuelve { hablado, motivo } (MOTIVO.*). El texto
+ * del mensaje aceptado se emite a onTexto() aunque el audio no pueda.
+ *
+ * @param {string} texto - lo que dice (el carácter lo aterciopela).
+ * @param {Object} [opciones]
+ * @param {number}  [opciones.prioridad=PRIORIDAD.NORMAL] - ver PRIORIDAD.
+ * @param {boolean} [opciones.reemplaza=false] - vaciar todo y sonar ya
+ *   (modo chat: la respuesta nueva deja obsoleta la anterior).
+ * @param {string}  [opciones.origen='app'] - etiqueta de la superficie
+ *   (diagnóstico/telemetría, no afecta la política).
+ * @param {Object}  [opciones.voz] - override puntual de {voice, rate, lang}.
+ * @returns {Promise<{hablado: boolean, motivo: string, id?: string}>}
+ */
+export function decir(texto, opciones = {}) {
+  if (typeof texto !== 'string' || texto.trim().length === 0) {
+    return Promise.resolve({ hablado: false, motivo: MOTIVO.VACIO });
+  }
+  const limpio = texto.trim();
+
+  // Dedup: el mismo texto sonando o esperando no se apila (doble tap,
+  // efecto que re-dispara). Con reemplaza:true sí pasa — reemplazar lo
+  // mismo es legítimo (re-escuchar).
+  if (!opciones.reemplaza
+    && ((actual && actual.texto === limpio) || cola.some((m) => m.texto === limpio))) {
+    return Promise.resolve({ hablado: false, motivo: MOTIVO.DUPLICADO });
+  }
+
+  const msg = {
+    id: `voz-${++contadorId}`,
+    texto: limpio,
+    textoVoz: darCaracter(limpio),
+    prioridad: opciones.prioridad ?? PRIORIDAD.NORMAL,
+    origen: opciones.origen || 'app',
+    opcionesVoz: { ...opcionesDeVozAngelita(), ...(opciones.voz || {}) },
+    vivo: true,
+    resuelto: false,
+    resolver: null,
+    desarmarGuardia: null,
+  };
+  const promesa = new Promise((res) => { msg.resolver = res; });
+
+  if (opciones.reemplaza) {
+    callar();
+    activar(msg);
+    return promesa;
+  }
+
+  const veredicto = politicaLlegada(msg, actual);
+  if (veredicto === 'reproducir') {
+    activar(msg);
+  } else if (veredicto === 'interrumpir') {
+    // Lo AMBIENTE encolado pierde su momento con la interrupción: se purga.
+    cola = cola.filter((m) => {
+      if (m.prioridad <= PRIORIDAD.AMBIENTE) {
+        resolverMsg(m, { hablado: false, motivo: MOTIVO.OCUPADA });
+        return false;
+      }
+      return true;
+    });
+    cortarActual(MOTIVO.INTERRUMPIDO);
+    activar(msg);
+  } else if (veredicto === 'encolar') {
+    encolar(msg);
+  } else {
+    resolverMsg(msg, { hablado: false, motivo: MOTIVO.OCUPADA });
+  }
+  return promesa;
+}
+
+/**
+ * Calla a Angelita del todo: corta lo que suena y vacía la cola. Cada
+ * mensaje pendiente resuelve { hablado:false, motivo:'callada' }.
+ * Idempotente.
+ */
+export function callar() {
+  cortarActual(MOTIVO.CALLADA);
+  const pendientes = cola;
+  cola = [];
+  for (const m of pendientes) resolverMsg(m, { hablado: false, motivo: MOTIVO.CALLADA });
+}
+
+/** ¿Está Angelita con un mensaje activo (sonando o entregándose)? */
+export function estaHablando() { return actual !== null; }
+
+/** Foto del estado para diagnóstico/tests: qué suena y cuánto espera. */
+export function estadoCola() {
+  return {
+    actual: actual ? { id: actual.id, texto: actual.texto, prioridad: actual.prioridad } : null,
+    pendientes: cola.map((m) => ({ id: m.id, texto: m.texto, prioridad: m.prioridad })),
+  };
+}
+
+/**
+ * SOLO PARA TESTS: resetea el estado del singleton e inyecta un motor
+ * falso. gesto/audio arrancan permitidos para no ensuciar cada test.
+ * @param {{motor?: {decir: Function, parar: Function}, gesto?: boolean, audio?: boolean}} [cfg]
+ */
+export function __resetParaTests(cfg = {}) {
+  callar();
+  motor = cfg.motor || motorTts;
+  desbloqueada = cfg.gesto !== undefined ? !!cfg.gesto : true;
+  audioHabilitado = cfg.audio !== undefined ? !!cfg.audio : true;
+  actual = null;
+  cola = [];
+  oyentesTexto.clear();
+}
+
+export default {
+  PRIORIDAD,
+  MOTIVO,
+  MAX_COLA,
+  decir,
+  callar,
+  estaHablando,
+  estadoCola,
+  onTexto,
+  politicaLlegada,
+  marcarGesto,
+  hayGesto,
+  setAudioHabilitado,
+};

--- a/src/services/angelitaVozBridge.js
+++ b/src/services/angelitaVozBridge.js
@@ -1,0 +1,66 @@
+/*
+ * angelitaVozBridge — el CABLE entre la cabeza de Angelita y su garganta.
+ *
+ * La cabeza (angelitaInteligencia vía useAngelitaStore) ya decide QUÉ decir
+ * en toda la app: avisos con datos reales, husmeos al entrar a un mundo,
+ * celebraciones. Hasta hoy eso salía solo ESCRITO (burbuja del FAB). Este
+ * puente escucha el store y manda cada mensaje nuevo a la garganta única
+ * (angelitaVoz.decir) con la prioridad que le corresponde:
+ *
+ *   severidad 'urgente'  → ALERTA   (interrumpe lo que esté sonando)
+ *   estado 'husmea'      → AMBIENTE (si ella ya habla, se descarta — el
+ *                          comentario de ambiente es del momento)
+ *   resto (aviso/celebra)→ NORMAL   (espera su turno)
+ *
+ * RESPETOS (se chequean AQUÍ, en el borde, no en la cola):
+ *   · store.silenciado  — el usuario pidió silencio a Angelita.
+ *   · prefs.ttsEnabled  — el toggle global de voz de la app.
+ * La cola además aplica sus propios vetos (gesto de autoplay, reduced
+ * motion para AMBIENTE) — ver angelitaVoz.js.
+ *
+ * Idempotente y perezoso: initAngelitaVozBridge() instala UNA sola vez
+ * (singleton de módulo); llamadas repetidas son no-op. Se cablea desde
+ * AgentFab (el FAB vive en TODA pantalla), con import dinámico para no
+ * cargar el stack de voz hasta que la app ya montó.
+ */
+
+import useAngelitaStore from '../store/useAngelitaStore';
+import usePrefsStore from '../store/usePrefsStore';
+import { decir, PRIORIDAD } from './angelitaVoz.js';
+
+let instalado = false;
+
+/** Mapea la decisión viva del store a una prioridad de la garganta. */
+export function prioridadDeEstado(estado, severidad) {
+  if (severidad === 'urgente') return PRIORIDAD.ALERTA;
+  if (estado === 'husmea') return PRIORIDAD.AMBIENTE;
+  return PRIORIDAD.NORMAL;
+}
+
+/**
+ * Instala el puente (una sola vez). Devuelve un no-op de compatibilidad:
+ * el puente es un singleton de app, no se desinstala al desmontar un FAB
+ * (hay un FAB por pantalla; desinstalar con uno callaría a los demás).
+ * @returns {() => void}
+ */
+export function initAngelitaVozBridge() {
+  if (instalado) return () => {};
+  instalado = true;
+
+  useAngelitaStore.subscribe((estadoStore, estadoPrevio) => {
+    const mensaje = estadoStore.mensaje;
+    if (!mensaje || mensaje === estadoPrevio?.mensaje) return;
+    if (estadoStore.silenciado) return;
+    try {
+      if (!usePrefsStore.getState().ttsEnabled) return;
+    } catch (_) { return; }
+    decir(mensaje, {
+      prioridad: prioridadDeEstado(estadoStore.estado, estadoStore.severidad),
+      origen: `angelita-store:${estadoStore.estado}`,
+    }).catch(() => { /* la garganta nunca rechaza; cinturón por si acaso */ });
+  });
+
+  return () => {};
+}
+
+export default { initAngelitaVozBridge, prioridadDeEstado };

--- a/src/services/recorridoService.js
+++ b/src/services/recorridoService.js
@@ -35,7 +35,8 @@
 import { getCurrentPosition } from './gpsFincaDetector';
 import * as loteService from './loteService';
 import { haversineMeters } from '../utils/geo';
-import { speakSentences } from './ttsService';
+// (2026-07-19) El TTS ya no se importa directo: el habla sale por la
+// garganta única de Angelita (angelitaVoz, import perezoso más abajo).
 import { normalize } from '../utils/entityMatcher';
 import { newUlid } from '../utils/id';
 
@@ -403,7 +404,17 @@ export function construirResumenRecorrido(observaciones = [], opts = {}) {
  */
 export async function leerResumenRecorrido(observaciones = [], opts = {}) {
   const texto = construirResumenRecorrido(observaciones, opts);
-  const hablar = typeof opts.speak === 'function' ? opts.speak : speakSentences;
+  // GARGANTA ÚNICA (2026-07-19): por defecto el resumen habla por la cola
+  // de Angelita (prioridad RESPUESTA — el campesino lo pidió) en vez del
+  // speakSentences suelto; así no se pisa con narraciones de mundos ni
+  // avisos. `opts.speak` inyectable se mantiene para tests.
+  const hablar = typeof opts.speak === 'function'
+    ? opts.speak
+    : (t) => import('./angelitaVoz.js').then((m) => m.decir(t, {
+        prioridad: m.PRIORIDAD.RESPUESTA,
+        reemplaza: true,
+        origen: 'recorrido-resumen',
+      }));
   try {
     await hablar(texto);
   } catch (_) {


### PR DESCRIPTION
Angelita hablaba solo en el oso y el jaguar, y los audios se pisaban entre sí.

- **Autoridad única de reproducción** (`angelitaVoz.js`): cola serializada con política de prioridad, para que nunca suenen dos audios encima.
- **Carácter de la voz** (`angelitaCaracter.js`) según la DR de diseño de voz.
- **Puente al TTS existente** (`angelitaVozBridge.js`), respetando que kokoro es CPU-only y su latencia escala con los caracteres.
- **Generalizada a toda la app**, no solo a dos criaturas.
- Degrada con dignidad sin red: el texto siempre llega aunque el audio no.
- 442 líneas de test nuevas (`angelitaVoz`, `angelitaCaracter`).

Rescatado de un worktree cuyo agente cayó por límite de sesión antes de commitear. **Pendiente de verificación**: el agente no alcanzó a correr la suite ni a revisar dos callers con TTS directo (re-speak de ChatBubble y el test de recorrido) — hay que confirmar que no queden vectores de pisón.