### PR TITLE
feat(bosque): los tres árboles maestros del gradiente andino

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -263,6 +263,11 @@ const MundoParamo3DMockup = lazy(() => import('./mockups/MundoParamo3D'));
 // de crecimiento con los que se representa el catálogo de flora sin modelar las
 // 581 especies una por una.
 const BosqueTresEstratos3DMockup = lazy(() => import('./mockups/BosqueTresEstratos3D'));
+// Los TRES ÁRBOLES MAESTROS del gradiente andino: un Ent por piso térmico
+// (roble, aliso y la queñua que ya existía), el agua que baja del páramo al
+// templado y la red de micorrizas que amarra sus raíces en la cara cortada
+// de la ladera.
+const TresEntsGradiente3DMockup = lazy(() => import('./mockups/TresEntsGradiente3D'));
 const CamaraDirectorDemoMockup = lazy(() => import('./mockups/CamaraDirectorDemo'));
 const MomentoVentaMercado3DMockup = lazy(() => import('./mockups/MomentoVentaMercado3D'));
 const ArtesaniaAndinaDemoMockup = lazy(() => import('./mockups/ArtesaniaAndinaDemo'));
@@ -724,6 +729,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/juego-la-milpa': 'mockup_juego_la_milpa',
   'mockups/mundo-paramo-3d': 'mockup_mundo_paramo_3d',
   'mockups/bosque-tres-estratos': 'mockup_bosque_tres_estratos',
+  'mockups/tres-ents-gradiente': 'mockup_tres_ents_gradiente',
   'mockups/camara-director': 'mockup_camara_director',
   'mockups/momento-venta-mercado-3d': 'mockup_momento_venta_mercado_3d',
   'mockups/artesania-andina': 'mockup_artesania_andina',
@@ -2468,6 +2474,23 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El bosque nativo y sus tres estratos">
               <BosqueTresEstratos3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_tres_ents_gradiente':
+        // LOS TRES ÁRBOLES MAESTROS DEL GRADIENTE: un Ent por piso térmico —
+        // el roble andino (Quercus humboldtii, templado y frío, con sus
+        // ectomicorrizas y las setas de Cantharellus y Lactarius al pie), el
+        // aliso (Alnus acuminata, frío, con los nódulos de Frankia que le
+        // fijan el nitrógeno) y la queñua del páramo (Polylepis, la fábrica de
+        // agua, el Ent que ya existía). La ladera va cortada como lámina de
+        // Humboldt: el agua baja por encima y la red de micorrizas amarra las
+        // raíces de los tres por debajo.
+        // Ruta #/mockups/tres-ents-gradiente, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Los tres árboles maestros del gradiente">
+              <TresEntsGradiente3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/TresEntsGradiente3D.jsx
+++ b/src/mockups/TresEntsGradiente3D.jsx
@@ -1,0 +1,390 @@
+/*
+ * TresEntsGradiente3D — LOS TRES ÁRBOLES MAESTROS DEL GRADIENTE ANDINO.
+ * Ruta #/mockups/tres-ents-gradiente, sin auth.
+ *
+ * De qué se trata
+ * ───────────────
+ * Un Ent por piso térmico, y los tres contando la misma historia: la de una
+ * ladera de los Andes leída de arriba abajo.
+ *
+ *   · EL ENT DE LA QUEÑUA (páramo) — *Polylepis*. El árbol que llega más
+ *     arriba. Su copa y su musgo peinan la niebla: es una fábrica de agua.
+ *     Es el Ent que YA EXISTÍA en el mundo del páramo, traído tal cual.
+ *   · EL ENT DEL ALISO (frío) — *Alnus acuminata*. Fabrica su propio abono:
+ *     la bacteria *Frankia* le arma nódulos en la raíz que fijan el nitrógeno
+ *     del aire. Levanta suelos degradados.
+ *   · EL ENT DEL ROBLE (templado y frío) — *Quercus humboldtii*. El único
+ *     roble de Suramérica, y cruza el gradiente él solo de 750 a 3.450 metros.
+ *     Su lección son las ectomicorrizas: cuatro hongos le forran las raíces y
+ *     dos de ellos —*Cantharellus* y *Lactarius*— sacan la seta a su pie.
+ *
+ * Y lo que los amarra, que es el punto: EL AGUA baja por encima (nace en el
+ * páramo, se despeña dos veces, llega abajo hecha quebrada) y LA RED DE
+ * MICORRIZAS circula por debajo, en la cara cortada de la ladera. Dos
+ * corrientes en espejo. Si le tumban el páramo, el roble del templado se
+ * entera.
+ *
+ * La ladera está CORTADA como una lámina de Humboldt: el perfil de la montaña
+ * con sus fajas de vegetación arriba y los horizontes del suelo abajo. Es el
+ * mismo recurso con el que él dibujó el Chimborazo, y es lo que permite
+ * enseñar el subsuelo sin inventarse una vista de rayos X.
+ *
+ * Congruencia: paleta madre, materiales madre y `<LuzMadre>` con la familia de
+ * cielo `ladera`. Cero rig de luz propio.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import * as THREE from 'three';
+import EscenaTresEnts from '../visual/mundo3d/bosque/EscenaTresEnts.jsx';
+import { PISOS, alturaLadera } from '../visual/mundo3d/bosque/gradienteAndino.geom.js';
+import { LECCIONES } from '../visual/mundo3d/bosque/entsGradiente.geom.js';
+import { LuzMadre, CIELOS, mezclarCielo } from '../visual/mundo3d/paleta/index.js';
+import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LAS VISTAS — dónde se para la cámara
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/*
+ * EL RETRATO DE LOS TRES (`juntos`) es la vista madre y la razón de ser del
+ * mundo: los tres hermanos en un solo cuadro, escalonados por la ladera. En
+ * pantalla ANCHA se toma de frente, que es donde la escalera de terrazas se lee
+ * como escalera.
+ *
+ * En pantalla ANGOSTA (teléfono en vertical) de frente no cabe: la ladera mide
+ * 28 metros-escena de largo y un retrato 390×844 solo alcanzaría a mostrar un
+ * tercio. Entonces la cámara BAJA AL VALLE y mira LADERA ARRIBA: los tres Ents
+ * se alinean en profundidad, el cuadro se vuelve alto y angosto como el
+ * teléfono, y la lección —que hay que subir para llegar al agua— se lee mejor
+ * que de frente. No es un parche de encuadre: es el mismo mundo contado desde
+ * donde está parado el campesino.
+ */
+const VISTAS = {
+  /* La cámara mira desde ARRIBA de la copa del páramo, no desde la altura de
+     los ojos: con el ángulo bajo, las tres terrazas se veían de canto y ni el
+     lomo de la ladera ni el cauce de la quebrada entraban en el cuadro. Un
+     diorama se lee desde arriba y de frente. */
+  juntosAncho: {
+    pos: new THREE.Vector3(0.8, 15.5, 34),
+    mira: new THREE.Vector3(0.3, 4.4, -1.5),
+    fov: 40,
+  },
+  /* El retrato vertical: la misma vista de frente, pero MÁS ATRÁS y con más
+     ángulo, porque en un teléfono en vertical el ancho es lo escaso. La ladera
+     queda como una FRANJA en el medio del cuadro — y esa franja es justo el
+     hueco que dejan el título arriba y la carta de la lección abajo. */
+  juntosAlto: {
+    pos: new THREE.Vector3(0.4, 16.6, 70),
+    mira: new THREE.Vector3(0.2, 0.9, -1.5),
+    fov: 52,
+  },
+};
+
+/**
+ * El retrato de un Ent: el árbol entero, de raíz a copa, con su lección al pie.
+ *
+ * El objetivo se corre a la IZQUIERDA del árbol a propósito: así el guardián
+ * queda en la mitad derecha del cuadro y no debajo de la carta de la lección,
+ * que en pantalla ancha vive arriba a la izquierda. Un retrato con el sujeto
+ * tapado por su propio texto no es un retrato.
+ */
+function vistaDeEnt(piso) {
+  const ySuelo = alturaLadera(piso.x, piso.z);
+  return {
+    mira: new THREE.Vector3(piso.x - 1.9, ySuelo + 4.4, piso.z),
+    pos: new THREE.Vector3(piso.x - 0.4, ySuelo + 7.2, piso.z + 19),
+    fov: 38,
+  };
+}
+
+const VISTA_ENT = {
+  templado: vistaDeEnt(PISOS[0]),
+  frio: vistaDeEnt(PISOS[1]),
+  paramo: vistaDeEnt(PISOS[2]),
+};
+
+/* Qué lección le toca a cada vista. */
+const LECCION_DE = {
+  juntos: LECCIONES.juntos,
+  templado: LECCIONES.roble,
+  frio: LECCIONES.aliso,
+  paramo: LECCIONES.quenua,
+};
+
+const BOTONES = [
+  { id: 'templado', texto: 'El roble' },
+  { id: 'frio', texto: 'El aliso' },
+  { id: 'paramo', texto: 'La queñua' },
+  { id: 'juntos', texto: 'Los tres' },
+];
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL CAMARÓGRAFO — lleva la cámara de una vista a otra
+   ══════════════════════════════════════════════════════════════════════════ */
+/*
+ * Mueve cámara Y objetivo con una interpolación exponencial (llega rápido y
+ * frena suave, nunca un corte). Deja de mandar cuando llega, y también apenas
+ * el usuario toca la escena: si el lerp siguiera vivo mientras alguien arrastra
+ * con el dedo, la cámara le pelearía la mano y el mundo se sentiría trabado.
+ */
+function Camarografo({ vista, controls }) {
+  const size = useThree((s) => s.size);
+  const animando = useRef(true);
+
+  const destino = useMemo(() => {
+    if (vista !== 'juntos') return VISTA_ENT[vista] || VISTAS.juntosAncho;
+    return size.width / Math.max(1, size.height) < 0.95 ? VISTAS.juntosAlto : VISTAS.juntosAncho;
+  }, [vista, size.width, size.height]);
+
+  useEffect(() => {
+    animando.current = true;
+  }, [destino]);
+
+  useEffect(() => {
+    const c = controls.current;
+    if (!c) return undefined;
+    const parar = () => { animando.current = false; };
+    c.addEventListener('start', parar);
+    return () => c.removeEventListener('start', parar);
+  }, [controls]);
+
+  /* La cámara se toma del ESTADO DEL CUADRO (`estado.camera`), no de un
+     `useThree()` en el cuerpo del componente: el `fov` se escribe a mano y
+     escribirle una propiedad a un valor devuelto por un hook es exactamente lo
+     que la regla de inmutabilidad prohíbe. Aquí es una variable local del
+     callback y la intención queda clara: esto pasa por cuadro, no por render. */
+  useFrame((estado, dt) => {
+    if (!animando.current) return;
+    const cam = estado.camera;
+    const k = 1 - Math.exp(-Math.min(0.1, dt) * 3.2);
+    cam.position.lerp(destino.pos, k);
+    if (Math.abs(cam.fov - destino.fov) > 0.01) {
+      cam.fov += (destino.fov - cam.fov) * k;
+      cam.updateProjectionMatrix();
+    }
+    const c = controls.current;
+    if (c) {
+      c.target.lerp(destino.mira, k);
+      c.update();
+    }
+    /* LA CONDICIÓN DE LLEGADA MIRA LAS DOS COSAS, cámara Y objetivo.
+       Mirando solo la posición, arrancar YA en el sitio (que es lo que pasa al
+       cargar: el Canvas nace con la cámara de la vista madre) daba "llegué" en
+       el primer frame — y el objetivo se quedaba clavado donde lo dejó
+       OrbitControls, que por defecto es el ORIGEN. La cámara terminaba mirando
+       al piso del bloque, el mundo se subía en el cuadro y las copas de los
+       tres Ents salían cortadas por el borde de arriba en TODA captura. */
+    const lejosMira = c ? c.target.distanceTo(destino.mira) : 0;
+    if (cam.position.distanceTo(destino.pos) < 0.06 && lejosMira < 0.06) {
+      animando.current = false;
+    }
+  });
+
+  return null;
+}
+
+/* La carta de la lección. Se monta DOS veces (arriba y al pie) y el CSS deja
+   viva una sola según el ancho: la de arriba en pantalla ancha, la del pie en
+   teléfono. Dos nodos en el DOM cuestan nada y evitan tener que medir la
+   ventana en JavaScript para decidir un layout — que es el tipo de cosa que se
+   desincroniza con el CSS y termina mostrando las dos o ninguna. */
+function Carta({ leccion }) {
+  return (
+    <article className="teg-carta" role="status">
+      <header className="teg-carta-cab">
+        <h3>{leccion.titulo}</h3>
+        <p className="teg-cientifico">
+          <em>{leccion.arbol}</em>
+          <span className="teg-piso">{leccion.piso}</span>
+        </p>
+      </header>
+      <p className="teg-texto">{leccion.texto}</p>
+    </article>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL MUNDO
+   ══════════════════════════════════════════════════════════════════════════ */
+export default function TresEntsGradiente3D() {
+  const [listo, setListo] = useState(false);
+  const [vista, setVista] = useState('juntos');
+  const controls = useRef(null);
+
+  const { tier } = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () => typeof window !== 'undefined'
+      && typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const perfil = useMemo(() => perfilDeTier(tier), [tier]);
+
+  /* La atmósfera: la familia `ladera` mezclada 60 % hacia la madre, que es la
+     ley de la casa. Es la bruma verde-plata del páramo andino — nunca el
+     celeste frío de postal. El fondo y la niebla salen de ahí, ni un hex a mano. */
+  const cielo = useMemo(() => mezclarCielo(CIELOS.ladera), []);
+
+  const leccion = LECCION_DE[vista] || LECCIONES.juntos;
+  const foco = vista === 'juntos' ? null : vista;
+
+  const elegir = useCallback((id) => {
+    setVista((v) => (v === id && id !== 'juntos' ? 'juntos' : id));
+  }, []);
+
+  /* Teclado: 1-4 saltan de vista. Un mundo que se maneja con el teclado se
+     puede capturar y revisar sin pelear con el mouse. */
+  useEffect(() => {
+    const alTeclear = (e) => {
+      const i = ['1', '2', '3', '4'].indexOf(e.key);
+      if (i >= 0) setVista(BOTONES[i].id);
+    };
+    window.addEventListener('keydown', alTeclear);
+    return () => window.removeEventListener('keydown', alTeclear);
+  }, []);
+
+  return (
+    <section
+      className="teg-root"
+      data-tier={tier}
+      data-vista={vista}
+      aria-label="Los tres árboles maestros del gradiente andino"
+    >
+      <style>{CSS}</style>
+      <Canvas
+        className="teg-canvas"
+        /* El fundido va en estilo EN LÍNEA, no en una clase: construir la
+           ladera y los tres Ents bloquea el hilo principal un momento y, con el
+           fundido en clase, el navegador se queda con la opacidad en 0 mientras
+           está bloqueado → la escena aparece VACÍA en la captura, con todo
+           dibujado e invisible. Ya pasó en el bosque de los tres estratos. */
+        style={{ opacity: listo ? 1 : 0, transition: 'opacity 0.9s ease' }}
+        dpr={perfil.dpr}
+        gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+        camera={{ position: [0.8, 15.5, 34], fov: 40, near: 0.4, far: 240 }}
+        shadows={!!perfil.sombras}
+        frameloop={reducedMotion ? 'demand' : 'always'}
+        onCreated={() => setListo(true)}
+      >
+        <color attach="background" args={[cielo.fondo]} />
+        {/* La niebla empieza LEJOS: tiene que velar el fondo del valle, no la
+            ladera que uno está mirando. Con la niebla encima, los tres pisos se
+            funden en un beige — que es lo contrario de lo que este mundo
+            existe para enseñar. */}
+        {perfil.fog && <fog attach="fog" args={[cielo.niebla, 42, 130]} />}
+
+        <LuzMadre
+          cielo={CIELOS.ladera}
+          perfil={perfil}
+          /* El sol entra por el hombro derecho, del lado del páramo: la luz
+             viene de arriba de la ladera y baja con el agua. Las sombras de los
+             tres Ents caen hacia el valle. */
+          solPos={[19, 27, 13]}
+          sombra={{ left: -22, right: 22, top: 22, bottom: -22, far: 96 }}
+        />
+
+        <EscenaTresEnts
+          tier={tier}
+          perfil={perfil}
+          reducedMotion={reducedMotion}
+          foco={foco}
+        />
+
+        <Camarografo vista={vista} controls={controls} />
+
+        <OrbitControls
+          ref={controls}
+          makeDefault
+          enablePan={false}
+          enableZoom
+          /* El objetivo ARRANCA en la vista madre. Sin esto queda en el origen
+             —dentro del bloque de tierra— y el primer cuadro que ve el usuario
+             (y toda captura) sale mirando al piso. */
+          target={[0.3, 4.4, -1.5]}
+          minDistance={7}
+          maxDistance={88}
+          /* Se puede mirar hacia arriba (a las copas) pero no meterse bajo
+             tierra: por debajo del bloque no hay nada que enseñar. */
+          minPolarAngle={0.24}
+          maxPolarAngle={1.44}
+          enableDamping
+          dampingFactor={0.08}
+          autoRotate={false}
+        />
+        <AdaptiveDpr pixelated />
+      </Canvas>
+
+      {/* EL CROMO. En pantalla ancha la carta de la lección va ARRIBA A LA
+          IZQUIERDA, sobre el cielo vacío que deja la ladera: puesta abajo —que
+          fue la primera versión— le tapaba justo la banda de micorrizas, o sea
+          media lección. En teléfono no hay cielo a los lados y la carta vuelve
+          al pie, que es donde cae el pulgar. */}
+      <div className="teg-chrome">
+        <div className="teg-cabeza">
+          <h2 className="teg-titulo">
+            Los tres árboles maestros del gradiente
+            <small>Un Ent por piso térmico · el agua baja por encima, las micorrizas amarran por debajo</small>
+          </h2>
+
+          <Carta leccion={leccion} />
+        </div>
+
+        <div className="teg-pie">
+          <div className="teg-botones" role="group" aria-label="Los tres Ents del gradiente">
+            {BOTONES.map((b, i) => (
+              <button
+                key={b.id}
+                type="button"
+                className={`teg-boton${b.id === 'juntos' ? ' teg-boton--juntos' : ''}`}
+                aria-pressed={vista === b.id}
+                onClick={() => elegir(b.id)}
+                title={`Tecla ${i + 1}`}
+              >
+                {b.texto}
+              </button>
+            ))}
+          </div>
+          <Carta leccion={leccion} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const CSS = `
+.teg-root { position: relative; width: 100%; height: 100dvh; min-height: 320px; overflow: hidden; background: #d6e0d2; }
+.teg-canvas { position: absolute; inset: 0; }
+.teg-chrome { position: absolute; inset: 0; z-index: 7; pointer-events: none; display: flex; flex-direction: column; justify-content: space-between; }
+.teg-cabeza { display: flex; flex-direction: column; align-items: flex-start; gap: 0.6rem; }
+.teg-titulo { margin: 0; padding: 0.9rem 1rem 0; color: #22301f; text-shadow: 0 1px 8px rgba(236,242,226,0.85); font: 700 1.18rem/1.2 system-ui, sans-serif; letter-spacing: 0.01em; }
+.teg-titulo small { display: block; font: 500 0.8rem/1.35 system-ui, sans-serif; opacity: 0.86; margin-top: 0.15rem; }
+.teg-pie { padding: 0 1rem 0.9rem; display: flex; flex-direction: column; align-items: center; gap: 0.55rem; }
+.teg-botones { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 0.5rem; }
+.teg-boton { pointer-events: auto; appearance: none; border: 1px solid rgba(30,46,28,0.35); border-radius: 999px; padding: 0.44rem 1rem; background: rgba(236,244,228,0.86); color: #253320; font: 600 0.8rem/1.1 system-ui, sans-serif; cursor: pointer; backdrop-filter: blur(3px); transition: background 0.2s ease, border-color 0.2s ease; }
+.teg-boton:hover, .teg-boton:focus-visible { background: rgba(255,255,255,0.95); border-color: rgba(30,46,28,0.6); outline: none; }
+.teg-boton[aria-pressed='true'] { background: #cfe3c2; border-color: rgba(37,51,32,0.75); }
+.teg-boton--juntos { font-weight: 700; }
+.teg-carta { margin: 0 1rem; max-width: 25rem; padding: 0.6rem 0.95rem 0.7rem; border-radius: 0.8rem; background: rgba(28,40,26,0.72); backdrop-filter: blur(4px); color: #eff5e9; }
+.teg-carta-cab h3 { margin: 0; font: 700 0.92rem/1.25 system-ui, sans-serif; }
+.teg-cientifico { margin: 0.1rem 0 0.35rem; display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: baseline; font: 500 0.74rem/1.3 system-ui, sans-serif; opacity: 0.9; }
+.teg-piso { opacity: 0.78; }
+.teg-texto { margin: 0; font: 500 0.79rem/1.5 system-ui, sans-serif; }
+/* En teléfono (o en cualquier ventana angosta) la ladera ocupa la franja del
+   medio y no hay cielo lateral que aprovechar: la carta baja al pie, junto a
+   los botones, que es donde alcanza el pulgar. */
+@media (max-width: 760px) {
+  .teg-chrome { justify-content: space-between; }
+  .teg-cabeza { gap: 0; }
+  .teg-cabeza .teg-carta { display: none; }
+  .teg-pie .teg-carta { display: block; }
+  .teg-titulo { font-size: 1rem; padding: 0.7rem 0.8rem 0; }
+  .teg-titulo small { font-size: 0.72rem; }
+  .teg-carta { margin: 0; max-width: 100%; padding: 0.5rem 0.8rem 0.6rem; }
+  .teg-carta-cab h3 { font-size: 0.86rem; }
+  .teg-texto { font-size: 0.74rem; line-height: 1.45; }
+  .teg-boton { padding: 0.4rem 0.78rem; font-size: 0.75rem; }
+}
+@media (min-width: 761px) { .teg-pie .teg-carta { display: none; } }
+@media (prefers-reduced-motion: reduce) { .teg-canvas { transition: none !important; } }
+`;

--- a/src/visual/mundo3d/bosque/EntGradiente.jsx
+++ b/src/visual/mundo3d/bosque/EntGradiente.jsx
@@ -1,0 +1,372 @@
+/*
+ * EntGradiente — el componente r3f de los dos ÁRBOLES MAESTROS nuevos del
+ * gradiente: el ENT DEL ROBLE y el ENT DEL ALISO.
+ *
+ * Es el hermano de `EntQuenua.jsx` (el Ent del páramo, que NO se toca ni se
+ * redibuja): misma talla, mismos gestos, mismo peso ancestral, pero paramétrico
+ * por especie. La geometría vive en `entsGradiente.geom.js`; aquí se le pone
+ * material, luz y VIDA.
+ *
+ * Lo que hace vivo a un Ent (y lo que nunca se le puede quitar):
+ *   · el balanceo pesado desde la raíz — lento, con inercia, nunca un metrónomo;
+ *   · el parpadeo ancestral (mucho rato abierto, un pestañeo corto);
+ *   · la mirada que deriva despacio y vuelve;
+ *   · la mandíbula de madera que murmura por frases, con silencios.
+ * Con `reducedMotion` todo eso queda QUIETO y sereno — nunca desaparece.
+ *
+ * ── La trampa de los ojos (documentada para que no se repita) ───────────────
+ * El apilado del ojo es GEOMETRÍA, no gusto: el frente del iris DEBE quedar por
+ * delante del frente del globo y del pozo de la cuenca. Si no, el ámbar queda
+ * literalmente DENTRO de las esferas oscuras y el Ent mira con cuencas vacías de
+ * calavera. En el queñual pasó dos veces (una de ellas SOLO con la animación
+ * encendida, así que la captura con reducedMotion salía bien y el bug vivo
+ * pasaba de largo). Aquí los frentes se derivan del radio del fuste
+ * (`proporcionesRostro`) para que la relación se conserve en un tronco grueso
+ * como el del roble y en uno delgado como el del aliso.
+ */
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { crearMaterialVertexColors } from '../paleta/index.js';
+import { factorParpadeo, factorHabla, ROSTRO_BOCA_Y } from './entQuenua.geom.js';
+import {
+  ESPECIES,
+  paramsDeTier,
+  anclaRostro,
+  proporcionesRostro,
+  mallaRostro,
+  construirMadera,
+  construirRaices,
+  construirCopa,
+  geomSetasDelRoble,
+  geomNodulosFrankia,
+} from './entsGradiente.geom.js';
+
+/* ══════════════════════════════════════════════════════════════════════════
+   UN OJO — hundido en su cuenca, en sombra bajo la cornisa de la ceja
+   ══════════════════════════════════════════════════════════════════════════ */
+/* El globo es madera húmeda oscura; el IRIS ámbar-miel es CHICO y asoma desde
+   la sombra (rescoldo de fogón, jamás un farol naranja); los párpados son del
+   MISMO palo que el rostro. Una sola chispa húmeda da la vida. */
+function Ojo({ x, z, k, blinkRef, gazeRef, flip, mats }) {
+  return (
+    <group position={[x, -0.035, z]} scale={[0.94 * k, 0.86 * k, 0.6 * k]}>
+      {/* el POZO de la cuenca: oscuridad honda donde se asienta el ojo */}
+      <mesh position={[0, -0.005, -0.03]} scale={[1.26, 1.2, 1.24]}>
+        <sphereGeometry args={[0.115, 14, 12]} />
+        <primitive object={mats.grieta} attach="material" />
+      </mesh>
+      <group ref={blinkRef}>
+        {/* el GLOBO: nace hundido, solo su cara frontal asoma del pozo */}
+        <mesh position={[0, 0, 0.04]}>
+          <sphereGeometry args={[0.09, 16, 14]} />
+          <primitive object={mats.ojo} attach="material" />
+        </mesh>
+        <group ref={gazeRef} position={[0, 0.004, 0.105]}>
+          <mesh scale={[1, 1, 0.65]}>
+            <sphereGeometry args={[0.062, 16, 14]} />
+            <primitive object={mats.iris} attach="material" />
+          </mesh>
+          {/* pupila: pozo hondo y amplio en el centro (mirada mansa) */}
+          <mesh position={[0, 0, 0.026]} scale={[1, 1, 0.7]}>
+            <sphereGeometry args={[0.031, 12, 10]} />
+            <primitive object={mats.grieta} attach="material" />
+          </mesh>
+          {/* la chispa de húmedo: mínima, arriba a un lado — la vida */}
+          <mesh position={[flip * 0.021, 0.025, 0.044]}>
+            <sphereGeometry args={[0.008, 8, 8]} />
+            <primitive object={mats.brillo} attach="material" />
+          </mesh>
+        </group>
+      </group>
+      {/* párpado superior de CORTEZA: pesado, entrecerrado — la gravedad sabia */}
+      <mesh position={[0, 0.082, 0.032]} rotation={[0.7, 0, flip * 0.08]} scale={[1.24, 0.52, 0.7]}>
+        <sphereGeometry args={[0.104, 14, 10]} />
+        <primitive object={mats.parpado} attach="material" />
+      </mesh>
+      {/* párpado inferior: reborde discreto de la misma corteza */}
+      <mesh position={[0, -0.08, 0.028]} rotation={[-0.35, 0, -flip * 0.1]} scale={[1.08, 0.4, 0.6]}>
+        <sphereGeometry args={[0.095, 12, 8]} />
+        <primitive object={mats.parpado} attach="material" />
+      </mesh>
+    </group>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL ROSTRO — la cáscara tallada + los ojos + la mandíbula que murmura
+   ══════════════════════════════════════════════════════════════════════════ */
+function Rostro({ esp, P, mats, reducedMotion, blinkRefs }) {
+  const { centro } = useMemo(() => anclaRostro(esp), [esp]);
+  const prop = useMemo(() => proporcionesRostro(esp), [esp]);
+  const { cara, mandibula } = useMemo(
+    () => mallaRostro(esp, { segRostro: P.segRostro }),
+    [esp, P.segRostro],
+  );
+  useLayoutEffect(() => () => {
+    cara.dispose();
+    mandibula.dispose();
+  }, [cara, mandibula]);
+
+  const gazeIzq = useRef(null);
+  const gazeDer = useRef(null);
+  const mandibulaRef = useRef(null);
+
+  /* Escala de los ojos relativa a la talla del rostro: en el fuste delgado del
+     aliso el ojo del queñual quedaría del tamaño de la cara entera. */
+  const k = Math.min(1.15, Math.max(0.72, prop.frenteL / 0.53));
+
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const t = state.clock.elapsedTime;
+    // MIRADA: deriva lenta (recorre, se detiene, vuelve). Los dos ojos juntos.
+    const gx = Math.sin(t * 0.24 + esp.semilla) * 0.03 + Math.sin(t * 0.09 + 1.1) * 0.015;
+    const gy = Math.sin(t * 0.17 + 0.6) * 0.018;
+    // La z es la MISMA del grupo de la mirada en <Ojo> (0.105): escribir un
+    // valor menor hunde el iris dentro del globo y salen ojos de calavera.
+    if (gazeIzq.current) gazeIzq.current.position.set(gx, gy - 0.004, 0.105);
+    if (gazeDer.current) gazeDer.current.position.set(gx, gy - 0.004, 0.105);
+    // HABLA: la mandíbula pivota despacio — murmullo de árbol viejo, con pausas.
+    const abre = factorHabla(t + esp.semilla * 0.7);
+    if (mandibulaRef.current) mandibulaRef.current.rotation.x = 0.015 + abre * 0.11;
+  });
+
+  return (
+    <group position={[centro.x, centro.y, centro.z]} scale={esp.rostroEscala}>
+      {/* la cavidad oscura tras la boca-grieta: al abrirse se ve hondura, no
+          tronco. Discreta: agrandarla devuelve la franja negra de teatro. */}
+      <mesh position={[0, ROSTRO_BOCA_Y - 0.02, prop.zBoca - 0.16]} scale={[0.29, 0.1, 0.13]}>
+        <sphereGeometry args={[1, 14, 12]} />
+        <primitive object={mats.grieta} attach="material" />
+      </mesh>
+
+      <mesh geometry={cara} material={mats.corteza} castShadow receiveShadow />
+      <group ref={mandibulaRef} position={[0, ROSTRO_BOCA_Y, 0]}>
+        <mesh geometry={mandibula} material={mats.corteza} castShadow receiveShadow />
+      </group>
+
+      <Ojo x={-prop.sepOjo} z={prop.zOjo} k={k} blinkRef={blinkRefs.izq} gazeRef={gazeIzq} flip={-1} mats={mats} />
+      <Ojo x={prop.sepOjo} z={prop.zOjo} k={k} blinkRef={blinkRefs.der} gazeRef={gazeDer} flip={1} mats={mats} />
+    </group>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LAS MANOS — nudo de muñeca + dedos-ramita
+   ══════════════════════════════════════════════════════════════════════════ */
+/* En reposo los dedos van CORTOS y RECOGIDOS hacia la tierra: los dedos largos
+   y abiertos leen como garra de espanto junto al rostro. La mano que SEÑALA
+   estira el índice hacia la lección y recoge los otros tres. */
+function Mano({ spec, esc, mat }) {
+  const { muneca, dedos, lado } = spec;
+  if (dedos === 'senala') {
+    return (
+      <group position={[muneca.x, muneca.y, muneca.z]}>
+        <mesh rotation={[0.5, 0, 0]}>
+          <boxGeometry args={[0.2 * esc, 0.12 * esc, 0.22 * esc]} />
+          <primitive object={mat} attach="material" />
+        </mesh>
+        {/* ÍNDICE: el dedo largo que señala la lección del pie */}
+        <mesh position={[0.02 * esc, -0.16 * esc, 0.16 * esc]} rotation={[Math.PI - 0.55, 0, 0]}>
+          <coneGeometry args={[0.045 * esc, 0.5 * esc, 6]} />
+          <primitive object={mat} attach="material" />
+        </mesh>
+        <mesh position={[0.02 * esc, -0.05 * esc, 0.12 * esc]}>
+          <sphereGeometry args={[0.05 * esc, 8, 7]} />
+          <primitive object={mat} attach="material" />
+        </mesh>
+        {[-0.07, 0, 0.07].map((dx, i) => (
+          <mesh key={i} position={[dx * esc, -0.12 * esc, -0.02 * esc]} rotation={[Math.PI - 1.4, 0, 0]}>
+            <coneGeometry args={[0.032 * esc, 0.2 * esc, 5]} />
+            <primitive object={mat} attach="material" />
+          </mesh>
+        ))}
+        <mesh position={[-0.11 * esc, -0.02 * esc, 0.05 * esc]} rotation={[0, 0, 0.9 * lado]}>
+          <coneGeometry args={[0.035 * esc, 0.16 * esc, 5]} />
+          <primitive object={mat} attach="material" />
+        </mesh>
+      </group>
+    );
+  }
+  return (
+    <group position={[muneca.x, muneca.y, muneca.z]}>
+      <mesh scale={[1.1, 0.92, 1]}>
+        <sphereGeometry args={[0.12 * esc, 10, 8]} />
+        <primitive object={mat} attach="material" />
+      </mesh>
+      {[
+        [-0.06, -0.14, 0.02, 0.2],
+        [0, -0.16, 0.05, 0.24],
+        [0.06, -0.13, 0, 0.19],
+      ].map(([dx, dy, dz, len], j) => (
+        <mesh
+          key={j}
+          position={[dx * esc, dy * esc, dz * esc]}
+          rotation={[Math.PI - 0.12 + j * 0.06, 0, dx * 1.2]}
+        >
+          <coneGeometry args={[0.032 * esc, len * esc, 5]} />
+          <primitive object={mat} attach="material" />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL ENT COMPLETO
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * Un Ent del gradiente. Montar SOLO dentro de un <Canvas>.
+ *
+ * @param {object} props
+ * @param {'roble'|'aliso'} props.especie
+ * @param {'alto'|'medio'|'bajo'} [props.tier]
+ * @param {boolean} [props.reducedMotion]
+ * @param {boolean} [props.leccion]  monta la lección hecha cosa al pie del
+ *   árbol: el corro de setas del roble (Cantharellus + Lactarius) o los nódulos
+ *   de Frankia en las raíces del aliso.
+ */
+export default function EntGradiente({
+  especie = 'roble',
+  tier = 'alto',
+  reducedMotion = false,
+  leccion = true,
+}) {
+  const esp = ESPECIES[especie] || ESPECIES.roble;
+  const P = useMemo(() => paramsDeTier(tier), [tier]);
+
+  const swayRef = useRef(null);
+  const ojoIzq = useRef(null);
+  const ojoDer = useRef(null);
+
+  /* ── Geometrías (una vez por especie y tier) ── */
+  const { geo: maderaGeo, ramas, brazos } = useMemo(() => construirMadera(esp, P), [esp, P]);
+  const { geo: raicesGeo, raices } = useMemo(() => construirRaices(esp, P), [esp, P]);
+  const copaGeo = useMemo(
+    () => construirCopa(esp, P, ramas.map((r) => r.punta)),
+    [esp, P, ramas],
+  );
+  const leccionGeo = useMemo(() => {
+    if (!leccion) return null;
+    if (esp.id === 'roble') return geomSetasDelRoble({ q: P.hojasCopa }, 909);
+    return geomNodulosFrankia(raices, { q: P.hojasCopa }, 515);
+  }, [esp, P, raices, leccion]);
+
+  useEffect(() => () => {
+    maderaGeo.dispose();
+    raicesGeo.dispose();
+    copaGeo.dispose();
+    if (leccionGeo) leccionGeo.dispose();
+  }, [maderaGeo, raicesGeo, copaGeo, leccionGeo]);
+
+  /* ── Materiales ──
+     La madera y la copa viajan con el color HORNEADO por vértice: un solo
+     material blanco para todo (el patrón de la casa). El facetado de la corteza
+     va apagado —el relieve es geometría, no facetas— y el de la copa también,
+     porque `matojoNube` trae normales radiales que la hacen masa suave. */
+  const matCorteza = useMemo(
+    () => crearMaterialVertexColors(P, { flatShading: false, roughness: 0.94 }),
+    [P],
+  );
+  const matCopa = useMemo(
+    () => crearMaterialVertexColors(P, { flatShading: false, roughness: 0.88 }),
+    [P],
+  );
+  const matLeccion = useMemo(
+    () => crearMaterialVertexColors(P, { flatShading: false, roughness: 0.82 }),
+    [P],
+  );
+  /* Los materiales del rostro: un punto más oscuros que el fuste para que manos
+     y párpados no peguen en claro contra la corteza. Se derivan del color de
+     grieta de la especie, no de un hex suelto. */
+  const matManos = useMemo(() => {
+    const c = new THREE.Color(esp.corteza.grieta).lerp(new THREE.Color(esp.corteza.cuerpo), 0.45);
+    return P.materialRico
+      ? new THREE.MeshStandardMaterial({ color: c, roughness: 0.9 })
+      : new THREE.MeshLambertMaterial({ color: c });
+  }, [esp, P.materialRico]);
+  const matGrieta = useMemo(() => {
+    const c = new THREE.Color(esp.corteza.grieta).multiplyScalar(0.45);
+    return P.materialRico
+      ? new THREE.MeshStandardMaterial({ color: c, roughness: 0.8 })
+      : new THREE.MeshLambertMaterial({ color: c });
+  }, [esp, P.materialRico]);
+  const matParpado = useMemo(() => {
+    const c = new THREE.Color(esp.corteza.grieta).lerp(new THREE.Color(esp.corteza.cuerpo), 0.28);
+    return P.materialRico
+      ? new THREE.MeshStandardMaterial({ color: c, roughness: 0.92 })
+      : new THREE.MeshLambertMaterial({ color: c });
+  }, [esp, P.materialRico]);
+  const matOjo = useMemo(
+    () => (P.materialRico
+      ? new THREE.MeshStandardMaterial({ color: '#160f0a', roughness: 0.62 })
+      : new THREE.MeshLambertMaterial({ color: '#1a120d' })),
+    [P.materialRico],
+  );
+  const matBrillo = useMemo(() => new THREE.MeshBasicMaterial({ color: '#e6ecdd' }), []);
+  /* Iris ámbar-miel DISCRETO. En frugal va Lambert CON emisivo, nunca Basic
+     plano: el disco naranja sin sombreado era el peor de los goggles. */
+  const matIris = useMemo(
+    () => (P.materialRico
+      ? new THREE.MeshStandardMaterial({ color: '#b08137', emissive: '#6b4514', emissiveIntensity: 0.5, roughness: 0.55 })
+      : new THREE.MeshLambertMaterial({ color: '#b08137', emissive: '#6b4514', emissiveIntensity: 0.55 })),
+    [P.materialRico],
+  );
+
+  useEffect(() => () => {
+    [matCorteza, matCopa, matLeccion, matManos, matGrieta, matParpado, matOjo, matBrillo, matIris]
+      .forEach((m) => m.dispose());
+  }, [matCorteza, matCopa, matLeccion, matManos, matGrieta, matParpado, matOjo, matBrillo, matIris]);
+
+  const matsRostro = useMemo(
+    () => ({ corteza: matCorteza, grieta: matGrieta, parpado: matParpado, ojo: matOjo, iris: matIris, brillo: matBrillo }),
+    [matCorteza, matGrieta, matParpado, matOjo, matIris, matBrillo],
+  );
+
+  /* ── Vida: balanceo pesado desde la raíz + parpadeo lento ── */
+  useFrame((state) => {
+    if (reducedMotion) return;
+    const t = state.clock.elapsedTime;
+    if (swayRef.current) {
+      swayRef.current.rotation.z = Math.sin(t * 0.45 + esp.semilla) * 0.016;
+      swayRef.current.rotation.x = Math.sin(t * 0.37 + 1.1 + esp.semilla) * 0.011;
+    }
+    const b = factorParpadeo(t + esp.semilla * 1.3);
+    if (ojoIzq.current) ojoIzq.current.scale.y = b;
+    if (ojoDer.current) ojoDer.current.scale.y = b;
+  });
+
+  const escManos = esp.r0 / 0.86; // las manos siguen el grosor del palo
+
+  return (
+    <group name={`ent-${esp.id}`}>
+      {/* raíces plantadas: quedan FUERA del balanceo, ellas agarran la tierra */}
+      <mesh geometry={raicesGeo} material={matCorteza} castShadow receiveShadow />
+
+      {/* la lección hecha cosa, al pie del árbol y también fuera del balanceo */}
+      {leccionGeo && (
+        <mesh geometry={leccionGeo} material={matLeccion} castShadow receiveShadow />
+      )}
+
+      {/* fuste + ramas + brazos + rostro + copa: se mecen desde la base */}
+      <group ref={swayRef}>
+        <mesh geometry={maderaGeo} material={matCorteza} castShadow receiveShadow />
+
+        {brazos.map((b, i) => (
+          <Mano key={`mano-${i}`} spec={b} esc={escManos} mat={matManos} />
+        ))}
+
+        <Rostro
+          esp={esp}
+          P={P}
+          mats={matsRostro}
+          reducedMotion={reducedMotion}
+          blinkRefs={{ izq: ojoIzq, der: ojoDer }}
+        />
+
+        <mesh geometry={copaGeo} material={matCopa} castShadow />
+      </group>
+    </group>
+  );
+}

--- a/src/visual/mundo3d/bosque/EscenaTresEnts.jsx
+++ b/src/visual/mundo3d/bosque/EscenaTresEnts.jsx
@@ -1,0 +1,550 @@
+/*
+ * EscenaTresEnts — LA LADERA DE LOS TRES ÁRBOLES MAESTROS, puesta en pie.
+ *
+ * Monta el bloque de montaña cortado (`gradienteAndino.geom.js`), le siembra la
+ * vegetación que le toca a cada piso térmico, le pone el agua que baja y la red
+ * de micorrizas que amarra por debajo, y planta los TRES ENTS:
+ *
+ *   · EL ENT DEL ROBLE  (templado y frío) — `EntGradiente especie="roble"`
+ *   · EL ENT DEL ALISO  (frío)            — `EntGradiente especie="aliso"`
+ *   · EL ENT DE LA QUEÑUA (páramo)        — `EntQuenua`, el que ya existía,
+ *     traído tal cual desde su casa. No se redibuja ni se le cambia un vértice:
+ *     es el mismo guardián del páramo, aquí en compañía de sus hermanos.
+ *
+ * ── El detalle que cierra la lección ───────────────────────────────────────
+ * En la terraza del FRÍO, detrás del aliso, hay dos robles chicos. No son
+ * relleno: el roble andino cruza el gradiente él solo, de 750 a 3.450 metros, y
+ * verlo trepado en el piso del aliso es la única forma de decir eso sin texto.
+ *
+ * ── Presupuesto de dibujo ──────────────────────────────────────────────────
+ * El bloque son cuatro draw-calls (lomo, corte, faldón, piedras); la
+ * vegetación, un InstancedMesh por especie; el agua y la red, uno cada una.
+ * Todo comparte material de color por vértice: el color vive HORNEADO en la
+ * geometría, que es lo que permite que un teléfono barato dibuje esta ladera.
+ */
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { useFrame } from '@react-three/fiber';
+import { crearMaterialVertexColors } from '../paleta/index.js';
+import EntQuenua from './EntQuenua.jsx';
+import EntGradiente from './EntGradiente.jsx';
+import {
+  BLOQUE,
+  PISOS,
+  ESCARPES,
+  alturaLadera,
+  zCauce,
+  construirLomo,
+  construirCorte,
+  construirFaldon,
+  construirPiedras,
+  construirAgua,
+  construirPozas,
+  caminoAgua,
+  chispasDeAgua,
+  esqueletoRed,
+  construirRed,
+  nodosDeRed,
+  pulsosDeRed,
+  puntoBanda,
+} from './gradienteAndino.geom.js';
+import { rng } from './sombreadoVegetal.js';
+/*
+ * TODA la vegetación de acompañamiento sale de `floraParamo.geom.js`, y eso es
+ * a propósito.
+ *
+ * Los doce arquetipos del bosque de tres estratos (`estratosAltoandinos`)
+ * traen el color HORNEADO para vivir BAJO UN DOSEL CERRADO: su tinte de suelo
+ * es `mezclar(musgo, tinta, 0.42)`, casi negro, porque allá la lección es que
+ * al suelo del bosque no le llega luz. Sembrados en estas terrazas abiertas —
+ * que están al sol— se leían como manchones de alquitrán al pie de los Ents.
+ * No era un bug de la escena ni del arquetipo: era usar la pieza equivocada.
+ * La flora del páramo, en cambio, está calibrada para ladera abierta.
+ */
+import {
+  geomRoble,
+  geomAliso,
+  geomEncenillo,
+  geomGaque,
+  geomFrailejon,
+  geomMortino,
+  geomRomerillo,
+  geomMusgo,
+  geomRoca,
+  calidadDeTier,
+} from './floraParamo.geom.js';
+import { PALETA as MICO } from '../micorrizas/micorrizas.geom.js';
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LA SIEMBRA — dónde cae cada mata
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* Las zonas prohibidas: el pie de cada Ent (que se le vería la mata metida
+   dentro del tronco), la cama del agua y una faja al borde del corte (una mata
+   colgando del filo del tajo delata que el mundo es una maqueta). */
+/* Un Ent necesita AIRE alrededor: con el rodal pegado al fuste, en el retrato
+   de cerca el guardián se pierde dentro de su propio bosque. */
+const RADIO_ENT = 3.6;
+const MARGEN_CORTE = 1.1;
+
+function libre(x, z) {
+  if (z > BLOQUE.zFrente - MARGEN_CORTE) return false;
+  if (z < BLOQUE.zFondo + 0.6) return false;
+  if (Math.abs(z - zCauce(x)) < 1.15) return false;
+  for (const p of PISOS) {
+    if ((x - p.x) ** 2 + (z - p.z) ** 2 < RADIO_ENT * RADIO_ENT) return false;
+  }
+  for (const e of ESCARPES) {
+    if (x > e.desde - 0.3 && x < e.hasta + 0.3) return false; // el talud queda pelado
+  }
+  return true;
+}
+
+/**
+ * Siembra `n` matas en la faja [desde, hasta] de la ladera, respetando las
+ * zonas prohibidas y una distancia mínima entre vecinas. Devuelve la matriz de
+ * cada instancia lista para el InstancedMesh.
+ */
+function sembrar({
+  desde, hasta, n, seed, escMin = 0.9, escMax = 1.3, distMin = 0.9, ladeo = 0.06,
+  zDesde = BLOQUE.zFondo + 0.8, zHasta = BLOQUE.zFrente - 1.4,
+}) {
+  const r = rng(seed);
+  const items = [];
+  const intentos = n * 22;
+  for (let i = 0; i < intentos && items.length < n; i++) {
+    const x = desde + r() * (hasta - desde);
+    const z = zDesde + r() * (zHasta - zDesde);
+    if (!libre(x, z)) continue;
+    let choca = false;
+    for (const it of items) {
+      if ((it.x - x) ** 2 + (it.z - z) ** 2 < distMin * distMin) { choca = true; break; }
+    }
+    if (choca) continue;
+    items.push({
+      x,
+      z,
+      y: alturaLadera(x, z),
+      esc: escMin + r() * (escMax - escMin),
+      rotY: r() * Math.PI * 2,
+      tilt: [(r() - 0.5) * ladeo, (r() - 0.5) * ladeo],
+      tono: 0.9 + r() * 0.2,
+    });
+  }
+  return items;
+}
+
+/** UN BANCO: todas las matas de una especie en un solo InstancedMesh. */
+function Banco({ geo, mat, items, castShadow = false, hundir = 0 }) {
+  const ref = useRef(null);
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !items.length) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const e = new THREE.Euler();
+    const p = new THREE.Vector3();
+    const s = new THREE.Vector3();
+    const c = new THREE.Color();
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      p.set(it.x, it.y - hundir * it.esc, it.z);
+      e.set(it.tilt[0], it.rotY, it.tilt[1]);
+      q.setFromEuler(e);
+      s.setScalar(it.esc);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      // ni dos matas del mismo verde: variación chica, la justa para que el
+      // rodal no se lea clonado
+      c.setRGB(it.tono, it.tono, it.tono);
+      mesh.setColorAt(i, c);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items, hundir]);
+
+  if (!geo || !items.length) return null;
+  return (
+    <instancedMesh
+      ref={ref}
+      args={[geo, mat, items.length]}
+      frustumCulled={false}
+      castShadow={castShadow}
+      receiveShadow={false}
+    />
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL AGUA QUE CORRE — chispas que viajan por el cauce
+   ══════════════════════════════════════════════════════════════════════════ */
+/* Sin esto la quebrada es un tubo azul pintado en el suelo. Las chispas son lo
+   que la hace CORRER, y de paso dicen para dónde va: siempre hacia abajo. */
+function ChispasAgua({ curva, n, reducedMotion, mat }) {
+  const ref = useRef(null);
+  const chispas = useMemo(() => chispasDeAgua(n), [n]);
+  const geo = useMemo(() => new THREE.SphereGeometry(1, 6, 5), []);
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  /* Los objetos de trabajo van en un REF, no en un `useMemo`: se mutan por
+     cuadro y mutar un valor memoizado es lo que la regla de inmutabilidad de
+     hooks prohíbe (con razón: un memo se recalcula cuando quiere). Un ref
+     existe precisamente para esto. */
+  const tmpRef = useRef({
+    m: new THREE.Matrix4(),
+    q: new THREE.Quaternion(),
+    p: new THREE.Vector3(),
+    s: new THREE.Vector3(),
+    aux: new THREE.Vector3(),
+  });
+
+  const colocar = useCallback((t0) => {
+    const mesh = ref.current;
+    const tmp = tmpRef.current;
+    if (!mesh) return;
+    for (let i = 0; i < chispas.length; i++) {
+      const ch = chispas[i];
+      const t = (ch.t + t0 * ch.vel) % 1;
+      curva.getPointAt(t, tmp.p);
+      curva.getTangentAt(t, tmp.aux);
+      // desplazada al lado del hilo: el agua no corre por una línea sola
+      tmp.p.x += -tmp.aux.z * ch.lado;
+      tmp.p.z += tmp.aux.x * ch.lado;
+      tmp.p.y += ch.alto;
+      tmp.s.setScalar(ch.esc);
+      tmp.m.compose(tmp.p, tmp.q, tmp.s);
+      mesh.setMatrixAt(i, tmp.m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [chispas, curva]);
+
+  useLayoutEffect(() => { colocar(0); }, [colocar]);
+  useFrame(({ clock }) => {
+    if (reducedMotion) return;
+    colocar(clock.getElapsedTime());
+  });
+
+  return <instancedMesh ref={ref} args={[geo, mat, chispas.length]} frustumCulled={false} />;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LA RED QUE REPARTE — nodos y pulsos
+   ══════════════════════════════════════════════════════════════════════════ */
+/* Los pulsos van en los DOS sentidos a propósito: el mineral y el agua suben
+   del hongo a la mata, el azúcar baja de la mata al hongo. Es un trato, no una
+   tubería. */
+function PulsosRed({ curva, pulsos, reducedMotion, mat }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.SphereGeometry(1, 6, 5), []);
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  const tmpRef = useRef({
+    m: new THREE.Matrix4(),
+    q: new THREE.Quaternion(),
+    p: new THREE.Vector3(),
+    s: new THREE.Vector3(),
+  });
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const c = new THREE.Color();
+    for (let i = 0; i < pulsos.length; i++) {
+      mesh.setColorAt(i, c.set(pulsos[i].color));
+    }
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [pulsos]);
+
+  const colocar = useCallback((t0) => {
+    const mesh = ref.current;
+    const tmp = tmpRef.current;
+    if (!mesh) return;
+    for (let i = 0; i < pulsos.length; i++) {
+      const pu = pulsos[i];
+      let t = (pu.t + t0 * pu.vel * pu.dir) % 1;
+      if (t < 0) t += 1;
+      curva.getPointAt(t, tmp.p);
+      tmp.p.z += 0.06;
+      tmp.p.y += pu.lado;
+      tmp.s.setScalar(pu.esc);
+      tmp.m.compose(tmp.p, tmp.q, tmp.s);
+      mesh.setMatrixAt(i, tmp.m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [pulsos, curva]);
+
+  useLayoutEffect(() => { colocar(0); }, [colocar]);
+  useFrame(({ clock }) => {
+    if (reducedMotion) return;
+    colocar(clock.getElapsedTime());
+  });
+
+  return <instancedMesh ref={ref} args={[geo, mat, pulsos.length]} frustumCulled={false} />;
+}
+
+/** Los nodos de intercambio: perlas donde la red se junta con una raíz. Laten
+    despacio — el más grande es el de cada árbol. */
+function NodosRed({ nodos, reducedMotion, mat }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.SphereGeometry(1, 8, 6), []);
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  const tmpRef = useRef({
+    m: new THREE.Matrix4(), q: new THREE.Quaternion(), s: new THREE.Vector3(),
+  });
+
+  const colocar = useCallback((t0) => {
+    const mesh = ref.current;
+    const tmp = tmpRef.current;
+    if (!mesh) return;
+    for (let i = 0; i < nodos.length; i++) {
+      const nd = nodos[i];
+      const late = 1 + Math.sin(t0 * 1.1 + i * 1.7) * (nd.tipo === 'intercambio' ? 0.16 : 0.1);
+      tmp.s.setScalar(nd.esc * late);
+      tmp.m.compose(nd.p, tmp.q, tmp.s);
+      mesh.setMatrixAt(i, tmp.m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [nodos]);
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const c = new THREE.Color();
+    for (let i = 0; i < nodos.length; i++) {
+      mesh.setColorAt(i, c.set(nodos[i].tipo === 'intercambio' ? MICO.arbusculo : MICO.nodo));
+    }
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+    colocar(0);
+  }, [nodos, colocar]);
+
+  useFrame(({ clock }) => {
+    if (reducedMotion) return;
+    colocar(clock.getElapsedTime());
+  });
+
+  return <instancedMesh ref={ref} args={[geo, mat, nodos.length]} frustumCulled={false} />;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LA LADERA COMPLETA
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @param {object} props
+ * @param {'alto'|'medio'|'bajo'} props.tier
+ * @param {{materialRico?:boolean, flatShading?:boolean, sombras?:boolean}} props.perfil
+ * @param {boolean} [props.reducedMotion]
+ * @param {string|null} [props.foco]  id del piso al que se le está prestando
+ *   atención ('templado' | 'frio' | 'paramo' | null): los otros se apagan un
+ *   punto para que el ojo sepa a dónde mirar, sin ocultar nada.
+ */
+export default function EscenaTresEnts({
+  tier = 'alto',
+  perfil,
+  reducedMotion = false,
+  foco = null,
+}) {
+  const q = calidadDeTier(tier);
+  const denso = tier === 'alto' ? 1 : tier === 'medio' ? 0.62 : 0.35;
+
+  /* ── El bloque de montaña ── */
+  const lomo = useMemo(() => construirLomo({ q: denso }), [denso]);
+  const corte = useMemo(() => construirCorte({ q: denso }), [denso]);
+  const faldon = useMemo(() => construirFaldon({ q: denso }), [denso]);
+  const piedras = useMemo(() => construirPiedras({ q: denso }), [denso]);
+
+  /* ── El agua ── */
+  const curvaAgua = useMemo(() => caminoAgua(), []);
+  const agua = useMemo(() => construirAgua({ q: denso }), [denso]);
+  const pozas = useMemo(() => construirPozas({ q: denso }), [denso]);
+
+  /* ── La red del subsuelo ── */
+  const hilos = useMemo(() => esqueletoRed({ q: denso }), [denso]);
+  const red = useMemo(() => construirRed(hilos, { q: denso }), [hilos, denso]);
+  const nodos = useMemo(() => nodosDeRed(hilos, { q: denso }), [hilos, denso]);
+  const pulsos = useMemo(
+    () => pulsosDeRed(tier === 'alto' ? 26 : tier === 'medio' ? 12 : 0),
+    [tier],
+  );
+  /* El rizomorfo como curva: es el riel por el que viajan los pulsos de punta a
+     punta de la ladera. Que crucen los tres pisos es la lección hecha
+     movimiento. */
+  const curvaRed = useMemo(() => {
+    const pts = [];
+    for (let x = BLOQUE.xMax - 1.6; x >= BLOQUE.xMin + 1.2; x -= 0.7) {
+      pts.push(puntoBanda(x, Math.sin(x * 1.7) * 0.16));
+    }
+    return new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.4);
+  }, []);
+
+  /* ── La vegetación de cada terraza ──
+     Cada piso lleva SU cortejo. No es decoración: el frailejonal dice páramo,
+     el robledal cerrado dice templado, y el roble chico metido en la terraza
+     del frío dice que el roble sube solo. */
+  const geosVeg = useMemo(() => ({
+    roble: geomRoble({ q }, 31),
+    aliso: geomAliso({ q }, 32),
+    encenillo: geomEncenillo({ q }, 33),
+    gaque: geomGaque({ q }, 39),
+    frailejon: geomFrailejon({ q, edad: 0.7 }, 34),
+    frailejonFlor: geomFrailejon({ q, edad: 0.95, flor: true }, 35),
+    mortino: geomMortino({ q }, 36),
+    romerillo: geomRomerillo({ q }, 37),
+    musgo: geomMusgo(38),
+    roca: geomRoca(40),
+  }), [q]);
+
+  const siembra = useMemo(() => {
+    const templado = PISOS[0];
+    const frio = PISOS[1];
+    const paramo = PISOS[2];
+    const k = (n) => Math.max(1, Math.round(n * denso));
+    /* Los ÁRBOLES del cortejo se siembran DETRÁS de los Ents (zAtras): el Ent es
+       el protagonista de su terraza y tiene que recortarse contra el rodal, no
+       perderse dentro de él. La primera pasada los repartió por toda la
+       profundidad y el robledal se le tragó el rostro al roble. */
+    const zAtras = { zDesde: BLOQUE.zFondo + 0.9, zHasta: -3.6 };
+    return {
+      /* TEMPLADO — el robledal cerrado */
+      roble: [
+        ...sembrar({ desde: templado.desde + 1, hasta: templado.hasta - 0.6, n: k(5), seed: 101, escMin: 1.05, escMax: 1.5, distMin: 2.6, ...zAtras }),
+        /* …y los dos robles trepados en la terraza del FRÍO: el roble andino
+           cruza el gradiente él solo (750–3.450 m) y esto es decirlo sin texto. */
+        ...sembrar({ desde: frio.desde + 1.4, hasta: frio.hasta - 1.4, n: k(2), seed: 102, escMin: 0.7, escMax: 0.92, distMin: 2.6, ...zAtras }),
+      ],
+      /* el gaque, domo denso de hoja gruesa: el sotobosque alto del robledal */
+      gaque: sembrar({ desde: templado.desde + 1, hasta: templado.hasta - 0.5, n: k(5), seed: 103, escMin: 0.9, escMax: 1.35, distMin: 1.6 }),
+      /* FRÍO — el alisal con su encenillo */
+      aliso: sembrar({ desde: frio.desde + 0.8, hasta: frio.hasta - 0.8, n: k(4), seed: 106, escMin: 0.85, escMax: 1.15, distMin: 2, ...zAtras }),
+      encenillo: sembrar({ desde: frio.desde + 0.8, hasta: frio.hasta - 0.8, n: k(3), seed: 107, escMin: 0.8, escMax: 1.05, distMin: 2, ...zAtras }),
+      /* PÁRAMO — el frailejonal manda */
+      frailejon: sembrar({ desde: paramo.desde + 0.6, hasta: paramo.hasta - 0.8, n: k(9), seed: 109, escMin: 1.05, escMax: 1.65, distMin: 1.15 }),
+      frailejonFlor: sembrar({ desde: paramo.desde + 0.8, hasta: paramo.hasta - 1, n: k(3), seed: 110, escMin: 1.1, escMax: 1.5, distMin: 1.6 }),
+      /* el matorral bajo, de una punta a otra de la ladera */
+      mortino: sembrar({ desde: templado.desde + 0.8, hasta: paramo.hasta - 0.6, n: k(16), seed: 111, escMin: 0.8, escMax: 1.2, distMin: 0.85 }),
+      romerillo: sembrar({ desde: frio.desde - 1.5, hasta: paramo.hasta - 0.6, n: k(14), seed: 112, escMin: 0.85, escMax: 1.25, distMin: 0.8 }),
+      musgo: sembrar({ desde: BLOQUE.xMin + 1, hasta: BLOQUE.xMax - 1, n: k(24), seed: 113, escMin: 0.8, escMax: 1.6, distMin: 0.55 }),
+      roca: sembrar({ desde: BLOQUE.xMin + 1, hasta: BLOQUE.xMax - 1, n: k(10), seed: 114, escMin: 0.7, escMax: 1.5, distMin: 1.2 }),
+    };
+  }, [denso]);
+
+  useEffect(() => () => {
+    [lomo, corte, faldon, piedras, agua, pozas, red].forEach((g) => g && g.dispose());
+    Object.values(geosVeg).forEach((g) => g && g.dispose());
+  }, [lomo, corte, faldon, piedras, agua, pozas, red, geosVeg]);
+
+  /* ── Materiales ── */
+  const matTierra = useMemo(
+    () => crearMaterialVertexColors(perfil, { flatShading: false, roughness: 1 }),
+    [perfil],
+  );
+  const matVeg = useMemo(() => crearMaterialVertexColors(perfil), [perfil]);
+  /*
+   * EL AGUA. La receta 'agua' de `materialesMadre` es para una lámina de COLOR
+   * PLANO y va con metalness 0,4 — que es lo correcto cuando hay un entorno que
+   * reflejar. Esta quebrada es otra cosa: lleva el color HORNEADO por vértice
+   * (hondo en el eje, lechoso en la orilla, espuma en los saltos) y la escena no
+   * tiene mapa de entorno. Con metalness 0,4 y nada que reflejar, el difuso se
+   * apaga y la quebrada sale NEGRA — se veía como un charco de alquitrán en vez
+   * de agua. Aquí es agua de día en ladera abierta: casi sin metal, con brillo,
+   * y la transparencia que la receta madre le da a lo único que la lleva.
+   */
+  const matAgua = useMemo(() => {
+    const base = { vertexColors: true, transparent: true, opacity: 0.92 };
+    return perfil?.materialRico
+      ? new THREE.MeshStandardMaterial({ ...base, roughness: 0.26, metalness: 0.06 })
+      : new THREE.MeshLambertMaterial(base);
+  }, [perfil]);
+  const matEspuma = useMemo(
+    () => new THREE.MeshBasicMaterial({ color: '#fdf7e8', transparent: true, opacity: 0.85 }),
+    [],
+  );
+  /* La red es LUZ, no materia: material sin sombreado para que se lea encendida
+     contra la tierra casi negra de su banda. La raíz, en cambio, viaja en el
+     mismo material que la tierra — es cosa. Ese contraste es la lección. */
+  const matRed = useMemo(
+    () => new THREE.MeshBasicMaterial({ vertexColors: true, toneMapped: false }),
+    [],
+  );
+  const matNodo = useMemo(
+    () => new THREE.MeshBasicMaterial({ color: '#ffffff', toneMapped: false }),
+    [],
+  );
+  /* El material de los pisos apagados: multiplica hacia abajo sin desaturar del
+     todo. Señalar un piso NO puede ser esconder los otros. */
+  const matApagado = useMemo(() => {
+    const m = crearMaterialVertexColors(perfil);
+    m.color = new THREE.Color('#6a6b60');
+    return m;
+  }, [perfil]);
+
+  useEffect(() => () => {
+    [matTierra, matVeg, matAgua, matEspuma, matRed, matNodo, matApagado].forEach((m) => m.dispose());
+  }, [matTierra, matVeg, matAgua, matEspuma, matRed, matNodo, matApagado]);
+
+  /* ¿Qué material le toca a la vegetación de un piso? */
+  const matDe = (piso) => (foco && foco !== piso ? matApagado : matVeg);
+
+  /* Los Ents se HUNDEN un palmo en la tierra. El pie del fuste es un anillo
+     abierto de radio 1,3 y el terreno ondula dentro de esa huella: apoyado al
+     ras, por el lado de abajo se le vería el hueco del tubo. */
+  const alturaDe = (p) => alturaLadera(p.x, p.z) - 0.22;
+
+  return (
+    <group name="ladera-tres-ents">
+      {/* ── EL BLOQUE ── */}
+      <mesh geometry={lomo} material={matTierra} receiveShadow />
+      <mesh geometry={corte} material={matTierra} receiveShadow />
+      <mesh geometry={faldon} material={matTierra} />
+      <mesh geometry={piedras} material={matTierra} castShadow receiveShadow />
+
+      {/* ── EL AGUA: nace arriba, se despeña dos veces, llega hecha quebrada ── */}
+      <mesh geometry={pozas} material={matAgua} />
+      <mesh geometry={agua} material={matAgua} />
+      <ChispasAgua
+        curva={curvaAgua}
+        n={tier === 'alto' ? 34 : tier === 'medio' ? 16 : 0}
+        reducedMotion={reducedMotion}
+        mat={matEspuma}
+      />
+
+      {/* ── LA RED DEL SUBSUELO: lo que amarra a los tres por debajo ── */}
+      <mesh geometry={red} material={matRed} />
+      <NodosRed nodos={nodos} reducedMotion={reducedMotion} mat={matNodo} />
+      {pulsos.length > 0 && (
+        <PulsosRed curva={curvaRed} pulsos={pulsos} reducedMotion={reducedMotion} mat={matNodo} />
+      )}
+
+      {/* ── LA VEGETACIÓN DE CADA PISO ── */}
+      <Banco geo={geosVeg.roble} mat={matDe('templado')} items={siembra.roble} castShadow={!!perfil?.sombras} />
+      <Banco geo={geosVeg.gaque} mat={matDe('templado')} items={siembra.gaque} />
+      <Banco geo={geosVeg.aliso} mat={matDe('frio')} items={siembra.aliso} castShadow={!!perfil?.sombras} />
+      <Banco geo={geosVeg.encenillo} mat={matDe('frio')} items={siembra.encenillo} />
+      <Banco geo={geosVeg.frailejon} mat={matDe('paramo')} items={siembra.frailejon} castShadow={!!perfil?.sombras} />
+      <Banco geo={geosVeg.frailejonFlor} mat={matDe('paramo')} items={siembra.frailejonFlor} />
+      <Banco geo={geosVeg.mortino} mat={matVeg} items={siembra.mortino} />
+      <Banco geo={geosVeg.romerillo} mat={matVeg} items={siembra.romerillo} />
+      <Banco geo={geosVeg.musgo} mat={matVeg} items={siembra.musgo} hundir={0.04} />
+      <Banco geo={geosVeg.roca} mat={matVeg} items={siembra.roca} hundir={0.12} />
+
+      {/* ══════════════════════════════════════════════════════════════════
+          LOS TRES ÁRBOLES MAESTROS
+          ══════════════════════════════════════════════════════════════════ */}
+
+      {/* EL ROBLE — templado y frío. Su mano señala las setas del pie. */}
+      <group position={[PISOS[0].x, alturaDe(PISOS[0]), PISOS[0].z]} rotation={[0, -0.16, 0]}>
+        <EntGradiente especie="roble" tier={tier} reducedMotion={reducedMotion} />
+      </group>
+
+      {/* EL ALISO — frío. Su mano señala los nódulos de Frankia de su raíz. */}
+      <group position={[PISOS[1].x, alturaDe(PISOS[1]), PISOS[1].z]} rotation={[0, 0.1, 0]}>
+        <EntGradiente especie="aliso" tier={tier} reducedMotion={reducedMotion} />
+      </group>
+
+      {/* LA QUEÑUA — páramo. El Ent que ya existía, traído tal cual: mismo
+          rostro tallado, misma barba de usnea, mismos brazos. Aquí en su casa,
+          arriba del todo, con el nacimiento del agua a sus pies. */}
+      <group position={[PISOS[2].x, alturaDe(PISOS[2]), PISOS[2].z]} rotation={[0, 0.22, 0]}>
+        <EntQuenua tier={tier} reducedMotion={reducedMotion} />
+      </group>
+    </group>
+  );
+}

--- a/src/visual/mundo3d/bosque/entsGradiente.geom.js
+++ b/src/visual/mundo3d/bosque/entsGradiente.geom.js
@@ -1,0 +1,1013 @@
+/*
+ * entsGradiente.geom — la GEOMETRÍA de los ÁRBOLES MAESTROS del gradiente
+ * andino: el ENT DEL ROBLE (templado y frío) y el ENT DEL ALISO (frío).
+ *
+ * El tercero del gradiente —la QUEÑUA del páramo— NO se redibuja aquí: es el
+ * `EntQuenua` que ya existe, traído tal cual desde su casa (`entQuenua.geom.js`
+ * + `EntQuenua.jsx`). Este módulo le pone DOS HERMANOS coherentes: la misma
+ * talla (rostro que emerge de la madera, brazos que caen con peso, raíces que
+ * agarran), pero cada uno con la forma, la corteza y la LECCIÓN de su especie.
+ *
+ * ── Qué es cierto de cada uno (y no se puede inventar más) ─────────────────
+ *
+ * ROBLE ANDINO · *Quercus humboldtii* · 750–3.450 msnm
+ *   Es el ÚNICO Quercus de Suramérica y cruza el gradiente él solo, del
+ *   templado hasta rozar el páramo. Forma robledales densos. Su lección son
+ *   las ECTOMICORRIZAS, y tiene cuatro géneros de hongo documentados:
+ *   *Cantharellus*, *Lactarius*, *Cenococcum* y *Tomentella*. Los dos primeros
+ *   sacan seta visible al pie del árbol — y son los dos que se dibujan; los
+ *   otros dos viven solo en el suelo y por eso no tienen cuerpo aquí. Suelos
+ *   poco profundos con capa gruesa de humus.
+ *
+ * ALISO · *Alnus acuminata* · Betulaceae · bosque altoandino
+ *   Fabrica su propio nitrógeno. Simbiosis DUAL: la bacteria *Frankia* le arma
+ *   NÓDULOS en la raíz que fijan el nitrógeno del aire, MÁS micorrizas endo y
+ *   ecto. Recupera suelos degradados: es el árbol que le regala abono al suelo.
+ *
+ * Nada más. Ni una hoja, ni un fruto, ni un color de especie que no venga de
+ * ahí o de la paleta ya aprobada (`floraParamo.geom.js` PAL, que es de donde
+ * salen los verdes y las cortezas del roble y del aliso del proyecto).
+ *
+ * ── Reglas de taller ───────────────────────────────────────────────────────
+ * · Todo pasa por `sombreadoVegetal.js`: `fusionarSeguro` es la ÚNICA fusión
+ *   (mergeGeometries devuelve NULL EN SILENCIO al mezclar indexadas con
+ *   no-indexadas y la pieza no se dibuja: ya mordió tres veces).
+ * · El CAMPO DEL ROSTRO no se reinventa: es `campoRostro` del Ent queñua, la
+ *   talla que ya pasó revisión. Lo que cambia por especie es la ESCALA de la
+ *   cáscara y su relieve, no la anatomía.
+ * · Three core puro: corre headless, sin contexto GL.
+ */
+import * as THREE from 'three';
+import {
+  rng,
+  ruidoFbm,
+  fusionarSeguro,
+  taperTronco,
+  taperLineal,
+  poner,
+  pintarPorVertice,
+  pintarPlano,
+  hornearFollaje,
+  matojoNube,
+} from './sombreadoVegetal.js';
+import { campoRostro, ROSTRO_BOCA_Y } from './entQuenua.geom.js';
+import { PAL } from './floraParamo.geom.js';
+import { TIERRAS, ACENTOS, CORTEZAS, VERDES, mezclar } from '../paleta/paletaMadre.js';
+
+/* Fusión canónica del taller. Las copas llevan normales RADIALES (matojoNube):
+   sin `preservarNormales` el merge las recalcula y la masa de hojas vuelve a
+   leerse como poliedro facetado. */
+const fusionar = (partes, etiqueta) => fusionarSeguro(partes, etiqueta, { preservarNormales: true });
+/* La madera SÍ quiere normales recalculadas: el facetado es parte del tallado. */
+const fusionarDura = (partes, etiqueta) => fusionarSeguro(partes, etiqueta);
+
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+const suave = (a, b, x) => {
+  const t = clamp01((x - a) / (b - a));
+  return t * t * (3 - 2 * t);
+};
+
+/* ══════════════════════════════════════════════════════════════════════════
+   PARÁMETROS POR TIER — el mismo contrato tier-safe del resto de la casa
+   ══════════════════════════════════════════════════════════════════════════ */
+export const PARAMS_TIER = {
+  alto: {
+    tubular: 96, radial: 14, segRostro: [52, 58], deform: 0.5,
+    hojasCopa: 1, ramas: 1, raices: 1, materialRico: true, flatShading: true,
+  },
+  medio: {
+    tubular: 60, radial: 10, segRostro: [38, 42], deform: 0.5,
+    hojasCopa: 0.7, ramas: 0.8, raices: 0.8, materialRico: false, flatShading: false,
+  },
+  bajo: {
+    tubular: 36, radial: 7, segRostro: [24, 28], deform: 0.45,
+    hojasCopa: 0.42, ramas: 0.6, raices: 0.6, materialRico: false, flatShading: false,
+  },
+};
+
+/** Parámetros para un tier (desconocido → 'medio', nunca el más caro). */
+export const paramsDeTier = (tier) => PARAMS_TIER[tier] || PARAMS_TIER.medio;
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LAS DOS ESPECIES — forma, corteza, hoja y lección
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * @typedef {object} EspecieEnt
+ * @property {string} id
+ * @property {number} altura          alto del fuste (metros-escena)
+ * @property {number} r0              radio del pie
+ * @property {number} r1              radio de la punta
+ * @property {number} rostroT         a qué altura del fuste (0..1) va la mirada
+ * @property {[number,number,number]} rostroEscala  escala del grupo del rostro
+ */
+
+/* El ROBLE: macizo, ancho, de corteza gris-parda profundamente fisurada y copa
+   en SOMBRILLA (la más ancha del dosel — así lo dibuja ya el roble del páramo).
+   El abuelo del gradiente: el que cruza los tres pisos él solo. */
+const ROBLE = {
+  id: 'roble',
+  nombre: 'El Ent del roble',
+  arbol: 'Roble andino',
+  cientifico: 'Quercus humboldtii',
+  piso: 'Templado y frío · de 750 a 3.450 m',
+  /* fuste: el más grueso de los tres — es el abuelo del gradiente */
+  altura: 8.2,
+  r0: 0.92,
+  r1: 0.16,
+  raigon: 0.42,
+  inclina: 0.05,
+  sinuoso: 0.055,
+  giro: 0.7,
+  semilla: 3,
+  /* corteza: fisuras hondas, grano grueso */
+  rugosidad: 1.0,
+  grano: { surcos: 9.0, fino: 17, bandas: 22, placas: 3.2 },
+  corteza: {
+    grieta: PAL.robleGrieta,
+    cuerpo: PAL.robleTronco,
+    cresta: PAL.robleCresta,
+    liquen: PAL.liquen,
+    hastaLiquen: 1.5,
+  },
+  /* hoja coriácea verde oscuro */
+  hoja: { base: PAL.robleHoja, sol: PAL.robleHoja2, luz: PAL.robleLuz },
+  /* rostro: ancho, pesado, de cejas de cornisa. La ESCALA no es a gusto — sale
+     de la proporción del rostro del queñual (la talla probada) llevada al
+     grosor de este fuste: ver `proporcionesRostro`. */
+  rostroT: 0.34,
+  rostroEscala: /** @type {[number,number,number]} */ ([1.87, 1.82, 1.43]),
+  relieve: 1.55,
+  musgoRostro: 0.5,
+  /* ramaje y copa */
+  ramas: { n: 6, desde: 0.56, hasta: 0.95, largo: 2.35, sube: 1.05, grosor: 0.4 },
+  /* La copa se levanta (`alturaExtra`) para dejarle AIRE al rostro: con la
+     sombrilla apoyada sobre las cejas, el roble se leía como un arbusto con
+     cara. Un Ent necesita fuste visible entre la cara y la copa. */
+  copa: { forma: 'domo', radio: 2.6, achatado: 0.6, alturaExtra: 1.15, lobulos: 8, radioLobulo: 1.38 },
+  raices: { n: 7, largo: 1.3, r0: 0.36 },
+  /* brazos: gruesos, cortos, de peso */
+  /* Los hombros van BAJO la frente: puestos en t=0,52 (que es donde los tiene
+     el queñual, cuyo rostro es más chico) las ramas-brazo le salían al roble
+     por encima de las cejas y se leían como astas, no como brazos. */
+  brazos: { tHombro: 0.46, drop: 2.3, abre: 2.05, r0: 0.3 },
+  /* el brazo maestro señala las setas del pie */
+  senala: { lado: 1, destino: [1.35, 0.16, 0.8], r0: 0.34 },
+};
+
+/* El ALISO: esbelto, erguido, de corteza gris clara casi lisa y copa en AGUJA
+   (el emergente delgado que pincha el dosel). El más joven de los tres: el que
+   llega primero al suelo cansado y lo levanta. */
+const ALISO = {
+  id: 'aliso',
+  nombre: 'El Ent del aliso',
+  arbol: 'Aliso',
+  cientifico: 'Alnus acuminata',
+  piso: 'Frío · bosque altoandino',
+  altura: 7.9,
+  r0: 0.62,
+  r1: 0.13,
+  raigon: 0.3,
+  inclina: 0.035,
+  sinuoso: 0.045,
+  giro: 2.1,
+  semilla: 5,
+  /* corteza LISA: el relieve baja a un tercio y el grano se hace fino */
+  rugosidad: 0.38,
+  grano: { surcos: 6.0, fino: 21, bandas: 30, placas: 1.5 },
+  corteza: {
+    grieta: PAL.alisoGrieta,
+    cuerpo: PAL.alisoTronco,
+    cresta: PAL.alisoCresta,
+    liquen: PAL.liquen2,
+    hastaLiquen: 1.1,
+  },
+  hoja: { base: PAL.alisoHoja, sol: PAL.alisoHoja2, luz: PAL.alisoLuz },
+  /* rostro: angosto y alto, de facciones más limpias (la corteza no se parte) */
+  rostroT: 0.35,
+  rostroEscala: /** @type {[number,number,number]} */ ([1.24, 1.36, 0.95]),
+  relieve: 1.2,
+  musgoRostro: 0.22,
+  ramas: { n: 5, desde: 0.6, hasta: 0.96, largo: 1.35, sube: 1.5, grosor: 0.3 },
+  /* La aguja se arma con lóbulos que TIENEN QUE TRASLAPARSE: con el radio muy
+     chico y el eje muy estirado, la copa se leía como una torre de bolas
+     sueltas con cielo entre una y otra, no como un solo penacho puntiagudo. */
+  copa: { forma: 'aguja', radio: 1.35, achatado: 0.86, alturaExtra: 1.9, lobulos: 8, radioLobulo: 0.92 },
+  raices: { n: 6, largo: 1.0, r0: 0.24 },
+  /* En un fuste delgado, un brazo grueso se lee como colmillo: el del aliso va
+     fino y nace bajo, a la altura del mentón. */
+  brazos: { tHombro: 0.47, drop: 2.3, abre: 1.5, r0: 0.155 },
+  /* el brazo maestro señala sus propios nódulos, al pie */
+  senala: { lado: -1, destino: [-1.5, 0.12, 1.75], r0: 0.24 },
+};
+
+export const ESPECIES = { roble: ROBLE, aliso: ALISO };
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL FUSTE — curva, conicidad y corteza
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * La espina del fuste: sube inclinándose y serpenteando apenas. Un árbol viejo
+ * peleado con el viento nunca es un eje recto, pero tampoco un zigzag: la
+ * desviación crece con la altura y abajo se mantiene aplomado (se lee UN palo).
+ */
+export function curvaFuste(esp) {
+  const r = rng(esp.semilla * 131 + 7);
+  const n = 7;
+  const pts = [];
+  for (let i = 0; i <= n; i++) {
+    const t = i / n;
+    const lean = esp.inclina * esp.altura * t * t;
+    const ang = esp.giro + t * Math.PI * 1.15;
+    const s = esp.sinuoso * esp.altura * (0.2 + t * 0.8);
+    pts.push(new THREE.Vector3(
+      Math.cos(esp.giro) * lean + Math.cos(ang) * s * (r() * 0.55 + 0.25),
+      esp.altura * t,
+      Math.sin(esp.giro) * lean + Math.sin(ang) * s * (r() * 0.55 + 0.25),
+    ));
+  }
+  return new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.45);
+}
+
+/**
+ * Conicidad del fuste: raigón ensanchado al pie (contrafuertes), adelgazamiento
+ * potencial hacia la copa, pulsos de nudo y un ENSANCHE DE HOMBROS donde nacen
+ * los brazos — eso último es lo que le da al fuste silueta de cuerpo y no de
+ * poste tapereado.
+ */
+export function taperFuste(esp) {
+  const base = taperTronco(esp.r0, esp.r1, esp.raigon);
+  const tH = esp.brazos.tHombro;
+  return (t) => {
+    const dh = (t - tH) / 0.12;
+    const hombro = esp.r0 * 0.11 * Math.exp(-dh * dh);
+    /* PECHO: un engrosamiento suave a la altura del rostro para que la cáscara
+       tallada tenga dónde vivir. Sin él, en el aliso (que es delgado) la cara
+       quedaba del tamaño de una moneda y no se leía. */
+    const dp = (t - esp.rostroT) / 0.16;
+    const pecho = esp.r0 * 0.1 * Math.exp(-dp * dp);
+    return Math.max(0.02, base(t) + hombro + pecho);
+  };
+}
+
+/**
+ * Relieve de la corteza en (t a lo largo, ang alrededor). Devuelve un factor
+ * relativo que multiplica el radio → surcos y placas REALES en la malla, no un
+ * normal-map. La amplitud la manda `esp.rugosidad`: el roble se parte en placas
+ * hondas, el aliso apenas se raya.
+ */
+export function relieveCorteza(esp, t, ang) {
+  const g = esp.grano;
+  const surcos = 0.075 * Math.sin(ang * g.surcos + t * 2.5);
+  const fino = 0.035 * Math.sin(ang * g.fino - t * 3);
+  const bandas = 0.035 * Math.sin(t * g.bandas + ang * 1.5);
+  const nudos = 0.055 * Math.sin(ang * 2 - t * 6.5) * Math.sin(t * Math.PI);
+  const placas = 0.085 * Math.tanh(Math.sin(ang * g.placas + Math.sin(t * 5.2) * 1.1 + t * 0.8) * 2.4);
+  const placasV = 0.045 * Math.tanh(Math.sin(t * 9 + ang * 0.6 + Math.sin(ang * 2) * 0.8) * 2.2);
+  const masAbajo = 1 + (1 - t) * 0.4; // el pie es más rugoso
+  return (surcos + fino + bandas + nudos + placas + placasV) * masAbajo * esp.rugosidad;
+}
+
+/** Color de corteza para un relieve dado: grieta honda → cuerpo → cresta pelada,
+    con el velo de líquen que trepa el pie. */
+export function colorCorteza(esp, disp, yMundo, destino = new THREE.Color()) {
+  const amp = 0.16 * Math.max(0.35, esp.rugosidad);
+  const n = clamp01((disp + amp) / (2 * amp));
+  destino.set(esp.corteza.grieta).lerp(new THREE.Color(esp.corteza.cuerpo), Math.min(1, n * 1.7));
+  if (n > 0.62) destino.lerp(new THREE.Color(esp.corteza.cresta), (n - 0.62) / 0.38);
+  const hasta = esp.corteza.hastaLiquen;
+  if (esp.corteza.liquen && yMundo < hasta) {
+    const m = ruidoFbm(yMundo * 3.1, disp * 9 + 5, yMundo * 1.7);
+    const cuanto = clamp01((hasta - yMundo) / hasta) * clamp01((m - 0.42) / 0.58);
+    destino.lerp(new THREE.Color(esp.corteza.liquen), cuanto * 0.6);
+  }
+  return destino;
+}
+
+/**
+ * TUBO DE MADERA sobre una curva: conicidad + corteza real + color horneado.
+ * Es la pieza con la que se hacen fuste, ramas, brazos y raíces.
+ *
+ * `bahia` excava el sector FRONTAL a la altura del rostro: el fuste se recoge y
+ * calma su corteza ahí para que ningún surco se asome por dentro de las cuencas
+ * ni de la boca. Sin la bahía, la cáscara tallada y el tronco se pelean y salen
+ * costras atravesando la cara (le pasó al queñual y por eso la bahía existe).
+ */
+export function tuboMadera(curva, esp, { tubular, radial, taper, semilla = 0, bahia = null, ampl = 1 }) {
+  const geo = new THREE.TubeGeometry(curva, tubular, 1, radial, false);
+  const pos = geo.attributes.position;
+  const nAnillo = radial + 1;
+
+  const centros = [];
+  for (let i = 0; i <= tubular; i++) centros.push(curva.getPointAt(i / tubular));
+
+  const colores = new Float32Array(pos.count * 3);
+  const v = new THREE.Vector3();
+  const off = new THREE.Vector3();
+  const c = new THREE.Color();
+
+  for (let k = 0; k < pos.count; k++) {
+    const anillo = Math.floor(k / nAnillo);
+    const j = k % nAnillo;
+    const t = anillo / tubular;
+    const ang = (j / radial) * Math.PI * 2 + semilla;
+    const centro = centros[Math.min(anillo, centros.length - 1)];
+
+    v.fromBufferAttribute(pos, k);
+    off.subVectors(v, centro);
+    let disp = relieveCorteza(esp, t, ang) * ampl;
+    let escBahia = 1;
+    if (bahia) {
+      const az = Math.atan2(Math.abs(off.x), off.z); // 0 = frente puro (+Z)
+      const mAng = 1 - suave(0.75, 1.15, az);
+      const mVert = 1 - suave(0.5, 0.85, Math.abs((centro.y - bahia.cy) / bahia.alto + 0.1));
+      const m = mAng * mVert;
+      disp *= 1 - 0.9 * m;
+      escBahia = 1 - 0.34 * m;
+    }
+    const radio = taper(t) * (1 + disp) * escBahia;
+    v.copy(centro).addScaledVector(off, radio);
+    pos.setXYZ(k, v.x, v.y, v.z);
+
+    colorCorteza(esp, disp, v.y, c);
+    colores[k * 3] = c.r;
+    colores[k * 3 + 1] = c.g;
+    colores[k * 3 + 2] = c.b;
+  }
+
+  geo.setAttribute('color', new THREE.BufferAttribute(colores, 3));
+  pos.needsUpdate = true;
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   RAMAS, BRAZOS Y RAÍCES
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/** Ramas del tercio alto: nacen por encima del rostro y trepan a la copa. */
+export function specsRamas(esp, n) {
+  const r = rng(esp.semilla * 21 + 11);
+  const curva = curvaFuste(esp);
+  const R = esp.ramas;
+  const specs = [];
+  const total = Math.max(2, n);
+  for (let i = 0; i < total; i++) {
+    const tBase = R.desde + ((R.hasta - R.desde) * i) / Math.max(1, total - 1);
+    const base = curva.getPointAt(tBase);
+    const ang = (i / total) * Math.PI * 2 + r() * 0.7 + esp.giro;
+    const largo = R.largo * (0.75 + r() * 0.4) * (1 - tBase * 0.3);
+    const dx = Math.cos(ang);
+    const dz = Math.sin(ang);
+    const sube = R.sube * (0.8 + r() * 0.45);
+    const pts = [
+      base.clone(),
+      base.clone().add(new THREE.Vector3(dx * largo * 0.34, sube * 0.3, dz * largo * 0.34)),
+      base.clone().add(new THREE.Vector3(
+        dx * largo * 0.7 + (r() - 0.5) * 0.3,
+        sube * 0.7,
+        dz * largo * 0.7 + (r() - 0.5) * 0.3,
+      )),
+      base.clone().add(new THREE.Vector3(dx * largo, sube, dz * largo)),
+    ];
+    const curve = new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
+    specs.push({
+      curve,
+      r0: Math.max(0.045, taperFuste(esp)(tBase) * R.grosor),
+      punta: pts[pts.length - 1].clone(),
+      tBase,
+    });
+  }
+  return specs;
+}
+
+/**
+ * Los BRAZOS del guardián: nacen de los hombros, abren, doblan el codo y CAEN
+ * con peso a los lados. Nunca tapan el rostro: lo enmarcan. El segundo brazo es
+ * el MAESTRO — baja hasta el suelo y su mano señala la lección de la especie
+ * (las setas del roble, los nódulos del aliso).
+ */
+export function specsBrazos(esp) {
+  const curva = curvaFuste(esp);
+  const B = esp.brazos;
+  const hombro = curva.getPointAt(B.tHombro);
+  const lado = -esp.senala.lado; // el brazo que cuelga va del lado contrario
+
+  const colgante = (() => {
+    const pts = [
+      hombro.clone(),
+      hombro.clone().add(new THREE.Vector3(lado * B.abre * 0.4, 0.12, 0.16)),
+      hombro.clone().add(new THREE.Vector3(lado * B.abre * 0.72, -B.drop * 0.33, 0.38)),
+      hombro.clone().add(new THREE.Vector3(lado * B.abre * 0.95, -B.drop * 0.74, 0.55)),
+      hombro.clone().add(new THREE.Vector3(lado * B.abre, -B.drop, 0.64)),
+    ];
+    return {
+      curve: new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.55),
+      r0: B.r0,
+      muneca: pts[pts.length - 1].clone(),
+      lado,
+      dedos: 'reposo',
+    };
+  })();
+
+  const maestro = (() => {
+    const S = esp.senala;
+    const hom = curva.getPointAt(B.tHombro + 0.03);
+    const fin = new THREE.Vector3(S.destino[0], S.destino[1] + 0.95, S.destino[2] - 0.35);
+    const pts = [
+      hom.clone(),
+      hom.clone().lerp(fin, 0.22).add(new THREE.Vector3(S.lado * 0.35, 0.16, 0.3)),
+      hom.clone().lerp(fin, 0.55).add(new THREE.Vector3(S.lado * 0.28, 0.02, 0.42)),
+      hom.clone().lerp(fin, 0.82).add(new THREE.Vector3(0, -0.08, 0.24)),
+      fin,
+    ];
+    return {
+      curve: new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5),
+      r0: S.r0,
+      muneca: fin.clone(),
+      lado: S.lado,
+      dedos: 'senala',
+      destino: new THREE.Vector3(S.destino[0], S.destino[1], S.destino[2]),
+    };
+  })();
+
+  return [colgante, maestro];
+}
+
+/** Raíces-contrafuerte: nacen altas en el pie, se abren y se HUNDEN. El tramo
+    profundo queda bajo tierra: se ve el raigón que agarra, nunca un palo tendido. */
+export function specsRaices(esp, n) {
+  const r = rng(esp.semilla * 33 + 5);
+  const R = esp.raices;
+  const specs = [];
+  const total = Math.max(3, n);
+  for (let i = 0; i < total; i++) {
+    const ang = (i / total) * Math.PI * 2 + r() * 0.5;
+    const largo = R.largo * (0.8 + r() * 0.45);
+    const dx = Math.cos(ang);
+    const dz = Math.sin(ang);
+    const pts = [
+      new THREE.Vector3(dx * 0.22, esp.r0 * 0.85, dz * 0.22),
+      new THREE.Vector3(dx * largo * 0.62, 0.16, dz * largo * 0.62),
+      new THREE.Vector3(dx * largo, -0.34, dz * largo),
+      new THREE.Vector3(dx * largo * 1.04, -0.95 - r() * 0.25, dz * largo * 1.04),
+    ];
+    specs.push({
+      curve: new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5),
+      r0: R.r0 * (0.85 + r() * 0.3),
+      ang,
+      largo,
+    });
+  }
+  return specs;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LA COPA — masa de hojas con huecos y silueta mordida
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * Los lóbulos de la copa. El ROBLE arma una SOMBRILLA: domo central aplanado y
+ * corona de lóbulos que se abren horizontal (hoja agrupada hacia la punta de
+ * las ramas). El ALISO arma una AGUJA: columna de lóbulos que se adelgazan
+ * hasta una punta fina. Esas dos siluetas son las que ya usa la flora del
+ * proyecto para el roble y el aliso, y a treinta metros son lo que los separa.
+ */
+export function lobulosCopa(esp, puntasRama) {
+  const r = rng(esp.semilla * 51 + 3);
+  const curva = curvaFuste(esp);
+  const cima = curva.getPointAt(1);
+  const C = esp.copa;
+  const lobs = [];
+
+  if (C.forma === 'aguja') {
+    const n = C.lobulos;
+    for (let i = 0; i < n; i++) {
+      const f = i / (n - 1); // 0 base → 1 punta
+      const ang = r() * Math.PI * 2;
+      const rad = C.radio * (1 - f * 0.9) * (0.35 + r() * 0.6);
+      lobs.push({
+        c: [cima.x + Math.cos(ang) * rad, cima.y - 1.5 + f * (C.alturaExtra + 1.6) + r() * 0.16, cima.z + Math.sin(ang) * rad],
+        radio: C.radioLobulo * (1 - f * 0.45) + r() * 0.1,
+      });
+    }
+    // las puntas de rama sostienen matojos chicos: la aguja no flota sobre nada
+    for (const p of puntasRama) {
+      lobs.push({ c: [p.x, p.y + 0.16, p.z], radio: C.radioLobulo * (0.5 + r() * 0.2) });
+    }
+    return lobs;
+  }
+
+  // DOMO ancho (roble)
+  lobs.push({ c: [cima.x, cima.y + C.alturaExtra, cima.z], radio: C.radioLobulo * 1.12 });
+  for (const p of puntasRama) {
+    lobs.push({ c: [p.x * 1.06, p.y + 0.3, p.z * 1.06], radio: C.radioLobulo * (0.78 + r() * 0.3) });
+  }
+  const n = C.lobulos;
+  for (let i = 0; i < n; i++) {
+    const ang = (i / n) * Math.PI * 2 + r() * 0.55;
+    const rad = C.radio * (0.62 + r() * 0.5);
+    lobs.push({
+      c: [cima.x + Math.cos(ang) * rad, cima.y + C.alturaExtra * (0.2 + r() * 0.6) - 0.35, cima.z + Math.sin(ang) * rad],
+      radio: C.radioLobulo * (0.6 + r() * 0.36),
+    });
+  }
+  return lobs;
+}
+
+/**
+ * La copa entera en UNA geometría: cada lóbulo es una nube de follaje
+ * (`matojoNube`, normales radiales = masa suave, no poliedro) con el sombreado
+ * horneado por vértice — oclusión hacia el corazón, gradiente de altura y
+ * contraluz en la piel. Es lo que separa una copa creíble de una bola de
+ * helado, y es gratis en runtime.
+ */
+export function construirCopa(esp, P, puntasRama) {
+  const lobs = lobulosCopa(esp, puntasRama);
+  const partes = [];
+  let i = 0;
+  for (const L of lobs) {
+    const radio = L.radio * (P.hojasCopa < 0.6 ? 1.12 : 1); // menos lóbulos → algo más gordos
+    const geo = matojoNube(radio, esp.semilla * 17 + i * 7, P.deform);
+    poner(geo, L.c);
+    hornearFollaje(geo, {
+      base: esp.hoja.base,
+      sol: esp.hoja.sol,
+      luz: esp.hoja.luz,
+      centro: L.c,
+      radio,
+      ao: 0.62,
+      manchas: 0.15,
+    });
+    partes.push(geo);
+    i += 1;
+  }
+  return fusionar(partes, `copa-${esp.id}`);
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL ROSTRO — la cáscara tallada sobre la madera
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/** Dónde vive el rostro: centro sobre la curva y radio del fuste ahí. */
+export function anclaRostro(esp) {
+  const curva = curvaFuste(esp);
+  const centro = curva.getPointAt(esp.rostroT);
+  const radio = taperFuste(esp)(esp.rostroT);
+  return { centro, radio, t: esp.rostroT };
+}
+
+/*
+ * LA REGLA DE LA ESCALA DEL ROSTRO (para el que venga a agregar una cuarta
+ * especie y no quiera romper la talla):
+ *
+ * El ANCHO del rostro en el mundo NO lo decide `rostroEscala`: lo decide el
+ * radio del fuste, porque la cáscara abraza el tronco (ancho ≈ 2·R·sen 1.4).
+ * `rostroEscala[1]` decide el ALTO. Entonces, para que un Ent nuevo tenga la
+ * misma CARA que el queñual —que es la que pasó revisión— y no una careta
+ * estirada, las tres escalas se derivan de su radio:
+ *
+ *   E[0] ≈ 2.45 · R      (cuánto del campo del rostro cubre la cáscara)
+ *   E[1] ≈ 1.68 · R/0.661 (el alto, proporcional al ancho)
+ *   E[2] ≈ 0.765 · E[0]  (la profundidad, aplanada como en el queñual)
+ *
+ * donde 0.661 es el radio del fuste del queñual a la altura de su mirada y
+ * [1.62, 1.68, 1.24] es su escala. De ahí salen los números del roble y del
+ * aliso; desviarse de la proporción es legítimo (el roble tiene la cara más
+ * cuadrada, el aliso más larga), inventarla desde cero no.
+ */
+
+/**
+ * Las proporciones locales del rostro, derivadas del fuste. Los ojos y la boca
+ * viven en coordenadas LOCALES del grupo del rostro; si se calcaran los números
+ * del queñual, en un fuste más delgado los ojos quedarían FUERA de la cáscara
+ * (o enterrados dentro del tronco: el bug de "ojos de calavera").
+ * Todo se deriva de `frenteL` = dónde está la superficie de la cáscara.
+ */
+export function proporcionesRostro(esp) {
+  const { radio } = anclaRostro(esp);
+  const frenteL = radio / esp.rostroEscala[2]; // z local de la superficie frontal
+  return {
+    frenteL,
+    zOjo: frenteL * 0.6, // el ojo vive HUNDIDO en su cuenca
+    zBoca: frenteL * 0.82, // la cavidad tras la boca-grieta
+    sepOjo: 0.245, // separación de los ojos (la talla del queñual, probada)
+  };
+}
+
+/**
+ * La CÁSCARA del rostro: una malla paramétrica densa que abraza el fuste (sigue
+ * su curva, su conicidad y su corteza) y sobre la que `campoRostro` talla el
+ * relieve REAL. El rostro EMERGE de la madera: no es una careta pegada.
+ *
+ * Devuelve DOS geometrías: `cara` (de la línea de la boca hacia arriba) y
+ * `mandibula` (labio inferior + mentón) con el origen en la línea de la boca,
+ * para poder pivotarla al hablar.
+ */
+export function mallaRostro(esp, { segRostro = [48, 54] } = {}) {
+  const curva = curvaFuste(esp);
+  const taper = taperFuste(esp);
+  const centro = curva.getPointAt(esp.rostroT);
+  const E = esp.rostroEscala;
+  const [segU, segV] = segRostro;
+  const angMax = 1.4; // medio-abanico: la cara ocupa buena parte del frente
+
+  const construye = (yMin, yMax, pivotY, filas, wBajo, wAlto) => {
+    const cols = segU + 1;
+    const rows = filas + 1;
+    const pos = new Float32Array(cols * rows * 3);
+    const col = new Float32Array(cols * rows * 3);
+    const idx = [];
+    const c = new THREE.Color();
+    const liquen = new THREE.Color(esp.corteza.liquen);
+    const cresta = new THREE.Color(esp.corteza.cresta);
+    for (let iv = 0; iv < rows; iv++) {
+      const vN = iv / filas;
+      const y = yMin + (yMax - yMin) * vN;
+      const t = Math.max(0.02, Math.min(0.98, esp.rostroT + (y * E[1]) / esp.altura));
+      const R = taper(t);
+      const pC = curva.getPointAt(t);
+      const offX = (pC.x - centro.x) / E[0];
+      const offZ = (pC.z - centro.z) / E[2];
+      for (let iu = 0; iu < cols; iu++) {
+        const uN = iu / segU;
+        const ang = (uN * 2 - 1) * angMax;
+        const xl = (Math.sin(ang) * R) / E[0];
+        const { d, sombra, musgo } = campoRostro(xl, y);
+        const m = Math.exp(-((xl / 0.56) ** 2 + ((y + 0.08) / 0.66) ** 2));
+        const bark = relieveCorteza(esp, t, ang + 0.6) * (0.35 + 0.65 * (1 - m));
+        const eU = suave(0.7, 1, Math.abs(ang) / angMax);
+        const eV = Math.max(wAlto * suave(0.78, 1, vN), wBajo * suave(0.78, 1, 1 - vN));
+        const borde = Math.max(eU, eV);
+        const relieve = d * esp.relieve * m;
+        const f = (1 + relieve * (1 - borde) + bark) * (1 - 0.28 * borde);
+        const k = (iv * cols + iu) * 3;
+        pos[k] = (Math.sin(ang) * R * f) / E[0] + offX;
+        pos[k + 1] = y - pivotY;
+        pos[k + 2] = (Math.cos(ang) * R * f) / E[2] + offZ;
+        colorCorteza(esp, bark + d * 0.9, pC.y, c);
+        if (m > 0.2) c.lerp(cresta, m * 0.12);
+        if (d > 0.12) c.lerp(cresta, Math.min(0.28, (d - 0.12) * 1.4));
+        if (musgo > 0.03) c.lerp(liquen, Math.min(0.55, musgo * esp.musgoRostro) * m);
+        c.multiplyScalar(1 - 0.6 * sombra * (1 - borde));
+        col[k] = c.r;
+        col[k + 1] = c.g;
+        col[k + 2] = c.b;
+      }
+    }
+    for (let iv = 0; iv < filas; iv++) {
+      for (let iu = 0; iu < segU; iu++) {
+        const a = iv * cols + iu;
+        const b = a + 1;
+        const cc = a + cols;
+        const dd = cc + 1;
+        idx.push(a, b, cc, b, dd, cc);
+      }
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+    geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+    geo.setIndex(idx);
+    geo.computeVertexNormals();
+    return geo;
+  };
+
+  const filasCara = Math.max(8, Math.round(segV * 0.72));
+  const filasMand = Math.max(6, segV - filasCara);
+  return {
+    cara: construye(ROSTRO_BOCA_Y, 0.78, 0, filasCara, 0.18, 1),
+    mandibula: construye(-0.98, ROSTRO_BOCA_Y, ROSTRO_BOCA_Y, filasMand, 1, 0.18),
+  };
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LAS PIEZAS DEL ÁRBOL COMPLETO
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * La MADERA de un Ent en UNA geometría: fuste (con la bahía del rostro
+ * excavada) + ramas + los dos brazos. Un solo draw-call para todo el cuerpo.
+ */
+export function construirMadera(esp, P) {
+  const curva = curvaFuste(esp);
+  const taper = taperFuste(esp);
+  const partes = [];
+
+  partes.push(tuboMadera(curva, esp, {
+    tubular: P.tubular,
+    radial: P.radial,
+    taper,
+    semilla: 0.6,
+    bahia: { cy: curva.getPointAt(esp.rostroT).y, alto: esp.altura * 0.26 },
+  }));
+
+  const ramas = specsRamas(esp, Math.max(2, Math.round(esp.ramas.n * P.ramas)));
+  for (const rama of ramas) {
+    partes.push(tuboMadera(rama.curve, esp, {
+      tubular: Math.max(14, Math.round(P.tubular * 0.34)),
+      radial: Math.max(5, P.radial - 4),
+      taper: taperLineal(rama.r0, 0.035),
+      semilla: rama.tBase * 10,
+      ampl: 0.8,
+    }));
+  }
+
+  for (const b of specsBrazos(esp)) {
+    partes.push(tuboMadera(b.curve, esp, {
+      tubular: Math.max(16, Math.round(P.tubular * 0.36)),
+      radial: Math.max(5, P.radial - 4),
+      taper: taperLineal(b.r0, b.dedos === 'senala' ? 0.09 : 0.075),
+      semilla: 2 + b.lado * 1.7,
+      ampl: 0.75,
+    }));
+  }
+
+  return { geo: fusionarDura(partes, `madera-${esp.id}`), ramas, brazos: specsBrazos(esp) };
+}
+
+/** Las RAÍCES-contrafuerte en UNA geometría (van fuera del balanceo: agarran). */
+export function construirRaices(esp, P) {
+  const raices = specsRaices(esp, Math.max(3, Math.round(esp.raices.n * P.raices)));
+  const partes = raices.map((rz, i) => tuboMadera(rz.curve, esp, {
+    tubular: 16,
+    radial: Math.max(5, P.radial - 5),
+    taper: taperLineal(rz.r0, 0.05),
+    semilla: i,
+    ampl: 0.7,
+  }));
+  return { geo: fusionarDura(partes, `raices-${esp.id}`), raices };
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LAS DOS LECCIONES, HECHAS COSA
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* Los colores de las dos setas del roble. Cantharellus es amarillo yema y sale
+   del oro del textil andino; Lactarius es anaranjado y se deriva del cobre del
+   siete cueros — ningún hex nuevo, todo derivado de la paleta madre. */
+const SETAS = {
+  cantarelo: new THREE.Color(ACENTOS.guayacan),
+  cantareloHondo: new THREE.Color(mezclar(ACENTOS.guayacan, TIERRAS.arcilla, 0.42)),
+  cantareloPie: new THREE.Color(mezclar(ACENTOS.maizTextil, TIERRAS.camino, 0.35)),
+  lactario: new THREE.Color(CORTEZAS.sieteCuerosClaro),
+  lactarioZona: new THREE.Color(mezclar(CORTEZAS.sieteCueros, TIERRAS.arcilla, 0.3)),
+  lactarioPie: new THREE.Color(mezclar(CORTEZAS.sieteCuerosClaro, TIERRAS.camino, 0.45)),
+};
+
+/**
+ * UN CANTARELO (*Cantharellus*): embudo de borde ondulado, amarillo yema, con
+ * los pliegues corriendo por fuera hacia el pie. No tiene láminas de cuchillo:
+ * tiene arrugas que bajan — por eso el sombrero se dibuja como una trompeta
+ * hundida en el centro y no como una sombrilla.
+ */
+function geomCantarelo(alto, q, seed) {
+  const r = rng(seed);
+  const partes = [];
+  const segR = Math.max(9, Math.round(16 * q));
+
+  // el embudo: perfil de revolución hundido en el centro y abierto en el borde
+  const perfil = [];
+  const pasos = Math.max(6, Math.round(10 * q));
+  for (let i = 0; i <= pasos; i++) {
+    const f = i / pasos;
+    const rad = alto * (0.06 + f * 0.52);
+    const y = alto * (0.62 + Math.pow(f, 1.7) * 0.42 - f * 0.06);
+    perfil.push(new THREE.Vector2(Math.max(0.005, rad), y));
+  }
+  const sombrero = new THREE.LatheGeometry(perfil, segR);
+  // borde ondulado: el cantarelo nunca tiene el filo recto
+  const pos = sombrero.attributes.position;
+  const v = new THREE.Vector3();
+  for (let i = 0; i < pos.count; i++) {
+    v.fromBufferAttribute(pos, i);
+    const rad = Math.hypot(v.x, v.z);
+    const ang = Math.atan2(v.z, v.x);
+    const borde = clamp01((rad / (alto * 0.58) - 0.55) / 0.45);
+    const onda = Math.sin(ang * 5 + seed) * alto * 0.09 * borde;
+    pos.setXYZ(i, v.x, v.y + onda, v.z);
+  }
+  pos.needsUpdate = true;
+  sombrero.computeVertexNormals();
+  pintarPorVertice(sombrero, (x, y, z, i, c) => {
+    const rad = Math.hypot(x, z) / (alto * 0.58);
+    c.copy(SETAS.cantareloHondo).lerp(SETAS.cantarelo, clamp01(rad * 1.25));
+    return c;
+  });
+  partes.push(sombrero);
+
+  // el pie: corto, grueso y del mismo amarillo apagado
+  const pie = new THREE.CylinderGeometry(alto * 0.11, alto * 0.16, alto * 0.66, Math.max(6, Math.round(9 * q)));
+  poner(pie, [0, alto * 0.33, 0], [0, 0, 0], [1, 1, 1]);
+  partes.push(pintarPlano(pie, SETAS.cantareloPie));
+
+  const g = fusionarDura(partes, 'cantarelo');
+  // una inclinación mínima: ninguna seta crece a plomo
+  poner(g, [0, 0, 0], [(r() - 0.5) * 0.24, r() * Math.PI * 2, (r() - 0.5) * 0.24]);
+  return g;
+}
+
+/**
+ * UN LACTARIO (*Lactarius*): sombrero convexo que se hunde en el centro, con
+ * ZONAS CONCÉNTRICAS más oscuras — esa es su firma y por eso el color se pinta
+ * por radio, en anillos. Anaranjado.
+ */
+function geomLactario(alto, q, seed) {
+  const r = rng(seed);
+  const partes = [];
+  const segR = Math.max(9, Math.round(16 * q));
+
+  const perfil = [];
+  const pasos = Math.max(6, Math.round(10 * q));
+  for (let i = 0; i <= pasos; i++) {
+    const f = i / pasos;
+    const rad = alto * (0.05 + f * 0.62);
+    // convexo con el centro deprimido: sube en el aro medio y baja en el filo
+    const y = alto * (0.72 + Math.sin(f * Math.PI * 0.82) * 0.16 - f * 0.14);
+    perfil.push(new THREE.Vector2(Math.max(0.005, rad), y));
+  }
+  const sombrero = new THREE.LatheGeometry(perfil, segR);
+  pintarPorVertice(sombrero, (x, y, z, i, c) => {
+    const rad = Math.hypot(x, z) / (alto * 0.67);
+    const anillo = 0.5 + 0.5 * Math.sin(rad * 13.5 + seed); // las zonas concéntricas
+    c.copy(SETAS.lactario).lerp(SETAS.lactarioZona, anillo * 0.55 + (1 - clamp01(rad)) * 0.18);
+    return c;
+  });
+  partes.push(sombrero);
+
+  const pie = new THREE.CylinderGeometry(alto * 0.1, alto * 0.13, alto * 0.72, Math.max(6, Math.round(9 * q)));
+  poner(pie, [0, alto * 0.36, 0]);
+  partes.push(pintarPlano(pie, SETAS.lactarioPie));
+
+  const g = fusionarDura(partes, 'lactario');
+  poner(g, [0, 0, 0], [(r() - 0.5) * 0.2, r() * Math.PI * 2, (r() - 0.5) * 0.2]);
+  return g;
+}
+
+/**
+ * EL CORRO DE SETAS AL PIE DEL ROBLE — la prueba visible del trato.
+ *
+ * Cuatro géneros de hongo le forran las raíces al roble (Cantharellus,
+ * Lactarius, Cenococcum, Tomentella). Solo los DOS primeros sacan cuerpo
+ * fructífero a la superficie: son los únicos que se dibujan. Los otros dos
+ * trabajan abajo y su lugar es la red del subsuelo, no el suelo del bosque.
+ * Cuando el campesino ve estas setas, el trato está andando.
+ */
+/*
+ * SOBRE EL TAMAÑO DE LAS SETAS: un cantarelo real mide ocho centímetros y el
+ * roble veinticinco metros. A escala honesta, la lección sería INVISIBLE — un
+ * píxel al pie del árbol. Aquí van a media altura de rodilla del Ent, que es la
+ * misma licencia con la que el guardián tiene cara: en este mundo lo que hay
+ * que entender se dibuja del tamaño en que se entiende. Lo que NO se estira es
+ * la BOTÁNICA: la forma de embudo del cantarelo, sus pliegues que bajan por
+ * fuera y las zonas concéntricas del lactario son las de verdad.
+ */
+export function geomSetasDelRoble({ q = 1 } = {}, seed = 909) {
+  const r = rng(seed);
+  const partes = [];
+  const grupos = Math.max(3, Math.round(6 * q));
+  for (let i = 0; i < grupos; i++) {
+    const cantarelo = i % 2 === 0;
+    const ang = r() * Math.PI * 2;
+    const rad = 0.5 + r() * 1.3;
+    const cx = Math.cos(ang) * rad;
+    /* El corro se sesga apenas hacia el frente (para que se vea) pero NO se
+       estira hasta el cauce: unas setas creciendo dentro de la quebrada serían
+       una mentira botánica y además se verían atravesadas por el agua. */
+    const cz = Math.sin(ang) * rad * 0.7 + 0.2;
+    const cuantas = cantarelo ? 2 + Math.floor(r() * 2) : 1 + Math.floor(r() * 2);
+    for (let k = 0; k < cuantas; k++) {
+      const alto = (cantarelo ? 0.62 : 0.54) * (0.78 + r() * 0.5);
+      const g = cantarelo
+        ? geomCantarelo(alto, q, seed + i * 13 + k)
+        : geomLactario(alto, q, seed + i * 13 + k + 7);
+      poner(g, [cx + (r() - 0.5) * 0.34, 0, cz + (r() - 0.5) * 0.3]);
+      partes.push(g);
+    }
+  }
+  return fusionarDura(partes, 'setas-del-roble');
+}
+
+/* Los NÓDULOS de *Frankia*: racimos de lóbulos leñosos pegados a la raíz. Su
+   color sale de la tierra roja andina y del ámbar — no son un objeto extraño en
+   el suelo, son raíz hinchada.
+   OJO CON EL VALOR: derivados hacia la raicilla oscura quedaban casi negros, y
+   al pie del árbol (que además está en sombra propia) el racimo se leía como un
+   tizón quemado. La fábrica de abono tiene que verse VIVA. */
+const NODULO = {
+  cuerpo: new THREE.Color(mezclar(TIERRAS.arcilla, ACENTOS.ambar, 0.25)),
+  punta: new THREE.Color(mezclar(TIERRAS.camino, ACENTOS.ambar, 0.45)),
+};
+
+/**
+ * LOS NÓDULOS DE FRANKIA EN LAS RAÍCES DEL ALISO — la fábrica de abono.
+ *
+ * La bacteria *Frankia* vive dentro de estos bultos y toma el nitrógeno del
+ * aire; el aliso le da casa y comida y se queda con el abono. Se dibujan como
+ * racimos de coral: muchos lóbulos chicos apiñados sobre la raíz, no una bola
+ * lisa (un nódulo actinorrícico real es lobulado y se ramifica con los años).
+ *
+ * @param {{curve: THREE.Curve, r0: number}[]} raices  las raíces donde prenden.
+ */
+export function geomNodulosFrankia(raices, { q = 1 } = {}, seed = 515) {
+  const r = rng(seed);
+  const partes = [];
+  const porRaiz = Math.max(1, Math.round(2 * q));
+  for (let i = 0; i < raices.length; i++) {
+    const rz = raices[i];
+    for (let k = 0; k < porRaiz; k++) {
+      const t = 0.34 + r() * 0.38; // en el tramo de raíz que aún se ve
+      const p = rz.curve.getPointAt(Math.min(0.98, t));
+      if (p.y < -0.28) continue; // los muy hondos quedarían enterrados: no se ven
+      const esc = 0.13 + r() * 0.07;
+      const lobulos = Math.max(3, Math.round(5 * q));
+      for (let j = 0; j < lobulos; j++) {
+        const a = r() * Math.PI * 2;
+        const b = (r() - 0.5) * 1.4;
+        const rad = esc * (0.55 + r() * 0.7);
+        const lob = new THREE.IcosahedronGeometry(rad, 0);
+        poner(
+          lob,
+          [
+            p.x + Math.cos(a) * esc * 1.15,
+            p.y + b * esc * 1.2 + esc * 0.4,
+            p.z + Math.sin(a) * esc * 1.15,
+          ],
+          [r(), r(), r()],
+          [1, 0.82, 1],
+        );
+        const cerca = j / lobulos;
+        partes.push(pintarPlano(lob, NODULO.cuerpo.clone().lerp(NODULO.punta, cerca * 0.7)));
+      }
+    }
+  }
+  if (!partes.length) return null;
+  return fusionarDura(partes, 'nodulos-frankia');
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LAS LECCIONES EN PALABRAS — español de Colombia, tratando de usted
+   ══════════════════════════════════════════════════════════════════════════ */
+export const LECCIONES = {
+  roble: {
+    id: 'roble',
+    boton: 'El roble',
+    titulo: 'El roble andino y sus cuatro hongos',
+    arbol: 'Roble andino · Quercus humboldtii',
+    piso: 'Templado y frío · de 750 a 3.450 metros',
+    texto:
+      'Es el único roble de Suramérica y cruza el gradiente él solo: arranca en el '
+      + 'templado y sube hasta rozar el páramo, formando robledales cerrados. Bajo su '
+      + 'sombra hay un trato firmado: cuatro hongos —Cantharellus, Lactarius, '
+      + 'Cenococcum y Tomentella— le forran las raíces con ectomicorrizas y le buscan '
+      + 'agua y minerales lejos de donde el árbol alcanza; él les paga con azúcar de '
+      + 'sus hojas. Los dos primeros sacan la seta al pie del árbol: cuando usted las '
+      + 've, el trato está andando. Necesita suelo poco profundo pero con capa gruesa '
+      + 'de humus encima.',
+  },
+  aliso: {
+    id: 'aliso',
+    boton: 'El aliso',
+    titulo: 'El aliso fabrica su propio abono',
+    arbol: 'Aliso · Alnus acuminata (Betulaceae)',
+    piso: 'Frío · bosque altoandino',
+    texto:
+      'Esta es la lección que más le sirve a usted en la finca. El aliso no espera a '
+      + 'que le abonen: en sus raíces la bacteria Frankia arma nódulos que toman el '
+      + 'nitrógeno del aire y lo dejan en el suelo. Y encima lleva micorrizas de los '
+      + 'dos tipos, endo y ecto. Por eso levanta suelos degradados: donde usted siembra '
+      + 'aliso, la tierra queda mejor de lo que estaba.',
+  },
+  quenua: {
+    id: 'quenua',
+    boton: 'La queñua',
+    titulo: 'La queñua es una fábrica de agua',
+    arbol: 'Queñua o colorado · Polylepis',
+    piso: 'Páramo',
+    texto:
+      'Es el árbol que llega más arriba y la que empieza esta historia. Su copa y el '
+      + 'musgo que la viste peinan la niebla, el agua escurre por el tronco y el suelo '
+      + 'de páramo la guarda como una esponja. De ahí abajo sale la quebrada que riega '
+      + 'el bosque frío y llega al templado.',
+  },
+  juntos: {
+    id: 'juntos',
+    boton: 'Los tres',
+    titulo: 'Los tres son un solo gradiente',
+    arbol: 'El gradiente andino',
+    piso: 'Del páramo al templado',
+    texto:
+      'No son tres árboles sueltos: son la misma ladera a tres alturas. El agua nace '
+      + 'arriba en el páramo, baja por el bosque frío y llega al templado. Y por debajo, '
+      + 'la red de micorrizas amarra las raíces de los tres, así que lo que pasa arriba '
+      + 'se siente abajo. Si le tumban el páramo, el roble del templado se entera.',
+  },
+};
+
+/* Verdes por piso térmico, para teñir la vegetación de cada terraza. Salen del
+   eje térmico de la paleta madre: a más altura, menos saturación y más plata. */
+export const TINTE_PISO = {
+  templado: { base: VERDES.monte, sol: VERDES.templado, luz: VERDES.brote },
+  frio: { base: mezclar(VERDES.frio, VERDES.paramoNiebla, 0.4), sol: VERDES.frio, luz: VERDES.aliso },
+  paramo: { base: VERDES.paramoMusgo, sol: VERDES.paramoLiquen, luz: VERDES.paramoPlata },
+};

--- a/src/visual/mundo3d/bosque/gradienteAndino.geom.js
+++ b/src/visual/mundo3d/bosque/gradienteAndino.geom.js
@@ -1,0 +1,969 @@
+/*
+ * gradienteAndino.geom — LA LADERA donde viven los tres Ents, cortada como una
+ * lámina de Humboldt.
+ *
+ * De qué se trata
+ * ───────────────
+ * Los tres árboles maestros no son tres demos sueltos: son la MISMA ladera a
+ * tres alturas. Para que eso se vea y no haya que explicarlo, el mundo entero
+ * es UN BLOQUE DE MONTAÑA CORTADO — el mismo recurso con el que Humboldt
+ * dibujó el Chimborazo: el perfil de la ladera con sus fajas de vegetación, y
+ * lo que pasa por dentro a la vista.
+ *
+ *   ARRIBA, sobre el lomo del bloque: tres terrazas —templado, frío, páramo—
+ *   cada una con su Ent y su vegetación, y EL AGUA que nace en el páramo,
+ *   se despeña dos veces y llega abajo hecha quebrada.
+ *
+ *   ABAJO, en la cara cortada: los horizontes del suelo (hojarasca, humus,
+ *   zona de raíces, red micorrízica, roca madre) y LA RED DE MICORRIZAS que
+ *   amarra las raíces de los tres árboles a lo largo de toda la ladera.
+ *
+ * Las dos corrientes son la lección entera y van en espejo: el agua BAJA por
+ * encima, el alimento CIRCULA por debajo. Si le tumban el páramo, el roble del
+ * templado se entera.
+ *
+ * ── Reglas de taller ───────────────────────────────────────────────────────
+ * · `fusionarSeguro` es la ÚNICA fusión (mergeGeometries devuelve NULL EN
+ *   SILENCIO al mezclar indexadas con no-indexadas y la pieza no se dibuja).
+ * · Los colores de los horizontes son EXACTAMENTE los de la vitrina del corte
+ *   (`corteSuelo.geom.js` CAPAS) y los de la red son los del mundo de las
+ *   micorrizas (`micorrizas.geom.js` PALETA): la lección del suelo en Chagra
+ *   es una sola y no puede verse distinta según por dónde se entre.
+ * · Three core puro: corre headless, sin contexto GL.
+ */
+import * as THREE from 'three';
+import {
+  rng,
+  ruidoFbm,
+  fusionarSeguro,
+  tuboOrganico,
+  poner,
+  pintarPorVertice,
+  pintarPlano,
+} from './sombreadoVegetal.js';
+import { PALETA as MICO } from '../micorrizas/micorrizas.geom.js';
+import { TIERRAS, VERDES, AGUAS, NEUTROS, mezclar } from '../paleta/paletaMadre.js';
+
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+const suave = (a, b, x) => {
+  const t = clamp01((x - a) / (b - a));
+  return t * t * (3 - 2 * t);
+};
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL BLOQUE — medidas de la ladera cortada
+   ══════════════════════════════════════════════════════════════════════════ */
+export const BLOQUE = {
+  xMin: -14,
+  xMax: 14,
+  zFrente: 3.4, // el plano del corte: mira a la cámara
+  zFondo: -7.4,
+  /* Hasta dónde baja el bloque. Es una decisión de ENCUADRE, no de geología:
+     cada metro que baja es un metro de tierra oscura que hay que meter en el
+     cuadro y que le quita aire a las copas. Lo justo para que la banda de
+     micorrizas del piso más bajo quede DENTRO del bloque y no colgando. */
+  yFondo: -5.0,
+};
+
+/* Las tres terrazas del gradiente. El desnivel entre una y otra es de 3,6
+   metros-escena: suficiente para que la ladera SUBA de verdad y no tanto como
+   para que los tres dejen de caber juntos en un retrato — que es la prueba que
+   este mundo tiene que pasar. */
+export const PISOS = [
+  {
+    id: 'templado',
+    nombre: 'Templado',
+    ent: 'roble',
+    y: 0,
+    x: -8.6,
+    z: -2.3,
+    desde: BLOQUE.xMin,
+    hasta: -4.8,
+    tinte: 'templado',
+  },
+  {
+    id: 'frio',
+    nombre: 'Frío',
+    ent: 'aliso',
+    y: 3.6,
+    x: 0.4,
+    z: -2.4,
+    desde: -2.4,
+    hasta: 4.6,
+    tinte: 'frio',
+  },
+  {
+    id: 'paramo',
+    nombre: 'Páramo',
+    ent: 'quenua',
+    y: 7.2,
+    x: 8.8,
+    z: -2.6,
+    desde: 6.8,
+    hasta: BLOQUE.xMax,
+    tinte: 'paramo',
+  },
+];
+
+/** Los dos escarpes (los taludes entre terraza y terraza), donde cae el agua. */
+export const ESCARPES = [
+  { desde: -4.8, hasta: -2.4, salto: 3.6, base: 0 },
+  { desde: 4.6, hasta: 6.8, salto: 3.6, base: 3.6 },
+];
+
+/*
+ * El cauce serpentea: a qué z va el agua a la altura x.
+ *
+ * OJO CON EL RANGO (0,4 a 1,9). No puede irse ni muy atrás ni muy adelante:
+ *   · muy atrás, el cauce se le mete por debajo a los Ents;
+ *   · muy adelante, se pega al filo del corte — y ahí el labio de la terraza
+ *     queda MÁS BAJO que el pelo de agua, así que la quebrada se desborda sobre
+ *     el filo y se asoma por la cara del tajo, que es imposible.
+ * Esta banda deja metro y medio de terraza por delante (el labio siempre por
+ * encima del agua) y espacio de sobra por detrás para los tres guardianes.
+ */
+export function zCauce(x) {
+  return 1.15 + 0.75 * Math.sin(x * 0.3 + 1.1);
+}
+
+/** Cuánto pesa el escarpe en la abscisa x (1 en el centro del salto, 0 fuera). */
+export function enEscarpe(x) {
+  let m = 0;
+  for (const e of ESCARPES) {
+    m = Math.max(m, 1 - clamp01(Math.abs(x - (e.desde + e.hasta) / 2) / ((e.hasta - e.desde) * 0.62)));
+  }
+  return m;
+}
+
+/** Perfil del cauce en la abscisa x: qué tan hondo y qué tan ancho es el surco,
+    y cuánta agua lleva (el "pelo de agua" sobre el fondo). */
+export function perfilCauce(x) {
+  const dn = clamp01((12.4 - x) / 26); // 0 en el nacimiento → 1 en la salida
+  const esc = enEscarpe(x);
+  return {
+    /* El surco se abre aguas abajo… y se ABARRANCA en los dos escarpes. Eso
+       último no es adorno: en una pared de 56 grados, un pelo de agua de un
+       palmo se ve de perfil como una raya de dos píxeles y LAS CASCADAS
+       DESAPARECÍAN — la quebrada se leía como tres charcos sueltos, uno por
+       terraza, en vez de como una sola agua que baja. Con la canal excavada,
+       el salto tiene dónde caer y se ve. */
+    hondo: 0.3 + 0.28 * dn + 0.85 * esc,
+    sigma: (0.85 + 0.95 * dn) * (1 + 0.35 * esc),
+    lamina: 0.16 + 0.26 * dn + 0.5 * esc,
+  };
+}
+
+/**
+ * LA ALTURA DE LA LADERA en (x, z): la escalera de las tres terrazas + el
+ * relieve suave del terreno + el surco por donde corre el agua.
+ *
+ * Es la función madre del mundo: la usan el lomo del bloque, la cara cortada,
+ * la siembra de la vegetación, el agua y hasta dónde se paran los Ents. Que
+ * TODO salga de aquí es lo que impide que algo quede flotando o enterrado.
+ */
+export function alturaLadera(x, z) {
+  // la escalera
+  let y = 3.6 * suave(-4.8, -2.4, x) + 3.6 * suave(4.6, 6.8, x);
+  // relieve: lomos y hondonadas suaves (nada de terraza de billar)
+  y += 0.3 * Math.sin(x * 0.42 + 1.1) * Math.cos(z * 0.36);
+  y += 0.16 * Math.sin(x * 0.9 - z * 0.55);
+  // cada terraza cae apenas hacia el frente: por ahí drena
+  y -= 0.045 * (z - BLOQUE.zFondo);
+  /* EL SURCO del cauce: el agua no va encima del pasto, va por su cama. Y la
+     cama se ABRE aguas abajo (más honda y más ancha), que es lo que hace que la
+     lámina de agua se vea angosta arriba y ancha abajo sin tener que estirar la
+     cinta a mano: el cauce la ensancha solo. */
+  const { hondo, sigma } = perfilCauce(x);
+  const d = (z - zCauce(x)) / sigma;
+  y -= hondo * Math.exp(-d * d);
+  /* EL BORDO DEL LABIO: el filo de la terraza sube apenas antes del corte, para
+     que el borde contenga el agua y de paso enmarque cada terraza.
+     APENAS. Un bordo alto (se probó con 0,7) hace de PARAPETO: desde la cámara,
+     que mira casi a ras, el borde levantado tapa el cauce entero y la quebrada
+     desaparece del cuadro. Quien contiene el agua de verdad es el candado de
+     `nivelAgua`; esto es solo el relieve del borde. */
+  y += 0.2 * suave(BLOQUE.zFrente - 2.6, BLOQUE.zFrente, z);
+  return y;
+}
+
+/** El PELO DE AGUA: a qué altura va la lámina en la abscisa x (el fondo del
+    cauce más lo que lleve de agua). TODO el ancho de la quebrada vive a ESTA
+    altura, y es el terreno el que la recorta: donde la orilla sube, la tapa. */
+export const nivelAgua = (x) => Math.min(
+  alturaLadera(x, zCauce(x)) + perfilCauce(x).lamina,
+  /* CANDADO: pase lo que pase con el relieve, el pelo de agua queda por debajo
+     del labio del corte. El bordo de arriba ya lo resuelve casi siempre; esto
+     es lo que garantiza que NUNCA se vea un chorro saliendo de la pared. */
+  alturaLadera(x, BLOQUE.zFrente) - 0.1,
+);
+
+/** La altura del lomo justo en el plano del corte (para la cara y el faldón). */
+export const alturaEnCorte = (x) => alturaLadera(x, BLOQUE.zFrente);
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LOS HORIZONTES DEL SUELO — los mismos de la vitrina del corte
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/*
+ * `hasta` es la PROFUNDIDAD (positiva hacia abajo) donde termina el horizonte,
+ * medida desde la superficie de ESA columna: los horizontes siguen el lomo de
+ * la ladera, no un plano horizontal. Así se ve lo que es cierto — que el suelo
+ * es una piel que viste la montaña.
+ *
+ * `hueco` es cuánto se retira la cara del corte en ese horizonte: la excavación
+ * escalonada que abre la ALCOBA de la red micorrízica. Sin esa alcoba, la red
+ * queda pegada a la pared y se lee como una calcomanía; metida en su nicho, se
+ * lee como lo que es: algo que vive DENTRO de la tierra.
+ */
+export const HORIZONTES = [
+  { id: 'hojarasca', nombre: 'Hojarasca', hasta: 0.4, color: '#8a6038', hueco: 0 },
+  { id: 'humus', nombre: 'Humus', hasta: 1.4, color: '#4a3325', hueco: 0.08 },
+  { id: 'raices', nombre: 'Zona de raíces', hasta: 3.0, color: '#63492f', hueco: 0.24 },
+  { id: 'micorrizas', nombre: 'Red micorrízica', hasta: 4.4, color: '#33261c', hueco: 0.5 },
+  { id: 'roca', nombre: 'Roca madre', hasta: 99, color: '#514f5a', hueco: 0.22 },
+];
+
+/*
+ * LA TIERRA AL AIRE LIBRE ES MÁS CLARA QUE LA TIERRA EN VITRINA.
+ *
+ * Los hex de arriba son los de `corteSuelo.geom.js`, y allá están calibrados
+ * para una vitrina cerrada CON SUS PROPIAS LUCES apuntándole a la banda. Aquí
+ * la pared del corte es una ladera a la intemperie: le llega el sol de refilón
+ * (la cara mira al frente, el sol viene de arriba) y el resto es cielo. Puestos
+ * tal cual, el corte entero se leía como UN AGUJERO NEGRO y los horizontes —que
+ * son la lección— no se distinguían.
+ *
+ * La corrección es de VALOR, no de tono: se levanta el brillo conservando el
+ * color exacto de cada horizonte, para que la lección del suelo se siga
+ * reconociendo como la misma que la de la vitrina. La oscuridad del corte tiene
+ * que ser LOCAL (grano, interfaces, la sombra de la alcoba), nunca un lavado
+ * global — eso ya se aprendió una vez en el corte y no se vuelve a repetir.
+ */
+const LUZ_INTEMPERIE = 2.1;
+
+/*
+ * Subir el brillo a puro multiplicador SATURA: el rojo se dispara antes que el
+ * verde y el azul, y el corte entero se pone naranja de macetero. La tierra
+ * andina es parda, no naranja. Por eso, después de levantar el valor, se le
+ * quita un quinto de saturación llevándolo hacia su propia luminancia: el tono
+ * se conserva, el grito se va.
+ */
+function alIntemperie(hex, extra = 1) {
+  const c = new THREE.Color(hex).multiplyScalar(LUZ_INTEMPERIE * extra);
+  const lum = c.r * 0.2126 + c.g * 0.7152 + c.b * 0.0722;
+  return c.lerp(new THREE.Color(lum, lum, lum), 0.22);
+}
+
+/* La ROCA MADRE se levanta más: es el PISO de la lámina, la faja gris sobre la
+   que se apoya todo el suelo. En la vitrina puede ser un fondo callado porque
+   allá compite con la red; aquí, si se apaga, el tercio de abajo del cuadro se
+   vuelve un manchón negro y la ladera pierde su base. */
+const HZ_COLOR = HORIZONTES.map((h) => alIntemperie(h.color, h.id === 'roca' ? 1.25 : 1));
+
+/** El horizonte al que pertenece una profundidad (0 = superficie, + hacia abajo). */
+export function horizonteDe(prof) {
+  for (let i = 0; i < HORIZONTES.length; i++) if (prof <= HORIZONTES[i].hasta) return i;
+  return HORIZONTES.length - 1;
+}
+
+/** Color del suelo a esa profundidad, con la transición difuminada entre
+    horizontes (en la tierra real ninguna raya es una línea). */
+export function colorHorizonte(prof, destino = new THREE.Color()) {
+  const i = horizonteDe(prof);
+  destino.copy(HZ_COLOR[i]);
+  const h = HORIZONTES[i];
+  const anterior = i > 0 ? HORIZONTES[i - 1].hasta : 0;
+  const grosor = Math.max(0.001, h.hasta - anterior);
+  const cerca = clamp01((prof - anterior) / Math.min(0.35, grosor * 0.4));
+  if (i > 0 && cerca < 1) destino.lerp(HZ_COLOR[i - 1], (1 - cerca) * 0.5);
+  return destino;
+}
+
+/** z de la cara del corte a esa profundidad (la alcoba escalonada). */
+export function zCorteDe(prof) {
+  const i = horizonteDe(prof);
+  const h = HORIZONTES[i];
+  const anterior = i > 0 ? HORIZONTES[i - 1].hasta : 0;
+  const huecoAnt = i > 0 ? HORIZONTES[i - 1].hueco : 0;
+  // el escalón se suaviza en el primer tercio del horizonte: es un scoop, no un
+  // error de modelado
+  const f = suave(anterior, anterior + Math.min(0.5, (h.hasta - anterior) * 0.45), prof);
+  return BLOQUE.zFrente - (huecoAnt + (h.hueco - huecoAnt) * f);
+}
+
+/* Las profundidades donde se ponen filas de vértices en la cara del corte: los
+   bordes de horizonte (para que la raya se vea nítida) y pasos intermedios.
+   La última fila NO es una profundidad sino EL PISO DEL BLOQUE: la cara del
+   corte tiene que llegar hasta abajo o por el frente se ve el hueco (la ladera
+   sube 7,8 m y una pared de profundidad fija dejaba el páramo destapado). */
+function filasDeProfundidad() {
+  const filas = [0];
+  let anterior = 0;
+  for (const h of HORIZONTES) {
+    const fin = Math.min(h.hasta, 6.6);
+    const pasos = Math.max(2, Math.round((fin - anterior) / 0.42));
+    for (let i = 1; i <= pasos; i++) filas.push(anterior + ((fin - anterior) * i) / pasos);
+    anterior = fin;
+    if (h.hasta > 6.6) break;
+  }
+  filas.push('fondo');
+  return filas;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL LOMO — la superficie de la ladera con sus tres fajas de color
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* El verde de cada faja sale del EJE TÉRMICO de la paleta madre: a más altura,
+   menos saturación y más plata adentro. Es la misma ley con la que la sierra
+   pinta sus bandas — la ladera no puede contradecirla. */
+const FAJA = {
+  templado: new THREE.Color(mezclar(VERDES.monte, TIERRAS.mantillo, 0.3)),
+  frio: new THREE.Color(mezclar(VERDES.frio, TIERRAS.mantilloSombra, 0.34)),
+  paramo: new THREE.Color(mezclar(TIERRAS.pajonal, VERDES.paramoMusgo, 0.42)),
+};
+const SUELO_DESNUDO = new THREE.Color(TIERRAS.mantillo);
+const ROCA = new THREE.Color(TIERRAS.rocaParamo);
+const ORILLA = new THREE.Color(mezclar(VERDES.paramoMusgo, AGUAS.lagunaOrilla, 0.3));
+
+/** El color de la superficie en (x,z): la faja térmica que le toca, más la
+    tierra que asoma en lo empinado y el verde húmedo de la orilla del agua. */
+export function colorSuperficie(x, z, y, destino = new THREE.Color()) {
+  // mezcla entre fajas: la frontera entre pisos no es una raya, es un traslape
+  const aFrio = suave(-5.6, -1.6, x);
+  const aParamo = suave(3.8, 7.6, x);
+  destino.copy(FAJA.templado).lerp(FAJA.frio, aFrio).lerp(FAJA.paramo, aParamo);
+  // pendiente: donde la ladera se empina, la tierra y la roca asoman
+  const pend = Math.abs(alturaLadera(x + 0.35, z) - alturaLadera(x - 0.35, z)) / 0.7;
+  const empinado = clamp01((pend - 0.55) / 1.2);
+  destino.lerp(SUELO_DESNUDO, empinado * 0.6);
+  destino.lerp(ROCA, clamp01((pend - 1.4) / 1.6) * 0.5);
+  // la orilla del cauce: siempre más verde y más oscura (ahí nunca falta agua)
+  const d = Math.abs(z - zCauce(x)) / 1.5;
+  destino.lerp(ORILLA, clamp01(1 - d) * 0.5);
+  // manchas de terreno: nada de césped de estadio
+  const n = ruidoFbm(x * 0.55 + 3, y * 0.4, z * 0.55);
+  destino.multiplyScalar(0.88 + n * 0.26);
+  return destino;
+}
+
+/**
+ * EL LOMO DE LA LADERA: la malla de la superficie, con el color de las fajas
+ * horneado por vértice. Es la pieza más grande del mundo y va en UN draw-call.
+ */
+/* Las columnas del bloque. El lomo y la cara del corte DEBEN muestrear la
+   misma malla en x: con dos resoluciones distintas los vértices del borde no
+   coinciden y se abre una costura de un píxel por la que se ve el cielo. */
+const columnas = (q) => Math.max(56, Math.round(140 * q));
+
+export function construirLomo({ q = 1 } = {}) {
+  const nx = columnas(q);
+  const nz = Math.max(24, Math.round(64 * q));
+  const ancho = BLOQUE.xMax - BLOQUE.xMin;
+  const hondo = BLOQUE.zFrente - BLOQUE.zFondo;
+  const geo = new THREE.PlaneGeometry(ancho, hondo, nx, nz);
+  geo.rotateX(-Math.PI / 2);
+  geo.translate((BLOQUE.xMin + BLOQUE.xMax) / 2, 0, (BLOQUE.zFondo + BLOQUE.zFrente) / 2);
+  const pos = geo.attributes.position;
+  for (let i = 0; i < pos.count; i++) {
+    pos.setY(i, alturaLadera(pos.getX(i), pos.getZ(i)));
+  }
+  pos.needsUpdate = true;
+  geo.computeVertexNormals();
+  pintarPorVertice(geo, (x, y, z, i, c) => colorSuperficie(x, z, y, c));
+  return geo;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LA CARA CORTADA — el perfil del suelo, la lámina de Humboldt
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * La pared del corte: una malla de columnas (a lo largo de la ladera) por filas
+ * (profundidad). Cada fila sigue su horizonte, se hunde en la alcoba y lleva su
+ * color horneado con grano y oclusión en las interfaces.
+ *
+ * OJO con la oscuridad: la banda de micorrizas es la MÁS oscura a propósito —
+ * es el fondo contra el que resalta la red. Pero la oscuridad tiene que ser
+ * LOCAL (grano, interfaces, alcoba), nunca un lavado global: un corte
+ * uniformemente negro se lee como un agujero, no como tierra.
+ */
+export function construirCorte({ q = 1 } = {}) {
+  const nx = columnas(q);
+  const filas = filasDeProfundidad();
+  const cols = nx + 1;
+  const rows = filas.length;
+  const pos = new Float32Array(cols * rows * 3);
+  const col = new Float32Array(cols * rows * 3);
+  const idx = [];
+  const c = new THREE.Color();
+
+  for (let iv = 0; iv < rows; iv++) {
+    const fondo = filas[iv] === 'fondo';
+    const prof = fondo ? 6.6 : filas[iv];
+    const z = zCorteDe(prof);
+    for (let iu = 0; iu < cols; iu++) {
+      const x = BLOQUE.xMin + ((BLOQUE.xMax - BLOQUE.xMin) * iu) / nx;
+      const ySup = alturaEnCorte(x);
+      /* La ladera sube 7,8 m: en el extremo del templado, 6,6 m de perfil se
+         salen POR DEBAJO del piso del bloque y la pared se doblaba sobre sí
+         misma. El perfil se recorta contra el piso — que es exactamente lo que
+         hace un bloque de verdad: la roca madre se va por el borde de abajo. */
+      const y = fondo ? BLOQUE.yFondo : Math.max(ySup - prof, BLOQUE.yFondo);
+      const k = (iv * cols + iu) * 3;
+      pos[k] = x;
+      pos[k + 1] = y;
+      pos[k + 2] = z + Math.sin(x * 1.7 + prof * 2.3) * 0.03; // la pared no es un vidrio
+      colorHorizonte(fondo ? 9 : prof, c);
+      // grano de tierra
+      const n = ruidoFbm(x * 1.6, prof * 2.2, 7);
+      c.multiplyScalar(0.92 + n * 0.22);
+      // oclusión en el borde de cada horizonte (las interfaces se ven)
+      const i = horizonteDe(prof);
+      const anterior = i > 0 ? HORIZONTES[i - 1].hasta : 0;
+      const pegado = 1 - clamp01((prof - anterior) / 0.22);
+      c.multiplyScalar(1 - pegado * 0.2);
+      // la alcoba está en sombra: se hunde en la pared
+      const hondo = clamp01((BLOQUE.zFrente - z) / 0.5);
+      c.multiplyScalar(1 - hondo * 0.16);
+      // el pie del bloque se apaga: el ojo tiene que quedarse en la lección
+      if (fondo) c.multiplyScalar(0.72);
+      col[k] = c.r;
+      col[k + 1] = c.g;
+      col[k + 2] = c.b;
+    }
+  }
+  for (let iv = 0; iv < rows - 1; iv++) {
+    for (let iu = 0; iu < nx; iu++) {
+      const a = iv * cols + iu;
+      const b = a + 1;
+      const cc = a + cols;
+      const dd = cc + 1;
+      idx.push(a, cc, b, b, cc, dd); // normal hacia +Z (a la cámara)
+    }
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  geo.setIndex(idx);
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/**
+ * EL FALDÓN: los costados, el fondo y la base del bloque. No es decorado — sin
+ * él la ladera es una cáscara y por los flancos se ve el cielo por dentro.
+ * Va en tierra honda: el ojo tiene que quedarse en la cara del corte.
+ */
+export function construirFaldon({ q = 1 } = {}) {
+  const partes = [];
+  const nx = Math.max(24, Math.round(60 * q));
+  const nz = Math.max(10, Math.round(24 * q));
+  const yF = BLOQUE.yFondo;
+
+  const cortina = (puntos, etiqueta) => {
+    // puntos: [{x,z}] a lo largo del borde; se baja una cortina hasta yFondo
+    const n = puntos.length;
+    const pos = new Float32Array(n * 2 * 3);
+    const col = new Float32Array(n * 2 * 3);
+    const idx = [];
+    const c = new THREE.Color();
+    for (let i = 0; i < n; i++) {
+      const { x, z } = puntos[i];
+      const ySup = alturaLadera(x, z);
+      for (let j = 0; j < 2; j++) {
+        const y = j === 0 ? ySup : yF;
+        const k = (j * n + i) * 3;
+        pos[k] = x;
+        pos[k + 1] = y;
+        pos[k + 2] = z;
+        colorHorizonte(j === 0 ? 0.2 : ySup - yF, c);
+        c.multiplyScalar(j === 0 ? 0.8 : 0.62);
+        col[k] = c.r;
+        col[k + 1] = c.g;
+        col[k + 2] = c.b;
+      }
+    }
+    for (let i = 0; i < n - 1; i++) {
+      const a = i;
+      const b = i + 1;
+      const cc = n + i;
+      const dd = n + i + 1;
+      idx.push(a, cc, b, b, cc, dd);
+    }
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+    g.setAttribute('color', new THREE.BufferAttribute(col, 3));
+    g.setIndex(idx);
+    g.computeVertexNormals();
+    g.name = etiqueta;
+    return g;
+  };
+
+  // costado izquierdo (de frente hacia el fondo) y derecho (al revés, para que
+  // la cara mire hacia afuera en los dos)
+  const izq = [];
+  const der = [];
+  for (let i = 0; i <= nz; i++) {
+    const z = BLOQUE.zFrente - ((BLOQUE.zFrente - BLOQUE.zFondo) * i) / nz;
+    izq.push({ x: BLOQUE.xMin, z });
+    der.push({ x: BLOQUE.xMax, z: BLOQUE.zFondo + ((BLOQUE.zFrente - BLOQUE.zFondo) * i) / nz });
+  }
+  partes.push(cortina(izq, 'faldon-izq'));
+  partes.push(cortina(der, 'faldon-der'));
+
+  // fondo
+  const atras = [];
+  for (let i = 0; i <= nx; i++) {
+    atras.push({ x: BLOQUE.xMax - ((BLOQUE.xMax - BLOQUE.xMin) * i) / nx, z: BLOQUE.zFondo });
+  }
+  partes.push(cortina(atras, 'faldon-fondo'));
+
+  // la base del bloque
+  const base = new THREE.PlaneGeometry(
+    BLOQUE.xMax - BLOQUE.xMin,
+    BLOQUE.zFrente - BLOQUE.zFondo,
+  );
+  base.rotateX(Math.PI / 2);
+  base.translate(
+    (BLOQUE.xMin + BLOQUE.xMax) / 2,
+    yF,
+    (BLOQUE.zFondo + BLOQUE.zFrente) / 2,
+  );
+  /* Las cortinas se arman a mano (position+color+normal) y el plano de la base
+     viene con `uv`: si los atributos no coinciden, `mergeGeometries` devuelve
+     NULL EN SILENCIO y el faldón entero no se dibuja. `fusionarSeguro` lo
+     trona, pero mejor no llegar ahí: se le quita el uv al plano. */
+  base.deleteAttribute('uv');
+  partes.push(pintarPlano(base, new THREE.Color(HORIZONTES[4].color).multiplyScalar(0.5)));
+
+  return fusionarSeguro(partes, 'faldon-ladera');
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   EL AGUA — nace en el páramo, se despeña dos veces y llega hecha quebrada
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/** El nacimiento: dónde brota el agua, arriba del todo. */
+export const MANANTIAL = { x: 12.1, z: zCauce(12.1) };
+
+/**
+ * El camino del agua a lo largo de la ladera. Sigue el surco del terreno (por
+ * eso pega tan bien: el surco y el agua salen de la misma función) y en los
+ * escarpes cae casi a plomo.
+ */
+export function caminoAgua(pasos = 130) {
+  const pts = [];
+  const x0 = MANANTIAL.x;
+  const x1 = BLOQUE.xMin + 0.4;
+  for (let i = 0; i <= pasos; i++) {
+    const x = x0 + ((x1 - x0) * i) / pasos;
+    pts.push(new THREE.Vector3(x, nivelAgua(x), zCauce(x)));
+  }
+  return new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.3);
+}
+
+/**
+ * LA QUEBRADA: una CINTA que se acuesta sobre el terreno y ENSANCHA aguas
+ * abajo. Lo del ancho no es capricho de dibujo — es la lección: el hilo del
+ * páramo llega abajo hecho quebrada porque por el camino recoge todo lo que la
+ * ladera le entrega.
+ *
+ * Antes era un tubo, y un tubo de sección redonda tendido en el suelo se lee
+ * como una MANGUERA, no como agua: la silueta cilíndrica delata el sólido. Una
+ * cinta que sigue la altura del terreno en TODO su ancho (no solo en el eje) se
+ * mete en su cama sola, se dobla en los escarpes y se lee como lámina de agua.
+ */
+export function construirAgua({ q = 1 } = {}) {
+  const curva = caminoAgua();
+  const pasos = Math.max(80, Math.round(230 * q));
+  const cols = 5;
+  const pos = new Float32Array((pasos + 1) * cols * 3);
+  const col = new Float32Array((pasos + 1) * cols * 3);
+  const idx = [];
+  const viva = new THREE.Color(AGUAS.viva);
+  const honda = new THREE.Color(AGUAS.lagunaHonda);
+  const orilla = new THREE.Color(AGUAS.lagunaOrilla);
+  const espuma = new THREE.Color(AGUAS.espuma);
+  const c = new THREE.Color();
+  const p = new THREE.Vector3();
+  const tg = new THREE.Vector3();
+  const lat = new THREE.Vector3();
+  const arriba = new THREE.Vector3(0, 1, 0);
+
+  for (let i = 0; i <= pasos; i++) {
+    const t = i / pasos;
+    curva.getPointAt(t, p);
+    curva.getTangentAt(t, tg);
+    lat.crossVectors(tg, arriba).normalize();
+    if (!Number.isFinite(lat.x)) lat.set(1, 0, 0);
+    /* La cinta se hace MÁS ANCHA de lo que se va a ver: sobra a los lados para
+       que el terreno la recorte. Lo que el ojo lee como ancho de la quebrada lo
+       decide el cauce, no este número. */
+    /* …pero NUNCA se pasa del labio: si la cinta cruza el filo del corte, se
+       asoma por la cara del tajo y se ve un chorro de agua saliendo de la
+       pared de tierra. */
+    const ancho = Math.min(2.6 + 2.2 * t, 2 * (BLOQUE.zFrente - 0.3 - zCauce(p.x)));
+    const salto = enEscarpe(p.x); // ¿va cayendo? ahí el agua se rompe y blanquea
+    /* LA LÁMINA ES PLANA A LO ANCHO, no calcada del terreno punto por punto.
+       La primera versión pedía la altura para CADA vértice del ancho: los
+       bordes caían sobre las orillas —que son más altas que el fondo del
+       cauce— y quedaban ENTERRADOS, así que la quebrada se rompía en charcos
+       sueltos. El agua se pone al NIVEL del cauce y la deja que el terreno la
+       recorte: donde la orilla sube, tapa la lámina; donde el surco se abre, la
+       quebrada se ensancha sola. Eso es lo que hace un río de verdad. */
+    const yNivel = nivelAgua(p.x);
+    for (let j = 0; j < cols; j++) {
+      const u = (j / (cols - 1)) * 2 - 1; // -1 orilla ← 0 eje → 1 orilla
+      const x = p.x + lat.x * u * ancho * 0.5;
+      const z = p.z + lat.z * u * ancho * 0.5;
+      const k = (i * cols + j) * 3;
+      pos[k] = x;
+      pos[k + 1] = yNivel + (1 - Math.abs(u)) * 0.03; // apenas abombada al centro
+      pos[k + 2] = z;
+      const n = ruidoFbm(x * 2.2, i * 0.35, z * 2.2);
+      /* El agua andina a la luz del día es CLARA, no un pozo negro: manda el
+         azul vivo y la orilla verde-lechosa; el azul hondo es solo el veteado. */
+      c.copy(viva).lerp(honda, clamp01(0.45 - n * 0.6));
+      c.lerp(orilla, Math.abs(u) ** 2 * 0.5);
+      if (salto > 0) c.lerp(espuma, salto * (0.5 + n * 0.4));
+      col[k] = c.r;
+      col[k + 1] = c.g;
+      col[k + 2] = c.b;
+    }
+  }
+  /*
+   * EL SENTIDO DE LOS TRIÁNGULOS: la cara de la lámina tiene que mirar ARRIBA.
+   *
+   * Con el orden (a, d, b) la normal salía HACIA ABAJO y la quebrada entera
+   * quedaba descartada por back-face culling: en pantalla solo se veían las
+   * pozas (que se arman aparte, con un `CircleGeometry` ya girado y por eso
+   * bien orientado), así que el agua se leía como una cadena de charcos sueltos
+   * y el tramo que los une simplemente no existía. No era el color, ni el
+   * nivel, ni el cauce: eran tres índices en el orden equivocado, y no avisa
+   * nadie — la geometría se construye igual de bien.
+   */
+  for (let i = 0; i < pasos; i++) {
+    for (let j = 0; j < cols - 1; j++) {
+      const a = i * cols + j;
+      const b = a + 1;
+      const d = a + cols;
+      const e = d + 1;
+      idx.push(a, b, d, b, e, d);
+    }
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  geo.setIndex(idx);
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/** El charco del nacimiento y las dos pozas al pie de cada salto. */
+export function construirPozas({ q = 1 } = {}) {
+  const partes = [];
+  const sitios = [
+    { x: MANANTIAL.x, r: 0.95 },
+    { x: ESCARPES[1].desde - 0.55, r: 0.7 },
+    { x: ESCARPES[1].hasta + 0.6, r: 1.05 },
+    { x: ESCARPES[0].desde - 0.55, r: 0.78 },
+    { x: ESCARPES[0].hasta + 0.65, r: 1.3 },
+    { x: BLOQUE.xMin + 2.4, r: 1.5 },
+  ];
+  const viva = new THREE.Color(AGUAS.viva);
+  const honda = new THREE.Color(AGUAS.lagunaHonda);
+  const orilla = new THREE.Color(AGUAS.lagunaOrilla);
+  for (const s of sitios) {
+    const z = zCauce(s.x);
+    const g = new THREE.CircleGeometry(s.r, Math.max(10, Math.round(22 * q)));
+    g.rotateX(-Math.PI / 2);
+    poner(g, [s.x, nivelAgua(s.x) + 0.01, z]);
+    pintarPorVertice(g, (px, py, pz, i, c) => {
+      const d = clamp01(Math.hypot(px - s.x, pz - z) / s.r);
+      // la poza es honda en el centro y se aclara en la orilla
+      c.copy(honda).lerp(viva, d * 0.8).lerp(orilla, d ** 3 * 0.6);
+      return c;
+    });
+    partes.push(g);
+  }
+  return fusionarSeguro(partes, 'pozas');
+}
+
+/** Las CHISPAS del agua que bajan: instancias que viajan por el camino. Es lo
+    que hace que la quebrada CORRA en vez de quedarse pintada en el suelo. */
+export function chispasDeAgua(n = 34, seed = 71) {
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    out.push({
+      t: r(), // posición inicial en el camino (0 arriba → 1 abajo)
+      vel: 0.028 + r() * 0.03,
+      lado: (r() - 0.5) * 0.22,
+      alto: 0.04 + r() * 0.1,
+      esc: 0.05 + r() * 0.06,
+    });
+  }
+  return out;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   LA RED DE MICORRIZAS — lo que amarra a los tres por debajo
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* La banda donde vive la red: sigue el lomo de la ladera a una profundidad
+   fija, así que la red SUBE con la montaña. Ver la red escalonarse detrás de
+   las tres terrazas es, literalmente, la lección. */
+export const PROF_RED = 3.6;
+
+/** El punto de la banda micorrízica bajo la abscisa x, sobre el plano del corte. */
+export function puntoBanda(x, jitter = 0) {
+  return new THREE.Vector3(
+    x,
+    alturaEnCorte(x) - PROF_RED + Math.sin(x * 0.8 + 1.3) * 0.28 + jitter,
+    zCorteDe(PROF_RED) + 0.12 + Math.sin(x * 1.9) * 0.05,
+  );
+}
+
+/**
+ * LA RAÍZ DE SECCIÓN de cada Ent: la raíz gruesa que baja del árbol, se acerca
+ * al plano del corte y llega a la banda. Es la que hace que la red no sea un
+ * adorno bonito bajo tierra sino algo ENGANCHADO a un árbol que está ahí
+ * arriba: se ve salir del pie del Ent y se ve llegar a la red.
+ */
+export function raizDeSeccion(piso) {
+  const ySup = alturaLadera(piso.x, piso.z);
+  const yCorte = alturaEnCorte(piso.x);
+  const fin = puntoBanda(piso.x);
+  /* Los tramos intermedios SIGUEN la cara escalonada del corte (`zCorteDe`),
+     0,12 por delante. Si la raíz cortara recto del pie del árbol a la banda, se
+     metería dentro del bloque y desaparecería a media bajada: se vería una raíz
+     que sale del árbol, se corta, y una red que empieza de la nada. */
+  /* El primer tramo SE HUNDE de una: sale del pie del árbol y a un metro ya va
+     bajo tierra. Si en cambio viajara del árbol al plano del corte por encima
+     del suelo —que fue la primera versión— se veía una vara pálida de casi seis
+     metros tendida sobre el pasto. Una raíz se mete en la tierra; lo que se
+     asoma de ella es lo que el tajo dejó al descubierto, y nada más. */
+  const pts = [
+    new THREE.Vector3(piso.x, ySup + 0.15, piso.z),
+    new THREE.Vector3(piso.x + 0.1, ySup - 1.1, piso.z + 1.1),
+  ];
+  for (const prof of [1.7, 2.5, 3.2]) {
+    pts.push(new THREE.Vector3(
+      piso.x + Math.sin(prof * 1.7) * 0.16,
+      yCorte - prof,
+      zCorteDe(prof) + 0.12,
+    ));
+  }
+  pts.push(fin.clone());
+  return new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.5);
+}
+
+/**
+ * EL ESQUELETO DE LA RED: el rizomorfo que corre toda la ladera, las raíces de
+ * sección que bajan de los tres Ents y los filamentos finos que se abren a los
+ * lados. Devuelve polilíneas con su grosor y su tipo.
+ */
+export function esqueletoRed({ q = 1 } = {}) {
+  const r = rng(4242);
+  const hilos = [];
+
+  /* 1. EL RIZOMORFO: el cordón grueso que va de punta a punta de la ladera.
+        Es el que dice "esto es UNA red", no tres matas con hongos aparte. */
+  const troncal = [];
+  for (let x = BLOQUE.xMax - 1.6; x >= BLOQUE.xMin + 1.2; x -= 0.7) {
+    troncal.push(puntoBanda(x, Math.sin(x * 1.7) * 0.16));
+  }
+  hilos.push({ pts: troncal, grosor: 0.055, tipo: 'rizomorfo' });
+
+  /* 2. Un segundo cordón más hondo y más tenue: la red tiene espesor. */
+  const troncal2 = [];
+  for (let x = BLOQUE.xMax - 2.6; x >= BLOQUE.xMin + 2.2; x -= 0.9) {
+    troncal2.push(puntoBanda(x, -0.75 + Math.sin(x * 1.1 + 2) * 0.22));
+  }
+  hilos.push({ pts: troncal2, grosor: 0.032, tipo: 'rizomorfo' });
+
+  /* 3. Las bajantes de los tres Ents (las que enganchan la red al árbol). */
+  for (const piso of PISOS) {
+    const curva = raizDeSeccion(piso);
+    const pts = [];
+    for (let i = 0; i <= 16; i++) pts.push(curva.getPointAt(i / 16));
+    hilos.push({ pts, grosor: 0.075, tipo: 'raiz', piso: piso.id });
+  }
+
+  /* 4. Los PUENTES: filamentos que salen del rizomorfo y trepan a buscar la
+        raíz del vecino. Son los que se ven "cosiendo" un árbol con otro. */
+  for (let i = 0; i < PISOS.length - 1; i++) {
+    const a = puntoBanda(PISOS[i].x);
+    const b = puntoBanda(PISOS[i + 1].x);
+    const medio = a.clone().lerp(b, 0.5).add(new THREE.Vector3(0, 0.95, 0.08));
+    const curva = new THREE.CatmullRomCurve3([a, medio, b], false, 'catmullrom', 0.5);
+    const pts = [];
+    for (let k = 0; k <= 18; k++) pts.push(curva.getPointAt(k / 18));
+    hilos.push({ pts, grosor: 0.028, tipo: 'puente' });
+  }
+
+  /* 5. Los filamentos finos: la maraña que hace que la banda no sea un cable
+        sino un tejido. Se recortan por tier. */
+  const cuantos = Math.max(10, Math.round(34 * q));
+  for (let i = 0; i < cuantos; i++) {
+    const x = BLOQUE.xMin + 2 + r() * (BLOQUE.xMax - BLOQUE.xMin - 4);
+    const base = puntoBanda(x, (r() - 0.5) * 0.5);
+    const sube = r() > 0.45;
+    const pts = [base.clone()];
+    let p = base.clone();
+    const n = 3 + Math.floor(r() * 3);
+    for (let k = 0; k < n; k++) {
+      p = p.clone().add(new THREE.Vector3(
+        (r() - 0.5) * 1.5,
+        (sube ? 0.42 : -0.38) * (0.5 + r()),
+        (r() - 0.5) * 0.16,
+      ));
+      // la hifa no puede salirse por debajo del bloque: colgaría en el aire
+      p.y = Math.max(p.y, BLOQUE.yFondo + 0.45);
+      pts.push(p);
+    }
+    hilos.push({ pts, grosor: 0.011 + r() * 0.008, tipo: 'hifa' });
+  }
+
+  return hilos;
+}
+
+/**
+ * LA RED en UNA geometría. El color va horneado: el rizomorfo en turquesa
+ * pleno, las hifas finas apagándose, las raíces en su pardo de raíz VIVA — que
+ * es materia y no luz. Ese contraste (la raíz es cosa, la red es luz) es lo que
+ * hace legible la lección.
+ */
+export function construirRed(hilos, { q = 1 } = {}) {
+  const partes = [];
+  const micelio = new THREE.Color(MICO.micelio);
+  const tenue = new THREE.Color(MICO.micelioTenue);
+  const puente = new THREE.Color(MICO.puente);
+  const raiz = new THREE.Color(MICO.raiz);
+  const raizPunta = new THREE.Color(MICO.raizPunta);
+
+  for (const h of hilos) {
+    if (h.pts.length < 2) continue;
+    const curva = new THREE.CatmullRomCurve3(h.pts, false, 'catmullrom', 0.4);
+    const radial = h.tipo === 'hifa' ? 4 : Math.max(4, Math.round(7 * q));
+    const tubular = Math.max(6, Math.round((h.tipo === 'hifa' ? 10 : 26) * q));
+    const geo = tuboOrganico(curva, {
+      tubular,
+      radial,
+      taper: (t) => h.grosor * (h.tipo === 'raiz' ? 1 - 0.72 * t : 1 - 0.35 * t),
+      arruga: h.tipo === 'raiz' ? 0.16 : 0.06,
+      semilla: h.pts[0].x * 3,
+      minRadio: 0.004,
+    });
+    const largo = curva.getLength();
+    pintarPorVertice(geo, (x, y, z, i, c) => {
+      if (h.tipo === 'raiz') {
+        const t = clamp01((h.pts[0].y - y) / Math.max(0.001, h.pts[0].y - h.pts[h.pts.length - 1].y));
+        c.copy(raiz).lerp(raizPunta, t * 0.8);
+        return c;
+      }
+      const n = ruidoFbm(x * 1.4, y * 1.4, z * 1.4);
+      if (h.tipo === 'puente') c.copy(puente).lerp(micelio, n * 0.5);
+      else if (h.tipo === 'rizomorfo') c.copy(micelio).lerp(tenue, n * 0.45);
+      else c.copy(tenue).lerp(micelio, n * 0.6);
+      // el filamento se apaga hacia la punta: la red se pierde en la tierra
+      if (h.tipo === 'hifa') c.multiplyScalar(0.65 + 0.35 * clamp01(largo));
+      return c;
+    });
+    partes.push(geo);
+  }
+  return fusionarSeguro(partes, 'red-micorrizas-ladera');
+}
+
+/** Los NODOS: donde la red se junta consigo misma o con una raíz. Se dibujan
+    como perlas para que el ojo tenga dónde parar (una maraña pareja no enseña). */
+export function nodosDeRed(hilos, { q = 1 } = {}) {
+  const r = rng(77);
+  const nodos = [];
+  for (const piso of PISOS) {
+    // el nodo de intercambio de cada árbol: el más grande, el que importa
+    nodos.push({ p: puntoBanda(piso.x), esc: 0.16, tipo: 'intercambio', piso: piso.id });
+  }
+  const troncal = hilos.find((h) => h.tipo === 'rizomorfo');
+  if (troncal) {
+    const cuantos = Math.max(5, Math.round(14 * q));
+    for (let i = 0; i < cuantos; i++) {
+      const p = troncal.pts[Math.floor(r() * troncal.pts.length)];
+      nodos.push({ p: p.clone().add(new THREE.Vector3(0, (r() - 0.5) * 0.2, 0.02)), esc: 0.055 + r() * 0.04, tipo: 'nodo' });
+    }
+  }
+  return nodos;
+}
+
+/**
+ * LOS PULSOS que viajan por la red. En el mundo de las micorrizas ya está
+ * dicho qué viaja: minerales y agua del hongo hacia la planta, azúcar de la
+ * planta hacia el hongo. Aquí los pulsos recorren el rizomorfo de punta a
+ * punta — que es lo que hace visible que los tres están conectados.
+ */
+export function pulsosDeRed(n = 26, seed = 53) {
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const carbono = r() > 0.55;
+    out.push({
+      t: r(),
+      vel: 0.035 + r() * 0.045,
+      dir: carbono ? -1 : 1, // el azúcar baja al hongo; el mineral sube a la mata
+      color: carbono ? MICO.carbono : (r() > 0.5 ? MICO.fosforo : MICO.agua),
+      esc: 0.05 + r() * 0.05,
+      lado: (r() - 0.5) * 0.12,
+    });
+  }
+  return out;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   PIEDRAS Y DETALLE DE LOS ESCARPES
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/** Las piedras del talud y de la orilla: rompen el borde de los escarpes para
+    que el salto de terraza se lea como roca y no como un escalón de plastilina. */
+export function construirPiedras({ q = 1 } = {}, seed = 313) {
+  const r = rng(seed);
+  const partes = [];
+  const roca = new THREE.Color(TIERRAS.rocaParamo);
+  const rocaClara = new THREE.Color(mezclar(TIERRAS.rocaParamo, NEUTROS.cal, 0.28));
+  const cuantas = Math.max(14, Math.round(46 * q));
+  for (let i = 0; i < cuantas; i++) {
+    // la mitad en los escarpes, la mitad regadas por las terrazas
+    let x;
+    let z;
+    if (i % 2 === 0) {
+      const e = ESCARPES[i % 4 < 2 ? 0 : 1];
+      x = e.desde + r() * (e.hasta - e.desde);
+      z = BLOQUE.zFondo + 1.5 + r() * (BLOQUE.zFrente - BLOQUE.zFondo - 2.4);
+    } else {
+      x = BLOQUE.xMin + 1 + r() * (BLOQUE.xMax - BLOQUE.xMin - 2);
+      z = BLOQUE.zFondo + 1.2 + r() * (BLOQUE.zFrente - BLOQUE.zFondo - 2);
+    }
+    const y = alturaLadera(x, z);
+    const esc = 0.18 + r() * 0.42;
+    const g = new THREE.IcosahedronGeometry(esc, 0);
+    const pos = g.attributes.position;
+    const v = new THREE.Vector3();
+    for (let k = 0; k < pos.count; k++) {
+      v.fromBufferAttribute(pos, k);
+      const n = ruidoFbm(v.x * 3 + i, v.y * 3, v.z * 3) - 0.5;
+      v.multiplyScalar(1 + n * 0.5);
+      pos.setXYZ(k, v.x, v.y * 0.72, v.z);
+    }
+    pos.needsUpdate = true;
+    poner(g, [x, y + esc * 0.28, z], [r(), r() * 6, r()]);
+    pintarPorVertice(g, (px, py, pz, k, c) => {
+      const alto = clamp01((py - (y - esc)) / (esc * 2));
+      c.copy(roca).lerp(rocaClara, alto * 0.7);
+      const n = ruidoFbm(px * 2.5, py * 2.5, pz * 2.5);
+      c.multiplyScalar(0.86 + n * 0.28);
+      return c;
+    });
+    partes.push(g);
+  }
+  return fusionarSeguro(partes, 'piedras-ladera');
+}


### PR DESCRIPTION
Encargo del operador: un Ent por piso térmico, que juntos cuenten el gradiente andino con las
miradas de Peter Jackson y de Humboldt.

## La resolución: una lámina de Humboldt, no tres demos

No son tres árboles sueltos en tres escenas. Es **un solo bloque de montaña cortado en tres
terrazas**, con las fajas de vegetación arriba y **los horizontes del suelo visibles en el tajo**.

Lo que los amarra:
- **El agua** nace en el páramo, se despeña dos veces y llega abajo hecha quebrada
- **La red de micorrizas** enlaza las raíces de los tres a lo largo de la cara del corte, con
  pulsos que viajan en ambos sentidos

Y la lección se lee sola: *"Si le tumban el páramo, el roble del templado se entera"*.

## Las tres especies, con fidelidad verificada

| Ent | Especie | Detalle que NO es decorativo |
|---|---|---|
| **Roble** | *Quercus humboldtii* (750–3450 m) | Al pie, *Cantharellus* y *Lactarius* — **los dos únicos de sus cuatro géneros de ectomicorriza que sacan cuerpo fructífero a la superficie**. Los otros dos (*Cenococcum*, *Tomentella*) no se ven, así que no se dibujan |
| **Aliso** | *Alnus acuminata* | **Nódulos de *Frankia* dibujados en las raíces**, lobulados como coral — es el árbol que fabrica su propio nitrógeno |
| **Queñua** | *Polylepis* | **NO se redibujó**: es el `EntQuenua` que ya existía, traído tal cual |

Y un detalle que enseña sin texto: **dos robles chicos en la terraza del frío**, porque el roble
cruza el gradiente él solo hasta los 3450 m.

## Cinco trampas encontradas, documentadas en el código

1. **El `target` de `OrbitControls` arranca en el origen** y la condición de llegada solo miraba
   la posición de la cámara → miraba al piso del bloque y **todas** las capturas salían con las
   copas cortadas.
2. **La cinta del agua tenía los triángulos al revés**: descartada por back-face culling. Solo se
   veían las pozas, así que la quebrada parecía una cadena de charcos. Tres índices mal, y **nadie
   avisa**.
3. La lámina de agua se calcaba del terreno vértice a vértice y se enterraba en las orillas.
4. **Los doce arquetipos de `estratosAltoandinos` traen el color horneado para dosel cerrado**
   (`mezclar(musgo, tinta, 0.42)`): sembrados en terraza abierta se leen como alquitrán. La
   vegetación de acompañamiento pasó a `floraParamo`, calibrada para ladera abierta.
5. La receta `'agua'` de `materialesMadre` va con `metalness 0.4`: sin mapa de entorno la quebrada
   sale negra.

## Verificación

`vite build` verde (20,2 s) · eslint limpio · `fusionarSeguro` como única fusión · paleta,
materiales y `<LuzMadre>` de la casa, cero rig propio. Capturas contra build local servido en
puerto propio con el hash confirmado en disco y en el servidor.

Ruta: `#/mockups/tres-ents-gradiente`

**Observación mía para una pasada futura**: los tres Ents quedan pequeños en el plano general; los
retratos individuales cargan el peso de mostrarlos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)