### PR TITLE
deploy(agente): gemma4:e2b a producción

### DIFF
--- a/src/components/HelpVoiceQuestion.jsx
+++ b/src/components/HelpVoiceQuestion.jsx
@@ -155,7 +155,7 @@ Formato: párrafo breve (máximo unas 8 oraciones). Sin listas largas salvo que 
       full = await streamOllama(
         OLLAMA_CHAT_URL,
         {
-          model: ENV.NLU_MODEL || 'gemma3:4b',
+          model: ENV.NLU_MODEL || 'gemma4:e2b',
           messages: [
             { role: 'system', content: system },
             { role: 'user', content: userMsg },

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -29,8 +29,13 @@ export const ENV = {
   // Modelos de inferencia (configurables sin recompilar).
   // Cambia en .env cuando bumpees el modelo local.
   STT_MODEL: import.meta.env?.VITE_STT_MODEL || 'base',
-  // 2026-06-11: default gemma3:4b → granite3.3:8b. gemma3:4b NO carga junto a
-  // granite3.3 pinned (VRAM) → la extracción de voz daba 0 plantas. granite3.3
-  // (hot) extrae bien. Alinea el display + HelpVoiceQuestion con el modelo real.
-  NLU_MODEL: import.meta.env?.VITE_NLU_MODEL || 'granite3.3:8b',
+  // 2026-07-22: granite3.3:8b → gemma4:e2b, por medición con juez semántico sobre
+  // 70 sondas: granite3.3 contamina el 47,7% de sus respuestas y falla el piso
+  // térmico el 41,7% de las veces (le da consejo de tierra caliente a alguien de
+  // páramo). gemma4:e2b baja a 10% global y 6,7% en piso térmico — 4,8x mejor.
+  // Además pesa 8,1GB cargado contra 7,2GB, y CONVIVE con el embedder del RAG
+  // (snowflake-arctic-embed2) en la M6000 de 12GB, cosa que granite3.3 no hacía:
+  // con granite el embedder daba cudaMalloc OOM y el RAG semántico se apagaba en
+  // silencio. Verificado en vivo: embed 200ms + agente 860-1450ms, conviviendo.
+  NLU_MODEL: import.meta.env?.VITE_NLU_MODEL || 'gemma4:e2b',
 };

--- a/src/services/entityExtractor.js
+++ b/src/services/entityExtractor.js
@@ -35,7 +35,11 @@ const OLLAMA_CHAT_URL = '/api/ollama/api/chat';
 // Fix: usar granite3.3 (YA cargado, hot) — extrae el JSON bien sin esperar
 // carga ni evictar el chat. Verificado en vivo: granite3.3 devuelve
 // {crop,quantity,location} correcto donde gemma3:4b daba vacío.
-const MODEL = 'granite3.3:8b';
+// 2026-07-22: granite3.3:8b → gemma4:e2b. La razón original (usar el que ya
+// está hot para no evictar el chat) SIGUE VALIENDO: ahora el hot es e2b.
+// Y el motivo de fondo cambió a favor: granite3.3 contamina 47,7% contra 10%
+// de e2b, medido con juez semántico sobre 70 sondas.
+const MODEL = 'gemma4:e2b';
 // El modelo responde en pocos segundos para extracción JSON con format:json.
 // Nginx permite hasta 120s en /api/ollama/; 60s cliente es el punto medio seguro.
 const TIMEOUT_MS = 60000;

--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -90,7 +90,12 @@ export const ROUTES = {
     // Override via env VITE_LLM_CHAT_MODEL para experimentos.
     model:
       (typeof import.meta !== 'undefined' && import.meta?.env?.VITE_LLM_CHAT_MODEL) ||
-      'granite3.3:8b',
+      // 2026-07-22: granite3.3:8b -> gemma4:e2b. La nota de arriba decía que
+      // granite3.3 se eligió para "mitigar errores geográficos + piso térmico
+      // observados en producción". La medición dice que NO los mitigó: con juez
+      // semántico sobre 70 sondas, granite3.3 falla el piso térmico el 41,7% de
+      // las veces y contamina el 47,7% global. gemma4:e2b: 6,7% y 10%.
+      'gemma4:e2b',
     keep_alive_min: 30,
     temperature: 0.3,
     // 2026-06-06: 512→768. Fuga real (interacción operador): respuesta de
@@ -106,7 +111,7 @@ export const ROUTES = {
     stop: CHAT_STOP_SEQUENCES,
     url: '/api/ollama/v1/chat/completions',
     rationale:
-      'granite3.3:8b (chat+complex unificado, evita cold-start). ' +
+      'gemma4:e2b (chat+complex unificado, evita cold-start). ' +
       'Detalle + por qué + alternativas en Chagra-strategy/ops/MODELS.md (fuente única).',
   },
   chat_complex: {
@@ -116,7 +121,10 @@ export const ROUTES = {
     // evita confusiones taxonómicas con cupo de GPU razonable).
     model:
       (typeof import.meta !== 'undefined' && import.meta?.env?.VITE_LLM_COMPLEX_MODEL) ||
-      'granite3.3:8b',
+      // 2026-07-22: la nota de arriba decía que granite3.3 "evita confusiones
+      // taxonómicas". El bench con juez semántico lo desmiente: confusión de
+      // especie y cruce de cultivos al 91,7%. gemma4:e2b baja el cruce a 33,3%.
+      'gemma4:e2b',
     keep_alive_min: 5,
     temperature: 0.3,
     // 2026-06-06: 768→1024. Las queries complejas (planes multi-cultivo,
@@ -127,21 +135,21 @@ export const ROUTES = {
     stop: CHAT_STOP_SEQUENCES,
     url: '/api/ollama/v1/chat/completions',
     rationale:
-      'granite3.3:8b (chat+complex unificado, evita cold-start). ' +
+      'gemma4:e2b (chat+complex unificado, evita cold-start). ' +
       'Detalle + por qué + alternativas en Chagra-strategy/ops/MODELS.md (fuente única).',
   },
   nlu: {
     // NLU REAL = sidecar agro-mcp nlu.ts (granite3.3:8b). Este campo es
     // vestigial: la PWA delega NLU al sidecar /nlu. Ver
     // Chagra-strategy/ops/MODELS.md (fuente única de verdad de modelos).
-    model: 'granite3.3:8b',
+    model: 'gemma4:e2b',
     keep_alive_min: 0,
     temperature: 0,
     max_tokens: 150,
     url: '/api/ollama/v1/chat/completions',
     rationale:
       'Vestigial — NLU real ejecuta en sidecar agro-mcp nlu.ts con ' +
-      'granite3.3:8b (unificado con chat para no tener 2 modelos en 12 GB). ' +
+      'gemma4:e2b (unificado con chat para no tener 2 modelos en 12 GB). ' +
       'Detalle en Chagra-strategy/ops/MODELS.md (fuente única).',
   },
   reasoning: {
@@ -164,10 +172,17 @@ export const ROUTES = {
     max_tokens: 512,
     url: '/api/ollama/v1/chat/completions',
     rationale:
-      'Bench visión M6000 2026-06-23: qwen2.5vl:7b es el PEOR (alucina + ' +
-      'offload 14 GB → thrash). gemma3:4b co-reside con granite3.3:8b ' +
-      '(10.2/12 GB, sin offload) e identifica patógenos mejor. Validado ' +
-      'contra gate AGE validate_visual_match. Detalle en ' +
+      'Bench visión M6000 2026-06-23: qwen2.5vl:7b salió el PEOR (alucina + ' +
+      'offload 14 GB → thrash) y gemma3:4b identificaba patógenos mejor. ' +
+      'PERO 2026-07-22, arena visual con la GPU limpia y casos de presencia ' +
+      'emparejados con su ausencia: qwen2.5vl:7b saca 92% (5/5 presencia, ' +
+      '6/7 ausencia) contra 75% de gemma4:e4b y 58% de gemma4:e2b (este ' +
+      'último dice "no" a todo sin mirar). La sospecha es que el bench de ' +
+      'junio lo midió EN THRASHING (el propio texto dice offload 14 GB), y ' +
+      'un modelo partido a CPU alucina. Son tareas distintas —identificar ' +
+      'patógeno en foto vs. verificar elementos en escena 3D— así que ' +
+      'ninguno invalida al otro, pero hay que re-medir patógenos con la GPU ' +
+      'libre antes de dar por bueno el descarte. Detalle en ' +
       'Chagra-strategy/ops/MODELS.md (fuente única).',
   },
 };


### PR DESCRIPTION
Lleva a producción el cambio de modelo del agente que ya entró a `dev` en #2671.

## Por qué cherry-pick y no `dev → main`

`main` tiene **archivos de `src/` que `dev` no tiene** — los murales
(`src/mockups/murales/FichasMural.jsx` y compañía), `diagnosticoFotoData.js`,
`hojaVidaMataData.js` — y `App.jsx` está **+723 líneas** adelante. Un merge a lo bruto los
perdería, tal como advirtió el triaje.

Se portó **solo el commit del modelo** (4 archivos, +40/−16). Verificado tras el cherry-pick:
los murales de `main` siguen en su sitio y entran al bundle (`MuralesNewDonk-*.js`).

## La medición que lo justifica

| Modelo | Contaminación | Piso térmico | Velocidad (hot) |
|---|---|---|---|
| **`gemma4:e2b`** | **10 %** | 6,7 % | **2,0 s** · 50 tok/s |
| `granite3.3:8b` *(saliente)* | **47,7 %** | **41,7 %** | 8,8 s · 23,4 tok/s |

**4,8× menos contaminación y 4,4× más rápido.** El renglón que más importa: `granite3.3` le da
consejo de tierra caliente a alguien de páramo **el 41,7 % de las veces**.

Ninguno gana por callarse: e2b promedia 993 caracteres, granite 625; cero respuestas vacías.

## Lo que además desbloquea

Con `granite3.3` (7,2 GB) el embedder del RAG y los modelos de visión no cabían. Con `e2b`
(8,1 GB pero mejor repartido) quedan **4,7 GB libres**, y eso permite que `gemma3:4b` (4,5 GB) y
`moondream` (1,5 GB) **convivan al 100 % en GPU** sin desalojar al agente.

*(Nota medida: `qwen2.5vl:7b` sigue sin caber — pide **14 GB** y hace offload aun con la GPU
vacía. Verificado dos veces, la segunda con `granite` explícitamente descargado.)*

## Verificación

`npx vite build` → **verde, 1m 45s** · `gemma4:e2b` en **3 chunks** del bundle · **cero**
referencias a `granite3.3` · murales de `main` presentes en el bundle.

⚠️ **Mergear esto dispara el deploy a producción.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)