### PR TITLE
arte(jaguar+frutales): rosetas con puntos, patas leonadas y el vergel de las siete andinas

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -311,6 +311,15 @@ const MundoFrutales3DMockup = lazy(() => import('./mockups/MundoFrutales3D'));
 // maíz + fríjol + calabaza —, quinua en grupo con panojas de color, yucas
 // frondosas). Standalone tipo botica: no monta el sistema MUNDO ni EscenaBase3D.
 const MundoLeguminosas3DMockup = lazy(() => import('./mockups/MundoLeguminosas3D'));
+// La HOJA DE PERSONAJE DEL JAGUAR (Panthera onca): el retrato en grande donde
+// las rosetas se pueden juzgar, la lámina de la regla de oro (anillo roto +
+// puntos negros adentro) y el claro del monte en 3D donde el felino camina
+// pisando el terreno. Ruta #/mockups/jaguar-monte-3d, sin auth.
+const JaguarMonte3DMockup = lazy(() => import('./mockups/JaguarMonte3D'));
+// El VERGEL DE FRUTALES ANDINOS: mora, lulo, tomate de árbol, granadilla,
+// uchuva, gulupa y curuba — las siete del clima frío, cada una con su porte y
+// su tutorado. Ruta #/mockups/frutales-andinos-3d, sin auth.
+const FrutalesAndinos3DMockup = lazy(() => import('./mockups/FrutalesAndinos3D'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
@@ -760,6 +769,8 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo-frutales-3d': 'mockup_mundo_frutales_3d',
   'mockups/mundo-leguminosas-3d': 'mockup_mundo_leguminosas_3d',
   'mockups/hoja-prueba-valle': 'mockup_hoja_prueba_valle',
+  'mockups/jaguar-monte-3d': 'mockup_jaguar_monte_3d',
+  'mockups/frutales-andinos-3d': 'mockup_frutales_andinos_3d',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -2552,6 +2563,31 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El lote de leguminosas y raíces">
               <MundoLeguminosas3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_jaguar_monte_3d':
+        // La hoja de personaje del jaguar (Panthera onca): el retrato en grande
+        // (las rosetas solo se juzgan grandes), la lámina de la regla de oro
+        // —anillo roto + puntos negros adentro, lo que lo separa del leopardo—,
+        // el elenco de poses y el claro del monte en 3D donde el felino camina
+        // pisando el terreno. Ruta #/mockups/jaguar-monte-3d, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El jaguar del monte">
+              <JaguarMonte3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_frutales_andinos_3d':
+        // El vergel de frutales andinos de clima frío: la mora en espaldera, el
+        // lulo de hoja gigante, el tomate de árbol, la uchuva con su capacho y
+        // las tres pasifloras (granadilla, gulupa y curuba) en su ramada —
+        // cada una con su porte real. Ruta #/mockups/frutales-andinos-3d.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El vergel de frutales andinos">
+              <FrutalesAndinos3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/FrutalesAndinos3D.css
+++ b/src/mockups/FrutalesAndinos3D.css
@@ -1,0 +1,179 @@
+/*
+ * FrutalesAndinos3D — la vitrina del vergel de clima frío.
+ * Papel cálido de finca, la escena mandando arriba, tabla del elenco que se
+ * apila sola en móvil.
+ */
+
+.vfrut {
+  --vf-tinta: #2b2013;
+  --vf-borde: rgba(43, 32, 19, 0.16);
+
+  min-height: 100dvh;
+  margin: 0;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  background: radial-gradient(120% 80% at 50% 0%, #f2f4dc 0%, #e4e2bd 52%, #cfd0a2 100%);
+  color: var(--vf-tinta);
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+  line-height: 1.55;
+}
+
+.vfrut__head {
+  max-width: 62ch;
+  margin: 0 auto clamp(1.2rem, 3vw, 2rem);
+  text-align: center;
+}
+
+.vfrut__kicker {
+  margin: 0 0 0.35rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.62;
+}
+
+.vfrut__head h1 {
+  margin: 0 0 0.6rem;
+  font-size: clamp(1.5rem, 4.6vw, 2.5rem);
+  line-height: 1.15;
+}
+
+.vfrut__lema {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.2vw, 1.06rem);
+  opacity: 0.85;
+}
+
+.vfrut__escena {
+  position: relative;
+  max-width: 1120px;
+  height: clamp(300px, 58vh, 580px);
+  margin: 0 auto clamp(1.4rem, 3.5vw, 2.6rem);
+  overflow: hidden;
+  background: #dfe0bb;
+  border: 1px solid var(--vf-borde);
+  border-radius: 18px;
+  box-shadow: 0 14px 32px rgba(43, 32, 19, 0.16);
+}
+
+.vfrut__escena canvas { display: block; }
+
+.vfrut__cargando,
+.vfrut__ficha {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 1.4rem;
+  text-align: center;
+}
+
+.vfrut__ficha p {
+  max-width: 46ch;
+  margin: 0;
+  font-size: 0.96rem;
+  opacity: 0.82;
+}
+
+.vfrut__toggle {
+  position: absolute;
+  right: 0.8rem;
+  bottom: 0.8rem;
+  padding: 0.5rem 0.95rem;
+  color: #f6f3e2;
+  font: inherit;
+  font-size: 0.86rem;
+  background: rgba(43, 32, 19, 0.82);
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.vfrut__toggle:hover { background: rgba(43, 32, 19, 0.95); }
+
+.vfrut__elenco,
+.vfrut__saberes {
+  max-width: 1120px;
+  margin: 0 auto clamp(1.4rem, 3.5vw, 2.6rem);
+}
+
+.vfrut__elenco h2,
+.vfrut__saberes h2 {
+  margin: 0 0 0.9rem;
+  font-size: clamp(1.1rem, 3vw, 1.4rem);
+  text-align: center;
+}
+
+.vfrut__elenco ul,
+.vfrut__saberes ul {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.vfrut__elenco li,
+.vfrut__saberes li {
+  padding: 1rem;
+  background: rgba(255, 254, 244, 0.72);
+  border: 1px solid var(--vf-borde);
+  border-radius: 16px;
+}
+
+.vfrut__elenco h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.02rem;
+}
+
+.vfrut__elenco h3 em {
+  display: block;
+  font-weight: 400;
+  font-size: 0.82rem;
+  opacity: 0.66;
+}
+
+.vfrut__sena {
+  margin: 0 0 0.45rem;
+  font-weight: 600;
+  font-size: 0.94rem;
+}
+
+.vfrut__detalle {
+  margin: 0;
+  font-size: 0.88rem;
+  opacity: 0.82;
+}
+
+.vfrut__saberes li span {
+  display: block;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.vfrut__saberes li h3 {
+  margin: 0.4rem 0 0.35rem;
+  font-size: 1rem;
+}
+
+.vfrut__saberes li p {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.84;
+}
+
+.vfrut__nota {
+  max-width: 62ch;
+  margin: 0 auto;
+  padding: 0.9rem 1.1rem;
+  font-size: 0.88rem;
+  text-align: center;
+  background: rgba(255, 254, 244, 0.6);
+  border: 1px dashed var(--vf-borde);
+  border-radius: 14px;
+  opacity: 0.85;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vfrut * { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; }
+}

--- a/src/mockups/FrutalesAndinos3D.jsx
+++ b/src/mockups/FrutalesAndinos3D.jsx
@@ -1,0 +1,197 @@
+/*
+ * FrutalesAndinos3D — vitrina pública del VERGEL DE FRUTALES ANDINOS.
+ * Ruta #/mockups/frutales-andinos-3d, sin auth.
+ *
+ * Las SIETE del clima frío que el catálogo respalda: mora de Castilla, lulo,
+ * tomate de árbol, uchuva, granadilla, gulupa y curuba. El vergel se recorre
+ * como es en la finca — la mora y la gulupa amarradas a su espaldera, la
+ * granadilla y la curuba tendidas en la ramada, el lulo en su claro, el tomate
+ * de árbol de porte alto atrás y la uchuva al borde del lote.
+ *
+ * LO QUE ESTA PÁGINA NO TIENE, A PROPÓSITO: mango y cítricos. Son de piso
+ * cálido, no de este vergel, y el catálogo no los respalda con la misma fuerza.
+ * Un frutal dibujado de memoria le llega al campesino como enseñanza falsa, así
+ * que preferimos siete bien hechas a nueve de las cuales dos son inventadas.
+ *
+ * Device-tiering REAL (`decidirTier`): gama media/alta ve el vergel en 3D
+ * (chunk perezoso `vendor-three`); en equipo humilde, ahorro de datos o
+ * sin-WebGL se ve la tabla del elenco, que enseña lo mismo sin sudar la GPU.
+ * Copy en español de Colombia, en "usted". Autocontenida: cero CDN.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import './FrutalesAndinos3D.css';
+
+const Vergel = lazy(() => import('../visual/mundo3d/frutalesAndinos/VergelFrutalesAndinos.jsx'));
+
+/* El elenco con lo que de verdad lo distingue en el campo. Cada ficha responde
+   a una sola pregunta: ¿en qué me fijo para saber cuál es? */
+const ELENCO = [
+  {
+    id: 'mora',
+    nombre: 'Mora de Castilla',
+    cientifico: 'Rubus glaucus',
+    sena: 'No es un árbol: son cañas con espinas amarradas a la espaldera.',
+    detalle:
+      'La hoja va en tres hojitas (trifoliada) y por debajo es más clara. En la misma rama usted ve fruta verde, roja y morada casi negra: por eso se cosecha por pases y no de un solo tirón.',
+  },
+  {
+    id: 'lulo',
+    nombre: 'Lulo',
+    cientifico: 'Solanum quitoense',
+    sena: 'La hoja enorme, ancha y con la nervadura morada.',
+    detalle:
+      'Es la hoja más grande de todo el vergel — se reconoce de lejos sin mirar el fruto. La mata es baja y el fruto naranja sale pegado al tallo.',
+  },
+  {
+    id: 'tomate',
+    nombre: 'Tomate de árbol',
+    cientifico: 'Solanum betaceum',
+    sena: 'El único de porte alto: tronco que sube y se abre arriba.',
+    detalle:
+      'Hoja grande acorazonada, y el fruto ovalado (nunca redondo) colgando en racimos. Si el fruto le sale redondo, ya dibujó otra cosa.',
+  },
+  {
+    id: 'uchuva',
+    nombre: 'Uchuva',
+    cientifico: 'Physalis peruviana',
+    sena: 'El capacho: la fruta va dentro de un farolito de papel.',
+    detalle:
+      'Mata baja que se tutorea. El capacho es el cáliz que envuelve la baya y se seca a medida que madura. Sin capacho no es uchuva, es una bolita naranja.',
+  },
+  {
+    id: 'granadilla',
+    nombre: 'Granadilla',
+    cientifico: 'Passiflora ligularis',
+    sena: 'Hoja entera acorazonada y fruto redondo anaranjado.',
+    detalle:
+      'Bejuco que se tiende en ramada: uno camina por debajo y la fruta cuelga sobre la cabeza. Su hoja es de una sola pieza — ahí se separa de la gulupa y la curuba.',
+  },
+  {
+    id: 'gulupa',
+    nombre: 'Gulupa',
+    cientifico: 'Passiflora edulis f. edulis',
+    sena: 'Hoja de tres lóbulos y fruto redondo morado oscuro.',
+    detalle:
+      'Es la pasiflora que más se confunde con la granadilla. La diferencia se ve en dos sitios: la hoja partida en tres y el color del fruto.',
+  },
+  {
+    id: 'curuba',
+    nombre: 'Curuba',
+    cientifico: 'Passiflora tripartita',
+    sena: 'Flor rosada colgante de tubo largo y fruto alargado amarillo.',
+    detalle:
+      'La flor la delata antes que la fruta: cuelga hacia abajo, rosada y con el tubo largo. Y el fruto es alargado, no redondo como el de sus dos parientes.',
+  },
+];
+
+/* Lo que enseña el vergel completo (más allá de cada especie). */
+const SABERES = [
+  {
+    emoji: '🪜',
+    titulo: 'Cada una se conduce distinto',
+    texto:
+      'La mora y la gulupa van en espaldera (postes con alambres); la granadilla y la curuba, en ramada, que es un techo de varas por el que se tiende el bejuco. El lulo, el tomate de árbol y la uchuva van sueltos o con tutor. La estructura no es adorno: es la mitad del cultivo.',
+  },
+  {
+    emoji: '🌡️',
+    titulo: 'Todas son de clima frío',
+    texto:
+      'Este vergel es de tierra fría andina. Por eso acá no hay mango ni naranjos: esos son de piso cálido y no comparten ni la altura, ni el manejo, ni las plagas. Mezclarlos en un mismo dibujo confunde más de lo que enseña.',
+  },
+  {
+    emoji: '🍃',
+    titulo: 'Primero la hoja, después la fruta',
+    texto:
+      'En el campo usted casi siempre llega a la mata cuando no tiene fruta. Por eso lo que hay que aprender a leer es la hoja y el porte: la hoja gigante del lulo, la de tres hojitas de la mora, la partida en tres de la gulupa.',
+  },
+  {
+    emoji: '🐝',
+    titulo: 'Sin polinizador no hay cosecha',
+    texto:
+      'Las pasifloras dependen de que alguien les lleve el polen, y las flores grandes de la curuba están hechas para pico largo. Si usted acaba con lo que vuela, la ramada florece bonito y no cuaja nada.',
+  },
+];
+
+export default function FrutalesAndinos3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+
+  return (
+    <main className="vfrut">
+      <header className="vfrut__head">
+        <p className="vfrut__kicker">El vergel de clima frío · vitrina</p>
+        <h1>Siete frutales que no se parecen en nada</h1>
+        <p className="vfrut__lema">
+          Mora, lulo, tomate de árbol, uchuva, granadilla, gulupa y curuba. Todas
+          de tierra fría, y todas con una seña propia que se aprende de una:
+          recorra el vergel y después mire la tabla.
+        </p>
+      </header>
+
+      <section className="vfrut__escena" aria-label="El vergel de frutales andinos en 3D">
+        {mostrar3D ? (
+          <Suspense fallback={<p className="vfrut__cargando">Sembrando el vergel…</p>}>
+            <Vergel tier={tier} reducedMotion={reducedMotion} />
+          </Suspense>
+        ) : (
+          <div className="vfrut__ficha">
+            <p>
+              En este equipo le mostramos el vergel en tabla, que enseña lo mismo
+              y no le hace sudar la máquina. Baje y mire las siete señas.
+            </p>
+          </div>
+        )}
+        {puede3D && (
+          <button type="button" className="vfrut__toggle" onClick={() => setVer2d((v) => !v)}>
+            {ver2d ? 'Ver el vergel en 3D' : 'Ver solo la tabla'}
+          </button>
+        )}
+      </section>
+
+      <section className="vfrut__elenco" aria-label="Las siete del vergel">
+        <h2>En qué se fija para saber cuál es</h2>
+        <ul>
+          {ELENCO.map((f) => (
+            <li key={f.id}>
+              <h3>
+                {f.nombre} <em>{f.cientifico}</em>
+              </h3>
+              <p className="vfrut__sena">{f.sena}</p>
+              <p className="vfrut__detalle">{f.detalle}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="vfrut__saberes" aria-label="Lo que enseña el vergel">
+        <h2>Cuatro cosas del vergel entero</h2>
+        <ul>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span aria-hidden="true">{s.emoji}</span>
+              <h3>{s.titulo}</h3>
+              <p>{s.texto}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <p className="vfrut__nota">
+        Acá no hay mango ni cítricos a propósito: son frutales de piso cálido y
+        este vergel es de tierra fría. Cuando les toque el turno se dibujarán con
+        el mismo cuidado, en su propio piso térmico.
+      </p>
+    </main>
+  );
+}

--- a/src/mockups/JaguarMonte3D.css
+++ b/src/mockups/JaguarMonte3D.css
@@ -1,0 +1,257 @@
+/*
+ * JaguarMonte3D — la hoja de personaje del jaguar.
+ * Fondo de monte al atardecer (los mismos tonos cálidos del resto de vitrinas),
+ * el retrato mandando en la primera pantalla y todo apilándose en móvil.
+ */
+
+.jmonte {
+  --jm-tinta: #241608;
+  --jm-papel: #f6ead2;
+  --jm-papel-hondo: #e7d7ba;
+  --jm-monte: #3f6f3a;
+  --jm-pelaje: #d99a45;
+  --jm-borde: rgba(36, 22, 8, 0.16);
+
+  min-height: 100dvh;
+  margin: 0;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  background:
+    radial-gradient(120% 80% at 50% 0%, #f3e6cc 0%, #e2d0ae 55%, #cdb98f 100%);
+  color: var(--jm-tinta);
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+  line-height: 1.55;
+}
+
+.jmonte__head {
+  max-width: 62ch;
+  margin: 0 auto clamp(1.2rem, 3vw, 2.2rem);
+  text-align: center;
+}
+
+.jmonte__kicker {
+  margin: 0 0 0.35rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.62;
+}
+
+.jmonte__head h1 {
+  margin: 0 0 0.6rem;
+  font-size: clamp(1.5rem, 4.6vw, 2.5rem);
+  line-height: 1.15;
+}
+
+.jmonte__lema {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.2vw, 1.06rem);
+  opacity: 0.85;
+}
+
+/* ── EL RETRATO ─────────────────────────────────────────────────────────── */
+
+.jmonte__retrato {
+  display: grid;
+  gap: clamp(1rem, 2.5vw, 2rem);
+  grid-template-columns: minmax(0, 1fr);
+  max-width: 1080px;
+  margin: 0 auto clamp(1.4rem, 3.5vw, 2.6rem);
+}
+
+@media (min-width: 860px) {
+  .jmonte__retrato { grid-template-columns: 1.05fr 1fr; align-items: center; }
+}
+
+.jmonte__figura {
+  margin: 0;
+  padding: clamp(0.8rem, 2vw, 1.4rem);
+  background: linear-gradient(170deg, #f7edd6 0%, #eadcbc 100%);
+  border: 1px solid var(--jm-borde);
+  border-radius: 18px;
+  box-shadow: 0 12px 28px rgba(36, 22, 8, 0.14);
+  text-align: center;
+}
+
+.jmonte__retratoSvg {
+  display: block;
+  width: 100%;
+  max-width: 460px;
+  height: auto;
+  margin: 0 auto;
+}
+
+.jmonte__figura figcaption {
+  margin: 0.5rem auto 0;
+  max-width: 44ch;
+  font-size: 0.92rem;
+  opacity: 0.78;
+}
+
+.jmonte__regla h2 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.1rem, 3vw, 1.4rem);
+}
+
+.jmonte__regla > p {
+  margin: 0 0 0.9rem;
+  font-size: 0.96rem;
+  opacity: 0.82;
+}
+
+.jmonte__lamina {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.9rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.jmonte__marca {
+  padding: 0.7rem;
+  background: rgba(255, 253, 245, 0.72);
+  border: 1px solid var(--jm-borde);
+  border-radius: 14px;
+  text-align: center;
+}
+
+.jmonte__marca svg {
+  display: block;
+  width: 100%;
+  max-width: 94px;
+  height: auto;
+  margin: 0 auto 0.45rem;
+  border-radius: 8px;
+}
+
+.jmonte__marcaNombre {
+  margin: 0 0 0.2rem;
+  font-weight: 700;
+  font-size: 0.94rem;
+}
+
+.jmonte__marcaPie {
+  margin: 0;
+  font-size: 0.82rem;
+  opacity: 0.76;
+}
+
+/* ── LA ESCENA 3D ───────────────────────────────────────────────────────── */
+
+.jmonte__escena {
+  position: relative;
+  max-width: 1080px;
+  height: clamp(300px, 56vh, 560px);
+  margin: 0 auto clamp(1.4rem, 3.5vw, 2.6rem);
+  overflow: hidden;
+  background: #ded0b4;
+  border: 1px solid var(--jm-borde);
+  border-radius: 18px;
+  box-shadow: 0 14px 32px rgba(36, 22, 8, 0.16);
+}
+
+.jmonte__escena canvas { display: block; }
+
+.jmonte__cargando,
+.jmonte__ficha {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 1.4rem;
+  text-align: center;
+}
+
+.jmonte__ficha p {
+  max-width: 46ch;
+  margin: 0;
+  font-size: 0.94rem;
+  opacity: 0.8;
+}
+
+.jmonte__toggle {
+  position: absolute;
+  right: 0.8rem;
+  bottom: 0.8rem;
+  padding: 0.5rem 0.95rem;
+  color: var(--jm-papel);
+  font: inherit;
+  font-size: 0.86rem;
+  background: rgba(36, 22, 8, 0.82);
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.jmonte__toggle:hover { background: rgba(36, 22, 8, 0.95); }
+
+/* ── POSES Y SABERES ────────────────────────────────────────────────────── */
+
+.jmonte__poses,
+.jmonte__saberes {
+  max-width: 1080px;
+  margin: 0 auto clamp(1.4rem, 3.5vw, 2.6rem);
+}
+
+.jmonte__poses h2,
+.jmonte__saberes h2 {
+  margin: 0 0 0.9rem;
+  font-size: clamp(1.1rem, 3vw, 1.4rem);
+  text-align: center;
+}
+
+.jmonte__poses ul,
+.jmonte__saberes ul {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.jmonte__poses li {
+  padding: 1rem 0.9rem;
+  background: rgba(255, 253, 245, 0.68);
+  border: 1px solid var(--jm-borde);
+  border-radius: 16px;
+  text-align: center;
+}
+
+.jmonte__poses li svg { display: block; margin: 0 auto 0.5rem; }
+
+.jmonte__poses li p {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.84;
+}
+
+.jmonte__saberes li {
+  padding: 1rem;
+  background: rgba(255, 253, 245, 0.68);
+  border: 1px solid var(--jm-borde);
+  border-radius: 16px;
+}
+
+.jmonte__saberes li span {
+  display: block;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.jmonte__saberes li h3 {
+  margin: 0.4rem 0 0.35rem;
+  font-size: 1rem;
+}
+
+.jmonte__saberes li p {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.84;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .jmonte * { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; }
+}

--- a/src/mockups/JaguarMonte3D.jsx
+++ b/src/mockups/JaguarMonte3D.jsx
@@ -1,0 +1,237 @@
+/*
+ * JaguarMonte3D — LA HOJA DE PERSONAJE DEL JAGUAR (Panthera onca).
+ * Ruta #/mockups/jaguar-monte-3d, sin auth.
+ *
+ * Dos cosas en una página, porque el jaguar necesita las dos para leerse bien:
+ *
+ *   1. EL RETRATO EN GRANDE — la cabeza maciza y las ROSETAS al tamaño en que
+ *      de verdad se distinguen. A 64 px el jaguar de cualquiera parece un gato
+ *      manchado; la diferencia con el leopardo solo se ve grande. Al lado va la
+ *      lámina de la REGLA DE ORO: anillo roto + campo + PUNTOS NEGROS DENTRO.
+ *
+ *   2. EL CLARO DEL MONTE EN 3D — el felino andando de verdad por un claro, que
+ *      es donde se comprueba lo otro: que pisa el suelo, que tiene peso, que se
+ *      detiene a mirar y sigue. Un personaje quieto en fondo blanco siempre se
+ *      ve bien; caminando es donde se caen los dibujos.
+ *
+ * DIRECCIÓN DE ARTE (todo de la casa, nada inventado por fuera):
+ *   - Paleta madre (`visual/mundo3d/paleta`): VERDES por piso térmico, TIERRAS,
+ *     CORTEZAS. Ni un hex suelto de vegetación inventado acá.
+ *   - Luz: `<LuzMadre>` con la familia `CIELOS.sotobosque` mezclada por
+ *     `mezclarCielo` (la ley del 60% hacia la madre). Cero rig propio.
+ *   - El felino es el SVG rubber-hose de `creatures/Jaguar.jsx` colgado como
+ *     billboard (`fauna/JaguarBillboard.jsx`) — la fauna NO se modela en
+ *     geometría procedural: se dibuja y se cuelga.
+ *   - Toda mata fusionada pasa por `fusionarSeguro` (el merge que TRUENA en vez
+ *     de devolver null y dejar la especie invisible).
+ *
+ * RENDIMIENTO: los árboles, las piedras y las matas van instanciados (3 draw
+ * calls para todo el monte); Lambert flatShading sin shadow-map; presupuestos
+ * por `perfilDeTier`. `reducedMotion` congela el felino y pasa el frameloop a
+ * demanda. Autocontenida: cero CDN, cero imágenes externas.
+ *
+ * Español de Colombia, en "usted".
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../visual/mundo3d/deviceTier.js';
+import { Jaguar } from '../visual/creatures/index.js';
+import './JaguarMonte3D.css';
+
+const ClaroDelJaguar = lazy(() => import('../visual/mundo3d/fauna/ClaroDelJaguar.jsx'));
+
+/* Lo que enseña el jaguar (anatomía verificable, en "usted"). */
+const SABERES = [
+  {
+    emoji: '🔎',
+    titulo: 'La roseta lleva puntos adentro',
+    texto:
+      'La mancha del jaguar no es un borrón: es un anillo roto que encierra un campo de pelaje más hondo, y dentro de ese campo hay uno o varios puntos negros. El leopardo tiene el anillo, pero vacío. Ese punto de adentro es lo único que hay que mirar para saber cuál es cuál.',
+  },
+  {
+    emoji: '🐾',
+    titulo: 'Cabeza maciza, mandíbula de romper hueso',
+    texto:
+      'Es el felino con la mordida más fuerte de América, y eso se le nota en la testa: ancha, casi cuadrada, con las carrilleras marcadas. Si usted le dibuja cabeza redondita y fina, ya no es un jaguar — es un gato grande con manchas.',
+  },
+  {
+    emoji: '⚖️',
+    titulo: 'Patas cortas y gruesas, cola corta',
+    texto:
+      'El cuerpo es compacto y pesado, con el centro de gravedad bajo: patas gruesas, zarpas grandes y redondas, cola más corta que la de un leopardo o un puma. Una silueta esbelta y de patas largas es otro animal.',
+  },
+  {
+    emoji: '🌑',
+    titulo: 'El patrón cambia según la parte del cuerpo',
+    texto:
+      'Rosetas grandes con puntos en el lomo y los costados; puntos sólidos pequeños en la cabeza y hacia las patas; anillos en la cola, con la punta negra. No es el mismo dibujo repetido de la nariz al rabo.',
+  },
+];
+
+/* La lámina de la regla de oro: las tres marcas, dibujadas al lado para que la
+   diferencia se vea de una, sin tener que creerle a nadie. */
+function LaminaRosetas() {
+  const ink = '#241608';
+  const campo = '#a86a24';
+  const pelo = '#d99a45';
+  const marcas = [
+    {
+      k: 'jaguar',
+      nombre: 'Jaguar',
+      pie: 'Anillo roto + campo más hondo + PUNTOS NEGROS adentro.',
+      puntos: [
+        [-2.4, -1.6, 2.2], [2.6, 1.4, 1.8], [-0.4, 3.0, 1.4],
+      ],
+    },
+    {
+      k: 'leopardo',
+      nombre: 'Leopardo',
+      pie: 'El mismo anillo, pero vacío por dentro. Es el error más común.',
+      puntos: [],
+    },
+    {
+      k: 'solida',
+      nombre: 'Mancha sólida',
+      pie: 'Lo que lleva la cabeza y las patas del jaguar — nunca el lomo.',
+      solida: true,
+    },
+  ];
+  return (
+    <ul className="jmonte__lamina" aria-label="Cómo se distingue la roseta del jaguar">
+      {marcas.map((m) => (
+        <li key={m.k} className="jmonte__marca">
+          <svg viewBox="-16 -16 32 32" width="94" height="94" role="img" aria-label={m.nombre}>
+            <rect x="-16" y="-16" width="32" height="32" fill={pelo} rx="3" />
+            {m.solida ? (
+              <ellipse cx="0" cy="0" rx="7.4" ry="6.5" fill={ink} />
+            ) : (
+              <>
+                <ellipse cx="0" cy="0" rx="7" ry="6.2" fill={campo} opacity="0.92" />
+                <ellipse
+                  cx="0" cy="0" rx="10" ry="8.8" fill="none" stroke={ink} strokeWidth="4.6"
+                  strokeLinecap="round"
+                  strokeDasharray="17.7 4.7 15.3 5.9 10.6 4.7"
+                />
+                {m.puntos.map(([cx, cy, r], i) => (
+                  <circle key={i} cx={cx} cy={cy} r={r} fill={ink} />
+                ))}
+              </>
+            )}
+          </svg>
+          <p className="jmonte__marcaNombre">{m.nombre}</p>
+          <p className="jmonte__marcaPie">{m.pie}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function JaguarMonte3D() {
+  const decision = useMemo(() => decidirTier(), []);
+  const reducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+  const puede3D = permite3D(decision.tier);
+  const [ver2d, setVer2d] = useState(false);
+  const tier = ver2d || !puede3D ? 'bajo' : decision.tier;
+  const mostrar3D = puede3D && !ver2d;
+  const vivo = !reducedMotion;
+
+  return (
+    <main className="jmonte">
+      <header className="jmonte__head">
+        <p className="jmonte__kicker">El jaguar · hoja de personaje</p>
+        <h1>El que se para a mirarlo y después sigue</h1>
+        <p className="jmonte__lema">
+          <em>Panthera onca</em>, dibujado con la anatomía que lo separa de
+          cualquier otro felino manchado: la cabeza maciza, el cuerpo compacto y
+          las rosetas con puntos adentro. Véalo grande primero — las rosetas no
+          se distinguen chiquitas — y después camínelo por el claro.
+        </p>
+      </header>
+
+      {/* ── EL RETRATO: la cabeza al tamaño en que se puede juzgar ──────────── */}
+      <section className="jmonte__retrato" aria-label="Retrato del jaguar">
+        <figure className="jmonte__figura">
+          {/* El SVG en modo `inline` devuelve un <g>: así podemos ENCUADRAR la
+              testa con nuestro propio viewBox sin redibujar nada del personaje.
+              El cuerpo completo vive abajo, en el elenco de poses. */}
+          <svg viewBox="-11.5 -17.5 23 20" className="jmonte__retratoSvg" role="img"
+            aria-label="Retrato del jaguar: cabeza maciza y rosetas con puntos internos">
+            <Jaguar inline animated={vivo} tier={tier} />
+          </svg>
+          <figcaption>
+            La testa ancha y las carrilleras marcadas. Mire una roseta del
+            cachete: el anillo está cortado y adentro hay un punto.
+          </figcaption>
+        </figure>
+        <div className="jmonte__regla">
+          <h2>La regla de oro</h2>
+          <p>
+            Es el detalle que más se falla al dibujar un jaguar, y el campesino
+            que lo ha visto lo nota de una:
+          </p>
+          <LaminaRosetas />
+        </div>
+      </section>
+
+      {/* ── EL CLARO EN 3D: el felino andando, pisando el suelo ─────────────── */}
+      <section className="jmonte__escena" aria-label="El jaguar en el claro del monte">
+        {mostrar3D ? (
+          <Suspense fallback={<p className="jmonte__cargando">Abriendo el claro…</p>}>
+            <ClaroDelJaguar tier={tier} reducedMotion={reducedMotion} />
+          </Suspense>
+        ) : (
+          <div className="jmonte__ficha">
+            <Jaguar size={190} animated={false} tier="bajo" />
+            <p>
+              En este equipo mostramos el jaguar quieto, que se ve igual de
+              digno y no le hace sudar la máquina. El claro en 3D queda para
+              equipos con más aire.
+            </p>
+          </div>
+        )}
+        {puede3D && (
+          <button type="button" className="jmonte__toggle" onClick={() => setVer2d((v) => !v)}>
+            {ver2d ? 'Ver el claro en 3D' : 'Ver la ficha quieta'}
+          </button>
+        )}
+      </section>
+
+      {/* ── EL ELENCO DE POSES: lo mismo que el mundo va a montar ───────────── */}
+      <section className="jmonte__poses" aria-label="Poses del jaguar">
+        <h2>Las tres caras del mismo animal</h2>
+        <ul>
+          <li>
+            <Jaguar size={150} animated={vivo} tier={tier} />
+            <p><strong>En reposo.</strong> Impone sin gruñir. Ni peluche ni villano.</p>
+          </li>
+          <li>
+            <Jaguar size={150} animated={vivo} tier={tier} acecha />
+            <p><strong>Acechando.</strong> Los omóplatos suben, la testa baja, el paso se vuelve la mitad de lento.</p>
+          </li>
+          <li>
+            <Jaguar size={150} animated={vivo} tier={tier} ruge />
+            <p><strong>Rugiendo.</strong> Abre las fauces y el pecho suelta. Es su rato serio, no su carácter.</p>
+          </li>
+        </ul>
+      </section>
+
+      <section className="jmonte__saberes" aria-label="Lo que hay que mirar">
+        <h2>Cuatro cosas que hay que mirarle</h2>
+        <ul>
+          {SABERES.map((s) => (
+            <li key={s.titulo}>
+              <span aria-hidden="true">{s.emoji}</span>
+              <h3>{s.titulo}</h3>
+              <p>{s.texto}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/src/visual/creatures/Jaguar.jsx
+++ b/src/visual/creatures/Jaguar.jsx
@@ -2,7 +2,7 @@ import { useId, useRef } from 'react';
 import './creatures.css';
 import { useVidaIdle, useRitmoPropio, useMiradaUsted } from './useVidaIdle.js';
 import { CreatureFilters } from './_filters.jsx';
-import { OjosRubber, Cachetes, Sonrisa, BocaVisema, Miembro, RH_INK, RH_BOCA } from './_rubberhose.jsx';
+import { OjosRubber, Cachetes, Sonrisa, BocaVisema, RH_INK, RH_GLOVE, RH_BOCA } from './_rubberhose.jsx';
 import { JAGUAR_PALETA, JAGUAR_PROPORCION, JAGUAR_SLUG, PERFIL_JAGUAR } from './jaguarIdentidad.js';
 import { cuerpoDeClima, ropaDeClimaBicho } from './creatureClimaCuerpo.js';
 import { AccesoriosClima } from './AccesoriosClima.jsx';
@@ -29,30 +29,28 @@ import { auraDeBicho } from './transformacion.js';
    PERFIL_JAGUAR (pelaje lustroso que escurre agua, robusto ante la seca) — y de
    tierra cálida: NUNCA suda (aguanta el calor sin sudar ni sombrero).
 
-   MÍSTICO (cosmología andino-amazónica: el jaguar es el ANIMAL-ESPÍRITU DEL
-   CHAMÁN — transformación, mundo espiritual, visión nocturna, poder sagrado).
-   Tejido con gusto, permanente y sutil: OJOS LUMINOSOS que respiran
-   (fosforescencia, visión nocturna del espíritu), un AURA ESPECTRAL etérea que
-   lo envuelve (no solo en poder), CONSTELACIONES de geometría sagrada sobre las
-   rosetas (estrellas que titilan, patrón andino), un SHIMMER espectral en el
-   contorno, BRUMA etérea a los pies y MOTAS de luz que flotan lento (polvo del
-   espíritu). En modo poder el aura, los ojos y las estrellas se vuelven
-   CHAMÁNICOS, y con `revelacion` (opt-in, su entrada cinematográfica) el
-   espíritu SE MANIFIESTA: las marcas gemelas brillan sobre las rosetas, la
-   bruma se adensa y el felino levita apenas (ingravidez). Todo se PODA en tier
-   bajo / reduced-motion (queda un fotograma digno y quieto).
+   REGISTRO NOCTURNO (el felino que anda de noche, tratado como LUZ, no como
+   símbolo): OJOS LUMINOSOS que respiran (el ojo de gato que devuelve la luz),
+   un AURA tenue que lo envuelve, un TITILEO de estrellas sobre las rosetas
+   (la piel que lleva el cielo de la noche), un SHIMMER en el contorno, BRUMA a
+   los pies y MOTAS de luz que flotan lento. En modo poder el aura, los ojos y
+   las estrellas suben de intensidad, y con `revelacion` (opt-in, su entrada
+   cinematográfica) las marcas gemelas brillan sobre las rosetas, la bruma se
+   adensa y el felino levita apenas (ingravidez). Todo se PODA en tier bajo /
+   reduced-motion (queda un fotograma digno y quieto).
 
    VOLUMEN Y PESO (que parezca de verdad): el pelaje lleva GRADIENTE radial (luz
    dorsal → sombra ventral), las rosetas son ANILLOS ROTOS reales de Panthera
-   onca (arcos con cortes, giro propio por mancha, motas internas en las
-   grandes), hay definición muscular sutil en ancas y pecho, VIBRISAS y motas
+   onca (arcos con cortes, giro propio por mancha y PUNTOS NEGROS DENTRO —
+   la regla de oro anti-leopardo, en TODAS), el patrón se simplifica a puntos
+   sólidos hacia las patas, hay definición muscular sutil en ancas y pecho, VIBRISAS y motas
    oscuras en el hocico, y una SOMBRA DE SUELO blanda bajo las zarpas — un
    animal con masa, no un sticker.
 
    CARÁCTER (el registro de casa, tipo reloj-carismático de los años 30):
    CARISMÁTICO y encantador en reposo — ojos grandes ámbar con catchlight,
    sonrisa de goma, cachetes — PERO capaz de volverse SERIO e IMPONENTE
-   (acecho, rugido, revelación). Esa DUALIDAD es su corazón: guardián sagrado
+   (acecho, rugido, revelación). Esa DUALIDAD es su corazón: guardián de monte
    que cae bien y a la vez impone respeto. Nunca gore, nunca ojos vacíos. */
 const VIEWBOX = '-16 -20 32 40';
 
@@ -64,23 +62,86 @@ function anilloRoto(r) {
   return `${c * 0.3} ${c * 0.08} ${c * 0.26} ${c * 0.1} ${c * 0.18} ${c * 0.08}`;
 }
 
-/* Roseta del jaguar: ANILLO ROTO oscuro con centro ocre (la firma de la
-   especie — mancha CON centro, no el puntito del leopardo). Cada roseta gira
-   distinto (`rot`) para que los cortes del anillo no se repitan, y las GRANDES
-   del lomo llevan una mota interna extra (`motas`), como en el animal real.
+/* LA REGLA DE ORO de Panthera onca — lo que lo separa del leopardo y del
+   ocelote, y el error más repetido al dibujarlo: la roseta del jaguar NO es una
+   mancha sólida ni un aro vacío, es un ANILLO ROTO que ENCIERRA UN CAMPO de
+   pelaje más hondo, y DENTRO de ese campo hay UNO O VARIOS PUNTOS NEGROS. Sin
+   esos puntos internos el animal se lee como leopardo. Por eso `puntosInternos`
+   no es opcional: toda roseta del lomo y el flanco los lleva.
+
+   Los puntos se reparten en ángulos derivados de `rot` (determinista: la misma
+   roseta se dibuja igual en cada render, y dos rosetas vecinas nunca repiten el
+   mismo arreglo). Van a ~0.42 r del centro, dentro del campo y sin tocar el
+   anillo. */
+function puntosInternos(r, rot, n) {
+  const pts = [];
+  const base = (rot * Math.PI) / 180 + 0.7;
+  for (let i = 0; i < n; i++) {
+    // ángulos NO equidistantes (el jaguar real no tiene puntos en compás)
+    const a = base + i * 2.4 + Math.sin(rot * 0.13 + i) * 0.55;
+    const d = r * (n === 1 ? 0.2 : 0.4 + (i % 2) * 0.12);
+    pts.push({
+      x: Math.cos(a) * d,
+      y: Math.sin(a) * d * 0.88,
+      r: r * (0.19 - i * 0.025),
+    });
+  }
+  return pts;
+}
+
+/* Roseta del jaguar: ANILLO ROTO oscuro + CAMPO ocre + PUNTOS NEGROS dentro
+   (la firma de la especie). Cada roseta gira distinto (`rot`) para que los
+   cortes del anillo no se repitan, y `motas` fija cuántos puntos internos lleva
+   (las grandes del lomo, dos o tres; las chicas de la cara, uno).
    Decorativa (aria-hidden en el grupo padre). */
-function Roseta({ cx, cy, r = 1.5, ink, centro, opacity = 0.9, rot = 0, motas = 1 }) {
+function Roseta({ cx, cy, r = 1.5, ink, centro, opacity = 0.9, rot = 0, motas = 2 }) {
   return (
     <g opacity={opacity} transform={rot ? `rotate(${rot} ${cx} ${cy})` : undefined}>
+      {/* el CAMPO interior: dentro del anillo el pelaje es más hondo que afuera
+          (no un agujero de color plano) — es lo que hace que el punto negro se
+          lea como puesto SOBRE la mancha y no flotando sobre el lomo. */}
+      <ellipse cx={cx} cy={cy} rx={r * 0.62} ry={r * 0.55} fill={centro} opacity="0.92" />
+      {/* el ANILLO ROTO: arcos gruesos e irregulares, nunca un círculo perfecto */}
       <ellipse cx={cx} cy={cy} rx={r} ry={r * 0.88} fill="none" stroke={ink}
         strokeWidth={r * 0.46} strokeDasharray={anilloRoto(r)} strokeLinecap="round" />
-      <circle cx={cx} cy={cy} r={r * 0.3} fill={centro} />
-      {motas > 1 && <circle cx={cx + r * 0.38} cy={cy - r * 0.32} r={r * 0.16} fill={ink} />}
+      {/* LOS PUNTOS INTERNOS — la regla de oro, en toda roseta */}
+      {puntosInternos(r, rot, motas).map((p, i) => (
+        <circle key={i} cx={cx + p.x} cy={cy + p.y} r={p.r} fill={ink} />
+      ))}
     </g>
   );
 }
 
-/* Estrella de constelación — el titileo "de geometría sagrada" sobre las
+/* PATA DEL FELINO — la manguera rubber-hose, pero LEONADA.
+   El `Miembro` compartido dibuja la extremidad como una manguera de TINTA
+   maciza (la manga negra de los años 30, que a la abeja y al oso les queda
+   perfecta). Al jaguar lo arruinaba: cuatro mangueras negras se comen la mitad
+   del cuerpo, el pelaje leonado desaparece de las patas y —lo peor— los puntos
+   de la pata, que son parte del patrón real de la especie, quedan invisibles
+   sobre negro. Acá la manguera se dibuja DOS VECES: la de tinta abajo (que
+   queda como contorno grueso) y encima la de pelaje, un poco más delgada. Sigue
+   siendo una manguera de goma con su línea gorda; solo que ahora es un jaguar.
+   La zarpa (crema, grande y redonda) es la misma del kit. */
+function PataJaguar({
+  d, ancho, punta, puntaR, pelaje, clase, origen = 'top center', sway = false, delay = 0,
+}) {
+  const style = {
+    transformBox: 'fill-box',
+    transformOrigin: origen,
+    ...(sway ? { animationDelay: `${delay}s` } : null),
+  };
+  const clases = [sway ? 'rh-sway' : null, clase].filter(Boolean).join(' ') || undefined;
+  return (
+    <g className={clases} style={style}>
+      <path d={d} stroke={RH_INK} strokeWidth={ancho} fill="none" strokeLinecap="round" strokeLinejoin="round" />
+      <path d={d} stroke={pelaje} strokeWidth={Math.max(0.8, ancho - 1.25)} fill="none" strokeLinecap="round" strokeLinejoin="round" />
+      <ellipse cx={punta[0]} cy={punta[1]} rx={puntaR * 1.15} ry={puntaR * 0.72}
+        fill={RH_GLOVE} stroke={RH_INK} strokeWidth="0.7" />
+    </g>
+  );
+}
+
+/* Estrella de constelación — el titileo de estrellas sobre las
    rosetas (el jaguar-espíritu lleva el cielo nocturno en la piel). Sparkle de 4
    puntas; titila (.jaguar-estrella) solo viva — con animated=false / RM queda
    quieta y digna. */
@@ -102,38 +163,74 @@ function Estrella({ cx, cy, r = 0.9, color, delay = 0, vivo = false }) {
 /* ROSETAS del cuerpo y la cara, como DATOS (una sola fuente): las dibuja la
    capa de tinta y las REUSA la capa de marcas-espíritu (las gemelas
    espectrales que se encienden en la revelación). rot varía el corte del
-   anillo; las dos grandes del lomo llevan mota interna (motas: 2). */
+   anillo; `motas` es cuántos PUNTOS NEGROS lleva dentro (nunca cero).
+
+   EL PATRÓN VA POR ZONAS, que es como lo lleva el animal: ROSETAS en el
+   costado y el anca (el pelaje leonado), PUNTOS SÓLIDOS en el vientre crema y
+   en las patas. Antes estaban todas apiñadas encima de la panza clara: se leían
+   como una condecoración en el pecho y dejaban los flancos lisos. */
 const ROSETAS_CUERPO = [
-  { cx: -5.4, cy: 2.6, r: 1.5, rot: 15, motas: 2 },
-  { cx: -2.0, cy: 5.0, r: 1.35, rot: 130 },
-  { cx: 5.6, cy: 1.4, r: 1.5, rot: 250, motas: 2 },
-  { cx: 6.6, cy: 4.6, r: 1.15, rot: 40, o: 0.8 },
-  { cx: 2.4, cy: -0.6, r: 1.2, rot: 205, o: 0.85 },
-  { cx: -6.6, cy: -0.8, r: 1.2, rot: 320, o: 0.8 },
+  /* COSTADOS: las más grandes, con tres puntos dentro — es donde el patrón del
+     jaguar se lee mejor y donde el error del leopardo se nota primero. */
+  { cx: -6.0, cy: 0.4, r: 1.28, rot: 15, motas: 3 },
+  { cx: 6.0, cy: 0.2, r: 1.28, rot: 250, motas: 3 },
+  /* ANCAS */
+  { cx: -6.2, cy: 4.2, r: 1.08, rot: 130, o: 0.92, motas: 2 },
+  { cx: 6.2, cy: 4.4, r: 1.08, rot: 40, o: 0.92, motas: 2 },
+  /* la vuelta baja del costado, ya cerca de la pata */
+  { cx: -4.7, cy: 7.6, r: 0.95, rot: 320, o: 0.9, motas: 2 },
+  { cx: 4.7, cy: 7.7, r: 0.95, rot: 205, o: 0.9, motas: 2 },
 ];
+
+/* VIENTRE: el pecho y la panza del jaguar son claros y llevan MANCHAS SÓLIDAS,
+   no rosetas. Es la misma regla zonal de la cabeza y las patas. */
+const PUNTOS_VIENTRE = [
+  { cx: -1.9, cy: 1.1, r: 0.3 }, { cx: 1.5, cy: 0.2, r: 0.25 },
+  { cx: -0.6, cy: 3.4, r: 0.32 }, { cx: 2.3, cy: 4.0, r: 0.24 },
+  { cx: -2.5, cy: 5.6, r: 0.27 }, { cx: 0.7, cy: 6.9, r: 0.22 },
+  { cx: -3.1, cy: 2.5, r: 0.21 }, { cx: 2.9, cy: 2.0, r: 0.19 },
+];
+/* CARA: en el jaguar real la cabeza lleva sobre todo puntos sólidos y rosetas
+   PEQUEÑAS — por eso acá el radio baja y cada una lleva un solo punto interno. */
 const ROSETAS_CARA = [
-  { cx: -3.4, cy: -10.6, r: 0.95, rot: 25, o: 0.8 },
-  { cx: 3.4, cy: -10.6, r: 0.95, rot: 200, o: 0.8 },
-  { cx: -4.8, cy: -7.6, r: 0.85, rot: 95, o: 0.7 },
-  { cx: 4.8, cy: -7.6, r: 0.85, rot: 300, o: 0.7 },
+  { cx: -3.4, cy: -10.6, r: 0.95, rot: 25, o: 0.8, motas: 1 },
+  { cx: 3.4, cy: -10.6, r: 0.95, rot: 200, o: 0.8, motas: 1 },
+  { cx: -4.8, cy: -7.6, r: 0.85, rot: 95, o: 0.7, motas: 1 },
+  { cx: 4.8, cy: -7.6, r: 0.85, rot: 300, o: 0.7, motas: 1 },
+];
+
+/* PATAS: hacia las extremidades el patrón se SIMPLIFICA — las rosetas se
+   vuelven puntos sólidos pequeños (dato del DR primario). Sin esta transición
+   las cuatro patas quedan lisas y el animal parece dos dibujos pegados. */
+const PUNTOS_PATAS = [
+  /* patas delanteras (la manguera va de (-7,-1) a (-9.6,5.8)) */
+  { cx: -8.7, cy: 1.3, r: 0.3 }, { cx: -9.5, cy: 3.3, r: 0.25 },
+  { cx: 8.7, cy: 1.3, r: 0.3 }, { cx: 9.5, cy: 3.3, r: 0.25 },
+  /* traseras: solo lo que asoma bajo el tronco */
+  { cx: -7.9, cy: 10.3, r: 0.26 }, { cx: 7.9, cy: 10.3, r: 0.26 },
 ];
 
 /* Vértices de la constelación: coinciden con centros de rosetas para que el
    "cielo" viva SOBRE las manchas. Partida en dos: el LOMO (grandes + menores,
-   la telaraña sagrada) va en el tronco; la FRENTE va DENTRO del grupo de la
+   la retícula del lomo) va en el tronco; la FRENTE va DENTRO del grupo de la
    cabeza (si no, el círculo de la cabeza — que se pinta después — la tapa) y
-   así además acompaña el acecho cuando la testa baja. */
+   así además acompaña el acecho cuando la testa baja.
+
+   OJO — las estrellas van al BORDE de la mancha, nunca en el centro: el centro
+   es de los PUNTOS NEGROS (la firma de la especie). Cuando la estrella se
+   plantaba justo en el medio, tapaba el dato que este personaje existe para
+   enseñar y la roseta volvía a leerse como una condecoración. */
 const ESTRELLAS_LOMO = [
-  { cx: -5.4, cy: 2.6, r: 0.95, d: -1.1 },
-  { cx: 2.4, cy: -0.6, r: 0.8, d: -0.7 },
-  { cx: 5.6, cy: 1.4, r: 0.95, d: -1.5 },
-  { cx: -6.6, cy: -0.8, r: 0.55, d: -0.3 },
-  { cx: -2.0, cy: 5.0, r: 0.5, d: -1.9 },
-  { cx: 6.6, cy: 4.6, r: 0.55, d: -2.2 },
+  { cx: -4.9, cy: -0.5, r: 0.42, d: -1.1 },
+  { cx: 4.9, cy: -0.7, r: 0.42, d: -0.7 },
+  { cx: -5.2, cy: 2.6, r: 0.3, d: -1.5 },
+  { cx: 5.2, cy: 2.8, r: 0.3, d: -0.3 },
+  { cx: -3.6, cy: 6.4, r: 0.26, d: -1.9 },
+  { cx: 3.6, cy: 6.5, r: 0.26, d: -2.2 },
 ];
 const ESTRELLAS_FRENTE = [
-  { cx: -3.4, cy: -10.6, r: 0.85, d: 0 },
-  { cx: 3.4, cy: -10.6, r: 0.85, d: -0.5 },
+  { cx: -4.3, cy: -11.5, r: 0.5, d: 0 },
+  { cx: 4.3, cy: -11.5, r: 0.5, d: -0.5 },
 ];
 
 /* MOTAS de luz (polvo del espíritu): flotan lento alrededor del felino, cada
@@ -147,10 +244,10 @@ const MOTAS = [
   { cx: 6.4, cy: -10.2, r: 0.4, d: -5.2, s: 6.1 },
 ];
 
-/* GLIFO ESPIRAL — geometría sagrada (espiral, principio estético andino: San
-   Agustín / Chavín / orfebrería, NO copia de un diseño específico). Símbolo de
-   PODER como adorno (nunca arma). Invisible en reposo; se enciende en la
-   revelación / el poder. Se posiciona/espeja con transform en cada hombro. */
+/* GLIFO ESPIRAL — ornamento geométrico puro (una espiral abierta, dibujada
+   para este personaje; no cita ni reproduce ningún diseño de nadie). Adorno de
+   hombro, nunca arma. Invisible en reposo; se enciende en la revelación / el
+   poder. Se posiciona/espeja con transform en cada hombro. */
 const GLIFO_ESPIRAL = 'M0,0 C0.3,-0.3 0.75,-0.15 0.85,0.35 C0.95,0.95 0.35,1.4 -0.4,1.15 '
   + 'C-1.35,0.85 -1.6,-0.35 -0.95,-1.15 C-0.2,-2.05 1.3,-1.95 2.05,-0.95';
 
@@ -228,7 +325,7 @@ export function Jaguar({
      marcas-espíritu (rosetas gemelas espectrales) se encienden y laten, la
      bruma etérea se adensa, el felino LEVITA apenas (ingravidez contenida), la
      sombra del suelo cede (el peso se vuelve espíritu) y aura/ojos/estrellas
-     suben a su registro chamánico. MAJESTAD, no susto: todo lento y digno.
+     suben a su registro nocturno. MAJESTAD, no susto: todo lento y digno.
      Default false → los consumidores actuales NO cambian. Se poda en tier
      bajo / reduced-motion (quedan las marcas encendidas, quietas). */
   revelacion = false,
@@ -236,7 +333,7 @@ export function Jaguar({
      OPT-IN: con aparicion=true el jaguar-espíritu APARECE y DESAPARECE
      místicamente en ciclo — se desvanece casi por completo y vuelve a
      materializarse desde la bruma (opacidad que respira + emergencia leve,
-     como una presencia sagrada que va y viene). Pensado para su entrada/
+     como una presencia que va y viene). Pensado para su entrada/
      ambiente en el valle/bosque. Default false → los consumidores actuales NO
      cambian. Se poda en tier bajo / reduced-motion (queda PRESENTE y quieto,
      nunca invisible — fotograma digno). */
@@ -339,9 +436,9 @@ export function Jaguar({
           la revelación CEDE por CSS (el peso se vuelve espíritu). */}
       <ellipse className="jaguar-sombra-suelo" cx="0" cy="13.2" rx="8.2" ry="1.5"
         fill={P.sombraSuelo} filter={`url(#${blur})`} aria-hidden="true" />
-      {/* AURA ESPECTRAL etérea (PERMANENTE, sutil): la presencia sagrada del
-          jaguar-espíritu del chamán envuelve al felino aun en reposo. Late lento
-          y se vuelve CHAMÁNICA en modo poder (CSS). */}
+      {/* AURA ESPECTRAL etérea (PERMANENTE, sutil): un halo de luz nocturna
+          envuelve al felino aun en reposo. Late lento
+          y sube de intensidad en modo poder (CSS). */}
       <circle className={vivo ? 'jaguar-aura-espectral' : undefined}
         cx="0" cy="1.4" r={auraR + 2.6} fill={P.espectral} opacity="0.13"
         filter={`url(#${blur})`}
@@ -384,8 +481,8 @@ export function Jaguar({
       {/* patas traseras GRUESAS y CORTAS (muslos musculosos con planta crema,
           zarpas grandes y redondas — centro de gravedad bajo, anti-leopardo).
           Se mecen suave. */}
-      <Miembro d="M-6.6,7.4 C-8.4,9.0 -8.6,10.6 -7.4,11.8" ancho={4.2} punta={[-7.4, 12.0]} puntaR={2.6} pie sway={vivo} delay={-0.7} />
-      <Miembro d="M6.6,7.4 C8.4,9.0 8.6,10.6 7.4,11.8" ancho={4.2} punta={[7.4, 12.0]} puntaR={2.6} pie sway={vivo} delay={-1.0} />
+      <PataJaguar d="M-6.6,7.4 C-8.4,9.0 -8.6,10.6 -7.4,11.8" ancho={4.2} punta={[-7.4, 12.0]} puntaR={2.6} pelaje={P.cuerpoSombra} sway={vivo} delay={-0.7} />
+      <PataJaguar d="M6.6,7.4 C8.4,9.0 8.6,10.6 7.4,11.8" ancho={4.2} punta={[7.4, 12.0]} puntaR={2.6} pelaje={P.cuerpoSombra} sway={vivo} delay={-1.0} />
 
       {/* tronco leonado musculoso con contorno grueso (la línea que respira con
           el boil). El fill es el GRADIENTE de pelaje: luz dorsal → sombra
@@ -393,12 +490,14 @@ export function Jaguar({
       <ellipse cx="0" cy="2" rx={PR.troncoRx} ry={PR.troncoRy}
         fill={`url(#${pelaje})`} stroke={RH_INK} strokeWidth="1.4"
         style={{ filter: `drop-shadow(0 0 6px ${P.cuerpoGlow})` }} />
-      {/* SHIMMER MÍSTICO — destello espectral sutil en el contorno (se apoya en
-          el glow del cuerpo; el line-boil lo remata en su entrada heroica).
-          Pulsa lento; se intensifica en modo poder (CSS). */}
+      {/* SHIMMER — el destello del pelaje al borde del cuerpo. Iba en VIOLETA
+          espectral a opacidad 0.16 y a tamaño de retrato se leía como un ARO
+          morado atravesado en el pecho: exactamente el tipo de aro que está
+          prohibido en el elenco. Ahora es CÁLIDO (la luz del propio pelaje) y
+          casi transparente: sigue respirando, ya no dibuja un anillo. */}
       <ellipse className={vivo ? 'jaguar-shimmer' : undefined}
         cx="0" cy="2" rx={PR.troncoRx} ry={PR.troncoRy}
-        fill="none" stroke={P.espectral} strokeWidth="0.8" opacity="0.16" aria-hidden="true" />
+        fill="none" stroke={P.cuerpoLuz} strokeWidth="0.7" opacity="0.1" aria-hidden="true" />
       {/* vientre/pecho crema */}
       <path d="M0,-4.2 C4.2,-3.2 5.4,2 4.0,6.2 C2.4,9.0 -2.4,9.0 -4.0,6.2 C-5.4,2 -4.2,-3.2 0,-4.2 Z"
         fill={P.vientre} opacity="0.9" />
@@ -421,7 +520,13 @@ export function Jaguar({
       <g aria-hidden="true">
         {ROSETAS_CUERPO.map((m, i) => (
           <Roseta key={i} cx={m.cx} cy={m.cy} r={m.r} rot={m.rot} motas={m.motas}
-            ink={P.roseta} centro={P.rosetaCentro} opacity={m.o ?? 0.9} />
+            ink={P.roseta} centro={P.rosetaCentro} opacity={m.o ?? 0.95} />
+        ))}
+      </g>
+      {/* MANCHAS SÓLIDAS del vientre claro (la zona ventral no lleva rosetas). */}
+      <g aria-hidden="true" fill={P.roseta} opacity="0.72">
+        {PUNTOS_VIENTRE.map((p, i) => (
+          <circle key={i} cx={p.cx} cy={p.cy} r={p.r} />
         ))}
       </g>
       {/* MARCAS-ESPÍRITU del lomo — las rosetas gemelas espectrales: invisibles
@@ -436,14 +541,14 @@ export function Jaguar({
         ))}
       </g>
 
-      {/* CONSTELACIÓN del lomo — geometría sagrada sobre las rosetas: la
+      {/* CONSTELACIÓN del lomo — retícula de estrellas sobre las rosetas: la
           telaraña de líneas etéreas punteadas (el patrón andino) RESPIRA
           (pulso co-primo con el titilar) y las estrellas TITILAN en los
           centros de mancha — grandes en los vértices mayores, menores en los
           secundarios. El cielo nocturno del jaguar-espíritu. Decorativa. */}
       <g className="jaguar-constelacion" aria-hidden="true">
         <path className={vivo ? 'jaguar-constelacion-linea' : undefined}
-          d="M-6.6,-0.8 L-5.4,2.6 L-2.0,5.0 M-5.4,2.6 L2.4,-0.6 L5.6,1.4 L6.6,4.6"
+          d="M-4.9,-0.5 L-5.2,2.6 L-3.6,6.4 M4.9,-0.7 L5.2,2.8 L3.6,6.5"
           fill="none" stroke={P.espectral}
           strokeWidth="0.3" strokeLinecap="round" strokeDasharray="0.5 1.1" opacity="0.28" />
         {ESTRELLAS_LOMO.map((e, i) => (
@@ -460,7 +565,7 @@ export function Jaguar({
         <path d="M6.4,-1.4 Q4.4,-6.2 1.8,-2.6 Z" fill={P.hombro} stroke={RH_INK} strokeWidth="1.1" strokeLinejoin="round" />
       </g>
 
-      {/* GLIFOS SAGRADOS — espirales de geometría andina (cobre de orfebrería)
+      {/* GLIFOS — espirales de ornamento geométrico (acento cobre)
           sobre los hombros. Símbolo de poder como ADORNO (nunca arma).
           Invisibles en reposo; se encienden en la revelación / el poder (CSS).
           Van sobre el lomo, bajo los bracitos y la cabeza. Decorativos. */}
@@ -473,10 +578,19 @@ export function Jaguar({
       {/* bracitos manguera GRUESOS (zarpas delanteras grandes y redondas) con
           planta crema, pivote en el HOMBRO para que celebra/señala los alcen
           desde el hombro. Patas cortas y macizas — el felino asienta bajo. */}
-      <Miembro clase="crt-brazo-l" origen="right top"
-        d="M-7.0,-1.0 C-9.6,0.6 -10.4,3.2 -9.6,5.8" ancho={3.9} punta={[-9.6, 6.2]} puntaR={2.6} pie sway={vivo} delay={-0.15} />
-      <Miembro clase="crt-brazo-r" origen="left top"
-        d="M7.0,-1.0 C9.6,0.6 10.4,3.2 9.6,5.8" ancho={3.9} punta={[9.6, 6.2]} puntaR={2.6} pie sway={vivo} delay={-0.45} />
+      <PataJaguar clase="crt-brazo-l" origen="right top"
+        d="M-7.0,-1.0 C-9.6,0.6 -10.4,3.2 -9.6,5.8" ancho={3.9} punta={[-9.6, 6.2]} puntaR={2.6} pelaje={P.cuerpo} sway={vivo} delay={-0.15} />
+      <PataJaguar clase="crt-brazo-r" origen="left top"
+        d="M7.0,-1.0 C9.6,0.6 10.4,3.2 9.6,5.8" ancho={3.9} punta={[9.6, 6.2]} puntaR={2.6} pelaje={P.cuerpo} sway={vivo} delay={-0.45} />
+
+      {/* PUNTOS DE LAS PATAS — la transición del patrón: rosetas grandes en el
+          lomo, puntos sólidos chicos en las extremidades. Van DESPUÉS de los
+          miembros (si no, las patas los taparían). Decorativos. */}
+      <g aria-hidden="true" fill={P.roseta} opacity="0.6">
+        {PUNTOS_PATAS.map((p, i) => (
+          <circle key={i} cx={p.cx} cy={p.cy} r={p.r} />
+        ))}
+      </g>
 
       {/* CABEZA MACIZA (grupo propio .jaguar-cabeza para que el ACECHO la baje).
           Ancha y robusta — el jaguar tiene la cabeza más maciza y la mordida
@@ -526,7 +640,7 @@ export function Jaguar({
             el círculo, si no quedaba oculta) y baja con la testa en el acecho. */}
         <g className="jaguar-constelacion" aria-hidden="true">
           <path className={vivo ? 'jaguar-constelacion-linea' : undefined}
-            d="M-3.4,-10.6 L3.4,-10.6" fill="none" stroke={P.espectral}
+            d="M-4.3,-11.5 L4.3,-11.5" fill="none" stroke={P.espectral}
             strokeWidth="0.3" strokeLinecap="round" strokeDasharray="0.5 1.1" opacity="0.28" />
           {ESTRELLAS_FRENTE.map((e, i) => (
             <Estrella key={i} cx={e.cx} cy={e.cy} r={e.r} delay={e.d} color={P.estrella} vivo={vivo} />
@@ -576,9 +690,9 @@ export function Jaguar({
             <circle cx="-2.5" cy="-9.2" r="1.44" />
             <circle cx="2.5" cy="-9.2" r="1.44" />
           </g>
-          {/* OJOS LUMINOSOS — fosforescencia del espíritu (visión nocturna del
-              chamán): un halo suave que respira sobre cada ojo. Sutil siempre;
-              CHAMÁNICO (más brillante) en modo poder / revelación (CSS). */}
+          {/* OJOS LUMINOSOS — el tapetum del felino, el ojo que devuelve la luz
+              de noche: un halo suave que respira sobre cada ojo. Sutil siempre;
+              MÁS BRILLANTE en modo poder / revelación (CSS). */}
           <g className={vivo ? 'jaguar-ojo-brillo' : undefined} filter={`url(#${blur})`} aria-hidden="true"
             style={{ transformBox: 'fill-box', transformOrigin: 'center' }}>
             <circle cx="-2.5" cy="-9.2" r="1.25" fill={P.ojoBrillo} opacity="0.55" />

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1291,14 +1291,14 @@
 }
 
 /* ───────────────────────────────────────────────────────────────────────────
-   JAGUAR MÍSTICO — el animal-espíritu del chamán (cosmología andino-amazónica).
+   JAGUAR NOCTURNO — el felino que anda de noche, tratado como LUZ.
    Capas PERMANENTES y sutiles (elegante, no recargado): aura espectral etérea,
    ojos luminosos (fosforescencia), estrellas de constelación en las rosetas y
-   un shimmer espectral. En modo poder se vuelven CHAMÁNICAS (se revela el
+   un shimmer espectral. En modo poder se vuelven más intensas (se revela el
    espíritu). Todo transform/opacity. Se PODA en tier bajo / reduced-motion.
    ─────────────────────────────────────────────────────────────────────────── */
 
-/* AURA ESPECTRAL — la presencia sagrada envuelve al felino; respira lento. */
+/* AURA ESPECTRAL — la presencia envuelve al felino; respira lento. */
 .jaguar-aura-espectral {
   animation: jaguar-aura-espectral 5.2s ease-in-out infinite;
 }
@@ -1357,7 +1357,7 @@
   50%      { opacity: 0.16; transform: translateX(0.5px) scaleX(1.07); }
 }
 
-/* LÍNEAS DE LA CONSTELACIÓN — la geometría sagrada respira (pulso lentísimo,
+/* LÍNEAS DE LA CONSTELACIÓN — la retícula de estrellas respira (pulso lentísimo,
    período co-primo con el titilar de las estrellas). */
 .jaguar-constelacion-linea {
   animation: jaguar-constelacion-linea 6.2s ease-in-out infinite;
@@ -1371,33 +1371,33 @@
    encienden cuando el espíritu se revela (revelación / modo poder, abajo). */
 .jaguar-marcas-espiritu { opacity: 0; }
 
-/* MODO PODER CHAMÁNICO — el jaguar-espíritu se revela: el aura, los ojos y las
+/* MODO PODER NOCTURNO — el felino se revela: el aura, los ojos y las
    estrellas se intensifican y aceleran. Vale tanto en standalone (wrapper
    .jaguar-poder) como en inline (data-poder en el <g>). */
 .jaguar-poder .jaguar-aura-espectral,
 [data-creature='jaguar'][data-poder='1'] .jaguar-aura-espectral {
-  animation-name: jaguar-aura-chaman;
+  animation-name: jaguar-aura-noche;
   animation-duration: 3.0s;
 }
-@keyframes jaguar-aura-chaman {
+@keyframes jaguar-aura-noche {
   0%, 100% { opacity: 0.22; transform: scale(1.02); }
   50%      { opacity: 0.4;  transform: scale(1.1); }
 }
 .jaguar-poder .jaguar-ojo-brillo,
 [data-creature='jaguar'][data-poder='1'] .jaguar-ojo-brillo {
-  animation-name: jaguar-ojo-chaman;
+  animation-name: jaguar-ojo-noche;
   animation-duration: 2.1s;
 }
-@keyframes jaguar-ojo-chaman {
+@keyframes jaguar-ojo-noche {
   0%, 100% { opacity: 0.85; transform: scale(1.02); }
   50%      { opacity: 1;    transform: scale(1.22); }
 }
 .jaguar-poder .jaguar-estrella,
 [data-creature='jaguar'][data-poder='1'] .jaguar-estrella {
-  animation-name: jaguar-titilar-chaman;
+  animation-name: jaguar-titilar-noche;
   animation-duration: 1.5s;
 }
-@keyframes jaguar-titilar-chaman {
+@keyframes jaguar-titilar-noche {
   0%, 100% { opacity: 0.6; transform: scale(1); }
   50%      { opacity: 1;   transform: scale(1.4); }
 }
@@ -1412,18 +1412,18 @@
    La entrada cinematográfica: el jaguar-espíritu SE MANIFIESTA — las marcas
    gemelas brillan sobre las rosetas, la bruma se adensa, el felino LEVITA
    apenas (ingravidez contenida), la sombra del suelo cede (el peso se vuelve
-   espíritu) y aura/ojos/estrellas suben a su registro chamánico. MAJESTAD, no
+   espíritu) y aura/ojos/estrellas suben a su registro nocturno. MAJESTAD, no
    susto: todo lento, digno, transform/opacity. */
 [data-creature='jaguar'][data-revelacion='1'] .jaguar-aura-espectral {
-  animation-name: jaguar-aura-chaman;
+  animation-name: jaguar-aura-noche;
   animation-duration: 3.4s;
 }
 [data-creature='jaguar'][data-revelacion='1'] .jaguar-ojo-brillo {
-  animation-name: jaguar-ojo-chaman;
+  animation-name: jaguar-ojo-noche;
   animation-duration: 2.4s;
 }
 [data-creature='jaguar'][data-revelacion='1'] .jaguar-estrella {
-  animation-name: jaguar-titilar-chaman;
+  animation-name: jaguar-titilar-noche;
   animation-duration: 1.7s;
 }
 [data-creature='jaguar'][data-revelacion='1'] .jaguar-shimmer { animation-duration: 2.6s; }
@@ -1462,7 +1462,7 @@
   50%      { opacity: 0.85; }
 }
 
-/* GLIFOS SAGRADOS (espirales cobre) — invisibles en reposo; se encienden y
+/* GLIFOS (espirales cobre, ornamento geométrico) — invisibles en reposo; se encienden y
    laten en la revelación / el poder (símbolo de poder como adorno). */
 .jaguar-glifos { opacity: 0; }
 [data-creature='jaguar'][data-revelacion='1'] .jaguar-glifos,
@@ -1502,7 +1502,7 @@
 }
 
 /* ── APARICIÓN ESPECTRAL — el jaguar-espíritu se MATERIALIZA y se DESVANECE ───
-   Ciclo místico de presencia (opt-in, data-aparicion): emerge desde la bruma
+   Ciclo de presencia (opt-in, data-aparicion): emerge desde la bruma
    (opacidad que sube + leve escala/ascenso, como si se condensara del aire) se
    queda un rato PRESENTE y vuelve a disolverse en la nada. Solo opacity+transform
    (GPU). El nodo .jaguar-aparicion envuelve TODO el dibujo por fuera de la
@@ -1515,7 +1515,7 @@
   0%   { opacity: 0;    transform: scale(0.94) translateY(1.3px); }  /* la nada */
   14%  { opacity: 0.22; transform: scale(0.97) translateY(0.6px); }  /* se insinúa */
   32%  { opacity: 1;    transform: scale(1) translateY(0); }         /* materializado */
-  66%  { opacity: 1;    transform: scale(1) translateY(0); }         /* presente, sagrado */
+  66%  { opacity: 1;    transform: scale(1) translateY(0); }         /* presente, pleno */
   86%  { opacity: 0.18; transform: scale(0.985) translateY(0.5px); } /* se disuelve */
   100% { opacity: 0;    transform: scale(0.94) translateY(1.3px); }  /* vuelve a la nada */
 }

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1825,7 +1825,7 @@
 [data-creature='borugo'][data-acurruca='1'] .rh-antic,
 [data-creature='borugo'][data-acurruca='1'] .rh-travieso { animation: none; }
 
-/* ── NOCTURNO SAGRADO — el brillo lunar (permanente y sutil) ─────────────────
+/* ── NOCTURNO — el brillo lunar (permanente y sutil) ─────────────────
    Las MOTAS crema de los flancos brillan tenue y los OJOS grandes reflejan la
    luna; en modo poder se vuelve PLATA LUNAR pleno (el ser protegido se revela). */
 .borugo-motas-luz {

--- a/src/visual/creatures/jaguarIdentidad.js
+++ b/src/visual/creatures/jaguarIdentidad.js
@@ -48,16 +48,16 @@ export const JAGUAR_PALETA = {
   colmillo: '#fff8ec',      // colmillos del rugido
   vibrisa: '#f7edd8',       // bigotes (vibrisas) crema claro
   sombraSuelo: 'rgba(36,22,8,0.38)', // la sombra bajo las zarpas (peso real)
-  /* ── Místico (el jaguar-espíritu del chamán, cosmología andino-amazónica) ──
-     Paleta de acentos: violeta/azul (cielo nocturno, la piel = noche estrellada)
-     + DORADO/COBRE (orfebrería andina Tairona/Zenú + el sol del jaguar). */
-  espectral: '#b98cff',     // aura etérea / presencia sagrada (violeta espectral)
-  estrella: '#efe6ff',      // el titileo de las constelaciones en las rosetas
-  ojoBrillo: '#ffe6a0',     // fosforescencia del ojo-espíritu (visión nocturna)
-  bruma: '#cdb4ff',         // el velo de niebla del mundo-espíritu a los pies
-  mota: '#ece1ff',          // motas de luz que flotan lento (polvo del espíritu)
+  /* ── Registro NOCTURNO (el felino que anda de noche, como LUZ y no como
+     símbolo) — acentos violeta/azul del cielo de noche + un cobre cálido que
+     lo amarra al resto del elenco. */
+  espectral: '#b98cff',     // el halo tenue que lo envuelve (violeta espectral)
+  estrella: '#efe6ff',      // el titileo de estrellas sobre las rosetas
+  ojoBrillo: '#ffe6a0',     // el ojo que devuelve la luz de noche (tapetum)
+  bruma: '#cdb4ff',         // el velo de niebla a los pies
+  mota: '#ece1ff',          // motas de luz que flotan lento
   marcaEspiritu: '#c9a4ff', // las rosetas gemelas que BRILLAN en la revelación
-  cobre: '#e0a24a',         // glifos de geometría sagrada (cobre de orfebrería)
+  cobre: '#e0a24a',         // glifos de ornamento geométrico (acento cobre)
 };
 
 export const JAGUAR_PROPORCION = {

--- a/src/visual/mundo3d/fauna/ClaroDelJaguar.jsx
+++ b/src/visual/mundo3d/fauna/ClaroDelJaguar.jsx
@@ -1,0 +1,306 @@
+/*
+ * ClaroDelJaguar — EL CLARO DEL MONTE donde el jaguar camina de verdad.
+ *
+ * La escena existe para probar UNA cosa que un dibujo quieto nunca prueba: que
+ * el felino PISA. Por eso el claro es deliberadamente sobrio — una vaguada de
+ * monte templado con su sendero de tierra, el monte cerrando al fondo, matas de
+ * hierba y piedra — y toda la atención se la lleva el animal andando.
+ *
+ * LEY DE LA CASA, sin excepciones:
+ *   - Color: SOLO de la paleta madre (`../paleta`). Ni un hex de vegetación
+ *     inventado acá; lo que falta se deriva con `mezclar` desde el pariente.
+ *   - Luz: `<LuzMadre>` con la familia `CIELOS.sotobosque` mezclada 60% hacia la
+ *     madre por `mezclarCielo`. Cero rig propio, cero números calcados.
+ *   - Geometría fusionada: `fusionarSeguro` SIEMPRE. Mezclar una geometría
+ *     indexada con una no indexada hace que `mergeGeometries` devuelva null EN
+ *     SILENCIO y la especie no se dibuje — acá truena y dice quién falló.
+ *   - La fauna es SVG colgado como billboard (`JaguarBillboard`), nunca un
+ *     felino de geometría procedural.
+ *
+ * RENDIMIENTO: el monte entero son 3 InstancedMesh (árbol, mata, piedra) sobre
+ * geometrías ya fusionadas → 3 draw calls; Lambert flatShading sin shadow-map;
+ * los conteos salen de `perfilDeTier`. Con `reducedMotion` el frameloop pasa a
+ * demanda y el jaguar queda quieto y digno.
+ *
+ * Vive en el chunk perezoso `vendor-three` (importa three/@react-three).
+ */
+import { useEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { VERDES, TIERRAS, CORTEZAS, CIELOS, mezclar, mezclarCielo, LuzMadre } from '../paleta/index.js';
+import { perfilDeTier } from '../deviceTier.js';
+import { fusionarSeguro, poner } from '../bosque/sombreadoVegetal.js';
+import { crearRng } from '../particulasData.js';
+import JaguarBillboard from './JaguarBillboard.jsx';
+
+/* La familia de cielo del sotobosque, ya mezclada hacia la madre (ley del 60%). */
+const CIELO = CIELOS.sotobosque;
+
+/* Paleta del claro: TODO derivado de la paleta madre. El piso es templado (la
+   franja donde el monte todavía es cerrado), tinteado apenas hacia la niebla
+   del sotobosque para que no se despegue del resto de los mundos. */
+const NIEBLA = mezclarCielo(CIELO).niebla;
+const P = {
+  pastoSol: mezclar(VERDES.brote, NIEBLA, 0.2),
+  pasto: mezclar(VERDES.trabajo, NIEBLA, 0.24),
+  pastoSombra: mezclar(VERDES.monte, NIEBLA, 0.26),
+  sendero: mezclar(TIERRAS.camino, NIEBLA, 0.22),
+  hojarasca: mezclar(TIERRAS.mantillo, NIEBLA, 0.2),
+  copa: mezclar(VERDES.monte, NIEBLA, 0.3),
+  copaSol: mezclar(VERDES.templado, NIEBLA, 0.26),
+  tronco: mezclar(CORTEZAS.roble, NIEBLA, 0.22),
+  piedra: mezclar(TIERRAS.piedra, NIEBLA, 0.3),
+};
+
+const ANCHO = 30;
+const FONDO = 26;
+
+/* Ruido determinista (hash de senos): el mismo claro en cada visita. */
+function ruido(x, z) {
+  return (
+    Math.sin(x * 0.7 + z * 0.5) * 0.5 +
+    Math.sin(x * 1.7 - z * 1.3 + 2.1) * 0.32 +
+    Math.sin(x * 3.3 + z * 2.5 + 4.7) * 0.18
+  );
+}
+
+/* La geografía: una VAGUADA — el claro se hunde apenas en el centro y el monte
+   sube por los bordes. Eso es lo que hace que el felino se lea "adentro" del
+   monte y no parado en una mesa. */
+function alturaClaro(x, z) {
+  const r = Math.hypot(x / (ANCHO * 0.5), z / (FONDO * 0.5));
+  // el monte sube alrededor — suave, para que la cámara no quede ENTERRADA
+  // en el borde de la vaguada (con el reborde empinado el claro se comía la toma).
+  const borde = Math.max(0, r - 0.55) ** 2 * 4.2;
+  return borde + ruido(x * 0.3, z * 0.3) * 0.2;
+}
+
+/* El sendero: una banda de tierra pisada que cruza el claro. Devuelve 0..1 (1 =
+   plena huella). Es lo que le da al claro una dirección de lectura. */
+function sendero(x, z) {
+  const d = Math.abs(x * 0.36 + z * 0.24);
+  return Math.max(0, 1 - d / 1.5);
+}
+
+/* Malla del claro con color por vértice. Indexada y luego desindexada en bloque
+   (todo el atributo uniforme): sale del taller, no del ojo. */
+function construirClaro(seg) {
+  const nx = seg + 1;
+  const pos = new Float32Array(nx * nx * 3);
+  const col = new Float32Array(nx * nx * 3);
+  const cSol = new THREE.Color(P.pastoSol);
+  const cPasto = new THREE.Color(P.pasto);
+  const cSombra = new THREE.Color(P.pastoSombra);
+  const cSendero = new THREE.Color(P.sendero);
+  const c = new THREE.Color();
+  let p = 0;
+  for (let iz = 0; iz < nx; iz++) {
+    const z = -FONDO / 2 + (FONDO * iz) / seg;
+    for (let ix = 0; ix < nx; ix++) {
+      const x = -ANCHO / 2 + (ANCHO * ix) / seg;
+      const y = alturaClaro(x, z);
+      pos[p] = x; pos[p + 1] = y; pos[p + 2] = z;
+      // el pasto se apaga hacia el monte (menos sol adentro del bosque)
+      c.lerpColors(cSol, cPasto, Math.min(1, Math.max(0, ruido(x, z) * 0.5 + 0.5)));
+      c.lerp(cSombra, Math.min(1, y * 0.42));
+      c.lerp(cSendero, sendero(x, z) * 0.85);
+      col[p] = c.r; col[p + 1] = c.g; col[p + 2] = c.b;
+      p += 3;
+    }
+  }
+  const idx = [];
+  for (let iz = 0; iz < seg; iz++) {
+    for (let ix = 0; ix < seg; ix++) {
+      const a = iz * nx + ix; const b = a + 1; const d = a + nx; const e = d + 1;
+      idx.push(a, d, b, b, d, e);
+    }
+  }
+  let geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  geo.setIndex(idx);
+  geo = geo.toNonIndexed();
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/* ── UN ÁRBOL DEL MONTE en una sola geometría ────────────────────────────────
+   Tronco (cilindro: INDEXADO) + tres bloques de copa (icosaedros: NO indexados).
+   Justo la mezcla que hace que `mergeGeometries` devuelva null sin decir nada.
+   Por eso pasa por `fusionarSeguro`, que desindexa todo y truena si algo falla.
+   El color va por vértice para que UN InstancedMesh baste. */
+function construirArbol() {
+  const partes = [];
+  const pintar = (g, hex) => {
+    const n = g.attributes.position.count;
+    const col = new Float32Array(n * 3);
+    const c = new THREE.Color(hex);
+    for (let i = 0; i < n; i++) { col[i * 3] = c.r; col[i * 3 + 1] = c.g; col[i * 3 + 2] = c.b; }
+    g.setAttribute('color', new THREE.BufferAttribute(col, 3));
+    return g;
+  };
+  // el tronco (indexado de fábrica)
+  partes.push(pintar(poner(new THREE.CylinderGeometry(0.16, 0.26, 2.6, 6), [0, 1.3, 0]), P.tronco));
+  // la copa en tres masas desiguales (no indexadas de fábrica)
+  const masas = [
+    { pos: [0, 3.1, 0], r: 1.25, hex: P.copaSol },
+    { pos: [-0.72, 2.5, 0.34], r: 0.92, hex: P.copa },
+    { pos: [0.66, 2.62, -0.38], r: 0.85, hex: P.copa },
+  ];
+  masas.forEach((m) => {
+    const g = new THREE.IcosahedronGeometry(m.r, 0);
+    g.scale(1, 0.82, 1);
+    partes.push(pintar(poner(g, m.pos), m.hex));
+  });
+  return fusionarSeguro(partes, 'arbol-del-claro');
+}
+
+/* Una mata de hierba: dos cuñas cruzadas, color por vértice (mismo atributo que
+   el árbol para que la ley de fusión se cumpla también acá). */
+function construirMata() {
+  const partes = [];
+  const pintar = (g, hex) => {
+    const n = g.attributes.position.count;
+    const col = new Float32Array(n * 3);
+    const c = new THREE.Color(hex);
+    for (let i = 0; i < n; i++) { col[i * 3] = c.r; col[i * 3 + 1] = c.g; col[i * 3 + 2] = c.b; }
+    g.setAttribute('color', new THREE.BufferAttribute(col, 3));
+    return g;
+  };
+  partes.push(pintar(poner(new THREE.ConeGeometry(0.16, 0.5, 4), [0, 0.25, 0]), P.pastoSol));
+  partes.push(pintar(poner(new THREE.ConeGeometry(0.13, 0.38, 4), [0.11, 0.19, 0.08], [0, 0.7, 0.3]), P.pasto));
+  return fusionarSeguro(partes, 'mata-del-claro');
+}
+
+function construirPiedra() {
+  const g = new THREE.DodecahedronGeometry(1, 0);
+  g.scale(1, 0.66, 0.9);
+  const n = g.attributes.position.count;
+  const col = new Float32Array(n * 3);
+  const c = new THREE.Color(P.piedra);
+  for (let i = 0; i < n; i++) { col[i * 3] = c.r; col[i * 3 + 1] = c.g; col[i * 3 + 2] = c.b; }
+  g.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  return fusionarSeguro([g], 'piedra-del-claro');
+}
+
+/* Siembra instanciada genérica: coloca `n` copias con la geometría dada,
+   evitando el corredor del sendero (por donde anda el felino). */
+function Sembrado({ geo, n, semilla, escala, aparta = 0, sinFrente = null, sobreSuelo = 0 }) {
+  const ref = useRef(null);
+  const sitios = useMemo(() => {
+    const rng = crearRng(semilla);
+    const lista = [];
+    let intentos = 0;
+    while (lista.length < n && intentos < n * 12) {
+      intentos += 1;
+      const x = (rng() - 0.5) * (ANCHO - 2);
+      const z = (rng() - 0.5) * (FONDO - 2);
+      // deja libre el claro central si `aparta` lo pide (los árboles no crecen
+      // en la mitad del claro: por eso es un claro)
+      if (aparta && Math.hypot(x / (ANCHO * 0.5), z / (FONDO * 0.5)) < aparta) continue;
+      // NADA DE ÁRBOLES DELANTE DEL FELINO: el billboard <Html> se dibuja
+      // SIEMPRE encima de la geometría (no hay test de profundidad contra el
+      // 3D), así que un árbol en primer plano no lo tapa — lo atraviesa, y se
+      // ve como un sticker pegado al vidrio. La cura es de composición: se deja
+      // libre la banda del frente por donde mira la cámara.
+      if (sinFrente != null && z > sinFrente) continue;
+      if (sendero(x, z) > 0.55) continue; // ni encima de la huella
+      lista.push({
+        x, z, y: alturaClaro(x, z),
+        esc: escala[0] + rng() * (escala[1] - escala[0]),
+        giro: rng() * Math.PI * 2,
+        ladeo: (rng() - 0.5) * 0.16,
+      });
+    }
+    return lista;
+  }, [n, semilla, escala, aparta, sinFrente]);
+
+  useEffect(() => {
+    const m = ref.current;
+    if (!m) return;
+    const dummy = new THREE.Object3D();
+    sitios.forEach((s, i) => {
+      dummy.position.set(s.x, s.y + sobreSuelo * s.esc, s.z);
+      dummy.rotation.set(s.ladeo, s.giro, s.ladeo * 0.6);
+      dummy.scale.setScalar(s.esc);
+      dummy.updateMatrix();
+      m.setMatrixAt(i, dummy.matrix);
+    });
+    m.instanceMatrix.needsUpdate = true;
+  }, [sitios, sobreSuelo]);
+
+  if (!sitios.length) return null;
+  return (
+    <instancedMesh ref={ref} args={[geo, undefined, sitios.length]} frustumCulled={false}>
+      <meshLambertMaterial vertexColors flatShading />
+    </instancedMesh>
+  );
+}
+
+function Claro({ tier, reducedMotion }) {
+  const perfil = useMemo(() => perfilDeTier(tier), [tier]);
+  const rico = tier === 'alto';
+
+  const geoClaro = useMemo(() => construirClaro(rico ? 76 : 46), [rico]);
+  const geoArbol = useMemo(() => construirArbol(), []);
+  const geoMata = useMemo(() => construirMata(), []);
+  const geoPiedra = useMemo(() => construirPiedra(), []);
+  useEffect(() => () => {
+    geoClaro.dispose(); geoArbol.dispose(); geoMata.dispose(); geoPiedra.dispose();
+  }, [geoClaro, geoArbol, geoMata, geoPiedra]);
+
+  const nArbol = rico ? 54 : tier === 'medio' ? 34 : 20;
+  const nMata = rico ? 170 : tier === 'medio' ? 90 : 40;
+
+  return (
+    <>
+      <LuzMadre cielo={CIELO} perfil={perfil} solPos={[7, 8, 5]} />
+      <mesh geometry={geoClaro} receiveShadow={false}>
+        <meshLambertMaterial vertexColors flatShading />
+      </mesh>
+      <Sembrado geo={geoArbol} n={nArbol} semilla={17} escala={[0.85, 1.65]} aparta={0.72} sinFrente={2.5} />
+      <Sembrado geo={geoMata} n={nMata} semilla={53} escala={[0.6, 1.35]} />
+      <Sembrado geo={geoPiedra} n={rico ? 26 : 12} semilla={91} escala={[0.14, 0.4]} sobreSuelo={0.4} />
+
+      {/* EL FELINO: el SVG de la casa, pisando el terreno del claro. */}
+      <JaguarBillboard
+        centro={[0, 0, 1]}
+        radio={3.8}
+        suelo={alturaClaro}
+        alto={0.02}
+        px={168}
+        factor={5.4}
+        animated={!reducedMotion}
+        tier={tier}
+      />
+    </>
+  );
+}
+
+export default function ClaroDelJaguar({ tier = 'alto', reducedMotion = false }) {
+  const cielo = useMemo(() => mezclarCielo(CIELO), []);
+  const perfil = useMemo(() => perfilDeTier(tier), [tier]);
+  return (
+    <Canvas
+      camera={{ position: [0, 3.2, 10.6], fov: 40 }}
+      dpr={perfil.dpr}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+    >
+      <color attach="background" args={[cielo.fondo]} />
+      {perfil.fog && <fog attach="fog" args={[cielo.niebla, 16, 44]} />}
+      <Claro tier={tier} reducedMotion={reducedMotion} />
+      <OrbitControls
+        enablePan={false}
+        target={[0, 1.1, 0.5]}
+        minDistance={5}
+        maxDistance={16}
+        maxPolarAngle={Math.PI * 0.49}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.28}
+      />
+      <AdaptiveDpr pixelated />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/fauna/JaguarBillboard.jsx
+++ b/src/visual/mundo3d/fauna/JaguarBillboard.jsx
@@ -1,0 +1,251 @@
+/*
+ * JaguarBillboard — EL JAGUAR VIVO EN CUALQUIER ESCENA 3D DE SUELO.
+ *
+ * Hermano de tierra del `CondorBillboard`: el jaguar entra a un mundo 3D como
+ * billboard `<Html>` del SVG rubber-hose de la casa (`creatures/Jaguar.jsx`) —
+ * el SVG dibujado le gana a cualquier low-poly, decisión de arte del operador.
+ * REUTILIZABLE: cualquier escena con `<Canvas>` lo monta (el claro, el bosque,
+ * la vitrina del monte).
+ *
+ * LO QUE HACE DISTINTO A UN FELINO DE UN PÁJARO — y la razón de que esto no sea
+ * una copia del cóndor con la Y pegada al suelo:
+ *
+ *  1. PISA. La Y no la elige el componente: la lee del terreno (`suelo`, número
+ *     o función x,z→y). Un jaguar flotando dos dedos sobre la hierba arruina la
+ *     escena entera, y es el error más fácil de cometer.
+ *
+ *  2. IMPONE POR EL TIEMPO, NO POR LA AMENAZA (regla del módulo `fauna/`: ni
+ *     ternura boba ni villano). Su máquina de fases es lenta a propósito:
+ *       · 'anda'    — cruza el claro con paso deliberado y pesado, siguiendo una
+ *                     querencia (vuelve al centro si se aleja). No trota nunca.
+ *       · 'observa' — SE DETIENE. Se queda quieto un rato largo mirando, y
+ *                     sigue. Es la fase que da la presencia: el animal que se
+ *                     para a mirarlo a usted y después se va como si nada.
+ *       · 'acecha'  — avanza agazapado y lentísimo (el SVG recibe `acecha` y
+ *                     sube los omóplatos, baja la testa). Raro, con cooldown.
+ *     Nunca acecha a la cámara: el rumbo del acecho es el mismo de su paso.
+ *
+ *  3. SE ESPEJA SEGÚN EL RUMBO. El SVG está dibujado de frente; al caminar hacia
+ *     la izquierda de la pantalla se voltea con `scaleX(-1)` (proyectando la
+ *     velocidad al eje derecha de la cámara). Sin eso el felino camina de lado
+ *     como una calcomanía.
+ *
+ *  4. SOMBRA DE CONTACTO PEGADA. Una mancha cálida bajo las zarpas que lo ancla
+ *     al piso (+1 draw call, opcional por `suelo`). La sombra del jaguar casi no
+ *     se separa de él: camina, no vuela.
+ *
+ * Todo el gesto va por CSS transform sobre el nodo del billboard (mutación por
+ * ref, cero re-renders) y la matemática es O(1) por frame.
+ *
+ * Tier-safe / reduced-motion: con `animated=false` queda QUIETO y digno en un
+ * punto del claro (también congela el SVG y apaga la sombra móvil). Tier 'bajo'
+ * poda el acecho.
+ *
+ * Importa three/@react-three → montar SOLO dentro de un <Canvas>.
+ */
+import { useMemo, useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import { Vector3 } from 'three';
+import { Jaguar } from '../../creatures/Jaguar.jsx';
+
+const azar = (a, b) => a + Math.random() * (b - a);
+const clamp = (v, a, b) => (v < a ? a : v > b ? b : v);
+
+/* temporal reutilizado (cero alloc por frame) */
+const _right = new Vector3();
+
+const ESTILO_JAGUAR = {
+  filter: 'drop-shadow(0 3px 4px rgba(28, 20, 11, 0.34))',
+  pointerEvents: 'none',
+  willChange: 'transform',
+};
+
+/* Velocidades en unidades de mundo por segundo. El jaguar real camina con paso
+   medido; acá el paso es LENTO a propósito y el acecho es la mitad de lento. */
+const V_ANDA = 0.62;
+const V_ACECHA = 0.24;
+
+/**
+ * @param {Object} props
+ * @param {[number,number,number]} [props.centro=[0,0,0]] querencia del felino: el
+ *   punto del claro al que siempre vuelve. La Y se ignora si hay `suelo`.
+ * @param {number} [props.radio=6] radio del territorio que recorre.
+ * @param {number|((x:number,z:number)=>number)} [props.suelo=0] Y del terreno
+ *   (número o función x,z→y). ES LO QUE LO HACE PISAR: sin esto el jaguar flota.
+ * @param {number} [props.alto=0]  levantada extra sobre el suelo (px de mundo)
+ *   para compensar que el SVG trae aire bajo las zarpas.
+ * @param {number} [props.px=132]  tamaño del SVG en px (nitidez del billboard).
+ * @param {number} [props.factor=9] distanceFactor del <Html> (escala en mundo).
+ * @param {boolean} [props.animated=true] false = quieto y digno (tier bajo / RM).
+ * @param {string}  [props.tier]   device-tier ('bajo' poda acecho + sombra).
+ * @param {Object|string|null} [props.clima=null] clima vivo de la escena (se pasa
+ *   al SVG: el pelaje lustroso que escurre agua).
+ * @param {boolean} [props.aparicion=false] entrada espectral del SVG (opt-in).
+ */
+export default function JaguarBillboard({
+  centro = [0, 0, 0],
+  radio = 6,
+  suelo = 0,
+  alto = 0,
+  px = 132,
+  factor = 9,
+  animated = true,
+  tier,
+  clima = null,
+  aparicion = false,
+}) {
+  const grupo = useRef(/** @type {any} */ (null));
+  const capa = useRef(/** @type {HTMLDivElement|null} */ (null));
+  const sombra = useRef(/** @type {any} */ (null));
+  /* El ACECHO sí va por estado de React: las fases cambian cada varios SEGUNDOS
+     (no por frame), así que un re-render por cambio de fase es gratis — y a
+     cambio el SVG recibe el prop `acecha` de verdad, que es lo que sube los
+     omóplatos y baja la testa. Un data-attr en el wrapper no lo lograría: el
+     CSS de creatures lee `[data-acecha]` en la RAÍZ del SVG, no en el padre. */
+  const [acechando, setAcechando] = useState(false);
+
+  const yDe = (x, z) => (typeof suelo === 'function' ? suelo(x, z) : suelo);
+
+  /* El PUNTO DE ENTRADA se calcula puro (useMemo), no leyendo un ref en el
+     render: el render necesita la posición inicial para montar el grupo y la
+     sombra, y leer `ref.current` ahí es justamente lo que React desaconseja.
+     Del punto de entrada cuelga después el estado vivo, que sí es un ref. */
+  const inicio = useMemo(() => {
+    const ang = azar(0, Math.PI * 2);
+    const x = centro[0] + Math.cos(ang) * radio * 0.55;
+    const z = centro[2] + Math.sin(ang) * radio * 0.55;
+    return { x, z, y: (typeof suelo === 'function' ? suelo(x, z) : suelo) + alto };
+    // el claro no se re-siembra si cambia el tier: la entrada es de una vez
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const st = useRef(/** @type {any} */ (null));
+  if (st.current === null) {
+    st.current = {
+      fase: 'anda',
+      hasta: azar(6, 11),
+      rumbo: azar(0, Math.PI * 2),
+      x: inicio.x, z: inicio.z,
+      px: inicio.x, pz: inicio.z,
+      esp: 1, espT: 1,        // espejo (scaleX) suavizado
+      proxAcecho: azar(26, 55),
+      lastTf: '', dataAcecha: false,
+      init: false,
+    };
+  }
+
+  useFrame(({ clock, camera }, delta) => {
+    const g = grupo.current;
+    if (!g || !animated) return;
+    const t = clock.getElapsedTime();
+    const dt = Math.min(delta || 0.016, 0.1);
+    const s = st.current;
+
+    /* ── máquina de fases: anda → observa → anda, y de vez en cuando acecha ── */
+    if (s.fase === 'anda' || s.fase === 'acecha') {
+      const v = s.fase === 'acecha' ? V_ACECHA : V_ANDA;
+      // deriva mínima del rumbo (nadie camina en línea de regla)…
+      s.rumbo += Math.sin(t * 0.31) * 0.14 * dt;
+      // …y si se sale del territorio, vira de vuelta a la querencia sin drama.
+      const dCentro = Math.hypot(s.x - centro[0], s.z - centro[2]);
+      if (dCentro > radio) {
+        const haciaCasa = Math.atan2(centro[2] - s.z, centro[0] - s.x);
+        let d = haciaCasa - s.rumbo;
+        d = Math.atan2(Math.sin(d), Math.cos(d));
+        s.rumbo += d * Math.min(1, dt * 0.9);
+      }
+      s.x += Math.cos(s.rumbo) * v * dt;
+      s.z += Math.sin(s.rumbo) * v * dt;
+      if (t >= s.hasta) {
+        // SE DETIENE A MIRAR: la fase que da la presencia (larga a propósito).
+        s.fase = 'observa';
+        s.hasta = t + azar(4.5, 9);
+      }
+    } else if (s.fase === 'observa') {
+      if (t >= s.hasta) {
+        const puedeAcechar = tier !== 'bajo' && t >= s.proxAcecho;
+        // gira un poco antes de arrancar (no reanuda en la misma línea)
+        s.rumbo += azar(-1.1, 1.1);
+        if (puedeAcechar) {
+          s.fase = 'acecha';
+          s.hasta = t + azar(7, 12);
+          s.proxAcecho = t + azar(45, 90);
+        } else {
+          s.fase = 'anda';
+          s.hasta = t + azar(7, 13);
+        }
+      }
+    }
+
+    /* ── PISA: la Y sale del terreno, siempre ─────────────────────────────── */
+    const y = yDe(s.x, s.z) + alto;
+    g.position.set(s.x, y, s.z);
+
+    /* ── ESPEJO según el rumbo proyectado a pantalla ───────────────────────── */
+    if (!s.init) { s.px = s.x; s.pz = s.z; s.init = true; }
+    const vx = (s.x - s.px) / dt;
+    const vz = (s.z - s.pz) / dt;
+    s.px = s.x; s.pz = s.z;
+    if (Math.hypot(vx, vz) > 0.03) {
+      _right.setFromMatrixColumn(camera.matrixWorld, 0);
+      const proy = vx * _right.x + vz * _right.z;
+      if (Math.abs(proy) > 0.02) s.espT = proy < 0 ? -1 : 1;
+    }
+    // el volteo se suaviza (un felino gira el cuerpo, no parpadea de lado)
+    s.esp += clamp(s.espT - s.esp, -dt * 4, dt * 4);
+
+    const capaEl = capa.current;
+    if (capaEl) {
+      const tf = `scaleX(${s.esp.toFixed(2)})`;
+      if (tf !== s.lastTf) { capaEl.style.transform = tf; s.lastTf = tf; }
+    }
+    const enAcecho = s.fase === 'acecha';
+    if (enAcecho !== s.dataAcecha) {
+      s.dataAcecha = enAcecho;
+      setAcechando(enAcecho);
+    }
+
+    /* ── SOMBRA DE CONTACTO pegada a las zarpas ────────────────────────────── */
+    if (sombra.current) {
+      sombra.current.position.set(s.x, yDe(s.x, s.z) + 0.04, s.z);
+    }
+  });
+
+  const conSombra = tier !== 'bajo';
+
+  return (
+    <>
+      <group ref={grupo} position={[inicio.x, inicio.y, inicio.z]}>
+        <Html center distanceFactor={factor} zIndexRange={[14, 0]} pointerEvents="none">
+          <div ref={capa} aria-hidden="true" data-vecino="jaguar" style={ESTILO_JAGUAR}>
+            <Jaguar
+              size={px}
+              animated={animated}
+              tier={tier}
+              clima={clima}
+              aparicion={aparicion}
+              acecha={acechando}
+              title="Jaguar"
+            />
+          </div>
+        </Html>
+      </group>
+      {conSombra && (
+        <mesh ref={sombra} position={[inicio.x, inicio.y - alto + 0.04, inicio.z]} rotation-x={-Math.PI / 2} renderOrder={2}>
+          <circleGeometry args={[0.95, 22]} />
+          <meshBasicMaterial
+            /* sombra de contacto CÁLIDA (ley de la casa: bajo el sol andino ni
+               la sombra es azul). */
+            color="#1c140b"
+            transparent
+            opacity={0.3}
+            depthWrite={false}
+            polygonOffset
+            polygonOffsetFactor={-2}
+          />
+        </mesh>
+      )}
+    </>
+  );
+}

--- a/src/visual/mundo3d/frutalesAndinos/VergelFrutalesAndinos.jsx
+++ b/src/visual/mundo3d/frutalesAndinos/VergelFrutalesAndinos.jsx
@@ -1,0 +1,273 @@
+/*
+ * VergelFrutalesAndinos — EL VERGEL DE CLIMA FRÍO, sembrado como se siembra.
+ *
+ * Las siete del catálogo (mora, lulo, tomate de árbol, uchuva, granadilla,
+ * gulupa y curuba) puestas en una ladera de finca con la lógica de manejo real,
+ * no en fila de vivero: la mora y la gulupa amarradas a su ESPALDERA, la
+ * granadilla y la curuba tendidas sobre la RAMADA (uno camina por debajo), el
+ * lulo en su claro a media sombra, el tomate de árbol como el único de porte
+ * alto y la uchuva al borde, que es donde se pone.
+ *
+ * NO HAY MANGO NI CÍTRICOS en este vergel, y no es un olvido: son de piso
+ * cálido y este es el elenco de clima frío que el catálogo respalda. Ponerlos
+ * acá "para que se vea más lleno" es enseñar mal.
+ *
+ * LEY DE LA CASA: color de la paleta madre, luz de `<LuzMadre>` sobre la
+ * familia `CIELOS.huerta`, y toda geometría fusionada por `fusionarSeguro`.
+ *
+ * RENDIMIENTO: cada especie es UNA geometría con color por vértice → un
+ * InstancedMesh por especie (7 + 2 estructuras + terreno ≈ 10 draw calls para
+ * todo el vergel). Lambert flatShading a dos caras (las hojas son láminas).
+ * Presupuestos por `perfilDeTier`; `reducedMotion` pasa el frameloop a demanda.
+ *
+ * Vive en el chunk perezoso `vendor-three`.
+ */
+import { useEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import { VERDES, TIERRAS, CIELOS, mezclar, mezclarCielo, LuzMadre } from '../paleta/index.js';
+import { perfilDeTier } from '../deviceTier.js';
+import { crearRng } from '../particulasData.js';
+import { Bicho } from '../escenas/FaunaEscena.jsx';
+import {
+  construirMora, construirLulo, construirTomateArbol, construirUchuva,
+  construirGranadilla, construirGulupa, construirCuruba,
+  construirEspaldera, construirRamada, construirArbolLindero,
+} from './frutalesAndinos.geom.js';
+
+const CIELO = CIELOS.huerta;
+const NIEBLA = mezclarCielo(CIELO).niebla;
+
+const P = {
+  pasto: mezclar(VERDES.brote, NIEBLA, 0.14),
+  pastoHondo: mezclar(VERDES.trabajo, NIEBLA, 0.18),
+  calle: mezclar(TIERRAS.camino, NIEBLA, 0.2),   // la calle entre surcos
+  plateo: mezclar(TIERRAS.mantillo, NIEBLA, 0.18), // el plateo al pie de la mata
+};
+
+const ANCHO = 42;
+const FONDO = 32;
+
+function ruido(x, z) {
+  return (
+    Math.sin(x * 0.62 + z * 0.44) * 0.5 +
+    Math.sin(x * 1.5 - z * 1.2 + 1.7) * 0.32 +
+    Math.sin(x * 2.9 + z * 2.2 + 4.1) * 0.18
+  );
+}
+
+/* La ladera: el vergel está en pendiente suave, que es donde de verdad se
+   siembra (drenaje). Cae hacia el frente. */
+function alturaVergel(x, z) {
+  // sube atrás (el monte del lindero queda más alto que el lote sembrado)
+  const monte = Math.max(0, -z - 7) ** 1.6 * 0.09;
+  return z * 0.085 + monte + ruido(x * 0.28, z * 0.28) * 0.16;
+}
+
+/* Las CALLES del vergel: bandas de tierra pisada entre las hileras. Devuelve
+   0..1. Es lo que hace que se lea como cultivo manejado y no como matorral. */
+function calle(x) {
+  const banda = Math.abs(((x + 40) % 5.2) - 2.6);
+  return Math.max(0, 1 - banda / 0.85);
+}
+
+function construirLadera(seg) {
+  const nx = seg + 1;
+  const pos = new Float32Array(nx * nx * 3);
+  const col = new Float32Array(nx * nx * 3);
+  const cPasto = new THREE.Color(P.pasto);
+  const cHondo = new THREE.Color(P.pastoHondo);
+  const cCalle = new THREE.Color(P.calle);
+  const c = new THREE.Color();
+  let p = 0;
+  for (let iz = 0; iz < nx; iz++) {
+    const z = -FONDO / 2 + (FONDO * iz) / seg;
+    for (let ix = 0; ix < nx; ix++) {
+      const x = -ANCHO / 2 + (ANCHO * ix) / seg;
+      const y = alturaVergel(x, z);
+      pos[p] = x; pos[p + 1] = y; pos[p + 2] = z;
+      c.lerpColors(cPasto, cHondo, Math.min(1, Math.max(0, ruido(x, z) * 0.5 + 0.5)));
+      c.lerp(cCalle, calle(x) * 0.8);
+      col[p] = c.r; col[p + 1] = c.g; col[p + 2] = c.b;
+      p += 3;
+    }
+  }
+  const idx = [];
+  for (let iz = 0; iz < seg; iz++) {
+    for (let ix = 0; ix < seg; ix++) {
+      const a = iz * nx + ix; const b = a + 1; const d = a + nx; const e = d + 1;
+      idx.push(a, d, b, b, d, e);
+    }
+  }
+  let geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  geo.setIndex(idx);
+  geo = geo.toNonIndexed();
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/* Siembra instanciada: una especie, N sitios, 1 draw call. Los sitios los pone
+   la escena (la disposición ES la lección: cada especie donde va). */
+function Hilera({ geo, sitios }) {
+  const ref = useRef(null);
+  useEffect(() => {
+    const m = ref.current;
+    if (!m) return;
+    const dummy = new THREE.Object3D();
+    sitios.forEach((s, i) => {
+      dummy.position.set(s.x, alturaVergel(s.x, s.z), s.z);
+      dummy.rotation.set(0, s.giro ?? 0, 0);
+      dummy.scale.setScalar(s.esc ?? 1);
+      dummy.updateMatrix();
+      m.setMatrixAt(i, dummy.matrix);
+    });
+    m.instanceMatrix.needsUpdate = true;
+  }, [sitios]);
+  if (!sitios.length) return null;
+  return (
+    <instancedMesh ref={ref} args={[geo, undefined, sitios.length]} frustumCulled={false}>
+      {/* DoubleSide porque las hojas son LÁMINAS: sin esto media hoja
+          desaparece según de qué lado la mire la cámara. */}
+      <meshLambertMaterial vertexColors flatShading side={THREE.DoubleSide} />
+    </instancedMesh>
+  );
+}
+
+/* La disposición del vergel — el mapa de la finca. Cada especie donde va por
+   manejo, no donde quepa. */
+function disponer(densidad) {
+  const rng = crearRng(29);
+  const fila = (n, x0, z0, dx, dz, esc = [0.9, 1.1]) =>
+    Array.from({ length: n }, (_, i) => ({
+      x: x0 + dx * i + (rng() - 0.5) * 0.28,
+      z: z0 + dz * i + (rng() - 0.5) * 0.28,
+      giro: rng() * Math.PI * 2,
+      esc: esc[0] + rng() * (esc[1] - esc[0]),
+    }));
+
+  const n = (base) => Math.max(2, Math.round(base * densidad));
+
+  return {
+    // MORA: dos hileras amarradas a espaldera, a la izquierda
+    mora: [...fila(n(5), -8.6, 3.4, 0.78, 0), ...fila(n(5), -8.6, 0.9, 0.78, 0)],
+    espalderaMora: [
+      { x: -6.8, z: 3.4, giro: 0, esc: 1 },
+      { x: -6.8, z: 0.9, giro: 0, esc: 1 },
+    ],
+    // UCHUVA: la hilera del BORDE, al frente — es la que se ve de cerca, y el
+    // capacho hay que poder mirarlo sin agacharse
+    uchuva: fila(n(7), -4.8, 5.6, 1.45, -0.1, [1, 1.25]),
+    // LULO: en su claro a media sombra, en el medio izquierdo
+    lulo: fila(n(6), -8.2, -1.6, 1.28, 0.2, [0.9, 1.25]),
+    // TOMATE DE ÁRBOL: los altos, atrás a la derecha (no le hacen sombra al resto)
+    tomate: [
+      ...fila(n(4), 4.2, -1.4, 1.9, 0.25, [0.92, 1.12]),
+      ...fila(n(3), 5.0, -4.4, 2.0, 0.2, [0.95, 1.1]),
+    ],
+    // GULUPA: en espaldera propia, al centro
+    gulupa: fila(n(3), -1.9, 2.6, 1.5, 0, [0.95, 1.05]),
+    espalderaGulupa: [{ x: 0.1, z: 2.6, giro: 0, esc: 1.3 }],
+    // GRANADILLA y CURUBA: bajo la ramada del fondo
+    granadilla: [{ x: -3.4, z: -6.6, giro: 0.2, esc: 1 }, { x: -1.4, z: -7.6, giro: 1.1, esc: 0.95 }],
+    curuba: [{ x: 1.4, z: -7.2, giro: 2.6, esc: 1 }, { x: 3.2, z: -6.4, giro: 3.6, esc: 0.95 }],
+    ramada: [{ x: -2.4, z: -6.9, giro: 0, esc: 1.05 }, { x: 2.3, z: -6.8, giro: 0, esc: 1.05 }],
+    // EL LINDERO: la hilera de monte que cierra el lote por detrás
+    lindero: Array.from({ length: 16 }, (_, i) => ({
+      x: -14.5 + i * 1.95 + (rng() - 0.5) * 1.3,
+      z: -10.6 - rng() * 2.6,
+      giro: rng() * Math.PI * 2,
+      esc: 0.85 + rng() * 0.6,
+    })),
+  };
+}
+
+function Vergel({ tier, reducedMotion }) {
+  const perfil = useMemo(() => perfilDeTier(tier), [tier]);
+  const rico = tier === 'alto';
+  const densidad = rico ? 1 : tier === 'medio' ? 0.7 : 0.45;
+
+  const geoLadera = useMemo(() => construirLadera(rico ? 68 : 42), [rico]);
+  const G = useMemo(() => ({
+    mora: construirMora(),
+    lulo: construirLulo(),
+    tomate: construirTomateArbol(),
+    uchuva: construirUchuva(),
+    granadilla: construirGranadilla(),
+    gulupa: construirGulupa(),
+    curuba: construirCuruba(),
+    espaldera: construirEspaldera(),
+    ramada: construirRamada(),
+    lindero: construirArbolLindero(4),
+  }), []);
+  const sitios = useMemo(() => disponer(densidad), [densidad]);
+
+  useEffect(() => () => {
+    geoLadera.dispose();
+    Object.values(G).forEach((g) => g.dispose());
+  }, [geoLadera, G]);
+
+  return (
+    <>
+      <LuzMadre cielo={CIELO} perfil={perfil} solPos={[7, 9, 6]} />
+      <mesh geometry={geoLadera}>
+        <meshLambertMaterial vertexColors flatShading />
+      </mesh>
+
+      {/* el monte del fondo primero: es el telón del lote */}
+      <Hilera geo={G.lindero} sitios={sitios.lindero} />
+
+      {/* estructuras de conducción primero (las matas se amarran a ellas) */}
+      <Hilera geo={G.espaldera} sitios={[...sitios.espalderaMora, ...sitios.espalderaGulupa]} />
+      <Hilera geo={G.ramada} sitios={sitios.ramada} />
+
+      {/* las siete */}
+      <Hilera geo={G.mora} sitios={sitios.mora} />
+      <Hilera geo={G.lulo} sitios={sitios.lulo} />
+      <Hilera geo={G.tomate} sitios={sitios.tomate} />
+      <Hilera geo={G.uchuva} sitios={sitios.uchuva} />
+      <Hilera geo={G.granadilla} sitios={sitios.granadilla} />
+      <Hilera geo={G.gulupa} sitios={sitios.gulupa} />
+      <Hilera geo={G.curuba} sitios={sitios.curuba} />
+
+      {/* la vida que cuaja la fruta: la misma librería de siempre, poquita y
+          bien puesta (nunca un enjambre). */}
+      {!reducedMotion && (
+        <>
+          <Bicho tipo="colibri" base={[-2.2, alturaVergel(-2.2, -5.2) + 2.5, -5.2]} rol="polinizador" size={26} df={7} />
+          <Bicho tipo="mariposa" base={[-6.4, alturaVergel(-6.4, 1.4) + 1.3, 1.4]} rol="polinizador" size={22} df={7} fase={1.4} />
+          <Bicho tipo="mariposa" base={[4.6, alturaVergel(4.6, 3.2) + 1.1, 3.2]} rol="polinizador" size={20} df={7} fase={3.1} />
+        </>
+      )}
+    </>
+  );
+}
+
+export default function VergelFrutalesAndinos({ tier = 'alto', reducedMotion = false }) {
+  const cielo = useMemo(() => mezclarCielo(CIELO), []);
+  const perfil = useMemo(() => perfilDeTier(tier), [tier]);
+  return (
+    <Canvas
+      camera={{ position: [0.4, 3.3, 9.2], fov: 47 }}
+      dpr={perfil.dpr}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+    >
+      <color attach="background" args={[cielo.fondo]} />
+      {perfil.fog && <fog attach="fog" args={[cielo.niebla, 18, 46]} />}
+      <Vergel tier={tier} reducedMotion={reducedMotion} />
+      <OrbitControls
+        enablePan={false}
+        target={[0, 1.5, -1.8]}
+        minDistance={5}
+        maxDistance={20}
+        maxPolarAngle={Math.PI * 0.48}
+        autoRotate={!reducedMotion}
+        autoRotateSpeed={0.22}
+      />
+      <AdaptiveDpr pixelated />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/frutalesAndinos/frutalesAndinos.geom.js
+++ b/src/visual/mundo3d/frutalesAndinos/frutalesAndinos.geom.js
@@ -1,0 +1,605 @@
+/*
+ * frutalesAndinos.geom — LAS SIETE DEL CLIMA FRÍO, cada una con su porte real.
+ *
+ * El elenco de frutales andinos que el catálogo respalda: MORA de Castilla,
+ * LULO, TOMATE DE ÁRBOL, GRANADILLA, UCHUVA, GULUPA y CURUBA. Ni una más: si no
+ * está en esta lista, no se dibuja acá. (El mango y los cítricos son de piso
+ * cálido y no pertenecen a este vergel; dibujarlos "a ojo" junto a estos siete
+ * sería enseñar mal una cosa fácil de verificar en el campo.)
+ *
+ * POR QUÉ ESTE MÓDULO EXISTE — el riesgo real de dibujar frutales es que todos
+ * salgan "arbolito con bolitas". Estas siete se diferencian ANTES por la HOJA y
+ * el TUTORADO que por el fruto, y eso es lo que decide si el campesino las
+ * reconoce:
+ *
+ *   · MORA (Rubus glaucus) — no es un árbol: son CAÑAS arqueadas con espinas,
+ *     conducidas en ESPALDERA. Hoja TRIFOLIADA con el envés claro. El fruto
+ *     madura desgranado: verde, rojo y morado casi negro en la misma rama.
+ *   · LULO (Solanum quitoense) — arbusto bajo de HOJA ENORME, ancha y lobulada,
+ *     con la nervadura MORADA. Es su firma: ninguna otra del vergel tiene una
+ *     hoja de ese tamaño. Fruto naranja redondo.
+ *   · TOMATE DE ÁRBOL (Solanum betaceum) — el único con porte de ARBOLITO: un
+ *     tronco que sube y se abre arriba. Hoja grande acorazonada; frutos
+ *     OVOIDES colgando en racimo.
+ *   · UCHUVA (Physalis peruviana) — mata baja tutorada, y el fruto va dentro de
+ *     un CAPACHO de papel (el cáliz que la envuelve). El capacho es la firma:
+ *     sin él, es una bolita naranja cualquiera.
+ *   · Las TRES PASIFLORAS no son intercambiables, y es el error más fácil:
+ *       – GRANADILLA (P. ligularis): hoja ENTERA acorazonada, fruto REDONDO
+ *         naranja. Va en RAMADA (emparrado horizontal).
+ *       – GULUPA (P. edulis f. edulis): hoja TRILOBULADA, fruto REDONDO MORADO.
+ *       – CURUBA (P. tripartita): hoja trilobulada más angosta, FLOR ROSADA
+ *         colgante de tubo largo y fruto ALARGADO amarillo. La flor y la forma
+ *         del fruto la separan de las otras dos de una sola mirada.
+ *
+ * LEY DE LA CASA:
+ *   - Color: SOLO de la paleta madre (`../paleta`), derivando con `mezclar`.
+ *   - Fusión: SIEMPRE por `fusionarSeguro`. Acá se mezclan geometrías indexadas
+ *     (cilindros, esferas, láminas de hoja) con no indexadas: exactamente el
+ *     caso en que `mergeGeometries` devuelve null EN SILENCIO y la especie
+ *     desaparece sin un solo error en consola. `fusionarSeguro` desindexa todo
+ *     y truena con el nombre de la especie si algo no cuadra.
+ *   - Una especie = UNA geometría con color por vértice = 1 draw call
+ *     instanciable.
+ *
+ * Todas las matas nacen con la base en y=0 y miran a +Z, listas para instanciar.
+ * three-core puro: cero react, cero @react-three.
+ */
+import * as THREE from 'three';
+import { VERDES, TIERRAS, CORTEZAS, ACENTOS, PALETA, mezclar } from '../paleta/index.js';
+import { fusionarSeguro, poner } from '../bosque/sombreadoVegetal.js';
+
+/* ── PALETA DEL VERGEL — todo derivado de la paleta madre ──────────────────── */
+export const P_FRUTAL = {
+  /* verdes por especie (piso frío/templado: el vergel andino no es selva) */
+  hojaMora: mezclar(VERDES.templado, '#ffffff', 0.06),
+  hojaMoraEnves: mezclar(VERDES.templado, '#e8efdc', 0.32), // el envés glauco
+  hojaLulo: VERDES.trabajo,
+  hojaLuloClara: mezclar(VERDES.brote, '#ffffff', 0.08),
+  /* la nervadura MORADA del lulo: derivada del índigo de la paleta hacia el
+     verde de la hoja (no un morado inventado suelto). */
+  nervaduraLulo: mezclar(ACENTOS.indigo, ACENTOS.florDeMonte, 0.42),
+  hojaTomate: mezclar(VERDES.templadoVivo, VERDES.monte, 0.2),
+  hojaGranadilla: mezclar(VERDES.trabajo, VERDES.templado, 0.35),
+  hojaGulupa: mezclar(VERDES.monte, VERDES.trabajo, 0.3),
+  hojaCuruba: mezclar(VERDES.aliso, VERDES.brote, 0.22),
+  hojaUchuva: mezclar(VERDES.brote, VERDES.trabajo, 0.4),
+
+  /* tallos y estructura */
+  canaMora: mezclar(CORTEZAS.roble, VERDES.monte, 0.3),
+  espina: mezclar(TIERRAS.cacao, '#ffffff', 0.1),
+  talloLulo: mezclar(VERDES.monte, TIERRAS.siembra, 0.28),
+  troncoTomate: CORTEZAS.roble,
+  guia: mezclar(VERDES.monte, CORTEZAS.roble, 0.35), // el bejuco de la pasiflora
+  talloUchuva: mezclar(VERDES.trabajo, TIERRAS.siembra, 0.22),
+  poste: PALETA.madera,
+  posteSombra: PALETA.maderaOscura,
+  alambre: mezclar('#9a8b74', '#ffffff', 0.15),
+
+  /* frutos — su color ES el saber: van casi puros */
+  moraVerde: '#8fa84a',
+  moraRoja: '#b6303a',
+  moraMadura: '#3a1330', // morado casi negro
+  luloFruto: '#e8792a',
+  luloPelusa: mezclar('#e8792a', '#f6e0b8', 0.4),
+  tomateFruto: '#d94b28',
+  tomateFrutoPinton: '#e0913a',
+  uchuvaFruto: '#e8a326',
+  capacho: '#c9b071', // el capacho de papel, seco y translúcido
+  granadillaFruto: '#e39a34',
+  gulupaFruto: '#54305e', // morado oscuro
+  curubaFruto: '#dcc24a', // amarillo alargado
+  curubaFlor: '#e07898', // la flor rosada colgante (la firma de la curuba)
+  florPasiflora: '#f2ecdc',
+};
+
+/* ── AYUDAS ────────────────────────────────────────────────────────────────── */
+
+/** Pinta una geometría entera de un color (atributo `color` por vértice). */
+function pintar(geo, hex) {
+  const n = geo.attributes.position.count;
+  const col = new Float32Array(n * 3);
+  const c = new THREE.Color(hex);
+  for (let i = 0; i < n; i++) { col[i * 3] = c.r; col[i * 3 + 1] = c.g; col[i * 3 + 2] = c.b; }
+  geo.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  return geo;
+}
+
+/**
+ * Una LÁMINA DE HOJA a partir de un contorno 2D. La hoja se dibuja en el plano
+ * XY con el pecíolo en el origen y la punta hacia +Y; después se coloca con
+ * `poner`. Sale de `ShapeGeometry` (indexada, con normal y uv) — el material de
+ * la escena la pinta a dos caras.
+ *
+ * Es lo que permite que la hoja de la granadilla (entera, acorazonada) y la de
+ * la gulupa (trilobulada) se distingan de verdad, en vez de ser dos bolas
+ * verdes con nombres distintos.
+ */
+function laminaHoja(contorno, segmentos = 8) {
+  const g = new THREE.ShapeGeometry(contorno, segmentos);
+  g.computeVertexNormals();
+  return g;
+}
+
+/** Hoja ACORAZONADA entera (granadilla, tomate de árbol, uchuva). */
+function hojaCorazon(largo, ancho) {
+  const s = new THREE.Shape();
+  const a = ancho / 2;
+  s.moveTo(0, 0);
+  s.bezierCurveTo(a * 0.9, largo * 0.06, a, largo * 0.42, a * 0.62, largo * 0.82);
+  s.bezierCurveTo(a * 0.34, largo * 1.02, a * 0.12, largo, 0, largo);
+  s.bezierCurveTo(-a * 0.12, largo, -a * 0.34, largo * 1.02, -a * 0.62, largo * 0.82);
+  s.bezierCurveTo(-a, largo * 0.42, -a * 0.9, largo * 0.06, 0, 0);
+  return s;
+}
+
+/** Hoja TRILOBULADA (gulupa, curuba): tres lóbulos francos, el central mayor. */
+function hojaTrilobulada(largo, ancho, angostura = 1) {
+  const s = new THREE.Shape();
+  const a = (ancho / 2) * angostura;
+  s.moveTo(0, 0);
+  // lóbulo lateral derecho
+  s.bezierCurveTo(a * 0.5, largo * 0.1, a * 1.05, largo * 0.28, a * 0.95, largo * 0.5);
+  s.bezierCurveTo(a * 0.9, largo * 0.62, a * 0.5, largo * 0.5, a * 0.42, largo * 0.58);
+  // lóbulo central
+  s.bezierCurveTo(a * 0.5, largo * 0.78, a * 0.3, largo * 0.96, 0, largo);
+  s.bezierCurveTo(-a * 0.3, largo * 0.96, -a * 0.5, largo * 0.78, -a * 0.42, largo * 0.58);
+  // lóbulo lateral izquierdo
+  s.bezierCurveTo(-a * 0.5, largo * 0.5, -a * 0.9, largo * 0.62, -a * 0.95, largo * 0.5);
+  s.bezierCurveTo(-a * 1.05, largo * 0.28, -a * 0.5, largo * 0.1, 0, 0);
+  return s;
+}
+
+/** Hoja GRANDE y ondulada del lulo: ancha, con el borde en lóbulos suaves. */
+function hojaLuloGrande(largo, ancho) {
+  const s = new THREE.Shape();
+  const a = ancho / 2;
+  s.moveTo(0, 0);
+  s.bezierCurveTo(a * 0.7, largo * 0.02, a * 1.02, largo * 0.2, a * 0.86, largo * 0.36);
+  s.bezierCurveTo(a * 1.06, largo * 0.44, a * 0.96, largo * 0.62, a * 0.72, largo * 0.68);
+  s.bezierCurveTo(a * 0.86, largo * 0.82, a * 0.42, largo * 0.96, 0, largo);
+  s.bezierCurveTo(-a * 0.42, largo * 0.96, -a * 0.86, largo * 0.82, -a * 0.72, largo * 0.68);
+  s.bezierCurveTo(-a * 0.96, largo * 0.62, -a * 1.06, largo * 0.44, -a * 0.86, largo * 0.36);
+  s.bezierCurveTo(-a * 1.02, largo * 0.2, -a * 0.7, largo * 0.02, 0, 0);
+  return s;
+}
+
+/** Folíolo simple (cada una de las tres hojitas de la mora). */
+function folioloMora(largo, ancho) {
+  const s = new THREE.Shape();
+  const a = ancho / 2;
+  s.moveTo(0, 0);
+  s.bezierCurveTo(a, largo * 0.22, a * 0.86, largo * 0.72, 0, largo);
+  s.bezierCurveTo(-a * 0.86, largo * 0.72, -a, largo * 0.22, 0, 0);
+  return s;
+}
+
+/** Esfera barata (fruto). `alarga` estira en Y (curuba, tomate de árbol). */
+function fruto(r, alarga = 1, seg = 8) {
+  const g = new THREE.SphereGeometry(r, seg, Math.max(5, Math.round(seg * 0.6)));
+  if (alarga !== 1) g.scale(1, alarga, 1);
+  return g;
+}
+
+/** Tallo/rama recta como cilindro, de `a` a `b`. */
+function rama(a, b, r0, r1 = r0, seg = 5) {
+  const va = new THREE.Vector3(...a);
+  const vb = new THREE.Vector3(...b);
+  const dir = new THREE.Vector3().subVectors(vb, va);
+  const largo = dir.length();
+  const g = new THREE.CylinderGeometry(r1, r0, largo, seg);
+  const q = new THREE.Quaternion().setFromUnitVectors(
+    new THREE.Vector3(0, 1, 0), dir.clone().normalize(),
+  );
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3().addVectors(va, vb).multiplyScalar(0.5), q, new THREE.Vector3(1, 1, 1),
+  );
+  g.applyMatrix4(m);
+  return g;
+}
+
+/* Reparto determinista sin Math.random: la misma mata en cada visita. */
+function az(i, s = 1) {
+  const x = Math.sin(i * 12.9898 + s * 78.233) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+/* ── 1. MORA DE CASTILLA (Rubus glaucus) ───────────────────────────────────
+   No es un árbol: son CAÑAS que salen de la base, se arquean y se amarran a la
+   espaldera. Hoja trifoliada (tres folíolos) con el envés más claro, espinas en
+   la caña y el fruto DESGRANADO en tres estados a la vez — verde, rojo y morado
+   casi negro. Ese "todo a la vez" es la verdad de la mora: se cosecha por pases,
+   no de un tirón. */
+export function construirMora() {
+  const partes = [];
+  const nCanas = 5;
+  for (let k = 0; k < nCanas; k++) {
+    const lado = k % 2 === 0 ? 1 : -1;
+    const desv = (az(k, 3) - 0.5) * 0.5;
+    const alto = 1.25 + az(k, 7) * 0.5;
+    const pie = [desv * 0.4, 0, (az(k, 11) - 0.5) * 0.35];
+    const codo = [desv + lado * 0.28, alto * 0.66, (az(k, 13) - 0.5) * 0.3];
+    const punta = [desv + lado * (0.72 + az(k, 17) * 0.3), alto, (az(k, 19) - 0.5) * 0.5];
+    partes.push(pintar(rama(pie, codo, 0.045, 0.036), P_FRUTAL.canaMora));
+    partes.push(pintar(rama(codo, punta, 0.036, 0.022), P_FRUTAL.canaMora));
+
+    // ESPINAS de la caña (chiquitas, pero son lo que uno recuerda de la mora)
+    for (let e = 0; e < 4; e++) {
+      const t = 0.2 + e * 0.2;
+      const p = [
+        pie[0] + (punta[0] - pie[0]) * t,
+        pie[1] + (punta[1] - pie[1]) * t,
+        pie[2] + (punta[2] - pie[2]) * t,
+      ];
+      const g = new THREE.ConeGeometry(0.018, 0.07, 4);
+      partes.push(pintar(poner(g, p, [az(e, k) * 3, az(e, k + 2) * 3, 2.1]), P_FRUTAL.espina));
+    }
+
+    // HOJA TRIFOLIADA: tres folíolos por hoja, cuatro hojas por caña
+    for (let h = 0; h < 4; h++) {
+      const t = 0.34 + h * 0.19;
+      const base = [
+        pie[0] + (punta[0] - pie[0]) * t,
+        pie[1] + (punta[1] - pie[1]) * t + 0.03,
+        pie[2] + (punta[2] - pie[2]) * t,
+      ];
+      const giroY = az(h, k * 5) * Math.PI * 2;
+      [-0.62, 0, 0.62].forEach((abre, j) => {
+        const g = laminaHoja(folioloMora(0.3, 0.19), 6);
+        const inclina = -0.5 - az(h + j, k) * 0.3;
+        partes.push(pintar(
+          poner(g, base, [inclina, giroY + abre, 0]),
+          j === 1 ? P_FRUTAL.hojaMora : P_FRUTAL.hojaMoraEnves,
+        ));
+      });
+    }
+
+    // EL FRUTO en sus tres estados sobre la misma caña
+    const estados = [P_FRUTAL.moraMadura, P_FRUTAL.moraRoja, P_FRUTAL.moraVerde];
+    for (let f = 0; f < 3; f++) {
+      const t = 0.55 + f * 0.14;
+      const cx = pie[0] + (punta[0] - pie[0]) * t + (az(f, k) - 0.5) * 0.12;
+      const cy = pie[1] + (punta[1] - pie[1]) * t - 0.1;
+      const cz = pie[2] + (punta[2] - pie[2]) * t + (az(f, k + 3) - 0.5) * 0.12;
+      // la mora es un fruto AGREGADO: cuatro drupeolitas, no una bolita lisa
+      for (let d = 0; d < 4; d++) {
+        const r = 0.028;
+        const off = [
+          Math.cos((d / 4) * Math.PI * 2) * 0.026,
+          -Math.abs(Math.sin(d * 1.7)) * 0.02,
+          Math.sin((d / 4) * Math.PI * 2) * 0.026,
+        ];
+        partes.push(pintar(
+          poner(fruto(r, 1, 6), [cx + off[0], cy + off[1], cz + off[2]]),
+          estados[f],
+        ));
+      }
+      partes.push(pintar(poner(fruto(0.03, 1.1, 6), [cx, cy + 0.018, cz]), estados[f]));
+    }
+  }
+  return fusionarSeguro(partes, 'mora-de-castilla');
+}
+
+/* ── 2. LULO (Solanum quitoense) ────────────────────────────────────────────
+   Arbusto BAJO cuya firma no es el fruto sino la HOJA: enorme, ancha, lobulada,
+   con la nervadura morada marcada. Al lado de las otras seis, el lulo es "el de
+   la hoja grande". El fruto es naranja y va casi al pie del tallo. */
+export function construirLulo() {
+  const partes = [];
+  const alto = 1.35;
+  partes.push(pintar(rama([0, 0, 0], [0.04, alto, 0.02], 0.085, 0.055, 6), P_FRUTAL.talloLulo));
+
+  // las hojas GRANDES, repartidas en espiral por el tallo
+  const nHojas = 9;
+  for (let i = 0; i < nHojas; i++) {
+    const t = 0.25 + (i / nHojas) * 0.78;
+    const y = alto * t;
+    const giro = i * 2.4;
+    const largo = 0.88 - t * 0.2;   // LA HOJA MÁS GRANDE DEL VERGEL: su firma
+    const ancho = largo * 0.9;
+    // se abre casi horizontal (antes colgaba vertical y la mata leía como palo)
+    const caida = -0.55 - az(i, 2) * 0.3;
+    const base = [Math.cos(giro) * 0.05, y, Math.sin(giro) * 0.05];
+    const g = laminaHoja(hojaLuloGrande(largo, ancho), 10);
+    partes.push(pintar(poner(g, base, [caida, giro, 0]), i % 3 === 0 ? P_FRUTAL.hojaLuloClara : P_FRUTAL.hojaLulo));
+    // NERVADURA MORADA: la costilla central, que es lo que se ve de lejos
+    const nerv = rama([0, 0, 0], [0, largo * 0.9, 0], 0.008, 0.004, 4);
+    partes.push(pintar(poner(nerv, base, [caida, giro, 0]), P_FRUTAL.nervaduraLulo));
+    // pecíolo
+    partes.push(pintar(poner(rama([0, 0, 0], [0, 0.1, 0], 0.012, 0.009, 4), base, [caida, giro, 0]), P_FRUTAL.talloLulo));
+  }
+
+  // los frutos naranja, abajo y pegados al tallo
+  [[0.16, 0.34, 0.9], [-0.13, 0.28, -0.6], [0.05, 0.52, 2.3]].forEach(([dx, y, giro], i) => {
+    const p = [dx + Math.cos(giro) * 0.06, y, Math.sin(giro) * 0.09];
+    partes.push(pintar(poner(fruto(0.088, 0.94, 8), p), i === 2 ? P_FRUTAL.luloPelusa : P_FRUTAL.luloFruto));
+    partes.push(pintar(poner(rama([p[0], p[1] + 0.07, p[2]], [p[0] * 0.4, p[1] + 0.13, p[2] * 0.4], 0.01, 0.008, 4)), P_FRUTAL.talloLulo));
+  });
+
+  return fusionarSeguro(partes, 'lulo');
+}
+
+/* ── 3. TOMATE DE ÁRBOL (Solanum betaceum) ──────────────────────────────────
+   El ÚNICO del vergel con porte de arbolito: un tronco que sube limpio y se
+   abre arriba en pocas ramas gruesas. Hoja grande acorazonada y frutos OVOIDES
+   colgando en racimos — nunca redondos, que es lo que lo confundiría con todo
+   lo demás. */
+export function construirTomateArbol() {
+  const partes = [];
+  const alto = 1.95;
+  partes.push(pintar(rama([0, 0, 0], [0.03, alto * 0.62, 0], 0.09, 0.062, 7), P_FRUTAL.troncoTomate));
+
+  // la horqueta: tres ramas madre que abren arriba
+  const brazos = [];
+  for (let k = 0; k < 3; k++) {
+    const a = (k / 3) * Math.PI * 2 + 0.5;
+    const punta = [Math.cos(a) * 0.56, alto, Math.sin(a) * 0.56];
+    partes.push(pintar(rama([0.03, alto * 0.62, 0], punta, 0.055, 0.03, 6), P_FRUTAL.troncoTomate));
+    brazos.push({ a, punta });
+  }
+
+  // hojas grandes acorazonadas en las puntas
+  brazos.forEach((b, k) => {
+    for (let i = 0; i < 5; i++) {
+      const t = 0.4 + i * 0.15;
+      const base = [
+        0.03 + (b.punta[0] - 0.03) * t,
+        alto * 0.62 + (alto - alto * 0.62) * t,
+        b.punta[2] * t,
+      ];
+      const giro = b.a + (az(i, k) - 0.5) * 1.6;
+      const g = laminaHoja(hojaCorazon(0.44, 0.3), 9);
+      partes.push(pintar(poner(g, base, [-0.75 - az(i, k + 4) * 0.4, giro, 0]), P_FRUTAL.hojaTomate));
+    }
+    // RACIMO de frutos ovoides colgando de la horqueta
+    for (let f = 0; f < 3; f++) {
+      const cx = b.punta[0] * 0.62 + (az(f, k) - 0.5) * 0.14;
+      const cz = b.punta[2] * 0.62 + (az(f, k + 6) - 0.5) * 0.14;
+      const cy = alto * 0.78 - f * 0.09;
+      partes.push(pintar(
+        poner(fruto(0.062, 1.5, 7), [cx, cy, cz]),
+        f === 1 ? P_FRUTAL.tomateFrutoPinton : P_FRUTAL.tomateFruto,
+      ));
+      partes.push(pintar(rama([cx, cy + 0.09, cz], [cx * 0.8, cy + 0.17, cz * 0.8], 0.008, 0.006, 4), P_FRUTAL.troncoTomate));
+    }
+  });
+
+  return fusionarSeguro(partes, 'tomate-de-arbol');
+}
+
+/* ── 4. UCHUVA (Physalis peruviana) ─────────────────────────────────────────
+   Mata baja y ramificada que se tutorea. Su firma NO es la bolita naranja: es el
+   CAPACHO — el cáliz de papel que la envuelve y que se abre seco al madurar.
+   Dibujar la uchuva sin capacho es dibujar otra cosa. */
+export function construirUchuva() {
+  const partes = [];
+  const alto = 0.95;
+  partes.push(pintar(rama([0, 0, 0], [0, alto * 0.5, 0], 0.04, 0.03, 5), P_FRUTAL.talloUchuva));
+
+  const ramas = [];
+  for (let k = 0; k < 4; k++) {
+    const a = (k / 4) * Math.PI * 2 + 0.4;
+    const punta = [Math.cos(a) * 0.42, alto, Math.sin(a) * 0.42];
+    partes.push(pintar(rama([0, alto * 0.5, 0], punta, 0.028, 0.016, 5), P_FRUTAL.talloUchuva));
+    ramas.push({ a, punta });
+  }
+
+  ramas.forEach((b, k) => {
+    // hojas acorazonadas pequeñas
+    for (let i = 0; i < 4; i++) {
+      const t = 0.3 + i * 0.2;
+      const base = [b.punta[0] * t, alto * 0.5 + (alto - alto * 0.5) * t, b.punta[2] * t];
+      const g = laminaHoja(hojaCorazon(0.2, 0.15), 7);
+      partes.push(pintar(poner(g, base, [-0.9 - az(i, k) * 0.4, b.a + (az(i, k + 2) - 0.5) * 1.4, 0]), P_FRUTAL.hojaUchuva));
+    }
+    // EL CAPACHO colgando: un farolito de papel (cono invertido de 5 caras) con
+    // la baya naranja adentro, asomando apenas por la boca.
+    const cx = b.punta[0] * 0.78;
+    const cz = b.punta[2] * 0.78;
+    const cy = alto * 0.78;
+    const cap = new THREE.ConeGeometry(0.055, 0.13, 5);
+    partes.push(pintar(poner(cap, [cx, cy - 0.07, cz], [Math.PI, 0, 0.12]), P_FRUTAL.capacho));
+    partes.push(pintar(poner(fruto(0.036, 1, 6), [cx, cy - 0.085, cz]), P_FRUTAL.uchuvaFruto));
+    partes.push(pintar(rama([cx, cy, cz], [b.punta[0], b.punta[1], b.punta[2]], 0.008, 0.006, 4), P_FRUTAL.talloUchuva));
+  });
+
+  return fusionarSeguro(partes, 'uchuva');
+}
+
+/* ── 5-7. LAS TRES PASIFLORAS ───────────────────────────────────────────────
+   Comparten el cuerpo (bejuco trepador con zarcillos) y se diferencian en HOJA,
+   FRUTO y —la curuba— FLOR. Se construyen con la misma fábrica para que las
+   diferencias sean EXPLÍCITAS y no accidentes de dos dibujos distintos.
+
+   @param {object} o
+   @param {'entera'|'trilobulada'} o.hoja  forma de la lámina.
+   @param {number} o.angostura   qué tan angostos los lóbulos (curuba < gulupa).
+   @param {string} o.colorHoja
+   @param {string} o.colorFruto
+   @param {number} o.alargaFruto 1 = redondo (granadilla, gulupa); >1 = oblongo
+                                 (curuba).
+   @param {number} o.rFruto
+   @param {boolean} [o.florRosada] la flor colgante de tubo largo de la curuba.
+   @param {string} o.etiqueta    nombre de la especie para el error de fusión.
+*/
+function construirPasiflora(o) {
+  const partes = [];
+  const alto = 1.9;   // sube hasta la ramada
+  const largoGuia = 1.5; // y después corre horizontal por encima
+
+  // el bejuco: sube en espiral por el tutor y se tiende sobre la ramada
+  let prev = [0, 0, 0];
+  for (let i = 1; i <= 8; i++) {
+    const t = i / 8;
+    const p = [Math.cos(t * 7) * 0.07, alto * t, Math.sin(t * 7) * 0.07];
+    partes.push(pintar(rama(prev, p, 0.032 - t * 0.012, 0.03 - t * 0.012, 5), P_FRUTAL.guia));
+    prev = p;
+  }
+  const corrida = [];
+  for (let i = 1; i <= 6; i++) {
+    const t = i / 6;
+    const p = [prev[0] + largoGuia * t, alto + Math.sin(t * 3.1) * 0.06, prev[2] + largoGuia * 0.28 * t];
+    partes.push(pintar(rama(corrida.length ? corrida[corrida.length - 1] : prev, p, 0.02, 0.016, 4), P_FRUTAL.guia));
+    corrida.push(p);
+  }
+
+  // hojas colgando de la corrida (la ramada se ve desde abajo: la hoja manda)
+  corrida.forEach((p, i) => {
+    for (let j = 0; j < 2; j++) {
+      const base = [p[0] + (az(i, j) - 0.5) * 0.2, p[1] - 0.03, p[2] + (az(i, j + 3) - 0.5) * 0.2];
+      const forma = o.hoja === 'entera'
+        ? hojaCorazon(0.34, 0.3)
+        : hojaTrilobulada(0.32, 0.34, o.angostura);
+      const g = laminaHoja(forma, 9);
+      partes.push(pintar(poner(g, base, [-2.0 - az(i, j) * 0.5, az(i, j + 7) * 6.28, 0]), o.colorHoja));
+      // ZARCILLO: el resorte con que la pasiflora se agarra. Sin él parece
+      // una rama cualquiera amarrada a un palo.
+      if (j === 0) {
+        const z0 = [base[0] + 0.04, base[1], base[2]];
+        partes.push(pintar(rama(z0, [z0[0] + 0.05, z0[1] - 0.13, z0[2] + 0.05], 0.006, 0.004, 4), P_FRUTAL.guia));
+        partes.push(pintar(rama([z0[0] + 0.05, z0[1] - 0.13, z0[2] + 0.05], [z0[0] - 0.02, z0[1] - 0.2, z0[2] + 0.09], 0.005, 0.004, 4), P_FRUTAL.guia));
+      }
+    }
+  });
+
+  // LOS FRUTOS colgando de la ramada — el rasgo que decide la especie
+  [1, 3, 5].forEach((i, k) => {
+    const p = corrida[i];
+    const cx = p[0] + (az(k, 2) - 0.5) * 0.16;
+    const cz = p[2] + (az(k, 5) - 0.5) * 0.16;
+    const cuelga = 0.2 + az(k, 9) * 0.12;
+    partes.push(pintar(rama([cx, p[1], cz], [cx, p[1] - cuelga, cz], 0.008, 0.007, 4), P_FRUTAL.guia));
+    partes.push(pintar(
+      poner(fruto(o.rFruto, o.alargaFruto, 9), [cx, p[1] - cuelga - o.rFruto * o.alargaFruto, cz]),
+      o.colorFruto,
+    ));
+  });
+
+  // LA FLOR de la curuba: rosada, de tubo largo, colgando hacia abajo. Es la
+  // seña más rápida para distinguirla de granadilla y gulupa.
+  if (o.florRosada) {
+    [2, 4].forEach((i, k) => {
+      const p = corrida[i];
+      const cx = p[0] - 0.1 + k * 0.08;
+      const cz = p[2] + 0.12;
+      partes.push(pintar(rama([cx, p[1], cz], [cx, p[1] - 0.26, cz], 0.011, 0.009, 5), P_FRUTAL.curubaFlor));
+      const corola = new THREE.ConeGeometry(0.07, 0.06, 6);
+      partes.push(pintar(poner(corola, [cx, p[1] - 0.3, cz], [Math.PI, 0, 0]), P_FRUTAL.curubaFlor));
+    });
+  }
+
+  return fusionarSeguro(partes, o.etiqueta);
+}
+
+/** GRANADILLA (Passiflora ligularis): hoja ENTERA acorazonada, fruto REDONDO naranja. */
+export function construirGranadilla() {
+  return construirPasiflora({
+    hoja: 'entera', angostura: 1,
+    colorHoja: P_FRUTAL.hojaGranadilla,
+    colorFruto: P_FRUTAL.granadillaFruto,
+    alargaFruto: 1, rFruto: 0.075,
+    etiqueta: 'granadilla',
+  });
+}
+
+/** GULUPA (Passiflora edulis f. edulis): hoja TRILOBULADA, fruto REDONDO MORADO. */
+export function construirGulupa() {
+  return construirPasiflora({
+    hoja: 'trilobulada', angostura: 1,
+    colorHoja: P_FRUTAL.hojaGulupa,
+    colorFruto: P_FRUTAL.gulupaFruto,
+    alargaFruto: 1, rFruto: 0.062,
+    etiqueta: 'gulupa',
+  });
+}
+
+/** CURUBA (Passiflora tripartita): hoja trilobulada angosta, FLOR ROSADA colgante
+    y fruto ALARGADO amarillo. */
+export function construirCuruba() {
+  return construirPasiflora({
+    hoja: 'trilobulada', angostura: 0.8,
+    colorHoja: P_FRUTAL.hojaCuruba,
+    colorFruto: P_FRUTAL.curubaFruto,
+    alargaFruto: 1.75, rFruto: 0.05,
+    florRosada: true,
+    etiqueta: 'curuba',
+  });
+}
+
+/* ── ESTRUCTURAS DE CONDUCCIÓN ──────────────────────────────────────────────
+   La mora y la gulupa van en ESPALDERA (postes + alambres); la granadilla y la
+   curuba, en RAMADA (emparrado horizontal, que es como se ven de verdad en la
+   finca: uno camina por debajo y la fruta cuelga sobre la cabeza). Sin la
+   estructura, un frutal trepador se lee como una mata suelta. */
+
+/** Un tramo de ESPALDERA: dos postes y tres alambres. */
+export function construirEspaldera(largo = 3.2, alto = 1.7) {
+  const partes = [];
+  [-largo / 2, largo / 2].forEach((x) => {
+    partes.push(pintar(rama([x, 0, 0], [x, alto, 0], 0.055, 0.045, 5), P_FRUTAL.poste));
+    partes.push(pintar(poner(new THREE.CylinderGeometry(0.07, 0.09, 0.1, 5), [x, 0.05, 0]), P_FRUTAL.posteSombra));
+  });
+  [0.6, 1.1, 1.55].forEach((y) => {
+    partes.push(pintar(rama([-largo / 2, y, 0], [largo / 2, y, 0], 0.009, 0.009, 4), P_FRUTAL.alambre));
+  });
+  return fusionarSeguro(partes, 'espaldera');
+}
+
+/** Una RAMADA (emparrado): cuatro postes y la parrilla de varas arriba. */
+export function construirRamada(ancho = 3.4, fondo = 2.6, alto = 2.0) {
+  const partes = [];
+  const ax = ancho / 2;
+  const az_ = fondo / 2;
+  [[-ax, -az_], [ax, -az_], [-ax, az_], [ax, az_]].forEach(([x, z]) => {
+    partes.push(pintar(rama([x, 0, z], [x, alto, z], 0.06, 0.05, 5), P_FRUTAL.poste));
+  });
+  // vigas
+  [-az_, az_].forEach((z) => {
+    partes.push(pintar(rama([-ax, alto, z], [ax, alto, z], 0.04, 0.04, 4), P_FRUTAL.poste));
+  });
+  // la parrilla de varas
+  for (let i = 0; i <= 5; i++) {
+    const x = -ax + (ancho * i) / 5;
+    partes.push(pintar(rama([x, alto + 0.04, -az_], [x, alto + 0.04, az_], 0.022, 0.022, 4), P_FRUTAL.posteSombra));
+  }
+  return fusionarSeguro(partes, 'ramada');
+}
+
+/* ── EL LINDERO DE MONTE ────────────────────────────────────────────────────
+   Ningún vergel de finca está solo en medio de la nada: atrás hay monte, o el
+   cercado vivo del vecino. Además de ser verdad, cierra la composición — sin
+   lindero la escena es media pantalla de cielo vacío y el vergel se lee como
+   una maqueta flotando. Un árbol genérico de monte, sin especie declarada: no
+   pretende ser ninguna de las siete ni dice ser nada en particular. */
+export function construirArbolLindero(semilla = 1) {
+  const partes = [];
+  const alto = 1.9 + az(semilla, 3) * 0.8;
+  partes.push(pintar(rama([0, 0, 0], [az(semilla, 5) * 0.2 - 0.1, alto, 0], 0.17, 0.11, 6),
+    mezclar(CORTEZAS.roble, TIERRAS.cacao, 0.3)));
+  /* copa ANCHA en varias masas: un monte de verdad, no una paleta de bombón */
+  const masas = [
+    { p: [0, alto + 0.8, 0], r: 1.5, c: mezclar(VERDES.monte, VERDES.templado, 0.3) },
+    { p: [-1.15, alto + 0.35, 0.4], r: 1.05, c: VERDES.monte },
+    { p: [1.1, alto + 0.45, -0.42], r: 1.0, c: mezclar(VERDES.monte, TIERRAS.cacao, 0.12) },
+    { p: [0.25, alto + 1.35, 0.35], r: 0.82, c: mezclar(VERDES.templado, VERDES.monte, 0.35) },
+    { p: [-0.5, alto + 0.9, -0.75], r: 0.78, c: VERDES.monte },
+  ];
+  masas.forEach((m, i) => {
+    const g = new THREE.IcosahedronGeometry(m.r * (0.9 + az(semilla, i + 7) * 0.3), 0);
+    g.scale(1, 0.86, 1);
+    partes.push(pintar(poner(g, m.p), m.c));
+  });
+  return fusionarSeguro(partes, 'arbol-del-lindero');
+}
+
+/* El elenco, como dato: lo que la escena siembra y lo que la ficha explica.
+   Si una especie no está acá, no se dibuja en este vergel. */
+export const ELENCO_FRUTALES = [
+  { id: 'mora', nombre: 'Mora de Castilla', cientifico: 'Rubus glaucus', porte: 'cañas en espaldera' },
+  { id: 'lulo', nombre: 'Lulo', cientifico: 'Solanum quitoense', porte: 'arbusto de hoja grande' },
+  { id: 'tomate', nombre: 'Tomate de árbol', cientifico: 'Solanum betaceum', porte: 'arbolito' },
+  { id: 'uchuva', nombre: 'Uchuva', cientifico: 'Physalis peruviana', porte: 'mata tutorada' },
+  { id: 'granadilla', nombre: 'Granadilla', cientifico: 'Passiflora ligularis', porte: 'bejuco en ramada' },
+  { id: 'gulupa', nombre: 'Gulupa', cientifico: 'Passiflora edulis f. edulis', porte: 'bejuco en espaldera' },
+  { id: 'curuba', nombre: 'Curuba', cientifico: 'Passiflora tripartita', porte: 'bejuco en ramada' },
+];


### PR DESCRIPTION
## 🐆 El jaguar — ya existía, y la regla de oro estaba a medias

No era un personaje nuevo: `src/visual/creatures/Jaguar.jsx` ya estaba. Lo que se corrigió:

| Bug | Detalle |
|---|---|
| **La regla de oro, a medias** | La roseta se dibujaba como anillo roto con centro ocre, pero **solo 2 de 6 llevaban el punto negro adentro** — que es exactamente lo único que lo separa del leopardo |
| **Patrón apiñado** | Todas las rosetas sobre la panza. Ahora va **por zonas, como en el animal**: rosetas en costados y ancas, manchas sólidas en el vientre, puntos chicos en las patas |
| **Patas de tinta maciza** | Las cuatro eran el `Miembro` compartido del kit: **se comían medio cuerpo**, borraban el pelaje leonado y hacían invisibles los puntos. Nuevo `PataJaguar` de manguera doble |
| **Un aro morado** | El shimmer iba en violeta a 0,16 y a tamaño de retrato **leía como un anillo cruzado en el pecho** |

Y trae una **lámina comparativa** que no estaba en el encargo y vale mucho: jaguar / leopardo /
mancha sólida, con el pie *"es el detalle que más se falla, y el campesino que lo ha visto lo nota
de una"*. Eso **enseña a distinguirlos**, no solo dibuja.

### Anti-leak cumplido
Sacó la carga simbólica de comentarios, de la paleta **y de los nombres de keyframes CSS**
(`jaguar-*-chaman` → `jaguar-*-noche`). El registro nocturno queda intacto, descrito como luz.

**Deuda preexistente detectada**: `dev` tiene **15 menciones más** de ese tipo en archivos que
este PR no toca. Merecen una pasada aparte.

## 🍑 El vergel — las siete con respaldo, sin inventar

Mora de Castilla, lulo, tomate de árbol, uchuva, granadilla, gulupa y curuba.

**Cero mango, cero cítricos** — verificado: las 5 menciones en el diff son todas para decir que
**no están, a propósito**, y la vitrina lo explica al usuario: *"Este vergel es de tierra fría
andina; por eso acá no hay mango ni naranjos"*. La ausencia se lee como decisión botánica.

Las tres pasifloras eran el riesgo real (granadilla, gulupa, curuba) y quedaron distinguibles
**por hoja y tutorado antes que por fruto**. Toda fusión pasa por `fusionarSeguro`: acá se mezclan
láminas de hoja indexadas con poliedros no indexados — **el caso exacto del `null` silencioso**.

## ⚠️ Lo que casi sale mal, y lo detectó él

**`origin/dev` se movió mientras trabajaba** (4 PRs mergeados). Su primer push quedó como una
**reversión masiva de 87 archivos** — el patrón destructivo que ya nos mordió antes. Lo detectó,
rebaseó sobre el `dev` actual y forzó el push.

Verificado por mí: el diff es **8 archivos nuevos + 4 modificados, CERO borrados**.

## Verificación

`vite build` verde (15,6 s) · rutas `#/mockups/jaguar-monte-3d` y `#/mockups/frutales-andinos-3d`
**confirmadas en el bundle**, no solo en el build · capturas contra vite propio en puerto 5219
**con sonda de procedencia que aborta si otro servidor secuestra el puerto**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)