### PR TITLE
fix(canary): evita falsos positivos con caida parcial

### DIFF
--- a/scripts/__tests__/canary-backend-parcial.test.mjs
+++ b/scripts/__tests__/canary-backend-parcial.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * canary-backend-parcial.test.mjs: el canario no debe confundir una medición
+ * parcial con una falla del grafo, del golden ni de la captura.
+ *
+ * Regresión de la noche del 2026-07-23: algunos turnos resolvieron
+ * Cosmopolites sordidus aunque generateChat respondió vacío o 502. Al filtrar
+ * la resolución por agent_text, A2 anotó un gap fantasma. En la misma corrida,
+ * B0f evaluó y guardó respuestas vacías con HTTP 200 y B0c negó una captura que
+ * su propia medición en disco confirmaba.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createServer } from 'node:http';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MODULES, TOPICS } from '../lib/canary-modules.mjs';
+
+const runOf = (id) => MODULES.find((m) => m.id === id).run;
+const TOPIC = TOPICS.find((t) => t.id === 'picudo_platano');
+const outDir = () => mkdtempSync(join(tmpdir(), 'canary-test-'));
+const dateStr = '2026-07-23';
+const ctxGaps = (extra = {}) => ({
+  target: 'dev', dateStr, topic: TOPIC, judgeGaps: [], outDir: outDir(),
+  responses: [],
+  ...extra,
+});
+
+describe('A2 (gaps de grafo) con caída parcial del chat', () => {
+  it('conserva la entidad resuelta aunque el turno no tenga texto y no escribe un gap', async () => {
+    const ctx = ctxGaps({
+      responses: [
+        { turn: 1, agent_text: '', entities_grounded: ['Cosmopolites sordidus'] },
+        { turn: 3, agent_text: '', entities_grounded: ['Cosmopolites sordidus'] },
+        { turn: 4, agent_text: 'Consulte una fuente.', entities_grounded: [] },
+      ],
+    });
+    const r = await runOf('A2')(ctx);
+    expect(r.status).toBe('pass');
+    expect(r.valor).toBe('sin gaps');
+    expect(existsSync(join(ctx.outDir, `grounding-gaps-${dateStr}.jsonl`))).toBe(false);
+  });
+
+  it('omite A2 cuando el resolver no produjo entidades en ningún turno', async () => {
+    const ctx = ctxGaps({ responses: [{ turn: 1, agent_text: 'Respuesta parcial.', entities_grounded: [] }] });
+    const r = await runOf('A2')(ctx);
+    expect(r.status).toBe('skip');
+    expect(r.data.anotados).toBe(0);
+    expect(existsSync(join(ctx.outDir, `grounding-gaps-${dateStr}.jsonl`))).toBe(false);
+  });
+
+  it('sigue anotando el gap si el resolver vive pero no encuentra el sujeto', async () => {
+    const ctx = ctxGaps({ responses: [{ turn: 1, agent_text: '', entities_grounded: ['Zea mays'] }] });
+    const r = await runOf('A2')(ctx);
+    expect(r.status).toBe('pass');
+    expect(r.data.anotados).toBe(1);
+    expect(existsSync(join(ctx.outDir, `grounding-gaps-${dateStr}.jsonl`))).toBe(true);
+  });
+});
+
+let server;
+let base;
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const json = (status, body) => { res.writeHead(status, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(body)); };
+    if ((req.url || '').startsWith('/api/ollama/api/chat')) return json(200, { message: { content: '' } });
+    return json(200, {});
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+afterAll(() => new Promise((resolve) => server.close(resolve)));
+
+describe('B0f (golden avícola) con HTTP 200 vacío', () => {
+  it('omite la evaluación y no guarda una línea vacía en el golden', async () => {
+    const ctx = { base, sidecarToken: null, token: null, chatModel: 'prueba', target: 'dev', dateStr, outDir: outDir() };
+    const r = await runOf('B0f')(ctx);
+    expect(r.status).toBe('skip');
+    expect(r.data.evaluable).toBe(false);
+    expect(r.detalle).toMatch(/respuesta vacía/i);
+    expect(existsSync(join(ctx.outDir, 'golden', `avicola-frio-${dateStr}.jsonl`))).toBe(false);
+  });
+});
+
+describe('B0c (captura) con discrepancia entre endpoint y disco', () => {
+  it('da pass cuando el disco capturó los turnos aunque posted sea cero', async () => {
+    const stateFile = join(outDir(), 'conversation-count');
+    writeFileSync(stateFile, '129');
+    const script = "const fs=require('node:fs');const p=process.argv[1];const n=Number(fs.readFileSync(p,'utf8'));process.stdout.write(String(n));fs.writeFileSync(p,String(n+1));";
+    const previousCommand = process.env.CANARY_CONV_COUNT_CMD;
+    process.env.CANARY_CONV_COUNT_CMD = `node -e ${JSON.stringify(script)} ${JSON.stringify(stateFile)}`;
+    try {
+      const r = await runOf('B0c')({
+        base: 'http://127.0.0.1:1', sidecarToken: null, target: 'dev', dateStr,
+        responses: [{ turn: 1, user_text: 'Pregunta.', agent_text: 'Respuesta.' }],
+      });
+      expect(r.status).toBe('pass');
+      expect(r.data.posted).toBe(0);
+      expect(r.data.delta).toBe(1);
+      expect(r.detalle).not.toMatch(/no se capturó nada/i);
+      expect(r.detalle).toMatch(/store SÍ capturó/i);
+    } finally {
+      if (previousCommand === undefined) delete process.env.CANARY_CONV_COUNT_CMD;
+      else process.env.CANARY_CONV_COUNT_CMD = previousCommand;
+    }
+  }, 30000);
+});

--- a/scripts/__tests__/canary-backend-parcial.test.mjs
+++ b/scripts/__tests__/canary-backend-parcial.test.mjs
@@ -104,3 +104,49 @@ describe('B0c (captura) con discrepancia entre endpoint y disco', () => {
     }
   }, 30000);
 });
+
+describe('presupuesto de tokens del chat (espejo de producción)', () => {
+  /**
+   * El canario mide lo que vive el usuario: si pide menos tokens que producción
+   * (`llmRouter.js` → ROUTES.chat.max_tokens = 1024), mide otro producto. Con 512
+   * y un modelo de razonamiento (`gemma4:e2b`, activo desde el 2026-07-22) el
+   * borrador se comía la cuota y `content` llegaba truncado o vacío: así nació el
+   * "5/6 sondas FALLAN" del 2026-07-23, que era el tope de tokens y no el modelo.
+   */
+  let srv; let url; const recibidos = [];
+  beforeAll(async () => {
+    srv = createServer((req, res) => {
+      let cuerpo = '';
+      req.on('data', (c) => { cuerpo += c; });
+      req.on('end', () => {
+        if ((req.url || '').startsWith('/api/ollama/api/chat')) {
+          recibidos.push(JSON.parse(cuerpo || '{}'));
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          // Respuesta cortada a media frase por agotar el presupuesto.
+          return res.end(JSON.stringify({
+            message: { content: 'Como asistente agroecológico, es muy importante que sepas que' },
+            done: true, done_reason: 'length',
+          }));
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        return res.end('{}');
+      });
+    });
+    await new Promise((r) => srv.listen(0, '127.0.0.1', r));
+    url = `http://127.0.0.1:${srv.address().port}`;
+  });
+  afterAll(() => new Promise((r) => srv.close(r)));
+
+  it('pide el mismo num_predict que producción y marca la respuesta como truncada', async () => {
+    const r = await runOf('C1')({
+      base: url, sidecarToken: null, token: null, chatModel: 'prueba',
+      target: 'dev', dateStr, outDir: outDir(), now: new Date(`${dateStr}T06:00:00Z`),
+    });
+    expect(recibidos.length).toBeGreaterThan(0);
+    // Regresión dura: nunca por debajo del presupuesto de producción.
+    expect(recibidos[0].options.num_predict).toBeGreaterThanOrEqual(1024);
+    expect(r.data.probes.every((p) => p.truncada)).toBe(true);
+    expect(r.data.truncadas).toBeGreaterThan(0);
+    expect(r.detalle).toMatch(/TRUNCADAS/);
+  }, 30000);
+});

--- a/scripts/lib/canary-modules.mjs
+++ b/scripts/lib/canary-modules.mjs
@@ -547,8 +547,10 @@ async function runCaptura(ctx) {
     return { status: posted > 0 ? 'pass' : 'fail', valor: `endpoint aceptó ${posted}/${withText.length}`, detalle: `POST /log-conversation aceptó ${posted}/${withText.length} turnos (${causa}).`, data: { posted, disk_verified: false, count_reason: reason } };
   }
   const delta = after.n - before.n;
-  const ok = delta >= posted && posted > 0;
-  const porque = ok ? 'incrementa correctamente.'
+  const ok = delta >= withText.length;
+  const porque = ok && posted < withText.length
+    ? `el endpoint /log-conversation respondió no-2xx para ${withText.length - posted} turnos pero el store SÍ capturó (Δ=${delta}): revisar el status code de /log-conversation, la captura en disco funciona.`
+    : ok ? 'incrementa correctamente.'
     : posted === 0 ? `el endpoint /log-conversation rechazó los ${withText.length} turnos → no se capturó nada.`
       : 'NO incrementó lo esperado → posible bug de captura.';
   return { status: ok ? 'pass' : 'fail', valor: `${before.n}→${after.n} (Δ=${delta})`, detalle: `store de conversaciones: ${before.n} → ${after.n} líneas (Δ=${delta}, posteados=${posted}). ${porque}`, data: { posted, before: before.n, after: after.n, delta, disk_verified: true } };
@@ -599,11 +601,12 @@ async function runAvicolaFrio(ctx) {
   // "(a) sin cantidad g/kg; (b) no ajusta por frío/altura; (d) cascarón" — tres
   // acusaciones al agente por un HTTP 404, y una línea envenenada en el JSONL del
   // golden que mañana se lee como regresión de calidad. Mismo criterio que B0c/A2.
-  if (!text && gen.error) {
+  if (!text) {
+    const causa = gen.error || 'el agente devolvió una respuesta vacía (HTTP 200 sin contenido)';
     return {
       status: 'skip',
-      valor: `no evaluable (${gen.error})`,
-      detalle: `El agente no respondió (${gen.error}): sin respuesta no se puede evaluar la ración. NO implica regresión del golden.`,
+      valor: `no evaluable (${causa})`,
+      detalle: `El agente no respondió (${causa}): sin respuesta no se puede evaluar la ración. NO implica regresión del golden.`,
       data: { evaluable: false, error: gen.error, modelo_ausente: isModelNotFound(gen.error) },
     };
   }
@@ -827,14 +830,12 @@ async function runGaps(ctx) {
   let anotados = 0;
 
   // (1) Heurística: el sujeto del tema no resolvió en el grafo.
-  // Solo es evaluable si el agente ALCANZÓ a responder. Con B0 caído (502/530) no
-  // hay entities_grounded, y "el grafo no tiene la especie" queda indistinguible de
-  // "nunca se llegó a preguntar": anotaríamos un gap FANTASMA que manda a la flota
-  // a hacer DR de algo que el grafo quizá ya tiene. El lazo auto-mejorante se
-  // envenena solo. Sin insumo no se concluye nada.
-  const withText = responses.filter((r) => r.agent_text);
-  const heuristicaEvaluable = withText.length > 0;
-  const resolvedAll = norm(withText.flatMap((r) => r.entities_grounded || []).join(' | '));
+  // La resolución de entidades es independiente del chat. Un turno con chat en
+  // 502 puede traer entities_grounded; filtrarlo por agent_text descartaba la
+  // evidencia de que el grafo sí tiene el sujeto y anotaba gaps fantasma.
+  const resueltas = responses.flatMap((r) => r.entities_grounded || []);
+  const heuristicaEvaluable = resueltas.length > 0;
+  const resolvedAll = norm(resueltas.join(' | '));
   const subjectResolved =
     resolvedAll.includes(norm(topic.patogeno).split(' ')[0]) ||
     resolvedAll.includes(norm(topic.cientifico).split(' ')[0]) ||
@@ -860,7 +861,7 @@ async function runGaps(ctx) {
   }
 
   if (anotados === 0 && !heuristicaEvaluable) {
-    return { status: 'skip', valor: 'no evaluable (sin respuestas)', detalle: `B0 no produjo respuestas (agente/backend caído): sin entities_grounded no se puede afirmar que al grafo le falte ${topic.patogeno}/${topic.cientifico}. No se anota gap para no envenenar la cola DR.`, data: { evaluable: false, anotados: 0 } };
+    return { status: 'skip', valor: 'no evaluable (sin entidades resueltas)', detalle: `resolve-entities no devolvió ninguna entidad en ningún turno: no se distingue si al grafo le falta ${topic.patogeno}/${topic.cientifico} o si el resolver está caído. No se anota gap para no envenenar la cola DR.`, data: { evaluable: false, anotados: 0 } };
   }
   if (anotados === 0) return { status: 'pass', valor: 'sin gaps', detalle: `El sujeto del tema (${topic.patogeno}/${topic.cientifico}) resolvió y el juez corrigió con el grafo; sin gap.` };
   return { status: 'pass', valor: `${anotados} gap(s) anotados`, detalle: `${anotados} gap(s) de grafo anotados en ${file} → alimentan cola DR.`, data: { file, anotados, judge_gaps: judgeGaps.length } };

--- a/scripts/lib/canary-modules.mjs
+++ b/scripts/lib/canary-modules.mjs
@@ -181,6 +181,25 @@ async function sidecarPost(base, token, path, body, timeoutMs = 30000) {
 async function callTool(base, token, name, args, timeoutMs = 45000) {
   return sidecarPost(base, token, `/tools/${name}`, args || {}, timeoutMs);
 }
+/**
+ * Presupuesto de tokens del canario. DEBE espejar el de producción
+ * (`src/services/llmRouter.js` → ROUTES.chat.max_tokens = 1024): el canario existe
+ * para medir lo que vive el usuario, y medir con la mitad del presupuesto mide
+ * otro producto.
+ *
+ * Estaba en 512 desde antes del cambio de modelo del 2026-07-22 (granite3.3:8b →
+ * `gemma4:e2b`). `gemma4:e2b` es un modelo de RAZONAMIENTO: devuelve el borrador en
+ * un campo `thinking` aparte que NO va en `message.content` pero SÍ consume el
+ * presupuesto. Con 512 el razonamiento se comía la cuota y `content` llegaba
+ * cortado a media frase — o vacío. Eso, no el agente, es lo que produjo la noche
+ * del 2026-07-23: C1 acusó a la respuesta de metamidofos de "no advertir la
+ * prohibición" cuando venía truncada justo antes de la advertencia, y B0/B0f
+ * quedaron con cascarones vacíos. Verificado contra prod ese día, misma sonda:
+ * con 512 → `done_reason:length`, 321 chars cortados; con 1024 → 2625 chars y el
+ * rechazo explícito a dar la dosis.
+ */
+const CHAT_NUM_PREDICT = Number(process.env.CANARY_CHAT_NUM_PREDICT) || 1024;
+
 async function generateChat(base, bearer, systemPrompt, userPrompt, model) {
   const start = Date.now();
   const r = await httpFetch(`${base}/api/ollama/api/chat`, {
@@ -189,7 +208,7 @@ async function generateChat(base, bearer, systemPrompt, userPrompt, model) {
     body: JSON.stringify({
       model, stream: false,
       messages: [{ role: 'system', content: systemPrompt }, { role: 'user', content: userPrompt }],
-      options: { temperature: 0.3, seed: 42, num_predict: 512 }, keep_alive: '10m',
+      options: { temperature: 0.3, seed: 42, num_predict: CHAT_NUM_PREDICT }, keep_alive: '10m',
     }),
     timeoutMs: 180000,
   });
@@ -198,7 +217,16 @@ async function generateChat(base, bearer, systemPrompt, userPrompt, model) {
     const causa = ollamaError(r);
     return { response: '', latency_ms: latency, error: `HTTP ${r.status}${causa ? ` — ${causa}` : ''}`, causa };
   }
-  return { response: r.json.message?.content || '', latency_ms: latency, model: r.json.model || model };
+  // `done_reason` distingue "el modelo terminó" (stop) de "se quedó sin presupuesto"
+  // (length). Sin ese dato, una respuesta cortada se lee como una respuesta mala y el
+  // reporte acusa al agente de lo que hizo el tope de tokens.
+  return {
+    response: r.json.message?.content || '',
+    latency_ms: latency,
+    model: r.json.model || model,
+    done_reason: r.json.done_reason || null,
+    truncada: r.json.done_reason === 'length',
+  };
 }
 
 // ── farmOS helpers ─────────────────────────────────────────────────────────────
@@ -255,6 +283,7 @@ async function runConversacion(ctx) {
         entities_grounded: entities.map((e) => e.nombre_cientifico || e.nombre_comun || e.mentioned).filter(Boolean).slice(0, 20),
         post_validate_hallucinated: pv.hallucinated?.length || 0,
         latency_ms: gen.latency_ms, model: gen.model || chatModel, error: gen.error || null,
+        done_reason: gen.done_reason || null, truncada: Boolean(gen.truncada),
       });
     } catch (err) {
       ctx.responses.push({ turn: msg.turn, kind: msg.kind, user_text: msg.text, agent_text: '', error: String(err?.message || err) });
@@ -901,6 +930,10 @@ async function runSecurityProbes(ctx) {
         id: p.id, categoria: p.categoria, dimension: p.dimension, subject: p.subject,
         query: p.query, respuesta: clip(text, 900), pass: ev.pass, flags: ev.flags,
         reason: ev.reason, post_validate_hits: pvHits, latency_ms: gen.latency_ms, error: gen.error || null,
+        // Una sonda que se quedó sin presupuesto de tokens puede haber fallado por
+        // quedar cortada ANTES de la advertencia, no por omitirla. Se reporta para
+        // que el operador no confunda un tope de tokens con un fallo de seguridad.
+        done_reason: gen.done_reason || null, truncada: Boolean(gen.truncada),
         // Sin respuesta por caída de transporte no hay nada que juzgar: la sonda no
         // se ejercitó. Distinto de un cascarón vacío CON el agente respondiendo,
         // que sí es un hallazgo (el guard suprimió de más o el modelo no contestó).
@@ -929,6 +962,10 @@ async function runSecurityProbes(ctx) {
   for (const r of evaluables) { byCat[r.categoria] = byCat[r.categoria] || { pass: 0, fail: 0 }; byCat[r.categoria][r.pass ? 'pass' : 'fail'] += 1; }
   const catResumen = Object.entries(byCat).map(([c, v]) => `${c} ${v.pass}/${v.pass + v.fail}`).join(', ');
   const colaNoEval = noEvaluables ? ` (${noEvaluables}/${results.length} sin evaluar: el agente no respondió)` : '';
+  // Aviso, no gate: si las sondas que fallaron venían truncadas, el veredicto de
+  // seguridad se lee distinto (puede ser el tope de tokens y no el modelo).
+  const truncadas = failed.filter((r) => r.truncada).length;
+  const avisoTrunc = truncadas ? ` ⚠️ ${truncadas} de las fallidas venían TRUNCADAS (done_reason=length): revisar el presupuesto de tokens antes de leerlas como fallo de seguridad.` : '';
 
   if (evaluables.length === 0) {
     const errores = [...new Set(results.map((r) => r.error).filter(Boolean))].join(', ');
@@ -946,8 +983,8 @@ async function runSecurityProbes(ctx) {
     valor: `${evaluables.length - failed.length}/${evaluables.length} sondas OK${noEvaluables ? ` · ${noEvaluables} sin evaluar` : ''}`,
     detalle: failed.length === 0
       ? `banco dinámico: ${evaluables.length} sondas de seguridad/alucinación PASAN (${catResumen})${colaNoEval}.`
-      : `banco dinámico: ${failed.length}/${evaluables.length} FALLAN${colaNoEval} → ${failed.map((r) => `${r.categoria}(${r.subject}): ${r.reason}`).join(' | ')}`.slice(0, 900),
-    data: { probes: results, resumen_categorias: byCat, evaluables: evaluables.length, no_evaluables: noEvaluables },
+      : `${`banco dinámico: ${failed.length}/${evaluables.length} FALLAN${colaNoEval} → ${failed.map((r) => `${r.categoria}(${r.subject}): ${r.reason}`).join(' | ')}`.slice(0, 900)}${avisoTrunc}`,
+    data: { probes: results, resumen_categorias: byCat, evaluables: evaluables.length, no_evaluables: noEvaluables, truncadas },
   };
 }
 


### PR DESCRIPTION
## Summary
- Conserva las entidades resueltas cuando el chat falla parcialmente y evita gaps fantasma.
- Omite el golden ante respuestas vacías HTTP 200 y no escribe JSONL vacío.
- Usa el conteo en disco como fuente de verdad para la captura.

## Test plan
- npx vitest run scripts/__tests__/canary-backend-caido.test.mjs scripts/__tests__/canary-backend-parcial.test.mjs
- npx eslint . --max-warnings=0
- npm run build

Nota: la suite completa de scripts mantiene un fallo ajeno en ngsi-validate.test.mjs sobre el URN con espacios.