### PR TITLE
test(abejas): actualizar foco de seleccion 3D

### DIFF
--- a/src/mockups/__tests__/mundoAbejas3D.smoke.test.jsx
+++ b/src/mockups/__tests__/mundoAbejas3D.smoke.test.jsx
@@ -6,11 +6,13 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 vi.mock('@react-three/fiber', () => ({
   Canvas: ({ children, frameloop }) => <div data-testid="canvas" data-frameloop={frameloop}>{children}</div>,
   useFrame: () => {},
+  useThree: (selector) => selector({ size: { width: 390, height: 844 } }),
 }));
 
 vi.mock('@react-three/drei', () => ({
   AdaptiveDpr: () => null,
   OrbitControls: () => null,
+  PerspectiveCamera: () => null,
   // El enjambre monta las Angelitas rubber-hose como billboards <Html>.
   Html: ({ children }) => <div data-testid="html-billboard">{children}</div>,
 }));
@@ -30,7 +32,7 @@ describe('MundoAbejas3D', () => {
     expect(screen.getByTestId('canvas')).toHaveAttribute('data-frameloop', 'always');
     expect(screen.getByRole('region', { name: 'Diorama 3D de abejas, meliponas y flores meliferas' })).toBeInTheDocument();
     expect(screen.getAllByRole('button')).toHaveLength(3);
-    expect(screen.getByRole('button', { name: /Polinizacion que da fruto/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /Polinización que da fruto/ })).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('permite elegir la leccion sobre conservacion de nativas', () => {
@@ -38,7 +40,7 @@ describe('MundoAbejas3D', () => {
     const nativas = screen.getByRole('button', { name: /Meliponas nativas/ });
     fireEvent.click(nativas);
     expect(nativas).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('button', { name: /Polinizacion que da fruto/ })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: /Polinización que da fruto/ })).toHaveAttribute('aria-pressed', 'false');
   });
 
   // Cableado de `seleccion` al 3D: antes la tarjeta activa solo se pintaba a
@@ -48,21 +50,21 @@ describe('MundoAbejas3D', () => {
       const { container } = render(<MundoAbejas3D />);
       const foco = container.querySelector('group[name="foco-seleccion"]');
       expect(foco).toBeTruthy();
-      expect(foco.getAttribute('position')).toBe('0,0.55,3');
+      expect(foco.getAttribute('position')).toBe('0,0.85,1.9');
     });
 
     test('tocar la tarjeta 02 (miel) lleva el foco al panal/colmenas', () => {
       const { container } = render(<MundoAbejas3D />);
       fireEvent.click(screen.getByRole('button', { name: /Miel, cera y cuidado/ }));
       const foco = container.querySelector('group[name="foco-seleccion"]');
-      expect(foco.getAttribute('position')).toBe('-1.7,0.75,-1.8');
+      expect(foco.getAttribute('position')).toBe('-2.0999999999999996,1.05,-1.3');
     });
 
     test('tocar la tarjeta 03 (nativas) lleva el foco a la caja melipona', () => {
       const { container } = render(<MundoAbejas3D />);
       fireEvent.click(screen.getByRole('button', { name: /Meliponas nativas/ }));
       const foco = container.querySelector('group[name="foco-seleccion"]');
-      expect(foco.getAttribute('position')).toBe('3.65,0.4,-1.7');
+      expect(foco.getAttribute('position')).toBe('1.3,0.8,0.2');
     });
   });
 });


### PR DESCRIPTION
ESCALATE_TO_OPUS: La rama asignada parte de origin/dev y el PR contra main contiene 388 archivos ajenos a esta tarea. Se requiere rebasar o recrear la rama desde la base correcta antes de considerar merge.

## Summary
- Actualiza el mock del Canvas con las APIs 3D usadas por la escena de abejas.
- Sincroniza las expectativas del foco con las zonas reales de polinizacion, miel y meliponas.
- Mantiene cubierta la propagacion de seleccion desde las tarjetas hacia la escena 3D.

## Test plan
- npx vitest run src/mockups/__tests__/mundoAbejas3D.smoke.test.jsx
- npx eslint . --max-warnings=0
- npm run build

La suite completa de Vitest mantiene fallos preexistentes fuera de este cambio.