### PR TITLE
art(cafe): la ladera cafetera entera en el arquetipo de producción

### DIFF
--- a/src/visual/mundo3d/cafetal/CasaBeneficio.jsx
+++ b/src/visual/mundo3d/cafetal/CasaBeneficio.jsx
@@ -1,0 +1,103 @@
+/*
+ * CasaBeneficio — la casa campesina con su BENEFICIADERO, la pieza que corona
+ * el cafetal: paredes encaladas, techo de teja, y al lado la marquesina — la
+ * cama elevada bajo plástico donde el café pergamino se seca al sol. Con los
+ * canastos de cosecha esperando en el patio.
+ *
+ * Vivía privada dentro de EscenaCafetalVivo; ahora es pieza compartida — la
+ * monta también el arquetipo `cafe` del framework (EscenaCafe). Primitivas
+ * Lambert, cero texturas: el contrato austero de los mundos.
+ *
+ * Componente r3f: montar dentro de un <Canvas>.
+ */
+import * as THREE from 'three';
+import {
+  mezclar,
+  TIERRAS,
+  CASA,
+  ACENTOS,
+  NIEBLAS,
+  PALETA,
+} from '../paleta/index.js';
+
+export default function CasaBeneficio({ pos }) {
+  return (
+    <group position={pos} rotation={[0, -0.35, 0]}>
+      {/* la casa: LA casa campesina de la paleta madre (la misma del valle) */}
+      <mesh position={[0, 0.72, 0]}>
+        <boxGeometry args={[2.6, 1.44, 1.9]} />
+        <meshLambertMaterial color={CASA.encalado} flatShading />
+      </mesh>
+      <mesh position={[0, 0.18, 0]}>
+        <boxGeometry args={[2.64, 0.36, 1.94]} />
+        <meshLambertMaterial color={CASA.zocalo} flatShading />
+      </mesh>
+      {/* la puerta y una ventana (la carpintería pintada de la casa) */}
+      <mesh position={[0.5, 0.62, 0.96]}>
+        <boxGeometry args={[0.44, 0.95, 0.06]} />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
+      </mesh>
+      <mesh position={[-0.6, 0.86, 0.96]}>
+        <boxGeometry args={[0.5, 0.44, 0.06]} />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
+      </mesh>
+      {/* techo a dos aguas de teja */}
+      <mesh position={[0, 1.62, -0.62]} rotation={[-0.62, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.5]} />
+        <meshLambertMaterial color={CASA.tejaSombra} flatShading />
+      </mesh>
+      <mesh position={[0, 1.62, 0.62]} rotation={[0.62, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.5]} />
+        <meshLambertMaterial color={CASA.teja} flatShading />
+      </mesh>
+
+      {/* la MARQUESINA de secado, al lado: patas + cama de pergamino + techo
+          translúcido a dos aguas (la señal del beneficio) */}
+      <group position={[2.6, 0, 0.4]}>
+        {[[-1.0, -0.55], [1.0, -0.55], [-1.0, 0.55], [1.0, 0.55]].map((q, i) => (
+          <mesh key={i} position={[q[0], 0.35, q[1]]}>
+            <boxGeometry args={[0.09, 0.7, 0.09]} />
+            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
+          </mesh>
+        ))}
+        <mesh position={[0, 0.72, 0]}>
+          <boxGeometry args={[2.2, 0.07, 1.3]} />
+          <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+        </mesh>
+        {/* el café pergamino extendido secándose al sol */}
+        <mesh position={[0, 0.77, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[2.0, 1.1]} />
+          <meshLambertMaterial color={mezclar(TIERRAS.arenaOrilla, TIERRAS.camino, 0.2)} flatShading />
+        </mesh>
+        {[[-1.05, -0.62], [1.05, -0.62], [-1.05, 0.62], [1.05, 0.62]].map((q, i) => (
+          <mesh key={`p${i}`} position={[q[0], 1.15, q[1]]}>
+            <boxGeometry args={[0.06, 0.85, 0.06]} />
+            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
+          </mesh>
+        ))}
+        <mesh position={[0, 1.62, -0.36]} rotation={[-0.5, 0, 0]}>
+          <planeGeometry args={[2.4, 0.95]} />
+          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+        </mesh>
+        <mesh position={[0, 1.62, 0.36]} rotation={[0.5, 0, 0]}>
+          <planeGeometry args={[2.4, 0.95]} />
+          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+        </mesh>
+      </group>
+
+      {/* dos canastos de cosecha esperando en el patio */}
+      {[[-1.8, 0.6], [-1.35, 0.9]].map((q, i) => (
+        <group key={`c${i}`} position={[q[0], 0, q[1]]}>
+          <mesh position={[0, 0.18, 0]}>
+            <cylinderGeometry args={[0.24, 0.17, 0.36, 9, 1, true]} />
+            <meshLambertMaterial color={CASA.bejuco} flatShading side={THREE.DoubleSide} />
+          </mesh>
+          <mesh position={[0, 0.36, 0]} scale={[1, 0.4, 1]}>
+            <sphereGeometry args={[0.2, 8, 5]} />
+            <meshLambertMaterial color={ACENTOS.cafeCereza} flatShading />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
+++ b/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
@@ -29,27 +29,16 @@ import { perfilDeTier } from '../deviceTier.js';
 import { Fauna } from '../escenas/FaunaEscena.jsx';
 import FaunaCalido from '../escenas/FaunaCalido.jsx';
 import FloraCafetal from './FloraCafetal.jsx';
-import { ANCHO, FONDO, alturaLadera, SITIO_CASA } from './floraCafetal.geom.js';
+import CasaBeneficio from './CasaBeneficio.jsx';
+import { alturaLadera, construirLadera, SITIO_CASA } from './floraCafetal.geom.js';
 import {
   AtmosferaMundo,
   DomoCielo,
   useAtmosferaMundo,
   useGradienteBandas,
-  construirTerreno,
-  ruidoTerreno,
-  smoothstep,
   CamaraDirector,
 } from '../kit/index.js';
-import {
-  mezclar,
-  VERDES,
-  TIERRAS,
-  CASA,
-  ACENTOS,
-  LUCES,
-  NIEBLAS,
-  PALETA,
-} from '../paleta/index.js';
+import { mezclar, VERDES, LUCES } from '../paleta/index.js';
 
 /* La identidad del piso templado dentro de la familia del valle: `corral`
    ("corral y cafetal: tarde de finca"). El 60% restante lo pone la HORA. */
@@ -62,118 +51,9 @@ const RADIO_CAFETAL = 11;
 /* El frustum de sombra a medida de la ladera (la luz colada del sombrío). */
 const SOMBRA_CAFETAL = { left: -16, right: 16, top: 16, bottom: -6, far: 40 };
 
-/* La malla de la ladera — el heightfield del KIT (mismo andamiaje que todos los
-   mundos) con la pintura PROPIA del piso templado: arvenses verdes (cobertura
-   viva), tierra roja andina asomando y el mantillo pardo hacia la sombra. */
-function construirLadera(seg, plano) {
-  const cPasto = new THREE.Color(VERDES.brote); // pasto al sol del piso templado
-  const cPasto2 = new THREE.Color(VERDES.calido); // el oliva que asoma hacia lo seco
-  const cTierra = new THREE.Color(TIERRAS.arcilla); // la tierra roja cafetera
-  const cMantillo = new THREE.Color(TIERRAS.mantillo); // hojarasca bajo el sombrío
-  const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.4));
-  return construirTerreno({
-    ancho: ANCHO,
-    fondo: FONDO,
-    seg,
-    plano,
-    altura: alturaLadera,
-    pintar: (wx, wz, alt, c) => {
-      const enLoma = smoothstep(5, -8, wz);
-      c.lerpColors(cPasto, cPasto2, 0.5 + 0.5 * ruidoTerreno(wx * 0.9, wz * 0.7));
-      // la tierra roja asoma a manchas entre los surcos
-      c.lerp(cTierra, smoothstep(-0.1, 0.85, ruidoTerreno(wx * 1.3, wz * 1.1)) * 0.45 * enLoma);
-      // el mantillo pardo gana hacia lo alto (más sombrío, más hojarasca)
-      c.lerp(cMantillo, enLoma * 0.22);
-      // el caminito seco del frente, por donde se llega
-      c.lerp(cCamino, smoothstep(1.2, 0, Math.abs(wx - Math.sin(wz * 0.4) * 2.2)) * smoothstep(2, 12, wz));
-    },
-  });
-}
-
-/* La casa campesina con su BENEFICIADERO, arriba al fondo: paredes encaladas,
-   techo de teja, y al lado la marquesina — la cama elevada bajo plástico donde
-   el café pergamino se seca al sol. Insinuada, medio velada por la bruma. */
-function CasaBeneficio({ pos }) {
-  return (
-    <group position={pos} rotation={[0, -0.35, 0]}>
-      {/* la casa: LA casa campesina de la paleta madre (la misma del valle) */}
-      <mesh position={[0, 0.72, 0]}>
-        <boxGeometry args={[2.6, 1.44, 1.9]} />
-        <meshLambertMaterial color={CASA.encalado} flatShading />
-      </mesh>
-      <mesh position={[0, 0.18, 0]}>
-        <boxGeometry args={[2.64, 0.36, 1.94]} />
-        <meshLambertMaterial color={CASA.zocalo} flatShading />
-      </mesh>
-      {/* la puerta y una ventana (la carpintería pintada de la casa) */}
-      <mesh position={[0.5, 0.62, 0.96]}>
-        <boxGeometry args={[0.44, 0.95, 0.06]} />
-        <meshLambertMaterial color={CASA.carpinteria} flatShading />
-      </mesh>
-      <mesh position={[-0.6, 0.86, 0.96]}>
-        <boxGeometry args={[0.5, 0.44, 0.06]} />
-        <meshLambertMaterial color={CASA.carpinteria} flatShading />
-      </mesh>
-      {/* techo a dos aguas de teja */}
-      <mesh position={[0, 1.62, -0.62]} rotation={[-0.62, 0, 0]}>
-        <boxGeometry args={[3.0, 0.08, 1.5]} />
-        <meshLambertMaterial color={CASA.tejaSombra} flatShading />
-      </mesh>
-      <mesh position={[0, 1.62, 0.62]} rotation={[0.62, 0, 0]}>
-        <boxGeometry args={[3.0, 0.08, 1.5]} />
-        <meshLambertMaterial color={CASA.teja} flatShading />
-      </mesh>
-
-      {/* la MARQUESINA de secado, al lado: patas + cama de pergamino + techo
-          translúcido a dos aguas (la señal del beneficio) */}
-      <group position={[2.6, 0, 0.4]}>
-        {[[-1.0, -0.55], [1.0, -0.55], [-1.0, 0.55], [1.0, 0.55]].map((q, i) => (
-          <mesh key={i} position={[q[0], 0.35, q[1]]}>
-            <boxGeometry args={[0.09, 0.7, 0.09]} />
-            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
-          </mesh>
-        ))}
-        <mesh position={[0, 0.72, 0]}>
-          <boxGeometry args={[2.2, 0.07, 1.3]} />
-          <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-        </mesh>
-        {/* el café pergamino extendido secándose al sol */}
-        <mesh position={[0, 0.77, 0]} rotation={[-Math.PI / 2, 0, 0]}>
-          <planeGeometry args={[2.0, 1.1]} />
-          <meshLambertMaterial color={mezclar(TIERRAS.arenaOrilla, TIERRAS.camino, 0.2)} flatShading />
-        </mesh>
-        {[[-1.05, -0.62], [1.05, -0.62], [-1.05, 0.62], [1.05, 0.62]].map((q, i) => (
-          <mesh key={`p${i}`} position={[q[0], 1.15, q[1]]}>
-            <boxGeometry args={[0.06, 0.85, 0.06]} />
-            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
-          </mesh>
-        ))}
-        <mesh position={[0, 1.62, -0.36]} rotation={[-0.5, 0, 0]}>
-          <planeGeometry args={[2.4, 0.95]} />
-          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
-        </mesh>
-        <mesh position={[0, 1.62, 0.36]} rotation={[0.5, 0, 0]}>
-          <planeGeometry args={[2.4, 0.95]} />
-          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
-        </mesh>
-      </group>
-
-      {/* dos canastos de cosecha esperando en el patio */}
-      {[[-1.8, 0.6], [-1.35, 0.9]].map((q, i) => (
-        <group key={`c${i}`} position={[q[0], 0, q[1]]}>
-          <mesh position={[0, 0.18, 0]}>
-            <cylinderGeometry args={[0.24, 0.17, 0.36, 9, 1, true]} />
-            <meshLambertMaterial color={CASA.bejuco} flatShading side={THREE.DoubleSide} />
-          </mesh>
-          <mesh position={[0, 0.36, 0]} scale={[1, 0.4, 1]}>
-            <sphereGeometry args={[0.2, 8, 5]} />
-            <meshLambertMaterial color={ACENTOS.cafeCereza} flatShading />
-          </mesh>
-        </group>
-      ))}
-    </group>
-  );
-}
+/* La malla de la ladera y la casa-beneficiadero viven ahora en piezas
+   compartidas del cafetal (floraCafetal.geom / CasaBeneficio.jsx): las monta
+   también el arquetipo `cafe` del framework — una sola geografía, dos tomas. */
 
 /* El anillo del paso didáctico: respira sobre el punto que la lección señala.
    Con reducedMotion queda quieto (presencia sin parpadeo). */

--- a/src/visual/mundo3d/cafetal/floraCafetal.geom.js
+++ b/src/visual/mundo3d/cafetal/floraCafetal.geom.js
@@ -42,6 +42,10 @@
 import * as THREE from 'three';
 import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
 import { rng } from '../bosque/entQuenua.geom.js';
+import { construirTerreno } from '../kit/terreno.js';
+import { ruidoTerreno } from '../kit/ruido.js';
+import { VERDES, TIERRAS } from '../paleta/paletaMadre.js';
+import { mezclar } from '../atmosferaMadre.js';
 
 /* -------------------------------------------------------------------------- */
 /*  La ladera cafetera (la geografía del mundo, determinista)                  */
@@ -72,6 +76,38 @@ export function alturaLadera(wx, wz) {
   h += sub * 5.4; // la ladera cafetera gana altura hacia atrás
   h += ruido(wx * 0.5, wz * 0.5) * 0.35 * (0.3 + sub); // ondulación natural
   return h;
+}
+
+/*
+ * LA MALLA de la ladera — el heightfield del KIT (mismo andamiaje que todos los
+ * mundos) con la pintura PROPIA del piso templado: arvenses verdes (cobertura
+ * viva), tierra roja andina asomando y el mantillo pardo hacia la sombra. Vivía
+ * duplicada en cada escena que montaba el cafetal; aquí es la geografía única
+ * (headless, testeable, memoizar en quien llama).
+ */
+export function construirLadera(seg, plano) {
+  const cPasto = new THREE.Color(VERDES.brote); // pasto al sol del piso templado
+  const cPasto2 = new THREE.Color(VERDES.calido); // el oliva que asoma hacia lo seco
+  const cTierra = new THREE.Color(TIERRAS.arcilla); // la tierra roja cafetera
+  const cMantillo = new THREE.Color(TIERRAS.mantillo); // hojarasca bajo el sombrío
+  const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.4));
+  return construirTerreno({
+    ancho: ANCHO,
+    fondo: FONDO,
+    seg,
+    plano,
+    altura: alturaLadera,
+    pintar: (wx, wz, alt, c) => {
+      const enLoma = smoothstep(5, -8, wz);
+      c.lerpColors(cPasto, cPasto2, 0.5 + 0.5 * ruidoTerreno(wx * 0.9, wz * 0.7));
+      // la tierra roja asoma a manchas entre los surcos
+      c.lerp(cTierra, smoothstep(-0.1, 0.85, ruidoTerreno(wx * 1.3, wz * 1.1)) * 0.45 * enLoma);
+      // el mantillo pardo gana hacia lo alto (más sombrío, más hojarasca)
+      c.lerp(cMantillo, enLoma * 0.22);
+      // el caminito seco del frente, por donde se llega
+      c.lerp(cCamino, smoothstep(1.2, 0, Math.abs(wx - Math.sin(wz * 0.4) * 2.2)) * smoothstep(2, 12, wz));
+    },
+  });
 }
 
 /* -------------------------------------------------------------------------- */
@@ -532,6 +568,22 @@ const SITIOS_PLATANO = [
 /* La casa/beneficiadero vive arriba al fondo; los surcos la respetan. */
 export const SITIO_CASA = /** @type {[number, number]} */ ([9.0, -14.6]);
 
+/*
+ * Los CAFETOS PROTAGONISTAS del primer plano: tres matas grandes y CARGADAS que
+ * flanquean el camino de entrada (los surcos arrancan en z=2.6; estos viven más
+ * acá, donde la cámara llega). Son la respuesta al reclamo "el café no se
+ * distingue como planta": a esta distancia los pisos de ramas plagiotrópicas,
+ * la hoja elíptica oscura y el racimo de cereza PEGADO a la rama se leen sin
+ * ayuda. Deterministas y en TODOS los tiers (son pocos y son la lección).
+ * `maduro` alto = cosecha a la vista (roja/vino con su pintón); el verde queda
+ * en los surcos del fondo — la maduración despareja real de la ladera.
+ */
+export const SITIOS_HERO = [
+  { px: -2.8, pz: 5.6, esc: 1.6, rotY: 2.2, maduro: 0.85, carga: 1, hero: true },
+  { px: 4.2, pz: 4.6, esc: 1.35, rotY: 0.7, maduro: 0.7, carga: 1, hero: true },
+  { px: -5.0, pz: 3.2, esc: 1.25, rotY: 4.1, maduro: 0.75, carga: 1, hero: true },
+];
+
 /** ¿Qué tan maduro está el café en esta franja? Abajo (más caliente) más rojo. */
 function madurezEn(wz, r) {
   const base = smoothstep(-13.5, 3.0, wz); // el frente de la ladera pinta primero
@@ -586,6 +638,9 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
     const paso = sitios.length / c.cafeto;
     for (let k = 0; k < c.cafeto; k++) matas.push(sitios[Math.floor(k * paso)]);
   }
+  // Los protagonistas del primer plano van SIEMPRE (fuera del presupuesto: son
+  // tres y son la lección — hasta 'bajo' tiene que leer "eso es un cafeto").
+  matas.push(...SITIOS_HERO);
 
   const cafeto = matas.map((s) => ({
     pos: [s.px, alturaLadera(s.px, s.pz), s.pz],
@@ -605,7 +660,17 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
   const col = new THREE.Color();
   const cereza = [];
   const nPisos = pisosCafetoDeQ(q);
-  const cargadas = matas.filter((s) => s.carga > 0.3);
+  // Los héroes del primer plano entran TRES veces a la rueda Y AL FRENTE:
+  // cargan el triple de racimos que una mata del surco y cargan PRIMERO — la
+  // cereza pegada a la rama tiene que leerse desde la entrada en TODOS los
+  // tiers (en 'bajo' el presupuesto se agota rápido: si el héroe espera turno
+  // al final, queda pelado — mordida encontrada en el sanity headless).
+  const cargadas = [
+    ...SITIOS_HERO,
+    ...SITIOS_HERO,
+    ...SITIOS_HERO,
+    ...matas.filter((s) => s.carga > 0.3 && !s.hero),
+  ];
   /* Un punto local de la rama (piso i, rama j, avance t) llevado al mundo:
      escala de la mata + su giro + su sitio en la ladera. */
   const enRama = (s, i, j, t, dy, jit, rr) => {
@@ -631,7 +696,7 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
     const i = Math.floor(rCer() * Math.min(nPisos, 3));
     const p = PISOS_CAFETO[i];
     const j = Math.floor(rCer() * p.ramas);
-    const cuantas = 3 + Math.floor(rCer() * 4);
+    const cuantas = 3 + Math.floor(rCer() * 4) + (s.hero ? 2 : 0);
     const t0 = 0.2 + rCer() * 0.28;
     for (let k = 0; k < cuantas && cereza.length < c.cereza; k++) {
       const t = t0 + k * 0.085; // el racimo EN FILA, cuenta tras cuenta
@@ -645,7 +710,8 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
       cereza.push({
         pos: enRama(s, i, j, t, -0.045, 0.035, rCer), // colgada APENAS bajo la rama
         rotY: rCer() * Math.PI,
-        escala: 0.8 + rCer() * 0.45,
+        // en el héroe la cuenta es un pelín más gorda: legible desde la entrada
+        escala: (0.8 + rCer() * 0.45) * (s.hero ? 1.3 : 1),
         tint: [col.r, col.g, col.b],
       });
     }

--- a/src/visual/mundo3d/escenas/EscenaCafe.jsx
+++ b/src/visual/mundo3d/escenas/EscenaCafe.jsx
@@ -1,261 +1,270 @@
 /*
- * EscenaCafe — ARQUETIPO `cafe`: el CAFETAL BAJO SOMBRA de la ladera andina.
+ * EscenaCafe — ARQUETIPO `cafe`: la LADERA CAFETERA BAJO SOMBRA, entera.
  *
- * De la familia del `recinto` (un lugar que se camina), pero su lección es el
- * CULTIVO BANDERA hecho espacio: el café no crece solo ni a pleno rayo — vive
- * ABAJO, bajo el techo de árboles altos que lo cuidan. El diorama enseña lo que
- * de verdad es una finca cafetera del país:
+ * SEGUNDA TOMA del mundo del café. La primera era un diorama de mesa (un
+ * círculo de 2 m con esferas verdes): pobre al lado del valle, con la entrada
+ * amontonada y un café que podía ser cualquier arbusto. Esta toma monta EL
+ * MUNDO que ya existía en `cafetal/` (la ladera de 38×36 m con su geografía
+ * determinista) dentro del contrato del arquetipo — atmósfera de la franja,
+ * hotspots-puerta, Angelita, cámara de director — y responde reclamo por
+ * reclamo:
  *
- *   · la SOMBRA arriba — el guamo (Inga) y el nogal cafetero que le hacen techo
- *     al cultivo: menos sol quemante, más humedad, hoja que cae y abona, y monte
- *     donde vuelven las aves (café de sombra = café con vida, no potrero de sol);
- *   · los CAFETOS abajo — los arbustos cargados de CEREZA roja madura (el fruto);
- *   · el GRANO en sus tres estados, SIN tostar en la finca — cereza (el fruto
- *     rojo) → pergamino (el grano seco en su cascarilla) → oro (el grano verde
- *     ya trillado, listo para vender); el tueste es del otro lado, no del campo;
- *   · la ROYA (Hemileia vastatrix, el polvillo naranja bajo la hoja) y la BROCA
- *     (Hypothenemus hampei, el gorgojo que perfora la cereza) — señaladas sin
- *     drama, porque se manejan con criterio, no con recetas de veneno;
- *   · el BENEFICIO en el rincón — despulpar, fermentar en el tanque y secar al
- *     sol en el paseo/parabólico: el paso del fruto al grano vendible.
+ *   · RIQUEZA (la vara del valle): ladera real en heightfield pintado (arvenses,
+ *     tierra roja andina, mantillo), los TRES ESTRATOS del café de sombra
+ *     (cafetos abajo, plátano intercalado en medio, guamos y nogales haciendo
+ *     techo), montañas del fondo comidas por la niebla de la hora, velos de
+ *     bruma entre planos, la luz colada bajo las copas (gama alta) y la casa
+ *     con su beneficiadero coronando la loma.
+ *   · ENTRADA CON AIRE: un solo punto focal — el CAFETO PROTAGONISTA cargado de
+ *     cereza junto al camino de llegada — y las demás puertas repartidas EN
+ *     PROFUNDIDAD ladera arriba (sombrío → roya → trampa → beneficio): el ojo
+ *     sube con el terreno en vez de tropezar con un montón.
+ *   · EL CAFÉ SE LEE COMO CAFÉ: la mata protagonista trae la anatomía real del
+ *     arábica (geomCafeto): porte columnar, PISOS de ramas plagiotrópicas, hoja
+ *     elíptica oscura lustrosa y el racimo de CEREZA PEGADO A LA RAMA en
+ *     cuentas apretadas — verde, pintón, rojo y vino conviviendo, porque la
+ *     maduración despareja es la verdad del arábica (por eso se cosecha a mano
+ *     en pases). La roya es una mata señalada con su polvillo naranja bajo la
+ *     hoja; la broca, su trampa artesanal roja junto al surco. Señal, no drama.
  *
- * Todo `MeshLambert`/`Basic`, sin sombras (contrato de EscenaBase3D). Geometría
- * de primitivas: cero GLTF, offline y liviano.
+ * Comparte geografía y flora con EscenaCafetalVivo (floraCafetal.geom): una
+ * sola verdad del cafetal, dos tomas. Todo primitivas Lambert sin sombras
+ * (contrato de EscenaBase3D), una draw-call por especie (InstancedMesh).
  */
-import { useMemo } from 'react';
+import { useLayoutEffect, useMemo } from 'react';
+import * as THREE from 'three';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
-import { CIELOS, PALETA } from '../atmosferaMadre.js';
+import { CIELOS, PALETA, mezclarCielo, mezclar } from '../atmosferaMadre.js';
+import useCicloDia from '../useCicloDia.js';
+import { presetDeHora } from '../cielosHoraData.js';
+import { perfilDeTier } from '../deviceTier.js';
+import FloraCafetal from '../cafetal/FloraCafetal.jsx';
+import CasaBeneficio from '../cafetal/CasaBeneficio.jsx';
+import {
+  alturaLadera,
+  construirLadera,
+  calidadCafetal,
+  geomCafeto,
+  SITIO_CASA,
+  PAL,
+} from '../cafetal/floraCafetal.geom.js';
+import { VERDES, NIEBLAS } from '../paleta/index.js';
 
-/* La fauna que delata el CAFÉ DE SOMBRA: bajo el techo de guamo vuelven las
-   aves y las mariposas (el café a pleno sol las espanta). Pocas y por criterio
-   ecológico (contrato del DR: vida, no enjambre) — la sombra ES el hábitat. */
+/* La identidad atmosférica del piso templado: la familia del corral y el
+   cafetal ("tarde de finca"), mezclada 60% hacia la franja REAL del día. */
+const CIELO_CAFE = CIELOS.corral;
+
+/* El encuadre por defecto de la ladera (el registro puede pisarlo): la cámara
+   llega desde abajo del camino y mira loma arriba — entrar es subir. */
+const ENTRADA_LADERA = { zoom: 13, centro: /** @type {[number,number,number]} */ ([0, 2.4, -2]) };
+
+/* La fauna que delata el café DE SOMBRA: colibríes y mariposas que el café a
+   pleno sol espanta. Pocas y por criterio (la sombra ES el hábitat); alturas
+   horneadas sobre el terreno real. Orden = prominencia (recorte por tier). */
 const FAUNA_CAFE = [
-  { tipo: 'colibri', base: [-1.15, 1.45, 0.35], patron: 'revoloteo', size: 30, fase: 0.5 },
-  { tipo: 'mariposa', base: [0.9, 0.82, 0.7], patron: 'revoloteo', size: 26, fase: 1.8 },
-  { tipo: 'colibri', base: [1.25, 1.55, -0.5], patron: 'revoloteo', size: 26, fase: 2.6 },
+  { tipo: 'colibri', base: [-2.2, 1.9, 5.0], patron: 'revoloteo', size: 30, fase: 0.5, df: 10 },
+  { tipo: 'mariposa', base: [1.8, 1.5, 6.4], patron: 'revoloteo', size: 26, fase: 1.8, df: 9 },
+  { tipo: 'colibri', base: [3.4, 3.5, 2.0], patron: 'revoloteo', size: 26, fase: 2.6, df: 10 },
+  { tipo: 'mariposa', base: [-6.5, 3.3, -4.0], patron: 'revoloteo', size: 22, fase: 3.4, df: 9 },
 ];
 
-/* Un ÁRBOL DE SOMBRA (guamo/nogal cafetero): tronco alto de madera + copa ancha
-   y aireada en varias esferas. Le hace TECHO al cafetal — es lo primero que se
-   lee "el café vive debajo". */
-function ArbolSombra({ pos, color = '#3f6b39', alto = 2.1 }) {
-  const copa = [
-    [0, alto, 0, 0.72], [0.5, alto - 0.22, 0.1, 0.5], [-0.46, alto - 0.18, -0.08, 0.52],
-    [0.12, alto + 0.34, -0.3, 0.46], [-0.2, alto + 0.28, 0.32, 0.42],
-  ];
+/* Los VELOS de bruma entre planos (la lección de la sierra): tres láminas
+   lechosas que separan primer plano, ladera media y la loma de la casa — la
+   profundidad se lee aunque la niebla del fog aún no muerda. Estáticos,
+   aditivo-suaves, baratísimos; fuera del perfil mínimo. */
+const VELOS = [
+  { pos: [0, 4.0, -10.5], tam: [34, 2.6], op: 0.14 },
+  { pos: [-6, 5.2, -14.5], tam: [26, 3.0], op: 0.11 },
+  { pos: [8, 6.6, -15.8], tam: [16, 2.4], op: 0.16 }, // el que vela la casa
+];
+
+/* EL GRANO EN SUS TRES ESTADOS — cereza → pergamino → oro, NUNCA tostado en la
+   finca — como tres bandejas de muestra en el patio del beneficiadero (donde
+   ese paso ocurre de verdad, no regado por la entrada). */
+const ESTADOS_GRANO = [
+  { color: PAL.cerezaRoja, label: 'cereza' },
+  { color: '#d4c199', label: 'pergamino' },
+  { color: '#9fae5a', label: 'oro' },
+];
+
+function MesaGrano({ pos }) {
   return (
-    <group position={pos}>
-      {/* el tronco alto */}
-      <mesh position={[0, alto * 0.5, 0]}>
-        <cylinderGeometry args={[0.09, 0.14, alto, 6]} />
-        <meshLambertMaterial color={PALETA.madera} flatShading />
-      </mesh>
-      {/* la copa ancha y aireada que da la sombra */}
-      {copa.map(([x, y, z, r], i) => (
-        <mesh key={i} position={[x, y, z]}>
-          <sphereGeometry args={[r, 9, 7]} />
-          <meshLambertMaterial color={i % 2 ? PALETA.follajeOscuro : color} flatShading />
-        </mesh>
+    <group position={pos} rotation={[0, 0.4, 0]}>
+      {ESTADOS_GRANO.map((g, i) => (
+        <group key={g.label} position={[(i - 1) * 0.62, 0, i === 1 ? -0.18 : 0]}>
+          {/* la bandeja/zaranda de madera clara */}
+          <mesh position={[0, 0.05, 0]}>
+            <cylinderGeometry args={[0.22, 0.22, 0.06, 12]} />
+            <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+          </mesh>
+          {/* el montón de grano de este estado */}
+          <mesh position={[0, 0.09, 0]}>
+            <sphereGeometry args={[0.17, 12, 6, 0, Math.PI * 2, 0, Math.PI / 2]} />
+            <meshLambertMaterial color={g.color} flatShading />
+          </mesh>
+        </group>
       ))}
     </group>
   );
 }
 
-/* Un CAFETO: arbusto cargado. Tallo + follaje verde firme + CEREZAS rojas (el
-   fruto maduro que se cosecha grano a grano). `roya` le pinta la mancha naranja
-   del polvillo bajo una hoja (Hemileia vastatrix) — la señal, sin alarma. */
-function Cafeto({ pos, color = '#3f6f3a', cerezas = 5, roya = false }) {
-  const hojas = [
-    [0, 0.56, 0, 0.2], [0.16, 0.44, 0.06, 0.15], [-0.15, 0.46, -0.06, 0.15],
-    [0.05, 0.66, -0.12, 0.14],
-  ];
-  // Las cerezas maduras repartidas por el follaje (deterministas por índice).
-  const frutos = useMemo(() => {
-    return Array.from({ length: cerezas }, (_, i) => {
-      const a = (i / cerezas) * Math.PI * 2 + 0.4;
-      const r = 0.18 + (i % 2) * 0.05;
-      return /** @type {[number, number, number]} */ ([
-        Math.cos(a) * r, 0.42 + (i % 3) * 0.09, Math.sin(a) * r,
-      ]);
-    });
-  }, [cerezas]);
+/* La MATA CON ROYA: un cafeto del surco señalado con el polvillo naranja de
+   Hemileia vastatrix BAJO la hoja de los pisos bajos (donde de verdad arranca).
+   Señal legible sin alarma; la puerta `roya` flota encima. */
+const MOTAS_ROYA = [
+  [0.3, 0.3, 0.12], [-0.22, 0.28, 0.25], [0.05, 0.5, -0.3], [-0.3, 0.44, -0.1], [0.18, 0.6, 0.2],
+];
+
+function MataConRoya({ pos, geo, mat }) {
   return (
-    <group position={pos}>
-      <mesh position={[0, 0.26, 0]}>
-        <cylinderGeometry args={[0.035, 0.06, 0.52, 5]} />
-        <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
-      </mesh>
-      {hojas.map(([x, y, z, r], i) => (
-        <mesh key={i} position={[x, y, z]}>
-          <sphereGeometry args={[r, 8, 7]} />
-          <meshLambertMaterial color={color} flatShading />
-        </mesh>
-      ))}
-      {/* las cerezas rojas: el fruto que se recoge maduro */}
-      {frutos.map((p, i) => (
-        <mesh key={i} position={p}>
-          <sphereGeometry args={[0.035, 7, 6]} />
-          <meshLambertMaterial color="#b8342a" flatShading />
-        </mesh>
-      ))}
-      {/* la roya: la mancha naranja del polvillo bajo la hoja (señal, no drama) */}
-      {roya && (
-        <mesh position={[0.16, 0.4, 0.16]}>
-          <sphereGeometry args={[0.06, 8, 6]} />
+    <group position={pos} scale={1.15}>
+      <mesh geometry={geo} material={mat} />
+      {MOTAS_ROYA.map((p, i) => (
+        <mesh key={i} position={p} scale={[1, 0.5, 1]}>
+          <icosahedronGeometry args={[0.05, 0]} />
           <meshLambertMaterial color={PALETA.ambar} flatShading />
         </mesh>
-      )}
+      ))}
     </group>
   );
 }
 
-/* Un ESTADO DEL GRANO en una bandeja: el paso cereza → pergamino → oro (NUNCA
-   tostado en la finca). Tabla baja + montón de grano del color de su estado. */
-function GranoEstado({ pos, color = '#b8342a' }) {
+/* La TRAMPA DE BROCA artesanal: la botella roja con su gorro, colgada de una
+   estaca junto al surco — el manejo sin veneno hecho objeto (etanol que llama
+   al gorgojo, cosecha bien recogida y hongos de biocontrol hacen el resto). */
+function TrampaBroca({ pos }) {
   return (
     <group position={pos}>
-      {/* la bandeja/zaranda de madera clara */}
-      <mesh position={[0, 0.05, 0]}>
-        <cylinderGeometry args={[0.17, 0.17, 0.05, 12]} />
-        <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-      </mesh>
-      {/* el montón de grano de este estado */}
-      <mesh position={[0, 0.085, 0]}>
-        <sphereGeometry args={[0.13, 12, 6, 0, Math.PI * 2, 0, Math.PI / 2]} />
-        <meshLambertMaterial color={color} flatShading />
-      </mesh>
-    </group>
-  );
-}
-
-/* El BENEFICIO en su rincón: la DESPULPADORA (tolva + cuerpo con manija), el
-   TANQUE DE FERMENTACIÓN (recipiente abierto con el agua del mucílago) y el
-   SECADERO (paseo/parabólico: cama elevada con la capa de grano al sol). El paso
-   del fruto rojo al grano vendible, sin química. */
-function Beneficio({ pos }) {
-  return (
-    <group position={pos}>
-      {/* la despulpadora: cuerpo + tolva + manija */}
-      <mesh position={[0, 0.28, 0]}>
-        <boxGeometry args={[0.34, 0.4, 0.28]} />
-        <meshLambertMaterial color={PALETA.lamina} flatShading />
-      </mesh>
-      <mesh position={[0, 0.54, 0]} rotation={[0, 0, Math.PI]}>
-        <cylinderGeometry args={[0.05, 0.19, 0.2, 4]} />
-        <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-      </mesh>
-      <mesh position={[0.24, 0.3, 0]} rotation={[Math.PI / 2, 0, 0]}>
-        <cylinderGeometry args={[0.02, 0.02, 0.16, 6]} />
+      <mesh position={[0, 0.45, 0]}>
+        <cylinderGeometry args={[0.025, 0.035, 0.9, 5]} />
         <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
       </mesh>
-
-      {/* el tanque de fermentación: recipiente abierto con agua del mucílago */}
-      <mesh position={[0.62, 0.18, 0.2]}>
-        <cylinderGeometry args={[0.19, 0.16, 0.36, 12]} />
-        <meshLambertMaterial color={PALETA.concreto} flatShading />
+      <mesh position={[0, 0.78, 0]}>
+        <cylinderGeometry args={[0.09, 0.075, 0.24, 8]} />
+        <meshLambertMaterial color={PAL.cerezaRoja} flatShading />
       </mesh>
-      <mesh position={[0.62, 0.31, 0.2]}>
-        <cylinderGeometry args={[0.165, 0.165, 0.04, 12]} />
-        <meshLambertMaterial color={PALETA.agua} flatShading />
+      <mesh position={[0, 0.94, 0]}>
+        <cylinderGeometry args={[0.11, 0.11, 0.05, 8]} />
+        <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
       </mesh>
-
-      {/* el secadero (paseo/parabólico): cama elevada con la capa de grano al sol */}
-      <group position={[0.3, 0, 0.72]}>
-        {[[-0.28, 0.16, -0.16], [0.28, 0.16, -0.16], [-0.28, 0.16, 0.16], [0.28, 0.16, 0.16]].map((p, i) => (
-          <mesh key={i} position={/** @type {[number, number, number]} */ (p)}>
-            <cylinderGeometry args={[0.02, 0.02, 0.32, 5]} />
-            <meshLambertMaterial color={PALETA.madera} flatShading />
-          </mesh>
-        ))}
-        <mesh position={[0, 0.33, 0]}>
-          <boxGeometry args={[0.66, 0.03, 0.44]} />
-          <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-        </mesh>
-        {/* la capa de grano en pergamino secándose */}
-        <mesh position={[0, 0.36, 0]}>
-          <boxGeometry args={[0.6, 0.03, 0.38]} />
-          <meshLambertMaterial color="#d4c199" flatShading />
-        </mesh>
-      </group>
     </group>
   );
 }
 
-function Diorama({ params, reducedMotion }) {
-  const cafetos = params?.cafetos || [
-    { color: '#3f6f3a', pos: [-0.55, 0, 0.42], cerezas: 6 },
-    { color: '#468637', pos: [0.5, 0, 0.12], cerezas: 5 },
-    { color: '#3f6f3a', pos: [0.02, 0, -0.5], cerezas: 4, roya: true },
-    { color: '#457d38', pos: [-0.78, 0, -0.32], cerezas: 5 },
-  ];
-  const sombra = params?.sombra || [
-    { pos: [-1.65, 0, -0.95], color: '#4b7a3a', alto: 2.2 }, // guamo
-    { pos: [1.7, 0, -0.8], color: '#3f6b39', alto: 2.0 },    // nogal cafetero
-  ];
-  // El grano en sus tres estados (cereza→pergamino→oro), SIN tostar en finca.
-  const granos = params?.granos || [
-    { estado: 'cereza', color: '#b8342a', pos: [-1.5, 0, 0.75] },
-    { estado: 'pergamino', color: '#d4c199', pos: [-1.15, 0, 1.05] },
-    { estado: 'oro', color: '#9fae5a', pos: [-0.72, 0, 1.2] },
-  ];
+function Diorama({ tier, reducedMotion }) {
+  const perfil = perfilDeTier(tier);
+  const q = calidadCafetal(tier);
+  const frugal = tier === 'bajo';
 
-  // El surco del cafetal en la ladera: hilera curva que ordena las matas (café
-  // sembrado a curva de nivel, no ladera abajo — cuida el suelo del aguacero).
-  const surcos = useMemo(() => {
-    const n = 3;
-    return Array.from({ length: n }, (_, i) => {
-      const z = -0.75 + i * 0.62;
-      return /** @type {[number, number, number]} */ ([0, 0.03, z]);
-    });
-  }, []);
+  /* La atmósfera de la franja (la MISMA mezcla que hace EscenaBase3D con este
+     cielo): solo para teñir los montes del fondo con la niebla de la hora —
+     perspectiva aérea viva, al atardecer se doran y de noche se apagan. */
+  const { franja } = useCicloDia({ reducedMotion });
+  const c = useMemo(() => mezclarCielo(CIELO_CAFE, presetDeHora(franja)), [franja]);
+  const montes = useMemo(
+    () => ({
+      cerca: mezclar(VERDES.monte, c.niebla, 0.22),
+      media: mezclar(VERDES.monte, c.niebla, 0.3),
+      lejos: mezclar(VERDES.monte, c.niebla, 0.4),
+    }),
+    [c.niebla],
+  );
+
+  /* La ladera (heightfield compartido con EscenaCafetalVivo) y la mata enferma
+     (una vez por tier). */
+  const geoLadera = useMemo(
+    () => construirLadera(perfil.segmentosTerreno, perfil.flatShading),
+    [perfil.segmentosTerreno, perfil.flatShading],
+  );
+  const geoEnferma = useMemo(() => geomCafeto({ q }, 31), [q]);
+  const matEnferma = useMemo(
+    () => new THREE.MeshLambertMaterial({ vertexColors: true, flatShading: true }),
+    [],
+  );
+  useLayoutEffect(
+    () => () => {
+      geoLadera.dispose();
+      geoEnferma.dispose();
+      matEnferma.dispose();
+    },
+    [geoLadera, geoEnferma, matEnferma],
+  );
+
+  const fauna = useMemo(
+    () => (tier === 'alto' ? FAUNA_CAFE : FAUNA_CAFE.slice(0, 2)),
+    [tier],
+  );
+
+  const hCasa = alturaLadera(SITIO_CASA[0], SITIO_CASA[1]);
 
   return (
     <group>
-      {/* piso del cafetal (ladera) */}
-      <mesh position={[0, -0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
-        <circleGeometry args={[2.1, 30]} />
-        <meshLambertMaterial color="#7a6a3e" />
+      {/* LA LADERA: el suelo verdadero del mundo (arvenses, tierra roja,
+          mantillo y el caminito de llegada pintados por vértice). */}
+      <mesh geometry={geoLadera}>
+        <meshLambertMaterial vertexColors />
       </mesh>
-      {/* los surcos a curva de nivel (lomos de tierra que ordenan el cafetal) */}
-      {surcos.map((p, i) => (
-        <mesh key={i} position={p} rotation={[-Math.PI / 2, 0, 0]}>
-          <ringGeometry args={[0.55 + i * 0.02, 1.65, 40, 1, 0.6, 1.9]} />
-          <meshLambertMaterial color="#6b5636" />
-        </mesh>
-      ))}
 
-      {/* la SOMBRA arriba: los árboles altos que le hacen techo al café */}
-      {sombra.map((a, i) => (
-        <ArbolSombra key={i} pos={a.pos} color={a.color} alto={a.alto} />
-      ))}
+      {/* las montañas cafeteras del fondo, comidas por la niebla de la hora */}
+      <mesh position={[-14, 3.0, -23]} scale={[10, 4.6, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={montes.media} />
+      </mesh>
+      <mesh position={[8, 3.4, -26]} scale={[12, 5.6, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={montes.lejos} />
+      </mesh>
+      <mesh position={[21, 2.2, -22]} scale={[8, 3.6, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={montes.cerca} />
+      </mesh>
 
-      {/* los CAFETOS cargados de cereza (uno con la señal de roya) */}
-      {cafetos.map((c, i) => (
-        <Cafeto key={i} pos={c.pos} color={c.color} cerezas={c.cerezas} roya={c.roya} />
-      ))}
+      {/* EL CAFETAL ENTERO: surcos a curva de nivel con los tres protagonistas
+          del primer plano, cerezas en racimo pegadas a la rama (verde→pintón→
+          rojo→vino), la flor axilar blanca, el sombrío de guamos y nogales, el
+          plátano intercalado y la luz colada bajo las copas (gama alta). */}
+      <FloraCafetal tier={tier} reducedMotion={reducedMotion} />
 
-      {/* el GRANO en sus tres estados, SIN tostar (cereza→pergamino→oro) */}
-      {granos.map((g, i) => (
-        <GranoEstado key={i} pos={g.pos} color={g.color} />
-      ))}
+      {/* la mata señalada con roya y la trampa de broca: sanidad con criterio */}
+      <MataConRoya pos={[-5.6, 1.5, -1.5]} geo={geoEnferma} mat={matEnferma} />
+      <TrampaBroca pos={[4.6, 1.38, -0.6]} />
 
-      {/* el BENEFICIO: despulpar, fermentar, secar (el paso al grano vendible) */}
-      <Beneficio pos={[1.0, 0, 0.55]} />
+      {/* la casa con su beneficiadero coronando la loma, medio velada */}
+      <CasaBeneficio pos={[SITIO_CASA[0], hCasa, SITIO_CASA[1]]} />
 
-      {/* la vida que trae la sombra: colibríes y mariposa (café con hábitat) */}
-      <Fauna items={FAUNA_CAFE} reducedMotion={reducedMotion} />
+      {/* el grano en sus tres estados, en el patio del beneficio */}
+      <MesaGrano pos={[7.4, 4.89, -12.6]} />
+
+      {/* los velos de bruma que separan los planos de la ladera */}
+      {!frugal &&
+        VELOS.map((v, i) => (
+          <mesh key={i} position={v.pos}>
+            <planeGeometry args={v.tam} />
+            <meshBasicMaterial
+              color={NIEBLAS.lechosa}
+              transparent
+              opacity={v.op}
+              depthWrite={false}
+              side={THREE.DoubleSide}
+            />
+          </mesh>
+        ))}
+
+      {/* LA VIDA que trae la sombra: colibríes y mariposas (café con hábitat) */}
+      {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
     </group>
   );
 }
 
 export default function EscenaCafe(props) {
-  // Cielo de "corral y cafetal: tarde de finca" (atmosferaMadre) — la mezcla lo
-  // entibia igual hacia la hora dorada del valle.
-  const cielo = CIELOS.corral;
   return (
-    <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.7, 0] }}>
-      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
+    <EscenaBase3D
+      {...props}
+      cielo={CIELO_CAFE}
+      entrada={{ ...ENTRADA_LADERA, ...(props.entrada || {}) }}
+    >
+      <Diorama tier={props.tier || 'alto'} reducedMotion={!!props.reducedMotion} />
     </EscenaBase3D>
   );
 }

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -219,33 +219,23 @@ export const MUNDO = {
     pisoTermico: 'templado',
     escena: 'cafe',
     valle: { tipo: 'cafetal', pos: [3.4, 0, 2.2], escala: 1 },
-    params: {
-      // El diorama tiene defaults propios; aquí los hacemos explícitos y
-      // deterministas (mismos cafetos, sombra y estados del grano).
-      cafetos: [
-        { color: '#3f6f3a', pos: [-0.55, 0, 0.42], cerezas: 6 },
-        { color: '#468637', pos: [0.5, 0, 0.12], cerezas: 5 },
-        { color: '#3f6f3a', pos: [0.02, 0, -0.5], cerezas: 4, roya: true },
-        { color: '#457d38', pos: [-0.78, 0, -0.32], cerezas: 5 },
-      ],
-      sombra: [
-        { pos: [-1.65, 0, -0.95], color: '#4b7a3a', alto: 2.2 }, // guamo (Inga)
-        { pos: [1.7, 0, -0.8], color: '#3f6b39', alto: 2.0 },    // nogal cafetero
-      ],
-      granos: [
-        { estado: 'cereza', color: '#b8342a', pos: [-1.5, 0, 0.75] },
-        { estado: 'pergamino', color: '#d4c199', pos: [-1.15, 0, 1.05] },
-        { estado: 'oro', color: '#9fae5a', pos: [-0.72, 0, 1.2] },
-      ],
-    },
+    // La escena es LA LADERA COMPLETA de `cafetal/` (geografía determinista en
+    // floraCafetal.geom): ya no hay cafetos de mesa que declarar aquí. El `id`
+    // ancla la capa viva (partículas/momentos) a la siembra propia del mundo.
+    params: { id: 'cafe' },
+    // Las puertas repartidas EN PROFUNDIDAD ladera arriba (entrada con aire, un
+    // solo foco cerca): el grano en la mata protagonista del camino, la sombra
+    // en el guamo del centro, la roya en su mata señalada, el manejo en la
+    // trampa de broca y el beneficio en la casa que corona la loma. Alturas
+    // horneadas del terreno real (alturaLadera + el porte de cada elemento).
     hotspots: [
-      { id: 'grano', pos: [-0.55, 0.9, 0.42], emoji: '☕', label: 'El grano, paso a paso', view: 'cafe' },
-      { id: 'sombra', pos: [-1.65, 2.5, -0.95], emoji: '🌳', label: 'El café bajo sombra', view: 'biodiversidad' },
-      { id: 'roya', pos: [0.02, 0.85, -0.5], emoji: '🍂', label: 'La roya y la broca', view: 'plagas' },
-      { id: 'manejo', pos: [0.5, 0.82, 0.12], emoji: '🐞', label: 'Manejo sin veneno', view: 'biopreparados' },
-      { id: 'beneficio', pos: [1.0, 0.7, 0.55], emoji: '💧', label: 'Despulpar, fermentar, secar', view: 'poscosecha' },
+      { id: 'grano', pos: [-2.8, 1.9, 5.6], emoji: '☕', label: 'El grano, paso a paso', view: 'cafe' },
+      { id: 'sombra', pos: [3.2, 4.7, 2.4], emoji: '🌳', label: 'El café bajo sombra', view: 'biodiversidad' },
+      { id: 'roya', pos: [-5.6, 2.7, -1.5], emoji: '🍂', label: 'La roya y la broca', view: 'plagas' },
+      { id: 'manejo', pos: [4.6, 2.6, -0.6], emoji: '🐞', label: 'Manejo sin veneno', view: 'biopreparados' },
+      { id: 'beneficio', pos: [10.2, 7.5, -13.6], emoji: '💧', label: 'Despulpar, fermentar, secar', view: 'poscosecha' },
     ],
-    entrada: { zoom: 7.5, narra: 'cafe' },
+    entrada: { zoom: 13, centro: [0, 2.4, -2], narra: 'cafe' },
     // El gemelo 2D digno: la ficha del café (misma lección, en cifras y notas).
     fallback2d: {
       escena: 'infografia',


### PR DESCRIPTION
## Qué cambió y por qué

El operador reportó el mundo del café **"demasiado pobre visualmente, no se parece nada al valle, la entrada sobrepoblada, y no se distingue el café como planta"**. Causa raíz: `mundoId="cafe"` montaba `escenas/EscenaCafe.jsx` — un diorama de mesa de 2 m con cafetos de esferas — mientras el cafetal RICO de `cafetal/` (ladera 38×36, cafeto anatómico, sombrío real) solo lo consumía un mockup fuera del bundle.

### Los tres reclamos, uno por uno

1. **Riqueza (la vara del valle)** — `EscenaCafe` ahora monta la ladera completa dentro del contrato `EscenaBase3D`: heightfield pintado por vértice (arvenses, tierra roja andina, mantillo, camino de llegada), los tres estratos del café de sombra (cafetos → plátano intercalado → guamos y nogales haciendo techo), montañas del fondo teñidas por la niebla de la franja real del día, tres velos de bruma entre planos, luz colada bajo las copas (tier alto) y la casa-beneficiadero coronando la loma, medio velada.
2. **Entrada con aire** — un solo punto focal cerca (el cafeto protagonista cargado junto al camino) y las 5 puertas repartidas EN PROFUNDIDAD ladera arriba: grano → sombra → roya → trampa de broca → beneficio. Alturas horneadas del terreno real. El ojo sube con la ladera en vez de tropezar con un montón.
3. **El café se lee como café** — 3 cafetos HÉROE de primer plano (todos los tiers) con la anatomía real del arábica que ya vivía en `floraCafetal.geom`: porte columnar, pisos de ramas plagiotrópicas, hoja elíptica oscura lustrosa y el racimo de cereza **pegado a la rama** en cuentas apretadas — verde, pintón, rojo y vino conviviendo (la maduración despareja real: por eso se cosecha a mano en pases). Cargan PRIMERO en la rueda de cerezas (mordida encontrada en el sanity: en tier bajo el presupuesto se agotaba antes de llegarles). Mata con roya señalada con su polvillo naranja bajo la hoja + trampa artesanal roja de broca: sanidad con criterio, sin drama.

### Reuso, no re-autoría
- `construirLadera` baja de `EscenaCafetalVivo` al geom compartido (headless, testeable).
- `CasaBeneficio` se extrae a pieza propia; ambas escenas la consumen.
- El cafetal del VALLE (`CafetalDensoValle`) solo importa las 4 geometrías, intactas: **byte-idéntico**. `Valle3D`/`composicionValle3D` sin tocar.
- Leyenda didáctica de la vitrina (`Mundo3DCafe.jsx`) sin tocar (copy verificado).

### Verificación
- `vitest` mundo3d: 22 archivos verdes (incl. `mundo.smoke`, `mundosPorPisoTermico`, `kit`); los 4 rojos (`bosqueRealismo`, `hiloVida`, `navegacion`, `useAudioMundo`) fallan idéntico en la base — preexistentes, verificado con stash.
- Sanity headless del geom: fusiones sin null (truena si falla), héroes con 26-27 cerezas en alto y 15-18 hasta en bajo, ladera desindexada con vertexColors.
- ESLint limpio en los 5 archivos.
- Falta el gate visual con captura (build + screenshot los hace el orquestador).

🤖 Generated with [Claude Code](https://claude.com/claude-code)