### PR TITLE
fix(canary): decir que falta el modelo de chat en vez de dar verde y culpar al agente

### DIFF
--- a/scripts/__tests__/canary-modelo-chat-ausente.test.mjs
+++ b/scripts/__tests__/canary-modelo-chat-ausente.test.mjs
@@ -1,0 +1,121 @@
+/**
+ * canary-modelo-chat-ausente.test.mjs — cuando el modelo de chat desaparece del
+ * host, el canario tiene que DECIRLO, no dar verde ni culpar al agente.
+ *
+ * Regresión de la noche del 2026-07-22: `granite3.3:8b` dejó de existir en ollama
+ * a mitad de la corrida. Ollama contestó 404 `model 'granite3.3:8b' not found` a
+ * cada turno, y el reporte salió así:
+ *   - D5 dio PASS ("ollama_up=true, kokoro=true, /tools=true"), porque /health,
+ *     /tools, kokoro y /tags respondían: ollama estaba arriba, solo que sin EL
+ *     modelo. Falso verde con el agente 100% mudo — el fallo más caro del set,
+ *     porque D5 es el check al que se mira para saber si el backend está sano.
+ *   - B0 reportó "0/4 respuestas" sin decir por qué, mandando al operador a
+ *     investigar desde cero lo que ollama ya había explicado en el cuerpo.
+ *   - B0f acusó al agente de "(a) sin cantidad g/kg; (b) no ajusta por frío/altura;
+ *     (d) cascarón" — tres regresiones de CALIDAD inventadas a partir de un 404 —
+ *     y escribió esa línea al JSONL del golden, que mañana se lee como regresión
+ *     real.
+ *
+ * Es la misma regla que ya cubre `canary-backend-caido.test.mjs` ("no pude medir"
+ * ≠ "está roto"), más su reverso: si el componente SÍ está roto, el canario no
+ * puede reportarlo verde.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer } from 'node:http';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MODULES, TOPICS, buildConversation } from '../lib/canary-modules.mjs';
+
+const runOf = (id) => MODULES.find((m) => m.id === id).run;
+const TOPIC = TOPICS.find((t) => t.id === 'broca_cafe');
+const CHAT_MODEL = 'granite3.3:8b';
+
+/**
+ * Stub del target de la noche del 22: todo el sidecar en verde, ollama arriba y
+ * listando modelos — pero SIN el modelo que el chat pide por nombre exacto.
+ */
+let server;
+let base;
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const url = req.url || '';
+    const json = (code, obj) => { res.writeHead(code, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(obj)); };
+    if (url.startsWith('/api/mcp/agro/health')) return json(200, { status: 'ok', build_sha: '373f780', ollama_up: true });
+    if (url.startsWith('/api/mcp/agro/tools')) return json(200, { tools: Array.from({ length: 40 }, (_, i) => ({ name: `tool_${i}`, description: 'x'.repeat(40) })) });
+    if (url.startsWith('/api/kokoro/health')) return json(200, { status: 'ok', kokoro: true });
+    // ollama ARRIBA y con modelos… pero granite3.3:8b no está entre ellos.
+    if (url.startsWith('/api/ollama/api/tags')) return json(200, { models: [{ name: 'granite4.1:8b' }, { name: 'qwen3.5:9b' }, { name: 'llama3.1:8b' }] });
+    if (url.startsWith('/api/ollama/api/chat')) return json(404, { error: `model '${CHAT_MODEL}' not found` });
+    // el sidecar responde al resto (NLU/resolve-entities/post-validate) sin datos.
+    return json(200, {});
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+afterAll(() => new Promise((r) => server.close(r)));
+
+const ctxBase = () => ({
+  base, sidecarToken: 'x', token: 'x', chatModel: CHAT_MODEL, target: 'dev',
+  dateStr: '2026-07-22', outDir: mkdtempSync(join(tmpdir(), 'canary-test-')),
+  topic: TOPIC, conversation: buildConversation(TOPIC, '2026-07-22'),
+});
+
+describe('D5 (salud del sidecar/agente) con el modelo de chat ausente', () => {
+  it('FALLA y nombra el modelo faltante en vez de dar verde por "ollama arriba"', async () => {
+    const r = await runOf('D5')(ctxBase());
+    // Antes: pass "sidecar 373f780, ollama=true, kokoro=true, tools=true".
+    expect(r.status).toBe('fail');
+    expect(r.data.chatModelPresente).toBe(false);
+    expect(r.data.chatModel).toBe(CHAT_MODEL);
+    expect(r.detalle).toMatch(/MODELO DE CHAT AUSENTE/);
+    expect(r.detalle).toContain(CHAT_MODEL);
+  });
+
+  it('con el modelo presente vuelve a dar verde (no rompe la corrida sana)', async () => {
+    const r = await runOf('D5')({ ...ctxBase(), chatModel: 'granite4.1:8b' });
+    expect(r.status).toBe('pass');
+    expect(r.data.chatModelPresente).toBe(true);
+  });
+
+  it('si /tags no se pudo listar NO acusa de ausente (no pude medir ≠ roto)', async () => {
+    // Puerto cerrado para /tags: sin lista no se puede afirmar que el modelo falte.
+    const r = await runOf('D5')({ ...ctxBase(), base: 'http://127.0.0.1:1' });
+    expect(r.status).toBe('fail'); // el sidecar entero está caído, eso sí es rojo
+    expect(r.data.chatModelPresente).toBe(null); // pero no se le echa la culpa al modelo
+    expect(r.detalle).not.toMatch(/MODELO DE CHAT AUSENTE/);
+  }, 30000);
+});
+
+describe('B0 (conversación) con el modelo de chat ausente', () => {
+  it('reporta la CAUSA del 404, no solo "0/4 respuestas"', async () => {
+    const ctx = ctxBase();
+    const r = await runOf('B0')(ctx);
+    expect(r.status).toBe('fail');
+    expect(r.valor).toMatch(/0\/\d+ respuestas/);
+    // Antes: "Conversación compleja sobre broca_cafe (0/4 turnos con respuesta)." y nada más.
+    expect(r.detalle).toMatch(/Causa:/);
+    expect(r.detalle).toMatch(/not found/);
+    expect(r.data.modelo_ausente).toBe(true);
+    expect(ctx.responses.every((x) => /HTTP 404 — model .* not found/.test(x.error))).toBe(true);
+  }, 30000);
+});
+
+describe('B0f (golden de ración avícola) con el modelo de chat ausente', () => {
+  it('no evalúa la calidad de una respuesta que nunca llegó', async () => {
+    const ctx = ctxBase();
+    const r = await runOf('B0f')(ctx);
+    // Antes: fail "(a) sin cantidad g/kg; (b) no ajusta por frío/altura; (d) cascarón".
+    expect(r.status).toBe('skip');
+    expect(r.data.evaluable).toBe(false);
+    expect(r.data.modelo_ausente).toBe(true);
+    expect(r.valor).not.toMatch(/cascar[oó]n|cantidad|altura/i);
+    expect(r.detalle).toMatch(/NO implica regresión del golden/);
+  }, 30000);
+
+  it('no envenena el JSONL del golden con una línea de respuesta vacía', async () => {
+    const ctx = ctxBase();
+    await runOf('B0f')(ctx);
+    expect(existsSync(join(ctx.outDir, 'golden', 'avicola-frio-2026-07-22.jsonl'))).toBe(false);
+  }, 30000);
+});

--- a/scripts/lib/canary-modules.mjs
+++ b/scripts/lib/canary-modules.mjs
@@ -79,6 +79,38 @@ function isPermissionError(msg) {
   return typeof msg === 'string' && /not permitted|permission|forbidden|access denied|no autorizado/i.test(msg);
 }
 
+/**
+ * Extrae la CAUSA legible de un error de la API de ollama (`{"error":"…"}`).
+ * Mismo racional que `jsonApiError`: un "HTTP 404" pelado no distingue "el proxy
+ * perdió la ruta" de "el modelo que pide el canario ya no está en el host", y esa
+ * ambigüedad costó la noche del 2026-07-22 — `granite3.3:8b` desapareció de ollama
+ * a mitad de la corrida y B0/B0f/B0g/C1 cayeron en cascada sin que el reporte
+ * dijera por qué. Ollama lo venía diciendo en el cuerpo desde el primer turno:
+ * `model 'granite3.3:8b' not found`.
+ */
+function ollamaError(res) {
+  const raw = res?.json?.error || (typeof res?.text === 'string' ? res.text.trim() : '');
+  if (!raw) return null;
+  return String(raw).replace(/\s+/g, ' ').slice(0, 200);
+}
+
+/** ¿La causa del error es que el modelo pedido no existe en el host de ollama? */
+function isModelNotFound(msg) {
+  return typeof msg === 'string' && /model\s+.*not found|no such model|pull the model/i.test(msg);
+}
+
+/**
+ * Causa predominante de una tanda de turnos sin respuesta. Se queda con el error
+ * más repetido para que el `detalle` diga "por qué" y no solo "cuántos".
+ */
+function causaPredominante(errores) {
+  const limpios = errores.filter(Boolean);
+  if (!limpios.length) return null;
+  const conteo = new Map();
+  for (const e of limpios) conteo.set(e, (conteo.get(e) || 0) + 1);
+  return [...conteo.entries()].sort((a, b) => b[1] - a[1])[0][0];
+}
+
 const JSONAPI = { Accept: 'application/vnd.api+json', 'Content-Type': 'application/vnd.api+json' };
 // JPEG 1x1 válido (marcador de foto del canario; embebido para no depender de assets).
 const CANARY_JPEG_B64 =
@@ -162,7 +194,10 @@ async function generateChat(base, bearer, systemPrompt, userPrompt, model) {
     timeoutMs: 180000,
   });
   const latency = Date.now() - start;
-  if (!r.ok || !r.json) return { response: '', latency_ms: latency, error: `HTTP ${r.status}` };
+  if (!r.ok || !r.json) {
+    const causa = ollamaError(r);
+    return { response: '', latency_ms: latency, error: `HTTP ${r.status}${causa ? ` — ${causa}` : ''}`, causa };
+  }
   return { response: r.json.message?.content || '', latency_ms: latency, model: r.json.model || model };
 }
 
@@ -226,7 +261,17 @@ async function runConversacion(ctx) {
     }
   }
   const status = turnOk === conversation.length ? 'pass' : 'fail';
-  return { status, valor: `${turnOk}/${conversation.length} respuestas`, detalle: `Conversación compleja sobre ${topic.id} (${turnOk}/${conversation.length} turnos con respuesta).`, data: { topic: topic.id } };
+  // Un "0/4 respuestas" sin causa manda al operador a investigar de cero. El error
+  // que devolvió el transporte ya está en ctx.responses: subirlo al detalle es lo
+  // que convierte el reporte en accionable (mismo racional que B0b, PR #2559).
+  const causa = causaPredominante(ctx.responses.map((r) => r.error));
+  const porQue = status === 'pass' || !causa ? '' : ` Causa: ${causa}.`;
+  return {
+    status,
+    valor: `${turnOk}/${conversation.length} respuestas`,
+    detalle: `Conversación compleja sobre ${topic.id} (${turnOk}/${conversation.length} turnos con respuesta).${porQue}`,
+    data: { topic: topic.id, causa, modelo_ausente: isModelNotFound(causa) },
+  };
 }
 
 /**
@@ -548,6 +593,21 @@ async function runAvicolaFrio(ctx) {
   const systemPrompt = buildEnrichedSystemPrompt(entities);
   const gen = await generateChat(base, token, systemPrompt, q, chatModel);
   const text = gen.response || '';
+
+  // Sin respuesta del transporte no hay nada que juzgar: el golden mide la CALIDAD
+  // de la ración, no la disponibilidad del agente. Antes esto salía como
+  // "(a) sin cantidad g/kg; (b) no ajusta por frío/altura; (d) cascarón" — tres
+  // acusaciones al agente por un HTTP 404, y una línea envenenada en el JSONL del
+  // golden que mañana se lee como regresión de calidad. Mismo criterio que B0c/A2.
+  if (!text && gen.error) {
+    return {
+      status: 'skip',
+      valor: `no evaluable (${gen.error})`,
+      detalle: `El agente no respondió (${gen.error}): sin respuesta no se puede evaluar la ración. NO implica regresión del golden.`,
+      data: { evaluable: false, error: gen.error, modelo_ausente: isModelNotFound(gen.error) },
+    };
+  }
+
   const ev = evalAvicolaFrio(text);
 
   // Golden/regresión: acumula la respuesta + sub-flags para trackear cuándo pasa.
@@ -630,7 +690,7 @@ async function runCalendario(ctx) {
 }
 
 async function runSidecarHealth(ctx) {
-  const { base, sidecarToken } = ctx;
+  const { base, sidecarToken, chatModel } = ctx;
   const h = await httpFetch(`${base}/api/mcp/agro/health`, { headers: { 'X-Chagra-Token': sidecarToken }, timeoutMs: 20000 });
   const health = h.json || {};
   const sidecarOk = h.ok && health.status === 'ok';
@@ -640,13 +700,22 @@ async function runSidecarHealth(ctx) {
   const kokoro = await httpFetch(`${base}/api/kokoro/health`, { timeoutMs: 15000 });
   const kokoroOk = kokoro.ok && /ok|kokoro/i.test(kokoro.text);
   const tags = await httpFetch(`${base}/api/ollama/api/tags`, { headers: { Authorization: `Bearer ${ctx.token || ''}` }, timeoutMs: 15000 });
-  const ollamaTagsOk = tags.ok && Array.isArray(tags.json?.models) && tags.json.models.length > 0;
-  const status = sidecarOk && ollamaOk && toolsOk && kokoroOk && ollamaTagsOk ? 'pass' : 'fail';
+  const modelos = Array.isArray(tags.json?.models) ? tags.json.models.map((m) => m?.name || m?.model).filter(Boolean) : [];
+  const ollamaTagsOk = tags.ok && modelos.length > 0;
+  // "ollama está arriba" NO es "el agente puede responder": el chat pide chatModel
+  // por nombre EXACTO y, si el host ya no lo tiene, ollama contesta 404 y el agente
+  // queda mudo con /health, /tools y kokoro los tres en verde. Eso fue exactamente
+  // la noche del 2026-07-22 (granite3.3:8b borrado del host): D5 dio PASS mientras
+  // B0 iba 0/4. Solo se puede afirmar la ausencia si /tags respondió — si no
+  // pudimos listar, no acusamos (no confundir "no pude medir" con "está roto").
+  const chatModelPresente = ollamaTagsOk ? modelos.includes(chatModel) : null;
+  const status = sidecarOk && ollamaOk && toolsOk && kokoroOk && ollamaTagsOk && chatModelPresente !== false ? 'pass' : 'fail';
+  const faltaModelo = chatModelPresente === false ? ` MODELO DE CHAT AUSENTE: '${chatModel}' no está en el host (ollama devolverá 404 y el agente queda mudo; ${modelos.length} modelos presentes).` : '';
   return {
     status,
-    valor: `sidecar ${health.build_sha || '?'}, ollama=${ollamaOk}, kokoro=${kokoroOk}, tools=${toolsOk}`,
-    detalle: `/health build_sha=${health.build_sha || '?'} (${sidecarOk ? 'ok' : 'DOWN'}), ollama_up=${ollamaOk}, kokoro=${kokoroOk}, /tools=${toolsOk}, ollama/tags=${ollamaTagsOk}.`,
-    data: { build_sha: health.build_sha, sidecarOk, ollamaOk, kokoroOk, toolsOk, ollamaTagsOk },
+    valor: `sidecar ${health.build_sha || '?'}, ollama=${ollamaOk}, kokoro=${kokoroOk}, tools=${toolsOk}${chatModelPresente === false ? `, chatModel=AUSENTE(${chatModel})` : ''}`,
+    detalle: `/health build_sha=${health.build_sha || '?'} (${sidecarOk ? 'ok' : 'DOWN'}), ollama_up=${ollamaOk}, kokoro=${kokoroOk}, /tools=${toolsOk}, ollama/tags=${ollamaTagsOk}.${faltaModelo}`,
+    data: { build_sha: health.build_sha, sidecarOk, ollamaOk, kokoroOk, toolsOk, ollamaTagsOk, chatModel, chatModelPresente, modelos_count: modelos.length },
   };
 }
 


### PR DESCRIPTION
## Qué pasó

La noche del 2026-07-22, `granite3.3:8b` desapareció del host de ollama a mitad de la corrida (en dev alcanzó a responder 3 turnos y el 4º ya dio 404; en prod los 4 fallaron). Ollama venía diciendo la causa en el cuerpo de cada respuesta:

```
HTTP 404 {"error":"model 'granite3.3:8b' not found"}
```

El reporte del canario no lo dijo en ninguna parte. Verificado en vivo: `/api/ollama/api/tags` lista 55 modelos y `granite3.3:8b` no está entre ellos (sí `granite4.1:8b`, `granite33-curado`, `granite3.1-dense:8b`).

## Los tres síntomas

| check | qué reportó | qué pasaba |
|---|---|---|
| **D5** | `PASS` — "ollama_up=true, kokoro=true, /tools=true" | `/health`, `/tools`, kokoro y `/tags` respondían: ollama **estaba** arriba, solo que sin **el** modelo. Falso verde con el agente 100% mudo — y D5 es justo el check al que se mira para saber si el backend está sano. |
| **B0** | `FAIL` — "0/4 respuestas" | Sin causa. Manda al operador a investigar desde cero lo que ollama ya había explicado. |
| **B0f** | `FAIL` — "(a) sin cantidad g/kg; (b) no ajusta por frío/altura; (d) cascarón" | Tres regresiones de **calidad** inventadas a partir de un 404, más una línea envenenada en el JSONL del golden que mañana se lee como regresión real. |

B0g y C1 cayeron en cascada por lo mismo (y C1 **sí** lo reportó bien, gracias a #2489).

## Cambios

- `generateChat` adjunta la causa que devuelve ollama al lado del código: `HTTP 404 — model '…' not found` en vez de `HTTP 404` pelado. Mismo racional que `jsonApiError` para B0b (#2559).
- **D5** verifica que `chatModel` esté en `/api/tags` y falla nombrándolo si falta. Solo lo afirma si `/tags` respondió — si no se pudo listar, no acusa.
- **B0** sube la causa predominante de los turnos al `detalle`.
- **B0f** devuelve `skip` cuando no hubo respuesta y no escribe el golden, en vez de fabricar un veredicto de calidad. Mismo criterio que B0c/A2 (#2489).

Es la regla de `canary-backend-caido.test.mjs` ("no pude medir" ≠ "está roto") más su reverso: **si el componente sí está roto, el canario no puede darlo verde.**

## Tests

6 casos nuevos contra un stub del target de esa noche (sidecar en verde, ollama arriba, modelo ausente). **Los 6 fallan con el código anterior** (verificado con el archivo stasheado). Suite del canario completa: 23/23. `eslint` limpio, gates de `lefthook` (secret-scan + voseo + conventional) en verde.

## Base de la rama

Va contra `feat/nightly-canary`, no `main`: el framework del canario **solo existe en esa rama** (`git ls-tree origin/main` no tiene `scripts/nightly-canary.mjs`), y es de ahí que el runner hace checkout. Un PR contra `main` crearía el archivo desde cero.

## Lo que este PR NO arregla

Que el modelo falte es **infra**, no código — sigue faltando ahora mismo y el agente sigue mudo en dev y prod hasta que se re-pinnee o se re-pullee en el host. Este PR solo hace que la próxima vez el canario lo diga en la primera línea del reporte en vez de esconderlo detrás de un PASS.
