### PR TITLE
perf(paramo): instanciar mariposas/abejas del páramo definitivo (−19% draw calls)

### DIFF
--- a/ops/informes/hermanos-valle-2026-07-23.md
+++ b/ops/informes/hermanos-valle-2026-07-23.md
@@ -1,0 +1,154 @@
+# Instanciar el hermano más pesado del valle (PERF-HERMANOS-VALLE)
+
+**Fecha:** 2026-07-23 · **Rama:** `perf/hermanos-valle-instancing` (desde `dev`
+fresco, commit base `c18fb0da`) · **Sigue a:** `ops/informes/valle-instancing-
+2026-07-23.md` (#2710, instanció `Valle3D.jsx`: 605→404 draw calls, −33%).
+Este trabajo ataca el resto: las escenas hermanas que el valle compone/enlaza.
+
+## Paso 1 — medir, no adivinar
+
+El encargo proponía como candidatos `FaunaBosque.jsx`, `EscenaBosqueVivo.jsx`,
+`EscenaCafetalVivo.jsx`, `floraCafetal.geom.js`, `floraParamo.geom.js`. Antes
+de tocar nada se auditó qué compone REALMENTE `Valle3D.jsx` (la ruta
+`entrada-3d`): importa sus PROPIOS componentes (`BosqueDensoValle.jsx`,
+`CafetalDensoValle.jsx`, `ParamoDensoValle.jsx`, `LaderaAltaValle.jsx`,
+`HatoMovil.jsx`, `ArrieriaValle.jsx`, `CampesinosValle.jsx`,
+`AguaVivaValle.jsx`, `DetalleSueloValle.jsx`, `composicionValle3D.jsx`) — NO
+los mundos standalone que sugería el encargo. Revisando esos archivos
+(comentarios propios + grep de `<Instances>`/`instancedMesh`/`Banco`) resultó
+que **ya estaban todos instanciados** por el trabajo previo (#2710 y el commit
+base de `Valle3D.jsx`): bancos por especie×banda-LOD (`Banco`/`BancoInstancias`,
+~39-54 draw calls combinados entre los cuatro), ovejas/gallinas en
+`InstancedMesh` en `HatoMovil`, pórticos/patios en `<Instances>` en
+`composicionValle3D`. Los candidatos del encargo eran una buena hipótesis pero
+**no correspondían a lo que el valle realmente monta** — exactamente el motivo
+por el que el encargo pedía medir en vez de adivinar.
+
+Se midieron entonces los MUNDOS HERMANOS de verdad — las rutas standalone a
+las que el valle lleva (portales/ventanas) y que comparten arquetipos con el
+valle — con `scripts/medir-fps-mundos.mjs` (`--rates 1 --window 12000 --settle
+6000`, GPU real `ANGLE (AMD Radeon Vega 10)`, nunca SwiftShader). Nota: la ruta
+legacy `mundo-paramo-3d` que sugería el encargo está ARCHIVADA desde
+2026-07-22 (reemplazada por `paramo-definitivo`, ver comentario en el propio
+script de medición); se usó su reemplazo vivo.
+
+| Mundo hermano | Ruta | Draw calls | Triángulos |
+|---|---|---:|---:|
+| Valle (referencia, ya instanciado en #2710) | `mockups/entrada-3d` | 388 | 960.543 |
+| **Páramo definitivo** | `mockups/paramo-definitivo` | **158** | 541.303 |
+| `[legacy] Mundo3D bosque` | `mockups/mundo3d-bosque` | 66 | 1.558 |
+| Cafetal vivo 3D | `mockups/cafetal-vivo-3d` | 49 | 277.802 |
+
+**El páramo definitivo (`EscenaBosqueVivo.jsx`, montado por
+`MundoEntBosque.jsx` en la ruta `paramo-definitivo`) es el hermano más
+pesado por lejos**: 3.2× los draw calls del cafetal y 2.4× los del bosque
+legacy, con 541k triángulos (más de la mitad de los del propio valle).
+
+## Paso 2 — instanciar el más pesado
+
+Dentro de `EscenaBosqueVivo.jsx`, casi todo el terreno/vegetación/estructura
+YA estaba instanciado (`Quenual`, `Hojarasca`, `CentroParamo`, `Penas`, todos
+con `Banco`/`Instancias`). El contribuyente sin instanciar más grande vive en
+`FaunaBosque.jsx` (que `EscenaBosqueVivo` monta): `MariposasDelParamo` — 8
+mariposas en tier alto, cada una con 2 alas + 1 cuerpo como `<mesh>` sueltos
+= hasta **24 draw calls**, SIEMPRE visibles (no gateadas por evento raro como
+`BandadaDeAves`). De paso se instanció también `AbejasDelFrailejonar` (3
+`<mesh>` sueltos → 1 `InstancedMesh`, ganancia menor pero gratis).
+
+### El fix
+
+- `MariposasDelParamo`: 3 `InstancedMesh` totales (ala-izquierda,
+  ala-derecha, cuerpo) en vez de 24 `<mesh>`. El offset/rotación/flip local
+  del ala (antes en un `<group scale={[lado,1,1]}><mesh position={[0.11,0,0]}
+  rotation={[-Math.PI/2,0,0]}>` anidado) queda HORNEADO en la geometría
+  (`geomAla()`, verificado a mano: `rotateX→translate→scale` en ese orden
+  replica exactamente la composición T·R·S de los Object3D anidados). Lo
+  único dinámico por frame es la matriz del cuerpo (posición/yaw/banqueo/
+  escala) compuesta con el aleteo (rotación Z), vía `Matrix4.compose` +
+  `multiply` — mismo patrón que `HatoMovil` usa para oveja/gallina. Color por
+  instancia (cada mariposa tiene su propio color) vía `setColorAt`.
+- `AbejasDelFrailejonar`: 3 `<mesh>` → 1 `InstancedMesh` (solo posición
+  cambia, mismo color para las tres).
+- **Sin `frames={1}`**: a diferencia del bug de #2710 (contenido QUIETO
+  recalculado de más), aquí el contenido SÍ se mueve cada frame — no aplica.
+
+### El bug que casi se aprueba a ciegas: `vertexColors` sin atributo de color
+
+Primera versión traía `vertexColors: true` en el material del ala (copiado
+del patrón de `Banco`/`BancoInstancias`, que SÍ lo necesitan porque sus
+geometrías —frailejón, roble— vienen con sombreado horneado por vértice de
+verdad). Pero `PlaneGeometry` no tiene atributo `color`: three.js activa
+`USE_COLOR` igual (`material.vertexColors` se lee directo, sin comprobar si
+la geometría tiene el atributo — verificado en
+`node_modules/three/src/renderers/webgl/WebGLPrograms.js:296`), WebGL lee el
+atributo faltante como `(0,0,0)`, y `vColor *= color` deja el ala EN NEGRO
+antes de multiplicar por el tinte de instancia — el color de instancia
+quedaba bien pintado pero invisible. Se encontró SOLO por verificación visual
+dirigida (ver abajo); las mediciones de draw-calls/triángulos no lo habrían
+detectado (no cambian). Fix: quitar `vertexColors` del material del ala — el
+tinte por instancia lo pone `USE_INSTANCING_COLOR`, que no depende de ese
+flag.
+
+## Medición (antes/después, pares espalda-con-espalda)
+
+```bash
+npm run build
+node scripts/medir-fps-mundos.mjs --routes mockups/paramo-definitivo --rates 1 --window 12000 --settle 6000
+```
+
+| Condición | Corrida 1 | Corrida 2 | Media |
+|---|---:|---:|---:|
+| Antes — draw calls | 162 | 160 | **161** |
+| Antes — triángulos | 541.337 | 541.334 | 541.336 |
+| Después — draw calls | 131 | 129 | **130** |
+| Después — triángulos | 541.382 | 541.393 | 541.388 |
+
+**Draw calls: 161 → 130 (−31, −19,3%).** Triángulos prácticamente idénticos
+(diferencia <0,01%, dentro del ruido de otras piezas condicionales del
+frame — `BandadaDeAves`, `Stars` — no del instanciado): la prueba de que
+esto es el mismo dibujo, con menos llamadas a la GPU. `entrada-3d` (el valle)
+se re-midió de paso para confirmar que `Valle3D.jsx` no se tocó: sigue en el
+mismo rango (351-388) que reportó #2710, la variación es ruido de
+franja/clima entre corridas, no una regresión.
+
+## Verificación visual
+
+GPU real (`ANGLE (AMD Radeon Vega 10 Graphics)`, nunca SwiftShader) en ambos
+lados. `scripts/gate-real-gpu.mjs` usa `reducedMotion:'reduce'`, que
+DESMONTA `MariposasDelParamo`/`AbejasDelFrailejonar` (gateadas a
+`!reducedMotion`) — no sirve para verificar ESTE cambio en particular. Se
+usó una copia ad hoc del mismo patrón (misma guarda GPU-real, mismo puerto
+por corrida) con `reducedMotion:'no-preference'`, y además una verificación
+dirigida: un hook de auditoría TEMPORAL (mismo patrón que
+`AuditoriaValle.jsx` del valle, dormido salvo `?debugparamo=1`, retirado
+antes de este commit) que expuso `{gl,scene,camera}` para teleportar la
+cámara junto a cada mariposa y aislar (ocultando el resto de la escena) los
+`InstancedMesh` de fauna. Confirmado: 8 mariposas con sus 8 colores propios
+(rosa/azul/amarillo/verde… según `MARIPOSAS`), forma de ala en V intacta,
+3 abejas ámbar — mismo layout/colores que la versión sin instanciar,
+capturada en el mismo punto de la órbita (la mariposa Morpho azul aparece en
+el mismo lugar junto a las rocas en ambas capturas de contexto completo).
+
+## Lo que NO se tocó (y por qué)
+
+- **`RayosDeSol`/`BrumaParallax`** (`EscenaBosqueVivo.jsx`, 10 `<mesh>` cada
+  uno, tier alto): candidatos legítimos a instanciar (posiciones estáticas
+  relativas a su grupo padre), pero `BrumaParallax` anima la opacidad POR
+  CAPA de forma independiente con materiales separados — instanciarlo bien
+  pide mover esa animación a un atributo por instancia (más alcance, más
+  riesgo de tocar el comportamiento). Se deja como seguimiento.
+- **`BandadaDeAves`** (6 aves × 3 `<mesh>` = 18 draw calls): evento raro
+  (dura ~10s cada 42-90s, oculto el resto del tiempo — 0 draw calls la
+  mayoría del tiempo). Baja prioridad frente a las mariposas (siempre
+  visibles).
+- **Bosque/Cafetal/Páramo/LaderaAlta** (los archivos que el encargo nombraba
+  como hermanos): ya instanciados, ver Paso 1. Fusionar sus bandas LOD/
+  especies para bajar más los ~39-54 draw calls combinados es el mismo
+  seguimiento que ya señaló el informe de #2710 — no se repite aquí.
+
+## Reproducibilidad
+
+```bash
+npm run build
+node scripts/medir-fps-mundos.mjs --routes mockups/paramo-definitivo,mockups/entrada-3d --rates 1 --window 12000 --settle 6000 --out /tmp/despues.json
+```

--- a/src/visual/mundo3d/bosque/FaunaBosque.jsx
+++ b/src/visual/mundo3d/bosque/FaunaBosque.jsx
@@ -40,7 +40,7 @@
  * son SVG en <Html>. Importa three/@react-three → montar SOLO dentro del
  * <Canvas> del bosque.
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { useFrame } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
@@ -1198,7 +1198,20 @@ function Luciernagas() {
    Revolotean entre los frailejones con rumbo propio (lissajous + fase): nada
    vuela en fila ni bate al unísono. Dos planos por bicha, aleteo de verdad.
    La PRIMERA es la Morpho azul del referente: más grande que todas, la
-   protagonista del primer plano. */
+   protagonista del primer plano.
+   Instanciadas (perf/hermanos-valle-instancing, 2026-07-23): eran 3 <mesh>
+   sueltos por bicha (2 alas + cuerpo) — hasta 24 draw calls en tier alto
+   (8 mariposas), medido como el mayor contribuyente sin instanciar del
+   páramo definitivo (ver ops/informes/hermanos-valle-2026-07-23.md). Ahora
+   son 3 InstancedMesh TOTALES (ala-izq/ala-der/cuerpo) que sirven para las
+   8 a la vez, con el MISMO aleteo/lissajous de siempre: el offset+rotación
+   local del ala (posición 0.11 en X, giro −90° en X, el flip de lado) queda
+   HORNEADO en la geometría (geomAla), así que lo único que cambia por frame
+   es la matriz del cuerpo (posición/yaw/banqueo/escala) compuesta con el
+   aleteo (rotación Z local) vía Matrix4 — mismo patrón que HatoMovil usa
+   para oveja/gallina. Sin `frames={1}`: a diferencia de la vegetación
+   estática del valle, esto SÍ se mueve cada frame (bug documentado en
+   #2710 era al revés: recalcular de más contenido QUIETO). */
 const MARIPOSAS = [
   { color: '#2e7ef0', centro: [2.4, 1.75, 4.4], rx: 1.6, rz: 1.2, v: 0.5, fase: 0.0, esc: 1.7 }, // LA MORPHO
   { color: '#b7a4ff', centro: [-2.0, 1.5, 5.2], rx: 1.3, rz: 1.5, v: 0.62, fase: 2.1 },
@@ -1210,15 +1223,90 @@ const MARIPOSAS = [
   { color: '#4aa3ff', centro: [-0.9, 1.4, 4.2], rx: 1.8, rz: 1.0, v: 0.6, fase: 2.9 },
 ];
 
+/* Geometría del ala, horneada con el MISMO offset/rotación/flip que antes
+   vivía en <group scale={[lado,1,1]}><mesh position={[0.11,0,0]}
+   rotation={[-Math.PI/2,0,0]}>: se rota, LUEGO se traslada (world space del
+   grupo) y por último se aplica el flip de lado — mismo orden T·R·S que
+   componían los Object3D anidados (verificado a mano: BufferGeometry
+   aplica cada llamada al acumulado, así que rotateX→translate→scale replica
+   exactamente scale(translate(rotateX(v)))). El único transform dinámico
+   por frame es el aleteo (rotación Z), que se compone DESPUÉS multiplicando
+   a la derecha de la matriz del cuerpo (mismo efecto que un hijo anidado). */
+function geomAla(lado) {
+  const g = new THREE.PlaneGeometry(0.2, 0.13).rotateX(-Math.PI / 2).translate(0.11, 0, 0);
+  return lado < 0 ? g.scale(-1, 1, 1) : g;
+}
+
 function MariposasDelParamo({ n }) {
-  const cuerpos = useRef([]);
   const bichas = useMemo(() => MARIPOSAS.slice(0, n), [n]);
+  const refAlaIzq = useRef(/** @type {THREE.InstancedMesh|null} */ (null));
+  const refAlaDer = useRef(/** @type {THREE.InstancedMesh|null} */ (null));
+  const refCuerpo = useRef(/** @type {THREE.InstancedMesh|null} */ (null));
+  const geoAlaIzq = useMemo(() => geomAla(1), []);
+  const geoAlaDer = useMemo(() => geomAla(-1), []);
+  const geoCuerpo = useMemo(() => new THREE.CylinderGeometry(0.012, 0.016, 0.14, 4).rotateX(Math.PI / 2), []);
+  // OJO: SIN vertexColors aquí — el color por instancia lo pone
+  // USE_INSTANCING_COLOR (activo solo con mesh.instanceColor, ver setColorAt
+  // abajo), que es independiente del flag `vertexColors`. Con
+  // `vertexColors:true` puesto (bug encontrado en la verificación visual de
+  // esta misma rama), three.js agrega el atributo de color POR VÉRTICE
+  // (USE_COLOR) — que este PlaneGeometry no tiene — y al faltar el atributo
+  // WebGL lo lee como (0,0,0): vColor se multiplica por negro ANTES de
+  // multiplicarlo por el tinte de instancia, y el ala sale negra pese a que
+  // `instanceColor` esté bien pintado. Los materiales de Banco/BancoInstancias
+  // sí llevan vertexColors:true porque SUS geometrías (frailejón, roble…)
+  // vienen con sombreado horneado por vértice de verdad — no es el mismo caso.
+  const matAla = useMemo(
+    () => new THREE.MeshBasicMaterial({
+      color: '#ffffff', side: THREE.DoubleSide, transparent: true, opacity: 0.92,
+    }),
+    [],
+  );
+  const matCuerpo = useMemo(() => new THREE.MeshBasicMaterial({ color: '#3a3428' }), []);
+  // Escrachos reusados: cero alocación por frame/instancia (mismo patrón que
+  // HatoMovil.util.o para oveja/gallina).
+  const util = useMemo(() => ({
+    pos: new THREE.Vector3(),
+    esc: new THREE.Vector3(),
+    euler: new THREE.Euler(0, 0, 0, 'XYZ'),
+    quat: new THREE.Quaternion(),
+    mCuerpo: new THREE.Matrix4(),
+    mFlap: new THREE.Matrix4(),
+    mFinal: new THREE.Matrix4(),
+    col: new THREE.Color(),
+  }), []);
+
+  useLayoutEffect(() => () => {
+    geoAlaIzq.dispose();
+    geoAlaDer.dispose();
+    geoCuerpo.dispose();
+    matAla.dispose();
+    matCuerpo.dispose();
+  }, [geoAlaIzq, geoAlaDer, geoCuerpo, matAla, matCuerpo]);
+
+  // El tinte por bicha (color de ala) no cambia en el tiempo: se pinta una
+  // sola vez, igual que el color por instancia de Banco/BancoInstancias.
+  useLayoutEffect(() => {
+    const pinta = (mesh) => {
+      if (!mesh) return;
+      for (let i = 0; i < bichas.length; i++) mesh.setColorAt(i, util.col.set(bichas[i].color));
+      if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+    };
+    pinta(refAlaIzq.current);
+    pinta(refAlaDer.current);
+  }, [bichas, util]);
+
   useFrame(({ clock }) => {
+    const ai = refAlaIzq.current;
+    const ad = refAlaDer.current;
+    const cu = refCuerpo.current;
+    if (!ai || !ad || !cu) return;
     const t = clock.getElapsedTime();
-    for (let i = 0; i < cuerpos.current.length; i++) {
-      const g = cuerpos.current[i];
+    const {
+      pos, esc, euler, quat, mCuerpo, mFlap, mFinal,
+    } = util;
+    for (let i = 0; i < bichas.length; i++) {
       const m = bichas[i];
-      if (!g || !m) continue;
       const w = t * m.v + m.fase;
       const x = m.centro[0] + Math.sin(w) * m.rx;
       const z = m.centro[2] + Math.sin(w * 1.31 + 1.2) * m.rz;
@@ -1226,53 +1314,61 @@ function MariposasDelParamo({ n }) {
       // El rumbo sale del propio camino (derivada): la bicha mira a donde va.
       const dx = Math.cos(w) * m.rx * m.v;
       const dz = Math.cos(w * 1.31 + 1.2) * m.rz * m.v * 1.31;
-      g.position.set(x, y, z);
-      g.rotation.y = Math.atan2(dx, dz);
+      const yaw = Math.atan2(dx, dz);
       // Banqueo: se ladea en las curvas — vista desde arriba deja de ser
       // un papelito plano y se le ve el cuerpo de bicho.
-      g.rotation.z = Math.sin(w * 0.9) * 0.35;
+      const bank = Math.sin(w * 0.9) * 0.35;
       // Aleteo: cada una a su compás (7.5–10 Hz aprox, fase propia). Las alas
       // pasan más tiempo ARRIBA en V (así se leen mariposa, no confeti).
       const flap = Math.sin(t * (7.5 + i * 0.9) + m.fase) * 0.85 + 0.55;
-      if (g.children[0]) g.children[0].rotation.z = flap;
-      if (g.children[1]) g.children[1].rotation.z = -flap;
+
+      pos.set(x, y, z);
+      euler.set(0, yaw, bank);
+      quat.setFromEuler(euler);
+      esc.setScalar(m.esc ?? 1);
+      mCuerpo.compose(pos, quat, esc);
+
+      mFinal.copy(mCuerpo).multiply(mFlap.makeRotationZ(flap));
+      ai.setMatrixAt(i, mFinal);
+      mFinal.copy(mCuerpo).multiply(mFlap.makeRotationZ(-flap));
+      ad.setMatrixAt(i, mFinal);
+      cu.setMatrixAt(i, mCuerpo);
     }
+    ai.instanceMatrix.needsUpdate = true;
+    ad.instanceMatrix.needsUpdate = true;
+    cu.instanceMatrix.needsUpdate = true;
   });
+
+  if (!bichas.length) return null;
   return (
-    <group>
-      {bichas.map((m, i) => (
-        <group
-          key={i}
-          position={/** @type {[number, number, number]} */ (m.centro)}
-          scale={m.esc ?? 1}
-          ref={(el) => {
-            cuerpos.current[i] = el;
-          }}
-        >
-          {/* Dos alas HORIZONTALES con bisagra en el cuerpo (el grupo rota en
-              z = el ala sube y baja de verdad; el plano vive acostado en XZ y
-              extendido hacia afuera para que el pivote quede en el lomo). */}
-          {[1, -1].map((lado) => (
-            <group key={lado} scale={[lado, 1, 1]}>
-              <mesh position={[0.11, 0, 0]} rotation={[-Math.PI / 2, 0, 0]}>
-                <planeGeometry args={[0.2, 0.13]} />
-                <meshBasicMaterial color={m.color} side={2} transparent opacity={0.92} />
-              </mesh>
-            </group>
-          ))}
-          {/* el cuerpito: la línea oscura entre las alas */}
-          <mesh rotation={[Math.PI / 2, 0, 0]}>
-            <cylinderGeometry args={[0.012, 0.016, 0.14, 4]} />
-            <meshBasicMaterial color="#3a3428" />
-          </mesh>
-        </group>
-      ))}
-    </group>
+    <>
+      <instancedMesh
+        key={`ala-izq-${bichas.length}`}
+        ref={refAlaIzq}
+        args={[geoAlaIzq, matAla, bichas.length]}
+        frustumCulled={false}
+      />
+      <instancedMesh
+        key={`ala-der-${bichas.length}`}
+        ref={refAlaDer}
+        args={[geoAlaDer, matAla, bichas.length]}
+        frustumCulled={false}
+      />
+      <instancedMesh
+        key={`cuerpo-mariposa-${bichas.length}`}
+        ref={refCuerpo}
+        args={[geoCuerpo, matCuerpo, bichas.length]}
+        frustumCulled={false}
+      />
+    </>
   );
 }
 
 /* ── LAS ABEJAS DEL FRAILEJONAR — el zumbido del primer plano ────────────
-   Tres puntos ámbar orbitando las flores, cada uno a su velocidad. */
+   Tres puntos ámbar orbitando las flores, cada uno a su velocidad.
+   Instanciadas (mismo barrido de perf/hermanos-valle-instancing): 3 <mesh>
+   sueltos → 1 InstancedMesh (solo posición cambia por frame, mismo color
+   para las tres — no hace falta instanceColor). */
 const ABEJAS = [
   { anclaje: [2.9, 1.05, 4.7], r: 0.34, v: 2.6, fase: 0 },
   { anclaje: [3.3, 0.9, 4.3], r: 0.28, v: 3.4, fase: 2.4 },
@@ -1280,37 +1376,33 @@ const ABEJAS = [
 ];
 
 function AbejasDelFrailejonar() {
-  const puntos = useRef([]);
+  const ref = useRef(/** @type {THREE.InstancedMesh|null} */ (null));
+  const geo = useMemo(() => new THREE.SphereGeometry(0.038, 6, 5), []);
+  const mat = useMemo(() => new THREE.MeshBasicMaterial({ color: '#e8b13a' }), []);
+  const util = useMemo(() => ({ m: new THREE.Matrix4(), pos: new THREE.Vector3() }), []);
+  useLayoutEffect(() => () => {
+    geo.dispose();
+    mat.dispose();
+  }, [geo, mat]);
   useFrame(({ clock }) => {
+    const mesh = ref.current;
+    if (!mesh) return;
     const t = clock.getElapsedTime();
+    const { m, pos } = util;
     for (let i = 0; i < ABEJAS.length; i++) {
-      const p = puntos.current[i];
       const b = ABEJAS[i];
-      if (!p) continue;
       const w = t * b.v + b.fase;
-      p.position.set(
+      pos.set(
         b.anclaje[0] + Math.cos(w) * b.r,
         b.anclaje[1] + Math.sin(t * 3.1 + b.fase) * 0.09,
         b.anclaje[2] + Math.sin(w) * b.r,
       );
+      m.makeTranslation(pos.x, pos.y, pos.z);
+      mesh.setMatrixAt(i, m);
     }
+    mesh.instanceMatrix.needsUpdate = true;
   });
-  return (
-    <group>
-      {ABEJAS.map((b, i) => (
-        <mesh
-          key={i}
-          position={/** @type {[number, number, number]} */ (b.anclaje)}
-          ref={(el) => {
-            puntos.current[i] = el;
-          }}
-        >
-          <sphereGeometry args={[0.038, 6, 5]} />
-          <meshBasicMaterial color="#e8b13a" />
-        </mesh>
-      ))}
-    </group>
-  );
+  return <instancedMesh ref={ref} args={[geo, mat, ABEJAS.length]} frustumCulled={false} />;
 }
 
 /**


### PR DESCRIPTION
## Resumen
- Continuación medida de #2710 (instanciado de `Valle3D.jsx`, −33% draw calls). Se midió con `medir-fps-mundos.mjs` cuál de los mundos hermanos que el valle compone/enlaza pesa más SIN instanciar: el **páramo definitivo** (`EscenaBosqueVivo.jsx`, ruta `paramo-definitivo`) resultó el más pesado por lejos — 158 draw calls / 541k triángulos, 3.2× el cafetal.
- Los archivos que el encargo original señalaba como "hermanos" (`BosqueDensoValle`/`CafetalDensoValle`/`ParamoDensoValle`/`LaderaAltaValle`, los que Valle3D compone de verdad) ya estaban instanciados por trabajo previo — se documenta en el informe por qué esa hipótesis inicial no correspondía a lo que el valle realmente monta.
- Dentro del páramo definitivo, `MariposasDelParamo` (8 bichas × 3 `<mesh>` = hasta 24 draw calls, SIEMPRE visibles) y `AbejasDelFrailejonar` (3 `<mesh>`) pasan a `InstancedMesh` — mismo patrón que `HatoMovil` usa para oveja/gallina (matriz compuesta por frame, sin `frames={1}` porque esto SÍ se mueve cada frame).
- Bug encontrado en la verificación visual (no en las métricas de draw-calls): `vertexColors:true` copiado del patrón de `Banco` multiplicaba por un atributo de color que `PlaneGeometry` no tiene, dejando el ala NEGRA pese al tinte de instancia correcto. Corregido (documentado en el código y el informe).

## Medición (pares espalda-con-espalda, GPU real AMD Vega, nunca SwiftShader)
| | Draw calls | Triángulos |
|---|---:|---:|
| Antes | 161 (media de 162/160) | 541.336 |
| Después | 130 (media de 131/129) | 541.388 |

**−31 draw calls (−19,3%), triángulos prácticamente idénticos** (prueba de que es el mismo dibujo, no arte distinto). `entrada-3d` (el valle) se re-midió de paso para confirmar que `Valle3D.jsx` no se tocó.

## Verificación visual
GPU real en ambos lados. Como `gate-real-gpu.mjs` usa `reducedMotion:'reduce'` (que desmonta Mariposas/Abejas, gateadas a `!reducedMotion`), se usó una copia ad hoc del mismo patrón con movimiento activo, más un hook de auditoría temporal (mismo patrón que `AuditoriaValle.jsx` del valle, retirado antes de este commit) para teleportar la cámara junto a cada mariposa y aislar los `InstancedMesh` de fauna. Confirmado: 8 colores propios intactos, forma de ala en V intacta, 3 abejas ámbar — mismo layout que la versión sin instanciar.

Detalle completo, tabla de mundos medidos y lo que NO se tocó (y por qué) en `ops/informes/hermanos-valle-2026-07-23.md`.

## Test plan
- [x] `npm run build` verde
- [x] `npx eslint src/visual/mundo3d/bosque/FaunaBosque.jsx` limpio
- [x] `npx vitest run` sobre los smoke tests de `mundo3d`/`bosque` (85 tests, todos pasan)
- [x] Medición antes/después pareada (2 corridas cada lado)
- [x] Verificación visual con GPU real (AMD Vega, nunca SwiftShader) — color, forma y posición de las 8 mariposas + 3 abejas confirmados
- [ ] Revisión del operador antes de tocar el mundo central (no mergear)

🤖 Generado con [Claude Code](https://claude.com/claude-code)