### PR TITLE
feat(onboarding): la escala, el invernadero y el agua siembran el valle

### DIFF
--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -10,7 +10,7 @@ import MapPicker from './MapPicker';
 import PlanEditor from './PlanEditor';
 import { useAssetPerformance } from '../hooks/useAssetPerformance';
 import { MATERIAL_CATEGORIES } from '../config/materials';
-import { FARM_CONFIG } from '../config/defaults';
+import { getContextoGeoParaIA } from '../services/perfilFincaService';
 import { geoJsonToWkt, wktToGeoJson } from '../utils/geo';
 import { proximityCheck, findNearestLand, checkInvasiveProximity, getCoords } from '../utils/spatialAnalysis';
 import { ExternalAiButton } from './common/ExternalAiButton';
@@ -869,7 +869,7 @@ export const AssetDetailView = () => {
                     </>
                   )}
                   <ExternalAiButton
-                    context={{ speciesName: name, thermalZones: FARM_CONFIG.THERMAL_ZONES, speciesThermalZones, altitudMsnm: FARM_CONFIG.ALTITUD_MSNM, municipio: FARM_CONFIG.MUNICIPIO }}
+                    context={{ speciesName: name, speciesThermalZones, ...getContextoGeoParaIA() }}
                     buildPrompt={buildOpenExternalPrompt}
                     label="Ayuda IA"
                   />

--- a/src/components/GuildSuggestions.jsx
+++ b/src/components/GuildSuggestions.jsx
@@ -4,7 +4,7 @@ import { Sprout, AlertTriangle, Sparkles, Loader2, Check } from 'lucide-react';
 import { getSuggestedCompanions, buildGuildPrompt } from '../services/guildService';
 import { getAllSpecies } from '../db/catalogDB';
 import { SPECIES_DEFAULTS } from '../config/speciesDefaults';
-import { FARM_CONFIG } from '../config/defaults';
+import { getContextoGeoParaIA } from '../services/perfilFincaService';
 import { CROP_TAXONOMY } from '../config/taxonomy';
 import { registry } from '../core/moduleRegistry';
 import useAssetStore from '../store/useAssetStore';
@@ -270,7 +270,7 @@ export const GuildSuggestions = ({ speciesId, onSelectCompanion }) => {
               estrato: defaults.estrato,
               companions: companions.map((c) => c.name),
               antagonists: antagonists.map((a) => a.name),
-              thermalZones: FARM_CONFIG.THERMAL_ZONES || [],
+              ...getContextoGeoParaIA(),
               speciesThermalZones,
               altitudMsnm: defaults.altitud_msnm?.optimo_min,
             }}

--- a/src/components/InvasiveObservationLog.jsx
+++ b/src/components/InvasiveObservationLog.jsx
@@ -7,7 +7,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { ArrowLeft, AlertCircle, CheckCircle } from 'lucide-react';
 import { savePayload } from '../services/payloadService';
 import { getAllSpecies } from '../db/catalogDB';
-import { FARM_CONFIG } from '../config/defaults';
+import { getContextoGeoFinca } from '../services/perfilFincaService';
 import PhotoCaptureField from './PhotoCaptureField';
 import NativeSubstituteSuggestion from './NativeSubstituteSuggestion';
 import GeolocationButton from './GeolocationButton';
@@ -16,7 +16,7 @@ import { PEST_STATUSES } from '../constants/assetStatuses';
 
 // Autopilot D (2026-05-03): ordena especies invasoras por relevancia al
 // piso térmico del operador. Las que reportan thermal_zones que matchean
-// FARM_CONFIG.THERMAL_ZONES van primero. Reduce friction visual cuando
+// del piso térmico de la finca (perfil) van primero. Reduce friction visual cuando
 // hay 50+ invasoras en catálogo y solo 5-10 son relevantes a la altitud.
 function sortByThermalRelevance(species, userZones) {
     if (!Array.isArray(userZones) || userZones.length === 0) {
@@ -80,21 +80,25 @@ export default function InvasiveObservationLog({ onBack, onSave, initialLocation
         return () => { cancelled = true; };
     }, []);
 
+    /* El piso térmico sale del PERFIL de la finca (lo que ubicó en el
+       onboarding); VITE_FARM_THERMAL_ZONES queda solo de default de demo. */
+    const userThermalZones = useMemo(() => getContextoGeoFinca().thermalZones, []);
+
     // Lista ordenada por relevancia al piso térmico del operador (Autopilot D).
     const sortedSpeciesList = useMemo(
-        () => sortByThermalRelevance(speciesList, FARM_CONFIG.THERMAL_ZONES),
-        [speciesList]
+        () => sortByThermalRelevance(speciesList, userThermalZones),
+        [speciesList, userThermalZones]
     );
 
     // Cuántas matchean exactamente el piso térmico (para mostrar badge contextual).
     const thermalMatchCount = useMemo(() => {
-        if (!Array.isArray(FARM_CONFIG.THERMAL_ZONES) || FARM_CONFIG.THERMAL_ZONES.length === 0) return 0;
-        const userZoneSet = new Set(FARM_CONFIG.THERMAL_ZONES);
+        if (!Array.isArray(userThermalZones) || userThermalZones.length === 0) return 0;
+        const userZoneSet = new Set(userThermalZones);
         return speciesList.filter((sp) => {
             const spZones = Array.isArray(sp.thermal_zones) ? sp.thermal_zones : [];
             return spZones.some((z) => userZoneSet.has(z));
         }).length;
-    }, [speciesList]);
+    }, [speciesList, userThermalZones]);
 
     const handleInput = (e) => {
         const { name, value } = e.target;
@@ -266,7 +270,7 @@ export default function InvasiveObservationLog({ onBack, onSave, initialLocation
                                 <option value="">Selecciona especie…</option>
                                 {sortedSpeciesList.map((s) => {
                                     const spZones = Array.isArray(s.thermal_zones) ? s.thermal_zones : [];
-                                    const userZones = FARM_CONFIG.THERMAL_ZONES || [];
+                                    const userZones = userThermalZones;
                                     const isRelevant = userZones.length > 0 && spZones.some((z) => userZones.includes(z));
                                     return (
                                         <option key={s.id} value={s.id}>
@@ -279,7 +283,7 @@ export default function InvasiveObservationLog({ onBack, onSave, initialLocation
                     </select>
                     {catalogStatus === 'ready' && thermalMatchCount > 0 && (
                         <p className="text-xs text-slate-500 mt-1">
-                            ★ marca {thermalMatchCount} especies relevantes a tu piso térmico ({(FARM_CONFIG.THERMAL_ZONES || []).join(', ')})
+                            ★ marca {thermalMatchCount} especies relevantes a tu piso térmico ({userThermalZones.join(', ')})
                         </p>
                     )}
                     {catalogStatus === 'error' && (

--- a/src/components/OnboardingCondensado.jsx
+++ b/src/components/OnboardingCondensado.jsx
@@ -28,12 +28,14 @@ import {
 import { getDepartamentos, getMunicipios } from '../utils/colombiaLocations';
 import {
   PROFILE_QUESTIONS,
+  INVERNADERO_FORMAS,
   getProfile,
   saveProfile,
   markProfileDone,
   markProfileSkipped,
   resolveAltitudToSave,
 } from '../services/userProfileService';
+import usePerfilFincaStore from '../store/usePerfilFincaStore';
 
 /**
  * OnboardingCondensado — la reescritura del onboarding (spec 2026-07-08).
@@ -73,7 +75,41 @@ import {
  *   - onExplorarEjemplo(): SKIP rico → finca de ejemplo (opcional).
  */
 
-const PASOS = ['identidad', 'ubicacion', 'finca', 'listo'];
+const PASOS = ['identidad', 'ubicacion', 'finca', 'escala', 'invernadero', 'agua', 'listo'];
+
+const ESCALAS_TARJETAS = [
+  {
+    id: 'balcon',
+    emoji: '🪴',
+    titulo: 'Un rincón con matas',
+    copy: 'Una mata o varias materas en balcón, terraza o patio',
+  },
+  {
+    id: 'invernadero',
+    emoji: '🏠',
+    titulo: 'Un invernadero',
+    copy: 'El cultivo protegido es el centro de su finca',
+  },
+  {
+    id: 'finca',
+    emoji: '🌄',
+    titulo: 'Una finca o cultivo abierto',
+    copy: 'Desde un lote pequeño hasta 10.000 matas o más',
+  },
+];
+
+const INVERNADEROS_TARJETAS = [
+  { id: 'cuadrado', emoji: '⬜', titulo: 'Cuadrado', copy: 'Techo a dos aguas' },
+  { id: 'tunel', emoji: '🌙', titulo: 'Túnel', copy: 'Plástico curvo en media luna' },
+  { id: 'casa_sombra', emoji: '🪟', titulo: 'Casa malla', copy: 'Paredes y techo de malla' },
+].filter((opcion) => INVERNADERO_FORMAS.includes(opcion.id));
+
+const AGUAS_TARJETAS = [
+  { id: 'quebrada', emoji: '🏞️', titulo: 'Quebrada', copy: 'El agua llega de una corriente' },
+  { id: 'tanque', emoji: '🛢️', titulo: 'Tanque', copy: 'La guarda en tanque o reservorio' },
+  { id: 'lluvia', emoji: '🌧️', titulo: 'Lluvia', copy: 'Cultiva con lluvia o agua recogida' },
+  { id: 'acueducto', emoji: '🚰', titulo: 'Acueducto', copy: 'El agua llega por tubería' },
+];
 
 /**
  * Tarjetas de identidad: UNA elección que fusiona vocacion + rol + finca_tipo
@@ -274,6 +310,41 @@ function FilaDato({ emoji, label, children }) {
   );
 }
 
+/** Opciones grandes y concretas para sembrar una respuesta en el valle. */
+function TarjetasPregunta({ opciones, seleccion, onSelect, testId }) {
+  return (
+    <div className="grid grid-cols-1 gap-2.5">
+      {opciones.map((opcion, i) => {
+        const seleccionada = seleccion === opcion.id;
+        return (
+          <button
+            key={opcion.id}
+            type="button"
+            aria-pressed={seleccionada}
+            onClick={() => onSelect(opcion.id)}
+            className={`anim-brota w-full flex items-center gap-3.5 text-left px-4 py-3.5 min-h-[72px] rounded-2xl border transition-all active:scale-[0.99] ${
+              seleccionada
+                ? 'bg-emerald-900/40 border-emerald-500 ring-1 ring-emerald-500/40 text-white'
+                : 'bg-slate-900 border-slate-700 text-slate-200 hover:border-slate-500'
+            }`}
+            style={{ '--i': i + 1 }}
+            data-testid={`${testId}-${opcion.id}`}
+          >
+            <span className="text-3xl leading-none shrink-0" aria-hidden="true">
+              {opcion.emoji}
+            </span>
+            <span className="min-w-0">
+              <span className="block text-base font-black leading-tight">{opcion.titulo}</span>
+              <span className="block text-sm text-slate-400">{opcion.copy}</span>
+            </span>
+            {seleccionada ? <Check size={18} className="ml-auto text-emerald-400 shrink-0" /> : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export default function OnboardingCondensado({
   onComplete,
   onClose = undefined,
@@ -309,6 +380,29 @@ export default function OnboardingCondensado({
     Array.isArray(perfilInicial.animales) ? perfilInicial.animales : [],
   );
   const [cultivos, setCultivos] = useState(perfilInicial.cultivos_actuales || '');
+
+  // ── Pasos 4 a 6: lo que siembra la forma del valle ────────────────────
+  const setEscalaPerfil = usePerfilFincaStore((s) => s.setEscala);
+  const setInvernaderoPerfil = usePerfilFincaStore((s) => s.setInvernadero);
+  const setAguaPerfil = usePerfilFincaStore((s) => s.setAgua);
+  const [escala, setEscala] = useState(
+    ['balcon', 'invernadero', 'finca'].includes(perfilInicial.escala)
+      ? perfilInicial.escala
+      : null,
+  );
+  const invernaderoInicial = perfilInicial.invernadero_tiene === 'si'
+    || perfilInicial.finca_tipo === 'invernadero';
+  const [tieneInvernadero, setTieneInvernadero] = useState(
+    perfilInicial.invernadero_tiene === 'no' ? false : (invernaderoInicial ? true : null),
+  );
+  const [tipoInvernadero, setTipoInvernadero] = useState(
+    INVERNADERO_FORMAS.includes(perfilInicial.invernadero_forma)
+      ? perfilInicial.invernadero_forma
+      : null,
+  );
+  const [agua, setAgua] = useState(
+    AGUAS_TARJETAS.some((opcion) => opcion.id === perfilInicial.agua) ? perfilInicial.agua : null,
+  );
 
   const manualAltitudNum = useMemo(() => {
     const t = manualAltitud.trim();
@@ -498,6 +592,26 @@ export default function OnboardingCondensado({
     setPaso(3);
   };
 
+  const avanzarDesdeEscala = () => {
+    if (!escala) return;
+    setEscalaPerfil(escala);
+    if (escala === 'invernadero') setTieneInvernadero(true);
+    setPaso(4);
+  };
+
+  const avanzarDesdeInvernadero = () => {
+    if (tieneInvernadero == null) return;
+    if (tieneInvernadero && !tipoInvernadero) return;
+    setInvernaderoPerfil(tieneInvernadero ? { tipo: tipoInvernadero } : null);
+    setPaso(5);
+  };
+
+  const avanzarDesdeAgua = () => {
+    if (!agua) return;
+    setAguaPerfil(agua);
+    setPaso(6);
+  };
+
   const atras = () => {
     if (paso === 0) onClose?.();
     else setPaso((p) => p - 1);
@@ -511,6 +625,9 @@ export default function OnboardingCondensado({
     'Cuéntenos de usted. Su nombre, y qué hace en el campo.',
     'Ubiquemos su finca. Con un toque sabemos su vereda, su altura y su clima. Si algo sale mal, lo corrige ahí mismo.',
     '¿Qué tiene en su finca? Marque lo que tenga. El detalle lo vamos llenando con la voz.',
+    '¿Qué tan grande es su cultivo? Escoja el espacio que más se parece al suyo.',
+    '¿Tiene invernadero? Si tiene, escoja la forma que más se parece al suyo.',
+    '¿De dónde llega el agua que usa en su cultivo?',
     'Su finca está lista. El consejo le va a llegar acertado para su clima.',
   ];
 
@@ -520,7 +637,7 @@ export default function OnboardingCondensado({
       <div className="w-full max-w-md mx-auto flex items-center justify-between gap-3">
         <div className="flex-1 min-w-0">
           <p className="text-[11px] font-bold uppercase tracking-widest text-slate-400">
-            {paso < 3 ? `Paso ${paso + 1} de 3` : '¡Listo!'}
+            {paso < 6 ? `Paso ${paso + 1} de 6` : '¡Listo!'}
           </p>
           {/* La costura: la firma "cada dato va cosido a su fuente". */}
           <div className="bienvenida-costura" aria-hidden="true">
@@ -531,7 +648,7 @@ export default function OnboardingCondensado({
             />
           </div>
         </div>
-        {paso < 3 && (
+        {paso < 6 && (
           <button
             type="button"
             onClick={saltarTodo}
@@ -931,8 +1048,116 @@ export default function OnboardingCondensado({
           </>
         )}
 
-        {/* ═══ LISTO ═══ */}
+        {/* ═══ PASO 4: ESCALA DEL MUNDO ═══ */}
         {paso === 3 && (
+          <>
+            <div className="flex flex-col gap-1.5">
+              <p className="text-[11px] uppercase tracking-widest font-bold text-emerald-400/90">
+                El tamaño de su valle
+              </p>
+              <h1 className="text-2xl font-black leading-tight text-slate-100">
+                ¿Qué tan grande es su cultivo?
+              </h1>
+              <p className="text-sm text-slate-400">
+                Escoja el espacio que más se parece al suyo. Así verá un valle de su tamaño.
+              </p>
+            </div>
+            <TarjetasPregunta
+              opciones={ESCALAS_TARJETAS}
+              seleccion={escala}
+              onSelect={setEscala}
+              testId="onb2-escala"
+            />
+          </>
+        )}
+
+        {/* ═══ PASO 5: INVERNADERO Y FORMA ═══ */}
+        {paso === 4 && (
+          <>
+            <div className="flex flex-col gap-1.5">
+              <p className="text-[11px] uppercase tracking-widest font-bold text-emerald-400/90">
+                Una pieza de su finca
+              </p>
+              <h1 className="text-2xl font-black leading-tight text-slate-100">
+                {escala === 'invernadero' ? '¿Cómo es su invernadero?' : '¿Tiene invernadero?'}
+              </h1>
+              <p className="text-sm text-slate-400">
+                {escala === 'invernadero'
+                  ? 'Escoja la forma que más se parece al suyo.'
+                  : 'Si tiene uno, lo sembraremos con su forma en el valle.'}
+              </p>
+            </div>
+
+            {escala !== 'invernadero' ? (
+              <div className="grid grid-cols-2 gap-2.5" role="group" aria-label="¿Tiene invernadero?">
+                <button
+                  type="button"
+                  aria-pressed={tieneInvernadero === true}
+                  onClick={() => setTieneInvernadero(true)}
+                  className={`min-h-[64px] rounded-2xl border px-3 font-bold transition-colors ${
+                    tieneInvernadero === true
+                      ? 'bg-emerald-900/40 border-emerald-500 text-white'
+                      : 'bg-slate-900 border-slate-700 text-slate-300'
+                  }`}
+                  data-testid="onb2-invernadero-si"
+                >
+                  Sí, tengo uno
+                </button>
+                <button
+                  type="button"
+                  aria-pressed={tieneInvernadero === false}
+                  onClick={() => {
+                    setTieneInvernadero(false);
+                    setTipoInvernadero(null);
+                  }}
+                  className={`min-h-[64px] rounded-2xl border px-3 font-bold transition-colors ${
+                    tieneInvernadero === false
+                      ? 'bg-emerald-900/40 border-emerald-500 text-white'
+                      : 'bg-slate-900 border-slate-700 text-slate-300'
+                  }`}
+                  data-testid="onb2-invernadero-no"
+                >
+                  No tengo
+                </button>
+              </div>
+            ) : null}
+
+            {tieneInvernadero === true ? (
+              <TarjetasPregunta
+                opciones={INVERNADEROS_TARJETAS}
+                seleccion={tipoInvernadero}
+                onSelect={setTipoInvernadero}
+                testId="onb2-invernadero-tipo"
+              />
+            ) : null}
+          </>
+        )}
+
+        {/* ═══ PASO 6: FUENTE DE AGUA ═══ */}
+        {paso === 5 && (
+          <>
+            <div className="flex flex-col gap-1.5">
+              <p className="text-[11px] uppercase tracking-widest font-bold text-emerald-400/90">
+                El agua de su finca
+              </p>
+              <h1 className="text-2xl font-black leading-tight text-slate-100">
+                ¿De dónde llega el agua?
+              </h1>
+              <p className="text-sm text-slate-400">
+                Escoja la fuente que más usa. El agua de su valle saldrá de ahí.
+              </p>
+            </div>
+            <TarjetasPregunta
+              opciones={AGUAS_TARJETAS}
+              seleccion={agua}
+              onSelect={setAgua}
+              testId="onb2-agua"
+            />
+          </>
+        )}
+
+        {/* ═══ LISTO ═══ */}
+        {paso === 6 && (
           <div className="flex-1 flex flex-col items-center justify-center text-center gap-5">
             <ChagraAgentAvatarAngelita size={168} state="speaking" ariaLabel="Angelita, la abeja de Chagra" />
             <div className="flex flex-col gap-2">
@@ -971,7 +1196,7 @@ export default function OnboardingCondensado({
         )}
 
         <div className="flex items-center gap-3">
-          {paso > 0 && paso < 3 && (
+          {paso > 0 && paso < 6 && (
             <button
               type="button"
               onClick={atras}
@@ -1023,6 +1248,39 @@ export default function OnboardingCondensado({
             </button>
           )}
           {paso === 3 && (
+            <button
+              type="button"
+              onClick={avanzarDesdeEscala}
+              disabled={!escala}
+              className="onboarding-piso-primary !w-auto px-6 disabled:opacity-50"
+              data-testid="onb2-guardar-escala"
+            >
+              Siguiente <ArrowRight size={20} aria-hidden="true" />
+            </button>
+          )}
+          {paso === 4 && (
+            <button
+              type="button"
+              onClick={avanzarDesdeInvernadero}
+              disabled={tieneInvernadero == null || (tieneInvernadero && !tipoInvernadero)}
+              className="onboarding-piso-primary !w-auto px-6 disabled:opacity-50"
+              data-testid="onb2-guardar-invernadero"
+            >
+              Siguiente <ArrowRight size={20} aria-hidden="true" />
+            </button>
+          )}
+          {paso === 5 && (
+            <button
+              type="button"
+              onClick={avanzarDesdeAgua}
+              disabled={!agua}
+              className="onboarding-piso-primary !w-auto px-6 disabled:opacity-50"
+              data-testid="onb2-guardar-agua"
+            >
+              Sembrar mi valle <ArrowRight size={20} aria-hidden="true" />
+            </button>
+          )}
+          {paso === 6 && (
             <button
               type="button"
               onClick={terminar}

--- a/src/components/OnboardingHero.jsx
+++ b/src/components/OnboardingHero.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Camera, Mic, Pencil, MapPin, Check } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
-import { FARM_CONFIG } from '../config/defaults';
+import { getContextoGeoFinca } from '../services/perfilFincaService';
 import { getProfile, saveProfile } from '../services/userProfileService';
 import { getPisoTermicoInfo } from '../services/locationService';
 import { useAutosave } from '../hooks/useAutosave';
@@ -21,9 +21,9 @@ import { MSG } from '../config/messages.js';
  *
  * Adaptive (Autopilot 2026-05-06): el copy del header se ajusta al contexto
  * detectado del operador para reducir ambigüedad cold-start:
- *   - Sin zonas creadas Y sin FARM_CONFIG → "primera vez en Chagra"
+ *   - Sin zonas creadas Y sin contexto de finca → "primera vez en Chagra"
  *   - Con zonas pero sin plantas → "ya tienes zonas listas, falta la primera planta"
- *   - Sin zonas pero con FARM_CONFIG → "tu finca está configurada"
+ *   - Sin zonas pero con contexto de finca → "tu finca está configurada"
  *
  * Piso térmico primero (feat/onboarding-ayuda): la altitud es el FILTRO
  * MAESTRO de todos los módulos (suelo/agua/animal/restauración/clima).
@@ -47,7 +47,8 @@ import { MSG } from '../config/messages.js';
 export default function OnboardingHero({ onNavigate, compact = false }) {
   const lands = useAssetStore((s) => s.lands);
   const hasZones = lands.length > 0;
-  const hasFarmContext = !!(FARM_CONFIG.ALTITUD_MSNM || (FARM_CONFIG.THERMAL_ZONES || []).length > 0);
+  const geoFinca = getContextoGeoFinca();
+  const hasFarmContext = !!(geoFinca.altitudMsnm || geoFinca.thermalZones.length > 0);
 
   const { savedState: obState, save: obSave } = useAutosave('onboarding-hero', { lastCta: null, pisoConfirmed: false });
   const [profile] = useState(() => getProfile());

--- a/src/components/PestMonitoringWindow.jsx
+++ b/src/components/PestMonitoringWindow.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Bug } from 'lucide-react';
 import { lunarPhase } from '../utils/skyEphemeris';
 import { pestMonitoringMessage } from '../services/lunarPestService';
-import { FARM_CONFIG } from '../config/defaults';
+import { getContextoGeoFinca } from '../services/perfilFincaService';
 
 /**
  * PestMonitoringWindow, Feature C.1 ADR-033.
@@ -50,7 +50,7 @@ export default function PestMonitoringWindow() {
 }
 
 function computeMessage() {
-  const lat = FARM_CONFIG.LATITUDE ?? 0;
+  const lat = getContextoGeoFinca().lat ?? 0;
   const lunar = lunarPhase(new Date(), { latitude: lat });
   return pestMonitoringMessage(lunar);
 }

--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -3,6 +3,7 @@ import { MSG } from '../config/messages.js';
 import { Info } from 'lucide-react';
 import { assetCache } from '../db/assetCache';
 import { FARM_CONFIG } from '../config/defaults';
+import { getContextoGeoParaIA } from '../services/perfilFincaService';
 import AIStreamPanel from './common/AIStreamPanel';
 import IoTSensorCard from './IoTSensorCard';
 import ChagraGrowLoader from './ChagraGrowLoader';
@@ -823,9 +824,7 @@ export default function TelemetryAlerts() {
                 label="Copiar prompt para IA externa"
                 context={{
                   speciesName: 'cultivo en monitoreo',
-                  altitudMsnm: FARM_CONFIG.ALTITUD_MSNM,
-                  municipio: FARM_CONFIG.MUNICIPIO,
-                  thermalZones: FARM_CONFIG.THERMAL_ZONES || [],
+                  ...getContextoGeoParaIA(),
                   speciesThermalZones: [],
                   sintomas: aiAlert || '',
                 }}

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -1,5 +1,18 @@
 const DEMO_MODE = import.meta.env.VITE_DEMO_MODE === 'true';
 
+/*
+ * OJO — LA UBICACIÓN DE LA FINCA YA NO SE LEE DE AQUÍ.
+ *
+ * `VITE_FARM_LAT` / `VITE_FARM_LON` / `VITE_FARM_ALTITUD_MSNM` /
+ * `VITE_FARM_MUNICIPIO` / `VITE_FARM_THERMAL_ZONES` son variables de BUILD:
+ * describen la finca de DEMO, no la del usuario. El onboarding
+ * (OnboardingCondensado, paso 2) captura la ubicación REAL — GPS → municipio
+ * DANE → altitud → piso térmico → vereda — y la guarda en el perfil.
+ *
+ * Quien necesite "dónde está la finca" debe pedir
+ * `getContextoGeoFinca()` (services/perfilFincaService), que hace la cascada
+ * honesta perfil → demo. Estas constantes quedan como ÚLTIMO recurso de demo.
+ */
 export const FARM_CONFIG = {
   LOCATION_ID: import.meta.env.VITE_DEFAULT_LOCATION_ID || '',
   // eslint-disable-next-line chagra-i18n/no-hardcoded-spanish -- fallback de config build-time preexistente (no es copy de UI); el hook lo marca al re-tocar el archivo

--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -34,14 +34,18 @@ import '../visual/effects/effects.css';
 import './entradaValle3D.css';
 import MinimapaValle from './valle/MinimapaValle.jsx';
 import { componerMundos } from '../visual/mundo3d/direccion/composicionValle.js';
-import { MUNDOS_VALLE } from './valle/valleData.js';
+import { construirMundosValle, indexarMundosValle } from './valle/valleData.js';
 import {
-  MUNDO_VALLE_BY_ID,
   COSA_DEL_DIA,
   CLIMAS,
   animoDeFinca,
   NARRACION,
 } from './valle/valleData';
+/* EL VALLE DINÁMICO (spec paso 1-2): el valle se arma del PERFIL DE LA FINCA
+   — si tiene balcón, su valle es un balcón; si tiene 10.000 matas, es el valle
+   completo. Sin perfil, el store entrega el perfil de demo y esto es idéntico
+   al valle de siempre. */
+import usePerfilFincaStore from '../store/usePerfilFincaStore.js';
 /* El reloj del ciclo diurno vivo (franja real del día + override ?ciclo=). */
 import useCicloDia from '../visual/mundo3d/useCicloDia.js';
 import Valle2DFallback from './valle/Valle2DFallback';
@@ -71,7 +75,7 @@ import { TunelLamina, rectDeOrigen, VeloOdyssey } from '../visual/mundo3d/transi
 // La escena 3D pesada (three/fiber/drei) en su PROPIO chunk perezoso.
 const Valle3D = lazy(() => import('./valle/Valle3D'));
 /* Los lugares del valle en planta, para el minimapa RTS (AoE). */
-const LUGARES_MINIMAPA = componerMundos(MUNDOS_VALLE).map((m) => ({
+const lugaresDeMinimapa = (mundosDir) => mundosDir.map((m) => ({
   id: m.id, x: m.pos[0], z: m.pos[2], emoji: m.emoji, tinte: m.tinte, nombre: m.nombre,
 }));
 
@@ -124,6 +128,17 @@ class Valle3DGuard extends Component {
  */
 /** @param {{ onBack?: () => void; onNavigate?: (view: string, data?: any) => void; initialMundoId?: any }} props */
 export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = null }) {
+  /* SU VALLE, NO UN VALLE: los lugares se siembran del perfil de la finca. El
+     store se rehidrata solo cuando el onboarding ubica la finca, así que el
+     valle se ajusta sin recargar. Perfil vacío = el valle completo de siempre. */
+  const perfilFinca = usePerfilFincaStore((s) => s.perfil);
+  const mundosValle = useMemo(() => construirMundosValle(perfilFinca), [perfilFinca]);
+  /* La capa del DIRECTOR sigue mandando el DÓNDE (COMPOSICION_LUGARES): la
+     siembra decide qué hay, el director decide dónde va. */
+  const mundosDir = useMemo(() => componerMundos(mundosValle), [mundosValle]);
+  const mundoValleById = useMemo(() => indexarMundosValle(mundosValle), [mundosValle]);
+  const lugaresMinimapa = useMemo(() => lugaresDeMinimapa(mundosDir), [mundosDir]);
+
   const [focoId, setFocoId] = useState(null);
   const [panel, setPanel] = useState(null); // null | 'alerta' | <mundoId>
   const [voz, setVoz] = useState(true);
@@ -349,9 +364,9 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
     (id) => {
       setFocoId(id);
       setPanel(id);
-      decir(NARRACION[id] || MUNDO_VALLE_BY_ID[id]?.lema || '');
+      decir(NARRACION[id] || mundoValleById[id]?.lema || '');
     },
-    [decir],
+    [decir, mundoValleById],
   );
 
   // ── ABRIR la pantalla real de un lugar: el túnel recibe el cambio de hash
@@ -462,14 +477,14 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
     const texto =
       (clave && NARRACION[clave]) ||
       NARRACION[nav.mundoId] ||
-      MUNDO_VALLE_BY_ID[nav.mundoId]?.lema ||
+      mundoValleById[nav.mundoId]?.lema ||
       `Está en ${tituloDeMundo(nav.mundoId)}.`;
     const t = setTimeout(
       () => decir(`${texto} Toque un punto para ver a dónde lo lleva.`),
       700,
     );
     return () => clearTimeout(t);
-  }, [nav.enMundo, nav.mundoId, decir]);
+  }, [nav.enMundo, nav.mundoId, decir, mundoValleById]);
 
   // ── Una puerta tocada DENTRO del mundo: en la vitrina (sin sesión) no
   //    navega — ANGELITA la nombra (voz + burbuja) y asiente: el agente
@@ -496,7 +511,7 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
     [nav.mundoId, decir, asentir, onNavigate],
   );
 
-  const mundoPanel = panel && panel !== 'alerta' ? MUNDO_VALLE_BY_ID[panel] : null;
+  const mundoPanel = panel && panel !== 'alerta' ? mundoValleById[panel] : null;
   // ¿Este lugar tiene pantalla real en la app? (wire3DNav). Decide el CTA
   // primario del panel: abrir la pantalla manda; recorrer el 3D acompaña.
   const rutaPanel = mundoPanel ? rutaDesdeMundo3D(mundoPanel.id) : null;
@@ -521,6 +536,7 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
                   onEntrar={entrarMundo}
                   onAlerta={abrirAlerta}
                   webglBloqueado={valle3dError || equipo.motivo === 'sin-webgl'}
+                  mundos={mundosValle}
                 />
               )}
             >
@@ -542,6 +558,7 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
                    que presenta el valle vivo. Gateada por tier/reduced-motion
                    adentro; una sola vez por sesión. */
                 camaraDirector
+                mundos={mundosDir}
               />
               {/* Dispara el cruce 2D→3D cuando el chunk 3D del valle resolvió
                   (hermano de <Valle3D> en el Suspense). DOM puro, sin three. */}
@@ -552,7 +569,7 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
         {/* AoE: el minimapa RTS del valle (planta, blips, salto-a-lugar) — solo con el valle a la vista */}
         {!nav.enMundo && (
           <MinimapaValle
-            lugares={LUGARES_MINIMAPA}
+            lugares={lugaresMinimapa}
             foco={focoId}
             onSaltar={entrarMundo}
             tier={equipo.tier}

--- a/src/mockups/VitrinaMaestraMundos.jsx
+++ b/src/mockups/VitrinaMaestraMundos.jsx
@@ -88,6 +88,8 @@ import {
   calidadDeTier,
 } from '../visual/mundo3d/bosque/floraParamo.geom.js';
 import { rng } from '../visual/mundo3d/bosque/entQuenua.geom.js';
+import usePerfilFincaStore from '../store/usePerfilFincaStore.js';
+import { COPY_VITRINA_PERFIL, estadoMundoVitrina } from './vitrinaPerfil.js';
 
 /* EL VALLE VIVO en la galería: los personajes asoman ENTRE los mundos, desde
    los bordes (nunca sobre los portales ni el chrome), hacen su giño lejano y
@@ -690,7 +692,7 @@ function ArcosPiedra({ tier }) {
   return <instancedMesh ref={ref} args={[geo, MAT_PAISAJE, PORTALES.length]} frustumCulled={false} />;
 }
 
-function PortalMundo({ portal, elegido, interactivo, tier, onElegir, onSenalar }) {
+function PortalMundo({ portal, elegido, interactivo, tier, estado, onElegir, onSenalar }) {
   const halo = useRef(null);
   const q = calidadDeTier(tier);
   const geoVineta = useMemo(() => geomVineta(portal.id, { q }), [portal.id, q]);
@@ -753,6 +755,14 @@ function PortalMundo({ portal, elegido, interactivo, tier, onElegir, onSenalar }
           emissiveIntensity={0.32}
         />
       </mesh>
+      <mesh position={[0, 0, 0.06]}>
+        <torusGeometry args={[0.9, estado === 'conocer' ? 0.025 : 0.04, 5, 26]} />
+        <meshBasicMaterial
+          color={estado === 'propio' ? '#3f8f4e' : estado === 'agregado' ? '#397f9f' : '#d49a35'}
+          transparent
+          opacity={estado === 'conocer' ? 0.72 : 0.95}
+        />
+      </mesh>
       {/* la VENTANA ENTERA es el botón: blanco de toque invisible y generoso */}
       <mesh position={[0, 0, 0.1]} onClick={alTocar} onPointerOver={manito} onPointerOut={normal}>
         <circleGeometry args={[0.95, 18]} />
@@ -766,7 +776,7 @@ function PortalMundo({ portal, elegido, interactivo, tier, onElegir, onSenalar }
    GALERÍA — la montaña completa con las cuatro terrazas de pisos térmicos
    ══════════════════════════════════════════════════════════════════════════ */
 
-function GaleriaVitrina({ elegidoId, interactivo, tier, reducedMotion, onElegir, onSenalar }) {
+function GaleriaVitrina({ elegidoId, interactivo, tier, reducedMotion, estados, onElegir, onSenalar }) {
   const animada = !reducedMotion;
   return (
     <group>
@@ -796,6 +806,7 @@ function GaleriaVitrina({ elegidoId, interactivo, tier, reducedMotion, onElegir,
           elegido={elegidoId === p.id}
           interactivo={interactivo}
           tier={tier}
+          estado={estados[p.id] || 'conocer'}
           onElegir={onElegir}
           onSenalar={onSenalar}
         />
@@ -943,6 +954,48 @@ const CSS_VMX = `
 }
 .vmx-chip:hover, .vmx-chip:focus-visible { background: #fff8ea; transform: translateY(-2px); }
 .vmx-chip:active { transform: translateY(0); }
+.vmx-chip-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px;
+  border-radius: 999px;
+  background: rgba(255, 249, 235, 0.54);
+}
+.vmx-chip-wrap[data-estado='propio'] { box-shadow: inset 0 0 0 2px rgba(63,143,78,0.7); }
+.vmx-chip-wrap[data-estado='agregado'] { box-shadow: inset 0 0 0 2px rgba(57,127,159,0.75); }
+.vmx-estado {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  border: 0;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.72rem;
+  font-weight: 850;
+  white-space: nowrap;
+}
+.vmx-estado--propio { background: #dcebd9; color: #285f34; }
+.vmx-estado--agregado { background: #d9ebf0; color: #285f76; cursor: pointer; }
+.vmx-estado--conocer { background: #f5dfae; color: #674612; cursor: pointer; }
+.vmx-estado:focus-visible { outline: 3px solid #fff8ea; outline-offset: 2px; }
+.vmx-leyenda {
+  align-self: center;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 7px 12px;
+  border-radius: 14px;
+  background: rgba(255,249,235,0.9);
+  color: #4a3520;
+  font-size: 0.76rem;
+  font-weight: 750;
+  box-shadow: 0 3px 12px rgba(58,42,24,0.14);
+}
+.vmx-leyenda b:first-child { color: #285f34; }
+.vmx-leyenda b:last-child { color: #805814; }
 
 /* viñeta de succión durante el dolly */
 .vmx-vineta {
@@ -1039,6 +1092,20 @@ const CSS_VMX = `
   box-shadow: 0 4px 12px rgba(58, 42, 24, 0.22);
   transition: transform 140ms ease;
 }
+.vmx-tarjeta[data-estado='propio'] { box-shadow: 0 0 0 4px #dcebd9, 0 5px 14px rgba(58,42,24,0.24); }
+.vmx-tarjeta[data-estado='agregado'] { box-shadow: 0 0 0 4px #d9ebf0, 0 5px 14px rgba(58,42,24,0.24); }
+.vmx-tarjeta__entrada {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  font: inherit;
+  cursor: pointer;
+}
 .vmx-tarjeta:hover, .vmx-tarjeta:focus-visible { transform: translateY(-3px); }
 .vmx-tarjeta__aro {
   width: 84px;
@@ -1090,6 +1157,34 @@ const CSS_VMX = `
 }
 `;
 
+function AccionMundo({ estado, titulo, onAgregar, onQuitar }) {
+  if (estado === 'propio') {
+    return <span className="vmx-estado vmx-estado--propio">✓ Está en su finca</span>;
+  }
+  if (estado === 'agregado') {
+    return (
+      <button
+        type="button"
+        className="vmx-estado vmx-estado--agregado"
+        onClick={onQuitar}
+        aria-label={`Quitar ${titulo} de los mundos agregados`}
+      >
+        ✓ Agregado para conocer
+      </button>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className="vmx-estado vmx-estado--conocer"
+      onClick={onAgregar}
+      aria-label={COPY_VITRINA_PERFIL.ariaAgregar(titulo)}
+    >
+      {COPY_VITRINA_PERFIL.agregar}
+    </button>
+  );
+}
+
 /* ══════════════════════════════════════════════════════════════════════════
    EL MOCKUP — la máquina de fases del cruce maestro
    ══════════════════════════════════════════════════════════════════════════ */
@@ -1107,6 +1202,9 @@ const CSS_VMX = `
  */
 export default function VitrinaMaestraMundos({ onBack }) {
   const [{ tier, reducedMotion }] = useState(() => decidirTier());
+  const perfilFinca = usePerfilFincaStore((s) => s.perfil);
+  const agregarMundo = usePerfilFincaStore((s) => s.agregarMundo);
+  const quitarMundo = usePerfilFincaStore((s) => s.quitarMundo);
   /* EL CENTRAL MANDA: el avatar que la persona eligió (perfil/onboarding) es
      el protagonista de la vitrina — grande, pleno, al frente. Sin elección el
      hook cae a Angelita. El coro ambiental lo excluye del elenco. */
@@ -1117,6 +1215,11 @@ export default function VitrinaMaestraMundos({ onBack }) {
   const [mundoId, setMundoId] = useState(null);
   const [senalado, setSenalado] = useState(null);
   const [listo, setListo] = useState(false);
+
+  const estados = useMemo(
+    () => Object.fromEntries(PORTALES.map((p) => [p.id, estadoMundoVitrina(p.id, perfilFinca)])),
+    [perfilFinca],
+  );
 
   const sinCanvas = !permite3D(tier);
   const portal = mundoId ? PORTAL_POR_ID[mundoId] : null;
@@ -1200,6 +1303,7 @@ export default function VitrinaMaestraMundos({ onBack }) {
             interactivo={enGaleria}
             tier={tier}
             reducedMotion={reducedMotion}
+            estados={estados}
             onElegir={elegir}
             onSenalar={senalar}
           />
@@ -1221,23 +1325,35 @@ export default function VitrinaMaestraMundos({ onBack }) {
               </h3>
               <div className="vmx-piso__grid" role="list">
                 {piso.mundos.map((p) => (
-                  <button
+                  <article
                     key={p.id}
-                    type="button"
                     role="listitem"
                     className="vmx-tarjeta"
+                    data-estado={estados[p.id]}
                     style={{ background: `linear-gradient(160deg, ${p.colorA} 0%, ${p.colorB} 100%)` }}
-                    onClick={() => elegir(p.id)}
                   >
-                    <span
-                      className="vmx-tarjeta__aro"
-                      aria-hidden="true"
-                      style={{ background: `radial-gradient(circle at 50% 30%, ${p.colorA} 0%, ${p.colorB} 85%)` }}
+                    <button
+                      type="button"
+                      className="vmx-tarjeta__entrada"
+                      onClick={() => elegir(p.id)}
+                      aria-label={`Entrar a ${p.titulo}`}
                     >
-                      <span>{p.emoji}</span>
-                    </span>
-                    {p.titulo}
-                  </button>
+                      <span
+                        className="vmx-tarjeta__aro"
+                        aria-hidden="true"
+                        style={{ background: `radial-gradient(circle at 50% 30%, ${p.colorA} 0%, ${p.colorB} 85%)` }}
+                      >
+                        <span>{p.emoji}</span>
+                      </span>
+                      {p.titulo}
+                    </button>
+                    <AccionMundo
+                      estado={estados[p.id]}
+                      titulo={p.titulo}
+                      onAgregar={() => agregarMundo(p.id)}
+                      onQuitar={() => quitarMundo(p.id)}
+                    />
+                  </article>
                 ))}
               </div>
             </section>
@@ -1269,6 +1385,11 @@ export default function VitrinaMaestraMundos({ onBack }) {
             </div>
           </div>
           <div className="vmx-pie">
+            <div className="vmx-leyenda" aria-label="Cómo leer esta vitrina">
+              <b>Verde: lo que usted tiene</b>
+              <span aria-hidden="true">·</span>
+              <b>Dorado: lo que puede conocer</b>
+            </div>
             {defSenalado && (
               <p className="vmx-senal" role="status">
                 {defSenalado.emoji} {defSenalado.titulo} — {defSenalado.pisoNombre.toLowerCase()} · toque para entrar
@@ -1288,17 +1409,28 @@ export default function VitrinaMaestraMundos({ onBack }) {
                       {piso.icono} {piso.nombre}
                     </span>
                     {piso.mundos.map((p) => (
-                      <button
+                      <div
                         key={p.id}
-                        type="button"
                         role="listitem"
-                        className="vmx-chip"
-                        onClick={() => elegir(p.id)}
-                        disabled={!enGaleria}
+                        className="vmx-chip-wrap"
+                        data-estado={estados[p.id]}
                       >
-                        <span aria-hidden="true">{p.emoji}</span>
-                        {p.titulo}
-                      </button>
+                        <button
+                          type="button"
+                          className="vmx-chip"
+                          onClick={() => elegir(p.id)}
+                          disabled={!enGaleria}
+                        >
+                          <span aria-hidden="true">{p.emoji}</span>
+                          {p.titulo}
+                        </button>
+                        <AccionMundo
+                          estado={estados[p.id]}
+                          titulo={p.titulo}
+                          onAgregar={() => agregarMundo(p.id)}
+                          onQuitar={() => quitarMundo(p.id)}
+                        />
+                      </div>
                     ))}
                   </div>
                 ))}

--- a/src/mockups/valle/Valle2DFallback.jsx
+++ b/src/mockups/valle/Valle2DFallback.jsx
@@ -8,7 +8,7 @@
  * abeja VUELA hasta el lugar: el mismo "entrar al mundo" del 3D, dibujado.
  * "Wow" 3D se pierde; el PROPÓSITO no.
  */
-import { MUNDOS_VALLE, MUNDO_VALLE_BY_ID, COSA_DEL_DIA, CLIMAS } from './valleData';
+import { MUNDOS_VALLE, indexarMundosValle, COSA_DEL_DIA, CLIMAS } from './valleData';
 import { AbejaAngelita } from '../../visual/creatures/AbejaAngelita.jsx';
 
 /* Proyección isométrica plana de las coordenadas del valle a la lámina SVG. */
@@ -33,15 +33,21 @@ export default function Valle2DFallback({
   onEntrar,
   onAlerta,
   webglBloqueado = false,
+  /* LOS LUGARES DE SU VALLE (valle dinámico): la lista sembrada del perfil de
+     la finca, que el host (EntradaValle3D) construye con
+     construirMundosValle(perfil). Default = el valle completo de siempre: sin
+     perfil, esta lámina se ve exactamente como antes. */
+  mundos = MUNDOS_VALLE,
 }) {
   const c = CLIMAS[clima];
-  const ancla = MUNDOS_VALLE.find((m) => m.id === COSA_DEL_DIA.anclaMundo);
+  const lugares = Array.isArray(mundos) && mundos.length > 0 ? mundos : MUNDOS_VALLE;
+  const ancla = lugares.find((m) => m.id === COSA_DEL_DIA.anclaMundo);
   // Mundos ordenados de atrás hacia adelante para que se solapen bien.
-  const orden = [...MUNDOS_VALLE].sort((a, b) => a.pos[0] + a.pos[2] - (b.pos[0] + b.pos[2]));
+  const orden = [...lugares].sort((a, b) => a.pos[0] + a.pos[2] - (b.pos[0] + b.pos[2]));
 
   // "Entrar al mundo": la lámina se acerca hacia el lugar tocado y la abeja
   // vuela hasta él. Sin foco, la abeja ronda el centro del valle.
-  const foco = focoId ? MUNDO_VALLE_BY_ID[focoId] : null;
+  const foco = focoId ? indexarMundosValle(lugares)[focoId] : null;
   const camPos = foco ? pct(foco.pos[0], foco.pos[2]) : { left: 50, top: 50 };
   const abejaPos = foco ? pct(foco.pos[0], foco.pos[2]) : { left: 52, top: 46 };
 

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -411,7 +411,7 @@ function ArboledaEspecies({ q }) {
       redondeadas (cilindros, conos, esferas) — pocas piezas por lugar para
       dejar aire. La arboleda va por especie (mallas de floraParamo); `q` baja
       el detalle geométrico en perfil frugal. ── */
-function LandmarkGeom({ tipo, tinte, reducedMotion, q = 1 }) {
+function LandmarkGeom({ tipo, tinte, reducedMotion, q = 1, forma = null }) {
   const [fuerte, suave] = tinte;
   switch (tipo) {
     case 'milpa': // LA PARCELA VIVA (estilo granja de Age of Empires, en modo
@@ -566,6 +566,63 @@ function LandmarkGeom({ tipo, tinte, reducedMotion, q = 1 }) {
           ))}
         </group>
       );
+    case 'tanque':
+      return (
+        <group>
+          <mesh position={[0, 0.48, 0]} castShadow>
+            <cylinderGeometry args={[0.48, 0.52, 0.9, 14]} />
+            <meshStandardMaterial color="#477b8f" flatShading roughness={0.65} />
+          </mesh>
+          <mesh position={[0, 0.95, 0]}>
+            <cylinderGeometry args={[0.5, 0.5, 0.06, 14]} />
+            <meshStandardMaterial color="#315c6d" flatShading roughness={0.8} />
+          </mesh>
+          <mesh position={[0.45, 0.22, 0.1]} rotation={[0, 0, Math.PI / 2]}>
+            <cylinderGeometry args={[0.045, 0.045, 0.32, 7]} />
+            <meshStandardMaterial color="#b6c2c3" metalness={0.3} roughness={0.5} />
+          </mesh>
+        </group>
+      );
+    case 'lluvia':
+      return (
+        <group>
+          <mesh position={[0, 0.34, 0]} castShadow>
+            <cylinderGeometry args={[0.38, 0.42, 0.65, 12]} />
+            <meshStandardMaterial color="#4c7f92" flatShading roughness={0.7} />
+          </mesh>
+          <mesh position={[0, 0.82, 0]} rotation={[Math.PI, 0, 0]}>
+            <coneGeometry args={[0.68, 0.36, 12, 1, true]} />
+            <meshStandardMaterial color="#a8c8d5" transparent opacity={0.72} side={2} />
+          </mesh>
+          {[-0.38, 0, 0.38].map((x) => (
+            <mesh key={x} position={[x, 1.25, 0]}>
+              <capsuleGeometry args={[0.025, 0.16, 3, 5]} />
+              <meshBasicMaterial color="#bfe5f4" transparent opacity={0.8} />
+            </mesh>
+          ))}
+        </group>
+      );
+    case 'acueducto':
+      return (
+        <group>
+          <mesh position={[0, 0.48, 0]}>
+            <cylinderGeometry args={[0.07, 0.07, 0.96, 8]} />
+            <meshStandardMaterial color="#b8c1c2" metalness={0.35} roughness={0.45} />
+          </mesh>
+          <mesh position={[0.2, 0.92, 0]} rotation={[0, 0, Math.PI / 2]}>
+            <cylinderGeometry args={[0.07, 0.07, 0.42, 8]} />
+            <meshStandardMaterial color="#b8c1c2" metalness={0.35} roughness={0.45} />
+          </mesh>
+          <mesh position={[0.41, 0.78, 0]}>
+            <cylinderGeometry args={[0.045, 0.045, 0.28, 7]} />
+            <meshStandardMaterial color="#8fa2a4" metalness={0.4} roughness={0.4} />
+          </mesh>
+          <mesh position={[0.41, 0.52, 0]} scale={[0.7, 1.2, 0.7]}>
+            <sphereGeometry args={[0.08, 8, 6]} />
+            <meshBasicMaterial color="#73b6d2" transparent opacity={0.8} />
+          </mesh>
+        </group>
+      );
     case 'quebrada': // nacimiento: charca redonda + juncos
       return (
         <group>
@@ -642,6 +699,44 @@ function LandmarkGeom({ tipo, tinte, reducedMotion, q = 1 }) {
       // verdad — arcos de madera, el plástico traslúcido que brilla al sol,
       // la puerta abierta y las mesas de germinación adentro. Se destaca
       // como pieza propia del valle: la fábrica de la matica.
+      if (forma === 'cuadrado') {
+        return (
+          <group>
+            {[[-0.62, -0.65], [0.62, -0.65], [-0.62, 0.65], [0.62, 0.65]].map(([x, z], i) => (
+              <mesh key={i} position={[x, 0.45, z]} castShadow>
+                <cylinderGeometry args={[0.035, 0.045, 0.9, 5]} />
+                <meshStandardMaterial color="#8a6a44" flatShading roughness={1} />
+              </mesh>
+            ))}
+            <mesh position={[-0.32, 0.88, 0]} rotation={[0, 0, -0.5]} castShadow>
+              <boxGeometry args={[0.78, 0.035, 1.42]} />
+              <meshStandardMaterial color="#eef7f2" transparent opacity={0.48} side={2} />
+            </mesh>
+            <mesh position={[0.32, 0.88, 0]} rotation={[0, 0, 0.5]} castShadow>
+              <boxGeometry args={[0.78, 0.035, 1.42]} />
+              <meshStandardMaterial color="#eef7f2" transparent opacity={0.48} side={2} />
+            </mesh>
+            <mesh position={[0, 0.45, 0]}>
+              <boxGeometry args={[1.24, 0.84, 1.34]} />
+              <meshStandardMaterial color="#e4f2ea" transparent opacity={0.2} side={2} />
+            </mesh>
+          </group>
+        );
+      }
+      if (forma === 'casa_sombra') {
+        return (
+          <group>
+            <mesh position={[0, 0.48, 0]}>
+              <boxGeometry args={[1.3, 0.95, 1.35]} />
+              <meshStandardMaterial color="#6f9b72" wireframe transparent opacity={0.78} />
+            </mesh>
+            <mesh position={[0, 0.98, 0]}>
+              <boxGeometry args={[1.38, 0.05, 1.43]} />
+              <meshStandardMaterial color="#aac8a7" transparent opacity={0.56} side={2} />
+            </mesh>
+          </group>
+        );
+      }
       return (
         <group>
           {/* los arcos del túnel (medio-toroide de pie), en tono madera */}
@@ -1243,6 +1338,7 @@ function MundoLugar({ mundo, reducedMotion, perfil, onEntrar = null }) {
       tinte={mundo.tinte}
       reducedMotion={reducedMotion}
       q={perfil.materialRico ? 1 : 0.55}
+      forma={mundo.invernaderoTipo}
     />
   );
   return (

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -2365,7 +2365,7 @@ function poseValleParaAspecto(aspect) {
 }
 
 /* ── Contenido de la escena (dentro del Canvas). ── */
-function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = null, onAngelita = null, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false, aplanando = false, camaraDirector = false, beatsRef = null, portada = false, pose = null }) {
+function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = null, onAngelita = null, reducedMotion, perfil, tier = 'alto', estadoFinca = null, hayAlerta = false, aplanando = false, camaraDirector = false, beatsRef = null, portada = false, pose = null, mundos = MUNDOS_DIR }) {
   /* La pose de reposo (aspecto-consciente, viene del host del Canvas). */
   const poseReposo = pose || { position: CAMARA_VALLE.position, fov: CAMARA_VALLE.fov, k: 1, mira: MIRA_VALLE };
   const miraReposo = poseReposo.mira || MIRA_VALLE;
@@ -2509,7 +2509,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = nu
           discos-espejo); los toris de madera quedan SOLO para los lugares
           secundarios de menos uso. */}
       <VentanasVivas
-        mundos={MUNDOS_DIR}
+        mundos={mundos}
         alturaDe={alturaTerreno}
         nocturno={nocturno}
         practicas={practicas}
@@ -2517,7 +2517,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = nu
         perfil={perfil}
         onEntrar={portada ? null : onEntrar}
       />
-      <PorticosSecundarios mundos={MUNDOS_DIR} alturaDe={alturaTerreno} />
+      <PorticosSecundarios mundos={mundos} alturaDe={alturaTerreno} />
       {/* EL ACCESO AL PÁRAMO — el Ent-queñua+frailejones del filo (VistaParamoEnt)
           se ARCHIVÓ 2026-07-18 (pedido del operador): se veía amontonado en la
           vista del valle. Ver src/mockups/valle/_archivo/vistaParamo.archivado.jsx.
@@ -2532,16 +2532,16 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = nu
           en su loma. Separa la profundidad sin mover nada — la casa, los
           hitos y las matas dejan de flotar. De noche se atenúa, no se va. */}
       <SombrasContacto
-        mundos={MUNDOS_DIR}
+        mundos={mundos}
         alturaDe={alturaTerreno}
         nocturno={nocturno}
         franja={clima}
       />
       {!portada && (
-        <PatiosLugares mundos={MUNDOS_DIR} alturaDe={alturaTerreno} nocturno={nocturno} />
+        <PatiosLugares mundos={mundos} alturaDe={alturaTerreno} nocturno={nocturno} />
       )}
 
-      {MUNDOS_DIR.map((m) => (
+      {mundos.map((m) => (
         <MundoLugar
           key={m.id}
           mundo={m}
@@ -2570,7 +2570,7 @@ function Escena({ clima, focoId, animo, energia, onEntrar, onAlerta, onCasa = nu
           ciclo del día) se queda: la finca espera, no está muerta. */}
       {!portada && (
         <RotulosLugares
-          mundos={MUNDOS_DIR}
+          mundos={mundos}
           focoId={focoId}
           onEntrar={onEntrar}
           occluders={occluders}
@@ -2686,6 +2686,13 @@ export default function Valle3D({
      vivo pero como paisaje que ESPERA — sin rótulos de mundos ni faro del día,
      con una llegada de cámara más lenta. La UI de la entrada vive en el host. */
   portada = false,
+  /* VALLE DINÁMICO (spec paso 2): los lugares de ESTA finca, ya compuestos por
+     el director (componerMundos). El host los siembra del perfil con
+     construirMundosValle(perfil). Default = el valle completo de siempre: sin
+     perfil, la escena es idéntica a la de antes.
+     OJO: `perfil` (arriba) es el perfil de RENDER del tier — no confundir con
+     el perfil de la FINCA, que llega ya resuelto en esta lista. */
+  mundos = MUNDOS_DIR,
 }) {
   const [listo, setListo] = useState(false);
   /* GUARD DEL NEGRO INTERMITENTE (auditoría 2026-07-16): sin oyente de
@@ -2761,6 +2768,7 @@ export default function Valle3D({
           beatsRef={beatsRef}
           portada={portada}
           pose={pose}
+          mundos={mundos}
         />
       </Suspense>
     </Canvas>

--- a/src/mockups/valle/__tests__/valleDinamico.compat.test.js
+++ b/src/mockups/valle/__tests__/valleDinamico.compat.test.js
@@ -1,0 +1,201 @@
+/*
+ * LA RED DE SEGURIDAD DEL VALLE DINÁMICO (spec paso 2).
+ *
+ * El valle dejó de ser un array fijo y pasó a sembrarse del perfil de la finca.
+ * Toda esa migración se sostiene sobre UNA garantía dura:
+ *
+ *     construirLugaresValle(PERFIL_FINCA_DEMO) === los lugares de siempre
+ *
+ * Si esta suite se pone roja, alguien le quitó un lugar al valle de todo el
+ * mundo. Aquí también se prueba la regla no destructiva: un dato que FALTA
+ * nunca resta — solo una respuesta EXPLÍCITA cambia el mundo.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  MUNDOS_VALLE,
+  construirLugaresValle,
+  construirMundosValle,
+} from '../valleData.js';
+import {
+  PERFIL_FINCA_DEMO,
+  derivarPerfilFinca,
+} from '../../../services/perfilFincaService.js';
+
+/** Los ids del valle tal como estaban ANTES de que fuera dinámico. */
+const IDS_DE_SIEMPRE = [
+  'agua',
+  'cafe',
+  'cultivos',
+  'suelo',
+  'sanidad',
+  'animales',
+  'disenio',
+  'clima',
+  'mercado',
+  'semillero',
+  'micorrizas',
+  'abono',
+  'aprender',
+  'paramo',
+];
+
+describe('construirLugaresValle — compatibilidad con el valle de siempre', () => {
+  test('el perfil de DEMO devuelve EXACTAMENTE los lugares actuales', () => {
+    const lugares = construirLugaresValle(PERFIL_FINCA_DEMO);
+    expect(lugares.map((l) => l.id)).toEqual(IDS_DE_SIEMPRE);
+  });
+
+  test('los lugares del demo son idénticos a los que consume el valle hoy', () => {
+    const mundos = construirMundosValle(PERFIL_FINCA_DEMO);
+    // Mismo contenido, mismo orden, mismas props resueltas del manifiesto.
+    expect(mundos).toEqual(MUNDOS_VALLE);
+  });
+
+  test('sin perfil (undefined/null/{}) el valle se ve como hoy — nunca menos', () => {
+    for (const p of [undefined, null, {}, { escala: 'basura' }, 42, 'perfil']) {
+      expect(construirLugaresValle(p).map((l) => l.id)).toEqual(IDS_DE_SIEMPRE);
+    }
+  });
+
+  test('un perfil vacío del onboarding (usuario que no contestó nada) tampoco resta', () => {
+    const perfil = derivarPerfilFinca({});
+    expect(construirLugaresValle(perfil).map((l) => l.id)).toEqual(IDS_DE_SIEMPRE);
+  });
+
+  test('cada lugar conserva su geometría cruda (pos/escala/tipo)', () => {
+    const lugares = construirLugaresValle(PERFIL_FINCA_DEMO);
+    for (const l of lugares) {
+      expect(Array.isArray(l.pos)).toBe(true);
+      expect(l.pos).toHaveLength(3);
+      expect(typeof l.escala).toBe('number');
+      expect(typeof l.tipo).toBe('string');
+    }
+  });
+});
+
+describe('construirLugaresValle — el valle se siembra del perfil', () => {
+  test('un BALCÓN recibe un mundo íntimo, sin potrero ni cafetal ni páramo', () => {
+    const perfil = derivarPerfilFinca({ finca_tipo: 'balcon' });
+    const ids = construirLugaresValle(perfil).map((l) => l.id);
+    expect(ids).not.toContain('animales');
+    expect(ids).not.toContain('cafe');
+    expect(ids).not.toContain('paramo');
+    expect(ids).not.toContain('disenio');
+    // Pero la mata, el suelo y el saber siguen ahí: nunca un mundo vacío.
+    expect(ids).toEqual(expect.arrayContaining(['cultivos', 'suelo', 'aprender']));
+    expect(ids.length).toBeGreaterThan(0);
+  });
+
+  test('una finca INVERNADERO conserva su invernadero y su mercado', () => {
+    const perfil = derivarPerfilFinca({ finca_tipo: 'invernadero' });
+    const ids = construirLugaresValle(perfil).map((l) => l.id);
+    expect(ids).toEqual(expect.arrayContaining(['semillero', 'mercado', 'agua']));
+    expect(ids).not.toContain('animales');
+  });
+
+  test('quien dijo que NO tiene animales no recibe potrero', () => {
+    const perfil = derivarPerfilFinca({ finca_tipo: 'rural', animales: ['ninguno'] });
+    expect(construirLugaresValle(perfil).map((l) => l.id)).not.toContain('animales');
+  });
+
+  test('quien SÍ tiene gallinas conserva su potrero', () => {
+    const perfil = derivarPerfilFinca({ finca_tipo: 'rural', animales: ['gallinas'] });
+    expect(construirLugaresValle(perfil).map((l) => l.id)).toContain('animales');
+  });
+
+  test('quien NO contestó por animales conserva el potrero (el dato falta, no resta)', () => {
+    const perfil = derivarPerfilFinca({ finca_tipo: 'rural' });
+    expect(construirLugaresValle(perfil).map((l) => l.id)).toContain('animales');
+  });
+
+  test('quien dijo que no tiene invernadero no recibe semillero', () => {
+    const perfil = derivarPerfilFinca({ finca_tipo: 'rural', invernadero_tiene: 'no' });
+    expect(construirLugaresValle(perfil).map((l) => l.id)).not.toContain('semillero');
+  });
+
+  test('en el páramo no hay cafetal; en tierra caliente no hay páramo', () => {
+    const arriba = derivarPerfilFinca({ finca_tipo: 'rural', finca_altitud: '3400' });
+    const idsArriba = construirLugaresValle(arriba).map((l) => l.id);
+    expect(idsArriba).not.toContain('cafe');
+    expect(idsArriba).toContain('paramo');
+
+    const abajo = derivarPerfilFinca({ finca_tipo: 'rural', finca_altitud: '600' });
+    const idsAbajo = construirLugaresValle(abajo).map((l) => l.id);
+    expect(idsAbajo).toContain('cafe');
+    expect(idsAbajo).not.toContain('paramo');
+  });
+
+  test('un mundo AGREGADO a mano entra aunque su escala no lo siembre', () => {
+    const perfil = {
+      ...derivarPerfilFinca({ finca_tipo: 'balcon' }),
+      mundosActivos: ['paramo', 'animales'],
+    };
+    const ids = construirLugaresValle(perfil).map((l) => l.id);
+    expect(ids).toContain('paramo');
+    expect(ids).toContain('animales');
+  });
+
+  test('el orden del catálogo se respeta siempre (el director compone sobre él)', () => {
+    const perfil = derivarPerfilFinca({ finca_tipo: 'rural', animales: ['ninguno'] });
+    const ids = construirLugaresValle(perfil).map((l) => l.id);
+    const esperado = IDS_DE_SIEMPRE.filter((id) => ids.includes(id));
+    expect(ids).toEqual(esperado);
+  });
+});
+
+describe('derivarPerfilFinca — la ubicación sale del perfil, no del build', () => {
+  test('perfil vacío = perfil de demo (nada declarado)', () => {
+    const p = derivarPerfilFinca({});
+    expect(p.ubicacion.fuente).toBe('demo');
+    expect(p.pisoTermico).toBeNull();
+    expect(p.escala).toBe('finca');
+    expect(p.declarado.ubicacion).toBe(false);
+  });
+
+  test('lo que captura el onboarding queda tipado en el perfil', () => {
+    const p = derivarPerfilFinca({
+      ubicacion_lat: 4.526,
+      ubicacion_lng: -73.922,
+      finca_altitud: '2450',
+      municipio: 'Choachí',
+      departamento: 'Cundinamarca',
+      vereda: 'Potrero Grande',
+      piso_termico: 'frio',
+      finca_tipo: 'rural',
+      invernadero_tiene: 'si',
+      invernadero_forma: 'cuadrado',
+      animales: ['gallinas', 'cerdos'],
+      cultivos_actuales: 'café, mora',
+      riego: 'acequia',
+    });
+    expect(p.ubicacion).toMatchObject({
+      lat: 4.526,
+      lon: -73.922,
+      altitudMsnm: 2450,
+      municipio: 'Choachí',
+      departamento: 'Cundinamarca',
+      vereda: 'Potrero Grande',
+      fuente: 'perfil',
+    });
+    expect(p.pisoTermico).toBe('frio');
+    expect(p.escala).toBe('finca');
+    expect(p.invernadero).toEqual({ tipo: 'cuadrado', tamano: null });
+    expect(p.animales).toEqual(['gallinas', 'cerdos']);
+    expect(p.cultiva).toEqual(['café', 'mora']);
+    expect(p.agua).toBe('quebrada');
+    expect(p.declarado.ubicacion).toBe(true);
+  });
+
+  test('el piso térmico se deduce de la altitud cuando falta el slug', () => {
+    expect(derivarPerfilFinca({ finca_altitud: '3200' }).pisoTermico).toBe('paramo');
+    expect(derivarPerfilFinca({ finca_altitud: '2400' }).pisoTermico).toBe('frio');
+    expect(derivarPerfilFinca({ finca_altitud: '1500' }).pisoTermico).toBe('templado');
+    expect(derivarPerfilFinca({ finca_altitud: '600' }).pisoTermico).toBe('calido');
+  });
+
+  test('el piso térmico NUNCA sale del env de demo (no le recorta el valle a nadie)', () => {
+    // Sin ubicación en el perfil, el piso queda null aunque el build tenga
+    // VITE_FARM_THERMAL_ZONES: por eso el valle de un usuario nuevo es completo.
+    expect(derivarPerfilFinca({ finca_tipo: 'rural' }).pisoTermico).toBeNull();
+  });
+});

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -204,6 +204,36 @@ const LUGARES = [
   },
 ];
 
+/* Piezas de la vitrina que no forman parte de los 14 lugares históricos.
+ * Solo se siembran cuando la persona las agrega para conocerlas. Mantenerlas
+ * fuera de LUGARES conserva intacto el perfil demo y los valles existentes. */
+const LUGARES_PARA_CONOCER = [
+  {
+    id: 'cacao', pos: [7.2, 0, 7.8], escala: 0.9, tipo: 'cafetal',
+    fallbackMundo: { titulo: 'El cacao', emoji: '🍫', lema: 'Conozca el cultivo y beneficio del cacao.', tinte: ['#79502d', '#c9873c'] },
+  },
+  {
+    id: 'papa', pos: [6.8, 0, -3.4], escala: 0.9, tipo: 'huerta',
+    fallbackMundo: { titulo: 'La papa', emoji: '🥔', lema: 'Conozca la tierra de la papa.', tinte: ['#8c6a3f', '#c7a36d'] },
+  },
+  {
+    id: 'abejas', pos: [7.4, 0, 1.8], escala: 0.82, tipo: 'saber',
+    fallbackMundo: { titulo: 'Las abejas', emoji: '🐝', lema: 'Conozca las polinizadoras de la finca.', tinte: ['#87651c', '#e8b83a'] },
+  },
+  {
+    id: 'lluvia', pos: [-6.8, 0, -4.8], escala: 0.82, tipo: 'veleta',
+    fallbackMundo: { titulo: 'La lluvia', emoji: '🌧️', lema: 'Conozca cómo se mueve el agua del cielo.', tinte: ['#58758f', '#9fb3c8'] },
+  },
+  {
+    id: 'sierra', pos: [6.2, 0, -7.2], escala: 0.85, tipo: 'bosque',
+    fallbackMundo: { titulo: 'La Sierra', emoji: '🏔️', lema: 'Conozca la montaña completa.', tinte: ['#456353', '#b8c6b6'] },
+  },
+  {
+    id: 'compost', pos: [-6.6, 0, 8.0], escala: 0.8, tipo: 'compost',
+    fallbackMundo: { titulo: 'El compost', emoji: '🍂', lema: 'Conozca cómo vuelve la materia a la tierra.', tinte: ['#59401f', '#a8854c'] },
+  },
+];
+
 /* ── 2b. LA SIEMBRA: QUÉ LUGARES LE TOCAN A ESTA FINCA ───────────────────────
  * El valle se ARMA del perfil (spec del valle dinámico, paso 2): si la persona
  * tiene un balcón, su valle es un balcón; si tiene 10.000 matas, es el valle
@@ -264,6 +294,7 @@ function perfilSeguro(perfil) {
     escala: ESCALAS_VALLE.includes(p.escala) ? p.escala : 'finca',
     pisoTermico: typeof p.pisoTermico === 'string' ? p.pisoTermico : null,
     invernadero: p.invernadero || null,
+    agua: typeof p.agua === 'string' ? p.agua : null,
     animales: Array.isArray(p.animales) ? p.animales : [],
     cultiva: Array.isArray(p.cultiva) ? p.cultiva : [],
     mundosActivos: Array.isArray(p.mundosActivos) ? p.mundosActivos : [],
@@ -302,20 +333,46 @@ export function construirLugaresValle(perfil) {
     if (typeof regla.requiere === 'function' && !regla.requiere(p)) return false;
     return true;
   });
-  return lugares.length > 0 ? lugares : LUGARES;
+  const opcionales = LUGARES_PARA_CONOCER.filter((l) => p.mundosActivos.includes(l.id));
+  const sembrados = lugares.length > 0 ? [...lugares, ...opcionales] : LUGARES;
+  return sembrados.map((lugar) => {
+    if (lugar.id === 'semillero' && p.invernadero?.tipo) {
+      return { ...lugar, invernaderoTipo: p.invernadero.tipo };
+    }
+    if (lugar.id === 'agua' && p.declarado.agua && p.agua) {
+      return { ...lugar, tipo: p.agua, fuenteAgua: p.agua };
+    }
+    return lugar;
+  });
 }
 
 /** Resuelve un lugar contra el manifiesto real de mundos (título/emoji/tinte). */
 function resolverMundo(l) {
   /** @type {{ titulo?: string, emoji?: string, lema?: string, tinte?: string[] }} */
   const real = MUNDO_BY_ID[l.id] || l.fallbackMundo || {};
-  return {
+  const mundo = {
     ...l,
     titulo: real.titulo || l.id,
     emoji: real.emoji || '📍',
     lema: real.lema || '',
     tinte: real.tinte || ['#3f8f4e', '#dcedc9'],
   };
+  if (l.id === 'semillero' && l.invernaderoTipo) {
+    const nombres = { cuadrado: 'cuadrado', tunel: 'tipo túnel', casa_sombra: 'de casa malla' };
+    mundo.titulo = `Su invernadero ${nombres[l.invernaderoTipo] || ''}`.trim();
+  }
+  if (l.id === 'agua' && l.fuenteAgua) {
+    const nombres = {
+      quebrada: ['Su quebrada', '🏞️'],
+      tanque: ['Su tanque de agua', '🛢️'],
+      lluvia: ['Su agua lluvia', '🌧️'],
+      acueducto: ['Su acueducto', '🚰'],
+    };
+    const [titulo, emoji] = nombres[l.fuenteAgua] || [mundo.titulo, mundo.emoji];
+    mundo.titulo = titulo;
+    mundo.emoji = emoji;
+  }
+  return mundo;
 }
 
 /**

--- a/src/mockups/valle/valleData.js
+++ b/src/mockups/valle/valleData.js
@@ -134,6 +134,10 @@ export const VEGETACION_PISOS = [
  * en el clima medio, el bosque trepando al frío, la veleta arriba en el filo
  * del páramo (desde donde se lee el cielo), y el corral, la huerta y el
  * semillero abajo en la tierra caliente. Pocos y separados > muchos amontonados.
+ *
+ * ESTE ES EL CATÁLOGO COMPLETO, no la lista final: qué lugares le tocan a CADA
+ * finca lo decide `construirLugaresValle(perfil)` (abajo) — el valle se siembra
+ * del perfil, no es el mismo para todos.
  */
 const LUGARES = [
   // (Las posiciones finales las manda COMPOSICION_LUGARES — la capa del
@@ -200,12 +204,109 @@ const LUGARES = [
   },
 ];
 
-/**
- * Mundos del valle, ya resueltos contra el manifiesto real. Cada uno trae su
- * `titulo`, `emoji` y `tinte` verdaderos + la geometría de su lugar. Un lugar
- * sin mundo en el manifiesto (el kiosco de aprender) usa su `fallbackMundo`.
+/* ── 2b. LA SIEMBRA: QUÉ LUGARES LE TOCAN A ESTA FINCA ───────────────────────
+ * El valle se ARMA del perfil (spec del valle dinámico, paso 2): si la persona
+ * tiene un balcón, su valle es un balcón; si tiene 10.000 matas, es el valle
+ * completo. Aquí vive la regla de QUÉ hay; el DÓNDE lo sigue mandando la capa
+ * del director (COMPOSICION_LUGARES en visual/mundo3d/direccion), que no se
+ * toca: la función siembra, el director compone.
+ *
+ * REGLA DURA — un dato que FALTA nunca resta. Solo una respuesta EXPLÍCITA del
+ * usuario (`perfil.declarado.*`) o una escala declarada encogen el mundo. Un
+ * perfil vacío devuelve el valle de siempre, idéntico.
+ *
+ * Campos:
+ *   escalas   en qué tamaños de mundo cabe el lugar ('balcon'|'invernadero'|'finca')
+ *   requiere  (perfil) => boolean — condición extra; devuelve TRUE si el dato falta
  */
-export const MUNDOS_VALLE = LUGARES.map((l) => {
+const SIEMBRA_LUGARES = {
+  // La quebrada y su toma: hay finca y hay invernadero, no hay balcón.
+  agua: { escalas: ['finca', 'invernadero'] },
+  // El cafetal solo en la finca abierta, y NUNCA en el páramo (a 3.000+ m no
+  // hay café: fidelidad agroecológica, no capricho).
+  cafe: { escalas: ['finca'], requiere: (p) => p.pisoTermico !== 'paramo' },
+  // La milpa: la mata está en toda escala — es el corazón de Chagra.
+  cultivos: { escalas: ['balcon', 'invernadero', 'finca'] },
+  suelo: { escalas: ['balcon', 'invernadero', 'finca'] },
+  sanidad: { escalas: ['balcon', 'invernadero', 'finca'] },
+  // El potrero solo si de verdad tiene animales (si contestó la pregunta y
+  // quedó vacía —'ninguno'— no se dibuja un potrero que no existe).
+  animales: {
+    escalas: ['finca'],
+    requiere: (p) => !p.declarado.animales || p.animales.length > 0,
+  },
+  disenio: { escalas: ['finca'] },
+  clima: { escalas: ['balcon', 'invernadero', 'finca'] },
+  mercado: { escalas: ['finca', 'invernadero'] },
+  // El invernadero/semillero: si la finca ES un invernadero, obvio que va; si
+  // dijo explícitamente que NO tiene, no se le dibuja uno.
+  semillero: {
+    escalas: ['balcon', 'invernadero', 'finca'],
+    requiere: (p) => p.escala === 'invernadero' || !p.declarado.invernadero || !!p.invernadero,
+  },
+  micorrizas: { escalas: ['balcon', 'invernadero', 'finca'] },
+  abono: { escalas: ['finca', 'invernadero'] },
+  aprender: { escalas: ['balcon', 'invernadero', 'finca'] },
+  // El páramo de arriba: no existe en tierra caliente (< 1.000 m).
+  paramo: { escalas: ['finca'], requiere: (p) => p.pisoTermico !== 'calido' },
+};
+
+const ESCALAS_VALLE = ['balcon', 'invernadero', 'finca'];
+
+/* Lectura DEFENSIVA del perfil. valleData es un módulo de DATOS: no importa el
+   servicio del perfil a propósito (arrastraría el dataset DANE de 186 KB a
+   todo chunk que toque el valle). El perfil se le PASA ya normalizado
+   (services/perfilFincaService.derivarPerfilFinca); aquí solo se sanea. */
+function perfilSeguro(perfil) {
+  const p = perfil && typeof perfil === 'object' ? perfil : {};
+  const d = p.declarado && typeof p.declarado === 'object' ? p.declarado : {};
+  return {
+    escala: ESCALAS_VALLE.includes(p.escala) ? p.escala : 'finca',
+    pisoTermico: typeof p.pisoTermico === 'string' ? p.pisoTermico : null,
+    invernadero: p.invernadero || null,
+    animales: Array.isArray(p.animales) ? p.animales : [],
+    cultiva: Array.isArray(p.cultiva) ? p.cultiva : [],
+    mundosActivos: Array.isArray(p.mundosActivos) ? p.mundosActivos : [],
+    declarado: {
+      escala: !!d.escala,
+      invernadero: !!d.invernadero,
+      animales: !!d.animales,
+      cultiva: !!d.cultiva,
+      agua: !!d.agua,
+      ubicacion: !!d.ubicacion,
+    },
+  };
+}
+
+/**
+ * LOS LUGARES DE **SU** VALLE. Siembra el catálogo según el perfil de la finca.
+ *
+ * - Sin perfil (o perfil de demo) devuelve el catálogo COMPLETO: exactamente
+ *   los lugares de siempre, en el mismo orden y con los mismos objetos.
+ * - `perfil.escala` manda el tamaño del mundo.
+ * - `perfil.mundosActivos` FUERZA la entrada de un mundo que la persona
+ *   agregó a mano para conocerlo (la vitrina maestra, paso 5 del spec).
+ * - Si por lo que sea la siembra quedara vacía, cae al catálogo completo: el
+ *   valle nunca se queda sin lugares.
+ *
+ * @param {import('../../services/perfilFincaService').PerfilFinca} [perfil]
+ * @returns {typeof LUGARES}
+ */
+export function construirLugaresValle(perfil) {
+  const p = perfilSeguro(perfil);
+  const lugares = LUGARES.filter((l) => {
+    if (p.mundosActivos.includes(l.id)) return true; // lo agregó para conocerlo
+    const regla = SIEMBRA_LUGARES[l.id];
+    if (!regla) return true; // lugar nuevo sin regla: se siembra (nunca menos)
+    if (!regla.escalas.includes(p.escala)) return false;
+    if (typeof regla.requiere === 'function' && !regla.requiere(p)) return false;
+    return true;
+  });
+  return lugares.length > 0 ? lugares : LUGARES;
+}
+
+/** Resuelve un lugar contra el manifiesto real de mundos (título/emoji/tinte). */
+function resolverMundo(l) {
   /** @type {{ titulo?: string, emoji?: string, lema?: string, tinte?: string[] }} */
   const real = MUNDO_BY_ID[l.id] || l.fallbackMundo || {};
   return {
@@ -215,11 +316,32 @@ export const MUNDOS_VALLE = LUGARES.map((l) => {
     lema: real.lema || '',
     tinte: real.tinte || ['#3f8f4e', '#dcedc9'],
   };
-});
+}
 
-export const MUNDO_VALLE_BY_ID = Object.fromEntries(
-  MUNDOS_VALLE.map((m) => [m.id, m]),
-);
+/**
+ * Los mundos de SU valle, ya resueltos contra el manifiesto real. Cada uno trae
+ * su `titulo`, `emoji` y `tinte` verdaderos + la geometría de su lugar. Un lugar
+ * sin mundo en el manifiesto (el kiosco de aprender) usa su `fallbackMundo`.
+ *
+ * @param {import('../../services/perfilFincaService').PerfilFinca} [perfil]
+ */
+export function construirMundosValle(perfil) {
+  return construirLugaresValle(perfil).map(resolverMundo);
+}
+
+/** Índice por id de una lista de mundos ya construida. */
+export function indexarMundosValle(mundos) {
+  return Object.fromEntries(mundos.map((m) => [m.id, m]));
+}
+
+/**
+ * EL VALLE DE MUESTRA (retrocompatible): el catálogo completo resuelto, tal
+ * como estaba antes de que el valle se sembrara del perfil. Es el respaldo de
+ * quien todavía no recibe un perfil — y el default de toda vista del valle.
+ */
+export const MUNDOS_VALLE = LUGARES.map(resolverMundo);
+
+export const MUNDO_VALLE_BY_ID = indexarMundosValle(MUNDOS_VALLE);
 
 /* ── 1. LA COSA DEL DÍA (una sola, anclada a un lugar) ───────────────────────
  * Un único destello: la alerta del día aparece DONDE toca. Aquí, una helada

--- a/src/mockups/vitrinaPerfil.js
+++ b/src/mockups/vitrinaPerfil.js
@@ -1,0 +1,18 @@
+import { construirLugaresValle } from './valle/valleData.js';
+
+export const COPY_VITRINA_PERFIL = Object.freeze({
+  agregar: '+ Agregar a mi valle',
+  ariaAgregar: (titulo) => `Agregar ${titulo} a mi valle`,
+});
+
+/** Distingue el espejo de la finca de los mundos disponibles para conocer. */
+export function estadoMundoVitrina(id, perfil) {
+  if (id === 'valle') return 'propio';
+  const p = perfil && typeof perfil === 'object' ? perfil : {};
+  const mundosActivos = Array.isArray(p.mundosActivos) ? p.mundosActivos : [];
+  const sinAgregados = { ...p, mundosActivos: [] };
+  const propios = new Set(construirLugaresValle(sinAgregados).map((lugar) => lugar.id));
+  if (propios.has(id) || (id === 'compost' && propios.has('abono'))) return 'propio';
+  if (mundosActivos.includes(id)) return 'agregado';
+  return 'conocer';
+}

--- a/src/services/guildService.js
+++ b/src/services/guildService.js
@@ -20,7 +20,7 @@
 
 import { SPECIES_DEFAULTS } from '../config/speciesDefaults';
 import { CROP_TAXONOMY } from '../config/taxonomy';
-import { FARM_CONFIG } from '../config/defaults';
+import { getContextoGeoFinca } from './perfilFincaService';
 import { retrieve } from './ragRetriever';
 
 const DEFAULT_MAX_ASSETS = parseInt(import.meta.env.VITE_LLM_CONTEXT_MAX_ASSETS || '50', 10);
@@ -231,9 +231,14 @@ export const getSuggestedCompanions = (speciesId) => {
  * El caller envía esto a /api/ollama/api/generate y parsea el JSON response.
  */
 export const buildGuildPrompt = (speciesName, estrato) => {
-  const altitud = FARM_CONFIG.ALTITUD_MSNM;
-  const zonas = (FARM_CONFIG.THERMAL_ZONES || []).join(', ') || 'no especificada';
-  const municipio = FARM_CONFIG.MUNICIPIO || 'Colombia';
+  /* La finca sale del PERFIL del usuario (lo que ubicó en el onboarding), no
+     de las variables de build: antes, en prod sin VITE_FARM_*, el gremio se
+     pedía "en Colombia, piso térmico no especificada" aunque la persona
+     acabara de ubicar su vereda. Las envs quedan de default de demo. */
+  const geo = getContextoGeoFinca();
+  const altitud = geo.altitudMsnm;
+  const zonas = (geo.thermalZones || []).join(', ') || 'no especificada';
+  const municipio = geo.municipio || 'Colombia';
   const ctxAltitud = altitud != null
     ? `a ${altitud} msnm (piso térmico: ${zonas})`
     : `(piso térmico: ${zonas})`;

--- a/src/services/perfilFincaService.js
+++ b/src/services/perfilFincaService.js
@@ -1,0 +1,336 @@
+/*
+ * EL PERFIL DE LA FINCA — la fuente ÚNICA de verdad de "cómo es SU finca".
+ *
+ * EL PROBLEMA QUE RESUELVE (spec valle dinámico, paso 1): el onboarding
+ * (OnboardingCondensado, paso 2) SÍ captura la ubicación real — GPS →
+ * municipio DANE → altitud → piso térmico → vereda — y la guarda en el perfil
+ * (`chagra:profile:*`, userProfileService). Pero media app leía la finca de
+ * VARIABLES DE BUILD (`VITE_FARM_LAT`, `VITE_FARM_ALTITUD_MSNM`,
+ * `VITE_FARM_MUNICIPIO`, `VITE_FARM_THERMAL_ZONES`): dos verdades distintas
+ * sobre la MISMA finca. En prod sin esas envs quedaba `null` y el consejo
+ * salía "altitud no especificada" aunque el usuario acabara de ubicarse.
+ *
+ * LA REGLA: el sistema lee la ubicación del PERFIL; `VITE_FARM_*` queda solo
+ * como VALOR POR DEFECTO DE DEMO (la finca de muestra del guión). Nunca al
+ * revés.
+ *
+ * Este módulo es PURO y sin React (lo consumen servicios, componentes y el
+ * store `usePerfilFincaStore`): lee el perfil de localStorage vía
+ * userProfileService y lo normaliza a una forma TIPADA y estable.
+ *
+ * FORMA DEL PERFIL (contrato del spec):
+ *   ubicacion     { lat, lon, altitudMsnm, municipio, departamento, vereda, fuente }
+ *   pisoTermico   'calido'|'templado'|'frio'|'paramo'|null
+ *   escala        'balcon'|'invernadero'|'finca'   ← decide el tamaño del mundo
+ *   invernadero   null | { tipo, tamano }
+ *   cultiva       string[]   (ids/nombres de lo que siembra)
+ *   animales      string[]
+ *   agua          'quebrada'|'tanque'|'lluvia'|'acueducto'|null
+ *   mundosActivos string[]   (mundos AGREGADOS a mano desde la vitrina)
+ *   declarado     { ... }    ¿el usuario RESPONDIÓ esa pregunta?
+ *
+ * `declarado` es la red de seguridad del valle: un dato que FALTA nunca resta
+ * (el valle se ve como hoy); solo una respuesta EXPLÍCITA cambia el mundo.
+ */
+import { FARM_CONFIG } from '../config/defaults';
+import { getProfile } from './userProfileService';
+
+/** Escalas válidas del mundo. `finca` es el default seguro (valle completo). */
+export const ESCALAS_FINCA = Object.freeze(['balcon', 'invernadero', 'finca']);
+
+/** Pisos térmicos IDEAM/IGAC (mismos ids de src/data/piso-termico.json). */
+export const PISOS_TERMICOS_IDS = Object.freeze(['calido', 'templado', 'frio', 'paramo']);
+
+/** De dónde toma el agua la finca (paso 3 del spec la pregunta explícita). */
+export const FUENTES_AGUA = Object.freeze(['quebrada', 'tanque', 'lluvia', 'acueducto']);
+
+/**
+ * Tipos de invernadero. Reusa el catálogo YA existente del perfil
+ * (`INVERNADERO_FORMAS` de userProfileService, que la escena F2 ya dibuja):
+ * cuadrado · tunel · casa_sombra · malla_sombra · umbraculo · otro.
+ * NO se inventa un catálogo paralelo.
+ */
+export const TIPOS_INVERNADERO = Object.freeze([
+  'cuadrado',
+  'tunel',
+  'casa_sombra',
+  'malla_sombra',
+  'umbraculo',
+  'otro',
+]);
+
+/**
+ * @typedef {Object} UbicacionFinca
+ * @property {number|null} lat
+ * @property {number|null} lon
+ * @property {number|null} altitudMsnm
+ * @property {string|null} municipio
+ * @property {string|null} departamento
+ * @property {string|null} vereda
+ * @property {'perfil'|'demo'} fuente  'perfil' = la ubicó el usuario; 'demo' = default de build
+ */
+
+/**
+ * @typedef {Object} PerfilFinca
+ * @property {UbicacionFinca} ubicacion
+ * @property {'calido'|'templado'|'frio'|'paramo'|null} pisoTermico
+ * @property {'balcon'|'invernadero'|'finca'} escala
+ * @property {{ tipo: string|null, tamano: string|null }|null} invernadero
+ * @property {string[]} cultiva
+ * @property {string[]} animales
+ * @property {'quebrada'|'tanque'|'lluvia'|'acueducto'|null} agua
+ * @property {string[]} mundosActivos
+ * @property {{ ubicacion: boolean, escala: boolean, invernadero: boolean,
+ *              cultiva: boolean, animales: boolean, agua: boolean }} declarado
+ */
+
+/** Ubicación neutra: nada declarado. */
+const UBICACION_VACIA = Object.freeze({
+  lat: null,
+  lon: null,
+  altitudMsnm: null,
+  municipio: null,
+  departamento: null,
+  vereda: null,
+  fuente: 'demo',
+});
+
+/**
+ * EL PERFIL DE DEMO: la finca de muestra. No declara NADA, así que el valle se
+ * siembra COMPLETO — es la referencia de compatibilidad del paso 2 del spec
+ * (`construirLugaresValle(PERFIL_FINCA_DEMO)` = los lugares de siempre).
+ */
+export const PERFIL_FINCA_DEMO = Object.freeze({
+  ubicacion: UBICACION_VACIA,
+  pisoTermico: null,
+  escala: 'finca',
+  invernadero: null,
+  cultiva: Object.freeze([]),
+  animales: Object.freeze([]),
+  agua: null,
+  mundosActivos: Object.freeze([]),
+  declarado: Object.freeze({
+    ubicacion: false,
+    escala: false,
+    invernadero: false,
+    cultiva: false,
+    animales: false,
+    agua: false,
+  }),
+});
+
+const num = (v) => {
+  const n = typeof v === 'string' ? Number(v) : v;
+  return typeof n === 'number' && Number.isFinite(n) ? n : null;
+};
+
+const texto = (v) => (typeof v === 'string' && v.trim() !== '' ? v.trim() : null);
+
+const listaTexto = (v) => {
+  if (Array.isArray(v)) return v.map(texto).filter(Boolean);
+  const t = texto(v);
+  if (!t) return [];
+  // El onboarding guarda `cultivos_actuales` como texto libre ("café, mora").
+  return t.split(/[,;]+/).map((s) => s.trim()).filter(Boolean);
+};
+
+/**
+ * Piso térmico a partir de la altitud (tabla IDEAM/IGAC). Se usa solo cuando
+ * el perfil trae altitud pero no alcanzó a guardar el slug.
+ * @param {number|null} msnm
+ * @returns {'calido'|'templado'|'frio'|'paramo'|null}
+ */
+export function pisoTermicoDeAltitud(msnm) {
+  const m = num(msnm);
+  if (m == null) return null;
+  if (m < 1000) return 'calido';
+  if (m < 2000) return 'templado';
+  if (m <= 3000) return 'frio';
+  return 'paramo';
+}
+
+/**
+ * ESCALA del mundo desde el perfil plano.
+ *
+ * Cascada: `escala` explícita (paso 3 del spec) → `finca_tipo` del onboarding
+ * actual (balcón/terraza/invernadero/rural) → vocación urbana → 'finca'.
+ * El default SIEMPRE es 'finca' (el valle completo): un dato que falta nunca
+ * encoge el mundo.
+ *
+ * @param {Object} p perfil plano (`chagra:profile`)
+ * @returns {{ escala: 'balcon'|'invernadero'|'finca', declarado: boolean }}
+ */
+export function derivarEscala(p = {}) {
+  if (ESCALAS_FINCA.includes(p.escala)) return { escala: p.escala, declarado: true };
+  if (p.finca_tipo === 'invernadero') return { escala: 'invernadero', declarado: true };
+  if (p.finca_tipo === 'balcon' || p.finca_tipo === 'terraza') {
+    return { escala: 'balcon', declarado: true };
+  }
+  if (p.finca_tipo === 'rural') return { escala: 'finca', declarado: true };
+  if (p.vocacion === 'urbano') return { escala: 'balcon', declarado: true };
+  return { escala: 'finca', declarado: false };
+}
+
+/**
+ * De dónde toma el agua. Hoy se DERIVA de la pregunta `riego` que ya existe,
+ * y solo en los dos casos inequívocos (secano = lluvia · acequia = quebrada).
+ * Manguera/goteo no dicen de dónde SALE el agua → queda null hasta que el
+ * paso 3 del spec agregue la pregunta explícita (`agua`).
+ *
+ * @param {Object} p perfil plano
+ * @returns {{ agua: string|null, declarado: boolean }}
+ */
+export function derivarAgua(p = {}) {
+  if (FUENTES_AGUA.includes(p.agua)) return { agua: p.agua, declarado: true };
+  if (p.riego === 'lluvia') return { agua: 'lluvia', declarado: true };
+  if (p.riego === 'acequia') return { agua: 'quebrada', declarado: true };
+  return { agua: null, declarado: false };
+}
+
+/**
+ * Normaliza CUALQUIER entrada (perfil plano del onboarding, perfil ya tipado,
+ * null) a un `PerfilFinca` completo y seguro. Nunca lanza: si no entiende algo,
+ * cae al valor del perfil de demo (que no resta nada).
+ *
+ * @param {Object|null} perfil
+ * @returns {PerfilFinca}
+ */
+export function normalizarPerfilFinca(perfil) {
+  if (!perfil || typeof perfil !== 'object') return { ...PERFIL_FINCA_DEMO };
+  // ¿Ya viene tipado (tiene `declarado`)? Entonces solo se sanea.
+  const yaTipado = perfil.declarado && typeof perfil.declarado === 'object';
+  const base = yaTipado ? perfil : derivarPerfilFinca(perfil);
+  return {
+    ...PERFIL_FINCA_DEMO,
+    ...base,
+    ubicacion: { ...UBICACION_VACIA, ...(base.ubicacion || {}) },
+    escala: ESCALAS_FINCA.includes(base.escala) ? base.escala : 'finca',
+    pisoTermico: PISOS_TERMICOS_IDS.includes(base.pisoTermico) ? base.pisoTermico : null,
+    cultiva: Array.isArray(base.cultiva) ? base.cultiva : [],
+    animales: Array.isArray(base.animales) ? base.animales : [],
+    mundosActivos: Array.isArray(base.mundosActivos) ? base.mundosActivos : [],
+    declarado: { ...PERFIL_FINCA_DEMO.declarado, ...(base.declarado || {}) },
+  };
+}
+
+/**
+ * EL DERIVADOR: perfil plano del onboarding → `PerfilFinca` tipado.
+ *
+ * Migración suave garantizada: un perfil viejo (o vacío) devuelve el perfil de
+ * demo — nada declarado, valle completo, cero regresiones.
+ *
+ * @param {Object} [profile] perfil plano; si se omite, se lee de localStorage
+ * @returns {PerfilFinca}
+ */
+export function derivarPerfilFinca(profile) {
+  const p = profile && typeof profile === 'object' ? profile : {};
+
+  const lat = num(p.ubicacion_lat);
+  const lon = num(p.ubicacion_lng);
+  const altitud = num(p.finca_altitud);
+  const municipio = texto(p.municipio) || null;
+  const hayUbicacion = lat != null || lon != null || altitud != null || municipio != null;
+
+  /* El PISO TÉRMICO solo sale del perfil REAL del usuario (slug guardado o su
+     altitud). Jamás del env de demo: la finca de muestra no puede recortarle
+     el valle a nadie. */
+  const pisoDeclarado = PISOS_TERMICOS_IDS.includes(p.piso_termico) ? p.piso_termico : null;
+  const pisoTermico = pisoDeclarado || (hayUbicacion ? pisoTermicoDeAltitud(altitud) : null);
+
+  const { escala, declarado: escalaDeclarada } = derivarEscala(p);
+  const { agua, declarado: aguaDeclarada } = derivarAgua(p);
+
+  const tieneInvernadero = p.invernadero_tiene === 'si' || p.finca_tipo === 'invernadero';
+  const invernaderoDeclarado = p.invernadero_tiene === 'si' || p.invernadero_tiene === 'no'
+    || p.finca_tipo === 'invernadero';
+  const invernadero = tieneInvernadero
+    ? {
+      tipo: TIPOS_INVERNADERO.includes(p.invernadero_forma) ? p.invernadero_forma : null,
+      tamano: texto(p.invernadero_tamano),
+    }
+    : null;
+
+  const animales = listaTexto(p.animales).filter((a) => a !== 'ninguno');
+  const animalesDeclarados = Array.isArray(p.animales) && p.animales.length > 0;
+  const cultiva = listaTexto(p.cultivos_actuales);
+
+  return {
+    ubicacion: {
+      lat,
+      lon,
+      altitudMsnm: altitud,
+      municipio,
+      departamento: texto(p.departamento),
+      vereda: texto(p.vereda),
+      fuente: hayUbicacion ? 'perfil' : 'demo',
+    },
+    pisoTermico,
+    escala,
+    invernadero,
+    cultiva,
+    animales,
+    agua,
+    mundosActivos: Array.isArray(p.mundos_activos) ? p.mundos_activos.filter(Boolean) : [],
+    declarado: {
+      ubicacion: hayUbicacion,
+      escala: escalaDeclarada,
+      invernadero: invernaderoDeclarado,
+      cultiva: cultiva.length > 0,
+      animales: animalesDeclarados,
+      agua: aguaDeclarada,
+    },
+  };
+}
+
+/**
+ * El perfil de la finca AHORA (lee localStorage). Sin React: sirve en
+ * servicios, builders de prompt y tests.
+ * @returns {PerfilFinca}
+ */
+export function getPerfilFinca() {
+  try {
+    return derivarPerfilFinca(getProfile());
+  } catch (_) {
+    return { ...PERFIL_FINCA_DEMO };
+  }
+}
+
+/**
+ * CONTEXTO GEOAGRONÓMICO de la finca para quien antes leía `VITE_FARM_*`
+ * (builders de IA externa, gremios, alertas, plagas).
+ *
+ * Cascada honesta: lo que el usuario ubicó en el onboarding → el default de
+ * demo del build (`FARM_CONFIG`) → null. Así el consejo sale con la altitud y
+ * el municipio VERDADEROS, y la demo del guión sigue funcionando igual.
+ *
+ * @param {Object} [profile] perfil plano; si se omite, se lee de localStorage
+ * @returns {{ lat: number|null, lon: number|null, altitudMsnm: number|null,
+ *             municipio: string|null, thermalZones: string[],
+ *             fuente: 'perfil'|'demo' }}
+ */
+export function getContextoGeoFinca(profile) {
+  const perfil = profile !== undefined
+    ? derivarPerfilFinca(profile)
+    : getPerfilFinca();
+  const u = perfil.ubicacion;
+  const zonasEnv = Array.isArray(FARM_CONFIG.THERMAL_ZONES) ? FARM_CONFIG.THERMAL_ZONES : [];
+  return {
+    lat: u.lat ?? (typeof FARM_CONFIG.LATITUDE === 'number' ? FARM_CONFIG.LATITUDE : null),
+    lon: u.lon ?? (typeof FARM_CONFIG.LONGITUDE === 'number' ? FARM_CONFIG.LONGITUDE : null),
+    altitudMsnm: u.altitudMsnm ?? FARM_CONFIG.ALTITUD_MSNM ?? null,
+    municipio: u.municipio ?? FARM_CONFIG.MUNICIPIO ?? null,
+    thermalZones: perfil.pisoTermico ? [perfil.pisoTermico] : zonasEnv,
+    fuente: u.fuente,
+  };
+}
+
+/**
+ * El contexto geoagronómico en las claves que hablan los builders de IA
+ * externa (`altitudMsnm` · `municipio` · `thermalZones`). Azúcar sobre
+ * `getContextoGeoFinca()` para que los componentes lo esparzan de una:
+ * `context={{ speciesName, ...getContextoGeoParaIA() }}`.
+ */
+export function getContextoGeoParaIA() {
+  const { altitudMsnm, municipio, thermalZones } = getContextoGeoFinca();
+  return { altitudMsnm, municipio, thermalZones };
+}

--- a/src/services/perfilFincaService.js
+++ b/src/services/perfilFincaService.js
@@ -33,7 +33,7 @@
  * (el valle se ve como hoy); solo una respuesta EXPLÍCITA cambia el mundo.
  */
 import { FARM_CONFIG } from '../config/defaults';
-import { getProfile } from './userProfileService';
+import { getProfile, INVERNADERO_FORMAS } from './userProfileService';
 
 /** Escalas válidas del mundo. `finca` es el default seguro (valle completo). */
 export const ESCALAS_FINCA = Object.freeze(['balcon', 'invernadero', 'finca']);
@@ -50,14 +50,7 @@ export const FUENTES_AGUA = Object.freeze(['quebrada', 'tanque', 'lluvia', 'acue
  * cuadrado · tunel · casa_sombra · malla_sombra · umbraculo · otro.
  * NO se inventa un catálogo paralelo.
  */
-export const TIPOS_INVERNADERO = Object.freeze([
-  'cuadrado',
-  'tunel',
-  'casa_sombra',
-  'malla_sombra',
-  'umbraculo',
-  'otro',
-]);
+export const TIPOS_INVERNADERO = INVERNADERO_FORMAS;
 
 /**
  * @typedef {Object} UbicacionFinca

--- a/src/store/usePerfilFincaStore.js
+++ b/src/store/usePerfilFincaStore.js
@@ -1,0 +1,136 @@
+/*
+ * usePerfilFincaStore — EL PERFIL DE LA FINCA, vivo, para la UI.
+ *
+ * Paso 1 del spec del valle dinámico: UN SOLO ORIGEN DE VERDAD de "cómo es SU
+ * finca". El valle deja de ser el mismo para todos y se arma con ESTO.
+ *
+ * NO duplica persistencia: la verdad sigue viviendo en el perfil del usuario
+ * (`chagra:profile:*`, userProfileService) — lo que el onboarding ya escribe.
+ * Este store es la CARA REACTIVA de ese perfil: lo normaliza (perfilFincaService),
+ * lo mantiene fresco cuando el usuario se ubica o cambia su perfil, y ofrece
+ * los setters de los datos que faltan (escala · invernadero · agua · mundos
+ * agregados) para que los pasos 3-5 solo tengan que llamarlos.
+ *
+ * Regla dura heredada: un dato que FALTA nunca resta. Sin perfil, el store
+ * entrega `PERFIL_FINCA_DEMO` y el valle se ve como siempre.
+ */
+import { create } from 'zustand';
+import {
+  ESCALAS_FINCA,
+  FUENTES_AGUA,
+  PERFIL_FINCA_DEMO,
+  TIPOS_INVERNADERO,
+  getPerfilFinca,
+} from '../services/perfilFincaService';
+import { getProfile, saveProfile } from '../services/userProfileService';
+
+/** Eventos que dejan el perfil desactualizado en pantalla. */
+const EVENTOS_PERFIL = [
+  'chagra:location-updated', // el onboarding acaba de ubicar la finca
+  'chagra:profile-changed', // cambió algo del perfil (presets, guardián…)
+  'chagra:profile:demo-switched', // se entró/salió del perfil de demo
+];
+
+function leerPerfil() {
+  try {
+    return getPerfilFinca();
+  } catch (_) {
+    return { ...PERFIL_FINCA_DEMO };
+  }
+}
+
+/** Persiste en el perfil real y re-hidrata el store desde ahí (una verdad). */
+function persistir(partial, set) {
+  try {
+    saveProfile(partial);
+  } catch (_) {
+    /* sin storage (SSR / tests): el store igual refleja el cambio abajo */
+  }
+  set({ perfil: leerPerfil() });
+}
+
+const usePerfilFincaStore = create((set, get) => ({
+  /** @type {import('../services/perfilFincaService').PerfilFinca} */
+  perfil: leerPerfil(),
+
+  /** Re-lee el perfil desde localStorage (tras onboarding, import, demo…). */
+  hidratar: () => set({ perfil: leerPerfil() }),
+
+  /**
+   * ESCALA del mundo: 'balcon' | 'invernadero' | 'finca'. Es lo que decide el
+   * tamaño del valle (paso 3 del spec la pregunta en el onboarding).
+   */
+  setEscala: (escala) => {
+    if (!ESCALAS_FINCA.includes(escala)) return;
+    persistir({ escala }, set);
+  },
+
+  /**
+   * Invernadero: `null` = no tiene. `{ tipo, tamano }` = sí, y de qué forma.
+   * Escribe las MISMAS claves planas que ya usa el onboarding/escena F2.
+   */
+  setInvernadero: (inv) => {
+    if (!inv) {
+      persistir({ invernadero_tiene: 'no', invernadero_forma: undefined }, set);
+      return;
+    }
+    const tipo = TIPOS_INVERNADERO.includes(inv.tipo) ? inv.tipo : undefined;
+    const tamano = typeof inv.tamano === 'string' && inv.tamano.trim() ? inv.tamano.trim() : undefined;
+    persistir({ invernadero_tiene: 'si', invernadero_forma: tipo, invernadero_tamano: tamano }, set);
+  },
+
+  /** De dónde toma el agua la finca: quebrada | tanque | lluvia | acueducto. */
+  setAgua: (agua) => {
+    if (!FUENTES_AGUA.includes(agua)) return;
+    persistir({ agua }, set);
+  },
+
+  /**
+   * AGREGAR un mundo que la persona NO tiene, para conocerlo (paso 5 del spec:
+   * la vitrina maestra como catálogo). Se guarda aparte de lo que sí tiene —
+   * el valle puede distinguir "su finca" de "lo que puede conocer".
+   */
+  agregarMundo: (id) => {
+    if (typeof id !== 'string' || !id.trim()) return;
+    const actuales = get().perfil.mundosActivos || [];
+    if (actuales.includes(id)) return;
+    persistir({ mundos_activos: [...actuales, id] }, set);
+  },
+
+  /** Quitar un mundo agregado a mano (no toca los que la finca sí tiene). */
+  quitarMundo: (id) => {
+    const actuales = get().perfil.mundosActivos || [];
+    if (!actuales.includes(id)) return;
+    persistir({ mundos_activos: actuales.filter((m) => m !== id) }, set);
+  },
+
+  /** El perfil PLANO crudo (escape hatch para quien necesite una clave suelta). */
+  perfilCrudo: () => {
+    try {
+      return getProfile();
+    } catch (_) {
+      return {};
+    }
+  },
+}));
+
+/* El valle vive montado mientras el usuario se ubica en el onboarding: sin
+   esto el 3D seguiría mostrando la finca de demo hasta recargar. Fail-silent
+   en SSR/tests sin window. */
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  const rehidratar = () => {
+    try {
+      usePerfilFincaStore.getState().hidratar();
+    } catch (_) {
+      /* noop */
+    }
+  };
+  EVENTOS_PERFIL.forEach((evt) => window.addEventListener(evt, rehidratar));
+}
+
+/** Snapshot sin hooks (servicios, builders, tests). */
+export function getPerfilFincaActual() {
+  return usePerfilFincaStore.getState().perfil;
+}
+
+export default usePerfilFincaStore;


### PR DESCRIPTION
Pasos 3-5 del contrato del valle dinámico, construidos encima del store y de
`construirLugaresValle` que entregó #2654.

## El principio

**Cada respuesta del onboarding siembra algo que el campesino después ve.** Si una pregunta
no cambia nada de su valle, esa pregunta sobra y no debería existir.

| Paso nuevo | Qué siembra |
|---|---|
| **Escala** — balcón / invernadero / finca | Decide el tamaño del mundo. Es el dato que más manda: un balcón no es una finca de 10.000 matas |
| **Invernadero** y su forma | Reusa el catálogo `INVERNADERO_FORMAS` que **ya existía** — el cuadrado ya estaba como forma válida — en vez de abrir uno paralelo |
| **Agua** — quebrada / tanque / lluvia / acueducto | Para que el ciclo del agua sea el de SU finca y no uno de muestra |

Más **agregar mundos desde la vitrina maestra**, distinguiendo visualmente lo que el campesino
**tiene** de lo que **puede conocer**. Si esos dos se confunden, el campesino termina creyendo
que su finca tiene cosas que no tiene.

## Verificación

- **Suite de compatibilidad: 18/18.** `construirLugaresValle(PERFIL_DEMO)` sigue devolviendo los
  14 lugares de siempre — a ningún usuario existente se le mueve el valle que ya tenía. Esa era
  la regla dura del contrato.
- `npx vite build` → verde, 24,7 s
- `eslint` → 0 errores (5 warnings de i18n del patrón ADR-050, preexistentes en el estilo del repo)

## Nota de procedencia

El trabajo estaba terminado en un worktree que el worker mató antes de que alcanzara a pushear
(`branch NO llegó a origin`). Se rescató, se verificó de nuevo desde cero, y va acá. Nada se
dio por bueno sin volver a correrlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)