### PR TITLE
fix(casa-adentro): fogón en cuadro, ventana con paisaje y cocina viva

### DIFF
--- a/src/visual/mundo3d/casa/EscenaCasaAdentro.jsx
+++ b/src/visual/mundo3d/casa/EscenaCasaAdentro.jsx
@@ -264,20 +264,24 @@ function FuegoFogon({ tier, reducedMotion, fuerza = 1 }) {
     const p = 0.82 + 0.18 * Math.sin(t * 9.1) * Math.sin(t * 3.7 + 1.2);
     if (llama1.current) llama1.current.scale.set(1, p, 1);
     if (llama2.current) llama2.current.scale.set(1, 1.5 - p * 0.5, 1);
-    if (luz.current) luz.current.intensity = (0.85 + 0.22 * (p - 0.82)) * fuerza;
+    if (luz.current) luz.current.intensity = (1.08 + 0.26 * (p - 0.82)) * fuerza;
   });
   return (
-    <group position={[-2.34, 0.16, 0.2]}>
+    // En la BOCA de la candela, no adentro de la masa: el hueco de la boca es
+    // geometría maciza (caja tinta hasta x=-2.06) y el grupo vivía en -2.34 —
+    // las llamas quedaban ENTERRADAS en el adobe, invisibles. Aquí el fuego
+    // asoma por el frente de la boca, que es donde se ve de verdad.
+    <group position={[-2.06, 0.16, 0.2]}>
       {/* las brasas y las dos lenguas de candela */}
       <mesh position={[0, 0.03, 0]}>
         <boxGeometry args={[0.34, 0.06, 0.4]} />
         <meshBasicMaterial color="#e05a2b" />
       </mesh>
-      <mesh ref={llama1} position={[0.02, 0.16, -0.06]}>
+      <mesh ref={llama1} position={[0.04, 0.16, -0.06]}>
         <coneGeometry args={[0.085, 0.26, 6]} />
         <meshBasicMaterial color="#ff9a3d" transparent opacity={0.92} />
       </mesh>
-      <mesh ref={llama2} position={[-0.04, 0.13, 0.09]}>
+      <mesh ref={llama2} position={[0.07, 0.13, 0.09]}>
         <coneGeometry args={[0.06, 0.18, 6]} />
         <meshBasicMaterial color={LUCES.candela} transparent opacity={0.85} />
       </mesh>
@@ -286,10 +290,10 @@ function FuegoFogon({ tier, reducedMotion, fuerza = 1 }) {
       <pointLight
         ref={luz}
         color="#ffb066"
-        intensity={0.92 * fuerza}
-        distance={6.5}
+        intensity={1.15 * fuerza}
+        distance={7.5}
         decay={1.8}
-        position={[0.1, 0.55, 0]}
+        position={[0.15, 0.55, 0]}
       />
     </group>
   );
@@ -361,13 +365,13 @@ const LUCES_MUNDOS = [
   { color: LUCES.luna, pos: [0.05, 1.58] },
 ];
 
-function VentanaMundos({ atm, reducedMotion, onPortales }) {
+function VentanaMundos({ atm, noche, reducedMotion, onPortales }) {
   const velo = useRef(null);
   const luces = useRef(null);
   useFrame(({ clock }) => {
     if (reducedMotion) return;
     const t = clock.elapsedTime;
-    if (velo.current) velo.current.opacity = 0.2 + 0.1 * Math.sin(t * 1.1);
+    if (velo.current) velo.current.opacity = 0.06 + 0.04 * Math.sin(t * 1.1);
     const g = luces.current;
     if (g) {
       for (let i = 0; i < g.children.length; i++) {
@@ -380,6 +384,19 @@ function VentanaMundos({ atm, reducedMotion, onPortales }) {
   const w = VENTANA_MUNDOS.x1 - VENTANA_MUNDOS.x0 - 0.04;
   const h = VENTANA_MUNDOS.alto - VENTANA_MUNDOS.base - 0.04;
   const z = -SALA.fondo / 2 + 0.02;
+  /* LO QUE SE VE POR EL VANO ES PAISAJE, no un plano quemado: de día el cielo
+     azulado del valle (rellenoFrio templa el crema del corral, que solo
+     dejaba blanco puro), la cordillera lejana en bruma y la loma verde
+     cercana. De noche todo baja a índigo de luna. */
+  const cieloAfuera = noche
+    ? mezclar(CIELO_NOCHE_CASA, LUCES.luna, 0.18)
+    : mezclar(LUCES.rellenoFrio, atm.cielo, 0.32);
+  const cordillera = noche
+    ? mezclar(CIELO_NOCHE_CASA, VERDES.altoAndino, 0.3)
+    : mezclar(VERDES.altoAndino, LUCES.luna, 0.42);
+  const loma = noche
+    ? mezclar(VERDES.monte, CIELO_NOCHE_CASA, 0.72)
+    : mezclar(VERDES.brote, NIEBLAS.dorada, 0.18);
   return (
     <group
       onClick={
@@ -393,19 +410,29 @@ function VentanaMundos({ atm, reducedMotion, onPortales }) {
       onPointerOver={onPortales ? alApuntar : undefined}
       onPointerOut={onPortales ? alSoltar : undefined}
     >
-      {/* el cielo-portal: la hora del valle mezclada con la plata de la luna */}
+      {/* el cielo de afuera (la hora del valle, templada — nunca blanco) */}
       <mesh position={[cx, cy, z]}>
         <planeGeometry args={[w, h]} />
-        <meshBasicMaterial color={mezclar(atm.cielo, LUCES.luna, 0.45)} />
+        <meshBasicMaterial color={cieloAfuera} />
       </mesh>
-      {/* el velo dorado que respira sobre el vano (la invitación) */}
+      {/* la cordillera lejana, en bruma */}
+      <mesh position={[cx, VENTANA_MUNDOS.base + 0.34, z + 0.006]}>
+        <planeGeometry args={[w, 0.42]} />
+        <meshBasicMaterial color={cordillera} />
+      </mesh>
+      {/* la loma verde cercana (el valle asomándose al vano) */}
+      <mesh position={[cx, VENTANA_MUNDOS.base + 0.12, z + 0.012]}>
+        <planeGeometry args={[w, 0.22]} />
+        <meshBasicMaterial color={loma} />
+      </mesh>
+      {/* el velo dorado que respira sobre el vano (la invitación, tenue) */}
       <mesh position={[cx, cy, z + 0.015]}>
         <planeGeometry args={[w, h]} />
         <meshBasicMaterial
           ref={velo}
           color={NIEBLAS.dorada}
           transparent
-          opacity={0.24}
+          opacity={0.08}
           depthWrite={false}
           blending={THREE.AdditiveBlending}
         />
@@ -570,17 +597,23 @@ function Diorama({ tier, reducedMotion, foco, onPortales, onFermentos }) {
           techo. De día la hora del valle; de noche se APAGA a índigo. */}
       <color attach="background" args={[fondoCasa]} />
 
-      {/* LA PENUMBRA es la imagen: el ambiente se queda corto a propósito —
-          una casa de tapia se alumbra por UN vano y el resto es sombra que
-          abriga. De noche baja aún más y queda el fogón. */}
+      {/* LA PENUMBRA sigue siendo la imagen, pero con LUZ DE LECTURA: la
+          cocina tiene que leerse (el fogón, la loza, la cuelga). El refuerzo
+          compensa cuando la atmósfera viene tenue (patrón de #2707) y la base
+          sube para que el interior no sea un pardo ciego. De noche baja y
+          manda el fogón. */}
       <ambientLight
         color={LUCES.ambienteTibio}
-        intensity={sol.deDia ? 0.15 + 0.14 * atm.intensidad : 0.12}
+        intensity={
+          sol.deDia
+            ? 0.24 + 0.16 * atm.intensidad + 0.12 * Math.max(0, 1 - atm.intensidad)
+            : 0.14
+        }
       />
       <hemisphereLight
         skyColor={atm.cielo}
         groundColor={NEUTROS.tinta}
-        intensity={sol.deDia ? 0.19 : 0.12}
+        intensity={sol.deDia ? 0.26 : 0.13}
       />
       {/* LA LUZ TIENE FUENTE: de día la direccional viaja por el arco REAL del
           sol (por eso el rectángulo de la ventana camina y las sombras giran
@@ -625,22 +658,75 @@ function Diorama({ tier, reducedMotion, foco, onPortales, onFermentos }) {
           }
         />
       </mesh>
-      {/* el resplandor del día en el vano de la puerta */}
-      <mesh position={[(PUERTA.x0 + PUERTA.x1) / 2, PUERTA.alto / 2, hz + 0.03]}>
-        <planeGeometry args={[PUERTA.x1 - PUERTA.x0 - 0.04, PUERTA.alto - 0.04]} />
-        <meshBasicMaterial color={mezclar(atm.cielo, NIEBLAS.dorada, 0.35)} side={THREE.DoubleSide} />
-      </mesh>
-      {/* y en la ventana del sur */}
-      <mesh
+      {/* lo que se ve por el vano de la PUERTA: cielo, loma y el pasto del
+          umbral — paisaje de verdad, no un plano dorado quemado */}
+      <group position={[(PUERTA.x0 + PUERTA.x1) / 2, 0, hz + 0.03]}>
+        <mesh position={[0, PUERTA.alto / 2, 0]}>
+          <planeGeometry args={[PUERTA.x1 - PUERTA.x0 - 0.04, PUERTA.alto - 0.04]} />
+          <meshBasicMaterial
+            color={
+              sol.deDia
+                ? mezclar(mezclar(LUCES.rellenoFrio, atm.cielo, 0.4), NIEBLAS.dorada, 0.18)
+                : mezclar(CIELO_NOCHE_CASA, LUCES.luna, 0.16)
+            }
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+        <mesh position={[0, 0.68, 0.012]}>
+          <planeGeometry args={[PUERTA.x1 - PUERTA.x0 - 0.04, 0.3]} />
+          <meshBasicMaterial
+            color={
+              sol.deDia
+                ? mezclar(VERDES.templado, LUCES.luna, 0.3)
+                : mezclar(VERDES.monte, CIELO_NOCHE_CASA, 0.7)
+            }
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+        <mesh position={[0, 0.27, 0.024]}>
+          <planeGeometry args={[PUERTA.x1 - PUERTA.x0 - 0.04, 0.56]} />
+          <meshBasicMaterial
+            color={
+              sol.deDia
+                ? mezclar(VERDES.brote, atm.niebla, 0.3)
+                : mezclar(VERDES.brote, CIELO_NOCHE_CASA, 0.82)
+            }
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      </group>
+      {/* y por la VENTANA DEL SUR: el mismo día con su loma (de aquí sale el
+          haz — luminosa sí, quemada no) */}
+      <group
         position={[
           (VENTANA_SUR.x0 + VENTANA_SUR.x1) / 2,
-          (VENTANA_SUR.base + VENTANA_SUR.alto) / 2,
+          0,
           hz + 0.03,
         ]}
       >
-        <planeGeometry args={[VENTANA_SUR.x1 - VENTANA_SUR.x0 - 0.04, VENTANA_SUR.alto - VENTANA_SUR.base - 0.04]} />
-        <meshBasicMaterial color={mezclar(atm.cielo, NIEBLAS.dorada, 0.35)} side={THREE.DoubleSide} />
-      </mesh>
+        <mesh position={[0, (VENTANA_SUR.base + VENTANA_SUR.alto) / 2, 0]}>
+          <planeGeometry args={[VENTANA_SUR.x1 - VENTANA_SUR.x0 - 0.04, VENTANA_SUR.alto - VENTANA_SUR.base - 0.04]} />
+          <meshBasicMaterial
+            color={
+              sol.deDia
+                ? mezclar(mezclar(LUCES.rellenoFrio, atm.cielo, 0.48), NIEBLAS.dorada, 0.14)
+                : mezclar(CIELO_NOCHE_CASA, LUCES.luna, 0.14)
+            }
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+        <mesh position={[0, VENTANA_SUR.base + 0.16, 0.012]}>
+          <planeGeometry args={[VENTANA_SUR.x1 - VENTANA_SUR.x0 - 0.04, 0.3]} />
+          <meshBasicMaterial
+            color={
+              sol.deDia
+                ? mezclar(VERDES.brote, NIEBLAS.dorada, 0.22)
+                : mezclar(VERDES.monte, CIELO_NOCHE_CASA, 0.72)
+            }
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+      </group>
 
       {/* EL RECTÁNGULO DE SOL: la ventana del sur riega su vano en el piso y
           la mancha CAMINA con el día — sliver al pie del muro a mediodía,
@@ -718,33 +804,37 @@ function Diorama({ tier, reducedMotion, foco, onPortales, onFermentos }) {
       <HumoFogon n={nHumo} reducedMotion={reducedMotion} />
 
       {/* LOS DOS ACCESOS legibles desde adentro */}
-      <VentanaMundos atm={atm} reducedMotion={reducedMotion} onPortales={onPortales} />
+      <VentanaMundos atm={atm} noche={!sol.deDia} reducedMotion={reducedMotion} onPortales={onPortales} />
       <RinconFermentos reducedMotion={reducedMotion} onFermentos={onFermentos} />
 
       {/* el anillo del paso didáctico (lo maneja el host) */}
       <FocoPaso foco={foco} reducedMotion={reducedMotion} />
 
+      {/* EL ENCUADRE MIRA AL FOGÓN: el paso 1 se llama "El fogón" y la cámara
+          tiene que abrirle el cuadro — el rincón del fuego, la cuelga y el
+          humo, con la mesa de refilón. (Antes miraba la mesa vacía y el
+          corazón de la cocina quedaba fuera de pantalla.) */}
       <OrbitControls
         ref={controls}
         makeDefault
-        target={[-0.2, 0.98, -0.4]}
+        target={[-1.6, 0.95, 0.15]}
         enablePan={false}
         enableZoom
         minDistance={1.3}
-        maxDistance={3.3}
+        maxDistance={4.0}
         minPolarAngle={0.6}
         maxPolarAngle={1.52}
-        minAzimuthAngle={-1.15}
-        maxAzimuthAngle={1.15}
+        minAzimuthAngle={-1.35}
+        maxAzimuthAngle={1.35}
         enableDamping
         dampingFactor={0.08}
       />
       {/* La LLEGADA: el dolly corto de cruzar el umbral — de la puerta hacia
-          el centro del cuarto, una vez por sesión. */}
+          el rincón del fogón, una vez por sesión. */}
       <CamaraDirector
         controls={controls}
-        reposo={[1.35, 1.95, 2.35]}
-        mirada={[-0.3, 1.35, -0.5]}
+        reposo={[1.5, 1.7, 1.45]}
+        mirada={[-1.6, 1.05, 0.15]}
         respiro={0.03}
         activa={!reducedMotion && tier !== 'bajo'}
         unaVezClave="mundoCasaAdentro"
@@ -779,7 +869,7 @@ export default function EscenaCasaAdentro({
       dpr={perfil.dpr}
       gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
       shadows={perfil.sombras ? 'soft' : false}
-      camera={{ position: [1.35, 1.95, 2.35], fov: 48 }}
+      camera={{ position: [1.5, 1.7, 1.45], fov: 48 }}
       frameloop={reducedMotion ? 'demand' : 'always'}
       onCreated={() => setListo(true)}
     >

--- a/src/visual/mundo3d/casa/EscenaCasaAdentro.jsx
+++ b/src/visual/mundo3d/casa/EscenaCasaAdentro.jsx
@@ -277,13 +277,15 @@ function FuegoFogon({ tier, reducedMotion, fuerza = 1 }) {
         <boxGeometry args={[0.34, 0.06, 0.4]} />
         <meshBasicMaterial color="#e05a2b" />
       </mesh>
+      {/* naranja de candela de verdad (los tonos pálidos leían como conos
+          de papel, no como fuego) */}
       <mesh ref={llama1} position={[0.04, 0.16, -0.06]}>
         <coneGeometry args={[0.085, 0.26, 6]} />
-        <meshBasicMaterial color="#ff9a3d" transparent opacity={0.92} />
+        <meshBasicMaterial color="#d94f16" transparent opacity={0.96} />
       </mesh>
       <mesh ref={llama2} position={[0.07, 0.13, 0.09]}>
         <coneGeometry args={[0.06, 0.18, 6]} />
-        <meshBasicMaterial color={LUCES.candela} transparent opacity={0.85} />
+        <meshBasicMaterial color="#f28c26" transparent opacity={0.92} />
       </mesh>
       {/* la luz de la candela: la casa siempre espera caliente — y de noche,
           cuando el sol se va de verdad, es ELLA la que manda en el cuarto */}

--- a/src/visual/mundo3d/casa/casaAdentro.geom.js
+++ b/src/visual/mundo3d/casa/casaAdentro.geom.js
@@ -317,6 +317,39 @@ export function construirCasaAdentro(rico = true) {
   poner(L, cil(0.09, 0.1, 0.22, 8), PAL.barro, -2.75, 1.64, -hz + 0.26);
   poner(L, cil(0.07, 0.08, 0.18, 8), PAL.barro, -2.45, 1.62, -hz + 0.24);
   poner(L, caja(0.14, 0.2, 0.14), NEUTROS.lamina, -2.1, 1.63, -hz + 0.27);
+  // el pocillo esmaltado en la punta de la repisa (la loza de diario)
+  poner(L, cil(0.05, 0.042, 0.09, 8), CASA.carpinteria, -1.68, 1.57, -hz + 0.28);
+
+  /* ── LA COCINA VIVA (lo que toda cocina de humo cuelga y guarda) ───────── */
+  // LA CUELGA del tirante del poniente: los manojos de hierbas boca abajo y
+  // la ristra de ají — la despensa aérea, curándose al calor del fogón.
+  for (const [cz, colHierba] of [[0.85, VERDES.aliso], [-0.12, VERDES.calido]]) {
+    poner(L, cil(0.012, 0.012, 0.26, 5), PAL.vigaOscura, -1.6, 2.23, cz);
+    poner(L, cil(0.05, 0.1, 0.24, 7), colHierba, -1.6, 1.98, cz);
+  }
+  poner(L, cil(0.012, 0.012, 0.3, 5), PAL.vigaOscura, -1.6, 2.21, 0.38);
+  for (let i = 0; i < 4; i++) {
+    poner(
+      L,
+      cil(0.02, 0.045, 0.11, 6),
+      i % 2 ? ACENTOS.cochinilla : ACENTOS.cafeCereza,
+      -1.625 + (i % 2) * 0.05,
+      2.06 - i * 0.12,
+      0.38,
+    );
+  }
+  // LA PAILA y el CUCHARÓN de palo en el muro del fogón (a mano de la candela)
+  poner(L, cil(0.17, 0.17, 0.035, 12), NEUTROS.lamina, -3.48, 1.72, 0.9, 0, 0, Math.PI / 2);
+  poner(L, cil(0.016, 0.016, 0.34, 5), CASA.madera, -3.5, 1.6, 1.25);
+  poner(L, esfera(0.045, 7, 5), CASA.madera, -3.5, 1.41, 1.25);
+  // LAS PAPAS asomadas en el canasto de cosecha (que el canasto no esté vacío)
+  for (const [px, pz] of [[-2.2, -1.85], [-2.08, -1.95], [-2.18, -1.98]]) {
+    poner(L, esfera(0.07, 7, 5), TIERRAS.camino, px, 0.41, pz);
+  }
+  // EL PLATO DE AREPAS en la mesa (lo que la finca dio, servido)
+  poner(L, cil(0.13, 0.13, 0.02, 10), NEUTROS.cal, 0.4, 0.825, 0.42);
+  poner(L, cil(0.085, 0.085, 0.03, 9), mezclar(TIERRAS.vega, ACENTOS.maizGrano, 0.4), 0.37, 0.85, 0.44);
+  poner(L, cil(0.08, 0.08, 0.03, 9), mezclar(TIERRAS.vega, ACENTOS.maizGrano, 0.55), 0.45, 0.875, 0.4);
 
   /* ── LA CASA HABITADA (pasada Nolan: historia, no catálogo) ────────────── */
 

--- a/src/visual/mundo3d/casa/casaAdentro.geom.js
+++ b/src/visual/mundo3d/casa/casaAdentro.geom.js
@@ -323,19 +323,21 @@ export function construirCasaAdentro(rico = true) {
   /* ── LA COCINA VIVA (lo que toda cocina de humo cuelga y guarda) ───────── */
   // LA CUELGA del tirante del poniente: los manojos de hierbas boca abajo y
   // la ristra de ají — la despensa aérea, curándose al calor del fogón.
+  // (ancho arriba y punta abajo: manojo amarrado, no pantalla de lámpara)
   for (const [cz, colHierba] of [[0.85, VERDES.aliso], [-0.12, VERDES.calido]]) {
-    poner(L, cil(0.012, 0.012, 0.26, 5), PAL.vigaOscura, -1.6, 2.23, cz);
-    poner(L, cil(0.05, 0.1, 0.24, 7), colHierba, -1.6, 1.98, cz);
+    poner(L, cil(0.014, 0.014, 0.14, 5), PAL.vigaOscura, -1.6, 2.29, cz);
+    poner(L, cil(0.095, 0.03, 0.26, 7), colHierba, -1.6, 2.09, cz);
+    poner(L, cil(0.05, 0.014, 0.12, 6), mezclar(colHierba, NEUTROS.tinta, 0.25), -1.6, 1.92, cz);
   }
-  poner(L, cil(0.012, 0.012, 0.3, 5), PAL.vigaOscura, -1.6, 2.21, 0.38);
-  for (let i = 0; i < 4; i++) {
+  poner(L, cil(0.012, 0.012, 0.5, 5), PAL.vigaOscura, -1.6, 2.11, 0.38);
+  for (let i = 0; i < 5; i++) {
     poner(
       L,
-      cil(0.02, 0.045, 0.11, 6),
+      cil(0.042, 0.016, 0.1, 6),
       i % 2 ? ACENTOS.cochinilla : ACENTOS.cafeCereza,
-      -1.625 + (i % 2) * 0.05,
-      2.06 - i * 0.12,
-      0.38,
+      -1.615 + (i % 2) * 0.03,
+      2.26 - i * 0.095,
+      0.38 + (i % 2 ? -0.015 : 0.015),
     );
   }
   // LA PAILA y el CUCHARÓN de palo en el muro del fogón (a mano de la candela)


### PR DESCRIPTION
## Qué arregla (verificado a ojo con GPU real)

1. **Ventana quemada**: la ventana de los mundos era un rectángulo de blanco puro (crema del corral + luna + dos capas aditivas). Ahora se ve paisaje: cielo templado con `rellenoFrio`, cordillera en bruma, loma verde y el velo aditivo bajado de 0.24 a 0.08. Puerta y ventana del sur con el mismo tratamiento por capas. De noche todo baja a índigo de luna.
2. **El fogón no se veía**: dos causas. (a) La cámara del paso 1 «El fogón» miraba la mesa vacía — reencuadre de cámara inicial, dolly y target de OrbitControls hacia el rincón del fuego. (b) Bug real: las llamas vivían **dentro de la caja maciza de la boca** (grupo en x=-2.34, caja opaca hasta x=-2.06) — el fuego estaba enterrado en geometría opaca. Ahora asoma por el frente de la boca, con naranja de candela de verdad (`#d94f16`/`#f28c26`; los tonos pálidos leían como conos de papel bajo ACES).
3. **Cocina pobre/plana**: luz de lectura con el patrón `refuerzo = max(0, 1 − atm.intensidad)` (#2707) + base ambiente subida; candela con más fuerza y alcance. Poblada: cuelga de hierbas y ristra de ají del tirante, paila y cucharón en el muro del fogón, papas en el canasto, plato de arepas en la mesa, pocillo esmaltado en la repisa.

## Verificación
- `npm run build` verde.
- `gate-real-gpu.mjs` en GPU real (renderer: AMD Radeon Vega 10, no SwiftShader): captura final con el fogón protagonista (candela, ollas, humo, cuelga) y captura de control con el encuadre viejo confirmando la ventana con paisaje (antes: blanco quemado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)