### PR TITLE
feat(botica-cana): la molienda muele y el guarapo arrastra su cachaza (F-11 + F-13)

### DIFF
--- a/src/mockups/MundoBoticaCana3D.jsx
+++ b/src/mockups/MundoBoticaCana3D.jsx
@@ -1113,6 +1113,9 @@ function Buey({ reducedMotion }) {
       const s = Math.sin(t * 2) * 0.03;
       cuerpo.current.position.y = Math.abs(Math.sin(t)) * 0.045;
       cuerpo.current.scale.set(1 - s * 0.6, 1 + s, 1 - s * 0.6);
+      // y se ECHA AL YUGO: la cabeza va adelante (+x) y el tiro le pide
+      // inclinarse hacia allá — el esfuerzo del que arrastra, no del que pasea
+      cuerpo.current.rotation.z = -0.05 + Math.sin(t * 2 + 0.8) * 0.02;
     }
     // la cabeza cabecea con el esfuerzo del tiro
     if (cabeza.current) {
@@ -1215,8 +1218,18 @@ function Buey({ reducedMotion }) {
 const TRAPICHE_POS = [6.2, Y_PATIO, 1.2];
 function Trapiche({ reducedMotion }) {
   const vuelta = useRef(null);
+  const masas = useRef([]);
   useFrame(({ clock }) => {
     if (reducedMotion || !vuelta.current) return;
+    // LA MECÁNICA COMPLETA: el buey mueve la palanca, la palanca mueve el eje
+    // y el eje muerde la caña con las masas. Antes la palanca daba la vuelta
+    // pero los rodillos quedaban clavados — el molino giraba sin moler. La
+    // mazamorrera (centro) va 1:1 con la palanca; las dos de al lado van
+    // ENGRANADAS y giran al contrario, como en el trapiche de verdad.
+    const angulo = 3.05 + clock.elapsedTime * 0.22;
+    masas.current.forEach((m, i) => {
+      if (m) m.rotation.y = i === 1 ? angulo : -angulo;
+    });
     // El paso manso del buey. ARRANCA EN 3.05, no en 2.3: con la cámara
     // vertical del teléfono la fase 2.3 lo escondía detrás del molino y la
     // 4.7 (la vieja "pose visible") caía FUERA del borde derecho del
@@ -1270,9 +1283,11 @@ function Trapiche({ reducedMotion }) {
         <boxGeometry args={[1.5, 0.84, 1.2]} />
         <meshLambertMaterial color={mezclar(P.maderaVieja, '#5c4228', 0.35)} flatShading />
       </mesh>
-      {/* los TRES rodillos verticales de madera (la mazamorrera al centro) */}
+      {/* los TRES rodillos verticales de madera (la mazamorrera al centro),
+          GIRANDO con la palanca — flatShading a 9 caras: las facetas dejan
+          ver la vuelta sin estrías nuevas */}
       {[-0.38, 0, 0.38].map((x, i) => (
-        <mesh key={i} position={[x, 1.14, 0]}>
+        <mesh key={i} position={[x, 1.14, 0]} ref={(el) => { masas.current[i] = el; }}>
           <cylinderGeometry args={[i === 1 ? 0.19 : 0.16, i === 1 ? 0.19 : 0.16, 0.6, 9]} />
           <meshLambertMaterial
             color={mezclar(P.maderaClara, TINTE, i * 0.08)}
@@ -1286,12 +1301,6 @@ function Trapiche({ reducedMotion }) {
         <meshLambertMaterial color={P.maderaVieja} flatShading />
       </mesh>
 
-      {/* el eje que sube del rodillo mayor a la palanca */}
-      <mesh position={[0, 1.78, 0]}>
-        <cylinderGeometry args={[0.09, 0.09, 0.5, 7]} />
-        <meshLambertMaterial color={P.maderaClara} flatShading />
-      </mesh>
-
       {/* LA VUELTA: palanca + buey giran juntos alrededor del eje */}
       {/* pose base (reduced-motion y captura): 3.05 = el buey en el claro de
           pasto al lado izquierdo del molino, de cara a la cámara y ADENTRO
@@ -1299,6 +1308,12 @@ function Trapiche({ reducedMotion }) {
           borde derecho del teléfono, y entre 3.3 y 3.6 quedaba camuflado
           contra la canoa y el molino, debajo del humo de la hornilla */}
       <group ref={vuelta} position={[0, 0, 0]} rotation={[0, 3.05, 0]}>
+        {/* el eje que sube del rodillo mayor a la palanca — vive DENTRO de la
+            vuelta: gira con ella, que es lo que hace girar la mazamorrera */}
+        <mesh position={[0, 1.78, 0]}>
+          <cylinderGeometry args={[0.09, 0.09, 0.5, 7]} />
+          <meshLambertMaterial color={P.maderaClara} flatShading />
+        </mesh>
         {/* la palanca, del eje hacia afuera y bajando al pecho del buey */}
         <mesh position={[1.45, 1.6, 0]} rotation={[0, 0, 0.26]}>
           <boxGeometry args={[3.1, 0.13, 0.13]} />
@@ -1348,6 +1363,29 @@ function Trapiche({ reducedMotion }) {
 function CanalGuarapo({ reducedMotion }) {
   const pulsos = useRef(null);
   const chorro = useRef(null);
+  const nacimiento = useRef(null);
+  const espuma = useRef(null);
+  const cachaza = useRef(null);
+  /* LO QUE FLOTA EN EL GUARAPO — es lo que el campesino reconoce de una
+     mirada: la ESPUMA clara que hace el jugo al correr y la CACHAZA verdosa
+     (el bagacillo y la tierra que se colaron) que baja flotando hasta que el
+     cucharón la retira en la paila. Motas deterministas, repartidas a lo
+     largo para que la canoa se lea CORRIENDO aun en la pose quieta. */
+  const motas = useMemo(() => {
+    const rng = crearRng(430);
+    return {
+      espuma: Array.from({ length: 6 }, (_, i) => ({
+        fase: i / 6 + rng() * 0.08,
+        z: (rng() - 0.5) * 0.11,
+        esc: 0.7 + rng() * 0.5,
+      })),
+      cachaza: Array.from({ length: 4 }, (_, i) => ({
+        fase: i / 4 + rng() * 0.1,
+        z: (rng() - 0.5) * 0.09,
+        esc: 0.8 + rng() * 0.45,
+      })),
+    };
+  }, []);
   // del trapiche (6.2, 1.2) hacia la hornilla (3.4, 4.2): largo ~3.9;
   // el extremo local +x queda en el molino (arriba), el -x en la paila (abajo)
   useFrame(({ clock }) => {
@@ -1361,9 +1399,34 @@ function CanalGuarapo({ reducedMotion }) {
         p2.scale.setScalar(0.75 + Math.sin(f * Math.PI) * 0.45);
       });
     }
+    // la espuma viaja CON la corriente (misma velocidad que los pulsos)
+    if (espuma.current) {
+      espuma.current.children.forEach((m, i) => {
+        const d = motas.espuma[i];
+        const f = (t * 0.55 + d.fase) % 1;
+        m.position.x = 1.7 - f * 3.45;
+        m.position.z = d.z + Math.sin(t * 2.3 + i * 1.9) * 0.02;
+        m.scale.setScalar(d.esc * (0.8 + Math.sin(f * Math.PI) * 0.35));
+      });
+    }
+    // la cachaza pesa más: baja MÁS DESPACIO que la espuma, rezagándose
+    if (cachaza.current) {
+      cachaza.current.children.forEach((m, i) => {
+        const d = motas.cachaza[i];
+        const f = (t * 0.3 + d.fase) % 1;
+        m.position.x = 1.6 - f * 3.3;
+        m.position.z = d.z + Math.cos(t * 1.7 + i * 2.3) * 0.015;
+        m.scale.setScalar(d.esc * (0.85 + Math.sin(t * 2.6 + i) * 0.12));
+      });
+    }
     if (chorro.current) {
       const s = 0.9 + Math.sin(t * 7.3) * 0.14;
       chorro.current.scale.set(s, 1 + Math.sin(t * 9.1) * 0.12, s);
+    }
+    // el chorrito del NACIMIENTO late con el mordisco de las masas
+    if (nacimiento.current) {
+      const s = 0.85 + Math.sin(t * 6.1 + 1.2) * 0.16;
+      nacimiento.current.scale.set(s, 1 + Math.sin(t * 8.3) * 0.1, s);
     }
   });
   return (
@@ -1397,6 +1460,48 @@ function CanalGuarapo({ reducedMotion }) {
           </mesh>
         ))}
       </group>
+      {/* EL NACIMIENTO: el jugo cae de la salida del molino a la cabeza de la
+          canoa — sin este chorrito la canoa arrancaba llena de la nada y el
+          recorrido molino → canoa no se leía */}
+      <group position={[1.88, 0, 0]}>
+        <mesh ref={nacimiento} position={[0, 0.3, 0]}>
+          <cylinderGeometry args={[0.028, 0.042, 0.38, 5]} />
+          <meshLambertMaterial color={mezclar(P.guarapo, '#f0c86a', 0.45)} flatShading />
+        </mesh>
+        {/* el salpique donde el chorro toca la canoa */}
+        <mesh position={[0, 0.1, 0]} scale={[1, 0.4, 1]}>
+          <sphereGeometry args={[0.055, 6, 4]} />
+          <meshLambertMaterial color={P.espuma} flatShading />
+        </mesh>
+      </group>
+      {/* LA ESPUMA del jugo que corre: motas claras que viajan con la corriente */}
+      <group ref={espuma}>
+        {motas.espuma.map((d, i) => (
+          <mesh
+            key={i}
+            position={[1.7 - d.fase * 3.45, 0.095, d.z]}
+            scale={[d.esc, d.esc * 0.5, d.esc]}
+          >
+            <sphereGeometry args={[0.032, 5, 4]} />
+            <meshLambertMaterial color={P.espuma} flatShading />
+          </mesh>
+        ))}
+      </group>
+      {/* LA CACHAZA: los cuajarones verdosos de bagacillo y tierra que bajan
+          flotando — la impureza que el campesino reconoce y que el cucharón
+          retirará en la paila */}
+      <group ref={cachaza}>
+        {motas.cachaza.map((d, i) => (
+          <mesh
+            key={i}
+            position={[1.6 - d.fase * 3.3, 0.092, d.z]}
+            scale={[d.esc, d.esc * 0.42, d.esc]}
+          >
+            <sphereGeometry args={[0.045, 5, 4]} />
+            <meshLambertMaterial color={mezclar(P.cachaza, '#a8a45c', 0.35)} flatShading />
+          </mesh>
+        ))}
+      </group>
       {/* el chorrito que cae del pico de la canoa al recibidor */}
       <group position={[-2.0, -0.12, 0]}>
         <mesh ref={chorro} position={[0, -0.06, 0]}>
@@ -1413,6 +1518,18 @@ function CanalGuarapo({ reducedMotion }) {
           <planeGeometry args={[0.45, 0.36]} />
           <meshLambertMaterial color={P.guarapo} />
         </mesh>
+        {/* la cachaza que llegó flotando se JUNTA aquí, esperando el cucharón */}
+        {[
+          [-0.2, 0.09], [0.02, -0.1], [-0.06, 0.02],
+        ].map((c, i) => (
+          <mesh key={i} position={[c[0], -0.165, c[1]]} scale={[1, 0.4, 1]}>
+            <sphereGeometry args={[0.05 + (i % 2) * 0.015, 5, 4]} />
+            <meshLambertMaterial
+              color={mezclar(P.cachaza, '#a8a45c', 0.25 + i * 0.12)}
+              flatShading
+            />
+          </mesh>
+        ))}
       </group>
       {/* dos horquetas cortas que la sostienen */}
       <mesh position={[-1.3, -0.2, 0]}>

--- a/src/mockups/MundoBoticaCana3D.jsx
+++ b/src/mockups/MundoBoticaCana3D.jsx
@@ -1446,10 +1446,11 @@ function CanalGuarapo({ reducedMotion }) {
         <boxGeometry args={[4.0, 0.14, 0.06]} />
         <meshLambertMaterial color={P.maderaVieja} flatShading />
       </mesh>
-      {/* la cinta de jugo */}
+      {/* la cinta de jugo — aclarada hacia el dorado: con el P.guarapo puro se
+          confundía con la tabla de la canoa y el jugo no se LEÍA líquido */}
       <mesh position={[0, 0.07, 0]}>
-        <boxGeometry args={[3.9, 0.03, 0.16]} />
-        <meshLambertMaterial color={P.guarapo} flatShading />
+        <boxGeometry args={[3.9, 0.03, 0.18]} />
+        <meshLambertMaterial color={mezclar(P.guarapo, '#f0c86a', 0.3)} flatShading />
       </mesh>
       {/* los pulsos de guarapo que BAJAN (el brillo que corre) */}
       <group ref={pulsos}>
@@ -1465,12 +1466,12 @@ function CanalGuarapo({ reducedMotion }) {
           recorrido molino → canoa no se leía */}
       <group position={[1.88, 0, 0]}>
         <mesh ref={nacimiento} position={[0, 0.3, 0]}>
-          <cylinderGeometry args={[0.028, 0.042, 0.38, 5]} />
+          <cylinderGeometry args={[0.05, 0.07, 0.42, 5]} />
           <meshLambertMaterial color={mezclar(P.guarapo, '#f0c86a', 0.45)} flatShading />
         </mesh>
         {/* el salpique donde el chorro toca la canoa */}
-        <mesh position={[0, 0.1, 0]} scale={[1, 0.4, 1]}>
-          <sphereGeometry args={[0.055, 6, 4]} />
+        <mesh position={[0, 0.11, 0]} scale={[1, 0.4, 1]}>
+          <sphereGeometry args={[0.09, 6, 4]} />
           <meshLambertMaterial color={P.espuma} flatShading />
         </mesh>
       </group>
@@ -1479,10 +1480,10 @@ function CanalGuarapo({ reducedMotion }) {
         {motas.espuma.map((d, i) => (
           <mesh
             key={i}
-            position={[1.7 - d.fase * 3.45, 0.095, d.z]}
+            position={[1.7 - d.fase * 3.45, 0.1, d.z]}
             scale={[d.esc, d.esc * 0.5, d.esc]}
           >
-            <sphereGeometry args={[0.032, 5, 4]} />
+            <sphereGeometry args={[0.055, 5, 4]} />
             <meshLambertMaterial color={P.espuma} flatShading />
           </mesh>
         ))}
@@ -1494,10 +1495,10 @@ function CanalGuarapo({ reducedMotion }) {
         {motas.cachaza.map((d, i) => (
           <mesh
             key={i}
-            position={[1.6 - d.fase * 3.3, 0.092, d.z]}
+            position={[1.6 - d.fase * 3.3, 0.098, d.z]}
             scale={[d.esc, d.esc * 0.42, d.esc]}
           >
-            <sphereGeometry args={[0.045, 5, 4]} />
+            <sphereGeometry args={[0.065, 5, 4]} />
             <meshLambertMaterial color={mezclar(P.cachaza, '#a8a45c', 0.35)} flatShading />
           </mesh>
         ))}
@@ -1522,8 +1523,8 @@ function CanalGuarapo({ reducedMotion }) {
         {[
           [-0.2, 0.09], [0.02, -0.1], [-0.06, 0.02],
         ].map((c, i) => (
-          <mesh key={i} position={[c[0], -0.165, c[1]]} scale={[1, 0.4, 1]}>
-            <sphereGeometry args={[0.05 + (i % 2) * 0.015, 5, 4]} />
+          <mesh key={i} position={[c[0], -0.163, c[1]]} scale={[1, 0.4, 1]}>
+            <sphereGeometry args={[0.07 + (i % 2) * 0.018, 5, 4]} />
             <meshLambertMaterial
               color={mezclar(P.cachaza, '#a8a45c', 0.25 + i * 0.12)}
               flatShading


### PR DESCRIPTION
## Qué hace

Dos mejoras **aditivas** al mundo de la botica y el trapiche (`/#/mockups/mundo-botica-cana-3d`). No se rehízo nada de lo que ya estaba bueno (nudos de caña, buey destapado, 7 aromáticas, paso «La botica»).

### F-11 — la molienda muele
El buey ya caminaba su vuelta en `dev` (entró con `865cc066` y se afinó en #2698), pero **la palanca daba vueltas sin mover el molino**. Ahora:
- El **eje** vive dentro del grupo de la vuelta: gira con la palanca.
- Las **tres masas** giran: la mazamorrera 1:1 con la palanca, las laterales engranadas al contrario, como en el trapiche real.
- El buey se **echa al yugo**: inclinación de esfuerzo sumada al squash/cabeceo/rabo que ya traía.
- `reducedMotion`: pose quieta intacta (la de F-10, el gate captura igual que antes).

### F-13 — el guarapo corre y se le ve la cachaza
La canoa ya traía pulsos y chorrito, pero se leía seca: la cinta se confundía con la tabla y no había impureza flotando. Ahora:
- **Nacimiento del jugo**: chorro dorado del molino a la cabeza de la canoa, con salpique — se lee molino → canoa.
- **Espuma** clara que viaja con la corriente (6 motas deterministas).
- **Cachaza** verdosa que baja más despacio (pesa más) y se **junta en el recibidor** esperando el cucharón — el recorrido canoa → paila cierra.
- Todo visible también en pose quieta: las motas quedan repartidas a lo largo.

## Verificación (GPU real, `scripts/gate-real-gpu.mjs`)

- Renderer verificado en cada captura: `ANGLE (AMD Radeon Vega 10 … radeonsi raven ACO)` — **no** SwiftShader. Puerto y carpeta por corrida.
- **Antes/después** en pose quieta con los botones `2. El molino` y `3. El jugo`: en el después aparecen el chorro del nacimiento, la espuma y la cachaza sobre la lámina dorada.
- **Movimiento probado con series multi-frame** (variante del gate con las mismas guardas — GPU real, puerto propio, aborta en SwiftShader — pero sin `prefers-reduced-motion` y 6 frames cada 4,2 s):
  - Paso 2: en f2 el buey está a la **izquierda** del molino con la palanca hacia él; en f6 ya dio la vuelta y asoma por la **derecha** con la palanca girada. Camina el círculo y mueve la palanca.
  - Paso 3: espuma, cachaza y pulsos en posiciones distintas en cada frame — el guarapo baja por la canoa.
  - Primera pasada (motas r 0.032–0.045) resultó sub-pixel a la distancia del recorrido; se agrandaron y se re-verificó (`3a9771d0`).
- Build verde (`vite build`) y 6/6 tests de `src/mockups/__tests__/mundoBoticaCana3D.test.jsx` en los dos commits.

Capturas de evidencia en stg: `/tmp/claude-1000/-home-kortux-workspace/6d0b524d-4356-4e95-a4dc-4f829122c883/scratchpad/` (`gate-antes/`, `gate-despues2/`, `gate-mov2/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)