### PR TITLE
fix(cafetal): piso de luz legible + cerezas visibles en el mundo del café

### DIFF
--- a/scripts/gate-real-gpu.mjs
+++ b/scripts/gate-real-gpu.mjs
@@ -9,7 +9,11 @@ import { setTimeout as sleep } from 'node:timers/promises';
 
 const DIST = process.argv[2];
 // <ruta>=<nombre>[=<texto del botón a tocar antes de capturar>]
-const SHOTS = process.argv.slice(3).map((a) => { const [ruta, name, click] = a.split('='); return [name, ruta, click]; });
+// La ruta pasa por decodeURIComponent: si la ruta misma lleva '=' (p. ej. el
+// override '?ciclo=12' del ciclo diurno), se pasa percent-encodeada
+// ('...%3Fciclo%3D12') y aquí se restaura — sin eso el split de abajo la
+// partía por el '=' del query y el gate iba a una ruta trunca (2026-07-23).
+const SHOTS = process.argv.slice(3).map((a) => { const [ruta, name, click] = a.split('='); return [name, decodeURIComponent(ruta), click]; });
 // PUERTO POR CORRIDA, NO FIJO. Estaba clavado en 8097 y con varios agentes
 // gateando a la vez el segundo encontraba el puerto ocupado, su servidor moría
 // callado, y terminaba fotografiando LA APP DEL OTRO. Lo detectó un agente el

--- a/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
+++ b/src/visual/mundo3d/cafetal/EscenaCafetalVivo.jsx
@@ -151,6 +151,10 @@ function Diorama({ tier, reducedMotion, foco }) {
   const controls = useRef(null);
   const casaY = alturaLadera(SITIO_CASA[0], SITIO_CASA[1]);
 
+  /* Cuánta luz le FALTA a la hora para que el cultivo se lea (la noche y el
+     atardecer bajan `atm.intensidad`; a mediodía esto es ~0). */
+  const refuerzo = Math.max(0, 1 - atm.intensidad);
+
   return (
     <>
       {/* LA ATMÓSFERA DEL KIT: fondo, niebla, luces y estrellas de LA HORA DEL
@@ -162,6 +166,23 @@ function Diorama({ tier, reducedMotion, foco }) {
         radio={RADIO_CAFETAL}
         conSuelo={false}
         sombra={SOMBRA_CAFETAL}
+      />
+
+      {/* EL PISO DE LECTURA del cafetal: el sombrío es penumbra, NO ceguera.
+          Dos luces locales de la escena (no tocan el kit): un relleno hemisférico
+          cálido que COMPENSA lo que la hora apaga (de noche sube, a mediodía casi
+          no suma) y una clave dorada fija SIN sombras — aclara lo que el guamo
+          tapa pero deja intacto el dibujo de la sombra proyectada. El domo y la
+          niebla siguen contando la hora: el ambiente de sombra se conserva. */}
+      <hemisphereLight
+        color="#f2e6c8"
+        groundColor="#41502e"
+        intensity={0.38 + 1.15 * refuerzo}
+      />
+      <directionalLight
+        position={[7, 10, 5]}
+        color="#ffe9c0"
+        intensity={0.5 + 0.95 * refuerzo}
       />
 
       {/* El DOMO de la toma B: gradiente cenit→horizonte + glow del sol de la

--- a/src/visual/mundo3d/cafetal/floraCafetal.geom.js
+++ b/src/visual/mundo3d/cafetal/floraCafetal.geom.js
@@ -133,9 +133,9 @@ export function construirLadera(seg, plano) {
  * el conteo del InstancedMesh de frutos (repartidos entre las matas cargadas).
  */
 export const FLORA_CAFETAL = {
-  alto: { cafeto: 120, cereza: 460, flor: 90, guamo: 10, nogal: 4, platano: 9, hojarasca: 14, piedra: 6 },
-  medio: { cafeto: 70, cereza: 250, flor: 40, guamo: 6, nogal: 2, platano: 5, hojarasca: 8, piedra: 4 },
-  bajo: { cafeto: 30, cereza: 100, flor: 0, guamo: 3, nogal: 1, platano: 2, hojarasca: 4, piedra: 2 },
+  alto: { cafeto: 120, cereza: 680, flor: 90, guamo: 10, nogal: 4, platano: 9, hojarasca: 14, piedra: 6 },
+  medio: { cafeto: 70, cereza: 380, flor: 40, guamo: 6, nogal: 2, platano: 5, hojarasca: 8, piedra: 4 },
+  bajo: { cafeto: 30, cereza: 150, flor: 0, guamo: 3, nogal: 1, platano: 2, hojarasca: 4, piedra: 2 },
 };
 
 /** Conteos para un tier (desconocido → frugal, nunca el más caro). */
@@ -162,11 +162,13 @@ export const PAL = {
   cafetoBrote: '#8cb752', // cogollo tierno arriba
 
   // Los estados de la cereza (van POR INSTANCIA, no aquí; referencia — la gama
-  // real de la foto de cosecha: verde → pintón naranja → rojo cereza → VINO):
-  cerezaVerde: '#7aa244',
-  cerezaPinton: '#e0a33a',
-  cerezaRoja: '#cf2a1d',
-  cerezaVino: '#8e1a20',
+  // real de la foto de cosecha: verde → pintón naranja → rojo cereza → VINO).
+  // Subidos de valor a propósito: bajo el sombrío el fruto tiene que GRITAR
+  // (es lo que hace reconocible el cafetal y lo que enseña la lección).
+  cerezaVerde: '#88b44c',
+  cerezaPinton: '#f2a52f',
+  cerezaRoja: '#e62f1c',
+  cerezaVino: '#b0202a',
 
   // La flor axilar blanca del arábica (nace pegada a la rama, como la cereza)
   florCafe: '#f6f1e2',
@@ -531,7 +533,10 @@ export function geomCafeto({ q = 1, porte = 'tallo' } = {}, seed = 1) {
 /** La cereza del café: OVOIDE (como en la rama real), pintada blanca — el
     color verdadero (verde→pintón→rojo→vino) va POR INSTANCIA. */
 export function geomCereza() {
-  const g = new THREE.IcosahedronGeometry(0.068, 0);
+  /* Radio EXAGERADO adrede (rubber-hose): la cereza real mide 1.5 cm, pero a
+     los 12–14 m de la cámara eso son 3–4 px — invisible. La cuenta gorda es
+     la que deja LEER el racimo verde→rojo desde la entrada. */
+  const g = new THREE.IcosahedronGeometry(0.095, 0);
   g.scale(1, 1.28, 1);
   return pintar(g.index ? g.toNonIndexed() : g, '#ffffff');
 }
@@ -962,15 +967,17 @@ export function distribucionCafetal(conteos, seed = 311, q = 1) {
       if (t > 0.82) break; // la punta de la rama es de las hojas
       // el estado del fruto: la madurez de la mata + su propio azar
       const m = clamp(s.maduro + (rCer() - 0.5) * 0.45, 0, 1);
+      /* El VINO solo asoma (0.55 de mezcla máxima): el granate en penumbra lee
+         NEGRO y borraba la cosecha — el maduro se queda rojo cereza. */
       if (m < 0.35) col.lerpColors(verde, pinton, m / 0.35);
       else if (m < 0.68) col.lerpColors(pinton, roja, (m - 0.35) / 0.33);
-      else col.lerpColors(roja, vino, (m - 0.68) / 0.32);
-      col.multiplyScalar(0.94 + rCer() * 0.12);
+      else col.lerpColors(roja, vino, ((m - 0.68) / 0.32) * 0.55);
+      col.multiplyScalar(0.98 + rCer() * 0.1);
       cereza.push({
         pos: enRama(s, e, i, j, t, -0.045, 0.035, rCer), // colgada APENAS bajo la rama
         rotY: rCer() * Math.PI,
         // en el héroe la cuenta es un pelín más gorda: legible desde la entrada
-        escala: (0.8 + rCer() * 0.45) * (s.hero ? 1.3 : 1),
+        escala: (1.0 + rCer() * 0.5) * (s.hero ? 1.4 : 1),
         tint: [col.r, col.g, col.b],
       });
     }


### PR DESCRIPTION
## Los dos problemas (verificados con captura en GPU real)

1. **El paso 1 «El sombrío» arrancaba en penumbra ilegible**: la atmósfera hereda la franja horaria real del valle y de noche (`intensidad` ≈ 0.58) el toon aplastaba todo a negro — el cultivo parecía matorral verde negruzco.
2. **Las cerezas no se leían**: existían (460 instancias) pero medían ~7 cm de mundo vistos a 14 m (≈4 px en pantalla) y un tercio caía al color «vino» granate, que en penumbra lee negro.

## El arreglo (aditivo, sin tocar el kit compartido)

**Luz** (`EscenaCafetalVivo.jsx`): piso de lectura local — una hemisférica cálida que compensa lo que la hora apaga (`refuerzo = max(0, 1 − atm.intensidad)`; a mediodía suma ~0) más una clave dorada fija SIN sombras, que aclara lo que el guamo tapa sin borrar el dibujo de la sombra proyectada. El domo y la niebla siguen contando la hora: de noche el cielo sigue oscuro, el ambiente de sombra se conserva.

**Cerezas** (`floraCafetal.geom.js`, beneficia también al arquetipo `cafe` del framework):
- Cuenta 40 % más gorda (radio 0.068 → 0.095) y escala de instancia subida (héroes ×1.4) — exageración rubber-hose a propósito: es lo que deja LEER el racimo.
- Conteos 460→680 / 250→380 / 100→150 por tier (instanciado: una draw-call igual).
- Rojos más vivos (`#e62f1c`) y el «vino» capado al 55 % de mezcla — el maduro se queda rojo cereza.

**Gate** (`gate-real-gpu.mjs`): la ruta ahora pasa por `decodeURIComponent` — rutas con `=` en el query (p. ej. el override `?ciclo=12`) ya no se parten por el split de argumentos. Retrocompatible.

## Verificación (GPU real, Radeon Vega — no SwiftShader)

- **Noche (franja real de la captura, la misma del «antes» negro)**: surcos, sombrío y racimos rojos legibles; cielo nocturno intacto.
- **Mediodía (`?ciclo=12`)** y **tarde (`?ciclo=17`)**: no se lava; juez visual local `triar-capturas` 2/2 PASA con «un cafetal con cerezas de café rojas y verdes visibles, bien iluminado».
- Build verde (26.9 s) y eslint limpio en los archivos tocados.
- Antes/después lado a lado capturado en stg (scratchpad de la sesión: `cafetal-antes-despues.png`).

NO mergear: queda para review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)