### PR TITLE
fix(casa-adentro): restaurar altura del canvas 3D

### DIFF
--- a/src/visual/mundo3d/casa/MundoCasaAdentro.jsx
+++ b/src/visual/mundo3d/casa/MundoCasaAdentro.jsx
@@ -59,7 +59,11 @@ const PASOS = [
 ];
 
 const CSS = `
-.mcasa { position: relative; width: 100%; height: 100%; overflow: hidden; background: #2b2116; }
+.mcasa {
+  position: relative; width: 100%; height: 100vh; height: 100dvh; min-height: 320px;
+  display: flex; overflow: hidden; background: #2b2116;
+}
+.casadentro-canvas { width: 100%; height: 100%; }
 .mcasa canvas { opacity: 0; transition: opacity 0.9s ease; }
 .mcasa .casadentro-canvas--lista canvas, .mcasa canvas.casadentro-canvas--lista { opacity: 1; }
 .mcasa__accesos {

--- a/tests/casa-adentro-canvas.spec.js
+++ b/tests/casa-adentro-canvas.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Casa por dentro, altura del canvas', () => {
+  test('el canvas 3D ocupa el alto disponible del viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 820 });
+    await page.goto('/?ciclo=12#/mockups/casa-adentro', { waitUntil: 'domcontentloaded' });
+
+    const mundo = page.locator('.mcasa');
+    const canvas = mundo.locator('canvas');
+
+    await expect(mundo).toBeVisible({ timeout: 20_000 });
+    await expect(canvas).toBeVisible({ timeout: 20_000 });
+
+    const alturas = await page.evaluate(() => ({
+      viewport: window.innerHeight,
+      mundo: document.querySelector('.mcasa')?.getBoundingClientRect().height ?? 0,
+      canvas: document.querySelector('.mcasa canvas')?.getBoundingClientRect().height ?? 0,
+    }));
+
+    expect(alturas.mundo).toBeGreaterThan(150);
+    expect(alturas.canvas).toBe(alturas.mundo);
+    expect(alturas.canvas).toBe(alturas.viewport);
+  });
+});


### PR DESCRIPTION
## Summary

- Da al host `.mcasa` una altura real basada en el viewport, con fallback `vh`, `dvh` y minimo de 320 px.
- Extiende el canvas de la casa al 100% del host sin modificar escena, materiales ni luces.
- Agrega una regresion Playwright que navega con `?ciclo=12` antes del hash y verifica las alturas reales.

## Test plan

- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:43127 npx playwright test tests/casa-adentro-canvas.spec.js --project=chromium --reporter=line` (dev: pasa, canvas 820 px en viewport de 820 px)
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:43128 npx playwright test tests/casa-adentro-canvas.spec.js --project=chromium --reporter=line` (build preview: pasa)
- `npx eslint . --max-warnings=0` (pasa)
- `npm run build` (pasa)
- `npx vitest run` (suite base no verde: 82 fallos en 35 archivos no relacionados; 11482 pruebas pasan, 24 omitidas)