### PR TITLE
feat(abejas): rastro de polen visible — la polinizacion se lee como proceso

### DIFF
--- a/src/mockups/MundoAbejas3D.jsx
+++ b/src/mockups/MundoAbejas3D.jsx
@@ -9,6 +9,9 @@
  *   · CICLO DE FORRAJEO — cada Angelita vuela a una flor, SE POSA, liba un
  *     momento, y sigue a la siguiente; al cerrar la ronda ENTRA a la piquera de
  *     su vivienda y sale cargada. Máquina de estados en refs (cero re-render).
+ *   · EL RASTRO DE POLEN — en vuelo va soltando motas ámbar que suben y se
+ *     apagan: la sarta dibuja el RECORRIDO flor→flor. Así la polinización se lee
+ *     como PROCESO (y no como abejas quietas) hasta con la escena detenida.
  *   · LA FLOR RESPONDE — se estremece cuando la visitan, la corola se abre un
  *     punto y suelta un puff de polen que sube y se disuelve. Las visitas
  *     viajan por un Float32Array compartido: la abeja escribe, la flor lee.
@@ -318,6 +321,26 @@ const puntoDeFlor = (f) => new THREE.Vector3(f.p[0], f.p[1] + 0.62 * f.esc + 0.0
    módulo a propósito — es un canal de animación entre hermanos, no estado de
    interfaz; el mundo se monta uno a la vez y el canal se limpia al montar. */
 const VISITAS = new Float32Array(FLORES.length);
+
+/* ═══════════════════ EL RASTRO DE POLEN ═══════════════════
+   La lección que un cuadro FIJO no contaba: la abeja no solo se posa — LLEVA el
+   polen de una flor a la siguiente. Ahí está la polinización, y en una captura
+   congelada no se veía (parecían abejas quietas encima de las flores). Cada
+   forrajera en vuelo va soltando motas ámbar que suben y se desvanecen: la sarta
+   dibuja el RECORRIDO flor→flor, así el PROCESO se lee hasta con la escena
+   detenida. Mismo canal entre hermanos que VISITAS: la abeja escribe una mota en
+   un anillo de módulo, el rastro la lee y la apaga. Cero re-render por cuadro. */
+const RASTRO_MAX = 66;
+const rastroPos = new Float32Array(RASTRO_MAX * 3);
+const rastroVida = new Float32Array(RASTRO_MAX); // 0 = mota apagada
+let rastroCursor = 0;
+function emitirPolen(x, y, z) {
+  const i = rastroCursor;
+  rastroPos[i * 3] = x; rastroPos[i * 3 + 1] = y; rastroPos[i * 3 + 2] = z;
+  rastroVida[i] = 1;
+  rastroCursor = (rastroCursor + 1) % RASTRO_MAX;
+}
+function limpiarRastro() { rastroVida.fill(0); }
 
 /* UNA flor: tallo con dos hojas y corola de pétalos ahuecados. Se mece con su
    brisa propia y REACCIONA a la visita — se estremece, la corola se abre un
@@ -686,7 +709,7 @@ function pintar(capa, ref, dir, k) {
    React es `libando` (dos veces por parada), que enciende la probóscide y el
    polvillo de polen del propio dibujo de la casa. Con reduced-motion la abeja
    queda POSADA en su primera flor: quieta, pero polinizando. */
-function AbejaForrajera({ datos, reducedMotion }) {
+function AbejaForrajera({ datos, reducedMotion, rastro = true }) {
   const grupo = useRef(/** @type {any} */ (null));
   const capa = useRef(/** @type {HTMLDivElement|null} */ (null));
   const pincel = useRef({ dir: 1, k: 1 });
@@ -743,6 +766,16 @@ function AbejaForrajera({ datos, reducedMotion }) {
       v.x += Math.sin(t * 4.6 + datos.fase) * 0.06 * (1 - s);
       v.z += Math.cos(t * 3.9 + datos.fase) * 0.05 * (1 - s);
       g.position.copy(v);
+      /* va soltando polen mientras viaja: la sarta ámbar ES el recorrido
+         flor→flor. Cada ~0,08s una mota bajo el cuerpo, con leve deriva. */
+      if (rastro && t - (e.emit || 0) > 0.075) {
+        e.emit = t;
+        emitirPolen(
+          v.x + Math.sin(t * 21 + datos.fase) * 0.05,
+          v.y - 0.05,
+          v.z + Math.cos(t * 17 + datos.fase) * 0.05,
+        );
+      }
       if (u >= 1) {
         e.fase = parada.tipo === 'flor' ? 'posada' : 'boca';
         e.t0 = t;
@@ -798,6 +831,44 @@ function AbejaForrajera({ datos, reducedMotion }) {
         </div>
       </Html>
     </group>
+  );
+}
+
+/* EL RASTRO, VISIBLE. Un solo InstancedMesh lee el anillo de motas que las
+   forrajeras van soltando en vuelo y las pinta: suben un punto y se apagan. La
+   sarta ámbar dibuja el recorrido flor→flor — la polinización que un cuadro
+   fijo no mostraba. Cero geometría por mota (una instancia reusada), cero
+   re-render: todo se escribe en las matrices cuadro a cuadro. */
+function RastroPolen({ reducedMotion }) {
+  const malla = useRef(/** @type {any} */ (null));
+  const dummy = useMemo(() => new THREE.Object3D(), []);
+  useFrame((_s, delta) => {
+    const m = malla.current;
+    if (!m) return;
+    for (let i = 0; i < RASTRO_MAX; i++) {
+      const v = rastroVida[i];
+      if (v > 0) {
+        const s = 0.026 + v * 0.075;
+        dummy.position.set(
+          rastroPos[i * 3],
+          rastroPos[i * 3 + 1] + (1 - v) * 0.42, // sube al desvanecerse
+          rastroPos[i * 3 + 2],
+        );
+        dummy.scale.setScalar(s);
+        if (!reducedMotion) rastroVida[i] = Math.max(0, v - delta * 0.7);
+      } else {
+        dummy.scale.setScalar(0); // apagada: colapsada, no se ve
+      }
+      dummy.updateMatrix();
+      m.setMatrixAt(i, dummy.matrix);
+    }
+    m.instanceMatrix.needsUpdate = true;
+  });
+  return (
+    <instancedMesh ref={malla} args={[undefined, undefined, RASTRO_MAX]} frustumCulled={false}>
+      <sphereGeometry args={[1, 6, 5]} />
+      <meshBasicMaterial color={C.miel} transparent opacity={0.85} depthWrite={false} />
+    </instancedMesh>
   );
 }
 
@@ -890,8 +961,10 @@ function Escena({ tier, reducedMotion, seleccion }) {
   const guardianas = tier === 'bajo' ? GUARDIANAS.slice(0, 1) : GUARDIANAS;
   const controlsRef = useRef(/** @type {any} */ (null));
   const objetivoInicial = ZONAS[seleccion] || ZONAS.polinizacion;
-  /* el canal de visitas arranca limpio cada vez que el mundo se monta */
-  useEffect(() => { VISITAS.fill(0); }, []);
+  /* los canales entre hermanos (visitas y rastro) arrancan limpios cada vez que
+     el mundo se monta */
+  const rastroOn = tier !== 'bajo';
+  useEffect(() => { VISITAS.fill(0); limpiarRastro(); }, []);
   return (
     <>
       <color attach="background" args={[DORADA.cielo]} />
@@ -934,11 +1007,13 @@ function Escena({ tier, reducedMotion, seleccion }) {
         <Flor key={`flor-${i}`} indice={i} datos={datos} reducedMotion={reducedMotion} motas={tier !== 'bajo'} />
       ))}
       {forrajeras.map((datos, i) => (
-        <AbejaForrajera key={`for-${i}`} datos={datos} reducedMotion={reducedMotion} />
+        <AbejaForrajera key={`for-${i}`} datos={datos} reducedMotion={reducedMotion} rastro={rastroOn} />
       ))}
       {guardianas.map((datos, i) => (
         <AbejaGuardiana key={`gua-${i}`} datos={datos} reducedMotion={reducedMotion} />
       ))}
+      {/* el polen viajando de flor en flor: el proceso, no solo las abejas */}
+      {rastroOn ? <RastroPolen reducedMotion={reducedMotion} /> : null}
 
       <ParticulasAmbientales tipo="polen" tier={tier} reducedMotion={reducedMotion} area={[9, 3, 6]} position={[0, 1.0, 1.2]} />
       <OrbitControls ref={controlsRef} makeDefault enablePan={false} minDistance={7} maxDistance={22} minPolarAngle={0.6} maxPolarAngle={1.36} target={objetivoInicial} />

--- a/src/mockups/__tests__/mundoAbejas3D.smoke.test.jsx
+++ b/src/mockups/__tests__/mundoAbejas3D.smoke.test.jsx
@@ -6,11 +6,15 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 vi.mock('@react-three/fiber', () => ({
   Canvas: ({ children, frameloop }) => <div data-testid="canvas" data-frameloop={frameloop}>{children}</div>,
   useFrame: () => {},
+  // Encuadre lee el tamaño del canvas para decidir vertical/horizontal; en el
+  // test le damos una pantalla angosta (el objetivo real: celular 390×844).
+  useThree: (selector) => selector({ size: { width: 390, height: 844 } }),
 }));
 
 vi.mock('@react-three/drei', () => ({
   AdaptiveDpr: () => null,
   OrbitControls: () => null,
+  PerspectiveCamera: () => null,
   // El enjambre monta las Angelitas rubber-hose como billboards <Html>.
   Html: ({ children }) => <div data-testid="html-billboard">{children}</div>,
 }));
@@ -30,7 +34,7 @@ describe('MundoAbejas3D', () => {
     expect(screen.getByTestId('canvas')).toHaveAttribute('data-frameloop', 'always');
     expect(screen.getByRole('region', { name: 'Diorama 3D de abejas, meliponas y flores meliferas' })).toBeInTheDocument();
     expect(screen.getAllByRole('button')).toHaveLength(3);
-    expect(screen.getByRole('button', { name: /Polinizacion que da fruto/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /Polinización que da fruto/ })).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('permite elegir la leccion sobre conservacion de nativas', () => {
@@ -38,31 +42,40 @@ describe('MundoAbejas3D', () => {
     const nativas = screen.getByRole('button', { name: /Meliponas nativas/ });
     fireEvent.click(nativas);
     expect(nativas).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('button', { name: /Polinizacion que da fruto/ })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: /Polinización que da fruto/ })).toHaveAttribute('aria-pressed', 'false');
   });
 
   // Cableado de `seleccion` al 3D: antes la tarjeta activa solo se pintaba a
   // sí misma y el Canvas no se enteraba de cuál estaba tocada.
+  // El foco arranca en el surco y salta a la vivienda de cada tarjeta. Se
+  // compara por cercanía (toBeCloseTo): la posición se deriva de constantes de
+  // escena que pueden llevar coma flotante (p. ej. -2.3 + 0.2), y lo que importa
+  // es que el foco aterrice en la ZONA correcta, no el string exacto.
+  const posDelFoco = (container) =>
+    container.querySelector('group[name="foco-seleccion"]').getAttribute('position').split(',').map(Number);
+  const esperarCerca = (pos, [x, y, z]) => {
+    expect(pos[0]).toBeCloseTo(x, 2);
+    expect(pos[1]).toBeCloseTo(y, 2);
+    expect(pos[2]).toBeCloseTo(z, 2);
+  };
+
   describe('cablea la tarjeta activa al Canvas (no solo su propio borde)', () => {
     test('empieza mirando el surco de flores (tarjeta 01)', () => {
       const { container } = render(<MundoAbejas3D />);
-      const foco = container.querySelector('group[name="foco-seleccion"]');
-      expect(foco).toBeTruthy();
-      expect(foco.getAttribute('position')).toBe('0,0.55,3');
+      expect(container.querySelector('group[name="foco-seleccion"]')).toBeTruthy();
+      esperarCerca(posDelFoco(container), [0, 0.85, 1.9]);
     });
 
     test('tocar la tarjeta 02 (miel) lleva el foco al panal/colmenas', () => {
       const { container } = render(<MundoAbejas3D />);
       fireEvent.click(screen.getByRole('button', { name: /Miel, cera y cuidado/ }));
-      const foco = container.querySelector('group[name="foco-seleccion"]');
-      expect(foco.getAttribute('position')).toBe('-1.7,0.75,-1.8');
+      esperarCerca(posDelFoco(container), [-2.1, 1.05, -1.3]);
     });
 
     test('tocar la tarjeta 03 (nativas) lleva el foco a la caja melipona', () => {
       const { container } = render(<MundoAbejas3D />);
       fireEvent.click(screen.getByRole('button', { name: /Meliponas nativas/ }));
-      const foco = container.querySelector('group[name="foco-seleccion"]');
-      expect(foco.getAttribute('position')).toBe('3.65,0.4,-1.7');
+      esperarCerca(posDelFoco(container), [1.3, 0.8, 0.2]);
     });
   });
 });


### PR DESCRIPTION
## Qué

El mundo 3D **«Polinización que da fruto»** (`diorama_abejas`) ya movía las abejas de flor en flor desde #2672, pero en un **cuadro fijo** (que es como se revisa por captura) parecían quietas encima de las flores: el gesto que da nombre al mundo no se leía. Este PR hace **legible el proceso** — cada forrajera en vuelo va soltando **motas ámbar de polen** que suben y se apagan, dibujando el **recorrido flor→flor**. La polinización se entiende como proceso incluso con la escena detenida.

## Cambios

- **`RastroPolen`**: un solo `InstancedMesh` lee un anillo de motas que las forrajeras escriben en vuelo (mismo patrón de *canal entre hermanos* que el `VISITAS` existente: la abeja escribe, el rastro lee y apaga). Cero geometría por mota, cero re-render por cuadro. Tier-aware (apagado en `bajo`), se limpia al montar, y con `reduced-motion` no deja motas congeladas.
- **Smoke test del mundo, verde**: estaba **rojo pre-existente** (el mock de R3F no exportaba `useThree`/`PerspectiveCamera` que usa `Encuadre` desde #2672, y las aserciones del foco tenían posiciones desactualizadas). Se completan los mocks, se corrige el título acentuado y las posiciones se comparan por cercanía (`toBeCloseTo`, robusto a floats). **5/5 pasa.**

## Verificación

- `npm run build` OK.
- `vitest` del mundo: 5/5 verde.
- Captura local (chromium + swiftshader, ruta `diorama_abejas`): se ve el reguero de polen entre las flores y entrando a la piquera de la caja melipona.
- Juez visual local (qwen3-vl:8b): pasa de **«falta proceso de polinización»** (antes) a **«ocurre»** (después).

## Nota para review

El juez local valida **presencia**, no finura de arte. Movimiento animado (abejas volando, rastro fluyendo) verificado con serie temporal de capturas; una sola imagen no puede mostrar animación. El review de arte final es del operador.

Fidelidad al DR de *Tetragonisca angustula* (meliponino sin aguijón): vuelo lento y flotante, colmena Langstroth vs. caja melipona con potes de cerumen, apicultor rubber-hose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)