### PR TITLE
refactor(agent): unificar agente+visión en gemma3:4b (PR #2738)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,14 +9,16 @@ VITE_HA_ACCESS_TOKEN=tu_token_home_assistant_aqui
 # nodo productor. Se muestran en el header del menu de voz.
 VITE_STT_MODEL=base
 
-# Modelo(s) del agente LLM — fuente unica de verdad: src/config/env.js
-# (ver comentario ahi). Las 4 vars de abajo son overrides opcionales de
-# build-time; sin definirlas, cada rol usa su default (hoy gemma4:e4b).
+# Modelo(s) del agente LLM (texto + vision) — fuente unica de verdad:
+# src/config/env.js (ver comentario ahi). Las 5 vars de abajo son
+# overrides opcionales de build-time; sin definirlas, cada rol usa su
+# default (hoy gemma3:4b, unificado texto+vision — PR #2738).
 # Deben coincidir con un modelo pulled en Ollama en el nodo productor.
-VITE_NLU_MODEL=gemma4:e4b
-VITE_EXTRACTOR_MODEL=gemma4:e4b
-VITE_LLM_CHAT_MODEL=gemma4:e4b
-VITE_LLM_COMPLEX_MODEL=gemma4:e4b
+VITE_NLU_MODEL=gemma3:4b
+VITE_EXTRACTOR_MODEL=gemma3:4b
+VITE_LLM_CHAT_MODEL=gemma3:4b
+VITE_LLM_COMPLEX_MODEL=gemma3:4b
+VITE_VISION_MODEL=gemma3:4b
 
 # Sidecar chagra-agro-mcp — ADR-045 Fase 2 (NLU planner + MCP tools).
 # Master switch. Mientras no esté desplegado el sidecar en el nodo

--- a/src/components/GuildSuggestions.jsx
+++ b/src/components/GuildSuggestions.jsx
@@ -11,6 +11,7 @@ import useAssetStore from '../store/useAssetStore';
 import ExternalAiButton from './common/ExternalAiButton';
 import { buildGuildExternalPrompt } from '../services/externalAiPromptBuilder';
 import { fetchWithAuthRetry } from '../services/apiService';
+import { ENV } from '../config/env';
 
 // Autopilot #8 (2026-05-03): re-rank companions putting existing plants first.
 // Reduce friction de "tengo que comprar otra especie", mostrar primero las
@@ -138,7 +139,7 @@ export const GuildSuggestions = ({ speciesId, onSelectCompanion }) => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          model: 'gemma3:4b',
+          model: ENV.CHAT_MODEL,
           stream: false,
           messages: [
             { role: 'system', content: 'Asistente de diseño de gremios agroecológicos. Responde SOLO en JSON válido, sin texto adicional.' },

--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -8,6 +8,7 @@ import AIStreamPanel from './common/AIStreamPanel';
 import IoTSensorCard from './IoTSensorCard';
 import ChagraGrowLoader from './ChagraGrowLoader';
 import { streamOllama } from '../services/ollamaStream';
+import { ENV } from '../config/env';
 import ExternalAiButton from './common/ExternalAiButton';
 import { buildDiagnosticExternalPrompt } from '../services/externalAiPromptBuilder';
 import { detectAndTruncateRepetition } from '../utils/repetitionGuard';
@@ -535,7 +536,7 @@ export default function TelemetryAlerts() {
         const content = await streamOllama(
           `${OLLAMA_URL}/api/chat`,
           {
-            model: 'gemma3:4b',
+            model: ENV.CHAT_MODEL,
             messages: [
               { role: 'system', content: 'Asistente agronómico para finca agroecológica andina (2400msnm). PROHIBIDO recomendar agroquímicos sintéticos. Solo biopreparados orgánicos (biol, caldo sulfocálcico, caldo bordelés, purín de ortiga, compost tea, microorganismos de montaña, Trichoderma). Responde en máximo 3 frases concisas, sin superlativos, sin repetir información.' },
               { role: 'user', content: userPrompt },
@@ -550,7 +551,7 @@ export default function TelemetryAlerts() {
             onDone: (parsed) => {
               if (parentSignal?.aborted) return;
               setAiMeta({
-                model: parsed.model || 'gemma3:4b',
+                model: parsed.model || ENV.CHAT_MODEL,
                 totalDuration: parsed.total_duration ? (parsed.total_duration / 1e9).toFixed(1) : null,
                 evalCount: parsed.eval_count || null,
                 promptTokens: parsed.prompt_eval_count || null,

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -34,10 +34,11 @@ export const ENV = {
   // FUENTE DE VERDAD del/los modelo(s) del agente — cambiar SOLO aquí.
   //
   // Todo el código de este repo que invoca el LLM del agente (NLU local,
-  // extractor de entidades por voz, chat, chat_complex) DEBE leer su
-  // modelo de una de las 4 claves de abajo. Prohibido volver a hardcodear
-  // el nombre del modelo en servicios/componentes — si aparece un nuevo
-  // caso de uso del agente, agregue una clave aquí, no un literal disperso.
+  // extractor de entidades por voz, chat, chat_complex, visión) DEBE leer
+  // su modelo de una de las 5 claves de abajo. Prohibido volver a
+  // hardcodear el nombre del modelo en servicios/componentes — si aparece
+  // un nuevo caso de uso del agente, agregue una clave aquí, no un literal
+  // disperso.
   //
   // El sidecar (chagra-pro, repo aparte) corre su propio NLU real
   // (agro-mcp nlu.ts) con su propia env var runtime `NLU_MODEL` — ESE valor
@@ -54,22 +55,39 @@ export const ENV = {
   //  - CHAT_MODEL:         llmRouter ROUTES.chat (queries simples).
   //  - CHAT_COMPLEX_MODEL: llmRouter ROUTES.chat_complex (queries complejas,
   //                        anti-alucinación taxonómica/piso térmico).
+  //  - VISION_MODEL:       diagnóstico foliar + reconocimiento de especies
+  //                        (aiService.js), pre-warm de cámara
+  //                        (visionWarmService.js) y llmRouter ROUTES.vision.
   //
-  // 2026-07-23: gemma4:e2b → gemma4:e4b como default de las 4 claves. Índice
-  // de inteligencia interno (línea base reproducible, ver test #2735): e4b
-  // 81.6 vs e2b 69.9 (+11.7). e4b + nomic-embed conviven en la M6000 de 12GB
-  // (10.9/12 GB verificado). Ver Chagra-strategy/ops/MODELS.md (fuente
-  // única de detalle/bench).
+  // 2026-07-23 (PR #2738, §8/§9): gemma4:e4b → gemma3:4b como default de
+  // las 5 claves — unifica agente de texto Y visión en un solo modelo de
+  // 3.3GB. Texto: 81.7 en el índice de inteligencia interno (línea base
+  // reproducible, test #2735), prácticamente empatado con e4b (81.6).
+  // Visión (bench profundo, 18 plagas + 5 sanas control): gemma3:4b saca
+  // 45.5 (33.3% identificación, 100% honestidad) contra 16.9 de
+  // qwen3-vl:8b (11.1% ident., 80% honestidad, swap de ~53s que este
+  // cambio elimina). `llama3.2-vision:11b` queda retirado como primary de
+  // reconocimiento de especies: 0% honestidad, alucina diagnóstico en
+  // TODAS las muestras sanas del bench (peligroso para una feature de
+  // salud de planta). Detalle completo en PR #2738 (bench) y
+  // Chagra-strategy/ops/MODELS.md (fuente única de detalle/bench).
   //
-  // Historial previo (2026-07-22): granite3.3:8b → gemma4:e2b, por medición
-  // con juez semántico sobre 70 sondas: granite3.3 contamina el 47,7% de sus
-  // respuestas y falla el piso térmico el 41,7% de las veces (le da consejo
-  // de tierra caliente a alguien de páramo). gemma4:e2b bajaba a 10% global
-  // y 6,7% en piso térmico — 4,8x mejor, y convivía con el embedder del RAG
-  // (snowflake-arctic-embed2) en la M6000 de 12GB sin el cudaMalloc OOM que
-  // sufría granite3.3.
-  NLU_MODEL: import.meta.env?.VITE_NLU_MODEL || 'gemma4:e4b',
-  EXTRACTOR_MODEL: import.meta.env?.VITE_EXTRACTOR_MODEL || 'gemma4:e4b',
-  CHAT_MODEL: import.meta.env?.VITE_LLM_CHAT_MODEL || 'gemma4:e4b',
-  CHAT_COMPLEX_MODEL: import.meta.env?.VITE_LLM_COMPLEX_MODEL || 'gemma4:e4b',
+  // ⚠️ Caveat metodológico (dejar explícito para revisión humana antes de
+  // producción): el bench de PR #2738 usa un dataset distinto (18 plagas +
+  // 5 sanas, métrica agregada IDENT/HONESTIDAD) del bench "Arena visual
+  // 2026-07-22" ya citado en llmRouter.js (12 casos, presencia SIEMPRE
+  // emparejada con su ausencia), que había marcado gemma3:4b como
+  // "inservible como gate" — fallaba 3/7 casos de AUSENCIA (alucinaba ver
+  // algo que no estaba). El bench nuevo no repite ese diseño pareado
+  // presencia/ausencia específico, así que no re-testea directamente esa
+  // falla puntual; sí corrige un bug real del harness de honestidad
+  // (reconocía solo "no sé" literal). PR #2738 está abierto y marcado
+  // "No mergear — para revisión" al momento de este cambio. Confirmar con
+  // el operador que la lectura de ambos benches se concilia antes de que
+  // este PR llegue a producción (dev→main).
+  NLU_MODEL: import.meta.env?.VITE_NLU_MODEL || 'gemma3:4b',
+  EXTRACTOR_MODEL: import.meta.env?.VITE_EXTRACTOR_MODEL || 'gemma3:4b',
+  CHAT_MODEL: import.meta.env?.VITE_LLM_CHAT_MODEL || 'gemma3:4b',
+  CHAT_COMPLEX_MODEL: import.meta.env?.VITE_LLM_COMPLEX_MODEL || 'gemma3:4b',
+  VISION_MODEL: import.meta.env?.VITE_VISION_MODEL || 'gemma3:4b',
 };

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -24,18 +24,27 @@ import { retrieve } from './ragRetriever';
 import { callTool, isSidecarEnabled, judgeVision } from './sidecarClient';
 import { parseJsonTolerant } from '../utils/parseJsonTolerant';
 import { hashImage, getCached, setCached } from './visionCacheService';
+import { ENV } from '../config/env';
 
 // Ruta relativa: Nginx proxea /api/ollama/ → http://localhost:11434/
 // Ruta final: /api/ollama/api/generate → http://localhost:11434/api/generate
 const OLLAMA_BASE = '/api/ollama';
 const OLLAMA_URL = `${OLLAMA_BASE}/api/generate`;
-// Modelo de diagnóstico multimodal configurado.
-const DIAGNOSIS_MODEL = 'gemma3:4b';
-// Modelo de visión configurado para reconocimiento de especies. La
-// selección de primary y de los fallbacks se basa en bench interno de
-// confiabilidad del parseo JSON y de latencia en GPU local.
-const VISION_SPECIES_MODEL = 'llama3.2-vision:11b';
-const VISION_SPECIES_FALLBACK_MODEL = 'gemma3:4b';
+// Modelo de diagnóstico multimodal — lee de ENV.VISION_MODEL (src/config/env.js,
+// fuente única de verdad de los modelos del agente).
+const DIAGNOSIS_MODEL = ENV.VISION_MODEL;
+// Modelo(s) de visión para reconocimiento de especies.
+// 2026-07-23 (PR #2738 §9): primary y fallback 1 unificados en
+// ENV.VISION_MODEL (gemma3:4b) — retira `llama3.2-vision:11b` como primary,
+// que en el bench profundo (18 plagas + 5 sanas) dio 0% honestidad y
+// alucinó diagnóstico en TODAS las muestras sanas de control (peligroso
+// para una feature de salud de planta). Efecto secundario conocido: al
+// unificarse, fallback 1 ahora coincide con el primary (mismo valor), así
+// que el único respaldo real de arquitectura distinta que queda es
+// fallback 2 (qwen2.5vl:7b) — colapsar la cadena a 2 niveles es un
+// follow-up fuera de este cambio, no una decisión tomada en este commit.
+const VISION_SPECIES_MODEL = ENV.VISION_MODEL;
+const VISION_SPECIES_FALLBACK_MODEL = ENV.VISION_MODEL;
 const VISION_SPECIES_FALLBACK_2_MODEL = 'qwen2.5vl:7b';
 
 // Prompt base sin contexto RAG. Fallback usado cuando el corpus no cargó

--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -91,7 +91,7 @@ export const ROUTES = {
     // Modelo leído de ENV.CHAT_MODEL (src/config/env.js, fuente única de
     // verdad — override en build-time con VITE_LLM_CHAT_MODEL para
     // experimentos, sin tocar código). Ver el comentario de esa clave para
-    // el historial de bench (granite3.3 → gemma4:e2b → gemma4:e4b).
+    // el historial de bench (granite3.3 → gemma4:e2b → gemma4:e4b → gemma3:4b).
     model: ENV.CHAT_MODEL,
     keep_alive_min: 30,
     temperature: 0.3,
@@ -115,7 +115,7 @@ export const ROUTES = {
     // Modelo leído de ENV.CHAT_COMPLEX_MODEL (src/config/env.js, fuente
     // única de verdad — override en build-time con VITE_LLM_COMPLEX_MODEL
     // para experimentos, sin tocar código). Ver el comentario de esa clave
-    // para el historial de bench (granite3.3 → gemma4:e2b → gemma4:e4b).
+    // para el historial de bench (granite3.3 → gemma4:e2b → gemma4:e4b → gemma3:4b).
     model: ENV.CHAT_COMPLEX_MODEL,
     keep_alive_min: 5,
     temperature: 0.3,
@@ -159,13 +159,22 @@ export const ROUTES = {
       'mejor capability) o deepseek-r1:8b (46 t/s, chain-of-thought).',
   },
   vision: {
-    model: 'qwen3-vl:8b',
+    // 2026-07-23 (PR #2738 §9): qwen3-vl:8b JUBILADO. Bench profundo (18
+    // plagas + 5 sanas control) da a gemma3:4b 45.5 (33.3% ident., 100%
+    // honestidad) contra 16.9 de qwen3-vl:8b (11.1% ident., 80% honestidad,
+    // + el swap de ~53s que este cambio elimina al unificar con el modelo
+    // de texto). Ver ENV.VISION_MODEL en src/config/env.js (fuente única)
+    // para el caveat metodológico pendiente de confirmación (el bench
+    // "Arena visual 2026-07-22" citado abajo usaba un diseño distinto —
+    // presencia SIEMPRE emparejada con su ausencia — que no se re-testeó
+    // con el dataset nuevo).
+    model: ENV.VISION_MODEL,
     keep_alive_min: 0,
     temperature: 0.2,
     max_tokens: 512,
     url: '/api/ollama/v1/chat/completions',
     rationale:
-      'Arena visual 2026-07-22 (12 casos, cada presencia emparejada con su ausencia, GPU limpia): qwen3-vl:8b acierta 12/12 — 5/5 presencia y 7/7 ausencia — a 17s por imagen, 100% GPU sin offload (7,6 GB). Le siguen qwen2.5vl:7b 92% (pero pide 14 GB y SIEMPRE hace offload, verificado con la GPU vacia), gemma4:e4b 75%, gemma3:4b 58% (el que estaba aqui: fallaba 3 de 7 ausencias, o sea decia ver cosas que no estan — inservible como gate) y moondream 0%. El bench del 2026-06-23 daba a qwen2.5vl como el PEOR: lo midio en thrashing por el offload, con granite3.3 ocupando la GPU. El cambio a gemma4:e2b (8,1 GB) libero el espacio que permite este carril. keep_alive_min 0 se conserva: se carga, responde y se descarga, asi que los 17s no compiten con el agente. Detalle en Chagra-strategy/ops/MODELS.md (fuente unica).',
+      'Histórico (Arena visual 2026-07-22, 12 casos, cada presencia emparejada con su ausencia, GPU limpia): qwen3-vl:8b acierta 12/12 — 5/5 presencia y 7/7 ausencia — a 17s por imagen, 100% GPU sin offload (7,6 GB). Le seguían qwen2.5vl:7b 92%, gemma4:e4b 75%, gemma3:4b 58% (fallaba 3 de 7 ausencias — inservible como gate en ESE diseño) y moondream 0%. Superseded por PR #2738 §9 (dataset distinto, 18 plagas + 5 sanas): gemma3:4b sale primero en identificación y honestidad. Detalle en Chagra-strategy/ops/MODELS.md (fuente unica).',
   },
 };
 

--- a/src/services/visionWarmService.js
+++ b/src/services/visionWarmService.js
@@ -25,9 +25,13 @@
  */
 
 import { fetchWithAuthRetry } from './apiService.js';
+import { ENV } from '../config/env';
 
 const OLLAMA_URL = '/api/ollama/api/generate';
-const VISION_MODEL = 'llama3.2-vision:11b';
+// 2026-07-23 (PR #2738 §9): lee de ENV.VISION_MODEL (src/config/env.js,
+// fuente única) — antes hardcodeaba 'llama3.2-vision:11b', retirado por
+// bench (0% honestidad, alucinaba en muestras sanas).
+const VISION_MODEL = ENV.VISION_MODEL;
 // keep_alive 5min: si user demora entre click cámara y submit, el modelo
 // sigue caliente. Si user abandona el flow, Ollama lo desaloja en 5min y
 // libera memoria de GPU. Más corto causaría re-warm si el flow toma >2min.

--- a/src/store/__tests__/useOllamaWarmStore.test.js
+++ b/src/store/__tests__/useOllamaWarmStore.test.js
@@ -19,10 +19,16 @@
  * expiración por timer) en vez de '30m'.
  *
  * El nombre exacto del modelo de chat evoluciona (granite3.1-dense:8b →
- * granite3.3:8b, 2026-06-11). Por eso aserta contra `DEFAULT_MODEL`
- * (importado de llmRouter), NUNCA contra un string hardcoded: la invariante
- * que protege este test es "pre-warm == modelo de chat ≠ NLU", no qué granite
- * específico está promovido hoy.
+ * granite3.3:8b → gemma4:e2b/e4b → gemma3:4b). Por eso aserta contra
+ * `DEFAULT_MODEL` (importado de llmRouter), NUNCA contra un string
+ * hardcoded: la invariante que protege este test es "pre-warm == modelo de
+ * chat REAL configurado", no qué modelo específico está promovido hoy.
+ *
+ * 2026-07-23 (PR #2738): desde la unificación de agente+visión en un solo
+ * modelo (ENV.CHAT_MODEL / ENV.NLU_MODEL / etc. en src/config/env.js),
+ * chat y NLU pueden legítimamente coincidir en valor — por eso el test ya
+ * NO asegura "≠ NLU" contra un literal; sólo que el pre-warm siga el
+ * modelo de chat REAL (DEFAULT_MODEL), no un string fijo desactualizado.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import useOllamaWarmStore from '../useOllamaWarmStore';
@@ -74,7 +80,7 @@ describe('useOllamaWarmStore — NN4 pre-warm Ollama al login', () => {
     });
   });
 
-  it('pre-warm apunta al modelo de CHAT (granite), no al NLU (gemma)', async () => {
+  it('pre-warm apunta exactamente al modelo de CHAT configurado (DEFAULT_MODEL)', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(/** @type {Response} */ ({ ok: true, status: 200 }));
     useOllamaWarmStore.getState().startWarmup();
 
@@ -85,10 +91,11 @@ describe('useOllamaWarmStore — NN4 pre-warm Ollama al login', () => {
     // en llmRouter (ROUTES.chat.model). Si fueran distintos, el modelo de chat
     // queda frío y el primer chat sufre el cold-start de ~46s. Aserta contra
     // DEFAULT_MODEL (no un string fijo) para sobrevivir promociones de modelo.
+    // NOTA (PR #2738): ya NO se aserta "≠ NLU" contra un literal — desde la
+    // unificación agente+visión, chat y NLU pueden coincidir en valor
+    // legítimamente. Lo que importa es que sea SIEMPRE el modelo real
+    // configurado, nunca un string hardcodeado y potencialmente stale.
     expect(body.model).toBe(DEFAULT_MODEL);
-    // Invariante anti-regresión del bug NN4: NUNCA debe calentar el modelo de
-    // NLU (gemma3:4b) en vez del de chat.
-    expect(body.model).not.toBe('gemma3:4b');
   });
 
   it('pre-warm pinnea el modelo con keep_alive=-1 (sin expiración por timer)', async () => {


### PR DESCRIPTION
## Contexto

PR #2737 (fuente única de verdad del modelo del agente, default `gemma4:e4b`) ya se mergeó a `dev` (squash, commit `31f32f14`). Este PR continúa esa consolidación con la siguiente decisión del operador, tomada mientras #2737 estaba en review: adoptar **`gemma3:4b`** como modelo unificado de agente **y** visión, basado en el bench de PR #2738 (`eval: comparativa de 10 modelos + bench visual profundo`).

## Resumen del bench (PR #2738 §8/§9)

| | texto (índice inteligencia) | visión (IDENT/HONESTIDAD/VISIÓN) |
|---|---|---|
| `gemma3:4b` | **81.7** | **33.3% / 100% / 45.5** |
| `gemma4:e4b` | 81.6 | 16.7% / 100% / 25.0 |
| `qwen3-vl:8b` (brazo visual anterior) | — | 11.1% / 80% / 16.9 |
| `llama3.2-vision:11b` (primary especies anterior) | — | 16.7% / **0%** (alucina en TODAS las sanas) / 0 |

`gemma3:4b` empata en texto con `e4b` y triplica a `qwen3-vl:8b` en visión, en un modelo de 3.3GB que elimina el swap de ~53s entre modelo de chat y de visión.

## Cambios

- **`src/config/env.js`**: default de las 4 claves existentes (`NLU_MODEL`/`EXTRACTOR_MODEL`/`CHAT_MODEL`/`CHAT_COMPLEX_MODEL`) `gemma4:e4b` → `gemma3:4b`. Nueva 5ta clave `VISION_MODEL` (default `gemma3:4b`, override `VITE_VISION_MODEL`) — misma fuente única, ahora cubre también visión.
- **`.env.example`**: refleja las 5 claves con su nuevo default.
- **`llmRouter.js`** `ROUTES.vision`: `qwen3-vl:8b` → `ENV.VISION_MODEL`. El rationale histórico se preserva, marcado explícitamente "Superseded por PR #2738 §9".
- **`aiService.js`**: `DIAGNOSIS_MODEL`, `VISION_SPECIES_MODEL` y `VISION_SPECIES_FALLBACK_MODEL` → `ENV.VISION_MODEL`. Retira `llama3.2-vision:11b` como primary de reconocimiento de especies — en el bench nuevo alucina diagnóstico en el 100% de las muestras sanas de control (peligroso para una feature de salud de planta). `VISION_SPECIES_FALLBACK_2_MODEL` se deja en `qwen2.5vl:7b`: con primary y fallback 1 unificados en el mismo valor, es el único respaldo de arquitectura realmente distinta que queda en la cadena de 3 niveles. Colapsar esa cadena a 2 niveles es un follow-up — no se decide en este PR.
- **`visionWarmService.js`**: `VISION_MODEL` hardcodeado (`llama3.2-vision:11b`) → `ENV.VISION_MODEL`.
- **`TelemetryAlerts.jsx` / `GuildSuggestions.jsx`**: 3 hardcodes sueltos de `'gemma3:4b'` que bypaseaban `env.js` y `llmRouter` por completo → `ENV.CHAT_MODEL` (son llamadas de texto/chat — asistente agronómico y diseño de gremios — no de visión).
- **`useOllamaWarmStore.test.js`**: el test del fix NN4 tenía un guard hardcodeado `expect(body.model).not.toBe('gemma3:4b')`, escrito cuando `gemma3:4b` era específicamente el modelo de NLU (≠ chat). Con la unificación esa asunción ya no aplica (chat y NLU pueden coincidir en valor por diseño) — se retira el literal y se preserva la aserción real y dinámica (`body.model === DEFAULT_MODEL`), que sobrevive futuros cambios de modelo.

## ⚠️ Caveat metodológico — para revisión humana antes de producción

El bench visual de PR #2738 (18 plagas + 5 sanas control, métrica agregada IDENT/HONESTIDAD) **no repite el diseño** del bench "Arena visual 2026-07-22" ya citado en `llmRouter.js` (12 casos, presencia **siempre** emparejada con su ausencia), que había marcado a `gemma3:4b` como **"inservible como gate"**: fallaba 3 de 7 casos de ausencia (alucinaba ver algo que no estaba). El bench nuevo corrige un bug real del harness de honestidad (antes solo reconocía "no sé" literal), pero no vuelve a testear específicamente ese modo de falla puntual con el mismo diseño pareado.

PR #2738 está **abierto y marcado "No mergear — para revisión"** al momento de este PR. Se implementa la decisión relayada por la coordinación, pero se deja este caveat explícito en el código (`env.js`, `llmRouter.js`) y aquí para que el operador confirme que ambos benches se concilian antes de que este cambio llegue a `main`/producción — es una feature de diagnóstico fitosanitario, con consecuencias reales si el gate visual falla silenciosamente.

## Test plan

- [x] `npm run build` — compila limpio (`✓ built in 55.27s`), mismos warnings preexistentes de chunk-size no relacionados.
- [x] `npx eslint` dirigido sobre los 8 archivos tocados — 0 problemas.
- [x] Suite unitaria dirigida (`llmRouter`, `entityExtractor.*`, `aiService`, `visionWarmService*`, `useOllamaWarmStore`) — 85/85 pass tras actualizar el guard obsoleto de NN4.
- [ ] Suite unitaria completa / lint completo del proyecto: no corrido local (máquina saturada con benches paralelos de GPU, causa OOM incluso en `eslint .` del proyecto completo) — a cargo de CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)