### PR TITLE
fix(mundos): cablear paso/seleccion a la escena 3D (gallinero, abejas, botica)

### DIFF
--- a/src/mockups/MundoAbejas3D.jsx
+++ b/src/mockups/MundoAbejas3D.jsx
@@ -69,6 +69,14 @@ const TARJETAS = [
     texto: 'Las abejas sin aguijon viven en cajas distintas y producen poca miel valiosa. Conservar flores y sitios de anidacion protege su diversidad.',
   },
 ];
+/* A dónde lleva la mirada cada tarjeta: 01 al surco de flores, 02 al
+   panal/colmenas Langstroth, 03 a la caja melipona. Antes `seleccion` solo se
+   pintaba a sí misma; con esto tocar una tarjeta mueve el mundo. */
+const ZONAS = {
+  polinizacion: [0, 0.55, 3.0],
+  miel: [-1.7, 0.75, -1.8],
+  nativas: [3.65, 0.4, -1.7],
+};
 
 function Flor({ posicion, color }) {
   return (
@@ -188,9 +196,33 @@ function AbejaDelEnjambre({ datos, reducedMotion }) {
   );
 }
 
-function Escena({ tier, reducedMotion }) {
+/* Lleva el `target` de OrbitControls hacia la zona de la tarjeta activa.
+   Antes `seleccion` solo cambiaba el borde de su propia tarjeta HTML; esto la
+   cablea a la cámara del Canvas. Sin reducedMotion camina suave (lerp);
+   con reducedMotion salta directo, sin marear. */
+function EnfocarSeleccion({ seleccion, reducedMotion, controlsRef }) {
+  const objetivo = useMemo(() => new THREE.Vector3(...(ZONAS[seleccion] || ZONAS.polinizacion)), [seleccion]);
+  useFrame((_state, delta) => {
+    const controles = controlsRef.current;
+    if (!controles) return;
+    if (reducedMotion) {
+      controles.target.copy(objetivo);
+    } else {
+      controles.target.lerp(objetivo, Math.min(1, delta * 1.6));
+    }
+    controles.update();
+  });
+  /* Ancla inerte (sin geometría ni material) que expone declarativamente a
+     dónde apunta el foco activo — el mismo punto que persigue OrbitControls
+     cuadro a cuadro. Marca la escena y sirve de gancho de prueba. */
+  return <group name="foco-seleccion" position={[objetivo.x, objetivo.y, objetivo.z]} />;
+}
+
+function Escena({ tier, reducedMotion, seleccion }) {
   const perfil = perfilDeTier(tier);
   const abejas = tier === 'bajo' ? ENJAMBRE.slice(0, 4) : tier === 'medio' ? ENJAMBRE.slice(0, 7) : ENJAMBRE;
+  const controlsRef = useRef(/** @type {any} */ (null));
+  const objetivoInicial = ZONAS[seleccion] || ZONAS.polinizacion;
   return (
     <>
       <color attach="background" args={[DORADA.cielo]} />
@@ -208,7 +240,8 @@ function Escena({ tier, reducedMotion }) {
       {FLORES.map(([x, y, z, color]) => <Flor key={`${x}-${z}`} posicion={[x, y, z]} color={color} />)}
       {abejas.map((datos) => <AbejaDelEnjambre key={datos.ancla.join('-')} datos={datos} reducedMotion={reducedMotion} />)}
       <ParticulasAmbientales tipo="polen" tier={tier} reducedMotion={reducedMotion} area={[10, 3.5, 7]} position={[0, 0.5, 0]} />
-      <OrbitControls makeDefault enablePan={false} minDistance={8.5} maxDistance={15} minPolarAngle={0.65} maxPolarAngle={1.35} target={[0, 0.8, 0]} />
+      <OrbitControls ref={controlsRef} makeDefault enablePan={false} minDistance={8.5} maxDistance={15} minPolarAngle={0.65} maxPolarAngle={1.35} target={objetivoInicial} />
+      <EnfocarSeleccion seleccion={seleccion} reducedMotion={reducedMotion} controlsRef={controlsRef} />
       {tier === 'alto' ? <AdaptiveDpr pixelated /> : null}
     </>
   );
@@ -249,7 +282,7 @@ export default function MundoAbejas3D() {
           gl={{ antialias: perfil.antialias, alpha: false, powerPreference: 'high-performance' }}
           camera={{ position: [10, 7.2, 11], fov: 42, near: 0.1, far: 55 }}
         >
-          <Escena tier={decision.tier} reducedMotion={decision.reducedMotion} />
+          <Escena tier={decision.tier} reducedMotion={decision.reducedMotion} seleccion={seleccion} />
         </Canvas>
         <p style={estilos.pista}>{decision.reducedMotion ? 'Vista quieta para su comodidad' : 'Arrastre para recorrer el colmenar'}</p>
       </section>

--- a/src/mockups/MundoBoticaCana3D.jsx
+++ b/src/mockups/MundoBoticaCana3D.jsx
@@ -15,8 +15,8 @@
  *     rodillos de madera movido por el buey que da vueltas a la palanca, el
  *     canal del guarapo, la HORNILLA con la paila humeando hasta punto de miel
  *     y la mesa con las GAVERAS donde cuaja la panela. El proceso legible de
- *     una mirada: caña → molino → jugo → paila → panela (botón «paso a paso»
- *     con etiquetas sobre la escena).
+ *     una mirada: caña → molino → jugo → paila → panela, con un recorrido de
+ *     5 botones que acerca la cámara al paso activo y resalta su etiqueta.
  *
  * DIRECCIÓN DE ARTE (todo dentro del framework, nada inventado por fuera):
  *   - Atmósfera del MEDIODÍA claro del kit (`CIELOS_HORA.mediodia`): la
@@ -194,11 +194,11 @@ function NubesDia() {
 }
 
 /* Etiqueta didáctica sobre la escena (solo en modo «paso a paso»). */
-function Etiqueta({ pos, texto, paso }) {
+function Etiqueta({ pos, texto, paso, activo }) {
   return (
-    <group position={pos}>
+    <group position={pos} name={paso != null ? `etiqueta-paso-${paso}` : undefined}>
       <Html center distanceFactor={9} zIndexRange={[30, 0]}>
-        <div className="bocana-chip" aria-hidden="true">
+        <div className={`bocana-chip${activo ? ' bocana-chip--activo' : ''}`} aria-hidden="true">
           {paso != null && <b>{paso}</b>}
           {texto}
         </div>
@@ -979,22 +979,58 @@ function MesaGaveras() {
   );
 }
 
-/* Las etiquetas del paso a paso panelero: caña → molino → jugo → paila → panela. */
-function PasosPanela() {
+/* El recorrido de la caña a la panela: caña → molino → jugo → paila →
+   panela. Única fuente de verdad para la etiqueta 3D, el botón del pie y a
+   dónde se acerca la cámara — antes `etiquetas` era un booleano todo-o-nada
+   y esto vivía repetido e inconexo. */
+const RECORRIDO_PANELA = [
+  { paso: 1, texto: 'La caña', pos: [9.5, 3.6, -4.5] },
+  { paso: 2, texto: 'El molino', pos: [6.2, 3.4, 1.2] },
+  { paso: 3, texto: 'El jugo', pos: [4.8, 1.9, 2.8] },
+  { paso: 4, texto: 'La paila', pos: [3.2, 2.5, 4.3] },
+  { paso: 5, texto: 'La panela', pos: [0.7, 2.0, 5.9] },
+];
+/* A dónde mira la cámara cuando no hay paso activo (vista calma original). */
+const OBJETIVO_CALMA = [0.5, 1.0, 1.5];
+
+/* Las etiquetas del paso a paso panelero. Solo la del paso activo se resalta
+   (clase CSS, sin tocar geometría ni materiales de Three). */
+function PasosPanela({ pasoActivo }) {
   return (
     <>
-      <Etiqueta pos={[9.5, 3.6, -4.5]} paso="1" texto="La caña" />
-      <Etiqueta pos={[6.2, 3.4, 1.2]} paso="2" texto="El molino" />
-      <Etiqueta pos={[4.8, 1.9, 2.8]} paso="3" texto="El jugo" />
-      <Etiqueta pos={[3.2, 2.5, 4.3]} paso="4" texto="La paila" />
-      <Etiqueta pos={[0.7, 2.0, 5.9]} paso="5" texto="La panela" />
+      {RECORRIDO_PANELA.map((p) => (
+        <Etiqueta key={p.paso} pos={p.pos} paso={String(p.paso)} texto={p.texto} activo={pasoActivo === p.paso} />
+      ))}
     </>
   );
 }
 
+/* Lleva el `target` de OrbitControls hacia la posición del paso activo del
+   recorrido panelero — antes la cámara nunca se movía con `etiquetas`.
+   Sin reducedMotion camina suave (lerp); con reducedMotion salta directo. */
+function EnfocarPaso({ paso, reducedMotion, controlsRef }) {
+  const objetivo = useMemo(() => {
+    const destino = paso > 0 ? RECORRIDO_PANELA[paso - 1].pos : OBJETIVO_CALMA;
+    return new THREE.Vector3(...destino);
+  }, [paso]);
+  useFrame((_state, delta) => {
+    const controles = controlsRef.current;
+    if (!controles) return;
+    if (reducedMotion) {
+      controles.target.copy(objetivo);
+    } else {
+      controles.target.lerp(objetivo, Math.min(1, delta * 1.4));
+    }
+    controles.update();
+  });
+  /* Ancla inerte (sin geometría ni material): expone declarativamente a
+     dónde apunta el foco activo, y sirve de gancho de prueba. */
+  return <group name="foco-paso" position={[objetivo.x, objetivo.y, objetivo.z]} />;
+}
+
 /* ══════════════════════ LA ESCENA COMPLETA ══════════════════════ */
 
-function EscenaBoticaCana({ tier, reducedMotion, etiquetas }) {
+function EscenaBoticaCana({ tier, reducedMotion, etiquetas, paso }) {
   const perfil = perfilDeTier(tier);
   const geo = useMemo(
     () => construirTerreno(perfil.segmentosTerreno, perfil.flatShading),
@@ -1025,7 +1061,7 @@ function EscenaBoticaCana({ tier, reducedMotion, etiquetas }) {
       <CanalGuarapo />
       <Hornilla reducedMotion={reducedMotion} tier={tier} />
       <MesaGaveras />
-      {etiquetas && <PasosPanela />}
+      {etiquetas && <PasosPanela pasoActivo={paso} />}
 
       {/* unas piedras que amueblan el borde del patio */}
       {[
@@ -1103,12 +1139,15 @@ const CSS_BOCANA = `
 .bocana-canvas--lista { opacity: 1; }
 .bocana-chrome { position: absolute; inset: 0; pointer-events: none; display: flex; flex-direction: column; justify-content: flex-end; }
 .bocana-pie { padding: 0 1rem 0.9rem; display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 0.6rem; }
+.bocana-recorrido { margin: 0; padding: 0; list-style: none; display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 0.45rem; }
 .bocana-carta { margin: 0; max-width: 34rem; text-align: center; padding: 0.5rem 0.95rem; border-radius: 0.7rem; background: rgba(74,52,24,0.66); backdrop-filter: blur(3px); color: #fbf3e2; font: 500 0.8rem/1.5 system-ui, sans-serif; }
 .bocana-boton { pointer-events: auto; appearance: none; border: 1px solid rgba(74,52,24,0.35); border-radius: 999px; padding: 0.44rem 1rem; background: rgba(255,247,228,0.85); color: #5a3f1c; font: 600 0.8rem/1.1 system-ui, sans-serif; cursor: pointer; backdrop-filter: blur(3px); transition: background 0.2s ease, border-color 0.2s ease; }
 .bocana-boton:hover, .bocana-boton:focus-visible { background: rgba(255,255,255,0.95); border-color: rgba(74,52,24,0.6); outline: none; }
 .bocana-boton[aria-pressed='true'] { background: #ffe8b0; border-color: rgba(90,63,28,0.75); color: #4a3418; }
 .bocana-chip { pointer-events: none; display: inline-flex; align-items: center; gap: 0.3em; padding: 2px 8px; border-radius: 999px; background: rgba(58,42,24,0.82); color: #fdf6e3; font: 600 10px/1.5 system-ui, sans-serif; white-space: nowrap; box-shadow: 0 2px 6px rgba(40,28,10,0.3); }
 .bocana-chip b { display: inline-flex; align-items: center; justify-content: center; width: 1.35em; height: 1.35em; border-radius: 50%; background: #e8a24a; color: #3c2410; font-size: 9px; }
+.bocana-chip--activo { background: #e8a24a; color: #2c1c0a; box-shadow: 0 0 0 2px rgba(255,255,255,0.85), 0 3px 10px rgba(40,28,10,0.4); }
+.bocana-chip--activo b { background: #fdf6e3; color: #6b3e12; }
 .mundo-fauna { pointer-events: none; filter: drop-shadow(0 2px 5px rgba(40, 30, 10, 0.24)); }
 .bocana-leyenda { padding: 1.4rem 1rem 0; }
 .bocana-leyenda h2 { margin: 0 0 0.3rem; font-size: 1.12rem; color: #4a3418; }
@@ -1205,7 +1244,12 @@ const COPY_PASOS =
  */
 export default function MundoBoticaCana3D() {
   const [listo, setListo] = useState(false);
-  const [etiquetas, setEtiquetas] = useState(false);
+  /* 0 = vista calma (sin etiquetas); 1..5 = paso activo del recorrido
+     caña→panela. Antes esto era un booleano todo-o-nada que no movía la
+     cámara ni distinguía un paso de otro. */
+  const [paso, setPaso] = useState(0);
+  const etiquetas = paso > 0;
+  const controlsRef = useRef(/** @type {any} */ (null));
   const tier = useMemo(() => decidirTier().tier, []);
   const reducedMotion = useMemo(
     () =>
@@ -1245,14 +1289,15 @@ export default function MundoBoticaCana3D() {
           frameloop={reducedMotion ? 'demand' : 'always'}
           onCreated={() => setListo(true)}
         >
-          <EscenaBoticaCana tier={tier} reducedMotion={reducedMotion} etiquetas={etiquetas} />
+          <EscenaBoticaCana tier={tier} reducedMotion={reducedMotion} etiquetas={etiquetas} paso={paso} />
           <OrbitControls
+            ref={controlsRef}
             makeDefault
             enablePan={false}
             enableZoom
             minDistance={7}
             maxDistance={22}
-            target={[0.5, 1.0, 1.5]}
+            target={paso > 0 ? RECORRIDO_PANELA[paso - 1].pos : OBJETIVO_CALMA}
             minPolarAngle={0.5}
             maxPolarAngle={1.4}
             minAzimuthAngle={-1.05}
@@ -1262,19 +1307,26 @@ export default function MundoBoticaCana3D() {
             autoRotate={!reducedMotion}
             autoRotateSpeed={0.08}
           />
+          <EnfocarPaso paso={paso} reducedMotion={reducedMotion} controlsRef={controlsRef} />
           <AdaptiveDpr pixelated />
         </Canvas>
 
         <div className="bocana-chrome">
           <div className="bocana-pie">
-            <button
-              type="button"
-              className="bocana-boton"
-              aria-pressed={etiquetas}
-              onClick={() => setEtiquetas((v) => !v)}
-            >
-              {etiquetas ? 'Quitar las etiquetas' : 'Ver nombres y paso a paso'}
-            </button>
+            <ol className="bocana-recorrido" aria-label="Recorrido de la caña a la panela">
+              {RECORRIDO_PANELA.map((p) => (
+                <li key={p.paso}>
+                  <button
+                    type="button"
+                    className="bocana-boton"
+                    aria-pressed={paso === p.paso}
+                    onClick={() => setPaso((actual) => (actual === p.paso ? 0 : p.paso))}
+                  >
+                    {p.paso}. {p.texto}
+                  </button>
+                </li>
+              ))}
+            </ol>
             <p className="bocana-carta" role="status">
               {etiquetas ? COPY_PASOS : COPY_CALMA}
             </p>

--- a/src/mockups/MundoGallinero3D.jsx
+++ b/src/mockups/MundoGallinero3D.jsx
@@ -15,9 +15,19 @@ const PARCELAS = [
   { id: 'descanso', nombre: '3. Descanso', detalle: 'La parcela reposa, absorbe el abono y se regenera.', x: 4.2, z: -1.8, color: '#a7b85e' },
   { id: 'huerto', nombre: '4. Huerto aliado', detalle: 'Después del descanso, las gallinas ayudan con plagas y fertilidad.', x: 4.2, z: 2.6, color: '#557f39' },
 ];
+/* Posiciones RELATIVAS al centro de la parcela activa (no absolutas): así
+   las 8 gallinas se reparten a donde esté `paso` en vez de vivir siempre en
+   la parcela 1. Conserva el mismo patrón de dispersión que tenían las
+   coordenadas originales (todas caían dentro de una sola parcela). */
 const GALLINAS = [
-  [-5.2, -2.2, 0.1], [-4.3, -1.4, 1.7], [-3.5, -2.4, 3.2], [-4.7, -3, 4.5],
-  [-3.3, -1.2, 5.6], [-5.5, -1.4, 0.8], [-4, -2.9, 2.5], [-2.9, -2, 3.8],
+  { dx: -1.0, dz: -0.4, rot: 0.1 },
+  { dx: -0.1, dz: 0.4, rot: 1.7 },
+  { dx: 0.7, dz: -0.6, rot: 3.2 },
+  { dx: -0.5, dz: -1.2, rot: 4.5 },
+  { dx: 0.9, dz: 0.6, rot: 5.6 },
+  { dx: -1.3, dz: 0.4, rot: 0.8 },
+  { dx: 0.2, dz: -1.1, rot: 2.5 },
+  { dx: 1.3, dz: -0.2, rot: 3.8 },
 ];
 const CULTIVOS = Array.from({ length: 18 }, (_, i) => ({
   x: 2.8 + (i % 6) * 0.55,
@@ -26,19 +36,27 @@ const CULTIVOS = Array.from({ length: 18 }, (_, i) => ({
 }));
 const POSTES = [-6.1, -2.1, 2.1, 6.1];
 
-function Terreno() {
+function Terreno({ pasoActivo }) {
   return (
     <>
       <mesh position={[0, -0.2, 0]}>
         <boxGeometry args={[14, 0.35, 9]} />
         <meshLambertMaterial color={PALETA.tierraClara} />
       </mesh>
-      {PARCELAS.map((p) => (
-        <mesh key={p.id} position={[p.x, 0.01, p.z]}>
-          <boxGeometry args={[3.75, 0.18, 3.8]} />
-          <meshLambertMaterial color={p.color} flatShading />
-        </mesh>
-      ))}
+      {PARCELAS.map((p) => {
+        const activa = p.id === pasoActivo;
+        /* La parcela activa se distingue por estado (no solo por su hex fijo
+           de rol): se aclara hacia PALETA.cal y se levanta un poco. Nada de
+           geometría nueva, solo el color/alto que ya existían reaccionando
+           al paso elegido. */
+        const color = activa ? mezclar(p.color, PALETA.cal, 0.45) : p.color;
+        return (
+          <mesh key={p.id} name={`parcela-${p.id}`} position={[p.x, activa ? 0.05 : 0.01, p.z]}>
+            <boxGeometry args={[3.75, 0.18, 3.8]} />
+            <meshLambertMaterial color={color} flatShading />
+          </mesh>
+        );
+      })}
       <mesh position={[-2.1, 0.02, 2.6]}>
         <boxGeometry args={[3.75, 0.18, 3.8]} />
         <meshLambertMaterial color={mezclar(PALETA.tierra, PALETA.follaje, 0.18)} />
@@ -73,18 +91,36 @@ function Cerca() {
   );
 }
 
-function Gallina({ posicion, indice, reducedMotion }) {
+function Gallina({ objetivo, indice, reducedMotion }) {
   const grupo = useRef(null);
-  useFrame(({ clock }) => {
-    if (reducedMotion || !grupo.current) return;
+  /* `actual` guarda la posición viva de la gallina; `objetivo` es a donde
+     debe llegar según el paso elegido. Cada frame camina un poco hacia allá
+     en vez de teletransportarse — el prop declarativo de abajo ya la deja en
+     el punto correcto en cuanto cambia `paso` (para quien no anima frames),
+     y aquí se suaviza el tránsito cuando sí hay animación. */
+  const actual = useRef([objetivo[0], objetivo[1]]);
+  useFrame(({ clock }, delta) => {
+    if (!grupo.current) return;
     const t = clock.elapsedTime * 1.8 + indice;
-    grupo.current.rotation.y = posicion[2] + Math.sin(t * 0.35) * 0.45;
-    grupo.current.position.y = Math.max(0, Math.sin(t * 2.2)) * 0.025;
+    if (reducedMotion) {
+      actual.current[0] = objetivo[0];
+      actual.current[1] = objetivo[1];
+      grupo.current.rotation.y = objetivo[2];
+      grupo.current.position.y = 0.2;
+    } else {
+      const avance = Math.min(1, delta * 1.3);
+      actual.current[0] += (objetivo[0] - actual.current[0]) * avance;
+      actual.current[1] += (objetivo[1] - actual.current[1]) * avance;
+      grupo.current.rotation.y = objetivo[2] + Math.sin(t * 0.35) * 0.45;
+      grupo.current.position.y = 0.2 + Math.max(0, Math.sin(t * 2.2)) * 0.025;
+    }
+    grupo.current.position.x = actual.current[0];
+    grupo.current.position.z = actual.current[1];
   });
   const clara = indice % 3 === 0;
   const cuerpo = clara ? '#d9c5a1' : indice % 2 ? '#9a5431' : '#b86a38';
   return (
-    <group ref={grupo} position={[posicion[0], 0.2, posicion[1]]} rotation={[0, posicion[2], 0]}>
+    <group ref={grupo} name={`gallina-${indice}`} position={[objetivo[0], 0.2, objetivo[1]]} rotation={[0, objetivo[2], 0]}>
       <mesh scale={[0.38, 0.3, 0.52]}>
         <sphereGeometry args={[0.55, 7, 5]} />
         <meshLambertMaterial color={cuerpo} flatShading />
@@ -109,9 +145,24 @@ function Gallina({ posicion, indice, reducedMotion }) {
   );
 }
 
-function TractorGallinas() {
+function TractorGallinas({ objetivo, reducedMotion }) {
+  const grupo = useRef(null);
+  const actual = useRef([objetivo[0], objetivo[1]]);
+  useFrame((_state, delta) => {
+    if (!grupo.current) return;
+    if (reducedMotion) {
+      actual.current[0] = objetivo[0];
+      actual.current[1] = objetivo[1];
+    } else {
+      const avance = Math.min(1, delta * 0.9);
+      actual.current[0] += (objetivo[0] - actual.current[0]) * avance;
+      actual.current[1] += (objetivo[1] - actual.current[1]) * avance;
+    }
+    grupo.current.position.x = actual.current[0];
+    grupo.current.position.z = actual.current[1];
+  });
   return (
-    <group position={[-0.2, 0.25, -1.8]}>
+    <group ref={grupo} name="tractor-gallinas" position={[objetivo[0], 0.25, objetivo[1]]}>
       <mesh position={[0, 0.55, 0]}>
         <boxGeometry args={[2.5, 1.05, 1.8]} />
         <meshLambertMaterial color={PALETA.maderaClara} transparent opacity={0.35} />
@@ -223,8 +274,12 @@ function FlechasCiclo() {
   });
 }
 
-function Escena({ tier, reducedMotion }) {
+function Escena({ tier, reducedMotion, paso }) {
   const cantidad = tier === 'alto' ? 8 : tier === 'medio' ? 6 : 4;
+  /* La parcela activa según el paso elegido en el DOM: de aquí sale a dónde
+     caminan las gallinas y a dónde se traslada el tractor. Antes `paso`
+     nunca llegaba hasta acá. */
+  const activa = useMemo(() => PARCELAS.find((p) => p.id === paso) ?? PARCELAS[0], [paso]);
   return (
     <>
       <color attach="background" args={[CIELO.fondo]} />
@@ -233,13 +288,15 @@ function Escena({ tier, reducedMotion }) {
       <ambientLight color={DORADA.luz} intensity={0.28} />
       <directionalLight color={ATMOSFERA.luz} intensity={1.15} position={/** @type {[number, number, number]} */ (DORADA.solPos)} />
       <directionalLight color={ATMOSFERA.relleno} intensity={0.22} position={[-6, 5, -3]} />
-      <Terreno />
+      <Terreno pasoActivo={activa.id} />
       <Cerca />
-      <TractorGallinas />
+      <TractorGallinas objetivo={[activa.x, activa.z]} reducedMotion={reducedMotion} />
       <Ponedero />
       <Huerto />
       <FlechasCiclo />
-      {GALLINAS.slice(0, cantidad).map((p, i) => <Gallina key={i} posicion={p} indice={i} reducedMotion={reducedMotion} />)}
+      {GALLINAS.slice(0, cantidad).map((g, i) => (
+        <Gallina key={i} indice={i} reducedMotion={reducedMotion} objetivo={[activa.x + g.dx, activa.z + g.dz, g.rot]} />
+      ))}
       <ParticulasAmbientales tipo="polen" tier={tier} reducedMotion={reducedMotion} area={[12, 2.5, 8]} semilla={712} />
       <OrbitControls makeDefault enablePan={false} minDistance={7} maxDistance={19} minPolarAngle={0.48} maxPolarAngle={1.3} target={[0, 0.5, 0]} autoRotate={!reducedMotion} autoRotateSpeed={0.18} />
       <AdaptiveDpr pixelated />
@@ -269,7 +326,7 @@ export default function MundoGallinero3D({ onBack }) {
     <section className="mgall-root" data-tier={tier} aria-label="Mundo del gallinero con pastoreo rotativo">
       <style>{CSS}</style>
       <Canvas className="mgall-canvas" data-lista={listo} dpr={perfil.dpr} frameloop={reducedMotion ? 'demand' : 'always'} gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }} camera={{ position: [11, 8.5, 12], fov: 43 }} onCreated={() => setListo(true)}>
-        <Escena tier={tier} reducedMotion={reducedMotion} />
+        <Escena tier={tier} reducedMotion={reducedMotion} paso={paso} />
       </Canvas>
       <div className="mgall-ui">
         <header className="mgall-cabecera">

--- a/src/mockups/__tests__/mundoAbejas3D.smoke.test.jsx
+++ b/src/mockups/__tests__/mundoAbejas3D.smoke.test.jsx
@@ -40,4 +40,29 @@ describe('MundoAbejas3D', () => {
     expect(nativas).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('button', { name: /Polinizacion que da fruto/ })).toHaveAttribute('aria-pressed', 'false');
   });
+
+  // Cableado de `seleccion` al 3D: antes la tarjeta activa solo se pintaba a
+  // sí misma y el Canvas no se enteraba de cuál estaba tocada.
+  describe('cablea la tarjeta activa al Canvas (no solo su propio borde)', () => {
+    test('empieza mirando el surco de flores (tarjeta 01)', () => {
+      const { container } = render(<MundoAbejas3D />);
+      const foco = container.querySelector('group[name="foco-seleccion"]');
+      expect(foco).toBeTruthy();
+      expect(foco.getAttribute('position')).toBe('0,0.55,3');
+    });
+
+    test('tocar la tarjeta 02 (miel) lleva el foco al panal/colmenas', () => {
+      const { container } = render(<MundoAbejas3D />);
+      fireEvent.click(screen.getByRole('button', { name: /Miel, cera y cuidado/ }));
+      const foco = container.querySelector('group[name="foco-seleccion"]');
+      expect(foco.getAttribute('position')).toBe('-1.7,0.75,-1.8');
+    });
+
+    test('tocar la tarjeta 03 (nativas) lleva el foco a la caja melipona', () => {
+      const { container } = render(<MundoAbejas3D />);
+      fireEvent.click(screen.getByRole('button', { name: /Meliponas nativas/ }));
+      const foco = container.querySelector('group[name="foco-seleccion"]');
+      expect(foco.getAttribute('position')).toBe('3.65,0.4,-1.7');
+    });
+  });
 });

--- a/src/mockups/__tests__/mundoBoticaCana3D.test.jsx
+++ b/src/mockups/__tests__/mundoBoticaCana3D.test.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+
+/*
+ * El Canvas se mockea abajo (como en sus mundos hermanos) para poder leer el
+ * árbol de la escena con testing-library, sin WebGL real. Eso significa que
+ * `<instancedMesh>` (el cañal de `Canal`, 2 draw calls instanciados) monta
+ * como un elemento DOM plano, no como un `THREE.InstancedMesh` real — y su
+ * `useEffect` de siembra llama `setMatrixAt`/`setColorAt`/`instanceMatrix`
+ * sobre esa ref. Sin este parche, CUALQUIER render de este mundo revienta en
+ * ese efecto (nada que ver con `paso`/`etiquetas`: es el cañal, no tocado por
+ * este cableado). Se rellenan como no-op solo para que el efecto no truene;
+ * no se afirma nada sobre el cañal en estos tests.
+ */
+beforeAll(() => {
+  const proto = window.HTMLUnknownElement?.prototype;
+  if (proto && !proto.setMatrixAt) {
+    proto.setMatrixAt = () => {};
+    proto.setColorAt = () => {};
+    Object.defineProperty(proto, 'instanceMatrix', {
+      configurable: true,
+      get() { return { needsUpdate: false }; },
+      set() {},
+    });
+    Object.defineProperty(proto, 'instanceColor', {
+      configurable: true,
+      get() { return null; },
+      set() {},
+    });
+  }
+});
+
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children, onCreated, ...props }) => {
+    React.useEffect(() => onCreated?.(), [onCreated]);
+    return <div data-testid="canvas" {...props}>{children}</div>;
+  },
+  useFrame: vi.fn(),
+}));
+
+vi.mock('@react-three/drei', () => ({
+  AdaptiveDpr: () => null,
+  OrbitControls: () => null,
+  Html: ({ children }) => <div data-testid="html-billboard">{children}</div>,
+}));
+
+vi.mock('../../visual/mundo3d/ParticulasAmbientales.jsx', () => ({
+  ParticulasAmbientales: () => null,
+}));
+
+import MundoBoticaCana3D from '../MundoBoticaCana3D.jsx';
+
+afterEach(cleanup);
+
+describe('MundoBoticaCana3D', () => {
+  test('presenta la botica y el trapiche, y monta su propio Canvas', () => {
+    render(<MundoBoticaCana3D />);
+    expect(screen.getByRole('heading', { name: 'La botica y el trapiche' })).toBeInTheDocument();
+    expect(screen.getByLabelText('La botica campesina y el trapiche panelero en 3D')).toBeInTheDocument();
+    expect(screen.getByRole('list', { name: 'Recorrido de la caña a la panela' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(5);
+  });
+
+  // Cableado de `paso`: antes `etiquetas` era un booleano todo-o-nada que no
+  // movía la cámara ni distinguía un paso de otro dentro del Canvas.
+  describe('cablea el recorrido de la caña a la panela al Canvas', () => {
+    test('en vista calma (sin tocar nada) no hay etiquetas 3D y la cámara mira al punto de reposo', () => {
+      const { container } = render(<MundoBoticaCana3D />);
+      expect(container.querySelector('group[name="etiqueta-paso-1"]')).toBeNull();
+      const foco = container.querySelector('group[name="foco-paso"]');
+      expect(foco).toBeTruthy();
+      expect(foco.getAttribute('position')).toBe('0.5,1,1.5');
+      expect(screen.getByRole('status')).toHaveTextContent(/Toque el botón/i);
+    });
+
+    test('tocar "2. El molino" activa el recorrido, resalta esa etiqueta y acerca la cámara a su posición', () => {
+      const { container } = render(<MundoBoticaCana3D />);
+      fireEvent.click(screen.getByRole('button', { name: '2. El molino' }));
+
+      // La cámara (el foco) se mueve al punto del paso 2, no al de reposo.
+      const foco = container.querySelector('group[name="foco-paso"]');
+      expect(foco.getAttribute('position')).toBe('6.2,3.4,1.2');
+
+      // Solo la etiqueta del paso 2 lleva la clase de "activo".
+      const etiqueta2 = container.querySelector('div[data-testid="html-billboard"] .bocana-chip--activo');
+      expect(etiqueta2).toBeTruthy();
+      expect(etiqueta2).toHaveTextContent('El molino');
+
+      // El botón queda marcado y el texto cambia al del recorrido.
+      expect(screen.getByRole('button', { name: '2. El molino' })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByRole('status')).toHaveTextContent(/Siga los números/i);
+    });
+
+    test('tocar el mismo paso otra vez vuelve a la vista calma (apaga el recorrido)', () => {
+      const { container } = render(<MundoBoticaCana3D />);
+      const boton = screen.getByRole('button', { name: '4. La paila' });
+      fireEvent.click(boton);
+      expect(boton).toHaveAttribute('aria-pressed', 'true');
+      fireEvent.click(boton);
+      expect(boton).toHaveAttribute('aria-pressed', 'false');
+      expect(container.querySelector('group[name="etiqueta-paso-4"]')).toBeNull();
+      const foco = container.querySelector('group[name="foco-paso"]');
+      expect(foco.getAttribute('position')).toBe('0.5,1,1.5');
+    });
+  });
+});

--- a/src/mockups/__tests__/mundoGallinero3D.test.jsx
+++ b/src/mockups/__tests__/mundoGallinero3D.test.jsx
@@ -26,7 +26,7 @@ afterEach(cleanup);
 
 describe('MundoGallinero3D', () => {
   test('presenta el ciclo completo y monta su propio Canvas', () => {
-    render(<MundoGallinero3D onBack={() => {}} />);
+    render(<MundoGallinero3D />);
     expect(screen.getByRole('heading', { name: 'El gallinero que camina' })).toBeInTheDocument();
     expect(screen.getByTestId('canvas')).toHaveAttribute('data-lista', 'true');
     expect(screen.getByRole('list', { name: 'Ciclo del pastoreo rotativo' })).toBeInTheDocument();
@@ -41,5 +41,58 @@ describe('MundoGallinero3D', () => {
     expect(screen.getByRole('status')).toHaveTextContent('absorbe el abono y se regenera');
     fireEvent.click(screen.getByRole('button', { name: 'Volver' }));
     expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  // Cableado de `paso` a la escena 3D: antes de este arreglo los 4 botones
+  // solo cambiaban un párrafo de texto y nada dentro del <Canvas> se movía.
+  describe('cablea el paso al Canvas (no solo el párrafo)', () => {
+    test('la parcela de pastoreo empieza activa (más alta y más clara) y el tractor y las gallinas viven ahí', () => {
+      const { container } = render(<MundoGallinero3D />);
+      const parcelaPastoreo = container.querySelector('mesh[name="parcela-pastoreo"]');
+      const parcelaTraslado = container.querySelector('mesh[name="parcela-traslado"]');
+      expect(parcelaPastoreo).toBeTruthy();
+      // La parcela activa se levanta (0.05) y las inactivas quedan más bajas (0.01):
+      // la diferencia de estado es real, no solo un hex fijo.
+      expect(parcelaPastoreo.getAttribute('position')).toBe('-4.2,0.05,-1.8');
+      expect(parcelaTraslado.getAttribute('position')).toBe('0,0.01,-1.8');
+
+      // El tractor arranca en la parcela activa (pastoreo), no en una posición
+      // fija arbitraria.
+      const tractor = container.querySelector('group[name="tractor-gallinas"]');
+      expect(tractor.getAttribute('position')).toBe('-4.2,0.25,-1.8');
+
+      // Las 8 gallinas se reparten alrededor de esa MISMA parcela, no
+      // amontonadas en un rincón fijo del mundo.
+      const gallina0 = container.querySelector('group[name="gallina-0"]');
+      expect(gallina0.getAttribute('position')).toBe('-5.2,0.2,-2.2');
+    });
+
+    test('tocar "2. Traslado" mueve el tractor y las gallinas a la nueva parcela, y la activa cambia', () => {
+      const { container } = render(<MundoGallinero3D />);
+      fireEvent.click(screen.getByRole('button', { name: /2. Traslado/i }));
+
+      const parcelaPastoreo = container.querySelector('mesh[name="parcela-pastoreo"]');
+      const parcelaTraslado = container.querySelector('mesh[name="parcela-traslado"]');
+      // La activa ahora es traslado (levantada); pastoreo vuelve a su altura de reposo.
+      expect(parcelaTraslado.getAttribute('position')).toBe('0,0.05,-1.8');
+      expect(parcelaPastoreo.getAttribute('position')).toBe('-4.2,0.01,-1.8');
+
+      const tractor = container.querySelector('group[name="tractor-gallinas"]');
+      expect(tractor.getAttribute('position')).toBe('0,0.25,-1.8');
+
+      const gallina0 = container.querySelector('group[name="gallina-0"]');
+      expect(gallina0.getAttribute('position')).toBe('-1,0.2,-2.2');
+    });
+
+    test('tocar "4. Huerto aliado" lleva el tractor y las gallinas a esa parcela (distinta de las otras tres)', () => {
+      const { container } = render(<MundoGallinero3D />);
+      fireEvent.click(screen.getByRole('button', { name: /4. Huerto aliado/i }));
+
+      const tractor = container.querySelector('group[name="tractor-gallinas"]');
+      expect(tractor.getAttribute('position')).toBe('4.2,0.25,2.6');
+
+      const gallina0 = container.querySelector('group[name="gallina-0"]');
+      expect(gallina0.getAttribute('position')).toBe('3.2,0.2,2.2');
+    });
   });
 });


### PR DESCRIPTION
## Qué estaba pasando

Los tres mundos se veían bien pero los controles del DOM no movían nada dentro
del `<Canvas>`: el estado de React se quedaba en el HTML y nunca llegaba a la
escena 3D. Diagnóstico completo en `ops/BRIEF-FABLE-3-MUNDOS-MUERTOS.md`.

## Qué se movía antes vs. ahora

**`MundoGallinero3D.jsx`**
- Antes: los 4 botones del ciclo solo cambiaban un párrafo de texto. `paso`
  nunca llegaba a `<Escena>`. Las 8 gallinas vivían siempre en la parcela 1
  (coordenadas absolutas fijas) y el tractor estaba clavado en
  `[-0.2, 0.25, -1.8]` sin moverse nunca. Las 4 parcelas solo se distinguían
  por un hex de verde fijo por rol.
- Ahora: `paso` llega a `<Escena>`. Las gallinas se reparten (offsets
  relativos) a la parcela activa y caminan hacia allá (lerp por frame, no
  teletransporte). El tractor se traslada con el paso elegido. La parcela
  activa se distingue por estado (se aclara hacia `PALETA.cal` y se levanta
  un poco), además de su color de rol.
- Qué NO se tocó: geometría de las gallinas/tractor/parcelas, materiales,
  `FlechasCiclo`, ni el encuadre de cámara (roto en móvil, es tarea de arte
  aparte).

**`MundoAbejas3D.jsx`**
- Antes: `seleccion` solo cambiaba el borde de su propia tarjeta HTML. La
  cámara (`OrbitControls.target`) era fija.
- Ahora: la tarjeta activa cablea `OrbitControls.target` hacia su zona: 01 al
  surco de flores, 02 al panal/colmenas Langstroth, 03 a la caja melipona
  (componente `EnfocarSeleccion`, lerp cuadro a cuadro; salta directo con
  `reducedMotion`).
- Qué NO se tocó: las órbitas lissajous del enjambre, geometría de flores/
  colmenas/apicultor, ni el encuadre (media pantalla de degradado vacío en
  móvil sigue así, es arte).

**`MundoBoticaCana3D.jsx`**
- Antes: `etiquetas` era un booleano todo-o-nada (ver todas las 12 etiquetas a
  la vez o ninguna); la cámara no se movía nunca.
- Ahora: se convirtió en un recorrido de paso 1 a 5 (caña→molino→jugo→paila→
  panela). Tocar un paso acerca la cámara a su posición y resalta *solo* esa
  etiqueta (clase CSS `.bocana-chip--activo`, sin tocar materiales/geometría
  de Three). Tocar el mismo paso otra vez vuelve a la vista calma.
- Qué NO se tocó: el cañal instanciado, el trapiche/buey, la hornilla, las 7
  matas, ni el encuadre (en móvil sigue sin mostrar trapiche+botica a la vez,
  es la tarea de arte pendiente).

## Restricciones respetadas

Solo cableado de estado — cero geometría nueva, cero materiales nuevos. El
encuadre móvil se dejó roto a propósito (carril de arte, para no chocar).

## Verificación

- `npm run build`: verde (dos corridas, antes y después de agregar los tests).
- `npx eslint` sobre los 6 archivos tocados: limpio, exit 0.
- Tests nuevos/extendidos que verifican que cambiar el estado cambia **props
  reales dentro del árbol del Canvas** (posición de `<group>`, no solo el
  párrafo de texto fuera del Canvas):
  - `src/mockups/__tests__/mundoGallinero3D.test.jsx` (extendido): posición de
    parcelas/tractor/gallinas antes y después de tocar "2. Traslado" y
    "4. Huerto aliado".
  - `src/mockups/__tests__/mundoAbejas3D.smoke.test.jsx` (extendido): posición
    del foco de cámara al tocar cada una de las 3 tarjetas.
  - `src/mockups/__tests__/mundoBoticaCana3D.test.jsx` (nuevo — este mundo no
    tenía test): vista calma, activar/resaltar un paso, y volver a apagar el
    recorrido tocando el mismo botón.
  - `npx vitest run` sobre estos 3 archivos: **14/14 verde**.

### Qué NO se alcanzó a verificar (y por qué)

- **No corrí la suite completa de `vitest`.** En este repo tarda 25+ minutos y
  la máquina está compartida con otros procesos en paralelo corriendo a la
  vez; el run se cortó dos veces sin dar información nueva. Solo corrí los 3
  archivos de test tocados/nuevos.
- **`dev` ya tiene fallas preexistentes en al menos 6 archivos de test**,
  detectadas en un worktree limpio de `origin/dev` sin este cambio — entre
  ellos `mundoGallinero3D.test.jsx`. Verifiqué esa puntualmente: fallaba
  también en `origin/dev` (un botón "Volver" de más por pasar `onBack` en un
  test que no lo necesitaba) y la arreglé de una vez ya que estaba en ese
  mismo archivo — no es un problema introducido por este PR. No investigué
  los otros ~5 archivos rojos preexistentes: quedan fuera de este alcance.
- **No hice captura visual contra un build local servido.** El brief de
  diagnóstico (`ops/BRIEF-FABLE-3-MUNDOS-MUERTOS.md` §0.1) advierte que
  `chagra-dev` sirve chunks con hash viejo para 2 de los 3 mundos — no lo usé
  para juzgar nada. Recomiendo que quien revise sirva el build local
  (`npm run build && cd dist && python3 -m http.server 8791`) y toque los
  botones de cada mundo antes de mergear, ya que el objetivo original de la
  tarea era exactamente que los controles del DOM muevan la escena.

## Test plan

- [ ] `npm run build`
- [ ] `npx vitest run src/mockups/__tests__/mundoGallinero3D.test.jsx src/mockups/__tests__/mundoAbejas3D.smoke.test.jsx src/mockups/__tests__/mundoBoticaCana3D.test.jsx`
- [ ] Servir `dist/` local, entrar a los 3 mundos y confirmar que tocar los botones mueve la escena (no solo el texto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)