### PR TITLE
fix(vitrina): montar infraestructura viva

### DIFF
--- a/src/mockups/vitrina3d/VitrinaInfraestructura.jsx
+++ b/src/mockups/vitrina3d/VitrinaInfraestructura.jsx
@@ -31,7 +31,7 @@ import {
   INFRAESTRUCTURA_IDS,
   INFRAESTRUCTURA_CATEGORIAS,
 } from '../../visual/mundo3d/infraestructura/infraestructuraData.js';
-import Infraestructura from '../../visual/mundo3d/infraestructura/Infraestructura.jsx';
+import InfraestructuraViva from '../../visual/mundo3d/infraestructura/InfraestructuraViva.jsx';
 import { decidirTier, permite3D } from '../../visual/mundo3d/deviceTier.js';
 import { ATMOSFERA } from '../../visual/mundo3d/atmosferaMadre.js';
 import './VitrinaInfraestructura.css';
@@ -126,7 +126,7 @@ function LienzoPieza({ tipo, dims, tier, reducedMotion }) {
         <meshLambertMaterial color="#b49873" />
       </mesh>
       <Suspense fallback={null}>
-        <Infraestructura tipo={tipo} dims={dims} params={{}} tier={tier} reducedMotion={reducedMotion} />
+        <InfraestructuraViva tipo={tipo} dims={dims} params={{}} tier={tier} reducedMotion={reducedMotion} />
       </Suspense>
       <OrbitControls
         target={[0, dims.alto * 0.42, 0]}
@@ -410,7 +410,7 @@ function DemoColocar({ modo3D, tier, reducedMotion }) {
             <directionalLight position={[-6, 5, -8]} intensity={0.22} color={ATMOSFERA.relleno} />
             <TerrenoDemo segmentos={tier === 'alto' ? 56 : 34} onTocar={tocarTerreno} />
             {colocadas.map((c, i) => (
-              <Infraestructura
+              <InfraestructuraViva
                 key={`${c.tipo}-${i}`}
                 tipo={c.tipo}
                 pos={c.pos}
@@ -424,7 +424,7 @@ function DemoColocar({ modo3D, tier, reducedMotion }) {
             {borrador && (
               <>
                 <AnilloBorrador borrador={borrador} />
-                <Infraestructura
+                <InfraestructuraViva
                   tipo={borrador.tipo}
                   pos={borrador.pos}
                   rot={borrador.rot}

--- a/src/mockups/vitrina3d/__tests__/VitrinaInfraestructura.test.jsx
+++ b/src/mockups/vitrina3d/__tests__/VitrinaInfraestructura.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }) => <div data-testid="lienzo-3d">{children}</div>,
+}));
+
+vi.mock('@react-three/drei', () => ({ OrbitControls: () => null }));
+
+vi.mock('../../../visual/mundo3d/deviceTier.js', () => ({
+  decidirTier: () => ({ tier: 'alto' }),
+  permite3D: () => true,
+}));
+
+vi.mock('../../../visual/mundo3d/infraestructura/Infraestructura.jsx', () => ({
+  default: () => <div data-testid="infraestructura-base" />,
+}));
+
+vi.mock('../../../visual/mundo3d/infraestructura/InfraestructuraViva.jsx', () => ({
+  default: ({ tipo }) => <div data-testid="infraestructura-viva" data-tipo={tipo} />,
+}));
+
+import VitrinaInfraestructura from '../VitrinaInfraestructura.jsx';
+import {
+  INFRAESTRUCTURA,
+  INFRAESTRUCTURA_CATEGORIAS,
+} from '../../../visual/mundo3d/infraestructura/infraestructuraData.js';
+
+afterEach(() => cleanup());
+
+describe('VitrinaInfraestructura', () => {
+  test('monta InfraestructuraViva en los dioramas del catálogo', () => {
+    const { container } = render(<VitrinaInfraestructura />);
+    const categoriaInicial = INFRAESTRUCTURA_CATEGORIAS[0];
+    const esperadas = Object.values(INFRAESTRUCTURA).filter(
+      (pieza) => pieza.categoria === categoriaInicial,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Vitrina de infraestructura' })).toBeInTheDocument();
+    expect(screen.getAllByTestId('infraestructura-viva')).toHaveLength(esperadas.length);
+    expect(container.querySelector('[data-testid="infraestructura-base"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Monta InfraestructuraViva en los dioramas y el demo de VitrinaInfraestructura.
- Agrega una prueba de integración que verifica el adaptador vivo.

## Test plan
- npx vitest run src/mockups/vitrina3d/__tests__/VitrinaInfraestructura.test.jsx
- npx eslint . --max-warnings=0
- npm run build
- npx vitest run (falla por pruebas preexistentes fuera de este cambio)