### PR TITLE
test(ci): extender audit-integraciones a componentes huérfanos (D-5)

### DIFF
--- a/ops/integraciones-no-consumidas.json
+++ b/ops/integraciones-no-consumidas.json
@@ -53,5 +53,47 @@
       "reason": "Construido chagra-pro #77 (serie ubicación, PRs #75-77) para una cascada Tier1/Tier2 vía sidecar. El propio spec tests/ubicacion-auto.spec.js lo documenta: 'muchos tests están skipped hasta que se mergee el PR 4/4'. Ese PR4 SÍ se mergeó (#1143, 2026-06) pero implementó otra cosa — un fallback OFFLINE (32 dptos x municipios curados) para cuando Nominatim falla, no la llamada al sidecar. locationService.js::resolveUbicacion() es una reimplementación cliente (Nominatim + fallback offline) con el mismo nombre mas no llama al endpoint. A diferencia de los otros casos, esto NO parece un olvido sino una decisión de producto razonable (mejor para offline-first evitar el round-trip a alpha) que dejó el endpoint del sidecar como infraestructura huérfana sin que nadie lo haya limpiado del lado chagra-pro. No cablear — si acaso, evaluar deprecar el endpoint en chagra-pro. Caso 5 del ADR, encontrado por este script.",
       "date": "2026-07-15"
     }
+  ],
+  "orphan_components": [
+    {
+      "id": "src/visual/mundo3d/ArtesaniaAndina.jsx",
+      "reason": "Extensión D-5 del audit (2026-07-21, ver ADR-INTEGRACIONES-NO-CONSUMIDAS-2026-07-15 §componentes): verificado con grep en todo src/ — únicamente su smoke test (__tests__/artesania.smoke.test.jsx) importa el componente; ningún archivo de producto lo hace. Solo el módulo de datos hermano (artesaniaAndina.js: PERFILES_VASIJA/SEGMENTOS_VASIJA) tiene consumidor real (el propio ArtesaniaAndina.jsx). Encontrado por el nuevo check, no cableado en este PR (es una PR de test, no de producto) — requiere decidir en qué mundo/vitrina se monta.",
+      "date": "2026-07-21"
+    },
+    {
+      "id": "src/visual/mundo3d/CamaraDioramas.jsx",
+      "reason": "Verificado con grep: nadie importa el componente React <CamaraDioramas>. Lo que SÍ está cableado (App.jsx, mockups/vitrina3d/VitrinaMundos.jsx) es resolverEncuadre() desde el módulo hermano camaraDioramas.js — la lógica de encuadre se usa directo, sin pasar por el wrapper de componente. El 'import CamaraDioramas from ...' que aparece en el docstring de camaraDioramas.js es un ejemplo de uso en prosa, no código real (y su ruta relativa ni siquiera resuelve). Encontrado por el nuevo check.",
+      "date": "2026-07-21"
+    },
+    {
+      "id": "src/visual/mundo3d/CielosHora.jsx",
+      "reason": "El propio comentario de CapaVivaMundo.jsx dice literalmente 'CielosHora.jsx no existe en dev a la fecha de esta capa; cuando aterrice, se compone aquí mismo' — es un scaffold para una integración futura documentada, todavía sin consumidor real. Encontrado por el nuevo check; no se cablea en este PR (decisión de producto pendiente, no un olvido silencioso).",
+      "date": "2026-07-21"
+    },
+    {
+      "id": "src/visual/mundo3d/GemeloValle2D.jsx",
+      "reason": "Verificado con grep en src/: el único importador es su propio smoke test (__tests__/gemeloValle2D.smoke.test.jsx). Sin consumidor de producto. Encontrado por el nuevo check.",
+      "date": "2026-07-21"
+    },
+    {
+      "id": "src/visual/mundo3d/PisosTermicosBandas.jsx",
+      "reason": "El comentario de pisosTermicos.js dice 'Lo consume el overlay PisosTermicosBandas.jsx (bandas r3f)', pero verificado con grep: ningún archivo real importa el componente — la intención de diseño no llegó a cablearse. Encontrado por el nuevo check.",
+      "date": "2026-07-21"
+    },
+    {
+      "id": "src/visual/mundo3d/TransicionMundoKit.jsx",
+      "reason": "Verificado con grep: el único importador real es su propio test (__tests__/transicionMundoKit.test.jsx). Su hermano TransicionSierraMundo.jsx solo lo menciona en un comentario de docstring ('misma filosofía que'), no en código. Encontrado por el nuevo check.",
+      "date": "2026-07-21"
+    },
+    {
+      "id": "src/visual/mundo3d/TransicionSierraMundo.jsx",
+      "reason": "Mismo caso que TransicionMundoKit.jsx: sin consumidor real fuera de su propia prosa de docstring y su export default. Ninguno de los dos está montado en una ruta viva hoy. Encontrado por el nuevo check.",
+      "date": "2026-07-21"
+    },
+    {
+      "id": "src/visual/mundo3d/infraestructura/InfraestructuraViva.jsx",
+      "reason": "Exportado por el barrel infraestructura/index.js ('export { default as InfraestructuraViva } from ./InfraestructuraViva.jsx'), pero ese barrel a su vez no tiene NINGÚN importador real — solo la variante base Infraestructura.jsx (importada directo, sin pasar por el barrel) está cableada hoy. La variante 'Viva' (auto-alimentada) quedó construida sin consumidor. Encontrado por el nuevo check.",
+      "date": "2026-07-21"
+    }
   ]
 }

--- a/scripts/audit-integraciones.mjs
+++ b/scripts/audit-integraciones.mjs
@@ -14,6 +14,16 @@
  *    "TRAMPA REPO PRIVADO" abajo) Endpoints del sidecar agro-mcp
  *    (`chagra-pro/modules/agro-mcp/sidecar/src/server.ts`): ¿los llama
  *    alguien en `src/`?
+ * 3. Componentes bajo `src/mockups/` y `src/visual/` (extensión 2026-07-21,
+ *    D-5 de la reingeniería del pipeline): ¿son ALCANZABLES por import
+ *    estático desde el entry point real de la app (`src/App.jsx`)? Este es
+ *    el gate del patrón "se construye, pasa el build, pero nunca se
+ *    renderiza / nunca entra al bundle / nunca se importa" — casos reales
+ *    que lo motivaron: `PerrosValle.jsx` existía y no se veía en ninguna
+ *    ruta; mockups nuevos que quedaron fuera del bundle de producción. Se
+ *    hace con un mini-resolver de imports (BFS desde App.jsx, ver
+ *    `buildReachableSet`) — NO un bundler real, así que comparte el mismo
+ *    LÍMITE CONOCIDO de abajo (imports dinámicos por variable no se ven).
  *
  * Cualquier capacidad SIN consumidor y SIN entrada en el allowlist
  * (`ops/integraciones-no-consumidas.json`) hace fallar el script (exit 1).
@@ -51,6 +61,11 @@
  *   - llamadas indirectas vía un wrapper genérico si el string del
  *     endpoint no aparece literal (ej. `callTool(name)` con `name` armado
  *     en runtime en vez de la ruta completa).
+ * La auditoría de componentes huérfanos (§3) comparte esta misma limitación:
+ * `buildReachableSet` resuelve especificadores de import LITERALES (string
+ * fijo tras `from`/`import(`), no rutas armadas con template strings
+ * (`import(\`./x/${var}.jsx\`)`) — si aparece un caso así, cae en el mismo
+ * hueco documentado, no en uno nuevo.
  * Si un caso legítimo cae en alguno de estos huecos, la respuesta NO es
  * afinar el regex hasta la perfección (ruido = la gente lo silencia) sino
  * declararlo en el allowlist con la razón "false positive conocido: <por
@@ -191,6 +206,116 @@ if (chagraProAvailable) {
   warn('Esto es esperado en CI del repo público. Para la auditoría completa, correr con chagra-pro clonado al lado (o CHAGRA_PRO_PATH=<ruta>).');
 }
 
+// -----------------------------------------------------------------------
+// 3) Componentes huérfanos bajo src/mockups/ y src/visual/ (D-5, 2026-07-21)
+// -----------------------------------------------------------------------
+// Entry point real de la app (ver src/App.jsx: rutas hash `#/mockups/<slug>`
+// resueltas vía `lazy(() => import('./mockups/<Componente>'))` antes del
+// check de sesión). Si un .jsx nuevo bajo estos dos directorios no es
+// alcanzable desde acá por ninguna cadena de imports estáticos, quedó
+// "construido pero no cableado" — el mismo patrón de `PerrosValle.jsx`.
+const ENTRY_POINT = 'src/App.jsx';
+const ORPHAN_SCAN_DIRS = ['src/mockups', 'src/visual'];
+// Extensiones que el resolver intenta al completar un especificador relativo
+// sin extensión (orden = prioridad). Incluye no-JS (css/json/assets) porque
+// un archivo reachable puede importar un `./Foo.css` — no lo contamos como
+// "componente" en el reporte (eso lo filtra COMPONENT_EXTS abajo) pero sí
+// necesita resolverse para que el BFS no se detenga ahí.
+const RESOLVABLE_EXTS = ['.jsx', '.js', '.mjs', '.ts', '.tsx', '.css', '.json', '.svg', '.png'];
+// Lo que este audit trata como "componente" reportable (los .js/.ts de estos
+// dos directorios suelen ser datos/config — arquetipos.js, mundoData.js — no
+// "algo que debería verse en una ruta"; no se auditan como huérfanos).
+const COMPONENT_EXTS = new Set(['.jsx', '.tsx']);
+
+function resolveWithExts(basePath) {
+  if (existsSync(basePath) && statSync(basePath).isFile()) return basePath;
+  for (const ext of RESOLVABLE_EXTS) {
+    if (existsSync(basePath + ext)) return basePath + ext;
+  }
+  for (const ext of RESOLVABLE_EXTS) {
+    const idx = join(basePath, 'index' + ext);
+    if (existsSync(idx)) return idx;
+  }
+  return null;
+}
+
+// Resuelve un especificador de import tal como aparece en el código fuente.
+// Soporta relativos (`./x`, `../x`) y el alias `@/` (`jsconfig.json` →
+// `src/*`, usado en un puñado de archivos aunque no está en vite.config.js
+// como alias de build real — igual se resuelve para no perder esos casos).
+// Paquetes de node_modules (sin `.` ni `@/` al inicio) se ignoran: no son
+// auditables ni relevantes para "¿esto vive en una ruta viva?".
+function resolveSpecifier(fromFile, spec) {
+  if (spec.startsWith('@/')) return resolveWithExts(join(SRC_DIR, spec.slice(2)));
+  if (spec.startsWith('.')) return resolveWithExts(resolve(dirname(fromFile), spec));
+  return null;
+}
+
+// Extrae especificadores de import de un archivo fuente. A propósito NO es
+// un parser AST (mismo criterio "barato, regex, documentado" que el resto
+// del script) — cubre `import ... from '...'`, `export ... from '...'`,
+// `import('...')` (incluye el caso `lazy(() => import('...'))`) e
+// `import '...'` (side-effect, ej. una hoja de estilos).
+const SPEC_PATTERNS = [
+  /\bfrom\s*['"`]([^'"`]+)['"`]/g,
+  /\bimport\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/g,
+  /^\s*import\s*['"`]([^'"`]+)['"`]/gm,
+];
+
+function extractSpecifiers(content) {
+  const specs = new Set();
+  for (const re of SPEC_PATTERNS) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(content)) !== null) specs.add(m[1]);
+  }
+  return specs;
+}
+
+// BFS desde el entry point siguiendo imports estáticos resolubles. El
+// resultado es el conjunto de archivos que un bundler real incluiría en el
+// grafo de módulos alcanzable desde App.jsx (con la salvedad de imports
+// dinámicos por variable — ver LÍMITE CONOCIDO en el header).
+function buildReachableSet(entryFile) {
+  const visited = new Set();
+  const queue = [entryFile];
+  while (queue.length) {
+    const file = queue.shift();
+    if (visited.has(file)) continue;
+    visited.add(file);
+    let content;
+    try { content = readFileSync(file, 'utf8'); } catch { continue; }
+    for (const spec of extractSpecifiers(content)) {
+      const resolved = resolveSpecifier(file, spec);
+      if (resolved && !visited.has(resolved)) queue.push(resolved);
+    }
+  }
+  return visited;
+}
+
+const entryAbs = resolve(ROOT, ENTRY_POINT);
+const entryAvailable = existsSync(entryAbs);
+const reachableSet = entryAvailable ? buildReachableSet(entryAbs) : new Set();
+
+function auditOrphanComponents() {
+  if (!entryAvailable) {
+    warn(`entry point ${ENTRY_POINT} no existe — se salta la auditoría de componentes huérfanos.`);
+    return [];
+  }
+  const results = [];
+  for (const dir of ORPHAN_SCAN_DIRS) {
+    const absDir = resolve(ROOT, dir);
+    for (const f of walk(absDir, COMPONENT_EXTS)) {
+      if (f.includes('__tests__')) continue;
+      if (/\.(test|spec|stories)\.[jt]sx?$/.test(f)) continue;
+      results.push({ id: f.slice(ROOT.length + 1), file: f, status: reachableSet.has(f) ? 'consumed' : 'orphan' });
+    }
+  }
+  return results;
+}
+
+const orphanResults = auditOrphanComponents();
+
 // -----------------------------
 // Allowlist
 // -----------------------------
@@ -221,6 +346,11 @@ for (const e of allowlist.sidecar_endpoints || []) {
   validateAllowlistEntry(e, e.endpoint || '(sin endpoint)');
   allowedEndpoints.set(e.endpoint, e);
 }
+const allowedOrphanIds = new Map();
+for (const e of allowlist.orphan_components || []) {
+  validateAllowlistEntry(e, e.id || '(sin id)');
+  allowedOrphanIds.set(e.id, e);
+}
 
 // -----------------------------
 // Reporte + veredicto
@@ -229,6 +359,7 @@ console.log('Chagra — auditor de integraciones no consumidas');
 console.log(`  targets same-repo:     ${SAME_REPO_TARGETS.length}`);
 console.log(`  chagra-pro disponible: ${chagraProAvailable ? SERVER_TS : 'no'}`);
 console.log(`  endpoints auditados:   ${sidecarResults.length}${chagraProAvailable ? '' : ' (saltado)'}`);
+console.log(`  componentes auditados (mockups+visual): ${orphanResults.length}${entryAvailable ? '' : ' (saltado)'}`);
 console.log('');
 
 const failures = [];
@@ -248,6 +379,19 @@ for (const r of sidecarResults) {
   if (allow) { skippedAllowlisted.push(r.endpoint); warn(`endpoint SIN consumidor pero allowlisted: ${r.endpoint} — ${allow.reason} (${allow.date})`); continue; }
   failures.push(`[sidecar] ${r.endpoint} — SIN consumidor en src/ y SIN entrada en allowlist`);
 }
+
+// Reporte de §3 resumido (no un `ok()` por archivo — con ~250 componentes
+// bajo mockups+visual eso solo agrega ruido al log de CI): se cuenta, y solo
+// se imprime línea por línea lo que NO está limpio (huérfano u orphan
+// allowlisted), igual que el resto del script hace con sus fallas.
+let orphanConsumedCount = 0;
+for (const r of orphanResults) {
+  if (r.status === 'consumed') { orphanConsumedCount++; continue; }
+  const allow = allowedOrphanIds.get(r.id);
+  if (allow) { skippedAllowlisted.push(r.id); warn(`componente SIN ruta viva pero allowlisted: ${r.id} — ${allow.reason} (${allow.date})`); continue; }
+  failures.push(`[orphan] ${r.id} — construido pero NO alcanzable desde ${ENTRY_POINT} (ninguna ruta viva lo importa) y SIN entrada en allowlist`);
+}
+if (orphanResults.length > 0) ok(`componentes cableados en mockups/visual: ${orphanConsumedCount}/${orphanResults.length}`);
 
 console.log('');
 if (failures.length === 0) {


### PR DESCRIPTION
## Resumen
- Extiende el gate anti-"construido-no-cableado" de PR #2475 con una 3ª auditoría: falla el CI si un componente `.jsx`/`.tsx` nuevo bajo `src/mockups/` o `src/visual/` no es alcanzable por import estático desde el entry point real (`src/App.jsx`) — el mismo patrón que dejó `PerrosValle.jsx` invisible o mockups fuera del bundle de producción.
- Mecanismo: mini-resolver de imports (BFS desde `App.jsx`, sigue `import`/`export ... from`/`import()` incl. `lazy()`, y el alias `@/`) — mismo criterio "barato, regex, allowlist documentado" que las 2 auditorías previas del script, no un bundler real (comparte el mismo LÍMITE CONOCIDO: no ve imports dinámicos por variable).
- Encontró **8 huérfanos reales** en la primera corrida contra `main`, todos bajo `src/visual/mundo3d/`. Cada uno verificado con grep antes de allowlistar (mismo estándar que los casos 4/5 del ADR original) — el patrón dominante: el módulo de *datos* hermano tiene consumidor real, pero el *componente* React que lo envuelve nunca se monta en ninguna ruta. Detalle por archivo en `ops/integraciones-no-consumidas.json` → `orphan_components`. Ninguno se cablea en este PR (es una PR de test, no de producto).

## Validación
- Negativo: se inyectó un `.jsx` sin importar bajo `src/mockups/` → el script lo detectó y falló (`exit 1`) con el mensaje exacto de huérfano; al retirarlo volvió a `exit 0`.
- `node scripts/audit-integraciones.mjs` → `exit 0`, 129 componentes auditados, 121 cableados + 8 huérfanos + 3 same-repo allowlisted, 0 sin declarar. ~0.7s de runtime (sigue siendo "barato a propósito", sin build/red/GPU).

## Test plan
- [x] `npm run audit:integraciones` en verde localmente.
- [x] Test negativo confirmado (falla ante un huérfano nuevo real).
- [ ] CI (`.github/workflows/integraciones-audit.yml`, ya existente, corre el mismo script — no requiere cambios de workflow).

Contexto de diseño ampliado: addendum 2026-07-21 en `Chagra-strategy/ops/ADR-INTEGRACIONES-NO-CONSUMIDAS-2026-07-15.md` (repo privado, PR hermano).

🤖 Generado con [Claude Code](https://claude.com/claude-code)