### PR TITLE
feat(mockups): exponer showcase de artesania

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -290,6 +290,7 @@ const ParamoHumboldt3DMockup = lazy(() => import('./mockups/ParamoHumboldt3D'));
 const CamaraDirectorDemoMockup = lazy(() => import('./mockups/CamaraDirectorDemo'));
 const MomentoVentaMercado3DMockup = lazy(() => import('./mockups/MomentoVentaMercado3D'));
 const ArtesaniaAndinaDemoMockup = lazy(() => import('./mockups/ArtesaniaAndinaDemo'));
+const ShowcaseArtesaniaMockup = lazy(() => import('./visual/mundo3d/ArtesaniaAndina'));
 const EfectosFuncionalesDemoMockup = lazy(() => import('./mockups/EfectosFuncionalesDemo'));
 const CatalogoInfraDemoMockup = lazy(() => import('./mockups/CatalogoInfraDemo'));
 const MundoAbejas3DMockup = lazy(() => import('./mockups/MundoAbejas3D'));
@@ -760,6 +761,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/camara-director': 'mockup_camara_director',
   'mockups/momento-venta-mercado-3d': 'mockup_momento_venta_mercado_3d',
   'mockups/artesania-andina': 'mockup_artesania_andina',
+  'mockups/showcase-artesania': 'mockup_showcase_artesania',
   'mockups/efectos-funcionales': 'mockup_efectos_funcionales',
   'mockups/catalogo-infra': 'mockup_catalogo_infra',
   'mockups/mundo-abejas-3d': 'mockup_mundo_abejas_3d',
@@ -2397,6 +2399,14 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Artesanía andina">
               <ArtesaniaAndinaDemoMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_showcase_artesania':
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Muestrario de artesanía andina">
+              <ShowcaseArtesaniaMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/__tests__/App.mockup-routes-contract.test.js
+++ b/src/__tests__/App.mockup-routes-contract.test.js
@@ -30,4 +30,11 @@ describe('App route contracts', () => {
     expect(hashRoutes.get(route)).toBe(view);
     expect(switchCases.has(view)).toBe(true);
   });
+
+  it('conecta ShowcaseArtesania como ruta mockup publica', () => {
+    const mockupRoutes = new Map(getRouteEntries('MOCKUP_HASH_ROUTES').map(({ route, view }) => [route, view]));
+
+    expect(mockupRoutes.get('mockups/showcase-artesania')).toBe('mockup_showcase_artesania');
+    expect(switchCases.has('mockup_showcase_artesania')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Registra ShowcaseArtesania en #/mockups/showcase-artesania.
- Cubre el contrato de la ruta mockup.

## Test plan
- npx vitest run src/__tests__/App.mockup-routes-contract.test.js src/visual/mundo3d/__tests__/artesania.smoke.test.jsx
- npx eslint . --max-warnings=0
- npx vitest run (falla por problemas preexistentes fuera de este cambio)
- npm run build (no concluye en este entorno; queda en vite build transforming...)