### PR TITLE
feat(visual): set coherente de iconos por etapa de ciclo en cards

### DIFF
--- a/src/components/aprendizaje/GuiaEspecieCards.jsx
+++ b/src/components/aprendizaje/GuiaEspecieCards.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { Sprout, AlertTriangle, CheckCircle, ChevronDown, ChevronUp, Bug, Wrench } from 'lucide-react';
+import { Sprout, AlertTriangle, ChevronDown, ChevronUp, Bug, Wrench } from 'lucide-react';
 import { GUIAS_DEMO } from '../../data/aprendizaje/guias-demo.js';
+import { IconoEtapaCiclo } from '../../visual/icons/index.js';
 
 /**
  * GuiaEspecieCards — tarjetas visuales del módulo de APRENDIZAJE.
@@ -56,18 +57,6 @@ export default function GuiaEspecieCards({ especie = 'papa', etapas: etapasProp 
     return colors[orden - 1] || colors[colors.length - 1];
   };
 
-  const getEtapaIcon = (orden) => {
-    const icons = [
-      <Sprout size={16} />,    // Germinación
-      <Sprout size={16} />,    // Vegetativo
-      <CheckCircle size={16} />, // Floración
-      <CheckCircle size={16} />, // Fructificación
-      <CheckCircle size={16} />, // Cosecha
-      <CheckCircle size={16} />  // Producto
-    ];
-    return icons[orden - 1] || icons[icons.length - 1];
-  };
-
   return (
     <div
       data-testid="guia-especie-cards"
@@ -108,7 +97,7 @@ export default function GuiaEspecieCards({ especie = 'papa', etapas: etapasProp 
               <div className="flex items-start justify-between gap-2 mb-2">
                 <div className="flex items-center gap-2">
                   <div className={`p-1.5 rounded-lg ${getEtapaColor(etapa.orden)}`}>
-                    {getEtapaIcon(etapa.orden)}
+                    <IconoEtapaCiclo orden={etapa.orden} size={16} />
                   </div>
                   <div>
                     <h4 className="text-sm font-bold text-slate-100">

--- a/src/components/aprendizaje/GuiaEspecieCards.test.jsx
+++ b/src/components/aprendizaje/GuiaEspecieCards.test.jsx
@@ -179,6 +179,24 @@ describe('GuiaEspecieCards — módulo APRENDIZAJE', () => {
     expect(etapa4.className).toContain('border-amber-600');
   });
 
+  it('cada etapa muestra su icono de ciclo distinto (no un genérico repetido)', () => {
+    const { container } = render(<GuiaEspecieCards especie="papa" />);
+
+    // Un icono de etapa por card, con el orden fenológico correcto…
+    const ordenes = Array.from(
+      container.querySelectorAll('svg[data-etapa-orden]'),
+      (svg) => svg.getAttribute('data-etapa-orden'),
+    );
+    expect(ordenes).toEqual(['1', '2', '3', '4', '5', '6']);
+
+    // …y los seis glifos son geometrías distintas entre sí.
+    const glifos = Array.from(
+      container.querySelectorAll('svg[data-etapa-orden]'),
+      (svg) => svg.innerHTML,
+    );
+    expect(new Set(glifos).size).toBe(6);
+  });
+
   it('es móvil-first (responsive)', () => {
     render(<GuiaEspecieCards especie="papa" />);
 

--- a/src/visual/icons/IconosEtapaCiclo.jsx
+++ b/src/visual/icons/IconosEtapaCiclo.jsx
@@ -1,0 +1,150 @@
+/*
+ * Iconos de ETAPA DE CICLO — set coherente para catálogo y cards.
+ *
+ * Seis glifos que cuentan la vida de una mata en orden: semilla que germina →
+ * mata frondosa → flor → fruto → canasta de cosecha → frasco guardado. Todos
+ * comparten la MISMA familia visual: línea de un solo grosor, uniones
+ * redondeadas y `currentColor` — no traen color propio, así que toman el tinte
+ * de su etapa (la clase `text-*` del contenedor) y quedan legibles a 16 px.
+ *
+ * Reutilizable: antes de dibujar un icono de fase, úselos desde aquí. La forma
+ * de consumo canónica es <IconoEtapaCiclo orden={1..6} />, que respeta el mismo
+ * orden fenológico que ya usan las guías (germinación=1 … producto=6).
+ *
+ * Props comunes: { size = 16, title, className, ...rest }.
+ *   - Sin `title` el icono es decorativo (aria-hidden): úselo junto a un rótulo
+ *     de texto, que es lo normal en una card.
+ *   - Con `title` pasa a role="img" con su <title> accesible (uso suelto).
+ */
+
+const VIEWBOX = '0 0 24 24';
+
+/* Rasgos compartidos por las seis etapas: una sola familia de trazo. */
+const TRAZO = {
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.9,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+};
+
+function IconoEtapaBase({ size = 16, title = '', className = '', children, ...rest }) {
+  const decorativo = !title;
+  return (
+    <svg
+      viewBox={VIEWBOX}
+      width={size}
+      height={size}
+      className={className}
+      role={decorativo ? undefined : 'img'}
+      aria-hidden={decorativo ? 'true' : undefined}
+      aria-label={decorativo ? undefined : title}
+      {...rest}
+    >
+      {decorativo ? null : <title>{title}</title>}
+      <g {...TRAZO}>{children}</g>
+    </svg>
+  );
+}
+
+/* 1 · Germinación — la semilla revienta y saca su primer par de cotiledones. */
+export function IconoGerminacion(props) {
+  return (
+    <IconoEtapaBase {...props}>
+      <path d="M3.5 19 H20.5" />
+      <path d="M12 19 V11.5" />
+      <path d="M12 12.5 C9.4 12.9 7.5 11.6 6.7 9.2 C9.4 8.8 11.4 10.1 12 12.5 Z" />
+      <path d="M12 12.5 C14.6 12.9 16.5 11.6 17.3 9.2 C14.6 8.8 12.6 10.1 12 12.5 Z" />
+    </IconoEtapaBase>
+  );
+}
+
+/* 2 · Vegetativo — la mata frondosa: tallo con dos pares de hojas. */
+export function IconoVegetativo(props) {
+  return (
+    <IconoEtapaBase {...props}>
+      <path d="M12 21 V6" />
+      <path d="M12 9.5 C9.6 9.9 7.7 8.6 6.9 6.2 C9.6 5.8 11.4 7.1 12 9.5 Z" />
+      <path d="M12 9.5 C14.4 9.9 16.3 8.6 17.1 6.2 C14.4 5.8 12.6 7.1 12 9.5 Z" />
+      <path d="M12 14.5 C9.8 14.9 8 13.7 7.3 11.5 C9.8 11.1 11.5 12.3 12 14.5 Z" />
+      <path d="M12 14.5 C14.2 14.9 16 13.7 16.7 11.5 C14.2 11.1 12.5 12.3 12 14.5 Z" />
+    </IconoEtapaBase>
+  );
+}
+
+/* 3 · Floración — flor de cinco pétalos sobre su tallo con hoja. */
+export function IconoFloracion(props) {
+  return (
+    <IconoEtapaBase {...props}>
+      <path d="M12 21 V13" />
+      <path d="M12 16.5 C10 16.9 8.4 15.7 7.8 13.7 C10 13.3 11.5 14.5 12 16.5 Z" />
+      <g transform="translate(12 8.5)">
+        <ellipse cx="0" cy="-3.3" rx="1.6" ry="2.5" />
+        <ellipse cx="0" cy="-3.3" rx="1.6" ry="2.5" transform="rotate(72)" />
+        <ellipse cx="0" cy="-3.3" rx="1.6" ry="2.5" transform="rotate(144)" />
+        <ellipse cx="0" cy="-3.3" rx="1.6" ry="2.5" transform="rotate(216)" />
+        <ellipse cx="0" cy="-3.3" rx="1.6" ry="2.5" transform="rotate(288)" />
+      </g>
+      <circle cx="12" cy="8.5" r="1.5" fill="currentColor" stroke="none" />
+    </IconoEtapaBase>
+  );
+}
+
+/* 4 · Fructificación — el fruto cuajado con su pedúnculo y una hoja. */
+export function IconoFructificacion(props) {
+  return (
+    <IconoEtapaBase {...props}>
+      <path d="M12 21 C8.9 21 6.7 18.6 6.7 15.6 C6.7 12.8 9.1 11.2 12 11.2 C14.9 11.2 17.3 12.8 17.3 15.6 C17.3 18.6 15.1 21 12 21 Z" />
+      <path d="M12 11.2 V7.5" />
+      <path d="M12.2 9.1 C13.4 7.2 15.5 6.4 17.4 6.6 C17.2 8.6 15.4 9.6 12.2 9.1 Z" />
+    </IconoEtapaBase>
+  );
+}
+
+/* 5 · Cosecha — la canasta con asa y banda de trenzado. */
+export function IconoCosecha(props) {
+  return (
+    <IconoEtapaBase {...props}>
+      <path d="M8 11 C8.4 7.6 15.6 7.6 16 11" />
+      <path d="M4.5 11 H19.5" />
+      <path d="M6 11 L7.4 19.2 A1.3 1.3 0 0 0 8.7 20.3 H15.3 A1.3 1.3 0 0 0 16.6 19.2 L18 11" />
+      <path d="M6.8 15.5 H17.2" />
+    </IconoEtapaBase>
+  );
+}
+
+/* 6 · Producto — la cosecha guardada en su frasco, con su tapa y nivel. */
+export function IconoProducto(props) {
+  return (
+    <IconoEtapaBase {...props}>
+      <path d="M8.5 3.5 H15.5 A1 1 0 0 1 16.5 4.5 V6 H7.5 V4.5 A1 1 0 0 1 8.5 3.5 Z" />
+      <path d="M8 6 H16 V18.5 A2 2 0 0 1 14 20.5 H10 A2 2 0 0 1 8 18.5 Z" />
+      <path d="M8 12 H16" />
+    </IconoEtapaBase>
+  );
+}
+
+/* Set en orden fenológico (1-indexado por posición): germinación → producto. */
+// eslint-disable-next-line react-refresh/only-export-components -- registro del set que los tests validan junto a los iconos (patrón EjemplosVoz)
+export const ICONOS_ETAPA_POR_ORDEN = [
+  IconoGerminacion,
+  IconoVegetativo,
+  IconoFloracion,
+  IconoFructificacion,
+  IconoCosecha,
+  IconoProducto,
+];
+
+/*
+ * IconoEtapaCiclo — punto de entrada por `orden` (1..6). Recorta a rango y cae
+ * a la última etapa si el orden viene fuera de rango, para que una card nunca
+ * quede sin icono. Marca `data-etapa-orden` con la etapa resuelta.
+ */
+export function IconoEtapaCiclo({ orden = 1, ...props }) {
+  const total = ICONOS_ETAPA_POR_ORDEN.length;
+  const n = Number.isFinite(orden) ? Math.min(Math.max(Math.trunc(orden), 1), total) : total;
+  const Icono = ICONOS_ETAPA_POR_ORDEN[n - 1];
+  return <Icono data-etapa-orden={n} {...props} />;
+}
+
+export default IconoEtapaCiclo;

--- a/src/visual/icons/IconosEtapaCiclo.test.jsx
+++ b/src/visual/icons/IconosEtapaCiclo.test.jsx
@@ -1,0 +1,102 @@
+/*
+ * IconosEtapaCiclo.test.jsx — el set de iconos de etapa de ciclo.
+ *
+ * Task #iconos-especie-ciclo: verifica que las seis etapas rindan un glifo
+ * distinto, coherente (mismo trazo + currentColor) y accesible según se use
+ * decorativo o rotulado.
+ */
+import { createElement } from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import {
+  IconoEtapaCiclo,
+  IconoGerminacion,
+  IconoVegetativo,
+  IconoFloracion,
+  IconoFructificacion,
+  IconoCosecha,
+  IconoProducto,
+  ICONOS_ETAPA_POR_ORDEN,
+} from './IconosEtapaCiclo.jsx';
+
+describe('IconosEtapaCiclo — set de etapa de ciclo', () => {
+  it('exporta las seis etapas en orden fenológico', () => {
+    expect(ICONOS_ETAPA_POR_ORDEN).toHaveLength(6);
+    expect(ICONOS_ETAPA_POR_ORDEN).toEqual([
+      IconoGerminacion,
+      IconoVegetativo,
+      IconoFloracion,
+      IconoFructificacion,
+      IconoCosecha,
+      IconoProducto,
+    ]);
+  });
+
+  it('cada etapa rinde un <svg> con geometría propia (glifos distintos)', () => {
+    const marcado = ICONOS_ETAPA_POR_ORDEN.map((Icono) => {
+      const { container } = render(createElement(Icono));
+      const svg = container.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+      // Serializa la geometría del glifo (paths/ellipses/circles) para comparar.
+      return container.innerHTML.replace(/\s+/g, '');
+    });
+    // Ningún par de etapas comparte el mismo dibujo.
+    expect(new Set(marcado).size).toBe(6);
+  });
+
+  it('todo el set usa un trazo coherente sobre currentColor', () => {
+    ICONOS_ETAPA_POR_ORDEN.forEach((Icono) => {
+      const { container } = render(createElement(Icono));
+      const g = container.querySelector('g');
+      expect(g).toHaveAttribute('stroke', 'currentColor');
+      expect(g).toHaveAttribute('stroke-width', '1.9');
+    });
+  });
+
+  it('respeta el tamaño pedido', () => {
+    const { container } = render(<IconoGerminacion size={24} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+  });
+
+  it('es decorativo por defecto (aria-hidden, sin rol)', () => {
+    const { container } = render(<IconoCosecha />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+    expect(svg).not.toHaveAttribute('role');
+    expect(container.querySelector('title')).toBeNull();
+  });
+
+  it('con title pasa a role="img" con su <title> accesible', () => {
+    const { container, getByTitle } = render(<IconoCosecha title="Cosecha" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('role', 'img');
+    expect(svg).toHaveAttribute('aria-label', 'Cosecha');
+    expect(getByTitle('Cosecha')).toBeInTheDocument();
+  });
+
+  describe('IconoEtapaCiclo — despacho por orden', () => {
+    it('elige el glifo de cada orden 1..6', () => {
+      for (let orden = 1; orden <= 6; orden += 1) {
+        const { container } = render(<IconoEtapaCiclo orden={orden} />);
+        expect(container.querySelector('svg')).toHaveAttribute(
+          'data-etapa-orden',
+          String(orden),
+        );
+      }
+    });
+
+    it('recorta el orden fuera de rango a una etapa válida', () => {
+      const bajo = render(<IconoEtapaCiclo orden={0} />);
+      expect(bajo.container.querySelector('svg')).toHaveAttribute('data-etapa-orden', '1');
+
+      const alto = render(<IconoEtapaCiclo orden={99} />);
+      expect(alto.container.querySelector('svg')).toHaveAttribute('data-etapa-orden', '6');
+
+      const nan = render(<IconoEtapaCiclo orden={undefined} />);
+      // undefined → default 1
+      expect(nan.container.querySelector('svg')).toHaveAttribute('data-etapa-orden', '1');
+    });
+  });
+});

--- a/src/visual/icons/index.js
+++ b/src/visual/icons/index.js
@@ -1,0 +1,17 @@
+/*
+ * Barrel de ICONOS de dominio de la librería visual (`src/visual/icons`).
+ *
+ * Iconos pequeños y coherentes para catálogo y cards. Hoy: el set de etapa de
+ * ciclo (fenología). Antes de dibujar un icono de fase de cero, tráigalo de aquí.
+ */
+export {
+  default,
+  IconoEtapaCiclo,
+  IconoGerminacion,
+  IconoVegetativo,
+  IconoFloracion,
+  IconoFructificacion,
+  IconoCosecha,
+  IconoProducto,
+  ICONOS_ETAPA_POR_ORDEN,
+} from './IconosEtapaCiclo.jsx';


### PR DESCRIPTION
## Qué

Refina los **iconos por etapa de ciclo** en las cards de guía fenológica. Hoy `GuiaEspecieCards` mapeaba las seis etapas con `getEtapaIcon`, donde **5 de 6 compartían el mismo `CheckCircle`** genérico (y las dos primeras un `Sprout` idéntico): sin identidad por etapa.

Introduce un **set propio y coherente** de seis glifos que cuentan la vida de la mata en orden:

`germinación → vegetativo → floración → fructificación → cosecha → producto`
(semilla que brota · mata frondosa · flor · fruto · canasta · frasco guardado)

Todos comparten la misma familia visual (línea de un solo grosor, uniones redondeadas) y dibujan sobre `currentColor`, así que **cada etapa toma el tinte de su token** (`text-lime-200`, `text-pink-200`, …) que ya definía `getEtapaColor`. Legibles a 16 px.

Nuevo namespace reutilizable **`src/visual/icons/`** (`<IconoEtapaCiclo orden={1..6} />` + iconos sueltos), en línea con la política de la librería visual (reusar/crecer, no recrear de cero).

**Solo capa visual**: no cambia lógica, datos ni contratos de props. `GuiaEspecieCards` solo intercambia el glifo dentro del mismo chip de color.

## Alcance

- `src/visual/icons/IconosEtapaCiclo.jsx` — el set + despachador por `orden` (recorta a rango).
- `src/visual/icons/index.js` — barrel del namespace.
- `src/visual/icons/IconosEtapaCiclo.test.jsx` — cobertura del set.
- `src/components/aprendizaje/GuiaEspecieCards.jsx` — usa `IconoEtapaCiclo`, elimina `getEtapaIcon`.
- `src/components/aprendizaje/GuiaEspecieCards.test.jsx` — asegura un icono distinto por etapa.

## Test plan

- `npx vitest run src/visual/icons/IconosEtapaCiclo.test.jsx src/components/aprendizaje/GuiaEspecieCards.test.jsx` → **20/20 verde** (glifos distintos, trazo coherente sobre `currentColor`, decorativo por defecto / `role=img` con `title`, despacho y recorte por `orden`, y en la card los seis órdenes 1–6 con geometrías distintas).
- `npx eslint` de los archivos tocados → limpio.
- `npm run build` → verde.
- Verificación visual: render con Playwright a 16 px (tamaño real de card) y 44 px sobre fondo oscuro y sobre el chip redondeado — los seis leen distintos y coherentes, con su tinte por etapa.

## Vista previa

Set a tamaño de card (16 px), zoom del trazo (44 px) y sobre el chip de la card. Cada etapa con el color de su token:

`germinación (lima) · vegetativo (verde) · floración (rosa) · fructificación (ámbar) · cosecha (amarillo) · producto (pizarra)`