### PR TITLE
fix(valle): los chips de los portales ya no se cortan contra el borde en 390px

### DIFF
--- a/src/mockups/valle/Valle2DFallback.jsx
+++ b/src/mockups/valle/Valle2DFallback.jsx
@@ -24,6 +24,35 @@ function pct(x, z) {
   return { left: (cx / 400) * 100, top: (cy / 340) * 100 };
 }
 
+/* Anti-corte de borde (BUG-VALLE-390): la proyección isométrica de arriba
+ * puede caer bien afuera de [0,400]x[0,340] para lugares en los bordes de la
+ * ladera (la milpa a la izquierda, el mercado abajo…) — en un equipo angosto
+ * (390px) ese % negativo o >100%, sumado al `translate(-50%,-50%)` que
+ * centra el chip sobre su punto, dejaba las primeras letras del rótulo
+ * fuera de cuadro («semillas» en vez de «Cultivos y semillas»). `clampPct`
+ * mezcla unidades (px fijos de aire + % del contenedor) para que el chip
+ * SIEMPRE quede entero dentro de la pantalla, sea cual sea su ancho: no se
+ * reubica el lugar en el valle, solo dónde CAE su etiqueta en pantalla. */
+function clampPct(pct, mitadPx) {
+  return `clamp(${mitadPx}px, ${pct}%, calc(100% - ${mitadPx}px))`;
+}
+
+/* Ancho/alto aproximados (px) de un chip 2D según su texto — el emoji vive
+ * ARRIBA del nombre (columna), así que el ancho lo manda el texto, no la
+ * suma de los dos. Basta con acercarse: solo evita el corte de borde, no
+ * exige exactitud de layout. */
+function mitadChip2D(titulo) {
+  return Math.max(34, Math.round((titulo.length * 6.6) / 2 + 14));
+}
+
+/* Medio-alto (px) del chip más alto medido (emoji+nombre en 2 líneas, p. ej.
+ * "El páramo"): 88px de alto real ⇒ 44px de mitad. Antes esta constante
+ * estaba en 28px (la mitad del chip de UNA línea) y el chip de "El clima"
+ * — con el mismo alto de una línea pero un `top` natural apenas por encima
+ * del piso de 28px — seguía asomando ~5px por el borde SUPERIOR. Usar el
+ * caso más alto como piso cubre a todos, de una sola línea o dos. */
+const MEDIO_ALTO_CHIP2D = 44;
+
 export default function Valle2DFallback({
   clima,
   focoId,
@@ -107,10 +136,15 @@ export default function Valle2DFallback({
           {orden.map((m) => {
             const p = pct(m.pos[0], m.pos[2]);
             const activo = focoId === m.id;
+            const mitad = mitadChip2D(m.titulo);
             return (
               <button key={m.id} type="button"
                 className={`valle2d__poi${activo ? ' valle2d__poi--activo' : ''}`}
-                style={{ left: `${p.left}%`, top: `${p.top}%`, '--poi-tinte': m.tinte[0] }}
+                style={{
+                  left: clampPct(p.left, mitad),
+                  top: clampPct(p.top, MEDIO_ALTO_CHIP2D),
+                  '--poi-tinte': m.tinte[0],
+                }}
                 onClick={() => onEntrar(m.id)}
                 aria-label={`Viajar al mundo ${m.titulo}. ${m.lema}`}>
                 <span className="valle2d__emoji" aria-hidden="true">{m.emoji}</span>
@@ -122,9 +156,13 @@ export default function Valle2DFallback({
           {/* la cosa del día: un solo destello, anclado a su lugar */}
           {ancla && (() => {
             const p = pct(ancla.pos[0], ancla.pos[2]);
+            // Fila (emoji + texto), no columna: un poco más ancha que el chip
+            // de lugar de arriba — el mismo criterio de mitadChip2D se queda
+            // corto para ella.
+            const mitad = mitadChip2D(COSA_DEL_DIA.titulo) + 20;
             return (
               <button type="button" className="valle2d__alerta"
-                style={{ left: `${p.left}%`, top: `${p.top - 12}%` }}
+                style={{ left: clampPct(p.left, mitad), top: clampPct(p.top - 12, 24) }}
                 onClick={onAlerta}
                 aria-label={`Alerta del día: ${COSA_DEL_DIA.titulo}. ${COSA_DEL_DIA.detalle}`}>
                 <span aria-hidden="true">⚠️</span> {COSA_DEL_DIA.titulo}

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -1396,6 +1396,26 @@ function MundoLugar({ mundo, reducedMotion, perfil, onEntrar = null }) {
  * mundos en cualquiera de los dos modos visibles — la navegación no cambia. ── */
 const _proj = new THREE.Vector3();
 
+/* Ancho aproximado (px) del chip según su modo — MISMO criterio que usan las
+ * cajas de anti-colisión de abajo (rectoDe): 'plena' crece con el título,
+ * 'punto'/'oculto' es el círculo fijo de 44px. El nudge anti-corte de borde
+ * (BUG-VALLE-390) reutiliza esta cuenta para no clampear con un margen
+ * distinto al que en verdad ocupa el chip en pantalla. */
+function anchoRotulo(modo, titulo) {
+  return modo === 'plena' ? 76 + titulo.length * 9 : 44;
+}
+
+/* Clampa v al rango [mitad, total-mitad] (deja `mitad` px de aire contra
+ * cada borde). Si el rango se invierte — un título larguísimo en una
+ * pantalla diminuta, el chip no cabe entero de ningún modo — cede al
+ * centro: mejor centrado que pegado a un filo. */
+function clamp1D(v, mitad, total) {
+  const lo = mitad;
+  const hi = total - mitad;
+  if (lo > hi) return total / 2;
+  return Math.min(Math.max(v, lo), hi);
+}
+
 function RotulosLugares({ mundos, focoId, onEntrar, occluders, controls = null, kReposo = 1 }) {
   const botones = useRef({});
   const tapados = useRef({});
@@ -1544,6 +1564,26 @@ function RotulosLugares({ mundos, focoId, onEntrar, occluders, controls = null, 
         // La banda queda en el DOM (data-banda): CSS futuro puede reaccionar
         // (p. ej. chips más grandes en estratégica) sin tocar este JS.
         if (btn.dataset.banda !== enBanda) btn.dataset.banda = enBanda;
+        // Anti-corte de borde (BUG-VALLE-390): el ancla 3D no sabe de bordes
+        // de pantalla — en equipos angostos (390px) un rótulo cerca del filo
+        // del encuadre perdía sus primeras letras (o quedaba imposible de
+        // tocar entero) fuera de cuadro. Se NUDGEA con un transform propio,
+        // por ENCIMA del centrado que ya aplica drei, lo justo para que el
+        // chip completo quede legible y tocable — el portal no se mueve de
+        // su lugar en el valle, solo se corrige dónde CAE su etiqueta.
+        if (modo === 'oculto') {
+          if (btn.style.transform) btn.style.transform = '';
+        } else {
+          const BORDE = 10;
+          const ancho = anchoRotulo(modo, p.titulo);
+          const alto = modo === 'plena' ? 48 : 44;
+          const cx = clamp1D(p.x, ancho / 2 + BORDE, size.width);
+          const cy = clamp1D(p.y, alto / 2 + BORDE, size.height);
+          const dx = cx - p.x;
+          const dy = cy - p.y;
+          const nuevo = dx || dy ? `translate(${dx.toFixed(1)}px, ${dy.toFixed(1)}px)` : '';
+          if (btn.style.transform !== nuevo) btn.style.transform = nuevo;
+        }
       }
     }
   });
@@ -1589,14 +1629,35 @@ function Beacon({ onAlerta, reducedMotion, conLuz = true }) {
   const ancla = MUNDO_DIR_BY_ID[COSA_DEL_DIA.anclaMundo];
   const luz = useRef(null);
   const halo = useRef(null);
+  const boton = useRef(null);
   useFrame((state) => {
-    if (reducedMotion) return;
-    const p = (Math.sin(state.clock.elapsedTime * 1.6) + 1) / 2;
-    if (luz.current) luz.current.intensity = 1.4 + p * 2.6;
-    if (halo.current) {
-      const s = 1 + p * 0.5;
-      halo.current.scale.set(s, s, s);
-      halo.current.material.opacity = 0.5 - p * 0.35;
+    if (!reducedMotion) {
+      const p = (Math.sin(state.clock.elapsedTime * 1.6) + 1) / 2;
+      if (luz.current) luz.current.intensity = 1.4 + p * 2.6;
+      if (halo.current) {
+        const s = 1 + p * 0.5;
+        halo.current.scale.set(s, s, s);
+        halo.current.material.opacity = 0.5 - p * 0.35;
+      }
+    }
+    // Anti-corte de borde (BUG-VALLE-390), mismo criterio que RotulosLugares:
+    // el faro del día es un solo chip fijo, pero su ancla puede caer cerca
+    // del filo de la pantalla en equipos angostos y perder sus primeras
+    // letras. Se nudgea hacia adentro sin moverlo de su lugar en el valle.
+    if (boton.current && ancla) {
+      const alturaAncla = alturaTerreno(ancla.pos[0], ancla.pos[2]);
+      _proj.set(ancla.pos[0], alturaAncla + 2.7, ancla.pos[2]).project(state.camera);
+      const sx = (_proj.x * 0.5 + 0.5) * state.size.width;
+      const sy = (0.5 - _proj.y * 0.5) * state.size.height;
+      const BORDE = 10;
+      const ancho = 64 + COSA_DEL_DIA.titulo.length * 9;
+      const alto = 52;
+      const cx = clamp1D(sx, ancho / 2 + BORDE, state.size.width);
+      const cy = clamp1D(sy, alto / 2 + BORDE, state.size.height);
+      const dx = cx - sx;
+      const dy = cy - sy;
+      const nuevo = dx || dy ? `translate(${dx.toFixed(1)}px, ${dy.toFixed(1)}px)` : '';
+      if (boton.current.style.transform !== nuevo) boton.current.style.transform = nuevo;
     }
   });
   if (!ancla) return null;
@@ -1621,6 +1682,7 @@ function Beacon({ onAlerta, reducedMotion, conLuz = true }) {
       {/* Sin distanceFactor: la alerta mantiene su tamaño táctil en píxeles. */}
       <Html center position={[0, 2.7, 0]} zIndexRange={[30, 0]}>
         <button
+          ref={boton}
           type="button"
           className="valle-alerta v3d-alerta"
           onClick={(e) => {
@@ -1743,7 +1805,6 @@ function CompaneroAbeja({ foco, focoId = null, entrando, animo, energia, reduced
     };
     // `entrando` vive en entrandoRef a propósito: un viaje real no debe
     // reiniciar la cadencia del husmeo autónomo.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reducedMotion, entrarMundoAngelita, reposarAngelita]);
 
   useFrame((state) => {


### PR DESCRIPTION
## Qué pasaba

En el valle (`#/mockups/entrada-3d`), a 390×844 los chips de los portales
(«Cultivos y semillas», «Suelo vivo», «Mercado y despensa»…) y la alerta del
día se posicionaban por su ancla en el mundo (proyección de cámara en 3D,
proyección isométrica en el fallback 2D) **sin contemplar el borde de
pantalla**. En equipos angostos, la mitad quedaban con sus primeras letras
fuera de cuadro — y algunos (Los animales, Estiércol y compost, Semillero y
vivero) quedaban **100% invisibles e intocables**, no solo con texto cortado.

Se veía tanto en el valle 3D como en su fallback 2D (`GemeloValle2D`/tier
bajo), y también en producción — confirmado que es un problema de
posicionamiento de los chips, no de una escena puntual.

## Causa raíz

- **Fallback 2D** (`Valle2DFallback.jsx`): los botones `.valle2d__poi` se
  posicionaban con `left/top` en % puro (de una proyección isométrica plana
  que puede caer bien afuera de `[0,400]×[0,340]`) + `transform:
  translate(-50%,-50%)`, sin ningún clamp contra los bordes del contenedor.
- **3D** (`Valle3D.jsx`): `RotulosLugares` (los rótulos de cada portal) y
  `Beacon` (la alerta del día) usan `<Html center>` de drei, que centra el
  chip sobre la proyección de cámara del ancla 3D — tampoco contemplaba el
  borde de pantalla.

## El arreglo (aditivo — ningún portal se quita, solo se corrige dónde CAE su etiqueta)

- **2D**: `clampPct()` nuevo — mezcla px fijos (aire mínimo) + % del
  contenedor vía CSS `clamp()`, así el chip completo queda siempre dentro de
  `[0, ancho]×[0, alto]` sin importar el tamaño de pantalla ni el largo del
  texto.
- **3D**: `RotulosLugares` y `Beacon` ahora nudgean su `<Html>` con un
  `transform` propio (por encima del centrado que ya aplica drei) cuando la
  proyección de cámara cae cerca del filo — mismo criterio de ancho que ya
  usaba el sistema de anti-colisión existente (`rectoDe`), reutilizado para
  no clampear con un margen distinto al que en verdad ocupa el chip.

## Verificación

Capturas a 390×844 con GPU real (`scripts/gate-real-gpu.mjs`, Vega 10 nativa,
sin SwiftShader) y con `getBoundingClientRect()` sobre los 15 chips reales del
fallback 2D forzando tier bajo (mismo camino sugerido cuando el 3D es pesado
de levantar en el gate):

| | antes | después |
|---|---|---|
| chips clippeados (2D, de 15) | **11/15** | **0/15** |
| ejemplos invisibles al 100% | Los animales, Estiércol y compost, Semillero y vivero | — |

También verificado en el valle 3D por defecto (GPU real): la alerta «Helada
esta noche», que antes tenía el borde izquierdo cortado en seco contra el
filo de pantalla, ahora aparece con su píldora completa y redondeada.

- Build: `vite build` verde.
- Lint: `eslint` limpio en ambos archivos (se quitó de paso un
  `eslint-disable` de `exhaustive-deps` que ya no hacía falta y bloqueaba el
  hook de pre-commit).
- Tests: `entradaValle3D.nav.test.jsx` tiene 4 fallos preexistentes
  (verificados idénticos con y sin este cambio, vía stash) no relacionados —
  son fallos de ambigüedad de `getByRole` en el test, no del componente.

## Test plan

- [ ] Abrir `#/mockups/entrada-3d` en un viewport de 390×844 y confirmar que
      ningún chip de portal ni la alerta del día tienen texto cortado contra
      el borde.
- [ ] Forzar tier bajo (poca RAM/CPU o `prefers-reduced-motion` en equipo no
      "alto") y repetir la verificación sobre el fallback 2D.
- [ ] Tocar cada portal y confirmar que sigue siendo tocable/legible
      (ninguno se movió de su lugar en el valle, solo se corrigió el chip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)