### PR TITLE
fix(home): tres módulos no se dibujaban por faltar en el orden por defecto

### DIFF
--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -1102,7 +1102,7 @@ export const HOME_MODULES = Object.freeze([
   {
     id: 'clima',
     label: 'Clima',
-    description: 'Pronóstico del clima para tu zona (7 días)',
+    description: 'Pronóstico del clima para su zona (7 días)',
     category: 'principal',
   },
   {
@@ -1277,6 +1277,13 @@ export function isModuleVisible(moduleId) {
 // render (FUSED_EN_ESTADO_DEL_DIA en DashboardLive) para no duplicarlos ni en
 // los perfiles existentes que ya los tenían guardados en su orden.
 export const HOME_MODULE_DEFAULT_ORDER = Object.freeze([
+  // Los de categoría 'principal' van primero: son lo que el campesino mira al
+  // abrir la app. hoyfinca, clima y analisis FALTABAN en esta lista aunque sí
+  // estaban en HOME_MODULES, así que no se dibujaban para nadie sin un orden
+  // guardado — y clima es justo lo que se consulta antes de sembrar o fumigar.
+  'hoyfinca',
+  'clima',
+  'analisis',
   'asociaciones',
   'plantas',
   'hoy',


### PR DESCRIPTION
`HOME_MODULES` tiene **12** entradas y `HOME_MODULE_DEFAULT_ORDER` tenía solo **9**. Los tres que
faltaban **no se le mostraban a ningún usuario** que no tuviera un orden guardado:

| módulo | etiqueta | categoría |
|---|---|---|
| `hoyfinca` | Hoy en la finca | **principal** |
| `clima` | Clima | **principal** |
| `analisis` | Análisis IA | ia |

## Lo que lo hace grave

**Los dos módulos de categoría `principal` — lo primero que debería ver el campesino al abrir la
app — eran justo dos de los invisibles.** El Home arrancaba con `asociaciones` y `plantas`,
módulos secundarios ocupando el lugar de los principales.

Y **`clima` es el más caro de perder**: es lo que se consulta antes de sembrar, fumigar o
cosechar. Una helada o un aguacero deciden si se pierde una cosecha.

## Cómo apareció

Investigando **por qué CodeQL marcaba `js/syntax-error`** en dos archivos de test. Ese
`syntax-error` resultó ser ruido del parser de CodeQL —vitest los lee perfectamente— pero al
correr los tests para comprobarlo, **4 estaban en rojo denunciando exactamente este desajuste**.
Llevaban tiempo así.

## El arreglo

Los tres entran respetando su propia categoría: los `principal` de primeros. De paso,
*"para tu zona"* → *"para su zona"*, que la app trata de usted.

## Verificación

`userProfileService.test.js`: de **4 fallas a 75/75 en verde**. `npx vite build` verde en 30,3 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)