### PR TITLE
El mundo de la caña y el trapiche

### DIFF
--- a/src/mockups/CanaTrapiche3D.css
+++ b/src/mockups/CanaTrapiche3D.css
@@ -1,0 +1,300 @@
+/*
+ * CanaTrapiche3D.css — vitrina del mundo de la caña (#/mockups/cana-trapiche-3d).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Paleta de tierra caliente: el dorado seco del cañaveral, el pardo quemado de
+ * la hornilla y el ámbar de la miel. Solo opacity/transform se animan.
+ */
+
+.ctrap {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  /* la familia plaza bajo la hora dorada (paleta madre): tierra baja, no menta */
+  background: linear-gradient(180deg, #ecdcb6 0%, #f0e2c2 46%, #f6ecd4 100%);
+  color: #33291b;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.ctrap__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.ctrap__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #9a4a1c;
+}
+.ctrap__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #43361f;
+}
+.ctrap__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 40rem;
+}
+
+.ctrap__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+.ctrap__lienzo {
+  position: relative;
+  height: min(66vh, 32rem);
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(154, 74, 28, 0.28);
+  box-shadow: 0 12px 30px rgba(58, 42, 22, 0.18);
+  background: radial-gradient(120% 90% at 52% 22%, #e8d2a2 0%, #c3a878 100%);
+}
+.ctrap__lienzo canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+}
+.ctrap__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.95rem;
+  color: #5a4423;
+  background: radial-gradient(120% 90% at 52% 22%, #e8d2a2 0%, #c3a878 100%);
+}
+
+.ctrap__barra {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0.6rem 0 0;
+}
+.ctrap__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: #5b4a2e;
+  flex: 1 1 14rem;
+}
+.ctrap__toggle {
+  flex: 0 0 auto;
+  padding: 0.5rem 0.95rem;
+  border: 1px solid rgba(154, 74, 28, 0.4);
+  border-radius: 999px;
+  background: linear-gradient(180deg, #f0a83e 0%, #c9761f 100%);
+  color: #2a1606;
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+.ctrap__toggle:hover {
+  opacity: 0.92;
+}
+.ctrap__toggle:active {
+  transform: scale(0.97);
+}
+.ctrap__toggle:focus-visible {
+  outline: 3px solid #7a3d10;
+  outline-offset: 2px;
+}
+
+.ctrap__saberes {
+  max-width: 46rem;
+  margin: 1.8rem auto 0;
+}
+.ctrap__saberes h2 {
+  margin: 0 0 0.7rem;
+  font-size: clamp(1.15rem, 4vw, 1.5rem);
+  color: #43361f;
+}
+.ctrap__saberes ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.7rem;
+}
+.ctrap__saberes li {
+  display: flex;
+  gap: 0.7rem;
+  align-items: flex-start;
+  padding: 0.8rem 0.9rem;
+  border-radius: 12px;
+  background: rgba(255, 250, 238, 0.72);
+  border: 1px solid rgba(154, 74, 28, 0.16);
+}
+.ctrap__emoji {
+  font-size: 1.35rem;
+  line-height: 1.2;
+  flex: 0 0 auto;
+}
+.ctrap__saberes b {
+  display: block;
+  margin-bottom: 0.15rem;
+  color: #7a3d10;
+  font-size: 0.98rem;
+}
+.ctrap__saberes p {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+.ctrap__cierre {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  font-style: italic;
+  color: #5b4a2e;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  La ficha: el fallback digno para equipo humilde / sin WebGL                */
+/* -------------------------------------------------------------------------- */
+
+.ctrap__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  padding: 1rem;
+  background: linear-gradient(180deg, #e8d2a2 0%, #cdb582 62%, #b59a6a 100%);
+}
+.ctrap__estampa {
+  position: relative;
+  width: 200px;
+  height: 190px;
+  margin-bottom: 0.4rem;
+}
+
+/* la enramada del fondo: techo a dos aguas sobre sus horcones */
+.ctrap__enramada {
+  position: absolute;
+  right: 4px;
+  bottom: 34px;
+  width: 108px;
+  height: 52px;
+  background:
+    linear-gradient(180deg, #b0603f 0%, #b0603f 34%, transparent 34%),
+    linear-gradient(90deg, transparent 8%, #7a5a38 8%, #7a5a38 13%, transparent 13%,
+      transparent 46%, #7a5a38 46%, #7a5a38 51%, transparent 51%,
+      transparent 86%, #7a5a38 86%, #7a5a38 91%, transparent 91%);
+  clip-path: polygon(0 34%, 50% 0, 100% 34%, 100% 100%, 0 100%);
+}
+.ctrap__chimenea {
+  position: absolute;
+  right: 92px;
+  bottom: 66px;
+  width: 13px;
+  height: 40px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #4a3a30 0%, #a35a3c 45%, #8f4b31 100%);
+}
+.ctrap__humo {
+  position: absolute;
+  right: 90px;
+  bottom: 104px;
+  width: 17px;
+  height: 40px;
+  border-radius: 50% 50% 40% 60%;
+  background: radial-gradient(circle at 40% 80%, rgba(150, 143, 133, 0.62), rgba(150, 143, 133, 0) 70%);
+}
+
+/* LA CAÑA: un tallo con sus NUDOS bien marcados — la firma de la planta */
+.ctrap__cana {
+  position: absolute;
+  left: 44px;
+  bottom: 12px;
+  width: 15px;
+  height: 152px;
+  border-radius: 7px;
+  background: linear-gradient(90deg, #6f8a34 0%, #9ab84c 38%, #7d9a3c 100%);
+  box-shadow: 0 2px 6px rgba(50, 38, 18, 0.28);
+}
+.ctrap__cana i {
+  position: absolute;
+  left: -2px;
+  width: 19px;
+  height: 5px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #b9cd82 0%, #e3ecc2 45%, #adc276 100%);
+}
+.ctrap__cana i:nth-child(1) { bottom: 20px; }
+.ctrap__cana i:nth-child(2) { bottom: 48px; }
+.ctrap__cana i:nth-child(3) { bottom: 76px; }
+.ctrap__cana i:nth-child(4) { bottom: 104px; }
+.ctrap__cana i:nth-child(5) { bottom: 130px; }
+
+/* las hojas acintadas, que se arquean y caen de punta */
+.ctrap__hoja {
+  position: absolute;
+  width: 74px;
+  height: 13px;
+  background: linear-gradient(180deg, #7fa63c 0%, #cfdd96 46%, #5f8a2e 54%, #4e7526 100%);
+}
+.ctrap__hoja--a {
+  left: 52px;
+  bottom: 128px;
+  transform: rotate(-24deg);
+  border-radius: 0 60% 60% 0 / 0 70% 70% 0;
+  transform-origin: left center;
+}
+.ctrap__hoja--b {
+  right: 108px;
+  bottom: 110px;
+  transform: rotate(20deg) scaleX(-1);
+  border-radius: 0 60% 60% 0 / 0 70% 70% 0;
+  transform-origin: right center;
+}
+/* el penacho plumoso de la caña que ya espigó */
+.ctrap__penacho {
+  position: absolute;
+  left: 42px;
+  bottom: 158px;
+  width: 19px;
+  height: 30px;
+  border-radius: 50% 50% 40% 40%;
+  background: radial-gradient(circle at 50% 85%, #efe7ce 0%, rgba(226, 216, 188, 0.5) 58%, rgba(226, 216, 188, 0) 78%);
+}
+
+.ctrap__ficha-nombre {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.02rem;
+  color: #3a2c18;
+}
+.ctrap__ficha-sub {
+  margin: 0;
+  font-size: 0.84rem;
+  color: #5f4c2c;
+}
+
+@media (min-width: 40rem) {
+  .ctrap {
+    padding: 1.6rem 1.4rem 3rem;
+  }
+  .ctrap__saberes ol {
+    grid-template-columns: 1fr 1fr;
+  }
+  .ctrap__saberes li:last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ctrap__toggle {
+    transition: none;
+  }
+}

--- a/src/mockups/CanaTrapiche3D.jsx
+++ b/src/mockups/CanaTrapiche3D.jsx
@@ -1,0 +1,166 @@
+/*
+ * CanaTrapiche3D — vitrina pública del MUNDO DE LA CAÑA Y EL TRAPICHE: el
+ * cañaveral de tierra caliente y la enramada donde se hace la panela.
+ * Ruta #/mockups/cana-trapiche-3d, sin auth.
+ *
+ * Dos mitades que se necesitan: un lote de caña que le pasa por encima a
+ * cualquiera, y al lado la enramada con su molienda, su hornilla prendida y sus
+ * gaveras. Cinco pasos cortos recorren la transformación completa — la caña en
+ * pie, el corte y la molienda, el bagazo que vuelve como leña, la hornilla con
+ * su fila de pailas, y las gaveras donde la miel se vuelve bloque.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el mundo 3D (chunk
+ * perezoso `vendor-three`); en equipo humilde, ahorro de datos o sin-WebGL se ve
+ * la ficha del trapiche, digna y sin sudar la GPU. Copy en español de Colombia,
+ * en "usted". Autocontenida: cero CDN/imágenes externas.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import './CanaTrapiche3D.css';
+
+const MundoCana = lazy(() => import('../visual/mundo3d/cana/MundoCana.jsx'));
+
+/* Lo que enseña el trapiche (en "usted"). */
+const SABERES = [
+  {
+    emoji: '🌾',
+    titulo: 'La caña le pasa por encima',
+    texto:
+      'Una caña de trapiche madura pasa de los cuatro metros: más de dos veces una persona. El tallo viene por segmentos, con un nudo entre uno y otro, y en cada nudo hay una yema. De un pedazo de tallo con yemas sale la mata siguiente: la caña se siembra de caña, no de semilla.',
+  },
+  {
+    emoji: '⚙️',
+    titulo: 'Del corte al molino, sin demora',
+    texto:
+      'Caña cortada que se queda esperando empieza a fermentar y la panela sale mala. Por eso el trapiche se para al lado del cañaveral: se corta, se despunta, se arruma y se muele. Entre las tres masas del molino sale el guarapo, que es el jugo, y queda el bagazo.',
+  },
+  {
+    emoji: '🔥',
+    titulo: 'La caña calienta su propia miel',
+    texto:
+      'El bagazo sale mojado del molino, se apila unas semanas a secar y seco vuelve a la hornilla como combustible. El trapiche se alimenta solo: ni compra leña ni le baja un palo al monte. Es de los pocos oficios del campo donde el desecho de un paso es la energía del siguiente.',
+  },
+  {
+    emoji: '🥄',
+    titulo: 'Una candela para toda la fila',
+    texto:
+      'El fuego va en un extremo de la hornilla y la chimenea en el otro, así que cada paila recibe distinto calor. El guarapo entra por la más templada — ahí se le retira la cachaza, la espuma que se lleva la suciedad y que después sirve de abono o de comida para los animales — y va caminando hacia el fuego mientras se vuelve miel.',
+  },
+  {
+    emoji: '🟫',
+    titulo: 'La panela es jugo de caña y nada más',
+    texto:
+      'La miel en su punto se bate para que entre aire y granule, y se vacía en las gaveras, los moldes de madera, donde cuaja. No se le quita nada ni se le agrega nada: la panela es el jugo de la caña concentrado. Por eso conserva el color y el sabor que el azúcar blanco pierde en el camino.',
+  },
+];
+
+export default function CanaTrapiche3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  return (
+    <main className="ctrap">
+      <header className="ctrap__head">
+        <p className="ctrap__kicker">El mundo de la caña · vitrina</p>
+        <h1>El cañaveral y el trapiche</h1>
+        <p className="ctrap__lema">
+          Un lote de caña que le pasa por encima, y al lado la enramada donde esa
+          caña se vuelve panela. Recorra la escena con el dedo y siga los cinco
+          pasos: del surco al bloque que cabe en la mano.
+        </p>
+      </header>
+
+      <section className="ctrap__escena" aria-label="El cañaveral y el trapiche panelero en 3D">
+        <div className="ctrap__lienzo">
+          {mostrar3D ? (
+            <Suspense
+              fallback={
+                <div className="ctrap__cargando" role="status">
+                  Prendiendo la hornilla…
+                </div>
+              }
+            >
+              <MundoCana tier={tier} reducedMotion={reducedMotion} />
+            </Suspense>
+          ) : (
+            <FichaTrapiche />
+          )}
+        </div>
+
+        <div className="ctrap__barra">
+          <p className="ctrap__tier">
+            {mostrar3D
+              ? 'Está viendo el trapiche en 3D. Gírelo con el dedo o el mouse y siga los pasos.'
+              : puede3D
+                ? 'Está viendo la ficha del trapiche.'
+                : 'Su equipo ve la ficha del trapiche (va parejo en cualquier teléfono).'}
+          </p>
+          {puede3D && (
+            <button type="button" className="ctrap__toggle" onClick={() => setVer2d((v) => !v)}>
+              {ver2d ? 'Ver el trapiche en 3D' : 'Ver la ficha'}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <section className="ctrap__saberes" aria-label="Lo que enseña el trapiche">
+        <h2>Lo que le enseña este trapiche</h2>
+        <ol>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span className="ctrap__emoji" aria-hidden="true">
+                {s.emoji}
+              </span>
+              <div>
+                <b>{s.titulo}</b>
+                <p>{s.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="ctrap__cierre">
+          Un trapiche de finca no es una fábrica: es un cobertizo abierto, una
+          molienda, una candela y unas manos que saben cuándo la miel llegó al
+          punto. Ese punto no lo mide un aparato — lo conoce el hornillero a ojo,
+          y ese saber no está escrito en ninguna parte sino en quien lo hace.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+/* La ficha del trapiche: el fallback digno para equipo humilde / sin-WebGL.
+   Una caña con sus nudos y la enramada humeando detrás — cero GPU, puro CSS. */
+function FichaTrapiche() {
+  return (
+    <div
+      className="ctrap__ficha"
+      role="img"
+      aria-label="El cañaveral y el trapiche: una caña con sus nudos y la enramada con su chimenea humeando"
+    >
+      <div className="ctrap__estampa" aria-hidden="true">
+        <span className="ctrap__enramada" />
+        <span className="ctrap__chimenea" />
+        <span className="ctrap__humo" />
+        <span className="ctrap__cana">
+          <i /><i /><i /><i /><i />
+        </span>
+        <span className="ctrap__hoja ctrap__hoja--a" />
+        <span className="ctrap__hoja ctrap__hoja--b" />
+        <span className="ctrap__penacho" />
+      </div>
+      <p className="ctrap__ficha-nombre">El cañaveral y el trapiche</p>
+      <p className="ctrap__ficha-sub">Tierra caliente · de la caña a la panela</p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/__tests__/canaTrapiche.geom.test.js
+++ b/src/visual/mundo3d/__tests__/canaTrapiche.geom.test.js
@@ -1,0 +1,320 @@
+/*
+ * Las cosas del mundo de la caña que NO se ven leyendo el código y que, si se
+ * rompen, no dan ningún error: la escena simplemente queda mal y nadie se
+ * entera hasta que alguien la mira.
+ *
+ * Cuatro familias de chequeo:
+ *
+ *   1. Que las mallas se FUSIONEN. `mergeGeometries` devuelve null en silencio
+ *      al mezclar geometrías indexadas con no-indexadas, y la pieza deja de
+ *      dibujarse sin una línea en consola. Ya mordió tres veces en este repo.
+ *   2. Que la CAÑA SIGA SIENDO ALTA. Es la premisa del mundo entero: si una
+ *      cepa deja de pasarle por encima a una persona, dejó de ser un cañaveral.
+ *   3. Que el PASILLO DEL PASO 1 esté tupido y despejado. Es el plano que
+ *      sostiene la lección: la cámara se mete a caminar entre surcos y tiene
+ *      que haber caña cerrada a lado y lado, pero ninguna cepa encima del eje.
+ *      El surco ONDULA, así que una x fija se sale de la calle a los pocos
+ *      metros — por eso el pasillo se calcula, no se escribe a mano.
+ *   4. Que los CINCO ENCUADRES sean navegables: dentro de los límites de
+ *      distancia y de ángulo que OrbitControls impone, y sobre el suelo. Un
+ *      encuadre fuera de rango no falla: se endereza solo y se pierde el plano.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ANCHO,
+  FONDO,
+  alturaVega,
+  enLaEra,
+  enZonaCerca,
+  pasilloCanaveral,
+  canaDeTier,
+  calidadCana,
+  mallasDeTier,
+  sembrarCanaveral,
+  geomMataCana,
+  geomPenachoCana,
+  geomHojarascaCana,
+  geomPiedraCana,
+  geomMatojoCana,
+  geomMuroCanaveral,
+  VARIEDADES,
+  Y_ERA,
+  enTrapiche,
+} from '../cana/floraCana.geom.js';
+import {
+  ENRAMADA,
+  PAILAS,
+  CELDAS_GAVERA,
+  geomEsqueletoEnramada,
+  geomTechoEnramada,
+  geomMolienda,
+  geomCanoaGuarapo,
+  geomHornilla,
+  geomPailas,
+  geomArrumeCana,
+  geomMoldeo,
+  geomUtiles,
+  geomBagazo,
+} from '../cana/trapiche.geom.js';
+import { PASOS, LIMITES, OJOS } from '../cana/leccionCana.js';
+
+const ATRIBUTOS = 'color,normal,position,uv';
+const atributosDe = (g) => Object.keys(g.attributes).sort().join(',');
+const triangulos = (g) => (g.index ? g.index.count : g.attributes.position.count) / 3;
+
+/* El mundo a calidad plena, una sola vez (construirlo es lo caro del test). */
+const TIER = 'alto';
+const q = calidadCana(TIER);
+const mallas = mallasDeTier(TIER);
+const cepas = mallas.map((m) => geomMataCana(m.v, { q, detalle: m.detalle }, 101));
+const siembra = sembrarCanaveral(
+  canaDeTier(TIER),
+  mallas,
+  cepas.map((c) => c.topes),
+  907,
+);
+const matas = siembra.matas.flat();
+
+describe('cañaveral — las mallas se fusionan de verdad', () => {
+  it('cada pieza de la cepa sale con los mismos atributos (o el merge da null y no se dibuja)', () => {
+    for (const c of cepas) {
+      for (const pieza of [c.tallos, c.hojas, c.chala]) {
+        expect(pieza).toBeTruthy();
+        expect(atributosDe(pieza)).toBe(ATRIBUTOS);
+        expect(triangulos(pieza)).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('las piezas sueltas del lote también', () => {
+    for (const g of [
+      geomPenachoCana(q, 41),
+      geomHojarascaCana(),
+      geomPiedraCana(),
+      geomMatojoCana(),
+      geomMuroCanaveral({ largo: 40, alto: 4 }),
+    ]) {
+      expect(atributosDe(g)).toBe(ATRIBUTOS);
+      expect(triangulos(g)).toBeGreaterThan(0);
+    }
+  });
+
+  it('todas las piezas del trapiche también', () => {
+    for (const g of [
+      geomEsqueletoEnramada({ q }),
+      geomTechoEnramada({ q }),
+      geomMolienda({ q }),
+      geomCanoaGuarapo(),
+      geomHornilla({ q }),
+      geomPailas({ q }),
+      geomArrumeCana({ q }),
+      geomMoldeo({ q }),
+      geomUtiles({ q }),
+      geomBagazo({ radio: 1, alto: 0.6, estado: 'humedo', q }),
+    ]) {
+      expect(atributosDe(g)).toBe(ATRIBUTOS);
+      expect(triangulos(g)).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('cañaveral — la escala es la premisa del mundo', () => {
+  it('una cepa le pasa MUY por encima a una persona (1,7 m)', () => {
+    for (const c of cepas) expect(c.alto).toBeGreaterThan(1.7 * 2);
+  });
+
+  it('ni la cepa más chica del lote baja de 2,6 m', () => {
+    const menor = Math.min(...cepas.map((c) => c.alto)) * Math.min(...matas.map((m) => m.escala));
+    expect(menor).toBeGreaterThan(2.6);
+  });
+
+  it('sirve caña de las cuatro variedades y ninguna repite tinte', () => {
+    expect(VARIEDADES).toHaveLength(4);
+    const tintes = new Set(VARIEDADES.map((v) => v.tinte.join(',')));
+    expect(tintes.size).toBe(4);
+    // los pesos reparten el lote completo
+    const suma = VARIEDADES.reduce((a, v) => a + v.peso, 0);
+    expect(suma).toBeCloseTo(1, 5);
+  });
+});
+
+describe('cañaveral — la siembra', () => {
+  it('no siembra una sola mata dentro de la era del trapiche', () => {
+    expect(matas.filter((m) => enLaEra(m.pos[0], m.pos[2]))).toHaveLength(0);
+  });
+
+  it('cada mata se para SOBRE el terreno, no flotando ni enterrada', () => {
+    for (const m of matas) {
+      expect(m.pos[1]).toBeCloseTo(alturaVega(m.pos[0], m.pos[2]), 6);
+    }
+  });
+
+  it('todo cae dentro del terreno construido', () => {
+    for (const m of matas) {
+      expect(Math.abs(m.pos[0])).toBeLessThan(ANCHO / 2);
+      expect(Math.abs(m.pos[2])).toBeLessThan(FONDO / 2);
+    }
+  });
+
+  it('cada penacho cuelga de una punta de tallo con su ancla en el pie de la cepa', () => {
+    expect(siembra.penacho.length).toBeGreaterThan(10);
+    for (const p of siembra.penacho) {
+      // sin `ancla`/`brazo` el güin se queda flotando cuando la caña se mece
+      expect(p.ancla).toBeTruthy();
+      expect(p.brazo).toBeTruthy();
+      expect(p.pos[1]).toBeGreaterThan(p.ancla[1] + 2.4); // va allá arriba
+    }
+  });
+
+  it('hoja y chala acompañan a cada tallo: una cepa nunca queda pelada', () => {
+    for (let i = 0; i < mallas.length; i++) {
+      expect(siembra.hojas[i]).toHaveLength(siembra.matas[i].length);
+      expect(siembra.chala[i]).toHaveLength(siembra.matas[i].length);
+    }
+  });
+
+  it('la gama baja sigue siendo un cañaveral, solo que frugal', () => {
+    const mb = mallasDeTier('bajo');
+    const cb = mb.map((m) => geomMataCana(m.v, { q: calidadCana('bajo'), detalle: m.detalle }, 101));
+    const sb = sembrarCanaveral(canaDeTier('bajo'), mb, cb.map((c) => c.topes), 907);
+    expect(sb.matas.flat().length).toBeGreaterThan(20);
+    expect(cb[0].alto).toBeGreaterThan(1.7 * 2);
+  });
+});
+
+describe('el pasillo del paso 1 — el plano que sostiene el mundo', () => {
+  it('el eje del pasillo SIGUE al surco, que ondula (no es una x fija)', () => {
+    const ejes = [-6, 0, 6.5].map((z) => pasilloCanaveral(z));
+    // si fuera una x fija la cámara se saldría de la calle a los pocos metros
+    expect(Math.max(...ejes) - Math.min(...ejes)).toBeGreaterThan(0.8);
+  });
+
+  it('hay caña cerrada a lado y lado en todo el recorrido', () => {
+    for (const z of [6.5, 3, 0, -3, -6]) {
+      const cx = pasilloCanaveral(z);
+      const flanco = matas.filter(
+        (m) => Math.abs(m.pos[2] - z) < 2 && Math.abs(m.pos[0] - cx) < 2.2,
+      );
+      expect(flanco.length).toBeGreaterThanOrEqual(6);
+    }
+  });
+
+  it('pero ninguna cepa se para ENCIMA del eje (la cámara no atraviesa una mata)', () => {
+    for (const z of [6.5, 3, 0, -3, -6]) {
+      const cx = pasilloCanaveral(z);
+      const encima = matas.filter((m) => Math.hypot(m.pos[0] - cx, m.pos[2] - z) < 0.5);
+      expect(encima).toHaveLength(0);
+    }
+  });
+
+  it('el pasillo cae en la zona de calidad CERCA (ahí sí se le ven los nudos)', () => {
+    for (const z of [6, 0, -6]) expect(enZonaCerca(pasilloCanaveral(z), z)).toBe(true);
+  });
+});
+
+describe('la lección — los cinco encuadres son navegables', () => {
+  it('son cinco pasos, en el orden del proceso', () => {
+    expect(PASOS.map((p) => p.id)).toEqual([
+      'canaveral',
+      'molienda',
+      'bagazo',
+      'hornilla',
+      'gaveras',
+    ]);
+  });
+
+  it.each(PASOS.map((p) => [p.id, p]))(
+    '«%s»: dentro de los límites de OrbitControls y sobre el suelo',
+    (_id, paso) => {
+      const [px, py, pz] = paso.vista.pos;
+      const [mx, my, mz] = paso.vista.mira;
+      const d = Math.hypot(px - mx, py - my, pz - mz);
+      const polar = Math.acos((py - my) / d);
+      // fuera de rango OrbitControls la reacomoda sola y se pierde el encuadre
+      expect(d).toBeGreaterThanOrEqual(LIMITES.minDistancia);
+      expect(d).toBeLessThanOrEqual(LIMITES.maxDistancia);
+      expect(polar).toBeGreaterThan(LIMITES.minPolar);
+      expect(polar).toBeLessThan(LIMITES.maxPolar);
+      expect(py).toBeGreaterThan(alturaVega(px, pz) + 0.4);
+    },
+  );
+
+  it('el paso 1 mira desde la altura de los ojos y la caña le pasa por encima', () => {
+    const p1 = PASOS[0];
+    const alturaOjos = p1.vista.pos[1] - alturaVega(p1.vista.pos[0], p1.vista.pos[2]);
+    expect(alturaOjos).toBeCloseTo(OJOS, 5);
+    expect(Math.max(...cepas.map((c) => c.alto))).toBeGreaterThan(alturaOjos * 2.5);
+  });
+
+  it('el paso 1 mira HACIA ARRIBA (por eso se siente alto el cañaveral)', () => {
+    const p1 = PASOS[0];
+    expect(p1.vista.mira[1]).toBeGreaterThan(p1.vista.pos[1]);
+  });
+
+  it('cada foco cae sobre algo del mundo, no en el aire', () => {
+    for (const p of PASOS) {
+      expect(Number.isFinite(p.foco[0])).toBe(true);
+      expect(Number.isFinite(p.foco[1])).toBe(true);
+      expect(Number.isFinite(p.foco[2])).toBe(true);
+    }
+  });
+
+  it('el copy va en «usted» y sin voseo', () => {
+    const todo = PASOS.map((p) => `${p.kicker} ${p.texto}`).join(' ');
+    expect(todo).toMatch(/usted|métase|mire|fíjese/i);
+    expect(todo).not.toMatch(/\b(tenés|querés|podés|mirá|fijate|sabés)\b/i);
+  });
+});
+
+describe('el trapiche — la física del sitio', () => {
+  it('la enramada es ALTA y abierta (adentro hay una hornilla prendida)', () => {
+    expect(ENRAMADA.alero).toBeGreaterThan(2.5);
+    expect(ENRAMADA.cumbre).toBeGreaterThan(ENRAMADA.alero + 1.5);
+  });
+
+  it('las pailas van de la más FRÍA a la del punteo, y en ese orden', () => {
+    expect(PAILAS.map((p) => p.oficio)).toEqual([
+      'clarificación',
+      'evaporación',
+      'evaporación',
+      'punteo',
+    ]);
+    // ordenadas a lo largo de la hornilla, sin montarse una sobre otra
+    for (let i = 1; i < PAILAS.length; i++) {
+      expect(PAILAS[i].x).toBeGreaterThan(PAILAS[i - 1].x);
+      expect(PAILAS[i].x - PAILAS[i - 1].x).toBeGreaterThan(PAILAS[i].r);
+    }
+  });
+
+  it('las celdas de la gavera van dentro del molde y en fila', () => {
+    expect(CELDAS_GAVERA.length).toBeGreaterThan(3);
+    for (let i = 1; i < CELDAS_GAVERA.length; i++) {
+      expect(CELDAS_GAVERA[i][0]).toBeGreaterThan(CELDAS_GAVERA[i - 1][0]);
+      expect(CELDAS_GAVERA[i][2]).toBeCloseTo(CELDAS_GAVERA[0][2], 6);
+    }
+  });
+
+  it('el trapiche se para en PLANO: la era está aplanada de verdad', () => {
+    // con la hornilla en desnivel no se trabaja
+    const alturas = [
+      [10.5, 2],
+      [8, 0],
+      [13, 4],
+      [10.5, -2],
+    ].map(([x, z]) => alturaVega(x, z));
+    for (const a of alturas) expect(Math.abs(a - Y_ERA)).toBeLessThan(0.05);
+  });
+
+  it('enTrapiche aterriza sobre el piso de la era', () => {
+    expect(enTrapiche(0, 0, 0)[1]).toBeCloseTo(Y_ERA, 6);
+  });
+
+  it('ningún montón de bagazo queda enterrado bajo el piso', () => {
+    for (const estado of ['humedo', 'secando', 'seco']) {
+      const g = geomBagazo({ radio: 1.2, alto: 0.8, estado, q });
+      g.computeBoundingBox();
+      expect(g.boundingBox.min.y).toBeGreaterThan(-0.35);
+      expect(g.boundingBox.max.y).toBeGreaterThan(0.3);
+    }
+  });
+});

--- a/src/visual/mundo3d/cana/Canaveral.jsx
+++ b/src/visual/mundo3d/cana/Canaveral.jsx
@@ -30,7 +30,7 @@ import { perfilDeTier } from '../deviceTier.js';
 import {
   canaDeTier,
   calidadCana,
-  variantesDeTier,
+  mallasDeTier,
   sembrarCanaveral,
   geomMataCana,
   geomPenachoCana,
@@ -148,12 +148,18 @@ export default function Canaveral({ tier = 'alto', reducedMotion = false }) {
   const perfil = perfilDeTier(tier);
   const conteos = canaDeTier(tier);
   const q = calidadCana(tier);
-  const nV = variantesDeTier(tier);
+  const mallas = useMemo(
+    () => /** @type {{v:number, detalle:'cerca'|'lejos'}[]} */ (mallasDeTier(tier)),
+    [tier],
+  );
 
-  /* Las matas (una geometría por variante, una vez por tier). */
+  /* Las matas: una geometría por (variante × calidad), una vez por tier. La
+     variante evita que el lote se lea como plantilla; la calidad es lo que hace
+     que quepan más del doble de cepas — las del pasillo con todo el detalle,
+     las del fondo con un tubo de 16 anillos que a esa distancia nadie discute. */
   const variantes = useMemo(
-    () => Array.from({ length: nV }, (_, v) => geomMataCana(v, { q }, 101)),
-    [nV, q],
+    () => mallas.map((m) => geomMataCana(m.v, { q, detalle: m.detalle }, 101)),
+    [mallas, q],
   );
 
   const geoPenacho = useMemo(() => geomPenachoCana(q, 41), [q]);
@@ -169,8 +175,8 @@ export default function Canaveral({ tier = 'alto', reducedMotion = false }) {
   /* La siembra determinista: los surcos, los claros del corte, las variedades
      y las puntas donde se montan los penachos. */
   const dist = useMemo(
-    () => sembrarCanaveral(conteos, variantes.map((v) => v.topes), 907),
-    [conteos, variantes],
+    () => sembrarCanaveral(conteos, mallas, variantes.map((v) => v.topes), 907),
+    [conteos, mallas, variantes],
   );
 
   /* Material único con vertexColors (el color va horneado por pieza y el tinte

--- a/src/visual/mundo3d/cana/Canaveral.jsx
+++ b/src/visual/mundo3d/cana/Canaveral.jsx
@@ -1,0 +1,272 @@
+/*
+ * Canaveral — el LOTE DE CAÑA sembrado en surcos, con el viento encima.
+ *
+ * Consume `floraCana.geom.js`: cada pieza es UN InstancedMesh de una geometría
+ * fusionada (una draw-call por pieza, por más cepas que haya) — mismo contrato
+ * tier-safe que `FloraCafetal`. El TALLO lleva el color de la VARIEDAD por
+ * instancia (verde, amarilla, morada, rayada), mientras la hoja va siempre verde
+ * y la chala siempre paja: por eso van en mallas separadas.
+ *
+ * EL VIENTO es la razón de existir de este archivo. Un cañaveral quieto está
+ * muerto: lo que uno recuerda de una cañada es la ONDA que la cruza cuando entra
+ * la brisa — las cañas altas se inclinan, se recuperan, y la ola sigue de largo.
+ * Aquí eso se hace recomponiendo las matrices de instancia por cuadro con un
+ * balanceo cuya FASE depende de la posición (x·0,32 + z·0,19): la ráfaga viaja
+ * por el lote en diagonal en vez de mecerse todo a la vez. Tallo, hoja, chala y
+ * penacho de una misma cepa comparten fase, así que la mata se mueve ENTERA.
+ *
+ * Como la mata pivota en su PIE, un giro chiquito (0,03 rad) mueve la punta a
+ * 4 m casi 15 cm: alcanza y sobra, y cuesta una composición de matriz.
+ *
+ * `reducedMotion` y la gama 'bajo' dejan el lote QUIETO (presencia sin vaivén):
+ * las matrices se escriben una sola vez y no se vuelve a tocar el frameloop.
+ *
+ * Componente r3f: montar dentro del <Canvas> de EscenaCanaTrapiche.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import {
+  canaDeTier,
+  calidadCana,
+  variantesDeTier,
+  sembrarCanaveral,
+  geomMataCana,
+  geomPenachoCana,
+  geomHojarascaCana,
+  geomPiedraCana,
+  geomMatojoCana,
+} from './floraCana.geom.js';
+
+/* La brisa del cañaveral. `amplitud` en radianes de inclinación del pie. */
+const VIENTO = {
+  amplitud: 0.034, // ~15 cm de vaivén en la punta de una caña de 4,3 m
+  velocidad: 0.62, // qué tan seguido pasa la ráfaga
+  racha: 0.45, // la segunda armónica: el viento no es un metrónomo
+  rachaVel: 0.23,
+};
+
+/*
+ * Un banco de instancias de UNA pieza. Si `viento` viene, las matrices se
+ * recomponen por cuadro con el balanceo; si no, se escriben una vez y listo.
+ *
+ * (Mismo molde `Especie` de FloraCafetal/FloraParamo, con el vaivén encima.)
+ */
+function Pieza({ geo, mat, items, viento = null, castShadow = false }) {
+  const ref = useRef(null);
+
+  // Objetos reusados: nada de `new` dentro del bucle de cuadro.
+  const tmp = useMemo(
+    () => ({
+      m: new THREE.Matrix4(),
+      q: new THREE.Quaternion(),
+      e: new THREE.Euler(),
+      p: new THREE.Vector3(),
+      s: new THREE.Vector3(),
+      brazo: new THREE.Vector3(),
+      col: new THREE.Color(),
+    }),
+    [],
+  );
+
+  /* La colocación base (y el color de variedad, que nunca cambia). */
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const { m, q, e, p, s, col } = tmp;
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items, tmp]);
+
+  /* LA ONDA. La fase por instancia hace que la ráfaga CRUCE el lote. */
+  useFrame(({ clock }) => {
+    const mesh = ref.current;
+    if (!viento || !mesh || !items.length) return;
+    const t = clock.elapsedTime;
+    const { m, q, e, p, s, brazo } = tmp;
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      const f = it.fase;
+      // Dos senos de periodo distinto: la brisa respira, no marca el compás.
+      const golpe =
+        Math.sin(t * VIENTO.velocidad - f) +
+        VIENTO.racha * Math.sin(t * VIENTO.rachaVel - f * 0.55 + 1.3);
+      const inc = viento * golpe;
+      // Se inclina en X y algo en Z: la caña no se mece en un solo plano.
+      e.set(inc, it.rotY, inc * 0.45);
+      q.setFromEuler(e);
+      if (it.brazo) {
+        /* Pieza colgada de la punta de una caña (el penacho): pivota en el PIE
+           DE LA CEPA, no en sí misma. Se gira el brazo pie→punta con el mismo
+           balanceo y se recoloca — así el güin viaja pegado a su tallo. */
+        e.set(inc, 0, inc * 0.45);
+        brazo.set(it.brazo[0], it.brazo[1], it.brazo[2]).applyEuler(e);
+        p.set(
+          it.ancla[0] + brazo.x,
+          it.ancla[1] + brazo.y,
+          it.ancla[2] + brazo.z,
+        );
+      } else {
+        p.set(it.pos[0], it.pos[1], it.pos[2]);
+      }
+      s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  });
+
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+    />
+  );
+}
+
+/**
+ * El cañaveral vivo: surcos de caña, su suelo y el viento que lo cruza.
+ * Montar dentro del <Canvas>.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function Canaveral({ tier = 'alto', reducedMotion = false }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = canaDeTier(tier);
+  const q = calidadCana(tier);
+  const nV = variantesDeTier(tier);
+
+  /* Las matas (una geometría por variante, una vez por tier). */
+  const variantes = useMemo(
+    () => Array.from({ length: nV }, (_, v) => geomMataCana(v, { q }, 101)),
+    [nV, q],
+  );
+
+  const geoPenacho = useMemo(() => geomPenachoCana(q, 41), [q]);
+  const geoSuelo = useMemo(
+    () => ({
+      hojarasca: geomHojarascaCana(61),
+      piedra: geomPiedraCana(62),
+      matojo: conteos.matojo ? geomMatojoCana(63) : null,
+    }),
+    [conteos.matojo],
+  );
+
+  /* La siembra determinista: los surcos, los claros del corte, las variedades
+     y las puntas donde se montan los penachos. */
+  const dist = useMemo(
+    () => sembrarCanaveral(conteos, variantes.map((v) => v.topes), 907),
+    [conteos, variantes],
+  );
+
+  /* Material único con vertexColors (el color va horneado por pieza y el tinte
+     por instancia lo multiplica — en el tallo el tinte ES la variedad). */
+  const mat = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.82, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  /* LA HOJA es una CINTA: si se dibuja a una cara, media hoja desaparece según
+     de qué lado la mire uno. Va a dos caras siempre, y algo más lustrosa (la
+     hoja de caña brilla al sol). */
+  const matHoja = useMemo(() => {
+    const base = {
+      vertexColors: true,
+      flatShading: perfil.flatShading,
+      side: THREE.DoubleSide,
+    };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.55, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  /* La chala seca no brilla: es paja. Misma cinta a dos caras, mate. */
+  const matSeco = useMemo(() => {
+    const base = {
+      vertexColors: true,
+      flatShading: perfil.flatShading,
+      side: THREE.DoubleSide,
+    };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.95, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  /* Liberar GPU al desmontar. */
+  useLayoutEffect(
+    () => () => {
+      variantes.forEach((v) => {
+        v.tallos.dispose();
+        v.hojas.dispose();
+        v.chala.dispose();
+      });
+      geoPenacho.dispose();
+      Object.values(geoSuelo).forEach((g) => g && g.dispose());
+      mat.dispose();
+      matHoja.dispose();
+      matSeco.dispose();
+    },
+    [variantes, geoPenacho, geoSuelo, mat, matHoja, matSeco],
+  );
+
+  /* El viento solo en gama que lo aguanta y con movimiento permitido. En 'bajo'
+     el lote monta quieto: se ve el cañaveral igual, no se recompone nada. */
+  const viento = reducedMotion || tier === 'bajo' ? null : VIENTO.amplitud;
+  const sombra = perfil.sombras;
+
+  return (
+    <group>
+      {/* El suelo de la calle del surco: hoja caída, matojos, terrones. */}
+      <Pieza geo={geoSuelo.hojarasca} mat={matSeco} items={dist.hojarasca} />
+      <Pieza geo={geoSuelo.matojo} mat={matHoja} items={dist.matojo} />
+      <Pieza geo={geoSuelo.piedra} mat={mat} items={dist.piedra} />
+
+      {/* EL LOTE. Por variante: primero la chala (queda detrás, pegada al
+          tallo), luego el tallo, y encima la hoja verde del cogollo. */}
+      {variantes.map((v, i) => (
+        <group key={i}>
+          <Pieza geo={v.chala} mat={matSeco} items={dist.chala[i]} viento={viento} />
+          <Pieza
+            geo={v.tallos}
+            mat={mat}
+            items={dist.matas[i]}
+            viento={viento}
+            castShadow={sombra}
+          />
+          <Pieza
+            geo={v.hojas}
+            mat={matHoja}
+            items={dist.hojas[i]}
+            viento={viento}
+            castShadow={sombra}
+          />
+        </group>
+      ))}
+
+      {/* LOS PENACHOS: lo que espigó. Van sobre puntas reales de tallo y se
+          mecen con más amplitud — son lo más liviano y lo más alto del lote. */}
+      <Pieza
+        geo={geoPenacho}
+        mat={matHoja}
+        items={dist.penacho}
+        viento={viento ? viento * 1.45 : null}
+      />
+    </group>
+  );
+}

--- a/src/visual/mundo3d/cana/EscenaCanaTrapiche.jsx
+++ b/src/visual/mundo3d/cana/EscenaCanaTrapiche.jsx
@@ -358,7 +358,11 @@ function Diorama({ tier, reducedMotion, foco, vista, vistaToken }) {
         minDistance={5}
         maxDistance={34}
         minPolarAngle={0.28}
-        maxPolarAngle={1.5}
+        /* Pasa de los 90°: la cámara TIENE que poder quedar por debajo de su
+           punto de mira. Es lo que permite el plano del paso 1 — parado en el
+           surco mirando hacia arriba. Con el tope en 1,5 rad OrbitControls la
+           subía sola en cuanto empezaba el viaje y el encuadre se enderezaba. */
+        maxPolarAngle={1.7}
         enableDamping
         dampingFactor={0.08}
         autoRotate={false}

--- a/src/visual/mundo3d/cana/EscenaCanaTrapiche.jsx
+++ b/src/visual/mundo3d/cana/EscenaCanaTrapiche.jsx
@@ -1,0 +1,424 @@
+/*
+ * EscenaCanaTrapiche — el MUNDO DE LA CAÑA Y EL TRAPICHE (tierra caliente).
+ *
+ * Un mundo de DOS MITADES que se necesitan. A la izquierda el CAÑAVERAL: un
+ * lote alto, en surcos, que se mece cuando entra la brisa. A la derecha la
+ * ENRAMADA DEL TRAPICHE, con su molienda, su hornilla prendida y sus gaveras.
+ * En el medio, la era pisada por donde entra la caña cortada. La lección es el
+ * camino entre las dos: cómo una mata de dos veces la altura de uno termina
+ * siendo un bloque de panela que cabe en la mano.
+ *
+ * LA LUZ. Este es el único mundo de Chagra con candela de verdad, y por eso es
+ * el único donde la fuente principal puede no ser el sol. La boca de la hornilla
+ * quema bagazo todo el día: de mañana es un acento tibio bajo el techo, al
+ * atardecer empieza a ganarle al cielo, y de noche es lo ÚNICO que alumbra la
+ * enramada. Eso no se inventó para que se viera bonito — es lo que pasa en una
+ * molienda de verdad, y por eso `fuerzaDeFranja` cuelga de la hora del valle y
+ * no de un antojo.
+ *
+ * LA ESCALA. Una caña madura le pasa MUY por encima a una persona, y un plano
+ * general no puede contar eso: de lejos todo se ve chiquito. Por eso la lección
+ * MUEVE LA CÁMARA (`CamaraLeccion`): el primer paso la mete a 1,55 m del suelo
+ * DENTRO de un pasillo entre surcos, mirando hacia arriba, con la caña cerrada a
+ * lado y lado. Ahí es donde el cañaveral se siente alto. Después de cada
+ * movimiento la cámara se la devuelve al dedo del que está mirando.
+ *
+ * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`: 'alto' con
+ * sombras, viento, vapor y candela con luz; 'medio' frugal; 'bajo' mínimo pero
+ * legible. Con `reducedMotion` el mundo monta QUIETO — la candela se planta en
+ * un instante fijo y el lote deja de mecerse, pero los dos siguen ahí.
+ *
+ * Importa three/@react-three → montar SOLO perezosa (lazy).
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { perfilDeTier } from '../deviceTier.js';
+import { Fauna } from '../escenas/FaunaEscena.jsx';
+import FaunaCalido from '../escenas/FaunaCalido.jsx';
+import Canaveral from './Canaveral.jsx';
+import Trapiche from './Trapiche.jsx';
+import {
+  ANCHO,
+  FONDO,
+  alturaVega,
+  caminoX,
+  enLaEra,
+  SITIO_TRAPICHE,
+  Y_ERA,
+  geomMuroCanaveral,
+  PAL as PAL_CANA,
+} from './floraCana.geom.js';
+import {
+  AtmosferaMundo,
+  DomoCielo,
+  useAtmosferaMundo,
+  useGradienteBandas,
+  construirTerreno,
+  ruidoTerreno,
+  smoothstep,
+  CamaraDirector,
+} from '../kit/index.js';
+import { mezclar, VERDES, TIERRAS, LUCES, PALETA } from '../paleta/index.js';
+
+/* La identidad de la tierra caliente cañera dentro de la familia del valle:
+   `plaza` — el dorado seco de media mañana en tierra baja. El otro 60 % lo pone
+   LA HORA, igual que en todos los mundos. */
+const FAMILIA_CANA = 'plaza';
+
+/* Escala de la escena para la niebla y las luces del kit. */
+const RADIO_CANA = 15;
+
+/* El frustum de sombra a medida del lote y la enramada. */
+const SOMBRA_CANA = { left: -24, right: 24, top: 20, bottom: -10, far: 60 };
+
+/*
+ * CUÁNTO MANDA EL FUEGO SEGÚN LA HORA. Esta tabla es la decisión de fotografía
+ * del mundo: de día la hornilla es un detalle tibio; al caer la tarde empieza a
+ * pintar el techo y las pailas; de noche la enramada existe SOLO porque hay
+ * candela. Una molienda no se para porque anochezca — al contrario, muchas
+ * arrancan de madrugada y terminan de noche.
+ */
+const FUERZA_FUEGO = {
+  amanecer: 1.35,
+  manana: 0.75,
+  mediodia: 0.58,
+  tarde: 0.82,
+  atardecer: 1.5,
+  noche: 1.95,
+};
+const fuerzaDeFranja = (franja) => FUERZA_FUEGO[franja] ?? 0.9;
+
+/* -------------------------------------------------------------------------- */
+/*  El terreno                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/* La vega cañera: tierra de labor oscura entre los surcos, la era del trapiche
+   PISADA y clara (años de pasarle caña y bagazo por encima), y el camino por
+   donde entra la carga. */
+function construirVega(seg, plano) {
+  const cLabor = new THREE.Color(TIERRAS.siembra); // tierra removida del lote
+  const cSeca = new THREE.Color(TIERRAS.camino); // lo que se abre al sol
+  const cVerde = new THREE.Color(VERDES.trabajo); // la arvense de la calle
+  const cEra = new THREE.Color(mezclar(PALETA.tierraClara, PALETA.concreto, 0.35));
+  const cBagazo = new THREE.Color(PAL_CANA.hojarascaSeca);
+
+  return construirTerreno({
+    ancho: ANCHO,
+    fondo: FONDO,
+    seg,
+    plano,
+    altura: alturaVega,
+    pintar: (wx, wz, alt, c) => {
+      // el fondo del lote: tierra de labor con arvense a manchas
+      c.lerpColors(cLabor, cVerde, 0.35 + 0.4 * ruidoTerreno(wx * 0.8, wz * 0.65));
+      c.lerp(cSeca, smoothstep(-0.1, 0.9, ruidoTerreno(wx * 1.5, wz * 1.2)) * 0.4);
+
+      // LA ERA del trapiche: pisada, clara y sin una brizna de pasto
+      const era = enLaEra(wx, wz, 1.15) ? 1 : 0;
+      const suave = smoothstep(
+        1.35,
+        0.8,
+        Math.max(Math.abs(wx - SITIO_TRAPICHE[0]) / 8.4, Math.abs(wz - SITIO_TRAPICHE[1]) / 7.0),
+      );
+      c.lerp(cEra, Math.max(era * 0.55, suave * 0.72));
+      // y regada de bagacillo, que es lo que uno pisa alrededor de un trapiche
+      c.lerp(cBagazo, suave * 0.3 * smoothstep(0.3, 0.85, ruidoTerreno(wx * 2.2 + 7, wz * 2.2)));
+
+      // EL CAMINO de llegada: por ahí sube la caña cortada
+      c.lerp(cSeca, smoothstep(1.9, 0, Math.abs(wx - caminoX(wz))) * smoothstep(-3, 12, wz) * 0.8);
+    },
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  La cámara de la lección                                                    */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Lleva la cámara al sitio del paso que se está leyendo y SE RETIRA. No es un
+ * riel: en cuanto termina el viaje, el que mira vuelve a mandar con el dedo.
+ * Sin esto, el paso del cañaveral no se podría contar — la altura de la caña
+ * solo se siente parado adentro, y desde el plano general no se ve.
+ */
+function CamaraLeccion({ vista, token, controls, reducedMotion }) {
+  const { camera } = useThree();
+  const viaje = useRef(null);
+  const anterior = useRef(token);
+
+  useEffect(() => {
+    // En el primer montaje no se toca nada: de la llegada se encarga
+    // CamaraDirector. Solo se viaja cuando el que mira CAMBIA de paso.
+    if (token === anterior.current || !vista) return;
+    anterior.current = token;
+    const ctr = controls.current;
+    const desdeMira = ctr ? ctr.target.clone() : new THREE.Vector3();
+    viaje.current = {
+      t: 0,
+      dur: reducedMotion ? 0.001 : 1.5,
+      desdePos: camera.position.clone(),
+      haciaPos: new THREE.Vector3(...vista.pos),
+      desdeMira,
+      haciaMira: new THREE.Vector3(...vista.mira),
+    };
+  }, [token, vista, camera, controls, reducedMotion]);
+
+  useFrame((_, dt) => {
+    const v = viaje.current;
+    const ctr = controls.current;
+    if (!v || !ctr) return;
+    v.t = Math.min(1, v.t + dt / v.dur);
+    // easeInOutCubic: sale suave, llega suave. Un corte duro marea.
+    const e = v.t < 0.5 ? 4 * v.t ** 3 : 1 - (-2 * v.t + 2) ** 3 / 2;
+    camera.position.lerpVectors(v.desdePos, v.haciaPos, e);
+    ctr.target.lerpVectors(v.desdeMira, v.haciaMira, e);
+    ctr.update();
+    if (v.t >= 1) viaje.current = null;
+  });
+
+  return null;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  El anillo del paso                                                         */
+/* -------------------------------------------------------------------------- */
+
+function FocoPaso({ foco, reducedMotion }) {
+  const anillo = useRef(null);
+  useFrame(({ clock }) => {
+    const m = anillo.current;
+    if (!m) return;
+    if (reducedMotion) {
+      m.material.opacity = 0.42;
+      return;
+    }
+    const t = clock.elapsedTime;
+    m.material.opacity = 0.3 + 0.2 * Math.sin(t * 1.8);
+    m.scale.setScalar(1 + 0.06 * Math.sin(t * 1.8));
+  });
+  if (!foco) return null;
+  return (
+    <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+      <ringGeometry args={[1.05, 1.4, 32]} />
+      <meshBasicMaterial
+        color={LUCES.candela}
+        transparent
+        opacity={0.4}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  La fauna                                                                   */
+/* -------------------------------------------------------------------------- */
+
+/* Los bichos que de verdad se paran en un trapiche. El guarapo dulce y
+   destapado es un imán: a una molienda le llegan mariposas y abejas al olor
+   desde lejos, y por eso la canoa y la batea siempre tienen visita. */
+const FAUNA_TRAPICHE = [
+  { tipo: 'mariposa', base: [9.6, 1.9, 0.9], patron: 'revoloteo', size: 26, fase: 0.6, df: 9 },
+  { tipo: 'mariposa', base: [14.4, 1.7, 4.8], patron: 'revoloteo', size: 23, fase: 2.4, df: 9 },
+  { tipo: 'escarabajo', base: [4.2, 0.4, 6.2], patron: 'reptar', size: 20, fase: 1.2, df: 8 },
+];
+
+/* La fauna emblemática del piso CÁLIDO, que es donde vive la caña de trapiche
+   (tierra caliente y falda baja, muy por debajo del cafetal). Billboards SVG
+   con su coreografía por nicho. Orden = prominencia: el recorte por tier deja
+   siempre lo insignia. */
+const FAUNA_CALIDO_CANA = [
+  { tipo: 'guacamaya', base: [-4, 7.2, -8], patron: 'vuela', size: 60, fase: 0.3, df: 13, title: 'Guacamaya bandera (Ara macao)' },
+  { tipo: 'tucan', base: [-13.5, 4.2, 2.5], patron: 'posa', size: 56, fase: 1.4, df: 10, title: 'Tucán pechiblanco (Ramphastos tucanus)' },
+  { tipo: 'morfo', base: [-6.5, 2.4, 7.5], patron: 'morfo', size: 38, fase: 0.9, df: 9, title: 'Morfo azul (Morpho peleides)' },
+  { tipo: 'mico', base: [17.5, 3.6, -7.5], patron: 'trepa', size: 50, fase: 2.2, df: 10, title: 'Mico maicero (Saimiri sciureus)' },
+];
+
+/* -------------------------------------------------------------------------- */
+/*  El diorama                                                                 */
+/* -------------------------------------------------------------------------- */
+
+function Diorama({ tier, reducedMotion, foco, vista, vistaToken }) {
+  const perfil = perfilDeTier(tier);
+  const atm = useAtmosferaMundo({ familia: FAMILIA_CANA, reducedMotion });
+  const bandas = useGradienteBandas();
+  const controls = useRef(null);
+
+  const geoVega = useMemo(
+    () => construirVega(perfil.segmentosTerreno, perfil.flatShading),
+    [perfil.segmentosTerreno, perfil.flatShading],
+  );
+
+  /* EL MURO DE CAÑAVERAL DEL FONDO. Sin esto el lote se acaba en seco y se ve
+     el borde del mundo. Y sirve para lo otro: a media distancia un cañaveral
+     tiene que seguir leyéndose como caña — una masa vertical de borde superior
+     RASGADO, nunca una fila de conos (el error que se pagó en el cafetal). */
+  const geoMuro = useMemo(
+    () => geomMuroCanaveral({ largo: 62, alto: 4.1, semilla: 88, dientes: perfil.flatShading ? 34 : 48 }),
+    [perfil.flatShading],
+  );
+  const geoMuroLado = useMemo(
+    () => geomMuroCanaveral({ largo: 40, alto: 3.8, semilla: 91, dientes: perfil.flatShading ? 22 : 32 }),
+    [perfil.flatShading],
+  );
+
+  const matMuro = useMemo(
+    () => new THREE.MeshLambertMaterial({ vertexColors: true, flatShading: true }),
+    [],
+  );
+
+  const montes = useMemo(
+    () => ({
+      cerca: mezclar(VERDES.monte, atm.niebla, 0.24),
+      media: mezclar(VERDES.monte, atm.niebla, 0.34),
+      lejos: mezclar(VERDES.monte, atm.niebla, 0.46),
+    }),
+    [atm.niebla],
+  );
+
+  const fuerza = fuerzaDeFranja(atm.franja);
+
+  const fauna = useMemo(
+    () => (tier === 'alto' ? FAUNA_TRAPICHE : FAUNA_TRAPICHE.slice(0, 1)),
+    [tier],
+  );
+  const faunaCalido = useMemo(
+    () => (tier === 'alto' ? FAUNA_CALIDO_CANA : FAUNA_CALIDO_CANA.slice(0, 2)),
+    [tier],
+  );
+
+  const yTrapiche = Y_ERA;
+
+  return (
+    <>
+      {/* La atmósfera del kit: fondo, niebla, sol y estrellas de LA HORA DEL
+          VALLE (familia plaza), con el shadow-map del lote en gama alta. */}
+      <AtmosferaMundo
+        familia={FAMILIA_CANA}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        radio={RADIO_CANA}
+        conSuelo={false}
+        sombra={SOMBRA_CANA}
+      />
+      <DomoCielo atm={atm} radio={78} />
+
+      {/* LA VEGA por bandas (recibe la sombra del lote y de la enramada). */}
+      <mesh geometry={geoVega} receiveShadow={perfil.sombras}>
+        <meshToonMaterial vertexColors gradientMap={bandas} />
+      </mesh>
+
+      {/* Los montes de tierra caliente al fondo, comidos por la niebla de la
+          hora (perspectiva aérea viva: al atardecer se doran). */}
+      <mesh position={[-16, 3.2, -30]} scale={[13, 5.4, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.media} gradientMap={bandas} />
+      </mesh>
+      <mesh position={[12, 3.8, -34]} scale={[15, 7.0, 7]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.lejos} gradientMap={bandas} />
+      </mesh>
+      <mesh position={[30, 2.4, -26]} scale={[10, 4.2, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshToonMaterial color={montes.cerca} gradientMap={bandas} />
+      </mesh>
+
+      {/* El cañaveral que sigue más allá de lo sembrado a mano. */}
+      <mesh geometry={geoMuro} material={matMuro} position={[-4, alturaVega(-4, -21) - 0.3, -21.5]} />
+      <mesh
+        geometry={geoMuroLado}
+        material={matMuro}
+        position={[-23.5, alturaVega(-23, -2) - 0.3, -2]}
+        rotation={[0, Math.PI / 2, 0]}
+      />
+
+      {/* EL LOTE: surcos, chala, penachos y la onda del viento. */}
+      <Canaveral tier={tier} reducedMotion={reducedMotion} />
+
+      {/* LA ENRAMADA, plantada en su era aplanada. */}
+      <group position={[SITIO_TRAPICHE[0], yTrapiche, SITIO_TRAPICHE[1]]}>
+        <Trapiche tier={tier} reducedMotion={reducedMotion} fuerza={fuerza} />
+      </group>
+
+      {/* La vida que el guarapo dulce atrae, y la del piso cálido alrededor. */}
+      {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
+      {perfil.criaturas > 0 && <FaunaCalido items={faunaCalido} reducedMotion={reducedMotion} />}
+
+      <FocoPaso foco={foco} reducedMotion={reducedMotion} />
+
+      <OrbitControls
+        ref={controls}
+        makeDefault
+        target={[3.5, 2.6, 0.5]}
+        enablePan={false}
+        enableZoom
+        minDistance={5}
+        maxDistance={34}
+        minPolarAngle={0.28}
+        maxPolarAngle={1.5}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={false}
+      />
+
+      {/* La LLEGADA: dolly de establishing, una vez por sesión. */}
+      <CamaraDirector
+        controls={controls}
+        reposo={[7.5, 2.6, 21]}
+        mirada={[3.5, 3.0, 0.5]}
+        respiro={0.035}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="mundoCanaTrapiche"
+      />
+
+      {/* Y el viaje a cada paso de la lección (ahí se siente la altura). */}
+      <CamaraLeccion
+        vista={vista}
+        token={vistaToken}
+        controls={controls}
+        reducedMotion={reducedMotion}
+      />
+
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * El mundo de la caña y el trapiche. Montar SOLO perezosa (lazy).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean,
+ *          foco?: number[]|null, vista?: {pos:number[], mira:number[]}|null,
+ *          vistaToken?: number}} props
+ */
+export default function EscenaCanaTrapiche({
+  tier = 'alto',
+  reducedMotion = false,
+  foco = null,
+  vista = null,
+  vistaToken = 0,
+}) {
+  const perfil = perfilDeTier(tier);
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`cana-canvas${listo ? ' cana-canvas--lista' : ''}`}
+      dpr={perfil.dpr}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      shadows={perfil.sombras ? 'soft' : false}
+      camera={{ position: [7.5, 2.6, 21], fov: 52 }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Diorama
+        tier={tier}
+        reducedMotion={reducedMotion}
+        foco={foco}
+        vista={vista}
+        vistaToken={vistaToken}
+      />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/cana/FuegoHornilla.jsx
+++ b/src/visual/mundo3d/cana/FuegoHornilla.jsx
@@ -1,0 +1,267 @@
+/*
+ * FuegoHornilla — el FUEGO, el VAPOR y el HUMO del trapiche.
+ *
+ * Este es el único mundo de Chagra con candela de verdad, y esa es su suerte:
+ * en una molienda la LUZ ESTÁ MOTIVADA. No hay que inventar un foco bonito —
+ * la fuente es la boca de la hornilla, quemando el bagazo de la misma caña que
+ * se molió hace un rato. De noche esa boca es lo único que alumbra la enramada,
+ * y el mundo entero se ordena alrededor de ella.
+ *
+ * Tres piezas, las tres deliberadamente baratas (cero shaders, cero texturas,
+ * cero CDN — todo corre en un teléfono de gama media):
+ *
+ *   · Candela — los conos aditivos de la llama sobre la boca del horno, más la
+ *     `pointLight` que de verdad ilumina los postes, las pailas y el techo. La
+ *     intensidad la manda la HORA: de día es un acento tibio, de noche manda.
+ *   · Vaho    — el vapor que sube de las pailas hirviendo. Discos que miran a la
+ *     cámara, suben, se ensanchan y se deshacen. Blanco tibio, no humo.
+ *   · Humo    — la columna gris de la chimenea. Más lento, más grande, más
+ *     opaco abajo, y se ladea con la brisa (la misma que mece el cañaveral).
+ *
+ * REDUCED-MOTION: nada de congelar la escena en negro. Las tres piezas quedan
+ * QUIETAS pero PRESENTES, cada partícula parada en su punto del recorrido — se
+ * sigue leyendo "aquí hay fuego y aquí sube vapor", sin un solo parpadeo.
+ *
+ * Componentes r3f: montar dentro del <Canvas> de EscenaCanaTrapiche.
+ */
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { rng } from '../bosque/sombreadoVegetal.js';
+
+/* La paleta de la candela: del naranja hondo de la brasa al amarillo del
+   cogollo de la llama. (No se usan los ACENTOS de la paleta madre: esto es luz
+   emitida, no pigmento — vive en otra escala.) */
+const LLAMA = {
+  brasa: '#c2380f',
+  cuerpo: '#f2751c',
+  lengua: '#ffab35',
+  cogollo: '#ffe08a',
+};
+
+/**
+ * LA CANDELA de la boca del horno: lenguas de fuego + la luz que sale de ellas.
+ *
+ * @param {object} p
+ * @param {[number,number,number]} p.pos  la boca del horno, en coords del mundo.
+ * @param {number} [p.fuerza]  cuánto manda el fuego en la escena (lo pone la
+ *   hora: de día ~0,7; al atardecer ~1,2; de noche ~1,8).
+ * @param {number} [p.escala]  tamaño de la llama.
+ * @param {boolean} [p.luz]    montar la pointLight (solo gama que la aguanta).
+ * @param {boolean} [p.reducedMotion]
+ */
+export function Candela({ pos, fuerza = 1, escala = 1, luz = true, reducedMotion = false }) {
+  const grupo = useRef(null);
+  const foco = useRef(null);
+  const brillo = useRef(null);
+
+  /* Las lenguas: unas pocas, de tamaños y ritmos distintos. Una llama pareja no
+     existe; lo que la hace leer como fuego es que cada lengua vaya a su aire. */
+  const lenguas = useMemo(() => {
+    const r = rng(313);
+    const cols = [LLAMA.brasa, LLAMA.cuerpo, LLAMA.cuerpo, LLAMA.lengua, LLAMA.lengua, LLAMA.cogollo];
+    return cols.map((color, i) => ({
+      color,
+      // las de adentro son chicas y altas; las de afuera, anchas y bajas
+      radio: (0.36 - i * 0.045) * escala,
+      alto: (0.52 + i * 0.14) * escala,
+      x: (r() - 0.5) * 0.34 * escala,
+      z: (r() - 0.5) * 0.26 * escala,
+      fase: r() * Math.PI * 2,
+      vel: 2.6 + r() * 2.8,
+      op: 0.30 + i * 0.09,
+    }));
+  }, [escala]);
+
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (!g) return;
+    // Con reducedMotion se planta un instante fijo del fuego: presencia sin baile.
+    const t = reducedMotion ? 1.7 : clock.elapsedTime;
+    let suma = 0;
+    for (let i = 0; i < g.children.length; i++) {
+      const m = /** @type {any} */ (g.children[i]);
+      const d = lenguas[i];
+      if (!d) continue;
+      // La lengua sube, se estira y se encoge; nunca las dos igual.
+      const pulso = 0.72 + 0.28 * Math.sin(t * d.vel + d.fase);
+      const lateral = 0.14 * Math.sin(t * d.vel * 0.6 + d.fase * 1.7);
+      m.scale.set(pulso, 0.78 + 0.42 * Math.sin(t * d.vel * 0.8 + d.fase), pulso);
+      m.position.set(d.x + lateral * escala, d.alto * 0.5 * m.scale.y, d.z);
+      m.rotation.z = lateral * 0.8;
+      m.material.opacity = d.op * (0.72 + 0.28 * Math.sin(t * d.vel * 1.3 + d.fase));
+      suma += pulso;
+    }
+    // LA LUZ sale de la llama, no al revés: sigue su pulso.
+    const vivo = suma / Math.max(1, lenguas.length);
+    if (foco.current) foco.current.intensity = 2.5 * fuerza * vivo;
+    if (brillo.current) brillo.current.material.opacity = 0.28 * fuerza * vivo;
+  });
+
+  return (
+    <group position={pos}>
+      <group ref={grupo}>
+        {lenguas.map((d, i) => (
+          <mesh key={i}>
+            <coneGeometry args={[d.radio, d.alto, 7, 1, true]} />
+            <meshBasicMaterial
+              color={d.color}
+              transparent
+              opacity={d.op}
+              depthWrite={false}
+              blending={THREE.AdditiveBlending}
+              side={THREE.DoubleSide}
+            />
+          </mesh>
+        ))}
+      </group>
+
+      {/* El resplandor sobre el piso de la era: la mancha de luz de la boca. */}
+      <mesh ref={brillo} position={[0, -0.28, 0.5]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[1.7 * escala, 18]} />
+        <meshBasicMaterial
+          color={LLAMA.lengua}
+          transparent
+          opacity={0.26}
+          depthWrite={false}
+          blending={THREE.AdditiveBlending}
+        />
+      </mesh>
+
+      {/* LA LUZ MOTIVADA de este mundo. Sin sombras a propósito: el shadow-map
+          se lo lleva el sol de la atmósfera, y una segunda cámara de sombra por
+          una llama no vale lo que cuesta en un teléfono. */}
+      {luz && <pointLight ref={foco} color={LLAMA.lengua} intensity={2.5 * fuerza} distance={17} decay={2} position={[0, 0.5, 0.3]} />}
+    </group>
+  );
+}
+
+/**
+ * Una COLUMNA de partículas que miran a la cámara: sirve igual para el vapor de
+ * una paila que para el humo de la chimenea. Cada disco sube desde la base,
+ * crece y se desvanece; al llegar arriba vuelve a nacer abajo.
+ *
+ * Los discos se orientan UNO POR UNO con la cámara (no el grupo entero): así el
+ * penacho sigue subiendo en vertical de verdad aunque uno gire alrededor.
+ *
+ * @param {object} p
+ * @param {[number,number,number]} p.pos   la base de la columna.
+ * @param {number} p.n        cuántos discos.
+ * @param {number} p.alto     hasta dónde sube antes de deshacerse.
+ * @param {number} p.radio    radio inicial del disco.
+ * @param {number} [p.crece]  cuánto se ensancha al subir.
+ * @param {string} p.color
+ * @param {number} [p.opacidad]
+ * @param {number} [p.vel]    vueltas por segundo del ciclo de una partícula.
+ * @param {[number,number]} [p.deriva]  hacia dónde lo ladea la brisa (x, z).
+ * @param {boolean} [p.reducedMotion]
+ */
+export function Columna({
+  pos, n, alto, radio, crece = 2.4, color, opacidad = 0.3, vel = 0.22,
+  deriva = [0.5, 0], reducedMotion = false,
+}) {
+  const grupo = useRef(null);
+
+  const datos = useMemo(() => {
+    const r = rng(Math.round((pos[0] + pos[2]) * 97) + n * 13 + 5);
+    return Array.from({ length: n }, () => ({
+      fase: r(),
+      jx: (r() - 0.5) * radio * 1.5,
+      jz: (r() - 0.5) * radio * 1.5,
+      vueltas: 0.75 + r() * 0.55, // cada bocanada va a su ritmo
+      bamboleo: (r() - 0.5) * 1.6,
+      esc: 0.7 + r() * 0.6,
+    }));
+  }, [n, radio, pos]);
+
+  useFrame(({ clock, camera }) => {
+    const g = grupo.current;
+    if (!g) return;
+    const t = reducedMotion ? 3.3 : clock.elapsedTime;
+    for (let i = 0; i < g.children.length; i++) {
+      const m = /** @type {any} */ (g.children[i]);
+      const d = datos[i];
+      if (!d) continue;
+      // u ∈ [0,1): dónde va esta bocanada en su recorrido.
+      const u = (t * vel * d.vueltas + d.fase) % 1;
+      const y = u * alto;
+      // Sube ladeándose con la brisa y bamboleando un poco.
+      const abre = 1 + u * crece;
+      m.position.set(
+        d.jx + deriva[0] * y * 0.42 + Math.sin(u * 3.4 + d.bamboleo * 4) * radio * 0.5,
+        y,
+        d.jz + deriva[1] * y * 0.42,
+      );
+      m.scale.setScalar(radio * abre * d.esc);
+      // Nace de golpe, se apaga despacio: así se lee "sale de ahí".
+      const nace = Math.min(1, u * 7);
+      const muere = 1 - u;
+      m.material.opacity = opacidad * nace * muere * muere;
+      // El disco mira a la cámara, uno por uno.
+      m.quaternion.copy(camera.quaternion);
+    }
+  });
+
+  return (
+    <group ref={grupo} position={pos}>
+      {datos.map((d, i) => (
+        <mesh key={i}>
+          <circleGeometry args={[1, 12]} />
+          <meshBasicMaterial
+            color={color}
+            transparent
+            opacity={0}
+            depthWrite={false}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/**
+ * EL VAPOR de una paila hirviendo: blanco tibio, sube rápido y se deshace cerca.
+ * @param {{pos: [number,number,number], n?: number, fuerza?: number,
+ *          color?: string, reducedMotion?: boolean}} p
+ */
+export function VaporPaila({ pos, n = 6, fuerza = 1, color = '#fdf6e6', reducedMotion = false }) {
+  return (
+    <Columna
+      pos={pos}
+      n={n}
+      alto={2.1}
+      radio={0.22}
+      crece={3.1}
+      color={color}
+      opacidad={0.30 * fuerza}
+      vel={0.30}
+      deriva={[0.34, -0.1]}
+      reducedMotion={reducedMotion}
+    />
+  );
+}
+
+/**
+ * EL HUMO de la chimenea: gris, lento, grande. La caña quemando su propio
+ * bagazo — el penacho que se ve desde el otro lado del valle y anuncia que hoy
+ * hay molienda.
+ * @param {{pos: [number,number,number], n?: number, color?: string,
+ *          reducedMotion?: boolean}} p
+ */
+export function HumoChimenea({ pos, n = 10, color = '#9a938a', reducedMotion = false }) {
+  return (
+    <Columna
+      pos={pos}
+      n={n}
+      alto={5.6}
+      radio={0.44}
+      crece={2.9}
+      color={color}
+      opacidad={0.26}
+      vel={0.15}
+      deriva={[0.72, -0.22]}
+      reducedMotion={reducedMotion}
+    />
+  );
+}

--- a/src/visual/mundo3d/cana/MundoCana.jsx
+++ b/src/visual/mundo3d/cana/MundoCana.jsx
@@ -5,11 +5,9 @@
  * auto-detecta con decidirTier si se monta suelto), llena a su padre y guarda su
  * estado local.
  *
- * Sobre la escena viven los CINCO PASOS, y están puestos en el orden en que
- * pasan las cosas de verdad: la caña en pie → el corte y la molienda → el
- * bagazo que vuelve como leña → la hornilla y sus pailas → las gaveras. Al
- * final de ese camino, una mata que mide más de cuatro metros terminó siendo un
- * bloque que cabe en la mano. Esa transformación es la lección entera.
+ * Los cinco pasos y sus encuadres viven en `leccionCana.js` (sin React ni
+ * WebGL) para poder verificarlos headless: que ninguna cámara arranque metida
+ * dentro de una cepa ni quede bajo tierra. Aquí solo queda el andamiaje.
  *
  * Cada paso señala SU lugar con un anillo (el `foco`) Y LLEVA LA CÁMARA (la
  * `vista`). Lo segundo importa tanto como lo primero: la altura del cañaveral no
@@ -24,62 +22,7 @@ import { useCallback, useMemo, useState } from 'react';
 import EscenaCanaTrapiche from './EscenaCanaTrapiche.jsx';
 import PanelPasos from '../PanelPasos.jsx';
 import { decidirTier, permite3D } from '../deviceTier.js';
-import { alturaVega, enTrapiche } from './floraCana.geom.js';
-
-/* Un punto del cañaveral, a ras de suelo. */
-const enElLote = (x, z) => /** @type {[number,number,number]} */ ([x, alturaVega(x, z), z]);
-
-/* El pasillo entre dos surcos por donde se mete la cámara en el primer paso.
-   1,55 m es la altura de los ojos de una persona parada: desde ahí, y solo
-   desde ahí, se entiende que la caña le pasa por encima. */
-const PASILLO_X = -8.56;
-const OJOS = 1.55;
-
-const PASOS = [
-  {
-    id: 'canaveral',
-    kicker: 'Paso 1 de 5 · El cañaveral',
-    texto:
-      'Métase al surco y mire para arriba: la caña le pasa por encima. Una caña de trapiche madura pasa de los cuatro metros — más de dos veces usted. Fíjese en el tallo: viene por segmentos, con un nudo entre uno y otro, y en cada nudo hay una yema. De un pedazo de tallo con yemas sale la mata siguiente.',
-    foco: enElLote(PASILLO_X, 0),
-    vista: {
-      pos: [PASILLO_X, alturaVega(PASILLO_X, 6.5) + OJOS, 6.5],
-      mira: [PASILLO_X + 0.3, 3.5, -6],
-    },
-  },
-  {
-    id: 'molienda',
-    kicker: 'Paso 2 de 5 · La molienda',
-    texto:
-      'La caña se corta, se despunta y se arruma; y de ahí derecho al molino, porque caña cortada que se demora empieza a fermentar y daña la panela. El molino la pasa entre tres masas que la exprimen. Salen dos cosas: el JUGO, que aquí se llama guarapo, y el BAGAZO, que es la fibra ya seca de tanto apretarla.',
-    foco: enTrapiche(-4.2, 0, -1.2),
-    vista: { pos: [1.2, 2.4, 5.8], mira: [6.3, 1.5, 0.6] },
-  },
-  {
-    id: 'bagazo',
-    kicker: 'Paso 3 de 5 · El bagazo',
-    texto:
-      'Aquí está lo mejor del oficio. El bagazo sale mojado del molino, se apila unas semanas a secar, y seco vuelve a la hornilla como leña. El trapiche se calienta con la misma caña que muele: no le toca comprar combustible ni bajarle un palo al monte. Mire los tres montones y va a ver el mismo bagazo en sus tres momentos.',
-    foco: enTrapiche(8.2, 0, 2.0),
-    vista: { pos: [22.5, 3.2, 8.0], mira: [17.2, 1.2, 1.8] },
-  },
-  {
-    id: 'hornilla',
-    kicker: 'Paso 4 de 5 · La hornilla y las pailas',
-    texto:
-      'Una sola candela calienta toda la fila. El fuego está en un extremo y la chimenea en el otro, así que cada paila recibe distinto calor: el guarapo entra por la más templada, donde se le retira la CACHAZA — esa espuma verdosa que se lleva la suciedad y que después sirve de abono o de comida para los animales —, y va caminando hacia el fuego mientras se evapora y se vuelve miel. La última, la de al lado de la llama, es la del punteo.',
-    foco: enTrapiche(2.3, 0, -1.4),
-    vista: { pos: [12.6, 2.6, 6.4], mira: [12.8, 1.5, 0.5] },
-  },
-  {
-    id: 'gaveras',
-    kicker: 'Paso 5 de 5 · Las gaveras',
-    texto:
-      'La miel en su punto se pasa a la batea y se bate: al batirla entra aire, aclara y empieza a granular. Ahí mismo se vacía en las GAVERAS, los moldes de madera, y se deja enfriar. Cuando cuaja se voltea el molde y sale el bloque. De una mata más alta que usted salió algo que cabe en la mano — y eso es todo lo que pasa en un trapiche.',
-    foco: enTrapiche(4.3, 0, 2.6),
-    vista: { pos: [11.8, 2.2, 9.4], mira: [14.8, 1.2, 4.8] },
-  },
-];
+import { PASOS, TEMA_PANEL } from './leccionCana.js';
 
 const CSS = `
 .mcana { position: relative; width: 100%; height: 100%; overflow: hidden; background: #e6d6b4; }
@@ -89,19 +32,6 @@ const CSS = `
   .mcana canvas { transition: none; }
 }
 `;
-
-/* El acento del trapiche para el panel compartido: el ámbar de la miel sobre el
-   pardo quemado de la hornilla. */
-const TEMA_PANEL = {
-  fondo: 'rgba(30, 17, 9, 0.70)',
-  borde: 'rgba(226, 160, 82, 0.30)',
-  tinta: '#f6ead6',
-  kicker: '#e6b877',
-  acentoA: 'rgba(240, 168, 62, 0.95)',
-  acentoB: 'rgba(184, 96, 30, 0.95)',
-  tintaAccion: '#2a1606',
-  activo: '#f0a83e',
-};
 
 /**
  * El mundo de la caña y el trapiche panelero, completo: escena + pasos.

--- a/src/visual/mundo3d/cana/MundoCana.jsx
+++ b/src/visual/mundo3d/cana/MundoCana.jsx
@@ -1,0 +1,152 @@
+/*
+ * MundoCana — el MUNDO DE LA CAÑA Y EL TRAPICHE completo: la escena + la lección.
+ *
+ * Mismo contrato de host que MundoCafetal: acepta `{tier, reducedMotion}` (o
+ * auto-detecta con decidirTier si se monta suelto), llena a su padre y guarda su
+ * estado local.
+ *
+ * Sobre la escena viven los CINCO PASOS, y están puestos en el orden en que
+ * pasan las cosas de verdad: la caña en pie → el corte y la molienda → el
+ * bagazo que vuelve como leña → la hornilla y sus pailas → las gaveras. Al
+ * final de ese camino, una mata que mide más de cuatro metros terminó siendo un
+ * bloque que cabe en la mano. Esa transformación es la lección entera.
+ *
+ * Cada paso señala SU lugar con un anillo (el `foco`) Y LLEVA LA CÁMARA (la
+ * `vista`). Lo segundo importa tanto como lo primero: la altura del cañaveral no
+ * se puede contar desde lejos, hay que meterse al pasillo entre surcos y mirar
+ * para arriba. El paso 1 hace exactamente eso.
+ *
+ * Copy en español de Colombia, en "usted".
+ *
+ * Importa three/@react-three (vía la escena) → montar SOLO perezoso (lazy).
+ */
+import { useCallback, useMemo, useState } from 'react';
+import EscenaCanaTrapiche from './EscenaCanaTrapiche.jsx';
+import PanelPasos from '../PanelPasos.jsx';
+import { decidirTier, permite3D } from '../deviceTier.js';
+import { alturaVega, enTrapiche } from './floraCana.geom.js';
+
+/* Un punto del cañaveral, a ras de suelo. */
+const enElLote = (x, z) => /** @type {[number,number,number]} */ ([x, alturaVega(x, z), z]);
+
+/* El pasillo entre dos surcos por donde se mete la cámara en el primer paso.
+   1,55 m es la altura de los ojos de una persona parada: desde ahí, y solo
+   desde ahí, se entiende que la caña le pasa por encima. */
+const PASILLO_X = -8.56;
+const OJOS = 1.55;
+
+const PASOS = [
+  {
+    id: 'canaveral',
+    kicker: 'Paso 1 de 5 · El cañaveral',
+    texto:
+      'Métase al surco y mire para arriba: la caña le pasa por encima. Una caña de trapiche madura pasa de los cuatro metros — más de dos veces usted. Fíjese en el tallo: viene por segmentos, con un nudo entre uno y otro, y en cada nudo hay una yema. De un pedazo de tallo con yemas sale la mata siguiente.',
+    foco: enElLote(PASILLO_X, 0),
+    vista: {
+      pos: [PASILLO_X, alturaVega(PASILLO_X, 6.5) + OJOS, 6.5],
+      mira: [PASILLO_X + 0.3, 3.5, -6],
+    },
+  },
+  {
+    id: 'molienda',
+    kicker: 'Paso 2 de 5 · La molienda',
+    texto:
+      'La caña se corta, se despunta y se arruma; y de ahí derecho al molino, porque caña cortada que se demora empieza a fermentar y daña la panela. El molino la pasa entre tres masas que la exprimen. Salen dos cosas: el JUGO, que aquí se llama guarapo, y el BAGAZO, que es la fibra ya seca de tanto apretarla.',
+    foco: enTrapiche(-4.2, 0, -1.2),
+    vista: { pos: [1.2, 2.4, 5.8], mira: [6.3, 1.5, 0.6] },
+  },
+  {
+    id: 'bagazo',
+    kicker: 'Paso 3 de 5 · El bagazo',
+    texto:
+      'Aquí está lo mejor del oficio. El bagazo sale mojado del molino, se apila unas semanas a secar, y seco vuelve a la hornilla como leña. El trapiche se calienta con la misma caña que muele: no le toca comprar combustible ni bajarle un palo al monte. Mire los tres montones y va a ver el mismo bagazo en sus tres momentos.',
+    foco: enTrapiche(8.2, 0, 2.0),
+    vista: { pos: [22.5, 3.2, 8.0], mira: [17.2, 1.2, 1.8] },
+  },
+  {
+    id: 'hornilla',
+    kicker: 'Paso 4 de 5 · La hornilla y las pailas',
+    texto:
+      'Una sola candela calienta toda la fila. El fuego está en un extremo y la chimenea en el otro, así que cada paila recibe distinto calor: el guarapo entra por la más templada, donde se le retira la CACHAZA — esa espuma verdosa que se lleva la suciedad y que después sirve de abono o de comida para los animales —, y va caminando hacia el fuego mientras se evapora y se vuelve miel. La última, la de al lado de la llama, es la del punteo.',
+    foco: enTrapiche(2.3, 0, -1.4),
+    vista: { pos: [12.6, 2.6, 6.4], mira: [12.8, 1.5, 0.5] },
+  },
+  {
+    id: 'gaveras',
+    kicker: 'Paso 5 de 5 · Las gaveras',
+    texto:
+      'La miel en su punto se pasa a la batea y se bate: al batirla entra aire, aclara y empieza a granular. Ahí mismo se vacía en las GAVERAS, los moldes de madera, y se deja enfriar. Cuando cuaja se voltea el molde y sale el bloque. De una mata más alta que usted salió algo que cabe en la mano — y eso es todo lo que pasa en un trapiche.',
+    foco: enTrapiche(4.3, 0, 2.6),
+    vista: { pos: [11.8, 2.2, 9.4], mira: [14.8, 1.2, 4.8] },
+  },
+];
+
+const CSS = `
+.mcana { position: relative; width: 100%; height: 100%; overflow: hidden; background: #e6d6b4; }
+.mcana canvas { opacity: 0; transition: opacity 0.9s ease; }
+.mcana .cana-canvas--lista canvas, .mcana canvas.cana-canvas--lista { opacity: 1; }
+@media (prefers-reduced-motion: reduce) {
+  .mcana canvas { transition: none; }
+}
+`;
+
+/* El acento del trapiche para el panel compartido: el ámbar de la miel sobre el
+   pardo quemado de la hornilla. */
+const TEMA_PANEL = {
+  fondo: 'rgba(30, 17, 9, 0.70)',
+  borde: 'rgba(226, 160, 82, 0.30)',
+  tinta: '#f6ead6',
+  kicker: '#e6b877',
+  acentoA: 'rgba(240, 168, 62, 0.95)',
+  acentoB: 'rgba(184, 96, 30, 0.95)',
+  tintaAccion: '#2a1606',
+  activo: '#f0a83e',
+};
+
+/**
+ * El mundo de la caña y el trapiche panelero, completo: escena + pasos.
+ * Montar SOLO perezoso (lazy); llena a su contenedor.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function MundoCana({ tier: tierProp, reducedMotion: rmProp } = {}) {
+  // Contrato de mundos: props del host si llegan; si se monta suelto,
+  // auto-detección del equipo (no matar la gama baja).
+  const auto = useMemo(() => decidirTier(), []);
+  const tier = tierProp ?? (permite3D(auto.tier) ? auto.tier : 'bajo');
+  const reducedMotion = rmProp ?? auto.reducedMotion;
+
+  const [paso, setPaso] = useState(0);
+  /* El token sube en CADA toque, no solo al cambiar de paso: si el que mira ya
+     giró la escena con el dedo y vuelve a tocar el mismo paso, la cámara lo
+     lleva otra vez al sitio en vez de quedarse quieta. */
+  const [token, setToken] = useState(0);
+
+  const irAlPaso = useCallback((i) => {
+    setPaso(i);
+    setToken((t) => t + 1);
+  }, []);
+
+  const actual = PASOS[paso];
+
+  return (
+    <div className="mcana">
+      <style>{CSS}</style>
+      <EscenaCanaTrapiche
+        tier={tier}
+        reducedMotion={reducedMotion}
+        foco={actual.foco}
+        vista={actual.vista}
+        vistaToken={token}
+      />
+
+      <PanelPasos
+        etiqueta="De la caña a la panela"
+        pasos={PASOS}
+        paso={paso}
+        onPaso={irAlPaso}
+        tema={TEMA_PANEL}
+        reducedMotion={reducedMotion}
+      />
+    </div>
+  );
+}

--- a/src/visual/mundo3d/cana/Trapiche.jsx
+++ b/src/visual/mundo3d/cana/Trapiche.jsx
@@ -1,0 +1,365 @@
+/*
+ * Trapiche — la ENRAMADA completa, armada y prendida.
+ *
+ * Monta las piezas fusionadas de `trapiche.geom.js` (esqueleto, techo, molienda,
+ * hornilla, pailas, moldeo, bagazo, útiles) y les pone encima lo único que NO
+ * puede ir horneado en una geometría opaca: los LÍQUIDOS y el FUEGO. El jugo
+ * que corre por la canoa, lo que hierve en cada paila, la cachaza que hay que
+ * retirar, la panela cuajándose en la gavera, la candela de la boca del horno,
+ * el vapor de las pailas y el humo de la chimenea.
+ *
+ * El orden de las pailas ES la lección, y por eso lo que hay adentro de cada
+ * una es distinto: en la primera (la más lejos del fuego) todavía hay jugo
+ * verdoso y turbio con su espuma; en la última, al lado de la candela, ya hay
+ * miel oscura a punto de panela. Un solo vistazo cuenta el proceso.
+ *
+ * `fuerza` es cuánto manda el fuego en la escena y lo decide LA HORA: de día la
+ * candela es un acento tibio; de noche es lo único que alumbra la enramada, y
+ * entonces este mundo se ve como se ve una molienda de verdad a las ocho de la
+ * noche. Eso no es un efecto: es la luz motivada del sitio.
+ *
+ * Componente r3f: montar dentro del <Canvas> de EscenaCanaTrapiche.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import { Candela, VaporPaila, HumoChimenea } from './FuegoHornilla.jsx';
+import {
+  ENRAMADA,
+  SITIOS,
+  PAILAS,
+  PAILA_Y,
+  PAILA_Z,
+  CELDAS_GAVERA,
+  PAL,
+  geomEsqueletoEnramada,
+  geomTechoEnramada,
+  geomMolienda,
+  geomCanoaGuarapo,
+  geomHornilla,
+  geomPailas,
+  geomArrumeCana,
+  geomMoldeo,
+  geomUtiles,
+  geomBagazo,
+} from './trapiche.geom.js';
+
+/*
+ * QUÉ HAY EN CADA PAILA. Se camina de la chimenea (frío) hacia la candela
+ * (caliente) y el jugo se va oscureciendo y espesando en el camino:
+ *
+ *   1. CLARIFICACIÓN — entra el guarapo crudo, verdoso y turbio. Al calentarse
+ *      sube a la superficie la CACHAZA: una espuma verdosa que se lleva la
+ *      tierra y el bagacillo. Se retira con el cucharón y no se bota — sirve de
+ *      alimento para los animales o se devuelve al cultivo como abono.
+ *   2 y 3. EVAPORACIÓN — hierve duro y suelta agua. Aquí es donde sale casi todo
+ *      el vapor de la enramada.
+ *   4. PUNTEO — ya es miel espesa y oscura. El punto se conoce a ojo y a mano,
+ *      con la prueba de la gota en agua: es el saber más difícil del oficio.
+ */
+const CONTENIDO = [
+  { color: PAL.guarapo, hondo: 0.10, brillo: 0.20, cachaza: true },
+  { color: '#a08a2c', hondo: 0.13, brillo: 0.28, cachaza: false },
+  { color: '#9a6b1e', hondo: 0.15, brillo: 0.34, cachaza: false },
+  { color: PAL.miel, hondo: 0.17, brillo: 0.46, cachaza: false },
+];
+
+/* La superficie de una paila: hierve (sube y baja apenas) y devuelve algo de
+   luz de la candela. Con reducedMotion queda plana y quieta. */
+function Caldo({ paila, cfg, hervor, reducedMotion }) {
+  const malla = useRef(null);
+  useFrame(({ clock }) => {
+    const m = malla.current;
+    if (!m || reducedMotion) return;
+    const t = clock.elapsedTime;
+    // el hervor: la lámina de miel respira y se agita más donde pega el fuego
+    m.position.y = PAILA_Y - cfg.hondo + Math.sin(t * (2.2 + hervor * 3)) * 0.012 * hervor;
+    m.scale.setScalar(1 + Math.sin(t * (1.6 + hervor * 2.4)) * 0.012 * hervor);
+  });
+  return (
+    <mesh
+      ref={malla}
+      position={[paila.x, PAILA_Y - cfg.hondo, PAILA_Z]}
+      rotation={[-Math.PI / 2, 0, 0]}
+    >
+      <circleGeometry args={[paila.r * 0.93, 20]} />
+      <meshStandardMaterial
+        color={cfg.color}
+        roughness={1 - cfg.brillo}
+        metalness={0}
+        emissive={cfg.color}
+        emissiveIntensity={0.12 + cfg.brillo * 0.18}
+      />
+    </mesh>
+  );
+}
+
+/* LA CACHAZA: los cuajarones de espuma verdosa que se juntan en la primera
+   paila y que el hornillero retira antes de que el jugo rompa a hervir. */
+function Cachaza({ paila, reducedMotion }) {
+  const grupo = useRef(null);
+  const manchas = useMemo(() => {
+    const lista = [];
+    for (let i = 0; i < 5; i++) {
+      const a = (i / 5) * Math.PI * 2 + 0.6;
+      const d = paila.r * (0.18 + (i % 3) * 0.2);
+      lista.push({
+        p: /** @type {[number,number,number]} */ ([
+          paila.x + Math.cos(a) * d,
+          PAILA_Y - 0.085,
+          PAILA_Z + Math.sin(a) * d,
+        ]),
+        r: paila.r * (0.16 + (i % 4) * 0.055),
+        fase: i * 1.27,
+      });
+    }
+    return lista;
+  }, [paila]);
+
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (!g || reducedMotion) return;
+    const t = clock.elapsedTime;
+    for (let i = 0; i < g.children.length; i++) {
+      const m = g.children[i];
+      const d = manchas[i];
+      // la espuma da vueltas despacio sobre el jugo caliente
+      m.position.x = d.p[0] + Math.sin(t * 0.35 + d.fase) * 0.045;
+      m.position.z = d.p[2] + Math.cos(t * 0.31 + d.fase) * 0.045;
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {manchas.map((d, i) => (
+        <mesh key={i} position={d.p} rotation={[-Math.PI / 2, 0, i * 0.7]}>
+          <circleGeometry args={[d.r, 8]} />
+          <meshStandardMaterial color={PAL.cachaza} roughness={0.95} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* EL BOMBILLO de la enramada, colgado de un tirante. Se prende cuando cae la
+   tarde — una molienda no se para porque anochezca. */
+function Bombillo({ pos, fuerza }) {
+  const luz = useRef(null);
+  const bulbo = useRef(null);
+  // Solo tiene sentido cuando ya no hay sol: la misma señal que el fuego.
+  const prendido = Math.max(0, Math.min(1, (fuerza - 0.95) / 0.85));
+  useLayoutEffect(() => {
+    if (luz.current) luz.current.intensity = 1.5 * prendido;
+    if (bulbo.current) bulbo.current.material.opacity = 0.35 + 0.65 * prendido;
+  }, [prendido]);
+  return (
+    <group position={pos}>
+      <mesh position={[0, 0.3, 0]}>
+        <cylinderGeometry args={[0.006, 0.006, 0.6, 4]} />
+        <meshBasicMaterial color="#2e2620" />
+      </mesh>
+      <mesh ref={bulbo}>
+        <sphereGeometry args={[0.075, 10, 7]} />
+        <meshBasicMaterial color="#ffd98a" transparent opacity={0.95} />
+      </mesh>
+      <pointLight ref={luz} color="#ffd08a" intensity={1.5} distance={9} decay={2} />
+    </group>
+  );
+}
+
+/**
+ * La enramada del trapiche, completa.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean,
+ *          fuerza?: number}} props  `fuerza` = cuánto manda el fuego (la hora).
+ */
+export default function Trapiche({ tier = 'alto', reducedMotion = false, fuerza = 1 }) {
+  const perfil = perfilDeTier(tier);
+  const q = tier === 'alto' ? 1 : tier === 'medio' ? 0.62 : 0.42;
+  const rico = perfil.materialRico;
+
+  /* Las piezas fusionadas: once draw-calls para toda la enramada. */
+  const geos = useMemo(
+    () => ({
+      esqueleto: geomEsqueletoEnramada({ q }),
+      techo: geomTechoEnramada({ q }),
+      molienda: geomMolienda({ q }),
+      canoa: geomCanoaGuarapo(),
+      hornilla: geomHornilla({ q }),
+      pailas: geomPailas({ q }),
+      arrume: geomArrumeCana({ q }),
+      moldeo: geomMoldeo({ q }),
+      utiles: q > 0.5 ? geomUtiles({ q }) : null,
+      // Los TRES estados del bagazo, que es la lección escondida del mundo:
+      // sale mojado del molino, se apila a secar, y seco vuelve como leña.
+      bagazoHumedo: geomBagazo({ radio: 0.95, alto: 0.55, estado: 'humedo', q, semilla: 301 }),
+      bagazoSecando: geomBagazo({ radio: 1.7, alto: 1.25, estado: 'secando', q, semilla: 302 }),
+      bagazoSeco: geomBagazo({ radio: 0.7, alto: 0.5, estado: 'seco', q, semilla: 303 }),
+    }),
+    [q],
+  );
+
+  /* Dos materiales para todo: uno mate (madera, ladrillo, bagazo, teja) y otro
+     metálico para las pailas. El color va horneado en vertexColors. */
+  const matMate = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return rico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.92, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [rico, perfil.flatShading]);
+
+  const matMetal = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return rico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.34, metalness: 0.72 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [rico, perfil.flatShading]);
+
+  useLayoutEffect(
+    () => () => {
+      Object.values(geos).forEach((g) => g && g.dispose());
+      matMate.dispose();
+      matMetal.dispose();
+    },
+    [geos, matMate, matMetal],
+  );
+
+  const sombra = perfil.sombras;
+  const vaporN = tier === 'alto' ? 6 : 3;
+
+  return (
+    <group>
+      {/* LA ESTRUCTURA: horcones, soleras, pares y el techo de teja con su
+          caballete alzado (por ahí se va el humo). */}
+      <mesh geometry={geos.esqueleto} material={matMate} castShadow={sombra} receiveShadow={sombra} />
+      <mesh geometry={geos.techo} material={matMate} castShadow={sombra} />
+
+      {/* LA CAÑA que llegó del lote, despuntada y arrumada. */}
+      <group position={SITIOS.arrume}>
+        <mesh geometry={geos.arrume} material={matMate} castShadow={sombra} />
+      </group>
+
+      {/* LA MOLIENDA sobre su bancada, con el motor y la correa. */}
+      <group position={SITIOS.molienda}>
+        <mesh geometry={geos.molienda} material={matMate} castShadow={sombra} />
+      </group>
+
+      {/* EL BAGAZO en sus tres estados: recién salido del molino (mojado), la
+          bagacera secando al sol afuera, y el montoncito seco listo al pie de
+          la boca del horno. La caña calienta su propia miel. */}
+      <group position={[-2.7, 0, -3.3]}>
+        <mesh geometry={geos.bagazoHumedo} material={matMate} castShadow={sombra} />
+      </group>
+      <group position={SITIOS.bagacera}>
+        <mesh geometry={geos.bagazoSecando} material={matMate} castShadow={sombra} />
+      </group>
+      <group position={[6.1, 0, -0.5]}>
+        <mesh geometry={geos.bagazoSeco} material={matMate} castShadow={sombra} />
+      </group>
+
+      {/* LA CANOA del guarapo, con el jugo corriendo hacia la primera paila. */}
+      <group position={SITIOS.canoa}>
+        <mesh geometry={geos.canoa} material={matMate} />
+        {/* el guarapo: verdoso y turbio, NO ámbar — el ámbar viene después */}
+        <mesh position={[0, 0.02, 0]} rotation={[0, 0, -0.056]}>
+          <boxGeometry args={[3.7, 0.035, 0.26]} />
+          <meshStandardMaterial
+            color={PAL.guarapo}
+            roughness={0.25}
+            metalness={0}
+            transparent
+            opacity={0.88}
+          />
+        </mesh>
+      </group>
+
+      {/* LA HORNILLA: una sola cámara larga, la boca en un extremo y la
+          chimenea en el otro. Encima, el tren de pailas. */}
+      <group position={SITIOS.hornilla}>
+        <mesh geometry={geos.hornilla} material={matMate} castShadow={sombra} receiveShadow={sombra} />
+      </group>
+      <mesh geometry={geos.pailas} material={matMetal} castShadow={sombra} />
+
+      {/* Lo que hierve en cada paila: de jugo crudo a miel de punteo. */}
+      {PAILAS.map((p, i) => (
+        <Caldo
+          key={p.oficio + i}
+          paila={p}
+          cfg={CONTENIDO[i]}
+          hervor={p.hervor}
+          reducedMotion={reducedMotion}
+        />
+      ))}
+      {CONTENIDO[0].cachaza && <Cachaza paila={PAILAS[0]} reducedMotion={reducedMotion} />}
+
+      {/* EL MOLDEO: la batea de batido y las gaveras. */}
+      <group position={SITIOS.moldeo}>
+        <mesh geometry={geos.moldeo} material={matMate} castShadow={sombra} />
+        {/* la miel batida en la batea, ya clarita de tanto aire */}
+        <mesh position={[-1.05, 1.14, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[1.0, 0.6]} />
+          <meshStandardMaterial
+            color={PAL.panelaLuz}
+            roughness={0.42}
+            emissive={PAL.miel}
+            emissiveIntensity={0.16}
+          />
+        </mesh>
+        {/* LA PANELA cuajando en las celdas de la gavera: la de la punta apenas
+            se vació y todavía está clara y caliente; las de atrás ya cuajaron
+            y se pusieron oscuras. */}
+        {CELDAS_GAVERA.map((c, i) => {
+          const fresca = i / (CELDAS_GAVERA.length - 1);
+          return (
+            <mesh key={i} position={[c[0], c[1] + 0.035, c[2]]}>
+              <boxGeometry args={[0.17, 0.07, 0.34]} />
+              <meshStandardMaterial
+                color={new THREE.Color(PAL.panela).lerp(new THREE.Color(PAL.panelaLuz), fresca)}
+                roughness={0.55 - fresca * 0.2}
+                emissive={PAL.miel}
+                emissiveIntensity={fresca * 0.22}
+              />
+            </mesh>
+          );
+        })}
+      </group>
+
+      {/* Lo que dejó la gente: el sombrero, la ruana, el cucharón, la pala. */}
+      {geos.utiles && <mesh geometry={geos.utiles} material={matMate} castShadow={sombra} />}
+
+      {/* ───── LA CANDELA. La fuente de luz de este mundo. ───── */}
+      <Candela
+        pos={SITIOS.boca}
+        fuerza={fuerza}
+        escala={1.15}
+        luz={tier !== 'bajo'}
+        reducedMotion={reducedMotion}
+      />
+
+      {/* EL VAPOR de las pailas que hierven (las del medio botan más). */}
+      {tier !== 'bajo' &&
+        PAILAS.map((p, i) => (
+          <VaporPaila
+            key={`v${i}`}
+            pos={[p.x, PAILA_Y + 0.06, PAILA_Z]}
+            n={Math.max(2, Math.round(vaporN * p.hervor))}
+            fuerza={0.55 + p.hervor * 0.6}
+            color={fuerza > 1.3 ? '#ffe3b4' : '#fdf6e6'}
+            reducedMotion={reducedMotion}
+          />
+        ))}
+
+      {/* EL HUMO de la chimenea: el penacho que anuncia al valle que hoy hay
+          molienda. Sale por encima del techo, no adentro. */}
+      <HumoChimenea
+        pos={[SITIOS.chimenea[0], 6.85, SITIOS.chimenea[2]]}
+        n={tier === 'alto' ? 10 : 5}
+        color={fuerza > 1.3 ? '#6e675f' : '#9a938a'}
+        reducedMotion={reducedMotion}
+      />
+
+      {/* El bombillo del tirante, para cuando la molienda pasa de la tarde. */}
+      {tier !== 'bajo' && <Bombillo pos={[-0.2, ENRAMADA.alero - 0.35, 1.5]} fuerza={fuerza} />}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/cana/floraCana.geom.js
+++ b/src/visual/mundo3d/cana/floraCana.geom.js
@@ -118,6 +118,22 @@ export function enLaEra(wx, wz, margen = 1.06) {
 /* El camino de llegada: entra por el frente y sube hasta la era del trapiche. */
 export const caminoX = (wz) => 10.5 + Math.sin(wz * 0.19) * 2.1 - smoothstep(6, 20, wz) * 1.4;
 
+/** La altura del piso de la era (todo el trapiche se para en este plano). */
+export const Y_ERA = PLANO_TRAPICHE.y;
+
+/**
+ * Pasa un punto en coordenadas LOCALES del trapiche a coordenadas del mundo.
+ * La enramada se arma alrededor de su propio origen (ver trapiche.geom) y se
+ * planta en `SITIO_TRAPICHE`; esta es la única conversión, para que la lección,
+ * el fuego y la cámara no tengan que repetir la cuenta y desalinearse.
+ */
+export const enTrapiche = (lx, ly, lz) =>
+  /** @type {[number,number,number]} */ ([
+    SITIO_TRAPICHE[0] + lx,
+    PLANO_TRAPICHE.y + ly,
+    SITIO_TRAPICHE[1] + lz,
+  ]);
+
 /* -------------------------------------------------------------------------- */
 /*  Presupuesto por tier                                                       */
 /* -------------------------------------------------------------------------- */

--- a/src/visual/mundo3d/cana/floraCana.geom.js
+++ b/src/visual/mundo3d/cana/floraCana.geom.js
@@ -139,15 +139,41 @@ export const enTrapiche = (lx, ly, lz) =>
 /* -------------------------------------------------------------------------- */
 
 /*
- * `mata` es el número de CEPAS del lote (cada una ya trae 6–9 tallos, así que la
- * cuenta real de tallos es ~7×). 'alto' llena el cañaveral; 'medio' es frugal;
- * 'bajo' deja lo mínimo para que AÚN se lea "cañaveral alto junto al trapiche".
+ * Las CEPAS del lote (cada una ya trae 7–8 tallos, así que la cuenta real de
+ * tallos es ~7×). Van repartidas en dos calidades, y ese reparto es lo que hace
+ * viable el mundo:
+ *
+ *   · CERCA — las que la cámara pisa de verdad: el pasillo por donde entra la
+ *     lección y el frente del lote que mira al plano general. Van con todo el
+ *     detalle, porque a ochenta centímetros se le ven los nudos al tallo.
+ *   · LEJOS — el resto del lote. A quince metros nadie le cuenta los nudos a
+ *     una caña: bastan un tubo de dieciséis anillos y la mitad de las hojas.
+ *
+ * Sin este reparto había que elegir entre un cañaveral RALO con detalle o uno
+ * denso que no corre. Con él caben más del doble de cepas por MENOS triángulos
+ * que antes — y el pasillo del paso 1, que era lo que importaba, queda tupido.
  */
 export const FLORA_CANA = {
-  alto: { mata: 112, penacho: 40, hojarasca: 20, piedra: 8, matojo: 24 },
-  medio: { mata: 76, penacho: 22, hojarasca: 11, piedra: 5, matojo: 13 },
-  bajo: { mata: 34, penacho: 9, hojarasca: 6, piedra: 3, matojo: 6 },
+  alto: { mataCerca: 140, mataLejos: 76, penacho: 46, hojarasca: 22, piedra: 8, matojo: 26 },
+  medio: { mataCerca: 68, mataLejos: 36, penacho: 24, hojarasca: 12, piedra: 5, matojo: 14 },
+  bajo: { mataCerca: 24, mataLejos: 14, penacho: 9, hojarasca: 6, piedra: 3, matojo: 6 },
 };
+
+/* El detalle geométrico de cada calidad de cepa. `tubular` es lo caro y lo que
+   decide si el NUDO se ve: con ~20 nudos en 4 m hacen falta 2+ anillos por nudo
+   o la banda nodal se aliasea. Alrededor, 4 lados sobran en un tallo de 3 cm. */
+export const DETALLE = {
+  cerca: { tubular: 44, radial: 4, hojas: 1, chala: 1, filasHoja: 8, filasChala: 6 },
+  lejos: { tubular: 16, radial: 4, hojas: 0.5, chala: 0.42, filasHoja: 5, filasChala: 4 },
+};
+
+/*
+ * LA ZONA CERCANA: dónde vale la pena gastar triángulos. Es el pasillo que
+ * recorre el paso 1 más el frente del lote que entra en el plano general, y la
+ * manchita de la derecha junto al camino de llegada. Todo lo demás es fondo.
+ */
+export const enZonaCerca = (x, z) =>
+  (x > -15.5 && x < 1 && z > -9.5 && z < 13.5) || (x > 15.8 && z > -3 && z < 12.5);
 
 /** Conteos para un tier (desconocido → frugal, nunca el más caro). */
 export const canaDeTier = (tier) => FLORA_CANA[tier] || FLORA_CANA.medio;
@@ -156,8 +182,31 @@ export const canaDeTier = (tier) => FLORA_CANA[tier] || FLORA_CANA.medio;
 export const CALIDAD_CANA = { alto: 1, medio: 0.62, bajo: 0.42 };
 export const calidadCana = (tier) => CALIDAD_CANA[tier] ?? CALIDAD_CANA.medio;
 
-/** Cuántas variantes de mata se construyen por tier (anti-plantilla). */
-export const variantesDeTier = (tier) => (tier === 'alto' ? 2 : 1);
+/*
+ * Las MALLAS de cepa que se construyen por tier: una por (variante × calidad).
+ * Dos variantes de mata (una alta y delgada, otra más baja y tupida) por dos
+ * calidades. La variante es lo que evita que el lote se lea como plantilla; la
+ * calidad es lo que lo hace correr. En gama frugal se cae a una sola variante, y
+ * en gama baja a una sola malla.
+ *
+ * @param {string} tier
+ * @returns {{v: number, detalle: 'cerca'|'lejos'}[]}
+ */
+export function mallasDeTier(tier) {
+  if (tier === 'alto') {
+    return [
+      { v: 0, detalle: 'cerca' },
+      { v: 1, detalle: 'cerca' },
+      { v: 0, detalle: 'lejos' },
+      { v: 1, detalle: 'lejos' },
+    ];
+  }
+  if (tier === 'bajo') return [{ v: 0, detalle: 'lejos' }];
+  return [
+    { v: 0, detalle: 'cerca' },
+    { v: 0, detalle: 'lejos' },
+  ];
+}
 
 /* -------------------------------------------------------------------------- */
 /*  Paleta del cañaveral (colores horneados en vertexColors)                   */
@@ -365,11 +414,15 @@ const ENTRENUDO = 0.205;
  * @param {number} o.inclina  cuánto se abre respecto a la vertical (rad).
  * @param {number} o.rumbo    hacia dónde se abre (rad, en XZ).
  * @param {number} [o.q]      calidad (detalle) 0..1.
+ * @param {{tubular:number, radial:number}} [o.det]  el detalle de la CALIDAD de
+ *   cepa (cerca o lejos): cuántos anillos lleva el tubo a lo largo y cuántos
+ *   lados alrededor. Es lo que decide si el nudo se ve o se aliasea.
  * @param {number} [o.semilla]
  */
 export function geomTalloCana(o) {
   const { altura, radio, inclina, rumbo } = o;
   const q = o.q ?? 1;
+  const det = o.det ?? DETALLE.cerca;
   const semilla = o.semilla ?? 1;
   const r = rng(semilla * 11 + 5);
 
@@ -404,12 +457,12 @@ export function geomTalloCana(o) {
     return Math.max(0.012, base * (1 + 0.17 * bulto));
   };
 
-  /* El tallo necesita MUCHOS anillos a lo largo (y muy pocos alrededor: la caña
-     es delgada). Con ~20 nudos en 4 m hacen falta ≥2 anillos por nudo o la banda
-     nodal se aliasea y la caña vuelve a parecer un tubo liso. Alrededor, 5 lados
-     bastan y de frente ni se notan. */
-  const tubular = Math.max(16, Math.round(60 * q));
-  const radial = 5;
+  /* El tallo necesita anillos a lo largo (y muy pocos alrededor: la caña es
+     delgada). Cuántos, lo decide la CALIDAD de la cepa: la de primer plano se
+     gana sus 44 anillos porque a ochenta centímetros se le ven los nudos; la
+     del fondo se conforma con 16, que a quince metros nadie los cuenta. */
+  const tubular = Math.max(8, Math.round(det.tubular * q));
+  const radial = det.radial;
   const geo = tuboOrganico(curva, {
     tubular,
     radial,
@@ -536,23 +589,27 @@ export const N_VARIANTES = VARIANTES_MATA.length;
  * tallos, para que el penacho se pueda sembrar EN una punta y no en el aire.
  *
  * @param {number} v  índice de variante (0…N_VARIANTES-1).
- * @param {{q: number}} o
+ * @param {{q: number, detalle?: 'cerca'|'lejos'}} o  `detalle` decide cuánta
+ *   geometría se gasta: la cepa del pasillo se gana sus 44 anillos por tallo
+ *   porque a ochenta centímetros se le ven los nudos; la del fondo, 16.
  * @param {number} semilla
  * @returns {{tallos: THREE.BufferGeometry, hojas: THREE.BufferGeometry,
  *            chala: THREE.BufferGeometry, topes: [number,number,number][],
  *            alto: number}}
  */
-export function geomMataCana(v, { q }, semilla = 101) {
+export function geomMataCana(v, { q, detalle = 'cerca' }, semilla = 101) {
   const cfg = VARIANTES_MATA[v % VARIANTES_MATA.length];
+  const det = DETALLE[detalle] || DETALLE.cerca;
   const r = rng(semilla + v * 37);
 
   /* El recorte por tier va al CUADRADO de la calidad: la mata es la pieza más
-     cara del mundo (cada tallo es un tubo de 60 anillos) y en gama frugal hay
-     que bajar de 7–8 tallos a 3 sin pensarlo. Con 3 tallos, giro y escala la
-     cepa todavía se lee como macolla. */
+     cara del mundo y en gama frugal hay que bajar de 7–8 tallos a 3 sin
+     pensarlo. Con 3 tallos, giro y escala la cepa todavía se lee como macolla.
+     El número de TALLOS no baja con la distancia (es la silueta de la cepa: sin
+     tallos deja de ser macolla), pero sí bajan las hojas y la chala. */
   const nTallos = Math.max(3, Math.round(cfg.tallos * q * q));
-  const nHojas = Math.max(2, Math.round(cfg.hojas * q));
-  const nChala = Math.max(1, Math.round(cfg.chala * q));
+  const nHojas = Math.max(2, Math.round(cfg.hojas * q * det.hojas));
+  const nChala = Math.max(1, Math.round(cfg.chala * q * det.chala));
 
   const partesTallo = [];
   const partesHoja = [];
@@ -572,7 +629,7 @@ export function geomMataCana(v, { q }, semilla = 101) {
     const rumbo = ang + (r() - 0.5) * 0.8;
     const radio = cfg.radio * (0.86 + r() * 0.3);
 
-    const tallo = geomTalloCana({ altura, radio, inclina, rumbo, q, semilla: semilla + i * 13 });
+    const tallo = geomTalloCana({ altura, radio, inclina, rumbo, q, det, semilla: semilla + i * 13 });
     poner(tallo, [bx, 0, bz]);
     partesTallo.push(tallo);
 
@@ -604,7 +661,7 @@ export function geomMataCana(v, { q }, semilla = 101) {
         doblez: 0.34,
         torsion: 0.85 + r() * 0.6,
         lateral: 0.14 + r() * 0.12,
-        filas: q > 0.8 ? 9 : 6,
+        filas: Math.max(4, Math.round(det.filasHoja * (q > 0.8 ? 1 : 0.75))),
         semilla: semilla + i * 31 + h,
       });
       poner(hoja, [hx, y, hz], [0, -giro, alza]);
@@ -628,7 +685,7 @@ export function geomMataCana(v, { q }, semilla = 101) {
         doblez: 0.46, // y se enrolla sobre sí misma al secarse
         torsion: 1.5 + r() * 0.9,
         lateral: 0.10,
-        filas: q > 0.8 ? 7 : 5,
+        filas: Math.max(3, Math.round(det.filasChala * (q > 0.8 ? 1 : 0.75))),
         seca: true,
         semilla: semilla + i * 17 + c + 400,
       });
@@ -714,39 +771,82 @@ const PASO_CEPA = 1.05; // distancia entre cepas dentro del surco
 
 /* Los tres tablones sembrados del lote. La era del trapiche los parte al medio:
    el cañaveral rodea al trapiche, que es exactamente como se ve en la finca. */
+/*
+ * Los tablones SEMBRADOS A MANO (instanciados). Son deliberadamente más chicos
+ * que el cañaveral que se ve: de ahí para atrás toma el relevo el MURO de fondo,
+ * que cuesta mil triángulos y llena el horizonte. Repartir el presupuesto en un
+ * lote enorme daba un cañaveral RALO — con la cámara metida en el surco se veían
+ * dos matas y el pasillo pelado. Sembrar tupido un área más chica y cerrar
+ * atrás con el muro es lo que hace que se sienta cañaveral.
+ */
 const TABLONES = [
-  // el grande de la izquierda: el que la cámara mira de frente
-  { x0: -23, x1: -1.4, z0: -20, z1: 13.5, giro: 0.06 },
+  // el grande de la izquierda: el que la cámara mira de frente y por el que
+  // camina la lección
+  { x0: -17.5, x1: -1.4, z0: -13, z1: 13.5, giro: 0.06 },
   // el de atrás, subiendo la loma detrás de la enramada
-  { x0: 0.5, x1: 23, z0: -20, z1: -6.5, giro: -0.05 },
+  { x0: 0.5, x1: 19, z0: -13.5, z1: -6.5, giro: -0.05 },
   // la manchita del frente derecho, junto al camino de llegada
-  { x0: 16.5, x1: 23.5, z0: -5, z1: 12, giro: 0.03 },
+  { x0: 16.5, x1: 22.5, z0: -4, z1: 12, giro: 0.03 },
 ];
+
+/**
+ * El eje de un PASILLO entre dos surcos del tablón grande, a la altura `z`.
+ *
+ * Existe por una razón concreta: la lección mete la cámara a caminar por una
+ * calle del cañaveral, y el surco NO es una recta — ondula con el terreno y
+ * sesga con el tablón. Una x fija se sale de la calle a los pocos metros y la
+ * cámara termina dentro de una cepa. Esta función sale de las MISMAS constantes
+ * con las que se siembra (SURCO, TABLONES, la ondulación), así que el pasillo y
+ * las matas no se pueden desalinear: una sola cuenta, no dos.
+ *
+ * @param {number} z    profundidad del mundo.
+ * @param {number} [s]  entre qué surco y el siguiente se camina.
+ */
+export function pasilloCanaveral(z, s = 5) {
+  const tb = TABLONES[0];
+  const xs = tb.x0 + (s + 0.5) * SURCO; // el centro entre el surco s y el s+1
+  return xs + Math.sin(z * 0.17) * 0.42 + z * tb.giro;
+}
 
 /**
  * Siembra el lote completo, determinista.
  *
- * @param {{mata:number, penacho:number, hojarasca:number, piedra:number, matojo:number}} conteos
- * @param {[number,number,number][][]} topesPorVariante  puntas de cada variante.
+ * Cada cepa cae en UNA de las mallas de `mallas` (variante × calidad). La
+ * VARIANTE la decide un ruido de posición (matas vecinas se parecen, como en un
+ * lote real donde una zona macolló mejor que otra); la CALIDAD la decide la
+ * distancia a donde camina la cámara. Los presupuestos de cerca y lejos son
+ * independientes: así el pasillo queda tupido aunque el fondo se ralee.
+ *
+ * @param {{mataCerca:number, mataLejos:number, penacho:number, hojarasca:number,
+ *          piedra:number, matojo:number}} conteos
+ * @param {{v:number, detalle:string}[]} mallas  las mallas construidas.
+ * @param {[number,number,number][][]} topesPorMalla  puntas de tallo por malla.
  * @param {number} [seed]
- * @returns {{matas: {pos:[number,number,number], rotY:number, escala:number, tint:number[]}[][],
- *            hojas: object[][], chala: object[][], penacho: object[],
- *            hojarasca: object[], piedra: object[], matojo: object[]}}
  */
-export function sembrarCanaveral(conteos, topesPorVariante, seed = 907) {
+export function sembrarCanaveral(conteos, mallas, topesPorMalla, seed = 907) {
   const r = rng(seed);
-  const nV = topesPorVariante.length;
+  const nM = mallas.length;
 
-  const matas = Array.from({ length: nV }, () => []);
-  const hojas = Array.from({ length: nV }, () => []);
-  const chala = Array.from({ length: nV }, () => []);
+  const matas = Array.from({ length: nM }, () => []);
+  const hojas = Array.from({ length: nM }, () => []);
+  const chala = Array.from({ length: nM }, () => []);
   const penacho = [];
   const cPenacho = [0.98, 0.96, 0.9];
 
-  /* 1) Se recorren los surcos de cada tablón y se van poniendo cepas hasta
-        gastar el presupuesto de `conteos.mata`. Se reparte proporcional al área
-        para que ningún tablón quede pelado en gama baja. */
-  const sitios = [];
+  /* A qué malla va una cepa. Si el tier no construyó esa combinación (gama
+     frugal o baja), cae en la primera que exista: nunca se pierde una mata por
+     no haber malla — se pierde detalle, que es lo barato. */
+  const mallaDe = (v, detalle) => {
+    const i = mallas.findIndex((m) => m.v === v && m.detalle === detalle);
+    if (i >= 0) return i;
+    const j = mallas.findIndex((m) => m.detalle === detalle);
+    return j >= 0 ? j : 0;
+  };
+
+  /* 1) Se recorren los surcos de cada tablón y se apuntan todos los sitios
+        posibles, separando los de CERCA de los de LEJOS. */
+  const cerca = [];
+  const lejos = [];
   TABLONES.forEach((tb, ti) => {
     const nSurcos = Math.floor((tb.x1 - tb.x0) / SURCO);
     for (let s = 0; s <= nSurcos; s++) {
@@ -761,30 +861,59 @@ export function sembrarCanaveral(conteos, topesPorVariante, seed = 907) {
         if (enLaEra(x, z)) continue; // la era del trapiche está limpia
         // el camino de llegada se respeta (por ahí entra la caña cortada)
         if (Math.abs(x - caminoX(z)) < 2.3 && z > -2) continue;
-        sitios.push([x, z, ti]);
+        (enZonaCerca(x, z) ? cerca : lejos).push([x, z, ti]);
       }
     }
   });
 
   // Barajado determinista: al recortar por tier el lote se ralea PAREJO, no se
   // queda media hectárea llena y la otra vacía.
-  for (let i = sitios.length - 1; i > 0; i--) {
-    const j = Math.floor(r() * (i + 1));
-    const t = sitios[i];
-    sitios[i] = sitios[j];
-    sitios[j] = t;
-  }
+  const barajar = (lista) => {
+    for (let i = lista.length - 1; i > 0; i--) {
+      const j = Math.floor(r() * (i + 1));
+      const t = lista[i];
+      lista[i] = lista[j];
+      lista[j] = t;
+    }
+    return lista;
+  };
+  barajar(cerca);
+  barajar(lejos);
 
-  const cuantas = Math.min(conteos.mata, sitios.length);
-  for (let i = 0; i < cuantas; i++) {
-    const [x, z, ti] = sitios[i];
+  /*
+   * Las cepas de CERCA no se recortan al azar: se gastan EMPEZANDO POR EL
+   * PASILLO que camina la lección y abriéndose hacia afuera. Barajar parejo
+   * dejaba huecos justo donde la cámara se para — un tramo del pasillo con tres
+   * matas y el resto aire, que es exactamente lo que no puede pasar en el plano
+   * que sostiene todo el mundo.
+   *
+   * El ruido que se le suma al puntaje evita lo contrario: sin él quedaría una
+   * franja densa de bordes rectos y el lote se leería como una banda pintada.
+   * Con él, la densidad baja a manchas — como baja de verdad en un cultivo.
+   */
+  cerca.sort((a, b) => {
+    const pa = Math.abs(a[0] - pasilloCanaveral(a[1])) + ruidoFbm(a[0] * 0.5 + 3, 1.5, a[1] * 0.5) * 5.5;
+    const pb = Math.abs(b[0] - pasilloCanaveral(b[1])) + ruidoFbm(b[0] * 0.5 + 3, 1.5, b[1] * 0.5) * 5.5;
+    return pa - pb;
+  });
+
+  const elegidos = [
+    ...cerca.slice(0, conteos.mataCerca).map((s) => [...s, 'cerca']),
+    ...lejos.slice(0, conteos.mataLejos).map((s) => [...s, 'lejos']),
+  ];
+
+  for (let i = 0; i < elegidos.length; i++) {
+    const [x, z, ti, detalle] = elegidos[i];
     const y = alturaVega(x, z);
     // Claros: donde ya pasó el corte queda la cepa rapada. Se salta una de cada
     // tantas, en manchas (ruido), no al azar puro — así se ve el corte por eras.
+    // Solo en el fondo del tablón grande: el pasillo que camina la lección NO se
+    // ralea, que es justo donde se necesita la caña cerrada.
     const corte = ruidoFbm(x * 0.14 + 5, 0.5, z * 0.14);
-    if (corte > 0.74 && ti === 0) continue;
+    if (corte > 0.76 && ti === 0 && detalle === 'lejos') continue;
 
-    const v = nV > 1 ? (ruidoFbm(x * 0.3, 1.5, z * 0.3) > 0.5 ? 1 : 0) : 0;
+    const v = ruidoFbm(x * 0.3, 1.5, z * 0.3) > 0.5 ? 1 : 0;
+    const m = mallaDe(v, detalle);
     const variedad = variedadPara(ruidoFbm(x * 0.09 + 21, 3.5, z * 0.09));
     // las cepas de la orilla del tablón vienen más chicas (menos competencia,
     // pero más golpe de sol y de viento) — el borde de un lote nunca va parejo
@@ -797,17 +926,20 @@ export function sembrarCanaveral(conteos, topesPorVariante, seed = 907) {
       tint: variedad.tinte,
       fase: x * 0.32 + z * 0.19, // la ONDA del viento viaja por el lote
     };
-    matas[v].push(item);
+    matas[m].push(item);
     // hoja y chala comparten transformación con el tallo (misma cepa), pero la
     // hoja va siempre verde: el tinte de la variedad NO le toca el follaje
-    hojas[v].push({ ...item, tint: [0.94 + r() * 0.1, 1, 0.9 + r() * 0.12] });
-    chala[v].push({ ...item, tint: [1, 0.97, 0.92] });
+    hojas[m].push({ ...item, tint: [0.94 + r() * 0.1, 1, 0.9 + r() * 0.12] });
+    chala[m].push({ ...item, tint: [1, 0.97, 0.92] });
 
     /* EL PENACHO: solo en las cepas que ya espigaron, y montado EN una punta
        real de tallo (por eso hicieron falta los `topes`). */
     if (penacho.length < conteos.penacho && r() < 0.42) {
-      const tops = topesPorVariante[v];
-      const tp = tops[Math.floor(r() * tops.length)];
+      /* Las puntas de SU malla. El `||` no es adorno: si un llamador manda
+         menos listas de topes que mallas, sin esto el mundo entero truena al
+         sembrar. Un penacho de menos es barato; una escena en blanco no. */
+      const tops = topesPorMalla[m] || topesPorMalla[0] || [];
+      const tp = tops.length ? tops[Math.floor(r() * tops.length)] : null;
       if (tp) {
         const ca = Math.cos(rotY);
         const sa = Math.sin(rotY);

--- a/src/visual/mundo3d/cana/floraCana.geom.js
+++ b/src/visual/mundo3d/cana/floraCana.geom.js
@@ -795,14 +795,22 @@ export function sembrarCanaveral(conteos, topesPorVariante, seed = 907) {
       if (tp) {
         const ca = Math.cos(rotY);
         const sa = Math.sin(rotY);
-        const px = x + (tp[0] * ca - tp[2] * sa) * escala;
-        const pz = z + (tp[0] * sa + tp[2] * ca) * escala;
+        const dx = (tp[0] * ca - tp[2] * sa) * escala;
+        const dz = (tp[0] * sa + tp[2] * ca) * escala;
+        const dy = tp[1] * escala - 0.06;
         penacho.push({
-          pos: /** @type {[number,number,number]} */ ([px, y + tp[1] * escala - 0.06, pz]),
+          pos: /** @type {[number,number,number]} */ ([x + dx, y + dy, z + dz]),
           rotY: r() * Math.PI * 2,
           escala: escala * (0.85 + r() * 0.4),
           tint: cPenacho,
-          fase: px * 0.32 + pz * 0.19,
+          // La fase la hereda de SU cepa: penacho y tallo se mecen juntos.
+          fase: x * 0.32 + z * 0.19,
+          /* El penacho no pivota en su propio pie: pivota en el PIE DE LA CEPA,
+             a 4 m más abajo. Sin esto, al mecerse la caña la punta del tallo se
+             corre ~15 cm y el penacho se queda flotando en el aire. `ancla` es
+             el pie de la mata y `brazo` el vector del pie a la punta. */
+          ancla: /** @type {[number,number,number]} */ ([x, y, z]),
+          brazo: /** @type {[number,number,number]} */ ([dx, dy, dz]),
         });
       }
     }

--- a/src/visual/mundo3d/cana/floraCana.geom.js
+++ b/src/visual/mundo3d/cana/floraCana.geom.js
@@ -1,0 +1,884 @@
+/*
+ * floraCana.geom — la GEOMETRÍA del CAÑAVERAL panelero (tierra caliente andina).
+ *
+ * La caña es una GRAMÍNEA GIGANTE, y ese es el dato que manda todo el dibujo:
+ * una caña madura de trapiche le pasa MUY por encima a una persona. Aquí la mata
+ * mide entre 3,4 y 4,7 m — dos veces y media un adulto — para que entrar a un
+ * pasillo entre surcos se sienta como entrar a un corredor con techo de hojas.
+ * Si esta escala se rompe, el mundo entero deja de ser un cañaveral.
+ *
+ * Cada pieza con su identidad inequívoca:
+ *
+ *   · Mata (cepa) de caña   — la caña NO nace de a un tallo: macolla. Cada mata
+ *     (Saccharum officinarum)  es un manojo de 6–9 tallos que salen del mismo
+ *                              pie y se abren en abanico. Por eso el cañaveral
+ *                              se lee como MASA y no como fila de palos.
+ *   · Tallo con NUDOS        — la firma de la caña: el tallo viene segmentado en
+ *     y ENTRENUDOS             entrenudos (~20 cm) separados por un nudo que se
+ *                              ENGRUESA un poco y se ve MÁS PÁLIDO (el anillo
+ *                              nodal ceroso, con su yema). Va horneado en la
+ *                              geometría: bulto de radio + anillo claro.
+ *   · Hoja larga acintada    — cinta de más de un metro, con la NERVADURA
+ *                              CENTRAL pálida marcada, doblada en V a lo largo
+ *                              de esa nervadura, que se arquea y se cae de punta.
+ *                              Nacen alternas en DOS filas opuestas (dístico),
+ *                              como toda gramínea.
+ *   · Chala (hoja seca)      — el tercio bajo/medio de la caña va vestido de
+ *                              hoja SECA colgando pegada al tallo. Sin esto un
+ *                              cañaveral parece bambú; con esto, parece caña.
+ *   · Penacho o güin         — la panícula plumosa, plateada, cuando la caña
+ *                              espiga. Rompe la silueta por arriba y es lo que
+ *                              atrapa la luz de la tarde.
+ *
+ * TÉCNICA tier-safe (mismo contrato que floraCafetal.geom): cada pieza se FUSIONA
+ * en UNA geometría con el color horneado en vertexColors, y se dibuja con UN
+ * InstancedMesh. Los TALLOS se pintan en escala CLARA casi neutra a propósito:
+ * el color por instancia (setColorAt) es el que decide la VARIEDAD — caña verde,
+ * caña morada o caña rayada conviven en el mismo lote, como en la finca. Las
+ * hojas van en su propio mesh (siempre verdes) para que el morado del tallo no
+ * les manche el follaje.
+ *
+ * Hay DOS variantes de mata (una alta y delgada, otra más baja y tupida) para
+ * que el lote no se lea como una plantilla repetida: variante + giro + escala +
+ * variedad dan un cañaveral que no se repite a ojo.
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO al mezclar geometrías indexadas
+ * con no-indexadas: TODO pasa por `fusionarSeguro`, que desindexa, valida los
+ * atributos y TRUENA con el nombre de la pieza si falla.
+ *
+ * Aquí viven SOLO los datos y las mallas (nada de WebGL): corre headless.
+ */
+import * as THREE from 'three';
+import {
+  rng,
+  ruidoFbm,
+  fusionarSeguro,
+  poner,
+  pintarPorVertice,
+  pintarPlano,
+  tuboOrganico,
+  matojoHoja,
+} from '../bosque/sombreadoVegetal.js';
+
+/* -------------------------------------------------------------------------- */
+/*  La vega cañera (la geografía del mundo, determinista)                      */
+/* -------------------------------------------------------------------------- */
+
+export const ANCHO = 48; // x: -24 … 24
+export const FONDO = 44; // z: -22 (la loma del fondo) … 22 (el frente, la llegada)
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+
+/* Ruido determinista (hash de senos): misma vega siempre, sin Math.random. */
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.7 + wz * 0.55) * 0.5 +
+    Math.sin(wx * 1.7 - wz * 1.3 + 1.7) * 0.3 +
+    Math.sin(wx * 2.9 + wz * 2.4 + 4.4) * 0.2
+  );
+}
+
+/* El sitio de la enramada del trapiche: aplanado a pala, como en la finca real
+   (el trapiche se para en PLANO — con la hornilla en desnivel no se trabaja). */
+export const SITIO_TRAPICHE = /** @type {[number, number]} */ ([10.5, 2.0]);
+const PLANO_TRAPICHE = { cx: 10.5, cz: 2.0, rx: 8.4, rz: 7.0, y: 0.34 };
+
+/**
+ * La altura de la vega en un punto. La caña de trapiche se siembra en tierra
+ * caliente de vega y falda baja: casi plana adelante, con la loma subiendo al
+ * fondo. Bajo la enramada se aplana del todo (la era del trapiche).
+ */
+export function alturaVega(wx, wz) {
+  const sube = smoothstep(2, -20, wz); // 0 al frente, 1 contra la loma del fondo
+  let h = 0.1;
+  h += sube * 3.6;
+  h += ruido(wx * 0.42, wz * 0.42) * 0.34 * (0.35 + sube);
+  // la era aplanada del trapiche: una meseta suave, no un escalón
+  const d = Math.max(
+    Math.abs(wx - PLANO_TRAPICHE.cx) / PLANO_TRAPICHE.rx,
+    Math.abs(wz - PLANO_TRAPICHE.cz) / PLANO_TRAPICHE.rz,
+  );
+  const era = smoothstep(1.25, 0.72, d);
+  return h * (1 - era) + PLANO_TRAPICHE.y * era;
+}
+
+/** ¿Este punto cae dentro de la era del trapiche? (ahí no se siembra caña). */
+export function enLaEra(wx, wz, margen = 1.06) {
+  const d = Math.max(
+    Math.abs(wx - PLANO_TRAPICHE.cx) / (PLANO_TRAPICHE.rx * margen),
+    Math.abs(wz - PLANO_TRAPICHE.cz) / (PLANO_TRAPICHE.rz * margen),
+  );
+  return d < 1;
+}
+
+/* El camino de llegada: entra por el frente y sube hasta la era del trapiche. */
+export const caminoX = (wz) => 10.5 + Math.sin(wz * 0.19) * 2.1 - smoothstep(6, 20, wz) * 1.4;
+
+/* -------------------------------------------------------------------------- */
+/*  Presupuesto por tier                                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * `mata` es el número de CEPAS del lote (cada una ya trae 6–9 tallos, así que la
+ * cuenta real de tallos es ~7×). 'alto' llena el cañaveral; 'medio' es frugal;
+ * 'bajo' deja lo mínimo para que AÚN se lea "cañaveral alto junto al trapiche".
+ */
+export const FLORA_CANA = {
+  alto: { mata: 112, penacho: 40, hojarasca: 20, piedra: 8, matojo: 24 },
+  medio: { mata: 76, penacho: 22, hojarasca: 11, piedra: 5, matojo: 13 },
+  bajo: { mata: 34, penacho: 9, hojarasca: 6, piedra: 3, matojo: 6 },
+};
+
+/** Conteos para un tier (desconocido → frugal, nunca el más caro). */
+export const canaDeTier = (tier) => FLORA_CANA[tier] || FLORA_CANA.medio;
+
+/** Factor de detalle geométrico por tier (menos tallos y hojas por mata). */
+export const CALIDAD_CANA = { alto: 1, medio: 0.62, bajo: 0.42 };
+export const calidadCana = (tier) => CALIDAD_CANA[tier] ?? CALIDAD_CANA.medio;
+
+/** Cuántas variantes de mata se construyen por tier (anti-plantilla). */
+export const variantesDeTier = (tier) => (tier === 'alto' ? 2 : 1);
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del cañaveral (colores horneados en vertexColors)                   */
+/* -------------------------------------------------------------------------- */
+
+export const PAL = {
+  /* EL TALLO va casi NEUTRO a propósito: el color real lo pone la VARIEDAD por
+     instancia. Lo que sí se hornea es la ESTRUCTURA — el entrenudo un punto más
+     oscuro que el nudo, para que el anillo nodal se lea siempre. */
+  tallo: '#d8d2c2', // cuerpo del entrenudo (base neutra que la variedad tiñe)
+  talloNudo: '#f4efe2', // el anillo del nudo: ceroso, SIEMPRE más pálido
+  talloRaya: '#bfb7a4', // la veta longitudinal (la que hace la caña "rayada")
+  talloPie: '#8f8877', // el pie sucio de la mata, entre hoja seca y tierra
+
+  /* LA HOJA verde: cinta con la nervadura pálida marcada. */
+  hoja: '#4f8a34', // verde de trabajo de la hoja de caña
+  hojaSol: '#84ac3e', // la cara que da al sol
+  hojaSombra: '#2f5c2a', // el fondo del manojo, donde no entra luz
+  nervadura: '#c3d489', // la nervadura central pálida — la firma de la gramínea
+  hojaPunta: '#9a9a4a', // la punta que ya se está secando
+
+  /* LA CHALA: la hoja seca que viste el tallo. Paja, no café. */
+  chala: '#b9964f',
+  chalaClara: '#d8bd7c',
+  chalaOscura: '#8a6a34',
+
+  /* EL PENACHO (güin): panícula plumosa, plateada contra la luz. */
+  penachoEje: '#c9b98e',
+  penacho: '#e5ddc6',
+  penachoLuz: '#f6f0dd',
+
+  /* El suelo del cañaveral: hoja caída y terrones. */
+  hojarasca: '#9a7c42',
+  hojarascaSeca: '#c0a165',
+  piedra: '#9a8b74',
+  matojo: '#6f8c3c', // la arvense que vive en la calle del surco
+};
+
+/*
+ * LAS VARIEDADES que conviven en un lote panelero campesino. El campesino no
+ * siembra un monocultivo clonal: mezcla la que le rinde con la criolla que
+ * heredó. Cada tinte MULTIPLICA el tallo neutro horneado arriba.
+ *
+ * (Los nombres son los de finca — verde, morada, rayada, amarilla —, no nombres
+ * de variedad registrada: no vamos a afirmar un cultivar que no verificamos.)
+ */
+export const VARIEDADES = [
+  { id: 'verde', tinte: [0.60, 0.74, 0.38], peso: 0.34 },
+  { id: 'amarilla', tinte: [0.86, 0.78, 0.40], peso: 0.24 },
+  { id: 'morada', tinte: [0.55, 0.30, 0.42], peso: 0.22 },
+  { id: 'rayada', tinte: [0.78, 0.56, 0.40], peso: 0.20 },
+];
+
+/** Elige una variedad con el peso declarado, de forma determinista. */
+export function variedadPara(u) {
+  let acc = 0;
+  for (let i = 0; i < VARIEDADES.length; i++) {
+    acc += VARIEDADES[i].peso;
+    if (u <= acc) return VARIEDADES[i];
+  }
+  return VARIEDADES[0];
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Piezas: la HOJA ACINTADA                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Una hoja de caña: cinta larga, doblada en V sobre su nervadura central, que
+ * sale hacia arriba, se arquea y se CAE de punta. Se construye como una malla
+ * de 3 columnas (borde · nervadura · borde) × N filas a lo largo — así la
+ * nervadura puede pintarse pálida y el doblez existe de verdad en la geometría.
+ *
+ * La hoja sale sobre el eje +X, con la nervadura hacia arriba en +Y.
+ *
+ * @param {object} o
+ * @param {number} o.largo    largo de la cinta (m). Una hoja madura pasa de 1 m.
+ * @param {number} o.ancho    semiancho máximo (m).
+ * @param {number} [o.caida]  cuánto se desploma la punta (0 recta … 1 colgando).
+ * @param {number} [o.doblez] profundidad de la V sobre la nervadura.
+ * @param {number} [o.torsion] giro acumulado de la sección hacia la punta (rad).
+ * @param {number} [o.lateral] curvatura fuera del plano (la hoja no es plana).
+ * @param {number} [o.filas]  segmentos a lo largo (detalle por tier).
+ * @param {boolean} [o.seca]  paleta de CHALA en vez de hoja verde.
+ * @param {number} [o.semilla]
+ */
+export function geomHojaCana(o) {
+  const largo = o.largo;
+  const ancho = o.ancho;
+  const caida = o.caida ?? 1;
+  const doblez = o.doblez ?? 0.34;
+  const torsion = o.torsion ?? 0.9;
+  const lateral = o.lateral ?? 0.16;
+  const filas = Math.max(5, Math.round(o.filas ?? 11));
+  const seca = !!o.seca;
+  const r = rng((o.semilla ?? 1) * 7 + 3);
+
+  const cBase = new THREE.Color(seca ? PAL.chalaOscura : PAL.hoja);
+  const cSol = new THREE.Color(seca ? PAL.chalaClara : PAL.hojaSol);
+  const cNerv = new THREE.Color(seca ? PAL.chala : PAL.nervadura);
+  const cPunta = new THREE.Color(seca ? PAL.chalaOscura : PAL.hojaPunta);
+  const tmp = new THREE.Color();
+
+  const pos = new Float32Array((filas + 1) * 3 * 3);
+  const uvs = new Float32Array((filas + 1) * 3 * 2);
+  const cols = new Float32Array((filas + 1) * 3 * 3);
+  const idx = [];
+
+  // Un pequeño desorden por hoja: ninguna sale igual a la de al lado.
+  const jitter = 0.86 + r() * 0.3;
+
+  for (let i = 0; i <= filas; i++) {
+    const t = i / filas;
+    // Centro de la cinta: sube, se arquea y se desploma. La caña "cae de punta".
+    const px = largo * t * (0.98 + 0.04 * Math.sin(t * 5));
+    const py = largo * (0.52 * t - 0.92 * caida * t * t * t) * jitter;
+    const pz = largo * lateral * Math.sin(t * 2.4) * (0.4 + t);
+
+    // Ancho: angosto en la vaina, máximo al 25 %, y punta de aguja.
+    const w =
+      ancho *
+      Math.pow(1 - t, 0.55) *
+      (0.42 + 0.58 * Math.min(1, t * 5.5)) *
+      (0.9 + 0.2 * ruidoFbm(t * 6 + (o.semilla ?? 1), 0.5, 0.5));
+
+    // La V se abre en la base y casi se plancha en la punta, con torsión.
+    const fold = doblez * w * (1 - 0.55 * t);
+    const giro = torsion * t * t;
+    const cg = Math.cos(giro);
+    const sg = Math.sin(giro);
+
+    for (let j = 0; j < 3; j++) {
+      const s = j - 1; // -1 borde, 0 nervadura, +1 borde
+      // Offset de la sección: hacia el lado (z) y hundido bajo la nervadura (y).
+      const oy = s === 0 ? 0 : -fold;
+      const oz = s * w;
+      // Torsión: la sección gira alrededor del eje de la hoja.
+      const ry = oy * cg - oz * sg;
+      const rz = oy * sg + oz * cg;
+
+      const k = (i * 3 + j) * 3;
+      pos[k] = px;
+      pos[k + 1] = py + ry;
+      pos[k + 2] = pz + rz;
+
+      const ku = (i * 3 + j) * 2;
+      uvs[ku] = t;
+      uvs[ku + 1] = (s + 1) * 0.5;
+
+      /* EL COLOR de la hoja, horneado:
+         · la nervadura central va PÁLIDA (la firma de la gramínea);
+         · el borde queda más oscuro que el centro (sombra propia del doblez);
+         · sube el verde de sol hacia la mitad alta, y la punta amarillea;
+         · un ruido suave rompe el plano uniforme. */
+      const borde = Math.abs(s);
+      tmp.copy(cBase).lerp(cSol, clamp(0.18 + t * 0.55, 0, 1));
+      if (borde === 0) tmp.lerp(cNerv, seca ? 0.35 : 0.62);
+      else tmp.multiplyScalar(0.82);
+      tmp.lerp(cPunta, smoothstep(0.62, 1, t) * (seca ? 0.5 : 0.68));
+      const n = ruidoFbm(px * 2.2 + 13, py * 2.2, pz * 2.2);
+      tmp.multiplyScalar(0.92 + n * 0.18);
+
+      const kc = (i * 3 + j) * 3;
+      cols[kc] = tmp.r;
+      cols[kc + 1] = tmp.g;
+      cols[kc + 2] = tmp.b;
+    }
+  }
+
+  for (let i = 0; i < filas; i++) {
+    for (let j = 0; j < 2; j++) {
+      const a = i * 3 + j;
+      const b = a + 1;
+      const c = a + 3;
+      const d = c + 1;
+      idx.push(a, c, b, b, c, d);
+    }
+  }
+
+  const g = new THREE.BufferGeometry();
+  g.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  g.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
+  g.setAttribute('color', new THREE.BufferAttribute(cols, 3));
+  g.setIndex(idx);
+  g.computeVertexNormals();
+  return g;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Piezas: el TALLO con nudos y entrenudos                                    */
+/* -------------------------------------------------------------------------- */
+
+/* Largo del entrenudo (m). En caña de trapiche madura anda por ahí; lo que
+   importa para el dibujo es que se VEAN unos 18–22 segmentos en 4 m de caña. */
+const ENTRENUDO = 0.205;
+
+/**
+ * Un tallo de caña: tubo casi vertical, con el radio que ENGRUESA en cada nudo
+ * y el color que se ACLARA en el anillo nodal. Se devuelve en el origen (base en
+ * y=0, creciendo en +Y) para que el llamador lo coloque dentro de la mata.
+ *
+ * @param {object} o
+ * @param {number} o.altura
+ * @param {number} o.radio    radio en la base.
+ * @param {number} o.inclina  cuánto se abre respecto a la vertical (rad).
+ * @param {number} o.rumbo    hacia dónde se abre (rad, en XZ).
+ * @param {number} [o.q]      calidad (detalle) 0..1.
+ * @param {number} [o.semilla]
+ */
+export function geomTalloCana(o) {
+  const { altura, radio, inclina, rumbo } = o;
+  const q = o.q ?? 1;
+  const semilla = o.semilla ?? 1;
+  const r = rng(semilla * 11 + 5);
+
+  // La curva del tallo: se abre del pie con la altura y serpentea apenas. Una
+  // caña real pelea con el viento y con sus hermanas: no es una vara de metal.
+  const n = 6;
+  const pts = [];
+  for (let i = 0; i <= n; i++) {
+    const t = i / n;
+    const abre = Math.sin(inclina) * altura * t * t * 0.92;
+    const serp = 0.045 * altura * Math.sin(t * 3.1 + semilla) * (0.25 + t);
+    pts.push(
+      new THREE.Vector3(
+        Math.cos(rumbo) * abre + Math.cos(rumbo + 1.9) * serp,
+        altura * t,
+        Math.sin(rumbo) * abre + Math.sin(rumbo + 1.9) * serp,
+      ),
+    );
+  }
+  const curva = new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
+
+  /* EL TAPER CON NUDOS — el corazón del dibujo de la caña. El radio decrece
+     hacia arriba, pero en cada nudo hay un ANILLO que engorda: por eso la caña
+     se ve segmentada aunque no tenga textura. */
+  const taper = (t) => {
+    const y = t * altura;
+    const f = y / ENTRENUDO;
+    // 0 justo en el nudo, 1 a mitad del entrenudo.
+    const medio = Math.abs(Math.sin(Math.PI * f));
+    const bulto = Math.pow(1 - medio, 3); // pico angosto EN el nudo
+    const base = radio * (1 - 0.30 * t);
+    return Math.max(0.012, base * (1 + 0.17 * bulto));
+  };
+
+  /* El tallo necesita MUCHOS anillos a lo largo (y muy pocos alrededor: la caña
+     es delgada). Con ~20 nudos en 4 m hacen falta ≥2 anillos por nudo o la banda
+     nodal se aliasea y la caña vuelve a parecer un tubo liso. Alrededor, 5 lados
+     bastan y de frente ni se notan. */
+  const tubular = Math.max(16, Math.round(60 * q));
+  const radial = 5;
+  const geo = tuboOrganico(curva, {
+    tubular,
+    radial,
+    taper,
+    arruga: 0.035, // la caña es LISA (nada de corteza rugosa de árbol)
+    semilla: semilla * 3,
+    minRadio: 0.012,
+  });
+
+  /* EL COLOR del tallo: neutro claro (la variedad lo tiñe por instancia), con
+     el ANILLO NODAL pálido, la veta longitudinal de la caña rayada y el pie
+     ensuciado. Se pinta ANTES de colocar el tallo: aquí `y` es altura local. */
+  const cCuerpo = new THREE.Color(PAL.tallo);
+  const cNudo = new THREE.Color(PAL.talloNudo);
+  const cRaya = new THREE.Color(PAL.talloRaya);
+  const cPie = new THREE.Color(PAL.talloPie);
+  const tmp = new THREE.Color();
+  const gruesoAnillo = 0.16 + r() * 0.06;
+
+  pintarPorVertice(geo, (x, y, z) => {
+    const f = y / ENTRENUDO;
+    const medio = Math.abs(Math.sin(Math.PI * f));
+    // El anillo del nudo: banda angosta y clara justo donde engorda el tallo.
+    const anillo = smoothstep(gruesoAnillo, 0, medio);
+    tmp.copy(cCuerpo).lerp(cNudo, anillo * 0.95);
+    // Veta longitudinal: corre A LO LARGO del tallo (mucha frecuencia alrededor,
+    // poca en Y). Es lo que en la caña rayada se ve como franjas de color.
+    const ang = Math.atan2(z, x);
+    const veta = 0.5 + 0.5 * Math.sin(ang * 5 + semilla * 2.1);
+    tmp.lerp(cRaya, veta * 0.22 * (1 - anillo));
+    // Sombra propia: el lado que mira al corazón de la mata queda en penumbra.
+    const lado = 0.5 + 0.5 * Math.cos(ang - rumbo);
+    tmp.multiplyScalar(0.72 + 0.28 * lado);
+    // El pie de la mata vive entre hoja seca, tierra y sombra.
+    tmp.lerp(cPie, smoothstep(0.85, 0.02, y) * 0.6);
+    // Un poco de suciedad de campo, para que no se vea plástico.
+    const nn = ruidoFbm(x * 5 + 3, y * 1.4, z * 5);
+    tmp.multiplyScalar(0.93 + nn * 0.16);
+    return tmp;
+  });
+
+  return geo;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Piezas: el PENACHO (güin)                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * La panícula plumosa de la caña espigada: un eje delgado del que salen muchas
+ * ramitas finas, abiertas y colgantes, plateadas. No es una espiga compacta: es
+ * una PLUMA, y a contraluz es lo más bonito del cañaveral.
+ */
+export function geomPenachoCana(q = 1, semilla = 41) {
+  const r = rng(semilla);
+  const partes = [];
+  const largo = 0.62 + r() * 0.24;
+
+  // El eje (raquis) que continúa el tallo.
+  const eje = new THREE.CylinderGeometry(0.010, 0.016, largo, 5, 1);
+  poner(eje, [0, largo * 0.5, 0]);
+  partes.push(pintarPlano(eje, PAL.penachoEje));
+
+  // Las ramitas de la pluma: finas, hacia arriba y afuera, cayendo de punta.
+  const nRamas = Math.max(10, Math.round(30 * q));
+  const cPluma = new THREE.Color(PAL.penacho);
+  const cLuz = new THREE.Color(PAL.penachoLuz);
+  const tmp = new THREE.Color();
+
+  for (let i = 0; i < nRamas; i++) {
+    const t = i / nRamas;
+    // Suben en espiral por el eje; las de abajo salen más largas y más abiertas.
+    const y0 = largo * (0.16 + 0.84 * t);
+    const ang = t * Math.PI * 2 * 3.6 + r() * 0.5;
+    const abre = 0.55 + (1 - t) * 0.75;
+    const lr = largo * (0.30 + (1 - t) * 0.42) * (0.75 + r() * 0.5);
+
+    const rama = geomHojaCana({
+      largo: lr,
+      ancho: 0.008 + r() * 0.005,
+      caida: 1.25,
+      doblez: 0.1,
+      torsion: 0.3,
+      lateral: 0.22,
+      filas: q > 0.8 ? 6 : 4,
+      semilla: semilla + i,
+    });
+    // Pintarla de pluma (no de hoja): plateada, más clara en la punta.
+    pintarPorVertice(rama, (x) => {
+      const u = clamp(x / Math.max(0.01, lr), 0, 1);
+      return tmp.copy(cPluma).lerp(cLuz, u * 0.8);
+    });
+    poner(rama, [0, y0, 0], [0, -ang, abre * 0.7], [1, 1, 1]);
+    partes.push(rama);
+  }
+
+  return fusionarSeguro(partes, 'penacho-cana');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  La MATA: el manojo de tallos con sus hojas y su chala                      */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Las dos variantes del lote. La caña no crece pareja: hay cepas que se
+ * dispararon y cepas rezagadas, y esa desigualdad es lo que hace que un
+ * cañaveral se vea vivo y no estampado.
+ */
+const VARIANTES_MATA = [
+  // 0 — la cepa ALTA: pocos tallos, muy derechos, la que ya se puede cortar.
+  { tallos: 7, hMin: 3.9, hMax: 4.7, radio: 0.031, abre: 0.16, hojas: 6, chala: 5 },
+  // 1 — la cepa TUPIDA: más tallos, más abiertos y algo más bajos.
+  { tallos: 8, hMin: 3.3, hMax: 4.1, radio: 0.029, abre: 0.26, hojas: 5, chala: 6 },
+];
+
+export const N_VARIANTES = VARIANTES_MATA.length;
+
+/**
+ * Construye UNA variante de mata de caña.
+ *
+ * Devuelve las tres piezas por separado porque cada una va a su propio
+ * InstancedMesh: el TALLO se tiñe con la variedad, la HOJA siempre verde y la
+ * CHALA siempre paja. Además devuelve `topes`: dónde quedaron las puntas de los
+ * tallos, para que el penacho se pueda sembrar EN una punta y no en el aire.
+ *
+ * @param {number} v  índice de variante (0…N_VARIANTES-1).
+ * @param {{q: number}} o
+ * @param {number} semilla
+ * @returns {{tallos: THREE.BufferGeometry, hojas: THREE.BufferGeometry,
+ *            chala: THREE.BufferGeometry, topes: [number,number,number][],
+ *            alto: number}}
+ */
+export function geomMataCana(v, { q }, semilla = 101) {
+  const cfg = VARIANTES_MATA[v % VARIANTES_MATA.length];
+  const r = rng(semilla + v * 37);
+
+  /* El recorte por tier va al CUADRADO de la calidad: la mata es la pieza más
+     cara del mundo (cada tallo es un tubo de 60 anillos) y en gama frugal hay
+     que bajar de 7–8 tallos a 3 sin pensarlo. Con 3 tallos, giro y escala la
+     cepa todavía se lee como macolla. */
+  const nTallos = Math.max(3, Math.round(cfg.tallos * q * q));
+  const nHojas = Math.max(2, Math.round(cfg.hojas * q));
+  const nChala = Math.max(1, Math.round(cfg.chala * q));
+
+  const partesTallo = [];
+  const partesHoja = [];
+  const partesChala = [];
+  const topes = /** @type {[number,number,number][]} */ ([]);
+  let alto = 0;
+
+  for (let i = 0; i < nTallos; i++) {
+    // El pie de cada tallo dentro de la cepa: un manojo apretado, no una fila.
+    const ang = (i / nTallos) * Math.PI * 2 + r() * 0.9;
+    const rad = 0.05 + r() * 0.15;
+    const bx = Math.cos(ang) * rad;
+    const bz = Math.sin(ang) * rad;
+
+    const altura = cfg.hMin + r() * (cfg.hMax - cfg.hMin);
+    const inclina = cfg.abre * (0.35 + r() * 0.85);
+    const rumbo = ang + (r() - 0.5) * 0.8;
+    const radio = cfg.radio * (0.86 + r() * 0.3);
+
+    const tallo = geomTalloCana({ altura, radio, inclina, rumbo, q, semilla: semilla + i * 13 });
+    poner(tallo, [bx, 0, bz]);
+    partesTallo.push(tallo);
+
+    // Dónde quedó la punta (para colgar hoja, chala y penacho de verdad).
+    const abre = Math.sin(inclina) * altura * 0.92;
+    const tx = bx + Math.cos(rumbo) * abre;
+    const tz = bz + Math.sin(rumbo) * abre;
+    topes.push([tx, altura, tz]);
+    if (altura > alto) alto = altura;
+
+    /* LAS HOJAS VERDES viven en el tercio de arriba, alternas en DOS filas
+       opuestas (dístico, como toda gramínea) y saliendo de los nudos. */
+    for (let h = 0; h < nHojas; h++) {
+      const u = h / Math.max(1, nHojas - 1);
+      const y = altura * (0.60 + 0.38 * u);
+      const k = y / altura;
+      const hx = bx + Math.cos(rumbo) * (abre * k * k);
+      const hz = bz + Math.sin(rumbo) * (abre * k * k);
+      // dístico: dos filas opuestas, con el giro del tallo encima
+      const lado = h % 2 === 0 ? 0 : Math.PI;
+      const giro = rumbo + lado + (r() - 0.5) * 0.55;
+      // las de arriba salen más erguidas (el cogollo apunta al cielo)
+      const alza = 0.42 + u * 0.55 + (r() - 0.5) * 0.28;
+
+      const hoja = geomHojaCana({
+        largo: 1.05 + r() * 0.55,
+        ancho: 0.030 + r() * 0.012,
+        caida: 1.15 - u * 0.55,
+        doblez: 0.34,
+        torsion: 0.85 + r() * 0.6,
+        lateral: 0.14 + r() * 0.12,
+        filas: q > 0.8 ? 9 : 6,
+        semilla: semilla + i * 31 + h,
+      });
+      poner(hoja, [hx, y, hz], [0, -giro, alza]);
+      partesHoja.push(hoja);
+    }
+
+    /* LA CHALA: hoja SECA colgando pegada al tallo en la mitad baja. Sin esto
+       el cañaveral parece un guadual; con esto, parece caña de verdad. */
+    for (let c = 0; c < nChala; c++) {
+      const u = c / Math.max(1, nChala - 1);
+      const y = altura * (0.20 + 0.42 * u);
+      const k = y / altura;
+      const cx = bx + Math.cos(rumbo) * (abre * k * k);
+      const cz = bz + Math.sin(rumbo) * (abre * k * k);
+      const giro = rumbo + (c % 2 === 0 ? 0 : Math.PI) + (r() - 0.5) * 0.9;
+
+      const seca = geomHojaCana({
+        largo: 0.70 + r() * 0.45,
+        ancho: 0.024 + r() * 0.010,
+        caida: 1.65, // la hoja seca CUELGA: se desploma casi vertical
+        doblez: 0.46, // y se enrolla sobre sí misma al secarse
+        torsion: 1.5 + r() * 0.9,
+        lateral: 0.10,
+        filas: q > 0.8 ? 7 : 5,
+        seca: true,
+        semilla: semilla + i * 17 + c + 400,
+      });
+      poner(seca, [cx, y, cz], [0, -giro, -0.55 - r() * 0.5]);
+      partesChala.push(seca);
+    }
+  }
+
+  return {
+    tallos: fusionarSeguro(partesTallo, `mata-cana-tallos-v${v}`),
+    hojas: fusionarSeguro(partesHoja, `mata-cana-hojas-v${v}`),
+    chala: fusionarSeguro(partesChala, `mata-cana-chala-v${v}`),
+    topes,
+    alto,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Piezas del suelo                                                           */
+/* -------------------------------------------------------------------------- */
+
+/** Hojarasca: la hoja de caña caída que tapiza la calle entre surcos. */
+export function geomHojarascaCana(semilla = 61) {
+  const r = rng(semilla);
+  const partes = [];
+  for (let i = 0; i < 5; i++) {
+    const h = geomHojaCana({
+      largo: 0.55 + r() * 0.4,
+      ancho: 0.026,
+      caida: 0.15,
+      doblez: 0.5,
+      torsion: 1.8,
+      lateral: 0.3,
+      filas: 6,
+      seca: true,
+      semilla: semilla + i,
+    });
+    poner(h, [(r() - 0.5) * 0.7, 0.015 + r() * 0.02, (r() - 0.5) * 0.7], [0, r() * Math.PI * 2, 0]);
+    partes.push(h);
+  }
+  return fusionarSeguro(partes, 'hojarasca-cana');
+}
+
+/** Piedra de vega: terrón/canto rodado suelto. */
+export function geomPiedraCana(semilla = 62) {
+  const g = matojoHoja(0.17, semilla, 0.5);
+  poner(g, [0, 0.08, 0], [0, 0, 0], [1.25, 0.6, 1.05]);
+  return fusionarSeguro([pintarPlano(g, PAL.piedra)], 'piedra-cana');
+}
+
+/** Matojo de arvense: la yerba que vive en la calle del surco (y da refugio). */
+export function geomMatojoCana(semilla = 63) {
+  const r = rng(semilla);
+  const partes = [];
+  for (let i = 0; i < 7; i++) {
+    const h = geomHojaCana({
+      largo: 0.26 + r() * 0.2,
+      ancho: 0.012,
+      caida: 0.9,
+      doblez: 0.3,
+      torsion: 0.8,
+      lateral: 0.2,
+      filas: 5,
+      semilla: semilla + i * 3,
+    });
+    poner(h, [(r() - 0.5) * 0.1, 0.02, (r() - 0.5) * 0.1], [0, r() * Math.PI * 2, 0.6 + r() * 0.5]);
+    partes.push(h);
+  }
+  const g = fusionarSeguro(partes, 'matojo-cana');
+  return pintarPorVertice(g, (x, y, z, i, c) => c.set(PAL.matojo).multiplyScalar(0.8 + y * 0.9));
+}
+
+/* -------------------------------------------------------------------------- */
+/*  La SIEMBRA: el lote en surcos                                              */
+/* -------------------------------------------------------------------------- */
+
+/* Los surcos de caña SÍ son regulares en la vida real — es un cultivo sembrado
+   a chorrillo en surco. Lo que no puede pasar es que la ESCENA se vea de
+   plantilla: por eso el surco tiene su ondulación, la distancia entre cepas
+   respira, hay claros donde ya cortaron y las variedades se mezclan. */
+const SURCO = 1.52; // distancia entre surcos (m) — se camina apretado entre caña
+const PASO_CEPA = 1.05; // distancia entre cepas dentro del surco
+
+/* Los tres tablones sembrados del lote. La era del trapiche los parte al medio:
+   el cañaveral rodea al trapiche, que es exactamente como se ve en la finca. */
+const TABLONES = [
+  // el grande de la izquierda: el que la cámara mira de frente
+  { x0: -23, x1: -1.4, z0: -20, z1: 13.5, giro: 0.06 },
+  // el de atrás, subiendo la loma detrás de la enramada
+  { x0: 0.5, x1: 23, z0: -20, z1: -6.5, giro: -0.05 },
+  // la manchita del frente derecho, junto al camino de llegada
+  { x0: 16.5, x1: 23.5, z0: -5, z1: 12, giro: 0.03 },
+];
+
+/**
+ * Siembra el lote completo, determinista.
+ *
+ * @param {{mata:number, penacho:number, hojarasca:number, piedra:number, matojo:number}} conteos
+ * @param {[number,number,number][][]} topesPorVariante  puntas de cada variante.
+ * @param {number} [seed]
+ * @returns {{matas: {pos:[number,number,number], rotY:number, escala:number, tint:number[]}[][],
+ *            hojas: object[][], chala: object[][], penacho: object[],
+ *            hojarasca: object[], piedra: object[], matojo: object[]}}
+ */
+export function sembrarCanaveral(conteos, topesPorVariante, seed = 907) {
+  const r = rng(seed);
+  const nV = topesPorVariante.length;
+
+  const matas = Array.from({ length: nV }, () => []);
+  const hojas = Array.from({ length: nV }, () => []);
+  const chala = Array.from({ length: nV }, () => []);
+  const penacho = [];
+  const cPenacho = [0.98, 0.96, 0.9];
+
+  /* 1) Se recorren los surcos de cada tablón y se van poniendo cepas hasta
+        gastar el presupuesto de `conteos.mata`. Se reparte proporcional al área
+        para que ningún tablón quede pelado en gama baja. */
+  const sitios = [];
+  TABLONES.forEach((tb, ti) => {
+    const nSurcos = Math.floor((tb.x1 - tb.x0) / SURCO);
+    for (let s = 0; s <= nSurcos; s++) {
+      const xs = tb.x0 + s * SURCO;
+      const largo = tb.z1 - tb.z0;
+      const nCepas = Math.floor(largo / PASO_CEPA);
+      for (let c = 0; c <= nCepas; c++) {
+        const zc = tb.z0 + c * PASO_CEPA;
+        // el surco no es una recta de tiralíneas: ondula con el terreno
+        const x = xs + Math.sin(zc * 0.17 + ti) * 0.42 + zc * tb.giro;
+        const z = zc + (r() - 0.5) * 0.34;
+        if (enLaEra(x, z)) continue; // la era del trapiche está limpia
+        // el camino de llegada se respeta (por ahí entra la caña cortada)
+        if (Math.abs(x - caminoX(z)) < 2.3 && z > -2) continue;
+        sitios.push([x, z, ti]);
+      }
+    }
+  });
+
+  // Barajado determinista: al recortar por tier el lote se ralea PAREJO, no se
+  // queda media hectárea llena y la otra vacía.
+  for (let i = sitios.length - 1; i > 0; i--) {
+    const j = Math.floor(r() * (i + 1));
+    const t = sitios[i];
+    sitios[i] = sitios[j];
+    sitios[j] = t;
+  }
+
+  const cuantas = Math.min(conteos.mata, sitios.length);
+  for (let i = 0; i < cuantas; i++) {
+    const [x, z, ti] = sitios[i];
+    const y = alturaVega(x, z);
+    // Claros: donde ya pasó el corte queda la cepa rapada. Se salta una de cada
+    // tantas, en manchas (ruido), no al azar puro — así se ve el corte por eras.
+    const corte = ruidoFbm(x * 0.14 + 5, 0.5, z * 0.14);
+    if (corte > 0.74 && ti === 0) continue;
+
+    const v = nV > 1 ? (ruidoFbm(x * 0.3, 1.5, z * 0.3) > 0.5 ? 1 : 0) : 0;
+    const variedad = variedadPara(ruidoFbm(x * 0.09 + 21, 3.5, z * 0.09));
+    // las cepas de la orilla del tablón vienen más chicas (menos competencia,
+    // pero más golpe de sol y de viento) — el borde de un lote nunca va parejo
+    const escala = 0.84 + r() * 0.3;
+    const rotY = r() * Math.PI * 2;
+    const item = {
+      pos: /** @type {[number,number,number]} */ ([x, y, z]),
+      rotY,
+      escala,
+      tint: variedad.tinte,
+      fase: x * 0.32 + z * 0.19, // la ONDA del viento viaja por el lote
+    };
+    matas[v].push(item);
+    // hoja y chala comparten transformación con el tallo (misma cepa), pero la
+    // hoja va siempre verde: el tinte de la variedad NO le toca el follaje
+    hojas[v].push({ ...item, tint: [0.94 + r() * 0.1, 1, 0.9 + r() * 0.12] });
+    chala[v].push({ ...item, tint: [1, 0.97, 0.92] });
+
+    /* EL PENACHO: solo en las cepas que ya espigaron, y montado EN una punta
+       real de tallo (por eso hicieron falta los `topes`). */
+    if (penacho.length < conteos.penacho && r() < 0.42) {
+      const tops = topesPorVariante[v];
+      const tp = tops[Math.floor(r() * tops.length)];
+      if (tp) {
+        const ca = Math.cos(rotY);
+        const sa = Math.sin(rotY);
+        const px = x + (tp[0] * ca - tp[2] * sa) * escala;
+        const pz = z + (tp[0] * sa + tp[2] * ca) * escala;
+        penacho.push({
+          pos: /** @type {[number,number,number]} */ ([px, y + tp[1] * escala - 0.06, pz]),
+          rotY: r() * Math.PI * 2,
+          escala: escala * (0.85 + r() * 0.4),
+          tint: cPenacho,
+          fase: px * 0.32 + pz * 0.19,
+        });
+      }
+    }
+  }
+
+  /* 2) El suelo: hojarasca y matojos en las calles, piedras sueltas. */
+  const suelo = (n, semilla, filtro) => {
+    const rr = rng(semilla);
+    const lista = [];
+    let intentos = 0;
+    while (lista.length < n && intentos < n * 40) {
+      intentos++;
+      const x = -23 + rr() * 46;
+      const z = -20 + rr() * 40;
+      if (enLaEra(x, z, 0.94)) continue;
+      if (filtro && !filtro(x, z)) continue;
+      lista.push({
+        pos: /** @type {[number,number,number]} */ ([x, alturaVega(x, z), z]),
+        rotY: rr() * Math.PI * 2,
+        escala: 0.7 + rr() * 0.7,
+        tint: [0.9 + rr() * 0.2, 0.92 + rr() * 0.16, 0.88 + rr() * 0.2],
+        fase: 0,
+      });
+    }
+    return lista;
+  };
+
+  return {
+    matas,
+    hojas,
+    chala,
+    penacho,
+    hojarasca: suelo(conteos.hojarasca, 71),
+    piedra: suelo(conteos.piedra, 72),
+    matojo: suelo(conteos.matojo, 73),
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/*  El cañaveral del FONDO (la silueta a media y larga distancia)              */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * El error que ya se pagó en el café: la mata de primer plano quedaba perfecta y
+ * a media distancia la ladera parecía un bosque de pinos. Un cañaveral visto de
+ * lejos NO es una fila de conos: es un MURO verde de borde superior RASGADO y
+ * casi horizontal, del que sobresalen penachos sueltos. Esto lo dibuja barato:
+ * una banda de altura ondulada con flecos arriba, detrás del lote instanciado,
+ * para que el cultivo no se acabe en seco.
+ */
+export function geomMuroCanaveral({ largo, alto, semilla = 88, dientes = 46 }) {
+  const r = rng(semilla);
+  const partes = [];
+  const paso = largo / dientes;
+  const cBaja = new THREE.Color(PAL.hojaSombra);
+  const cAlta = new THREE.Color(PAL.hoja);
+  const cLuz = new THREE.Color(PAL.hojaSol);
+  const tmp = new THREE.Color();
+
+  for (let i = 0; i < dientes; i++) {
+    const x = -largo / 2 + i * paso + paso * 0.5;
+    // el borde de arriba RASGA: cada diente tiene su altura y su ancho
+    const h = alto * (0.72 + 0.45 * ruidoFbm(i * 0.4, 0.5, 0.5) + r() * 0.12);
+    const w = paso * (1.05 + r() * 0.7);
+    const d = 1.1 + r() * 1.3;
+    const g = new THREE.BoxGeometry(w, h, d, 1, 3, 1);
+    poner(g, [x, h * 0.5, (r() - 0.5) * 1.4], [0, (r() - 0.5) * 0.4, (r() - 0.5) * 0.06]);
+    pintarPorVertice(g, (px, py) => {
+      const u = clamp(py / Math.max(0.01, alto), 0, 1);
+      tmp.copy(cBaja).lerp(cAlta, u * 0.85);
+      tmp.lerp(cLuz, Math.pow(u, 2.2) * 0.55);
+      const n = ruidoFbm(px * 0.7 + 9, py * 0.7, 0.5);
+      tmp.multiplyScalar(0.86 + n * 0.28);
+      return tmp;
+    });
+    partes.push(g);
+  }
+  return fusionarSeguro(partes, 'muro-canaveral');
+}

--- a/src/visual/mundo3d/cana/leccionCana.js
+++ b/src/visual/mundo3d/cana/leccionCana.js
@@ -1,0 +1,110 @@
+/*
+ * leccionCana — LOS CINCO PASOS del mundo de la caña, y a dónde mira cada uno.
+ *
+ * Vive aparte del host (`MundoCana.jsx`) a propósito: aquí no hay React ni
+ * WebGL, solo datos y las funciones de geometría del mundo. Así la lección se
+ * puede verificar HEADLESS — que ninguna cámara arranque metida dentro de una
+ * cepa, que ninguna quede bajo tierra, y que todas caigan dentro de los límites
+ * de distancia y de ángulo que OrbitControls va a imponer después. Esas cuatro
+ * cosas no se pueden ver leyendo el código, y equivocarse en cualquiera arruina
+ * el plano sin dar un solo error.
+ *
+ * El orden de los pasos es el orden en que pasan las cosas de verdad: la caña
+ * en pie → el corte y la molienda → el bagazo que vuelve como leña → la hornilla
+ * y sus pailas → las gaveras. Al final de ese camino, una mata de más de cuatro
+ * metros terminó siendo un bloque que cabe en la mano.
+ *
+ * Copy en español de Colombia, en "usted".
+ */
+import { alturaVega, enTrapiche, pasilloCanaveral } from './floraCana.geom.js';
+
+/* Un punto del cañaveral, a ras de suelo. */
+const enElLote = (x, z) => /** @type {[number,number,number]} */ ([x, alturaVega(x, z), z]);
+
+/*
+ * El pasillo entre dos surcos por donde se mete la cámara en el primer paso.
+ * 1,55 m es la altura de los ojos de una persona parada: desde ahí, y solo
+ * desde ahí, se entiende que la caña le pasa por encima.
+ *
+ * OJO con la x: el surco ONDULA y se sesga, así que el eje de la calle CAMBIA
+ * con la profundidad. Se le pide a `pasilloCanaveral(z)`, que sale de las
+ * mismas constantes de la siembra — con una x fija la cámara arranca metida
+ * dentro de una cepa a los pocos metros.
+ */
+export const OJOS = 1.55;
+const Z_ENTRADA = 6.5;
+const Z_FONDO = -6;
+const X_ENTRADA = pasilloCanaveral(Z_ENTRADA);
+const X_FONDO = pasilloCanaveral(Z_FONDO);
+
+/* Los límites que OrbitControls impone en la escena. Se declaran aquí para que
+   el chequeo headless valide contra los MISMOS números que usa la escena. */
+export const LIMITES = {
+  minDistancia: 5,
+  maxDistancia: 34,
+  minPolar: 0.28,
+  maxPolar: 1.7,
+};
+
+export const PASOS = [
+  {
+    id: 'canaveral',
+    kicker: 'Paso 1 de 5 · El cañaveral',
+    texto:
+      'Métase al surco y mire para arriba: la caña le pasa por encima. Una caña de trapiche madura pasa de los cuatro metros — más de dos veces usted. Fíjese en el tallo: viene por segmentos, con un nudo entre uno y otro, y en cada nudo hay una yema. De un pedazo de tallo con yemas sale la mata siguiente: la caña se siembra de caña, no de semilla.',
+    foco: enElLote(pasilloCanaveral(0), 0),
+    /* La mira va a 2,6 m: por encima de los ojos (la vista sube ~4°, se siente
+       que uno levanta la cabeza) pero SIN quedar tan alta que la cámara caiga
+       por debajo del límite polar y el encuadre se enderece solo. Con fov 52, a
+       tres metros la caña ya se sale por arriba del cuadro. */
+    vista: {
+      pos: [X_ENTRADA, alturaVega(X_ENTRADA, Z_ENTRADA) + OJOS, Z_ENTRADA],
+      mira: [X_FONDO, 2.6, Z_FONDO],
+    },
+  },
+  {
+    id: 'molienda',
+    kicker: 'Paso 2 de 5 · La molienda',
+    texto:
+      'La caña se corta, se despunta y se arruma; y de ahí derecho al molino, porque caña cortada que se demora empieza a fermentar y daña la panela. El molino la pasa entre tres masas que la exprimen. Salen dos cosas: el JUGO, que aquí se llama guarapo, y el BAGAZO, que es la fibra que queda de tanto apretarla.',
+    foco: enTrapiche(-4.2, 0, -1.2),
+    vista: { pos: [1.2, 2.4, 5.8], mira: [6.3, 1.5, 0.6] },
+  },
+  {
+    id: 'bagazo',
+    kicker: 'Paso 3 de 5 · El bagazo',
+    texto:
+      'Aquí está lo mejor del oficio. El bagazo sale mojado del molino, se apila unas semanas a secar, y seco vuelve a la hornilla como leña. El trapiche se calienta con la misma caña que muele: no le toca comprar combustible ni bajarle un palo al monte. Mire los tres montones y va a ver el mismo bagazo en sus tres momentos.',
+    foco: enTrapiche(8.2, 0, 2.0),
+    vista: { pos: [22.5, 3.2, 8.0], mira: [17.2, 1.2, 1.8] },
+  },
+  {
+    id: 'hornilla',
+    kicker: 'Paso 4 de 5 · La hornilla y las pailas',
+    texto:
+      'Una sola candela calienta toda la fila. El fuego está en un extremo y la chimenea en el otro, así que cada paila recibe distinto calor: el guarapo entra por la más templada, donde se le retira la CACHAZA — esa espuma verdosa que se lleva la suciedad y que después sirve de abono o de comida para los animales —, y va caminando hacia el fuego mientras se evapora y se vuelve miel. La última, la de al lado de la llama, es la del punteo.',
+    foco: enTrapiche(2.3, 0, -1.4),
+    vista: { pos: [12.6, 2.6, 6.4], mira: [12.8, 1.5, 0.5] },
+  },
+  {
+    id: 'gaveras',
+    kicker: 'Paso 5 de 5 · Las gaveras',
+    texto:
+      'La miel en su punto se pasa a la batea y se bate: al batirla entra aire, aclara y empieza a granular. Ahí mismo se vacía en las GAVERAS, los moldes de madera, y se deja enfriar. Cuando cuaja se voltea el molde y sale el bloque. De una mata más alta que usted salió algo que cabe en la mano — y eso es todo lo que pasa en un trapiche.',
+    foco: enTrapiche(4.3, 0, 2.6),
+    vista: { pos: [11.8, 2.2, 9.4], mira: [14.8, 1.2, 4.8] },
+  },
+];
+
+/* El acento del trapiche para el panel compartido: el ámbar de la miel sobre el
+   pardo quemado de la hornilla. */
+export const TEMA_PANEL = {
+  fondo: 'rgba(30, 17, 9, 0.70)',
+  borde: 'rgba(226, 160, 82, 0.30)',
+  tinta: '#f6ead6',
+  kicker: '#e6b877',
+  acentoA: 'rgba(240, 168, 62, 0.95)',
+  acentoB: 'rgba(184, 96, 30, 0.95)',
+  tintaAccion: '#2a1606',
+  activo: '#f0a83e',
+};

--- a/src/visual/mundo3d/cana/trapiche.geom.js
+++ b/src/visual/mundo3d/cana/trapiche.geom.js
@@ -1,0 +1,874 @@
+/*
+ * trapiche.geom — la GEOMETRÍA de la ENRAMADA DEL TRAPICHE PANELERO.
+ *
+ * Un trapiche de finca no es un ingenio: es un COBERTIZO ABIERTO con una
+ * molienda, una hornilla larga y una mesa de moldeo, montado al lado del
+ * cañaveral que lo alimenta. Todo lo que hay aquí está por una razón física:
+ *
+ *   · La enramada es ALTA (2,95 m al alero, 5,0 m al caballete) y ABIERTA por
+ *     los lados. No es un capricho de diseño: adentro hay una hornilla prendida
+ *     todo el día. El techo alto y los costados libres son los que sacan el
+ *     calor, el humo y el vapor. Un trapiche con techo bajo y cerrado no se
+ *     aguanta — y por eso el caballete va ALZADO, con su boquete para que el
+ *     humo salga por arriba.
+ *   · La molienda va sobre una BANCADA elevada. Tampoco es capricho: el guarapo
+ *     baja a las pailas POR GRAVEDAD, así que el molino tiene que quedar más
+ *     alto que la hornilla o el jugo no corre.
+ *   · La hornilla es UNA sola cámara larga con la boca en un extremo y la
+ *     chimenea en el otro. Las pailas se ordenan según el calor que reciben:
+ *     la más lejos del fuego (junto a la chimenea) es la más fría y es donde
+ *     ENTRA el jugo; la de al lado del fuego es la del punteo. El jugo camina
+ *     hacia el fuego mientras se concentra. Por eso el mundo se lee de
+ *     izquierda a derecha: caña → molienda → guarapo → pailas → gaveras.
+ *   · El bagazo sale de la molienda mojado, se apila a secar, y seco vuelve
+ *     como COMBUSTIBLE de la misma hornilla. El trapiche se calienta solo: ese
+ *     es el dato más bonito del oficio y hay que poderlo VER — por eso hay tres
+ *     montones de bagazo distintos en la escena, en tres estados.
+ *
+ * TÉCNICA: las piezas repetidas (postes, pares del techo, tallos del arrume,
+ * fibras del bagazo, celdas de la gavera) se FUSIONAN en una geometría por
+ * conjunto — el esqueleto entero de la enramada es UNA draw-call en vez de
+ * veintiséis. El color va horneado en vertexColors, así que todo comparte un
+ * material mate y las pailas otro metálico.
+ *
+ * ⚠️ Todo pasa por `fusionarSeguro`: mezclar indexadas con no-indexadas devuelve
+ * null EN SILENCIO y la pieza no se dibuja sin dar error.
+ *
+ * Aquí viven SOLO los datos y las mallas (nada de WebGL): corre headless.
+ */
+import * as THREE from 'three';
+import {
+  rng,
+  ruidoFbm,
+  fusionarSeguro,
+  poner,
+  pintarPorVertice,
+  pintarPlano,
+  matojoHoja,
+} from '../bosque/sombreadoVegetal.js';
+import { PAL as PAL_CANA, VARIEDADES } from './floraCana.geom.js';
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Las medidas de la enramada (todo el mundo se cuelga de aquí)               */
+/* -------------------------------------------------------------------------- */
+
+export const ENRAMADA = {
+  medioX: 6.6, // media luz de la nave (x)
+  medioZ: 4.4, // media profundidad (z)
+  alero: 2.95, // altura al alero — un trapiche NO es de techo bajo
+  cumbre: 5.0, // altura al caballete
+  vuelo: 0.55, // el volado del techo por fuera del alero
+};
+
+/* Dónde queda cada oficio dentro de la enramada (coords locales del trapiche).
+   Se exportan porque la escena los usa para los focos de la lección, el fuego,
+   el vapor y la fauna: una sola fuente de verdad para el sitio de cada cosa. */
+export const SITIOS = {
+  arrume: /** @type {[number,number,number]} */ ([-5.9, 0, 2.6]), // la caña cortada
+  molienda: /** @type {[number,number,number]} */ ([-4.2, 0, -1.2]),
+  canoa: /** @type {[number,number,number]} */ ([-1.5, 1.28, -1.25]), // el guarapo corriendo
+  hornilla: /** @type {[number,number,number]} */ ([2.35, 0, -1.4]),
+  boca: /** @type {[number,number,number]} */ ([5.45, 0.46, -1.4]), // la candela
+  chimenea: /** @type {[number,number,number]} */ ([-0.6, 0, -1.4]),
+  moldeo: /** @type {[number,number,number]} */ ([4.3, 0, 2.6]),
+  bagacera: /** @type {[number,number,number]} */ ([8.2, 0, 2.0]), // el bagazo secando
+};
+
+/* Las cuatro pailas, de la MÁS FRÍA (junto a la chimenea, donde entra el jugo)
+   a la MÁS CALIENTE (junto al fuego, donde se puntea). El orden IMPORTA: es la
+   lección entera del mundo. */
+export const PAILAS = [
+  { x: 0.55, r: 0.50, oficio: 'clarificación', hervor: 0.25 },
+  { x: 1.70, r: 0.50, oficio: 'evaporación', hervor: 0.85 },
+  { x: 2.85, r: 0.50, oficio: 'evaporación', hervor: 1.0 },
+  { x: 4.00, r: 0.48, oficio: 'punteo', hervor: 0.7 },
+];
+export const PAILA_Z = -1.4;
+export const PAILA_Y = 1.05; // la boca de la paila, al ras del bloque
+
+/* Las celdas de la gavera de adelante, en coordenadas del MOLDEO (la escena les
+   mete la panela cuajándose). Se calculan aquí para que el molde y el bloque no
+   se puedan desalinear: una sola cuenta, no dos. */
+const GAVERA = { ox: 0.42, oz: 0.3, largo: 1.28, celdas: 6, y: 0.935 };
+export const CELDAS_GAVERA = Array.from({ length: GAVERA.celdas }, (_, i) => {
+  const paso = GAVERA.largo / GAVERA.celdas;
+  return /** @type {[number,number,number]} */ ([
+    GAVERA.ox - GAVERA.largo / 2 + (i + 0.5) * paso,
+    GAVERA.y,
+    GAVERA.oz,
+  ]);
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del trapiche                                                        */
+/* -------------------------------------------------------------------------- */
+
+export const PAL = {
+  madera: '#7a5a38', // el horcón rollizo, sin cepillar
+  maderaClara: '#a98a5c', // tabla curada: mesa, canoa, gavera
+  maderaOscura: '#5a4326', // viga vieja, ahumada por años de hornilla
+  maderaHumo: '#4a3a26', // lo que queda encima de la hornilla: negro de humo
+
+  teja: '#b0603f', // teja de barro cocido
+  tejaSombra: '#8f4b31',
+  tejaMusgo: '#7d6a44', // la teja vieja se ensucia y le sale verdín
+
+  ladrillo: '#a35a3c', // la mampostería de la hornilla
+  ladrilloClaro: '#bd7350',
+  hollin: '#2e2620', // el tizne alrededor de la boca del horno
+  cal: '#efe7d8', // el repello encalado del cuerpo de la hornilla
+
+  hierro: '#6f6a63', // las masas del molino, el eje
+  hierroLuz: '#9a948b',
+  cobre: '#b2673a', // la paila vieja de cobre
+  cobreLuz: '#d89257',
+  aluminio: '#a7a49c', // la paila nueva, de aluminio fundido
+
+  bagazo: '#c2a464', // la fibra exprimida — paja clara, no café
+  bagazoSeco: '#dcc48a',
+  bagazoHumedo: '#8e7442',
+
+  guarapo: '#b6a63e', // el jugo crudo: verdoso turbio, NO ámbar
+  cachaza: '#8f9a55', // la espuma verdosa que se retira
+  miel: '#a85f16', // la miel ya concentrada
+  panela: '#8a4a12', // el bloque cuajado
+  panelaLuz: '#c2802c',
+
+  tierra: '#8a6a44',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Helpers de madera                                                          */
+/* -------------------------------------------------------------------------- */
+
+/** Un rollizo de madera con veta horneada y el pie oscurecido por el contacto. */
+function palo(geo, { claro = PAL.maderaClara, oscuro = PAL.maderaOscura, grano = 4.5, humo = 0 } = {}) {
+  const cA = new THREE.Color(oscuro);
+  const cB = new THREE.Color(claro);
+  const cHumo = new THREE.Color(PAL.maderaHumo);
+  const tmp = new THREE.Color();
+  return pintarPorVertice(geo, (x, y, z) => {
+    // veta: mucha frecuencia alrededor, poca a lo largo → la fibra corre derecha
+    const v = ruidoFbm(x * grano * 2, y * grano * 0.4, z * grano * 2);
+    tmp.copy(cA).lerp(cB, clamp(v * 1.55, 0, 1));
+    // contacto con el piso: el pie del poste vive en penumbra y en barro
+    tmp.multiplyScalar(0.6 + 0.4 * clamp(y / 1.2, 0, 1));
+    // lo que está encima de la hornilla lleva años recibiendo humo
+    if (humo > 0) tmp.lerp(cHumo, humo * clamp((y - 2.2) / 2.4, 0, 1));
+    return tmp;
+  });
+}
+
+/** Un poste rollizo (ligeramente cónico, como un palo de monte descortezado). */
+function horcon(r0, r1, h, seg = 7) {
+  return new THREE.CylinderGeometry(r1, r0, h, seg, 1);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  1) El ESQUELETO de la enramada: horcones, soleras, cumbrera y pares        */
+/* -------------------------------------------------------------------------- */
+
+export function geomEsqueletoEnramada({ q = 1 } = {}, semilla = 201) {
+  const r = rng(semilla);
+  const { medioX, medioZ, alero, cumbre } = ENRAMADA;
+  const partes = [];
+
+  /* Los HORCONES de los costados. Van rollizos y no perfectamente a plomo: son
+     palos de monte parados a pulso, no perfiles de acero. */
+  const xs = [-medioX + 0.4, -2.1, 2.1, medioX - 0.4];
+  xs.forEach((x, i) => {
+    [-medioZ + 0.2, medioZ - 0.2].forEach((z) => {
+      const g = horcon(0.155, 0.125, alero, q > 0.8 ? 8 : 6);
+      poner(
+        g,
+        [x + (r() - 0.5) * 0.1, alero * 0.5, z + (r() - 0.5) * 0.1],
+        [(r() - 0.5) * 0.03, r() * 3, (r() - 0.5) * 0.03],
+      );
+      partes.push(palo(g, { humo: i >= 2 ? 0.5 : 0.15 }));
+    });
+  });
+
+  /* Los dos horcones ALTOS de los hastiales, que cargan la cumbrera. */
+  [-medioX - 0.1, medioX + 0.1].forEach((x, i) => {
+    const g = horcon(0.17, 0.13, cumbre, q > 0.8 ? 8 : 6);
+    poner(g, [x, cumbre * 0.5, 0], [0, r() * 3, 0]);
+    partes.push(palo(g, { humo: i === 1 ? 0.6 : 0.2 }));
+  });
+
+  /* SOLERAS (las vigas que corren sobre los horcones) y CUMBRERA. */
+  [-medioZ + 0.2, medioZ - 0.2].forEach((z) => {
+    const g = new THREE.BoxGeometry(medioX * 2 + 0.5, 0.17, 0.21);
+    poner(g, [0, alero + 0.06, z]);
+    partes.push(palo(g, { humo: 0.35 }));
+  });
+  const cum = new THREE.BoxGeometry(medioX * 2 + 0.7, 0.22, 0.24);
+  poner(cum, [0, cumbre + 0.05, 0]);
+  partes.push(palo(cum, { humo: 0.7 }));
+
+  /* TIRANTES: los travesaños que amarran la nave de lado a lado. De ellos
+     cuelgan el bombillo, la ruana y todo lo que hay que tener a mano. */
+  [-4.1, 0, 4.1].forEach((x) => {
+    const g = new THREE.BoxGeometry(0.15, 0.15, medioZ * 2 - 0.2);
+    poner(g, [x, alero + 0.02, 0]);
+    partes.push(palo(g, { humo: 0.5 }));
+  });
+
+  /* Los PARES del techo: de la solera a la cumbrera, a lado y lado. */
+  const nPares = Math.max(5, Math.round(9 * q));
+  const largo = Math.hypot(medioZ, cumbre - alero) + ENRAMADA.vuelo;
+  const angulo = Math.atan2(cumbre - alero, medioZ);
+  for (let i = 0; i < nPares; i++) {
+    const x = -medioX + (i / (nPares - 1)) * medioX * 2;
+    [1, -1].forEach((lado) => {
+      const g = new THREE.BoxGeometry(0.10, 0.12, largo);
+      // centro del par: a mitad de la pendiente, corrido por el volado
+      const zc = lado * (medioZ * 0.5 + ENRAMADA.vuelo * 0.5 * Math.cos(angulo));
+      const yc = (alero + cumbre) * 0.5 - ENRAMADA.vuelo * 0.5 * Math.sin(angulo) + 0.14;
+      poner(g, [x, yc, zc], [lado * angulo, 0, 0]);
+      partes.push(palo(g, { humo: 0.55 }));
+    });
+  }
+
+  return fusionarSeguro(partes, 'esqueleto-enramada');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  2) El TECHO de teja                                                        */
+/* -------------------------------------------------------------------------- */
+
+export function geomTechoEnramada({ q = 1 } = {}, semilla = 202) {
+  const r = rng(semilla);
+  const { medioX, medioZ, alero, cumbre, vuelo } = ENRAMADA;
+  const partes = [];
+  const angulo = Math.atan2(cumbre - alero, medioZ);
+  const pendiente = Math.hypot(medioZ, cumbre - alero) + vuelo;
+
+  const cTeja = new THREE.Color(PAL.teja);
+  const cSombra = new THREE.Color(PAL.tejaSombra);
+  const cMusgo = new THREE.Color(PAL.tejaMusgo);
+  const tmp = new THREE.Color();
+
+  /* Las dos aguas. El color se hornea con el CANAL de la teja: franjas a lo
+     largo de la pendiente, para que el techo se lea como teja de barro y no
+     como una lámina plana. */
+  [1, -1].forEach((lado) => {
+    const g = new THREE.BoxGeometry(medioX * 2 + 0.9, 0.11, pendiente, 1, 1, Math.max(4, Math.round(14 * q)));
+    pintarPorVertice(g, (x, y, z) => {
+      // la onda de la teja corre a lo largo de la pendiente (eje x del techo)
+      const canal = 0.5 + 0.5 * Math.sin(x * 7.4);
+      tmp.copy(cSombra).lerp(cTeja, canal);
+      // las hiladas: cada teja se monta sobre la de abajo y hace su sombrita
+      const hilada = 0.5 + 0.5 * Math.sin(z * 9.2);
+      tmp.multiplyScalar(0.84 + 0.16 * hilada);
+      // verdín en la parte baja, donde escurre y no le da el sol
+      const bajo = smoothstep(0, pendiente * 0.45, z * lado + pendiente * 0.5);
+      tmp.lerp(cMusgo, (1 - bajo) * 0.3 * ruidoFbm(x * 0.9 + 4, z * 0.9, 0.5));
+      const n = ruidoFbm(x * 1.6 + 7, z * 1.6, 2.5);
+      tmp.multiplyScalar(0.9 + n * 0.2);
+      return tmp;
+    });
+    const zc = lado * (medioZ * 0.5 + vuelo * 0.5 * Math.cos(angulo));
+    const yc = (alero + cumbre) * 0.5 - vuelo * 0.5 * Math.sin(angulo) + 0.26;
+    poner(g, [(r() - 0.5) * 0.06, yc, zc], [lado * angulo, 0, 0]);
+    partes.push(g);
+  });
+
+  /* EL CABALLETE ALZADO. La pieza que más dice de un trapiche: la cumbrera va
+     montada EN ALTO sobre la cumbre, dejando un boquete corrido por donde se
+     escapan el humo y el vapor. Sin esa rendija, adentro no se puede trabajar. */
+  [1, -1].forEach((lado) => {
+    const g = new THREE.BoxGeometry(medioX * 2 + 0.4, 0.09, 1.45);
+    pintarPorVertice(g, (x) => {
+      const canal = 0.5 + 0.5 * Math.sin(x * 7.4);
+      return tmp.copy(cSombra).lerp(cTeja, canal).multiplyScalar(0.96);
+    });
+    poner(g, [0, cumbre + 0.62, lado * 0.62], [lado * 0.5, 0, 0]);
+    partes.push(g);
+  });
+  // los cuatro pies que levantan el caballete (por ahí sale el humo)
+  [-medioX + 1, -1.8, 1.8, medioX - 1].forEach((x) => {
+    const g = new THREE.BoxGeometry(0.09, 0.6, 0.09);
+    poner(g, [x, cumbre + 0.34, 0]);
+    partes.push(palo(g, { humo: 0.9 }));
+  });
+
+  return fusionarSeguro(partes, 'techo-enramada');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  3) La MOLIENDA: el molino de tres masas sobre su bancada                   */
+/* -------------------------------------------------------------------------- */
+
+/* El molino es la única pieza sin azar: sus medidas las manda la mecánica (las
+   tres masas tienen que quedar tangentes o no muerden la caña), no un ruido. */
+export function geomMolienda({ q = 1 } = {}) {
+  const partes = [];
+  const BANCADA = 0.85; // el molino va ALTO: el guarapo baja por gravedad
+
+  /* La bancada de mampostería. */
+  const base = new THREE.BoxGeometry(2.3, BANCADA, 1.9);
+  poner(base, [0, BANCADA * 0.5, 0]);
+  partes.push(
+    pintarPorVertice(base, (x, y, z, i, c) =>
+      c
+        .set(PAL.ladrillo)
+        .lerp(new THREE.Color(PAL.ladrilloClaro), ruidoFbm(x * 3 + 1, y * 3, z * 3))
+        .multiplyScalar(0.72 + 0.28 * clamp(y / BANCADA, 0, 1)),
+    ),
+  );
+
+  /* EL CASTILLO: el bastidor de hierro que aguanta las masas. Un molino de
+     trapiche trabaja a una presión bestia; el marco es lo más macizo que hay. */
+  [-0.62, 0.62].forEach((z) => {
+    const g = new THREE.BoxGeometry(1.5, 1.15, 0.16);
+    poner(g, [0, BANCADA + 0.58, z]);
+    partes.push(pintarPlano(g, PAL.hierro));
+  });
+  const techoCastillo = new THREE.BoxGeometry(1.6, 0.15, 1.5);
+  poner(techoCastillo, [0, BANCADA + 1.2, 0]);
+  partes.push(pintarPlano(techoCastillo, PAL.hierroLuz));
+
+  /* LAS TRES MASAS (los rodillos). Van estriadas a lo largo: esas ranuras son
+     las que muerden la caña y la arrastran. Sin estrías, el molino patina. */
+  const cHierro = new THREE.Color(PAL.hierro);
+  const cLuz = new THREE.Color(PAL.hierroLuz);
+  const tmp = new THREE.Color();
+  [-0.34, 0, 0.34].forEach((z, i) => {
+    const g = new THREE.CylinderGeometry(0.165, 0.165, 0.62, q > 0.8 ? 22 : 12, 1);
+    poner(g, [i === 1 ? 0.02 : 0, BANCADA + 0.55, z], [Math.PI / 2, 0, 0]);
+    pintarPorVertice(g, (x, y) => {
+      // estrías: franjas alrededor del rodillo (su eje corre en z)
+      const ang = Math.atan2(y - (BANCADA + 0.55), x);
+      const estria = 0.5 + 0.5 * Math.sin(ang * 26);
+      tmp.copy(cHierro).lerp(cLuz, estria * 0.55);
+      // el rodillo del medio es el que más muele: queda pulido y con guarapo
+      if (i === 1) tmp.lerp(new THREE.Color(PAL.guarapo), 0.16);
+      return tmp;
+    });
+    partes.push(g);
+    // los piñones de arriba, que sincronizan las tres masas
+    const p = new THREE.CylinderGeometry(0.19, 0.19, 0.085, q > 0.8 ? 16 : 9, 1);
+    poner(p, [0, BANCADA + 1.06, z], [Math.PI / 2, 0, 0]);
+    partes.push(pintarPlano(p, PAL.hierroLuz));
+  });
+
+  /* LA MESA DE ALIMENTACIÓN: por ahí se le mete la caña al molino, y por el
+     otro lado sale el bagazo. Tabla curada de tanto pasarle caña encima. */
+  const mesa = new THREE.BoxGeometry(1.35, 0.09, 1.25);
+  poner(mesa, [-1.35, BANCADA + 0.5, 0], [0, 0, 0.1]);
+  partes.push(palo(mesa, { claro: PAL.maderaClara, grano: 7 }));
+  [-1.85, -0.9].forEach((x) => {
+    const g = new THREE.BoxGeometry(0.09, 0.5, 0.09);
+    poner(g, [x, BANCADA + 0.25, -0.55]);
+    partes.push(palo(g));
+    const g2 = new THREE.BoxGeometry(0.09, 0.5, 0.09);
+    poner(g2, [x, BANCADA + 0.25, 0.55]);
+    partes.push(palo(g2));
+  });
+  // la bandeja de salida del bagazo, del otro lado
+  const salida = new THREE.BoxGeometry(1.0, 0.08, 1.1);
+  poner(salida, [1.2, BANCADA + 0.34, 0], [0, 0, -0.22]);
+  partes.push(palo(salida, { claro: PAL.maderaClara }));
+
+  /* EL MOTOR y su correa. Hoy casi todo trapiche de finca muele con motor; la
+     yunta de bueyes dando vueltas al palanquín es la forma vieja, y todavía se
+     ve, pero dibujar la de hoy es lo honesto. */
+  const motor = new THREE.BoxGeometry(0.62, 0.46, 0.42);
+  poner(motor, [-0.15, 0.28, -1.55]);
+  partes.push(pintarPlano(motor, PAL.hierro));
+  const patin = new THREE.BoxGeometry(0.8, 0.14, 0.6);
+  poner(patin, [-0.15, 0.07, -1.55]);
+  partes.push(pintarPlano(patin, PAL.tierra));
+  // polea del motor y polea del molino
+  const pol1 = new THREE.CylinderGeometry(0.17, 0.17, 0.07, 14, 1);
+  poner(pol1, [0.28, 0.34, -1.55], [0, 0, Math.PI / 2]);
+  partes.push(pintarPlano(pol1, PAL.hierroLuz));
+  const pol2 = new THREE.CylinderGeometry(0.30, 0.30, 0.07, q > 0.8 ? 18 : 10, 1);
+  poner(pol2, [0.28, BANCADA + 0.55, -0.78], [0, 0, Math.PI / 2]);
+  partes.push(pintarPlano(pol2, PAL.hierroLuz));
+  // la correa: dos tramos rectos entre las poleas
+  const dy = BANCADA + 0.55 - 0.34;
+  const dz = -0.78 + 1.55;
+  const largoC = Math.hypot(dy, dz);
+  [-0.17, 0.17].forEach((off) => {
+    const g = new THREE.BoxGeometry(0.05, largoC, 0.05);
+    poner(g, [0.28, 0.34 + dy * 0.5, -1.55 + dz * 0.5 + off * 0.9], [Math.atan2(dz, dy), 0, 0]);
+    partes.push(pintarPlano(g, PAL.hollin));
+  });
+
+  return fusionarSeguro(partes, 'molienda');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  4) La CANOA del guarapo (con su prelimpiador)                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * El canal de madera que lleva el jugo del molino a la primera paila. Va en
+ * BAJADA: el guarapo corre solo. En el camino pasa por el prelimpiador, un
+ * cajón donde se quedan la tierra, el bagacillo y la hoja que se colaron.
+ */
+export function geomCanoaGuarapo() {
+  const partes = [];
+  const largo = 3.9;
+  const caida = 0.22;
+
+  // el fondo y las dos paredes del canal
+  const fondo = new THREE.BoxGeometry(largo, 0.06, 0.30);
+  poner(fondo, [0, 0, 0], [0, 0, -Math.atan2(caida, largo)]);
+  partes.push(palo(fondo, { claro: PAL.maderaClara }));
+  [-0.17, 0.17].forEach((z) => {
+    const g = new THREE.BoxGeometry(largo, 0.17, 0.05);
+    poner(g, [0, 0.09, z], [0, 0, -Math.atan2(caida, largo)]);
+    partes.push(palo(g, { claro: PAL.maderaClara }));
+  });
+  // los caballetes que la sostienen
+  [-largo * 0.36, largo * 0.34].forEach((x, i) => {
+    const h = 1.15 - i * 0.1;
+    [-0.2, 0.2].forEach((z) => {
+      const g = new THREE.BoxGeometry(0.07, h, 0.07);
+      poner(g, [x, -h * 0.5 - 0.05, z]);
+      partes.push(palo(g));
+    });
+  });
+  // EL PRELIMPIADOR: el cajón que atrapa la basurita antes de que llegue al fuego
+  const caja = new THREE.BoxGeometry(0.62, 0.34, 0.52);
+  poner(caja, [-0.2, -0.06, 0]);
+  partes.push(palo(caja, { claro: PAL.maderaClara, grano: 6 }));
+
+  return fusionarSeguro(partes, 'canoa-guarapo');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  5) La HORNILLA y su chimenea                                               */
+/* -------------------------------------------------------------------------- */
+
+export function geomHornilla({ q = 1 } = {}, semilla = 205) {
+  const partes = [];
+  const x0 = -0.35;
+  const x1 = 5.05;
+  const largo = x1 - x0;
+  const cx = (x0 + x1) * 0.5;
+  const ancho = 1.5;
+  const alto = 1.05;
+
+  const cLadrillo = new THREE.Color(PAL.ladrillo);
+  const cClaro = new THREE.Color(PAL.ladrilloClaro);
+  const cCal = new THREE.Color(PAL.cal);
+  const cHollin = new THREE.Color(PAL.hollin);
+  const tmp = new THREE.Color();
+
+  /* EL CUERPO: un bloque largo de mampostería, repellado y encalado por partes,
+     con el TIZNE que se acumula alrededor de la boca del horno. Ese degradado a
+     negro hacia el extremo del fuego es lo que hace que se lea "aquí quema". */
+  const cuerpo = new THREE.BoxGeometry(largo, alto, ancho, Math.max(6, Math.round(20 * q)), 3, 3);
+  poner(cuerpo, [cx - cx, alto * 0.5, 0]); // se coloca luego desde la escena
+  pintarPorVertice(cuerpo, (x, y, z) => {
+    const wx = x + cx;
+    const n = ruidoFbm(wx * 2.6 + 3, y * 2.6, z * 2.6);
+    tmp.copy(cLadrillo).lerp(cClaro, n);
+    // el repello de cal, comido a manchas
+    tmp.lerp(cCal, smoothstep(0.42, 0.85, ruidoFbm(wx * 1.1 + 9, y * 1.1, z * 1.1)) * 0.55);
+    // EL TIZNE: crece hacia la boca del horno (el extremo +x) y hacia arriba
+    const cerca = smoothstep(1.6, 5.0, wx);
+    const arriba = clamp(y / alto, 0, 1);
+    tmp.lerp(cHollin, cerca * (0.35 + 0.5 * arriba));
+    // sombra de contacto contra el piso
+    tmp.multiplyScalar(0.68 + 0.32 * arriba);
+    return tmp;
+  });
+  partes.push(cuerpo);
+
+  /* La cornisa: el reborde donde se apoyan las pailas. */
+  const cornisa = new THREE.BoxGeometry(largo + 0.16, 0.1, ancho + 0.16);
+  poner(cornisa, [0, alto - 0.03, 0]);
+  partes.push(
+    pintarPorVertice(cornisa, (x) => {
+      const cerca = smoothstep(1.6, 5.0, x + cx);
+      return tmp.copy(cClaro).lerp(cHollin, cerca * 0.7);
+    }),
+  );
+
+  /* LA BOCA DEL HORNO, en el extremo caliente: el arco por donde se le echa el
+     bagazo. Se dibuja como un recuadro hundido y renegrido; la candela la pone
+     la escena encima (FuegoHornilla). */
+  const marco = new THREE.BoxGeometry(0.22, 0.78, 0.92);
+  poner(marco, [x1 - cx + 0.06, 0.45, 0]);
+  partes.push(pintarPlano(marco, PAL.ladrillo));
+  const hueco = new THREE.BoxGeometry(0.30, 0.60, 0.70);
+  poner(hueco, [x1 - cx + 0.10, 0.44, 0]);
+  partes.push(pintarPlano(hueco, PAL.hollin));
+  // el delantal de ceniza y brasa en el piso, frente a la boca
+  const ceniza = matojoHoja(0.55, semilla + 3, 0.35);
+  poner(ceniza, [x1 - cx + 0.62, 0.03, 0], [0, 0, 0], [1.5, 0.14, 1.3]);
+  partes.push(pintarPlano(ceniza, '#4a423a'));
+
+  /* LA CHIMENEA: el tiro que arrastra el humo a lo largo de toda la cámara y lo
+     saca por encima del techo. Va en el extremo FRÍO, al otro lado del fuego —
+     por eso la paila de allá es la más templada y es donde entra el jugo. */
+  const xCh = SITIOS.chimenea[0] - SITIOS.hornilla[0];
+  const cana = new THREE.BoxGeometry(0.8, 6.6, 0.8, 1, Math.max(4, Math.round(12 * q)), 1);
+  poner(cana, [xCh, 3.3, 0]);
+  pintarPorVertice(cana, (x, y, z) => {
+    const n = ruidoFbm(x * 3 + 5, y * 1.4, z * 3);
+    tmp.copy(cLadrillo).lerp(cClaro, n);
+    tmp.lerp(cCal, 0.3);
+    // el tizne baja desde la boca de arriba: el humo mancha su propia chimenea
+    tmp.lerp(cHollin, smoothstep(4.6, 6.6, y) * 0.5);
+    tmp.multiplyScalar(0.74 + 0.26 * clamp(y / 3, 0, 1));
+    return tmp;
+  });
+  partes.push(cana);
+  // el collarín donde la chimenea atraviesa el techo (la babeta de siempre)
+  const collar = new THREE.BoxGeometry(1.04, 0.2, 1.04);
+  poner(collar, [xCh, 4.42, 0]);
+  partes.push(pintarPlano(collar, PAL.tejaSombra));
+  // la capucha de arriba, para que no le entre el agua
+  const capucha = new THREE.BoxGeometry(1.1, 0.16, 1.1);
+  poner(capucha, [xCh, 6.72, 0]);
+  partes.push(pintarPlano(capucha, PAL.hollin));
+
+  return fusionarSeguro(partes, 'hornilla');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  6) Las PAILAS (metal: van con su propio material)                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * El tren de pailas. Dos de COBRE viejo y dos de ALUMINIO: es lo que se ve de
+ * verdad en una enramada — el cobre heredado conviviendo con las nuevas.
+ */
+export function geomPailas({ q = 1 } = {}) {
+  const partes = [];
+  const seg = q > 0.8 ? 22 : 12;
+  const cCobre = new THREE.Color(PAL.cobre);
+  const cCobreLuz = new THREE.Color(PAL.cobreLuz);
+  const cAlu = new THREE.Color(PAL.aluminio);
+  const cHollin = new THREE.Color(PAL.hollin);
+  const tmp = new THREE.Color();
+
+  PAILAS.forEach((p, i) => {
+    const cobre = i === 1 || i === 3; // las viejas, salteadas
+    const base = cobre ? cCobre : cAlu;
+    const luz = cobre ? cCobreLuz : new THREE.Color('#c8c4bb');
+
+    /* El fondo: media esfera achatada. Una paila panelera es ancha y poco
+       honda — así el jugo evapora rápido y se puede espumar cómodo. */
+    const bol = new THREE.SphereGeometry(p.r, seg, Math.max(5, Math.round(10 * q)), 0, Math.PI * 2, Math.PI / 2, Math.PI / 2);
+    poner(bol, [p.x, PAILA_Y, PAILA_Z], [0, 0, 0], [1, 0.62, 1]);
+    pintarPorVertice(bol, (_x, y) => {
+      const hondo = clamp((PAILA_Y - y) / (p.r * 0.62), 0, 1);
+      tmp.copy(base).lerp(luz, 1 - hondo);
+      // por debajo la paila está negra: ahí le pega la llama todo el día
+      tmp.lerp(cHollin, Math.pow(hondo, 1.6) * 0.75);
+      return tmp;
+    });
+    partes.push(bol);
+
+    /* El aro del borde, martillado y brillante de tanto rozarlo. */
+    const aro = new THREE.TorusGeometry(p.r, 0.042, 6, seg);
+    poner(aro, [p.x, PAILA_Y, PAILA_Z], [Math.PI / 2, 0, 0]);
+    partes.push(pintarPlano(aro, luz));
+  });
+
+  return fusionarSeguro(partes, 'pailas');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  7) El BAGAZO — la caña que calienta su propia miel                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Un montón de bagazo. NO es un montículo liso: el bagazo es FIBRA aplastada,
+ * y lo que lo delata son las hebras tiesas que se salen del montón por todos
+ * lados. Sin las hebras parece un montón de arena.
+ *
+ * @param {object} o
+ * @param {number} o.radio
+ * @param {number} o.alto
+ * @param {'humedo'|'secando'|'seco'} o.estado
+ * @param {number} [o.q]
+ * @param {number} [o.semilla]
+ */
+export function geomBagazo({ radio, alto, estado, q = 1, semilla = 207 }) {
+  const r = rng(semilla);
+  const partes = [];
+  const col =
+    estado === 'humedo' ? PAL.bagazoHumedo : estado === 'seco' ? PAL.bagazoSeco : PAL.bagazo;
+  const cBase = new THREE.Color(col);
+  const cAlto = new THREE.Color(estado === 'humedo' ? PAL.bagazo : PAL.bagazoSeco);
+  const tmp = new THREE.Color();
+
+  /* El cuerpo del montón: dos o tres masas deformadas, no una cúpula perfecta
+     (un montón de bagazo lo hace una pala, no un compás). */
+  const nMasas = q > 0.8 ? 3 : 2;
+  for (let i = 0; i < nMasas; i++) {
+    /* El achatado se calcula contra el RADIO de la masa, no contra el radio
+       nominal del montón: si no, el montón se hunde medio metro bajo el piso y
+       el bagazo aparece enterrado. Centro a 0,42·alto y semialtura ≈ 0,28·alto
+       dejan el montón apoyado en el suelo y de la altura pedida. */
+    const rMasa = radio * (0.72 + r() * 0.35);
+    const g = matojoHoja(rMasa, semilla + i * 5, 0.44);
+    poner(
+      g,
+      [(r() - 0.5) * radio * 0.7, alto * 0.42, (r() - 0.5) * radio * 0.6],
+      [r() * 0.3, r() * 3, r() * 0.3],
+      [1.15, alto / (rMasa * 1.9), 1.05],
+    );
+    pintarPorVertice(g, (x, y) => {
+      tmp.copy(cBase).lerp(cAlto, clamp(y / Math.max(0.1, alto), 0, 1));
+      const n = ruidoFbm(x * 4 + 2, y * 4, 1.5);
+      return tmp.multiplyScalar(0.82 + n * 0.36);
+    });
+    partes.push(g);
+  }
+
+  /* LAS HEBRAS: lo que convierte un montón en BAGAZO. Tiesas, sueltas y en
+     todas las direcciones — es fibra de caña exprimida, no paja peinada. */
+  const nHebras = Math.max(8, Math.round(26 * q));
+  for (let i = 0; i < nHebras; i++) {
+    const ang = r() * Math.PI * 2;
+    const rad = radio * (0.25 + r() * 0.8);
+    const largo = 0.22 + r() * 0.42;
+    const g = new THREE.BoxGeometry(largo, 0.018, 0.03);
+    poner(
+      g,
+      [Math.cos(ang) * rad, alto * (0.25 + r() * 0.75), Math.sin(ang) * rad],
+      [r() * 3, ang + (r() - 0.5), (r() - 0.5) * 1.7],
+    );
+    partes.push(pintarPlano(g, r() > 0.5 ? PAL.bagazoSeco : col));
+  }
+
+  return fusionarSeguro(partes, `bagazo-${estado}`);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  8) El ARRUME de caña cortada                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * La caña ya cortada, esperando el molino. Va DESPUNTADA (sin cogollo ni hoja:
+ * eso se deja en el lote) y arrumada de a montón. No puede esperar mucho: caña
+ * cortada que se demora empieza a fermentar y la panela sale mala.
+ */
+export function geomArrumeCana({ q = 1 } = {}, semilla = 208) {
+  const r = rng(semilla);
+  const partes = [];
+  const n = Math.max(9, Math.round(26 * q));
+  const cols = VARIEDADES.map((v) => new THREE.Color(v.tinte[0], v.tinte[1], v.tinte[2]));
+  const cCana = new THREE.Color(PAL_CANA.tallo);
+  const cNudo = new THREE.Color(PAL_CANA.talloNudo);
+  const tmp = new THREE.Color();
+
+  for (let i = 0; i < n; i++) {
+    const largo = 1.6 + r() * 0.55;
+    const cap = Math.floor(i / Math.max(1, Math.ceil(n / 4))); // cuatro capas
+    const g = new THREE.CylinderGeometry(0.028, 0.031, largo, 6, Math.max(6, Math.round(largo * 9 * q)));
+    const y = 0.05 + cap * 0.062 + r() * 0.03;
+    // cada capa cruzada sobre la anterior, como se arruma de verdad
+    const giro = (cap % 2 === 0 ? 0.15 : 1.35) + (r() - 0.5) * 0.5;
+    poner(
+      g,
+      [(r() - 0.5) * 1.2, y, (r() - 0.5) * 1.0],
+      [Math.PI / 2 + (r() - 0.5) * 0.12, giro, (r() - 0.5) * 0.1],
+    );
+    // la variedad de cada caña + el anillo del nudo, que aquí se ve de cerca
+    const variedad = cols[Math.floor(r() * cols.length)];
+    pintarPorVertice(g, (x, yy, z) => {
+      // el eje de la caña quedó tumbado: el nudo se lee sobre el eje largo
+      const s = Math.cos(giro) * x + Math.sin(giro) * z;
+      const f = s / 0.205;
+      const medio = Math.abs(Math.sin(Math.PI * f));
+      tmp.copy(cCana).lerp(cNudo, smoothstep(0.18, 0, medio) * 0.9);
+      tmp.multiply(variedad);
+      return tmp.multiplyScalar(0.72 + 0.28 * clamp((yy - 0.02) / 0.35, 0, 1));
+    });
+    partes.push(g);
+  }
+
+  return fusionarSeguro(partes, 'arrume-cana');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  9) El MOLDEO: mesa de batido y gaveras                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * La zona donde la miel se vuelve panela: la canoa de batido (donde se bate
+ * para que cristalice y aclare) y las GAVERAS — los moldes de madera con sus
+ * celdas, que le dan al bloque la forma con la que uno la conoce.
+ */
+export function geomMoldeo({ q = 1 } = {}, semilla = 209) {
+  const partes = [];
+  const r = rng(semilla);
+
+  /* LA MESA. Todo esto pasa a la altura de la cintura: se bate y se vacía de
+     pie, rápido, antes de que la miel cuaje en la batea. */
+  const tabla = new THREE.BoxGeometry(3.4, 0.1, 1.25);
+  poner(tabla, [0, 0.86, 0]);
+  partes.push(palo(tabla, { claro: PAL.maderaClara, grano: 8 }));
+  [-1.5, 1.5].forEach((x) => {
+    [-0.5, 0.5].forEach((z) => {
+      const g = new THREE.BoxGeometry(0.1, 0.86, 0.1);
+      poner(g, [x, 0.43, z]);
+      partes.push(palo(g));
+    });
+  });
+
+  /* LA CANOA DE BATIDO: batea honda de madera, a la izquierda de la mesa. */
+  const fondo = new THREE.BoxGeometry(1.15, 0.08, 0.66);
+  poner(fondo, [-1.05, 0.98, 0]);
+  partes.push(palo(fondo, { claro: PAL.maderaClara }));
+  [[-1.05, -0.37, 1.15, 0.06], [-1.05, 0.37, 1.15, 0.06]].forEach(([x, z, lx, lz]) => {
+    const g = new THREE.BoxGeometry(lx, 0.24, lz);
+    poner(g, [x, 1.09, z]);
+    partes.push(palo(g, { claro: PAL.maderaClara }));
+  });
+  [[-1.63, 0], [-0.47, 0]].forEach(([x, z]) => {
+    const g = new THREE.BoxGeometry(0.06, 0.24, 0.72);
+    poner(g, [x, 1.09, z]);
+    partes.push(palo(g, { claro: PAL.maderaClara }));
+  });
+  // EL MECEDOR: la paleta de madera con la que se bate. Recostada en la batea.
+  const mango = new THREE.CylinderGeometry(0.022, 0.026, 1.05, 6, 1);
+  poner(mango, [-0.62, 1.42, 0.2], [0, 0, -0.62]);
+  partes.push(palo(mango, { claro: PAL.maderaClara }));
+  const pala = new THREE.BoxGeometry(0.26, 0.05, 0.16);
+  poner(pala, [-1.06, 1.05, 0.2], [0, 0, -0.62]);
+  partes.push(palo(pala, { claro: PAL.maderaClara }));
+
+  /* LAS GAVERAS: dos marcos de madera con sus celdas. La miel batida se vacía
+     de una en una y ahí cuaja. Al enfriar, se voltea el molde y sale el bloque. */
+  const gavera = (ox, oz, celdas) => {
+    const largoG = 1.28;
+    const anchoG = 0.42;
+    const paso = largoG / celdas;
+    // los dos largueros del marco
+    [-anchoG / 2 - 0.025, anchoG / 2 + 0.025].forEach((z) => {
+      const g = new THREE.BoxGeometry(largoG + 0.1, 0.11, 0.05);
+      poner(g, [ox, 0.97, oz + z]);
+      partes.push(palo(g, { claro: PAL.maderaClara, grano: 9 }));
+    });
+    // los tabiques que hacen las celdas (uno de más: los dos topes)
+    for (let i = 0; i <= celdas; i++) {
+      const g = new THREE.BoxGeometry(0.045, 0.11, anchoG);
+      poner(g, [ox - largoG / 2 + i * paso, 0.97, oz]);
+      partes.push(palo(g, { claro: PAL.maderaClara, grano: 9 }));
+    }
+    // el piso del molde
+    const piso = new THREE.BoxGeometry(largoG + 0.1, 0.04, anchoG + 0.1);
+    poner(piso, [ox, 0.915, oz]);
+    partes.push(palo(piso, { claro: PAL.maderaClara }));
+  };
+  /* Dos gaveras sobre la mesa: la de adelante recién vaciada (la escena le pone
+     la panela caliente adentro) y la de atrás todavía vacía, esperando turno. */
+  gavera(0.42, 0.3, 6);
+  gavera(0.52, -0.32, 6);
+
+  /* EL ARRUME DE PANELA LISTA, en el extremo de la mesa: bloques cuajados y
+     apilados, esperando el papel. */
+  const nBloques = Math.max(4, Math.round(9 * q));
+  const cPanela = new THREE.Color(PAL.panela);
+  const cLuzP = new THREE.Color(PAL.panelaLuz);
+  const tmp = new THREE.Color();
+  for (let i = 0; i < nBloques; i++) {
+    const cap = Math.floor(i / 3);
+    const g = new THREE.BoxGeometry(0.2, 0.075, 0.13);
+    poner(
+      g,
+      [1.42 + (i % 3) * 0.02, 0.955 + cap * 0.08, -0.28 + (i % 3) * 0.2 + (r() - 0.5) * 0.02],
+      [0, (r() - 0.5) * 0.16, 0],
+    );
+    pintarPorVertice(g, (x, y) => tmp.copy(cPanela).lerp(cLuzP, clamp((y - 0.9) * 3, 0, 1) * 0.6));
+    partes.push(g);
+  }
+
+  return fusionarSeguro(partes, 'moldeo');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  10) Los ÚTILES: la gente que no está dibujada pero se nota                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * En una molienda trabajan varias personas a la vez — el que arrima la caña, el
+ * molinero, el HORNILLERO que manda el fuego y las pailas, el que espuma, el
+ * GAVERERO que vacía los moldes. Aquí no se dibuja a nadie: se dibuja lo que
+ * dejaron a mano. El sombrero colgado, el cucharón atravesado en la paila, la
+ * pala clavada en el bagazo, la ruana en el tirante, los baldes. Un lugar se
+ * siente habitado por sus cosas, no por muñecos.
+ */
+export function geomUtiles({ q = 1 } = {}, semilla = 210) {
+  const partes = [];
+  const r = rng(semilla);
+
+  /* EL CUCHARÓN espumador, atravesado sobre la segunda paila. Con eso se retira
+     la CACHAZA: la espuma verdosa que sube al calentar el jugo y que se lleva la
+     suciedad. No se bota — se va para los animales o para el abono. */
+  const cuchara = new THREE.SphereGeometry(0.17, 12, 6, 0, Math.PI * 2, Math.PI / 2, Math.PI / 2);
+  poner(cuchara, [PAILAS[1].x + 0.3, PAILA_Y + 0.12, PAILA_Z - 0.1], [0, 0, 0], [1, 0.45, 1]);
+  partes.push(pintarPlano(cuchara, PAL.aluminio));
+  const palo1 = new THREE.CylinderGeometry(0.02, 0.024, 1.3, 6, 1);
+  poner(palo1, [PAILAS[1].x - 0.32, PAILA_Y + 0.24, PAILA_Z - 0.1], [0, 0.2, Math.PI / 2 - 0.16]);
+  partes.push(palo(palo1, { claro: PAL.maderaClara }));
+
+  /* EL SOMBRERO en un horcón: el que llegó, se lo quitó y se metió al calor. */
+  const copa = new THREE.CylinderGeometry(0.14, 0.16, 0.13, 12, 1);
+  poner(copa, [-2.1, 2.35, 4.05], [0.35, 0, 0.1]);
+  partes.push(pintarPlano(copa, '#d8c79a'));
+  const ala = new THREE.CylinderGeometry(0.27, 0.27, 0.02, 14, 1);
+  poner(ala, [-2.1, 2.29, 4.06], [0.35, 0, 0.1]);
+  partes.push(pintarPlano(ala, '#cbb887'));
+
+  /* LA RUANA doblada sobre el tirante. */
+  const ruana = new THREE.BoxGeometry(0.5, 0.62, 0.09);
+  poner(ruana, [-4.1, 2.62, 0.9], [0.06, 0, 0.04]);
+  partes.push(pintarPlano(ruana, '#7d5a4a'));
+  const ruana2 = new THREE.BoxGeometry(0.48, 0.4, 0.08);
+  poner(ruana2, [-4.1, 2.66, 0.78], [-0.1, 0, 0]);
+  partes.push(pintarPlano(ruana2, '#8e6a56'));
+
+  /* LA PALA clavada en el bagazo de la boca del horno. */
+  const cabo = new THREE.CylinderGeometry(0.022, 0.026, 1.35, 6, 1);
+  poner(cabo, [5.95, 0.72, -0.3], [0.28, 0.4, 0.34]);
+  partes.push(palo(cabo, { claro: PAL.maderaClara }));
+  const hoja = new THREE.BoxGeometry(0.26, 0.02, 0.3);
+  poner(hoja, [5.7, 0.14, -0.42], [0.28, 0.4, 0.34]);
+  partes.push(pintarPlano(hoja, PAL.hierroLuz));
+
+  /* Dos BALDES: uno con agua para las manos, otro para acarrear miel. */
+  [
+    { x: -2.6, z: 1.0, col: PAL.hierroLuz },
+    { x: 3.0, z: 3.4, col: PAL.aluminio },
+  ].forEach((b) => {
+    const g = new THREE.CylinderGeometry(0.17, 0.13, 0.3, 10, 1, true);
+    poner(g, [b.x, 0.15, b.z], [0, r() * 3, (r() - 0.5) * 0.12]);
+    partes.push(pintarPlano(g, b.col));
+  });
+
+  /* EL MACHETE recostado en el arrume de caña. */
+  const mCabo = new THREE.BoxGeometry(0.13, 0.035, 0.035);
+  poner(mCabo, [-5.2, 0.42, 3.3], [0, 0.5, 1.15]);
+  partes.push(pintarPlano(mCabo, PAL.maderaOscura));
+  const mHoja = new THREE.BoxGeometry(0.52, 0.012, 0.07);
+  poner(mHoja, [-5.32, 0.72, 3.36], [0, 0.5, 1.15]);
+  partes.push(pintarPlano(mHoja, '#b8b4ac'));
+
+  if (q > 0.55) {
+    /* Un cajón de gaveras vacías esperando turno, apilado contra un horcón. */
+    for (let i = 0; i < 3; i++) {
+      const g = new THREE.BoxGeometry(1.2, 0.1, 0.42);
+      poner(g, [2.2, 0.08 + i * 0.12, 3.9], [0, (r() - 0.5) * 0.2, 0]);
+      partes.push(palo(g, { claro: PAL.maderaClara, grano: 9 }));
+    }
+  }
+
+  return fusionarSeguro(partes, 'utiles-trapiche');
+}


### PR DESCRIPTION
Un mundo de **dos mitades que se necesitan**: el cañaveral y la enramada del trapiche. La lección es el camino entre las dos — cómo una mata de más de cuatro metros termina siendo un bloque de panela que cabe en la mano.

Solo agrega archivos. **No toca `Valle3D.jsx`, `composicionValle3D.jsx` ni nada con PR abierto** (casa, invernadero, lechería, cafetal, aguacatal, frutales, criaturas nocturnas): 11 archivos nuevos, 0 modificados.

## La caña como planta

- **Tallo con nudos y entrenudos**: el radio ENGRUESA en cada nudo y el anillo nodal va horneado más pálido. 44 anillos por tallo en la cepa de primer plano — con menos, la banda nodal se aliasea y la caña vuelve a parecer un tubo liso.
- **Hoja acintada**: cinta de más de un metro, doblada en V sobre su nervadura central, que se pinta pálida (la firma de la gramínea). Nacen alternas en dos filas opuestas, como toda gramínea.
- **Chala**: la hoja SECA colgando del tercio bajo. Sin esto un cañaveral parece un guadual.
- **Penacho**: la panícula plumosa, sembrada sobre una punta REAL de tallo, y anclada al pie de la cepa para que no se quede flotando cuando la caña se mece.
- **Variedad por instancia** (verde, amarilla, morada, rayada) sobre un tallo neutro. Hoja y tallo van en mallas aparte a propósito: así el morado del tallo no le mancha el follaje.

## Que se sienta ALTO

La cepa mide 3,4–4,7 m: entre dos y tres veces una persona. Pero **eso no se puede contar desde un plano general** — de lejos todo se ve chiquito. Por eso cada paso de la lección lleva su encuadre, y el paso 1 mete la cámara a **1,55 m del suelo dentro de un pasillo entre surcos**, mirando hacia arriba, con caña cerrada a lado y lado. Al terminar el viaje la cámara se la devuelve al dedo del que está mirando.

## El trapiche: todo está por una razón física

- La enramada va **alta** (2,95 m al alero, 5,0 al caballete) y **abierta** de lados porque adentro hay una hornilla prendida todo el día. El caballete va **alzado** con su boquete: por ahí se escapan el humo y el vapor.
- La molienda va sobre **bancada elevada** porque el guarapo baja a las pailas por gravedad.
- La hornilla es **una sola cámara larga**: boca en un extremo, chimenea en el otro. Las cuatro pailas se ordenan por el calor que reciben — el jugo entra por la más fría y camina hacia el fuego concentrándose. Lo que hay adentro de cada una es distinto: guarapo verdoso con su cachaza, hervor, hervor, y miel oscura de punteo. Un vistazo cuenta el proceso.
- El bagazo aparece en **tres estados** (mojado saliendo del molino, secando en la bagacera, seco al pie de la boca): la caña calienta su propia miel.

## La luz está motivada

La fuente es la boca del horno quemando bagazo. `fuerzaDeFranja` cuelga de la hora del valle: de mañana es un acento tibio, al atardecer empieza a ganarle al cielo, de noche es lo único que alumbra la enramada. Vapor por paila (más donde más hierve) y humo de chimenea, ambos orientados a la cámara uno por uno.

**Sin figuras humanas**: el lugar se siente habitado por sus cosas — el sombrero en el horcón, el cucharón atravesado en la paila, la pala clavada en el bagazo, la ruana en el tirante.

## Los errores de esta tanda, atendidos

- **Silueta a media distancia** (lo del cafetal): muro de cañaveral de borde rasgado detrás del lote instanciado. A media distancia un cañaveral es un MURO, no una fila de conos.
- **`mergeGeometries` null en silencio**: todo pasa por `fusionarSeguro`, y hay un test que lo verifica pieza por pieza.
- **Nada de plantilla**: dos variantes de mata, giro y escala por instancia, variedades mezcladas, claros donde ya pasó el corte, y la densidad baja a manchas (no en una franja de bordes rectos).
- **Paleta**: familia atmosférica `plaza` (dorado seco de tierra baja), distinta del `corral` del cafetal.

## Lo que el chequeo headless cazó antes de desplegar

El plano firma **no funcionaba** y tres bugs no daban ningún error:

1. El presupuesto repartido en un lote enorme daba un cañaveral ralo: **4 cepas** alrededor del pasillo. Ahora la cepa viene en dos calidades (cerca / lejos) y caben **213 cepas en menos triángulos que las 112 de antes**. El pasillo pasa a **10–11 cepas** en todo el recorrido.
2. El eje del pasillo estaba escrito a mano y **el surco ondula**: la cámara arrancaba dentro de una cepa. Ahora sale de `pasilloCanaveral(z)`, calculado con las mismas constantes de la siembra.
3. `maxPolarAngle` a 1,5 impedía que la cámara quedara por debajo de su punto de mira — o sea que enderezaba el encuadre justo cuando uno mira hacia arriba.

## Verificación

- `tsc` 0 errores · `eslint` limpio · el grafo de imports completo empaqueta con esbuild.
- **32 tests** (`canaTrapiche.geom.test.js`) sobre lo que no se ve leyendo el código y no falla cuando se rompe: que las mallas fusionen, que la caña le siga pasando por encima a una persona, que el pasillo esté tupido y despejado, que los cinco encuadres caigan dentro de los límites de OrbitControls y sobre el suelo, y que el copy vaya en usted y sin voseo.
- Presupuesto: **827K tris en 12 draw-calls** (alto) · 90K en 6 (medio) · 13K en 3 (bajo). El trapiche entero son 12K tris en 11 draw-calls.
- Autocontenido: cero CDN, cero imágenes externas. Móvil-first, device-tiering real, `reducedMotion` monta el mundo quieto pero presente.

**Falta el cableado a ruta y la captura** — van aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
