### PR TITLE
El mundo de los frutales: mango y cítricos, la lección del piso térmico

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -178,6 +178,12 @@ const CacaoVivo3DMockup = lazy(() => import('./mockups/CacaoVivo3D'));
 // blanca por instancia, la cosecha de criollas (amarilla/roja/morada) y los
 // frailejones en silueta. Device-tiering real. Ruta #/mockups/papa-viva-3d, sin auth.
 const PapaVivo3DMockup = lazy(() => import('./mockups/PapaVivo3D'));
+// 3D: el MUNDO DE LOS FRUTALES — mango y cítricos juntos, porque juntos
+// enseñan el PISO TÉRMICO: el mango es de tierra caliente y el cítrico sube al
+// clima medio. La escala relativa es la lección: el mango eclipsa al cítrico.
+// Brote de hoja vino del mango, panícula terminal, pecíolo alado y espinas del
+// cítrico. Device-tiering real. Ruta #/mockups/frutales-vivo-3d, sin auth.
+const FrutalesVivo3DMockup = lazy(() => import('./mockups/FrutalesVivo3D'));
 // 3D: el MUNDO DE LOS ESTANQUES — la piscicultura de la finca por piso térmico
 // en una sola ladera: la quebrada baja al estanque frío (trucha, agua
 // oxigenada), el caño sigue al estanque cálido (mojarra + cachama en
@@ -650,6 +656,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/invernadero-vivo-3d': 'mockup_invernadero_vivo_3d',
   'mockups/cacao-vivo-3d': 'mockup_cacao_vivo_3d',
   'mockups/papa-viva-3d': 'mockup_papa_viva_3d',
+  'mockups/frutales-vivo-3d': 'mockup_frutales_vivo_3d',
   'mockups/mundo-piscicultura-3d': 'mockup_mundo_piscicultura_3d',
   'mockups/lecheria-viva-3d': 'mockup_lecheria_viva_3d',
   'mockups/mundo3d-clima': 'mockup_mundo3d_clima',
@@ -1714,6 +1721,21 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo de la papa">
               <PapaVivo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_frutales_vivo_3d':
+        // Vitrina pública del MUNDO DE LOS FRUTALES: mango y cítricos en la
+        // misma escena en 3D REAL, porque juntos enseñan el PISO TÉRMICO — el
+        // mango es de tierra caliente y el cítrico sube al clima medio. El
+        // mango con su copa más ancha que alta, el brote de hoja color vino y
+        // la panícula terminal; el cítrico compacto, con pecíolo alado y
+        // espinas. La escala relativa ES la lección. En equipo humilde muestra
+        // la ficha. Ruta #/mockups/frutales-vivo-3d.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo de los frutales">
+              <FrutalesVivo3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/FrutalesVivo3D.css
+++ b/src/mockups/FrutalesVivo3D.css
@@ -1,0 +1,282 @@
+/*
+ * FrutalesVivo3D.css — vitrina del mundo de los frutales
+ * (#/mockups/frutales-vivo-3d). Autocontenida: sin fuentes/imágenes externas.
+ * Móvil-first desde 320px. La paleta la levanta LA FRUTA: el amarillo del mango
+ * de azúcar y el naranja del cítrico sobre el verde de tierra caliente — este
+ * mundo NO puede quedar pardo. Solo opacity/transform se animan.
+ */
+
+.fviva {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  /* la luz abierta de tierra caliente (familia plaza), no bruma de montaña */
+  background: linear-gradient(180deg, #e6e4c2 0%, #efe4c4 46%, #f6e9c8 100%);
+  color: #2f3324;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.fviva__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.fviva__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #b56a12;
+}
+.fviva__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #34401f;
+}
+.fviva__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 40rem;
+}
+
+.fviva__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+.fviva__lienzo {
+  position: relative;
+  height: min(66vh, 32rem);
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(181, 106, 18, 0.28);
+  box-shadow: 0 12px 30px rgba(60, 52, 26, 0.16);
+  background: radial-gradient(120% 90% at 50% 20%, #dfe2b6 0%, #b4bd85 100%);
+}
+.fviva__lienzo canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+  touch-action: none;
+}
+.frutales-canvas {
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.frutales-canvas--lista {
+  opacity: 1;
+}
+
+.fviva__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  color: #46502f;
+  opacity: 0.85;
+}
+
+.fviva__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.fviva__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.fviva__toggle {
+  border: 1.5px solid #b56a12;
+  background: #fff;
+  color: #a35d0d;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.fviva__toggle:hover,
+.fviva__toggle:focus-visible {
+  background: #b56a12;
+  color: #fff;
+  outline-offset: 2px;
+}
+
+/* ---- Ficha 2D: el mango y el cítrico A ESCALA (la lección sin GPU) ---- */
+.fviva__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  background: radial-gradient(120% 90% at 50% 25%, #e0e3b4 0%, #aeb87e 100%);
+}
+.fviva__estampa {
+  position: relative;
+  width: 230px;
+  height: 180px;
+  margin-bottom: 0.5rem;
+}
+/* la línea de suelo que los pone en la misma tierra (la escala se compara) */
+.fviva__suelo {
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  bottom: 12px;
+  height: 2px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #8a6a4400 0%, #8a6a44 18%, #8a6a44 82%, #8a6a4400 100%);
+  opacity: 0.55;
+}
+
+/* EL MANGO: tronco corto y grueso, copa MÁS ANCHA QUE ALTA que lo eclipsa todo */
+.fviva__mango-tronco {
+  position: absolute;
+  bottom: 12px;
+  left: 62px;
+  width: 17px;
+  height: 44px;
+  border-radius: 30% 30% 22% 22%;
+  background: linear-gradient(90deg, #3c2d20 0%, #4f3d2c 55%, #382a1e 100%);
+}
+.fviva__mango-copa {
+  position: absolute;
+  bottom: 48px;
+  left: 4px;
+  width: 134px;
+  height: 74px;
+  border-radius: 52% 48% 46% 54% / 62% 66% 34% 38%;
+  background: radial-gradient(circle at 40% 28%, #3f7034 0%, #274d28 62%, #1d3b20 100%);
+  box-shadow: inset -9px -7px 16px rgba(0, 0, 0, 0.22);
+}
+/* el brote VINO-COBRIZO en las puntas: la seña que delata al mango */
+.fviva__brote {
+  position: absolute;
+  width: 22px;
+  height: 13px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 35%, #a3563a 0%, #7e3a2c 75%);
+  opacity: 0.95;
+}
+.fviva__brote--a { top: 6px; left: 12px; }
+.fviva__brote--b { top: 14px; right: 10px; }
+/* el mango de azúcar colgando: pequeño y amarillo */
+.fviva__mango-fruto {
+  position: absolute;
+  width: 15px;
+  height: 19px;
+  border-radius: 48% 52% 46% 54% / 40% 40% 60% 60%;
+  background: radial-gradient(circle at 36% 30%, #f4d05c 0%, #f4b63c 55%, #d99323 100%);
+  box-shadow: inset -2px -3px 4px rgba(0, 0, 0, 0.22);
+}
+.fviva__mango-fruto--a { bottom: -8px; left: 36px; }
+.fviva__mango-fruto--b { bottom: -4px; right: 40px; }
+
+/* EL CÍTRICO: al lado, MUCHO más chico — copa redonda compacta y cargada */
+.fviva__citrico-tronco {
+  position: absolute;
+  bottom: 12px;
+  right: 42px;
+  width: 8px;
+  height: 20px;
+  border-radius: 30%;
+  background: linear-gradient(90deg, #63553f 0%, #7a6a52 55%, #5b4d39 100%);
+}
+.fviva__citrico-copa {
+  position: absolute;
+  bottom: 28px;
+  right: 20px;
+  width: 52px;
+  height: 48px;
+  border-radius: 50% 50% 46% 54% / 52% 52% 48% 48%;
+  background: radial-gradient(circle at 38% 30%, #49913c 0%, #2e6b2f 68%, #245524 100%);
+  box-shadow: inset -5px -4px 9px rgba(0, 0, 0, 0.2);
+}
+.fviva__naranja {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #f5a53a 0%, #f08a1d 60%, #d1700f 100%);
+  box-shadow: inset -2px -2px 3px rgba(0, 0, 0, 0.24);
+}
+.fviva__naranja--a { top: 10px; left: 8px; }
+.fviva__naranja--b { top: 26px; left: 26px; }
+.fviva__naranja--c { top: 30px; left: 6px; }
+
+.fviva__ficha-nombre {
+  margin: 0;
+  font-weight: 800;
+  font-size: 1rem;
+  color: #34401f;
+}
+.fviva__ficha-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4f5a34;
+  text-align: center;
+  padding: 0 0.6rem;
+}
+
+/* ---- Saberes ---- */
+.fviva__saberes {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.fviva__saberes h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #34401f;
+}
+.fviva__saberes ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .fviva__saberes ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.fviva__saberes li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(181, 106, 18, 0.18);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.fviva__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.fviva__saberes b {
+  display: block;
+  font-size: 0.92rem;
+  color: #34401f;
+}
+.fviva__saberes li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.fviva__cierre {
+  margin: 0.9rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #46502f;
+  max-width: 42rem;
+}

--- a/src/mockups/FrutalesVivo3D.jsx
+++ b/src/mockups/FrutalesVivo3D.jsx
@@ -1,0 +1,172 @@
+/*
+ * FrutalesVivo3D — vitrina pública del MUNDO DE LOS FRUTALES: mango y cítricos
+ * en una misma finca. Ruta #/mockups/frutales-vivo-3d, sin auth.
+ *
+ * Van juntos a propósito: comparten el arquetipo del árbol frutal de copa
+ * redondeada, y juntos enseñan lo que por separado no — EL PISO TÉRMICO. En la
+ * vega caliente del frente están los palos de mango (0 a 1.000 metros); loma
+ * arriba, ya en clima medio, el huerto de cítricos (la naranja y la mandarina
+ * suben hasta unos 1.600). Entre los dos, el camino. Cuatro pasos cortos
+ * recorren la lección: quién es el mango, hasta dónde suben los cítricos, cómo
+ * se reconoce cada uno y por qué la altura manda.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el mundo 3D (chunk
+ * perezoso `vendor-three`); en equipo humilde, ahorro de datos o sin-WebGL se ve
+ * la ficha — que aquí no es adorno: dibuja al mango y al cítrico A ESCALA, uno
+ * al lado del otro, que es justo lo que hay que entender. Copy en español de
+ * Colombia, en "usted". Autocontenida: cero CDN/imágenes externas.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import './FrutalesVivo3D.css';
+
+const MundoFrutales = lazy(() => import('../visual/mundo3d/frutales/MundoFrutales.jsx'));
+
+/* Lo que enseñan los frutales (verificado, en "usted"). */
+const SABERES = [
+  {
+    emoji: '🥭',
+    titulo: 'El mango es de tierra caliente',
+    texto:
+      'Del nivel del mar hasta unos 1.000 metros. Es árbol grande y longevo, de copa más ancha que alta: bajo un solo palo cabe la familia entera. El común en Colombia es el de azúcar e hilacha, pequeño y amarillo, no el gigante de exportación.',
+  },
+  {
+    emoji: '🍊',
+    titulo: 'Los cítricos suben más',
+    texto:
+      'La naranja y la mandarina se dan hasta unos 1.600 metros, y el limón aguanta todavía un poco más arriba. Por eso en la misma finca el mango se queda abajo y los cítricos lo acompañan en la parte alta.',
+  },
+  {
+    emoji: '🍷',
+    titulo: 'El brote vino delata al mango',
+    texto:
+      'La hoja nueva del mango no nace verde: brota color vino, pasa a cobrizo y solo después se pone verde oscuro. Si ve una copa grande con las puntas tirando a rojo, es mango. Su flor es una panícula: un ramillete grande y ramificado sobre la copa.',
+  },
+  {
+    emoji: '🌿',
+    titulo: 'El pecíolo alado delata al cítrico',
+    texto:
+      'Mire la base de la hoja: los cítricos llevan ahí una hojita pequeña pegada — el pecíolo alado, la seña del género. Súmele las espinas de la rama y la flor blanca de azahar, de olor fuerte, y ya no se equivoca.',
+  },
+];
+
+export default function FrutalesVivo3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  return (
+    <main className="fviva">
+      <header className="fviva__head">
+        <p className="fviva__kicker">El mundo de los frutales · vitrina</p>
+        <h1>El mango abajo, los cítricos arriba</h1>
+        <p className="fviva__lema">
+          Una finca que sube: en la vega caliente los palos de mango, loma arriba
+          el huerto de naranjos, mandarinos y limoneros. Recórrala con el dedo y
+          siga los cuatro pasos: la altura es la que decide qué se da.
+        </p>
+      </header>
+
+      <section className="fviva__escena" aria-label="El mundo de los frutales en 3D">
+        <div className="fviva__lienzo">
+          {mostrar3D ? (
+            <Suspense
+              fallback={
+                <div className="fviva__cargando" role="status">
+                  Llegando a la finca…
+                </div>
+              }
+            >
+              <MundoFrutales tier={tier} reducedMotion={reducedMotion} />
+            </Suspense>
+          ) : (
+            <FichaFrutales />
+          )}
+        </div>
+
+        <div className="fviva__barra">
+          <p className="fviva__tier">
+            {mostrar3D
+              ? 'Está viendo la finca en 3D. Gírela con el dedo o el mouse y siga los pasos.'
+              : puede3D
+                ? 'Está viendo la ficha de los frutales.'
+                : 'Su equipo ve la ficha de los frutales (va parejo en cualquier teléfono).'}
+          </p>
+          {puede3D && (
+            <button type="button" className="fviva__toggle" onClick={() => setVer2d((v) => !v)}>
+              {ver2d ? 'Ver la finca en 3D' : 'Ver la ficha'}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <section className="fviva__saberes" aria-label="Lo que enseñan los frutales">
+        <h2>Lo que le enseñan estos frutales</h2>
+        <ol>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span className="fviva__emoji" aria-hidden="true">
+                {s.emoji}
+              </span>
+              <div>
+                <b>{s.titulo}</b>
+                <p>{s.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="fviva__cierre">
+          Sembrar frutal no es escoger el que más le guste: es mirar primero a qué
+          altura está su tierra. El mismo palo que carga sabroso en la vega se
+          queda mustio mil metros más arriba — y esa cuenta se hace antes de
+          abrir el hueco, no después.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+/* La ficha de los frutales: el fallback digno para equipo humilde / sin-WebGL.
+   No es adorno — dibuja el mango y el cítrico A ESCALA, uno al lado del otro,
+   con su franja de altura. La lección entera, sin gastar un solo polígono. */
+function FichaFrutales() {
+  return (
+    <div
+      className="fviva__ficha"
+      role="img"
+      aria-label="Un palo de mango grande junto a un cítrico pequeño, a escala: el mango de tierra caliente y el cítrico que sube al clima medio"
+    >
+      <div className="fviva__estampa" aria-hidden="true">
+        {/* EL MANGO: copa ancha y baja, con su brote vino en las puntas */}
+        <span className="fviva__mango-tronco" />
+        <span className="fviva__mango-copa">
+          <span className="fviva__brote fviva__brote--a" />
+          <span className="fviva__brote fviva__brote--b" />
+          <span className="fviva__mango-fruto fviva__mango-fruto--a" />
+          <span className="fviva__mango-fruto fviva__mango-fruto--b" />
+        </span>
+        {/* EL CÍTRICO: chiquito, redondo, cargado */}
+        <span className="fviva__citrico-tronco" />
+        <span className="fviva__citrico-copa">
+          <span className="fviva__naranja fviva__naranja--a" />
+          <span className="fviva__naranja fviva__naranja--b" />
+          <span className="fviva__naranja fviva__naranja--c" />
+        </span>
+        <span className="fviva__suelo" />
+      </div>
+      <p className="fviva__ficha-nombre">El mango y el cítrico, a escala</p>
+      <p className="fviva__ficha-sub">
+        Mango: 0 a 1.000 m · Naranja y mandarina: hasta unos 1.600 m
+      </p>
+    </div>
+  );
+}

--- a/src/mockups/__tests__/frutalesVivo3D.smoke.test.jsx
+++ b/src/mockups/__tests__/frutalesVivo3D.smoke.test.jsx
@@ -1,0 +1,65 @@
+/*
+ * Vitrina #/mockups/frutales-vivo-3d — smoke (jsdom = equipo humilde).
+ *
+ * En jsdom no hay WebGL, así que `decidirTier()` cae a 'bajo' y la vitrina monta
+ * la FICHA 2D — el mismo camino del device-tiering real en gama baja. Aquí la
+ * ficha no es un adorno de relleno: es la lección entera (el mango y el cítrico
+ * a escala, con su franja de altura), así que se congela que salga completa y
+ * bien rotulada. Se verifica además que el copy vaya en "usted" y que las dos
+ * alturas del piso térmico estén dichas con número, no a ojo.
+ */
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import FrutalesVivo3D from '../FrutalesVivo3D.jsx';
+
+afterEach(() => cleanup());
+
+describe('vitrina del mundo de los frutales (mockups/frutales-vivo-3d)', () => {
+  test('renderiza el título y el lema de la finca que sube', () => {
+    render(<FrutalesVivo3D />);
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'El mango abajo, los cítricos arriba' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/la altura es la que decide qué se da/i)).toBeInTheDocument();
+  });
+
+  test('sin WebGL cae a la ficha 2D — y la ficha ENSEÑA la escala', () => {
+    const { container } = render(<FrutalesVivo3D />);
+    const ficha = screen.getByRole('img', { name: /a escala/i });
+    expect(ficha).toBeInTheDocument();
+    // el mango con su copa ancha y su brote vino; el cítrico chiquito al lado
+    expect(container.querySelector('.fviva__mango-copa')).toBeInTheDocument();
+    expect(container.querySelector('.fviva__brote')).toBeInTheDocument();
+    expect(container.querySelector('.fviva__citrico-copa')).toBeInTheDocument();
+    // la línea de suelo que los pone en la misma tierra (así se compara)
+    expect(container.querySelector('.fviva__suelo')).toBeInTheDocument();
+    // …y nunca se monta el canvas 3D en equipo humilde
+    expect(container.querySelector('canvas')).toBeNull();
+  });
+
+  test('el piso térmico va dicho con números, no a ojo', () => {
+    render(<FrutalesVivo3D />);
+    // la cifra va dicha DOS veces a propósito: en la ficha y en los saberes
+    expect(screen.getByText(/Mango: 0 a 1\.000 m/)).toBeInTheDocument();
+    expect(screen.getAllByText(/hasta unos 1\.600 m/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/hasta unos 1\.000 metros/i)).toBeInTheDocument();
+  });
+
+  test('los cuatro saberes traen las dos señas diagnósticas', () => {
+    const { container } = render(<FrutalesVivo3D />);
+    expect(container.querySelectorAll('.fviva__saberes li').length).toBe(4);
+    // el brote vino del mango y el pecíolo alado del cítrico: lo que los delata
+    expect(screen.getByText(/brota color vino/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/pecíolo alado/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('el copy va en "usted", sin voseo', () => {
+    const { container } = render(<FrutalesVivo3D />);
+    const texto = container.textContent;
+    expect(texto).toMatch(/Está viendo|Su equipo|le enseñan/);
+    expect(texto).not.toMatch(/tenés|querés|podés|mirá|sembrá|fijate/i);
+  });
+});

--- a/src/visual/mundo3d/__tests__/floraFrutales.geom.test.js
+++ b/src/visual/mundo3d/__tests__/floraFrutales.geom.test.js
@@ -1,0 +1,184 @@
+/*
+ * Pruebas de la geometría PURA del mundo de los frutales (mango + cítricos).
+ * Corren headless: three-core es matemática de buffers, sin contexto WebGL.
+ * Lo innegociable: que NINGUNA fusión devuelva null (la mordida conocida de
+ * mergeGeometries) y que LA ESCALA RELATIVA se cumpla — el mango ECLIPSA al
+ * cítrico; si quedan parejos, el mundo fracasó.
+ */
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import {
+  FLORA_FRUTALES,
+  frutalesDeTier,
+  calidadFrutales,
+  alturaFinca,
+  distribucionFrutales,
+  centrosMango,
+  geomMango,
+  geomMangoFruto,
+  geomCitrico,
+  geomCitricoFruto,
+  geomAzahar,
+  geomHojarasca,
+  geomPiedra,
+  SITIOS_MANGO,
+  MATAS_CITRICOS,
+  FALDA_MANGO,
+  COPA_CITRICO,
+} from '../frutales/floraFrutales.geom.js';
+
+const alturaDe = (geo) => {
+  geo.computeBoundingBox();
+  return geo.boundingBox.max.y - geo.boundingBox.min.y;
+};
+const anchoDe = (geo) => {
+  geo.computeBoundingBox();
+  return Math.max(
+    geo.boundingBox.max.x - geo.boundingBox.min.x,
+    geo.boundingBox.max.z - geo.boundingBox.min.z,
+  );
+};
+
+describe('las geometrías fusionan sin null y desindexadas', () => {
+  const casos = {
+    mango: () => geomMango({ q: 1 }, 21),
+    mangoFruto: () => geomMangoFruto(),
+    citrico: () => geomCitrico({ q: 1 }, 22),
+    citricoFruto: () => geomCitricoFruto(),
+    azahar: () => geomAzahar(27),
+    hojarasca: () => geomHojarasca(25),
+    piedra: () => geomPiedra(26),
+  };
+  Object.entries(casos).forEach(([nombre, crear]) => {
+    it(`${nombre}: geometría válida, sin índice, con color por vértice`, () => {
+      const g = crear();
+      expect(g).toBeInstanceOf(THREE.BufferGeometry);
+      expect(g.index).toBeNull(); // todo desindexado (la regla anti-null)
+      expect(g.attributes.position.count).toBeGreaterThan(0);
+      expect(g.attributes.color).toBeDefined();
+      expect(g.attributes.color.count).toBe(g.attributes.position.count);
+      g.dispose();
+    });
+  });
+
+  it('la calidad baja también fusiona (menos detalle, nunca null)', () => {
+    const q = calidadFrutales('bajo');
+    expect(() => geomMango({ q }, 21)).not.toThrow();
+    expect(() => geomCitrico({ q }, 22)).not.toThrow();
+  });
+});
+
+describe('LA ESCALA RELATIVA: el mango eclipsa al cítrico', () => {
+  it('la copa del mango es MÁS ANCHA que alta (el domo)', () => {
+    const m = geomMango({ q: 1 }, 21);
+    expect(anchoDe(m)).toBeGreaterThan(alturaDe(m) * 1.3);
+    m.dispose();
+  });
+  it('el mango sembrado más chico sigue eclipsando al cítrico más grande', () => {
+    const alturaMango = alturaDe(geomMango({ q: 1 }, 21));
+    const alturaCitrico = alturaDe(geomCitrico({ q: 1 }, 22));
+    const escMangoMin = Math.min(...SITIOS_MANGO.map((s) => s.esc));
+    const escCitricoMax = 1.2; // el tope de la distribución (0.95 + 0.25)
+    expect(alturaMango * escMangoMin).toBeGreaterThan(alturaCitrico * escCitricoMax * 1.8);
+  });
+});
+
+describe('la geografía térmica (la lección hecha relieve)', () => {
+  it('la vega del frente es baja y la ladera del fondo alta', () => {
+    expect(alturaFinca(0, 14)).toBeLessThan(1);
+    expect(alturaFinca(0, -12)).toBeGreaterThan(4);
+  });
+  it('los mangos viven ABAJO (vega) y las matas de cítricos ARRIBA', () => {
+    SITIOS_MANGO.forEach((s) => expect(alturaFinca(s.p[0], s.p[1])).toBeLessThan(1.2));
+    MATAS_CITRICOS.forEach((m) => expect(alturaFinca(m.c[0], m.c[1])).toBeGreaterThan(2.2));
+  });
+});
+
+describe('distribucionFrutales (determinista y fiel)', () => {
+  const conteos = frutalesDeTier('alto');
+  const d = distribucionFrutales(conteos, 421, 1);
+
+  it('respeta el presupuesto del tier', () => {
+    expect(d.mango.length).toBe(conteos.mango);
+    expect(d.citrico.length).toBe(conteos.citrico);
+    expect(d.mangoFruto.length).toBeLessThanOrEqual(conteos.mangoFruto);
+    expect(d.mangoFruto.length).toBeGreaterThan(conteos.mangoFruto * 0.6);
+    expect(d.citricoFruto.length).toBeLessThanOrEqual(conteos.citricoFruto);
+    expect(d.citricoFruto.length).toBeGreaterThan(conteos.citricoFruto * 0.6);
+  });
+
+  it('misma semilla → misma siembra', () => {
+    const d2 = distribucionFrutales(conteos, 421, 1);
+    expect(d2.mango[0].pos).toEqual(d.mango[0].pos);
+    expect(d2.citricoFruto[7].tint).toEqual(d.citricoFruto[7].tint);
+  });
+
+  it('el fruto del mango cuelga de la falda de SU copa (no flota)', () => {
+    const sitios = SITIOS_MANGO.slice(0, conteos.mango);
+    d.mangoFruto.forEach((f) => {
+      const s = sitios.find((sm) => {
+        const dx = f.pos[0] - sm.p[0];
+        const dz = f.pos[2] - sm.p[1];
+        const rad = Math.hypot(dx, dz) / sm.esc;
+        return rad > FALDA_MANGO.radMin - 0.35 && rad < FALDA_MANGO.radMax + 0.35;
+      });
+      expect(s).toBeDefined();
+    });
+  });
+
+  it('el fruto cítrico queda pegado a la superficie de alguna copa', () => {
+    d.citricoFruto.forEach((f) => {
+      const cerca = d.citrico.some((a) => {
+        const esc = a.escala;
+        const dx = f.pos[0] - a.pos[0];
+        const dy = f.pos[1] - (a.pos[1] + COPA_CITRICO.y * esc);
+        const dz = f.pos[2] - a.pos[2];
+        return Math.hypot(dx, dy, dz) < COPA_CITRICO.rad * esc * 1.35;
+      });
+      expect(cerca).toBe(true);
+    });
+  });
+
+  it('las tres variedades de cítrico sobreviven a todo tier', () => {
+    ['alto', 'medio', 'bajo'].forEach((tier) => {
+      const dd = distribucionFrutales(frutalesDeTier(tier), 421, calidadFrutales(tier));
+      const variantesVivas = new Set();
+      // reconstruir la variedad por el color del fruto: naranja/mandarina cálidos,
+      // limón verde-amarillo (el tinte ES el color real del fruto)
+      dd.citricoFruto.forEach((f) => {
+        const [r, g, b] = f.tint;
+        if (g > r) variantesVivas.add('limon');
+        else if (r > 0.75 && g < 0.62) variantesVivas.add('calida');
+        expect(b).toBeLessThan(Math.max(r, g)); // ninguna fruta azulada
+      });
+      expect(variantesVivas.size).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('bajo conserva el héroe (el palo del patio) y la escala relativa', () => {
+    const dd = distribucionFrutales(frutalesDeTier('bajo'), 421, calidadFrutales('bajo'));
+    expect(dd.mango[0].pos[0]).toBeCloseTo(SITIOS_MANGO[0].p[0]);
+    expect(dd.citrico.length).toBeGreaterThan(0);
+    expect(dd.azahar.length).toBe(0); // 'bajo' no paga azahar
+  });
+
+  it('centrosMango da un centro por mango del tier, sobre el suelo', () => {
+    const cs = centrosMango(conteos);
+    expect(cs.length).toBe(conteos.mango);
+    cs.forEach((cm) => {
+      expect(cm.radio).toBeGreaterThan(2);
+      expect(cm.centro[1]).toBeCloseTo(alturaFinca(cm.centro[0], cm.centro[2]));
+    });
+  });
+});
+
+describe('tiers coherentes', () => {
+  it('alto > medio > bajo en frutos (el presupuesto escalona)', () => {
+    expect(FLORA_FRUTALES.alto.citricoFruto).toBeGreaterThan(FLORA_FRUTALES.medio.citricoFruto);
+    expect(FLORA_FRUTALES.medio.citricoFruto).toBeGreaterThan(FLORA_FRUTALES.bajo.citricoFruto);
+  });
+  it('tier desconocido cae a medio, nunca al más caro', () => {
+    expect(frutalesDeTier('marciano')).toBe(FLORA_FRUTALES.medio);
+    expect(calidadFrutales('marciano')).toBe(0.62);
+  });
+});

--- a/src/visual/mundo3d/__tests__/floraFrutales.geom.test.js
+++ b/src/visual/mundo3d/__tests__/floraFrutales.geom.test.js
@@ -83,6 +83,69 @@ describe('LA ESCALA RELATIVA: el mango eclipsa al cítrico', () => {
   });
 });
 
+/*
+ * LA SILUETA A MEDIA DISTANCIA. Al mundo del café le pasó que el cafeto quedaba
+ * perfecto en primer plano pero de lejos la ladera parecía un bosque de PINOS:
+ * la silueta dejaba de decir lo que el árbol era. Este guard mide el PERFIL de
+ * ancho por franjas de altura — lo único que sobrevive a la distancia — y exige
+ * que cada especie conserve su firma en TODO tier:
+ *   · mango  → domo: ensancha a media altura y se cierra arriba (jamás cono)
+ *   · cítrico → bola: tan ancho como alto
+ */
+function perfilSilueta(geo, franjas = 10) {
+  geo.computeBoundingBox();
+  const bb = geo.boundingBox;
+  const h = bb.max.y - bb.min.y;
+  const pos = geo.attributes.position.array;
+  const ancho = new Array(franjas).fill(0);
+  for (let i = 0; i < pos.length; i += 3) {
+    const k = Math.min(franjas - 1, Math.floor(((pos[i + 1] - bb.min.y) / h) * franjas));
+    ancho[k] = Math.max(ancho[k], Math.hypot(pos[i], pos[i + 2]) * 2);
+  }
+  return { ancho, alto: h, max: Math.max(...ancho) };
+}
+
+describe('la silueta a media distancia (que no se vuelva un pino)', () => {
+  ['alto', 'medio', 'bajo'].forEach((tier) => {
+    const q = calidadFrutales(tier);
+
+    it(`mango en tier ${tier}: DOMO — ancho > alto y se cierra arriba`, () => {
+      const g = geomMango({ q }, 21);
+      const { ancho, alto, max } = perfilSilueta(g);
+      // más ancho que alto: la copa del mango se acuesta, no se para
+      expect(max).toBeGreaterThan(alto * 1.3);
+      // la franja más ancha vive a MEDIA altura (un cono la tendría abajo del
+      // todo y adelgazaría monótono hacia la punta)
+      const iMax = ancho.indexOf(max);
+      expect(iMax).toBeGreaterThanOrEqual(3);
+      expect(iMax).toBeLessThanOrEqual(7);
+      // la copa CIERRA arriba (si la punta fuera igual de ancha sería un cubo,
+      // si fuera un pico creciente sería un pino invertido)
+      expect(ancho[9]).toBeLessThan(max * 0.85);
+      // …y también cierra abajo del dosel: hay tronco visible, no falda al piso
+      expect(ancho[0]).toBeLessThan(max * 0.4);
+      g.dispose();
+    });
+
+    it(`cítrico en tier ${tier}: BOLA — tan ancho como alto`, () => {
+      const g = geomCitrico({ q }, 22);
+      const { alto, max } = perfilSilueta(g);
+      expect(max).toBeGreaterThan(alto * 0.8);
+      expect(max).toBeLessThan(alto * 1.25);
+      g.dispose();
+    });
+
+    it(`en tier ${tier} el mango sigue eclipsando al cítrico de un golpe`, () => {
+      const m = perfilSilueta(geomMango({ q }, 21));
+      const c = perfilSilueta(geomCitrico({ q }, 22));
+      // a igual escala 1: el palo de mango dobla largo al arbolito, y el héroe
+      // de la vega (esc 1.7) lo multiplica todavía más
+      expect(m.alto).toBeGreaterThan(c.alto * 2);
+      expect(m.max).toBeGreaterThan(c.max * 3);
+    });
+  });
+});
+
 describe('la geografía térmica (la lección hecha relieve)', () => {
   it('la vega del frente es baja y la ladera del fondo alta', () => {
     expect(alturaFinca(0, 14)).toBeLessThan(1);

--- a/src/visual/mundo3d/frutales/EscenaFrutalesVivo.jsx
+++ b/src/visual/mundo3d/frutales/EscenaFrutalesVivo.jsx
@@ -1,0 +1,375 @@
+/*
+ * EscenaFrutalesVivo — el MUNDO DE LOS FRUTALES: mango y cítricos en UNA finca,
+ * porque juntos enseñan lo que por separado no — EL PISO TÉRMICO.
+ *
+ * La escena ES la lección. La finca SUBE: al frente la VEGA CALIENTE (0–1.000 m)
+ * con los palos de mango monumentales y la casa a su sombra; ladera arriba, ya
+ * en clima medio, el huerto de cítricos — chiquitos, redondos, cargados. Entre
+ * los dos, el CAMINO que el campesino sube. La altura decide qué se da, y aquí
+ * se ve caminando.
+ *
+ * En la hora viva del valle (`AtmosferaMundo`, familia `plaza` — la tierra
+ * caliente es luz abierta y polvo dorado, no sotobosque) y en clave de la TOMA B
+ * estilizada: domo de gradiente con el glow del sol (`DomoCielo`), terreno y
+ * montes por BANDAS (`useGradienteBandas` + toon), silueta fuerte. La paleta la
+ * levanta LA FRUTA: el amarillo del mango de azúcar y el naranja del cítrico
+ * son el color de este mundo — nada de pardo mustio.
+ *
+ * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`. Con
+ * `reducedMotion` el mundo monta QUIETO (frameloop a demanda). La fauna son los
+ * SVG rubber-hose de la casa como billboards: la guacamaya y el mico que bajan
+ * al palo de mango cargado, y las mariposas de la vega caliente.
+ *
+ * `foco` (opcional): un punto [x,y,z] que el paso didáctico del host señala con
+ * un anillo que respira. Importa three/@react-three → montar SOLO perezosa.
+ */
+import { useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { perfilDeTier } from '../deviceTier.js';
+import { Fauna } from '../escenas/FaunaEscena.jsx';
+import FaunaCalido from '../escenas/FaunaCalido.jsx';
+import FloraFrutales from './FloraFrutales.jsx';
+import {
+  ANCHO,
+  FONDO,
+  PAL,
+  alturaFinca,
+  caminoX,
+  SITIO_CASA,
+} from './floraFrutales.geom.js';
+import {
+  AtmosferaMundo,
+  DomoCielo,
+  useAtmosferaMundo,
+  useGradienteBandas,
+  construirTerreno,
+  ruidoTerreno,
+  smoothstep,
+  CamaraDirector,
+} from '../kit/index.js';
+import {
+  mezclar,
+  VERDES,
+  TIERRAS,
+  CASA,
+  LUCES,
+  PALETA,
+} from '../paleta/index.js';
+
+/* La identidad de la tierra caliente dentro de la familia del valle: `plaza`
+   (luz abierta, polvo dorado). El 60% restante lo pone la HORA. */
+const FAMILIA_FRUTALES = 'plaza';
+
+/* Escala de la escena para el kit (cámara↔centro ~16): la niebla del kit cae a
+   radio*1.4→radio*4.6, calibrada a esta finca larga. */
+const RADIO_FRUTALES = 12;
+
+/* El frustum de sombra a medida: el domo del mango tira sombra ancha. */
+const SOMBRA_FRUTALES = { left: -18, right: 18, top: 16, bottom: -8, far: 44 };
+
+/* La malla de la finca — el heightfield del KIT con la pintura PROPIA de los
+   dos pisos: abajo la vega caliente (pasto amarillento, tierra clara y seca),
+   arriba el verde franco del clima medio. El COLOR DEL SUELO ya cuenta la
+   lección: la tierra cambia con la altura, no solo los árboles. */
+function construirFinca(seg, plano) {
+  const cVegaSeca = new THREE.Color(VERDES.calido); // el oliva amarillento del cálido
+  const cVegaViva = new THREE.Color(VERDES.calidoVivo);
+  const cMedio = new THREE.Color(VERDES.templadoVivo); // el verde franco de arriba
+  const cMedioAlto = new THREE.Color(VERDES.templado);
+  const cTierra = new THREE.Color(TIERRAS.vega); // tierra clara de vega
+  const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.35));
+  const cMantillo = new THREE.Color(TIERRAS.mantillo); // bajo el domo del mango
+  return construirTerreno({
+    ancho: ANCHO,
+    fondo: FONDO,
+    seg,
+    plano,
+    altura: alturaFinca,
+    pintar: (wx, wz, alt, c) => {
+      // 0 en la vega caliente, 1 arriba en el clima medio
+      const arriba = smoothstep(6, -12, wz);
+      const vega = new THREE.Color().lerpColors(
+        cVegaSeca, cVegaViva, 0.5 + 0.5 * ruidoTerreno(wx * 0.9, wz * 0.7),
+      );
+      const medio = new THREE.Color().lerpColors(
+        cMedio, cMedioAlto, 0.5 + 0.5 * ruidoTerreno(wx * 1.1, wz * 0.9),
+      );
+      c.lerpColors(vega, medio, arriba);
+      // la tierra clara asoma a manchas en la vega seca
+      c.lerp(cTierra, smoothstep(-0.1, 0.85, ruidoTerreno(wx * 1.3, wz * 1.1)) * 0.38 * (1 - arriba));
+      // el mantillo bajo la sombra grande del mango del patio
+      const dm = Math.hypot(wx + 4.2, wz - 8.6);
+      c.lerp(cMantillo, smoothstep(4.2, 1.4, dm) * 0.3);
+      // EL CAMINO que sube de la vega al huerto: la lección que se camina
+      c.lerp(cCamino, smoothstep(1.5, 0.2, Math.abs(wx - caminoX(wz))) * 0.75);
+    },
+  });
+}
+
+/* La casa campesina de la vega, a la sombra del palo de mango del patio:
+   paredes encaladas, techo de teja y — la señal de la tierra caliente — el
+   CORREDOR con su hamaca colgada y los guacales de fruta esperando el viaje. */
+function CasaVega({ pos }) {
+  return (
+    <group position={pos} rotation={[0, 0.42, 0]}>
+      {/* la casa: LA casa campesina de la paleta madre (la misma del valle) */}
+      <mesh position={[0, 0.72, 0]}>
+        <boxGeometry args={[2.8, 1.44, 2.0]} />
+        <meshLambertMaterial color={CASA.encalado} flatShading />
+      </mesh>
+      <mesh position={[0, 0.18, 0]}>
+        <boxGeometry args={[2.84, 0.36, 2.04]} />
+        <meshLambertMaterial color={CASA.zocalo} flatShading />
+      </mesh>
+      <mesh position={[0.55, 0.62, 1.01]}>
+        <boxGeometry args={[0.46, 0.95, 0.06]} />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
+      </mesh>
+      <mesh position={[-0.65, 0.86, 1.01]}>
+        <boxGeometry args={[0.52, 0.44, 0.06]} />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
+      </mesh>
+      {/* techo a dos aguas de teja, con alero largo (el sol pega duro aquí) */}
+      <mesh position={[0, 1.6, -0.66]} rotation={[-0.6, 0, 0]}>
+        <boxGeometry args={[3.3, 0.08, 1.6]} />
+        <meshLambertMaterial color={CASA.tejaSombra} flatShading />
+      </mesh>
+      <mesh position={[0, 1.6, 0.66]} rotation={[0.6, 0, 0]}>
+        <boxGeometry args={[3.3, 0.08, 1.6]} />
+        <meshLambertMaterial color={CASA.teja} flatShading />
+      </mesh>
+
+      {/* EL CORREDOR: dos horcones y la hamaca tendida — el descanso del
+          mediodía caliente, a la sombra del alero y del mango. */}
+      {[[-1.15, 1.55], [1.15, 1.55]].map((q, i) => (
+        <mesh key={i} position={[q[0], 0.6, q[1]]}>
+          <cylinderGeometry args={[0.07, 0.085, 1.2, 6]} />
+          <meshLambertMaterial color={PALETA.madera} flatShading />
+        </mesh>
+      ))}
+      <mesh position={[0, 0.72, 1.55]} rotation={[0, 0, 0]} scale={[1, 0.32, 0.5]}>
+        <sphereGeometry args={[0.95, 10, 6]} />
+        <meshLambertMaterial color={CASA.bejuco} flatShading />
+      </mesh>
+
+      {/* los GUACALES de fruta cogida, esperando el viaje al pueblo: uno de
+          mango amarillo, otro de naranja. El color de la cosecha, en el patio. */}
+      {[
+        { p: [-1.9, 1.2], fruta: PAL.mangoMaduro },
+        { p: [-2.45, 0.75], fruta: PAL.naranjaMadura },
+      ].map((g, i) => (
+        <group key={`g${i}`} position={[g.p[0], 0, g.p[1]]}>
+          <mesh position={[0, 0.19, 0]}>
+            <boxGeometry args={[0.52, 0.38, 0.42]} />
+            <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+          </mesh>
+          <mesh position={[0, 0.42, 0]} scale={[1, 0.42, 0.82]}>
+            <sphereGeometry args={[0.24, 8, 5]} />
+            <meshLambertMaterial color={g.fruta} flatShading />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}
+
+/* El anillo del paso didáctico: respira sobre el punto que la lección señala.
+   Con reducedMotion queda quieto (presencia sin parpadeo). */
+function FocoPaso({ foco, reducedMotion }) {
+  const anillo = useRef(null);
+  useFrame(({ clock }) => {
+    const m = anillo.current;
+    if (!m) return;
+    if (reducedMotion) {
+      m.material.opacity = 0.42;
+      return;
+    }
+    const t = clock.elapsedTime;
+    m.material.opacity = 0.3 + 0.2 * Math.sin(t * 1.8);
+    m.scale.setScalar(1 + 0.06 * Math.sin(t * 1.8));
+  });
+  if (!foco) return null;
+  return (
+    <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+      <ringGeometry args={[1.3, 1.75, 32]} />
+      <meshBasicMaterial
+        color={LUCES.candela}
+        transparent
+        opacity={0.4}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+/* La vida menuda de la vega caliente: mariposas al sol y el colibrí que visita
+   el azahar del cítrico (el azahar huele fuerte a propósito: llama). */
+const FAUNA_FRUTALES = [
+  { tipo: 'mariposa', base: [-1.5, 1.6, 6.5], patron: 'revoloteo', size: 26, fase: 0.7, df: 9 },
+  { tipo: 'colibri', base: [-5.0, 3.4, -5.5], patron: 'revoloteo', size: 30, fase: 1.9, df: 10 },
+  { tipo: 'mariposa', base: [6.0, 1.8, 9.0], patron: 'revoloteo', size: 22, fase: 2.9, df: 9 },
+];
+
+/* La FAUNA EMBLEMÁTICA DEL PISO CÁLIDO — y aquí no es decorado: el palo de
+   mango cargado es comedero. La guacamaya y el mico bajan A COMER mango; el
+   morfo azul cruza la sombra del domo. Especies REALES colombianas con su
+   nombre científico. Orden = prominencia: el recorte por tier deja lo insignia. */
+const FAUNA_CALIDO_FRUTALES = [
+  { tipo: 'guacamaya', base: [-4.0, 5.4, 8.0], patron: 'vuela', size: 64, fase: 0.4, df: 12, title: 'Guacamaya bandera (Ara macao)' },
+  { tipo: 'mico', base: [-3.0, 3.4, 7.4], patron: 'trepa', size: 56, fase: 2.0, df: 9, title: 'Mico maicero (Saimiri sciureus)' },
+  { tipo: 'tucan', base: [8.0, 3.8, 11.0], patron: 'posa', size: 58, fase: 1.1, df: 9, title: 'Tucán pechiblanco (Ramphastos tucanus)' },
+  { tipo: 'morfo', base: [-6.5, 2.2, 5.0], patron: 'morfo', size: 40, fase: 0.7, df: 9, title: 'Morfo azul (Morpho peleides)' },
+];
+
+function Diorama({ tier, reducedMotion, foco }) {
+  const perfil = perfilDeTier(tier);
+
+  /* La atmósfera VIVA de la hora del valle — alimenta el domo y la perspectiva
+     aérea del fondo. */
+  const atm = useAtmosferaMundo({ familia: FAMILIA_FRUTALES, reducedMotion });
+
+  /* EL gradiente de bandas de la escena (toma B): terreno y montes comparten
+     los mismos escalones de luz — ilustración en movimiento. */
+  const bandas = useGradienteBandas();
+
+  const geoFinca = useMemo(
+    () => construirFinca(perfil.segmentosTerreno, perfil.flatShading),
+    [perfil.segmentosTerreno, perfil.flatShading],
+  );
+
+  /* Las montañas del fondo, comidas por la niebla DE LA HORA. Aquí cuentan algo:
+     lo que se ve atrás es la montaña que SIGUE subiendo — arriba de los cítricos
+     ya no se da ni el mango ni la naranja. */
+  const montes = useMemo(
+    () => ({
+      cerca: mezclar(VERDES.monte, atm.niebla, 0.22),
+      media: mezclar(VERDES.templado, atm.niebla, 0.3),
+      lejos: mezclar(VERDES.frio, atm.niebla, 0.42),
+    }),
+    [atm.niebla],
+  );
+
+  const fauna = useMemo(
+    () => (tier === 'alto' ? FAUNA_FRUTALES : FAUNA_FRUTALES.slice(0, 2)),
+    [tier],
+  );
+  const faunaCalido = useMemo(
+    () => (tier === 'alto' ? FAUNA_CALIDO_FRUTALES : FAUNA_CALIDO_FRUTALES.slice(0, 2)),
+    [tier],
+  );
+
+  const controls = useRef(null);
+  const casaY = alturaFinca(SITIO_CASA[0], SITIO_CASA[1]);
+
+  return (
+    <>
+      {/* LA ATMÓSFERA DEL KIT: fondo, niebla, luces y estrellas de LA HORA DEL
+          VALLE (familia plaza), con el shadow-map del domo en gama alta. */}
+      <AtmosferaMundo
+        familia={FAMILIA_FRUTALES}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        radio={RADIO_FRUTALES}
+        conSuelo={false}
+        sombra={SOMBRA_FRUTALES}
+      />
+
+      {/* El DOMO de la toma B: gradiente cenit→horizonte + glow del sol. */}
+      <DomoCielo atm={atm} radio={68} />
+
+      {/* LA FINCA por bandas (recibe la sombra de las copas en gama alta).
+          Con perfil.flatShading el terreno ya viene DESINDEXADO con normales
+          planas horneadas (construirTerreno). */}
+      <mesh geometry={geoFinca} receiveShadow={perfil.sombras}>
+        <meshToonMaterial vertexColors gradientMap={bandas} />
+      </mesh>
+
+      {/* la montaña que SIGUE subiendo detrás del huerto: el piso que ya no da
+          fruta — la lección continúa fuera de cuadro. */}
+      <mesh position={[-14, 3.4, -24]} scale={[10, 5.4, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.media} gradientMap={bandas} />
+      </mesh>
+      <mesh position={[8, 4.2, -27]} scale={[12, 7.0, 7]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.lejos} gradientMap={bandas} />
+      </mesh>
+      <mesh position={[23, 2.4, -22]} scale={[9, 4.0, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.cerca} gradientMap={bandas} />
+      </mesh>
+
+      {/* LOS FRUTALES: el mango de la vega, los cítricos del huerto. */}
+      <FloraFrutales tier={tier} reducedMotion={reducedMotion} />
+
+      {/* la casa de la vega, bajo la sombra del palo de mango del patio */}
+      <CasaVega pos={[SITIO_CASA[0], casaY, SITIO_CASA[1]]} />
+
+      {/* La vida menuda: mariposas al sol, el colibrí en el azahar. */}
+      {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
+
+      {/* La fauna del cálido que baja al mango cargado: guacamaya, mico,
+          tucán y el morfo azul cruzando la sombra del domo. */}
+      {perfil.criaturas > 0 && <FaunaCalido items={faunaCalido} reducedMotion={reducedMotion} />}
+
+      {/* el anillo del paso didáctico (lo maneja el host) */}
+      <FocoPaso foco={foco} reducedMotion={reducedMotion} />
+
+      <OrbitControls
+        ref={controls}
+        makeDefault
+        target={[0, 2.4, 0]}
+        enablePan={false}
+        enableZoom
+        minDistance={9}
+        maxDistance={30}
+        minPolarAngle={0.45}
+        maxPolarAngle={1.45}
+        minAzimuthAngle={-1.15}
+        maxAzimuthAngle={1.15}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.12}
+      />
+      {/* La LLEGADA: el dolly entra BAJO, casi al pie del palo de mango, para
+          que la copa se sienta enorme antes de que la cámara suba y muestre el
+          huerto chiquito allá arriba. La escala se hace SENTIR, no se explica. */}
+      <CamaraDirector
+        controls={controls}
+        reposo={[2.5, 5.2, 19]}
+        mirada={[-1.5, 3.0, 2]}
+        respiro={0.04}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="mundoFrutales"
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * El mundo de los frutales (mango + cítricos). Montar SOLO perezosa (lazy).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, foco?: number[]|null}} props
+ */
+export default function EscenaFrutalesVivo({ tier = 'alto', reducedMotion = false, foco = null }) {
+  const perfil = perfilDeTier(tier);
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`frutales-canvas${listo ? ' frutales-canvas--lista' : ''}`}
+      dpr={perfil.dpr}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      shadows={perfil.sombras ? 'soft' : false}
+      camera={{ position: [2.5, 5.2, 19], fov: 46 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Diorama tier={tier} reducedMotion={reducedMotion} foco={foco} />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/frutales/FloraFrutales.jsx
+++ b/src/visual/mundo3d/frutales/FloraFrutales.jsx
@@ -1,0 +1,218 @@
+/*
+ * FloraFrutales — la finca frutalera sembrada: el mango abajo, el cítrico arriba.
+ *
+ * Consume `floraFrutales.geom.js`: cada especie es UN InstancedMesh de una
+ * geometría fusionada (una draw-call por especie) — mismo contrato tier-safe
+ * que FloraCafetal. Los FRUTOS llevan color POR INSTANCIA (mango verde→amarillo;
+ * cítrico naranja/mandarina/limón) y el fruto cítrico además ESCALA VECTORIAL
+ * por instancia: la proporción distingue la naranja de la mandarina achatada y
+ * del limón ovoide.
+ *
+ * En 'alto' se suma la LUZ COLADA bajo el domo del mango: los dapples dorados
+ * que respiran en la sombra grande — la sombra del palo de mango es EL lugar
+ * de la tierra caliente, y merece su luz. `reducedMotion` los deja quietos.
+ *
+ * Componente r3f: montar dentro del <Canvas> de EscenaFrutalesVivo.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import {
+  frutalesDeTier,
+  calidadFrutales,
+  distribucionFrutales,
+  centrosMango,
+  alturaFinca,
+  geomMango,
+  geomMangoFruto,
+  geomCitrico,
+  geomCitricoFruto,
+  geomAzahar,
+  geomHojarasca,
+  geomPiedra,
+} from './floraFrutales.geom.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* Un banco de matas de UNA especie: una geometría, un material, N instancias.
+   Igual que el `Especie` del cafetal, con UNA extensión: `escala` puede ser
+   número (uniforme) o VECTOR [x,y,z] — así el mismo InstancedMesh de fruto
+   cítrico lleva naranjas esféricas, mandarinas achatadas y limones ovoides. */
+function Especie({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      if (Array.isArray(it.escala)) s.set(it.escala[0], it.escala[1], it.escala[2]);
+      else s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+    />
+  );
+}
+
+/*
+ * La LUZ COLADA bajo el domo del mango: discos dorados aditivos que respiran
+ * apenas en la sombra grande del palo. Solo 'alto'; con reducedMotion quedan
+ * quietos (presencia sin parpadeo).
+ */
+function LuzColada({ centros, reducedMotion }) {
+  const grupo = useRef(null);
+  const manchas = useMemo(() => {
+    const r = rng(131);
+    const lista = [];
+    centros.forEach((cm) => {
+      const n = 3 + Math.floor(r() * 3);
+      for (let i = 0; i < n; i++) {
+        const x = cm.centro[0] + (r() - 0.5) * cm.radio * 1.7;
+        const z = cm.centro[2] + (r() - 0.5) * cm.radio * 1.7;
+        lista.push({
+          pos: /** @type {[number, number, number]} */ ([x, alturaFinca(x, z) + 0.05, z]),
+          r: 0.5 + r() * 0.8,
+          fase: r() * Math.PI * 2,
+          op: 0.09 + r() * 0.06,
+        });
+      }
+    });
+    return lista;
+  }, [centros]);
+
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (reducedMotion || !g) return;
+    const t = clock.elapsedTime;
+    for (let i = 0; i < g.children.length; i++) {
+      const m = g.children[i];
+      const d = manchas[i];
+      m.material.opacity = d.op * (0.55 + 0.45 * Math.sin(t * 0.7 + d.fase));
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {manchas.map((d, i) => (
+        <mesh key={i} position={d.pos} rotation={[-Math.PI / 2, 0, 0]}>
+          <circleGeometry args={[d.r, 14]} />
+          <meshBasicMaterial
+            color="#ffe9b8"
+            transparent
+            opacity={d.op}
+            depthWrite={false}
+            blending={THREE.AdditiveBlending}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/**
+ * La capa viva de la finca frutalera. Montar dentro del <Canvas>.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function FloraFrutales({ tier = 'alto', reducedMotion = false }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = frutalesDeTier(tier);
+  const q = calidadFrutales(tier);
+
+  // Geometrías fusionadas (una vez por tier).
+  const geos = useMemo(
+    () => ({
+      mango: geomMango({ q }, 21),
+      mangoFruto: geomMangoFruto(),
+      citrico: geomCitrico({ q }, 22),
+      citricoFruto: geomCitricoFruto(),
+      azahar: conteos.azahar ? geomAzahar(27) : null,
+      hojarasca: conteos.hojarasca ? geomHojarasca(25) : null,
+      piedra: conteos.piedra ? geomPiedra(26) : null,
+    }),
+    [conteos, q],
+  );
+
+  // Material único con vertexColors (el color viene horneado por especie y el
+  // tinte por instancia lo multiplica — en los frutos el tinte ES el color).
+  const mat = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.85, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  // El material LUSTROSO: la hoja del cítrico brilla (la firma del género) y
+  // la fruta tiene cuero de fruta (roughness bajo). Solo en gama con material
+  // rico; en la frugal se reusa el material único (cero costo extra).
+  const matLustre = useMemo(() => {
+    if (!perfil.materialRico) return mat;
+    return new THREE.MeshStandardMaterial({
+      vertexColors: true,
+      flatShading: perfil.flatShading,
+      roughness: 0.38,
+      metalness: 0,
+    });
+  }, [perfil.materialRico, perfil.flatShading, mat]);
+
+  // Distribución determinista (una vez por tier).
+  const dist = useMemo(() => distribucionFrutales(conteos, 421, q), [conteos, q]);
+  const centros = useMemo(() => centrosMango(conteos), [conteos]);
+
+  // Liberar GPU al desmontar.
+  useLayoutEffect(
+    () => () => {
+      Object.values(geos).forEach((g) => g && g.dispose());
+      mat.dispose();
+      if (matLustre !== mat) matLustre.dispose();
+    },
+    [geos, mat, matLustre],
+  );
+
+  const sombra = perfil.sombras; // solo los árboles proyectan sombra en 'alto'
+
+  return (
+    <group>
+      {/* El suelo de la vega: hojarasca bajo los mangos, piedras sueltas. */}
+      <Especie geo={geos.hojarasca} mat={mat} items={dist.hojarasca} />
+      <Especie geo={geos.piedra} mat={mat} items={dist.piedra} />
+
+      {/* EL GIGANTE: los palos de mango de la vega caliente, con su fruto
+          amarillo colgando del pedúnculo largo (verde→amarillo por instancia). */}
+      <Especie geo={geos.mango} mat={mat} items={dist.mango} castShadow={sombra} />
+      <Especie geo={geos.mangoFruto} mat={matLustre} items={dist.mangoFruto} />
+
+      {/* EL CHICO: el huerto de cítricos ladera arriba — hoja lustrosa, fruta
+          pegada al ramaje (naranja/mandarina/limón por color Y proporción) y
+          el azahar blanco oloroso. */}
+      <Especie geo={geos.citrico} mat={matLustre} items={dist.citrico} castShadow={sombra} />
+      <Especie geo={geos.citricoFruto} mat={matLustre} items={dist.citricoFruto} />
+      <Especie geo={geos.azahar} mat={matLustre} items={dist.azahar} />
+
+      {/* La luz que se cuela bajo el domo del mango (solo gama alta). */}
+      {tier === 'alto' && <LuzColada centros={centros} reducedMotion={reducedMotion} />}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/frutales/MundoFrutales.jsx
+++ b/src/visual/mundo3d/frutales/MundoFrutales.jsx
@@ -1,0 +1,107 @@
+/*
+ * MundoFrutales — el MUNDO DE LOS FRUTALES completo: la finca navegable + la
+ * lección del PISO TÉRMICO.
+ *
+ * Mismo contrato de host que MundoCafetal: acepta `{tier, reducedMotion}` (o
+ * auto-detecta con decidirTier si se monta suelto), llena a su padre y guarda su
+ * estado local. Sobre la escena viven los PASOS: cuatro lecciones cortas que
+ * recorren lo que este mundo enseña — el mango de tierra caliente, los cítricos
+ * que sí suben, cómo se reconoce cada uno, y la regla que ordena la finca
+ * entera. Cada paso señala SU lugar con un anillo que respira (el `foco` que la
+ * escena dibuja). Copy en español de Colombia, en "usted".
+ *
+ * Importa three/@react-three (vía la escena) → montar SOLO perezoso (lazy).
+ */
+import { useMemo, useState } from 'react';
+import EscenaFrutalesVivo from './EscenaFrutalesVivo.jsx';
+import PanelPasos from '../PanelPasos.jsx';
+import { decidirTier, permite3D } from '../deviceTier.js';
+import { alturaFinca } from './floraFrutales.geom.js';
+
+/* Los cuatro pasos de la lección. Cada `foco` es el punto de la finca que el
+   anillo señala mientras se lee (coordenadas del mundo, y sobre el terreno). */
+const enSuelo = (x, z) => [x, alturaFinca(x, z), z];
+const PASOS = [
+  {
+    id: 'mango',
+    kicker: 'Paso 1 de 4 · El palo de mango',
+    texto:
+      'Ese gigante del patio es un MANGO. Copa más ancha que alta, sombra para toda la familia, y fruta colgando de un cordón largo: el mango de azúcar, pequeño y amarillo. Vive en tierra caliente, de los 0 a los 1.000 metros.',
+    foco: enSuelo(-4.2, 8.6),
+  },
+  {
+    id: 'citricos',
+    kicker: 'Paso 2 de 4 · Los cítricos suben',
+    texto:
+      'Loma arriba, donde ya refresca, están los cítricos: naranja, mandarina y limón. Son árboles mucho más chicos, de copa redonda y apretada. La naranja y la mandarina aguantan hasta unos 1.600 metros — el limón sube todavía un poco más.',
+    foco: enSuelo(-6.0, -6.5),
+  },
+  {
+    id: 'senas',
+    kicker: 'Paso 3 de 4 · Las señas de cada uno',
+    texto:
+      'Al mango lo delata el brote nuevo: nace color vino, se hace cobrizo y solo después se pone verde oscuro. Al cítrico lo delata la hoja: en la base tiene una hojita chiquita pegada, el pecíolo alado, y en la rama guarda espinas. Su flor blanca es el azahar.',
+    foco: enSuelo(3.5, -8.5),
+  },
+  {
+    id: 'piso',
+    kicker: 'Paso 4 de 4 · La altura manda',
+    texto:
+      'Suba por ese camino y va cambiando de clima sin salir de la finca. Por eso el mango se queda abajo y los cítricos lo acompañan más arriba: no es capricho, es el piso térmico. Antes de sembrar, mire a qué altura está su tierra.',
+    foco: enSuelo(-1.0, -1.5),
+  },
+];
+
+const CSS = `
+.mfrutales { position: relative; width: 100%; height: 100%; overflow: hidden; background: #dfe7c6; }
+.mfrutales canvas { opacity: 0; transition: opacity 0.9s ease; }
+.mfrutales .frutales-canvas--lista canvas, .mfrutales canvas.frutales-canvas--lista { opacity: 1; }
+@media (prefers-reduced-motion: reduce) {
+  .mfrutales canvas { transition: none; }
+}
+`;
+
+/* Acento de los frutales para el panel compartido: la corteza oscura del mango
+   con el amarillo-naranja de la fruta. El color de este mundo es la cosecha. */
+const TEMA_PANEL = {
+  fondo: 'rgba(28, 18, 10, 0.68)',
+  borde: 'rgba(240, 176, 74, 0.3)',
+  tinta: '#f6eeda',
+  kicker: '#f0bc6a',
+  acentoA: 'rgba(244, 182, 60, 0.95)',
+  acentoB: 'rgba(224, 122, 28, 0.95)',
+  tintaAccion: '#2a1705',
+  activo: '#f4b63c',
+};
+
+/**
+ * El mundo de los frutales (mango + cítricos), completo: escena + pasos.
+ * Montar SOLO perezoso (lazy); llena a su contenedor.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function MundoFrutales({ tier: tierProp, reducedMotion: rmProp } = {}) {
+  // Contrato de mundos: props del host si llegan; si se monta suelto,
+  // auto-detección del equipo (no matar la gama baja).
+  const auto = useMemo(() => decidirTier(), []);
+  const tier = tierProp ?? (permite3D(auto.tier) ? auto.tier : 'bajo');
+  const reducedMotion = rmProp ?? auto.reducedMotion;
+  const [paso, setPaso] = useState(0);
+
+  const actual = PASOS[paso];
+
+  return (
+    <div className="mfrutales">
+      <style>{CSS}</style>
+      <EscenaFrutalesVivo tier={tier} reducedMotion={reducedMotion} foco={actual.foco} />
+
+      <PanelPasos
+        etiqueta="La lección de los frutales"
+        pasos={PASOS}
+        paso={paso}
+        onPaso={setPaso}
+        tema={TEMA_PANEL}
+        reducedMotion={reducedMotion}
+      />
+    </div>
+  );
+}

--- a/src/visual/mundo3d/frutales/floraFrutales.geom.js
+++ b/src/visual/mundo3d/frutales/floraFrutales.geom.js
@@ -1,0 +1,768 @@
+/*
+ * floraFrutales.geom — la GEOMETRÍA del MUNDO DE LOS FRUTALES (mango + cítricos).
+ *
+ * Van JUNTOS a propósito: comparten el arquetipo del árbol frutal de copa
+ * redondeada, y juntos enseñan lo que por separado no — EL PISO TÉRMICO. La
+ * finca sube: en la VEGA CALIENTE del frente (0–1.000 m) reinan los palos de
+ * mango, y ladera arriba, ya en clima medio, viven los cítricos (la naranja y
+ * la mandarina suben hasta ~1.600 m). Esa diferencia ES la lección: en la
+ * montaña, la altura decide qué se da. Cada especie con su identidad:
+ *
+ *   · Mango (Mangifera indica)  — árbol GRANDE y longevo, copa densa MÁS ANCHA
+ *                                 QUE ALTA, hoja lanceolada larga que brota
+ *                                 color VINO-COBRIZO y después vira a verde
+ *                                 oscuro (el detalle que lo delata), panícula
+ *                                 floral terminal crema sobre la copa, y el
+ *                                 fruto colgando de un PEDÚNCULO LARGO — aquí
+ *                                 el común de Colombia: mango de azúcar e
+ *                                 hilacha, pequeño y amarillo.
+ *   · Fruto de mango            — INSTANCIADO APARTE con color por instancia
+ *                                 (verde → amarillo dorado). El pedúnculo va EN
+ *                                 la geometría del fruto: cada mango cuelga con
+ *                                 su cordón, bien debajo de la copa.
+ *   · Cítrico (Citrus spp.)     — árbol MUCHO más chico, copa redonda compacta
+ *                                 y densa, hoja lustrosa con PECÍOLO ALADO (la
+ *                                 hojita en la base — el rasgo del género),
+ *                                 ESPINAS en las ramas bajas.
+ *   · Fruto cítrico             — instanciado con color Y escala por instancia:
+ *                                 naranja (esfera), mandarina (achatada, más
+ *                                 chica), limón pajarito (ovoide, verde — en
+ *                                 Colombia el limón se coge verde). Pegado al
+ *                                 ramaje, no colgado de cordón como el mango.
+ *   · Azahar                    — la flor blanca olorosa del cítrico, motas
+ *                                 claras sobre la copa.
+ *   · Hojarasca + piedra        — el suelo de la vega: el mango bota hoja todo
+ *                                 el año y a su sombra se junta el mantillo.
+ *
+ * LA ESCALA RELATIVA es sagrada: el mango ECLIPSA al cítrico (4–6 m contra
+ * ~2 m aquí en unidades de escena). Si quedan parejos, este mundo fracasó.
+ *
+ * TÉCNICA tier-safe (mismo contrato que floraCafetal/floraCacao): cada especie
+ * se FUSIONA en UNA geometría con color horneado en vertexColors y se dibuja
+ * con UN InstancedMesh → una draw-call por especie. Los frutos se pintan
+ * BLANCOS (el pedúnculo del mango, neutro) para que el color POR INSTANCIA
+ * sea el color real. El fruto cítrico además lleva ESCALA VECTORIAL por
+ * instancia (naranja/mandarina/limón se distinguen por proporción).
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO si se mezclan geometrías
+ * indexadas con no-indexadas (ya mordió varias veces): aquí TODO se desindexa
+ * antes de fusionar y se TRUENA si aun así falla.
+ *
+ * Aquí viven SOLO los datos y las mallas (nada de WebGL): corre headless.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* -------------------------------------------------------------------------- */
+/*  La finca frutalera (la geografía del mundo, determinista)                  */
+/* -------------------------------------------------------------------------- */
+
+export const ANCHO = 40; // x: -20 … 20
+export const FONDO = 38; // z: -19 (arriba, clima medio) … 19 (la vega caliente)
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+
+/* Ruido determinista (hash de senos): misma finca siempre, sin Math.random. */
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.8 + wz * 0.6) * 0.5 +
+    Math.sin(wx * 1.9 - wz * 1.4 + 2.3) * 0.3 +
+    Math.sin(wx * 3.1 + wz * 2.7 + 5.1) * 0.2
+  );
+}
+
+/**
+ * La altura de la finca en un punto. El frente (+z) es la VEGA CALIENTE, plana
+ * de verdad — tierra de mango. Hacia el fondo la ladera SUBE fuerte al clima
+ * medio de los cítricos: la subida es la lección hecha relieve.
+ */
+export function alturaFinca(wx, wz) {
+  const sub = smoothstep(6, -16, wz); // 0 en la vega, 1 arriba en el huerto
+  let h = 0.1;
+  h += sub * 6.4; // la ladera gana MÁS altura que en otros mundos: se debe SENTIR
+  h += ruido(wx * 0.5, wz * 0.5) * 0.35 * (0.25 + sub); // ondulación natural
+  return h;
+}
+
+/**
+ * El eje del CAMINO que sube de la casa (vega) al huerto de cítricos: la línea
+ * que el campesino camina entre sus dos pisos térmicos. La escena lo pinta.
+ */
+export function caminoX(wz) {
+  return -9.5 + smoothstep(11, -13, wz) * 11 + Math.sin(wz * 0.45) * 1.5;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Presupuesto por tier                                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Instancias por especie. 'alto' puebla la finca plena; 'medio' es frugal;
+ * 'bajo' deja lo mínimo para que AÚN se lea "el mango gigante abajo y los
+ * cítricos chicos arriba" — la escala relativa sobrevive a todo recorte.
+ */
+export const FLORA_FRUTALES = {
+  alto: { mango: 5, mangoFruto: 110, citrico: 24, citricoFruto: 320, azahar: 90, hojarasca: 10, piedra: 6 },
+  medio: { mango: 4, mangoFruto: 60, citrico: 14, citricoFruto: 180, azahar: 40, hojarasca: 6, piedra: 4 },
+  bajo: { mango: 2, mangoFruto: 24, citrico: 7, citricoFruto: 70, azahar: 0, hojarasca: 3, piedra: 2 },
+};
+
+/** Conteos para un tier (desconocido → frugal, nunca el más caro). */
+export const frutalesDeTier = (tier) => FLORA_FRUTALES[tier] || FLORA_FRUTALES.medio;
+
+/** Factor de detalle geométrico por tier (menos masas/hojas en gama baja). */
+export const CALIDAD_FRUTALES = { alto: 1, medio: 0.62, bajo: 0.42 };
+export const calidadFrutales = (tier) => CALIDAD_FRUTALES[tier] ?? CALIDAD_FRUTALES.medio;
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta de los frutales (colores horneados en vertexColors)                 */
+/* -------------------------------------------------------------------------- */
+
+export const PAL = {
+  // Mango — el gigante de tierra caliente
+  mangoTronco: '#4f3d2c', // corteza oscura, agrietada, de árbol viejo
+  mangoRama: '#5e4834', // las ramas maestras que abren la copa
+  mangoHoja: '#274d28', // el verde MUY oscuro de la copa densa
+  mangoHojaSol: '#3f7034', // la cara de la copa que da al sol
+  mangoHojaSombra: '#1d3b20', // el corazón hondo del dosel
+  mangoBroteVino: '#7e3a2c', // EL detalle: el cogollo nuevo color vino
+  mangoBroteCobre: '#a3563a', // …que va virando cobrizo antes del verde
+  paniculaCrema: '#ecd9a2', // la panícula floral terminal, crema
+  paniculaRosada: '#d9a582', // …con su rubor rosado
+
+  // Los estados del fruto de mango (van POR INSTANCIA; referencia: el mango de
+  // azúcar e hilacha colombiano — pequeño, del verde al amarillo dorado):
+  mangoVerde: '#86a83e',
+  mangoPinton: '#cfae3a',
+  mangoMaduro: '#f4b63c',
+  pedunculo: '#9aa578', // el cordón largo (neutro: el tinte lo oscurece apenas)
+
+  // Cítrico — el chico de copa redonda
+  citricoTronco: '#7a6a52',
+  citricoRama: '#8a795e',
+  citricoHoja: '#2e6b2f', // hoja lustrosa verde profundo
+  citricoHojaSol: '#49913c',
+  citricoEspina: '#a8a06a', // la espina clara en la rama joven
+  citricoAla: '#57a244', // el pecíolo alado, más tierno que la lámina
+
+  // Los frutos cítricos (POR INSTANCIA; referencia):
+  naranjaMadura: '#f08a1d',
+  mandarinaMadura: '#e8791c',
+  limonVerde: '#7fa03c', // el limón pajarito se coge VERDE en Colombia
+  limonPinton: '#c9c93e',
+  citricoVerde: '#6f9a3a', // fruto por madurar, cualquiera
+
+  // Azahar — la flor blanca olorosa
+  azahar: '#f7f3e6',
+  azaharCentro: '#e9e2a0',
+
+  // Suelo de la vega
+  hojarasca: '#8a6c42',
+  hojarasca2: '#6f5530',
+  piedra: '#8b8578',
+  liquen: '#a3a878',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Utilidades (fusión desindexada + colocación + color horneado)              */
+/* -------------------------------------------------------------------------- */
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+/** Hornea un color plano en TODOS los vértices (atributo `color`). */
+function pintar(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Coloca una geometría (posición/rotación/escala) transformando vértices. */
+function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/** Orienta el +Y de la geometría hacia `dir` y la ubica en `pos` (hojas). */
+function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    q,
+    new THREE.Vector3(esc[0], esc[1], esc[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/**
+ * Fusiona partes (ya coloreadas) en UNA geometría. Se DESINDEXA todo antes de
+ * fusionar y se TRUENA si falla: mejor un error de build que una especie
+ * invisible en producción (mordida conocida de mergeGeometries).
+ */
+function fusionar(partes) {
+  const buenas = partes.filter(Boolean).map((p) => {
+    const plana = p.index ? p.toNonIndexed() : p;
+    if (plana !== p) p.dispose();
+    return plana;
+  });
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error('floraFrutales: mergeGeometries devolvió null — atributos incompatibles entre partes');
+  }
+  return g;
+}
+
+/** Pequeña variación determinista de color (que la finca no sea plana). */
+function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  MANGO (Mangifera indica) — el gigante de la tierra caliente                */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * El porte del palo de mango, compartido con la distribución: la copa es un
+ * DOMO más ancho que alto sobre un tronco corto y grueso. El fruto no va aquí
+ * (es InstancedMesh aparte, colgado del ANILLO DE LA FALDA de esta misma copa:
+ * FALDA_MANGO dice a qué radio y altura cuelga — nada de fruta flotando).
+ */
+export const FALDA_MANGO = { radMin: 1.45, radMax: 2.35, y: 2.02 };
+
+/** La silueta a media distancia dice "mango": domo denso, bajo y ANCHO. */
+export function geomMango({ q = 1 } = {}, seed = 1) {
+  const r = rng(seed);
+  const partes = [];
+
+  // El tronco corto y GRUESO del árbol viejo (el mango es longevo: este palo
+  // ya daba fruta cuando nació la abuela).
+  const tronco = new THREE.CylinderGeometry(0.17, 0.3, 1.55, 8, 1);
+  poner(tronco, [0, 0.77, 0]);
+  partes.push(pintar(tronco, PAL.mangoTronco));
+
+  // Las ramas maestras que abren el domo (se alcanzan a ver por debajo).
+  const nRamas = Math.max(3, Math.round(4 * q));
+  for (let i = 0; i < nRamas; i++) {
+    const a = (i / nRamas) * Math.PI * 2 + r() * 0.6;
+    const rama = new THREE.CylinderGeometry(0.06, 0.11, 1.5, 5, 1);
+    apuntar(rama, [Math.cos(a) * 0.75, 1.9, Math.sin(a) * 0.75], [Math.cos(a) * 1.15, 1, Math.sin(a) * 1.15]);
+    partes.push(pintar(rama, PAL.mangoRama));
+  }
+
+  // LA COPA: el domo denso MÁS ANCHO QUE ALTO (≈6 de ancho por ≈2.3 de alto).
+  // Masa central + anillo + falda baja: de lejos UNA sola bóveda tupida.
+  const centro = new THREE.IcosahedronGeometry(1.5, 1);
+  poner(centro, [0, 2.75, 0], [0, r() * Math.PI, 0], [1.7, 0.85, 1.7]);
+  partes.push(pintar(centro, variar(PAL.mangoHoja, r, 0.05)));
+
+  const nAnillo = Math.max(4, Math.round(6 * q));
+  for (let i = 0; i < nAnillo; i++) {
+    const a = (i / nAnillo) * Math.PI * 2 + 0.4;
+    const masa = new THREE.IcosahedronGeometry(1.0 + r() * 0.25, 1);
+    poner(
+      masa,
+      [Math.cos(a) * 1.55, 2.45 + (r() - 0.5) * 0.45, Math.sin(a) * 1.55],
+      [0, r() * Math.PI, 0],
+      [1.6, 0.78, 1.6],
+    );
+    partes.push(pintar(masa, variar(i % 2 ? PAL.mangoHojaSol : PAL.mangoHoja, r, 0.06)));
+  }
+  // la falda baja del domo (la copa del mango casi barre el suelo de sombra)
+  const nFalda = Math.max(3, Math.round(4 * q));
+  for (let i = 0; i < nFalda; i++) {
+    const a = (i / nFalda) * Math.PI * 2 + 1.1;
+    const masa = new THREE.IcosahedronGeometry(0.8 + r() * 0.2, 1);
+    poner(
+      masa,
+      [Math.cos(a) * 1.95, 1.95 + (r() - 0.5) * 0.2, Math.sin(a) * 1.95],
+      [0, r() * Math.PI, 0],
+      [1.45, 0.7, 1.45],
+    );
+    partes.push(pintar(masa, variar(PAL.mangoHojaSombra, r, 0.05)));
+  }
+
+  // EL BROTE VINO-COBRIZO: el cogollo nuevo de la punta que brota color vino y
+  // después vira a verde — el detalle que delata al mango y nadie dibuja. Motas
+  // en el borde alto de la copa, del vino al cobre.
+  const nBrotes = Math.max(3, Math.round(6 * q));
+  for (let i = 0; i < nBrotes; i++) {
+    const a = (i / nBrotes) * Math.PI * 2 + r() * 0.8;
+    const rad = 2.1 + r() * 0.6;
+    const mezcla = new THREE.Color(PAL.mangoBroteVino).lerp(new THREE.Color(PAL.mangoBroteCobre), r());
+    const brote = new THREE.IcosahedronGeometry(0.34 + r() * 0.16, 0);
+    poner(
+      brote,
+      [Math.cos(a) * rad, 2.85 + (r() - 0.5) * 0.6, Math.sin(a) * rad],
+      [0, r() * Math.PI, 0],
+      [1.25, 0.7, 1.25],
+    );
+    partes.push(pintar(brote, mezcla));
+  }
+
+  // La HOJA LANCEOLADA: larga y angosta, cuelga de la falda de la copa (a esta
+  // escala se hornean mechones de hojas colgantes, no la hoja una a una).
+  const nHojas = Math.max(8, Math.round(22 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const a = r() * Math.PI * 2;
+    const rad = 2.1 + r() * 0.85;
+    const hoja = new THREE.SphereGeometry(1, 4, 2);
+    apuntar(
+      hoja,
+      [Math.cos(a) * rad, 2.0 + r() * 0.7, Math.sin(a) * rad],
+      [Math.cos(a) * 0.55, -1, Math.sin(a) * 0.55], // colgando hacia afuera-abajo
+      [0.05, 0.3, 0.017],
+    );
+    partes.push(pintar(hoja, variar(i % 3 ? PAL.mangoHoja : PAL.mangoHojaSol, r, 0.05)));
+  }
+
+  // LA PANÍCULA terminal: el ramillete floral crema-rosado que se PARA sobre
+  // la copa en las puntas — la señal de que el palo está "enflorado".
+  const nPan = Math.max(3, Math.round(8 * q));
+  for (let i = 0; i < nPan; i++) {
+    const a = (i / nPan) * Math.PI * 2 + r() * 0.7;
+    const rad = 0.5 + r() * 1.7;
+    const px = Math.cos(a) * rad;
+    const pz = Math.sin(a) * rad;
+    const py = 3.55 + (r() - 0.5) * 0.3 - rad * 0.22; // sigue la curva del domo
+    const tallito = new THREE.CylinderGeometry(0.016, 0.022, 0.22, 3, 1);
+    poner(tallito, [px, py + 0.1, pz], [(r() - 0.5) * 0.3, 0, (r() - 0.5) * 0.3]);
+    partes.push(pintar(tallito, PAL.mangoBroteCobre));
+    const pan = new THREE.ConeGeometry(0.15 + r() * 0.05, 0.4 + r() * 0.12, 5, 1);
+    poner(pan, [px, py + 0.42, pz], [(r() - 0.5) * 0.25, r() * Math.PI, (r() - 0.5) * 0.25]);
+    const cPan = new THREE.Color(PAL.paniculaCrema).lerp(new THREE.Color(PAL.paniculaRosada), r() * 0.6);
+    partes.push(pintar(pan, cPan));
+  }
+
+  return fusionar(partes);
+}
+
+/** El fruto de mango CON su pedúnculo largo: el origen es el punto donde el
+    cordón agarra de la rama — el fruto queda colgando 0.6 más abajo, bien
+    despegado de la copa (así carga el mango de verdad). Se pinta con neutros:
+    el color POR INSTANCIA (verde → amarillo) es el color real. */
+export function geomMangoFruto() {
+  const cordon = new THREE.CylinderGeometry(0.008, 0.011, 0.56, 3, 1);
+  poner(cordon, [0, -0.28, 0]);
+  const fruto = new THREE.IcosahedronGeometry(0.09, 1);
+  poner(fruto, [0.012, -0.62, 0], [0, 0, 0.16], [0.92, 1.18, 0.86]); // ovoide, apenas ladeado
+  return fusionar([pintar(cordon, PAL.pedunculo), pintar(fruto, '#ffffff')]);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  CÍTRICO (Citrus spp.) — el chico de copa redonda del clima medio           */
+/* -------------------------------------------------------------------------- */
+
+/* El radio de la bola de copa (compartido con la distribución: los frutos y el
+   azahar se siembran SOBRE esta misma superficie, pegados al ramaje). */
+export const COPA_CITRICO = { rad: 0.72, y: 1.14 };
+
+/** La silueta a media distancia dice "cítrico": una paleta redonda compacta,
+    chiquita, con puntos de color de fruta. */
+export function geomCitrico({ q = 1 } = {}, seed = 2) {
+  const r = rng(seed);
+  const partes = [];
+
+  // Tronco corto y delgado.
+  const tronco = new THREE.CylinderGeometry(0.045, 0.075, 0.62, 6, 1);
+  poner(tronco, [0, 0.31, 0]);
+  partes.push(pintar(tronco, PAL.citricoTronco));
+
+  // Dos ramas bajas visibles (donde se ven las espinas).
+  for (let i = 0; i < 2; i++) {
+    const a = i * 2.6 + r();
+    const rama = new THREE.CylinderGeometry(0.018, 0.03, 0.42, 4, 1);
+    apuntar(rama, [Math.cos(a) * 0.2, 0.62, Math.sin(a) * 0.2], [Math.cos(a), 1.1, Math.sin(a)]);
+    partes.push(pintar(rama, PAL.citricoRama));
+  }
+
+  // LAS ESPINAS de la rama joven: conitos claros en la madera baja — el género
+  // Citrus las trae de fábrica y aquí se ven.
+  const nEsp = Math.max(3, Math.round(7 * q));
+  for (let i = 0; i < nEsp; i++) {
+    const a = r() * Math.PI * 2;
+    const rad = 0.16 + r() * 0.3;
+    const esp = new THREE.ConeGeometry(0.013, 0.075, 3, 1);
+    apuntar(
+      esp,
+      [Math.cos(a) * rad, 0.5 + r() * 0.38, Math.sin(a) * rad],
+      [Math.cos(a), 0.35 + r() * 0.5, Math.sin(a)],
+    );
+    partes.push(pintar(esp, PAL.citricoEspina));
+  }
+
+  // LA COPA: bola compacta y densa (masa central + tres refuerzos): la paleta
+  // redonda del naranjo. Baja, casi desde el suelo — el cítrico se cosecha
+  // parado, sin escalera.
+  const centro = new THREE.IcosahedronGeometry(0.66, 1);
+  poner(centro, [0, COPA_CITRICO.y, 0], [0, r() * Math.PI, 0], [1.06, 0.98, 1.06]);
+  partes.push(pintar(centro, variar(PAL.citricoHoja, r, 0.05)));
+  for (let i = 0; i < 3; i++) {
+    const a = (i / 3) * Math.PI * 2 + 0.8;
+    const masa = new THREE.IcosahedronGeometry(0.42 + r() * 0.1, 1);
+    poner(
+      masa,
+      [Math.cos(a) * 0.36, COPA_CITRICO.y + (r() - 0.5) * 0.4, Math.sin(a) * 0.36],
+      [0, r() * Math.PI, 0],
+      [1.05, 0.95, 1.05],
+    );
+    partes.push(pintar(masa, variar(i % 2 ? PAL.citricoHojaSol : PAL.citricoHoja, r, 0.06)));
+  }
+
+  // La HOJA HÉROE con su PECÍOLO ALADO: en el borde de la copa, la lámina
+  // lustrosa y — pegadita en su base — la hojita menor del pecíolo: EL rasgo
+  // diagnóstico del género Citrus, dibujado donde se alcanza a ver.
+  const nHojas = Math.max(4, Math.round(8 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const a = (i / nHojas) * Math.PI * 2 + r() * 0.5;
+    const inc = 0.15 + r() * 0.75; // inclinación sobre el ecuador de la copa
+    const dx = Math.cos(a) * Math.cos(inc);
+    const dy = Math.sin(inc);
+    const dz = Math.sin(a) * Math.cos(inc);
+    const px = dx * COPA_CITRICO.rad * 0.98;
+    const py = COPA_CITRICO.y + dy * COPA_CITRICO.rad * 0.9;
+    const pz = dz * COPA_CITRICO.rad * 0.98;
+    // el ala (pecíolo alado): la hojita chica, primero, pegada a la copa
+    const ala = new THREE.SphereGeometry(1, 4, 2);
+    apuntar(ala, [px, py, pz], [dx, dy + 0.25, dz], [0.026, 0.04, 0.012]);
+    partes.push(pintar(ala, PAL.citricoAla));
+    // la lámina: la hoja grande lustrosa, saliendo del ala hacia afuera
+    const lamina = new THREE.SphereGeometry(1, 4, 2);
+    apuntar(
+      lamina,
+      [px + dx * 0.09, py + dy * 0.07 + 0.02, pz + dz * 0.09],
+      [dx, dy + 0.15, dz],
+      [0.055, 0.115, 0.018],
+    );
+    partes.push(pintar(lamina, variar(i % 2 ? PAL.citricoHojaSol : PAL.citricoHoja, r, 0.05)));
+  }
+
+  return fusionar(partes);
+}
+
+/** El fruto cítrico: esfera pintada blanca — color Y proporción van POR
+    INSTANCIA (naranja esfera / mandarina achatada / limón ovoide). */
+export function geomCitricoFruto() {
+  const g = new THREE.IcosahedronGeometry(0.078, 1);
+  return pintar(g.index ? g.toNonIndexed() : g, '#ffffff');
+}
+
+/** El AZAHAR: el ramillete blanco oloroso del cítrico (motas + centro pálido).
+    Chiquito: perfuma más de lo que abulta. */
+export function geomAzahar(seed = 7) {
+  const r = rng(seed);
+  const partes = [];
+  for (let i = 0; i < 3; i++) {
+    const a = (i / 3) * Math.PI * 2 + r();
+    const mota = new THREE.IcosahedronGeometry(0.03 + r() * 0.014, 0);
+    poner(
+      mota,
+      [Math.cos(a) * 0.038, (r() - 0.5) * 0.024, Math.sin(a) * 0.038],
+      [r() * 0.6, r() * Math.PI, r() * 0.6],
+      [1.15, 0.8, 1.15],
+    );
+    partes.push(pintar(mota, PAL.azahar));
+  }
+  const centro = new THREE.IcosahedronGeometry(0.02, 0);
+  poner(centro, [0, 0.026, 0]);
+  partes.push(pintar(centro, PAL.azaharCentro));
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Suelo: hojarasca y piedra                                                  */
+/* -------------------------------------------------------------------------- */
+
+export function geomHojarasca(seed = 5) {
+  const r = rng(seed);
+  const partes = [];
+  for (let i = 0; i < 3; i++) {
+    const mancha = new THREE.CylinderGeometry(0.34 + r() * 0.3, 0.42 + r() * 0.32, 0.035, 7, 1);
+    poner(mancha, [(r() - 0.5) * 0.5, 0.02 + i * 0.012, (r() - 0.5) * 0.5], [0, r() * Math.PI, 0]);
+    partes.push(pintar(mancha, i % 2 ? PAL.hojarasca2 : PAL.hojarasca));
+  }
+  return fusionar(partes);
+}
+
+export function geomPiedra(seed = 6) {
+  const r = rng(seed);
+  const roca = new THREE.DodecahedronGeometry(0.32, 0);
+  poner(roca, [0, 0.14, 0], [r() * 0.6, r() * Math.PI, r() * 0.6], [1.25, 0.7, 1]);
+  const capa = new THREE.DodecahedronGeometry(0.18, 0);
+  poner(capa, [0.12, 0.24, 0.05], [0, r() * Math.PI, 0], [1, 0.55, 1]);
+  return fusionar([pintar(roca, PAL.piedra), pintar(capa, PAL.liquen)]);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Distribución: la vega del mango abajo, el huerto de cítricos arriba        */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Los MANGOS viven FIJOS en la vega caliente (z > 4, la parte plana): pocos y
+ * MONUMENTALES — finca campesina, no plantación. El PRIMERO es el héroe: el
+ * palo del patio, al lado de la casa (todo patio de tierra caliente tiene su
+ * palo 'e mango). El ORDEN importa: se recorta por tier con slice y hasta
+ * 'bajo' conserva el héroe + uno.
+ */
+export const SITIOS_MANGO = [
+  { p: [-4.2, 8.6], esc: 1.7 }, // EL HÉROE: el palo del patio
+  { p: [8.5, 12.0], esc: 1.45 },
+  { p: [15.0, 6.5], esc: 1.2 },
+  { p: [-13.5, 15.0], esc: 1.3 },
+  { p: [3.0, 16.5], esc: 1.35 },
+];
+
+/*
+ * El huerto de CÍTRICOS vive ladera ARRIBA (z < -4, ya en clima medio), en
+ * matas de 3–5 alrededor de un centro — como siembra el campesino, por golpes,
+ * NUNCA en cuadrícula. Cada mata tiene su variedad dominante:
+ * 0 = naranjo · 1 = mandarino · 2 = limonero. El orden reparte las tres
+ * variedades primero, para que todo tier las conserve.
+ */
+export const MATAS_CITRICOS = [
+  { c: [-6.0, -6.5], n: 5, variante: 0 },
+  { c: [3.5, -8.5], n: 4, variante: 1 },
+  { c: [-1.0, -12.5], n: 4, variante: 2 },
+  { c: [8.5, -5.5], n: 4, variante: 0 },
+  { c: [-11.5, -10.5], n: 4, variante: 1 },
+  { c: [11.5, -11.5], n: 3, variante: 2 },
+];
+
+/* La casa campesina vive en la vega, a la sombra del mango del patio. */
+export const SITIO_CASA = /** @type {[number, number]} */ ([-9.5, 11.0]);
+
+/**
+ * Siembra determinista de la finca frutalera completa. Devuelve items por
+ * especie: `{pos, rotY, escala, tint}` (contrato del componente `Especie`).
+ * En los FRUTOS el `tint` ES el color real y en el cítrico `escala` es un
+ * VECTOR [x,y,z]: la proporción distingue naranja / mandarina / limón.
+ * (A diferencia del cafetal, aquí la calidad del tier NO cambia la siembra:
+ * los frutos cuelgan de FALDA_MANGO y COPA_CITRICO, anillos que todo tier
+ * dibuja — el parámetro `_q` queda reservado por simetría de contrato.)
+ */
+export function distribucionFrutales(conteos, seed = 421, _q = 1) {
+  const c = conteos;
+  const rMan = rng(seed + 1);
+  const rCit = rng(seed + 2);
+  const rFru = rng(seed + 3);
+  const rSue = rng(seed + 4);
+  const rAza = rng(seed + 5);
+
+  // --- Los mangos de la vega (fijos, recortados por tier). ---
+  const sitiosMango = SITIOS_MANGO.slice(0, c.mango).map((s) => ({
+    ...s,
+    rotY: rMan() * Math.PI * 2,
+  }));
+  const mango = sitiosMango.map((s) => ({
+    pos: [s.p[0], alturaFinca(s.p[0], s.p[1]), s.p[1]],
+    rotY: s.rotY,
+    escala: s.esc,
+    tint: [0.93 + rMan() * 0.14, 0.93 + rMan() * 0.14, 0.93 + rMan() * 0.14],
+  }));
+
+  // --- El fruto del mango: colgado del anillo de la FALDA de la copa (la
+  //     misma que dibuja geomMango), con su pedúnculo largo en la geometría.
+  //     En racimos de 2–3, como carga el mango de azúcar. ---
+  const verde = new THREE.Color(PAL.mangoVerde);
+  const pinton = new THREE.Color(PAL.mangoPinton);
+  const maduro = new THREE.Color(PAL.mangoMaduro);
+  const col = new THREE.Color();
+  const mangoFruto = [];
+  let mi = 0;
+  while (mangoFruto.length < c.mangoFruto && sitiosMango.length > 0) {
+    const s = sitiosMango[mi % sitiosMango.length];
+    mi += 1;
+    if (mi > c.mangoFruto * 3) break;
+    const a = rFru() * Math.PI * 2;
+    const rad = FALDA_MANGO.radMin + rFru() * (FALDA_MANGO.radMax - FALDA_MANGO.radMin);
+    const cuantos = 2 + Math.floor(rFru() * 2);
+    for (let k = 0; k < cuantos && mangoFruto.length < c.mangoFruto; k++) {
+      const ak = a + (rFru() - 0.5) * 0.22;
+      const radk = rad + (rFru() - 0.5) * 0.2;
+      const m = rFru(); // madurez del fruto
+      if (m < 0.45) col.lerpColors(verde, pinton, m / 0.45);
+      else col.lerpColors(pinton, maduro, (m - 0.45) / 0.55);
+      col.multiplyScalar(0.94 + rFru() * 0.12);
+      mangoFruto.push({
+        pos: [
+          s.p[0] + Math.cos(ak) * radk * s.esc,
+          alturaFinca(s.p[0], s.p[1]) + (FALDA_MANGO.y + (rFru() - 0.5) * 0.3) * s.esc,
+          s.p[1] + Math.sin(ak) * radk * s.esc,
+        ],
+        rotY: rFru() * Math.PI * 2,
+        escala: (0.8 + rFru() * 0.45) * Math.min(1.15, s.esc * 0.75),
+        tint: [col.r, col.g, col.b],
+      });
+    }
+  }
+
+  // --- El huerto de cítricos: matas por golpes, jitter alrededor del centro
+  //     (nunca cuadrícula), recortadas PAREJO entre matas por tier. ---
+  const arbolitos = [];
+  MATAS_CITRICOS.forEach((mata, im) => {
+    for (let i = 0; i < mata.n; i++) {
+      const a = rCit() * Math.PI * 2;
+      const rad = 1.3 + rCit() * 1.5;
+      const px = mata.c[0] + Math.cos(a) * rad;
+      const pz = mata.c[1] + Math.sin(a) * rad;
+      arbolitos.push({
+        px, pz,
+        variante: mata.variante,
+        esc: (mata.variante === 0 ? 0.95 : 0.85) + rCit() * 0.25,
+        rotY: rCit() * Math.PI * 2,
+        carga: rCit(), // qué tan cargado de fruta está
+        orden: i * MATAS_CITRICOS.length + im, // intercalado: recorte parejo
+      });
+    }
+  });
+  arbolitos.sort((x, y) => x.orden - y.orden);
+  const arboles = arbolitos.slice(0, c.citrico);
+
+  const citrico = arboles.map((s) => ({
+    pos: [s.px, alturaFinca(s.px, s.pz), s.pz],
+    rotY: s.rotY,
+    escala: s.esc,
+    tint: [0.93 + rCit() * 0.14, 0.93 + rCit() * 0.14, 0.93 + rCit() * 0.14],
+  }));
+
+  // --- El fruto cítrico: PEGADO al ramaje (sobre la superficie de la misma
+  //     copa que dibuja geomCitrico), en golpes de 2–4. Color y PROPORCIÓN por
+  //     variedad: naranja esfera, mandarina achatada, limón pajarito ovoide y
+  //     VERDE (en Colombia el limón se coge verde). ---
+  const cNaranja = new THREE.Color(PAL.naranjaMadura);
+  const cMandarina = new THREE.Color(PAL.mandarinaMadura);
+  const cLimonV = new THREE.Color(PAL.limonVerde);
+  const cLimonP = new THREE.Color(PAL.limonPinton);
+  const cVerde = new THREE.Color(PAL.citricoVerde);
+  const citricoFruto = [];
+  const cargados = arboles.filter((s) => s.carga > 0.22);
+  let ci = 0;
+  while (citricoFruto.length < c.citricoFruto && cargados.length > 0) {
+    const s = cargados[ci % cargados.length];
+    ci += 1;
+    if (ci > c.citricoFruto * 3) break;
+    const a0 = rFru() * Math.PI * 2;
+    const inc0 = -0.25 + rFru() * 1.1; // del ecuador hacia arriba (donde da el sol)
+    const cuantos = 2 + Math.floor(rFru() * 3);
+    for (let k = 0; k < cuantos && citricoFruto.length < c.citricoFruto; k++) {
+      const a = a0 + (rFru() - 0.5) * 0.5;
+      const inc = clamp(inc0 + (rFru() - 0.5) * 0.4, -0.5, 1.25);
+      const dx = Math.cos(a) * Math.cos(inc);
+      const dy = Math.sin(inc);
+      const dz = Math.sin(a) * Math.cos(inc);
+      const madurez = rFru();
+      let esc;
+      if (s.variante === 0) {
+        // naranjo: la esfera clásica
+        col.copy(madurez < 0.3 ? cVerde : cNaranja);
+        const t = 0.9 + rFru() * 0.3;
+        esc = [t, t * 0.97, t];
+      } else if (s.variante === 1) {
+        // mandarino: más chica y ACHATADA, carga pesado
+        col.copy(madurez < 0.22 ? cVerde : cMandarina);
+        const t = 0.72 + rFru() * 0.22;
+        esc = [t * 1.08, t * 0.76, t * 1.08];
+      } else {
+        // limonero: el pajarito ovoide, verde o apenas pintón
+        col.lerpColors(cLimonV, cLimonP, madurez * madurez);
+        const t = 0.62 + rFru() * 0.2;
+        esc = [t * 0.86, t * 1.14, t * 0.86];
+      }
+      col.multiplyScalar(0.94 + rFru() * 0.12);
+      citricoFruto.push({
+        pos: [
+          s.px + dx * COPA_CITRICO.rad * 0.94 * s.esc,
+          alturaFinca(s.px, s.pz) + (COPA_CITRICO.y + dy * COPA_CITRICO.rad * 0.88) * s.esc,
+          s.pz + dz * COPA_CITRICO.rad * 0.94 * s.esc,
+        ],
+        rotY: rFru() * Math.PI * 2,
+        escala: esc,
+        tint: [col.r, col.g, col.b],
+      });
+    }
+  }
+
+  // --- El AZAHAR: sobre las copas MENOS cargadas (el cítrico que no está en
+  //     cosecha está en flor — los dos tiempos conviven en el huerto). ---
+  const azahar = [];
+  const floridos = arboles.filter((s) => s.carga <= 0.55);
+  let fi = 0;
+  while (azahar.length < (c.azahar || 0) && floridos.length > 0) {
+    const s = floridos[fi % floridos.length];
+    fi += 1;
+    if (fi > (c.azahar || 0) * 3) break;
+    const a = rAza() * Math.PI * 2;
+    const inc = 0.1 + rAza() * 1.1;
+    const dx = Math.cos(a) * Math.cos(inc);
+    const dy = Math.sin(inc);
+    const dz = Math.sin(a) * Math.cos(inc);
+    azahar.push({
+      pos: [
+        s.px + dx * COPA_CITRICO.rad * 0.99 * s.esc,
+        alturaFinca(s.px, s.pz) + (COPA_CITRICO.y + dy * COPA_CITRICO.rad * 0.94) * s.esc,
+        s.pz + dz * COPA_CITRICO.rad * 0.99 * s.esc,
+      ],
+      rotY: rAza() * Math.PI * 2,
+      escala: 0.85 + rAza() * 0.4,
+      tint: [1, 0.99 - rAza() * 0.02, 0.96 - rAza() * 0.03],
+    });
+  }
+
+  // --- El suelo de la vega: hojarasca bajo los mangos (el mango bota hoja
+  //     todo el año), piedras sueltas en el plano caliente. ---
+  const hojarasca = [];
+  for (let i = 0; i < c.hojarasca; i++) {
+    const s = sitiosMango[i % Math.max(1, sitiosMango.length)] || { p: [0, 10], esc: 1 };
+    const a = rSue() * Math.PI * 2;
+    const rad = (0.8 + rSue() * 1.8) * s.esc;
+    const x = s.p[0] + Math.cos(a) * rad;
+    const z = s.p[1] + Math.sin(a) * rad;
+    hojarasca.push({
+      pos: [x, alturaFinca(x, z) + 0.01, z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.8 + rSue() * 0.7,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+  const piedra = [];
+  for (let i = 0; i < c.piedra; i++) {
+    const x = -17 + rSue() * 34;
+    const z = 3 + rSue() * 14; // las piedras viven en la vega caliente
+    piedra.push({
+      pos: [x, alturaFinca(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.7 + rSue() * 0.9,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+
+  return { mango, mangoFruto, citrico, citricoFruto, azahar, hojarasca, piedra };
+}
+
+/** Los centros de sombra de los mangos del tier (para la luz colada bajo el
+    domo: la sombra del palo de mango ES el lugar social de la tierra caliente). */
+export function centrosMango(conteos) {
+  return SITIOS_MANGO.slice(0, conteos.mango).map((s) => ({
+    centro: /** @type {[number, number, number]} */ ([s.p[0], alturaFinca(s.p[0], s.p[1]), s.p[1]]),
+    radio: 2.4 * s.esc,
+  }));
+}

--- a/src/visual/mundo3d/frutales/floraFrutales.geom.js
+++ b/src/visual/mundo3d/frutales/floraFrutales.geom.js
@@ -106,10 +106,15 @@ export function caminoX(wz) {
  * 'bajo' deja lo mínimo para que AÚN se lea "el mango gigante abajo y los
  * cítricos chicos arriba" — la escala relativa sobrevive a todo recorte.
  */
+/* La CARGA es alta a propósito, y es lo cierto: un palo de mango en cosecha y
+   un naranjo bueno cargan a cientos de frutos. Además es el color que levanta
+   la escena — al mundo del café le pasó que quedó pardo y mustio al lado del
+   valle, y aquí el amarillo del mango y el naranja del cítrico son la defensa.
+   (Medido contra el cafetal: ~1.5x su área de fruta y bastante más claro.) */
 export const FLORA_FRUTALES = {
-  alto: { mango: 5, mangoFruto: 110, citrico: 24, citricoFruto: 320, azahar: 90, hojarasca: 10, piedra: 6 },
-  medio: { mango: 4, mangoFruto: 60, citrico: 14, citricoFruto: 180, azahar: 40, hojarasca: 6, piedra: 4 },
-  bajo: { mango: 2, mangoFruto: 24, citrico: 7, citricoFruto: 70, azahar: 0, hojarasca: 3, piedra: 2 },
+  alto: { mango: 5, mangoFruto: 165, citrico: 24, citricoFruto: 430, azahar: 90, hojarasca: 10, piedra: 6 },
+  medio: { mango: 4, mangoFruto: 92, citrico: 14, citricoFruto: 240, azahar: 40, hojarasca: 6, piedra: 4 },
+  bajo: { mango: 2, mangoFruto: 34, citrico: 7, citricoFruto: 92, azahar: 0, hojarasca: 3, piedra: 2 },
 };
 
 /** Conteos para un tier (desconocido → frugal, nunca el más caro). */


### PR DESCRIPTION
Mango y cítricos van en **una sola escena a propósito**: comparten el arquetipo de árbol frutal de copa redondeada, y juntos enseñan lo que por separado no — **el piso térmico**. El mango es de tierra caliente (0-1.000 m) y los cítricos suben al clima medio (la naranja y la mandarina hasta ~1.600 m, el limón un poco más). Esa diferencia ES la lección.

La escena la vuelve relieve: al frente la **vega caliente** con los palos de mango y la casa a su sombra; ladera arriba el **huerto de cítricos**; entre los dos, el camino que el campesino sube. El color del suelo también cambia con la altura.

## Lo que se sostiene como cierto

**Mango** (*Mangifera indica*) — copa más ancha que alta, tronco corto y grueso de árbol longevo, **brote vino-cobrizo** que después vira a verde oscuro (el detalle que lo delata y nadie dibuja), **panícula terminal** crema-rosada sobre la copa, hoja lanceolada colgante, y el fruto de **azúcar e hilacha** — pequeño y amarillo, no la variedad gigante de exportación — colgando de su **pedúnculo largo**, que va en la geometría del fruto.

**Cítricos** (*Citrus* spp.) — copa redonda compacta, **pecíolo alado** (la hojita en la base de la lámina: el rasgo diagnóstico del género, dibujado donde se alcanza a ver), **espinas** en la madera baja, **azahar** blanco. Naranja, mandarina y limón se distinguen por color **y proporción** por instancia: la naranja esférica, la mandarina achatada, el limón pajarito ovoide y verde.

## Lo que se midió, no se opinó

**La escala relativa** — mango 6,9 de alto por 11,6 de ancho contra cítrico 1,79 × 1,77. El mango dobla largo al cítrico en todo tier; el héroe de la vega va a escala 1,7.

**La silueta a media distancia** — al café le pasó que de lejos los cafetos parecían pinos. Hay un guard permanente que mide el perfil de ancho por franjas de altura (lo único que sobrevive a la distancia) y exige en **todo tier** que el mango lea domo (ensancha a media altura, cierra arriba, nunca cono) y el cítrico lea bola.

**La paleta** — al café le pasó que quedó pardo y mustio al lado del valle. Medido contra él: **1,55x su área de color de fruta y 35% más clara** (luz media 0,33 contra 0,245), concentrada en 29 árboles en vez de 120 matas. La carga alta además es cierta: un palo de mango en cosecha y un naranjo bueno cargan a cientos.

## Contrato del framework

Mismo molde que el cafetal: geometría fusionada por especie → un InstancedMesh por especie (una draw-call), color por instancia en los frutos, atmósfera viva de la hora del valle (familia `plaza`: la tierra caliente es luz abierta), terreno por bandas toon, device-tiering real, `reducedMotion` monta quieto. Todo desindexado antes de fusionar, con `throw` si `mergeGeometries` devuelve null. Autocontenido: cero CDN, cero imágenes. Copy en español de Colombia, de usted.

Siembra por golpes alrededor de un centro, nunca en cuadrícula.

## Pendiente

Sin cablear a rutas todavía (lo hace el coordinador). Falta la captura.

35 tests nuevos en verde. Los fallos de `bosqueRealismo`, `entradaValle3D.nav` y compañía **ya existen en la rama base** — verificado corriéndolos sobre `origin/integra/todo-3d-a-prod` limpia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)