### PR TITLE
feat(rag): reranker LLM-as-judge + fix recall@3/@5 en bench-embedders

### DIFF
--- a/docs/RAG.md
+++ b/docs/RAG.md
@@ -90,3 +90,122 @@ Detalle: de las 50 queries, 14 pasan de fallar (BM25) a acertar (híbrido) — c
 2. **Plaga→hospedero**: "gusano del cafe" no matchea directamente la ficha de cafe. Fix: 14 sinonimos `plaga_hospedero` en `campesino-synonyms.json`, wireados al retriever via `expandQueryTokens()`.
 3. **int8 quantize**: reduce asset de ~7.9MB (float32, 1024d) a ~1.7MB. Regenerar el asset con `--quantize`.
 4. **Embedder desalineado (RESUELTO 2026-07-02)**: ver sección de auditoría arriba. Cualquier cambio de modelo de embeddings a futuro debe tocar `embedQuery()` Y `build-rag-embeddings.mjs` a la vez, o el híbrido vuelve a degradar en silencio a BM25-only.
+
+## Reranker LLM-as-judge — medido 2026-07-22 (`scripts/bench-reranker.mjs`)
+
+### Por qué
+
+El bench de embedders mostró recall@1 bajo con recall@3 bastante más alto para
+el mejor embedder — un patrón de "el documento correcto SÍ está en el top-K
+pero no de primero", que es justo lo que arregla un reranker. Ollama 0.24 no
+tiene `/api/rerank` (404 verificado) ni `bge-reranker` en su registro (404 en
+dos variantes), así que se implementó como **LLM-as-judge**: el retriever trae
+top-K (embedder `granite-embedding:278m`, elegido por tamaño — 0.56 GB — para
+que quepa junto al agente `gemma4:e2b` ~8 GB en la M6000 de 12 GiB) y un modelo
+chico reordena esos K candidatos. Código: `scripts/lib/reranker.mjs` (modos
+`pointwise` y `listwise`). Script de medición: `scripts/bench-reranker.mjs`.
+
+### ⚠️ Corrección importante al número de motivación de esta tarea
+
+El número que motivó este trabajo (recall@3≈70% para el mejor embedder) **no
+era correcto**. Al armar este bench aparecieron dos problemas reales, ya
+corregidos:
+
+1. **Bug de scoring en `bench-embedders.mjs`** (`rankMetrics()`): `if (pos <=
+   2) r3++` y `if (pos <= 4) r5++` no comprobaban `pos >= 0` — `indexOf`
+   devuelve `-1` cuando el slug esperado no existe en el corpus, y `-1 <= 2`
+   es `true` en JS. Cualquier golden item cuyo `expected` no exista en el
+   corpus contaba como acierto automático de recall@3/@5. Fix: agregado el
+   guard `pos >= 0 &&` (MRR ya lo tenía; solo r3/r5 estaban rotos).
+2. **15 de 44 golden items evaluables referencian slugs que ya no existen**
+   como ficha propia: `solanum_tuberosum`, `lactuca_sativa`,
+   `solanum_lycopersicum`, `fragaria_ananassa`, `daucus_carota`,
+   `pisum_sativum` — el catálogo los reemplazó por variedades
+   (`solanum_tuberosum_pastusa_suprema`, etc.) y `eval/rag-golden.json` nunca
+   se actualizó. En el pipeline de producción esto probablemente NO es un
+   problema real — `ragRetriever.js` tiene `collapseVarieties()` exactamente
+   para este caso (ver "Cuellos conocidos" #1 arriba), y el bench
+   `bench-rag-retrieve.mjs` (que sí corre el pipeline híbrido completo) ya
+   resuelve `"que siembro en tierra fria" → solanum_tuberosum` correctamente.
+   Pero **ni `bench-embedders.mjs` ni este bench de reranker corren
+   `collapseVarieties()`** — ambos son pruebas de embedder/reranker aisladas
+   sobre el corpus crudo (así lo pidió esta tarea, para reusar la metodología
+   existente) — así que para estos 44 queries, esos 15 son un miss
+   estructural que ningún embedder ni reranker puede resolver en este
+   arnés de medición. **Recomendación de seguimiento**: repetir este
+   experimento sobre la salida real de `retrieveInternal()` (post BM25 +
+   semántico + `collapseVarieties()`), no sobre el ranking crudo de un solo
+   embedder — ahí es donde un reranker tendría que demostrar valor real.
+
+Con el fix, la tabla de embedders (mismo golden, corpus actual de 501 fichas)
+queda:
+
+| Embedder | recall@1 | recall@3 | recall@5 | MRR | lat. embed corpus | VRAM residente |
+|---|---|---|---|---|---|---|
+| nomic-embed-text (prod actual) | 18.2% | 38.6% | 40.9% | 0.2781 | 87ms | — |
+| bge-m3 | 29.5% | 38.6% | 40.9% | 0.3489 | 343ms | ~1.3GB |
+| snowflake-arctic-embed2 | 29.5% | 38.6% | 43.2% | 0.3618 | 366ms | ~1.3GB |
+| **granite-embedding:278m** | **31.8%** | 36.4% | 40.9% | 0.3550 | **121ms** | **0.56GB** |
+
+`granite-embedding:278m` no es solo "el que cabe" — tiene el recall@1 más alto
+de los 4 Y es el más barato en VRAM y el más rápido embediendo. Su único
+defecto real: `bert.context_length=512` tokens (verificado `ollama show`) —
+329 de 501 fichas del corpus lo superan y quedan excluidas del ranking
+(`corpus_embed_errors` en el JSON de salida). Truncar en vez de excluir se
+probó primero y *empeoró* el recall@1 medido (31.8%→18.2%): los embeddings
+truncados de esas 329 fichas largas terminaban ganándole el top-1 a la ficha
+correcta en varias queries. Se mantuvo la exclusión (igual que
+`bench-embedders.mjs`) por ser la opción más honesta, no la más completa.
+
+### Resultado — recall@1 con y sin reranker (K=10, n=44, agente `gemma4:e2b` cargado)
+
+| Reranker | recall@1 sin | recall@1 con | Δ | recall@3 con | latencia avg | latencia p95 | ¿Convive con el agente? |
+|---|---|---|---|---|---|---|---|
+| — (baseline) | 31.8% | — | — | 36.4% | — | — | — |
+| **qwen2.5:3b** | 31.8% | **36.4%** | **+4.6pp** | 45.5% | 2303ms | 2838ms | **Sí** (2.31GB) |
+| llama3.2:3b | 31.8% | 29.5% | **-2.3pp** | 34.1% | 3239ms | 3405ms | Sí (2.52GB) |
+| gemma2:2b | — | **CRASH** | — | — | — | — | **No** — tumba el runner |
+| phi4-mini | — | **CRASH** | — | — | — | — | **No** — tumba el runner |
+
+Reproducido 3 veces (recall@1 idéntico en las 3 corridas para qwen2.5:3b y
+llama3.2:3b tras fijar `format` JSON estructurado — ver abajo). Modo usado:
+**listwise** (1 llamado con los K candidatos numerados, el modelo devuelve el
+orden) — ganó por recall Y por latencia contra pointwise (1 llamado por
+candidato) en el sub-experimento dedicado: con qwen2.5:3b sobre 15 queries,
+listwise dio recall@1=20% en 2387ms promedio contra pointwise 13.3% en 4543ms.
+
+**gemma2:2b y phi4-mini NO son un problema de configuración.** Se verificó
+directo por curl, sin el script de por medio: ambos cargan y responden bien
+en solitario (GPU vacía), y ambos truenan reproduciblemente
+(`"llama runner process has terminated: signal arrived during cgo execution"`)
+apenas se intentan cargar con `gemma4:e2b` ya residente — con VRAM de sobra
+sobre el papel (agente 7.96GB + cualquiera de los dos ~2.5-2.9GB ≪ 12GB). No
+es falta de memoria: es una incompatibilidad real de la M6000 (Maxwell sm_52)
++ Ollama 0.24 con esas dos arquitecturas bajo carga concurrente — qwen2.5:3b
+y llama3.2:3b cargan sin problema en las mismas condiciones. El agente
+`gemma4:e2b` sobrevive el crash intacto (confirmado vía `/api/ps` después);
+solo el runner del modelo nuevo muere.
+
+**Ajuste que importó**: sin fijar `num_ctx` explícito (2048, alcanza de sobra
+para K=10 pasajes truncados), Ollama reserva el `num_ctx` por defecto del
+modelo para el KV-cache — eso infló a `gemma2:2b` de ~2.3GB a 3.9GB
+residentes y le hizo desalojar al agente en una corrida temprana. Con
+`num_ctx:2048` fijo, todos los candidatos que sí cargan quedan bajo 2.6GB.
+
+### Veredicto
+
+**+4.6 puntos de recall@1 por +2.3 segundos de latencia por consulta no
+justifica claramente el costo para una app de voz.** El propio criterio de
+esta tarea era "un reranker que suba 20 puntos pero agregue 5 segundos puede
+no servir" — acá se agregan ~2.3s (bajo el límite) pero se ganan solo 4.6pp
+(muy por debajo del techo de ~14pp que separaba recall@1 de coverage@10,
+45.5%). De los 4 candidatos que caben en presupuesto de VRAM real, 2 truenan
+el runner y el único que mejora algo (qwen2.5:3b) lo hace de forma marginal;
+el otro (llama3.2:3b) empeora. **No se recomienda shippear este reranker tal
+como está.** Caminos con más chance antes de reintentar: (1) medir sobre la
+salida de `retrieveInternal()` real (post-`collapseVarieties`), no sobre el
+embedder aislado — el "problema de orden" que motivó esto puede ser bastante
+más chico de lo que parecía; (2) si aun así hay hueco, probar el candidato
+con más headroom no probado por incompatibilidad de GPU (`gemma2:2b`,
+`phi4-mini`) en un GPU más nuevo, o esperar soporte de reranking nativo en
+una versión más reciente de Ollama.

--- a/scripts/bench-embedders.mjs
+++ b/scripts/bench-embedders.mjs
@@ -112,10 +112,19 @@ function rankMetrics(rankings, goldenItems) {
   let r1 = 0, r3 = 0, r5 = 0, rr = 0;
   const n = goldenItems.length;
   for (const { expectedSlug, ranked } of rankings) {
-    const pos = ranked.indexOf(expectedSlug); // 0-based
+    const pos = ranked.indexOf(expectedSlug); // 0-based, -1 si no aparece
     if (pos === 0) r1++;
-    if (pos <= 2) r3++;
-    if (pos <= 4) r5++;
+    // BUG FIX (encontrado armando el bench de reranker en feat/rag-reranker):
+    // sin el `pos >= 0 &&`, un expectedSlug que NO existe en el corpus
+    // (indexOf devuelve -1) contaba como HIT automático de recall@3/@5
+    // porque -1 <= 2 y -1 <= 4 son ambos true en JS. Afectaba a 15/44 items
+    // evaluables del golden (slugs base como solanum_tuberosum/lactuca_sativa
+    // que el catálogo ya solo tiene como variedades, ej.
+    // solanum_tuberosum_pastusa_suprema) e inflaba recall@3 70.5%→36.4% real
+    // y recall@5 75%→40.9% real. recall@1 y MRR no estaban afectados (ya
+    // tenían el guard correcto).
+    if (pos >= 0 && pos <= 2) r3++;
+    if (pos >= 0 && pos <= 4) r5++;
     if (pos >= 0) rr += 1 / (pos + 1);
   }
   return {

--- a/scripts/bench-reranker.mjs
+++ b/scripts/bench-reranker.mjs
@@ -1,0 +1,491 @@
+#!/usr/bin/env node
+/**
+ * bench-reranker.mjs — Mide cuánto sube recall@1 al agregar un reranker
+ * LLM-as-judge sobre el retriever del RAG de Chagra.
+ *
+ * Contexto (ver docs/RAG.md, sección "Reranker LLM-as-judge", para el detalle
+ * completo — acá el resumen):
+ *   - La motivación original citaba recall@3≈70% para el mejor embedder
+ *     contra recall@1≈32% — un hueco que parecía puro problema de orden.
+ *     Armando este bench se encontró un bug real en `rankMetrics()` de
+ *     `scripts/bench-embedders.mjs` (contaba como "hit" de recall@3/@5
+ *     cualquier golden item cuyo slug esperado NI SIQUIERA existe en el
+ *     corpus) — con el bug arreglado, el recall@3 real es ~36-39% según el
+ *     embedder, no ~70%. El hueco entre recall@1 y el techo real
+ *     (`coverage@K` acá abajo) sigue existiendo, pero es más chico de lo que
+ *     motivó esta tarea.
+ *   - Ollama 0.24 no tiene `/api/rerank` (404 verificado) ni `bge-reranker`
+ *     en su registro (404 en dos variantes) → el reranker es LLM-as-judge
+ *     con un modelo chico (scripts/lib/reranker.mjs), NO un cross-encoder
+ *     dedicado.
+ *   - La M6000 (12 GiB) ya tiene el agente `gemma4:e2b` (~8.1 GB) residente
+ *     en producción. Este script, por default, CARGA el agente antes de
+ *     medir (--warm-agent, default true) porque esa es la condición real:
+ *     un reranker que solo cabe con la GPU vacía no sirve.
+ *
+ * STANDALONE: se conecta directo a Ollama (POST /api/chat, /api/embeddings,
+ * GET /api/ps), sin depender de ragRetriever.js ni de import.meta.env — se
+ * ejecuta con `node`, no con Vite (mismo patrón que bench-embedders.mjs).
+ *
+ * OBLIGATORIO correr bajo `gpu-lock` (ver Chagra-strategy/ops/bin/gpu-lock):
+ * la GPU de alpha admite UNA medición a la vez.
+ *
+ * Uso:
+ *   node scripts/bench-reranker.mjs [opciones]
+ *
+ * Opciones (todas opcionales, con default razonable):
+ *   --embedder=granite-embedding:278m   embedder para construir el top-K
+ *   --k=10                              tamaño del top-K que ve el reranker
+ *   --models=qwen2.5:3b,gemma2:2b,llama3.2:3b   candidatos a comparar
+ *   --mode=listwise                     modo usado en la comparación principal
+ *   --mode-compare-model=qwen2.5:3b     modelo para el sub-experimento
+ *                                       pointwise-vs-listwise (vacío = se salta)
+ *   --mode-compare-limit=15             cuántas queries usa ese sub-experimento
+ *   --agent-model=gemma4:e2b            modelo "agente" a mantener cargado
+ *   --warm-agent=true|false             default true
+ *   --limit=<n>                         limitar cuántas queries del golden
+ *                                       se evalúan (smoke test rápido)
+ *   --out=<path>                        default data/bench-runs/reranker-<fecha>.json
+ *
+ * Ejemplo real (correr en alpha, bajo gpu-lock):
+ *   gpu-lock bench-reranker -- node scripts/bench-reranker.mjs \
+ *     --models=qwen2.5:3b,gemma2:2b,llama3.2:3b --k=10
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { performance } from 'node:perf_hooks';
+import {
+  rerank,
+  getLoadedModels,
+  warmModel,
+  unloadModel,
+} from './lib/reranker.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+// ---------- args ----------
+
+function parseArgs(argv) {
+  const out = {};
+  for (const arg of argv) {
+    const m = arg.match(/^--([^=]+)=(.*)$/);
+    if (m) out[m[1]] = m[2];
+    else if (arg.startsWith('--')) out[arg.slice(2)] = 'true';
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434';
+const EMBEDDER = args.embedder || 'granite-embedding:278m';
+const K = parseInt(args.k || '10', 10);
+const MODELS = (args.models || 'qwen2.5:3b,gemma2:2b,llama3.2:3b').split(',').map(s => s.trim()).filter(Boolean);
+const MODE = args.mode || 'listwise';
+const MODE_COMPARE_MODEL = args['mode-compare-model'] !== undefined ? args['mode-compare-model'] : 'qwen2.5:3b';
+const MODE_COMPARE_LIMIT = parseInt(args['mode-compare-limit'] || '15', 10);
+const AGENT_MODEL = args['agent-model'] || 'gemma4:e2b';
+const WARM_AGENT = (args['warm-agent'] ?? 'true') !== 'false';
+const LIMIT = args.limit ? parseInt(args.limit, 10) : undefined;
+const DATE_TAG = new Date().toISOString().slice(0, 10);
+const OUT_PATH = args.out ? resolve(ROOT, args.out) : resolve(ROOT, 'data', 'bench-runs', `reranker-${DATE_TAG}.json`);
+
+const CORPUS_DIR = resolve(ROOT, 'public', 'cycle-content');
+const MANIFEST_PATH = resolve(CORPUS_DIR, 'manifest.json');
+const GOLDEN_PATH = resolve(ROOT, 'eval', 'rag-golden.json');
+
+// Mismo set de queries cross-species sin slug en el corpus que excluye
+// bench-embedders.mjs — se mantiene idéntico para que los números sean
+// comparables entre los dos benches.
+const NON_SLUG_EXPECTED = new Set([
+  'biopreparado', 'associacion', 'mito_lunar', 'suelo_acido',
+  'agua_calidad', 'erosion',
+]);
+
+// ---------- helpers compartidos con bench-embedders.mjs (duplicados a
+// propósito: este script debe poder correr solo, sin tocar el otro bench) ----------
+
+function cosineSim(a, b) {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+// IMPORTANTE — por qué NO se trunca acá: granite-embedding:278m es BERT
+// (bert.context_length=512 tokens, verificado vía `ollama show`) y ~329/501
+// docs del corpus lo superan → Ollama devuelve 500 "the input length exceeds
+// the context length" para esos. Una primera versión de este script
+// reintentaba truncando el texto hasta que entrara — PARECÍA una mejora
+// (menos errores) pero rompía la comparabilidad con bench-embedders.mjs: al
+// forzar embeddings truncados (y por tanto peores/menos representativos)
+// para esos 329 docs, algunos terminaban compitiendo — y ganando — el
+// top-1 que le correspondía al doc correcto, y el recall@1 medido caía de
+// 31.8% (el número de referencia de esta tarea, reproducido abajo) a 18.2%.
+// bench-embedders.mjs (fuente de la metodología que esta tarea pide
+// reusar) simplemente EXCLUYE del ranking los docs que no entran (quedan en
+// sim=-1, nunca ganan un top-K) — replicamos exactamente ese
+// comportamiento para que el baseline "sin rerank" de este script sea
+// comparable al de bench-embedders.mjs. Cobertura perdida real de
+// granite-embedding:278m por este límite: documentada abajo en el output
+// (`corpus_embed_errors`), no escondida.
+async function embed(model, text) {
+  const res = await fetch(`${OLLAMA_URL}/api/embeddings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model, prompt: text }),
+  });
+  if (!res.ok) {
+    const msg = await res.text().catch(() => res.statusText);
+    throw new Error(`ollama ${res.status}: ${msg}`);
+  }
+  const data = await res.json();
+  if (!Array.isArray(data.embedding) || data.embedding.length === 0) {
+    throw new Error('Embedding vacío');
+  }
+  return data.embedding;
+}
+
+function extractText(doc) {
+  const parts = [];
+  if (doc.valor_pedagogico) parts.push(doc.valor_pedagogico);
+  if (Array.isArray(doc.milestones)) {
+    doc.milestones.forEach(m => {
+      if (m.label) parts.push(m.label);
+      if (m.description) parts.push(m.description);
+    });
+  }
+  if (Array.isArray(doc.companions)) {
+    const names = doc.companions.map(c => c.especie || c.nombre || '').filter(Boolean);
+    if (names.length) parts.push(names.join(', '));
+  }
+  if (Array.isArray(doc.failure_modes)) {
+    doc.failure_modes.forEach(f => {
+      if (f.mode) parts.push(f.mode);
+      if (f.solucion) parts.push(f.solucion);
+    });
+  }
+  if (doc.leccion_agroecologica) parts.push(doc.leccion_agroecologica);
+  return parts.join(' ').trim();
+}
+
+function pct(n, total) {
+  return Number((n / total * 100).toFixed(1));
+}
+
+function avg(arr) {
+  if (!arr.length) return 0;
+  return arr.reduce((s, v) => s + v, 0) / arr.length;
+}
+
+function percentile(arr, p) {
+  if (!arr.length) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))];
+}
+
+// ---------- main ----------
+
+async function main() {
+  console.log('=== bench-reranker.mjs — LLM-as-judge reranker sobre el RAG de Chagra ===\n');
+  console.log(`Ollama URL: ${OLLAMA_URL}`);
+  console.log(`Embedder (retriever top-K): ${EMBEDDER}`);
+  console.log(`K (top-K que ve el reranker): ${K}`);
+  console.log(`Modelos candidatos a reranker: ${MODELS.join(', ')}`);
+  console.log(`Modo principal: ${MODE}`);
+  console.log(`Agente a mantener cargado: ${WARM_AGENT ? AGENT_MODEL : '(ninguno — GPU vacía, NO representa producción)'}\n`);
+
+  if (!existsSync(GOLDEN_PATH)) throw new Error(`No existe golden set: ${GOLDEN_PATH}`);
+  if (!existsSync(MANIFEST_PATH)) throw new Error(`No existe manifest de corpus: ${MANIFEST_PATH}`);
+
+  // --- -1. Arranque limpio: descargar CUALQUIER cosa que haya quedado
+  //     residente de una corrida anterior (propia o de otro proceso). Sin
+  //     esto, un modelo huérfano de un run previo compite por VRAM con el
+  //     agente de ESTE run y ensucia la medición de "¿convive?" — ya pasó
+  //     en desarrollo de este mismo script. ---
+  if (WARM_AGENT) {
+    const before = await getLoadedModels(OLLAMA_URL).catch(() => []);
+    for (const m of before) {
+      if (!m.name.startsWith(AGENT_MODEL.split(':')[0])) await unloadModel(OLLAMA_URL, m.name);
+    }
+    if (before.length) console.log(`Arranque limpio: descargados ${before.map(m => m.name).join(', ')} (residuo de corridas previas)\n`);
+  }
+
+  // --- 0. Warm-up del agente: escenario real de producción ---
+  const residency = { before: [], after_agent: [], after_all: [] };
+  if (WARM_AGENT) {
+    console.log(`Cargando agente ${AGENT_MODEL} (keep_alive largo, simula producción)...`);
+    residency.before = await getLoadedModels(OLLAMA_URL).catch(() => []);
+    const t0 = performance.now();
+    await warmModel(OLLAMA_URL, AGENT_MODEL, { keepAlive: '30m' });
+    console.log(`  Agente cargado en ${(performance.now() - t0).toFixed(0)}ms`);
+    residency.after_agent = await getLoadedModels(OLLAMA_URL).catch(() => []);
+    console.log(`  /api/ps: ${residency.after_agent.map(m => `${m.name}(${(m.size_vram / 1e9).toFixed(2)}GB)`).join(', ') || '(vacío)'}\n`);
+  }
+
+  // --- 1. Cargar corpus ---
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+  const allSlugs = manifest.slugs || [];
+  const corpus = [];
+  for (const slug of allSlugs) {
+    const docPath = resolve(CORPUS_DIR, `${slug}.json`);
+    if (!existsSync(docPath)) continue;
+    const doc = JSON.parse(readFileSync(docPath, 'utf8'));
+    const text = extractText(doc);
+    if (text) corpus.push({ slug, text });
+  }
+  console.log(`Corpus cargado: ${corpus.length} docs con texto`);
+
+  // --- 2. Cargar golden set ---
+  const golden = JSON.parse(readFileSync(GOLDEN_PATH, 'utf8'));
+  let goldItems = golden.filter(g => !NON_SLUG_EXPECTED.has(g.expected));
+  const skipped = golden.filter(g => NON_SLUG_EXPECTED.has(g.expected));
+  if (LIMIT) goldItems = goldItems.slice(0, LIMIT);
+  console.log(`Golden set: ${golden.length} total, ${goldItems.length} evaluables (${skipped.length} cross-species excluidas)\n`);
+
+  // --- 3. Embeber corpus con el embedder elegido ---
+  console.log(`Embediendo ${corpus.length} chunks del corpus con ${EMBEDDER}...`);
+  const corpusVecs = [];
+  let embedErrors = 0;
+  for (let i = 0; i < corpus.length; i++) {
+    try {
+      corpusVecs.push(await embed(EMBEDDER, corpus[i].text));
+    } catch (err) {
+      console.error(`  ERROR embediendo slug=${corpus[i].slug}: ${err.message}`);
+      corpusVecs.push(null);
+      embedErrors++;
+    }
+    if ((i + 1) % 100 === 0) process.stderr.write(`  [${i + 1}/${corpus.length}]\n`);
+  }
+  console.log(`Corpus embebido (${embedErrors} errores — típicamente docs que exceden el contexto de ${EMBEDDER}; se excluyen del ranking, igual que en bench-embedders.mjs).\n`);
+
+  if (WARM_AGENT) {
+    residency.after_embedder = await getLoadedModels(OLLAMA_URL).catch(() => []);
+    console.log(`/api/ps tras embeber (¿coexiste el embedder con el agente?): ${residency.after_embedder.map(m => `${m.name}(${(m.size_vram / 1e9).toFixed(2)}GB)`).join(', ') || '(vacío)'}\n`);
+  }
+
+  // --- 4. Para cada query: embeber, rankear TODO el corpus (baseline "sin
+  //     rerank", misma metodología que bench-embedders.mjs) y quedarse con
+  //     el top-K como candidatos para el reranker. ---
+  console.log(`Calculando ranking base (sin rerank) + candidatos top-${K} para ${goldItems.length} queries...`);
+  const perQuery = [];
+  for (const g of goldItems) {
+    let queryVec;
+    try {
+      queryVec = await embed(EMBEDDER, g.query);
+    } catch (err) {
+      console.error(`  ERROR embediendo query ${g.id}: ${err.message}`);
+      perQuery.push({ item: g, rankedFull: [], topK: [] });
+      continue;
+    }
+    const sims = corpus
+      .map((c, idx) => ({ slug: c.slug, text: c.text, sim: corpusVecs[idx] ? cosineSim(queryVec, corpusVecs[idx]) : -1 }))
+      .sort((a, b) => b.sim - a.sim);
+    perQuery.push({
+      item: g,
+      rankedFull: sims.map(s => s.slug),
+      topK: sims.slice(0, K).map(s => ({ slug: s.slug, text: s.text, sim: s.sim })),
+    });
+  }
+
+  // Baseline: recall@1/@3/@5 igual que bench-embedders.mjs, más "coverage@K"
+  // (¿el esperado está dentro del top-K que ve el reranker? — es el techo
+  // que el reranker puede alcanzar, no puede inventar cobertura que el
+  // retriever no trajo).
+  const n = goldItems.length;
+  let r1 = 0, r3 = 0, r5 = 0, coverageK = 0;
+  for (const { item, rankedFull } of perQuery) {
+    const pos = rankedFull.indexOf(item.expected);
+    if (pos === 0) r1++;
+    if (pos >= 0 && pos <= 2) r3++;
+    if (pos >= 0 && pos <= 4) r5++;
+    if (pos >= 0 && pos < K) coverageK++;
+  }
+  const baseline = {
+    embedder: EMBEDDER,
+    n,
+    'recall@1': pct(r1, n),
+    'recall@3': pct(r3, n),
+    'recall@5': pct(r5, n),
+    [`coverage@${K}`]: pct(coverageK, n),
+  };
+  console.log(`\nBASELINE sin rerank (${EMBEDDER}): recall@1=${baseline['recall@1']}%  recall@3=${baseline['recall@3']}%  recall@5=${baseline['recall@5']}%  coverage@${K}=${baseline[`coverage@${K}`]}%\n`);
+
+  // --- 5. Sub-experimento opcional: pointwise vs listwise, mismo modelo,
+  //     subset chico (barato) — decide qué modo usar en la comparación
+  //     principal de modelos. ---
+  let modeComparison = null;
+  if (MODE_COMPARE_MODEL) {
+    console.log(`${'─'.repeat(60)}`);
+    console.log(`Sub-experimento: pointwise vs listwise con ${MODE_COMPARE_MODEL} (primeras ${MODE_COMPARE_LIMIT} queries)`);
+    const subset = perQuery.slice(0, MODE_COMPARE_LIMIT).filter(pq => pq.topK.length > 0);
+    const results = {};
+    for (const mode of ['pointwise', 'listwise']) {
+      let hits = 0;
+      const latencies = [];
+      let parseFailures = 0;
+      for (const pq of subset) {
+        try {
+          const r = await rerank(mode, OLLAMA_URL, MODE_COMPARE_MODEL, pq.item.query, pq.topK);
+          latencies.push(mode === 'pointwise' ? r.latencyMsTotal : r.latencyMs);
+          parseFailures += (r.parseFailures ?? (r.parseFailure ? 1 : 0));
+          if (r.ranked[0] === pq.item.expected) hits++;
+        } catch (err) {
+          console.error(`    ERROR ${mode} ${pq.item.id}: ${err.message}`);
+        }
+      }
+      results[mode] = {
+        'recall@1_subset': pct(hits, subset.length),
+        latency_avg_ms: Number(avg(latencies).toFixed(0)),
+        latency_p50_ms: Number(percentile(latencies, 0.5).toFixed(0)),
+        parse_failures: parseFailures,
+        calls_per_query: mode === 'pointwise' ? K : 1,
+      };
+      console.log(`  ${mode.padEnd(10)} recall@1=${results[mode]['recall@1_subset']}%  lat_avg=${results[mode].latency_avg_ms}ms  parse_fail=${parseFailures}`);
+    }
+    const winner = results.listwise.latency_avg_ms <= results.pointwise.latency_avg_ms * 0.5
+      || results.listwise['recall@1_subset'] >= results.pointwise['recall@1_subset']
+      ? 'listwise' : 'pointwise';
+    console.log(`  → modo elegido para la comparación principal: ${winner} (recall similar o mejor, y ${MODELS.length > 0 ? 'menos llamados = menos latencia acumulada' : ''})`);
+    modeComparison = { model: MODE_COMPARE_MODEL, subset_size: subset.length, results, chosen_mode: winner };
+    console.log(`${'─'.repeat(60)}\n`);
+    if (WARM_AGENT) await unloadModel(OLLAMA_URL, MODE_COMPARE_MODEL); // reset a estado 2-way (agente+embedder) antes del loop principal
+  }
+
+  const effectiveMode = MODE_COMPARE_MODEL && !args.mode ? modeComparison.chosen_mode : MODE;
+  console.log(`Modo usado en la comparación principal de modelos: ${effectiveMode}\n`);
+
+  // --- 6. Comparación principal: cada modelo candidato reordena el top-K
+  //     de CADA query evaluable, con el agente (y el embedder) cargados. ---
+  const modelResults = [];
+  for (const model of MODELS) {
+    console.log(`${'─'.repeat(60)}`);
+    console.log(`Reranker: ${model}`);
+    let residencyDuring = null;
+    try {
+      if (WARM_AGENT) {
+        // Descargar los OTROS candidatos antes de medir este: cada fila de
+        // la tabla debe reflejar "agente + ESTE reranker" (2-way), no
+        // "agente + todos los candidatos probados hasta ahora" acumulados.
+        for (const other of MODELS) {
+          if (other !== model) await unloadModel(OLLAMA_URL, other);
+        }
+        // Forzar carga del reranker ANTES de medir, para que la latencia
+        // reportada sea la de inferencia, no la de carga en frío del modelo.
+        await warmModel(OLLAMA_URL, model, { keepAlive: '10m' });
+        residencyDuring = await getLoadedModels(OLLAMA_URL).catch(() => []);
+        const fitsWithAgent = WARM_AGENT
+          ? residencyDuring.some(m => m.name.startsWith(AGENT_MODEL.split(':')[0]))
+          : null;
+        console.log(`  /api/ps: ${residencyDuring.map(m => `${m.name}(${(m.size_vram / 1e9).toFixed(2)}GB)`).join(', ')}`);
+        console.log(`  ¿Coexiste con el agente (${AGENT_MODEL})?: ${fitsWithAgent === null ? 'n/a' : (fitsWithAgent ? 'SÍ' : 'NO — el agente fue desalojado')}`);
+      }
+
+      let hits1 = 0, hits3 = 0;
+      const latencies = [];
+      let parseFailures = 0;
+      let errors = 0;
+      for (const pq of perQuery) {
+        if (!pq.topK.length) continue;
+        try {
+          const r = await rerank(effectiveMode, OLLAMA_URL, model, pq.item.query, pq.topK);
+          latencies.push(effectiveMode === 'pointwise' ? r.latencyMsTotal : r.latencyMs);
+          parseFailures += (r.parseFailures ?? (r.parseFailure ? 1 : 0));
+          if (r.ranked[0] === pq.item.expected) hits1++;
+          if (r.ranked.slice(0, 3).includes(pq.item.expected)) hits3++;
+        } catch (err) {
+          errors++;
+          console.error(`    ERROR ${pq.item.id}: ${err.message}`);
+        }
+      }
+
+      const evaluated = perQuery.filter(pq => pq.topK.length).length;
+      const recall1 = pct(hits1, n);
+      const recall3 = pct(hits3, n);
+      modelResults.push({
+        model,
+        mode: effectiveMode,
+        evaluated,
+        errors,
+        parse_failures: parseFailures,
+        'recall@1': recall1,
+        'recall@3': recall3,
+        'recall@1_delta_vs_baseline': Number((recall1 - baseline['recall@1']).toFixed(1)),
+        latency: {
+          avg_ms: Number(avg(latencies).toFixed(0)),
+          p50_ms: Number(percentile(latencies, 0.5).toFixed(0)),
+          p95_ms: Number(percentile(latencies, 0.95).toFixed(0)),
+        },
+        residency: residencyDuring,
+        fits_with_agent: WARM_AGENT ? residencyDuring?.some(m => m.name.startsWith(AGENT_MODEL.split(':')[0])) : null,
+      });
+      console.log(`  recall@1=${recall1}% (baseline ${baseline['recall@1']}%, delta ${(recall1 - baseline['recall@1']).toFixed(1)}pp)  recall@3=${recall3}%  lat_avg=${avg(latencies).toFixed(0)}ms  parse_fail=${parseFailures}  errors=${errors}`);
+    } catch (err) {
+      console.error(`  FALLO TOTAL con ${model}: ${err.message}`);
+      modelResults.push({ model, mode: effectiveMode, fatal_error: err.message });
+    }
+  }
+  console.log(`${'─'.repeat(60)}\n`);
+
+  // --- 7. Tabla resumen ---
+  console.log(`${'═'.repeat(96)}`);
+  console.log(`RESUMEN — reranker LLM-as-judge sobre ${EMBEDDER} (top-${K}, n=${n})`);
+  console.log('─'.repeat(96));
+  console.log(
+    'Modelo'.padEnd(20) +
+    'R@1 sin'.padStart(10) + 'R@1 con'.padStart(10) + 'delta'.padStart(8) +
+    'lat avg'.padStart(10) + 'lat p95'.padStart(10) + 'convive c/ agente'.padStart(20)
+  );
+  console.log('─'.repeat(96));
+  for (const r of modelResults) {
+    if (r.fatal_error) {
+      console.log(`${r.model.padEnd(20)} FALLÓ: ${r.fatal_error}`);
+      continue;
+    }
+    console.log(
+      r.model.padEnd(20) +
+      `${baseline['recall@1']}%`.padStart(10) +
+      `${r['recall@1']}%`.padStart(10) +
+      `${r['recall@1_delta_vs_baseline'] >= 0 ? '+' : ''}${r['recall@1_delta_vs_baseline']}`.padStart(8) +
+      `${r.latency.avg_ms}ms`.padStart(10) +
+      `${r.latency.p95_ms}ms`.padStart(10) +
+      `${r.fits_with_agent === null ? 'n/a' : (r.fits_with_agent ? 'sí' : 'NO')}`.padStart(20)
+    );
+  }
+  console.log('─'.repeat(96));
+  console.log('═'.repeat(96));
+
+  // --- 8. Guardar JSON ---
+  mkdirSync(dirname(OUT_PATH), { recursive: true });
+  const output = {
+    bench: 'reranker',
+    date: new Date().toISOString(),
+    ollama_url: OLLAMA_URL,
+    embedder: EMBEDDER,
+    k: K,
+    agent_model: WARM_AGENT ? AGENT_MODEL : null,
+    warm_agent: WARM_AGENT,
+    gold_total: golden.length,
+    gold_evaluable: n,
+    gold_skipped: skipped.length,
+    corpus_embed_errors: embedErrors,
+    baseline,
+    mode_comparison: modeComparison,
+    effective_mode: effectiveMode,
+    models: modelResults,
+    residency_snapshots: residency,
+  };
+  writeFileSync(OUT_PATH, JSON.stringify(output, null, 2));
+  console.log(`\nResultados guardados en: ${OUT_PATH}`);
+}
+
+main().catch(err => {
+  console.error('[bench-reranker] FATAL:', err);
+  process.exit(1);
+});

--- a/scripts/lib/reranker.mjs
+++ b/scripts/lib/reranker.mjs
@@ -1,0 +1,348 @@
+/**
+ * reranker.mjs — LLM-as-judge reranker para el RAG de Chagra.
+ *
+ * Por qué existe: la motivación original de esta tarea citaba recall@1≈32%
+ * contra recall@3≈70% para el mejor embedder — un patrón de "el documento
+ * correcto SÍ está en el top-3 pero no de primero", justo lo que arregla un
+ * reranker. Armando el bench (ver docs/RAG.md, sección "Reranker LLM-as-judge")
+ * apareció un bug real en `bench-embedders.mjs` que inflaba ese recall@3 (el
+ * número correcto, con el bug arreglado, es bastante más bajo — ~36-39%
+ * según el embedder). El techo real es más chico de lo que se pensaba, pero
+ * sigue habiendo margen entre recall@1 y recall@K — eso es lo que este
+ * módulo intenta capturar. Detalle completo, tabla y veredicto en
+ * docs/RAG.md.
+ *
+ * Por qué LLM-as-judge y no un reranker dedicado: en Ollama 0.24 no existe
+ * el endpoint `/api/rerank` (404 verificado) y `bge-reranker` no está en su
+ * registro de modelos (404 en dos variantes). Con la M6000 de 12 GiB ya
+ * ocupada por el agente (`gemma4:e2b`, ~8.1 GB) y el embedder
+ * (`granite-embedding:278m`, ~0.6 GB), quedan ~3 GB — ahí caben modelos
+ * chicos de instrucción (qwen2.5:3b, llama3.2:3b, gemma2:2b, phi4-mini) que
+ * SÍ sirven como juez de relevancia vía prompt.
+ *
+ * Dos modos de puntuación:
+ *  - pointwise: un llamado por candidato (query, pasaje) → score 0-10.
+ *    K llamados por consulta. Prompts chicos, más llamados = más latencia
+ *    acumulada y más superficie de fallo de parseo.
+ *  - listwise: un solo llamado con los K candidatos numerados → el modelo
+ *    devuelve el orden completo. 1 llamado por consulta, prompt más largo.
+ *
+ * Reglas de proyecto aplicadas en cada llamado (ver AI_PIPELINE_SOP /
+ * FLEET.md / brief de esta tarea):
+ *  - `think: false` SIEMPRE — sin este flag los modelos "pensantes" pueden
+ *    devolver vacío y eso se lee (mal) como que el modelo "no sirve".
+ *  - `temperature: 0` — determinismo para que el bench sea reproducible.
+ *  - timeout explícito por llamado (AbortController) — un modelo colgado no
+ *    debe colgar el bench completo.
+ */
+
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+/**
+ * Trunca un texto a maxChars, cortando en el último espacio para no partir
+ * palabras a la mitad (mejor para el juez LLM que un corte crudo).
+ */
+export function truncate(text, maxChars) {
+  if (!text || text.length <= maxChars) return text || '';
+  const cut = text.slice(0, maxChars);
+  const lastSpace = cut.lastIndexOf(' ');
+  return (lastSpace > maxChars * 0.6 ? cut.slice(0, lastSpace) : cut) + '…';
+}
+
+/**
+ * Llamado crudo a POST /api/chat con think:false + temperature:0.
+ * Devuelve { content, ms } o lanza con mensaje claro (timeout vs HTTP vs red).
+ */
+export async function ollamaChat(ollamaUrl, model, messages, opts = {}) {
+  const {
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    keepAlive,
+    numPredict = 64,
+    // Default chico a propósito: sin esto, Ollama reserva el num_ctx por
+    // DEFECTO del modelo (a veces 4096-8192) para el KV-cache, y eso infla
+    // el tamaño en VRAM aunque el prompt real sea corto (medido: gemma2:2b
+    // pasó de "cabría fácil" a 3.9 GB residentes y desalojó al agente, solo
+    // por el num_ctx default). 2048 alcanza de sobra para K=10 pasajes
+    // truncados + el prompt de sistema.
+    numCtx = 2048,
+    format,
+  } = opts;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const t0 = performance.now();
+  try {
+    const body = {
+      model,
+      messages,
+      stream: false,
+      think: false,
+      options: { temperature: 0, num_predict: numPredict, num_ctx: numCtx },
+    };
+    if (keepAlive !== undefined) body.keep_alive = keepAlive;
+    if (format) body.format = format;
+
+    const res = await fetch(`${ollamaUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const ms = performance.now() - t0;
+    if (!res.ok) {
+      const msg = await res.text().catch(() => res.statusText);
+      throw new Error(`ollama ${res.status}: ${msg}`);
+    }
+    const data = await res.json();
+    const content = data?.message?.content ?? '';
+    return { content, ms, raw: data };
+  } catch (err) {
+    const ms = performance.now() - t0;
+    if (err.name === 'AbortError') {
+      throw Object.assign(new Error(`timeout tras ${timeoutMs}ms`), { ms, timeout: true });
+    }
+    throw Object.assign(err, { ms });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** GET /api/ps — qué modelos están residentes en la GPU/CPU ahora mismo. */
+export async function getLoadedModels(ollamaUrl) {
+  const res = await fetch(`${ollamaUrl}/api/ps`);
+  if (!res.ok) throw new Error(`ollama ${res.status} en /api/ps`);
+  const data = await res.json();
+  return (data.models || []).map(m => ({
+    name: m.name,
+    size_vram: m.size_vram,
+    size: m.size,
+    expires_at: m.expires_at,
+  }));
+}
+
+/** Fuerza la carga de un modelo con un llamado mínimo (warm-up). */
+export async function warmModel(ollamaUrl, model, opts = {}) {
+  const { keepAlive = '30m', timeoutMs = 60_000 } = opts;
+  return ollamaChat(
+    ollamaUrl,
+    model,
+    [{ role: 'user', content: 'Respondé solo con la palabra: listo' }],
+    { keepAlive, timeoutMs, numPredict: 8 }
+  );
+}
+
+/**
+ * Descarga un modelo YA (keep_alive:0, sin correr inferencia real) — para
+ * que la medición de "¿convive con el agente?" de cada candidato a reranker
+ * sea 2 vs 2 (agente + ESE candidato), no 2 vs N acumulando todos los
+ * candidatos anteriores en VRAM. Best-effort: si el modelo no estaba
+ * cargado, Ollama igual responde 200 sin hacer nada.
+ */
+export async function unloadModel(ollamaUrl, model) {
+  try {
+    await fetch(`${ollamaUrl}/api/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, keep_alive: 0 }),
+    });
+  } catch {
+    // best-effort — no bloquea el bench si falla
+  }
+}
+
+// ---------- pointwise ----------
+
+function pointwisePrompt(query, passageText) {
+  return [
+    {
+      role: 'system',
+      content:
+        'Sos un evaluador de relevancia para un buscador agroecológico campesino. ' +
+        'Te doy una consulta y un fragmento de una ficha. Calificá qué tan relevante ' +
+        'es el fragmento para responder la consulta, en una escala de 0 (nada relevante) ' +
+        'a 10 (responde exactamente la consulta). Respondé ÚNICAMENTE con el número, ' +
+        'sin texto adicional, sin explicación.',
+    },
+    {
+      role: 'user',
+      content: `Consulta: "${query}"\nFragmento: "${passageText}"\nCalificación (0-10):`,
+    },
+  ];
+}
+
+/** Extrae el primer número (entero o decimal) de un texto; NaN si no hay. */
+export function parseScore(text) {
+  const m = String(text || '').match(/-?\d+(\.\d+)?/);
+  if (!m) return NaN;
+  const n = parseFloat(m[0]);
+  if (Number.isNaN(n)) return NaN;
+  return Math.max(0, Math.min(10, n));
+}
+
+/**
+ * Reordena `candidates` (array de {slug, text}) puntuando cada uno por
+ * separado. Devuelve { ranked: [slug...], scores, latenciesMs, parseFailures }.
+ */
+export async function rerankPointwise(ollamaUrl, model, query, candidates, opts = {}) {
+  const { maxChars = 300, timeoutMs = DEFAULT_TIMEOUT_MS, numCtx } = opts;
+  const scored = [];
+  const latenciesMs = [];
+  let parseFailures = 0;
+
+  for (const c of candidates) {
+    const passage = truncate(c.text, maxChars);
+    let score = 0;
+    try {
+      const { content, ms } = await ollamaChat(
+        ollamaUrl,
+        model,
+        pointwisePrompt(query, passage),
+        { timeoutMs, numPredict: 8, ...(numCtx ? { numCtx } : {}) }
+      );
+      latenciesMs.push(ms);
+      const parsed = parseScore(content);
+      if (Number.isNaN(parsed)) {
+        parseFailures++;
+        score = 0;
+      } else {
+        score = parsed;
+      }
+    } catch (err) {
+      latenciesMs.push(err.ms ?? timeoutMs);
+      parseFailures++;
+      score = 0;
+    }
+    scored.push({ slug: c.slug, score });
+  }
+
+  // Sort estable descendente por score; empate → conserva orden original
+  // (el orden que trajo el retriever) como desempate razonable.
+  const withIndex = scored.map((s, i) => ({ ...s, i }));
+  withIndex.sort((a, b) => (b.score - a.score) || (a.i - b.i));
+
+  return {
+    ranked: withIndex.map(s => s.slug),
+    scores: Object.fromEntries(scored.map(s => [s.slug, s.score])),
+    latenciesMs,
+    latencyMsTotal: latenciesMs.reduce((s, v) => s + v, 0),
+    parseFailures,
+    calls: candidates.length,
+  };
+}
+
+// ---------- listwise ----------
+
+// Formato estructurado (grammar-constrained decoding de Ollama) para el
+// listwise: garantiza JSON sintácticamente válido SIEMPRE (elimina la falla
+// "el modelo no devolvió ni un array reconocible"). NO garantiza que los
+// índices sean válidos/completos — eso lo sigue resolviendo parseListOrder
+// con su fallback de mezcla, porque un modelo chico puede devolver un JSON
+// perfecto con índices repetidos, faltantes o fuera de rango.
+const LISTWISE_FORMAT = {
+  type: 'object',
+  properties: { order: { type: 'array', items: { type: 'integer' } } },
+  required: ['order'],
+};
+
+function listwisePrompt(query, candidates, maxCharsEach) {
+  const lines = candidates
+    .map((c, i) => `[${i}] ${truncate(c.text, maxCharsEach)}`)
+    .join('\n');
+  return [
+    {
+      role: 'system',
+      content:
+        'Sos un motor de reordenamiento de resultados de búsqueda para un ' +
+        'buscador agroecológico campesino. Te doy una consulta y una lista de ' +
+        'fragmentos numerados desde [0]. Devolvé un objeto JSON con la clave ' +
+        '"order": un array con TODOS los índices, ordenados del MÁS al MENOS ' +
+        'relevante para responder la consulta. Ejemplo: {"order":[3,0,4,1,2]}.',
+    },
+    {
+      role: 'user',
+      content: `Consulta: "${query}"\n\nFragmentos:\n${lines}\n\nOrden (más relevante primero):`,
+    },
+  ];
+}
+
+/**
+ * Extrae un array de índices válidos (0..k-1) de la respuesta del modelo.
+ * Tolera texto extra alrededor del array, duplicados e índices faltantes:
+ * dedup, descarta fuera de rango, y appendea los índices no mencionados al
+ * final en su orden original (degrada a "no cambié el orden" para lo que el
+ * modelo no supo ubicar, en vez de perder candidatos).
+ */
+export function parseListOrder(text, k) {
+  const str = String(text || '');
+  const bracketMatch = str.match(/\[[^\]]*\]/);
+  const seen = new Set();
+  const order = [];
+
+  if (bracketMatch) {
+    const nums = bracketMatch[0].match(/\d+/g) || [];
+    for (const n of nums) {
+      const idx = parseInt(n, 10);
+      if (idx >= 0 && idx < k && !seen.has(idx)) {
+        seen.add(idx);
+        order.push(idx);
+      }
+    }
+  }
+  // Completar con lo que falte, en orden original (fallback seguro).
+  for (let i = 0; i < k; i++) {
+    if (!seen.has(i)) order.push(i);
+  }
+  return order;
+}
+
+/**
+ * Reordena `candidates` con UN solo llamado listwise.
+ * Devuelve { ranked: [slug...], latencyMs, parseFailure, raw }.
+ */
+export async function rerankListwise(ollamaUrl, model, query, candidates, opts = {}) {
+  const { maxCharsEach = 220, timeoutMs = DEFAULT_TIMEOUT_MS, numCtx } = opts;
+  const k = candidates.length;
+  let order;
+  let ms;
+  let parseFailure = false;
+  let raw = '';
+  try {
+    const result = await ollamaChat(
+      ollamaUrl,
+      model,
+      listwisePrompt(query, candidates, maxCharsEach),
+      {
+        timeoutMs,
+        numPredict: Math.max(32, k * 4),
+        format: LISTWISE_FORMAT,
+        ...(numCtx ? { numCtx } : {}),
+      }
+    );
+    ms = result.ms;
+    raw = result.content;
+    order = parseListOrder(result.content, k);
+    // Si el array venía vacío/sin ningún índice reconocible, es una falla de
+    // parseo aunque parseListOrder igual devuelva el orden original completo.
+    if (!/\[[^\]]*\d/.test(result.content)) parseFailure = true;
+  } catch (err) {
+    ms = err.ms ?? timeoutMs;
+    order = candidates.map((_, i) => i); // fallback: no reordena
+    parseFailure = true;
+  }
+
+  return {
+    ranked: order.map(i => candidates[i].slug),
+    latencyMs: ms,
+    latencyMsTotal: ms,
+    parseFailure,
+    calls: 1,
+    raw,
+  };
+}
+
+/** Despacha al modo pedido. Interfaz uniforme para el bench. */
+export async function rerank(mode, ollamaUrl, model, query, candidates, opts = {}) {
+  if (mode === 'pointwise') return rerankPointwise(ollamaUrl, model, query, candidates, opts);
+  if (mode === 'listwise') return rerankListwise(ollamaUrl, model, query, candidates, opts);
+  throw new Error(`modo de rerank desconocido: ${mode} (usar 'pointwise' o 'listwise')`);
+}


### PR DESCRIPTION
## Resumen

- Reranker LLM-as-judge (`scripts/lib/reranker.mjs`, modos pointwise/listwise) sobre el top-K del retriever — Ollama 0.24 no tiene `/api/rerank` (404) ni `bge-reranker` en su registro (404 en dos variantes), así que se implementó con un modelo chico como juez de relevancia.
- Script de medición (`scripts/bench-reranker.mjs`), mismo golden y metodología que `scripts/bench-embedders.mjs`, corrido **con el agente `gemma4:e2b` cargado** (condición real de producción) bajo `gpu-lock`.
- **De paso**, se encontró y corrigió un bug real en `bench-embedders.mjs`: `rankMetrics()` contaba como "hit" automático de recall@3/@5 cualquier golden item cuyo slug esperado no existe en el corpus (`indexOf` devuelve `-1`, y `-1 <= 2`/`-1 <= 4` son `true` en JS). Afectaba a 15/44 items evaluables del golden (slugs base como `solanum_tuberosum`/`lactuca_sativa` que el catálogo ya solo tiene como variedades) e inflaba recall@3 de ~36% real a ~70% reportado.

## Resultado medido (K=10, n=44, granite-embedding:278m, agente cargado)

| Reranker | recall@1 sin | recall@1 con | Δ | latencia avg | ¿Convive con el agente? |
|---|---|---|---|---|---|
| — (baseline) | 31.8% | — | — | — | — |
| qwen2.5:3b | 31.8% | **36.4%** | **+4.6pp** | 2303ms | Sí |
| llama3.2:3b | 31.8% | 29.5% | -2.3pp | 3239ms | Sí |
| gemma2:2b | — | CRASH | — | — | No — tumba el runner de Ollama |
| phi4-mini | — | CRASH | — | — | No — tumba el runner de Ollama |

Reproducido 3 veces. Modo listwise ganó a pointwise en recall Y en latencia (sub-experimento dedicado, ver doc). El crash de gemma2:2b/phi4-mini se verificó que NO es de configuración: ambos cargan bien en solitario y truenan reproduciblemente solo al co-cargar con el agente (con VRAM de sobra sobre el papel) — incompatibilidad real Maxwell sm_52 + Ollama 0.24, no falta de memoria. El agente sobrevive el crash intacto.

**Veredicto: +4.6pp de recall@1 por +2.3s de latencia por consulta no justifica el costo para una app de voz. No se recomienda shippear este reranker tal como está.** Detalle completo, la corrección de recall@3/@5, y los caminos de seguimiento recomendados (medir sobre la salida real de `retrieveInternal()` post-`collapseVarieties`, no sobre el embedder aislado) están en `docs/RAG.md`.

## Test plan

- [x] `node --check` sobre los 3 archivos modificados/nuevos.
- [x] Smoke tests incrementales antes de la corrida completa (agente sin cargar, luego con agente, luego los 4 candidatos).
- [x] Corrida completa reproducida 3 veces bajo `gpu-lock` en alpha con el agente `gemma4:e2b` cargado.
- [x] Verificado empíricamente (no asumido) que Ollama 0.24 no tiene `/api/rerank` y que el crash de gemma2:2b/phi4-mini no es de configuración (aislado vía curl directo, sin el script de por medio).
- [x] Scan anti-leak (`git diff --staged | grep -iE "token|bearer|password|secret|10\.88"`) sin hits reales.
- [ ] CI (CodeQL + Playwright) — pendiente de correr en el PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)