### PR TITLE
art(mundos): yuca y quinua — el arranque de la raíz y el campo de panojas

### DIFF
--- a/scripts/diag/encuadre-mundo.mjs
+++ b/scripts/diag/encuadre-mundo.mjs
@@ -1,0 +1,242 @@
+/*
+ * encuadre-mundo — ¿QUÉ SE VE de verdad por la cámara de un mundo 3D?
+ *
+ * Medir la geometría NO es ver la escena. Un mundo puede tener las plantas del
+ * tamaño correcto, la distribución correcta y el relieve correcto, y aun así
+ * entregar un encuadre donde el sujeto no aparece porque la cámara quedó
+ * enterrada en la ladera y el 60% del cuadro es loma vacía. Eso ya pasó, con
+ * números "correctos" de respaldo.
+ *
+ * Este script traza RAYOS por la retícula del encuadre real (la misma posición,
+ * la misma mirada y el mismo fov que monta la escena) contra la MISMA función
+ * de altura del terreno, y reporta el reparto del cuadro: cuánto es cielo,
+ * cuánto suelo, y a qué distancia cae cada golpe. Con eso se sabe si el sujeto
+ * está en cuadro y en qué tercio, sin GPU y sin captura.
+ *
+ * No reemplaza mirar la foto — la reemplaza CUANDO NO HAY foto todavía, y
+ * atrapa el desastre antes de gastar un deploy en descubrirlo.
+ *
+ * Uso:  node scripts/diag/encuadre-mundo.mjs yuca
+ *       node scripts/diag/encuadre-mundo.mjs quinua
+ */
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const AQUI = dirname(fileURLToPath(import.meta.url));
+const RAIZ = resolve(AQUI, '../..');
+
+/* Los mundos que este diagnóstico sabe mirar. Cada uno declara de dónde saca su
+   función de altura, su cámara y cuál es el SUJETO que no puede faltar. */
+const MUNDOS = {
+  /* El PAPAL es la línea base: un mundo ya aprobado y desplegado. Sirve para
+     calibrar qué reparto de cuadro se considera bueno en esta casa, en vez de
+     inventarse umbrales de la nada. Su cámara no declara constante CAMARA, así
+     que va escrita aquí tal como la monta EscenaPapaVivo. */
+  papa: {
+    modulo: 'src/visual/mundo3d/papa/floraPapa.geom.js',
+    altura: 'alturaLadera',
+    camaraFija: { pos: [2, 5.4, 15.5], mira: [0, 3.8, -3], fov: 46 },
+    sujeto: { nombre: 'el claro de la cosecha', clave: 'SITIO_COSECHA', alto: 0.9 },
+  },
+  yuca: {
+    modulo: 'src/visual/mundo3d/yuca/floraYuca.geom.js',
+    altura: 'alturaYucal',
+    camaraModulo: 'src/visual/mundo3d/yuca/EscenaYucaViva.jsx',
+    sujeto: { nombre: 'el claro del arranque', clave: 'SITIO_ARRANQUE', alto: 0.9 },
+  },
+  quinua: {
+    modulo: 'src/visual/mundo3d/quinua/floraQuinua.geom.js',
+    altura: 'alturaQuinual',
+    camaraModulo: 'src/visual/mundo3d/quinua/EscenaQuinuaViva.jsx',
+    sujeto: { nombre: 'la era de la trilla', clave: 'SITIO_TRILLA', alto: 0.9 },
+  },
+};
+
+/* La cámara se lee del propio archivo de la escena (constante CAMARA), para que
+   este diagnóstico no pueda quedar desfasado de lo que la escena monta. */
+async function leerCamara(rutaEscena) {
+  const { readFile } = await import('node:fs/promises');
+  const txt = await readFile(resolve(RAIZ, rutaEscena), 'utf8');
+  const num = '(-?\\d+(?:\\.\\d+)?)';
+  const trio = `\\[\\s*${num}\\s*,\\s*${num}\\s*,\\s*${num}\\s*\\]`;
+  // ojo: el `[^\n]*?` (no `[^\[]*`) es a propósito — la anotación de tipo
+  // `/** @type {[number, number, number]} */` trae corchetes por delante y con
+  // la clase negada de corchete el match nunca llega a los números de verdad.
+  const rep = txt.match(new RegExp(`reposo:[^\\n]*?${trio}`));
+  const mir = txt.match(new RegExp(`mirada:[^\\n]*?${trio}`));
+  const fov = txt.match(new RegExp(`fov:\\s*${num}`));
+  if (!rep || !mir || !fov) {
+    throw new Error(`no encontré la constante CAMARA en ${rutaEscena}`);
+  }
+  return {
+    pos: rep.slice(1, 4).map(Number),
+    mira: mir.slice(1, 4).map(Number),
+    fov: Number(fov[1]),
+  };
+}
+
+const sub = (a, b) => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+const cruz = (a, b) => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+];
+const norm = (v) => {
+  const n = Math.hypot(v[0], v[1], v[2]) || 1;
+  return [v[0] / n, v[1] / n, v[2] / n];
+};
+
+/* Marcha por el rayo hasta que baje del terreno. Paso fino cerca (donde está el
+   sujeto) y grueso lejos: exacto donde importa, barato donde no. */
+function golpear(origen, dir, altura, maxDist = 90) {
+  let t = 0.2;
+  let prevArriba = true;
+  while (t < maxDist) {
+    const p = [origen[0] + dir[0] * t, origen[1] + dir[1] * t, origen[2] + dir[2] * t];
+    // fuera del heightfield: se acabó el mundo, es cielo/telón
+    if (Math.abs(p[0]) > 20 || p[2] < -19 || p[2] > 19) return null;
+    const h = altura(p[0], p[2]);
+    if (p[1] <= h) {
+      if (prevArriba) return { t, punto: p, altura: h };
+      return { t, punto: p, altura: h };
+    }
+    prevArriba = false;
+    t += t < 18 ? 0.16 : 0.55;
+  }
+  return null;
+}
+
+async function main() {
+  const cual = process.argv[2] || 'yuca';
+  const def = MUNDOS[cual];
+  if (!def) {
+    console.error(`mundo desconocido: ${cual}. Conozco: ${Object.keys(MUNDOS).join(', ')}`);
+    process.exit(2);
+  }
+
+  const geom = await import(resolve(RAIZ, def.modulo));
+  const altura = geom[def.altura];
+  const cam = def.camaraFija || (await leerCamara(def.camaraModulo));
+  const sujeto = geom[def.sujeto.clave];
+
+  const adelante = norm(sub(cam.mira, cam.pos));
+  const derecha = norm(cruz(adelante, [0, 1, 0]));
+  const arriba = cruz(derecha, adelante);
+
+  // retícula del encuadre (móvil-first: 9:16 es el caso apretado, pero el
+  // lienzo real es más ancho; se mide 3:2, que es el que se fotografía)
+  const COLS = 48;
+  const FILAS = 30;
+  const aspecto = 3 / 2;
+  const mediaV = Math.tan((cam.fov * Math.PI) / 180 / 2);
+  const mediaH = mediaV * aspecto;
+
+  let cielo = 0;
+  let suelo = 0;
+  const porTercio = [0, 0, 0]; // golpes de suelo por tercio vertical del cuadro
+  let masCerca = Infinity;
+  let masLejos = 0;
+  let sumaDist = 0;
+
+  // ¿en qué parte del cuadro cae el SUJETO?
+  let sujetoFila = null;
+  let sujetoCol = null;
+
+  for (let f = 0; f < FILAS; f++) {
+    for (let cN = 0; cN < COLS; cN++) {
+      const sx = ((cN + 0.5) / COLS) * 2 - 1;
+      const sy = 1 - ((f + 0.5) / FILAS) * 2;
+      const dir = norm([
+        adelante[0] + derecha[0] * sx * mediaH + arriba[0] * sy * mediaV,
+        adelante[1] + derecha[1] * sx * mediaH + arriba[1] * sy * mediaV,
+        adelante[2] + derecha[2] * sx * mediaH + arriba[2] * sy * mediaV,
+      ]);
+      const g = golpear(cam.pos, dir, altura);
+      if (!g) {
+        cielo += 1;
+        continue;
+      }
+      suelo += 1;
+      porTercio[Math.min(2, Math.floor((f / FILAS) * 3))] += 1;
+      masCerca = Math.min(masCerca, g.t);
+      masLejos = Math.max(masLejos, g.t);
+      sumaDist += g.t;
+
+      // ¿este rayo cayó encima del sujeto?
+      const dx = g.punto[0] - sujeto[0];
+      const dz = g.punto[2] - sujeto[1];
+      if (dx * dx + dz * dz < 6.5) {
+        if (sujetoFila === null) sujetoFila = f;
+        sujetoCol = cN;
+      }
+    }
+  }
+
+  const total = COLS * FILAS;
+  const pct = (n) => `${((n / total) * 100).toFixed(1)}%`;
+
+  console.log(`\n═══ ENCUADRE DE «${cual}» ═══`);
+  console.log(
+    `cámara ${cam.pos.map((v) => v.toFixed(1)).join(', ')} → mira ${cam.mira
+      .map((v) => v.toFixed(1))
+      .join(', ')}  ·  fov ${cam.fov}°  ·  3:2`,
+  );
+  console.log(`\n  cielo/telón : ${pct(cielo)}`);
+  console.log(`  terreno     : ${pct(suelo)}`);
+  console.log(
+    `  reparto vertical del terreno — tercio alto ${pct(porTercio[0])} · medio ${pct(
+      porTercio[1],
+    )} · bajo ${pct(porTercio[2])}`,
+  );
+  if (suelo > 0) {
+    console.log(
+      `  distancia   : más cerca ${masCerca.toFixed(1)} m · promedio ${(sumaDist / suelo).toFixed(
+        1,
+      )} m · más lejos ${masLejos.toFixed(1)} m`,
+    );
+  }
+
+  console.log(`\n  SUJETO — ${def.sujeto.nombre}:`);
+  if (sujetoFila === null) {
+    console.log('  ✗ NO APARECE EN CUADRO. La cámara no lo está mirando.');
+  } else {
+    const tercioV = ['alto', 'medio', 'bajo'][Math.min(2, Math.floor((sujetoFila / FILAS) * 3))];
+    const tercioH = ['izquierda', 'centro', 'derecha'][
+      Math.min(2, Math.floor((sujetoCol / COLS) * 3))
+    ];
+    console.log(`  ✓ en cuadro, tercio ${tercioV} · ${tercioH}`);
+  }
+
+  /* Los avisos que este diagnóstico existe para dar. */
+  /* Los umbrales NO son inventados: salen de medir el papal, que es un mundo ya
+     aprobado y desplegado (`node scripts/diag/encuadre-mundo.mjs papa`):
+       cielo 32.8% · terreno 67.2% · tercio alto 0.6% · más cerca 10.4 m
+     Es decir, la casa compone en plano general de diorama —el tercio alto casi
+     libre de terreno y el sujeto abajo—, NO en primer plano cercano. Un umbral
+     de "falta primer plano" en 6 m marcaba en rojo hasta al propio papal. */
+  const avisos = [];
+  if (cielo / total < 0.12) avisos.push('casi no hay cielo: el cuadro se siente tapiado');
+  if (cielo / total > 0.55) avisos.push('demasiado cielo: el mundo queda vacío abajo');
+  if (porTercio[0] / total > 0.1) {
+    avisos.push(
+      'el tercio ALTO tiene terreno encima del umbral de la casa (papal: 0.6%): la cámara está mirando contra la loma',
+    );
+  }
+  if (suelo > 0 && masCerca > 14) {
+    avisos.push('nada cerca de la cámara: la escena se ve lejana incluso para el estilo de la casa');
+  }
+  if (sujetoFila === null) avisos.push('EL SUJETO NO ESTÁ EN CUADRO — esto es un bloqueante');
+
+  if (avisos.length) {
+    console.log('\n  ⚠ avisos:');
+    avisos.forEach((a) => console.log(`    · ${a}`));
+  } else {
+    console.log('\n  ✓ sin avisos de encuadre');
+  }
+  console.log('');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/diag/encuadre-mundo.mjs
+++ b/scripts/diag/encuadre-mundo.mjs
@@ -36,17 +36,20 @@ const MUNDOS = {
     modulo: 'src/visual/mundo3d/papa/floraPapa.geom.js',
     altura: 'alturaLadera',
     camaraFija: { pos: [2, 5.4, 15.5], mira: [0, 3.8, -3], fov: 46 },
-    sujeto: { nombre: 'el claro de la cosecha', clave: 'SITIO_COSECHA', alto: 0.9 },
+    sujeto: { nombre: 'el claro de la cosecha', clave: 'SITIO_COSECHA' },
+    altoCultivo: 0.45, // la mata de papa es bajita y aporcada
   },
   yuca: {
     modulo: 'src/visual/mundo3d/yuca/floraYuca.geom.js',
     altura: 'alturaYucal',
     sujeto: { nombre: 'el claro del arranque', clave: 'SITIO_ARRANQUE' },
+    altoCultivo: 2.3, // la mata de yuca adulta
   },
   quinua: {
     modulo: 'src/visual/mundo3d/quinua/floraQuinua.geom.js',
     altura: 'alturaQuinual',
     sujeto: { nombre: 'la era de la trilla', clave: 'SITIO_TRILLA' },
+    altoCultivo: 1.6, // la mata de quinua con su panoja
   },
 };
 
@@ -61,21 +64,28 @@ const norm = (v) => {
   return [v[0] / n, v[1] / n, v[2] / n];
 };
 
-/* Marcha por el rayo hasta que baje del terreno. Paso fino cerca (donde está el
-   sujeto) y grueso lejos: exacto donde importa, barato donde no. */
-function golpear(origen, dir, altura, maxDist = 90) {
+/*
+ * Marcha por el rayo hasta que toque el mundo. Paso fino cerca (donde está el
+ * sujeto) y grueso lejos: exacto donde importa, barato donde no.
+ *
+ * OJO — golpea contra el TERRENO MÁS EL DOSEL DEL CULTIVO, no contra el terreno
+ * pelado. Es la diferencia entre medir bien y engañarse: una yuca mide 2,3 m y
+ * una quinua 1,6 m, así que lo que de verdad llena el cuadro de esos mundos es
+ * la planta, no el suelo bajo la planta. Midiendo solo terreno, un quinual
+ * denso "ocupaba 8,6% del cuadro" — y lo que ocupa 8,6% es el barro entre las
+ * matas, que es justo lo que no se ve.
+ */
+function golpear(origen, dir, altura, dosel, maxDist = 90) {
   let t = 0.2;
-  let prevArriba = true;
   while (t < maxDist) {
     const p = [origen[0] + dir[0] * t, origen[1] + dir[1] * t, origen[2] + dir[2] * t];
     // fuera del heightfield: se acabó el mundo, es cielo/telón
     if (Math.abs(p[0]) > 20 || p[2] < -19 || p[2] > 19) return null;
-    const h = altura(p[0], p[2]);
-    if (p[1] <= h) {
-      if (prevArriba) return { t, punto: p, altura: h };
-      return { t, punto: p, altura: h };
+    const suelo = altura(p[0], p[2]);
+    const sobre = dosel(p[0], p[2]);
+    if (p[1] <= suelo + sobre) {
+      return { t, punto: p, altura: suelo, enCultivo: sobre > 0.01 };
     }
-    prevArriba = false;
     t += t < 18 ? 0.16 : 0.55;
   }
   return null;
@@ -98,6 +108,12 @@ async function main() {
   const cam = def.camaraFija || { ...geom.CAMARA, pos: geom.CAMARA.reposo, mira: geom.CAMARA.mirada };
   if (!cam || !cam.pos) throw new Error(`el módulo de «${cual}» no exporta CAMARA`);
   const sujeto = geom[def.sujeto.clave];
+  /* El dosel: cuánto levanta el cultivo sobre el suelo en cada punto del lote.
+     Se apoya en el `dentroLote` del propio mundo, así que respeta los claros
+     (la era, el patio, el sitio de cosecha) sin duplicar esa lógica aquí. */
+  const alto = def.altoCultivo || 0;
+  const dosel = (x, z) =>
+    geom.dentroLote && alto ? geom.dentroLote(x, z) * alto : 0;
 
   const adelante = norm(sub(cam.mira, cam.pos));
   const derecha = norm(cruz(adelante, [0, 1, 0]));
@@ -114,6 +130,7 @@ async function main() {
   let cielo = 0;
   let suelo = 0;
   const porTercio = [0, 0, 0]; // golpes de suelo por tercio vertical del cuadro
+  let enLote = 0; // rayos que caen sobre el cultivo sembrado
   let masCerca = Infinity;
   let masLejos = 0;
   let sumaDist = 0;
@@ -131,7 +148,7 @@ async function main() {
         adelante[1] + derecha[1] * sx * mediaH + arriba[1] * sy * mediaV,
         adelante[2] + derecha[2] * sx * mediaH + arriba[2] * sy * mediaV,
       ]);
-      const g = golpear(cam.pos, dir, altura);
+      const g = golpear(cam.pos, dir, altura, dosel);
       if (!g) {
         cielo += 1;
         continue;
@@ -149,6 +166,11 @@ async function main() {
         if (sujetoFila === null) sujetoFila = f;
         sujetoCol = cN;
       }
+
+      // ¿y cayó sobre el CULTIVO? En un mundo cuyo entregable es la planta
+      // misma (el campo de color de la quinua), esto importa más que dónde cae
+      // tal o cual rincón: mide si el cultivo llena el cuadro.
+      if (g.enCultivo) enLote += 1;
     }
   }
 
@@ -175,6 +197,8 @@ async function main() {
       )} m · más lejos ${masLejos.toFixed(1)} m`,
     );
   }
+
+  console.log(`  sobre el CULTIVO sembrado: ${pct(enLote)} del cuadro`);
 
   console.log(`\n  SUJETO — ${def.sujeto.nombre}:`);
   if (sujetoFila === null) {
@@ -206,6 +230,9 @@ async function main() {
     avisos.push('nada cerca de la cámara: la escena se ve lejana incluso para el estilo de la casa');
   }
   if (sujetoFila === null) avisos.push('EL SUJETO NO ESTÁ EN CUADRO — esto es un bloqueante');
+  if (enLote / total < 0.12) {
+    avisos.push('el cultivo sembrado ocupa muy poco cuadro: se está fotografiando el paisaje, no el cultivo');
+  }
 
   if (avisos.length) {
     console.log('\n  ⚠ avisos:');

--- a/scripts/diag/encuadre-mundo.mjs
+++ b/scripts/diag/encuadre-mundo.mjs
@@ -41,39 +41,14 @@ const MUNDOS = {
   yuca: {
     modulo: 'src/visual/mundo3d/yuca/floraYuca.geom.js',
     altura: 'alturaYucal',
-    camaraModulo: 'src/visual/mundo3d/yuca/EscenaYucaViva.jsx',
-    sujeto: { nombre: 'el claro del arranque', clave: 'SITIO_ARRANQUE', alto: 0.9 },
+    sujeto: { nombre: 'el claro del arranque', clave: 'SITIO_ARRANQUE' },
   },
   quinua: {
     modulo: 'src/visual/mundo3d/quinua/floraQuinua.geom.js',
     altura: 'alturaQuinual',
-    camaraModulo: 'src/visual/mundo3d/quinua/EscenaQuinuaViva.jsx',
-    sujeto: { nombre: 'la era de la trilla', clave: 'SITIO_TRILLA', alto: 0.9 },
+    sujeto: { nombre: 'la era de la trilla', clave: 'SITIO_TRILLA' },
   },
 };
-
-/* La cámara se lee del propio archivo de la escena (constante CAMARA), para que
-   este diagnóstico no pueda quedar desfasado de lo que la escena monta. */
-async function leerCamara(rutaEscena) {
-  const { readFile } = await import('node:fs/promises');
-  const txt = await readFile(resolve(RAIZ, rutaEscena), 'utf8');
-  const num = '(-?\\d+(?:\\.\\d+)?)';
-  const trio = `\\[\\s*${num}\\s*,\\s*${num}\\s*,\\s*${num}\\s*\\]`;
-  // ojo: el `[^\n]*?` (no `[^\[]*`) es a propósito — la anotación de tipo
-  // `/** @type {[number, number, number]} */` trae corchetes por delante y con
-  // la clase negada de corchete el match nunca llega a los números de verdad.
-  const rep = txt.match(new RegExp(`reposo:[^\\n]*?${trio}`));
-  const mir = txt.match(new RegExp(`mirada:[^\\n]*?${trio}`));
-  const fov = txt.match(new RegExp(`fov:\\s*${num}`));
-  if (!rep || !mir || !fov) {
-    throw new Error(`no encontré la constante CAMARA en ${rutaEscena}`);
-  }
-  return {
-    pos: rep.slice(1, 4).map(Number),
-    mira: mir.slice(1, 4).map(Number),
-    fov: Number(fov[1]),
-  };
-}
 
 const sub = (a, b) => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
 const cruz = (a, b) => [
@@ -116,7 +91,12 @@ async function main() {
 
   const geom = await import(resolve(RAIZ, def.modulo));
   const altura = geom[def.altura];
-  const cam = def.camaraFija || (await leerCamara(def.camaraModulo));
+  /* La cámara sale del PROPIO módulo del mundo (constante CAMARA, que vive
+     junto a la geografía): así este diagnóstico no puede quedar desfasado de lo
+     que la escena monta de verdad. El papal, que es anterior a esa convención,
+     la trae escrita a mano aquí arriba. */
+  const cam = def.camaraFija || { ...geom.CAMARA, pos: geom.CAMARA.reposo, mira: geom.CAMARA.mirada };
+  if (!cam || !cam.pos) throw new Error(`el módulo de «${cual}» no exporta CAMARA`);
   const sujeto = geom[def.sujeto.clave];
 
   const adelante = norm(sub(cam.mira, cam.pos));

--- a/src/mockups/QuinuaViva3D.css
+++ b/src/mockups/QuinuaViva3D.css
@@ -1,0 +1,249 @@
+/*
+ * QuinuaViva3D.css — vitrina del mundo de la quinua (#/mockups/quinua-viva-3d).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Paleta de tierra fría con el morado de Tunkahuán de acento — que es el color
+ * que hace la foto de este mundo. Solo opacity/transform.
+ */
+
+.qviva {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  /* la ladera alta bajo la hora clara (familia `ladera` de la paleta madre) */
+  background: linear-gradient(180deg, #dfe4d8 0%, #e6e3d4 48%, #ece7d6 100%);
+  color: #2e2a30;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.qviva__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.qviva__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8e4f80;
+}
+.qviva__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #33303a;
+}
+.qviva__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 40rem;
+}
+
+.qviva__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+.qviva__lienzo {
+  position: relative;
+  height: min(66vh, 32rem);
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(142, 79, 128, 0.25);
+  box-shadow: 0 12px 30px rgba(44, 42, 50, 0.16);
+  background: radial-gradient(120% 90% at 50% 22%, #e9eee0 0%, #92a084 100%);
+}
+.qviva__lienzo canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+  touch-action: none;
+}
+.quinual-canvas {
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.quinual-canvas--lista {
+  opacity: 1;
+}
+
+.qviva__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  color: #3c3842;
+  opacity: 0.85;
+}
+
+.qviva__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.qviva__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.qviva__toggle {
+  border: 1.5px solid #8e4f80;
+  background: #fff;
+  color: #8e4f80;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.qviva__toggle:hover,
+.qviva__toggle:focus-visible {
+  background: #8e4f80;
+  color: #fff;
+  outline-offset: 2px;
+}
+
+/* ---- Ficha 2D (fallback digno, sin GPU): LAS DOS PANOJAS ---- */
+.qviva__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  background: linear-gradient(180deg, #e9eee0 0%, #d3d8c2 56%, #b4bb9e 100%);
+}
+.qviva__estampa {
+  position: relative;
+  display: flex;
+  gap: 2.4rem;
+  align-items: flex-end;
+  height: 190px;
+  margin-bottom: 0.5rem;
+}
+.qviva__panoja {
+  position: relative;
+  width: 66px;
+  height: 175px;
+}
+.qviva__eje {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
+  width: 5px;
+  height: 100%;
+  border-radius: 3px;
+  background: linear-gradient(180deg, #8f9a62 0%, #76824f 100%);
+}
+
+/* GLOMERULADA: los glomérulos apretados contra el eje — se lee maciza */
+.qviva__glom {
+  position: absolute;
+  left: 50%;
+  width: 30px;
+  height: 21px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #a86bb0 0%, #7b4a86 62%, #5f3669 100%);
+  box-shadow: inset -3px -3px 5px rgba(0, 0, 0, 0.22);
+}
+.qviva__glom--0 { top: 4px; transform: translateX(-52%) scale(0.62); }
+.qviva__glom--1 { top: 20px; transform: translateX(-44%) scale(0.78); }
+.qviva__glom--2 { top: 36px; transform: translateX(-58%) scale(0.9); }
+.qviva__glom--3 { top: 54px; transform: translateX(-42%) scale(1); }
+.qviva__glom--4 { top: 74px; transform: translateX(-58%) scale(1); }
+.qviva__glom--5 { top: 94px; transform: translateX(-44%) scale(0.94); }
+.qviva__glom--6 { top: 114px; transform: translateX(-56%) scale(0.84); }
+.qviva__glom--7 { top: 133px; transform: translateX(-48%) scale(0.7); }
+
+/* AMARANTIFORME: ramitas largas, abiertas y vencidas — se lee suelta */
+.qviva__ramita {
+  position: absolute;
+  left: 50%;
+  width: 40px;
+  height: 9px;
+  border-radius: 5px;
+  background: linear-gradient(90deg, #9b3f57 0%, #b85566 55%, #8e3550 100%);
+  box-shadow: inset -2px -1px 3px rgba(0, 0, 0, 0.2);
+  transform-origin: 0 50%;
+}
+.qviva__ramita--0 { top: 16px; transform: rotate(28deg) scaleX(0.62); }
+.qviva__ramita--1 { top: 40px; transform: translateX(-100%) rotate(-30deg) scaleX(0.7); }
+.qviva__ramita--2 { top: 66px; transform: rotate(34deg) scaleX(0.86); }
+.qviva__ramita--3 { top: 94px; transform: translateX(-100%) rotate(-36deg) scaleX(0.94); }
+.qviva__ramita--4 { top: 122px; transform: rotate(40deg) scaleX(1); }
+.qviva__ramita--5 { top: 148px; transform: translateX(-100%) rotate(-42deg) scaleX(0.9); }
+
+.qviva__ficha-nombre {
+  margin: 0;
+  font-weight: 800;
+  font-size: 1rem;
+  color: #33303a;
+}
+.qviva__ficha-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4c4752;
+  text-align: center;
+  padding: 0 0.8rem;
+}
+
+/* ---- Saberes ---- */
+.qviva__saberes {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.qviva__saberes h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #33303a;
+}
+.qviva__saberes ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .qviva__saberes ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.qviva__saberes li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(142, 79, 128, 0.16);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.qviva__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.qviva__saberes b {
+  display: block;
+  font-size: 0.92rem;
+  color: #33303a;
+}
+.qviva__saberes li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.qviva__cierre {
+  margin: 0.9rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #3c3842;
+  max-width: 42rem;
+}

--- a/src/mockups/QuinuaViva3D.jsx
+++ b/src/mockups/QuinuaViva3D.jsx
@@ -1,0 +1,177 @@
+/*
+ * QuinuaViva3D — vitrina pública del MUNDO DE LA QUINUA: el quinual maduro de
+ * tierra fría (2.500–3.200 m). Ruta #/mockups/quinua-viva-3d, sin auth.
+ *
+ * OJO, no confundir con `components/quinua/QuinuaScreen` (ruta #quinua): esa es
+ * la pantalla 2D de granos andinos —quinua, amaranto, chía, cañihua, tarwi—,
+ * photo-forward y con otro propósito. Esta es el MUNDO 3D del cultivo, y no la
+ * reemplaza ni la duplica.
+ *
+ * Lo que este mundo entrega es el color. Un quinual maduro es de las cosas más
+ * bonitas del campo andino: cada mata remata en una panoja que al madurar se
+ * enciende, y como el campesino siembra una variedad por tabla, el lote se ve a
+ * manchas —morado, rojizo, blanco rosado, verde— hasta el fondo de la ladera.
+ * Alrededor, la era de la trilla con la hoz, el garrote, la zaranda y la batea
+ * del lavado. Cuatro pasos cortos van de mirar el cultivo a poder comerlo.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el mundo 3D (chunk
+ * perezoso `vendor-three`); en equipo humilde, ahorro de datos o sin-WebGL se ve
+ * la ficha con las DOS panojas lado a lado —la compacta y la suelta—, que es la
+ * misma lección sin sudar la GPU. Copy en español de Colombia, en "usted".
+ * Autocontenida: cero CDN/imágenes externas.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import './QuinuaViva3D.css';
+
+const MundoQuinua = lazy(() => import('../visual/mundo3d/quinua/MundoQuinua.jsx'));
+
+/* Lo que enseña el quinual (verificado, en "usted"). */
+const SABERES = [
+  {
+    emoji: '🌾',
+    titulo: 'Hay dos formas de panoja',
+    texto:
+      'La glomerulada lleva los granitos apretados contra el eje y se ve maciza. La amarantiforme abre sus ramitas y cuelga suelta, como una escoba. No es un detalle de botánico: por ahí se reconoce la variedad, y con la variedad se sabe cómo se cosecha y si toca lavarla mucho o poco.',
+  },
+  {
+    emoji: '🎨',
+    titulo: 'El color dice la variedad',
+    texto:
+      'Al madurar la panoja se enciende, y cada variedad tiene su tono: Tunkahuán vira a morado y pasa de los dos metros; Punto Rojo se pone rojizo; Aurora queda blanca rosada y bajita; Blanca de Jericó se queda verde. Un lote de una sola variedad es un lote de un solo riesgo.',
+  },
+  {
+    emoji: '💨',
+    titulo: 'Se trilla y se avienta',
+    texto:
+      'Cuando el grano ya no se raja con la uña, se corta con hoz y se hace gavilla. En la era se le da garrote sobre la manta para que suelte el grano, y luego se avienta: se deja caer al viento, que se lleva la paja y deja la semilla limpia. Después la zaranda termina de emparejar.',
+  },
+  {
+    emoji: '🫧',
+    titulo: 'Y se le lava lo amargo',
+    texto:
+      'El grano viene forrado en saponina, que es amarga, y así no se come. Se lava y se frota con agua hasta que deje de hacer espuma — esa espuma es la saponina saliendo. La Blanca de Jericó nace dulce y casi no lo necesita: por eso saber cuál sembró le ahorra media jornada de trabajo.',
+  },
+];
+
+export default function QuinuaViva3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  return (
+    <main className="qviva">
+      <header className="qviva__head">
+        <p className="qviva__kicker">El mundo de la quinua · vitrina</p>
+        <h1>El quinual maduro de la tierra fría</h1>
+        <p className="qviva__lema">
+          Un quinual en su punto es de las cosas más bonitas del campo andino: la
+          ladera baja sembrada a manchas de color, cada tabla con su variedad —
+          morada, rojiza, blanca rosada, verde — y arriba, en el filo, la era
+          donde se trilla, se avienta y se le lava lo amargo. Recórralo con el
+          dedo y siga los cuatro pasos de la lección.
+        </p>
+      </header>
+
+      <section className="qviva__escena" aria-label="El quinual maduro en 3D">
+        <div className="qviva__lienzo">
+          {mostrar3D ? (
+            <Suspense
+              fallback={
+                <div className="qviva__cargando" role="status">
+                  Subiendo al filo del quinual…
+                </div>
+              }
+            >
+              <MundoQuinua tier={tier} reducedMotion={reducedMotion} />
+            </Suspense>
+          ) : (
+            <FichaQuinual />
+          )}
+        </div>
+
+        <div className="qviva__barra">
+          <p className="qviva__tier">
+            {mostrar3D
+              ? 'Está viendo el quinual en 3D. Gírelo con el dedo o el mouse y siga los pasos.'
+              : puede3D
+                ? 'Está viendo la ficha de la panoja.'
+                : 'Su equipo ve la ficha de la panoja (va parejo en cualquier teléfono).'}
+          </p>
+          {puede3D && (
+            <button type="button" className="qviva__toggle" onClick={() => setVer2d((v) => !v)}>
+              {ver2d ? 'Ver el quinual en 3D' : 'Ver la ficha'}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <section className="qviva__saberes" aria-label="Lo que enseña el quinual">
+        <h2>Lo que le enseña este quinual</h2>
+        <ol>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span className="qviva__emoji" aria-hidden="true">
+                {s.emoji}
+              </span>
+              <div>
+                <b>{s.titulo}</b>
+                <p>{s.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="qviva__cierre">
+          La quinua aguanta lo que pocos cultivos aguantan en la altura: la
+          helada, el suelo salino, la sequía. Por eso los Andes llevan miles de
+          años sembrándola, y por eso vale la pena que no se pierda ninguna de
+          sus variedades — cada una guarda una respuesta distinta para un año
+          distinto. En Colombia se da bien en Nariño, Boyacá y Cundinamarca.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+/* La ficha del quinual: el fallback digno para equipo humilde / sin-WebGL.
+   Las DOS panojas lado a lado en CSS — la compacta y la suelta — que es la
+   lección que más rinde de este mundo. Cero GPU. */
+function FichaQuinual() {
+  return (
+    <div
+      className="qviva__ficha"
+      role="img"
+      aria-label="Las dos formas de panoja de la quinua: la glomerulada compacta y la amarantiforme suelta"
+    >
+      <div className="qviva__estampa" aria-hidden="true">
+        {/* GLOMERULADA: los glomérulos apretados contra el eje */}
+        <span className="qviva__panoja qviva__panoja--glom">
+          <span className="qviva__eje" />
+          {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => (
+            <span key={`g${i}`} className={`qviva__glom qviva__glom--${i}`} />
+          ))}
+        </span>
+        {/* AMARANTIFORME: las ramitas largas, abiertas y vencidas */}
+        <span className="qviva__panoja qviva__panoja--amar">
+          <span className="qviva__eje" />
+          {[0, 1, 2, 3, 4, 5].map((i) => (
+            <span key={`a${i}`} className={`qviva__ramita qviva__ramita--${i}`} />
+          ))}
+        </span>
+      </div>
+      <p className="qviva__ficha-nombre">Las dos panojas de la quinua</p>
+      <p className="qviva__ficha-sub">
+        Izquierda glomerulada (compacta) · derecha amarantiforme (suelta)
+      </p>
+    </div>
+  );
+}

--- a/src/mockups/YucaViva3D.css
+++ b/src/mockups/YucaViva3D.css
@@ -1,0 +1,269 @@
+/*
+ * YucaViva3D.css — vitrina del mundo de la yuca (#/mockups/yuca-viva-3d).
+ * Autocontenida: sin fuentes/imágenes externas. Móvil-first desde 320px.
+ * Paleta de clima medio: cielo dorado de tarde, tierra roja andina, verde
+ * franco de trabajo y el pardo de la cáscara con la pulpa blanca. Solo
+ * opacity/transform.
+ */
+
+.yviva {
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  /* la tarde de finca del piso cálido (familia `corral` de la paleta madre) */
+  background: linear-gradient(180deg, #ecdcc2 0%, #e8ddc0 44%, #ddd3b2 100%);
+  color: #33291d;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.yviva__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.yviva__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #a0562f;
+}
+.yviva__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #3a3020;
+}
+.yviva__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 40rem;
+}
+
+.yviva__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}
+.yviva__lienzo {
+  position: relative;
+  height: min(66vh, 32rem);
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(160, 86, 47, 0.25);
+  box-shadow: 0 12px 30px rgba(58, 44, 30, 0.18);
+  background: radial-gradient(120% 90% at 50% 20%, #f0e2c4 0%, #a9a86a 100%);
+}
+.yviva__lienzo canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+  touch-action: none;
+}
+.yucal-canvas {
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+.yucal-canvas--lista {
+  opacity: 1;
+}
+
+.yviva__cargando {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  color: #45381f;
+  opacity: 0.85;
+}
+
+.yviva__barra {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+.yviva__tier {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+.yviva__toggle {
+  border: 1.5px solid #a0562f;
+  background: #fff;
+  color: #a0562f;
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.yviva__toggle:hover,
+.yviva__toggle:focus-visible {
+  background: #a0562f;
+  color: #fff;
+  outline-offset: 2px;
+}
+
+/* ---- Ficha 2D (fallback digno, sin GPU): la mata en CORTE ---- */
+.yviva__ficha {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  background: linear-gradient(180deg, #f0e2c4 0%, #d8d4a8 54%, #bfae86 100%);
+}
+.yviva__estampa {
+  position: relative;
+  width: 190px;
+  height: 200px;
+  margin-bottom: 0.4rem;
+}
+
+/* el follaje: arriba no más, que es como carga la yuca */
+.yviva__copa {
+  position: absolute;
+  top: 0;
+  left: 58px;
+  width: 74px;
+  height: 46px;
+}
+.yviva__hoja {
+  position: absolute;
+  width: 46px;
+  height: 15px;
+  border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+  background: linear-gradient(90deg, #3f6f3a 0%, #548c3d 60%, #3f6f3a 100%);
+  box-shadow: inset -2px -2px 4px rgba(0, 0, 0, 0.2);
+}
+/* las tres láminas palmeadas, abiertas en abanico */
+.yviva__hoja--a { top: 4px; left: -14px; transform: rotate(-28deg); }
+.yviva__hoja--b { top: 0; left: 14px; transform: rotate(4deg); }
+.yviva__hoja--c { top: 6px; left: 40px; transform: rotate(30deg); }
+
+/* EL TALLO: pelado y anillado — la seña que delata a la yuca */
+.yviva__tallo {
+  position: absolute;
+  top: 40px;
+  left: 88px;
+  width: 15px;
+  height: 74px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #6d5138 0%, #8d6c4a 45%, #6d5138 100%);
+}
+.yviva__cicatriz {
+  position: absolute;
+  left: -3px;
+  width: 21px;
+  height: 5px;
+  border-radius: 3px;
+  background: #5a3f29;
+  box-shadow: inset 0 -1px 2px rgba(0, 0, 0, 0.3);
+}
+
+/* el corte de tierra: donde de verdad pasa lo importante */
+.yviva__tierra {
+  position: absolute;
+  top: 112px;
+  left: 8px;
+  width: 176px;
+  height: 76px;
+  border-radius: 6px 6px 12px 12px;
+  background: linear-gradient(180deg, #6d4527 0%, #563520 62%, #452a19 100%);
+  box-shadow: inset 0 4px 8px rgba(0, 0, 0, 0.25);
+}
+/* EL RACIMO: las raíces colgando del mismo cuello, abriéndose en abanico.
+   La franja clara del centro es la pulpa blanca bajo la cáscara parda. */
+.yviva__raiz {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 15px;
+  height: 58px;
+  border-radius: 42% 42% 50% 50% / 14% 14% 86% 86%;
+  background: linear-gradient(180deg, #a4593a 0%, #9a6b45 42%, #8a5c3c 100%);
+  box-shadow: inset -3px 0 5px rgba(0, 0, 0, 0.28);
+  transform-origin: 50% 0;
+}
+.yviva__raiz--a { transform: translateX(-50%) rotate(-42deg); }
+.yviva__raiz--b { transform: translateX(-50%) rotate(-14deg); height: 64px; }
+.yviva__raiz--c { transform: translateX(-50%) rotate(15deg); height: 61px; }
+.yviva__raiz--d {
+  transform: translateX(-50%) rotate(41deg);
+  height: 52px;
+  /* esta es la que se partió: se le ve la pulpa blanca del corte */
+  background: linear-gradient(180deg, #9a6b45 0%, #9a6b45 62%, #f2e8d2 62%, #f2e8d2 100%);
+}
+
+.yviva__ficha-nombre {
+  margin: 0;
+  font-weight: 800;
+  font-size: 1rem;
+  color: #3a3020;
+}
+.yviva__ficha-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #55462f;
+}
+
+/* ---- Saberes ---- */
+.yviva__saberes {
+  max-width: 46rem;
+  margin: 1.6rem auto 0;
+}
+.yviva__saberes h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.7rem;
+  color: #3a3020;
+}
+.yviva__saberes ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+@media (min-width: 640px) {
+  .yviva__saberes ol {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.yviva__saberes li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(160, 86, 47, 0.16);
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+.yviva__emoji {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+.yviva__saberes b {
+  display: block;
+  font-size: 0.92rem;
+  color: #3a3020;
+}
+.yviva__saberes li p {
+  margin: 0.15rem 0 0;
+  font-size: 0.86rem;
+  line-height: 1.42;
+}
+.yviva__cierre {
+  margin: 0.9rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #45381f;
+  max-width: 42rem;
+}

--- a/src/mockups/YucaViva3D.jsx
+++ b/src/mockups/YucaViva3D.jsx
@@ -1,0 +1,177 @@
+/*
+ * YucaViva3D — vitrina pública del MUNDO DE LA YUCA: el yucal de clima medio
+ * (0–2.000 m) en el momento del arranque. Ruta #/mockups/yuca-viva-3d, sin auth.
+ *
+ * La yuca es el pan del piso cálido y templado, y aquí se muestra por lo que de
+ * verdad la distingue: el tallo leñoso PELADO Y ANILLADO de cicatrices —cada
+ * anillo es una hoja que se cayó— con el follaje arriba no más, y el momento en
+ * que la tierra suelta el racimo de raíces. Al lado, el semillero de estacas
+ * inclinadas, porque la yuca se siembra de tallo y no de semilla. Cuatro pasos
+ * cortos recorren la vuelta entera: reconocerla, sembrarla, cosecharla y
+ * comerla sin riesgo.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el mundo 3D (chunk
+ * perezoso `vendor-three`); en equipo humilde, ahorro de datos o sin-WebGL se ve
+ * la ficha de la yuca en corte —el tallo anillado arriba y el racimo de raíces
+ * bajo la línea de tierra— digna y sin sudar la GPU. Copy en español de
+ * Colombia, en "usted". Autocontenida: cero CDN/imágenes externas.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import './YucaViva3D.css';
+
+const MundoYuca = lazy(() => import('../visual/mundo3d/yuca/MundoYuca.jsx'));
+
+/* Lo que enseña el yucal (verificado, en "usted"). */
+const SABERES = [
+  {
+    emoji: '🪵',
+    titulo: 'El tallo lleva la cuenta',
+    texto:
+      'La yuca suelta las hojas de abajo mientras crece y en cada nudo le queda la cicatriz. Por eso el tallo va pelado y anillado, con el follaje arriba no más. Esa seña la delata de lejos: ningún otro cultivo de la finca tiene ese palo marcado.',
+  },
+  {
+    emoji: '🌱',
+    titulo: 'Se siembra de tallo',
+    texto:
+      'No va de semilla: va de ESTACA. Un pedazo de tallo maduro de 20 a 25 centímetros, con cinco a siete yemas, enterrado inclinado. De ahí rebrota la mata. Por eso al cosechar lo primero que se hace es cortar y guardar los tallos: esa es la siembra de la vuelta que viene.',
+  },
+  {
+    emoji: '🍠',
+    titulo: 'La raíz sale en racimo',
+    texto:
+      'No sale una: salen cuatro, cinco o seis, colgadas del mismo cuello, de 30 a 50 centímetros. Se corta el tallo, se palanquea la mata con el gancho y la tierra entrega el racimo entero. Por fuera parda o rojiza; por dentro, blanca.',
+  },
+  {
+    emoji: '🔥',
+    titulo: 'Dulce o amarga, cocida siempre',
+    texto:
+      'La yuca amarga carga mucho más compuesto cianogénico que la dulce, y por eso jamás se come cruda. Cocinarla, remojarla o rallarla y exprimirla es lo que la vuelve segura. La dulce pide menos trabajo, pero también va cocida. Esta regla no se salta.',
+  },
+];
+
+export default function YucaViva3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  return (
+    <main className="yviva">
+      <header className="yviva__head">
+        <p className="yviva__kicker">El mundo de la yuca · vitrina</p>
+        <h1>El yucal de clima medio, en el arranque</h1>
+        <p className="yviva__lema">
+          La parcela de yuca como es de verdad: los tallos pelados y anillados de
+          cicatrices con el follaje arriba, el plátano y el maíz asociados, el
+          semillero de estacas inclinadas — y adelante, la tierra abierta con el
+          racimo de raíces ya destapado. Recórrala con el dedo y siga los cuatro
+          pasos de la lección.
+        </p>
+      </header>
+
+      <section className="yviva__escena" aria-label="El yucal de clima medio en 3D">
+        <div className="yviva__lienzo">
+          {mostrar3D ? (
+            <Suspense
+              fallback={
+                <div className="yviva__cargando" role="status">
+                  Bajando al yucal…
+                </div>
+              }
+            >
+              <MundoYuca tier={tier} reducedMotion={reducedMotion} />
+            </Suspense>
+          ) : (
+            <FichaYucal />
+          )}
+        </div>
+
+        <div className="yviva__barra">
+          <p className="yviva__tier">
+            {mostrar3D
+              ? 'Está viendo el yucal en 3D. Gírelo con el dedo o el mouse y siga los pasos.'
+              : puede3D
+                ? 'Está viendo la ficha de la yuca.'
+                : 'Su equipo ve la ficha de la yuca (va parejo en cualquier teléfono).'}
+          </p>
+          {puede3D && (
+            <button type="button" className="yviva__toggle" onClick={() => setVer2d((v) => !v)}>
+              {ver2d ? 'Ver el yucal en 3D' : 'Ver la ficha'}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <section className="yviva__saberes" aria-label="Lo que enseña el yucal">
+        <h2>Lo que le enseña este yucal</h2>
+        <ol>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span className="yviva__emoji" aria-hidden="true">
+                {s.emoji}
+              </span>
+              <div>
+                <b>{s.titulo}</b>
+                <p>{s.texto}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+        <p className="yviva__cierre">
+          La yuca aguanta donde otros cultivos no: suelo pobre, sequía larga, y
+          se queda en la tierra esperando hasta que la casa la necesite — no hay
+          bodega mejor que el mismo suelo. Por eso en la parcela campesina nunca
+          va sola: va con el plátano, con el maíz, con el fríjol. Esa mezcla es
+          la que sostiene la mesa cuando un cultivo falla.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+/* La ficha de la yuca: el fallback digno para equipo humilde / sin-WebGL.
+   El corte en CSS — el tallo anillado de cicatrices arriba, y bajo la línea de
+   tierra el racimo de raíces colgando del cuello. Cero GPU. */
+function FichaYucal() {
+  return (
+    <div
+      className="yviva__ficha"
+      role="img"
+      aria-label="La mata de yuca en corte: el tallo anillado de cicatrices arriba y el racimo de raíces bajo la tierra"
+    >
+      <div className="yviva__estampa" aria-hidden="true">
+        {/* el follaje, arriba no más */}
+        <span className="yviva__copa">
+          <span className="yviva__hoja yviva__hoja--a" />
+          <span className="yviva__hoja yviva__hoja--b" />
+          <span className="yviva__hoja yviva__hoja--c" />
+        </span>
+        {/* el tallo con sus cicatrices en espiral */}
+        <span className="yviva__tallo">
+          <span className="yviva__cicatriz" style={{ top: '12%' }} />
+          <span className="yviva__cicatriz" style={{ top: '32%' }} />
+          <span className="yviva__cicatriz" style={{ top: '52%' }} />
+          <span className="yviva__cicatriz" style={{ top: '72%' }} />
+        </span>
+        {/* bajo la línea de tierra: el racimo */}
+        <span className="yviva__tierra">
+          <span className="yviva__raiz yviva__raiz--a" />
+          <span className="yviva__raiz yviva__raiz--b" />
+          <span className="yviva__raiz yviva__raiz--c" />
+          <span className="yviva__raiz yviva__raiz--d" />
+        </span>
+      </div>
+      <p className="yviva__ficha-nombre">La mata de yuca, en corte</p>
+      <p className="yviva__ficha-sub">Clima medio · el tallo anillado y el racimo de raíces</p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/quinua/EscenaQuinuaViva.jsx
+++ b/src/visual/mundo3d/quinua/EscenaQuinuaViva.jsx
@@ -1,0 +1,407 @@
+/*
+ * EscenaQuinuaViva — el MUNDO donde vive la quinua (tierra fría, 2.500–3.200 m).
+ *
+ * Una ladera alta EN LA HORA VIVA DEL VALLE (`AtmosferaMundo`, familia
+ * `ladera`), pero tratada al revés que el papal: allá la bruma era la
+ * protagonista y aquí la bruma es el ENEMIGO. Este mundo se sostiene sobre el
+ * COLOR de las panojas, y una niebla lechosa encima se lo lava todo. Así que la
+ * niebla va lejos y floja, y la luz entra limpia y un poco rasante para que cada
+ * panoja recorte su silueta contra la de atrás.
+ *
+ * La composición es la decisión fuerte: la ladera BAJA alejándose de la cámara.
+ * En una loma que sube, la primera fila de quinua tapa a la segunda y del lote
+ * solo se ve el borde; bajando, las veintitantas filas quedan todas a la vista y
+ * el campo de color se lee hasta el fondo. La cámara se para en el filo, junto a
+ * la ERA DE LA TRILLA —que queda de primer plano— y mira ladera abajo.
+ *
+ * En la era está la otra mitad de la lección, la que casi nadie cuenta: la
+ * quinua no se come recién cosechada. Hay que trillarla, aventarla y LAVARLA
+ * para sacarle la saponina amarga. Por eso ahí viven la hoz, el garrote de
+ * trillar, la zaranda y la batea del lavado.
+ *
+ * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`. Con
+ * `reducedMotion` el mundo monta QUIETO (frameloop a demanda).
+ *
+ * `foco` (opcional): un punto [x,y,z] que el paso didáctico del host señala con
+ * un anillo que respira. Importa three/@react-three → montar SOLO perezosa.
+ */
+import { useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { perfilDeTier } from '../deviceTier.js';
+import { Fauna } from '../escenas/FaunaEscena.jsx';
+import FloraQuinua from './FloraQuinua.jsx';
+import {
+  ANCHO,
+  FONDO,
+  alturaQuinual,
+  reliefSurco,
+  SITIO_CASA,
+  SITIO_TRILLA,
+  CAMARA,
+} from './floraQuinua.geom.js';
+import {
+  AtmosferaMundo,
+  useAtmosferaMundo,
+  construirTerreno,
+  ruidoTerreno,
+  smoothstep,
+  CamaraDirector,
+} from '../kit/index.js';
+import {
+  mezclar,
+  VERDES,
+  TIERRAS,
+  AGUAS,
+  CASA,
+  LUCES,
+  NEUTROS,
+  PALETA,
+} from '../paleta/index.js';
+
+/* La identidad del piso frío dentro de la familia del valle. */
+const FAMILIA_QUINUAL = 'ladera';
+
+/* Escala de la escena para el kit (cámara↔centro ~17). */
+const RADIO_QUINUAL = 14;
+
+/* El frustum de sombra a medida del quinual. */
+const SOMBRA_QUINUAL = { left: -18, right: 18, top: 14, bottom: -12, far: 50 };
+
+/* La malla de la ladera. La pintura tiene un trabajo concreto: NO competir con
+   las panojas. Por eso el suelo va en pardos y verdes callados — si el terreno
+   también gritara, el campo de color se volvería ruido. La tierra del surco
+   asoma apenas entre fila y fila, y la ERA es un ruedo de piso duro y barrido,
+   sin surco, que es donde se trilla. */
+function construirLadera(seg, plano) {
+  const cPasto = new THREE.Color(mezclar(VERDES.frio, VERDES.paramoMusgo, 0.4));
+  const cPasto2 = new THREE.Color(mezclar(VERDES.paramoLiquen, VERDES.frio, 0.5));
+  const cSurco = new THREE.Color(mezclar(TIERRAS.turba, TIERRAS.siembra, 0.4));
+  const cEntre = new THREE.Color(mezclar(TIERRAS.turba, NEUTROS.tinta, 0.4));
+  const cEra = new THREE.Color(mezclar(TIERRAS.camino, NEUTROS.concreto, 0.35)); // piso duro
+  const cHondo = new THREE.Color(mezclar(VERDES.paramoNiebla, VERDES.frio, 0.4)); // el fondo del valle
+  return construirTerreno({
+    ancho: ANCHO,
+    fondo: FONDO,
+    seg,
+    plano,
+    altura: alturaQuinual,
+    pintar: (wx, wz, alt, c) => {
+      const s = reliefSurco(wx, wz);
+      const hondo = smoothstep(-4, -15, wz); // hacia el fondo se hunde y oscurece
+      c.lerpColors(cPasto, cPasto2, 0.5 + 0.5 * ruidoTerreno(wx * 0.8, wz * 0.6));
+      c.lerp(cHondo, hondo * 0.55);
+      // dentro del lote: la tierra entre fila y fila…
+      c.lerp(cEntre, s.lote * 0.7);
+      // …y el lomito del surco, apenas más claro (aquí no se aporca)
+      c.lerp(cSurco, smoothstep(0.2, 0.8, s.lomo) * 0.85);
+      // LA ERA: el ruedo de piso duro donde se trilla
+      const dTx = wx - SITIO_TRILLA[0];
+      const dTz = wz - SITIO_TRILLA[1];
+      c.lerp(cEra, smoothstep(13, 3, dTx * dTx + dTz * dTz) * 0.9);
+    },
+  });
+}
+
+/* La casita de tierra fría, en el filo junto a la era. */
+function CasaAlta({ pos }) {
+  return (
+    <group position={pos} rotation={[0, 0.5, 0]}>
+      <mesh position={[0, 0.68, 0]}>
+        <boxGeometry args={[2.3, 1.36, 1.8]} />
+        <meshLambertMaterial color={CASA.encalado} flatShading />
+      </mesh>
+      <mesh position={[0, 0.16, 0]}>
+        <boxGeometry args={[2.34, 0.32, 1.84]} />
+        <meshLambertMaterial color={CASA.zocalo} flatShading />
+      </mesh>
+      <mesh position={[0.4, 0.58, 0.91]}>
+        <boxGeometry args={[0.42, 0.88, 0.06]} />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
+      </mesh>
+      <mesh position={[0, 1.5, -0.56]} rotation={[-0.6, 0, 0]}>
+        <boxGeometry args={[2.7, 0.08, 1.38]} />
+        <meshLambertMaterial color={CASA.tejaSombra} flatShading />
+      </mesh>
+      <mesh position={[0, 1.5, 0.56]} rotation={[0.6, 0, 0]}>
+        <boxGeometry args={[2.7, 0.08, 1.38]} />
+        <meshLambertMaterial color={CASA.teja} flatShading />
+      </mesh>
+      {/* la chimenea del fogón (en el frío se cocina con candela) */}
+      <mesh position={[-0.8, 1.78, -0.28]}>
+        <boxGeometry args={[0.22, 0.58, 0.22]} />
+        <meshLambertMaterial color={mezclar(NEUTROS.lamina, TIERRAS.rocaParamo, 0.5)} flatShading />
+      </mesh>
+    </group>
+  );
+}
+
+/*
+ * LA ERA DE LA TRILLA — la otra mitad de la lección.
+ *
+ * Aquí está lo que casi nunca se cuenta de la quinua: entre el corte y el plato
+ * hay tres trabajos. Se TRILLA (se le da garrote a la gavilla sobre la manta
+ * para que suelte el grano), se AVIENTA (se deja caer al viento para que se
+ * lleve la paja) y se LAVA — porque el grano viene cubierto de saponina, que es
+ * amarga y no se quita sino con agua y fricción. La batea con el agua turbia y
+ * la espuma es la pieza clave: esa espuma ES la saponina saliendo.
+ */
+function EraDeTrilla({ pos }) {
+  return (
+    <group position={pos}>
+      {/* la MANTA tendida donde se trilla */}
+      <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0.3]}>
+        <planeGeometry args={[3.2, 2.4]} />
+        <meshLambertMaterial
+          color={mezclar(TIERRAS.vega, NEUTROS.cal, 0.3)}
+          flatShading
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      {/* el montón de grano ya trillado sobre la manta */}
+      <mesh position={[-0.35, 0.11, 0.25]} scale={[1, 0.42, 1]}>
+        <sphereGeometry args={[0.42, 9, 6]} />
+        <meshLambertMaterial color={mezclar('#d8c79a', TIERRAS.camino, 0.2)} flatShading />
+      </mesh>
+
+      {/* EL GARROTE de trillar, recostado en el montón */}
+      <group position={[0.5, 0.1, 0.5]} rotation={[0, 0.7, 1.15]}>
+        <mesh position={[0, 0.42, 0]}>
+          <cylinderGeometry args={[0.036, 0.05, 0.86, 6, 1]} />
+          <meshLambertMaterial color={PALETA.madera} flatShading />
+        </mesh>
+      </group>
+
+      {/* LA HOZ con que se corta la panoja: hoja curva y cabo de madera */}
+      <group position={[-1.3, 0.05, -0.5]} rotation={[0, 0.5, 0]}>
+        <mesh position={[0, 0.03, 0]} rotation={[Math.PI / 2, 0, 0]}>
+          <torusGeometry args={[0.19, 0.014, 4, 9, Math.PI * 1.05]} />
+          <meshLambertMaterial color={mezclar(NEUTROS.lamina, NEUTROS.cal, 0.35)} flatShading />
+        </mesh>
+        <mesh position={[0.2, 0.04, 0.05]} rotation={[0, 0, 1.5]}>
+          <cylinderGeometry args={[0.026, 0.03, 0.2, 5, 1]} />
+          <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
+        </mesh>
+      </group>
+
+      {/* LA ZARANDA con que se limpia el grano después de aventarlo */}
+      <group position={[1.5, 0, -0.7]} rotation={[0.35, 0.4, 0.15]}>
+        <mesh position={[0, 0.3, 0]} rotation={[Math.PI / 2, 0, 0]}>
+          <torusGeometry args={[0.34, 0.035, 5, 12]} />
+          <meshLambertMaterial color={CASA.bejuco} flatShading />
+        </mesh>
+        <mesh position={[0, 0.3, 0]} rotation={[Math.PI / 2, 0, 0]}>
+          <circleGeometry args={[0.33, 12]} />
+          <meshLambertMaterial
+            color={mezclar(CASA.bejuco, NEUTROS.cal, 0.35)}
+            flatShading
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      </group>
+
+      {/* LA BATEA DEL LAVADO: el agua turbia y la ESPUMA. Esa espuma es la
+          saponina saliendo del grano — el detalle que explica por qué la quinua
+          se lava antes de comerla. */}
+      <group position={[-1.9, 0, 1.0]}>
+        <mesh position={[0, 0.16, 0]}>
+          <cylinderGeometry args={[0.46, 0.38, 0.32, 10, 1, true]} />
+          <meshLambertMaterial color={PALETA.maderaOscura} flatShading side={THREE.DoubleSide} />
+        </mesh>
+        {/* el agua lechosa de tanto lavar */}
+        <mesh position={[0, 0.27, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <circleGeometry args={[0.44, 12]} />
+          <meshLambertMaterial color={mezclar(AGUAS.viva, NEUTROS.cal, 0.55)} flatShading />
+        </mesh>
+        {/* la espuma de saponina, en la orilla */}
+        {[
+          [0.2, 0.14],
+          [-0.16, 0.24],
+          [0.05, -0.22],
+        ].map((p, i) => (
+          <mesh key={`e${i}`} position={[p[0], 0.3, p[1]]} scale={[1, 0.4, 1]}>
+            <sphereGeometry args={[0.1 + i * 0.02, 7, 5]} />
+            <meshLambertMaterial color={NEUTROS.hueso} flatShading />
+          </mesh>
+        ))}
+      </group>
+    </group>
+  );
+}
+
+/* El anillo del paso didáctico. Con reducedMotion queda quieto. */
+function FocoPaso({ foco, reducedMotion }) {
+  const anillo = useRef(null);
+  useFrame(({ clock }) => {
+    const m = anillo.current;
+    if (!m) return;
+    if (reducedMotion) {
+      m.material.opacity = 0.42;
+      return;
+    }
+    const t = clock.elapsedTime;
+    m.material.opacity = 0.3 + 0.2 * Math.sin(t * 1.8);
+    m.scale.setScalar(1 + 0.06 * Math.sin(t * 1.8));
+  });
+  if (!foco) return null;
+  return (
+    <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+      <ringGeometry args={[1.15, 1.5, 32]} />
+      <meshBasicMaterial
+        color={LUCES.candela}
+        transparent
+        opacity={0.4}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+/* La fauna del quinual maduro: el pájaro que viene por el grano es parte de la
+   verdad del cultivo (por algo se cuida la cosecha), y la mariposa del frío. */
+const FAUNA_QUINUAL = [
+  { tipo: 'mariposa', base: [-4.2, 6.0, 3.2], patron: 'revoloteo', size: 22, fase: 0.5, df: 9 },
+  { tipo: 'colibri', base: [4.6, 6.4, 1.4], patron: 'revoloteo', size: 26, fase: 1.9, df: 10 },
+  { tipo: 'mariposa', base: [-7.0, 5.2, -1.6], patron: 'revoloteo', size: 20, fase: 2.6, df: 9 },
+];
+
+function Diorama({ tier, reducedMotion, foco }) {
+  const perfil = perfilDeTier(tier);
+  const atm = useAtmosferaMundo({ familia: FAMILIA_QUINUAL, reducedMotion });
+
+  /* La niebla va LEJOS y floja — al revés que en el papal. Aquí el entregable
+     es el color de las panojas, y una bruma cercana lo lava todo a gris. Se
+     deja lo justo para que el fondo del valle se separe en planos. */
+  const bruma = useMemo(
+    () => mezclar(atm.niebla, '#cfd8d4', atm.franja === 'noche' ? 0.18 : 0.3),
+    [atm.niebla, atm.franja],
+  );
+
+  const geoLadera = useMemo(
+    () => construirLadera(perfil.segmentosTerreno, perfil.flatShading),
+    [perfil.segmentosTerreno, perfil.flatShading],
+  );
+
+  const cerros = useMemo(
+    () => ({
+      cerca: mezclar(VERDES.paramoHoja, bruma, 0.3),
+      media: mezclar(VERDES.paramoNiebla, bruma, 0.42),
+      lejos: mezclar(VERDES.altoAndino, bruma, 0.56),
+    }),
+    [bruma],
+  );
+
+  const fauna = useMemo(
+    () => (tier === 'alto' ? FAUNA_QUINUAL : FAUNA_QUINUAL.slice(0, 2)),
+    [tier],
+  );
+
+  const controls = useRef(null);
+  const casaY = alturaQuinual(SITIO_CASA[0], SITIO_CASA[1]);
+  const trillaY = alturaQuinual(SITIO_TRILLA[0], SITIO_TRILLA[1]);
+
+  return (
+    <>
+      <AtmosferaMundo
+        familia={FAMILIA_QUINUAL}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        radio={RADIO_QUINUAL}
+        conSuelo={false}
+        conNiebla={false}
+        sombra={SOMBRA_QUINUAL}
+      />
+      {/* la bruma, lejos: que separe planos sin lavar el color */}
+      {perfil.fog && <fog attach="fog" args={[bruma, 30, 74]} />}
+      {/* Una luz de relleno FRÍA y baja, entrando casi rasante desde el lado
+          opuesto al sol: es la que le saca el borde a cada panoja contra la de
+          atrás. Sin este contraluz el campo se aplana en una sola mancha. */}
+      <directionalLight position={[-9, 3.5, -6]} intensity={0.3} color="#dfe8ea" />
+
+      {/* LA LADERA que baja, con sus surcos a curva de nivel */}
+      <mesh geometry={geoLadera} receiveShadow={perfil.sombras}>
+        <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
+      </mesh>
+
+      {/* la segunda cordillera, al otro lado del valle que se abre abajo */}
+      <mesh position={[-13, 1.0, -27]} scale={[12, 5.2, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={cerros.media} />
+      </mesh>
+      <mesh position={[8, 1.6, -30]} scale={[14, 6.4, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={cerros.lejos} />
+      </mesh>
+      <mesh position={[23, 0.6, -26]} scale={[9, 4.2, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={cerros.cerca} />
+      </mesh>
+
+      {/* EL QUINUAL: el campo de panojas de color */}
+      <FloraQuinua tier={tier} />
+
+      {/* la casita del filo */}
+      <CasaAlta pos={[SITIO_CASA[0], casaY, SITIO_CASA[1]]} />
+
+      {/* LA ERA: trilla, aventado y el lavado de la saponina */}
+      <EraDeTrilla pos={[SITIO_TRILLA[0], trillaY, SITIO_TRILLA[1]]} />
+
+      {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
+
+      <FocoPaso foco={foco} reducedMotion={reducedMotion} />
+
+      <OrbitControls
+        ref={controls}
+        makeDefault
+        target={CAMARA.objetivo}
+        enablePan={false}
+        enableZoom
+        minDistance={8}
+        maxDistance={28}
+        minPolarAngle={0.5}
+        maxPolarAngle={1.4}
+        minAzimuthAngle={-1.0}
+        maxAzimuthAngle={1.0}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.1}
+      />
+      {/* La LLEGADA: el dolly se asoma al filo y el campo se abre abajo. */}
+      <CamaraDirector
+        controls={controls}
+        reposo={CAMARA.reposo}
+        mirada={CAMARA.mirada}
+        respiro={0.04}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="mundoQuinual"
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * El mundo del quinual de tierra fría. Montar SOLO perezosa (lazy).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, foco?: number[]|null}} props
+ */
+export default function EscenaQuinuaViva({ tier = 'alto', reducedMotion = false, foco = null }) {
+  const perfil = perfilDeTier(tier);
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`quinual-canvas${listo ? ' quinual-canvas--lista' : ''}`}
+      dpr={perfil.dpr}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      shadows={perfil.sombras ? 'soft' : false}
+      camera={{ position: CAMARA.reposo, fov: CAMARA.fov }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Diorama tier={tier} reducedMotion={reducedMotion} foco={foco} />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/quinua/FloraQuinua.jsx
+++ b/src/visual/mundo3d/quinua/FloraQuinua.jsx
@@ -1,0 +1,146 @@
+/*
+ * FloraQuinua — el QUINUAL de tierra fría, que es sobre todo un CAMPO DE COLOR.
+ *
+ * Consume `floraQuinua.geom.js`: una geometría fusionada por especie y UN
+ * InstancedMesh — mismo contrato tier-safe que FloraPapa/FloraYuca. Lo propio de
+ * este mundo es cómo reparte los bancos:
+ *
+ *   · LA MATA VA EN TRES BANCOS (tres esqueletos distintos), para que el campo
+ *     no se lea como una planta fotocopiada doscientas veces.
+ *   · LA PANOJA VA EN DOS BANCOS, y no por rendimiento: por FIDELIDAD. Son los
+ *     dos tipos reales —glomerulada (compacta) y amarantiforme (laxa)— y cuál le
+ *     toca a cada planta lo decide su variedad, no el azar.
+ *   · EL COLOR ENTERO viaja por instancia. La geometría está horneada casi
+ *     blanca; sin `setColorAt` este mundo sería un lote de un solo tono, que es
+ *     precisamente lo contrario de lo que un quinual maduro es.
+ *
+ * Componente r3f: montar dentro del <Canvas> de EscenaQuinuaViva.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import {
+  quinualDeTier,
+  calidadQuinua,
+  construirEsqueletos,
+  distribucionQuinual,
+  geomMataQuinua,
+  geomPanojaGlomerulada,
+  geomPanojaAmarantiforme,
+  geomGavilla,
+  geomPaja,
+  geomPiedra,
+} from './floraQuinua.geom.js';
+
+/* Un banco de UNA especie: una geometría, un material, N instancias.
+   (El molde de la casa — aquí no hace falta la rotación libre del yucal: todo
+   lo de este mundo se para derecho y gira sobre su eje.) */
+function Especie({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      e.set(0, it.rotY, 0);
+      q.setFromEuler(e);
+      s.setScalar(it.escala);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+    />
+  );
+}
+
+/**
+ * La capa viva del quinual. Montar dentro del <Canvas>.
+ * @param {{tier?: 'alto'|'medio'|'bajo'}} props
+ */
+export default function FloraQuinua({ tier = 'alto' }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = quinualDeTier(tier);
+  const q = calidadQuinua(tier);
+
+  const esqs = useMemo(() => construirEsqueletos(q), [q]);
+
+  const geos = useMemo(
+    () => ({
+      mata: esqs.map((e) => geomMataQuinua(e, { q })),
+      glom: geomPanojaGlomerulada({ q }),
+      amar: geomPanojaAmarantiforme({ q }),
+      gavilla: conteos.gavilla ? geomGavilla({ q }) : null,
+      paja: conteos.paja ? geomPaja({ q }) : null,
+      piedra: conteos.piedra ? geomPiedra() : null,
+    }),
+    [esqs, conteos, q],
+  );
+
+  /* La hoja y la panoja se ven por las dos caras: son láminas y racimos, no
+     paredes. Un solo material para todo el mundo (una llamada menos). */
+  const mat = useMemo(() => {
+    const base = {
+      vertexColors: true,
+      flatShading: perfil.flatShading,
+      side: THREE.DoubleSide,
+    };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.87, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  const dist = useMemo(() => distribucionQuinual(conteos, esqs), [conteos, esqs]);
+
+  // Liberar GPU al desmontar.
+  useLayoutEffect(
+    () => () => {
+      geos.mata.forEach((g) => g && g.dispose());
+      Object.entries(geos).forEach(([k, g]) => k !== 'mata' && g && g.dispose());
+      mat.dispose();
+    },
+    [geos, mat],
+  );
+
+  const sombra = perfil.sombras;
+
+  return (
+    <group>
+      {/* El pajonal y la piedra: la tierra alta rodeando el lote. */}
+      <Especie geo={geos.paja} mat={mat} items={dist.paja} />
+      <Especie geo={geos.piedra} mat={mat} items={dist.piedra} />
+
+      {/* EL CULTIVO: los tres bancos de mata (tallo anguloso, hoja romboidal). */}
+      {geos.mata.map((g, i) => (
+        <Especie key={`mata${i}`} geo={g} mat={mat} items={dist.mata[i]} castShadow={sombra} />
+      ))}
+
+      {/* LAS PANOJAS — lo que este mundo vino a entregar. Dos bancos porque son
+          dos tipos de verdad, no por rendimiento. */}
+      <Especie geo={geos.glom} mat={mat} items={dist.panojaGlom} castShadow={sombra} />
+      <Especie geo={geos.amar} mat={mat} items={dist.panojaAmar} castShadow={sombra} />
+
+      {/* LA ERA: las gavillas cortadas con hoz, esperando la trilla. */}
+      <Especie geo={geos.gavilla} mat={mat} items={dist.gavilla} castShadow={sombra} />
+    </group>
+  );
+}

--- a/src/visual/mundo3d/quinua/MundoQuinua.jsx
+++ b/src/visual/mundo3d/quinua/MundoQuinua.jsx
@@ -1,0 +1,113 @@
+/*
+ * MundoQuinua — el MUNDO DE LA QUINUA completo: el quinual navegable + la lección.
+ *
+ * Mismo contrato de host que MundoPapa/MundoYuca: acepta `{tier, reducedMotion}`
+ * (o auto-detecta con decidirTier si se monta suelto), llena a su padre y guarda
+ * su estado local. Sobre la escena viven los PASOS: cuatro lecciones cortas que
+ * van de mirar el cultivo a poder comerlo — la panoja y sus dos formas, el color
+ * como seña de variedad, la cosecha y la trilla, y el lavado de la saponina.
+ *
+ * El cuarto paso es el que casi nunca se cuenta y el que de verdad hace falta:
+ * la quinua no se come recién trillada. Hay que lavarle la saponina, que es
+ * amarga. Es el mismo tipo de saber que cierra el mundo de la yuca (la amarga
+ * no se come cruda): entre la cosecha y el plato hay un trabajo, y ese trabajo
+ * es conocimiento campesino, no un detalle.
+ *
+ * La cámara NO cambia entre pasos (mismo patrón que el papal y el yucal): lo que
+ * se mueve es el anillo del `foco`. Copy en español de Colombia, en "usted".
+ *
+ * Importa three/@react-three (vía la escena) → montar SOLO perezoso (lazy).
+ */
+import { useMemo, useState } from 'react';
+import EscenaQuinuaViva from './EscenaQuinuaViva.jsx';
+import PanelPasos from '../PanelPasos.jsx';
+import { decidirTier, permite3D } from '../deviceTier.js';
+import { alturaQuinual, SITIO_TRILLA } from './floraQuinua.geom.js';
+
+/* Los cuatro pasos de la lección. Cada `foco` es el punto de la ladera que el
+   anillo señala mientras se lee (coordenadas del mundo, y sobre el terreno). */
+const enSuelo = (x, z) => [x, alturaQuinual(x, z), z];
+const PASOS = [
+  {
+    id: 'panoja',
+    kicker: 'Paso 1 de 4 · La panoja',
+    texto:
+      'Lo que remata cada mata es la PANOJA, y no todas son iguales. La compacta —glomerulada— lleva los granitos apretados contra el eje y se ve maciza. La suelta —amarantiforme— abre sus ramitas y cuelga como una escoba. Mírelas: en este lote están las dos, y saber cuál es cuál es saber qué sembró.',
+    foco: enSuelo(-2.4, 2.0),
+  },
+  {
+    id: 'color',
+    kicker: 'Paso 2 de 4 · El color no es adorno',
+    texto:
+      'Ese campo de colores no es una postal: cada mancha es una variedad distinta. Tunkahuán vira a morado y se levanta hasta más de dos metros; Punto Rojo se enciende rojizo; Aurora queda blanca rosada y bajita; Blanca de Jericó se queda verde. Sembrar varias no es capricho — es que si una falla, las otras responden.',
+    foco: enSuelo(5.0, -2.4),
+  },
+  {
+    id: 'trilla',
+    kicker: 'Paso 3 de 4 · Cortar, trillar, aventar',
+    texto:
+      'Cuando la panoja seca y el grano ya no se raja con la uña, se corta con hoz y se hace gavilla. En la era se le da garrote sobre la manta para que suelte el grano, y después se avienta: se deja caer al viento, que se lleva la paja y deja la semilla limpia en el suelo.',
+    foco: enSuelo(SITIO_TRILLA[0] - 0.4, SITIO_TRILLA[1] + 0.3),
+  },
+  {
+    id: 'lavado',
+    kicker: 'Paso 4 de 4 · Lavarle lo amargo',
+    texto:
+      'Falta lo que casi nadie cuenta: el grano viene forrado en saponina, que es amarga, y así no se come. Se lava y se frota con agua hasta que deje de hacer espuma — esa espuma ES la saponina saliendo. La Blanca de Jericó es la excepción: nace dulce y casi no pide lavado. Por eso hay que saber cuál se sembró.',
+    foco: enSuelo(SITIO_TRILLA[0] - 1.9, SITIO_TRILLA[1] + 1.0),
+  },
+];
+
+const CSS = `
+.mquinual { position: relative; width: 100%; height: 100%; overflow: hidden; background: #d6e0d2; }
+.mquinual canvas { opacity: 0; transition: opacity 0.9s ease; }
+.mquinual .quinual-canvas--lista canvas, .mquinual canvas.quinual-canvas--lista { opacity: 1; }
+@media (prefers-reduced-motion: reduce) {
+  .mquinual canvas { transition: none; }
+}
+`;
+
+/* Acento del quinual para el panel compartido. El morado de Tunkahuán manda —
+   es el color que hace la foto de este mundo. */
+const TEMA_PANEL = {
+  fondo: 'rgba(24, 18, 26, 0.72)',
+  borde: 'rgba(198, 158, 200, 0.3)',
+  tinta: '#f1ecf1',
+  kicker: '#d7a9c8',
+  acentoA: 'rgba(155, 88, 140, 0.95)',
+  acentoB: 'rgba(110, 56, 104, 0.95)',
+  tintaAccion: '#f6eef4',
+  activo: '#9b588c',
+};
+
+/**
+ * El mundo del quinual de tierra fría, completo: escena + pasos didácticos.
+ * Montar SOLO perezoso (lazy); llena a su contenedor.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function MundoQuinua({ tier: tierProp, reducedMotion: rmProp } = {}) {
+  // Contrato de mundos: props del host si llegan; si se monta suelto,
+  // auto-detección del equipo (no matar la gama baja).
+  const auto = useMemo(() => decidirTier(), []);
+  const tier = tierProp ?? (permite3D(auto.tier) ? auto.tier : 'bajo');
+  const reducedMotion = rmProp ?? auto.reducedMotion;
+  const [paso, setPaso] = useState(0);
+
+  const actual = PASOS[paso];
+
+  return (
+    <div className="mquinual">
+      <style>{CSS}</style>
+      <EscenaQuinuaViva tier={tier} reducedMotion={reducedMotion} foco={actual.foco} />
+
+      <PanelPasos
+        etiqueta="La lección del quinual"
+        pasos={PASOS}
+        paso={paso}
+        onPaso={setPaso}
+        tema={TEMA_PANEL}
+        reducedMotion={reducedMotion}
+      />
+    </div>
+  );
+}

--- a/src/visual/mundo3d/quinua/floraQuinua.geom.js
+++ b/src/visual/mundo3d/quinua/floraQuinua.geom.js
@@ -1,0 +1,859 @@
+/*
+ * floraQuinua.geom — la GEOMETRÍA del QUINUAL de tierra fría (2.500–3.200 m).
+ *
+ * Un quinual maduro es de las cosas más bonitas del campo andino, y la razón es
+ * una sola: LA PANOJA. Cada planta remata en una panoja terminal que al madurar
+ * se enciende —verde, amarilla, naranja, rosada, roja, púrpura, casi negra— y un
+ * lote entero se vuelve un campo de color que no se parece a ningún otro
+ * cultivo. Ese es el entregable de este mundo. Todo lo demás le hace marco.
+ *
+ * DECISIÓN DE COMPOSICIÓN: aquí la loma BAJA alejándose de la cámara, al revés
+ * que en el yucal y el papal. No es capricho — es lo que hace posible la foto.
+ * En una loma que sube, la primera fila tapa a la segunda y de un quinual solo
+ * se ve el borde; en una que baja, TODAS las filas quedan a la vista y el color
+ * se lee hasta el fondo. Además es como se siembra de verdad en la ladera
+ * andina. La geografía está al servicio de lo que hay que mostrar.
+ *
+ * Cada pieza con su identidad:
+ *
+ *   · Mata de quinua      — TRES esqueletos distintos: tallo estriado y anguloso
+ *                           (cilíndrico abajo, con aristas desde que ramifica) y
+ *                           hojas ROMBOIDALES alternas, que es la forma real.
+ *   · Panoja GLOMERULADA  — la compacta: glomérulos apretados contra el eje.
+ *   · Panoja AMARANTIFORME— la laxa: ramitas largas y sueltas que se vencen.
+ *                           Son los DOS tipos con nombre técnico de verdad, y
+ *                           distinguirlos es media lección de campo.
+ *   · Gavilla             — la quinua ya cortada con hoz y amontonada en la era.
+ *   · Pajonal y piedra    — la tierra alta alrededor del lote.
+ *
+ * EL COLOR: la mata y la panoja se hornean casi BLANCAS y el color real viaja
+ * POR INSTANCIA (setColorAt). Sin eso no hay campo de colores: habría un lote de
+ * un solo tono. Y el color no se sortea planta por planta — se sortea POR
+ * MANCHAS, porque el campesino siembra una variedad por tabla y el lote real se
+ * ve a bloques, no a confeti.
+ *
+ * TÉCNICA tier-safe (mismo contrato que floraPapa/floraYuca.geom): una geometría
+ * fusionada por especie y UN InstancedMesh → una draw-call por especie.
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO si se mezclan geometrías
+ * indexadas con no-indexadas: aquí TODO se desindexa antes de fusionar y se
+ * TRUENA si aun así falla.
+ *
+ * Aquí viven SOLO los datos y las mallas (nada de WebGL): corre headless.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* -------------------------------------------------------------------------- */
+/*  La ladera que BAJA (la geografía del mundo, determinista)                  */
+/* -------------------------------------------------------------------------- */
+
+export const ANCHO = 40; // x: -20 … 20
+export const FONDO = 38; // z: -19 (el fondo, abajo) … 19 (el filo, arriba)
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+
+/* Ruido determinista (hash de senos): misma ladera siempre, sin Math.random. */
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.7 + wz * 0.5) * 0.5 +
+    Math.sin(wx * 1.6 - wz * 1.2 + 3.1) * 0.3 +
+    Math.sin(wx * 2.8 + wz * 2.3 + 5.7) * 0.2
+  );
+}
+
+/**
+ * La altura BASE de la ladera. Ojo al signo: es ALTA AL FRENTE (donde está la
+ * era y donde se para la cámara) y BAJA hacia el fondo. Así el quinual se
+ * despliega hacia abajo y no hay fila que tape a otra.
+ */
+export function alturaBase(wx, wz) {
+  const filo = smoothstep(-18, 11, wz); // 0 en el fondo hondo, 1 en el filo
+  let h = 0.2;
+  h += Math.pow(filo, 1.55) * 6.1;
+  h += ruido(wx * 0.4, wz * 0.38) * 0.4 * (0.4 + filo * 0.6);
+  return h;
+}
+
+/* --- Los SURCOS a curva de nivel: la quinua va en fila, no regada. --------- */
+
+/* Las filas del lote (z del centro de cada surco). La quinua se siembra en
+   surcos separados unos 70–80 cm, siguiendo la curva de nivel de la ladera. */
+export const FILAS_QUINUA = [];
+for (let z = 7.0; z >= -11.0; z -= 0.86) FILAS_QUINUA.push(Number(z.toFixed(3)));
+
+/** La curva de nivel del surco: el surco serpentea con la ladera. */
+export function curvaSurco(wx, fila) {
+  return Math.sin(wx * 0.1 + fila * 0.48) * 0.95;
+}
+
+/* Los sitios del mundo. La ERA DE LA TRILLA va ARRIBA, en el filo plano, junto
+   a la casa: así es de verdad (se trilla en piso duro y parejo, no en la
+   pendiente) y así queda cerca de la cámara, de primer plano. */
+export const SITIO_TRILLA = /** @type {[number, number]} */ ([5.8, 9.4]);
+export const SITIO_CASA = /** @type {[number, number]} */ ([-9.8, 10.6]);
+
+/** Máscara 0…1 del lote sembrado (dentro hay surcos; fuera, pajonal). */
+export function dentroLote(wx, wz) {
+  let m =
+    smoothstep(-16, -13.5, wx) *
+    smoothstep(16, 13.5, wx) *
+    smoothstep(8.0, 6.4, wz) *
+    smoothstep(-12.4, -10.4, wz);
+  // la era de la trilla y el patio de la casa están fuera del sembrado
+  const dTx = wx - SITIO_TRILLA[0];
+  const dTz = wz - SITIO_TRILLA[1];
+  m *= smoothstep(6, 14, dTx * dTx + dTz * dTz);
+  const dHx = wx - SITIO_CASA[0];
+  const dHz = wz - SITIO_CASA[1];
+  m *= smoothstep(9, 20, dHx * dHx + dHz * dHz);
+  return m;
+}
+
+/**
+ * El RELIEVE del surco: una loma suave de tierra por fila. En la quinua el
+ * surco es MUCHO más bajo que el caballón de la papa (aquí no se aporca para
+ * engordar tubérculo: solo se abre la fila para sembrar y desyerbar).
+ */
+export function reliefSurco(wx, wz) {
+  const lote = dentroLote(wx, wz);
+  if (lote <= 0.001) return { alza: 0, lomo: 0, lote: 0 };
+  let mejor = 1e9;
+  for (let i = 0; i < FILAS_QUINUA.length; i++) {
+    const zc = FILAS_QUINUA[i] + curvaSurco(wx, i);
+    const d = wz - zc;
+    const d2 = d * d;
+    if (d2 < mejor) mejor = d2;
+  }
+  const perfil = Math.exp(-mejor / 0.1);
+  return { alza: perfil * 0.16 * lote, lomo: perfil * lote, lote };
+}
+
+/** La altura FINAL de la ladera con los surcos horneados. */
+export function alturaQuinual(wx, wz) {
+  return alturaBase(wx, wz) + reliefSurco(wx, wz).alza;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LA CÁMARA — lo que este mundo NO puede fallar                             */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La cámara vive JUNTO A LA GEOGRAFÍA (misma convención que el yucal): así el
+ * diagnóstico de encuadre la importa de verdad en vez de adivinarla.
+ *
+ * Aquí el sujeto NO es un rincón: es EL CAMPO ENTERO de panojas. La cámara se
+ * para en el filo, un poco por encima de la era, y mira ladera abajo para que el
+ * color se despliegue en profundidad hasta el fondo del valle. La era de la
+ * trilla queda de primer plano a la derecha.
+ *
+ * Verificado por trazado de rayos contra esta MISMA función de altura
+ * (`node scripts/diag/encuadre-mundo.mjs quinua`) y calibrado contra el papal,
+ * que es un mundo ya aprobado:
+ *
+ *              cielo   tercio alto   cultivo en cuadro
+ *   papal      32.8%      0.6%            59.4%
+ *   yucal      34.8%      0.2%            52.5%
+ *   quinual    34.8%      0.0%            38.1%
+ *
+ * LA ALTURA DE LA CÁMARA ES EL PARÁMETRO CRÍTICO y costó encontrarla. La
+ * primera versión iba a 10,4 m y parecía razonable — hasta que el trazado
+ * mostró que el cultivo llenaba apenas el 19% del cuadro. El motivo: con las
+ * matas a 1,6 m y los surcos a 0,86 m, una cámara rasante deja que la primera
+ * fila tape las cinco de atrás, y la ladera no baja lo suficiente para
+ * compensar. Subiendo a 14 m el campo se abre y el color se lee hasta el fondo.
+ *
+ * Si alguien mueve esto, que vuelva a correr el trazado: medir el tamaño de las
+ * panojas NO es ver la escena.
+ */
+export const CAMARA = {
+  reposo: /** @type {[number, number, number]} */ ([0.6, 14.0, 15.8]),
+  mirada: /** @type {[number, number, number]} */ ([0.2, 3.5, -2.0]),
+  objetivo: /** @type {[number, number, number]} */ ([0.3, 3.2, -1.5]),
+  fov: 50,
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Presupuesto por tier                                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La MATA es lo que más pesa aquí (es un campo, no un huerto), así que el
+ * presupuesto se le va casi todo a ella: sin cantidad no hay campo de color, y
+ * el campo de color es el entregable. Las panojas van una por mata.
+ */
+export const FLORA_QUINUA = {
+  alto: { mata: 190, gavilla: 9, paja: 70, piedra: 8 },
+  medio: { mata: 120, gavilla: 6, paja: 40, piedra: 5 },
+  bajo: { mata: 48, gavilla: 3, paja: 18, piedra: 3 },
+};
+
+/** Conteos para un tier (desconocido → frugal, nunca el más caro). */
+export const quinualDeTier = (tier) => FLORA_QUINUA[tier] || FLORA_QUINUA.medio;
+
+/** Factor de detalle geométrico por tier (menos glomérulos/hojas en gama baja). */
+export const CALIDAD_QUINUA = { alto: 1, medio: 0.6, bajo: 0.4 };
+export const calidadQuinua = (tier) => CALIDAD_QUINUA[tier] ?? CALIDAD_QUINUA.medio;
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del quinual                                                         */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * LAS VARIEDADES. Estas cuatro son variedades reales cultivadas en Colombia —
+ * no nombres de adorno: cada una trae su porte, su tipo de panoja y su color de
+ * madurez, que es exactamente lo que se ve en campo.
+ *
+ * Blanca de Jericó lleva una nota aparte: es DULCE, o sea naturalmente baja en
+ * saponina, y por eso casi no necesita lavado. Esa es la excepción que le da
+ * sentido a la lección del desaponificado.
+ */
+export const VARIEDADES = [
+  {
+    id: 'tunkahuan',
+    nombre: 'Tunkahuán',
+    alto: [1.6, 2.3],
+    panoja: 'amarantiforme', // grande, ramificada, poco compacta
+    largoPanoja: [0.32, 0.52],
+    // púrpura que vira a púrpura-anaranjado al madurar
+    colores: ['#7b4a86', '#8f4a72', '#a55a52', '#b8703c'],
+    dulce: false,
+  },
+  {
+    id: 'aurora',
+    nombre: 'Aurora',
+    alto: [0.9, 1.3],
+    panoja: 'glomerulada', // semicompacta
+    largoPanoja: [0.2, 0.32],
+    // blanco-rosada
+    colores: ['#e8d7c4', '#e3bdb0', '#d9a79e', '#c9908c'],
+    dulce: false,
+  },
+  {
+    id: 'blanca-jerico',
+    nombre: 'Blanca de Jericó',
+    alto: [1.2, 2.1],
+    panoja: 'amarantiforme', // erecta y ramificada
+    largoPanoja: [0.26, 0.44],
+    // follaje y panoja verdes: madura sin encenderse
+    colores: ['#7d9147', '#8ba055', '#9aad63', '#b0b96a'],
+    dulce: true, // baja en saponina: casi no pide lavado
+  },
+  {
+    id: 'punto-rojo',
+    nombre: 'Punto Rojo',
+    alto: [1.4, 2.1],
+    panoja: 'amarantiforme', // semicompacta
+    largoPanoja: [0.28, 0.46],
+    // púrpura-rojizo, el más encendido del lote
+    colores: ['#8e3550', '#a33546', '#b34338', '#6d2f4e'],
+    dulce: false,
+  },
+];
+
+export const PAL = {
+  // La mata y la panoja se hornean CASI BLANCAS: el color va por instancia.
+  // Estos son los valores de luminancia que le dan estructura interna a la
+  // pieza (si todo fuera blanco plano, el tinte la dejaría como una calcomanía).
+  mataClaro: '#f4f2ec',
+  mataMedio: '#d8d5cc',
+  mataOscuro: '#b9b6ac',
+  panojaClaro: '#fbfaf6',
+  panojaMedio: '#e2dfd6',
+  panojaOscuro: '#c2beb3',
+
+  // El pajonal del frío y la piedra (estos SÍ con su color propio)
+  paja: '#b3a95e',
+  pajaSeca: '#c2b476',
+  pajaVerde: '#8f9a52',
+  piedra: '#8d8a80',
+  liquen: '#a5a986',
+
+  // La gavilla cortada y esperando la trilla (paja de quinua, ya seca)
+  gavilla: '#c9b478',
+  tierra: '#5a4433',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Utilidades (fusión desindexada + colocación + color horneado)              */
+/* -------------------------------------------------------------------------- */
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+/** Hornea un color plano en TODOS los vértices (atributo `color`). */
+function pintar(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Coloca una geometría (posición/rotación/escala) transformando vértices. */
+function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/** Orienta el +Y de la geometría hacia `dir` y la ubica en `pos`. */
+function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    q,
+    new THREE.Vector3(esc[0], esc[1], esc[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/**
+ * Fusiona partes (ya coloreadas) en UNA geometría. Se DESINDEXA todo antes de
+ * fusionar y se TRUENA si falla: mejor un error de build que una especie
+ * invisible en producción (mordida conocida de mergeGeometries).
+ */
+function fusionar(partes) {
+  const buenas = partes.filter(Boolean).map((p) => {
+    const plana = p.index ? p.toNonIndexed() : p;
+    if (plana !== p) p.dispose();
+    return plana;
+  });
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error('floraQuinua: mergeGeometries devolvió null — atributos incompatibles entre partes');
+  }
+  return g;
+}
+
+/** Pequeña variación determinista de color. */
+function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL ESQUELETO DE LA MATA                                                    */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La quinua es un tallo principal derecho con ramas que salen alternas, hojas
+ * romboidales, y LA PANOJA rematando arriba (y panojitas menores en las puntas
+ * de las ramas altas). El tallo es cilíndrico en la base y se vuelve ANGULOSO
+ * desde que ramifica — un detalle chiquito que la separa de cualquier pasto.
+ *
+ * Como en el yucal, se generan varios esqueletos con semillas distintas para
+ * que el campo no se lea como un estampado de la misma planta repetida.
+ */
+export function esqueletoQuinua(seed = 11, q = 1) {
+  const r = rng(seed);
+  const alto = 1.0 + r() * 0.35; // altura NORMALIZADA (la variedad la escala)
+  const radioBase = 0.03 + r() * 0.01;
+
+  // las ramas alternas, subiendo por el tallo
+  const nRamas = Math.max(3, Math.round(7 * q));
+  const ramas = [];
+  for (let i = 0; i < nRamas; i++) {
+    const t = 0.28 + (i / nRamas) * 0.58; // desde media caña para arriba
+    const a = i * 2.399 + r() * 0.3; // alternas, en espiral
+    const largo = (0.16 + r() * 0.14) * (1 - t * 0.45);
+    ramas.push({
+      base: [0, t * alto, 0],
+      ang: a,
+      largo,
+      // las de arriba son las que rematan en panojita
+      remata: t > 0.55 && r() > 0.4,
+    });
+  }
+
+  // las hojas romboidales, alternas y en espiral por todo el tallo
+  const nHojas = Math.max(4, Math.round(11 * q));
+  const hojas = [];
+  for (let i = 0; i < nHojas; i++) {
+    const t = 0.1 + (i / nHojas) * 0.72;
+    const a = i * 2.399 + r() * 0.35;
+    hojas.push({
+      y: t * alto,
+      ang: a,
+      // las de abajo son más grandes; hacia la inflorescencia se achican y se
+      // vuelven lanceoladas (así es de verdad)
+      tam: (1.05 - t * 0.5) * (0.85 + r() * 0.3),
+      caida: 0.1 + r() * 0.5,
+    });
+  }
+
+  return { alto, radioBase, ramas, hojas };
+}
+
+/* -------------------------------------------------------------------------- */
+/*  MATA DE QUINUA — tallo anguloso y hoja romboidal                          */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Todo se hornea casi BLANCO (con luminancia variada para que la pieza tenga
+ * estructura): el color de verdad lo pone el tinte de la instancia, y de ahí
+ * sale el campo de colores.
+ *
+ * La HOJA es un rombo: cuatro lados, ancha en la mitad y en punta arriba y
+ * abajo. Se construye con un octaedro achatado, que es exactamente esa forma y
+ * cuesta ocho triángulos.
+ */
+export function geomMataQuinua(esq, { q = 1 } = {}) {
+  const r = rng(23);
+  const partes = [];
+
+  // EL TALLO: cilíndrico en la base…
+  const base = new THREE.CylinderGeometry(esq.radioBase * 0.8, esq.radioBase, esq.alto * 0.3, 6, 1);
+  poner(base, [0, esq.alto * 0.15, 0]);
+  partes.push(pintar(base, PAL.mataMedio));
+  // …y ANGULOSO de ahí para arriba (pocos lados a propósito: son aristas)
+  const arriba = new THREE.CylinderGeometry(
+    esq.radioBase * 0.42,
+    esq.radioBase * 0.8,
+    esq.alto * 0.72,
+    q < 0.5 ? 4 : 5,
+    1,
+  );
+  poner(arriba, [0, esq.alto * 0.3 + esq.alto * 0.36, 0]);
+  partes.push(pintar(arriba, PAL.mataClaro));
+
+  // LAS RAMAS alternas
+  for (const rama of esq.ramas) {
+    const dir = [Math.cos(rama.ang) * 0.62, 1, Math.sin(rama.ang) * 0.62];
+    const brazo = new THREE.CylinderGeometry(0.008, 0.014, rama.largo, 4, 1);
+    apuntar(
+      brazo,
+      [
+        rama.base[0] + Math.cos(rama.ang) * rama.largo * 0.26,
+        rama.base[1] + rama.largo * 0.42,
+        rama.base[2] + Math.sin(rama.ang) * rama.largo * 0.26,
+      ],
+      dir,
+    );
+    partes.push(pintar(brazo, PAL.mataMedio));
+  }
+
+  // LAS HOJAS ROMBOIDALES
+  for (const h of esq.hojas) {
+    const rombo = new THREE.OctahedronGeometry(1, 0);
+    const largo = 0.1 * h.tam;
+    const ancho = 0.062 * h.tam;
+    // el rombo acostado, saliendo del tallo y vencido hacia abajo
+    poner(rombo, [0, 0, 0], [0, 0, 0], [ancho, 0.008, largo]);
+    apuntar(
+      rombo,
+      [Math.cos(h.ang) * (largo * 0.85), h.y, Math.sin(h.ang) * (largo * 0.85)],
+      [Math.cos(h.ang) * 0.9, -h.caida, Math.sin(h.ang) * 0.9],
+    );
+    partes.push(
+      pintar(rombo, variar(r() > 0.5 ? PAL.mataClaro : PAL.mataMedio, r, 0.05)),
+    );
+  }
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LA PANOJA — lo que hay que entregar                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Los DOS tipos con nombre técnico de verdad, y se ven bien distintos:
+ *
+ *   GLOMERULADA (compacta): los glomérulos —racimitos de grano— van apretados
+ *   contra el eje. La panoja se lee como una mazorca densa, de contorno
+ *   cerrado. Es la que parece "maciza".
+ *
+ *   AMARANTIFORME (laxa): las ramitas del eje son largas y se separan, y la
+ *   panoja queda abierta, con los glomérulos colgando de sus ramitas. Se lee
+ *   como una escoba suelta y se mueve con el viento.
+ *
+ * Ambas se construyen del origen hacia +Y con largo 1: la instancia las escala
+ * al largo real de su variedad (de 15 a 70 cm en campo). Todo casi blanco: el
+ * color de madurez lo pone el tinte por instancia.
+ */
+export function geomPanojaGlomerulada({ q = 1 } = {}, seed = 31) {
+  const r = rng(seed);
+  const partes = [];
+
+  // el eje de la panoja
+  const eje = new THREE.CylinderGeometry(0.02, 0.035, 1, 5, 1);
+  poner(eje, [0, 0.5, 0]);
+  partes.push(pintar(eje, PAL.panojaOscuro));
+
+  /* los GLOMÉRULOS, apretados contra el eje en espiral.
+     OJO al primitivo: son OCTAEDROS (8 triángulos), no icosaedros (20). A 5 cm
+     de tamaño y vistos desde la cámara del mundo se leen exactamente igual, y
+     como aquí hay una panoja por planta y cientos de plantas, ese cambio es la
+     diferencia entre 400.000 y 160.000 triángulos en escena. La densidad del
+     campo es el entregable: el ahorro tiene que salir del primitivo, no de
+     quitar plantas. */
+  const nPisos = Math.max(5, Math.round(10 * q));
+  const porPiso = q < 0.5 ? 3 : 4;
+  for (let p = 0; p < nPisos; p++) {
+    const t = 0.06 + (p / nPisos) * 0.92;
+    // la panoja es más gorda en el medio y se afina en la punta
+    const gordo = Math.sin(t * Math.PI) * 0.62 + 0.38;
+    for (let i = 0; i < porPiso; i++) {
+      const a = p * 1.9 + (i / porPiso) * Math.PI * 2 + r() * 0.3;
+      const rad = 0.085 * gordo;
+      const bola = new THREE.OctahedronGeometry(0.058 * gordo, 0);
+      poner(
+        bola,
+        [Math.cos(a) * rad, t, Math.sin(a) * rad],
+        [0, r() * Math.PI, 0],
+        [1, 0.85, 1],
+      );
+      const tono = r();
+      partes.push(
+        pintar(bola, variar(tono > 0.6 ? PAL.panojaClaro : tono > 0.25 ? PAL.panojaMedio : PAL.panojaOscuro, r, 0.06)),
+      );
+    }
+  }
+  return fusionar(partes);
+}
+
+export function geomPanojaAmarantiforme({ q = 1 } = {}, seed = 33) {
+  const r = rng(seed);
+  const partes = [];
+
+  const eje = new THREE.CylinderGeometry(0.016, 0.032, 1, 5, 1);
+  poner(eje, [0, 0.5, 0]);
+  partes.push(pintar(eje, PAL.panojaOscuro));
+
+  // LAS RAMITAS largas y sueltas — lo que la hace laxa
+  const nPisos = Math.max(4, Math.round(8 * q));
+  const porPiso = 2;
+  for (let p = 0; p < nPisos; p++) {
+    const t = 0.1 + (p / nPisos) * 0.86;
+    // las de abajo son más largas: la panoja se abre en cono invertido
+    const largo = (0.3 - t * 0.19) * (0.85 + r() * 0.3);
+    for (let i = 0; i < porPiso; i++) {
+      const a = p * 2.1 + (i / porPiso) * Math.PI * 2 + r() * 0.35;
+      // la ramita sale hacia afuera y se vence: la panoja laxa cuelga
+      const caida = -0.25 - r() * 0.4;
+      const dir = [Math.cos(a), caida, Math.sin(a)];
+      const n = Math.hypot(dir[0], dir[1], dir[2]);
+      const ramita = new THREE.CylinderGeometry(0.006, 0.011, largo, 4, 1);
+      apuntar(
+        ramita,
+        [Math.cos(a) * largo * 0.34, t + (caida * largo) / 2.4, Math.sin(a) * largo * 0.34],
+        dir,
+      );
+      partes.push(pintar(ramita, PAL.panojaOscuro));
+
+      // los glomérulos colgados de la ramita
+      const nBolas = q < 0.5 ? 2 : 3;
+      for (let k = 1; k <= nBolas; k++) {
+        const u = k / (nBolas + 0.4);
+        // octaedros, por lo mismo que en la glomerulada (ver allá)
+        const bola = new THREE.OctahedronGeometry(0.04 * (1.1 - u * 0.3), 0);
+        poner(
+          bola,
+          [
+            (dir[0] / n) * largo * u,
+            t + (dir[1] / n) * largo * u,
+            (dir[2] / n) * largo * u,
+          ],
+          [0, r() * Math.PI, 0],
+          [1, 0.9, 1],
+        );
+        const tono = r();
+        partes.push(
+          pintar(bola, variar(tono > 0.55 ? PAL.panojaClaro : PAL.panojaMedio, r, 0.07)),
+        );
+      }
+    }
+  }
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  GAVILLA — la quinua ya cortada con hoz, esperando la trilla               */
+/* -------------------------------------------------------------------------- */
+
+export function geomGavilla({ q = 1 } = {}, seed = 37) {
+  const r = rng(seed);
+  const partes = [];
+  const nTallos = Math.max(5, Math.round(11 * q));
+  for (let i = 0; i < nTallos; i++) {
+    const a = (i / nTallos) * Math.PI * 2 + r() * 0.5;
+    const abre = 0.32 + r() * 0.3;
+    const largo = 0.75 + r() * 0.3;
+    const tallo = new THREE.CylinderGeometry(0.012, 0.02, largo, 4, 1);
+    apuntar(
+      tallo,
+      [Math.cos(a) * 0.1, largo * 0.44, Math.sin(a) * 0.1],
+      [Math.cos(a) * abre, 1, Math.sin(a) * abre],
+    );
+    partes.push(pintar(tallo, variar(PAL.gavilla, r, 0.08)));
+    // la panojita seca en la punta de cada tallo del atado
+    const bola = new THREE.IcosahedronGeometry(0.055, 0);
+    poner(
+      bola,
+      [Math.cos(a) * (0.1 + abre * largo * 0.8), largo * 0.9, Math.sin(a) * (0.1 + abre * largo * 0.8)],
+      [0, r() * Math.PI, 0],
+      [1, 1.5, 1],
+    );
+    partes.push(pintar(bola, variar(PAL.pajaSeca, r, 0.1)));
+  }
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  PAJONAL Y PIEDRA — la tierra alta alrededor del lote                      */
+/* -------------------------------------------------------------------------- */
+
+export function geomPaja({ q = 1 } = {}, seed = 41) {
+  const r = rng(seed);
+  const partes = [];
+  const nHojas = Math.max(4, Math.round(7 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const a = (i / nHojas) * Math.PI * 2 + r() * 0.6;
+    const inclina = 0.25 + r() * 0.4;
+    const alto = 0.45 + r() * 0.3;
+    const hoja = new THREE.ConeGeometry(0.032, alto, 4, 1);
+    apuntar(
+      hoja,
+      [Math.cos(a) * 0.06, alto * 0.42, Math.sin(a) * 0.06],
+      [Math.cos(a) * inclina, 1, Math.sin(a) * inclina],
+    );
+    const tono = r();
+    partes.push(
+      pintar(hoja, variar(tono > 0.6 ? PAL.pajaSeca : tono > 0.25 ? PAL.paja : PAL.pajaVerde, r, 0.06)),
+    );
+  }
+  return fusionar(partes);
+}
+
+export function geomPiedra(seed = 43) {
+  const r = rng(seed);
+  const roca = new THREE.DodecahedronGeometry(0.3, 0);
+  poner(roca, [0, 0.12, 0], [r() * 0.6, r() * Math.PI, r() * 0.6], [1.25, 0.65, 1]);
+  const capa = new THREE.DodecahedronGeometry(0.15, 0);
+  poner(capa, [0.1, 0.21, 0.04], [0, r() * Math.PI, 0], [1, 0.55, 1]);
+  return fusionar([pintar(roca, PAL.piedra), pintar(capa, PAL.liquen)]);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Distribución: el campo de colores                                         */
+/* -------------------------------------------------------------------------- */
+
+/* Cuántos esqueletos distintos hay (que el campo no se lea como estampado). */
+export const N_ESQUELETOS = 3;
+export const SEMILLAS_ESQUELETO = [11, 211, 307];
+
+/** Construye los N esqueletos del quinual. */
+export function construirEsqueletos(q = 1) {
+  return SEMILLAS_ESQUELETO.map((s) => esqueletoQuinua(s, q));
+}
+
+/*
+ * LA MANCHA DE VARIEDAD. El campesino siembra una variedad por tabla, así que
+ * un quinual real se ve A BLOQUES: un pedazo morado, al lado uno verde, más
+ * allá uno rosado. Si el color se sorteara planta por planta el lote quedaría
+ * de confeti — bonito en el papel y falso en el campo, y además ilegible.
+ *
+ * Esta función es un ruido de baja frecuencia que devuelve qué variedad manda
+ * en cada punto del lote. Las fronteras quedan algo dentadas a propósito: las
+ * tablas de una finca no son rectángulos de catastro.
+ */
+/* Los dos ruidos de baja frecuencia que dibujan las tablas del lote. */
+const tablaN1 = (wx, wz) =>
+  Math.sin(wx * 0.16 + wz * 0.1) + Math.sin(wx * 0.06 - wz * 0.19 + 1.7) * 0.8;
+const tablaN2 = (wx, wz) =>
+  Math.sin(wx * 0.09 - wz * 0.14 + 4.2) + Math.sin(wx * 0.21 + wz * 0.07 + 2.4) * 0.8;
+
+/*
+ * Los umbrales de corte, calculados UNA VEZ como la MEDIANA de cada ruido sobre
+ * el lote real. Cortar en cero parecía lo natural y no lo es: sobre un pedazo
+ * acotado de terreno la mediana de una suma de senos no cae en cero, y el
+ * reparto se desfonda. Con corte en cero, Blanca de Jericó se llevaba el 46% del
+ * campo y Tunkahuán —la más alta y la más morada, la que hace la foto— se
+ * quedaba en 7%. Cortando en la mediana medida, cada variedad se lleva su cuarto
+ * y las fronteras siguen saliendo orgánicas.
+ */
+const UMBRALES = (() => {
+  const a = [];
+  const b = [];
+  for (let x = -13.6; x <= 13.6; x += 0.7) {
+    for (let z = -11; z <= 7; z += 0.7) {
+      if (dentroLote(x, z) < 0.6) continue;
+      a.push(tablaN1(x, z));
+      b.push(tablaN2(x, z));
+    }
+  }
+  const mediana = (arr) => {
+    if (!arr.length) return 0;
+    const s = arr.slice().sort((p, q2) => p - q2);
+    return s[Math.floor(s.length / 2)];
+  };
+  return [mediana(a), mediana(b)];
+})();
+
+/**
+ * Qué variedad manda en un punto del lote. Dos ruidos independientes parten el
+ * campo en cuatro tablas de área pareja (ver UMBRALES arriba); el resultado es
+ * un lote a BLOQUES, que es como se ve una finca de verdad — no a confeti.
+ */
+export function variedadEn(wx, wz) {
+  const n1 = tablaN1(wx, wz);
+  const n2 = tablaN2(wx, wz);
+  return (n1 > UMBRALES[0] ? 0 : 1) + (n2 > UMBRALES[1] ? 0 : 2);
+}
+
+/**
+ * Siembra determinista del quinual completo. Devuelve items por especie con el
+ * contrato del componente `Especie`. La MATA va en un banco por esqueleto y la
+ * PANOJA en dos bancos (glomerulada y amarantiforme) — el tipo de panoja lo
+ * decide la variedad de cada mata, no el azar.
+ */
+export function distribucionQuinual(conteos, esqs, seed = 811) {
+  const c = conteos;
+  const rMat = rng(seed + 1);
+  const rSue = rng(seed + 2);
+
+  /* --- Los sitios de siembra, sobre los surcos a curva de nivel. ---------- */
+  const sitios = [];
+  FILAS_QUINUA.forEach((z0, fila) => {
+    for (let wx = -13.6; wx <= 13.6; wx += 0.62) {
+      const px = wx + (rMat() - 0.5) * 0.24;
+      const pz = z0 + curvaSurco(px, fila) + (rMat() - 0.5) * 0.12;
+      if (dentroLote(px, pz) < 0.6) continue;
+      sitios.push({ px, pz });
+    }
+  });
+  // recorte determinista al presupuesto del tier (salto parejo, no los primeros N)
+  const paso = Math.max(1, Math.floor(sitios.length / Math.max(1, c.mata)));
+  const elegidos = [];
+  for (let k = 0; k < sitios.length && elegidos.length < c.mata; k += paso) {
+    elegidos.push(sitios[k]);
+  }
+
+  const mata = Array.from({ length: esqs.length }, () => []);
+  const panojaGlom = [];
+  const panojaAmar = [];
+  const col = new THREE.Color();
+  const col2 = new THREE.Color();
+
+  elegidos.forEach((s) => {
+    const iVar = variedadEn(s.px, s.pz);
+    const v = VARIEDADES[iVar];
+    const variante = Math.floor(rMat() * esqs.length) % esqs.length;
+    const esq = esqs[variante];
+
+    // el porte real de ESTA planta, dentro del rango de su variedad
+    const altoReal = v.alto[0] + rMat() * (v.alto[1] - v.alto[0]);
+    const escala = altoReal / esq.alto;
+    const rotY = rMat() * Math.PI * 2;
+    const y = alturaQuinual(s.px, s.pz);
+
+    /* EL COLOR DE MADUREZ. Dentro de una misma tabla las plantas no maduran
+       todas el mismo día, así que el color se mueve a lo largo de la rampa de
+       la variedad. Eso es lo que le da al lote su vibración: es un bloque de
+       color, pero no es un bloque plano. */
+    const madurez = rMat();
+    const paleta = v.colores;
+    const fPos = madurez * (paleta.length - 1);
+    const i0 = Math.floor(fPos);
+    const i1 = Math.min(paleta.length - 1, i0 + 1);
+    col.set(paleta[i0]);
+    col2.set(paleta[i1]);
+    col.lerp(col2, fPos - i0);
+
+    // el TALLO y la hoja van un paso más apagados que la panoja: la que grita
+    // es la panoja, y si gritan las dos el campo se vuelve una mancha
+    const tinteMata = col.clone().lerp(new THREE.Color('#8b9a6a'), 0.42);
+    tinteMata.multiplyScalar(0.9 + rMat() * 0.18);
+
+    mata[variante].push({
+      pos: [s.px, y, s.pz],
+      rotY,
+      escala,
+      tint: [tinteMata.r, tinteMata.g, tinteMata.b],
+    });
+
+    // LA PANOJA, encima de la mata, con el largo de su variedad
+    const largoPanoja =
+      v.largoPanoja[0] + rMat() * (v.largoPanoja[1] - v.largoPanoja[0]);
+    const tintePanoja = col.clone().multiplyScalar(0.92 + rMat() * 0.16);
+    const item = {
+      pos: [s.px, y + altoReal * 0.93, s.pz],
+      rotY: rMat() * Math.PI * 2,
+      escala: largoPanoja,
+      tint: [tintePanoja.r, tintePanoja.g, tintePanoja.b],
+    };
+    if (v.panoja === 'glomerulada') panojaGlom.push(item);
+    else panojaAmar.push(item);
+  });
+
+  /* --- LA ERA: las gavillas cortadas, amontonadas para trillar. ----------- */
+  const gavilla = [];
+  for (let i = 0; i < c.gavilla; i++) {
+    const a = (i / Math.max(1, c.gavilla)) * Math.PI * 2 + rSue() * 0.5;
+    const rad = 1.0 + Math.sqrt(rSue()) * 1.9;
+    const x = SITIO_TRILLA[0] + Math.cos(a) * rad;
+    const z = SITIO_TRILLA[1] + Math.sin(a) * rad * 0.7;
+    gavilla.push({
+      pos: [x, alturaQuinual(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.85 + rSue() * 0.4,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+
+  /* --- El pajonal y la piedra del borde (fuera del lote). ---------------- */
+  const paja = [];
+  let intentosPaja = 0;
+  while (paja.length < c.paja && intentosPaja < c.paja * 16) {
+    intentosPaja += 1;
+    const x = -19 + rSue() * 38;
+    const z = -18 + rSue() * 36;
+    if (dentroLote(x, z) > 0.25) continue;
+    const dTx = x - SITIO_TRILLA[0];
+    const dTz = z - SITIO_TRILLA[1];
+    if (dTx * dTx + dTz * dTz < 10) continue; // la era está barrida
+    const dHx = x - SITIO_CASA[0];
+    const dHz = z - SITIO_CASA[1];
+    if (dHx * dHx + dHz * dHz < 9) continue;
+    paja.push({
+      pos: [x, alturaQuinual(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.7 + rSue() * 0.8,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+
+  const piedra = [];
+  let intentosPiedra = 0;
+  while (piedra.length < c.piedra && intentosPiedra < c.piedra * 16) {
+    intentosPiedra += 1;
+    const x = -18 + rSue() * 36;
+    const z = -16 + rSue() * 32;
+    if (dentroLote(x, z) > 0.25) continue;
+    piedra.push({
+      pos: [x, alturaQuinual(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.7 + rSue() * 0.8,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+
+  return { mata, panojaGlom, panojaAmar, gavilla, paja, piedra };
+}

--- a/src/visual/mundo3d/yuca/EscenaYucaViva.jsx
+++ b/src/visual/mundo3d/yuca/EscenaYucaViva.jsx
@@ -42,6 +42,7 @@ import {
   SITIO_CASA,
   SITIO_ARRANQUE,
   SITIO_ESTACAS,
+  CAMARA,
 } from './floraYuca.geom.js';
 import {
   AtmosferaMundo,
@@ -71,29 +72,6 @@ const RADIO_YUCAL = 13;
 
 /* El frustum de sombra a medida del yucal (el sol de media tarde). */
 const SOMBRA_YUCAL = { left: -18, right: 18, top: 16, bottom: -8, far: 46 };
-
-/* -------------------------------------------------------------------------- */
-/*  LA CÁMARA — lo que este mundo NO puede fallar                             */
-/* -------------------------------------------------------------------------- */
-
-/*
- * El sujeto es el claro del ARRANQUE (z ≈ 6,4), no el cerro del fondo. Estos
- * números están verificados por trazado de rayos contra la MISMA función de
- * altura del terreno (scripts/diag: se lanzan rayos por el encuadre y se cuenta
- * qué toca cada uno). El reparto que buscan es: cielo arriba, cultivo en la
- * franja media, y el arranque ocupando el tercio inferior-central — que es
- * donde el ojo cae solo.
- *
- * Si alguien mueve esto, que vuelva a correr el trazado: medir la geometría de
- * las plantas NO es ver la escena, y una cámara enterrada en la loma da números
- * correctos de todo menos de lo único que importa.
- */
-export const CAMARA = {
-  reposo: /** @type {[number, number, number]} */ ([1.4, 5.2, 16.4]),
-  mirada: /** @type {[number, number, number]} */ ([1.8, 3.4, 4.0]),
-  objetivo: /** @type {[number, number, number]} */ ([1.8, 2.2, 3.0]),
-  fov: 50,
-};
 
 /* La malla de la loma — el heightfield del KIT con la pintura PROPIA del clima
    medio: la tierra roja andina del montículo, el claro del arranque abierto a

--- a/src/visual/mundo3d/yuca/EscenaYucaViva.jsx
+++ b/src/visual/mundo3d/yuca/EscenaYucaViva.jsx
@@ -1,0 +1,451 @@
+/*
+ * EscenaYucaViva — el MUNDO donde vive la yuca (clima medio, 0–2.000 m).
+ *
+ * Una loma templada EN LA HORA VIVA DEL VALLE: la atmósfera la pone el kit
+ * compartido (`AtmosferaMundo`, familia `corral` — la tarde de finca del piso
+ * cálido), y el yucal amanece y anochece CON el valle. Aquí NO manda la bruma
+ * (eso es del papal frío): manda la LUZ HORIZONTAL de clima medio, que entra
+ * rasante y le saca el relieve a lo que este mundo vino a contar.
+ *
+ * Y lo que vino a contar es EL ARRANQUE. La yuca no se explica con la mata: se
+ * explica con el momento en que la tierra suelta el racimo. Por eso la escena
+ * está compuesta al revés de lo habitual — el claro de la cosecha va ADELANTE,
+ * pegado a la cámara, y el cultivo queda DETRÁS haciéndole de telón. Un yucal
+ * bien sembrado es un bosquecito de tallos pelados y anillados con el follaje
+ * arriba no más; eso es el fondo, no el sujeto.
+ *
+ * El resto del lote cuenta la vuelta completa del cultivo: el SEMILLERO de
+ * estacas inclinadas a un lado (la yuca se siembra por tallo, no por semilla),
+ * el plátano de los bordes y el maíz intercalado (parcela asociada, que de eso
+ * come la casa), y arriba al fondo la casita con su canasto.
+ *
+ * Todo procedural (cero CDN/imágenes). Tier-safe vía `perfilDeTier`: 'alto' con
+ * sombras; 'medio' frugal; 'bajo' mínimo. Con `reducedMotion` el mundo monta
+ * QUIETO (frameloop a demanda). La fauna son los SVG rubber-hose de la casa como
+ * billboards (`Fauna`): las mariposas del clima medio.
+ *
+ * `foco` (opcional): un punto [x,y,z] que el paso didáctico del host señala con
+ * un anillo que respira. Importa three/@react-three → montar SOLO perezosa.
+ */
+import { useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { perfilDeTier } from '../deviceTier.js';
+import { Fauna } from '../escenas/FaunaEscena.jsx';
+import FloraYuca from './FloraYuca.jsx';
+import {
+  ANCHO,
+  FONDO,
+  alturaYucal,
+  reliefMonticulo,
+  SITIO_CASA,
+  SITIO_ARRANQUE,
+  SITIO_ESTACAS,
+} from './floraYuca.geom.js';
+import {
+  AtmosferaMundo,
+  useAtmosferaMundo,
+  construirTerreno,
+  ruidoTerreno,
+  smoothstep,
+  CamaraDirector,
+} from '../kit/index.js';
+import {
+  mezclar,
+  VERDES,
+  TIERRAS,
+  CASA,
+  ACENTOS,
+  LUCES,
+  NEUTROS,
+  PALETA,
+} from '../paleta/index.js';
+
+/* La identidad del clima medio dentro de la familia del valle: `corral`
+   (la tarde de finca, cálida). La HORA pone el resto. */
+const FAMILIA_YUCAL = 'corral';
+
+/* Escala de la escena para el kit (cámara↔centro ~16). */
+const RADIO_YUCAL = 13;
+
+/* El frustum de sombra a medida del yucal (el sol de media tarde). */
+const SOMBRA_YUCAL = { left: -18, right: 18, top: 16, bottom: -8, far: 46 };
+
+/* -------------------------------------------------------------------------- */
+/*  LA CÁMARA — lo que este mundo NO puede fallar                             */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * El sujeto es el claro del ARRANQUE (z ≈ 6,4), no el cerro del fondo. Estos
+ * números están verificados por trazado de rayos contra la MISMA función de
+ * altura del terreno (scripts/diag: se lanzan rayos por el encuadre y se cuenta
+ * qué toca cada uno). El reparto que buscan es: cielo arriba, cultivo en la
+ * franja media, y el arranque ocupando el tercio inferior-central — que es
+ * donde el ojo cae solo.
+ *
+ * Si alguien mueve esto, que vuelva a correr el trazado: medir la geometría de
+ * las plantas NO es ver la escena, y una cámara enterrada en la loma da números
+ * correctos de todo menos de lo único que importa.
+ */
+export const CAMARA = {
+  reposo: /** @type {[number, number, number]} */ ([1.4, 5.2, 16.4]),
+  mirada: /** @type {[number, number, number]} */ ([1.8, 3.4, 4.0]),
+  objetivo: /** @type {[number, number, number]} */ ([1.8, 2.2, 3.0]),
+  fov: 50,
+};
+
+/* La malla de la loma — el heightfield del KIT con la pintura PROPIA del clima
+   medio: la tierra roja andina del montículo, el claro del arranque abierto a
+   pala, el caminito de entrada y el pasto de los bordes. Los montículos van en
+   la ALTURA (alturaYucal ya los trae horneados): relieve de verdad. */
+function construirLoma(seg, plano) {
+  const cPasto = new THREE.Color(mezclar(VERDES.calidoVivo, VERDES.trabajo, 0.35));
+  const cPasto2 = new THREE.Color(VERDES.brote);
+  const cMonton = new THREE.Color(mezclar(TIERRAS.arcilla, TIERRAS.siembra, 0.4)); // el montículo
+  const cMontonSeco = new THREE.Color(mezclar(TIERRAS.arcilla, TIERRAS.camino, 0.45)); // la cresta al sol
+  const cEntreSurco = new THREE.Color(mezclar(TIERRAS.siembra, NEUTROS.tinta, 0.35));
+  const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.3));
+  const cAbierta = new THREE.Color(TIERRAS.siembra); // el claro recién removido
+  const cLoma = new THREE.Color(mezclar(VERDES.templado, VERDES.monte, 0.45)); // el monte del fondo
+  return construirTerreno({
+    ancho: ANCHO,
+    fondo: FONDO,
+    seg,
+    plano,
+    altura: alturaYucal,
+    pintar: (wx, wz, alt, c) => {
+      const s = reliefMonticulo(wx, wz);
+      const enLoma = smoothstep(-7, -16, wz);
+      // base: el pasto del clima medio, con manchas, apagándose hacia el monte
+      c.lerpColors(cPasto, cPasto2, 0.5 + 0.5 * ruidoTerreno(wx * 0.85, wz * 0.65));
+      c.lerp(cLoma, enLoma * 0.6);
+      // dentro del lote: la tierra removida entre montículo y montículo…
+      c.lerp(cEntreSurco, s.lote * 0.8);
+      // …y el MONTÓN encima, tierra roja con la cresta secada por el sol
+      const lomo = smoothstep(0.18, 0.75, s.lomo);
+      c.lerp(cMonton, lomo);
+      c.lerp(cMontonSeco, smoothstep(0.6, 1, s.lomo) * 0.8);
+      // EL CLARO DEL ARRANQUE: tierra abierta a pala, ya sin montículo
+      const dAx = wx - SITIO_ARRANQUE[0];
+      const dAz = wz - SITIO_ARRANQUE[1];
+      c.lerp(cAbierta, smoothstep(11, 2, dAx * dAx + dAz * dAz) * 0.9);
+      // el semillero de estacas: tierra mullida, más clara
+      const dEx = wx - SITIO_ESTACAS[0];
+      const dEz = wz - SITIO_ESTACAS[1];
+      c.lerp(cCamino, smoothstep(9, 2, dEx * dEx + dEz * dEz) * 0.6);
+      // el caminito por donde se entra al lote, al frente
+      c.lerp(
+        cCamino,
+        smoothstep(1.2, 0, Math.abs(wx + 9 - Math.sin(wz * 0.3) * 2)) * smoothstep(2, 12, wz),
+      );
+    },
+  });
+}
+
+/* La casita de clima medio, arriba al fondo: paredes encaladas, teja, y en el
+   patio el canasto de la yuca que ya subió. Insinuada, que el mundo es el
+   arranque. */
+function CasaTemplada({ pos }) {
+  return (
+    <group position={pos} rotation={[0, -0.35, 0]}>
+      <mesh position={[0, 0.72, 0]}>
+        <boxGeometry args={[2.5, 1.44, 1.9]} />
+        <meshLambertMaterial color={CASA.encalado} flatShading />
+      </mesh>
+      <mesh position={[0, 0.17, 0]}>
+        <boxGeometry args={[2.54, 0.34, 1.94]} />
+        <meshLambertMaterial color={CASA.zocalo} flatShading />
+      </mesh>
+      <mesh position={[0.45, 0.62, 0.96]}>
+        <boxGeometry args={[0.44, 0.94, 0.06]} />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
+      </mesh>
+      <mesh position={[-0.58, 0.86, 0.96]}>
+        <boxGeometry args={[0.48, 0.42, 0.06]} />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
+      </mesh>
+      {/* techo a dos aguas, con el alero largo del clima con aguacero */}
+      <mesh position={[0, 1.58, -0.62]} rotation={[-0.55, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.55]} />
+        <meshLambertMaterial color={CASA.tejaSombra} flatShading />
+      </mesh>
+      <mesh position={[0, 1.58, 0.62]} rotation={[0.55, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.55]} />
+        <meshLambertMaterial color={CASA.teja} flatShading />
+      </mesh>
+
+      {/* el canasto de la yuca en el patio, y un par de raíces asomando */}
+      <group position={[1.85, 0, 0.5]}>
+        <mesh position={[0, 0.24, 0]}>
+          <cylinderGeometry args={[0.34, 0.26, 0.48, 9, 1, true]} />
+          <meshLambertMaterial color={CASA.bejuco} flatShading side={THREE.DoubleSide} />
+        </mesh>
+        {[0, 1, 2].map((i) => (
+          <mesh
+            key={`y${i}`}
+            position={[(i - 1) * 0.12, 0.48, i === 1 ? 0.06 : -0.05]}
+            rotation={[0.35 + i * 0.25, i * 1.2, 0.4 - i * 0.3]}
+          >
+            <cylinderGeometry args={[0.045, 0.075, 0.42, 6, 1]} />
+            <meshLambertMaterial color={mezclar('#9a6b45', TIERRAS.camino, 0.15)} flatShading />
+          </mesh>
+        ))}
+      </group>
+    </group>
+  );
+}
+
+/* El RINCÓN DEL ARRANQUE: lo que deja el campesino en el claro cuando está en
+   plena faena. El GANCHO —la palanca de madera con la que se alza la mata, que
+   es la herramienta propia de esta cosecha—, el machete con que cortó los
+   tallos, y el atado de tallos ya cortados que se van a guardar para semilla.
+   Ese atado es media lección: la yuca de la próxima cosecha sale de ahí. */
+function RinconArranque({ pos }) {
+  return (
+    <group position={pos}>
+      {/* EL GANCHO de palanquear, clavado en la tierra abierta */}
+      <group position={[1.5, 0, 0.9]} rotation={[0.62, 0.5, -0.28]}>
+        <mesh position={[0, 0.7, 0]}>
+          <cylinderGeometry args={[0.035, 0.045, 1.4, 6, 1]} />
+          <meshLambertMaterial color={PALETA.madera} flatShading />
+        </mesh>
+        <mesh position={[0.1, 0.06, 0]} rotation={[0, 0, -0.9]}>
+          <boxGeometry args={[0.26, 0.07, 0.07]} />
+          <meshLambertMaterial color={mezclar(NEUTROS.lamina, NEUTROS.tinta, 0.35)} flatShading />
+        </mesh>
+      </group>
+
+      {/* EL ATADO de tallos cortados: la semilla de la próxima siembra. Van
+          amarrados y recostados, con sus cicatrices a la vista. */}
+      <group position={[-2.0, 0, 1.1]} rotation={[0, 0.6, 0]}>
+        {[0, 1, 2, 3, 4].map((i) => (
+          <mesh
+            key={`t${i}`}
+            position={[(i - 2) * 0.075, 0.28 + Math.abs(i - 2) * 0.015, (i % 2) * 0.05]}
+            rotation={[0.06 * (i - 2), 0, 1.42 + 0.05 * (i - 2)]}
+          >
+            <cylinderGeometry args={[0.032, 0.038, 1.15, 6, 1]} />
+            <meshLambertMaterial color={mezclar('#8d6c4a', TIERRAS.camino, 0.12)} flatShading />
+          </mesh>
+        ))}
+        {/* el bejuco que los amarra */}
+        <mesh position={[0.18, 0.3, 0.02]} rotation={[0, 0, 0]}>
+          <torusGeometry args={[0.2, 0.018, 5, 10]} />
+          <meshLambertMaterial color={CASA.bejuco} flatShading />
+        </mesh>
+      </group>
+
+      {/* el machete recostado en el atado (con el que cortó los tallos) */}
+      <group position={[-1.35, 0.06, 1.45]} rotation={[0, 0.9, 1.15]}>
+        <mesh position={[0, 0.28, 0]}>
+          <boxGeometry args={[0.055, 0.56, 0.012]} />
+          <meshLambertMaterial color={mezclar(NEUTROS.lamina, NEUTROS.cal, 0.3)} flatShading />
+        </mesh>
+        <mesh position={[0, -0.06, 0]}>
+          <boxGeometry args={[0.045, 0.16, 0.035]} />
+          <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
+        </mesh>
+      </group>
+
+      {/* el costal de fique abierto, donde se va echando la raíz limpia */}
+      <group position={[0.35, 0, 1.75]}>
+        <mesh position={[0, 0.26, 0]}>
+          <cylinderGeometry args={[0.3, 0.24, 0.52, 8, 1]} />
+          <meshLambertMaterial color={mezclar(TIERRAS.vega, NEUTROS.cal, 0.2)} flatShading />
+        </mesh>
+        <mesh position={[0.04, 0.54, 0]} rotation={[0.2, 0.4, 0.15]} scale={[1, 0.45, 1]}>
+          <sphereGeometry args={[0.26, 8, 5]} />
+          <meshLambertMaterial color={mezclar('#9a6b45', TIERRAS.siembra, 0.25)} flatShading />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/* El anillo del paso didáctico: respira sobre el punto que la lección señala.
+   Con reducedMotion queda quieto (presencia sin parpadeo). */
+function FocoPaso({ foco, reducedMotion }) {
+  const anillo = useRef(null);
+  useFrame(({ clock }) => {
+    const m = anillo.current;
+    if (!m) return;
+    if (reducedMotion) {
+      m.material.opacity = 0.42;
+      return;
+    }
+    const t = clock.elapsedTime;
+    m.material.opacity = 0.3 + 0.2 * Math.sin(t * 1.8);
+    m.scale.setScalar(1 + 0.06 * Math.sin(t * 1.8));
+  });
+  if (!foco) return null;
+  return (
+    <mesh ref={anillo} position={[foco[0], foco[1] + 0.12, foco[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+      <ringGeometry args={[1.15, 1.5, 32]} />
+      <meshBasicMaterial
+        color={LUCES.candela}
+        transparent
+        opacity={0.4}
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+/* La fauna del yucal: los SVG rubber-hose de la casa como billboards. Pocas y
+   por criterio — el clima medio tiene mariposa todo el año, y donde hay tierra
+   recién abierta siempre baja un pájaro a ver qué salió. */
+const FAUNA_YUCAL = [
+  { tipo: 'mariposa', base: [-2.6, 1.4, 4.6], patron: 'revoloteo', size: 26, fase: 0.4, df: 9 },
+  { tipo: 'mariposa', base: [6.4, 1.8, 2.2], patron: 'revoloteo', size: 22, fase: 2.1, df: 9 },
+  { tipo: 'colibri', base: [-7.5, 2.3, 1.0], patron: 'revoloteo', size: 28, fase: 1.3, df: 10 },
+];
+
+function Diorama({ tier, reducedMotion, foco }) {
+  const perfil = perfilDeTier(tier);
+
+  /* La atmósfera VIVA (misma resolución que monta AtmosferaMundo: barata,
+     cambia por franja) — alimenta la niebla propia y los cerros del fondo. */
+  const atm = useAtmosferaMundo({ familia: FAMILIA_YUCAL, reducedMotion });
+
+  /* La calina del clima medio: LEJOS y tenue, al revés que la bruma del papal.
+     Aquí el aire es caliente y transparente — la distancia se dora, no se
+     borra. Si esto se acerca, el yucal del fondo se pierde y con él la silueta
+     de tallos anillados que es media identidad del cultivo. */
+  const calina = useMemo(
+    () => mezclar(atm.niebla, ACENTOS.ambar, atm.franja === 'noche' ? 0.06 : 0.18),
+    [atm.niebla, atm.franja],
+  );
+
+  const geoLoma = useMemo(
+    () => construirLoma(perfil.segmentosTerreno, perfil.flatShading),
+    [perfil.segmentosTerreno, perfil.flatShading],
+  );
+
+  /* Los cerros del fondo, dorados por la distancia (perspectiva aérea viva). */
+  const cerros = useMemo(
+    () => ({
+      cerca: mezclar(VERDES.templado, calina, 0.26),
+      media: mezclar(VERDES.templado, calina, 0.36),
+      lejos: mezclar(VERDES.frio, calina, 0.48),
+    }),
+    [calina],
+  );
+
+  const fauna = useMemo(
+    () => (tier === 'alto' ? FAUNA_YUCAL : FAUNA_YUCAL.slice(0, 2)),
+    [tier],
+  );
+
+  const controls = useRef(null);
+  const casaY = alturaYucal(SITIO_CASA[0], SITIO_CASA[1]);
+  const arranqueY = alturaYucal(SITIO_ARRANQUE[0], SITIO_ARRANQUE[1]);
+
+  return (
+    <>
+      {/* LA ATMÓSFERA DEL KIT: fondo, luces y estrellas de LA HORA DEL VALLE
+          (familia corral), con el shadow-map del sol en gama alta. */}
+      <AtmosferaMundo
+        familia={FAMILIA_YUCAL}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        radio={RADIO_YUCAL}
+        conSuelo={false}
+        conNiebla={false}
+        sombra={SOMBRA_YUCAL}
+      />
+      {/* La calina: LEJOS y tenue — que el yucal del fondo se siga leyendo. */}
+      {perfil.fog && <fog attach="fog" args={[calina, 26, 62]} />}
+      {/* El rebote CÁLIDO del suelo: en clima medio la tierra roja devuelve luz
+          y le quita el gris a la cara de abajo de las hojas. */}
+      <directionalLight position={[2, -6, 4]} intensity={0.14} color={TIERRAS.arcilla} />
+
+      {/* LA LOMA con sus montículos horneados en el relieve */}
+      <mesh geometry={geoLoma} receiveShadow={perfil.sombras}>
+        <meshLambertMaterial vertexColors flatShading={perfil.flatShading} />
+      </mesh>
+
+      {/* los cerros del fondo, dorados por la distancia */}
+      <mesh position={[-15, 4.0, -25]} scale={[11, 5.0, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={cerros.media} />
+      </mesh>
+      <mesh position={[7, 4.6, -28]} scale={[13, 6.2, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={cerros.lejos} />
+      </mesh>
+      <mesh position={[22, 3.2, -24]} scale={[9, 4.2, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={cerros.cerca} />
+      </mesh>
+
+      {/* EL YUCAL: matas anilladas, follaje arriba, raíz destapada, estacas */}
+      <FloraYuca tier={tier} />
+
+      {/* la casita de clima medio con su canasto, arriba al fondo */}
+      <CasaTemplada pos={[SITIO_CASA[0], casaY, SITIO_CASA[1]]} />
+
+      {/* el rincón del arranque: el gancho, el atado de semilla y el costal */}
+      <RinconArranque pos={[SITIO_ARRANQUE[0], arranqueY, SITIO_ARRANQUE[1]]} />
+
+      {/* LA VIDA del clima medio */}
+      {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
+
+      {/* el anillo del paso didáctico (lo maneja el host) */}
+      <FocoPaso foco={foco} reducedMotion={reducedMotion} />
+
+      <OrbitControls
+        ref={controls}
+        makeDefault
+        target={CAMARA.objetivo}
+        enablePan={false}
+        enableZoom
+        minDistance={7}
+        maxDistance={26}
+        minPolarAngle={0.55}
+        maxPolarAngle={1.42}
+        minAzimuthAngle={-1.0}
+        maxAzimuthAngle={1.0}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.1}
+      />
+      {/* La LLEGADA del kit: el dolly de establishing baja al claro del
+          arranque — entrar al yucal es agacharse a ver lo que salió. */}
+      <CamaraDirector
+        controls={controls}
+        reposo={CAMARA.reposo}
+        mirada={CAMARA.mirada}
+        respiro={0.04}
+        activa={!reducedMotion && tier !== 'bajo'}
+        unaVezClave="mundoYucal"
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * El mundo del yucal de clima medio. Montar SOLO perezosa (lazy).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, foco?: number[]|null}} props
+ */
+export default function EscenaYucaViva({ tier = 'alto', reducedMotion = false, foco = null }) {
+  const perfil = perfilDeTier(tier);
+  const [listo, setListo] = useState(false);
+  return (
+    <Canvas
+      className={`yucal-canvas${listo ? ' yucal-canvas--lista' : ''}`}
+      dpr={perfil.dpr}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      shadows={perfil.sombras ? 'soft' : false}
+      camera={{ position: CAMARA.reposo, fov: CAMARA.fov }}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Diorama tier={tier} reducedMotion={reducedMotion} foco={foco} />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/yuca/FloraYuca.jsx
+++ b/src/visual/mundo3d/yuca/FloraYuca.jsx
@@ -1,0 +1,187 @@
+/*
+ * FloraYuca — el YUCAL de clima medio sembrado sobre sus montículos.
+ *
+ * Consume `floraYuca.geom.js`: cada especie es UN InstancedMesh de una geometría
+ * fusionada (una draw-call por especie, por más matas que haya) — mismo contrato
+ * tier-safe que FloraPapa/FloraCafetal, con dos diferencias que este cultivo
+ * pide:
+ *
+ *   · LA MATA VA EN TRES BANCOS, no en uno. Tres esqueletos distintos (troncos
+ *     de otra altura, horquetas de otro número y otro giro) y cada mata cae en
+ *     uno. Cuestan tres draw-calls en vez de una, y a cambio el yucal no se lee
+ *     como un estampado de la misma planta repetida.
+ *   · EL PECÍOLO LLEVA COLOR POR INSTANCIA (verde, rojo o morado, según la
+ *     variedad de la mata) y va en su propio banco, aparte de la lámina — si
+ *     fueran una sola pieza, el tinte de la variedad ensuciaría el verde de la
+ *     hoja. Lo mismo con la RAÍZ (cáscara por instancia) y su CORTE (la pulpa
+ *     blanca, de color fijo: el contraste es justo lo que enseña).
+ *
+ * Componente r3f: montar dentro del <Canvas> de EscenaYucaViva.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import {
+  yucalDeTier,
+  calidadYuca,
+  construirEsqueletos,
+  distribucionYucal,
+  geomMataYuca,
+  geomHojaYuca,
+  geomPecioloYuca,
+  geomRaizYuca,
+  geomCorteRaiz,
+  geomToconYuca,
+  geomEstacaYuca,
+  geomPlatano,
+  geomMaiz,
+  geomMonte,
+  geomPiedra,
+} from './floraYuca.geom.js';
+
+/*
+ * Un banco de UNA especie: una geometría, un material, N instancias.
+ *
+ * Extiende el molde de la casa (`Especie` de FloraPapa) con la rotación LIBRE
+ * que este mundo necesita: una hoja de yuca cuelga en cualquier dirección y una
+ * raíz sale de la tierra en cualquier ángulo — con `rotY` sola no se pueden
+ * poner. Cada item acepta, de más específico a más general:
+ *   · `quat`      [x,y,z,w]  — la rotación ya resuelta (hojas, pecíolos, raíces)
+ *   · `rot`       [x,y,z]    — ángulos de Euler (las estacas inclinadas)
+ *   · `rotY`      número     — el giro sobre su eje de toda la vida
+ * y `escalaXYZ` para lo que se estira en un solo eje (el pecíolo).
+ */
+function Especie({ geo, mat, items, castShadow = false }) {
+  const ref = useRef(null);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const col = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.pos[0], it.pos[1], it.pos[2]);
+      if (it.quat) q.set(it.quat[0], it.quat[1], it.quat[2], it.quat[3]);
+      else if (it.rot) q.setFromEuler(e.set(it.rot[0], it.rot[1], it.rot[2]));
+      else q.setFromEuler(e.set(0, it.rotY || 0, 0));
+      if (it.escalaXYZ) s.set(it.escalaXYZ[0], it.escalaXYZ[1], it.escalaXYZ[2]);
+      else s.setScalar(it.escala ?? 1);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      col.setRGB(it.tint[0], it.tint[1], it.tint[2]);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+    />
+  );
+}
+
+/**
+ * La capa viva del yucal. Montar dentro del <Canvas>.
+ * @param {{tier?: 'alto'|'medio'|'bajo'}} props
+ */
+export default function FloraYuca({ tier = 'alto' }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = yucalDeTier(tier);
+  const q = calidadYuca(tier);
+
+  /* Los TRES esqueletos: la malla de la mata y sus hojas salen del mismo, o las
+     hojas quedan flotando al lado del tallo. */
+  const esqs = useMemo(() => construirEsqueletos(q), [q]);
+
+  const geos = useMemo(
+    () => ({
+      mata: esqs.map((e) => geomMataYuca(e, { q })),
+      hoja: geomHojaYuca({ q }),
+      peciolo: geomPecioloYuca(),
+      raiz: geomRaizYuca({ q }),
+      corte: geomCorteRaiz(),
+      tocon: geomToconYuca({ q }),
+      estaca: conteos.estaca ? geomEstacaYuca({ q }) : null,
+      platano: conteos.platano ? geomPlatano({ q }) : null,
+      maiz: conteos.maiz ? geomMaiz({ q }) : null,
+      monte: conteos.monte ? geomMonte({ q }) : null,
+      piedra: conteos.piedra ? geomPiedra() : null,
+    }),
+    [esqs, conteos, q],
+  );
+
+  // Material único con vertexColors (el color viene horneado por especie y el
+  // tinte por instancia lo multiplica — en pecíolo y raíz el tinte ES el color).
+  const mat = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.9, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  // La lámina de la hoja se ve por las dos caras: es una hoja, no una pared.
+  const matHoja = useMemo(() => {
+    const base = { vertexColors: true, flatShading: perfil.flatShading, side: THREE.DoubleSide };
+    return perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.86, metalness: 0 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil.materialRico, perfil.flatShading]);
+
+  // Distribución determinista (una vez por tier).
+  const dist = useMemo(() => distribucionYucal(conteos, esqs), [conteos, esqs]);
+
+  // Liberar GPU al desmontar.
+  useLayoutEffect(
+    () => () => {
+      geos.mata.forEach((g) => g && g.dispose());
+      Object.entries(geos).forEach(([k, g]) => k !== 'mata' && g && g.dispose());
+      mat.dispose();
+      matHoja.dispose();
+    },
+    [geos, mat, matHoja],
+  );
+
+  const sombra = perfil.sombras; // solo lo que abulta proyecta sombra en 'alto'
+
+  return (
+    <group>
+      {/* El monte y la piedra del borde: el lote no flota en el vacío. */}
+      <Especie geo={geos.monte} mat={mat} items={dist.monte} />
+      <Especie geo={geos.piedra} mat={mat} items={dist.piedra} />
+
+      {/* EL CULTIVO: los tres bancos de mata (troncos anillados de cicatrices). */}
+      {geos.mata.map((g, i) => (
+        <Especie key={`mata${i}`} geo={g} mat={mat} items={dist.mata[i]} castShadow={sombra} />
+      ))}
+
+      {/* El follaje, solo arriba: el pecíolo con el color de su variedad y la
+          lámina palmeada en su propio banco. */}
+      <Especie geo={geos.peciolo} mat={mat} items={dist.peciolo} />
+      <Especie geo={geos.hoja} mat={matHoja} items={dist.hoja} castShadow={sombra} />
+
+      {/* LA ASOCIACIÓN: plátano en los bordes, maíz intercalado. */}
+      <Especie geo={geos.platano} mat={matHoja} items={dist.platano} castShadow={sombra} />
+      <Especie geo={geos.maiz} mat={matHoja} items={dist.maiz} />
+
+      {/* EL SEMILLERO: las estacas sembradas inclinadas. */}
+      <Especie geo={geos.estaca} mat={mat} items={dist.estaca} />
+
+      {/* EL ARRANQUE: el tocón por donde se palanqueó, el racimo de raíces que
+          la tierra soltó, y la pulpa blanca de la que se partió. */}
+      <Especie geo={geos.tocon} mat={mat} items={dist.tocon} castShadow={sombra} />
+      <Especie geo={geos.raiz} mat={mat} items={dist.raiz} castShadow={sombra} />
+      <Especie geo={geos.corte} mat={mat} items={dist.corte} />
+    </group>
+  );
+}

--- a/src/visual/mundo3d/yuca/MundoYuca.jsx
+++ b/src/visual/mundo3d/yuca/MundoYuca.jsx
@@ -1,0 +1,113 @@
+/*
+ * MundoYuca — el MUNDO DE LA YUCA completo: la loma navegable + la lección.
+ *
+ * Mismo contrato de host que MundoPapa/MundoCafetal: acepta `{tier,
+ * reducedMotion}` (o auto-detecta con decidirTier si se monta suelto), llena a
+ * su padre y guarda su estado local. Sobre la escena viven los PASOS: cuatro
+ * lecciones cortas que recorren la vuelta entera del cultivo — el tallo que
+ * lleva escrita su historia, la siembra por estaca, el arranque de la raíz y la
+ * diferencia entre yuca dulce y amarga.
+ *
+ * El orden no es decorativo: va de RECONOCERLA (el tallo anillado) a SEMBRARLA
+ * (la estaca) a COSECHARLA (el arranque) a COMERLA SIN RIESGO (dulce/amarga).
+ * El último paso es el que más importa y el que casi nunca se cuenta.
+ *
+ * La cámara NO cambia entre pasos (mismo patrón que el papal): lo que se mueve
+ * es el anillo del `foco`, que señala en la loma el lugar del que habla cada
+ * paso. Copy en español de Colombia, en "usted".
+ *
+ * Importa three/@react-three (vía la escena) → montar SOLO perezoso (lazy).
+ */
+import { useMemo, useState } from 'react';
+import EscenaYucaViva from './EscenaYucaViva.jsx';
+import PanelPasos from '../PanelPasos.jsx';
+import { decidirTier, permite3D } from '../deviceTier.js';
+import { alturaYucal, SITIO_ARRANQUE, SITIO_ESTACAS } from './floraYuca.geom.js';
+
+/* Los cuatro pasos de la lección. Cada `foco` es el punto de la loma que el
+   anillo señala mientras se lee (coordenadas del mundo, y sobre el terreno). */
+const enSuelo = (x, z) => [x, alturaYucal(x, z), z];
+const PASOS = [
+  {
+    id: 'tallo',
+    kicker: 'Paso 1 de 4 · El tallo que lleva la cuenta',
+    texto:
+      'Fíjese en el palo: va pelado abajo y con hojas solo arriba, y todo él está anillado de marcas. Cada marca es una hoja que se le cayó. La yuca va soltando la hoja de abajo mientras crece, y en el nudo queda la cicatriz — por eso, mirando el tallo, usted le lee la vida a la mata.',
+    foco: enSuelo(-1.6, 1.2),
+  },
+  {
+    id: 'estaca',
+    kicker: 'Paso 2 de 4 · Se siembra un palo, no una semilla',
+    texto:
+      'La yuca no se siembra de semilla: se siembra de ESTACA. Se corta un pedazo de tallo maduro de unos 20 a 25 centímetros, con cinco a siete yemas, y se entierra inclinado. De esas yemas —las mismas que están sobre cada cicatriz— rebrota la mata nueva. La cosecha de mañana sale del tallo de hoy.',
+    foco: enSuelo(SITIO_ESTACAS[0], SITIO_ESTACAS[1]),
+  },
+  {
+    id: 'arranque',
+    kicker: 'Paso 3 de 4 · El arranque',
+    texto:
+      'Primero se le corta el tallo y se guarda para semilla. Después se palanquea la mata con el gancho hasta que la tierra afloja, y sale el racimo entero: cuatro, cinco, seis raíces colgando del mismo cuello, de 30 a 50 centímetros cada una. Por fuera parda; por dentro, blanca. Eso es la yuca.',
+    foco: enSuelo(SITIO_ARRANQUE[0], SITIO_ARRANQUE[1]),
+  },
+  {
+    id: 'dulce-amarga',
+    kicker: 'Paso 4 de 4 · Dulce y amarga',
+    texto:
+      'Hay yucas dulces y yucas amargas, y la diferencia no es el sabor no más: la amarga carga mucho más compuesto cianogénico, y por eso NUNCA se come cruda. Cocinarla, remojarla o rallarla y exprimirla es lo que la vuelve segura. La dulce necesita menos, pero cocida siempre. Esta es la regla que no se salta.',
+    foco: enSuelo(SITIO_ARRANQUE[0] - 2.6, SITIO_ARRANQUE[1] + 1.4),
+  },
+];
+
+const CSS = `
+.myucal { position: relative; width: 100%; height: 100%; overflow: hidden; background: #e3d3b4; }
+.myucal canvas { opacity: 0; transition: opacity 0.9s ease; }
+.myucal .yucal-canvas--lista canvas, .myucal canvas.yucal-canvas--lista { opacity: 1; }
+@media (prefers-reduced-motion: reduce) {
+  .myucal canvas { transition: none; }
+}
+`;
+
+/* Acento del yucal para el panel compartido (tierra roja y follaje de clima
+   medio — la paleta del piso cálido, no la del páramo). */
+const TEMA_PANEL = {
+  fondo: 'rgba(26, 19, 12, 0.72)',
+  borde: 'rgba(214, 174, 122, 0.3)',
+  tinta: '#f3ece0',
+  kicker: '#e0b98a',
+  acentoA: 'rgba(206, 138, 74, 0.95)',
+  acentoB: 'rgba(160, 96, 48, 0.95)',
+  tintaAccion: '#221505',
+  activo: '#ce8a4a',
+};
+
+/**
+ * El mundo de la yuca de clima medio, completo: escena + pasos didácticos.
+ * Montar SOLO perezoso (lazy); llena a su contenedor.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function MundoYuca({ tier: tierProp, reducedMotion: rmProp } = {}) {
+  // Contrato de mundos: props del host si llegan; si se monta suelto,
+  // auto-detección del equipo (no matar la gama baja).
+  const auto = useMemo(() => decidirTier(), []);
+  const tier = tierProp ?? (permite3D(auto.tier) ? auto.tier : 'bajo');
+  const reducedMotion = rmProp ?? auto.reducedMotion;
+  const [paso, setPaso] = useState(0);
+
+  const actual = PASOS[paso];
+
+  return (
+    <div className="myucal">
+      <style>{CSS}</style>
+      <EscenaYucaViva tier={tier} reducedMotion={reducedMotion} foco={actual.foco} />
+
+      <PanelPasos
+        etiqueta="La lección del yucal"
+        pasos={PASOS}
+        paso={paso}
+        onPaso={setPaso}
+        tema={TEMA_PANEL}
+        reducedMotion={reducedMotion}
+      />
+    </div>
+  );
+}

--- a/src/visual/mundo3d/yuca/floraYuca.geom.js
+++ b/src/visual/mundo3d/yuca/floraYuca.geom.js
@@ -1,0 +1,1126 @@
+/*
+ * floraYuca.geom — la GEOMETRÍA del YUCAL de clima medio (0–2.000 m).
+ *
+ * La yuca (Manihot esculenta) es el pan del piso cálido y templado, y tiene dos
+ * firmas visuales que ninguna otra mata de la finca comparte:
+ *
+ *   1. EL TALLO CON CICATRICES. La yuca bota las hojas de abajo a medida que
+ *      crece, y cada hoja caída deja su marca en el nudo. El resultado es un
+ *      tallo leñoso, PELADO y ANILLADO de cicatrices en espiral, con el follaje
+ *      arriba no más. Esa es la seña que la delata a media distancia.
+ *   2. LA RAÍZ ARRANCADA. La imagen del cultivo no es la mata: es el momento en
+ *      que se alza la planta y la tierra entrega el racimo de raíces.
+ *
+ * Por eso este mundo se compone alrededor del ARRANQUE, y no del sembrado.
+ *
+ * Cada pieza con su identidad:
+ *
+ *   · Mata de yuca        — TRES esqueletos distintos (no una copia repetida):
+ *                           tronco leñoso anillado, horqueta arriba y follaje
+ *                           solo en las puntas. Cada mata deterministamente
+ *                           asignada a uno de los tres.
+ *   · Hoja palmeada       — 5–7 lóbulos lanceolados en abanico. Instanciada
+ *                           aparte para que quepa la variación.
+ *   · Pecíolo             — INSTANCIADO APARTE con color POR INSTANCIA: verde,
+ *                           rojo o morado. Es un rasgo de VARIEDAD real, y en la
+ *                           parcela campesina conviven varias.
+ *   · Raíz tuberosa       — el racimo destapado, color POR INSTANCIA (cáscara
+ *                           parda o rojiza).
+ *   · Corte de raíz       — la cara blanca de la pulpa donde se partió: cáscara
+ *                           parda por fuera, pulpa blanca por dentro.
+ *   · Estaca              — el trozo de tallo sembrado INCLINADO: así se
+ *                           propaga la yuca, por estaca y no por semilla.
+ *   · Plátano y maíz      — la asociación real de la parcela campesina.
+ *   · Monte / piedra      — el borde vivo del lote.
+ *
+ * TÉCNICA tier-safe (mismo contrato que floraPapa.geom): cada especie se FUSIONA
+ * en UNA geometría con el color horneado en vertexColors y se dibuja con UN
+ * InstancedMesh. PECÍOLO y RAÍZ se pintan BLANCOS en la geometría para que el
+ * color POR INSTANCIA (setColorAt) sea el real.
+ *
+ * ⚠️ mergeGeometries devuelve NULL EN SILENCIO si se mezclan geometrías
+ * indexadas con no-indexadas (mordida conocida): aquí TODO se desindexa antes de
+ * fusionar y se TRUENA si aun así falla.
+ *
+ * Aquí viven SOLO los datos y las mallas (nada de WebGL): corre headless.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+
+/* -------------------------------------------------------------------------- */
+/*  La loma templada (la geografía del mundo, determinista)                    */
+/* -------------------------------------------------------------------------- */
+
+export const ANCHO = 40; // x: -20 … 20
+export const FONDO = 38; // z: -19 (la loma del fondo) … 19 (el frente, abajo)
+
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const smoothstep = (a, b, x) => {
+  const t = clamp((x - a) / (b - a), 0, 1);
+  return t * t * (3 - 2 * t);
+};
+
+/* Ruido determinista (hash de senos): misma loma siempre, sin Math.random. */
+function ruido(wx, wz) {
+  return (
+    Math.sin(wx * 0.75 + wz * 0.55) * 0.5 +
+    Math.sin(wx * 1.7 - wz * 1.3 + 1.7) * 0.3 +
+    Math.sin(wx * 2.9 + wz * 2.5 + 4.4) * 0.2
+  );
+}
+
+/**
+ * La altura BASE de la loma (sin montículos). La yuca es de clima medio: la
+ * pendiente es MANSA comparada con el papal de tierra fría — loma de vega, no
+ * ladera brava. Y se queda baja a propósito: el sujeto es el arranque, no el
+ * cerro (si el fondo sube mucho, se come el encuadre).
+ */
+export function alturaBase(wx, wz) {
+  const sub = smoothstep(10, -17, wz); // 0 al frente (bajo), 1 en la loma
+  let h = 0.12;
+  h += sub * sub * 4.2; // loma mansa de clima medio
+  h += ruido(wx * 0.4, wz * 0.4) * 0.42 * (0.35 + sub);
+  return h;
+}
+
+/* --- Los MONTÍCULOS: la yuca se siembra en montón, mata por mata. ---------- */
+
+/* La yuca no va en caballón corrido como la papa: va en MONTÍCULO individual,
+   un montón de tierra por mata para que la raíz tenga dónde engordar y el agua
+   escurra. La retícula de siembra (~1,4 m entre matas) va horneada en el
+   relieve, y las matas se siembran justo encima de cada montón. */
+export const PASO_X = 1.45;
+export const PASO_Z = 1.6;
+
+/* Jitter determinista por celda: la siembra campesina no es una cuadrícula
+   de ingeniero, pero tampoco es azar — se ve la fila y se ve el desorden. */
+function hash2(i, j) {
+  const s = Math.sin(i * 127.1 + j * 311.7) * 43758.5453;
+  return s - Math.floor(s);
+}
+
+/** El centro real de la mata de la celda (i, j), con su desorden de siembra. */
+export function centroMata(i, j) {
+  return [
+    i * PASO_X + (hash2(i, j) - 0.5) * 0.52,
+    j * PASO_Z + (hash2(j + 7, i - 3) - 0.5) * 0.48,
+  ];
+}
+
+/* El lote sembrado y los claros que respeta. El ARRANQUE va ADELANTE, cerca de
+   la cámara: es el sujeto, no puede quedar escondido detrás del cultivo. */
+export const SITIO_ARRANQUE = /** @type {[number, number]} */ ([3.2, 6.4]);
+
+/* Las CEPAS ya arrancadas del claro: cada una es un tocón ladeado con su racimo
+   de raíces colgando. Van aquí arriba (y no enterradas en la distribución)
+   porque la escena las necesita para poner el canasto y el gancho al lado. */
+export const CEPAS_ARRANQUE = /** @type {[number, number][]} */ ([
+  [3.2 - 0.5, 6.4 + 0.3],
+  [3.2 + 1.4, 6.4 - 0.9],
+  [3.2 - 1.7, 6.4 - 1.3],
+]);
+export const SITIO_ESTACAS = /** @type {[number, number]} */ ([-5.2, 7.0]);
+export const SITIO_CASA = /** @type {[number, number]} */ ([-11.0, -12.2]);
+
+/** Máscara 0…1 del lote sembrado (dentro hay montículos; fuera, monte). */
+export function dentroLote(wx, wz) {
+  let m =
+    smoothstep(-15.5, -13, wx) *
+    smoothstep(15.5, 13, wx) *
+    smoothstep(8.2, 6.4, wz) *
+    smoothstep(-12.6, -10.4, wz);
+  // el claro del ARRANQUE (la tierra ya destapada)
+  const dAx = wx - SITIO_ARRANQUE[0];
+  const dAz = wz - SITIO_ARRANQUE[1];
+  m *= smoothstep(5.5, 12.5, dAx * dAx + dAz * dAz);
+  // el semillero de ESTACAS (la siembra que apenas arranca)
+  const dEx = wx - SITIO_ESTACAS[0];
+  const dEz = wz - SITIO_ESTACAS[1];
+  m *= smoothstep(4.5, 11, dEx * dEx + dEz * dEz);
+  // el patio de la casa
+  const dHx = wx - SITIO_CASA[0];
+  const dHz = wz - SITIO_CASA[1];
+  m *= smoothstep(9, 20, dHx * dHx + dHz * dHz);
+  return m;
+}
+
+/**
+ * El RELIEVE del montículo en un punto: la campana de tierra amontonada de la
+ * mata más cercana (se revisan las 9 celdas vecinas porque el jitter puede
+ * acercar la de al lado). `lomo` sirve para pintar la tierra en el terreno.
+ */
+export function reliefMonticulo(wx, wz) {
+  const lote = dentroLote(wx, wz);
+  if (lote <= 0.001) return { alza: 0, lomo: 0, lote: 0 };
+  const i0 = Math.round(wx / PASO_X);
+  const j0 = Math.round(wz / PASO_Z);
+  let mejor = 1e9;
+  for (let di = -1; di <= 1; di++) {
+    for (let dj = -1; dj <= 1; dj++) {
+      const [cx, cz] = centroMata(i0 + di, j0 + dj);
+      const dx = wx - cx;
+      const dz = wz - cz;
+      const d2 = dx * dx + dz * dz;
+      if (d2 < mejor) mejor = d2;
+    }
+  }
+  const perfil = Math.exp(-mejor / 0.4);
+  return { alza: perfil * 0.3 * lote, lomo: perfil * lote, lote };
+}
+
+/** La altura FINAL de la loma con los montículos horneados. */
+export function alturaYucal(wx, wz) {
+  return alturaBase(wx, wz) + reliefMonticulo(wx, wz).alza;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Presupuesto por tier                                                       */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Instancias por especie. 'alto' puebla el yucal pleno; 'medio' es frugal;
+ * 'bajo' deja lo mínimo para que AÚN se lea "yucal con la raíz destapada". Las
+ * HOJAS no se cuentan aquí: salen del esqueleto de cada mata (tantas como
+ * puntas tenga), y el tier las recorta bajando el detalle del esqueleto.
+ */
+export const FLORA_YUCA = {
+  alto: { mata: 58, raiz: 30, estaca: 20, platano: 8, maiz: 46, monte: 34, piedra: 9 },
+  medio: { mata: 34, raiz: 18, estaca: 12, platano: 5, maiz: 26, monte: 20, piedra: 5 },
+  bajo: { mata: 16, raiz: 9, estaca: 6, platano: 3, maiz: 12, monte: 9, piedra: 3 },
+};
+
+/** Conteos para un tier (desconocido → frugal, nunca el más caro). */
+export const yucalDeTier = (tier) => FLORA_YUCA[tier] || FLORA_YUCA.medio;
+
+/** Factor de detalle geométrico por tier (menos nudos/lóbulos en gama baja). */
+export const CALIDAD_YUCA = { alto: 1, medio: 0.62, bajo: 0.42 };
+export const calidadYuca = (tier) => CALIDAD_YUCA[tier] ?? CALIDAD_YUCA.medio;
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del yucal (colores horneados en vertexColors)                       */
+/* -------------------------------------------------------------------------- */
+
+export const PAL = {
+  // El tallo leñoso: pardo claro, y las cicatrices MÁS OSCURAS para que el
+  // anillado se lea aunque la luz esté plana.
+  tallo: '#8d6c4a',
+  talloAlto: '#9d7f55', // arriba, donde la madera aún está tierna
+  cicatriz: '#63472f', // la marca de la hoja caída (el rasgo que la delata)
+  yema: '#7d9440', // la yema que asoma sobre cada cicatriz
+
+  // El follaje: verde franco de clima medio, con cara al sol y cara en sombra
+  hoja: '#3f6f3a',
+  hojaSol: '#548c3d',
+  hojaSombra: '#335b31',
+
+  // El PECÍOLO va POR INSTANCIA (referencia): el rasgo de variedad
+  pecioloVerde: '#83a244',
+  pecioloRojo: '#b04530',
+  pecioloMorado: '#7a3a68',
+
+  // La RAÍZ va POR INSTANCIA (referencia): la cáscara
+  raizParda: '#9a6b45',
+  raizRojiza: '#a4593a',
+  // …y la PULPA es fija: blanca cremosa, el contraste que enseña el corte
+  raizPulpa: '#f2e8d2',
+
+  // La asociación de la parcela
+  platanoTallo: '#7f8c4a',
+  platanoHoja: '#4a8340',
+  platanoHojaSol: '#63a04a',
+  maizTallo: '#7d9340',
+  maizHoja: '#6d9a3e',
+
+  // El borde vivo y el suelo
+  monte: '#4d7a3c',
+  monteSeco: '#8e9a52',
+  tierraRoja: '#8a5636',
+  tierraAbierta: '#6d4527',
+  piedra: '#9a8b74',
+  liquen: '#a5a986',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Utilidades (fusión desindexada + colocación + color horneado)              */
+/* -------------------------------------------------------------------------- */
+
+const UP = new THREE.Vector3(0, 1, 0);
+
+/** Hornea un color plano en TODOS los vértices (atributo `color`). */
+function pintar(geo, color) {
+  const c = color instanceof THREE.Color ? color : new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Coloca una geometría (posición/rotación/escala) transformando vértices. */
+function poner(geo, pos = [0, 0, 0], rot = [0, 0, 0], scale = [1, 1, 1]) {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rot[0], rot[1], rot[2])),
+    new THREE.Vector3(scale[0], scale[1], scale[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/** Orienta el +Y de la geometría hacia `dir` y la ubica en `pos`. */
+function apuntar(geo, pos, dir, esc = [1, 1, 1]) {
+  const d = new THREE.Vector3(dir[0], dir[1], dir[2]).normalize();
+  const q = new THREE.Quaternion().setFromUnitVectors(UP, d);
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos[0], pos[1], pos[2]),
+    q,
+    new THREE.Vector3(esc[0], esc[1], esc[2]),
+  );
+  geo.applyMatrix4(m);
+  return geo;
+}
+
+/**
+ * Fusiona partes (ya coloreadas) en UNA geometría. Se DESINDEXA todo antes de
+ * fusionar y se TRUENA si falla: mejor un error de build que una especie
+ * invisible en producción (mordida conocida de mergeGeometries).
+ */
+function fusionar(partes) {
+  const buenas = partes.filter(Boolean).map((p) => {
+    const plana = p.index ? p.toNonIndexed() : p;
+    if (plana !== p) p.dispose();
+    return plana;
+  });
+  const g = mergeGeometries(buenas, false);
+  if (!g) {
+    throw new Error('floraYuca: mergeGeometries devolvió null — atributos incompatibles entre partes');
+  }
+  return g;
+}
+
+/** Pequeña variación determinista de color (que el yucal no sea plano). */
+function variar(base, r, amt = 0.06) {
+  const c = new THREE.Color(base);
+  c.multiplyScalar(1 + (r() - 0.5) * amt * 2);
+  return c;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL ESQUELETO DE LA MATA — la estructura, aparte de la malla               */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La forma de la yuca en tres datos: el tronco anillado, la horqueta donde se
+ * abre, y las PUNTAS donde vive el follaje. Se calcula aparte de la geometría
+ * porque las HOJAS se instancian por separado (para que el pecíolo pueda llevar
+ * su color de variedad) y necesitan saber dónde se agarran.
+ *
+ * Se generan VARIOS esqueletos con semillas distintas y cada mata se asigna a
+ * uno: sin esto todas las matas salen clonadas y el yucal se lee como
+ * estampado, no como cultivo (el pecado de las copas-brócoli).
+ */
+export function esqueletoYuca(seed = 31, q = 1) {
+  const r = rng(seed);
+
+  const altoTronco = 1.15 + r() * 0.55; // hasta la primera horqueta
+  const radioBase = 0.055 + r() * 0.016;
+  const radioHorqueta = radioBase * 0.62;
+
+  // Los NUDOS del tronco: donde estuvo cada hoja que ya se cayó. Van en
+  // espiral (filotaxia), que es como de verdad se ordenan en el tallo.
+  const nNudos = Math.max(5, Math.round(12 * q));
+  const nudos = [];
+  for (let i = 0; i < nNudos; i++) {
+    const t = (i + 0.6) / (nNudos + 0.5);
+    nudos.push({
+      y: t * altoTronco,
+      ang: i * 2.399 + r() * 0.25, // ~137,5°: la espiral de la filotaxia
+      radio: radioBase * (1 - t * 0.38),
+    });
+  }
+
+  // La HORQUETA: la yuca se abre en dos o tres brazos cuando florece.
+  const nRamas = q < 0.5 ? 2 : 2 + (r() > 0.55 ? 1 : 0);
+  const ramas = [];
+  const puntas = [];
+  const giro = r() * Math.PI * 2;
+  for (let i = 0; i < nRamas; i++) {
+    const a = giro + (i / nRamas) * Math.PI * 2 + (r() - 0.5) * 0.4;
+    const abre = 0.42 + r() * 0.3; // cuánto se abre del eje vertical
+    const largo = 0.6 + r() * 0.3;
+    const dir = [Math.cos(a) * abre, 1, Math.sin(a) * abre];
+    const base = [0, altoTronco, 0];
+    const n = Math.hypot(dir[0], dir[1], dir[2]);
+    const fin = [
+      base[0] + (dir[0] / n) * largo,
+      base[1] + (dir[1] / n) * largo,
+      base[2] + (dir[2] / n) * largo,
+    ];
+    ramas.push({ base, fin, dir, largo, radio: radioHorqueta });
+
+    // Segunda horqueta en gama alta: la mata adulta se vuelve a partir.
+    if (q >= 0.6 && r() > 0.35) {
+      const nSub = 2;
+      for (let k = 0; k < nSub; k++) {
+        const a2 = a + (k === 0 ? -0.7 : 0.7) + (r() - 0.5) * 0.3;
+        const abre2 = 0.5 + r() * 0.3;
+        const largo2 = largo * (0.6 + r() * 0.2);
+        const dir2 = [Math.cos(a2) * abre2, 1, Math.sin(a2) * abre2];
+        const n2 = Math.hypot(dir2[0], dir2[1], dir2[2]);
+        const fin2 = [
+          fin[0] + (dir2[0] / n2) * largo2,
+          fin[1] + (dir2[1] / n2) * largo2,
+          fin[2] + (dir2[2] / n2) * largo2,
+        ];
+        ramas.push({ base: fin, fin: fin2, dir: dir2, largo: largo2, radio: radioHorqueta * 0.7 });
+        puntas.push({ pos: fin2, dir: dir2, vigor: 0.85 + r() * 0.25 });
+      }
+    } else {
+      puntas.push({ pos: fin, dir, vigor: 0.9 + r() * 0.25 });
+    }
+  }
+
+  return { altoTronco, radioBase, radioHorqueta, nudos, ramas, puntas };
+}
+
+/**
+ * Las HOJAS que cuelga un esqueleto, en espacio local de la mata. Cada punta
+ * saca una roseta de hojas: así es la yuca — el follaje SOLO arriba, porque
+ * abajo ya se le cayeron (y por eso el tallo queda anillado de cicatrices).
+ * Devuelve, por hoja, dónde se agarra el pecíolo y hacia dónde sale.
+ */
+export function hojasDeEsqueleto(esq, q = 1) {
+  const r = rng(97);
+  const hojas = [];
+  const nPorPunta = Math.max(3, Math.round(6 * q));
+  for (const punta of esq.puntas) {
+    for (let i = 0; i < nPorPunta; i++) {
+      const a = (i / nPorPunta) * Math.PI * 2 + r() * 0.7;
+      // las hojas salen en abanico alrededor de la punta, unas paradas y
+      // otras ya vencidas hacia afuera (la yuca las carga colgando)
+      const caida = -0.15 + r() * 0.95;
+      const dir = [Math.cos(a) * (0.55 + r() * 0.5), caida, Math.sin(a) * (0.55 + r() * 0.5)];
+      const n = Math.hypot(dir[0], dir[1], dir[2]) || 1;
+      hojas.push({
+        base: [
+          punta.pos[0] + (r() - 0.5) * 0.05,
+          punta.pos[1] - r() * 0.1,
+          punta.pos[2] + (r() - 0.5) * 0.05,
+        ],
+        dir: [dir[0] / n, dir[1] / n, dir[2] / n],
+        peciolo: (0.19 + r() * 0.13) * punta.vigor, // 19–32 cm: bien visible
+        esc: (0.85 + r() * 0.35) * punta.vigor,
+        giro: r() * Math.PI * 2,
+      });
+    }
+  }
+  return hojas;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  MATA DE YUCA — el tallo leñoso ANILLADO DE CICATRICES                     */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * El tronco pelado con su anillado, la horqueta y nada más: el follaje se
+ * instancia aparte. Cada CICATRIZ es un anillo un poco más ancho que el tallo,
+ * pintado más oscuro, con una yema encima — y van en espiral. Ese detalle es
+ * caro en vértices pero es LA identidad del cultivo: sin él la yuca es un palo
+ * cualquiera.
+ */
+export function geomMataYuca(esq, { q = 1 } = {}) {
+  const r = rng(41);
+  const partes = [];
+
+  // El tronco: leñoso abajo, más tierno arriba.
+  const tronco = new THREE.CylinderGeometry(
+    esq.radioHorqueta,
+    esq.radioBase,
+    esq.altoTronco,
+    q < 0.5 ? 5 : 7,
+    1,
+  );
+  poner(tronco, [0, esq.altoTronco / 2, 0]);
+  partes.push(pintar(tronco, PAL.tallo));
+
+  // LAS CICATRICES: el anillado en espiral que delata a la yuca.
+  const ladosNudo = q < 0.5 ? 5 : 6;
+  for (const nd of esq.nudos) {
+    const anillo = new THREE.CylinderGeometry(nd.radio * 1.34, nd.radio * 1.2, 0.036, ladosNudo, 1);
+    poner(anillo, [0, nd.y, 0]);
+    partes.push(pintar(anillo, PAL.cicatriz));
+    // la marca en relieve de la hoja que se cayó, mirando hacia su lado
+    const marca = new THREE.ConeGeometry(nd.radio * 0.52, 0.075, 4, 1);
+    apuntar(
+      marca,
+      [Math.cos(nd.ang) * nd.radio * 1.1, nd.y + 0.012, Math.sin(nd.ang) * nd.radio * 1.1],
+      [Math.cos(nd.ang), 0.55, Math.sin(nd.ang)],
+    );
+    partes.push(pintar(marca, PAL.cicatriz));
+    // y la YEMA que espera arriba de la cicatriz (de ahí rebrota la estaca)
+    if (q >= 0.6) {
+      const yema = new THREE.IcosahedronGeometry(nd.radio * 0.3, 0);
+      poner(yema, [
+        Math.cos(nd.ang) * nd.radio * 1.05,
+        nd.y + 0.055,
+        Math.sin(nd.ang) * nd.radio * 1.05,
+      ]);
+      partes.push(pintar(yema, PAL.yema));
+    }
+  }
+
+  // La horqueta: los brazos que se abren arriba, también anillados.
+  for (const rama of esq.ramas) {
+    const largo = Math.hypot(
+      rama.fin[0] - rama.base[0],
+      rama.fin[1] - rama.base[1],
+      rama.fin[2] - rama.base[2],
+    );
+    const brazo = new THREE.CylinderGeometry(rama.radio * 0.68, rama.radio, largo, q < 0.5 ? 4 : 6, 1);
+    apuntar(
+      brazo,
+      [
+        (rama.base[0] + rama.fin[0]) / 2,
+        (rama.base[1] + rama.fin[1]) / 2,
+        (rama.base[2] + rama.fin[2]) / 2,
+      ],
+      [
+        rama.fin[0] - rama.base[0],
+        rama.fin[1] - rama.base[1],
+        rama.fin[2] - rama.base[2],
+      ],
+    );
+    partes.push(pintar(brazo, variar(PAL.talloAlto, r, 0.05)));
+
+    // un par de cicatrices también en el brazo (sigue botando hoja)
+    if (q >= 0.6) {
+      for (let k = 1; k <= 2; k++) {
+        const t = k / 3;
+        const anillo = new THREE.CylinderGeometry(rama.radio * 1.3, rama.radio * 1.15, 0.03, 5, 1);
+        apuntar(
+          anillo,
+          [
+            rama.base[0] + (rama.fin[0] - rama.base[0]) * t,
+            rama.base[1] + (rama.fin[1] - rama.base[1]) * t,
+            rama.base[2] + (rama.fin[2] - rama.base[2]) * t,
+          ],
+          [
+            rama.fin[0] - rama.base[0],
+            rama.fin[1] - rama.base[1],
+            rama.fin[2] - rama.base[2],
+          ],
+        );
+        partes.push(pintar(anillo, PAL.cicatriz));
+      }
+    }
+  }
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  HOJA PALMEADA — los lóbulos en abanico                                    */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La hoja de yuca es PALMEADA y profundamente lobulada: los lóbulos salen todos
+ * de un mismo punto, como los dedos de una mano abierta, y los del centro son
+ * más largos que los de los lados. Cada lóbulo es un octaedro achatado —
+ * lanceolado, puntudo en las dos puntas y ancho en la mitad — que es justo la
+ * forma del lóbulo real y cuesta ocho triángulos.
+ *
+ * Se construye ACOSTADA en el plano XZ y con el punto de agarre en el origen:
+ * la instancia la orienta después.
+ */
+export function geomHojaYuca({ q = 1 } = {}, seed = 51) {
+  const r = rng(seed);
+  const partes = [];
+  const nLobulos = q < 0.5 ? 5 : 5 + Math.round(r() * 2); // 5–7 lóbulos
+
+  for (let i = 0; i < nLobulos; i++) {
+    // el abanico se abre ~200°, con los lóbulos del centro más largos
+    const t = nLobulos === 1 ? 0.5 : i / (nLobulos - 1);
+    const a = (t - 0.5) * 2.6;
+    const centro = 1 - Math.abs(t - 0.5) * 1.25; // 1 en el medio, 0.37 en el borde
+    const largo = 0.17 + centro * 0.13;
+    const ancho = 0.031 + centro * 0.019;
+
+    const lobulo = new THREE.OctahedronGeometry(1, 0);
+    // achatado a lámina y estirado a lanceta
+    poner(
+      lobulo,
+      [Math.sin(a) * largo * 0.52, 0, Math.cos(a) * largo * 0.52],
+      [0, -a, 0],
+      [ancho, 0.012, largo * 0.62],
+    );
+    const tono = r();
+    partes.push(
+      pintar(lobulo, variar(tono > 0.66 ? PAL.hojaSol : tono > 0.28 ? PAL.hoja : PAL.hojaSombra, r, 0.07)),
+    );
+  }
+
+  return fusionar(partes);
+}
+
+/**
+ * El PECÍOLO: el rabito que sostiene la hoja. Va BLANCO en la geometría porque
+ * su color real —verde, rojo o morado— es un rasgo de VARIEDAD y viaja POR
+ * INSTANCIA. Es largo y bien visible: en la yuca no es un detalle, es una seña.
+ * Se construye del origen hacia +Y con largo 1 (la instancia lo escala).
+ */
+export function geomPecioloYuca() {
+  const g = new THREE.CylinderGeometry(0.011, 0.015, 1, 4, 1);
+  poner(g, [0, 0.5, 0]);
+  return pintar(g.index ? g.toNonIndexed() : g, '#ffffff');
+}
+
+/* -------------------------------------------------------------------------- */
+/*  RAÍZ TUBEROSA — la imagen del cultivo                                     */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La raíz de yuca es ALARGADA y cónica, con el cuello grueso pegado a la mata y
+ * la punta afilada. Va BLANCA en la geometría: la cáscara —parda o rojiza según
+ * la variedad— viaja POR INSTANCIA. Se construye acostada a lo largo de +Y para
+ * que la instancia la pueda apuntar en cualquier dirección del racimo.
+ */
+export function geomRaizYuca({ q = 1 } = {}) {
+  const partes = [];
+  const lados = q < 0.5 ? 5 : 7;
+  // el cuerpo: grueso en el cuello, afilándose a la punta
+  const cuerpo = new THREE.CylinderGeometry(0.052, 0.085, 0.62, lados, 1);
+  poner(cuerpo, [0, 0.31, 0]);
+  partes.push(pintar(cuerpo, '#ffffff'));
+  // la punta afilada
+  const punta = new THREE.ConeGeometry(0.052, 0.16, lados, 1);
+  poner(punta, [0, 0.68, 0]);
+  partes.push(pintar(punta, '#ffffff'));
+  // el cuello leñoso que la amarra a la mata
+  const cuello = new THREE.CylinderGeometry(0.03, 0.052, 0.1, lados, 1);
+  poner(cuello, [0, -0.05, 0]);
+  partes.push(pintar(cuello, '#ffffff'));
+  return fusionar(partes);
+}
+
+/**
+ * EL CORTE de la raíz: la cara blanca de la pulpa donde se partió. Color FIJO
+ * (no por instancia) — justamente porque el punto es el contraste: por fuera
+ * parda, por dentro blanca. Se pega en el cuello de algunas raíces.
+ */
+export function geomCorteRaiz() {
+  const g = new THREE.CylinderGeometry(0.054, 0.05, 0.03, 8, 1);
+  return pintar(g.index ? g.toNonIndexed() : g, PAL.raizPulpa);
+}
+
+/*
+ * EL TOCÓN del arranque: cuando se cosecha yuca NO se hala la planta entera —
+ * primero se le corta el tallo (que se guarda para semilla) y queda un muñón de
+ * unos 30 cm, y de ese muñón se palanquea la mata hasta que la tierra suelta el
+ * racimo. Por eso el arranque se dibuja así: el tocón inclinado con las raíces
+ * colgando del cuello, y no una planta entera acostada.
+ */
+export function geomToconYuca({ q = 1 } = {}, seed = 63) {
+  const r = rng(seed);
+  const partes = [];
+  const largo = 0.42;
+  const palo = new THREE.CylinderGeometry(0.045, 0.062, largo, q < 0.5 ? 5 : 7, 1);
+  poner(palo, [0, largo / 2, 0]);
+  partes.push(pintar(palo, PAL.tallo));
+
+  // el corte de machete arriba: la cara clara de la madera fresca
+  const corte = new THREE.CylinderGeometry(0.046, 0.045, 0.02, 7, 1);
+  poner(corte, [0, largo + 0.008, 0], [0.12, 0, 0.06]);
+  partes.push(pintar(corte, PAL.talloAlto));
+
+  const nNudos = q < 0.5 ? 2 : 4;
+  for (let i = 0; i < nNudos; i++) {
+    const y = 0.07 + (i / nNudos) * (largo - 0.1);
+    const ang = i * 2.399 + r() * 0.3;
+    const anillo = new THREE.CylinderGeometry(0.07, 0.062, 0.03, 5, 1);
+    poner(anillo, [0, y, 0]);
+    partes.push(pintar(anillo, PAL.cicatriz));
+    const marca = new THREE.ConeGeometry(0.026, 0.06, 4, 1);
+    apuntar(marca, [Math.cos(ang) * 0.06, y + 0.01, Math.sin(ang) * 0.06], [Math.cos(ang), 0.5, Math.sin(ang)]);
+    partes.push(pintar(marca, PAL.cicatriz));
+  }
+
+  // el CUELLO: la corona leñosa de donde salen las raíces
+  const cuello = new THREE.IcosahedronGeometry(0.1, 0);
+  poner(cuello, [0, 0.02, 0], [0, r() * Math.PI, 0], [1.25, 0.8, 1.25]);
+  partes.push(pintar(cuello, PAL.cicatriz));
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  ESTACA — así se siembra la yuca (por tallo, no por semilla)               */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Un trozo de tallo maduro de unos 20–25 cm con varias yemas, enterrado
+ * INCLINADO. Esa inclinación no es capricho de dibujo: es como se siembra. La
+ * estaca lleva sus cicatrices y sus yemas, que es de donde rebrota.
+ */
+export function geomEstacaYuca({ q = 1 } = {}, seed = 61) {
+  const r = rng(seed);
+  const partes = [];
+  const largo = 0.36; // lo que asoma + lo que va enterrado
+  const palo = new THREE.CylinderGeometry(0.028, 0.032, largo, q < 0.5 ? 4 : 6, 1);
+  poner(palo, [0, largo / 2, 0]);
+  partes.push(pintar(palo, PAL.tallo));
+
+  const nNudos = q < 0.5 ? 2 : 4;
+  for (let i = 0; i < nNudos; i++) {
+    const y = 0.06 + (i / nNudos) * (largo - 0.08);
+    const ang = i * 2.399 + r() * 0.3;
+    const anillo = new THREE.CylinderGeometry(0.039, 0.035, 0.028, 5, 1);
+    poner(anillo, [0, y, 0]);
+    partes.push(pintar(anillo, PAL.cicatriz));
+    const yema = new THREE.IcosahedronGeometry(0.019, 0);
+    poner(yema, [Math.cos(ang) * 0.033, y + 0.035, Math.sin(ang) * 0.033]);
+    partes.push(pintar(yema, PAL.yema));
+  }
+
+  // el brote tierno que ya arrancó en las estacas más viejas del semillero
+  const brote = new THREE.ConeGeometry(0.03, 0.15, 4, 1);
+  apuntar(brote, [0.02, largo - 0.02, 0.01], [0.25, 1, 0.15]);
+  partes.push(pintar(brote, PAL.hojaSol));
+
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LA ASOCIACIÓN — plátano y maíz (la parcela campesina no es monocultivo)   */
+/* -------------------------------------------------------------------------- */
+
+/** El plátano: pseudotallo grueso y las paletas grandes, ya rasgadas por el viento. */
+export function geomPlatano({ q = 1 } = {}, seed = 71) {
+  const r = rng(seed);
+  const partes = [];
+  const alto = 2.1 + r() * 0.5;
+
+  const tallo = new THREE.CylinderGeometry(0.11, 0.19, alto, q < 0.5 ? 5 : 7, 1);
+  poner(tallo, [0, alto / 2, 0]);
+  partes.push(pintar(tallo, PAL.platanoTallo));
+
+  const nHojas = Math.max(4, Math.round(7 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const a = (i / nHojas) * Math.PI * 2 + r() * 0.5;
+    const caida = -0.25 - r() * 0.5; // las paletas se vencen hacia afuera
+    const largo = 1.0 + r() * 0.5;
+    // la paleta: una lámina larga, no una bola
+    const paleta = new THREE.OctahedronGeometry(1, 0);
+    poner(paleta, [0, 0, 0], [0, 0, 0], [0.15, 0.02, largo * 0.5]);
+    apuntar(
+      paleta,
+      [Math.cos(a) * largo * 0.42, alto + caida * 0.35, Math.sin(a) * largo * 0.42],
+      [Math.cos(a) * 0.85, 0.42 + caida * 0.3, Math.sin(a) * 0.85],
+    );
+    partes.push(pintar(paleta, variar(i % 2 ? PAL.platanoHojaSol : PAL.platanoHoja, r, 0.07)));
+  }
+  return fusionar(partes);
+}
+
+/** El maíz: la caña con sus hojas colgadas y la espiga arriba. */
+export function geomMaiz({ q = 1 } = {}, seed = 73) {
+  const r = rng(seed);
+  const partes = [];
+  const alto = 1.5 + r() * 0.45;
+
+  const cana = new THREE.CylinderGeometry(0.022, 0.035, alto, 4, 1);
+  poner(cana, [0, alto / 2, 0]);
+  partes.push(pintar(cana, PAL.maizTallo));
+
+  const nHojas = Math.max(3, Math.round(6 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const a = i * 2.4 + r() * 0.4;
+    const y = 0.35 + (i / nHojas) * (alto - 0.5);
+    const largo = 0.55 + r() * 0.3;
+    const hoja = new THREE.OctahedronGeometry(1, 0);
+    poner(hoja, [0, 0, 0], [0, 0, 0], [0.045, 0.012, largo * 0.5]);
+    apuntar(
+      hoja,
+      [Math.cos(a) * largo * 0.34, y, Math.sin(a) * largo * 0.34],
+      [Math.cos(a) * 0.9, -0.25 - r() * 0.35, Math.sin(a) * 0.9],
+    );
+    partes.push(pintar(hoja, variar(PAL.maizHoja, r, 0.08)));
+  }
+
+  const espiga = new THREE.ConeGeometry(0.035, 0.28, 4, 1);
+  poner(espiga, [0, alto + 0.12, 0]);
+  partes.push(pintar(espiga, PAL.monteSeco));
+  return fusionar(partes);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  MONTE Y PIEDRA — el borde vivo del lote                                   */
+/* -------------------------------------------------------------------------- */
+
+export function geomMonte({ q = 1 } = {}, seed = 77) {
+  const r = rng(seed);
+  const partes = [];
+  const nMasas = Math.max(2, Math.round(4 * q));
+  for (let i = 0; i < nMasas; i++) {
+    const a = (i / nMasas) * Math.PI * 2 + r();
+    const rad = 0.18 + r() * 0.14;
+    const masa = new THREE.IcosahedronGeometry(rad, 0);
+    poner(
+      masa,
+      [Math.cos(a) * 0.16, 0.14 + r() * 0.18, Math.sin(a) * 0.16],
+      [0, r() * Math.PI, 0],
+      [1.2, 0.8, 1.2],
+    );
+    partes.push(pintar(masa, variar(r() > 0.7 ? PAL.monteSeco : PAL.monte, r, 0.08)));
+  }
+  return fusionar(partes);
+}
+
+export function geomPiedra(seed = 79) {
+  const r = rng(seed);
+  const roca = new THREE.DodecahedronGeometry(0.3, 0);
+  poner(roca, [0, 0.12, 0], [r() * 0.6, r() * Math.PI, r() * 0.6], [1.3, 0.65, 1]);
+  const capa = new THREE.DodecahedronGeometry(0.15, 0);
+  poner(capa, [0.1, 0.22, 0.04], [0, r() * Math.PI, 0], [1, 0.55, 1]);
+  return fusionar([pintar(roca, PAL.piedra), pintar(capa, PAL.liquen)]);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Distribución: el yucal sembrado + el arranque + el semillero              */
+/* -------------------------------------------------------------------------- */
+
+/* Cuántos esqueletos distintos hay (que el yucal no se lea como estampado). */
+export const N_ESQUELETOS = 3;
+
+/* Las semillas de las tres variantes de mata (deterministas, una por variante). */
+export const SEMILLAS_ESQUELETO = [31, 137, 419];
+
+/**
+ * Construye los N esqueletos del yucal, cada uno YA con sus hojas colgadas.
+ * Es la única puerta: la malla de la mata y la instancia de sus hojas tienen que
+ * salir del MISMO esqueleto, o las hojas quedan flotando al lado del tallo.
+ */
+export function construirEsqueletos(q = 1) {
+  return SEMILLAS_ESQUELETO.map((s) => {
+    const esq = esqueletoYuca(s, q);
+    return { ...esq, hojas: hojasDeEsqueleto(esq, q) };
+  });
+}
+
+/**
+ * Siembra determinista del yucal completo.
+ *
+ * `esqs` son los N esqueletos ya construidos (uno por variante de mata): se
+ * necesitan aquí porque las HOJAS se instancian aparte y tienen que agarrarse
+ * exactamente donde la malla de la mata puso sus puntas.
+ *
+ * Devuelve items por especie con el contrato del componente `Especie`:
+ * `{pos, quat?, rotY?, escala, tint}`. Para PECÍOLO el `tint` ES el color de la
+ * variedad, y para RAÍZ el de la cáscara.
+ */
+export function distribucionYucal(conteos, esqs, seed = 523) {
+  const c = conteos;
+  const rMat = rng(seed + 1);
+  const rHoj = rng(seed + 2);
+  const rSue = rng(seed + 3);
+  const rRaiz = rng(seed + 4);
+
+  /* --- Las matas sobre su montículo, en la retícula de siembra. ----------- */
+  const sitios = [];
+  const iMin = Math.ceil(-14 / PASO_X);
+  const iMax = Math.floor(14 / PASO_X);
+  const jMin = Math.ceil(-11.5 / PASO_Z);
+  const jMax = Math.floor(7.5 / PASO_Z);
+  for (let j = jMin; j <= jMax; j++) {
+    for (let i = iMin; i <= iMax; i++) {
+      const [px, pz] = centroMata(i, j);
+      if (dentroLote(px, pz) < 0.6) continue; // fuera del lote o en un claro
+      sitios.push({ px, pz, i, j });
+    }
+  }
+  // recorte determinista al presupuesto del tier (salto parejo, no los primeros N)
+  const paso = Math.max(1, Math.floor(sitios.length / Math.max(1, c.mata)));
+  const elegidos = [];
+  for (let k = 0; k < sitios.length && elegidos.length < c.mata; k += paso) {
+    elegidos.push(sitios[k]);
+  }
+
+  /* La VARIEDAD de cada mata decide el color de su pecíolo. En una parcela
+     campesina conviven varias: verde la más común, y las de pecíolo rojo o
+     morado se reconocen de lejos. */
+  const pecVerde = new THREE.Color(PAL.pecioloVerde);
+  const pecRojo = new THREE.Color(PAL.pecioloRojo);
+  const pecMorado = new THREE.Color(PAL.pecioloMorado);
+  const col = new THREE.Color();
+
+  // una lista de items por VARIANTE de esqueleto (cada una es su propio banco)
+  const mata = Array.from({ length: esqs.length }, () => []);
+  const hoja = [];
+  const peciolo = [];
+
+  const mPlanta = new THREE.Matrix4();
+  const mHoja = new THREE.Matrix4();
+  const mFinal = new THREE.Matrix4();
+  const vPos = new THREE.Vector3();
+  const qRot = new THREE.Quaternion();
+  const vEsc = new THREE.Vector3();
+  const vDir = new THREE.Vector3();
+  const qDir = new THREE.Quaternion();
+  const arriba = new THREE.Vector3(0, 1, 0);
+
+  elegidos.forEach((s) => {
+    const variante = Math.floor(rMat() * esqs.length) % esqs.length;
+    const esq = esqs[variante];
+    const escala = 0.82 + rMat() * 0.45;
+    const rotY = rMat() * Math.PI * 2;
+    const y = alturaYucal(s.px, s.pz);
+
+    mata[variante].push({
+      pos: [s.px, y, s.pz],
+      rotY,
+      escala,
+      tint: [0.92 + rMat() * 0.14, 0.92 + rMat() * 0.14, 0.92 + rMat() * 0.14],
+    });
+
+    // el color de pecíolo de ESTA mata (su variedad)
+    const v = rMat();
+    if (v > 0.82) col.copy(pecMorado);
+    else if (v > 0.58) col.copy(pecRojo);
+    else col.copy(pecVerde);
+    col.multiplyScalar(0.92 + rMat() * 0.16);
+    const tintePeciolo = [col.r, col.g, col.b];
+
+    // la matriz de la planta, para llevar sus hojas locales al mundo
+    mPlanta.compose(
+      vPos.set(s.px, y, s.pz),
+      qRot.setFromEuler(new THREE.Euler(0, rotY, 0)),
+      vEsc.setScalar(escala),
+    );
+
+    for (const h of esq.hojas) {
+      // el PECÍOLO: del punto de agarre hacia la dirección de la hoja
+      vDir.set(h.dir[0], h.dir[1], h.dir[2]).normalize();
+      qDir.setFromUnitVectors(arriba, vDir);
+      mHoja.compose(
+        vPos.set(h.base[0], h.base[1], h.base[2]),
+        qDir,
+        vEsc.set(1, h.peciolo, 1),
+      );
+      mFinal.multiplyMatrices(mPlanta, mHoja);
+      mFinal.decompose(vPos, qRot, vEsc);
+      peciolo.push({
+        pos: [vPos.x, vPos.y, vPos.z],
+        quat: [qRot.x, qRot.y, qRot.z, qRot.w],
+        escalaXYZ: [vEsc.x, vEsc.y, vEsc.z],
+        tint: tintePeciolo,
+      });
+
+      // LA LÁMINA: al final del pecíolo, acostada y con su giro propio. Se
+      // inclina un poco con la caída de la hoja (la yuca la carga vencida).
+      const bx = h.base[0] + h.dir[0] * h.peciolo;
+      const by = h.base[1] + h.dir[1] * h.peciolo;
+      const bz = h.base[2] + h.dir[2] * h.peciolo;
+      const inclina = 0.25 + rHoj() * 0.45;
+      mHoja.compose(
+        vPos.set(bx, by, bz),
+        qRot.setFromEuler(
+          new THREE.Euler(Math.cos(h.giro) * inclina, h.giro, Math.sin(h.giro) * inclina),
+        ),
+        vEsc.setScalar(h.esc),
+      );
+      mFinal.multiplyMatrices(mPlanta, mHoja);
+      mFinal.decompose(vPos, qRot, vEsc);
+      hoja.push({
+        pos: [vPos.x, vPos.y, vPos.z],
+        quat: [qRot.x, qRot.y, qRot.z, qRot.w],
+        escala: vEsc.x,
+        tint: [0.9 + rHoj() * 0.2, 0.9 + rHoj() * 0.2, 0.9 + rHoj() * 0.2],
+      });
+    }
+  });
+
+  /* --- EL ARRANQUE: el racimo de raíces destapado. ------------------------ */
+  /* Las raíces no salen sueltas: salen EN RACIMO desde el cuello de la mata,
+     abriéndose como los radios de una rueda. Aquí se arman dos o tres matas
+     arrancadas con su racimo, más las raíces ya apartadas en el suelo. */
+  const cascParda = new THREE.Color(PAL.raizParda);
+  const cascRojiza = new THREE.Color(PAL.raizRojiza);
+  const raiz = [];
+  const corte = [];
+
+  const tocon = [];
+  const nCepas = Math.max(1, Math.min(CEPAS_ARRANQUE.length, Math.round(c.raiz / 7)));
+  let puestas = 0;
+
+  for (let k = 0; k < nCepas && puestas < c.raiz; k++) {
+    const [cx, cz] = CEPAS_ARRANQUE[k];
+    const suelo = alturaYucal(cx, cz);
+    /* EL CUELLO de la mata, ya alzado fuera de la tierra: de ahí para arriba va
+       el tocón cortado y de ahí para abajo cuelga el racimo. */
+    const cy = suelo + 0.56;
+    const ladeo = 0.45 + rRaiz() * 0.35; // lo que quedó ladeada al palanquearla
+    const haciaDonde = rRaiz() * Math.PI * 2;
+
+    // el TOCÓN: el muñón de tallo por donde se palanqueó, ladeado
+    tocon.push({
+      pos: [cx, cy - 0.06, cz],
+      rot: [Math.sin(haciaDonde) * ladeo, rRaiz() * Math.PI * 2, Math.cos(haciaDonde) * ladeo],
+      escala: 0.95 + rRaiz() * 0.25,
+      tint: [0.94 + rRaiz() * 0.12, 0.94 + rRaiz() * 0.12, 0.94 + rRaiz() * 0.12],
+    });
+
+    const nEnCepa = 4 + Math.floor(rRaiz() * 3); // 4–6 raíces por mata
+    const giro = rRaiz() * Math.PI * 2;
+    for (let i = 0; i < nEnCepa && puestas < c.raiz; i++) {
+      const a = giro + (i / nEnCepa) * Math.PI * 2 + (rRaiz() - 0.5) * 0.5;
+      // el racimo se abre hacia abajo-afuera, como salió de la tierra
+      const abre = 0.8 + rRaiz() * 0.5;
+      vDir.set(Math.cos(a) * abre, -0.62 - rRaiz() * 0.3, Math.sin(a) * abre).normalize();
+      qDir.setFromUnitVectors(arriba, vDir);
+      const esc = 0.85 + rRaiz() * 0.45;
+      if (rRaiz() > 0.62) col.copy(cascRojiza);
+      else col.copy(cascParda);
+      col.multiplyScalar(0.9 + rRaiz() * 0.2);
+      const px = cx + Math.cos(a) * 0.09;
+      const pz = cz + Math.sin(a) * 0.09;
+      raiz.push({
+        pos: [px, cy, pz],
+        quat: [qDir.x, qDir.y, qDir.z, qDir.w],
+        escala: esc,
+        tint: [col.r, col.g, col.b],
+      });
+      puestas += 1;
+    }
+    // el corte blanco: en cada cepa hay una raíz partida mostrando la pulpa
+    corte.push({
+      pos: [cx + 0.14, cy - 0.02, cz + 0.09],
+      rotY: rRaiz() * Math.PI,
+      escala: 1,
+      tint: [1, 1, 1],
+    });
+  }
+
+  // las raíces ya apartadas, acostadas en la tierra abierta del claro
+  while (puestas < c.raiz) {
+    const a = rRaiz() * Math.PI * 2;
+    const rad = 0.9 + Math.sqrt(rRaiz()) * 1.7;
+    const px = SITIO_ARRANQUE[0] + Math.cos(a) * rad;
+    const pz = SITIO_ARRANQUE[1] + Math.sin(a) * rad * 0.75;
+    // acostada: el eje +Y de la raíz apuntando casi horizontal
+    const ah = rRaiz() * Math.PI * 2;
+    vDir.set(Math.cos(ah), 0.12 + rRaiz() * 0.16, Math.sin(ah)).normalize();
+    qDir.setFromUnitVectors(arriba, vDir);
+    if (rRaiz() > 0.62) col.copy(cascRojiza);
+    else col.copy(cascParda);
+    col.multiplyScalar(0.9 + rRaiz() * 0.2);
+    raiz.push({
+      pos: [px, alturaYucal(px, pz) + 0.07, pz],
+      quat: [qDir.x, qDir.y, qDir.z, qDir.w],
+      escala: 0.8 + rRaiz() * 0.4,
+      tint: [col.r, col.g, col.b],
+    });
+    if (rRaiz() > 0.55) {
+      corte.push({
+        pos: [px - Math.cos(ah) * 0.05, alturaYucal(px, pz) + 0.07, pz - Math.sin(ah) * 0.05],
+        rotY: rRaiz() * Math.PI,
+        escala: 0.95,
+        tint: [1, 1, 1],
+      });
+    }
+    puestas += 1;
+  }
+
+  /* --- EL SEMILLERO: las estacas sembradas INCLINADAS. -------------------- */
+  const estaca = [];
+  for (let i = 0; i < c.estaca; i++) {
+    const fila = Math.floor(i / 5);
+    const enFila = i % 5;
+    const px = SITIO_ESTACAS[0] - 1.5 + enFila * 0.72 + (rSue() - 0.5) * 0.16;
+    const pz = SITIO_ESTACAS[1] - 0.9 + fila * 0.62 + (rSue() - 0.5) * 0.14;
+    // la inclinación de siembra: ~35–50° del vertical, todas para el mismo lado
+    const inc = 0.62 + rSue() * 0.26;
+    const giro = 0.5 + (rSue() - 0.5) * 0.5;
+    estaca.push({
+      pos: [px, alturaYucal(px, pz) - 0.04, pz],
+      rot: [Math.sin(giro) * inc, rSue() * Math.PI * 2, Math.cos(giro) * inc],
+      escala: 0.9 + rSue() * 0.3,
+      tint: [0.94 + rSue() * 0.12, 0.94 + rSue() * 0.12, 0.94 + rSue() * 0.12],
+    });
+  }
+
+  /* --- La ASOCIACIÓN: plátano en los bordes, maíz entre las matas. -------- */
+  const platano = [];
+  const sitiosPlat = [
+    [-12.8, 2.4], [-13.4, -3.6], [-12.2, -8.2], [12.6, 1.2],
+    [13.2, -4.8], [12.0, -9.0], [-9.5, 6.6], [9.8, 6.2],
+  ];
+  for (let i = 0; i < Math.min(c.platano, sitiosPlat.length); i++) {
+    const [x, z] = sitiosPlat[i];
+    platano.push({
+      pos: [x, alturaYucal(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.85 + rSue() * 0.35,
+      tint: [0.9 + rSue() * 0.18, 0.9 + rSue() * 0.18, 0.9 + rSue() * 0.18],
+    });
+  }
+
+  const maiz = [];
+  let intentosMaiz = 0;
+  while (maiz.length < c.maiz && intentosMaiz < c.maiz * 20) {
+    intentosMaiz += 1;
+    const x = -13 + rSue() * 26;
+    const z = -10.5 + rSue() * 16.5;
+    if (dentroLote(x, z) < 0.5) continue; // el maíz va DENTRO, intercalado
+    // que no se pare justo encima de una mata de yuca
+    const i0 = Math.round(x / PASO_X);
+    const j0 = Math.round(z / PASO_Z);
+    const [cx, cz] = centroMata(i0, j0);
+    if ((x - cx) ** 2 + (z - cz) ** 2 < 0.35) continue;
+    maiz.push({
+      pos: [x, alturaYucal(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.85 + rSue() * 0.35,
+      tint: [0.9 + rSue() * 0.2, 0.9 + rSue() * 0.2, 0.9 + rSue() * 0.2],
+    });
+  }
+
+  /* --- El monte y la piedra del borde (fuera del lote). ------------------- */
+  const monte = [];
+  let intentosMonte = 0;
+  while (monte.length < c.monte && intentosMonte < c.monte * 16) {
+    intentosMonte += 1;
+    const x = -19 + rSue() * 38;
+    const z = -18 + rSue() * 36;
+    if (dentroLote(x, z) > 0.25) continue;
+    const dHx = x - SITIO_CASA[0];
+    const dHz = z - SITIO_CASA[1];
+    if (dHx * dHx + dHz * dHz < 9) continue;
+    monte.push({
+      pos: [x, alturaYucal(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.7 + rSue() * 0.9,
+      tint: [0.9 + rSue() * 0.2, 0.9 + rSue() * 0.2, 0.9 + rSue() * 0.2],
+    });
+  }
+
+  const piedra = [];
+  let intentosPiedra = 0;
+  while (piedra.length < c.piedra && intentosPiedra < c.piedra * 16) {
+    intentosPiedra += 1;
+    const x = -18 + rSue() * 36;
+    const z = -16 + rSue() * 32;
+    if (dentroLote(x, z) > 0.25) continue;
+    piedra.push({
+      pos: [x, alturaYucal(x, z), z],
+      rotY: rSue() * Math.PI * 2,
+      escala: 0.7 + rSue() * 0.8,
+      tint: [0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16, 0.92 + rSue() * 0.16],
+    });
+  }
+
+  return { mata, hoja, peciolo, raiz, corte, tocon, estaca, platano, maiz, monte, piedra };
+}

--- a/src/visual/mundo3d/yuca/floraYuca.geom.js
+++ b/src/visual/mundo3d/yuca/floraYuca.geom.js
@@ -175,6 +175,35 @@ export function alturaYucal(wx, wz) {
 }
 
 /* -------------------------------------------------------------------------- */
+/*  LA CÁMARA — lo que este mundo NO puede fallar                             */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La cámara vive JUNTO A LA GEOGRAFÍA, no en la escena: encuadrar es una
+ * decisión sobre el terreno, y así el diagnóstico de encuadre puede importarla
+ * de verdad en vez de adivinarla leyendo el .jsx.
+ *
+ * El sujeto es el claro del ARRANQUE (z ≈ 6,4), no el cerro del fondo. Estos
+ * números están verificados por trazado de rayos contra esta MISMA función de
+ * altura (`node scripts/diag/encuadre-mundo.mjs yuca`), y calibrados contra el
+ * papal, que es un mundo ya aprobado:
+ *
+ *              cielo   terreno   tercio alto   sujeto
+ *   papal      32.8%    67.2%       0.6%       tercio bajo · derecha
+ *   yucal      37.2%    62.8%       0.0%       tercio bajo · derecha
+ *
+ * Si alguien mueve esto, que vuelva a correr el trazado. Medir el tamaño de las
+ * plantas NO es ver la escena: una cámara enterrada en la loma da números
+ * correctos de todo menos de lo único que importa, que es si el sujeto aparece.
+ */
+export const CAMARA = {
+  reposo: /** @type {[number, number, number]} */ ([1.4, 5.2, 16.4]),
+  mirada: /** @type {[number, number, number]} */ ([1.8, 3.4, 4.0]),
+  objetivo: /** @type {[number, number, number]} */ ([1.8, 2.2, 3.0]),
+  fov: 50,
+};
+
+/* -------------------------------------------------------------------------- */
 /*  Presupuesto por tier                                                       */
 /* -------------------------------------------------------------------------- */
 


### PR DESCRIPTION
Dos mundos 3D nuevos, **escenas separadas** a propósito: la yuca es de clima medio y la quinua de tierra fría, y por eso no comparten parcela.

Ninguno existía. Verificado antes de dibujar (`git ls-tree` + `grep` en App.jsx): sí existe `components/quinua/QuinuaScreen` en la ruta `#quinua`, pero es la pantalla **2D photo-forward de granos andinos** (quinua, amaranto, chía, cañihua, tarwi) — otro artefacto, ni se toca ni se duplica.

## Yuca — «el arranque»

La yuca se cuenta por dos señas que ningún otro cultivo de la finca tiene:

1. **El tallo pelado y anillado de cicatrices foliares.** Va soltando la hoja de abajo mientras crece y en cada nudo queda la marca, en espiral (filotaxia ~137,5°). Por eso el follaje va arriba no más. Esa es la seña que la delata a media distancia.
2. **El arranque.** La imagen del cultivo no es la mata: es el momento en que la tierra suelta el racimo.

Por eso la escena se compone al revés de lo habitual: **el claro de la cosecha va adelante y el cultivo queda detrás haciéndole de telón.**

- Montículo individual horneado en el relieve (la yuca no va en caballón corrido como la papa).
- **Tres esqueletos distintos** de mata — sin eso el yucal se lee como estampado.
- Hoja palmeada de 5–7 lóbulos lanceolados; **pecíolo con color por instancia** (verde / rojo / morado), que es un rasgo de variedad real.
- Racimo de raíces con cáscara por instancia y **la pulpa blanca del corte en color fijo** — el contraste es lo que enseña.
- Tocón de palanqueo (primero se corta el tallo y se guarda para semilla), estaca inclinada, plátano y maíz asociados.

## Quinua — «el campo de color»

El entregable es la **panoja**. La mata y la panoja se hornean casi blancas y todo el color viaja por instancia.

- **La ladera BAJA alejándose de la cámara**, al revés que el yucal y el papal. En una loma que sube, la primera fila tapa a la segunda; bajando, las 22 filas quedan a la vista.
- **El color va por manchas, no por planta**: el campesino siembra una variedad por tabla. Dos ruidos independientes cortados en la mediana medida del lote.
- **Dos tipos de panoja en bancos separados** por fidelidad, no por rendimiento: glomerulada (compacta) y amarantiforme (laxa).
- Cuatro variedades reales colombianas con su porte, tipo de panoja y color: Tunkahuán, Aurora, Blanca de Jericó y Punto Rojo. **Blanca de Jericó es dulce** (baja en saponina) y esa excepción le da sentido al paso del lavado.
- La era de la trilla con hoz, garrote, zaranda y **la batea del lavado — la espuma ES la saponina saliendo.**

## La cámara, que es lo que más ha fallado

Se añadió `scripts/diag/encuadre-mundo.mjs`: traza rayos por el encuadre real contra la misma función de altura del mundo y reporta el reparto del cuadro. **Medir la geometría no es ver la escena.**

Dos cosas que hacen que sirva de verdad:

- **Los umbrales salen de medir el papal**, que es un mundo ya aprobado, no de inventárselos. Un umbral puesto a ojo marcaba en rojo hasta al propio papal.
- **Traza contra el terreno MÁS el dosel del cultivo.** Con solo terreno, el quinual medía 8,6% de cuadro — y ese 8,6% era el barro entre las matas, justo lo que no se ve. Con el dosel se destapó que la cámara iba demasiado rasante (19% real) y se subió a 14 m.

|         | cielo | tercio alto | cultivo en cuadro |
|---------|-------|-------------|-------------------|
| papal (base aprobada) | 32.8% | 0.6% | 59.4% |
| yucal   | 34.8% | 0.2% | 52.5% |
| quinual | 34.8% | 0.0% | 38.1% |

Los tres sin avisos, y los dos nuevos con el sujeto en tercio bajo, igual que el papal.

## Presupuesto

|         | alto | medio | bajo |
|---------|------|-------|------|
| papal (base) | 79k | 45k | 17k |
| yucal   | 125k | 46k | 10k |
| quinual | 159k | 64k | 18k |

En quinua los glomérulos son **octaedros (8 tris), no icosaedros (20)**: a 5 cm se leen igual y es la diferencia entre 402k y 159k. El ahorro sale del primitivo, no de quitar plantas — la densidad es el entregable.

## Verificado

- Geometría headless en los tres tiers, ambos mundos: sin `mergeGeometries` nulo (truena si pasa), sin NaN, sin escalas malas, y toda mata con su panoja.
- Las cuatro variedades de quinua presentes en los tres tiers.
- `npx eslint --max-warnings=0` limpio. Escáner de voseo limpio.
- Ambos puntos de entrada empaquetan con esbuild: todos los imports resuelven.
- `public/chagra-stats.json` y `public/cycle-content/manifest.json` sin diff contra la base.

## Nota sobre el grounding

El DR `cultivo-y-manejo-de-la-quinua-en-clima-frio-andino-...-gemini.md` **está corrupto**: sus 198 KB son ~193.000 caracteres de espacios dentro del header de una tabla, cero filas de datos. Toda la sustancia de quinua salió del DR de anatomía. Y se descartaron los aportes del brazo GLM que fabricaban taxones (`M. esculenta var. apiana`, `C. quinoa var. quinoa`), cultivares sin respaldo («Blanca de Boyacá») y plagas con nombre científico de organismo ajeno.

**No se hizo** build de producción, cableado a rutas, captura ni deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)