### PR TITLE
refactor(onboarding): consolidar flujo de primera vez

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -355,7 +355,6 @@ const CaprinosScreen = lazy(() => import('./components/CaprinosScreen'));
 const EstiercolScreen = lazy(() => import('./components/EstiercolScreen'));
 const CompostScreen = lazy(() => import('./components/CompostScreen'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
-const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const OnboardingCondensado = lazy(() => import('./components/OnboardingCondensado'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
@@ -2629,13 +2628,12 @@ export default function App() {
           </ErrorBoundary>
         );
       case 'onboarding-perfil-clasico':
-        // #200: el onboarding extendido ORIGINAL (hasta 25 preguntas
-        // condicionales). Se conserva cableado (features no huérfanas) como
-        // camino largo/diagnóstico mientras el operador valida el condensado.
+        // Alias de compatibilidad para enlaces guardados antes de consolidar
+        // el onboarding. Ambos paths montan el unico flujo vigente.
         return (
           <ErrorBoundary>
-            <OnboardingProfile
-              onComplete={() => navigate('ubicacion-detectada', { next: 'dashboard' })}
+            <OnboardingCondensado
+              onComplete={() => navigate('dashboard')}
               onClose={() => navigate(currentViewData?.back || 'dashboard')}
               onExplorarEjemplo={async () => {
                 try {

--- a/src/components/FarmOSSetupModal.jsx
+++ b/src/components/FarmOSSetupModal.jsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { ArrowRight, ChevronDown, ExternalLink, Server, X } from 'lucide-react';
+
+/** Configuración específica de FarmOS para una finca de la red. */
+export default function FarmOSSetupModal({ finca, onClose, onConfigureLater }) {
+  const [showTech, setShowTech] = useState(false);
+  if (!finca) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+      <div
+        className="relative w-full max-w-md bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl overflow-hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="farmos-setup-title"
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute top-3 right-3 p-1.5 rounded-lg bg-slate-800 text-slate-400 hover:text-white hover:bg-slate-700 transition-colors"
+          aria-label="Cerrar"
+        >
+          <X size={18} />
+        </button>
+
+        <div className="p-6 space-y-5">
+          <div className="text-center space-y-2">
+            <div className="w-14 h-14 mx-auto bg-amber-900/30 rounded-full flex items-center justify-center">
+              <Server size={28} className="text-amber-400" />
+            </div>
+            <h2 id="farmos-setup-title" className="text-xl font-bold text-white">
+              Configurar FarmOS
+            </h2>
+            <p className="text-sm text-slate-400">
+              Para usar <span className="text-white font-medium">{finca.nombre}</span> con Chagra,
+              necesita conectar su servidor FarmOS.
+            </p>
+          </div>
+
+          <div className="bg-slate-800/50 rounded-xl p-4 space-y-3">
+            <p className="text-xs text-slate-400 leading-relaxed">
+              Chagra se conecta a un servidor FarmOS para guardar los datos de su finca.
+              Si usted no administra el servidor, pídale a su técnico de confianza que lo configure.
+            </p>
+            <button
+              type="button"
+              onClick={() => setShowTech((visible) => !visible)}
+              className="inline-flex items-center gap-1 text-xs text-slate-500 hover:text-slate-300 transition-colors"
+            >
+              <ChevronDown size={14} className={`transition-transform ${showTech ? 'rotate-180' : ''}`} />
+              {showTech ? 'Ocultar opciones técnicas' : 'Ver opciones técnicas'}
+            </button>
+            {showTech ? (
+              <ul className="text-xs text-slate-400 space-y-2">
+                <li>1. Instale FarmOS en un servidor local o VPS.</li>
+                <li>2. Use el servicio Hosted FarmOS.</li>
+                <li>3. Configure el endpoint en los ajustes de Chagra.</li>
+              </ul>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <a
+              href="https://farmos.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center gap-2 py-2.5 bg-emerald-600 text-white rounded-lg font-bold hover:bg-emerald-500 active:scale-95 transition-all"
+            >
+              <ExternalLink size={16} /> Visitar FarmOS.org <ArrowRight size={16} />
+            </a>
+            <button
+              type="button"
+              onClick={onConfigureLater}
+              className="w-full py-2 text-sm text-slate-400 hover:text-white transition-colors"
+            >
+              Configurar más tarde
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MultiFincaModal.jsx
+++ b/src/components/MultiFincaModal.jsx
@@ -1,8 +1,10 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- deuda i18n preexistente;
+   esta consolidacion solo renombra el modal tecnico que consume. */
 import React, { useState, useEffect } from 'react';
 import { X, Globe, LayoutGrid, Info } from 'lucide-react';
 import MultiFincaGlobe from './MultiFincaGlobe';
 import { FincaGrid } from './FincaCard';
-import OnboardingModal from './OnboardingModal';
+import FarmOSSetupModal from './FarmOSSetupModal';
 import { useFincaActiveStore } from '../services/fincaActiveStore';
 
 export default function MultiFincaModal({ onClose }) {
@@ -131,7 +133,7 @@ export default function MultiFincaModal({ onClose }) {
             </div>
 
             {showOnboarding && selectedFinca && (
-                <OnboardingModal
+                <FarmOSSetupModal
                     finca={selectedFinca}
                     onClose={() => setShowOnboarding(false)}
                     onConfigureLater={() => setShowOnboarding(false)}

--- a/src/components/OnboardingCondensado.jsx
+++ b/src/components/OnboardingCondensado.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- el flujo conserva copy
+   colombiano preexistente; su migracion a messages.js queda fuera de scope. */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   MapPin,
@@ -12,6 +14,11 @@ import {
   Search,
   AlertCircle,
   SkipForward,
+  BadgeCheck,
+  Camera,
+  Download,
+  Mic,
+  Share,
 } from 'lucide-react';
 import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
 import AvatarSelector from './Settings/AvatarSelector';
@@ -36,6 +43,7 @@ import {
   resolveAltitudToSave,
 } from '../services/userProfileService';
 import usePerfilFincaStore from '../store/usePerfilFincaStore';
+import usePwaInstall from '../hooks/usePwaInstall';
 
 /**
  * OnboardingCondensado — la reescritura del onboarding (spec 2026-07-08).
@@ -55,8 +63,8 @@ import usePerfilFincaStore from '../store/usePerfilFincaStore';
  *
  * Todo lo demás (hectáreas, invernadero, manejo, riego, preferencias...) se
  * DIFIERE a la voz / progressive profiling / ProfileScreen — ver el flag
- * `deferred` en PROFILE_QUESTIONS. El flujo viejo (OnboardingProfile) queda
- * cableado en la ruta 'onboarding-perfil-clasico' (sin huérfanos).
+ * `deferred` en PROFILE_QUESTIONS. La ruta histórica
+ * 'onboarding-perfil-clasico' queda como alias de este mismo flujo.
  *
  * Persistencia: MISMAS claves de perfil que el flujo viejo + las nuevas de
  * vereda (vereda_codigo / vereda_source geométrico / barrio). 100% client-side
@@ -352,6 +360,7 @@ export default function OnboardingCondensado({
 }) {
   const [paso, setPaso] = useState(0);
   const [sembrando, setSembrando] = useState(false);
+  const { canInstall, installed, isIos, promptInstall } = usePwaInstall();
   // Marca de inicio para onboarding_tiempo_segundos (regla react: nada impuro
   // en render — se fija una sola vez al montar).
   const startedAtRef = useRef(null);
@@ -1158,8 +1167,8 @@ export default function OnboardingCondensado({
 
         {/* ═══ LISTO ═══ */}
         {paso === 6 && (
-          <div className="flex-1 flex flex-col items-center justify-center text-center gap-5">
-            <ChagraAgentAvatarAngelita size={168} state="speaking" ariaLabel="Angelita, la abeja de Chagra" />
+          <div className="flex-1 flex flex-col items-center justify-center text-center gap-4">
+            <ChagraAgentAvatarAngelita size={140} state="speaking" ariaLabel="Angelita, la abeja de Chagra" />
             <div className="flex flex-col gap-2">
               <h1 className="text-3xl font-black leading-tight text-slate-100">
                 Su finca está lista 🌱
@@ -1172,6 +1181,45 @@ export default function OnboardingCondensado({
                 Ahora háblele al colibrí: «Hola Chagra, ¿cuándo abono el café?»
               </p>
             </div>
+            <div
+              className="grid w-full grid-cols-3 gap-2"
+              aria-label="Capacidades principales de Chagra"
+              data-testid="onb2-capacidades"
+            >
+              {[
+                { Icon: Mic, label: 'Hablar por voz' },
+                { Icon: Camera, label: 'Mostrar una foto' },
+                { Icon: BadgeCheck, label: 'Revisar fuentes' },
+              ].map(({ Icon, label }) => (
+                <div key={label} className="rounded-xl border border-slate-700 bg-slate-900 p-2 text-xs text-slate-300">
+                  {React.createElement(Icon, {
+                    size: 20,
+                    className: 'mx-auto mb-1 text-emerald-300',
+                    'aria-hidden': true,
+                  })}
+                  {label}
+                </div>
+              ))}
+            </div>
+            {installed ? (
+              <p className="text-sm font-bold text-emerald-300" data-testid="onb2-pwa-instalada">
+                Chagra ya está instalada en este equipo.
+              </p>
+            ) : canInstall ? (
+              <button
+                type="button"
+                onClick={promptInstall}
+                className="onboarding-piso-secondary inline-flex items-center justify-center gap-2"
+                data-testid="onb2-instalar-pwa"
+              >
+                <Download size={18} aria-hidden="true" /> Instalar Chagra
+              </button>
+            ) : isIos ? (
+              <p className="text-xs text-slate-400" data-testid="onb2-instalar-ios">
+                Para instalarla, toque <Share size={14} className="inline" aria-hidden="true" /> Compartir y luego
+                Añadir a pantalla de inicio.
+              </p>
+            ) : null}
           </div>
         )}
 

--- a/src/components/PrimerRegistroCard.jsx
+++ b/src/components/PrimerRegistroCard.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { Camera, MapPin, Mic, Pencil } from 'lucide-react';
+import useAssetStore from '../store/useAssetStore';
+import { getContextoGeoFinca } from '../services/perfilFincaService';
+import { useAutosave } from '../hooks/useAutosave';
+import { MSG } from '../config/messages.js';
+
+/**
+ * Estado vacío del dashboard para orientar el primer registro.
+ *
+ * La configuración inicial pertenece exclusivamente a OnboardingCondensado.
+ * Este componente conserva las tres entradas operativas para registrar una
+ * planta que antes estaban mezcladas dentro de OnboardingHero.
+ */
+export default function PrimerRegistroCard({ onNavigate, compact = false }) {
+  const lands = useAssetStore((state) => state.lands);
+  const geoFinca = getContextoGeoFinca();
+  const { save } = useAutosave('primer-registro', { lastCta: null });
+
+  const navegar = (route) => {
+    save({ lastCta: route });
+    onNavigate(route);
+  };
+
+  if (compact) {
+    return (
+      <section
+        aria-label="Configure su finca"
+        className="onboarding-piso-card onboarding-piso-card-compact"
+        data-testid="primer-registro-configurar"
+      >
+        <div className="flex items-start gap-3">
+          <MapPin size={28} className="shrink-0 text-emerald-300" aria-hidden="true" />
+          <div>
+            <p className="onboarding-piso-title">Primero, cuéntenos de su finca</p>
+            <p className="onboarding-piso-copy">
+              En un solo recorrido guardamos su ubicación, escala, invernadero y agua.
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => navegar('onboarding-perfil')}
+          className="onboarding-piso-primary"
+        >
+          <MapPin size={22} aria-hidden="true" /> Configurar mi finca
+        </button>
+      </section>
+    );
+  }
+
+  const hasZones = lands.length > 0;
+  const hasFarmContext = Boolean(
+    geoFinca.altitudMsnm || geoFinca.thermalZones.length > 0,
+  );
+  const title = hasZones
+    ? MSG.onboarding.zonasListas(lands.length)
+    : hasFarmContext
+      ? MSG.onboarding.fincaConfigurada
+      : MSG.onboarding.primeraPlanta;
+  const subtitle = hasFarmContext && !hasZones
+    ? MSG.onboarding.tipZonas
+    : MSG.onboarding.elegirRegistro;
+  const actions = [
+    {
+      id: 'plant_asset',
+      Icon: Camera,
+      label: 'Foto',
+      description: 'Tomar foto de una planta',
+      className: 'border-purple-500 active:bg-purple-900/30 text-purple-300',
+    },
+    {
+      id: 'voz',
+      Icon: Mic,
+      label: 'Voz',
+      description: 'Dictar registro',
+      className: 'border-lime-500 active:bg-lime-900/30 text-lime-300',
+    },
+    {
+      id: 'sembrar',
+      Icon: Pencil,
+      label: 'Escribir',
+      description: 'Formulario manual',
+      className: 'border-emerald-500 active:bg-emerald-900/30 text-emerald-300',
+    },
+  ];
+
+  return (
+    <section
+      aria-label="Comenzar a registrar plantas"
+      className="w-full bg-slate-900/50 border border-slate-800 rounded-xl p-5 flex flex-col gap-4"
+      data-testid="primer-registro-card"
+    >
+      <div className="flex flex-col gap-1">
+        <h2 className="text-2xl font-black text-white">{title}</h2>
+        <p className="text-sm text-slate-400">{subtitle}</p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {actions.map(({ id, Icon, label, description, className }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => navegar(id)}
+            className={`flex flex-col items-center justify-center gap-2 p-6 rounded-xl bg-slate-950 border-2 ${className} min-h-[140px] transition-colors`}
+          >
+            {React.createElement(Icon, { size: 34, 'aria-hidden': true })}
+            <span className="text-2xl font-black">{label}</span>
+            <span className="text-xs text-slate-400">{description}</span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/__tests__/BienvenidaFinca.test.jsx
+++ b/src/components/__tests__/BienvenidaFinca.test.jsx
@@ -27,7 +27,7 @@ vi.mock('../../services/ttsService', () => ({
 import BienvenidaFinca, {
   bienvenidaYaVista,
   marcarBienvenidaVista,
-} from '../BienvenidaFinca';
+} from '../_archivo/BienvenidaFinca';
 import { MSG } from '../../config/messages.js';
 
 beforeEach(() => {

--- a/src/components/__tests__/FarmOSSetupModal.test.jsx
+++ b/src/components/__tests__/FarmOSSetupModal.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import FarmOSSetupModal from '../FarmOSSetupModal';
+
+describe('FarmOSSetupModal', () => {
+  it('conserva la ayuda de conexion fuera del onboarding de perfil', () => {
+    const onConfigureLater = vi.fn();
+    render(
+      <FarmOSSetupModal
+        finca={{ nombre: 'La Ceiba' }}
+        onClose={vi.fn()}
+        onConfigureLater={onConfigureLater}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Configurar FarmOS' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Ver opciones técnicas/i }));
+    expect(screen.getByText(/Configure el endpoint/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Configurar más tarde/i }));
+    expect(onConfigureLater).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/__tests__/MultiFincaModal.test.jsx
+++ b/src/components/__tests__/MultiFincaModal.test.jsx
@@ -30,7 +30,7 @@ vi.mock('../MultiFincaGlobe', () => ({
   default: () => <div data-testid="multifinca-globe-stub" />,
 }));
 
-vi.mock('../OnboardingModal', () => ({
+vi.mock('../FarmOSSetupModal', () => ({
   default: ({ finca, onClose }) => (
     <div data-testid="onboarding-modal-stub">
       <span>{finca?.nombre}</span>

--- a/src/components/__tests__/OnboardingCondensado.capacidades.test.jsx
+++ b/src/components/__tests__/OnboardingCondensado.capacidades.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import OnboardingCondensado from '../OnboardingCondensado';
+
+const promptInstall = vi.fn();
+
+vi.mock('../../hooks/usePwaInstall', () => ({
+  default: () => ({
+    canInstall: true,
+    installed: false,
+    isIos: false,
+    promptInstall,
+  }),
+}));
+
+vi.mock('../ChagraAgentAvatarAngelita', () => ({
+  default: () => <div data-testid="angelita-stub" />,
+}));
+
+describe('OnboardingCondensado, capacidades consolidadas', () => {
+  beforeEach(() => {
+    promptInstall.mockClear();
+    window.localStorage.clear();
+  });
+
+  it('conserva capacidades e instalación PWA en el paso final', () => {
+    render(<OnboardingCondensado onComplete={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId('onb2-siguiente'));
+    fireEvent.click(screen.getByTestId('onb2-ubicacion-despues'));
+    fireEvent.click(screen.getByTestId('onb2-terminar-finca'));
+    fireEvent.click(screen.getByRole('button', { name: /Una finca o cultivo abierto/i }));
+    fireEvent.click(screen.getByTestId('onb2-guardar-escala'));
+    fireEvent.click(screen.getByTestId('onb2-invernadero-no'));
+    fireEvent.click(screen.getByTestId('onb2-guardar-invernadero'));
+    fireEvent.click(screen.getByRole('button', { name: /Lluvia/i }));
+    fireEvent.click(screen.getByTestId('onb2-guardar-agua'));
+
+    expect(screen.getByTestId('onb2-capacidades').textContent).toContain('Hablar por voz');
+    expect(screen.getByTestId('onb2-capacidades').textContent).toContain('Mostrar una foto');
+    expect(screen.getByTestId('onb2-capacidades').textContent).toContain('Revisar fuentes');
+
+    fireEvent.click(screen.getByTestId('onb2-instalar-pwa'));
+    expect(promptInstall).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/__tests__/OnboardingHero.piso.test.jsx
+++ b/src/components/__tests__/OnboardingHero.piso.test.jsx
@@ -23,7 +23,7 @@ vi.mock('../../config/defaults', () => ({
   FARM_CONFIG: {},
 }));
 
-import OnboardingHero from '../OnboardingHero';
+import OnboardingHero from '../_archivo/OnboardingHero';
 import { saveProfile, getProfile } from '../../services/userProfileService';
 
 beforeEach(() => {

--- a/src/components/__tests__/OnboardingHero.validation.test.jsx
+++ b/src/components/__tests__/OnboardingHero.validation.test.jsx
@@ -16,7 +16,7 @@ vi.mock('../../config/defaults', () => ({
   FARM_CONFIG: {},
 }));
 
-import OnboardingHero from '../OnboardingHero';
+import OnboardingHero from '../_archivo/OnboardingHero';
 
 beforeEach(() => {
   window.localStorage.clear();

--- a/src/components/__tests__/OnboardingProfile.explorarEjemplo.test.jsx
+++ b/src/components/__tests__/OnboardingProfile.explorarEjemplo.test.jsx
@@ -11,7 +11,7 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
-import OnboardingProfile from '../OnboardingProfile';
+import OnboardingProfile from '../_archivo/OnboardingProfile';
 
 beforeEach(() => {
   window.localStorage.clear();

--- a/src/components/__tests__/OnboardingProfile.piso.test.jsx
+++ b/src/components/__tests__/OnboardingProfile.piso.test.jsx
@@ -12,7 +12,7 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
-import OnboardingProfile from '../OnboardingProfile';
+import OnboardingProfile from '../_archivo/OnboardingProfile';
 import { saveProfile, getProfile } from '../../services/userProfileService';
 
 beforeEach(() => {

--- a/src/components/__tests__/PrimerRegistroCard.test.jsx
+++ b/src/components/__tests__/PrimerRegistroCard.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PrimerRegistroCard from '../PrimerRegistroCard';
+
+const save = vi.fn();
+
+vi.mock('../../store/useAssetStore', () => ({
+  default: (selector) => selector({ lands: [] }),
+}));
+
+vi.mock('../../services/perfilFincaService', () => ({
+  getContextoGeoFinca: () => ({ altitudMsnm: null, thermalZones: [] }),
+}));
+
+vi.mock('../../hooks/useAutosave', () => ({
+  useAutosave: () => ({ save }),
+}));
+
+describe('PrimerRegistroCard', () => {
+  beforeEach(() => save.mockClear());
+
+  it('envia la configuracion inicial al unico onboarding vigente', () => {
+    const onNavigate = vi.fn();
+    render(<PrimerRegistroCard onNavigate={onNavigate} compact />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Configurar mi finca/i }));
+
+    expect(onNavigate).toHaveBeenCalledWith('onboarding-perfil');
+    expect(save).toHaveBeenCalledWith({ lastCta: 'onboarding-perfil' });
+  });
+
+  it.each([
+    ['Foto', 'plant_asset'],
+    ['Voz', 'voz'],
+    ['Escribir', 'sembrar'],
+  ])('conserva la entrada de registro por %s', (label, route) => {
+    const onNavigate = vi.fn();
+    render(<PrimerRegistroCard onNavigate={onNavigate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(label, 'i') }));
+
+    expect(onNavigate).toHaveBeenCalledWith(route);
+  });
+});

--- a/src/components/_archivo/BienvenidaFinca.jsx
+++ b/src/components/_archivo/BienvenidaFinca.jsx
@@ -1,11 +1,15 @@
+/**
+ * Archivado en 2026-07-22 porque duplicaba la entrada de primer uso.
+ * OnboardingCondensado lo reemplaza e incorpora sus capacidades utiles.
+ */
 /* eslint-disable react-refresh/only-export-components -- bienvenidaYaVista/
    marcarBienvenidaVista son los helpers de gating "una sola vez" y deben
    exportarse junto al componente (mismo patrón que NotifPermissionPrompt). */
 import React, { useEffect, useRef, useState } from 'react';
 import { Mic, Camera, BadgeCheck, MapPin, ArrowRight, Volume2, Sparkles, Glasses, Share, Download, WifiOff, Save, Smartphone, Check } from 'lucide-react';
-import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
-import usePwaInstall from '../hooks/usePwaInstall';
-import { MSG } from '../config/messages.js';
+import ChagraAgentAvatarAngelita from '../ChagraAgentAvatarAngelita';
+import usePwaInstall from '../../hooks/usePwaInstall';
+import { MSG } from '../../config/messages.js';
 
 /**
  * BienvenidaFinca — la PRIMERA impresión de Chagra (primera vez, una sola vez).
@@ -134,7 +138,7 @@ export function marcarBienvenidaVista() {
 /** Lee el momento en voz alta. Import perezoso del ttsService (no pesa en el
  * bundle del dashboard) y fail-silent: sin red/voz no rompe nada. */
 function escucharTexto(texto) {
-  import('../services/ttsService')
+  import('../../services/ttsService')
     .then((m) => m.speakSentences(texto).catch(() => {}))
     .catch(() => {});
 }

--- a/src/components/_archivo/OnboardingHero.jsx
+++ b/src/components/_archivo/OnboardingHero.jsx
@@ -1,11 +1,15 @@
+/**
+ * Archivado en 2026-07-22 porque mezclaba configuracion y primer registro.
+ * OnboardingCondensado lo reemplaza; PrimerRegistroCard conserva sus tres CTA.
+ */
 import React, { useState } from 'react';
 import { Camera, Mic, Pencil, MapPin, Check } from 'lucide-react';
-import useAssetStore from '../store/useAssetStore';
-import { getContextoGeoFinca } from '../services/perfilFincaService';
-import { getProfile, saveProfile } from '../services/userProfileService';
-import { getPisoTermicoInfo } from '../services/locationService';
-import { useAutosave } from '../hooks/useAutosave';
-import { MSG } from '../config/messages.js';
+import useAssetStore from '../../store/useAssetStore';
+import { getContextoGeoFinca } from '../../services/perfilFincaService';
+import { getProfile, saveProfile } from '../../services/userProfileService';
+import { getPisoTermicoInfo } from '../../services/locationService';
+import { useAutosave } from '../../hooks/useAutosave';
+import { MSG } from '../../config/messages.js';
 
 /**
  * OnboardingHero, empty-state cold-start del dashboard (DR-030 QW5).

--- a/src/components/_archivo/OnboardingModal.jsx
+++ b/src/components/_archivo/OnboardingModal.jsx
@@ -1,3 +1,7 @@
+/**
+ * Archivado en 2026-07-22 porque no es un onboarding de perfil.
+ * FarmOSSetupModal conserva la configuracion tecnica que contenia.
+ */
 import React, { useState } from 'react';
 import { X, ExternalLink, Server, ArrowRight, ChevronDown } from 'lucide-react';
 

--- a/src/components/_archivo/OnboardingProfile.jsx
+++ b/src/components/_archivo/OnboardingProfile.jsx
@@ -1,3 +1,8 @@
+/**
+ * Archivado en 2026-07-22 porque el flujo extendido quedo reemplazado por
+ * OnboardingCondensado. Las preguntas diferidas siguen disponibles en Perfil.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- archivo historico sin uso. */
 import React, { useMemo, useState } from 'react';
 import {
   Sprout,
@@ -14,8 +19,8 @@ import {
   saveProfile,
   markProfileDone,
   markProfileSkipped,
-} from '../services/userProfileService';
-import { PISO_TERMICO_INFO } from '../services/locationService';
+} from '../../services/userProfileService';
+import { PISO_TERMICO_INFO } from '../../services/locationService';
 
 /**
  * OnboardingProfile — flujo de onboarding extendido (#200).
@@ -141,7 +146,7 @@ export default function OnboardingProfile({
   const explorarEjemploFallback = onNavigate
     ? async () => {
       try {
-        const { seedExampleFinca } = await import('../services/demoFincaEjemplo');
+        const { seedExampleFinca } = await import('../../services/demoFincaEjemplo');
         await seedExampleFinca();
       } catch (err) {
         console.error('[OnboardingProfile] No se pudo sembrar la finca de ejemplo:', err);

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -28,8 +28,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical, Snowflake, ChevronRight, Layers, TestTube, ShieldAlert, BookOpen, ClipboardList, Recycle, FlaskConical, Wheat, Droplets, Wrench, Eye, CalendarDays, Sprout, HelpCircle, Store, Mic, CloudRain, Leaf, Gauge, Stethoscope } from 'lucide-react';
 import AgentHero from './AgentHero';
-import OnboardingHero from '../OnboardingHero';
-import BienvenidaFinca, { bienvenidaYaVista } from '../BienvenidaFinca';
+import PrimerRegistroCard from '../PrimerRegistroCard';
 import {
     getProfile,
     getModuleVisibility,
@@ -397,13 +396,8 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
         }
     });
     const iotAlerts = useAssetStore((s) => s.iotAlerts) || [];
-    // Primer uso (feat/onboarding-ayuda): sin plantas registradas se re-monta
-    // el OnboardingHero existente (quedó huérfano del DashboardView legacy al
-    // pasar a DashboardLive 2026-05-28). Trae el Paso 1 "piso térmico" —
-    // filtro maestro de todos los módulos — + las 3 rutas de registro.
-    // Si falta capturar/confirmar el piso, el Paso 1 se muestra como banner
-    // compacto flotando SOBRE el AgentHero (overlay, no empuja el hero — ver
-    // el bloque de render); ya confirmado, las 3 rutas bajan al flujo normal.
+    // Primer uso: OnboardingCondensado concentra la configuracion. Cuando ya
+    // existe perfil, PrimerRegistroCard conserva las tres rutas operativas.
     const plantsCount = useAssetStore((s) => s.plants.length);
     const [needsPisoCapture] = useState(() => {
         const p = getProfile();
@@ -411,16 +405,6 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
         const hasAltitud = p.finca_altitud !== '' && p.finca_altitud != null && Number.isFinite(alt);
         return !hasAltitud || p.piso_confirmado !== '1';
     });
-    // Bienvenida de PRIMERA VEZ (BienvenidaFinca): recorrido de 5 momentos
-    // (colibrí + capacidades estrella + "hola Chagra" manos-libres +
-    // instalar la app + ubicación mágica) que se muestra UNA
-    // sola vez, con la MISMA señal de primer uso del banner compacto (sin
-    // plantas y sin piso) + flag persistente "ya la vi". Capa 100% visual:
-    // "Ubicar mi finca" delega en la ruta existente 'ubicacion-detectada';
-    // al saltar queda el flujo de siempre (banner del piso térmico).
-    const [showBienvenida, setShowBienvenida] = useState(
-        () => plantsCount === 0 && needsPisoCapture && !bienvenidaYaVista(),
-    );
 
     // HOME "Finca Viva" por perfil (flag VITE_FINCA_VIVA_HOME_PERFIL). Se evalúa
     // una vez al montar. Con la flag ON: (1) la escena de la finca se muestra
@@ -671,33 +655,6 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
             className="relative flex flex-col w-full h-full overflow-y-auto pb-6"
             data-scroll-key="dashboard-live"
         >
-            {/* BIENVENIDA de primera vez — overlay a pantalla completa SOBRE
-                cualquiera de las dos portadas (AgentHero / Finca Viva). Solo
-                se monta en el verdadero primer uso y una sola vez (flag en
-                localStorage dentro del componente). */}
-            {showBienvenida && (
-                <BienvenidaFinca
-                    onUbicar={() => {
-                        setShowBienvenida(false);
-                        onNavigate('ubicacion-detectada');
-                    }}
-                    onClose={() => setShowBienvenida(false)}
-                    onExplorarEjemplo={async () => {
-                        // SKIP rico: sembrar la finca de ejemplo (multi-piso,
-                        // grounded al catálogo) y quedarse en el home, que la
-                        // renderiza POBLADA sin recargar (seedExampleFinca
-                        // re-hidrata el asset store). Import perezoso: no pesa en
-                        // el bundle del dashboard salvo que se use.
-                        try {
-                            const { seedExampleFinca } = await import('../../services/demoFincaEjemplo');
-                            await seedExampleFinca();
-                        } catch (err) {
-                            console.error('[DashboardLive] No se pudo sembrar la finca de ejemplo:', err);
-                        }
-                        setShowBienvenida(false);
-                    }}
-                />
-            )}
             {/* PORTADA del home — depende de la flag VITE_FINCA_VIVA_HOME_PERFIL:
                 ─────────────────────────────────────────────────────────────────
                 · Flag ON  → la ESCENA ISOMÉTRICA "Finca Viva" (mockup F2) es el
@@ -746,7 +703,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
                             data-testid="dashboard-onboarding-top"
                         >
                             <div className="pointer-events-auto mx-auto w-full max-w-[26rem]">
-                                <OnboardingHero onNavigate={onNavigate} compact />
+                                <PrimerRegistroCard onNavigate={onNavigate} compact />
                             </div>
                         </div>
                     )}
@@ -1078,7 +1035,7 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null, onL
             {/* Primer uso con piso ya confirmado: las 3 rutas de registro. */}
             {plantsCount === 0 && !needsPisoCapture && (
                 <div className="px-4 pt-3">
-                    <OnboardingHero onNavigate={onNavigate} />
+                    <PrimerRegistroCard onNavigate={onNavigate} />
                 </div>
             )}
 

--- a/src/components/dashboard/__tests__/DashboardLive.asociaciones.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.asociaciones.test.jsx
@@ -9,7 +9,7 @@ vi.mock('../../../config/glaciarAccess', () => ({
 }));
 
 vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
-vi.mock('../../OnboardingHero', () => ({ default: () => <div /> }));
+vi.mock('../../PrimerRegistroCard', () => ({ default: () => <div /> }));
 vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
 vi.mock('../ClimaStrip', () => ({ default: () => <div /> }));
 vi.mock('../HoyEnFincaStrip', () => ({ default: () => <div /> }));

--- a/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.extensionistaMundos.test.jsx
@@ -49,7 +49,7 @@ vi.mock('../FincaRedInstitucional', () => ({
 }));
 
 vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
-vi.mock('../../OnboardingHero', () => ({ default: () => <div /> }));
+vi.mock('../../PrimerRegistroCard', () => ({ default: () => <div /> }));
 vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
 vi.mock('../MiFincaVivaHomeCard', () => ({ default: () => <div /> }));
 vi.mock('../../CaseStudyTopWidget', () => ({ default: () => null }));

--- a/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
@@ -28,7 +28,7 @@ vi.mock('../../../config/glaciarAccess', () => ({
 
 // Hijos pesados → stubs livianos.
 vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
-vi.mock('../../OnboardingHero', () => ({ default: () => <div data-testid="onboarding-hero" /> }));
+vi.mock('../../PrimerRegistroCard', () => ({ default: () => <div data-testid="primer-registro-card" /> }));
 vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
 vi.mock('../ClimaStrip', () => ({ default: () => <div /> }));
 vi.mock('../HoyEnFincaStrip', () => ({ default: () => <div /> }));
@@ -47,6 +47,8 @@ vi.mock('../../../services/userProfileService', () => ({
   isModuleVisible: vi.fn(() => true),
   getModuleVisibility: vi.fn(() => ({})),
   hasManualModuleVisibility: vi.fn(() => false),
+  getGuardianEspecie: vi.fn(() => null),
+  setGuardianEspecie: vi.fn(),
   // Orden de módulos del home (reorder por drag, 2026-06-15). Para este test el
   // orden por defecto basta; setModuleOrder es no-op.
   HOME_MODULE_DEFAULT_ORDER: [
@@ -60,7 +62,7 @@ vi.mock('../../../services/userProfileService', () => ({
   setModuleOrder: vi.fn(),
 }));
 
-// Store de assets: plantsCount > 0 para que NO se monte el OnboardingHero de
+// Store de assets: plantsCount > 0 para que NO se monte el primer registro de
 // "primer uso" (no relevante a este test) y mantener el árbol pequeño.
 vi.mock('../../../store/useAssetStore', () => ({
   default: (selector) => selector({ plants: [{ id: 'p1' }], needsPisoCapture: false }),

--- a/src/components/dashboard/__tests__/DashboardLive.homeGating.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.homeGating.test.jsx
@@ -30,14 +30,14 @@ vi.mock('../../../config/glaciarAccess', () => ({
 // Hijos pesados → stubs livianos. NO mockeamos FincaCards (queremos las
 // tarjetas de seguimiento reales para ver "Cerdos").
 vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
-vi.mock('../../OnboardingHero', () => ({ default: () => <div data-testid="onboarding-hero" /> }));
+vi.mock('../../PrimerRegistroCard', () => ({ default: () => <div data-testid="primer-registro-card" /> }));
 vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
 vi.mock('../ClimaStrip', () => ({ default: () => <div /> }));
 vi.mock('../HoyEnFincaStrip', () => ({ default: () => <div /> }));
 vi.mock('../AIStatusFooter', () => ({ default: () => <div /> }));
 vi.mock('../AnalisisProactivoIA', () => ({ default: () => <div /> }));
 
-// Store de assets: plantsCount > 0 para no montar el OnboardingHero de primer uso.
+// Store de assets: plantsCount > 0 para no montar el primer registro.
 vi.mock('../../../store/useAssetStore', () => ({
   default: (selector) => selector({ plants: [{ id: 'p1' }], lands: [], materials: [], isHydrated: true, iotAlerts: [] }),
 }));

--- a/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.redistribucion.test.jsx
@@ -42,7 +42,7 @@ vi.mock('../FincaVivaHero', () => ({
   },
 }));
 vi.mock('../FincaRedInstitucional', () => ({ default: () => <div /> }));
-vi.mock('../../OnboardingHero', () => ({ default: () => <div /> }));
+vi.mock('../../PrimerRegistroCard', () => ({ default: () => <div /> }));
 vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
 vi.mock('../MiFincaVivaHomeCard', () => ({ default: () => <div /> }));
 vi.mock('../../CaseStudyTopWidget', () => ({ default: () => null }));

--- a/src/components/dashboard/__tests__/DashboardLive.registroUnificado.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.registroUnificado.test.jsx
@@ -32,7 +32,7 @@ vi.mock('../FincaVivaHero', () => ({
   default: (props) => <div data-testid="finca-viva-hero">{props.children}</div>,
 }));
 vi.mock('../FincaRedInstitucional', () => ({ default: () => <div /> }));
-vi.mock('../../OnboardingHero', () => ({ default: () => <div /> }));
+vi.mock('../../PrimerRegistroCard', () => ({ default: () => <div /> }));
 vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
 vi.mock('../MiFincaVivaHomeCard', () => ({ default: () => <div /> }));
 vi.mock('../../CaseStudyTopWidget', () => ({ default: () => null }));

--- a/src/config/__tests__/onboardingRoutes.test.js
+++ b/src/config/__tests__/onboardingRoutes.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { NUCLEO_APP, PENDIENTE_DECISION } from '../rutasProdChagraApp';
+
+describe('rutas de onboarding', () => {
+  it('resuelve los paths vigente y clasico al flujo condensado', () => {
+    const onboardingRoutes = NUCLEO_APP.filter(({ path }) => path.startsWith('onboarding-perfil'));
+
+    expect(onboardingRoutes).toEqual([
+      expect.objectContaining({ path: 'onboarding-perfil', componente: 'OnboardingCondensado' }),
+      expect.objectContaining({ path: 'onboarding-perfil-clasico', componente: 'OnboardingCondensado' }),
+    ]);
+    expect(PENDIENTE_DECISION).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: 'onboarding-perfil-clasico' })]),
+    );
+  });
+});

--- a/src/config/rutasProdChagraApp.js
+++ b/src/config/rutasProdChagraApp.js
@@ -439,8 +439,14 @@ export const NUCLEO_APP = [
   // ── Onboarding ──────────────────────────────────────────────────
   {
     path: 'onboarding-perfil',
-    componente: 'OnboardingProfile',
-    importLazy: 'src/components/OnboardingProfile.jsx',
+    componente: 'OnboardingCondensado',
+    importLazy: 'src/components/OnboardingCondensado.jsx',
+    categoria: '2D-app',
+  },
+  {
+    path: 'onboarding-perfil-clasico',
+    componente: 'OnboardingCondensado',
+    importLazy: 'src/components/OnboardingCondensado.jsx',
     categoria: '2D-app',
   },
 
@@ -1152,7 +1158,7 @@ export const EXCLUIDO = [
   },
   {
     path: 'mockup_primer_cultivo',
-    motivo: 'Onboarding viejo. Reemplazado por OnboardingProfile/OnboardingCondensado.',
+    motivo: 'Onboarding viejo. Reemplazado por OnboardingCondensado.',
   },
   {
     path: 'mockup_guardianes',
@@ -1207,18 +1213,11 @@ export const EXCLUIDO = [
 export const PENDIENTE_DECISION = [
   // ── Onboarding: ¿Profile o Siembra (mockup)? ──────────────────
   {
-    path: 'onboarding-perfil-clasico',
-    componente: 'OnboardingCondensado',
-    importLazy: 'src/components/OnboardingCondensado.jsx',
-    decision: null,
-    motivo: 'Variante clásica del onboarding. Decidir si convive con OnboardingProfile o se elimina.',
-  },
-  {
     path: 'mockup_onboarding_siembra',
     componente: 'OnboardingSiembra',
     importLazy: 'src/mockups/OnboardingSiembra.jsx',
     decision: null,
-    motivo: 'Onboarding como ritual de siembra (SVG animado). ¿Reemplaza o complementa OnboardingProfile?',
+    motivo: 'Onboarding como ritual de siembra (SVG animado). ¿Reemplaza o complementa OnboardingCondensado?',
   },
 
   // ── Juegos PROMOVIDOS a NUCLEO_APP (smoke-test OK, 2026-07-14) ─

--- a/src/prodApp/ProdChagraApp.jsx
+++ b/src/prodApp/ProdChagraApp.jsx
@@ -104,7 +104,7 @@ const LAZY_MAP = {
   AgentScreen: lazy(() => import('../components/AgentScreen/AgentScreen.jsx')),
   ProfileScreen: lazy(() => import('../components/ProfileScreen.jsx')),
   EspirituProScreen: lazy(() => import('../components/EspirituProScreen.jsx')),
-  OnboardingProfile: lazy(() => import('../components/OnboardingProfile.jsx')),
+  OnboardingCondensado: lazy(() => import('../components/OnboardingCondensado.jsx')),
   HoyEnFincaScreen: lazy(() => import('../components/hoy/HoyEnFincaScreen.jsx')),
   MiFincaEvolucionScreen: lazy(() => import('../components/hoy/MiFincaEvolucionScreen.jsx')),
   DirectorioEspeciesScreen: lazy(() => import('../components/DirectorioEspecies/DirectorioEspeciesScreen.jsx')),
@@ -183,7 +183,6 @@ const LAZY_MAP = {
   DashboardLive: lazy(() => import('../components/dashboard/DashboardLive.jsx')),
 
   // ── PENDIENTE_DECISION (operador dijo "nada afuera") ────────────
-  OnboardingCondensado: lazy(() => import('../components/OnboardingCondensado.jsx')),
   OnboardingSiembra: lazy(() => import('../mockups/OnboardingSiembra.jsx')),
   // La sala de juegos: el hub que hace VISIBLES los juegos (#juegos) desde
   // Aprender. Los dos de abajo estaban en el manifiesto SIN entrada aquí →


### PR DESCRIPTION
## Summary

- Consolida las rutas `onboarding-perfil` y `onboarding-perfil-clasico` sobre `OnboardingCondensado` en ambos shells.
- Archiva los cuatro componentes reemplazados bajo `src/components/_archivo/`, con comentario de motivo y reemplazo, sin borrarlos.
- Conserva las capacidades exclusivas: las tres entradas de primer registro viven en `PrimerRegistroCard`, la ayuda FarmOS vive en `FarmOSSetupModal`, y la instalación PWA junto con voz, foto y fuentes verificadas pasan al cierre de `OnboardingCondensado`.
- Mantiene intacto el fallback `gemma4:e2b`.

## Reachability report

- `OnboardingProfile.jsx`: alcanzable directamente desde `src/App.jsx` por `onboarding-perfil-clasico`, y desde el manifiesto de `ProdChagraApp`. Ambas rutas ahora resuelven a `OnboardingCondensado`.
- `BienvenidaFinca.jsx`: alcanzable desde `src/App.jsx` por `DashboardLive` en el primer uso. Su valor funcional se porta al flujo condensado y se retira el montaje duplicado.
- `OnboardingHero.jsx`: alcanzable desde `src/App.jsx` por `DashboardLive`, tanto compacto como completo. La configuración pasa al flujo condensado y las tres CTA operativas pasan a `PrimerRegistroCard`.
- `OnboardingModal.jsx`: alcanzable desde `src/App.jsx` por `AssetsDashboard` y `MultiFincaModal`. La ayuda técnica se conserva como `FarmOSSetupModal`, pues no es onboarding de perfil.

## Test plan

- `npx vitest run` focalizado en 16 archivos tocados: 65 pruebas verdes.
- Hook pre-commit con ESLint `--max-warnings=0`: verde.
- `npm run build`: verde, 3830 módulos transformados.
- `grep -rl OnboardingCondensado dist/assets/*.js`: encuentra el chunk principal y `OnboardingCondensado`.
- El intento global `npx eslint . --max-warnings=0` agotó memoria de Node con límites de 4 GB y 8 GB sin reportar errores; ESLint focalizado y el hook sobre todos los archivos staged quedaron verdes.