### PR TITLE
exp(rag): chunking passage-level MEDIDO — no mejora, degrada el recall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,9 @@ chagra-anthropic-judge-key
 
 # Canario nocturno: reportes y datasets (efímeros, nunca commitear)
 /data/canary-runs/
+
+# Experimento chunking passage-level (exp/rag-chunking-passages) — artefactos grandes, NO commitear
+# (se ignora el CONTENIDO, no el dir, para poder re-incluir results.json: git no
+#  desciende a un dir excluido, así que un `!` sobre el dir entero no funciona.)
+/data/rag-chunking-exp/*
+!/data/rag-chunking-exp/results.json

--- a/data/rag-chunking-exp/results.json
+++ b/data/rag-chunking-exp/results.json
@@ -1,0 +1,1343 @@
+{
+  "bench": "rag-chunking-passages",
+  "date": "2026-07-23T19:52:05.620Z",
+  "embed_host": "http://alpha:11434",
+  "model": "nomic-embed-text",
+  "n_queries": 50,
+  "ceiling_hits": 44,
+  "ceiling_pct": 88,
+  "method": "puro semántico (cosine), colapso variedad→base (parts[0:2]), max-pool por especie; match base==expected||startsWith; 50 queries golden",
+  "passage_corpus": {
+    "total_passages": 20201,
+    "unique_texts": 3909,
+    "truncate_chars": 5000,
+    "truncated_passages": 22
+  },
+  "arms": {
+    "A_doc_prod": {
+      "label": "doc-level PROD (extractPassageText, 1 vec/especie)",
+      "metrics": {
+        "recall@1": 40,
+        "recall@3": 56,
+        "recall@5": 58,
+        "MRR": 0.4833
+      }
+    },
+    "B_doc_flatten": {
+      "label": "doc-level flatten (concat flattenDoc, 1 vec/especie)",
+      "metrics": {
+        "recall@1": 10,
+        "recall@3": 18,
+        "recall@5": 30,
+        "MRR": 0.1861
+      }
+    },
+    "C_passage_max": {
+      "label": "passage-level max-pool (flattenDoc, N vec/especie)",
+      "metrics": {
+        "recall@1": 12,
+        "recall@3": 32,
+        "recall@5": 42,
+        "MRR": 0.2646
+      }
+    },
+    "D_passage_mean": {
+      "label": "passage-level mean-pool (flattenDoc, N vec/especie)",
+      "metrics": {
+        "recall@1": 0,
+        "recall@3": 0,
+        "recall@5": 0,
+        "MRR": 0.0261
+      }
+    },
+    "E_passage_top3": {
+      "label": "passage-level top3-mean (flattenDoc, N vec/especie)",
+      "metrics": {
+        "recall@1": 6,
+        "recall@3": 20,
+        "recall@5": 32,
+        "MRR": 0.1664
+      }
+    }
+  },
+  "best_passage_arm": "C_passage_max",
+  "delta_bestPassage_vs_docProd": {
+    "recall@1_pp": -28,
+    "recall@3_pp": -24,
+    "recall@5_pp": -16,
+    "MRR": -0.2187
+  },
+  "gained_at5": [],
+  "lost_at5": [
+    "G06:zea_mays (A=4→best=156)",
+    "G07:solanum_lycopersicum (A=1→best=10)",
+    "G11:persea_americana (A=1→best=20)",
+    "G14:rubus_glaucus (A=3→best=6)",
+    "G23:solanum_lycopersicum (A=2→best=6)",
+    "G26:zea_mays (A=2→best=28)",
+    "G32:pisum_sativum (A=2→best=91)",
+    "G41:coffea_arabica (A=3→best=10)"
+  ],
+  "per_query": {
+    "A_doc_prod": [
+      {
+        "id": "G01",
+        "expected": "coffea_arabica",
+        "rank": 12
+      },
+      {
+        "id": "G02",
+        "expected": "allium_cepa",
+        "rank": 410
+      },
+      {
+        "id": "G03",
+        "expected": "solanum_tuberosum",
+        "rank": 46
+      },
+      {
+        "id": "G04",
+        "expected": "lactuca_sativa",
+        "rank": 1
+      },
+      {
+        "id": "G05",
+        "expected": "coffea_arabica",
+        "rank": 326
+      },
+      {
+        "id": "G06",
+        "expected": "zea_mays",
+        "rank": 4
+      },
+      {
+        "id": "G07",
+        "expected": "solanum_lycopersicum",
+        "rank": 1
+      },
+      {
+        "id": "G08",
+        "expected": "solanum_tuberosum",
+        "rank": 7
+      },
+      {
+        "id": "G09",
+        "expected": "phaseolus_vulgaris",
+        "rank": 1
+      },
+      {
+        "id": "G10",
+        "expected": "fragaria_ananassa",
+        "rank": 25
+      },
+      {
+        "id": "G11",
+        "expected": "persea_americana",
+        "rank": 1
+      },
+      {
+        "id": "G12",
+        "expected": "allium_cepa",
+        "rank": 135
+      },
+      {
+        "id": "G13",
+        "expected": "manihot_esculenta",
+        "rank": 1
+      },
+      {
+        "id": "G14",
+        "expected": "rubus_glaucus",
+        "rank": 3
+      },
+      {
+        "id": "G15",
+        "expected": "daucus_carota",
+        "rank": 1
+      },
+      {
+        "id": "G16",
+        "expected": "musa_paradisiaca",
+        "rank": 432
+      },
+      {
+        "id": "G17",
+        "expected": "solanum_tuberosum",
+        "rank": 1
+      },
+      {
+        "id": "G18",
+        "expected": "zea_mays",
+        "rank": 22
+      },
+      {
+        "id": "G19",
+        "expected": "solanum_betaceum",
+        "rank": 10
+      },
+      {
+        "id": "G20",
+        "expected": "coffea_arabica",
+        "rank": 1
+      },
+      {
+        "id": "G21",
+        "expected": "coffea_arabica",
+        "rank": 3
+      },
+      {
+        "id": "G22",
+        "expected": "lactuca_sativa",
+        "rank": 1
+      },
+      {
+        "id": "G23",
+        "expected": "solanum_lycopersicum",
+        "rank": 2
+      },
+      {
+        "id": "G24",
+        "expected": "solanum_tuberosum",
+        "rank": 1
+      },
+      {
+        "id": "G25",
+        "expected": "coffea_arabica",
+        "rank": 3
+      },
+      {
+        "id": "G26",
+        "expected": "zea_mays",
+        "rank": 2
+      },
+      {
+        "id": "G27",
+        "expected": "phaseolus_vulgaris",
+        "rank": 1
+      },
+      {
+        "id": "G28",
+        "expected": "persea_americana",
+        "rank": 1
+      },
+      {
+        "id": "G29",
+        "expected": "allium_cepa",
+        "rank": 1
+      },
+      {
+        "id": "G30",
+        "expected": "coriandrum_sativum",
+        "rank": 1
+      },
+      {
+        "id": "G31",
+        "expected": "manihot_esculenta",
+        "rank": 1
+      },
+      {
+        "id": "G32",
+        "expected": "pisum_sativum",
+        "rank": 2
+      },
+      {
+        "id": "G33",
+        "expected": "rubus_glaucus",
+        "rank": 2
+      },
+      {
+        "id": "G34",
+        "expected": "solanum_quitoense",
+        "rank": 13
+      },
+      {
+        "id": "G35",
+        "expected": "physalis_peruviana",
+        "rank": 1
+      },
+      {
+        "id": "G36",
+        "expected": "coffea_arabica",
+        "rank": 30
+      },
+      {
+        "id": "G37",
+        "expected": "solanum_tuberosum",
+        "rank": 1
+      },
+      {
+        "id": "G38",
+        "expected": "solanum_lycopersicum",
+        "rank": 69
+      },
+      {
+        "id": "G39",
+        "expected": "biopreparado",
+        "rank": null
+      },
+      {
+        "id": "G40",
+        "expected": "musa_paradisiaca",
+        "rank": 399
+      },
+      {
+        "id": "G41",
+        "expected": "coffea_arabica",
+        "rank": 3
+      },
+      {
+        "id": "G42",
+        "expected": "daucus_carota",
+        "rank": 1
+      },
+      {
+        "id": "G43",
+        "expected": "solanum_tuberosum",
+        "rank": 1
+      },
+      {
+        "id": "G44",
+        "expected": "associacion",
+        "rank": null
+      },
+      {
+        "id": "G45",
+        "expected": "phaseolus_vulgaris",
+        "rank": 1
+      },
+      {
+        "id": "G46",
+        "expected": "mito_lunar",
+        "rank": null
+      },
+      {
+        "id": "G47",
+        "expected": "suelo_acido",
+        "rank": null
+      },
+      {
+        "id": "G48",
+        "expected": "agua_calidad",
+        "rank": null
+      },
+      {
+        "id": "G49",
+        "expected": "erosion",
+        "rank": null
+      },
+      {
+        "id": "G50",
+        "expected": "coffea_arabica",
+        "rank": 127
+      }
+    ],
+    "B_doc_flatten": [
+      {
+        "id": "G01",
+        "expected": "coffea_arabica",
+        "rank": 16
+      },
+      {
+        "id": "G02",
+        "expected": "allium_cepa",
+        "rank": 431
+      },
+      {
+        "id": "G03",
+        "expected": "solanum_tuberosum",
+        "rank": 258
+      },
+      {
+        "id": "G04",
+        "expected": "lactuca_sativa",
+        "rank": 10
+      },
+      {
+        "id": "G05",
+        "expected": "coffea_arabica",
+        "rank": 192
+      },
+      {
+        "id": "G06",
+        "expected": "zea_mays",
+        "rank": 2
+      },
+      {
+        "id": "G07",
+        "expected": "solanum_lycopersicum",
+        "rank": 217
+      },
+      {
+        "id": "G08",
+        "expected": "solanum_tuberosum",
+        "rank": 26
+      },
+      {
+        "id": "G09",
+        "expected": "phaseolus_vulgaris",
+        "rank": 44
+      },
+      {
+        "id": "G10",
+        "expected": "fragaria_ananassa",
+        "rank": 12
+      },
+      {
+        "id": "G11",
+        "expected": "persea_americana",
+        "rank": 5
+      },
+      {
+        "id": "G12",
+        "expected": "allium_cepa",
+        "rank": 80
+      },
+      {
+        "id": "G13",
+        "expected": "manihot_esculenta",
+        "rank": 1
+      },
+      {
+        "id": "G14",
+        "expected": "rubus_glaucus",
+        "rank": 4
+      },
+      {
+        "id": "G15",
+        "expected": "daucus_carota",
+        "rank": 7
+      },
+      {
+        "id": "G16",
+        "expected": "musa_paradisiaca",
+        "rank": 341
+      },
+      {
+        "id": "G17",
+        "expected": "solanum_tuberosum",
+        "rank": 110
+      },
+      {
+        "id": "G18",
+        "expected": "zea_mays",
+        "rank": 178
+      },
+      {
+        "id": "G19",
+        "expected": "solanum_betaceum",
+        "rank": 325
+      },
+      {
+        "id": "G20",
+        "expected": "coffea_arabica",
+        "rank": 1
+      },
+      {
+        "id": "G21",
+        "expected": "coffea_arabica",
+        "rank": 5
+      },
+      {
+        "id": "G22",
+        "expected": "lactuca_sativa",
+        "rank": 4
+      },
+      {
+        "id": "G23",
+        "expected": "solanum_lycopersicum",
+        "rank": 57
+      },
+      {
+        "id": "G24",
+        "expected": "solanum_tuberosum",
+        "rank": 7
+      },
+      {
+        "id": "G25",
+        "expected": "coffea_arabica",
+        "rank": 4
+      },
+      {
+        "id": "G26",
+        "expected": "zea_mays",
+        "rank": 3
+      },
+      {
+        "id": "G27",
+        "expected": "phaseolus_vulgaris",
+        "rank": 20
+      },
+      {
+        "id": "G28",
+        "expected": "persea_americana",
+        "rank": 1
+      },
+      {
+        "id": "G29",
+        "expected": "allium_cepa",
+        "rank": 1
+      },
+      {
+        "id": "G30",
+        "expected": "coriandrum_sativum",
+        "rank": 2
+      },
+      {
+        "id": "G31",
+        "expected": "manihot_esculenta",
+        "rank": 1
+      },
+      {
+        "id": "G32",
+        "expected": "pisum_sativum",
+        "rank": 72
+      },
+      {
+        "id": "G33",
+        "expected": "rubus_glaucus",
+        "rank": 2
+      },
+      {
+        "id": "G34",
+        "expected": "solanum_quitoense",
+        "rank": 55
+      },
+      {
+        "id": "G35",
+        "expected": "physalis_peruviana",
+        "rank": 17
+      },
+      {
+        "id": "G36",
+        "expected": "coffea_arabica",
+        "rank": 85
+      },
+      {
+        "id": "G37",
+        "expected": "solanum_tuberosum",
+        "rank": 80
+      },
+      {
+        "id": "G38",
+        "expected": "solanum_lycopersicum",
+        "rank": 57
+      },
+      {
+        "id": "G39",
+        "expected": "biopreparado",
+        "rank": null
+      },
+      {
+        "id": "G40",
+        "expected": "musa_paradisiaca",
+        "rank": 361
+      },
+      {
+        "id": "G41",
+        "expected": "coffea_arabica",
+        "rank": 4
+      },
+      {
+        "id": "G42",
+        "expected": "daucus_carota",
+        "rank": 33
+      },
+      {
+        "id": "G43",
+        "expected": "solanum_tuberosum",
+        "rank": 22
+      },
+      {
+        "id": "G44",
+        "expected": "associacion",
+        "rank": null
+      },
+      {
+        "id": "G45",
+        "expected": "phaseolus_vulgaris",
+        "rank": 7
+      },
+      {
+        "id": "G46",
+        "expected": "mito_lunar",
+        "rank": null
+      },
+      {
+        "id": "G47",
+        "expected": "suelo_acido",
+        "rank": null
+      },
+      {
+        "id": "G48",
+        "expected": "agua_calidad",
+        "rank": null
+      },
+      {
+        "id": "G49",
+        "expected": "erosion",
+        "rank": null
+      },
+      {
+        "id": "G50",
+        "expected": "coffea_arabica",
+        "rank": 103
+      }
+    ],
+    "C_passage_max": [
+      {
+        "id": "G01",
+        "expected": "coffea_arabica",
+        "rank": 10
+      },
+      {
+        "id": "G02",
+        "expected": "allium_cepa",
+        "rank": 404
+      },
+      {
+        "id": "G03",
+        "expected": "solanum_tuberosum",
+        "rank": 86
+      },
+      {
+        "id": "G04",
+        "expected": "lactuca_sativa",
+        "rank": 2
+      },
+      {
+        "id": "G05",
+        "expected": "coffea_arabica",
+        "rank": 148
+      },
+      {
+        "id": "G06",
+        "expected": "zea_mays",
+        "rank": 156
+      },
+      {
+        "id": "G07",
+        "expected": "solanum_lycopersicum",
+        "rank": 10
+      },
+      {
+        "id": "G08",
+        "expected": "solanum_tuberosum",
+        "rank": 146
+      },
+      {
+        "id": "G09",
+        "expected": "phaseolus_vulgaris",
+        "rank": 1
+      },
+      {
+        "id": "G10",
+        "expected": "fragaria_ananassa",
+        "rank": 119
+      },
+      {
+        "id": "G11",
+        "expected": "persea_americana",
+        "rank": 20
+      },
+      {
+        "id": "G12",
+        "expected": "allium_cepa",
+        "rank": 6
+      },
+      {
+        "id": "G13",
+        "expected": "manihot_esculenta",
+        "rank": 2
+      },
+      {
+        "id": "G14",
+        "expected": "rubus_glaucus",
+        "rank": 6
+      },
+      {
+        "id": "G15",
+        "expected": "daucus_carota",
+        "rank": 5
+      },
+      {
+        "id": "G16",
+        "expected": "musa_paradisiaca",
+        "rank": 407
+      },
+      {
+        "id": "G17",
+        "expected": "solanum_tuberosum",
+        "rank": 2
+      },
+      {
+        "id": "G18",
+        "expected": "zea_mays",
+        "rank": 41
+      },
+      {
+        "id": "G19",
+        "expected": "solanum_betaceum",
+        "rank": 293
+      },
+      {
+        "id": "G20",
+        "expected": "coffea_arabica",
+        "rank": 4
+      },
+      {
+        "id": "G21",
+        "expected": "coffea_arabica",
+        "rank": 4
+      },
+      {
+        "id": "G22",
+        "expected": "lactuca_sativa",
+        "rank": 4
+      },
+      {
+        "id": "G23",
+        "expected": "solanum_lycopersicum",
+        "rank": 6
+      },
+      {
+        "id": "G24",
+        "expected": "solanum_tuberosum",
+        "rank": 3
+      },
+      {
+        "id": "G25",
+        "expected": "coffea_arabica",
+        "rank": 2
+      },
+      {
+        "id": "G26",
+        "expected": "zea_mays",
+        "rank": 28
+      },
+      {
+        "id": "G27",
+        "expected": "phaseolus_vulgaris",
+        "rank": 2
+      },
+      {
+        "id": "G28",
+        "expected": "persea_americana",
+        "rank": 2
+      },
+      {
+        "id": "G29",
+        "expected": "allium_cepa",
+        "rank": 1
+      },
+      {
+        "id": "G30",
+        "expected": "coriandrum_sativum",
+        "rank": 1
+      },
+      {
+        "id": "G31",
+        "expected": "manihot_esculenta",
+        "rank": 1
+      },
+      {
+        "id": "G32",
+        "expected": "pisum_sativum",
+        "rank": 91
+      },
+      {
+        "id": "G33",
+        "expected": "rubus_glaucus",
+        "rank": 4
+      },
+      {
+        "id": "G34",
+        "expected": "solanum_quitoense",
+        "rank": 183
+      },
+      {
+        "id": "G35",
+        "expected": "physalis_peruviana",
+        "rank": 1
+      },
+      {
+        "id": "G36",
+        "expected": "coffea_arabica",
+        "rank": 21
+      },
+      {
+        "id": "G37",
+        "expected": "solanum_tuberosum",
+        "rank": 1
+      },
+      {
+        "id": "G38",
+        "expected": "solanum_lycopersicum",
+        "rank": 22
+      },
+      {
+        "id": "G39",
+        "expected": "biopreparado",
+        "rank": null
+      },
+      {
+        "id": "G40",
+        "expected": "musa_paradisiaca",
+        "rank": 365
+      },
+      {
+        "id": "G41",
+        "expected": "coffea_arabica",
+        "rank": 10
+      },
+      {
+        "id": "G42",
+        "expected": "daucus_carota",
+        "rank": 2
+      },
+      {
+        "id": "G43",
+        "expected": "solanum_tuberosum",
+        "rank": 2
+      },
+      {
+        "id": "G44",
+        "expected": "associacion",
+        "rank": null
+      },
+      {
+        "id": "G45",
+        "expected": "phaseolus_vulgaris",
+        "rank": 2
+      },
+      {
+        "id": "G46",
+        "expected": "mito_lunar",
+        "rank": null
+      },
+      {
+        "id": "G47",
+        "expected": "suelo_acido",
+        "rank": null
+      },
+      {
+        "id": "G48",
+        "expected": "agua_calidad",
+        "rank": null
+      },
+      {
+        "id": "G49",
+        "expected": "erosion",
+        "rank": null
+      },
+      {
+        "id": "G50",
+        "expected": "coffea_arabica",
+        "rank": 8
+      }
+    ],
+    "D_passage_mean": [
+      {
+        "id": "G01",
+        "expected": "coffea_arabica",
+        "rank": 10
+      },
+      {
+        "id": "G02",
+        "expected": "allium_cepa",
+        "rank": 366
+      },
+      {
+        "id": "G03",
+        "expected": "solanum_tuberosum",
+        "rank": 170
+      },
+      {
+        "id": "G04",
+        "expected": "lactuca_sativa",
+        "rank": 36
+      },
+      {
+        "id": "G05",
+        "expected": "coffea_arabica",
+        "rank": 62
+      },
+      {
+        "id": "G06",
+        "expected": "zea_mays",
+        "rank": 39
+      },
+      {
+        "id": "G07",
+        "expected": "solanum_lycopersicum",
+        "rank": 69
+      },
+      {
+        "id": "G08",
+        "expected": "solanum_tuberosum",
+        "rank": 171
+      },
+      {
+        "id": "G09",
+        "expected": "phaseolus_vulgaris",
+        "rank": 26
+      },
+      {
+        "id": "G10",
+        "expected": "fragaria_ananassa",
+        "rank": 27
+      },
+      {
+        "id": "G11",
+        "expected": "persea_americana",
+        "rank": 190
+      },
+      {
+        "id": "G12",
+        "expected": "allium_cepa",
+        "rank": 155
+      },
+      {
+        "id": "G13",
+        "expected": "manihot_esculenta",
+        "rank": 137
+      },
+      {
+        "id": "G14",
+        "expected": "rubus_glaucus",
+        "rank": 144
+      },
+      {
+        "id": "G15",
+        "expected": "daucus_carota",
+        "rank": 171
+      },
+      {
+        "id": "G16",
+        "expected": "musa_paradisiaca",
+        "rank": 227
+      },
+      {
+        "id": "G17",
+        "expected": "solanum_tuberosum",
+        "rank": 180
+      },
+      {
+        "id": "G18",
+        "expected": "zea_mays",
+        "rank": 202
+      },
+      {
+        "id": "G19",
+        "expected": "solanum_betaceum",
+        "rank": 382
+      },
+      {
+        "id": "G20",
+        "expected": "coffea_arabica",
+        "rank": 11
+      },
+      {
+        "id": "G21",
+        "expected": "coffea_arabica",
+        "rank": 15
+      },
+      {
+        "id": "G22",
+        "expected": "lactuca_sativa",
+        "rank": 42
+      },
+      {
+        "id": "G23",
+        "expected": "solanum_lycopersicum",
+        "rank": 67
+      },
+      {
+        "id": "G24",
+        "expected": "solanum_tuberosum",
+        "rank": 225
+      },
+      {
+        "id": "G25",
+        "expected": "coffea_arabica",
+        "rank": 12
+      },
+      {
+        "id": "G26",
+        "expected": "zea_mays",
+        "rank": 68
+      },
+      {
+        "id": "G27",
+        "expected": "phaseolus_vulgaris",
+        "rank": 12
+      },
+      {
+        "id": "G28",
+        "expected": "persea_americana",
+        "rank": 18
+      },
+      {
+        "id": "G29",
+        "expected": "allium_cepa",
+        "rank": 41
+      },
+      {
+        "id": "G30",
+        "expected": "coriandrum_sativum",
+        "rank": 250
+      },
+      {
+        "id": "G31",
+        "expected": "manihot_esculenta",
+        "rank": 68
+      },
+      {
+        "id": "G32",
+        "expected": "pisum_sativum",
+        "rank": 307
+      },
+      {
+        "id": "G33",
+        "expected": "rubus_glaucus",
+        "rank": 63
+      },
+      {
+        "id": "G34",
+        "expected": "solanum_quitoense",
+        "rank": 168
+      },
+      {
+        "id": "G35",
+        "expected": "physalis_peruviana",
+        "rank": 7
+      },
+      {
+        "id": "G36",
+        "expected": "coffea_arabica",
+        "rank": 16
+      },
+      {
+        "id": "G37",
+        "expected": "solanum_tuberosum",
+        "rank": 234
+      },
+      {
+        "id": "G38",
+        "expected": "solanum_lycopersicum",
+        "rank": 55
+      },
+      {
+        "id": "G39",
+        "expected": "biopreparado",
+        "rank": null
+      },
+      {
+        "id": "G40",
+        "expected": "musa_paradisiaca",
+        "rank": 295
+      },
+      {
+        "id": "G41",
+        "expected": "coffea_arabica",
+        "rank": 13
+      },
+      {
+        "id": "G42",
+        "expected": "daucus_carota",
+        "rank": 117
+      },
+      {
+        "id": "G43",
+        "expected": "solanum_tuberosum",
+        "rank": 118
+      },
+      {
+        "id": "G44",
+        "expected": "associacion",
+        "rank": null
+      },
+      {
+        "id": "G45",
+        "expected": "phaseolus_vulgaris",
+        "rank": 13
+      },
+      {
+        "id": "G46",
+        "expected": "mito_lunar",
+        "rank": null
+      },
+      {
+        "id": "G47",
+        "expected": "suelo_acido",
+        "rank": null
+      },
+      {
+        "id": "G48",
+        "expected": "agua_calidad",
+        "rank": null
+      },
+      {
+        "id": "G49",
+        "expected": "erosion",
+        "rank": null
+      },
+      {
+        "id": "G50",
+        "expected": "coffea_arabica",
+        "rank": 14
+      }
+    ],
+    "E_passage_top3": [
+      {
+        "id": "G01",
+        "expected": "coffea_arabica",
+        "rank": 5
+      },
+      {
+        "id": "G02",
+        "expected": "allium_cepa",
+        "rank": 426
+      },
+      {
+        "id": "G03",
+        "expected": "solanum_tuberosum",
+        "rank": 97
+      },
+      {
+        "id": "G04",
+        "expected": "lactuca_sativa",
+        "rank": 2
+      },
+      {
+        "id": "G05",
+        "expected": "coffea_arabica",
+        "rank": 239
+      },
+      {
+        "id": "G06",
+        "expected": "zea_mays",
+        "rank": 94
+      },
+      {
+        "id": "G07",
+        "expected": "solanum_lycopersicum",
+        "rank": 25
+      },
+      {
+        "id": "G08",
+        "expected": "solanum_tuberosum",
+        "rank": 25
+      },
+      {
+        "id": "G09",
+        "expected": "phaseolus_vulgaris",
+        "rank": 14
+      },
+      {
+        "id": "G10",
+        "expected": "fragaria_ananassa",
+        "rank": 66
+      },
+      {
+        "id": "G11",
+        "expected": "persea_americana",
+        "rank": 17
+      },
+      {
+        "id": "G12",
+        "expected": "allium_cepa",
+        "rank": 92
+      },
+      {
+        "id": "G13",
+        "expected": "manihot_esculenta",
+        "rank": 2
+      },
+      {
+        "id": "G14",
+        "expected": "rubus_glaucus",
+        "rank": 7
+      },
+      {
+        "id": "G15",
+        "expected": "daucus_carota",
+        "rank": 58
+      },
+      {
+        "id": "G16",
+        "expected": "musa_paradisiaca",
+        "rank": 386
+      },
+      {
+        "id": "G17",
+        "expected": "solanum_tuberosum",
+        "rank": 25
+      },
+      {
+        "id": "G18",
+        "expected": "zea_mays",
+        "rank": 171
+      },
+      {
+        "id": "G19",
+        "expected": "solanum_betaceum",
+        "rank": 388
+      },
+      {
+        "id": "G20",
+        "expected": "coffea_arabica",
+        "rank": 3
+      },
+      {
+        "id": "G21",
+        "expected": "coffea_arabica",
+        "rank": 5
+      },
+      {
+        "id": "G22",
+        "expected": "lactuca_sativa",
+        "rank": 3
+      },
+      {
+        "id": "G23",
+        "expected": "solanum_lycopersicum",
+        "rank": 25
+      },
+      {
+        "id": "G24",
+        "expected": "solanum_tuberosum",
+        "rank": 5
+      },
+      {
+        "id": "G25",
+        "expected": "coffea_arabica",
+        "rank": 2
+      },
+      {
+        "id": "G26",
+        "expected": "zea_mays",
+        "rank": 48
+      },
+      {
+        "id": "G27",
+        "expected": "phaseolus_vulgaris",
+        "rank": 3
+      },
+      {
+        "id": "G28",
+        "expected": "persea_americana",
+        "rank": 1
+      },
+      {
+        "id": "G29",
+        "expected": "allium_cepa",
+        "rank": 1
+      },
+      {
+        "id": "G30",
+        "expected": "coriandrum_sativum",
+        "rank": 12
+      },
+      {
+        "id": "G31",
+        "expected": "manihot_esculenta",
+        "rank": 2
+      },
+      {
+        "id": "G32",
+        "expected": "pisum_sativum",
+        "rank": 325
+      },
+      {
+        "id": "G33",
+        "expected": "rubus_glaucus",
+        "rank": 8
+      },
+      {
+        "id": "G34",
+        "expected": "solanum_quitoense",
+        "rank": 141
+      },
+      {
+        "id": "G35",
+        "expected": "physalis_peruviana",
+        "rank": 1
+      },
+      {
+        "id": "G36",
+        "expected": "coffea_arabica",
+        "rank": 14
+      },
+      {
+        "id": "G37",
+        "expected": "solanum_tuberosum",
+        "rank": 5
+      },
+      {
+        "id": "G38",
+        "expected": "solanum_lycopersicum",
+        "rank": 23
+      },
+      {
+        "id": "G39",
+        "expected": "biopreparado",
+        "rank": null
+      },
+      {
+        "id": "G40",
+        "expected": "musa_paradisiaca",
+        "rank": 394
+      },
+      {
+        "id": "G41",
+        "expected": "coffea_arabica",
+        "rank": 5
+      },
+      {
+        "id": "G42",
+        "expected": "daucus_carota",
+        "rank": 13
+      },
+      {
+        "id": "G43",
+        "expected": "solanum_tuberosum",
+        "rank": 5
+      },
+      {
+        "id": "G44",
+        "expected": "associacion",
+        "rank": null
+      },
+      {
+        "id": "G45",
+        "expected": "phaseolus_vulgaris",
+        "rank": 8
+      },
+      {
+        "id": "G46",
+        "expected": "mito_lunar",
+        "rank": null
+      },
+      {
+        "id": "G47",
+        "expected": "suelo_acido",
+        "rank": null
+      },
+      {
+        "id": "G48",
+        "expected": "agua_calidad",
+        "rank": null
+      },
+      {
+        "id": "G49",
+        "expected": "erosion",
+        "rank": null
+      },
+      {
+        "id": "G50",
+        "expected": "coffea_arabica",
+        "rank": 21
+      }
+    ]
+  }
+}

--- a/ops/informes/chunking-passages-2026-07-23.md
+++ b/ops/informes/chunking-passages-2026-07-23.md
@@ -1,0 +1,211 @@
+# Informe — Chunking passage-level MEDIDO sobre el RAG de Chagra
+
+**Fecha:** 2026-07-23 · **Autor:** carril RAG/infra · **Rama:** `exp/rag-chunking-passages`
+**Modelo embedder:** `nomic-embed-text` (768d), el mismo que prod usa hoy en `embedQuery()` y en `build-rag-embeddings.mjs`.
+**Golden set:** `eval/rag-golden.json` (50 queries campesinas, 1 especie esperada por query).
+**Infra:** embeddings servidos por Ollama en alpha (`http://alpha.local:11434`). No se tocó `public/rag-embeddings.json` de prod ni el modelo servido.
+
+---
+
+## 0. Veredicto — NO vale la pena (el chunking fino DEGRADA el recall)
+
+La hipótesis del experimento era: *"hoy el corpus tiene UN vector por especie (chunking grueso);
+ese es el cuello del retrieval semántico; embeber cada passage por separado debería subir el
+recall."* **La medición la refuta.** Bajo condiciones idénticas (mismo modelo, mismas 50 queries,
+misma regla de match), el chunking passage-level **empeora** el retrieve semántico, no lo mejora:
+
+| arm (retrieval puro-semántico, cosine) | recall@1 | recall@3 | recall@5 | MRR |
+|---|---|---|---|---|
+| **A — doc-level PROD** (`extractPassageText`, 1 vec/especie) — *baseline* | **40%** | **56%** | **58%** | **0.4833** |
+| B — doc-level flatten (concat de `flattenDoc`, 1 vec/especie) | 10% | 18% | 30% | 0.1861 |
+| C — passage-level **max-pool** (`flattenDoc`, N vec/especie) | 12% | 32% | 42% | 0.2646 |
+| D — passage-level mean-pool | 0% | 0% | 0% | 0.0261 |
+| E — passage-level top3-mean | 6% | 20% | 32% | 0.1664 |
+
+**Delta del MEJOR passage-level (max-pool) vs doc-level PROD: recall@1 −28 pp · recall@3 −24 pp ·
+recall@5 −16 pp · MRR −0.2187.** Ningún esquema de pooling (max / mean / top3) alcanza al
+doc-level. El passage-level max-pool no **gana** ni una sola query en top-5 y **pierde 8**.
+
+**Recomendación:** NO cablear passage-level a producción. El techo del RAG **no** está en la
+granularidad del chunk (como se conjeturó en el informe del reranker), sino en la **selección de
+contenido**: la ficha doc-level de prod gana porque `extractPassageText` embebe un **resumen
+curado** (valor pedagógico + hitos + modos de fallo + lección), mientras que `flattenDoc` indexa
+**todo** —incluyendo boilerplate genérico compartido entre cientos de especies— y ese ruido
+ahoga la señal, tanto agregado en un vector (arm B) como troceado en passages (arm C).
+
+Esto encadena con la memoria `ci-green-not-real-value` y con el informe hermano
+`reranker-medido-2026-07-23.md`: la técnica "obviamente buena" de la literatura (chunking fino)
+**sobre este corpus mide negativo**. Medir antes de cablear evitó re-indexar prod a un esquema que
+habría bajado el recall@5 de 58% a 42%.
+
+---
+
+## 1. Qué se construyó (sin tocar prod)
+
+1. **Respaldo** de `public/rag-embeddings.json` (corpus doc-level de prod, 501 vectores) →
+   `data/rag-chunking-exp/rag-embeddings.doc-level.backup.json`.
+2. **Corpus passage-level** (`scripts/rag-chunking-build-passages.mjs`): usa el `flattenDoc()`
+   **real** de `src/services/ragRetriever.js` (importado vía el loader de `bench-rag-retrieve.mjs`,
+   sin drift) para sacar los passages de cada ficha de `public/cycle-content/*.json` y embebe
+   **cada passage** con nomic. Salida `data/rag-chunking-exp/rag-embeddings-passages.json`.
+3. **Arm de control docflat** (mismo script): 1 vector por especie con el texto **concatenado** de
+   `flattenDoc` (mismo contenido que los passages, pero pooled a un solo vector). Aísla el efecto
+   *"más contenido"* del efecto *"chunking fino"*.
+4. **Bench** (`scripts/rag-chunking-bench.mjs`): retrieval puro-semántico de los 5 arms sobre las
+   50 queries, con max-pooling por especie y colapso variedad→base.
+
+Artefactos grandes en `data/rag-chunking-exp/` (gitignored); solo `results.json` se commitea.
+
+---
+
+## 2. Dimensionado del corpus passage-level
+
+`scripts/rag-chunking-count.mjs` (importa el `flattenDoc` real):
+
+| métrica | valor |
+|---|---|
+| Fichas en el manifest | 501 |
+| **Passages totales** (`flattenDoc`) | **20.201** |
+| **Textos ÚNICOS de passage** | **3.909** |
+| Passages por ficha (min / mediana / media / p95 / max) | 22 / 39 / 40,3 / 49 / 153 |
+| Passages truncados a 5.000 chars (ver §5) | 22 / 20.201 (0,1%) |
+
+**Hallazgo de dimensionado #1 — el 80% de los passages son boilerplate repetido.** De 20.201
+passages solo hay **3.909 textos únicos**: labels de hitos ("germinación", "cosecha"), campos
+contextuales ("clima templado", "altitud 1800"), nombres de companions y frases de manejo se
+**repiten idénticos** entre cientos de especies. Por eso el build embebe solo los 3.909 únicos y
+reusa el vector (5× menos llamadas a Ollama). Esto ya anticipa el problema de recall (§4): la
+mayoría de los "passages" no discriminan especie.
+
+**Hallazgo de dimensionado #2 — es el umbral donde pgvector empezaría a tener sentido.** 20.201
+vectores materializados como `{slug,key,vector[768]}` pesan **~140 MB** en JSON (deduplicados, con
+índice de refs, ~61 MB). El retriever JS actual los maneja en memoria, pero cada query debe correr
+**3.909 cosines** (por texto único) + max-pool sobre 20.201 refs. A este tamaño, un índice ANN en
+Postgres/pgvector (que la infra ya tiene: `postgres-farm`, PG 15.17) sería la evolución natural
+**si** el passage-level hubiera ganado recall. No ganó, así que la migración a pgvector **no se
+justifica por este experimento** (sí podría por otros: catálogo Pro, multi-tenant).
+
+---
+
+## 3. Metodología (por qué la comparación es limpia)
+
+- **Puro semántico**: se mide solo cosine (sin BM25), para aislar el efecto del chunking sobre la
+  capa que el experimento cuestiona. Los 5 arms comparten modelo, queries y regla de match; **lo
+  único que cambia es el chunking**, así que el delta es atribuible a él.
+- **Query embebida igual que prod**: prompt crudo, sin prefijos `search_query:`/`search_document:`
+  (idéntico a `embedQuery()` y a `build-rag-embeddings.mjs`). Cacheada en
+  `query-embeddings.json` para reproducibilidad.
+- **Colapso variedad→base**: cada arm colapsa `solanum_tuberosum_pastusa_suprema` →
+  `solanum_tuberosum` tomando el max score por base (igual que `collapseVarieties` en prod), y el
+  `expected` del golden es especie base. Match: `base === expected || base.startsWith(expected+'_')`.
+- **Max-pool por especie** (lo que pide el brief): score de una especie = MÁXIMO cosine entre sus
+  passages. Se añadieron mean-pool y top3-mean para verificar que el resultado negativo no fuera un
+  artefacto del max-pool (no lo es — todos pierden).
+- **Techo del set**: 44/50 = 88%. Seis queries (`G39 biopreparado`, `G44 associacion`,
+  `G46 mito_lunar`, `G47 suelo_acido`, `G48 agua_calidad`, `G49 erosion`) son conceptos
+  cross-especie sin slug; ningún arm puede acertarlas → penalizan a todos por igual.
+- **Validación del harness**: el arm A (doc-level PROD) reproduce **recall@1 = 40% (20/50) exacto**,
+  el mismo headline que el baseline de prod. Si el harness estuviera roto/deflactando, el arm A no
+  daría 40%. (Los @3/@5 de este bench —56/58%— son más altos que las cifras híbridas citadas en
+  otros informes porque acá es puro-semántico + match por base colapsada; el número invariante y
+  decisivo es el **delta controlado entre arms**, no el valor absoluto.)
+
+---
+
+## 4. Por qué el chunking fino DEGRADA (causa raíz, con evidencia)
+
+**El max-pool premia el ruido genérico y sufre sesgo de longitud.** El score de una especie es el
+máximo cosine entre sus passages; una especie con 118–153 passages tiene 118–153 "boletos" para un
+cosine espuriamente alto contra la query, y la mayoría de esos passages son boilerplate genérico
+(`propagation.notas`, campos contextuales) que se parece semánticamente a muchas queries sin
+identificar especie.
+
+**Caso G06 — "como abonar el maiz"** (esperado `zea_mays`):
+
+| arm | rank de zea_mays |
+|---|---|
+| A doc-level PROD | **4** (acierta @5) |
+| C passage-level max-pool | **165** (falla) |
+
+Top-5 especies que el passage-level max-pool pone por encima del maíz para esa query:
+
+```
+1. amaranthus_caudatus     sim=0.674  via key=propagation.notas
+2. phaseolus_vulgaris_nuna  sim=0.666  via key=propagation.notas
+3. practica_cogollero_maiz  sim=0.662  via key=species_slug
+4. practica_bocashi         sim=0.643  via key=failure_modes[0].mode
+5. practica_biol            sim=0.642  via key=milestones[2].label
+...
+165. zea_mays               sim=0.590  via key=propagation.notas
+```
+
+El passage ganador de casi todas es `propagation.notas` —una nota de propagación genérica que
+menciona nutrición/abono y existe casi idéntica en decenas de fichas—. El maíz no tiene un passage
+que supere a esos genéricos, así que cae al puesto 165. En cambio, el vector **doc-level** del maíz
+(que concatena su valor pedagógico + hitos + modos de fallo + lección en **un texto coherente**)
+captura el "gestalt" de *cultivar maíz, incluida su fertilización* y rankea maíz en el puesto 4.
+
+**El mean-pool es catastrófico (0% recall)** justamente por lo mismo: promediar ~40 passages, la
+mayoría boilerplate corto, produce un score casi idéntico entre especies → cero poder
+discriminante → ranking ~aleatorio.
+
+**El arm B (docflat) lo confirma desde el otro lado.** Embeber TODO el contenido de `flattenDoc`
+concatenado en **un** vector (misma granularidad gruesa que prod, pero más contenido) también se
+desploma a 10/18/30. Es decir: **el problema no es la granularidad, es el contenido.**
+`extractPassageText` gana porque es un **subconjunto curado** de campos pedagógicos;
+`flattenDoc` (todo lo indexable, incluidos slugs, taxonomía, números contextuales, boilerplate)
+mete ruido que ahoga la señal, se trocee (C) o no (B).
+
+---
+
+## 5. Notas de implementación / gotchas
+
+- **Contexto de nomic (HTTP 500 "input length exceeds the context length").** nomic-embed-text en
+  este Ollama tiene ctx ~2.048 tokens y **rechaza** (no trunca) textos largos; `num_ctx` NO lo
+  extiende (verificado: falla >~6.000 chars de prosa densa aun con `num_ctx:8192`). Se truncan los
+  textos a 5.000 chars antes de embeber —régimen de contexto por defecto, el mismo con el que se
+  construyó el corpus doc-level de prod—. Afecta a **22 de 3.909** passages únicos (0,6%) y a
+  algunos concat de docflat; impacto en el veredicto: nulo (el passage-level pierde por 16–28 pp,
+  no por un margen que 22 truncados moverían).
+- **`flattenDoc` importado, no copiado.** El build y el contador importan el `flattenDoc` real de
+  `ragRetriever.js` vía `scripts/bench-rag-retrieve.loader.mjs` (stubea authService/tenantContext/
+  catalogDB y neutraliza `import.meta.env`), así que no hay drift con producción.
+- **Dedup de embeddings.** 20.201 passages → 3.909 embeds reales. Sin dedup, el build sería 5× más
+  lento y el asset ~5× más grande.
+
+---
+
+## 6. Si en el futuro se quisiera pasar passage-level a prod (NO ahora)
+
+Documentado por completitud; **hoy no se cablea** porque no sube el recall. El camino sería:
+
+1. **Build**: `build-rag-embeddings.mjs` generaría un asset passage-level (no `{slug→vec}` sino
+   `{slug,key→vec}`), reusando `flattenDoc` + dedup por texto. Tamaño ~60–140 MB → pasa el umbral
+   donde conviene **pgvector** (postgres-farm ya está) en vez de JSON en memoria.
+2. **Retriever**: `scoreSemanticDocs()` cambiaría de `embeddings[doc.species]` (1 vector) a
+   max-pool sobre los passages de la especie, y `combineResults` fusionaría con BM25 igual que hoy.
+3. **Requisito previo NO cumplido**: primero habría que **arreglar la selección de contenido** (que
+   `flattenDoc` no meta boilerplate/IDs/números como passages semánticos) — porque el experimento
+   muestra que passages sobre `flattenDoc` crudo degradan. Sin ese filtro, no hay caso.
+
+### Lever real sugerido por los datos (fuera del alcance de este experimento)
+El delta A vs B/C dice que la palanca no es el tamaño del chunk sino **qué se embebe**. Hipótesis a
+medir en un próximo experimento: (a) enriquecer `extractPassageText` con más campos pedagógicos
+curados (no todos), o (b) passage-level pero **filtrando** los passages genéricos/contextuales
+(indexar solo campos discriminantes: valor pedagógico, plagas, manejo, lección — no
+`propagation.notas` ni contextuales numéricos). Ambas atacan el ruido, que es la causa raíz medida.
+
+---
+
+## 7. Reproducir
+
+```bash
+# 1. corpus passage-level + docflat (embebe ~4.410 textos en alpha, ~3 min)
+OLLAMA_URL=http://alpha.local:11434 node scripts/rag-chunking-build-passages.mjs
+# 2. bench de los 5 arms (queries cacheadas tras la 1ª corrida)
+OLLAMA_URL=http://alpha.local:11434 node scripts/rag-chunking-bench.mjs
+# (opcional) dimensionar el corpus
+node scripts/rag-chunking-count.mjs
+```
+
+Resultados crudos: `data/rag-chunking-exp/results.json`.

--- a/scripts/rag-chunking-bench.mjs
+++ b/scripts/rag-chunking-bench.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+/**
+ * rag-chunking-bench.mjs — mide si el chunking passage-level mejora el recall
+ * SEMÁNTICO del RAG de Chagra vs el chunking doc-level de prod.
+ *
+ * Compara TRES arms de retrieval PURO-SEMÁNTICO (cosine, sin BM25), con el MISMO
+ * modelo (nomic-embed-text 768d), las MISMAS 50 queries de eval/rag-golden.json y
+ * la MISMA regla de match, de modo que el único cambio entre arms es el chunking:
+ *
+ *   A) doc-level (PROD)      — public/rag-embeddings.json: 1 vector/especie con
+ *                              extractPassageText() (subconjunto de campos). Es el
+ *                              baseline a batir.
+ *   B) doc-level (flatten)   — data/rag-chunking-exp/rag-embeddings-docflat.json:
+ *                              1 vector/especie pero embebiendo el texto
+ *                              CONCATENADO de flattenDoc (todo el contenido
+ *                              indexable, pooled). Aísla "más contenido" de
+ *                              "chunking fino".
+ *   C) passage-level         — data/rag-chunking-exp/rag-embeddings-passages.json:
+ *                              N vectores/especie (flattenDoc), score de la
+ *                              especie = MAX cosine entre sus passages (max-pooling).
+ *
+ * Match: el `expected` del golden es especie BASE (genus_species). Cada arm
+ * colapsa variedades a base (parts.slice(0,2), como collapseVarieties en prod),
+ * toma el max score por base, rankea, y cuenta hit si la base esperada cae en
+ * top-K. Techo del set: 44/50 (6 queries son conceptos cross-especie sin slug).
+ *
+ * Uso:
+ *   OLLAMA_URL=http://alpha.local:11434 node scripts/rag-chunking-bench.mjs
+ *   (requiere haber corrido antes scripts/rag-chunking-build-passages.mjs)
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const EXP_DIR = resolve(ROOT, 'data', 'rag-chunking-exp');
+const GOLDEN_PATH = resolve(ROOT, 'eval', 'rag-golden.json');
+const DOC_PROD_PATH = resolve(ROOT, 'public', 'rag-embeddings.json');
+const DOCFLAT_PATH = resolve(EXP_DIR, 'rag-embeddings-docflat.json');
+const PASSAGES_PATH = resolve(EXP_DIR, 'rag-embeddings-passages.json');
+const QCACHE_PATH = resolve(EXP_DIR, 'query-embeddings.json');
+const RESULTS_PATH = resolve(EXP_DIR, 'results.json');
+
+const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434';
+const EMBED_MODEL = process.env.RAG_EMBED_MODEL || 'nomic-embed-text';
+
+// ── helpers ──────────────────────────────────────────────────────────────
+function cosine(a, b) {
+  if (!a || !b || a.length !== b.length) return 0;
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  const d = Math.sqrt(na) * Math.sqrt(nb);
+  return d > 0 ? dot / d : 0;
+}
+
+function collapseToBase(slug) {
+  const parts = String(slug).split('_');
+  return parts.length >= 2 ? parts.slice(0, 2).join('_') : slug;
+}
+
+function matchesSpecies(base, expected) {
+  return base === expected || base.startsWith(`${expected}_`);
+}
+
+// Dequantiza un valor del asset (soporta int8 como ragRetriever). Prod hoy usa
+// float plano, pero mantenemos el guard por si el asset viene quantizado.
+function toVec(entry) {
+  if (Array.isArray(entry) && entry.length > 0) return entry;
+  if (entry && entry.q === 'int8' && Array.isArray(entry.v) && entry.s) {
+    return entry.v.map((x) => x * entry.s);
+  }
+  return null;
+}
+
+async function embedQuery(text, tries = 3) {
+  for (let attempt = 1; attempt <= tries; attempt += 1) {
+    try {
+      const res = await fetch(`${OLLAMA_URL}/api/embeddings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: EMBED_MODEL, prompt: text }),
+      });
+      if (!res.ok) throw new Error(`ollama ${res.status}`);
+      const data = await res.json();
+      if (!Array.isArray(data.embedding) || !data.embedding.length) throw new Error('vacío');
+      return data.embedding;
+    } catch (err) {
+      if (attempt === tries) throw err;
+      await new Promise((r) => setTimeout(r, 300 * attempt));
+    }
+  }
+  throw new Error('unreachable');
+}
+
+// Rankea especies BASE para un arm que mapea slug→vector.
+function rankBasesFromSlugMap(qVec, slugMap) {
+  const baseScore = new Map();
+  for (const [slug, entry] of Object.entries(slugMap)) {
+    const vec = toVec(entry);
+    if (!vec) continue;
+    const s = cosine(qVec, vec);
+    const base = collapseToBase(slug);
+    const prev = baseScore.get(base);
+    if (prev === undefined || s > prev) baseScore.set(base, s);
+  }
+  return [...baseScore.entries()].sort((a, b) => b[1] - a[1]).map(([base]) => base);
+}
+
+// Rankea especies BASE para el arm passage-level. `pool` define cómo se agregan
+// los scores de los passages de una especie a UN score de especie:
+//   'max'  → el MÁXIMO (lo que pide el brief; sesgo de longitud: más passages =
+//            más chances de un cosine espuriamente alto).
+//   'mean' → el PROMEDIO de todos los passages de la especie.
+//   'top3' → el promedio de los 3 mejores passages (compromiso robusto).
+// El pooling se hace por SLUG (variedad) y luego se colapsa a base con MAX,
+// igual que collapseVarieties en prod. Recibe simByTextId ya calculado.
+function rankBasesFromPassages(simByTextId, passageBySlug, pool) {
+  const slugScore = new Map();
+  for (const [slug, refs] of passageBySlug.entries()) {
+    const sims = [];
+    for (const ref of refs) {
+      const s = simByTextId.get(ref.t);
+      if (s !== undefined) sims.push(s);
+    }
+    if (sims.length === 0) continue;
+    let score;
+    if (pool === 'max') {
+      score = Math.max(...sims);
+    } else if (pool === 'mean') {
+      score = sims.reduce((a, b) => a + b, 0) / sims.length;
+    } else { // top3
+      sims.sort((a, b) => b - a);
+      const top = sims.slice(0, 3);
+      score = top.reduce((a, b) => a + b, 0) / top.length;
+    }
+    slugScore.set(slug, score);
+  }
+  const baseScore = new Map();
+  for (const [slug, s] of slugScore.entries()) {
+    const base = collapseToBase(slug);
+    const prev = baseScore.get(base);
+    if (prev === undefined || s > prev) baseScore.set(base, s);
+  }
+  return [...baseScore.entries()].sort((a, b) => b[1] - a[1]).map(([base]) => base);
+}
+
+function rankOfExpected(rankedBases, expected) {
+  for (let i = 0; i < rankedBases.length; i++) {
+    if (matchesSpecies(rankedBases[i], expected)) return i + 1; // 1-based
+  }
+  return null;
+}
+
+function metricsFromRanks(ranks) {
+  const n = ranks.length;
+  let r1 = 0, r3 = 0, r5 = 0, rr = 0;
+  for (const rank of ranks) {
+    if (rank === null) continue;
+    if (rank === 1) r1 += 1;
+    if (rank <= 3) r3 += 1;
+    if (rank <= 5) r5 += 1;
+    rr += 1 / rank;
+  }
+  return {
+    'recall@1': Number((r1 / n * 100).toFixed(1)),
+    'recall@3': Number((r3 / n * 100).toFixed(1)),
+    'recall@5': Number((r5 / n * 100).toFixed(1)),
+    MRR: Number((rr / n).toFixed(4)),
+  };
+}
+
+async function main() {
+  console.log('=== rag-chunking-bench (puro semántico, nomic-embed-text) ===');
+  console.log(`  Ollama: ${OLLAMA_URL}`);
+  for (const p of [DOCFLAT_PATH, PASSAGES_PATH]) {
+    if (!existsSync(p)) { console.error(`  FALTA ${p} — corra rag-chunking-build-passages.mjs primero.`); process.exit(1); }
+  }
+
+  const golden = JSON.parse(readFileSync(GOLDEN_PATH, 'utf8'));
+  const docProd = JSON.parse(readFileSync(DOC_PROD_PATH, 'utf8'));
+  const docFlat = JSON.parse(readFileSync(DOCFLAT_PATH, 'utf8'));
+  const passageCorpus = JSON.parse(readFileSync(PASSAGES_PATH, 'utf8'));
+  const passageRefs = passageCorpus.passages;   // [{slug, key, t}]
+  const passageTexts = passageCorpus.texts;      // { t: number[768] }
+
+  // Agrupar refs por slug UNA vez (reuso en cada query y cada pooling).
+  const passageBySlug = new Map();
+  for (const ref of passageRefs) {
+    if (!passageBySlug.has(ref.slug)) passageBySlug.set(ref.slug, []);
+    passageBySlug.get(ref.slug).push(ref);
+  }
+
+  // Techo: cuántos expected-base existen como base en el arm passage (mejor
+  // cobertura). Se reporta como cota superior alcanzable.
+  const passageBases = new Set(passageRefs.map((r) => collapseToBase(r.slug)));
+  const ceiling = golden.filter((g) => passageBases.has(g.expected)).length;
+
+  console.log(`  Golden: ${golden.length} queries | passages: ${passageRefs.length} refs, ${Object.keys(passageTexts).length} vectores únicos`);
+  console.log(`  Techo (expected-base presente en corpus): ${ceiling}/${golden.length} = ${(ceiling / golden.length * 100).toFixed(1)}%`);
+
+  // 1. Embeber queries (cache).
+  let qcache = existsSync(QCACHE_PATH) ? JSON.parse(readFileSync(QCACHE_PATH, 'utf8')) : {};
+  let embedded = 0;
+  for (const g of golden) {
+    if (!qcache[g.id]) { qcache[g.id] = await embedQuery(g.query); embedded += 1; }
+  }
+  if (embedded > 0) writeFileSync(QCACHE_PATH, JSON.stringify(qcache));
+  console.log(`  Queries embebidas: ${embedded} nuevas, ${golden.length - embedded} de cache`);
+
+  // 2. Rankear por arm.
+  const arms = {
+    A_doc_prod: { label: 'doc-level PROD (extractPassageText, 1 vec/especie)', ranks: [], perQuery: [] },
+    B_doc_flatten: { label: 'doc-level flatten (concat flattenDoc, 1 vec/especie)', ranks: [], perQuery: [] },
+    C_passage_max: { label: 'passage-level max-pool (flattenDoc, N vec/especie)', ranks: [], perQuery: [] },
+    D_passage_mean: { label: 'passage-level mean-pool (flattenDoc, N vec/especie)', ranks: [], perQuery: [] },
+    E_passage_top3: { label: 'passage-level top3-mean (flattenDoc, N vec/especie)', ranks: [], perQuery: [] },
+  };
+
+  for (const g of golden) {
+    const qVec = qcache[g.id];
+
+    const ra = rankOfExpected(rankBasesFromSlugMap(qVec, docProd), g.expected);
+    arms.A_doc_prod.ranks.push(ra);
+    arms.A_doc_prod.perQuery.push({ id: g.id, expected: g.expected, rank: ra });
+
+    const rb = rankOfExpected(rankBasesFromSlugMap(qVec, docFlat), g.expected);
+    arms.B_doc_flatten.ranks.push(rb);
+    arms.B_doc_flatten.perQuery.push({ id: g.id, expected: g.expected, rank: rb });
+
+    // passage-level: cosine por texto único una vez, luego 3 poolings.
+    const simByTextId = new Map();
+    for (const [tid, vec] of Object.entries(passageTexts)) simByTextId.set(tid, cosine(qVec, vec));
+    for (const [key, pool] of [['C_passage_max', 'max'], ['D_passage_mean', 'mean'], ['E_passage_top3', 'top3']]) {
+      const r = rankOfExpected(rankBasesFromPassages(simByTextId, passageBySlug, pool), g.expected);
+      arms[key].ranks.push(r);
+      arms[key].perQuery.push({ id: g.id, expected: g.expected, rank: r });
+    }
+  }
+
+  // 3. Métricas + tabla.
+  const results = {};
+  for (const [k, arm] of Object.entries(arms)) results[k] = { label: arm.label, metrics: metricsFromRanks(arm.ranks) };
+
+  const A = results.A_doc_prod.metrics;
+  const fmtDelta = (v, base) => { const d = (v - base); return `${d >= 0 ? '+' : ''}${d.toFixed(1)}`; };
+
+  console.log(`\n${'='.repeat(104)}`);
+  console.log(`RESULTADOS — chunking doc-level vs passage-level (n=${golden.length}, techo ${(ceiling / golden.length * 100).toFixed(0)}%)`);
+  console.log('-'.repeat(104));
+  console.log('arm'.padEnd(52) + 'R@1'.padStart(10) + 'R@3'.padStart(12) + 'R@5'.padStart(12) + 'MRR'.padStart(12));
+  console.log('-'.repeat(104));
+  for (const [k, r] of Object.entries(results)) {
+    const m = r.metrics;
+    const isA = k === 'A_doc_prod';
+    const d1 = isA ? '' : `(${fmtDelta(m['recall@1'], A['recall@1'])})`;
+    const d3 = isA ? '' : `(${fmtDelta(m['recall@3'], A['recall@3'])})`;
+    const d5 = isA ? '' : `(${fmtDelta(m['recall@5'], A['recall@5'])})`;
+    const dm = isA ? '' : `(${(m.MRR - A.MRR >= 0 ? '+' : '')}${(m.MRR - A.MRR).toFixed(4)})`;
+    console.log(
+      r.label.padEnd(52) +
+      `${m['recall@1']}%${d1}`.padStart(10) +
+      `${m['recall@3']}%${d3}`.padStart(12) +
+      `${m['recall@5']}%${d5}`.padStart(12) +
+      `${m.MRR}${dm}`.padStart(12),
+    );
+  }
+  console.log('-'.repeat(104));
+
+  // 4. Mejor arm passage-level (por recall@5, desempate MRR) para el veredicto.
+  const passageKeys = ['C_passage_max', 'D_passage_mean', 'E_passage_top3'];
+  const bestPassageKey = passageKeys.reduce((best, k) => {
+    const m = results[k].metrics; const bm = results[best].metrics;
+    if (m['recall@5'] !== bm['recall@5']) return m['recall@5'] > bm['recall@5'] ? k : best;
+    return m.MRR > bm.MRR ? k : best;
+  }, passageKeys[0]);
+
+  // 5. Qué queries GANA/PIERDE el MEJOR passage-level vs prod (top-5).
+  const gained = [], lost = [];
+  for (let i = 0; i < golden.length; i++) {
+    const a = arms.A_doc_prod.ranks[i];
+    const c = arms[bestPassageKey].ranks[i];
+    const aHit = a !== null && a <= 5;
+    const cHit = c !== null && c <= 5;
+    if (cHit && !aHit) gained.push(`${golden[i].id}:${golden[i].expected} (A=${a ?? '-'}→best=${c})`);
+    if (aHit && !cHit) lost.push(`${golden[i].id}:${golden[i].expected} (A=${a}→best=${c ?? '-'})`);
+  }
+  console.log(`\nmejor passage-level = ${bestPassageKey} (${results[bestPassageKey].label})`);
+  console.log(`best passage vs prod @5 — GANA (${gained.length}): ${gained.join('; ') || 'ninguna'}`);
+  console.log(`best passage vs prod @5 — PIERDE (${lost.length}): ${lost.join('; ') || 'ninguna'}`);
+
+  // 6. Veredicto: mejor passage-level vs doc-level PROD.
+  const C = results[bestPassageKey].metrics;
+  const d5 = C['recall@5'] - A['recall@5'];
+  const dmrr = C.MRR - A.MRR;
+  console.log(`\nVEREDICTO: MEJOR passage-level (${bestPassageKey}) vs doc-level PROD → recall@5 ${d5 >= 0 ? '+' : ''}${d5.toFixed(1)}pp, MRR ${dmrr >= 0 ? '+' : ''}${dmrr.toFixed(4)}`);
+
+  // 6. Persistir.
+  // Redacta IPs privadas del host antes de persistir (repo público, anti-leak;
+  // ver lefthook infra-refs-scan). El backend es Ollama en alpha vía OLLAMA_URL.
+  const embedHost = OLLAMA_URL.replace(/\b(10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+)\b/g, 'alpha');
+  const out = {
+    bench: 'rag-chunking-passages',
+    date: new Date().toISOString(),
+    embed_host: embedHost,
+    model: EMBED_MODEL,
+    n_queries: golden.length,
+    ceiling_hits: ceiling,
+    ceiling_pct: Number((ceiling / golden.length * 100).toFixed(1)),
+    method: 'puro semántico (cosine), colapso variedad→base (parts[0:2]), max-pool por especie; match base==expected||startsWith; 50 queries golden',
+    passage_corpus: {
+      total_passages: passageCorpus.total_passages,
+      unique_texts: passageCorpus.unique_texts,
+      truncate_chars: passageCorpus.truncate_chars,
+      truncated_passages: passageCorpus.truncated_passages,
+    },
+    arms: results,
+    best_passage_arm: bestPassageKey,
+    delta_bestPassage_vs_docProd: {
+      'recall@1_pp': Number((C['recall@1'] - A['recall@1']).toFixed(1)),
+      'recall@3_pp': Number((C['recall@3'] - A['recall@3']).toFixed(1)),
+      'recall@5_pp': Number((C['recall@5'] - A['recall@5']).toFixed(1)),
+      MRR: Number((C.MRR - A.MRR).toFixed(4)),
+    },
+    gained_at5: gained,
+    lost_at5: lost,
+    per_query: Object.fromEntries(Object.entries(arms).map(([k, a]) => [k, a.perQuery])),
+  };
+  writeFileSync(RESULTS_PATH, JSON.stringify(out, null, 2));
+  console.log(`\nResultados → ${RESULTS_PATH}`);
+}
+
+main().catch((err) => { console.error('[bench] FATAL:', err?.stack || err); process.exit(1); });

--- a/scripts/rag-chunking-build-passages.mjs
+++ b/scripts/rag-chunking-build-passages.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * rag-chunking-build-passages.mjs — corpus PASSAGE-LEVEL para el experimento
+ * exp/rag-chunking-passages (NO toca prod).
+ *
+ * Hoy prod tiene UN vector por especie (chunking grueso): extractPassageText()
+ * en build-rag-embeddings.mjs aplasta toda la ficha en un texto y lo embebe una
+ * vez. Este script hace lo contrario: usa el flattenDoc() REAL de
+ * src/services/ragRetriever.js para sacar los N passages de cada ficha y embebe
+ * CADA passage por separado con el MISMO modelo que prod (nomic-embed-text, 768d).
+ *
+ * Hallazgo de dimensionado (rag-chunking-count.mjs): 501 fichas → 20.201 passages,
+ * pero solo 3.909 TEXTOS ÚNICOS (mucho boilerplate compartido entre especies:
+ * labels de milestones, campos contextuales "clima templado", nombres de
+ * companions...). Por eso embebemos los textos ÚNICOS una sola vez y reusamos el
+ * vector para cada (slug,key) que lo repite — 5× menos llamadas a Ollama.
+ *
+ * Salidas (data/rag-chunking-exp/, gitignored — son grandes):
+ *   1. rag-embeddings-passages.json  — corpus passage-level DEDUPADO:
+ *        { model, dim, generated_at, total_passages, unique_texts,
+ *          texts: { <id>: number[768] },              // 3.909 vectores únicos
+ *          passages: [ { slug, key, t: <id> } ] }     // 20.201 refs
+ *      (La forma literal {slug,key,vector[]} × 20.201 pesaría ~140MB; deduped ~27MB.)
+ *   2. rag-embeddings-docflat.json   — arm de control: { slug: number[768] }
+ *      con el vector del TEXTO CONCATENADO de flattenDoc por ficha (mismo
+ *      contenido que los passages, pero 1 vector/especie). Aísla el efecto
+ *      "más contenido" del efecto "chunking fino".
+ *
+ * Uso:
+ *   OLLAMA_URL=http://alpha.local:11434 node scripts/rag-chunking-build-passages.mjs
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+import { register } from 'node:module';
+import { performance } from 'node:perf_hooks';
+
+register(new URL('./bench-rag-retrieve.loader.mjs', import.meta.url).href);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const CORPUS_DIR = resolve(ROOT, 'public', 'cycle-content');
+const MANIFEST_PATH = resolve(CORPUS_DIR, 'manifest.json');
+const OUT_DIR = resolve(ROOT, 'data', 'rag-chunking-exp');
+
+const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434';
+const EMBED_MODEL = process.env.RAG_EMBED_MODEL || 'nomic-embed-text';
+const CONCURRENCY = Number.parseInt(process.env.RAG_EMBED_CONCURRENCY || '8', 10);
+// nomic-embed-text en este Ollama tiene ctx ~2048 tokens y devuelve HTTP 500
+// ("input length exceeds the context length") con textos largos (verificado:
+// falla >~6000 chars de prosa densa, OK a 5000). num_ctx NO lo extiende. Los
+// passages > este budget se truncan a los primeros N chars antes de embeber
+// (mismo régimen de contexto por defecto con el que se construyó el corpus
+// doc-level de prod). Afecta a un puñado de outliers (<2% de los textos únicos);
+// se cuenta y se reporta.
+const TRUNCATE_CHARS = Number.parseInt(process.env.RAG_EMBED_TRUNCATE_CHARS || '5000', 10);
+let truncatedPassages = 0;
+let truncatedConcats = 0;
+
+const { flattenDoc } = await import('../src/services/ragRetriever.js');
+
+function textId(text) {
+  return createHash('sha1').update(text).digest('hex').slice(0, 12);
+}
+
+async function embedOne(text, tries = 3) {
+  for (let attempt = 1; attempt <= tries; attempt += 1) {
+    try {
+      const res = await fetch(`${OLLAMA_URL}/api/embeddings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // Mismo contrato que prod: prompt crudo, sin prefijos search_query/document.
+        body: JSON.stringify({ model: EMBED_MODEL, prompt: text }),
+      });
+      if (!res.ok) throw new Error(`ollama ${res.status}: ${await res.text().catch(() => res.statusText)}`);
+      const data = await res.json();
+      if (!Array.isArray(data.embedding) || data.embedding.length === 0) throw new Error('embedding vacío');
+      return data.embedding;
+    } catch (err) {
+      if (attempt === tries) throw err;
+      await new Promise((r) => setTimeout(r, 400 * attempt));
+    }
+  }
+  throw new Error('unreachable');
+}
+
+// Embebe una lista de textos con concurrencia acotada. Devuelve Map<text, vec>.
+async function embedTexts(texts, label) {
+  const out = new Map();
+  let done = 0;
+  const t0 = performance.now();
+  for (let i = 0; i < texts.length; i += CONCURRENCY) {
+    const batch = texts.slice(i, i + CONCURRENCY);
+    const vecs = await Promise.all(batch.map((t) => embedOne(t)));
+    batch.forEach((t, j) => out.set(t, vecs[j]));
+    done += batch.length;
+    if (done % 200 === 0 || done === texts.length) {
+      const rate = done / ((performance.now() - t0) / 1000);
+      process.stderr.write(`  [${label}] ${done}/${texts.length} (${rate.toFixed(1)}/s)\n`);
+    }
+  }
+  return out;
+}
+
+async function main() {
+  console.log('=== rag-chunking-build-passages ===');
+  console.log(`  Ollama: ${OLLAMA_URL}  modelo: ${EMBED_MODEL}  concurrencia: ${CONCURRENCY}`);
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+  const slugs = manifest.slugs || [];
+
+  // 1. Extraer passages (flattenDoc REAL) + texto concatenado por ficha.
+  const passages = [];            // { slug, key, text }
+  const concatBySlug = new Map();  // slug -> texto concatenado de sus passages
+  for (const slug of slugs) {
+    const p = resolve(CORPUS_DIR, `${slug}.json`);
+    if (!existsSync(p)) continue;
+    const doc = JSON.parse(readFileSync(p, 'utf8'));
+    const flat = flattenDoc(doc, '', slug);
+    if (flat.length === 0) continue;
+    for (const pg of flat) {
+      let text = pg.text;
+      if (text.length > TRUNCATE_CHARS) { text = text.slice(0, TRUNCATE_CHARS); truncatedPassages += 1; }
+      passages.push({ slug, key: pg.key, text });
+    }
+    let concat = flat.map((pg) => pg.text).join(' ');
+    if (concat.length > TRUNCATE_CHARS) { concat = concat.slice(0, TRUNCATE_CHARS); truncatedConcats += 1; }
+    concatBySlug.set(slug, concat);
+  }
+  const uniqueTexts = [...new Set(passages.map((p) => p.text))];
+  console.log(`  Fichas: ${concatBySlug.size}  passages: ${passages.length}  textos únicos: ${uniqueTexts.length}`);
+  console.log(`  Truncados a ${TRUNCATE_CHARS} chars — passages: ${truncatedPassages}/${passages.length}  concats(docflat): ${truncatedConcats}/${concatBySlug.size}`);
+
+  // 2. Embeber textos ÚNICOS de passages.
+  console.log('  Embebiendo textos únicos de passages...');
+  const vecByText = await embedTexts(uniqueTexts, 'passages');
+  const dim = vecByText.get(uniqueTexts[0]).length;
+
+  // 3. Escribir corpus passage-level deduplicado.
+  const texts = {};
+  for (const t of uniqueTexts) texts[textId(t)] = vecByText.get(t);
+  const passageRefs = passages.map((p) => ({ slug: p.slug, key: p.key, t: textId(p.text) }));
+  const passageCorpus = {
+    model: EMBED_MODEL,
+    dim,
+    generated_at: new Date().toISOString(),
+    total_passages: passages.length,
+    unique_texts: uniqueTexts.length,
+    truncate_chars: TRUNCATE_CHARS,
+    truncated_passages: truncatedPassages,
+    texts,
+    passages: passageRefs,
+  };
+  const passagesPath = resolve(OUT_DIR, 'rag-embeddings-passages.json');
+  writeFileSync(passagesPath, JSON.stringify(passageCorpus));
+  console.log(`  OK passage-level → ${passagesPath} (${(Buffer.byteLength(JSON.stringify(passageCorpus)) / 1e6).toFixed(1)} MB)`);
+
+  // 4. Arm de control: 1 vector por ficha con el texto CONCATENADO (flattenDoc).
+  console.log('  Embebiendo texto concatenado por ficha (arm docflat)...');
+  const concatSlugs = [...concatBySlug.keys()];
+  const concatTexts = concatSlugs.map((s) => concatBySlug.get(s));
+  const vecByConcat = await embedTexts(concatTexts, 'docflat');
+  const docflat = {};
+  concatSlugs.forEach((s, i) => { docflat[s] = vecByConcat.get(concatTexts[i]); });
+  const docflatPath = resolve(OUT_DIR, 'rag-embeddings-docflat.json');
+  writeFileSync(docflatPath, JSON.stringify(docflat));
+  console.log(`  OK docflat → ${docflatPath} (${Object.keys(docflat).length} vectores)`);
+
+  console.log('=== build listo ===');
+}
+
+main().catch((err) => {
+  console.error('[build-passages] FATAL:', err?.stack || err?.message || err);
+  process.exit(1);
+});

--- a/scripts/rag-chunking-count.mjs
+++ b/scripts/rag-chunking-count.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * rag-chunking-count.mjs — dimensiona el corpus passage-level ANTES de embeber.
+ *
+ * Importa el `flattenDoc()` REAL de src/services/ragRetriever.js (vía el loader
+ * que ya usa bench-rag-retrieve.mjs para stubear las deps de browser) y cuenta
+ * cuántos passages saldrían por especie y en total. No embebe nada — solo mide.
+ *
+ * Uso: node --import ./scripts/bench-rag-retrieve.loader.mjs scripts/rag-chunking-count.mjs
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { register } from 'node:module';
+
+register(new URL('./bench-rag-retrieve.loader.mjs', import.meta.url).href);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const CORPUS_DIR = resolve(ROOT, 'public', 'cycle-content');
+const MANIFEST_PATH = resolve(CORPUS_DIR, 'manifest.json');
+
+const { flattenDoc } = await import('../src/services/ragRetriever.js');
+
+const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+const slugs = manifest.slugs || [];
+
+let totalPassages = 0;
+let docsWithText = 0;
+const perDoc = [];
+const uniqueTexts = new Set();
+
+for (const slug of slugs) {
+  const p = resolve(CORPUS_DIR, `${slug}.json`);
+  if (!existsSync(p)) continue;
+  const doc = JSON.parse(readFileSync(p, 'utf8'));
+  const passages = flattenDoc(doc, '', slug);
+  if (passages.length > 0) docsWithText += 1;
+  totalPassages += passages.length;
+  perDoc.push(passages.length);
+  passages.forEach((pg) => uniqueTexts.add(pg.text));
+}
+
+perDoc.sort((a, b) => a - b);
+const sum = perDoc.reduce((s, n) => s + n, 0);
+const avg = sum / perDoc.length;
+const median = perDoc[Math.floor(perDoc.length / 2)];
+const p95 = perDoc[Math.floor(perDoc.length * 0.95)];
+
+console.log(JSON.stringify({
+  slugs_in_manifest: slugs.length,
+  docs_with_passages: docsWithText,
+  total_passages: totalPassages,
+  unique_passage_texts: uniqueTexts.size,
+  passages_per_doc: {
+    min: perDoc[0],
+    median,
+    avg: Number(avg.toFixed(1)),
+    p95,
+    max: perDoc[perDoc.length - 1],
+  },
+}, null, 2));


### PR DESCRIPTION
## Veredicto: NO vale la pena (el chunking fino DEGRADA el recall)

Experimento del mayor retorno identificado: ¿trocear cada ficha en passages (`flattenDoc`, N vectores/especie) mejora el recall semántico vs el chunking doc-level de prod (`extractPassageText`, 1 vector/especie)? **Medido sobre `eval/rag-golden.json` (50 queries) con `nomic-embed-text` — no mejora, empeora.**

| arm (puro semántico, cosine) | R@1 | R@3 | R@5 | MRR |
|---|---|---|---|---|
| **A — doc-level PROD** (`extractPassageText`) — baseline | **40%** | **56%** | **58%** | **0.4833** |
| B — doc-level flatten (concat `flattenDoc`) | 10% | 18% | 30% | 0.1861 |
| C — passage-level **max-pool** | 12% | 32% | 42% | 0.2646 |
| D — passage-level mean-pool | 0% | 0% | 0% | 0.0261 |
| E — passage-level top3-mean | 6% | 20% | 32% | 0.1664 |

**Mejor passage-level (max-pool) vs doc-level PROD: R@1 −28pp · R@3 −24pp · R@5 −16pp · MRR −0.2187.** Ningún pooling alcanza al doc-level; el passage-level no gana ni una query en top-5 y pierde 8.

## Causa raíz (medida, §4 del informe)
`flattenDoc` genera 20.201 passages pero solo **3.909 textos únicos** — el ~80% es boilerplate genérico (`propagation.notas`, campos contextuales, labels de hitos) repetido entre cientos de especies. Bajo max-pool ese ruido gana: p.ej. "como abonar el maiz" hunde a `zea_mays` del puesto 4 (doc-level) al 156 (passage-level), superado por notas genéricas de amaranto/fríjol/prácticas de abono. El arm B (flatten concat, misma granularidad gruesa que prod pero todo el contenido) también se desploma → **el problema no es la granularidad, es la selección de contenido**. La ficha doc-level gana porque `extractPassageText` es un resumen curado.

Refuta la conjetura del informe hermano `reranker-medido-2026-07-23.md` ("el lever es la granularidad del retrieve").

## Entregables
- Informe: `ops/informes/chunking-passages-2026-07-23.md` (tabla, dimensionado, causa raíz, cómo se cablearía si algún día ganara).
- Scripts standalone (importan el `flattenDoc` real vía loader, sin drift): `rag-chunking-count.mjs`, `rag-chunking-build-passages.mjs`, `rag-chunking-bench.mjs`.
- Datos crudos: `data/rag-chunking-exp/results.json`.

## Alcance / seguridad
- NO toca `public/rag-embeddings.json` de prod ni el modelo servido. Artefactos grandes (~61MB) gitignored.
- **PR de medición — no mergear a la ligera.** Documenta un negativo; el valor es el número, no un cambio de prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)