### PR TITLE
art(fauna): la ruana pierde las mangas · la zarigüeya deja de ser el gurre

### DIFF
--- a/shot-oso.jsx
+++ b/shot-oso.jsx
@@ -1,0 +1,41 @@
+/* Harness EFÍMERO de captura (no se commitea): OsoGuardian y su ruana. */
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { OsoGuardian, AbejaAngelita, Jaguar, Danta } from './src/visual/creatures/index.js';
+import './src/visual/creatures/creatures.css';
+
+function Caja({ titulo, children }) {
+  return (
+    <div className="caja">
+      <h2>{titulo}</h2>
+      {children}
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <div className="fila" data-listo="si">
+      <Caja titulo="OSO — sin ruana">
+        <OsoGuardian size={180} animated={false} />
+      </Caja>
+      <Caja titulo="OSO — ruana noche">
+        <OsoGuardian size={180} animated={false} vestuario clima="noche" tempC={6} />
+      </Caja>
+      <Caja titulo="ANGELITA — sin ruana">
+        <AbejaAngelita size={180} animated={false} />
+      </Caja>
+      <Caja titulo="ANGELITA — ruana noche">
+        <AbejaAngelita size={180} animated={false} vestuario clima="noche" tempC={6} />
+      </Caja>
+      <Caja titulo="JAGUAR — ruana noche">
+        <Jaguar size={180} animated={false} vestuario clima="noche" tempC={6} />
+      </Caja>
+      <Caja titulo="DANTA — ruana noche">
+        <Danta size={180} animated={false} vestuario clima="noche" tempC={6} />
+      </Caja>
+    </div>
+  );
+}
+
+createRoot(document.getElementById('root')).render(<App />);

--- a/shot-sierra.html
+++ b/shot-sierra.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>shot sierra</title>
+    <style>
+      html, body, #root { margin: 0; height: 100%; background: #0d1b1f; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/shot-sierra.jsx"></script>
+  </body>
+</html>

--- a/shot-sierra.jsx
+++ b/shot-sierra.jsx
@@ -1,0 +1,8 @@
+/* Harness EFÍMERO de captura (no se commitea): SierraMonte3D con el oso nuevo. */
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import SierraMonte3D from './src/visual/mundo3d/sierra/SierraMonte3D.jsx';
+
+createRoot(document.getElementById('root')).render(
+  <SierraMonte3D tier="alto" reducedMotion={false} />,
+);

--- a/src/components/Settings/__tests__/AvatarSelector.test.jsx
+++ b/src/components/Settings/__tests__/AvatarSelector.test.jsx
@@ -65,11 +65,11 @@ describe('useAvatarCreature — resolución slug→personaje', () => {
     it('sigue la elección del store en vivo', () => {
         const { result } = renderHook(() => useAvatarCreature());
         act(() => {
-            usePrefsStore.getState().setAvatarCreatureId('oso-andino');
+            usePrefsStore.getState().setAvatarCreatureId('oso-guardian');
         });
-        expect(result.current.id).toBe('oso-andino');
-        expect(result.current.Component).toBe(CREATURES['oso-andino'].Component);
-        expect(JSON.parse(localStorage.getItem(STORAGE_KEY))).toBe('oso-andino');
+        expect(result.current.id).toBe('oso-guardian');
+        expect(result.current.Component).toBe(CREATURES['oso-guardian'].Component);
+        expect(JSON.parse(localStorage.getItem(STORAGE_KEY))).toBe('oso-guardian');
     });
 
     it('slug desconocido (bicho retirado / typo) cae al default', () => {

--- a/src/components/dashboard/CriaturasNocturnas.jsx
+++ b/src/components/dashboard/CriaturasNocturnas.jsx
@@ -12,10 +12,30 @@
  * Componentes reutilizables (patrón GuardianEspiritu): funciones Avatar<X> que
  * comparten <CriaturasNocturnasDefs/> (glow + blur). El ROSTER se exporta para
  * que la vitrina —u otras superficies— lo pinten sin duplicar datos.
+ *
+ * NIVEL PERSONAJE: murciélago, gurre y tigrillo dejaron de ser siluetas-chip y
+ * son personajes completos (anatomía diagnóstica real, peso, gesto y animación
+ * rubber-hose andina — boil steps ~12fps, parpadeo irregular, mirada co-prima;
+ * clases cn-* nuevas al final de criaturas-nocturnas.css).
  */
+import { useId } from 'react';
+import { LineBoilFilter } from '../../visual/creatures/LineBoilFilter';
 import './criaturas-nocturnas.css';
 
+/* Respeta prefers-reduced-motion para el line-boil SMIL (los transforms CSS ya
+   se congelan por media-query). Se evalúa una vez en cliente; si el usuario lo
+   cambia luego, el resto de la animación ya obedece la media-query. */
+const CN_REDUCED =
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
 /* ─── ROSTER GROUNDED — 7 nocturnas + el cóndor del valle ─────────────────── */
+/* El roster y el buscador por id conviven a propósito con los componentes: son
+   los DATOS de estas mismas criaturas y la vitrina los pinta sin duplicarlos.
+   Eso rompe `react-refresh/only-export-components` (deuda que ya venía en el
+   archivo, no la introduce este cambio): solo cuesta un full-reload en dev. */
+// eslint-disable-next-line react-refresh/only-export-components
 export const CRIATURAS_NOCTURNAS = [
   {
     id: 'zariguya',
@@ -116,78 +136,471 @@ export function CriaturasNocturnasDefs() {
 
 /* ─── los avatares (SVG biopunk, uno por criatura) ────────────────────────── */
 
-/* Zarigüeya (Didelphis marsupialis): cuadrúpedo de hocico puntudo, orejas
-   grandes y cola pelona prensil enroscada; contorno cian glacial. */
+/* Zarigüeya / chucha (Didelphis marsupialis) — PERSONAJE COMPLETO.
+   Rasgos diagnósticos reales del marsupial: hocico largo y puntudo con
+   VIBRISAS, orejas desnudas membranosas, COLA PRENSIL DESNUDA (el rasgo que la
+   delata, con su anillado escamoso), pelaje de guardia largo y desgreñado sobre
+   lanilla clara. Y el gesto que le gana el corazón a una niña de once: las
+   CRÍAS cargadas en el lomo, agarradas con sus manitos.
+
+   ── POR QUÉ ESTÁ ERGUIDA: EL PROBLEMA DEL GURRE ─────────────────────────────
+   Puestas lado a lado y reducidas a 64 px, la zarigüeya y el gurre eran EL
+   MISMO BICHO: dos masas oscuras horizontales con hocico largo al frente. Y la
+   cola nacía tan arriba del lomo que se leía como un ala flotando, cuando la
+   cola prensil desnuda es justo el rasgo que la delata.
+
+   La DR `distinguir-visualmente-zariguya-de-armadillo` (gemini, 2026-06-19)
+   resuelve las dos cosas, y esto es lo que quedó dibujado aquí:
+
+     · LA ACCIÓN ANTES QUE LA FORMA. Dos criaturas parecidas se separan mejor
+       por lo que HACEN. El gurre escarba: cuerpo bajo, pegado al suelo, nariz
+       enterrada. La zarigüeya HUSMEA ERGUIDA: se incorpora sobre los cuartos
+       traseros, el eje del cuerpo se para en diagonal y el hocico apunta
+       ARRIBA, leyendo el aire. Una masa horizontal contra una vertical: a 64 px
+       ya no hay forma de confundirlas.
+     · EXAGERACIÓN SELECTIVA DEL RASGO DIAGNÓSTICO. La cola prensil ahora nace
+       BAJA, en la propia grupa, con su base peluda que la ancla al cuerpo —
+       nunca suelta en el aire—, barre el suelo y remata en GANCHO enroscado
+       hacia arriba. Esa S es la firma que ningún armadillo tiene: la del gurre
+       es cónica, rígida y recta hacia atrás.
+     · CONTRASTE DE LENGUAJE DE FORMAS. La zarigüeya es toda curva orgánica y
+       pelo de guardia que rompe la silueta; el gurre es domo rígido segmentado.
+       Las orejas grandes, redondeadas y desnudas asoman altas en el contorno,
+       contra la oreja tubular chica del gurre.
+     · LAS MANOS RECOGIDAS contra el pecho — lo que hace un marsupial cuando se
+       para a oler — dejan el frente despejado y suben todavía más el eje.
+
+   Las CRÍAS ganan con la postura: sobre el lomo en diagonal quedan escalonadas
+   como en una escalera y se ven las tres enteras, no encimadas.
+   Animación: husmea (el marsupial vive por la nariz), le tiemblan las vibrisas,
+   la cola prensil se mece y las crías se acomodan. Contorno con line-boil. */
 function AvatarZariguya() {
+  const uid = useId().replace(/[:]/g, '');
+  const boilId = `cn-boil-zari-${uid}`;
+
   return (
     <g className="cn-av-camina" filter="url(#cn-glow1)">
-      <ellipse cx="0" cy="14" rx="16" ry="3" fill="#000" opacity="0.38" />
-      <path d="M-12,6 C-20,8 -22,2 -18,-2 C-16,-4 -13,-3 -14,0" fill="none" stroke="#9ff0ff" strokeWidth="1.6" strokeLinecap="round" opacity="0.85" />
-      <path d="M-13,8 C-15,1 -9,-4 0,-4 C9,-4 14,1 14,7 C14,11 8,13 -2,13 C-9,13 -12,12 -13,8 Z" fill="#171030" stroke="#9ff0ff" strokeWidth="0.9" strokeOpacity="0.6" />
-      <path d="M-10,-1 C-3,-5 8,-4 13,2" fill="none" stroke="#d8f6ff" strokeWidth="0.9" opacity="0.5" />
-      <path d="M-8,12 L-8,7 M0,13 L0,7.5 M8,11 L8,6.5" stroke="#0f0a24" strokeWidth="3.2" strokeLinecap="round" />
-      {/* orejas grandes */}
-      <path d="M6,-4 C4,-10 10,-11 11,-6 C10,-4.5 8,-4 6,-4 Z" fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.7" strokeOpacity="0.6" />
-      <path d="M11,-4 C9,-10 15,-11 16,-6 C15,-4.5 13,-4 11,-4 Z" fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.7" strokeOpacity="0.6" />
-      {/* cabeza + hocico puntudo a la derecha */}
-      <path d="M11,-1 C17,-2 22,1 24.4,4 C25,5.4 24,6.5 22.4,6 C22,4 18.5,2.5 14.5,3 C12.6,3.2 11,1 11,-1 Z" fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.8" strokeOpacity="0.6" />
-      {/* cara pálida del marsupial */}
-      <path d="M13,-0.5 C15,-1 17,-0.6 18,1 C16.5,2 14.5,1.6 13,0.6 Z" fill="#eafff6" opacity="0.5" />
-      <circle cx="24" cy="4.2" r="1.15" fill="#ffc0dc" opacity="0.9" />
-      <circle cx="15.4" cy="1" r="1.15" fill="#04160f" />
-      <circle cx="15.4" cy="1" r="1.15" fill="none" stroke="#9ff0ff" strokeWidth="0.7" />
-      <circle cx="15.8" cy="0.6" r="0.4" fill="#eafff6" />
+      <defs>
+        <LineBoilFilter id={boilId} baseFrequency={0.038} scale={1.8} animated={!CN_REDUCED} dur="0.42s" />
+      </defs>
+
+      {/* la sombra es CORTA y está bajo la grupa: sentada apoya poco suelo (el
+          gurre, tendido, derrama sombra a lo largo). Otra pista de postura. */}
+      <ellipse cx="-4" cy="15.2" rx="11" ry="2.6" fill="#000" opacity="0.36" />
+
+      <g className="cn-zari">
+        {/* ── COLA PRENSIL DESNUDA — el rasgo diagnóstico, exagerado.
+               Nace BAJA en la grupa (no del lomo: eso la hacía ala), barre el
+               suelo hacia atrás y remata en GANCHO enroscado hacia arriba. Va
+               adelgazando: gruesa en la base, fina en la punta que agarra. ── */}
+        <g className="cn-zari-cola">
+          <path d="M-7.2,11.4 C-11.8,12.6 -16.8,12.4 -19.8,9.4
+                   C-22.6,6.6 -22,1.8 -18.6,0.4 C-16.8,-0.4 -15.4,0.8 -16,2
+                   C-17.8,2 -19.4,3.4 -19.2,5.6 C-19,8.4 -15.6,10 -11.4,9.2
+                   C-9.8,8.9 -8.4,8.7 -7.2,8.7 Z"
+            fill="#1c2350" stroke="#9ff0ff" strokeWidth="0.85" strokeOpacity="0.65" />
+          {/* anillado escamoso de la cola pelona */}
+          <g stroke="#d8f6ff" strokeWidth="0.5" fill="none" opacity="0.42">
+            <path d="M-10.2,11.5 C-10.4,10.4 -10.4,9.6 -10.2,8.9" />
+            <path d="M-13.6,11.7 C-13.9,10.6 -14,9.8 -13.8,9.1" />
+            <path d="M-17,10.9 C-17.6,9.9 -17.9,9.2 -17.8,8.5" />
+            <path d="M-19.6,8.4 C-20.4,7.8 -20.8,7.4 -21,6.8" />
+            <path d="M-20.9,4.6 C-21.5,4.4 -21.8,4 -21.9,3.6" />
+            <path d="M-19,1.6 C-19.3,1 -19.4,0.6 -19.3,0.2" />
+          </g>
+          {/* base peluda: donde el pelo de guardia todavía cubre la cola y la
+              ANCLA al cuerpo. Sin esta pieza la cola se lee pegada aparte. */}
+          <path d="M-6.4,11.8 C-9.4,12.2 -11.4,11.4 -12.2,9.4 C-10.2,9.6 -8.2,9.4 -6.4,8.6 Z"
+            fill="#171030" stroke="#9ff0ff" strokeWidth="0.6" strokeOpacity="0.5" />
+        </g>
+
+        <g filter={`url(#${boilId})`}>
+          {/* ── CUERPO ERGUIDO: sentada sobre los cuartos traseros, el eje sube
+                 en diagonal hacia el pecho. Pera inclinada, no barril. ── */}
+          <path d="M-9.8,13.2 C-13,9.2 -12.6,2.4 -8.2,-2.4
+                   C-4.6,-6.4 -0.4,-8.6 3.6,-9
+                   C6.6,-9.3 8.4,-7.2 7.8,-4.4
+                   C7.2,-1.2 4.8,3 2.2,7.2
+                   C0.4,10.4 -1.6,13.4 -4.4,13.8
+                   C-6.6,14 -8.8,13.9 -9.8,13.2 Z"
+            fill="#171030" stroke="#9ff0ff" strokeWidth="0.9" strokeOpacity="0.6" />
+
+          {/* lanilla clara del vientre: ahora corre por el FRENTE del pecho,
+              que es donde da la luz cuando el animal se para */}
+          <path d="M-7.4,12.4 C-3.6,13.4 -0.2,10.2 2.4,5.4 C4.6,1.4 6.4,-2.6 6.8,-5.2
+                   C7.4,-2 5,3 2,8 C0,11.4 -3.8,14 -7.4,12.4 Z"
+            fill="#eafff6" opacity="0.2" />
+
+          {/* PELO DE GUARDIA largo y desgreñado: mechones que rompen la
+              silueta a lo largo del LOMO en diagonal */}
+          <g stroke="#9ff0ff" strokeWidth="0.8" strokeLinecap="round" fill="none" opacity="0.5">
+            <path d="M-11.8,8.4 C-13.8,8.6 -14.8,8.4 -15.6,7.8" />
+            <path d="M-12.4,4.2 C-14.4,3.8 -15.4,3.2 -16,2.4" />
+            <path d="M-11.6,0.4 C-13.2,-0.8 -14,-1.8 -14.2,-2.8" />
+            <path d="M-9,-3.2 C-10.2,-4.8 -10.6,-6 -10.4,-7" />
+            <path d="M-5.8,-6.2 C-6.4,-8 -6.4,-9.2 -5.8,-10.2" />
+            <path d="M-2,-8.2 C-2.2,-10 -1.8,-11.2 -1,-12" />
+            <path d="M1.8,-9 C2,-10.6 2.6,-11.6 3.6,-12.2" />
+            <path d="M5.4,-8 C6.4,-9.2 7.2,-9.8 8.2,-10" />
+          </g>
+          {/* textura interna del pelaje: el pelo cae siguiendo la diagonal */}
+          <g stroke="#d8f6ff" strokeWidth="0.55" fill="none" opacity="0.3">
+            <path d="M-9.2,7.6 C-8.4,4.4 -6.4,0.8 -3.4,-2.4" />
+            <path d="M-6.4,10.4 C-5,7.2 -2.6,3.4 0.4,0.2" />
+            <path d="M-8.6,2.2 C-6.6,-1 -3.8,-4.2 -0.4,-6.4" />
+          </g>
+        </g>
+
+        {/* ── PATAS TRASERAS PLANTÍGRADAS: cargan todo el peso de la sentada,
+               con la planta entera apoyada y los deditos abiertos ── */}
+        <path d="M-6.6,11.6 C-7.6,12.8 -8,13.6 -7.8,14.4" stroke="#0f0a24" strokeWidth="3.2" strokeLinecap="round" fill="none" />
+        <path d="M-10.4,14.6 L-3.8,14.6" stroke="#0f0a24" strokeWidth="2.6" strokeLinecap="round" />
+        <g stroke="#9ff0ff" strokeWidth="0.7" strokeLinecap="round" opacity="0.65">
+          <path d="M-10.2,14.9 L-11.2,15.7" /><path d="M-8.2,15.1 L-8.6,16.1" />
+          <path d="M-6.2,15.1 L-6,16.1" /><path d="M-4.2,14.9 L-3.4,15.7" />
+        </g>
+
+        {/* ── MANOS RECOGIDAS contra el pecho: lo que hace un marsupial cuando
+               se para a oler. Cortas, con garras finas, colgando. ── */}
+        <g stroke="#0f0a24" strokeWidth="2.2" strokeLinecap="round" fill="none">
+          <path d="M4.4,-3.6 C5.4,-1.6 5.6,-0.2 5.2,1" />
+          <path d="M1.6,-1 C2.4,0.8 2.6,2.2 2.2,3.4" />
+        </g>
+        <g stroke="#9ff0ff" strokeWidth="0.6" strokeLinecap="round" opacity="0.7">
+          <path d="M5,1.4 L5.6,2.4" /><path d="M5.2,1.6 L4.8,2.6" />
+          <path d="M2,3.8 L2.6,4.8" /><path d="M2.2,4 L1.8,5" />
+        </g>
+
+        {/* ── LAS CRÍAS AL LOMO: el gesto. Escalonadas sobre la diagonal del
+               lomo, cada una acostada en el ángulo de la espalda — así se ven
+               las tres enteras, como en una escalera. ── */}
+        <g className="cn-zari-cria">
+          <ZariguyaCria x={-11.4} y={8.6} escala={0.95} rot={-72} />
+        </g>
+        <g className="cn-zari-cria cn-zari-cria-b">
+          <ZariguyaCria x={-13.4} y={2.6} escala={0.95} rot={-46} />
+        </g>
+        <g className="cn-zari-cria cn-zari-cria-c">
+          <ZariguyaCria x={-9.6} y={-5.4} escala={0.9} rot={-20} />
+        </g>
+
+        {/* ── CABEZA que HUSMEA EL AIRE: el hocico sube en diagonal, las orejas
+               grandes y desnudas asoman altas en la silueta ── */}
+        <g className="cn-zari-hocico">
+          {/* OREJAS GRANDES, REDONDEADAS Y DESNUDAS — asoman altas sobre el
+              cráneo y son media silueta del bicho. Contra la oreja tubular
+              chica del gurre, es de las lecturas más rápidas a 64 px. */}
+          <path d="M1,-12.4 C0,-17.4 4.6,-19.6 6.6,-15.8 C6.2,-13.4 3.6,-12.2 1,-12.4 Z"
+            fill="#141a3a" stroke="#9ff0ff" strokeWidth="0.7" strokeOpacity="0.6" />
+          <path d="M2.4,-13.4 C2,-16.4 4.4,-17.6 5.4,-15.4 C4.8,-14.2 3.6,-13.4 2.4,-13.4 Z"
+            fill="#ffc0dc" opacity="0.22" />
+          <path d="M6.4,-14 C6,-19.6 11.4,-21.2 12.6,-16.6 C11.6,-14.6 9,-13.8 6.4,-14 Z"
+            fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.7" strokeOpacity="0.7" />
+          <path d="M7.8,-15 C7.8,-18.4 10.4,-19.4 11.2,-16.8 C10.4,-15.6 9,-15 7.8,-15 Z"
+            fill="#ffc0dc" opacity="0.28" />
+
+          {/* CRÁNEO con volumen + HOCICO LARGO Y PUNTUDO que sale de él y sube
+              a leer el aire. El cráneo primero: sin bulto el hocico se lee como
+              un pico de ave clavado al cuello. */}
+          <path d="M1.4,-8.6
+                   C0.6,-12.8 3.6,-16 7.8,-15.8
+                   C10.2,-15.7 12,-14.8 12.9,-13.2
+                   C14.8,-13.9 17,-15.2 18.9,-16.4
+                   C20.1,-17.1 21,-16.2 20.4,-15
+                   C19.1,-14.4 16.5,-12.9 14,-11.7
+                   C11.4,-10.4 8.4,-9 6.2,-7.2
+                   C4.4,-6.1 1.9,-6.9 1.4,-8.6 Z"
+            fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.85" strokeOpacity="0.65" />
+          {/* cara pálida del marsupial (la máscara clara sobre el hocico) */}
+          <path d="M5.4,-9.8 C8,-12.6 11.4,-13 15.6,-14.6 C12.6,-12.2 9.6,-10.6 6.8,-8.8 Z"
+            fill="#eafff6" opacity="0.32" />
+          {/* mejilla: pelo de guardia también en la cara */}
+          <g stroke="#9ff0ff" strokeWidth="0.6" strokeLinecap="round" fill="none" opacity="0.4">
+            <path d="M3.2,-6.8 C2.6,-5.4 2.4,-4.6 2.4,-3.8" />
+            <path d="M1.6,-11 C0.4,-11.6 -0.4,-11.8 -1.2,-11.6" />
+          </g>
+
+          {/* trufa rosada, en la punta que lee el aire */}
+          <ellipse cx="19.6" cy="-15.7" rx="1.4" ry="1.1" fill="#ffc0dc" opacity="0.95"
+            transform="rotate(-28 19.6 -15.7)"
+            style={{ filter: 'drop-shadow(0 0 3px rgba(255,192,220,0.8))' }} />
+          <path d="M19.2,-15 L18.6,-14.4" stroke="#0f0a24" strokeWidth="0.4" strokeLinecap="round" opacity="0.7" />
+
+          {/* VIBRISAS (el marsupial lee el mundo con ellas) */}
+          <g className="cn-zari-bigote">
+            <g stroke="#eafff6" strokeWidth="0.45" fill="none" opacity="0.6" strokeLinecap="round">
+              <path d="M17.8,-16.6 C18.6,-18.4 18.8,-19.8 18.6,-21.2" />
+              <path d="M18.8,-16.2 C20.2,-17.4 21.2,-18.2 22,-18.8" />
+              <path d="M19.6,-14.4 C21.2,-14.2 22.2,-13.8 23,-13.2" />
+              <path d="M18.2,-13.6 C19.2,-12.4 19.8,-11.4 20,-10.2" />
+            </g>
+          </g>
+
+          {/* ojo: cuenta negra con anillo neón y brillo de linterna */}
+          <circle cx="6.6" cy="-11.8" r="1.55" fill="#04160f" />
+          <circle cx="6.6" cy="-11.8" r="1.55" fill="none" stroke="#9ff0ff" strokeWidth="0.7"
+            style={{ filter: 'drop-shadow(0 0 3px #9ff0ff)' }} />
+          <circle cx="7" cy="-12.3" r="0.5" fill="#eafff6" />
+        </g>
+      </g>
     </g>
   );
 }
 
-/* Currucutú (Megascops choliba): búho compacto de penachos, disco facial y ojos
-   enormes ámbar con glow; posado. Acento dorado. */
+/* Cría de zarigüeya agarrada al lomo de la madre: cuerpito, hocico ya puntudo,
+   orejas desnudas, manito que agarra el pelo y colita pelona. Miniatura fiel —
+   la cría de Didelphis es la madre en pequeño, no un muñeco redondo.
+   `rot` inclina la cría para que se acueste sobre el ángulo del lomo: con la
+   madre erguida la espalda es una diagonal, y una cría horizontal encima se
+   leería pegada como calcomanía. El dibujo no cambia, solo su apoyo. */
+function ZariguyaCria({ x, y, escala = 1, rot = 0 }) {
+  return (
+    <g transform={`translate(${x} ${y}) rotate(${rot}) scale(${escala})`}>
+      {/* cuerpito agachado sobre el lomo */}
+      <path d="M-3.2,2.6 C-4,0.4 -2.6,-1.6 0,-1.8 C2.6,-2 4.2,-0.6 4.2,1.4 C4.2,2.8 2.6,3.4 -0.4,3.4 C-2,3.4 -2.8,3.2 -3.2,2.6 Z"
+        fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.55" strokeOpacity="0.65" />
+      {/* colita pelona enroscada */}
+      <path d="M-3,2.2 C-5.2,2.4 -6.2,1 -5.6,-0.4" fill="none" stroke="#9ff0ff" strokeWidth="0.6"
+        strokeLinecap="round" opacity="0.7" />
+      {/* orejita desnuda */}
+      <path d="M2.6,-1.4 C2.2,-3.4 4.4,-4.2 5,-2.4 C4.6,-1.6 3.6,-1.2 2.6,-1.4 Z"
+        fill="#141a3a" stroke="#9ff0ff" strokeWidth="0.45" strokeOpacity="0.6" />
+      {/* cabecita con hocico ya puntudo */}
+      <path d="M2.4,-0.6 C4,-1.6 5.6,-1 6.8,0 C7.4,0.5 7.3,1.3 6.6,1.3 C5.8,0.7 4.6,0.4 3.6,0.7
+               C2.8,0.9 2.3,0.2 2.4,-0.6 Z"
+        fill="#1c1338" stroke="#9ff0ff" strokeWidth="0.5" strokeOpacity="0.65" />
+      <circle cx="6.5" cy="1.1" r="0.4" fill="#ffc0dc" opacity="0.9" />
+      {/* ojito */}
+      <circle cx="4" cy="-0.3" r="0.5" fill="#04160f" />
+      <circle cx="4.15" cy="-0.45" r="0.18" fill="#eafff6" />
+      {/* manito que AGARRA el pelo de la madre */}
+      <path d="M-1,3 C-1.4,4 -1.2,4.8 -0.4,5" fill="none" stroke="#9ff0ff" strokeWidth="0.6"
+        strokeLinecap="round" opacity="0.75" />
+      <path d="M2,3.2 C2,4.2 2.4,4.8 3.2,5" fill="none" stroke="#9ff0ff" strokeWidth="0.6"
+        strokeLinecap="round" opacity="0.75" />
+    </g>
+  );
+}
+
+/* Currucutú (Megascops choliba) — PERSONAJE COMPLETO, no silueta.
+   Rasgos diagnósticos reales del estrígido andino: disco facial marcado con
+   REBORDE oscuro, penachos auriculares erectos, ojos amarillos frontales
+   enormes, patrón CRÍPTICO de corteza en el plumaje (estrías verticales +
+   barrado fino) y postura vertical compacta con garras prensiles agarrando la
+   madera. Anatomía = el efecto especial: si Julieta lo mira, entiende que ese
+   pájaro está hecho para ver y agarrar en lo oscuro.
+   Animación: respira (squash&stretch del pecho), gira la cabeza como búho,
+   parpadea y le tiemblan los penachos. Contorno con line-boil rubber-hose. */
 function AvatarBuho() {
+  const uid = useId().replace(/[:]/g, '');
+  const boilId = `cn-boil-buho-${uid}`;
+
   return (
     <g className="cn-av-flota" filter="url(#cn-glow1)">
-      <ellipse cx="0" cy="15" rx="12" ry="2.6" fill="#000" opacity="0.38" />
-      <path d="M-10,13 C-12,2 -8,-10 0,-11 C8,-10 12,2 10,13 C7,16 -7,16 -10,13 Z" fill="#171030" stroke="#ffcf5a" strokeWidth="0.9" strokeOpacity="0.55" />
-      {/* barrado del pecho */}
-      <path d="M-5,2 Q0,4 5,2 M-6,6 Q0,8 6,6 M-5,10 Q0,12 5,10" fill="none" stroke="#ffe6a6" strokeWidth="0.8" opacity="0.45" />
-      {/* penachos */}
-      <path d="M-9,-8 L-6,-15.5 L-3,-8 Z" fill="#1c1338" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.6" />
-      <path d="M9,-8 L6,-15.5 L3,-8 Z" fill="#1c1338" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.6" />
-      {/* disco facial */}
-      <ellipse cx="0" cy="-5" rx="9" ry="8" fill="#1c1338" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.45" />
-      {/* ojos enormes */}
-      <circle cx="-3.6" cy="-5" r="3.4" fill="#04160f" stroke="#ffd76a" strokeWidth="1" />
-      <circle cx="3.6" cy="-5" r="3.4" fill="#04160f" stroke="#ffd76a" strokeWidth="1" />
-      <circle cx="-3.6" cy="-5" r="1.7" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 4px #ffd76a)' }} />
-      <circle cx="3.6" cy="-5" r="1.7" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 4px #ffd76a)' }} />
-      <circle cx="-3" cy="-5.7" r="0.55" fill="#eafff6" />
-      <circle cx="4.2" cy="-5.7" r="0.55" fill="#eafff6" />
-      {/* pico */}
-      <path d="M-1.4,-2 L1.4,-2 L0,1.6 Z" fill="#ffcf5a" />
-      {/* garras */}
-      <path d="M-4,14 l0,2 M4,14 l0,2" stroke="#ffcf5a" strokeWidth="1.4" strokeLinecap="round" />
+      <defs>
+        <LineBoilFilter id={boilId} baseFrequency={0.038} scale={1.8} animated={!CN_REDUCED} dur="0.42s" />
+      </defs>
+
+      <ellipse cx="0" cy="19" rx="14" ry="2.6" fill="#000" opacity="0.34" />
+
+      {/* ── la rama: le da suelo, escala y oficio de vigía ── */}
+      <g filter={`url(#${boilId})`}>
+        <path d="M-19,15.4 C-9,14 9,14 19,15.6 C19,17.8 -19,17.6 -19,15.4 Z"
+          fill="#141a3a" stroke="#ffcf5a" strokeWidth="0.8" strokeOpacity="0.42" />
+        <path d="M-15,16.2 C-6,15.2 7,15.2 15,16.4" fill="none" stroke="#ffe6a6" strokeWidth="0.5" opacity="0.3" />
+        {/* muñón de rama seca */}
+        <path d="M13,15 C16,12.6 18.6,12 20.4,12.6 C18.6,13.6 17,14.4 16,15.4 Z"
+          fill="#141a3a" stroke="#ffcf5a" strokeWidth="0.6" strokeOpacity="0.35" />
+      </g>
+
+      {/* ── cuerpo: masa compacta que RESPIRA ── */}
+      <g className="cn-buho-respira">
+        <g filter={`url(#${boilId})`}>
+          {/* cola corta bajo el cuerpo */}
+          <path d="M-5,10 C-4.6,15.6 4.6,15.6 5,10 Z" fill="#141a3a" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.5" />
+          <path d="M-2.6,11.4 L-2.2,15 M0,11.6 L0,15.4 M2.6,11.4 L2.2,15" stroke="#0f0a24" strokeWidth="0.7" opacity="0.8" />
+
+          {/* torso rechoncho, hombros anchos y panza de búho posado */}
+          <path d="M-10.6,-2 C-12.4,4 -10.4,11.4 -0.2,13.8 C10,11.6 12.4,4 10.6,-2 C8.6,-7.4 -8.6,-7.4 -10.6,-2 Z"
+            fill="#171030" stroke="#ffcf5a" strokeWidth="0.9" strokeOpacity="0.55" />
+
+          {/* volumen: el vientre recibe la luz de la luna */}
+          <path d="M-6.6,1 C-7.4,6 -5.2,10.6 0,12.4 C5.2,10.6 7.4,6 6.6,1 C4,-1.4 -4,-1.4 -6.6,1 Z"
+            fill="#1c1338" opacity="0.85" />
+
+          {/* patrón CRÍPTICO de corteza: estrías verticales + barrado fino */}
+          <path d="M-4.4,0.6 C-4.8,4 -4.6,8 -3.6,11 M0,-0.2 C-0.3,4 -0.2,8.4 0,12
+                   M4.4,0.6 C4.8,4 4.6,8 3.6,11"
+            fill="none" stroke="#0f0a24" strokeWidth="1.1" strokeLinecap="round" opacity="0.9" />
+          <path d="M-6,2.4 Q0,4 6,2.4 M-6.6,5.6 Q0,7.2 6.6,5.6 M-5.6,8.8 Q0,10.4 5.6,8.8"
+            fill="none" stroke="#ffe6a6" strokeWidth="0.7" opacity="0.4" />
+
+          {/* ── alas plegadas: escapulares escalonadas, no una mancha plana ── */}
+          <path d="M-10.6,-2.4 C-13.4,3 -12.6,10 -7.6,13.2 C-6,9.8 -6.2,3 -7.4,-2.4 Z"
+            fill="#141a3a" stroke="#ffcf5a" strokeWidth="0.8" strokeOpacity="0.55" />
+          <path d="M10.6,-2.4 C13.4,3 12.6,10 7.6,13.2 C6,9.8 6.2,3 7.4,-2.4 Z"
+            fill="#141a3a" stroke="#ffcf5a" strokeWidth="0.8" strokeOpacity="0.55" />
+          {/* escalones de pluma (coberteras) */}
+          <path d="M-11.6,1.6 C-9.6,2.6 -8,2.4 -7,1.6 M-12,5.4 C-10,6.4 -8.4,6.2 -7.2,5.4 M-11.4,9.2 C-9.6,10.2 -8.2,10 -7,9.2"
+            fill="none" stroke="#ffe6a6" strokeWidth="0.6" opacity="0.45" />
+          <path d="M11.6,1.6 C9.6,2.6 8,2.4 7,1.6 M12,5.4 C10,6.4 8.4,6.2 7.2,5.4 M11.4,9.2 C9.6,10.2 8.2,10 7,9.2"
+            fill="none" stroke="#ffe6a6" strokeWidth="0.6" opacity="0.45" />
+        </g>
+
+        {/* ── GARRAS PRENSILES agarrando la madera (rasgo diagnóstico) ── */}
+        {/* tarsos emplumados */}
+        <path d="M-5.4,11 C-6.6,12.4 -6.6,13.6 -5.6,14.2 C-4.4,13.8 -4.2,12.4 -4.6,11 Z"
+          fill="#1c1338" stroke="#ffcf5a" strokeWidth="0.5" strokeOpacity="0.5" />
+        <path d="M5.4,11 C6.6,12.4 6.6,13.6 5.6,14.2 C4.4,13.8 4.2,12.4 4.6,11 Z"
+          fill="#1c1338" stroke="#ffcf5a" strokeWidth="0.5" strokeOpacity="0.5" />
+        {/* dedos que ABRAZAN la rama */}
+        <g stroke="#ffcf5a" strokeWidth="1.5" strokeLinecap="round" fill="none" opacity="0.92">
+          <path d="M-5.2,13.6 C-7.4,14 -8.8,15 -9.2,16.4" />
+          <path d="M-5.2,13.6 C-5.4,14.8 -5.2,15.8 -5,16.8" />
+          <path d="M-5.2,13.6 C-3.4,14.2 -2.4,15.2 -2.2,16.4" />
+          <path d="M5.2,13.6 C7.4,14 8.8,15 9.2,16.4" />
+          <path d="M5.2,13.6 C5.4,14.8 5.2,15.8 5,16.8" />
+          <path d="M5.2,13.6 C3.4,14.2 2.4,15.2 2.2,16.4" />
+        </g>
+        {/* uñas */}
+        <g fill="#eafff6" opacity="0.75">
+          <circle cx="-9.3" cy="16.7" r="0.45" /><circle cx="-5" cy="17.1" r="0.45" /><circle cx="-2.1" cy="16.7" r="0.45" />
+          <circle cx="9.3" cy="16.7" r="0.45" /><circle cx="5" cy="17.1" r="0.45" /><circle cx="2.1" cy="16.7" r="0.45" />
+        </g>
+      </g>
+
+      {/* ── CABEZA: gira como búho, sin mover el cuerpo ── */}
+      <g className="cn-buho-cabeza">
+        {/* penachos auriculares erectos (mechones) */}
+        <g className="cn-buho-penacho">
+          <path d="M-9.6,-9.6 C-11.4,-14.6 -10,-18.6 -7.6,-19.4 C-7,-16 -6.2,-12.6 -5,-10.2 Z"
+            fill="#171030" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.6" />
+          <path d="M-9,-11.4 C-9.8,-14.6 -9,-17 -7.8,-18" fill="none" stroke="#ffe6a6" strokeWidth="0.5" opacity="0.45" />
+        </g>
+        <g className="cn-buho-penacho cn-buho-penacho-r">
+          <path d="M9.6,-9.6 C11.4,-14.6 10,-18.6 7.6,-19.4 C7,-16 6.2,-12.6 5,-10.2 Z"
+            fill="#171030" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.6" />
+          <path d="M9,-11.4 C9.8,-14.6 9,-17 7.8,-18" fill="none" stroke="#ffe6a6" strokeWidth="0.5" opacity="0.45" />
+        </g>
+
+        {/* DISCO FACIAL con reborde oscuro (el rasgo que lo hace currucutú) */}
+        <path d="M0,-16.4 C-7.4,-16.8 -11.4,-12 -11,-6 C-10.6,-0.6 -5.6,2.6 0,2.6 C5.6,2.6 10.6,-0.6 11,-6 C11.4,-12 7.4,-16.8 0,-16.4 Z"
+          fill="#1c1338" stroke="#0f0a24" strokeWidth="1.6" strokeOpacity="0.95" />
+        <path d="M0,-16.4 C-7.4,-16.8 -11.4,-12 -11,-6 C-10.6,-0.6 -5.6,2.6 0,2.6 C5.6,2.6 10.6,-0.6 11,-6 C11.4,-12 7.4,-16.8 0,-16.4 Z"
+          fill="none" stroke="#ffcf5a" strokeWidth="0.7" strokeOpacity="0.5" />
+        {/* plumitas radiales del disco */}
+        <g stroke="#ffe6a6" strokeWidth="0.45" fill="none" opacity="0.32">
+          <path d="M-8.6,-11.4 C-6.6,-10 -5.4,-8.6 -4.8,-7.2" />
+          <path d="M-9.8,-6.4 C-7.4,-6 -6,-5.4 -5,-4.6" />
+          <path d="M-8.4,-1.4 C-6.4,-2 -5,-2.6 -4.2,-3.4" />
+          <path d="M8.6,-11.4 C6.6,-10 5.4,-8.6 4.8,-7.2" />
+          <path d="M9.8,-6.4 C7.4,-6 6,-5.4 5,-4.6" />
+          <path d="M8.4,-1.4 C6.4,-2 5,-2.6 4.2,-3.4" />
+        </g>
+        {/* cejas crípticas: la expresión seria del cazador */}
+        <path d="M-8.6,-10.2 C-6.6,-12.4 -2.6,-12.6 -1,-10.6 M8.6,-10.2 C6.6,-12.4 2.6,-12.6 1,-10.6"
+          fill="none" stroke="#0f0a24" strokeWidth="1.5" strokeLinecap="round" opacity="0.85" />
+
+        {/* OJOS AMARILLOS FRONTALES ENORMES */}
+        <circle cx="-4.4" cy="-6.4" r="4.3" fill="#04160f" stroke="#ffd76a" strokeWidth="1.1" />
+        <circle cx="4.4" cy="-6.4" r="4.3" fill="#04160f" stroke="#ffd76a" strokeWidth="1.1" />
+        <circle cx="-4.4" cy="-6.4" r="2.7" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 5px #ffd76a)' }} />
+        <circle cx="4.4" cy="-6.4" r="2.7" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 5px #ffd76a)' }} />
+        <circle cx="-4.4" cy="-6.4" r="1.35" fill="#04160f" />
+        <circle cx="4.4" cy="-6.4" r="1.35" fill="#04160f" />
+        <circle cx="-3.4" cy="-7.6" r="0.75" fill="#eafff6" />
+        <circle cx="5.4" cy="-7.6" r="0.75" fill="#eafff6" />
+        {/* párpados (parpadeo) */}
+        <circle className="cn-buho-parpado" cx="-4.4" cy="-6.4" r="4.3" fill="#1c1338" />
+        <circle className="cn-buho-parpado" cx="4.4" cy="-6.4" r="4.3" fill="#1c1338" />
+
+        {/* pico ganchudo entre los ojos */}
+        <path d="M-1.7,-3.4 C-1.4,-1 -0.7,0.6 0,1.6 C0.7,0.6 1.4,-1 1.7,-3.4 Z" fill="#ffcf5a" />
+        <path d="M0,0.4 C-0.5,1 -0.2,1.8 0.4,1.6" fill="none" stroke="#ffe6a6" strokeWidth="0.5" opacity="0.8" />
+      </g>
     </g>
   );
 }
 
-/* Murciélago nectarívoro (Glossophaga soricina): alas membranosas abiertas,
-   hocico largo y lengua de glow; en vuelo. Acento violeta. */
+/* Murciélago nectarívoro (Glossophaga soricina) — PERSONAJE COMPLETO.
+   Pose: cernido de alimentación sobre una flor nocturna, con la LENGUA
+   larguísima extensible (el rasgo diagnóstico) metida en la corola — la
+   polinización pasando en vivo. El ala de un murciélago es una MANO: húmero,
+   muñeca con pulgar-garfio y cuatro dedos larguísimos como huesos visibles
+   dentro del patagio festoneado (nada de ala de pájaro). Uropatagio entre las
+   patas, hoja nasal en el hocico, polen dorado pegado al hocico. Vuelo de
+   aleteo rápido y errático (cernido irregular, nunca planeo). Acento violeta. */
 function AvatarMurcielago() {
   return (
-    <g className="cn-av-vuela" filter="url(#cn-glow1)">
-      <path className="cn-ala-mur" d="M-2,-2 C-9,-8 -19,-8 -24,-2 C-20,-2.6 -16,-1.4 -14,1.6 C-12,-0.6 -9.5,-0.4 -8,1.4 C-6,-0.4 -4,-0.4 -2,1 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.8" strokeOpacity="0.7" />
-      <path className="cn-ala-mur" style={{ animationDelay: '-0.05s' }} d="M2,-2 C9,-8 19,-8 24,-2 C20,-2.6 16,-1.4 14,1.6 C12,-0.6 9.5,-0.4 8,1.4 C6,-0.4 4,-0.4 2,1 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.8" strokeOpacity="0.7" />
-      <ellipse cx="0" cy="0.5" rx="3.2" ry="5.4" fill="#171030" stroke="#c78bff" strokeWidth="0.8" strokeOpacity="0.6" />
-      {/* cabeza + orejas */}
-      <circle cx="0" cy="-5" r="3" fill="#1c1338" stroke="#c78bff" strokeWidth="0.7" strokeOpacity="0.6" />
-      <path d="M-2.4,-7 L-3.6,-10.4 L-1,-8 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.6" />
-      <path d="M2.4,-7 L3.6,-10.4 L1,-8 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.6" />
-      {/* hocico largo + lengua */}
-      <path d="M-1.2,-3 L1.2,-3 L0,1 Z" fill="#c78bff" opacity="0.9" />
-      <path d="M0,1 L0,4.2" stroke="#f0d9ff" strokeWidth="0.9" strokeLinecap="round" style={{ filter: 'drop-shadow(0 0 3px #e6c6ff)' }} />
-      {/* ojos */}
-      <circle cx="-1.2" cy="-5.2" r="0.7" fill="#f0d9ff" style={{ filter: 'drop-shadow(0 0 3px #e6c6ff)' }} />
-      <circle cx="1.2" cy="-5.2" r="0.7" fill="#f0d9ff" style={{ filter: 'drop-shadow(0 0 3px #e6c6ff)' }} />
+    <g filter="url(#cn-glow1)">
+      {/* ── flor nocturna anclada (abre al oscurecer): campana pálida ── */}
+      <path d="M20,22 C18.4,17.8 16.4,14.6 14.4,12.4" fill="none" stroke="#6fe6c0" strokeWidth="1" strokeLinecap="round" opacity="0.45" />
+      <path d="M17.6,17.4 C19.4,17 20.8,17.6 21.6,18.8 C20,19.4 18.4,18.8 17.6,17.4 Z" fill="#6fe6c0" opacity="0.35" />
+      {/* pétalos traseros abriéndose hacia el visitante */}
+      <path d="M13.2,10.8 C11,9.4 9.6,7.4 9.4,5.6 C10.9,5.8 12.5,7.1 13.6,8.9 Z" fill="#eafff6" opacity="0.72" stroke="#c78bff" strokeWidth="0.5" strokeOpacity="0.4" />
+      <path d="M13.2,10.8 C12.4,8.4 12.6,6.2 13.9,4.7 C14.9,6.2 15.1,8.3 14.5,10.2 Z" fill="#eafff6" opacity="0.6" stroke="#c78bff" strokeWidth="0.5" strokeOpacity="0.4" />
+      <path d="M13.2,10.8 C14.9,9.8 16.7,9.6 18.1,10.3 C17.2,11.5 15.4,11.9 13.8,11.7 Z" fill="#eafff6" opacity="0.66" stroke="#c78bff" strokeWidth="0.5" strokeOpacity="0.4" />
+      {/* estambres con antera dorada: ahí queda el polen */}
+      <path d="M13,10.6 C11.6,9 10.6,7.6 10,6.4" fill="none" stroke="#f0d9ff" strokeWidth="0.5" opacity="0.7" />
+      <circle cx="9.8" cy="6.2" r="0.55" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 2.5px #ffd76a)' }} />
+      {/* ── ala LEJANA (subiendo, en contrafase): la mano foreshortened ── */}
+      <g className="cn-mur-ala-far" style={{ transformBox: 'fill-box', transformOrigin: '8% 96%' }}>
+        <path d="M0,-3 C2.2,-6.8 4.4,-10.4 6.5,-13.5 C9,-15 11.2,-16.4 13.5,-17.5 C13.2,-15.3 14.5,-13.5 16,-12 C14.7,-10.2 14.1,-8.4 14,-6.5 C11,-4.4 7,-2.6 4,-2 C2.6,-1.8 1,-2.2 0,-3 Z" fill="#171030" opacity="0.85" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.4" />
+        <path d="M6.5,-13.5 C9,-15 11.2,-16.4 13.5,-17.5 M6.5,-13.5 C9.6,-13.3 13,-12.6 16,-12 M6.5,-13.5 C8.9,-11.4 11.6,-8.8 14,-6.5" fill="none" stroke="#c78bff" strokeWidth="0.5" strokeOpacity="0.45" />
+      </g>
+      {/* ── el cuerpo: cernido errático (nunca en el mismo compás que la lengua) ── */}
+      <g className="cn-mur-cierne">
+        {/* torso peludito con boil de respiración */}
+        <g className="cn-boil">
+          <path d="M-2.2,-4.6 C0.4,-3 0.6,0 -1.6,1.6 C-4,3.2 -8,2 -10.4,-0.6 C-12,-2.6 -11.4,-5.4 -9,-6.6 C-6.6,-7.6 -4,-6.4 -2.2,-4.6 Z" fill="#171030" stroke="#c78bff" strokeWidth="0.9" strokeOpacity="0.6" />
+          {/* lomo iluminado + ticks de pelaje */}
+          <path d="M-9.6,-5.6 C-7.4,-6.6 -5,-6.2 -3.4,-4.8" fill="none" stroke="#eafff6" strokeWidth="0.7" opacity="0.45" />
+          <path d="M-9.8,-2.4 l-1,0.8 M-7.6,0.2 l-0.9,0.9 M-4.8,1.2 l-0.7,1" stroke="#c78bff" strokeWidth="0.5" strokeLinecap="round" opacity="0.4" />
+        </g>
+        {/* patas + UROPATAGIO (membrana entre las patas, rasgo real) */}
+        <path d="M-9.8,0.6 L-11,3.5 M-8.4,1.4 L-8,4.5" stroke="#0f0a24" strokeWidth="1.1" strokeLinecap="round" />
+        <path d="M-11,3.5 C-10.4,5.9 -9,6.4 -8,4.5 C-8.6,3.4 -10,3 -11,3.5 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.5" />
+        {/* cabeza inclinada hacia la flor */}
+        <circle cx="2" cy="0" r="3.1" fill="#1c1338" stroke="#c78bff" strokeWidth="0.8" strokeOpacity="0.6" />
+        {/* orejas medianas SEPARADAS (no de orejón) */}
+        <path d="M0.4,-2.6 C-0.8,-6.4 1.6,-7.6 2.6,-4.6 C2.4,-3.5 1.6,-2.8 0.4,-2.6 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.6" />
+        <path d="M3.4,-2.9 C3.4,-6.6 6,-6.9 6.4,-4.2 C5.7,-3.2 4.6,-2.8 3.4,-2.9 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.6" strokeOpacity="0.6" />
+        <path d="M1.2,-4.6 C1.4,-3.9 1.4,-3.4 1.2,-3 M4.6,-4.8 C4.7,-4.1 4.7,-3.6 4.5,-3.2" stroke="#f0d9ff" strokeWidth="0.4" fill="none" opacity="0.5" />
+        {/* hocico ALARGADO de nectarívoro con hoja nasal */}
+        <path d="M3.2,-1.6 C6,-0.8 7.8,1.4 8.4,4 C8.6,4.9 7.8,5.4 7,4.9 C5.4,3.8 3.6,2 2.6,0.2 Z" fill="#1c1338" stroke="#c78bff" strokeWidth="0.7" strokeOpacity="0.6" />
+        <path d="M7.5,3.2 L8.8,4.2 L7.4,4.8 Z" fill="#c78bff" opacity="0.9" />
+        {/* ojo de goma: pupila grande, iris con glow, catchlight vivo */}
+        <g className="cn-parpadeo">
+          <circle cx="3.6" cy="0.4" r="1.25" fill="#04160f" stroke="#c78bff" strokeWidth="0.6" />
+          <g className="cn-mirada">
+            <circle cx="3.7" cy="0.5" r="0.75" fill="#e6c6ff" style={{ filter: 'drop-shadow(0 0 3px #e6c6ff)' }} />
+            <circle cx="3.4" cy="0.1" r="0.34" fill="#eafff6" />
+          </g>
+        </g>
+        {/* LA LENGUA: extensible, con glow, lamiendo el néctar (dasharray) */}
+        <path className="cn-mur-lengua" pathLength="10" d="M7.6,5.2 C9.4,6.6 11.2,8.4 12.8,10.4" fill="none" stroke="#f0d9ff" strokeWidth="1.15" strokeLinecap="round" style={{ filter: 'drop-shadow(0 0 3.5px #e6c6ff)' }} />
+        {/* polen dorado pegado al hocico: se lo lleva a la próxima flor */}
+        <circle cx="6.6" cy="3.1" r="0.4" fill="#ffd76a" opacity="0.9" style={{ filter: 'drop-shadow(0 0 2px #ffd76a)' }} />
+        <circle cx="7.5" cy="4.3" r="0.3" fill="#ffd76a" opacity="0.75" />
+      </g>
+      {/* pétalo delantero: tapa la punta de la lengua → se ve ADENTRO de la flor */}
+      <path d="M11.4,9.4 C12.4,11 14.2,11.8 16,11.4 C14.6,12.6 12.4,12.2 11,10.6 Z" fill="#eafff6" opacity="0.82" stroke="#c78bff" strokeWidth="0.5" strokeOpacity="0.45" />
+      {/* motas de polen en el aire entre flor y hocico */}
+      <circle className="cn-mur-polen" cx="11.2" cy="7.2" r="0.45" fill="#ffd76a" />
+      <circle className="cn-mur-polen" style={{ animationDelay: '-1.3s' }} cx="9.2" cy="4.6" r="0.35" fill="#e6c6ff" />
+      {/* ── ala CERCANA: la MANO desplegada — húmero, muñeca, pulgar y 4 dedos ── */}
+      <g className="cn-mur-ala" style={{ transformBox: 'fill-box', transformOrigin: '94% 90%' }}>
+        {/* patagio: membrana festoneada colgada de los dedos */}
+        <path d="M-3,-4 C-6.6,-7.2 -10,-10.6 -13,-13 C-16.6,-13.6 -20.2,-13.5 -23.5,-13.2 C-22.6,-11 -23.4,-8.6 -24.8,-7.6 C-22.6,-6 -21.4,-4.2 -20.8,-2.2 C-18.6,-1.6 -16.6,0 -15,1.8 C-13.2,1.4 -11.2,1.2 -9.6,1.6 C-7.4,-0.6 -5,-2.2 -3,-4 Z" fill="#1c1338" fillOpacity="0.94" stroke="#c78bff" strokeWidth="0.8" strokeOpacity="0.7" />
+        {/* el brazo (húmero + radio) hasta la muñeca */}
+        <path d="M-3,-4 C-6.6,-7.2 -10,-10.6 -13,-13" fill="none" stroke="#c78bff" strokeWidth="1.2" strokeLinecap="round" opacity="0.85" />
+        {/* pulgar con garfio libre en la muñeca (con eso se agarra) */}
+        <path d="M-13,-13 L-14.2,-15" stroke="#eafff6" strokeWidth="0.8" strokeLinecap="round" opacity="0.85" />
+        {/* los CUATRO dedos larguísimos: huesos visibles dentro de la membrana */}
+        <path d="M-13,-13 C-16.6,-13.5 -20.2,-13.4 -23.5,-13.2 M-13,-13 C-17,-11.4 -21.4,-9.4 -24.8,-7.6 M-13,-13 C-15.8,-9.6 -18.6,-5.6 -20.8,-2.2 M-13,-13 C-14.2,-8.6 -14.8,-3 -15,1.8" fill="none" stroke="#c78bff" strokeWidth="0.7" strokeLinecap="round" opacity="0.8" />
+        {/* nudillos de la muñeca: la articulación de la mano-ala */}
+        <circle cx="-13" cy="-13" r="0.7" fill="#eafff6" opacity="0.8" />
+      </g>
     </g>
   );
 }
@@ -253,61 +666,196 @@ function AvatarMarteja() {
   );
 }
 
-/* Gurre / armadillo (Dasypus novemcinctus): caparazón abombado con bandas,
-   hocico largo, orejas tubulares y cola cónica. Acento menta. */
+/* Gurre / armadillo (Dasypus novemcinctus) — PERSONAJE COMPLETO.
+   Pose: la nariz AL SUELO, husmeando y escarbando — su gesto de siempre.
+   Anatomía real: caparazón óseo con escudo escapular y pélvico RÍGIDOS y
+   exactamente NUEVE bandas móviles en la cintura (cuéntelas: de ahí el
+   nombre), hocico largo cónico, orejas tubulares erguidas, cola anillada que
+   se afina, garras delanteras ENORMES de excavador. La tierra vuela con cada
+   zarpazo: así airea el suelo de la finca. Acento menta. */
 function AvatarArmadillo() {
   return (
-    <g className="cn-av-camina" filter="url(#cn-glow1)">
-      <ellipse cx="0" cy="13" rx="16" ry="3" fill="#000" opacity="0.38" />
-      <path d="M-13,6 C-19,7 -22,4 -23.5,1" fill="none" stroke="#6fe6c0" strokeWidth="1.6" strokeLinecap="round" opacity="0.8" />
-      {/* caparazón */}
-      <path d="M-13,9 C-14,-1 -6,-7 3,-7 C11,-7 15,-1 15,7 C15,10 10,12 0,12 C-8,12 -12,11 -13,9 Z" fill="#141a3a" stroke="#6fe6c0" strokeWidth="0.9" strokeOpacity="0.65" />
-      {/* bandas */}
-      <path d="M-6,-6 C-7,-1 -7,6 -6,11" stroke="#8ff0d4" strokeWidth="0.8" fill="none" opacity="0.55" />
-      <path d="M-1,-7 C-2,-1 -2,7 -1,12" stroke="#8ff0d4" strokeWidth="0.8" fill="none" opacity="0.55" />
-      <path d="M4,-7 C3,-1 3,7 4,12" stroke="#8ff0d4" strokeWidth="0.8" fill="none" opacity="0.55" />
-      <path d="M9,-5 C9.5,0 9.5,7 9,11" stroke="#8ff0d4" strokeWidth="0.8" fill="none" opacity="0.5" />
-      <path d="M-10,3 C-6,1 8,1 13,4" stroke="#8ff0d4" strokeWidth="0.7" fill="none" opacity="0.4" />
-      <path d="M-8,11 L-8,7 M2,12 L2,7.5 M10,10 L10,6" stroke="#0f0a24" strokeWidth="3" strokeLinecap="round" />
-      {/* cabeza + hocico largo */}
-      <path d="M13,-1 C19,-2 24,0 25.4,3 C26,4.4 25,5.4 23.4,5 C22.4,3 19,2 15,2.6 C13.6,2.8 13,0.8 13,-1 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.8" strokeOpacity="0.6" />
-      {/* orejas tubulares */}
-      <path d="M9,-5 C8,-11 13,-12 14,-7 C13,-5.5 11,-5 9,-5 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.7" strokeOpacity="0.6" />
-      <circle cx="16.6" cy="0" r="1" fill="#04160f" />
-      <circle cx="16.6" cy="0" r="1" fill="none" stroke="#6fe6c0" strokeWidth="0.6" />
-      <circle cx="16.9" cy="-0.4" r="0.35" fill="#eafff6" />
-      <circle cx="24.8" cy="3.6" r="1" fill="#8ff0d4" opacity="0.9" />
+    <g filter="url(#cn-glow1)">
+      <ellipse cx="-1" cy="14.2" rx="17" ry="2.8" fill="#000" opacity="0.38" />
+      {/* montículo de tierra recién escarbada bajo la nariz */}
+      <path d="M12.5,13.6 C14,11.8 17.5,11.6 19.5,13.2 C17,13.9 14.5,14 12.5,13.6 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.5" strokeOpacity="0.4" />
+      {/* tierra que vuela con el zarpazo (misma cadencia del escarbe) */}
+      <g className="cn-gurre-tierra">
+        <circle cx="11.6" cy="11.4" r="0.6" fill="#8ff0d4" opacity="0.9" />
+        <circle cx="10" cy="12.4" r="0.45" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.4" />
+        <circle cx="12.8" cy="10.2" r="0.35" fill="#8ff0d4" opacity="0.7" />
+      </g>
+      <g className="cn-av-camina">
+        {/* cola anillada que se AFINA (dos tramos: grueso → punta fina) */}
+        <path d="M-14,6 C-18.6,6.8 -21.8,8.6 -23.6,11" fill="none" stroke="#6fe6c0" strokeWidth="2" strokeLinecap="round" opacity="0.8" />
+        <path d="M-23.6,11 C-24.4,12 -24.9,12.8 -25.2,13.4" fill="none" stroke="#6fe6c0" strokeWidth="1" strokeLinecap="round" opacity="0.8" />
+        <path d="M-16.6,6.1 l-0.5,1.9 M-19.2,7 l-0.7,1.8 M-21.5,8.4 l-0.9,1.6 M-23.3,10.4 l-1,1.3" stroke="#0f0a24" strokeWidth="0.8" strokeLinecap="round" opacity="0.85" />
+        {/* patas lejanas (en penumbra) */}
+        <path d="M-9.5,10 L-9.5,13.6 M5.5,7.5 L5.5,13.2" stroke="#0f0a24" strokeWidth="2.6" strokeLinecap="round" opacity="0.8" />
+        {/* ── el caparazón: respira con boil de goma ── */}
+        <g className="cn-boil">
+          <path d="M-14.5,10 C-17,3 -14,-4 -7.5,-7 C-2,-9.2 4,-8.6 8,-5.4 C10.6,-3.2 12,-0.4 12.2,2.6 C12.3,4.6 11,5.8 9,6.2 C3,7.8 -3,9.6 -8,11.2 C-11.5,11.4 -13.8,11 -14.5,10 Z" fill="#141a3a" stroke="#6fe6c0" strokeWidth="0.9" strokeOpacity="0.65" />
+          {/* filo del lomo iluminado: el volumen del domo */}
+          <path d="M-12.6,1 C-10,-4.4 -4.6,-7.6 1.4,-7.6" fill="none" stroke="#eafff6" strokeWidth="0.7" opacity="0.4" />
+          {/* borde del escudo ESCAPULAR (rígido, adelante) */}
+          <path d="M5.2,-7.9 C4.4,-3.4 4.6,1.6 5.8,6.9" fill="none" stroke="#8ff0d4" strokeWidth="0.9" opacity="0.7" />
+          {/* borde del escudo PÉLVICO (rígido, atrás) */}
+          <path d="M-5.8,-7.5 C-6.6,-1.6 -6.4,4.4 -5.4,10.4" fill="none" stroke="#8ff0d4" strokeWidth="0.9" opacity="0.7" />
+          {/* las NUEVE bandas móviles de la cintura — exactamente nueve */}
+          {Array.from({ length: 9 }, (_, i) => {
+            const x = -4.6 + i * 1.15;
+            return (
+              <path
+                key={i}
+                d={`M${x.toFixed(2)},-7.6 C${(x - 0.7).toFixed(2)},-2.4 ${(x - 0.5).toFixed(2)},3.2 ${(x + 0.4).toFixed(2)},${(9.2 - i * 0.28).toFixed(2)}`}
+                fill="none" stroke="#8ff0d4" strokeWidth="0.6" opacity={i % 2 ? 0.42 : 0.58}
+              />
+            );
+          })}
+          {/* escamas (escudos poligonales) punteadas sobre los escudos rígidos */}
+          <path d="M-11.5,3 l1.2,-0.4 M-10.8,-1.6 l1.2,-0.3 M-9,-4.8 l1.2,-0.2 M7.6,-3.4 l1.1,0.5 M8.8,0 l1.1,0.5 M8.6,3.4 l1.1,0.3" stroke="#6fe6c0" strokeWidth="0.5" strokeLinecap="round" opacity="0.45" />
+        </g>
+        {/* patas cercanas: cortas y macizas de excavador */}
+        <path d="M-11,10.8 L-11,14 M2.5,8.6 L2.5,13.8" stroke="#0f0a24" strokeWidth="3" strokeLinecap="round" />
+        {/* ── cabeza husmeando: baja hasta el suelo, olfatea con vaho ── */}
+        <g className="cn-gurre-nariz" style={{ transformBox: 'fill-box', transformOrigin: '12% 18%' }}>
+          {/* cuello + cabeza con placas y hocico largo CÓNICO hasta la tierra */}
+          <path d="M10.6,1.4 C13.4,2 16,4.4 18.2,7.6 C19.4,9.4 20.3,11.2 20.8,12.6 C21.1,13.5 20.2,14.1 19.3,13.5 C17.3,12.1 14.6,10 12.6,7.8 C11.2,6.2 10.4,3.6 10.6,1.4 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.8" strokeOpacity="0.6" />
+          {/* placas de la frente (el gurre lleva casco propio) */}
+          <path d="M11.8,3.4 C13.2,3.8 14.6,4.9 15.8,6.4 M12.8,2.6 C13.6,2.9 14.4,3.5 15.2,4.3" fill="none" stroke="#8ff0d4" strokeWidth="0.5" opacity="0.5" />
+          {/* orejas TUBULARES erguidas (dos tubos, no conos) */}
+          <path d="M10.4,1.6 C9.8,-3.2 12,-4.2 12.8,-0.6 C12.2,0.6 11.4,1.3 10.4,1.6 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.7" strokeOpacity="0.65" />
+          <path d="M8.2,1.2 C7.6,-2.8 9.7,-3.8 10.4,-0.6 C9.9,0.4 9.1,1 8.2,1.2 Z" fill="#1c2350" stroke="#6fe6c0" strokeWidth="0.7" strokeOpacity="0.65" />
+          <path d="M11.3,-2.6 C11.5,-1.7 11.5,-0.9 11.4,-0.2" fill="none" stroke="#8ff0d4" strokeWidth="0.4" opacity="0.55" />
+          {/* ojito concentrado en el oficio (párpado a media asta) */}
+          <g className="cn-parpadeo">
+            <circle cx="14.2" cy="6" r="1" fill="#04160f" stroke="#6fe6c0" strokeWidth="0.6" />
+            <circle cx="14.5" cy="5.7" r="0.35" fill="#eafff6" />
+            <path d="M13.2,5.2 C13.9,4.9 14.7,4.9 15.3,5.3" fill="none" stroke="#1c2350" strokeWidth="0.7" />
+          </g>
+          {/* nariz rosada contra la tierra + vaho de husmeo subiendo */}
+          <circle cx="20.2" cy="12.9" r="0.75" fill="#8ff0d4" opacity="0.95" style={{ filter: 'drop-shadow(0 0 2.5px #8ff0d4)' }} />
+          <g className="cn-gurre-vaho">
+            <circle cx="21.4" cy="11.6" r="0.4" fill="#eafff6" />
+            <circle cx="22.2" cy="10.4" r="0.3" fill="#eafff6" />
+          </g>
+        </g>
+        {/* ── la GARRA excavadora: enorme, en pleno zarpazo ── */}
+        <g className="cn-gurre-pala" style={{ transformBox: 'fill-box', transformOrigin: '28% 10%' }}>
+          <path d="M9.4,5.6 C11,6.6 12.4,8.4 13.2,10.6" fill="none" stroke="#0f0a24" strokeWidth="2.6" strokeLinecap="round" />
+          {/* tres garras GRANDES de pala (el rasgo del oficio) */}
+          <path d="M13,10 L15.4,10.6 M13.3,10.9 L15.6,11.9 M13.1,11.7 L15,12.9" stroke="#eafff6" strokeWidth="0.9" strokeLinecap="round" opacity="0.9" />
+        </g>
+      </g>
     </g>
   );
 }
 
-/* Tigrillo / oncilla (Leopardus tigrinus): felino pequeño agazapado, orejas
-   puntudas, ojos de pupila vertical con glow, rosetas y cola anillada.
-   Acento coral. */
+/* Roseta ABIERTA del tigrillo: anillo INTERRUMPIDO de borde oscuro con el
+   centro leonado — el patrón real de Leopardus tigrinus (no lunar cerrado de
+   jaguar). Reutilizable en cualquier parte del cuerpo con escala y giro. */
+function RosetaAbierta({ cx, cy, s = 1, rot = 0 }) {
+  return (
+    <g transform={`translate(${cx} ${cy}) rotate(${rot}) scale(${s})`}>
+      <circle r="0.75" fill="#ffb066" opacity="0.48" />
+      <path d="M-1.1,-0.45 C-0.6,-1.15 0.4,-1.25 1.05,-0.7" fill="none" stroke="#ff7d5a" strokeWidth="0.6" strokeLinecap="round" opacity="0.6" />
+      <path d="M1.1,0.4 C0.6,1.05 -0.4,1.2 -1,0.65" fill="none" stroke="#ff7d5a" strokeWidth="0.6" strokeLinecap="round" opacity="0.45" />
+    </g>
+  );
+}
+
+/* Tigrillo / oncilla (Leopardus tigrinus) — PERSONAJE COMPLETO.
+   Felino PEQUEÑO (menos de 3 kg, tamaño de gato casero — NO un jaguar
+   chiquito): cabeza pequeña y redondeada, hocico corto, ojos grandes cuya
+   pupila se abre REDONDA en la noche, orejas amplias con la mancha blanca en
+   el dorso, rosetas abiertas de borde oscuro y centro leonado, y la cola
+   anillada casi tan larga como el cuerpo. Pose: agazapado ACECHANDO, con el
+   peso cargado atrás y un paso furtivo congelado. Acento coral. */
 function AvatarTigrillo() {
   return (
-    <g className="cn-av-flota" filter="url(#cn-glow1)">
-      <ellipse cx="0" cy="13" rx="16" ry="3" fill="#000" opacity="0.38" />
-      <path d="M13,7 C20,6 23,1 21,-4 C20,-6 17,-6 18,-3" fill="none" stroke="#ff7d5a" strokeWidth="1.8" strokeLinecap="round" opacity="0.85" />
-      <path d="M18.6,3.2 l2,0.6 M19.8,-0.8 l2,0.5" stroke="#ffb59a" strokeWidth="0.8" strokeLinecap="round" opacity="0.7" />
-      <path d="M-13,9 C-15,3 -9,-3 0,-4 C9,-4 14,1 14,7 C14,11 8,12 -3,12 C-9,12 -12,11 -13,9 Z" fill="#171030" stroke="#ff7d5a" strokeWidth="0.9" strokeOpacity="0.6" />
-      {/* rosetas */}
-      <circle cx="-4" cy="2" r="1.2" fill="none" stroke="#ff7d5a" strokeWidth="0.7" opacity="0.6" />
-      <circle cx="2" cy="4" r="1.1" fill="none" stroke="#ff7d5a" strokeWidth="0.7" opacity="0.55" />
-      <circle cx="7" cy="1" r="1" fill="none" stroke="#ff7d5a" strokeWidth="0.7" opacity="0.5" />
-      <path d="M-8,11 L-8,7 M-1,12 L-1,7.5 M7,11 L7,6.5" stroke="#0f0a24" strokeWidth="3" strokeLinecap="round" />
-      {/* cabeza */}
-      <circle cx="-10" cy="-5" r="6" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.9" strokeOpacity="0.6" />
-      {/* orejas puntudas */}
-      <path d="M-14,-9 L-15.5,-14 L-11,-11 Z" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.7" strokeOpacity="0.6" />
-      <path d="M-6,-9 L-4.5,-14 L-9,-11 Z" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.7" strokeOpacity="0.6" />
-      {/* ojos con pupila vertical */}
-      <ellipse cx="-12" cy="-5" rx="1.5" ry="2" fill="#04160f" stroke="#ffd76a" strokeWidth="0.7" />
-      <ellipse cx="-8" cy="-5" rx="1.5" ry="2" fill="#04160f" stroke="#ffd76a" strokeWidth="0.7" />
-      <path d="M-12,-6.2 L-12,-3.8 M-8,-6.2 L-8,-3.8" stroke="#ffd76a" strokeWidth="0.7" style={{ filter: 'drop-shadow(0 0 3px #ffd76a)' }} />
-      {/* hocico + nariz */}
-      <path d="M-11.4,-2 L-8.6,-2 L-10,-0.2 Z" fill="#ffb59a" opacity="0.85" />
-      <path d="M-9.4,-0.6 C-6.4,-0.2 -4.4,-0.8 -3.4,-1.8" stroke="#eafff6" strokeWidth="0.5" fill="none" opacity="0.6" />
+    <g filter="url(#cn-glow1)">
+      <ellipse cx="-1" cy="14" rx="16" ry="2.6" fill="#000" opacity="0.38" />
+      <g className="cn-tigri-acecha">
+        {/* ── cola LARGA anillada (casi tan larga como el cuerpo) ── */}
+        <g className="cn-tigri-cola" style={{ transformBox: 'fill-box', transformOrigin: '0% 100%' }}>
+          {/* rim neón bajo la cola para que no se funda con la noche */}
+          <path d="M11.8,6.2 C17,5.8 20.8,3 21.4,-2.4" fill="none" stroke="#ff7d5a" strokeWidth="3.3" strokeLinecap="round" opacity="0.3" />
+          <path d="M11.8,6.2 C17,5.8 20.8,3 21.4,-2.4" fill="none" stroke="#1c1338" strokeWidth="2.4" strokeLinecap="round" />
+          <path d="M12,5.2 C16.6,4.8 20,2.2 20.6,-2.2" fill="none" stroke="#ff7d5a" strokeWidth="0.5" opacity="0.55" />
+          {/* anillos oscuros de la cola */}
+          <path d="M14.6,4.6 l0.5,2.2 M17.2,3.4 l0.9,2 M19.4,1.2 l1.4,1.4 M20.6,-1 l1.7,0.6" stroke="#0f0a24" strokeWidth="1.2" strokeLinecap="round" opacity="0.9" />
+          {/* la punta: latigazo propio del cazador (flick súbito) */}
+          <g className="cn-tigri-colatip" style={{ transformBox: 'fill-box', transformOrigin: '100% 100%' }}>
+            <path d="M21.4,-2.4 C21.7,-5 21,-7.2 19.2,-7.8" fill="none" stroke="#ff7d5a" strokeWidth="3" strokeLinecap="round" opacity="0.3" />
+            <path d="M21.4,-2.4 C21.7,-5 21,-7.2 19.2,-7.8" fill="none" stroke="#1c1338" strokeWidth="2" strokeLinecap="round" />
+            <path d="M21.5,-4.4 l1.6,-0.2" stroke="#0f0a24" strokeWidth="1.1" strokeLinecap="round" opacity="0.9" />
+            <circle cx="19.1" cy="-7.7" r="1.05" fill="#0f0a24" stroke="#ff7d5a" strokeWidth="0.6" strokeOpacity="0.85" />
+          </g>
+        </g>
+        {/* ── cuerpo liviano agazapado: pecho a ras de tierra, peso ATRÁS ── */}
+        <g className="cn-boil">
+          <path d="M-12.6,9.6 C-13.8,7 -12.6,4.8 -9.6,4.4 C-5.4,3.8 -1.2,3 2.6,1.8 C6.4,0.6 10.4,1.4 12.2,4.4 C13.6,6.8 13.2,9.4 11,10.8 C7.4,13 -4,13.2 -9.8,12.2 C-11.6,11.9 -12.2,11 -12.6,9.6 Z" fill="#171030" stroke="#ff7d5a" strokeWidth="0.9" strokeOpacity="0.6" />
+          {/* la anca coilada: el resorte del salto cargado */}
+          <path d="M4.6,3.2 C8.8,2.6 11.6,4.6 11.8,8 C11.9,10.2 10.4,11.8 8.2,12.2" fill="none" stroke="#ff7d5a" strokeWidth="0.7" opacity="0.45" />
+          {/* línea del lomo iluminada */}
+          <path d="M-10.4,5.2 C-5.6,4.2 -0.6,3.2 3.4,2.2" fill="none" stroke="#eafff6" strokeWidth="0.6" opacity="0.35" />
+          {/* omóplato del paso furtivo: rompe la hogaza, marca el hombro */}
+          <path d="M-9.6,5.2 C-8,6.2 -7.3,8.2 -8,10.4" fill="none" stroke="#ff7d5a" strokeWidth="0.65" opacity="0.4" />
+          {/* rosetas ABIERTAS de centro leonado (patrón diagnóstico) */}
+          <RosetaAbierta cx={-6.2} cy={7} s={0.9} rot={-10} />
+          <RosetaAbierta cx={-1.5} cy={5.6} s={1} rot={18} />
+          <RosetaAbierta cx={3} cy={7.4} s={1.05} rot={-14} />
+          <RosetaAbierta cx={7.8} cy={5.2} s={1.1} rot={10} />
+          <RosetaAbierta cx={9.6} cy={8.8} s={0.85} rot={-22} />
+          <RosetaAbierta cx={-9.3} cy={9.4} s={0.7} rot={6} />
+        </g>
+        {/* pata trasera plantada (el peso vive aquí) */}
+        <path d="M11.4,8.6 C11.8,10.8 10.4,12 8.4,12.6" fill="none" stroke="#0f0a24" strokeWidth="2.2" strokeLinecap="round" />
+        <ellipse cx="7.8" cy="12.8" rx="1.7" ry="0.9" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.5" strokeOpacity="0.6" />
+        {/* patas delanteras: una plantada, la otra ALZADA a mitad de paso furtivo */}
+        <path d="M-11.6,8.8 C-12,10.2 -12.1,11.4 -12,12.4" fill="none" stroke="#0f0a24" strokeWidth="2.2" strokeLinecap="round" />
+        <ellipse cx="-12" cy="12.7" rx="1.5" ry="0.85" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.5" strokeOpacity="0.6" />
+        <path d="M-8.6,9.4 C-8.2,10.4 -8.1,11.2 -8.2,11.9" fill="none" stroke="#0f0a24" strokeWidth="2.2" strokeLinecap="round" />
+        <ellipse cx="-8.3" cy="12.1" rx="1.4" ry="0.8" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.5" strokeOpacity="0.6" />
+        {/* manchitas sólidas en las patas (allá la roseta se vuelve punto) */}
+        <circle cx="-11" cy="10.6" r="0.4" fill="#ff7d5a" opacity="0.5" />
+        <circle cx="10.2" cy="10.8" r="0.4" fill="#ff7d5a" opacity="0.5" />
+        {/* pelaje del pecho: ticks crema */}
+        <path d="M-12.2,6.6 l-1.2,0.7 M-12.6,8.2 l-1.3,0.4" stroke="#eafff6" strokeWidth="0.5" strokeLinecap="round" opacity="0.5" />
+        {/* ── cabeza PEQUEÑA y redondeada, baja, empujada adelante ── */}
+        <circle cx="-15.5" cy="0.2" r="4.1" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.9" strokeOpacity="0.6" />
+        {/* cuello que la une al pecho, con su rim coral para no romper el contorno */}
+        <path d="M-12.4,2.8 C-11.2,3.6 -10.2,4.4 -9.4,5.2" fill="none" stroke="#1c1338" strokeWidth="3.4" strokeLinecap="round" />
+        <path d="M-13.2,1.2 C-11.8,1.9 -10.6,2.9 -9.6,4" fill="none" stroke="#ff7d5a" strokeWidth="0.6" strokeLinecap="round" opacity="0.55" />
+        {/* oreja LEJANA: se ve el dorso → la mancha BLANCA (ocelo) visible */}
+        <path d="M-18.2,-2.9 C-19.8,-7.2 -16.2,-8.6 -14.7,-4.4 C-15.6,-3.3 -16.9,-2.8 -18.2,-2.9 Z" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.7" strokeOpacity="0.6" />
+        <circle cx="-16.9" cy="-4.9" r="0.7" fill="#eafff6" opacity="0.8" />
+        {/* oreja CERCANA: amplia, redondeada, parada de cacería */}
+        <path d="M-13.4,-3.1 C-12.2,-7.5 -9.4,-7.1 -10.3,-3.4 C-11.3,-2.6 -12.4,-2.6 -13.4,-3.1 Z" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.7" strokeOpacity="0.6" />
+        <path d="M-12.6,-4 C-12,-5.6 -11.2,-5.8 -10.9,-4.4" fill="none" stroke="#ffb59a" strokeWidth="0.5" opacity="0.6" />
+        {/* manchitas de la frente (rayitas, no rosetas: la cabeza va punteada) */}
+        <path d="M-16.6,-3 l0.5,1 M-15.2,-3.4 l0.3,1.1 M-13.9,-3 l0.1,1" stroke="#ff7d5a" strokeWidth="0.5" strokeLinecap="round" opacity="0.55" />
+        {/* ── OJOS GRANDES de noche: pupila abierta REDONDA (no rendija) ── */}
+        <g className="cn-parpadeo">
+          <circle cx="-17" cy="-0.6" r="1.6" fill="#04160f" stroke="#ffd76a" strokeWidth="0.7" />
+          <circle cx="-13.8" cy="-0.9" r="1.6" fill="#04160f" stroke="#ffd76a" strokeWidth="0.7" />
+          <circle cx="-17" cy="-0.6" r="1.05" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 4px #ffd76a)' }} />
+          <circle cx="-13.8" cy="-0.9" r="1.05" fill="#ffd76a" style={{ filter: 'drop-shadow(0 0 4px #ffd76a)' }} />
+          <g className="cn-mirada">
+            <circle cx="-17" cy="-0.6" r="0.72" fill="#0d0620" />
+            <circle cx="-13.8" cy="-0.9" r="0.72" fill="#0d0620" />
+            <circle cx="-17.3" cy="-1" r="0.32" fill="#eafff6" />
+            <circle cx="-14.1" cy="-1.3" r="0.32" fill="#eafff6" />
+          </g>
+        </g>
+        {/* hocico CORTO de gato: bump chico, nariz coral, boquita */}
+        <ellipse cx="-18.4" cy="1.7" rx="1.9" ry="1.5" fill="#1c1338" stroke="#ff7d5a" strokeWidth="0.6" strokeOpacity="0.5" />
+        <ellipse cx="-18.4" cy="1.8" rx="1.2" ry="0.9" fill="#eafff6" opacity="0.22" />
+        <path d="M-19.7,0.9 L-18.3,0.9 L-19,2 Z" fill="#ffb59a" opacity="0.95" />
+        <path d="M-19,2 C-18.7,2.6 -18,2.8 -17.4,2.5" fill="none" stroke="#eafff6" strokeWidth="0.45" opacity="0.6" />
+        {/* bigotes */}
+        <path d="M-19.4,1.9 C-21,1.7 -22.4,1.9 -23.4,2.4 M-19.2,2.5 C-20.7,2.9 -21.9,3.5 -22.8,4.2" fill="none" stroke="#eafff6" strokeWidth="0.4" strokeLinecap="round" opacity="0.55" />
+      </g>
     </g>
   );
 }
@@ -366,4 +914,5 @@ export function CriaturaNocturnaAvatar({ id, size = 64 }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { byId as criaturaNocturnaById };

--- a/src/components/dashboard/criaturas-nocturnas.css
+++ b/src/components/dashboard/criaturas-nocturnas.css
@@ -44,3 +44,285 @@
   .cn-av-camina, .cn-av-flota, .cn-av-vuela, .cn-av-planea,
   .cn-ala-mur, .cn-luz, .cn-luz-halo { animation: none !important; }
 }
+
+/* ════════════════════════════════════════════════════════════════════════════
+   BLOQUE NUEVO — criaturas nocturnas elevadas a PERSONAJE (búho + zarigüeya).
+   No reescribe nada de arriba: solo suma. Rubber-hose andino sobre el biopunk:
+   squash & stretch, follow-through y gestos que cuentan qué hace el animal.
+   `transform-box: fill-box` deja que cada parte pivote sobre SU propia caja,
+   sin tener que calcular el origen en coordenadas del viewBox.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* ── Currucutú (Megascops choliba) ─────────────────────────────────────────
+   Respira, gira la cabeza como solo un búho puede, parpadea y le tiemblan los
+   penachos. El peso vive abajo: el pecho se infla, las garras no se mueven. */
+.cn-buho-respira {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-buho-respira 3.6s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+@keyframes cn-buho-respira {
+  0%, 100% { transform: scale(1, 1); }
+  45% { transform: scale(0.985, 1.035); }
+  70% { transform: scale(1.012, 0.99); }
+}
+
+/* giro de cabeza: dos miradas al monte con pausa entre ellas (no un vaivén
+   de metrónomo — el búho SE DETIENE a mirar, que es lo que lo hace vigía) */
+.cn-buho-cabeza {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-buho-mira 7.4s cubic-bezier(0.5, 0, 0.25, 1.25) infinite;
+}
+@keyframes cn-buho-mira {
+  0%, 14% { transform: rotate(0deg) translateY(0); }
+  26%, 40% { transform: rotate(8deg) translateY(-0.4px); }
+  52%, 58% { transform: rotate(0deg) translateY(0); }
+  70%, 84% { transform: rotate(-7deg) translateY(-0.3px); }
+  96%, 100% { transform: rotate(0deg) translateY(0); }
+}
+
+/* párpado: baja desde arriba. scaleY(0) = ojo abierto, scaleY(1) = cerrado. */
+.cn-buho-parpado {
+  transform-box: fill-box;
+  transform-origin: center top;
+  /* estado por defecto = ojo ABIERTO: si la animación no corre, el párpado
+     nunca debe quedarse tapando el ojo */
+  transform: scaleY(0);
+  animation: cn-buho-parpadea 6.2s ease-in-out infinite;
+}
+@keyframes cn-buho-parpadea {
+  0%, 6% { transform: scaleY(0); }
+  8% { transform: scaleY(1); }
+  10%, 48% { transform: scaleY(0); }
+  50% { transform: scaleY(1); }
+  53%, 100% { transform: scaleY(0); }
+}
+
+/* penachos: tic auricular corto y seco al final del ciclo */
+.cn-buho-penacho {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-buho-penacho 5.2s ease-in-out infinite;
+}
+.cn-buho-penacho-r { animation-delay: -0.18s; }
+@keyframes cn-buho-penacho {
+  0%, 84%, 100% { transform: rotate(0deg); }
+  88% { transform: rotate(-6deg); }
+  92% { transform: rotate(4deg); }
+  96% { transform: rotate(-1.5deg); }
+}
+
+/* ── Zarigüeya (Didelphis marsupialis) ─────────────────────────────────────
+   Husmea: el marsupial lee el mundo con la nariz, así que el gesto rector es
+   el olfateo, no el paso. La cola prensil arrastra el movimiento (follow-
+   through) y las crías se acomodan encima con su propio ritmo. */
+.cn-zari {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-zari-husmea 3.4s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+@keyframes cn-zari-husmea {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  22% { transform: translateY(-0.7px) rotate(-0.8deg); }
+  48% { transform: translateY(0.5px) rotate(0.5deg); }
+  74% { transform: translateY(-0.4px) rotate(-0.3deg); }
+}
+
+/* el hocico olfatea más rápido que el cuerpo: sube, husmea, vuelve */
+.cn-zari-hocico {
+  transform-box: fill-box;
+  transform-origin: left center;
+  animation: cn-zari-hocico 1.6s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+}
+@keyframes cn-zari-hocico {
+  0%, 100% { transform: rotate(0deg) translateX(0); }
+  30% { transform: rotate(-2.8deg) translateX(0.35px); }
+  62% { transform: rotate(1.6deg) translateX(-0.2px); }
+}
+
+/* cola prensil: pesada y lenta, va detrás del cuerpo */
+.cn-zari-cola {
+  transform-box: fill-box;
+  transform-origin: right bottom;
+  animation: cn-zari-cola 4.8s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+@keyframes cn-zari-cola {
+  0%, 100% { transform: rotate(0deg); }
+  35% { transform: rotate(-4.5deg) translateY(-0.4px); }
+  72% { transform: rotate(2.5deg) translateY(0.3px); }
+}
+
+/* las crías: cada una con su desfase, para que no parezcan calcomanías */
+.cn-zari-cria {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-zari-cria 2.8s ease-in-out infinite;
+}
+.cn-zari-cria-b { animation-delay: -0.7s; }
+.cn-zari-cria-c { animation-delay: -1.5s; }
+@keyframes cn-zari-cria {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  40% { transform: translateY(-0.6px) rotate(2deg); }
+  75% { transform: translateY(0.3px) rotate(-1.2deg); }
+}
+
+/* vibrisas: el temblor fino que delata que está oliendo */
+.cn-zari-bigote {
+  transform-box: fill-box;
+  transform-origin: left center;
+  animation: cn-zari-bigote 0.9s ease-in-out infinite;
+}
+@keyframes cn-zari-bigote {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-3.5deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cn-buho-respira, .cn-buho-cabeza, .cn-buho-parpado, .cn-buho-penacho,
+  .cn-zari, .cn-zari-hocico, .cn-zari-cola, .cn-zari-cria, .cn-zari-bigote {
+    animation: none !important;
+  }
+  /* con el párpado congelado, scaleY(0) por defecto dejaría el ojo tapado:
+     lo forzamos abierto */
+  .cn-buho-parpado { transform: scaleY(0); }
+}
+
+/* ═══ NIVEL PERSONAJE (murciélago · gurre · tigrillo) — rubber-hose andino en
+   clave biopunk: boil en cadencia dibujada (~12fps vía steps), parpadeo
+   irregular con blink doble y mirada co-prima, mismos principios que las
+   clases rh-* de creatures.css pero en el namespace cn- de las nocturnas. ═══ */
+
+/* BOIL — squash & stretch que respira: anticipa, aplasta, overshoot. */
+.cn-boil {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: cn-boil 1.6s steps(14, end) infinite;
+}
+@keyframes cn-boil {
+  0%   { transform: translateY(0) scale(1, 1); }
+  22%  { transform: translateY(-0.25px) scale(0.98, 1.04); }  /* stretch (anticipa) */
+  50%  { transform: translateY(0.35px) scale(1.04, 0.96); }   /* squash */
+  72%  { transform: translateY(-0.1px) scale(0.99, 1.015); }  /* overshoot */
+  100% { transform: translateY(0) scale(1, 1); }
+}
+
+/* PARPADEO irregular: un blink suelto y luego un blink-blink — la cadencia
+   pareja delataba al robot. Período co-primo con boil y mirada. */
+.cn-parpadeo {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: cn-parpadeo 6.1s linear infinite;
+}
+@keyframes cn-parpadeo {
+  0%, 37%, 41%, 73%, 77%, 81%, 85%, 100% { transform: scaleY(1); }
+  39% { transform: scaleY(0.12); }
+  75% { transform: scaleY(0.1); }
+  79% { transform: scaleY(0.15); }
+}
+
+/* MIRADA — pupilas de reojo con double-take, nunca en el compás del parpadeo. */
+.cn-mirada { animation: cn-mirada 8.3s ease-in-out infinite; }
+@keyframes cn-mirada {
+  0%, 22%, 49%, 60%, 78%, 100% { transform: translate(0, 0); }
+  25%, 36% { transform: translate(-0.5px, 0.1px); }
+  40% { transform: translate(0.45px, 0); }        /* double-take */
+  43%, 46% { transform: translate(-0.45px, 0.1px); }
+  63%, 73% { transform: translate(0.4px, -0.35px); }
+}
+
+/* ── MURCIÉLAGO: cernido ERRÁTICO (nunca simétrico) + aleteo rápido de mano ── */
+.cn-mur-cierne { animation: cn-mur-cierne 2.7s cubic-bezier(0.37, 0, 0.63, 1) infinite; }
+@keyframes cn-mur-cierne {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  14% { transform: translate(-0.6px, -1.4px) rotate(-2.5deg); }
+  32% { transform: translate(0.5px, -0.5px) rotate(2deg); }   /* corrige seco */
+  47% { transform: translate(-0.3px, -1.8px) rotate(-1.5deg); }
+  66% { transform: translate(0.7px, -0.7px) rotate(2deg); }
+  83% { transform: translate(-0.4px, -1.2px) rotate(-1.5deg); }
+}
+.cn-mur-ala { animation: cn-mur-aleteo 0.3s cubic-bezier(0.5, 0, 0.5, 1) infinite alternate; }
+@keyframes cn-mur-aleteo {
+  from { transform: rotate(-14deg); }
+  to   { transform: rotate(8deg); }
+}
+.cn-mur-ala-far { animation: cn-mur-aleteo-far 0.3s cubic-bezier(0.5, 0, 0.5, 1) infinite alternate; animation-delay: -0.15s; }
+@keyframes cn-mur-aleteo-far {
+  from { transform: rotate(9deg); }
+  to   { transform: rotate(-6deg); }
+}
+/* la lengua lame la corola: se extiende, retrae un pelo y vuelve (dasharray) */
+.cn-mur-lengua { stroke-dasharray: 10; animation: cn-mur-lame 3.1s ease-in-out infinite; }
+@keyframes cn-mur-lame {
+  0%, 10% { stroke-dashoffset: 9.7; }
+  26% { stroke-dashoffset: 0; }
+  40% { stroke-dashoffset: 1.6; }   /* lame */
+  54%, 66% { stroke-dashoffset: 0; }
+  82%, 100% { stroke-dashoffset: 9.7; }
+}
+.cn-mur-polen { animation: cn-mur-polen 3.1s ease-in-out infinite; }
+@keyframes cn-mur-polen {
+  0%, 100% { opacity: 0.15; transform: translateY(0); }
+  45% { opacity: 0.9; transform: translateY(-1.2px); }
+}
+
+/* ── GURRE: husmea con la nariz al suelo y escarba a zarpazos con pausa ── */
+.cn-gurre-nariz { animation: cn-gurre-husmea 2.3s steps(12, end) infinite; }
+@keyframes cn-gurre-husmea {
+  0%, 54%, 100% { transform: rotate(0deg) translateY(0); }
+  12% { transform: rotate(2.2deg) translateY(0.4px); }   /* husmea */
+  22% { transform: rotate(0.6deg) translateY(0.1px); }
+  32% { transform: rotate(2.6deg) translateY(0.6px); }   /* husmea más hondo */
+  42% { transform: rotate(0.8deg) translateY(0.2px); }
+}
+.cn-gurre-vaho { animation: cn-gurre-vaho 2.3s ease-out infinite; }
+@keyframes cn-gurre-vaho {
+  0%, 10%, 44%, 100% { opacity: 0; transform: translate(0, 0); }
+  18% { opacity: 0.7; transform: translate(0.6px, -0.5px); }
+  34% { opacity: 0; transform: translate(1.6px, -1.5px); }
+}
+.cn-gurre-pala { animation: cn-gurre-escarba 1.15s steps(9, end) infinite; }
+@keyframes cn-gurre-escarba {
+  0%, 58%, 100% { transform: rotate(0deg); }
+  14% { transform: rotate(-24deg); }   /* zarpazo */
+  28% { transform: rotate(5deg); }     /* overshoot */
+  42% { transform: rotate(-20deg); }   /* segundo zarpazo, y pausa */
+}
+.cn-gurre-tierra { animation: cn-gurre-tierra 1.15s ease-out infinite; }
+@keyframes cn-gurre-tierra {
+  0%, 12% { opacity: 0; transform: translate(0, 0); }
+  30% { opacity: 0.9; transform: translate(-1.8px, -2.4px); }
+  60%, 100% { opacity: 0; transform: translate(-3.4px, 0.6px); }
+}
+
+/* ── TIGRILLO: acecho con el peso atrás + paso furtivo; la cola manda ── */
+.cn-tigri-acecha {
+  transform-box: fill-box;
+  transform-origin: 70% 100%;
+  animation: cn-tigri-acecha 4.6s steps(20, end) infinite;
+}
+@keyframes cn-tigri-acecha {
+  0%, 42%, 100% { transform: translate(0, 0); }
+  50%, 58% { transform: translate(0.9px, 0.5px); }   /* anticipa: carga el peso atrás */
+  66% { transform: translate(-1.2px, 0.1px); }       /* paso furtivo adelante */
+  74%, 88% { transform: translate(-0.5px, 0); }
+}
+.cn-tigri-cola { animation: cn-tigri-cola 3.7s ease-in-out infinite; }
+@keyframes cn-tigri-cola {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-5deg); }
+}
+.cn-tigri-colatip { animation: cn-tigri-colatip 3.7s cubic-bezier(0.68, -0.3, 0.32, 1.3) infinite; }
+@keyframes cn-tigri-colatip {
+  0%, 58%, 100% { transform: rotate(0deg); }
+  64% { transform: rotate(-20deg); }   /* latigazo */
+  70% { transform: rotate(8deg); }
+  76% { transform: rotate(-12deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cn-boil, .cn-parpadeo, .cn-mirada,
+  .cn-mur-cierne, .cn-mur-ala, .cn-mur-ala-far, .cn-mur-lengua, .cn-mur-polen,
+  .cn-gurre-nariz, .cn-gurre-vaho, .cn-gurre-pala, .cn-gurre-tierra,
+  .cn-tigri-acecha, .cn-tigri-cola, .cn-tigri-colatip { animation: none !important; }
+}

--- a/src/mockups/MetalSlugCampo.jsx
+++ b/src/mockups/MetalSlugCampo.jsx
@@ -23,7 +23,7 @@
    (mismo criterio que metalSlugCampoData / defensoresFincaData): copy pedagógico
    campesino en «usted», no strings de UI transversal migrables a messages.js. */
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { AbejaAngelita, OsoAndino } from '../visual/creatures';
+import { AbejaAngelita, OsoGuardian } from '../visual/creatures';
 import { decidirTier } from '../visual/mundo3d/deviceTier.js';
 import {
   NIVELES,
@@ -802,7 +802,7 @@ const SpriteHeroe = memo(function SpriteHeroe(/** @type {{ tier: any; reducedMot
 });
 
 const SpriteOso = memo(function SpriteOso(/** @type {{ tier: any; reducedMotion: any }} */ { tier, reducedMotion }) {
-  return <OsoAndino size={92} inline={false} animated={!reducedMotion} tier={tier} title="Oso andino" />;
+  return <OsoGuardian size={92} inline={false} animated={!reducedMotion} tier={tier} title="Oso guardián" />;
 });
 
 /* PlagaSprite ahora vive en ./metalslug/PlagasSprites.jsx (bestiario expresivo). */

--- a/src/visual/creatures/OsoAndino.jsx
+++ b/src/visual/creatures/OsoAndino.jsx
@@ -117,7 +117,7 @@ export function OsoAndino({
   const raizRef = useRef(null);
   const ritmoPropio = useRitmoPropio();
   const enBase = pose === 'anda' && !resopla && !rasca && !visema;
-  const momento = useVidaIdle('oso-andino', vida && vivo && tier !== 'bajo' && enBase);
+  const momento = useVidaIdle('oso-guardian', vida && vivo && tier !== 'bajo' && enBase);
   useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
   const resoplaFx = resopla || momento === 'resopla';
   const rascaFx = rasca || momento === 'rasca';

--- a/src/visual/creatures/OsoAnteojos.jsx
+++ b/src/visual/creatures/OsoAnteojos.jsx
@@ -131,7 +131,7 @@ export function OsoAnteojos({
   const raizRef = useRef(null);
   const ritmoPropio = useRitmoPropio();
   const enBase = pose === 'anda' && !resopla && !rasca && !visema;
-  const momento = useVidaIdle('oso-andino', vida && vivo && tier !== 'bajo' && enBase);
+  const momento = useVidaIdle('oso-guardian', vida && vivo && tier !== 'bajo' && enBase);
   useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
   const resoplaFx = resopla || momento === 'resopla';
   const rascaFx = rasca || momento === 'rasca';

--- a/src/visual/creatures/OsoGuardian.jsx
+++ b/src/visual/creatures/OsoGuardian.jsx
@@ -4,11 +4,11 @@ import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
 import { CreatureFilters } from './_filters.jsx';
 import { BocaVisema } from './_rubberhose.jsx';
 import {
-  OSO_GUARDIAN_PALETA, OSO_GUARDIAN_PROPORCION, OSO_GUARDIAN_RUANA_ANCLA,
+  OSO_GUARDIAN_PALETA, OSO_GUARDIAN_PROPORCION,
   OSO_GUARDIAN_SLUG, OSO_GUARDIAN_TINTA, PERFIL_OSO_GUARDIAN,
 } from './osoGuardianIdentidad.js';
 import { cuerpoDeClima, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
-import { AccesoriosClima } from './AccesoriosClima.jsx';
+import { RuanaGuardian } from './RuanaGuardian.jsx';
 import { LineBoilFilter } from './LineBoilFilter.jsx';
 import { PropEnMano } from './PropEnMano.jsx';
 import { AuraPoder } from './AuraPoder.jsx';
@@ -21,13 +21,27 @@ import { auraDeBicho } from './transformacion.js';
    CRECIENTE crema en el pecho (su emblema, conservado) y los anteojos del oso
    andino hechos de AROS DE LUZ que respiran.
 
-   QUÉ CORRIGE de los dos osos rechazados (el café OsoAndino y el OsoAnteojos
-   de peluche) — el mandato "que no se vea tan infantil":
+   QUÉ CORRIGE ESTA PASADA — la revisión visual a 760 px marcó tres defectos,
+   y son los tres del CUERPO. La cara, la luna del pecho y el rim menta pasaron
+   la revisión y NO se tocaron:
+   · NO TENÍA ANATOMÍA, ERA UN DOMO. El cuerpo era una campana lisa sin cruz,
+     sin cuello y sin grupa, con la cabeza pegada encima como calcomanía. Ahora
+     la silueta recorre las marcas reales del Tremarctos (grupa → cintura →
+     costillar → cruz → cuello), el trapecio sube ESCONDIDO tras el cráneo para
+     que la cabeza nazca del cuerpo, y una GOLILLA de pelaje denso —el
+     "ahuecado" de hombros que documenta la DR— remacha la costura.
+   · LAS EXTREMIDADES NO EXISTÍAN. Al frente había dos rectángulos redondeados
+     flotando a media panza; atrás, cuatro juegos de garras apoyados en el piso
+     SIN PATAS que los sostuvieran. Ahora los brazos nacen del deltoides y son
+     largos (esta especie los tiene más largos que las traseras: es trepadora),
+     y las traseras tienen caña y planta plantígrada completa.
+   · LA RUANA ERA UNA TABLA. Ver RuanaGuardian.jsx: se fue el trapecio genérico
+     de AccesoriosClima y entró una prenda con caída, pliegue y punta al hombro.
+
+   Lo que ya venía bien de la pasada anterior y se conserva:
    · PROPORCIONES DE ADULTO: cabeza chica (ratio cabeza:hombros ≈ 1:3, antes
-     ≈ 1:1.6) hundida en una JOROBA de hombros anchos; la silueta es un PATH
-     propio de mole plantígrada sentada como montaña — no el círculo-sobre-
-     elipse del peluche. Hocico canela PRESENTE que proyecta del cráneo,
-     carrilleras que ensanchan la cara abajo (cara adulta, no carita redonda).
+     ≈ 1:1.6). Hocico canela PRESENTE que proyecta del cráneo, carrilleras que
+     ensanchan la cara abajo (cara adulta, no carita redonda).
    · OJOS CON ALMA, NO DE JUGUETE: almendras oscuras de párpado pesado con
      iris menta-luz chico y catchlight — dentro de los aros luminosos. Nada de
      esclerótica blanca con pupila gigante (OjosRubber queda fuera adrede).
@@ -65,25 +79,140 @@ function Garras({ xs, y, color, largo = 1.2 }) {
    la mole (reusa la cadencia osoa-mota ya existente). Delays/duraciones
    propios: vida, no metrónomo. */
 const ESPORAS = [
-  { cx: -11.8, cy: -5.2, r: 0.46, d: 0, s: 6.9 },
-  { cx: 12.2, cy: -1.4, r: 0.4, d: -2.2, s: 7.5 },
-  { cx: -9.6, cy: 9.4, r: 0.34, d: -3.9, s: 6.1 },
-  { cx: 10.2, cy: -8.8, r: 0.44, d: -1.5, s: 6.5 },
-  { cx: -13.2, cy: 1.6, r: 0.3, d: -4.8, s: 7.8 },
+  { cx: -12.2, cy: -6.4, r: 0.46, d: 0, s: 6.9 },
+  { cx: 12.6, cy: -3.0, r: 0.4, d: -2.2, s: 7.5 },
+  { cx: -14.4, cy: 4.6, r: 0.34, d: -3.9, s: 6.1 },
+  { cx: 10.6, cy: -9.8, r: 0.44, d: -1.5, s: 6.5 },
+  { cx: -13.9, cy: -1.2, r: 0.3, d: -4.8, s: 7.8 },
 ];
 
-/* LA SILUETA DE LA MOLE (el corazón del rediseño): un solo path de oso sentado
-   como montaña — joroba de hombros arriba, flancos que se abren a las ancas,
-   asiento ancho. Nada de elipse de peluche. */
+/* ═══ LA SILUETA — ANATOMÍA DE OSO, NO UN DOMO.
+ *
+ * La versión anterior era una campana lisa: sin cruz, sin cuello, sin grupa, y
+ * con la cabeza apoyada encima como calcomanía. Este path recorre las marcas
+ * reales del Tremarctos ornatus (DR gemini, 2026-06-19), de abajo a arriba por
+ * el costado izquierdo y espejado de vuelta:
+ *
+ *   ASIENTO → GRUPA (±12.7, el punto MÁS ancho del oso sentado: son las ancas)
+ *   → CINTURA (±10.6: hay talle. Es un trepador musculoso, no una bola. El
+ *     estrechamiento es del 17% y GRADUAL — la especie no tiene cintura de
+ *     avispa, la DR es explícita en que la transición es suave)
+ *   → COSTILLAR de pecho profundo → CRUZ (la paletilla sube hasta y=-11, POR
+ *     ENCIMA de la base del cráneo, y asoma a los costados de la cabeza)
+ *   → CUELLO CORTO Y MUSCULOSO: el trapecio sigue subiendo hasta y=-14, pero
+ *     ahí ya va ESCONDIDO detrás del cráneo. Ese tramo es el que hace que la
+ *     cabeza NAZCA del cuerpo en vez de posarse encima. Es literalmente lo
+ *     único que separa un oso de un muñeco de nieve.
+ *
+ * Ojo con la cruz: es pelaje denso, el "ahuecado" de hombro que describe la DR
+ * — NO la joroba del oso pardo, que esta especie no tiene. Si se exagera, deja
+ * de ser un oso andino y pasa a ser un grizzly. */
 const SILUETA_MOLE =
-  'M -10.9,13.1 '
-  + 'C -13.3,10.6 -13.9,6.2 -12.6,1.8 '
-  + 'C -11.8,-1.6 -10.7,-4.2 -9.0,-6.3 '
-  + 'C -7.2,-8.6 -4.0,-9.8 0,-9.8 '
-  + 'C 4.0,-9.8 7.2,-8.6 9.0,-6.3 '
-  + 'C 10.7,-4.2 11.8,-1.6 12.6,1.8 '
-  + 'C 13.9,6.2 13.3,10.6 10.9,13.1 '
-  + 'C 7.4,13.9 -7.4,13.9 -10.9,13.1 Z';
+  'M -10.8,13.6 '
+  + 'C -12.4,12.0 -13.0,9.8 -12.7,7.4 '     // grupa: las ancas, lo más ancho
+  + 'C -12.4,5.0 -11.0,3.0 -10.6,1.0 '      // cintura: el talle del trepador
+  + 'C -10.3,-1.4 -10.6,-4.2 -10.2,-6.0 '   // costillar: el pecho es profundo
+  + 'C -9.8,-8.0 -8.4,-9.8 -6.4,-11.0 '     // CRUZ: la paletilla sube
+  + 'C -5.2,-11.9 -4.2,-13.0 -2.8,-13.7 '   // cuello corto: el trapecio…
+  + 'C -1.5,-14.3 1.5,-14.3 2.8,-13.7 '     // …y acá va oculto tras el cráneo
+  + 'C 4.2,-13.0 5.2,-11.9 6.4,-11.0 '
+  + 'C 8.4,-9.8 9.8,-8.0 10.2,-6.0 '
+  + 'C 10.6,-4.2 10.3,-1.4 10.6,1.0 '
+  + 'C 11.0,3.0 12.4,5.0 12.7,7.4 '
+  + 'C 13.0,9.8 12.4,12.0 10.8,13.6 '
+  + 'C 7.2,14.4 -7.2,14.4 -10.8,13.6 Z';
+
+/* ═══ PATA TRASERA del plantígrado sentado (`s`: -1 izquierda, +1 derecha).
+ *
+ * El defecto que corrige: antes había CUATRO JUEGOS DE GARRAS apoyados en el
+ * piso sin ninguna pata que los sostuviera. Era lo que más gritaba "sin
+ * terminar".
+ *
+ * El muslo ya vive en la silueta (es el bulto de la grupa); lo que falta y se
+ * dibuja acá es la CAÑA que baja de ese muslo hasta el tobillo. Va por delante
+ * del flanco, así que se lee por su contorno sobre el cuerpo oscuro. */
+function canaTrasera(s) {
+  const x = (v) => (s * v).toFixed(2);
+  return (
+    `M ${x(10.6)},6.8 `
+    + `C ${x(11.9)},8.6 ${x(12.6)},10.6 ${x(12.7)},12.3 `  // baja por fuera
+    + `C ${x(12.75)},13.1 ${x(12.2)},13.6 ${x(11.3)},13.65 ` // tobillo
+    + `C ${x(10.4)},13.7 ${x(9.8)},13.2 ${x(9.8)},12.4 `
+    + `C ${x(9.75)},10.6 ${x(9.5)},8.6 ${x(8.9)},7.0 `      // corva interna
+    + `C ${x(9.4)},6.4 ${x(10.1)},6.3 ${x(10.6)},6.8 Z`
+  );
+}
+
+/* PLANTA TRASERA — plantígrada de verdad: apoya la planta COMPLETA, talón y
+ * dedos, como nosotros. Por eso es larga y descansa entera sobre el suelo, no
+ * de puntillas. Va abierta hacia afuera (postura real del oso sentado) con el
+ * talón hacia adentro y los dedos al exterior: así los cuatro apoyos se leen
+ * separados y no se pisan con las manos. */
+function plantaTrasera(s) {
+  const x = (v) => (s * v).toFixed(2);
+  return (
+    `M ${x(9.6)},12.5 `
+    + `C ${x(8.7)},12.55 ${x(8.2)},13.05 ${x(8.25)},13.7 `   // talón (interno)
+    + `C ${x(8.3)},14.3 ${x(9.2)},14.6 ${x(10.5)},14.55 `
+    + `C ${x(12.1)},14.5 ${x(13.4)},14.25 ${x(13.8)},13.65 ` // dedos (externo)
+    + `C ${x(14.1)},13.15 ${x(13.7)},12.55 ${x(12.8)},12.45 `
+    + `C ${x(11.6)},12.3 ${x(10.5)},12.42 ${x(9.6)},12.5 Z`
+  );
+}
+
+/* ═══ PATA DELANTERA. En esta especie las delanteras son MÁS LARGAS que las
+ * traseras — es la adaptación trepadora, y es de las cosas que más rápido
+ * distinguen un oso andino de un oso negro. Por eso el codo cae bajo y el
+ * antebrazo es largo.
+ *
+ * Antes eran dos rectángulos redondeados verticales que arrancaban a media
+ * panza, sin conexión con ningún hombro (porque no había hombro). Ahora nace
+ * en el deltoides, baja por fuera, y el antebrazo entra hacia el centro hasta
+ * la mano — que es como se sienta un oso: los brazos caen y se recogen. */
+function brazo(s) {
+  const x = (v) => (s * v).toFixed(2);
+  return (
+    `M ${x(9.9)},-7.6 `
+    + `C ${x(11.0)},-4.6 ${x(11.3)},-1.0 ${x(10.8)},2.2 `   // brazo por fuera
+    + `C ${x(10.4)},5.2 ${x(9.8)},8.2 ${x(9.2)},10.6 `      // antebrazo largo
+    + `C ${x(8.9)},11.8 ${x(8.2)},12.5 ${x(7.2)},12.7 `     // muñeca
+    + `C ${x(6.0)},12.9 ${x(5.2)},12.4 ${x(5.0)},11.4 `
+    + `C ${x(4.9)},9.0 ${x(5.4)},6.0 ${x(5.9)},3.0 `        // borde interno
+    + `C ${x(6.4)},0.0 ${x(6.8)},-3.2 ${x(7.3)},-6.2 `
+    + `C ${x(7.8)},-7.4 ${x(9.0)},-8.0 ${x(9.9)},-7.6 Z`
+  );
+}
+
+/* MANO plantígrada apoyada: fondo plano contra el suelo (carga peso), lomo
+ * redondo. Las garras salen del borde delantero. */
+function mano(s) {
+  const x = (v) => (s * v).toFixed(2);
+  return (
+    `M ${x(8.7)},12.4 `
+    + `C ${x(8.75)},11.6 ${x(7.9)},11.15 ${x(6.4)},11.15 `
+    + `C ${x(4.9)},11.15 ${x(4.05)},11.6 ${x(4.1)},12.4 `
+    + `C ${x(4.15)},13.3 ${x(4.6)},13.85 ${x(6.4)},13.9 `   // el suelo
+    + `C ${x(8.2)},13.85 ${x(8.65)},13.3 ${x(8.7)},12.4 Z`
+  );
+}
+
+/* GOLILLA DEL CUELLO — el pelaje denso que la DR describe como un "ahuecado"
+ * en cuello y hombros. Además de ser cierto, es el remache del problema de la
+ * cabeza-calcomanía: una corona de mechones que monta sobre los hombros y pasa
+ * por detrás del cráneo cose la cabeza al cuerpo. Los mechones del centro
+ * quedan ocultos tras la cabeza; los que se ven son los de los flancos, que es
+ * justo donde hacía falta la costura. */
+const GOLILLA =
+  'M -8.8,-7.0 '
+  + 'C -8.5,-8.8 -7.6,-10.4 -6.2,-11.5 '
+  + 'C -5.6,-10.3 -5.0,-11.7 -4.4,-10.5 '
+  + 'C -3.9,-11.9 -3.2,-10.9 -2.6,-12.1 '
+  + 'C -1.8,-10.9 -1.0,-12.3 -0.2,-11.1 '
+  + 'C 0.6,-12.3 1.4,-10.9 2.2,-12.1 '
+  + 'C 2.8,-10.9 3.5,-11.9 4.0,-10.5 '
+  + 'C 4.6,-11.7 5.2,-10.3 5.8,-11.5 '
+  + 'C 7.2,-10.4 8.1,-8.8 8.4,-7.0 '
+  + 'C 5.6,-5.9 -6.0,-5.9 -8.8,-7.0 Z';
 
 /* LA LUNA CRECIENTE del pecho — el emblema conservado de la base. Media
    circunferencia externa (r 3.0, centrada en 0,-2.2) + arco interno tendido
@@ -246,51 +375,81 @@ export function OsoGuardian({
   //    bruma y esporas. `.crt-body` respira con oso-boil (pesado, lento).
   const body = (
     <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
-      {/* SOMBRA DE SUELO — el peso de la montaña (masa real, no sticker). */}
-      <ellipse cx="0" cy="14.35" rx="12.4" ry="2.1" fill={`url(#${haloSombra})`} aria-hidden="true" />
+      {/* SOMBRA DE SUELO — el peso de la montaña (masa real, no sticker).
+          Ahora abarca las cuatro plantas, que llegan más afuera que la mole. */}
+      <ellipse cx="0" cy="14.9" rx="14.8" ry="2.2" fill={`url(#${haloSombra})`} aria-hidden="true" />
       {/* aura menta tenue: bioluminiscencia de niebla, no neón de feria */}
       <circle cx="0" cy="1.5" r={auraR + 2} fill={`url(#${haloMenta})`} opacity={auraOp * 0.5} />
 
-      {/* PATAS TRASERAS del plantígrado sentado: las plantas asoman adelante,
-          a los lados de la mole (postura real de oso sentado). */}
-      <g aria-hidden="true">
-        <ellipse cx="-10.5" cy="13.15" rx="2.35" ry="1.35" fill={P.planta} stroke={INK} strokeWidth="0.8" />
-        <ellipse cx="10.5" cy="13.15" rx="2.35" ry="1.35" fill={P.planta} stroke={INK} strokeWidth="0.8" />
-        <Garras xs={[-11.5, -10.5, -9.5]} y={13.9} color={P.garra} largo={0.95} />
-        <Garras xs={[9.5, 10.5, 11.5]} y={13.9} color={P.garra} largo={0.95} />
-      </g>
-
-      {/* ═══ LA MOLE — la silueta que manda: joroba de hombros, flancos a las
-          ancas, asiento de montaña. El halo menta va MEDIDO en el drop-shadow
+      {/* ═══ LA MOLE — la silueta que manda: grupa, cintura, cruz y el cuello
+          que sube a buscar el cráneo. El halo menta va MEDIDO en el drop-shadow
           (la estética del avatar aprobado, sin contorno de neón chillón). */}
       <path d={SILUETA_MOLE} fill={`url(#${pelaje})`} stroke={INK} strokeWidth="1.35"
         strokeLinejoin="round" style={{ filter: `drop-shadow(0 0 6px ${P.cuerpoGlow})` }} />
+
+      {/* PATAS TRASERAS — caña + planta plantígrada. Van DELANTE del flanco
+          (un oso sentado recoge las patas hacia adelante), así que se leen por
+          su contorno sobre el cuerpo oscuro. Ya no son garras flotando. */}
+      <g aria-hidden="true">
+        {[-1, 1].map((s) => (
+          <g key={`tras${s}`}>
+            <path d={canaTrasera(s)} fill={P.pata} stroke={INK}
+              strokeWidth="0.85" strokeLinejoin="round" />
+            <path d={plantaTrasera(s)} fill={P.planta} stroke={INK}
+              strokeWidth="0.85" strokeLinejoin="round" />
+          </g>
+        ))}
+        {/* garras traseras: en el borde EXTERNO, que es donde van los dedos */}
+        <Garras xs={[-13.4, -12.4, -11.4]} y={13.95} color={P.garra} largo={0.8} />
+        <Garras xs={[11.4, 12.4, 13.4]} y={13.95} color={P.garra} largo={0.8} />
+      </g>
 
       {/* RIM-LIGHT LUNAR — la luz que dibuja al guardián por el lado de la
           luna (izquierdo), con un eco tenue al flanco derecho. Es EL trazo
           neón de la base, vuelto luz de borde con criterio. */}
       <g aria-hidden="true" fill="none" strokeLinecap="round">
-        <path d="M -12.4,3.0 C -11.6,-2.2 -9.6,-6.3 -5.2,-8.9" stroke={P.menta}
+        {/* sigue el borde nuevo: costillar → cruz, que es donde la luz pega */}
+        <path d="M -11.4,4.2 C -10.6,-0.8 -10.0,-6.4 -6.6,-10.8" stroke={P.menta}
           strokeWidth="0.85" opacity="0.55" style={{ filter: `drop-shadow(0 0 2.5px ${P.menta})` }} />
-        <path d="M 12.45,4.0 C 12.9,7.4 12.4,10.6 10.9,13.0" stroke={P.menta}
+        {/* eco tenue en la grupa del otro flanco */}
+        <path d="M 11.4,3.6 C 12.3,7.0 12.9,10.4 11.4,12.8" stroke={P.menta}
           strokeWidth="0.7" opacity="0.18" />
       </g>
 
-      {/* PELAJE SUGERIDO en la silueta: mechones cortos a contraluz en joroba,
-          flancos y ancas + definición muscular tenue (deltoides y pectoral).
-          Sugiere, no delinea — la mole sigue siendo casi silueta. */}
+      {/* PELAJE Y MÚSCULO SUGERIDOS sobre la anatomía nueva. Sugiere, no
+          delinea — la mole sigue siendo casi silueta. */}
       <g aria-hidden="true" fill="none" stroke={P.cuerpoLuz} strokeLinecap="round">
-        <g strokeWidth="0.5" opacity="0.5">
-          <path d="M -4.6,-9.15 l 0.5,-0.55 l 0.45,0.62 l 0.5,-0.55" />
-          <path d="M 4.6,-9.15 l -0.5,-0.55 l -0.45,0.62 l -0.5,-0.55" />
-          <path d="M -12.9,4.6 l 0.75,0.5 l -0.7,0.62 l 0.72,0.58" />
-          <path d="M 12.9,5.6 l -0.75,0.5 l 0.7,0.62 l -0.72,0.58" />
-          <path d="M -11.9,9.2 l 0.7,0.4 l -0.6,0.6" />
+        {/* mechones cortos a contraluz: costillar, cintura y grupa */}
+        <g strokeWidth="0.5" opacity="0.48">
+          <path d="M -10.7,-3.4 l 0.72,0.48 l -0.68,0.6 l 0.7,0.56" />
+          <path d="M 10.7,-2.6 l -0.72,0.48 l 0.68,0.6 l -0.7,0.56" />
+          <path d="M -11.9,6.4 l 0.75,0.5 l -0.7,0.62 l 0.72,0.58" />
+          <path d="M 12.1,7.4 l -0.75,0.5 l 0.7,0.62 l -0.72,0.58" />
         </g>
-        <g strokeWidth="0.55" opacity="0.22">
-          <path d="M -9.9,-4.4 C -8.7,-2.0 -7.3,-0.6 -5.5,0.3" />
-          <path d="M 9.9,-4.4 C 8.7,-2.0 7.3,-0.6 5.5,0.3" />
-          <path d="M -3.4,-6.4 C -1.5,-5.3 1.5,-5.3 3.4,-6.4" />
+        {/* la ESCÁPULA sobre la cruz: el hueso que se marca cuando el oso
+            carga el peso en las manos. Sin esto la cruz vuelve a ser un bulto */}
+        <g strokeWidth="0.5" opacity="0.26">
+          <path d="M -8.6,-9.6 C -8.0,-7.6 -7.4,-6.2 -6.6,-5.2" />
+          <path d="M 8.6,-9.6 C 8.0,-7.6 7.4,-6.2 6.6,-5.2" />
+        </g>
+        {/* el arco del costillar: el pecho es profundo, y se nota */}
+        <g strokeWidth="0.5" opacity="0.2">
+          <path d="M -8.8,-2.4 C -7.6,0.2 -5.2,1.6 -2.6,2.0" />
+          <path d="M 8.8,-2.4 C 7.6,0.2 5.2,1.6 2.6,2.0" />
+        </g>
+      </g>
+
+      {/* ═══ GOLILLA — el pelaje denso de cuello y hombros. Es anatomía real
+          (el "ahuecado" que describe la DR) y a la vez la costura que ata la
+          cabeza al cuerpo: los mechones montan sobre las paletillas y pasan
+          por detrás del cráneo. Con esto la cabeza deja de estar posada. */}
+      <g aria-hidden="true">
+        <path d={GOLILLA} fill={P.cuerpo} stroke={INK} strokeWidth="0.9"
+          strokeLinejoin="round" opacity="0.96" />
+        {/* mechones a contraluz en las puntas de la golilla */}
+        <g fill="none" stroke={P.cuerpoLuz} strokeWidth="0.42" strokeLinecap="round" opacity="0.4">
+          <path d="M -6.6,-10.6 C -6.2,-9.4 -5.9,-8.4 -5.9,-7.4" />
+          <path d="M 6.6,-10.6 C 6.2,-9.4 5.9,-8.4 5.9,-7.4" />
         </g>
       </g>
 
@@ -317,21 +476,34 @@ export function OsoGuardian({
         </g>
       </g>
 
-      {/* PATAS DELANTERAS: columnas plantadas CORTAS (nacen bajo la luna — el
-          pecho queda abierto para el emblema), redondeadas arriba, en sombra
-          propia para despegarlas del pecho; plantas anchas y GARRAS visibles. */}
+      {/* ═══ PATAS DELANTERAS — nacen del DELTOIDES, no del aire. Largas (esta
+          especie las tiene más largas que las traseras: es trepadora), bajan
+          por fuera y recogen hacia el centro hasta la mano apoyada. El pecho
+          queda libre entre las dos: ahí manda la luna. */}
       <g>
-        <path d="M -7.7,1.0 C -8.3,4.4 -8.3,8.6 -7.7,12.2 C -6.5,12.8 -5.1,12.8 -4.2,12.3 C -4.6,8.6 -4.6,4.6 -4.3,1.6 C -5.4,0.5 -6.9,0.4 -7.7,1.0 Z"
-          fill={P.pata} stroke={INK} strokeWidth="0.85" strokeLinejoin="round" />
-        <path d="M 7.7,1.0 C 8.3,4.4 8.3,8.6 7.7,12.2 C 6.5,12.8 5.1,12.8 4.2,12.3 C 4.6,8.6 4.6,4.6 4.3,1.6 C 5.4,0.5 6.9,0.4 7.7,1.0 Z"
-          fill={P.pata} stroke={INK} strokeWidth="0.85" strokeLinejoin="round" />
-        {/* rim menta finísimo en la columna del lado de la luna */}
-        <path d="M -7.5,2.2 C -8.05,5.2 -8.05,8.8 -7.5,11.8" fill="none"
-          stroke={P.menta} strokeWidth="0.4" opacity="0.28" aria-hidden="true" />
-        <ellipse cx="-6.0" cy="12.7" rx="2.5" ry="1.45" fill={P.planta} stroke={INK} strokeWidth="0.85" />
-        <ellipse cx="6.0" cy="12.7" rx="2.5" ry="1.45" fill={P.planta} stroke={INK} strokeWidth="0.85" />
-        <Garras xs={[-7.6, -6.55, -5.5, -4.45]} y={13.35} color={P.garra} />
-        <Garras xs={[4.45, 5.5, 6.55, 7.6]} y={13.35} color={P.garra} />
+        {[-1, 1].map((s) => (
+          <path key={`brazo${s}`} d={brazo(s)} fill={P.pata} stroke={INK}
+            strokeWidth="0.85" strokeLinejoin="round" />
+        ))}
+        {/* codo y antebrazo insinuados: sin esto el brazo vuelve a ser un tubo */}
+        <g aria-hidden="true" fill="none" stroke={P.cuerpoSombra} strokeWidth="0.5" opacity="0.45" strokeLinecap="round">
+          <path d="M -10.7,1.4 C -9.6,2.0 -8.2,2.1 -7.0,1.6" />
+          <path d="M 10.7,1.4 C 9.6,2.0 8.2,2.1 7.0,1.6" />
+        </g>
+        {/* rim menta finísimo en el brazo del lado de la luna */}
+        <path d="M -10.9,-1.0 C -10.5,3.4 -9.9,7.6 -9.3,10.4" fill="none"
+          stroke={P.menta} strokeWidth="0.4" opacity="0.3" aria-hidden="true" />
+        {[-1, 1].map((s) => (
+          <path key={`mano${s}`} d={mano(s)} fill={P.planta} stroke={INK}
+            strokeWidth="0.85" strokeLinejoin="round" />
+        ))}
+        {/* los dedos de la mano, apenas dichos */}
+        <g aria-hidden="true" fill="none" stroke={INK} strokeWidth="0.4" opacity="0.5" strokeLinecap="round">
+          <path d="M -7.4,13.5 l0,-1.1  M -6.4,13.6 l0,-1.15  M -5.4,13.5 l0,-1.1" />
+          <path d="M 5.4,13.5 l0,-1.1  M 6.4,13.6 l0,-1.15  M 7.4,13.5 l0,-1.1" />
+        </g>
+        <Garras xs={[-7.9, -6.9, -5.9, -4.9]} y={13.5} color={P.garra} largo={0.85} />
+        <Garras xs={[4.9, 5.9, 6.9, 7.9]} y={13.5} color={P.garra} largo={0.85} />
       </g>
 
       {/* ═══ CABEZA proporcionada, hundida en la joroba (sin cuello de peluche).
@@ -421,18 +593,12 @@ export function OsoGuardian({
         {boca}
       </g>
 
-      {/* Vestuario por clima+hora (RUANA de noche/frío del páramo). El ancla NO
-          es la mole entera: es OSO_GUARDIAN_RUANA_ANCLA, calculada para que el
-          poncho se apoye sobre el lomo y deje ver la luna del pecho (ver la
-          nota con las desigualdades en osoGuardianIdentidad.js). */}
-      {ropa && (
-        <AccesoriosClima
-          estado={ropa}
-          tronco={OSO_GUARDIAN_RUANA_ANCLA}
-          cabeza={{ cx: 0, cy: -12.9, r: PR.cabezaRx }}
-          animated={vivo}
-        />
-      )}
+      {/* ═══ LA RUANA del frío del páramo — la propia del guardián, no el
+          trapecio genérico de AccesoriosClima. Se cuelga de la cruz que este
+          rediseño le dio (sin hombro no hay dónde apoyarla), cae abierta al
+          frente dejando el pecho —y la luna— a la vista, y lleva la punta
+          echada al hombro, que es el gesto real de frío de verdad. */}
+      {ropa?.ruana && <RuanaGuardian animated={vivo} ink={INK} />}
 
       {/* Prop del mundo junto a la zarpa. */}
       {propMundo}
@@ -441,7 +607,7 @@ export function OsoGuardian({
       {vaho}
 
       {/* BRUMA a los pies — el velo del bosque nublado (tenue). */}
-      <ellipse cx="0" cy="13.7" rx="11.6" ry="2.3" fill={`url(#${haloMenta})`} opacity="0.09"
+      <ellipse cx="0" cy="14.2" rx="13.8" ry="2.4" fill={`url(#${haloMenta})`} opacity="0.09"
         aria-hidden="true" />
 
       {/* ESPORAS del bosque nublado (cadencia osoa-mota compartida). */}

--- a/src/visual/creatures/OsoGuardian.jsx
+++ b/src/visual/creatures/OsoGuardian.jsx
@@ -93,13 +93,13 @@ const ESPORAS = [
  * reales del Tremarctos ornatus (DR gemini, 2026-06-19), de abajo a arriba por
  * el costado izquierdo y espejado de vuelta:
  *
- *   ASIENTO → GRUPA (±12.7, el punto MÁS ancho del oso sentado: son las ancas)
- *   → CINTURA (±10.6: hay talle. Es un trepador musculoso, no una bola. El
- *     estrechamiento es del 17% y GRADUAL — la especie no tiene cintura de
+ *   ASIENTO → GRUPA (±12.5, el punto MÁS ancho del oso sentado: son las ancas)
+ *   → CINTURA (±10.2: hay talle. Es un trepador musculoso, no una bola. El
+ *     estrechamiento es del 18% y GRADUAL — la especie no tiene cintura de
  *     avispa, la DR es explícita en que la transición es suave)
- *   → COSTILLAR de pecho profundo → CRUZ (la paletilla sube hasta y=-11, POR
+ *   → COSTILLAR de pecho profundo → CRUZ (la paletilla sube hasta y≈-11, POR
  *     ENCIMA de la base del cráneo, y asoma a los costados de la cabeza)
- *   → CUELLO CORTO Y MUSCULOSO: el trapecio sigue subiendo hasta y=-14, pero
+ *   → CUELLO CORTO Y MUSCULOSO: el trapecio sigue subiendo hasta y≈-14, pero
  *     ahí ya va ESCONDIDO detrás del cráneo. Ese tramo es el que hace que la
  *     cabeza NAZCA del cuerpo en vez de posarse encima. Es literalmente lo
  *     único que separa un oso de un muñeco de nieve.
@@ -108,19 +108,19 @@ const ESPORAS = [
  * — NO la joroba del oso pardo, que esta especie no tiene. Si se exagera, deja
  * de ser un oso andino y pasa a ser un grizzly. */
 const SILUETA_MOLE =
-  'M -10.8,13.6 '
-  + 'C -12.4,12.0 -13.0,9.8 -12.7,7.4 '     // grupa: las ancas, lo más ancho
-  + 'C -12.4,5.0 -11.0,3.0 -10.6,1.0 '      // cintura: el talle del trepador
-  + 'C -10.3,-1.4 -10.6,-4.2 -10.2,-6.0 '   // costillar: el pecho es profundo
-  + 'C -9.8,-8.0 -8.4,-9.8 -6.4,-11.0 '     // CRUZ: la paletilla sube
-  + 'C -5.2,-11.9 -4.2,-13.0 -2.8,-13.7 '   // cuello corto: el trapecio…
-  + 'C -1.5,-14.3 1.5,-14.3 2.8,-13.7 '     // …y acá va oculto tras el cráneo
-  + 'C 4.2,-13.0 5.2,-11.9 6.4,-11.0 '
-  + 'C 8.4,-9.8 9.8,-8.0 10.2,-6.0 '
-  + 'C 10.6,-4.2 10.3,-1.4 10.6,1.0 '
-  + 'C 11.0,3.0 12.4,5.0 12.7,7.4 '
-  + 'C 13.0,9.8 12.4,12.0 10.8,13.6 '
-  + 'C 7.2,14.4 -7.2,14.4 -10.8,13.6 Z';
+  'M -10.6,13.6 '
+  + 'C -12.2,12.0 -12.8,9.8 -12.5,7.4 '     // grupa: las ancas, lo más ancho
+  + 'C -12.2,5.0 -10.6,3.0 -10.2,1.0 '      // cintura: el talle del trepador
+  + 'C -9.9,-1.4 -10.2,-4.0 -9.7,-5.8 '     // costillar: el pecho es profundo
+  + 'C -9.0,-7.8 -7.6,-9.6 -5.8,-10.9 '     // CRUZ: la paletilla sube
+  + 'C -4.8,-11.8 -4.0,-12.8 -2.7,-13.6 '   // cuello corto: el trapecio…
+  + 'C -1.5,-14.2 1.5,-14.2 2.7,-13.6 '     // …y acá va oculto tras el cráneo
+  + 'C 4.0,-12.8 4.8,-11.8 5.8,-10.9 '
+  + 'C 7.6,-9.6 9.0,-7.8 9.7,-5.8 '
+  + 'C 10.2,-4.0 9.9,-1.4 10.2,1.0 '
+  + 'C 10.6,3.0 12.2,5.0 12.5,7.4 '
+  + 'C 12.8,9.8 12.2,12.0 10.6,13.6 '
+  + 'C 7.2,14.4 -7.2,14.4 -10.6,13.6 Z';
 
 /* ═══ PATA TRASERA del plantígrado sentado (`s`: -1 izquierda, +1 derecha).
  *
@@ -134,12 +134,12 @@ const SILUETA_MOLE =
 function canaTrasera(s) {
   const x = (v) => (s * v).toFixed(2);
   return (
-    `M ${x(10.6)},6.8 `
-    + `C ${x(11.9)},8.6 ${x(12.6)},10.6 ${x(12.7)},12.3 `  // baja por fuera
-    + `C ${x(12.75)},13.1 ${x(12.2)},13.6 ${x(11.3)},13.65 ` // tobillo
-    + `C ${x(10.4)},13.7 ${x(9.8)},13.2 ${x(9.8)},12.4 `
-    + `C ${x(9.75)},10.6 ${x(9.5)},8.6 ${x(8.9)},7.0 `      // corva interna
-    + `C ${x(9.4)},6.4 ${x(10.1)},6.3 ${x(10.6)},6.8 Z`
+    `M ${x(10.3)},6.8 `
+    + `C ${x(11.5)},8.6 ${x(12.2)},10.6 ${x(12.3)},12.3 `  // baja por fuera
+    + `C ${x(12.35)},13.1 ${x(11.9)},13.6 ${x(11.0)},13.65 ` // tobillo
+    + `C ${x(10.1)},13.7 ${x(9.5)},13.2 ${x(9.5)},12.4 `
+    + `C ${x(9.45)},10.6 ${x(9.2)},8.6 ${x(8.6)},7.0 `      // corva interna
+    + `C ${x(9.1)},6.4 ${x(9.8)},6.3 ${x(10.3)},6.8 Z`
   );
 }
 
@@ -151,12 +151,12 @@ function canaTrasera(s) {
 function plantaTrasera(s) {
   const x = (v) => (s * v).toFixed(2);
   return (
-    `M ${x(9.6)},12.5 `
-    + `C ${x(8.7)},12.55 ${x(8.2)},13.05 ${x(8.25)},13.7 `   // talón (interno)
-    + `C ${x(8.3)},14.3 ${x(9.2)},14.6 ${x(10.5)},14.55 `
-    + `C ${x(12.1)},14.5 ${x(13.4)},14.25 ${x(13.8)},13.65 ` // dedos (externo)
-    + `C ${x(14.1)},13.15 ${x(13.7)},12.55 ${x(12.8)},12.45 `
-    + `C ${x(11.6)},12.3 ${x(10.5)},12.42 ${x(9.6)},12.5 Z`
+    `M ${x(9.3)},12.5 `
+    + `C ${x(8.4)},12.55 ${x(7.9)},13.05 ${x(7.95)},13.7 `   // talón (interno)
+    + `C ${x(8.0)},14.3 ${x(8.9)},14.6 ${x(10.2)},14.55 `
+    + `C ${x(11.8)},14.5 ${x(13.0)},14.25 ${x(13.4)},13.65 ` // dedos (externo)
+    + `C ${x(13.7)},13.15 ${x(13.3)},12.55 ${x(12.4)},12.45 `
+    + `C ${x(11.3)},12.3 ${x(10.2)},12.42 ${x(9.3)},12.5 Z`
   );
 }
 
@@ -172,14 +172,14 @@ function plantaTrasera(s) {
 function brazo(s) {
   const x = (v) => (s * v).toFixed(2);
   return (
-    `M ${x(9.9)},-7.6 `
-    + `C ${x(11.0)},-4.6 ${x(11.3)},-1.0 ${x(10.8)},2.2 `   // brazo por fuera
-    + `C ${x(10.4)},5.2 ${x(9.8)},8.2 ${x(9.2)},10.6 `      // antebrazo largo
-    + `C ${x(8.9)},11.8 ${x(8.2)},12.5 ${x(7.2)},12.7 `     // muñeca
-    + `C ${x(6.0)},12.9 ${x(5.2)},12.4 ${x(5.0)},11.4 `
-    + `C ${x(4.9)},9.0 ${x(5.4)},6.0 ${x(5.9)},3.0 `        // borde interno
-    + `C ${x(6.4)},0.0 ${x(6.8)},-3.2 ${x(7.3)},-6.2 `
-    + `C ${x(7.8)},-7.4 ${x(9.0)},-8.0 ${x(9.9)},-7.6 Z`
+    `M ${x(8.7)},-7.0 `
+    + `C ${x(9.4)},-4.4 ${x(9.6)},-1.4 ${x(9.3)},1.6 `      // brazo por fuera
+    + `C ${x(9.0)},4.6 ${x(8.6)},7.6 ${x(8.2)},10.1 `       // antebrazo largo
+    + `C ${x(7.9)},11.4 ${x(7.4)},12.1 ${x(6.6)},12.3 `     // muñeca
+    + `C ${x(5.8)},12.5 ${x(5.2)},12.0 ${x(5.1)},11.0 `
+    + `C ${x(5.2)},8.6 ${x(5.7)},5.6 ${x(6.1)},2.6 `        // borde interno
+    + `C ${x(6.5)},-0.4 ${x(6.8)},-3.4 ${x(7.1)},-5.8 `
+    + `C ${x(7.5)},-6.9 ${x(8.1)},-7.3 ${x(8.7)},-7.0 Z`
   );
 }
 
@@ -203,16 +203,16 @@ function mano(s) {
  * quedan ocultos tras la cabeza; los que se ven son los de los flancos, que es
  * justo donde hacía falta la costura. */
 const GOLILLA =
-  'M -8.8,-7.0 '
-  + 'C -8.5,-8.8 -7.6,-10.4 -6.2,-11.5 '
-  + 'C -5.6,-10.3 -5.0,-11.7 -4.4,-10.5 '
-  + 'C -3.9,-11.9 -3.2,-10.9 -2.6,-12.1 '
-  + 'C -1.8,-10.9 -1.0,-12.3 -0.2,-11.1 '
-  + 'C 0.6,-12.3 1.4,-10.9 2.2,-12.1 '
-  + 'C 2.8,-10.9 3.5,-11.9 4.0,-10.5 '
-  + 'C 4.6,-11.7 5.2,-10.3 5.8,-11.5 '
-  + 'C 7.2,-10.4 8.1,-8.8 8.4,-7.0 '
-  + 'C 5.6,-5.9 -6.0,-5.9 -8.8,-7.0 Z';
+  'M -8.0,-7.0 '
+  + 'C -7.8,-8.7 -7.0,-10.2 -5.8,-11.3 '
+  + 'C -5.3,-10.2 -4.7,-11.5 -4.2,-10.4 '
+  + 'C -3.7,-11.7 -3.1,-10.8 -2.5,-11.9 '
+  + 'C -1.7,-10.8 -1.0,-12.1 -0.2,-11.0 '
+  + 'C 0.6,-12.1 1.3,-10.8 2.1,-11.9 '
+  + 'C 2.7,-10.8 3.3,-11.7 3.8,-10.4 '
+  + 'C 4.3,-11.5 4.9,-10.2 5.4,-11.3 '
+  + 'C 6.6,-10.2 7.4,-8.7 7.6,-7.0 '
+  + 'C 5.0,-6.2 -5.4,-6.2 -8.0,-7.0 Z';
 
 /* LA LUNA CRECIENTE del pecho — el emblema conservado de la base. Media
    circunferencia externa (r 3.0, centrada en 0,-2.2) + arco interno tendido
@@ -268,6 +268,8 @@ export function OsoGuardian({
   const boil = `crt-boil-${uid}`;
   const pelaje = `crt-pelaje-${uid}`;
   const lunaGrad = `crt-luna-${uid}`;
+  const limboIzq = `osog-limbo-i-${uid}`;
+  const limboDer = `osog-limbo-d-${uid}`;
   /* HALOS POR GRADIENTE RADIAL (no por blur): los círculos blureados del kit
      recortan su región de filtro en un CUADRADO visible sobre el pelaje
      oscuro (verificado empíricamente con el halo de la luna). El gradiente
@@ -323,6 +325,22 @@ export function OsoGuardian({
         <stop offset="55%" stopColor={P.luna} />
         <stop offset="100%" stopColor="#dcf5e9" />
       </radialGradient>
+      {/* MIEMBROS CON VOLUMEN: un miembro relleno de color plano se lee como
+          una losa pegada encima del animal (fue el defecto de la pasada
+          anterior). Cada pata lleva la luz de luna en su borde EXTERNO y se
+          hunde en sombra hacia el cuerpo — así es un cilindro, no un recorte.
+          Van dos gradientes espejados porque `objectBoundingBox` mapea igual a
+          ambos lados y el de la derecha necesita la luz invertida. */}
+      <linearGradient id={limboIzq} x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stopColor={P.cuerpoLuz} />
+        <stop offset="42%" stopColor={P.pata} />
+        <stop offset="100%" stopColor={P.cuerpoSombra} />
+      </linearGradient>
+      <linearGradient id={limboDer} x1="100%" y1="0%" x2="0%" y2="0%">
+        <stop offset="0%" stopColor={P.cuerpoLuz} />
+        <stop offset="42%" stopColor={P.pata} />
+        <stop offset="100%" stopColor={P.cuerpoSombra} />
+      </linearGradient>
       {/* halos suaves sin filtro (ver nota en los ids) */}
       <radialGradient id={haloCrema}>
         <stop offset="0%" stopColor={P.lunaHalo} stopOpacity="1" />
@@ -393,15 +411,15 @@ export function OsoGuardian({
       <g aria-hidden="true">
         {[-1, 1].map((s) => (
           <g key={`tras${s}`}>
-            <path d={canaTrasera(s)} fill={P.pata} stroke={INK}
-              strokeWidth="0.85" strokeLinejoin="round" />
+            <path d={canaTrasera(s)} fill={`url(#${s < 0 ? limboIzq : limboDer})`}
+              stroke={INK} strokeWidth="0.85" strokeLinejoin="round" />
             <path d={plantaTrasera(s)} fill={P.planta} stroke={INK}
               strokeWidth="0.85" strokeLinejoin="round" />
           </g>
         ))}
         {/* garras traseras: en el borde EXTERNO, que es donde van los dedos */}
-        <Garras xs={[-13.4, -12.4, -11.4]} y={13.95} color={P.garra} largo={0.8} />
-        <Garras xs={[11.4, 12.4, 13.4]} y={13.95} color={P.garra} largo={0.8} />
+        <Garras xs={[-13.0, -12.0, -11.0]} y={13.95} color={P.garra} largo={0.8} />
+        <Garras xs={[11.0, 12.0, 13.0]} y={13.95} color={P.garra} largo={0.8} />
       </g>
 
       {/* RIM-LIGHT LUNAR — la luz que dibuja al guardián por el lado de la
@@ -409,10 +427,10 @@ export function OsoGuardian({
           neón de la base, vuelto luz de borde con criterio. */}
       <g aria-hidden="true" fill="none" strokeLinecap="round">
         {/* sigue el borde nuevo: costillar → cruz, que es donde la luz pega */}
-        <path d="M -11.4,4.2 C -10.6,-0.8 -10.0,-6.4 -6.6,-10.8" stroke={P.menta}
-          strokeWidth="0.85" opacity="0.55" style={{ filter: `drop-shadow(0 0 2.5px ${P.menta})` }} />
+        <path d="M -10.4,2.6 C -10.0,-1.0 -10.1,-4.6 -9.2,-7.2 C -8.8,-8.2 -8.2,-9.0 -7.4,-9.7" stroke={P.menta}
+          strokeWidth="0.85" opacity="0.5" style={{ filter: `drop-shadow(0 0 2.5px ${P.menta})` }} />
         {/* eco tenue en la grupa del otro flanco */}
-        <path d="M 11.4,3.6 C 12.3,7.0 12.9,10.4 11.4,12.8" stroke={P.menta}
+        <path d="M 11.0,3.6 C 12.1,7.0 12.7,10.4 11.2,12.8" stroke={P.menta}
           strokeWidth="0.7" opacity="0.18" />
       </g>
 
@@ -421,21 +439,15 @@ export function OsoGuardian({
       <g aria-hidden="true" fill="none" stroke={P.cuerpoLuz} strokeLinecap="round">
         {/* mechones cortos a contraluz: costillar, cintura y grupa */}
         <g strokeWidth="0.5" opacity="0.48">
-          <path d="M -10.7,-3.4 l 0.72,0.48 l -0.68,0.6 l 0.7,0.56" />
-          <path d="M 10.7,-2.6 l -0.72,0.48 l 0.68,0.6 l -0.7,0.56" />
-          <path d="M -11.9,6.4 l 0.75,0.5 l -0.7,0.62 l 0.72,0.58" />
-          <path d="M 12.1,7.4 l -0.75,0.5 l 0.7,0.62 l -0.72,0.58" />
+          <path d="M -11.9,5.6 C -11.4,6.4 -11.2,7.2 -11.4,8.0" />
+          <path d="M -11.6,9.0 C -11.2,9.7 -11.1,10.4 -11.3,11.0" />
+          <path d="M 12.0,6.6 C 11.5,7.4 11.3,8.2 11.5,9.0" />
         </g>
         {/* la ESCÁPULA sobre la cruz: el hueso que se marca cuando el oso
             carga el peso en las manos. Sin esto la cruz vuelve a ser un bulto */}
-        <g strokeWidth="0.5" opacity="0.26">
-          <path d="M -8.6,-9.6 C -8.0,-7.6 -7.4,-6.2 -6.6,-5.2" />
-          <path d="M 8.6,-9.6 C 8.0,-7.6 7.4,-6.2 6.6,-5.2" />
-        </g>
-        {/* el arco del costillar: el pecho es profundo, y se nota */}
-        <g strokeWidth="0.5" opacity="0.2">
-          <path d="M -8.8,-2.4 C -7.6,0.2 -5.2,1.6 -2.6,2.0" />
-          <path d="M 8.8,-2.4 C 7.6,0.2 5.2,1.6 2.6,2.0" />
+        <g strokeWidth="0.5" opacity="0.24">
+          <path d="M -8.1,-9.2 C -7.6,-7.6 -7.2,-6.4 -6.8,-5.4" />
+          <path d="M 8.1,-9.2 C 7.6,-7.6 7.2,-6.4 6.8,-5.4" />
         </g>
       </g>
 
@@ -444,12 +456,19 @@ export function OsoGuardian({
           cabeza al cuerpo: los mechones montan sobre las paletillas y pasan
           por detrás del cráneo. Con esto la cabeza deja de estar posada. */}
       <g aria-hidden="true">
-        <path d={GOLILLA} fill={P.cuerpo} stroke={INK} strokeWidth="0.9"
-          strokeLinejoin="round" opacity="0.96" />
-        {/* mechones a contraluz en las puntas de la golilla */}
-        <g fill="none" stroke={P.cuerpoLuz} strokeWidth="0.42" strokeLinecap="round" opacity="0.4">
-          <path d="M -6.6,-10.6 C -6.2,-9.4 -5.9,-8.4 -5.9,-7.4" />
-          <path d="M 6.6,-10.6 C 6.2,-9.4 5.9,-8.4 5.9,-7.4" />
+        {/* SIN TRAZO Y SIN BORDE RECTO. La segunda prueba de render la tenía
+            delineada y cerrando con una casi-horizontal a lo ancho del pecho:
+            leía cuello de camisa, y el oso entero pasaba a estar vestido. Una
+            golilla de pelo no tiene dobladillo. Va como SOMBRA suave —el
+            hueco entre cuello y hombros— y nada más. */}
+        <path d={GOLILLA} fill={P.cuerpoSombra} opacity="0.5" />
+        {/* el contraluz SOLO en las puntas de los mechones que asoman al lado
+            del cráneo: es lo que la vuelve pelaje y ata la cabeza al cuerpo */}
+        <g fill="none" stroke={P.cuerpoLuz} strokeWidth="0.42" strokeLinecap="round" opacity="0.38">
+          <path d="M -7.4,-9.4 C -7.0,-8.4 -6.7,-7.6 -6.6,-6.8" />
+          <path d="M -5.6,-10.6 C -5.3,-9.6 -5.1,-8.8 -5.1,-7.9" />
+          <path d="M 5.6,-10.6 C 5.3,-9.6 5.1,-8.8 5.1,-7.9" />
+          <path d="M 7.4,-9.4 C 7.0,-8.4 6.7,-7.6 6.6,-6.8" />
         </g>
       </g>
 
@@ -481,18 +500,33 @@ export function OsoGuardian({
           por fuera y recogen hacia el centro hasta la mano apoyada. El pecho
           queda libre entre las dos: ahí manda la luna. */}
       <g>
+        {/* SIN CONTORNO CERRADO. Un brazo delineado entero con la tinta de la
+            familia se despega del torso y el oso se lee VESTIDO: los brazos
+            pasan a mangas y el pecho a peto. Se vio clarísimo en la segunda
+            prueba de render. Un miembro que nace del mismo cuerpo no tiene
+            línea arriba — se funde en el hombro. Así que el brazo va relleno
+            sin trazo, y solo se dibujan DESPUÉS los dos filos que sí existen:
+            la sombra del borde interno y la luz del borde externo. */}
         {[-1, 1].map((s) => (
-          <path key={`brazo${s}`} d={brazo(s)} fill={P.pata} stroke={INK}
-            strokeWidth="0.85" strokeLinejoin="round" />
+          <path key={`brazo${s}`} d={brazo(s)} fill={`url(#${s < 0 ? limboIzq : limboDer})`} />
         ))}
-        {/* codo y antebrazo insinuados: sin esto el brazo vuelve a ser un tubo */}
-        <g aria-hidden="true" fill="none" stroke={P.cuerpoSombra} strokeWidth="0.5" opacity="0.45" strokeLinecap="round">
-          <path d="M -10.7,1.4 C -9.6,2.0 -8.2,2.1 -7.0,1.6" />
-          <path d="M 10.7,1.4 C 9.6,2.0 8.2,2.1 7.0,1.6" />
+        {/* el filo INTERNO: la sombra que separa el brazo del pecho */}
+        <g aria-hidden="true" fill="none" strokeLinecap="round" stroke={INK}
+          strokeWidth="0.75" strokeOpacity="0.4">
+          <path d="M -6.9,-3.6 C -6.4,1.0 -5.7,6.0 -5.1,10.8" />
+          <path d="M 6.9,-3.6 C 6.4,1.0 5.7,6.0 5.1,10.8" />
         </g>
-        {/* rim menta finísimo en el brazo del lado de la luna */}
-        <path d="M -10.9,-1.0 C -10.5,3.4 -9.9,7.6 -9.3,10.4" fill="none"
-          stroke={P.menta} strokeWidth="0.4" opacity="0.3" aria-hidden="true" />
+        {/* el filo EXTERNO: donde la luna moja el canto del brazo */}
+        <g aria-hidden="true" fill="none" strokeLinecap="round" stroke={P.cuerpoLuz}
+          strokeWidth="0.55" opacity="0.5">
+          <path d="M -9.4,-4.4 C -9.6,-1.4 -9.3,1.6 -9.0,4.6" />
+          <path d="M 9.4,-4.4 C 9.6,-1.4 9.3,1.6 9.0,4.6" />
+        </g>
+        {/* el CODO: el pliegue donde el brazo dobla. Sin él, tubo. */}
+        <g aria-hidden="true" fill="none" stroke={P.cuerpoSombra} strokeWidth="0.5" opacity="0.5" strokeLinecap="round">
+          <path d="M -9.3,1.0 C -8.4,1.7 -7.3,1.8 -6.2,1.4" />
+          <path d="M 9.3,1.0 C 8.4,1.7 7.3,1.8 6.2,1.4" />
+        </g>
         {[-1, 1].map((s) => (
           <path key={`mano${s}`} d={mano(s)} fill={P.planta} stroke={INK}
             strokeWidth="0.85" strokeLinejoin="round" />
@@ -506,7 +540,19 @@ export function OsoGuardian({
         <Garras xs={[4.9, 5.9, 6.9, 7.9]} y={13.5} color={P.garra} largo={0.85} />
       </g>
 
-      {/* ═══ CABEZA proporcionada, hundida en la joroba (sin cuello de peluche).
+      {/* ═══ LA RUANA del frío del páramo — la propia del guardián, no el
+          trapecio genérico de AccesoriosClima. Se cuelga de la cruz que este
+          rediseño le dio (sin hombro no hay dónde apoyarla), cae abierta al
+          frente dejando el pecho —y la luna— a la vista, y lleva la punta
+          echada al hombro, que es el gesto real de frío de verdad.
+
+          VA ANTES DE LA CABEZA a propósito: el canesú tiene que poder subir por
+          detrás del cuello para que se lea UNA prenda cruzando los hombros. Si
+          se dibuja después, o le tapa el hocico o hay que bajarlo tanto que los
+          dos paños quedan sueltos y la ruana se lee como dos mangas. */}
+      {ropa?.ruana && <RuanaGuardian animated={vivo} ink={INK} />}
+
+      {/* ═══ CABEZA proporcionada, hundida en la cruz (sin cuello de peluche).
           QUIETA a propósito: la gravitas del guardián. */}
       <g>
         {/* orejas CHICAS y bajas de oso real (detrás del cráneo) */}
@@ -593,12 +639,6 @@ export function OsoGuardian({
         {boca}
       </g>
 
-      {/* ═══ LA RUANA del frío del páramo — la propia del guardián, no el
-          trapecio genérico de AccesoriosClima. Se cuelga de la cruz que este
-          rediseño le dio (sin hombro no hay dónde apoyarla), cae abierta al
-          frente dejando el pecho —y la luna— a la vista, y lleva la punta
-          echada al hombro, que es el gesto real de frío de verdad. */}
-      {ropa?.ruana && <RuanaGuardian animated={vivo} ink={INK} />}
 
       {/* Prop del mundo junto a la zarpa. */}
       {propMundo}

--- a/src/visual/creatures/OsoGuardian.jsx
+++ b/src/visual/creatures/OsoGuardian.jsx
@@ -156,7 +156,7 @@ export function OsoGuardian({
   const raizRef = useRef(null);
   const ritmoPropio = useRitmoPropio();
   const enBase = pose === 'anda' && !resopla && !rasca && !visema;
-  const momento = useVidaIdle('oso-andino', vida && vivo && tier !== 'bajo' && enBase);
+  const momento = useVidaIdle('oso-guardian', vida && vivo && tier !== 'bajo' && enBase);
   useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
   const resoplaFx = resopla || momento === 'resopla';
   const rascaFx = rasca || momento === 'rasca';

--- a/src/visual/creatures/OsoGuardian.jsx
+++ b/src/visual/creatures/OsoGuardian.jsx
@@ -1,0 +1,516 @@
+import { useId, useRef } from 'react';
+import './creatures.css';
+import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
+import { CreatureFilters } from './_filters.jsx';
+import { BocaVisema } from './_rubberhose.jsx';
+import {
+  OSO_GUARDIAN_PALETA, OSO_GUARDIAN_PROPORCION, OSO_GUARDIAN_RUANA_ANCLA,
+  OSO_GUARDIAN_SLUG, OSO_GUARDIAN_TINTA, PERFIL_OSO_GUARDIAN,
+} from './osoGuardianIdentidad.js';
+import { cuerpoDeClima, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
+import { AccesoriosClima } from './AccesoriosClima.jsx';
+import { LineBoilFilter } from './LineBoilFilter.jsx';
+import { PropEnMano } from './PropEnMano.jsx';
+import { AuraPoder } from './AuraPoder.jsx';
+import { auraDeBicho } from './transformacion.js';
+
+/* Oso guardián — Tremarctos ornatus, EL GUARDIÁN NEGRO DE LA LUNA.
+   Tercera y definitiva dirección de arte del oso de anteojos, sobre la BASE
+   aprobada por el operador (dashboard/GuardianEspiritu → AvatarOso): pelaje
+   AZABACHE AZULADO casi silueta, luz MENTA medida en el contorno, la LUNA
+   CRECIENTE crema en el pecho (su emblema, conservado) y los anteojos del oso
+   andino hechos de AROS DE LUZ que respiran.
+
+   QUÉ CORRIGE de los dos osos rechazados (el café OsoAndino y el OsoAnteojos
+   de peluche) — el mandato "que no se vea tan infantil":
+   · PROPORCIONES DE ADULTO: cabeza chica (ratio cabeza:hombros ≈ 1:3, antes
+     ≈ 1:1.6) hundida en una JOROBA de hombros anchos; la silueta es un PATH
+     propio de mole plantígrada sentada como montaña — no el círculo-sobre-
+     elipse del peluche. Hocico canela PRESENTE que proyecta del cráneo,
+     carrilleras que ensanchan la cara abajo (cara adulta, no carita redonda).
+   · OJOS CON ALMA, NO DE JUGUETE: almendras oscuras de párpado pesado con
+     iris menta-luz chico y catchlight — dentro de los aros luminosos. Nada de
+     esclerótica blanca con pupila gigante (OjosRubber queda fuera adrede).
+   · SIN TERNURA POSTIZA: cero cachetes de rubor, cero sonrisa amplia (la boca
+     es un arco breve y calmo), orejas chicas y bajas de oso real. QUIETUD:
+     la cabeza no se mece — la gravitas vive en el respirar lento de la mole,
+     el aliento de los aros y el latido de la luna.
+   · PRESENCIA SIN MIEDO (registro Mufasa): impone por MASA (sombra de suelo,
+     boil pesado oso-boil, garras visibles pero romas) y serenidad (cejas casi
+     horizontales con caída interna mínima), jamás por amenaza: ni colmillos,
+     ni ceño bravo, ni ojos vacíos.
+
+   Hereda la fundación transversal de la familia (cero código duplicado):
+   lip-sync (BocaVisema), clima→cuerpo (PERFIL_OSO_GUARDIAN), ropa por clima
+   (fila 'oso-andino': misma especie, mismos umbrales de páramo), vida propia
+   (repertorio 'oso-andino': resopla/rasca/reposo — aquí el rascado es un
+   remecerse de peso, digno), line-boil y modo poder (aura MENTA). Todo se
+   PODA en tier bajo / reduced-motion a un fotograma digno y quieto. */
+const VIEWBOX = '-16 -20 32 40';
+
+/* GARRAS del plantígrado: cuatro uñas cortas y ROMAS que asoman del borde de
+   la planta, en hueso-menta que agarra la luz de luna. Identidad de especie y
+   señal de adulto — nunca amenaza (curvas suaves, puntas redondas). */
+function Garras({ xs, y, color, largo = 1.2 }) {
+  return (
+    <g aria-hidden="true" stroke={color} strokeWidth="0.55" strokeLinecap="round" fill="none" opacity="0.9">
+      {xs.map((x, i) => (
+        <path key={i} d={`M${x},${y} q0.12,${largo * 0.62} 0.02,${largo}`} />
+      ))}
+    </g>
+  );
+}
+
+/* ESPORAS del bosque nublado — bioluminiscencia que flota lento alrededor de
+   la mole (reusa la cadencia osoa-mota ya existente). Delays/duraciones
+   propios: vida, no metrónomo. */
+const ESPORAS = [
+  { cx: -11.8, cy: -5.2, r: 0.46, d: 0, s: 6.9 },
+  { cx: 12.2, cy: -1.4, r: 0.4, d: -2.2, s: 7.5 },
+  { cx: -9.6, cy: 9.4, r: 0.34, d: -3.9, s: 6.1 },
+  { cx: 10.2, cy: -8.8, r: 0.44, d: -1.5, s: 6.5 },
+  { cx: -13.2, cy: 1.6, r: 0.3, d: -4.8, s: 7.8 },
+];
+
+/* LA SILUETA DE LA MOLE (el corazón del rediseño): un solo path de oso sentado
+   como montaña — joroba de hombros arriba, flancos que se abren a las ancas,
+   asiento ancho. Nada de elipse de peluche. */
+const SILUETA_MOLE =
+  'M -10.9,13.1 '
+  + 'C -13.3,10.6 -13.9,6.2 -12.6,1.8 '
+  + 'C -11.8,-1.6 -10.7,-4.2 -9.0,-6.3 '
+  + 'C -7.2,-8.6 -4.0,-9.8 0,-9.8 '
+  + 'C 4.0,-9.8 7.2,-8.6 9.0,-6.3 '
+  + 'C 10.7,-4.2 11.8,-1.6 12.6,1.8 '
+  + 'C 13.9,6.2 13.3,10.6 10.9,13.1 '
+  + 'C 7.4,13.9 -7.4,13.9 -10.9,13.1 Z';
+
+/* LA LUNA CRECIENTE del pecho — el emblema conservado de la base. Media
+   circunferencia externa (r 3.0, centrada en 0,-2.2) + arco interno tendido
+   (r 3.4) = creciente que abre a la derecha. Ligeramente rotada: un emblema
+   colgado con gracia, no un icono clavado. */
+const LUNA_CRECIENTE = 'M 0,-5.55 A 3.35,3.35 0 1 0 0,1.15 A 3.8,3.8 0 0 1 0,-5.55 Z';
+
+export function OsoGuardian({
+  size = 64,
+  className = '',
+  inline = false,
+  animated = true,
+  title = 'Oso guardián',
+  /* Pose de VIDA species-agnostic (gestos rh-g-* de creatures.css):
+     'anda' (base) | 'celebra' | 'reposo' | 'señala'. Con animated=false o
+     reduced-motion queda en fotograma digno. */
+  pose = 'anda',
+  animo = 'sereno',
+  energia = 1,
+  /* CLIMA REAL escrito en el cuerpo (perfil de bosque altoandino). Sin clima
+     (avatares, catálogo) = neutro digno. */
+  clima = null,
+  enso = 'neutro',
+  /* Lip-sync transversal (useLipSync → 'V1'..'V4'). Sin visema = el arco
+     breve y calmo de siempre. */
+  visema = null,
+  /* Vestuario por clima+hora (opt-in): RUANA de noche/frío del páramo. Nunca
+     sombrero ni sudor (el oso de niebla no se acalora). */
+  vestuario = false,
+  tempC = undefined,
+  /* RESOPLA (opt-in): el huff pesado del guardián — vaho por la trufa, pecho
+     que hincha y suelta. Refunfuño grave, no berrinche. */
+  resopla = false,
+  /* RASCA (opt-in): en este oso el "rascado" del repertorio es un REMECERSE
+     de peso lento (oso-rasca-cuerpo), sin manoteo — la mole se acomoda. */
+  rasca = false,
+  /* VIDA PROPIA (idle-cerebro v2): default ON. Reusa el repertorio
+     'oso-andino' de vidaEstados.js (misma especie, mismo temperamento lento). */
+  vida = true,
+  /* Device-tier: 'bajo' apaga el idle continuo; quedan los estados reactivos. */
+  tier,
+  /* Line-boil (opt-in, capa cara): reservado para su entrada heroica. */
+  lineBoil = false,
+  /* MODO PODER (opt-in, standalone): aura MENTA bioluminiscente. */
+  poder = false,
+  /* Prop por mundo (opt-in): la herramienta en su zarpa izquierda. */
+  mundoId = null,
+  ...rest
+}) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const glow = `crt-glow-${uid}`;
+  const blur = `crt-blur-${uid}`;
+  const boil = `crt-boil-${uid}`;
+  const pelaje = `crt-pelaje-${uid}`;
+  const lunaGrad = `crt-luna-${uid}`;
+  /* HALOS POR GRADIENTE RADIAL (no por blur): los círculos blureados del kit
+     recortan su región de filtro en un CUADRADO visible sobre el pelaje
+     oscuro (verificado empíricamente con el halo de la luna). El gradiente
+     cae suave hasta opacidad 0 sin filtro — y es más barato en GPU. */
+  const haloCrema = `osog-halo-crema-${uid}`;
+  const haloMenta = `osog-halo-menta-${uid}`;
+  const haloSombra = `osog-halo-sombra-${uid}`;
+  const vivo = animated;
+  const auraOp = Math.max(0.08, Math.min(0.26, 0.1 + 0.16 * (energia ?? 1)));
+  const auraR = 9.5 + 1.6 * (energia ?? 1);
+
+  // ═══ VIDA PROPIA (idle-cerebro + ritmo propio + mirada — vara Angelita v2).
+  // Repertorio 'oso-andino': misma especie (Tremarctos), temperamento lento ya
+  // afinado — cero filas duplicadas.
+  const raizRef = useRef(null);
+  const ritmoPropio = useRitmoPropio();
+  const enBase = pose === 'anda' && !resopla && !rasca && !visema;
+  const momento = useVidaIdle('oso-andino', vida && vivo && tier !== 'bajo' && enBase);
+  useMiradaUsted(raizRef, vida && vivo && tier !== 'bajo');
+  const resoplaFx = resopla || momento === 'resopla';
+  const rascaFx = rasca || momento === 'rasca';
+  const poseFx = momento === 'reposo' ? 'reposo' : pose;
+
+  // CLIMA → cuerpo (determinista): tinte + opacidad al contorno. Sin alas.
+  const cuerpoClima = cuerpoDeClima(clima, { enso: /** @type {any} */ (enso), tier, perfil: PERFIL_OSO_GUARDIAN });
+  const estiloClima = (cuerpoClima.tinte || cuerpoClima.opacidad < 1)
+    ? { filter: cuerpoClima.tinte || undefined, opacity: cuerpoClima.opacidad < 1 ? cuerpoClima.opacidad : undefined }
+    : undefined;
+
+  // Vestuario por clima+hora (opt-in): fila 'oso-andino' compartida (misma
+  // especie, mismos umbrales de páramo). Sombrero/sudor suprimidos SIEMPRE.
+  const ropaBase = (vestuario && clima) ? ropaDeClimaBicho('oso-andino', clima, { tempC }) : null;
+  const ropa = ropaBase ? { ...ropaBase, sombrero: false, sudor: false } : null;
+
+  const P = OSO_GUARDIAN_PALETA;
+  const PR = OSO_GUARDIAN_PROPORCION;
+  const INK = OSO_GUARDIAN_TINTA;
+
+  const defs = (
+    <defs>
+      <CreatureFilters glow={glow} blur={blur} />
+      {/* PELAJE CON VOLUMEN: luz de luna azulada arriba-izquierda → azabache
+          medio → sombra ventral casi negra. Viste mole y cráneo. */}
+      <radialGradient id={pelaje} cx="40%" cy="26%" r="88%">
+        <stop offset="0%" stopColor={P.cuerpoLuz} />
+        <stop offset="50%" stopColor={P.cuerpo} />
+        <stop offset="100%" stopColor={P.cuerpoSombra} />
+      </radialGradient>
+      {/* LA LUNA con cuerpo propio: crema-luz al borde iluminado → crema-sombra
+          hacia el interior (que no sea un sticker plano). */}
+      <radialGradient id={lunaGrad} cx="30%" cy="35%" r="90%">
+        <stop offset="0%" stopColor="#ffffff" />
+        <stop offset="55%" stopColor={P.luna} />
+        <stop offset="100%" stopColor="#dcf5e9" />
+      </radialGradient>
+      {/* halos suaves sin filtro (ver nota en los ids) */}
+      <radialGradient id={haloCrema}>
+        <stop offset="0%" stopColor={P.lunaHalo} stopOpacity="1" />
+        <stop offset="55%" stopColor={P.lunaHalo} stopOpacity="0.55" />
+        <stop offset="100%" stopColor={P.lunaHalo} stopOpacity="0" />
+      </radialGradient>
+      <radialGradient id={haloMenta}>
+        <stop offset="0%" stopColor={P.menta} stopOpacity="1" />
+        <stop offset="55%" stopColor={P.menta} stopOpacity="0.5" />
+        <stop offset="100%" stopColor={P.menta} stopOpacity="0" />
+      </radialGradient>
+      <radialGradient id={haloSombra}>
+        <stop offset="0%" stopColor="#040a12" stopOpacity="0.55" />
+        <stop offset="70%" stopColor="#040a12" stopOpacity="0.3" />
+        <stop offset="100%" stopColor="#040a12" stopOpacity="0" />
+      </radialGradient>
+      {lineBoil && <LineBoilFilter id={boil} animated={vivo} />}
+    </defs>
+  );
+
+  // VAHO del resoplido: motas frías que salen de la trufa y se disuelven.
+  const vaho = resoplaFx ? (
+    <g className="crt-vaho" fill={P.lunaHalo} aria-hidden="true" opacity="0.65">
+      <circle className={vivo ? 'crt-vaho-mota' : undefined} cx="2.4" cy="-8.8" r="1.0" />
+      <circle className={vivo ? 'crt-vaho-mota' : undefined} style={{ animationDelay: '-0.7s' }} cx="3.3" cy="-7.8" r="0.8" />
+    </g>
+  ) : null;
+
+  // PROP DEL MUNDO junto a la zarpa izquierda.
+  const propMundo = mundoId ? (
+    <PropEnMano mundoId={mundoId} x={-11.3} y={8.6} escala={0.74} ink={INK} animated={vivo} />
+  ) : null;
+
+  // BOCA: lip-sync si narra; si no, el arco BREVE y calmo (no sonrisa amplia
+  // de mascota — serenidad, no ternura postiza).
+  // BOCA: lip-sync si narra (BocaVisema del kit); si no, un arco BREVE y calmo
+  // en trazo fino — la Sonrisa del kit (0.9 de grosor) se funde con la trufa a
+  // esta escala de hocico y hace blob; el guardián lleva la boca apenas dicha.
+  const boca = visema
+    ? <BocaVisema cx={0} cy={-8.8} w={2.4} prof={0.8} visema={visema} ink={INK} />
+    : (
+      <path d="M -1.05,-8.85 Q 0,-8.42 1.05,-8.85" fill="none"
+        stroke={INK} strokeWidth="0.5" strokeLinecap="round" />
+    );
+
+  // ── EL DIBUJO (atrás→adelante): sombra de suelo, aura menta, patas traseras
+  //    asomando, LA MOLE (path propio), rim-light lunar + pelaje sugerido,
+  //    LA LUNA del pecho, columnas delanteras con garras, cabeza (orejas
+  //    chicas, cráneo, carrilleras, aros de luz, ojos-almendra, hocico canela),
+  //    bruma y esporas. `.crt-body` respira con oso-boil (pesado, lento).
+  const body = (
+    <g className={`crt-body${vivo ? ' rh-boil' : ''}`} filter={`url(#${glow})`}>
+      {/* SOMBRA DE SUELO — el peso de la montaña (masa real, no sticker). */}
+      <ellipse cx="0" cy="14.35" rx="12.4" ry="2.1" fill={`url(#${haloSombra})`} aria-hidden="true" />
+      {/* aura menta tenue: bioluminiscencia de niebla, no neón de feria */}
+      <circle cx="0" cy="1.5" r={auraR + 2} fill={`url(#${haloMenta})`} opacity={auraOp * 0.5} />
+
+      {/* PATAS TRASERAS del plantígrado sentado: las plantas asoman adelante,
+          a los lados de la mole (postura real de oso sentado). */}
+      <g aria-hidden="true">
+        <ellipse cx="-10.5" cy="13.15" rx="2.35" ry="1.35" fill={P.planta} stroke={INK} strokeWidth="0.8" />
+        <ellipse cx="10.5" cy="13.15" rx="2.35" ry="1.35" fill={P.planta} stroke={INK} strokeWidth="0.8" />
+        <Garras xs={[-11.5, -10.5, -9.5]} y={13.9} color={P.garra} largo={0.95} />
+        <Garras xs={[9.5, 10.5, 11.5]} y={13.9} color={P.garra} largo={0.95} />
+      </g>
+
+      {/* ═══ LA MOLE — la silueta que manda: joroba de hombros, flancos a las
+          ancas, asiento de montaña. El halo menta va MEDIDO en el drop-shadow
+          (la estética del avatar aprobado, sin contorno de neón chillón). */}
+      <path d={SILUETA_MOLE} fill={`url(#${pelaje})`} stroke={INK} strokeWidth="1.35"
+        strokeLinejoin="round" style={{ filter: `drop-shadow(0 0 6px ${P.cuerpoGlow})` }} />
+
+      {/* RIM-LIGHT LUNAR — la luz que dibuja al guardián por el lado de la
+          luna (izquierdo), con un eco tenue al flanco derecho. Es EL trazo
+          neón de la base, vuelto luz de borde con criterio. */}
+      <g aria-hidden="true" fill="none" strokeLinecap="round">
+        <path d="M -12.4,3.0 C -11.6,-2.2 -9.6,-6.3 -5.2,-8.9" stroke={P.menta}
+          strokeWidth="0.85" opacity="0.55" style={{ filter: `drop-shadow(0 0 2.5px ${P.menta})` }} />
+        <path d="M 12.45,4.0 C 12.9,7.4 12.4,10.6 10.9,13.0" stroke={P.menta}
+          strokeWidth="0.7" opacity="0.18" />
+      </g>
+
+      {/* PELAJE SUGERIDO en la silueta: mechones cortos a contraluz en joroba,
+          flancos y ancas + definición muscular tenue (deltoides y pectoral).
+          Sugiere, no delinea — la mole sigue siendo casi silueta. */}
+      <g aria-hidden="true" fill="none" stroke={P.cuerpoLuz} strokeLinecap="round">
+        <g strokeWidth="0.5" opacity="0.5">
+          <path d="M -4.6,-9.15 l 0.5,-0.55 l 0.45,0.62 l 0.5,-0.55" />
+          <path d="M 4.6,-9.15 l -0.5,-0.55 l -0.45,0.62 l -0.5,-0.55" />
+          <path d="M -12.9,4.6 l 0.75,0.5 l -0.7,0.62 l 0.72,0.58" />
+          <path d="M 12.9,5.6 l -0.75,0.5 l 0.7,0.62 l -0.72,0.58" />
+          <path d="M -11.9,9.2 l 0.7,0.4 l -0.6,0.6" />
+        </g>
+        <g strokeWidth="0.55" opacity="0.22">
+          <path d="M -9.9,-4.4 C -8.7,-2.0 -7.3,-0.6 -5.5,0.3" />
+          <path d="M 9.9,-4.4 C 8.7,-2.0 7.3,-0.6 5.5,0.3" />
+          <path d="M -3.4,-6.4 C -1.5,-5.3 1.5,-5.3 3.4,-6.4" />
+        </g>
+      </g>
+
+      {/* derrame de luz de la luna sobre el vientre (bajísima opacidad) */}
+      <ellipse cx="0" cy="7" rx="2.6" ry="3.6" fill={P.lunaHalo} opacity="0.04" aria-hidden="true" />
+
+      {/* ═══ LA LUNA CRECIENTE — el emblema del pecho, CONSERVADO de la base y
+          con PRESENCIA real (no un sticker apagado): halo que respira
+          (osog-luna), cuerpo blanco-crema encendido, mares tenues y un anillo
+          de radiancia menta apenas insinuado. */}
+      <g aria-hidden="true">
+        <circle className={vivo ? 'osog-luna' : undefined} cx="-0.9" cy="-2.2" r="5.4"
+          fill={`url(#${haloCrema})`} opacity="0.26" />
+        <circle cx="-0.6" cy="-2.2" r="3.9" fill="none" stroke={P.menta} strokeWidth="0.35" opacity="0.12" />
+        <g transform="rotate(14 0 -2.2)">
+          <path d={LUNA_CRECIENTE} fill={`url(#${lunaGrad})`}
+            style={{ filter: `drop-shadow(0 0 5px ${P.lunaHalo})` }} />
+          {/* mares de la luna: el emblema tiene textura, no es una calcomanía */}
+          <g fill={P.lunaSombra} opacity="0.45">
+            <circle cx="-1.8" cy="-3.6" r="0.46" />
+            <circle cx="-2.35" cy="-1.5" r="0.3" />
+            <circle cx="-1.15" cy="-0.3" r="0.24" />
+          </g>
+        </g>
+      </g>
+
+      {/* PATAS DELANTERAS: columnas plantadas CORTAS (nacen bajo la luna — el
+          pecho queda abierto para el emblema), redondeadas arriba, en sombra
+          propia para despegarlas del pecho; plantas anchas y GARRAS visibles. */}
+      <g>
+        <path d="M -7.7,1.0 C -8.3,4.4 -8.3,8.6 -7.7,12.2 C -6.5,12.8 -5.1,12.8 -4.2,12.3 C -4.6,8.6 -4.6,4.6 -4.3,1.6 C -5.4,0.5 -6.9,0.4 -7.7,1.0 Z"
+          fill={P.pata} stroke={INK} strokeWidth="0.85" strokeLinejoin="round" />
+        <path d="M 7.7,1.0 C 8.3,4.4 8.3,8.6 7.7,12.2 C 6.5,12.8 5.1,12.8 4.2,12.3 C 4.6,8.6 4.6,4.6 4.3,1.6 C 5.4,0.5 6.9,0.4 7.7,1.0 Z"
+          fill={P.pata} stroke={INK} strokeWidth="0.85" strokeLinejoin="round" />
+        {/* rim menta finísimo en la columna del lado de la luna */}
+        <path d="M -7.5,2.2 C -8.05,5.2 -8.05,8.8 -7.5,11.8" fill="none"
+          stroke={P.menta} strokeWidth="0.4" opacity="0.28" aria-hidden="true" />
+        <ellipse cx="-6.0" cy="12.7" rx="2.5" ry="1.45" fill={P.planta} stroke={INK} strokeWidth="0.85" />
+        <ellipse cx="6.0" cy="12.7" rx="2.5" ry="1.45" fill={P.planta} stroke={INK} strokeWidth="0.85" />
+        <Garras xs={[-7.6, -6.55, -5.5, -4.45]} y={13.35} color={P.garra} />
+        <Garras xs={[4.45, 5.5, 6.55, 7.6]} y={13.35} color={P.garra} />
+      </g>
+
+      {/* ═══ CABEZA proporcionada, hundida en la joroba (sin cuello de peluche).
+          QUIETA a propósito: la gravitas del guardián. */}
+      <g>
+        {/* orejas CHICAS y bajas de oso real (detrás del cráneo) */}
+        <g aria-hidden="true">
+          <circle cx="-3.05" cy="-15.85" r={PR.orejaR} fill={P.cuerpo} stroke={INK} strokeWidth="1.05" />
+          <circle cx="-3.05" cy="-15.85" r={PR.orejaR * 0.44} fill="#352a63" />
+          <circle cx="3.05" cy="-15.85" r={PR.orejaR} fill={P.cuerpo} stroke={INK} strokeWidth="1.05" />
+          <circle cx="3.05" cy="-15.85" r={PR.orejaR * 0.44} fill="#352a63" />
+        </g>
+        {/* cráneo (elipse levemente más ancha que alta: testa de oso adulto) */}
+        <ellipse cx="0" cy="-12.9" rx={PR.cabezaRx} ry={PR.cabezaRy}
+          fill={`url(#${pelaje})`} stroke={INK} strokeWidth="1.25" />
+        {/* rim lunar del cráneo (el lado de la luna) */}
+        <path d="M -4.05,-13.6 C -3.3,-15.6 -1.5,-16.5 0.4,-16.45" fill="none"
+          stroke={P.menta} strokeWidth="0.6" opacity="0.4" strokeLinecap="round" aria-hidden="true" />
+        {/* CARRILLERAS: sombras que ensanchan la cara abajo — cara adulta,
+            no carita redonda de cría */}
+        <g aria-hidden="true" fill={P.cuerpoSombra} opacity="0.55">
+          <ellipse cx="-2.9" cy="-10.4" rx="1.7" ry="1.4" />
+          <ellipse cx="2.9" cy="-10.4" rx="1.7" ry="1.4" />
+        </g>
+        {/* mechones de mejilla a contraluz */}
+        <g aria-hidden="true" fill="none" stroke={P.cuerpoLuz} strokeWidth="0.45" strokeLinecap="round" opacity="0.45">
+          <path d="M -4.15,-11.6 l 0.66,0.3 l -0.55,0.5" />
+          <path d="M 4.15,-11.6 l -0.66,0.3 l 0.55,0.5" />
+        </g>
+
+        {/* aliento de los AROS (detrás del trazo): respira despacio */}
+        <g className={vivo ? 'osoa-anteojo-brillo' : undefined} aria-hidden="true"
+          style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+          <circle cx="-1.85" cy="-13.05" r="2.6" fill={`url(#${haloCrema})`} opacity="0.32" />
+          <circle cx="1.85" cy="-13.05" r="2.6" fill={`url(#${haloCrema})`} opacity="0.32" />
+        </g>
+        {/* ═══ LOS ANTEOJOS DE LUZ — la firma de la base, asimétricos como el
+            patrón real: el izquierdo casi cierra; el derecho abre por abajo y
+            DERRAMA su lágrima por el hocico, camino de la luna del pecho. */}
+        <g aria-hidden="true" fill="none" strokeLinecap="round">
+          <ellipse cx="-1.85" cy="-13.05" rx="1.52" ry="1.68" transform="rotate(-8 -1.85 -13.05)"
+            stroke={P.anteojo} strokeWidth="0.8" strokeDasharray="8.6 1.5" strokeDashoffset="-2.2"
+            style={{ filter: `drop-shadow(0 0 2.5px ${P.anteojoGlow})` }} />
+          <ellipse cx="1.85" cy="-13.05" rx="1.52" ry="1.68" transform="rotate(8 1.85 -13.05)"
+            stroke={P.anteojo} strokeWidth="0.8" strokeDasharray="7.6 2.5" strokeDashoffset="-8.6"
+            style={{ filter: `drop-shadow(0 0 2.5px ${P.anteojoGlow})` }} />
+          <path d="M 3.05,-11.8 C 3.55,-10.5 3.35,-9.3 2.55,-8.35"
+            stroke={P.anteojo} strokeWidth="0.7" opacity="0.85" />
+        </g>
+
+        {/* CEJAS del sereno: casi horizontales, caída interna mínima —
+            seriedad noble (Mufasa), jamás ceño bravo. Respiran apenas
+            (oso-cejas) y se aprietan al resoplar. */}
+        <g className="oso-cejas" stroke={P.ceja} strokeWidth="0.85" strokeLinecap="round" fill="none" opacity="0.85">
+          <path d="M -3.1,-14.88 C -2.35,-15.28 -1.35,-15.24 -0.8,-14.96" />
+          <path d="M 3.1,-14.88 C 2.35,-15.28 1.35,-15.24 0.8,-14.96" />
+        </g>
+
+        {/* ═══ OJOS-ALMENDRA con alma (no ojos-juguete): párpado pesado, iris
+            menta-luz chico, pupila honda y catchlight. Parpadean y dardean con
+            el kit (rh-blink / rh-mirada). */}
+        <g className={vivo ? 'rh-blink' : undefined} style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
+          <path d="M -2.82,-13.05 Q -1.85,-13.9 -0.88,-13.05 Q -1.85,-12.32 -2.82,-13.05 Z"
+            fill={P.ojo} stroke={INK} strokeWidth="0.3" />
+          <path d="M 0.88,-13.05 Q 1.85,-13.9 2.82,-13.05 Q 1.85,-12.32 0.88,-13.05 Z"
+            fill={P.ojo} stroke={INK} strokeWidth="0.3" />
+          <g className={vivo ? 'rh-mirada' : undefined}>
+            <circle cx="-1.85" cy="-13.0" r="0.6" fill={P.iris} opacity="0.95" />
+            <circle cx="1.85" cy="-13.0" r="0.6" fill={P.iris} opacity="0.95" />
+            <circle cx="-1.85" cy="-13.0" r="0.33" fill="#03120c" />
+            <circle cx="1.85" cy="-13.0" r="0.33" fill="#03120c" />
+            <circle cx="-2.05" cy="-13.2" r="0.15" fill={P.luna} />
+            <circle cx="1.65" cy="-13.2" r="0.15" fill={P.luna} />
+          </g>
+        </g>
+
+        {/* HOCICO canela PRESENTE (proyecta del cráneo — la única nota cálida,
+            heredada del avatar aprobado): puente, trufa con brillo frío,
+            surco y la boca calma. */}
+        <path d="M -1.75,-12.2 C -2.15,-10.35 -1.5,-8.6 0,-8.35 C 1.5,-8.6 2.15,-10.35 1.75,-12.2 C 1.05,-13.0 -1.05,-13.0 -1.75,-12.2 Z"
+          fill={P.hocico} stroke={INK} strokeWidth="0.75" strokeLinejoin="round" />
+        <path d="M -0.95,-12.35 C -0.3,-12.65 0.3,-12.65 0.95,-12.35" fill="none"
+          stroke={P.hocicoSombra} strokeWidth="0.45" opacity="0.6" aria-hidden="true" />
+        <ellipse cx="0" cy="-9.85" rx="0.88" ry="0.62" fill={P.trufa} />
+        <ellipse cx="-0.3" cy="-10.05" rx="0.26" ry="0.16" fill={P.lunaHalo} opacity="0.5" />
+        <path d="M 0,-9.25 L 0,-9.0" stroke={INK} strokeWidth="0.4" strokeLinecap="round" />
+        {boca}
+      </g>
+
+      {/* Vestuario por clima+hora (RUANA de noche/frío del páramo). El ancla NO
+          es la mole entera: es OSO_GUARDIAN_RUANA_ANCLA, calculada para que el
+          poncho se apoye sobre el lomo y deje ver la luna del pecho (ver la
+          nota con las desigualdades en osoGuardianIdentidad.js). */}
+      {ropa && (
+        <AccesoriosClima
+          estado={ropa}
+          tronco={OSO_GUARDIAN_RUANA_ANCLA}
+          cabeza={{ cx: 0, cy: -12.9, r: PR.cabezaRx }}
+          animated={vivo}
+        />
+      )}
+
+      {/* Prop del mundo junto a la zarpa. */}
+      {propMundo}
+
+      {/* Vaho del resoplido (el huff grave del guardián). */}
+      {vaho}
+
+      {/* BRUMA a los pies — el velo del bosque nublado (tenue). */}
+      <ellipse cx="0" cy="13.7" rx="11.6" ry="2.3" fill={`url(#${haloMenta})`} opacity="0.09"
+        aria-hidden="true" />
+
+      {/* ESPORAS del bosque nublado (cadencia osoa-mota compartida). */}
+      <g aria-hidden="true" fill={P.espora}>
+        {ESPORAS.map((m, i) => (
+          <circle key={i} className={vivo ? 'osoa-mota' : undefined}
+            cx={m.cx} cy={m.cy} r={m.r} opacity="0.3"
+            style={vivo ? { animationDelay: `${m.d}s`, animationDuration: `${m.s}s` } : undefined} />
+        ))}
+      </g>
+    </g>
+  );
+
+  // Antics de VIDA solo viva; el CSS los apaga con RM / tier bajo / estados
+  // (un guardián que resopla no da además vueltas de campana).
+  const conAntics = vivo ? (
+    <g className="rh-antic">
+      <g className="rh-travieso">{body}</g>
+    </g>
+  ) : body;
+  const cuerpoVivo = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
+
+  const estadoAttrs = {
+    'data-creature': OSO_GUARDIAN_SLUG,
+    'data-pose': vivo ? poseFx : undefined,
+    'data-animo': animo,
+    'data-tier': tier || undefined,
+    'data-visema': visema || undefined,
+    'data-ruana': ropa?.ruana ? '1' : undefined,
+    'data-mojado': ropa?.mojado ? '1' : undefined,
+    'data-resopla': resoplaFx ? '1' : undefined,
+    'data-rasca': rascaFx ? '1' : undefined,
+    'data-vida': momento || undefined,
+    'data-lineboil': lineBoil ? '1' : undefined,
+    'data-prop': mundoId || undefined,
+  };
+  const estiloRaiz = { ...ritmoPropio, ...estiloClima };
+
+  if (inline) {
+    // En modo inline el power-up lo pone el host DOM; acá solo data-poder.
+    return (
+      <g ref={raizRef} className={className} style={estiloRaiz} data-poder={poder ? '1' : undefined} {...estadoAttrs}>
+        {defs}
+        {cuerpoVivo}
+      </g>
+    );
+  }
+  const svg = (
+    <svg ref={raizRef} viewBox={VIEWBOX} width={size} height={size} className={className} style={estiloRaiz}
+      role="img" aria-label={title} {...estadoAttrs} {...rest}>
+      <title>{title}</title>
+      {defs}
+      {cuerpoVivo}
+    </svg>
+  );
+  // MODO PODER (standalone): aura MENTA bioluminiscente de 4 capas.
+  if (poder) {
+    return (
+      <span
+        className="is-powered-up osog-poder"
+        data-creature-poder={OSO_GUARDIAN_SLUG}
+        style={{ '--aura-color': auraDeBicho(OSO_GUARDIAN_SLUG), display: 'inline-flex' }}
+      >
+        {svg}
+        <AuraPoder />
+      </span>
+    );
+  }
+  return svg;
+}
+
+export default OsoGuardian;

--- a/src/visual/creatures/RuanaGuardian.jsx
+++ b/src/visual/creatures/RuanaGuardian.jsx
@@ -1,0 +1,191 @@
+import { useId } from 'react';
+import './climaAccesorios.css';
+import { OSO_GUARDIAN_RUANA, OSO_GUARDIAN_TINTA } from './osoGuardianIdentidad.js';
+
+/*
+ * RuanaGuardian — LA RUANA DEL OSO, tejida para ESTE cuerpo.
+ *
+ * Reemplaza, solo para el guardián, el poncho genérico de `AccesoriosClima`
+ * (un trapecio plano con dos franjas y un pico en V, compartido con toda la
+ * fauna). Aquel no tenía caída ni pliegue, competía en área con la luna del
+ * pecho y no se apoyaba en ningún lado, porque el oso todavía no tenía hombros.
+ * Ahora los tiene, y la prenda se cuelga de ellos.
+ *
+ * Lo que manda la DR `la-ruana-andina-colombiana` (gemini, 2026-06-19) y que
+ * está dibujado acá punto por punto:
+ *
+ *   · PESO. Lana virgen de oveja, cerca de un kilo. Cae con gravedad: los
+ *     pliegues se asientan, se abren hacia el ruedo y no flotan. El vaivén
+ *     reusa `crt-ruana` del kit pero a casi el doble de duración — una lana
+ *     pesada se mece lento. Esa es toda la diferencia entre lana y trapo.
+ *   · APOYO. Se asienta firme sobre la cruz y no resbala. El paño rompe sobre
+ *     el hombro y de ese quiebre bajan los pliegues, abriéndose en abanico.
+ *   · ABIERTA AL FRENTE. Eso la distingue del poncho, que es cerrado. Los dos
+ *     paños caen a los costados y dejan el pecho libre.
+ *   · LA PUNTA AL HOMBRO. Con frío de verdad se echa una punta sobre el hombro
+ *     contrario; el antropólogo Fals-Borda anotó que llevarla así sobre un solo
+ *     hombro tenía lectura propia. Acá hace doble trabajo: es el gesto real y
+ *     además rompe la simetría, que es lo que separa una prenda vivida de un
+ *     disfraz. Y deja el pecho despejado, así la LUNA nunca queda tapada.
+ *   · COLOR SOBRIO. Altiplano cundiboyacense: negro, azul oscuro, gris oscuro.
+ *     Las franjas rojas y amarillas son la variante vieja y sobre este oso
+ *     peleaban con el emblema. Queda UNA banda de lana cruda cerca del ruedo.
+ *   · SOBRE CUERPO NO HUMANO. Los pliegues se exageran contra la musculatura y
+ *     la tela se adapta al ancho de la grupa. Si la prenda cuelga sin tocar el
+ *     cuerpo, se lee disfraz; por eso el paño se ciñe en la cruz, se abolsa en
+ *     el codo y vuelve a abrirse sobre las ancas.
+ *
+ * Species-specific a propósito: vive en el oso, no en el kit. `AccesoriosClima`
+ * queda intacto para el resto de la fauna.
+ */
+
+/* EL CORTE DE UN PAÑO, parametrizado por lado (`s` = -1 izquierda, +1 derecha).
+ *
+ * Una ruana es una pieza rectangular de telar: los dos paños salen del MISMO
+ * corte, y por eso el trazo se genera espejado en vez de escribirse dos veces.
+ * Lo que NO se espeja es la caída —los pliegues y la punta al hombro van
+ * aparte— porque una prenda con las dos mitades idénticas se lee estampada.
+ *
+ * El recorrido: arranca en la abertura del cuello, monta la cruz, cae por el
+ * brazo abolsándose, se abre hacia el ruedo, recorre el ruedo en festón y
+ * vuelve por el borde interno, que es la abertura delantera — por ahí se ve el
+ * pecho, y por ahí sigue mandando la luna.
+ *
+ * EL RUEDO NO ES UNA LÍNEA RECTA: una lana de ese peso cuelga más donde el
+ * pliegue junta tela, así que el borde baja en festón, con un valle por cada
+ * pliegue que carga. Un ruedo recto delata el cartón.
+ */
+function pano(s) {
+  const x = (v) => (s * v).toFixed(2);
+  return (
+    `M ${x(5.6)},-8.5 `
+    + `C ${x(7.6)},-8.9 ${x(9.6)},-8.4 ${x(11.0)},-7.0 `   // monta la cruz
+    + `C ${x(12.3)},-5.6 ${x(13.0)},-3.4 ${x(13.2)},-1.0 ` // cae por el brazo
+    + `C ${x(13.5)},2.4 ${x(13.6)},5.8 ${x(13.5)},9.2 `    // se abre al ruedo
+    + `C ${x(13.2)},9.9 ${x(12.4)},10.4 ${x(11.5)},10.1 `  // ruedo en festón
+    + `C ${x(10.4)},9.7 ${x(9.6)},10.6 ${x(8.5)},10.3 `
+    + `C ${x(7.5)},10.0 ${x(6.8)},10.7 ${x(6.0)},10.2 `
+    + `C ${x(5.9)},8.0 ${x(5.8)},5.4 ${x(5.8)},2.6 `       // borde interno
+    + `C ${x(5.8)},-0.8 ${x(5.6)},-4.2 ${x(5.0)},-6.9 `
+    + `C ${x(5.1)},-7.7 ${x(5.3)},-8.2 ${x(5.6)},-8.5 Z`
+  );
+}
+const PANO_IZQ = pano(-1);
+const PANO_DER = pano(1);
+
+/* PLIEGUES. Nacen apretados en el quiebre del hombro y se abren hacia abajo:
+   así se lee que la tela cuelga de ahí. Cada uno lleva su sombra (el fondo de
+   la arruga) y su luz (el lomo). Sin el par, el pliegue es una raya. */
+const PLIEGUES_IZQ = [
+  { d: 'M -10.4,-6.2 C -11.4,-2.6 -12.0,2.6 -12.2,8.8', w: 0.62, op: 0.55 },
+  { d: 'M -8.9,-6.8 C -9.5,-2.8 -9.9,2.4 -10.0,9.4', w: 0.5, op: 0.42 },
+  { d: 'M -7.4,-7.2 C -7.7,-3.2 -7.9,2.2 -7.9,9.9', w: 0.44, op: 0.34 },
+];
+const PLIEGUES_DER = [
+  { d: 'M 10.4,-6.2 C 11.4,-2.6 12.0,2.6 12.2,8.8', w: 0.62, op: 0.55 },
+  { d: 'M 8.9,-6.8 C 9.5,-2.8 9.9,2.4 10.0,9.4', w: 0.5, op: 0.42 },
+  { d: 'M 7.6,-7.0 C 7.9,-3.0 8.1,2.4 8.1,9.8', w: 0.44, op: 0.34 },
+];
+
+/**
+ * @param {Object} props
+ * @param {boolean} [props.animated=true]  mece la lana (lento: pesa).
+ * @param {string} [props.ink]             la tinta del contorno.
+ * @returns {import('react').JSX.Element}
+ */
+export function RuanaGuardian({ animated = true, ink = OSO_GUARDIAN_TINTA }) {
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+  const tejido = `osog-ruana-tejido-${uid}`;
+  const R = OSO_GUARDIAN_RUANA;
+
+  /* FLECOS del ruedo: hebras cortas y pesadas, con largo desparejo (un telar
+     artesanal no da dos iguales). Cuelgan a plomo, no se abren. */
+  const flecos = [
+    -12.9, -12.0, -11.1, -10.2, -9.3, -8.4, -7.5, -6.6,
+    6.6, 7.5, 8.4, 9.3, 10.2, 11.1, 12.0, 12.9,
+  ];
+
+  return (
+    <g className={animated ? 'crt-ruana' : undefined}
+      /* lana de un kilo: se mece MÁS LENTO que el trapo del kit (3.4s).
+         El peso de una prenda se lee en su tiempo, no solo en su forma. */
+      style={animated ? { animationDuration: '6.2s' } : undefined}
+      data-ruana-guardian="" aria-hidden="true">
+      <defs>
+        {/* el tejido: lana densa, sin transparencia, con la luz de luna
+            cayendo del hombro izquierdo hacia el ruedo */}
+        <linearGradient id={tejido} x1="18%" y1="0%" x2="72%" y2="100%">
+          <stop offset="0%" stopColor={R.panoLuz} />
+          <stop offset="46%" stopColor={R.pano} />
+          <stop offset="100%" stopColor={R.panoSombra} />
+        </linearGradient>
+      </defs>
+
+      {/* ── LOS DOS PAÑOS. Abierta al frente: entre ellos queda el pecho, y
+             ahí sigue mandando la luna. ─────────────────────────────────── */}
+      <path d={PANO_IZQ} fill={`url(#${tejido})`} stroke={ink}
+        strokeWidth="0.95" strokeLinejoin="round" />
+      <path d={PANO_DER} fill={`url(#${tejido})`} stroke={ink}
+        strokeWidth="0.95" strokeLinejoin="round" />
+
+      {/* ── PLIEGUES. Sombra y luz por pliegue: la arruga tiene fondo y lomo.
+             Se cierran arriba (donde la tela se junta en el hombro) y se
+             abren abajo (donde el peso la separa). ──────────────────────── */}
+      <g fill="none" strokeLinecap="round">
+        {[...PLIEGUES_IZQ, ...PLIEGUES_DER].map((p, i) => (
+          <path key={`s${i}`} d={p.d} stroke={R.panoSombra}
+            strokeWidth={p.w} opacity={p.op} />
+        ))}
+        {[...PLIEGUES_IZQ, ...PLIEGUES_DER].map((p, i) => (
+          <path key={`l${i}`} d={p.d} stroke={R.panoLuz} strokeWidth={p.w * 0.5}
+            opacity={p.op * 0.45} transform="translate(0.42 0)" />
+        ))}
+      </g>
+
+      {/* ── LA BANDA DE LANA CRUDA cerca del ruedo. UNA sola y angosta: la
+             ruana acompaña, el emblema del pecho es la luna. Sigue la caída
+             del paño, no cruza recta (una franja recta delata la tabla). ── */}
+      <g fill="none" stroke={R.franja} strokeLinecap="round" opacity="0.6">
+        <path d="M -13.4,6.6 C -11.0,7.2 -8.4,7.0 -6.0,6.5" strokeWidth="0.75" />
+        <path d="M 13.4,6.6 C 11.0,7.2 8.4,7.0 6.0,6.5" strokeWidth="0.75" />
+      </g>
+
+      {/* ── FLECOS: hebras del telar, cortas y a plomo. Largo desparejo. ── */}
+      <g stroke={R.fleco} strokeWidth="0.34" strokeLinecap="round" opacity="0.72">
+        {flecos.map((x, i) => {
+          const y0 = 10.15 + (i % 3) * 0.16;
+          const largo = 0.85 + ((i * 7) % 5) * 0.16;
+          return <path key={i} d={`M${x},${y0} l0.05,${largo}`} />;
+        })}
+      </g>
+
+      {/* ── LA ABERTURA DEL CUELLO. La lana se abolsa en el borde: un
+             cuello de ruana es un canto grueso, no un corte de tijera. ─── */}
+      <path d="M -5.6,-8.5 C -3.6,-7.0 -1.6,-6.4 0.2,-6.35 C 2.0,-6.4 4.0,-7.0 5.6,-8.5"
+        fill="none" stroke={ink} strokeWidth="0.9" strokeLinecap="round" />
+      <path d="M -5.2,-8.0 C -3.4,-6.6 -1.5,-6.0 0.2,-5.95 C 1.9,-6.0 3.8,-6.6 5.2,-8.0"
+        fill="none" stroke={R.panoLuz} strokeWidth="0.5" strokeLinecap="round" opacity="0.5" />
+
+      {/* ═══ LA PUNTA ECHADA AL HOMBRO (derecho del espectador) — el gesto de
+             frío de verdad que documenta la DR. Un doblez de paño levantado y
+             tendido sobre la cruz, con el ENVÉS a la vista: en el envés el
+             tejido toma la luz distinto, y ese cambio de valor es lo que
+             convence de que hay dos caras de tela y no una silueta pintada. */}
+      <g>
+        <path d="M 4.6,-8.2 C 6.6,-9.6 9.0,-10.2 11.2,-9.4
+                 C 12.0,-8.4 11.6,-6.8 10.6,-5.6
+                 C 9.2,-4.0 7.2,-3.2 5.6,-3.6
+                 C 4.8,-5.2 4.4,-6.8 4.6,-8.2 Z"
+          fill={R.panoRevés} stroke={ink} strokeWidth="0.85" strokeLinejoin="round" />
+        {/* el quiebre del doblez: donde la tela dobla sobre sí misma */}
+        <path d="M 5.4,-7.6 C 7.2,-8.5 9.2,-8.7 10.9,-8.2"
+          fill="none" stroke={R.panoSombra} strokeWidth="0.5" opacity="0.65" strokeLinecap="round" />
+        {/* la punta cuelga por detrás del hombro, con su peso */}
+        <path d="M 10.6,-5.6 C 11.4,-4.6 11.8,-3.4 11.6,-2.2"
+          fill="none" stroke={R.panoSombra} strokeWidth="0.55" opacity="0.5" strokeLinecap="round" />
+      </g>
+    </g>
+  );
+}
+
+export default RuanaGuardian;

--- a/src/visual/creatures/RuanaGuardian.jsx
+++ b/src/visual/creatures/RuanaGuardian.jsx
@@ -11,17 +11,40 @@ import { OSO_GUARDIAN_RUANA, OSO_GUARDIAN_TINTA } from './osoGuardianIdentidad.j
  * pecho y no se apoyaba en ningún lado, porque el oso todavía no tenía hombros.
  * Ahora los tiene, y la prenda se cuelga de ellos.
  *
+ * LO QUE ESTA VERSIÓN CORRIGE DE LA ANTERIOR: las MANGAS. La primera ruana se
+ * dibujó como dos paños cerrados, uno por brazo, con el ruedo rematando justo
+ * sobre la muñeca — o sea, dos tubos con puño. Eso es un abrigo de catálogo.
+ * Una ruana NO TIENE MANGAS: es UNA manta rectangular de lana con una abertura
+ * para la cabeza, abierta al frente, que CAE SOBRE los brazos sin envolverlos.
+ * La diferencia se dibuja con tres decisiones:
+ *
+ *   · UN SOLO PATH. La prenda entera —yugo sobre los hombros y las dos caídas—
+ *     es una sola silueta cerrada con el hueco del pecho recortado. Dos formas
+ *     separadas se leen como dos prendas (mangas); una forma continua se lee
+ *     como una manta puesta.
+ *   · ESQUINAS. Un rectángulo colgado tiene esquinas, y las esquinas cuelgan
+ *     en punta con su propio peso. Una manga jamás tiene esquinas — la punta
+ *     del vértice exterior es la firma inconfundible del corte rectangular.
+ *   · EL QUIEBRE SOBRE EL BRAZO. La tela es un plano que el codo empuja desde
+ *     abajo: donde toca, la lana se tiende y QUIEBRA en un pliegue horizontal,
+ *     y sigue cayendo a plomo después del quiebre. Un contorno que acompaña al
+ *     brazo lo envuelve (manga); un plano interrumpido por la forma que tiene
+ *     debajo cae sobre él (manta). Por lo mismo el paño baja MÁS ANCHO que el
+ *     brazo y la mano asoma por DEBAJO del ruedo, nunca de un puño.
+ *
  * Lo que manda la DR `la-ruana-andina-colombiana` (gemini, 2026-06-19) y que
  * está dibujado acá punto por punto:
  *
+ *   · CORTE RECTANGULAR de telar (1.20 m × 1.60 m la boyacense típica): manta
+ *     con abertura central para la cabeza. Sin mangas, sin sisa, sin puño.
  *   · PESO. Lana virgen de oveja, cerca de un kilo. Cae con gravedad: los
  *     pliegues se asientan, se abren hacia el ruedo y no flotan. El vaivén
  *     reusa `crt-ruana` del kit pero a casi el doble de duración — una lana
  *     pesada se mece lento. Esa es toda la diferencia entre lana y trapo.
  *   · APOYO. Se asienta firme sobre la cruz y no resbala. El paño rompe sobre
  *     el hombro y de ese quiebre bajan los pliegues, abriéndose en abanico.
- *   · ABIERTA AL FRENTE. Eso la distingue del poncho, que es cerrado. Los dos
- *     paños caen a los costados y dejan el pecho libre.
+ *   · ABIERTA AL FRENTE. Eso la distingue del poncho, que es cerrado. Las dos
+ *     caídas dejan el pecho libre y ahí sigue mandando la luna.
  *   · LA PUNTA AL HOMBRO. Con frío de verdad se echa una punta sobre el hombro
  *     contrario; el antropólogo Fals-Borda anotó que llevarla así sobre un solo
  *     hombro tenía lectura propia. Acá hace doble trabajo: es el gesto real y
@@ -32,59 +55,79 @@ import { OSO_GUARDIAN_RUANA, OSO_GUARDIAN_TINTA } from './osoGuardianIdentidad.j
  *     peleaban con el emblema. Queda UNA banda de lana cruda cerca del ruedo.
  *   · SOBRE CUERPO NO HUMANO. Los pliegues se exageran contra la musculatura y
  *     la tela se adapta al ancho de la grupa. Si la prenda cuelga sin tocar el
- *     cuerpo, se lee disfraz; por eso el paño se ciñe en la cruz, se abolsa en
- *     el codo y vuelve a abrirse sobre las ancas.
+ *     cuerpo, se lee disfraz; por eso el plano se ciñe en la cruz, quiebra
+ *     sobre el codo y vuelve a abrirse hacia las esquinas.
  *
  * Species-specific a propósito: vive en el oso, no en el kit. `AccesoriosClima`
  * queda intacto para el resto de la fauna.
  */
 
-/* EL CORTE DE UN PAÑO, parametrizado por lado (`s` = -1 izquierda, +1 derecha).
+/* LA MANTA ENTERA, un solo trazo cerrado.
  *
- * Una ruana es una pieza rectangular de telar: los dos paños salen del MISMO
- * corte, y por eso el trazo se genera espejado en vez de escribirse dos veces.
- * Lo que NO se espeja es la caída —los pliegues y la punta al hombro van
- * aparte— porque una prenda con las dos mitades idénticas se lee estampada.
- *
- * El recorrido: arranca en la abertura del cuello, monta la cruz, cae por el
- * brazo abolsándose, se abre hacia el ruedo, recorre el ruedo en festón y
- * vuelve por el borde interno, que es la abertura delantera — por ahí se ve el
- * pecho, y por ahí sigue mandando la luna.
+ * El recorrido, en el sentido del reloj: arranca en el quiebre del hombro
+ * izquierdo, monta la cruz y pasa POR DETRÁS del cuello (esa parte la tapa la
+ * cabeza — que es exactamente donde va el cuello de la prenda), rompe sobre el
+ * hombro derecho y cae por el orillo exterior ABRIÉNDOSE — la esquina de una
+ * manta colgada barre más afuera que el cuerpo que la carga —, remata en la
+ * PUNTA de la esquina, recorre el ruedo en festón hacia adentro, sube por el
+ * borde delantero (la abertura al frente: por ahí se ve el pecho y la luna),
+ * dibuja el escote y baja espejado por el lado izquierdo.
  *
  * EL RUEDO NO ES UNA LÍNEA RECTA: una lana de ese peso cuelga más donde el
  * pliegue junta tela, así que el borde baja en festón, con un valle por cada
- * pliegue que carga. Un ruedo recto delata el cartón.
- */
-function pano(s) {
-  const x = (v) => (s * v).toFixed(2);
-  return (
-    `M ${x(5.6)},-8.5 `
-    + `C ${x(7.6)},-8.9 ${x(9.6)},-8.4 ${x(11.0)},-7.0 `   // monta la cruz
-    + `C ${x(12.3)},-5.6 ${x(13.0)},-3.4 ${x(13.2)},-1.0 ` // cae por el brazo
-    + `C ${x(13.5)},2.4 ${x(13.6)},5.8 ${x(13.5)},9.2 `    // se abre al ruedo
-    + `C ${x(13.2)},9.9 ${x(12.4)},10.4 ${x(11.5)},10.1 `  // ruedo en festón
-    + `C ${x(10.4)},9.7 ${x(9.6)},10.6 ${x(8.5)},10.3 `
-    + `C ${x(7.5)},10.0 ${x(6.8)},10.7 ${x(6.0)},10.2 `
-    + `C ${x(5.9)},8.0 ${x(5.8)},5.4 ${x(5.8)},2.6 `       // borde interno
-    + `C ${x(5.8)},-0.8 ${x(5.6)},-4.2 ${x(5.0)},-6.9 `
-    + `C ${x(5.1)},-7.7 ${x(5.3)},-8.2 ${x(5.6)},-8.5 Z`
-  );
-}
-const PANO_IZQ = pano(-1);
-const PANO_DER = pano(1);
+ * pliegue que carga — y cuelga MÁS en las esquinas, que cargan el vuelo del
+ * vértice. Los dos lados NO son espejo exacto: un telar artesanal no da dos
+ * caídas iguales, y una prenda perfectamente simétrica se lee estampada. */
+const RUANA_MANTA =
+  'M -10.9,-6.4 '
+  + 'C -10.3,-8.8 -8.2,-10.7 -5.4,-11.4 '   // monta la cruz (tapado por la cabeza)
+  + 'C -2.8,-11.9 2.8,-11.9 5.4,-11.4 '
+  + 'C 8.2,-10.7 10.3,-8.8 10.9,-6.4 '      // rompe sobre el hombro derecho
+  + 'C 11.9,-4.2 12.9,-0.6 13.6,3.2 '       // orillo RECTO en diagonal: tela a plomo,
+  + 'C 14.0,5.5 14.35,7.5 14.55,8.9 '       // más ancha que el brazo (que no abombe)
+  + 'C 14.75,10.0 14.5,10.9 13.65,10.75 '   // LA ESQUINA: cuelga bajo la línea del ruedo
+  + 'C 12.75,9.9 11.75,10.3 10.65,9.85 '    // ruedo en festón, de vuelta hacia el pecho:
+  + 'C 9.55,9.5 8.65,10.05 7.65,9.75 '      // ALTO — la mano asoma por DEBAJO, no de un puño
+  + 'C 7.05,9.6 6.65,9.95 6.35,10.2 '       // la esquina delantera, punta chica
+  + 'C 6.1,7.6 5.98,4.6 5.93,1.6 '          // borde delantero: la abertura al frente
+  + 'C 5.85,-1.8 5.75,-5.2 5.6,-8.5 '
+  + 'C 4.0,-7.0 2.0,-6.4 0.2,-6.35 '        // el escote (el canto del cuello)
+  + 'C -1.6,-6.4 -3.6,-7.0 -5.6,-8.5 '
+  + 'C -5.75,-5.2 -5.85,-1.8 -5.93,1.6 '    // borde delantero izquierdo
+  + 'C -5.98,4.6 -6.12,7.6 -6.4,10.15 '
+  + 'C -6.7,9.9 -7.1,9.55 -7.7,9.7 '        // festón izquierdo: valles propios, no espejo
+  + 'C -8.7,10.0 -9.6,9.45 -10.7,9.8 '
+  + 'C -11.8,10.25 -12.8,9.85 -13.7,10.8 '
+  + 'C -14.55,10.95 -14.78,10.0 -14.6,8.95 ' // la esquina izquierda
+  + 'C -14.4,7.5 -14.05,5.5 -13.65,3.25 '
+  + 'C -12.95,-0.6 -11.95,-4.2 -10.9,-6.4 Z';
 
 /* PLIEGUES. Nacen apretados en el quiebre del hombro y se abren hacia abajo:
    así se lee que la tela cuelga de ahí. Cada uno lleva su sombra (el fondo de
-   la arruga) y su luz (el lomo). Sin el par, el pliegue es una raya. */
+   la arruga) y su luz (el lomo). Sin el par, el pliegue es una raya.
+   Cada trazo lleva un CODO a la altura del quiebre del brazo (y≈2): el pliegue
+   entra al quiebre con una dirección y sale con otra — la tela que solo cae
+   hace rayas rectas; la que cae SOBRE algo, se dobla. */
 const PLIEGUES_IZQ = [
-  { d: 'M -10.4,-6.2 C -11.4,-2.6 -12.0,2.6 -12.2,8.8', w: 0.62, op: 0.55 },
-  { d: 'M -8.9,-6.8 C -9.5,-2.8 -9.9,2.4 -10.0,9.4', w: 0.5, op: 0.42 },
-  { d: 'M -7.4,-7.2 C -7.7,-3.2 -7.9,2.2 -7.9,9.9', w: 0.44, op: 0.34 },
+  { d: 'M -12.1,-5.2 C -12.9,-1.8 -13.3,1.0 -13.4,2.4 C -13.55,5.2 -13.6,7.6 -13.6,9.6', w: 0.62, op: 0.55 },
+  { d: 'M -10.2,-5.9 C -10.8,-2.2 -11.1,0.9 -11.15,2.3 C -11.25,5.0 -11.2,7.4 -11.1,9.5', w: 0.5, op: 0.42 },
+  { d: 'M -8.3,-6.5 C -8.6,-2.8 -8.8,0.7 -8.82,2.1 C -8.85,5.0 -8.78,7.4 -8.65,9.55', w: 0.44, op: 0.34 },
 ];
 const PLIEGUES_DER = [
-  { d: 'M 10.4,-6.2 C 11.4,-2.6 12.0,2.6 12.2,8.8', w: 0.62, op: 0.55 },
-  { d: 'M 8.9,-6.8 C 9.5,-2.8 9.9,2.4 10.0,9.4', w: 0.5, op: 0.42 },
-  { d: 'M 7.6,-7.0 C 7.9,-3.0 8.1,2.4 8.1,9.8', w: 0.44, op: 0.34 },
+  { d: 'M 12.1,-5.2 C 12.9,-1.8 13.3,1.0 13.4,2.4 C 13.55,5.2 13.6,7.6 13.6,9.5', w: 0.62, op: 0.55 },
+  { d: 'M 10.3,-5.9 C 10.9,-2.2 11.2,0.9 11.25,2.3 C 11.35,5.0 11.3,7.4 11.2,9.5', w: 0.5, op: 0.42 },
+  { d: 'M 8.4,-6.4 C 8.7,-2.8 8.9,0.7 8.9,2.1 C 8.9,5.0 8.85,7.4 8.75,9.6', w: 0.44, op: 0.34 },
+];
+
+/* FLECOS del ruedo: hebras cortas y pesadas, con largo desparejo (un telar
+   artesanal no da dos iguales). Cuelgan a plomo, no se abren. Siguen el festón
+   —cada hebra nace donde su tramo de ruedo cuelga— y acompañan las esquinas,
+   que es donde el ruedo baja más. */
+const FLECOS = [
+  [-14.15, 10.55], [-13.35, 10.15], [-12.55, 9.85], [-11.75, 10.05], [-10.85, 9.75],
+  [-9.95, 9.55], [-9.05, 9.75], [-8.15, 9.65], [-7.25, 9.8],
+  [7.25, 9.75], [8.15, 9.7], [9.05, 9.8], [9.95, 9.5], [10.85, 9.8],
+  [11.75, 10.1], [12.55, 9.9], [13.35, 10.2], [14.15, 10.5],
 ];
 
 /**
@@ -97,13 +140,6 @@ export function RuanaGuardian({ animated = true, ink = OSO_GUARDIAN_TINTA }) {
   const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
   const tejido = `osog-ruana-tejido-${uid}`;
   const R = OSO_GUARDIAN_RUANA;
-
-  /* FLECOS del ruedo: hebras cortas y pesadas, con largo desparejo (un telar
-     artesanal no da dos iguales). Cuelgan a plomo, no se abren. */
-  const flecos = [
-    -12.9, -12.0, -11.1, -10.2, -9.3, -8.4, -7.5, -6.6,
-    6.6, 7.5, 8.4, 9.3, 10.2, 11.1, 12.0, 12.9,
-  ];
 
   return (
     <g className={animated ? 'crt-ruana' : undefined}
@@ -121,36 +157,39 @@ export function RuanaGuardian({ animated = true, ink = OSO_GUARDIAN_TINTA }) {
         </linearGradient>
       </defs>
 
-      {/* ── EL CANESÚ: el paño que cruza de hombro a hombro por encima de la
-             cruz y pasa por detrás del cuello. Es LA pieza que convierte dos
-             paños colgando en UNA prenda puesta. Sin él, la primera prueba de
-             render se leyó como dos mangas sueltas: una ruana es una sola
-             manta con un agujero, no un abrigo con brazos. El centro queda
-             tapado por la cabeza, que es exactamente donde va el cuello. ── */}
-      <path d="M -10.5,-6.2
-               C -10.1,-8.7 -8.2,-10.6 -5.4,-11.3
-               C -2.8,-11.8 2.8,-11.8 5.4,-11.3
-               C 8.2,-10.6 10.1,-8.7 10.5,-6.2
-               C 7.6,-7.3 -7.6,-7.3 -10.5,-6.2 Z"
-        fill={`url(#${tejido})`} stroke={ink} strokeWidth="0.95" strokeLinejoin="round" />
-
-      {/* ── LOS DOS PAÑOS. Abierta al frente: entre ellos queda el pecho, y
-             ahí sigue mandando la luna. ─────────────────────────────────── */}
-      <path d={PANO_IZQ} fill={`url(#${tejido})`} stroke={ink}
-        strokeWidth="0.95" strokeLinejoin="round" />
-      <path d={PANO_DER} fill={`url(#${tejido})`} stroke={ink}
+      {/* ── LA MANTA. Una sola pieza: yugo sobre la cruz, detrás del cuello, y
+             las dos caídas — todo el mismo trazo, porque es la misma tela.
+             Abierta al frente: en el hueco queda el pecho, y ahí manda la
+             luna. Las manos del oso asoman por DEBAJO del ruedo. ─────────── */}
+      <path d={RUANA_MANTA} fill={`url(#${tejido})`} stroke={ink}
         strokeWidth="0.95" strokeLinejoin="round" />
 
-      {/* el QUIEBRE sobre cada hombro: donde la lana pasa del canesú al paño y
-          se rompe. De ese quiebre nacen los pliegues que bajan. */}
+      {/* el QUIEBRE sobre cada hombro: donde la lana pasa del yugo a la caída
+          y se rompe. De ese quiebre nacen los pliegues que bajan. */}
       <g fill="none" stroke={R.panoSombra} strokeWidth="0.55" opacity="0.5" strokeLinecap="round">
         <path d="M -10.0,-7.0 C -8.9,-6.1 -7.6,-5.7 -6.3,-5.8" />
         <path d="M 10.0,-7.0 C 8.9,-6.1 7.6,-5.7 6.3,-5.8" />
       </g>
 
+      {/* ── EL QUIEBRE SOBRE EL BRAZO — lo que hace que la tela caiga SOBRE el
+             brazo en vez de envolverlo. El codo empuja el plano desde abajo:
+             en el contacto la lana se tiende (el lomo toma luz) y justo debajo
+             se dobla (la sombra del doblez). Es la señal de que hay un cuerpo
+             DEBAJO de la manta, no dentro de una manga. ───────────────────── */}
+      <g fill="none" strokeLinecap="round">
+        <path d="M -13.3,2.7 C -11.6,1.8 -9.5,1.6 -6.9,2.2"
+          stroke={R.panoSombra} strokeWidth="0.6" opacity="0.55" />
+        <path d="M -13.0,1.9 C -11.4,1.1 -9.6,1.0 -7.3,1.5"
+          stroke={R.panoLuz} strokeWidth="0.45" opacity="0.5" />
+        <path d="M 13.3,2.6 C 11.6,1.7 9.5,1.5 6.9,2.1"
+          stroke={R.panoSombra} strokeWidth="0.6" opacity="0.55" />
+        <path d="M 13.0,1.8 C 11.4,1.0 9.6,0.9 7.3,1.4"
+          stroke={R.panoLuz} strokeWidth="0.45" opacity="0.5" />
+      </g>
+
       {/* ── PLIEGUES. Sombra y luz por pliegue: la arruga tiene fondo y lomo.
-             Se cierran arriba (donde la tela se junta en el hombro) y se
-             abren abajo (donde el peso la separa). ──────────────────────── */}
+             Se cierran arriba (donde la tela se junta en el hombro), se doblan
+             en el quiebre del brazo y caen a plomo hasta el ruedo. ────────── */}
       <g fill="none" strokeLinecap="round">
         {[...PLIEGUES_IZQ, ...PLIEGUES_DER].map((p, i) => (
           <path key={`s${i}`} d={p.d} stroke={R.panoSombra}
@@ -163,19 +202,19 @@ export function RuanaGuardian({ animated = true, ink = OSO_GUARDIAN_TINTA }) {
       </g>
 
       {/* ── LA BANDA DE LANA CRUDA cerca del ruedo. UNA sola y angosta: la
-             ruana acompaña, el emblema del pecho es la luna. Sigue la caída
-             del paño, no cruza recta (una franja recta delata la tabla). ── */}
+             ruana acompaña, el emblema del pecho es la luna. Es una LISTA del
+             telar — tejida a lo ancho de la manta, de orillo a borde — así que
+             sigue la caída del paño y se hunde donde el festón carga tela. ── */}
       <g fill="none" stroke={R.franja} strokeLinecap="round" opacity="0.6">
-        <path d="M -13.4,6.6 C -11.0,7.2 -8.4,7.0 -6.0,6.5" strokeWidth="0.75" />
-        <path d="M 13.4,6.6 C 11.0,7.2 8.4,7.0 6.0,6.5" strokeWidth="0.75" />
+        <path d="M -14.15,6.7 C -12.0,7.3 -9.3,7.1 -6.15,6.5" strokeWidth="0.75" />
+        <path d="M 14.15,6.6 C 12.0,7.2 9.3,7.0 6.15,6.4" strokeWidth="0.75" />
       </g>
 
       {/* ── FLECOS: hebras del telar, cortas y a plomo. Largo desparejo. ── */}
       <g stroke={R.fleco} strokeWidth="0.34" strokeLinecap="round" opacity="0.72">
-        {flecos.map((x, i) => {
-          const y0 = 10.15 + (i % 3) * 0.16;
+        {FLECOS.map(([x, y0], i) => {
           const largo = 0.85 + ((i * 7) % 5) * 0.16;
-          return <path key={i} d={`M${x},${y0} l0.05,${largo}`} />;
+          return <path key={i} d={`M${x},${y0 + 0.35} l0.05,${largo}`} />;
         })}
       </g>
 

--- a/src/visual/creatures/RuanaGuardian.jsx
+++ b/src/visual/creatures/RuanaGuardian.jsx
@@ -121,12 +121,32 @@ export function RuanaGuardian({ animated = true, ink = OSO_GUARDIAN_TINTA }) {
         </linearGradient>
       </defs>
 
+      {/* ── EL CANESÚ: el paño que cruza de hombro a hombro por encima de la
+             cruz y pasa por detrás del cuello. Es LA pieza que convierte dos
+             paños colgando en UNA prenda puesta. Sin él, la primera prueba de
+             render se leyó como dos mangas sueltas: una ruana es una sola
+             manta con un agujero, no un abrigo con brazos. El centro queda
+             tapado por la cabeza, que es exactamente donde va el cuello. ── */}
+      <path d="M -10.5,-6.2
+               C -10.1,-8.7 -8.2,-10.6 -5.4,-11.3
+               C -2.8,-11.8 2.8,-11.8 5.4,-11.3
+               C 8.2,-10.6 10.1,-8.7 10.5,-6.2
+               C 7.6,-7.3 -7.6,-7.3 -10.5,-6.2 Z"
+        fill={`url(#${tejido})`} stroke={ink} strokeWidth="0.95" strokeLinejoin="round" />
+
       {/* ── LOS DOS PAÑOS. Abierta al frente: entre ellos queda el pecho, y
              ahí sigue mandando la luna. ─────────────────────────────────── */}
       <path d={PANO_IZQ} fill={`url(#${tejido})`} stroke={ink}
         strokeWidth="0.95" strokeLinejoin="round" />
       <path d={PANO_DER} fill={`url(#${tejido})`} stroke={ink}
         strokeWidth="0.95" strokeLinejoin="round" />
+
+      {/* el QUIEBRE sobre cada hombro: donde la lana pasa del canesú al paño y
+          se rompe. De ese quiebre nacen los pliegues que bajan. */}
+      <g fill="none" stroke={R.panoSombra} strokeWidth="0.55" opacity="0.5" strokeLinecap="round">
+        <path d="M -10.0,-7.0 C -8.9,-6.1 -7.6,-5.7 -6.3,-5.8" />
+        <path d="M 10.0,-7.0 C 8.9,-6.1 7.6,-5.7 6.3,-5.8" />
+      </g>
 
       {/* ── PLIEGUES. Sombra y luz por pliegue: la arruga tiene fondo y lomo.
              Se cierran arriba (donde la tela se junta en el hombro) y se
@@ -172,17 +192,23 @@ export function RuanaGuardian({ animated = true, ink = OSO_GUARDIAN_TINTA }) {
              tejido toma la luz distinto, y ese cambio de valor es lo que
              convence de que hay dos caras de tela y no una silueta pintada. */}
       <g>
-        <path d="M 4.6,-8.2 C 6.6,-9.6 9.0,-10.2 11.2,-9.4
-                 C 12.0,-8.4 11.6,-6.8 10.6,-5.6
-                 C 9.2,-4.0 7.2,-3.2 5.6,-3.6
-                 C 4.8,-5.2 4.4,-6.8 4.6,-8.2 Z"
-          fill={R.panoRevés} stroke={ink} strokeWidth="0.85" strokeLinejoin="round" />
-        {/* el quiebre del doblez: donde la tela dobla sobre sí misma */}
-        <path d="M 5.4,-7.6 C 7.2,-8.5 9.2,-8.7 10.9,-8.2"
-          fill="none" stroke={R.panoSombra} strokeWidth="0.5" opacity="0.65" strokeLinecap="round" />
-        {/* la punta cuelga por detrás del hombro, con su peso */}
-        <path d="M 10.6,-5.6 C 11.4,-4.6 11.8,-3.4 11.6,-2.2"
-          fill="none" stroke={R.panoSombra} strokeWidth="0.55" opacity="0.5" strokeLinecap="round" />
+        {/* Va en DIAGONAL y termina en punta que cuelga: un doblez de manta.
+            La primera prueba de render lo tenía como un óvalo cerrado sobre el
+            hombro y se leía hombrera de armadura — la diferencia entre tela y
+            placa es que la tela tiene una punta con peso y un filo que dobla. */}
+        <path d="M 5.2,-9.6
+                 C 7.2,-10.6 9.2,-10.7 10.4,-9.8
+                 C 11.0,-9.0 10.9,-7.7 10.4,-6.6
+                 C 10.0,-5.7 9.7,-4.8 9.8,-4.0
+                 C 9.2,-4.9 8.4,-5.7 7.6,-6.6
+                 C 6.6,-7.7 5.6,-8.7 5.2,-9.6 Z"
+          fill={R.panoRevés} stroke={ink} strokeWidth="0.7" strokeOpacity="0.55" strokeLinejoin="round" />
+        {/* el FILO del doblez: la arista donde la manta se pliega sobre sí */}
+        <path d="M 5.9,-9.1 C 7.4,-9.8 8.9,-9.9 10.1,-9.3"
+          fill="none" stroke={R.panoSombra} strokeWidth="0.5" opacity="0.7" strokeLinecap="round" />
+        {/* el peso que tira de la punta hacia abajo */}
+        <path d="M 9.9,-7.2 C 9.8,-6.0 9.7,-5.0 9.8,-4.2"
+          fill="none" stroke={R.panoSombra} strokeWidth="0.5" opacity="0.45" strokeLinecap="round" />
       </g>
     </g>
   );

--- a/src/visual/creatures/__tests__/faunaAmbiental.test.jsx
+++ b/src/visual/creatures/__tests__/faunaAmbiental.test.jsx
@@ -46,7 +46,7 @@ describe('1. castAmbiental — data-driven desde el registro', () => {
     expect(cast).not.toContain(CENTRAL_DEFECTO);
     MICROFAUNA_EXCLUIDA.forEach((m) => expect(cast).not.toContain(m));
     // Los personajes reales del registro sí están (oso, jaguar, colibrí…).
-    expect(cast).toContain('oso-andino');
+    expect(cast).toContain('oso-guardian');
     expect(cast).toContain('jaguar');
     expect(cast).toContain('colibri');
   });
@@ -57,9 +57,9 @@ describe('1. castAmbiental — data-driven desde el registro', () => {
   });
 
   it('si el central es otro (oso), la abeja entra al coro y el oso sale', () => {
-    const cast = castAmbiental('oso-andino');
+    const cast = castAmbiental('oso-guardian');
     expect(cast).toContain('abeja-angelita');
-    expect(cast).not.toContain('oso-andino');
+    expect(cast).not.toContain('oso-guardian');
   });
 
   it('el morrocoy (recién aterrizado en CREATURES) ya está en el elenco', () => {
@@ -67,9 +67,9 @@ describe('1. castAmbiental — data-driven desde el registro', () => {
   });
 
   it('excluir saca extras del coro (Angelita donde ya es la acompañante)', () => {
-    const cast = castAmbiental('oso-andino', CREATURES, ['abeja-angelita']);
+    const cast = castAmbiental('oso-guardian', CREATURES, ['abeja-angelita']);
     expect(cast).not.toContain('abeja-angelita');
-    expect(cast).not.toContain('oso-andino');
+    expect(cast).not.toContain('oso-guardian');
     expect(cast).toContain('jaguar');
   });
 });
@@ -107,7 +107,7 @@ describe('3. limiteAmbiental — el presupuesto duro por gama', () => {
 });
 
 describe('4. el pool rotativo — invariantes bajo mil vueltas', () => {
-  const cast = ['colibri', 'oso-andino', 'rana-andina', 'perezoso', 'ardilla', 'jaguar'];
+  const cast = ['colibri', 'oso-guardian', 'rana-andina', 'perezoso', 'ardilla', 'jaguar'];
 
   it('crearEstado arma min(limite, cast) slots, todos descansando', () => {
     const e = crearEstado(cast, 3);
@@ -177,7 +177,7 @@ describe('5. coherencia de entradas — solo el jaguar es mágico', () => {
   it('el jaguar aparece mágico; el resto viene de un lado', () => {
     expect(MAGICOS).toEqual(['jaguar']);
     expect(esMagico('jaguar')).toBe(true);
-    expect(esMagico('oso-andino')).toBe(false);
+    expect(esMagico('oso-guardian')).toBe(false);
     expect(esMagico(null)).toBe(false);
   });
 });
@@ -191,7 +191,7 @@ describe('6. <FaunaAmbiental> — el DOM cumple el presupuesto', () => {
   });
 
   const registro = registroFake([
-    'abeja-angelita', 'colibri', 'oso-andino', 'rana-andina', 'perezoso',
+    'abeja-angelita', 'colibri', 'oso-guardian', 'rana-andina', 'perezoso',
   ]);
 
   it('reduced-motion → la capa NI SE MONTA', () => {

--- a/src/visual/creatures/__tests__/vidaEstados.test.js
+++ b/src/visual/creatures/__tests__/vidaEstados.test.js
@@ -57,8 +57,8 @@ describe('2. elegirMomentoVida — azar ponderado sin repetir', () => {
   });
 
   it('el azar se inyecta: rand=0 da siempre el primer candidato (determinista)', () => {
-    const a = elegirMomentoVida('oso-andino', null, () => 0);
-    const b = elegirMomentoVida('oso-andino', null, () => 0);
+    const a = elegirMomentoVida('oso-guardian', null, () => 0);
+    const b = elegirMomentoVida('oso-guardian', null, () => 0);
     expect(a).toBe(b);
   });
 
@@ -70,8 +70,8 @@ describe('2. elegirMomentoVida — azar ponderado sin repetir', () => {
 
 describe('3. Duraciones — el contrato con el CSS', () => {
   it('duracionDeMomentoVida devuelve el dur del repertorio (0 si no existe)', () => {
-    expect(duracionDeMomentoVida('oso-andino', 'resopla')).toBe(4500);
-    expect(duracionDeMomentoVida('oso-andino', 'nada')).toBe(0);
+    expect(duracionDeMomentoVida('oso-guardian', 'resopla')).toBe(4500);
+    expect(duracionDeMomentoVida('oso-guardian', 'nada')).toBe(0);
     expect(duracionDeMomentoVida('nadie', 'resopla')).toBe(0);
   });
 

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -2702,3 +2702,68 @@
   [data-creature='oso-anteojos'][data-rasca='1'] .crt-brazo-r,
   [data-creature='oso-anteojos'][data-rasca='1'] .crt-body { animation: none !important; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   OSO GUARDIÁN (oso-guardian) — la mole serena del guardián negro de la luna.
+   Aditivo sobre el KIT y sobre los keyframes ya existentes del oso (oso-boil,
+   oso-resoplido, oso-rasca-cuerpo, oso-cejas-frunce) — cero keyframes
+   duplicados; solo el LATIDO DE LA LUNA es nuevo (osog-luna). La cabeza NO se
+   mece (gravitas): la vida vive en el respirar pesado, el aliento de los aros
+   (osoa-anteojo-brillo compartido) y la luna que late. Gates RM + tier abajo.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* BOIL DE MONTAÑA — aún más lento que el oso café: la masa asienta despacio. */
+[data-creature='oso-guardian'] .rh-boil {
+  animation-name: oso-boil;
+  animation-duration: 3.2s;
+  animation-timing-function: steps(14, end);
+}
+
+/* RESOPLA — el huff grave del guardián (pecho hincha y suelta con peso). */
+[data-creature='oso-guardian'][data-resopla='1'] .crt-body {
+  animation: oso-resoplido 1.8s cubic-bezier(0.4, 0, 0.5, 1) infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+[data-creature='oso-guardian'][data-resopla='1'] .oso-cejas {
+  animation: oso-cejas-frunce 1.1s ease-in-out infinite;
+}
+
+/* RASCA → en este oso es un REMECERSE de peso (sin manoteo: la mole se
+   acomoda de gusto, digna). Reusa el meneíto del cuerpo del oso café. */
+[data-creature='oso-guardian'][data-rasca='1'] .crt-body {
+  animation: oso-rasca-cuerpo 1.3s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center bottom;
+}
+
+/* Los estados PISAN el arrebato (antic/travieso): el gesto lee limpio. */
+[data-creature='oso-guardian'][data-resopla='1'] .rh-antic,
+[data-creature='oso-guardian'][data-rasca='1'] .rh-antic,
+[data-creature='oso-guardian'][data-resopla='1'] .rh-travieso,
+[data-creature='oso-guardian'][data-rasca='1'] .rh-travieso { animation: none; }
+
+/* LA LUNA LATE — el halo del emblema del pecho respira MUY despacio (7.3s,
+   co-primo con el aliento de los aros 5.3s y el boil 3.2s: nunca en compás). */
+.osog-luna {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: osog-luna 7.3s ease-in-out infinite;
+}
+@keyframes osog-luna {
+  0%, 100% { opacity: 0.22; transform: scale(1); }
+  50%      { opacity: 0.38; transform: scale(1.07); }
+}
+
+/* device-tier 'bajo': el boil reescrito lo reactivaría (misma clase) →
+   re-apagarlo; cejas y luna continuas también. Estados reactivos siguen. */
+[data-tier='bajo'][data-creature='oso-guardian'] .rh-boil,
+[data-tier='bajo'][data-creature='oso-guardian'] .oso-cejas,
+[data-tier='bajo'] .osog-luna { animation: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .osog-luna,
+  [data-creature='oso-guardian'][data-resopla='1'] .crt-body,
+  [data-creature='oso-guardian'][data-resopla='1'] .oso-cejas,
+  [data-creature='oso-guardian'][data-rasca='1'] .crt-body { animation: none !important; }
+}

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -25,17 +25,29 @@ export {
 } from './AbejaTransicion.jsx';
 export { avisarSalidaAbeja, resetSalidaAbeja, useSalidaAbeja } from './senalSalidaAbeja.js';
 export { Colibri } from './Colibri.jsx';
+/* OsoAndino (el café) ARCHIVADO (operador): rechazado por feo. Queda exportado
+   por compatibilidad/historia, pero NO se surfacea (fuera del registro
+   CREATURES). La dirección vigente es OsoGuardian, más abajo. */
 export { OsoAndino } from './OsoAndino.jsx';
-/* EL OSO DE ANTEOJOS EN SU VERSIÓN BUENA — NEGRO BIOPUNK (la dirección
-   aprobada por el operador: azabache azulado + aros crema luminosos + acentos
-   menta medidos; ver dashboard/GuardianEspiritu → AvatarOso). El OsoAndino
-   café de arriba queda archivado (decisión del operador: no surfacear); este
-   es EL oso de primera clase para valle/mundos. Identidad como datos: jamás
-   arrastra three al bundle base — igual que jaguarIdentidad. */
+/* OsoAnteojos ARCHIVADO (operador, 2026-07-18: "casi feíto como el anterior")
+   — igual que el OsoAndino café. El componente queda exportado por
+   compatibilidad, pero NO se surfacea (fuera del registro CREATURES). */
 export { OsoAnteojos } from './OsoAnteojos.jsx';
 export {
   OSO_ANTEOJOS_PALETA, OSO_ANTEOJOS_PROPORCION, OSO_ANTEOJOS_SLUG, PERFIL_OSO_ANTEOJOS,
 } from './osoAnteojosIdentidad.js';
+/* EL OSO DE ANTEOJOS EN SU DIRECCIÓN VIGENTE — EL GUARDIÁN NEGRO DE LA LUNA
+   (base: el avatar aprobado del selector del guardián, dashboard/
+   GuardianEspiritu → AvatarOso: azabache azulado + luna creciente en el pecho
+   + aros de luz + menta medida), elevado a proporciones de ADULTO (cabeza
+   chica sobre joroba de hombros, hocico presente, ojos-almendra serenos,
+   garras) para que deje de leer infantil. Identidad como datos: jamás
+   arrastra three al bundle base — igual que jaguarIdentidad. */
+export { OsoGuardian } from './OsoGuardian.jsx';
+export {
+  OSO_GUARDIAN_PALETA, OSO_GUARDIAN_PROPORCION, OSO_GUARDIAN_RUANA_ANCLA,
+  OSO_GUARDIAN_SLUG, OSO_GUARDIAN_TINTA, PERFIL_OSO_GUARDIAN,
+} from './osoGuardianIdentidad.js';
 export { RanaAndina } from './RanaAndina.jsx';
 export { Ardilla } from './Ardilla.jsx';
 export { Jaguar } from './Jaguar.jsx';
@@ -168,8 +180,9 @@ export { useVidaIdle, useRitmoPropio, useMiradaUsted, prefiereQuietud } from './
 
 import AbejaAngelita from './AbejaAngelita.jsx';
 import Colibri from './Colibri.jsx';
-import OsoAndino from './OsoAndino.jsx';
-import OsoAnteojos from './OsoAnteojos.jsx';
+/* OsoAndino y OsoAnteojos NO se importan acá a propósito: están archivados y
+   fuera del registro CREATURES. Solo entra el guardián. */
+import OsoGuardian from './OsoGuardian.jsx';
 import RanaAndina from './RanaAndina.jsx';
 import Perezoso from './Perezoso.jsx';
 import Ardilla from './Ardilla.jsx';
@@ -192,11 +205,14 @@ import EntFrailejon from './EntFrailejon.jsx';
 export const CREATURES = {
   'abeja-angelita': { Component: AbejaAngelita, nombre: 'Abeja angelita', cientifico: 'Tetragonisca angustula' },
   colibri: { Component: Colibri, nombre: 'Colibrí chillón', cientifico: 'Colibri coruscans' },
-  'oso-andino': { Component: OsoAndino, nombre: 'Oso andino', cientifico: 'Tremarctos ornatus' },
-  // La VERSIÓN BUENA del oso (negro biopunk, aprobada por el operador). El
-  // 'oso-andino' café de arriba queda archivado; surfacear ESTE.
-  /* OSO-ANTEOJOS ARCHIVADO (operador): rechazado por feo. El oso bueno es el
-     negro de la luna del GuardianEspiritu. */
+  /* EL OSO: 'oso-guardian' es la ÚNICA dirección aprobada por el operador (el
+     guardián negro con la luna en el pecho). Los otros dos quedaron ARCHIVADOS
+     por feos y NO se surfacean: 'oso-andino' (OsoAndino.jsx, el café) y
+     'oso-anteojos' (OsoAnteojos.jsx). Fuera del registro para que NADA
+     data-driven los muestre — avatar-selector, fauna ambiental, vecinos del
+     valle (mismo patrón que el borugo). Los componentes quedan en disco por
+     historia, por si alguna vez se rehacen. */
+  'oso-guardian': { Component: OsoGuardian, nombre: 'Oso de anteojos', cientifico: 'Tremarctos ornatus' },
   'rana-andina': { Component: RanaAndina, nombre: 'Rana arlequín andina', cientifico: 'Atelopus spp.' },
   perezoso: { Component: Perezoso, nombre: 'Perezoso de tres dedos', cientifico: 'Bradypus variegatus' },
   ardilla: { Component: Ardilla, nombre: 'Ardilla de cola roja', cientifico: 'Notosciurus granatensis' },

--- a/src/visual/creatures/osoGuardianIdentidad.js
+++ b/src/visual/creatures/osoGuardianIdentidad.js
@@ -92,14 +92,14 @@ export const OSO_GUARDIAN_PROPORCION = {
  *
  *     7.3 + 4.83 + 1.6 = 13.73 ✓
  *
- * El ancho (rx * 1.18 = 10.6) queda DENTRO de la silueta (flancos ±11.9 a esa
- * altura): se apoya, no engulle.
+ * El ancho (rx * 1.18 = 9.2) queda DENTRO de la silueta (flancos ±11.9 a esa
+ * altura): se apoya sobre el regazo, no engulle.
  *
  * OJO: esto es un arreglo de PROPORCIÓN, quirúrgico. El rediseño de fondo de la
  * ruana (que hoy es un trapecio genérico compartido con el resto de la fauna)
  * va aparte, con su propia DR. Si tocás estos números, revisá las dos
  * desigualdades de arriba o la luna se vuelve a tapar. */
-export const OSO_GUARDIAN_RUANA_ANCLA = { cx: 0, cy: 7.3, rx: 9.0, ry: 4.6 };
+export const OSO_GUARDIAN_RUANA_ANCLA = { cx: 0, cy: 7.3, rx: 7.8, ry: 4.6 };
 
 /*
  * PERFIL_OSO_GUARDIAN — perfil de CLIMA→cuerpo para `cuerpoDeClima`

--- a/src/visual/creatures/osoGuardianIdentidad.js
+++ b/src/visual/creatures/osoGuardianIdentidad.js
@@ -69,8 +69,8 @@ export const OSO_GUARDIAN_PALETA = {
  *
  * Fuente: DR `anatomia-y-silueta-del-oso-de-anteojos` (brazo gemini, 2026-06-19).
  * Lo que manda de ahí, y que este oso ahora sí cumple:
- *   · Musculoso y TREPADOR, no gordo: hay cintura (grupa 12.7 contra costillar
- *     10.6 = ~17% de estrechamiento). Gradual, nunca cintura de avispa.
+ *   · Musculoso y TREPADOR, no gordo: hay cintura (grupa 12.5 contra costillar
+ *     10.2 = ~18% de estrechamiento). Gradual, nunca cintura de avispa.
  *   · Cuello CORTO Y MUSCULOSO: el trapecio sube DETRÁS del cráneo (cuelloY)
  *     y la cabeza nace del cuerpo. No hay cabeza posada.
  *   · Cruz (paletillas) marcada por pelaje denso — el "ahuecado" del hombro,
@@ -80,21 +80,21 @@ export const OSO_GUARDIAN_PALETA = {
  *   · Plantígrado: apoya la planta completa, talón y dedos (como nosotros).
  */
 export const OSO_GUARDIAN_PROPORCION = {
-  grupaRx: 12.7,     // el punto MÁS ancho: las ancas del oso sentado
+  grupaRx: 12.5,     // el punto MÁS ancho: las ancas del oso sentado
   grupaY: 7.4,       // altura de esa cadera
-  cinturaRx: 10.6,   // el costillar: hay estrechamiento, es un oso atlético
+  cinturaRx: 10.2,   // el costillar: hay estrechamiento, es un oso atlético
   cinturaY: 1.0,
-  cruzX: 6.4,        // dónde asoma la paletilla al costado del cráneo
-  cruzY: -11.0,      // altura de la cruz (por encima de la base del cráneo)
-  cuelloY: -14.0,    // el trapecio sube hasta acá, ESCONDIDO tras el cráneo
-  hombroX: 9.6,      // el deltoides: de ahí nace la pata delantera
-  hombroY: -7.4,
+  cruzX: 5.8,        // dónde asoma la paletilla al costado del cráneo
+  cruzY: -10.9,      // altura de la cruz (por encima de la base del cráneo)
+  cuelloY: -14.2,    // el trapecio sube hasta acá, ESCONDIDO tras el cráneo
+  hombroX: 8.7,      // el deltoides: de ahí nace la pata delantera
+  hombroY: -7.0,
   sueloY: 13.4,      // la línea de suelo donde apoyan las cuatro plantas
   cabezaRx: 4.15,    // cráneo proporcionado (no cabezón) — CONSERVADO
   cabezaRy: 3.6,
   orejaR: 1.32,      // orejas chicas y bajas de oso real (no discos de peluche)
   /* compat: consumidores viejos que leían la media anchura/altura de la mole */
-  hombrosRx: 12.7,
+  hombrosRx: 12.5,
   troncoRy: 10.8,
 };
 

--- a/src/visual/creatures/osoGuardianIdentidad.js
+++ b/src/visual/creatures/osoGuardianIdentidad.js
@@ -59,46 +59,85 @@ export const OSO_GUARDIAN_PALETA = {
   sombraSuelo: 'rgba(4,10,18,0.52)', // el peso de la mole en el suelo
 };
 
-/* PROPORCIONES DEL ADULTO (el corazón del rediseño):
-   hombros 24.4 de ancho contra cabeza de 8.3 → ratio ≈ 0.34 (el OsoAnteojos
-   rechazado andaba por 0.6, proporción de cría/peluche). Cabeza hundida en la
-   joroba de hombros (plantígrado sin cuello), sentado como montaña. */
+/* PROPORCIONES DEL ADULTO — ANATOMÍA, no un domo.
+ *
+ * El rediseño anterior acertó el REGISTRO (cabeza chica sobre cuerpo grande,
+ * ratio ≈ 0.34) pero falló el CUERPO: era una campana lisa, sin cruz, sin
+ * cuello, sin grupa, con la cabeza apoyada encima como calcomanía. Estos
+ * números fijan las marcas anatómicas reales del Tremarctos ornatus para que
+ * la silueta se construya sobre ellas y no a ojo.
+ *
+ * Fuente: DR `anatomia-y-silueta-del-oso-de-anteojos` (brazo gemini, 2026-06-19).
+ * Lo que manda de ahí, y que este oso ahora sí cumple:
+ *   · Musculoso y TREPADOR, no gordo: hay cintura (grupa 12.7 contra costillar
+ *     10.6 = ~17% de estrechamiento). Gradual, nunca cintura de avispa.
+ *   · Cuello CORTO Y MUSCULOSO: el trapecio sube DETRÁS del cráneo (cuelloY)
+ *     y la cabeza nace del cuerpo. No hay cabeza posada.
+ *   · Cruz (paletillas) marcada por pelaje denso — el "ahuecado" del hombro,
+ *     no la joroba de grizzly (que esta especie NO tiene).
+ *   · Patas delanteras MÁS LARGAS que las traseras (adaptación trepadora):
+ *     por eso el codo cae bajo y el antebrazo es largo.
+ *   · Plantígrado: apoya la planta completa, talón y dedos (como nosotros).
+ */
 export const OSO_GUARDIAN_PROPORCION = {
-  hombrosRx: 12.2,   // media anchura de la mole a la altura de los flancos
-  troncoRy: 10.8,    // media altura de la mole (de la joroba al asiento)
-  cabezaRx: 4.15,    // cráneo proporcionado (no cabezón)
+  grupaRx: 12.7,     // el punto MÁS ancho: las ancas del oso sentado
+  grupaY: 7.4,       // altura de esa cadera
+  cinturaRx: 10.6,   // el costillar: hay estrechamiento, es un oso atlético
+  cinturaY: 1.0,
+  cruzX: 6.4,        // dónde asoma la paletilla al costado del cráneo
+  cruzY: -11.0,      // altura de la cruz (por encima de la base del cráneo)
+  cuelloY: -14.0,    // el trapecio sube hasta acá, ESCONDIDO tras el cráneo
+  hombroX: 9.6,      // el deltoides: de ahí nace la pata delantera
+  hombroY: -7.4,
+  sueloY: 13.4,      // la línea de suelo donde apoyan las cuatro plantas
+  cabezaRx: 4.15,    // cráneo proporcionado (no cabezón) — CONSERVADO
   cabezaRy: 3.6,
   orejaR: 1.32,      // orejas chicas y bajas de oso real (no discos de peluche)
+  /* compat: consumidores viejos que leían la media anchura/altura de la mole */
+  hombrosRx: 12.7,
+  troncoRy: 10.8,
 };
 
-/* ANCLA DE LA RUANA (AccesoriosClima) — NO es la medida de la mole.
+/* LA RUANA DEL GUARDIÁN — lana pesada de verdad, no un trapecio.
  *
- * Bug corregido: se le pasaba la mole entera (rx 12.2 / ry 10.8 / cy 2) como
- * ancla. AccesoriosClima dibuja el poncho a `rx * 1.18` de media anchura, o sea
- * 28.8 de ancho en un viewBox de 32: más ancho que el propio oso (flancos a
- * ±12.4) y con el borde superior curvándose hasta y≈-6.6. Resultado: una caja
- * café que se tragaba el cuerpo y tapaba LA LUNA DEL PECHO, que es la firma del
- * personaje. El operador lo llamó "un fail".
+ * Fuente: DR `la-ruana-andina-colombiana` (brazo gemini, 2026-06-19). Lo que
+ * obliga ese dossier y que la ruana genérica de AccesoriosClima no daba:
+ *   · Lana virgen de oveja, ~1 kg: cae con GRAVEDAD. Pliegues amplios y
+ *     definidos que se asientan; no una tela que flota.
+ *   · Se asienta FIRME sobre los hombros y no resbala — por eso hubo que
+ *     dibujarle hombros al oso primero. Sin cruz no hay dónde apoyarla.
+ *   · Abierta al frente (eso la separa del poncho, que es cerrado).
+ *   · Colores sobrios del altiplano cundiboyacense: negro, azul oscuro, gris
+ *     oscuro. Las franjas rojas/amarillas son la variante vieja y acá
+ *     COMPETÍAN en área con la luna del pecho, que es el emblema. Fuera.
+ *   · Al frío se echa una punta sobre el hombro contrario. Eso resuelve dos
+ *     cosas de una: es el gesto auténtico documentado Y deja el pecho abierto,
+ *     así la luna nunca queda tapada.
+ *   · Sobre cuerpo no humano: los pliegues se exageran por la musculatura y la
+ *     prenda se integra. Si "cuelga" sin interactuar, se lee disfraz.
+ */
+export const OSO_GUARDIAN_RUANA = {
+  pano: '#2e2657',        // lana teñida de índigo oscuro (sobrio de altiplano)
+  panoLuz: '#413873',     // el lomo del pliegue donde pega la luz de luna
+  panoSombra: '#171233',  // el fondo de la arruga: la lana es densa, no traslúcida
+  panoRevés: '#4a4180',   // el envés que se ve en la punta echada al hombro
+  franja: '#8e8468',      // UNA banda de lana cruda: sobria, no compite
+  fleco: '#7b7259',       // los flecos del ruedo, tejidos y pesados
+};
+
+/* ANCLA DE LA RUANA GENÉRICA — OBSOLETA, se conserva solo por compatibilidad.
  *
- * La ruana se APOYA sobre el lomo/ancas, por DEBAJO de la luna. La luna vive en
- * un círculo de r=5.4 centrado en (-0.9, -2.2) → su borde inferior está en
- * y=3.2. AccesoriosClima levanta el borde superior del poncho hasta
- * `cy - ry*0.8` (el pico de la curva del cuello), así que la restricción dura es:
+ * Historia: la ruana venía de `AccesoriosClima`, el trapecio species-agnostic
+ * que viste a toda la fauna. Sobre este oso se le pasaba la mole entera como
+ * ancla y el poncho salía más ancho que el propio animal, tapando la luna del
+ * pecho. Se corrigió encogiendo el ancla a estos números — un parche de
+ * PROPORCIÓN, con la nota de que el rediseño de fondo iba aparte.
  *
- *     cy - ry*0.8 > 3.2      → con cy 7.3 / ry 4.6 da 3.62 ✓ (holgura 0.4)
- *
- * y el ruedo (`cy + ry*1.05`, con el vaivén de +1.6 al centro) tiene que quedar
- * sobre el cuerpo, no colgando bajo las garras (y=13.9):
- *
- *     7.3 + 4.83 + 1.6 = 13.73 ✓
- *
- * El ancho (rx * 1.18 = 9.2) queda DENTRO de la silueta (flancos ±11.9 a esa
- * altura): se apoya sobre el regazo, no engulle.
- *
- * OJO: esto es un arreglo de PROPORCIÓN, quirúrgico. El rediseño de fondo de la
- * ruana (que hoy es un trapecio genérico compartido con el resto de la fauna)
- * va aparte, con su propia DR. Si tocás estos números, revisá las dos
- * desigualdades de arriba o la luna se vuelve a tapar. */
+ * Ese rediseño ya se hizo: el guardián tiene su propia `RuanaGuardian.jsx`,
+ * dibujada con la caída, los pliegues y la punta al hombro que documenta la DR
+ * de la ruana andina, y apoyada sobre unos hombros que antes no existían. El
+ * oso ya NO consume AccesoriosClima. Este export queda para no romper a quien
+ * lo reexporte; no lo use para dibujar. */
 export const OSO_GUARDIAN_RUANA_ANCLA = { cx: 0, cy: 7.3, rx: 7.8, ry: 4.6 };
 
 /*

--- a/src/visual/creatures/osoGuardianIdentidad.js
+++ b/src/visual/creatures/osoGuardianIdentidad.js
@@ -1,0 +1,118 @@
+/*
+ * osoGuardianIdentidad — LA IDENTIDAD VISUAL DEL OSO GUARDIÁN, COMO DATOS.
+ *
+ * El oso de anteojos (Tremarctos ornatus) en su TERCERA y definitiva dirección
+ * de arte: el GUARDIÁN NEGRO DE LA LUNA. La base aprobada por el operador es el
+ * avatar del selector del guardián (dashboard/GuardianEspiritu → AvatarOso):
+ * pelaje AZABACHE AZULADO casi silueta, contorno con luz MENTA (#2dffc4), la
+ * LUNA CRECIENTE crema en el pecho (su emblema) y los anteojos hechos de AROS
+ * DE LUZ. Este archivo fija esa paleta como fuente única.
+ *
+ * Lo que este rediseño CORRIGE de los dos osos rechazados (el café OsoAndino y
+ * el OsoAnteojos de peluche): las PROPORCIONES. Cabeza proporcionada sobre
+ * hombros anchos (ratio cabeza:hombros ≈ 1:3, no 1:1.6), hocico presente,
+ * ojos almendrados serenos (no ojos-juguete de pupila gigante), sin rubor de
+ * cachetes, garras visibles. Presencia de guardián adulto, no ternura de cría.
+ *
+ * REGLA DE ORO (idéntica a jaguarIdentidad/abejaIdentidad): SOLO datos. Cero
+ * three, cero react. La CADENCIA vive en `creatures.css` (clases `rh-*`/
+ * `oso-*`/`osog-*`); el DIBUJO compone el KIT `_rubberhose.jsx` donde sirve
+ * (BocaVisema, Sonrisa, blink/mirada); el CLIMA→cuerpo, en
+ * `creatureClimaCuerpo.js` vía PERFIL_OSO_GUARDIAN.
+ */
+
+/* Slug estable del oso guardián (data-creature, aura, perfiles). */
+export const OSO_GUARDIAN_SLUG = 'oso-guardian';
+
+/* TINTA NOCTURNA propia: el contorno de este oso NO es la tinta cálida de la
+   familia (RH_INK marrón) sino un índigo casi negro — es un espíritu de noche
+   y luna, la línea que manda es fría. Deviación deliberada de identidad. */
+export const OSO_GUARDIAN_TINTA = '#07051a';
+
+export const OSO_GUARDIAN_PALETA = {
+  /* pelaje azabache azulado (del avatar aprobado #171030/#1c1338) con volumen:
+     luz de luna en el lomo → azabache medio → sombra ventral casi negra */
+  cuerpo: '#181130',
+  cuerpoLuz: '#352b62',      // el lametón de luz lunar sobre el hombro
+  cuerpoSombra: '#0b0722',   // la panza en penumbra
+  cuerpoGlow: 'rgba(45,255,196,0.30)', // el halo menta MEDIDO de la silueta
+  pata: '#161038',           // las columnas de las patas, en sombra propia
+  planta: '#241d40',         // la planta plantígrada
+  garra: '#cfe8dd',          // garras hueso-menta: visibles, romas, sin amenaza
+  /* la firma luminosa (del avatar aprobado) */
+  menta: '#2dffc4',          // el neón biopunk del contorno/rim
+  luna: '#f4fff9',           // la LUNA CRECIENTE del pecho (cara iluminada)
+  lunaSombra: '#c9e8d8',     // los mares de la luna (que no sea un sticker)
+  lunaHalo: '#eafff6',       // el halo que respira alrededor del emblema
+  anteojo: '#eafff6',        // los AROS de luz de los anteojos
+  anteojoGlow: '#bfffe9',    // el aliento de los aros
+  /* la cara */
+  iris: '#7dffd9',           // ojo con alma: iris menta-luz, pupila honda
+  ojo: '#0a0620',            // la almendra oscura del ojo (ojo real de oso)
+  ceja: '#4d4380',           // ceño índigo-claro: serio sereno, no bravo
+  hocico: '#e2c69d',         // el morro canela del avatar aprobado (la única nota cálida)
+  hocicoSombra: '#ab8760',
+  trufa: '#0b0f1c',
+  /* atmósfera */
+  espora: '#bfffe9',         // motas de bosque nublado que flotan lento
+  bruma: '#9fffe0',          // el velo tenue a los pies
+  sombraSuelo: 'rgba(4,10,18,0.52)', // el peso de la mole en el suelo
+};
+
+/* PROPORCIONES DEL ADULTO (el corazón del rediseño):
+   hombros 24.4 de ancho contra cabeza de 8.3 → ratio ≈ 0.34 (el OsoAnteojos
+   rechazado andaba por 0.6, proporción de cría/peluche). Cabeza hundida en la
+   joroba de hombros (plantígrado sin cuello), sentado como montaña. */
+export const OSO_GUARDIAN_PROPORCION = {
+  hombrosRx: 12.2,   // media anchura de la mole a la altura de los flancos
+  troncoRy: 10.8,    // media altura de la mole (de la joroba al asiento)
+  cabezaRx: 4.15,    // cráneo proporcionado (no cabezón)
+  cabezaRy: 3.6,
+  orejaR: 1.32,      // orejas chicas y bajas de oso real (no discos de peluche)
+};
+
+/* ANCLA DE LA RUANA (AccesoriosClima) — NO es la medida de la mole.
+ *
+ * Bug corregido: se le pasaba la mole entera (rx 12.2 / ry 10.8 / cy 2) como
+ * ancla. AccesoriosClima dibuja el poncho a `rx * 1.18` de media anchura, o sea
+ * 28.8 de ancho en un viewBox de 32: más ancho que el propio oso (flancos a
+ * ±12.4) y con el borde superior curvándose hasta y≈-6.6. Resultado: una caja
+ * café que se tragaba el cuerpo y tapaba LA LUNA DEL PECHO, que es la firma del
+ * personaje. El operador lo llamó "un fail".
+ *
+ * La ruana se APOYA sobre el lomo/ancas, por DEBAJO de la luna. La luna vive en
+ * un círculo de r=5.4 centrado en (-0.9, -2.2) → su borde inferior está en
+ * y=3.2. AccesoriosClima levanta el borde superior del poncho hasta
+ * `cy - ry*0.8` (el pico de la curva del cuello), así que la restricción dura es:
+ *
+ *     cy - ry*0.8 > 3.2      → con cy 7.3 / ry 4.6 da 3.62 ✓ (holgura 0.4)
+ *
+ * y el ruedo (`cy + ry*1.05`, con el vaivén de +1.6 al centro) tiene que quedar
+ * sobre el cuerpo, no colgando bajo las garras (y=13.9):
+ *
+ *     7.3 + 4.83 + 1.6 = 13.73 ✓
+ *
+ * El ancho (rx * 1.18 = 10.6) queda DENTRO de la silueta (flancos ±11.9 a esa
+ * altura): se apoya, no engulle.
+ *
+ * OJO: esto es un arreglo de PROPORCIÓN, quirúrgico. El rediseño de fondo de la
+ * ruana (que hoy es un trapecio genérico compartido con el resto de la fauna)
+ * va aparte, con su propia DR. Si tocás estos números, revisá las dos
+ * desigualdades de arriba o la luna se vuelve a tapar. */
+export const OSO_GUARDIAN_RUANA_ANCLA = { cx: 0, cy: 7.3, rx: 9.0, ry: 4.6 };
+
+/*
+ * PERFIL_OSO_GUARDIAN — perfil de CLIMA→cuerpo para `cuerpoDeClima`
+ * (creatureClimaCuerpo.js), mismo shape que PERFIL_JAGUAR. Es de bosque
+ * altoandino/páramo:
+ *   alas    false → sin aleteo.
+ *   humedad 0.55 → pelaje denso de niebla: el agua apenas lo toca.
+ *   difusa  0.5  → la mole grande: la niebla apenas lo difumina.
+ *   sequia  0.4  → el bosque nublado sufre la seca un poco más que el jaguar.
+ */
+export const PERFIL_OSO_GUARDIAN = Object.freeze({
+  alas: false,
+  humedad: 0.55,
+  difusa: 0.5,
+  sequia: 0.4,
+});

--- a/src/visual/creatures/transformacion.js
+++ b/src/visual/creatures/transformacion.js
@@ -28,7 +28,8 @@ export const CLASE_PODER = 'is-powered-up';
 export const AURA_POR_BICHO = Object.freeze({
   'abeja-angelita': '#ffd54a', // dorada clásica
   'oso-andino': '#ff3b30',     // roja berserker
-  'oso-anteojos': '#2dffc4',   // MENTA bioluminiscente (el oso negro biopunk — la versión buena)
+  'oso-anteojos': '#2dffc4',   // MENTA bioluminiscente (archivado 2026-07-18; ver oso-guardian)
+  'oso-guardian': '#2dffc4',   // MENTA lunar (el guardián negro de la luna — la dirección vigente)
   'rana-andina': '#39d98a',    // verde-zen (slug real de la creature)
   'rana-arlequin': '#39d98a',  // alias biblia
   colibri: '#4fd1ff',          // iridiscente (aprox. celeste)

--- a/src/visual/creatures/vidaEstados.js
+++ b/src/visual/creatures/vidaEstados.js
@@ -33,7 +33,10 @@
    no es de cuarzo). El TEMPERAMENTO va en el compás: los nerviosos (ardilla,
    colibrí) gesticulan seguido; los lentos (morrocoy, perezoso) casi nunca. */
 export const VIDA_REPERTORIO = {
-  'oso-andino': {
+  /* Tremarctos ornatus. El slug vivo del registro es 'oso-guardian'; los dibujos
+     archivados ('oso-andino' el café, 'oso-anteojos') siguen leyendo esta misma
+     fila por alias más abajo: MISMA especie, mismo temperamento lento. */
+  'oso-guardian': {
     descanso: [4200, 9800],
     momentos: {
       resopla: { dur: 4500, peso: 2 }, // 3× oso-resoplido 1.5s · 5× oso-cejas-frunce 0.9s

--- a/src/visual/mundo3d/sierra/SierraMonte3D.jsx
+++ b/src/visual/mundo3d/sierra/SierraMonte3D.jsx
@@ -56,7 +56,7 @@ import {
   geomVenadoCuerpo, geomVenadoPata, geomAguilaCuerpo, geomAguilaAla,
 } from './sierraBiodiversa.geom.js';
 import CondorBillboard from '../CondorBillboard.jsx';
-import { OsoAndino } from '../../creatures/index.js';
+import { OsoGuardian } from '../../creatures/index.js';
 
 /* Las cuatro bandas navegables, del grafo (pisosTermicos.js). `azimut` reparte
    sus hotspots alrededor del macizo para que orbitar los descubra. */
@@ -346,8 +346,8 @@ function OsoDeAnteojos({ pos, tier, animated, px = 56, factor = 15 }) {
   return (
     <group position={/** @type {[number,number,number]} */ (pos)}>
       <Html center distanceFactor={factor} zIndexRange={[12, 0]} occlude pointerEvents="none">
-        <div aria-hidden="true" data-vecino="oso-andino" style={ESTILO_BICHO}>
-          <OsoAndino size={px} animated={animated} tier={tier} />
+        <div aria-hidden="true" data-vecino="oso-guardian" style={ESTILO_BICHO}>
+          <OsoGuardian size={px} animated={animated} tier={tier} />
         </div>
       </Html>
     </group>

--- a/src/visual/registry.js
+++ b/src/visual/registry.js
@@ -86,7 +86,7 @@ const VARIANTES_OSO = [
   { label: 'se rasca', props: { size: 88, rasca: true } },
   { label: 'ruana de noche', props: { size: 88, vestuario: true, clima: 'noche' } },
   { label: 'con lupa (suelo)', props: { size: 88, mundoId: 'suelo' } },
-  { label: 'poder ROJO', props: { size: 88, poder: true } },
+  { label: 'poder MENTA', props: { size: 88, poder: true } },
   { label: 'línea que hierve', props: { size: 88, lineBoil: true } },
   { label: 'sin animación', props: { size: 88, animated: false } },
 ];
@@ -244,7 +244,7 @@ const VARIANTES_ENT = [
 const VARIANTES_POR_SLUG = {
   'abeja-angelita': VARIANTES_ABEJA,
   colibri: VARIANTES_TRIO_AIRE,
-  'oso-andino': VARIANTES_OSO,
+  'oso-guardian': VARIANTES_OSO,
   'rana-andina': VARIANTES_TRIO_SUELO,
   perezoso: VARIANTES_PEREZOSO,
   ardilla: VARIANTES_ARDILLA,
@@ -261,7 +261,7 @@ const VARIANTES_POR_SLUG = {
 const NOTAS_CREATURE = {
   'abeja-angelita': 'Meliponino sin aguijón, polinizadora de la chagra; alas que baten y antenas vivas.',
   colibri: 'Pico recto y garganta violeta iridiscente; el ave-agente de Chagra, ya en rubber-hose.',
-  'oso-andino': 'Oso de anteojos, guardián del páramo; mole parda entrañable con los anteojos crema (su firma).',
+  'oso-guardian': 'Oso de anteojos, guardián del páramo; mole azabache de hombros altos con la luna creciente en el pecho (su firma) y rim-light lunar.',
   'rana-andina': 'Rana arlequín del páramo, guardiana del agua; verde húmedo con manchas ocre y ojos saltones.',
   perezoso: 'Perezoso de tres dedos, la calma total; cuelga de la rama por sus garras largas, antifaz y tinte verdoso de algas. Todo en cámara lenta.',
   ardilla: 'Ardilla de cola roja del templado; rufa con la línea dorsal oscura (su firma), cola tupida y su inspección invertida.',


### PR DESCRIPTION
Dos encargos cortos de dibujo, sin archivos compartidos. Un commit por
encargo, para poder revertir uno sin tumbar el otro.

## 1 — La ruana tiene mangas, y una ruana no tiene mangas
`src/visual/creatures/RuanaGuardian.jsx`

La ruana del guardián estaba dibujada como dos paños cerrados, uno por
brazo, con el ruedo rematando sobre la muñeca: dos tubos con puño, o sea
un abrigo de catálogo. Una ruana andina no tiene mangas — es UNA manta
rectangular de lana con abertura para la cabeza, abierta al frente, que
cae SOBRE los brazos sin envolverlos.

Cómo se dibuja esa diferencia:

- **Un solo path cerrado**: yugo sobre la cruz + las dos caídas son la
  misma silueta continua. Dos formas separadas se leen como dos prendas.
- **Esquinas**: los vértices del rectángulo cuelgan en punta con su peso,
  por debajo de la línea del ruedo. Una manga nunca tiene esquinas.
- **Quiebre sobre el brazo**: el codo empuja el plano desde abajo y la
  lana quiebra en un pliegue horizontal (lomo con luz + doblez en sombra).
  Los pliegues verticales llevan ese codo.
- **Ruedo alto y orillo recto en diagonal**: el antebrazo y la mano asoman
  por debajo de la manta, nunca de un puño. Festón asimétrico.

Se conserva lo aprobado: caída con pliegues, festón, flecos, banda única
de lana cruda, colores sobrios del altiplano, la punta echada al hombro y
el pecho despejado para que la luna nunca quede tapada. **La anatomía del
oso, su cara, la luna y el rim menta no se tocan.**

Grounding: DR `la-ruana-andina-colombiana` (brazo gemini).

## 2 — La zarigüeya se confundía con el gurre
`src/components/dashboard/CriaturasNocturnas.jsx`

A 64 px la zarigüeya y el gurre eran el mismo bicho: dos masas oscuras
horizontales con hocico largo al frente. Y la cola nacía tan arriba del
lomo que se leía como un ala, cuando la cola prensil desnuda es justo el
rasgo que la delata.

- **La acción antes que la forma**: el gurre escarba (cuerpo bajo, nariz
  al suelo); la zarigüeya husmea ERGUIDA, sobre los cuartos traseros, eje
  en diagonal y hocico leyendo el aire. Masa horizontal contra vertical.
- **Exageración del rasgo diagnóstico**: la cola prensil nace baja en la
  grupa, con su base peluda que la ancla, barre el suelo y remata en
  gancho enroscado. La del gurre es cónica y rígida.
- **Contraste de formas**: curva orgánica y pelo de guardia que rompe la
  silueta, contra el domo rígido segmentado. Orejas grandes y redondeadas
  altas en el contorno, contra la oreja tubular chica del gurre.
- **Manos recogidas** contra el pecho y sombra corta bajo la grupa.

Las **crías al lomo se conservan y se realzan**: sobre el lomo en diagonal
van escalonadas en abanico, cada una con su ángulo, y se ven las tres
enteras con su hocico y sus manitos en vez de encimarse. `ZariguyaCria`
acepta un `rot` opcional; su dibujo no cambia.

**El gurre, el búho, el murciélago y el tigrillo no se tocan.** El roster
grounded (nombre científico, rol, frase, fuente) tampoco.

Grounding: DR `distinguir-visualmente-zariguya-de-armadillo`.

## Verificación
- Render propio a 300 px, a 64 px junto al gurre y con **test de silueta
  en negro**: ya no se confunden.
- Oso con ruana renderizado a 760 px con `clima="noche" vestuario`.
- `vite build` verde (38 s).
- Lint limpio en los dos archivos.
- Suite de `creatures` + `dashboard`: 482 pasan. Los 6 fallos (Borugo,
  vidaEstados, ClimaStrip, glaciarBanner) **son preexistentes** —
  verificado corriéndolos sobre la rama base.

## Notas
- Este PR **sincroniza** `CriaturasNocturnas.jsx` y `criaturas-nocturnas
  .css` con `integra/nocturnas-cinco` (02f98e5f) para retocar sobre la
  versión elevada. Al integrar ambas ramas el merge es trivial.
- Dos `eslint-disable` puntuales por la deuda de `react-refresh` que ya
  traía el archivo (el roster y el buscador conviven con los componentes).
- La captura la revisa el operador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)