### PR TITLE
art(aguacatal): el MUNDO DEL AGUACATE — el árbol que le pasa por encima a la casa

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -156,6 +156,12 @@ const BosqueVivo3DMockup = lazy(() => import('./mockups/BosqueVivo3D'));
 // de guamos y nogales, y la casa-beneficiadero en la bruma. Device-tiering
 // real. Ruta #/mockups/cafetal-vivo-3d, sin auth.
 const CafetalVivo3DMockup = lazy(() => import('./mockups/CafetalVivo3D'));
+// 3D: el MUNDO DEL AGUACATE — el árbol GRANDE, que es todo el punto: el Hass
+// adulto le dobla la altura a la casa y le hace techo a uno. Fruto rugoso en
+// racimos flojos del pedúnculo, panícula con abejas, el envés que platea con
+// el viento, y la hojarasca sin pasto bajo cada copa. Device-tiering real.
+// Ruta #/mockups/aguacatal-vivo-3d, sin auth.
+const AguacatalVivo3DMockup = lazy(() => import('./mockups/AguacatalVivo3D'));
 // 3D: LA MICROCUENCA CORTADA — la misma loma bajo la misma nube, partida:
 // suelo VIVO que se traga el aguacero y lo devuelve limpio todo el verano vs
 // suelo PELADO que lo bota de una. Por qué se seca un cauce.
@@ -643,6 +649,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo3d-bosque': 'mockup_mundo3d_bosque',
   'mockups/bosque-vivo-3d': 'mockup_bosque_vivo_3d',
   'mockups/cafetal-vivo-3d': 'mockup_cafetal_vivo_3d',
+  'mockups/aguacatal-vivo-3d': 'mockup_aguacatal_vivo_3d',
   'mockups/microcuenca': 'mockup_microcuenca',
   'casa_adentro': 'mundo_casa_adentro',
   'mockups/casa-adentro': 'mundo_casa_adentro',
@@ -1675,6 +1682,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo del café">
               <CafetalVivo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_aguacatal_vivo_3d':
+        // Vitrina pública del MUNDO DEL AGUACATE: el árbol GRANDE en 3D real —
+        // el Hass adulto que le dobla la altura a la casa y le hace techo a
+        // uno, el fruto rugoso colgando del pedúnculo en racimos flojos, la
+        // panícula con abejas, el envés que platea al viento y la hojarasca sin
+        // pasto bajo la copa. En equipo humilde muestra la ficha, que también
+        // vende la escala. Ruta #/mockups/aguacatal-vivo-3d.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo del aguacate">
+              <AguacatalVivo3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/AguacatalVivo3D.css
+++ b/src/mockups/AguacatalVivo3D.css
@@ -1,0 +1,274 @@
+/*
+ * AguacatalVivo3D.css — vitrina del mundo del aguacate (#/mockups/aguacatal-vivo-3d).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Paleta de piso templado alto: verde hoja profundo, luz fresca de ladera y el
+ * morado-negro del Hass como acento. Solo opacity/transform se animan.
+ */
+
+.aviva {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  /* la familia ladera bajo la hora viva: verde fresco, nunca pardo mustio */
+  background: linear-gradient(180deg, #dde5cd 0%, #e5e8cd 44%, #eeeacf 100%);
+  color: #263123;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.aviva__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.aviva__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #5e3a54;
+}
+.aviva__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #27402a;
+}
+.aviva__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 40rem;
+}
+
+.aviva__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+.aviva__lienzo {
+  position: relative;
+  height: min(66vh, 32rem);
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(94, 58, 84, 0.25);
+  box-shadow: 0 12px 30px rgba(38, 49, 35, 0.16);
+  background: radial-gradient(120% 90% at 50% 20%, #c9dcc4 0%, #a4bd9d 100%);
+}
+.aviva__lienzo canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+  touch-action: none;
+}
+.aguacatal-canvas {
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.aguacatal-canvas--lista {
+  opacity: 1;
+}
+
+.aviva__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  color: #37472f;
+  opacity: 0.85;
+}
+
+.aviva__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.aviva__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.aviva__toggle {
+  border: 1.5px solid #5e3a54;
+  background: #fff;
+  color: #5e3a54;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.aviva__toggle:hover,
+.aviva__toggle:focus-visible {
+  background: #5e3a54;
+  color: #fff;
+  outline-offset: 2px;
+}
+
+/* ---- Ficha 2D (fallback digno, sin GPU) ---- */
+/* La escala también aquí: el árbol ENORME y la casita al pie. */
+.aviva__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  background: radial-gradient(120% 90% at 50% 25%, #cfdcc6 0%, #9fb295 100%);
+}
+.aviva__estampa {
+  position: relative;
+  width: 200px;
+  height: 190px;
+  margin-bottom: 0.4rem;
+}
+/* la copa densa, verde muy oscuro, dominando la estampa */
+.aviva__copa {
+  position: absolute;
+  top: 0;
+  left: 22px;
+  width: 150px;
+  height: 96px;
+  border-radius: 52% 48% 58% 42% / 68% 72% 28% 32%;
+  background: radial-gradient(circle at 40% 28%, #3d703877 0%, #24512c 55%, #16301b 100%);
+  box-shadow: inset -10px -8px 16px rgba(0, 0, 0, 0.22);
+}
+.aviva__copa-baja {
+  position: absolute;
+  top: 62px;
+  left: 8px;
+  width: 120px;
+  height: 52px;
+  border-radius: 60% 40% 55% 45% / 70% 66% 34% 30%;
+  background: radial-gradient(circle at 45% 30%, #2f5c2f88 0%, #1d3f24 60%, #152e1a 100%);
+}
+.aviva__tronco {
+  position: absolute;
+  top: 96px;
+  left: 88px;
+  width: 16px;
+  height: 88px;
+  border-radius: 40%;
+  background: linear-gradient(90deg, #4e4234 0%, #6a5844 55%, #493e30 100%);
+}
+/* los frutos colgando del borde de la copa, con su rabito */
+.aviva__fruto {
+  position: absolute;
+  width: 15px;
+  height: 20px;
+  border-radius: 46% 54% 48% 52% / 38% 36% 64% 62%;
+}
+.aviva__fruto::before {
+  content: '';
+  position: absolute;
+  top: -6px;
+  left: 6px;
+  width: 2.5px;
+  height: 7px;
+  background: #8a7a4f;
+  border-radius: 2px;
+}
+.aviva__fruto--verde {
+  top: 102px;
+  left: 44px;
+  background: radial-gradient(circle at 35% 30%, #6f9440 0%, #5b7c36 70%);
+}
+.aviva__fruto--pinton {
+  top: 112px;
+  left: 128px;
+  background: radial-gradient(circle at 35% 30%, #5e4152 0%, #503046 70%);
+}
+.aviva__fruto--negro {
+  top: 96px;
+  left: 152px;
+  background: radial-gradient(circle at 35% 30%, #3a2a35 0%, #251722 70%);
+}
+/* la casita campesina, CHIQUITA al pie del árbol: la lección de escala */
+.aviva__casita {
+  position: absolute;
+  bottom: 4px;
+  left: 10px;
+  width: 46px;
+  height: 30px;
+  background: linear-gradient(180deg, #f3ede0 0%, #e6ddc9 100%);
+  border-radius: 2px;
+  box-shadow: inset 0 -6px 0 rgba(90, 74, 52, 0.25);
+}
+.aviva__techo {
+  position: absolute;
+  top: -13px;
+  left: -4px;
+  width: 0;
+  height: 0;
+  border-left: 27px solid transparent;
+  border-right: 27px solid transparent;
+  border-bottom: 14px solid #a0522d;
+}
+.aviva__ficha-nombre {
+  margin: 0;
+  font-weight: 700;
+  color: #1f3322;
+}
+.aviva__ficha-sub {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #33462e;
+}
+
+/* ---- Saberes ---- */
+.aviva__saberes {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.aviva__saberes h2 {
+  font-size: 1.15rem;
+  color: #27402a;
+  margin: 0 0 0.7rem;
+}
+.aviva__saberes ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.7rem;
+}
+@media (min-width: 640px) {
+  .aviva__saberes ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.aviva__saberes li {
+  display: flex;
+  gap: 0.6rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(39, 64, 42, 0.14);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.aviva__emoji {
+  font-size: 1.3rem;
+  line-height: 1.2;
+}
+.aviva__saberes b {
+  display: block;
+  margin-bottom: 0.15rem;
+  color: #27402a;
+}
+.aviva__saberes p {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+.aviva__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: #2f4030;
+  border-left: 3px solid #5e3a54;
+  padding-left: 0.7rem;
+}

--- a/src/mockups/AguacatalVivo3D.jsx
+++ b/src/mockups/AguacatalVivo3D.jsx
@@ -1,0 +1,163 @@
+/*
+ * AguacatalVivo3D — vitrina pública del MUNDO DEL AGUACATE: la finca del árbol
+ * grande del piso templado alto (1.800–2.200 m, la franja andina del Hass).
+ * Ruta #/mockups/aguacatal-vivo-3d, sin auth.
+ *
+ * El aguacate se muestra como lo que es: un ÁRBOL que le pasa por encima a la
+ * casa — no un arbustico más. La finca campesina navegable: los Hass adultos
+ * en sus camellones (matorros irregulares, nunca cuadrícula), el criollo viejo
+ * del patio con la escalera de cosecha recostada, la floración en panícula con
+ * sus abejas, el fruto rugoso pintando de verde a morado-negro, los jóvenes
+ * con tutor junto a la zanjilla, y bajo cada copa el microclima de hojarasca.
+ * Cuatro pasos cortos recorren la lección.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el mundo 3D (chunk
+ * perezoso `vendor-three`); en equipo humilde, ahorro de datos o sin-WebGL se
+ * ve la ficha del aguacatal, digna y sin sudar la GPU. Copy en español de
+ * Colombia, en "usted". Autocontenida: cero CDN/imágenes externas.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import './AguacatalVivo3D.css';
+
+const MundoAguacatal = lazy(() => import('../visual/mundo3d/aguacatal/MundoAguacatal.jsx'));
+
+/* Lo que enseña el aguacatal (verificado, en "usted"). */
+const SABERES = [
+  {
+    emoji: '🌳',
+    titulo: 'Es un árbol, no una mata',
+    texto:
+      'Un Hass adulto injertado pasa de los 8 metros — más alto que la casa — y el criollo de semilla crece más todavía. Quien siembra aguacate siembra sombra para años: hay que darle campo, luz y escalera.',
+  },
+  {
+    emoji: '🐝',
+    titulo: 'Miles de flores, poquitos frutos',
+    texto:
+      'La floración sale en panículas de miles de flores pequeñas, amarillo-verdosas. De todas esas, cuajan poquitas — y las que cuajan se las deben a las abejas y demás polinizadores. Cuidar el enjambre es cuidar la cosecha.',
+  },
+  {
+    emoji: '🥑',
+    titulo: 'Hass rugoso, criollo liso',
+    texto:
+      'El Hass se conoce por su cáscara rugosa, que pinta de verde a morado-negro al madurar. El criollo es más grande, de cáscara lisa y verde aunque esté maduro. Distinguirlos importa: se cosechan, se venden y se pagan distinto.',
+  },
+  {
+    emoji: '⛏️',
+    titulo: 'La raíz manda: camellón y drenaje',
+    texto:
+      'La raíz del aguacate es superficial: el viento lo voltea y el encharcamiento lo ahoga. Por eso se siembra en camellón, el joven lleva tutor y la zanjilla saca el agua sobrada. Y su sombra densa deja hojarasca gruesa: suelo fresco que se abona solo.',
+  },
+];
+
+export default function AguacatalVivo3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  return (
+    <main className="aviva">
+      <header className="aviva__head">
+        <p className="aviva__kicker">El mundo del aguacate · vitrina</p>
+        <h1>El árbol que le pasa por encima a la casa</h1>
+        <p className="aviva__lema">
+          La finca aguacatera como es de verdad: el Hass adulto en su camellón,
+          el criollo viejo del patio con la escalera recostada, la floración
+          zumbando de abejas y el fruto pintando de verde a morado-negro.
+          Recórrala con el dedo y siga los cuatro pasos de la lección.
+        </p>
+      </header>
+
+      <section className="aviva__escena" aria-label="La finca del aguacate en 3D">
+        <div className="aviva__lienzo">
+          {mostrar3D ? (
+            <Suspense
+              fallback={
+                <div className="aviva__cargando" role="status">
+                  Entrando a la finca…
+                </div>
+              }
+            >
+              <MundoAguacatal tier={tier} reducedMotion={reducedMotion} />
+            </Suspense>
+          ) : (
+            <FichaAguacatal />
+          )}
+        </div>
+
+        <div className="aviva__barra">
+          <p className="aviva__tier">
+            {mostrar3D
+              ? 'Está viendo la finca en 3D. Gírela con el dedo o el mouse y siga los pasos.'
+              : puede3D
+                ? 'Está viendo la ficha del aguacatal.'
+                : 'Su equipo ve la ficha del aguacatal (va parejo en cualquier teléfono).'}
+          </p>
+          {puede3D && (
+            <button type="button" className="aviva__toggle" onClick={() => setVer2d((v) => !v)}>
+              {ver2d ? 'Ver la finca en 3D' : 'Ver la ficha'}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <section className="aviva__saberes" aria-label="Lo que enseña el aguacatal">
+        <h2>Lo que le enseña este aguacatal</h2>
+        <ol>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span className="aviva__emoji" aria-hidden="true">
+                {s.emoji}
+              </span>
+              <div>
+                <b>{s.titulo}</b>
+                <p>{s.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="aviva__cierre">
+          El aguacate no es plantación en cuadrícula: es árbol de finca, sembrado
+          con casa cerca, maíz al lado y abejas encima. Donde el camellón drena y
+          la sombra deja su hojarasca, el árbol grande produce por décadas — y
+          eso no lo da ningún afán.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+/* La ficha del aguacatal: el fallback digno para equipo humilde / sin-WebGL.
+   La ESCALA también aquí: el árbol CSS enorme y la casita al pie — cero GPU. */
+function FichaAguacatal() {
+  return (
+    <div
+      className="aviva__ficha"
+      role="img"
+      aria-label="El aguacatal: un árbol de aguacate enorme con sus frutos, y la casa campesina pequeña a su pie"
+    >
+      <div className="aviva__estampa" aria-hidden="true">
+        <span className="aviva__copa" />
+        <span className="aviva__copa-baja" />
+        <span className="aviva__tronco" />
+        <span className="aviva__fruto aviva__fruto--verde" />
+        <span className="aviva__fruto aviva__fruto--pinton" />
+        <span className="aviva__fruto aviva__fruto--negro" />
+        <span className="aviva__casita">
+          <span className="aviva__techo" />
+        </span>
+      </div>
+      <p className="aviva__ficha-nombre">El árbol del aguacate</p>
+      <p className="aviva__ficha-sub">Piso templado alto · más alto que la casa</p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/aguacatal/EscenaAguacatalVivo.jsx
+++ b/src/visual/mundo3d/aguacatal/EscenaAguacatalVivo.jsx
@@ -1,0 +1,404 @@
+/*
+ * EscenaAguacatalVivo — el MUNDO donde vive el aguacate (piso templado alto,
+ * 1.800–2.200 m: la franja andina del Hass).
+ *
+ * El problema de diseño de este mundo es LA ESCALA: el aguacate es un ÁRBOL
+ * GRANDE — el Hass adulto le pasa por encima a la casa y el criollo viejo del
+ * patio todavía más — y la escena está compuesta para HACERLA SENTIR: la casa
+ * campesina vive pegada al criollo gigante (las dos siluetas se comparan
+ * solas), la ESCALERA de cosecha recostada al tronco dice "a este árbol se le
+ * sube", y la cámara llega BAJA, mirando apenas hacia arriba, para que las
+ * copas oscuras hagan techo.
+ *
+ * En clave de la TOMA B (estilizada Switch/BOTW): atmósfera del kit compartido
+ * (familia `ladera` — el mundo amanece, dora y anochece CON el valle), domo de
+ * gradiente con el glow del sol, terreno y montes por BANDAS (toon) y silueta
+ * fuerte. La finca se cuenta como es: matorros IRREGULARES de Hass en sus
+ * camellones (nunca cuadrícula), el lote nuevo de jóvenes con tutor junto a la
+ * ZANJILLA de drenaje, el maíz asociado, y bajo cada copa el suelo cambia —
+ * hojarasca gruesa y poco pasto: el microclima que la sombra densa fabrica.
+ *
+ * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`; con
+ * `reducedMotion` el mundo monta QUIETO. La fauna son los SVG rubber-hose de
+ * la casa como billboards (mariposa y colibrí) más las abejas ámbar de la
+ * floración (capa viva de FloraAguacatal).
+ *
+ * `foco` (opcional): un punto [x,y,z] que el paso didáctico del host señala
+ * con un anillo que respira. Importa three/@react-three → montar SOLO perezosa.
+ */
+import { useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { perfilDeTier } from '../deviceTier.js';
+import { Fauna } from '../escenas/FaunaEscena.jsx';
+import FloraAguacatal from './FloraAguacatal.jsx';
+import {
+  ANCHO,
+  FONDO,
+  alturaFinca,
+  zanjaEnX,
+  SITIO_CASA,
+  SITIOS_CRIOLLO,
+  RADIO_COPA,
+  aguacatalDeTier,
+  centrosCopa,
+} from './floraAguacatal.geom.js';
+import {
+  AtmosferaMundo,
+  DomoCielo,
+  useAtmosferaMundo,
+  useGradienteBandas,
+  construirTerreno,
+  ruidoTerreno,
+  smoothstep,
+  CamaraDirector,
+} from '../kit/index.js';
+import {
+  mezclar,
+  VERDES,
+  TIERRAS,
+  CASA,
+  LUCES,
+  NIEBLAS,
+  PALETA,
+} from '../paleta/index.js';
+
+/* La identidad del piso templado alto dentro de la familia del valle:
+   `ladera` (verde fresco de montaña). El 60% restante lo pone la HORA. */
+const FAMILIA_AGUACATAL = 'ladera';
+
+/* Escala de la escena para el kit (cámara↔centro ~15). */
+const RADIO_AGUACATAL = 12;
+
+/* El frustum de sombra a medida de la finca (las copas grandes proyectan). */
+const SOMBRA_AGUACATAL = { left: -18, right: 18, top: 18, bottom: -8, far: 44 };
+
+/* El camino de la finca: sube culebreando del frente hasta la casa. */
+const caminoEnX = (wz) => 2.2 + Math.sin(wz * 0.3) * 1.6 + smoothstep(0, -12, wz) * 6.4;
+
+/* La malla de la finca — el heightfield del KIT con la pintura PROPIA del
+   templado alto: pasto fresco al sol, y BAJO CADA COPA el suelo cambia a
+   mantillo pardo (la hojarasca gruesa del microclima — la lección pintada en
+   el terreno). La zanjilla va húmeda y oscura; el camino, seco. */
+function construirFinca(seg, plano, centros) {
+  const cPasto = new THREE.Color(VERDES.brote); // pasto al sol del templado
+  const cPasto2 = new THREE.Color(VERDES.calidoVivo); // el verde cálido que asoma
+  const cMantillo = new THREE.Color(TIERRAS.mantillo); // hojarasca bajo la copa
+  const cMantillo2 = new THREE.Color(TIERRAS.mantilloSombra); // el corazón húmedo
+  const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.4));
+  const cZanja = new THREE.Color(TIERRAS.mantilloSombra).multiplyScalar(0.72);
+  const cArcilla = new THREE.Color(TIERRAS.arcilla);
+  return construirTerreno({
+    ancho: ANCHO,
+    fondo: FONDO,
+    seg,
+    plano,
+    altura: alturaFinca,
+    pintar: (wx, wz, alt, c) => {
+      c.lerpColors(cPasto, cPasto2, 0.5 + 0.5 * ruidoTerreno(wx * 0.9, wz * 0.7));
+      // la arcilla asoma a manchas en lo abierto
+      c.lerp(cArcilla, smoothstep(0.15, 0.9, ruidoTerreno(wx * 1.4, wz * 1.2)) * 0.18);
+      // EL MICROCLIMA: bajo cada copa, el pasto se rinde a la hojarasca
+      let sombra = 0;
+      for (let i = 0; i < centros.length; i++) {
+        const s = centros[i];
+        const rad = RADIO_COPA * s.esc;
+        const d = Math.hypot(wx - s.pos[0], wz - s.pos[2]);
+        sombra = Math.max(sombra, smoothstep(rad * 1.15, rad * 0.35, d));
+      }
+      if (sombra > 0) {
+        c.lerp(cMantillo, sombra * 0.8);
+        c.lerp(cMantillo2, sombra * sombra * 0.5);
+      }
+      // la zanjilla de drenaje, húmeda y oscura, curveando por el frente
+      const enZanja =
+        smoothstep(1.2, 0.25, Math.abs(wx - zanjaEnX(wz))) *
+        smoothstep(1.5, 4.5, wz) *
+        smoothstep(16.5, 13.0, wz);
+      c.lerp(cZanja, enZanja * 0.85);
+      // el caminito seco que sube a la casa
+      c.lerp(cCamino, smoothstep(1.15, 0, Math.abs(wx - caminoEnX(wz))) * smoothstep(-13, -2, wz) * 0.9);
+    },
+  });
+}
+
+/* La casa campesina con su patio de cosecha: paredes encaladas, techo de teja,
+   canastos y costales de aguacate esperando. Vive PEGADA al criollo gigante —
+   la comparación de siluetas ES la lección de escala. */
+function CasaPatio({ pos }) {
+  return (
+    <group position={pos} rotation={[0, -2.35, 0]}>
+      {/* la casa: LA casa campesina de la paleta madre (la misma del valle) */}
+      <mesh position={[0, 0.72, 0]}>
+        <boxGeometry args={[2.6, 1.44, 1.9]} />
+        <meshLambertMaterial color={CASA.encalado} flatShading />
+      </mesh>
+      <mesh position={[0, 0.18, 0]}>
+        <boxGeometry args={[2.64, 0.36, 1.94]} />
+        <meshLambertMaterial color={CASA.zocalo} flatShading />
+      </mesh>
+      {/* la puerta y una ventana (la carpintería pintada) */}
+      <mesh position={[0.5, 0.62, 0.96]}>
+        <boxGeometry args={[0.44, 0.95, 0.06]} />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
+      </mesh>
+      <mesh position={[-0.6, 0.86, 0.96]}>
+        <boxGeometry args={[0.5, 0.44, 0.06]} />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
+      </mesh>
+      {/* techo a dos aguas de teja */}
+      <mesh position={[0, 1.62, -0.62]} rotation={[-0.62, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.5]} />
+        <meshLambertMaterial color={CASA.tejaSombra} flatShading />
+      </mesh>
+      <mesh position={[0, 1.62, 0.62]} rotation={[0.62, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.5]} />
+        <meshLambertMaterial color={CASA.teja} flatShading />
+      </mesh>
+
+      {/* el patio de cosecha: canastos con Hass morado-negro y el costal */}
+      {[[-1.85, 0.7], [-1.4, 1.05]].map((q, i) => (
+        <group key={`c${i}`} position={[q[0], 0, q[1]]}>
+          <mesh position={[0, 0.18, 0]}>
+            <cylinderGeometry args={[0.24, 0.17, 0.36, 9, 1, true]} />
+            <meshLambertMaterial color={CASA.bejuco} flatShading side={THREE.DoubleSide} />
+          </mesh>
+          <mesh position={[0, 0.36, 0]} scale={[1, 0.45, 1]}>
+            <sphereGeometry args={[0.2, 8, 5]} />
+            <meshLambertMaterial color={i % 2 ? '#2c1c26' : '#3f2b3a'} flatShading />
+          </mesh>
+        </group>
+      ))}
+      <mesh position={[-1.15, 0.3, 0.35]} rotation={[0, 0.5, 0]} scale={[1, 1.25, 1]}>
+        <cylinderGeometry args={[0.22, 0.26, 0.5, 7, 1]} />
+        <meshLambertMaterial color={TIERRAS.vega} flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/*
+ * La ESCALERA de cosecha recostada al criollo del patio: dos largueros y sus
+ * peldaños, apuntando a la copa. Es la seña campesina de la escala — a una
+ * mata de café no se le arrima escalera; a ESTE árbol sí.
+ */
+function EscaleraCosecha() {
+  const trunco = SITIOS_CRIOLLO[0];
+  const yBase = alturaFinca(trunco[0] + 0.95, trunco[1] + 1.1);
+  const base = [trunco[0] + 0.95, yBase, trunco[1] + 1.1];
+  // apuntar el larguero hacia el tronco (rotY mira a la mata, rotX la recuesta)
+  const rotY = Math.atan2(trunco[0] - base[0], trunco[1] - base[2]);
+  const tilt = 0.42;
+  return (
+    <group position={base} rotation={[0, rotY, 0]}>
+      <group rotation={[tilt, 0, 0]}>
+        {[-0.24, 0.24].map((x) => (
+          <mesh key={x} position={[x, 1.85, 0]}>
+            <boxGeometry args={[0.07, 3.7, 0.07]} />
+            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.4)} flatShading />
+          </mesh>
+        ))}
+        {[0.45, 0.95, 1.45, 1.95, 2.45, 2.95, 3.4].map((y) => (
+          <mesh key={y} position={[0, y, 0]}>
+            <boxGeometry args={[0.52, 0.055, 0.055]} />
+            <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+          </mesh>
+        ))}
+      </group>
+      {/* el canasto del cosechero, al pie de la escalera */}
+      <group position={[0.55, 0, 0.3]}>
+        <mesh position={[0, 0.16, 0]}>
+          <cylinderGeometry args={[0.22, 0.16, 0.32, 9, 1, true]} />
+          <meshLambertMaterial color={CASA.bejuco} flatShading side={THREE.DoubleSide} />
+        </mesh>
+        <mesh position={[0, 0.32, 0]} scale={[1, 0.42, 1]}>
+          <sphereGeometry args={[0.18, 8, 5]} />
+          <meshLambertMaterial color="#79a13f" flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* El anillo del paso didáctico: respira sobre el punto que la lección señala.
+   Con reducedMotion queda quieto (presencia sin parpadeo). */
+function FocoPaso({ foco, reducedMotion }) {
+  const anillo = useRef(null);
+  useFrame(({ clock }) => {
+    const m = anillo.current;
+    if (!m) return;
+    if (reducedMotion) {
+      m.material.opacity = 0.42;
+      return;
+    }
+    const t = clock.elapsedTime;
+    m.material.opacity = 0.3 + 0.2 * Math.sin(t * 1.8);
+    m.scale.setScalar(1 + 0.06 * Math.sin(t * 1.8));
+  });
+  if (!foco) return null;
+  return (
+    <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+      <ringGeometry args={[1.25, 1.65, 32]} />
+      <meshBasicMaterial
+        color={LUCES.candela}
+        transparent
+        opacity={0.4}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+/* La fauna del templado que la floración y la sombra traen: los SVG
+   rubber-hose de la casa como billboards. El colibrí ronda un árbol
+   FLORECIDO (ahí está el néctar); las mariposas, lo abierto. */
+const FAUNA_AGUACATAL = [
+  { tipo: 'colibri', base: [-4.0, 3.8, -6.2], patron: 'revoloteo', size: 30, fase: 0.6, df: 10 },
+  { tipo: 'mariposa', base: [-1.2, 2.1, 3.4], patron: 'revoloteo', size: 26, fase: 1.8, df: 9 },
+  { tipo: 'mariposa', base: [7.0, 2.5, -1.8], patron: 'revoloteo', size: 22, fase: 2.9, df: 9 },
+];
+
+function Diorama({ tier, reducedMotion, foco }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = aguacatalDeTier(tier);
+
+  /* La atmósfera VIVA del kit — alimenta el domo y la perspectiva aérea. */
+  const atm = useAtmosferaMundo({ familia: FAMILIA_AGUACATAL, reducedMotion });
+
+  /* EL gradiente de bandas de la escena (toma B): terreno y montes comparten
+     los mismos escalones de luz — ilustración en movimiento. */
+  const bandas = useGradienteBandas();
+
+  /* Los centros de copa del tier: pintan el microclima en el terreno. */
+  const centros = useMemo(() => centrosCopa(conteos), [conteos]);
+
+  const geoFinca = useMemo(
+    () => construirFinca(perfil.segmentosTerreno, perfil.flatShading, centros),
+    [perfil.segmentosTerreno, perfil.flatShading, centros],
+  );
+
+  /* Las montañas del fondo, comidas por la niebla DE LA HORA. */
+  const montes = useMemo(
+    () => ({
+      cerca: mezclar(VERDES.monte, atm.niebla, 0.2),
+      media: mezclar(VERDES.monte, atm.niebla, 0.28),
+      lejos: mezclar(VERDES.monte, atm.niebla, 0.38),
+    }),
+    [atm.niebla],
+  );
+
+  const fauna = useMemo(
+    () => (tier === 'alto' ? FAUNA_AGUACATAL : FAUNA_AGUACATAL.slice(0, 2)),
+    [tier],
+  );
+
+  const controls = useRef(null);
+  const casaY = alturaFinca(SITIO_CASA[0], SITIO_CASA[1]);
+
+  return (
+    <>
+      {/* LA ATMÓSFERA DEL KIT: fondo, niebla, luces y estrellas de LA HORA DEL
+          VALLE (familia ladera), con el shadow-map de las copas en gama alta. */}
+      <AtmosferaMundo
+        familia={FAMILIA_AGUACATAL}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        radio={RADIO_AGUACATAL}
+        conSuelo={false}
+        sombra={SOMBRA_AGUACATAL}
+      />
+
+      {/* El DOMO de la toma B: gradiente cenit→horizonte + glow del sol. */}
+      <DomoCielo atm={atm} radio={64} />
+
+      {/* LA FINCA por bandas (recibe la sombra de las copas en gama alta). */}
+      <mesh geometry={geoFinca} receiveShadow={perfil.sombras}>
+        <meshToonMaterial vertexColors gradientMap={bandas} />
+      </mesh>
+
+      {/* las montañas templadas del fondo, comidas por la niebla de la hora */}
+      <mesh position={[-14, 2.4, -22]} scale={[9.5, 4.6, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.media} gradientMap={bandas} />
+      </mesh>
+      <mesh position={[8, 2.8, -25]} scale={[11, 5.6, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.lejos} gradientMap={bandas} />
+      </mesh>
+      <mesh position={[21, 1.8, -20]} scale={[8, 3.6, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.cerca} gradientMap={bandas} />
+      </mesh>
+
+      {/* EL AGUACATAL: los árboles grandes, frutos, panículas, jóvenes, maíz,
+          el plateo del envés, la luz colada y las abejas. */}
+      <FloraAguacatal tier={tier} reducedMotion={reducedMotion} />
+
+      {/* la casa con su patio, PEGADA al criollo gigante */}
+      <CasaPatio pos={[SITIO_CASA[0], casaY, SITIO_CASA[1]]} />
+
+      {/* la escalera de cosecha recostada al criollo: "a este árbol se le sube" */}
+      <EscaleraCosecha />
+
+      {/* LA VIDA del templado: colibrí en la floración, mariposas en lo abierto */}
+      {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
+
+      {/* el anillo del paso didáctico (lo maneja el host) */}
+      <FocoPaso foco={foco} reducedMotion={reducedMotion} />
+
+      <OrbitControls
+        ref={controls}
+        makeDefault
+        target={[0, 3.0, -3]}
+        enablePan={false}
+        enableZoom
+        minDistance={7}
+        maxDistance={26}
+        minPolarAngle={0.5}
+        maxPolarAngle={1.48}
+        minAzimuthAngle={-1.15}
+        maxAzimuthAngle={1.15}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.12}
+      />
+      {/* La LLEGADA del kit: dolly de establishing BAJO, con la mirada apenas
+          alzada — entrar a la finca es que las copas le hagan techo a uno. */}
+      <CamaraDirector
+        controls={controls}
+        reposo={[2.2, 4.0, 15.2]}
+        mirada={[0, 3.6, -3]}
+        respiro={0.04}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="mundoAguacatal"
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * El mundo del aguacate. Montar SOLO perezosa (lazy).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, foco?: number[]|null}} props
+ */
+export default function EscenaAguacatalVivo({ tier = 'alto', reducedMotion = false, foco = null }) {
+  const perfil = perfilDeTier(tier);
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`aguacatal-canvas${listo ? ' aguacatal-canvas--lista' : ''}`}
+      dpr={perfil.dpr}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      shadows={perfil.sombras ? 'soft' : false}
+      camera={{ position: [2.2, 4.0, 15.2], fov: 47 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Diorama tier={tier} reducedMotion={reducedMotion} foco={foco} />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/aguacatal/FloraAguacatal.jsx
+++ b/src/visual/mundo3d/aguacatal/FloraAguacatal.jsx
@@ -1,0 +1,371 @@
+/*
+ * FloraAguacatal — la FINCA AGUACATERA sembrada en su ladera.
+ *
+ * Consume `floraAguacatal.geom.js`: cada especie es UN InstancedMesh de una
+ * geometría fusionada (una draw-call por especie, por más árboles que haya) —
+ * mismo contrato tier-safe que FloraCafetal. Los FRUTOS llevan color POR
+ * INSTANCIA: un solo InstancedMesh cuenta el Hass verde → morado → morado-negro
+ * y otro el criollo liso en sus verdes.
+ *
+ * Lo VIVO de esta capa (lo que hace árbol al árbol):
+ *   · El PLATEO del envés — la hoja del aguacate es oscura por el haz y pálida
+ *     por debajo; cuando una ráfaga la voltea, la copa "platea". Un puñado de
+ *     quads pálidos por árbol que suben y bajan de opacidad EN RÁFAGAS
+ *     desfasadas: el viento recorre la finca, no parpadea parejo. Gratis y es
+ *     lo que vuelve vivo el verde oscuro.
+ *   · La LUZ COLADA bajo las copas (solo 'alto'): dapples dorados respirando
+ *     sobre la hojarasca — el microclima de la sombra, visible.
+ *   · Las ABEJAS de la floración (solo 'alto'): puntitos ámbar orbitando las
+ *     panículas de los árboles florecidos. El aguacate florece por miles y ahí
+ *     zumba la polinización — la imagen que nadie dibuja.
+ *
+ * `reducedMotion` deja todo QUIETO (presencia sin parpadeo).
+ * Componente r3f: montar dentro del <Canvas> de EscenaAguacatalVivo.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import {
+  aguacatalDeTier,
+  calidadAguacatal,
+  distribucionAguacatal,
+  centrosCopa,
+  alturaFinca,
+  RADIO_COPA,
+  geomAguacate,
+  geomAguacateJoven,
+  geomFrutoHass,
+  geomFrutoCriollo,
+  geomPanicula,
+  geomMaiz,
+  geomHojarasca,
+  geomPiedra,
+  geomPlateo,
+  ALZA_CRIOLLO,
+} from './floraAguacatal.geom.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* Un banco de matas de UNA especie: una geometría, un material, N instancias.
+   (El molde de la casa — mismo patrón que FloraCafetal/FloraParamo.) */
+function Especie({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+    />
+  );
+}
+
+/*
+ * El PLATEO del envés: un mesh de quads pálidos por árbol cuya opacidad sube
+ * en RÁFAGAS desfasadas — el viento voltea las hojas y la copa platea. Un
+ * material propio por árbol (13–15 draw-calls chiquitas, mismo costo-clase que
+ * la luz colada). Con reducedMotion queda un asomo fijo, sin parpadeo.
+ */
+function PlateoEnves({ centros, reducedMotion }) {
+  const grupo = useRef(null);
+
+  const arboles = useMemo(() => {
+    const r = rng(53);
+    const geoHass = geomPlateo(9, 1);
+    const geoCriollo = geomPlateo(9, ALZA_CRIOLLO);
+    return {
+      geoHass,
+      geoCriollo,
+      items: centros.map((c) => ({
+        pos: c.pos,
+        esc: c.esc,
+        alza: c.alza,
+        rotY: r() * Math.PI * 2,
+        fase: r() * Math.PI * 2,
+        vel: 0.38 + r() * 0.2, // cada árbol con su ritmo de ráfaga
+      })),
+    };
+  }, [centros]);
+
+  useLayoutEffect(
+    () => () => {
+      arboles.geoHass.dispose();
+      arboles.geoCriollo.dispose();
+    },
+    [arboles],
+  );
+
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (reducedMotion || !g) return;
+    const t = clock.elapsedTime;
+    for (let i = 0; i < g.children.length; i++) {
+      const d = arboles.items[i];
+      // la ráfaga: casi siempre abajo, y cada tanto un pico que platea
+      const gusto = Math.sin(t * d.vel + d.fase) + Math.sin(t * d.vel * 2.7 + d.fase * 1.7) * 0.35;
+      g.children[i].material.opacity = Math.max(0, gusto - 0.82) * 0.85;
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {arboles.items.map((d, i) => (
+        <mesh
+          key={i}
+          geometry={d.alza > 1 ? arboles.geoCriollo : arboles.geoHass}
+          position={d.pos}
+          rotation={[0, d.rotY, 0]}
+          scale={d.esc}
+        >
+          <meshBasicMaterial
+            color="#cdd9ab"
+            transparent
+            opacity={reducedMotion ? 0.14 : 0}
+            depthWrite={false}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/*
+ * La LUZ COLADA bajo las copas: discos dorados aditivos que respiran sobre la
+ * hojarasca — el sol moviéndose entre las hojas del árbol grande. Solo 'alto';
+ * con reducedMotion quedan quietos.
+ */
+function LuzColada({ centros, reducedMotion }) {
+  const grupo = useRef(null);
+  const manchas = useMemo(() => {
+    const r = rng(97);
+    const lista = [];
+    centros.forEach((c) => {
+      const n = 3 + Math.floor(r() * 3);
+      for (let i = 0; i < n; i++) {
+        const x = c.pos[0] + (r() - 0.5) * RADIO_COPA * c.esc * 1.5;
+        const z = c.pos[2] + (r() - 0.5) * RADIO_COPA * c.esc * 1.5;
+        lista.push({
+          pos: /** @type {[number, number, number]} */ ([x, alturaFinca(x, z) + 0.05, z]),
+          r: 0.4 + r() * 0.6,
+          fase: r() * Math.PI * 2,
+          op: 0.08 + r() * 0.06,
+        });
+      }
+    });
+    return lista;
+  }, [centros]);
+
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (reducedMotion || !g) return;
+    const t = clock.elapsedTime;
+    for (let i = 0; i < g.children.length; i++) {
+      const m = g.children[i];
+      const d = manchas[i];
+      m.material.opacity = d.op * (0.55 + 0.45 * Math.sin(t * 0.7 + d.fase));
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {manchas.map((d, i) => (
+        <mesh key={i} position={d.pos} rotation={[-Math.PI / 2, 0, 0]}>
+          <circleGeometry args={[d.r, 14]} />
+          <meshBasicMaterial
+            color="#ffe9b8"
+            transparent
+            opacity={d.op}
+            depthWrite={false}
+            blending={THREE.AdditiveBlending}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/*
+ * Las ABEJAS de la floración: puntitos ámbar orbitando la copa alta de los
+ * árboles FLORECIDOS (donde la distribución asoma las panículas). Pocas, en
+ * enjambre flojo — se leen como zumbido, no como mosquero. Solo 'alto'; con
+ * reducedMotion quedan posadas quietas.
+ */
+function AbejasFloracion({ centros, reducedMotion }) {
+  const grupo = useRef(null);
+  const bees = useMemo(() => {
+    const r = rng(61);
+    const lista = [];
+    centros.slice(0, 3).forEach((c) => {
+      const n = 5;
+      for (let i = 0; i < n; i++) {
+        lista.push({
+          centro: [
+            c.pos[0],
+            c.pos[1] + (3.1 + r() * 0.9) * c.esc * c.alza,
+            c.pos[2],
+          ],
+          rad: (0.9 + r() * 0.9) * c.esc,
+          vel: 1.6 + r() * 1.3,
+          fase: r() * Math.PI * 2,
+          vy: 0.1 + r() * 0.16,
+        });
+      }
+    });
+    return lista;
+  }, [centros]);
+
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (!g || reducedMotion) return;
+    const t = clock.elapsedTime;
+    for (let i = 0; i < g.children.length; i++) {
+      const b = bees[i];
+      const m = g.children[i];
+      m.position.set(
+        b.centro[0] + Math.cos(t * b.vel + b.fase) * b.rad,
+        b.centro[1] + Math.sin(t * b.vel * 2.3 + b.fase) * b.vy,
+        b.centro[2] + Math.sin(t * b.vel + b.fase) * b.rad * 0.8,
+      );
+    }
+  });
+
+  if (!bees.length) return null;
+  return (
+    <group ref={grupo}>
+      {bees.map((b, i) => (
+        <mesh
+          key={i}
+          position={[b.centro[0] + Math.cos(b.fase) * b.rad, b.centro[1], b.centro[2] + Math.sin(b.fase) * b.rad * 0.8]}
+        >
+          <icosahedronGeometry args={[0.05, 0]} />
+          <meshBasicMaterial color="#d9a13b" />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/**
+ * La capa viva del aguacatal. Montar dentro del <Canvas>.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function FloraAguacatal({ tier = 'alto', reducedMotion = false }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = aguacatalDeTier(tier);
+  const q = calidadAguacatal(tier);
+
+  // Geometrías fusionadas (una vez por tier).
+  const geos = useMemo(
+    () => ({
+      hass: geomAguacate({ q }, 21),
+      criollo: geomAguacate({ q, criollo: true }, 31),
+      joven: conteos.joven ? geomAguacateJoven({ q }, 41) : null,
+      frutoHass: geomFrutoHass(),
+      frutoCriollo: geomFrutoCriollo(),
+      panicula: conteos.panicula ? geomPanicula(27) : null,
+      maiz: conteos.maiz ? geomMaiz({ q }, 24) : null,
+      hojarasca: conteos.hojarasca ? geomHojarasca(25) : null,
+      piedra: conteos.piedra ? geomPiedra(26) : null,
+    }),
+    [conteos, q],
+  );
+
+  // Material único con vertexColors (el color viene horneado por especie y el
+  // tinte por instancia lo multiplica — en los frutos el tinte ES el color).
+  const mat = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.85, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  // El material con CUERO DE FRUTA (roughness bajo): el brillo de la cáscara.
+  // Solo en gama con material rico; en la frugal se reusa el material único.
+  const matLustre = useMemo(() => {
+    if (!perfil.materialRico) return mat;
+    return new THREE.MeshStandardMaterial({
+      vertexColors: true,
+      flatShading: perfil.flatShading,
+      roughness: 0.42,
+      metalness: 0,
+    });
+  }, [perfil.materialRico, perfil.flatShading, mat]);
+
+  // Distribución determinista (una vez por tier).
+  const dist = useMemo(() => distribucionAguacatal(conteos, 411, q), [conteos, q]);
+  const centros = useMemo(() => centrosCopa(conteos), [conteos]);
+  const florecidos = useMemo(() => centros.filter((c) => c.florecido), [centros]);
+
+  // Liberar GPU al desmontar.
+  useLayoutEffect(
+    () => () => {
+      Object.values(geos).forEach((g) => g && g.dispose());
+      mat.dispose();
+      if (matLustre !== mat) matLustre.dispose();
+    },
+    [geos, mat, matLustre],
+  );
+
+  const sombra = perfil.sombras; // solo los árboles grandes proyectan, en 'alto'
+
+  return (
+    <group>
+      {/* El suelo del microclima: hojarasca gruesa bajo las copas, piedras. */}
+      <Especie geo={geos.hojarasca} mat={mat} items={dist.hojarasca} />
+      <Especie geo={geos.piedra} mat={mat} items={dist.piedra} />
+
+      {/* LOS ÁRBOLES GRANDES: el lote de Hass en sus camellones y los criollos
+          de patio — la copa densa que le pasa por encima a la casa. */}
+      <Especie geo={geos.hass} mat={mat} items={dist.itemsHass} castShadow={sombra} />
+      <Especie geo={geos.criollo} mat={mat} items={dist.itemsCriollo} castShadow={sombra} />
+
+      {/* Los frutos: Hass rugoso (verde→morado→negro por instancia) colgando
+          del pedúnculo, y el criollo liso y verde — el contraste que enseña. */}
+      <Especie geo={geos.frutoHass} mat={matLustre} items={dist.frutoHass} />
+      <Especie geo={geos.frutoCriollo} mat={matLustre} items={dist.frutoCriollo} />
+
+      {/* La floración en panícula, amarillo-verdosa, al borde alto de la copa. */}
+      <Especie geo={geos.panicula} mat={matLustre} items={dist.panicula} />
+
+      {/* El lote nuevo: los jóvenes con su tutor, junto a la zanjilla. */}
+      <Especie geo={geos.joven} mat={mat} items={dist.joven} />
+
+      {/* El maíz asociado de la casa. */}
+      <Especie geo={geos.maiz} mat={mat} items={dist.maiz} />
+
+      {/* El envés que platea con la ráfaga — el árbol vivo. */}
+      <PlateoEnves centros={centros} reducedMotion={reducedMotion} />
+
+      {/* La luz que se cuela y las abejas de la floración (solo gama alta). */}
+      {tier === 'alto' && <LuzColada centros={centros} reducedMotion={reducedMotion} />}
+      {tier === 'alto' && <AbejasFloracion centros={florecidos} reducedMotion={reducedMotion} />}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/aguacatal/MundoAguacatal.jsx
+++ b/src/visual/mundo3d/aguacatal/MundoAguacatal.jsx
@@ -1,0 +1,107 @@
+/*
+ * MundoAguacatal — el MUNDO DEL AGUACATE completo: la finca navegable + la lección.
+ *
+ * Mismo contrato de host que MundoCafetal: acepta `{tier, reducedMotion}` (o
+ * auto-detecta con decidirTier si se monta suelto), llena a su padre y guarda
+ * su estado local. Sobre la escena viven los PASOS: cuatro lecciones cortas
+ * que recorren lo que este mundo enseña — la ESCALA del árbol, la floración
+ * en panícula con sus abejas, el fruto Hass contra el criollo, y la raíz
+ * superficial con su camellón, su tutor y su zanjilla — y cada paso señala SU
+ * lugar en la finca con un anillo que respira (el `foco` que la escena
+ * dibuja). Copy en español de Colombia, en "usted".
+ *
+ * Importa three/@react-three (vía la escena) → montar SOLO perezoso (lazy).
+ */
+import { useMemo, useState } from 'react';
+import EscenaAguacatalVivo from './EscenaAguacatalVivo.jsx';
+import PanelPasos from '../PanelPasos.jsx';
+import { decidirTier, permite3D } from '../deviceTier.js';
+import { alturaFinca, SITIOS_CRIOLLO, SITIOS_HASS, SITIOS_JOVEN } from './floraAguacatal.geom.js';
+
+/* Los cuatro pasos de la lección. Cada `foco` es el punto de la finca que el
+   anillo señala mientras se lee (coordenadas del mundo, sobre el terreno). */
+const enSuelo = (x, z) => [x, alturaFinca(x, z), z];
+const PASOS = [
+  {
+    id: 'escala',
+    kicker: 'Paso 1 de 4 · El árbol grande',
+    texto:
+      'Mire la casa y mire el árbol del patio: el aguacate NO es una mata, es un ÁRBOL. Un Hass adulto pasa de los 8 metros y el criollo viejo, sembrado de semilla, más todavía. Por eso la escalera recostada: a este árbol se le sube. Párese debajo y la copa le hace techo.',
+    foco: enSuelo(SITIOS_CRIOLLO[0][0], SITIOS_CRIOLLO[0][1]),
+  },
+  {
+    id: 'floracion',
+    kicker: 'Paso 2 de 4 · La flor y las abejas',
+    texto:
+      'El aguacate florece en PANÍCULAS: racimos de miles de flores pequeñas, amarillo-verdosas. De miles, cuajan poquitas — y las que cuajan es porque las abejas hicieron su trabajo. Donde ve el borde de la copa pintado de amarillo, acérquese: ahí está el zumbido.',
+    foco: enSuelo(SITIOS_HASS[1][0], SITIOS_HASS[1][1]),
+  },
+  {
+    id: 'fruto',
+    kicker: 'Paso 3 de 4 · Hass rugoso, criollo liso',
+    texto:
+      'El fruto cuelga de su pedúnculo, en racimos flojos. El Hass se conoce por la cáscara RUGOSA que pinta de verde a morado-negro cuando madura. El criollo del patio es otra cosa: más grande, de cáscara LISA y verde aunque esté maduro. Aprenda a distinguirlos: valen distinto y se venden distinto.',
+    foco: enSuelo(SITIOS_HASS[0][0], SITIOS_HASS[0][1]),
+  },
+  {
+    id: 'raiz',
+    kicker: 'Paso 4 de 4 · La raíz superficial',
+    texto:
+      'La raíz del aguacate es SUPERFICIAL: no ancla hondo y se ahoga encharcada. Por eso cada árbol va sembrado en su CAMELLÓN, el joven lleva su tutor contra el viento, y la zanjilla saca el agua sobrada. Y fíjese en el suelo bajo la copa: hojarasca gruesa, fresco, casi sin pasto — esa sombra es un microclima que abona solo.',
+    foco: enSuelo(SITIOS_JOVEN[0][0], SITIOS_JOVEN[0][1]),
+  },
+];
+
+const CSS = `
+.maguacatal { position: relative; width: 100%; height: 100%; overflow: hidden; background: #cfdcc6; }
+.maguacatal canvas { opacity: 0; transition: opacity 0.9s ease; }
+.maguacatal .aguacatal-canvas--lista canvas, .maguacatal canvas.aguacatal-canvas--lista { opacity: 1; }
+@media (prefers-reduced-motion: reduce) {
+  .maguacatal canvas { transition: none; }
+}
+`;
+
+/* Acento del aguacatal para el panel compartido: verde hoja profundo con el
+   morado Hass de acento — nunca pardo apagado. */
+const TEMA_PANEL = {
+  fondo: 'rgba(15, 24, 13, 0.7)',
+  borde: 'rgba(163, 196, 118, 0.3)',
+  tinta: '#eef3e0',
+  kicker: '#b9d078',
+  acentoA: 'rgba(140, 178, 74, 0.95)',
+  acentoB: 'rgba(97, 58, 84, 0.95)',
+  tintaAccion: '#0f1906',
+  activo: '#a8c855',
+};
+
+/**
+ * El mundo del aguacate, completo: escena + pasos didácticos.
+ * Montar SOLO perezoso (lazy); llena a su contenedor.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function MundoAguacatal({ tier: tierProp, reducedMotion: rmProp } = {}) {
+  // Contrato de mundos: props del host si llegan; si se monta suelto,
+  // auto-detección del equipo (no matar la gama baja).
+  const auto = useMemo(() => decidirTier(), []);
+  const tier = tierProp ?? (permite3D(auto.tier) ? auto.tier : 'bajo');
+  const reducedMotion = rmProp ?? auto.reducedMotion;
+  const [paso, setPaso] = useState(0);
+
+  const actual = PASOS[paso];
+
+  return (
+    <div className="maguacatal">
+      <style>{CSS}</style>
+      <EscenaAguacatalVivo tier={tier} reducedMotion={reducedMotion} foco={actual.foco} />
+
+      <PanelPasos
+        etiqueta="La lección del aguacatal"
+        pasos={PASOS}
+        paso={paso}
+        onPaso={setPaso}
+        tema={TEMA_PANEL}
+        reducedMotion={reducedMotion}
+      />
+    </div>
+  );
+}

--- a/src/visual/mundo3d/aguacatal/floraAguacatal.geom.js
+++ b/src/visual/mundo3d/aguacatal/floraAguacatal.geom.js
@@ -1,0 +1,828 @@
+/*
+ * floraAguacatal.geom — la GEOMETRÍA del MUNDO DEL AGUACATE (piso templado
+ * alto, 1.800–2.200 m: la franja del Hass en la montaña andina).
+ *
+ * El aguacate NO es un arbusto de era: es un ÁRBOL GRANDE, y esa escala es la
+ * lección entera de este mundo. Un Hass adulto injertado llega a 8–10 m — le
+ * pasa por encima a la casa — y el criollo viejo del patio, sembrado de
+ * semilla, todavía más. Aquí cada especie se cuenta como es:
+ *
+ *   · Aguacate Hass adulto      — tronco corto y grueso que abre en ramas
+ *                                 maestras, copa DENSA de hoja perenne verde
+ *                                 muy oscuro (casi negra en sombra), más ancha
+ *                                 que la casa y el doble de alta. Sembrado en
+ *                                 CAMELLÓN (el montículo que salva su raíz
+ *                                 superficial del encharcamiento).
+ *   · Aguacate criollo de patio — el árbol de la casa, de semilla y de años:
+ *                                 aún más alto, de copa elevada. Contra su
+ *                                 tronco vive la ESCALERA de cosecha (la pone
+ *                                 la escena): a ese árbol se le sube.
+ *   · Fruto Hass                — piriforme y RUGOSO (facetado a propósito),
+ *                                 colgando del PEDÚNCULO en racimos flojos.
+ *                                 INSTANCIADO con color por instancia: verde →
+ *                                 morado → morado-negro al madurar.
+ *   · Fruto criollo             — más grande, cáscara LISA (malla suave) y
+ *                                 verde brillante aun maduro: el contraste que
+ *                                 enseña a distinguirlos.
+ *   · Panícula de floración     — el aguacate florece en racimos de MILES de
+ *                                 flores pequeñas amarillo-verdosas; aquí son
+ *                                 motas pálidas al borde alto de la copa (las
+ *                                 abejas las pone la capa viva).
+ *   · Aguacate joven con TUTOR  — recién sembrado en su camellón, amarrado a
+ *                                 la estaca: la raíz superficial no ancla y el
+ *                                 viento lo tumba. El tutor ES la lección.
+ *   · Maíz asociado             — la finca campesina no es monocultivo: junto
+ *                                 a la casa, el manchón de maíz acompañando.
+ *   · Hojarasca gruesa + piedra — bajo la copa densa casi no entra sol: queda
+ *                                 el mantillo fresco, la cama del microclima.
+ *
+ * TÉCNICA tier-safe (mismo contrato que floraCafetal.geom): cada especie se
+ * FUSIONA en UNA geometría con color horneado en vertexColors y se dibuja con
+ * UN InstancedMesh → una draw-call por especie. Los FRUTOS van pintados
+ * BLANCOS para que el color POR INSTANCIA (setColorAt) sea el color real de la
+ * cáscara — un solo InstancedMesh lleva verdes, pintones y morado-negros.
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO si se mezclan geometrías
+ * indexadas con no-indexadas (mordida conocida, 3 veces): aquí TODO se
+ * desindexa antes de fusionar y se TRUENA si aun así falla.
+ *
+ * Aquí viven SOLO los datos y las mallas (nada de WebGL): corre headless.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* -------------------------------------------------------------------------- */
+/*  La finca aguacatera (la geografía del mundo, determinista)                 */
+/* -------------------------------------------------------------------------- */
+
+export const ANCHO = 40; // x: -20 … 20
+export const FONDO = 38; // z: -19 (la loma, arriba) … 19 (el frente, abajo)
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+
+/* Ruido determinista (hash de senos): misma finca siempre, sin Math.random. */
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
+    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
+    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
+  );
+}
+
+/* La ZANJILLA de drenaje: el corte a media ladera que saca el agua del lote
+   nuevo — la raíz superficial del aguacate se AHOGA encharcada, y esta zanja
+   es la defensa campesina. Corre curveada por el frente; se exporta el trazo
+   para que el terreno la pinte húmeda y los pasos la señalen. */
+export const zanjaEnX = (wz) => 4.6 + Math.sin(wz * 0.55 + 1.2) * 1.4;
+const hondoZanja = (wx, wz) => {
+  const enFrente = smoothstep(1.5, 4.5, wz) * smoothstep(16.5, 13.0, wz);
+  const dx = Math.abs(wx - zanjaEnX(wz));
+  return smoothstep(1.1, 0.2, dx) * 0.16 * enFrente;
+};
+
+/** La altura de la finca en un punto: media ladera suave (el aguacate quiere
+    pendiente que drene, no risco) que gana altura hacia el fondo. */
+export function alturaFinca(wx, wz) {
+  const sub = smoothstep(8, -17, wz); // 0 al frente (bajo), 1 al fondo (la loma)
+  let h = 0.12;
+  h += sub * 3.6; // la ladera templada, más tendida que la cafetera
+  h += ruido(wx * 0.5, wz * 0.5) * 0.3 * (0.35 + sub); // ondulación natural
+  h -= hondoZanja(wx, wz); // la zanjilla de drenaje tallada
+  return h;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Presupuesto por tier                                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Instancias por especie. 'alto' puebla la finca plena; 'medio' es frugal;
+ * 'bajo' deja lo mínimo para que AÚN se lea "finca de árboles grandes". Los
+ * frutos son conteos de InstancedMesh repartidos entre los árboles cargados.
+ */
+export const FLORA_AGUACATAL = {
+  alto: { hass: 13, criollo: 2, joven: 4, frutoHass: 110, frutoCriollo: 26, panicula: 46, maiz: 12, hojarasca: 18, piedra: 6 },
+  medio: { hass: 9, criollo: 1, joven: 3, frutoHass: 60, frutoCriollo: 14, panicula: 22, maiz: 7, hojarasca: 10, piedra: 4 },
+  bajo: { hass: 5, criollo: 1, joven: 2, frutoHass: 26, frutoCriollo: 8, panicula: 0, maiz: 4, hojarasca: 5, piedra: 2 },
+};
+
+/** Conteos para un tier (desconocido → frugal, nunca el más caro). */
+export const aguacatalDeTier = (tier) => FLORA_AGUACATAL[tier] || FLORA_AGUACATAL.medio;
+
+/** Factor de detalle geométrico por tier (menos masas/hojas en gama baja). */
+export const CALIDAD_AGUACATAL = { alto: 1, medio: 0.62, bajo: 0.42 };
+export const calidadAguacatal = (tier) => CALIDAD_AGUACATAL[tier] ?? CALIDAD_AGUACATAL.medio;
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del aguacatal (colores horneados en vertexColors)                   */
+/* -------------------------------------------------------------------------- */
+
+export const PAL = {
+  // El árbol
+  corteza: '#6a5844', // tronco gris-pardo del aguacate
+  rama: '#77644c', // las ramas maestras que abren la copa
+  copaSombra: '#1d3f24', // la copa perenne, verde MUY oscuro (la firma)
+  copaOscura: '#152e1a', // el faldón de abajo, casi negro: el techo de sombra
+  copaSol: '#2f5c2f', // la cara que da al sol
+  copaBrillo: '#3d7038', // los remates altos donde pega la luz
+  enves: '#93a873', // el envés pálido de la hoja (asoma horneado a motas)
+
+  // Fruto (referencia — el color real va POR INSTANCIA):
+  frutoVerde: '#5b7c36',
+  frutoMorado: '#503046',
+  frutoNegro: '#251722', // el Hass maduro, morado-negro
+  criolloVerde: '#79a13f', // el criollo, liso y verde aun maduro
+  criolloClaro: '#8fb54a',
+  pedunculo: '#8a7a4f', // el rabito del que cuelga
+
+  // Floración en panícula (amarillo-verdosa, nunca blanca de azahar)
+  panicula: '#d3d488',
+  paniculaCentro: '#c2cc6e',
+
+  // Siembra: camellón, tutor y amarre
+  camellon: '#8a5636', // la tierra del montículo (arcilla andina)
+  camellonSeco: '#9a6a42',
+  tutor: '#8a6f4d', // la estaca del joven
+  amarre: '#c9b593', // la cabuya del amarre
+
+  // Maíz asociado
+  maizTallo: '#9fae62',
+  maizHoja: '#7fb04a',
+  maizHojaSol: '#98c258',
+  mazorca: '#e2c04c',
+
+  // Suelo del microclima
+  hojarasca: '#6f5530', // la hoja gruesa del aguacate, cama parda
+  hojarasca2: '#5e4728', // la capa húmeda de abajo
+  piedra: '#8b8578',
+  liquen: '#a3a878',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Utilidades (fusión desindexada + colocación + color horneado)              */
+/* -------------------------------------------------------------------------- */
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+/** Hornea un color plano en TODOS los vértices (atributo `color`). */
+function pintar(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Coloca una geometría (posición/rotación/escala) transformando vértices. */
+function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/** Orienta el +Y de la geometría hacia `dir` y la ubica en `pos`. */
+function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    q,
+    new THREE.Vector3(esc[0], esc[1], esc[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/**
+ * Fusiona partes (ya coloreadas) en UNA geometría. Se DESINDEXA todo antes de
+ * fusionar y se TRUENA si falla: mejor un error de build que una especie
+ * invisible en producción (mordida conocida de mergeGeometries).
+ */
+function fusionar(partes) {
+  const buenas = partes.filter(Boolean).map((p) => {
+    const plana = p.index ? p.toNonIndexed() : p;
+    if (plana !== p) p.dispose();
+    return plana;
+  });
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error('floraAguacatal: mergeGeometries devolvió null — atributos incompatibles entre partes');
+  }
+  return g;
+}
+
+/** Pequeña variación determinista de color (que la copa no sea plana). */
+function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  AGUACATE — el árbol grande (Persea americana)                              */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La ARQUITECTURA de la copa, compartida entre la malla y la distribución:
+ * masas de follaje alrededor del eje. Se EXPORTA para que frutos, panículas y
+ * el plateo del envés se siembren SOBRE la misma copa que la geometría dibuja
+ * (nunca fruto flotando fuera del follaje). Coordenadas LOCALES de un árbol de
+ * escala 1: la copa densa arranca en y≈2.2 y remata en y≈4.9 — con la casa de
+ * ~2.3 de alto, el árbol de escala 1 ya la dobla.
+ *
+ * `borde`: las masas del CONTORNO BAJO donde cuelga el fruto (el aguacate
+ * carga hacia afuera de la copa, donde hubo flor y llega la luz).
+ */
+export const MASAS_COPA = [
+  { p: [0, 3.15, 0], s: 1.55, borde: false }, // el corazón denso
+  { p: [1.2, 2.75, 0.35], s: 1.02, borde: true },
+  { p: [-1.1, 2.9, -0.5], s: 1.06, borde: true },
+  { p: [0.45, 2.6, -1.2], s: 0.96, borde: true },
+  { p: [-0.55, 2.7, 1.15], s: 1.0, borde: true },
+  { p: [0.8, 3.9, 0.55], s: 0.94, borde: false },
+  { p: [-0.85, 3.85, -0.35], s: 0.9, borde: false },
+  { p: [0.1, 4.4, -0.15], s: 0.84, borde: false }, // el remate alto
+];
+
+/** Cuántas masas de copa dibuja (y carga) cada tier. */
+export const masasDeQ = (q) => (q < 0.5 ? 5 : q < 0.85 ? 7 : MASAS_COPA.length);
+
+/* El estiramiento vertical del criollo de patio: de semilla y de años, más
+   alto y de copa más elevada que el Hass injertado. */
+export const ALZA_CRIOLLO = 1.14;
+
+/*
+ * El árbol adulto. `criollo` cambia el porte: más alto, copa más recogida y
+ * elevada, SIN camellón (el del patio se sembró hace treinta años); el Hass
+ * lleva su montículo de tierra — la siembra en camellón que salva la raíz
+ * superficial del encharcamiento.
+ */
+export function geomAguacate({ q = 1, criollo = false } = {}, seed = 1) {
+  const r = rng(seed);
+  const partes = [];
+  const alza = criollo ? ALZA_CRIOLLO : 1;
+
+  // El camellón del Hass: el montículo donde va sembrado (la lección de la
+  // raíz superficial, visible en CADA árbol del lote).
+  if (!criollo) {
+    const monte = new THREE.CylinderGeometry(0.62, 1.05, 0.34, 9, 1);
+    poner(monte, [0, 0.13, 0]);
+    partes.push(pintar(monte, PAL.camellon));
+    const monteSeco = new THREE.CylinderGeometry(0.5, 0.7, 0.1, 9, 1);
+    poner(monteSeco, [0, 0.32, 0]);
+    partes.push(pintar(monteSeco, PAL.camellonSeco));
+  }
+
+  // Tronco corto y grueso que abre pronto en ramas maestras (porte real del
+  // aguacate: no es palo recto de eucalipto, es candelabro ancho).
+  const hTronco = 1.5 * alza;
+  const tronco = new THREE.CylinderGeometry(0.13, 0.22, hTronco, 7, 1);
+  poner(tronco, [0, hTronco * 0.5 + (criollo ? 0 : 0.24), 0]);
+  partes.push(pintar(tronco, PAL.corteza));
+
+  const nRamas = Math.max(3, Math.round(5 * q));
+  for (let i = 0; i < nRamas; i++) {
+    const a = (i / nRamas) * Math.PI * 2 + r() * 0.6;
+    const abre = 0.55 + r() * 0.35; // cuánto abre la rama maestra
+    const rama = new THREE.CylinderGeometry(0.05, 0.1, 1.6 * alza, 5, 1);
+    apuntar(
+      rama,
+      [Math.cos(a) * 0.62, (1.95 + r() * 0.3) * alza, Math.sin(a) * 0.62],
+      [Math.cos(a) * abre, 1, Math.sin(a) * abre],
+    );
+    partes.push(pintar(rama, PAL.rama));
+  }
+
+  // LA COPA: densa, perenne, verde muy oscuro — el techo que domina el
+  // paisaje. Masas de la tabla compartida; abajo más oscuras (la sombra
+  // interior), arriba los remates al sol.
+  const nMasas = masasDeQ(q);
+  for (let i = 0; i < nMasas; i++) {
+    const m = MASAS_COPA[i];
+    const alta = m.p[1] > 3.5;
+    const base = i === 0 ? PAL.copaSombra : alta ? (i % 2 ? PAL.copaBrillo : PAL.copaSol) : i % 2 ? PAL.copaSol : PAL.copaSombra;
+    const masa = new THREE.IcosahedronGeometry(m.s, 1);
+    poner(
+      masa,
+      [m.p[0], m.p[1] * alza + (r() - 0.5) * 0.12, m.p[2]],
+      [0, r() * Math.PI, 0],
+      [1.35 * (criollo ? 0.92 : 1), 0.95, 1.35 * (criollo ? 0.92 : 1)],
+    );
+    partes.push(pintar(masa, variar(base, r, 0.05)));
+  }
+
+  // El FALDÓN de abajo: dos masas casi negras cerrando la copa por debajo —
+  // desde el suelo, pararse bajo el árbol es ver este techo oscuro.
+  for (let i = 0; i < 2; i++) {
+    const a = i * 2.6 + 0.8;
+    const faldon = new THREE.IcosahedronGeometry(0.95, 1);
+    poner(
+      faldon,
+      [Math.cos(a) * 0.55, 2.25 * alza, Math.sin(a) * 0.55],
+      [0, r() * Math.PI, 0],
+      [1.5, 0.6, 1.5],
+    );
+    partes.push(pintar(faldon, variar(PAL.copaOscura, r, 0.04)));
+  }
+
+  // Motas de ENVÉS pálido asomando en el contorno: la hoja del aguacate es
+  // verde oscuro por el haz y pálida por debajo — cuando el viento la voltea,
+  // el árbol "platea" (el brillo vivo lo anima la capa viva; esto es el
+  // asomo quieto que lo hace verdad también en pausa).
+  const nEnves = Math.max(2, Math.round(4 * q));
+  for (let i = 0; i < nEnves; i++) {
+    const m = MASAS_COPA[1 + Math.floor(r() * Math.min(nMasas - 1, 6))];
+    const a = r() * Math.PI * 2;
+    const mota = new THREE.SphereGeometry(1, 4, 2);
+    poner(
+      mota,
+      [m.p[0] + Math.cos(a) * m.s * 1.15, m.p[1] * alza + (r() - 0.3) * 0.5, m.p[2] + Math.sin(a) * m.s * 1.15],
+      [r() * 0.5, r() * Math.PI, r() * 0.5],
+      [0.3, 0.06, 0.2],
+    );
+    partes.push(pintar(mota, variar(PAL.enves, r, 0.05)));
+  }
+
+  return fusionar(partes);
+}
+
+/*
+ * El AGUACATE JOVEN con su TUTOR: recién sembrado en el lote nuevo del frente.
+ * Camellón + arbolito de copa rala + la estaca con su amarre. La raíz
+ * superficial no ancla al viento: sin tutor se tumba — la estaca ES la lección.
+ */
+export function geomAguacateJoven({ q = 1 } = {}, seed = 8) {
+  const r = rng(seed);
+  const partes = [];
+
+  const monte = new THREE.CylinderGeometry(0.42, 0.78, 0.3, 9, 1);
+  poner(monte, [0, 0.12, 0]);
+  partes.push(pintar(monte, PAL.camellon));
+
+  const tronco = new THREE.CylinderGeometry(0.035, 0.06, 1.05, 5, 1);
+  poner(tronco, [0, 0.72, 0], [0.05, 0, 0.04]);
+  partes.push(pintar(tronco, PAL.corteza));
+
+  const nMasas = Math.max(2, Math.round(3 * q));
+  for (let i = 0; i < nMasas; i++) {
+    const a = i * 2.4 + 0.6;
+    const rad = i === 0 ? 0 : 0.28 + r() * 0.14;
+    const masa = new THREE.IcosahedronGeometry(0.34 + r() * 0.12, 1);
+    poner(
+      masa,
+      [Math.cos(a) * rad, 1.35 + i * 0.22, Math.sin(a) * rad],
+      [0, r() * Math.PI, 0],
+      [1.2, 0.9, 1.2],
+    );
+    partes.push(pintar(masa, variar(i % 2 ? PAL.copaSol : PAL.copaSombra, r, 0.06)));
+  }
+
+  // El TUTOR: la estaca clavada al lado, con el amarre de cabuya.
+  const estaca = new THREE.CylinderGeometry(0.028, 0.036, 1.45, 4, 1);
+  poner(estaca, [0.24, 0.82, 0.1], [0, 0, -0.06]);
+  partes.push(pintar(estaca, PAL.tutor));
+  const amarre = new THREE.CylinderGeometry(0.075, 0.075, 0.06, 6, 1, true);
+  poner(amarre, [0.12, 1.02, 0.05], [0.2, 0, 1.45]);
+  partes.push(pintar(amarre, PAL.amarre));
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  FRUTOS — el Hass rugoso vs el criollo liso                                 */
+/* -------------------------------------------------------------------------- */
+
+/** El fruto Hass: piriforme y RUGOSO (dodecaedro facetado + cuello), colgando
+    de su PEDÚNCULO. Pintado blanco — el color real (verde→morado→negro) va
+    POR INSTANCIA. El pedúnculo sí lleva su pardo fijo. */
+export function geomFrutoHass() {
+  const partes = [];
+  const cuerpo = new THREE.DodecahedronGeometry(0.1, 0); // facetas = cáscara rugosa
+  poner(cuerpo, [0, -0.06, 0], [0.35, 0.4, 0.2], [0.92, 1.28, 0.92]);
+  partes.push(pintar(cuerpo, '#ffffff'));
+  const cuello = new THREE.DodecahedronGeometry(0.06, 0);
+  poner(cuello, [0, 0.06, 0], [0.8, 0.2, 0.5], [0.95, 1.1, 0.95]);
+  partes.push(pintar(cuello, '#ffffff'));
+  const ped = new THREE.CylinderGeometry(0.011, 0.014, 0.16, 4, 1);
+  poner(ped, [0, 0.18, 0]);
+  partes.push(pintar(ped, PAL.pedunculo));
+  return fusionar(partes);
+}
+
+/** El fruto criollo: más grande, de cuello marcado y cáscara LISA (malla
+    suave), verde brillante aun maduro. Pintado blanco; tinte por instancia en
+    la gama de verdes. */
+export function geomFrutoCriollo() {
+  const partes = [];
+  const cuerpo = new THREE.IcosahedronGeometry(0.115, 1); // detalle 1 = liso
+  poner(cuerpo, [0, -0.08, 0], [0, 0, 0], [0.95, 1.2, 0.95]);
+  partes.push(pintar(cuerpo, '#ffffff'));
+  const cuello = new THREE.IcosahedronGeometry(0.07, 1);
+  poner(cuello, [0, 0.08, 0], [0, 0, 0], [0.85, 1.25, 0.85]);
+  partes.push(pintar(cuello, '#ffffff'));
+  const ped = new THREE.CylinderGeometry(0.012, 0.016, 0.18, 4, 1);
+  poner(ped, [0, 0.24, 0]);
+  partes.push(pintar(ped, PAL.pedunculo));
+  return fusionar(partes);
+}
+
+/** La PANÍCULA de floración: el racimo terminal de flores diminutas
+    amarillo-verdosas (miles en el árbol real; aquí motas legibles de lejos). */
+export function geomPanicula(seed = 7) {
+  const r = rng(seed);
+  const partes = [];
+  const tallo = new THREE.CylinderGeometry(0.012, 0.018, 0.22, 4, 1);
+  poner(tallo, [0, 0.1, 0], [0.15, 0, 0.1]);
+  partes.push(pintar(tallo, PAL.paniculaCentro));
+  for (let i = 0; i < 5; i++) {
+    const a = (i / 5) * Math.PI * 2 + r();
+    const rad = i === 0 ? 0 : 0.06 + r() * 0.05;
+    const mota = new THREE.IcosahedronGeometry(0.045 + r() * 0.02, 0);
+    poner(
+      mota,
+      [Math.cos(a) * rad, 0.2 + r() * 0.08, Math.sin(a) * rad],
+      [r() * 0.6, r() * Math.PI, r() * 0.6],
+      [1.2, 0.85, 1.2],
+    );
+    partes.push(pintar(mota, variar(i % 2 ? PAL.panicula : PAL.paniculaCentro, r, 0.06)));
+  }
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  MAÍZ asociado — la finca no es monocultivo                                 */
+/* -------------------------------------------------------------------------- */
+
+export function geomMaiz({ q = 1 } = {}, seed = 4) {
+  const r = rng(seed);
+  const partes = [];
+  const tallo = new THREE.CylinderGeometry(0.024, 0.04, 1.7, 5, 1);
+  poner(tallo, [0, 0.85, 0], [0.03, 0, 0.05]);
+  partes.push(pintar(tallo, PAL.maizTallo));
+  const nHojas = Math.max(4, Math.round(6 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const a = i * 2.4 + r() * 0.4;
+    const y = 0.4 + (i / nHojas) * 1.05;
+    const hoja = new THREE.SphereGeometry(1, 5, 3);
+    apuntar(
+      hoja,
+      [Math.cos(a) * 0.16, y, Math.sin(a) * 0.16],
+      [Math.cos(a), 0.55 - (i / nHojas) * 0.25, Math.sin(a)],
+      [0.05, 0.5, 0.12],
+    );
+    partes.push(pintar(hoja, variar(i % 2 ? PAL.maizHojaSol : PAL.maizHoja, r, 0.06)));
+  }
+  // La mazorca asomando con su amarillo (acento a cucharadas).
+  const maz = new THREE.IcosahedronGeometry(0.07, 0);
+  poner(maz, [0.1, 0.95, 0.05], [0, 0, -0.5], [0.8, 1.7, 0.8]);
+  partes.push(pintar(maz, PAL.mazorca));
+  const espiga = new THREE.CylinderGeometry(0.008, 0.02, 0.3, 4, 1);
+  poner(espiga, [0, 1.82, 0]);
+  partes.push(pintar(espiga, variar(PAL.maizTallo, r, 0.1)));
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Suelo del microclima: hojarasca gruesa y piedra                            */
+/* -------------------------------------------------------------------------- */
+
+export function geomHojarasca(seed = 5) {
+  const r = rng(seed);
+  const partes = [];
+  for (let i = 0; i < 3; i++) {
+    const mancha = new THREE.CylinderGeometry(0.36 + r() * 0.34, 0.46 + r() * 0.36, 0.04, 7, 1);
+    poner(mancha, [(r() - 0.5) * 0.55, 0.02 + i * 0.013, (r() - 0.5) * 0.55], [0, r() * Math.PI, 0]);
+    partes.push(pintar(mancha, i % 2 ? PAL.hojarasca2 : PAL.hojarasca));
+  }
+  return fusionar(partes);
+}
+
+export function geomPiedra(seed = 6) {
+  const r = rng(seed);
+  const roca = new THREE.DodecahedronGeometry(0.3, 0);
+  poner(roca, [0, 0.13, 0], [r() * 0.6, r() * Math.PI, r() * 0.6], [1.25, 0.7, 1]);
+  const capa = new THREE.DodecahedronGeometry(0.17, 0);
+  poner(capa, [0.11, 0.22, 0.05], [0, r() * Math.PI, 0], [1, 0.55, 1]);
+  return fusionar([pintar(roca, PAL.piedra), pintar(capa, PAL.liquen)]);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  El PLATEO del envés (geometría para la capa viva)                          */
+/* -------------------------------------------------------------------------- */
+
+/** Quads de "hojas volteadas" repartidos por el contorno de la copa, en
+    coordenadas LOCALES del árbol (escala 1). La capa viva pone UNO de estos
+    por árbol y le anima la opacidad a ráfagas: el viento voltea la hoja y el
+    árbol platea. SIN color de vértice: el material pálido lo pone la escena. */
+export function geomPlateo(seed = 9, alza = 1) {
+  const r = rng(seed);
+  const partes = [];
+  for (let i = 0; i < 7; i++) {
+    const m = MASAS_COPA[1 + Math.floor(r() * (MASAS_COPA.length - 1))];
+    const a = r() * Math.PI * 2;
+    const quad = new THREE.PlaneGeometry(0.5 + r() * 0.25, 0.3 + r() * 0.15);
+    poner(
+      quad,
+      [m.p[0] + Math.cos(a) * m.s * 1.2, m.p[1] * alza + (r() - 0.35) * m.s, m.p[2] + Math.sin(a) * m.s * 1.2],
+      [(r() - 0.5) * 1.2, r() * Math.PI * 2, (r() - 0.5) * 0.8],
+    );
+    partes.push(quad);
+  }
+  const g = mergeGeometries(partes.map((p) => (p.index ? p.toNonIndexed() : p)), false);
+  if (!g) throw new Error('floraAguacatal: geomPlateo — mergeGeometries devolvió null');
+  return g;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Distribución: finca campesina, nunca cuadrícula                            */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Los árboles viven FIJOS en la finca (posiciones compuestas a mano): matorros
+ * IRREGULARES de dos y tres, distancias desiguales — un lote campesino que fue
+ * creciendo con los años, no una plantación de plantilla. El ORDEN importa: se
+ * recorta por tier con slice, así que las primeras posiciones reparten el
+ * campo entero para que hasta 'bajo' lea "finca de árboles grandes".
+ */
+export const SITIOS_HASS = [
+  [2.6, -3.8], // el Hass grande del centro (cerca del camino: uno SE PARA debajo)
+  [-4.2, -6.8], [12.6, -4.6], [-8.6, -2.2], [-1.6, 1.4],
+  [-12.4, -7.8], [-6.4, 4.2], [3.8, -8.4], [-14.8, 0.6],
+  [-10.2, -12.0], [8.2, 1.2], [-2.8, -12.6], [15.2, -9.0],
+];
+
+/* El criollo de PATIO junto a la casa (el primero: el que sale en todo tier) y
+   el segundo criollo viejo del lindero, para gama alta. */
+export const SITIOS_CRIOLLO = [
+  [5.6, -10.4],
+  [-17.2, -5.4],
+];
+
+/* El lote NUEVO del frente: los jóvenes con tutor, cerca de la zanjilla que
+   los defiende del encharcamiento (la lección completa en un vistazo). */
+export const SITIOS_JOVEN = [
+  [1.2, 6.4], [-5.2, 8.6], [6.8, 7.6], [-10.8, 6.2],
+];
+
+/* El manchón de maíz asociado, pegado a la casa. */
+const CENTRO_MAIZ = [13.6, -12.2];
+
+/* La casa campesina (la escena pone la malla; la siembra la respeta). */
+export const SITIO_CASA = /** @type {[number, number]} */ ([9.2, -9.8]);
+
+/* Radio de copa aproximado en el suelo (para pintar la sombra/mantillo y
+   sembrar la hojarasca): árbol de escala 1 → copa de ~2.1 de radio. */
+export const RADIO_COPA = 2.1;
+
+/** ¿Qué tan cargado/maduro va el lote? Los árboles de abajo (más viejos en
+    esta finca) cargan más maduro; jitter determinista por árbol. */
+function madurezEn(wz, r) {
+  const base = smoothstep(-14, 2.5, wz);
+  return clamp(base + (r() - 0.5) * 0.4, 0, 1);
+}
+
+/**
+ * Siembra determinista de la finca completa. Devuelve items por especie:
+ * `{pos, rotY, escala, tint}` (contrato del componente `Especie`); en los
+ * FRUTOS el `tint` ES el color de la cáscara (Hass verde→morado→negro;
+ * criollo en verdes). `q` fija cuántas masas de copa dibuja el tier — y por
+ * tanto de cuáles masas pueden colgar frutos y asomar panículas.
+ */
+export function distribucionAguacatal(conteos, seed = 411, q = 1) {
+  const c = conteos;
+  const rArb = rng(seed + 1);
+  const rFru = rng(seed + 2);
+  const rSue = rng(seed + 3);
+  const rFlo = rng(seed + 5);
+  const nMasas = masasDeQ(q);
+
+  // --- Los adultos: Hass en sus sitios (con jitter corto) y los criollos. ---
+  const hass = SITIOS_HASS.slice(0, c.hass).map((p, i) => ({
+    px: p[0] + (rArb() - 0.5) * 0.5,
+    pz: p[1] + (rArb() - 0.5) * 0.5,
+    esc: i === 0 ? 1.16 : 0.82 + rArb() * 0.28, // el del centro, el mayor del lote
+    rotY: rArb() * Math.PI * 2,
+    florecido: i % 3 === 1, // un tercio en floración: panícula + abejas
+    carga: i % 3 !== 1 ? 0.5 + rArb() * 0.5 : 0.15, // el florecido casi no carga
+  }));
+  const criollo = SITIOS_CRIOLLO.slice(0, c.criollo).map((p, i) => ({
+    px: p[0],
+    pz: p[1],
+    esc: i === 0 ? 1.18 : 1.05, // el de la casa: el árbol MAYOR del mundo
+    rotY: rArb() * Math.PI * 2,
+  }));
+
+  const items = (lista) =>
+    lista.map((s) => ({
+      pos: [s.px, alturaFinca(s.px, s.pz), s.pz],
+      rotY: s.rotY,
+      escala: s.esc,
+      tint: [0.93 + rArb() * 0.14, 0.93 + rArb() * 0.14, 0.93 + rArb() * 0.14],
+    }));
+
+  // --- Los frutos Hass: RACIMOS FLOJOS de 2–4 colgando del borde bajo de la
+  //     copa (las masas `borde` de la tabla), con el pedúnculo a la vista.
+  //     Color por instancia: verde → morado → morado-negro al madurar. ---
+  const verde = new THREE.Color(PAL.frutoVerde);
+  const morado = new THREE.Color(PAL.frutoMorado);
+  const negro = new THREE.Color(PAL.frutoNegro);
+  const col = new THREE.Color();
+  const frutoHass = [];
+  const cargados = hass.filter((s) => s.carga > 0.3);
+  const bordes = MASAS_COPA.slice(0, nMasas).filter((m) => m.borde);
+  /* Un punto local de la copa (masa m, ángulo a, descuelgue dy) al mundo. */
+  const enCopa = (s, m, a, radMul, dy, rr, alza = 1) => {
+    const lx = m.p[0] + Math.cos(a) * m.s * radMul + (rr() - 0.5) * 0.1;
+    const ly = m.p[1] * alza + dy + (rr() - 0.5) * 0.08;
+    const lz = m.p[2] + Math.sin(a) * m.s * radMul + (rr() - 0.5) * 0.1;
+    const cosR = Math.cos(s.rotY);
+    const sinR = Math.sin(s.rotY);
+    return [
+      s.px + (lx * cosR + lz * sinR) * s.esc,
+      alturaFinca(s.px, s.pz) + ly * s.esc,
+      s.pz + (-lx * sinR + lz * cosR) * s.esc,
+    ];
+  };
+  let gi = 0;
+  while (frutoHass.length < c.frutoHass && cargados.length > 0 && bordes.length > 0) {
+    const s = cargados[gi % cargados.length];
+    gi += 1;
+    if (gi > cargados.length * 14) break;
+    const m = bordes[Math.floor(rFru() * bordes.length)];
+    const a0 = rFru() * Math.PI * 2;
+    const madre = madurezEn(s.pz, rFru); // la madurez de la mata
+    const cuantas = 2 + Math.floor(rFru() * 3); // el racimo FLOJO del aguacate
+    for (let k = 0; k < cuantas && frutoHass.length < c.frutoHass; k++) {
+      const a = a0 + (rFru() - 0.5) * 0.55;
+      const dy = -0.62 - rFru() * 0.3; // colgado BAJO el follaje, pedúnculo visible
+      const mz = clamp(madre + (rFru() - 0.5) * 0.5, 0, 1);
+      if (mz < 0.55) col.lerpColors(verde, morado, mz / 0.55);
+      else col.lerpColors(morado, negro, (mz - 0.55) / 0.45);
+      col.multiplyScalar(0.94 + rFru() * 0.12);
+      frutoHass.push({
+        pos: enCopa(s, m, a, 1.02, dy, rFru),
+        rotY: rFru() * Math.PI * 2,
+        escala: (0.85 + rFru() * 0.35) * s.esc,
+        tint: [col.r, col.g, col.b],
+      });
+    }
+  }
+
+  // --- Los frutos del criollo: menos, más grandes, verdes aun maduros. ---
+  const cVerde = new THREE.Color(PAL.criolloVerde);
+  const cClaro = new THREE.Color(PAL.criolloClaro);
+  const frutoCriollo = [];
+  let ci = 0;
+  while (frutoCriollo.length < c.frutoCriollo && criollo.length > 0 && bordes.length > 0) {
+    const s = criollo[ci % criollo.length];
+    ci += 1;
+    if (ci > 40) break;
+    const m = bordes[Math.floor(rFru() * bordes.length)];
+    const a0 = rFru() * Math.PI * 2;
+    const cuantas = 2 + Math.floor(rFru() * 2);
+    for (let k = 0; k < cuantas && frutoCriollo.length < c.frutoCriollo; k++) {
+      const a = a0 + (rFru() - 0.5) * 0.5;
+      col.lerpColors(cVerde, cClaro, rFru());
+      col.multiplyScalar(0.95 + rFru() * 0.1);
+      frutoCriollo.push({
+        pos: enCopa(s, m, a, 1.02, -0.7 - rFru() * 0.3, rFru, ALZA_CRIOLLO),
+        rotY: rFru() * Math.PI * 2,
+        escala: 0.9 + rFru() * 0.3,
+        tint: [col.r, col.g, col.b],
+      });
+    }
+  }
+
+  // --- Las panículas: en los Hass florecidos y en el criollo de patio (los
+  //     criollos florecen a mares), asomadas al borde ALTO de la copa. ---
+  const panicula = [];
+  const florecidos = [
+    ...hass.filter((s) => s.florecido).map((s) => ({ s, alza: 1 })),
+    ...criollo.slice(0, 1).map((s) => ({ s, alza: ALZA_CRIOLLO })),
+  ];
+  const masasAltas = MASAS_COPA.slice(0, nMasas).filter((m) => m.p[1] > 2.6);
+  let fi = 0;
+  while (panicula.length < (c.panicula || 0) && florecidos.length > 0 && masasAltas.length > 0) {
+    const { s, alza } = florecidos[fi % florecidos.length];
+    fi += 1;
+    if (fi > florecidos.length * 20) break;
+    const m = masasAltas[Math.floor(rFlo() * masasAltas.length)];
+    const a = rFlo() * Math.PI * 2;
+    panicula.push({
+      pos: enCopa(s, m, a, 1.12, 0.15, rFlo, alza),
+      rotY: rFlo() * Math.PI * 2,
+      escala: (0.9 + rFlo() * 0.5) * s.esc,
+      tint: [1, 1 - rFlo() * 0.04, 0.92 - rFlo() * 0.05],
+    });
+  }
+
+  // --- Los jóvenes con tutor, en el lote nuevo del frente. ---
+  const joven = SITIOS_JOVEN.slice(0, c.joven).map((p) => ({
+    pos: [p[0], alturaFinca(p[0], p[1]), p[1]],
+    rotY: rArb() * Math.PI * 2,
+    escala: 0.85 + rArb() * 0.3,
+    tint: [0.94 + rArb() * 0.12, 0.94 + rArb() * 0.12, 0.94 + rArb() * 0.12],
+  }));
+
+  // --- El maíz asociado, en su manchón pegado a la casa (nunca surco). ---
+  const maiz = [];
+  for (let i = 0; i < c.maiz; i++) {
+    const a = rSue() * Math.PI * 2;
+    const rad = Math.sqrt(rSue()) * 2.6;
+    const x = CENTRO_MAIZ[0] + Math.cos(a) * rad;
+    const z = CENTRO_MAIZ[1] + Math.sin(a) * rad * 0.7;
+    maiz.push({
+      pos: [x, alturaFinca(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.8 + rSue() * 0.4,
+      tint: [0.93 + rSue() * 0.14, 0.93 + rSue() * 0.14, 0.93 + rSue() * 0.14],
+    });
+  }
+
+  // --- La hojarasca GRUESA bajo las copas (el microclima) y las piedras. ---
+  const bajoCopa = [
+    ...hass.map((s) => [s.px, s.pz, s.esc]),
+    ...criollo.map((s) => [s.px, s.pz, s.esc]),
+  ];
+  const hojarasca = [];
+  for (let i = 0; i < c.hojarasca; i++) {
+    const s = bajoCopa[i % Math.max(1, bajoCopa.length)] || [0, -6, 1];
+    const a = rSue() * Math.PI * 2;
+    const rad = rSue() * RADIO_COPA * s[2] * 0.8;
+    const x = s[0] + Math.cos(a) * rad;
+    const z = s[1] + Math.sin(a) * rad;
+    hojarasca.push({
+      pos: [x, alturaFinca(x, z) + 0.01, z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.8 + rSue() * 0.7,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+  const piedra = [];
+  for (let i = 0; i < c.piedra; i++) {
+    const x = -17 + rSue() * 34;
+    const z = -15 + rSue() * 30;
+    piedra.push({
+      pos: [x, alturaFinca(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.7 + rSue() * 0.9,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+
+  return {
+    hass,
+    criollo,
+    itemsHass: items(hass),
+    itemsCriollo: items(criollo),
+    frutoHass,
+    frutoCriollo,
+    panicula,
+    joven,
+    maiz,
+    hojarasca,
+    piedra,
+  };
+}
+
+/** Los centros de copa del tier con su escala (para la luz colada, el plateo
+    del envés y las abejas de la capa viva): `{pos:[x,ySuelo,z], esc, alza,
+    florecido}` — misma siembra determinista que la distribución. */
+export function centrosCopa(conteos, seed = 411) {
+  const r = rng(seed + 1);
+  const centros = [];
+  for (let i = 0; i < Math.min(conteos.hass, SITIOS_HASS.length); i++) {
+    const p = SITIOS_HASS[i];
+    const px = p[0] + (r() - 0.5) * 0.5;
+    const pz = p[1] + (r() - 0.5) * 0.5;
+    const esc = i === 0 ? 1.16 : 0.82 + r() * 0.28;
+    r(); // rotY (mantener el hilo del rng en fase con la distribución)
+    if (i % 3 !== 1) r(); // carga (solo los no-florecidos la consumen allá)
+    centros.push({ pos: [px, alturaFinca(px, pz), pz], esc, alza: 1, florecido: i % 3 === 1 });
+  }
+  for (let i = 0; i < Math.min(conteos.criollo, SITIOS_CRIOLLO.length); i++) {
+    const p = SITIOS_CRIOLLO[i];
+    r(); // rotY
+    centros.push({
+      pos: [p[0], alturaFinca(p[0], p[1]), p[1]],
+      esc: i === 0 ? 1.18 : 1.05,
+      alza: ALZA_CRIOLLO,
+      florecido: i === 0, // el criollo de patio florece a mares
+    });
+  }
+  return centros;
+}


### PR DESCRIPTION
## El mundo del aguacate (mundo nuevo)

Piso templado alto (1.800–2.200 m, la franja andina del Hass). **La escala es el argumento**: el aguacate es un ÁRBOL GRANDE, no un arbustico — y la escena está compuesta para hacerla sentir.

### Qué trae
- `src/visual/mundo3d/aguacatal/floraAguacatal.geom.js` — geometría headless: Hass adulto en camellón (copa densa verde muy oscuro, faldón casi negro por debajo), criollo de patio aún más alto, fruto Hass RUGOSO (facetado) colgando del pedúnculo en racimos flojos con color por instancia (verde→morado→morado-negro), fruto criollo LISO y verde (el contraste que enseña), panícula amarillo-verdosa, joven con tutor, maíz asociado, hojarasca gruesa. Fusión desindexada con throw anti-null (mordida conocida de mergeGeometries).
- `FloraAguacatal.jsx` — un InstancedMesh por especie + **el plateo del envés** (quads pálidos que suben de opacidad en ráfagas desfasadas: el viento voltea la hoja y la copa platea), luz colada bajo las copas y **abejas ámbar orbitando la floración** (solo gama alta).
- `EscenaAguacatalVivo.jsx` — atmósfera del kit (familia `ladera`, hora viva del valle), domo + bandas toon, terreno pintado con el MICROCLIMA (bajo cada copa el pasto se rinde a la hojarasca), zanjilla de drenaje tallada y húmeda, camino a la casa, **casa campesina pegada al criollo gigante** con la **escalera de cosecha recostada** (a este árbol se le sube), cámara que llega BAJA mirando apenas hacia arriba.
- `MundoAguacatal.jsx` — 4 pasos didácticos con foco: la escala · la flor y las abejas · Hass rugoso vs criollo liso · la raíz superficial (camellón, tutor, zanjilla, microclima).
- `src/mockups/AguacatalVivo3D.jsx` + `.css` — vitrina con device-tiering real y ficha 2D digna (la escala también en la ficha: árbol enorme, casita al pie).

### Qué NO trae (a propósito)
Sin cableado a rutas (App.jsx intacto — lo hace el orquestador). Sugerido: `mockups/aguacatal-vivo-3d` → `mockup_aguacatal_vivo_3d`, mismo patrón del cafetal.

### Verificación
- Smoke headless por tier (alto/medio/bajo): fusiones no-nulas y desindexadas, conteos completos, rng de centros EN FASE con la distribución, ningún fruto arrastrado por el suelo.
- eslint limpio · esbuild JSX limpio · anti-leak y anti-voseo limpios.
- Falta la CAPTURA (la hace el orquestador tras cablear): `/?ciclo=10#/mockups/aguacatal-vivo-3d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)