### PR TITLE
feat(bosque): tres estratos del bosque altoandino diferenciados por silueta

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -259,6 +259,10 @@ const JuegoLaMilpaMockup = lazy(() => import('./mockups/JuegoLaMilpa'));
 // 3D: el PÁRAMO altoandino — el ecosistema de la niebla (frailejones, musgo,
 // quenuas, aves) y el NACIMIENTO del agua. Didáctico: la fábrica de agua.
 const MundoParamo3DMockup = lazy(() => import('./mockups/MundoParamo3D'));
+// 3D: el BOSQUE nativo altoandino por ESTRATOS — los doce arquetipos de forma
+// de crecimiento con los que se representa el catálogo de flora sin modelar las
+// 581 especies una por una.
+const BosqueTresEstratos3DMockup = lazy(() => import('./mockups/BosqueTresEstratos3D'));
 const CamaraDirectorDemoMockup = lazy(() => import('./mockups/CamaraDirectorDemo'));
 const MomentoVentaMercado3DMockup = lazy(() => import('./mockups/MomentoVentaMercado3D'));
 const ArtesaniaAndinaDemoMockup = lazy(() => import('./mockups/ArtesaniaAndinaDemo'));
@@ -719,6 +723,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/valle-noche-3d': 'mockup_valle_noche_3d',
   'mockups/juego-la-milpa': 'mockup_juego_la_milpa',
   'mockups/mundo-paramo-3d': 'mockup_mundo_paramo_3d',
+  'mockups/bosque-tres-estratos': 'mockup_bosque_tres_estratos',
   'mockups/camara-director': 'mockup_camara_director',
   'mockups/momento-venta-mercado-3d': 'mockup_momento_venta_mercado_3d',
   'mockups/artesania-andina': 'mockup_artesania_andina',
@@ -2449,6 +2454,20 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El páramo altoandino">
               <MundoParamo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_bosque_tres_estratos':
+        // El bosque nativo altoandino por ESTRATOS: dosel (palma de cera,
+        // encenillo, cedro, nogal), sotobosque (mano de oso, helecho arbóreo,
+        // chusque, arbusto florecido, bejuco con bromelias) y suelo (helechos,
+        // hierba de sombra, cojines de musgo y hojarasca). Doce arquetipos de
+        // forma de crecimiento con los que se representa el catálogo de 581
+        // especies. Ruta #/mockups/bosque-tres-estratos, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El bosque nativo y sus tres estratos">
+              <BosqueTresEstratos3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/BosqueTresEstratos3D.jsx
+++ b/src/mockups/BosqueTresEstratos3D.jsx
@@ -1,0 +1,192 @@
+/*
+ * BosqueTresEstratos3D — la vitrina del bosque nativo altoandino y sus TRES
+ * ESTRATOS. Ruta #/mockups/bosque-tres-estratos, sin auth.
+ *
+ * De qué se trata
+ * ───────────────
+ * El catálogo de Chagra tiene 581 especies de flora. Dibujarlas una por una es
+ * imposible; dibujar DOCE FORMAS DE CRECIMIENTO sí, y con esas doce se puede
+ * mostrar el catálogo entero. Esta vitrina es esa prueba puesta en pie: un
+ * bosque altoandino armado solo con los doce arquetipos, repartidos en los tres
+ * pisos verticales que tiene un bosque de verdad.
+ *
+ *   · El DOSEL — el techo. La palma de cera asomando por encima de todo, el
+ *     cono invertido del encenillo, la mesa ancha del cedro, la bola del nogal.
+ *   · El SOTOBOSQUE — a media altura, a la sombra. El parasol del mano de oso,
+ *     el volante del helecho arbóreo, el abanico del chusque, el arbusto en
+ *     flor y el bejuco que sube cargando bromelias.
+ *   · El SUELO — lo rastrero. Helechos bajos, hierba de hoja ancha, cojines de
+ *     musgo y hojarasca.
+ *
+ * Los tres botones de abajo no son un filtro: dejan el bosque completo y
+ * apagan lo que no es el estrato señalado, para que el campesino vea de un
+ * golpe qué parte del bosque se está nombrando.
+ *
+ * Congruencia: paleta madre, materiales madre y `<LuzMadre>` con la familia de
+ * cielo `sotobosque`. Cero rig de luz propio (los dos mundos que lo tenían ya
+ * se convirtieron).
+ */
+import { useMemo, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import BosqueTresEstratos from '../visual/mundo3d/bosque/BosqueTresEstratos.jsx';
+import { ESTRATOS } from '../visual/mundo3d/bosque/estratosAltoandinos.geom.js';
+import { LuzMadre, CIELOS, mezclarCielo } from '../visual/mundo3d/paleta/index.js';
+import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
+
+/* La cámara se para en el CLARO, sobre la lomita, mirando la ORILLA del bosque
+   desde afuera y un poco desde arriba. Es la única posición desde la que los
+   tres pisos se apilan a la vista: metida entre los troncos uno solo ve fustes
+   y las copas quedan cortadas por el borde de la pantalla. Retroceder fue,
+   literalmente, lo que hizo visible la lección. */
+const CAM = /** @type {[number, number, number]} */ ([2.4, 8.6, 31]);
+const MIRA = /** @type {[number, number, number]} */ ([0, 7.2, -9]);
+
+const ORDEN = ['dosel', 'sotobosque', 'suelo'];
+
+const COPY_ENTERO =
+  'Así se ve un bosque altoandino: no es una masa de árboles iguales sino tres pisos, y cada piso vive de una luz distinta. Toque un piso para que se lo señale.';
+
+export default function BosqueTresEstratos3D() {
+  const [listo, setListo] = useState(false);
+  const [destacado, setDestacado] = useState(/** @type {string|null} */ (null));
+  const [neblina, setNeblina] = useState(true);
+
+  const { tier } = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () => typeof window !== 'undefined'
+      && typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const perfil = useMemo(() => perfilDeTier(tier), [tier]);
+
+  /* La atmósfera: la familia `sotobosque` mezclada 60 % hacia la madre, que es
+     la ley de la casa. El fondo y la niebla salen de ahí — ni un hex a mano. */
+  const cielo = useMemo(() => mezclarCielo(CIELOS.sotobosque), []);
+
+  const copia = destacado ? ESTRATOS[destacado].clave : COPY_ENTERO;
+
+  return (
+    <section
+      className="bte-root"
+      data-tier={tier}
+      aria-label="El bosque nativo altoandino y sus tres estratos"
+    >
+      <style>{CSS}</style>
+      <Canvas
+        className="bte-canvas"
+        /* El fundido va en estilo EN LÍNEA, no en una clase.
+           Construir las doce geometrías bloquea el hilo principal un momento;
+           con el fundido en clase, el navegador se quedaba con la opacidad en 0
+           mientras estaba bloqueado y la escena aparecía VACÍA — así salió la
+           primera captura, con el bosque entero dibujado y invisible. El estilo
+           en línea no depende de que el recálculo de CSS alcance a correr. */
+        style={{ opacity: listo ? 1 : 0, transition: 'opacity 0.9s ease' }}
+        dpr={perfil.dpr}
+        gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+        camera={{ position: CAM, fov: 46 }}
+        shadows={!!perfil.sombras}
+        frameloop={reducedMotion ? 'demand' : 'always'}
+        onCreated={() => setListo(true)}
+      >
+        <color attach="background" args={[cielo.fondo]} />
+        {/* La niebla empieza LEJOS. Con la niebla encima, el bosque entero se
+            lava en beige y los tres pisos se funden — que es justo lo contrario
+            de lo que esta vitrina existe para enseñar. Que vele el fondo, no el
+            rodal que uno está mirando. El botón la corre todavía más lejos. */}
+        {perfil.fog && (
+          <fog attach="fog" args={neblina ? [cielo.niebla, 30, 104] : [cielo.niebla, 76, 240]} />
+        )}
+
+        <LuzMadre
+          cielo={CIELOS.sotobosque}
+          perfil={perfil}
+          /* El sol entra rasante por el hombro izquierdo: en un bosque cerrado
+             la luz llega de lado y por arriba, nunca de frente. */
+          solPos={[-14, 26, 10]}
+          sombra={{ left: -26, right: 26, top: 26, bottom: -26, far: 76 }}
+        />
+
+        <BosqueTresEstratos
+          tier={tier}
+          perfil={perfil}
+          reducedMotion={reducedMotion}
+          destacado={destacado}
+        />
+
+        <OrbitControls
+          makeDefault
+          enablePan={false}
+          enableZoom
+          target={MIRA}
+          minDistance={9}
+          maxDistance={36}
+          /* Se puede mirar hacia arriba (al dosel) pero no meterse bajo tierra. */
+          minPolarAngle={0.32}
+          maxPolarAngle={1.46}
+          minAzimuthAngle={-0.85}
+          maxAzimuthAngle={0.85}
+          enableDamping
+          dampingFactor={0.08}
+          autoRotate={!reducedMotion && !destacado}
+          autoRotateSpeed={0.08}
+        />
+        <AdaptiveDpr pixelated />
+      </Canvas>
+
+      <div className="bte-chrome">
+        <h2 className="bte-titulo">
+          El bosque nativo: sus tres estratos
+          <small>Doce formas de crecimiento con las que se puede mostrar el catálogo entero</small>
+        </h2>
+
+        <div className="bte-pie">
+          <div className="bte-estratos" role="group" aria-label="Estratos del bosque">
+            {ORDEN.map((id) => (
+              <button
+                key={id}
+                type="button"
+                className="bte-boton"
+                aria-pressed={destacado === id}
+                onClick={() => setDestacado((v) => (v === id ? null : id))}
+              >
+                {ESTRATOS[id].nombre}
+              </button>
+            ))}
+            <button
+              type="button"
+              className="bte-boton bte-boton--tenue"
+              aria-pressed={neblina}
+              onClick={() => setNeblina((v) => !v)}
+            >
+              {neblina ? 'Quitar la neblina' : 'Poner la neblina'}
+            </button>
+          </div>
+          <p className="bte-carta" role="status">{copia}</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const CSS = `
+.bte-root { position: relative; width: 100%; height: 100dvh; min-height: 320px; overflow: hidden; background: #d7e6c9; }
+.bte-canvas { position: absolute; inset: 0; }
+.bte-chrome { position: absolute; inset: 0; z-index: 7; pointer-events: none; display: flex; flex-direction: column; justify-content: space-between; }
+.bte-titulo { margin: 0; padding: 0.9rem 1rem 0; color: #22301f; text-shadow: 0 1px 8px rgba(232,242,223,0.8); font: 700 1.18rem/1.2 system-ui, sans-serif; letter-spacing: 0.01em; }
+.bte-titulo small { display: block; font: 500 0.8rem/1.3 system-ui, sans-serif; opacity: 0.86; margin-top: 0.15rem; }
+.bte-pie { padding: 0 1rem 0.9rem; display: flex; flex-direction: column; align-items: center; gap: 0.55rem; }
+.bte-estratos { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 0.5rem; }
+.bte-carta { margin: 0; max-width: 34rem; text-align: center; padding: 0.5rem 0.95rem; border-radius: 0.7rem; background: rgba(28,40,26,0.66); backdrop-filter: blur(3px); color: #eff5e9; font: 500 0.8rem/1.5 system-ui, sans-serif; }
+.bte-boton { pointer-events: auto; appearance: none; border: 1px solid rgba(30,46,28,0.35); border-radius: 999px; padding: 0.44rem 1rem; background: rgba(236,244,228,0.86); color: #253320; font: 600 0.8rem/1.1 system-ui, sans-serif; cursor: pointer; backdrop-filter: blur(3px); transition: background 0.2s ease, border-color 0.2s ease; }
+.bte-boton:hover, .bte-boton:focus-visible { background: rgba(255,255,255,0.95); border-color: rgba(30,46,28,0.6); outline: none; }
+.bte-boton[aria-pressed='true'] { background: #cfe3c2; border-color: rgba(37,51,32,0.75); }
+.bte-boton--tenue { font-weight: 500; opacity: 0.9; }
+@media (max-width: 460px) {
+  .bte-titulo { font-size: 1.02rem; padding: 0.7rem 0.8rem 0; }
+  .bte-carta { font-size: 0.75rem; max-width: 100%; }
+  .bte-boton { padding: 0.4rem 0.8rem; font-size: 0.75rem; }
+}
+@media (prefers-reduced-motion: reduce) { .bte-canvas { transition: none !important; } }
+`;

--- a/src/visual/mundo3d/bosque/BosqueTresEstratos.jsx
+++ b/src/visual/mundo3d/bosque/BosqueTresEstratos.jsx
@@ -1,0 +1,251 @@
+/*
+ * BosqueTresEstratos — el bosque nativo altoandino montado por ESTRATOS.
+ *
+ * Consume `estratosAltoandinos.geom.js` (los doce arquetipos y la siembra) y lo
+ * pone en pie: un InstancedMesh por arquetipo, el suelo y el mecido de la
+ * vegetación.
+ *
+ * ── Presupuesto de dibujo ──────────────────────────────────────────────────
+ * Doce bancos + el suelo = TRECE draw-calls para todo el bosque,
+ * hayan 60 plantas o 600. Todo comparte UN material de color por vértice: el
+ * color vive horneado en la geometría (AO, gradiente de altura, contraluz), que
+ * es lo que permite que un teléfono barato dibuje un bosque de niebla.
+ *
+ * ── El mecido ──────────────────────────────────────────────────────────────
+ * Squash & stretch de rubber-hose, pero de bosque: el dosel cabecea amplio y
+ * lento porque le pega el viento de verdad; el sotobosque apenas se mueve
+ * porque está resguardado; el suelo NO se mueve (y además son cientos de
+ * instancias: no vale la pena tocarlas por frame). Con reduced-motion todo
+ * queda quieto.
+ */
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { useFrame } from '@react-three/fiber';
+import { crearMaterialVertexColors } from '../paleta/index.js';
+import { VERDES, TIERRAS, NEUTROS, mezclar } from '../paleta/paletaMadre.js';
+import {
+  ARQUETIPOS,
+  ESTRATOS,
+  CONSTRUCTORES,
+  CALIDAD,
+  alturaSuelo,
+  poblarBosque,
+} from './estratosAltoandinos.geom.js';
+
+/* Cuánto mece el viento a cada estrato (amplitud en radianes, período en s). */
+const MECIDO = {
+  dosel: { amp: 0.03, per: 4.6 },
+  sotobosque: { amp: 0.014, per: 3.4 },
+  suelo: { amp: 0, per: 1 },
+};
+
+/* ══════════════════════════════════════════════════════════════════════════
+   UN BANCO: todas las matas de UN arquetipo en un solo InstancedMesh
+   ══════════════════════════════════════════════════════════════════════════ */
+function Banco({ geo, mat, items, estrato, mece = false, castShadow = false }) {
+  const ref = useRef(null);
+  /* Se guardan los datos de cada instancia para poder recomponer la matriz en
+     el mecido sin volver a leer del atributo (que sería ida y vuelta a GPU). */
+  const datos = useMemo(
+    () => items.map((it) => ({
+      p: new THREE.Vector3(it.pos[0], it.pos[1], it.pos[2]),
+      s: new THREE.Vector3(it.escala[0], it.escala[1], it.escala[2]),
+      rotY: it.rotY,
+      tiltX: it.tilt[0],
+      tiltZ: it.tilt[1],
+      fase: it.semilla * Math.PI * 2,
+    })),
+    [items],
+  );
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !datos.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const col = new THREE.Color();
+    for (let i = 0; i < datos.length; i++) {
+      const d = datos[i];
+      e.set(d.tiltX, d.rotY, d.tiltZ);
+      q.setFromEuler(e);
+      m.compose(d.p, q, d.s);
+      mesh.setMatrixAt(i, m);
+      /* Tinte por instancia: ni dos matas del mismo verde. La variación es
+         chica (±6 %) — lo justo para que el rodal no se lea clonado. */
+      const v = 0.94 + ((d.fase * 37) % 1) * 0.12;
+      col.setRGB(v, v, v);
+      mesh.setColorAt(i, col);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [datos]);
+
+  const tmp = useMemo(
+    () => (mece
+      ? { m: new THREE.Matrix4(), q: new THREE.Quaternion(), e: new THREE.Euler() }
+      : null),
+    [mece],
+  );
+
+  useFrame(({ clock }) => {
+    if (!mece || !tmp) return;
+    const mesh = ref.current;
+    if (!mesh || !datos.length) return;
+    const t = clock.getElapsedTime();
+    const { amp, per } = MECIDO[estrato] || MECIDO.sotobosque;
+    const w = (Math.PI * 2) / per;
+    for (let i = 0; i < datos.length; i++) {
+      const d = datos[i];
+      /* Dos senos desfasados: el cabeceo no es un metrónomo. */
+      const a = Math.sin(t * w + d.fase) * amp;
+      const b = Math.sin(t * w * 0.61 + d.fase * 1.7) * amp * 0.7;
+      tmp.e.set(d.tiltX + a, d.rotY, d.tiltZ + b);
+      tmp.q.setFromEuler(tmp.e);
+      tmp.m.compose(d.p, tmp.q, d.s);
+      mesh.setMatrixAt(i, tmp.m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  });
+
+  if (!geo || !datos.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, datos.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+      receiveShadow={false}
+    />
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL SUELO — mantillo con parches de musgo, hundido en las hondonadas
+   ══════════════════════════════════════════════════════════════════════════ */
+function SueloBosque({ mat, extension }) {
+  const geo = useMemo(() => {
+    const lado = extension * 3.4; // debe pasarse de donde llega el rodal
+    const seg = 68;
+    const g = new THREE.PlaneGeometry(lado, lado, seg, seg);
+    g.rotateX(-Math.PI / 2);
+    const pos = g.attributes.position;
+    const colores = new Float32Array(pos.count * 3);
+    const c = new THREE.Color();
+    const mantillo = new THREE.Color(TIERRAS.mantillo);
+    const sombra = new THREE.Color(TIERRAS.mantilloSombra);
+    const musgo = new THREE.Color(mezclar(VERDES.paramoMusgo, NEUTROS.tinta, 0.3));
+    for (let i = 0; i < pos.count; i++) {
+      const x = pos.getX(i);
+      const z = pos.getZ(i);
+      const y = alturaSuelo(x, z);
+      pos.setY(i, y);
+      /* El musgo se agarra en lo húmedo (las hondonadas); el mantillo seco
+         queda en los lomos. Un piso de un solo pardo se ve a plástico —y si
+         además queda claro y anaranjado, el bosque de niebla se lee como
+         potrero polvoriento, que fue justo lo que pasó en la primera pasada. */
+      const humedo = Math.max(0, Math.min(1, 0.62 - y * 0.7));
+      c.copy(mantillo).lerp(sombra, 0.35 + humedo * 0.55);
+      const parche = (Math.sin(x * 0.9) * Math.cos(z * 0.75) + 1) * 0.5;
+      c.lerp(musgo, Math.min(0.88, 0.3 + humedo * parche * 1.35));
+      /* LA LUZ ES LA LECCIÓN. El claro recibe sol y su piso es claro; a medida
+         que uno se mete bajo el dosel el piso se apaga. Ese degradado, pintado
+         en el propio suelo, es lo que hace sentir que el techo del bosque está
+         cobrando su sombra — y de paso separa el claro del rodal sin una sola
+         línea dibujada. */
+      const enBosque = Math.max(0, Math.min(1, (2 - z) / 15));
+      c.multiplyScalar(0.92 - 0.36 * enBosque);
+      colores[i * 3] = c.r;
+      colores[i * 3 + 1] = c.g;
+      colores[i * 3 + 2] = c.b;
+    }
+    pos.needsUpdate = true;
+    g.setAttribute('color', new THREE.BufferAttribute(colores, 3));
+    g.computeVertexNormals();
+    return g;
+  }, [extension]);
+
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+
+  return <mesh geometry={geo} material={mat} receiveShadow />;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL BOSQUE COMPLETO
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @param {object} props
+ * @param {'alto'|'medio'|'bajo'} props.tier
+ * @param {{materialRico?:boolean, flatShading?:boolean, sombras?:boolean}} props.perfil
+ * @param {boolean} [props.reducedMotion]
+ * @param {string|null} [props.destacado]  id de estrato a destacar (los otros se
+ *   apagan un poco). Es la ayuda pedagógica: sirve para señalar «este es el
+ *   dosel» sin ocultar el resto del bosque.
+ */
+export default function BosqueTresEstratos({
+  tier = 'alto',
+  perfil,
+  reducedMotion = false,
+  destacado = null,
+  extension = 23,
+  seed = 4242,
+}) {
+  const q = CALIDAD[tier] ?? CALIDAD.medio;
+
+  /* Las doce geometrías: se construyen UNA vez por tier y se comparten entre
+     todas las instancias del arquetipo. */
+  const geos = useMemo(() => {
+    const out = {};
+    for (const arq of ARQUETIPOS) {
+      const construir = CONSTRUCTORES[arq.id];
+      if (!construir) continue;
+      out[arq.id] = construir({ q }, undefined);
+    }
+    return out;
+  }, [q]);
+
+  useEffect(() => () => {
+    Object.values(geos).forEach((g) => g && g.dispose());
+  }, [geos]);
+
+  const bancos = useMemo(() => poblarBosque({ tier, seed, extension }), [tier, seed, extension]);
+
+  /* UN material para todo el bosque (color por vértice horneado). */
+  const mat = useMemo(() => crearMaterialVertexColors(perfil), [perfil]);
+  useEffect(() => () => mat.dispose(), [mat]);
+
+  /* El apagado del estrato no destacado: se hace con un material gemelo más
+     oscuro, no tocando las geometrías (que son compartidas). */
+  const matApagado = useMemo(() => {
+    const m = crearMaterialVertexColors(perfil);
+    m.color = new THREE.Color('#5c6152'); // multiplica: baja valor y satura menos
+    return m;
+  }, [perfil]);
+  useEffect(() => () => matApagado.dispose(), [matApagado]);
+
+  const puedeMecer = !reducedMotion && tier !== 'bajo';
+
+  return (
+    <group name="bosque-tres-estratos">
+      <SueloBosque mat={mat} extension={extension} />
+
+      {ARQUETIPOS.map((arq) => {
+        const apagar = destacado && destacado !== arq.estrato;
+        return (
+          <Banco
+            key={arq.id}
+            geo={geos[arq.id]}
+            mat={apagar ? matApagado : mat}
+            items={bancos[arq.id] || []}
+            estrato={arq.estrato}
+            mece={puedeMecer && arq.estrato !== 'suelo'}
+            castShadow={!!perfil?.sombras && arq.estrato === 'dosel'}
+          />
+        );
+      })}
+    </group>
+  );
+}
+
+export { ESTRATOS, ARQUETIPOS };

--- a/src/visual/mundo3d/bosque/estratosAltoandinos.geom.js
+++ b/src/visual/mundo3d/bosque/estratosAltoandinos.geom.js
@@ -1,0 +1,1497 @@
+/*
+ * estratosAltoandinos.geom — LOS DOCE ARQUETIPOS DE FORMA DE CRECIMIENTO del
+ * bosque altoandino colombiano, repartidos en sus TRES ESTRATOS verticales.
+ *
+ * ── Por qué existe este módulo ─────────────────────────────────────────────
+ * El catálogo de Chagra tiene 581 especies de flora. Modelarlas una por una es
+ * imposible y además innecesario: la botánica andina se deja resumir en un
+ * puñado de FORMAS DE CRECIMIENTO. El DR primario (taxonomía de ~12 arquetipos,
+ * gemini + glm 2026-06-19) fija esa lista; el DR de diferenciación visual de
+ * árboles altoandinos (34.5 KB, gemini + glm) dice CÓMO se distingue cada uno a
+ * 30 metros. Con doce siluetas bien dibujadas se puede mostrar el catálogo
+ * entero sin modelar 581 mallas.
+ *
+ * ── La prueba de cada arquetipo ────────────────────────────────────────────
+ * Si hay que acercarse para saber qué es, no sirve. Cada forma se diseñó por su
+ * SILUETA, no por su detalle:
+ *
+ *   DOSEL (el techo, 9–17 m)
+ *     1. palma-de-cera   columna pelada altísima + penacho apical  (Ceroxylon)
+ *     2. encenillo       CONO INVERTIDO: la copa se abre hacia arriba (Weinmannia)
+ *     3. cedro           copa muy ancha y aplanada, tronco recto grueso (Cedrela)
+ *     4. nogal           bola irregular, ramas en ángulo agudo      (Juglans/Alnus)
+ *
+ *   SOTOBOSQUE (a media altura, a la sombra, 2–6 m)
+ *     5. mano-de-oso     PARASOL abierto de hojas trilobuladas      (Oreopanax)
+ *     6. helecho-arboreo VOLANTE: estípite pelado + corona de frondas (Cyathea)
+ *     7. chusque         ABANICO de cañas, sin copa                 (Chusquea)
+ *     8. arbusto-florecido mata multicaule redonda con flor fucsia  (Tibouchina/Vallea)
+ *     9. bejuco-bromelia el hilo VERTICAL: liana + rosetas epífitas  (Araceae/Bromeliaceae)
+ *
+ *   SUELO (lo rastrero, 0–1.2 m)
+ *    10. helecho-suelo   roseta baja de frondas arqueadas
+ *    11. hierba-sombra   hoja ancha simple, nervadura pálida
+ *    12. cojin-hojarasca cojines de musgo + manto de hoja caída
+ *
+ * Los otros tres arquetipos de la taxonomía (frailejón-rosetal, cactus y
+ * acuática) NO viven dentro de un bosque altoandino cerrado: el frailejón ya
+ * está dibujado en `floraParamo.geom.js` (su mundo es el páramo), el cactus
+ * pertenece al valle seco interandino y la acuática al borde del agua. Meterlos
+ * aquí sería falsear el piso térmico. Cada uno se cita en `ARQUETIPOS_FUERA`.
+ *
+ * ── Ley de la casa ─────────────────────────────────────────────────────────
+ * · Todo pasa por el taller `sombreadoVegetal.js`: `fusionarSeguro` es la ÚNICA
+ *   fusión permitida. Nunca `mergeGeometries` a pelo — devuelve NULL en silencio
+ *   cuando se mezclan geometrías indexadas (tubo/cono) con no indexadas
+ *   (icosaedro) y la planta simplemente no se dibuja. Ese fallo ya costó dos
+ *   depuraciones largas en este proyecto y aquí es especialmente peligroso,
+ *   porque se instancian cientos de plantas.
+ * · Colores SOLO de la paleta madre (`paletaMadre.js`). Ni un hex suelto.
+ * · Cada arquetipo se FUSIONA en UNA geometría con color horneado por vértice y
+ *   se dibuja con UN InstancedMesh: doce draw-calls para el bosque entero, por
+ *   muchas matas que haya.
+ * · Aquí no hay WebGL ni React: solo datos y mallas. El componente
+ *   `BosqueTresEstratos.jsx` los instancia y les pone la luz de la casa.
+ */
+import * as THREE from 'three';
+import {
+  rng,
+  fusionarSeguro,
+  poner,
+  pintarPlano,
+  hornearFollaje,
+  hornearCorteza,
+  tuboOrganico,
+  taperLineal,
+  taperTronco,
+  curvaTronco,
+  sembrarFollaje,
+  matojoNube,
+} from './sombreadoVegetal.js';
+import {
+  VERDES,
+  TIERRAS,
+  CORTEZAS,
+  ACENTOS,
+  NEUTROS,
+  mezclar,
+} from '../paleta/paletaMadre.js';
+
+/* ══════════════════════════════════════════════════════════════════════════
+   1. LOS TRES ESTRATOS — la ley vertical del bosque
+   ══════════════════════════════════════════════════════════════════════════
+   La luz cae de arriba y se va gastando: el dosel la recibe entera, el
+   sotobosque vive de sobras y el suelo casi de nada. Ese gradiente NO es
+   decoración — es lo que hace que las tres capas se lean como capas. Por eso
+   cada estrato trae su propio par (base, sol) horneado en el color de vértice:
+   aunque la luz de la escena sea una sola, el bosque ya viene con sus pisos.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+export const ESTRATOS = {
+  dosel: {
+    id: 'dosel',
+    nombre: 'El dosel',
+    clave: 'el techo: las copas que reciben el sol de frente y hacen la sombra de todo lo demás',
+    rango: [9, 17],
+    /* Verde encendido: aquí pega el sol sin filtro. */
+    tinte: {
+      base: VERDES.paramoNiebla, // copa en penumbra propia
+      sol: VERDES.brote, // la cara que da al cielo
+      luz: mezclar(VERDES.brote, ACENTOS.maizTextil, 0.32), // contraluz de hoja
+    },
+  },
+  sotobosque: {
+    id: 'sotobosque',
+    nombre: 'El sotobosque',
+    clave: 'lo que crece a media altura, a la sombra: aquí la luz ya llega colada y verde',
+    rango: [2, 6],
+    /* Verde hondo y húmedo: la luz llegó filtrada por el dosel. */
+    tinte: {
+      base: mezclar(VERDES.paramoNiebla, NEUTROS.tinta, 0.3),
+      sol: VERDES.monte,
+      luz: mezclar(VERDES.monte, VERDES.brote, 0.45),
+    },
+  },
+  suelo: {
+    id: 'suelo',
+    nombre: 'El suelo',
+    clave: 'helechos, musgos y hojarasca: la fábrica callada donde el bosque se vuelve tierra otra vez',
+    rango: [0, 1.2],
+    /* Casi sin sol directo; lo que salva al suelo del negro es el musgo. */
+    tinte: {
+      base: mezclar(VERDES.paramoMusgo, NEUTROS.tinta, 0.42),
+      sol: VERDES.paramoMusgo,
+      luz: mezclar(VERDES.paramoMusgo, TIERRAS.mantillo, 0.4),
+    },
+  },
+};
+
+/* Los doce arquetipos, con su respaldo. `canonico` apunta a la clase de la
+   taxonomía del DR primario; `silueta` es la prueba de lectura a distancia. */
+export const ARQUETIPOS = [
+  {
+    id: 'palma-de-cera',
+    estrato: 'dosel',
+    canonico: 'palma',
+    nombre: 'Palma de cera',
+    cientifico: 'Ceroxylon quindiuense',
+    silueta: 'Una columna pelada larguísima con un penacho arriba. Es lo más alto del bosque y no se confunde con nada.',
+  },
+  {
+    id: 'encenillo',
+    estrato: 'dosel',
+    canonico: 'arbol-andino',
+    nombre: 'Encenillo',
+    cientifico: 'Weinmannia tomentosa',
+    silueta: 'Cono INVERTIDO: la copa se abre hacia arriba en una sola capa, sobre ramas delgadas y empinadas.',
+  },
+  {
+    id: 'cedro',
+    estrato: 'dosel',
+    canonico: 'arbol-andino',
+    nombre: 'Cedro de altura',
+    cientifico: 'Cedrela montana',
+    silueta: 'Tronco recto y grueso rematado en una copa muy ancha y aplanada, cargada de epífitas.',
+  },
+  {
+    id: 'nogal',
+    estrato: 'dosel',
+    canonico: 'arbol-andino',
+    nombre: 'Nogal',
+    cientifico: 'Juglans neotropica',
+    silueta: 'Bola irregular y amplia sobre ramas que salen en ángulo cerrado. La copa más maciza del dosel.',
+  },
+  {
+    id: 'mano-de-oso',
+    estrato: 'sotobosque',
+    canonico: 'arbol-andino',
+    nombre: 'Mano de oso',
+    cientifico: 'Oreopanax bogotensis',
+    silueta: 'Parasol abierto: pocas hojas grandes de tres lóbulos —la garra del oso— y el envés dorado.',
+  },
+  {
+    id: 'helecho-arboreo',
+    estrato: 'sotobosque',
+    canonico: 'helecho-arboreo',
+    nombre: 'Helecho arbóreo',
+    cientifico: 'Cyathea caracasana',
+    silueta: 'Un volante: estípite pelado y corona de frondas que se arquean, con el báculo enrollado en el centro.',
+  },
+  {
+    id: 'chusque',
+    estrato: 'sotobosque',
+    canonico: 'pasto',
+    nombre: 'Chusque',
+    cientifico: 'Chusquea scandens',
+    silueta: 'Abanico de cañas finas que sale de una sola mata. No tiene copa: es una masa rayada.',
+  },
+  {
+    id: 'arbusto-florecido',
+    estrato: 'sotobosque',
+    canonico: 'arbusto',
+    nombre: 'Arbusto florecido',
+    cientifico: 'Tibouchina lepidota / Vallea stipularis',
+    silueta: 'Mata redonda de varios tallos desde el suelo, salpicada de flor fucsia. La única mancha de color del sotobosque.',
+  },
+  {
+    id: 'bejuco-bromelia',
+    estrato: 'sotobosque',
+    canonico: 'enredadera + bromelia-epifita',
+    nombre: 'Bejuco con bromelias',
+    cientifico: 'Anthurium spp. / Tillandsia spp.',
+    silueta: 'El hilo vertical: una liana que sube en arco cargando rosetas. Es lo que cose los tres estratos.',
+  },
+  {
+    id: 'helecho-suelo',
+    estrato: 'suelo',
+    canonico: 'hierba',
+    nombre: 'Helecho de suelo',
+    cientifico: 'Blechnum spp.',
+    silueta: 'Roseta baja y abierta de frondas arqueadas, al ras de la hojarasca.',
+  },
+  {
+    id: 'hierba-sombra',
+    estrato: 'suelo',
+    canonico: 'hierba',
+    nombre: 'Hierba de sombra',
+    cientifico: 'Anthurium / Chusquea juvenil',
+    silueta: 'Hojas anchas y enteras que se abren en abanico bajo, con la nervadura pálida marcada.',
+  },
+  {
+    id: 'cojin-hojarasca',
+    estrato: 'suelo',
+    canonico: 'hierba',
+    nombre: 'Cojín de musgo y hojarasca',
+    cientifico: 'Sphagnum spp. + manto de hoja caída',
+    silueta: 'Cojines redondos pegados al piso, entre hojas caídas. Es el piso del bosque, no un adorno.',
+  },
+];
+
+/* Los tres arquetipos de la taxonomía que NO se dibujan aquí, y dónde viven.
+   Se declaran para que quede constancia de que la lista está completa y de que
+   la ausencia es una decisión botánica, no un olvido. */
+export const ARQUETIPOS_FUERA = [
+  { canonico: 'frailejon-rosetal', motivo: 'es la firma del páramo, no del bosque cerrado', vive: 'floraParamo.geom.js' },
+  { canonico: 'cactus', motivo: 'valle seco interandino: no hay cactus bajo un dosel de niebla', vive: 'pendiente (mundo del valle seco)' },
+  { canonico: 'acuatica', motivo: 'vive en el cuerpo de agua, no en el suelo del bosque', vive: 'mundo del agua / arroyo' },
+];
+
+export const arquetiposDe = (estrato) => ARQUETIPOS.filter((a) => a.estrato === estrato);
+
+/* ══════════════════════════════════════════════════════════════════════════
+   2. EL SUELO — la cota sobre la que se posa todo
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* El claro está en una loma que SUBE hacia donde se para el observador: desde
+   ahí se mira un poco hacia abajo y la vista entra por debajo del dosel, entre
+   los fustes. Parado al mismo nivel, uno solo ve troncos. */
+export function alturaSuelo(x, z) {
+  return (
+    Math.sin(x * 0.14) * 0.55
+    + Math.cos(z * 0.11 + 0.7) * 0.42
+    + Math.sin((x + z) * 0.07) * 0.3
+    + Math.max(0, z - 2) * 0.07
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   3. HERRAMIENTAS DE DIBUJO — las piezas de las que están hechas las plantas
+   ══════════════════════════════════════════════════════════════════════════
+   Rubber-hose: nada de cilindros de catálogo ni conos de librería a la vista.
+   Todo lo que se ve es hoja gorda, tallo de manguera y curva con squash.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* Una HOJA: cuerpo achatado con la base en el origen, para pivotar desde donde
+   se ancla al tallo. Icosaedro escalado = 20 caras, chunky y barato. */
+function hojaBlanda(largo, ancho, grosor = 0.22) {
+  const g = new THREE.IcosahedronGeometry(0.5, 0);
+  g.scale(ancho, largo, ancho * grosor);
+  g.translate(0, largo * 0.5, 0);
+  return g;
+}
+
+/* Una hoja LOBULADA de tres dedos — la "mano de oso". Tres hojas blandas que
+   salen del mismo punto abriéndose: la garra se lee desde lejos. */
+function hojaTrilobulada(largo, ancho) {
+  const dedos = [];
+  for (let k = -1; k <= 1; k++) {
+    const l = k === 0 ? largo : largo * 0.82;
+    const h = hojaBlanda(l, ancho * 0.5);
+    poner(h, [0, 0, 0], [0, 0, -k * 0.62]);
+    dedos.push(h);
+  }
+  return dedos;
+}
+
+/* Un TALLO de manguera: curva libre, taper y arruga. La base es la unidad de
+   todo lo leñoso de este módulo. */
+function tallo(pts, r0, r1, { tubular = 10, radial = 6, arruga = 0.1, semilla = 1 } = {}) {
+  const curva = new THREE.CatmullRomCurve3(
+    pts.map((p) => new THREE.Vector3(p[0], p[1], p[2])),
+    false,
+    'catmullrom',
+    0.5,
+  );
+  return tuboOrganico(curva, {
+    tubular, radial, taper: taperLineal(r0, r1), arruga, semilla, minRadio: 0.012,
+  });
+}
+
+/*
+ * Una FRONDA pinnada: raquis arqueado + folíolos a lado y lado, decrecientes
+ * hacia la punta. Es la pieza que construye la palma, el helecho arbóreo y el
+ * helecho de suelo — tres siluetas muy distintas hechas del mismo gesto,
+ * cambiando arqueo, largo y cuántas hay.
+ *
+ * @returns {THREE.BufferGeometry[]} partes SIN pintar (las pinta el llamador).
+ */
+function fronda({ largo, ancho, pares, arqueo = 0.55, caida = 0.35, semilla = 1, grosorRaquis = 0.035 }) {
+  const r = rng(semilla);
+  const partes = [];
+  /* El raquis: sale casi horizontal y se va cayendo — el arco es lo que hace
+     que una palma se vea palma y no una escoba. */
+  const pts = [];
+  const n = 4;
+  for (let i = 0; i <= n; i++) {
+    const t = i / n;
+    pts.push([
+      0,
+      arqueo * largo * Math.sin(t * 1.15) - caida * largo * t * t,
+      largo * t,
+    ]);
+  }
+  partes.push(tallo(pts, grosorRaquis * largo, grosorRaquis * largo * 0.28, {
+    tubular: 9, radial: 5, arruga: 0.05, semilla,
+  }));
+
+  /* Los folíolos: pares opuestos a lo largo del raquis. El de la punta es corto
+     y el del medio es el más largo → la fronda tiene cintura, no es un rectángulo. */
+  for (let i = 1; i <= pares; i++) {
+    const t = i / (pares + 0.6);
+    const y = arqueo * largo * Math.sin(t * 1.15) - caida * largo * t * t;
+    const z = largo * t;
+    /* Campana: corto en la base, largo al medio, corto en la punta. */
+    const perfil = Math.sin(Math.min(1, t * 1.08) * Math.PI) * 0.72 + 0.28;
+    const l = ancho * perfil * (0.86 + r() * 0.28);
+    for (const lado of [-1, 1]) {
+      const h = hojaBlanda(l, l * 0.3);
+      /* Cae hacia afuera y hacia atrás: el folíolo cuelga, no está tieso. */
+      poner(h, [0, 0, 0], [0, 0, lado * (1.02 + t * 0.3)]);
+      poner(h, [0, y, z], [-0.34 - t * 0.3, 0, 0]);
+      partes.push(h);
+    }
+  }
+  return partes;
+}
+
+/*
+ * El BÁCULO: la fronda joven todavía enrollada del helecho. Una espiral que se
+ * cierra sobre sí misma. Es puro rubber-hose y es EL detalle que dice "helecho"
+ * aunque el resto de la planta esté en sombra.
+ */
+function baculo(alto, semilla = 1) {
+  const pts = [];
+  const vueltas = 1.75;
+  const n = 16;
+  for (let i = 0; i <= n; i++) {
+    const t = i / n;
+    /* Sube recto y arriba se enrosca cerrando el radio. */
+    const enrolle = Math.max(0, (t - 0.45) / 0.55);
+    const ang = enrolle * Math.PI * 2 * vueltas;
+    const rad = alto * 0.19 * (1 - enrolle * 0.82);
+    pts.push([
+      Math.sin(ang) * rad,
+      alto * (0.5 + t * 0.5) - Math.cos(ang) * rad * 0.9 + rad * 0.9,
+      Math.cos(ang) * rad * 0.28,
+    ]);
+  }
+  return tallo(pts, alto * 0.055, alto * 0.018, { tubular: 22, radial: 5, arruga: 0.06, semilla });
+}
+
+/* Copa sembrada dentro de un CONO (invertido si rBase < rTope) — el molde de la
+   copa del encenillo, que es su rasgo inconfundible a 30 metros. */
+function sembrarCono({ base, alto, rBase, rTope, n, semilla = 1, distMin = 0.5 }) {
+  const r = rng(semilla);
+  const puntos = [];
+  const intentos = n * 16;
+  for (let i = 0; i < intentos && puntos.length < n; i++) {
+    const t = Math.pow(r(), 0.62); // sesgo hacia arriba: la copa carga en el tope
+    const radio = rBase + (rTope - rBase) * t;
+    const ang = r() * Math.PI * 2;
+    const rr = radio * Math.sqrt(r());
+    const p = [
+      base[0] + Math.cos(ang) * rr,
+      base[1] + alto * t,
+      base[2] + Math.sin(ang) * rr,
+    ];
+    let choca = false;
+    for (let k = 0; k < puntos.length; k++) {
+      const q = puntos[k].pos;
+      if ((q[0] - p[0]) ** 2 + (q[1] - p[1]) ** 2 + (q[2] - p[2]) ** 2 < distMin * distMin) {
+        choca = true;
+        break;
+      }
+    }
+    if (choca) continue;
+    puntos.push({ pos: p, esc: 0.66 + r() * 0.5 });
+  }
+  return puntos;
+}
+
+/* Pinta un cúmulo de copa con el tinte del estrato. Azúcar para no repetir el
+   objeto de `hornearFollaje` doce veces. */
+function pintarCopa(geo, estrato, { centro, radio, yMin, yMax, ao = 0.6, manchas = 0.12, tinte }) {
+  const t = tinte || ESTRATOS[estrato].tinte;
+  return hornearFollaje(geo, {
+    base: t.base, sol: t.sol, luz: t.luz, centro, radio, yMin, yMax, ao, manchas,
+  });
+}
+
+/* Una rama de manguera que sale del tronco a la altura `y`, con `az` de azimut. */
+function rama({ y, az, largo, alzada, r0, curva = 0.35, semilla = 1 }) {
+  const dx = Math.cos(az);
+  const dz = Math.sin(az);
+  const pts = [];
+  const n = 4;
+  for (let i = 0; i <= n; i++) {
+    const t = i / n;
+    pts.push([
+      dx * largo * t,
+      y + alzada * largo * t + curva * largo * t * t,
+      dz * largo * t,
+    ]);
+  }
+  return tallo(pts, r0, r0 * 0.3, { tubular: 8, radial: 5, arruga: 0.14, semilla });
+}
+
+/* Una roseta de BROMELIA: hojas rígidas que radian de un punto y forman la copa
+   que junta el agua. Va sobre ramas y troncos: es lo que dice "bosque de niebla". */
+function bromelia(radio, semilla = 1) {
+  const r = rng(semilla);
+  const partes = [];
+  const n = 9;
+  for (let i = 0; i < n; i++) {
+    const ang = (i / n) * Math.PI * 2 + r() * 0.3;
+    const abre = 0.62 + r() * 0.5;
+    const h = hojaBlanda(radio * (1.5 + r() * 0.5), radio * 0.36);
+    poner(h, [0, 0, 0], [abre, 0, 0]);
+    poner(h, [0, 0, 0], [0, ang, 0]);
+    partes.push(h);
+  }
+  return partes;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   4. ESTRATO DOSEL — el techo del bosque
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/*
+ * 1. PALMA DE CERA (Ceroxylon quindiuense) — el emergente.
+ *
+ * La palma más alta del mundo, y crece hasta los 3.000 m: es el arquetipo
+ * `palma` de la taxonomía y, en el bosque altoandino colombiano, es también el
+ * hito del paisaje. Su silueta es un regalo para el dibujo: una COLUMNA pelada
+ * clarísima, anillada, que sube muy por encima del dosel y remata en un penacho
+ * apical. A 200 metros ya se sabe qué es.
+ */
+export function geomPalmaDeCera({ q = 1 } = {}, seed = 101) {
+  const r = rng(seed);
+  const partes = [];
+  /* Muy por encima del dosel: si no sobresale, deja de ser emergente y se
+     confunde con un árbol más. La distancia entre su penacho y el techo del
+     bosque es el rasgo, no la altura en sí. */
+  const alto = 18.6;
+
+  /* El estípite: apenas curvado, cerúleo pálido, con los anillos de las hojas
+     que se cayeron. Nada de cilindro perfecto — se mece. */
+  const curva = curvaTronco({ altura: alto, inclina: 0.035, sinuoso: 0.028, giro: r() * 6 }, seed);
+  const col = tuboOrganico(curva, {
+    tubular: Math.max(12, Math.round(22 * q)),
+    radial: Math.max(6, Math.round(9 * q)),
+    taper: taperTronco(0.36, 0.24, 0.55),
+    arruga: 0.05,
+    semilla: seed,
+  });
+  hornearCorteza(col, {
+    grieta: mezclar(CORTEZAS.yarumo, NEUTROS.tinta, 0.45),
+    cuerpo: CORTEZAS.yarumo, // el tronco pálido anillado ya está en la paleta
+    cresta: mezclar(CORTEZAS.yarumo, NEUTROS.hueso, 0.35),
+    liquen: VERDES.paramoMusgo,
+    escalaGrano: 2.2,
+    hastaLiquen: 2.4,
+  });
+  partes.push(col);
+
+  /* Los anillos: discos delgados que marcan dónde estuvo cada hoja. Es el rasgo
+     que separa una palma de un poste. */
+  const nAnillos = Math.max(5, Math.round(11 * q));
+  for (let i = 0; i < nAnillos; i++) {
+    const t = 0.16 + (i / nAnillos) * 0.74;
+    const p = curva.getPointAt(t);
+    const anillo = new THREE.TorusGeometry(0.3, 0.035, 4, Math.max(6, Math.round(10 * q)));
+    poner(anillo, [p.x, p.y, p.z], [Math.PI / 2, 0, 0]);
+    pintarPlano(anillo, mezclar(CORTEZAS.yarumo, NEUTROS.tinta, 0.5));
+    partes.push(anillo);
+  }
+
+  /* El penacho: frondas que salen del ápice, unas alzadas y otras ya vencidas.
+     La mezcla de alturas es lo que le da vida — una corona pareja se ve de plástico. */
+  const cima = curva.getPointAt(1);
+  const nFrondas = Math.max(7, Math.round(11 * q));
+  const tinteFronda = { base: VERDES.frio, sol: VERDES.aliso, luz: ESTRATOS.dosel.tinte.luz };
+  for (let i = 0; i < nFrondas; i++) {
+    const ang = (i / nFrondas) * Math.PI * 2 + r() * 0.4;
+    /* Las de arriba jóvenes y alzadas; las de abajo viejas y colgando. */
+    const vieja = i / nFrondas;
+    const alza = 0.9 - vieja * 1.5;
+    const trozos = fronda({
+      largo: 3.3 + r() * 0.7,
+      ancho: 0.66,
+      pares: Math.max(5, Math.round(9 * q)),
+      arqueo: 0.34,
+      caida: 0.42 + vieja * 0.3,
+      semilla: seed + i,
+    });
+    for (const t of trozos) {
+      poner(t, [0, 0, 0], [alza * 0.45 - 0.35, 0, 0]);
+      poner(t, [cima.x, cima.y - 0.12, cima.z], [0, ang, 0]);
+      pintarCopa(t, 'dosel', {
+        centro: [cima.x, cima.y, cima.z], radio: 3.4, yMin: cima.y - 2, yMax: cima.y + 1,
+        ao: 0.32, manchas: 0.1, tinte: tinteFronda,
+      });
+      partes.push(t);
+    }
+  }
+
+  return fusionarSeguro(partes, 'palma-de-cera', { preservarNormales: true });
+}
+
+/*
+ * 2. ENCENILLO (Weinmannia tomentosa) — el árbol de niebla, y la silueta más
+ * rara y más útil del dosel altoandino.
+ *
+ * El DR es tajante: la copa tiene forma de PIRÁMIDE INVERTIDA, con el follaje
+ * concentrado en UNA sola capa superior, sobre ramas sinuosas, empinadas,
+ * delgadas y oscuras. Ese cono al revés es lo que lo distingue del gaque y de
+ * todo lo demás a 30 metros. Corteza rojiza (ya está en la paleta) y el toque
+ * de espiga color caramelo cuando fructifica.
+ */
+export function geomEncenillo({ q = 1 } = {}, seed = 202) {
+  const r = rng(seed);
+  const partes = [];
+  const alto = 9.2;
+
+  const curva = curvaTronco({ altura: alto * 0.62, inclina: 0.08, sinuoso: 0.1, giro: r() * 6 }, seed);
+  const tronco = tuboOrganico(curva, {
+    tubular: Math.max(9, Math.round(16 * q)),
+    radial: Math.max(6, Math.round(8 * q)),
+    taper: taperTronco(0.34, 0.13, 0.45),
+    arruga: 0.16,
+    semilla: seed,
+  });
+  hornearCorteza(tronco, {
+    grieta: mezclar(CORTEZAS.encenillo, NEUTROS.tinta, 0.5),
+    cuerpo: CORTEZAS.encenillo, // «corteza rojiza del árbol de niebla»
+    cresta: mezclar(CORTEZAS.encenillo, TIERRAS.arcilla, 0.4),
+    liquen: VERDES.paramoMusgo,
+    escalaGrano: 5.5,
+    hastaLiquen: 2.2,
+  });
+  partes.push(tronco);
+
+  /* Las ramas: EMPINADAS y delgadas, saliendo del tercio alto y abriéndose poco.
+     Son las que sostienen el cono invertido; si salieran horizontales, la copa
+     se leería como sombrilla y perderíamos la especie. */
+  const cuello = curva.getPointAt(1);
+  const nRamas = Math.max(4, Math.round(7 * q));
+  for (let i = 0; i < nRamas; i++) {
+    const az = (i / nRamas) * Math.PI * 2 + r() * 0.5;
+    const g = rama({
+      y: cuello.y - 0.5 + r() * 0.4,
+      az,
+      largo: 1.5 + r() * 0.9,
+      alzada: 1.35, // casi vertical: la firma del encenillo
+      r0: 0.075,
+      curva: 0.5,
+      semilla: seed + i,
+    });
+    poner(g, [cuello.x, 0, cuello.z]);
+    hornearCorteza(g, {
+      grieta: mezclar(CORTEZAS.encenillo, NEUTROS.tinta, 0.62),
+      cuerpo: mezclar(CORTEZAS.encenillo, NEUTROS.tinta, 0.3),
+      escalaGrano: 7,
+    });
+    partes.push(g);
+  }
+
+  /* LA COPA: cono invertido — angosta abajo, ancha arriba, y aplanada por el
+     tope como una sola capa de follaje. */
+  const yCopa = cuello.y + 0.9;
+  const cumulos = sembrarCono({
+    base: [cuello.x, yCopa, cuello.z],
+    /* Cono BAJO y MUY abierto: el encenillo carga su follaje en una sola capa
+       arriba. Cuanto más plano el cono y más marcada la diferencia entre pie y
+       tope, más se lee la pirámide invertida contra el cielo. */
+    alto: 2.5,
+    rBase: 0.5,
+    rTope: 3.6,
+    n: Math.max(14, Math.round(32 * q)),
+    semilla: seed,
+    distMin: 0.62,
+  });
+  for (let i = 0; i < cumulos.length; i++) {
+    const c = cumulos[i];
+    const m = matojoNube(0.82 * c.esc, seed + i * 7, 0.46);
+    m.scale(1, 0.68, 1); // achata: una capa, no una nube esférica
+    poner(m, c.pos);
+    pintarCopa(m, 'dosel', {
+      centro: [cuello.x, yCopa + 2.4, cuello.z], radio: 3.4,
+      yMin: yCopa, yMax: yCopa + 3.3, ao: 0.66, manchas: 0.14,
+    });
+    partes.push(m);
+  }
+
+  /* Las espigas: cuando fructifica se pone color caramelo. Una cucharada, no
+     una capa — el acento está para que la copa no se lea plana. */
+  const nEspigas = Math.max(3, Math.round(9 * q));
+  for (let i = 0; i < nEspigas; i++) {
+    const c = cumulos[Math.floor(r() * cumulos.length)];
+    if (!c) break;
+    const e = hojaBlanda(0.42, 0.12);
+    poner(e, [c.pos[0] + (r() - 0.5) * 0.5, c.pos[1] + 0.4, c.pos[2] + (r() - 0.5) * 0.5], [r() * 0.4, 0, (r() - 0.5) * 0.6]);
+    pintarPlano(e, mezclar(TIERRAS.arcilla, ACENTOS.ambar, 0.35));
+    partes.push(e);
+  }
+
+  return fusionarSeguro(partes, 'encenillo', { preservarNormales: true });
+}
+
+/*
+ * 3. CEDRO DE ALTURA (Cedrela montana) — el gigante de copa ancha.
+ *
+ * Tronco recto y grueso; copa MUY AMPLIA y densa, más ancha que alta. El DR
+ * anota que sus ramas suelen cargar bromeliáceas, helechos y orquídeas: esa
+ * carga de epífitas se dibuja, porque es lo que convierte un árbol en un
+ * ecosistema y explica de un vistazo el arquetipo bromelia-epífita.
+ */
+export function geomCedro({ q = 1 } = {}, seed = 303) {
+  const r = rng(seed);
+  const partes = [];
+  const alto = 11.6;
+
+  const curva = curvaTronco({ altura: alto * 0.66, inclina: 0.04, sinuoso: 0.06, giro: r() * 6 }, seed);
+  const tronco = tuboOrganico(curva, {
+    tubular: Math.max(10, Math.round(18 * q)),
+    radial: Math.max(7, Math.round(10 * q)),
+    taper: taperTronco(0.52, 0.2, 0.6),
+    arruga: 0.2, // corteza escamosa: relieve marcado
+    semilla: seed,
+  });
+  hornearCorteza(tronco, {
+    grieta: mezclar(CORTEZAS.roble, NEUTROS.tinta, 0.55),
+    cuerpo: CORTEZAS.roble,
+    cresta: mezclar(CORTEZAS.roble, TIERRAS.camino, 0.4),
+    liquen: VERDES.paramoMusgo,
+    escalaGrano: 4.4,
+    hastaLiquen: 3.2,
+  });
+  partes.push(tronco);
+
+  /* Ramas gruesas y HORIZONTALES: lo contrario del encenillo. Ahí está la
+     diferencia de silueta entre los dos árboles del dosel. */
+  const cuello = curva.getPointAt(1);
+  const nRamas = Math.max(4, Math.round(6 * q));
+  const brazos = [];
+  for (let i = 0; i < nRamas; i++) {
+    const az = (i / nRamas) * Math.PI * 2 + r() * 0.4;
+    const largo = 2.5 + r() * 1.1;
+    const g = rama({ y: cuello.y - 0.3, az, largo, alzada: 0.3, r0: 0.16, curva: 0.1, semilla: seed + i });
+    poner(g, [cuello.x, 0, cuello.z]);
+    hornearCorteza(g, {
+      grieta: mezclar(CORTEZAS.roble, NEUTROS.tinta, 0.6),
+      cuerpo: mezclar(CORTEZAS.roble, NEUTROS.tinta, 0.22),
+      escalaGrano: 6,
+    });
+    partes.push(g);
+    brazos.push({ az, largo, y: cuello.y - 0.3 + 0.4 * largo });
+  }
+
+  /* La copa: ancha y ACHATADA (achatado 0.5) — una nube tendida sobre el bosque. */
+  const yCopa = cuello.y + 1.5;
+  const cumulos = sembrarFollaje({
+    centro: [cuello.x, yCopa, cuello.z],
+    /* Ancha y baja: la MESA. Contra el cono invertido del encenillo y la bola
+       del nogal, es la tercera manera de ser copa que tiene este bosque. */
+    radio: 4.7,
+    achatado: 0.34,
+    n: Math.max(16, Math.round(42 * q)),
+    semilla: seed,
+    huecos: 0.4,
+    mordida: 0.38,
+    distMin: 0.72,
+  });
+  for (let i = 0; i < cumulos.length; i++) {
+    const c = cumulos[i];
+    const m = matojoNube(0.95 * c.esc, seed + i * 5, 0.5);
+    poner(m, c.pos, c.giro);
+    pintarCopa(m, 'dosel', {
+      centro: [cuello.x, yCopa, cuello.z], radio: 4.8,
+      yMin: yCopa - 1.4, yMax: yCopa + 1.5, ao: 0.6, manchas: 0.13,
+    });
+    partes.push(m);
+  }
+
+  /* Las epífitas montadas en las ramas: bromelias que viven del aire. */
+  const nEpi = Math.max(2, Math.round(5 * q));
+  for (let i = 0; i < nEpi; i++) {
+    const b = brazos[i % brazos.length];
+    if (!b) break;
+    const t = 0.45 + r() * 0.4;
+    const px = Math.cos(b.az) * b.largo * t;
+    const pz = Math.sin(b.az) * b.largo * t;
+    const py = cuello.y - 0.3 + 0.3 * b.largo * t + 0.1 * b.largo * t * t + 0.1;
+    for (const h of bromelia(0.3, seed + i * 3)) {
+      poner(h, [cuello.x + px, py, cuello.z + pz]);
+      pintarCopa(h, 'dosel', {
+        centro: [cuello.x + px, py, cuello.z + pz], radio: 0.6, yMin: py, yMax: py + 0.5,
+        ao: 0.35, manchas: 0.08,
+        tinte: { base: VERDES.frio, sol: VERDES.brote, luz: ACENTOS.maizTextil },
+      });
+      partes.push(h);
+    }
+  }
+
+  return fusionarSeguro(partes, 'cedro', { preservarNormales: true });
+}
+
+/*
+ * 4. NOGAL (Juglans neotropica) — la copa globosa.
+ *
+ * Ramificación monopódica con ramas en ángulo AGUDO y una copa globosa
+ * irregular y amplia que hace sombra densa. Es el volumen macizo del dosel: al
+ * lado del cono invertido del encenillo y de la mesa del cedro, la bola del
+ * nogal completa las tres maneras de ser copa que tiene este bosque.
+ */
+export function geomNogal({ q = 1 } = {}, seed = 404) {
+  const r = rng(seed);
+  const partes = [];
+  const alto = 10.2;
+
+  const curva = curvaTronco({ altura: alto * 0.55, inclina: 0.07, sinuoso: 0.09, giro: r() * 6 }, seed);
+  const tronco = tuboOrganico(curva, {
+    tubular: Math.max(9, Math.round(16 * q)),
+    radial: Math.max(6, Math.round(9 * q)),
+    taper: taperTronco(0.44, 0.17, 0.5),
+    arruga: 0.15,
+    semilla: seed,
+  });
+  hornearCorteza(tronco, {
+    grieta: mezclar(CORTEZAS.quenual, NEUTROS.tinta, 0.55),
+    cuerpo: mezclar(CORTEZAS.quenual, CORTEZAS.roble, 0.35), // pardo-rojiza
+    cresta: mezclar(CORTEZAS.quenual, TIERRAS.camino, 0.3),
+    liquen: VERDES.paramoMusgo,
+    escalaGrano: 5,
+    hastaLiquen: 2.6,
+  });
+  partes.push(tronco);
+
+  /* Ramas en ángulo agudo (alzada alta, poca apertura) — el gesto monopódico. */
+  const cuello = curva.getPointAt(1);
+  const nRamas = Math.max(3, Math.round(6 * q));
+  for (let i = 0; i < nRamas; i++) {
+    const az = (i / nRamas) * Math.PI * 2 + r() * 0.5;
+    const g = rama({
+      y: cuello.y - 0.9 - r() * 0.6, az, largo: 1.9 + r() * 0.8,
+      alzada: 0.95, r0: 0.12, curva: 0.22, semilla: seed + i,
+    });
+    poner(g, [cuello.x, 0, cuello.z]);
+    hornearCorteza(g, {
+      grieta: mezclar(CORTEZAS.quenual, NEUTROS.tinta, 0.62),
+      cuerpo: mezclar(CORTEZAS.quenual, NEUTROS.tinta, 0.25),
+      escalaGrano: 6.5,
+    });
+    partes.push(g);
+  }
+
+  const yCopa = cuello.y + 1.9;
+  const cumulos = sembrarFollaje({
+    centro: [cuello.x, yCopa, cuello.z],
+    radio: 3.15,
+    achatado: 0.88, // casi esférica: la bola
+    n: Math.max(16, Math.round(34 * q)),
+    semilla: seed,
+    huecos: 0.44,
+    mordida: 0.36,
+    distMin: 0.6,
+  });
+  for (let i = 0; i < cumulos.length; i++) {
+    const c = cumulos[i];
+    const m = matojoNube(0.92 * c.esc, seed + i * 9, 0.52);
+    poner(m, c.pos, c.giro);
+    pintarCopa(m, 'dosel', {
+      centro: [cuello.x, yCopa, cuello.z], radio: 3.2,
+      yMin: yCopa - 2.6, yMax: yCopa + 2.6, ao: 0.68, manchas: 0.12,
+    });
+    partes.push(m);
+  }
+
+  return fusionarSeguro(partes, 'nogal', { preservarNormales: true });
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   5. ESTRATO SOTOBOSQUE — a media altura, a la sombra
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/*
+ * 5. MANO DE OSO (Oreopanax bogotensis) — el parasol.
+ *
+ * Copa ABIERTA en forma de parasol, con pocas hojas pero enormes, de tres
+ * lóbulos (de ahí el nombre: la garra del oso) y envés amarillento-dorado. Es
+ * la silueta más generosa del sotobosque: pocas piezas, muy grandes, muy
+ * legibles. Se dibuja con las hojas casi horizontales y el dorado por debajo,
+ * que es justo lo que se ve cuando uno camina bajo el árbol.
+ */
+export function geomManoDeOso({ q = 1 } = {}, seed = 505) {
+  const r = rng(seed);
+  const partes = [];
+  const alto = 4.4;
+
+  const curva = curvaTronco({ altura: alto, inclina: 0.13, sinuoso: 0.14, giro: r() * 6 }, seed);
+  const tronco = tuboOrganico(curva, {
+    tubular: Math.max(8, Math.round(14 * q)),
+    radial: Math.max(5, Math.round(7 * q)),
+    taper: taperTronco(0.17, 0.075, 0.4),
+    arruga: 0.13,
+    semilla: seed,
+  });
+  hornearCorteza(tronco, {
+    grieta: mezclar(CORTEZAS.roble, NEUTROS.tinta, 0.6),
+    cuerpo: mezclar(CORTEZAS.roble, VERDES.paramoMusgo, 0.22),
+    cresta: CORTEZAS.roble,
+    liquen: VERDES.paramoMusgo,
+    escalaGrano: 6,
+    hastaLiquen: 1.8,
+  });
+  partes.push(tronco);
+
+  const cima = curva.getPointAt(1);
+  /* El parasol: hojas grandes, casi horizontales, radiando del ápice. Pocas y
+     enormes — si fueran muchas y chicas volveríamos a un arbusto cualquiera. */
+  const nHojas = Math.max(6, Math.round(10 * q));
+  const dorado = mezclar(ACENTOS.ambar, VERDES.brote, 0.35); // el envés amarillento
+  for (let i = 0; i < nHojas; i++) {
+    const ang = (i / nHojas) * Math.PI * 2 + r() * 0.32;
+    const largo = 1.15 + r() * 0.35;
+    /* Pecíolo: la hoja no nace pegada al tronco, cuelga de su propio tallito. */
+    const pec = tallo(
+      [[0, 0, 0], [0, 0.12, largo * 0.3], [0, 0.06, largo * 0.55]],
+      0.035, 0.022, { tubular: 5, radial: 4, arruga: 0.04, semilla: seed + i },
+    );
+    poner(pec, [cima.x, cima.y - 0.1, cima.z], [0, ang, 0]);
+    pintarPlano(pec, mezclar(CORTEZAS.roble, NEUTROS.tinta, 0.35));
+    partes.push(pec);
+
+    for (const dedo of hojaTrilobulada(largo, 0.72)) {
+      /* Se acuesta: la hoja mira al cielo y enseña el dorado por debajo. */
+      poner(dedo, [0, 0, 0], [-1.24 + r() * 0.16, 0, 0]);
+      poner(dedo, [cima.x, cima.y - 0.16, cima.z], [0, ang, 0]);
+      poner(dedo, [Math.cos(ang + Math.PI / 2) * 0, 0, 0]);
+      /* El horneado usa el eje Y como sol/sombra: como la hoja está acostada,
+         su cara de abajo queda en la banda baja del gradiente → ahí entra el
+         dorado, que es exactamente donde el ojo lo ve en el bosque real. */
+      hornearFollaje(dedo, {
+        base: dorado,
+        sol: ESTRATOS.sotobosque.tinte.sol,
+        luz: ESTRATOS.sotobosque.tinte.luz,
+        centro: [cima.x, cima.y, cima.z],
+        radio: 1.9,
+        yMin: cima.y - 0.45,
+        yMax: cima.y + 0.25,
+        ao: 0.3,
+        manchas: 0.09,
+      });
+      partes.push(dedo);
+    }
+  }
+
+  /* El racimo de cabezuelas: bolitas blancas sobre la copa. Detalle mínimo que
+     remata el parasol y lo separa del helecho arbóreo a media distancia. */
+  const nBolas = Math.max(3, Math.round(7 * q));
+  for (let i = 0; i < nBolas; i++) {
+    const b = new THREE.IcosahedronGeometry(0.075, 0);
+    poner(b, [cima.x + (r() - 0.5) * 0.6, cima.y + 0.24 + r() * 0.3, cima.z + (r() - 0.5) * 0.6]);
+    pintarPlano(b, mezclar(NEUTROS.hueso, VERDES.brote, 0.22));
+    partes.push(b);
+  }
+
+  return fusionarSeguro(partes, 'mano-de-oso', { preservarNormales: true });
+}
+
+/*
+ * 6. HELECHO ARBÓREO (Cyathea caracasana) — el volante del sotobosque.
+ *
+ * Estípite columnar pelado con las cicatrices de las frondas viejas, y una
+ * corona de frondas grandes que se arquean hacia afuera y caen. En el centro,
+ * el BÁCULO: la fronda nueva todavía enrollada. Esa espiral es el detalle que
+ * hace que el helecho se lea como helecho y no como palma pequeña, y de paso es
+ * el gesto más rubber-hose de todo el bosque.
+ */
+export function geomHelechoArboreo({ q = 1 } = {}, seed = 606) {
+  const r = rng(seed);
+  const partes = [];
+  const alto = 3.3;
+
+  const curva = curvaTronco({ altura: alto, inclina: 0.06, sinuoso: 0.05, giro: r() * 6 }, seed);
+  const estipite = tuboOrganico(curva, {
+    tubular: Math.max(8, Math.round(14 * q)),
+    radial: Math.max(5, Math.round(8 * q)),
+    taper: taperTronco(0.19, 0.15, 0.7),
+    arruga: 0.26, // las cicatrices: relieve fuerte, casi escamoso
+    semilla: seed,
+  });
+  hornearCorteza(estipite, {
+    grieta: mezclar(TIERRAS.cacao, NEUTROS.tinta, 0.4),
+    cuerpo: TIERRAS.turba,
+    cresta: mezclar(TIERRAS.turba, TIERRAS.mantillo, 0.45),
+    liquen: VERDES.paramoMusgo,
+    escalaGrano: 9, // grano fino y apretado = cicatrices
+    hastaLiquen: 1.6,
+  });
+  partes.push(estipite);
+
+  const cima = curva.getPointAt(1);
+  const nFrondas = Math.max(6, Math.round(9 * q));
+  for (let i = 0; i < nFrondas; i++) {
+    const ang = (i / nFrondas) * Math.PI * 2 + r() * 0.35;
+    const trozos = fronda({
+      largo: 1.75 + r() * 0.4,
+      ancho: 0.5,
+      pares: Math.max(5, Math.round(8 * q)),
+      arqueo: 0.5, // sube y luego cae: el arco del volante
+      caida: 0.72,
+      semilla: seed + i * 3,
+      grosorRaquis: 0.028,
+    });
+    for (const t of trozos) {
+      poner(t, [0, 0, 0], [-0.28, 0, 0]);
+      poner(t, [cima.x, cima.y - 0.05, cima.z], [0, ang, 0]);
+      pintarCopa(t, 'sotobosque', {
+        centro: [cima.x, cima.y, cima.z], radio: 2.0,
+        yMin: cima.y - 0.9, yMax: cima.y + 0.7, ao: 0.42, manchas: 0.12,
+      });
+      partes.push(t);
+    }
+  }
+
+  /* Los báculos: dos, uno más abierto que el otro (la planta está creciendo). */
+  for (let i = 0; i < 2; i++) {
+    const b = baculo(0.85 - i * 0.2, seed + 40 + i);
+    poner(b, [cima.x + (i - 0.5) * 0.16, cima.y - 0.06, cima.z + (i - 0.5) * 0.14], [0, r() * 6, 0]);
+    pintarCopa(b, 'sotobosque', {
+      centro: [cima.x, cima.y + 0.6, cima.z], radio: 1.0,
+      yMin: cima.y, yMax: cima.y + 1.1, ao: 0.25, manchas: 0.1,
+      tinte: { base: VERDES.monte, sol: VERDES.brote, luz: ACENTOS.maizTextil },
+    });
+    partes.push(b);
+  }
+
+  return fusionarSeguro(partes, 'helecho-arboreo', { preservarNormales: true });
+}
+
+/*
+ * 7. CHUSQUE (Chusquea scandens) — el bambú andino.
+ *
+ * No tiene copa: es una MASA densa de cañas finas que sale de una sola mata y
+ * se abre en abanico, con matojos de hoja en los nudos. Forma el sotobosque
+ * cerrado de verdad — el que uno tiene que abrir a machete. Su textura rayada
+ * y su verde más claro lo separan de todo lo demás a esa altura.
+ *
+ * (En la taxonomía es el arquetipo `pasto`: Chusquea es Poaceae, una gramínea
+ * leñosa. Ese es el mismo arquetipo del pajonal, en su versión de bosque.)
+ */
+export function geomChusque({ q = 1 } = {}, seed = 707) {
+  const r = rng(seed);
+  const partes = [];
+  const nCanias = Math.max(9, Math.round(18 * q));
+
+  for (let i = 0; i < nCanias; i++) {
+    const ang = r() * Math.PI * 2;
+    const abre = 0.35 + r() * 0.85; // cuánto se tumba hacia afuera
+    const largo = 2.4 + r() * 2.0;
+    const pts = [];
+    const n = 5;
+    for (let k = 0; k <= n; k++) {
+      const t = k / n;
+      /* La caña sube y se va venciendo: arco de manguera, no palo. */
+      const rad = abre * largo * t * t * 0.42;
+      pts.push([
+        Math.cos(ang) * rad,
+        largo * t * (1 - 0.18 * t * t),
+        Math.sin(ang) * rad,
+      ]);
+    }
+    const c = tallo(pts, 0.05, 0.022, { tubular: 9, radial: 4, arruga: 0.07, semilla: seed + i });
+    pintarPlano(c, mezclar(VERDES.trabajo, TIERRAS.pajonal, 0.22 + r() * 0.2));
+    partes.push(c);
+
+    /* Los nudos con su matojo de hoja: lo que hace la masa. */
+    const nNudos = Math.max(2, Math.round(4 * q));
+    for (let k = 1; k <= nNudos; k++) {
+      const t = 0.36 + (k / (nNudos + 1)) * 0.6;
+      const rad = abre * largo * t * t * 0.42;
+      const p = [Math.cos(ang) * rad, largo * t * (1 - 0.18 * t * t), Math.sin(ang) * rad];
+      const nHojas = 3;
+      for (let h = 0; h < nHojas; h++) {
+        const hj = hojaBlanda(0.34 + r() * 0.2, 0.055);
+        poner(hj, [0, 0, 0], [0.5 + r() * 0.7, (h / nHojas) * Math.PI * 2 + r(), 0]);
+        poner(hj, p);
+        pintarCopa(hj, 'sotobosque', {
+          centro: [0, largo * 0.6, 0], radio: 2.4, yMin: 0, yMax: largo,
+          ao: 0.38, manchas: 0.14,
+          tinte: { base: VERDES.monte, sol: VERDES.brote, luz: ESTRATOS.sotobosque.tinte.luz },
+        });
+        partes.push(hj);
+      }
+    }
+  }
+
+  return fusionarSeguro(partes, 'chusque', { preservarNormales: true });
+}
+
+/*
+ * 8. ARBUSTO FLORECIDO (Tibouchina lepidota / Vallea stipularis) — la mancha
+ * de color.
+ *
+ * Arquetipo `arbusto`: varios tallos leñosos desde la base y copa redondeada.
+ * El siete cueros y el raque son los dos arbolitos que ponen el color del
+ * bosque altoandino —púrpura el uno, fucsia el otro— y son los únicos que
+ * justifican un acento fuerte aquí. Se usan a cucharadas: unas pocas flores
+ * grandes sobre la mata, jamás una superficie de color.
+ */
+export function geomArbustoFlorecido({ q = 1 } = {}, seed = 808) {
+  const r = rng(seed);
+  const partes = [];
+  const nTallos = Math.max(4, Math.round(6 * q));
+  const alto = 1.9;
+
+  for (let i = 0; i < nTallos; i++) {
+    const ang = (i / nTallos) * Math.PI * 2 + r() * 0.6;
+    const abre = 0.28 + r() * 0.3;
+    const h = alto * (0.7 + r() * 0.42);
+    const pts = [];
+    const n = 4;
+    for (let k = 0; k <= n; k++) {
+      const t = k / n;
+      const rad = abre * h * t * t;
+      pts.push([Math.cos(ang) * rad, h * t, Math.sin(ang) * rad]);
+    }
+    const c = tallo(pts, 0.062, 0.026, { tubular: 7, radial: 5, arruga: 0.14, semilla: seed + i });
+    hornearCorteza(c, {
+      grieta: mezclar(CORTEZAS.sieteCueros, NEUTROS.tinta, 0.55),
+      cuerpo: CORTEZAS.sieteCueros, // «cobre que se descama» — las siete pieles
+      cresta: CORTEZAS.sieteCuerosClaro,
+      escalaGrano: 8,
+    });
+    partes.push(c);
+  }
+
+  /* La copa redondeada de la mata. */
+  const cumulos = sembrarFollaje({
+    centro: [0, alto * 0.95, 0],
+    radio: 1.1,
+    achatado: 0.82,
+    n: Math.max(8, Math.round(18 * q)),
+    semilla: seed,
+    huecos: 0.36,
+    mordida: 0.4,
+    distMin: 0.34,
+  });
+  for (let i = 0; i < cumulos.length; i++) {
+    const c = cumulos[i];
+    const m = matojoNube(0.42 * c.esc, seed + i * 11, 0.5);
+    poner(m, c.pos, c.giro);
+    pintarCopa(m, 'sotobosque', {
+      centro: [0, alto * 0.95, 0], radio: 1.15,
+      yMin: alto * 0.35, yMax: alto * 1.55, ao: 0.55, manchas: 0.14,
+    });
+    partes.push(m);
+  }
+
+  /* Las flores: cinco pétalos abiertos, fucsia. Pocas y grandes. */
+  const nFlores = Math.max(3, Math.round(8 * q));
+  for (let i = 0; i < nFlores; i++) {
+    const c = cumulos[Math.floor(r() * cumulos.length)];
+    if (!c) break;
+    const base = [c.pos[0], c.pos[1] + 0.24, c.pos[2]];
+    for (let p = 0; p < 5; p++) {
+      const petalo = hojaBlanda(0.15, 0.12, 0.18);
+      poner(petalo, [0, 0, 0], [1.15, 0, 0]);
+      poner(petalo, base, [0, (p / 5) * Math.PI * 2 + r(), 0]);
+      pintarPlano(petalo, p % 2 === 0 ? ACENTOS.florDeMonte : mezclar(ACENTOS.florDeMonte, ACENTOS.indigo, 0.3));
+      partes.push(petalo);
+    }
+    const centro = new THREE.IcosahedronGeometry(0.045, 0);
+    poner(centro, [base[0], base[1] + 0.03, base[2]]);
+    pintarPlano(centro, ACENTOS.maizTextil); // los estambres amarillos
+    partes.push(centro);
+  }
+
+  return fusionarSeguro(partes, 'arbusto-florecido', { preservarNormales: true });
+}
+
+/*
+ * 9. BEJUCO CON BROMELIAS — el hilo vertical.
+ *
+ * Junta dos arquetipos que en el bosque real siempre andan juntos: la
+ * ENREDADERA (tallo largo y flexible que trepa buscando la luz) y la
+ * BROMELIA-EPÍFITA (roseta que vive montada sin parasitar). Es la pieza que
+ * COSE los tres estratos: nace en la hojarasca, sube por el sotobosque y llega
+ * al dosel. Sin ella los tres pisos se ven como tres decorados apilados; con
+ * ella se ven como un solo bosque.
+ */
+export function geomBejucoBromelia({ q = 1 } = {}, seed = 909) {
+  const r = rng(seed);
+  const partes = [];
+  const alto = 5.6;
+
+  /* La liana: sube en hélice como si abrazara un tronco invisible, y cuelga un
+     lazo — el bucle es lo que la delata como bejuco y no como tallo. */
+  const pts = [];
+  const n = 9;
+  for (let i = 0; i <= n; i++) {
+    const t = i / n;
+    const ang = t * Math.PI * 3.1;
+    const rad = 0.42 * (1 - t * 0.35);
+    pts.push([Math.cos(ang) * rad, alto * t, Math.sin(ang) * rad]);
+  }
+  const liana = tallo(pts, 0.062, 0.03, {
+    tubular: Math.max(14, Math.round(26 * q)), radial: 5, arruga: 0.15, semilla: seed,
+  });
+  hornearCorteza(liana, {
+    grieta: mezclar(CORTEZAS.raicilla, NEUTROS.tinta, 0.45),
+    cuerpo: CORTEZAS.raicilla,
+    cresta: mezclar(CORTEZAS.raicilla, TIERRAS.mantillo, 0.4),
+    liquen: VERDES.paramoMusgo,
+    escalaGrano: 7,
+    hastaLiquen: 2.5,
+  });
+  partes.push(liana);
+
+  /* El lazo que cuelga: puro rubber-hose, una manguera que se descuelga. */
+  const lazo = tallo(
+    [[0.3, alto * 0.72, 0.1], [0.72, alto * 0.55, 0.42], [0.55, alto * 0.3, 0.72], [0.12, alto * 0.34, 0.5]],
+    0.04, 0.026, { tubular: 12, radial: 4, arruga: 0.1, semilla: seed + 5 },
+  );
+  pintarPlano(lazo, mezclar(CORTEZAS.raicilla, NEUTROS.tinta, 0.2));
+  partes.push(lazo);
+
+  /* Las hojas acorazonadas del bejuco, repartidas a lo largo. */
+  const nHojas = Math.max(5, Math.round(11 * q));
+  for (let i = 0; i < nHojas; i++) {
+    const t = 0.18 + (i / nHojas) * 0.78;
+    const ang = t * Math.PI * 3.1;
+    const rad = 0.42 * (1 - t * 0.35);
+    const p = [Math.cos(ang) * rad, alto * t, Math.sin(ang) * rad];
+    const h = hojaBlanda(0.4 + r() * 0.18, 0.3, 0.16);
+    poner(h, [0, 0, 0], [1.05 + r() * 0.4, 0, 0]);
+    poner(h, p, [0, ang + Math.PI / 2 + r() * 0.5, 0]);
+    pintarCopa(h, 'sotobosque', {
+      centro: [0, alto * 0.5, 0], radio: 2.4, yMin: 0, yMax: alto,
+      ao: 0.4, manchas: 0.12,
+    });
+    partes.push(h);
+  }
+
+  /* Las bromelias montadas: tres rosetas a distintas alturas. */
+  const nBro = Math.max(2, Math.round(4 * q));
+  for (let i = 0; i < nBro; i++) {
+    const t = 0.35 + (i / nBro) * 0.55;
+    const ang = t * Math.PI * 3.1;
+    const rad = 0.42 * (1 - t * 0.35);
+    const p = [Math.cos(ang) * rad * 1.3, alto * t, Math.sin(ang) * rad * 1.3];
+    for (const h of bromelia(0.26 + r() * 0.08, seed + i * 7)) {
+      poner(h, p, [0.35 * (r() - 0.5), r() * 6, 0]);
+      pintarCopa(h, 'sotobosque', {
+        centro: p, radio: 0.55, yMin: p[1] - 0.1, yMax: p[1] + 0.45,
+        ao: 0.3, manchas: 0.1,
+        tinte: { base: VERDES.frio, sol: VERDES.brote, luz: ACENTOS.cochinilla },
+      });
+      partes.push(h);
+    }
+  }
+
+  return fusionarSeguro(partes, 'bejuco-bromelia', { preservarNormales: true });
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   6. ESTRATO SUELO — helechos, musgos, hojarasca, lo rastrero
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/*
+ * 10. HELECHO DE SUELO (Blechnum spp.) — la misma fronda del helecho arbóreo,
+ * pero sin estípite y abierta al ras. Que compartan el gesto no es pereza: en
+ * el bosque real es exactamente la misma forma de crecimiento a dos escalas, y
+ * verlo es parte de la lección.
+ */
+export function geomHelechoSuelo({ q = 1 } = {}, seed = 110) {
+  const r = rng(seed);
+  const partes = [];
+  const nFrondas = Math.max(5, Math.round(8 * q));
+
+  for (let i = 0; i < nFrondas; i++) {
+    const ang = (i / nFrondas) * Math.PI * 2 + r() * 0.4;
+    const largo = 0.62 + r() * 0.3;
+    const trozos = fronda({
+      largo,
+      ancho: 0.24,
+      pares: Math.max(4, Math.round(7 * q)),
+      arqueo: 0.68,
+      caida: 0.5,
+      semilla: seed + i * 3,
+      grosorRaquis: 0.03,
+    });
+    for (const t of trozos) {
+      poner(t, [0, 0, 0], [0.1 + r() * 0.2, 0, 0]);
+      poner(t, [0, 0.06, 0], [0, ang, 0]);
+      pintarCopa(t, 'suelo', {
+        centro: [0, 0.4, 0], radio: 0.95, yMin: 0, yMax: 0.8, ao: 0.44, manchas: 0.16,
+      });
+      partes.push(t);
+    }
+  }
+
+  /* Un báculo pequeño: el helecho del suelo también se desenrolla. */
+  const b = baculo(0.34, seed + 9);
+  poner(b, [0.04, 0.05, -0.03], [0, r() * 6, 0]);
+  pintarCopa(b, 'suelo', {
+    centro: [0, 0.4, 0], radio: 0.6, yMin: 0, yMax: 0.6, ao: 0.3, manchas: 0.1,
+    tinte: { base: VERDES.paramoMusgo, sol: VERDES.brote, luz: ACENTOS.maizTextil },
+  });
+  partes.push(b);
+
+  return fusionarSeguro(partes, 'helecho-suelo', { preservarNormales: true });
+}
+
+/*
+ * 11. HIERBA DE SOMBRA — hoja ancha, entera, con la nervadura pálida marcada.
+ * El arquetipo `hierba`: tallo no leñoso. En la penumbra del bosque las hojas
+ * se hacen grandes y planas para cazar la poca luz que baja; dibujarlas anchas
+ * no es licencia, es la adaptación.
+ */
+export function geomHierbaSombra({ q = 1 } = {}, seed = 111) {
+  const r = rng(seed);
+  const partes = [];
+  const nHojas = Math.max(4, Math.round(7 * q));
+
+  for (let i = 0; i < nHojas; i++) {
+    const ang = (i / nHojas) * Math.PI * 2 + r() * 0.5;
+    const largo = 0.46 + r() * 0.28;
+    const h = hojaBlanda(largo, largo * 0.62, 0.14);
+    poner(h, [0, 0, 0], [0.62 + r() * 0.5, 0, 0]);
+    poner(h, [0, 0.04, 0], [0, ang, 0]);
+    pintarCopa(h, 'suelo', {
+      centro: [0, 0.3, 0], radio: 0.8, yMin: 0, yMax: 0.7, ao: 0.4, manchas: 0.15,
+    });
+    partes.push(h);
+
+    /* La nervadura: un hilo pálido por el centro de la hoja. Detalle chico que
+       a media distancia se lee como brillo y saca la hoja del plano. */
+    const nerv = tallo(
+      [[0, 0, 0], [0, largo * 0.5, 0.01], [0, largo * 0.92, 0.02]],
+      0.014, 0.005, { tubular: 4, radial: 4, arruga: 0.02, semilla: seed + i },
+    );
+    poner(nerv, [0, 0, 0], [0.62 + r() * 0.5, 0, 0]);
+    poner(nerv, [0, 0.04, 0], [0, ang, 0]);
+    pintarPlano(nerv, mezclar(VERDES.brote, NEUTROS.hueso, 0.42));
+    partes.push(nerv);
+  }
+
+  return fusionarSeguro(partes, 'hierba-sombra', { preservarNormales: true });
+}
+
+/*
+ * 12. COJÍN DE MUSGO Y HOJARASCA — el piso del bosque.
+ *
+ * Cojines redondos de musgo entre hojas caídas. No es relleno: la hojarasca es
+ * donde el bosque se recicla a sí mismo, y visualmente es lo que impide que el
+ * suelo se vea como una alfombra verde de videojuego. Va en gran cantidad y
+ * por eso es la pieza más barata de todas.
+ */
+export function geomCojinHojarasca({ q = 1 } = {}, seed = 112) {
+  const r = rng(seed);
+  const partes = [];
+
+  /* Los cojines: domos achatados de musgo, en grupo. */
+  const nCojines = Math.max(2, Math.round(4 * q));
+  for (let i = 0; i < nCojines; i++) {
+    const rad = 0.19 + r() * 0.16;
+    const c = matojoNube(rad, seed + i * 5, 0.34);
+    c.scale(1.25, 0.55, 1.25);
+    poner(c, [(r() - 0.5) * 0.7, rad * 0.3, (r() - 0.5) * 0.7]);
+    hornearFollaje(c, {
+      base: mezclar(VERDES.paramoMusgo, NEUTROS.tinta, 0.45),
+      sol: VERDES.paramoMusgo,
+      luz: mezclar(VERDES.paramoMusgo, VERDES.brote, 0.4),
+      centro: [0, 0.1, 0], radio: 0.75, yMin: 0, yMax: 0.4, ao: 0.5, manchas: 0.22,
+    });
+    partes.push(c);
+  }
+
+  /* Las hojas caídas: lozas casi planas, pardas, tiradas de cualquier manera. */
+  const nHojas = Math.max(4, Math.round(9 * q));
+  const pardos = [TIERRAS.mantillo, TIERRAS.mantilloSombra, TIERRAS.camino, mezclar(TIERRAS.mantillo, ACENTOS.ambar, 0.25)];
+  for (let i = 0; i < nHojas; i++) {
+    const h = hojaBlanda(0.2 + r() * 0.14, 0.13, 0.1);
+    poner(h, [0, 0, 0], [Math.PI / 2 + (r() - 0.5) * 0.5, r() * 6, 0]);
+    poner(h, [(r() - 0.5) * 1.15, 0.022, (r() - 0.5) * 1.15]);
+    pintarPlano(h, pardos[i % pardos.length]);
+    partes.push(h);
+  }
+
+  /* Una ramita caída: la firma de que arriba hay dosel. */
+  const ram = tallo(
+    [[-0.35, 0.03, 0.1], [0, 0.05, -0.05], [0.4, 0.03, 0.12]],
+    0.026, 0.012, { tubular: 6, radial: 4, arruga: 0.18, semilla: seed + 3 },
+  );
+  pintarPlano(ram, mezclar(CORTEZAS.raicilla, NEUTROS.tinta, 0.35));
+  partes.push(ram);
+
+  return fusionarSeguro(partes, 'cojin-hojarasca', { preservarNormales: true });
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   7. EL CATÁLOGO DE CONSTRUCTORES + LA SIEMBRA DEL BOSQUE
+   ══════════════════════════════════════════════════════════════════════════ */
+
+export const CONSTRUCTORES = {
+  'palma-de-cera': geomPalmaDeCera,
+  encenillo: geomEncenillo,
+  cedro: geomCedro,
+  nogal: geomNogal,
+  'mano-de-oso': geomManoDeOso,
+  'helecho-arboreo': geomHelechoArboreo,
+  chusque: geomChusque,
+  'arbusto-florecido': geomArbustoFlorecido,
+  'bejuco-bromelia': geomBejucoBromelia,
+  'helecho-suelo': geomHelechoSuelo,
+  'hierba-sombra': geomHierbaSombra,
+  'cojin-hojarasca': geomCojinHojarasca,
+};
+
+/* Cuántas matas de cada arquetipo por tier. Son INSTANCIAS, no draw-calls:
+   cada arquetipo es un solo InstancedMesh por muchas que haya. El tier bajo
+   conserva la LECTURA de los tres estratos (que es la lección) aunque pierda
+   densidad. */
+export const POBLACION = {
+  alto: {
+    'palma-de-cera': 9, encenillo: 16, cedro: 8, nogal: 12,
+    'mano-de-oso': 20, 'helecho-arboreo': 26, chusque: 19, 'arbusto-florecido': 22, 'bejuco-bromelia': 15,
+    'helecho-suelo': 250, 'hierba-sombra': 280, 'cojin-hojarasca': 430,
+  },
+  medio: {
+    'palma-de-cera': 6, encenillo: 11, cedro: 5, nogal: 8,
+    'mano-de-oso': 12, 'helecho-arboreo': 15, chusque: 11, 'arbusto-florecido': 13, 'bejuco-bromelia': 9,
+    'helecho-suelo': 140, 'hierba-sombra': 155, 'cojin-hojarasca': 235,
+  },
+  bajo: {
+    'palma-de-cera': 4, encenillo: 7, cedro: 3, nogal: 5,
+    'mano-de-oso': 6, 'helecho-arboreo': 8, chusque: 6, 'arbusto-florecido': 7, 'bejuco-bromelia': 5,
+    'helecho-suelo': 38, 'hierba-sombra': 42, 'cojin-hojarasca': 58,
+  },
+};
+
+/* La calidad geométrica por tier (subdivisiones, cuántas hojas por planta). */
+export const CALIDAD = { alto: 1, medio: 0.66, bajo: 0.42 };
+
+/*
+ * LA ORILLA DEL BOSQUE. Esta es la decisión de composición que decide si la
+ * lección se ve o no se ve.
+ *
+ * Un bosque sembrado de forma pareja alrededor de la cámara NO enseña sus
+ * estratos: uno queda parado entre troncos, mirando un muro de fustes, con las
+ * copas cortadas por el borde de la pantalla. (Así salió el primer intento.)
+ *
+ * Lo que sí enseña los tres pisos es pararse en el CLARO y mirar la ORILLA del
+ * bosque desde afuera, un poco elevado: entonces el suelo llena el primer
+ * plano, el sotobosque forma su banda a media altura, el dosel cierra arriba y
+ * los emergentes asoman contra el cielo. Cuatro planos en profundidad, que es
+ * exactamente lo que hay que ver.
+ *
+ * Por eso el mundo se parte en dos: el bosque vive en z ≤ `ORILLA` y de ahí
+ * hacia la cámara solo hay claro — con su piso vivo, pero sin nada que tape.
+ */
+const ORILLA = 4.5; // el frente del bosque: cerca, para que llene el cuadro
+const FONDO = -32; // hasta dónde se mete el rodal
+const CLARO = { x: 0, z: 12, radio: 10.5 };
+
+const distanciaAlClaro = (x, z) => Math.hypot(x - CLARO.x, z - CLARO.z);
+
+/*
+ * Siembra el bosque: para cada arquetipo devuelve la lista de instancias
+ * `{ pos, rotY, escala, tilt }`. El reparto no es aleatorio uniforme —
+ * obedece a cómo se organiza un bosque de verdad:
+ *
+ *   · Los EMERGENTES (palma, cedro) van sueltos y lejos entre sí: son los que
+ *     asoman por encima del techo y si se agrupan, tapan.
+ *   · El DOSEL se cierra al fondo y se abre hacia el claro.
+ *   · El SOTOBOSQUE busca los bordes y los claros, que es donde le llega luz.
+ *   · El SUELO cubre todo, con más musgo en las hondonadas.
+ */
+export function poblarBosque({ tier = 'alto', seed = 4242, extension = 23 } = {}) {
+  const r = rng(seed);
+  const conteos = POBLACION[tier] || POBLACION.medio;
+  const bancos = {};
+  /* Memoria de posiciones por estrato para no apiñar los grandes. */
+  const ocupadas = { dosel: [], sotobosque: [] };
+
+  const libre = (x, z, minDist, lista) => {
+    for (let i = 0; i < lista.length; i++) {
+      const [ox, oz] = lista[i];
+      if ((ox - x) ** 2 + (oz - z) ** 2 < minDist * minDist) return false;
+    }
+    return true;
+  };
+
+  const esEmergente = (id) => id === 'palma-de-cera' || id === 'cedro';
+  /* Los que piden MÁS espacio se siembran PRIMERO. Si van de últimos, los que
+     ya están puestos les tapan todos los sitios válidos y el arquetipo entra a
+     medias o no entra — se pierde una especie del rodal sin que nada avise. */
+  const orden = [...ARQUETIPOS].sort((a, b) => {
+    const peso = (x) => (esEmergente(x.id) ? 0 : x.estrato === 'dosel' ? 1 : x.estrato === 'sotobosque' ? 2 : 3);
+    return peso(a) - peso(b);
+  });
+
+  for (const arq of orden) {
+    const n = conteos[arq.id] || 0;
+    const items = [];
+    const esGrande = arq.estrato === 'dosel';
+    const emergente = esEmergente(arq.id);
+    /* Separación mínima entre matas del mismo porte. */
+    const minDist = emergente ? 7.4 : esGrande ? 4.1 : arq.estrato === 'sotobosque' ? 1.6 : 0;
+    /* Los grandes se siembran con separación mínima contra TODOS los árboles ya
+       puestos, así que necesitan muchos más intentos: con pocos, los últimos
+       arquetipos de la lista se quedan sin cupo y el rodal pierde una especie
+       entera sin avisar (al cedro le pasó: pedía 8 y entraban 3). */
+    const intentos = minDist > 0 ? n * 160 : n * 40;
+
+    for (let i = 0; i < intentos && items.length < n; i++) {
+      const x = (r() * 2 - 1) * extension;
+      /* El SUELO cubre todo (también el claro, que si queda pelado se lee como
+         potrero); los otros dos estratos viven detrás de la orilla. */
+      const z = arq.estrato === 'suelo'
+        ? FONDO + r() * (extension + 8 - FONDO)
+        : FONDO + r() * (ORILLA - FONDO);
+      const dClaro = distanciaAlClaro(x, z);
+
+      /* El claro: los grandes no entran; los del sotobosque rondan el borde. */
+      if (esGrande && dClaro < CLARO.radio) continue;
+      if (arq.estrato === 'sotobosque' && dClaro < CLARO.radio * 0.68) continue;
+      /* Los emergentes, además, se van al fondo: su gracia es verlos LEJOS y
+         aun así por encima de todo. */
+      if (emergente && z > -6) continue;
+
+      if (minDist > 0) {
+        const lista = esGrande ? ocupadas.dosel : ocupadas.sotobosque;
+        if (!libre(x, z, minDist, lista)) continue;
+        lista.push([x, z]);
+      }
+
+      const y = alturaSuelo(x, z);
+      /* Escala: variación honesta (un rodal tiene árboles de todas las edades)
+         y squash & stretch — unas matas más gordas y bajitas, otras espigadas. */
+      const base = 0.82 + r() * 0.42;
+      const estira = 0.92 + r() * 0.2;
+      items.push({
+        pos: [x, y, z],
+        rotY: r() * Math.PI * 2,
+        escala: [base / Math.sqrt(estira), base * estira, base / Math.sqrt(estira)],
+        /* Ladeo: nada crece a plomo. Los altos se ladean menos que los bajos. */
+        tilt: [
+          (r() - 0.5) * (esGrande ? 0.05 : 0.17),
+          (r() - 0.5) * (esGrande ? 0.05 : 0.17),
+        ],
+        semilla: r(),
+      });
+    }
+    bancos[arq.id] = items;
+  }
+
+  return bancos;
+}
+
+/*
+ * NOTA SOBRE LA NIEBLA — dos intentos descartados, para que no se repitan.
+ *
+ * 1) Velos horizontales a la altura de corte de cada estrato, para recortar el
+ *    dosel contra el sotobosque con perspectiva aérea. Desde una cámara algo
+ *    elevada se ven POR ENCIMA y se leen como una lámina gris atravesada en el
+ *    bosque: parece un defecto de render, no atmósfera.
+ * 2) Un solo velo bajo, a ras de suelo. Como el terreno sube hacia el claro, el
+ *    piso lo ATRAVIESA y deja una arista recta y dura cruzando la escena.
+ *
+ * Ningún plano translúcido flotando aguanta que la cámara orbite. La separación
+ * entre pisos la hacen los dos recursos que sí aguantan cualquier ángulo: el
+ * VALOR horneado de cada estrato (dosel encendido, sotobosque medio, suelo
+ * oscuro) y la niebla de DISTANCIA del propio motor. La niebla que se ve en la
+ * escena es esa, y el botón la corre de cerca a lejos.
+ */

--- a/src/visual/mundo3d/bosque/estratosAltoandinos.geom.js
+++ b/src/visual/mundo3d/bosque/estratosAltoandinos.geom.js
@@ -5,11 +5,10 @@
  * ── Por qué existe este módulo ─────────────────────────────────────────────
  * El catálogo de Chagra tiene 581 especies de flora. Modelarlas una por una es
  * imposible y además innecesario: la botánica andina se deja resumir en un
- * puñado de FORMAS DE CRECIMIENTO. El DR primario (taxonomía de ~12 arquetipos,
- * gemini + glm 2026-06-19) fija esa lista; el DR de diferenciación visual de
- * árboles altoandinos (34.5 KB, gemini + glm) dice CÓMO se distingue cada uno a
- * 30 metros. Con doce siluetas bien dibujadas se puede mostrar el catálogo
- * entero sin modelar 581 mallas.
+ * puñado de FORMAS DE CRECIMIENTO. El dossier de taxonomía de arquetipos fija
+ * esa lista de ~12; el de diferenciación visual de árboles altoandinos dice
+ * CÓMO se distingue cada uno a 30 metros. Con doce siluetas bien dibujadas se
+ * puede mostrar el catálogo entero sin modelar 581 mallas.
  *
  * ── La prueba de cada arquetipo ────────────────────────────────────────────
  * Si hay que acercarse para saber qué es, no sirve. Cada forma se diseñó por su

--- a/src/visual/mundo3d/bosque/floraParamo.geom.js
+++ b/src/visual/mundo3d/bosque/floraParamo.geom.js
@@ -553,17 +553,19 @@ export function geomYarumo({ q = 1 } = {}, seed = 2) {
     puntas.push([base[0] + dir[0] * largo, base[1] + dir[1] * largo, base[2] + dir[2] * largo]);
   }
 
-  // Hojas palmeadas: discos aplanados de 7 lóbulos, envés blanco, colgando.
-  const porPunta = Math.max(2, Math.round(3 * q));
+  // Hojas palmeadas: discos aplanados de 7 lóbulos, envés blanco, formando una
+  // SOMBRILLA ancha y CHATA sostenida en lo alto del fuste pálido desnudo — la
+  // firma inconfundible del yarumo (Cecropia) que remata el estrato emergente.
+  const porPunta = Math.max(3, Math.round(4 * q));
   for (const p of puntas) {
     for (let i = 0; i < porPunta; i++) {
       const ang = (i / porPunta) * Math.PI * 2 + r();
-      const rad = 0.18 + r() * 0.12;
-      const hoja = new THREE.ConeGeometry(0.42, 0.09, 7, 1); // 7-gono chato = "mano"
+      const rad = 0.22 + r() * 0.18; // se abre más ancha = parasol
+      const hoja = new THREE.ConeGeometry(0.52, 0.08, 7, 1); // 7-gono chato = "mano"
       apuntar(
         hoja,
-        [p[0] + Math.cos(ang) * rad, p[1] - 0.05 - r() * 0.08, p[2] + Math.sin(ang) * rad],
-        [Math.cos(ang) * 0.4, 0.9, Math.sin(ang) * 0.4],
+        [p[0] + Math.cos(ang) * rad, p[1] - 0.02 - r() * 0.05, p[2] + Math.sin(ang) * rad],
+        [Math.cos(ang) * 0.55, 0.78, Math.sin(ang) * 0.55], // más horizontal = plato
         [1, 0.5, 1],
       );
       partes.push(pintar(hoja, variar(PAL.yarumoEnves, r, 0.05)));
@@ -605,20 +607,23 @@ export function geomRoble({ q = 1 } = {}, seed = 3) {
     partes.push(pintar(rama, PAL.robleTronco));
   }
 
-  // Copa ANCHA: domo central + corona de lóbulos alrededor (masa de hojas).
-  const lobs = [{ c: [top.x, top.y + 0.55, top.z], radio: 0.9 }];
-  const nL = Math.max(3, Math.round(5 * q));
+  // Copa ANCHA y EXTENDIDA: la más ancha del dosel. Domo central APLANADO +
+  // corona de lóbulos que se ABREN horizontal → sombrilla frondosa de roble
+  // (hojas agrupadas hacia los extremos de las ramas, DR). Ancha y baja de
+  // perfil: contrasta con la pirámide invertida del encenillo y la aguja del aliso.
+  const lobs = [{ c: [top.x, top.y + 0.46, top.z], radio: 1.04 }];
+  const nL = Math.max(4, Math.round(6 * q));
   for (let i = 0; i < nL; i++) {
-    const ang = (i / nL) * Math.PI * 2 + r() * 0.6;
-    const rad = 0.6 + r() * 0.5;
+    const ang = (i / nL) * Math.PI * 2 + r() * 0.5;
+    const rad = 0.95 + r() * 0.62; // se ABRE ancho (antes 0.6–1.1)
     lobs.push({
-      c: [Math.cos(ang) * rad, H + 0.1 + r() * 0.7, Math.sin(ang) * rad],
-      radio: 0.55 + r() * 0.32,
+      c: [top.x + Math.cos(ang) * rad, H + 0.12 + r() * 0.48, top.z + Math.sin(ang) * rad],
+      radio: 0.6 + r() * 0.34,
     });
   }
   copaMasa(lobs, {
     base: PAL.robleHoja, sol: PAL.robleHoja2, luz: PAL.robleLuz,
-    q, seed: seed + 7, achatado: 0.82, huecos: 0.44, mordida: 0.4, ao: 0.66, manchas: 0.15,
+    q, seed: seed + 7, achatado: 0.86, huecos: 0.44, mordida: 0.4, ao: 0.66, manchas: 0.15,
   }).forEach((cc) => partes.push(cc));
 
   // Bellotas (unas pocas, cuelgan del borde de la copa).
@@ -645,9 +650,11 @@ export function geomRoble({ q = 1 } = {}, seed = 3) {
 /* -------------------------------------------------------------------------- */
 
 /*
- * Copa oscura, compacta e irregular —masa de hojas sombría— sobre tronco rojizo
- * algo torcido, con barbas de musgo colgando (vive envuelto en niebla). Más
- * estrecho y sombrío que el roble.
+ * LA FIRMA DEL ENCENILLO (DR primario): copa en PIRÁMIDE INVERTIDA / triángulo
+ * invertido, con el follaje concentrado en UNA sola capa superior ANCHA que se
+ * estrecha hacia el tronco rojizo torcido. Barbas de musgo colgando del borde
+ * (vive envuelto en niebla). Esa silueta de "paraguas triangular al revés" es
+ * lo que lo distingue del domo redondo del roble a treinta metros.
  */
 export function geomEncenillo({ q = 1 } = {}, seed = 4) {
   const r = rng(seed);
@@ -662,27 +669,45 @@ export function geomEncenillo({ q = 1 } = {}, seed = 4) {
   partes.push(geo);
   const top = curva.getPointAt(1);
 
-  // Copa estrecha y alta: lóbulos apilados que suben poco a poco.
-  const lobs = [{ c: [top.x, top.y + 0.45, top.z], radio: 0.62 }];
-  const nL = Math.max(3, Math.round(5 * q));
-  for (let i = 0; i < nL; i++) {
-    const f = i / nL;
-    const ang = r() * Math.PI * 2;
-    const rad = 0.15 + r() * 0.42;
-    lobs.push({
-      c: [Math.cos(ang) * rad, H + 0.1 + f * 0.9 + r() * 0.3, Math.sin(ang) * rad],
-      radio: 0.4 + r() * 0.28,
-    });
+  // PIRÁMIDE INVERTIDA: anillos de lóbulos cuyo radio CRECE con la altura →
+  // el vértice del triángulo abajo (pegado al fuste) y la boca ancha arriba.
+  // La masa se concentra en la banda superior (más lóbulos y más grandes),
+  // como manda el DR: "follaje concentrado en una sola capa superior".
+  const cyBase = top.y + 0.02; // donde la copa toca el fuste (vértice angosto)
+  const alturaCopa = 1.4;
+  const lobs = [
+    // El vértice del triángulo invertido: un núcleo ESTRECHO al pie de la copa.
+    { c: [top.x, cyBase + 0.05, top.z], radio: 0.26 },
+  ];
+  const niveles = Math.max(3, Math.round(4 * q));
+  for (let k = 1; k <= niveles; k++) {
+    const f = k / niveles; // 0 abajo (angosto) → 1 arriba (ancho)
+    const y = cyBase + f * alturaCopa;
+    const anilloR = 0.1 + f * f * 1.05; // se ABRE fuerte hacia arriba (embudo)
+    // La masa se concentra ARRIBA (boca ancha del embudo): pocos lóbulos abajo,
+    // muchos en la corona → "follaje en una sola capa superior" (DR).
+    const porNivel = f < 0.34 ? 1 : Math.max(2, Math.round((1 + f * 4) * q));
+    for (let i = 0; i < porNivel; i++) {
+      const ang = (i / porNivel) * Math.PI * 2 + r() * 1.2;
+      const rad = anilloR * (0.72 + r() * 0.46);
+      lobs.push({
+        c: [top.x + Math.cos(ang) * rad, y + (r() - 0.5) * 0.12, top.z + Math.sin(ang) * rad],
+        radio: (0.28 + f * 0.32) + r() * 0.12, // lóbulos más grandes en la corona
+      });
+    }
   }
   copaMasa(lobs, {
     base: PAL.encenilloHoja, sol: PAL.encenilloHoja2, luz: PAL.encenilloLuz,
     q, seed: seed + 7, achatado: 0.78, huecos: 0.4, mordida: 0.34, ao: 0.68, manchas: 0.16,
   }).forEach((cc) => partes.push(cc));
 
-  // Barbas de musgo/usnea colgando del borde de la copa (el velo de la niebla).
+  // Barbas de musgo/usnea colgando del BORDE ANCHO de arriba (los últimos
+  // lóbulos = la boca de la pirámide invertida) → el velo de la niebla cuelga
+  // de la capa superior, no del vértice angosto pegado al fuste.
   const nBarbas = Math.max(2, Math.round(5 * q));
+  const desdeArriba = Math.max(1, Math.floor(lobs.length * 0.45));
   for (let i = 0; i < nBarbas; i++) {
-    const lb = lobs[i % lobs.length];
+    const lb = lobs[lobs.length - 1 - (i % desdeArriba)];
     const ang = r() * Math.PI * 2;
     const largo = 0.28 + r() * 0.3;
     const barba = new THREE.ConeGeometry(0.04, largo, 4, 1);
@@ -719,16 +744,18 @@ export function geomAliso({ q = 1 } = {}, seed = 5) {
   partes.push(geo);
   const top = curva.getPointAt(1);
 
-  // Copa cónica: lóbulos que se estrechan y sesgan hacia arriba desde el fuste.
+  // Copa CÓNICA-AGUJA: columna de lóbulos apilados que se ADELGAZAN hasta una
+  // PUNTA fina — el aliso es el emergente esbelto que pincha el dosel (silueta
+  // opuesta a la sombrilla chata del yarumo). Estrecha, alta y puntiaguda.
   const lobs = [];
-  const nL = Math.max(4, Math.round(6 * q));
+  const nL = Math.max(5, Math.round(7 * q));
   for (let i = 0; i < nL; i++) {
-    const f = i / (nL - 1); // 0 abajo → 1 punta
+    const f = i / (nL - 1); // 0 base → 1 punta
     const ang = r() * Math.PI * 2;
-    const rad = (0.62 - f * 0.5) * (0.4 + r() * 0.7);
+    const rad = (0.5 - f * 0.46) * (0.4 + r() * 0.6); // casi 0 en la punta
     lobs.push({
-      c: [top.x + Math.cos(ang) * rad, H - 1.0 + f * 2.1 + r() * 0.15, top.z + Math.sin(ang) * rad],
-      radio: (0.52 - f * 0.24) + r() * 0.12,
+      c: [top.x + Math.cos(ang) * rad, H - 0.85 + f * 2.2 + r() * 0.12, top.z + Math.sin(ang) * rad],
+      radio: (0.46 - f * 0.34) + r() * 0.08, // se afina hacia la aguja
     });
   }
   copaMasa(lobs, {
@@ -792,19 +819,21 @@ export function geomMortino({ q = 1 } = {}, seed = 7) {
   const r = rng(seed);
   const partes = [];
 
+  // Arbusto BAJO y EXTENDIDO del piso del monte: cojín ancho que abraza el suelo
+  // (más ancho que alto) → lee sotobosque, no arbolito, bajo el dosel.
   const lobs = [];
   const nBlobs = Math.max(3, Math.round(5 * q));
   for (let i = 0; i < nBlobs; i++) {
     const ang = r() * Math.PI * 2;
-    const rad = r() * 0.3;
+    const rad = r() * 0.42; // se extiende ancho por el piso
     lobs.push({
-      c: [Math.cos(ang) * rad, 0.2 + r() * 0.42, Math.sin(ang) * rad],
-      radio: 0.2 + r() * 0.16,
+      c: [Math.cos(ang) * rad, 0.13 + r() * 0.3, Math.sin(ang) * rad], // más bajo
+      radio: 0.2 + r() * 0.17,
     });
   }
   copaMasa(lobs, {
     base: PAL.mortinoHoja, sol: PAL.mortinoHoja2, luz: '#9ab06a',
-    q, seed: seed + 5, achatado: 0.8, huecos: 0.34, mordida: 0.32, ao: 0.58, manchas: 0.18, densidad: 8,
+    q, seed: seed + 5, achatado: 0.84, huecos: 0.34, mordida: 0.32, ao: 0.58, manchas: 0.18, densidad: 8,
   }).forEach((cc) => partes.push(cc));
 
   // Brotes rojizos nuevos (puntas tiernas).
@@ -844,16 +873,19 @@ export function geomRomerillo({ q = 1 } = {}, seed = 8) {
   const r = rng(seed);
   const partes = [];
 
+  // Cojín BAJO de ramitas que se ARQUEAN hacia afuera (mata de páramo que se
+  // abre en abanico), no aguja vertical: silueta de matorral raso del piso.
   const nRamitas = Math.max(6, Math.round(14 * q));
   for (let i = 0; i < nRamitas; i++) {
     const ang = r() * Math.PI * 2;
-    const rad = r() * 0.28;
-    const largo = 0.28 + r() * 0.32;
+    const rad = r() * 0.34; // más extendido por el suelo
+    const largo = 0.22 + r() * 0.26; // ramitas más cortas (cojín)
     const ramita = new THREE.ConeGeometry(0.05, largo, 4, 1);
     apuntar(
       ramita,
-      [Math.cos(ang) * rad, largo * 0.4, Math.sin(ang) * rad],
-      [Math.cos(ang) * 0.35 + (r() - 0.5) * 0.3, 1, Math.sin(ang) * 0.35 + (r() - 0.5) * 0.3],
+      [Math.cos(ang) * rad, 0.16 + largo * 0.26, Math.sin(ang) * rad],
+      // ARQUEA hacia afuera (0.75 lateral vs 0.85 vertical) → abanico bajo
+      [Math.cos(ang) * 0.75 + (r() - 0.5) * 0.3, 0.85, Math.sin(ang) * 0.75 + (r() - 0.5) * 0.3],
     );
     partes.push(pintar(ramita, variar(r() > 0.5 ? PAL.romerilloHoja : PAL.romerilloHoja2, r, 0.1)));
   }
@@ -863,7 +895,7 @@ export function geomRomerillo({ q = 1 } = {}, seed = 8) {
       const ang = r() * Math.PI * 2;
       const rad = r() * 0.26;
       const flor = new THREE.IcosahedronGeometry(0.035, 0);
-      poner(flor, [Math.cos(ang) * rad, 0.35 + r() * 0.3, Math.sin(ang) * rad]);
+      poner(flor, [Math.cos(ang) * rad, 0.24 + r() * 0.2, Math.sin(ang) * rad]);
       partes.push(pintar(flor, PAL.romerilloFlor));
     }
   }


### PR DESCRIPTION
## Qué
Pase de ARTE sobre los 7 arquetipos de flora del bosque del valle (`src/visual/mundo3d/bosque/floraParamo.geom.js`) para que los **tres estratos** se distingan por **SILUETA reconocible a distancia**, no solo por altura del mismo mesh repetido.

Lente: Cartoon Saloon (bosque de trazo vivo) + Humboldt (silueta reconocible). Especies nativas reales del altoandino colombiano.

## Los tres estratos
- **Emergentes** (pinchan el dosel):
  - *Yarumo* (Cecropia telealba): sombrilla pálida ancha y chata sobre fuste desnudo — la firma andina.
  - *Aliso* (Alnus acuminata): aguja cónica esbelta y puntiaguda.
- **Dosel** (cuerpo continuo, tres siluetas distintas):
  - *Encenillo* (Weinmannia): copa en **pirámide invertida / embudo** — follaje concentrado en una sola capa superior que se estrecha hacia el fuste (rasgo documentado en el DR primario).
  - *Roble andino* (Quercus humboldtii): domo ancho y extendido, la copa más amplia.
  - *Gaque* (Clusia): domo bajo compacto.
- **Sotobosque** (arbustivas bajas):
  - *Mortiño* (Vaccinium meridionale) con bayas de agraz y *romerillo*, rebajados a matorral bajo y extendido.

## Cómo
- Reforma solo la geometría/forma de copa de cada arquetipo (arreglo de lóbulos de `copaMasa`, conos de hoja, alturas de siembra del follaje).
- **Aditivo**: conserva paleta/material madre, la técnica `copaMasa` + `hornearFollaje` con normales radiales y `fusionarSeguro` (gotcha `mergeGeometries` respetado), y **todos los exports**.
- **No toca** `siembraValle.js` ni la lógica de placement/composición (carril separado).

## Verificación
- `npm run build` **verde** (exit 0).
- Tests de construcción de especies (`bosqueRealismo.test.js`) **intactos**: las 7 especies siguen construyendo con vértices + color horneado en todos los tiers; sombreado de gaque conservado. (Los fallos preexistentes de `distribucionFlora`/`geometriaLaminas` son ajenos a este cambio.)
- Prueba visual de día (elevación lateral de los 7 arquetipos, banco efímero no commiteado): los tres estratos se leen por silueta y por altura.

Gate visual final con GPU real → a cargo del revisor. NO deploy.

Diff: 1 archivo, +77/-45.