### PR TITLE
fix(papa): piso de luz legible + cosecha criolla visible en el mundo de la papa

### DIFF
--- a/src/visual/mundo3d/papa/EscenaPapaVivo.jsx
+++ b/src/visual/mundo3d/papa/EscenaPapaVivo.jsx
@@ -304,6 +304,10 @@ function Diorama({ tier, reducedMotion, foco }) {
   const casaY = alturaLadera(SITIO_CASA[0], SITIO_CASA[1]);
   const cosechaY = alturaLadera(SITIO_COSECHA[0], SITIO_COSECHA[1]);
 
+  /* Cuánta luz le FALTA a la hora para que el cultivo se lea (la noche y el
+     atardecer bajan `atm.intensidad`; a mediodía esto es ~0). */
+  const refuerzo = Math.max(0, 1 - atm.intensidad);
+
   return (
     <>
       {/* LA ATMÓSFERA DEL KIT: fondo, luces y estrellas de LA HORA DEL VALLE
@@ -318,6 +322,26 @@ function Diorama({ tier, reducedMotion, foco }) {
         conNiebla={false}
         sombra={SOMBRA_PAPAL}
       />
+      {/* EL PISO DE LECTURA del papal (mismo remedio del cafetal #2707, el
+          aguacatal #2709 y la lechería #2712): de noche los caballones de
+          tierra negra y las matas aporcadas caían a bulto negro y el lote no
+          se leía. Dos luces locales de la escena (no tocan el kit): un relleno
+          hemisférico cálido que COMPENSA lo que la hora apaga (de noche sube,
+          a mediodía casi no suma) y una clave dorada fija SIN sombras — deja
+          ver el surco, la flor lila y la cosecha destapada sin tocar el dibujo
+          de la sombra proyectada. El domo, las estrellas y la bruma siguen
+          contando la hora: la noche se conserva noche, pero el papal se LEE. */}
+      <hemisphereLight
+        color="#f2e6c8"
+        groundColor="#453d2a"
+        intensity={0.38 + 1.15 * refuerzo}
+      />
+      <directionalLight
+        position={[7, 10, 5]}
+        color="#ffe9c0"
+        intensity={0.5 + 0.95 * refuerzo}
+      />
+
       {/* La bruma lechosa de la toma A: cerca y espesa — se come los cerros. */}
       {perfil.fog && <fog attach="fog" args={[nieblaFria, 14, 46]} />}
       {/* La luz FRÍA de la altura: un relleno plata desde arriba que platea

--- a/src/visual/mundo3d/papa/floraPapa.geom.js
+++ b/src/visual/mundo3d/papa/floraPapa.geom.js
@@ -81,7 +81,12 @@ export function curvaSurco(wx, fila) {
 
 /* El lote sembrado (dónde hay caballones) y los claros que el lote respeta. */
 export const SITIO_CASA = /** @type {[number, number]} */ ([-11.5, -13.2]);
-export const SITIO_COSECHA = /** @type {[number, number]} */ ([6.8, 4.6]);
+/* El claro de la COSECHA va EN EL ENCUADRE de la llegada: antes vivía en
+   [6.8, 4.6], ~24° a la derecha del eje de la cámara de reposo — la copy
+   prometía "la cosecha destapada" y la foto no la mostraba NUNCA. Aquí queda
+   centro-derecha abajo, con las filas delanteras despejadas por la propia
+   máscara del claro (dentroLote), y las papas criollas se leen de entrada. */
+export const SITIO_COSECHA = /** @type {[number, number]} */ ([3.2, 1.2]);
 
 /** Máscara 0…1 del lote sembrado (dentro hay caballones; fuera, pajonal). */
 export function dentroLote(wx, wz) {

--- a/src/visual/mundo3d/papa/floraPapa.geom.js
+++ b/src/visual/mundo3d/papa/floraPapa.geom.js
@@ -136,9 +136,9 @@ export function alturaLadera(wx, wz) {
  * la papa el de tubérculos destapados en el rincón de cosecha.
  */
 export const FLORA_PAPA = {
-  alto: { mata: 130, flor: 300, papa: 44, paja: 90, frailejon: 9, monticulo: 3, piedra: 7 },
-  medio: { mata: 78, flor: 160, papa: 26, paja: 52, frailejon: 5, monticulo: 2, piedra: 4 },
-  bajo: { mata: 36, flor: 66, papa: 12, paja: 24, frailejon: 3, monticulo: 1, piedra: 2 },
+  alto: { mata: 130, flor: 300, papa: 84, paja: 90, frailejon: 9, monticulo: 3, piedra: 7 },
+  medio: { mata: 78, flor: 160, papa: 48, paja: 52, frailejon: 5, monticulo: 2, piedra: 4 },
+  bajo: { mata: 36, flor: 66, papa: 22, paja: 24, frailejon: 3, monticulo: 1, piedra: 2 },
 };
 
 /** Conteos para un tier (desconocido → frugal, nunca el más caro). */
@@ -164,11 +164,14 @@ export const PAL = {
   florLila2: '#9a72c4',
   florBlanca: '#f3eef8',
 
-  // El tubérculo va POR INSTANCIA (referencia): la diversidad andina
-  papaCriolla: '#e5b93c', // la amarilla, la reina
-  papaCriolla2: '#d4a52f',
-  papaRoja: '#a4503a', // la pastusa roja
-  papaMorada: '#5c3a66', // la morada andina
+  // El tubérculo va POR INSTANCIA (referencia): la diversidad andina.
+  // Subidos de valor a propósito (receta del cafetal #2707): sobre tierra
+  // negra el tubérculo tiene que GRITAR — la morada original ('#5c3a66')
+  // leía NEGRO en penumbra y borraba la lección de las tres variedades.
+  papaCriolla: '#f2c440', // la amarilla, la reina
+  papaCriolla2: '#e0ad2e',
+  papaRoja: '#c25538', // la pastusa roja
+  papaMorada: '#7d5290', // la morada andina
 
   // Pajonal (los macollos del frío)
   paja: '#b3a95e',
@@ -333,7 +336,11 @@ export function geomFlorPapa() {
 
 /** El tubérculo: bolita apenas ovalada, blanca — el color va POR INSTANCIA. */
 export function geomPapa() {
-  const g = new THREE.IcosahedronGeometry(0.085, 1);
+  /* Radio EXAGERADO adrede (rubber-hose, receta de la cereza del café #2707):
+     la criolla real cabe en la mano, pero a los ~12 m de la cámara eso son
+     unos pocos px — invisible. La cuenta gorda es la que deja LEER la
+     diversidad amarilla/roja/morada en el claro desde la entrada. */
+  const g = new THREE.IcosahedronGeometry(0.125, 1);
   poner(g, [0, 0, 0], [0, 0, 0.35], [1.25, 0.85, 0.95]);
   return pintar(g.index ? g.toNonIndexed() : g, '#ffffff');
 }
@@ -535,16 +542,17 @@ export function distribucionPapal(conteos, seed = 419) {
     const rad = Math.sqrt(rSue()) * 2.1;
     const x = SITIO_COSECHA[0] + Math.cos(a) * rad;
     const z = SITIO_COSECHA[1] + Math.sin(a) * rad * 0.8;
-    // la mayoría criolla amarilla; unas rojas y unas moradas (variedades)
+    // la mayoría criolla amarilla; rojas y moradas en cuota que SE VEA (la
+    // lección son las TRES variedades — con 14% la morada se perdía)
     const v = rSue();
-    if (v > 0.86) col.copy(morada);
-    else if (v > 0.7) col.copy(roja);
+    if (v > 0.8) col.copy(morada);
+    else if (v > 0.6) col.copy(roja);
     else col.lerpColors(criolla, criolla2, rSue());
-    col.multiplyScalar(0.92 + rSue() * 0.16);
+    col.multiplyScalar(0.98 + rSue() * 0.1);
     papa.push({
-      pos: [x, alturaLadera(x, z) + 0.06, z],
+      pos: [x, alturaLadera(x, z) + 0.08, z],
       rotY: rSue() * Math.PI * 2,
-      escala: 0.8 + rSue() * 0.55,
+      escala: 1.0 + rSue() * 0.55,
       tint: [col.r, col.g, col.b],
     });
   }


### PR DESCRIPTION
Mismo mal y mismo remedio que el cafetal (#2707), el aguacatal (#2709) y la lechería (#2712). Ruta: `/#/mockups/papa-viva-3d`.

## Los dos problemas (verificados con captura en GPU real)

1. **Arrancaba en penumbra**: la escena hereda la franja horaria del valle y de noche (`intensidad` ≈ 0.55) los caballones de tierra negra y las matas aporcadas caían a bulto negro — el lote no se leía.
2. **La cosecha destapada no se veía NUNCA**: la copy promete «criolla amarilla, roja y morada», pero `SITIO_COSECHA` vivía en `[6.8, 4.6]` — ~24° a la derecha del eje de la cámara de reposo, FUERA del encuadre de la llegada. Y aun girando, el tubérculo medía 0.085 de radio (pocos px a ~12 m) y la morada `#5c3a66` leía negra en penumbra.

## El arreglo (aditivo, sin tocar el kit compartido)

**Luz** (`EscenaPapaVivo.jsx`): piso de lectura local — hemisférica cálida que compensa lo que la hora apaga (`refuerzo = max(0, 1 − atm.intensidad)`; a mediodía suma ~0) más una clave dorada fija SIN sombras. El domo, las estrellas y la bruma de la toma A siguen contando la hora: la noche se conserva noche, pero el papal se lee.

**Cosecha** (`floraPapa.geom.js`):
- `SITIO_COSECHA` `[6.8, 4.6]` → `[3.2, 1.2]`: el claro entra al encuadre centro-derecha abajo; las filas delanteras las despeja la propia máscara `dentroLote`. Todo deriva de la misma constante (pintura del terreno, montículos, rincón, focos de la lección) y se mueve junto.
- Tubérculo 47 % más gordo (radio 0.085 → 0.125) y escala de instancia subida — exageración rubber-hose a propósito, la misma de la cereza del café.
- Colores de variedad subidos de valor: amarilla `#f2c440`, roja `#c25538`, morada `#7d5290` (la original leía negra). Cuota de rojas y moradas 20 %+20 % para que las TRES se distingan — es la lección.
- Conteos 44→84 / 26→48 / 12→22 por tier (instanciado: una draw-call igual).

## Verificación (GPU real, Radeon Vega — no SwiftShader, `gate-real-gpu.mjs`)

- **Mediodía (`?ciclo=12`)** y **noche (`?ciclo=22`)** capturados; el query percent-encodeado ANTES del hash como manda el gate.
- Juez visual local `triar-capturas`: día PASA con «un papal con papas de colores visibles en la cosecha, bien iluminado»; noche PASA con «un papal nocturno legible con la cosecha de papas amarillas, rojas y moradas visible en un claro».
- El cielo nocturno gris-bruma es la identidad previa de la toma A (idéntico al del «antes»: allí lo negro era el SUELO) — no se tocó.
- Build verde (23 s) y eslint limpio en los archivos tocados.
- Antes/después/noche lado a lado capturado en stg (scratchpad de la sesión: `papa-antes-despues.png`).

NO mergear: queda para review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)