### PR TITLE
feat(valle): cablear perros de la casa

### DIFF
--- a/src/mockups/valle/PerrosValle.jsx
+++ b/src/mockups/valle/PerrosValle.jsx
@@ -1,0 +1,75 @@
+/*
+ * Los perros de la casa en el valle: dos billboards rubber-hose livianos,
+ * posados sobre el terreno y con aire suficiente para que cada raza se lea.
+ * Viven en todos los tiers; los componentes de criatura podan su movimiento
+ * internamente y reducedMotion los deja en un fotograma quieto.
+ */
+import { Html } from '@react-three/drei';
+import { Dalmata } from '../../visual/creatures/Dalmata.jsx';
+import { Beagle } from '../../visual/creatures/Beagle.jsx';
+
+const PERROS = [
+  {
+    id: 'oliver-dalmata',
+    Component: Dalmata,
+    punto: [-2.5, 3.25],
+    px: 42,
+    factor: 7.8,
+    dy: 0.36,
+  },
+  {
+    id: 'dante-beagle',
+    Component: Beagle,
+    punto: [0.85, 3.85],
+    px: 38,
+    factor: 7.4,
+    dy: 0.3,
+  },
+];
+
+function PerroBillboard({ perro, alturaDe, tier, animated }) {
+  const { Component } = perro;
+  const [x, z] = perro.punto;
+  const y = (alturaDe ? alturaDe(x, z) : 0) + perro.dy;
+
+  return (
+    <group position={[x, y, z]}>
+      <Html center distanceFactor={perro.factor} zIndexRange={[6, 0]} pointerEvents="none">
+        <div className="valle-critter" data-perro={perro.id} aria-hidden="true">
+          <Component
+            size={perro.px}
+            animated={animated}
+            tier={tier}
+            vida={animated}
+          />
+        </div>
+      </Html>
+    </group>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {(x:number, z:number) => number} props.alturaDe
+ * @param {'bajo'|'medio'|'alto'} [props.tier='alto']
+ * @param {boolean} [props.reducedMotion=false]
+ */
+export function PerrosValle({ alturaDe, tier = 'alto', reducedMotion = false }) {
+  const animated = !reducedMotion;
+
+  return (
+    <group>
+      {PERROS.map((perro) => (
+        <PerroBillboard
+          key={perro.id}
+          perro={perro}
+          alturaDe={alturaDe}
+          tier={tier}
+          animated={animated}
+        />
+      ))}
+    </group>
+  );
+}
+
+export default PerrosValle;

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -60,6 +60,7 @@ import ArrieriaValle from './ArrieriaValle.jsx';
 import AguaVivaValle from './AguaVivaValle.jsx';
 import DetalleSueloValle from './DetalleSueloValle.jsx';
 import { CampesinosValle } from './CampesinosValle.jsx';
+import { PerrosValle } from './PerrosValle.jsx';
 import HatoMovil from './HatoMovil.jsx';
 /* Árboles POR ESPECIE (no genéricos): las mismas mallas del bosque altoandino
    (roble, aliso, gaque) que ya viven en floraParamo — cada árbol se distingue. */
@@ -1647,7 +1648,6 @@ function CompaneroAbeja({ foco, focoId = null, entrando, animo, energia, reduced
     };
     // `entrando` vive en entrandoRef a propósito: un viaje real no debe
     // reiniciar la cadencia del husmeo autónomo.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reducedMotion, entrarMundoAngelita, reposarAngelita]);
 
   useFrame((state) => {
@@ -2484,6 +2484,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = nu
           haba, cubio, arracacha + barbecho), cerca de piedra, camino y abrigo. */}
       <LaderaAltaValle alturaDe={alturaTerreno} tier={tier} nocturno={nocturno} reducedMotion={reducedMotion} />
       {!portada && <CampesinosValle alturaDe={alturaTerreno} tier={tier} reducedMotion={reducedMotion} />}
+      {!portada && <PerrosValle alturaDe={alturaTerreno} tier={tier} reducedMotion={reducedMotion} />}
       {!portada && <HatoMovil alturaDe={alturaTerreno} tier={tier === 'alto' ? 10 : tier === 'bajo' ? 4 : 7} radio={4.8} reducedMotion={reducedMotion} />}
       {/* LOGÍSTICA VISIBLE (alma Settlers): la mula acarrea estiércol→pila,
           compost→eras y cosecha→casa por los senderos, y las pilas crecen. */}

--- a/src/mockups/valle/__tests__/PerrosValle.test.jsx
+++ b/src/mockups/valle/__tests__/PerrosValle.test.jsx
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@react-three/drei', () => ({
+  Html: ({ children, distanceFactor }) => (
+    <div data-testid="html-billboard" data-distance-factor={distanceFactor}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../../../visual/creatures/Dalmata.jsx', () => ({
+  Dalmata: (props) => <i data-testid="dalmata" data-props={JSON.stringify(props)} />,
+}));
+
+vi.mock('../../../visual/creatures/Beagle.jsx', () => ({
+  Beagle: (props) => <i data-testid="beagle" data-props={JSON.stringify(props)} />,
+}));
+
+import { PerrosValle } from '../PerrosValle.jsx';
+
+afterEach(cleanup);
+
+function propsDe(elemento) {
+  return JSON.parse(elemento.getAttribute('data-props'));
+}
+
+describe('PerrosValle', () => {
+  test('monta un dalmata y un beagle separados y posados en el terreno', () => {
+    const alturaDe = vi.fn(() => 2);
+    const { container, getAllByTestId, getByTestId } = render(
+      <PerrosValle alturaDe={alturaDe} tier="medio" />,
+    );
+
+    expect(getAllByTestId('html-billboard')).toHaveLength(2);
+    expect(container.querySelectorAll('.valle-critter[data-perro]')).toHaveLength(2);
+    expect(alturaDe.mock.calls).toEqual([
+      [-2.5, 3.25],
+      [0.85, 3.85],
+    ]);
+
+    const [[x1, z1], [x2, z2]] = alturaDe.mock.calls;
+    expect(Math.hypot(x2 - x1, z2 - z1)).toBeGreaterThan(3);
+    expect(propsDe(getByTestId('dalmata'))).toMatchObject({
+      size: 42,
+      animated: true,
+      tier: 'medio',
+      vida: true,
+    });
+    expect(propsDe(getByTestId('beagle'))).toMatchObject({
+      size: 38,
+      animated: true,
+      tier: 'medio',
+      vida: true,
+    });
+  });
+
+  test('congela la vida de ambos perros con movimiento reducido', () => {
+    const { getByTestId } = render(
+      <PerrosValle alturaDe={() => 0} tier="bajo" reducedMotion />,
+    );
+
+    expect(propsDe(getByTestId('dalmata'))).toMatchObject({
+      animated: false,
+      tier: 'bajo',
+      vida: false,
+    });
+    expect(propsDe(getByTestId('beagle'))).toMatchObject({
+      animated: false,
+      tier: 'bajo',
+      vida: false,
+    });
+  });
+
+  test('queda conectado a la escena del valle con el mismo contrato', () => {
+    const vallePath = resolve('src/mockups/valle/Valle3D.jsx');
+    const valleSource = readFileSync(vallePath, 'utf8');
+
+    expect(valleSource).toMatch(
+      /import\s+\{\s*PerrosValle\s*\}\s+from\s+'\.\/PerrosValle\.jsx';/,
+    );
+    expect(valleSource).toMatch(
+      /<PerrosValle\s+alturaDe=\{alturaTerreno\}\s+tier=\{tier\}\s+reducedMotion=\{reducedMotion\}\s*\/>/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- agrega PerrosValle con un dalmata y un beagle en billboards Html
- posa ambos con alturaDe y los mantiene separados cerca de la casa
- conecta tier y reducedMotion desde Valle3D

## Test plan
- npx vitest run src/mockups/valle/__tests__/PerrosValle.test.jsx
- npx eslint src/mockups/valle/PerrosValle.jsx src/mockups/valle/Valle3D.jsx src/mockups/valle/__tests__/PerrosValle.test.jsx --max-warnings=0
- npm run build
- npx vitest run (baseline: 780 archivos pasan, 35 fallan fuera de este cambio)
- npx eslint . --max-warnings=0 (el proceso global agota el heap cerca de 4 GB)