### PR TITLE
fix(gallinero): viaje de camara a la parcela del paso elegido (integra #2743, supera #2752)

### DIFF
--- a/src/mockups/MundoGallinero3D.jsx
+++ b/src/mockups/MundoGallinero3D.jsx
@@ -1,5 +1,6 @@
-import { useMemo, useRef, useState } from 'react';
-import { Canvas, useFrame } from '@react-three/fiber';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { AdaptiveDpr, Html, OrbitControls } from '@react-three/drei';
 import { ATMOSFERA, CIELOS, PALETA, mezclar, mezclarCielo } from '../visual/mundo3d/atmosferaMadre.js';
 import { ACENTOS, VERDES, TIERRAS } from '../visual/mundo3d/paleta/paletaMadre.js';
@@ -48,6 +49,49 @@ const CULTIVOS = Array.from({ length: 18 }, (_, i) => ({
   fruto: i % 6 === 2,
 }));
 const POSTES = [-6.1, -2.1, 2.1, 6.1];
+const VISTAS_PASO = {
+  pastoreo: { posicion: [-9.4, 5.2, 7.2], mira: [-4.2, 0.55, -1.8] },
+  traslado: { posicion: [7.4, 4.7, 8.2], mira: [0, 0.7, -1.8] },
+  descanso: { posicion: [10.2, 5.1, 5.8], mira: [4.2, 0.5, -1.8] },
+  huerto: { posicion: [8.4, 4.2, 10.2], mira: [4.2, 0.7, 2.6] },
+};
+
+function CamaraPaso({ paso, controls, reducedMotion }) {
+  const { camera } = useThree();
+  const viaje = useRef(null);
+  const pasoAnterior = useRef(paso);
+
+  useEffect(() => {
+    if (paso === pasoAnterior.current) return;
+    pasoAnterior.current = paso;
+    const vista = VISTAS_PASO[paso];
+    const control = controls.current;
+    if (!vista || !control) return;
+    viaje.current = {
+      progreso: 0,
+      duracion: reducedMotion ? 0.001 : 1.1,
+      desdePosicion: camera.position.clone(),
+      haciaPosicion: new THREE.Vector3(...vista.posicion),
+      desdeMira: control.target.clone(),
+      haciaMira: new THREE.Vector3(...vista.mira),
+    };
+  }, [camera, controls, paso, reducedMotion]);
+
+  useFrame((_, delta) => {
+    const estado = viaje.current;
+    const control = controls.current;
+    if (!estado || !control) return;
+    estado.progreso = Math.min(1, estado.progreso + delta / estado.duracion);
+    const t = estado.progreso;
+    const suave = t < 0.5 ? 4 * t ** 3 : 1 - (-2 * t + 2) ** 3 / 2;
+    camera.position.lerpVectors(estado.desdePosicion, estado.haciaPosicion, suave);
+    control.target.lerpVectors(estado.desdeMira, estado.haciaMira, suave);
+    control.update();
+    if (estado.progreso === 1) viaje.current = null;
+  });
+
+  return null;
+}
 
 /* LOMAS del horizonte: la vereda que faltaba para que la losa no flotara en
    crema. Anillo completo (la cámara auto-rota 360°) en dos planos de
@@ -409,6 +453,7 @@ function Escena({ tier, reducedMotion, paso, vertical }) {
      caminan las gallinas y a dónde se traslada el tractor. Antes `paso`
      nunca llegaba hasta acá. */
   const activa = useMemo(() => PARCELAS.find((p) => p.id === paso) ?? PARCELAS[0], [paso]);
+  const controls = useRef(null);
   return (
     <>
       <color attach="background" args={[CIELO.fondo]} />
@@ -433,7 +478,8 @@ function Escena({ tier, reducedMotion, paso, vertical }) {
       {/* Encuadre por orientación: en retrato la cámara sube y se aleja para
           que la losa ENTERA quepa, y el target baja para dejarle a la banda
           inferior (panel del ciclo) aire sin tapar la parvada. */}
-      <OrbitControls makeDefault enablePan={false} minDistance={7} maxDistance={vertical ? 26 : 19} minPolarAngle={0.48} maxPolarAngle={1.3} target={vertical ? [0, -0.8, 0] : [0, 0.5, 0]} autoRotate={!reducedMotion} autoRotateSpeed={0.18} />
+      <OrbitControls ref={controls} makeDefault enablePan={false} minDistance={7} maxDistance={vertical ? 26 : 19} minPolarAngle={0.48} maxPolarAngle={1.3} target={vertical ? [0, -0.8, 0] : [0, 0.5, 0]} autoRotate={!reducedMotion} autoRotateSpeed={0.18} />
+      <CamaraPaso paso={paso} controls={controls} reducedMotion={reducedMotion} />
       <AdaptiveDpr pixelated />
     </>
   );
@@ -468,7 +514,7 @@ export default function MundoGallinero3D({ onBack }) {
   return (
     <section className="mgall-root" data-tier={tier} aria-label="Mundo del gallinero con pastoreo rotativo">
       <style>{CSS}</style>
-      <Canvas className="mgall-canvas" data-lista={listo} dpr={perfil.dpr} frameloop={reducedMotion ? 'demand' : 'always'} gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }} camera={vertical ? { position: [13.5, 12.5, 16], fov: 47 } : { position: [11, 8.5, 12], fov: 43 }} onCreated={() => setListo(true)}>
+      <Canvas className="mgall-canvas" data-lista={listo} data-paso={paso} dpr={perfil.dpr} frameloop={reducedMotion ? 'demand' : 'always'} gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }} camera={vertical ? { position: [13.5, 12.5, 16], fov: 47 } : { position: [11, 8.5, 12], fov: 43 }} onCreated={() => setListo(true)}>
         <Escena tier={tier} reducedMotion={reducedMotion} paso={paso} vertical={vertical} />
       </Canvas>
       <div className="mgall-ui">

--- a/src/mockups/__tests__/mundoGallinero3D.test.jsx
+++ b/src/mockups/__tests__/mundoGallinero3D.test.jsx
@@ -1,7 +1,29 @@
 import React from 'react';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { useFrame } from '@react-three/fiber';
+
+const threeMock = vi.hoisted(() => {
+  const vector = (x, y, z) => ({
+    x,
+    y,
+    z,
+    clone() {
+      return vector(this.x, this.y, this.z);
+    },
+    lerpVectors(desde, hacia, t) {
+      this.x = desde.x + (hacia.x - desde.x) * t;
+      this.y = desde.y + (hacia.y - desde.y) * t;
+      this.z = desde.z + (hacia.z - desde.z) * t;
+      return this;
+    },
+  });
+  return {
+    camera: { position: vector(11, 8.5, 12) },
+    vector,
+  };
+});
 
 vi.mock('@react-three/fiber', () => ({
   Canvas: ({ children, onCreated, ...props }) => {
@@ -9,11 +31,19 @@ vi.mock('@react-three/fiber', () => ({
     return <div data-testid="canvas" {...props}>{children}</div>;
   },
   useFrame: vi.fn(),
+  useThree: () => ({ camera: threeMock.camera }),
 }));
 
 vi.mock('@react-three/drei', () => ({
   AdaptiveDpr: () => null,
-  OrbitControls: () => null,
+  Html: ({ children }) => <div data-mock="html">{children}</div>,
+  OrbitControls: React.forwardRef(function OrbitControls(_, ref) {
+    React.useImperativeHandle(ref, () => ({
+      target: threeMock.vector(0, 0.5, 0),
+      update: vi.fn(),
+    }));
+    return null;
+  }),
 }));
 
 vi.mock('../../visual/mundo3d/ParticulasAmbientales.jsx', () => ({
@@ -24,13 +54,18 @@ import MundoGallinero3D from '../MundoGallinero3D.jsx';
 
 afterEach(cleanup);
 
+beforeEach(() => {
+  threeMock.camera.position = threeMock.vector(11, 8.5, 12);
+  vi.mocked(useFrame).mockClear();
+});
+
 describe('MundoGallinero3D', () => {
   test('presenta el ciclo completo y monta su propio Canvas', () => {
     render(<MundoGallinero3D />);
     expect(screen.getByRole('heading', { name: 'El gallinero que camina' })).toBeInTheDocument();
     expect(screen.getByTestId('canvas')).toHaveAttribute('data-lista', 'true');
     expect(screen.getByRole('list', { name: 'Ciclo del pastoreo rotativo' })).toBeInTheDocument();
-    expect(screen.getAllByRole('button')).toHaveLength(4);
+    expect(screen.getByRole('list', { name: 'Ciclo del pastoreo rotativo' }).getElementsByTagName('button')).toHaveLength(4);
     expect(screen.getByText(/evita el sobrepastoreo/i)).toBeInTheDocument();
   });
 
@@ -62,9 +97,10 @@ describe('MundoGallinero3D', () => {
       expect(tractor.getAttribute('position')).toBe('-4.2,0.25,-1.8');
 
       // Las 8 gallinas se reparten alrededor de esa MISMA parcela, no
-      // amontonadas en un rincón fijo del mundo.
+      // amontonadas en un rincón fijo del mundo. (Radios del anillo estirados
+      // en #2723 al destapar el tractor: gallina-0 va a activa + [-1.7, -0.6].)
       const gallina0 = container.querySelector('group[name="gallina-0"]');
-      expect(gallina0.getAttribute('position')).toBe('-5.2,0.2,-2.2');
+      expect(gallina0.getAttribute('position')).toBe('-5.9,0,-2.4');
     });
 
     test('tocar "2. Traslado" mueve el tractor y las gallinas a la nueva parcela, y la activa cambia', () => {
@@ -81,7 +117,7 @@ describe('MundoGallinero3D', () => {
       expect(tractor.getAttribute('position')).toBe('0,0.25,-1.8');
 
       const gallina0 = container.querySelector('group[name="gallina-0"]');
-      expect(gallina0.getAttribute('position')).toBe('-1,0.2,-2.2');
+      expect(gallina0.getAttribute('position')).toBe('-1.7,0,-2.4');
     });
 
     test('tocar "4. Huerto aliado" lleva el tractor y las gallinas a esa parcela (distinta de las otras tres)', () => {
@@ -92,7 +128,18 @@ describe('MundoGallinero3D', () => {
       expect(tractor.getAttribute('position')).toBe('4.2,0.25,2.6');
 
       const gallina0 = container.querySelector('group[name="gallina-0"]');
-      expect(gallina0.getAttribute('position')).toBe('3.2,0.2,2.2');
+      expect(gallina0.getAttribute('position')).toBe('2.5,0,2');
     });
+  });
+
+  test('lleva la camara a la parcela elegida en el ciclo', () => {
+    render(<MundoGallinero3D onBack={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /3. Descanso/i }));
+
+    const [callback] = vi.mocked(useFrame).mock.calls.at(-1);
+    callback({ clock: { elapsedTime: 0 } }, 1.1);
+
+    expect(screen.getByTestId('canvas')).toHaveAttribute('data-paso', 'descanso');
+    expect(threeMock.camera.position).toMatchObject({ x: 10.2, y: 5.1, z: 5.8 });
   });
 });


### PR DESCRIPTION
## Qué integra

Integración del arte pendiente del gallinero 3D (carril codex, PRs #2752 y #2743) sobre `origin/dev`.

- **#2743 (cámara)**: INTEGRADO. Nuevo `CamaraPaso` + `VISTAS_PASO`: al tocar un paso del ciclo la cámara viaja 1.1s (ease in-out cúbica) al encuadre de esa parcela y el target del OrbitControls la acompaña. Con reduced-motion el salto es inmediato. Se agrega `data-paso` al Canvas.
- **#2752 (billboards)**: NO se aplica — dev ya lo superó vía #2661/#2723 (parvada billboard con marcha lerp, poses anda/picotea, flip con histéresis, Gallina criolla de 203 líneas vs 63 del PR). Aplicarlo sería regresión (borraba lomas, cultivos variados, parcela activa). Se puede cerrar.
- **Tests**: mock de `Html` en drei (faltaba; dev usa billboards `<Html>` y el mock viejo lo dejaba undefined) + expectativas de `gallina-0` corregidas a los radios reales de #2723 — estaban rotas en dev (escritas en #2655, el mundo cambió después sin actualizar el test). 6/6 verdes.

## Gate visual (GPU real, AMD Vega 10 — NO SwiftShader)

Capturas 390x844 (móvil objetivo), servidas desde `dist/` del build de esta rama:

1. **gallinero-pastoreo** (estado inicial): parvada de 8 gallinas billboard (coloradas + claras) alrededor del tractor en la parcela 1, ponedero con huevos, huerto con matas variadas y tomates, lomas fundidas en la niebla.
2. **gallinero-descanso** (tocando «3. Descanso»): la cámara viajó al encuadre de la parcela 3 — tractor centrado con techo rojo y bebederos, parvada repartida a su alrededor, parcela activa levantada/aclarada, pie actualizado.
3. **gallinero-huerto** (tocando «4. Huerto aliado»): cámara sobre la parcela 4, tractor entre los surcos del huerto, parvada en el borde.

PNG en stg:
- /tmp/claude-1000/-home-kortux-workspace/6d0b524d-4356-4e95-a4dc-4f829122c883/scratchpad/gate-gallinero/gr-gallinero-pastoreo.png
- /tmp/claude-1000/-home-kortux-workspace/6d0b524d-4356-4e95-a4dc-4f829122c883/scratchpad/gate-gallinero/gr-gallinero-descanso.png
- /tmp/claude-1000/-home-kortux-workspace/6d0b524d-4356-4e95-a4dc-4f829122c883/scratchpad/gate-gallinero/gr-gallinero-huerto.png

`npm run build` verde (3m06s). `vitest` del mundo 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)