### PR TITLE
test(botica): actualizar encuadre de reposo

### DIFF
--- a/src/mockups/__tests__/mundoBoticaCana3D.test.jsx
+++ b/src/mockups/__tests__/mundoBoticaCana3D.test.jsx
@@ -136,7 +136,9 @@ describe('MundoBoticaCana3D', () => {
       expect(container.querySelector('group[name="etiqueta-paso-4"]')).toBeNull();
       expect(container.querySelector('group[name="ojo-paso"]')).toBeNull();
       const foco = container.querySelector('group[name="foco-paso"]');
-      expect(foco.getAttribute('position')).toBe('0.5,1,1.5');
+      // Al apagar el recorrido se vuelve a la MISMA vista calma que #2698
+      // reencuadró hacia el trapiche (0.9,1,1.8), no al punto de reposo viejo.
+      expect(foco.getAttribute('position')).toBe('0.9,1,1.8');
     });
   });
 });

--- a/src/mockups/__tests__/mundoBoticaCana3D.test.jsx
+++ b/src/mockups/__tests__/mundoBoticaCana3D.test.jsx
@@ -71,7 +71,9 @@ describe('MundoBoticaCana3D', () => {
       expect(container.querySelector('group[name="etiqueta-paso-1"]')).toBeNull();
       const foco = container.querySelector('group[name="foco-paso"]');
       expect(foco).toBeTruthy();
-      expect(foco.getAttribute('position')).toBe('0.5,1,1.5');
+      // #2698 reencuadró la vista calma hacia el trapiche para que el molino
+      // y el buey queden dentro del encuadre vertical.
+      expect(foco.getAttribute('position')).toBe('0.9,1,1.8');
       expect(screen.getByRole('status')).toHaveTextContent(/Toque el botón/i);
     });
 


### PR DESCRIPTION
## Summary

Actualiza la aserción del encuadre de reposo de MundoBoticaCana3D al objetivo vigente tras #2698: [0.9, 1, 1.8].

El reporte sobre el paso 2 ya estaba resuelto en dev por #2694, que actualizó tanto la escena como el test a [6.2, 2.5, 1.6]. Los otros cuatro tests reportados no fallaron en la base dev fresca.

## Test plan

- npx vitest run
- npx eslint . --max-warnings=0
- npm run build

La primera corrida completa de Vitest reportó 3 fallos ajenos al alcance: sidecarClient, coverage-jornada-48h y SeguimientoProcesoScreen.