### PR TITLE
feat(vitrina): el bosque de tres pisos entra al catálogo de mundos

### DIFF
--- a/src/mockups/VitrinaMaestraMundos.jsx
+++ b/src/mockups/VitrinaMaestraMundos.jsx
@@ -116,6 +116,7 @@ const IMPORTADORES = {
   compost: () => import('./MundoCompost3D.jsx'),
   agua: () => import('./MundoAgua3D.jsx'),
   paramo: () => import('./MundoParamo3D.jsx'),
+  bosque: () => import('./BosqueTresEstratos3D.jsx'),
   suelo: () => import('./MundoSueloVivo3D.jsx'),
   lluvia: () => import('./ValleLluvia3D.jsx'),
   sierra: () => import('../visual/mundo3d/VistaGlobalSierra.jsx'),
@@ -192,6 +193,7 @@ const PISOS = [
     mundos: [
       { id: 'papa', titulo: 'La papa', emoji: '🥔', colorA: '#b28a52', colorB: '#2e2618' },
       { id: 'suelo', titulo: 'El suelo vivo', emoji: '🪱', colorA: '#a97b4f', colorB: '#2b1d10' },
+      { id: 'bosque', titulo: 'El bosque de tres pisos', emoji: '🌳', colorA: '#4e7a46', colorB: '#1b2b1a' },
       { id: 'agua', titulo: 'El agua', emoji: '💧', colorA: '#7db8d4', colorB: '#1e3a4f' },
       { id: 'lluvia', titulo: 'La lluvia', emoji: '🌧️', colorA: '#9fb3c8', colorB: '#26323f' },
     ],


### PR DESCRIPTION
El mundo existía en `#/mockups/bosque-tres-estratos` y **nadie llegaba navegando**: cero
referencias en `valleData.js`, cero en la vitrina. Alcanzable **solo por URL directa**.

Es el patrón "construido pero no cableado" que ya mordió 6 veces en 24 horas — y esta vez lo
produje yo, al mergear el mundo sin su puerta.

## Por qué la vitrina y no el valle

Investigué los dos contratos:

- **`valleData.js`** resuelve contra `MUNDO_BY_ID`, donde cada mundo tiene `entradas` que son
  **vistas internas de la app**, no rutas de mockup. Meter el bosque ahí exigiría crear una `view`
  nueva — es otro trabajo, no un cableado.
- **La vitrina** ya es el catálogo de mundos 3D y su contrato es exacto: un mapa `IMPORTADORES`
  de imports lazy, más una tarjeta por piso térmico.

Queda en el piso **frío**, que es donde vive el bosque altoandino.

## Verificación

- `npx vite build` → **verde, 1m 29s**
- `BosqueTresEstratos3D` **exporta por defecto**, que es lo que el `lazy()` espera
- El chunk `BosqueTresEstratos3D-BjQZHvCD.js` **entra al bundle** — verificado por contenido, no
  por build verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)