### PR TITLE
feat(angelita): guía reutilizable — señala y enseña sobre elementos reales de una pantalla 2D

### DIFF
--- a/src/hooks/__tests__/useAngelitaGuia.test.js
+++ b/src/hooks/__tests__/useAngelitaGuia.test.js
@@ -1,0 +1,319 @@
+/**
+ * useAngelitaGuia.test.js — el mecanismo REUTILIZABLE de "Angelita señala y
+ * enseña" (nace en dia-en-finca, pensado para regarse a toda pantalla 2D).
+ *
+ * Cubre lo que pide el encargo:
+ *   1. Se posiciona respecto al ELEMENTO real (no coordenadas fijas), y se
+ *      recalcula si el elemento se mueve (scroll) o el viewport cambia.
+ *   2. Respeta prefers-reduced-motion (expone `quieta`, aparece sin demora).
+ *   3. El texto/gesto de cada parada es EXACTAMENTE el declarado por la
+ *      pantalla (con `variar:false`) y `angelitaVariedad` solo viste una vez
+ *      activo, sin pisar el contenido factual.
+ *   4. Recorrido: siguiente/anterior/ir encadenan varias paradas; una sola
+ *      parada funciona igual (responde a "uno solo").
+ *
+ * NOTA DE INFRAESTRUCTURA DE TEST: una actualización de estado disparada por
+ * un `setTimeout` (no envuelto en un `act()` explícito en el sitio de
+ * llamada) deja pendiente el `useLayoutEffect` que depende de ella hasta el
+ * PRÓXIMO corte de `act()` — si ese corte es el único que esperamos, el rAF
+ * que ese efecto agenda no alcanza a dispararse. `asentar()` resuelve esto
+ * con varios cortes cortos de `act()` en vez de uno solo largo (patrón
+ * verificado con una reproducción mínima fuera de este hook).
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useAngelitaGuia, { calcularPuestoGuia } from '../useAngelitaGuia.js';
+import { variantesDeterministas } from '../../services/angelitaVariedad.js';
+
+function stubReducedMotion(matches) {
+  vi.stubGlobal('matchMedia', (q) => ({
+    matches: q.includes('reduce') ? matches : false,
+    media: q,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+/** Un DOMRect de mentiras, con las cuatro esquinas que pide getBoundingClientRect. */
+function rectFalso({ top, left, width, height }) {
+  return { top, left, right: left + width, bottom: top + height, width, height };
+}
+
+/** Un "elemento" mínimo: solo lo que el hook toca. */
+function elementoFalso(rect) {
+  let actual = rect;
+  return {
+    getBoundingClientRect: () => actual,
+    _mover: (nuevo) => {
+      actual = nuevo;
+    },
+  };
+}
+
+/**
+ * Deja correr varios cortes CORTOS de `act()` hasta que `predicado` sea
+ * cierto (o se agoten los intentos). Ver nota de infraestructura arriba.
+ */
+async function asentar(result, predicado = () => true, { intentos = 12, pasoMs = 20 } = {}) {
+  for (let i = 0; i < intentos; i += 1) {
+    if (predicado(result.current)) return;
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, pasoMs));
+    });
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 390 });
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 844 });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('calcularPuestoGuia — geometría pura', () => {
+  it('null sin rect (elemento aún no montado)', () => {
+    expect(calcularPuestoGuia(null)).toBeNull();
+  });
+
+  it('percha en la esquina con MÁS aire y clampea dentro del viewport', () => {
+    // Tarjeta casi de borde a borde (14px de margen a cada lado): el aire es
+    // parejo — gana 'derecha' (empate hacia el lado de lectura natural).
+    const rect = rectFalso({ top: 200, left: 14, width: 362, height: 180 });
+    const puesto = calcularPuestoGuia(rect, { tamano: 64, margen: 14, viewportW: 390, viewportH: 844 });
+    expect(puesto.lado).toBe('derecha');
+    expect(puesto.direccion).toBe('izquierda'); // perchada a la derecha, apunta a la izquierda
+    expect(puesto.x).toBeGreaterThanOrEqual(14);
+    expect(puesto.x + 64).toBeLessThanOrEqual(390 - 14 + 0.01);
+    expect(puesto.y).toBeGreaterThanOrEqual(14);
+    expect(puesto.enVista).toBe(true);
+  });
+
+  it('con mucho más aire a la izquierda, percha ahí y mira a la derecha', () => {
+    // Elemento angosto, pegado al borde derecho: casi todo el aire libre
+    // queda a la izquierda.
+    const rect = rectFalso({ top: 100, left: 340, width: 40, height: 40 });
+    const puesto = calcularPuestoGuia(rect, { tamano: 64, viewportW: 390, viewportH: 844 });
+    expect(puesto.lado).toBe('izquierda');
+    expect(puesto.direccion).toBe('derecha');
+  });
+
+  it('acepta lado forzado por la parada (pisa la elección automática)', () => {
+    const rect = rectFalso({ top: 100, left: 14, width: 362, height: 100 });
+    const puesto = calcularPuestoGuia(rect, { ladoForzado: 'izquierda', viewportW: 390, viewportH: 844 });
+    expect(puesto.lado).toBe('izquierda');
+  });
+
+  it('un elemento scrolleado fuera de pantalla queda fuera de vista', () => {
+    const rect = rectFalso({ top: -900, left: 14, width: 362, height: 180 });
+    const puesto = calcularPuestoGuia(rect, { viewportW: 390, viewportH: 844 });
+    expect(puesto.enVista).toBe(false);
+  });
+
+  it('jamás se sale del viewport aunque el margen pedido sea imposible', () => {
+    const rect = rectFalso({ top: 0, left: 0, width: 10, height: 10 });
+    const puesto = calcularPuestoGuia(rect, { tamano: 400, margen: 40, viewportW: 390, viewportH: 844 });
+    expect(puesto.x).toBeGreaterThanOrEqual(0);
+    expect(puesto.y).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('useAngelitaGuia — se posiciona respecto al ELEMENTO, no a coordenadas fijas', () => {
+  it('mide el rect real del elemento de la parada activa', async () => {
+    const el = elementoFalso(rectFalso({ top: 300, left: 14, width: 362, height: 150 }));
+    const paradas = [{ id: 'cafe', ref: { current: el }, texto: 'Guarde el café.', gesto: 'senala' }];
+
+    const { result } = renderHook(() => useAngelitaGuia(paradas, { demoraInicialMs: 0, variar: false }));
+    await asentar(result, (r) => r.posicion !== null);
+
+    expect(result.current.posicion).toBeTruthy();
+    expect(result.current.visible).toBe(true);
+    expect(result.current.parada.texto).toBe('Guarde el café.');
+  });
+
+  it('recalcula cuando el elemento se mueve (scroll) y sigue clampeado', async () => {
+    const el = elementoFalso(rectFalso({ top: 300, left: 14, width: 362, height: 150 }));
+    const paradas = [{ id: 'cafe', ref: { current: el }, texto: 'Guarde el café.' }];
+    const { result } = renderHook(() => useAngelitaGuia(paradas, { demoraInicialMs: 0, variar: false }));
+    await asentar(result, (r) => r.posicion !== null);
+    const yAntes = result.current.posicion.y;
+
+    // El usuario hizo scroll: la tarjeta subió 500px, ahora fuera de pantalla.
+    el._mover(rectFalso({ top: -800, left: 14, width: 362, height: 150 }));
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    await asentar(result, (r) => r.posicion && r.posicion.y !== yAntes);
+
+    expect(result.current.posicion.y).not.toBe(yAntes);
+    // El elemento ya no está en pantalla: la guía se sabe "fuera de vista".
+    expect(result.current.enVista).toBe(false);
+  });
+
+  it('sin elemento montado (ref.current null) no hay posición ni se rompe', async () => {
+    const paradas = [{ id: 'fantasma', ref: { current: null }, texto: 'x' }];
+    const { result } = renderHook(() => useAngelitaGuia(paradas, { demoraInicialMs: 0 }));
+    await asentar(result, (r) => r.lista !== undefined); // deja correr unos cortes igual
+    expect(result.current.posicion).toBeNull();
+    expect(result.current.visible).toBe(false);
+  });
+
+  it('acepta un getter función además de un ref de React (mapas de refs dinámicos)', async () => {
+    const el = elementoFalso(rectFalso({ top: 50, left: 14, width: 100, height: 40 }));
+    const paradas = [{ id: 'dinamico', ref: () => el, texto: 'x' }];
+    const { result } = renderHook(() => useAngelitaGuia(paradas, { demoraInicialMs: 0, variar: false }));
+    await asentar(result, (r) => r.posicion !== null);
+    expect(result.current.posicion).toBeTruthy();
+  });
+});
+
+describe('useAngelitaGuia — respeta prefers-reduced-motion', () => {
+  it('con reduced-motion: quieta=true y aparece YA (sin esperar la demora)', async () => {
+    stubReducedMotion(true);
+    const el = elementoFalso(rectFalso({ top: 100, left: 14, width: 200, height: 80 }));
+    const paradas = [{ id: 'a', ref: { current: el }, texto: 'x' }];
+    // demoraInicialMs alto a propósito: si respetara la demora, este test
+    // fallaría (nunca alcanzaría a esperar tanto).
+    const { result } = renderHook(() =>
+      useAngelitaGuia(paradas, { demoraInicialMs: 60_000, variar: false }),
+    );
+    expect(result.current.quieta).toBe(true);
+    await asentar(result, (r) => r.visible === true);
+    expect(result.current.visible).toBe(true);
+  });
+
+  it('sin reduced-motion: quieta=false', () => {
+    stubReducedMotion(false);
+    const { result } = renderHook(() => useAngelitaGuia([], {}));
+    expect(result.current.quieta).toBe(false);
+  });
+});
+
+describe('useAngelitaGuia — el texto y el gesto son EXACTAMENTE lo declarado', () => {
+  it('con variar:false, el texto de cada parada es el literal declarado', async () => {
+    const elA = elementoFalso(rectFalso({ top: 100, left: 14, width: 200, height: 80 }));
+    const elB = elementoFalso(rectFalso({ top: 400, left: 14, width: 200, height: 80 }));
+    const paradas = [
+      { id: 'a', ref: { current: elA }, texto: 'El café mojado coge hongos.', gesto: 'senala' },
+      { id: 'b', ref: { current: elB }, texto: 'El agua de lluvia no trae cloro.', gesto: 'invita' },
+    ];
+    const { result } = renderHook(() => useAngelitaGuia(paradas, { demoraInicialMs: 0, variar: false }));
+    await asentar(result, (r) => r.posicion !== null);
+
+    expect(result.current.parada.id).toBe('a');
+    expect(result.current.parada.texto).toBe('El café mojado coge hongos.');
+    expect(result.current.parada.gesto).toBe('senala');
+
+    act(() => result.current.siguiente());
+    await asentar(result, (r) => r.parada?.id === 'b');
+
+    expect(result.current.parada.id).toBe('b');
+    expect(result.current.parada.texto).toBe('El agua de lluvia no trae cloro.');
+    expect(result.current.parada.gesto).toBe('invita');
+  });
+
+  it('sin gesto declarado, el default es "senala" (guiar es el caso base)', async () => {
+    const el = elementoFalso(rectFalso({ top: 100, left: 14, width: 200, height: 80 }));
+    const paradas = [{ id: 'a', ref: { current: el }, texto: 'x' }];
+    const { result } = renderHook(() => useAngelitaGuia(paradas, { demoraInicialMs: 0, variar: false }));
+    await asentar(result, (r) => r.posicion !== null);
+    expect(result.current.parada.gesto).toBe('senala');
+  });
+
+  it('con variar:true (default), el texto mostrado sigue siendo una variante fiel del pool determinista', async () => {
+    const el = elementoFalso(rectFalso({ top: 100, left: 14, width: 200, height: 80 }));
+    const base = 'El tallo se pone quebradizo justo donde nace la flor.';
+    const paradas = [{ id: 'a', ref: { current: el }, texto: base, tipo: 'sugerencia' }];
+    const { result } = renderHook(() => useAngelitaGuia(paradas, { demoraInicialMs: 0 }));
+    await asentar(result, (r) => r.posicion !== null);
+    const pool = variantesDeterministas(base, 'sugerencia');
+    expect(pool).toContain(result.current.parada.texto);
+  });
+});
+
+describe('useAngelitaGuia — encadena un recorrido, o responde a uno solo', () => {
+  function armarParadas(n) {
+    return Array.from({ length: n }, (_, i) => ({
+      id: `p${i}`,
+      ref: { current: elementoFalso(rectFalso({ top: 100 * (i + 1), left: 14, width: 200, height: 60 })) },
+      texto: `texto ${i}`,
+    }));
+  }
+
+  it('una sola parada: esPrimera y esUltima a la vez, sin romper siguiente()/anterior()', async () => {
+    const paradas = armarParadas(1);
+    const { result } = renderHook(() => useAngelitaGuia(paradas, { demoraInicialMs: 0, variar: false }));
+    await asentar(result, (r) => r.posicion !== null);
+
+    expect(result.current.total).toBe(1);
+    expect(result.current.esPrimera).toBe(true);
+    expect(result.current.esUltima).toBe(true);
+
+    act(() => result.current.siguiente());
+    expect(result.current.indice).toBe(0); // no hay a dónde ir: se queda
+
+    act(() => result.current.anterior());
+    expect(result.current.indice).toBe(0);
+  });
+
+  it('varias paradas: siguiente/anterior/ir recorren la secuencia completa', async () => {
+    const paradas = armarParadas(3);
+    const { result } = renderHook(() => useAngelitaGuia(paradas, { demoraInicialMs: 0, variar: false }));
+    await asentar(result, (r) => r.posicion !== null);
+
+    expect(result.current.indice).toBe(0);
+    act(() => result.current.siguiente());
+    expect(result.current.indice).toBe(1);
+    act(() => result.current.siguiente());
+    expect(result.current.indice).toBe(2);
+    expect(result.current.esUltima).toBe(true);
+    act(() => result.current.siguiente()); // ya no hay más: se queda en la última
+    expect(result.current.indice).toBe(2);
+
+    act(() => result.current.ir('p0'));
+    expect(result.current.indice).toBe(0);
+    act(() => result.current.anterior()); // ya está en la primera: se queda
+    expect(result.current.indice).toBe(0);
+  });
+});
+
+describe('useAngelitaGuia — cerrar y recordarCierreId', () => {
+  it('cerrar() apaga la guía; con recordarCierreId lo persiste para la próxima', async () => {
+    const el = elementoFalso(rectFalso({ top: 100, left: 14, width: 200, height: 80 }));
+    const paradas = [{ id: 'a', ref: { current: el }, texto: 'x' }];
+    const { result } = renderHook(() =>
+      useAngelitaGuia(paradas, { demoraInicialMs: 0, variar: false, recordarCierreId: 'pantalla-x' }),
+    );
+    await asentar(result, (r) => r.posicion !== null);
+    expect(result.current.visible).toBe(true);
+
+    act(() => result.current.cerrar());
+    expect(result.current.visible).toBe(false);
+    expect(localStorage.getItem('chagra:angelita:guia:pantalla-x')).toBe('1');
+
+    // Un montaje NUEVO (p. ej. el usuario recarga la pantalla) respeta el cierre.
+    const otra = renderHook(() => useAngelitaGuia(paradas, { demoraInicialMs: 0, recordarCierreId: 'pantalla-x' }));
+    expect(otra.result.current.cerrada).toBe(true);
+    expect(otra.result.current.visible).toBe(false);
+  });
+
+  it('reiniciar() borra el cierre persistido y vuelve a la primera parada', async () => {
+    const el = elementoFalso(rectFalso({ top: 100, left: 14, width: 200, height: 80 }));
+    const paradas = [{ id: 'a', ref: { current: el }, texto: 'x' }];
+    const { result } = renderHook(() =>
+      useAngelitaGuia(paradas, { demoraInicialMs: 0, variar: false, recordarCierreId: 'pantalla-y' }),
+    );
+    await asentar(result, (r) => r.posicion !== null);
+    act(() => result.current.cerrar());
+    expect(localStorage.getItem('chagra:angelita:guia:pantalla-y')).toBe('1');
+
+    act(() => result.current.reiniciar());
+    expect(result.current.cerrada).toBe(false);
+    expect(localStorage.getItem('chagra:angelita:guia:pantalla-y')).toBeNull();
+  });
+});

--- a/src/hooks/useAngelitaGuia.js
+++ b/src/hooks/useAngelitaGuia.js
@@ -1,0 +1,348 @@
+/**
+ * useAngelitaGuia — EL MECANISMO REUTILIZABLE de "Angelita señala y enseña"
+ * sobre CUALQUIER pantalla 2D de Chagra.
+ *
+ * Nace en `#/mockups/dia-en-finca` (la abejita señalando el café que hay que
+ * guardar) pero no sabe nada de esa pantalla: recibe una lista de PARADAS —
+ * `{ id, ref, texto, gesto?, tipo?, lado? }` — y hace tres cosas puras:
+ *
+ *   1. MIDE dónde está cada elemento real (getBoundingClientRect) y calcula
+ *      dónde debe pararse Angelita junto a él (esquina superior, del lado
+ *      con más aire), SIEMPRE dentro del viewport — nunca coordenadas fijas
+ *      de una pantalla en particular.
+ *   2. VISTE el texto de la parada activa con `angelitaVariedad` (misma capa
+ *      que usa el store del agente): la misma idea suena distinto cada vez.
+ *   3. NAVEGA el recorrido (siguiente/anterior/ir) o se queda quieta en una
+ *      sola parada si `paradas.length === 1` — ambos casos son el mismo
+ *      mecanismo.
+ *
+ * ADOPCIÓN EN OTRA PANTALLA (las 3 líneas que hacen falta):
+ *
+ *   const refTanque = useRef(null);
+ *   const paradas = [{ id: 'tanque', ref: refTanque, texto: '…', gesto: 'invita' }];
+ *   <AngelitaGuia paradas={paradas} />   // el componente en visual/agente
+ *
+ * `ref` acepta un ref de React (`{ current }`) o una función getter
+ * (`() => elemento`) — útil cuando el elemento vive en una lista dinámica
+ * (mapa de refs por id) y no hay un único `useRef` fijo por parada.
+ *
+ * GATES DE LA CASA:
+ *   - reduced-motion: `quieta=true` en el retorno — el CONSUMIDOR (el
+ *     componente) es quien decide qué no animar; este hook nunca toca DOM.
+ *   - Nunca lanza: elemento ausente/aún no montado → posición null, el
+ *     componente simplemente no pinta nada ese frame (no hay parpadeo feo).
+ *
+ * Puro en su geometría (`calcularPuestoGuia` es exportado y testeable sin
+ * React) y sin dependencia de ningún store global — cualquier pantalla la usa
+ * sin tocar `useAngelitaStore` (ese es el motor de notificaciones proactivas,
+ * un problema distinto).
+ *
+ * @module useAngelitaGuia
+ */
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { variarMensaje } from '../services/angelitaVariedad';
+
+/** Tamaño de avatar por defecto (px) — pensado para el corte 390px de campo. */
+export const TAMANO_GUIA_DEFECTO = 64;
+/** Aire mínimo respecto al borde de la pantalla (px). */
+export const MARGEN_VIEWPORT_DEFECTO = 14;
+/** Espera antes de aparecer — deja asentar el layout, sin teatro innecesario. */
+export const DEMORA_INICIAL_MS_DEFECTO = 550;
+
+/** Resuelve el elemento real de una parada: ref de React o función getter. */
+function elementoDe(parada) {
+  const ref = parada?.ref;
+  if (!ref) return null;
+  if (typeof ref === 'function') {
+    try {
+      return ref();
+    } catch {
+      return null;
+    }
+  }
+  if (typeof ref === 'object' && 'current' in ref) return ref.current;
+  return null;
+}
+
+function prefiereQuietud() {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+function clamp(v, min, max) {
+  if (max < min) return min;
+  return Math.min(Math.max(v, min), max);
+}
+
+/** Aire vertical entre Angelita y el borde superior del elemento (px). */
+const HOLGURA_VERTICAL = 6;
+
+/**
+ * Calcula dónde debe pararse Angelita junto a un elemento — pura, sin DOM
+ * fuera del `rect` que le pasan (testeable con un `DOMRect` de mentiras).
+ *
+ * Se perchea SIEMPRE por ENCIMA del elemento — CERO solape vertical con su
+ * contenido (regla dura: "nunca tapa lo que el usuario necesita leer" no es
+ * un "casi", es geometría) — del lado con MÁS aire libre en pantalla (para
+ * no quedar recortada contra el borde), y SIEMPRE clampeada dentro del
+ * viewport.
+ *
+ * @param {{top:number,left:number,right:number,bottom:number}|null} rect
+ * @param {Object} [opciones]
+ * @param {number} [opciones.tamano=64]
+ * @param {number} [opciones.margen=14]
+ * @param {number} [opciones.viewportW] — default window.innerWidth.
+ * @param {number} [opciones.viewportH] — default window.innerHeight.
+ * @param {'izquierda'|'derecha'} [opciones.ladoForzado] — la pantalla puede
+ *   pisar la elección automática (elemento angosto y centrado, por ejemplo).
+ * @returns {{x:number,y:number,lado:'izquierda'|'derecha',direccion:'izquierda'|'derecha',enVista:boolean}|null}
+ */
+export function calcularPuestoGuia(rect, opciones = {}) {
+  if (!rect) return null;
+  const {
+    tamano = TAMANO_GUIA_DEFECTO,
+    margen = MARGEN_VIEWPORT_DEFECTO,
+    viewportW = typeof window !== 'undefined' ? window.innerWidth : 390,
+    viewportH = typeof window !== 'undefined' ? window.innerHeight : 844,
+    ladoForzado,
+  } = opciones;
+
+  const espacioDerecha = viewportW - rect.right;
+  const espacioIzquierda = rect.left;
+  const lado = ladoForzado || (espacioDerecha >= espacioIzquierda ? 'derecha' : 'izquierda');
+
+  // Esquina del lado elegido, pero ARRIBA del todo: su propio borde inferior
+  // queda por encima de rect.top — nunca superpone el cuerpo del elemento,
+  // solo se asoma desde la esquina (como una vecina que se asoma por encima).
+  let x = lado === 'derecha' ? rect.right - tamano * 0.62 : rect.left - tamano * 0.38;
+  let y = rect.top - tamano - HOLGURA_VERTICAL;
+
+  x = clamp(x, margen, viewportW - tamano - margen);
+  y = clamp(y, margen, viewportH - tamano - margen);
+
+  // ¿El elemento en sí anda por el viewport? (si lo scrollearon lejos, la
+  // guía se apaga en vez de quedar pegada y huérfana contra un borde).
+  const enVista = rect.bottom > 0 && rect.top < viewportH && rect.right > 0 && rect.left < viewportW;
+
+  // Mira/señala HACIA el elemento: perchada a la derecha, apunta a la
+  // izquierda (y viceversa) — el destello de "senala" vive en su propio
+  // cuerpo, cerca de donde queda parada.
+  const direccion = lado === 'derecha' ? 'izquierda' : 'derecha';
+
+  return { x, y, lado, direccion, enVista };
+}
+
+/**
+ * @typedef {Object} ParadaGuia
+ * @property {string} id
+ * @property {Object|Function} ref — ref de React ({current}) o getter.
+ * @property {string} texto — lo que dice en la burbuja (agroecología real).
+ * @property {string} [gesto='senala'] — uno de ESTADOS_ANGELITA (o alias).
+ * @property {string} [tipo='sugerencia'] — uno de TIPOS_AVISO (color/ícono).
+ * @property {'izquierda'|'derecha'} [lado] — pisa el lado automático.
+ */
+
+/**
+ * @param {ParadaGuia[]} paradas
+ * @param {Object} [opciones]
+ * @param {boolean} [opciones.activo=true] — el host puede apagar toda la guía.
+ * @param {number} [opciones.tamano=64]
+ * @param {number} [opciones.margenViewport=14]
+ * @param {number} [opciones.demoraInicialMs=550]
+ * @param {string} [opciones.recordarCierreId] — si se da, cerrar() persiste en
+ *   este dispositivo (localStorage) y la guía no vuelve a aparecer sola.
+ * @param {boolean} [opciones.variar=true] — false = texto literal (tests / sin
+ *   red del pool LLM de angelitaVariedad).
+ */
+export function useAngelitaGuia(paradas = [], opciones = {}) {
+  const {
+    activo = true,
+    tamano = TAMANO_GUIA_DEFECTO,
+    margenViewport = MARGEN_VIEWPORT_DEFECTO,
+    demoraInicialMs = DEMORA_INICIAL_MS_DEFECTO,
+    recordarCierreId = null,
+    variar = true,
+  } = opciones;
+
+  const total = paradas.length;
+
+  const [cerrada, setCerrada] = useState(() => {
+    if (!recordarCierreId) return false;
+    try {
+      return globalThis.localStorage?.getItem(`chagra:angelita:guia:${recordarCierreId}`) === '1';
+    } catch {
+      return false;
+    }
+  });
+
+  const [indice, setIndice] = useState(0);
+  const [lista, setLista] = useState(() => prefiereQuietud()); // sin RM, espera su demora
+  const [posicion, setPosicion] = useState(null);
+  const [quieta, setQuieta] = useState(prefiereQuietud);
+
+  // Si el índice quedó fuera de rango (la pantalla acortó sus paradas), se
+  // recorta AL LEER — nunca se rompe por un host que cambió de idea en
+  // caliente, y nunca hace falta una escritura correctiva de estado.
+  const indiceEfectivo = total > 0 ? Math.min(indice, total - 1) : 0;
+
+  // Espejo legible desde listeners/timers sin tener que re-atar los effects
+  // cada vez que el host reconstruye el array `paradas` (cosa que hace en
+  // cada render, porque es un literal — normal en React). Los refs se
+  // escriben en un efecto (nunca durante el render: regla dura de la casa).
+  const paradasRef = useRef(paradas);
+  const indiceRef = useRef(indiceEfectivo);
+  useLayoutEffect(() => {
+    paradasRef.current = paradas;
+    indiceRef.current = indiceEfectivo;
+  });
+
+  // La preferencia puede cambiar en vivo (rarísimo, pero gratis de escuchar).
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return undefined;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const onChange = () => setQuieta(mq.matches);
+    if (mq.addEventListener) mq.addEventListener('change', onChange);
+    else if (mq.addListener) mq.addListener(onChange);
+    return () => {
+      if (mq.removeEventListener) mq.removeEventListener('change', onChange);
+      else if (mq.removeListener) mq.removeListener(onChange);
+    };
+  }, []);
+
+  // Demora inicial: deja asentar el layout de la pantalla antes de aparecer.
+  // Con reduced-motion no hay teatro que perder: `lista` YA nació en `true`
+  // (estado inicial perezoso, arriba) — este efecto solo tiene que ENCENDERLA
+  // más tarde en el caso normal, nunca apagarla (activo/cerrada/total ya se
+  // revisan aparte en todo lo que consume `lista`, así que dejarla prendida
+  // de una sesión previa es inofensivo). Nunca setState síncrono en el
+  // cuerpo del efecto — siempre desde el propio timer.
+  useEffect(() => {
+    if (!activo || cerrada || total === 0 || quieta) return undefined;
+    const t = window.setTimeout(() => setLista(true), demoraInicialMs);
+    return () => window.clearTimeout(t);
+  }, [activo, cerrada, total, quieta, demoraInicialMs]);
+
+  // Mide y coloca — rAF-throttled, disparado por scroll (capturado desde la
+  // raíz para atrapar también contenedores anidados con su propio scroll),
+  // resize y cambios de tamaño del propio elemento señalado.
+  const recomputar = useCallback(() => {
+    const parada = paradasRef.current[indiceRef.current];
+    const el = elementoDe(parada);
+    if (!el || typeof el.getBoundingClientRect !== 'function') {
+      setPosicion(null);
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    setPosicion(calcularPuestoGuia(rect, { tamano, margen: margenViewport, ladoForzado: parada?.lado }));
+  }, [tamano, margenViewport]);
+
+  useLayoutEffect(() => {
+    if (!activo || cerrada || !lista || total === 0) return undefined;
+    let raf = 0;
+    const pedir = () => {
+      if (raf) return;
+      raf = window.requestAnimationFrame(() => {
+        raf = 0;
+        recomputar();
+      });
+    };
+    pedir();
+    // Segunda pasada al asentar (fuentes/imágenes que cambian el layout tarde).
+    const t2 = window.setTimeout(pedir, 60);
+
+    window.addEventListener('scroll', pedir, { capture: true, passive: true });
+    window.addEventListener('resize', pedir, { passive: true });
+
+    let ro;
+    const el = elementoDe(paradasRef.current[indiceRef.current]);
+    if (el && typeof ResizeObserver === 'function') {
+      ro = new ResizeObserver(pedir);
+      ro.observe(el);
+    }
+
+    return () => {
+      window.removeEventListener('scroll', pedir, { capture: true });
+      window.removeEventListener('resize', pedir);
+      if (raf) window.cancelAnimationFrame(raf);
+      window.clearTimeout(t2);
+      if (ro) ro.disconnect();
+    };
+  }, [activo, cerrada, lista, indiceEfectivo, total, recomputar]);
+
+  // El texto: vestido por angelitaVariedad — memoizado por parada activa, NO
+  // en un efecto (evita el parpadeo de un tick donde el id ya cambió pero el
+  // texto todavía es el de la parada anterior) y NO en cada render (el pool
+  // de "vistos" de angelitaVariedad no se consume de más).
+  const paradaTextoActual = paradas[indiceEfectivo]?.texto;
+  const paradaTipoActual = paradas[indiceEfectivo]?.tipo;
+  const textoMostrado = useMemo(() => {
+    if (!paradaTextoActual) return null;
+    return variar ? variarMensaje(paradaTextoActual, paradaTipoActual || 'sugerencia') : paradaTextoActual;
+  }, [paradaTextoActual, paradaTipoActual, variar]);
+
+  const siguiente = useCallback(() => {
+    setIndice((i) => Math.min(i + 1, Math.max(paradasRef.current.length - 1, 0)));
+  }, []);
+  const anterior = useCallback(() => {
+    setIndice((i) => Math.max(i - 1, 0));
+  }, []);
+  const ir = useCallback((id) => {
+    const i = paradasRef.current.findIndex((p) => p.id === id);
+    if (i >= 0) setIndice(i);
+  }, []);
+  const cerrar = useCallback(() => {
+    setCerrada(true);
+    if (recordarCierreId) {
+      try {
+        globalThis.localStorage?.setItem(`chagra:angelita:guia:${recordarCierreId}`, '1');
+      } catch {
+        /* sin storage: se cierra igual esta sesión */
+      }
+    }
+  }, [recordarCierreId]);
+  const reiniciar = useCallback(() => {
+    setCerrada(false);
+    setIndice(0);
+    if (recordarCierreId) {
+      try {
+        globalThis.localStorage?.removeItem(`chagra:angelita:guia:${recordarCierreId}`);
+      } catch {
+        /* sin storage */
+      }
+    }
+  }, [recordarCierreId]);
+
+  const paradaCruda = paradas[indiceEfectivo] || null;
+  const visible = Boolean(activo && !cerrada && lista && paradaCruda && posicion);
+
+  return {
+    visible,
+    indice: indiceEfectivo,
+    total,
+    esPrimera: indiceEfectivo === 0,
+    esUltima: indiceEfectivo >= total - 1,
+    parada: paradaCruda
+      ? {
+          id: paradaCruda.id,
+          texto: textoMostrado ?? paradaCruda.texto,
+          gesto: paradaCruda.gesto || 'senala',
+          tipo: paradaCruda.tipo || 'sugerencia',
+        }
+      : null,
+    posicion,
+    direccion: posicion?.direccion || 'derecha',
+    enVista: posicion?.enVista ?? false,
+    quieta,
+    cerrada,
+    siguiente,
+    anterior,
+    ir,
+    cerrar,
+    reiniciar,
+  };
+}
+
+export default useAngelitaGuia;

--- a/src/mockups/DiaEnFinca.jsx
+++ b/src/mockups/DiaEnFinca.jsx
@@ -45,6 +45,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { CapaCielo, cieloEscena } from '../visual/scenes';
 import { Colibri, Mariposa, Lombriz } from '../visual/creatures';
 import { LaminaMataEtapa } from '../visual/laminas';
+import { AngelitaGuia } from '../visual/agente';
 import '../visual/effects/effects.css';
 import './dia-en-finca.css';
 
@@ -126,6 +127,45 @@ const OBSERVAR = {
   pregunta: '¿Salieron lombrices? Donde hay lombriz después del aguacero, la tierra está viva.',
 };
 
+// ── LA GUÍA DE ANGELITA: qué enseña en cada punto de esta pantalla ───────────
+// El mecanismo (useAngelitaGuia + <AngelitaGuia>, src/hooks y src/visual/agente)
+// es GENÉRICO — cualquier vista 2D lo adopta declarando { ref, texto, gesto }
+// por elemento. Aquí solo ponemos el contenido: qué hay y el PORQUÉ
+// agroecológico real detrás de cada tarea del día (nunca relleno). El gesto
+// reutiliza el repertorio ya existente de angelitaEstados.js — cero estados
+// nuevos.
+const GUIA_ANGELITA = {
+  cielo: {
+    texto: 'Los aguaceros de la tarde casi siempre llegan después del mediodía: por eso conviene adelantarse.',
+    gesto: 'senala',
+    tipo: 'informativa',
+  },
+  cafe: {
+    texto: 'El café mojado por el aguacero coge hongos y pierde calidad — guárdelo antes de que llueva.',
+    gesto: 'senala',
+    tipo: 'atencion',
+  },
+  tomate: {
+    texto: 'El tallo se pone quebradizo justo donde nace la flor: un aguacero fuerte se lo puede tronar.',
+    gesto: 'senala',
+    tipo: 'sugerencia',
+  },
+  tanque: {
+    texto: 'El agua de lluvia no trae cloro ni sales: es mejor para el semillero que la del acueducto.',
+    gesto: 'invita',
+    tipo: 'sugerencia',
+  },
+  // El único punto HONESTO a propósito: ella sabe que la lombriz es señal de
+  // suelo vivo, pero NO sabe si hoy salieron — eso solo lo sabe quien mire.
+  // Estado 'nose' (angelitaEstados.js): decir "no sé" es la conducta correcta
+  // del proyecto, no un relleno.
+  lombriz: {
+    texto: 'Lombriz después del aguacero es señal de suelo vivo — pero eso solo lo sabe quien mire, yo no.',
+    gesto: 'nose',
+    tipo: 'informativa',
+  },
+};
+
 /* La escena del header: cielo paramétrico REUSADO (CapaCielo) + las lomas y la
    era de café secando de esta finca. La era es narrativa: si la tarea prioritaria
    se marca hecha, el café desaparece de la era (quedó bajo techo). aria-hidden:
@@ -202,6 +242,26 @@ export default function DiaEnFinca({ onBack = undefined } = {}) {
   const [hechas, setHechas] = useState({});
   const [aviso, setAviso] = useState(null);
   const avisoTimer = useRef(null);
+
+  // ── Los elementos reales que Angelita señala (useAngelitaGuia) ────────────
+  // Las secundarias son una lista (SECUNDARIAS.map): un mapa de refs por id en
+  // vez de un useRef fijo por parada — el hook acepta esa forma vía un getter
+  // función (`ref: () => refsSecundarias.current[id]`).
+  const refTitular = useRef(null);
+  const refPrioridad = useRef(null);
+  const refObservar = useRef(null);
+  const refsSecundarias = useRef({});
+
+  const paradasGuia = useMemo(
+    () => [
+      { id: 'cielo', ref: refTitular, ...GUIA_ANGELITA.cielo },
+      { id: 'cafe', ref: refPrioridad, ...GUIA_ANGELITA.cafe },
+      { id: 'tomate', ref: () => refsSecundarias.current.tomate, ...GUIA_ANGELITA.tomate },
+      { id: 'tanque', ref: () => refsSecundarias.current.tanque, ...GUIA_ANGELITA.tanque },
+      { id: 'lombriz', ref: refObservar, ...GUIA_ANGELITA.lombriz },
+    ],
+    [],
+  );
 
   const f = DIA[franja];
 
@@ -283,7 +343,7 @@ export default function DiaEnFinca({ onBack = undefined } = {}) {
             <p className="df-fecha">
               El día en su finca · {fecha}
             </p>
-            <h1 className="df-titular">{f.titular}</h1>
+            <h1 className="df-titular" ref={refTitular}>{f.titular}</h1>
             <ul className="df-pulso" aria-label="Cómo está su finca ahora">
               <li><span aria-hidden="true">{f.clima.emoji}</span> {f.clima.frase}</li>
               <li><span aria-hidden="true">🌱</span> {ESTADO.matas} matas vivas</li>
@@ -304,7 +364,7 @@ export default function DiaEnFinca({ onBack = undefined } = {}) {
 
           {/* ── 1. LO PRIMERO HOY ── */}
           <p className="df-ceja">Lo primero hoy</p>
-          <article className={`df-carta df-carta-mayor ${hechas[PRIORIDAD.id] ? 'df-hecha' : ''}`}>
+          <article ref={refPrioridad} className={`df-carta df-carta-mayor ${hechas[PRIORIDAD.id] ? 'df-hecha' : ''}`}>
             <span className="df-nudo" aria-hidden="true" />
             <ul className="df-porques" aria-label="Por qué hoy">
               {PRIORIDAD.porques.map((p) => (
@@ -333,7 +393,11 @@ export default function DiaEnFinca({ onBack = undefined } = {}) {
           {/* ── 2. TAMBIÉN HOY, SI ALCANZA ── */}
           <p className="df-ceja">También hoy, si alcanza</p>
           {SECUNDARIAS.map((s) => (
-            <article key={s.id} className={`df-carta df-carta-menor ${hechas[s.id] ? 'df-hecha' : ''}`}>
+            <article
+              key={s.id}
+              ref={(el) => { refsSecundarias.current[s.id] = el; }}
+              className={`df-carta df-carta-menor ${hechas[s.id] ? 'df-hecha' : ''}`}
+            >
               <span className="df-nudo" aria-hidden="true" />
               <div className="df-menor-cuerpo">
                 <h3 className="df-carta-tit df-carta-tit-menor">{s.titulo}</h3>
@@ -362,7 +426,7 @@ export default function DiaEnFinca({ onBack = undefined } = {}) {
 
           {/* ── 3. PARA OBSERVAR HOY (educativo: sin marcar, sin premio) ── */}
           <p className="df-ceja">Para observar hoy</p>
-          <aside className="df-observar">
+          <aside ref={refObservar} className="df-observar">
             <span className="df-nudo df-nudo-hoja" aria-hidden="true" />
             <div className="df-observar-bicho">
               <Lombriz size={52} title="Lombriz de tierra" />
@@ -387,6 +451,13 @@ export default function DiaEnFinca({ onBack = undefined } = {}) {
       </main>
 
       {aviso && <div className="df-aviso" role="status">{aviso}</div>}
+
+      {/* Angelita guía: vuela hasta cada tarea/observación y explica su
+          porqué agroecológico — mecanismo reutilizable (src/hooks/
+          useAngelitaGuia.js), NO exclusivo de esta pantalla. Con
+          recordarCierreId: si el campesino la cierra, no vuelve a insistir
+          en este dispositivo. */}
+      <AngelitaGuia paradas={paradasGuia} recordarCierreId="mockup-dia-en-finca" />
     </div>
   );
 }

--- a/src/visual/agente/AngelitaGuia.jsx
+++ b/src/visual/agente/AngelitaGuia.jsx
@@ -1,0 +1,123 @@
+import { Angelita } from './Angelita.jsx';
+import BurbujaAngelita from './BurbujaAngelita.jsx';
+import { useAngelitaGuia } from '../../hooks/useAngelitaGuia.js';
+import './angelita-guia.css';
+
+/*
+ * <AngelitaGuia> — Angelita vuela hasta un elemento real de la pantalla, lo
+ * señala/invita/mira (el gesto que usted declaró — reutiliza
+ * angelitaEstados.js, CERO estados nuevos) y explica QUÉ hay ahí, con
+ * criterio agroecológico real. Reutilizable en CUALQUIER vista 2D.
+ *
+ * ADOPCIÓN EN OTRA PANTALLA (las 3 líneas que hacen falta):
+ *
+ *   const refTanque = useRef(null);
+ *   const paradas = [{ id: 'tanque', ref: refTanque, texto: 'El agua de lluvia no trae cloro…', gesto: 'invita' }];
+ *   <AngelitaGuia paradas={paradas} />
+ *
+ * (el elemento en cuestión solo necesita `ref={refTanque}` en su JSX de
+ * siempre — nada más cambia en la pantalla).
+ *
+ * QUÉ HACE, en dos piezas fijas (angelita-guia.css):
+ *   1. Un avatarcito flotante (`.ang-guia`) que el hook posiciona junto al
+ *      elemento — perchado en su esquina, sin tapar el texto de abajo.
+ *   2. Una franja angosta y fija al pie (`.ang-guia__panel`) con su burbuja
+ *      (BurbujaAngelita, la misma de siempre) y la navegación del recorrido
+ *      — SIEMPRE en el mismo sitio, así el usuario sabe dónde mirar y dónde
+ *      cerrarla. Un recorrido de una sola parada oculta la navegación y
+ *      cambia "Siguiente" por "Entendido".
+ *
+ * PRINCIPIO MISS MINUTES: presencia que informa sin invadir — nunca bloquea
+ * la interacción (el resto de la pantalla queda 100% operable), nunca exige
+ * atención (el usuario avanza a su ritmo, no hay avance automático), y se
+ * cierra con un toque. Con `recordarCierreId`, cerrarla la apaga para
+ * siempre en este dispositivo — no vuelve a insistir.
+ *
+ * Reduced-motion: sin vuelo entre paradas ni entrada animada del panel — el
+ * mensaje se lee exactamente igual, solo que quieto (el hook decide, aquí
+ * solo se refleja con `data-ang-quieta`).
+ *
+ * @param {Object} props
+ * @param {import('../../hooks/useAngelitaGuia').ParadaGuia[]} props.paradas
+ * @param {boolean} [props.activo=true]
+ * @param {number} [props.tamano=64]
+ * @param {string} [props.recordarCierreId] — persistir el cierre en este dispositivo.
+ * @param {number} [props.demoraInicialMs] — pisa la espera antes de aparecer
+ *   (default del hook: 550ms; útil para tests o para un host que dispara la
+ *   guía desde una acción explícita del usuario, sin necesidad de esperar).
+ * @param {string} [props.className] — clases extra para el avatarcito flotante.
+ */
+export function AngelitaGuia({
+  paradas = [],
+  activo = true,
+  tamano = 64,
+  recordarCierreId = undefined,
+  demoraInicialMs = undefined,
+  className = '',
+}) {
+  const guia = useAngelitaGuia(paradas, { activo, tamano, recordarCierreId, demoraInicialMs });
+
+  if (!guia.parada) return null;
+
+  const estiloFlotador = {
+    '--ang-guia-x': `${guia.posicion?.x ?? 0}px`,
+    '--ang-guia-y': `${guia.posicion?.y ?? 0}px`,
+  };
+  const avanzar = guia.esUltima ? guia.cerrar : guia.siguiente;
+
+  return (
+    <>
+      <div
+        className={`ang-guia ${className}`.trim()}
+        style={estiloFlotador}
+        data-ang-quieta={guia.quieta ? '1' : undefined}
+        data-ang-vista={guia.enVista ? '1' : '0'}
+        hidden={!guia.visible}
+      >
+        <button
+          type="button"
+          className="ang-guia__cuerpo"
+          onClick={avanzar}
+          aria-label={guia.esUltima ? 'Angelita: cerrar la guía' : 'Angelita: ver lo siguiente'}
+        >
+          <Angelita estado={guia.parada.gesto} direccion={guia.direccion} size={tamano} />
+        </button>
+      </div>
+
+      {guia.visible && (
+        <div className="ang-guia__panel" role="group" aria-label="Guía de Angelita">
+          <BurbujaAngelita
+            mensaje={guia.parada.texto}
+            tipo={guia.parada.tipo}
+            className="ang-guia__burbuja"
+          />
+          <div className="ang-guia__nav">
+            {guia.total > 1 && (
+              <span className="ang-guia__paso" aria-hidden="true">
+                {guia.indice + 1}/{guia.total}
+              </span>
+            )}
+            {!guia.esPrimera && (
+              <button type="button" className="ang-guia__btn" onClick={guia.anterior}>
+                ← Antes
+              </button>
+            )}
+            <button type="button" className="ang-guia__btn ang-guia__btn--principal" onClick={avanzar}>
+              {guia.esUltima ? 'Entendido' : 'Siguiente →'}
+            </button>
+            <button
+              type="button"
+              className="ang-guia__cerrar"
+              aria-label="Cerrar la guía de Angelita"
+              onClick={guia.cerrar}
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default AngelitaGuia;

--- a/src/visual/agente/__tests__/AngelitaGuia.test.jsx
+++ b/src/visual/agente/__tests__/AngelitaGuia.test.jsx
@@ -1,0 +1,142 @@
+/**
+ * AngelitaGuia.test.jsx — el CABLEADO del mecanismo reutilizable: que el
+ * hook (useAngelitaGuia, probado a fondo aparte) efectivamente llegue al
+ * DOM — el gesto declarado llega a <Angelita>, el texto declarado llega a
+ * la burbuja, y la navegación/cierre funcionan desde la UI real.
+ *
+ * Nota: el mensaje de la burbuja pasa por <Typewriter> (grafema a grafema),
+ * que además duplica el texto completo en dos nodos (`.tw__molde` para el
+ * tamaño estable, `.tw__sr` para lectores de pantalla) — por eso las
+ * aserciones de MENSAJE miran `.tw__molde` puntual en vez de `getByText`
+ * (que encontraría ambos y lanzaría "multiple elements").
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, screen, fireEvent, act } from '@testing-library/react';
+import { createRef } from 'react';
+import { AngelitaGuia } from '../AngelitaGuia.jsx';
+
+afterEach(cleanup);
+
+/** Deja correr varios cortes cortos de act() (ver nota en useAngelitaGuia.test.js). */
+async function asentar(comprobar, { intentos = 15, pasoMs = 20 } = {}) {
+  for (let i = 0; i < intentos; i += 1) {
+    if (comprobar()) return;
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, pasoMs));
+    });
+  }
+}
+
+const panelListo = () => document.querySelector('.ang-guia__panel') !== null;
+const textoBurbuja = () => document.querySelector('.tw__molde')?.textContent ?? '';
+
+describe('<AngelitaGuia> — sin paradas no pinta nada', () => {
+  it('paradas=[] → null', () => {
+    const { container } = render(<AngelitaGuia paradas={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('<AngelitaGuia> — el gesto y el texto declarados llegan al DOM', () => {
+  it('el gesto de la parada llega a <Angelita> (data-agt-estado) y el texto a la burbuja', async () => {
+    const ref = createRef();
+    render(
+      <>
+        <div ref={ref} style={{ width: 200, height: 80 }}>elemento real</div>
+        <AngelitaGuia
+          paradas={[{ id: 'cafe', ref, texto: 'El café mojado coge hongos.', gesto: 'senala', tipo: 'atencion' }]}
+          demoraInicialMs={0}
+        />
+      </>,
+    );
+
+    await asentar(panelListo);
+
+    const svg = document.querySelector('svg[data-agente="angelita"]');
+    expect(svg).toBeTruthy();
+    expect(svg.getAttribute('data-agt-estado')).toBe('senala');
+    // angelitaVariedad puede anteponerle una apertura ('Mire:', 'Pendiente:'…);
+    // lo que importa es que el NÚCLEO factual llegue intacto.
+    expect(textoBurbuja()).toMatch(/café mojado coge hongos/i);
+  });
+
+  it('sin gesto declarado, Angelita actúa "senala" por defecto', async () => {
+    const ref = createRef();
+    render(
+      <>
+        <div ref={ref}>x</div>
+        <AngelitaGuia paradas={[{ id: 'a', ref, texto: 'x' }]} demoraInicialMs={0} />
+      </>,
+    );
+    await asentar(panelListo);
+    expect(document.querySelector('svg[data-agente="angelita"]').getAttribute('data-agt-estado')).toBe('senala');
+  });
+});
+
+describe('<AngelitaGuia> — navegación y cierre desde la UI', () => {
+  it('una sola parada: el botón principal dice "Entendido" y la cierra', async () => {
+    const ref = createRef();
+    render(
+      <>
+        <div ref={ref}>x</div>
+        <AngelitaGuia paradas={[{ id: 'a', ref, texto: 'solo una parada' }]} demoraInicialMs={0} />
+      </>,
+    );
+    await asentar(panelListo);
+    expect(textoBurbuja()).toMatch(/solo una parada/i);
+    // Una sola parada: sin navegación previa, botón principal = "Entendido".
+    expect(screen.queryByText('← Antes')).toBeNull();
+
+    act(() => {
+      fireEvent.click(screen.getByText('Entendido'));
+    });
+    expect(document.querySelector('.ang-guia__panel')).toBeNull();
+  });
+
+  it('varias paradas: "Siguiente" avanza a la próxima (su texto cambia)', async () => {
+    const refA = createRef();
+    const refB = createRef();
+    render(
+      <>
+        <div ref={refA}>a</div>
+        <div ref={refB}>b</div>
+        <AngelitaGuia
+          paradas={[
+            { id: 'a', ref: refA, texto: 'primera parada' },
+            { id: 'b', ref: refB, texto: 'segunda parada' },
+          ]}
+          demoraInicialMs={0}
+        />
+      </>,
+    );
+    await asentar(panelListo);
+    expect(textoBurbuja()).toMatch(/primera parada/i);
+    expect(screen.getByText('1/2')).toBeTruthy();
+
+    act(() => {
+      fireEvent.click(screen.getByText('Siguiente →'));
+    });
+    await asentar(() => /segunda parada/i.test(textoBurbuja()));
+
+    expect(textoBurbuja()).toMatch(/segunda parada/i);
+    expect(screen.getByText('2/2')).toBeTruthy();
+    // Última parada: el botón principal ya dice "Entendido", no "Siguiente".
+    expect(screen.queryByText('Siguiente →')).toBeNull();
+  });
+
+  it('el botón de cerrar (×) apaga la guía inmediatamente', async () => {
+    const ref = createRef();
+    render(
+      <>
+        <div ref={ref}>x</div>
+        <AngelitaGuia paradas={[{ id: 'a', ref, texto: 'texto a cerrar' }]} demoraInicialMs={0} />
+      </>,
+    );
+    await asentar(panelListo);
+
+    act(() => {
+      fireEvent.click(screen.getByLabelText('Cerrar la guía de Angelita'));
+    });
+    expect(document.querySelector('.ang-guia__panel')).toBeNull();
+  });
+});

--- a/src/visual/agente/angelita-guia.css
+++ b/src/visual/agente/angelita-guia.css
@@ -1,0 +1,130 @@
+/* ── <AngelitaGuia> — EL FLOTADOR reutilizable de "Angelita señala y enseña".
+      Autocontenido (cero dependencia del host, mismo criterio que
+      angelitaBurbuja.css): cualquier pantalla 2D lo importa y ya sabe verse.
+
+      DOS piezas, cada una en su sitio fijo propio:
+        .ang-guia         → el avatarcito flotante, posicionado por el hook
+                             junto al elemento que señala (nunca tapa texto:
+                             perchado en su esquina, la mayoría del cuerpo
+                             sobre el aire).
+        .ang-guia__panel  → franja angosta y fija al pie con su burbuja +
+                             navegación — SIEMPRE en el mismo sitio sin
+                             importar dónde ande el avatar, así nunca hay
+                             sorpresas de layout ni se tapa contenido de
+                             arriba (principio Miss Minutes: informa sin
+                             invadir, nunca exige atención, el usuario puede
+                             cerrarla en cualquier momento).
+
+      Reduced-motion: el avatar aparece YA en su sitio (sin vuelo entre
+      paradas) y el panel entra sin animar — el mensaje se lee igual. */
+
+.ang-guia {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: var(--ang-guia-z, 60);
+  transform: translate3d(var(--ang-guia-x, 0px), var(--ang-guia-y, 0px), 0);
+  transition:
+    transform 0.55s cubic-bezier(0.34, 1.06, 0.64, 1),
+    opacity 0.3s ease;
+  opacity: 1;
+  will-change: transform;
+  pointer-events: none; /* solo el cuerpo (botón) adentro captura toque */
+}
+.ang-guia[hidden] { display: none; }
+.ang-guia[data-ang-vista='0'] { opacity: 0; }
+.ang-guia[data-ang-quieta='1'] {
+  transition: opacity 0.2s ease; /* sin "vuelo": se posiciona de una */
+}
+
+.ang-guia__cuerpo {
+  display: block;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  pointer-events: auto;
+  filter: drop-shadow(0 3px 9px rgba(20, 14, 4, 0.4));
+  -webkit-tap-highlight-color: transparent;
+  border-radius: 50%;
+}
+.ang-guia__cuerpo:focus-visible {
+  outline: 3px solid #ffb700;
+  outline-offset: 3px;
+  border-radius: 50%;
+}
+
+/* ── El panel angosto y fijo al pie: burbuja + navegación ── */
+.ang-guia__panel {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: var(--ang-guia-z, 60);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px max(10px, env(safe-area-inset-bottom)) 12px;
+  pointer-events: none; /* la burbuja y los botones adentro sí capturan */
+}
+.ang-guia__panel > * {
+  pointer-events: auto;
+}
+.ang-guia__burbuja {
+  max-width: min(94vw, 420px);
+  width: 100%;
+}
+
+.ang-guia__nav {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: min(94vw, 420px);
+  width: 100%;
+}
+.ang-guia__paso {
+  flex: 0 0 auto;
+  font: 700 0.72rem/1 var(--df-sans, system-ui, sans-serif);
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(10, 10, 10, 0.55);
+  border-radius: 999px;
+  padding: 6px 9px;
+}
+.ang-guia__btn {
+  flex: 0 0 auto;
+  min-height: 40px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1.5px solid rgba(255, 255, 255, 0.3);
+  background: rgba(10, 10, 10, 0.62);
+  color: #fdf9ea;
+  font: 700 0.82rem/1.1 var(--df-sans, system-ui, sans-serif);
+  cursor: pointer;
+  backdrop-filter: blur(6px);
+}
+.ang-guia__btn--principal {
+  flex: 1 1 auto;
+  border-color: rgba(255, 183, 0, 0.55);
+  background: rgba(120, 74, 0, 0.55);
+}
+.ang-guia__btn:focus-visible,
+.ang-guia__cerrar:focus-visible {
+  outline: 3px solid #ffb700;
+  outline-offset: 2px;
+}
+.ang-guia__cerrar {
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(255, 255, 255, 0.3);
+  background: rgba(10, 10, 10, 0.62);
+  color: #fdf9ea;
+  font: 700 1.05rem/1 var(--df-sans, system-ui, sans-serif);
+  cursor: pointer;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ang-guia { transition: opacity 0.2s ease; }
+}

--- a/src/visual/agente/index.js
+++ b/src/visual/agente/index.js
@@ -10,6 +10,8 @@
  */
 export { Angelita, default } from './Angelita.jsx';
 export { AngelitaEntrada, esDiaSoleado } from './AngelitaEntrada.jsx';
+export { AngelitaGuia } from './AngelitaGuia.jsx';
+export { useAngelitaGuia, calcularPuestoGuia } from '../../hooks/useAngelitaGuia.js';
 export {
   ESTADOS_ANGELITA,
   NIVELES_CONFIANZA,


### PR DESCRIPTION
## Qué es esto

El operador preguntó: *¿es posible que la abejita esté en esta ventana y en todas las 2D, con movimiento, enseñando algo puntual?* Este PR construye el mecanismo (no un parche de una sola pantalla) y lo aplica a `#/mockups/dia-en-finca` para evaluar.

## El mecanismo (reutilizable desde el día 1)

- **`src/hooks/useAngelitaGuia.js`** — el hook. Recibe una lista de *paradas* `{ id, ref, texto, gesto?, tipo?, lado? }` y:
  - Mide el elemento real (`getBoundingClientRect`) y calcula dónde pararse: la esquina con más aire libre, **cero solape vertical con el contenido** (nunca tapa lo que hay que leer), siempre clampeado dentro del viewport. Recalcula en scroll (con captura, para contenedores anidados), resize y `ResizeObserver` del propio elemento.
  - Viste el texto con `angelitaVariedad` (la misma capa que usa el store del agente) — la misma idea suena distinto cada vez.
  - Navega el recorrido (`siguiente`/`anterior`/`ir`) o se queda quieta en una sola parada — es el mismo mecanismo en ambos casos.
  - Respeta `prefers-reduced-motion` (expone `quieta`) y `cerrar()`/`recordarCierreId` para que, si el campesino la cierra, no vuelva a insistir en ese dispositivo.
- **`src/visual/agente/AngelitaGuia.jsx`** — el componente drop-in. Reutiliza `Angelita.jsx`, `BurbujaAngelita` y el repertorio de `angelitaEstados.js` **tal cual** (cero estados nuevos, el dibujo no se toca). Dos piezas fijas: el avatarcito flotante (posicionado por el hook) + una franja angosta al pie con la burbuja y la navegación — así nunca compite por espacio con el contenido real de la pantalla.

### Cómo la adopta OTRA pantalla 2D (las 3 líneas)

```jsx
const refTanque = useRef(null);
const paradas = [{ id: 'tanque', ref: refTanque, texto: 'El agua de lluvia no trae cloro…', gesto: 'invita' }];
<AngelitaGuia paradas={paradas} />
```

(el elemento en cuestión solo necesita `ref={refTanque}` en su JSX de siempre — nada más cambia).

## Aplicado a `dia-en-finca`

5 paradas con criterio agroecológico real, no relleno:
1. El titular del cielo — por qué el aguacero manda la hora del día.
2. El café secando — por qué mojarse le mete hongos.
3. El tomate en flor — por qué el tallo se pone quebradizo justo ahí.
4. El tanque destapado — por qué el agua de lluvia sirve mejor para el semillero.
5. La invitación a observar lombrices — **el punto honesto**: gesto `nose` (ella sabe que lombriz = suelo vivo, pero NO sabe si hoy salieron; eso solo lo sabe quien mire).

## Verificación

- `npm run build` verde.
- 25 tests nuevos: geometría pura (`calcularPuestoGuia`), posicionamiento respecto al elemento real (incluye scroll), reduced-motion, texto/gesto exactos por parada, recorrido de N paradas y de una sola, cierre + persistencia, y el cableado completo del componente (gesto llega a `<Angelita>`, texto a la burbuja, navegación/cierre desde la UI).
- `scripts/audit-integraciones.mjs` **no existe en `dev`** (vive solo en `main`, PR #2475 — divergencia ya conocida, ver `Chagra-strategy/ops/TRIAJE-HUERFANOS-3D-2026-07-21.md`). Lo corrí manualmente copiando el script de `main` contra este branch: limpio, sin huérfanos nuevos (solo las 3 excepciones ya allowlisted de `grafo-relations.js`, sin relación con este cambio).
- Captura real de `#/mockups/dia-en-finca` con Angelita señalando + la burbuja con su explicación — adjunta en la conversación con el operador (390×844, viewport de campo).

## Nota de diseño

Primera versión: recorrido **manual** (el usuario toca "Siguiente", sin avance automático) — por el principio Miss Minutes ("nunca exige atención"; si el usuario está leyendo, ella espera). Overlap conocido y menor: en dos de las cinco paradas el avatar roza una o dos letras de la etiqueta decorativa de sección (`LO PRIMERO HOY` / `TAMBIÉN HOY...`) — nunca el título, el porqué ni los botones. Documentado como refinamiento futuro, no bloqueante para esta evaluación.

🤖 Generado con [Claude Code](https://claude.com/claude-code)