### PR TITLE
feat(rag): medir cross-encoder reranker (bge-v2-m3/TEI) — degrada, NO cablear

### DIFF
--- a/ops/informes/reranker-medido-2026-07-23.md
+++ b/ops/informes/reranker-medido-2026-07-23.md
@@ -1,0 +1,258 @@
+# Informe — Cross-encoder reranker MEDIDO sobre el RAG de Chagra
+
+**Fecha:** 2026-07-23 · **Autor:** carril RAG/infra · **Rama:** `feat/rag-reranker-medido`
+**DR de referencia:** `Chagra-strategy/ops/DR-RAG-RERANKER-2026-07-10.md`
+**Modelo:** `BAAI/bge-reranker-v2-m3` (cross-encoder 568M, Apache-2.0) servido con TEI.
+**Golden set:** `eval/rag-golden.json` (50 queries campesinas, 1 slug esperado por query).
+
+---
+
+## 0. Veredicto — NO vale la pena (hoy DEGRADA)
+
+Montamos el reranker de verdad, lo medimos sobre el golden set, y **el cross-encoder EMPEORA
+el retrieve**, no lo mejora:
+
+| modo | recall@1 | recall@3 | recall@5 | MRR |
+|---|---|---|---|---|
+| BM25-only | 28.0% | 34.0% | 34.0% | 0.3067 |
+| **Hybrid (nomic)** — baseline | **30.0%** | **42.0%** | **44.0%** | **0.3507** |
+| **Hybrid + rerank (bge-v2-m3)** | **14.0%** | **26.0%** | **36.0%** | **0.2210** |
+
+**Delta híbrido → híbrido+rerank: recall@1 −16 pp · recall@5 −8 pp · MRR −0.1297.**
+
+Gate del DR §3.4 (recall@1 ≥ +8 pp **Y** MRR ≥ +0.05 para encender el flag en prod): **NO PASA**
+— y no por poco: pasa lo contrario, el reranker destruye la señal del híbrido.
+
+**Recomendación:** NO cablear el reranker a producción. El flag `VITE_RAG_RERANK` queda
+documentado (§5) pero **OFF**, y el container de alpha se puede tumbar. El techo de calidad del
+RAG **no** está en re-ordenar el top-k; está en la **granularidad del retrieve** (una razón
+concreta, medida, en §4). Ese es el lever real, no el reranker.
+
+Esto es exactamente el caso que la memoria `ci-green-not-real-value` anticipa: el reranker es
+"obviamente bueno" en la literatura, pero **sobre este corpus y este pipeline la medición dice
+que no**. Medir antes de encender salvó un flag que habría bajado el recall a la mitad.
+
+---
+
+## 1. Qué se montó en alpha
+
+- **Servidor:** TEI (`ghcr.io/huggingface/text-embeddings-inference:cpu-latest`) en podman,
+  container `chagra-reranker-tei`, escuchando en `127.0.0.1:7997` (loopback), backend **Candle CPU**.
+- **Modelo:** `BAAI/bge-reranker-v2-m3` (safetensors, 2 271 071 852 bytes) cargado desde un
+  directorio local (`~/tei-models/bge-reranker-v2-m3` en alpha) con `HF_HUB_OFFLINE=1`.
+- **Endpoint `/rerank` verificado en vivo** (query "gusano del cafe broca" contra 3 textos):
+  devuelve `[{index,score}]` ordenado y **discrimina bien** cuando le das el texto correcto
+  (broca 0.908 · roya 0.132 · maíz 0.00002). El problema NO es el modelo (ver §4).
+
+### 1.1 Bloqueador de GPU (documentar, no se pudo servir en GPU)
+
+La GPU actual de alpha es una **Quadro M6000 (12 GB, compute capability 5.2, Maxwell)**. Las
+imágenes GPU de TEI requieren **sm_75+** (Turing/Ampere/Ada/Hopper) → **la M6000 no arranca en
+GPU con TEI**. El DR asumía la RTX 3090 (Ampere sm_86), que sí está soportada, pero hoy alpha
+está con la M6000 (la 3090 rota entre entrenamiento y servicio, ver memoria
+`gpu-ampere-vs-m3000`).
+
+**Impacto en la medición: NINGUNO.** El recall de un cross-encoder es **determinístico** (mismos
+pesos → mismos scores) en CPU o GPU. Los números de recall de arriba son reales y definitivos.
+Lo único que la CPU NO representa es la **latencia** (§3.3).
+
+**Para producción en GPU** (si algún día valiera la pena, que hoy no): o esperar la ventana de la
+3090 (TEI, plan A del DR), o el plan B `llama.cpp --rerank` con GGUF, que sí compila para Maxwell
+en CUDA 12. Ninguno urge dado el veredicto.
+
+### 1.2 Gotcha de descarga (HF Xet colgaba)
+
+El descargador `hf-hub` de TEI usa el protocolo **Xet** y **se colgaba en el paso de finalización**
+sobre el enlace off-grid de alpha (el `.sync.part` llegaba a tamaño completo pero nunca se
+renombraba al blob; CPU en idle, mtime congelado). `HF_HUB_DISABLE_XET=1` / `HF_XET_DISABLE=1`
+**no** lo evitaron (reconstruía desde una caché Xet local). **Solución que sí funcionó:** bajar
+los archivos con `curl` clásico (con reanudación `-C -` en loop hasta el tamaño exacto) a un
+directorio local y arrancar TEI con `--model-id /model` + `HF_HUB_OFFLINE=1`. Queda anotado para
+la próxima vez que se baje un modelo grande a alpha.
+
+---
+
+## 2. Cómo se midió (bench extendido)
+
+Se extendió `scripts/bench-rag-retrieve.mjs` con un **tercer modo `hybrid+rerank`** (los dos
+existentes, BM25 y híbrido, quedan idénticos):
+
+1. Retrieve híbrido con pool ancho: `retrieve(query, POOL_K=20)` → 20 resultados **colapsados por
+   especie** (mismo `collapseVarieties` de producción).
+2. `POST RERANK_URL/rerank` con `{ query, texts: pool.map(p=>p.text), raw_scores:false, truncate:true }`.
+3. Reordenar el pool por el score del cross-encoder y `slice(TOP_K=5)`.
+4. Recall@1/@3/@5 + MRR sobre el mismo golden set, comparado a nivel de especie
+   (`matchesSpecies`, igual que los otros modos).
+
+Detalles de rigor del bench:
+- **Fail-open:** si TEI no responde 2xx/timeout, se conserva el orden híbrido (fallbacks contados).
+  En esta corrida: **0/50 fallbacks** — TEI respondió todo, el degrade es real, no un artefacto de red.
+- **Métrica de aislamiento (`poolMetrics`):** las **mismas** 50 queries, el **mismo** pool de 20,
+  pero en **orden híbrido** (sin rerank). Aísla el aporte NETO del cross-encoder sobre un conjunto
+  de candidatos idéntico → controla por el efecto de ampliar el pool.
+- **`coverage@20`:** ¿está el esperado dentro del pool de 20? Es el techo que el reranker puede
+  alcanzar (no puede inventar cobertura que el retriever no trajo).
+- La 3ra pasada solo corre si `RERANK_URL/health` responde 200; si no, se salta con aviso (CI sin
+  TEI queda verde). `--no-rerank` la fuerza a saltar.
+- Baseline reproducido **exacto** contra el número conocido (30/42/44/.351), lo que confirma que
+  la extensión no tocó el camino híbrido.
+
+**Cómo correrlo:**
+```
+# túneles a alpha (ollama nomic + TEI) o correr en alpha directo:
+OLLAMA_URL=http://localhost:11500 RERANK_URL=http://localhost:7997 \
+  node scripts/bench-rag-retrieve.mjs --history
+```
+
+---
+
+## 3. Números completos
+
+### 3.1 Aislamiento — el reranker degrada incluso con el pool fijo
+
+| sobre el MISMO pool de 20 | recall@1 | recall@5 | MRR |
+|---|---|---|---|
+| orden híbrido (sin rerank) | 30.0% | 42.0% | 0.3440 |
+| orden reranqueado | 14.0% | 36.0% | 0.2210 |
+
+Con el conjunto de candidatos idéntico, reordenar con el cross-encoder baja MRR de .344 a .221.
+El daño es del reranker, no de haber ampliado el pool.
+
+### 3.2 Anatomía del daño (por query)
+
+- El híbrido tenía el esperado en **#1 en 15/50** queries.
+- El reranker **lo bajó de #1 en 11 de esas 15** (73%). Solo mantuvo 4 en #1.
+- El reranker **promovió** un #1 nuevo (que el híbrido no tenía arriba) en solo **3** queries.
+- En **5** queries el esperado estaba en el pool pero el reranker lo empujó **fuera del top-5**.
+- Neto recall@1: 15/50 (30%) → 7/50 (14%). ✔
+
+Demotions concretas (`hybrid#1 → rerank#N`): G01, G09, G18, G20, G21, G24, G25, G30, G35, G41,
+G45. **Nota amarga:** G21 ("broca en el café") era el caso que el DR §3.3 predecía como *cancha
+del reranker* — y es una de las que MÁS se dañó (de #1 a fuera del top-5).
+
+### 3.3 Latencia (CPU — NO representa producción)
+
+Rerank de 20 pasajes en CPU (Candle fp32, ~5 núcleos): **p50 17.0 s · p95 41.6 s · avg 18.9 s por
+query**. Esto es CPU y es irrelevante como número de producción (el DR estima ~20-50 ms en GPU
+Ampere). No se reporta como métrica de mérito porque la latencia no cambia el veredicto: aunque
+fuera instantánea, **bajar el recall 16 pp no se compra con velocidad**.
+
+---
+
+## 4. Por qué degrada (causa raíz, con traza en vivo)
+
+El endpoint funciona (§1). El bug tampoco: el mapeo `index→score` es correcto y verificado. El
+problema es **de granularidad del pipeline**, y lo diagnostica el propio DR §2.1 sin haberlo
+medido: *"el semántico ordena ESPECIES, no passages"*.
+
+Traza real, query **"gusano del cafe"** (esperado `coffea_arabica`), pool de 20:
+
+```
+HYBRID #1  coffea_arabica     rerank=3.05e-3   text="Café caturra / Castillo / Cenicafé 1"
+...
+RERANK #1  smallanthus_...    rerank=2.75e-2   text="El yacón (Smallanthus sonchifolius...)"
+RERANK #2  foeniculum_vulgare rerank=1.62e-2   text="### Antagonistas (no asociar)..."
+RERANK #5  coffea_arabica     rerank=3.05e-3   text="Café caturra / Castillo / Cenicafé 1"
+```
+
+Lo que pasa:
+1. El híbrido acierta y pone `coffea_arabica` en #1, pero el **texto representativo** de esa
+   especie (el pasaje que `collapseVarieties` conserva, = el de mayor score híbrido) es el
+   fragmento **"Café caturra / Castillo / Cenicafé 1"** — una lista de variedades, **NO** el
+   pasaje sobre la broca/gusano.
+2. El cross-encoder lee `query × "Café caturra / Castillo / Cenicafé 1"` y — **correctamente** —
+   juzga que ese fragmento no habla de gusanos → score 0.003.
+3. Como **nunca ve** el pasaje de plagas del café (no está en el pool a nivel especie), no tiene
+   forma de saber que `coffea_arabica` es la respuesta. Flota especies con introducciones más
+   "descriptivas" (yacón, hinojo) que se parecen marginalmente más a una respuesta, todas con
+   **scores ínfimos** (máximo 0.027: el reranker no encuentra NADA realmente relevante) → reordena
+   ruido y entierra la respuesta correcta.
+
+En resumen: el reranker recibe **un solo pasaje por especie, elegido por OTRO scorer**, y ese
+pasaje suele ser un fragmento léxico corto, no el contenido pertinente. Alimentado con el texto
+equivocado, hace lo correcto (lo descarta) y por eso rompe el ranking. **El cuello de botella es
+el retrieve a nivel especie con embeddings gruesos, no el orden del top-k.**
+
+### 4.1 ¿Y rerank-antes-de-colapsar (contrato del DR §2.3)?
+
+El DR propone reranquear el pool **de pasajes** ancho **antes** de `collapseVarieties` (para que
+el reranker vea TODOS los pasajes de una especie y elija el mejor). Esa variante **no se midió**
+(exige exponer `retrieveInternal` y ~2× el costo CPU). Pero la evidencia sugiere que tampoco es la
+bala de plata: para que ayude, el **pasaje correcto** (el de la broca) tiene que estar en el pool,
+y hoy para "gusano del cafe" el híbrido trae a `coffea_arabica` por un fragmento de variedades, no
+por su pasaje de plagas. El arreglo de fondo es **upstream**: embeddings/chunking a nivel pasaje
+(no un vector por especie) + re-indexar. Un reranker recién tiene sentido **después** de eso.
+
+---
+
+## 5. Contrato de integración (documentado — NO cablear hoy)
+
+Cómo se cablearía en `src/services/ragRetriever.js` (espejo exacto de `embedQuery()`), **dejado
+como registro; con el veredicto actual el flag va OFF y no se construye el camino de prod todavía:**
+
+```js
+// Kill-switch, mismo patrón que isSemanticEnabled(). Default OFF hasta bench verde
+// (que hoy NO existe: el bench dice que degrada).
+export function isRerankEnabled() {
+  const meta = /** @type {any} */ (import.meta);
+  const raw = meta?.env?.VITE_RAG_RERANK;
+  return raw === true || (typeof raw === 'string' && ['1','true','on','yes'].includes(raw.trim().toLowerCase()));
+}
+
+// Nuevo, análogo a embedQuery(): habla con TEI vía nginx /api/rerank/. Fail-open.
+async function rerankPassages(query, passages) {
+  try {
+    const texts = passages.map((p) => p.text);
+    const res = await fetchWithAuthRetry('/api/rerank/rerank', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, texts, raw_scores: false, truncate: true }),
+      signal: AbortSignal.timeout(TOOL_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;                       // fail-open → conserva fusión
+    const scored = await res.json();                // [{index, score}]
+    if (!Array.isArray(scored)) return null;
+    const byIndex = new Map(scored.map((s) => [s.index, s.score]));
+    return passages
+      .map((p, i) => ({ ...p, score: byIndex.get(i) ?? p.score }))
+      .sort((a, b) => b.score - a.score);
+  } catch (_) {
+    return null;                                    // fail-open
+  }
+}
+
+// En retrieve(), pool ancho ANTES de collapseVarieties (contrato DR §2.3):
+let pool = await retrieveInternal(query, Math.max(topK * 6, 24));
+if (isRerankEnabled()) {
+  const reranked = await rerankPassages(query, pool);
+  if (reranked) pool = reranked;                    // fail-open: null ⇒ deja la fusión
+}
+results = collapseVarieties(pool).slice(0, topK);
+```
+
+Más:
+- **nginx:** ruta `/api/rerank/` → `127.0.0.1:7997` con el mismo lockdown CORS + token que
+  `/api/ollama/` y `/api/mcp/agro/`.
+- **Build:** `rag-embeddings.json` NO cambia (el reranker no precomputa nada); solo se añade una
+  llamada runtime.
+- El asset y la lógica actuales quedan **intactos** — este informe no toca producción.
+
+---
+
+## 6. Qué se entrega y qué sigue
+
+**Entregado:**
+- Reranker `bge-reranker-v2-m3` montado y verificado en alpha (TEI, `127.0.0.1:7997`).
+- `scripts/bench-rag-retrieve.mjs` extendido con el modo `hybrid+rerank` + métrica de aislamiento
+  + cobertura + gate del DR §3.4 (commiteado).
+- Medición reproducible sobre el golden set con el veredicto de arriba.
+
+**Recomendación (en orden):**
+1. **NO** encender `VITE_RAG_RERANK`. Dejarlo OFF/no-construido.
+2. Tumbar el container de alpha si se necesita la RAM: `sudo podman rm -f chagra-reranker-tei`
+   (queda el modelo en `~/tei-models/` por si se retoma).
+3. El lever real de calidad del RAG es **el retrieve a nivel pasaje**: re-chunkear + embeddings por
+   pasaje (no un vector por especie) y re-indexar `rag-embeddings.json`. Recién ahí un reranker
+   puede aportar — y habría que **re-medir** con este mismo bench.
+4. Si en el futuro se retoma en GPU: esperar la 3090 (TEI) o `llama.cpp --rerank` (Maxwell), pero
+   solo **después** del punto 3 y con un bench verde de por medio.

--- a/scripts/bench-rag-retrieve.mjs
+++ b/scripts/bench-rag-retrieve.mjs
@@ -2,20 +2,36 @@
 /**
  * bench-rag-retrieve.mjs - benchmark de recall y latencia del retrieve RAG.
  *
- * Corre dos pasadas sobre el mismo golden set:
+ * Corre hasta TRES pasadas sobre el mismo golden set:
  *   1. BM25 only, con /rag-embeddings.json deshabilitado.
  *   2. Hybrid, con /rag-embeddings.json y embeddings de query activos.
+ *   3. Hybrid + cross-encoder rerank (opcional): tras el retrieve híbrido toma
+ *      los top-N (POOL_K) candidatos, los manda al reranker cross-encoder
+ *      (bge-reranker-v2-m3 servido por TEI), reordena por el score del
+ *      cross-encoder y evalúa recall@k sobre el mismo golden set.
  *
  * El benchmark usa el corpus real en public/cycle-content/ y el gold set
  * eval/rag-golden.json. La comparacion de recall no se hardcodea: se calcula
  * en cada corrida a partir de los resultados del retriever.
  *
+ * La 3ra pasada (rerank) es un cross-encoder REAL (query×passage puntuados
+ * conjuntamente), NO el LLM-as-judge de bench-reranker.mjs. Se activa solo si
+ * el endpoint TEI (RERANK_URL/health) responde 200; si no, se salta con aviso
+ * (CI sin TEI queda verde). Ver ops/DR-RAG-RERANKER-2026-07-10.md.
+ *
  * Uso:
  *   node scripts/bench-rag-retrieve.mjs
  *   OLLAMA_URL=http://localhost:11434 node scripts/bench-rag-retrieve.mjs
+ *   RERANK_URL=http://localhost:7997 node scripts/bench-rag-retrieve.mjs   # activa rerank
+ *
+ * Env:
+ *   OLLAMA_URL   default http://localhost:11434 — embedder de query (nomic-embed-text).
+ *   RERANK_URL   default http://localhost:7997  — TEI con bge-reranker-v2-m3 (/rerank).
+ *   RAG_POOL_K   default 20 — tamaño del pool que ve el reranker antes del slice(topK).
  *
  * Opcional:
- *   --history   escribe un record JSONL estandarizado en data/bench-runs/
+ *   --history       escribe un record JSONL estandarizado en data/bench-runs/
+ *   --no-rerank     fuerza a saltar la pasada de rerank aunque TEI responda
  */
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { performance } from 'node:perf_hooks';
@@ -34,6 +50,15 @@ const EMBEDDINGS_PATH = join(PUBLIC_DIR, 'rag-embeddings.json');
 const GOLDEN_PATH = join(ROOT_DIR, 'eval', 'rag-golden.json');
 const OUTPUT_DIR = join(ROOT_DIR, 'data', 'bench-runs');
 const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434';
+// Endpoint TEI del cross-encoder. El reranker se sirve FUERA de ollama (ollama
+// no expone /api/rerank) — ver el DR. Se llama con el fetch NATIVO (capturado
+// antes del monkeypatch de makeBenchFetch), porque el fetch del bench solo
+// enruta corpus/embeddings/ollama.
+const RERANK_URL = process.env.RERANK_URL || 'http://localhost:7997';
+// Pool que ve el reranker: se recupera híbrido topK=POOL_K (colapsado por
+// especie) y el cross-encoder reordena ese pool antes del slice(TOP_K) final.
+const POOL_K = Number.parseInt(process.env.RAG_POOL_K || '20', 10);
+const TOP_K = 5;
 const nativeFetch = globalThis.fetch?.bind(globalThis);
 register(new URL('./bench-rag-retrieve.loader.mjs', import.meta.url).href);
 
@@ -53,7 +78,10 @@ function percentile(sorted, p) {
   return sorted[idx];
 }
 
-function rankMetrics(rows) {
+// rankMetrics — recall@1/@3/@5 + MRR sobre un arreglo de filas {rank}.
+// `rankField` permite calcular las mismas métricas sobre un rank alternativo
+// (p.ej. el orden híbrido DENTRO del pool, para aislar el aporte del rerank).
+function rankMetrics(rows, rankField = 'rank') {
   if (rows.length === 0) {
     return { recall1: 0, recall3: 0, recall5: 0, mrr: 0 };
   }
@@ -62,7 +90,7 @@ function rankMetrics(rows) {
   let hit5 = 0;
   let rr = 0;
   for (const row of rows) {
-    const rank = row.rank;
+    const rank = row[rankField];
     if (rank === 1) hit1 += 1;
     if (rank >= 1 && rank <= 3) hit3 += 1;
     if (rank >= 1 && rank <= 5) hit5 += 1;
@@ -133,24 +161,102 @@ function makeBenchFetch({ includeEmbeddings }) {
   };
 }
 
-async function runMode(mode, { includeEmbeddings }) {
+// ── Cross-encoder rerank vía TEI ──────────────────────────────────────────
+//
+// TEI /rerank: body { query, texts:[...], raw_scores, truncate } → responde
+// [{ index, score }, ...] ordenado desc. Se mapea index→score alineado al
+// arreglo `texts`. Devuelve null ante cualquier fallo (fail-open: el caller
+// conserva el orden híbrido) — mismo contrato de degradación que la capa
+// semántica en ragRetriever.js.
+async function rerankScores(query, texts) {
+  if (!nativeFetch || texts.length === 0) return null;
+  try {
+    const res = await nativeFetch(`${RERANK_URL}/rerank`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, texts, raw_scores: false, truncate: true }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!Array.isArray(data)) return null;
+    const scores = new Array(texts.length).fill(Number.NEGATIVE_INFINITY);
+    for (const item of data) {
+      if (item && typeof item.index === 'number' && typeof item.score === 'number') {
+        scores[item.index] = item.score;
+      }
+    }
+    return scores;
+  } catch {
+    return null;
+  }
+}
+
+// Reordena `hits` (pool híbrido) por score del cross-encoder. Devuelve el pool
+// reordenado, o null si el reranker no respondió (fail-open).
+async function rerankHits(query, hits) {
+  const texts = hits.map((h) => (typeof h.text === 'string' ? h.text : ''));
+  const scores = await rerankScores(query, texts);
+  if (!scores) return null;
+  return hits
+    .map((h, i) => ({ ...h, rerankScore: scores[i] }))
+    .sort((a, b) => b.rerankScore - a.rerankScore);
+}
+
+async function teiReady() {
+  if (!nativeFetch) return false;
+  try {
+    const res = await nativeFetch(`${RERANK_URL}/health`, { method: 'GET' });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function runMode(mode, { includeEmbeddings, rerank = false }) {
   globalThis.fetch = makeBenchFetch({ includeEmbeddings });
   const moduleUrl = new URL(`../src/services/ragRetriever.js?bench=${mode}`, import.meta.url);
   const { retrieve, getCorpusStats } = await import(moduleUrl.href);
 
   const firstT0 = performance.now();
-  const firstHits = await retrieve(GOLDEN_SET[0].query, 5, 'bench');
+  const firstHits = await retrieve(GOLDEN_SET[0].query, TOP_K, 'bench');
   const coldMs = performance.now() - firstT0;
   const stats = await getCorpusStats();
 
+  // En rerank pedimos un pool ancho (POOL_K) para que el cross-encoder tenga
+  // material que reordenar; sin rerank, el retrieve normal (TOP_K).
+  const retrieveK = rerank ? POOL_K : TOP_K;
+
   let passed = 0;
   const latencies = [];
+  const rerankLatencies = [];
+  let rerankFallbacks = 0;
+  let coveragePool = 0; // ¿el esperado está en el pool ancho? (techo del rerank)
   const details = [];
 
   for (const item of GOLDEN_SET) {
     const t0 = performance.now();
-    const hits = await retrieve(item.query, 5, 'bench');
+    let hits = await retrieve(item.query, retrieveK, 'bench');
+
+    // rank del esperado en el orden HÍBRIDO dentro del pool (aísla el rerank).
+    const poolSlugs = hits.map((h) => h.species).filter(Boolean);
+    const poolRankIdx = poolSlugs.slice(0, TOP_K).findIndex((slug) => matchesSpecies(slug, item.expected));
+    const inPool = poolSlugs.findIndex((slug) => matchesSpecies(slug, item.expected)) >= 0;
+    if (inPool) coveragePool += 1;
+
+    let rerankMs = 0;
+    if (rerank && hits.length > 0) {
+      const rr0 = performance.now();
+      const reordered = await rerankHits(item.query, hits);
+      rerankMs = performance.now() - rr0;
+      if (reordered) {
+        hits = reordered;
+      } else {
+        rerankFallbacks += 1;
+      }
+    }
+    hits = hits.slice(0, TOP_K);
     latencies.push(performance.now() - t0);
+    if (rerank) rerankLatencies.push(rerankMs);
 
     const topSlugs = hits.map((h) => h.species).filter(Boolean);
     const rank = topSlugs.findIndex((slug) => matchesSpecies(slug, item.expected));
@@ -161,21 +267,34 @@ async function runMode(mode, { includeEmbeddings }) {
       expected: item.expected,
       found,
       rank: found ? rank + 1 : null,
-      topSlugs: topSlugs.slice(0, 5),
+      poolRank: poolRankIdx >= 0 ? poolRankIdx + 1 : null,
+      inPool,
+      topSlugs: topSlugs.slice(0, TOP_K),
     });
   }
 
   const metrics = rankMetrics(details);
+  // Métrica de aislamiento: mismas queries, MISMO pool, orden híbrido (sin
+  // rerank). El delta metrics−poolMetrics es el aporte NETO del cross-encoder
+  // sobre un conjunto de candidatos idéntico.
+  const poolMetrics = rerank ? rankMetrics(details, 'poolRank') : null;
   const sorted = [...latencies].sort((a, b) => a - b);
   const avg = latencies.reduce((sum, n) => sum + n, 0) / Math.max(latencies.length, 1);
+  const rrSorted = [...rerankLatencies].sort((a, b) => a - b);
+  const rrAvg = rerankLatencies.reduce((sum, n) => sum + n, 0) / Math.max(rerankLatencies.length, 1);
 
   return {
     mode,
     includeEmbeddings,
+    rerank,
+    poolK: rerank ? POOL_K : TOP_K,
     coldMs,
     stats,
     firstHitCount: firstHits.length,
     metrics,
+    poolMetrics,
+    coveragePool: rerank ? coveragePool / GOLDEN_SET.length : null,
+    rerankFallbacks: rerank ? rerankFallbacks : null,
     passed,
     total: GOLDEN_SET.length,
     latency: {
@@ -185,20 +304,45 @@ async function runMode(mode, { includeEmbeddings }) {
       minMs: sorted[0] || 0,
       maxMs: sorted[sorted.length - 1] || 0,
     },
+    rerankLatency: rerank
+      ? {
+          avgMs: rrAvg,
+          p50Ms: percentile(rrSorted, 50),
+          p95Ms: percentile(rrSorted, 95),
+        }
+      : null,
     details,
   };
 }
 
+function label(mode) {
+  if (mode === 'bm25') return 'BM25-only';
+  if (mode === 'hybrid') return 'Hybrid (nomic)';
+  if (mode === 'hybrid+rerank') return 'Hybrid + rerank (bge-v2-m3)';
+  return mode;
+}
+
 function printMode(result) {
-  const label = result.mode === 'bm25' ? 'BM25-only' : 'Hybrid';
-  console.log(`\n[bench] ${label}`);
+  console.log(`\n[bench] ${label(result.mode)}`);
   console.log(`[bench]   cold load: ${result.coldMs.toFixed(1)} ms`);
   console.log(`[bench]   corpus: ${result.stats.totalDocs} docs, ${result.stats.uniqueTerms} terms, avgDocLen=${result.stats.avgDocLen}`);
   console.log(`[bench]   recall@1: ${(result.metrics.recall1 * 100).toFixed(1)}%`);
   console.log(`[bench]   recall@3: ${(result.metrics.recall3 * 100).toFixed(1)}%`);
   console.log(`[bench]   recall@5: ${(result.metrics.recall5 * 100).toFixed(1)}%`);
   console.log(`[bench]   MRR: ${result.metrics.mrr.toFixed(4)}`);
+  if (result.rerank) {
+    console.log(`[bench]   pool: top-${result.poolK} (cobertura del esperado en el pool: ${(result.coveragePool * 100).toFixed(1)}% — techo del rerank)`);
+    if (result.poolMetrics) {
+      console.log(`[bench]   (aislado, mismo pool sin rerank) recall@1: ${(result.poolMetrics.recall1 * 100).toFixed(1)}%  recall@5: ${(result.poolMetrics.recall5 * 100).toFixed(1)}%  MRR: ${result.poolMetrics.mrr.toFixed(4)}`);
+    }
+    console.log(`[bench]   rerank fail-open (fallback a híbrido): ${result.rerankFallbacks}/${result.total}`);
+    console.log(`[bench]   rerank latency avg=${result.rerankLatency.avgMs.toFixed(1)} ms p50=${result.rerankLatency.p50Ms.toFixed(1)} ms p95=${result.rerankLatency.p95Ms.toFixed(1)} ms`);
+  }
   console.log(`[bench]   latency avg=${result.latency.avgMs.toFixed(1)} ms p50=${result.latency.p50Ms.toFixed(1)} ms p95=${result.latency.p95Ms.toFixed(1)} ms`);
+}
+
+function pp(x) {
+  return (x * 100).toFixed(1);
 }
 
 async function main() {
@@ -213,23 +357,42 @@ async function main() {
   const hybrid = await runMode('hybrid', { includeEmbeddings: true });
   printMode(hybrid);
 
+  // 3ra pasada opcional: solo si TEI responde y no se pasó --no-rerank.
+  const wantRerank = !process.argv.includes('--no-rerank');
+  const rerankUp = wantRerank ? await teiReady() : false;
+  let rerankRes = null;
+  if (wantRerank && !rerankUp) {
+    console.log(`\n[bench] rerank OMITIDO: TEI no responde en ${RERANK_URL}/health (levante el container o exporte RERANK_URL). CI sigue verde.`);
+  } else if (rerankUp) {
+    rerankRes = await runMode('hybrid+rerank', { includeEmbeddings: true, rerank: true });
+    printMode(rerankRes);
+  }
+
   const deltaRecall = (hybrid.metrics.recall5 - bm25.metrics.recall5) * 100;
   console.log('\n[bench] resumen');
-  console.log(`[bench]   recall@1 bm25  : ${(bm25.metrics.recall1 * 100).toFixed(1)}%`);
-  console.log(`[bench]   recall@1 hybrid: ${(hybrid.metrics.recall1 * 100).toFixed(1)}%`);
-  console.log(`[bench]   recall@3 bm25  : ${(bm25.metrics.recall3 * 100).toFixed(1)}%`);
-  console.log(`[bench]   recall@3 hybrid: ${(hybrid.metrics.recall3 * 100).toFixed(1)}%`);
-  console.log(`[bench]   recall@5 bm25  : ${(bm25.metrics.recall5 * 100).toFixed(1)}%`);
-  console.log(`[bench]   recall@5 hybrid: ${(hybrid.metrics.recall5 * 100).toFixed(1)}%`);
-  console.log(`[bench]   MRR bm25      : ${bm25.metrics.mrr.toFixed(4)}`);
-  console.log(`[bench]   MRR hybrid    : ${hybrid.metrics.mrr.toFixed(4)}`);
-  console.log(`[bench]   delta          : ${deltaRecall >= 0 ? '+' : ''}${deltaRecall.toFixed(1)} pp`);
+  console.log(`[bench]   ${'modo'.padEnd(28)} ${'R@1'.padStart(7)} ${'R@3'.padStart(7)} ${'R@5'.padStart(7)} ${'MRR'.padStart(8)}`);
+  const rows = [bm25, hybrid, ...(rerankRes ? [rerankRes] : [])];
+  for (const r of rows) {
+    console.log(`[bench]   ${label(r.mode).padEnd(28)} ${(`${pp(r.metrics.recall1)}%`).padStart(7)} ${(`${pp(r.metrics.recall3)}%`).padStart(7)} ${(`${pp(r.metrics.recall5)}%`).padStart(7)} ${r.metrics.mrr.toFixed(4).padStart(8)}`);
+  }
+  console.log(`[bench]   delta bm25→hybrid (recall@5): ${deltaRecall >= 0 ? '+' : ''}${deltaRecall.toFixed(1)} pp`);
+  if (rerankRes) {
+    const dR1 = (rerankRes.metrics.recall1 - hybrid.metrics.recall1) * 100;
+    const dR5 = (rerankRes.metrics.recall5 - hybrid.metrics.recall5) * 100;
+    const dMrr = rerankRes.metrics.mrr - hybrid.metrics.mrr;
+    console.log(`[bench]   delta hybrid→hybrid+rerank: recall@1 ${dR1 >= 0 ? '+' : ''}${dR1.toFixed(1)} pp | recall@5 ${dR5 >= 0 ? '+' : ''}${dR5.toFixed(1)} pp | MRR ${dMrr >= 0 ? '+' : ''}${dMrr.toFixed(4)}`);
+    // Gate del DR §3.4: recall@1 ≥ +8pp Y MRR ≥ +0.05 para encender el flag.
+    const gatePass = dR1 >= 8 && dMrr >= 0.05;
+    console.log(`[bench]   gate DR §3.4 (recall@1 ≥ +8pp Y MRR ≥ +0.05): ${gatePass ? 'PASA' : 'NO PASA'}`);
+  }
 
   mkdirSync(OUTPUT_DIR, { recursive: true });
   const output = {
     bench: 'rag-retrieve',
     date: new Date().toISOString(),
     ollama_url: OLLAMA_URL,
+    rerank_url: rerankRes ? RERANK_URL : null,
+    pool_k: POOL_K,
     corpus: {
       root: CORPUS_ROOT,
       manifest: MANIFEST_PATH,
@@ -239,10 +402,18 @@ async function main() {
     modes: {
       bm25,
       hybrid,
+      ...(rerankRes ? { 'hybrid+rerank': rerankRes } : {}),
     },
     delta: {
       recall_pp: Number(deltaRecall.toFixed(1)),
       recall_relative: bm25.metrics.recall5 > 0 ? Number(((hybrid.metrics.recall5 - bm25.metrics.recall5) / bm25.metrics.recall5).toFixed(4)) : null,
+      ...(rerankRes
+        ? {
+            rerank_recall1_pp: Number(((rerankRes.metrics.recall1 - hybrid.metrics.recall1) * 100).toFixed(1)),
+            rerank_recall5_pp: Number(((rerankRes.metrics.recall5 - hybrid.metrics.recall5) * 100).toFixed(1)),
+            rerank_mrr: Number((rerankRes.metrics.mrr - hybrid.metrics.mrr).toFixed(4)),
+          }
+        : {}),
     },
   };
   const outputPath = join(OUTPUT_DIR, `rag-retrieve-${new Date().toISOString().slice(0, 10)}.json`);
@@ -259,7 +430,7 @@ async function main() {
     const historyPath = writeHistoryRecord(
       buildHistoryRecord({
         bench: 'rag-retrieve',
-        model: 'bm25-vs-hybrid',
+        model: rerankRes ? 'bm25-vs-hybrid-vs-rerank' : 'bm25-vs-hybrid',
         config: 'recall',
         commit,
         metrics: {
@@ -272,6 +443,14 @@ async function main() {
           mrr_bm25: Number(bm25.metrics.mrr.toFixed(4)),
           mrr_hybrid: Number(hybrid.metrics.mrr.toFixed(4)),
           recall_delta_pp: Number(deltaRecall.toFixed(1)),
+          ...(rerankRes
+            ? {
+                recall1_rerank: Number((rerankRes.metrics.recall1 * 100).toFixed(1)),
+                recall5_rerank: Number((rerankRes.metrics.recall5 * 100).toFixed(1)),
+                mrr_rerank: Number(rerankRes.metrics.mrr.toFixed(4)),
+                lift_pp: Number(((rerankRes.metrics.recall1 - hybrid.metrics.recall1) * 100).toFixed(1)),
+              }
+            : {}),
         },
       }),
     );


### PR DESCRIPTION
## Resumen

Se montó y **midió** un cross-encoder reranker (`BAAI/bge-reranker-v2-m3` vía TEI) sobre el RAG de Chagra. Veredicto: **NO vale la pena hoy — degrada el recall**. Este PR deja la medición reproducible y el informe; **no toca producción** (el flag `VITE_RAG_RERANK` queda documentado pero OFF).

## Resultado (eval/rag-golden.json, 50 queries)

| modo | recall@1 | recall@3 | recall@5 | MRR |
|---|---|---|---|---|
| BM25-only | 28.0% | 34.0% | 34.0% | 0.3067 |
| **Hybrid (nomic)** | **30.0%** | **42.0%** | **44.0%** | **0.3507** |
| **Hybrid + rerank (bge-v2-m3)** | **14.0%** | **26.0%** | **36.0%** | **0.2210** |

Delta híbrido→rerank: **recall@1 −16 pp · MRR −0.13**. Gate del DR §3.4 (recall@1 ≥ +8 pp y MRR ≥ +0.05): **NO PASA**.

Métrica de aislamiento (mismo pool de 20, mismo conjunto de candidatos): orden híbrido MRR .344 → reranqueado .221. El daño es del reranker, no de ampliar el pool. Fail-open: 0/50 (TEI respondió todo).

## Causa raíz (medida, con traza en el informe)

El colapso por especie alimenta al cross-encoder con **un** pasaje representativo por especie, elegido por otro scorer (suele ser un fragmento léxico corto), no el pasaje pertinente. Ej. "gusano del cafe": el híbrido acierta `coffea_arabica` en #1, pero su texto representativo es "Café caturra / Castillo / Cenicafé 1" (lista de variedades) — el cross-encoder lo juzga irrelevante a "gusano" (correcto) y entierra la respuesta. El cuello de botella es el **retrieve a nivel especie**, no el orden del top-k.

## Qué cambia

- `scripts/bench-rag-retrieve.mjs`: tercer modo `hybrid+rerank` (top-20 → TEI `/rerank` → reordenar → slice 5), métrica de aislamiento, cobertura del pool, fail-open, gate DR §3.4. Los modos BM25/híbrido quedan **idénticos** (baseline reproducido exacto 30/42/44/.351).
- `ops/informes/reranker-medido-2026-07-23.md`: informe completo (montaje, medición, causa raíz, contrato de integración documentado, recomendaciones).

## Cómo correr

```
OLLAMA_URL=<ollama> RERANK_URL=<tei> node scripts/bench-rag-retrieve.mjs --history
```
La 3ra pasada solo corre si `RERANK_URL/health` responde 200; si no, se salta (CI verde).

## Recomendación

1. NO encender `VITE_RAG_RERANK`.
2. El lever real es el retrieve **a nivel pasaje** (re-chunk + embeddings por pasaje, no un vector por especie), luego re-medir con este mismo bench.

DR de referencia: `Chagra-strategy/ops/DR-RAG-RERANKER-2026-07-10.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)