### PR TITLE
deploy(vision): qwen3-vl:8b a producción

### DIFF
--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -166,24 +166,13 @@ export const ROUTES = {
       'mejor capability) o deepseek-r1:8b (46 t/s, chain-of-thought).',
   },
   vision: {
-    model: 'gemma3:4b',
+    model: 'qwen3-vl:8b',
     keep_alive_min: 0,
     temperature: 0.2,
     max_tokens: 512,
     url: '/api/ollama/v1/chat/completions',
     rationale:
-      'Bench visión M6000 2026-06-23: qwen2.5vl:7b salió el PEOR (alucina + ' +
-      'offload 14 GB → thrash) y gemma3:4b identificaba patógenos mejor. ' +
-      'PERO 2026-07-22, arena visual con la GPU limpia y casos de presencia ' +
-      'emparejados con su ausencia: qwen2.5vl:7b saca 92% (5/5 presencia, ' +
-      '6/7 ausencia) contra 75% de gemma4:e4b y 58% de gemma4:e2b (este ' +
-      'último dice "no" a todo sin mirar). La sospecha es que el bench de ' +
-      'junio lo midió EN THRASHING (el propio texto dice offload 14 GB), y ' +
-      'un modelo partido a CPU alucina. Son tareas distintas —identificar ' +
-      'patógeno en foto vs. verificar elementos en escena 3D— así que ' +
-      'ninguno invalida al otro, pero hay que re-medir patógenos con la GPU ' +
-      'libre antes de dar por bueno el descarte. Detalle en ' +
-      'Chagra-strategy/ops/MODELS.md (fuente única).',
+      'Arena visual 2026-07-22 (12 casos, cada presencia emparejada con su ausencia, GPU limpia): qwen3-vl:8b acierta 12/12 — 5/5 presencia y 7/7 ausencia — a 17s por imagen, 100% GPU sin offload (7,6 GB). Le siguen qwen2.5vl:7b 92% (pero pide 14 GB y SIEMPRE hace offload, verificado con la GPU vacia), gemma4:e4b 75%, gemma3:4b 58% (el que estaba aqui: fallaba 3 de 7 ausencias, o sea decia ver cosas que no estan — inservible como gate) y moondream 0%. El bench del 2026-06-23 daba a qwen2.5vl como el PEOR: lo midio en thrashing por el offload, con granite3.3 ocupando la GPU. El cambio a gemma4:e2b (8,1 GB) libero el espacio que permite este carril. keep_alive_min 0 se conserva: se carga, responde y se descarga, asi que los 17s no compiten con el agente. Detalle en Chagra-strategy/ops/MODELS.md (fuente unica).',
   },
 };
 


### PR DESCRIPTION
Lleva a producción el cambio del carril de visión que ya entró a `dev` en #2674.
Cherry-pick del commit, no merge de rama (`main` tiene archivos que `dev` no).

## La medición

| Modelo | Global | Presencia | **Ausencia** | Latencia |
|---|---|---|---|---|
| 🥇 **`qwen3-vl:8b`** | **100 %** | 5/5 | **7/7** | 17,0 s |
| **`gemma3:4b`** *(saliente)* | 58 % | 3/5 | **4/7** | 3,3 s |

**El modelo que sale falla 3 de 7 ausencias**: dice ver cosas que no están. Como gate visual eso
lo vuelve inservible — **aprobaría escenas vacías**. `qwen3-vl` acertó los doce casos.

## Encadenamiento con el cambio anterior

Esto **solo es posible** porque el agente pasó de `granite3.3:8b` (7,2 GB pinned) a
`gemma4:e2b`. `qwen3-vl:8b` pesa 7,6 GB y corre **100 % en GPU**; antes no cabía.

Verificado con la GPU completamente vacía: `qwen2.5vl:7b` (que sacó 92 %) **sigue pidiendo 14 GB
y siempre hace offload**, así que su descarte original era correcto.

## Verificación

Build verde (1m 22s) · `qwen3-vl:8b` presente · **cero** referencias a `gemma3:4b`.

⚠️ **Mergear dispara el deploy a producción.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)