### PR TITLE
fix(lecheria): piso de luz legible de noche en el mundo de la lechería

### DIFF
--- a/src/visual/mundo3d/lecheria/EscenaLecheriaViva.jsx
+++ b/src/visual/mundo3d/lecheria/EscenaLecheriaViva.jsx
@@ -748,6 +748,10 @@ function Diorama({ tier, reducedMotion, foco }) {
   const controls = useRef(null);
   const gY = (p) => /** @type {[number, number, number]} */ ([p[0], alturaPotrero(p[0], p[1]), p[1]]);
 
+  /* Cuánta luz le FALTA a la hora para que la lección se lea (la noche y el
+     atardecer bajan `atm.intensidad`; a mediodía esto es ~0). */
+  const refuerzo = Math.max(0, 1 - atm.intensidad);
+
   return (
     <>
       <AtmosferaMundo
@@ -759,6 +763,26 @@ function Diorama({ tier, reducedMotion, foco }) {
         sombra={SOMBRA_LECHERIA}
       />
       <DomoCielo atm={atm} radio={70} />
+
+      {/* EL PISO DE LECTURA de la lechería (mismo remedio del cafetal #2707 y
+          el aguacatal #2709): de noche la quesera, el biodigestor y el montón
+          de abono caían a bulto negro y la lección de cuatro pasos se perdía.
+          Dos luces locales de la escena (no tocan el kit): un relleno
+          hemisférico cálido que COMPENSA lo que la hora apaga (de noche sube,
+          a mediodía casi no suma) y una clave dorada fija SIN sombras — deja
+          ver la cantina, el queso y la bolsa de gas sin tocar el dibujo de la
+          sombra proyectada. El domo y la niebla siguen contando la hora: la
+          noche se conserva noche, pero la cadena láctea se LEE. */}
+      <hemisphereLight
+        color="#f2e6c8"
+        groundColor="#3d4a2a"
+        intensity={0.38 + 1.15 * refuerzo}
+      />
+      <directionalLight
+        position={[7, 10, 5]}
+        color="#ffe9c0"
+        intensity={0.5 + 0.95 * refuerzo}
+      />
 
       {/* EL POTRERO por bandas toon (recibe la sombra del banco forrajero). */}
       <mesh geometry={geoPotrero} receiveShadow={perfil.sombras}>


### PR DESCRIPTION
## Qué

El mismo remedio del cafetal (#2707) y el aguacatal (#2709) para el tercer mundo de la familia `-vivo-3d` con el mismo mal: de noche la lección de la cadena láctea (potrero → quesera → biodigestor → ciclo) caía a penumbra. Las vacas se veían a medias, pero el montón de abono era una silueta negra y el biodigestor tubular apenas se adivinaba.

**Piso de lectura local de la escena** (no toca el kit): hemisférica cálida + clave dorada fija sin sombras, moduladas por `refuerzo = max(0, 1 − atm.intensidad)` — a mediodía suman ~0, de noche levantan la penumbra. El domo nocturno y la niebla siguen contando la hora: la noche se conserva noche, pero la cadena láctea se LEE.

No hizo falta agrandar ni avivar ningún elemento: los materiales de la quesera y el biodigestor ya son claros (zinc, cal, madera, polietileno) — con luz se recuperan solos.

## Verificación (GPU real, Radeon Vega — no SwiftShader)

- **Noche (`?ciclo=22`)**: antes, el abono y el biodigestor eran bultos negros; después, el hato, el bebedero, el montón de abono café y el tubo del biodigestor se leen completos. Cielo nocturno con estrellas intacto.
- **Día (`?ciclo=12`)**: antes/después prácticamente idénticos — no se lava.
- Juez visual local `triar-capturas` 2/2 PASA con «potrero con vacas, bebedero, abono café y biodigestor tubular claro, todos legibles».
- Build verde y lefthook completo en verde (eslint, voseo, secret-scan).
- Antes/después lado a lado capturado en stg (scratchpad de la sesión: `lecheria-antes-despues.png`).
- Nota del gate: el override de hora va ANTES del hash (`/%3Fciclo%3D22#/mockups/lecheria-viva-3d`) — con el query dentro del hash el router no matchea la ruta del mockup y el gate fotografía el valle.

NO mergear: queda para review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)