### PR TITLE
test(router): cubrir rutas publicas sin case

### DIFF
--- a/src/__tests__/App.mockup-routes-contract.test.js
+++ b/src/__tests__/App.mockup-routes-contract.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import appSource from '../App.jsx?raw';
+
+function getRouteEntries(constantName) {
+  const block = appSource.match(new RegExp(`const ${constantName} = \\{([\\s\\S]*?)^\\};`, 'm'));
+  if (!block) throw new Error(`No se encontro ${constantName} en App.jsx`);
+
+  return [...block[1].matchAll(/^ {2}'([^']+)': '([^']+)'/gm)]
+    .map(([, route, view]) => ({ route, view }));
+}
+
+const switchCases = new Set([...appSource.matchAll(/case '([^']+)'/g)].map(([, view]) => view));
+
+describe('App route contracts', () => {
+  it('conecta cada ruta publica mockups con un case de render', () => {
+    const mockupRoutes = getRouteEntries('MOCKUP_HASH_ROUTES');
+
+    expect(mockupRoutes).not.toHaveLength(0);
+    expect(mockupRoutes.filter(({ view }) => !switchCases.has(view))).toEqual([]);
+  });
+
+  it.each([
+    ['mundo-subsuelo', 'subsuelo'],
+    ['almacenamiento-conservacion', 'almacenamiento'],
+    ['bosque-comestible', 'restauracion'],
+    ['comida-que-alimenta', 'nutricion'],
+  ])('conecta el alias %s con la vista %s', (route, view) => {
+    const hashRoutes = new Map(getRouteEntries('HASH_VIEW_ROUTES').map(({ route: key, view: value }) => [key, value]));
+
+    expect(hashRoutes.get(route)).toBe(view);
+    expect(switchCases.has(view)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Audita las 93 rutas publicas de mockups y verifica que cada destino tenga un case de render.
- Cubre los aliases mundo-subsuelo, almacenamiento-conservacion, bosque-comestible y comida-que-alimenta.
- La auditoria no encontro rutas mockups huerfanas ni componentes por cablear en dev.

## Test plan
- npx vitest run src/__tests__/App.mockup-routes-contract.test.js
- Hooks de lefthook, incluido ESLint del cambio staged
- npm run build
- npx vitest run tiene dos fallas preexistentes fuera del cambio: coverage-jornada-48h y SeguimientoProcesoScreen.
- gate-real-gpu.mjs no pudo iniciar porque su proceso no resuelve python3.