### PR TITLE
feat(modelo): qwen3.5:4b en prod (quirurgico, retira e2b)

### DIFF
--- a/public/chagra-stats.json
+++ b/public/chagra-stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-21T05:03:56.760Z",
+  "generated_at": "2026-07-24T20:47:22.344Z",
   "schema_version": "1.1.0",
   "catalogo": {
     "especies": 581,

--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-21T05:03:56.627Z",
+  "generated_at": "2026-07-24T20:47:22.206Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -37,5 +37,9 @@ export const ENV = {
   // (snowflake-arctic-embed2) en la M6000 de 12GB, cosa que granite3.3 no hacía:
   // con granite el embedder daba cudaMalloc OOM y el RAG semántico se apagaba en
   // silencio. Verificado en vivo: embed 200ms + agente 860-1450ms, conviviendo.
-  NLU_MODEL: import.meta.env?.VITE_NLU_MODEL || 'gemma4:e2b',
+  // 2026-07-24: gemma4:e2b → qwen3.5:4b (quirúrgico a prod). Ganador del maratón
+  // #2738: índice texto 84.7 (+14.8 vs e2b), y en el set duro v2 la ventaja crece
+  // +3→+13 (razona, no memoriza). Multimodal + tools, 3.4GB. Prueba dura end-to-end
+  // contra el stack vivo confirmó RAG 88.2 / grounding 81.2 / grafo 70 / taxonomía 92.3.
+  NLU_MODEL: import.meta.env?.VITE_NLU_MODEL || 'qwen3.5:4b',
 };

--- a/src/services/entityExtractor.js
+++ b/src/services/entityExtractor.js
@@ -39,7 +39,8 @@ const OLLAMA_CHAT_URL = '/api/ollama/api/chat';
 // está hot para no evictar el chat) SIGUE VALIENDO: ahora el hot es e2b.
 // Y el motivo de fondo cambió a favor: granite3.3 contamina 47,7% contra 10%
 // de e2b, medido con juez semántico sobre 70 sondas.
-const MODEL = 'gemma4:e2b';
+// 2026-07-24: gemma4:e2b → qwen3.5:4b (unificado con chat; ganador del maratón #2738).
+const MODEL = 'qwen3.5:4b';
 // El modelo responde en pocos segundos para extracción JSON con format:json.
 // Nginx permite hasta 120s en /api/ollama/; 60s cliente es el punto medio seguro.
 const TIMEOUT_MS = 60000;

--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -95,7 +95,7 @@ export const ROUTES = {
       // observados en producción". La medición dice que NO los mitigó: con juez
       // semántico sobre 70 sondas, granite3.3 falla el piso térmico el 41,7% de
       // las veces y contamina el 47,7% global. gemma4:e2b: 6,7% y 10%.
-      'gemma4:e2b',
+      'qwen3.5:4b',
     keep_alive_min: 30,
     temperature: 0.3,
     // 2026-06-06: 512→768. Fuga real (interacción operador): respuesta de
@@ -124,7 +124,7 @@ export const ROUTES = {
       // 2026-07-22: la nota de arriba decía que granite3.3 "evita confusiones
       // taxonómicas". El bench con juez semántico lo desmiente: confusión de
       // especie y cruce de cultivos al 91,7%. gemma4:e2b baja el cruce a 33,3%.
-      'gemma4:e2b',
+      'qwen3.5:4b',
     keep_alive_min: 5,
     temperature: 0.3,
     // 2026-06-06: 768→1024. Las queries complejas (planes multi-cultivo,
@@ -142,7 +142,7 @@ export const ROUTES = {
     // NLU REAL = sidecar agro-mcp nlu.ts (granite3.3:8b). Este campo es
     // vestigial: la PWA delega NLU al sidecar /nlu. Ver
     // Chagra-strategy/ops/MODELS.md (fuente única de verdad de modelos).
-    model: 'gemma4:e2b',
+    model: 'qwen3.5:4b',
     keep_alive_min: 0,
     temperature: 0,
     max_tokens: 150,


### PR DESCRIPTION
Quirurgico: lleva solo el modelo ganador a prod, sin el merge masivo dev a main (655 commits) ni tocar los guards de plaguicidas. Cambia los 5 puntos donde main clava gemma4:e2b a qwen3.5:4b (env.js NLU_MODEL, llmRouter chat/chat_complex/nlu, entityExtractor). Vision intacta (qwen3-vl:8b). Indice 84.7 (+14.8 vs e2b); ventaja +3 a +13 en el set duro. Build verde. Prueba dura end-to-end: RAG 88.2 grounding 81.2 grafo 70 taxonomia 92.3.

Generated with Claude Code