### PR TITLE
feat(valle): T1 — la ley del lenguaje visual (paleta, 3 bandas, borde) + hoja de prueba

### DIFF
--- a/LEY-VISUAL-VALLE.md
+++ b/LEY-VISUAL-VALLE.md
@@ -1,0 +1,130 @@
+# La ley del lenguaje visual del valle
+
+Corrección #1 de `AUDITORIA-VALLE.md` (hallazgo 1.1). El valle acumuló 321
+materiales únicos, 712 colores hex, 288 usos de `flatShading` contra 199 de
+sombreado suave y cuatro modelos de material en el mismo cuadro: "el ojo no
+interpreta variedad dentro de un lugar, sino activos de bibliotecas
+distintas". Esta ley reduce las decisiones y las aplica con disciplina.
+
+**Código fuente de la ley** (la verdad ejecutable; este documento solo la
+explica):
+
+- `src/visual/mundo3d/direccion/paletaValle.js` — paleta, borde, relaciones de luz.
+- `src/visual/mundo3d/direccion/materialValle.js` — la familia única de shader.
+- `src/visual/mundo3d/direccion/__tests__/paletaValle.test.js` — la ley fijada en CI.
+- `src/mockups/HojaPruebaValle.jsx` — el patrón oro (`#/mockups/hoja-prueba-valle`).
+
+## Las tres reglas
+
+### 1. La paleta: 4 madres, 16 muestras, cero hex suelto
+
+Todo color físico del valle sale de `MUESTRAS` de `paletaValle.js` (extraídas
+de la paleta madre aprobada, `src/visual/mundo3d/paleta/paletaMadre.js`).
+Cuatro familias: **verde** (vida vegetal), **tierra** (suelo, corteza, teja,
+madera), **cal** (encalado, piedra, carpintería), **agua** (el único azul).
+
+- Las variantes horneadas `*Sombra`, `*Claro`, `*Oscuro` **desaparecen**: la
+  banda de sombra de la rampa las produce. Un objeto = una muestra por parte.
+- Los estados horarios transforman las muestras **vía la luz**
+  (`CIELOS_HORA`), jamás con paletas paralelas por franja.
+- Acentos (`ACENTOS`: cochinilla, maíz, guayacán…): máximo **uno por objeto**
+  y nunca más del **5% del área visible**.
+- Emisivos con permiso (`EMISIVOS`): ventana, candela, luna, portal. Cualquier
+  otro brillo sin fuente diegética **se apaga en origen**.
+- ¿Un color que no mapea a ninguna muestra? Se mapea a la más cercana o la
+  pieza se rediseña. Agregar la muestra 17 exige decisión de dirección (el
+  test de CI truena).
+
+### 2. El sombreado: una familia, tres bandas
+
+Todo material físico opaco se crea con `crearMaterialValle(nombre)`:
+`MeshToonMaterial` con **una rampa compartida de tres bandas**
+(sombra 0.42 / media 0.74 / luz 1.0, cortes duros). La variación entre piezas
+es el **color de la muestra**, nunca el modelo de respuesta a la luz.
+
+- `MeshStandardMaterial`, `MeshLambertMaterial` y `MeshPhongMaterial` quedan
+  **prohibidos** en el valle. La familia no cambia por tier (la rampa cuesta
+  lo que un Lambert; el tier sigue mandando en dpr, sombras, fog y densidad).
+- `flatShading` queda **prohibido** (los 288 usos migran a suave): la banda es
+  el lenguaje, el relieve es geometría.
+- Mallas fusionadas con color por vértice → `crearMaterialValleVertexColors()`
+  (los colores de vértice también salen de las muestras).
+- El **agua** es el único material transparente (opacity 0.85, ya en la receta).
+- `MeshBasicMaterial` solo vía `crearMaterialEmisivo(nombre)` (lista blanca) y
+  para el cielo.
+- Sombra barata: solo `crearMaterialSombraContacto(preset.sombra)` (disco
+  radial). No cuenta contra la regla del agua.
+
+### 3. El borde: binario, sin grosores por autor
+
+- **Paisaje** (terreno, vegetación, arquitectura, roca, agua): **sin contorno**.
+- **Habitantes** (personas, animales) e **interactivos** (portales, señales
+  tocables): contorno **tinta** (`NEUTROS.tinta`, negro cálido, nunca `#000`)
+  de **~1.5 px de pantalla**.
+- Implementación 3D: casco invertido (`crearMaterialContorno()`, BackSide)
+  escalado con `grosorContornoMundo(distancia, fov, altoPx)`. Filos planos
+  (anillo de portal): `crearMaterialTinta()`.
+- Billboards SVG (campesinos, criaturas): el trazo del SVG se normaliza al
+  equivalente de 1.5 px de pantalla al tamaño de reposo — hoy el grosor
+  depende de cada archivo.
+
+## La luz de la ley (por franja)
+
+Colores, posición del sol, luna y niebla vienen del preset aprobado
+(`CIELOS_HORA`) — **intocables** (mar de nubes, crepúsculo corto, luna,
+cenital, ronda de perros). Lo que cambia: el relleno se **desacopla** de la
+clave con `intensidadesDeLey(preset, franja)` (`RELACION_LUZ`: día 0.55,
+amanecer 0.40, atardecer 0.38, noche 0.35 — nunca más el 90% fijo que aplanaba
+todas las horas; auditoría 4.1).
+
+## La hoja de prueba (el patrón oro)
+
+`#/mockups/hoja-prueba-valle` monta roca, árbol, casa, persona (1.70 u),
+perro (0.59 u), portal y agua bajo la ley, a escala 1 u = 1 m. Franjas:
+
+| Franja | URL |
+|---|---|
+| Amanecer | `/?ciclo=6.2#/mockups/hoja-prueba-valle` |
+| Mediodía | `/?ciclo=12#/mockups/hoja-prueba-valle` |
+| Tarde | `/?ciclo=16#/mockups/hoja-prueba-valle` |
+| Crepúsculo | `/?ciclo=18.1#/mockups/hoja-prueba-valle` |
+| Noche | `/?ciclo=22#/mockups/hoja-prueba-valle` |
+
+**Regla de entrada**: todo activo nuevo o migrado se captura junto a la hoja
+en las cinco franjas. Si rompe las bandas (aparece gradiente liso o faceta),
+el borde (contorno en paisaje, o habitante sin tinta) o mete un hex fuera de
+las muestras, **no entra**.
+
+## Guía de migración (el refactor de los 58 archivos)
+
+1. Por archivo: cada `new Mesh*Material` / `<mesh*Material>` →
+   `crearMaterialValle('<muestra>')`. El nombre se elige por semántica (¿qué
+   ES la pieza?), no por cercanía de hex.
+2. Cada hex local se mapea a su muestra (tabla en `MUESTRAS`, con `uso`).
+   Duplicados `*Sombra`/`*Claro` colapsan a la muestra base.
+3. `flatShading: true` se borra. Si la pieza pierde lectura, el problema es de
+   silueta: se arregla con geometría, no con facetas.
+4. `MeshBasicMaterial` físico → muestra opaca; halo sin fuente → se elimina.
+5. Habitante/interactivo → casco de tinta; paisaje → nada.
+6. Captura de la escena migrada junto a la hoja de prueba, 5 franjas, antes
+   del merge (política del brazo visual: la prueba del arte es la captura).
+
+**Criterios de aceptación medibles** (re-correr
+`scripts/diag/auditar-valle-runtime.mjs`):
+
+- Tipos de material en el grafo: `MeshToonMaterial` + `MeshBasicMaterial`
+  (emisivos/cielo/sombra/tinta). Cero Standard/Lambert/Phong.
+- Usos con `flatShading`: **0**.
+- Colores de material visibles ⊆ muestras ∪ emisivos ∪ acentos ∪ preset de
+  cielo (≤ 30 en total; base: 84 visibles, 712 en fuentes).
+- Contornos: solo en habitantes e interactivos, todos con la misma tinta.
+
+## Qué NO toca esta ley
+
+- `Valle3D.jsx` y `composicionValle3D.jsx` (escala y composición: T2).
+- `bosque/` (páramo: T4).
+- Los cinco intocables de la auditoría (mar de nubes, crepúsculo, ronda de
+  Dante y Oliver, luna, cenital de mediodía).
+- La paleta madre (`paleta/paletaMadre.js`): esta ley la restringe para el
+  valle, no la reemplaza. Los demás mundos siguen su propia guía hasta que
+  adopten la suya.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -147,6 +147,11 @@ const EvidenciaIlustrada = lazy(() => import('./mockups/EvidenciaIlustrada'));
 const MockupGuardianesNarrativos = lazy(() => import('./mockups/MockupGuardianesNarrativos'));
 const HojaVidaMataMockup = lazy(() => import('./components/mockups/HojaVidaMataMockup'));
 const VitrinaCriaturasMockup = lazy(() => import('./mockups/vitrina3d/VitrinaCriaturas'));
+// La HOJA DE PRUEBA de la ley visual del valle (AUDITORIA-VALLE.md 1.1):
+// roca, árbol, casa, persona, perro y portal bajo las cinco franjas con la
+// paleta de 16 muestras, la rampa de 3 bandas y el borde tinta. Patrón oro:
+// ningún activo entra al valle si desentona aquí. #/mockups/hoja-prueba-valle.
+const HojaPruebaValleMockup = lazy(() => import('./mockups/HojaPruebaValle'));
 // 3D: el MUNDO BOSQUE VIVO y su guardián, el Ent de la queñua (colorado,
 // Polylepis) — mallas three reales (tronco retorcido con rostro tallado, copa
 // instanciada), device-tiering real. Ruta #/mockups/bosque-vivo-3d, sin auth.
@@ -730,6 +735,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo-botica-cana-3d': 'mockup_mundo_botica_cana_3d',
   'mockups/mundo-frutales-3d': 'mockup_mundo_frutales_3d',
   'mockups/mundo-leguminosas-3d': 'mockup_mundo_leguminosas_3d',
+  'mockups/hoja-prueba-valle': 'mockup_hoja_prueba_valle',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -2485,6 +2491,17 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El lote de leguminosas y raíces">
               <MundoLeguminosas3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_hoja_prueba_valle':
+        // La hoja de prueba de la ley visual del valle: el patrón oro contra el
+        // que se compara todo activo nuevo (paleta, bandas, borde) bajo las
+        // cinco franjas (?ciclo=). Ruta #/mockups/hoja-prueba-valle, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="La hoja de prueba del valle">
+              <HojaPruebaValleMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/HojaPruebaValle.jsx
+++ b/src/mockups/HojaPruebaValle.jsx
@@ -1,0 +1,432 @@
+/*
+ * HojaPruebaValle — EL PATRÓN ORO de la ley visual del valle.
+ *
+ * La hoja de prueba que pide AUDITORIA-VALLE.md (corrección 1.1): una roca,
+ * un árbol, una casa, una persona, un animal y un portal — más el agua —
+ * bajo las cinco franjas del día, construidos SOLO con la ley:
+ *
+ *   · 16 muestras aprobadas (direccion/paletaValle.js), cero hex suelto.
+ *   · UNA familia de shader: rampa de tres bandas (materialValle.js),
+ *     flatShading prohibido, agua única transparencia, Basic solo emisivos.
+ *   · Borde binario: paisaje sin contorno; persona, perro y portal con
+ *     casco de tinta de ~1.5 px de pantalla.
+ *   · Luz de la ley: colores y sol del preset aprobado (CIELOS_HORA), con
+ *     el relleno DESACOPLADO de la clave (auditoría 4.1) para que las tres
+ *     bandas existan en todas las horas.
+ *   · Escala 1 u = 1 m: persona 1,70, puerta 2,05, cumbrera 3,4, perro 0,59
+ *     (el ancla de Oliver).
+ *
+ * Es una vara de medir, no un mundo: ningún activo entra al valle si al
+ * ponerlo junto a esta hoja rompe las bandas o el borde. Franja por URL:
+ *   #/mockups/hoja-prueba-valle?ciclo=6.2   → amanecer
+ *   ?ciclo=12 → mediodía · ?ciclo=16 → tarde · ?ciclo=18.1 → crepúsculo
+ *   ?ciclo=22 → noche   (sin parámetro: la hora real del dispositivo)
+ *
+ * NO toca Valle3D ni composicionValle3D (T2 vive allá): escena autónoma.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { Canvas, useThree } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
+import useCicloDia from '../visual/mundo3d/useCicloDia.js';
+import { presetDeHora } from '../visual/mundo3d/cielosHoraData.js';
+import {
+  COLORES_MADRE,
+  MUESTRAS,
+  ACENTOS,
+  grosorContornoMundo,
+} from '../visual/mundo3d/direccion/paletaValle.js';
+import {
+  crearMaterialValle,
+  crearMaterialEmisivo,
+  crearMaterialContorno,
+  crearMaterialTinta,
+  crearMaterialSombraContacto,
+  intensidadesDeLey,
+} from '../visual/mundo3d/direccion/materialValle.js';
+
+/* Las cinco franjas oficiales de la auditoría, como accesos directos. */
+const FRANJAS_HOJA = [
+  { id: 'amanecer', rotulo: 'Amanecer', hora: 6.2 },
+  { id: 'mediodia', rotulo: 'Mediodía', hora: 12 },
+  { id: 'tarde', rotulo: 'Tarde', hora: 16 },
+  { id: 'atardecer', rotulo: 'Crepúsculo', hora: 18.1 },
+  { id: 'noche', rotulo: 'Noche', hora: 22 },
+];
+
+const FOV = 40;
+const CAMARA = [0, 2.6, 9.8];
+
+/* Geometrías por clave — cada pieza se declara una vez y el casco de
+   contorno reutiliza la MISMA declaración (tinta, BackSide, escala). */
+function Geo({ tipo, args }) {
+  switch (tipo) {
+    case 'caja':
+      return <boxGeometry args={args} />;
+    case 'cil':
+      return <cylinderGeometry args={args} />;
+    case 'esf':
+      return <sphereGeometry args={args} />;
+    case 'ico':
+      return <icosahedronGeometry args={args} />;
+    case 'dod':
+      return <dodecahedronGeometry args={args} />;
+    case 'cono':
+      return <coneGeometry args={args} />;
+    case 'toro':
+      return <torusGeometry args={args} />;
+    case 'circ':
+      return <circleGeometry args={args} />;
+    case 'plano':
+      return <planeGeometry args={args} />;
+    default:
+      return null;
+  }
+}
+
+/*
+ * Una pieza de la hoja: malla + (si es habitante/interactivo) su casco
+ * invertido de tinta. `radio` es el radio aproximado de la pieza: el casco
+ * escala (radio + grosor) / radio para que el filo mida ~1.5 px en pantalla.
+ */
+function Pieza({ tipo, args, pos, rot, mat, casco, matCasco, g, radio = 0.2 }) {
+  const factor = casco ? (radio + g) / radio : 1;
+  return (
+    <group position={pos} rotation={rot}>
+      <mesh material={mat}>
+        <Geo tipo={tipo} args={args} />
+      </mesh>
+      {casco ? (
+        <mesh material={matCasco} scale={factor} renderOrder={-1}>
+          <Geo tipo={tipo} args={args} />
+        </mesh>
+      ) : null}
+    </group>
+  );
+}
+
+/* Sombra de contacto: el ÚNICO dispositivo de sombra de la hoja (disco
+   radial con el tinte de sombra de la franja — auditoría 4.1). */
+function SombraContacto({ pos, radio, mat }) {
+  return (
+    <mesh material={mat} position={[pos[0], 0.011, pos[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+      <circleGeometry args={[radio, 20]} />
+    </mesh>
+  );
+}
+
+/* Un árbol de la ley: tronco corteza suave + tres masas de copa. */
+function Arbol({ pos, escala = 1, matTronco, matCopa }) {
+  return (
+    <group position={pos} scale={escala}>
+      <Pieza tipo="cil" args={[0.16, 0.24, 2.3, 9]} pos={[0, 1.15, 0]} mat={matTronco} />
+      <Pieza tipo="ico" args={[1.15, 0]} pos={[0, 3.05, 0]} mat={matCopa} />
+      <Pieza tipo="ico" args={[0.85, 0]} pos={[0.75, 2.55, 0.25]} mat={matCopa} />
+      <Pieza tipo="ico" args={[0.7, 0]} pos={[-0.7, 2.5, -0.2]} mat={matCopa} />
+    </group>
+  );
+}
+
+function EscenaHoja({ preset, franja, mats }) {
+  const altoPx = useThree((s) => s.size.height);
+  /* el grosor de tinta, calibrado a la distancia del plano de autor */
+  const g = grosorContornoMundo(9, FOV, altoPx);
+  const luces = useMemo(() => intensidadesDeLey(preset, franja), [preset, franja]);
+  const contraPos = useMemo(
+    () => [-preset.solPos[0], preset.solPos[1] * 0.5 + 2, -preset.solPos[2]],
+    [preset],
+  );
+  const casco = { casco: true, matCasco: mats.contorno, g };
+
+  return (
+    <>
+      <color attach="background" args={[preset.fondo]} />
+      <fog attach="fog" args={[preset.niebla, preset.nieblaCerca, preset.nieblaLejos]} />
+
+      {/* LA LUZ DE LA LEY: preset aprobado + relleno desacoplado de la clave */}
+      <hemisphereLight args={[preset.cielo, preset.suelo, luces.hemisferio]} />
+      <ambientLight color={preset.niebla} intensity={luces.ambiente} />
+      <directionalLight position={preset.solPos} color={preset.luz} intensity={luces.clave} />
+      <directionalLight position={contraPos} color={preset.relleno} intensity={luces.contra} />
+
+      {/* ── PAISAJE (sin contorno) ─────────────────────────────────── */}
+      {/* el suelo: pasto con un sendero y una era labrada */}
+      <Pieza tipo="circ" args={[60, 40]} pos={[0, 0, 0]} rot={[-Math.PI / 2, 0, 0]} mat={mats.pasto} />
+      <Pieza
+        tipo="plano"
+        args={[1.7, 14]}
+        pos={[0.6, 0.01, 3]}
+        rot={[-Math.PI / 2, 0, 0.06]}
+        mat={mats.camino}
+      />
+      <Pieza
+        tipo="plano"
+        args={[2.6, 1.9]}
+        pos={[-4.7, 0.01, 2.8]}
+        rot={[-Math.PI / 2, 0, -0.15]}
+        mat={mats.tierraLabrada}
+      />
+
+      {/* la roca (paisaje: la luz la modela en tres bandas, sin borde) */}
+      <Pieza tipo="dod" args={[0.85, 0]} pos={[-5.4, 0.55, 0.4]} rot={[0.3, 0.5, 0.1]} mat={mats.roca} />
+      <Pieza tipo="dod" args={[0.38, 0]} pos={[-4.5, 0.26, 1.1]} rot={[0.8, 0.2, 0.4]} mat={mats.piedra} />
+
+      {/* el árbol cercano y la fila del fondo (follajeLejos: la muestra fría) */}
+      <Arbol pos={[-3.1, 0, -1]} matTronco={mats.corteza} matCopa={mats.follajeCerca} />
+      <Arbol pos={[-7.5, 0, -15]} escala={0.9} matTronco={mats.corteza} matCopa={mats.follajeLejos} />
+      <Arbol pos={[-5.2, 0, -17]} escala={1.1} matTronco={mats.corteza} matCopa={mats.follajeLejos} />
+      <Arbol pos={[6.4, 0, -16]} escala={0.95} matTronco={mats.corteza} matCopa={mats.follajeLejos} />
+
+      {/* las colinas del fondo: solo silueta y muestra fría */}
+      <Pieza tipo="cono" args={[8, 10, 7]} pos={[-14, 4.6, -30]} mat={mats.follajeLejos} />
+      <Pieza tipo="cono" args={[10, 13, 7]} pos={[-3, 6, -34]} mat={mats.follajeLejos} />
+      <Pieza tipo="cono" args={[7, 9, 7]} pos={[8, 4.1, -30]} mat={mats.follajeLejos} />
+      <Pieza tipo="cono" args={[11, 14, 7]} pos={[18, 6.5, -36]} mat={mats.follajeLejos} />
+
+      {/* LA CASA CANÓNICA a escala de ley: zócalo, encalado, teja, carpintería.
+          Puerta 2,05 · alero 2,5 · cumbrera 3,4. SIN tejaSombra: la banda la hace. */}
+      <group position={[1.4, 0, -1.8]} rotation={[0, -0.22, 0]}>
+        <Pieza tipo="caja" args={[3.7, 0.5, 3.1]} pos={[0, 0.25, 0]} mat={mats.zocalo} />
+        <Pieza tipo="caja" args={[3.6, 2.0, 3.0]} pos={[0, 1.5, 0]} mat={mats.encalado} />
+        {/* el hastial: prisma triangular encalado hasta la cumbrera */}
+        <Pieza
+          tipo="cil"
+          args={[1.04, 1.04, 2.9, 3, 1]}
+          pos={[0, 2.62, 0]}
+          rot={[-Math.PI / 2, 0, 0]}
+          mat={mats.encalado}
+        />
+        {/* los dos faldones de teja, con alero */}
+        <Pieza tipo="caja" args={[2.35, 0.09, 3.5]} pos={[-0.95, 3.0, 0]} rot={[0, 0, 0.72]} mat={mats.teja} />
+        <Pieza tipo="caja" args={[2.35, 0.09, 3.5]} pos={[0.95, 3.0, 0]} rot={[0, 0, -0.72]} mat={mats.teja} />
+        <Pieza tipo="caja" args={[0.18, 0.12, 3.55]} pos={[0, 3.42, 0]} mat={mats.madera} />
+        {/* puerta a 2,05 y ventana que espera */}
+        <Pieza tipo="caja" args={[0.95, 2.05, 0.08]} pos={[-0.7, 1.02, 1.53]} mat={mats.carpinteria} />
+        <Pieza tipo="caja" args={[0.75, 0.75, 0.08]} pos={[0.95, 1.55, 1.53]} mat={mats.ventana} />
+      </group>
+
+      {/* el agua: la única transparencia de la ley */}
+      <Pieza tipo="circ" args={[1.35, 26]} pos={[5.7, 0.02, 1.4]} rot={[-Math.PI / 2, 0, 0]} mat={mats.agua} />
+
+      {/* ── HABITANTES (contorno tinta ~1.5 px) ────────────────────── */}
+      {/* la persona: 1,70 m — ruana, sombrero y una sola cucharada de acento */}
+      <group position={[-1.5, 0, 0.9]} rotation={[0, 0.25, 0]}>
+        <Pieza tipo="cil" args={[0.14, 0.17, 0.8, 10]} pos={[0, 0.4, 0]} mat={mats.tierraLabrada} radio={0.4} {...casco} />
+        <Pieza tipo="cil" args={[0.37, 0.21, 0.64, 12]} pos={[0, 1.08, 0]} mat={mats.carpinteria} radio={0.37} {...casco} />
+        <Pieza tipo="toro" args={[0.31, 0.032, 8, 18]} pos={[0, 0.92, 0]} rot={[Math.PI / 2, 0, 0]} mat={mats.acento} radio={0.34} />
+        <Pieza tipo="esf" args={[0.17, 12, 10]} pos={[0, 1.5, 0]} mat={mats.piel} radio={0.17} {...casco} />
+        <Pieza tipo="cil" args={[0.31, 0.31, 0.035, 14]} pos={[0, 1.62, 0]} mat={mats.encalado} radio={0.31} {...casco} />
+        <Pieza tipo="cil" args={[0.15, 0.17, 0.15, 12]} pos={[0, 1.7, 0]} mat={mats.encalado} radio={0.17} {...casco} />
+      </group>
+
+      {/* el perro: 0,59 m — el ancla de Oliver, intocable */}
+      <group position={[-0.2, 0, 1.7]} rotation={[0, -0.5, 0]}>
+        <Pieza tipo="cil" args={[0.125, 0.125, 0.34, 10]} pos={[0, 0.33, 0]} rot={[0, 0, Math.PI / 2]} mat={mats.camino} radio={0.2} {...casco} />
+        <Pieza tipo="esf" args={[0.125, 10, 8]} pos={[0.19, 0.33, 0]} mat={mats.camino} radio={0.125} {...casco} />
+        <Pieza tipo="esf" args={[0.125, 10, 8]} pos={[-0.19, 0.33, 0]} mat={mats.camino} radio={0.125} {...casco} />
+        <Pieza tipo="esf" args={[0.115, 10, 8]} pos={[0.3, 0.47, 0]} mat={mats.camino} radio={0.115} {...casco} />
+        <Pieza tipo="cono" args={[0.04, 0.1, 6]} pos={[0.27, 0.585, 0.05]} rot={[0.15, 0, 0]} mat={mats.corteza} radio={0.05} {...casco} />
+        <Pieza tipo="cono" args={[0.04, 0.1, 6]} pos={[0.27, 0.585, -0.05]} rot={[-0.15, 0, 0]} mat={mats.corteza} radio={0.05} {...casco} />
+        <Pieza tipo="cil" args={[0.035, 0.045, 0.22, 8]} pos={[0.13, 0.11, 0.07]} mat={mats.camino} radio={0.1} {...casco} />
+        <Pieza tipo="cil" args={[0.035, 0.045, 0.22, 8]} pos={[0.13, 0.11, -0.07]} mat={mats.camino} radio={0.1} {...casco} />
+        <Pieza tipo="cil" args={[0.035, 0.045, 0.22, 8]} pos={[-0.13, 0.11, 0.07]} mat={mats.camino} radio={0.1} {...casco} />
+        <Pieza tipo="cil" args={[0.035, 0.045, 0.22, 8]} pos={[-0.13, 0.11, -0.07]} mat={mats.camino} radio={0.1} {...casco} />
+        <Pieza tipo="cil" args={[0.02, 0.035, 0.24, 8]} pos={[-0.33, 0.45, 0]} rot={[0, 0, 0.9]} mat={mats.camino} radio={0.09} {...casco} />
+      </group>
+
+      {/* ── INTERACTIVO (contorno tinta): el portal ventana-viva ───── */}
+      <group position={[4.2, 0, -1]} rotation={[0, -0.35, 0]}>
+        <Pieza tipo="cil" args={[0.09, 0.11, 2.1, 9]} pos={[-0.95, 1.05, 0]} mat={mats.madera} radio={0.11} {...casco} />
+        <Pieza tipo="cil" args={[0.09, 0.11, 2.1, 9]} pos={[0.95, 1.05, 0]} mat={mats.madera} radio={0.11} {...casco} />
+        <Pieza tipo="ico" args={[0.4, 0]} pos={[-0.9, 2.2, 0]} mat={mats.follajeCerca} radio={0.4} {...casco} />
+        <Pieza tipo="ico" args={[0.45, 0]} pos={[-0.45, 2.55, 0]} mat={mats.follajeCerca} radio={0.45} {...casco} />
+        <Pieza tipo="ico" args={[0.48, 0]} pos={[0.1, 2.68, 0]} mat={mats.follajeCerca} radio={0.48} {...casco} />
+        <Pieza tipo="ico" args={[0.45, 0]} pos={[0.6, 2.5, 0]} mat={mats.follajeCerca} radio={0.45} {...casco} />
+        <Pieza tipo="ico" args={[0.38, 0]} pos={[0.95, 2.15, 0]} mat={mats.follajeCerca} radio={0.38} {...casco} />
+        {/* el corazón emisivo con su anillo de tinta (el filo del interactivo) */}
+        <Pieza tipo="circ" args={[0.72, 26]} pos={[0, 1.45, 0]} mat={mats.portal} />
+        <mesh material={mats.tintaFrente} position={[0, 1.45, 0]}>
+          <torusGeometry args={[0.73, Math.max(g, 0.008), 8, 40]} />
+        </mesh>
+      </group>
+
+      {/* la luna emisiva, solo cuando la franja la motiva */}
+      {franja === 'noche' ? (
+        <Pieza tipo="esf" args={[1.5, 16, 12]} pos={[-22, 20, -30]} mat={mats.luna} />
+      ) : null}
+
+      {/* sombras de contacto: un solo lenguaje para toda la hoja */}
+      <SombraContacto pos={[-5.4, 0, 0.4]} radio={0.95} mat={mats.sombra} />
+      <SombraContacto pos={[-3.1, 0, -1]} radio={1.15} mat={mats.sombra} />
+      <SombraContacto pos={[-1.5, 0, 0.9]} radio={0.42} mat={mats.sombra} />
+      <SombraContacto pos={[-0.2, 0, 1.7]} radio={0.4} mat={mats.sombra} />
+      <SombraContacto pos={[1.4, 0, -1.8]} radio={2.5} mat={mats.sombra} />
+      <SombraContacto pos={[4.2, 0, -1]} radio={1.15} mat={mats.sombra} />
+
+      <OrbitControls
+        makeDefault
+        enablePan={false}
+        enableZoom
+        minDistance={5}
+        maxDistance={16}
+        target={[0.2, 1.3, 0]}
+        minPolarAngle={0.5}
+        maxPolarAngle={1.62}
+        minAzimuthAngle={-0.9}
+        maxAzimuthAngle={0.9}
+        enableDamping
+        dampingFactor={0.08}
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/** El mockup standalone: #/mockups/hoja-prueba-valle (franja con ?ciclo=). */
+export default function HojaPruebaValle() {
+  const [listo, setListo] = useState(false);
+  const { tier, reducedMotion } = useMemo(() => decidirTier(), []);
+  const perfil = perfilDeTier(tier);
+  const { franja, hora } = useCicloDia({ reducedMotion });
+  const preset = presetDeHora(franja);
+
+  /* Los materiales de la ley: una sola creación, liberación al desmontar.
+     Todo lo físico sale de crearMaterialValle; el acento es la única
+     cucharada (cochinilla) y la tinta solo existe como borde. */
+  const mats = useMemo(() => {
+    const m = {};
+    for (const nombre of Object.keys(MUESTRAS)) m[nombre] = crearMaterialValle(nombre);
+    m.acento = crearMaterialValle('zocalo', { color: ACENTOS.cochinilla });
+    m.ventana = crearMaterialEmisivo('ventana');
+    m.portal = crearMaterialEmisivo('portal');
+    m.luna = crearMaterialEmisivo('luna');
+    m.contorno = crearMaterialContorno();
+    m.tintaFrente = crearMaterialTinta();
+    return m;
+  }, []);
+  /* la sombra de contacto sigue el tinte de sombra de la franja */
+  const matsHora = useMemo(
+    () => ({ ...mats, sombra: crearMaterialSombraContacto(preset.sombra) }),
+    [mats, preset],
+  );
+  useEffect(() => {
+    return () => {
+      Object.values(mats).forEach((x) => x.dispose());
+    };
+  }, [mats]);
+  useEffect(() => {
+    const { sombra } = matsHora;
+    return () => sombra.dispose();
+  }, [matsHora]);
+
+  const irAFranja = (h) => {
+    const base = window.location.hash.split('?')[0] || '#/mockups/hoja-prueba-valle';
+    window.location.hash = `${base}?ciclo=${h}`;
+    window.location.reload();
+  };
+
+  return (
+    <section
+      style={{ position: 'fixed', inset: 0, background: preset.fondo }}
+      data-tier={tier}
+      data-franja={franja}
+      aria-label="Hoja de prueba de la ley visual del valle"
+    >
+      <style>{CSS_HOJA}</style>
+      <Canvas
+        className={`hpv-canvas${listo ? ' hpv-canvas--lista' : ''}`}
+        dpr={perfil.dpr}
+        gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+        camera={{ position: CAMARA, fov: FOV }}
+        frameloop="demand"
+        onCreated={({ gl }) => {
+          gl.setClearColor(preset.fondo);
+          setListo(true);
+        }}
+      >
+        <EscenaHoja preset={preset} franja={franja} mats={matsHora} />
+      </Canvas>
+
+      <div className="hpv-chrome">
+        <h2 className="hpv-titulo">
+          La hoja de prueba del valle
+          <small>
+            Roca, árbol, persona, perro, casa, portal y agua bajo una sola ley: 16 muestras,
+            tres bandas de luz y borde de tinta solo para habitantes e interactivos. Si un
+            activo nuevo desentona aquí, no entra al valle.
+          </small>
+        </h2>
+        <nav className="hpv-franjas" aria-label="Franja del día">
+          {FRANJAS_HOJA.map((f) => (
+            <button
+              key={f.id}
+              type="button"
+              className={`hpv-franja${franja === f.id ? ' hpv-franja--activa' : ''}`}
+              onClick={() => irAFranja(f.hora)}
+            >
+              {f.rotulo}
+            </button>
+          ))}
+          <span className="hpv-hora">{hora.toFixed(1)} h</span>
+        </nav>
+      </div>
+
+      <footer className="hpv-paleta" aria-label="Las dieciséis muestras aprobadas">
+        {Object.entries(COLORES_MADRE).map(([nombre, hex]) => (
+          <span key={nombre} className="hpv-chip hpv-chip--madre" style={{ background: hex }}>
+            {nombre}
+          </span>
+        ))}
+        <span className="hpv-sep" aria-hidden="true" />
+        {Object.entries(MUESTRAS).map(([nombre, m]) => (
+          <span key={nombre} className="hpv-chip" style={{ background: m.hex }} title={m.uso}>
+            {nombre}
+          </span>
+        ))}
+      </footer>
+    </section>
+  );
+}
+
+const CSS_HOJA = `
+.hpv-canvas { opacity: 0; transition: opacity 0.6s ease; }
+.hpv-canvas--lista { opacity: 1; }
+.hpv-chrome {
+  position: absolute; left: 0; right: 0; top: 0;
+  padding: max(14px, env(safe-area-inset-top)) 18px 0;
+  pointer-events: none;
+}
+.hpv-titulo {
+  margin: 0; font-size: 1.12rem; font-weight: 800; color: #241a10;
+  text-shadow: 0 1px 0 rgba(255,248,236,0.5);
+}
+.hpv-titulo small {
+  display: block; margin-top: 4px; max-width: 38rem;
+  font-size: 0.78rem; font-weight: 500; line-height: 1.45; color: #3a2a18;
+}
+.hpv-franjas {
+  display: flex; gap: 6px; align-items: center; margin-top: 10px;
+  pointer-events: auto; flex-wrap: wrap;
+}
+.hpv-franja {
+  border: 1px solid rgba(36,26,16,0.35); border-radius: 999px;
+  background: rgba(255,248,236,0.72); color: #241a10;
+  font-size: 0.74rem; font-weight: 700; padding: 4px 11px; cursor: pointer;
+}
+.hpv-franja--activa { background: #241a10; color: #fff8ec; }
+.hpv-hora { font-size: 0.72rem; font-weight: 600; color: #3a2a18; opacity: 0.75; }
+.hpv-paleta {
+  position: absolute; left: 0; right: 0; bottom: 0;
+  display: flex; gap: 5px; align-items: center;
+  padding: 8px 12px max(10px, env(safe-area-inset-bottom));
+  overflow-x: auto; background: linear-gradient(transparent, rgba(36,26,16,0.28));
+}
+.hpv-chip {
+  flex: 0 0 auto; border-radius: 7px; padding: 10px 8px 3px;
+  min-width: 52px; font-size: 0.58rem; font-weight: 700; text-align: center;
+  color: #fff8ec; text-shadow: 0 1px 2px rgba(36,26,16,0.85);
+  border: 1px solid rgba(36,26,16,0.4);
+}
+.hpv-chip--madre { min-width: 62px; padding-top: 16px; border-width: 2px; }
+.hpv-sep { flex: 0 0 1px; align-self: stretch; background: rgba(255,248,236,0.5); margin: 0 4px; }
+`;

--- a/src/visual/mundo3d/direccion/__tests__/paletaValle.test.js
+++ b/src/visual/mundo3d/direccion/__tests__/paletaValle.test.js
@@ -1,0 +1,97 @@
+/*
+ * La ley visual del valle, fijada en CI: si alguien agrega la muestra
+ * número 17, inventa un hex fuera de la paleta madre, rompe las tres
+ * bandas o cambia el borde sin decisión de dirección, este test truena.
+ * Ref: AUDITORIA-VALLE.md hallazgo 1.1 + LEY-VISUAL-VALLE.md.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  COLORES_MADRE,
+  MUESTRAS,
+  MUESTRAS_MIN,
+  MUESTRAS_MAX,
+  EMISIVOS,
+  RAMPA_BANDAS,
+  FLAT_SHADING_PROHIBIDO,
+  REGLA_BORDE,
+  RELACION_LUZ,
+  REPARTO_RELLENO,
+  grosorContornoMundo,
+} from '../paletaValle.js';
+
+const HEX = /^#[0-9a-f]{6}$/;
+
+describe('paletaValle — la ley del lenguaje visual', () => {
+  it('tiene exactamente cuatro colores madre, hex válidos', () => {
+    const nombres = Object.keys(COLORES_MADRE);
+    expect(nombres).toHaveLength(4);
+    expect(nombres.sort()).toEqual(['agua', 'cal', 'tierra', 'verde']);
+    for (const hex of Object.values(COLORES_MADRE)) expect(hex).toMatch(HEX);
+  });
+
+  it('tiene entre 12 y 16 muestras, cada una con madre válida, hex y uso', () => {
+    const entradas = Object.entries(MUESTRAS);
+    expect(entradas.length).toBeGreaterThanOrEqual(MUESTRAS_MIN);
+    expect(entradas.length).toBeLessThanOrEqual(MUESTRAS_MAX);
+    for (const [nombre, m] of entradas) {
+      expect(m.hex, nombre).toMatch(HEX);
+      expect(Object.keys(COLORES_MADRE), nombre).toContain(m.madre);
+      expect(m.uso, nombre).toBeTruthy();
+    }
+  });
+
+  it('no repite hex entre muestras (cada muestra es una decisión)', () => {
+    const hexes = Object.values(MUESTRAS).map((m) => m.hex);
+    expect(new Set(hexes).size).toBe(hexes.length);
+  });
+
+  it('la rampa es de TRES bandas ascendentes, sombra con color (no negra)', () => {
+    expect(RAMPA_BANDAS).toHaveLength(3);
+    expect(RAMPA_BANDAS[0]).toBeGreaterThan(0.25); // la sombra conserva color
+    expect(RAMPA_BANDAS[0]).toBeLessThan(RAMPA_BANDAS[1]);
+    expect(RAMPA_BANDAS[1]).toBeLessThan(RAMPA_BANDAS[2]);
+    expect(RAMPA_BANDAS[2]).toBe(1);
+    expect(FLAT_SHADING_PROHIBIDO).toBe(true);
+  });
+
+  it('la regla de borde es binaria: paisaje sin contorno, habitante e interactivo tinta 1.5px', () => {
+    expect(REGLA_BORDE.paisaje).toBeNull();
+    for (const clase of ['habitante', 'interactivo']) {
+      expect(REGLA_BORDE[clase].grosorPx).toBe(1.5);
+      expect(REGLA_BORDE[clase].color).toMatch(HEX);
+      expect(REGLA_BORDE[clase].color).not.toBe('#000000'); // tinta cálida, no negro puro
+    }
+  });
+
+  it('los emisivos con permiso son pocos y nombrados', () => {
+    const nombres = Object.keys(EMISIVOS);
+    expect(nombres.length).toBeLessThanOrEqual(6);
+    for (const hex of Object.values(EMISIVOS)) expect(hex).toMatch(HEX);
+  });
+
+  it('la relación relleno/clave cumple los objetivos de la auditoría 4.1', () => {
+    // día 0.45-0.60, amanecer/atardecer 0.30-0.45, noche 0.30-0.40 — nunca 0.90
+    for (const f of ['manana', 'mediodia', 'tarde']) {
+      expect(RELACION_LUZ[f]).toBeGreaterThanOrEqual(0.45);
+      expect(RELACION_LUZ[f]).toBeLessThanOrEqual(0.6);
+    }
+    for (const f of ['amanecer', 'atardecer']) {
+      expect(RELACION_LUZ[f]).toBeGreaterThanOrEqual(0.3);
+      expect(RELACION_LUZ[f]).toBeLessThanOrEqual(0.45);
+    }
+    expect(RELACION_LUZ.noche).toBeGreaterThanOrEqual(0.3);
+    expect(RELACION_LUZ.noche).toBeLessThanOrEqual(0.4);
+    const reparto =
+      REPARTO_RELLENO.hemisferio + REPARTO_RELLENO.ambiente + REPARTO_RELLENO.contra;
+    expect(reparto).toBeCloseTo(1, 5);
+  });
+
+  it('grosorContornoMundo da ~1.5px a la distancia del plano de autor', () => {
+    // cámara fov 40, viewport 1248px de alto, objeto a 8 unidades
+    const g = grosorContornoMundo(8, 40, 1248);
+    const mundoPorPx = (2 * 8 * Math.tan((40 * Math.PI) / 360)) / 1248;
+    expect(g).toBeCloseTo(1.5 * mundoPorPx, 10);
+    expect(g).toBeGreaterThan(0);
+    expect(g).toBeLessThan(0.02); // sub-centímetro: un filo, no un marco
+  });
+});

--- a/src/visual/mundo3d/direccion/materialValle.js
+++ b/src/visual/mundo3d/direccion/materialValle.js
@@ -121,6 +121,36 @@ export function crearMaterialContorno() {
   });
 }
 
+/**
+ * La tinta de frente: para filos que no son casco (el anillo de un portal,
+ * una arista dibujada). Mismo color de REGLA_BORDE, FrontSide.
+ * @returns {THREE.MeshBasicMaterial}
+ */
+export function crearMaterialTinta() {
+  return new THREE.MeshBasicMaterial({
+    color: REGLA_BORDE.interactivo.color,
+    toneMapped: false,
+  });
+}
+
+/**
+ * La sombra de contacto: el ÚNICO dispositivo de sombra barata sancionado
+ * (disco radial con el tinte de sombra de la franja — auditoría 4.1). Su
+ * transparencia no cuenta contra la regla del agua: es sombra, no material
+ * de objeto.
+ * @param {string} hexSombra  preset.sombra de la franja (CIELOS_HORA)
+ * @returns {THREE.MeshBasicMaterial}
+ */
+export function crearMaterialSombraContacto(hexSombra) {
+  return new THREE.MeshBasicMaterial({
+    color: hexSombra,
+    transparent: true,
+    opacity: 0.26,
+    depthWrite: false,
+    toneMapped: false,
+  });
+}
+
 /* ------------------------------------------------------------------ */
 /* La luz de la ley: colores y posición del sol vienen del preset       */
 /* aprobado (CIELOS_HORA); las INTENSIDADES aplican la relación         */

--- a/src/visual/mundo3d/direccion/materialValle.js
+++ b/src/visual/mundo3d/direccion/materialValle.js
@@ -1,0 +1,147 @@
+/*
+ * materialValle — LA FAMILIA ÚNICA DE SHADER del valle (fábrica three).
+ *
+ * Corrección #1 de AUDITORIA-VALLE.md: cuatro modelos de material (Standard,
+ * Lambert, Basic, Phong) competían en el mismo cuadro. Aquí queda UNO:
+ *
+ *   · Todo material físico opaco → MeshToonMaterial con LA MISMA rampa de
+ *     tres bandas (RAMPA_BANDAS de paletaValle). La variación entre piezas
+ *     es el COLOR de la muestra aprobada, nunca el modelo de respuesta.
+ *   · flatShading: false SIEMPRE. La banda es el lenguaje; el relieve es
+ *     geometría (regla heredada de EntQuenua y ahora ley del valle).
+ *   · El agua es el único material transparente (toon + opacity 0.85).
+ *   · MeshBasicMaterial queda reservado a EMISIVOS (ventana, candela, luna,
+ *     portal) y al cielo. Nada físico se dibuja sin responder a la luz.
+ *
+ * TIER: la rampa toon cuesta lo mismo que Lambert (una lectura de textura
+ * 16×1). Por eso la familia NO cambia por tier — ese era exactamente el
+ * origen de la deriva (rico→Standard, humilde→Lambert: dos películas). El
+ * tier sigue mandando en dpr, sombras, fog y densidad, no en el sombreado.
+ *
+ * USO (los creadores son PUROS; la escena memoiza y libera):
+ *   const mat = useMemo(() => crearMaterialValle('teja'), []);
+ *   useEffect(() => () => mat.dispose(), [mat]);
+ *
+ * El contorno tinta (habitantes e interactivos) es casco invertido:
+ *   <mesh geometry={geo} material={mat} />
+ *   <mesh geometry={geo} material={materialContorno()} scale={escalaCasco} />
+ * con escala derivada de grosorContornoMundo (≈1.5 px de pantalla).
+ */
+import * as THREE from 'three';
+import {
+  MUESTRAS,
+  EMISIVOS,
+  RAMPA_BANDAS,
+  REGLA_BORDE,
+  RELACION_LUZ,
+  COMPENSACION_CLAVE,
+  REPARTO_RELLENO,
+} from './paletaValle.js';
+
+/* ------------------------------------------------------------------ */
+/* La rampa: UNA DataTexture de 16×1 con tres escalones duros.         */
+/* Singleton de módulo: todos los materiales comparten la textura.     */
+/* ------------------------------------------------------------------ */
+let rampaCompartida = null;
+
+export function rampaValle() {
+  if (rampaCompartida) return rampaCompartida;
+  const ancho = 16;
+  const datos = new Uint8Array(ancho * 4);
+  for (let i = 0; i < ancho; i += 1) {
+    const t = i / (ancho - 1);
+    /* tres bandas parejas: [0, 1/3) sombra, [1/3, 2/3) media, [2/3, 1] luz */
+    const banda = t < 1 / 3 ? RAMPA_BANDAS[0] : t < 2 / 3 ? RAMPA_BANDAS[1] : RAMPA_BANDAS[2];
+    const v = Math.round(banda * 255);
+    datos.set([v, v, v, 255], i * 4);
+  }
+  const tex = new THREE.DataTexture(datos, ancho, 1, THREE.RGBAFormat);
+  tex.minFilter = THREE.NearestFilter;
+  tex.magFilter = THREE.NearestFilter;
+  tex.generateMipmaps = false;
+  tex.needsUpdate = true;
+  rampaCompartida = tex;
+  return tex;
+}
+
+/**
+ * EL material del valle. `nombre` es una muestra aprobada de paletaValle
+ * ('teja', 'follajeCerca', 'agua'…). No existe otro camino legal para crear
+ * un material físico en el valle.
+ *
+ * @param {keyof typeof MUESTRAS} nombre  muestra aprobada
+ * @param {object} [extra]  overrides finales (p. ej. { color } SOLO si el hex
+ *                          viene de la paleta madre — corteza de especie)
+ * @returns {THREE.MeshToonMaterial}
+ */
+export function crearMaterialValle(nombre, extra = {}) {
+  const muestra = MUESTRAS[nombre];
+  if (!muestra) throw new Error(`materialValle: muestra desconocida '${nombre}'`);
+  const props = {
+    color: muestra.hex,
+    gradientMap: rampaValle(),
+    ...(nombre === 'agua' ? { transparent: true, opacity: 0.85 } : {}),
+    ...extra,
+  };
+  return new THREE.MeshToonMaterial(props);
+}
+
+/**
+ * Variante para mallas fusionadas con color por vértice (el patrón de
+ * siembra/terreno horneado): un material, los colores en la geometría.
+ * Los colores de vértice TAMBIÉN deben salir de las muestras aprobadas.
+ * @returns {THREE.MeshToonMaterial}
+ */
+export function crearMaterialValleVertexColors() {
+  return new THREE.MeshToonMaterial({ vertexColors: true, gradientMap: rampaValle() });
+}
+
+/**
+ * Material emisivo con permiso (ventana, candela, luna, portal). Cualquier
+ * otro brillo sin fuente diegética se apaga en origen (auditoría 4.2).
+ * @param {keyof typeof EMISIVOS} nombre
+ * @returns {THREE.MeshBasicMaterial}
+ */
+export function crearMaterialEmisivo(nombre, extra = {}) {
+  const hex = EMISIVOS[nombre];
+  if (!hex) throw new Error(`materialValle: emisivo sin permiso '${nombre}'`);
+  return new THREE.MeshBasicMaterial({ color: hex, toneMapped: false, ...extra });
+}
+
+/**
+ * El material del contorno tinta (casco invertido, BackSide). Uno solo,
+ * compartible entre todos los habitantes e interactivos de una escena.
+ * @returns {THREE.MeshBasicMaterial}
+ */
+export function crearMaterialContorno() {
+  return new THREE.MeshBasicMaterial({
+    color: REGLA_BORDE.habitante.color,
+    side: THREE.BackSide,
+    toneMapped: false,
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* La luz de la ley: colores y posición del sol vienen del preset       */
+/* aprobado (CIELOS_HORA); las INTENSIDADES aplican la relación         */
+/* relleno/clave de la franja (auditoría 4.1: el 90% fijo aplanaba      */
+/* todas las horas). Datos puros: la escena monta las cuatro luces.     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Deriva el rig de luz de la ley para un preset de CIELOS_HORA.
+ * @param {object} preset  CIELOS_HORA[franja]
+ * @param {keyof typeof RELACION_LUZ} franja
+ * @returns {{ clave: number, hemisferio: number, ambiente: number, contra: number }}
+ */
+export function intensidadesDeLey(preset, franja) {
+  const relacion = RELACION_LUZ[franja] ?? 0.5;
+  const clave = preset.sol * preset.intensidad * COMPENSACION_CLAVE;
+  const relleno = clave * relacion;
+  return {
+    clave,
+    hemisferio: relleno * REPARTO_RELLENO.hemisferio,
+    ambiente: relleno * REPARTO_RELLENO.ambiente,
+    contra: relleno * REPARTO_RELLENO.contra,
+  };
+}

--- a/src/visual/mundo3d/direccion/paletaValle.js
+++ b/src/visual/mundo3d/direccion/paletaValle.js
@@ -1,0 +1,261 @@
+/*
+ * paletaValle — LA LEY DEL LENGUAJE VISUAL DEL VALLE (datos puros, cero three).
+ *
+ * La auditoría visual del valle (AUDITORIA-VALLE.md, hallazgo 1.1) midió el
+ * problema exacto: 321 materiales únicos, 712 colores hex, 288 usos de
+ * flatShading contra 199 de sombreado suave y CUATRO modelos de material
+ * (Standard, Lambert, Basic, Phong) compitiendo en el mismo cuadro. "Una
+ * misma luz produce faceta, gradiente y color plano según quién construyó la
+ * pieza. El ojo no interpreta variedad dentro de un lugar, sino activos de
+ * bibliotecas distintas."
+ *
+ * Este módulo es la corrección #1: UNA ley, pocas decisiones, disciplina
+ * total (la lente Nintendo: menos decisiones aplicadas con más rigor).
+ * Son TRES reglas:
+ *
+ *   1. LA PALETA: 4 colores madre y 16 muestras aprobadas (abajo). Ningún
+ *      material del valle usa un hex que no esté aquí. Los estados horarios
+ *      transforman valor y temperatura DE ESTAS muestras vía la luz
+ *      (CIELOS_HORA); jamás agregan paletas paralelas. Las variantes
+ *      "*Sombra" horneadas desaparecen: la banda de sombra las produce.
+ *   2. EL SOMBREADO: una sola familia de shader — rampa de TRES bandas
+ *      (sombra / media / luz) compartida por todo material físico opaco,
+ *      con variación POR COLOR de muestra, no por modelo de respuesta.
+ *      flatShading queda PROHIBIDO: la banda es el lenguaje, no la faceta.
+ *      La fábrica vive en ./materialValle.js.
+ *   3. EL BORDE: el paisaje NO lleva contorno. Los habitantes (personas,
+ *      animales) y los interactivos (portales, señales tocables) llevan
+ *      contorno tinta de ~1.5 px de pantalla. Regla binaria, sin grosores
+ *      por autor.
+ *
+ * TODO color de aquí se EXTRAE de la paleta madre aprobada
+ * (../paleta/paletaMadre.js) — cero hex inventado. Este módulo restringe
+ * aquel vocabulario al subconjunto del valle; no lo reemplaza.
+ *
+ * La verificación es visual: la HOJA DE PRUEBA (#/mockups/hoja-prueba-valle)
+ * monta roca, árbol, casa, persona, animal y portal bajo las cinco franjas.
+ * Ningún activo entra al valle si rompe las bandas o el borde en esa hoja.
+ */
+import {
+  VERDES,
+  TIERRAS,
+  CORTEZAS,
+  AGUAS,
+  NIEBLAS,
+  LUCES,
+  CASA,
+  NEUTROS,
+  ACENTOS,
+  PALETA,
+} from '../paleta/paletaMadre.js';
+import { mezclaHex } from '../cielosHoraData.js';
+
+/* ------------------------------------------------------------------ */
+/* 1. LOS CUATRO COLORES MADRE                                         */
+/* Toda muestra del valle pertenece a UNA de estas cuatro familias.    */
+/* Si una pieza no puede nombrar su madre, no entra a la escena.       */
+/* ------------------------------------------------------------------ */
+export const COLORES_MADRE = {
+  /* la vida vegetal: del pasto al monte, siempre con tierra adentro */
+  verde: VERDES.trabajo, // '#5f8a3f'
+  /* el suelo y lo que sale de él: labranza, camino, corteza, teja, barro */
+  tierra: TIERRAS.siembra, // '#6b4a2e'
+  /* la luz hecha materia: muro encalado, piedra clara, hueso, espuma */
+  cal: NEUTROS.cal, // '#efe7d8'
+  /* el único azul con permiso: quebrada, acequia, estanque */
+  agua: AGUAS.viva, // '#3f8fb0'
+};
+
+/* ------------------------------------------------------------------ */
+/* 2. LAS DIECISÉIS MUESTRAS APROBADAS                                 */
+/* Cada una: hex de la paleta madre (fuente comentada), color madre    */
+/* al que pertenece y uso semántico. El esclavo de refactor mapea cada */
+/* uno de los 712 hex del valle a la muestra más cercana — o lo borra. */
+/* ------------------------------------------------------------------ */
+export const MUESTRAS = {
+  /* — familia verde — */
+  follajeCerca: {
+    hex: VERDES.trabajo, // '#5f8a3f' — el verde de trabajo del juego
+    madre: 'verde',
+    uso: 'copa y hoja del plano cercano y medio; el verde por defecto',
+  },
+  follajeLejos: {
+    /* el monte del fondo, desaturado y enfriado hacia la bruma del páramo
+       (auditoría 3.2: fondo 15%-25% menos saturado y más frío que el medio) */
+    hex: mezclaHex(VERDES.monte, NIEBLAS.paramo, 0.3),
+    madre: 'verde',
+    uso: 'bosque y ladera a más de 25 u; nunca en primer plano',
+  },
+  pasto: {
+    hex: VERDES.brote, // '#7a9a3f' — brote, pasto al sol
+    madre: 'verde',
+    uso: 'potrero, pradera, brizna de suelo',
+  },
+  cultivo: {
+    hex: VERDES.templadoVivo, // '#4e9143' — el verde vivo del piso templado
+    madre: 'verde',
+    uso: 'surco trabajado, milpa, cafetal joven: lo sembrado por la mano',
+  },
+
+  /* — familia tierra — */
+  tierraLabrada: {
+    hex: TIERRAS.siembra, // '#6b4a2e' — cama de siembra
+    madre: 'tierra',
+    uso: 'era, surco abierto, tierra removida',
+  },
+  camino: {
+    hex: TIERRAS.camino, // '#8a6a44' — suelo seco, camino de finca
+    madre: 'tierra',
+    uso: 'sendero, patio pisado, suelo seco',
+  },
+  corteza: {
+    hex: CORTEZAS.roble, // '#6a5c4a' — la corteza gris-parda digna
+    madre: 'tierra',
+    uso: 'tronco vivo; variantes de especie SOLO desde CORTEZAS',
+  },
+  madera: {
+    hex: PALETA.madera, // '#7a5a38' — poste, tabla, mango
+    madre: 'tierra',
+    uso: 'madera trabajada: cerca, banco, viga, herramienta',
+  },
+  teja: {
+    hex: CASA.teja, // '#b0603f' — el faldón de la casa canónica
+    madre: 'tierra',
+    uso: 'cubierta de teja; SIN variante sombra: la banda la produce',
+  },
+  zocalo: {
+    hex: CASA.zocalo, // '#a35a3c' — la franja pintada de toda casa de vereda
+    madre: 'tierra',
+    uso: 'zócalo de casa, matera de barro, ladrillo',
+  },
+  piel: {
+    hex: TIERRAS.vega, // '#c9b593' — tierra clara de la vega
+    madre: 'tierra',
+    uso: 'piel de habitante 3D (persona); el SVG rubber-hose manda en 2D',
+  },
+
+  /* — familia cal — */
+  encalado: {
+    hex: CASA.encalado, // '#f3ecdc' — el muro de tapia encalada
+    madre: 'cal',
+    uso: 'muro de casa, tanque encalado',
+  },
+  piedra: {
+    hex: TIERRAS.piedra, // '#9a8b74' — roca de río, tanque (gris pardo)
+    madre: 'cal',
+    uso: 'piedra suelta, roca de quebrada, cimiento',
+  },
+  roca: {
+    hex: TIERRAS.rocaSierra, // '#6f6357' — el risco que asoma
+    madre: 'cal',
+    uso: 'afloramiento, risco de ladera, piedra grande',
+  },
+  carpinteria: {
+    hex: CASA.carpinteria, // '#44685a' — el verde-aguamarina campesino
+    madre: 'cal',
+    uso: 'puerta y ventana pintadas, silla, cancel',
+  },
+
+  /* — familia agua — */
+  agua: {
+    hex: AGUAS.viva, // '#3f8fb0' — el acento azul del juego
+    madre: 'agua',
+    uso: 'quebrada, acequia, estanque; ÚNICO material transparente',
+  },
+};
+
+/* Guardia de la ley: entre 12 y 16 muestras, jamás más. */
+export const MUESTRAS_MIN = 12;
+export const MUESTRAS_MAX = 16;
+
+/* ------------------------------------------------------------------ */
+/* 3. LOS EMISIVOS CON PERMISO                                         */
+/* MeshBasicMaterial queda RESERVADO para lo realmente emisivo o       */
+/* celeste (auditoría 1.1). Nada físico se dibuja sin responder a la   */
+/* luz. Un emisivo fuera de esta lista es un halo sin fuente: se apaga.*/
+/* ------------------------------------------------------------------ */
+export const EMISIVOS = {
+  ventana: CASA.ventana, // '#ffd9a0' — la luz cálida de "la casa espera"
+  candela: LUCES.candela, // '#ffd28a' — el hito encendido
+  luna: LUCES.luna, // '#b9c6e6' — la luna plata
+  portal: CASA.ventana, // '#ffd9a0' — el corazón de la ventana-mundo
+};
+
+/* Los acentos (cochinilla, maíz, guayacán…) SIGUEN siendo de ACENTOS de la
+   paleta madre: a cucharadas — una cinta, una flor, una baya — jamás una
+   superficie. Regla de dosis: máximo UN acento por objeto y nunca más del
+   5% del área visible de la pieza. */
+export { ACENTOS };
+
+/* ------------------------------------------------------------------ */
+/* 4. LA RAMPA DE TRES BANDAS                                          */
+/* Una sola respuesta a la luz para todo material físico opaco:        */
+/* sombra / media / luz, con cortes duros (NearestFilter). Los tres    */
+/* niveles son factores de luminancia sobre el color de la muestra.    */
+/* La banda de sombra NO es negra: conserva el color (regla Ghibli /   */
+/* BOTW: la sombra es color enfriado, no ausencia).                    */
+/* ------------------------------------------------------------------ */
+export const RAMPA_BANDAS = [0.42, 0.74, 1.0];
+
+/* flatShading queda prohibido en el valle: la banda es el lenguaje.
+   (288 usos actuales migran a suave; el relieve es geometría.) */
+export const FLAT_SHADING_PROHIBIDO = true;
+
+/* ------------------------------------------------------------------ */
+/* 5. LA REGLA DE BORDE                                                */
+/* Binaria, sin excepciones por autor:                                 */
+/*   paisaje (terreno, vegetación, arquitectura, roca, agua) → SIN     */
+/*   contorno. habitante (persona, animal) e interactivo (portal,      */
+/*   señal tocable) → contorno tinta de ~1.5 px de pantalla.           */
+/* La tinta es NEUTROS.tinta: negro cálido, nunca negro puro.          */
+/* ------------------------------------------------------------------ */
+export const REGLA_BORDE = {
+  paisaje: null,
+  habitante: { color: NEUTROS.tinta, grosorPx: 1.5 },
+  interactivo: { color: NEUTROS.tinta, grosorPx: 1.5 },
+};
+
+/**
+ * Grosor de contorno en unidades de mundo para que el borde mida
+ * `grosorPx` píxeles a la distancia dada (cámara perspectiva).
+ * El casco invertido usa este valor a la distancia del plano de autor;
+ * es geometría fija, no post-proceso (barato en todos los tiers).
+ * @param {number} distancia  distancia cámara→objeto en unidades
+ * @param {number} fovDeg     fov vertical de la cámara en grados
+ * @param {number} altoPx     alto del viewport en píxeles
+ * @param {number} [grosorPx] grosor deseado en píxeles de pantalla
+ */
+export function grosorContornoMundo(
+  distancia,
+  fovDeg,
+  altoPx,
+  grosorPx = REGLA_BORDE.habitante.grosorPx,
+) {
+  const mundoPorPx = (2 * distancia * Math.tan((fovDeg * Math.PI) / 360)) / altoPx;
+  return grosorPx * mundoPorPx;
+}
+
+/* ------------------------------------------------------------------ */
+/* 6. LA RELACIÓN LUZ/RELLENO POR FRANJA                               */
+/* La auditoría 4.1 midió relleno = 90% de la clave en TODAS las       */
+/* franjas: cambia el tinte, no la estructura. Para que las tres       */
+/* bandas EXISTAN, el relleno se desacopla de la clave. Estos son los  */
+/* objetivos de la ley (relleno total / luz direccional):              */
+/* ------------------------------------------------------------------ */
+export const RELACION_LUZ = {
+  amanecer: 0.4,
+  manana: 0.55,
+  mediodia: 0.55,
+  tarde: 0.5,
+  atardecer: 0.38,
+  noche: 0.35,
+};
+
+/* Compensación de exposición al bajar el relleno (auditoría 4.1:
+   "compensando exposición para no aplastar negros"). */
+export const COMPENSACION_CLAVE = 1.15;
+
+/* Reparto del presupuesto de relleno entre las luces de apoyo:
+   el hemisferio modela (cielo/suelo), el ambiente levanta el toe,
+   la direccional opuesta despega la silueta. Suman 1. */
+export const REPARTO_RELLENO = { hemisferio: 0.6, ambiente: 0.25, contra: 0.15 };


### PR DESCRIPTION
## Qué es

Corrección #1 de la auditoría visual del valle (`AUDITORIA-VALLE.md` 1.1): 321 materiales, 712 hex, 288 flatShading vs 199 suave y 4 modelos de material en el mismo cuadro. Esta rama entrega **la LEY, no el refactor masivo** (ese lo hace un carril de código con la ley en la mano).

## Entregables

- **`src/visual/mundo3d/direccion/paletaValle.js`** — 4 colores madre + 16 muestras aprobadas con nombre semántico, extraídas de la paleta madre aprobada (cero hex inventado); emisivos con lista blanca; regla de borde binaria; relación relleno/clave por franja (auditoría 4.1).
- **`src/visual/mundo3d/direccion/materialValle.js`** — UNA familia de shader: `MeshToonMaterial` + rampa compartida de 3 bandas (0.42/0.74/1.0, cortes duros), flatShading prohibido, agua única transparencia, Basic solo emisivos, casco invertido para contorno tinta ~1.5px.
- **`src/mockups/HojaPruebaValle.jsx`** — la HOJA DE PRUEBA (patrón oro): roca, árbol, casa canónica (1u=1m: puerta 2.05, cumbrera 3.4), persona 1.70, perro 0.59 (ancla Oliver), portal ventana-viva y agua bajo las 5 franjas. Ruta `#/mockups/hoja-prueba-valle` + `?ciclo=`.
- **`LEY-VISUAL-VALLE.md`** — el documento que sigue el esclavo de refactor: guía de migración + criterios de aceptación medibles contra `auditar-valle-runtime.mjs`.
- **Test en CI** que fija la ley (conteo 12-16, hex válidos, bandas ascendentes, borde 1.5, relaciones de luz en los rangos de la auditoría).

## Las 5 URLs de verificación

| Franja | URL |
|---|---|
| Amanecer | `/?ciclo=6.2#/mockups/hoja-prueba-valle` |
| Mediodía | `/?ciclo=12#/mockups/hoja-prueba-valle` |
| Tarde | `/?ciclo=16#/mockups/hoja-prueba-valle` |
| Crepúsculo | `/?ciclo=18.1#/mockups/hoja-prueba-valle` |
| Noche | `/?ciclo=22#/mockups/hoja-prueba-valle` |

## Verificación hecha

- `vitest` de la ley: 8/8 verdes. Suites `mundo3d`+`mockups`: fallos idénticos base vs rama (22=22, todos preexistentes: bosqueRealismo/nav/gallinero/audio).
- Build verde; chunk `HojaPruebaValle-*.js` y ruta `hoja-prueba-valle` verificados EN `dist`.
- NO toca `Valle3D.jsx`, `composicionValle3D.jsx` (T2) ni `bosque/` (T4). `chagra-stats.json` y `manifest.json` revertidos.

Falta (gate del brazo visual): captura de las 5 franjas por el orquestador antes de salir de draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)