### PR TITLE
fix(angelita): redibujar como Tetragonisca angustula (melipona real, sin aguijón)

### DIFF
--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -13,7 +13,10 @@ import { AuraPoder } from './AuraPoder.jsx';
 import { auraDeBicho } from './transformacion.js';
 
 /* Abeja angelita — Tetragonisca angustula (meliponino nativo SIN aguijón, NO
-   Apis). Cuerpo ámbar rayado (chumbe andino), cabeza clara, alitas de tul.
+   Apis). Cabeza y tórax OSCUROS (casi negros) + abdomen ámbar PÁLIDO y LISO,
+   sin bandas: las tres barras oscuras eran la firma de la Apis europea, la que
+   saquea las colmenas de angelita. Cuerpo esbelto, alitas de tul que le sobran
+   del cuerpo, remate redondo sin aguijón.
    Elevada al lenguaje RUBBER-HOSE PLENO (Cuphead + Miss Minutes de Loki):
    contorno grueso que respira, ojos de goma con pupila grande y brillo, cachetes
    campesinos, bracitos/patitas de manguera con mitones, antenas con bombillo que
@@ -24,12 +27,6 @@ import { auraDeBicho } from './transformacion.js';
    fuente que dimensiona/tiñe su presencia 3D (useEntradaAbeja) — una sola abeja. */
 const VIEWBOX = '-15 -15 32 30';
 
-/* Rayas del cuerpo tejidas como CHUMBE andino: banda de tinta con hilo tierra. */
-const BANDAS = [
-  { x: -3.6, y0: -4.7, y1: 4.7 },
-  { x: 0.4, y0: -5.0, y1: 5.0 },
-  { x: 4.0, y0: -4.0, y1: 4.0 },
-];
 
 export function AbejaAngelita({
   size = 64,
@@ -234,26 +231,33 @@ export function AbejaAngelita({
       {/* alitas de tul con contorno + smear (crt-wingbeat ya lleva el estirón).
           La duración del aleteo la modula el clima real (wingDur): dorada rápida,
           lluvia pesada. celebra/reposo (data-pose) mandan por especificidad CSS. */}
-      <ellipse className={wing} style={alaStyle} cx="-1.8" cy="-7" rx="6" ry="3.6" fill={ABEJA_PALETA.alaTul}
-        opacity="0.62" stroke="rgba(42,26,12,0.4)" strokeWidth="0.5" />
-      <ellipse className={wing} style={alaStyle2} cx="2.2" cy="-6.4"
-        rx="4.6" ry="2.8" fill={ABEJA_PALETA.alaTulClara} opacity="0.5" stroke="rgba(42,26,12,0.35)" strokeWidth="0.5" />
+      <ellipse className={wing} style={alaStyle} cx="-3.4" cy="-6" rx="8.8" ry="3.3" fill={ABEJA_PALETA.alaTul}
+        opacity="0.55" stroke="rgba(42,26,12,0.32)" strokeWidth="0.45" />
+      <ellipse className={wing} style={alaStyle2} cx="-0.4" cy="-5.2"
+        rx="6.6" ry="2.7" fill={ABEJA_PALETA.alaTulClara} opacity="0.44" stroke="rgba(42,26,12,0.28)" strokeWidth="0.45" />
 
       {/* patitas manguera con pie crema (detrás del tronco, se mecen suave) */}
       <Miembro d="M-2.6,4.4 C-3.2,6.6 -3.4,8 -3.0,9.2" ancho={1.9} punta={[-3.0, 9.4]} puntaR={1.3} pie sway={vivo} delay={-0.6} />
       <Miembro d="M1.8,4.7 C1.4,6.8 1.3,8.2 1.8,9.4" ancho={1.9} punta={[1.8, 9.6]} puntaR={1.3} pie sway={vivo} delay={-0.95} />
 
-      {/* tronco ámbar con contorno grueso (la línea que respira con el boil) */}
-      <ellipse cx="0" cy="0" rx={ABEJA_PROPORCION.troncoRx} ry={ABEJA_PROPORCION.troncoRy}
+      {/* ABDOMEN ámbar PÁLIDO, esbelto y LISO: SIN las tres barras verticales
+          oscuras (esas eran la firma de la Apis europea). Remata redondo — SIN
+          aguijón. Va a la izquierda, dejándole el lado derecho al tórax; su
+          contorno respira con el boil. */}
+      <ellipse cx="-1.4" cy="0" rx="7.4" ry="5.1"
         fill={ABEJA_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.3"
         style={{ filter: `drop-shadow(0 0 6px ${ABEJA_PALETA.cuerpoGlow})` }} />
-      {/* rayas = chumbe: banda de tinta + hilo tierra */}
-      {BANDAS.map((b, i) => (
-        <g key={i}>
-          <path d={`M${b.x},${b.y0} L${b.x},${b.y1}`} stroke={RH_INK} strokeWidth="1.9" strokeLinecap="round" />
-          <path d={`M${b.x},${b.y0 + 0.6} L${b.x},${b.y1 - 0.6}`} stroke={ABEJA_PALETA.hiloChumbe} strokeWidth="0.7" strokeLinecap="round" />
-        </g>
-      ))}
+      {/* brillo suave de volumen (el lomo del abdomen) — NUNCA una banda */}
+      <ellipse cx="-2.6" cy="-2.2" rx="3.6" ry="1.7" fill={ABEJA_PALETA.acento} opacity="0.28" />
+      {/* tergite APENAS insinuado (una línea suave que sigue la curva), el
+          detalle de segmento del meliponino, jamás una banda de color */}
+      <path d="M-6.6,-2.4 Q-7.3,0 -6.6,2.6" stroke={ABEJA_PALETA.hiloChumbe}
+        strokeWidth="0.5" fill="none" strokeLinecap="round" opacity="0.45" />
+      {/* TÓRAX oscuro y redondo (peludo): junto con la cabeza forma la mitad
+          OSCURA del cuerpo — la estructura de valores INVERTIDA respecto a la
+          Apis (que lo tiene claro). Sobre el arranque del abdomen, bajo la cabeza. */}
+      <ellipse cx="5.0" cy="-0.4" rx="3.5" ry="4.4" fill={ABEJA_PALETA.torax}
+        stroke={RH_INK} strokeWidth="1.2" />
 
       {/* bracitos manguera con mitón crema (delante del tronco, follow-through).
           Marcados (crt-brazo-l/r) y con pivote en el HOMBRO para que los gestos
@@ -265,8 +269,12 @@ export function AbejaAngelita({
       <Miembro clase="crt-brazo-r" origen="left top"
         d="M5.4,3.0 C6.9,4.2 7.5,5.9 7.0,7.5" ancho={2.2} punta={[7.0, 7.8]} puntaR={1.6} sway={vivo} delay={-0.45} />
 
-      {/* cabeza clara con contorno */}
+      {/* cabeza OSCURA (casi negra) con contorno — la mitad oscura del meliponino */}
       <circle cx="8.6" cy="-1.0" r={ABEJA_PROPORCION.cabezaR} fill={ABEJA_PALETA.cabeza} stroke={RH_INK} strokeWidth="1.2" />
+      {/* MÁSCARA FACIAL clara: la marca amarilla del clípeo de la angelita real —
+          y, a la vez, el fondo sobre el que la carita (ojos/boca/cejas del agente)
+          sigue leyéndose pese a la cabeza oscura. Va bajo ojos/cachetes/boca. */}
+      <ellipse cx="9.4" cy="-0.2" rx="3.2" ry="3.4" fill={ABEJA_PALETA.cara} opacity="0.95" />
       {/* chapetas campesinas + sonrisa + ojos de goma (parpadean juntos) */}
       <Cachetes puntos={[{ cx: 10.4, cy: 0.7, r: 1.15 }, { cx: 6.9, cy: 0.3, r: 0.85 }]} vivo={vivo} />
       {/* Boca: lip-sync si hay visema; si no, la sonrisa de goma de siempre. */}

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -244,14 +244,14 @@ export function AbejaAngelita({
           oscuras (esas eran la firma de la Apis europea). Remata redondo — SIN
           aguijón. Va a la izquierda, dejándole el lado derecho al tórax; su
           contorno respira con el boil. */}
-      <ellipse cx="-1.4" cy="0" rx="7.4" ry="5.1"
+      <ellipse cx="-2.0" cy="0.2" rx="8.1" ry="4.5"
         fill={ABEJA_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.3"
         style={{ filter: `drop-shadow(0 0 6px ${ABEJA_PALETA.cuerpoGlow})` }} />
       {/* brillo suave de volumen (el lomo del abdomen) — NUNCA una banda */}
-      <ellipse cx="-2.6" cy="-2.2" rx="3.6" ry="1.7" fill={ABEJA_PALETA.cabeza} opacity="0.28" />
+      <ellipse cx="-3.2" cy="-1.9" rx="3.9" ry="1.5" fill={ABEJA_PALETA.cabeza} opacity="0.26" />
       {/* tergite APENAS insinuado (una línea suave que sigue la curva), el
           detalle de segmento del meliponino, jamás una banda de color */}
-      <path d="M-6.6,-2.4 Q-7.3,0 -6.6,2.6" stroke={ABEJA_PALETA.hiloChumbe}
+      <path d="M-7.2,-2.1 Q-7.9,0.2 -7.2,2.3" stroke={ABEJA_PALETA.hiloChumbe}
         strokeWidth="0.5" fill="none" strokeLinecap="round" opacity="0.45" />
       {/* TÓRAX oscuro y redondo (peludo): junto con la cabeza forma la mitad
           OSCURA del cuerpo — la estructura de valores INVERTIDA respecto a la

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -248,7 +248,7 @@ export function AbejaAngelita({
         fill={ABEJA_PALETA.cuerpo} stroke={RH_INK} strokeWidth="1.3"
         style={{ filter: `drop-shadow(0 0 6px ${ABEJA_PALETA.cuerpoGlow})` }} />
       {/* brillo suave de volumen (el lomo del abdomen) — NUNCA una banda */}
-      <ellipse cx="-2.6" cy="-2.2" rx="3.6" ry="1.7" fill={ABEJA_PALETA.acento} opacity="0.28" />
+      <ellipse cx="-2.6" cy="-2.2" rx="3.6" ry="1.7" fill={ABEJA_PALETA.cabeza} opacity="0.28" />
       {/* tergite APENAS insinuado (una línea suave que sigue la curva), el
           detalle de segmento del meliponino, jamás una banda de color */}
       <path d="M-6.6,-2.4 Q-7.3,0 -6.6,2.6" stroke={ABEJA_PALETA.hiloChumbe}
@@ -270,7 +270,7 @@ export function AbejaAngelita({
         d="M5.4,3.0 C6.9,4.2 7.5,5.9 7.0,7.5" ancho={2.2} punta={[7.0, 7.8]} puntaR={1.6} sway={vivo} delay={-0.45} />
 
       {/* cabeza OSCURA (casi negra) con contorno — la mitad oscura del meliponino */}
-      <circle cx="8.6" cy="-1.0" r={ABEJA_PROPORCION.cabezaR} fill={ABEJA_PALETA.cabeza} stroke={RH_INK} strokeWidth="1.2" />
+      <circle cx="8.6" cy="-1.0" r={ABEJA_PROPORCION.cabezaR} fill={ABEJA_PALETA.testa} stroke={RH_INK} strokeWidth="1.2" />
       {/* MÁSCARA FACIAL clara: la marca amarilla del clípeo de la angelita real —
           y, a la vez, el fondo sobre el que la carita (ojos/boca/cejas del agente)
           sigue leyéndose pese a la cabeza oscura. Va bajo ojos/cachetes/boca. */}

--- a/src/visual/creatures/abejaIdentidad.js
+++ b/src/visual/creatures/abejaIdentidad.js
@@ -30,14 +30,21 @@
    para que el lado 3D tiña la sombra de Angelita con su misma línea. */
 export { RH_INK as ABEJA_TINTA } from './_rubberhose.jsx';
 
-/* Paleta del cuerpo — Tetragonisca angustula elevada a rubber-hose andino. */
+/* Paleta del cuerpo — Tetragonisca angustula REAL elevada a rubber-hose andino.
+   La firma de la especie es la ESTRUCTURA DE VALORES: cabeza y tórax OSCUROS
+   (casi negros) + abdomen ámbar PÁLIDO y LISO. Es lo contrario de la Apis
+   europea (cabeza/tórax claros + abdomen con bandas oscuras) — la que saquea
+   las colmenas de angelita; por eso el color es fidelidad, no decoración. */
 export const ABEJA_PALETA = {
-  cuerpo: '#ffb54f',      // ámbar del tronco y del aura viva
-  cuerpoGlow: 'rgba(255,181,79,0.9)', // el mismo ámbar como resplandor (drop-shadow)
-  cabeza: '#ffd76a',      // cabeza clara
-  hiloChumbe: '#9c3b1e',  // hilo tierra dentro de la banda de tinta (chumbe)
-  alaTul: '#bfeaff',      // ala grande de tul
-  alaTulClara: '#eafff6', // ala chica, más pálida
+  cuerpo: '#f2c064',      // ámbar PÁLIDO del abdomen liso y del aura viva
+  cuerpoGlow: 'rgba(242,192,100,0.85)', // el mismo ámbar como resplandor (drop-shadow)
+  cabeza: '#33281a',      // cabeza OSCURA (casi negra) — meliponino, NO Apis
+  torax: '#3d2c19',       // tórax oscuro (un pelo más cálido que la cabeza)
+  acento: '#ffd76a',      // dorado claro SOLO para acentos de UI (certeza del agente)
+  cara: '#ffe3ad',        // máscara facial clara (clípeo amarillo real de la angelita)
+  hiloChumbe: '#c98a3e',  // tergite tenue del abdomen (línea suave, ya NO banda)
+  alaTul: '#cfeeff',      // ala grande de tul (hialina)
+  alaTulClara: '#eafff8', // ala chica, más pálida
   lengua: '#c9524e',      // probóscide (sed / libar)
   gota: '#bfe6ff',        // gotas de lluvia cuando está mojada
 };

--- a/src/visual/creatures/abejaIdentidad.js
+++ b/src/visual/creatures/abejaIdentidad.js
@@ -38,9 +38,9 @@ export { RH_INK as ABEJA_TINTA } from './_rubberhose.jsx';
 export const ABEJA_PALETA = {
   cuerpo: '#f2c064',      // ámbar PÁLIDO del abdomen liso y del aura viva
   cuerpoGlow: 'rgba(242,192,100,0.85)', // el mismo ámbar como resplandor (drop-shadow)
-  cabeza: '#33281a',      // cabeza OSCURA (casi negra) — meliponino, NO Apis
+  cabeza: '#ffd76a',      // dorado histórico: acento de UI del agente (certeza) — NO el color real
+  testa: '#33281a',       // cabeza OSCURA REAL del meliponino (dibujo 2D + billboard 3D), NO Apis
   torax: '#3d2c19',       // tórax oscuro (un pelo más cálido que la cabeza)
-  acento: '#ffd76a',      // dorado claro SOLO para acentos de UI (certeza del agente)
   cara: '#ffe3ad',        // máscara facial clara (clípeo amarillo real de la angelita)
   hiloChumbe: '#c98a3e',  // tergite tenue del abdomen (línea suave, ya NO banda)
   alaTul: '#cfeeff',      // ala grande de tul (hialina)

--- a/src/visual/mundo3d/polinizadores/polinizadores.geom.js
+++ b/src/visual/mundo3d/polinizadores/polinizadores.geom.js
@@ -143,17 +143,16 @@ export function geomAngelita({ q = 1 } = {}) {
   const abd = new THREE.SphereGeometry(0.29, seg(q, 8), seg(q, 6));
   abd.scale(1.5, 0.92, 0.92);
   piezas.push(pintar(poner(abd, [-0.3, 0, 0]), PAL.angelitaCuerpo));
-  /* Las bandas del CHUMBE: el hilo de tierra sobre el ámbar. Es el mismo tono
-     que teje su dibujo 2D — la angelita de los mundos y la del home llevan la
-     misma faja, no una parecida. */
+  /* Tergites APENAS insinuados sobre el ámbar (ya NO bandas de color): el mismo
+     criterio del dibujo 2D — abdomen LISO del meliponino, no la faja de la Apis. */
   for (let i = 0; i < 2; i++) {
-    const b = new THREE.CylinderGeometry(0.27 - i * 0.05, 0.27 - i * 0.05, 0.06, seg(q, 8), 1, true);
-    piezas.push(pintar(poner(b, [-0.2 - i * 0.19, 0, 0], [0, 0, Math.PI / 2]), PAL.angelitaChumbe, 0.95));
+    const b = new THREE.CylinderGeometry(0.27 - i * 0.05, 0.27 - i * 0.05, 0.03, seg(q, 8), 1, true);
+    piezas.push(pintar(poner(b, [-0.2 - i * 0.19, 0, 0], [0, 0, Math.PI / 2]), PAL.angelitaChumbe, 0.4));
   }
-  // Tórax
+  // Tórax OSCURO (meliponino real: cabeza y tórax oscuros, no ámbar)
   const tor = new THREE.SphereGeometry(0.24, seg(q, 8), seg(q, 6));
   tor.scale(1.1, 1, 1);
-  piezas.push(pintar(poner(tor, [0.06, 0.02, 0]), '#e0a341'));
+  piezas.push(pintar(poner(tor, [0.06, 0.02, 0]), PAL.angelitaTorax));
   // Cabeza clara
   const cab = new THREE.SphereGeometry(0.2, seg(q, 8), seg(q, 6));
   piezas.push(pintar(poner(cab, [0.34, 0.03, 0]), PAL.angelitaCabeza));

--- a/src/visual/mundo3d/polinizadores/polinizadoresIdentidad.js
+++ b/src/visual/mundo3d/polinizadores/polinizadoresIdentidad.js
@@ -86,8 +86,9 @@ export const PAL = {
   // Cuerpos (cada bicho se reconoce de un vistazo).
   // La angelita NO tiene colores propios acá: son los de su identidad aprobada.
   angelitaCuerpo: ABEJA_PALETA.cuerpo,
-  angelitaCabeza: ABEJA_PALETA.cabeza,
-  angelitaChumbe: ABEJA_PALETA.hiloChumbe, // el hilo de tierra de su banda
+  angelitaCabeza: ABEJA_PALETA.testa, // cabeza oscura real del meliponino
+  angelitaTorax: ABEJA_PALETA.torax, // torax oscuro del meliponino real
+  angelitaChumbe: ABEJA_PALETA.hiloChumbe, // tergite tenue del abdomen (ya NO banda)
   apisCuerpo: '#e5a13c',
   apisBanda: '#4a3524',
   abejorroPelo: '#2b2723', // negro peludo


### PR DESCRIPTION
## Qué corrige

Angelita, el personaje-agente, estaba dibujada como **Apis mellifera** (abeja europea de miel) con el nombre de la melipona nativa. La abeja angelita real es **_Tetragonisca angustula_**, la abeja **sin aguijón** que los campesinos crían. El error era una **estructura de valores invertida**:

- **Antes (Apis):** cabeza clara + tres barras verticales oscuras en el abdomen — la firma de la europea, la que saquea las colmenas de angelita.
- **Ahora (angelita real):** **cabeza y tórax oscuros** (casi negros) + **abdomen ámbar pálido, liso y sin bandas**, cuerpo esbelto, alas de tul que le sobran del cuerpo, remate redondo **sin aguijón**, y una **máscara facial clara** (el clípeo amarillo real) que además deja legible la carita del agente sobre la cabeza oscura.

## Qué se conserva (medido)

- La **vida permanente** y la expresividad: respira, parpadea, antenas que tiemblan, poses, lip-sync, clima. No se rehízo el sistema de animación; solo cambió especie / anatomía / color.
- El carácter de compañera-agente. El agente (`Angelita.jsx`) queda **intacto**: su acento dorado de "certeza" sigue en `ABEJA_PALETA.cabeza` (dorado histórico), y el color oscuro real de la cabeza se movió a `ABEJA_PALETA.testa`.

## Alcance

- `AbejaAngelita.jsx` + `abejaIdentidad.js`: el redibujo y la paleta de especie.
- Coherencia "una sola Angelita" en 3D (`polinizadores`): cabeza/tórax oscuros y abdomen liso también en el billboard.
- **No** se tocó `Valle3D` / `composicionValle3D` / `bosque`.

## Verificación

- Contrato de render **15/15** verde. La suite completa pasa salvo 2 fallos **preexistentes y ajenos** (`vidaEstados`, `Borugo`), idénticos a la rama base.
- Verificación visual: lámina a 320/128/96/64/40 px (a 64 px sigue leyéndose como abeja) + estados vivos. Un agrónomo debería reconocerla como angelita, no como europea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
