### PR TITLE
feat(arte-3d): consolidar 4 PRs de arte (showcase, sierra, vitrina, grafias)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -290,6 +290,7 @@ const ParamoHumboldt3DMockup = lazy(() => import('./mockups/ParamoHumboldt3D'));
 const CamaraDirectorDemoMockup = lazy(() => import('./mockups/CamaraDirectorDemo'));
 const MomentoVentaMercado3DMockup = lazy(() => import('./mockups/MomentoVentaMercado3D'));
 const ArtesaniaAndinaDemoMockup = lazy(() => import('./mockups/ArtesaniaAndinaDemo'));
+const ShowcaseArtesaniaMockup = lazy(() => import('./visual/mundo3d/ArtesaniaAndina'));
 const EfectosFuncionalesDemoMockup = lazy(() => import('./mockups/EfectosFuncionalesDemo'));
 const CatalogoInfraDemoMockup = lazy(() => import('./mockups/CatalogoInfraDemo'));
 const MundoAbejas3DMockup = lazy(() => import('./mockups/MundoAbejas3D'));
@@ -760,6 +761,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/camara-director': 'mockup_camara_director',
   'mockups/momento-venta-mercado-3d': 'mockup_momento_venta_mercado_3d',
   'mockups/artesania-andina': 'mockup_artesania_andina',
+  'mockups/showcase-artesania': 'mockup_showcase_artesania',
   'mockups/efectos-funcionales': 'mockup_efectos_funcionales',
   'mockups/catalogo-infra': 'mockup_catalogo_infra',
   'mockups/mundo-abejas-3d': 'mockup_mundo_abejas_3d',
@@ -2397,6 +2399,14 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Artesanía andina">
               <ArtesaniaAndinaDemoMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_showcase_artesania':
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Muestrario de artesanía andina">
+              <ShowcaseArtesaniaMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/__tests__/App.mockup-routes-contract.test.js
+++ b/src/__tests__/App.mockup-routes-contract.test.js
@@ -30,4 +30,11 @@ describe('App route contracts', () => {
     expect(hashRoutes.get(route)).toBe(view);
     expect(switchCases.has(view)).toBe(true);
   });
+
+  it('conecta ShowcaseArtesania como ruta mockup publica', () => {
+    const mockupRoutes = new Map(getRouteEntries('MOCKUP_HASH_ROUTES').map(({ route, view }) => [route, view]));
+
+    expect(mockupRoutes.get('mockups/showcase-artesania')).toBe('mockup_showcase_artesania');
+    expect(switchCases.has('mockup_showcase_artesania')).toBe(true);
+  });
 });

--- a/src/mockups/vitrina3d/VitrinaInfraestructura.jsx
+++ b/src/mockups/vitrina3d/VitrinaInfraestructura.jsx
@@ -31,7 +31,7 @@ import {
   INFRAESTRUCTURA_IDS,
   INFRAESTRUCTURA_CATEGORIAS,
 } from '../../visual/mundo3d/infraestructura/infraestructuraData.js';
-import Infraestructura from '../../visual/mundo3d/infraestructura/Infraestructura.jsx';
+import InfraestructuraViva from '../../visual/mundo3d/infraestructura/InfraestructuraViva.jsx';
 import { decidirTier, permite3D } from '../../visual/mundo3d/deviceTier.js';
 import { ATMOSFERA } from '../../visual/mundo3d/atmosferaMadre.js';
 import './VitrinaInfraestructura.css';
@@ -126,7 +126,7 @@ function LienzoPieza({ tipo, dims, tier, reducedMotion }) {
         <meshLambertMaterial color="#b49873" />
       </mesh>
       <Suspense fallback={null}>
-        <Infraestructura tipo={tipo} dims={dims} params={{}} tier={tier} reducedMotion={reducedMotion} />
+        <InfraestructuraViva tipo={tipo} dims={dims} params={{}} tier={tier} reducedMotion={reducedMotion} />
       </Suspense>
       <OrbitControls
         target={[0, dims.alto * 0.42, 0]}
@@ -410,7 +410,7 @@ function DemoColocar({ modo3D, tier, reducedMotion }) {
             <directionalLight position={[-6, 5, -8]} intensity={0.22} color={ATMOSFERA.relleno} />
             <TerrenoDemo segmentos={tier === 'alto' ? 56 : 34} onTocar={tocarTerreno} />
             {colocadas.map((c, i) => (
-              <Infraestructura
+              <InfraestructuraViva
                 key={`${c.tipo}-${i}`}
                 tipo={c.tipo}
                 pos={c.pos}
@@ -424,7 +424,7 @@ function DemoColocar({ modo3D, tier, reducedMotion }) {
             {borrador && (
               <>
                 <AnilloBorrador borrador={borrador} />
-                <Infraestructura
+                <InfraestructuraViva
                   tipo={borrador.tipo}
                   pos={borrador.pos}
                   rot={borrador.rot}

--- a/src/mockups/vitrina3d/__tests__/VitrinaInfraestructura.test.jsx
+++ b/src/mockups/vitrina3d/__tests__/VitrinaInfraestructura.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }) => <div data-testid="lienzo-3d">{children}</div>,
+}));
+
+vi.mock('@react-three/drei', () => ({ OrbitControls: () => null }));
+
+vi.mock('../../../visual/mundo3d/deviceTier.js', () => ({
+  decidirTier: () => ({ tier: 'alto' }),
+  permite3D: () => true,
+}));
+
+vi.mock('../../../visual/mundo3d/infraestructura/Infraestructura.jsx', () => ({
+  default: () => <div data-testid="infraestructura-base" />,
+}));
+
+vi.mock('../../../visual/mundo3d/infraestructura/InfraestructuraViva.jsx', () => ({
+  default: ({ tipo }) => <div data-testid="infraestructura-viva" data-tipo={tipo} />,
+}));
+
+import VitrinaInfraestructura from '../VitrinaInfraestructura.jsx';
+import {
+  INFRAESTRUCTURA,
+  INFRAESTRUCTURA_CATEGORIAS,
+} from '../../../visual/mundo3d/infraestructura/infraestructuraData.js';
+
+afterEach(() => cleanup());
+
+describe('VitrinaInfraestructura', () => {
+  test('monta InfraestructuraViva en los dioramas del catálogo', () => {
+    const { container } = render(<VitrinaInfraestructura />);
+    const categoriaInicial = INFRAESTRUCTURA_CATEGORIAS[0];
+    const esperadas = Object.values(INFRAESTRUCTURA).filter(
+      (pieza) => pieza.categoria === categoriaInicial,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Vitrina de infraestructura' })).toBeInTheDocument();
+    expect(screen.getAllByTestId('infraestructura-viva')).toHaveLength(esperadas.length);
+    expect(container.querySelector('[data-testid="infraestructura-base"]')).toBeNull();
+  });
+});

--- a/src/visual/mundo3d/VistaGlobalSierra.jsx
+++ b/src/visual/mundo3d/VistaGlobalSierra.jsx
@@ -56,12 +56,14 @@
  *
  * El contenedor padre define el alto (como `.mundo-root`).
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Html, OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import { ATMOSFERA } from './atmosferaMadre.js';
 import { perfilDeTier } from './deviceTier.js';
+import PisosTermicosBandas from './PisosTermicosBandas.jsx';
+import TransicionSierraMundo from './TransicionSierraMundo.jsx';
 
 /* ── Geografía del macizo (validada contra el DR: mar al norte, macizo al sur,
       cumbres gemelas + Simmonds, costa de Palomino). Coordenadas de MUNDO:
@@ -380,6 +382,8 @@ function CreditoPueblos() {
  * @param {boolean} [props.luces=true]  monta las luces de la hora dorada.
  * @param {boolean} [props.atmosfera=true]  fondo + niebla dorada de la escena.
  * @param {boolean} [props.credito=true]  pie de crédito 3D a los cuatro pueblos.
+ * @param {(piso:object)=>void} [props.onSeleccionPiso]  avisa al host al llegar a un piso.
+ * @param {string|null} [props.pisoActivo=null]  piso resaltado desde el host.
  */
 export function SierraDiorama({
   tier = 'alto',
@@ -388,6 +392,8 @@ export function SierraDiorama({
   luces = true,
   atmosfera = true,
   credito = true,
+  onSeleccionPiso,
+  pisoActivo = null,
 }) {
   const perfil = perfilDeTier(tier);
   const geo = useMemo(
@@ -422,6 +428,16 @@ export function SierraDiorama({
       <Rotulo pos={[PALOMINO.x, PALOMINO.y, PALOMINO.z]} texto="Palomino" sub="Caribe · 0 m" distancia={11} alto={0.45} />
 
       {pisoUsuario && <MarcadorPiso piso={pisoUsuario} />}
+      <PisosTermicosBandas
+        pisoUsuario={pisoUsuario}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        alturaCumbre={CIMA}
+        radioBase={4}
+        radioCumbre={0.35}
+        onSeleccionPiso={onSeleccionPiso}
+        pisoActivo={pisoActivo}
+      />
       {credito && <CreditoPueblos />}
     </>
   );
@@ -461,16 +477,28 @@ const CSS_SIERRA = `
  * @param {'alto'|'medio'|'bajo'} [props.tier='alto']  presupuesto de render.
  * @param {boolean} [props.reducedMotion=false]  sin órbita ni nubes; frameloop a demanda.
  * @param {string}  [props.pisoUsuario]  piso de la finca a resaltar (opcional).
+ * @param {(piso:object)=>void} [props.onSeleccionPiso]  se llama al llegar al piso seleccionado.
  * @param {string}  [props.className]  clases extra del contenedor.
  */
 export default function VistaGlobalSierra({
   tier = 'alto',
   reducedMotion = false,
   pisoUsuario,
+  onSeleccionPiso,
   className = '',
 }) {
   const [listo, setListo] = useState(false);
+  const [pisoActivo, setPisoActivo] = useState(null);
+  const [viaje, setViaje] = useState(null);
   const perfil = perfilDeTier(tier);
+  const seleccionarPiso = useCallback((piso) => {
+    setPisoActivo(piso.id);
+    setViaje({ piso, activa: true });
+  }, []);
+  const llegarAPiso = useCallback(() => {
+    if (viaje?.piso) onSeleccionPiso?.(viaje.piso);
+  }, [onSeleccionPiso, viaje]);
+  const terminarViaje = useCallback(() => setViaje(null), []);
   return (
     <section
       className={`vsierra-root${className ? ` ${className}` : ''}`}
@@ -498,6 +526,8 @@ export default function VistaGlobalSierra({
           reducedMotion={reducedMotion}
           pisoUsuario={pisoUsuario}
           credito={false}
+          onSeleccionPiso={seleccionarPiso}
+          pisoActivo={pisoActivo}
         />
         <OrbitControls
           makeDefault
@@ -517,6 +547,15 @@ export default function VistaGlobalSierra({
         />
         <AdaptiveDpr pixelated />
       </Canvas>
+
+      <TransicionSierraMundo
+        activa={viaje?.activa ?? false}
+        pisoDestino={viaje?.piso.id}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        onMitad={llegarAPiso}
+        onFin={terminarViaje}
+      />
 
       {/* Chrome DOM anclado a la composición: título arriba; abajo la clave de
           pisos (accesible) y el pie de crédito, apoyados sobre la playa/mar del

--- a/src/visual/mundo3d/__tests__/fincaRealista.geom.test.js
+++ b/src/visual/mundo3d/__tests__/fincaRealista.geom.test.js
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { RAZAS_CERDO } from '../finca/fincaRealista.geom.js';
+
+describe('razas de cerdo', () => {
+  it('resuelve ambas grafías de San Pedreño a la misma ficha', () => {
+    expect(RAZAS_CERDO.sanpedreno).toBeDefined();
+    expect(RAZAS_CERDO['sanpedreño']).toBe(RAZAS_CERDO.sanpedreno);
+  });
+});

--- a/src/visual/mundo3d/__tests__/vistaGlobalSierra.cableado.test.jsx
+++ b/src/visual/mundo3d/__tests__/vistaGlobalSierra.cableado.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }) => <div data-testid="canvas-sierra">{children}</div>,
+  useFrame: () => {},
+}));
+
+vi.mock('@react-three/drei', () => ({
+  AdaptiveDpr: () => null,
+  Html: ({ children }) => <div>{children}</div>,
+  OrbitControls: () => null,
+}));
+
+import VistaGlobalSierra from '../VistaGlobalSierra.jsx';
+
+afterEach(() => vi.useRealTimers());
+
+describe('VistaGlobalSierra, cableado de pisos térmicos', () => {
+  test('monta las bandas y confirma la selección al llegar a destino', () => {
+    vi.useFakeTimers();
+    const onSeleccionPiso = vi.fn();
+    render(<VistaGlobalSierra onSeleccionPiso={onSeleccionPiso} />);
+
+    const bandaCalida = document.querySelector('[data-piso="calido"]');
+    expect(bandaCalida).toBeInTheDocument();
+    fireEvent.click(bandaCalida);
+
+    expect(screen.getByTestId('tsm')).toBeInTheDocument();
+    act(() => vi.advanceTimersByTime(750));
+    expect(onSeleccionPiso).toHaveBeenCalledWith(expect.objectContaining({ id: 'calido' }));
+
+    act(() => vi.advanceTimersByTime(750));
+    expect(screen.queryByTestId('tsm')).not.toBeInTheDocument();
+  });
+});

--- a/src/visual/mundo3d/finca/fincaRealista.geom.js
+++ b/src/visual/mundo3d/finca/fincaRealista.geom.js
@@ -538,6 +538,10 @@ RAZAS_CERDO['sanpedreño'] = RAZAS_CERDO.sanpedreno;
 RAZAS_CERDO['casco de mula'] = RAZAS_CERDO.cascoDeMula;
 RAZAS_CERDO.cascodemula = RAZAS_CERDO.cascoDeMula;
 
+// El hato puede registrar la raza sin eñe. Ambas grafías deben usar la misma
+// ficha para evitar que una de ellas caiga al cerdo zungo por defecto.
+RAZAS_CERDO['sanpedreño'] = RAZAS_CERDO.sanpedreno;
+
 /**
  * El cerdo por raza. Mira a +X, patas en y=0, lomo a ~0.62.
  * @returns {{cuerpo: THREE.BufferGeometry, cabeza: THREE.BufferGeometry, pivote: [number,number,number]}}


### PR DESCRIPTION
Consolida 4 PRs de arte de codex sobre dev, cada uno en su commit. **Build verde** (vite, 3m22s). **PENDIENTE gate visual** — NO mergear sin captura por contenido.

- #2747 feat(mockups): showcase de artesania
- #2750 feat(sierra): cablear pisos termicos (VistaGlobalSierra)
- #2751 fix(vitrina): infraestructura viva (VitrinaInfraestructura)
- #2748 fix(mundo3d): grafias sanpedreno (fincaRealista)

Gallinero (#2743/#2752) excluido: chocan entre si + con #2748. #2746 podrido (base main, 284k lineas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)