### PR TITLE
fix(huerfanos): cablear InfraestructuraViva + vitrina 2D de artesanía andina

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -170,6 +170,11 @@ const JuegoLaMilpaMockup = lazy(() => import('./mockups/JuegoLaMilpa'));
 // 3D: el PÁRAMO altoandino — el ecosistema de la niebla (frailejones, musgo,
 // quenuas, aves) y el NACIMIENTO del agua. Didáctico: la fábrica de agua.
 const MundoParamo3DMockup = lazy(() => import('./mockups/MundoParamo3D'));
+// 2D (SVG, three-free): el lenguaje de forma "artesanía andina" — paleta,
+// trazo, patrones de telar, banda chumbe, greca escalonada, marco de tarjeta
+// y siluetas de cerámica low-poly. Rescate de huérfano (ArtesaniaAndina.jsx
+// no tenía consumidor); ver su cabecera para el contrato de cableo.
+const ArtesaniaAndinaTelarMockup = lazy(() => import('./mockups/ArtesaniaAndinaTelarDemo'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
@@ -568,6 +573,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/valle-noche-3d': 'mockup_valle_noche_3d',
   'mockups/juego-la-milpa': 'mockup_juego_la_milpa',
   'mockups/mundo-paramo-3d': 'mockup_mundo_paramo_3d',
+  'mockups/artesania-andina-telar': 'mockup_artesania_andina_telar',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -1838,6 +1844,18 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El páramo altoandino">
               <MundoParamo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_artesania_andina_telar':
+        // El lenguaje de forma "artesanía andina" en su capa 2D (SVG,
+        // three-free): paleta, trazo, patrones de telar, banda chumbe, greca
+        // escalonada, marco de tarjeta y siluetas de cerámica. Ruta
+        // #/mockups/artesania-andina-telar, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Artesanía andina">
+              <ArtesaniaAndinaTelarMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/ArtesaniaAndinaTelarDemo.css
+++ b/src/mockups/ArtesaniaAndinaTelarDemo.css
@@ -1,0 +1,45 @@
+/*
+ * ArtesaniaAndinaTelarDemo.css — chrome MÍNIMO de la vitrina (título + marco).
+ * Los colores son la MISMA paleta que declara `artesaniaAndina.js`
+ * (ROLES_ANDINOS.fondo/linea): no se inventa tono nuevo para esta página.
+ */
+
+.artei {
+  min-height: 100dvh;
+  background: #ece0c7; /* PALETA_ANDINA.crudo == ROLES_ANDINOS.fondo */
+  color: #2a2016; /* PALETA_ANDINA.tinta == ROLES_ANDINOS.linea */
+  padding: 1.1rem 1rem 2.4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.artei__head {
+  max-width: 42rem;
+  text-align: center;
+  margin-bottom: 1.2rem;
+}
+
+.artei__kicker {
+  margin: 0 0 0.3rem;
+  font: 700 0.72rem/1.2 system-ui, sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.artei__head h1 {
+  margin: 0 0 0.5rem;
+  font: 700 1.35rem/1.25 system-ui, sans-serif;
+}
+
+.artei__lema {
+  margin: 0;
+  font: 500 0.92rem/1.5 system-ui, sans-serif;
+  opacity: 0.86;
+}
+
+.artei__lienzo {
+  width: 100%;
+  max-width: 46rem;
+}

--- a/src/mockups/ArtesaniaAndinaTelarDemo.jsx
+++ b/src/mockups/ArtesaniaAndinaTelarDemo.jsx
@@ -1,0 +1,48 @@
+/*
+ * ArtesaniaAndinaTelarDemo — vitrina pública (#/mockups/artesania-andina-telar)
+ * de la CAPA 2D (SVG, three-free) del lenguaje de forma "artesanía andina":
+ * paleta de tintes, trazo que respira, patrones de telar (rombo/zigzag/
+ * escalonado), banda chumbe, greca escalonada, marco de tarjeta y las
+ * siluetas de cerámica low-poly — todo dibujado por las primitivas de
+ * `ArtesaniaAndina.jsx` (nada reinventado aquí, cero CSS/props nuevos sobre
+ * las piezas).
+ *
+ * CABLEO (rescate de huérfano, ver ops/TRIAJE-HUERFANOS-3D-2026-07-21.md #4
+ * en Chagra-strategy): la propia cabecera de `ArtesaniaAndina.jsx` trae la
+ * instrucción "standalone (storybook / pantalla de estilo): montar
+ * <ShowcaseArtesania> directo". Este mockup hace exactamente eso — es la
+ * integración de riesgo cero de esa cabecera; adoptar `<MarcoTelar>` /
+ * `<BandaChumbe>` / `<GrecaEscalonada>` como tratamiento de las tarjetas 2D
+ * (`laminas2d/LaminaCultivo.jsx`, `Ficha.jsx`, `Infografia.jsx`) queda
+ * pendiente de dirección de arte, como marca el propio triaje.
+ *
+ * Es la CAPA 2D del kit, hermana de `ArtesaniaAndinaDemo.jsx` (la vitrina 3D
+ * de siluetas revolucionadas — hoy solo en `dev`, pendiente de promoción a
+ * `main`, por eso no está cableada aquí junto a ella). Ambas consumen el
+ * MISMO módulo de datos (`artesaniaAndina.js`) pero dibujan capas distintas
+ * (SVG plano vs. lathe 3D): no hay duplicación real entre ellas.
+ *
+ * Autocontenida: cero CDN/imágenes externas, sin auth, sin datos de finca.
+ * Español de Colombia, en "usted".
+ */
+import ShowcaseArtesania from '../visual/mundo3d/ArtesaniaAndina.jsx';
+import './ArtesaniaAndinaTelarDemo.css';
+
+export default function ArtesaniaAndinaTelarDemo() {
+  return (
+    <main className="artei">
+      <header className="artei__head">
+        <p className="artei__kicker">Lenguaje de forma · vitrina</p>
+        <h1>Artesanía andina: el telar como vocabulario</h1>
+        <p className="artei__lema">
+          Paleta de tintes naturales, trazo que respira y patrones de telar
+          (rombo, zigzag, escalonado) — el mismo lenguaje de forma listo para
+          vestir tarjetas, marcos y siluetas de cerámica de toda la finca.
+        </p>
+      </header>
+      <div className="artei__lienzo">
+        <ShowcaseArtesania />
+      </div>
+    </main>
+  );
+}

--- a/src/mockups/__tests__/artesaniaAndinaTelarDemo.smoke.test.jsx
+++ b/src/mockups/__tests__/artesaniaAndinaTelarDemo.smoke.test.jsx
@@ -1,0 +1,50 @@
+/*
+ * Vitrina #/mockups/artesania-andina-telar — smoke.
+ *
+ * A diferencia de las otras vitrinas del framework, esta es SVG puro
+ * (three-free): no monta Canvas ni depende de WebGL/decidirTier, así que el
+ * render es el MISMO en jsdom que en cualquier equipo. Congela que el cableo
+ * del huérfano `ArtesaniaAndina.jsx` quedó completo:
+ *   · la página renderiza título + <ShowcaseArtesania> (el svg autocontenido);
+ *   · la paleta trae las 9 muestras de PALETA_ANDINA;
+ *   · los 3 patrones de telar (rombos/zigzag/escalonado) están en <defs>;
+ *   · las 3 siluetas de cerámica (VASIJA_TIPOS) aparecen rotuladas.
+ */
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import ArtesaniaAndinaTelarDemo from '../ArtesaniaAndinaTelarDemo.jsx';
+import { PALETA_ANDINA, VASIJA_TIPOS } from '../../visual/mundo3d/artesaniaAndina.js';
+
+afterEach(() => cleanup());
+
+describe('vitrina de artesanía andina (mockups/artesania-andina-telar)', () => {
+  test('renderiza el muestrario completo del lenguaje de forma', () => {
+    const { container } = render(<ArtesaniaAndinaTelarDemo />);
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Artesanía andina: el telar como vocabulario' }),
+    ).toBeInTheDocument();
+
+    // el showcase es un <svg> autocontenido (three-free, nunca un Canvas roto)
+    const svg = container.querySelector('svg.artesania-showcase');
+    expect(svg).toBeInTheDocument();
+    expect(container.querySelector('canvas')).toBeNull();
+
+    // las 9 muestras de la paleta de tintes naturales
+    expect(svg.querySelectorAll('.artesania-rotulo').length).toBeGreaterThan(0);
+    expect(Object.keys(PALETA_ANDINA).length).toBe(9);
+
+    // los 3 patrones tejidos reutilizables, montados UNA vez en <defs>
+    expect(svg.querySelector('pattern#artesania-rombos')).toBeInTheDocument();
+    expect(svg.querySelector('pattern#artesania-zigzag')).toBeInTheDocument();
+    expect(svg.querySelector('pattern#artesania-escalonado')).toBeInTheDocument();
+
+    // las 3 siluetas de cerámica (mismo perfil que el lathe 3D), rotuladas
+    expect(VASIJA_TIPOS).toEqual(['olla', 'cantaro', 'cuenco']);
+    for (const tipo of VASIJA_TIPOS) {
+      expect(screen.getByText(tipo)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/mockups/vitrina3d/VitrinaInfraestructura.jsx
+++ b/src/mockups/vitrina3d/VitrinaInfraestructura.jsx
@@ -31,7 +31,7 @@ import {
   INFRAESTRUCTURA_IDS,
   INFRAESTRUCTURA_CATEGORIAS,
 } from '../../visual/mundo3d/infraestructura/infraestructuraData.js';
-import Infraestructura from '../../visual/mundo3d/infraestructura/Infraestructura.jsx';
+import InfraestructuraViva from '../../visual/mundo3d/infraestructura/InfraestructuraViva.jsx';
 import { decidirTier, permite3D } from '../../visual/mundo3d/deviceTier.js';
 import { ATMOSFERA } from '../../visual/mundo3d/atmosferaMadre.js';
 import './VitrinaInfraestructura.css';
@@ -126,7 +126,7 @@ function LienzoPieza({ tipo, dims, tier, reducedMotion }) {
         <meshLambertMaterial color="#b49873" />
       </mesh>
       <Suspense fallback={null}>
-        <Infraestructura tipo={tipo} dims={dims} tier={tier} reducedMotion={reducedMotion} />
+        <InfraestructuraViva tipo={tipo} dims={dims} tier={tier} reducedMotion={reducedMotion} />
       </Suspense>
       <OrbitControls
         target={[0, dims.alto * 0.42, 0]}
@@ -410,7 +410,7 @@ function DemoColocar({ modo3D, tier, reducedMotion }) {
             <directionalLight position={[-6, 5, -8]} intensity={0.22} color={ATMOSFERA.relleno} />
             <TerrenoDemo segmentos={tier === 'alto' ? 56 : 34} onTocar={tocarTerreno} />
             {colocadas.map((c, i) => (
-              <Infraestructura
+              <InfraestructuraViva
                 key={`${c.tipo}-${i}`}
                 tipo={c.tipo}
                 pos={c.pos}
@@ -422,7 +422,7 @@ function DemoColocar({ modo3D, tier, reducedMotion }) {
             {borrador && (
               <>
                 <AnilloBorrador borrador={borrador} />
-                <Infraestructura
+                <InfraestructuraViva
                   tipo={borrador.tipo}
                   pos={borrador.pos}
                   rot={borrador.rot}

--- a/src/visual/mundo3d/infraestructura/__tests__/infraestructuraViva.test.jsx
+++ b/src/visual/mundo3d/infraestructura/__tests__/infraestructuraViva.test.jsx
@@ -1,0 +1,103 @@
+/*
+ * InfraestructuraViva — el drop-in que se alimenta solo de useFincaViva.
+ *
+ * En jsdom no hay WebGL (ni Canvas R3F), así que se verifica con
+ * `renderToStaticMarkup` DIRECTO (sin <Canvas>) — el mismo truco que
+ * `vidaInfra.test.jsx` usa para <Infraestructura>. Se mockea `useFincaViva`
+ * (su propio hook interno, no la vitrina) para controlar el `estadoFinca` y
+ * comprobar el ÚNICO contrato de este wrapper: reenvía TODOS los props tal
+ * cual a <Infraestructura>, agregando `estadoFinca` = lo que devuelva el hook.
+ *
+ * Se congela:
+ *   · con useFincaViva() → estado real: el marcado es BYTE-IDÉNTICO al de
+ *     <Infraestructura estadoFinca={ESE_ESTADO} .../> con los mismos props.
+ *   · con useFincaViva() → null (finca "en camino"): el marcado es
+ *     BYTE-IDÉNTICO a la pieza neutra del catálogo (contrato anti-fabricación
+ *     heredado, sin fingir finca).
+ *   · props ajenos a estadoFinca (tipo/dims/params/tier/pos/rot/reducedMotion)
+ *     llegan intactos al dispatcher.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Infraestructura from '../Infraestructura.jsx';
+
+const ESTADO = {
+  clima: 'soleado',
+  enso: 'nino',
+  cosechaReciente: { cultivo: 'papa', mundoId: null },
+  saludFinca: { matasVivas: 12, matasTotal: 15, agua: 0.4 },
+  animales: [{ especie: 'Gallina criolla' }, { especie: 'Vaca normanda' }],
+};
+
+let estadoMock = ESTADO;
+vi.mock('../../useFincaViva.js', () => ({
+  useFincaViva: () => estadoMock,
+}));
+
+// Import DESPUÉS del mock (hoisted de todas formas, pero explícito por claridad).
+const { default: InfraestructuraViva } = await import('../InfraestructuraViva.jsx');
+
+afterEach(() => {
+  estadoMock = ESTADO;
+});
+
+const TIPOS = ['invernadero_tunel', 'almacen_bodega', 'galpon', 'gallinero_campo'];
+
+describe('InfraestructuraViva (drop-in alimentado por useFincaViva)', () => {
+  it('con estado real: idéntico a <Infraestructura estadoFinca={ese estado} .../>', () => {
+    estadoMock = ESTADO;
+    for (const tipo of TIPOS) {
+      for (const tier of ['alto', 'bajo']) {
+        const viva = renderToStaticMarkup(
+          <InfraestructuraViva tipo={tipo} tier={tier} reducedMotion />,
+        );
+        const directo = renderToStaticMarkup(
+          <Infraestructura tipo={tipo} tier={tier} reducedMotion estadoFinca={ESTADO} />,
+        );
+        expect(viva).toBe(directo);
+        // y de verdad refleja vida (no es la pieza neutra por accidente)
+        const neutro = renderToStaticMarkup(
+          <Infraestructura tipo={tipo} tier={tier} reducedMotion />,
+        );
+        expect(viva).not.toBe(neutro);
+      }
+    }
+  });
+
+  it('sin dato real (useFincaViva → null): byte-idéntico a la pieza neutra del catálogo', () => {
+    estadoMock = null;
+    for (const tipo of TIPOS) {
+      const viva = renderToStaticMarkup(<InfraestructuraViva tipo={tipo} tier="alto" reducedMotion />);
+      const neutro = renderToStaticMarkup(
+        <Infraestructura tipo={tipo} tier="alto" reducedMotion />,
+      );
+      expect(viva).toBe(neutro);
+    }
+  });
+
+  it('reenvía tipo/dims/params/tier/pos/rot/reducedMotion intactos al dispatcher', () => {
+    estadoMock = ESTADO;
+    const props = {
+      tipo: 'invernadero_tunel',
+      pos: [2, 0, -1],
+      rot: 0.4,
+      dims: { largo: 20, ancho: 5, alto: 3 },
+      params: { color: 'x' },
+      tier: 'bajo',
+      reducedMotion: true,
+    };
+    const viva = renderToStaticMarkup(<InfraestructuraViva {...props} />);
+    const directo = renderToStaticMarkup(<Infraestructura {...props} estadoFinca={ESTADO} />);
+    expect(viva).toBe(directo);
+    // las dims custom (20×5×3) sí llegaron: distinto del default del catálogo
+    const conDefaults = renderToStaticMarkup(
+      <Infraestructura tipo={props.tipo} tier={props.tier} reducedMotion estadoFinca={ESTADO} />,
+    );
+    expect(viva).not.toBe(conDefaults);
+  });
+
+  it('tipo desconocido no dibuja nada (ni siquiera intenta leer estadoFinca real)', () => {
+    estadoMock = ESTADO;
+    expect(renderToStaticMarkup(<InfraestructuraViva tipo="no_existe" />)).toBe('');
+  });
+});


### PR DESCRIPTION
## Resumen

Rescate de 2 de los 8 componentes huérfanos identificados en
`ops/TRIAJE-HUERFANOS-3D-2026-07-21.md` (Chagra-strategy, PR #160),
ambos marcados riesgo cero/bajo y ya autorizados por el operador.

- **`InfraestructuraViva.jsx`** — cableado en `VitrinaInfraestructura.jsx`
  (3 puntos de montaje: diorama de catálogo, piezas colocadas y el
  borrador). Mismo contrato de props que `Infraestructura` + un hook
  (`useFincaViva`); las piezas ahora reaccionan al estado real de la
  finca (microclima de invernadero, cosecha reciente, ocupación animal)
  en vez de verse siempre como catálogo estático neutro.

- **`ArtesaniaAndina.jsx`** (primitivas SVG del lenguaje "artesanía
  andina") — nueva vitrina `ArtesaniaAndinaTelarDemo.jsx`
  (`#/mockups/artesania-andina-telar`) que monta `<ShowcaseArtesania>`
  tal como la propia cabecera del archivo lo prescribe ("standalone:
  montar `<ShowcaseArtesania>` directo").

## Hallazgo importante (verificado, no asumido)

El brief original pedía verificar si `ArtesaniaAndinaDemo.jsx` (la
vitrina 3D hermana, que sí consume `artesaniaAndina.js`) ya tenía una
ruta viva en `App.jsx` y, de ser así, hacer que use las primitivas SVG.
Verifiqué con grep: **esa ruta y ese archivo no existen en `main`** —
viven solo en `origin/dev`, pendientes de promoción (mismo patrón que
`TransicionMundoKit.jsx` en el triaje). Por eso esta PR no toca ese
archivo ni su cableo.

Tampoco es un caso de duplicación real entre ambas vitrinas: consumen
el MISMO módulo de datos (`artesaniaAndina.js`) pero dibujan capas
distintas — SVG plano (2D) vs. `LatheGeometry` (3D), tal como documenta
la propia cabecera de `ArtesaniaAndina.jsx` ("3D: este archivo no
importa three; las escenas consumen los perfiles desde
`artesaniaAndina.js`"). Recomendación: cuando `dev` se promueva a
`main`, ambas vitrinas deberían convivir (no reemplazar una a la otra).
Adoptar `<MarcoTelar>`/`<BandaChumbe>`/`<GrecaEscalonada>` como
tratamiento visual de tarjetas 2D (`laminas2d/*`) queda pendiente de
dirección de arte, como marca el propio triaje — no es un cableo.

## No tocado a propósito

- El oso café (OsoAndino) y el borugo siguen archivados — ninguno de
  los 2 componentes rescatados los resucita.
- Ningún archivo de `laminas2d/*` ni de dirección de arte.
- `ArtesaniaAndina.jsx` / `artesaniaAndina.js` / `artesaniaAndina.css`
  no se modificaron — solo se consumen.

## Test plan

- [x] `infraestructuraViva.test.jsx` (nuevo): el wrapper es
      byte-idéntico a `<Infraestructura estadoFinca={X} .../>` llamado
      directo, con estado real y con `null` (contrato anti-fabricación);
      reenvío de props intacto; tipo desconocido no dibuja nada.
- [x] `artesaniaAndinaTelarDemo.smoke.test.jsx` (nuevo): la vitrina
      renderiza título + el showcase SVG completo (paleta de 9 tintes,
      3 patrones de telar en `<defs>`, las 3 siluetas de cerámica).
- [x] `npm run build` verde (`✓ built in 46.01s`) — ambos chunks nuevos
      (`ArtesaniaAndinaTelarDemo-*`, `VitrinaInfraestructura-*`)
      aparecen en `dist/`.
- [x] `node scripts/audit-integraciones.mjs` limpio (0 huérfanos sin
      declarar).
- [x] `eslint` limpio sobre todos los archivos tocados.
- [ ] Nota de honestidad: la corrida completa de `vitest run` en esta
      máquina (carga promedio ~34, varios worktrees corriendo pruebas a
      la vez) tiene fallas preexistentes y no relacionadas en ~20
      archivos (RAG retriever, VoiceSelector, GlaciarReporteScreen,
      themes coverage, IosInstallBanner, etc.) — ninguna toca los
      archivos de esta PR. No se investigaron a fondo por estar fuera de
      alcance de este rescate puntual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)