### PR TITLE
fix(mundo3d): hotspots fuera de pantalla en valle 2D + Sierra sin interacción

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1780,11 +1780,13 @@ export default function App() {
         // Vista global 3D de la Sierra Nevada de Santa Marta: el macizo maestro
         // (Simmonds + Palomino, bandas de piso térmico, hora dorada). Territorio
         // sagrado tratado con dignidad — crédito a Kogui/Arhuaco/Wiwa/Kankuamo.
-        // Ruta #/mockups/sierra-global, sin auth.
+        // Ruta #/mockups/sierra-global, sin auth. Tocar una banda de piso
+        // térmico SÍ navega de verdad (fix bug P1 huérfanos-3D 2026-07-21):
+        // baja al primer mundo real que declara `pisosTermicos.js` para ese piso.
         return (
           <ErrorBoundary>
             <ErrorFallback moduleName="Vista global Sierra Nevada">
-              <SierraGlobalMockup />
+              <SierraGlobalMockup onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/valle/Valle2DFallback.jsx
+++ b/src/mockups/valle/Valle2DFallback.jsx
@@ -8,20 +8,41 @@
  * abeja VUELA hasta el lugar: el mismo "entrar al mundo" del 3D, dibujado.
  * "Wow" 3D se pierde; el PROPÓSITO no.
  */
+/* eslint-disable react-refresh/only-export-components -- `pct` (proyección
+   isométrica) se exporta para el test de regresión del bug P0 huérfanos-3D
+   (ningún lugar de valleData.js puede caer fuera del viewBox visible): probar
+   la fórmula real en vez de reimplementarla en el test. Este fallback no es
+   hot-reload-sensible (gama baja / sin WebGL). */
 import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS } from './valleData';
 import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
 
-/* Proyección isométrica plana de las coordenadas del valle a la lámina SVG. */
+/*
+ * Proyección isométrica plana de las coordenadas del valle a la lámina SVG
+ * (viewBox 400×340, sin cambios: el arte de fondo —cordillera/piso/quebrada—
+ * es decorativo, no depende de los datos).
+ *
+ * Constantes recalibradas 2026-07-21 (fix bug P0 huérfanos-3D): las viejas
+ * (cx=200+(x−z)·30, cy=150+(x+z)·15) quedaron del "valle chico" y ya no
+ * calzan con el rango real de `valleData.js` (el "valle grande" del
+ * rediseño 2026-07, x∈[-6.4,6.2] z∈[-9.4,9.6] aprox.) — varios lugares
+ * (p.ej. `animales`, `disenio`, `semillero`) caían fuera del 0–100%
+ * visible: en gama baja el campesino simplemente no podía tocarlos.
+ * `clampPct` es el cinturón de seguridad (8–92%, igual que el gemelo 2D
+ * `GemeloValle2D.jsx`): ningún lugar futuro puede volver a quedar fuera de
+ * pantalla aunque cambien las coordenadas.
+ */
+const clampPct = (v) => Math.min(92, Math.max(8, v));
+
 function iso(x, z) {
-  const cx = 200 + (x - z) * 30;
-  const cy = 150 + (x + z) * 15;
+  const cx = 200 + (x - z) * 22;
+  const cy = 170 + (x + z) * 10;
   return { cx, cy };
 }
 
 /* Posición en % dentro de la lámina (para posicionar botones/abeja en CSS). */
-function pct(x, z) {
+export function pct(x, z) {
   const { cx, cy } = iso(x, z);
-  return { left: (cx / 400) * 100, top: (cy / 340) * 100 };
+  return { left: clampPct((cx / 400) * 100), top: clampPct((cy / 340) * 100) };
 }
 
 export default function Valle2DFallback({
@@ -100,7 +121,7 @@ export default function Valle2DFallback({
             const p = pct(ancla.pos[0], ancla.pos[2]);
             return (
               <button type="button" className="valle2d__alerta"
-                style={{ left: `${p.left}%`, top: `${p.top - 12}%` }}
+                style={{ left: `${p.left}%`, top: `${clampPct(p.top - 12)}%` }}
                 onClick={onAlerta}
                 aria-label={`Alerta del día: ${COSA_DEL_DIA.titulo}. ${COSA_DEL_DIA.detalle}`}>
                 <span aria-hidden="true">⚠️</span> {COSA_DEL_DIA.titulo}

--- a/src/mockups/valle/__tests__/valle2DFallback.hotspots.test.jsx
+++ b/src/mockups/valle/__tests__/valle2DFallback.hotspots.test.jsx
@@ -1,0 +1,88 @@
+/*
+ * Regresión del bug P0 de huérfanos-3D (2026-07-21): `Valle2DFallback.jsx`
+ * —el camino que ven los equipos de gama baja— usaba constantes de
+ * proyección obsoletas y dejaba lugares reales de `valleData.js` fuera del
+ * 0–100% visible del viewBox (p.ej. `animales` ≈ -28%, `disenio` ≈ 114.5%
+ * con las constantes viejas): en un celular modesto el campesino no podía
+ * tocarlos.
+ *
+ * Este test asegura DOS cosas:
+ *   1. La proyección pura (`pct`) de TODOS los lugares de `MUNDOS_VALLE` cae
+ *      dentro de [0,100]% en ambos ejes — para que un lugar nuevo que se
+ *      agregue a `valleData.js` no pueda volver a quedar fuera de pantalla.
+ *   2. El fallback REALMENTE RENDERIZADO posiciona sus botones tocables (los
+ *      lugares, la alerta del día y Angelita) dentro de ese mismo rango —
+ *      no solo la fórmula en aislamiento, sino lo que el usuario ve.
+ */
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import Valle2DFallback, { pct } from '../Valle2DFallback.jsx';
+import { MUNDOS_VALLE, COSA_DEL_DIA } from '../valleData';
+
+afterEach(() => cleanup());
+
+function pctDeEstilo(el) {
+  // jsdom expone left/top en `%` tal cual se escribieron en el style inline.
+  return {
+    left: parseFloat(el.style.left),
+    top: parseFloat(el.style.top),
+  };
+}
+
+describe('Valle2DFallback — ningún lugar queda fuera de pantalla (gama baja)', () => {
+  test('la proyección pura (pct) de cada lugar de valleData.js cae en [0,100]%', () => {
+    expect(MUNDOS_VALLE.length).toBeGreaterThan(0);
+    MUNDOS_VALLE.forEach((m) => {
+      const { left, top } = pct(m.pos[0], m.pos[2]);
+      expect(left).toBeGreaterThanOrEqual(0);
+      expect(left).toBeLessThanOrEqual(100);
+      expect(top).toBeGreaterThanOrEqual(0);
+      expect(top).toBeLessThanOrEqual(100);
+    });
+  });
+
+  test('cada botón de lugar renderizado queda dentro del viewBox visible', () => {
+    const { container } = render(
+      <Valle2DFallback clima="soleado" onEntrar={() => {}} onAlerta={() => {}} />,
+    );
+    const botones = container.querySelectorAll('.valle2d__poi');
+    expect(botones.length).toBe(MUNDOS_VALLE.length);
+    botones.forEach((btn) => {
+      const { left, top } = pctDeEstilo(btn);
+      expect(left).toBeGreaterThanOrEqual(0);
+      expect(left).toBeLessThanOrEqual(100);
+      expect(top).toBeGreaterThanOrEqual(0);
+      expect(top).toBeLessThanOrEqual(100);
+    });
+  });
+
+  test('la alerta del día (cosa del día) también queda visible', () => {
+    const ancla = MUNDOS_VALLE.find((m) => m.id === COSA_DEL_DIA.anclaMundo);
+    expect(ancla).toBeTruthy(); // si el ancla cambia de id, esto avisa primero
+    const { container } = render(
+      <Valle2DFallback clima="soleado" onEntrar={() => {}} onAlerta={() => {}} />,
+    );
+    const alerta = container.querySelector('.valle2d__alerta');
+    expect(alerta).toBeInTheDocument();
+    const { left, top } = pctDeEstilo(alerta);
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(left).toBeLessThanOrEqual(100);
+    // el letrero cuelga 12% arriba de su lugar: también debe quedar clampeado.
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(top).toBeLessThanOrEqual(100);
+  });
+
+  test('Angelita (la abeja) se posiciona dentro del rango visible', () => {
+    const { container } = render(<Valle2DFallback clima="soleado" onEntrar={() => {}} />);
+    const abeja = container.querySelector('.valle2d__abeja');
+    expect(abeja).toBeInTheDocument();
+    const { left, top } = pctDeEstilo(abeja);
+    expect(left).toBeGreaterThanOrEqual(0);
+    expect(left).toBeLessThanOrEqual(100);
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(top).toBeLessThanOrEqual(100);
+  });
+});

--- a/src/visual/mundo3d/VistaGlobalSierra.jsx
+++ b/src/visual/mundo3d/VistaGlobalSierra.jsx
@@ -35,9 +35,22 @@
  *                                 de crédito DOM + clave de pisos accesible.
  *   named    SierraDiorama      → grupo r3f puro para COMPONER dentro de otro
  *                                 <Canvas> (trae luces/niebla/crédito por props).
+ *   named    useViajeSierra     → el estado three-free "tocar piso → bajar al
+ *                                 mundo" (testeable sin Canvas; ver más abajo).
  *
- * ── CABLEO (lo hace el host / otra fable / Opus; este archivo NO toca App.jsx
- *    ni mundoData.js) ─────────────────────────────────────────────────────────
+ * ── INTERACCIÓN (2026-07-21, fix bug P1 huérfanos-3D) ───────────────────────
+ * La vista global YA NO es un panorama mudo: cada banda de piso térmico
+ * (`PisosTermicosBandas`, montada como hija del `<Canvas>`) es tocable, y al
+ * tocarla se dispara el descenso cinematográfico (`TransicionSierraMundo`,
+ * overlay hermano fuera del Canvas) hacia el PRIMER mundo real que
+ * `pisosTermicos.js` declara para ese piso (`piso.mundos[0].view` — la MISMA
+ * fuente de datos que ya cablea `PisosTermicosBandas`, sin duplicar banding:
+ * una sola verdad). `onMitad` (pantalla cubierta) es quien de verdad navega
+ * —vía `onNavigate(view, data)`, el mismo contrato de `navigate` del host—
+ * así el corte de escena ocurre bajo tapa, nunca a la vista.
+ *
+ * ── CABLEO (lo hace el host / otra fable / Opus; este archivo NO toca
+ *    mundoData.js) ────────────────────────────────────────────────────────
  *
  *   import VistaGlobalSierra from './visual/mundo3d/VistaGlobalSierra.jsx';
  *   // p.ej. ruta mockup #/mockups/sierra-global o nodo maestro del registro:
@@ -45,6 +58,7 @@
  *     tier={tier}                 // de decidirTier() (deviceTier.js)
  *     reducedMotion={reducedMotion}
  *     pisoUsuario="frio"          // opcional: resalta el piso de la finca
+ *     onNavigate={navigate}       // opcional: (view, data) => navega de verdad
  *   />                            // 'calido'|'templado'|'frio'|'paramo'|'superparamo'|'nival'
  *
  *   // O componer el grupo dentro de un Canvas propio:
@@ -55,12 +69,19 @@
  *
  * El contenedor padre define el alto (como `.mundo-root`).
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
+/* eslint-disable react-refresh/only-export-components -- `useViajeSierra` se
+   exporta a propósito (three-free) para testear el handler real "tocar banda
+   → bajar al mundo" SIN montar el <Canvas> r3f de esta escena (fix bug P1
+   huérfanos-3D). Este archivo se importa perezoso desde App.jsx; no es
+   hot-reload-sensible. */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Html, OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import { ATMOSFERA } from './atmosferaMadre.js';
 import { perfilDeTier } from './deviceTier.js';
+import PisosTermicosBandas from './PisosTermicosBandas.jsx';
+import TransicionSierraMundo from './TransicionSierraMundo.jsx';
 
 /* ── Geografía del macizo (validada contra el DR: mar al norte, macizo al sur,
       cumbres gemelas + Simmonds, costa de Palomino). Coordenadas de MUNDO:
@@ -435,26 +456,94 @@ const CSS_SIERRA = `
 @media (prefers-reduced-motion: reduce) { .vsierra-canvas { transition: none; } }
 `;
 
+/* Geometría de escena de las bandas de piso térmico: calibrada contra el
+   TERRENO REAL de esta escena (`alturaSierra`/`construirTerreno`, no valores
+   sueltos) para que el "aura" de contorno quede sobre el macizo, no flotando
+   en otro lado. La cumbre real mide ≈5.16 (ver CUMBRE.y=5.0, la misma
+   referencia que ya usan los rótulos); el centro se desplaza hacia el
+   complejo de cumbres (Colón/Bolívar + Simmonds, z≈2.9–4.4) en vez del origen
+   (que cae en la falda, cerca de la costa). */
+const BANDAS_CENTRO = [0.4, 0, 2.6];
+const BANDAS_ALTURA_CUMBRE = CIMA;
+const BANDAS_RADIO_BASE = ANCHO / 2.2; // cubre el ancho real del macizo (22)
+const BANDAS_RADIO_CUMBRE = 0.55;
+
+/**
+ * useViajeSierra — el ESTADO del viaje "tocar piso → bajar al mundo" (three-free,
+ * extraído para ser testeable SIN montar el `<Canvas>` r3f). Encapsula:
+ *   · `handleSeleccionPiso(piso)` — arma el viaje al PRIMER mundo real que
+ *     `pisosTermicos.js` declara para ese piso (`piso.mundos[0]`); honestidad:
+ *     sin mundo asociado, no arma nada (nunca finge una ruta).
+ *   · `handleMitad()` — a mitad de cubierta (pantalla 100% tapada) es cuando
+ *     de verdad se navega (`onNavigate(view, data)`), nunca a la vista.
+ *   · `handleFin()` — apaga el overlay al revelar.
+ * `viaje` alimenta directo a `<TransicionSierraMundo {...viaje}>`.
+ */
+export function useViajeSierra(onNavigate) {
+  const [viaje, setViaje] = useState(null); // null = sin viaje en curso
+
+  const handleSeleccionPiso = useCallback((piso) => {
+    setViaje((actual) => {
+      if (!piso || actual?.activa) return actual; // un viaje a la vez
+      const destino = piso.mundos?.[0]; // el mundo PRIMARIO del piso
+      if (!destino) return actual; // sin mundo asociado: no finge una ruta
+      return {
+        activa: true,
+        direccion: 'bajar',
+        pisoDestino: piso.id,
+        view: destino.view,
+        data: { pisoId: piso.id, mundoId: destino.id },
+      };
+    });
+  }, []);
+
+  const handleMitad = useCallback(() => {
+    setViaje((actual) => {
+      if (actual) onNavigate?.(actual.view, actual.data);
+      return actual;
+    });
+  }, [onNavigate]);
+
+  const handleFin = useCallback(() => {
+    setViaje((v) => (v ? { ...v, activa: false } : v));
+  }, []);
+
+  return { viaje, handleSeleccionPiso, handleMitad, handleFin };
+}
+
 /**
  * VistaGlobalSierra — la vista global montable con su propio `<Canvas>`.
  * Trae la cámara de establishing shot, órbita suave acotada, título, clave de
  * pisos accesible y el pie de crédito DOM a los cuatro pueblos. El host decide
  * cuándo mostrarla (no monta lógica de negocio).
  *
+ * Las bandas de piso térmico (`PisosTermicosBandas`) son tocables: al tocar
+ * una, `TransicionSierraMundo` cubre la pantalla y —a mitad de cubierta,
+ * nunca a la vista— dispara `onNavigate(view, data)` hacia el PRIMER mundo
+ * real que `pisosTermicos.js` asocia a ese piso (única fuente de verdad,
+ * la misma que ya pinta la etiqueta de cada banda).
+ *
  * @param {object} props
  * @param {'alto'|'medio'|'bajo'} [props.tier='alto']  presupuesto de render.
  * @param {boolean} [props.reducedMotion=false]  sin órbita ni nubes; frameloop a demanda.
  * @param {string}  [props.pisoUsuario]  piso de la finca a resaltar (opcional).
+ * @param {(view: string, data?: object) => void} [props.onNavigate]  navega
+ *        de verdad al mundo del piso tocado (mismo contrato que `navigate`
+ *        del host). Sin ella, tocar una banda solo corre la animación de
+ *        viaje (no hay a dónde ir).
  * @param {string}  [props.className]  clases extra del contenedor.
  */
 export default function VistaGlobalSierra({
   tier = 'alto',
   reducedMotion = false,
   pisoUsuario,
+  onNavigate,
   className = '',
 }) {
   const [listo, setListo] = useState(false);
   const perfil = perfilDeTier(tier);
+  const { viaje, handleSeleccionPiso, handleMitad, handleFin } = useViajeSierra(onNavigate);
+
   return (
     <section
       className={`vsierra-root${className ? ` ${className}` : ''}`}
@@ -476,6 +565,17 @@ export default function VistaGlobalSierra({
           pisoUsuario={pisoUsuario}
           credito={false}
         />
+        <PisosTermicosBandas
+          pisoUsuario={pisoUsuario}
+          tier={tier}
+          reducedMotion={reducedMotion}
+          centro={BANDAS_CENTRO}
+          alturaCumbre={BANDAS_ALTURA_CUMBRE}
+          radioBase={BANDAS_RADIO_BASE}
+          radioCumbre={BANDAS_RADIO_CUMBRE}
+          pisoActivo={viaje?.activa ? viaje.pisoDestino : null}
+          onSeleccionPiso={handleSeleccionPiso}
+        />
         <OrbitControls
           makeDefault
           enablePan={false}
@@ -494,6 +594,18 @@ export default function VistaGlobalSierra({
         />
         <AdaptiveDpr pixelated />
       </Canvas>
+
+      {/* Overlay HERMANO del Canvas (nunca dentro): el descenso cinematográfico
+          hacia el mundo del piso tocado. Contrato temporal en TransicionSierraMundo. */}
+      <TransicionSierraMundo
+        activa={!!viaje?.activa}
+        direccion={viaje?.direccion || 'bajar'}
+        pisoDestino={viaje?.pisoDestino || ''}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        onMitad={handleMitad}
+        onFin={handleFin}
+      />
 
       {/* Chrome DOM: título, clave de pisos (accesible) y pie de crédito. */}
       <div className="vsierra-chrome">

--- a/src/visual/mundo3d/__tests__/vistaGlobalSierra.wiring.test.jsx
+++ b/src/visual/mundo3d/__tests__/vistaGlobalSierra.wiring.test.jsx
@@ -1,0 +1,176 @@
+/*
+ * Regresión del bug P1 de huérfanos-3D (2026-07-21): `VistaGlobalSierra.jsx`
+ * (la montaña maestra) no tenía NINGÚN handler de clic — tocar una banda de
+ * piso térmico no hacía nada. `PisosTermicosBandas.jsx` y
+ * `TransicionSierraMundo.jsx` se construyeron en la misma ola para resolver
+ * exactamente esto y quedaron huérfanos (nadie los conectó).
+ *
+ * Este archivo NO puede montar `<VistaGlobalSierra>` completo: trae su propio
+ * `<Canvas>` r3f (WebGL2), y este repo no mockea un contexto WebGL en jsdom
+ * (ningún test existente en `visual/mundo3d/__tests__` monta un `<Canvas>`
+ * real — ver `particulasData.test.js` etc.: la convención es testear la capa
+ * de DATOS/LÓGICA, three-free). Por eso el cableo se extrajo a un hook
+ * exportado `useViajeSierra` (three-free) que SÍ es testeable, y se prueba:
+ *
+ *   1. Cada piso térmico de `pisosTermicos.js` (la fuente de datos que
+ *      `PisosTermicosBandas` ya consumía) declara al menos un mundo con
+ *      `view`, y ese `view` es una ruta REAL manejada por el router central
+ *      de la app (`case '<view>':` en App.jsx) — nada de rutas fantasma.
+ *   2. `useViajeSierra` (el handler real que `VistaGlobalSierra` usa) arma el
+ *      viaje correcto al seleccionar un piso, y navega de VERDAD
+ *      (`onNavigate`) a mitad de cubierta — nunca a la vista.
+ *   3. Integración end-to-end con el `TransicionSierraMundo` REAL (temporal,
+ *      con fake timers): tocar → cubre → a mitad navega → al final se apaga.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import React from 'react';
+import { render, renderHook, act, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach, vi } from 'vitest';
+
+import { useViajeSierra } from '../VistaGlobalSierra.jsx';
+import TransicionSierraMundo from '../TransicionSierraMundo.jsx';
+import { PISOS_TERMICOS, compatibilidadPiso } from '../pisosTermicos.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+/* Conjunto de vistas realmente manejadas por el router central (App.jsx no
+ * tiene un registry dedicado: el switch de `navigate(view)` ES la fuente de
+ * verdad). Lectura de texto: no requiere montar App.jsx (2800+ líneas, auth,
+ * servicios) solo para confirmar que una vista existe. */
+function rutasReales() {
+  const appPath = path.resolve(__dirname, '../../../App.jsx');
+  const src = fs.readFileSync(appPath, 'utf8');
+  const vistas = new Set();
+  for (const m of src.matchAll(/case '([a-z0-9_]+)':/g)) vistas.add(m[1]);
+  return vistas;
+}
+
+describe('pisosTermicos.js — cada piso apunta a un mundo con ruta real', () => {
+  test('todo piso térmico declara al menos un mundo con `view` no vacío', () => {
+    expect(PISOS_TERMICOS.length).toBeGreaterThan(0);
+    PISOS_TERMICOS.forEach((piso) => {
+      expect(Array.isArray(piso.mundos), piso.id).toBe(true);
+      expect(piso.mundos.length, piso.id).toBeGreaterThan(0);
+      piso.mundos.forEach((m) => {
+        expect(typeof m.view, `${piso.id}.${m.id}`).toBe('string');
+        expect(m.view.length, `${piso.id}.${m.id}`).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  test('el destino de CADA banda (piso.mundos[0]) es una ruta real de App.jsx — nada de rutas fantasma', () => {
+    const rutas = rutasReales();
+    expect(rutas.size).toBeGreaterThan(50); // sanity: el switch se leyó de verdad
+    // el MISMO arreglo que renderiza `PisosTermicosBandas` (una banda por piso).
+    const { pisos } = compatibilidadPiso(null);
+    expect(pisos.length).toBe(PISOS_TERMICOS.length);
+    pisos.forEach((piso) => {
+      const destino = piso.mundos[0];
+      expect(rutas.has(destino.view), `banda "${piso.id}" -> onNavigate('${destino.view}')`).toBe(true);
+    });
+  });
+});
+
+describe('useViajeSierra — el handler real de "tocar banda → bajar al mundo"', () => {
+  test('seleccionar un piso arma el viaje hacia su mundo primario', () => {
+    const { result } = renderHook(() => useViajeSierra(() => {}));
+    const piso = PISOS_TERMICOS.find((p) => p.id === 'paramo');
+    act(() => result.current.handleSeleccionPiso(piso));
+    expect(result.current.viaje).toMatchObject({
+      activa: true,
+      direccion: 'bajar',
+      pisoDestino: 'paramo',
+      view: piso.mundos[0].view,
+      data: { pisoId: 'paramo', mundoId: piso.mundos[0].id },
+    });
+  });
+
+  test('a mitad de cubierta navega de verdad, con pisoId y mundoId', () => {
+    const onNavigate = vi.fn();
+    const { result } = renderHook(() => useViajeSierra(onNavigate));
+    const piso = PISOS_TERMICOS.find((p) => p.id === 'templado'); // mundos[0] = cafe
+    act(() => result.current.handleSeleccionPiso(piso));
+    expect(onNavigate).not.toHaveBeenCalled(); // aún no cubrió: no navega antes de tiempo
+    act(() => result.current.handleMitad());
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith('cafe', { pisoId: 'templado', mundoId: 'cafe' });
+  });
+
+  test('un viaje a la vez: tocar otro piso mientras hay uno activo se ignora', () => {
+    const { result } = renderHook(() => useViajeSierra(() => {}));
+    const paramo = PISOS_TERMICOS.find((p) => p.id === 'paramo');
+    const calido = PISOS_TERMICOS.find((p) => p.id === 'calido');
+    act(() => result.current.handleSeleccionPiso(paramo));
+    act(() => result.current.handleSeleccionPiso(calido));
+    expect(result.current.viaje.pisoDestino).toBe('paramo');
+  });
+
+  test('piso sin mundos asociados no arma un viaje (honestidad: nunca finge una ruta)', () => {
+    const { result } = renderHook(() => useViajeSierra(() => {}));
+    act(() => result.current.handleSeleccionPiso({ id: 'inventado', mundos: [] }));
+    expect(result.current.viaje).toBeNull();
+  });
+
+  test('handleFin apaga el viaje sin perder el resto del estado', () => {
+    const { result } = renderHook(() => useViajeSierra(() => {}));
+    const piso = PISOS_TERMICOS.find((p) => p.id === 'frio');
+    act(() => result.current.handleSeleccionPiso(piso));
+    act(() => result.current.handleFin());
+    expect(result.current.viaje.activa).toBe(false);
+    expect(result.current.viaje.pisoDestino).toBe('frio');
+  });
+});
+
+/* Arnés mínimo: la MISMA integración que monta `VistaGlobalSierra` (hook +
+ * `TransicionSierraMundo` real como hermano), sin el `<Canvas>` r3f. */
+function ArnesSierra({ onNavigate, piso }) {
+  const { viaje, handleSeleccionPiso, handleMitad, handleFin } = useViajeSierra(onNavigate);
+  return (
+    <div>
+      <button type="button" onClick={() => handleSeleccionPiso(piso)}>
+        tocar banda
+      </button>
+      <TransicionSierraMundo
+        activa={!!viaje?.activa}
+        direccion={viaje?.direccion || 'bajar'}
+        pisoDestino={viaje?.pisoDestino || ''}
+        tier="alto"
+        reducedMotion={false}
+        onMitad={handleMitad}
+        onFin={handleFin}
+      />
+    </div>
+  );
+}
+
+describe('Integración end-to-end (hook + TransicionSierraMundo real, fake timers)', () => {
+  test('tocar → cubre pantalla → a mitad navega → al final se apaga', () => {
+    vi.useFakeTimers();
+    const onNavigate = vi.fn();
+    const piso = PISOS_TERMICOS.find((p) => p.id === 'templado'); // -> 'cafe'
+    const { getByRole, container } = render(<ArnesSierra onNavigate={onNavigate} piso={piso} />);
+
+    fireEvent.click(getByRole('button', { name: 'tocar banda' }));
+    expect(container.querySelector('[data-testid="tsm"]')).toBeInTheDocument();
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    // VIAJE_MS=1500 (tier alto, sin reduced-motion) · MITAD_FRAC=0.5 (fuente:
+    // TransicionSierraMundo.jsx — no exportadas, se replican los valores).
+    act(() => vi.advanceTimersByTime(749));
+    expect(onNavigate).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith('cafe', { pisoId: 'templado', mundoId: 'cafe' });
+
+    act(() => vi.advanceTimersByTime(750)); // hasta el total: onFin
+    expect(container.querySelector('[data-testid="tsm"]')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Resumen

Dos bugs reales de cara al usuario, detectados en el triaje de huérfanos (`Chagra-strategy/ops/TRIAJE-HUERFANOS-3D-2026-07-21.md`).

### Bug 1 (P0) — el fallback 2D del valle dejaba lugares fuera de pantalla

`src/mockups/valle/Valle2DFallback.jsx` (el camino que ven los equipos de gama baja / sin WebGL / reduced-motion) proyectaba con constantes de 2026-05 (`cx=200+(x−z)·30`) que ya no calzan con el rango de coordenadas actual de `valleData.js` (el "valle grande" del rediseño 2026-07). Verificado empíricamente: **4 de los 10 lugares** (`animales` ≈ -28%, `disenio` ≈ 114.5%, `semillero` ≈ -16%, `cultivos` ≈ -1%) caían fuera del 0–100% visible del viewBox — en un celular modesto el campesino simplemente no podía tocarlos.

Se evaluaron dos caminos (ver triaje): reemplazar el fallback por el huérfano `GemeloValle2D.jsx`, o recalibrar el fallback vivo. Se optó por el de **menor riesgo visual** (el fallback está en producción): recalibrar `iso()/pct()` en el mismo archivo para el rango real + agregar un clamp de seguridad (8–92%, mismo criterio que ya usa `GemeloValle2D`), sin tocar el arte SVG existente ni la estructura del componente.

### Bug 2 (P1) — la montaña de la Sierra no respondía al toque

`src/visual/mundo3d/VistaGlobalSierra.jsx` no tenía **ningún** handler de clic. `PisosTermicosBandas.jsx` y `TransicionSierraMundo.jsx` se construyeron en la misma ola de PRs para resolver exactamente esto y quedaron huérfanos (nadie las conectó).

Cableado: `PisosTermicosBandas` se monta como hija del `<Canvas>` (bandas tocables por piso térmico) y `TransicionSierraMundo` como overlay hermano fuera del Canvas (el descenso cinematográfico). Al tocar una banda, a mitad de cubierta (nunca a la vista) se navega de verdad al **primer mundo real** que `pisosTermicos.js` ya declara para ese piso (`piso.mundos[0].view`) — la MISMA fuente de datos que ya alimentaba las etiquetas de `PisosTermicosBandas`, sin crear un segundo registro de bandas. Se verificó que los 6 pisos térmicos resuelven a 6 `case` reales del router central de `App.jsx` (nada de rutas fantasma). `App.jsx` ahora pasa `onNavigate={navigate}` a la ruta mockup `#/mockups/sierra-global`.

La lógica de estado ("tocar piso → armar viaje → navegar a mitad de cubierta → apagar al final") se extrajo a un hook exportado `useViajeSierra` (three-free) para poder testearla sin montar el `<Canvas>` r3f — este repo no mockea un contexto WebGL en jsdom (confirmado: ningún test existente en `visual/mundo3d/__tests__` monta un `<Canvas>` real).

## Tests

- `src/mockups/valle/__tests__/valle2DFallback.hotspots.test.jsx` — proyección pura y botones renderizados de los 10 lugares de `valleData.js`, la alerta del día y Angelita, todos dentro de `[0,100]%`. Verificado que el test FALLA con las constantes viejas (regresión real, no un test que pasa por construcción).
- `src/visual/mundo3d/__tests__/vistaGlobalSierra.wiring.test.jsx` — (1) cada piso térmico declara un mundo con `view` no vacío; (2) el destino de cada banda es una ruta real de `App.jsx` (grep de `case`); (3) `useViajeSierra` arma/navega/apaga el viaje correctamente (un viaje a la vez, honestidad ante piso sin mundo); (4) integración end-to-end con el `TransicionSierraMundo` real y fake timers (tocar → cubre → a mitad navega → al final se apaga). Verificado que 6/8 tests fallan sin el cableo (los 2 que pasan son sanity checks de datos preexistentes).

## Verificación

- [x] `npm run build` verde (síncrono, 2m8s, sin errores nuevos)
- [x] `node scripts/audit-integraciones.mjs` → "Auditoría limpia — 0 huérfanos sin declarar"
- [x] `npx eslint` limpio en los archivos tocados
- [x] Tests nuevos pasan y se confirmó que fallan sin el fix (regresión real)
- [x] No se tocó arte de otros mundos, no se desplegó, no se activaron timers de producción

### Nota de honestidad

Al correr `entradaValle3D.nav.test.jsx` (test preexistente, no tocado por este PR) se encontró que 4/5 de sus casos fallan en este entorno — confirmado que fallan IDÉNTICO en la rama base (`origin/main`) sin ningún cambio mío, por lo que es una flakiness/rotura preexistente no relacionada con este PR (consistente con `unit-tests.yml`, que documenta 2 tests de visión ya conocidos como CI-flaky y por eso NO corre la suite completa en CI). No se intentó arreglar por estar fuera del alcance de esta tarea.

🤖 Generado con [Claude Code](https://claude.com/claude-code)