### PR TITLE
fix(mundo3d): resolver grafias sanpedreno

### DIFF
--- a/src/visual/mundo3d/__tests__/fincaRealista.geom.test.js
+++ b/src/visual/mundo3d/__tests__/fincaRealista.geom.test.js
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { RAZAS_CERDO } from '../finca/fincaRealista.geom.js';
+
+describe('razas de cerdo', () => {
+  it('resuelve ambas grafías de San Pedreño a la misma ficha', () => {
+    expect(RAZAS_CERDO.sanpedreno).toBeDefined();
+    expect(RAZAS_CERDO['sanpedreño']).toBe(RAZAS_CERDO.sanpedreno);
+  });
+});

--- a/src/visual/mundo3d/finca/fincaRealista.geom.js
+++ b/src/visual/mundo3d/finca/fincaRealista.geom.js
@@ -484,6 +484,10 @@ export const RAZAS_CERDO = {
   },
 };
 
+// El hato puede registrar la raza sin eñe. Ambas grafías deben usar la misma
+// ficha para evitar que una de ellas caiga al cerdo zungo por defecto.
+RAZAS_CERDO['sanpedreño'] = RAZAS_CERDO.sanpedreno;
+
 /**
  * El cerdo por raza. Mira a +X, patas en y=0, lomo a ~0.62.
  * @returns {{cuerpo: THREE.BufferGeometry, cabeza: THREE.BufferGeometry, pivote: [number,number,number]}}


### PR DESCRIPTION
## Summary
- Registra la grafía con eñe de San Pedreño como alias de `sanpedreno` en el resolvedor de geometría.
- Añade una prueba que garantiza que ambas grafías usan la misma ficha de raza.

## Test plan
- `npx vitest run src/visual/mundo3d/__tests__/fincaRealista.geom.test.js`
- `npx vitest run` (falla por pruebas preexistentes ajenas al cambio)
- `npx eslint . --max-warnings=0`
- `npm run build`