### PR TITLE
fix(mundo3d): acerca cámara en recorrido panelero

### DIFF
--- a/src/mockups/MundoBoticaCana3D.jsx
+++ b/src/mockups/MundoBoticaCana3D.jsx
@@ -1335,11 +1335,14 @@ function MesaGaveras({ reducedMotion }) {
    dónde se acerca la cámara — antes `etiquetas` era un booleano todo-o-nada
    y esto vivía repetido e inconexo. */
 const RECORRIDO_PANELA = [
-  { paso: 1, texto: 'La caña', pos: [9.5, 3.6, -4.5] },
-  { paso: 2, texto: 'El molino', pos: [6.2, 2.5, 1.6] },
-  { paso: 3, texto: 'El jugo', pos: [4.8, 1.9, 2.8] },
-  { paso: 4, texto: 'La paila', pos: [3.2, 2.5, 4.3] },
-  { paso: 5, texto: 'La panela', pos: [0.7, 2.0, 5.9] },
+  /* Cada paso conserva el objetivo y define un ojo propio. El primer ojo
+     entra por el lado sur del cañal, lejos de la enramada, para que se lean
+     los nudos del tallo en vez de mirar la mata desde el trapiche. */
+  { paso: 1, texto: 'La caña', pos: [9.5, 3.6, -4.5], ojo: [10.4, 5.2, 3.3] },
+  { paso: 2, texto: 'El molino', pos: [6.2, 2.5, 1.6], ojo: [8.0, 4.8, 8.1] },
+  { paso: 3, texto: 'El jugo', pos: [4.8, 1.9, 2.8], ojo: [7.3, 4.2, 9.1] },
+  { paso: 4, texto: 'La paila', pos: [3.2, 2.5, 4.3], ojo: [5.2, 4.8, 10.7] },
+  { paso: 5, texto: 'La panela', pos: [0.7, 2.0, 5.9], ojo: [2.4, 4.1, 12.5] },
 ];
 /* A dónde mira la cámara cuando no hay paso activo (vista calma original). */
 const OBJETIVO_CALMA = [0.5, 1.0, 1.5];
@@ -1356,36 +1359,40 @@ function PasosPanela({ pasoActivo }) {
   );
 }
 
-/* Lleva el `target` de OrbitControls hacia la posición del paso activo del
-   recorrido panelero — antes la cámara nunca se movía con `etiquetas`.
+/* Lleva el objetivo y el ojo de OrbitControls al encuadre del paso activo.
    Sin reducedMotion camina suave (lerp); con reducedMotion salta directo. */
-/* OJO (queda anotado, no arreglado aquí): este "recorrido" solo RE-APUNTA. El
-   objetivo viaja al paso activo, pero la CÁMARA se queda donde está —contra el
-   tope de `maxDistance`, a 22 unidades— así que el paso 1 muestra el cañal como
-   una mancha lejana y los NUDOS de la caña no se alcanzan a ver nunca desde la
-   app, por fiel que sea la malla. Acercarla no es cambiar una constante: los
-   topes de azimut obligan a mirar siempre desde el lado del trapiche, y a menos
-   de ~16 unidades la enramada se mete entre la cámara y el cañal. Necesita
-   coreografía POR PASO (una posición de ojo por encuadre, como los `OJOS` de
-   `cana/leccionCana.js`), que es tarea aparte de redibujar la caña. */
 function EnfocarPaso({ paso, reducedMotion, controlsRef }) {
-  const objetivo = useMemo(() => {
-    const destino = paso > 0 ? RECORRIDO_PANELA[paso - 1].pos : OBJETIVO_CALMA;
-    return new THREE.Vector3(...destino);
+  const encuadre = useMemo(() => {
+    const destino = paso > 0 ? RECORRIDO_PANELA[paso - 1] : null;
+    return {
+      objetivo: new THREE.Vector3(...(destino?.pos || OBJETIVO_CALMA)),
+      ojo: destino ? new THREE.Vector3(...destino.ojo) : null,
+    };
   }, [paso]);
   useFrame((_state, delta) => {
     const controles = controlsRef.current;
     if (!controles) return;
     if (reducedMotion) {
-      controles.target.copy(objetivo);
+      controles.target.copy(encuadre.objetivo);
+      if (encuadre.ojo) controles.object.position.copy(encuadre.ojo);
     } else {
-      controles.target.lerp(objetivo, Math.min(1, delta * 1.4));
+      const avance = Math.min(1, delta * 1.4);
+      controles.target.lerp(encuadre.objetivo, avance);
+      if (encuadre.ojo) controles.object.position.lerp(encuadre.ojo, avance);
     }
     controles.update();
   });
-  /* Ancla inerte (sin geometría ni material): expone declarativamente a
-     dónde apunta el foco activo, y sirve de gancho de prueba. */
-  return <group name="foco-paso" position={[objetivo.x, objetivo.y, objetivo.z]} />;
+  /* Anclas inertes (sin geometría ni material): exponen declarativamente el
+     objetivo y el ojo del encuadre activo, y sirven de gancho de prueba. */
+  return (
+    <>
+      <group
+        name="foco-paso"
+        position={[encuadre.objetivo.x, encuadre.objetivo.y, encuadre.objetivo.z]}
+      />
+      {encuadre.ojo && <group name="ojo-paso" position={encuadre.ojo.toArray()} />}
+    </>
+  );
 }
 
 /* ══════════════════════ LA GENTE DEL TRAPICHE ══════════════════════ */

--- a/src/mockups/__tests__/mundoBoticaCana3D.test.jsx
+++ b/src/mockups/__tests__/mundoBoticaCana3D.test.jsx
@@ -75,13 +75,15 @@ describe('MundoBoticaCana3D', () => {
       expect(screen.getByRole('status')).toHaveTextContent(/Toque el botón/i);
     });
 
-    test('tocar "2. El molino" activa el recorrido, resalta esa etiqueta y acerca la cámara a su posición', () => {
+    test('tocar "2. El molino" activa el recorrido, resalta esa etiqueta y usa su propio ojo de cámara', () => {
       const { container } = render(<MundoBoticaCana3D />);
       fireEvent.click(screen.getByRole('button', { name: '2. El molino' }));
 
       // La cámara (el foco) se mueve al punto del paso 2, no al de reposo.
       const foco = container.querySelector('group[name="foco-paso"]');
-      expect(foco.getAttribute('position')).toBe('6.2,3.4,1.2');
+      expect(foco.getAttribute('position')).toBe('6.2,2.5,1.6');
+      const ojo = container.querySelector('group[name="ojo-paso"]');
+      expect(ojo.getAttribute('position')).toBe('8,4.8,8.1');
 
       // Solo la etiqueta del paso 2 lleva la clase de "activo".
       const etiqueta2 = container.querySelector('div[data-testid="html-billboard"] .bocana-chip--activo');
@@ -93,6 +95,16 @@ describe('MundoBoticaCana3D', () => {
       expect(screen.getByRole('status')).toHaveTextContent(/Siga los números/i);
     });
 
+    test('el paso de la caña acerca el ojo al cañal desde fuera de la enramada', () => {
+      const { container } = render(<MundoBoticaCana3D />);
+      fireEvent.click(screen.getByRole('button', { name: '1. La caña' }));
+
+      const foco = container.querySelector('group[name="foco-paso"]');
+      const ojo = container.querySelector('group[name="ojo-paso"]');
+      expect(foco.getAttribute('position')).toBe('9.5,3.6,-4.5');
+      expect(ojo.getAttribute('position')).toBe('10.4,5.2,3.3');
+    });
+
     test('tocar el mismo paso otra vez vuelve a la vista calma (apaga el recorrido)', () => {
       const { container } = render(<MundoBoticaCana3D />);
       const boton = screen.getByRole('button', { name: '4. La paila' });
@@ -101,6 +113,7 @@ describe('MundoBoticaCana3D', () => {
       fireEvent.click(boton);
       expect(boton).toHaveAttribute('aria-pressed', 'false');
       expect(container.querySelector('group[name="etiqueta-paso-4"]')).toBeNull();
+      expect(container.querySelector('group[name="ojo-paso"]')).toBeNull();
       const foco = container.querySelector('group[name="foco-paso"]');
       expect(foco.getAttribute('position')).toBe('0.5,1,1.5');
     });


### PR DESCRIPTION
## Summary
- Agrega posiciones de ojo por paso para que el recorrido mueva cámara y objetivo.
- El encuadre de la caña entra por el lado libre de la enramada para mostrar los nudos del tallo.
- Añade cobertura del ojo de cámara para caña y molino.

## Test plan
- npx vitest run src/mockups/__tests__/mundoBoticaCana3D.test.jsx
- npx eslint src/mockups/MundoBoticaCana3D.jsx src/mockups/__tests__/mundoBoticaCana3D.test.jsx --max-warnings=0
- npm run build
- Intenté el gate GPU oficial antes y después. Chromium quedó bloqueado antes de escribir PNG, sin captura ni reporte de SwiftShader; no se usaron capturadores ni flags alternos.