### PR TITLE
art(nocturnas): currucutú y zarigüeya de silueta a personaje completo

### DIFF
--- a/src/components/dashboard/CriaturasNocturnas.jsx
+++ b/src/components/dashboard/CriaturasNocturnas.jsx
@@ -13,7 +13,17 @@
  * comparten <CriaturasNocturnasDefs/> (glow + blur). El ROSTER se exporta para
  * que la vitrina —u otras superficies— lo pinten sin duplicar datos.
  */
+import { useId } from 'react';
+import { LineBoilFilter } from '../../visual/creatures/LineBoilFilter';
 import './criaturas-nocturnas.css';
+
+/* Respeta prefers-reduced-motion para el line-boil SMIL (los transforms CSS ya
+   se congelan por media-query). Se evalúa una vez en cliente; si el usuario lo
+   cambia luego, el resto de la animación ya obedece la media-query. */
+const CN_REDUCED =
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 /* ─── ROSTER GROUNDED — 7 nocturnas + el cóndor del valle ─────────────────── */
 export const CRIATURAS_NOCTURNAS = [
@@ -116,56 +126,323 @@ export function CriaturasNocturnasDefs() {
 
 /* ─── los avatares (SVG biopunk, uno por criatura) ────────────────────────── */
 
-/* Zarigüeya (Didelphis marsupialis): cuadrúpedo de hocico puntudo, orejas
-   grandes y cola pelona prensil enroscada; contorno cian glacial. */
+/* Zarigüeya / chucha (Didelphis marsupialis) — PERSONAJE COMPLETO.
+   Rasgos diagnósticos reales del marsupial: hocico largo y puntudo con
+   VIBRISAS, orejas desnudas membranosas, COLA PRENSIL DESNUDA (el rasgo que la
+   delata, con su anillado escamoso), pelaje de guardia largo y desgreñado sobre
+   lanilla clara, y andar plantígrado bajo — apoya toda la planta, no de puntas.
+   Y el gesto que le gana el corazón a una niña de once: las CRÍAS cargadas en
+   el lomo, agarradas con sus manitos.
+   Animación: husmea (el marsupial vive por la nariz), le tiemblan las vibrisas,
+   la cola prensil se mece y las crías se acomodan. Contorno con line-boil. */
 function AvatarZariguya() {
+  const uid = useId().replace(/[:]/g, '');
+  const boilId = `cn-boil-zari-${uid}`;
+
   return (
     <g className="cn-av-camina" filter="url(#cn-glow1)">
-      <ellipse cx="0" cy="14" rx="16" ry="3" fill="#000" opacity="0.38" />
-      <path d="M-12,6 C-20,8 -22,2 -18,-2 C-16,-4 -13,-3 -14,0" fill="none" stroke="#9ff0ff" strokeWidth="1.6" strokeLinecap="round" opacity="0.85" />
-      <path d="M-13,8 C-15,1 -9,-4 0,-4 C9,-4 14,1 14,7 C14,11 8,13 -2,13 C-9,13 -12,12 -13,8 Z" fill="#171030" stroke="#9ff0ff" strokeWidth="0.9" strokeOpacity="0.6" />
-      <path d="M-10,-1 C-3,-5 8,-4 13,2" fill="none" stroke="#d8f6ff" strokeWidth="0.9" opacity="0.5" />
-      <path d="M-8,12 L-8,7 M0,13 L0,7.5 M8,11 L8,6.5" stroke="#0f0a24" strokeWidth="3.2" strokeLinecap="round" />
-      {/* orejas grandes */}
-      <path d="M6,-4 C4,-10 10,-11 11,-6 C10,-4.5 8,-4 6,-4 Z" fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.7" strokeOpacity="0.6" />
-      <path d="M11,-4 C9,-10 15,-11 16,-6 C15,-4.5 13,-4 11,-4 Z" fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.7" strokeOpacity="0.6" />
-      {/* cabeza + hocico puntudo a la derecha */}
-      <path d="M11,-1 C17,-2 22,1 24.4,4 C25,5.4 24,6.5 22.4,6 C22,4 18.5,2.5 14.5,3 C12.6,3.2 11,1 11,-1 Z" fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.8" strokeOpacity="0.6" />
-      {/* cara pálida del marsupial */}
-      <path d="M13,-0.5 C15,-1 17,-0.6 18,1 C16.5,2 14.5,1.6 13,0.6 Z" fill="#eafff6" opacity="0.5" />
-      <circle cx="24" cy="4.2" r="1.15" fill="#ffc0dc" opacity="0.9" />
-      <circle cx="15.4" cy="1" r="1.15" fill="#04160f" />
-      <circle cx="15.4" cy="1" r="1.15" fill="none" stroke="#9ff0ff" strokeWidth="0.7" />
-      <circle cx="15.8" cy="0.6" r="0.4" fill="#eafff6" />
+      <defs>
+        <LineBoilFilter id={boilId} baseFrequency={0.038} scale={1.8} animated={!CN_REDUCED} dur="0.42s" />
+      </defs>
+
+      <ellipse cx="0" cy="15" rx="17" ry="2.8" fill="#000" opacity="0.36" />
+
+      <g className="cn-zari">
+        {/* ── COLA PRENSIL DESNUDA: base gruesa, punta enroscada, anillos ── */}
+        <g className="cn-zari-cola">
+          <path d="M-9,10.6 C-17.4,11.6 -22.6,5.4 -21.4,-2.4 C-20.8,-6.4 -18.2,-8.4 -16,-7.4
+                   C-17.6,-6.4 -18.8,-4.6 -19.2,-2.2 C-20,3.8 -16.2,8.6 -9,7.4 Z"
+            fill="#1c2350" stroke="#9ff0ff" strokeWidth="0.85" strokeOpacity="0.65" />
+          {/* anillado escamoso de la cola pelona */}
+          <g stroke="#d8f6ff" strokeWidth="0.5" fill="none" opacity="0.42">
+            <path d="M-11.4,10.4 C-11.6,9.2 -11.6,8.4 -11.4,7.6" />
+            <path d="M-14.6,9.6 C-15,8.4 -15.2,7.6 -15,6.6" />
+            <path d="M-17.6,7.4 C-18.4,6.4 -18.8,5.6 -19,4.6" />
+            <path d="M-19.6,3.6 C-20.4,3 -21,2.8 -21.2,2.4" />
+            <path d="M-20.2,-0.8 C-20.8,-1 -21,-1.4 -21.2,-1.8" />
+            <path d="M-18.6,-5 C-19,-5.6 -19.2,-6 -19.2,-6.4" />
+          </g>
+          {/* base peluda: donde el pelo de guardia todavía cubre la cola */}
+          <path d="M-8.4,11 C-11.4,11 -13,9.6 -13.4,7.4 C-11.6,8.2 -10,8.4 -8.4,8 Z"
+            fill="#171030" stroke="#9ff0ff" strokeWidth="0.6" strokeOpacity="0.5" />
+        </g>
+
+        <g filter={`url(#${boilId})`}>
+          {/* ── cuerpo bajo y encorvado, con peso ── */}
+          <path d="M-11.6,12.4 C-14,5.4 -11.4,-2 -2.6,-3.6 C6,-5.2 13.4,-1.6 13.8,5.6
+                   C14,10.4 9.4,13.6 -0.4,13.8 C-6.4,13.9 -10.4,13.6 -11.6,12.4 Z"
+            fill="#171030" stroke="#9ff0ff" strokeWidth="0.9" strokeOpacity="0.6" />
+
+          {/* lanilla clara del vientre bajo el pelo de guardia */}
+          <path d="M-10.2,10.4 C-7.4,13.2 6,13.6 12.4,7.8 C11.4,12.4 -5.6,14.2 -10.2,10.4 Z"
+            fill="#eafff6" opacity="0.2" />
+
+          {/* PELO DE GUARDIA largo y desgreñado: mechones que rompen la silueta */}
+          <g stroke="#9ff0ff" strokeWidth="0.8" strokeLinecap="round" fill="none" opacity="0.5">
+            <path d="M-9.6,-0.4 C-11,-2.4 -11.8,-3.6 -11.6,-4.8" />
+            <path d="M-6.2,-2.4 C-7,-4.6 -7.2,-5.8 -6.6,-7" />
+            <path d="M-2.6,-3.6 C-2.8,-5.8 -2.6,-7.2 -1.8,-8.2" />
+            <path d="M1.4,-4 C1.6,-6.2 2.2,-7.4 3.2,-8.2" />
+            <path d="M5.4,-3.6 C6.2,-5.6 7,-6.6 8.2,-7.2" />
+            <path d="M9.4,-2 C10.6,-3.6 11.6,-4.4 12.8,-4.8" />
+            <path d="M-11.8,4.4 C-13.6,3.6 -14.6,3 -15.2,2.2" />
+            <path d="M-12,8.2 C-14,8.2 -15,8 -15.8,7.4" />
+          </g>
+          {/* textura interna del pelaje (dirección del pelo) */}
+          <g stroke="#d8f6ff" strokeWidth="0.55" fill="none" opacity="0.3">
+            <path d="M-8.4,2.4 C-6.4,0.6 -3.4,-0.6 0.4,-1" />
+            <path d="M-7.6,6.4 C-4.6,4.4 -0.6,3.2 4,3" />
+            <path d="M-5.6,10 C-1.6,8.6 3.4,7.6 8.4,7.4" />
+          </g>
+        </g>
+
+        {/* ── ANDAR PLANTÍGRADO: apoya toda la planta, con deditos ── */}
+        {/* pata trasera */}
+        <path d="M-7.4,11.4 C-8.2,12.6 -8.4,13.4 -8.2,14.2" stroke="#0f0a24" strokeWidth="3" strokeLinecap="round" fill="none" />
+        <path d="M-10.6,14.4 L-4.6,14.4" stroke="#0f0a24" strokeWidth="2.4" strokeLinecap="round" />
+        <g stroke="#9ff0ff" strokeWidth="0.7" strokeLinecap="round" opacity="0.65">
+          <path d="M-10.4,14.6 L-11.4,15.4" /><path d="M-8.6,14.8 L-9,15.8" />
+          <path d="M-6.8,14.8 L-6.6,15.8" /><path d="M-5,14.6 L-4.2,15.4" />
+        </g>
+        {/* pata delantera */}
+        <path d="M8.4,11 C8.8,12.4 8.8,13.4 8.6,14.2" stroke="#0f0a24" strokeWidth="2.8" strokeLinecap="round" fill="none" />
+        <path d="M6,14.4 L11.6,14.4" stroke="#0f0a24" strokeWidth="2.2" strokeLinecap="round" />
+        <g stroke="#9ff0ff" strokeWidth="0.7" strokeLinecap="round" opacity="0.65">
+          <path d="M6.2,14.6 L5.4,15.4" /><path d="M8,14.8 L7.8,15.8" />
+          <path d="M9.8,14.8 L10.2,15.8" /><path d="M11.4,14.6 L12.2,15.4" />
+        </g>
+
+        {/* ── LAS CRÍAS AL LOMO: el gesto ── */}
+        <g className="cn-zari-cria">
+          <ZariguyaCria x={-6.2} y={-6.4} escala={1} />
+        </g>
+        <g className="cn-zari-cria cn-zari-cria-b">
+          <ZariguyaCria x={-0.6} y={-7.6} escala={1.05} />
+        </g>
+        <g className="cn-zari-cria cn-zari-cria-c">
+          <ZariguyaCria x={5.2} y={-6.8} escala={0.92} />
+        </g>
+
+        {/* ── CABEZA que HUSMEA: hocico largo, orejas desnudas, vibrisas ── */}
+        <g className="cn-zari-hocico">
+          {/* oreja trasera (membranosa, desnuda) */}
+          <path d="M8.6,-3.4 C6.8,-9 11.4,-11.6 13.6,-7.6 C13.2,-5.2 11,-3.6 8.6,-3.4 Z"
+            fill="#141a3a" stroke="#9ff0ff" strokeWidth="0.7" strokeOpacity="0.6" />
+          <path d="M10,-4.6 C9.4,-7.8 11.6,-9.2 12.6,-7.4 C12.2,-6 11.2,-5 10,-4.6 Z"
+            fill="#ffc0dc" opacity="0.22" />
+          {/* oreja delantera */}
+          <path d="M13.6,-2.6 C12.4,-8.4 17.4,-10.6 19.2,-6.4 C18.6,-4.2 16.2,-2.8 13.6,-2.6 Z"
+            fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.7" strokeOpacity="0.7" />
+          <path d="M15,-3.8 C14.6,-7.2 17.2,-8.4 18.2,-6.2 C17.6,-4.8 16.4,-4 15,-3.8 Z"
+            fill="#ffc0dc" opacity="0.28" />
+
+          {/* cráneo + HOCICO LARGO Y PUNTUDO */}
+          <path d="M9.4,-1.4 C14.2,-4 19,-2.4 22.4,0.6 C24,2 25.4,3.4 25.6,4.6
+                   C25.8,5.8 24.6,6.4 23.4,5.8 C22,4 19,2.6 15.6,3.2 C12.4,3.8 9.6,1.8 9.4,-1.4 Z"
+            fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.85" strokeOpacity="0.65" />
+          {/* cara pálida del marsupial (la máscara clara sobre el hocico) */}
+          <path d="M12,-1.2 C15.4,-2.6 19.2,-1.4 22.6,1.6 C19.4,0.6 15.6,0.4 12.8,1.2 Z"
+            fill="#eafff6" opacity="0.32" />
+          {/* mejilla: pelo de guardia también en la cara */}
+          <g stroke="#9ff0ff" strokeWidth="0.6" strokeLinecap="round" fill="none" opacity="0.4">
+            <path d="M10.4,1.4 C9,2.4 8.2,3 7.8,3.8" />
+            <path d="M11,-2.2 C10.2,-3.6 9.8,-4.4 9.8,-5.2" />
+          </g>
+
+          {/* trufa rosada */}
+          <ellipse cx="24.4" cy="4.6" rx="1.4" ry="1.1" fill="#ffc0dc" opacity="0.95"
+            style={{ filter: 'drop-shadow(0 0 3px rgba(255,192,220,0.8))' }} />
+          <path d="M24.4,5.2 L24.4,6" stroke="#0f0a24" strokeWidth="0.4" strokeLinecap="round" opacity="0.7" />
+
+          {/* VIBRISAS (el marsupial lee el mundo con ellas) */}
+          <g className="cn-zari-bigote">
+            <g stroke="#eafff6" strokeWidth="0.45" fill="none" opacity="0.6" strokeLinecap="round">
+              <path d="M22.4,3.2 C23.8,1.4 24.4,0 24.6,-1.6" />
+              <path d="M22.8,4.2 C24.2,3.2 25,2.2 25.3,1" />
+              <path d="M22.6,5.4 C24.2,5.6 25,6.2 25.3,7.2" />
+              <path d="M21.6,6 C22.8,7.2 23.6,8.2 24,9.4" />
+            </g>
+          </g>
+
+          {/* ojo: cuenta negra con anillo neón y brillo de linterna */}
+          <circle cx="15.4" cy="-0.4" r="1.5" fill="#04160f" />
+          <circle cx="15.4" cy="-0.4" r="1.5" fill="none" stroke="#9ff0ff" strokeWidth="0.7"
+            style={{ filter: 'drop-shadow(0 0 3px #9ff0ff)' }} />
+          <circle cx="15.9" cy="-0.9" r="0.5" fill="#eafff6" />
+        </g>
+      </g>
     </g>
   );
 }
 
-/* Currucutú (Megascops choliba): búho compacto de penachos, disco facial y ojos
-   enormes ámbar con glow; posado. Acento dorado. */
+/* Cría de zarigüeya agarrada al lomo de la madre: cuerpito, hocico ya puntudo,
+   orejas desnudas, manito que agarra el pelo y colita pelona. Miniatura fiel —
+   la cría de Didelphis es la madre en pequeño, no un muñeco redondo. */
+function ZariguyaCria({ x, y, escala = 1 }) {
+  return (
+    <g transform={`translate(${x} ${y}) scale(${escala})`}>
+      {/* cuerpito agachado sobre el lomo */}
+      <path d="M-3.2,2.6 C-4,0.4 -2.6,-1.6 0,-1.8 C2.6,-2 4.2,-0.6 4.2,1.4 C4.2,2.8 2.6,3.4 -0.4,3.4 C-2,3.4 -2.8,3.2 -3.2,2.6 Z"
+        fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.55" strokeOpacity="0.65" />
+      {/* colita pelona enroscada */}
+      <path d="M-3,2.2 C-5.2,2.4 -6.2,1 -5.6,-0.4" fill="none" stroke="#9ff0ff" strokeWidth="0.6"
+        strokeLinecap="round" opacity="0.7" />
+      {/* orejita desnuda */}
+      <path d="M2.6,-1.4 C2.2,-3.4 4.4,-4.2 5,-2.4 C4.6,-1.6 3.6,-1.2 2.6,-1.4 Z"
+        fill="#141a3a" stroke="#9ff0ff" strokeWidth="0.45" strokeOpacity="0.6" />
+      {/* cabecita con hocico ya puntudo */}
+      <path d="M2.4,-0.6 C4,-1.6 5.6,-1 6.8,0 C7.4,0.5 7.3,1.3 6.6,1.3 C5.8,0.7 4.6,0.4 3.6,0.7
+               C2.8,0.9 2.3,0.2 2.4,-0.6 Z"
+        fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.5" strokeOpacity="0.65" />
+      <circle cx="6.5" cy="1.1" r="0.4" fill="#ffc0dc" opacity="0.9" />
+      {/* ojito */}
+      <circle cx="4" cy="-0.3" r="0.5" fill="#04160f" />
+      <circle cx="4.15" cy="-0.45" r="0.18" fill="#eafff6" />
+      {/* manito que AGARRA el pelo de la madre */}
+      <path d="M-1,3 C-1.4,4 -1.2,4.8 -0.4,5" fill="none" stroke="#9ff0ff" strokeWidth="0.6"
+        strokeLinecap="round" opacity="0.75" />
+      <path d="M2,3.2 C2,4.2 2.4,4.8 3.2,5" fill="none" stroke="#9ff0ff" strokeWidth="0.6"
+        strokeLinecap="round" opacity="0.75" />
+    </g>
+  );
+}
+
+/* Currucutú (Megascops choliba) — PERSONAJE COMPLETO, no silueta.
+   Rasgos diagnósticos reales del estrígido andino: disco facial marcado con
+   REBORDE oscuro, penachos auriculares erectos, ojos amarillos frontales
+   enormes, patrón CRÍPTICO de corteza en el plumaje (estrías verticales +
+   barrado fino) y postura vertical compacta con garras prensiles agarrando la
+   madera. Anatomía = el efecto especial: si Julieta lo mira, entiende que ese
+   pájaro está hecho para ver y agarrar en lo oscuro.
+   Animación: respira (squash&stretch del pecho), gira la cabeza como búho,
+   parpadea y le tiemblan los penachos. Contorno con line-boil rubber-hose. */
 function AvatarBuho() {
+  const uid = useId().replace(/[:]/g, '');
+  const boilId = `cn-boil-buho-${uid}`;
+
   return (
     <g className="cn-av-flota" filter="url(#cn-glow1)">
-      <ellipse cx="0" cy="15" rx="12" ry="2.6" fill="#000" opacity="0.38" />
-      <path d="M-10,13 C-12,2 -8,-10 0,-11 C8,-10 12,2 10,13 C7,16 -7,16 -10,13 Z" fill="#171030" stroke="#ffcf5a" strokeWidth="0.9" strokeOpacity="0.55" />
-      {/* barrado del pecho */}
-      <path d="M-5,2 Q0,4 5,2 M-6,6 Q0,8 6,6 M-5,10 Q0,12 5,10" fill="none" stroke="#ffe6a6" strokeWidth="0.8" opacity="0.45" />
-      {/* penachos */}
-      <path d="M-9,-8 L-6,-15.5 L-3,-8 Z" fill="#1c1338" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.6" />
-      <path d="M9,-8 L6,-15.5 L3,-8 Z" fill="#1c1338" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.6" />
-      {/* disco facial */}
-      <ellipse cx="0" cy="-5" rx="9" ry="8" fill="#1c1338" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.45" />
-      {/* ojos enormes */}
-      <circle cx="-3.6" cy="-5" r="3.4" fill="#04160f" stroke="#ffd76a" strokeWidth="1" />
-      <circle cx="3.6" cy="-5" r="3.4" fill="#04160f" stroke="#ffd76a" strokeWidth="1" />
-      <circle cx="-3.6" cy="-5" r="1.7" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 4px #ffd76a)' }} />
-      <circle cx="3.6" cy="-5" r="1.7" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 4px #ffd76a)' }} />
-      <circle cx="-3" cy="-5.7" r="0.55" fill="#eafff6" />
-      <circle cx="4.2" cy="-5.7" r="0.55" fill="#eafff6" />
-      {/* pico */}
-      <path d="M-1.4,-2 L1.4,-2 L0,1.6 Z" fill="#ffcf5a" />
-      {/* garras */}
-      <path d="M-4,14 l0,2 M4,14 l0,2" stroke="#ffcf5a" strokeWidth="1.4" strokeLinecap="round" />
+      <defs>
+        <LineBoilFilter id={boilId} baseFrequency={0.038} scale={1.8} animated={!CN_REDUCED} dur="0.42s" />
+      </defs>
+
+      <ellipse cx="0" cy="19" rx="14" ry="2.6" fill="#000" opacity="0.34" />
+
+      {/* ── la rama: le da suelo, escala y oficio de vigía ── */}
+      <g filter={`url(#${boilId})`}>
+        <path d="M-19,15.4 C-9,14 9,14 19,15.6 C19,17.8 -19,17.6 -19,15.4 Z"
+          fill="#141a3a" stroke="#ffcf5a" strokeWidth="0.8" strokeOpacity="0.42" />
+        <path d="M-15,16.2 C-6,15.2 7,15.2 15,16.4" fill="none" stroke="#ffe6a6" strokeWidth="0.5" opacity="0.3" />
+        {/* muñón de rama seca */}
+        <path d="M13,15 C16,12.6 18.6,12 20.4,12.6 C18.6,13.6 17,14.4 16,15.4 Z"
+          fill="#141a3a" stroke="#ffcf5a" strokeWidth="0.6" strokeOpacity="0.35" />
+      </g>
+
+      {/* ── cuerpo: masa compacta que RESPIRA ── */}
+      <g className="cn-buho-respira">
+        <g filter={`url(#${boilId})`}>
+          {/* cola corta bajo el cuerpo */}
+          <path d="M-5,10 C-4.6,15.6 4.6,15.6 5,10 Z" fill="#141a3a" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.5" />
+          <path d="M-2.6,11.4 L-2.2,15 M0,11.6 L0,15.4 M2.6,11.4 L2.2,15" stroke="#0f0a24" strokeWidth="0.7" opacity="0.8" />
+
+          {/* torso rechoncho, hombros anchos y panza de búho posado */}
+          <path d="M-10.6,-2 C-12.4,4 -10.4,11.4 -0.2,13.8 C10,11.6 12.4,4 10.6,-2 C8.6,-7.4 -8.6,-7.4 -10.6,-2 Z"
+            fill="#171030" stroke="#ffcf5a" strokeWidth="0.9" strokeOpacity="0.55" />
+
+          {/* volumen: el vientre recibe la luz de la luna */}
+          <path d="M-6.6,1 C-7.4,6 -5.2,10.6 0,12.4 C5.2,10.6 7.4,6 6.6,1 C4,-1.4 -4,-1.4 -6.6,1 Z"
+            fill="#1c1338" opacity="0.85" />
+
+          {/* patrón CRÍPTICO de corteza: estrías verticales + barrado fino */}
+          <path d="M-4.4,0.6 C-4.8,4 -4.6,8 -3.6,11 M0,-0.2 C-0.3,4 -0.2,8.4 0,12
+                   M4.4,0.6 C4.8,4 4.6,8 3.6,11"
+            fill="none" stroke="#0f0a24" strokeWidth="1.1" strokeLinecap="round" opacity="0.9" />
+          <path d="M-6,2.4 Q0,4 6,2.4 M-6.6,5.6 Q0,7.2 6.6,5.6 M-5.6,8.8 Q0,10.4 5.6,8.8"
+            fill="none" stroke="#ffe6a6" strokeWidth="0.7" opacity="0.4" />
+
+          {/* ── alas plegadas: escapulares escalonadas, no una mancha plana ── */}
+          <path d="M-10.6,-2.4 C-13.4,3 -12.6,10 -7.6,13.2 C-6,9.8 -6.2,3 -7.4,-2.4 Z"
+            fill="#141a3a" stroke="#ffcf5a" strokeWidth="0.8" strokeOpacity="0.55" />
+          <path d="M10.6,-2.4 C13.4,3 12.6,10 7.6,13.2 C6,9.8 6.2,3 7.4,-2.4 Z"
+            fill="#141a3a" stroke="#ffcf5a" strokeWidth="0.8" strokeOpacity="0.55" />
+          {/* escalones de pluma (coberteras) */}
+          <path d="M-11.6,1.6 C-9.6,2.6 -8,2.4 -7,1.6 M-12,5.4 C-10,6.4 -8.4,6.2 -7.2,5.4 M-11.4,9.2 C-9.6,10.2 -8.2,10 -7,9.2"
+            fill="none" stroke="#ffe6a6" strokeWidth="0.6" opacity="0.45" />
+          <path d="M11.6,1.6 C9.6,2.6 8,2.4 7,1.6 M12,5.4 C10,6.4 8.4,6.2 7.2,5.4 M11.4,9.2 C9.6,10.2 8.2,10 7,9.2"
+            fill="none" stroke="#ffe6a6" strokeWidth="0.6" opacity="0.45" />
+        </g>
+
+        {/* ── GARRAS PRENSILES agarrando la madera (rasgo diagnóstico) ── */}
+        {/* tarsos emplumados */}
+        <path d="M-5.4,11 C-6.6,12.4 -6.6,13.6 -5.6,14.2 C-4.4,13.8 -4.2,12.4 -4.6,11 Z"
+          fill="#1c1338" stroke="#ffcf5a" strokeWidth="0.5" strokeOpacity="0.5" />
+        <path d="M5.4,11 C6.6,12.4 6.6,13.6 5.6,14.2 C4.4,13.8 4.2,12.4 4.6,11 Z"
+          fill="#1c1338" stroke="#ffcf5a" strokeWidth="0.5" strokeOpacity="0.5" />
+        {/* dedos que ABRAZAN la rama */}
+        <g stroke="#ffcf5a" strokeWidth="1.5" strokeLinecap="round" fill="none" opacity="0.92">
+          <path d="M-5.2,13.6 C-7.4,14 -8.8,15 -9.2,16.4" />
+          <path d="M-5.2,13.6 C-5.4,14.8 -5.2,15.8 -5,16.8" />
+          <path d="M-5.2,13.6 C-3.4,14.2 -2.4,15.2 -2.2,16.4" />
+          <path d="M5.2,13.6 C7.4,14 8.8,15 9.2,16.4" />
+          <path d="M5.2,13.6 C5.4,14.8 5.2,15.8 5,16.8" />
+          <path d="M5.2,13.6 C3.4,14.2 2.4,15.2 2.2,16.4" />
+        </g>
+        {/* uñas */}
+        <g fill="#eafff6" opacity="0.75">
+          <circle cx="-9.3" cy="16.7" r="0.45" /><circle cx="-5" cy="17.1" r="0.45" /><circle cx="-2.1" cy="16.7" r="0.45" />
+          <circle cx="9.3" cy="16.7" r="0.45" /><circle cx="5" cy="17.1" r="0.45" /><circle cx="2.1" cy="16.7" r="0.45" />
+        </g>
+      </g>
+
+      {/* ── CABEZA: gira como búho, sin mover el cuerpo ── */}
+      <g className="cn-buho-cabeza">
+        {/* penachos auriculares erectos (mechones) */}
+        <g className="cn-buho-penacho">
+          <path d="M-9.6,-9.6 C-11.4,-14.6 -10,-18.6 -7.6,-19.4 C-7,-16 -6.2,-12.6 -5,-10.2 Z"
+            fill="#171030" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.6" />
+          <path d="M-9,-11.4 C-9.8,-14.6 -9,-17 -7.8,-18" fill="none" stroke="#ffe6a6" strokeWidth="0.5" opacity="0.45" />
+        </g>
+        <g className="cn-buho-penacho cn-buho-penacho-r">
+          <path d="M9.6,-9.6 C11.4,-14.6 10,-18.6 7.6,-19.4 C7,-16 6.2,-12.6 5,-10.2 Z"
+            fill="#171030" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.6" />
+          <path d="M9,-11.4 C9.8,-14.6 9,-17 7.8,-18" fill="none" stroke="#ffe6a6" strokeWidth="0.5" opacity="0.45" />
+        </g>
+
+        {/* DISCO FACIAL con reborde oscuro (el rasgo que lo hace currucutú) */}
+        <path d="M0,-16.4 C-7.4,-16.8 -11.4,-12 -11,-6 C-10.6,-0.6 -5.6,2.6 0,2.6 C5.6,2.6 10.6,-0.6 11,-6 C11.4,-12 7.4,-16.8 0,-16.4 Z"
+          fill="#1c1338" stroke="#0f0a24" strokeWidth="1.6" strokeOpacity="0.95" />
+        <path d="M0,-16.4 C-7.4,-16.8 -11.4,-12 -11,-6 C-10.6,-0.6 -5.6,2.6 0,2.6 C5.6,2.6 10.6,-0.6 11,-6 C11.4,-12 7.4,-16.8 0,-16.4 Z"
+          fill="none" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.5" />
+        {/* plumitas radiales del disco */}
+        <g stroke="#ffe6a6" strokeWidth="0.45" fill="none" opacity="0.32">
+          <path d="M-8.6,-11.4 C-6.6,-10 -5.4,-8.6 -4.8,-7.2" />
+          <path d="M-9.8,-6.4 C-7.4,-6 -6,-5.4 -5,-4.6" />
+          <path d="M-8.4,-1.4 C-6.4,-2 -5,-2.6 -4.2,-3.4" />
+          <path d="M8.6,-11.4 C6.6,-10 5.4,-8.6 4.8,-7.2" />
+          <path d="M9.8,-6.4 C7.4,-6 6,-5.4 5,-4.6" />
+          <path d="M8.4,-1.4 C6.4,-2 5,-2.6 4.2,-3.4" />
+        </g>
+        {/* cejas crípticas: la expresión seria del cazador */}
+        <path d="M-8.6,-10.2 C-6.6,-12.4 -2.6,-12.6 -1,-10.6 M8.6,-10.2 C6.6,-12.4 2.6,-12.6 1,-10.6"
+          fill="none" stroke="#0f0a24" strokeWidth="1.5" strokeLinecap="round" opacity="0.85" />
+
+        {/* OJOS AMARILLOS FRONTALES ENORMES */}
+        <circle cx="-4.4" cy="-6.4" r="4.3" fill="#04160f" stroke="#ffd76a" strokeWidth="1.1" />
+        <circle cx="4.4" cy="-6.4" r="4.3" fill="#04160f" stroke="#ffd76a" strokeWidth="1.1" />
+        <circle cx="-4.4" cy="-6.4" r="2.7" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 5px #ffd76a)' }} />
+        <circle cx="4.4" cy="-6.4" r="2.7" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 5px #ffd76a)' }} />
+        <circle cx="-4.4" cy="-6.4" r="1.35" fill="#04160f" />
+        <circle cx="4.4" cy="-6.4" r="1.35" fill="#04160f" />
+        <circle cx="-3.4" cy="-7.6" r="0.75" fill="#eafff6" />
+        <circle cx="5.4" cy="-7.6" r="0.75" fill="#eafff6" />
+        {/* párpados (parpadeo) */}
+        <circle className="cn-buho-parpado" cx="-4.4" cy="-6.4" r="4.3" fill="#1c1338" />
+        <circle className="cn-buho-parpado" cx="4.4" cy="-6.4" r="4.3" fill="#1c1338" />
+
+        {/* pico ganchudo entre los ojos */}
+        <path d="M-1.7,-3.4 C-1.4,-1 -0.7,0.6 0,1.6 C0.7,0.6 1.4,-1 1.7,-3.4 Z" fill="#ffcf5a" />
+        <path d="M0,0.4 C-0.5,1 -0.2,1.8 0.4,1.6" fill="none" stroke="#ffe6a6" strokeWidth="0.5" opacity="0.8" />
+      </g>
     </g>
   );
 }

--- a/src/components/dashboard/criaturas-nocturnas.css
+++ b/src/components/dashboard/criaturas-nocturnas.css
@@ -44,3 +44,146 @@
   .cn-av-camina, .cn-av-flota, .cn-av-vuela, .cn-av-planea,
   .cn-ala-mur, .cn-luz, .cn-luz-halo { animation: none !important; }
 }
+
+/* ════════════════════════════════════════════════════════════════════════════
+   BLOQUE NUEVO — criaturas nocturnas elevadas a PERSONAJE (búho + zarigüeya).
+   No reescribe nada de arriba: solo suma. Rubber-hose andino sobre el biopunk:
+   squash & stretch, follow-through y gestos que cuentan qué hace el animal.
+   `transform-box: fill-box` deja que cada parte pivote sobre SU propia caja,
+   sin tener que calcular el origen en coordenadas del viewBox.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* ── Currucutú (Megascops choliba) ─────────────────────────────────────────
+   Respira, gira la cabeza como solo un búho puede, parpadea y le tiemblan los
+   penachos. El peso vive abajo: el pecho se infla, las garras no se mueven. */
+.cn-buho-respira {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-buho-respira 3.6s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+@keyframes cn-buho-respira {
+  0%, 100% { transform: scale(1, 1); }
+  45% { transform: scale(0.985, 1.035); }
+  70% { transform: scale(1.012, 0.99); }
+}
+
+/* giro de cabeza: dos miradas al monte con pausa entre ellas (no un vaivén
+   de metrónomo — el búho SE DETIENE a mirar, que es lo que lo hace vigía) */
+.cn-buho-cabeza {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-buho-mira 7.4s cubic-bezier(0.5, 0, 0.25, 1.25) infinite;
+}
+@keyframes cn-buho-mira {
+  0%, 14% { transform: rotate(0deg) translateY(0); }
+  26%, 40% { transform: rotate(8deg) translateY(-0.4px); }
+  52%, 58% { transform: rotate(0deg) translateY(0); }
+  70%, 84% { transform: rotate(-7deg) translateY(-0.3px); }
+  96%, 100% { transform: rotate(0deg) translateY(0); }
+}
+
+/* párpado: baja desde arriba. scaleY(0) = ojo abierto, scaleY(1) = cerrado. */
+.cn-buho-parpado {
+  transform-box: fill-box;
+  transform-origin: center top;
+  /* estado por defecto = ojo ABIERTO: si la animación no corre, el párpado
+     nunca debe quedarse tapando el ojo */
+  transform: scaleY(0);
+  animation: cn-buho-parpadea 6.2s ease-in-out infinite;
+}
+@keyframes cn-buho-parpadea {
+  0%, 6% { transform: scaleY(0); }
+  8% { transform: scaleY(1); }
+  10%, 48% { transform: scaleY(0); }
+  50% { transform: scaleY(1); }
+  53%, 100% { transform: scaleY(0); }
+}
+
+/* penachos: tic auricular corto y seco al final del ciclo */
+.cn-buho-penacho {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-buho-penacho 5.2s ease-in-out infinite;
+}
+.cn-buho-penacho-r { animation-delay: -0.18s; }
+@keyframes cn-buho-penacho {
+  0%, 84%, 100% { transform: rotate(0deg); }
+  88% { transform: rotate(-6deg); }
+  92% { transform: rotate(4deg); }
+  96% { transform: rotate(-1.5deg); }
+}
+
+/* ── Zarigüeya (Didelphis marsupialis) ─────────────────────────────────────
+   Husmea: el marsupial lee el mundo con la nariz, así que el gesto rector es
+   el olfateo, no el paso. La cola prensil arrastra el movimiento (follow-
+   through) y las crías se acomodan encima con su propio ritmo. */
+.cn-zari {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-zari-husmea 3.4s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+@keyframes cn-zari-husmea {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  22% { transform: translateY(-0.7px) rotate(-0.8deg); }
+  48% { transform: translateY(0.5px) rotate(0.5deg); }
+  74% { transform: translateY(-0.4px) rotate(-0.3deg); }
+}
+
+/* el hocico olfatea más rápido que el cuerpo: sube, husmea, vuelve */
+.cn-zari-hocico {
+  transform-box: fill-box;
+  transform-origin: left center;
+  animation: cn-zari-hocico 1.6s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+}
+@keyframes cn-zari-hocico {
+  0%, 100% { transform: rotate(0deg) translateX(0); }
+  30% { transform: rotate(-2.8deg) translateX(0.35px); }
+  62% { transform: rotate(1.6deg) translateX(-0.2px); }
+}
+
+/* cola prensil: pesada y lenta, va detrás del cuerpo */
+.cn-zari-cola {
+  transform-box: fill-box;
+  transform-origin: right bottom;
+  animation: cn-zari-cola 4.8s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+@keyframes cn-zari-cola {
+  0%, 100% { transform: rotate(0deg); }
+  35% { transform: rotate(-4.5deg) translateY(-0.4px); }
+  72% { transform: rotate(2.5deg) translateY(0.3px); }
+}
+
+/* las crías: cada una con su desfase, para que no parezcan calcomanías */
+.cn-zari-cria {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-zari-cria 2.8s ease-in-out infinite;
+}
+.cn-zari-cria-b { animation-delay: -0.7s; }
+.cn-zari-cria-c { animation-delay: -1.5s; }
+@keyframes cn-zari-cria {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  40% { transform: translateY(-0.6px) rotate(2deg); }
+  75% { transform: translateY(0.3px) rotate(-1.2deg); }
+}
+
+/* vibrisas: el temblor fino que delata que está oliendo */
+.cn-zari-bigote {
+  transform-box: fill-box;
+  transform-origin: left center;
+  animation: cn-zari-bigote 0.9s ease-in-out infinite;
+}
+@keyframes cn-zari-bigote {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-3.5deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cn-buho-respira, .cn-buho-cabeza, .cn-buho-parpado, .cn-buho-penacho,
+  .cn-zari, .cn-zari-hocico, .cn-zari-cola, .cn-zari-cria, .cn-zari-bigote {
+    animation: none !important;
+  }
+  /* con el párpado congelado, scaleY(0) por defecto dejaría el ojo tapado:
+     lo forzamos abierto */
+  .cn-buho-parpado { transform: scaleY(0); }
+}


### PR DESCRIPTION
Las dos nocturnas existían **solo como siluetas**: chips planos de ~35 líneas, sin volumen, sin peso y sin gesto. Quedan elevadas al nivel de dibujo del resto del bestiario, dentro del lenguaje biopunk ya aprobado (cuerpos oscuros, contorno neón por especie, realces crema, glow en los ojos). Ese look no se tocó — lo que subió es **volumen, peso, gesto y animación**.

## Currucutú — *Megascops choliba*

| Rasgo diagnóstico real | Cómo quedó dibujado |
|---|---|
| Disco facial con reborde oscuro | Disco con doble contorno + plumitas radiales |
| Penachos auriculares erectos | Dos mechones con estría interna, con tic propio |
| Ojos amarillos frontales enormes | Iris ámbar con glow, pupila, brillo y párpado |
| Patrón críptico de corteza | Estrías verticales + barrado fino en pecho y alas |
| Postura vertical compacta | Torso rechoncho, alas plegadas con coberteras escalonadas |
| Garras prensiles sobre madera | Tres dedos por pata **abrazando** la rama, con uñas |

Animación: respira con squash & stretch, gira la cabeza y **se detiene a mirar** (no es un vaivén de metrónomo — esa pausa es lo que lo vuelve vigía), parpadea y le tiembla el penacho.

## Zarigüeya — *Didelphis marsupialis*

| Rasgo diagnóstico real | Cómo quedó dibujado |
|---|---|
| Hocico largo y puntudo con vibrisas | Muzzle alargado, máscara clara, trufa rosada, abanico de vibrisas |
| Orejas desnudas membranosas | Dos orejas con membrana interna translúcida |
| **Cola prensil desnuda** | Cola con anillado escamoso y base todavía peluda — el rasgo que la delata |
| Pelaje de guardia desgreñado | Mechones que rompen la silueta, sobre lanilla clara del vientre |
| Andar plantígrado bajo | Apoya toda la planta, con deditos — no de puntas |
| Crías al lomo | Tres crías, cada una con hocico ya puntudo, orejita desnuda, colita pelona y **manitos que agarran el pelo de la madre** |

Animación: husmea (el gesto rector del marsupial, que lee el mundo con la nariz), la cola arrastra el movimiento como follow-through, y las crías se acomodan con ritmo propio.

## Lo que NO cambió

- **Contrato intacto**: `CriaturaNocturnaAvatar({ id, size })`, el mapa `AVATAR`, `CriaturasNocturnasDefs` y el viewBox `-26 -24 52 46`. Las otras superficies que los consumen no se rompen.
- **Roster con grounding verificado**: nombre científico, rol agroecológico y fuente quedaron con **cero líneas de diff**.
- **Sin tocar** `Valle3D.jsx`, `composicionValle3D.jsx`, murciélago, armadillo ni tigrillo.
- **Sin tocar** el `creatures.css` compartido. El CSS nuevo entra como bloque al final de `criaturas-nocturnas.css`, sin reescribir ninguna regla existente.

## Verificación síncrona

- Los 8 avatares del roster renderizan sin error y conservan el viewBox.
- Dos instancias del mismo avatar **no colisionan** en el id del filtro line-boil (`useId`).
- `prefers-reduced-motion` congela todo lo nuevo, incluido el line-boil SMIL, y deja el párpado en estado abierto.
- Los 2 errores de eslint del archivo son **preexistentes** (idénticos al lintar la base).

Falta la captura y el cableado, que van por fuera de esta rama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)