### PR TITLE
fix(oso): OsoGuardian aprobado entra; el oso café archivado sale del registro

### DIFF
--- a/shot-oso.jsx
+++ b/shot-oso.jsx
@@ -1,0 +1,41 @@
+/* Harness EFÍMERO de captura (no se commitea): OsoGuardian y su ruana. */
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { OsoGuardian, AbejaAngelita, Jaguar, Danta } from './src/visual/creatures/index.js';
+import './src/visual/creatures/creatures.css';
+
+function Caja({ titulo, children }) {
+  return (
+    <div className="caja">
+      <h2>{titulo}</h2>
+      {children}
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <div className="fila" data-listo="si">
+      <Caja titulo="OSO — sin ruana">
+        <OsoGuardian size={180} animated={false} />
+      </Caja>
+      <Caja titulo="OSO — ruana noche">
+        <OsoGuardian size={180} animated={false} vestuario clima="noche" tempC={6} />
+      </Caja>
+      <Caja titulo="ANGELITA — sin ruana">
+        <AbejaAngelita size={180} animated={false} />
+      </Caja>
+      <Caja titulo="ANGELITA — ruana noche">
+        <AbejaAngelita size={180} animated={false} vestuario clima="noche" tempC={6} />
+      </Caja>
+      <Caja titulo="JAGUAR — ruana noche">
+        <Jaguar size={180} animated={false} vestuario clima="noche" tempC={6} />
+      </Caja>
+      <Caja titulo="DANTA — ruana noche">
+        <Danta size={180} animated={false} vestuario clima="noche" tempC={6} />
+      </Caja>
+    </div>
+  );
+}
+
+createRoot(document.getElementById('root')).render(<App />);

--- a/shot-sierra.html
+++ b/shot-sierra.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>shot sierra</title>
+    <style>
+      html, body, #root { margin: 0; height: 100%; background: #0d1b1f; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/shot-sierra.jsx"></script>
+  </body>
+</html>

--- a/shot-sierra.jsx
+++ b/shot-sierra.jsx
@@ -1,0 +1,8 @@
+/* Harness EFÍMERO de captura (no se commitea): SierraMonte3D con el oso nuevo. */
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import SierraMonte3D from './src/visual/mundo3d/sierra/SierraMonte3D.jsx';
+
+createRoot(document.getElementById('root')).render(
+  <SierraMonte3D tier="alto" reducedMotion={false} />,
+);

--- a/src/components/Settings/__tests__/AvatarSelector.test.jsx
+++ b/src/components/Settings/__tests__/AvatarSelector.test.jsx
@@ -65,11 +65,11 @@ describe('useAvatarCreature — resolución slug→personaje', () => {
     it('sigue la elección del store en vivo', () => {
         const { result } = renderHook(() => useAvatarCreature());
         act(() => {
-            usePrefsStore.getState().setAvatarCreatureId('oso-andino');
+            usePrefsStore.getState().setAvatarCreatureId('oso-guardian');
         });
-        expect(result.current.id).toBe('oso-andino');
-        expect(result.current.Component).toBe(CREATURES['oso-andino'].Component);
-        expect(JSON.parse(localStorage.getItem(STORAGE_KEY))).toBe('oso-andino');
+        expect(result.current.id).toBe('oso-guardian');
+        expect(result.current.Component).toBe(CREATURES['oso-guardian'].Component);
+        expect(JSON.parse(localStorage.getItem(STORAGE_KEY))).toBe('oso-guardian');
     });
 
     it('slug desconocido (bicho retirado / typo) cae al default', () => {

--- a/src/mockups/MetalSlugCampo.jsx
+++ b/src/mockups/MetalSlugCampo.jsx
@@ -23,7 +23,7 @@
    (mismo criterio que metalSlugCampoData / defensoresFincaData): copy pedagógico
    campesino en «usted», no strings de UI transversal migrables a messages.js. */
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { AbejaAngelita, OsoAndino } from '../visual/creatures';
+import { AbejaAngelita, OsoGuardian } from '../visual/creatures';
 import { decidirTier } from '../visual/mundo3d/deviceTier.js';
 import {
   NIVELES,
@@ -802,7 +802,7 @@ const SpriteHeroe = memo(function SpriteHeroe(/** @type {{ tier: any; reducedMot
 });
 
 const SpriteOso = memo(function SpriteOso(/** @type {{ tier: any; reducedMotion: any }} */ { tier, reducedMotion }) {
-  return <OsoAndino size={92} inline={false} animated={!reducedMotion} tier={tier} title="Oso andino" />;
+  return <OsoGuardian size={92} inline={false} animated={!reducedMotion} tier={tier} title="Oso guardián" />;
 });
 
 /* PlagaSprite ahora vive en ./metalslug/PlagasSprites.jsx (bestiario expresivo). */

--- a/src/visual/creatures/OsoAndino.jsx
+++ b/src/visual/creatures/OsoAndino.jsx
@@ -117,7 +117,7 @@ export function OsoAndino({
   const raizRef = useRef(null);
   const ritmoPropio = useRitmoPropio();
   const enBase = pose === 'anda' && !resopla && !rasca && !visema;
-  const momento = useVidaIdle('oso-andino', vida && vivo && tier !== 'bajo' && enBase);
+  const momento = useVidaIdle('oso-guardian', vida && vivo && tier !== 'bajo' && enBase);
   useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
   const resoplaFx = resopla || momento === 'resopla';
   const rascaFx = rasca || momento === 'rasca';

--- a/src/visual/creatures/OsoAnteojos.jsx
+++ b/src/visual/creatures/OsoAnteojos.jsx
@@ -131,7 +131,7 @@ export function OsoAnteojos({
   const raizRef = useRef(null);
   const ritmoPropio = useRitmoPropio();
   const enBase = pose === 'anda' && !resopla && !rasca && !visema;
-  const momento = useVidaIdle('oso-andino', vida && vivo && tier !== 'bajo' && enBase);
+  const momento = useVidaIdle('oso-guardian', vida && vivo && tier !== 'bajo' && enBase);
   useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
   const resoplaFx = resopla || momento === 'resopla';
   const rascaFx = rasca || momento === 'rasca';

--- a/src/visual/creatures/OsoGuardian.jsx
+++ b/src/visual/creatures/OsoGuardian.jsx
@@ -156,7 +156,7 @@ export function OsoGuardian({
   const raizRef = useRef(null);
   const ritmoPropio = useRitmoPropio();
   const enBase = pose === 'anda' && !resopla && !rasca && !visema;
-  const momento = useVidaIdle('oso-andino', vida && vivo && tier !== 'bajo' && enBase);
+  const momento = useVidaIdle('oso-guardian', vida && vivo && tier !== 'bajo' && enBase);
   useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
   const resoplaFx = resopla || momento === 'resopla';
   const rascaFx = rasca || momento === 'rasca';

--- a/src/visual/creatures/OsoGuardian.jsx
+++ b/src/visual/creatures/OsoGuardian.jsx
@@ -1,0 +1,516 @@
+import { useId, useRef } from 'react';
+import './creatures.css';
+import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
+import { CreatureFilters } from './_filters.jsx';
+import { BocaVisema } from './_rubberhose.jsx';
+import {
+  OSO_GUARDIAN_PALETA, OSO_GUARDIAN_PROPORCION, OSO_GUARDIAN_RUANA_ANCLA,
+  OSO_GUARDIAN_SLUG, OSO_GUARDIAN_TINTA, PERFIL_OSO_GUARDIAN,
+} from './osoGuardianIdentidad.js';
+import { cuerpoDeClima, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
+import { AccesoriosClima } from './AccesoriosClima.jsx';
+import { LineBoilFilter } from './LineBoilFilter.jsx';
+import { PropEnMano } from './PropEnMano.jsx';
+import { AuraPoder } from './AuraPoder.jsx';
+import { auraDeBicho } from './transformacion.js';
+
+/* Oso guardián — Tremarctos ornatus, EL GUARDIÁN NEGRO DE LA LUNA.
+   Tercera y definitiva dirección de arte del oso de anteojos, sobre la BASE
+   aprobada por el operador (dashboard/GuardianEspiritu → AvatarOso): pelaje
+   AZABACHE AZULADO casi silueta, luz MENTA medida en el contorno, la LUNA
+   CRECIENTE crema en el pecho (su emblema, conservado) y los anteojos del oso
+   andino hechos de AROS DE LUZ que respiran.
+
+   QUÉ CORRIGE de los dos osos rechazados (el café OsoAndino y el OsoAnteojos
+   de peluche) — el mandato "que no se vea tan infantil":
+   · PROPORCIONES DE ADULTO: cabeza chica (ratio cabeza:hombros ≈ 1:3, antes
+     ≈ 1:1.6) hundida en una JOROBA de hombros anchos; la silueta es un PATH
+     propio de mole plantígrada sentada como montaña — no el círculo-sobre-
+     elipse del peluche. Hocico canela PRESENTE que proyecta del cráneo,
+     carrilleras que ensanchan la cara abajo (cara adulta, no carita redonda).
+   · OJOS CON ALMA, NO DE JUGUETE: almendras oscuras de párpado pesado con
+     iris menta-luz chico y catchlight — dentro de los aros luminosos. Nada de
+     esclerótica blanca con pupila gigante (OjosRubber queda fuera adrede).
+   · SIN TERNURA POSTIZA: cero cachetes de rubor, cero sonrisa amplia (la boca
+     es un arco breve y calmo), orejas chicas y bajas de oso real. QUIETUD:
+     la cabeza no se mece — la gravitas vive en el respirar lento de la mole,
+     el aliento de los aros y el latido de la luna.
+   · PRESENCIA SIN MIEDO (registro Mufasa): impone por MASA (sombra de suelo,
+     boil pesado oso-boil, garras visibles pero romas) y serenidad (cejas casi
+     horizontales con caída interna mínima), jamás por amenaza: ni colmillos,
+     ni ceño bravo, ni ojos vacíos.
+
+   Hereda la fundación transversal de la familia (cero código duplicado):
+   lip-sync (BocaVisema), clima→cuerpo (PERFIL_OSO_GUARDIAN), ropa por clima
+   (fila 'oso-andino': misma especie, mismos umbrales de páramo), vida propia
+   (repertorio 'oso-andino': resopla/rasca/reposo — aquí el rascado es un
+   remecerse de peso, digno), line-boil y modo poder (aura MENTA). Todo se
+   PODA en tier bajo / reduced-motion a un fotograma digno y quieto. */
+const VIEWBOX = '-16 -20 32 40';
+
+/* GARRAS del plantígrado: cuatro uñas cortas y ROMAS que asoman del borde de
+   la planta, en hueso-menta que agarra la luz de luna. Identidad de especie y
+   señal de adulto — nunca amenaza (curvas suaves, puntas redondas). */
+function Garras({ xs, y, color, largo = 1.2 }) {
+  return (
+    <g aria-hidden="true" stroke={color} strokeWidth="0.55" strokeLinecap="round" fill="none" opacity="0.9">
+      {xs.map((x, i) => (
+        <path key={i} d={`M${x},${y} q0.12,${largo * 0.62} 0.02,${largo}`} />
+      ))}
+    </g>
+  );
+}
+
+/* ESPORAS del bosque nublado — bioluminiscencia que flota lento alrededor de
+   la mole (reusa la cadencia osoa-mota ya existente). Delays/duraciones
+   propios: vida, no metrónomo. */
+const ESPORAS = [
+  { cx: -11.8, cy: -5.2, r: 0.46, d: 0, s: 6.9 },
+  { cx: 12.2, cy: -1.4, r: 0.4, d: -2.2, s: 7.5 },
+  { cx: -9.6, cy: 9.4, r: 0.34, d: -3.9, s: 6.1 },
+  { cx: 10.2, cy: -8.8, r: 0.44, d: -1.5, s: 6.5 },
+  { cx: -13.2, cy: 1.6, r: 0.3, d: -4.8, s: 7.8 },
+];
+
+/* LA SILUETA DE LA MOLE (el corazón del rediseño): un solo path de oso sentado
+   como montaña — joroba de hombros arriba, flancos que se abren a las ancas,
+   asiento ancho. Nada de elipse de peluche. */
+const SILUETA_MOLE =
+  'M -10.9,13.1 '
+  + 'C -13.3,10.6 -13.9,6.2 -12.6,1.8 '
+  + 'C -11.8,-1.6 -10.7,-4.2 -9.0,-6.3 '
+  + 'C -7.2,-8.6 -4.0,-9.8 0,-9.8 '
+  + 'C 4.0,-9.8 7.2,-8.6 9.0,-6.3 '
+  + 'C 10.7,-4.2 11.8,-1.6 12.6,1.8 '
+  + 'C 13.9,6.2 13.3,10.6 10.9,13.1 '
+  + 'C 7.4,13.9 -7.4,13.9 -10.9,13.1 Z';
+
+/* LA LUNA CRECIENTE del pecho — el emblema conservado de la base. Media
+   circunferencia externa (r 3.0, centrada en 0,-2.2) + arco interno tendido
+   (r 3.4) = creciente que abre a la derecha. Ligeramente rotada: un emblema
+   colgado con gracia, no un icono clavado. */
+const LUNA_CRECIENTE = 'M 0,-5.55 A 3.35,3.35 0 1 0 0,1.15 A 3.8,3.8 0 0 1 0,-5.55 Z';
+
+export function OsoGuardian({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Oso guardián',
+  /* Pose de VIDA species-agnostic (gestos rh-g-* de creatures.css):
+     'anda' (base) | 'celebra' | 'reposo' | 'señala'. Con animated=false o
+     reduced-motion queda en fotograma digno. */
+  pose = 'anda',
+  animo = 'sereno',
+  energia = 1,
+  /* CLIMA REAL escrito en el cuerpo (perfil de bosque altoandino). Sin clima
+     (avatares, catálogo) = neutro digno. */
+  clima = null,
+  enso = 'neutro',
+  /* Lip-sync transversal (useLipSync → 'V1'..'V4'). Sin visema = el arco
+     breve y calmo de siempre. */
+  visema = null,
+  /* Vestuario por clima+hora (opt-in): RUANA de noche/frío del páramo. Nunca
+     sombrero ni sudor (el oso de niebla no se acalora). */
+  vestuario = false,
+  tempC = undefined,
+  /* RESOPLA (opt-in): el huff pesado del guardián — vaho por la trufa, pecho
+     que hincha y suelta. Refunfuño grave, no berrinche. */
+  resopla = false,
+  /* RASCA (opt-in): en este oso el "rascado" del repertorio es un REMECERSE
+     de peso lento (oso-rasca-cuerpo), sin manoteo — la mole se acomoda. */
+  rasca = false,
+  /* VIDA PROPIA (idle-cerebro v2): default ON. Reusa el repertorio
+     'oso-andino' de vidaEstados.js (misma especie, mismo temperamento lento). */
+  vida = true,
+  /* Device-tier: 'bajo' apaga el idle continuo; quedan los estados reactivos. */
+  tier,
+  /* Line-boil (opt-in, capa cara): reservado para su entrada heroica. */
+  lineBoil = false,
+  /* MODO PODER (opt-in, standalone): aura MENTA bioluminiscente. */
+  poder = false,
+  /* Prop por mundo (opt-in): la herramienta en su zarpa izquierda. */
+  mundoId = null,
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const boil = `crt-boil-${uid}`;
+  const pelaje = `crt-pelaje-${uid}`;
+  const lunaGrad = `crt-luna-${uid}`;
+  /* HALOS POR GRADIENTE RADIAL (no por blur): los círculos blureados del kit
+     recortan su región de filtro en un CUADRADO visible sobre el pelaje
+     oscuro (verificado empíricamente con el halo de la luna). El gradiente
+     cae suave hasta opacidad 0 sin filtro — y es más barato en GPU. */
+  const haloCrema = `osog-halo-crema-${uid}`;
+  const haloMenta = `osog-halo-menta-${uid}`;
+  const haloSombra = `osog-halo-sombra-${uid}`;
+  const vivo = animated;
+  const auraOp = Math.max(0.08, Math.min(0.26, 0.1 + 0.16 * (energia ?? 1)));
+  const auraR = 9.5 + 1.6 * (energia ?? 1);
+
+  // ═══ VIDA PROPIA (idle-cerebro + ritmo propio + mirada — vara Angelita v2).
+  // Repertorio 'oso-andino': misma especie (Tremarctos), temperamento lento ya
+  // afinado — cero filas duplicadas.
+  const raizRef = useRef(null);
+  const ritmoPropio = useRitmoPropio();
+  const enBase = pose === 'anda' && !resopla && !rasca && !visema;
+  const momento = useVidaIdle('oso-andino', vida && vivo && tier !== 'bajo' && enBase);
+  useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
+  const resoplaFx = resopla || momento === 'resopla';
+  const rascaFx = rasca || momento === 'rasca';
+  const poseFx = momento === 'reposo' ? 'reposo' : pose;
+
+  // CLIMA → cuerpo (determinista): tinte + opacidad al contorno. Sin alas.
+  const cuerpoClima = cuerpoDeClima(clima, { enso: /** @type {any} */ (enso), tier, perfil: PERFIL_OSO_GUARDIAN });
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
+
+  // Vestuario por clima+hora (opt-in): fila 'oso-andino' compartida (misma
+  // especie, mismos umbrales de páramo). Sombrero/sudor suprimidos SIEMPRE.
+  const ropaBase = (vestuario && clima) ? ropaDeClimaBicho('oso-andino', clima, { tempC }) : null;
+  const ropa = ropaBase ? { ...ropaBase, sombrero: false, sudor: false } : null;
+
+  const P = OSO_GUARDIAN_PALETA;
+  const PR = OSO_GUARDIAN_PROPORCION;
+  const INK = OSO_GUARDIAN_TINTA;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+      {/* PELAJE CON VOLUMEN: luz de luna azulada arriba-izquierda → azabache
+          medio → sombra ventral casi negra. Viste mole y cráneo. */}
+      <radialGradient id={pelaje} cx="40%" cy="26%" r="88%">
+        <stop offset="0%" stopColor={P.cuerpoLuz} />
+        <stop offset="50%" stopColor={P.cuerpo} />
+        <stop offset="100%" stopColor={P.cuerpoSombra} />
+      </radialGradient>
+      {/* LA LUNA con cuerpo propio: crema-luz al borde iluminado → crema-sombra
+          hacia el interior (que no sea un sticker plano). */}
+      <radialGradient id={lunaGrad} cx="30%" cy="35%" r="90%">
+        <stop offset="0%" stopColor="#ffffff" />
+        <stop offset="55%" stopColor={P.luna} />
+        <stop offset="100%" stopColor="#dcf5e9" />
+      </radialGradient>
+      {/* halos suaves sin filtro (ver nota en los ids) */}
+      <radialGradient id={haloCrema}>
+        <stop offset="0%" stopColor={P.lunaHalo} stopOpacity="1" />
+        <stop offset="55%" stopColor={P.lunaHalo} stopOpacity="0.55" />
+        <stop offset="100%" stopColor={P.lunaHalo} stopOpacity="0" />
+      </radialGradient>
+      <radialGradient id={haloMenta}>
+        <stop offset="0%" stopColor={P.menta} stopOpacity="1" />
+        <stop offset="55%" stopColor={P.menta} stopOpacity="0.5" />
+        <stop offset="100%" stopColor={P.menta} stopOpacity="0" />
+      </radialGradient>
+      <radialGradient id={haloSombra}>
+        <stop offset="0%" stopColor="#040a12" stopOpacity="0.55" />
+        <stop offset="70%" stopColor="#040a12" stopOpacity="0.3" />
+        <stop offset="100%" stopColor="#040a12" stopOpacity="0" />
+      </radialGradient>
+      {lineBoil && <LineBoilFilter id={boil} animated={vivo} />}
+    </defs>
+  );
+
+  // VAHO del resoplido: motas frías que salen de la trufa y se disuelven.
+  const vaho = resoplaFx ? (
+    <g className="crt-vaho" fill={P.lunaHalo} aria-hidden="true" opacity="0.65">
+      <circle className={vivo ? 'crt-vaho-mota' : undefined} cx="2.4" cy="-8.8" r="1.0" />
+      <circle className={vivo ? 'crt-vaho-mota' : undefined} style={{ animationDelay: '-0.7s' }} cx="3.3" cy="-7.8" r="0.8" />
+    </g>
+  ) : null;
+
+  // PROP DEL MUNDO junto a la zarpa izquierda.
+  const propMundo = mundoId ? (
+    <PropEnMano mundoId={mundoId} x={-11.3} y={8.6} escala={0.74} ink={INK} animated={vivo} />
+  ) : null;
+
+  // BOCA: lip-sync si narra; si no, el arco BREVE y calmo (no sonrisa amplia
+  // de mascota — serenidad, no ternura postiza).
+  // BOCA: lip-sync si narra (BocaVisema del kit); si no, un arco BREVE y calmo
+  // en trazo fino — la Sonrisa del kit (0.9 de grosor) se funde con la trufa a
+  // esta escala de hocico y hace blob; el guardián lleva la boca apenas dicha.
+  const boca = visema
+    ? <BocaVisema cx={0} cy={-8.8} w={2.4} prof={0.8} visema={visema} ink={INK} />
+    : (
+      <path d="M -1.05,-8.85 Q 0,-8.42 1.05,-8.85" fill="none"
+        stroke={INK} strokeWidth="0.5" strokeLinecap="round" />
+    );
+
+  // ── EL DIBUJO (atrás→adelante): sombra de suelo, aura menta, patas traseras
+  //    asomando, LA MOLE (path propio), rim-light lunar + pelaje sugerido,
+  //    LA LUNA del pecho, columnas delanteras con garras, cabeza (orejas
+  //    chicas, cráneo, carrilleras, aros de luz, ojos-almendra, hocico canela),
+  //    bruma y esporas. `.crt-body` respira con oso-boil (pesado, lento).
+  const body = (
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* SOMBRA DE SUELO — el peso de la montaña (masa real, no sticker). */}
+      <ellipse cx="0" cy="14.35" rx="12.4" ry="2.1" fill={`url(#${haloSombra})`} aria-hidden="true" />
+      {/* aura menta tenue: bioluminiscencia de niebla, no neón de feria */}
+      <circle cx="0" cy="1.5" r={auraR + 2} fill={`url(#${haloMenta})`} opacity={auraOp * 0.5} />
+
+      {/* PATAS TRASERAS del plantígrado sentado: las plantas asoman adelante,
+          a los lados de la mole (postura real de oso sentado). */}
+      <g aria-hidden="true">
+        <ellipse cx="-10.5" cy="13.15" rx="2.35" ry="1.35" fill={P.planta} stroke={INK} strokeWidth="0.8" />
+        <ellipse cx="10.5" cy="13.15" rx="2.35" ry="1.35" fill={P.planta} stroke={INK} strokeWidth="0.8" />
+        <Garras xs={[-11.5, -10.5, -9.5]} y={13.9} color={P.garra} largo={0.95} />
+        <Garras xs={[9.5, 10.5, 11.5]} y={13.9} color={P.garra} largo={0.95} />
+      </g>
+
+      {/* ═══ LA MOLE — la silueta que manda: joroba de hombros, flancos a las
+          ancas, asiento de montaña. El halo menta va MEDIDO en el drop-shadow
+          (la estética del avatar aprobado, sin contorno de neón chillón). */}
+      <path d={SILUETA_MOLE} fill={`url(#${pelaje})`} stroke={INK} strokeWidth="1.35"
+        strokeLinejoin="round" style={{ filter: `drop-shadow(0 0 6px ${P.cuerpoGlow})` }} />
+
+      {/* RIM-LIGHT LUNAR — la luz que dibuja al guardián por el lado de la
+          luna (izquierdo), con un eco tenue al flanco derecho. Es EL trazo
+          neón de la base, vuelto luz de borde con criterio. */}
+      <g aria-hidden="true" fill="none" strokeLinecap="round">
+        <path d="M -12.4,3.0 C -11.6,-2.2 -9.6,-6.3 -5.2,-8.9" stroke={P.menta}
+          strokeWidth="0.85" opacity="0.55" style={{ filter: `drop-shadow(0 0 2.5px ${P.menta})` }} />
+        <path d="M 12.45,4.0 C 12.9,7.4 12.4,10.6 10.9,13.0" stroke={P.menta}
+          strokeWidth="0.7" opacity="0.18" />
+      </g>
+
+      {/* PELAJE SUGERIDO en la silueta: mechones cortos a contraluz en joroba,
+          flancos y ancas + definición muscular tenue (deltoides y pectoral).
+          Sugiere, no delinea — la mole sigue siendo casi silueta. */}
+      <g aria-hidden="true" fill="none" stroke={P.cuerpoLuz} strokeLinecap="round">
+        <g strokeWidth="0.5" opacity="0.5">
+          <path d="M -4.6,-9.15 l 0.5,-0.55 l 0.45,0.62 l 0.5,-0.55" />
+          <path d="M 4.6,-9.15 l -0.5,-0.55 l -0.45,0.62 l -0.5,-0.55" />
+          <path d="M -12.9,4.6 l 0.75,0.5 l -0.7,0.62 l 0.72,0.58" />
+          <path d="M 12.9,5.6 l -0.75,0.5 l 0.7,0.62 l -0.72,0.58" />
+          <path d="M -11.9,9.2 l 0.7,0.4 l -0.6,0.6" />
+        </g>
+        <g strokeWidth="0.55" opacity="0.22">
+          <path d="M -9.9,-4.4 C -8.7,-2.0 -7.3,-0.6 -5.5,0.3" />
+          <path d="M 9.9,-4.4 C 8.7,-2.0 7.3,-0.6 5.5,0.3" />
+          <path d="M -3.4,-6.4 C -1.5,-5.3 1.5,-5.3 3.4,-6.4" />
+        </g>
+      </g>
+
+      {/* derrame de luz de la luna sobre el vientre (bajísima opacidad) */}
+      <ellipse cx="0" cy="7" rx="2.6" ry="3.6" fill={P.lunaHalo} opacity="0.04" aria-hidden="true" />
+
+      {/* ═══ LA LUNA CRECIENTE — el emblema del pecho, CONSERVADO de la base y
+          con PRESENCIA real (no un sticker apagado): halo que respira
+          (osog-luna), cuerpo blanco-crema encendido, mares tenues y un anillo
+          de radiancia menta apenas insinuado. */}
+      <g aria-hidden="true">
+        <circle className={vivo ? 'osog-luna' : undefined} cx="-0.9" cy="-2.2" r="5.4"
+          fill={`url(#${haloCrema})`} opacity="0.26" />
+        <circle cx="-0.6" cy="-2.2" r="3.9" fill="none" stroke={P.menta} strokeWidth="0.35" opacity="0.12" />
+        <g transform="rotate(14 0 -2.2)">
+          <path d={LUNA_CRECIENTE} fill={`url(#${lunaGrad})`}
+            style={{ filter: `drop-shadow(0 0 5px ${P.lunaHalo})` }} />
+          {/* mares de la luna: el emblema tiene textura, no es una calcomanía */}
+          <g fill={P.lunaSombra} opacity="0.45">
+            <circle cx="-1.8" cy="-3.6" r="0.46" />
+            <circle cx="-2.35" cy="-1.5" r="0.3" />
+            <circle cx="-1.15" cy="-0.3" r="0.24" />
+          </g>
+        </g>
+      </g>
+
+      {/* PATAS DELANTERAS: columnas plantadas CORTAS (nacen bajo la luna — el
+          pecho queda abierto para el emblema), redondeadas arriba, en sombra
+          propia para despegarlas del pecho; plantas anchas y GARRAS visibles. */}
+      <g>
+        <path d="M -7.7,1.0 C -8.3,4.4 -8.3,8.6 -7.7,12.2 C -6.5,12.8 -5.1,12.8 -4.2,12.3 C -4.6,8.6 -4.6,4.6 -4.3,1.6 C -5.4,0.5 -6.9,0.4 -7.7,1.0 Z"
+          fill={P.pata} stroke={INK} strokeWidth="0.85" strokeLinejoin="round" />
+        <path d="M 7.7,1.0 C 8.3,4.4 8.3,8.6 7.7,12.2 C 6.5,12.8 5.1,12.8 4.2,12.3 C 4.6,8.6 4.6,4.6 4.3,1.6 C 5.4,0.5 6.9,0.4 7.7,1.0 Z"
+          fill={P.pata} stroke={INK} strokeWidth="0.85" strokeLinejoin="round" />
+        {/* rim menta finísimo en la columna del lado de la luna */}
+        <path d="M -7.5,2.2 C -8.05,5.2 -8.05,8.8 -7.5,11.8" fill="none"
+          stroke={P.menta} strokeWidth="0.4" opacity="0.28" aria-hidden="true" />
+        <ellipse cx="-6.0" cy="12.7" rx="2.5" ry="1.45" fill={P.planta} stroke={INK} strokeWidth="0.85" />
+        <ellipse cx="6.0" cy="12.7" rx="2.5" ry="1.45" fill={P.planta} stroke={INK} strokeWidth="0.85" />
+        <Garras xs={[-7.6, -6.55, -5.5, -4.45]} y={13.35} color={P.garra} />
+        <Garras xs={[4.45, 5.5, 6.55, 7.6]} y={13.35} color={P.garra} />
+      </g>
+
+      {/* ═══ CABEZA proporcionada, hundida en la joroba (sin cuello de peluche).
+          QUIETA a propósito: la gravitas del guardián. */}
+      <g>
+        {/* orejas CHICAS y bajas de oso real (detrás del cráneo) */}
+        <g aria-hidden="true">
+          <circle cx="-3.05" cy="-15.85" r={PR.orejaR} fill={P.cuerpo} stroke={INK} strokeWidth="1.05" />
+          <circle cx="-3.05" cy="-15.85" r={PR.orejaR * 0.44} fill="#352a63" />
+          <circle cx="3.05" cy="-15.85" r={PR.orejaR} fill={P.cuerpo} stroke={INK} strokeWidth="1.05" />
+          <circle cx="3.05" cy="-15.85" r={PR.orejaR * 0.44} fill="#352a63" />
+        </g>
+        {/* cráneo (elipse levemente más ancha que alta: testa de oso adulto) */}
+        <ellipse cx="0" cy="-12.9" rx={PR.cabezaRx} ry={PR.cabezaRy}
+          fill={`url(#${pelaje})`} stroke={INK} strokeWidth="1.25" />
+        {/* rim lunar del cráneo (el lado de la luna) */}
+        <path d="M -4.05,-13.6 C -3.3,-15.6 -1.5,-16.5 0.4,-16.45" fill="none"
+          stroke={P.menta} strokeWidth="0.6" opacity="0.4" strokeLinecap="round" aria-hidden="true" />
+        {/* CARRILLERAS: sombras que ensanchan la cara abajo — cara adulta,
+            no carita redonda de cría */}
+        <g aria-hidden="true" fill={P.cuerpoSombra} opacity="0.55">
+          <ellipse cx="-2.9" cy="-10.4" rx="1.7" ry="1.4" />
+          <ellipse cx="2.9" cy="-10.4" rx="1.7" ry="1.4" />
+        </g>
+        {/* mechones de mejilla a contraluz */}
+        <g aria-hidden="true" fill="none" stroke={P.cuerpoLuz} strokeWidth="0.45" strokeLinecap="round" opacity="0.45">
+          <path d="M -4.15,-11.6 l 0.66,0.3 l -0.55,0.5" />
+          <path d="M 4.15,-11.6 l -0.66,0.3 l 0.55,0.5" />
+        </g>
+
+        {/* aliento de los AROS (detrás del trazo): respira despacio */}
+        <g className={vivo ? 'osoa-anteojo-brillo' : undefined} aria-hidden="true"
+          style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+          <circle cx="-1.85" cy="-13.05" r="2.6" fill={`url(#${haloCrema})`} opacity="0.32" />
+          <circle cx="1.85" cy="-13.05" r="2.6" fill={`url(#${haloCrema})`} opacity="0.32" />
+        </g>
+        {/* ═══ LOS ANTEOJOS DE LUZ — la firma de la base, asimétricos como el
+            patrón real: el izquierdo casi cierra; el derecho abre por abajo y
+            DERRAMA su lágrima por el hocico, camino de la luna del pecho. */}
+        <g aria-hidden="true" fill="none" strokeLinecap="round">
+          <ellipse cx="-1.85" cy="-13.05" rx="1.52" ry="1.68" transform="rotate(-8 -1.85 -13.05)"
+            stroke={P.anteojo} strokeWidth="0.8" strokeDasharray="8.6 1.5" strokeDashoffset="-2.2"
+            style={{ filter: `drop-shadow(0 0 2.5px ${P.anteojoGlow})` }} />
+          <ellipse cx="1.85" cy="-13.05" rx="1.52" ry="1.68" transform="rotate(8 1.85 -13.05)"
+            stroke={P.anteojo} strokeWidth="0.8" strokeDasharray="7.6 2.5" strokeDashoffset="-8.6"
+            style={{ filter: `drop-shadow(0 0 2.5px ${P.anteojoGlow})` }} />
+          <path d="M 3.05,-11.8 C 3.55,-10.5 3.35,-9.3 2.55,-8.35"
+            stroke={P.anteojo} strokeWidth="0.7" opacity="0.85" />
+        </g>
+
+        {/* CEJAS del sereno: casi horizontales, caída interna mínima —
+            seriedad noble (Mufasa), jamás ceño bravo. Respiran apenas
+            (oso-cejas) y se aprietan al resoplar. */}
+        <g className="oso-cejas" stroke={P.ceja} strokeWidth="0.85" strokeLinecap="round" fill="none" opacity="0.85">
+          <path d="M -3.1,-14.88 C -2.35,-15.28 -1.35,-15.24 -0.8,-14.96" />
+          <path d="M 3.1,-14.88 C 2.35,-15.28 1.35,-15.24 0.8,-14.96" />
+        </g>
+
+        {/* ═══ OJOS-ALMENDRA con alma (no ojos-juguete): párpado pesado, iris
+            menta-luz chico, pupila honda y catchlight. Parpadean y dardean con
+            el kit (rh-blink / rh-mirada). */}
+        <g className={vivo ? 'rh-blink' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+          <path d="M -2.82,-13.05 Q -1.85,-13.9 -0.88,-13.05 Q -1.85,-12.32 -2.82,-13.05 Z"
+            fill={P.ojo} stroke={INK} strokeWidth="0.3" />
+          <path d="M 0.88,-13.05 Q 1.85,-13.9 2.82,-13.05 Q 1.85,-12.32 0.88,-13.05 Z"
+            fill={P.ojo} stroke={INK} strokeWidth="0.3" />
+          <g className={vivo ? 'rh-mirada' : undefined}>
+            <circle cx="-1.85" cy="-13.0" r="0.6" fill={P.iris} opacity="0.95" />
+            <circle cx="1.85" cy="-13.0" r="0.6" fill={P.iris} opacity="0.95" />
+            <circle cx="-1.85" cy="-13.0" r="0.33" fill="#03120c" />
+            <circle cx="1.85" cy="-13.0" r="0.33" fill="#03120c" />
+            <circle cx="-2.05" cy="-13.2" r="0.15" fill={P.luna} />
+            <circle cx="1.65" cy="-13.2" r="0.15" fill={P.luna} />
+          </g>
+        </g>
+
+        {/* HOCICO canela PRESENTE (proyecta del cráneo — la única nota cálida,
+            heredada del avatar aprobado): puente, trufa con brillo frío,
+            surco y la boca calma. */}
+        <path d="M -1.75,-12.2 C -2.15,-10.35 -1.5,-8.6 0,-8.35 C 1.5,-8.6 2.15,-10.35 1.75,-12.2 C 1.05,-13.0 -1.05,-13.0 -1.75,-12.2 Z"
+          fill={P.hocico} stroke={INK} strokeWidth="0.75" strokeLinejoin="round" />
+        <path d="M -0.95,-12.35 C -0.3,-12.65 0.3,-12.65 0.95,-12.35" fill="none"
+          stroke={P.hocicoSombra} strokeWidth="0.45" opacity="0.6" aria-hidden="true" />
+        <ellipse cx="0" cy="-9.85" rx="0.88" ry="0.62" fill={P.trufa} />
+        <ellipse cx="-0.3" cy="-10.05" rx="0.26" ry="0.16" fill={P.lunaHalo} opacity="0.5" />
+        <path d="M 0,-9.25 L 0,-9.0" stroke={INK} strokeWidth="0.4" strokeLinecap="round" />
+        {boca}
+      </g>
+
+      {/* Vestuario por clima+hora (RUANA de noche/frío del páramo). El ancla NO
+          es la mole entera: es OSO_GUARDIAN_RUANA_ANCLA, calculada para que el
+          poncho se apoye sobre el lomo y deje ver la luna del pecho (ver la
+          nota con las desigualdades en osoGuardianIdentidad.js). */}
+      {ropa && (
+        <AccesoriosClima
+          estado={ropa}
+          tronco={OSO_GUARDIAN_RUANA_ANCLA}
+          cabeza={{ cx: 0, cy: -12.9, r: PR.cabezaRx }}
+          animated={vivo}
+        />
+      )}
+
+      {/* Prop del mundo junto a la zarpa. */}
+      {propMundo}
+
+      {/* Vaho del resoplido (el huff grave del guardián). */}
+      {vaho}
+
+      {/* BRUMA a los pies — el velo del bosque nublado (tenue). */}
+      <ellipse cx="0" cy="13.7" rx="11.6" ry="2.3" fill={`url(#${haloMenta})`} opacity="0.09"
+        aria-hidden="true" />
+
+      {/* ESPORAS del bosque nublado (cadencia osoa-mota compartida). */}
+      <g aria-hidden="true" fill={P.espora}>
+        {ESPORAS.map((m, i) => (
+          <circle key={i} className={vivo ? 'osoa-mota' : undefined}
+            cx={m.cx} cy={m.cy} r={m.r} opacity="0.3"
+            style={vivo ? { animationDelay: `${m.d}s`, animationDuration: `${m.s}s` } : undefined} />
+        ))}
+      </g>
+    </g>
+  );
+
+  // Antics de VIDA solo viva; el CSS los apaga con RM / tier bajo / estados
+  // (un guardián que resopla no da además vueltas de campana).
+  const conAntics = vivo ? (
+    <g className="rh-antic">
+      <g className="rh-travieso">{body}</g>
+    </g>
+  ) : body;
+  const cuerpoVivo = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
+
+  const estadoAttrs = {
+    'data-creature': OSO_GUARDIAN_SLUG,
+    'data-pose': vivo ? poseFx : undefined,
+    'data-animo': animo,
+    'data-tier': tier || undefined,
+    'data-visema': visema || undefined,
+    'data-ruana': ropa?.ruana ? '1' : undefined,
+    'data-mojado': ropa?.mojado ? '1' : undefined,
+    'data-resopla': resoplaFx ? '1' : undefined,
+    'data-rasca': rascaFx ? '1' : undefined,
+    'data-vida': momento || undefined,
+    'data-lineboil': lineBoil ? '1' : undefined,
+    'data-prop': mundoId || undefined,
+  };
+  const estiloRaiz = { ...ritmoPropio, ...estiloClima };
+
+  if (inline) {
+    // En modo inline el power-up lo pone el host DOM; acá solo data-poder.
+    return (
+      <g ref={raizRef} className={className} style={estiloRaiz} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+        {defs}
+        {cuerpoVivo}
+      </g>
+    );
+  }
+  const svg = (
+    <svg ref={raizRef} viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloRaiz}
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
+      <title>{title}</title>
+      {defs}
+      {cuerpoVivo}
+    </svg>
+  );
+  // MODO PODER (standalone): aura MENTA bioluminiscente de 4 capas.
+  if (poder) {
+    return (
+      <span
+        className="is-powered-up osog-poder"
+        data-creature-poder={OSO_GUARDIAN_SLUG}
+        style={{ '--aura-color': auraDeBicho(OSO_GUARDIAN_SLUG), display: 'inline-flex' }}
+      >
+        {svg}
+        <AuraPoder />
+      </span>
+    );
+  }
+  return svg;
+}
+
+export default OsoGuardian;

--- a/src/visual/creatures/__tests__/faunaAmbiental.test.jsx
+++ b/src/visual/creatures/__tests__/faunaAmbiental.test.jsx
@@ -46,7 +46,7 @@ describe('1. castAmbiental — data-driven desde el registro', () => {
     expect(cast).not.toContain(CENTRAL_DEFECTO);
     MICROFAUNA_EXCLUIDA.forEach((m) => expect(cast).not.toContain(m));
     // Los personajes reales del registro sí están (oso, jaguar, colibrí…).
-    expect(cast).toContain('oso-andino');
+    expect(cast).toContain('oso-guardian');
     expect(cast).toContain('jaguar');
     expect(cast).toContain('colibri');
   });
@@ -57,9 +57,9 @@ describe('1. castAmbiental — data-driven desde el registro', () => {
   });
 
   it('si el central es otro (oso), la abeja entra al coro y el oso sale', () => {
-    const cast = castAmbiental('oso-andino');
+    const cast = castAmbiental('oso-guardian');
     expect(cast).toContain('abeja-angelita');
-    expect(cast).not.toContain('oso-andino');
+    expect(cast).not.toContain('oso-guardian');
   });
 
   it('el morrocoy (recién aterrizado en CREATURES) ya está en el elenco', () => {
@@ -67,9 +67,9 @@ describe('1. castAmbiental — data-driven desde el registro', () => {
   });
 
   it('excluir saca extras del coro (Angelita donde ya es la acompañante)', () => {
-    const cast = castAmbiental('oso-andino', CREATURES, ['abeja-angelita']);
+    const cast = castAmbiental('oso-guardian', CREATURES, ['abeja-angelita']);
     expect(cast).not.toContain('abeja-angelita');
-    expect(cast).not.toContain('oso-andino');
+    expect(cast).not.toContain('oso-guardian');
     expect(cast).toContain('jaguar');
   });
 });
@@ -107,7 +107,7 @@ describe('3. limiteAmbiental — el presupuesto duro por gama', () => {
 });
 
 describe('4. el pool rotativo — invariantes bajo mil vueltas', () => {
-  const cast = ['colibri', 'oso-andino', 'rana-andina', 'perezoso', 'ardilla', 'jaguar'];
+  const cast = ['colibri', 'oso-guardian', 'rana-andina', 'perezoso', 'ardilla', 'jaguar'];
 
   it('crearEstado arma min(limite, cast) slots, todos descansando', () => {
     const e = crearEstado(cast, 3);
@@ -177,7 +177,7 @@ describe('5. coherencia de entradas — solo el jaguar es mágico', () => {
   it('el jaguar aparece mágico; el resto viene de un lado', () => {
     expect(MAGICOS).toEqual(['jaguar']);
     expect(esMagico('jaguar')).toBe(true);
-    expect(esMagico('oso-andino')).toBe(false);
+    expect(esMagico('oso-guardian')).toBe(false);
     expect(esMagico(null)).toBe(false);
   });
 });
@@ -191,7 +191,7 @@ describe('6. <FaunaAmbiental> — el DOM cumple el presupuesto', () => {
   });
 
   const registro = registroFake([
-    'abeja-angelita', 'colibri', 'oso-andino', 'rana-andina', 'perezoso',
+    'abeja-angelita', 'colibri', 'oso-guardian', 'rana-andina', 'perezoso',
   ]);
 
   it('reduced-motion → la capa NI SE MONTA', () => {

--- a/src/visual/creatures/__tests__/vidaEstados.test.js
+++ b/src/visual/creatures/__tests__/vidaEstados.test.js
@@ -57,8 +57,8 @@ describe('2. elegirMomentoVida — azar ponderado sin repetir', () => {
   });
 
   it('el azar se inyecta: rand=0 da siempre el primer candidato (determinista)', () => {
-    const a = elegirMomentoVida('oso-andino', null, () => 0);
-    const b = elegirMomentoVida('oso-andino', null, () => 0);
+    const a = elegirMomentoVida('oso-guardian', null, () => 0);
+    const b = elegirMomentoVida('oso-guardian', null, () => 0);
     expect(a).toBe(b);
   });
 
@@ -70,8 +70,8 @@ describe('2. elegirMomentoVida — azar ponderado sin repetir', () => {
 
 describe('3. Duraciones — el contrato con el CSS', () => {
   it('duracionDeMomentoVida devuelve el dur del repertorio (0 si no existe)', () => {
-    expect(duracionDeMomentoVida('oso-andino', 'resopla')).toBe(4500);
-    expect(duracionDeMomentoVida('oso-andino', 'nada')).toBe(0);
+    expect(duracionDeMomentoVida('oso-guardian', 'resopla')).toBe(4500);
+    expect(duracionDeMomentoVida('oso-guardian', 'nada')).toBe(0);
     expect(duracionDeMomentoVida('nadie', 'resopla')).toBe(0);
   });
 

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -2702,3 +2702,68 @@
   [data-creature='oso-anteojos'][data-rasca='1'] .crt-brazo-r,
   [data-creature='oso-anteojos'][data-rasca='1'] .crt-body { animation: none !important; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   OSO GUARDIÁN (oso-guardian) — la mole serena del guardián negro de la luna.
+   Aditivo sobre el KIT y sobre los keyframes ya existentes del oso (oso-boil,
+   oso-resoplido, oso-rasca-cuerpo, oso-cejas-frunce) — cero keyframes
+   duplicados; solo el LATIDO DE LA LUNA es nuevo (osog-luna). La cabeza NO se
+   mece (gravitas): la vida vive en el respirar pesado, el aliento de los aros
+   (osoa-anteojo-brillo compartido) y la luna que late. Gates RM + tier abajo.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* BOIL DE MONTAÑA — aún más lento que el oso café: la masa asienta despacio. */
+[data-creature='oso-guardian'] .rh-boil {
+  animation-name: oso-boil;
+  animation-duration: 3.2s;
+  animation-timing-function: steps(14, end);
+}
+
+/* RESOPLA — el huff grave del guardián (pecho hincha y suelta con peso). */
+[data-creature='oso-guardian'][data-resopla='1'] .crt-body {
+  animation: oso-resoplido 1.8s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+[data-creature='oso-guardian'][data-resopla='1'] .oso-cejas {
+  animation: oso-cejas-frunce 1.1s ease-in-out infinite;
+}
+
+/* RASCA → en este oso es un REMECERSE de peso (sin manoteo: la mole se
+   acomoda de gusto, digna). Reusa el meneíto del cuerpo del oso café. */
+[data-creature='oso-guardian'][data-rasca='1'] .crt-body {
+  animation: oso-rasca-cuerpo 1.3s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+
+/* Los estados PISAN el arrebato (antic/travieso): el gesto lee limpio. */
+[data-creature='oso-guardian'][data-resopla='1'] .rh-antic,
+[data-creature='oso-guardian'][data-rasca='1'] .rh-antic,
+[data-creature='oso-guardian'][data-resopla='1'] .rh-travieso,
+[data-creature='oso-guardian'][data-rasca='1'] .rh-travieso { animation: none; }
+
+/* LA LUNA LATE — el halo del emblema del pecho respira MUY despacio (7.3s,
+   co-primo con el aliento de los aros 5.3s y el boil 3.2s: nunca en compás). */
+.osog-luna {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: osog-luna 7.3s ease-in-out infinite;
+}
+@keyframes osog-luna {
+  0%, 100% { opacity: 0.22; transform: scale(1); }
+  50%      { opacity: 0.38; transform: scale(1.07); }
+}
+
+/* device-tier 'bajo': el boil reescrito lo reactivaría (misma clase) →
+   re-apagarlo; cejas y luna continuas también. Estados reactivos siguen. */
+[data-tier='bajo'][data-creature='oso-guardian'] .rh-boil,
+[data-tier='bajo'][data-creature='oso-guardian'] .oso-cejas,
+[data-tier='bajo'] .osog-luna { animation: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .osog-luna,
+  [data-creature='oso-guardian'][data-resopla='1'] .crt-body,
+  [data-creature='oso-guardian'][data-resopla='1'] .oso-cejas,
+  [data-creature='oso-guardian'][data-rasca='1'] .crt-body { animation: none !important; }
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -25,17 +25,29 @@ export {
 } from './AbejaTransicion.jsx';
 export { avisarSalidaAbeja, resetSalidaAbeja, useSalidaAbeja } from './senalSalidaAbeja.js';
 export { Colibri } from './Colibri.jsx';
+/* OsoAndino (el café) ARCHIVADO (operador): rechazado por feo. Queda exportado
+   por compatibilidad/historia, pero NO se surfacea (fuera del registro
+   CREATURES). La dirección vigente es OsoGuardian, más abajo. */
 export { OsoAndino } from './OsoAndino.jsx';
-/* EL OSO DE ANTEOJOS EN SU VERSIÓN BUENA — NEGRO BIOPUNK (la dirección
-   aprobada por el operador: azabache azulado + aros crema luminosos + acentos
-   menta medidos; ver dashboard/GuardianEspiritu → AvatarOso). El OsoAndino
-   café de arriba queda archivado (decisión del operador: no surfacear); este
-   es EL oso de primera clase para valle/mundos. Identidad como datos: jamás
-   arrastra three al bundle base — igual que jaguarIdentidad. */
+/* OsoAnteojos ARCHIVADO (operador, 2026-07-18: "casi feíto como el anterior")
+   — igual que el OsoAndino café. El componente queda exportado por
+   compatibilidad, pero NO se surfacea (fuera del registro CREATURES). */
 export { OsoAnteojos } from './OsoAnteojos.jsx';
 export {
   OSO_ANTEOJOS_PALETA, OSO_ANTEOJOS_PROPORCION, OSO_ANTEOJOS_SLUG, PERFIL_OSO_ANTEOJOS,
 } from './osoAnteojosIdentidad.js';
+/* EL OSO DE ANTEOJOS EN SU DIRECCIÓN VIGENTE — EL GUARDIÁN NEGRO DE LA LUNA
+   (base: el avatar aprobado del selector del guardián, dashboard/
+   GuardianEspiritu → AvatarOso: azabache azulado + luna creciente en el pecho
+   + aros de luz + menta medida), elevado a proporciones de ADULTO (cabeza
+   chica sobre joroba de hombros, hocico presente, ojos-almendra serenos,
+   garras) para que deje de leer infantil. Identidad como datos: jamás
+   arrastra three al bundle base — igual que jaguarIdentidad. */
+export { OsoGuardian } from './OsoGuardian.jsx';
+export {
+  OSO_GUARDIAN_PALETA, OSO_GUARDIAN_PROPORCION, OSO_GUARDIAN_RUANA_ANCLA,
+  OSO_GUARDIAN_SLUG, OSO_GUARDIAN_TINTA, PERFIL_OSO_GUARDIAN,
+} from './osoGuardianIdentidad.js';
 export { RanaAndina } from './RanaAndina.jsx';
 export { Ardilla } from './Ardilla.jsx';
 export { Jaguar } from './Jaguar.jsx';
@@ -168,8 +180,9 @@ export { useVidaIdle, useRitmoPropio, useMiradaUsted, prefiereQuietud } from './
 
 import AbejaAngelita from './AbejaAngelita.jsx';
 import Colibri from './Colibri.jsx';
-import OsoAndino from './OsoAndino.jsx';
-import OsoAnteojos from './OsoAnteojos.jsx';
+/* OsoAndino y OsoAnteojos NO se importan acá a propósito: están archivados y
+   fuera del registro CREATURES. Solo entra el guardián. */
+import OsoGuardian from './OsoGuardian.jsx';
 import RanaAndina from './RanaAndina.jsx';
 import Perezoso from './Perezoso.jsx';
 import Ardilla from './Ardilla.jsx';
@@ -192,11 +205,14 @@ import EntFrailejon from './EntFrailejon.jsx';
 export const CREATURES = {
   'abeja-angelita': { Component: AbejaAngelita, nombre: 'Abeja angelita', cientifico: 'Tetragonisca angustula' },
   colibri: { Component: Colibri, nombre: 'Colibrí chillón', cientifico: 'Colibri coruscans' },
-  'oso-andino': { Component: OsoAndino, nombre: 'Oso andino', cientifico: 'Tremarctos ornatus' },
-  // La VERSIÓN BUENA del oso (negro biopunk, aprobada por el operador). El
-  // 'oso-andino' café de arriba queda archivado; surfacear ESTE.
-  /* OSO-ANTEOJOS ARCHIVADO (operador): rechazado por feo. El oso bueno es el
-     negro de la luna del GuardianEspiritu. */
+  /* EL OSO: 'oso-guardian' es la ÚNICA dirección aprobada por el operador (el
+     guardián negro con la luna en el pecho). Los otros dos quedaron ARCHIVADOS
+     por feos y NO se surfacean: 'oso-andino' (OsoAndino.jsx, el café) y
+     'oso-anteojos' (OsoAnteojos.jsx). Fuera del registro para que NADA
+     data-driven los muestre — avatar-selector, fauna ambiental, vecinos del
+     valle (mismo patrón que el borugo). Los componentes quedan en disco por
+     historia, por si alguna vez se rehacen. */
+  'oso-guardian': { Component: OsoGuardian, nombre: 'Oso de anteojos', cientifico: 'Tremarctos ornatus' },
   'rana-andina': { Component: RanaAndina, nombre: 'Rana arlequín andina', cientifico: 'Atelopus spp.' },
   perezoso: { Component: Perezoso, nombre: 'Perezoso de tres dedos', cientifico: 'Bradypus variegatus' },
   ardilla: { Component: Ardilla, nombre: 'Ardilla de cola roja', cientifico: 'Notosciurus granatensis' },

--- a/src/visual/creatures/osoGuardianIdentidad.js
+++ b/src/visual/creatures/osoGuardianIdentidad.js
@@ -92,14 +92,14 @@ export const OSO_GUARDIAN_PROPORCION = {
  *
  *     7.3 + 4.83 + 1.6 = 13.73 ✓
  *
- * El ancho (rx * 1.18 = 10.6) queda DENTRO de la silueta (flancos ±11.9 a esa
- * altura): se apoya, no engulle.
+ * El ancho (rx * 1.18 = 9.2) queda DENTRO de la silueta (flancos ±11.9 a esa
+ * altura): se apoya sobre el regazo, no engulle.
  *
  * OJO: esto es un arreglo de PROPORCIÓN, quirúrgico. El rediseño de fondo de la
  * ruana (que hoy es un trapecio genérico compartido con el resto de la fauna)
  * va aparte, con su propia DR. Si tocás estos números, revisá las dos
  * desigualdades de arriba o la luna se vuelve a tapar. */
-export const OSO_GUARDIAN_RUANA_ANCLA = { cx: 0, cy: 7.3, rx: 9.0, ry: 4.6 };
+export const OSO_GUARDIAN_RUANA_ANCLA = { cx: 0, cy: 7.3, rx: 7.8, ry: 4.6 };
 
 /*
  * PERFIL_OSO_GUARDIAN — perfil de CLIMA→cuerpo para `cuerpoDeClima`

--- a/src/visual/creatures/osoGuardianIdentidad.js
+++ b/src/visual/creatures/osoGuardianIdentidad.js
@@ -1,0 +1,118 @@
+/*
+ * osoGuardianIdentidad — LA IDENTIDAD VISUAL DEL OSO GUARDIÁN, COMO DATOS.
+ *
+ * El oso de anteojos (Tremarctos ornatus) en su TERCERA y definitiva dirección
+ * de arte: el GUARDIÁN NEGRO DE LA LUNA. La base aprobada por el operador es el
+ * avatar del selector del guardián (dashboard/GuardianEspiritu → AvatarOso):
+ * pelaje AZABACHE AZULADO casi silueta, contorno con luz MENTA (#2dffc4), la
+ * LUNA CRECIENTE crema en el pecho (su emblema) y los anteojos hechos de AROS
+ * DE LUZ. Este archivo fija esa paleta como fuente única.
+ *
+ * Lo que este rediseño CORRIGE de los dos osos rechazados (el café OsoAndino y
+ * el OsoAnteojos de peluche): las PROPORCIONES. Cabeza proporcionada sobre
+ * hombros anchos (ratio cabeza:hombros ≈ 1:3, no 1:1.6), hocico presente,
+ * ojos almendrados serenos (no ojos-juguete de pupila gigante), sin rubor de
+ * cachetes, garras visibles. Presencia de guardián adulto, no ternura de cría.
+ *
+ * REGLA DE ORO (idéntica a jaguarIdentidad/abejaIdentidad): SOLO datos. Cero
+ * three, cero react. La CADENCIA vive en `creatures.css` (clases `rh-*`/
+ * `oso-*`/`osog-*`); el DIBUJO compone el KIT `_rubberhose.jsx` donde sirve
+ * (BocaVisema, Sonrisa, blink/mirada); el CLIMA→cuerpo, en
+ * `creatureClimaCuerpo.js` vía PERFIL_OSO_GUARDIAN.
+ */
+
+/* Slug estable del oso guardián (data-creature, aura, perfiles). */
+export const OSO_GUARDIAN_SLUG = 'oso-guardian';
+
+/* TINTA NOCTURNA propia: el contorno de este oso NO es la tinta cálida de la
+   familia (RH_INK marrón) sino un índigo casi negro — es un espíritu de noche
+   y luna, la línea que manda es fría. Deviación deliberada de identidad. */
+export const OSO_GUARDIAN_TINTA = '#07051a';
+
+export const OSO_GUARDIAN_PALETA = {
+  /* pelaje azabache azulado (del avatar aprobado #171030/#1c1338) con volumen:
+     luz de luna en el lomo → azabache medio → sombra ventral casi negra */
+  cuerpo: '#181130',
+  cuerpoLuz: '#352b62',      // el lametón de luz lunar sobre el hombro
+  cuerpoSombra: '#0b0722',   // la panza en penumbra
+  cuerpoGlow: 'rgba(45,255,196,0.30)', // el halo menta MEDIDO de la silueta
+  pata: '#161038',           // las columnas de las patas, en sombra propia
+  planta: '#241d40',         // la planta plantígrada
+  garra: '#cfe8dd',          // garras hueso-menta: visibles, romas, sin amenaza
+  /* la firma luminosa (del avatar aprobado) */
+  menta: '#2dffc4',          // el neón biopunk del contorno/rim
+  luna: '#f4fff9',           // la LUNA CRECIENTE del pecho (cara iluminada)
+  lunaSombra: '#c9e8d8',     // los mares de la luna (que no sea un sticker)
+  lunaHalo: '#eafff6',       // el halo que respira alrededor del emblema
+  anteojo: '#eafff6',        // los AROS de luz de los anteojos
+  anteojoGlow: '#bfffe9',    // el aliento de los aros
+  /* la cara */
+  iris: '#7dffd9',           // ojo con alma: iris menta-luz, pupila honda
+  ojo: '#0a0620',            // la almendra oscura del ojo (ojo real de oso)
+  ceja: '#4d4380',           // ceño índigo-claro: serio sereno, no bravo
+  hocico: '#e2c69d',         // el morro canela del avatar aprobado (la única nota cálida)
+  hocicoSombra: '#ab8760',
+  trufa: '#0b0f1c',
+  /* atmósfera */
+  espora: '#bfffe9',         // motas de bosque nublado que flotan lento
+  bruma: '#9fffe0',          // el velo tenue a los pies
+  sombraSuelo: 'rgba(4,10,18,0.52)', // el peso de la mole en el suelo
+};
+
+/* PROPORCIONES DEL ADULTO (el corazón del rediseño):
+   hombros 24.4 de ancho contra cabeza de 8.3 → ratio ≈ 0.34 (el OsoAnteojos
+   rechazado andaba por 0.6, proporción de cría/peluche). Cabeza hundida en la
+   joroba de hombros (plantígrado sin cuello), sentado como montaña. */
+export const OSO_GUARDIAN_PROPORCION = {
+  hombrosRx: 12.2,   // media anchura de la mole a la altura de los flancos
+  troncoRy: 10.8,    // media altura de la mole (de la joroba al asiento)
+  cabezaRx: 4.15,    // cráneo proporcionado (no cabezón)
+  cabezaRy: 3.6,
+  orejaR: 1.32,      // orejas chicas y bajas de oso real (no discos de peluche)
+};
+
+/* ANCLA DE LA RUANA (AccesoriosClima) — NO es la medida de la mole.
+ *
+ * Bug corregido: se le pasaba la mole entera (rx 12.2 / ry 10.8 / cy 2) como
+ * ancla. AccesoriosClima dibuja el poncho a `rx * 1.18` de media anchura, o sea
+ * 28.8 de ancho en un viewBox de 32: más ancho que el propio oso (flancos a
+ * ±12.4) y con el borde superior curvándose hasta y≈-6.6. Resultado: una caja
+ * café que se tragaba el cuerpo y tapaba LA LUNA DEL PECHO, que es la firma del
+ * personaje. El operador lo llamó "un fail".
+ *
+ * La ruana se APOYA sobre el lomo/ancas, por DEBAJO de la luna. La luna vive en
+ * un círculo de r=5.4 centrado en (-0.9, -2.2) → su borde inferior está en
+ * y=3.2. AccesoriosClima levanta el borde superior del poncho hasta
+ * `cy - ry*0.8` (el pico de la curva del cuello), así que la restricción dura es:
+ *
+ *     cy - ry*0.8 > 3.2      → con cy 7.3 / ry 4.6 da 3.62 ✓ (holgura 0.4)
+ *
+ * y el ruedo (`cy + ry*1.05`, con el vaivén de +1.6 al centro) tiene que quedar
+ * sobre el cuerpo, no colgando bajo las garras (y=13.9):
+ *
+ *     7.3 + 4.83 + 1.6 = 13.73 ✓
+ *
+ * El ancho (rx * 1.18 = 10.6) queda DENTRO de la silueta (flancos ±11.9 a esa
+ * altura): se apoya, no engulle.
+ *
+ * OJO: esto es un arreglo de PROPORCIÓN, quirúrgico. El rediseño de fondo de la
+ * ruana (que hoy es un trapecio genérico compartido con el resto de la fauna)
+ * va aparte, con su propia DR. Si tocás estos números, revisá las dos
+ * desigualdades de arriba o la luna se vuelve a tapar. */
+export const OSO_GUARDIAN_RUANA_ANCLA = { cx: 0, cy: 7.3, rx: 9.0, ry: 4.6 };
+
+/*
+ * PERFIL_OSO_GUARDIAN — perfil de CLIMA→cuerpo para `cuerpoDeClima`
+ * (creatureClimaCuerpo.js), mismo shape que PERFIL_JAGUAR. Es de bosque
+ * altoandino/páramo:
+ *   alas    false → sin aleteo.
+ *   humedad 0.55 → pelaje denso de niebla: el agua apenas lo toca.
+ *   difusa  0.5  → la mole grande: la niebla apenas lo difumina.
+ *   sequia  0.4  → el bosque nublado sufre la seca un poco más que el jaguar.
+ */
+export const PERFIL_OSO_GUARDIAN = Object.freeze({
+  alas: false,
+  humedad: 0.55,
+  difusa: 0.5,
+  sequia: 0.4,
+});

--- a/src/visual/creatures/transformacion.js
+++ b/src/visual/creatures/transformacion.js
@@ -28,7 +28,8 @@ export const CLASE_PODER = 'is-powered-up';
 export const AURA_POR_BICHO = Object.freeze({
   'abeja-angelita': '#ffd54a', // dorada clásica
   'oso-andino': '#ff3b30',     // roja berserker
-  'oso-anteojos': '#2dffc4',   // MENTA bioluminiscente (el oso negro biopunk — la versión buena)
+  'oso-anteojos': '#2dffc4',   // MENTA bioluminiscente (archivado 2026-07-18; ver oso-guardian)
+  'oso-guardian': '#2dffc4',   // MENTA lunar (el guardián negro de la luna — la dirección vigente)
   'rana-andina': '#39d98a',    // verde-zen (slug real de la creature)
   'rana-arlequin': '#39d98a',  // alias biblia
   colibri: '#4fd1ff',          // iridiscente (aprox. celeste)

--- a/src/visual/creatures/vidaEstados.js
+++ b/src/visual/creatures/vidaEstados.js
@@ -33,7 +33,10 @@
    no es de cuarzo). El TEMPERAMENTO va en el compás: los nerviosos (ardilla,
    colibrí) gesticulan seguido; los lentos (morrocoy, perezoso) casi nunca. */
 export const VIDA_REPERTORIO = {
-  'oso-andino': {
+  /* Tremarctos ornatus. El slug vivo del registro es 'oso-guardian'; los dibujos
+     archivados ('oso-andino' el café, 'oso-anteojos') siguen leyendo esta misma
+     fila por alias más abajo: MISMA especie, mismo temperamento lento. */
+  'oso-guardian': {
     descanso: [4200, 9800],
     momentos: {
       resopla: { dur: 4500, peso: 2 }, // 3× oso-resoplido 1.5s · 5× oso-cejas-frunce 0.9s

--- a/src/visual/mundo3d/sierra/SierraMonte3D.jsx
+++ b/src/visual/mundo3d/sierra/SierraMonte3D.jsx
@@ -56,7 +56,7 @@ import {
   geomVenadoCuerpo, geomVenadoPata, geomAguilaCuerpo, geomAguilaAla,
 } from './sierraBiodiversa.geom.js';
 import CondorBillboard from '../CondorBillboard.jsx';
-import { OsoAndino } from '../../creatures/index.js';
+import { OsoGuardian } from '../../creatures/index.js';
 
 /* Las cuatro bandas navegables, del grafo (pisosTermicos.js). `azimut` reparte
    sus hotspots alrededor del macizo para que orbitar los descubra. */
@@ -346,8 +346,8 @@ function OsoDeAnteojos({ pos, tier, animated, px = 56, factor = 15 }) {
   return (
     <group position={/** @type {[number,number,number]} */ (pos)}>
       <Html center distanceFactor={factor} zIndexRange={[12, 0]} occlude pointerEvents="none">
-        <div aria-hidden="true" data-vecino="oso-andino" style={ESTILO_BICHO}>
-          <OsoAndino size={px} animated={animated} tier={tier} />
+        <div aria-hidden="true" data-vecino="oso-guardian" style={ESTILO_BICHO}>
+          <OsoGuardian size={px} animated={animated} tier={tier} />
         </div>
       </Html>
     </group>

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -86,7 +86,7 @@ const VARIANTES_OSO = [
   { label: 'se rasca', props: { size: 88, rasca: true } },
   { label: 'ruana de noche', props: { size: 88, vestuario: true, clima: 'noche' } },
   { label: 'con lupa (suelo)', props: { size: 88, mundoId: 'suelo' } },
-  { label: 'poder ROJO', props: { size: 88, poder: true } },
+  { label: 'poder MENTA', props: { size: 88, poder: true } },
   { label: 'línea que hierve', props: { size: 88, lineBoil: true } },
   { label: 'sin animación', props: { size: 88, animated: false } },
 ];
@@ -244,7 +244,7 @@ const VARIANTES_ENT = [
 const VARIANTES_POR_SLUG = {
   'abeja-angelita': VARIANTES_ABEJA,
   colibri: VARIANTES_TRIO_AIRE,
-  'oso-andino': VARIANTES_OSO,
+  'oso-guardian': VARIANTES_OSO,
   'rana-andina': VARIANTES_TRIO_SUELO,
   perezoso: VARIANTES_PEREZOSO,
   ardilla: VARIANTES_ARDILLA,
@@ -261,7 +261,7 @@ const VARIANTES_POR_SLUG = {
 const NOTAS_CREATURE = {
   'abeja-angelita': 'Meliponino sin aguijón, polinizadora de la chagra; alas que baten y antenas vivas.',
   colibri: 'Pico recto y garganta violeta iridiscente; el ave-agente de Chagra, ya en rubber-hose.',
-  'oso-andino': 'Oso de anteojos, guardián del páramo; mole parda entrañable con los anteojos crema (su firma).',
+  'oso-guardian': 'Oso de anteojos, guardián del páramo; mole azabache de hombros altos con la luna creciente en el pecho (su firma) y rim-light lunar.',
   'rana-andina': 'Rana arlequín del páramo, guardiana del agua; verde húmedo con manchas ocre y ojos saltones.',
   perezoso: 'Perezoso de tres dedos, la calma total; cuelga de la rama por sus garras largas, antifaz y tinte verdoso de algas. Todo en cámara lenta.',
   ardilla: 'Ardilla de cola roja del templado; rufa con la línea dorsal oscura (su firma), cola tupida y su inspección invertida.',


### PR DESCRIPTION
Cierra el bug que reportó el operador: *"hasta el oso archivado sigue saliendo"*.

**Causa raíz**: el registro `CREATURES` tenía dos comentarios contradictorios y el resultado neto era el inverso del buscado — sobrevivía `oso-andino` (el café archivado por feo) y quedaba fuera `oso-anteojos`. Además `SierraMonte3D` lo renderizaba directo.

- `oso-guardian` es ahora la única dirección surfaceada (aprobada por el operador).
- `oso-andino` y `oso-anteojos` fuera del registro. Los archivos se conservan, no se borran.
- `SierraMonte3D` pasa a `OsoGuardian`.
- **Ruana**: ancla de `12.2x10.8` → `7.8x4.6`. Antes producía un poncho de ~28.8 unidades en un viewBox de 32: enterraba el cuerpo y tapaba la luna del pecho, que es la firma del personaje.

**Pendiente, dicho de frente**: el agente cayó por límite de sesión mientras verificaba si unos fallos de test preexistían. **No hay build verde confirmado ni captura de la escena**. No mergear sin eso.

**Iteración 2 ya pedida por el operador**: que lea más OSO y menos oso OBESO (hoy la silueta es una campana simétrica). Y el rediseño de fondo de la ruana, con DR propia en vuelo, que afecta también a Angelita.