### PR TITLE
feat(microfauna): dar aire al corte de suelo

### DIFF
--- a/src/mockups/MundoMicrofauna3D.jsx
+++ b/src/mockups/MundoMicrofauna3D.jsx
@@ -33,14 +33,15 @@ import { OrbitControls, Html, AdaptiveDpr } from '@react-three/drei';
 import { ATMOSFERA } from '../visual/mundo3d/atmosferaMadre.js';
 import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
 import { ParticulasAmbientales } from '../visual/mundo3d/ParticulasAmbientales.jsx';
+import { NEUTROS, TIERRAS, VERDES } from '../visual/mundo3d/paleta/paletaMadre.js';
 
 /* ── Paleta local del microcosmos (cálida andina + translúcidos de microscopio) */
 const PAL = {
-  litter: '#7d8a3e', // hojarasca verde
+  litter: VERDES.paramoMusgoClaro, // hojarasca verde
   litterAlt: '#96a44e', // hojarasca al sol
-  humus: '#3c2a1b', // la tierra negra, viva
+  humus: TIERRAS.turba, // la tierra negra, viva
   humusAlt: '#4a3625',
-  mineral: '#7c5836', // subsuelo mineral, ocre
+  mineral: TIERRAS.siembra, // subsuelo mineral, ocre
   mineralAlt: '#8f6a44',
   raiz: '#c9a86a', // raíces claras
   piedra: '#9a8b74',
@@ -61,8 +62,8 @@ const PAL = {
   hifaOro: '#ffd27a', // el pulso dorado de la red
   nodo: '#ffe6a8',
   hongo: '#e7c9a0', // sombrerito de hongo
-  ojoBlanco: '#fbf6ec',
-  ojoPupila: '#241a12',
+  ojoBlanco: NEUTROS.hueso,
+  ojoPupila: NEUTROS.tinta,
 };
 
 /* PRNG determinista (mismo corte siempre, sin azar por frame). */
@@ -94,7 +95,7 @@ const ORGANISMOS = [
     oficio: 'El saltarín que recicla',
     texto:
       'Diminuto y saltarín: bajo la panza guarda un resorte con el que brinca lejos del peligro. Mastica hongos y hojarasca en pedacitos cada vez más pequeños y así apura la descomposición, para que otros terminen de convertirla en tierra buena.',
-    anchor: [-1.7, 0.92, 1.16],
+    anchor: [-2.55, 0.98, 1.46],
     color: '#b7a9ef',
     fase: 0.0,
     halo: 0.22,
@@ -108,7 +109,7 @@ const ORGANISMOS = [
     oficio: 'El oso de agua indestructible',
     texto:
       'Gordito y lento, camina con ocho paticas de peluche por la película de agua que envuelve al suelo. Es el ser más resistente que se conoce: si el suelo se seca, se encoge y se duerme (criptobiosis) y así aguanta años, hasta el frío y el vacío. Come jugos de musgos y de otras diminutas criaturas.',
-    anchor: [-0.05, 0.98, 1.18],
+    anchor: [-0.55, 0.2, 1.43],
     color: '#bcd3a3',
     fase: 0.5,
     halo: 0.26,
@@ -122,7 +123,7 @@ const ORGANISMOS = [
     oficio: 'El vigilante de ocho patas',
     texto:
       'Con sus ocho paticas recorre la hojarasca cazando y desmenuzando. Controla las plaguitas pequeñas y reparte la materia orgánica por todo el suelo. Casi nadie lo ve, pero es un guardián que trabaja sin descanso.',
-    anchor: [-1.05, 0.55, 1.2],
+    anchor: [-0.95, 0.98, 1.48],
     color: '#d76a52',
     fase: 0.9,
     halo: 0.24,
@@ -136,7 +137,7 @@ const ORGANISMOS = [
     oficio: 'El aliado casi invisible',
     texto:
       'Un gusanito transparente, más fino que un pelo. Los buenos se comen bacterias y hongos y, al hacerlo, liberan nutrientes para las raíces; otros persiguen larvas de plagas bajo tierra. Tan pequeño que no se ve, y tan útil para la huerta.',
-    anchor: [1.55, 0.6, 1.14],
+    anchor: [2.45, 0.24, 1.42],
     color: '#bfe6d8',
     fase: 2.4,
     halo: 0.26,
@@ -150,7 +151,7 @@ const ORGANISMOS = [
     oficio: 'La ingeniera del suelo',
     texto:
       'Se come la tierra y las hojas viejas y las devuelve convertidas en abono negro y fértil. Al abrir sus túneles deja entrar el aire y el agua: cada lombriz es un arado vivo que nunca descansa. Donde hay lombrices, el suelo está sano.',
-    anchor: [0.5, 0.16, 1.24],
+    anchor: [1.1, -0.02, 1.52],
     color: '#e8a58f',
     fase: 1.7,
     halo: 0.34,
@@ -164,7 +165,7 @@ const ORGANISMOS = [
     oficio: 'El nadador de la gota',
     texto:
       'Una sola célula que nada en la película de agua remando con miles de pelitos (cilios). Se traga bacterias por montones y, al hacerlo, suelta nutrientes que la raíz aprovecha al instante. Donde el suelo está húmedo y vivo, hay un mundo entero de protozoos girando en cada gota.',
-    anchor: [1.3, -0.12, 1.12],
+    anchor: [2.3, -0.52, 1.4],
     color: '#c7e6ec',
     fase: 3.4,
     halo: 0.28,
@@ -178,7 +179,7 @@ const ORGANISMOS = [
     oficio: 'El internet del bosque',
     texto:
       'Son hilos de hongo (hifas) que se enredan con las raíces y se extienden como una red dorada bajo tierra. Le llevan agua y minerales a la planta y, a cambio, reciben su azúcar. Por esta red las plantas hasta se avisan y se comparten alimento entre vecinas.',
-    anchor: [-1.05, -0.5, 0.72],
+    anchor: [-1.8, -0.6, 0.82],
     color: '#ffd27a',
     fase: 3.1,
     halo: 0.4,
@@ -192,7 +193,7 @@ const ORGANISMOS = [
     oficio: 'Las cocineras invisibles',
     texto:
       'Son tan pequeñas que millones caben en una cucharada de tierra. Transforman la materia muerta en alimento que la planta sí puede comer, y algunas capturan el nitrógeno del aire para abonar el suelo. Sin ellas, nada volvería a nacer.',
-    anchor: [0.35, -0.55, 0.8],
+    anchor: [0.45, -0.82, 0.9],
     color: '#ffdf9a',
     fase: 3.8,
     halo: 0.36,
@@ -228,8 +229,8 @@ function Ojo({ pos = [0, 0, 0], r = 0.04 }) {
 /* ── EL CORTE DE SUELO (fondo): hojarasca verde arriba, tierra negra, subsuelo
       ocre; raíces que bajan, piedritas y hojas caídas. Redondeado, low-poly. ── */
 function CorteSuelo() {
-  const ANCHO = 4.6;
-  const PROF = 2.0;
+  const ANCHO = 6.8;
+  const PROF = 2.8;
   const capas = [
     { y: 0.86, h: 0.28, c: PAL.litter, cAlt: PAL.litterAlt }, // hojarasca
     { y: 0.3, h: 0.9, c: PAL.humus, cAlt: PAL.humusAlt }, // tierra negra
@@ -255,7 +256,7 @@ function CorteSuelo() {
   const raices = useMemo(() => {
     const r = rng(41);
     return Array.from({ length: 4 }, (_, i) => ({
-      x: -1.4 + i * 0.95 + (r() - 0.5) * 0.3,
+      x: -2.5 + i * 1.3 + (r() - 0.5) * 0.3,
       largo: 1.1 + r() * 0.9,
       tilt: (r() - 0.5) * 0.5,
     }));
@@ -307,9 +308,9 @@ function PeliculaAgua({ reducedMotion }) {
   const refs = useRef([]);
   const lentes = useMemo(
     () => [
-      { p: [0.2, 0.2, 1.02], s: [1.9, 1.0, 1], fase: 0 },
-      { p: [1.2, -0.1, 0.98], s: [1.0, 0.7, 1], fase: 1.4 },
-      { p: [-0.9, 0.5, 1.0], s: [0.9, 0.6, 1], fase: 2.7 },
+      { p: [-0.55, 0.2, 1.3], s: [1.3, 0.8, 1], fase: 0 },
+      { p: [2.3, -0.25, 1.28], s: [1.15, 0.76, 1], fase: 1.4 },
+      { p: [1.05, -0.05, 1.3], s: [1.1, 0.66, 1], fase: 2.7 },
     ],
     [],
   );
@@ -352,7 +353,7 @@ function Colembolo({ base, reducedMotion }) {
     cuerpo.current.rotation.z = Math.sin(t * 0.7) * 0.08;
   });
   return (
-    <group ref={cuerpo} position={base}>
+    <group ref={cuerpo} position={base} scale={1.16}>
       {/* cuerpo */}
       <mesh scale={[1.25, 0.9, 1]}>
         <sphereGeometry args={[0.13, 14, 12]} />
@@ -401,7 +402,7 @@ function Acaro({ base, reducedMotion }) {
     }
   });
   return (
-    <group ref={cuerpo} position={base}>
+    <group ref={cuerpo} position={base} scale={1.28}>
       <mesh>
         <sphereGeometry args={[0.13, 14, 12]} />
         <meshLambertMaterial color={PAL.acaro} flatShading />
@@ -415,8 +416,12 @@ function Acaro({ base, reducedMotion }) {
       {patasDef.map((pt, i) => (
         <group key={i} position={[0.1 * pt.lado, -0.02, 0.02 * (i % 4 - 1.5)]} rotation={[0, 0, pt.ang * pt.lado]}>
           <group ref={(el) => { patas.current[i] = el; }}>
-            <mesh position={[0.1 * pt.lado, -0.02, 0]} rotation={[0, 0, pt.lado * 0.6]}>
-              <cylinderGeometry args={[0.009, 0.006, 0.2, 4]} />
+            <mesh position={[0.08 * pt.lado, -0.02, 0]} rotation={[0, 0, pt.lado * 0.6]}>
+              <cylinderGeometry args={[0.01, 0.007, 0.18, 4]} />
+              <meshBasicMaterial color={PAL.acaroPata} />
+            </mesh>
+            <mesh position={[0.18 * pt.lado, -0.09, 0]} rotation={[0, 0, pt.lado * 1.05]}>
+              <cylinderGeometry args={[0.008, 0.004, 0.15, 4]} />
               <meshBasicMaterial color={PAL.acaroPata} />
             </mesh>
           </group>
@@ -431,11 +436,11 @@ function Acaro({ base, reducedMotion }) {
 function Lombriz({ base, reducedMotion }) {
   const segs = useRef([]);
   const puntos = useMemo(() => {
-    const n = 11;
+    const n = 15;
     return Array.from({ length: n }, (_, i) => {
       const u = i / (n - 1);
       return {
-        x: -0.5 + u * 1.0,
+        x: -0.78 + u * 1.56,
         y: Math.sin(u * Math.PI * 1.3) * 0.14,
         r: 0.075 * (0.5 + Math.sin(u * Math.PI) * 0.7),
         clitelo: u > 0.32 && u < 0.46,
@@ -454,7 +459,7 @@ function Lombriz({ base, reducedMotion }) {
     }
   });
   return (
-    <group position={base} rotation={[0, 0.2, 0]}>
+    <group position={base} scale={1.14} rotation={[0, 0.2, 0]}>
       {puntos.map((p, i) => (
         <group key={i} ref={(el) => { segs.current[i] = el; }} position={[p.x, p.y, 0]}>
           <mesh>
@@ -548,7 +553,7 @@ function Tardigrado({ base, reducedMotion }) {
     }
   });
   return (
-    <group ref={cuerpo} position={base} rotation={[0, -0.35, 0]}>
+    <group ref={cuerpo} position={base} scale={1.28} rotation={[0, -0.35, 0]}>
       {/* cuerpo segmentado, translúcido */}
       {segmentos.map((s, i) => (
         <mesh key={i} position={[s.x, 0, 0]}>
@@ -960,7 +965,7 @@ function EscenaMicro({ tier, reducedMotion, focus, hover, onSeleccion, onHover }
           tier={tier}
           reducedMotion={reducedMotion}
           position={[0, 0.4, 1.0]}
-          area={[4.4, 2.6, 2.2]}
+          area={[6.5, 2.6, 2.8]}
           semilla={31}
         />
       )}

--- a/src/mockups/MundoParamo3D.jsx
+++ b/src/mockups/MundoParamo3D.jsx
@@ -2229,6 +2229,12 @@ const COPY_FABRICA =
 const COPY_LECCION =
   'La guardiana abre la tierra y enseña sus cinco pisos, uno por uno: la hojarasca que abriga, el humus vivo, la zona de raíces, la red de hongos que reparte el alimento y la roca madre.';
 
+const RUTA_MUNDO_MICROFAUNA = '#/mockups/mundo-microfauna-3d';
+
+function abrirMundoMicrofauna() {
+  window.location.hash = RUTA_MUNDO_MICROFAUNA;
+}
+
 /**
  * MundoParamo3D — el páramo altoandino, montable con su propio `<Canvas>`.
  * Sin lógica de negocio: es una vitrina (#/mockups/mundo-paramo-3d). El tier y
@@ -2353,6 +2359,15 @@ export default function MundoParamo3D() {
           >
             {enLeccion ? 'Volver al páramo' : 'La lección del suelo'}
           </button>
+          {enLeccion && (
+            <button
+              type="button"
+              className="paramo-boton"
+              onClick={abrirMundoMicrofauna}
+            >
+              Explorar la vida del suelo
+            </button>
+          )}
           <button
             type="button"
             className="paramo-boton"

--- a/src/mockups/__tests__/mundoMicrofauna.layout.test.js
+++ b/src/mockups/__tests__/mundoMicrofauna.layout.test.js
@@ -1,0 +1,25 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, test } from 'vitest';
+
+const archivo = 'src/mockups/MundoMicrofauna3D.jsx';
+
+describe('MundoMicrofauna3D, corte con aire', () => {
+  test('amplia el corte y conserva el elenco separado por sus estratos', async () => {
+    const fuente = await readFile(archivo, 'utf8');
+
+    expect(fuente).toContain('const ANCHO = 6.8;');
+    expect(fuente).toContain('const PROF = 2.8;');
+    expect(fuente).toContain("anchor: [-2.55, 0.98, 1.46]");
+    expect(fuente).toContain("anchor: [-0.55, 0.2, 1.43]");
+    expect(fuente).toContain("anchor: [-1.8, -0.6, 0.82]");
+    expect(fuente).toContain("anchor: [0.45, -0.82, 0.9]");
+  });
+
+  test('mantiene las ocho patas del tardigrado y del acaro visibles', async () => {
+    const fuente = await readFile(archivo, 'utf8');
+
+    expect(fuente).toContain('const xs = [-0.05, 0.08, 0.21, 0.34];');
+    expect(fuente).toContain('Array.from({ length: 8 }');
+    expect(fuente).toContain('cylinderGeometry args={[0.008, 0.004, 0.15, 4]}');
+  });
+});

--- a/src/mockups/__tests__/mundoParamoMicrofauna.nav.test.jsx
+++ b/src/mockups/__tests__/mundoParamoMicrofauna.nav.test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@react-three/fiber', () => ({
+  Canvas: () => <div data-testid="canvas-paramo" />,
+  useFrame: () => {},
+  useThree: () => ({ camera: {}, invalidate: () => {}, gl: {} }),
+}));
+
+vi.mock('@react-three/drei', () => ({
+  AdaptiveDpr: () => null,
+  Html: ({ children }) => <>{children}</>,
+  OrbitControls: () => null,
+}));
+
+vi.mock('../../visual/mundo3d/deviceTier.js', () => ({
+  decidirTier: () => ({ tier: 'medio' }),
+  perfilDeTier: () => ({ dpr: [1, 1], antialias: false }),
+}));
+
+import MundoParamo3D from '../MundoParamo3D.jsx';
+
+afterEach(() => {
+  cleanup();
+  window.location.hash = '';
+});
+
+describe('entrada desde la leccion del suelo', () => {
+  test('muestra una puerta explicita hacia el mundo de microfauna', () => {
+    render(<MundoParamo3D />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'La lección del suelo' }));
+    const entrada = screen.getByRole('button', { name: 'Explorar la vida del suelo' });
+
+    fireEvent.click(entrada);
+    expect(window.location.hash).toBe('#/mockups/mundo-microfauna-3d');
+  });
+});

--- a/src/visual/mundo3d/MicrofaunaSuelo.css
+++ b/src/visual/mundo3d/MicrofaunaSuelo.css
@@ -8,7 +8,7 @@
   position: relative;
   width: 100%;
   height: 100%;
-  min-height: 320px;
+  min-height: 420px;
 }
 
 .microfauna__canvas {
@@ -26,7 +26,7 @@
   white-space: nowrap;
   padding: 0.16em 0.55em;
   border-radius: 999px;
-  font: 600 13px/1.1 system-ui, -apple-system, "Segoe UI", sans-serif;
+  font: 700 14px/1.1 system-ui, -apple-system, "Segoe UI", sans-serif;
   color: #4a2f1a;
   background: rgba(255, 249, 234, 0.92);
   border: 1.5px solid rgba(122, 84, 46, 0.35);

--- a/src/visual/mundo3d/MicrofaunaSuelo.jsx
+++ b/src/visual/mundo3d/MicrofaunaSuelo.jsx
@@ -31,23 +31,16 @@ import { useMemo, useRef, useEffect } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, Html, AdaptiveDpr } from '@react-three/drei';
 import * as THREE from 'three';
+import { NEUTROS, TIERRAS, VERDES } from './paleta/paletaMadre.js';
 
 import './MicrofaunaSuelo.css';
 
-// Stub components referenced in JSX but not yet implemented.
-/** @param {any} _ @returns {null} */
-function BloqueSuelo(_) { return null; }
-/** @param {any} _ @returns {null} */
-function Lombriz(_) { return null; }
-/** @param {any} _ @returns {null} */
-function Colembolo(_) { return null; }
-
 /* ── paleta andina + rubber-hose ─────────────────────────────────────────── */
 const PAL = {
-  hojarasca: '#7d8a3e',
+  hojarasca: VERDES.paramoMusgoClaro,
   litterAlt: '#9aa64f',
-  sueloNegro: '#3c2a1b',
-  subsuelo: '#7c5836',
+  sueloNegro: TIERRAS.turba,
+  subsuelo: TIERRAS.siembra,
   subsueloAlt: '#8f6a44',
   raiz: '#c9a86a',
   brote: '#6f9a45',
@@ -60,14 +53,14 @@ const PAL = {
   hifa: '#f2ece0',
   hifaOro: '#ffd27a',
   nodo: '#ffe6a8',
-  ojoBlanco: '#fbf6ec',
-  ojoPupila: '#241a12',
+  ojoBlanco: NEUTROS.hueso,
+  ojoPupila: NEUTROS.tinta,
 };
 
 /* frente del bloque (cara cortada): la vida se pega/protruye aquí para leerse. */
 const FRENTE = 1.06;
-const ANCHO = 4.6;
-const PROF = 2.2;
+const ANCHO = 6.8;
+const PROF = 2.8;
 
 /* PRNG determinista (mismo corte siempre, sin azar por frame). */
 function rng(seed) {
@@ -103,36 +96,95 @@ function presupuesto(tier, vida) {
 
 /* ── ojo rubber-hose (blanco grande + pupila oscura mirando al frente) ─────── */
 function Ojo({ pos = [0, 0, 0], size = 0.05 }) {
-  const cuerpo = null; const base = pos; const escala = 1; const furca = null;
   return (
-    <group ref={cuerpo} position={/** @type {[number, number, number]} */ (base)} scale={escala}>
+    <group position={/** @type {[number, number, number]} */ (pos)}>
       <mesh>
-        <sphereGeometry args={[0.1, 12, 10]} />
-        <meshLambertMaterial color={PAL.colembolo} flatShading />
+        <sphereGeometry args={[size, 10, 8]} />
+        <meshBasicMaterial color={PAL.ojoBlanco} />
       </mesh>
-      <mesh position={[0, -0.03, 0.06]} scale={[0.9, 0.7, 0.7]}>
-        <sphereGeometry args={[0.08, 10, 8]} />
-        <meshLambertMaterial color={PAL.colemboloVientre} flatShading />
+      <mesh position={[0, 0, size * 0.72]}>
+        <sphereGeometry args={[size * 0.46, 8, 6]} />
+        <meshBasicMaterial color={PAL.ojoPupila} />
       </mesh>
-      {/* ojos grandes rubber-hose */}
-      <Ojo pos={[0.05, 0.04, 0.08]} size={0.038} />
-      <Ojo pos={[-0.05, 0.04, 0.08]} size={0.038} />
-      {/* antenitas */}
-      <mesh position={[0.05, 0.12, 0.05]} rotation={[0.3, 0, 0.4]}>
-        <cylinderGeometry args={[0.006, 0.006, 0.14, 4]} />
-        <meshBasicMaterial color={PAL.colemboloVientre} />
-      </mesh>
-      <mesh position={[-0.05, 0.12, 0.05]} rotation={[0.3, 0, -0.4]}>
-        <cylinderGeometry args={[0.006, 0.006, 0.14, 4]} />
-        <meshBasicMaterial color={PAL.colemboloVientre} />
-      </mesh>
-      {/* furca (el "resorte" bajo el abdomen) */}
-      <group ref={furca} position={[0, -0.05, -0.08]}>
-        <mesh position={[0, -0.07, 0]}>
-          <cylinderGeometry args={[0.008, 0.004, 0.16, 4]} />
-          <meshBasicMaterial color={PAL.colembolo} />
+    </group>
+  );
+}
+
+function BloqueSuelo() {
+  const capas = [
+    { y: 0.86, h: 0.28, color: PAL.hojarasca },
+    { y: 0.28, h: 0.92, color: PAL.sueloNegro },
+    { y: -0.72, h: 1.08, color: PAL.subsuelo },
+  ];
+  return (
+    <group>
+      {capas.map((capa, i) => (
+        <mesh key={i} position={[0, capa.y, -0.25]}>
+          <boxGeometry args={[ANCHO, capa.h, PROF]} />
+          <meshLambertMaterial color={capa.color} flatShading />
         </mesh>
-      </group>
+      ))}
+      {[-2.45, -1.1, 0.2, 1.55, 2.7].map((x, i) => (
+        <mesh key={x} position={[x, 0.36, FRENTE - 0.42]} rotation={[0, 0, (i - 2) * 0.11]}>
+          <cylinderGeometry args={[0.022, 0.06, 1.18 + (i % 2) * 0.32, 6]} />
+          <meshLambertMaterial color={PAL.raiz} flatShading />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function Lombriz({ base, nSeg = 14, escala = 1, fase = 0, reducedMotion }) {
+  const segmentos = useRef([]);
+  const puntos = useMemo(() => Array.from({ length: nSeg }, (_, i) => {
+    const u = i / (nSeg - 1);
+    return {
+      x: -0.78 + u * 1.56,
+      y: Math.sin(u * Math.PI * 1.35) * 0.14,
+      r: 0.075 * (0.64 + Math.sin(u * Math.PI) * 0.55),
+      clitelo: u > 0.35 && u < 0.49,
+    };
+  }), [nSeg]);
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const t = state.clock.elapsedTime * 2.1 + fase;
+    segmentos.current.forEach((segmento, i) => {
+      if (!segmento) return;
+      const ola = 1 + Math.sin(t - i * 0.48) * 0.12;
+      segmento.scale.set(ola, 2 - ola, 2 - ola);
+      segmento.position.y = puntos[i].y + Math.sin(t * 0.5 - i * 0.4) * 0.02;
+    });
+  });
+  return (
+    <group position={base} scale={escala} rotation={[0, 0.16, 0]}>
+      {puntos.map((punto, i) => (
+        <group key={i} ref={(el) => { segmentos.current[i] = el; }} position={[punto.x, punto.y, 0]}>
+          <mesh>
+            <sphereGeometry args={[punto.r, 10, 8]} />
+            <meshLambertMaterial color={punto.clitelo ? '#f3cdbf' : PAL.lombriz} flatShading />
+          </mesh>
+          {i === 0 && <><Ojo pos={[0.03, 0.03, punto.r * 0.85]} size={0.022} /><Ojo pos={[-0.03, 0.03, punto.r * 0.85]} size={0.022} /></>}
+        </group>
+      ))}
+    </group>
+  );
+}
+
+function Colembolo({ base, escala = 1, fase = 0, reducedMotion }) {
+  const cuerpo = useRef(null);
+  useFrame((state) => {
+    if (reducedMotion || !cuerpo.current) return;
+    const t = state.clock.elapsedTime * 1.35 + fase;
+    cuerpo.current.position.y = base[1] + Math.max(0, Math.sin(t)) ** 4 * 0.18;
+    cuerpo.current.rotation.z = Math.sin(t * 0.7) * 0.08;
+  });
+  return (
+    <group ref={cuerpo} position={base} scale={escala}>
+      <mesh scale={[1.3, 0.92, 1]}><sphereGeometry args={[0.14, 14, 12]} /><meshLambertMaterial color={PAL.colembolo} flatShading /></mesh>
+      <mesh position={[0, -0.05, 0.1]} scale={[0.9, 0.62, 0.7]}><sphereGeometry args={[0.11, 10, 8]} /><meshLambertMaterial color={PAL.colemboloVientre} flatShading /></mesh>
+      <Ojo pos={[0.065, 0.055, 0.13]} size={0.045} /><Ojo pos={[-0.065, 0.055, 0.13]} size={0.045} />
+      {[0.07, -0.07].map((x) => <mesh key={x} position={[x, 0.16, 0.06]} rotation={[0.4, 0, x > 0 ? 0.5 : -0.5]}><cylinderGeometry args={[0.007, 0.007, 0.18, 4]} /><meshBasicMaterial color={PAL.colemboloVientre} /></mesh>)}
+      <mesh position={[0, -0.1, -0.12]} rotation={[0.7, 0, 0]}><cylinderGeometry args={[0.007, 0.013, 0.2, 5]} /><meshBasicMaterial color={PAL.colembolo} /></mesh>
     </group>
   );
 }
@@ -361,8 +413,8 @@ export function DioramaMicrofaunaSuelo({
   const lombrices = useMemo(
     () => Array.from({ length: P.lombrices }, (_, i) => ({
       key: i,
-      base: [-1.1 + i * 1.5, 0.28 - i * 0.55, FRENTE + 0.02],
-      escala: 0.9 - i * 0.1,
+      base: [-2.1 + i * 4.05, 0.2 - i * 0.58, FRENTE + 0.02],
+      escala: 1.12 - i * 0.08,
       fase: i * 1.9,
     })),
     [P.lombrices],
@@ -370,8 +422,8 @@ export function DioramaMicrofaunaSuelo({
   const colembolos = useMemo(
     () => Array.from({ length: P.colembolos }, (_, i) => ({
       key: i,
-      base: [-1.4 + i * 1.3, 0.9, FRENTE + 0.08],
-      escala: 0.85 + (i % 2) * 0.1,
+      base: [-2.55 + i * 2.5, 0.94, FRENTE + 0.08],
+      escala: 1.08 + (i % 2) * 0.08,
       fase: i * 1.1,
     })),
     [P.colembolos],
@@ -379,8 +431,8 @@ export function DioramaMicrofaunaSuelo({
   const acaros = useMemo(
     () => Array.from({ length: P.acaros }, (_, i) => ({
       key: i,
-      base: [-1.0 + i * 1.1, 0.72 - (i % 2) * 0.25, FRENTE + 0.02],
-      escala: 0.8 + (i % 2) * 0.12,
+      base: [-1.25 + i * 1.9, 0.94 - (i % 2) * 0.13, FRENTE + 0.02],
+      escala: 1.14 + (i % 2) * 0.1,
       fase: i * 2.3,
     })),
     [P.acaros],


### PR DESCRIPTION
## Summary
- Amplía el corte de suelo y separa la microfauna por estrato.
- Refuerza las siluetas de lombriz, ácaro y tardígrado con la paleta madre.
- Añade una entrada visible desde la lección del suelo del páramo.

## Test plan
- npx vitest run src/mockups/__tests__/mundoParamoMicrofauna.nav.test.jsx src/mockups/__tests__/mundoMicrofauna.layout.test.js
- npx eslint archivos cambiados --max-warnings=0
- npm run build

Nota: la suite global ya tenía fallos ajenos en servicios, rutas, voz y otros mundos; se interrumpió tras confirmarlos. scripts/audit-integraciones.mjs no existe en este worktree.