### PR TITLE
fix(tsc-gate): hacer determinista la comparacion

### DIFF
--- a/scripts/__tests__/tsc-check-gate.test.mjs
+++ b/scripts/__tests__/tsc-check-gate.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseTscOutput, compareToBaseline, formatReport } from '../tsc-check-gate.mjs';
+import { parseTscOutput, outputFromTscDiagnostic, compareToBaseline, formatReport } from '../tsc-check-gate.mjs';
 
 describe('parseTscOutput', function () {
   it('counts one error per opening diagnostic line', function () {
@@ -52,6 +52,19 @@ describe('parseTscOutput', function () {
   });
 });
 
+describe('outputFromTscDiagnostic', function () {
+  it('returns diagnostics when tsc exits after reporting type errors', function () {
+    var output = outputFromTscDiagnostic({ status: 2, stdout: 'src/a.js(1,1): error TS2322: Type mismatch.\n' });
+    expect(output).toContain('TS2322');
+  });
+
+  it('fails instead of treating a terminated tsc process as zero errors', function () {
+    expect(function () {
+      outputFromTscDiagnostic({ status: null, signal: 'SIGKILL' });
+    }).toThrow('tsc no terminó correctamente por señal SIGKILL');
+  });
+});
+
 describe('compareToBaseline', function () {
   it('passes when current matches baseline exactly', function () {
     var current = { total: 3, byFile: { 'a.js': 2, 'b.js': 1 } };
@@ -93,6 +106,23 @@ describe('compareToBaseline', function () {
     var r = compareToBaseline(current, baseline);
     expect(r.ok).toBe(false);
     expect(r.regressions).toEqual([{ file: 'a.js', baselineCount: 2, currentCount: 5, delta: 3 }]);
+  });
+
+  it('fails for a new 3D file with type errors', function () {
+    var current = { total: 1, byFile: { 'src/visual/mundo3d/NuevoMundo.jsx': 1 } };
+    var r = compareToBaseline(current, { totalErrors: 0, byFile: {} });
+    expect(r.ok).toBe(false);
+    expect(r.newFiles).toEqual([{ file: 'src/visual/mundo3d/NuevoMundo.jsx', count: 1 }]);
+  });
+
+  it('fails when a 3D file error count increases past the baseline', function () {
+    var current = { total: 2, byFile: { 'src/mockups/Valle3D.jsx': 2 } };
+    var baseline = { totalErrors: 1, byFile: { 'src/mockups/Valle3D.jsx': 1 } };
+    var r = compareToBaseline(current, baseline);
+    expect(r.ok).toBe(false);
+    expect(r.regressions).toEqual([
+      { file: 'src/mockups/Valle3D.jsx', baselineCount: 1, currentCount: 2, delta: 1 },
+    ]);
   });
 
   it('handles a missing baseline (no byFile) as an all-new report', function () {

--- a/scripts/tsc-check-gate.mjs
+++ b/scripts/tsc-check-gate.mjs
@@ -97,23 +97,38 @@ function sortedByFile(byFile) {
 }
 
 /**
+ * Devuelve la salida de un proceso tsc que terminó con diagnósticos de tipo.
+ * Un fallo de proceso no tiene un baseline comparable y debe bloquear el gate.
+ *
+ * @param {{ status?: number | null, signal?: string | null, stdout?: string | Buffer, stderr?: string | Buffer }} error
+ * @returns {string}
+ *
+ */
+export function outputFromTscDiagnostic(error) {
+  if (typeof error.status !== 'number') {
+    const detail = error.signal ? ` por señal ${error.signal}` : '';
+    throw new Error(`tsc no terminó correctamente${detail}. El gate no puede comparar un resultado incompleto.`);
+  }
+  return (error.stdout || '') + (error.stderr || '');
+}
+
+/**
  * Corre `tsc --noEmit -p jsconfig.json` y devuelve stdout+stderr combinados.
- * tsc sale con código != 0 cuando hay errores — eso es esperado, no un fallo
- * de esta función.
+ * tsc sale con código != 0 cuando hay errores de tipo, lo cual es esperado.
+ * Los fallos del proceso se propagan para no interpretarlos como cero errores.
  *
  * @returns {string}
  */
 export function runTsc() {
   const tscBin = require.resolve('typescript/bin/tsc');
   try {
-    return execFileSync(process.execPath, [tscBin, '--noEmit', '-p', 'jsconfig.json'], {
+    return execFileSync(process.execPath, [tscBin, '--noEmit', '--pretty', 'false', '-p', 'jsconfig.json'], {
       cwd: REPO_ROOT,
       encoding: 'utf8',
       maxBuffer: 200 * 1024 * 1024,
     });
   } catch (e) {
-    // tsc exit code != 0 al reportar errores: la salida real viene en stdout.
-    return (e.stdout || '') + (e.stderr || '');
+    return outputFromTscDiagnostic(e);
   }
 }
 
@@ -143,36 +158,19 @@ export function writeBaseline(parsed, path = BASELINE_PATH) {
  * @param {{ total: number, byFile: Record<string, number> }} current
  * @param {{ totalErrors?: number, byFile?: Record<string, number> }} baseline
  */
-// Zona EXPERIMENTAL 3D: mockups y el framework de mundos son código visual r3f
-// type-loose POR DISEÑO (JSX de three, props laxas) y NO son rutas de producción
-// del agente/datos. Un archivo NUEVO aquí NO bloquea el gate — así el trabajo
-// visual de fable no traba los promotes por deuda de tipos cosmética. La deuda
-// de PRODUCCIÓN (servicios, store, agente) sigue 100% blindada. Ver
-// feedback_ci_green_not_real_value: esto NO esconde regresiones reales, exime
-// una zona conscientemente laxa. Las regresiones (archivo que EMPEORA) sí fallan
-// en todos lados.
-const ZONA_EXPERIMENTAL_3D = /^src\/(mockups\/|visual\/(mundo3d|creatures|effects|scenes|laminas)\/)/;
-
 export function compareToBaseline(current, baseline) {
   const baselineByFile = baseline.byFile || {};
   const newFiles = [];
-  const newFilesExentos = [];
   const regressions = [];
   const improved = [];
 
   for (const file of Object.keys(current.byFile).sort()) {
     const currentCount = current.byFile[file];
     const baselineCount = baselineByFile[file] || 0;
-    const exento = ZONA_EXPERIMENTAL_3D.test(file);
     if (baselineCount === 0) {
-      if (exento) newFilesExentos.push({ file, count: currentCount });
-      else newFiles.push({ file, count: currentCount });
+      newFiles.push({ file, count: currentCount });
     } else if (currentCount > baselineCount) {
-      // Regresión: en la zona experimental 3D (JSX de three, type-loose) NO
-      // bloquea — cablear un componente suele sumar 1-2 errores de props laxas.
-      // En PRODUCCIÓN sí bloquea (deuda real). El total sube pero es cosmético.
-      if (exento) newFilesExentos.push({ file, count: currentCount - baselineCount });
-      else regressions.push({ file, baselineCount, currentCount, delta: currentCount - baselineCount });
+      regressions.push({ file, baselineCount, currentCount, delta: currentCount - baselineCount });
     } else if (currentCount < baselineCount) {
       improved.push({ file, baselineCount, currentCount, delta: baselineCount - currentCount });
     }
@@ -181,7 +179,6 @@ export function compareToBaseline(current, baseline) {
   return {
     ok: newFiles.length === 0 && regressions.length === 0,
     newFiles,
-    newFilesExentos,
     regressions,
     improved,
     totalCurrent: current.total,
@@ -199,12 +196,6 @@ export function formatReport(comparison) {
     for (const { file, count } of comparison.newFiles) {
       lines.push(`  - ${file}: ${count} error(es)`);
     }
-  }
-
-  if (comparison.newFilesExentos && comparison.newFilesExentos.length > 0) {
-    const n = comparison.newFilesExentos.reduce((s, i) => s + i.count, 0);
-    lines.push('');
-    lines.push(`(exentos: ${comparison.newFilesExentos.length} archivo(s) nuevos de la zona experimental 3D con ${n} error(es) de tipo cosméticos — NO bloquean el gate)`);
   }
 
   if (comparison.regressions.length > 0) {


### PR DESCRIPTION
## Summary

- elimina la excepcion por prefijo para archivos 3D: todos los archivos incluidos se comparan contra el mismo baseline.
- fuerza salida no coloreada de tsc y falla de forma explicita si el proceso termina por señal o sin estado, en vez de interpretar salida incompleta como cero errores.
- cubre errores nuevos y regresiones 3D, ademas de terminacion de proceso.

Causa: el gate clasificaba los errores segun rutas 3D y convertia cualquier fallo del proceso tsc en una comparacion vacia. Eso permitia resultados distintos cuando la ejecucion no terminaba de producir diagnosticos.

## Test plan

- [x] npx vitest run scripts/__tests__/tsc-check-gate.test.mjs (17 passed)
- [x] npx eslint . --max-warnings=0
- [x] npm run build
- [!] npx vitest run tiene fallos preexistentes no relacionados en servicios, componentes y pruebas 3D.