### PR TITLE
feat(nocturnas): murciélago, gurre y tigrillo a nivel personaje completo

### DIFF
--- a/src/components/dashboard/CriaturasNocturnas.jsx
+++ b/src/components/dashboard/CriaturasNocturnas.jsx
@@ -12,6 +12,11 @@
  * Componentes reutilizables (patrón GuardianEspiritu): funciones Avatar<X> que
  * comparten <CriaturasNocturnasDefs/> (glow + blur). El ROSTER se exporta para
  * que la vitrina —u otras superficies— lo pinten sin duplicar datos.
+ *
+ * NIVEL PERSONAJE: murciélago, gurre y tigrillo dejaron de ser siluetas-chip y
+ * son personajes completos (anatomía diagnóstica real, peso, gesto y animación
+ * rubber-hose andina — boil steps ~12fps, parpadeo irregular, mirada co-prima;
+ * clases cn-* nuevas al final de criaturas-nocturnas.css).
  */
 import './criaturas-nocturnas.css';
 
@@ -170,24 +175,85 @@ function AvatarBuho() {
   );
 }
 
-/* Murciélago nectarívoro (Glossophaga soricina): alas membranosas abiertas,
-   hocico largo y lengua de glow; en vuelo. Acento violeta. */
+/* Murciélago nectarívoro (Glossophaga soricina) — PERSONAJE COMPLETO.
+   Pose: cernido de alimentación sobre una flor nocturna, con la LENGUA
+   larguísima extensible (el rasgo diagnóstico) metida en la corola — la
+   polinización pasando en vivo. El ala de un murciélago es una MANO: húmero,
+   muñeca con pulgar-garfio y cuatro dedos larguísimos como huesos visibles
+   dentro del patagio festoneado (nada de ala de pájaro). Uropatagio entre las
+   patas, hoja nasal en el hocico, polen dorado pegado al hocico. Vuelo de
+   aleteo rápido y errático (cernido irregular, nunca planeo). Acento violeta. */
 function AvatarMurcielago() {
   return (
-    <g className="cn-av-vuela" filter="url(#cn-glow1)">
-      <path className="cn-ala-mur" d="M-2,-2 C-9,-8 -19,-8 -24,-2 C-20,-2.6 -16,-1.4 -14,1.6 C-12,-0.6 -9.5,-0.4 -8,1.4 C-6,-0.4 -4,-0.4 -2,1 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.8" strokeOpacity="0.7" />
-      <path className="cn-ala-mur" style={{ animationDelay: '-0.05s' }} d="M2,-2 C9,-8 19,-8 24,-2 C20,-2.6 16,-1.4 14,1.6 C12,-0.6 9.5,-0.4 8,1.4 C6,-0.4 4,-0.4 2,1 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.8" strokeOpacity="0.7" />
-      <ellipse cx="0" cy="0.5" rx="3.2" ry="5.4" fill="#171030" stroke="#c78bff" strokeWidth="0.8" strokeOpacity="0.6" />
-      {/* cabeza + orejas */}
-      <circle cx="0" cy="-5" r="3" fill="#1c1338" stroke="#c78bff" strokeWidth="0.7" strokeOpacity="0.6" />
-      <path d="M-2.4,-7 L-3.6,-10.4 L-1,-8 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.6" />
-      <path d="M2.4,-7 L3.6,-10.4 L1,-8 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.6" />
-      {/* hocico largo + lengua */}
-      <path d="M-1.2,-3 L1.2,-3 L0,1 Z" fill="#c78bff" opacity="0.9" />
-      <path d="M0,1 L0,4.2" stroke="#f0d9ff" strokeWidth="0.9" strokeLinecap="round" style={{ filter: 'drop-shadow(0 0 3px #e6c6ff)' }} />
-      {/* ojos */}
-      <circle cx="-1.2" cy="-5.2" r="0.7" fill="#f0d9ff" style={{ filter: 'drop-shadow(0 0 3px #e6c6ff)' }} />
-      <circle cx="1.2" cy="-5.2" r="0.7" fill="#f0d9ff" style={{ filter: 'drop-shadow(0 0 3px #e6c6ff)' }} />
+    <g filter="url(#cn-glow1)">
+      {/* ── flor nocturna anclada (abre al oscurecer): campana pálida ── */}
+      <path d="M20,22 C18.4,17.8 16.4,14.6 14.4,12.4" fill="none" stroke="#6fe6c0" strokeWidth="1" strokeLinecap="round" opacity="0.45" />
+      <path d="M17.6,17.4 C19.4,17 20.8,17.6 21.6,18.8 C20,19.4 18.4,18.8 17.6,17.4 Z" fill="#6fe6c0" opacity="0.35" />
+      {/* pétalos traseros abriéndose hacia el visitante */}
+      <path d="M13.2,10.8 C11,9.4 9.6,7.4 9.4,5.6 C10.9,5.8 12.5,7.1 13.6,8.9 Z" fill="#eafff6" opacity="0.72" stroke="#c78bff" strokeWidth="0.5" strokeOpacity="0.4" />
+      <path d="M13.2,10.8 C12.4,8.4 12.6,6.2 13.9,4.7 C14.9,6.2 15.1,8.3 14.5,10.2 Z" fill="#eafff6" opacity="0.6" stroke="#c78bff" strokeWidth="0.5" strokeOpacity="0.4" />
+      <path d="M13.2,10.8 C14.9,9.8 16.7,9.6 18.1,10.3 C17.2,11.5 15.4,11.9 13.8,11.7 Z" fill="#eafff6" opacity="0.66" stroke="#c78bff" strokeWidth="0.5" strokeOpacity="0.4" />
+      {/* estambres con antera dorada: ahí queda el polen */}
+      <path d="M13,10.6 C11.6,9 10.6,7.6 10,6.4" fill="none" stroke="#f0d9ff" strokeWidth="0.5" opacity="0.7" />
+      <circle cx="9.8" cy="6.2" r="0.55" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 2.5px #ffd76a)' }} />
+      {/* ── ala LEJANA (subiendo, en contrafase): la mano foreshortened ── */}
+      <g className="cn-mur-ala-far" style={{ transformBox: 'fill-box', transformOrigin: '8% 96%' }}>
+        <path d="M0,-3 C2.2,-6.8 4.4,-10.4 6.5,-13.5 C9,-15 11.2,-16.4 13.5,-17.5 C13.2,-15.3 14.5,-13.5 16,-12 C14.7,-10.2 14.1,-8.4 14,-6.5 C11,-4.4 7,-2.6 4,-2 C2.6,-1.8 1,-2.2 0,-3 Z" fill="#171030" opacity="0.85" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.4" />
+        <path d="M6.5,-13.5 C9,-15 11.2,-16.4 13.5,-17.5 M6.5,-13.5 C9.6,-13.3 13,-12.6 16,-12 M6.5,-13.5 C8.9,-11.4 11.6,-8.8 14,-6.5" fill="none" stroke="#c78bff" strokeWidth="0.5" strokeOpacity="0.45" />
+      </g>
+      {/* ── el cuerpo: cernido errático (nunca en el mismo compás que la lengua) ── */}
+      <g className="cn-mur-cierne">
+        {/* torso peludito con boil de respiración */}
+        <g className="cn-boil">
+          <path d="M-2.2,-4.6 C0.4,-3 0.6,0 -1.6,1.6 C-4,3.2 -8,2 -10.4,-0.6 C-12,-2.6 -11.4,-5.4 -9,-6.6 C-6.6,-7.6 -4,-6.4 -2.2,-4.6 Z" fill="#171030" stroke="#c78bff" strokeWidth="0.9" strokeOpacity="0.6" />
+          {/* lomo iluminado + ticks de pelaje */}
+          <path d="M-9.6,-5.6 C-7.4,-6.6 -5,-6.2 -3.4,-4.8" fill="none" stroke="#eafff6" strokeWidth="0.7" opacity="0.45" />
+          <path d="M-9.8,-2.4 l-1,0.8 M-7.6,0.2 l-0.9,0.9 M-4.8,1.2 l-0.7,1" stroke="#c78bff" strokeWidth="0.5" strokeLinecap="round" opacity="0.4" />
+        </g>
+        {/* patas + UROPATAGIO (membrana entre las patas, rasgo real) */}
+        <path d="M-9.8,0.6 L-11,3.5 M-8.4,1.4 L-8,4.5" stroke="#0f0a24" strokeWidth="1.1" strokeLinecap="round" />
+        <path d="M-11,3.5 C-10.4,5.9 -9,6.4 -8,4.5 C-8.6,3.4 -10,3 -11,3.5 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.5" />
+        {/* cabeza inclinada hacia la flor */}
+        <circle cx="2" cy="0" r="3.1" fill="#1c1338" stroke="#c78bff" strokeWidth="0.8" strokeOpacity="0.6" />
+        {/* orejas medianas SEPARADAS (no de orejón) */}
+        <path d="M0.4,-2.6 C-0.8,-6.4 1.6,-7.6 2.6,-4.6 C2.4,-3.5 1.6,-2.8 0.4,-2.6 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.6" />
+        <path d="M3.4,-2.9 C3.4,-6.6 6,-6.9 6.4,-4.2 C5.7,-3.2 4.6,-2.8 3.4,-2.9 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.6" />
+        <path d="M1.2,-4.6 C1.4,-3.9 1.4,-3.4 1.2,-3 M4.6,-4.8 C4.7,-4.1 4.7,-3.6 4.5,-3.2" stroke="#f0d9ff" strokeWidth="0.4" fill="none" opacity="0.5" />
+        {/* hocico ALARGADO de nectarívoro con hoja nasal */}
+        <path d="M3.2,-1.6 C6,-0.8 7.8,1.4 8.4,4 C8.6,4.9 7.8,5.4 7,4.9 C5.4,3.8 3.6,2 2.6,0.2 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.7" strokeOpacity="0.6" />
+        <path d="M7.5,3.2 L8.8,4.2 L7.4,4.8 Z" fill="#c78bff" opacity="0.9" />
+        {/* ojo de goma: pupila grande, iris con glow, catchlight vivo */}
+        <g className="cn-parpadeo">
+          <circle cx="3.6" cy="0.4" r="1.25" fill="#04160f" stroke="#c78bff" strokeWidth="0.6" />
+          <g className="cn-mirada">
+            <circle cx="3.7" cy="0.5" r="0.75" fill="#e6c6ff" style={{ filter: 'drop-shadow(0 0 3px #e6c6ff)' }} />
+            <circle cx="3.4" cy="0.1" r="0.34" fill="#eafff6" />
+          </g>
+        </g>
+        {/* LA LENGUA: extensible, con glow, lamiendo el néctar (dasharray) */}
+        <path className="cn-mur-lengua" pathLength="10" d="M7.6,5.2 C9.4,6.6 11.2,8.4 12.8,10.4" fill="none" stroke="#f0d9ff" strokeWidth="1.15" strokeLinecap="round" style={{ filter: 'drop-shadow(0 0 3.5px #e6c6ff)' }} />
+        {/* polen dorado pegado al hocico: se lo lleva a la próxima flor */}
+        <circle cx="6.6" cy="3.1" r="0.4" fill="#ffd76a" opacity="0.9" style={{ filter: 'drop-shadow(0 0 2px #ffd76a)' }} />
+        <circle cx="7.5" cy="4.3" r="0.3" fill="#ffd76a" opacity="0.75" />
+      </g>
+      {/* pétalo delantero: tapa la punta de la lengua → se ve ADENTRO de la flor */}
+      <path d="M11.4,9.4 C12.4,11 14.2,11.8 16,11.4 C14.6,12.6 12.4,12.2 11,10.6 Z" fill="#eafff6" opacity="0.82" stroke="#c78bff" strokeWidth="0.5" strokeOpacity="0.45" />
+      {/* motas de polen en el aire entre flor y hocico */}
+      <circle className="cn-mur-polen" cx="11.2" cy="7.2" r="0.45" fill="#ffd76a" />
+      <circle className="cn-mur-polen" style={{ animationDelay: '-1.3s' }} cx="9.2" cy="4.6" r="0.35" fill="#e6c6ff" />
+      {/* ── ala CERCANA: la MANO desplegada — húmero, muñeca, pulgar y 4 dedos ── */}
+      <g className="cn-mur-ala" style={{ transformBox: 'fill-box', transformOrigin: '94% 90%' }}>
+        {/* patagio: membrana festoneada colgada de los dedos */}
+        <path d="M-3,-4 C-6.6,-7.2 -10,-10.6 -13,-13 C-16.6,-13.6 -20.2,-13.5 -23.5,-13.2 C-22.6,-11 -23.4,-8.6 -24.8,-7.6 C-22.6,-6 -21.4,-4.2 -20.8,-2.2 C-18.6,-1.6 -16.6,0 -15,1.8 C-13.2,1.4 -11.2,1.2 -9.6,1.6 C-7.4,-0.6 -5,-2.2 -3,-4 Z" fill="#1c1338" fillOpacity="0.94" stroke="#c78bff" strokeWidth="0.8" strokeOpacity="0.7" />
+        {/* el brazo (húmero + radio) hasta la muñeca */}
+        <path d="M-3,-4 C-6.6,-7.2 -10,-10.6 -13,-13" fill="none" stroke="#c78bff" strokeWidth="1.2" strokeLinecap="round" opacity="0.85" />
+        {/* pulgar con garfio libre en la muñeca (con eso se agarra) */}
+        <path d="M-13,-13 L-14.2,-15" stroke="#eafff6" strokeWidth="0.8" strokeLinecap="round" opacity="0.85" />
+        {/* los CUATRO dedos larguísimos: huesos visibles dentro de la membrana */}
+        <path d="M-13,-13 C-16.6,-13.5 -20.2,-13.4 -23.5,-13.2 M-13,-13 C-17,-11.4 -21.4,-9.4 -24.8,-7.6 M-13,-13 C-15.8,-9.6 -18.6,-5.6 -20.8,-2.2 M-13,-13 C-14.2,-8.6 -14.8,-3 -15,1.8" fill="none" stroke="#c78bff" strokeWidth="0.7" strokeLinecap="round" opacity="0.8" />
+        {/* nudillos de la muñeca: la articulación de la mano-ala */}
+        <circle cx="-13" cy="-13" r="0.7" fill="#eafff6" opacity="0.8" />
+      </g>
     </g>
   );
 }
@@ -253,61 +319,196 @@ function AvatarMarteja() {
   );
 }
 
-/* Gurre / armadillo (Dasypus novemcinctus): caparazón abombado con bandas,
-   hocico largo, orejas tubulares y cola cónica. Acento menta. */
+/* Gurre / armadillo (Dasypus novemcinctus) — PERSONAJE COMPLETO.
+   Pose: la nariz AL SUELO, husmeando y escarbando — su gesto de siempre.
+   Anatomía real: caparazón óseo con escudo escapular y pélvico RÍGIDOS y
+   exactamente NUEVE bandas móviles en la cintura (cuéntelas: de ahí el
+   nombre), hocico largo cónico, orejas tubulares erguidas, cola anillada que
+   se afina, garras delanteras ENORMES de excavador. La tierra vuela con cada
+   zarpazo: así airea el suelo de la finca. Acento menta. */
 function AvatarArmadillo() {
   return (
-    <g className="cn-av-camina" filter="url(#cn-glow1)">
-      <ellipse cx="0" cy="13" rx="16" ry="3" fill="#000" opacity="0.38" />
-      <path d="M-13,6 C-19,7 -22,4 -23.5,1" fill="none" stroke="#6fe6c0" strokeWidth="1.6" strokeLinecap="round" opacity="0.8" />
-      {/* caparazón */}
-      <path d="M-13,9 C-14,-1 -6,-7 3,-7 C11,-7 15,-1 15,7 C15,10 10,12 0,12 C-8,12 -12,11 -13,9 Z" fill="#141a3a" stroke="#6fe6c0" strokeWidth="0.9" strokeOpacity="0.65" />
-      {/* bandas */}
-      <path d="M-6,-6 C-7,-1 -7,6 -6,11" stroke="#8ff0d4" strokeWidth="0.8" fill="none" opacity="0.55" />
-      <path d="M-1,-7 C-2,-1 -2,7 -1,12" stroke="#8ff0d4" strokeWidth="0.8" fill="none" opacity="0.55" />
-      <path d="M4,-7 C3,-1 3,7 4,12" stroke="#8ff0d4" strokeWidth="0.8" fill="none" opacity="0.55" />
-      <path d="M9,-5 C9.5,0 9.5,7 9,11" stroke="#8ff0d4" strokeWidth="0.8" fill="none" opacity="0.5" />
-      <path d="M-10,3 C-6,1 8,1 13,4" stroke="#8ff0d4" strokeWidth="0.7" fill="none" opacity="0.4" />
-      <path d="M-8,11 L-8,7 M2,12 L2,7.5 M10,10 L10,6" stroke="#0f0a24" strokeWidth="3" strokeLinecap="round" />
-      {/* cabeza + hocico largo */}
-      <path d="M13,-1 C19,-2 24,0 25.4,3 C26,4.4 25,5.4 23.4,5 C22.4,3 19,2 15,2.6 C13.6,2.8 13,0.8 13,-1 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.8" strokeOpacity="0.6" />
-      {/* orejas tubulares */}
-      <path d="M9,-5 C8,-11 13,-12 14,-7 C13,-5.5 11,-5 9,-5 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.7" strokeOpacity="0.6" />
-      <circle cx="16.6" cy="0" r="1" fill="#04160f" />
-      <circle cx="16.6" cy="0" r="1" fill="none" stroke="#6fe6c0" strokeWidth="0.6" />
-      <circle cx="16.9" cy="-0.4" r="0.35" fill="#eafff6" />
-      <circle cx="24.8" cy="3.6" r="1" fill="#8ff0d4" opacity="0.9" />
+    <g filter="url(#cn-glow1)">
+      <ellipse cx="-1" cy="14.2" rx="17" ry="2.8" fill="#000" opacity="0.38" />
+      {/* montículo de tierra recién escarbada bajo la nariz */}
+      <path d="M12.5,13.6 C14,11.8 17.5,11.6 19.5,13.2 C17,13.9 14.5,14 12.5,13.6 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.5" strokeOpacity="0.4" />
+      {/* tierra que vuela con el zarpazo (misma cadencia del escarbe) */}
+      <g className="cn-gurre-tierra">
+        <circle cx="11.6" cy="11.4" r="0.6" fill="#8ff0d4" opacity="0.9" />
+        <circle cx="10" cy="12.4" r="0.45" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.4" />
+        <circle cx="12.8" cy="10.2" r="0.35" fill="#8ff0d4" opacity="0.7" />
+      </g>
+      <g className="cn-av-camina">
+        {/* cola anillada que se AFINA (dos tramos: grueso → punta fina) */}
+        <path d="M-14,6 C-18.6,6.8 -21.8,8.6 -23.6,11" fill="none" stroke="#6fe6c0" strokeWidth="2" strokeLinecap="round" opacity="0.8" />
+        <path d="M-23.6,11 C-24.4,12 -24.9,12.8 -25.2,13.4" fill="none" stroke="#6fe6c0" strokeWidth="1" strokeLinecap="round" opacity="0.8" />
+        <path d="M-16.6,6.1 l-0.5,1.9 M-19.2,7 l-0.7,1.8 M-21.5,8.4 l-0.9,1.6 M-23.3,10.4 l-1,1.3" stroke="#0f0a24" strokeWidth="0.8" strokeLinecap="round" opacity="0.85" />
+        {/* patas lejanas (en penumbra) */}
+        <path d="M-9.5,10 L-9.5,13.6 M5.5,7.5 L5.5,13.2" stroke="#0f0a24" strokeWidth="2.6" strokeLinecap="round" opacity="0.8" />
+        {/* ── el caparazón: respira con boil de goma ── */}
+        <g className="cn-boil">
+          <path d="M-14.5,10 C-17,3 -14,-4 -7.5,-7 C-2,-9.2 4,-8.6 8,-5.4 C10.6,-3.2 12,-0.4 12.2,2.6 C12.3,4.6 11,5.8 9,6.2 C3,7.8 -3,9.6 -8,11.2 C-11.5,11.4 -13.8,11 -14.5,10 Z" fill="#141a3a" stroke="#6fe6c0" strokeWidth="0.9" strokeOpacity="0.65" />
+          {/* filo del lomo iluminado: el volumen del domo */}
+          <path d="M-12.6,1 C-10,-4.4 -4.6,-7.6 1.4,-7.6" fill="none" stroke="#eafff6" strokeWidth="0.7" opacity="0.4" />
+          {/* borde del escudo ESCAPULAR (rígido, adelante) */}
+          <path d="M5.2,-7.9 C4.4,-3.4 4.6,1.6 5.8,6.9" fill="none" stroke="#8ff0d4" strokeWidth="0.9" opacity="0.7" />
+          {/* borde del escudo PÉLVICO (rígido, atrás) */}
+          <path d="M-5.8,-7.5 C-6.6,-1.6 -6.4,4.4 -5.4,10.4" fill="none" stroke="#8ff0d4" strokeWidth="0.9" opacity="0.7" />
+          {/* las NUEVE bandas móviles de la cintura — exactamente nueve */}
+          {Array.from({ length: 9 }, (_, i) => {
+            const x = -4.6 + i * 1.15;
+            return (
+              <path
+                key={i}
+                d={`M${x.toFixed(2)},-7.6 C${(x - 0.7).toFixed(2)},-2.4 ${(x - 0.5).toFixed(2)},3.2 ${(x + 0.4).toFixed(2)},${(9.2 - i * 0.28).toFixed(2)}`}
+                fill="none" stroke="#8ff0d4" strokeWidth="0.6" opacity={i % 2 ? 0.42 : 0.58}
+              />
+            );
+          })}
+          {/* escamas (escudos poligonales) punteadas sobre los escudos rígidos */}
+          <path d="M-11.5,3 l1.2,-0.4 M-10.8,-1.6 l1.2,-0.3 M-9,-4.8 l1.2,-0.2 M7.6,-3.4 l1.1,0.5 M8.8,0 l1.1,0.5 M8.6,3.4 l1.1,0.3" stroke="#6fe6c0" strokeWidth="0.5" strokeLinecap="round" opacity="0.45" />
+        </g>
+        {/* patas cercanas: cortas y macizas de excavador */}
+        <path d="M-11,10.8 L-11,14 M2.5,8.6 L2.5,13.8" stroke="#0f0a24" strokeWidth="3" strokeLinecap="round" />
+        {/* ── cabeza husmeando: baja hasta el suelo, olfatea con vaho ── */}
+        <g className="cn-gurre-nariz" style={{ transformBox: 'fill-box', transformOrigin: '12% 18%' }}>
+          {/* cuello + cabeza con placas y hocico largo CÓNICO hasta la tierra */}
+          <path d="M10.6,1.4 C13.4,2 16,4.4 18.2,7.6 C19.4,9.4 20.3,11.2 20.8,12.6 C21.1,13.5 20.2,14.1 19.3,13.5 C17.3,12.1 14.6,10 12.6,7.8 C11.2,6.2 10.4,3.6 10.6,1.4 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.8" strokeOpacity="0.6" />
+          {/* placas de la frente (el gurre lleva casco propio) */}
+          <path d="M11.8,3.4 C13.2,3.8 14.6,4.9 15.8,6.4 M12.8,2.6 C13.6,2.9 14.4,3.5 15.2,4.3" fill="none" stroke="#8ff0d4" strokeWidth="0.5" opacity="0.5" />
+          {/* orejas TUBULARES erguidas (dos tubos, no conos) */}
+          <path d="M10.4,1.6 C9.8,-3.2 12,-4.2 12.8,-0.6 C12.2,0.6 11.4,1.3 10.4,1.6 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.7" strokeOpacity="0.65" />
+          <path d="M8.2,1.2 C7.6,-2.8 9.7,-3.8 10.4,-0.6 C9.9,0.4 9.1,1 8.2,1.2 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.7" strokeOpacity="0.65" />
+          <path d="M11.3,-2.6 C11.5,-1.7 11.5,-0.9 11.4,-0.2" fill="none" stroke="#8ff0d4" strokeWidth="0.4" opacity="0.55" />
+          {/* ojito concentrado en el oficio (párpado a media asta) */}
+          <g className="cn-parpadeo">
+            <circle cx="14.2" cy="6" r="1" fill="#04160f" stroke="#6fe6c0" strokeWidth="0.6" />
+            <circle cx="14.5" cy="5.7" r="0.35" fill="#eafff6" />
+            <path d="M13.2,5.2 C13.9,4.9 14.7,4.9 15.3,5.3" fill="none" stroke="#1c2350" strokeWidth="0.7" />
+          </g>
+          {/* nariz rosada contra la tierra + vaho de husmeo subiendo */}
+          <circle cx="20.2" cy="12.9" r="0.75" fill="#8ff0d4" opacity="0.95" style={{ filter: 'drop-shadow(0 0 2.5px #8ff0d4)' }} />
+          <g className="cn-gurre-vaho">
+            <circle cx="21.4" cy="11.6" r="0.4" fill="#eafff6" />
+            <circle cx="22.2" cy="10.4" r="0.3" fill="#eafff6" />
+          </g>
+        </g>
+        {/* ── la GARRA excavadora: enorme, en pleno zarpazo ── */}
+        <g className="cn-gurre-pala" style={{ transformBox: 'fill-box', transformOrigin: '28% 10%' }}>
+          <path d="M9.4,5.6 C11,6.6 12.4,8.4 13.2,10.6" fill="none" stroke="#0f0a24" strokeWidth="2.6" strokeLinecap="round" />
+          {/* tres garras GRANDES de pala (el rasgo del oficio) */}
+          <path d="M13,10 L15.4,10.6 M13.3,10.9 L15.6,11.9 M13.1,11.7 L15,12.9" stroke="#eafff6" strokeWidth="0.9" strokeLinecap="round" opacity="0.9" />
+        </g>
+      </g>
     </g>
   );
 }
 
-/* Tigrillo / oncilla (Leopardus tigrinus): felino pequeño agazapado, orejas
-   puntudas, ojos de pupila vertical con glow, rosetas y cola anillada.
-   Acento coral. */
+/* Roseta ABIERTA del tigrillo: anillo INTERRUMPIDO de borde oscuro con el
+   centro leonado — el patrón real de Leopardus tigrinus (no lunar cerrado de
+   jaguar). Reutilizable en cualquier parte del cuerpo con escala y giro. */
+function RosetaAbierta({ cx, cy, s = 1, rot = 0 }) {
+  return (
+    <g transform={`translate(${cx} ${cy}) rotate(${rot}) scale(${s})`}>
+      <circle r="0.75" fill="#ffb066" opacity="0.48" />
+      <path d="M-1.1,-0.45 C-0.6,-1.15 0.4,-1.25 1.05,-0.7" fill="none" stroke="#ff7d5a" strokeWidth="0.6" strokeLinecap="round" opacity="0.6" />
+      <path d="M1.1,0.4 C0.6,1.05 -0.4,1.2 -1,0.65" fill="none" stroke="#ff7d5a" strokeWidth="0.6" strokeLinecap="round" opacity="0.45" />
+    </g>
+  );
+}
+
+/* Tigrillo / oncilla (Leopardus tigrinus) — PERSONAJE COMPLETO.
+   Felino PEQUEÑO (menos de 3 kg, tamaño de gato casero — NO un jaguar
+   chiquito): cabeza pequeña y redondeada, hocico corto, ojos grandes cuya
+   pupila se abre REDONDA en la noche, orejas amplias con la mancha blanca en
+   el dorso, rosetas abiertas de borde oscuro y centro leonado, y la cola
+   anillada casi tan larga como el cuerpo. Pose: agazapado ACECHANDO, con el
+   peso cargado atrás y un paso furtivo congelado. Acento coral. */
 function AvatarTigrillo() {
   return (
-    <g className="cn-av-flota" filter="url(#cn-glow1)">
-      <ellipse cx="0" cy="13" rx="16" ry="3" fill="#000" opacity="0.38" />
-      <path d="M13,7 C20,6 23,1 21,-4 C20,-6 17,-6 18,-3" fill="none" stroke="#ff7d5a" strokeWidth="1.8" strokeLinecap="round" opacity="0.85" />
-      <path d="M18.6,3.2 l2,0.6 M19.8,-0.8 l2,0.5" stroke="#ffb59a" strokeWidth="0.8" strokeLinecap="round" opacity="0.7" />
-      <path d="M-13,9 C-15,3 -9,-3 0,-4 C9,-4 14,1 14,7 C14,11 8,12 -3,12 C-9,12 -12,11 -13,9 Z" fill="#171030" stroke="#ff7d5a" strokeWidth="0.9" strokeOpacity="0.6" />
-      {/* rosetas */}
-      <circle cx="-4" cy="2" r="1.2" fill="none" stroke="#ff7d5a" strokeWidth="0.7" opacity="0.6" />
-      <circle cx="2" cy="4" r="1.1" fill="none" stroke="#ff7d5a" strokeWidth="0.7" opacity="0.55" />
-      <circle cx="7" cy="1" r="1" fill="none" stroke="#ff7d5a" strokeWidth="0.7" opacity="0.5" />
-      <path d="M-8,11 L-8,7 M-1,12 L-1,7.5 M7,11 L7,6.5" stroke="#0f0a24" strokeWidth="3" strokeLinecap="round" />
-      {/* cabeza */}
-      <circle cx="-10" cy="-5" r="6" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.9" strokeOpacity="0.6" />
-      {/* orejas puntudas */}
-      <path d="M-14,-9 L-15.5,-14 L-11,-11 Z" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.7" strokeOpacity="0.6" />
-      <path d="M-6,-9 L-4.5,-14 L-9,-11 Z" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.7" strokeOpacity="0.6" />
-      {/* ojos con pupila vertical */}
-      <ellipse cx="-12" cy="-5" rx="1.5" ry="2" fill="#04160f" stroke="#ffd76a" strokeWidth="0.7" />
-      <ellipse cx="-8" cy="-5" rx="1.5" ry="2" fill="#04160f" stroke="#ffd76a" strokeWidth="0.7" />
-      <path d="M-12,-6.2 L-12,-3.8 M-8,-6.2 L-8,-3.8" stroke="#ffd76a" strokeWidth="0.7" style={{ filter: 'drop-shadow(0 0 3px #ffd76a)' }} />
-      {/* hocico + nariz */}
-      <path d="M-11.4,-2 L-8.6,-2 L-10,-0.2 Z" fill="#ffb59a" opacity="0.85" />
-      <path d="M-9.4,-0.6 C-6.4,-0.2 -4.4,-0.8 -3.4,-1.8" stroke="#eafff6" strokeWidth="0.5" fill="none" opacity="0.6" />
+    <g filter="url(#cn-glow1)">
+      <ellipse cx="-1" cy="14" rx="16" ry="2.6" fill="#000" opacity="0.38" />
+      <g className="cn-tigri-acecha">
+        {/* ── cola LARGA anillada (casi tan larga como el cuerpo) ── */}
+        <g className="cn-tigri-cola" style={{ transformBox: 'fill-box', transformOrigin: '0% 100%' }}>
+          {/* rim neón bajo la cola para que no se funda con la noche */}
+          <path d="M11.8,6.2 C17,5.8 20.8,3 21.4,-2.4" fill="none" stroke="#ff7d5a" strokeWidth="3.3" strokeLinecap="round" opacity="0.3" />
+          <path d="M11.8,6.2 C17,5.8 20.8,3 21.4,-2.4" fill="none" stroke="#1c1338" strokeWidth="2.4" strokeLinecap="round" />
+          <path d="M12,5.2 C16.6,4.8 20,2.2 20.6,-2.2" fill="none" stroke="#ff7d5a" strokeWidth="0.5" opacity="0.55" />
+          {/* anillos oscuros de la cola */}
+          <path d="M14.6,4.6 l0.5,2.2 M17.2,3.4 l0.9,2 M19.4,1.2 l1.4,1.4 M20.6,-1 l1.7,0.6" stroke="#0f0a24" strokeWidth="1.2" strokeLinecap="round" opacity="0.9" />
+          {/* la punta: latigazo propio del cazador (flick súbito) */}
+          <g className="cn-tigri-colatip" style={{ transformBox: 'fill-box', transformOrigin: '100% 100%' }}>
+            <path d="M21.4,-2.4 C21.7,-5 21,-7.2 19.2,-7.8" fill="none" stroke="#ff7d5a" strokeWidth="3" strokeLinecap="round" opacity="0.3" />
+            <path d="M21.4,-2.4 C21.7,-5 21,-7.2 19.2,-7.8" fill="none" stroke="#1c1338" strokeWidth="2" strokeLinecap="round" />
+            <path d="M21.5,-4.4 l1.6,-0.2" stroke="#0f0a24" strokeWidth="1.1" strokeLinecap="round" opacity="0.9" />
+            <circle cx="19.1" cy="-7.7" r="1.05" fill="#0f0a24" stroke="#ff7d5a" strokeWidth="0.6" strokeOpacity="0.85" />
+          </g>
+        </g>
+        {/* ── cuerpo liviano agazapado: pecho a ras de tierra, peso ATRÁS ── */}
+        <g className="cn-boil">
+          <path d="M-12.6,9.6 C-13.8,7 -12.6,4.8 -9.6,4.4 C-5.4,3.8 -1.2,3 2.6,1.8 C6.4,0.6 10.4,1.4 12.2,4.4 C13.6,6.8 13.2,9.4 11,10.8 C7.4,13 -4,13.2 -9.8,12.2 C-11.6,11.9 -12.2,11 -12.6,9.6 Z" fill="#171030" stroke="#ff7d5a" strokeWidth="0.9" strokeOpacity="0.6" />
+          {/* la anca coilada: el resorte del salto cargado */}
+          <path d="M4.6,3.2 C8.8,2.6 11.6,4.6 11.8,8 C11.9,10.2 10.4,11.8 8.2,12.2" fill="none" stroke="#ff7d5a" strokeWidth="0.7" opacity="0.45" />
+          {/* línea del lomo iluminada */}
+          <path d="M-10.4,5.2 C-5.6,4.2 -0.6,3.2 3.4,2.2" fill="none" stroke="#eafff6" strokeWidth="0.6" opacity="0.35" />
+          {/* omóplato del paso furtivo: rompe la hogaza, marca el hombro */}
+          <path d="M-9.6,5.2 C-8,6.2 -7.3,8.2 -8,10.4" fill="none" stroke="#ff7d5a" strokeWidth="0.65" opacity="0.4" />
+          {/* rosetas ABIERTAS de centro leonado (patrón diagnóstico) */}
+          <RosetaAbierta cx={-6.2} cy={7} s={0.9} rot={-10} />
+          <RosetaAbierta cx={-1.5} cy={5.6} s={1} rot={18} />
+          <RosetaAbierta cx={3} cy={7.4} s={1.05} rot={-14} />
+          <RosetaAbierta cx={7.8} cy={5.2} s={1.1} rot={10} />
+          <RosetaAbierta cx={9.6} cy={8.8} s={0.85} rot={-22} />
+          <RosetaAbierta cx={-9.3} cy={9.4} s={0.7} rot={6} />
+        </g>
+        {/* pata trasera plantada (el peso vive aquí) */}
+        <path d="M11.4,8.6 C11.8,10.8 10.4,12 8.4,12.6" fill="none" stroke="#0f0a24" strokeWidth="2.2" strokeLinecap="round" />
+        <ellipse cx="7.8" cy="12.8" rx="1.7" ry="0.9" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.5" strokeOpacity="0.6" />
+        {/* patas delanteras: una plantada, la otra ALZADA a mitad de paso furtivo */}
+        <path d="M-11.6,8.8 C-12,10.2 -12.1,11.4 -12,12.4" fill="none" stroke="#0f0a24" strokeWidth="2.2" strokeLinecap="round" />
+        <ellipse cx="-12" cy="12.7" rx="1.5" ry="0.85" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.5" strokeOpacity="0.6" />
+        <path d="M-8.6,9.4 C-8.2,10.4 -8.1,11.2 -8.2,11.9" fill="none" stroke="#0f0a24" strokeWidth="2.2" strokeLinecap="round" />
+        <ellipse cx="-8.3" cy="12.1" rx="1.4" ry="0.8" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.5" strokeOpacity="0.6" />
+        {/* manchitas sólidas en las patas (allá la roseta se vuelve punto) */}
+        <circle cx="-11" cy="10.6" r="0.4" fill="#ff7d5a" opacity="0.5" />
+        <circle cx="10.2" cy="10.8" r="0.4" fill="#ff7d5a" opacity="0.5" />
+        {/* pelaje del pecho: ticks crema */}
+        <path d="M-12.2,6.6 l-1.2,0.7 M-12.6,8.2 l-1.3,0.4" stroke="#eafff6" strokeWidth="0.5" strokeLinecap="round" opacity="0.5" />
+        {/* ── cabeza PEQUEÑA y redondeada, baja, empujada adelante ── */}
+        <circle cx="-15.5" cy="0.2" r="4.1" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.9" strokeOpacity="0.6" />
+        {/* cuello que la une al pecho, con su rim coral para no romper el contorno */}
+        <path d="M-12.4,2.8 C-11.2,3.6 -10.2,4.4 -9.4,5.2" fill="none" stroke="#1c1338" strokeWidth="3.4" strokeLinecap="round" />
+        <path d="M-13.2,1.2 C-11.8,1.9 -10.6,2.9 -9.6,4" fill="none" stroke="#ff7d5a" strokeWidth="0.6" strokeLinecap="round" opacity="0.55" />
+        {/* oreja LEJANA: se ve el dorso → la mancha BLANCA (ocelo) visible */}
+        <path d="M-18.2,-2.9 C-19.8,-7.2 -16.2,-8.6 -14.7,-4.4 C-15.6,-3.3 -16.9,-2.8 -18.2,-2.9 Z" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.7" strokeOpacity="0.6" />
+        <circle cx="-16.9" cy="-4.9" r="0.7" fill="#eafff6" opacity="0.8" />
+        {/* oreja CERCANA: amplia, redondeada, parada de cacería */}
+        <path d="M-13.4,-3.1 C-12.2,-7.5 -9.4,-7.1 -10.3,-3.4 C-11.3,-2.6 -12.4,-2.6 -13.4,-3.1 Z" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.7" strokeOpacity="0.6" />
+        <path d="M-12.6,-4 C-12,-5.6 -11.2,-5.8 -10.9,-4.4" fill="none" stroke="#ffb59a" strokeWidth="0.5" opacity="0.6" />
+        {/* manchitas de la frente (rayitas, no rosetas: la cabeza va punteada) */}
+        <path d="M-16.6,-3 l0.5,1 M-15.2,-3.4 l0.3,1.1 M-13.9,-3 l0.1,1" stroke="#ff7d5a" strokeWidth="0.5" strokeLinecap="round" opacity="0.55" />
+        {/* ── OJOS GRANDES de noche: pupila abierta REDONDA (no rendija) ── */}
+        <g className="cn-parpadeo">
+          <circle cx="-17" cy="-0.6" r="1.6" fill="#04160f" stroke="#ffd76a" strokeWidth="0.7" />
+          <circle cx="-13.8" cy="-0.9" r="1.6" fill="#04160f" stroke="#ffd76a" strokeWidth="0.7" />
+          <circle cx="-17" cy="-0.6" r="1.05" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 4px #ffd76a)' }} />
+          <circle cx="-13.8" cy="-0.9" r="1.05" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 4px #ffd76a)' }} />
+          <g className="cn-mirada">
+            <circle cx="-17" cy="-0.6" r="0.72" fill="#0d0620" />
+            <circle cx="-13.8" cy="-0.9" r="0.72" fill="#0d0620" />
+            <circle cx="-17.3" cy="-1" r="0.32" fill="#eafff6" />
+            <circle cx="-14.1" cy="-1.3" r="0.32" fill="#eafff6" />
+          </g>
+        </g>
+        {/* hocico CORTO de gato: bump chico, nariz coral, boquita */}
+        <ellipse cx="-18.4" cy="1.7" rx="1.9" ry="1.5" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.6" strokeOpacity="0.5" />
+        <ellipse cx="-18.4" cy="1.8" rx="1.2" ry="0.9" fill="#eafff6" opacity="0.22" />
+        <path d="M-19.7,0.9 L-18.3,0.9 L-19,2 Z" fill="#ffb59a" opacity="0.95" />
+        <path d="M-19,2 C-18.7,2.6 -18,2.8 -17.4,2.5" fill="none" stroke="#eafff6" strokeWidth="0.45" opacity="0.6" />
+        {/* bigotes */}
+        <path d="M-19.4,1.9 C-21,1.7 -22.4,1.9 -23.4,2.4 M-19.2,2.5 C-20.7,2.9 -21.9,3.5 -22.8,4.2" fill="none" stroke="#eafff6" strokeWidth="0.4" strokeLinecap="round" opacity="0.55" />
+      </g>
     </g>
   );
 }

--- a/src/components/dashboard/criaturas-nocturnas.css
+++ b/src/components/dashboard/criaturas-nocturnas.css
@@ -44,3 +44,142 @@
   .cn-av-camina, .cn-av-flota, .cn-av-vuela, .cn-av-planea,
   .cn-ala-mur, .cn-luz, .cn-luz-halo { animation: none !important; }
 }
+
+/* ═══ NIVEL PERSONAJE (murciélago · gurre · tigrillo) — rubber-hose andino en
+   clave biopunk: boil en cadencia dibujada (~12fps vía steps), parpadeo
+   irregular con blink doble y mirada co-prima, mismos principios que las
+   clases rh-* de creatures.css pero en el namespace cn- de las nocturnas. ═══ */
+
+/* BOIL — squash & stretch que respira: anticipa, aplasta, overshoot. */
+.cn-boil {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-boil 1.6s steps(14, end) infinite;
+}
+@keyframes cn-boil {
+  0%   { transform: translateY(0) scale(1, 1); }
+  22%  { transform: translateY(-0.25px) scale(0.98, 1.04); }  /* stretch (anticipa) */
+  50%  { transform: translateY(0.35px) scale(1.04, 0.96); }   /* squash */
+  72%  { transform: translateY(-0.1px) scale(0.99, 1.015); }  /* overshoot */
+  100% { transform: translateY(0) scale(1, 1); }
+}
+
+/* PARPADEO irregular: un blink suelto y luego un blink-blink — la cadencia
+   pareja delataba al robot. Período co-primo con boil y mirada. */
+.cn-parpadeo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: cn-parpadeo 6.1s linear infinite;
+}
+@keyframes cn-parpadeo {
+  0%, 37%, 41%, 73%, 77%, 81%, 85%, 100% { transform: scaleY(1); }
+  39% { transform: scaleY(0.12); }
+  75% { transform: scaleY(0.1); }
+  79% { transform: scaleY(0.15); }
+}
+
+/* MIRADA — pupilas de reojo con double-take, nunca en el compás del parpadeo. */
+.cn-mirada { animation: cn-mirada 8.3s ease-in-out infinite; }
+@keyframes cn-mirada {
+  0%, 22%, 49%, 60%, 78%, 100% { transform: translate(0, 0); }
+  25%, 36% { transform: translate(-0.5px, 0.1px); }
+  40% { transform: translate(0.45px, 0); }        /* double-take */
+  43%, 46% { transform: translate(-0.45px, 0.1px); }
+  63%, 73% { transform: translate(0.4px, -0.35px); }
+}
+
+/* ── MURCIÉLAGO: cernido ERRÁTICO (nunca simétrico) + aleteo rápido de mano ── */
+.cn-mur-cierne { animation: cn-mur-cierne 2.7s cubic-bezier(0.37, 0, 0.63, 1) infinite; }
+@keyframes cn-mur-cierne {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  14% { transform: translate(-0.6px, -1.4px) rotate(-2.5deg); }
+  32% { transform: translate(0.5px, -0.5px) rotate(2deg); }   /* corrige seco */
+  47% { transform: translate(-0.3px, -1.8px) rotate(-1.5deg); }
+  66% { transform: translate(0.7px, -0.7px) rotate(2deg); }
+  83% { transform: translate(-0.4px, -1.2px) rotate(-1.5deg); }
+}
+.cn-mur-ala { animation: cn-mur-aleteo 0.3s cubic-bezier(0.5, 0, 0.5, 1) infinite alternate; }
+@keyframes cn-mur-aleteo {
+  from { transform: rotate(-14deg); }
+  to   { transform: rotate(8deg); }
+}
+.cn-mur-ala-far { animation: cn-mur-aleteo-far 0.3s cubic-bezier(0.5, 0, 0.5, 1) infinite alternate; animation-delay: -0.15s; }
+@keyframes cn-mur-aleteo-far {
+  from { transform: rotate(9deg); }
+  to   { transform: rotate(-6deg); }
+}
+/* la lengua lame la corola: se extiende, retrae un pelo y vuelve (dasharray) */
+.cn-mur-lengua { stroke-dasharray: 10; animation: cn-mur-lame 3.1s ease-in-out infinite; }
+@keyframes cn-mur-lame {
+  0%, 10% { stroke-dashoffset: 9.7; }
+  26% { stroke-dashoffset: 0; }
+  40% { stroke-dashoffset: 1.6; }   /* lame */
+  54%, 66% { stroke-dashoffset: 0; }
+  82%, 100% { stroke-dashoffset: 9.7; }
+}
+.cn-mur-polen { animation: cn-mur-polen 3.1s ease-in-out infinite; }
+@keyframes cn-mur-polen {
+  0%, 100% { opacity: 0.15; transform: translateY(0); }
+  45% { opacity: 0.9; transform: translateY(-1.2px); }
+}
+
+/* ── GURRE: husmea con la nariz al suelo y escarba a zarpazos con pausa ── */
+.cn-gurre-nariz { animation: cn-gurre-husmea 2.3s steps(12, end) infinite; }
+@keyframes cn-gurre-husmea {
+  0%, 54%, 100% { transform: rotate(0deg) translateY(0); }
+  12% { transform: rotate(2.2deg) translateY(0.4px); }   /* husmea */
+  22% { transform: rotate(0.6deg) translateY(0.1px); }
+  32% { transform: rotate(2.6deg) translateY(0.6px); }   /* husmea más hondo */
+  42% { transform: rotate(0.8deg) translateY(0.2px); }
+}
+.cn-gurre-vaho { animation: cn-gurre-vaho 2.3s ease-out infinite; }
+@keyframes cn-gurre-vaho {
+  0%, 10%, 44%, 100% { opacity: 0; transform: translate(0, 0); }
+  18% { opacity: 0.7; transform: translate(0.6px, -0.5px); }
+  34% { opacity: 0; transform: translate(1.6px, -1.5px); }
+}
+.cn-gurre-pala { animation: cn-gurre-escarba 1.15s steps(9, end) infinite; }
+@keyframes cn-gurre-escarba {
+  0%, 58%, 100% { transform: rotate(0deg); }
+  14% { transform: rotate(-24deg); }   /* zarpazo */
+  28% { transform: rotate(5deg); }     /* overshoot */
+  42% { transform: rotate(-20deg); }   /* segundo zarpazo, y pausa */
+}
+.cn-gurre-tierra { animation: cn-gurre-tierra 1.15s ease-out infinite; }
+@keyframes cn-gurre-tierra {
+  0%, 12% { opacity: 0; transform: translate(0, 0); }
+  30% { opacity: 0.9; transform: translate(-1.8px, -2.4px); }
+  60%, 100% { opacity: 0; transform: translate(-3.4px, 0.6px); }
+}
+
+/* ── TIGRILLO: acecho con el peso atrás + paso furtivo; la cola manda ── */
+.cn-tigri-acecha {
+  transform-box: fill-box;
+  transform-origin: 70% 100%;
+  animation: cn-tigri-acecha 4.6s steps(20, end) infinite;
+}
+@keyframes cn-tigri-acecha {
+  0%, 42%, 100% { transform: translate(0, 0); }
+  50%, 58% { transform: translate(0.9px, 0.5px); }   /* anticipa: carga el peso atrás */
+  66% { transform: translate(-1.2px, 0.1px); }       /* paso furtivo adelante */
+  74%, 88% { transform: translate(-0.5px, 0); }
+}
+.cn-tigri-cola { animation: cn-tigri-cola 3.7s ease-in-out infinite; }
+@keyframes cn-tigri-cola {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-5deg); }
+}
+.cn-tigri-colatip { animation: cn-tigri-colatip 3.7s cubic-bezier(0.68, -0.3, 0.32, 1.3) infinite; }
+@keyframes cn-tigri-colatip {
+  0%, 58%, 100% { transform: rotate(0deg); }
+  64% { transform: rotate(-20deg); }   /* latigazo */
+  70% { transform: rotate(8deg); }
+  76% { transform: rotate(-12deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cn-boil, .cn-parpadeo, .cn-mirada,
+  .cn-mur-cierne, .cn-mur-ala, .cn-mur-ala-far, .cn-mur-lengua, .cn-mur-polen,
+  .cn-gurre-nariz, .cn-gurre-vaho, .cn-gurre-pala, .cn-gurre-tierra,
+  .cn-tigri-acecha, .cn-tigri-cola, .cn-tigri-colatip { animation: none !important; }
+}


### PR DESCRIPTION
Las tres criaturas nocturnas asignadas dejan de ser siluetas-chip y pasan a personaje completo en el lenguaje biopunk aprobado (oscuro + neón por especie), con anatomía diagnóstica real y animación rubber-hose andina.

## Qué cambia
- **Murciélago nectarívoro** (*Glossophaga soricina*): cernido errático alimentándose; la lengua extensible (rasgo diagnóstico) lame con glow dentro de una flor nocturna; el ala es una MANO — húmero, pulgar-garfio y cuatro dedos-hueso visibles en el patagio festoneado; uropatagio, hoja nasal, polen dorado en el hocico.
- **Gurre** (*Dasypus novemcinctus*): nariz al suelo husmeando (vaho animado); escudos escapular y pélvico rígidos + exactamente NUEVE bandas móviles contables; orejas tubulares; cola anillada que se afina; garra excavadora enorme en pleno zarpazo con la tierra volando en cadencia.
- **Tigrillo** (*Leopardus tigrinus*): proporción de gato casero (no jaguar chiquito); pupilas REDONDAS dilatadas de noche (el chip viejo tenía rendijas verticales: corregido); rosetas ABIERTAS de borde oscuro y centro leonado; ocelo blanco en el dorso de la oreja; cola anillada casi tan larga como el cuerpo con latigazo propio; acecho con el peso atrás.

## Animación
Bloques nuevos añadidos AL FINAL de `criaturas-nocturnas.css` (namespace `cn-`, archivo propio de las nocturnas — `creatures.css` compartido intacto): boil steps ~12fps con anticipación/overshoot, parpadeo irregular con blink doble, mirada co-prima con double-take, y los gestos por especie (aleteo de mano-ala 0.3s, lengua por dasharray, husmeo+zarpazos con pausa, acecho+latigazo). `prefers-reduced-motion` cubierto.

## Contrato intacto
`CriaturaNocturnaAvatar({id,size})`, `AVATAR` map, `CriaturasNocturnasDefs` y viewBox sin cambios. Roster grounded sin reescribir. Búho y zarigüeya NO tocados (van en rama paralela). Valle3D/composición sin tocar. Cero dependencias nuevas, todo autocontenido.

Verificado con render estático + captura headless a 300px, 430px y tamaño chip 64px: los tres leen a toda escala.

🤖 Generated with [Claude Code](https://claude.com/claude-code)