### PR TITLE
fix(agent): corregir triaje de sintomas por cultivo

### DIFF
--- a/src/services/__tests__/outputGuards.agente5bugsV2.test.js
+++ b/src/services/__tests__/outputGuards.agente5bugsV2.test.js
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyOutputGuards, guardThermalViability } from '../outputGuards';
+
+const BAD_RESPONSE =
+  'Sin foto es dificil saberlo. Los huecos pueden ser pulgones o mosca blanca que extraen jugo. ' +
+  'La melaza puede deberse a babosas u orugas. Dato verificado: la broca del cafe se controla con trampas. ' +
+  'Alerta para tomate cherry Sungold y tomate uvalina: se estresan por encima de 22 C aunque el pronostico llegue a 22 C.';
+
+const CASES = [
+  {
+    name: 'tomate de arbol chamuscado y fresa con huecos en invernadero',
+    userMessage:
+      'En el invernadero templado, el tomate de arbol tiene hojas chamuscadas y la fresa amanecio con huecos. Que hago?',
+    expectsScorch: true,
+    expectsChewing: true,
+    expectsSucking: false,
+  },
+  {
+    name: 'pimenton mordido y lechuga con melaza',
+    userMessage:
+      'Tengo pimenton con hojas mordidas y lechuga amarilla con melaza bajo cubierta. Que reviso primero?',
+    expectsScorch: false,
+    expectsChewing: true,
+    expectsSucking: true,
+  },
+  {
+    name: 'pepino perforado y frijol con fumagina',
+    userMessage:
+      'El pepino del invernadero tiene hojas perforadas y el frijol esta amarillo, pegajoso y con fumagina.',
+    expectsScorch: false,
+    expectsChewing: true,
+    expectsSucking: true,
+  },
+  {
+    name: 'fresa mordida y tomate de arbol con necrosis marginal',
+    userMessage:
+      'La fresa tiene bordes mordidos y el tomate de palo presenta necrosis marginal dentro del invernadero.',
+    expectsScorch: true,
+    expectsChewing: true,
+    expectsSucking: false,
+  },
+  {
+    name: 'espinaca con melaza y albahaca con agujeros',
+    userMessage:
+      'La espinaca esta amarilla y con melaza, mientras la albahaca tiene agujeros en las hojas del invernadero.',
+    expectsScorch: false,
+    expectsChewing: true,
+    expectsSucking: true,
+  },
+];
+
+function paragraphStarting(text, marker) {
+  return text.split('\n\n').find((paragraph) => paragraph.startsWith(marker)) || '';
+}
+
+function verifyCompletePass(testCase) {
+  const result = applyOutputGuards(BAD_RESPONSE, {
+    userMessage: testCase.userMessage,
+    hadVision: false,
+    resolvedEntities: [
+      { kind: 'species', nombre_comun: 'Tomate cherry Sungold' },
+      { kind: 'species', nombre_comun: 'Tomate uvalina' },
+      { kind: 'pest', nombre_comun: 'Broca del cafe' },
+    ],
+  });
+
+  expect(result.reasons).toEqual(['triaje_sintoma_observable']);
+  expect(result.text).not.toMatch(/broca|sungold|uvalina/i);
+  expect(result.text).not.toMatch(/sin foto (es|resulta) dificil/i);
+  expect(result.text.lastIndexOf('envíe una foto')).toBeGreaterThan(result.text.indexOf('hipótesis más probable'));
+
+  const chewing = paragraphStarting(result.text, 'Para los huecos o mordidas');
+  if (testCase.expectsChewing) {
+    expect(chewing).toMatch(/masticadores/i);
+    expect(chewing).toMatch(/revise|retire/i);
+    expect(chewing).not.toMatch(/pulgon|mosca blanca|chupador/i);
+  }
+
+  const sucking = paragraphStarting(result.text, 'Para el amarillamiento');
+  if (testCase.expectsSucking) {
+    expect(sucking).toMatch(/chupadores/i);
+    expect(sucking).toMatch(/revise el envés/i);
+    expect(sucking).not.toMatch(/masticador|babosa|caracol|oruga|tierrero/i);
+  } else {
+    expect(sucking).toBe('');
+  }
+
+  if (testCase.expectsScorch) {
+    expect(result.text).toMatch(/golpe de calor o quemadura de sol/i);
+    expect(result.text).toMatch(/ventilación|sombra temporal/i);
+    expect(result.text).toMatch(/sales o un desbalance de potasio/i);
+  }
+
+  const thermal = guardThermalViability(
+    'Le recomiendo sembrar fresa y lechuga.',
+    [
+      { kind: 'species', nombre_comun: 'fresa', temp_max: 22 },
+      { kind: 'species', nombre_comun: 'lechuga', temp_max: 22 },
+    ],
+    null,
+    { forecastTempMax: 22, marginC: 0 },
+  );
+  expect(thermal.modified).toBe(true);
+  expect(thermal.text).toMatch(/se estresa desde ~22°C y el pronóstico sube a 22°C/i);
+  expect(thermal.text).not.toMatch(/se estresa por encima de ~22°C y el pronóstico sube a 22°C/i);
+}
+
+describe('auditoria de produccion agente 5 bugs v2', () => {
+  for (const testCase of CASES) {
+    it(`pasada completa: ${testCase.name}`, () => {
+      verifyCompletePass(testCase);
+    });
+  }
+});

--- a/src/services/agentPromptBase.js
+++ b/src/services/agentPromptBase.js
@@ -640,7 +640,14 @@ CASO B: si NO reconoces el sustantivo como español común ni como planta/plaga/
 ANTI-INVENCIÓN-DE-SÍNTOMAS: NUNCA describas síntomas/problemas/observaciones que el usuario NO escribió ni le atribuyas síntomas genéricos del corpus. Indaga con pregunta abierta, NO afirmación.`);
 
   if (SYMPTOM_QUERY_RE.test(mention)) {
-    sections.push(`REGLA CRÍTICA DIAGNÓSTICO-SIN-EVIDENCIA: si el usuario reporta un síntoma VAGO ("manchas amarillas", "se está secando", "está triste") y se cumplen LAS DOS: (a) NO nombró la especie o no está clara, Y (b) NO adjuntó foto en este turno → PROHIBIDO nombrar un patógeno específico o binomio ("es Phytophthora…", "es el hongo Golovinomyces…") y PROHIBIDO inventar síntomas no escritos. Un síntoma vago tiene MUCHAS causas: responde con (1) un diferencial BREVE sin latín (2-3 causas comunes: falta de nutrientes, exceso/falta de agua, hongo, plaga, sol fuerte) y (2) preguntas para acotar: ¿qué planta es? ¿me envías una foto de la hoja? ¿la mancha está en el haz o el envés? ¿se siente seca o húmeda? ¿hace cuánto empezó? NUNCA cierres con un diagnóstico único y seguro sin esa evidencia. ES PREFERIBLE PEDIR LA FOTO QUE INVENTAR EL HONGO.`);
+    sections.push(`REGLA CRÍTICA DE TRIAJE DE SÍNTOMAS:
+- Huecos, perforaciones o mordidas indican daño de MASTICADORES (babosas, caracoles, tierreros u orugas). NUNCA propongas pulgones ni mosca blanca para explicar huecos: los chupadores no retiran tejido.
+- Amarillamiento acompañado de melaza o fumagina indica daño de CHUPADORES (pulgones o mosca blanca). NUNCA propongas masticadores para explicar ese conjunto.
+- Si la especie y el contexto están claros, comprométete primero con la hipótesis más probable y una acción concreta. Después pide la foto para confirmar; "sin foto es difícil" no puede ser la respuesta principal.
+- En tomate de árbol con hojas chamuscadas bajo invernadero templado, prioriza golpe de calor o quemadura de sol por mala ventilación; como segunda posibilidad, necrosis marginal por sales o desbalance de potasio. En fresa de invernadero con huecos, prioriza babosas.
+- Responde SOLO sobre cultivos mencionados en el turno o registrados como sembrados. No agregues plagas, datos verificados, variedades ni alertas de otros cultivos.
+
+REGLA CRÍTICA DIAGNÓSTICO-SIN-EVIDENCIA: si el usuario reporta un síntoma VAGO ("manchas amarillas", "se está secando", "está triste") y se cumplen LAS DOS: (a) NO nombró la especie o no está clara, Y (b) NO adjuntó foto en este turno, está PROHIBIDO nombrar un patógeno específico o binomio ("es Phytophthora", "es el hongo Golovinomyces") e inventar síntomas no escritos. Un síntoma vago tiene muchas causas: da un diferencial breve sin latín y pregunta por especie, distribución y evolución. Si hay una hipótesis probable por el contexto, declárala con cautela y da una acción de bajo riesgo antes de pedir la foto.`);
   }
 
   // Reglas crop-agnostic (aplican a cualquier cultivo)

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -2422,7 +2422,7 @@ export function guardThermalViability(
     }
     if (Number.isFinite(tMax) && haveMax && fMax >= tMax - marginC) {
       partes.push(
-        `riesgo de golpe de calor: ${nombre} se estresa por encima de ~${tMax}°C y el pronóstico sube a ` +
+        `riesgo de golpe de calor: ${nombre} se estresa desde ~${tMax}°C y el pronóstico sube a ` +
           `${Math.round(fMax)}°C`,
       );
     }
@@ -2430,9 +2430,9 @@ export function guardThermalViability(
 
     disparadas.push(nombre);
     advertencias.push(
-      `Ojo con ${nombre}: ${partes.join('; y ')}. No te digo que no lo siembres —hay quien lo logra con ` +
-        `cuidados— pero requiere protección (cobertor/manta térmica en las noches frías, o sombra y mulch ` +
-        `para el calor). Tenlo en cuenta antes de arriesgar la semilla.`,
+      `Ojo con ${nombre}: ${partes.join('; y ')}. No le digo que no lo siembre porque hay quien lo logra con ` +
+        `cuidados, pero requiere protección (cobertor o manta térmica en las noches frías, o sombra y mulch ` +
+        `para el calor). Téngalo en cuenta antes de arriesgar la semilla.`,
     );
   }
 
@@ -4963,7 +4963,7 @@ export function guardOffDomain(responseText, { userMessage = null } = {}) {
  */
 const SYMPTOM_DIAG_INTENT_PATTERNS = [
   /\bmanch(a|as)\b/,
-  /\bhojas?\s+(amarill|seca|negra|cafe|marchit|enroll|con\s+hueco)/,
+  /\bhojas?\s+(amarill|seca|negra|cafe|marchit|enroll|chamusc|mordid|perforad|con\s+hueco)/,
   // "se está secando", "se me está secando", "se me secan", "se le marchitan":
   // tolera el pronombre/clítico intermedio (me/le/te/nos) y la conjugación 3ª pl.
   /\bse\s+(me\s+|le\s+|te\s+|nos\s+)?(esta(n)?\s+)?(secand|marchitand|muriend|pudriend|amarilland|enferman|enrollan|cae|caen|secan|marchitan|mueren|pudren)/,
@@ -4977,6 +4977,7 @@ const SYMPTOM_DIAG_INTENT_PATTERNS = [
   /\b(plaga|enfermedad|hongo|bicho|gusano)s?\s+que\s+(no\s+conozco|no\s+s[eé]\s+qu[eé]|no\s+identifico)/,
   /\bpudric(ion|iones)\b/,
   /\bpuntos?\s+(negro|cafe|amarillo)/,
+  /\b(hueco|agujero|mordida|perforacion|melaza|fumagina)s?\b/,
   // síntomas vagos adicionales reportados en campo
   /\bse\s+(esta\s+)?(poniend|volviend)\s+(amarill|negr|cafe|seca)/,
   /\b(esta|se\s+ve)\s+(triste|mal|enferm|marchit|amarill|deca[ií]d)/,
@@ -4987,6 +4988,82 @@ function _isSymptomDiagnosisQuery(userMessage) {
   if (typeof userMessage !== 'string' || !userMessage.trim()) return false;
   const norm = _stripDiacritics(userMessage);
   return SYMPTOM_DIAG_INTENT_PATTERNS.some((re) => re.test(norm));
+}
+
+// Diagnostico observable: separa el aparato bucal antes de pedir evidencia.
+// Esta guarda se limita a sintomas con una primera hipotesis accionable y no
+// intenta identificar patogenos ni organismos a nivel de especie.
+const CHEWING_DAMAGE_RE = /\b(hueco|huequito|agujero|perforacion|perforad[ao]|mordida|mordido|comida|comido|borde\s+mordisqueado)s?\b/;
+const SUCKING_DAMAGE_RE = /\b(melaza|fumagina|pegajos[ao]s?|amarillamiento|amarillas?|moteado\s+amarillo)\b/;
+const SCORCHED_LEAF_RE = /\b(chamuscad[ao]s?|quemad[ao]s?|borde[s]?\s+(seco|quemado|necrotico)s?|necrosis\s+marginal)\b/;
+const GREENHOUSE_RE = /\b(invernadero|bajo\s+cubierta|cubierta\s+plastica)\b/;
+const TREE_TOMATO_RE = /\b(tomate\s+de\s+(arbol|palo)|tamarillo)\b/;
+
+const FIELD_PHOTO_REQUEST =
+  'Después de hacer esa revisión, envíe una foto de cerca y otra de la planta completa. Con esas imágenes puedo afinar la causa sin retrasar la primera acción.';
+
+/**
+ * Da un triaje comprometido para sintomas cuyo mecanismo ya orienta el manejo.
+ * Reemplaza el cuerpo completo para que no sobrevivan plagas de otro cultivo,
+ * variedades no consultadas ni una inversion entre chupadores y masticadores.
+ *
+ * @param {string} responseText
+ * @param {{userMessage?: string|null, hadVision?: boolean}} [ctx]
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardObservableSymptomTriage(
+  responseText,
+  { userMessage = null, hadVision = false } = {},
+) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  if (hadVision || typeof userMessage !== 'string' || !userMessage.trim()) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const userNorm = _stripDiacritics(userMessage);
+  const hasChewingDamage = CHEWING_DAMAGE_RE.test(userNorm);
+  const hasSuckingDamage = SUCKING_DAMAGE_RE.test(userNorm);
+  const hasScorchedLeaves = SCORCHED_LEAF_RE.test(userNorm);
+  if (!hasChewingDamage && !hasSuckingDamage && !hasScorchedLeaves) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const parts = [];
+  if (hasScorchedLeaves) {
+    const subject = TREE_TOMATO_RE.test(userNorm) ? 'En el tomate de árbol' : 'En las hojas chamuscadas';
+    const ventilation = GREENHOUSE_RE.test(userNorm)
+      ? 'Abra la ventilación lateral y superior desde ahora y ponga sombra temporal en las horas de mayor radiación.'
+      : 'Ponga sombra temporal en las horas de mayor radiación y revise que el suelo conserve humedad sin encharcarse.';
+    parts.push(
+      `${subject}, la hipótesis más probable es golpe de calor o quemadura de sol, favorecida por poca ventilación. ` +
+        `La segunda posibilidad es necrosis marginal por acumulación de sales o un desbalance de potasio. ${ventilation} ` +
+        'Además, revise la conductividad del agua o del drenaje antes de aplicar más fertilizante.',
+    );
+  }
+  if (hasChewingDamage) {
+    const greenhouse = GREENHOUSE_RE.test(userNorm);
+    parts.push(
+      'Para los huecos o mordidas, la hipótesis más probable es daño de masticadores. ' +
+        (greenhouse
+          ? 'En invernadero, primero sospeche babosas o caracoles. Revise al anochecer el envés, el borde de las camas y debajo de materas o residuos; retire los que encuentre y reduzca refugios húmedos.'
+          : 'Primero revise babosas, caracoles, orugas o tierreros al anochecer y retire los que encuentre.'),
+    );
+  }
+  if (hasSuckingDamage) {
+    parts.push(
+      'Para el amarillamiento, la melaza o la fumagina, la hipótesis más probable es daño de chupadores, como pulgones o mosca blanca. ' +
+        'Revise el envés de las hojas y coloque una trampa amarilla para confirmar presencia antes de tratar.',
+    );
+  }
+
+  bumpGuardTelemetry('observable_symptom_triage');
+  return {
+    text: `${parts.join('\n\n')}\n\n${FIELD_PHOTO_REQUEST}`,
+    modified: true,
+    reason: 'triaje_sintoma_observable',
+  };
 }
 
 /**
@@ -10473,6 +10550,30 @@ export function applyOutputGuards(
     text = toolingLeak.text;
     modified = true;
     if (toolingLeak.reason) reasons.push(toolingLeak.reason);
+  }
+
+  // Una pregunta cortada tiene precedencia sobre cualquier lectura del
+  // síntoma: no se puede inferir qué mezcla o acción iba a completar el usuario.
+  const earlyTruncated = guardTruncatedUserPrompt(text, { userMessage });
+  if (earlyTruncated && earlyTruncated.modified) {
+    return {
+      text: earlyTruncated.text,
+      modified: true,
+      reasons: earlyTruncated.reason ? [earlyTruncated.reason] : [],
+    };
+  }
+
+  // TRIAJE DE SINTOMAS OBSERVABLES: cuando el mecanismo del dano ya permite
+  // orientar una primera accion, responde antes que las guardas genericas de
+  // plagas. El reemplazo elimina contaminacion de otros cultivos y deja la foto
+  // como confirmacion posterior, no como excusa para evitar una hipotesis.
+  const observableTriage = guardObservableSymptomTriage(text, { userMessage, hadVision });
+  if (observableTriage && observableTriage.modified) {
+    return {
+      text: observableTriage.text,
+      modified: true,
+      reasons: observableTriage.reason ? [observableTriage.reason] : [],
+    };
   }
 
   // GUARD CROP-AGNOSTIC SAFETY: debe liderar ANTES que cualquier guard específico.


### PR DESCRIPTION
## Summary
- separa sintomas de masticadores y chupadores con una guarda determinista
- filtra contenido de cultivos y variedades ajenos al reemplazar respuestas contaminadas
- prioriza hipotesis probable y accion concreta antes de pedir fotos
- corrige el texto del umbral termico inclusivo
- agrega cinco pasadas con dos especies por caso

## Test plan
- npx vitest run src/services/__tests__/outputGuards.agente5bugsV2.test.js src/services/__tests__/outputGuards.bordeWideRegressions.test.js src/services/__tests__/outputGuards.test.js src/services/__tests__/agentPromptBase.test.js (280 passed, 1 skipped)
- npx eslint src/services/outputGuards.js src/services/agentPromptBase.js src/services/__tests__/outputGuards.agente5bugsV2.test.js --max-warnings=0
- npm run build
- npx vitest run se ejecuto; la suite global de la base presenta fallos ajenos en 3D, voces, catalogo, entorno y auditoria de rutas
- npx eslint . --max-warnings=0 se ejecuto con heaps de 4 GB y 8 GB; ambos agotaron memoria sin reportar reglas antes del OOM