### PR TITLE
fix(fauna): tres errores taxonómicos que hoy están en producción

### DIFF
--- a/src/components/dashboard/CriaturasNocturnas.jsx
+++ b/src/components/dashboard/CriaturasNocturnas.jsx
@@ -65,7 +65,7 @@ export const CRIATURAS_NOCTURNAS = [
   },
   {
     id: 'luciernaga',
-    nombre: 'Luciérnaga (cocuyo)',
+    nombre: 'Luciérnaga',
     cientifico: 'Lampyridae',
     eje: 'Bioindicador de la noche',
     rol: 'Escarabajo bioluminiscente: sus larvas comen babosas y caracoles; su presencia indica suelo sano y poca contaminación lumínica.',
@@ -96,7 +96,7 @@ export const CRIATURAS_NOCTURNAS = [
   {
     id: 'tigrillo',
     nombre: 'Tigrillo (oncilla)',
-    cientifico: 'Leopardus tigrinus',
+    cientifico: 'Leopardus pardinoides',
     eje: 'Depredador tope',
     rol: 'Felino pequeño nocturno: caza roedores y aves que atacan cultivos; regula la cadena y mantiene el equilibrio de la finca.',
     frase: 'Soy el que cierra la cadena: donde yo cazo, la plaga no manda.',
@@ -536,7 +536,7 @@ function AvatarMurcielago() {
   );
 }
 
-/* Luciérnaga / cocuyo (Lampyridae) — PERSONAJE COMPLETO.
+/* Luciérnaga (Lampyridae) — PERSONAJE COMPLETO.
    Pose: posada en una HOJA sana, con el FAROL (los últimos segmentos del
    abdomen) latiendo — su luz solo prende donde el campo está limpio, y ese
    pulso es todo el personaje. Anatomía real del coleóptero: cabeza con ojos
@@ -841,7 +841,7 @@ function AvatarArmadillo() {
 }
 
 /* Roseta ABIERTA del tigrillo: anillo INTERRUMPIDO de borde oscuro con el
-   centro leonado — el patrón real de Leopardus tigrinus (no lunar cerrado de
+   centro leonado — el patrón real de Leopardus pardinoides (no lunar cerrado de
    jaguar). Reutilizable en cualquier parte del cuerpo con escala y giro. */
 function RosetaAbierta({ cx, cy, s = 1, rot = 0 }) {
   return (
@@ -853,7 +853,7 @@ function RosetaAbierta({ cx, cy, s = 1, rot = 0 }) {
   );
 }
 
-/* Tigrillo / oncilla (Leopardus tigrinus) — PERSONAJE COMPLETO.
+/* Tigrillo / oncilla (Leopardus pardinoides) — PERSONAJE COMPLETO.
    Felino PEQUEÑO (menos de 3 kg, tamaño de gato casero — NO un jaguar
    chiquito): cabeza pequeña y redondeada, hocico corto, ojos grandes cuya
    pupila se abre REDONDA en la noche, orejas amplias con la mancha blanca en

--- a/src/components/dashboard/GuardianEspiritu.jsx
+++ b/src/components/dashboard/GuardianEspiritu.jsx
@@ -62,7 +62,7 @@ const ESPECIES = [
     cientifico: 'Tapirus pinchaque',
     eje: 'Suelo y semillas del bosque',
     frase: 'Soy la danta de montaña: siembro el bosque con cada semilla que dejo.',
-    fuente: 'Tapir andino endémico (EN) · fauna paramuna del catálogo de Chagra',
+    fuente: 'Tapir andino (EN) · Colombia, Ecuador y norte del Perú · fauna paramuna del catálogo de Chagra',
     acc: '#7fd0ff', accRgb: '127, 208, 255',
   },
   {


### PR DESCRIPTION
Salen de un pase de verificación taxonómica sobre los **41 taxones** que el
proyecto dibuja o nombra, contrastados contra la API de GBIF y literatura
primaria. Resultado del pase: 30 ✅ · 6 ⚠️ · 5 🔴. Acá van los 3 que **ya
están en producción enseñando mal**.

## 1. Tigrillo — `Leopardus tigrinus` → `Leopardus pardinoides`

Tras el split de 2024 (Nascimento et al., *Sci Rep*, doi 10.1038/s41598-024-52379-8),
el tigrillo de los bosques nublados andinos de Colombia es **`L. pardinoides`**.
`L. tigrinus` quedó reducido a las sabanas del Escudo Guayanés y el centro-noreste
de Brasil.

Es **el mismo patrón que el error de la angelita**: género correcto, especie de
otra región. Salvedad honesta: GBIF todavía no adoptó el split, así que la
corrección se sostiene en el paper, no en GBIF.

## 2. Luciérnaga — sale el apodo "(cocuyo)"

En Colombia *cocuyo* es `Pyrophorus`, familia **Elateridae**: otra familia, de luz
**constante** en vez de destellante. El rol que describe la ficha (larvas que comen
babosas) sí es de Lampyridae — así que **el taxón se queda y lo que sale es el
apodo**, que era lo único incorrecto.

## 3. Danta de montaña — deja de decirse endémica

`Tapirus pinchaque` vive en **Colombia, Ecuador y el norte del Perú**. El binomio y
la categoría EN estaban bien; el claim de endemismo no.

## Lo que NO se toca

**Angelita ya está correcta** como *Tetragonisca angustula* (commits `afaf4776`,
`6eff769e`, `e5c9ddea`). El brief que pedía corregirla prescribía un arreglo ya hecho.

## Verificación

`npx vite build` → **verde, 2m 3s**. Son cambios de cadena de texto; no hay
cambio de comportamiento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)