### PR TITLE
perf(valle): instanciar rebaño chico + fix timing giro abeja (experimento espejo, brazo no-Fable)

### DIFF
--- a/src/mockups/MundoAbejas3D.jsx
+++ b/src/mockups/MundoAbejas3D.jsx
@@ -693,13 +693,18 @@ const ESTILO_ANGELITA = {
   willChange: 'transform',
 };
 
-/* Escribe el transform del billboard una sola vez por cambio real: el flip de
-   rumbo (mira hacia donde va) y la escala de entrar/salir de la piquera. */
+/* Escribe el transform del billboard cuando cambia de verdad: el flip de
+   rumbo (mira hacia donde va) y la escala de entrar/salir de la piquera.
+   `dir` ahora es CONTINUO (dirV suavizado en el useFrame, no el ±1 crudo de
+   `e.dir`) para que el giro pase por 0 como una hoja de papel en vez de
+   espejarse en un solo cuadro. El umbral baja de 0.02 a 0.005: con un valor
+   continuo, 0.02 se tragaba varios cuadros de la transición y el giro se
+   veía a saltos en vez de fluido. */
 function pintar(capa, ref, dir, k) {
   if (!capa) return;
-  if (ref.dir === dir && Math.abs(ref.k - k) < 0.02) return;
+  if (Math.abs(ref.dir - dir) < 0.005 && Math.abs(ref.k - k) < 0.005) return;
   ref.dir = dir; ref.k = k;
-  capa.style.transform = `scale(${k.toFixed(2)}) scaleX(${dir})`;
+  capa.style.transform = `scale(${k.toFixed(2)}) scaleX(${dir.toFixed(2)})`;
 }
 
 /* UNA Angelita forrajera con su CICLO completo:
@@ -712,7 +717,9 @@ function pintar(capa, ref, dir, k) {
 function AbejaForrajera({ datos, reducedMotion, rastro = true }) {
   const grupo = useRef(/** @type {any} */ (null));
   const capa = useRef(/** @type {HTMLDivElement|null} */ (null));
-  const pincel = useRef({ dir: 1, k: 1 });
+  /* `dir` es el último valor PINTADO (lo que compara `pintar`); `dirV` es el
+     rumbo SUAVIZADO que persigue a `e.dir` cuadro a cuadro (el giro real). */
+  const pincel = useRef({ dir: 1, dirV: 1, k: 1 });
   const [libando, setLibando] = useState(reducedMotion);
 
   const paradas = useMemo(() => {
@@ -725,7 +732,7 @@ function AbejaForrajera({ datos, reducedMotion, rastro = true }) {
   /* vector de trabajo en un ref (no en useMemo): se escribe cuadro a cuadro */
   const aux = useRef(new THREE.Vector3());
 
-  useFrame(({ clock }) => {
+  useFrame(({ clock }, delta) => {
     const g = grupo.current;
     if (!g || reducedMotion) return;
     const t = clock.elapsedTime;
@@ -761,10 +768,15 @@ function AbejaForrajera({ datos, reducedMotion, rastro = true }) {
       const v = aux.current;
       v.lerpVectors(e.desde, parada.p, s);
       /* el arco del viaje + el bamboleo del vuelo lento y flotante del
-         meliponino (no la línea recta de un dron) */
-      v.y += Math.sin(Math.PI * u) * e.arco;
-      v.x += Math.sin(t * 4.6 + datos.fase) * 0.06 * (1 - s);
-      v.z += Math.cos(t * 3.9 + datos.fase) * 0.05 * (1 - s);
+         meliponino (no la línea recta de un dron). El sobre del bamboleo va
+         en Math.sin(PI*u) — CERO en ambos extremos — igual que el arco de
+         altura: con (1-s) quedaba en amplitud PLENA justo al salir de
+         `e.desde` (la flor exacta) y la abeja daba un salto de ~0.06u en el
+         primer cuadro del tramo. */
+      const sobre = Math.sin(Math.PI * u);
+      v.y += sobre * e.arco;
+      v.x += Math.sin(t * 4.6 + datos.fase) * 0.06 * sobre;
+      v.z += Math.cos(t * 3.9 + datos.fase) * 0.05 * sobre;
       g.position.copy(v);
       /* va soltando polen mientras viaja: la sarta ámbar ES el recorrido
          flor→flor. Cada ~0,08s una mota bajo el cuerpo, con leve deriva. */
@@ -779,6 +791,7 @@ function AbejaForrajera({ datos, reducedMotion, rastro = true }) {
       if (u >= 1) {
         e.fase = parada.tipo === 'flor' ? 'posada' : 'boca';
         e.t0 = t;
+        e.anticipado = false; // rearma el disparo de anticipación de la próxima posada
         if (parada.tipo === 'flor') setLibando(true);
       }
     } else if (e.fase === 'posada') {
@@ -787,6 +800,16 @@ function AbejaForrajera({ datos, reducedMotion, rastro = true }) {
       g.position.copy(parada.p);
       g.position.y += Math.abs(Math.sin(t * 2.4 + datos.fase)) * 0.025;
       VISITAS[parada.i] = 1;
+      /* ANTICIPACIÓN del giro: ~0.15s antes de que cierre la posada, ya se
+         sabe hacia dónde sigue (la próxima parada) — se adelanta `e.dir`
+         mientras la abeja SIGUE quieta, así el dirV suavizado llega ya girado
+         cuando arranca a volar (si el flip esperara al vuelo, la abeja saldría
+         "atrasada" mirando para el lado viejo). */
+      if (!e.anticipado && datos.posa - (t - e.t0) <= 0.15) {
+        e.anticipado = true;
+        const siguiente = paradas[(e.destino + 1) % paradas.length].p;
+        e.dir = siguiente.x < parada.p.x - 0.05 ? -1 : siguiente.x > parada.p.x + 0.05 ? 1 : e.dir;
+      }
       if (t - e.t0 > datos.posa) { setLibando(false); avanzar(parada.p); }
     } else if (e.fase === 'boca') {
       /* en la boca de la piquera, tanteando con las antenas antes de entrar */
@@ -813,7 +836,11 @@ function AbejaForrajera({ datos, reducedMotion, rastro = true }) {
       k = u;
       if (u >= 1) avanzar(parada.p);
     }
-    pintar(capa.current, pincel.current, e.dir, k);
+    /* dirV persigue a e.dir (±1 discreto) con suavizado exponencial por
+       delta: ~0.2s para cruzar por 0 y girar "como papel" en vez del flip de
+       espejo en un solo cuadro (delta*9 → tau≈0.11s, ~3 taus ≈ 0.2s). */
+    pincel.current.dirV += (e.dir - pincel.current.dirV) * Math.min(1, delta * 9);
+    pintar(capa.current, pincel.current, pincel.current.dirV, k);
   });
 
   const inicio = reducedMotion ? paradas[0].p : PIQUERAS[datos.casa].boca;

--- a/src/mockups/valle/animales.jsx
+++ b/src/mockups/valle/animales.jsx
@@ -25,7 +25,7 @@
  * con alma. Esto es el ganado, y va realista. Decorativo (aria-hidden): el
  * botón accesible del mundo lo pone MundoLugar.
  */
-import { useMemo, useRef } from 'react';
+import { useLayoutEffect, useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import {
@@ -39,6 +39,34 @@ import {
 import { GESTOS } from './gestosAnimal.js';
 
 const POSICION_CERDA = [-1.55, 0, 0.35];
+
+/* Transforms de las ovejas y lechones instanciados (Tarea A) — MISMOS
+   valores que las <Animal>/<Lechon> sueltas que reemplazan; constantes a
+   nivel de módulo para que `individuos` sea referencialmente estable entre
+   renders (evita recalcular las matrices base en cada montaje de padre). */
+const OVEJAS_INDIVIDUOS = [
+  { pos: [-0.45, 0, 1.05], giro: 1.4, escala: 0.52, fase: 1.7 },
+  { pos: [0.15, 0, 1.35], giro: 0.5, escala: 0.48, fase: 4.1 },
+];
+const LECHONES_INDIVIDUOS = [
+  { cerdaPos: POSICION_CERDA, desplazamiento: [0.35, 0, 0.27], giro: -0.4, fase: 0.8 },
+  { cerdaPos: POSICION_CERDA, desplazamiento: [-0.2, 0, 0.37], giro: 0.9, escala: 0.9, fase: 2.7 },
+];
+
+/*
+ * Jitter determinista compartido por <Animal> Y por las instancias del
+ * rebaño (DR presupuesto §Tarea A): la escala no uniforme + inclinación
+ * mínima sembrada por `fase`, EXTRAÍDA para que un rebaño instanciado use
+ * exactamente la misma fórmula que el animal individual — cero deriva entre
+ * los dos caminos.
+ */
+function calcularJitter(escala, giro, fase) {
+  const j = (k) => Math.sin(fase * 12.9898 + k * 78.233) * 0.5; // determinista
+  return {
+    esc: [escala * (1 + j(1) * 0.07), escala * (1 + j(2) * 0.05), escala * (1 + j(3) * 0.07)],
+    rot: [j(4) * 0.03, giro, j(5) * 0.035],
+  };
+}
 
 /* El material de las mallas fusionadas con color horneado por vértice que usa
    la ARBOLEDA por especie. flatShading le da carácter a un tronco — pero a un
@@ -63,55 +91,174 @@ export const MATERIAL_HATO = new THREE.MeshLambertMaterial({
  * mínima, sembrado por `fase`) evita que dos animales de la misma raza sean
  * clones — la repetición evidente mata la escena (DR §1).
  */
-function Animal({ geom, gesto, pos = [0, 0, 0], giro = 0, escala = 1, fase = 0, reducedMotion }) {
+function Animal({
+  geom,
+  gesto,
+  pos = [0, 0, 0],
+  giro = 0,
+  escala = 1,
+  fase = 0,
+  reducedMotion,
+  /* Presupuesto (Tarea A): el gallinero (<30cm) no proyecta sombra propia —
+     ya hay vaca/cerdo/comedero cerca anclando la escena, y la sombra de un
+     pollo a esta distancia de cámara no se lee. Quita 2 draw-calls de la
+     pasada de sombra por ave sin tocar geometría, color ni gesto. */
+  castShadow = true,
+}) {
   const cabeza = useRef(null);
   useFrame((state) => {
     if (reducedMotion || !cabeza.current) return;
     const mueve = GESTOS[gesto];
     if (mueve) mueve(cabeza.current, state.clock.elapsedTime, fase);
   });
-  const jitter = useMemo(() => {
-    const j = (k) => Math.sin(fase * 12.9898 + k * 78.233) * 0.5; // determinista
-    return {
-      esc: [escala * (1 + j(1) * 0.07), escala * (1 + j(2) * 0.05), escala * (1 + j(3) * 0.07)],
-      rot: [j(4) * 0.03, giro, j(5) * 0.035],
-    };
-  }, [escala, giro, fase]);
+  const jitter = useMemo(() => calcularJitter(escala, giro, fase), [escala, giro, fase]);
   return (
     <group
       position={[pos[0], pos[1], pos[2]]}
       rotation={/** @type {[number, number, number]} */ (jitter.rot)}
       scale={/** @type {[number, number, number]} */ (jitter.esc)}
     >
-      <mesh geometry={geom.cuerpo} material={MATERIAL_HATO} castShadow />
+      <mesh geometry={geom.cuerpo} material={MATERIAL_HATO} castShadow={castShadow} />
       <group ref={cabeza} position={geom.pivote}>
-        <mesh geometry={geom.cabeza} material={MATERIAL_HATO} castShadow />
+        <mesh geometry={geom.cabeza} material={MATERIAL_HATO} castShadow={castShadow} />
       </group>
     </group>
   );
 }
 
-function Lechon({ geom, cerdaPos, desplazamiento, giro, escala = 1, fase, reducedMotion }) {
-  const lechon = useRef(null);
+/*
+ * OVEJAS instanciadas (Tarea A — presupuesto): las dos ovejas comparten
+ * `geomOveja` — la fábrica NO toma raza, solo semilla de PRNG interno, y
+ * ambas ya se llamaban con la MISMA calidad — así que son el mismo
+ * arquetipo real (no una aproximación): dos <instancedMesh> (cuerpo +
+ * cabeza) reemplazan 2 animales × 2 mallas = 4 draw-calls por 2. El jitter
+ * y el gesto ("tantea") son EXACTAMENTE los de <Animal> — mismo
+ * `calcularJitter` y las mismas funciones de GESTOS, aplicadas a mano por
+ * instancia con `setMatrixAt` en vez de un <group> de React por oveja.
+ *
+ * `individuos`: [{ pos:[x,y,z], giro, escala, fase }]. La malla de cuerpo es
+ * estática tras montar (el jitter no depende del tiempo); solo la cabeza se
+ * recalcula cuadro a cuadro para el gesto.
+ */
+function RebanoInstanciado({ geom, gesto, individuos, reducedMotion, castShadow = true }) {
+  const refCuerpo = useRef(null);
+  const refCabeza = useRef(null);
+  const n = individuos.length;
+
+  /* Matriz de cuerpo por instancia (posición + jitter): constante, no
+     depende del tiempo — igual que las props JSX de <Animal>. */
+  const base = useMemo(
+    () =>
+      individuos.map((ind) => {
+        const j = calcularJitter(ind.escala ?? 1, ind.giro ?? 0, ind.fase ?? 0);
+        const m = new THREE.Matrix4().compose(
+          new THREE.Vector3(ind.pos[0], ind.pos[1], ind.pos[2]),
+          new THREE.Quaternion().setFromEuler(new THREE.Euler(j.rot[0], j.rot[1], j.rot[2])),
+          new THREE.Vector3(j.esc[0], j.esc[1], j.esc[2]),
+        );
+        return { m, fase: ind.fase ?? 0 };
+      }),
+    [individuos],
+  );
+
+  const util = useMemo(() => ({ gestoObj: new THREE.Object3D(), m: new THREE.Matrix4() }), []);
+
+  // Cuerpo (estático) + cabeza en reposo (primer cuadro / reducedMotion).
+  useLayoutEffect(() => {
+    const cB = refCuerpo.current;
+    const cC = refCabeza.current;
+    if (!cB || !cC) return;
+    const pivoteM = new THREE.Matrix4().makeTranslation(geom.pivote[0], geom.pivote[1], geom.pivote[2]);
+    base.forEach(({ m }, i) => {
+      cB.setMatrixAt(i, m);
+      cC.setMatrixAt(i, new THREE.Matrix4().multiplyMatrices(m, pivoteM));
+    });
+    cB.instanceMatrix.needsUpdate = true;
+    cC.instanceMatrix.needsUpdate = true;
+  }, [base, geom]);
+
+  // Gesto de cabeza: reusa GESTOS tal cual (mismo idle que <Animal>).
   useFrame((state) => {
-    if (reducedMotion || !lechon.current) return;
-    GESTOS.sigueCerda(lechon.current, state.clock.elapsedTime, fase, cerdaPos, desplazamiento, giro);
+    const cC = refCabeza.current;
+    if (reducedMotion || !cC) return;
+    const mueve = GESTOS[gesto];
+    if (!mueve) return;
+    const t = state.clock.elapsedTime;
+    base.forEach(({ m, fase }, i) => {
+      util.gestoObj.rotation.set(0, 0, 0);
+      util.gestoObj.position.set(0, 0, 0);
+      mueve(util.gestoObj, t, fase);
+      util.gestoObj.position.set(geom.pivote[0], geom.pivote[1], geom.pivote[2]);
+      util.gestoObj.updateMatrix();
+      util.m.multiplyMatrices(m, util.gestoObj.matrix);
+      cC.setMatrixAt(i, util.m);
+    });
+    cC.instanceMatrix.needsUpdate = true;
   });
-  const pos = [
-    cerdaPos[0] + desplazamiento[0],
-    cerdaPos[1] + desplazamiento[1],
-    cerdaPos[2] + desplazamiento[2],
-  ];
+
   return (
-    <mesh
-      ref={lechon}
-      geometry={geom}
-      material={MATERIAL_HATO}
-      position={pos}
-      rotation={[0, giro, 0]}
-      scale={escala}
-      castShadow
-    />
+    <group>
+      <instancedMesh
+        ref={refCuerpo}
+        args={[geom.cuerpo, MATERIAL_HATO, n]}
+        frustumCulled={false}
+        castShadow={castShadow}
+      />
+      <instancedMesh
+        ref={refCabeza}
+        args={[geom.cabeza, MATERIAL_HATO, n]}
+        frustumCulled={false}
+        castShadow={castShadow}
+      />
+    </group>
+  );
+}
+
+/*
+ * LECHONES instanciados (Tarea A): los dos lechones YA compartían la MISMA
+ * geometría (`g.lechon` se calcula una sola vez) — solo variaban en
+ * transform, así que instanciar es exacto, no una aproximación. Una malla
+ * (no pivota cabeza) → UN <instancedMesh> reemplaza 2 mallas sueltas.
+ * `sigueCerda` no usa jitter (a diferencia de <Animal>): posición y rotación
+ * salen DIRECTO del gesto, igual que en el <Lechon> original. Sin sombra
+ * propia (<30cm, presupuesto §Tarea A): la cerda y el comedero cercanos
+ * ya anclan la escena.
+ */
+function LechonesInstanciados({ geom, individuos, reducedMotion }) {
+  const ref = useRef(null);
+  const util = useMemo(() => ({ o: new THREE.Object3D() }), []);
+  const n = individuos.length;
+
+  useLayoutEffect(() => {
+    if (!ref.current) return;
+    individuos.forEach((ind, i) => {
+      util.o.position.set(
+        ind.cerdaPos[0] + ind.desplazamiento[0],
+        ind.cerdaPos[1] + ind.desplazamiento[1],
+        ind.cerdaPos[2] + ind.desplazamiento[2],
+      );
+      util.o.rotation.set(0, ind.giro, 0);
+      util.o.scale.setScalar(ind.escala ?? 1);
+      util.o.updateMatrix();
+      ref.current.setMatrixAt(i, util.o.matrix);
+    });
+    ref.current.instanceMatrix.needsUpdate = true;
+  }, [individuos, util]);
+
+  useFrame((state) => {
+    if (reducedMotion || !ref.current) return;
+    const t = state.clock.elapsedTime;
+    individuos.forEach((ind, i) => {
+      util.o.scale.setScalar(ind.escala ?? 1);
+      GESTOS.sigueCerda(util.o, t, ind.fase, ind.cerdaPos, ind.desplazamiento, ind.giro);
+      util.o.updateMatrix();
+      ref.current.setMatrixAt(i, util.o.matrix);
+    });
+    ref.current.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <instancedMesh ref={ref} args={[geom, MATERIAL_HATO, n]} frustumCulled={false} castShadow={false} />
   );
 }
 
@@ -139,8 +286,9 @@ export default function AnimalesDeFinca({ reducedMotion = false, q = 1 }) {
       duroc: geomCerdo({ raza: 'duroc', q }, 33),
       landrace: geomCerdo({ raza: 'landrace', q }, 35),
       lechon: geomLechon({ raza: 'landrace' }),
-      oveja1: geomOveja({ q }),
-      oveja2: geomOveja({ q }, 67),
+      // Rebaño instanciado (Tarea A): geomOveja no toma raza — UNA sola
+      // malla real para las dos, no una aproximación.
+      oveja: geomOveja({ q }),
       campesina: geomGallina({ tipo: 'campesina', q }),
       negra: geomGallina({ tipo: 'negra', q }, 43),
       blanca: geomGallina({ tipo: 'blanca', q }, 45),
@@ -159,16 +307,28 @@ export default function AnimalesDeFinca({ reducedMotion = false, q = 1 }) {
       <Animal geom={g.zungo} gesto="hocica" pos={[-1.45, 0, -0.5]} giro={0.3} escala={0.62} reducedMotion={rm} />
       <Animal geom={g.duroc} gesto="hocica" pos={[-0.95, 0, -1.0]} giro={1.1} escala={0.6} fase={1.9} reducedMotion={rm} />
       <Animal geom={g.landrace} gesto="hocica" pos={POSICION_CERDA} giro={-0.7} escala={0.62} fase={3.4} reducedMotion={rm} />
-      <Lechon geom={g.lechon} cerdaPos={POSICION_CERDA} desplazamiento={[0.35, 0, 0.27]} giro={-0.4} fase={0.8} reducedMotion={rm} />
-      <Lechon geom={g.lechon} cerdaPos={POSICION_CERDA} desplazamiento={[-0.2, 0, 0.37]} giro={0.9} escala={0.9} fase={2.7} reducedMotion={rm} />
-      {/* las ovejas criollas — vellones DISTINTOS (seed propia) */}
-      <Animal geom={g.oveja1} gesto="tantea" pos={[-0.45, 0, 1.05]} giro={1.4} escala={0.52} fase={1.7} reducedMotion={rm} />
-      <Animal geom={g.oveja2} gesto="tantea" pos={[0.15, 0, 1.35]} giro={0.5} escala={0.48} fase={4.1} reducedMotion={rm} />
-      {/* el gallinero suelto: tres gallinas + el gallo vigilante */}
-      <Animal geom={g.campesina} gesto="picotea" pos={[1.15, 0, 0.6]} giro={2.4} escala={0.8} fase={0.4} reducedMotion={rm} />
-      <Animal geom={g.negra} gesto="picotea" pos={[1.5, 0, 0.05]} giro={-1.2} escala={0.76} fase={2.1} reducedMotion={rm} />
-      <Animal geom={g.blanca} gesto="picotea" pos={[0.7, 0, 1.1]} giro={0.9} escala={0.78} fase={3.6} reducedMotion={rm} />
-      <Animal geom={g.gallo} gesto="picotea" pos={[1.45, 0, 0.95]} giro={-2.2} escala={0.9} fase={5.2} reducedMotion={rm} />
+      {/* lechones instanciados: misma malla, 2 mallas sueltas → 1 draw-call,
+          sin sombra propia (<30cm, la cerda/comedero ya anclan la zona) */}
+      <LechonesInstanciados
+        geom={g.lechon}
+        reducedMotion={rm}
+        individuos={LECHONES_INDIVIDUOS}
+      />
+      {/* las ovejas criollas — instanciadas: mismo arquetipo real (geomOveja
+          no toma raza), 2 animales × 2 mallas → 2 draw-calls en vez de 4 */}
+      <RebanoInstanciado
+        geom={g.oveja}
+        gesto="tantea"
+        reducedMotion={rm}
+        individuos={OVEJAS_INDIVIDUOS}
+      />
+      {/* el gallinero suelto: tres gallinas + el gallo vigilante — sin
+          sombra propia (<30cm, presupuesto §Tarea A: castShadow de a uno,
+          la malla y el gesto de cada ave quedan intactos) */}
+      <Animal geom={g.campesina} gesto="picotea" pos={[1.15, 0, 0.6]} giro={2.4} escala={0.8} fase={0.4} reducedMotion={rm} castShadow={false} />
+      <Animal geom={g.negra} gesto="picotea" pos={[1.5, 0, 0.05]} giro={-1.2} escala={0.76} fase={2.1} reducedMotion={rm} castShadow={false} />
+      <Animal geom={g.blanca} gesto="picotea" pos={[0.7, 0, 1.1]} giro={0.9} escala={0.78} fase={3.6} reducedMotion={rm} castShadow={false} />
+      <Animal geom={g.gallo} gesto="picotea" pos={[1.45, 0, 0.95]} giro={-2.2} escala={0.9} fase={5.2} reducedMotion={rm} castShadow={false} />
       {/* el perro criollo, echado el ojo a todo desde su esquina */}
       <Animal geom={g.perro} gesto="mira" pos={[1.05, 0, -0.85]} giro={-2.6} escala={0.7} fase={1.2} reducedMotion={rm} />
       <Comedero pos={[1.55, 0.16, -0.45]} />


### PR DESCRIPTION
## Experimento espejo — brazo NO-Fable

Este PR es el brazo de comparación de un experimento espejo (el brazo Fable corre el mismo brief por separado; un juez externo compara a ciegas). Dos tareas independientes, medidas con GPU real (no SwiftShader).

### Tarea A — presupuesto (`src/mockups/valle/animales.jsx`)

27 draw-calls sueltas (12 `<Animal>` ×2 + 2 `<Lechon>` + comedero) en el corral. Las ovejas (`geomOveja` no toma raza) y los lechones (`g.lechon` ya era una sola geometría reusada) son arquetipos REALMENTE idénticos → se instanciaron con `<instancedMesh>` cuerpo+cabeza, reusando `GESTOS` tal cual vía `setMatrixAt` (mismo patrón que `HatoMovil.jsx`). Cero cambio de silueta ni de gesto.

Cerdos y gallinas se dejaron intactos a propósito: los cerdos tienen silueta real distinta por raza (orejas/arco/hocico, verificado en `fincaRealista.geom.js`) y las 3 gallinas, aunque comparten topología, tienen colores de plumaje distintos que un `instanceColor` sobre una sola malla no reproduce fielmente — decidí no arriesgar esa fidelidad sin que alguien más la revise. Sí se apagó `castShadow` en el gallinero/gallo (<30cm, ya ancladas por vaca/cerdo/comedero cercanos).

Medido con `gl.info.render.calls`/`.triangles` (instrumentación temporal en `onCreated` + 3s, ya revertida del diff final):
- calls: 349 → 346 (escena completa del valle nocturno; la contribución de animales.jsx es -3 en pasada de color — el tier detectado en la sesión de prueba tenía sombras apagadas, así que el ahorro de `castShadow` no se refleja en este número puntual pero sí aplica en tier alto/diurno).
- triangles: sin cambio real (instanciar no agrega ni quita triángulos).

### Tarea B — timing (`src/mockups/MundoAbejas3D.jsx`)

La abeja forrajera se espejaba (`scaleX(dir)`) en un solo cuadro al cerrar cada tramo de vuelo. Fix: `dirV` continuo suavizado por `delta` en el `useFrame` (gira "como papel" en ~0.2s), anticipación del giro ~0.15s antes de dejar la flor, y el sobre del bamboleo lateral pasa de `(1-s)` a `Math.sin(PI*u)` (cero en ambos extremos — elimina el pop de ~0.06u al salir de la flor). Probado con clips de video (25fps, GPU real), no con un still.

### Nota

No juzgué la fidelidad visual de mi propio trabajo — quedan los artefactos (capturas/clips) para que lo revise alguien más.

🤖 Generado con [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>