### PR TITLE
fix(3d): res anatómica en el mercado y oso guardián en la escena del Ent

### DIFF
--- a/src/mockups/MomentoVentaMercado3D.jsx
+++ b/src/mockups/MomentoVentaMercado3D.jsx
@@ -38,6 +38,7 @@ import * as THREE from 'three';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { CIELOS_HORA } from '../visual/mundo3d/cielosHoraData.js';
 import { PALETA, mezclar } from '../visual/mundo3d/atmosferaMadre.js';
+import { geomVaca } from '../visual/mundo3d/finca/fincaRealista.geom.js';
 import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
 import { ParticulasAmbientales } from '../visual/mundo3d/ParticulasAmbientales.jsx';
 import { crearRng } from '../visual/mundo3d/particulasData.js';
@@ -301,20 +302,26 @@ function SolBajo() {
   );
 }
 
-/* ── La res low-poly (rubber-hose): caja de cuerpo con manchas, cabeza con
-      ojos grandes, orejas y cuernos, cola con borla y patas que pivotan en la
-      cadera. Mira hacia +x. Todos sus materiales son `transparent` para que
-      la partida pueda desvanecerla con dignidad (opacidad 1 el resto del
-      tiempo: costo nulo).
+/* ── La res ANATÓMICA del sistema del hato (fincaRealista.geom): loft orgánico
+      con sombreado horneado por vértice — no cajas apiladas ("la vaca
+      cuadrada", veredicto del operador). Raza criolla: el caramelo campesino
+      de la vereda, cuernos en lira y papada; la cría va mocha y sin ubre.
+      Mira hacia +x. `articulada` entrega las patas como piezas sueltas con
+      pivote en la cadera para que el andar las columpie de verdad.
 
       La res es PURAMENTE declarativa: expone sus partes animables por `name`
-      (res-nucleo/cuerpo/cabeza/cola/pata-N). El momento que la monta la
+      (res-nucleo/cuerpo/cabeza/pata-N; la cola va horneada en el cuerpo y los
+      momentos ya la tratan como opcional). El momento que la monta la
       envuelve en un <group ref>, resuelve las partes UNA vez fuera del render
       (resolverPartes, en efecto) y las anima en useFrame — así ningún ref
-      cruza fronteras de componente (contrato react-hooks v6). ─────────────── */
-const CADERAS = [
-  [-0.45, -0.19], [-0.45, 0.19], [0.42, -0.19], [0.42, 0.19],
-];
+      cruza fronteras de componente (contrato react-hooks v6).
+
+      Material PROPIO por res (no el MATERIAL_HATO compartido del valle): la
+      partida desvanece por `opacity` recorriendo el subárbol y no puede
+      arrastrar a otra res de la escena. `vertexColors` trae el pelaje y el AO
+      horneados; el `color` multiplica el conjunto hacia la niebla dorada —
+      la misma ley de coherencia del resto del mockup. ─────────────────────── */
+const TINTE_RES = mezclar('#fffaf2', TINTE, 0.24);
 
 /* Resuelve las partes animables de una res por nombre, DENTRO de su subárbol
    (dos reses en escena no se pisan). Llamar fuera del render y cachear. */
@@ -332,90 +339,36 @@ function resolverPartes(raiz) {
 
 /** @param {{ position?: [number, number, number]; giro?: number; escala?: number; cria?: boolean; semilla?: number }} props */
 function Vaca({ position = [0, 0, 0], giro = 0, escala = 1, cria = false, semilla = 3 }) {
-  const manchas = useMemo(() => {
-    const rng = crearRng(semilla);
-    return Array.from({ length: 3 }, () => ({
-      x: (rng() - 0.5) * 0.8,
-      y: 0.9 + (rng() - 0.5) * 0.18,
-      s: 0.7 + rng() * 0.6,
-      g: (rng() - 0.5) * 0.5,
-    }));
-  }, [semilla]);
-  const tono = cria ? P.resClara : P.res;
+  const geom = useMemo(
+    () => geomVaca({ raza: 'criolla', ubre: !cria, cuerno: cria ? 0 : null, articulada: true }, semilla),
+    [cria, semilla],
+  );
+  const material = useMemo(
+    () => new THREE.MeshLambertMaterial({
+      vertexColors: true,
+      transparent: true, // la partida desvanece; el resto del tiempo opacidad 1
+      color: new THREE.Color(TINTE_RES),
+    }),
+    [],
+  );
+  useEffect(() => () => material.dispose(), [material]);
   return (
     <group name="res-nucleo" position={position} rotation={[0, giro, 0]} scale={escala}>
-      {/* el torso, la cabeza y la cola comparten el squash & stretch */}
+      {/* el torso y la cabeza comparten el squash & stretch */}
       <group name="res-cuerpo">
-        <mesh position={[0, 0.98, 0]}>
-          <boxGeometry args={[1.3, 0.6, 0.62]} />
-          <meshLambertMaterial color={tono} flatShading transparent />
-        </mesh>
-        {manchas.map((m, i) => (
-          <mesh key={i} position={[m.x, m.y, 0]} rotation={[0, 0, m.g]} scale={m.s}>
-            <boxGeometry args={[0.34, 0.3, 0.66]} />
-            <meshLambertMaterial color={P.mancha} flatShading transparent />
-          </mesh>
-        ))}
-        <group name="res-cabeza" position={[0.76, 1.22, 0]}>
-          <mesh>
-            <boxGeometry args={[0.36, 0.34, 0.3]} />
-            <meshLambertMaterial color={tono} flatShading transparent />
-          </mesh>
-          <mesh position={[0.2, -0.08, 0]}>
-            <boxGeometry args={[0.18, 0.2, 0.24]} />
-            <meshLambertMaterial color={P.hocico} flatShading transparent />
-          </mesh>
-          {/* orejas */}
-          {[-0.21, 0.21].map((dz) => (
-            <mesh key={dz} position={[0, 0.12, dz]} rotation={[dz > 0 ? 0.5 : -0.5, 0, 0]}>
-              <boxGeometry args={[0.06, 0.09, 0.16]} />
-              <meshLambertMaterial color={tono} flatShading transparent />
-            </mesh>
-          ))}
-          {/* cuernos (la cría todavía no los tiene) */}
-          {!cria &&
-            [-0.13, 0.13].map((dz) => (
-              <mesh key={dz} position={[0.02, 0.22, dz]} rotation={[dz > 0 ? 0.6 : -0.6, 0, 0]}>
-                <cylinderGeometry args={[0.02, 0.04, 0.2, 5]} />
-                <meshLambertMaterial color={P.cuerno} flatShading transparent />
-              </mesh>
-            ))}
-          {/* ojos rubber-hose: grandes, francos */}
-          {[-0.12, 0.12].map((dz) => (
-            <group key={dz}>
-              <mesh position={[0.17, 0.08, dz]}>
-                <sphereGeometry args={[0.05, 7, 6]} />
-                <meshLambertMaterial color={P.ojo} flatShading transparent />
-              </mesh>
-              <mesh position={[0.205, 0.08, dz * 1.12]}>
-                <sphereGeometry args={[0.024, 6, 5]} />
-                <meshLambertMaterial color={P.pupila} flatShading transparent />
-              </mesh>
-            </group>
-          ))}
-        </group>
-        <group name="res-cola" position={[-0.66, 1.16, 0]} rotation={[0, 0, 0.5]}>
-          <mesh position={[0, -0.24, 0]}>
-            <cylinderGeometry args={[0.025, 0.035, 0.48, 5]} />
-            <meshLambertMaterial color={tono} flatShading transparent />
-          </mesh>
-          <mesh position={[0, -0.5, 0]}>
-            <sphereGeometry args={[0.06, 6, 5]} />
-            <meshLambertMaterial color={P.mancha} flatShading transparent />
-          </mesh>
+        <mesh geometry={geom.cuerpo} material={material} />
+        <group name="res-cabeza" position={geom.pivote}>
+          <mesh geometry={geom.cabeza} material={material} />
         </group>
       </group>
       {/* patas: pivotan en la cadera (el mesh cuelga del grupo) */}
-      {CADERAS.map((q, i) => (
-        <group key={i} name={`res-pata-${i}`} position={[q[0], 0.66, q[1]]}>
-          <mesh position={[0, -0.33, 0]}>
-            <boxGeometry args={[0.14, 0.66, 0.14]} />
-            <meshLambertMaterial color={tono} flatShading transparent />
-          </mesh>
-          <mesh position={[0, -0.62, 0]}>
-            <boxGeometry args={[0.15, 0.1, 0.15]} />
-            <meshLambertMaterial color={P.mancha} flatShading transparent />
-          </mesh>
+      {(geom.patas ?? []).map((geo, i) => (
+        <group
+          key={i}
+          name={`res-pata-${i}`}
+          position={[geom.caderas?.[i]?.[0] ?? 0, geom.yCadera ?? 0, geom.caderas?.[i]?.[1] ?? 0]}
+        >
+          <mesh geometry={geo} material={material} />
         </group>
       ))}
     </group>

--- a/src/visual/mundo3d/bosque/FaunaBosque.jsx
+++ b/src/visual/mundo3d/bosque/FaunaBosque.jsx
@@ -2,10 +2,10 @@
  * FaunaBosque — LA VIDA del Bosque Vivo. Un bosque sin bichos es un decorado.
  *
  * EL REGISTRO (decisión del operador, 2026-07): la fauna EMBLEMÁTICA del
- * bosque — oso, rana, colibrí, borugo, jaguar, danta — va con los SVG
- * rubber-hose de `src/visual/creatures/` como billboards <Html>: son el
- * estándar de calidad de la casa (la danta ya tiene su SVG — Danta.jsx, la
- * jardinera del bosque — y anda de día/atardecer con los vecinos). La fauna AMBIENTAL de fondo —
+ * bosque — oso (el GUARDIÁN NEGRO; el café y el borugo están archivados y no
+ * se surfacean), rana, colibrí, jaguar — va con los SVG rubber-hose de
+ * `src/visual/creatures/` como billboards <Html>: son el estándar de calidad
+ * de la casa. La fauna AMBIENTAL de fondo —
  * cóndor, venado en la niebla, bandada, quetzal fugaz, mariposas, abejas,
  * escarabajo, luciérnagas — sí es geometría mínima procedural (siluetas que
  * el fog completa). Hubo un intento de oso/rana procedurales: quedó jubilado
@@ -558,8 +558,8 @@ function QuetzalFugaz() {
    acompañan desde el frailejonar y el borde del monte). `franjas` = cuándo
    sale (null = siempre). `vida` = su repertorio de gestos (los que el bicho
    YA sabe hacer: props opt-in de su componente) y el compás de su reloj.
-   `paseo` = hasta dónde camina y vuelve (el oso y la danta, cada uno con su
-   rumbo y su compás — nunca en fila ni al unísono). */
+   `paseo` = hasta dónde camina y vuelve (movimiento 3D real del billboard,
+   con su rumbo y su compás propios — nunca en fila ni al unísono). */
 const VECINOS_BOSQUE = [
   {
     slug: 'rana-andina',
@@ -576,24 +576,29 @@ const VECINOS_BOSQUE = [
     },
   },
   {
-    /* LA DANTA — la jardinera del bosque, por fin en SVG de la casa. Mole
-       diurna y mansa: sale del arbolado del costado derecho y PASEA hacia el
-       claro con su andar pesado (rumbo y compás propios, nunca en fila con el
-       oso), husmea con la trompa en periscopio, reposa y otea. Al caer la
-       noche se retira monte adentro (franjas de día/atardecer). */
-    slug: 'danta',
-    pos: [3.0, 0.95, 2.1],
-    px: 66,
-    factor: 18,
-    franjas: ['manana', 'mediodia', 'tarde', 'atardecer'],
+    /* EL OSO — el GUARDIÁN NEGRO de la luna (OsoGuardian, la dirección vigente
+       del oso de anteojos; el café está archivado y NO vuelve). Vive en el
+       borde del arbolado, asomado al claro — nunca al pie del Ent: el guardián
+       del bosque manda el centro. Abre paseando (se ve que está VIVO), resopla
+       su vaho de páramo, se remece el peso y reposa.
+
+       NOTA de puesta en escena (operador, 2026-07): aquí vivía la danta a
+       billboard grande en pleno centro del claro — a ese tamaño su silueta
+       parada leía como el oso café archivado flotando frente al Ent. La danta
+       sigue en el elenco (vitrina, páramo); esta escena se compone sin ella. */
+    slug: 'oso-guardian',
+    pos: [-3.6, 0.34, 3.2],
+    px: 64,
+    factor: 15,
+    franjas: null,
     vida: {
       primero: 'pasea',
-      descanso: [6000, 13000],
+      descanso: [5000, 11000],
       momentos: {
-        pasea: { dur: 10500, props: { pose: 'anda' }, paseo: [-2.0, 0, 1.1] },
-        husmea: { dur: 4200, props: { husmea: true } },
-        reposo: { dur: 5600, props: { pose: 'reposo' } },
-        mira: { dur: 3200, props: { pose: 'señala' } },
+        pasea: { dur: 9000, props: { pose: 'anda' }, paseo: [1.7, 0, 1.0] },
+        resopla: { dur: 4500, props: { resopla: true } },
+        seAcomoda: { dur: 5200, props: { rasca: true } },
+        reposo: { dur: 4600, props: { pose: 'reposo' } },
       },
     },
   },
@@ -615,7 +620,10 @@ const VECINOS_BOSQUE = [
   },
 ];
 
-const VECINOS_TIER_BAJO = new Set(['oso-andino']);
+/* En tier bajo solo queda el oso, quieto (el colibrí va aparte): el slug DEBE
+   ser uno del roster de arriba — apuntaba al 'oso-andino' archivado y el tier
+   bajo se quedaba sin un solo vecino. */
+const VECINOS_TIER_BAJO = new Set(['oso-guardian']);
 
 const ESTILO_CRITTER = {
   filter: 'drop-shadow(0 2px 3px rgba(25, 32, 28, 0.35))',

--- a/src/visual/mundo3d/finca/fincaRealista.geom.js
+++ b/src/visual/mundo3d/finca/fincaRealista.geom.js
@@ -314,14 +314,24 @@ export const RAZAS_VACA = {
   },
 };
 
+/* Las caderas de la vaca (x, z, ¿trasera?) y la altura del pivote: compartidas
+   entre la res de patas fijas y la articulada para que ambas pisen igual. */
+const CADERAS_VACA = /** @type {[number, number, boolean][]} */ ([
+  [0.44, 0.17, false], [0.44, -0.17, false], [-0.46, 0.18, true], [-0.46, -0.18, true],
+]);
+const Y_CADERA_VACA = 0.72;
+
 /**
  * La vaca anatómica. Mira a +X, patas en y=0, cruz a ~1.1.
  * `cuerno` (opcional) escala los cuernos por encima de la raza — la ternera va
  * mocha aunque sea criolla.
- * @returns {{cuerpo: THREE.BufferGeometry, cabeza: THREE.BufferGeometry, pivote: [number,number,number]}}
+ * `articulada` (opt-in) entrega las patas como PIEZAS SUELTAS con pivote en la
+ * cadera (para escenas que columpian las patas al andar — el mercado). Con el
+ * default las patas van fusionadas al cuerpo, como siempre (valle/hato).
+ * @returns {{cuerpo: THREE.BufferGeometry, cabeza: THREE.BufferGeometry, pivote: [number,number,number], patas?: THREE.BufferGeometry[], caderas?: [number,number][], yCadera?: number}}
  */
-export function geomVaca({ raza = 'holstein', ubre = true, cuerno = null, q = 1 } = {}, seed = 21) {
-  return memo(`vaca|${raza}|${ubre}|${cuerno}|${q}|${seed}`, () => {
+export function geomVaca({ raza = 'holstein', ubre = true, cuerno = null, q = 1, articulada = false } = {}, seed = 21) {
+  return memo(`vaca|${raza}|${ubre}|${cuerno}|${q}|${articulada}|${seed}`, () => {
     const R = RAZAS_VACA[raza] || RAZAS_VACA.holstein;
     const r = rng(seed);
     const p = [];
@@ -373,11 +383,24 @@ export function geomVaca({ raza = 'holstein', ubre = true, cuerno = null, q = 1 
     }
 
     // ── Patas nacidas de la masa (muslo→caña→pezuña, con jitter) ──
-    for (const [px, pz, atras] of /** @type {[number, number, boolean][]} */ ([[0.44, 0.17, false], [0.44, -0.17, false], [-0.46, 0.18, true], [-0.46, -0.18, true]])) {
-      pataCuadrupedo(p, {
-        x: px, z: pz, yCadera: 0.72, rMuslo: 0.1, rCana: 0.046,
+    //    Articulada: cada pata se construye EN SU SITIO (mismas manchas y mismo
+    //    horneado que el cuerpo — sin costura de color) y luego se traslada al
+    //    origen para colgarla de un grupo pivotado en la cadera.
+    /** @type {THREE.BufferGeometry[]} */
+    const patasSueltas = [];
+    for (const [px, pz, atras] of CADERAS_VACA) {
+      const destino = articulada ? [] : p;
+      pataCuadrupedo(destino, {
+        x: px, z: pz, yCadera: Y_CADERA_VACA, rMuslo: 0.1, rCana: 0.046,
         pelaje: R.pelaje, pezuna: '#3c352d', r, atras, pintor: pinta,
       });
+      if (articulada) {
+        const pata = hornearPelaje(fusionarHato(destino, `vaca-${raza}-pata`), {
+          yBajo: 0.04, yAlto: 1.0, ao: 0.42, moteado: 0.06, semilla: seed,
+        });
+        pata.translate(-px, -Y_CADERA_VACA, -pz);
+        patasSueltas.push(pata);
+      }
     }
 
     // ── Ubre con tetillas (la seña de la lechera) ──
@@ -453,7 +476,14 @@ export function geomVaca({ raza = 'holstein', ubre = true, cuerno = null, q = 1 
       yBajo: -0.2, yAlto: 0.15, ao: 0.3, moteado: 0.05, semilla: seed + 3,
     });
 
-    return { cuerpo, cabeza, pivote: [0.82, 1.08, 0] };
+    /** @type {{cuerpo: THREE.BufferGeometry, cabeza: THREE.BufferGeometry, pivote: [number,number,number], patas?: THREE.BufferGeometry[], caderas?: [number,number][], yCadera?: number}} */
+    const res = { cuerpo, cabeza, pivote: [0.82, 1.08, 0] };
+    if (articulada) {
+      res.patas = patasSueltas;
+      res.caderas = CADERAS_VACA.map(([px, pz]) => /** @type {[number, number]} */ ([px, pz]));
+      res.yCadera = Y_CADERA_VACA;
+    }
+    return res;
   });
 }
 


### PR DESCRIPTION
Dos arreglos de cosas que están **hoy en producción**.

## 🐄 La vaca del mercado dejó de ser una caja

El operador la señaló él mismo: *"es la vaca cuadrada"*. Era literal —
`boxGeometry([1.3, 0.6, 0.62])` más cajas para cabeza y patas.

Ahora usa `geomVaca()` del sistema del hato que **ya existía y nadie estaba aprovechando**:
raza criolla (caramelo campesino, cuernos en lira, papada), loft orgánico y sombreado horneado
por vértice.

`geomVaca` gana una opción **opt-in `articulada`**: las patas salen como piezas sueltas con
pivote en la cadera, construidas en su sitio para conservar manchas y horneado sin costura.
**El default queda intacto** (`articulada = false`), así que el valle y `HatoMovil` no cambian.

El contrato `res-*` se respetó completo y se verificó contra build local servido: la venta
(patas que columpian al andar), el nacimiento (pop elástico de la cría mocha) y la partida
(a 15 s la res es un fantasma con la cabeza baja; a 21 s solo queda el anillo tibio).

## 🐻 El "oso café" no era un oso

**Hallazgo que corrige la premisa del encargo.** Con una sonda DOM sobre la escena viva se
verificó que `OsoAndino` **no estaba montado en ninguna escena**: el fix general `#2624` sí
había sacado el slug del roster.

El bicho café del centro era **la danta**, en billboard grande (66 px al pie del Ent), cuya
silueta parada se lee exactamente como el oso café archivado flotando.

La danta sale de esta escena (sigue en vitrina y en el páramo) y entra el **oso guardián negro
de la luna**, del elenco vigente, con vida propia: abre paseando, resopla, se remece el peso,
reposa.

### Bug extra encontrado de paso

`VECINOS_TIER_BAJO` apuntaba al slug archivado `'oso-andino'`, lo que dejaba el **tier bajo sin
ningún vecino**. Ahora apunta a `'oso-guardian'`.

## Verificación

`npx vite build` → **verde, 50,9 s**. Capturas antes/después en ancho y móvil, tomadas contra un
`vite preview` propio con el hash del bundle verificado antes de cada tanda — sin servidores
viejos sirviendo código anterior.

**Nota para quien revise:** en headless el `dt` clampeado a 0.1 hace que los momentos corran a
~la mitad del tiempo real; no es un bug del mockup. Y el encuadre móvil de la llegada al puesto
queda tapado por el toldo: es preexistente y no se tocó.

🤖 Generated with [Claude Code](https://claude.com/claude-code)