### PR TITLE
fix(grounding): filtrar entidades-ruido antes del prompt (ICA/SENA no son especies)

### DIFF
--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -1298,6 +1298,103 @@ describe('filterNoiseEntities', () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────────
+// R2 — siglas institucionales y meta-pregunta (fallo real canario 2026-07-20)
+// El canario preguntó "¿de dónde sale esa recomendación? Dame la fuente o la
+// entidad (ICA / SENA)..." y el resolver mapeó "ICA" → col rizada (Brassica
+// oleracea, cuya prosa cita "Fuentes Tier A: ICA Resolución 3168/2015...") y
+// "Fuente" → Pennisetum setaceum (nombre_comun "Pasto fuente"). El agente
+// construyó toda la respuesta sobre esas especies fantasma.
+// ──────────────────────────────────────────────────────────────────────────
+describe('filterNoiseEntities — siglas institucionales y meta-pregunta (canario 2026-07-20)', () => {
+  it('descarta "ICA" aunque haya resuelto a col rizada (Brassica oleracea)', () => {
+    const entities = [
+      { mentioned: 'ICA', kind: 'species', nombre_comun: 'col rizada', nombre_cientifico: 'Brassica oleracea' },
+    ];
+    expect(filterNoiseEntities(entities)).toHaveLength(0);
+  });
+
+  it('descarta "SENA" igual que "ICA"', () => {
+    const entities = [
+      { mentioned: 'SENA', kind: 'species', nombre_comun: 'algo', nombre_cientifico: 'Algo sp.' },
+    ];
+    expect(filterNoiseEntities(entities)).toHaveLength(0);
+  });
+
+  it('descarta "Fuente" aunque haya resuelto a Pennisetum setaceum ("pasto fuente")', () => {
+    const entities = [
+      { mentioned: 'Fuente', kind: 'species', nombre_comun: 'pasto fuente', nombre_cientifico: 'Pennisetum setaceum' },
+    ];
+    expect(filterNoiseEntities(entities)).toHaveLength(0);
+  });
+
+  it('descarta el resto de siglas institucionales y vocabulario de meta-pregunta', () => {
+    const ruido = [
+      'agrosavia', 'corpoica', 'mads', 'ideam', 'icontec', 'dane', 'cenicafe',
+      'fao', 'minagricultura', 'umata', 'car', 'cvc', 'invima', 'upra',
+      'fuentes', 'entidad', 'entidades', 'norma', 'normativa', 'resolucion',
+      'decreto', 'ley', 'cartilla', 'referencia', 'recomendacion',
+    ].map((m) => ({ mentioned: m, kind: 'species' }));
+    expect(filterNoiseEntities(ruido)).toHaveLength(0);
+  });
+
+  it('NO-REGRESIÓN: "pasto fuente" (mención completa de una especie real) se CONSERVA', () => {
+    const entities = [
+      { mentioned: 'pasto fuente', kind: 'species', nombre_comun: 'pasto fuente', nombre_cientifico: 'Pennisetum setaceum' },
+    ];
+    const out = filterNoiseEntities(entities);
+    expect(out).toHaveLength(1);
+    expect(out[0].mentioned).toBe('pasto fuente');
+  });
+
+  it('NO-REGRESIÓN: una especie legítima cualquiera (papa → Solanum tuberosum) se CONSERVA', () => {
+    const entities = [
+      { mentioned: 'papa', kind: 'species', nombre_comun: 'papa', nombre_cientifico: 'Solanum tuberosum' },
+    ];
+    const out = filterNoiseEntities(entities);
+    expect(out).toHaveLength(1);
+    expect(out[0].mentioned).toBe('papa');
+  });
+
+  it('en la cadena: "ICA"→col rizada NO dispara guards sobre la especie fantasma', () => {
+    const resolved = [
+      { mentioned: 'ICA', kind: 'species', nombre_comun: 'col rizada', nombre_cientifico: 'Brassica oleracea' },
+    ];
+    const txt = 'El ICA (Brassica oleracea) se cultiva bien en climas fríos.';
+    const out = applyOutputGuards(txt, { resolvedEntities: resolved });
+    expect(out.modified).toBe(false);
+  });
+
+  it('el cotejo es EXACTO y normalizado: "ICA" (mayúsculas) se filtra igual que "ica"', () => {
+    const entities = [
+      { mentioned: 'ICA', kind: 'species', nombre_comun: 'col rizada', nombre_cientifico: 'Brassica oleracea' },
+      { mentioned: 'ica', kind: 'species', nombre_comun: 'col rizada', nombre_cientifico: 'Brassica oleracea' },
+      { mentioned: 'IcA', kind: 'species', nombre_comun: 'col rizada', nombre_cientifico: 'Brassica oleracea' },
+    ];
+    expect(filterNoiseEntities(entities)).toHaveLength(0);
+  });
+
+  it('LIMITACIÓN CONOCIDA (no es un defecto a esconder): "ICA / SENA" como span largo NO se filtra', () => {
+    // El cotejo de filterNoiseEntities es sobre `mentioned` COMPLETO y
+    // normalizado contra la lista cerrada (NLU_NOISE_MENTIONS.has(...)), no
+    // substring ni tokenización interna. Si el sidecar devuelve un span largo
+    // ("ICA / SENA", la frase completa que el usuario tecleó) en vez del
+    // token institucional suelto ("ICA"), ese span NO es un elemento literal
+    // del Set → el filtro NO lo descarta. Esto es una limitación conocida y
+    // documentada del alcance de este fix, no una regresión: el fix de raíz
+    // (turno 4 del canario 2026-07-20) resolvía tokens sueltos ("ICA",
+    // "Fuente"), que sí quedan cubiertos. Si el resolver empieza a devolver
+    // spans largos con instituciones embebidas, hará falta un guard aparte
+    // (fuera de alcance de este PR).
+    const entities = [
+      { mentioned: 'ICA / SENA', kind: 'species', nombre_comun: 'col rizada', nombre_cientifico: 'Brassica oleracea' },
+    ];
+    const out = filterNoiseEntities(entities);
+    expect(out).toHaveLength(1);
+    expect(out[0].mentioned).toBe('ICA / SENA');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
 // ORQUESTADOR + telemetría
 // ──────────────────────────────────────────────────────────────────────────
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -1094,6 +1094,57 @@ describe('sidecarClient — feature flag on', () => {
   });
 });
 
+// ──────────────────────────────────────────────────────────────────────────
+// resolveEntities — filtro de entidades-ruido ANTES del prompt (canario
+// 2026-07-20): el resolver mapeó "ICA" → col rizada (Brassica oleracea) y
+// "Fuente" → Pennisetum setaceum, y el agente construyó su respuesta sobre
+// esas especies fantasma porque nada filtraba resolveEntities() antes de que
+// agentPromptBase.js las inyectara como "ENTIDADES RESUELTAS... autoritativo".
+// filterNoiseEntities (outputGuards.js) ya existía pero solo corría post-LLM
+// (applyOutputGuards). Este test cubre el cableado nuevo: filtrado en el
+// parseo mismo de /resolve-entities.
+// ──────────────────────────────────────────────────────────────────────────
+describe('sidecarClient — resolveEntities filtra entidades-ruido (canario 2026-07-20)', () => {
+  beforeEach(() => {
+    enableFlag();
+  });
+
+  it('descarta "ICA"→col rizada y "Fuente"→Pennisetum setaceum, conserva la especie real', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+      entities: [
+        { mentioned: 'ICA', kind: 'species', nombre_comun: 'col rizada', nombre_cientifico: 'Brassica oleracea' },
+        { mentioned: 'Fuente', kind: 'species', nombre_comun: 'pasto fuente', nombre_cientifico: 'Pennisetum setaceum' },
+        { mentioned: 'papa', kind: 'species', nombre_comun: 'papa', nombre_cientifico: 'Solanum tuberosum' },
+      ],
+      grounding: null,
+    }));
+    const { resolveEntities } = await importFresh();
+    const res = await resolveEntities('¿de dónde sale esa recomendación? Dame la fuente o la entidad (ICA)');
+    expect(res.entities).toHaveLength(1);
+    expect(res.entities[0].mentioned).toBe('papa');
+  });
+
+  it('NO-REGRESIÓN: "pasto fuente" (mención completa) sobrevive el filtro', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+      entities: [
+        { mentioned: 'pasto fuente', kind: 'species', nombre_comun: 'pasto fuente', nombre_cientifico: 'Pennisetum setaceum' },
+      ],
+      grounding: null,
+    }));
+    const { resolveEntities } = await importFresh();
+    const res = await resolveEntities('¿el pasto fuente es invasor?');
+    expect(res.entities).toHaveLength(1);
+    expect(res.entities[0].mentioned).toBe('pasto fuente');
+  });
+
+  it('entities vacío/ausente → sigue devolviendo [] sin romper', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { grounding: null }));
+    const { resolveEntities } = await importFresh();
+    const res = await resolveEntities('hola');
+    expect(res).toEqual({ entities: [], grounding: null });
+  });
+});
+
 describe('sidecarClient — getClimaSnapshot elevation (gradiente térmico)', () => {
   beforeEach(() => {
     enableFlag();

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -261,6 +261,29 @@ const NLU_NOISE_MENTIONS = new Set([
   'pues', 'bueno', 'oiga', 'oye', 'hombre', 'senor', 'senora',
   // genéricos vegetales sin especie concreta (solos)
   'pasto', 'monte', 'hierba', 'yerba', 'mata', 'planta', 'arbol', 'palo',
+  // FALLO REAL DEL CANARIO 2026-07-20: el usuario preguntó "¿de dónde sale esa
+  // recomendación? Dame la fuente o la entidad (ICA / SENA)..." y el resolver
+  // mapeó "ICA" → col rizada (Brassica oleracea, cuya prosa del catálogo cita
+  // "Fuentes Tier A: ICA Resolución 3168/2015...") y "Fuente" → Pennisetum
+  // setaceum (nombre_comun literal "Pasto fuente"). El agente contestó
+  // tratando ambas instituciones como especies fantasma. Siglas
+  // institucionales NUNCA son especies — las instituciones van en la columna
+  // de fuente/cita, jamás como entidad resuelta.
+  'ica', 'sena', 'agrosavia', 'corpoica', 'mads', 'ideam', 'icontec', 'dane',
+  'cenicafe', 'fao', 'minagricultura', 'umata', 'car', 'cvc', 'invima', 'upra',
+  // Vocabulario de META-PREGUNTA: cuando el usuario pide la FUENTE/norma de
+  // una recomendación no está nombrando un cultivo, aunque el resolver a
+  // veces case el token contra prosa del catálogo (ver "fuente" arriba). El
+  // cotejo es sobre `mentioned` COMPLETO y normalizado, no substring: "pasto
+  // fuente" (mención de una especie real) NO cae acá, solo "fuente" sola.
+  'fuente', 'fuentes', 'entidad', 'entidades', 'norma', 'normativa',
+  'resolucion', 'decreto', 'ley', 'cartilla', 'referencia', 'recomendacion',
+  // NOTA: se evaluaron 'ica'/'sena'/'agrosavia'/... y 'car'/'fao' (siglas
+  // cortas, mayor riesgo de colisión) contra `nombre_comun`/`nombre`/
+  // `nombres_comunes_regionales` de todo `catalog/*.json` — ninguna especie
+  // usa esas siglas como nombre común; "CAR" y "FAO" solo aparecen en
+  // catalog/*.json como valores de `autoridad`/`institucion`/`autores`
+  // (metadata de fuente), nunca como nombre de especie. Sin colisión conocida.
 ]);
 
 /**

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -37,6 +37,15 @@
 
 import { fetchWithAuthRetry } from './apiService.js';
 import { buildSidecarHeaders } from './tierService.js';
+// Fallo real del canario 2026-07-20: "ICA"/"Fuente" (mención de institución o
+// meta-pregunta) se resolvían a especies fantasma (col rizada / Pennisetum
+// setaceum) y el agente construía la respuesta sobre esa basura porque el
+// único filtro (filterNoiseEntities) corría DESPUÉS de que el LLM ya había
+// respondido (outputGuards.applyOutputGuards). Filtramos ACÁ, apenas llega la
+// respuesta del sidecar, para que ningún consumidor (prompt del LLM incluido)
+// vea entidades-ruido. outputGuards.js no importa nada (0 imports) → no hay
+// ciclo posible al importarlo desde acá.
+import { filterNoiseEntities } from './outputGuards.js';
 
 const NLU_TIMEOUT_MS = 18000;
 export const TOOL_TIMEOUT_MS = 5000;
@@ -509,7 +518,13 @@ export async function resolveEntities(userMessage, opts = {}) {
   if (!raw || typeof raw !== 'object') return null;
   const grounding = raw.grounding && typeof raw.grounding === 'object' ? raw.grounding : null;
   if (!Array.isArray(raw.entities)) return { entities: [], grounding };
-  return { entities: raw.entities, grounding };
+  // Filtramos entidades-ruido (siglas institucionales, meta-vocabulario de
+  // "dame la fuente/norma", muletillas campesinas) ANTES de devolver — así
+  // ningún consumidor (incluido el prompt del LLM en agentPromptBase.js, que
+  // las presenta como "ENTIDADES RESUELTAS... autoritativo") ve basura como
+  // verdad verificada. applyOutputGuards también filtra (idempotente y puro,
+  // aplicarlo dos veces es inofensivo) — se deja así como defensa en capas.
+  return { entities: filterNoiseEntities(raw.entities), grounding };
 }
 
 /**


### PR DESCRIPTION
## Fallo real de producción (canario nocturno, 2026-07-20)

En el turno 4 de la sesión de canario de anoche, el usuario preguntó:

> "¿De dónde sale esa recomendación? Dame la fuente o la entidad (por ejemplo ICA / SENA) para poder verificarlo. Si no la tienes, dímelo, no te la inventes."

El resolver de entidades del sidecar resolvió, para ese turno, `Pennisetum setaceum` + 3× `Brassica oleracea var. acephala` + `Passiflora edulis` — es decir, mapeó **"ICA" → col rizada (*Brassica oleracea*)** y **"Fuente" → Pennisetum setaceum**. El agente respondió tratando ambas instituciones como especies fantasma y construyó toda la respuesta sobre esa base. Se reprodujo idéntico en dev y en prod.

## Causa raíz

1. `src/services/ragRetriever.js:126-135` — el tokenizador solo filtra `t.length > 2` sin stopwords, así que `ica` (3 chars) sobrevive.
2. La prosa del catálogo (`catalog/chagra-catalog-oss-subset-v3.1.json:9504,9551`) trae citas institucionales tipo `"Fuentes Tier A: ICA Resolución 3168/2015..."` dentro de entradas de *Brassica oleracea* (79 entradas del catálogo llevan una cita `ICA Resolución…`). BM25 casa el token `ica` ahí.
3. `catalog/chagra-catalog-oss-subset-v3.2.json:2311` — `pennisetum_setaceum` tiene `nombre_comun` literal **"Pasto fuente"**, así que el token `fuente` casa exacto.
4. **El hueco principal:** ya existía el mecanismo correcto — `filterNoiseEntities` + `NLU_NOISE_MENTIONS` en `src/services/outputGuards.js` (antes de este PR, líneas 248-284) — pero su único call site era `applyOutputGuards` en `src/services/outputGuards.js:10021`, que corre **DESPUÉS de que el LLM ya respondió**. Nunca se aplicaba antes de construir el prompt.
5. `src/services/agentPromptBase.js:877-910` (línea 894 en particular) inyecta las entidades resueltas bajo el encabezado *"=== ENTIDADES RESUELTAS DEL CATÁLOGO (autoritativo, verificado en Apache AGE) ==="*, presentándole la basura al modelo como verdad verificada. Ese es el multiplicador de daño.

## Qué cambia este PR

1. **`src/services/outputGuards.js`** — amplía `NLU_NOISE_MENTIONS` con:
   - Siglas institucionales (nunca son especies): `ica`, `sena`, `agrosavia`, `corpoica`, `mads`, `ideam`, `icontec`, `dane`, `cenicafe`, `fao`, `minagricultura`, `umata`, `car`, `cvc`, `invima`, `upra`.
   - Vocabulario de meta-pregunta (el usuario pide la FUENTE, no nombra un cultivo): `fuente`, `fuentes`, `entidad`, `entidades`, `norma`, `normativa`, `resolucion`, `decreto`, `ley`, `cartilla`, `referencia`, `recomendacion`.

   Antes de agregar `car`/`fao` (siglas cortas, mayor riesgo de colisión) verifiqué con un script sobre todos los campos `nombre*` de `catalog/*.json`: ninguna especie usa esas siglas como `nombre_comun`. `CAR`/`FAO`/`ICA`/`AGROSAVIA` solo aparecen como valores de `autoridad`/`institucion`/`autores` (metadata de fuente), nunca como nombre de especie.

2. **`src/services/sidecarClient.js`** — aplica `filterNoiseEntities` dentro de `resolveEntities()`, justo al parsear la respuesta de `POST /resolve-entities`, para que **todo** consumidor (incluido el prompt del LLM vía `agentPromptBase.js`) reciba entidades ya limpias. Import directo de `outputGuards.js` (no hizo falta extraer un módulo nuevo: `outputGuards.js` tiene **cero** imports propios, por lo tanto no hay ciclo posible). `applyOutputGuards` se deja intacto — sigue filtrando post-respuesta como defensa en capas (es idempotente y puro, aplicarlo dos veces es inofensivo).

## Fuera de alcance (deliberado, mayor riesgo, van aparte)

- Stopwords en el tokenizador de `ragRetriever.js` (cambiaría el recall del RAG de forma amplia).
- El sangrado de historial en `sidecarClient.js:498-503` (bug real, pero arreglarlo puede regresionar el contexto multi-turno).
- `src/utils/entityMatcher.js`.
- `AgentScreen.jsx` (tiene warnings de eslint preexistentes y su hook pre-commit tarda ~18 min).
- El catálogo.

## Limitación conocida (documentada en test, no escondida)

El cotejo de `filterNoiseEntities` es sobre `mentioned` **completo y normalizado** contra un Set cerrado, no substring. Si el resolver del sidecar llegara a devolver un span largo ("ICA / SENA", la frase completa) en vez del token institucional suelto ("ICA"), ese span **no** se filtra — solo cubre tokens sueltos, que es exactamente lo que produjo el fallo real de anoche (turno 4). Cubierto con test explícito en `outputGuards.test.js`.

## Tests

`src/services/__tests__/outputGuards.test.js` (suite `filterNoiseEntities` existente + describe nuevo con 8 casos: ICA→col rizada, SENA, Fuente→Pennisetum setaceum, la lista completa nueva, no-regresión "pasto fuente", no-regresión "papa", cotejo exacto/normalizado mayúsculas, y la limitación conocida del span largo) y `src/services/__tests__/sidecarClient.test.js` (3 casos nuevos sobre el cableado de `resolveEntities()`).

## Verificación (salida real)

- `npx vitest run src/services/__tests__/outputGuards.test.js src/services/__tests__/sidecarClient.test.js` → **295 passed, 1 skipped, 1 failed (297 total)**. El único fallo (`reconciliación allow-list ↔ NLU (fix P0 2026-06-25): tools sin args ruteables quedan en DEFLECCIÓN HONESTA`, en `sidecarClient.test.js`) es **preexistente en `main`**: confirmado corriendo el mismo test con `git stash` (sin mis cambios) — falla idéntico. No relacionado con este cambio.
- `npx vitest run src/services/__tests__/` (suite completa) — **no se pudo completar**: la máquina de desarrollo tenía otro agente (`codex-task-worker`) corriendo en paralelo consumiendo CPU intensivamente, y varios intentos (background y foreground, hasta ~5 min cada uno) no terminaron dentro de un tiempo razonable. Se decidió no esperar indefinidamente y cerrar con la verificación acotada de arriba (los dos archivos de test directamente relacionados con el cambio, verdes salvo el fallo preexistente confirmado). Recomendado: correr la suite completa en CI o en una máquina sin contención antes de mergear, como doble chequeo.
- `npx eslint` sobre los 4 archivos tocados → limpio, sin errores ni warnings.
- Anti-leak (`git diff --cached | grep -iE 'kortux@|gmail|token|bearer|password|10\.88|alpha'`) → único hit: la palabra "token" dentro de comentarios en español referida al *tokenizador* del RAG ("el token contra prosa del catálogo", "tokenización interna", "token institucional suelto") — no es un secreto/credencial.
- Pre-commit hook (eslint) corrió normalmente, dentro del timeout — no hizo falta `--no-verify`.

🤖 Generated with [Claude Opus 4.8](https://claude.com/claude-code)