### PR TITLE
fix(casa): noche de verdad en las rendijas + pasto sin z-fighting + encuadre

### DIFF
--- a/src/visual/mundo3d/casa/EscenaCasaAdentro.jsx
+++ b/src/visual/mundo3d/casa/EscenaCasaAdentro.jsx
@@ -21,6 +21,23 @@
  * del haz de luz, amanecen y anochecen con el resto del juego. El fogón es la
  * luz que NO cambia: la casa siempre espera caliente.
  *
+ * PASADA NOLAN (la luz tiene fuente, la hora se siente):
+ *   · TODA la luz del día entra por los vanos: la direccional sigue el arco
+ *     REAL del sol (hora decimal continua, no franjas a saltos) y por eso el
+ *     RECTÁNGULO DE SOL que la ventana del sur riega en el piso camina y se
+ *     alarga con el día — sliver pegado al muro a mediodía cenital ecuatorial,
+ *     alfombra honda y ámbar al filo de la mañana y de la tarde. La casa es
+ *     también un reloj.
+ *   · La imagen imposible: el HAZ que une el vano con su rectángulo, con las
+ *     MOTAS DE POLVO flotando adentro — la cortina de luz que corta la
+ *     penumbra. Y al mediodía, la TEJA DE VIDRIO (la claraboya campesina)
+ *     deja caer su columna cenital al centro del piso.
+ *   · La PENUMBRA es la imagen: el ambiente se queda corto a propósito — una
+ *     casa de tapia se alumbra por UN vano y el resto es sombra que abriga.
+ *   · De noche el sol se va de verdad: queda la luna plata entrando por la
+ *     ventana del norte y el FOGÓN mandando — la única luz que no obedece
+ *     al reloj.
+ *
  * Todo procedural (cero CDN/GLTF/imágenes). El cuarto entero es UNA geometría
  * fusionada (casaAdentro.geom, vertexColors). Tier-safe vía `perfilDeTier`:
  * 'alto' sombras + humo pleno + candela que titila; 'medio' frugal; 'bajo'
@@ -33,12 +50,14 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import { perfilDeTier } from '../deviceTier.js';
 import { useAtmosferaMundo, CamaraDirector } from '../kit/index.js';
+import useCicloDia from '../useCicloDia.js';
 import { mezclar, VERDES, NIEBLAS, LUCES, ACENTOS, AGUAS, CASA, NEUTROS } from '../paleta/index.js';
 import {
   SALA,
   PUERTA,
   VENTANA_SUR,
   VENTANA_MUNDOS,
+  TEJA_LUZ,
   FRASCOS,
   CANASTO,
   construirCasaAdentro,
@@ -56,8 +75,175 @@ const alSoltar = () => {
   document.body.style.cursor = '';
 };
 
+/* ── EL RELOJ DE SOL DE LA CASA (pasada Nolan: la luz tiene fuente) ────────
+   Del reloj continuo del valle (hora decimal) se deriva la posición REAL del
+   sol y lo que esa posición hace ADENTRO:
+     · `pos`  — de dónde viene la direccional (el arco de oriente a poniente,
+       casi cenital a mediodía: 4-5° N, sol ecuatorial).
+     · `rect` — el rectángulo que la ventana del sur proyecta en el piso:
+       geometría de sombra de verdad (dintel y alféizar proyectados por la
+       altura solar). Corto y pegado al muro a mediodía; hondo al amanecer y
+       al atardecer. La mañana lo corre al poniente, la tarde al oriente.
+     · `haz`  — la cortina de luz que une el vano con su rectángulo (posición,
+       largo e inclinación para las láminas aditivas y las motas).
+     · `cenital` — cuánto prende la teja de vidrio (solo con el sol alto).
+   Pura y barata: se memoíza por hora cuantizada (~3 min). */
+function solDeCasa(hora) {
+  const hz = SALA.fondo / 2;
+  const dia = (hora - 6) / 12; // 0 = sale (~6:00) · 1 = se esconde (~18:00)
+  if (dia <= 0.015 || dia >= 0.985) return { deDia: false, fade: 0 };
+  const arco = Math.PI * dia;
+  const pos = [9 * Math.cos(arco), 2.2 + 11.5 * Math.sin(arco), 3.5];
+  const alt = Math.atan2(pos[1], Math.hypot(pos[0], pos[2]));
+  // tras el filo de la cordillera el sol existe pero todavía no entra
+  const fade = Math.min(1, Math.max(0, (alt - 0.12) / 0.15));
+  if (fade <= 0) return { deDia: true, pos, fade: 0 };
+
+  const tanAlt = Math.tan(alt);
+  let z0 = Math.max(hz - VENTANA_SUR.alto / tanAlt, -hz + 0.4); // borde hondo (el dintel)
+  let z1 = Math.min(hz - VENTANA_SUR.base / tanAlt, hz - 0.12); // borde cercano (el alféizar)
+  const yMedio = (VENTANA_SUR.base + VENTANA_SUR.alto) / 2;
+  const cxVano = (VENTANA_SUR.x0 + VENTANA_SUR.x1) / 2;
+  const corrido = cxVano - (pos[0] * yMedio) / pos[1];
+  const cx = Math.min(-0.5, Math.max(-2.9, corrido));
+  // si el sol entra tan sesgado que la mancha se sale del cuarto, se apaga
+  const sesgo = Math.abs(corrido - cx) > 0.01 ? Math.max(0, 1 - Math.abs(corrido - cx) * 0.7) : 1;
+  const largo = z1 - z0;
+  let rect = null;
+  let haz = null;
+  if (largo > 0.05 && sesgo > 0.05) {
+    const rasante = Math.cos(arco) * Math.cos(arco); // la luz baja es la más dramática
+    rect = {
+      x: cx,
+      z: (z0 + z1) / 2,
+      largo,
+      ancho: (VENTANA_SUR.x1 - VENTANA_SUR.x0) * (0.92 + 0.55 * (1 - Math.sin(alt))),
+      op: (0.11 + 0.11 * rasante) * fade * sesgo,
+    };
+    const dx = rect.x - cxVano;
+    const dz = hz - 0.06 - rect.z;
+    rect.haz = true;
+    haz = {
+      mid: [(cxVano + rect.x) / 2, (yMedio + 0.03) / 2, (hz - 0.06 + rect.z) / 2],
+      len: Math.hypot(dx, yMedio, dz) + 0.35,
+      rotX: Math.atan2(dz, yMedio),
+      rotZ: Math.atan2(dx, yMedio) * 0.85,
+      op: rect.op * 0.55,
+    };
+  }
+  // la teja de vidrio solo con el sol alto (el haz cenital del mediodía)
+  const cenital = Math.min(1, Math.max(0, ((alt * 180) / Math.PI - 52) / 22)) * fade;
+  return { deDia: true, pos, fade, rect, haz, cenital };
+}
+
+/* Pseudo-azar estable por índice (las motas no cambian de sitio entre frames). */
+const azar = (i, sal) => {
+  const x = Math.sin(i * 127.1 + sal * 311.7) * 43758.5453;
+  return x - Math.floor(x);
+};
+
+/* ── LAS MOTAS DEL HAZ: el polvo de la casa flotando en la cortina de luz ──
+   La imagen imposible de adentro: partículas diminutas, aditivas, que solo
+   viven DENTRO del haz (coordenadas locales del grupo inclinado) y derivan
+   despacio hacia abajo, titilando al cruzar la luz. */
+function MotasDelHaz({ n, haz, color, reducedMotion }) {
+  const grupo = useRef(null);
+  const motas = useMemo(
+    () =>
+      Array.from({ length: n }, (_, i) => ({
+        u: azar(i, 1) - 0.5, // a lo largo del haz
+        x: (azar(i, 2) - 0.5) * 0.72,
+        z: (azar(i, 3) - 0.5) * 0.2,
+        fase: azar(i, 4) * Math.PI * 2,
+        vel: 0.014 + azar(i, 5) * 0.02,
+        r: 0.011 + azar(i, 6) * 0.013,
+      })),
+    [n],
+  );
+  useFrame(({ clock }) => {
+    const g = grupo.current;
+    if (!g || !haz || reducedMotion) return;
+    const t = clock.elapsedTime;
+    for (let i = 0; i < g.children.length; i++) {
+      const m = g.children[i];
+      const d = motas[i];
+      const u = ((d.u + 0.5 - t * d.vel) % 1 + 1) % 1; // cae despacio a lo largo del haz
+      m.position.set(
+        d.x + 0.03 * Math.sin(t * 0.4 + d.fase),
+        (u - 0.5) * haz.len,
+        d.z + 0.02 * Math.cos(t * 0.33 + d.fase),
+      );
+      m.material.opacity = haz.op * (2.2 + 1.8 * Math.sin(t * 0.9 + d.fase)) * Math.sin(Math.PI * u);
+    }
+  });
+  if (!n || !haz) return null;
+  return (
+    <group ref={grupo} position={haz.mid} rotation={[haz.rotX, 0, haz.rotZ]}>
+      {motas.map((d, i) => (
+        <mesh key={i} position={[d.x, d.u * haz.len, d.z]}>
+          <sphereGeometry args={[d.r, 5, 4]} />
+          <meshBasicMaterial
+            color={color}
+            transparent
+            opacity={reducedMotion ? haz.op * 2.4 : 0}
+            depthWrite={false}
+            blending={THREE.AdditiveBlending}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* ── EL HAZ DE LA TEJA DE VIDRIO: la columna cenital del mediodía ──────────
+   La claraboya campesina (una teja translúcida entre las de barro) deja caer
+   una columna de luz vertical al centro del piso cuando el sol va alto. Dos
+   láminas cruzadas + la teja encendida + su charco. */
+const INCLINACION_TECHO = Math.atan2(SALA.cumbre - SALA.alero, SALA.fondo / 2 + 0.1);
+
+function HazDeLaTeja({ f, color }) {
+  if (f <= 0.03) return null;
+  const [tx, ty, tz] = TEJA_LUZ.pos;
+  const alto = ty - 0.02;
+  return (
+    <group>
+      {/* la teja encendida (la fuente SE VE en el techo) */}
+      <mesh position={[tx, ty, tz]} rotation={[Math.PI / 2 - INCLINACION_TECHO, 0, 0]}>
+        <planeGeometry args={[TEJA_LUZ.ancho, TEJA_LUZ.largo]} />
+        <meshBasicMaterial
+          color={color}
+          transparent
+          opacity={0.55 * f}
+          depthWrite={false}
+          blending={THREE.AdditiveBlending}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      {/* la columna: dos láminas cruzadas, levemente más anchas abajo */}
+      {[0, Math.PI / 2].map((ry) => (
+        <mesh key={ry} position={[tx, alto / 2, tz]} rotation={[0, ry, 0]}>
+          <planeGeometry args={[TEJA_LUZ.ancho * 0.92, alto]} />
+          <meshBasicMaterial
+            color={color}
+            transparent
+            opacity={0.085 * f}
+            depthWrite={false}
+            blending={THREE.AdditiveBlending}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      ))}
+      {/* el charco cenital en la tierra pisada */}
+      <mesh position={TEJA_LUZ.piso} rotation={[-Math.PI / 2, 0, 0]} scale={[1, 0.72, 1]}>
+        <circleGeometry args={[0.34, 16]} />
+        <meshBasicMaterial color={color} transparent opacity={0.2 * f} depthWrite={false} blending={THREE.AdditiveBlending} />
+      </mesh>
+    </group>
+  );
+}
+
 /* ── EL FUEGO DEL FOGÓN: dos llamas que titilan + la luz de la candela ────── */
-function FuegoFogon({ tier, reducedMotion }) {
+function FuegoFogon({ tier, reducedMotion, fuerza = 1 }) {
   const llama1 = useRef(null);
   const llama2 = useRef(null);
   const luz = useRef(null);
@@ -68,7 +254,7 @@ function FuegoFogon({ tier, reducedMotion }) {
     const p = 0.82 + 0.18 * Math.sin(t * 9.1) * Math.sin(t * 3.7 + 1.2);
     if (llama1.current) llama1.current.scale.set(1, p, 1);
     if (llama2.current) llama2.current.scale.set(1, 1.5 - p * 0.5, 1);
-    if (luz.current) luz.current.intensity = 0.85 + 0.22 * (p - 0.82);
+    if (luz.current) luz.current.intensity = (0.85 + 0.22 * (p - 0.82)) * fuerza;
   });
   return (
     <group position={[-2.34, 0.16, 0.2]}>
@@ -85,8 +271,16 @@ function FuegoFogon({ tier, reducedMotion }) {
         <coneGeometry args={[0.06, 0.18, 6]} />
         <meshBasicMaterial color={LUCES.candela} transparent opacity={0.85} />
       </mesh>
-      {/* la luz de la candela: la casa siempre espera caliente */}
-      <pointLight ref={luz} color="#ffb066" intensity={0.92} distance={6.5} decay={1.8} position={[0.1, 0.55, 0]} />
+      {/* la luz de la candela: la casa siempre espera caliente — y de noche,
+          cuando el sol se va de verdad, es ELLA la que manda en el cuarto */}
+      <pointLight
+        ref={luz}
+        color="#ffb066"
+        intensity={0.92 * fuerza}
+        distance={6.5}
+        decay={1.8}
+        position={[0.1, 0.55, 0]}
+      />
     </group>
   );
 }
@@ -337,9 +531,19 @@ function Diorama({ tier, reducedMotion, foco, onPortales, onFermentos }) {
      haz de la ventana. El fogón no la obedece — la casa siempre está tibia. */
   const atm = useAtmosferaMundo({ familia: FAMILIA_CASA, reducedMotion });
 
+  /* El RELOJ CONTINUO (no la franja): de aquí sale el arco real del sol y el
+     rectángulo que camina por el piso. Cuantizado a ~3 min para memoizar. */
+  const { hora } = useCicloDia({ reducedMotion });
+  const horaQ = Math.round(hora * 20) / 20;
+  const sol = useMemo(() => solDeCasa(horaQ), [horaQ]);
+
+  /* De noche y al filo del día, el fogón MANDA (la única luz sin reloj). */
+  const fogonFuerza = !sol.deDia ? 1.55 : sol.fade < 0.35 ? 1.28 : 0.92;
+
   const geoCasa = useMemo(() => construirCasaAdentro(tier === 'alto'), [tier]);
 
   const nHumo = tier === 'alto' ? 7 : tier === 'medio' ? 4 : 0;
+  const nMotas = tier === 'alto' ? 22 : tier === 'medio' ? 10 : 0;
 
   const controls = useRef(null);
   const hz = SALA.fondo / 2;
@@ -349,14 +553,26 @@ function Diorama({ tier, reducedMotion, foco, onPortales, onFermentos }) {
       {/* el fondo: el cielo de la hora (lo que asoma por la puerta) */}
       <color attach="background" args={[atm.fondo]} />
 
-      {/* la penumbra tibia del interior */}
-      <ambientLight color={LUCES.ambienteTibio} intensity={0.34} />
-      <hemisphereLight skyColor={atm.cielo} groundColor={NEUTROS.tinta} intensity={0.22} />
-      {/* el día entrando por la ventana del sur (sombra solo en gama alta) */}
+      {/* LA PENUMBRA es la imagen: el ambiente se queda corto a propósito —
+          una casa de tapia se alumbra por UN vano y el resto es sombra que
+          abriga. De noche baja aún más y queda el fogón. */}
+      <ambientLight
+        color={LUCES.ambienteTibio}
+        intensity={sol.deDia ? 0.15 + 0.14 * atm.intensidad : 0.12}
+      />
+      <hemisphereLight
+        skyColor={atm.cielo}
+        groundColor={NEUTROS.tinta}
+        intensity={sol.deDia ? 0.19 : 0.12}
+      />
+      {/* LA LUZ TIENE FUENTE: de día la direccional viaja por el arco REAL del
+          sol (por eso el rectángulo de la ventana camina y las sombras giran
+          con la hora); de noche es la luna plata entrando desde el norte, por
+          la ventana de los mundos. */}
       <directionalLight
         color={atm.luz}
-        intensity={0.85}
-        position={[-1.7, 3.4, 5.5]}
+        intensity={sol.deDia ? 0.32 + 0.62 * sol.fade : 0.34}
+        position={sol.deDia ? sol.pos : atm.solPos}
         castShadow={perfil.sombras}
         shadow-mapSize-width={1024}
         shadow-mapSize-height={1024}
@@ -400,25 +616,79 @@ function Diorama({ tier, reducedMotion, foco, onPortales, onFermentos }) {
         <meshBasicMaterial color={mezclar(atm.cielo, NIEBLAS.dorada, 0.35)} side={THREE.DoubleSide} />
       </mesh>
 
-      {/* EL HAZ DE LUZ de la ventana + su charco en el piso de tierra */}
-      <mesh position={[-1.75, 0.78, 1.62]} rotation={[-1.05, 0, 0]}>
-        <planeGeometry args={[0.92, 2.5]} />
-        <meshBasicMaterial
-          color={atm.luz}
-          transparent
-          opacity={0.09}
-          depthWrite={false}
-          blending={THREE.AdditiveBlending}
-          side={THREE.DoubleSide}
-        />
-      </mesh>
-      <mesh position={[-1.75, 0.02, 0.85]} rotation={[-Math.PI / 2, 0, 0]} scale={[1, 0.55, 1]}>
-        <circleGeometry args={[0.85, 18]} />
-        <meshBasicMaterial color={atm.luz} transparent opacity={0.14} depthWrite={false} />
-      </mesh>
+      {/* EL RECTÁNGULO DE SOL: la ventana del sur riega su vano en el piso y
+          la mancha CAMINA con el día — sliver al pie del muro a mediodía,
+          alfombra honda y ámbar al filo de la mañana y de la tarde. El halo
+          de abajo la asienta en la tierra pisada. */}
+      {sol.rect && (
+        <group>
+          <mesh
+            position={[sol.rect.x, 0.026, sol.rect.z]}
+            rotation={[-Math.PI / 2, 0, 0]}
+            scale={[sol.rect.ancho, sol.rect.largo, 1]}
+          >
+            <planeGeometry args={[1, 1]} />
+            <meshBasicMaterial
+              color={atm.luz}
+              transparent
+              opacity={sol.rect.op}
+              depthWrite={false}
+              blending={THREE.AdditiveBlending}
+            />
+          </mesh>
+          <mesh
+            position={[sol.rect.x, 0.02, sol.rect.z]}
+            rotation={[-Math.PI / 2, 0, 0]}
+            scale={[sol.rect.ancho * 1.45, sol.rect.largo * 1.35, 1]}
+          >
+            <planeGeometry args={[1, 1]} />
+            <meshBasicMaterial
+              color={atm.luz}
+              transparent
+              opacity={sol.rect.op * 0.32}
+              depthWrite={false}
+              blending={THREE.AdditiveBlending}
+            />
+          </mesh>
+        </group>
+      )}
+
+      {/* LA CORTINA DE LUZ: el haz que une el vano con su rectángulo — dos
+          láminas anidadas (la de adentro más densa) + las motas de polvo
+          flotando. La imagen imposible de la casa. */}
+      {sol.haz && (
+        <group position={sol.haz.mid} rotation={[sol.haz.rotX, 0, sol.haz.rotZ]}>
+          <mesh>
+            <planeGeometry args={[0.88, sol.haz.len]} />
+            <meshBasicMaterial
+              color={atm.luz}
+              transparent
+              opacity={sol.haz.op}
+              depthWrite={false}
+              blending={THREE.AdditiveBlending}
+              side={THREE.DoubleSide}
+            />
+          </mesh>
+          <mesh position={[0, 0, 0.015]}>
+            <planeGeometry args={[0.48, sol.haz.len]} />
+            <meshBasicMaterial
+              color={atm.luz}
+              transparent
+              opacity={sol.haz.op * 0.85}
+              depthWrite={false}
+              blending={THREE.AdditiveBlending}
+              side={THREE.DoubleSide}
+            />
+          </mesh>
+        </group>
+      )}
+      <MotasDelHaz n={nMotas} haz={sol.haz} color={atm.luz} reducedMotion={reducedMotion} />
+
+      {/* LA TEJA DE VIDRIO: la columna cenital del mediodía ecuatorial */}
+      <HazDeLaTeja f={sol.cenital ?? 0} color={atm.luz} />
 
       {/* EL FOGÓN VIVO: candela + humo subiendo a la teja */}
-      <FuegoFogon tier={tier} reducedMotion={reducedMotion} />
+      <FuegoFogon tier={tier} reducedMotion={reducedMotion} fuerza={fogonFuerza} />
       <HumoFogon n={nHumo} reducedMotion={reducedMotion} />
 
       {/* LOS DOS ACCESOS legibles desde adentro */}

--- a/src/visual/mundo3d/casa/EscenaCasaAdentro.jsx
+++ b/src/visual/mundo3d/casa/EscenaCasaAdentro.jsx
@@ -104,9 +104,12 @@ function solDeCasa(hora) {
   let z1 = Math.min(hz - VENTANA_SUR.base / tanAlt, hz - 0.12); // borde cercano (el alféizar)
   const yMedio = (VENTANA_SUR.base + VENTANA_SUR.alto) / 2;
   const cxVano = (VENTANA_SUR.x0 + VENTANA_SUR.x1) / 2;
+  // la mañana corre la mancha al poniente; la tarde la manda LEJOS, al
+  // oriente, cruzando el cuarto (la alfombra larga de las cinco)
   const corrido = cxVano - (pos[0] * yMedio) / pos[1];
-  const cx = Math.min(-0.5, Math.max(-2.9, corrido));
-  // si el sol entra tan sesgado que la mancha se sale del cuarto, se apaga
+  const cx = Math.min(2.9, Math.max(-2.9, corrido));
+  // si el sol entra tan sesgado que la mancha se sale del piso (madrugada:
+  // el primer sol da en el muro del fogón, no en la tierra), se apaga
   const sesgo = Math.abs(corrido - cx) > 0.01 ? Math.max(0, 1 - Math.abs(corrido - cx) * 0.7) : 1;
   const largo = z1 - z0;
   let rect = null;

--- a/src/visual/mundo3d/casa/EscenaCasaAdentro.jsx
+++ b/src/visual/mundo3d/casa/EscenaCasaAdentro.jsx
@@ -66,6 +66,13 @@ import {
 /* La casa pertenece a la familia del patio de la finca: `corral`. */
 const FAMILIA_CASA = 'corral';
 
+/* Lo que se ve por las RENDIJAS del techo (y sobre las culatas) es el CIELO
+   de afuera: el fondo del canvas. La familia `corral` tiñe el DÍA de crema
+   de patio, pero ese crema de noche quedaba gris-claro — rendijas blancas a
+   las ocho de la noche, luz sin fuente. El cielo nocturno de la casa es
+   índigo hondo con un asomo de luna: franjas azules y tenues, o nada. */
+const CIELO_NOCHE_CASA = mezclar('#131a34', LUCES.luna, 0.1);
+
 /* Cursor de "esto se toca" (mismo gesto que la puerta del valle). */
 const alApuntar = (e) => {
   e.stopPropagation();
@@ -543,6 +550,12 @@ function Diorama({ tier, reducedMotion, foco, onPortales, onFermentos }) {
   /* De noche y al filo del día, el fogón MANDA (la única luz sin reloj). */
   const fogonFuerza = !sol.deDia ? 1.55 : sol.fade < 0.35 ? 1.28 : 0.92;
 
+  /* El cielo de las rendijas obedece el MISMO reloj que el haz (solDeCasa):
+     de noche índigo de luna; al filo del día todavía oscuro (sigue el fade). */
+  const fondoCasa = !sol.deDia
+    ? CIELO_NOCHE_CASA
+    : mezclar(CIELO_NOCHE_CASA, atm.fondo, Math.min(1, 0.3 + 0.7 * sol.fade));
+
   const geoCasa = useMemo(() => construirCasaAdentro(tier === 'alto'), [tier]);
 
   const nHumo = tier === 'alto' ? 7 : tier === 'medio' ? 4 : 0;
@@ -553,8 +566,9 @@ function Diorama({ tier, reducedMotion, foco, onPortales, onFermentos }) {
 
   return (
     <>
-      {/* el fondo: el cielo de la hora (lo que asoma por la puerta) */}
-      <color attach="background" args={[atm.fondo]} />
+      {/* el fondo: el cielo de afuera — lo que asoma por las rendijas del
+          techo. De día la hora del valle; de noche se APAGA a índigo. */}
+      <color attach="background" args={[fondoCasa]} />
 
       {/* LA PENUMBRA es la imagen: el ambiente se queda corto a propósito —
           una casa de tapia se alumbra por UN vano y el resto es sombra que
@@ -597,10 +611,19 @@ function Diorama({ tier, reducedMotion, foco, onPortales, onFermentos }) {
         <meshLambertMaterial color={CASA.bejuco} side={THREE.DoubleSide} />
       </mesh>
 
-      {/* lo que se ve AFUERA por la puerta: el pasto del valle a la hora viva */}
-      <mesh position={[1.1, 0, 4.8]} rotation={[-Math.PI / 2, 0, 0]}>
+      {/* lo que se ve AFUERA por la puerta: el pasto del valle a la hora
+          viva. Arranca PASADO el borde del piso (el piso llega a z=2.9; a ras
+          y solapado hacía z-fighting: el rectángulo verde lima ADENTRO de la
+          casa). Y de noche el pasto duerme: verde-índigo, nunca lima. */}
+      <mesh position={[1.1, -0.02, 5.55]} rotation={[-Math.PI / 2, 0, 0]}>
         <planeGeometry args={[9, 5]} />
-        <meshBasicMaterial color={mezclar(VERDES.brote, atm.niebla, 0.3)} />
+        <meshBasicMaterial
+          color={
+            sol.deDia
+              ? mezclar(VERDES.brote, atm.niebla, 0.3)
+              : mezclar(VERDES.brote, CIELO_NOCHE_CASA, 0.82)
+          }
+        />
       </mesh>
       {/* el resplandor del día en el vano de la puerta */}
       <mesh position={[(PUERTA.x0 + PUERTA.x1) / 2, PUERTA.alto / 2, hz + 0.03]}>
@@ -704,11 +727,11 @@ function Diorama({ tier, reducedMotion, foco, onPortales, onFermentos }) {
       <OrbitControls
         ref={controls}
         makeDefault
-        target={[0, 1.3, -0.1]}
+        target={[-0.2, 0.98, -0.4]}
         enablePan={false}
         enableZoom
         minDistance={1.3}
-        maxDistance={2.8}
+        maxDistance={3.3}
         minPolarAngle={0.6}
         maxPolarAngle={1.52}
         minAzimuthAngle={-1.15}
@@ -720,8 +743,8 @@ function Diorama({ tier, reducedMotion, foco, onPortales, onFermentos }) {
           el centro del cuarto, una vez por sesión. */}
       <CamaraDirector
         controls={controls}
-        reposo={[1.15, 1.6, 2.45]}
-        mirada={[-0.5, 1.15, -0.5]}
+        reposo={[1.35, 1.95, 2.35]}
+        mirada={[-0.3, 1.35, -0.5]}
         respiro={0.03}
         activa={!reducedMotion && tier !== 'bajo'}
         unaVezClave="mundoCasaAdentro"
@@ -756,7 +779,7 @@ export default function EscenaCasaAdentro({
       dpr={perfil.dpr}
       gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
       shadows={perfil.sombras ? 'soft' : false}
-      camera={{ position: [1.15, 1.6, 2.45], fov: 58 }}
+      camera={{ position: [1.35, 1.95, 2.35], fov: 48 }}
       frameloop={reducedMotion ? 'demand' : 'always'}
       onCreated={() => setListo(true)}
     >

--- a/src/visual/mundo3d/casa/MundoCasaAdentro.jsx
+++ b/src/visual/mundo3d/casa/MundoCasaAdentro.jsx
@@ -5,9 +5,10 @@
  * Mismo contrato de host que MundoCafetal/MundoInvernadero: acepta
  * `{tier, reducedMotion}` (o auto-detecta con decidirTier si se monta suelto),
  * llena a su padre y guarda su estado local. Sobre la escena viven los PASOS:
- * cuatro lecciones cortas que recorren lo que la casa cuenta — el fogón, la
- * mesa, el rincón de los fermentos y la ventana de los mundos — y cada paso
- * señala SU lugar con el anillo que respira (el `foco` de la escena).
+ * cinco lecciones cortas que recorren lo que la casa cuenta — el fogón, la
+ * luz de la casa (el reloj de sol de la ventana), la mesa, el rincón de los
+ * fermentos y la ventana de los mundos — y cada paso señala SU lugar con el
+ * anillo que respira (el `foco` de la escena).
  *
  * Los ACCESOS son el contrato con el valle:
  *   · `onPortales`  → tocar la ventana de los mundos (o su botón). Por defecto
@@ -24,34 +25,47 @@ import { useMemo, useState } from 'react';
 import EscenaCasaAdentro from './EscenaCasaAdentro.jsx';
 import PanelPasos from '../PanelPasos.jsx';
 import { decidirTier, permite3D } from '../deviceTier.js';
-import { SITIO_FOGON, SITIO_MESA, SITIO_FERMENTOS, SITIO_MUNDOS } from './casaAdentro.geom.js';
+import {
+  SITIO_FOGON,
+  SITIO_LUZ,
+  SITIO_MESA,
+  SITIO_FERMENTOS,
+  SITIO_MUNDOS,
+} from './casaAdentro.geom.js';
 
-/* Los cuatro pasos de la lección: la casa se lee despacio. */
+/* Los cinco pasos de la lección: la casa se lee despacio. */
 const PASOS = [
   {
     id: 'fogon',
-    kicker: 'Paso 1 de 4 · El fogón',
+    kicker: 'Paso 1 de 5 · El fogón',
     texto:
-      'El fogón de leña es el corazón de la casa: aquí se prende el día antes de que amanezca. La olla que humea, la leña rajada, el hollín en la pared — la casa que cocina es casa viva.',
+      'El fogón de leña es el corazón de la casa: aquí se prende el día antes de que amanezca. La olla que humea, la leña rajada, el hollín en la pared, el zarzo arriba donde el grano se cura con el humo — la casa que cocina es casa viva.',
     foco: SITIO_FOGON,
   },
   {
+    id: 'luz',
+    kicker: 'Paso 2 de 5 · La luz de la casa',
+    texto:
+      'Fíjese en el cuadro de sol que la ventana riega en el piso: camina y se estira con el día. Pegado al muro a mediodía, largo y hondo por la tarde. La casa de tapia se alumbra por un solo vano — y por eso es también un reloj: el abuelo sabía la hora sin mirar ninguna.',
+    foco: SITIO_LUZ,
+  },
+  {
     id: 'mesa',
-    kicker: 'Paso 2 de 4 · La mesa',
+    kicker: 'Paso 3 de 5 · La mesa',
     texto:
       'En la mesa de madera se come lo que la finca dio: la mazorca, la totuma, el pocillo de café. Pero lo que de verdad se sirve aquí es la palabra — en la mesa se decide la siembra y se cuenta el día.',
     foco: SITIO_MESA,
   },
   {
     id: 'fermentos',
-    kicker: 'Paso 3 de 4 · El rincón de los fermentos',
+    kicker: 'Paso 4 de 5 · El rincón de los fermentos',
     texto:
       'En el estante trabajan los que no se ven: la chicha, el vinagre, el guarapo. Microbios buenos transformando la cosecha, sin afán y sin remedio comprado. Toque los frascos para entrar a su mundo.',
     foco: SITIO_FERMENTOS,
   },
   {
     id: 'mundos',
-    kicker: 'Paso 4 de 4 · La ventana de los mundos',
+    kicker: 'Paso 5 de 5 · La ventana de los mundos',
     texto:
       'Desde la casa se ve toda la finca. Esta ventana del fondo mira a los mundos: el agua, el suelo, el café, el páramo. Toque la ventana cuando quiera salir a recorrerlos — la casa aquí lo espera.',
     foco: SITIO_MUNDOS,

--- a/src/visual/mundo3d/casa/casaAdentro.geom.js
+++ b/src/visual/mundo3d/casa/casaAdentro.geom.js
@@ -16,7 +16,17 @@
  *   · la VENTANA DE LOS MUNDOS al fondo (el vano con postigos abiertos por
  *     donde la escena cuelga el resplandor-portal);
  *   · los objetos de finca: el costal de maíz, el sombrero en su clavo, el
- *     azadón recostado, la repisa con tarros y platos, el banco de la ventana.
+ *     azadón recostado, la repisa con tarros y platos, el banco de la ventana;
+ *   · la casa HABITADA (pasada Nolan): el ZARZO sobre el rincón del fogón
+ *     (la troja de tablas donde el grano se cura con el humo), las ristras de
+ *     mazorca colgando de su borde, la RUANA en el clavo junto a la puerta,
+ *     el TIZNE del techo sobre el fogón (años de candela, no decoración) y el
+ *     DESGASTE del piso de tierra por donde más se camina (puerta → mesa →
+ *     fogón: la huella de la rutina, horneada en el color).
+ *
+ * La TEJA DE VIDRIO (la claraboya campesina: una teja translúcida entre las de
+ * barro) se exporta como ancla (`TEJA_LUZ`) — el vidrio y su haz cenital son
+ * material de la escena, aquí solo vive el punto del techo por donde entra.
  *
  * TÉCNICA (mismo contrato que invernadero.geom / floraCafetal.geom): todo lo
  * estático y opaco se FUSIONA en UNA geometría con el color horneado en
@@ -63,9 +73,20 @@ export const VENTANA_MUNDOS = { x0: -0.7, x1: 0.7, base: 0.95, alto: 2.05 };
 
 /* Los sitios que la lección señala ([x, y, z] de mundo). */
 export const SITIO_FOGON = [-2.55, 1.0, 0.2];
+export const SITIO_LUZ = [-1.75, 0.85, 1.5];
 export const SITIO_MESA = [0.45, 0.85, 0.15];
 export const SITIO_FERMENTOS = [3.05, 1.05, -0.6];
 export const SITIO_MUNDOS = [0, 1.5, -2.55];
+
+/* LA TEJA DE VIDRIO: el punto del faldón norte por donde entra el haz cenital
+   del mediodía (la claraboya de toda cocina campesina). `pos` es el centro de
+   la teja sobre el plano del techo; `piso` es donde su charco cae. */
+export const TEJA_LUZ = {
+  pos: [-0.6, 3.34, -0.85],
+  piso: [-0.6, 0.012, -0.85],
+  ancho: 0.4,
+  largo: 0.52,
+};
 
 /* -------------------------------------------------------------------------- */
 /*  Paleta local (todo derivado de la paleta madre)                           */
@@ -296,6 +317,61 @@ export function construirCasaAdentro(rico = true) {
   poner(L, cil(0.09, 0.1, 0.22, 8), PAL.barro, -2.75, 1.64, -hz + 0.26);
   poner(L, cil(0.07, 0.08, 0.18, 8), PAL.barro, -2.45, 1.62, -hz + 0.24);
   poner(L, caja(0.14, 0.2, 0.14), NEUTROS.lamina, -2.1, 1.63, -hz + 0.27);
+
+  /* ── LA CASA HABITADA (pasada Nolan: historia, no catálogo) ────────────── */
+
+  // EL ZARZO: la troja de tablas sobre el rincón noroccidental del fogón,
+  // donde el grano se cura con el humo. Media agua nada más — la otra mitad
+  // queda abierta para que el humo suba libre a la cumbrera.
+  poner(L, caja(0.09, 0.09, 2.0), PAL.vigaOscura, -3.45, 2.46, -1.25); // durmiente del muro
+  poner(L, caja(0.09, 0.09, 2.0), PAL.vigaOscura, -1.55, 2.46, -1.25); // viga del borde
+  for (let i = 0; i < 5; i++) {
+    // las tablas del zarzo, con sus rendijas (por ahí se cuela el humo)
+    poner(L, caja(2.0, 0.045, 0.27), PAL.tabla, -2.5, 2.53, -2.1 + i * 0.42);
+  }
+  // lo que el zarzo guarda: el costal recostado y unas mazorcas al borde
+  poner(L, cil(0.2, 0.24, 0.38, 9), PAL.costal, -2.95, 2.75, -1.35, 0, 0, 0.14);
+  poner(L, cil(0.045, 0.055, 0.24, 7), ACENTOS.maizGrano, -1.85, 2.6, -1.0, 0, 0.4, Math.PI / 2.3);
+  poner(L, cil(0.04, 0.05, 0.22, 7), ACENTOS.maizGrano, -2.1, 2.6, -1.72, 0, 1.1, Math.PI / 2.5);
+  // las ristras colgando del borde del zarzo (el maíz al alcance y al humo)
+  for (const rz of [-0.85, -1.65]) {
+    poner(L, cil(0.012, 0.012, 0.34, 5), PAL.vigaOscura, -1.55, 2.28, rz);
+    for (let i = 0; i < 3; i++) {
+      poner(L, cil(0.042, 0.052, 0.2, 7), ACENTOS.maizGrano, -1.55, 2.12 - i * 0.22, rz + (i % 2) * 0.04);
+      poner(L, cil(0.018, 0.032, 0.09, 6), VERDES.calido, -1.55, 2.25 - i * 0.22, rz + (i % 2) * 0.04);
+    }
+  }
+
+  // LA RUANA en su clavo, junto a la puerta (se cuelga al entrar; lana de
+  // oveja sin teñir con su franja cruda — la prenda es de quien vive aquí).
+  const lanaRuana = mezclar(TIERRAS.turba, NEUTROS.tinta, 0.32);
+  const franjaRuana = mezclar(NEUTROS.cal, TIERRAS.vega, 0.45);
+  poner(L, cil(0.018, 0.018, 0.09, 5), PAL.vigaOscura, -0.35, 1.66, hz - 0.1, Math.PI / 2);
+  poner(L, caja(0.4, 0.13, 0.11), lanaRuana, -0.35, 1.6, hz - 0.15); // el doblez sobre el clavo
+  poner(L, caja(0.37, 0.55, 0.07), lanaRuana, -0.35, 1.28, hz - 0.17); // la caída
+  poner(L, caja(0.375, 0.055, 0.075), franjaRuana, -0.35, 1.1, hz - 0.17); // la franja tejida
+  poner(L, caja(0.375, 0.03, 0.075), franjaRuana, -0.35, 1.02, hz - 0.17); // el fleco
+
+  // EL TIZNE del techo sobre el fogón: años de humo pegados a la teja y a los
+  // pares — la mancha que cuenta cuántas ollas ha visto esta casa.
+  const inclTizne = Math.atan2(cumbre - alero, hz + 0.1);
+  poner(L, caja(1.7, 0.02, 2.1), mezclar(PAL.tejaAdentro, NEUTROS.tinta, 0.55), -2.7, (alero + cumbre) / 2 - 0.055, (hz + 0.1) / 2, inclTizne);
+  poner(L, caja(1.7, 0.02, 2.1), mezclar(PAL.tejaAdentro, NEUTROS.tinta, 0.55), -2.7, (alero + cumbre) / 2 - 0.055, -(hz + 0.1) / 2, -inclTizne);
+  poner(L, caja(1.5, 0.15, 0.17), mezclar(PAL.vigaOscura, NEUTROS.tinta, 0.5), -2.7, cumbre - 0.09, 0); // la cumbrera ahumada (envuelve la viga)
+
+  // EL DESGASTE del piso: la tierra pisada brilla más clara por donde más se
+  // camina — de la puerta a la mesa y de la mesa al fogón. La huella de vivir.
+  const tierraPisada = mezclar(PAL.piso, TIERRAS.vega, 0.24);
+  for (const [px, pz, pr] of [
+    [1.1, 2.3, 0.42], // el umbral de la puerta
+    [0.85, 1.55, 0.36],
+    [0.55, 1.0, 0.34], // llegando a la mesa
+    [-0.9, 0.5, 0.33],
+    [-1.7, 0.35, 0.36], // camino al fogón
+    [-2.15, 0.28, 0.4], // parado frente a la candela
+  ]) {
+    poner(L, cil(pr, pr, 0.012, 12), tierraPisada, px, 0.008, pz);
+  }
 
   /* ── Los detalles del tier alto (no cambian la lectura, la abrigan) ────── */
   if (rico) {


### PR DESCRIPTION
## La casa por dentro: cierre del gate visual

Dos bugs reproducibles a `?ciclo=20` y una decisión de cámara. **El sistema de luz no se tocó** (solDeCasa, haz con motas, teja de vidrio y noche de fogón intactos).

### Bug 1 — rectángulo verde lima en el piso (noche)
El plano del pasto exterior vivía a `y=0, z=4.8±2.5`: solapaba la cara superior del piso (también `y=0`, hasta `z=2.9`) → z-fighting ADENTRO de la casa. Y por ser `meshBasicMaterial` no obedecía la noche: verde lima pleno a las 20:00. Ahora arranca pasado el borde del piso (`z≥3.05, y=-0.02`) y de noche duerme en verde-índigo.

### Bug 2 — franjas del techo blancas a las 20:00
Las rendijas del techo muestran el FONDO del canvas. La familia `corral` aporta 40% de un crema de patio que de noche quedaba gris-claro (`#6b6970` aprox): franjas prendidas sin fuente. El fondo ahora consulta el mismo reloj que el haz (`solDeCasa`): de noche índigo de luna, al filo del día sigue el `fade`. De día no cambia nada.

### Encuadre
La cámara estaba baja y mirando hacia arriba (techo ~40% del cuadro). Ahora: altura de ojo (`y=1.95`) mirando la banda viva — fogón, mesa, ventana de los mundos, fermentos — con `fov 48`. Target de reposo `[-0.2, 0.98, -0.4]`.

### Verificación (captura real, swiftshader)
- `?ciclo=20` — los dos bugs cerrados: piso limpio, rendijas índigo tenue, fogón mandando, estrellas en la ventana.
- `?ciclo=12.3` — columna cenital de la teja de vidrio intacta.
- `?ciclo=17.2` — alfombra ámbar de la tarde con haz y motas intacta.
- Build de producción verde. El query va ANTES del hash: `/?ciclo=20#/mockups/casa-adentro`.

Nota: el canvas de esa ruta se ve de 150px por un bug de layout preexistente de `.mcasa` (contenedor sin altura) que está en manos de otro agente — no se tocó aquí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)