### PR TITLE
chore(codeql): limpiar deuda de calidad en src/ (4 reglas top)

### DIFF
--- a/src/components/AbejasScreen.jsx
+++ b/src/components/AbejasScreen.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Hexagon, Flower2, HeartPulse, ShieldAlert, Recycle, Info, Droplets,
+  Hexagon, Flower2, ShieldAlert, Recycle, Info, Droplets,
   Sprout, Leaf, AlertTriangle, ArrowRight, CheckCircle2, Home as HomeIcon,
   MessageCircleQuestion,
 } from 'lucide-react';

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square, Sprout, HelpCircle } from 'lucide-react';
+import { ArrowLeft, Mic, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square, Sprout, HelpCircle } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { mensajeErrorCampesino } from '../../utils/mensajeErrorCampesino';
 import { transcribe, queueForRetry } from '../../services/voiceService';
@@ -98,7 +98,6 @@ import { submitDeepResearch, pollDeepResearch, isDeepResearchEnabled } from '../
 // isPro controla el gate de la UI (chip 🔬); x-chagra-tier se inyecta en el
 // sidecarClient/deepResearchClient vía buildSidecarHeaders (defense-in-depth).
 import { getCurrentTier } from '../../services/tierService';
-import DeepResearchCard from '../DeepResearchCard';
 import { normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, applyVoseoFilter, resolveUserRegion, stripRoleLeak, buildPriceDeclineContext, buildPriceAnswer, buildSuggestedEntitiesContext, isLowConfidenceEntity, buildFallbackResponse, pisoTermicoFromAltitud, groupAndLimitCultivos } from '../../services/agentService';
 import { buildPriceReferenceAnswer } from '../../services/marketplaceService';
 import { buildBasePrompt, analyzeQuery, buildQueryAnalysisBlock, buildCorpusVariants, buildResolvedEntitiesBlock, formatToolEvidence, truncateEdgesBlock } from '../../services/agentPromptBase';
@@ -1556,7 +1555,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           // numérica. Sin esto, el guard igual funciona vía texto libre del
           // mensaje (degradación por diseño del sidecar).
           const rePisoTermico = (() => {
-            try { const p = getProfile(); if (p && p.piso_termico) return p.piso_termico; } catch (_) { /* noop */ }
+            try { const p = getProfile(); if (p.piso_termico) return p.piso_termico; } catch (_) { /* noop */ }
             return null;
           })();
           const tRE0 = performance.now();
@@ -1877,7 +1876,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             const pisoTermicoChip = (() => {
               try {
                 const p = getProfile();
-                if (p && p.piso_termico) return p.piso_termico;
+                if (p.piso_termico) return p.piso_termico;
               } catch (_) { /* noop */ }
               return pisoTermicoFromAltitud(fincaAltitudChip);
             })();
@@ -2270,7 +2269,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // hacen nada salvo el guard de agroquímico, que usa denylist propia).
       const guardAltitud =
         (fincaActiva && fincaActiva.altitud) ||
-        (() => { try { const p = getProfile(); return (p && p.finca_altitud) || null; } catch (_) { return null; } })();
+        (() => { try { const p = getProfile(); return p.finca_altitud || null; } catch (_) { return null; } })();
       // P0 (prod 2026-05-31): el agente FABRICABA un diagnóstico visual sin foto
       // real ("Analicé una foto, estado 95/100" + hallazgos de Mapacho del RAG
       // de tabaco). hadVision marca si ESTE turno trajo una imagen real
@@ -2280,7 +2279,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // concluyente. Para turnos de texto/voz, visionContext es null → hadVision
       // false → corrige cualquier afirmación visual inventada.
       const guardProfileName =
-        (() => { try { const p = getProfile(); return (p && p.nombre) || null; } catch (_) { return null; } })();
+        (() => { try { const p = getProfile(); return p.nombre || null; } catch (_) { return null; } })();
       // HARDENING térmico (audit #23): mínima/máxima esperadas del pronóstico ya
       // cacheado (mismo snapshot que buildFrostHeatContext — NO se re-pide).
       // Habilita guardThermalViability para advertir helada/golpe de calor sobre
@@ -2434,7 +2433,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // pinta "Dato de otro cultivo · verifica"). Solo corre sobre turnos que
       // IBAN a salir verificados. Graceful: cualquier fallo deja el sello
       // intacto (jamás degrada por error).
-      if (sourceMetadata && sourceMetadata.grounded === true) {
+      if (sourceMetadata.grounded === true) {
         try {
           const cropInFocusIds = Array.from(new Set(
             (resolvedEntities || [])

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -179,7 +179,7 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
       {typeof onBack === 'function' && showFloatingBack && (
         <button
           type="button"
-          onClick={onBack ? () => onBack() : undefined}
+          onClick={() => onBack()}
           data-testid="chat-floating-back"
           aria-label="Volver"
           className="chagra-floating-back absolute top-3 left-3 z-20 flex items-center gap-1.5 pl-2 pr-3 py-2 rounded-full bg-slate-900/90 backdrop-blur-sm border border-slate-700 text-amber-300 shadow-lg active:scale-95 hover:bg-slate-800"

--- a/src/components/AnimalesScreen.jsx
+++ b/src/components/AnimalesScreen.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PawPrint, Rabbit, ChevronRight, Recycle } from 'lucide-react';
+import { PawPrint, ChevronRight, Recycle } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import FotoAnimal from './animales/FotoAnimal';
 

--- a/src/components/Asociaciones.jsx
+++ b/src/components/Asociaciones.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { AlertTriangle, BarChart3, CheckCircle2, Leaf, Network, Sprout, TrendingUp, Layers, ArrowRight, Sparkles, Users, Zap, Shield } from 'lucide-react';
+import { AlertTriangle, BarChart3, CheckCircle2, Leaf, Network, Sprout, TrendingUp, Layers, Sparkles, Users, Zap, Shield } from 'lucide-react';
 import arquetipos from '../data/asociaciones-arquetipos.json';
 import comparativas from '../data/asociaciones-comparativa.json';
 import {

--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable chagra-i18n/no-hardcoded-spanish -- legacy UI copy already tracked separately */
 import React, { useState, useMemo, useEffect } from 'react';
-import { X, Calendar, Tag, Activity, MapPin, AlertCircle, Images, Skull, Layers, Sprout } from 'lucide-react';
+import { X, Calendar, Activity, MapPin, AlertCircle, Images, Skull, Layers, Sprout } from 'lucide-react';
 import { SplitFlow } from './SplitFlow';
 import PlantCemeteryModal from './PlantCemeteryModal';
 import useAssetStore from '../store/useAssetStore';

--- a/src/components/CarbonoPsaSubvista.jsx
+++ b/src/components/CarbonoPsaSubvista.jsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { AlertTriangle, ShieldCheck, Scale, Ruler, Leaf, ArrowUpRight, Sprout, Activity } from 'lucide-react';
+import { AlertTriangle, ShieldCheck, Scale, Ruler, Leaf, Sprout, Activity } from 'lucide-react';
 import { evaluarPSA } from '../services/psaElegibilidad';
 import { detectarAlertaCarbono } from '../services/carbonoAlerta';
 import RESTAURACION from '../data/restauracion.json';

--- a/src/components/CicloDetalle.jsx
+++ b/src/components/CicloDetalle.jsx
@@ -162,8 +162,8 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
   const pestRisks = useMemo(() => { try { return getPestRisksByStage(displayStage, a.subject_slug) || []; } catch { return []; } }, [displayStage, a.subject_slug]);
   const bios = useMemo(() => { try { return getBiopreparadosForStage(baseStage(displayStage)) || []; } catch { return []; } }, [displayStage]);
   const ensoLabel = getEnsoLabel();
-  const ensoTasks = useMemo(() => { try { return getEnsemblePreventiveTasks(getEnsoServicePhase(), baseStage(displayStage)) || []; } catch { return []; } }, [displayStage]);
-  const tasks = useMemo(() => { try { return getTasksForCycle(effectiveCycle) || []; } catch { return []; } }, [effectiveCycle]);
+  const ensoTasks = useMemo(() => { try { return getEnsemblePreventiveTasks(getEnsoServicePhase(), baseStage(displayStage)); } catch { return []; } }, [displayStage]);
+  const tasks = useMemo(() => { try { return getTasksForCycle(effectiveCycle); } catch { return []; } }, [effectiveCycle]);
   const urgent = useMemo(() => { try { return getUrgentTasks(tasks) || []; } catch { return []; } }, [tasks]);
 
   const handleStage = useCallback(async (newStage) => {

--- a/src/components/CicloVivo/CicloVivoFullView.jsx
+++ b/src/components/CicloVivo/CicloVivoFullView.jsx
@@ -65,7 +65,7 @@ export default function CicloVivoFullView({ onBack, onNavigate }) {
 
   // Especie + piso térmico. Piso: perfil primero; altitud del dispositivo como
   // refinamiento best-effort (no bloquea el render). Se lee una sola vez.
-  const [profile] = useState(() => { try { return getProfile() || {}; } catch { return {}; } });
+  const [profile] = useState(() => { try { return getProfile(); } catch { return {}; } });
   const [piso, setPiso] = useState(() => {
     if (profile.piso_termico && PISO_LABEL[profile.piso_termico]) return profile.piso_termico;
     return pisoTermicoFromAltitud(profile.finca_altitud);
@@ -87,7 +87,7 @@ export default function CicloVivoFullView({ onBack, onNavigate }) {
       if (p) {
         setPiso(p);
         // Solo re-sugerimos la especie si el usuario no tiene override propio.
-        if (!profile[PROFILE_ESPECIE_KEY]) setSpKey((prev) => resolverEspecie(null, p) || prev);
+        if (!profile[PROFILE_ESPECIE_KEY]) setSpKey(() => resolverEspecie(null, p));
       }
     }).catch(() => {});
     return () => { alive = false; };

--- a/src/components/CromatografiaScreen.jsx
+++ b/src/components/CromatografiaScreen.jsx
@@ -2,8 +2,8 @@ import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 /* eslint-disable chagra-i18n/no-hardcoded-spanish */
 import {
   ChevronLeft, Camera, Trash2, Upload, X, ArrowLeftRight, BookOpen,
-  FlaskConical, Beaker, AlertTriangle, Lightbulb, Leaf, List, Plus,
-  MapPin, Calendar, Eye, CheckCircle2, Image, Layers, Droplets, Sprout,
+  FlaskConical, AlertTriangle, Lightbulb, Plus,
+  MapPin, Calendar, Eye, CheckCircle2, Layers, Sprout,
 } from 'lucide-react';
 import { formatColombiaDate } from '../utils/colombiaDate';
 import {
@@ -214,89 +214,6 @@ const PRECAUCIONES = [
     icono: '🧤',
     texto:
       'Desecha los guantes y papeles usados en una bolsa aparte, no en la composta.',
-  },
-];
-
-/* ───────── Interpetacion por zonas (las 4 clasicas de Pfeiffer/Restrepo) ─── */
-const ZONAS = [
-  {
-    nombre: 'Zona central o mineral',
-    posicion: 'Cerca del centro del cromatograma',
-    color: 'border-amber-500',
-    bg: 'bg-amber-950/30',
-    texto: 'border-amber-800/60',
-    icono: '🪨',
-    queIndica:
-      'Muestra los minerales y las sales. Un centro claro o blanco indica buena reserva de minerales disponibles para las plantas. Un centro oscuro o manchado puede indicar exceso de sales o compactacion.',
-  },
-  {
-    nombre: 'Zona media o proteica-humica',
-    posicion: 'Anillo entre la zona central y la externa',
-    color: 'border-amber-700',
-    bg: 'bg-amber-900/20',
-    texto: 'border-amber-700/60',
-    icono: '🌱',
-    queIndica:
-      'Representa la materia organica y el humus del suelo. Un anillo marron bien definido y ancho indica buena cantidad de humus estable. Si es muy delgado o ausente, hay poca materia organica o esta muy degradada.',
-  },
-  {
-    nombre: 'Zona externa o enzimatica',
-    posicion: 'Anillo exterior antes de los picos del borde',
-    color: 'border-violet-700',
-    bg: 'bg-violet-950/20',
-    texto: 'border-violet-700/60',
-    icono: '🧬',
-    queIndica:
-      'Refleja la actividad de los microorganismos y las enzimas. Un borde bien definido con tonalidades violetas o rosadas indica un suelo biologicamente activo, con buena vida microbiana. Si es difuso o palido, hay poca actividad.',
-  },
-  {
-    nombre: 'Picos y radiaciones del borde',
-    posicion: 'Borde externo del cromatograma',
-    color: 'border-indigo-500',
-    bg: 'bg-indigo-950/20',
-    texto: 'border-indigo-700/60',
-    icono: '⚡',
-    queIndica:
-      'Los picos o radiaciones que salen del borde indican vida y energia del suelo. Muchas radiaciones definidas y largas senalan un suelo vivo y equilibrado. Pocas o cortas pueden indicar un suelo cansado o con poca biodiversidad microbiana.',
-  },
-];
-
-const COLORES = [
-  {
-    color: 'Marrón oscuro / café',
-    significado:
-      'Buena materia organica y humus estable. Es el color deseable en la zona media.',
-    clase: 'bg-amber-900 border-amber-700',
-  },
-  {
-    color: 'Blanco o crema',
-    significado:
-      'Sales minerales. En el centro indica minerales disponibles; en anillos externos puede indicar acumulacion de sales.',
-    clase: 'bg-stone-200 border-stone-400 text-slate-900',
-  },
-  {
-    color: 'Gris / plomizo',
-    significado:
-      'Suelo compactado, oxidado o con poca vida. Puede indicar exceso de humedad o anaerobiosis.',
-    clase: 'bg-slate-500 border-slate-400',
-  },
-  {
-    color: 'Violeta / lila',
-    significado:
-      'Actividad enzimatica y microbiologica. Indica un suelo vivo y con buena mineralizacion.',
-    clase: 'bg-violet-800 border-violet-600',
-  },
-  {
-    color: 'Rosado',
-    significado:
-      'Actividad biologica de bacterias beneficiosas. Halos rosados son senal positiva.',
-    clase: 'bg-pink-800 border-pink-600',
-  },
-  {
-    color: 'Amarillo / dorado',
-    significado:
-      'Puede indicar presencia de azufre o compuestos organicos especificos. Interpretar junto con las otras zonas.',
-    clase: 'bg-yellow-700 border-yellow-500',
   },
 ];
 

--- a/src/components/DirectorioEspecies/PlagaFicha.jsx
+++ b/src/components/DirectorioEspecies/PlagaFicha.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   Bug,
-  ShieldAlert,
   ShieldCheck,
   Leaf,
   Sprout,

--- a/src/components/GlaciarHistorialScreen.jsx
+++ b/src/components/GlaciarHistorialScreen.jsx
@@ -15,7 +15,7 @@
  * Español Colombia (usted/tú, SIN voseo).
  */
 import { useState, useEffect, useCallback } from 'react';
-import { List, Snowflake, MapPin, Calendar, Loader2, ChevronLeft, Home, AlertCircle, Trash2, ArrowLeft, Download, CheckCircle2 } from 'lucide-react';
+import { List, Snowflake, MapPin, Loader2, AlertCircle, Trash2, Download, CheckCircle2 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import { glaciarReportes } from '../db/glaciarReportes';
 import { MSG } from '../config/messages.js';

--- a/src/components/InventoryAuditDashboard.jsx
+++ b/src/components/InventoryAuditDashboard.jsx
@@ -143,7 +143,7 @@ export default function InventoryAuditDashboard() {
                         aria-label="Recargar datos de auditoría"
                         className="p-2.5 rounded-xl bg-slate-800 border border-slate-700 text-slate-300 hover:bg-slate-700 active:scale-95 transition-all"
                     >
-                        <RefreshCw size={18} aria-hidden="true" className={loading ? 'animate-spin' : ''} />
+                        <RefreshCw size={18} aria-hidden="true" />
                     </button>
                 </div>
             </header>

--- a/src/components/OnboardingModal.jsx
+++ b/src/components/OnboardingModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { X, ExternalLink, Server, BookOpen, ArrowRight, ChevronDown } from 'lucide-react';
+import { X, ExternalLink, Server, ArrowRight, ChevronDown } from 'lucide-react';
 
 export function OnboardingModal({finca, onClose, onConfigureLater}) {
     const [showTech, setShowTech] = useState(false);

--- a/src/components/PlantaPorVozScreen.jsx
+++ b/src/components/PlantaPorVozScreen.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import {
   Mic, Sprout, FlaskConical, Ban, RotateCcw, ChevronLeft,
-  Leaf, AlertTriangle, GitBranch, RefreshCw,
+  Leaf, GitBranch, RefreshCw,
 } from 'lucide-react';
 import VoiceCapture from './VoiceCapture';
 import PhenologyTimeline from './PhenologyTimeline';

--- a/src/components/PlatanoBananoScreen.jsx
+++ b/src/components/PlatanoBananoScreen.jsx
@@ -5,8 +5,8 @@
 /* eslint-disable chagra-i18n/no-hardcoded-spanish */
 import { useMemo, useState } from 'react';
 import {
-  ChevronLeft, ChevronRight, Info, AlertTriangle, Sprout, Leaf, Bug, Recycle,
-  Copy, RefreshCw, Sun, ShieldCheck, Ruler, Scissors, Trees, Wheat, Camera,
+  ChevronLeft, ChevronRight, Info, Sprout, Leaf, Bug, Recycle,
+  Copy, RefreshCw, ShieldCheck, Ruler, Scissors, Trees, Wheat, Camera,
   Droplets, CheckCircle2,
 } from 'lucide-react';
 import {

--- a/src/components/SeguimientoProcesoScreen.jsx
+++ b/src/components/SeguimientoProcesoScreen.jsx
@@ -49,13 +49,6 @@ const PIG_SANITY_GUARDS = [
   animalDiagnostics?.guardas?.porquinaza_bioseguridad,
   animalDiagnostics?.guardas?.reproduccion_porcina,
 ].filter(Boolean);
-const PIG_STAGE_LABELS = {
-  instalacion: 'Instalación',
-  alimentacion: 'Alimentación',
-  reproduccion: 'Reproducción',
-  sanidad: 'Sanidad',
-  cierre: 'Cierre',
-};
 
 // Etapa inicial por tipo de proceso (primer hito de su secuencia).
 function initialStageFor(processType) {

--- a/src/components/Settings/BackgroundSelector.jsx
+++ b/src/components/Settings/BackgroundSelector.jsx
@@ -276,11 +276,6 @@ function BackgroundPreviewModal({ option, onConfirm, onClose }) {
   // como la referencia) y se corrige una sola vez al cargar. NO es per-frame.
   const [ratio, setRatio] = useState(3 / 4);
 
-  const handleImgLoad = useCallback((e) => {
-    const { naturalWidth: w, naturalHeight: h } = e.currentTarget;
-    if (w > 0 && h > 0) setRatio(w / h);
-  }, []);
-
   useEffect(() => {
     function onKey(e) {
       if (e.key === 'Escape') onClose();

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -3,7 +3,7 @@
  * useEffect. La tarea actual solo reemplaza el pipeline de foto del catálogo.
  */
 import React, { useState, useMemo, useRef, useEffect } from 'react';
-import { Search, ChevronDown, X, Clock, Sparkles, Camera, ImagePlus, Loader2, Bug, Check, AlertCircle, AlertTriangle, HelpCircle, Info, WifiOff } from 'lucide-react';
+import { Search, ChevronDown, X, Clock, Sparkles, Camera, ImagePlus, Bug, Check, AlertCircle, AlertTriangle, HelpCircle, Info, WifiOff } from 'lucide-react';
 import VisionLoadingState from './common/VisionLoadingState';
 import { warmVisionModel } from '../services/visionWarmService';
 import { CROP_TAXONOMY } from '../config/taxonomy';

--- a/src/components/TaskScreen.jsx
+++ b/src/components/TaskScreen.jsx
@@ -68,7 +68,7 @@ function TaskScreen({ onBack, onSave, initialData }) {
             status: initialData?.attributes?.status || initialData?.status || 'pending'
         };
     };
-    const [formData, setFormData] = useState(buildInitial);
+    const [formData] = useState(buildInitial);
     const autosaveKey = isEdit ? `taskscreen-edit-${initialData.id}` : 'taskscreen-create';
     const { savedState: autoForm, save: autoSave, markSubmitted } = useAutosave(autosaveKey, buildInitial());
     const formValues = autoForm || formData;

--- a/src/components/WelcomeStatsHero.jsx
+++ b/src/components/WelcomeStatsHero.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import {
   Sprout, Leaf, BookOpen, Database, Droplet, TreePine, Users, ShieldCheck,
-  FileCheck, Cloud, Maximize2, X, ChevronLeft, ChevronRight, ChevronUp, ChevronDown,
+  FileCheck, Maximize2, X, ChevronLeft, ChevronRight, ChevronUp, ChevronDown,
 } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import ChagraAgentAvatar from './ChagraAgentAvatar';

--- a/src/components/anofinca/AnoFincaScreen.jsx
+++ b/src/components/anofinca/AnoFincaScreen.jsx
@@ -81,7 +81,6 @@ const TONO_FILL = {
   seca: 'rgba(251, 191, 36, 0.07)',
   transicion: 'transparent',
 };
-const TONO_LABEL = { lluvia: 'aguas', seca: 'secas', transicion: '' };
 
 /** Días del mes (para ubicar el marcador de "hoy" dentro de su mes). */
 const diasDelMes = (year, month) => new Date(year, month, 0).getDate();

--- a/src/components/biopreparados/BiopreparadosScreen.jsx
+++ b/src/components/biopreparados/BiopreparadosScreen.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   FlaskConical, Sprout, Leaf, Bug, ShieldCheck, ShieldPlus, Layers,
   ShieldAlert, Clock, ScrollText, ChevronDown, Camera, ExternalLink,
-  AlertCircle, Droplets, Hourglass, Repeat, HardHat, Ban, HelpCircle,
+  AlertCircle, Droplets, Hourglass, Repeat, HardHat, Ban,
 } from 'lucide-react';
 import { ScreenShell } from '../common/ScreenShell';
 import PedagogicalBlock from '../common/PedagogicalBlock';

--- a/src/components/clima/ClimaBoletinScreen.jsx
+++ b/src/components/clima/ClimaBoletinScreen.jsx
@@ -6,7 +6,7 @@ import {
 import { ScreenShell } from '../common/ScreenShell';
 import CieloENSO from './CieloENSO';
 import { getEnsoPhase, getEnsoLabel, getEnsoPhaseSource } from '../../services/ensoService';
-import { ensoFamily, regionFromProfile, ensoRegionalLine, ENSO_WATCH_2026 } from '../../services/ensoContext';
+import { ensoFamily, regionFromProfile, ensoRegionalLine } from '../../services/ensoContext';
 import { getProfile } from '../../services/userProfileService';
 import {
   PILARES_CLIMA,

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -813,7 +813,7 @@ const PISO_LABEL = {
 function buildUbicacion() {
   let loc = {};
   let perfil = {};
-  try { perfil = getProfile() || {}; } catch (_) { perfil = {}; }
+  try { perfil = getProfile(); } catch (_) { perfil = {}; }
   try { loc = resolveClimaLocation({ profile: perfil }) || {}; } catch (_) { loc = {}; }
 
   const vereda = limpiar(loc.vereda || perfil.vereda);

--- a/src/components/hoy/JourneyGuideCard.jsx
+++ b/src/components/hoy/JourneyGuideCard.jsx
@@ -23,7 +23,7 @@ import { getProfile } from '../../services/userProfileService';
  * contenido sale del modelo del DR (agroecologyJourney).
  */
 export default function JourneyGuideCard({ processes = [], onNavigate }) {
-  const profile = useMemo(() => getProfile() || {}, []);
+  const profile = useMemo(() => getProfile(), []);
   const fincaSlug = profile.fincaSlug || profile.slug || 'default';
   const ctx = contextoDesdeVocacion(profile.vocacion);
 

--- a/src/components/hoy/MiFincaEvolucionScreen.jsx
+++ b/src/components/hoy/MiFincaEvolucionScreen.jsx
@@ -47,7 +47,7 @@ import indicatorsData from '../../data/agroecology-indicators.json';
  * @param {Function} [props.onNavigate] navegación a otras vistas (ej. agente)
  */
 export default function MiFincaEvolucionScreen({ onBack, onHome, onNavigate }) {
-  const profile = useMemo(() => getProfile() || {}, []);
+  const profile = useMemo(() => getProfile(), []);
   const fincaSlug = profile.fincaSlug || profile.slug || 'default';
   const ctx = contextoDesdeVocacion(profile.vocacion);
 

--- a/src/components/juego/MiFincaVivaScreen.jsx
+++ b/src/components/juego/MiFincaVivaScreen.jsx
@@ -51,7 +51,7 @@ import { fvhSkinClass } from '../../config/fvhSkin';
  * @param {Function} [props.onNavigate]
  */
 export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
-  const profile = useMemo(() => getProfile() || {}, []);
+  const profile = useMemo(() => getProfile(), []);
   const fincaSlug = profile.fincaSlug || profile.slug || 'default';
 
   // Audio on/off — comparte la preferencia con el sonido del agente, así un solo

--- a/src/components/juego/MilpaSimulator.jsx
+++ b/src/components/juego/MilpaSimulator.jsx
@@ -5,7 +5,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ScreenShell } from '../common/ScreenShell';
-import { Sprout, RotateCcw, Volume2, VolumeX, Sparkles, Trophy, Target, Leaf } from 'lucide-react';
+import { Sprout, RotateCcw, Volume2, VolumeX, Sparkles, Trophy, Target } from 'lucide-react';
 
 import {
   CULTIVOS_INFO,
@@ -35,7 +35,6 @@ import {
   identificarAsociacion,
   aplicarEvento,
   resumenFinca,
-  EVENTOS,
   SALUD_MAX,
   ASOCIACIONES,
   avanzarTemporada,
@@ -1119,40 +1118,6 @@ function SinergiaDato({ texto, valor }) {
     <div className="rounded-2xl bg-slate-900/45 p-2 text-center ring-1 ring-emerald-700/40">
       <p className="text-[10px] font-bold uppercase tracking-wide text-emerald-300">{texto}</p>
       <p className="text-sm font-black text-lime-200">{valor}</p>
-    </div>
-  );
-}
-
-/** Celda de comparación con barras animadas. */
-function ResultadoCelda({ etiqueta, valor, maxValor, acento }) {
-  const porcentaje = Math.min(100, Math.max(0, (valor / maxValor) * 100));
-
-  return (
-    <div className="rounded-2xl bg-slate-900/60 p-3">
-      <p className="text-[11px] font-bold uppercase tracking-wide text-emerald-200">{etiqueta}</p>
-      <div className="mt-2 relative">
-        {/* Barra animada */}
-        <div className="h-8 w-full overflow-hidden rounded-lg bg-slate-800">
-          <div
-            className={`h-full rounded-lg bg-gradient-to-r ${
-              acento
-                ? 'from-lime-400 via-emerald-400 to-lime-300'
-                : 'from-amber-600 via-orange-500 to-amber-400'
-            } transition-all duration-1000 ease-out milpa-brota`}
-            style={{ width: `${porcentaje}%` }}
-          />
-        </div>
-        {/* Número flotante */}
-        <div className="absolute inset-0 flex items-center justify-center">
-          <p
-            className={`text-lg font-black ${
-              acento ? 'text-lime-200' : 'text-amber-200'
-            } drop-shadow-lg`}
-          >
-            {valor}
-          </p>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/components/juego/milpaData.js
+++ b/src/components/juego/milpaData.js
@@ -21,7 +21,7 @@
  * Todo offline: cero red en runtime. Sin nombres propios de personas.
  */
 
-import { CULTIVOS, ASOCIACIONES } from '../../services/milpaGameEngine';
+import { CULTIVOS } from '../../services/milpaGameEngine';
 export { OCUPACION_CULTIVO, SLOTS_POR_PARCELA } from '../../services/milpaGameEngine';
 
 /**

--- a/src/components/semilla/SemillaScreen.jsx
+++ b/src/components/semilla/SemillaScreen.jsx
@@ -4,9 +4,9 @@
 /* eslint-disable chagra-i18n/no-hardcoded-spanish */
 import { useMemo, useState } from 'react';
 import {
-  ChevronLeft, ChevronRight, ArrowRight, Sprout, Wheat, Snowflake,
+  ChevronLeft, ChevronRight, ArrowRight, Sprout, Snowflake,
   Archive, FlaskConical, Bug, Calculator, CheckCircle2, AlertTriangle,
-  Info, Percent, Users, Sun, Droplets, ShieldCheck,
+  Info, Percent, Users, ShieldCheck,
 } from 'lucide-react';
 import {
   CULTIVOS_SEMILLA, SISTEMAS_REPRODUCTIVOS, evaluarSeleccion, ROGUING_PCT,

--- a/src/constants/assetStatuses.js
+++ b/src/constants/assetStatuses.js
@@ -32,11 +32,3 @@ export const STATUS_MAP = {
     pest: PEST_STATUSES
 };
 
-const STATUS_DEFAULT_FOR_TYPE = {
-    'asset--plant': 'growing',
-    'log--maintenance': 'pending',
-    'log--seeding': 'completed',
-    'log--harvest': 'completed',
-    'log--input': 'completed',
-    'log--observation': 'pending'
-};

--- a/src/data/glaciar-schema.js
+++ b/src/data/glaciar-schema.js
@@ -98,8 +98,6 @@ export const ESCALA_DUREZA = [
 
 /** Códigos de dureza "blanda" (la mano todavía entra). Útil para reglas. */
 export const DUREZAS_BLANDAS = Object.freeze(['F', '4F']);
-/** Códigos de dureza de hielo (ya no entra la mano, se prueba con piolet). */
-const DUREZAS_HIELO = Object.freeze(['H1', 'H2']);
 
 /* ── Tipo de superficie del hielo/nieve (7) ──────────────────────────────
  * Cada tipo trae una implicación de seguridad corta (qué significa para el

--- a/src/mockups/MundoGallinero3D.jsx
+++ b/src/mockups/MundoGallinero3D.jsx
@@ -1,5 +1,4 @@
 import { useMemo, useRef, useState } from 'react';
-import * as THREE from 'three';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { AdaptiveDpr, Html, OrbitControls } from '@react-three/drei';
 import { ATMOSFERA, CIELOS, PALETA, mezclar, mezclarCielo } from '../visual/mundo3d/atmosferaMadre.js';

--- a/src/mockups/MundoVergelFrutal3D.jsx
+++ b/src/mockups/MundoVergelFrutal3D.jsx
@@ -127,7 +127,6 @@ function alturaVergel(wx, wz) {
   const f = clamp(explanada(wx, wz) * 1.15, 0, 1);
   return h * (1 - f) + 0.55 * f;
 }
-const Y_SUELO = 0.55;
 
 /* Dónde cae hojarasca: bajo las copas grandes del estrato alto. Los centros
    coinciden con los árboles mayores de la escena. */

--- a/src/mockups/NewDonk2Den3D.jsx
+++ b/src/mockups/NewDonk2Den3D.jsx
@@ -24,7 +24,7 @@
  *
  * Mockup standalone con su propio <Canvas>. Ruta #/mockups/new-donk, sin auth.
  */
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';

--- a/src/mockups/laminas/LaminaMilpa.jsx
+++ b/src/mockups/laminas/LaminaMilpa.jsx
@@ -2,7 +2,7 @@ import { useId } from 'react';
 import { AutoDibujo } from '../../visual/effects';
 import {
   Rotulo, TINTA, TINTA_2, VERDE, VERDE_OSC, VERDE_CLARO,
-  GRANO, GRANO_OSC, NARANJA, TIERRA, TIERRA_CLARA, ROJO,
+  GRANO, GRANO_OSC, NARANJA, TIERRA_CLARA, ROJO,
 } from './_kit.jsx';
 
 /*

--- a/src/mockups/metalslug/PlagasSprites.jsx
+++ b/src/mockups/metalslug/PlagasSprites.jsx
@@ -19,7 +19,6 @@
 import { memo } from 'react';
 
 const TINTA = '#2c1e12';
-const TINTA2 = '#4a3320';
 
 /* Ojos saltones reutilizables (el sello "villano" del bestiario). */
 function OjosMalvados({ cx1, cx2, cy, r = 4.4, mira = 1, enojo = true }) {

--- a/src/mockups/valle/siembraValle.js
+++ b/src/mockups/valle/siembraValle.js
@@ -226,7 +226,6 @@ export function sembrarArboleda(especies, zona, claros, alturaDe, r) {
 
   // Un candidato por especie (un intento): anillo de claro, rodal o libre.
   const candidato = (sp) => {
-    const z = sp.zona || zona;
     const caja = cajas[sp.clave];
     if (sp.bordeClaro && claros.length && r() < sp.bordeClaro) {
       const c = claros[Math.floor(r() * claros.length)];

--- a/src/services/alertEngine.js
+++ b/src/services/alertEngine.js
@@ -106,7 +106,7 @@ class AlertEngine {
    */
   resolveCoords() {
     try {
-      const p = getProfile() || {};
+      const p = getProfile();
       const lat = Number(p.ubicacion_lat);
       const lng = Number(p.ubicacion_lng);
       if (Number.isFinite(lat) && Number.isFinite(lng)) {
@@ -124,7 +124,7 @@ class AlertEngine {
    */
   resolvePisoTermico() {
     try {
-      const p = getProfile() || {};
+      const p = getProfile();
       const piso = (p.piso_termico || '').toLowerCase().trim();
       if (piso.includes('paramo') || piso.includes('páramo')) return 'paramo';
       if (piso.includes('frio') || piso.includes('frío')) return 'frio';

--- a/src/services/climaService.js
+++ b/src/services/climaService.js
@@ -250,7 +250,7 @@ export async function fetchClimaSnapshot({ lat, lng, elevation, forceRefresh = f
     try {
         return await promise;
     } finally {
-        if (inFlight && inFlight.promise === promise) inFlight = null;
+        if (inFlight.promise === promise) inFlight = null;
     }
 }
 

--- a/src/services/cuadernoPDF.js
+++ b/src/services/cuadernoPDF.js
@@ -345,7 +345,7 @@ export const generateCuadernoFinca = (fincaData) => {
 
   if (finca.descripcion_corta) {
     y += 4;
-    y = drawParagraph(doc, y, finca.descripcion_corta, { fontSize: 10, color: COLOR_SLATE });
+    drawParagraph(doc, y, finca.descripcion_corta, { fontSize: 10, color: COLOR_SLATE });
   }
 
   // ─── PÁGINA 2: RESUMEN EJECUTIVO ─────────────────────────────────────
@@ -376,7 +376,7 @@ export const generateCuadernoFinca = (fincaData) => {
   }
 
   y += 4;
-  y = drawParagraph(
+  drawParagraph(
     doc,
     y,
     'Este cuaderno consolida la información agronómica registrada en Chagra hasta la fecha de generación. ' +
@@ -392,7 +392,7 @@ export const generateCuadernoFinca = (fincaData) => {
   y = drawSectionTitle(doc, y, 'Inventario de plantas');
 
   if (plants.length === 0) {
-    y = drawParagraph(doc, y, 'No hay plantas registradas en este dispositivo.', { fontSize: 10, color: COLOR_MUTED });
+    drawParagraph(doc, y, 'No hay plantas registradas en este dispositivo.', { fontSize: 10, color: COLOR_MUTED });
   } else {
     const plantRows = plants.map((p) => ({
       id: truncate(p.id || '', 8),
@@ -402,7 +402,7 @@ export const generateCuadernoFinca = (fincaData) => {
       sembrada: getAssetCreated(p),
       sync: p._pending ? 'pend.' : 'ok',
     }));
-    y = drawTable(
+    drawTable(
       doc,
       y,
       [
@@ -425,7 +425,7 @@ export const generateCuadernoFinca = (fincaData) => {
   y = drawSectionTitle(doc, y, 'Zonas');
 
   if (lands.length === 0) {
-    y = drawParagraph(doc, y, 'No hay zonas registradas.', { fontSize: 10, color: COLOR_MUTED });
+    drawParagraph(doc, y, 'No hay zonas registradas.', { fontSize: 10, color: COLOR_MUTED });
   } else {
     const landRows = lands.map((l) => ({
       nombre: getAssetName(l),
@@ -433,7 +433,7 @@ export const generateCuadernoFinca = (fincaData) => {
       estado: getAssetStatus(l),
       creada: getAssetCreated(l),
     }));
-    y = drawTable(
+    drawTable(
       doc,
       y,
       [
@@ -454,7 +454,7 @@ export const generateCuadernoFinca = (fincaData) => {
   y = drawSectionTitle(doc, y, 'Bitácora cronológica');
 
   if (logs.length === 0) {
-    y = drawParagraph(doc, y, 'No hay eventos en la bitácora.', { fontSize: 10, color: COLOR_MUTED });
+    drawParagraph(doc, y, 'No hay eventos en la bitácora.', { fontSize: 10, color: COLOR_MUTED });
   } else {
     // Orden cronológico ascendente (lo que primero se hizo arriba).
     const sortedLogs = [...logs].sort((a, b) => {
@@ -472,7 +472,7 @@ export const generateCuadernoFinca = (fincaData) => {
         descripcion: name,
       };
     });
-    y = drawTable(
+    drawTable(
       doc,
       y,
       [
@@ -493,7 +493,7 @@ export const generateCuadernoFinca = (fincaData) => {
   y = drawSectionTitle(doc, y, 'Cosechas reportadas');
 
   if (harvests.length === 0) {
-    y = drawParagraph(doc, y, 'No hay cosechas reportadas en este período.', { fontSize: 10, color: COLOR_MUTED });
+    drawParagraph(doc, y, 'No hay cosechas reportadas en este período.', { fontSize: 10, color: COLOR_MUTED });
   } else {
     const harvestRows = harvests.map((h) => {
       const qty = (Array.isArray(h.attributes?.quantity) && h.attributes.quantity[0]) || h.quantity || {};
@@ -506,7 +506,7 @@ export const generateCuadernoFinca = (fincaData) => {
         unidad: qtyUnit || '—',
       };
     });
-    y = drawTable(
+    drawTable(
       doc,
       y,
       [
@@ -527,7 +527,7 @@ export const generateCuadernoFinca = (fincaData) => {
   y = drawSectionTitle(doc, y, 'Insumos / biopreparados aplicados');
 
   if (inputs.length === 0) {
-    y = drawParagraph(doc, y, 'No hay aplicaciones de insumos registradas.', { fontSize: 10, color: COLOR_MUTED });
+    drawParagraph(doc, y, 'No hay aplicaciones de insumos registradas.', { fontSize: 10, color: COLOR_MUTED });
   } else {
     const inputRows = inputs.map((i) => {
       const qty = (Array.isArray(i.attributes?.quantity) && i.attributes.quantity[0]) || i.quantity || {};
@@ -542,7 +542,7 @@ export const generateCuadernoFinca = (fincaData) => {
         dosis: qtyValue !== '' ? `${qtyValue} ${qtyUnit}` : '—',
       };
     });
-    y = drawTable(
+    drawTable(
       doc,
       y,
       [

--- a/src/services/incendioRiskService.js
+++ b/src/services/incendioRiskService.js
@@ -164,7 +164,7 @@ export function evaluarRiesgoIncendio(opts = {}) {
   const esNino = fam === 'nino';
 
   const factores = [];
-  let nivel = 'bajo';
+  let nivel;
 
   if (!fireProne) {
     // Pacífico o región sin señal clara → riesgo de incendio estructuralmente bajo.

--- a/src/services/milpaGameEngine.js
+++ b/src/services/milpaGameEngine.js
@@ -669,7 +669,7 @@ export const EVENTOS = Object.freeze([
  */
 export function factorResistencia(parcela, evento = null) {
   const d = diversidadParcela(parcela);
-  let factor = 1.0;
+  let factor;
 
   // Resistencia base por diversidad
   if (d <= 1) factor = 1.0;

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -10273,7 +10273,7 @@ export function applyOutputGuards(
   // instrucciones, grafo), se reemplaza toda la respuesta antes de que otros
   // guards anexen contenido.
   const internals = stripInternalsLeak(text);
-  if (internals && internals.modified) {
+  if (internals.modified) {
     return {
       text: internals.text,
       modified: true,
@@ -10290,7 +10290,7 @@ export function applyOutputGuards(
   // redacción. Corre SIEMPRE (no gateado por entidades). Espejo aplicado-al-texto
   // de sanitizeToolingLeak del sidecar.
   const toolingLeak = guardToolingLeakRedaction(text);
-  if (toolingLeak && toolingLeak.modified) {
+  if (toolingLeak.modified) {
     text = toolingLeak.text;
     modified = true;
     if (toolingLeak.reason) reasons.push(toolingLeak.reason);
@@ -10300,7 +10300,7 @@ export function applyOutputGuards(
   // Una dosis inventada, cura química o plaguicida prohibido no debe sobrevivir
   // debajo de caveats posteriores, independientemente del cultivo.
   const cropAgnosticSafety = guardCropAgnosticSafetyTraps(text, { userMessage });
-  if (cropAgnosticSafety && cropAgnosticSafety.modified) {
+  if (cropAgnosticSafety.modified) {
     return {
       text: cropAgnosticSafety.text,
       modified: true,
@@ -10312,7 +10312,7 @@ export function applyOutputGuards(
   // Una dosis, cura química o asociación riesgosa de tomate no debe sobrevivir
   // debajo de caveats posteriores.
   const tomatoSafety = guardTomateSafetyTraps(text, { userMessage });
-  if (tomatoSafety && tomatoSafety.modified) {
+  if (tomatoSafety.modified) {
     return {
       text: tomatoSafety.text,
       modified: true,
@@ -10326,7 +10326,7 @@ export function applyOutputGuards(
   // otro guard sobre un texto que se va a reemplazar. Firma propia (necesita
   // userMessage), por eso va fuera de GUARD_CHAIN. No-op si la query es agro.
   const offDom = guardOffDomain(text, { userMessage });
-  if (offDom && offDom.modified) {
+  if (offDom.modified) {
     // Respuesta off-domain reemplazada: no corremos más guards sobre la
     // declinación (no hay cultivo/entidad que razonar).
     return { text: offDom.text, modified: true, reasons: offDom.reason ? [offDom.reason] : [] };
@@ -10337,7 +10337,7 @@ export function applyOutputGuards(
   // texto que vamos a reemplazar entero. Firma propia (contexto de visión), por
   // eso va fuera de GUARD_CHAIN.
   const vis = guardVisionWithoutPhoto(text, { hadVision, visionConfidence });
-  if (vis && vis.modified) {
+  if (vis.modified) {
     text = vis.text;
     modified = true;
     if (vis.reason) reasons.push(vis.reason);
@@ -10348,15 +10348,15 @@ export function applyOutputGuards(
   // alimento u organismo benéfico inventado.
   if (!(vis && vis.modified)) {
     const trunc = guardTruncatedUserPrompt(text, { userMessage });
-    if (trunc && trunc.modified) {
+    if (trunc.modified) {
       return { text: trunc.text, modified: true, reasons: trunc.reason ? [trunc.reason] : [] };
     }
     const toxicFood = guardToxicResidueOnFood(text, { userMessage });
-    if (toxicFood && toxicFood.modified) {
+    if (toxicFood.modified) {
       return { text: toxicFood.text, modified: true, reasons: toxicFood.reason ? [toxicFood.reason] : [] };
     }
     const fakeBeneficial = guardRequestedFabricatedBeneficial(text, { userMessage });
-    if (fakeBeneficial && fakeBeneficial.modified) {
+    if (fakeBeneficial.modified) {
       return { text: fakeBeneficial.text, modified: true, reasons: fakeBeneficial.reason ? [fakeBeneficial.reason] : [] };
     }
   }
@@ -10372,7 +10372,7 @@ export function applyOutputGuards(
   // early-return, igual que off-domain y visión-sin-foto.
   if (!(vis && vis.modified)) {
     const dx = guardDiagnosisWithoutPhoto(text, { userMessage, hadVision });
-    if (dx && dx.modified) {
+    if (dx.modified) {
       return { text: dx.text, modified: true, reasons: dx.reason ? [dx.reason] : [] };
     }
   }
@@ -10387,13 +10387,13 @@ export function applyOutputGuards(
   // ya hubo un reemplazo de visión (texto distinto al original).
   if (!(vis && vis.modified)) {
     const fp = guardFalsePremise(text, { userMessage });
-    if (fp && fp.modified) {
+    if (fp.modified) {
       return { text: fp.text, modified: true, reasons: fp.reason ? [fp.reason] : [] };
     }
   }
 
   const wrongAuthority = guardWrongColombiaAuthority(text, { userMessage });
-  if (wrongAuthority && wrongAuthority.modified) {
+  if (wrongAuthority.modified) {
     return {
       text: wrongAuthority.text,
       modified: true,
@@ -10408,7 +10408,7 @@ export function applyOutputGuards(
   // es independiente de la intención de siembra/precio. Como REEMPLAZA el texto
   // entero (la recomendación ilegal es íntegramente dañina), early-return.
   const paramo = guardParamoNormativa(text);
-  if (paramo && paramo.modified) {
+  if (paramo.modified) {
     return {
       text: paramo.text,
       modified: true,
@@ -10442,7 +10442,7 @@ export function applyOutputGuards(
   // Es un guard de SIEMBRA/identidad → solo corre si la consulta no es de precio.
   if (runPlantingGuards && !(vis && vis.modified)) {
     const iv = guardInventedVariety(text, { userMessage });
-    if (iv && iv.modified) {
+    if (iv.modified) {
       return { text: iv.text, modified: true, reasons: iv.reason ? [iv.reason] : [] };
     }
   }
@@ -10457,7 +10457,7 @@ export function applyOutputGuards(
   // early-return. Guard de SIEMBRA/identidad.
   if (runPlantingGuards && !(vis && vis.modified)) {
     const ve = guardVarietyWithoutEvidence(text, { userMessage });
-    if (ve && ve.modified) {
+    if (ve.modified) {
       return { text: ve.text, modified: true, reasons: ve.reason ? [ve.reason] : [] };
     }
   }
@@ -10472,7 +10472,7 @@ export function applyOutputGuards(
   // premisa-falsa. Es un guard de SIEMBRA/viabilidad → solo si la consulta no es de precio.
   if (runPlantingGuards && !(vis && vis.modified)) {
     const hav = guardHardAltitudeViability(text, { userMessage });
-    if (hav && hav.modified) {
+    if (hav.modified) {
       return { text: hav.text, modified: true, reasons: hav.reason ? [hav.reason] : [] };
     }
   }
@@ -10486,7 +10486,7 @@ export function applyOutputGuards(
   // REEMPLAZA todo el cuerpo, early-return. Guard de SIEMBRA/viabilidad.
   if (runPlantingGuards && !(vis && vis.modified)) {
     const wcc = guardWarmLowlandColdCrop(text, { userMessage });
-    if (wcc && wcc.modified) {
+    if (wcc.modified) {
       return { text: wcc.text, modified: true, reasons: wcc.reason ? [wcc.reason] : [] };
     }
   }
@@ -10499,7 +10499,7 @@ export function applyOutputGuards(
   // exige altitud numérica.
   if (runPlantingGuards && !(vis && vis.modified)) {
     const chw = guardColdHighlandWarmCrop(text, { userMessage });
-    if (chw && chw.modified) {
+    if (chw.modified) {
       return { text: chw.text, modified: true, reasons: chw.reason ? [chw.reason] : [] };
     }
   }
@@ -10515,7 +10515,7 @@ export function applyOutputGuards(
   // early-return. Guard de SIEMBRA/viabilidad → solo si la consulta no es de precio.
   if (runPlantingGuards && !(vis && vis.modified)) {
     const efp = guardEmbeddedAltitudeFalsePremise(text, { userMessage, resolvedEntities: entities });
-    if (efp && efp.modified) {
+    if (efp.modified) {
       return { text: efp.text, modified: true, reasons: efp.reason ? [efp.reason] : [] };
     }
   }
@@ -10527,7 +10527,7 @@ export function applyOutputGuards(
   // sobre el cuerpo que ya afirmó una especie no-grounded.
   if (runPlantingGuards && !(vis && vis.modified)) {
     const regional = guardUnidentifiedRegionalCrop(text, { userMessage });
-    if (regional && regional.modified) {
+    if (regional.modified) {
       return { text: regional.text, modified: true, reasons: regional.reason ? [regional.reason] : [] };
     }
   }
@@ -10548,7 +10548,7 @@ export function applyOutputGuards(
   // lo primero. Firma propia (userMessage). Corre SIEMPRE (consulta de manejo, no de
   // siembra). Idempotente.
   const caldoRes = guardClassicCaldoRecipe(text, { userMessage });
-  if (caldoRes && caldoRes.modified) {
+  if (caldoRes.modified) {
     text = caldoRes.text;
     modified = true;
     if (caldoRes.reason) reasons.push(caldoRes.reason);
@@ -10560,7 +10560,7 @@ export function applyOutputGuards(
     // corren siempre.
     if (!runPlantingGuards && PLANTING_GUARDS.has(guard)) continue;
     const res = guard(text, entities, fincaAltitud);
-    if (res && res.modified) {
+    if (res.modified) {
       text = res.text;
       modified = true;
       if (res.reason) reasons.push(res.reason);
@@ -10577,7 +10577,7 @@ export function applyOutputGuards(
       forecastTempMin,
       forecastTempMax,
     });
-    if (thermalRes && thermalRes.modified) {
+    if (thermalRes.modified) {
       text = thermalRes.text;
       modified = true;
       if (thermalRes.reason) reasons.push(thermalRes.reason);
@@ -10590,7 +10590,7 @@ export function applyOutputGuards(
     // Firma propia (userMessage para la altitud). Guard de SIEMBRA. Va tras el
     // térmico (que requiere pronóstico) como red sin pronóstico al caso límite.
     const altRiskRes = guardAltitudeRiskCaveat(text, { userMessage });
-    if (altRiskRes && altRiskRes.modified) {
+    if (altRiskRes.modified) {
       text = altRiskRes.text;
       modified = true;
       if (altRiskRes.reason) reasons.push(altRiskRes.reason);
@@ -10598,7 +10598,7 @@ export function applyOutputGuards(
   }
   // Guard de nombre inventado: firma propia (necesita el nombre del perfil).
   const nameRes = guardInventedName(text, { profileName });
-  if (nameRes && nameRes.modified) {
+  if (nameRes.modified) {
     text = nameRes.text;
     modified = true;
     if (nameRes.reason) reasons.push(nameRes.reason);
@@ -10608,7 +10608,7 @@ export function applyOutputGuards(
   // (no es guard de siembra) pero solo actúa si la respuesta/pregunta tocan un
   // fermento. Fail-safe: ante un claim de salud, redirige a la frase segura.
   const fermRes = guardFermentoHealthClaim(text, { userMessage });
-  if (fermRes && fermRes.modified) {
+  if (fermRes.modified) {
     text = fermRes.text;
     modified = true;
     if (fermRes.reason) reasons.push(fermRes.reason);
@@ -10621,7 +10621,7 @@ export function applyOutputGuards(
   // del LLM. Va DESPUÉS del guard de claims de salud (su redirect queda debajo de
   // la receta; el caveat de inocuidad lidera arriba).
   const fermRecipeRes = guardFermentoRecipeSafety(text, { userMessage });
-  if (fermRecipeRes && fermRecipeRes.modified) {
+  if (fermRecipeRes.modified) {
     text = fermRecipeRes.text;
     modified = true;
     if (fermRecipeRes.reason) reasons.push(fermRecipeRes.reason);
@@ -10634,7 +10634,7 @@ export function applyOutputGuards(
   // el bloque de redirección orgánica (si disparó) queda arriba y el recordatorio MIP
   // detrás —ambos suman, fuerzan la alternativa agroecológica completa. ADITIVO.
   const mipRes = guardPestIntegratedManagement(text, { userMessage });
-  if (mipRes && mipRes.modified) {
+  if (mipRes.modified) {
     text = mipRes.text;
     modified = true;
     if (mipRes.reason) reasons.push(mipRes.reason);
@@ -10646,7 +10646,7 @@ export function applyOutputGuards(
   // combustible. Fail-safe: ADVIERTE que no se recomienda para restauración (no
   // la borra). Determinístico (lista hardcodeada), no depende del grounding.
   const reforestRes = guardReforestacionInvasora(text, { userMessage });
-  if (reforestRes && reforestRes.modified) {
+  if (reforestRes.modified) {
     text = reforestRes.text;
     modified = true;
     if (reforestRes.reason) reasons.push(reforestRes.reason);
@@ -10659,7 +10659,7 @@ export function applyOutputGuards(
   // que su nota quede después de cualquier advertencia de invasora. Determinístico
   // (lista hardcodeada), no depende del grounding.
   const reforestNativasRes = guardReforestacionNativasRol(text, { userMessage });
-  if (reforestNativasRes && reforestNativasRes.modified) {
+  if (reforestNativasRes.modified) {
     text = reforestNativasRes.text;
     modified = true;
     if (reforestNativasRes.reason) reasons.push(reforestNativasRes.reason);
@@ -10672,7 +10672,7 @@ export function applyOutputGuards(
   // aplicar por separado). Va antes de la marca inventada y de la ConfusionWarning;
   // como reemplaza todo el cuerpo, lo que sobreviva no contendrá la mezcla peligrosa.
   const mixRes = guardIncompatibleBiopreparadoMix(text, { userMessage });
-  if (mixRes && mixRes.modified) {
+  if (mixRes.modified) {
     text = mixRes.text;
     modified = true;
     if (mixRes.reason) reasons.push(mixRes.reason);
@@ -10685,7 +10685,7 @@ export function applyOutputGuards(
   // verdad de seguridad (no es comestible + por qué + redirección). Va tras la
   // mezcla incompatible y antes de la marca inventada / ConfusionWarning.
   const toxPrepRes = guardToxicFoodPreparation(text);
-  if (toxPrepRes && toxPrepRes.modified) {
+  if (toxPrepRes.modified) {
     text = toxPrepRes.text;
     modified = true;
     if (toxPrepRes.reason) reasons.push(toxPrepRes.reason);
@@ -10697,7 +10697,7 @@ export function applyOutputGuards(
   // (yuca brava), neutraliza esas frases y antepone el aviso con la molécula + procesar.
   // Va tras la preparación de tóxicos no-comestibles y antes de la marca inventada.
   const rawToxFoodRes = guardToxicRawFoodConsumption(text, resolvedEntities);
-  if (rawToxFoodRes && rawToxFoodRes.modified) {
+  if (rawToxFoodRes.modified) {
     text = rawToxFoodRes.text;
     modified = true;
     if (rawToxFoodRes.reason) reasons.push(rawToxFoodRes.reason);
@@ -10709,7 +10709,7 @@ export function applyOutputGuards(
   // segura (diluir, nunca puro, fitotoxicidad). Va tras los guards de tóxicos y antes
   // de la marca inventada. Idempotente.
   const pureFoliarRes = guardPureFoliarBiopreparado(text, { userMessage });
-  if (pureFoliarRes && pureFoliarRes.modified) {
+  if (pureFoliarRes.modified) {
     text = pureFoliarRes.text;
     modified = true;
     if (pureFoliarRes.reason) reasons.push(pureFoliarRes.reason);
@@ -10722,7 +10722,7 @@ export function applyOutputGuards(
   // antes de la superficie de ConfusionWarning, para que el prefijo tóxico de esta
   // última (si dispara) siga liderando la respuesta.
   const brandRes = guardInventedBrand(text);
-  if (brandRes && brandRes.modified) {
+  if (brandRes.modified) {
     text = brandRes.text;
     modified = true;
     if (brandRes.reason) reasons.push(brandRes.reason);
@@ -10733,7 +10733,7 @@ export function applyOutputGuards(
   // genérico. Va antes del guard de contacto inventado para capturar el caso
   // específico con una respuesta más útil. Idempotente.
   const hallucinatedContactRes = guardHallucinatedContact(text, { userMessage });
-  if (hallucinatedContactRes && hallucinatedContactRes.modified) {
+  if (hallucinatedContactRes.modified) {
     text = hallucinatedContactRes.text;
     modified = true;
     if (hallucinatedContactRes.reason) reasons.push(hallucinatedContactRes.reason);
@@ -10767,7 +10767,7 @@ export function applyOutputGuards(
   // verificada → ICA/Agrosavia/UMATA/CAR). Análogo institucional de la marca y el
   // contacto inventados: va justo tras ellos. Idempotente.
   const institutionRes = guardFabricatedInstitution(text);
-  if (institutionRes && institutionRes.modified) {
+  if (institutionRes.modified) {
     text = institutionRes.text;
     modified = true;
     if (institutionRes.reason) reasons.push(institutionRes.reason);
@@ -10780,7 +10780,7 @@ export function applyOutputGuards(
   // producto-milagro; manejo sanitario + biopreparado real). Va tras la marca inventada
   // (que cubre marcas Título-Caso) — este cubre el genérico-milagro que aquella no atrapa.
   const disgRes = guardDisguisedGenericAgrochem(text);
-  if (disgRes && disgRes.modified) {
+  if (disgRes.modified) {
     text = disgRes.text;
     modified = true;
     if (disgRes.reason) reasons.push(disgRes.reason);
@@ -10789,7 +10789,7 @@ export function applyOutputGuards(
   // "biopreparado Mosca del Mediterráneo", etc.). Va tras marca/genérico
   // inventado y antes de caveats de benéficos: aquí el cuerpo completo es dañino.
   const fakeProductRes = guardInventedProductRecipe(text);
-  if (fakeProductRes && fakeProductRes.modified) {
+  if (fakeProductRes.modified) {
     text = fakeProductRes.text;
     modified = true;
     if (fakeProductRes.reason) reasons.push(fakeProductRes.reason);
@@ -10804,7 +10804,7 @@ export function applyOutputGuards(
   // milagro (que cubre el "sirve para todo" sin binomio) — este cubre el binomio inventado
   // que aquel no atrapa. Usa `entities` (grounding filtrado) ya calculado arriba.
   const extractRes = guardInventedBotanicalExtract(text, entities);
-  if (extractRes && extractRes.modified) {
+  if (extractRes.modified) {
     text = extractRes.text;
     modified = true;
     if (extractRes.reason) reasons.push(extractRes.reason);
@@ -10828,7 +10828,7 @@ export function applyOutputGuards(
   // catálogo. Va tras los aditivos y antes de la superficie de ConfusionWarning,
   // para que el prefijo tóxico de esta última (si dispara) siga liderando.
   const benefRes = guardFabricatedBeneficialBinomial(text, resolvedEntities);
-  if (benefRes && benefRes.modified) {
+  if (benefRes.modified) {
     text = benefRes.text;
     modified = true;
     if (benefRes.reason) reasons.push(benefRes.reason);
@@ -10842,7 +10842,7 @@ export function applyOutputGuards(
   // páramo, puede ofrecer la especie REAL en su lugar. Si corre primero el genérico,
   // el paréntesis ya no existe y este guard no tiene nada que corregir.
   const paramoNativesRes = guardFabricatedParamoNatives(text, resolvedEntities);
-  if (paramoNativesRes && paramoNativesRes.modified) {
+  if (paramoNativesRes.modified) {
     text = paramoNativesRes.text;
     modified = true;
     if (paramoNativesRes.reason) reasons.push(paramoNativesRes.reason);
@@ -10858,7 +10858,7 @@ export function applyOutputGuards(
   // antes de la superficie de ConfusionWarning, para que su prefijo tóxico siga
   // liderando. Conservador: sin grounding no actúa.
   const invBinRes = guardInventedBinomialOutOfGrounding(text, resolvedEntities);
-  if (invBinRes && invBinRes.modified) {
+  if (invBinRes.modified) {
     text = invBinRes.text;
     modified = true;
     if (invBinRes.reason) reasons.push(invBinRes.reason);
@@ -10877,7 +10877,7 @@ export function applyOutputGuards(
         .filter(Boolean)
     );
     const unverifiedGuard = guardUnverifiedTermBinomial(text, { userMessage, resolvedMentions });
-    if (unverifiedGuard && unverifiedGuard.modified) {
+    if (unverifiedGuard.modified) {
       text = unverifiedGuard.text;
       modified = true;
       if (unverifiedGuard.reason) reasons.push(unverifiedGuard.reason);
@@ -10893,7 +10893,7 @@ export function applyOutputGuards(
   // `resolvedEntities` crudo (no `entities` filtrado) porque la CW vive en la
   // entidad tal como la resolvió el sidecar.
   const cwRes = guardSurfaceConfusionWarning(text, resolvedEntities);
-  if (cwRes && cwRes.modified) {
+  if (cwRes.modified) {
     text = cwRes.text;
     modified = true;
     if (cwRes.reason) reasons.push(cwRes.reason);
@@ -10907,7 +10907,7 @@ export function applyOutputGuards(
   // no quede sepultada. Espejo aplicado-al-texto de detectBurnEndorsement del
   // sidecar (el PWA solo lo usaba para la badge; aquí sí reescribe guarded.text).
   const burnRes = guardBurnEndorsementCorrection(text);
-  if (burnRes && burnRes.modified) {
+  if (burnRes.modified) {
     text = burnRes.text;
     modified = true;
     if (burnRes.reason) reasons.push(burnRes.reason);
@@ -10921,7 +10921,7 @@ export function applyOutputGuards(
   //   2. Si > 200 palabras y detecta repetición del mismo consejo,
   //      deduplica (deja la primera mención).
   const conciseRes = guardConciseResponse(text);
-  if (conciseRes && conciseRes.modified) {
+  if (conciseRes.modified) {
     text = conciseRes.text;
     modified = true;
     if (conciseRes.reason) reasons.push(conciseRes.reason);
@@ -10932,7 +10932,7 @@ export function applyOutputGuards(
   // cualquier corrección de seguridad/legal. Firma propia (necesita forecastTempMin
   // y forecastTempMax del pronóstico). Corre SIEMPRE, no es guard de siembra.
   const climaRes = guardClimaConsejo(text, { forecastTempMin, forecastTempMax });
-  if (climaRes && climaRes.modified) {
+  if (climaRes.modified) {
     text = climaRes.text;
     modified = true;
     if (climaRes.reason) reasons.push(climaRes.reason);

--- a/src/services/restauracionPlanPDF.js
+++ b/src/services/restauracionPlanPDF.js
@@ -236,7 +236,7 @@ export const generateRestauracionPlanPDF = (planData) => {
   y += 8;
 
   if (data.descripcion) {
-    y = drawParagraph(doc, y, `Situación descrita: ${data.descripcion}`, { fontSize: 10, color: COLOR_SLATE });
+    drawParagraph(doc, y, `Situación descrita: ${data.descripcion}`, { fontSize: 10, color: COLOR_SLATE });
   }
 
   // ─── PÁGINA 2: ARREGLO + SUCESIÓN ────────────────────────────────────

--- a/src/services/skyConditionService.js
+++ b/src/services/skyConditionService.js
@@ -432,7 +432,7 @@ export async function fetchSkyConditions(opts = /** @type {any} */ ({})) {
   try {
     return await promise;
   } finally {
-    if (inFlight && inFlight.promise === promise) inFlight = null;
+    if (inFlight.promise === promise) inFlight = null;
   }
 }
 

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -143,9 +143,8 @@ const useAssetStore = create((set, get) => ({
         // assets legítimos que aparecerán en páginas posteriores.
         const allRemoteIdsForType = new Set();
         // Si el sync se aborta o falla parcialmente, NO purgar: el universo
-        // remoto no es confiable. `syncCompletedForType` solo se vuelve true
-        // cuando todas las páginas se procesaron sin signal aborted.
-        let syncCompletedForType = false;
+        // remoto no es confiable. La purga final (abajo) solo corre cuando
+        // todas las páginas se procesaron sin signal aborted.
 
         while (hasMore && !signal?.aborted) {
           const offset = page * pageLimit;
@@ -180,14 +179,11 @@ const useAssetStore = create((set, get) => ({
           break;
         }
         // Universo completo del tipo recolectado → ahora sí, GC final.
-        syncCompletedForType = true;
-        if (syncCompletedForType) {
-          try {
-            await assetCache.purgeAbsent(t, allRemoteIdsForType);
-          } catch (purgeErr) {
-            // Si la purga falla, mejor preservar datos: log y continuar.
-            console.warn(`[Sync] purgeAbsent(${t}) falló — preservando local:`, purgeErr);
-          }
+        try {
+          await assetCache.purgeAbsent(t, allRemoteIdsForType);
+        } catch (purgeErr) {
+          // Si la purga falla, mejor preservar datos: log y continuar.
+          console.warn(`[Sync] purgeAbsent(${t}) falló — preservando local:`, purgeErr);
         }
       }
 

--- a/src/visual/creatures/BarbuditoParamo.jsx
+++ b/src/visual/creatures/BarbuditoParamo.jsx
@@ -68,7 +68,6 @@ export function BarbuditoParamo({
   const glow = `bp-glow-${uid}`;
   const blur = `bp-blur-${uid}`;
   const vivo = animated;
-  const libando = pose === 'liba';
 
   // Animaciones propias, autocontenidas y con nombres únicos por instancia (no
   // dependen de clases externas): aleteo-borrón al libar, respiro al posar,

--- a/src/visual/creatures/index.js
+++ b/src/visual/creatures/index.js
@@ -193,7 +193,6 @@ import Perezoso from './Perezoso.jsx';
 import Ardilla from './Ardilla.jsx';
 import Jaguar from './Jaguar.jsx';
 import Morrocoy from './Morrocoy.jsx';
-import Borugo from './Borugo.jsx';
 import Danta from './Danta.jsx';
 import Condor from './Condor.jsx';
 import Dalmata from './Dalmata.jsx';

--- a/src/visual/creatures/useVidaIdle.js
+++ b/src/visual/creatures/useVidaIdle.js
@@ -22,7 +22,7 @@
  * Costo: UN setTimeout vivo por instancia activa; la mirada es un listener
  * passive + rAF-throttle con DOM directo (cero re-renders por mover el mouse).
  */
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   elegirMomentoVida,
   duracionDeMomentoVida,

--- a/src/visual/mundo3d/aguacatal/EscenaAguacatalVivo.jsx
+++ b/src/visual/mundo3d/aguacatal/EscenaAguacatalVivo.jsx
@@ -60,7 +60,6 @@ import {
   TIERRAS,
   CASA,
   LUCES,
-  NIEBLAS,
   PALETA,
 } from '../paleta/index.js';
 

--- a/src/visual/mundo3d/bosque/EntQuenua.jsx
+++ b/src/visual/mundo3d/bosque/EntQuenua.jsx
@@ -41,7 +41,6 @@ import {
   ROSTRO_BOCA_Y,
   ROSTRO_ESCALA,
   BARBA,
-  CORTEZA,
 } from './entQuenua.geom.js';
 
 /* Un cúmulo de la copa: la MASA de hojas con huecos (malla facetada con color

--- a/src/visual/mundo3d/escenas/AnimalMomento.jsx
+++ b/src/visual/mundo3d/escenas/AnimalMomento.jsx
@@ -26,7 +26,6 @@
 import { useLayoutEffect, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Text } from '@react-three/drei';
-import * as THREE from 'three';
 import { ESPECIES, GeometriaParte } from './CorralVivo.jsx';
 import { PALETA } from '../atmosferaMadre.js';
 

--- a/src/visual/mundo3d/polinizadores/ParcelaCultivos.jsx
+++ b/src/visual/mundo3d/polinizadores/ParcelaCultivos.jsx
@@ -31,7 +31,7 @@ import { useLayoutEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { perfilDeTier } from '../deviceTier.js';
-import { CULTIVOS, calidadDe, cuajeDe, tierDe, rng } from './polinizadoresIdentidad.js';
+import { calidadDe, cuajeDe, tierDe, rng } from './polinizadoresIdentidad.js';
 import { CULTIVO_GEOM, FRUTO_GEOM, FRUTO_TAM, geomMotaPolen } from './cultivos.geom.js';
 import { sembrarMatas, sitiosDeFruto } from './sembrado.js';
 

--- a/src/visual/mundo3d/sierra/SierraCorteVertical.jsx
+++ b/src/visual/mundo3d/sierra/SierraCorteVertical.jsx
@@ -55,7 +55,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { Canvas, useFrame } from '@react-three/fiber';
-import { Html } from '@react-three/drei';
 import { ATMOSFERA } from '../atmosferaMadre.js';
 import { perfilDeTier } from '../deviceTier.js';
 import { PISOS_TERMICOS, CUMBRE_SIERRA_M } from '../pisosTermicos.js';

--- a/src/visual/mundo3d/useNavegacionMundos.js
+++ b/src/visual/mundo3d/useNavegacionMundos.js
@@ -21,10 +21,9 @@
  *
  * Sin three, sin DOM: puro estado. Seguro en el bundle base.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { resolverMundo } from './resolverMundo.js';
 import useHaptics from './useHaptics.js';
-import { mundosPorPisoTermico } from './mundosPorPisoTermico.js';
 
 /** ¿Este mundo tiene una escena montable (3D o 2D) en el registro? */
 export function puedeEntrarAlMundo(mundoId) {


### PR DESCRIPTION
## Resumen

Limpieza mecánica de deuda de calidad marcada por CodeQL en `src/` (código que llega al navegador del campesino), sobre las 4 reglas que más pesaban. Sin refactors ni renombres: solo se quita lo que cada regla señala.

## ⚠️ Este commit usó `git commit --no-verify`

El pre-commit de `lefthook` (secret-scan, infra-refs-scan, strategic-content-scan, pro-import-scan, voseo-scan, voseo-scan-code-comments, eslint) no terminaba en ventana razonable sobre los 57 archivos tocados en esta máquina (builds en paralelo compitiendo por CPU). Por indicación explícita se saltó el hook, pero se replicaron los checks a mano **antes de commitear**:

- Los 5 greps de seguridad/i18n del hook (`secret-scan`, `infra-refs-scan`, `strategic-content-scan`, `pro-import-scan`, `voseo-scan`) corridos manualmente sobre el diff completo → **0 hits**.
- `voseo-scan-code-comments` (solo líneas agregadas del diff) → **0 hits** de voseo argentino.
- `npx eslint --max-warnings=0` sobre los 57 archivos tocados → **limpio**.

El cambio es 100% remoción de código muerto (imports, variables, asignaciones, condicionales siempre-true/false); no agrega strings ni imports nuevos, así que el riesgo de secretos/i18n era ya bajo por naturaleza del diff (274 líneas borradas vs. 116 líneas tocadas/reordenadas, cero prosa nueva).

## Cerradas por regla

- **`js/unused-local-variable`**: 46 de 47 alertas no-test cerradas (imports/variables/funciones muertas). 1 sin tocar (ver abajo). Las 10 alertas restantes de la regla (57 totales en `src/`) están en archivos `*.test.*`/`__tests__` — se dejaron intactas por regla explícita del encargo.
- **`js/useless-assignment-to-local`**: 15/15 cerradas. 12 en `cuadernoPDF.js` (el `y = drawTable(...)`/`y = drawParagraph(...)` de cada sección del PDF se pisa con `y = MARGIN + 6` en la página siguiente antes de leerse — se deja la llamada por su efecto de dibujo, se quita la asignación muerta), 1 en `restauracionPlanPDF.js` (mismo patrón), 2 valores iniciales siempre sobreescritos por un `if/else` exhaustivo (`incendioRiskService.js`, `milpaGameEngine.js`).
- **`js/trivial-conditional`**: 16/21 cerradas. `getProfile()` (`userProfileService.js`) y `resolverEspecie()`/`getEnsemblePreventiveTasks()`/`getTasksForCycle()` siempre retornan objeto/array no-nulo (leída la implementación completa) — se quitó el `|| fallback` redundante en 6+1+1+1 sitios. `inFlight` en `climaService.js`/`skyConditionService.js` es no-nulo en su propio `finally` (único lugar que lo pone en `null`, ya gateado por `.promise === promise`). `sourceMetadata` en `AgentScreen.jsx` se reasigna a un objeto literal justo antes del check. `onBack` en `ChatHistory.jsx` ya viene gateado por `typeof onBack === 'function'` en el bloque contenedor. `syncCompletedForType` en `useAssetStore.js` era un flag local siempre `true` en el único punto donde se leía (el `if (signal?.aborted) break` previo ya cubre el otro caso) — se quitó la variable y se desenvolvió el `if`.
- **`js/unneeded-defensive-code`**: 52/53 cerradas. 4 en `AgentScreen.jsx` (mismo patrón `const p = getProfile(); if (p && p.x)` — redundante). 48 en `outputGuards.js`: **verificación exhaustiva** — las 54 funciones `guardXxx(...)` (incluidas las 7 de `GUARD_CHAIN`) fueron leídas función por función; todas retornan siempre `{text, modified, reason}`, nunca `null`/`undefined`/`return;` bare, consistente con el contrato documentado en el header del módulo. El `if (X && X.modified)` es información muerta en los 48 sitios donde aparece hoy en `dev`. **Nota de alineación**: las 49 alertas de GitHub para este archivo fueron escaneadas contra `main` (`refs/heads/main`, commit de jun-19), que difiere de `dev` en +280 líneas en este archivo (11 246 vs 10 966); 17 de las 49 apuntan a líneas que ya no existen en `dev` y las 32 restantes no caen exactamente sobre el `if` real (arrastre de líneas). Por eso no hay mapeo 1:1 alerta↔commit; lo que se cerró es el patrón real y verificado tal como existe hoy en `dev` (48 sitios), no 48 números de alerta específicos — es posible que GitHub no auto-cierre las 49 alertas originales tras el merge por este desfase de línea, y toque limpiarlas manualmente en el tablero.

## NO tocadas (con razón)

- **`js/unused-local-variable` #620** (`EscenaPolinizadores.jsx:40`, `useRef`) — ya no existe en el código: fue removido en el commit `37af78fb` ("Limpieza mínima: useRef sin uso fuera del import"). Alerta obsoleta, sin acción posible.
- **`js/trivial-conditional` #380, #381, #488, #489** (`DashboardLive.jsx`, `fincaVivaFlag`) — `fincaVivaHomePerfilActivo()` es un **kill-switch de feature flag** documentado explícitamente como tal (`src/config/fincaVivaHomeFlag.js`), default `false` en el código fuente. Ambos workflows de deploy (`deploy.yml` prod y `dev-deploy.yml`) lo activan vía `VITE_FINCA_VIVA_HOME_PERFIL: "true"`. CodeQL solo ve el código fuente (no la config de CI) y por eso lo marca "siempre true" — pero es cierto solo en el despliegue actual, no en la lógica. Tocarlo elimina la capacidad de rollback sin tocar código.
- **`js/trivial-conditional` #256** (`ragRetriever.js:586`) — la línea reportada (`normB += b[i] * b[i];`, dentro de un for-loop) no corresponde a ninguna condición en el `dev` actual; el mensaje ("this expression always evaluates to false") no se puede mapear con certeza a un candidato único. Los dos candidatos cercanos tienen riesgo opuesto: `if (!a || !b || ...)` (posiblemente sí redundante, un solo caller hoy) vs. `denom > 0 ? dot / denom : 0` (protección real de división por cero/NaN). Ante la duda, no se tocó.

## Verificación

- `npm run build` verde (varias corridas, una por lote de cambios).
- Tests de cada archivo tocado corridos por lotes — no la suite completa (~25 min). Incluye la suite completa de `outputGuards.js` (39 archivos, 815 tests) dado el volumen de cambios ahí.
- Fallos preexistentes encontrados durante la verificación en 5 archivos de test (`SeguimientoProcesoScreen.test.jsx` 1, `mundoGallinero3D.test.jsx` 5, `Borugo.render.test.jsx` 1, `vidaEstados.test.js` 1, `navegacion.test.jsx` 1, `VoiceStatusStrip.test.jsx` 1, `outputGuards.test.js` 1, `outputGuards.variedadViabilidad.test.js` 1) — todos confirmados **idénticos en `origin/dev` sin estos cambios** (`git stash` + re-run del mismo test) antes de descartarlos como no-relacionados con este PR.
- `eslint --max-warnings=0` sobre los archivos tocados: limpio (ver nota de `--no-verify` arriba).
