### PR TITLE
feat(agente): gemma4:e2b reemplaza a granite3.3:8b como modelo del agente

### DIFF
--- a/src/components/HelpVoiceQuestion.jsx
+++ b/src/components/HelpVoiceQuestion.jsx
@@ -155,7 +155,7 @@ Formato: párrafo breve (máximo unas 8 oraciones). Sin listas largas salvo que 
       full = await streamOllama(
         OLLAMA_CHAT_URL,
         {
-          model: ENV.NLU_MODEL || 'gemma3:4b',
+          model: ENV.NLU_MODEL || 'gemma4:e2b',
           messages: [
             { role: 'system', content: system },
             { role: 'user', content: userMsg },

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -29,8 +29,13 @@ export const ENV = {
   // Modelos de inferencia (configurables sin recompilar).
   // Cambia en .env cuando bumpees el modelo local.
   STT_MODEL: import.meta.env?.VITE_STT_MODEL || 'base',
-  // 2026-06-11: default gemma3:4b → granite3.3:8b. gemma3:4b NO carga junto a
-  // granite3.3 pinned (VRAM) → la extracción de voz daba 0 plantas. granite3.3
-  // (hot) extrae bien. Alinea el display + HelpVoiceQuestion con el modelo real.
-  NLU_MODEL: import.meta.env?.VITE_NLU_MODEL || 'granite3.3:8b',
+  // 2026-07-22: granite3.3:8b → gemma4:e2b, por medición con juez semántico sobre
+  // 70 sondas: granite3.3 contamina el 47,7% de sus respuestas y falla el piso
+  // térmico el 41,7% de las veces (le da consejo de tierra caliente a alguien de
+  // páramo). gemma4:e2b baja a 10% global y 6,7% en piso térmico — 4,8x mejor.
+  // Además pesa 8,1GB cargado contra 7,2GB, y CONVIVE con el embedder del RAG
+  // (snowflake-arctic-embed2) en la M6000 de 12GB, cosa que granite3.3 no hacía:
+  // con granite el embedder daba cudaMalloc OOM y el RAG semántico se apagaba en
+  // silencio. Verificado en vivo: embed 200ms + agente 860-1450ms, conviviendo.
+  NLU_MODEL: import.meta.env?.VITE_NLU_MODEL || 'gemma4:e2b',
 };

--- a/src/services/entityExtractor.js
+++ b/src/services/entityExtractor.js
@@ -35,7 +35,11 @@ const OLLAMA_CHAT_URL = '/api/ollama/api/chat';
 // Fix: usar granite3.3 (YA cargado, hot) — extrae el JSON bien sin esperar
 // carga ni evictar el chat. Verificado en vivo: granite3.3 devuelve
 // {crop,quantity,location} correcto donde gemma3:4b daba vacío.
-const MODEL = 'granite3.3:8b';
+// 2026-07-22: granite3.3:8b → gemma4:e2b. La razón original (usar el que ya
+// está hot para no evictar el chat) SIGUE VALIENDO: ahora el hot es e2b.
+// Y el motivo de fondo cambió a favor: granite3.3 contamina 47,7% contra 10%
+// de e2b, medido con juez semántico sobre 70 sondas.
+const MODEL = 'gemma4:e2b';
 // El modelo responde en pocos segundos para extracción JSON con format:json.
 // Nginx permite hasta 120s en /api/ollama/; 60s cliente es el punto medio seguro.
 const TIMEOUT_MS = 60000;

--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -90,7 +90,12 @@ export const ROUTES = {
     // Override via env VITE_LLM_CHAT_MODEL para experimentos.
     model:
       (typeof import.meta !== 'undefined' && import.meta?.env?.VITE_LLM_CHAT_MODEL) ||
-      'granite3.3:8b',
+      // 2026-07-22: granite3.3:8b -> gemma4:e2b. La nota de arriba decía que
+      // granite3.3 se eligió para "mitigar errores geográficos + piso térmico
+      // observados en producción". La medición dice que NO los mitigó: con juez
+      // semántico sobre 70 sondas, granite3.3 falla el piso térmico el 41,7% de
+      // las veces y contamina el 47,7% global. gemma4:e2b: 6,7% y 10%.
+      'gemma4:e2b',
     keep_alive_min: 30,
     temperature: 0.3,
     // 2026-06-06: 512→768. Fuga real (interacción operador): respuesta de
@@ -106,7 +111,7 @@ export const ROUTES = {
     stop: CHAT_STOP_SEQUENCES,
     url: '/api/ollama/v1/chat/completions',
     rationale:
-      'granite3.3:8b (chat+complex unificado, evita cold-start). ' +
+      'gemma4:e2b (chat+complex unificado, evita cold-start). ' +
       'Detalle + por qué + alternativas en Chagra-strategy/ops/MODELS.md (fuente única).',
   },
   chat_complex: {
@@ -116,7 +121,10 @@ export const ROUTES = {
     // evita confusiones taxonómicas con cupo de GPU razonable).
     model:
       (typeof import.meta !== 'undefined' && import.meta?.env?.VITE_LLM_COMPLEX_MODEL) ||
-      'granite3.3:8b',
+      // 2026-07-22: la nota de arriba decía que granite3.3 "evita confusiones
+      // taxonómicas". El bench con juez semántico lo desmiente: confusión de
+      // especie y cruce de cultivos al 91,7%. gemma4:e2b baja el cruce a 33,3%.
+      'gemma4:e2b',
     keep_alive_min: 5,
     temperature: 0.3,
     // 2026-06-06: 768→1024. Las queries complejas (planes multi-cultivo,
@@ -127,21 +135,21 @@ export const ROUTES = {
     stop: CHAT_STOP_SEQUENCES,
     url: '/api/ollama/v1/chat/completions',
     rationale:
-      'granite3.3:8b (chat+complex unificado, evita cold-start). ' +
+      'gemma4:e2b (chat+complex unificado, evita cold-start). ' +
       'Detalle + por qué + alternativas en Chagra-strategy/ops/MODELS.md (fuente única).',
   },
   nlu: {
     // NLU REAL = sidecar agro-mcp nlu.ts (granite3.3:8b). Este campo es
     // vestigial: la PWA delega NLU al sidecar /nlu. Ver
     // Chagra-strategy/ops/MODELS.md (fuente única de verdad de modelos).
-    model: 'granite3.3:8b',
+    model: 'gemma4:e2b',
     keep_alive_min: 0,
     temperature: 0,
     max_tokens: 150,
     url: '/api/ollama/v1/chat/completions',
     rationale:
       'Vestigial — NLU real ejecuta en sidecar agro-mcp nlu.ts con ' +
-      'granite3.3:8b (unificado con chat para no tener 2 modelos en 12 GB). ' +
+      'gemma4:e2b (unificado con chat para no tener 2 modelos en 12 GB). ' +
       'Detalle en Chagra-strategy/ops/MODELS.md (fuente única).',
   },
   reasoning: {
@@ -164,10 +172,17 @@ export const ROUTES = {
     max_tokens: 512,
     url: '/api/ollama/v1/chat/completions',
     rationale:
-      'Bench visión M6000 2026-06-23: qwen2.5vl:7b es el PEOR (alucina + ' +
-      'offload 14 GB → thrash). gemma3:4b co-reside con granite3.3:8b ' +
-      '(10.2/12 GB, sin offload) e identifica patógenos mejor. Validado ' +
-      'contra gate AGE validate_visual_match. Detalle en ' +
+      'Bench visión M6000 2026-06-23: qwen2.5vl:7b salió el PEOR (alucina + ' +
+      'offload 14 GB → thrash) y gemma3:4b identificaba patógenos mejor. ' +
+      'PERO 2026-07-22, arena visual con la GPU limpia y casos de presencia ' +
+      'emparejados con su ausencia: qwen2.5vl:7b saca 92% (5/5 presencia, ' +
+      '6/7 ausencia) contra 75% de gemma4:e4b y 58% de gemma4:e2b (este ' +
+      'último dice "no" a todo sin mirar). La sospecha es que el bench de ' +
+      'junio lo midió EN THRASHING (el propio texto dice offload 14 GB), y ' +
+      'un modelo partido a CPU alucina. Son tareas distintas —identificar ' +
+      'patógeno en foto vs. verificar elementos en escena 3D— así que ' +
+      'ninguno invalida al otro, pero hay que re-medir patógenos con la GPU ' +
+      'libre antes de dar por bueno el descarte. Detalle en ' +
       'Chagra-strategy/ops/MODELS.md (fuente única).',
   },
 };


### PR DESCRIPTION
## La medición

Juez semántico, 70 sondas, contaminación de conocimiento:

| Modelo | Global | Piso térmico | Cruce cultivos |
|---|---|---|---|
| 🥇 **`gemma4:e2b`** | **10 %** | 6,7 % | 33,3 % |
| `gemma4:e4b` | 13 % | **0 %** | 33,3 % |
| `qwen3.5:9b` | 42,9 % | 46,7 % | 58,3 % |
| `granite3.3:8b` *(actual)* | **47,7 %** | 41,7 % | **91,7 %** |

**`granite3.3` es 4,8× más contaminante.** Y su peor renglón es el que más daño hace: **le da
consejo de tierra caliente a alguien de páramo el 41,7 % de las veces.**

Lo irónico: el comentario del router decía que se había elegido *"para mitigar errores
geográficos + piso térmico observados en producción"*. **No los mitigó.**

Ninguno gana por callarse — verificado: e2b 993 caracteres de media, e4b 1445, qwen3.5 1571,
**cero respuestas vacías en los tres**.

## Por qué `e2b` y no `e4b`

El `e4b` es **mejor en piso térmico** (0 % contra 6,7 %) y no lo voy a esconder. Pero ocupa
**11 GB cargado** contra 8,1 GB, dejando 1,9 GB libres en una GPU de 12.

**Ese margen es exactamente lo que permite que el RAG funcione.**

## 🔴 El RAG ya estaba roto, y esto lo destapa

`snowflake-arctic-embed2` pide 1,3 GB y daba **`cudaMalloc OOM` junto a `granite3.3` aunque
quedaran 5,1 GB libres** — es fragmentación de VRAM, no falta de espacio.

Y como `embedQuery()` corre **en cada consulta** y degrada en silencio (`'[RAG] modo semántico
desactivado'`, solo en consola), **el RAG semántico probablemente llevaba tiempo apagado en
producción sin que nadie lo notara.** Los 5906 chunks indexados no se estaban usando.

**Con `e2b` y `num_gpu: 0` en el embedder, ambos conviven.** Verificado en vivo:

```
ciclo 1: embed=200ms  agente=1150ms
ciclo 2: embed=203ms  agente=1452ms
ciclo 3: embed=197ms  agente=860ms
contexto largo (9840 chars): 3307ms, sin OOM
```

**No hace falta cambiar de embedder ni reindexar los 5906 chunks.**

## Archivos

| Archivo | Cambio |
|---|---|
| `llmRouter.js` | chat y complex → `gemma4:e2b` (el override por env queda intacto) |
| `config/env.js` | `NLU_MODEL` → `gemma4:e2b` |
| `entityExtractor.js` | `MODEL` → `gemma4:e2b` |
| `HelpVoiceQuestion.jsx` | fallback `gemma3:4b` → `gemma4:e2b` |

## ⚠️ Nota sobre visión — no se cambia nada, se documenta

El `rationale` del carril de visión afirma que **`qwen2.5vl:7b` "es el PEOR (alucina + offload
14 GB → thrash)"**. El arena visual del 22-jul, **con la GPU limpia** y casos de presencia
emparejados con su ausencia, le da **92 %** — el mejor de los tres.

La sospecha: **aquel bench lo midió en thrashing**. El propio texto lo dice (*offload 14 GB*), y
un modelo partido a CPU alucina. Son tareas distintas (patógeno en foto vs. elemento en escena
3D), así que ninguno invalida al otro — **pero conviene re-medir patógenos con la GPU libre
antes de dar ese descarte por bueno.** Queda escrito en el propio `rationale`.

## Verificación

Build verde · `gemma4:e2b` presente en **3 chunks del bundle** · **cero referencias activas** a
`granite3.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)