### PR TITLE
art(cafe): el cafetal deja de leerse como pinar — silueta, paleta y cámara

### DIFF
--- a/scripts/diag/encuadre-mundo.mjs
+++ b/scripts/diag/encuadre-mundo.mjs
@@ -1,0 +1,259 @@
+/*
+ * encuadre-mundo — ¿QUÉ SE VE de verdad por la cámara de un mundo 3D?
+ *
+ * Medir la geometría NO es ver la escena. Un mundo puede tener las plantas del
+ * tamaño correcto, la distribución correcta y el relieve correcto, y aun así
+ * entregar un encuadre donde el sujeto no aparece porque la cámara quedó
+ * enterrada en la ladera y el 60% del cuadro es loma vacía. Eso ya pasó, con
+ * números "correctos" de respaldo.
+ *
+ * Este script traza RAYOS por la retícula del encuadre real (la misma posición,
+ * la misma mirada y el mismo fov que monta la escena) contra la MISMA función
+ * de altura del terreno, y reporta el reparto del cuadro: cuánto es cielo,
+ * cuánto suelo, y a qué distancia cae cada golpe. Con eso se sabe si el sujeto
+ * está en cuadro y en qué tercio, sin GPU y sin captura.
+ *
+ * No reemplaza mirar la foto — la reemplaza CUANDO NO HAY foto todavía, y
+ * atrapa el desastre antes de gastar un deploy en descubrirlo.
+ *
+ * Uso:  node scripts/diag/encuadre-mundo.mjs yuca
+ *       node scripts/diag/encuadre-mundo.mjs quinua
+ */
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const AQUI = dirname(fileURLToPath(import.meta.url));
+const RAIZ = resolve(AQUI, '../..');
+
+/* Los mundos que este diagnóstico sabe mirar. Cada uno declara de dónde saca su
+   función de altura, su cámara y cuál es el SUJETO que no puede faltar. */
+const MUNDOS = {
+  /* El PAPAL es la línea base: un mundo ya aprobado y desplegado. Sirve para
+     calibrar qué reparto de cuadro se considera bueno en esta casa, en vez de
+     inventarse umbrales de la nada. Su cámara no declara constante CAMARA, así
+     que va escrita aquí tal como la monta EscenaPapaVivo. */
+  papa: {
+    modulo: 'src/visual/mundo3d/papa/floraPapa.geom.js',
+    altura: 'alturaLadera',
+    camaraFija: { pos: [2, 5.4, 15.5], mira: [0, 3.8, -3], fov: 46 },
+    sujeto: { nombre: 'el claro de la cosecha', clave: 'SITIO_COSECHA' },
+    altoCultivo: 0.45, // la mata de papa es bajita y aporcada
+  },
+  yuca: {
+    modulo: 'src/visual/mundo3d/yuca/floraYuca.geom.js',
+    altura: 'alturaYucal',
+    sujeto: { nombre: 'el claro del arranque', clave: 'SITIO_ARRANQUE' },
+    altoCultivo: 2.3, // la mata de yuca adulta
+  },
+  quinua: {
+    modulo: 'src/visual/mundo3d/quinua/floraQuinua.geom.js',
+    altura: 'alturaQuinual',
+    sujeto: { nombre: 'la era de la trilla', clave: 'SITIO_TRILLA' },
+    altoCultivo: 1.6, // la mata de quinua con su panoja
+  },
+  /* La LADERA CAFETERA. El sujeto es el cafeto protagonista del camino: la mata
+     que enseña qué es un cafeto. `altoCultivo` se deja FIJO entre corridas para
+     que el antes/después mida la CÁMARA y la siembra, no el número que uno
+     mismo acaba de mover. */
+  cafe: {
+    modulo: 'src/visual/mundo3d/cafetal/floraCafetal.geom.js',
+    altura: 'alturaLadera',
+    sujeto: { nombre: 'el cafeto protagonista del camino', clave: 'SITIO_CAFETO_HERO' },
+    altoCultivo: 1.5, // la mata de café adulta bajo sombrío
+  },
+};
+
+const sub = (a, b) => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+const cruz = (a, b) => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+];
+const norm = (v) => {
+  const n = Math.hypot(v[0], v[1], v[2]) || 1;
+  return [v[0] / n, v[1] / n, v[2] / n];
+};
+
+/*
+ * Marcha por el rayo hasta que toque el mundo. Paso fino cerca (donde está el
+ * sujeto) y grueso lejos: exacto donde importa, barato donde no.
+ *
+ * OJO — golpea contra el TERRENO MÁS EL DOSEL DEL CULTIVO, no contra el terreno
+ * pelado. Es la diferencia entre medir bien y engañarse: una yuca mide 2,3 m y
+ * una quinua 1,6 m, así que lo que de verdad llena el cuadro de esos mundos es
+ * la planta, no el suelo bajo la planta. Midiendo solo terreno, un quinual
+ * denso "ocupaba 8,6% del cuadro" — y lo que ocupa 8,6% es el barro entre las
+ * matas, que es justo lo que no se ve.
+ */
+function golpear(origen, dir, altura, dosel, maxDist = 90) {
+  let t = 0.2;
+  while (t < maxDist) {
+    const p = [origen[0] + dir[0] * t, origen[1] + dir[1] * t, origen[2] + dir[2] * t];
+    // fuera del heightfield: se acabó el mundo, es cielo/telón
+    if (Math.abs(p[0]) > 20 || p[2] < -19 || p[2] > 19) return null;
+    const suelo = altura(p[0], p[2]);
+    const sobre = dosel(p[0], p[2]);
+    if (p[1] <= suelo + sobre) {
+      return { t, punto: p, altura: suelo, enCultivo: sobre > 0.01 };
+    }
+    t += t < 18 ? 0.16 : 0.55;
+  }
+  return null;
+}
+
+async function main() {
+  const cual = process.argv[2] || 'yuca';
+  const def = MUNDOS[cual];
+  if (!def) {
+    console.error(`mundo desconocido: ${cual}. Conozco: ${Object.keys(MUNDOS).join(', ')}`);
+    process.exit(2);
+  }
+
+  const geom = await import(resolve(RAIZ, def.modulo));
+  const altura = geom[def.altura];
+  /* La cámara sale del PROPIO módulo del mundo (constante CAMARA, que vive
+     junto a la geografía): así este diagnóstico no puede quedar desfasado de lo
+     que la escena monta de verdad. El papal, que es anterior a esa convención,
+     la trae escrita a mano aquí arriba. */
+  const cam = def.camaraFija || { ...geom.CAMARA, pos: geom.CAMARA.reposo, mira: geom.CAMARA.mirada };
+  if (!cam || !cam.pos) throw new Error(`el módulo de «${cual}» no exporta CAMARA`);
+  const sujeto = geom[def.sujeto.clave];
+  /* El dosel: cuánto levanta el cultivo sobre el suelo en cada punto del lote.
+     Se apoya en el `dentroLote` del propio mundo, así que respeta los claros
+     (la era, el patio, el sitio de cosecha) sin duplicar esa lógica aquí. */
+  const alto = def.altoCultivo || 0;
+  const dosel = (x, z) =>
+    geom.dentroLote && alto ? geom.dentroLote(x, z) * alto : 0;
+
+  const adelante = norm(sub(cam.mira, cam.pos));
+  const derecha = norm(cruz(adelante, [0, 1, 0]));
+  const arriba = cruz(derecha, adelante);
+
+  // retícula del encuadre (móvil-first: 9:16 es el caso apretado, pero el
+  // lienzo real es más ancho; se mide 3:2, que es el que se fotografía)
+  const COLS = 48;
+  const FILAS = 30;
+  const aspecto = 3 / 2;
+  const mediaV = Math.tan((cam.fov * Math.PI) / 180 / 2);
+  const mediaH = mediaV * aspecto;
+
+  let cielo = 0;
+  let suelo = 0;
+  const porTercio = [0, 0, 0]; // golpes de suelo por tercio vertical del cuadro
+  let enLote = 0; // rayos que caen sobre el cultivo sembrado
+  let masCerca = Infinity;
+  let masLejos = 0;
+  let sumaDist = 0;
+
+  // ¿en qué parte del cuadro cae el SUJETO?
+  let sujetoFila = null;
+  let sujetoCol = null;
+
+  for (let f = 0; f < FILAS; f++) {
+    for (let cN = 0; cN < COLS; cN++) {
+      const sx = ((cN + 0.5) / COLS) * 2 - 1;
+      const sy = 1 - ((f + 0.5) / FILAS) * 2;
+      const dir = norm([
+        adelante[0] + derecha[0] * sx * mediaH + arriba[0] * sy * mediaV,
+        adelante[1] + derecha[1] * sx * mediaH + arriba[1] * sy * mediaV,
+        adelante[2] + derecha[2] * sx * mediaH + arriba[2] * sy * mediaV,
+      ]);
+      const g = golpear(cam.pos, dir, altura, dosel);
+      if (!g) {
+        cielo += 1;
+        continue;
+      }
+      suelo += 1;
+      porTercio[Math.min(2, Math.floor((f / FILAS) * 3))] += 1;
+      masCerca = Math.min(masCerca, g.t);
+      masLejos = Math.max(masLejos, g.t);
+      sumaDist += g.t;
+
+      // ¿este rayo cayó encima del sujeto?
+      const dx = g.punto[0] - sujeto[0];
+      const dz = g.punto[2] - sujeto[1];
+      if (dx * dx + dz * dz < 6.5) {
+        if (sujetoFila === null) sujetoFila = f;
+        sujetoCol = cN;
+      }
+
+      // ¿y cayó sobre el CULTIVO? En un mundo cuyo entregable es la planta
+      // misma (el campo de color de la quinua), esto importa más que dónde cae
+      // tal o cual rincón: mide si el cultivo llena el cuadro.
+      if (g.enCultivo) enLote += 1;
+    }
+  }
+
+  const total = COLS * FILAS;
+  const pct = (n) => `${((n / total) * 100).toFixed(1)}%`;
+
+  console.log(`\n═══ ENCUADRE DE «${cual}» ═══`);
+  console.log(
+    `cámara ${cam.pos.map((v) => v.toFixed(1)).join(', ')} → mira ${cam.mira
+      .map((v) => v.toFixed(1))
+      .join(', ')}  ·  fov ${cam.fov}°  ·  3:2`,
+  );
+  console.log(`\n  cielo/telón : ${pct(cielo)}`);
+  console.log(`  terreno     : ${pct(suelo)}`);
+  console.log(
+    `  reparto vertical del terreno — tercio alto ${pct(porTercio[0])} · medio ${pct(
+      porTercio[1],
+    )} · bajo ${pct(porTercio[2])}`,
+  );
+  if (suelo > 0) {
+    console.log(
+      `  distancia   : más cerca ${masCerca.toFixed(1)} m · promedio ${(sumaDist / suelo).toFixed(
+        1,
+      )} m · más lejos ${masLejos.toFixed(1)} m`,
+    );
+  }
+
+  console.log(`  sobre el CULTIVO sembrado: ${pct(enLote)} del cuadro`);
+
+  console.log(`\n  SUJETO — ${def.sujeto.nombre}:`);
+  if (sujetoFila === null) {
+    console.log('  ✗ NO APARECE EN CUADRO. La cámara no lo está mirando.');
+  } else {
+    const tercioV = ['alto', 'medio', 'bajo'][Math.min(2, Math.floor((sujetoFila / FILAS) * 3))];
+    const tercioH = ['izquierda', 'centro', 'derecha'][
+      Math.min(2, Math.floor((sujetoCol / COLS) * 3))
+    ];
+    console.log(`  ✓ en cuadro, tercio ${tercioV} · ${tercioH}`);
+  }
+
+  /* Los avisos que este diagnóstico existe para dar. */
+  /* Los umbrales NO son inventados: salen de medir el papal, que es un mundo ya
+     aprobado y desplegado (`node scripts/diag/encuadre-mundo.mjs papa`):
+       cielo 32.8% · terreno 67.2% · tercio alto 0.6% · más cerca 10.4 m
+     Es decir, la casa compone en plano general de diorama —el tercio alto casi
+     libre de terreno y el sujeto abajo—, NO en primer plano cercano. Un umbral
+     de "falta primer plano" en 6 m marcaba en rojo hasta al propio papal. */
+  const avisos = [];
+  if (cielo / total < 0.12) avisos.push('casi no hay cielo: el cuadro se siente tapiado');
+  if (cielo / total > 0.55) avisos.push('demasiado cielo: el mundo queda vacío abajo');
+  if (porTercio[0] / total > 0.1) {
+    avisos.push(
+      'el tercio ALTO tiene terreno encima del umbral de la casa (papal: 0.6%): la cámara está mirando contra la loma',
+    );
+  }
+  if (suelo > 0 && masCerca > 14) {
+    avisos.push('nada cerca de la cámara: la escena se ve lejana incluso para el estilo de la casa');
+  }
+  if (sujetoFila === null) avisos.push('EL SUJETO NO ESTÁ EN CUADRO — esto es un bloqueante');
+  if (enLote / total < 0.12) {
+    avisos.push('el cultivo sembrado ocupa muy poco cuadro: se está fotografiando el paisaje, no el cultivo');
+  }
+
+  if (avisos.length) {
+    console.log('\n  ⚠ avisos:');
+    avisos.forEach((a) => console.log(`    · ${a}`));
+  } else {
+    console.log('\n  ✓ sin avisos de encuadre');
+  }
+  console.log('');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/diag/encuadre-mundo.mjs
+++ b/scripts/diag/encuadre-mundo.mjs
@@ -117,6 +117,17 @@ async function main() {
      la trae escrita a mano aquí arriba. */
   const cam = def.camaraFija || { ...geom.CAMARA, pos: geom.CAMARA.reposo, mira: geom.CAMARA.mirada };
   if (!cam || !cam.pos) throw new Error(`el módulo de «${cual}» no exporta CAMARA`);
+  /* Override por bandera: un mundo puede tener MÁS DE UNA cámara que se
+     fotografía (la de pantalla completa y la de la tarjeta de vitrina, que sale
+     de camaraDioramas). Las dos hay que medirlas: la vitrina es la que la gente
+     ve primero.  --pos x,y,z  --mira x,y,z  --fov n */
+  const trio = (s) => s.split(',').map(Number);
+  const fPos = process.argv.includes('--pos') ? trio(process.argv[process.argv.indexOf('--pos') + 1]) : null;
+  const fMira = process.argv.includes('--mira') ? trio(process.argv[process.argv.indexOf('--mira') + 1]) : null;
+  const fFov = process.argv.includes('--fov') ? Number(process.argv[process.argv.indexOf('--fov') + 1]) : null;
+  if (fPos) cam.pos = fPos;
+  if (fMira) cam.mira = fMira;
+  if (fFov) cam.fov = fFov;
   const sujeto = geom[def.sujeto.clave];
   /* El dosel: cuánto levanta el cultivo sobre el suelo en cada punto del lote.
      Se apoya en el `dentroLote` del propio mundo, así que respeta los claros
@@ -210,6 +221,83 @@ async function main() {
 
   console.log(`  sobre el CULTIVO sembrado: ${pct(enLote)} del cuadro`);
 
+  const avisosCopa = [];
+
+  /* ¿Hay una COPA tapando la vista? El ray-march de arriba golpea terreno más
+     dosel: es CIEGO a los árboles de sombra, que no son relieve del suelo sino
+     una tapa en el aire con hueco debajo. Y esa ceguera ya costó caro — un
+     mundo dio "sin avisos" con la copa de un guamo sentada sobre la cámara,
+     cortando media vista. Si el mundo declara sus copas, aquí se miden. */
+  if (geom.copasSombrio) {
+    const copas = geom.copasSombrio();
+    /* Un mundo de café DE SOMBRA tiene que tener techo de hojas: contar todo el
+       follaje del sombrío como "estorbo" castigaría justo lo que hace bien. Lo
+       que estorba es la copa CERCA del ojo — la que ya no enmarca sino tapa. */
+    const CERCA_COPA = 7;
+    let tapados = 0;
+    let tapadosCerca = 0;
+    let masCercaCopa = Infinity;
+    let culpable = null;
+    for (let f = 0; f < FILAS; f++) {
+      for (let cN = 0; cN < COLS; cN++) {
+        const sx = ((cN + 0.5) / COLS) * 2 - 1;
+        const sy = 1 - ((f + 0.5) / FILAS) * 2;
+        const dir = norm([
+          adelante[0] + derecha[0] * sx * mediaH + arriba[0] * sy * mediaV,
+          adelante[1] + derecha[1] * sx * mediaH + arriba[1] * sy * mediaV,
+          adelante[2] + derecha[2] * sx * mediaH + arriba[2] * sy * mediaV,
+        ]);
+        let tapa = null;
+        for (const copa of copas) {
+          // intersección rayo-esfera (la copa como bola en el aire)
+          const oc = sub(cam.pos, copa.c);
+          const b = 2 * (oc[0] * dir[0] + oc[1] * dir[1] + oc[2] * dir[2]);
+          const cc = oc[0] * oc[0] + oc[1] * oc[1] + oc[2] * oc[2] - copa.r * copa.r;
+          const disc = b * b - 4 * cc;
+          if (disc < 0) continue;
+          const t = (-b - Math.sqrt(disc)) / 2;
+          if (t > 0.2 && (!tapa || t < tapa.t)) tapa = { t, copa };
+        }
+        if (tapa) {
+          tapados += 1;
+          if (tapa.t < CERCA_COPA) tapadosCerca += 1;
+          if (tapa.t < masCercaCopa) {
+            masCercaCopa = tapa.t;
+            culpable = tapa.copa;
+          }
+        }
+      }
+    }
+    console.log(
+      `  bajo COPAS del sombrío: ${pct(tapados)} del cuadro ` +
+        `(de eso, CERCA —a menos de ${CERCA_COPA} m—: ${pct(tapadosCerca)})`,
+    );
+    if (culpable) {
+      console.log(
+        `    la más encima: ${culpable.quien} a ${masCercaCopa.toFixed(1)} m ` +
+          `(${culpable.c.map((v) => v.toFixed(1)).join(', ')})`,
+      );
+    }
+    /* Los umbrales miran la copa CERCANA, no el techo: una copa a 10 m es el
+       sombrío del cafetal (y debe estar); a menos de 5 m es una hoja en el
+       lente. Más de un octavo del cuadro en follaje cercano = cámara metida
+       ENTRE las copas, que fue exactamente el reclamo. */
+    if (masCercaCopa < 5) {
+      avisosCopa.push(
+        `la copa de un ${culpable.quien} está a ${masCercaCopa.toFixed(
+          1,
+        )} m de la cámara: no enmarca, TAPA`,
+      );
+    }
+    if (tapadosCerca / total > 0.125) {
+      avisosCopa.push(
+        `el follaje del sombrío a menos de ${CERCA_COPA} m tapa ${pct(
+          tapadosCerca,
+        )} del cuadro: la cámara está metida ENTRE las copas, no debajo`,
+      );
+    }
+  }
+
   console.log(`\n  SUJETO — ${def.sujeto.nombre}:`);
   if (sujetoFila === null) {
     console.log('  ✗ NO APARECE EN CUADRO. La cámara no lo está mirando.');
@@ -228,7 +316,7 @@ async function main() {
      Es decir, la casa compone en plano general de diorama —el tercio alto casi
      libre de terreno y el sujeto abajo—, NO en primer plano cercano. Un umbral
      de "falta primer plano" en 6 m marcaba en rojo hasta al propio papal. */
-  const avisos = [];
+  const avisos = [...avisosCopa];
   if (cielo / total < 0.12) avisos.push('casi no hay cielo: el cuadro se siente tapiado');
   if (cielo / total > 0.55) avisos.push('demasiado cielo: el mundo queda vacío abajo');
   if (porTercio[0] / total > 0.1) {

--- a/src/visual/mundo3d/cafetal/CasaBeneficio.jsx
+++ b/src/visual/mundo3d/cafetal/CasaBeneficio.jsx
@@ -1,0 +1,103 @@
+/*
+ * CasaBeneficio — la casa campesina con su BENEFICIADERO, la pieza que corona
+ * el cafetal: paredes encaladas, techo de teja, y al lado la marquesina — la
+ * cama elevada bajo plástico donde el café pergamino se seca al sol. Con los
+ * canastos de cosecha esperando en el patio.
+ *
+ * Vivía privada dentro de EscenaCafetalVivo; ahora es pieza compartida — la
+ * monta también el arquetipo `cafe` del framework (EscenaCafe). Primitivas
+ * Lambert, cero texturas: el contrato austero de los mundos.
+ *
+ * Componente r3f: montar dentro de un <Canvas>.
+ */
+import * as THREE from 'three';
+import {
+  mezclar,
+  TIERRAS,
+  CASA,
+  ACENTOS,
+  NIEBLAS,
+  PALETA,
+} from '../paleta/index.js';
+
+export default function CasaBeneficio({ pos }) {
+  return (
+    <group position={pos} rotation={[0, -0.35, 0]}>
+      {/* la casa: LA casa campesina de la paleta madre (la misma del valle) */}
+      <mesh position={[0, 0.72, 0]}>
+        <boxGeometry args={[2.6, 1.44, 1.9]} />
+        <meshLambertMaterial color={CASA.encalado} flatShading />
+      </mesh>
+      <mesh position={[0, 0.18, 0]}>
+        <boxGeometry args={[2.64, 0.36, 1.94]} />
+        <meshLambertMaterial color={CASA.zocalo} flatShading />
+      </mesh>
+      {/* la puerta y una ventana (la carpintería pintada de la casa) */}
+      <mesh position={[0.5, 0.62, 0.96]}>
+        <boxGeometry args={[0.44, 0.95, 0.06]} />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
+      </mesh>
+      <mesh position={[-0.6, 0.86, 0.96]}>
+        <boxGeometry args={[0.5, 0.44, 0.06]} />
+        <meshLambertMaterial color={CASA.carpinteria} flatShading />
+      </mesh>
+      {/* techo a dos aguas de teja */}
+      <mesh position={[0, 1.62, -0.62]} rotation={[-0.62, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.5]} />
+        <meshLambertMaterial color={CASA.tejaSombra} flatShading />
+      </mesh>
+      <mesh position={[0, 1.62, 0.62]} rotation={[0.62, 0, 0]}>
+        <boxGeometry args={[3.0, 0.08, 1.5]} />
+        <meshLambertMaterial color={CASA.teja} flatShading />
+      </mesh>
+
+      {/* la MARQUESINA de secado, al lado: patas + cama de pergamino + techo
+          translúcido a dos aguas (la señal del beneficio) */}
+      <group position={[2.6, 0, 0.4]}>
+        {[[-1.0, -0.55], [1.0, -0.55], [-1.0, 0.55], [1.0, 0.55]].map((q, i) => (
+          <mesh key={i} position={[q[0], 0.35, q[1]]}>
+            <boxGeometry args={[0.09, 0.7, 0.09]} />
+            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
+          </mesh>
+        ))}
+        <mesh position={[0, 0.72, 0]}>
+          <boxGeometry args={[2.2, 0.07, 1.3]} />
+          <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+        </mesh>
+        {/* el café pergamino extendido secándose al sol */}
+        <mesh position={[0, 0.77, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+          <planeGeometry args={[2.0, 1.1]} />
+          <meshLambertMaterial color={mezclar(TIERRAS.arenaOrilla, TIERRAS.camino, 0.2)} flatShading />
+        </mesh>
+        {[[-1.05, -0.62], [1.05, -0.62], [-1.05, 0.62], [1.05, 0.62]].map((q, i) => (
+          <mesh key={`p${i}`} position={[q[0], 1.15, q[1]]}>
+            <boxGeometry args={[0.06, 0.85, 0.06]} />
+            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
+          </mesh>
+        ))}
+        <mesh position={[0, 1.62, -0.36]} rotation={[-0.5, 0, 0]}>
+          <planeGeometry args={[2.4, 0.95]} />
+          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+        </mesh>
+        <mesh position={[0, 1.62, 0.36]} rotation={[0.5, 0, 0]}>
+          <planeGeometry args={[2.4, 0.95]} />
+          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
+        </mesh>
+      </group>
+
+      {/* dos canastos de cosecha esperando en el patio */}
+      {[[-1.8, 0.6], [-1.35, 0.9]].map((q, i) => (
+        <group key={`c${i}`} position={[q[0], 0, q[1]]}>
+          <mesh position={[0, 0.18, 0]}>
+            <cylinderGeometry args={[0.24, 0.17, 0.36, 9, 1, true]} />
+            <meshLambertMaterial color={CASA.bejuco} flatShading side={THREE.DoubleSide} />
+          </mesh>
+          <mesh position={[0, 0.36, 0]} scale={[1, 0.4, 1]}>
+            <sphereGeometry args={[0.2, 8, 5]} />
+            <meshLambertMaterial color={ACENTOS.cafeCereza} flatShading />
+          </mesh>
+        </group>
+      ))}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
+++ b/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
@@ -29,27 +29,16 @@ import { perfilDeTier } from '../deviceTier.js';
 import { Fauna } from '../escenas/FaunaEscena.jsx';
 import FaunaCalido from '../escenas/FaunaCalido.jsx';
 import FloraCafetal from './FloraCafetal.jsx';
-import { ANCHO, FONDO, alturaLadera, SITIO_CASA } from './floraCafetal.geom.js';
+import CasaBeneficio from './CasaBeneficio.jsx';
+import { alturaLadera, construirLadera, SITIO_CASA } from './floraCafetal.geom.js';
 import {
   AtmosferaMundo,
   DomoCielo,
   useAtmosferaMundo,
   useGradienteBandas,
-  construirTerreno,
-  ruidoTerreno,
-  smoothstep,
   CamaraDirector,
 } from '../kit/index.js';
-import {
-  mezclar,
-  VERDES,
-  TIERRAS,
-  CASA,
-  ACENTOS,
-  LUCES,
-  NIEBLAS,
-  PALETA,
-} from '../paleta/index.js';
+import { mezclar, VERDES, LUCES } from '../paleta/index.js';
 
 /* La identidad del piso templado dentro de la familia del valle: `corral`
    ("corral y cafetal: tarde de finca"). El 60% restante lo pone la HORA. */
@@ -62,118 +51,9 @@ const RADIO_CAFETAL = 11;
 /* El frustum de sombra a medida de la ladera (la luz colada del sombrío). */
 const SOMBRA_CAFETAL = { left: -16, right: 16, top: 16, bottom: -6, far: 40 };
 
-/* La malla de la ladera — el heightfield del KIT (mismo andamiaje que todos los
-   mundos) con la pintura PROPIA del piso templado: arvenses verdes (cobertura
-   viva), tierra roja andina asomando y el mantillo pardo hacia la sombra. */
-function construirLadera(seg, plano) {
-  const cPasto = new THREE.Color(VERDES.brote); // pasto al sol del piso templado
-  const cPasto2 = new THREE.Color(VERDES.calido); // el oliva que asoma hacia lo seco
-  const cTierra = new THREE.Color(TIERRAS.arcilla); // la tierra roja cafetera
-  const cMantillo = new THREE.Color(TIERRAS.mantillo); // hojarasca bajo el sombrío
-  const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.4));
-  return construirTerreno({
-    ancho: ANCHO,
-    fondo: FONDO,
-    seg,
-    plano,
-    altura: alturaLadera,
-    pintar: (wx, wz, alt, c) => {
-      const enLoma = smoothstep(5, -8, wz);
-      c.lerpColors(cPasto, cPasto2, 0.5 + 0.5 * ruidoTerreno(wx * 0.9, wz * 0.7));
-      // la tierra roja asoma a manchas entre los surcos
-      c.lerp(cTierra, smoothstep(-0.1, 0.85, ruidoTerreno(wx * 1.3, wz * 1.1)) * 0.45 * enLoma);
-      // el mantillo pardo gana hacia lo alto (más sombrío, más hojarasca)
-      c.lerp(cMantillo, enLoma * 0.22);
-      // el caminito seco del frente, por donde se llega
-      c.lerp(cCamino, smoothstep(1.2, 0, Math.abs(wx - Math.sin(wz * 0.4) * 2.2)) * smoothstep(2, 12, wz));
-    },
-  });
-}
-
-/* La casa campesina con su BENEFICIADERO, arriba al fondo: paredes encaladas,
-   techo de teja, y al lado la marquesina — la cama elevada bajo plástico donde
-   el café pergamino se seca al sol. Insinuada, medio velada por la bruma. */
-function CasaBeneficio({ pos }) {
-  return (
-    <group position={pos} rotation={[0, -0.35, 0]}>
-      {/* la casa: LA casa campesina de la paleta madre (la misma del valle) */}
-      <mesh position={[0, 0.72, 0]}>
-        <boxGeometry args={[2.6, 1.44, 1.9]} />
-        <meshLambertMaterial color={CASA.encalado} flatShading />
-      </mesh>
-      <mesh position={[0, 0.18, 0]}>
-        <boxGeometry args={[2.64, 0.36, 1.94]} />
-        <meshLambertMaterial color={CASA.zocalo} flatShading />
-      </mesh>
-      {/* la puerta y una ventana (la carpintería pintada de la casa) */}
-      <mesh position={[0.5, 0.62, 0.96]}>
-        <boxGeometry args={[0.44, 0.95, 0.06]} />
-        <meshLambertMaterial color={CASA.carpinteria} flatShading />
-      </mesh>
-      <mesh position={[-0.6, 0.86, 0.96]}>
-        <boxGeometry args={[0.5, 0.44, 0.06]} />
-        <meshLambertMaterial color={CASA.carpinteria} flatShading />
-      </mesh>
-      {/* techo a dos aguas de teja */}
-      <mesh position={[0, 1.62, -0.62]} rotation={[-0.62, 0, 0]}>
-        <boxGeometry args={[3.0, 0.08, 1.5]} />
-        <meshLambertMaterial color={CASA.tejaSombra} flatShading />
-      </mesh>
-      <mesh position={[0, 1.62, 0.62]} rotation={[0.62, 0, 0]}>
-        <boxGeometry args={[3.0, 0.08, 1.5]} />
-        <meshLambertMaterial color={CASA.teja} flatShading />
-      </mesh>
-
-      {/* la MARQUESINA de secado, al lado: patas + cama de pergamino + techo
-          translúcido a dos aguas (la señal del beneficio) */}
-      <group position={[2.6, 0, 0.4]}>
-        {[[-1.0, -0.55], [1.0, -0.55], [-1.0, 0.55], [1.0, 0.55]].map((q, i) => (
-          <mesh key={i} position={[q[0], 0.35, q[1]]}>
-            <boxGeometry args={[0.09, 0.7, 0.09]} />
-            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
-          </mesh>
-        ))}
-        <mesh position={[0, 0.72, 0]}>
-          <boxGeometry args={[2.2, 0.07, 1.3]} />
-          <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-        </mesh>
-        {/* el café pergamino extendido secándose al sol */}
-        <mesh position={[0, 0.77, 0]} rotation={[-Math.PI / 2, 0, 0]}>
-          <planeGeometry args={[2.0, 1.1]} />
-          <meshLambertMaterial color={mezclar(TIERRAS.arenaOrilla, TIERRAS.camino, 0.2)} flatShading />
-        </mesh>
-        {[[-1.05, -0.62], [1.05, -0.62], [-1.05, 0.62], [1.05, 0.62]].map((q, i) => (
-          <mesh key={`p${i}`} position={[q[0], 1.15, q[1]]}>
-            <boxGeometry args={[0.06, 0.85, 0.06]} />
-            <meshLambertMaterial color={mezclar(PALETA.madera, PALETA.maderaOscura, 0.5)} flatShading />
-          </mesh>
-        ))}
-        <mesh position={[0, 1.62, -0.36]} rotation={[-0.5, 0, 0]}>
-          <planeGeometry args={[2.4, 0.95]} />
-          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
-        </mesh>
-        <mesh position={[0, 1.62, 0.36]} rotation={[0.5, 0, 0]}>
-          <planeGeometry args={[2.4, 0.95]} />
-          <meshBasicMaterial color={NIEBLAS.lechosa} transparent opacity={0.34} depthWrite={false} side={THREE.DoubleSide} />
-        </mesh>
-      </group>
-
-      {/* dos canastos de cosecha esperando en el patio */}
-      {[[-1.8, 0.6], [-1.35, 0.9]].map((q, i) => (
-        <group key={`c${i}`} position={[q[0], 0, q[1]]}>
-          <mesh position={[0, 0.18, 0]}>
-            <cylinderGeometry args={[0.24, 0.17, 0.36, 9, 1, true]} />
-            <meshLambertMaterial color={CASA.bejuco} flatShading side={THREE.DoubleSide} />
-          </mesh>
-          <mesh position={[0, 0.36, 0]} scale={[1, 0.4, 1]}>
-            <sphereGeometry args={[0.2, 8, 5]} />
-            <meshLambertMaterial color={ACENTOS.cafeCereza} flatShading />
-          </mesh>
-        </group>
-      ))}
-    </group>
-  );
-}
+/* La malla de la ladera y la casa-beneficiadero viven ahora en piezas
+   compartidas del cafetal (floraCafetal.geom / CasaBeneficio.jsx): las monta
+   también el arquetipo `cafe` del framework — una sola geografía, dos tomas. */
 
 /* El anillo del paso didáctico: respira sobre el punto que la lección señala.
    Con reducedMotion queda quieto (presencia sin parpadeo). */

--- a/src/visual/mundo3d/cafetal/FloraCafetal.jsx
+++ b/src/visual/mundo3d/cafetal/FloraCafetal.jsx
@@ -141,7 +141,13 @@ export default function FloraCafetal({ tier = 'alto', reducedMotion = false }) {
   // Geometrías fusionadas (una vez por tier).
   const geos = useMemo(
     () => ({
-      cafeto: geomCafeto({ q }, 21),
+      /* UNA MALLA POR PORTE. La ladera dejó de ser un molde repetido: conviven
+         matas de un tallo, zoqueadas y agobiadas, que es como se ve un cafetal
+         de verdad. Cuesta dos draw-calls más y compra que a media distancia el
+         cultivo NO se lea como un pinar de clones. */
+      cafetoTallo: geomCafeto({ q, porte: 'tallo' }, 21),
+      cafetoZoqueo: geomCafeto({ q, porte: 'zoqueo' }, 41),
+      cafetoAgobio: geomCafeto({ q, porte: 'agobio' }, 61),
       cereza: geomCereza(),
       flor: conteos.flor ? geomFlorCafe(27) : null,
       guamo: conteos.guamo ? geomGuamo({ q }, 22) : null,
@@ -201,7 +207,9 @@ export default function FloraCafetal({ tier = 'alto', reducedMotion = false }) {
       {/* EL CULTIVO: los surcos de cafetos con hoja LUSTROSA, sus cerezas en
           racimos pegados a la rama (verde→pintón→rojo→vino) y la flor blanca
           axilar — flor y cosecha conviviendo, el ciclo real del arábica. */}
-      <Especie geo={geos.cafeto} mat={matLustre} items={dist.cafeto} />
+      <Especie geo={geos.cafetoTallo} mat={matLustre} items={dist.cafeto.tallo} />
+      <Especie geo={geos.cafetoZoqueo} mat={matLustre} items={dist.cafeto.zoqueo} />
+      <Especie geo={geos.cafetoAgobio} mat={matLustre} items={dist.cafeto.agobio} />
       <Especie geo={geos.cereza} mat={matLustre} items={dist.cereza} />
       <Especie geo={geos.flor} mat={matLustre} items={dist.flor} />
 

--- a/src/visual/mundo3d/cafetal/floraCafetal.geom.js
+++ b/src/visual/mundo3d/cafetal/floraCafetal.geom.js
@@ -568,6 +568,43 @@ const SITIOS_PLATANO = [
 /* La casa/beneficiadero vive arriba al fondo; los surcos la respetan. */
 export const SITIO_CASA = /** @type {[number, number]} */ ([9.0, -14.6]);
 
+/* El SUJETO del mundo: el cafeto protagonista junto al camino de llegada — la
+   mata que enseña qué es un cafeto. Se exporta aparte de SITIOS_HERO para que
+   el diagnóstico de encuadre pueda preguntar "¿está en cuadro?" sin conocer la
+   forma interna de la siembra. */
+export const SITIO_CAFETO_HERO = /** @type {[number, number]} */ ([-2.8, 5.6]);
+
+/*
+ * LA CÁMARA del mundo, declarada JUNTO A LA GEOGRAFÍA (convención de la casa):
+ * así `node scripts/diag/encuadre-mundo.mjs cafe` mide EXACTAMENTE el encuadre
+ * que monta la escena y no puede quedar desfasado de ella.
+ *
+ * Mira loma arriba desde el camino de llegada — entrar es subir.
+ */
+export const CAMARA = {
+  reposo: /** @type {[number, number, number]} */ ([7.15, 6.5, 13]),
+  mirada: /** @type {[number, number, number]} */ ([0, 3.96, -2]),
+  fov: 42,
+};
+
+/*
+ * El LOTE SEMBRADO: dónde el piso lleva cafetal encima. Lo usa el diagnóstico
+ * de encuadre para distinguir "el cuadro está lleno de CULTIVO" de "el cuadro
+ * está lleno de loma pelada" — medir solo terreno engaña, porque lo que llena
+ * el cuadro de un cafetal es la mata, no el barro entre surcos. Respeta el
+ * patio del beneficiadero y la calle del camino: los claros son claros.
+ */
+export function dentroLote(wx, wz) {
+  if (Math.abs(wx) > 15.6) return 0;
+  if (wz > 6.4 || wz < -14.2) return 0;
+  const dx = wx - SITIO_CASA[0];
+  const dz = wz - SITIO_CASA[1];
+  if (dx * dx + dz * dz < 16) return 0; // el patio del beneficiadero
+  const calle = Math.abs(wx - Math.sin(wz * 0.4) * 2.2); // el camino de llegada
+  if (wz > 1.5 && calle < 1.15) return 0;
+  return 1;
+}
+
 /*
  * Los CAFETOS PROTAGONISTAS del primer plano: tres matas grandes y CARGADAS que
  * flanquean el camino de entrada (los surcos arrancan en z=2.6; estos viven más

--- a/src/visual/mundo3d/cafetal/floraCafetal.geom.js
+++ b/src/visual/mundo3d/cafetal/floraCafetal.geom.js
@@ -42,6 +42,10 @@
 import * as THREE from 'three';
 import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
 import { rng } from '../bosque/entQuenua.geom.js';
+import { construirTerreno } from '../kit/terreno.js';
+import { ruidoTerreno } from '../kit/ruido.js';
+import { VERDES, TIERRAS } from '../paleta/paletaMadre.js';
+import { mezclar } from '../atmosferaMadre.js';
 
 /* -------------------------------------------------------------------------- */
 /*  La ladera cafetera (la geografía del mundo, determinista)                  */
@@ -72,6 +76,38 @@ export function alturaLadera(wx, wz) {
   h += sub * 5.4; // la ladera cafetera gana altura hacia atrás
   h += ruido(wx * 0.5, wz * 0.5) * 0.35 * (0.3 + sub); // ondulación natural
   return h;
+}
+
+/*
+ * LA MALLA de la ladera — el heightfield del KIT (mismo andamiaje que todos los
+ * mundos) con la pintura PROPIA del piso templado: arvenses verdes (cobertura
+ * viva), tierra roja andina asomando y el mantillo pardo hacia la sombra. Vivía
+ * duplicada en cada escena que montaba el cafetal; aquí es la geografía única
+ * (headless, testeable, memoizar en quien llama).
+ */
+export function construirLadera(seg, plano) {
+  const cPasto = new THREE.Color(VERDES.brote); // pasto al sol del piso templado
+  const cPasto2 = new THREE.Color(VERDES.calido); // el oliva que asoma hacia lo seco
+  const cTierra = new THREE.Color(TIERRAS.arcilla); // la tierra roja cafetera
+  const cMantillo = new THREE.Color(TIERRAS.mantillo); // hojarasca bajo el sombrío
+  const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.4));
+  return construirTerreno({
+    ancho: ANCHO,
+    fondo: FONDO,
+    seg,
+    plano,
+    altura: alturaLadera,
+    pintar: (wx, wz, alt, c) => {
+      const enLoma = smoothstep(5, -8, wz);
+      c.lerpColors(cPasto, cPasto2, 0.5 + 0.5 * ruidoTerreno(wx * 0.9, wz * 0.7));
+      // la tierra roja asoma a manchas entre los surcos
+      c.lerp(cTierra, smoothstep(-0.1, 0.85, ruidoTerreno(wx * 1.3, wz * 1.1)) * 0.45 * enLoma);
+      // el mantillo pardo gana hacia lo alto (más sombrío, más hojarasca)
+      c.lerp(cMantillo, enLoma * 0.22);
+      // el caminito seco del frente, por donde se llega
+      c.lerp(cCamino, smoothstep(1.2, 0, Math.abs(wx - Math.sin(wz * 0.4) * 2.2)) * smoothstep(2, 12, wz));
+    },
+  });
 }
 
 /* -------------------------------------------------------------------------- */
@@ -532,6 +568,22 @@ const SITIOS_PLATANO = [
 /* La casa/beneficiadero vive arriba al fondo; los surcos la respetan. */
 export const SITIO_CASA = /** @type {[number, number]} */ ([9.0, -14.6]);
 
+/*
+ * Los CAFETOS PROTAGONISTAS del primer plano: tres matas grandes y CARGADAS que
+ * flanquean el camino de entrada (los surcos arrancan en z=2.6; estos viven más
+ * acá, donde la cámara llega). Son la respuesta al reclamo "el café no se
+ * distingue como planta": a esta distancia los pisos de ramas plagiotrópicas,
+ * la hoja elíptica oscura y el racimo de cereza PEGADO a la rama se leen sin
+ * ayuda. Deterministas y en TODOS los tiers (son pocos y son la lección).
+ * `maduro` alto = cosecha a la vista (roja/vino con su pintón); el verde queda
+ * en los surcos del fondo — la maduración despareja real de la ladera.
+ */
+export const SITIOS_HERO = [
+  { px: -2.8, pz: 5.6, esc: 1.6, rotY: 2.2, maduro: 0.85, carga: 1, hero: true },
+  { px: 4.2, pz: 4.6, esc: 1.35, rotY: 0.7, maduro: 0.7, carga: 1, hero: true },
+  { px: -5.0, pz: 3.2, esc: 1.25, rotY: 4.1, maduro: 0.75, carga: 1, hero: true },
+];
+
 /** ¿Qué tan maduro está el café en esta franja? Abajo (más caliente) más rojo. */
 function madurezEn(wz, r) {
   const base = smoothstep(-13.5, 3.0, wz); // el frente de la ladera pinta primero
@@ -586,6 +638,9 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
     const paso = sitios.length / c.cafeto;
     for (let k = 0; k < c.cafeto; k++) matas.push(sitios[Math.floor(k * paso)]);
   }
+  // Los protagonistas del primer plano van SIEMPRE (fuera del presupuesto: son
+  // tres y son la lección — hasta 'bajo' tiene que leer "eso es un cafeto").
+  matas.push(...SITIOS_HERO);
 
   const cafeto = matas.map((s) => ({
     pos: [s.px, alturaLadera(s.px, s.pz), s.pz],
@@ -605,7 +660,17 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
   const col = new THREE.Color();
   const cereza = [];
   const nPisos = pisosCafetoDeQ(q);
-  const cargadas = matas.filter((s) => s.carga > 0.3);
+  // Los héroes del primer plano entran TRES veces a la rueda Y AL FRENTE:
+  // cargan el triple de racimos que una mata del surco y cargan PRIMERO — la
+  // cereza pegada a la rama tiene que leerse desde la entrada en TODOS los
+  // tiers (en 'bajo' el presupuesto se agota rápido: si el héroe espera turno
+  // al final, queda pelado — mordida encontrada en el sanity headless).
+  const cargadas = [
+    ...SITIOS_HERO,
+    ...SITIOS_HERO,
+    ...SITIOS_HERO,
+    ...matas.filter((s) => s.carga > 0.3 && !s.hero),
+  ];
   /* Un punto local de la rama (piso i, rama j, avance t) llevado al mundo:
      escala de la mata + su giro + su sitio en la ladera. */
   const enRama = (s, i, j, t, dy, jit, rr) => {
@@ -631,7 +696,7 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
     const i = Math.floor(rCer() * Math.min(nPisos, 3));
     const p = PISOS_CAFETO[i];
     const j = Math.floor(rCer() * p.ramas);
-    const cuantas = 3 + Math.floor(rCer() * 4);
+    const cuantas = 3 + Math.floor(rCer() * 4) + (s.hero ? 2 : 0);
     const t0 = 0.2 + rCer() * 0.28;
     for (let k = 0; k < cuantas && cereza.length < c.cereza; k++) {
       const t = t0 + k * 0.085; // el racimo EN FILA, cuenta tras cuenta
@@ -645,7 +710,8 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
       cereza.push({
         pos: enRama(s, i, j, t, -0.045, 0.035, rCer), // colgada APENAS bajo la rama
         rotY: rCer() * Math.PI,
-        escala: 0.8 + rCer() * 0.45,
+        // en el héroe la cuenta es un pelín más gorda: legible desde la entrada
+        escala: (0.8 + rCer() * 0.45) * (s.hero ? 1.3 : 1),
         tint: [col.r, col.g, col.b],
       });
     }

--- a/src/visual/mundo3d/cafetal/floraCafetal.geom.js
+++ b/src/visual/mundo3d/cafetal/floraCafetal.geom.js
@@ -85,9 +85,21 @@ export function alturaLadera(wx, wz) {
  * duplicada en cada escena que montaba el cafetal; aquí es la geografía única
  * (headless, testeable, memoizar en quien llama).
  */
+/*
+ * ⚠️ EL PISO TÉRMICO MANDA EN LA PALETA. Esta ladera se pintaba con
+ * `VERDES.calido` (#98ab4b, oliva amarillento) como color DOMINANTE — la mezcla
+ * `0.5 + 0.5·ruido` lo dejaba pesando la mitad o más del suelo. Pero `calido` es
+ * la banda del piso CÁLIDO, y el *Coffea arabica* colombiano es cultivo de piso
+ * TEMPLADO (la franja cafetera de montaña, ~1.200–1.900 m). Pintar el cafetal
+ * con la paleta del piso de abajo es lo que lo dejaba PARDO Y MUSTIO al lado del
+ * verde del valle: no era la luz ni la niebla, era la banda equivocada.
+ *
+ * Ahora manda el verde templado (`templadoVivo`) y el amarillento queda de
+ * variación al sol (`brote`), que es el reparto real de un cafetal bajo sombra.
+ */
 export function construirLadera(seg, plano) {
-  const cPasto = new THREE.Color(VERDES.brote); // pasto al sol del piso templado
-  const cPasto2 = new THREE.Color(VERDES.calido); // el oliva que asoma hacia lo seco
+  const cPasto = new THREE.Color(VERDES.templadoVivo); // el verde franco del templado
+  const cPasto2 = new THREE.Color(VERDES.brote); // el pasto al sol, apenas amarillento
   const cTierra = new THREE.Color(TIERRAS.arcilla); // la tierra roja cafetera
   const cMantillo = new THREE.Color(TIERRAS.mantillo); // hojarasca bajo el sombrío
   const cCamino = new THREE.Color(mezclar(TIERRAS.camino, TIERRAS.vega, 0.4));
@@ -100,10 +112,11 @@ export function construirLadera(seg, plano) {
     pintar: (wx, wz, alt, c) => {
       const enLoma = smoothstep(5, -8, wz);
       c.lerpColors(cPasto, cPasto2, 0.5 + 0.5 * ruidoTerreno(wx * 0.9, wz * 0.7));
-      // la tierra roja asoma a manchas entre los surcos
-      c.lerp(cTierra, smoothstep(-0.1, 0.85, ruidoTerreno(wx * 1.3, wz * 1.1)) * 0.45 * enLoma);
+      // la tierra roja asoma a manchas entre los surcos (ACENTO, no manto: a
+      // 0.45 se comía el verde y dejaba la ladera parda)
+      c.lerp(cTierra, smoothstep(-0.1, 0.85, ruidoTerreno(wx * 1.3, wz * 1.1)) * 0.32 * enLoma);
       // el mantillo pardo gana hacia lo alto (más sombrío, más hojarasca)
-      c.lerp(cMantillo, enLoma * 0.22);
+      c.lerp(cMantillo, enLoma * 0.16);
       // el caminito seco del frente, por donde se llega
       c.lerp(cCamino, smoothstep(1.2, 0, Math.abs(wx - Math.sin(wz * 0.4) * 2.2)) * smoothstep(2, 12, wz));
     },
@@ -140,10 +153,13 @@ export const PAL = {
   // Cafeto
   cafetoTallo: '#5a4430', // tallo leñoso delgado
   cafetoRama: '#6b5138', // la rama plagiotrópica, la percha de las cerezas
-  cafetoHoja: '#24512c', // hoja verde MUY oscura lustrosa (la firma del café)
-  cafetoHojaSol: '#3d7238', // la cara de la hoja que da al sol
-  cafetoHojaSombra: '#1c3f23', // el corazón tupido de cada piso, tras las hojas
-  cafetoBrote: '#7fa24c', // cogollo tierno arriba
+  // La hoja del arábica es oscura y LUSTROSA — pero lustrosa quiere decir que
+  // devuelve luz, no que sea negra. Subidas de valor medidas: la firma oscura
+  // se conserva, se le quita el apagado que la dejaba mustia bajo el sombrío.
+  cafetoHoja: '#2a6332', // hoja verde oscura lustrosa (la firma del café)
+  cafetoHojaSol: '#4d8f40', // la cara de la hoja que da al sol
+  cafetoHojaSombra: '#1b452a', // el corazón tupido de cada piso, tras las hojas
+  cafetoBrote: '#8cb752', // cogollo tierno arriba
 
   // Los estados de la cereza (van POR INSTANCIA, no aquí; referencia — la gama
   // real de la foto de cosecha: verde → pintón naranja → rojo cereza → VINO):
@@ -158,14 +174,14 @@ export const PAL = {
 
   // Guamo (Inga) — el parasol del sombrío
   guamoTronco: '#6b533a',
-  guamoCopa: '#4b7c3a',
-  guamoCopaSol: '#699a48',
+  guamoCopa: '#4e8640',
+  guamoCopaSol: '#74ad4d',
   guama: '#82a854', // las vainas verdes colgantes (la firma del Inga)
 
   // Nogal cafetero (Cordia alliodora) — el sombrío alto y recto
   nogalTronco: '#8a8274',
-  nogalCopa: '#527a40',
-  nogalCopaSol: '#6c9450',
+  nogalCopa: '#57874a',
+  nogalCopaSol: '#79a557',
 
   // Plátano intercalado
   platanoTallo: '#a8b06c',
@@ -260,57 +276,176 @@ function variar(base, r, amt = 0.06) {
  * pisos de ramas plagiotrópicas (horizontales, apenas caídas) alrededor del
  * tallo ortotrópico. Se EXPORTA para que las cerezas y las flores se siembren
  * SOBRE la misma rama que la geometría dibuja — el racimo pegado a la rama.
+ *
+ * ⚠️ LA SILUETA ES EL ENTREGABLE. La tabla anterior tenía los largos DECRECIENDO
+ * de abajo hacia arriba (0.56 → 0.50 → 0.42 → 0.32) sobre un tallo de 1.28 y
+ * remataba en punta: eso es un CONO — más alto que ancho y afilado arriba. De
+ * cerca no se notaba (mandaban la hoja y la cereza), pero a media distancia,
+ * cuando el detalle se pierde y solo queda el contorno, la ladera entera se leía
+ * como un BOSQUE DE PINOS. Ese fue el reclamo que sobrevivió.
+ *
+ * El *Coffea arabica* adulto de finca es al revés: 1,5–3 m de alto contra una
+ * copa de 2,5–4,5 m de diámetro — MÁS ANCHO QUE ALTO —, de contorno redondeado,
+ * elíptico e irregular, nunca cónico ni piramidal. Por eso la tabla nueva:
+ *
+ *   · el HOMBRO ANCHO no está abajo del todo sino en el segundo/tercer piso
+ *     (envolvente OVALADA, no triángulo),
+ *   · el remate de arriba es ROMO y corto (la mata no termina en punta),
+ *   · ancho máximo 0.90×2 = 1.80 contra 1.36 de alto → relación 1,3 a favor del
+ *     ancho, que es la proporción que separa un arbusto de una conífera.
  */
 export const PISOS_CAFETO = [
-  { y: 0.34, ramas: 4, len: 0.56, caida: -0.16 }, // el piso bajo, el más ancho
-  { y: 0.6, ramas: 4, len: 0.5, caida: -0.12 },
-  { y: 0.84, ramas: 3, len: 0.42, caida: -0.08 },
-  { y: 1.06, ramas: 3, len: 0.32, caida: -0.05 }, // el piso alto, el más corto
+  { y: 0.30, ramas: 4, len: 0.76, caida: -0.21 }, // el piso bajo, madera vieja
+  { y: 0.57, ramas: 4, len: 0.9, caida: -0.16 }, // EL HOMBRO: el piso más ancho
+  { y: 0.84, ramas: 4, len: 0.84, caida: -0.12 },
+  { y: 1.08, ramas: 3, len: 0.6, caida: -0.08 },
+  { y: 1.28, ramas: 3, len: 0.36, caida: -0.04 }, // el remate ROMO, no una punta
 ];
 
 /** El ángulo de la rama j del piso i (filotaxis simple, determinista). */
 export const anguloRamaCafeto = (piso, j, n) => (j / n) * Math.PI * 2 + piso * 0.55 + 0.35;
 
-/** Cuántos pisos de ramas dibuja (y carga) cada tier. */
-export const pisosCafetoDeQ = (q) => (q < 0.5 ? 2 : q < 0.85 ? 3 : PISOS_CAFETO.length);
+/** Cuántos pisos de ramas dibuja (y carga) cada tier. Aun recortado a 3, la
+    mata conserva el hombro ancho: queda más SQUAT, jamás más cónica. */
+export const pisosCafetoDeQ = (q) => (q < 0.5 ? 3 : q < 0.85 ? 4 : PISOS_CAFETO.length);
 
 /*
- * Porte columnar REAL del arábica: tallo leñoso central, pisos de RAMAS
- * horizontales visibles (la percha donde la distribución cuelga las cerezas),
- * HOJAS elípticas opuestas — grandes, oscuras, lustrosas: la firma del café —
- * y un corazón tupido por piso que da densidad a la silueta. Las CEREZAS y las
- * FLORES no van aquí: son InstancedMesh aparte, sembradas sobre estas ramas.
+ * LOS PORTES — el manejo colombiano hecho silueta.
+ *
+ * Un cafetal real NO es un molde repetido 120 veces: en la misma ladera conviven
+ * matas de un solo tallo, matas ZOQUEADAS (cortadas bajito para que rebroten,
+ * varios ejes desde el tocón) y matas AGOBIADAS (el tallo doblado para forzar
+ * brotación lateral). Cada manejo da una silueta distinta, y esa VARIEDAD entre
+ * individuos es la segunda mitad de por qué una ladera de café no se lee como
+ * plantación de coníferas: los pinos son todos iguales, los cafetos no.
+ *
+ * Cada eje es un tallo: `dx/dz` su sitio en el tocón, `inclina` cuánto se acuesta,
+ * `alto`/`ancho` su escala, `pisos` cuántos pisos alcanza a levantar.
  */
-export function geomCafeto({ q = 1 } = {}, seed = 1) {
-  const r = rng(seed);
-  const partes = [];
+export const PORTES = {
+  /* UN TALLO: el eje ortotrópico único con sus pisos abiertos. La silueta
+     ovalada de referencia — más ancha que alta, hombro a media altura. */
+  tallo: {
+    ejes: [{ dx: 0, dz: 0, azim: 0, inclina: 0, alto: 1, ancho: 1, pisos: 5 }],
+  },
+  /* ZOQUEADO: se cortó el tallo a 30–40 cm y rebrotaron varios. Base ANCHA y
+     tupida, tres copas cortas que se funden, remate romo y bajo. */
+  zoqueo: {
+    ejes: [
+      { dx: -0.13, dz: -0.06, azim: 3.5, inclina: 0.21, alto: 0.82, ancho: 0.88, pisos: 4 },
+      { dx: 0.12, dz: 0.09, azim: 0.6, inclina: 0.18, alto: 0.94, ancho: 0.82, pisos: 4 },
+      { dx: 0.02, dz: -0.15, azim: 4.9, inclina: 0.14, alto: 0.68, ancho: 0.76, pisos: 3 },
+    ],
+  },
+  /* AGOBIADO: el tallo doblado a propósito. Silueta HORIZONTAL, de seto bajo y
+     extendido — la más lejana posible de un cono. */
+  agobio: {
+    ejes: [
+      { dx: -0.17, dz: 0.05, azim: 2.9, inclina: 0.46, alto: 0.76, ancho: 1.18, pisos: 4 },
+      { dx: 0.15, dz: -0.05, azim: 0.2, inclina: 0.15, alto: 0.9, ancho: 1.0, pisos: 4 },
+    ],
+  },
+};
 
-  // El tallo ortotrópico central.
-  const tallo = new THREE.CylinderGeometry(0.028, 0.058, 1.24, 5, 1);
-  poner(tallo, [0, 0.62, 0]);
+/** Los portes en el orden en que se reparte la ladera (y su peso: el de un solo
+    tallo manda, el zoqueo es frecuente, el agobio es el menos común). */
+export const REPARTO_PORTES = /** @type {const} */ ([
+  ['tallo', 0.44],
+  ['zoqueo', 0.34],
+  ['agobio', 0.22],
+]);
+
+/** El porte que le toca a una mata según su azar (determinista aguas arriba). */
+export function porteDeAzar(u) {
+  let acc = 0;
+  for (const [id, peso] of REPARTO_PORTES) {
+    acc += peso;
+    if (u < acc) return id;
+  }
+  return 'tallo';
+}
+
+/**
+ * Un punto de la rama (piso `i`, rama `j`, avance `t`) del eje `e` de un porte,
+ * en coordenadas LOCALES de la mata. Es la MISMA cuenta que hace la malla, así
+ * que la cereza y la flor caen exactamente sobre la rama dibujada — la única
+ * verdad de dónde carga el café.
+ */
+export function puntoEnRama(porteId, ejeIdx, i, j, t) {
+  const porte = PORTES[porteId] || PORTES.tallo;
+  const eje = porte.ejes[ejeIdx % porte.ejes.length];
+  const p = PISOS_CAFETO[i];
+  const a = anguloRamaCafeto(i, j, p.ramas);
+  // en el marco del eje (antes de acostarlo)
+  const lx = Math.cos(a) * p.len * t * eje.ancho;
+  const ly = (p.y + p.caida * p.len * t) * eje.alto;
+  const lz = Math.sin(a) * p.len * t * eje.ancho;
+  // el eje se acuesta `inclina` hacia su azimut `azim`
+  const ca = Math.cos(eje.azim);
+  const sa = Math.sin(eje.azim);
+  const ci = Math.cos(eje.inclina);
+  const si = Math.sin(eje.inclina);
+  // rotar en el plano (dirección azim, vertical)
+  const along = lx * ca + lz * sa; // componente hacia el azimut
+  const cross = -lx * sa + lz * ca; // componente perpendicular
+  const along2 = along * ci + ly * si;
+  const y2 = ly * ci - along * si;
+  return [eje.dx + along2 * ca - cross * sa, y2, eje.dz + along2 * sa + cross * ca];
+}
+
+/*
+ * UN EJE (un tallo) del cafeto, en su marco propio: tallo leñoso, pisos de
+ * RAMAS plagiotrópicas visibles (la percha donde la distribución cuelga las
+ * cerezas), HOJAS elípticas opuestas y — lo que decide la lectura a distancia —
+ * los LÓBULOS del piso.
+ *
+ * Los lóbulos son la clave del reclamo. Antes cada piso llevaba UNA masa
+ * centrada: de lejos eso suma un volumen liso y continuo, que es justamente la
+ * textura de una conífera. Un cafetal visto a 20–50 m se ve GRANULOSO y
+ * ABULTADO: bultos de follaje con huecos entre ellos. Por eso ahora cada piso
+ * lleva DOS O TRES masas achatadas y DESCENTRADAS: el contorno queda escalonado
+ * y mordido, con luz colándose entre piso y piso. Eso es lo que a distancia
+ * dice "arbusto", y no "árbol de navidad".
+ */
+function geomEjeCafeto(eje, q, r) {
+  const partes = [];
+  const nPisos = Math.min(eje.pisos, pisosCafetoDeQ(q));
+  const nudosPorRama = q < 0.85 ? 1 : 2; // pares de hojas por rama según tier
+  const nLobulos = q < 0.85 ? 2 : 3;
+
+  // El tallo ortotrópico, solo hasta donde llegan sus pisos (un eje zoqueado es
+  // corto de verdad: nada de palos asomando sobre el follaje).
+  const alturaTallo = PISOS_CAFETO[nPisos - 1].y + 0.12;
+  const tallo = new THREE.CylinderGeometry(0.03, 0.064, alturaTallo, 5, 1);
+  poner(tallo, [0, alturaTallo * 0.5, 0]);
   partes.push(pintar(tallo, PAL.cafetoTallo));
 
-  const nPisos = pisosCafetoDeQ(q);
-  const nudosPorRama = q < 0.85 ? 1 : 2; // pares de hojas por rama según tier
   for (let i = 0; i < nPisos; i++) {
     const p = PISOS_CAFETO[i];
 
-    // El corazón tupido del piso (la masa oscura tras las hojas).
-    const core = new THREE.IcosahedronGeometry(p.len * 0.5, 0);
-    poner(
-      core,
-      [(r() - 0.5) * 0.06, p.y + 0.04, (r() - 0.5) * 0.06],
-      [0, r() * Math.PI, 0],
-      [1.3, 0.55, 1.3],
-    );
-    partes.push(pintar(core, variar(PAL.cafetoHojaSombra, r, 0.05)));
+    // LOS LÓBULOS del piso: masas achatadas y descentradas que hacen el
+    // contorno abultado e irregular (una centrada + las de afuera).
+    for (let L = 0; L < nLobulos; L++) {
+      const aL = (L / nLobulos) * Math.PI * 2 + i * 0.9 + r() * 0.4;
+      const radL = L === 0 ? 0 : p.len * (0.36 + r() * 0.22);
+      const masa = new THREE.IcosahedronGeometry(p.len * (L === 0 ? 0.44 : 0.3 + r() * 0.12), 0);
+      poner(
+        masa,
+        [Math.cos(aL) * radL, p.y + 0.03 + (r() - 0.5) * 0.06, Math.sin(aL) * radL],
+        [0, r() * Math.PI, 0],
+        [1.25, 0.5, 1.25], // ACHATADAS: el follaje del piso es una tabla, no una bola
+      );
+      partes.push(
+        pintar(masa, variar(L === 0 ? PAL.cafetoHojaSombra : PAL.cafetoHoja, r, 0.07)),
+      );
+    }
 
     for (let j = 0; j < p.ramas; j++) {
       const a = anguloRamaCafeto(i, j, p.ramas);
       const d = new THREE.Vector3(Math.cos(a), p.caida, Math.sin(a)).normalize();
 
       // La rama plagiotrópica visible (donde cargan racimos y hojas).
-      const rama = new THREE.CylinderGeometry(0.011, 0.021, p.len, 4, 1, true);
+      const rama = new THREE.CylinderGeometry(0.011, 0.022, p.len, 4, 1, true);
       apuntar(
         rama,
         [d.x * p.len * 0.5, p.y + d.y * p.len * 0.5, d.z * p.len * 0.5],
@@ -332,21 +467,65 @@ export function geomCafeto({ q = 1 } = {}, seed = 1) {
           hoja,
           [nx + Math.cos(ah) * 0.1, ny - 0.01, nz + Math.sin(ah) * 0.1],
           [0, -ah, lado * 0.16], // tendida, con una caída leve hacia su lado
-          [0.19 + r() * 0.03, 0.028, 0.1 + r() * 0.02],
+          [0.21 + r() * 0.04, 0.028, 0.11 + r() * 0.02],
         );
         partes.push(
-          pintar(hoja, variar((i + k) % 2 ? PAL.cafetoHojaSol : PAL.cafetoHoja, r, 0.05)),
+          pintar(hoja, variar((i + k) % 2 ? PAL.cafetoHojaSol : PAL.cafetoHoja, r, 0.06)),
         );
       }
     }
   }
 
-  // El cogollo tierno de la punta.
-  const brote = new THREE.IcosahedronGeometry(0.1, 0);
-  poner(brote, [0, 1.28, 0], [0, r() * Math.PI, 0], [1, 0.8, 1]);
-  partes.push(pintar(brote, PAL.cafetoBrote));
+  // EL REMATE: cogollos tiernos ACHATADOS repartidos en la corona. Antes era una
+  // sola mota centrada sobre el eje — una PUNTA, el remate de un pino. La mata
+  // de café no termina en punta: termina en una corona despeinada de brotes.
+  const nBrotes = q < 0.85 ? 2 : 3;
+  for (let b = 0; b < nBrotes; b++) {
+    const ab = (b / nBrotes) * Math.PI * 2 + 0.6;
+    const rb = b === 0 ? 0 : 0.1 + r() * 0.07;
+    const brote = new THREE.IcosahedronGeometry(0.085 + r() * 0.03, 0);
+    poner(
+      brote,
+      [Math.cos(ab) * rb, alturaTallo + (r() - 0.5) * 0.05, Math.sin(ab) * rb],
+      [0, r() * Math.PI, 0],
+      [1.4, 0.62, 1.4],
+    );
+    partes.push(pintar(brote, variar(PAL.cafetoBrote, r, 0.07)));
+  }
 
   return fusionar(partes);
+}
+
+/*
+ * EL CAFETO completo, según su PORTE (manejo). Monta uno o varios ejes y los
+ * acuesta/escala en su sitio del tocón — la MISMA cuenta que hace `puntoEnRama`,
+ * así que la cereza cae sobre la rama que aquí se dibuja.
+ *
+ * La silueta que sale de aquí es MÁS ANCHA QUE ALTA y de contorno mordido: es
+ * la diferencia entre una ladera que se lee "cafetal" y una que se lee "pinar".
+ */
+export function geomCafeto({ q = 1, porte = 'tallo' } = {}, seed = 1) {
+  const r = rng(seed);
+  const def = PORTES[porte] || PORTES.tallo;
+  const partes = [];
+
+  def.ejes.forEach((eje) => {
+    const g = geomEjeCafeto(eje, q, r);
+    // escala (ancho/alto) → acostar `inclina` hacia `azim` → sitio en el tocón.
+    const q4 = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(Math.sin(eje.azim), 0, -Math.cos(eje.azim)),
+      eje.inclina,
+    );
+    const m = new THREE.Matrix4().compose(
+      new THREE.Vector3(eje.dx, 0, eje.dz),
+      q4,
+      new THREE.Vector3(eje.ancho, eje.alto, eje.ancho),
+    );
+    g.applyMatrix4(m);
+    partes.push(g);
+  });
+
+  return partes.length === 1 ? partes[0] : fusionar(partes);
 }
 
 /** La cereza del café: OVOIDE (como en la rama real), pintada blanca — el
@@ -553,8 +732,15 @@ export function geomPiedra(seed = 6) {
    va). El ORDEN importa: se recortan por tier con slice, así que las primeras
    posiciones reparten frente y fondo para que hasta 'medio' y 'bajo' lean
    "cafetal bajo sombra", nunca hileras desnudas. */
+/* ⚠️ El segundo sitio ERA [3.2, 2.4] — justo sobre la línea de entrada. Su copa
+   le quedaba a UN METRO del ojo en el encuadre de vitrina y a 8,5 m en el de
+   pantalla completa: no enmarcaba, TAPABA (el reclamo "la cámara está metida
+   entre las copas y la de arriba a la izquierda corta la vista"). Se corre al
+   frente-derecha, fuera del cono de la cámara, donde SIGUE dando sombra a los
+   surcos del frente — que era para lo que estaba: café sin sombrío parece
+   potrero. Verificable: `node scripts/diag/encuadre-mundo.mjs cafe`. */
 const SITIOS_GUAMO = [
-  [-8.5, -5.5], [3.2, 2.4], [6.5, -6.0], [-6.8, 1.6], [-1.5, -8.5],
+  [-8.5, -5.5], [8.8, 4.4], [6.5, -6.0], [-6.8, 1.6], [-1.5, -8.5],
   [11.0, -2.5], [14.2, 1.2], [-12.5, -10.0], [-4.5, -2.0], [2.5, -12.5],
 ];
 const SITIOS_NOGAL = [
@@ -582,10 +768,20 @@ export const SITIO_CAFETO_HERO = /** @type {[number, number]} */ ([-2.8, 5.6]);
  * Mira loma arriba desde el camino de llegada — entrar es subir.
  */
 export const CAMARA = {
-  reposo: /** @type {[number, number, number]} */ ([7.15, 6.5, 13]),
-  mirada: /** @type {[number, number, number]} */ ([0, 3.96, -2]),
-  fov: 42,
+  reposo: /** @type {[number, number, number]} */ ([7.6, 7.8, 15.6]),
+  mirada: /** @type {[number, number, number]} */ ([-0.4, 3.8, -3.4]),
+  fov: 40,
 };
+
+/* El `centro` que EscenaBase3D necesita para que su mirada caiga en CAMARA.mirada
+   (la base le suma `zoom * 0.12` a la altura del centro: tilt-down de revelado).
+   Se deriva aquí para que las dos cuentas no puedan separarse. */
+export const ZOOM_LADERA = 13;
+export const CENTRO_LADERA = /** @type {[number, number, number]} */ ([
+  CAMARA.mirada[0],
+  CAMARA.mirada[1] - ZOOM_LADERA * 0.12,
+  CAMARA.mirada[2],
+]);
 
 /*
  * El LOTE SEMBRADO: dónde el piso lleva cafetal encima. Lo usa el diagnóstico
@@ -616,9 +812,9 @@ export function dentroLote(wx, wz) {
  * en los surcos del fondo — la maduración despareja real de la ladera.
  */
 export const SITIOS_HERO = [
-  { px: -2.8, pz: 5.6, esc: 1.6, rotY: 2.2, maduro: 0.85, carga: 1, hero: true },
-  { px: 4.2, pz: 4.6, esc: 1.35, rotY: 0.7, maduro: 0.7, carga: 1, hero: true },
-  { px: -5.0, pz: 3.2, esc: 1.25, rotY: 4.1, maduro: 0.75, carga: 1, hero: true },
+  { px: -2.8, pz: 5.6, esc: 1.6, rotY: 2.2, maduro: 0.85, carga: 1, hero: true, porte: 'tallo' },
+  { px: 4.2, pz: 4.6, esc: 1.35, rotY: 0.7, maduro: 0.7, carga: 1, hero: true, porte: 'zoqueo' },
+  { px: -5.0, pz: 3.2, esc: 1.25, rotY: 4.1, maduro: 0.75, carga: 1, hero: true, porte: 'agobio' },
 ];
 
 /** ¿Qué tan maduro está el café en esta franja? Abajo (más caliente) más rojo. */
@@ -661,6 +857,10 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
         rotY: rCaf() * Math.PI * 2,
         maduro: madurezEn(pz, rCaf),
         carga: rCaf(), // qué tan cargada de fruto está la mata
+        // el MANEJO de esta mata (un tallo / zoqueada / agobiada): la variedad
+        // de siluetas entre vecinas es lo que impide que la ladera se lea como
+        // plantación de coníferas — los pinos son clones, los cafetos no.
+        porte: porteDeAzar(rCaf()),
       });
     }
   });
@@ -679,12 +879,20 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
   // tres y son la lección — hasta 'bajo' tiene que leer "eso es un cafeto").
   matas.push(...SITIOS_HERO);
 
-  const cafeto = matas.map((s) => ({
-    pos: [s.px, alturaLadera(s.px, s.pz), s.pz],
-    rotY: s.rotY,
-    escala: s.esc,
-    tint: [0.92 + rCaf() * 0.16, 0.92 + rCaf() * 0.16, 0.92 + rCaf() * 0.16],
-  }));
+  /* Los cafetos salen AGRUPADOS POR PORTE: cada manejo es su propia malla y su
+     propio InstancedMesh (tres draw-calls en vez de una, a cambio de que la
+     ladera deje de ser un molde repetido 120 veces). El tinte por instancia
+     suma la última pizca de variación individual. */
+  const cafeto = { tallo: [], zoqueo: [], agobio: [] };
+  matas.forEach((s) => {
+    const banco = cafeto[s.porte] || cafeto.tallo;
+    banco.push({
+      pos: [s.px, alturaLadera(s.px, s.pz), s.pz],
+      rotY: s.rotY,
+      escala: s.esc,
+      tint: [0.9 + rCaf() * 0.2, 0.9 + rCaf() * 0.2, 0.9 + rCaf() * 0.2],
+    });
+  });
 
   // --- Las cerezas: RACIMOS EN FILA sobre la MISMA rama que la geometría
   //     dibuja (PISOS_CAFETO + anguloRamaCafeto) — el café carga pegado a la
@@ -708,14 +916,16 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
     ...SITIOS_HERO,
     ...matas.filter((s) => s.carga > 0.3 && !s.hero),
   ];
-  /* Un punto local de la rama (piso i, rama j, avance t) llevado al mundo:
-     escala de la mata + su giro + su sitio en la ladera. */
-  const enRama = (s, i, j, t, dy, jit, rr) => {
-    const p = PISOS_CAFETO[i];
-    const a = anguloRamaCafeto(i, j, p.ramas);
-    const lx = Math.cos(a) * p.len * t + (rr() - 0.5) * jit;
-    const ly = p.y + p.caida * p.len * t + dy + (rr() - 0.5) * jit * 0.6;
-    const lz = Math.sin(a) * p.len * t + (rr() - 0.5) * jit;
+  /* Un punto local de la rama (eje e, piso i, rama j, avance t) llevado al
+     mundo: `puntoEnRama` hace la MISMA cuenta que la malla — incluido el eje
+     acostado del zoqueo y del agobio —, y aquí solo se le suma la escala de la
+     mata, su giro y su sitio en la ladera. Una sola verdad de dónde carga el
+     café: si la rama se mueve, la cereza se mueve con ella. */
+  const enRama = (s, e, i, j, t, dy, jit, rr) => {
+    const [lx0, ly0, lz0] = puntoEnRama(s.porte || 'tallo', e, i, j, t);
+    const lx = lx0 + (rr() - 0.5) * jit;
+    const ly = ly0 + dy + (rr() - 0.5) * jit * 0.6;
+    const lz = lz0 + (rr() - 0.5) * jit;
     const cosR = Math.cos(s.rotY);
     const sinR = Math.sin(s.rotY);
     return [
@@ -724,13 +934,25 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
       s.pz + (-lx * sinR + lz * cosR) * s.esc,
     ];
   };
+  /* Cuántos ejes tiene el porte de esta mata (para repartirle la carga). */
+  const ejesDe = (s) => (PORTES[s.porte || 'tallo'] || PORTES.tallo).ejes.length;
+  /* Y hasta qué piso llega ESE eje: la cereza nunca puede colgar de un piso que
+     el eje no levantó (un zoqueo corto no carga arriba). */
+  const pisosDe = (s, e) => {
+    const porte = PORTES[s.porte || 'tallo'] || PORTES.tallo;
+    const eje = porte.ejes[e % porte.ejes.length];
+    return Math.min(eje.pisos, nPisos);
+  };
   let gi = 0;
   while (cereza.length < c.cereza && cargadas.length > 0) {
     const s = cargadas[gi % cargadas.length];
     gi += 1;
     if (gi > cargadas.length * 12) break;
+    // un eje al azar de la mata (en zoqueo y agobio la carga se reparte entre
+    // los tallos, como en la mata de verdad)
+    const e = Math.floor(rCer() * ejesDe(s));
     // los pisos BAJOS cargan más (madera más vieja, más cosecha)
-    const i = Math.floor(rCer() * Math.min(nPisos, 3));
+    const i = Math.floor(rCer() * Math.min(pisosDe(s, e), 3));
     const p = PISOS_CAFETO[i];
     const j = Math.floor(rCer() * p.ramas);
     const cuantas = 3 + Math.floor(rCer() * 4) + (s.hero ? 2 : 0);
@@ -745,7 +967,7 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
       else col.lerpColors(roja, vino, (m - 0.68) / 0.32);
       col.multiplyScalar(0.94 + rCer() * 0.12);
       cereza.push({
-        pos: enRama(s, i, j, t, -0.045, 0.035, rCer), // colgada APENAS bajo la rama
+        pos: enRama(s, e, i, j, t, -0.045, 0.035, rCer), // colgada APENAS bajo la rama
         rotY: rCer() * Math.PI,
         // en el héroe la cuenta es un pelín más gorda: legible desde la entrada
         escala: (0.8 + rCer() * 0.45) * (s.hero ? 1.3 : 1),
@@ -764,12 +986,13 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
     const s = florecidas[fi % florecidas.length];
     fi += 1;
     if (fi > florecidas.length * 6) break;
-    const i = Math.floor(rFlo() * nPisos);
+    const e = Math.floor(rFlo() * ejesDe(s));
+    const i = Math.floor(rFlo() * pisosDe(s, e));
     const p = PISOS_CAFETO[i];
     const j = Math.floor(rFlo() * p.ramas);
     const t = 0.28 + rFlo() * 0.5;
     flor.push({
-      pos: enRama(s, i, j, t, 0.025, 0.02, rFlo), // asomada SOBRE la rama
+      pos: enRama(s, e, i, j, t, 0.025, 0.02, rFlo), // asomada SOBRE la rama
       rotY: rFlo() * Math.PI * 2,
       escala: 0.85 + rFlo() * 0.4,
       tint: [1, 0.99 - rFlo() * 0.03, 0.95 - rFlo() * 0.04],
@@ -825,4 +1048,33 @@ export function centrosSombrio(conteos) {
     ...SITIOS_GUAMO.slice(0, conteos.guamo),
     ...SITIOS_NOGAL.slice(0, conteos.nogal),
   ].map(([x, z]) => /** @type {[number, number, number]} */ ([x, alturaLadera(x, z), z]));
+}
+
+/*
+ * LAS COPAS DEL SOMBRÍO como esferas, para saber CUÁL TAPA LA VISTA.
+ *
+ * Esto existe por una mordida concreta: el diagnóstico de encuadre marchaba
+ * rayos contra el terreno más un dosel uniforme y daba "sin avisos" mientras la
+ * copa de un guamo se le sentaba encima a la cámara y cortaba media vista. El
+ * trazador medía bien la geometría del suelo y era CIEGO al sombrío — y medir
+ * la geometría no es ver la escena.
+ *
+ * Una copa NO es una columna desde el suelo: es una TAPA a cierta altura, y por
+ * debajo se ve (ese es el punto del café de sombra). Por eso van como esferas
+ * en el aire y no como relieve del terreno.
+ */
+export function copasSombrio(conteos = FLORA_CAFETAL.alto) {
+  const copas = [];
+  SITIOS_GUAMO.slice(0, conteos.guamo).forEach(([x, z]) => {
+    // el parasol del Inga: ancho y plano, a unos 3,6 m sobre su sitio
+    copas.push({ c: [x, alturaLadera(x, z) + 3.7, z], r: 3.0, quien: 'guamo' });
+  });
+  SITIOS_NOGAL.slice(0, conteos.nogal).forEach(([x, z]) => {
+    // el nogal: copa recogida y ALTA (por eso estorba menos)
+    copas.push({ c: [x, alturaLadera(x, z) + 4.8, z], r: 1.7, quien: 'nogal' });
+  });
+  SITIOS_PLATANO.slice(0, conteos.platano).forEach(([x, z]) => {
+    copas.push({ c: [x, alturaLadera(x, z) + 2.1, z], r: 1.3, quien: 'plátano' });
+  });
+  return copas;
 }

--- a/src/visual/mundo3d/camaraDioramas.js
+++ b/src/visual/mundo3d/camaraDioramas.js
@@ -73,13 +73,24 @@ export const ENCUADRES = Object.freeze({
     beat: { retiro: 1.55, arcoY: -0.16, grua: 0.14, lente: 1.12, lambda: 1.6 },
   },
 
-  /* CAFÉ — caminar el cafetal: cámara baja, a la altura del grano, lente
-     tele íntimo. El arco lateral es el más marcado: entrar ENTRE surcos. */
+  /* CAFÉ — la LADERA cafetera desde el camino de llegada: se entra subiendo.
+     ⚠️ Este encuadre ERA [3.1, 1.9, 5.4] / fov 36 — "cámara baja, a la altura
+     del grano". La intención era buena y el resultado, medible y malo: la
+     cámara quedaba DENTRO del cafetal, con la copa de un guamo a UN METRO del
+     ojo, 0,5% de cielo (cuadro tapiado), el tercio alto 32,8% contra el 0,6%
+     del papal —o sea mirando de frente contra la loma— y el cafeto
+     protagonista FUERA DE CUADRO. Es el reclamo "la cámara está tan metida
+     entre las copas que la de arriba a la izquierda corta la vista".
+     Ahora se retira y se levanta: el ojo pasa POR DEBAJO del techo de sombra
+     en vez de entre las copas, la ladera se lee entera con sus surcos a curva
+     de nivel y el cafeto protagonista entra en cuadro.
+     Verificable: `node scripts/diag/encuadre-mundo.mjs cafe --pos 4.2,6.2,13.2
+     --mira -1.4,3,-2.5 --fov 40`. */
   cafe: {
-    posicion: [3.1, 1.9, 5.4],
-    target: [-0.2, 1.05, 0],
-    fov: 36,
-    beat: { retiro: 1.45, arcoY: 0.22, grua: 0.05, lente: 1.1, lambda: 2.0 },
+    posicion: [4.2, 6.2, 13.2],
+    target: [-1.4, 3.0, -2.5],
+    fov: 40,
+    beat: { retiro: 1.35, arcoY: 0.18, grua: 0.1, lente: 1.1, lambda: 2.0 },
   },
 
   /* SANIDAD — mirada de inspección: frontal elevada, sobria, sin arco casi.

--- a/src/visual/mundo3d/escenas/EscenaCafe.jsx
+++ b/src/visual/mundo3d/escenas/EscenaCafe.jsx
@@ -1,261 +1,270 @@
 /*
- * EscenaCafe — ARQUETIPO `cafe`: el CAFETAL BAJO SOMBRA de la ladera andina.
+ * EscenaCafe — ARQUETIPO `cafe`: la LADERA CAFETERA BAJO SOMBRA, entera.
  *
- * De la familia del `recinto` (un lugar que se camina), pero su lección es el
- * CULTIVO BANDERA hecho espacio: el café no crece solo ni a pleno rayo — vive
- * ABAJO, bajo el techo de árboles altos que lo cuidan. El diorama enseña lo que
- * de verdad es una finca cafetera del país:
+ * SEGUNDA TOMA del mundo del café. La primera era un diorama de mesa (un
+ * círculo de 2 m con esferas verdes): pobre al lado del valle, con la entrada
+ * amontonada y un café que podía ser cualquier arbusto. Esta toma monta EL
+ * MUNDO que ya existía en `cafetal/` (la ladera de 38×36 m con su geografía
+ * determinista) dentro del contrato del arquetipo — atmósfera de la franja,
+ * hotspots-puerta, Angelita, cámara de director — y responde reclamo por
+ * reclamo:
  *
- *   · la SOMBRA arriba — el guamo (Inga) y el nogal cafetero que le hacen techo
- *     al cultivo: menos sol quemante, más humedad, hoja que cae y abona, y monte
- *     donde vuelven las aves (café de sombra = café con vida, no potrero de sol);
- *   · los CAFETOS abajo — los arbustos cargados de CEREZA roja madura (el fruto);
- *   · el GRANO en sus tres estados, SIN tostar en la finca — cereza (el fruto
- *     rojo) → pergamino (el grano seco en su cascarilla) → oro (el grano verde
- *     ya trillado, listo para vender); el tueste es del otro lado, no del campo;
- *   · la ROYA (Hemileia vastatrix, el polvillo naranja bajo la hoja) y la BROCA
- *     (Hypothenemus hampei, el gorgojo que perfora la cereza) — señaladas sin
- *     drama, porque se manejan con criterio, no con recetas de veneno;
- *   · el BENEFICIO en el rincón — despulpar, fermentar en el tanque y secar al
- *     sol en el paseo/parabólico: el paso del fruto al grano vendible.
+ *   · RIQUEZA (la vara del valle): ladera real en heightfield pintado (arvenses,
+ *     tierra roja andina, mantillo), los TRES ESTRATOS del café de sombra
+ *     (cafetos abajo, plátano intercalado en medio, guamos y nogales haciendo
+ *     techo), montañas del fondo comidas por la niebla de la hora, velos de
+ *     bruma entre planos, la luz colada bajo las copas (gama alta) y la casa
+ *     con su beneficiadero coronando la loma.
+ *   · ENTRADA CON AIRE: un solo punto focal — el CAFETO PROTAGONISTA cargado de
+ *     cereza junto al camino de llegada — y las demás puertas repartidas EN
+ *     PROFUNDIDAD ladera arriba (sombrío → roya → trampa → beneficio): el ojo
+ *     sube con el terreno en vez de tropezar con un montón.
+ *   · EL CAFÉ SE LEE COMO CAFÉ: la mata protagonista trae la anatomía real del
+ *     arábica (geomCafeto): porte columnar, PISOS de ramas plagiotrópicas, hoja
+ *     elíptica oscura lustrosa y el racimo de CEREZA PEGADO A LA RAMA en
+ *     cuentas apretadas — verde, pintón, rojo y vino conviviendo, porque la
+ *     maduración despareja es la verdad del arábica (por eso se cosecha a mano
+ *     en pases). La roya es una mata señalada con su polvillo naranja bajo la
+ *     hoja; la broca, su trampa artesanal roja junto al surco. Señal, no drama.
  *
- * Todo `MeshLambert`/`Basic`, sin sombras (contrato de EscenaBase3D). Geometría
- * de primitivas: cero GLTF, offline y liviano.
+ * Comparte geografía y flora con EscenaCafetalVivo (floraCafetal.geom): una
+ * sola verdad del cafetal, dos tomas. Todo primitivas Lambert sin sombras
+ * (contrato de EscenaBase3D), una draw-call por especie (InstancedMesh).
  */
-import { useMemo } from 'react';
+import { useLayoutEffect, useMemo } from 'react';
+import * as THREE from 'three';
 import EscenaBase3D from './EscenaBase3D.jsx';
 import { Fauna } from './FaunaEscena.jsx';
-import { CIELOS, PALETA } from '../atmosferaMadre.js';
+import { CIELOS, PALETA, mezclarCielo, mezclar } from '../atmosferaMadre.js';
+import useCicloDia from '../useCicloDia.js';
+import { presetDeHora } from '../cielosHoraData.js';
+import { perfilDeTier } from '../deviceTier.js';
+import FloraCafetal from '../cafetal/FloraCafetal.jsx';
+import CasaBeneficio from '../cafetal/CasaBeneficio.jsx';
+import {
+  alturaLadera,
+  construirLadera,
+  calidadCafetal,
+  geomCafeto,
+  SITIO_CASA,
+  PAL,
+} from '../cafetal/floraCafetal.geom.js';
+import { VERDES, NIEBLAS } from '../paleta/index.js';
 
-/* La fauna que delata el CAFÉ DE SOMBRA: bajo el techo de guamo vuelven las
-   aves y las mariposas (el café a pleno sol las espanta). Pocas y por criterio
-   ecológico (contrato del DR: vida, no enjambre) — la sombra ES el hábitat. */
+/* La identidad atmosférica del piso templado: la familia del corral y el
+   cafetal ("tarde de finca"), mezclada 60% hacia la franja REAL del día. */
+const CIELO_CAFE = CIELOS.corral;
+
+/* El encuadre por defecto de la ladera (el registro puede pisarlo): la cámara
+   llega desde abajo del camino y mira loma arriba — entrar es subir. */
+const ENTRADA_LADERA = { zoom: 13, centro: /** @type {[number,number,number]} */ ([0, 2.4, -2]) };
+
+/* La fauna que delata el café DE SOMBRA: colibríes y mariposas que el café a
+   pleno sol espanta. Pocas y por criterio (la sombra ES el hábitat); alturas
+   horneadas sobre el terreno real. Orden = prominencia (recorte por tier). */
 const FAUNA_CAFE = [
-  { tipo: 'colibri', base: [-1.15, 1.45, 0.35], patron: 'revoloteo', size: 30, fase: 0.5 },
-  { tipo: 'mariposa', base: [0.9, 0.82, 0.7], patron: 'revoloteo', size: 26, fase: 1.8 },
-  { tipo: 'colibri', base: [1.25, 1.55, -0.5], patron: 'revoloteo', size: 26, fase: 2.6 },
+  { tipo: 'colibri', base: [-2.2, 1.9, 5.0], patron: 'revoloteo', size: 30, fase: 0.5, df: 10 },
+  { tipo: 'mariposa', base: [1.8, 1.5, 6.4], patron: 'revoloteo', size: 26, fase: 1.8, df: 9 },
+  { tipo: 'colibri', base: [3.4, 3.5, 2.0], patron: 'revoloteo', size: 26, fase: 2.6, df: 10 },
+  { tipo: 'mariposa', base: [-6.5, 3.3, -4.0], patron: 'revoloteo', size: 22, fase: 3.4, df: 9 },
 ];
 
-/* Un ÁRBOL DE SOMBRA (guamo/nogal cafetero): tronco alto de madera + copa ancha
-   y aireada en varias esferas. Le hace TECHO al cafetal — es lo primero que se
-   lee "el café vive debajo". */
-function ArbolSombra({ pos, color = '#3f6b39', alto = 2.1 }) {
-  const copa = [
-    [0, alto, 0, 0.72], [0.5, alto - 0.22, 0.1, 0.5], [-0.46, alto - 0.18, -0.08, 0.52],
-    [0.12, alto + 0.34, -0.3, 0.46], [-0.2, alto + 0.28, 0.32, 0.42],
-  ];
+/* Los VELOS de bruma entre planos (la lección de la sierra): tres láminas
+   lechosas que separan primer plano, ladera media y la loma de la casa — la
+   profundidad se lee aunque la niebla del fog aún no muerda. Estáticos,
+   aditivo-suaves, baratísimos; fuera del perfil mínimo. */
+const VELOS = [
+  { pos: [0, 4.0, -10.5], tam: [34, 2.6], op: 0.14 },
+  { pos: [-6, 5.2, -14.5], tam: [26, 3.0], op: 0.11 },
+  { pos: [8, 6.6, -15.8], tam: [16, 2.4], op: 0.16 }, // el que vela la casa
+];
+
+/* EL GRANO EN SUS TRES ESTADOS — cereza → pergamino → oro, NUNCA tostado en la
+   finca — como tres bandejas de muestra en el patio del beneficiadero (donde
+   ese paso ocurre de verdad, no regado por la entrada). */
+const ESTADOS_GRANO = [
+  { color: PAL.cerezaRoja, label: 'cereza' },
+  { color: '#d4c199', label: 'pergamino' },
+  { color: '#9fae5a', label: 'oro' },
+];
+
+function MesaGrano({ pos }) {
   return (
-    <group position={pos}>
-      {/* el tronco alto */}
-      <mesh position={[0, alto * 0.5, 0]}>
-        <cylinderGeometry args={[0.09, 0.14, alto, 6]} />
-        <meshLambertMaterial color={PALETA.madera} flatShading />
-      </mesh>
-      {/* la copa ancha y aireada que da la sombra */}
-      {copa.map(([x, y, z, r], i) => (
-        <mesh key={i} position={[x, y, z]}>
-          <sphereGeometry args={[r, 9, 7]} />
-          <meshLambertMaterial color={i % 2 ? PALETA.follajeOscuro : color} flatShading />
-        </mesh>
+    <group position={pos} rotation={[0, 0.4, 0]}>
+      {ESTADOS_GRANO.map((g, i) => (
+        <group key={g.label} position={[(i - 1) * 0.62, 0, i === 1 ? -0.18 : 0]}>
+          {/* la bandeja/zaranda de madera clara */}
+          <mesh position={[0, 0.05, 0]}>
+            <cylinderGeometry args={[0.22, 0.22, 0.06, 12]} />
+            <meshLambertMaterial color={PALETA.maderaClara} flatShading />
+          </mesh>
+          {/* el montón de grano de este estado */}
+          <mesh position={[0, 0.09, 0]}>
+            <sphereGeometry args={[0.17, 12, 6, 0, Math.PI * 2, 0, Math.PI / 2]} />
+            <meshLambertMaterial color={g.color} flatShading />
+          </mesh>
+        </group>
       ))}
     </group>
   );
 }
 
-/* Un CAFETO: arbusto cargado. Tallo + follaje verde firme + CEREZAS rojas (el
-   fruto maduro que se cosecha grano a grano). `roya` le pinta la mancha naranja
-   del polvillo bajo una hoja (Hemileia vastatrix) — la señal, sin alarma. */
-function Cafeto({ pos, color = '#3f6f3a', cerezas = 5, roya = false }) {
-  const hojas = [
-    [0, 0.56, 0, 0.2], [0.16, 0.44, 0.06, 0.15], [-0.15, 0.46, -0.06, 0.15],
-    [0.05, 0.66, -0.12, 0.14],
-  ];
-  // Las cerezas maduras repartidas por el follaje (deterministas por índice).
-  const frutos = useMemo(() => {
-    return Array.from({ length: cerezas }, (_, i) => {
-      const a = (i / cerezas) * Math.PI * 2 + 0.4;
-      const r = 0.18 + (i % 2) * 0.05;
-      return /** @type {[number, number, number]} */ ([
-        Math.cos(a) * r, 0.42 + (i % 3) * 0.09, Math.sin(a) * r,
-      ]);
-    });
-  }, [cerezas]);
+/* La MATA CON ROYA: un cafeto del surco señalado con el polvillo naranja de
+   Hemileia vastatrix BAJO la hoja de los pisos bajos (donde de verdad arranca).
+   Señal legible sin alarma; la puerta `roya` flota encima. */
+const MOTAS_ROYA = [
+  [0.3, 0.3, 0.12], [-0.22, 0.28, 0.25], [0.05, 0.5, -0.3], [-0.3, 0.44, -0.1], [0.18, 0.6, 0.2],
+];
+
+function MataConRoya({ pos, geo, mat }) {
   return (
-    <group position={pos}>
-      <mesh position={[0, 0.26, 0]}>
-        <cylinderGeometry args={[0.035, 0.06, 0.52, 5]} />
-        <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
-      </mesh>
-      {hojas.map(([x, y, z, r], i) => (
-        <mesh key={i} position={[x, y, z]}>
-          <sphereGeometry args={[r, 8, 7]} />
-          <meshLambertMaterial color={color} flatShading />
-        </mesh>
-      ))}
-      {/* las cerezas rojas: el fruto que se recoge maduro */}
-      {frutos.map((p, i) => (
-        <mesh key={i} position={p}>
-          <sphereGeometry args={[0.035, 7, 6]} />
-          <meshLambertMaterial color="#b8342a" flatShading />
-        </mesh>
-      ))}
-      {/* la roya: la mancha naranja del polvillo bajo la hoja (señal, no drama) */}
-      {roya && (
-        <mesh position={[0.16, 0.4, 0.16]}>
-          <sphereGeometry args={[0.06, 8, 6]} />
+    <group position={pos} scale={1.15}>
+      <mesh geometry={geo} material={mat} />
+      {MOTAS_ROYA.map((p, i) => (
+        <mesh key={i} position={p} scale={[1, 0.5, 1]}>
+          <icosahedronGeometry args={[0.05, 0]} />
           <meshLambertMaterial color={PALETA.ambar} flatShading />
         </mesh>
-      )}
+      ))}
     </group>
   );
 }
 
-/* Un ESTADO DEL GRANO en una bandeja: el paso cereza → pergamino → oro (NUNCA
-   tostado en la finca). Tabla baja + montón de grano del color de su estado. */
-function GranoEstado({ pos, color = '#b8342a' }) {
+/* La TRAMPA DE BROCA artesanal: la botella roja con su gorro, colgada de una
+   estaca junto al surco — el manejo sin veneno hecho objeto (etanol que llama
+   al gorgojo, cosecha bien recogida y hongos de biocontrol hacen el resto). */
+function TrampaBroca({ pos }) {
   return (
     <group position={pos}>
-      {/* la bandeja/zaranda de madera clara */}
-      <mesh position={[0, 0.05, 0]}>
-        <cylinderGeometry args={[0.17, 0.17, 0.05, 12]} />
-        <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-      </mesh>
-      {/* el montón de grano de este estado */}
-      <mesh position={[0, 0.085, 0]}>
-        <sphereGeometry args={[0.13, 12, 6, 0, Math.PI * 2, 0, Math.PI / 2]} />
-        <meshLambertMaterial color={color} flatShading />
-      </mesh>
-    </group>
-  );
-}
-
-/* El BENEFICIO en su rincón: la DESPULPADORA (tolva + cuerpo con manija), el
-   TANQUE DE FERMENTACIÓN (recipiente abierto con el agua del mucílago) y el
-   SECADERO (paseo/parabólico: cama elevada con la capa de grano al sol). El paso
-   del fruto rojo al grano vendible, sin química. */
-function Beneficio({ pos }) {
-  return (
-    <group position={pos}>
-      {/* la despulpadora: cuerpo + tolva + manija */}
-      <mesh position={[0, 0.28, 0]}>
-        <boxGeometry args={[0.34, 0.4, 0.28]} />
-        <meshLambertMaterial color={PALETA.lamina} flatShading />
-      </mesh>
-      <mesh position={[0, 0.54, 0]} rotation={[0, 0, Math.PI]}>
-        <cylinderGeometry args={[0.05, 0.19, 0.2, 4]} />
-        <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-      </mesh>
-      <mesh position={[0.24, 0.3, 0]} rotation={[Math.PI / 2, 0, 0]}>
-        <cylinderGeometry args={[0.02, 0.02, 0.16, 6]} />
+      <mesh position={[0, 0.45, 0]}>
+        <cylinderGeometry args={[0.025, 0.035, 0.9, 5]} />
         <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
       </mesh>
-
-      {/* el tanque de fermentación: recipiente abierto con agua del mucílago */}
-      <mesh position={[0.62, 0.18, 0.2]}>
-        <cylinderGeometry args={[0.19, 0.16, 0.36, 12]} />
-        <meshLambertMaterial color={PALETA.concreto} flatShading />
+      <mesh position={[0, 0.78, 0]}>
+        <cylinderGeometry args={[0.09, 0.075, 0.24, 8]} />
+        <meshLambertMaterial color={PAL.cerezaRoja} flatShading />
       </mesh>
-      <mesh position={[0.62, 0.31, 0.2]}>
-        <cylinderGeometry args={[0.165, 0.165, 0.04, 12]} />
-        <meshLambertMaterial color={PALETA.agua} flatShading />
+      <mesh position={[0, 0.94, 0]}>
+        <cylinderGeometry args={[0.11, 0.11, 0.05, 8]} />
+        <meshLambertMaterial color={PALETA.maderaOscura} flatShading />
       </mesh>
-
-      {/* el secadero (paseo/parabólico): cama elevada con la capa de grano al sol */}
-      <group position={[0.3, 0, 0.72]}>
-        {[[-0.28, 0.16, -0.16], [0.28, 0.16, -0.16], [-0.28, 0.16, 0.16], [0.28, 0.16, 0.16]].map((p, i) => (
-          <mesh key={i} position={/** @type {[number, number, number]} */ (p)}>
-            <cylinderGeometry args={[0.02, 0.02, 0.32, 5]} />
-            <meshLambertMaterial color={PALETA.madera} flatShading />
-          </mesh>
-        ))}
-        <mesh position={[0, 0.33, 0]}>
-          <boxGeometry args={[0.66, 0.03, 0.44]} />
-          <meshLambertMaterial color={PALETA.maderaClara} flatShading />
-        </mesh>
-        {/* la capa de grano en pergamino secándose */}
-        <mesh position={[0, 0.36, 0]}>
-          <boxGeometry args={[0.6, 0.03, 0.38]} />
-          <meshLambertMaterial color="#d4c199" flatShading />
-        </mesh>
-      </group>
     </group>
   );
 }
 
-function Diorama({ params, reducedMotion }) {
-  const cafetos = params?.cafetos || [
-    { color: '#3f6f3a', pos: [-0.55, 0, 0.42], cerezas: 6 },
-    { color: '#468637', pos: [0.5, 0, 0.12], cerezas: 5 },
-    { color: '#3f6f3a', pos: [0.02, 0, -0.5], cerezas: 4, roya: true },
-    { color: '#457d38', pos: [-0.78, 0, -0.32], cerezas: 5 },
-  ];
-  const sombra = params?.sombra || [
-    { pos: [-1.65, 0, -0.95], color: '#4b7a3a', alto: 2.2 }, // guamo
-    { pos: [1.7, 0, -0.8], color: '#3f6b39', alto: 2.0 },    // nogal cafetero
-  ];
-  // El grano en sus tres estados (cereza→pergamino→oro), SIN tostar en finca.
-  const granos = params?.granos || [
-    { estado: 'cereza', color: '#b8342a', pos: [-1.5, 0, 0.75] },
-    { estado: 'pergamino', color: '#d4c199', pos: [-1.15, 0, 1.05] },
-    { estado: 'oro', color: '#9fae5a', pos: [-0.72, 0, 1.2] },
-  ];
+function Diorama({ tier, reducedMotion }) {
+  const perfil = perfilDeTier(tier);
+  const q = calidadCafetal(tier);
+  const frugal = tier === 'bajo';
 
-  // El surco del cafetal en la ladera: hilera curva que ordena las matas (café
-  // sembrado a curva de nivel, no ladera abajo — cuida el suelo del aguacero).
-  const surcos = useMemo(() => {
-    const n = 3;
-    return Array.from({ length: n }, (_, i) => {
-      const z = -0.75 + i * 0.62;
-      return /** @type {[number, number, number]} */ ([0, 0.03, z]);
-    });
-  }, []);
+  /* La atmósfera de la franja (la MISMA mezcla que hace EscenaBase3D con este
+     cielo): solo para teñir los montes del fondo con la niebla de la hora —
+     perspectiva aérea viva, al atardecer se doran y de noche se apagan. */
+  const { franja } = useCicloDia({ reducedMotion });
+  const c = useMemo(() => mezclarCielo(CIELO_CAFE, presetDeHora(franja)), [franja]);
+  const montes = useMemo(
+    () => ({
+      cerca: mezclar(VERDES.monte, c.niebla, 0.22),
+      media: mezclar(VERDES.monte, c.niebla, 0.3),
+      lejos: mezclar(VERDES.monte, c.niebla, 0.4),
+    }),
+    [c.niebla],
+  );
+
+  /* La ladera (heightfield compartido con EscenaCafetalVivo) y la mata enferma
+     (una vez por tier). */
+  const geoLadera = useMemo(
+    () => construirLadera(perfil.segmentosTerreno, perfil.flatShading),
+    [perfil.segmentosTerreno, perfil.flatShading],
+  );
+  const geoEnferma = useMemo(() => geomCafeto({ q }, 31), [q]);
+  const matEnferma = useMemo(
+    () => new THREE.MeshLambertMaterial({ vertexColors: true, flatShading: true }),
+    [],
+  );
+  useLayoutEffect(
+    () => () => {
+      geoLadera.dispose();
+      geoEnferma.dispose();
+      matEnferma.dispose();
+    },
+    [geoLadera, geoEnferma, matEnferma],
+  );
+
+  const fauna = useMemo(
+    () => (tier === 'alto' ? FAUNA_CAFE : FAUNA_CAFE.slice(0, 2)),
+    [tier],
+  );
+
+  const hCasa = alturaLadera(SITIO_CASA[0], SITIO_CASA[1]);
 
   return (
     <group>
-      {/* piso del cafetal (ladera) */}
-      <mesh position={[0, -0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
-        <circleGeometry args={[2.1, 30]} />
-        <meshLambertMaterial color="#7a6a3e" />
+      {/* LA LADERA: el suelo verdadero del mundo (arvenses, tierra roja,
+          mantillo y el caminito de llegada pintados por vértice). */}
+      <mesh geometry={geoLadera}>
+        <meshLambertMaterial vertexColors />
       </mesh>
-      {/* los surcos a curva de nivel (lomos de tierra que ordenan el cafetal) */}
-      {surcos.map((p, i) => (
-        <mesh key={i} position={p} rotation={[-Math.PI / 2, 0, 0]}>
-          <ringGeometry args={[0.55 + i * 0.02, 1.65, 40, 1, 0.6, 1.9]} />
-          <meshLambertMaterial color="#6b5636" />
-        </mesh>
-      ))}
 
-      {/* la SOMBRA arriba: los árboles altos que le hacen techo al café */}
-      {sombra.map((a, i) => (
-        <ArbolSombra key={i} pos={a.pos} color={a.color} alto={a.alto} />
-      ))}
+      {/* las montañas cafeteras del fondo, comidas por la niebla de la hora */}
+      <mesh position={[-14, 3.0, -23]} scale={[10, 4.6, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={montes.media} />
+      </mesh>
+      <mesh position={[8, 3.4, -26]} scale={[12, 5.6, 6]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={montes.lejos} />
+      </mesh>
+      <mesh position={[21, 2.2, -22]} scale={[8, 3.6, 5]}>
+        <sphereGeometry args={[1, 12, 8]} />
+        <meshLambertMaterial color={montes.cerca} />
+      </mesh>
 
-      {/* los CAFETOS cargados de cereza (uno con la señal de roya) */}
-      {cafetos.map((c, i) => (
-        <Cafeto key={i} pos={c.pos} color={c.color} cerezas={c.cerezas} roya={c.roya} />
-      ))}
+      {/* EL CAFETAL ENTERO: surcos a curva de nivel con los tres protagonistas
+          del primer plano, cerezas en racimo pegadas a la rama (verde→pintón→
+          rojo→vino), la flor axilar blanca, el sombrío de guamos y nogales, el
+          plátano intercalado y la luz colada bajo las copas (gama alta). */}
+      <FloraCafetal tier={tier} reducedMotion={reducedMotion} />
 
-      {/* el GRANO en sus tres estados, SIN tostar (cereza→pergamino→oro) */}
-      {granos.map((g, i) => (
-        <GranoEstado key={i} pos={g.pos} color={g.color} />
-      ))}
+      {/* la mata señalada con roya y la trampa de broca: sanidad con criterio */}
+      <MataConRoya pos={[-5.6, 1.5, -1.5]} geo={geoEnferma} mat={matEnferma} />
+      <TrampaBroca pos={[4.6, 1.38, -0.6]} />
 
-      {/* el BENEFICIO: despulpar, fermentar, secar (el paso al grano vendible) */}
-      <Beneficio pos={[1.0, 0, 0.55]} />
+      {/* la casa con su beneficiadero coronando la loma, medio velada */}
+      <CasaBeneficio pos={[SITIO_CASA[0], hCasa, SITIO_CASA[1]]} />
 
-      {/* la vida que trae la sombra: colibríes y mariposa (café con hábitat) */}
-      <Fauna items={FAUNA_CAFE} reducedMotion={reducedMotion} />
+      {/* el grano en sus tres estados, en el patio del beneficio */}
+      <MesaGrano pos={[7.4, 4.89, -12.6]} />
+
+      {/* los velos de bruma que separan los planos de la ladera */}
+      {!frugal &&
+        VELOS.map((v, i) => (
+          <mesh key={i} position={v.pos}>
+            <planeGeometry args={v.tam} />
+            <meshBasicMaterial
+              color={NIEBLAS.lechosa}
+              transparent
+              opacity={v.op}
+              depthWrite={false}
+              side={THREE.DoubleSide}
+            />
+          </mesh>
+        ))}
+
+      {/* LA VIDA que trae la sombra: colibríes y mariposas (café con hábitat) */}
+      {perfil.criaturas > 0 && <Fauna items={fauna} reducedMotion={reducedMotion} />}
     </group>
   );
 }
 
 export default function EscenaCafe(props) {
-  // Cielo de "corral y cafetal: tarde de finca" (atmosferaMadre) — la mezcla lo
-  // entibia igual hacia la hora dorada del valle.
-  const cielo = CIELOS.corral;
   return (
-    <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.7, 0] }}>
-      <Diorama params={props.params} reducedMotion={props.reducedMotion} />
+    <EscenaBase3D
+      {...props}
+      cielo={CIELO_CAFE}
+      entrada={{ ...ENTRADA_LADERA, ...(props.entrada || {}) }}
+    >
+      <Diorama tier={props.tier || 'alto'} reducedMotion={!!props.reducedMotion} />
     </EscenaBase3D>
   );
 }

--- a/src/visual/mundo3d/escenas/EscenaCafe.jsx
+++ b/src/visual/mundo3d/escenas/EscenaCafe.jsx
@@ -48,6 +48,9 @@ import {
   geomCafeto,
   SITIO_CASA,
   PAL,
+  CAMARA,
+  ZOOM_LADERA,
+  CENTRO_LADERA,
 } from '../cafetal/floraCafetal.geom.js';
 import { VERDES, NIEBLAS } from '../paleta/index.js';
 
@@ -55,9 +58,12 @@ import { VERDES, NIEBLAS } from '../paleta/index.js';
    cafetal ("tarde de finca"), mezclada 60% hacia la franja REAL del día. */
 const CIELO_CAFE = CIELOS.corral;
 
-/* El encuadre por defecto de la ladera (el registro puede pisarlo): la cámara
-   llega desde abajo del camino y mira loma arriba — entrar es subir. */
-const ENTRADA_LADERA = { zoom: 13, centro: /** @type {[number,number,number]} */ ([0, 2.4, -2]) };
+/* El encuadre de la ladera: la cámara llega desde abajo del camino y mira loma
+   arriba — entrar es subir. Sale de floraCafetal.geom (junto a la geografía),
+   así el diagnóstico `encuadre-mundo.mjs cafe` mide ESTE encuadre y no otro.
+   Se retiró y se levantó respecto del anterior: el ojo pasa POR DEBAJO del
+   techo de sombra en vez de quedar metido entre las copas. */
+const ENTRADA_LADERA = { zoom: ZOOM_LADERA, centro: CENTRO_LADERA };
 
 /* La fauna que delata el café DE SOMBRA: colibríes y mariposas que el café a
    pleno sol espanta. Pocas y por criterio (la sombra ES el hábitat); alturas
@@ -263,6 +269,9 @@ export default function EscenaCafe(props) {
       {...props}
       cielo={CIELO_CAFE}
       entrada={{ ...ENTRADA_LADERA, ...(props.entrada || {}) }}
+      /* La pose EXPLÍCITA de la ladera: la derivada del `zoom` dejaba el ojo
+         entre las copas del sombrío. */
+      camara={props.camara || { position: CAMARA.reposo, fov: CAMARA.fov }}
     >
       <Diorama tier={props.tier || 'alto'} reducedMotion={!!props.reducedMotion} />
     </EscenaBase3D>

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -235,7 +235,10 @@ export const MUNDO = {
       { id: 'manejo', pos: [4.6, 2.6, -0.6], emoji: '🐞', label: 'Manejo sin veneno', view: 'biopreparados' },
       { id: 'beneficio', pos: [10.2, 7.5, -13.6], emoji: '💧', label: 'Despulpar, fermentar, secar', view: 'poscosecha' },
     ],
-    entrada: { zoom: 13, centro: [0, 2.4, -2], narra: 'cafe' },
+    // El centro se corre atrás y abajo para que la mirada de EscenaBase3D
+    // (centro.y + zoom·0.12) caiga en CAMARA.mirada de floraCafetal.geom: la
+    // cámara pasa POR DEBAJO del techo de sombra, no entre las copas.
+    entrada: { zoom: 13, centro: [-0.4, 2.24, -3.4], narra: 'cafe' },
     // El gemelo 2D digno: la ficha del café (misma lección, en cifras y notas).
     fallback2d: {
       escena: 'infografia',

--- a/src/visual/mundo3d/mundoData.js
+++ b/src/visual/mundo3d/mundoData.js
@@ -219,33 +219,23 @@ export const MUNDO = {
     pisoTermico: 'templado',
     escena: 'cafe',
     valle: { tipo: 'cafetal', pos: [3.4, 0, 2.2], escala: 1 },
-    params: {
-      // El diorama tiene defaults propios; aquí los hacemos explícitos y
-      // deterministas (mismos cafetos, sombra y estados del grano).
-      cafetos: [
-        { color: '#3f6f3a', pos: [-0.55, 0, 0.42], cerezas: 6 },
-        { color: '#468637', pos: [0.5, 0, 0.12], cerezas: 5 },
-        { color: '#3f6f3a', pos: [0.02, 0, -0.5], cerezas: 4, roya: true },
-        { color: '#457d38', pos: [-0.78, 0, -0.32], cerezas: 5 },
-      ],
-      sombra: [
-        { pos: [-1.65, 0, -0.95], color: '#4b7a3a', alto: 2.2 }, // guamo (Inga)
-        { pos: [1.7, 0, -0.8], color: '#3f6b39', alto: 2.0 },    // nogal cafetero
-      ],
-      granos: [
-        { estado: 'cereza', color: '#b8342a', pos: [-1.5, 0, 0.75] },
-        { estado: 'pergamino', color: '#d4c199', pos: [-1.15, 0, 1.05] },
-        { estado: 'oro', color: '#9fae5a', pos: [-0.72, 0, 1.2] },
-      ],
-    },
+    // La escena es LA LADERA COMPLETA de `cafetal/` (geografía determinista en
+    // floraCafetal.geom): ya no hay cafetos de mesa que declarar aquí. El `id`
+    // ancla la capa viva (partículas/momentos) a la siembra propia del mundo.
+    params: { id: 'cafe' },
+    // Las puertas repartidas EN PROFUNDIDAD ladera arriba (entrada con aire, un
+    // solo foco cerca): el grano en la mata protagonista del camino, la sombra
+    // en el guamo del centro, la roya en su mata señalada, el manejo en la
+    // trampa de broca y el beneficio en la casa que corona la loma. Alturas
+    // horneadas del terreno real (alturaLadera + el porte de cada elemento).
     hotspots: [
-      { id: 'grano', pos: [-0.55, 0.9, 0.42], emoji: '☕', label: 'El grano, paso a paso', view: 'cafe' },
-      { id: 'sombra', pos: [-1.65, 2.5, -0.95], emoji: '🌳', label: 'El café bajo sombra', view: 'biodiversidad' },
-      { id: 'roya', pos: [0.02, 0.85, -0.5], emoji: '🍂', label: 'La roya y la broca', view: 'plagas' },
-      { id: 'manejo', pos: [0.5, 0.82, 0.12], emoji: '🐞', label: 'Manejo sin veneno', view: 'biopreparados' },
-      { id: 'beneficio', pos: [1.0, 0.7, 0.55], emoji: '💧', label: 'Despulpar, fermentar, secar', view: 'poscosecha' },
+      { id: 'grano', pos: [-2.8, 1.9, 5.6], emoji: '☕', label: 'El grano, paso a paso', view: 'cafe' },
+      { id: 'sombra', pos: [3.2, 4.7, 2.4], emoji: '🌳', label: 'El café bajo sombra', view: 'biodiversidad' },
+      { id: 'roya', pos: [-5.6, 2.7, -1.5], emoji: '🍂', label: 'La roya y la broca', view: 'plagas' },
+      { id: 'manejo', pos: [4.6, 2.6, -0.6], emoji: '🐞', label: 'Manejo sin veneno', view: 'biopreparados' },
+      { id: 'beneficio', pos: [10.2, 7.5, -13.6], emoji: '💧', label: 'Despulpar, fermentar, secar', view: 'poscosecha' },
     ],
-    entrada: { zoom: 7.5, narra: 'cafe' },
+    entrada: { zoom: 13, centro: [0, 2.4, -2], narra: 'cafe' },
     // El gemelo 2D digno: la ficha del café (misma lección, en cifras y notas).
     fallback2d: {
       escena: 'infografia',


### PR DESCRIPTION
## El reclamo que sobrevivía

De los tres reclamos del mundo del café, la toma anterior (#2598) resolvió dos. Este remata el tercero: **«no se distingue el café como planta»** — resuelto en primer plano, pero a media distancia (el 80% del encuadre) la ladera se leía como un bosque de pinos.

## La causa raíz, medida

La tabla de pisos del cafeto tenía los largos **decreciendo** hacia arriba (0.56 → 0.50 → 0.42 → 0.32) y remataba en punta: un **cono**. Al perderse el detalle solo queda el contorno, y ese contorno decía «pino». Encima eran 120 clones del mismo molde — que es exactamente cómo se ve un pinar.

## Qué cambia

**Silueta** (el entregable):
- Hombro ancho al 2º/3er piso (envolvente ovalada, no triángulo), remate **romo** (corona de brotes, no punta), lóbulos achatados y descentrados por piso (contorno mordido = la textura granulosa de un cafetal a 20-50 m).
- Ancho conservado en la franja alta de la mata: **29% antes → 54-69% ahora** (medido sobre la malla). Relación ancho/alto: 1.02 → **1.28 / 1.62 / 1.71**.
- Los **tres manejos colombianos** conviven con silueta propia: un tallo, zoqueada (varios ejes desde el tocón) y agobiada (seto bajo extendido). Los tres cafetos protagonistas enseñan uno cada uno.
- La cereza sigue cayendo sobre la rama dibujada (`puntoEnRama` = la misma cuenta de la malla, ejes acostados incluidos; 270 puntos verificados headless, 0 fuera).

**Paleta**: la ladera se pintaba con la banda del piso **cálido** (`VERDES.calido`, oliva) siendo el arábica cultivo de piso **templado** — de ahí el pardo mustio. Manda `templadoVivo`; tierra/mantillo bajan a acento; la hoja sube de valor sin perder la firma oscura lustrosa.

**Cámara**: `encuadre-mundo.mjs` ahora ve las **copas del sombrío** (antes era ciego a ellas y daba «sin avisos» con una copa encima del lente). Con eso medido: se corre el guamo que tapaba la entrada y se recomponen las dos cámaras.

| encuadre | cielo | tercio alto | cultivo | copa más cercana | sujeto |
|---|---|---|---|---|---|
| vitrina antes | 0.5% | 32.8% | 82.7% | guamo a **1.0 m** | **fuera de cuadro** |
| vitrina después | 21.9% | 11.5% | 75.2% | plátano a 12.3 m | en cuadro |
| pantalla completa antes | 31.1% | 3.3% | 67.0% | guamo a 8.5 m (9.1% del cuadro <7 m) | en cuadro |
| pantalla completa después | 30.1% | 3.8% | 68.0% | guamo a 8.9 m (**0.0%** <7 m) | en cuadro |

(referencia papal: cielo 32.8% · tercio alto 0.6% · cultivo 59.4%)

## Verificación

- Antes/después fotografiado en `#/mockups/mundo3d-cafe` (dev server real, swiftshader): el antes muestra los conos; el después, matas anchas con cereza y ladera verde.
- Para fotografiar: **`/?ciclo=16#/mockups/mundo3d-cafe`** (el query ANTES del hash).
- Build de producción verde. Tests mundo3d: 17 archivos verdes; los 4 rojos (19 tests: audio, hilo de vida, navegación, bosque) fallan **igual en la base** — verificado con stash.
- `public/chagra-stats.json` y `public/cycle-content/manifest.json`: byte-idénticos a la base.
- No toca `Valle3D.jsx`, `composicionValle3D`, ni los mundos con PR abierto. `CafetalDensoValle` (valle) consume `geomCafeto` del geom compartido: hereda la silueta buena sin cambio de código.