### PR TITLE
El frailejonal DOMINA el páramo (2a pasada, planicie abierta)

### DIFF
--- a/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
+++ b/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
@@ -37,7 +37,6 @@ import { SombraContacto } from '../escenas/SombraContacto.jsx';
 import SueloRico from '../terreno/SueloRico.jsx';
 import EntQuenua from './EntQuenua.jsx';
 import FloraParamo from './FloraParamo.jsx';
-import DoselBiodiverso from './DoselBiodiverso.jsx';
 import FaunaBosque from './FaunaBosque.jsx';
 import {
   alturaBosque,
@@ -588,7 +587,13 @@ function BrumaParallax({ franja, reducedMotion }) {
    héroe aprobado (leve contrapicado, el rostro tallado legible), el rig de
    cámara se escala con él — misma proporción árbol/cuadro que el original, solo
    que 1.4× más grande y con el bosque catedral abriéndose alrededor. */
-const POSE_BOSQUE = { position: [11.2, 3.6, 16.2], fov: 42, mira: [0, 4.2, 0] };
+/* 2a pasada páramo (2026-07-20): se ABRE el encuadre para que respire la
+   PLANICIE. La cámara SUBE (y 3.6→4.7) y mira un pelo HACIA ABAJO (mira y
+   3.7→3.0): el frailejonal se despliega en abanico hacia un horizonte BAJO y el
+   cielo lechoso del páramo ocupa el tercio alto (la firma: planicie abierta,
+   cielo grande). La queñua Ent queda de acento vertical/guardián al fondo, ya no
+   como muro de copas. fov 45→46 para que entre más frailejonal. */
+const POSE_BOSQUE = { position: [12.0, 4.7, 17.6], fov: 46, mira: [0, 3.0, 0] };
 
 /* Anclas de sombra de contacto que la escena le pasa a SueloRico: el claro del
    guardián (el Ent es el objeto mayor y necesita el AO ancho que lo planta). */
@@ -649,16 +654,17 @@ function Diorama({ tier, reducedMotion, pose }) {
       {/* El arroyo que baja de la niebla (de noche, lo que más brilla). */}
       {tier !== 'bajo' && <Arroyo nocturno={nocturno} perfil={perfil} />}
 
-      {/* El ECOSISTEMA de páramo (frailejonar, sotobosque, árboles vecinos),
+      {/* EL FRAILEJONAL DEL PÁRAMO (bioma="paramo"): la planicie abierta con el
+          frailejonar dominando primer plano y media distancia, el cortejo de
+          árboles ralo y empujado al anillo lejano (siluetas en la niebla).
           POSADO sobre el relieve con alturaDe. */}
-      <FloraParamo tier={tier} reducedMotion={reducedMotion} alturaDe={alturaBosque} />
+      <FloraParamo tier={tier} reducedMotion={reducedMotion} alturaDe={alturaBosque} bioma="paramo" />
 
-      {/* EL DOSEL BIODIVERSO: la variedad andina/subandina colombiana que
-          TRIPLICA los árboles — emergentes (guadua, nogal cafetero, cedro),
-          dosel florecido (cámbulo rojo, gualanday morado, siete cueros magenta),
-          sotobosque (helecho arbóreo, heliconia) y epífitas (quiche). Con esto
-          el claro se lee como BOSQUE de tres estratos, no un árbol solo. */}
-      <DoselBiodiverso tier={tier} alturaDe={alturaBosque} />
+      {/* (2a pasada 2026-07-20) SE RETIRÓ el DoselBiodiverso: ese dosel andino/
+          subandino de tres estratos (guadua, cámbulo, gualanday, siete cueros,
+          heliconia, helecho arbóreo, quiche) es un ERROR DE BIOMA para un páramo
+          sobre 3500 m — convertía la planicie en bosque denso y sepultaba al
+          frailejón. El páramo lleva frailejonal + queñua de acento, no dosel. */}
 
       {/* LA VIDA: cóndor, vecinos rubber-hose, mariposas, luciérnagas. */}
       <FaunaBosque tier={tier} reducedMotion={reducedMotion} />

--- a/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
+++ b/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
@@ -168,11 +168,25 @@ function AtmosferaBosque({ franja, perfil, reducedMotion }) {
     pintar(actual);
   });
 
-  useFrame((_, dt) => {
+  useFrame((state, dt) => {
     if (reducedMotion) return;
     const k = 1 - Math.exp((-3 / TRANSICION.duracion) * Math.min(dt, 0.1));
     amortiguar(actual, objetivo, k);
     pintar(actual);
+    // LA MAREA DE NIEBLA: una onda lenta (~46 s) que hace ENTRAR y SALIR la
+    // bruma — cuando sube, el fog se cierra y se traga la montaña del fondo; al
+    // bajar, la revela. Es lo que vuelve la niebla protagonista (Jackson): la
+    // catedral aparece y desaparece, no un plano uniforme. Se aplica DESPUÉS de
+    // pintar (no acumula: parte del estado ya amortiguado de esta franja).
+    const marea = 0.5 + 0.5 * Math.sin(state.clock.elapsedTime * (Math.PI * 2 / 46));
+    if (fogRef.current) {
+      fogRef.current.far = actual.nieblaLejos * (1 - 0.44 * marea);
+      fogRef.current.near = actual.nieblaCerca * (1 - 0.22 * marea);
+    }
+    // El fondo se LECHA hacia el color de la niebla cuando la marea cierra: la
+    // pared del anfiteatro se disuelve en blanco y vuelve. copy() antes de lerp
+    // → no acumula (siempre parte del fondo amortiguado de la franja).
+    if (fondoRef.current) fondoRef.current.copy(actual.fondo).lerp(actual.niebla, 0.4 * marea);
   });
 
   return (
@@ -529,6 +543,11 @@ function BrumaParallax({ franja, reducedMotion }) {
     const t = state.clock.elapsedTime;
     const k = reducedMotion ? 1 : 1 - Math.exp(-0.8 * Math.min(dt, 0.1));
     peso.current += ((PESO_BRUMA[franja] ?? 1) - peso.current) * k;
+    // La misma MAREA de niebla que respira en el fog (mismo periodo/fase): las
+    // cartas de bruma se ESPESAN cuando la marea cierra y adelgazan al abrir →
+    // la niebla entra y sale a una, no cada capa por su lado.
+    const marea = reducedMotion ? 0 : 0.5 + 0.5 * Math.sin(t * (Math.PI * 2 / 46));
+    const envMarea = 0.7 + 0.62 * marea;
     let idx = 0;
     for (let c = 0; c < CAPAS_BRUMA.length; c++) {
       const capa = CAPAS_BRUMA[c];
@@ -542,7 +561,7 @@ function BrumaParallax({ franja, reducedMotion }) {
           Math.sin(az) * capa.rad,
         );
         carta.quaternion.copy(state.camera.quaternion);
-        carta.material.opacity = capa.op * peso.current
+        carta.material.opacity = capa.op * peso.current * envMarea
           * (reducedMotion ? 1 : 0.9 + 0.1 * Math.sin(t * 0.07 + capa.fase * 2 + lado * 3));
         idx++;
       }

--- a/src/visual/mundo3d/bosque/FloraParamo.jsx
+++ b/src/visual/mundo3d/bosque/FloraParamo.jsx
@@ -227,12 +227,25 @@ function NieblaRasante({ n, reducedMotion }) {
 }
 
 /*
+ * EL PROSCENIO: tres frailejones GIGANTES fijos en el primer plano del lado de
+ * la cámara de reposo (arco az ~55°, radio 4-5.5). Garantizan que —tras el dolly
+ * de llegada— el frailejonal IMPONGA al frente aunque el anillo aleatorio caiga
+ * de otro lado. La roseta plateada queda a la altura de mira (en cuadro). El
+ * campesino se planta a su pie. La queñua (Ent) queda detrás, de guardiana.
+ */
+const PROSCENIO = [
+  { x: 5.7, z: 8.2, escala: 2.3, rotY: 0.5, tiltX: 0.04, tiltZ: -0.05 }, // centro, el mayor
+  { x: 3.5, z: 8.9, escala: 1.9, rotY: 2.6, tiltX: -0.05, tiltZ: 0.05 }, // hacia el borde izq.
+  { x: 7.6, z: 6.6, escala: 2.05, rotY: 4.0, tiltX: 0.05, tiltZ: 0.04 }, // hacia el borde der.
+];
+
+/*
  * FiguraEscala — el campesino de referencia al pie del frailejonal héroe. Se
  * planta en el PRIMER PLANO del lado de la cámara en reposo (dirección al Ent),
  * posado sobre el relieve, mirando hacia el claro (contempla el frailejonal, de
  * espaldas a la cámara: la silueta pequeña que revela la escala del gigante).
  */
-const FIGURA_POS = [3.9, 0, 5.7]; // radio ~6.9 hacia la cámara de reposo
+const FIGURA_POS = [6.6, 0, 9.0]; // al pie del proscenio, en el corredor de cámara
 function FiguraEscala({ mat, alturaDe }) {
   const geo = useMemo(() => geomCampesinoEscala(44), []);
   useLayoutEffect(() => () => geo.dispose(), [geo]);
@@ -305,6 +318,19 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false, altu
     return Object.fromEntries(Object.entries(d).map(([k, v]) => [k, posar(v)]));
   }, [conteos, alturaDe]);
 
+  // El proscenio fijo (trío foreground): posado en el relieve, tinte neutro.
+  const proscenio = useMemo(
+    () => PROSCENIO.map((p) => ({
+      pos: [p.x, alturaDe ? alturaDe(p.x, p.z) : 0, p.z],
+      rotY: p.rotY,
+      escala: p.escala,
+      tint: [1, 1, 1],
+      tiltX: p.tiltX,
+      tiltZ: p.tiltZ,
+    })),
+    [alturaDe],
+  );
+
   // Liberar GPU al desmontar.
   useLayoutEffect(() => () => {
     Object.values(geos).forEach((gg) => gg && gg.dispose());
@@ -328,6 +354,7 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false, altu
           grandes y cercanos que IMPONEN en primer plano) + tres EDADES
           entremezcladas (joven al ras, adulto, viejo de columna alta) + los que
           florecen. El frailejón vuelve a ser el protagonista visible del páramo. */}
+      <Especie geo={geos.frailejonHero} mat={mat} items={proscenio} castShadow={sombra} />
       <Especie geo={geos.frailejonHero} mat={mat} items={dist.frailejonHero} castShadow={sombra} />
       <Especie geo={geos.frailejonJoven} mat={mat} items={dist.frailejonJoven} />
       <Especie geo={geos.frailejon} mat={mat} items={dist.frailejon} />

--- a/src/visual/mundo3d/bosque/FloraParamo.jsx
+++ b/src/visual/mundo3d/bosque/FloraParamo.jsx
@@ -78,6 +78,71 @@ function Especie({ geo, mat, items, castShadow = false }) {
   );
 }
 
+/* Textura de CHARCO: glint claro al centro que se apaga al borde (sin rim duro).
+   Un espejo de agua que nace del páramo, catch de la luz del cielo. */
+function texturaCharco() {
+  const s = 128;
+  const cv = document.createElement('canvas');
+  cv.width = cv.height = s;
+  const ctx = cv.getContext('2d');
+  const g = ctx.createRadialGradient(s / 2, s * 0.42, 0, s / 2, s / 2, s / 2);
+  g.addColorStop(0, 'rgba(226,240,244,0.92)'); // glint del cielo
+  g.addColorStop(0.4, 'rgba(150,190,203,0.66)');
+  g.addColorStop(0.82, 'rgba(96,140,156,0.34)');
+  g.addColorStop(1, 'rgba(96,140,156,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, s, s);
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+/*
+ * CHARCOS del páramo: unos pocos espejos de agua que nacen entre el musgo (el
+ * páramo es una fábrica de agua). Discos planos con glint del cielo, posados
+ * sobre el relieve. Reciben la niebla (fog) para receder al fondo. Baratos:
+ * una textura, un material, N discos. Quietos (paisaje).
+ */
+const CHARCOS = [
+  { x: 2.6, z: 3.4, r: 0.9 },
+  { x: 4.5, z: 5.6, r: 1.15 },
+  { x: -1.8, z: 4.2, r: 0.72 },
+  { x: 5.9, z: 2.1, r: 0.62 },
+  { x: 0.8, z: 6.6, r: 0.85 },
+];
+function Charcos({ alturaDe }) {
+  const tex = useMemo(() => texturaCharco(), []);
+  const mat = useMemo(
+    () => new THREE.MeshBasicMaterial({
+      map: tex,
+      transparent: true,
+      opacity: 0.72,
+      depthWrite: false,
+    }),
+    [tex],
+  );
+  const geo = useMemo(() => new THREE.CircleGeometry(1, 16), []);
+  useLayoutEffect(() => () => {
+    tex.dispose();
+    mat.dispose();
+    geo.dispose();
+  }, [tex, mat, geo]);
+  return (
+    <group>
+      {CHARCOS.map((c, i) => (
+        <mesh
+          key={i}
+          geometry={geo}
+          material={mat}
+          position={[c.x, (alturaDe ? alturaDe(c.x, c.z) : 0) + 0.035, c.z]}
+          rotation={[-Math.PI / 2, 0, i * 1.3]}
+          scale={[c.r, c.r, 1]}
+        />
+      ))}
+    </group>
+  );
+}
+
 /* Textura suave (radial) para el vaho, generada en runtime (sin assets). */
 function texturaVaho() {
   const s = 128;
@@ -250,9 +315,10 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false, altu
 
   return (
     <group>
-      {/* Suelo del páramo: rocas con líquen + musgo. */}
+      {/* Suelo del páramo: rocas con líquen + musgo + charcos (agua naciendo). */}
       <Especie geo={geos.roca} mat={mat} items={dist.roca} />
       <Especie geo={geos.musgo} mat={mat} items={dist.musgo} />
+      {tier !== 'bajo' && <Charcos alturaDe={alturaDe} />}
 
       {/* Sotobosque: romerillo y mortiño (con sus bayas de agraz). */}
       <Especie geo={geos.romerillo} mat={mat} items={dist.romerillo} />

--- a/src/visual/mundo3d/bosque/FloraParamo.jsx
+++ b/src/visual/mundo3d/bosque/FloraParamo.jsx
@@ -22,6 +22,7 @@ import * as THREE from 'three';
 import { perfilDeTier } from '../deviceTier.js';
 import {
   floraDeTier,
+  raleParamo,
   calidadDeTier,
   distribucionFlora,
   geomFrailejon,
@@ -267,11 +268,17 @@ function FiguraEscala({ mat, alturaDe }) {
  * La capa de flora del páramo alrededor del Ent. Montar dentro del <Canvas>.
  * `alturaDe(x,z)` (opcional) POSA cada mata sobre el relieve del terreno:
  * sin ella la siembra queda en y=0 (el claro plano de siempre).
- * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, alturaDe?: ((x:number,z:number)=>number)|null}} props
+ * `bioma`: 'bosque' (defecto — cortejo denso, para EscenaEntMaestro) | 'paramo'
+ * (planicie abierta: frailejonal dominante, árboles ralos y lejanos).
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, alturaDe?: ((x:number,z:number)=>number)|null, bioma?: 'bosque'|'paramo'}} props
  */
-export default function FloraParamo({ tier = 'alto', reducedMotion = false, alturaDe = null }) {
+export default function FloraParamo({ tier = 'alto', reducedMotion = false, alturaDe = null, bioma = 'bosque' }) {
   const perfil = perfilDeTier(tier);
-  const conteos = floraDeTier(tier);
+  // En páramo el cortejo de árboles se rala y el frailejonal se potencia.
+  const conteos = useMemo(
+    () => (bioma === 'paramo' ? raleParamo(floraDeTier(tier)) : floraDeTier(tier)),
+    [tier, bioma],
+  );
   const q = calidadDeTier(tier);
 
   // --- Geometrías fusionadas (una vez por tier). Solo lo que tenga matas. ---
@@ -309,14 +316,14 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false, altu
 
   // --- Distribución biogeográfica (una vez por tier), posada en el relieve. ---
   const dist = useMemo(() => {
-    const d = distribucionFlora(conteos, 707);
+    const d = distribucionFlora(conteos, 707, bioma);
     if (!alturaDe) return d;
     const posar = (items) => items.map((it) => ({
       ...it,
       pos: [it.pos[0], alturaDe(it.pos[0], it.pos[2]) + (it.pos[1] || 0), it.pos[2]],
     }));
     return Object.fromEntries(Object.entries(d).map(([k, v]) => [k, posar(v)]));
-  }, [conteos, alturaDe]);
+  }, [conteos, alturaDe, bioma]);
 
   // El proscenio fijo (trío foreground): posado en el relieve, tinte neutro.
   const proscenio = useMemo(

--- a/src/visual/mundo3d/bosque/FloraParamo.jsx
+++ b/src/visual/mundo3d/bosque/FloraParamo.jsx
@@ -25,6 +25,7 @@ import {
   calidadDeTier,
   distribucionFlora,
   geomFrailejon,
+  geomCampesinoEscala,
   geomYarumo,
   geomRoble,
   geomEncenillo,
@@ -160,6 +161,30 @@ function NieblaRasante({ n, reducedMotion }) {
   );
 }
 
+/*
+ * FiguraEscala — el campesino de referencia al pie del frailejonal héroe. Se
+ * planta en el PRIMER PLANO del lado de la cámara en reposo (dirección al Ent),
+ * posado sobre el relieve, mirando hacia el claro (contempla el frailejonal, de
+ * espaldas a la cámara: la silueta pequeña que revela la escala del gigante).
+ */
+const FIGURA_POS = [3.9, 0, 5.7]; // radio ~6.9 hacia la cámara de reposo
+function FiguraEscala({ mat, alturaDe }) {
+  const geo = useMemo(() => geomCampesinoEscala(44), []);
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  const y = alturaDe ? alturaDe(FIGURA_POS[0], FIGURA_POS[2]) : 0;
+  // Mira hacia el centro del claro (el frailejonal / el Ent).
+  const rotY = Math.atan2(-FIGURA_POS[0], -FIGURA_POS[2]);
+  return (
+    <mesh
+      geometry={geo}
+      material={mat}
+      position={[FIGURA_POS[0], y, FIGURA_POS[2]]}
+      rotation={[0, rotY, 0]}
+      castShadow
+    />
+  );
+}
+
 /**
  * La capa de flora del páramo alrededor del Ent. Montar dentro del <Canvas>.
  * `alturaDe(x,z)` (opcional) POSA cada mata sobre el relieve del terreno:
@@ -177,6 +202,9 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false, altu
   // banco → el frailejonal se lee como un paisaje con gradiente de edad.
   const geos = useMemo(() => {
     const g = {};
+    // El HÉROE del páramo: adulto pleno f3 — enagua larga + roseta plateada + flor.
+    // La banda héroe lo instancia grande y cerca (frailejonHero) para que imponga.
+    if (conteos.frailejonHero) g.frailejonHero = geomFrailejon({ flor: true, q, edad: 0.98 }, 91);
     if (conteos.frailejonJoven) g.frailejonJoven = geomFrailejon({ flor: false, q, edad: 0.26 }, 21);
     if (conteos.frailejon) g.frailejon = geomFrailejon({ flor: false, q, edad: 0.62 }, 1);
     if (conteos.frailejonViejo) g.frailejonViejo = geomFrailejon({ flor: false, q, edad: 0.95 }, 37);
@@ -230,12 +258,19 @@ export default function FloraParamo({ tier = 'alto', reducedMotion = false, altu
       <Especie geo={geos.romerillo} mat={mat} items={dist.romerillo} />
       <Especie geo={geos.mortino} mat={mat} items={dist.mortino} />
 
-      {/* Frailejonar: el ícono del páramo, al frente — tres EDADES entremezcladas
-          (joven al ras, adulto, viejo de columna alta) + los que florecen. */}
+      {/* Frailejonar: el ícono del páramo, al frente — la banda HÉROE (adultos f3
+          grandes y cercanos que IMPONEN en primer plano) + tres EDADES
+          entremezcladas (joven al ras, adulto, viejo de columna alta) + los que
+          florecen. El frailejón vuelve a ser el protagonista visible del páramo. */}
+      <Especie geo={geos.frailejonHero} mat={mat} items={dist.frailejonHero} castShadow={sombra} />
       <Especie geo={geos.frailejonJoven} mat={mat} items={dist.frailejonJoven} />
       <Especie geo={geos.frailejon} mat={mat} items={dist.frailejon} />
       <Especie geo={geos.frailejonViejo} mat={mat} items={dist.frailejonViejo} />
       <Especie geo={geos.frailejonFlor} mat={mat} items={dist.frailejonFlor} />
+
+      {/* La VARA DE MEDIR: un campesino pequeño al pie del frailejonal héroe.
+          Sin él, el ojo no sabe que el frailejón mide 3-4 m (lente Colossus). */}
+      <FiguraEscala mat={mat} alturaDe={alturaDe} />
 
       {/* Árboles de fondo (anillo exterior, velados por la niebla). */}
       <Especie geo={geos.gaque} mat={mat} items={dist.gaque} castShadow={sombra} />

--- a/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
+++ b/src/visual/mundo3d/bosque/bosqueTakeA.geom.js
@@ -313,10 +313,15 @@ const AZ_CAMARA = 0.61;
 /* Los vecinos rubber-hose viven en estas anclas (FaunaBosque): despejarlas. */
 const ANCLAS_VECINOS = [[-3.7, 3.0], [3.1, 3.2], [-4.9, 4.4], [3.0, 2.1]];
 
+/* REBIOMA PÁRAMO (2a pasada 2026-07-20): la queñua (Polylepis) es de los pocos
+   árboles que sube al páramo, y va como ACENTO/personaje, no como bosque que
+   compite con el frailejonal. Se RALEA el anillo cercano (el que se metía junto
+   al frailejonal) y se recorta el lejano, dejando unas pocas siluetas colosales
+   veladas por la niebla que dan fondo catedral sin tapiar la planicie. */
 const CUPO_QUENUAL = {
-  alto: { cerca: 8, lejos: 12 },
-  medio: { cerca: 5, lejos: 6 },
-  bajo: { cerca: 3, lejos: 0 },
+  alto: { cerca: 2, lejos: 4 },
+  medio: { cerca: 1, lejos: 3 },
+  bajo: { cerca: 1, lejos: 0 },
 };
 
 function tinteInstancia(r, amt = 0.1) {
@@ -385,7 +390,9 @@ export function sitiosQuenual(tier = 'alto') {
     sitios.push({
       pos: [x, alturaBosque(x, z) - 0.1, z],
       rotY: r() * Math.PI * 2,
-      esc: 1.5 + r() * 0.95,
+      // Rebioma páramo: siluetas más BAJAS (1.2–1.75, antes 1.5–2.45) para que
+      // la queñua lejana no forme un muro de copas que tapie el cielo grande.
+      esc: 1.2 + r() * 0.55,
       variante: sitios.length % 3,
       tinte: tinteInstancia(r, 0.14),
     });

--- a/src/visual/mundo3d/bosque/floraParamo.geom.js
+++ b/src/visual/mundo3d/bosque/floraParamo.geom.js
@@ -109,6 +109,45 @@ export const FLORA_TIER = {
 export const floraDeTier = (tier) => FLORA_TIER[tier] || FLORA_TIER.medio;
 
 /*
+ * REBIOMA PÁRAMO (2026-07-20, 2a pasada — dir. Jackson / lente Humboldt):
+ * tres revisiones visuales independientes coincidieron en que el claro se leía
+ * como BOSQUE altoandino denso y NO como la planicie abierta del páramo — el
+ * frailejón compartía cuadro con demasiados árboles verdes. El
+ * páramo real sobre 3500 m es planicie con frailejonal disperso, cielo grande y
+ * POCOS árboles (la queñua/Polylepis sube como acento, no como bosque).
+ *
+ * `raleParamo` toma los conteos del bioma "bosque" y los RALEA hacia páramo:
+ *   · el cortejo de árboles (yarumo/roble/encenillo/aliso/gaque) se capa a unos
+ *     pocos que se van al anillo lejano velados por la niebla — acentos, no muro;
+ *   · el frailejonal SE POTENCIA (más héroes y más edades) para que domine el
+ *     primer plano y la media distancia: al mirar la escena, lo primero que se
+ *     lee es "frailejones".
+ * Solo aplica al mundo páramo (EscenaBosqueVivo pasa bioma="paramo"); el resto
+ * de escenas que consumen FloraParamo (p. ej. EscenaEntMaestro) no se tocan.
+ */
+export function raleParamo(c) {
+  const capArbol = (v, cap) => (v > 0 ? Math.max(1, Math.min(v, cap)) : 0);
+  const boost = (v, f) => Math.round(v * f);
+  return {
+    ...c,
+    // El frailejonal manda: más gigantes héroe y más gradiente de edad.
+    frailejonHero: boost(c.frailejonHero, 1.55),
+    frailejonJoven: boost(c.frailejonJoven, 1.5),
+    frailejon: boost(c.frailejon, 1.5),
+    frailejonViejo: boost(c.frailejonViejo, 1.55),
+    frailejonFlor: boost(c.frailejonFlor, 1.4),
+    // El cortejo de árboles se rala a acentos lejanos (planicie, no bosque).
+    yarumo: capArbol(c.yarumo, 2),
+    roble: capArbol(c.roble, 2),
+    encenillo: capArbol(c.encenillo, 2),
+    aliso: capArbol(c.aliso, 1),
+    gaque: capArbol(c.gaque, 1),
+    // El pajonal-sotobosque bajo se conserva/refuerza (cubre el suelo abierto).
+    romerillo: boost(c.romerillo, 1.15),
+  };
+}
+
+/*
  * Factor de DETALLE geométrico por tier: escala cuántas hojas/matojos lleva cada
  * mata. Menos detalle en gama baja = menos vértices por instancia (que se
  * multiplican por el número de matas).
@@ -981,9 +1020,27 @@ function sembrar(n, rMin, rMax, r, opts = {}) {
   return arr;
 }
 
-/** Todas las instancias de flora para unos conteos dados. */
-export function distribucionFlora(conteos, seed = 707) {
+/** Todas las instancias de flora para unos conteos dados.
+ *  `bioma`: 'bosque' (defecto, cortejo denso) | 'paramo' (planicie abierta —
+ *  frailejonal disperso por toda la media distancia y árboles empujados al
+ *  anillo lejano velado por la niebla). */
+export function distribucionFlora(conteos, seed = 707, bioma = 'bosque') {
   const c = conteos;
+  const paramo = bioma === 'paramo';
+  // Radios por bioma. En páramo el frailejonal se ABRE por la planicie (hasta
+  // media-larga distancia) y los árboles se van MÁS LEJOS (siluetas en la
+  // niebla), para que el primer plano y la media distancia sean todo frailejón.
+  const R = paramo
+    ? {
+      hero: [5.0, 13.5], joven: [3.0, 14.0], frail: [3.5, 15.5], viejo: [4.0, 16.5], flor: [3.5, 13.5],
+      mortino: [4, 15], romerillo: [3, 15], roca: [2, 15], musgo: [1.2, 13],
+      gaque: [15, 24], roble: [16, 26], encenillo: [17, 27], yarumo: [17, 27], aliso: [18, 29],
+    }
+    : {
+      hero: [6.0, 10.5], joven: [2.6, 8.5], frail: [3.0, 9.5], viejo: [3.4, 10.5], flor: [3.2, 9],
+      mortino: [4, 12], romerillo: [3, 12], roca: [2, 11], musgo: [1.2, 9],
+      gaque: [8.5, 14], roble: [9.5, 16], encenillo: [10, 17], yarumo: [10, 17], aliso: [11, 19],
+    };
   return {
     // Banda HÉROE (2026-07-20): los gigantes de PRIMER PLANO. Un anillo CERCANO y
     // parejo (uniforme) de adultos GRANDES (esc 1.65-2.15 → 3.5-4.5 m) que rodea
@@ -991,25 +1048,27 @@ export function distribucionFlora(conteos, seed = 707) {
     // quedan enmarcando el cuadro e IMPONEN por delante de la queñua. Ladeo
     // generoso para que ninguno se lea clonado. La firma del páramo, por fin al
     // frente. (El proscenio fijo de FloraParamo.jsx garantiza el trío foreground.)
-    frailejonHero: sembrar(c.frailejonHero, 6.0, 10.5, rng(seed + 21), { eMin: 1.65, eMax: 2.15, uniforme: true, varia: 0.12, lean: 0.16 }),
+    // En páramo el anillo se ENSANCHA: héroes también en la media distancia →
+    // colosos de frailejón salpicando toda la planicie hasta la niebla.
+    frailejonHero: sembrar(c.frailejonHero, R.hero[0], R.hero[1], rng(seed + 21), { eMin: 1.65, eMax: 2.15, uniforme: true, varia: 0.12, lean: 0.16 }),
     // Frailejonal de acompañamiento: TRES edades entremezcladas, agrupadas y
     // ACERCADAS al claro (rMin bajado desde el rediseño 07-16) con mucha
     // variación de tamaño + ladeo → gradiente de edad denso, nada clonado.
-    frailejonJoven: sembrar(c.frailejonJoven, 2.6, 8.5, rng(seed + 1), { eMin: 0.8, eMax: 1.18, varia: 0.13, lean: 0.15 }),
-    frailejon: sembrar(c.frailejon, 3.0, 9.5, rng(seed + 12), { eMin: 0.95, eMax: 1.4, varia: 0.14, lean: 0.16 }),
-    frailejonViejo: sembrar(c.frailejonViejo, 3.4, 10.5, rng(seed + 13), { eMin: 1.05, eMax: 1.55, varia: 0.14, lean: 0.18 }),
-    frailejonFlor: sembrar(c.frailejonFlor, 3.2, 9, rng(seed + 2), { eMin: 1.0, eMax: 1.45, varia: 0.1, lean: 0.13 }),
+    frailejonJoven: sembrar(c.frailejonJoven, R.joven[0], R.joven[1], rng(seed + 1), { eMin: 0.8, eMax: 1.18, varia: 0.13, lean: 0.15 }),
+    frailejon: sembrar(c.frailejon, R.frail[0], R.frail[1], rng(seed + 12), { eMin: 0.95, eMax: 1.4, varia: 0.14, lean: 0.16 }),
+    frailejonViejo: sembrar(c.frailejonViejo, R.viejo[0], R.viejo[1], rng(seed + 13), { eMin: 1.05, eMax: 1.55, varia: 0.14, lean: 0.18 }),
+    frailejonFlor: sembrar(c.frailejonFlor, R.flor[0], R.flor[1], rng(seed + 2), { eMin: 1.0, eMax: 1.45, varia: 0.1, lean: 0.13 }),
     // Sotobosque.
-    mortino: sembrar(c.mortino, 4, 12, rng(seed + 3), { eMin: 0.8, eMax: 1.2, varia: 0.12 }),
-    romerillo: sembrar(c.romerillo, 3, 12, rng(seed + 4), { eMin: 0.8, eMax: 1.25, varia: 0.14 }),
+    mortino: sembrar(c.mortino, R.mortino[0], R.mortino[1], rng(seed + 3), { eMin: 0.8, eMax: 1.2, varia: 0.12 }),
+    romerillo: sembrar(c.romerillo, R.romerillo[0], R.romerillo[1], rng(seed + 4), { eMin: 0.8, eMax: 1.25, varia: 0.14 }),
     // Suelo.
-    roca: sembrar(c.roca, 2, 11, rng(seed + 5), { eMin: 0.7, eMax: 1.5, varia: 0.1 }),
-    musgo: sembrar(c.musgo, 1.2, 9, rng(seed + 6), { eMin: 0.7, eMax: 1.6, varia: 0.12 }),
+    roca: sembrar(c.roca, R.roca[0], R.roca[1], rng(seed + 5), { eMin: 0.7, eMax: 1.5, varia: 0.1 }),
+    musgo: sembrar(c.musgo, R.musgo[0], R.musgo[1], rng(seed + 6), { eMin: 0.7, eMax: 1.6, varia: 0.12 }),
     // Árboles de fondo (anillo exterior, reparto parejo, velados por niebla).
-    gaque: sembrar(c.gaque, 8.5, 14, rng(seed + 7), { eMin: 0.9, eMax: 1.1, uniforme: true, varia: 0.08 }),
-    roble: sembrar(c.roble, 9.5, 16, rng(seed + 8), { eMin: 0.92, eMax: 1.15, uniforme: true, varia: 0.08 }),
-    encenillo: sembrar(c.encenillo, 10, 17, rng(seed + 9), { eMin: 0.85, eMax: 1.1, uniforme: true, varia: 0.08 }),
-    yarumo: sembrar(c.yarumo, 10, 17, rng(seed + 10), { eMin: 0.9, eMax: 1.15, uniforme: true, varia: 0.06 }),
-    aliso: sembrar(c.aliso, 11, 19, rng(seed + 11), { eMin: 0.9, eMax: 1.12, uniforme: true, varia: 0.08 }),
+    gaque: sembrar(c.gaque, R.gaque[0], R.gaque[1], rng(seed + 7), { eMin: 0.9, eMax: 1.1, uniforme: true, varia: 0.08 }),
+    roble: sembrar(c.roble, R.roble[0], R.roble[1], rng(seed + 8), { eMin: 0.92, eMax: 1.15, uniforme: true, varia: 0.08 }),
+    encenillo: sembrar(c.encenillo, R.encenillo[0], R.encenillo[1], rng(seed + 9), { eMin: 0.85, eMax: 1.1, uniforme: true, varia: 0.08 }),
+    yarumo: sembrar(c.yarumo, R.yarumo[0], R.yarumo[1], rng(seed + 10), { eMin: 0.9, eMax: 1.15, uniforme: true, varia: 0.06 }),
+    aliso: sembrar(c.aliso, R.aliso[0], R.aliso[1], rng(seed + 11), { eMin: 0.9, eMax: 1.12, uniforme: true, varia: 0.08 }),
   };
 }

--- a/src/visual/mundo3d/bosque/floraParamo.geom.js
+++ b/src/visual/mundo3d/bosque/floraParamo.geom.js
@@ -78,21 +78,30 @@ import {
  * guadua, nogal, cedro, cámbulo, gualanday, siete cueros, helecho, heliconia,
  * quiche). Por eso se subieron los árboles y se bajaron los frailejones.
  */
+/*
+ * REDISEÑO 2026-07-20 (páramo espectacular, dir. Jackson): el operador revierte
+ * la degradación del 07-16 para ESTE claro. El frailejón vuelve a ser el
+ * PROTAGONISTA visual: un frailejonal DENSO que impone en primer plano, con una
+ * banda HÉROE de adultos f3 (enagua + roseta plateada + flor) grandes y cercanos.
+ * La queñua (Ent) sigue siendo la guardiana del centro — no se toca su rol.
+ *   · frailejonHero: los gigantes de primer plano (3-4 m), la firma del páramo.
+ *   · el resto de edades puebla el frailejonal alrededor (gradiente de edad).
+ */
 export const FLORA_TIER = {
   alto: {
-    frailejonJoven: 4, frailejon: 4, frailejonViejo: 2, frailejonFlor: 2,
+    frailejonHero: 7, frailejonJoven: 9, frailejon: 8, frailejonViejo: 5, frailejonFlor: 4,
     yarumo: 5, roble: 5, encenillo: 6,
-    aliso: 5, gaque: 4, mortino: 14, romerillo: 14, roca: 9, musgo: 12, niebla: 3,
+    aliso: 5, gaque: 4, mortino: 16, romerillo: 16, roca: 10, musgo: 20, niebla: 3,
   },
   medio: {
-    frailejonJoven: 2, frailejon: 3, frailejonViejo: 1, frailejonFlor: 1,
+    frailejonHero: 4, frailejonJoven: 5, frailejon: 5, frailejonViejo: 2, frailejonFlor: 2,
     yarumo: 3, roble: 3, encenillo: 3,
-    aliso: 3, gaque: 2, mortino: 8, romerillo: 8, roca: 5, musgo: 6, niebla: 0,
+    aliso: 3, gaque: 2, mortino: 9, romerillo: 9, roca: 5, musgo: 10, niebla: 0,
   },
   bajo: {
-    frailejonJoven: 1, frailejon: 2, frailejonViejo: 0, frailejonFlor: 0,
+    frailejonHero: 2, frailejonJoven: 2, frailejon: 3, frailejonViejo: 1, frailejonFlor: 0,
     yarumo: 2, roble: 2, encenillo: 1,
-    aliso: 1, gaque: 0, mortino: 3, romerillo: 3, roca: 2, musgo: 3, niebla: 0,
+    aliso: 1, gaque: 0, mortino: 3, romerillo: 3, roca: 2, musgo: 4, niebla: 0,
   },
 };
 
@@ -851,6 +860,74 @@ export function geomMusgo(seed = 10) {
 }
 
 /* -------------------------------------------------------------------------- */
+/*  FIGURA DE ESCALA — un campesino pequeño al pie del frailejonal              */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La lente Shadow of the Colossus: la escala inmensa NO se siente por tamaño
+ * absoluto sino por CONTRASTE con una figura conocida. Un campesino de ~1.7 m
+ * con ruana y sombrero, quieto al pie de un frailejón héroe, le da la vara de
+ * medir al ojo — recién ahí el frailejón de 3-4 m se lee "gigante que tardó un
+ * siglo". Low-poly, silueta legible a distancia, mira al frailejonal. Color
+ * horneado en vertexColors como toda la flora (mismo material compartido).
+ * Anti-leak: figura genérica, sin rostro ni rasgos identificables.
+ */
+const PAL_FIG = {
+  ruana: '#8a3b2e', // ruana rojo-tierra andina
+  ruana2: '#6e2f24', // pliegue en sombra
+  pantalon: '#3a3428',
+  bota: '#241f18',
+  piel: '#a8794f',
+  sombrero: '#c8a768', // paja
+  sombreroCinta: '#59452f',
+};
+
+/** Un campesino de ~1.75 unidades (mira a +Z). Pieza única, no instanciada. */
+export function geomCampesinoEscala(seed = 44) {
+  const r = rng(seed);
+  const partes = [];
+  // Piernas + botas.
+  for (const lado of [-1, 1]) {
+    const pierna = new THREE.CylinderGeometry(0.072, 0.088, 0.72, 6, 1);
+    poner(pierna, [lado * 0.1, 0.4, 0]);
+    partes.push(pintar(pierna, PAL_FIG.pantalon));
+    const bota = new THREE.CylinderGeometry(0.095, 0.11, 0.15, 6, 1);
+    poner(bota, [lado * 0.1, 0.075, 0.03]);
+    partes.push(pintar(bota, PAL_FIG.bota));
+  }
+  // Torso bajo la ruana.
+  const torso = new THREE.CylinderGeometry(0.17, 0.2, 0.5, 7, 1);
+  poner(torso, [0, 1.02, 0]);
+  partes.push(pintar(torso, PAL_FIG.ruana2));
+  // La RUANA: manto que cae en trapecio ancho desde los hombros (la firma andina).
+  const ruana = new THREE.CylinderGeometry(0.26, 0.4, 0.66, 6, 1);
+  poner(ruana, [0, 1.06, 0], [0, Math.PI / 6, 0]);
+  partes.push(pintar(ruana, variar(PAL_FIG.ruana, r, 0.05)));
+  // Hombros redondeados de la ruana (le da cuerpo humano, no cono).
+  const hombros = new THREE.SphereGeometry(0.28, 8, 6, 0, Math.PI * 2, 0, Math.PI * 0.55);
+  poner(hombros, [0, 1.3, 0], [0, 0, 0], [1, 0.7, 0.85]);
+  partes.push(pintar(hombros, variar(PAL_FIG.ruana, r, 0.05)));
+  // Cuello + cabeza.
+  const cuello = new THREE.CylinderGeometry(0.06, 0.07, 0.1, 6, 1);
+  poner(cuello, [0, 1.44, 0]);
+  partes.push(pintar(cuello, PAL_FIG.piel));
+  const cabeza = new THREE.SphereGeometry(0.125, 10, 8);
+  poner(cabeza, [0, 1.57, 0], [0, 0, 0], [1, 1.08, 1]);
+  partes.push(pintar(cabeza, PAL_FIG.piel));
+  // Sombrero: ala + copa + cinta (silueta de sombrero campesino).
+  const ala = new THREE.CylinderGeometry(0.28, 0.28, 0.03, 14, 1);
+  poner(ala, [0, 1.65, 0]);
+  partes.push(pintar(ala, PAL_FIG.sombrero));
+  const copa = new THREE.CylinderGeometry(0.135, 0.155, 0.15, 12, 1);
+  poner(copa, [0, 1.73, 0]);
+  partes.push(pintar(copa, PAL_FIG.sombrero));
+  const cinta = new THREE.CylinderGeometry(0.158, 0.158, 0.045, 12, 1);
+  poner(cinta, [0, 1.68, 0]);
+  partes.push(pintar(cinta, PAL_FIG.sombreroCinta));
+  return fusionarSeguro(partes, 'campesino-escala');
+}
+
+/* -------------------------------------------------------------------------- */
 /*  DISTRIBUCIÓN biogeográfica alrededor del Ent                               */
 /* -------------------------------------------------------------------------- */
 
@@ -904,14 +981,19 @@ function sembrar(n, rMin, rMax, r, opts = {}) {
 export function distribucionFlora(conteos, seed = 707) {
   const c = conteos;
   return {
-    // Frailejonal: TRES edades entremezcladas en el mismo anillo interior-medio,
-    // agrupadas, con mucha variación de tamaño + ladeo por instancia (`lean`) →
-    // un paisaje con gradiente de edad, nada clonado. Los jóvenes se acercan más
-    // al claro (rMin menor); los viejos quedan un poco más afuera.
-    frailejonJoven: sembrar(c.frailejonJoven, 3.4, 9.5, rng(seed + 1), { eMin: 0.78, eMax: 1.12, varia: 0.13, lean: 0.14 }),
-    frailejon: sembrar(c.frailejon, 3.8, 10.5, rng(seed + 12), { eMin: 0.86, eMax: 1.22, varia: 0.14, lean: 0.15 }),
-    frailejonViejo: sembrar(c.frailejonViejo, 4.4, 11, rng(seed + 13), { eMin: 0.9, eMax: 1.3, varia: 0.14, lean: 0.17 }),
-    frailejonFlor: sembrar(c.frailejonFlor, 4.5, 9.5, rng(seed + 2), { eMin: 0.9, eMax: 1.2, varia: 0.1, lean: 0.12 }),
+    // Banda HÉROE (2026-07-20): los gigantes de PRIMER PLANO. Un anillo cercano y
+    // parejo (uniforme) de adultos GRANDES (esc 1.5-1.95 → 3-4 m) que rodea el
+    // claro a media distancia: desde cualquier ángulo de órbita, varios quedan
+    // enmarcando la cámara e IMPONEN. Ladeo generoso para que ninguno se lea
+    // clonado. Son la firma del páramo — el personaje principal, por fin visible.
+    frailejonHero: sembrar(c.frailejonHero, 5.5, 9.5, rng(seed + 21), { eMin: 1.5, eMax: 1.95, uniforme: true, varia: 0.12, lean: 0.16 }),
+    // Frailejonal de acompañamiento: TRES edades entremezcladas, agrupadas y
+    // ACERCADAS al claro (rMin bajado desde el rediseño 07-16) con mucha
+    // variación de tamaño + ladeo → gradiente de edad denso, nada clonado.
+    frailejonJoven: sembrar(c.frailejonJoven, 2.6, 8.5, rng(seed + 1), { eMin: 0.8, eMax: 1.18, varia: 0.13, lean: 0.15 }),
+    frailejon: sembrar(c.frailejon, 3.0, 9.5, rng(seed + 12), { eMin: 0.95, eMax: 1.4, varia: 0.14, lean: 0.16 }),
+    frailejonViejo: sembrar(c.frailejonViejo, 3.4, 10.5, rng(seed + 13), { eMin: 1.05, eMax: 1.55, varia: 0.14, lean: 0.18 }),
+    frailejonFlor: sembrar(c.frailejonFlor, 3.2, 9, rng(seed + 2), { eMin: 1.0, eMax: 1.45, varia: 0.1, lean: 0.13 }),
     // Sotobosque.
     mortino: sembrar(c.mortino, 4, 12, rng(seed + 3), { eMin: 0.8, eMax: 1.2, varia: 0.12 }),
     romerillo: sembrar(c.romerillo, 3, 12, rng(seed + 4), { eMin: 0.8, eMax: 1.25, varia: 0.14 }),

--- a/src/visual/mundo3d/bosque/floraParamo.geom.js
+++ b/src/visual/mundo3d/bosque/floraParamo.geom.js
@@ -123,12 +123,12 @@ export const calidadDeTier = (tier) => CALIDAD_TIER[tier] ?? CALIDAD_TIER.medio;
 export const PAL = {
   // Frailejón
   frailejonTronco: '#6f5c40', // tallo bajo la enagua
-  frailejonSeco: '#9a7f57', // enagua: marcescentes pajizas (arriba, recientes)
-  frailejonSeco2: '#67502f', // marcescentes viejas curtidas (abajo, oscuras)
-  frailejonSeco3: '#7f6640', // tono intermedio dorado-marrón (variedad)
-  frailejonPlata: '#d7dccf', // roseta centro: tomento plateado-blanco (la firma)
-  frailejonPlata2: '#a9b593', // hojas externas: plateado-salvia apagado (viejas)
-  frailejonCorazon: '#e9eee2', // cogollo velloso central (el punto más pálido)
+  frailejonSeco: '#8f7550', // enagua: marcescentes pajizas (arriba, recientes)
+  frailejonSeco2: '#6f5a3a', // marcescentes viejas curtidas (abajo) — poco contraste
+  frailejonSeco3: '#7f6845', // tono intermedio dorado-marrón (variedad)
+  frailejonPlata: '#c2cdab', // roseta: tomento plateado-SALVIA (verde plata, no blanco)
+  frailejonPlata2: '#9fac86', // hojas externas: plateado-salvia apagado (viejas)
+  frailejonCorazon: '#d6dec2', // cogollo velloso central (salvia pálido, NO blanco)
   frailejonFlor: '#e6c84e', // capítulos amarillos
   frailejonTallo: '#93a06a', // escapo floral
 
@@ -373,28 +373,30 @@ export function geomFrailejon({ flor = false, q = 1, edad = 0.6 } = {}, seed = 1
   //    superpuestas como tejas de la base a la roseta. Cuanto más abajo, más
   //    viejas y oscuras. El número de anillos escala con la altura (el viejo
   //    lleva hábito largo; el joven, apenas un faldón).
-  const anillos = Math.max(2, Math.round((Ht / 0.24) * q));
-  const porAnillo = Math.max(6, Math.round(10 * q));
+  // La enagua es un FALDÓN GREÑUDO de tiras secas colgando (thatch), NO cestería:
+  // ángulo con jitter fuerte + giro por tira → se cruzan orgánicas, nunca en malla
+  // regular. Tiras ANCHAS y muy aplanadas que cuelgan casi a plomo, pardas
+  // homogéneas (sin el damero claro/oscuro que delataba el tejido).
+  const anillos = Math.max(3, Math.round((Ht / 0.17) * q));
+  const porAnillo = Math.max(8, Math.round(12 * q));
   for (let a = 0; a < anillos; a++) {
     const f = a / anillos; // 0 base(vieja) → 1 bajo la roseta(reciente)
-    const y = 0.1 + f * (Ht - 0.06);
-    const rad = 0.15;
+    const y = 0.06 + f * (Ht - 0.02);
+    const rad = 0.14;
     for (let i = 0; i < porAnillo; i++) {
-      const ang = (i / porAnillo) * Math.PI * 2 + a * 0.55;
-      const largo = 0.32 + r() * 0.16;
-      // lámina seca ancha (6 lados, aplanada) colgando casi a plomo y algo afuera.
-      const hoja = new THREE.ConeGeometry(0.11, largo, 6, 1);
+      const ang = (i / porAnillo) * Math.PI * 2 + (r() - 0.5) * 1.15;
+      const largo = 0.34 + r() * 0.24;
+      const cae = 0.1 + r() * 0.16; // cuánto se abre de la vertical (poco)
+      const hoja = new THREE.ConeGeometry(0.15 + r() * 0.035, largo, 5, 1);
       apuntar(
         hoja,
         [Math.cos(ang) * rad, y, Math.sin(ang) * rad],
-        [Math.cos(ang) * 0.32, -1, Math.sin(ang) * 0.32],
-        [1, 1, 0.5],
+        [Math.cos(ang) * cae, -1, Math.sin(ang) * cae],
+        [1, 1, 0.3],
+        (r() - 0.5) * 0.9,
       );
-      // pajiza arriba (reciente) → curtida oscura abajo (vieja), con variedad.
-      const tono = f > 0.55
-        ? (r() > 0.5 ? PAL.frailejonSeco : PAL.frailejonSeco3)
-        : (r() > 0.5 ? PAL.frailejonSeco3 : PAL.frailejonSeco2);
-      partes.push(pintar(hoja, variar(tono, r, 0.12)));
+      const tono = r() > 0.6 ? PAL.frailejonSeco : (r() > 0.4 ? PAL.frailejonSeco3 : PAL.frailejonSeco2);
+      partes.push(pintar(hoja, variar(tono, r, 0.08)));
     }
   }
 
@@ -402,18 +404,20 @@ export function geomFrailejon({ flor = false, q = 1, edad = 0.6 } = {}, seed = 1
   //    redonda, nunca cerdas) en espiral áurea sobre una cúpula, erguidas al
   //    centro y recostadas al borde, muy densas → una bola velluda plateada.
   //    Tomento horneado en gradiente (base salvia → punta casi blanca).
-  const nRoseta = Math.max(18, Math.round(38 * q));
+  const nRoseta = Math.max(16, Math.round(32 * q));
   const wSeg = Math.max(5, Math.round(6 * q));
   const hSeg = Math.max(3, Math.round(4 * q));
   const plataInt = new THREE.Color(PAL.frailejonPlata);
   const plataExt = new THREE.Color(PAL.frailejonPlata2);
+  // Roseta = CUENCO ancho y aplanado de hojas que RADIAN (no una bola): las
+  // externas se recuestan casi horizontales (estrella), el centro apenas erguido.
   const hojaRoseta = (f, ang, extraTilt = 0) => {
-    const posR = (0.02 + f * 0.12) * rosF; // nacen sobre una cúpula, no de un punto
-    const posY = cy - f * 0.1 * rosF; // borde más bajo → domo redondo
-    const tilt = 0.2 + f * 0.62 + (r() - 0.5) * 0.09 + extraTilt; // cuenco 11°→47°
+    const posR = (0.03 + f * 0.19) * rosF; // nacen sobre una cúpula ANCHA
+    const posY = cy - f * 0.17 * rosF; // borde bien caído → cuenco plano, no domo
+    const tilt = 0.34 + f * 0.86 + (r() - 0.5) * 0.1 + extraTilt; // 19°→~69° (se abren)
     const s = Math.sin(tilt);
-    const largo = (0.27 + (1 - f) * 0.13 + r() * 0.05) * rosF; // cortas y llenas
-    const hoja = petalo((0.1 + f * 0.02) * rosF, largo, 0.06, wSeg, hSeg);
+    const largo = (0.3 + (1 - f) * 0.1 + r() * 0.05) * rosF; // anchas y llenas
+    const hoja = petalo((0.12 + f * 0.03) * rosF, largo, 0.05, wSeg, hSeg);
     const base = variar(plataInt.clone().lerp(plataExt, f), r, 0.05);
     pintarGradiente(hoja, base, PAL.frailejonCorazon, 0, largo);
     apuntar(
@@ -441,7 +445,7 @@ export function geomFrailejon({ flor = false, q = 1, edad = 0.6 } = {}, seed = 1
     const s = Math.sin(tilt);
     const largoC = (0.16 + r() * 0.05) * rosF;
     const hoja = petalo(0.072 * rosF, largoC, 0.052, wSeg, hSeg);
-    pintarGradiente(hoja, variar(PAL.frailejonPlata, r, 0.04), '#f3f6ee', 0, largoC);
+    pintarGradiente(hoja, variar(PAL.frailejonPlata, r, 0.04), '#e2e8d0', 0, largoC);
     apuntar(
       hoja,
       [Math.cos(ang) * 0.025, cy + 0.04, Math.sin(ang) * 0.025],
@@ -981,12 +985,13 @@ function sembrar(n, rMin, rMax, r, opts = {}) {
 export function distribucionFlora(conteos, seed = 707) {
   const c = conteos;
   return {
-    // Banda HÉROE (2026-07-20): los gigantes de PRIMER PLANO. Un anillo cercano y
-    // parejo (uniforme) de adultos GRANDES (esc 1.5-1.95 → 3-4 m) que rodea el
-    // claro a media distancia: desde cualquier ángulo de órbita, varios quedan
-    // enmarcando la cámara e IMPONEN. Ladeo generoso para que ninguno se lea
-    // clonado. Son la firma del páramo — el personaje principal, por fin visible.
-    frailejonHero: sembrar(c.frailejonHero, 5.5, 9.5, rng(seed + 21), { eMin: 1.5, eMax: 1.95, uniforme: true, varia: 0.12, lean: 0.16 }),
+    // Banda HÉROE (2026-07-20): los gigantes de PRIMER PLANO. Un anillo CERCANO y
+    // parejo (uniforme) de adultos GRANDES (esc 1.65-2.15 → 3.5-4.5 m) que rodea
+    // el claro pegado a la cámara: desde cualquier ángulo de órbita, varios
+    // quedan enmarcando el cuadro e IMPONEN por delante de la queñua. Ladeo
+    // generoso para que ninguno se lea clonado. La firma del páramo, por fin al
+    // frente. (El proscenio fijo de FloraParamo.jsx garantiza el trío foreground.)
+    frailejonHero: sembrar(c.frailejonHero, 6.0, 10.5, rng(seed + 21), { eMin: 1.65, eMax: 2.15, uniforme: true, varia: 0.12, lean: 0.16 }),
     // Frailejonal de acompañamiento: TRES edades entremezcladas, agrupadas y
     // ACERCADAS al claro (rMin bajado desde el rediseño 07-16) con mucha
     // variación de tamaño + ladeo → gradiente de edad denso, nada clonado.


### PR DESCRIPTION
## Qué

Segunda pasada al páramo (sobre la 1a `fable/paramo-espectacular-jackson`). El frailejón vuelve a la escena en la 1a pasada, pero **no dominaba**: compartía cuadro con demasiados árboles verdes y el claro leía como bosque altoandino denso, no como la planicie abierta del páramo. Tres revisiones visuales independientes coincidieron.

Bioma real (lente Humboldt/Agrosavia): el páramo sobre 3500 m es **planicie abierta con frailejonal disperso, cielo grande y pocos árboles** (la queñua/Polylepis sube como acento, no como bosque).

## Cambios

- **Se retira `DoselBiodiverso`** de `EscenaBosqueVivo`: ese dosel andino/subandino de tres estratos (guadua, cámbulo, gualanday, siete cueros, heliconia, helecho arbóreo, quiche) es un **error de bioma** sobre 3500 m — ~180 plantas que convertían la planicie en bosque denso y sepultaban el frailejón. Solo se usaba en esta escena.
- **`FloraParamo` estrena `bioma="paramo"`** (`raleParamo` + `distribucionFlora` consciente del bioma): rala el cortejo de árboles a unos pocos acentos velados en el anillo lejano y **potencia/dispersa el frailejonal** por la planicie (más héroes y edades, radios abiertos). El default `bioma="bosque"` **preserva `EscenaEntMaestro`** sin tocarla.
- **Se rala el queñual** (`CUPO_QUENUAL`: 2 cerca + 4 lejos) y se baja la escala colosal de las queñuas lejanas: la queñua queda de **acento/guardián**, no de bosque que compite. `bosqueTakeA.geom` solo lo usa esta escena.
- **Se abre el encuadre de reposo**: cámara más alta mirando un pelo hacia abajo → el frailejonal se despliega en abanico hacia un horizonte bajo con cielo grande.

Se conserva lo bueno de la 1a pasada: roseta plateada, enagua, niebla que respira (marea), rayos colados, campesino de escala.

## Verificación

Build verde. Captura headless (chromium swiftshader, `reducedMotion`) en reposo confirmó que **en mañana, tarde y atardecer el frailejón domina primer plano y media distancia**, con la queñua Ent de guardián al fondo y planicie abierta en los flancos.

- No toca `Valle3D.jsx` ni `composicionValle3D.jsx`.
- Sin nuevos riesgos de `mergeGeometries` null (no se tocó geometría de frailejón, solo conteos/radios y se retiró un componente).

**Captura en reposo:** ruta `#/mockups/bosque-vivo-3d`, query ANTES del hash. Recomendado `?ciclo=8.5` (mañana, cielo abierto) o `?ciclo=15.5` (tarde, rayos cálidos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)