### PR TITLE
fix(vitrina): la vitrina-maestra truena — falta la viñeta del bosque + un ángulo

### DIFF
--- a/src/mockups/VitrinaMaestraMundos.jsx
+++ b/src/mockups/VitrinaMaestraMundos.jsx
@@ -144,7 +144,8 @@ const COMPONENTES = /** @type {Record<string, import('react').ComponentType<any>
    ningún arco se monte sobre otro). El orden dentro de `mundos` ES el arco de
    izquierda a derecha; colorA/colorB alimentan el iris del cruce, la brasa,
    los chips y la rejilla 2D — no el paisaje. */
-const PISOS = [
+// eslint-disable-next-line react-refresh/only-export-components
+export const PISOS = [
   {
     id: 'calido',
     nombre: 'Tierra cálida',
@@ -189,7 +190,7 @@ const PISOS = [
     radio: 12.0,
     alturaAro: 4.75,
     escala: 1.18,
-    angulos: [-42, -14, 14, 42],
+    angulos: [-56, -28, 0, 28, 56],
     mundos: [
       { id: 'papa', titulo: 'La papa', emoji: '🥔', colorA: '#b28a52', colorB: '#2e2618' },
       { id: 'suelo', titulo: 'El suelo vivo', emoji: '🪱', colorA: '#a97b4f', colorB: '#2b1d10' },

--- a/src/mockups/__tests__/vitrinaMaestraMundos.data.test.js
+++ b/src/mockups/__tests__/vitrinaMaestraMundos.data.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest';
+import { PISOS } from '../VitrinaMaestraMundos.jsx';
+import { VINETAS_GEOM } from '../../visual/mundo3d/vitrina/vinetasMundos.geom.js';
+
+describe('VitrinaMaestraMundos', () => {
+  test('asigna un angulo a cada mundo de todos los pisos termicos', () => {
+    for (const piso of PISOS) {
+      expect(piso.angulos, piso.id).toHaveLength(piso.mundos.length);
+    }
+  });
+
+  test('tiene una vineta para cada mundo de la galeria', () => {
+    for (const piso of PISOS) {
+      for (const mundo of piso.mundos) {
+        expect(VINETAS_GEOM[mundo.id], mundo.id).toBeTypeOf('function');
+      }
+    }
+  });
+});

--- a/src/visual/mundo3d/vitrina/vinetasMundos.geom.js
+++ b/src/visual/mundo3d/vitrina/vinetasMundos.geom.js
@@ -1141,6 +1141,7 @@ export const VINETAS_GEOM = {
   cacao: vinetaCacao,
   papa: vinetaPapa,
   abejas: vinetaAbejas,
+  bosque: (opts) => vinetaValle(opts, 116),
 };
 
 /**


### PR DESCRIPTION
La ruta `vitrina-maestra` reventaba **siempre** (determinístico), encontrada barriendo las 54
rutas 3D.

## Dos causas, ambas de datos

1. **El mundo `bosque` no tenía viñeta** en `VINETAS_GEOM`. Al dibujar su arco,
   `VINETAS_GEOM['bosque']` era `undefined` y la escena caía. Se registra
   `bosque → vinetaValle(opts, 116)`.
2. **El piso frío tenía 5 mundos pero solo 4 ángulos** — el quinto mundo quedaba sin posición en
   el arco. Se agrega el quinto ángulo.

## Un test que blinda las dos

Por cada mundo de cada piso, exige que exista su viñeta **y** que la cantidad de ángulos coincida
con la de mundos. Ese test es el que **destapó** que faltaba la viñeta del bosque — no se
encontró a ojo.

## Verificado en GPU real

La vitrina ahora **carga**: «El mirador de los mundos», con todos los portales dibujados y el del
bosque entre ellos. Renderer `ANGLE (AMD Radeon Vega 10)`. No basta con que el build pase: se
miró la captura, porque una ruta que carga con el canvas en un solo color habría pasado el build
igual.

## Nota de proceso

El fix venía en un PR (codex, #2697) que arrastraba **98 archivos de basura** (PNGs, docs) por
partir de un `dev` viejo. Se extrajeron **solo los tres archivos de código** a esta rama limpia
desde `dev` fresco. Cerrar #2697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)