### PR TITLE
feat(angelita): el estado no-se — que sepa decir que no sabe

### DIFF
--- a/src/mockups/AngelitaViva.jsx
+++ b/src/mockups/AngelitaViva.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { AngelitaEntrada } from '../visual/agente/AngelitaEntrada.jsx';
 import { Angelita } from '../visual/agente/Angelita.jsx';
+import BurbujaAngelita from '../visual/agente/BurbujaAngelita.jsx';
+import { TEXTO_NO_SE } from '../visual/agente/angelitaEstados.js';
 
 /*
  * AngelitaViva — vitrina de LA COMPAÑERA al máximo (#/mockups/angelita-viva).
@@ -25,7 +27,7 @@ const ESTADOS_VITRINA = [
   ['habla', 'respondiendo', 'Lip-sync + gestos + cejas vivas'],
   ['celebra', 'contenta', 'Brinca con chispas y ojos de dicha'],
   ['aviso', 'preocupada', 'Alerta honesta: cejas, sudor, aro'],
-  ['no sabe', 'no-se', 'Se encoge de hombros y lo dice'],
+  ['no sabe', 'no-se', 'Niega con la cabeza y lo dice: "No sé"'],
   ['señala', 'senala', 'Se inclina y apunta al lugar'],
   ['invita', 'invita', 'Venga, le muestro'],
   ['husmea', 'husmea', 'Fisgonea el rastro, cejas fruncidas'],
@@ -167,6 +169,11 @@ export default function AngelitaViva({ onBack }) {
                   visema={estado === 'respondiendo' ? visema : null}
                   confianza={estado === 'respondiendo' ? 'alta' : null}
                 />
+                {/* no-se: el gesto (niega con la cabeza) + el texto EXPLÍCITO,
+                    nunca solo el uno o el otro (feedback del operador). */}
+                {estado === 'no-se' && (
+                  <BurbujaAngelita mensaje={TEXTO_NO_SE} tipo="informativa" animado={false} />
+                )}
                 <figcaption style={{ fontSize: 13 }}>
                   <strong style={{ textTransform: 'capitalize' }}>{nombre}</strong>
                   <div style={{ fontSize: 11.5, opacity: 0.7, marginTop: 2 }}>{nota}</div>

--- a/src/visual/agente/Angelita.jsx
+++ b/src/visual/agente/Angelita.jsx
@@ -43,8 +43,11 @@ import {
  *   contenta     → brinca celebrando (pose celebra) con chispas doradas.
  *   preocupada   → alerta honesta: cejas fruncidas, gota de sudor, aro coral
  *                  que late, vibración inquieta. Para plaga/sequía/riesgo.
- *   no-se        → LA HONESTA: se encoge de hombros con las palmas arriba y
- *                  un "?" dibujado a mano. Sonríe: no saber no la avergüenza.
+ *   no-se        → LA HONESTA: NIEGA CON LA CABEZA mientras se encoge de
+ *                  hombros con las palmas arriba y un "?" dibujado a mano.
+ *                  Sonríe: no saber no la avergüenza. El texto que la
+ *                  acompaña debe decir "No sé" claro, sin rodeos
+ *                  (angelitaEstados.TEXTO_NO_SE).
  *   senala       → guía: se inclina y apunta (pose señala) con destello en
  *                  el punto señalado.
  *   invita       → guía: se inclina hacia usted y hace "venga" con la manita.
@@ -224,6 +227,11 @@ function MotaDeVilano() {
  * @param {number} [props.energia]
  * @param {string|null} [props.mundoId]  su herramienta por mundo (PropEnMano).
  * @param {boolean} [props.lineBoil]  contorno que hierve (momentos heroicos).
+ * @param {boolean} [props.idleCerebro=true]  false apaga SOLO el reloj de
+ *   micro-gestos (mira/distraída-con-mota/acicala/rasca/sacude/posa) del idle
+ *   'acompana' — el aleteo y el boil base de <AbejaAngelita> siguen intactos.
+ *   Para momentos "viva pero quieta" (la pausa de AngelitaEntrada antes del
+ *   número: nada que compita con la entrada que viene).
  * @param {string} [props.title]  pisa la narración aria derivada del estado.
  */
 export function Angelita({
@@ -241,6 +249,7 @@ export function Angelita({
   energia = 1,
   mundoId = null,
   lineBoil = false,
+  idleCerebro = true,
   /* Gafas de sol (día soleado / entrada teatral): passthrough al cuerpo.
      false | true | 'poniendose' (la caída one-shot). */
   gafas = false,
@@ -266,7 +275,7 @@ export function Angelita({
   /* ═══ IDLE-CEREBRO (solo acompana) — el reloj con jitter que hojea el
      repertorio de micro-gestos. flota → gesto → flota…; posa encadena
      posada → despega. Gates: animated, estado, tier bajo, reduced-motion. */
-  const idleActivo = vivo && e === 'acompana' && tier !== 'bajo';
+  const idleActivo = vivo && e === 'acompana' && tier !== 'bajo' && idleCerebro;
   const [momento, setMomento] = useState('flota');
   useEffect(() => {
     if (!idleActivo || prefiereQuietud()) return undefined;

--- a/src/visual/agente/AngelitaEntrada.jsx
+++ b/src/visual/agente/AngelitaEntrada.jsx
@@ -9,22 +9,34 @@ import { Angelita } from './Angelita.jsx';
  * AngelitaEntrada — LA ENTRADA TEATRAL de la compañera de Chagra.
  *
  * Después del paneo de cámara del host (el valle terminó de presentarse), la
- * abejita hace su aparición de estrella de cartoon años 30:
+ * abejita hace su aparición de estrella de cartoon años 30. Orden (feedback
+ * del operador: "tan pequeña que cuando al fondo hace cualquier cosa no se
+ * nota" — el ojo necesita encontrarla ANTES de que pase algo):
  *
- *   1. ASOMA pequeñita — pop elástico a escala chiquita, curiosa, aleteando.
- *   2. Si es de DÍA y hace SOL (clima 'soleado'/'dorada'): SE PONE LAS GAFAS —
- *      caen giradas desde arriba, rebasan la carita, rebotan y asientan, con
- *      el destello que barre el lente (AngelitaGafas + angelita-missminutes).
- *   3. CRECE — anticipa (se agacha a coger impulso), se estira con OVERSHOOT
- *      hasta su tamaño de asistente, squash de aterrizaje, rebotico, y el aro
- *      de energía ámbar revienta al llegar: ya está aquí la compañera viva.
+ *   1. ASOMA pequeñita — pop elástico a escala chiquita, apareciendo.
+ *   2. QUIETA — se queda ESTÁTICA a esa misma escala chiquita 1-2s: nada de
+ *      idle-cerebro (mirar/acicalarse/la mota que pasa — apagado con
+ *      idleCerebro=false), apenas el aleteo/boil base de <Angelita> para
+ *      leerse viva sin distraer. Es la pausa que deja que el ojo la encuentre
+ *      antes del número.
+ *   3. CRECE — la entrada MAGISTRAL: anticipa (se agacha a coger impulso), se
+ *      estira con OVERSHOOT hasta su tamaño de asistente, squash de
+ *      aterrizaje, rebotico, y el aro de energía ámbar revienta al llegar.
+ *   4. Si es de DÍA y hace SOL (clima 'soleado'/'dorada'): AHORA, ya a tamaño
+ *      completo, SE PONE LAS GAFAS — caen giradas desde arriba, rebasan la
+ *      carita, rebotan y asientan, con el destello que barre el lente
+ *      (AngelitaGafas + angelita-missminutes). A tamaño completo SE VEN Y
+ *      RESALTAN (antes pasaba a escala chiquita y se perdían).
+ *   5. BRILLO — un destello breve que remata y avisa "ya estoy lista"; se
+ *      apaga solo (no un glow permanente).
  *
  * El JS solo es el METRÓNOMO de fases (clases .ang-entrada--*); el timing y
  * las curvas viven en el CSS. Contratos de la casa:
  *   · reduced-motion (o animated=false) NO hace teatro: aparece YA en tamaño
  *     final, con las gafas puestas si corresponde — fotograma digno.
  *   · El line-boil (capa cara) se enciende SOLO durante el número (asoma →
- *     crece) y en tier alto/medio: es su momento heroico, no un loop eterno.
+ *     crece → gafas → brillo), NUNCA en la pausa quieta, y en tier alto/medio:
+ *     es su momento heroico, no un loop eterno.
  *   · Al terminar queda una <Angelita> normal (estadoFinal) y el host sigue
  *     mandando con sus props de siempre; `onLista` avisa el fin del show.
  *
@@ -36,8 +48,10 @@ import { Angelita } from './Angelita.jsx';
    (regla dura de la casa: el metrónomo suelta la clase cuando el gesto terminó
    en identidad, y el empalme no salta). */
 const DUR_ASOMA = 900;    // = ang-asoma
+const DUR_QUIETA = 1500;  // la pausa estática (1-2s): que el ojo la encuentre
 const DUR_GAFAS = 1650;   // = agz-ponerse (950) + destello (500 desde 0.9s) + respiro
 const DUR_CRECE = 1300;   // = ang-crece
+const DUR_BRILLO = 650;   // = ang-destello-final: el remate que avisa "ya lista"
 
 /** ¿Es un momento de gafas? Día con sol en el vocabulario canónico del valle
  *  ('dorada' | 'soleado' | 'niebla' | 'lluvia' | 'noche'). */
@@ -99,14 +113,20 @@ export function AngelitaEntrada({
       timer = window.setTimeout(siguiente, dur);
     };
     timer = window.setTimeout(() => {
+      // 1. Asoma (pop elástico, pequeñita) → 2. Quieta (pausa estática: que
+      // el ojo la encuentre) → 3. Crece (la entrada magistral, overshoot) →
+      // 4. Gafas si hay sol (ya a tamaño completo) → 5. Brillo (remate) → lista.
       paso('asoma', DUR_ASOMA + 350, () => {
-        if (soleado) {
-          paso('gafas', DUR_GAFAS, () => {
-            paso('crece', DUR_CRECE, () => setFase('lista'));
+        paso('quieta', DUR_QUIETA, () => {
+          paso('crece', DUR_CRECE, () => {
+            const rematar = () => paso('brillo', DUR_BRILLO, () => setFase('lista'));
+            if (soleado) {
+              paso('gafas', DUR_GAFAS, rematar);
+            } else {
+              rematar();
+            }
           });
-        } else {
-          paso('crece', DUR_CRECE, () => setFase('lista'));
-        }
+        });
       });
     }, retrasoMs);
     return () => window.clearTimeout(timer);
@@ -121,20 +141,26 @@ export function AngelitaEntrada({
     }
   }, [fase]);
 
-  // Las gafas: caen en la fase 'gafas' (one-shot) y QUEDAN puestas después.
+  // Las gafas: caen en la fase 'gafas' (one-shot, YA a tamaño completo — se
+  // ven y resaltan) y QUEDAN puestas de ahí en adelante (brillo → lista).
   const gafas = useMemo(() => {
     if (!soleado) return false;
     if (sinTeatro) return true;
     if (fase === 'gafas') return 'poniendose';
-    return (fase === 'crece' || fase === 'lista') ? true : false;
+    return (fase === 'brillo' || fase === 'lista') ? true : false;
   }, [soleado, sinTeatro, fase]);
 
-  // Estado del agente por fase: curiosa mientras asoma/se viste, CONTENTA en
-  // el estirón (brinca celebrando mientras crece — puro cartoon), y al quedar
-  // lista, lo que el host pida.
+  // Estado del agente por fase: curiosa mientras asoma/quieta/se viste,
+  // CONTENTA en el estirón (brinca celebrando mientras crece — puro cartoon),
+  // y al quedar lista, lo que el host pida.
   const estado = fase === 'crece' ? 'contenta' : fase === 'lista' ? estadoFinal : 'acompana';
-  // Su momento heroico: line-boil solo durante el número (y no en gama baja).
-  const heroica = !sinTeatro && fase !== 'lista' && fase !== 'espera' && tier !== 'bajo';
+  // En la pausa quieta se apaga el idle-cerebro grande (mirar, acicalarse, la
+  // mota que pasa): "apenas lo mínimo para leerse viva, nada que distraiga".
+  // El aleteo/boil base de <Angelita> sigue intacto (idleCerebro no los toca).
+  const idleCerebro = fase !== 'quieta';
+  // Su momento heroico: line-boil solo durante el número (asoma→crece→gafas→
+  // brillo), NUNCA en la pausa quieta ni en gama baja.
+  const heroica = !sinTeatro && fase !== 'lista' && fase !== 'espera' && fase !== 'quieta' && tier !== 'bajo';
 
   return (
     <span
@@ -148,6 +174,7 @@ export function AngelitaEntrada({
           size={size}
           animated={animated}
           tier={tier}
+          idleCerebro={idleCerebro}
           gafas={gafas}
           lineBoil={heroica}
           clima={clima}
@@ -155,6 +182,7 @@ export function AngelitaEntrada({
         />
       </span>
       <span className="ang-entrada__aro" aria-hidden="true" />
+      <span className="ang-entrada__brillo" aria-hidden="true" />
     </span>
   );
 }

--- a/src/visual/agente/__tests__/AngelitaEntrada.fases.test.jsx
+++ b/src/visual/agente/__tests__/AngelitaEntrada.fases.test.jsx
@@ -1,0 +1,152 @@
+/**
+ * AngelitaEntrada.fases.test.jsx — el ORDEN NUEVO de la entrada teatral
+ * (pedido textual del operador, 2026-07-21): "cambia el orden para que esté
+ * estática uno o dos segundos en el fondo, hace su entrada magistral, y si es
+ * el caso se pone las gafas que se vea y resalte, con un brillito temporal
+ * cuando ya queda lista."
+ *
+ * Secuencia verificada: espera → asoma → QUIETA (nueva, estática, idle-cerebro
+ * apagado) → crece (overshoot) → gafas (YA a tamaño completo, si hay sol) →
+ * BRILLO (nuevo, remate que se apaga solo) → lista. Las duraciones (ms) deben
+ * seguir coincidiendo con los keyframes de angelita-missminutes.css.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import { AngelitaEntrada } from '../AngelitaEntrada.jsx';
+
+afterEach(cleanup);
+
+const fase = (container) => {
+  const el = container.querySelector('.ang-entrada');
+  const clase = Array.from(el.classList).find((c) => c.startsWith('ang-entrada--'));
+  return clase.replace('ang-entrada--', '');
+};
+
+const gafasAttr = (container) => container.querySelector('[data-gafas]')?.getAttribute('data-gafas') ?? null;
+const lineboilAttr = (container) => container.querySelector('[data-lineboil]')?.getAttribute('data-lineboil') ?? null;
+
+describe('AngelitaEntrada — secuencia nueva (soleado)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('recorre espera→asoma→quieta→crece→gafas→brillo→lista, en orden', () => {
+    // Fronteras acumuladas (ms desde el montaje), a partir de las constantes
+    // del JS: asoma [0,1250) → quieta [1250,2750) → crece [2750,4050) →
+    // gafas [4050,5700) → brillo [5700,6350) → lista desde 6350.
+    const { container } = render(<AngelitaEntrada activa clima="soleado" />);
+
+    // Arranca en 'espera' (retrasoMs=0 aún no corrió el primer timer).
+    expect(fase(container)).toBe('espera');
+
+    act(() => { vi.advanceTimersByTime(0); });
+    expect(fase(container)).toBe('asoma');
+
+    // Todavía en 'asoma' justo antes de que cierre (frontera en 1250ms).
+    act(() => { vi.advanceTimersByTime(1200); }); // t=1200
+    expect(fase(container)).toBe('asoma');
+    act(() => { vi.advanceTimersByTime(100); }); // t=1300 (cruza 1250)
+    expect(fase(container)).toBe('quieta');
+
+    // 'quieta' se sostiene ~1.5s completos (nada que distraiga: sin idle-cerebro).
+    act(() => { vi.advanceTimersByTime(1400); }); // t=2700
+    expect(fase(container)).toBe('quieta');
+    act(() => { vi.advanceTimersByTime(100); }); // t=2800 (cruza 2750)
+    expect(fase(container)).toBe('crece');
+
+    // 'crece' dura 1300ms — la entrada magistral (overshoot).
+    act(() => { vi.advanceTimersByTime(1200); }); // t=4000
+    expect(fase(container)).toBe('crece');
+    act(() => { vi.advanceTimersByTime(100); }); // t=4100 (cruza 4050)
+    expect(fase(container)).toBe('gafas');
+
+    // Las gafas caen YA a tamaño completo (soleado): fase 'gafas' dura 1650ms.
+    act(() => { vi.advanceTimersByTime(1550); }); // t=5650
+    expect(fase(container)).toBe('gafas');
+    act(() => { vi.advanceTimersByTime(100); }); // t=5750 (cruza 5700)
+    expect(fase(container)).toBe('brillo');
+
+    // El brillito remata rápido (650ms) y se apaga solo pasando a 'lista'.
+    act(() => { vi.advanceTimersByTime(700); }); // t=6450 (cruza 6350)
+    expect(fase(container)).toBe('lista');
+  });
+
+  it('las gafas están OFF durante asoma/quieta/crece y YA a tamaño completo cuando caen', () => {
+    const { container } = render(<AngelitaEntrada activa clima="soleado" />);
+    act(() => { vi.advanceTimersByTime(0); }); // asoma
+    expect(gafasAttr(container)).toBeNull();
+    act(() => { vi.advanceTimersByTime(1260); }); // quieta
+    expect(fase(container)).toBe('quieta');
+    expect(gafasAttr(container)).toBeNull();
+    act(() => { vi.advanceTimersByTime(1600); }); // crece
+    expect(fase(container)).toBe('crece');
+    expect(gafasAttr(container)).toBeNull();
+    act(() => { vi.advanceTimersByTime(1350); }); // gafas
+    expect(fase(container)).toBe('gafas');
+    expect(gafasAttr(container)).toBe('poniendose');
+    // Y en esta fase el wrapper de escala YA quedó a tamaño completo (sin
+    // scale chiquito) — se ven y resaltan, no se pierden.
+    const escala = container.querySelector('.ang-entrada__escala');
+    expect(escala.className).toContain('ang-entrada__escala');
+  });
+
+  it('el line-boil (momento heroico) se apaga en la pausa quieta', () => {
+    const { container } = render(<AngelitaEntrada activa clima="soleado" />);
+    act(() => { vi.advanceTimersByTime(0); }); // asoma
+    expect(fase(container)).toBe('asoma');
+    expect(lineboilAttr(container)).toBe('1');
+    act(() => { vi.advanceTimersByTime(1260); }); // quieta
+    expect(fase(container)).toBe('quieta');
+    expect(lineboilAttr(container)).toBeNull();
+  });
+
+  it('onLista se dispara UNA sola vez, solo al llegar a "lista"', () => {
+    const onLista = vi.fn();
+    render(<AngelitaEntrada activa clima="soleado" onLista={onLista} />);
+    act(() => { vi.advanceTimersByTime(0); });
+    expect(onLista).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(1250 + 1500 + 1300 + 1650 + 650 + 50); });
+    expect(onLista).toHaveBeenCalledTimes(1);
+    act(() => { vi.advanceTimersByTime(5000); });
+    expect(onLista).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AngelitaEntrada — nublado (sin gafas)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('salta de crece directo a brillo (sin fase gafas)', () => {
+    const { container } = render(<AngelitaEntrada activa clima={null} />);
+    act(() => { vi.advanceTimersByTime(0); }); // asoma
+    act(() => { vi.advanceTimersByTime(1260); }); // quieta
+    act(() => { vi.advanceTimersByTime(1600); }); // crece
+    expect(fase(container)).toBe('crece');
+    act(() => { vi.advanceTimersByTime(1350); }); // brillo (nunca 'gafas')
+    expect(fase(container)).toBe('brillo');
+    expect(gafasAttr(container)).toBeNull();
+  });
+});
+
+describe('AngelitaEntrada — reduced motion / animated=false: sin teatro', () => {
+  it('cae YA en "lista" (sin recorrer fases) y con gafas puestas si hay sol', () => {
+    const { container } = render(<AngelitaEntrada activa clima="soleado" animated={false} />);
+    expect(fase(container)).toBe('lista');
+    expect(gafasAttr(container)).toBe('1');
+  });
+
+  it('respeta prefers-reduced-motion aunque animated=true', () => {
+    const original = window.matchMedia;
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: query.includes('reduce'),
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    const { container } = render(<AngelitaEntrada activa clima="soleado" />);
+    expect(fase(container)).toBe('lista');
+    window.matchMedia = original;
+  });
+});

--- a/src/visual/agente/__tests__/AngelitaNoSe.test.jsx
+++ b/src/visual/agente/__tests__/AngelitaNoSe.test.jsx
@@ -1,0 +1,74 @@
+/**
+ * AngelitaNoSe.test.jsx — cuando Angelita NO SABE (pedido textual del
+ * operador, 2026-07-21): "no sabe debe ser no con la cabeza y con el 'no sé'
+ * claro en texto". Dos partes, verificadas por separado:
+ *
+ *   1. EL GESTO — niega con la cabeza: el estado 'no-se' agrupa cabeza+cara+
+ *      antenas+gafas en `.crt-cabeza` (AbejaAngelita.jsx) para poder rotarla
+ *      de lado a lado (angelita-agente.css, `agt-niega`) sin mover el resto
+ *      del cuerpo.
+ *   2. EL TEXTO — TEXTO_NO_SE es la frase canónica, explícita, sin rodeos
+ *      ("No sé."), y BurbujaAngelita la muestra tal cual, sin recortarla.
+ *
+ * También cubre el prop nuevo `idleCerebro` de <Angelita> (la pausa "quieta"
+ * de AngelitaEntrada lo usa para apagar el idle-cerebro grande sin tocar el
+ * aleteo/boil base).
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import { Angelita } from '../Angelita.jsx';
+import { TEXTO_NO_SE, ARIA_DE_ESTADO } from '../angelitaEstados.js';
+import BurbujaAngelita from '../BurbujaAngelita.jsx';
+
+afterEach(cleanup);
+
+describe('1. El gesto — niega con la cabeza', () => {
+  it('estado="no-se" trae el grupo .crt-cabeza (blanco de la rotación)', () => {
+    const { container } = render(<Angelita estado="no-se" animated />);
+    expect(container.querySelector('svg').getAttribute('data-agt-estado')).toBe('no-se');
+    expect(container.querySelector('.crt-cabeza')).toBeTruthy();
+  });
+
+  it('el grupo .crt-cabeza existe en TODOS los estados (mismo dibujo, no se re-autora)', () => {
+    for (const estado of ['acompana', 'contenta', 'preocupada', 'senala']) {
+      const { container, unmount } = render(<Angelita estado={estado} animated />);
+      expect(container.querySelector('.crt-cabeza')).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it('la narración aria de no-se menciona la negación con la cabeza', () => {
+    expect(ARIA_DE_ESTADO['no-se']).toMatch(/niega con la cabeza/i);
+    const { container } = render(<Angelita estado="no-se" animated />);
+    expect(container.querySelector('svg').getAttribute('aria-label')).toMatch(/niega con la cabeza/i);
+  });
+});
+
+describe('2. El texto — "No sé" claro, sin rodeos', () => {
+  it('TEXTO_NO_SE es explícito y corto (no una evasiva)', () => {
+    expect(TEXTO_NO_SE).toMatch(/^No sé\.?$/i);
+  });
+
+  it('BurbujaAngelita muestra "No sé" tal cual (no lo recorta ni lo diluye)', () => {
+    const { container } = render(<BurbujaAngelita mensaje={TEXTO_NO_SE} animado={false} />);
+    const texto = container.querySelector('.angelita-burbuja__texto');
+    expect(texto.textContent).toContain('No sé');
+  });
+});
+
+describe('3. idleCerebro — apaga SOLO el idle-cerebro grande (usado por la pausa quieta)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('idleCerebro=false: nunca aparece data-agt-idle, ni avanzando el reloj', () => {
+    const { container } = render(<Angelita estado="acompana" animated idleCerebro={false} />);
+    act(() => { vi.advanceTimersByTime(5000); });
+    expect(container.querySelector('svg').getAttribute('data-agt-idle')).toBeNull();
+  });
+
+  it('idleCerebro=true (default): el reloj de micro-gestos SÍ arranca', () => {
+    const { container } = render(<Angelita estado="acompana" animated />);
+    act(() => { vi.advanceTimersByTime(0); });
+    expect(container.querySelector('svg').getAttribute('data-agt-idle')).toBe('flota');
+  });
+});

--- a/src/visual/agente/angelita-agente.css
+++ b/src/visual/agente/angelita-agente.css
@@ -538,11 +538,12 @@
   38%      { transform: scale(1.02); opacity: 0.5; }   /* latido de alerta */
 }
 
-/* ── NO-SÉ — la honestidad hecha gesto: encoge los hombros (squash del cuerpo
-   hacia arriba) mientras ambas manitas se abren palmas-arriba con overshoot,
+/* ── NO-SÉ — la honestidad hecha gesto: NIEGA CON LA CABEZA (de lado a lado,
+   ver agt-niega más abajo) mientras encoge los hombros (squash del cuerpo
+   hacia arriba) y ambas manitas se abren palmas-arriba con overshoot,
    sostiene el "pues no sé, vea" y suelta. El signo ? flota arriba con line-boil
    de baja cadencia (steps — dibujado a mano, no péndulo). La sonrisa se queda:
-   no saber NO la avergüenza. */
+   no saber NO la avergüenza — decir "no sé" es la conducta correcta. */
 [data-agt-vivo='1'][data-agt-estado='no-se'] .agt-cuerpo {
   animation: agt-encoge 3.6s cubic-bezier(0.4, 0, 0.3, 1.35) infinite;
 }
@@ -595,6 +596,29 @@
   26%  { transform: rotate(-83deg); }
   68%  { transform: rotate(-86deg); }
   86%  { transform: rotate(4deg); }
+}
+/* NIEGA CON LA CABEZA — el gesto que faltaba (feedback del operador: "no sabe
+   debe ser no con la cabeza", no solo el encogimiento de hombros). Pivota
+   SOLO la cabeza (.crt-cabeza, agrupada aparte en AbejaAngelita.jsx: cabeza +
+   carita + antenas + gafas) de lado a lado — el cuerpo sigue con SU encogida
+   (agt-encoge) por debajo; los dos transforms componen porque son nodos
+   distintos. Decae en 3-4 negaciones y se asienta antes de repetir — no es un
+   tic nervioso sin fin, es "no… no… no." dicho con la cabeza. */
+.crt-cabeza {
+  transform-box: fill-box;
+  transform-origin: center bottom; /* pivota desde el cuello, no desde (0,0) del SVG */
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-estado='no-se'] .crt-cabeza {
+  animation: agt-niega 3.3s cubic-bezier(0.4, 0, 0.3, 1) infinite;
+}
+@keyframes agt-niega {
+  0%, 62%, 100% { transform: rotate(0deg); }
+  8%   { transform: rotate(-9deg); }
+  17%  { transform: rotate(8deg); }
+  26%  { transform: rotate(-8deg); }
+  35%  { transform: rotate(7deg); }
+  44%  { transform: rotate(-5deg); }
+  53%  { transform: rotate(3deg); }
 }
 .agt-nose-signo {
   transform-box: fill-box;
@@ -973,6 +997,7 @@
   .agt-vuelo, .agt-mota,
   [data-agente='angelita'] .crt-brazo-l,
   [data-agente='angelita'] .crt-brazo-r,
+  [data-agente='angelita'] .crt-cabeza,
   [data-agente='angelita'] .rh-blink,
   [data-agente='angelita'] .rh-mirada,
   [data-agente='angelita'] .rh-mirada > circle:last-of-type { animation: none !important; }

--- a/src/visual/agente/angelitaEstados.js
+++ b/src/visual/agente/angelitaEstados.js
@@ -117,11 +117,17 @@ export const ARIA_DE_ESTADO = {
   respondiendo: 'Angelita le está respondiendo',
   contenta: 'Angelita está contenta',
   preocupada: 'Angelita está preocupada: hay algo que conviene revisar',
-  'no-se': 'Angelita no sabe la respuesta, y se lo dice con honestidad',
+  'no-se': 'Angelita niega con la cabeza: no sabe la respuesta, y se lo dice con honestidad',
   senala: 'Angelita le está señalando algo',
   invita: 'Angelita lo invita a acercarse',
   husmea: 'Angelita está husmeando: revisa la finca con cuidado',
 };
+
+/* Cuando Angelita NO SABE, el globo (BurbujaAngelita) debe decirlo CLARO: "No
+   sé" a secas, nunca una evasiva ni un rodeo — decir "no sé" es la conducta
+   correcta (política anti-alucinación de Chagra), no una falla que disimular.
+   Los hosts que compongan el mensaje del estado 'no-se' parten de aquí. */
+export const TEXTO_NO_SE = 'No sé.';
 
 /* ── EL REPERTORIO DEL IDLE VIVO (estado acompana) ───────────────────────────
    Una vecina de verdad EXISTE aunque nadie le hable: entre ratos de vuelo

--- a/src/visual/agente/index.js
+++ b/src/visual/agente/index.js
@@ -17,6 +17,7 @@ export {
   ARIA_DE_ESTADO,
   CEJAS_DE_ESTADO,
   MOMENTOS_IDLE,
+  TEXTO_NO_SE,
   estadoCanonico,
   nivelDeConfianza,
   elegirMomentoIdle,

--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -269,31 +269,39 @@ export function AbejaAngelita({
       <Miembro clase="crt-brazo-r" origen="left top"
         d="M5.4,3.0 C6.9,4.2 7.5,5.9 7.0,7.5" ancho={2.2} punta={[7.0, 7.8]} puntaR={1.6} sway={vivo} delay={-0.45} />
 
-      {/* cabeza OSCURA (casi negra) con contorno — la mitad oscura del meliponino */}
-      <circle cx="8.6" cy="-1.0" r={ABEJA_PROPORCION.cabezaR} fill={ABEJA_PALETA.testa} stroke={RH_INK} strokeWidth="1.2" />
-      {/* MÁSCARA FACIAL clara: la marca amarilla del clípeo de la angelita real —
-          y, a la vez, el fondo sobre el que la carita (ojos/boca/cejas del agente)
-          sigue leyéndose pese a la cabeza oscura. Va bajo ojos/cachetes/boca. */}
-      <ellipse cx="9.4" cy="-0.2" rx="3.2" ry="3.4" fill={ABEJA_PALETA.cara} opacity="0.95" />
-      {/* chapetas campesinas + sonrisa + ojos de goma (parpadean juntos) */}
-      <Cachetes puntos={[{ cx: 10.4, cy: 0.7, r: 1.15 }, { cx: 6.9, cy: 0.3, r: 0.85 }]} vivo={vivo} />
-      {/* Boca: lip-sync si hay visema; si no, la sonrisa de goma de siempre. */}
-      {visema
-        ? <BocaVisema cx={8.9} cy={1.4} w={2.8} prof={1.1} visema={visema} />
-        : <Sonrisa cx={8.9} cy={1.4} w={2.8} prof={1.1} />}
-      <OjosRubber
-        ojos={[{ cx: 10.1, cy: -1.9, r: 1.95 }, { cx: 7.4, cy: -2.2, r: 1.45 }]}
-        mirar={[0.3, 0.34]}
-        parpadea={vivo}
-      />
-      {/* cejas expresivas (opt-in): el rasgo que actúa alegría/atención/foco */}
-      {cejas && <CejasRubber estilo={cejas} />}
-      {/* antenas con bombillo que se mecen (secondary motion) */}
-      <AntenaRubber d="M7.7,-4.7 C6.7,-7.3 7.0,-9.3 8.3,-10.1" bulbo={[8.3, -10.3]} sway={vivo} delay={0} />
-      <AntenaRubber d="M9.7,-4.6 C11.0,-6.7 11.3,-8.7 10.5,-10.3" bulbo={[10.5, -10.5]} sway={vivo} delay={-0.3} />
-      {/* gafas de sol (opt-in): por ENCIMA de ojos y cejas — con 'poniendose'
-          caen desde arriba con overshoot y el destello barre el lente */}
-      {gafas && <GafasSol puesta={gafas === 'poniendose' ? 'poniendose' : 'puesta'} animated={vivo} />}
+      {/* CABEZA — agrupada aparte (crt-cabeza) SOLO para que el agente pueda
+          negarla de lado a lado ("no sé", angelita-agente.css) sin mover el
+          resto del cuerpo: el mismo dibujo de siempre, un wrapper más. Con
+          vestuario=true el sombrero se dibuja AFUERA de este grupo (posición
+          fija por coordenadas) — no la sigue si niega; caso opt-in raro que
+          no ocurre en el agente conversacional (donde vive el gesto). */}
+      <g className="crt-cabeza">
+        {/* cabeza OSCURA (casi negra) con contorno — la mitad oscura del meliponino */}
+        <circle cx="8.6" cy="-1.0" r={ABEJA_PROPORCION.cabezaR} fill={ABEJA_PALETA.testa} stroke={RH_INK} strokeWidth="1.2" />
+        {/* MÁSCARA FACIAL clara: la marca amarilla del clípeo de la angelita real —
+            y, a la vez, el fondo sobre el que la carita (ojos/boca/cejas del agente)
+            sigue leyéndose pese a la cabeza oscura. Va bajo ojos/cachetes/boca. */}
+        <ellipse cx="9.4" cy="-0.2" rx="3.2" ry="3.4" fill={ABEJA_PALETA.cara} opacity="0.95" />
+        {/* chapetas campesinas + sonrisa + ojos de goma (parpadean juntos) */}
+        <Cachetes puntos={[{ cx: 10.4, cy: 0.7, r: 1.15 }, { cx: 6.9, cy: 0.3, r: 0.85 }]} vivo={vivo} />
+        {/* Boca: lip-sync si hay visema; si no, la sonrisa de goma de siempre. */}
+        {visema
+          ? <BocaVisema cx={8.9} cy={1.4} w={2.8} prof={1.1} visema={visema} />
+          : <Sonrisa cx={8.9} cy={1.4} w={2.8} prof={1.1} />}
+        <OjosRubber
+          ojos={[{ cx: 10.1, cy: -1.9, r: 1.95 }, { cx: 7.4, cy: -2.2, r: 1.45 }]}
+          mirar={[0.3, 0.34]}
+          parpadea={vivo}
+        />
+        {/* cejas expresivas (opt-in): el rasgo que actúa alegría/atención/foco */}
+        {cejas && <CejasRubber estilo={cejas} />}
+        {/* antenas con bombillo que se mecen (secondary motion) */}
+        <AntenaRubber d="M7.7,-4.7 C6.7,-7.3 7.0,-9.3 8.3,-10.1" bulbo={[8.3, -10.3]} sway={vivo} delay={0} />
+        <AntenaRubber d="M9.7,-4.6 C11.0,-6.7 11.3,-8.7 10.5,-10.3" bulbo={[10.5, -10.5]} sway={vivo} delay={-0.3} />
+        {/* gafas de sol (opt-in): por ENCIMA de ojos y cejas — con 'poniendose'
+            caen desde arriba con overshoot y el destello barre el lente */}
+        {gafas && <GafasSol puesta={gafas === 'poniendose' ? 'poniendose' : 'puesta'} animated={vivo} />}
+      </g>
 
       {/* Vestuario por clima+hora (ruana/sombrero/sudor) — solo con vestuario=true. */}
       {ropa && (

--- a/src/visual/creatures/angelita-missminutes.css
+++ b/src/visual/creatures/angelita-missminutes.css
@@ -12,10 +12,13 @@
  *                                      a fisgonear, la mirada barre el piso,
  *                                      las antenas apuntan, y las virutas de
  *                                      olor entran hacia su nariz.
- *   4. ENTRADA TEATRAL (.ang-entrada)— asoma pequeñita → (si hace sol) se pone
- *                                      las gafas → anticipa y CRECE con
- *                                      overshoot a tamaño de asistente, con su
- *                                      aro de energía. Timing de cartoon puro.
+ *   4. ENTRADA TEATRAL (.ang-entrada)— asoma pequeñita → se queda QUIETA una
+ *                                      pausa (que el ojo la encuentre) →
+ *                                      CRECE con overshoot a tamaño de
+ *                                      asistente (su aro de energía) → (si
+ *                                      hace sol) YA a tamaño completo se pone
+ *                                      las gafas → BRILLO final que remata.
+ *                                      Timing de cartoon puro.
  *
  * REGLAS DE LA CASA (las mismas de creatures.css / angelita-agente.css):
  *   · Solo transform/opacity (GPU, gama baja).
@@ -154,11 +157,15 @@
 }
 
 /* ═══ 4. LA ENTRADA TEATRAL (.ang-entrada) ═══════════════════════════════════
-   Después del paneo del host: asoma PEQUEÑITA (pop elástico) → si hace sol se
-   pone las gafas (fase quieta a escala chiquita: el show es de las gafas) →
-   anticipa (se recoge) y CRECE con overshoot a su tamaño de asistente, con el
-   aro de energía que revienta al llegar. El JS (AngelitaEntrada.jsx) solo
-   cambia la clase de fase; el timing vive aquí. */
+   Después del paneo del host: asoma PEQUEÑITA (pop elástico) → se queda
+   QUIETA a esa misma escala (pausa de 1-2s: el ojo la encuentra ANTES de que
+   pase algo — feedback del operador: tan pequeña que lo que hacía al fondo no
+   se notaba) → CRECE con overshoot a su tamaño de asistente (el aro de
+   energía revienta al llegar: la entrada MAGISTRAL) → si hace sol, YA a
+   tamaño completo se pone las gafas (se ven y resaltan — a escala chiquita se
+   perdían) → BRILLO final que remata y avisa "ya estoy lista", y se apaga
+   solo. El JS (AngelitaEntrada.jsx) solo cambia la clase de fase; el timing
+   vive aquí. */
 .ang-entrada {
   position: relative;
   display: inline-flex;
@@ -172,7 +179,7 @@
 }
 /* espera: todavía nada (el paneo del host sigue andando) */
 .ang-entrada--espera .ang-entrada__escala { transform: scale(0.36); opacity: 0; }
-/* asoma: pop elástico a tamaño pequeñito */
+/* asoma: pop elástico a tamaño pequeñito — aparece */
 .ang-entrada--asoma .ang-entrada__escala {
   animation: ang-asoma 0.9s cubic-bezier(0.3, 1.4, 0.5, 1) both;
 }
@@ -183,9 +190,13 @@
   82% { transform: scale(0.33); }
   100% { transform: scale(0.36); opacity: 1; }
 }
-/* gafas: quieta a escala chica (el one-shot de las gafas manda) */
-.ang-entrada--gafas .ang-entrada__escala { transform: scale(0.36); }
-/* crece: anticipación (se agacha y recoge) → estirón con overshoot → asienta */
+/* quieta: se queda ESTÁTICA a la misma escala en la que asentó `asoma` (cero
+   salto) — la pausa para que el ojo la encuentre antes del número. Angelita
+   (idleCerebro=false en esta fase) sigue viva por su aleteo/boil base, sin
+   gestos grandes que compitan con la entrada que viene. */
+.ang-entrada--quieta .ang-entrada__escala { transform: scale(0.36); opacity: 1; }
+/* crece: anticipación (se agacha y recoge) → estirón con overshoot → asienta.
+   Arranca en la MISMA escala en la que quedó `quieta` (0.36): cero salto. */
 .ang-entrada--crece .ang-entrada__escala {
   animation: ang-crece 1.3s cubic-bezier(0.3, 0.9, 0.35, 1) both;
 }
@@ -198,6 +209,10 @@
   88% { transform: scale(1.04, 1.05); }                 /* rebotico */
   100% { transform: none; }
 }
+/* gafas / brillo: YA a tamaño completo (mismo valor en el que asentó `crece`:
+   cero salto) — las gafas se ven de verdad, no a escala chiquita perdidas. */
+.ang-entrada--gafas .ang-entrada__escala { transform: none; }
+.ang-entrada--brillo .ang-entrada__escala { transform: none; }
 .ang-entrada--lista .ang-entrada__escala { transform: none; }
 
 /* El ARO DE ENERGÍA que revienta cuando alcanza su tamaño (delay = el pico del
@@ -219,6 +234,32 @@
 @keyframes ang-aro {
   0% { transform: scale(0.4); opacity: 0.9; }
   100% { transform: scale(1.5); opacity: 0; }
+}
+
+/* El BRILLITO final (fase `brillo`): un destello suave y breve que remata el
+   show y avisa "ya estoy lista" — y se apaga SOLO (both, no infinite: nunca
+   queda un glow permanente encendido). Distinto del aro (que celebra que
+   CRECIÓ): este marca el cierre de TODO el número, con o sin gafas. */
+.ang-entrada__brillo {
+  position: absolute;
+  inset: 8%;
+  border-radius: 50%;
+  pointer-events: none;
+  opacity: 0;
+  background: radial-gradient(
+    circle,
+    rgba(255, 224, 130, 0.95) 0%,
+    rgba(255, 200, 90, 0.5) 40%,
+    rgba(255, 200, 90, 0) 72%
+  );
+}
+.ang-entrada--brillo .ang-entrada__brillo {
+  animation: ang-destello-final 0.65s cubic-bezier(0.2, 0.8, 0.3, 1) both;
+}
+@keyframes ang-destello-final {
+  0%   { transform: scale(0.7); opacity: 0; }
+  35%  { transform: scale(1.08); opacity: 1; }
+  100% { transform: scale(1.35); opacity: 0; }
 }
 
 /* ═══ GATES DE LA CASA ═══════════════════════════════════════════════════════ */
@@ -245,15 +286,21 @@
   [data-agente='angelita'][data-agt-estado='husmea'] .rh-mirada,
   .agm-olor,
   .ang-entrada__escala,
-  .ang-entrada__aro {
+  .ang-entrada__aro,
+  .ang-entrada__brillo {
     animation: none !important;
   }
   .ang-entrada--espera .ang-entrada__escala,
   .ang-entrada--asoma .ang-entrada__escala,
+  .ang-entrada--quieta .ang-entrada__escala,
   .ang-entrada--gafas .ang-entrada__escala,
-  .ang-entrada--crece .ang-entrada__escala {
+  .ang-entrada--crece .ang-entrada__escala,
+  .ang-entrada--brillo .ang-entrada__escala {
     transform: none;
     opacity: 1;
   }
   .agm-olor { opacity: 0.55; }
+  /* El brillito final NO se congela encendido: es un remate, no un glow
+     permanente — RM lo apaga del todo (mismo criterio que el aro). */
+  .ang-entrada__brillo { opacity: 0; }
 }


### PR DESCRIPTION
Angelita gana un estado explícito para la ignorancia: **niega con la cabeza, se encoge, y lo
dice con todas sus letras** (`angelitaEstados.TEXTO_NO_SE` en una burbuja informativa, sin
animación que distraiga del mensaje).

## Por qué importa más de lo que parece

Al otro lado hay un campesino que va a **sembrar, fumigar o vender** con lo que la guía le
diga. Un agente que inventa cuando no sabe le puede costar una cosecha.

Que Angelita tenga un **gesto propio para "no sé"** convierte la honestidad del sistema en algo
que se ve en pantalla, no en una promesa enterrada en el prompt. Y encaja con lo que ya medimos:
el modelo de producción contamina el 47,7 % de sus respuestas — un canal visual para admitir
ignorancia no es un lujo, es la contención.

También entra la **pausa de `AngelitaEntrada`**: el momento "viva pero quieta" antes de hablar,
para que la entrada no atropelle al usuario.

## Verificación

`npx vite build` → **verde, 35,7 s**. 10 archivos, +203/−72.

## Procedencia

Estaba **sin commitear ni PR** en un worktree, con horas de antigüedad. Salió en la revisión de
worktrees pendientes. Se verificó el build desde cero antes de rescatarlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)