### PR TITLE
rescate: fable/biodigestor-15 — mundo del biodigestor y el ciclo cerrado del estiércol

### DIFF
--- a/src/visual/mundo3d/estiercol/Biocompostera.jsx
+++ b/src/visual/mundo3d/estiercol/Biocompostera.jsx
@@ -1,0 +1,403 @@
+/*
+ * Biocompostera — TRES CAJONES EN CORTE: el estiércol volviéndose tierra, y el
+ * calor haciendo el trabajo que nadie ve.
+ *
+ * Se lee de izquierda a derecha como una frase: recién armado (las capas
+ * todavía se cuentan una por una, el corazón hirviendo, el vapor saliendo) →
+ * el volteo (revuelto, el bieldo clavado, todavía tibio) → maduro (oscuro,
+ * frío, y por fin la lombriz).
+ *
+ * Y al lado, fuera de todo, el MONTÓN MAL LLEVADO: encharcado, sin carbono, sin
+ * techo. Suelta amoníaco verde que se arrastra por el suelo en vez de subir, y
+ * tiene las moscas que los cajones no tienen. Los dos "humean". Uno es salud
+ * (agua tibia) y el otro es plata volándose. Esa comparación es el módulo
+ * entero: ver `HUMOS` en `estiercol.geom.js`.
+ *
+ * Componente r3f (va dentro del `<Canvas>` de `EscenaEstiercol.jsx`). Geometría
+ * y verdad técnica en `compostera.geom.js`; aquí, material, luz y movimiento.
+ * Con `reducedMotion` monta quieto: el humo se congela repartido en su columna
+ * y las lombrices dejan de moverse — pero todo sigue ahí.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { crearMaterialMadre } from '../paleta/index.js';
+import { PALETA_ESTIERCOL, HUMOS, columnaHumo, torcerConLaMano } from './estiercol.geom.js';
+import {
+  CAJON,
+  TECHO,
+  FASES,
+  MONTON_MALO,
+  cajonX,
+  capasDelMonton,
+  capaGeom,
+  corazonGeom,
+  colorCorazon,
+  tablasCajon,
+  techoGeom,
+  postesTecho,
+  bolaPunoGeom,
+  bieldo,
+  lombrices,
+  lombrizGeom,
+  montonMaloGeom,
+  charcoGeom,
+  moscas,
+} from './compostera.geom.js';
+
+/* ── EL HUMO: el mismo componente sirve para el vapor y para el amoníaco, y
+      esa es exactamente la gracia. Cambia el color, la subida y la deriva —
+      el vapor sube limpio y se va; el amoníaco se arrastra pegado al suelo,
+      que es por lo que uno se lo respira. Instanciado: un draw-call. ── */
+function Humo({ datos, tipo, reducedMotion }) {
+  const ref = useRef(null);
+  const receta = HUMOS[tipo] || HUMOS.vapor;
+  const geo = useMemo(() => new THREE.SphereGeometry(1, 5, 4), []);
+  const mat = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: receta.color,
+        transparent: true,
+        opacity: receta.opacidad,
+        depthWrite: false,
+      }),
+    [receta],
+  );
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+
+  const m = useMemo(() => new THREE.Matrix4(), []);
+  const q = useMemo(() => new THREE.Quaternion(), []);
+  const v = useMemo(() => new THREE.Vector3(), []);
+  const s = useMemo(() => new THREE.Vector3(), []);
+
+  const colocar = (h, t) => {
+    /* el vapor sube; el amoníaco casi no: se queda a la altura de la nariz */
+    const y = h.base.y + t * receta.vida * h.vel;
+    const abre = 1 + t * 1.9; // el jirón se abre al alejarse
+    v.set(
+      h.base.x + Math.sin(h.giro + t * 2.4) * h.deriva * (1 + t * 2.6),
+      y,
+      h.base.z + Math.cos(h.giro + t * 2) * h.deriva * (1 + t * 2.6),
+    );
+    const k = h.escala * abre;
+    s.set(k, k * 0.8, k);
+    m.compose(v, q, s);
+    return m;
+  };
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    datos.forEach((h, i) => mesh.setMatrixAt(i, colocar(h, h.fase)));
+    mesh.instanceMatrix.needsUpdate = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `colocar` solo usa memos estables
+  }, [datos]);
+
+  useFrame((st) => {
+    const mesh = ref.current;
+    if (!mesh || reducedMotion) return;
+    const t0 = st.clock.elapsedTime * 0.24;
+    for (let i = 0; i < datos.length; i += 1) {
+      const h = datos[i];
+      const t = (h.fase + t0) % 1;
+      mesh.setMatrixAt(i, colocar(h, t));
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  });
+
+  if (!datos.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, datos.length]} frustumCulled={false} />;
+}
+
+/* ── LAS LOMBRICES: solo en el cajón maduro. Se mueven despacio, como se mueve
+      una lombriz. Instanciadas. ── */
+function Lombrices({ datos, matLombriz, reducedMotion }) {
+  const geo = useMemo(() => lombrizGeom(), []);
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  const grupo = useRef(null);
+
+  useFrame((st) => {
+    const g = grupo.current;
+    if (!g || reducedMotion) return;
+    const t = st.clock.elapsedTime;
+    g.children.forEach((hijo, i) => {
+      const d = datos[i];
+      if (!d) return;
+      /* el vaivén lento del que se está enterrando */
+      hijo.rotation.z = d.rot[2] + Math.sin(t * 0.8 + d.fase * 6.28) * 0.22;
+      hijo.position.y = d.pos[1] + Math.sin(t * 0.5 + d.fase * 6.28) * 0.012;
+    });
+  });
+
+  if (!datos.length) return null;
+  return (
+    <group ref={grupo}>
+      {datos.map((d, i) => (
+        <mesh
+          key={i}
+          geometry={geo}
+          material={matLombriz}
+          position={d.pos}
+          rotation={d.rot}
+          scale={d.escala}
+        />
+      ))}
+    </group>
+  );
+}
+
+/* ── LAS MOSCAS: giran sobre el montón malo y sobre ningún otro. No vienen por
+      el olor: vienen por el material húmedo y blando donde ponen los huevos.
+      Son la misma causa que el olor, y por eso están donde está el olor. ── */
+function Moscas({ datos, reducedMotion }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.SphereGeometry(0.016, 4, 3), []);
+  const mat = useMemo(() => new THREE.MeshBasicMaterial({ color: PALETA_ESTIERCOL.mosca }), []);
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+  const m = useMemo(() => new THREE.Matrix4(), []);
+  const q = useMemo(() => new THREE.Quaternion(), []);
+  const v = useMemo(() => new THREE.Vector3(), []);
+  const s = useMemo(() => new THREE.Vector3(), []);
+
+  const colocar = (f, t) => {
+    v.set(
+      f.centro[0] + Math.sin(t * f.vel + f.fase) * f.radio,
+      f.centro[1] + Math.sin(t * f.vel * 1.7 + f.fase) * f.radio * 0.4,
+      f.centro[2] + Math.cos(t * f.vel + f.fase) * f.radio,
+    );
+    s.setScalar(f.escala);
+    m.compose(v, q, s);
+    return m;
+  };
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    datos.forEach((f, i) => mesh.setMatrixAt(i, colocar(f, 0)));
+    mesh.instanceMatrix.needsUpdate = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `colocar` solo usa memos estables
+  }, [datos]);
+
+  useFrame((st) => {
+    const mesh = ref.current;
+    if (!mesh || reducedMotion) return;
+    for (let i = 0; i < datos.length; i += 1) mesh.setMatrixAt(i, colocar(datos[i], st.clock.elapsedTime));
+    mesh.instanceMatrix.needsUpdate = true;
+  });
+
+  if (!datos.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, datos.length]} frustumCulled={false} />;
+}
+
+/* ── UN CAJÓN: sus capas en corte, su corazón de calor y su vapor. ── */
+function Cajon({ fase, perfil, params, materiales, reducedMotion }) {
+  const capas = useMemo(() => capasDelMonton(fase), [fase]);
+  const geos = useMemo(() => capas.map((c, i) => capaGeom(c, 3 + i * 5)), [capas]);
+  const gCorazon = useMemo(() => corazonGeom(fase), [fase]);
+  useLayoutEffect(
+    () => () => {
+      geos.forEach((g) => g.dispose());
+      gCorazon.dispose();
+    },
+    [geos, gCorazon],
+  );
+
+  const matCorazon = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: colorCorazon(fase),
+        transparent: true,
+        opacity: 0.3 * fase.temperatura + 0.06,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      }),
+    [fase],
+  );
+  useLayoutEffect(() => () => matCorazon.dispose(), [matCorazon]);
+
+  /* origen LOCAL: el grupo del cajón ya está en su x (ver `tablasCajon`) */
+  const humo = useMemo(
+    () =>
+      columnaHumo(
+        [0, 1.35, -CAJON.hondo * 0.5],
+        Math.max(2, Math.round(params.humo * fase.vapor)),
+        'vapor',
+        101 + fase.cajon,
+      ),
+    [params.humo, fase],
+  );
+
+  const datosLombriz = useMemo(
+    () => (fase.lombrices ? lombrices(params) : []),
+    [fase.lombrices, params],
+  );
+
+  return (
+    <group position={[cajonX(fase.cajon), 0, 0]}>
+      {/* las tablas del cajón (el frente está afuera: se está trabajando) */}
+      {tablasCajon().map((t, i) => (
+        <mesh key={i} material={materiales.madera} position={t.pos} castShadow={perfil.sombras}>
+          <boxGeometry args={t.args} />
+        </mesh>
+      ))}
+
+      {/* EL MONTÓN EN CORTE: capa de estiércol, capa de material seco. Las
+          secas son más gruesas — sin ese carbono, el nitrógeno se va al aire */}
+      {capas.map((c, i) => (
+        <mesh
+          key={i}
+          geometry={geos[i]}
+          material={
+            c.tipo === 'drenaje'
+              ? materiales.maderaVieja
+              : c.tipo === 'carbono'
+                ? materiales.carbono
+                : c.tipo === 'estiercol'
+                  ? materiales.estiercol
+                  : materiales.compost
+          }
+        />
+      ))}
+
+      {/* EL CORAZÓN CALIENTE: lo que sanitiza. Se encoge y se apaga con la fase */}
+      <mesh geometry={gCorazon} material={matCorazon} />
+
+      {/* el vapor: agua tibia subiendo. La señal de que va BIEN */}
+      <Humo datos={humo} tipo="vapor" reducedMotion={reducedMotion} />
+
+      {/* la lombriz: solo aquí, solo al final */}
+      <Lombrices datos={datosLombriz} matLombriz={materiales.lombriz} reducedMotion={reducedMotion} />
+    </group>
+  );
+}
+
+/**
+ * EL MONTÓN MAL LLEVADO — el contraejemplo, en su propio componente porque la
+ * escena lo planta FUERA del anillo del ciclo (estación 'monton'). Ese destierro
+ * es literal: de este montón la materia no vuelve al suelo, se va al aire.
+ *
+ * Sin carbono, sin techo, sin voltear, encharcado. Se ve BABOSO (por eso usa la
+ * receta de agua: un compost sano se ve seco a húmedo, nunca brillante), tiene
+ * su charco al pie —lo que escurre y termina en la quebrada si nadie lo ataja—
+ * y sus moscas. Y no tiene corazón caliente: la fermentación sin aire genera
+ * menos calor útil que la aeróbica, así que ni siquiera sanitiza.
+ *
+ * @param {object} props
+ * @param {object} props.perfil  perfilDeTier(tier)
+ * @param {object} props.params  paramsDeTier(tier)
+ * @param {boolean} [props.reducedMotion]
+ */
+export function MontonMalLlevado({ perfil, params, reducedMotion = false }) {
+  const materiales = useMemo(
+    () => ({
+      malo: crearMaterialMadre('agua', perfil, { color: PALETA_ESTIERCOL.lodoHondo, opacity: 1 }),
+      charco: crearMaterialMadre('agua', perfil, { color: PALETA_ESTIERCOL.purin }),
+    }),
+    [perfil],
+  );
+  useLayoutEffect(() => () => Object.values(materiales).forEach((m) => m.dispose()), [materiales]);
+
+  const gMalo = useMemo(() => montonMaloGeom(), []);
+  const gCharco = useMemo(() => charcoGeom(), []);
+  useLayoutEffect(() => () => { gMalo.dispose(); gCharco.dispose(); }, [gMalo, gCharco]);
+
+  /* el amoníaco: NO sube, se arrastra. Es nitrógeno yéndose — o sea, plata */
+  const humo = useMemo(
+    () => columnaHumo([0, MONTON_MALO.alto * 0.8, 0], params.humo, 'amoniaco', 111),
+    [params.humo],
+  );
+  const datosMoscas = useMemo(() => moscas(params), [params]);
+
+  return (
+    <group>
+      <mesh geometry={gCharco} material={materiales.charco} position={[0, 0.008, 0]} />
+      <mesh geometry={gMalo} material={materiales.malo} castShadow={perfil.sombras} />
+      <Humo datos={humo} tipo="amoniaco" reducedMotion={reducedMotion} />
+      <Moscas datos={datosMoscas} reducedMotion={reducedMotion} />
+    </group>
+  );
+}
+
+/**
+ * La biocompostera completa (los tres cajones y su techo).
+ * @param {object} props
+ * @param {object} props.perfil  perfilDeTier(tier)
+ * @param {object} props.params  paramsDeTier(tier)
+ * @param {boolean} [props.reducedMotion]
+ */
+export default function Biocompostera({ perfil, params, reducedMotion = false }) {
+  const materiales = useMemo(
+    () => ({
+      madera: crearMaterialMadre('madera', perfil),
+      maderaVieja: crearMaterialMadre('madera', perfil, { color: PALETA_ESTIERCOL.maderaVieja }),
+      carbono: crearMaterialMadre('tierra', perfil, { color: PALETA_ESTIERCOL.carbono }),
+      estiercol: crearMaterialMadre('tierra', perfil, { color: PALETA_ESTIERCOL.estiercolFresco }),
+      compost: crearMaterialMadre('tierra', perfil, { color: PALETA_ESTIERCOL.compostMaduro }),
+      lombriz: crearMaterialMadre('corteza', perfil, { color: PALETA_ESTIERCOL.lombriz }),
+      lamina: crearMaterialMadre('lamina', perfil),
+    }),
+    [perfil],
+  );
+  useLayoutEffect(
+    () => () => Object.values(materiales).forEach((m) => m.dispose()),
+    [materiales],
+  );
+
+  const gTecho = useMemo(() => techoGeom(), []);
+  const gBola = useMemo(() => bolaPunoGeom(), []);
+  const gPoste = useMemo(
+    () => torcerConLaMano(new THREE.CylinderGeometry(0.05, 0.062, TECHO.alturaFrente, 6, 3), { amplitud: 0.02, seed: 77 }),
+    [],
+  );
+  useLayoutEffect(
+    () => () => [gTecho, gBola, gPoste].forEach((g) => g.dispose()),
+    [gTecho, gBola, gPoste],
+  );
+
+  const b = useMemo(() => bieldo(), []);
+
+  return (
+    <group>
+      {/* ── EL TECHO: la pieza que decide si el montón va bien o se pudre. Sin
+             él la lluvia lo encharca y se vuelve anaerobio ── */}
+      {postesTecho().map((p, i) => (
+        <mesh key={i} geometry={gPoste} material={materiales.madera} position={[p[0], TECHO.alturaFrente / 2, p[2]]} castShadow={perfil.sombras} />
+      ))}
+      <mesh
+        geometry={gTecho}
+        material={materiales.lamina}
+        position={[0, (TECHO.alturaFrente + TECHO.alturaAtras) / 2, -CAJON.hondo / 2]}
+        rotation={[Math.atan2(TECHO.alturaFrente - TECHO.alturaAtras, CAJON.hondo + 0.75), 0, 0]}
+        castShadow={perfil.sombras}
+      />
+
+      {/* ── LAS TRES FASES, de izquierda a derecha: se arma, se voltea, madura ── */}
+      {FASES.map((fase) => (
+        <Cajon
+          key={fase.id}
+          fase={fase}
+          perfil={perfil}
+          params={params}
+          materiales={materiales}
+          reducedMotion={reducedMotion}
+        />
+      ))}
+
+      {/* ── EL BIELDO clavado en el cajón del volteo: el trabajo, presente ── */}
+      <group position={[cajonX(1) + 0.5, 1.1, -0.35]} rotation={[0.3, 0, -0.26]}>
+        <mesh material={materiales.madera}>
+          <cylinderGeometry args={b.cabo.args} />
+        </mesh>
+        {b.dientes.map((dx, i) => (
+          <mesh key={i} material={materiales.lamina} position={[dx, -0.62, 0]}>
+            <cylinderGeometry args={[0.008, 0.005, b.dienteAlto, 4]} />
+          </mesh>
+        ))}
+      </group>
+
+      {/* ── LA PRUEBA DEL PUÑO, hecha objeto: la bola apretada que se sostiene y
+             NO chorrea. Ese es el punto de humedad. Con los surcos de los dedos ── */}
+      <mesh geometry={gBola} material={materiales.compost} position={[cajonX(1) - 0.6, CAJON.alto + 0.08, -0.06]} />
+    </group>
+  );
+}

--- a/src/visual/mundo3d/estiercol/Biodigestor.jsx
+++ b/src/visual/mundo3d/estiercol/Biodigestor.jsx
@@ -1,0 +1,378 @@
+/*
+ * Biodigestor — la MANGA en corte, viva: el lodo fermentando sin aire, las
+ * burbujas de metano subiendo a la campana, el biol saliendo por el otro lado
+ * y —el momento que lo explica todo— el biogás llegando a la cocina y ardiendo
+ * AZUL.
+ *
+ * Componente r3f: se monta dentro de un `<Canvas>` (lo provee
+ * `EscenaEstiercol.jsx`). Importa three → siempre perezoso, nunca en el bundle
+ * base.
+ *
+ * La geometría y la física viven en `biodigestor.geom.js` (puro y testeable);
+ * aquí solo van el material, la luz y el movimiento. Todo lo que se mueve pasa
+ * por el gate `reducedMotion`: con la preferencia de calma el biodigestor monta
+ * QUIETO — las burbujas se congelan a media altura y la llama deja de respirar,
+ * pero SIGUEN AHÍ (la lección no depende del movimiento).
+ *
+ * Presupuesto: la manga, el lodo, la campana y la zanja son mallas estáticas;
+ * las burbujas van INSTANCIADAS (un draw-call para todas). La llama son tres
+ * lathes chiquitos por boca, sin luz propia salvo en tier alto.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { crearMaterialMadre } from '../paleta/index.js';
+import { PALETA_ESTIERCOL } from './estiercol.geom.js';
+import {
+  ENTRADA,
+  SALIDA,
+  TOMA_GAS,
+  VALVULA,
+  COCINA,
+  CLIMAS,
+  LLAMA,
+  lodoGeom,
+  campanaGeom,
+  mangaGeom,
+  cantosManga,
+  zanjaGeom,
+  camaZanjaGeom,
+  invernaderoGeom,
+  parcheGeom,
+  amarresGeom,
+  burbujas,
+  BURBUJA_TECHO,
+  recorridoGas,
+  recorridoCocina,
+  mangueraGeom,
+  bocasLlama,
+  llamaGeom,
+} from './biodigestor.geom.js';
+
+/* ── LAS BURBUJAS: la fermentación anaerobia, que es lo único que hay que
+      creerse de esta escena. Nacen en el fondo del lodo y mueren al llegar a
+      la superficie, donde entregan su gas a la campana. Instanciadas. ── */
+function Burbujas({ datos, reducedMotion }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.SphereGeometry(1, 6, 5), []);
+  const mat = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        color: PALETA_ESTIERCOL.burbuja,
+        transparent: true,
+        opacity: 0.72,
+        depthWrite: false,
+      }),
+    [],
+  );
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+
+  const m = useMemo(() => new THREE.Matrix4(), []);
+  const q = useMemo(() => new THREE.Quaternion(), []);
+  const v = useMemo(() => new THREE.Vector3(), []);
+  const s = useMemo(() => new THREE.Vector3(), []);
+
+  /* El recorrido de una burbuja, en función de su avance t ∈ [0,1). Se usa
+     igual con movimiento (t corre) que sin él (t congelado por fase): la
+     escena calma muestra las burbujas repartidas por toda la columna. */
+  const colocar = (b, t) => {
+    const y = b.y0 + (BURBUJA_TECHO - b.y0) * t;
+    /* sube culebreando: una burbuja en un lodo espeso no sube a plomo */
+    const bamboleo = Math.sin(t * 9 + b.fase * 6.28) * 0.022;
+    v.set(b.x + bamboleo, y, b.z);
+    /* engorda al subir (menos presión arriba) y se estira al final */
+    const k = b.escala * (0.7 + t * 0.5);
+    s.set(k, k * (1 + t * 0.3), k);
+    m.compose(v, q, s);
+    return m;
+  };
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    /* con calma esto es TODO lo que corre: las burbujas quedan repartidas por
+       la columna (cada una en su fase), que es lo que hay que ver. */
+    datos.forEach((b, i) => mesh.setMatrixAt(i, colocar(b, b.fase)));
+    mesh.instanceMatrix.needsUpdate = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `colocar` es estable (solo usa memos)
+  }, [datos]);
+
+  useFrame((st) => {
+    const mesh = ref.current;
+    if (!mesh || reducedMotion) return;
+    const t0 = st.clock.elapsedTime;
+    for (let i = 0; i < datos.length; i += 1) {
+      const b = datos[i];
+      const t = (b.fase + t0 * b.vel) % 1;
+      mesh.setMatrixAt(i, colocar(b, t));
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  });
+
+  if (!datos.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, datos.length]} frustumCulled={false} />;
+}
+
+/* ── LA LLAMA AZUL: tres capas por boca (corazón pálido, cono azul, borde).
+      Aditiva y sin sombra: es fuego, no un objeto. Respira apenas — una llama
+      de biogás bien regulada es PAREJA, no una fogata que bailotea. ── */
+function Llama({ reducedMotion, perfil }) {
+  const grupo = useRef(null);
+  const bocas = useMemo(() => bocasLlama(), []);
+  const geos = useMemo(() => LLAMA.capas.map((c) => llamaGeom(c)), []);
+  const mats = useMemo(
+    () =>
+      LLAMA.capas.map(
+        (c) =>
+          new THREE.MeshBasicMaterial({
+            color: c.color,
+            transparent: true,
+            opacity: c.opacidad,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+          }),
+      ),
+    [],
+  );
+  useLayoutEffect(
+    () => () => {
+      geos.forEach((g) => g.dispose());
+      mats.forEach((m) => m.dispose());
+    },
+    [geos, mats],
+  );
+
+  useFrame((st) => {
+    const g = grupo.current;
+    if (!g || reducedMotion) return;
+    /* el pulso corto y parejo del gas bien regulado */
+    const t = st.clock.elapsedTime;
+    g.children.forEach((hijo, i) => {
+      hijo.scale.y = 1 + Math.sin(t * 7 + i * 1.7) * 0.07;
+    });
+  });
+
+  return (
+    <group ref={grupo} position={[COCINA.pos[0], COCINA.alto, COCINA.pos[2]]}>
+      {bocas.map((b, i) => (
+        <group key={i} position={b}>
+          {LLAMA.capas.map((c, j) => (
+            <mesh key={j} geometry={geos[j]} material={mats[j]} />
+          ))}
+        </group>
+      ))}
+      {/* la luz de la llama sobre la olla: solo donde sobra GPU */}
+      {perfil.luzBeacon && (
+        <pointLight color={PALETA_ESTIERCOL.llama} intensity={0.5} distance={1.6} position={[0, 0.15, 0]} />
+      )}
+    </group>
+  );
+}
+
+/* ── EL SELLO DE AGUA: la pieza de seguridad. La manguera muere bajo el agua
+      del frasco; si la presión sube de más, el gas burbujea y se escapa por
+      ahí en vez de reventar la manga. Barato y decisivo. ── */
+function SelloDeAgua({ matVidrio, matAgua, reducedMotion }) {
+  const burbuja = useRef(null);
+  useFrame((st) => {
+    const b = burbuja.current;
+    if (!b) return;
+    if (reducedMotion) {
+      b.visible = true;
+      b.position.y = VALVULA.aguaY - 0.04;
+      return;
+    }
+    /* de vez en cuando escapa una: la manga está en su presión de trabajo */
+    const t = (st.clock.elapsedTime * 0.5) % 1;
+    b.visible = t > 0.6;
+    b.position.y = VALVULA.aguaY - VALVULA.sumergido + (t - 0.6) * 0.4;
+  });
+  return (
+    <group position={VALVULA.pos}>
+      {/* el frasco */}
+      <mesh material={matVidrio} position={[0, VALVULA.alto / 2, 0]}>
+        <cylinderGeometry args={[VALVULA.radio, VALVULA.radio * 0.94, VALVULA.alto, 10, 1, true]} />
+      </mesh>
+      {/* el agua: lo que fija la presión máxima */}
+      <mesh material={matAgua} position={[0, VALVULA.aguaY / 2, 0]}>
+        <cylinderGeometry args={[VALVULA.radio * 0.93, VALVULA.radio * 0.9, VALVULA.aguaY, 10]} />
+      </mesh>
+      {/* la manguera sumergida: ESE es el sello */}
+      <mesh position={[0, VALVULA.aguaY - VALVULA.sumergido / 2 + 0.16, 0]}>
+        <cylinderGeometry args={[0.03, 0.03, 0.32 + VALVULA.sumergido, 6]} />
+        <meshBasicMaterial color={PALETA_ESTIERCOL.manguera} />
+      </mesh>
+      <mesh ref={burbuja}>
+        <sphereGeometry args={[0.026, 6, 5]} />
+        <meshBasicMaterial color={PALETA_ESTIERCOL.burbuja} transparent opacity={0.8} />
+      </mesh>
+    </group>
+  );
+}
+
+/**
+ * El biodigestor completo.
+ * @param {object} props
+ * @param {object} props.perfil  perfilDeTier(tier)
+ * @param {object} props.params  paramsDeTier(tier)
+ * @param {'calido'|'frio'} [props.clima]  el régimen térmico (ver CLIMAS)
+ * @param {boolean} [props.reducedMotion]
+ */
+export default function Biodigestor({ perfil, params, clima = 'frio', reducedMotion = false }) {
+  const regimen = CLIMAS[clima] || CLIMAS.frio;
+
+  /* ── materiales: todos por receta de la casa (GUIA.md §2) ── */
+  const matTierra = useMemo(() => crearMaterialMadre('tierra', perfil, { color: PALETA_ESTIERCOL.tierraHonda, side: THREE.DoubleSide }), [perfil]);
+  const matCama = useMemo(() => crearMaterialMadre('tierra', perfil, { color: PALETA_ESTIERCOL.carbono }), [perfil]);
+  const matManga = useMemo(
+    () =>
+      crearMaterialMadre('lamina', perfil, {
+        color: PALETA_ESTIERCOL.polietileno,
+        side: THREE.DoubleSide, // se ve la cara de ADENTRO del plástico: media escena
+        transparent: true,
+        opacity: 0.55, // el polietileno es traslúcido: por eso se adivina el lodo
+      }),
+    [perfil],
+  );
+  const matParche = useMemo(() => crearMaterialMadre('lamina', perfil, { color: PALETA_ESTIERCOL.parche, side: THREE.DoubleSide }), [perfil]);
+  const matLodo = useMemo(() => crearMaterialMadre('tierra', perfil, { color: PALETA_ESTIERCOL.lodo }), [perfil]);
+  const matGas = useMemo(
+    () => new THREE.MeshBasicMaterial({ color: PALETA_ESTIERCOL.gas, transparent: true, opacity: 0.16, depthWrite: false }),
+    [],
+  );
+  const matTubo = useMemo(() => crearMaterialMadre('lamina', perfil, { color: PALETA_ESTIERCOL.polietilenoSol }), [perfil]);
+  const matManguera = useMemo(() => crearMaterialMadre('lamina', perfil, { color: PALETA_ESTIERCOL.manguera }), [perfil]);
+  const matBiol = useMemo(() => crearMaterialMadre('agua', perfil, { color: PALETA_ESTIERCOL.biol }), [perfil]);
+  const matVidrio = useMemo(
+    () => new THREE.MeshBasicMaterial({ color: PALETA_ESTIERCOL.gas, transparent: true, opacity: 0.3, side: THREE.DoubleSide, depthWrite: false }),
+    [],
+  );
+  const matPlastico = useMemo(
+    () => new THREE.MeshBasicMaterial({ color: PALETA_ESTIERCOL.polietileno, transparent: true, opacity: 0.17, side: THREE.DoubleSide, depthWrite: false }),
+    [],
+  );
+  const matMadera = useMemo(() => crearMaterialMadre('madera', perfil), [perfil]);
+  const matAmarre = useMemo(() => crearMaterialMadre('lamina', perfil, { color: PALETA_ESTIERCOL.manguera }), [perfil]);
+
+  useLayoutEffect(
+    () => () =>
+      [matTierra, matCama, matManga, matParche, matLodo, matGas, matTubo, matManguera, matBiol, matVidrio, matPlastico, matMadera, matAmarre].forEach(
+        (m) => m.dispose(),
+      ),
+    [matTierra, matCama, matManga, matParche, matLodo, matGas, matTubo, matManguera, matBiol, matVidrio, matPlastico, matMadera, matAmarre],
+  );
+
+  /* ── geometrías: una vez por montaje ── */
+  const gZanja = useMemo(() => zanjaGeom(), []);
+  const gCama = useMemo(() => camaZanjaGeom(), []);
+  const gManga = useMemo(() => mangaGeom({ seg: params.segRadial + 6 }), [params.segRadial]);
+  const gLodo = useMemo(() => lodoGeom(), []);
+  const gCampana = useMemo(() => campanaGeom(), []);
+  const gParche = useMemo(() => parcheGeom(), []);
+  const gCantos = useMemo(() => cantosManga(), []);
+  const gAmarres = useMemo(() => amarresGeom(), []);
+  const gInvernadero = useMemo(
+    () => (params.invernadero && regimen.invernadero ? invernaderoGeom() : null),
+    [params.invernadero, regimen.invernadero],
+  );
+  const { curva: curvaGas, trampa } = useMemo(() => recorridoGas(), []);
+  const gManguera = useMemo(() => mangueraGeom(curvaGas, params), [curvaGas, params]);
+  const gMangueraCocina = useMemo(() => mangueraGeom(recorridoCocina(), params), [params]);
+  const datosBurbujas = useMemo(() => burbujas(params, regimen), [params, regimen]);
+
+  useLayoutEffect(
+    () => () =>
+      [gZanja, gCama, gManga, gLodo, gCampana, gParche, gManguera, gMangueraCocina, gInvernadero]
+        .filter(Boolean)
+        .forEach((g) => g.dispose()),
+    [gZanja, gCama, gManga, gLodo, gCampana, gParche, gManguera, gMangueraCocina, gInvernadero],
+  );
+
+  return (
+    <group>
+      {/* ── la zanja: cavada a pala, con su cama de arena para que un palo no
+             le abra un hueco al polietileno ── */}
+      <mesh geometry={gZanja} material={matTierra} receiveShadow={perfil.sombras} />
+      <mesh geometry={gCama} material={matCama} />
+
+      {/* ── el lodo y la campana: el corte real. El lodo llena ~3/4; el gas se
+             junta en el cuarto de arriba. Sin aire: esto es anaerobio ── */}
+      <mesh geometry={gLodo} material={matLodo} />
+      <mesh geometry={gCampana} material={matGas} />
+      <Burbujas datos={datosBurbujas} reducedMotion={reducedMotion} />
+
+      {/* ── la manga, su parche (esto se pincha y se remienda) y el canto por
+             donde pasó el serrucho ── */}
+      <mesh geometry={gManga} material={matManga} castShadow={perfil.sombras} />
+      <mesh geometry={gParche} material={matParche} />
+      {gCantos.map(({ geo, y, key }) => (
+        <mesh key={key} geometry={geo} material={matParche} position={[0, y, 0]} />
+      ))}
+
+      {/* ── los amarres de neumático: así se sella de verdad. El remate se ve ── */}
+      {gAmarres.map((a, i) => (
+        <mesh key={i} geometry={a.geo} material={matAmarre} position={a.pos} rotation={a.rot} />
+      ))}
+
+      {/* ── LA ENTRADA: se carga por gravedad, todos los días. Su boca muere
+             BAJO el nivel del lodo: ese es el sello que no deja salir el gas ── */}
+      <mesh
+        material={matTubo}
+        position={[ENTRADA.x - 0.25, (ENTRADA.topeY + ENTRADA.bocaY) / 2, -0.1]}
+        rotation={[0, 0, ENTRADA.inclina]}
+      >
+        <cylinderGeometry args={[ENTRADA.radio, ENTRADA.radio, ENTRADA.topeY - ENTRADA.bocaY + 0.5, 8, 1, true]} />
+      </mesh>
+      {/* el balde de la carga diaria: el trabajo que esto cuesta, puesto ahí */}
+      <mesh material={matTubo} position={[ENTRADA.x - 0.72, 0.14, 0.42]}>
+        <cylinderGeometry args={[0.15, 0.12, 0.28, 8]} />
+      </mesh>
+
+      {/* ── LA SALIDA: su labio manda el nivel del lodo (vasos comunicantes).
+             Por aquí rebosa el biol cada vez que se carga por el otro lado ── */}
+      <mesh
+        material={matTubo}
+        position={[SALIDA.x + 0.22, (SALIDA.labioY + SALIDA.bocaY) / 2, -0.1]}
+        rotation={[0, 0, -SALIDA.inclina]}
+      >
+        <cylinderGeometry args={[SALIDA.radio, SALIDA.radio, SALIDA.labioY - SALIDA.bocaY + 0.75, 8, 1, true]} />
+      </mesh>
+      {/* el biol asomando en el labio: el abono líquido saliendo hacia el cultivo */}
+      <mesh material={matBiol} position={[SALIDA.x + 0.5, SALIDA.labioY - 0.02, 0.05]}>
+        <cylinderGeometry args={[SALIDA.radio * 0.8, SALIDA.radio * 0.8, 0.04, 8]} />
+      </mesh>
+
+      {/* ── EL GAS: de la campana al frasco, pasando por la trampa de agua
+             (el punto bajo donde se junta el condensado y se purga) ── */}
+      <mesh material={matTubo} position={[TOMA_GAS.x, TOMA_GAS.y + 0.03, -0.02]}>
+        <cylinderGeometry args={[TOMA_GAS.radio, TOMA_GAS.radio, 0.1, 6]} />
+      </mesh>
+      <mesh geometry={gManguera} material={matManguera} />
+      <mesh material={matTubo} position={[trampa.x, trampa.y - 0.05, trampa.z]}>
+        <cylinderGeometry args={[0.045, 0.045, 0.14, 6]} />
+      </mesh>
+      <SelloDeAgua matVidrio={matVidrio} matAgua={matBiol} reducedMotion={reducedMotion} />
+      <mesh geometry={gMangueraCocina} material={matManguera} />
+
+      {/* ── LA COCINA: ventilada, nunca en cuarto cerrado. La hornilla, la olla
+             y la llama azul: la mierda de ayer cocinando el almuerzo de hoy ── */}
+      <group position={COCINA.pos}>
+        <mesh material={matMadera} position={[0, COCINA.alto / 2, 0]}>
+          <boxGeometry args={[0.72, COCINA.alto, 0.6]} />
+        </mesh>
+        <mesh material={matTubo} position={[0, COCINA.alto + 0.02, 0]}>
+          <cylinderGeometry args={[0.16, 0.16, 0.04, 10]} />
+        </mesh>
+        {/* la olla, encima de la llama */}
+        <mesh material={matTubo} position={[0, COCINA.alto + 0.32, 0]}>
+          <cylinderGeometry args={[0.22, 0.19, 0.24, 12, 1, true]} />
+        </mesh>
+      </group>
+      <Llama reducedMotion={reducedMotion} perfil={perfil} />
+
+      {/* ── EL INVERNADERO: solo en tierra fría. La respuesta del campo al
+             páramo — ganarle unos grados a las bacterias. En caliente estorba ── */}
+      {gInvernadero && <mesh geometry={gInvernadero} material={matPlastico} />}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/estiercol/CicloCerrado.jsx
+++ b/src/visual/mundo3d/estiercol/CicloCerrado.jsx
@@ -1,0 +1,298 @@
+/*
+ * CicloCerrado — EL CÍRCULO, dibujado literal: animal → estiércol →
+ * biodigestor/compostera → gas + abono → suelo → comida → animal.
+ *
+ * Es la tesis del módulo y por eso no se insinúa con una flecha: se camina. Un
+ * sendero circular hecho a mano, con las estaciones encima y la materia
+ * corriendo por él como pulsos de color. Uno sigue un pulso con el ojo y da la
+ * vuelta entera — ahí entendió que el estiércol no es basura, es el principio.
+ *
+ * ── LOS DOS CARRILES ───────────────────────────────────────────────────────
+ * El anillo se BIFURCA en la rejilla y esa bifurcación es la lección más
+ * rentable del corpus: "el orín escurre solo hacia un lado y el sólido queda
+ * arriba para recogerlo seco; mezclados se pudren juntos y ahí nace el olor".
+ *
+ *   · carril de ADENTRO → el LÍQUIDO. Va por dentro y más bajo porque escurre
+ *     SOLO, por gravedad. Termina en el biodigestor y sigue como biol.
+ *   · carril de AFUERA  → el SÓLIDO. Va por fuera porque hay que CARGARLO
+ *     (carretilla, pala, brazo). Termina en la compostera y sigue como compost.
+ *
+ * Los dos se vuelven a juntar en el suelo. Separar en el origen, reunir en el
+ * suelo: eso es todo.
+ *
+ * ── DÓNDE SE ROMPE ─────────────────────────────────────────────────────────
+ * El anillo se cierra aquí, pero al lado de la compostera hay un montón mal
+ * llevado del que la materia SE SALE hacia el cielo (ver `Biocompostera.jsx`).
+ * El contraste es a propósito: el círculo cerrado es una decisión de manejo,
+ * no un regalo de la naturaleza. Se cierra si uno lo cierra.
+ *
+ * Componente r3f. Los pulsos van INSTANCIADOS (un draw-call para el ciclo
+ * entero) y con `reducedMotion` quedan quietos y repartidos: el círculo se
+ * sigue leyendo sin que nada se mueva.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { crearMaterialMadre } from '../paleta/index.js';
+import { puntosSilueta, SEGMENTOS_SILUETA } from '../artesaniaAndina.js';
+import {
+  PALETA_ESTIERCOL,
+  TRAMOS,
+  ESTACIONES,
+  posEstacion,
+  geometriaTramo,
+  pulsosDelCiclo,
+  eraGeom,
+  torcerConLaMano,
+} from './estiercol.geom.js';
+
+/* Borradores de cálculo, a nivel de módulo: se reescriben una vez por pulso por
+   frame y jamás sobreviven a la llamada. Van aquí y no en un `useMemo` porque
+   son MUTABLES por definición — un objeto de render memoizado que se muta es
+   justo lo que el compilador de React (con razón) prohíbe. Cero asignaciones
+   por frame, que es lo que pide un InstancedMesh. */
+const _m = new THREE.Matrix4();
+const _q = new THREE.Quaternion();
+const _v = new THREE.Vector3();
+const _s = new THREE.Vector3();
+
+/* ── LOS PULSOS: la materia corriendo. Cada uno lleva el color de su tramo, y
+      esos colores contados en orden son la frase completa: pardo (estiércol) →
+      oscuro (purín) → ámbar (biol) / negro (compost) → verde (comida). ── */
+function Pulsos({ datos, reducedMotion }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.SphereGeometry(1, 5, 4), []);
+  const mat = useMemo(() => new THREE.MeshBasicMaterial({ toneMapped: false }), []);
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+
+  const colocar = (p, t) => {
+    p.curva.getPointAt(t, _v);
+    /* el pulso rueda SOBRE el sendero, no dentro de él */
+    _v.setY(_v.y + 0.06);
+    _s.setScalar(p.escala);
+    _m.compose(_v, _q, _s);
+    return _m;
+  };
+
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    datos.forEach((p, i) => {
+      mesh.setMatrixAt(i, colocar(p, p.fase % 1));
+      mesh.setColorAt(i, p.color);
+    });
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [datos]);
+
+  useFrame((st) => {
+    const mesh = ref.current;
+    if (!mesh || reducedMotion) return;
+    const t0 = st.clock.elapsedTime;
+    for (let i = 0; i < datos.length; i += 1) {
+      const p = datos[i];
+      mesh.setMatrixAt(i, colocar(p, (p.fase + t0 * p.vel) % 1));
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  });
+
+  if (!datos.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, datos.length]} frustumCulled={false} />;
+}
+
+/* ── EL CORRAL: donde nace el problema. Un cerdo low-poly sobre su CAMA
+      PROFUNDA — el colchón de material seco que absorbe el estiércol en el
+      sitio en vez de lavarlo con manguera. La cama es lo que enseña; el cerdo
+      es quien lo hace entendible. ── */
+function Corral({ materiales, perfil }) {
+  const pos = useMemo(() => posEstacion('corral'), []);
+  return (
+    <group position={pos}>
+      {/* LA CAMA PROFUNDA: aserrín/cascarilla. Mientras esté seca y suelta,
+          controla el olor. Es más barata que cualquier desinfectante */}
+      <mesh material={materiales.carbono} position={[0, 0.09, 0]} receiveShadow={perfil.sombras}>
+        <boxGeometry args={[2.3, 0.18, 1.7]} />
+      </mesh>
+      {/* los horcones del corral, torcidos: son palos de la finca */}
+      {[-1.1, 1.1].map((x) =>
+        [-0.8, 0.8].map((z) => (
+          <mesh key={`${x}${z}`} material={materiales.madera} position={[x, 0.42, z]}>
+            <cylinderGeometry args={[0.045, 0.055, 0.84, 5]} />
+          </mesh>
+        )),
+      )}
+      {/* el cerdo: el que produce. Sin él, esto es una obra civil sin sentido */}
+      <group position={[0.1, 0.42, 0.1]} rotation={[0, 0.5, 0]}>
+        <mesh material={materiales.cerdo}>
+          <capsuleGeometry args={[0.19, 0.4, 3, 7]} />
+        </mesh>
+        <mesh material={materiales.cerdo} position={[0, 0.02, 0.32]}>
+          <sphereGeometry args={[0.14, 7, 6]} />
+        </mesh>
+        {/* las cuatro patas, cortas */}
+        {[[-0.1, -0.16], [0.1, -0.16], [-0.1, 0.18], [0.1, 0.18]].map(([x, z], i) => (
+          <mesh key={i} material={materiales.cerdo} position={[x, -0.23, z]}>
+            <cylinderGeometry args={[0.032, 0.028, 0.2, 4]} />
+          </mesh>
+        ))}
+      </group>
+    </group>
+  );
+}
+
+/* ── LA REJILLA: la mejora más rentable de la finca, y la más aburrida de
+      dibujar. Una pendiente y un canal. Aquí el ciclo se parte en dos: el
+      líquido se va solo por abajo, el sólido queda arriba para recogerlo seco. ── */
+function Rejilla({ materiales }) {
+  const pos = useMemo(() => posEstacion('separacion'), []);
+  return (
+    <group position={pos}>
+      {/* el piso EN PENDIENTE: sin pendiente, no hay separación que valga */}
+      <mesh material={materiales.concreto} position={[0, 0.06, 0]} rotation={[0, 0, -0.09]}>
+        <boxGeometry args={[1.5, 0.1, 1.2]} />
+      </mesh>
+      {/* el canal, en el punto más bajo */}
+      <mesh material={materiales.purin} position={[-0.62, 0.03, 0]}>
+        <boxGeometry args={[0.22, 0.06, 1.2]} />
+      </mesh>
+      {/* las barras de la rejilla: el sólido no pasa, el líquido sí */}
+      {[-0.5, -0.3, -0.1, 0.1, 0.3, 0.5].map((z) => (
+        <mesh key={z} material={materiales.lamina} position={[-0.62, 0.09, z]}>
+          <boxGeometry args={[0.24, 0.02, 0.035]} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+/* ── EL TANQUE DE BIOL: el biol no se aplica recién sale — reposa y se aplica
+      DILUIDO. El tanque toma la SILUETA DE VASIJA de `artesania/`: base ancha
+      y asentada, hombro marcado. No es adorno: es la forma que esta casa le da
+      a un recipiente que guarda algo con cuidado. ── */
+function TanqueBiol({ materiales }) {
+  const pos = useMemo(() => posEstacion('tanque'), []);
+  const geo = useMemo(() => {
+    const pts = puntosSilueta('vasija', { alto: 0.92 }).map(([r, y]) => new THREE.Vector2(Math.max(r, 0.0001), y));
+    const g = new THREE.LatheGeometry(pts, SEGMENTOS_SILUETA);
+    return torcerConLaMano(g, { amplitud: 0.012, seed: 33 });
+  }, []);
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  return (
+    <group position={pos}>
+      <mesh geometry={geo} material={materiales.barro} />
+      {/* el biol adentro, en reposo */}
+      <mesh material={materiales.biol} position={[0, 0.62, 0]}>
+        <cylinderGeometry args={[0.26, 0.26, 0.02, 10]} />
+      </mesh>
+    </group>
+  );
+}
+
+/* ── EL SUELO: donde llegan los dos carriles y donde el ciclo cobra. Surcos con
+      matas: lo único que de verdad importa de todo esto. ── */
+function Huerta({ materiales, perfil }) {
+  const pos = useMemo(() => posEstacion('huerta'), []);
+  return (
+    <group position={pos}>
+      {[-0.5, 0, 0.5].map((z) => (
+        <mesh key={z} material={materiales.tierra} position={[0, 0.06, z]} receiveShadow={perfil.sombras}>
+          <boxGeometry args={[1.9, 0.12, 0.34]} />
+        </mesh>
+      ))}
+      {/* las matas: abonadas con biol y compost, no con bulto comprado */}
+      {[-0.7, -0.2, 0.3, 0.8].map((x) =>
+        [-0.5, 0, 0.5].map((z) => (
+          <group key={`${x}${z}`} position={[x, 0.12, z]}>
+            <mesh material={materiales.tallo} position={[0, 0.13, 0]}>
+              <cylinderGeometry args={[0.012, 0.018, 0.26, 4]} />
+            </mesh>
+            <mesh material={materiales.follaje} position={[0, 0.28, 0]}>
+              <icosahedronGeometry args={[0.11, 0]} />
+            </mesh>
+          </group>
+        )),
+      )}
+    </group>
+  );
+}
+
+/**
+ * El ciclo completo: el anillo, los pulsos y las estaciones menores (las dos
+ * grandes —biodigestor y compostera— se montan aparte, cada una en su archivo).
+ * @param {object} props
+ * @param {object} props.perfil  perfilDeTier(tier)
+ * @param {object} props.params  paramsDeTier(tier)
+ * @param {boolean} [props.reducedMotion]
+ */
+export default function CicloCerrado({ perfil, params, reducedMotion = false }) {
+  const materiales = useMemo(
+    () => ({
+      era: crearMaterialMadre('tierra', perfil, { color: PALETA_ESTIERCOL.pasto }),
+      sendero: crearMaterialMadre('tierra', perfil, { color: PALETA_ESTIERCOL.sendero }),
+      carbono: crearMaterialMadre('tierra', perfil, { color: PALETA_ESTIERCOL.carbono }),
+      madera: crearMaterialMadre('madera', perfil),
+      cerdo: crearMaterialMadre('corteza', perfil, { color: PALETA_ESTIERCOL.compostJoven }),
+      concreto: crearMaterialMadre('cal', perfil),
+      purin: crearMaterialMadre('agua', perfil, { color: PALETA_ESTIERCOL.purin }),
+      lamina: crearMaterialMadre('lamina', perfil),
+      barro: crearMaterialMadre('roca', perfil, { color: PALETA_ESTIERCOL.compostJoven }),
+      biol: crearMaterialMadre('agua', perfil, { color: PALETA_ESTIERCOL.biol }),
+      tierra: crearMaterialMadre('tierra', perfil),
+      tallo: crearMaterialMadre('madera', perfil),
+      follaje: crearMaterialMadre('follaje', perfil),
+    }),
+    [perfil],
+  );
+  useLayoutEffect(() => () => Object.values(materiales).forEach((m) => m.dispose()), [materiales]);
+
+  const gEra = useMemo(() => eraGeom(), []);
+  const gTramos = useMemo(() => TRAMOS.map((t) => geometriaTramo(t, params)), [params]);
+  useLayoutEffect(
+    () => () => {
+      gEra.dispose();
+      gTramos.forEach((g) => g.dispose());
+    },
+    [gEra, gTramos],
+  );
+
+  const pulsos = useMemo(() => pulsosDelCiclo(params), [params]);
+
+  /* un material por tramo: el color del sendero delata QUÉ va por él (el
+     carril del líquido se ve más oscuro y húmedo que el del sólido) */
+  const matsTramo = useMemo(
+    () =>
+      TRAMOS.map((t) =>
+        crearMaterialMadre('tierra', perfil, {
+          color: t.color,
+          transparent: true,
+          opacity: 0.5, // pisado en la tierra, no pintado encima
+        }),
+      ),
+    [perfil],
+  );
+  useLayoutEffect(() => () => matsTramo.forEach((m) => m.dispose()), [matsTramo]);
+
+  return (
+    <group>
+      {/* la era: el pedazo de finca donde todo esto pasa */}
+      <mesh geometry={gEra} material={materiales.era} receiveShadow={perfil.sombras} position={[0, -0.02, 0]} />
+
+      {/* EL ANILLO: los dos carriles, pisados en la tierra. Se parten en la
+          rejilla y se vuelven a juntar en el suelo */}
+      {gTramos.map((g, i) => (
+        <mesh key={TRAMOS[i].id} geometry={g} material={matsTramo[i]} />
+      ))}
+
+      {/* la materia corriendo: siga un pulso con el ojo y dio la vuelta */}
+      <Pulsos datos={pulsos} reducedMotion={reducedMotion} />
+
+      <Corral materiales={materiales} perfil={perfil} />
+      <Rejilla materiales={materiales} />
+      <TanqueBiol materiales={materiales} />
+      <Huerta materiales={materiales} perfil={perfil} />
+    </group>
+  );
+}
+
+/** Las estaciones, para que la escena arme sus hotspots sin re-importar. */
+export { ESTACIONES };

--- a/src/visual/mundo3d/estiercol/EscenaEstiercol.jsx
+++ b/src/visual/mundo3d/estiercol/EscenaEstiercol.jsx
@@ -1,0 +1,201 @@
+/*
+ * EscenaEstiercol — EL MUNDO "la mierda volviéndose gas y abono".
+ *
+ * El estiércol es el problema más real y menos glamoroso de la finca: apesta,
+ * cría mosca y pelea con el vecino. Esta escena no lo esconde ni lo maquilla —
+ * lo abre en canal. Dos piezas en CORTE, una al lado de la otra, y el círculo
+ * que las une:
+ *
+ *   · EL BIODIGESTOR (izquierda): la manga de polietileno en su zanja, partida
+ *     a lo largo. Se ve el lodo llenando tres cuartos, la campana de gas en el
+ *     cuarto de arriba, las burbujas de metano subiendo sin una gota de aire, y
+ *     el biogás saliendo por la manguera hasta la hornilla, donde arde AZUL.
+ *     Por el otro extremo sale el biol hacia el cultivo.
+ *
+ *   · LA BIOCOMPOSTERA (derecha): tres cajones en corte. Las capas (estiércol
+ *     y material seco, y el seco más grueso), el corazón caliente que mata
+ *     patógenos y semilla de maleza, el volteo, y la lombriz al final —solo al
+ *     final—.
+ *
+ *   · EL ANILLO: animal → estiércol → biodigestor/compostera → gas + abono →
+ *     suelo → comida → animal. Se camina con el ojo siguiendo un pulso.
+ *
+ *   · Y AFUERA, EL MONTÓN MAL LLEVADO: la única estación que no está en el
+ *     círculo. Suelta amoníaco verde que se arrastra en vez de subir. Eso es
+ *     nitrógeno yéndose al aire — plata. Está ahí para que esto no sea un
+ *     folleto.
+ *
+ * ── LA CÁMARA MIRA DESDE +Z Y ESO NO ES CAPRICHO ───────────────────────────
+ * Todas las piezas nacen cortadas en el plano z=0 conservando la mitad de
+ * atrás (ver la convención en `biodigestor.geom.js`). Por eso los dos héroes
+ * NO se rotan tangentes al anillo: quedan mirando a la cámara, que es de donde
+ * el corte se lee. El anillo pasa por ellos; ellos no giran con él.
+ *
+ * ── TIER Y CALMA ───────────────────────────────────────────────────────────
+ * Todo se degrada por `paramsDeTier` (menos burbujas, menos pulsos, sin
+ * moscas, sin invernadero) sin perder NUNCA la lección. Con `reducedMotion`
+ * monta quieto: las burbujas quedan repartidas por la columna, el humo
+ * congelado en su jirón, la llama fija. Todo sigue ahí — la lección no depende
+ * del movimiento.
+ *
+ * Componente r3f standalone: trae su propio `<Canvas>` y su `<LuzMadre>` (GUIA
+ * §3). Importa three → montar SIEMPRE perezoso, dentro de un host que dé alto.
+ */
+import { Suspense, useMemo, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr, Html } from '@react-three/drei';
+import { LuzMadre, CIELOS, mezclarCielo } from '../paleta/index.js';
+import { perfilDeTier } from '../deviceTier.js';
+import { paramsDeTier, ESTACIONES, posEstacion } from './estiercol.geom.js';
+import { CLIMAS } from './biodigestor.geom.js';
+import Biodigestor from './Biodigestor.jsx';
+import Biocompostera, { MontonMalLlevado } from './Biocompostera.jsx';
+import CicloCerrado from './CicloCerrado.jsx';
+import './estiercol.css';
+
+/* ── UN HOTSPOT: el punto que se toca y la ficha que se abre. El texto sale de
+      ESTACIONES (el corpus hablando, en usted). ── */
+function Hotspot({ estacion, abierta, onToggle }) {
+  const pos = useMemo(() => posEstacion(estacion.id), [estacion.id]);
+  const malo = estacion.id === 'monton';
+  const p = [pos.x, (estacion.pos ? pos.y : 0) + (estacion.alturaHot ?? 1.15), pos.z];
+
+  if (abierta) {
+    return (
+      <Html position={p} center={false} zIndexRange={[20, 0]}>
+        <div className="est-ficha">
+          <button className="est-ficha__cerrar" onClick={onToggle} aria-label="Cerrar">
+            ×
+          </button>
+          <p className="est-ficha__tit">{estacion.etiqueta}</p>
+          <p className="est-ficha__txt">{estacion.nota}</p>
+        </div>
+      </Html>
+    );
+  }
+  return (
+    <Html position={p} center={false} zIndexRange={[10, 0]}>
+      <div className={`est-hot ${malo ? 'est-hot--malo' : ''}`}>
+        <button className="est-hot__btn" onClick={onToggle}>
+          <span className="est-hot__pt" />
+          {estacion.etiqueta}
+        </button>
+      </div>
+    </Html>
+  );
+}
+
+/* ── EL MUNDO: las piezas puestas en su sitio. Los dos héroes van a sus
+      estaciones SIN rotar (el corte mira a la cámara — ver cabecera). ── */
+function Mundo({ perfil, params, clima, reducedMotion }) {
+  const posBio = useMemo(() => posEstacion('biodigestor'), []);
+  const posComp = useMemo(() => posEstacion('compostera'), []);
+  const posMonton = useMemo(() => posEstacion('monton'), []);
+
+  return (
+    <>
+      <CicloCerrado perfil={perfil} params={params} reducedMotion={reducedMotion} />
+
+      <group position={posBio}>
+        <Biodigestor perfil={perfil} params={params} clima={clima} reducedMotion={reducedMotion} />
+      </group>
+
+      <group position={posComp}>
+        <Biocompostera perfil={perfil} params={params} reducedMotion={reducedMotion} />
+      </group>
+
+      {/* fuera del anillo, a propósito: de aquí no vuelve nada al suelo */}
+      {params.montonMalo && (
+        <group position={posMonton}>
+          <MontonMalLlevado perfil={perfil} params={params} reducedMotion={reducedMotion} />
+        </group>
+      )}
+    </>
+  );
+}
+
+/**
+ * La escena completa.
+ * @param {object} props
+ * @param {'alto'|'medio'|'bajo'} [props.tier]
+ * @param {boolean} [props.reducedMotion]
+ * @param {'calido'|'frio'} [props.climaInicial]  el régimen térmico (ver CLIMAS)
+ */
+export default function EscenaEstiercol({
+  tier = 'alto',
+  reducedMotion = false,
+  climaInicial = 'frio',
+}) {
+  const [lista, setLista] = useState(false);
+  const [abierta, setAbierta] = useState(null);
+  const [clima, setClima] = useState(climaInicial);
+
+  const perfil = useMemo(() => perfilDeTier(tier), [tier]);
+  const params = useMemo(() => paramsDeTier(tier), [tier]);
+
+  /* la familia de cielo: 'corral'. Es literalmente el patio de la finca — y la
+     ley 60%-hacia-la-madre la aplica `mezclarCielo`, nunca un hex a mano. */
+  const cielo = useMemo(() => mezclarCielo(CIELOS.corral), []);
+
+  const estaciones = useMemo(
+    () => ESTACIONES.filter((e) => e.id !== 'monton' || params.montonMalo),
+    [params.montonMalo],
+  );
+
+  return (
+    <>
+      <Canvas
+        className={`est-canvas ${lista ? 'est-canvas--lista' : ''}`}
+        dpr={perfil.dpr}
+        gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+        shadows={perfil.sombras}
+        camera={{ position: [0, 5.6, 15.5], fov: 44 }}
+        frameloop={reducedMotion ? 'demand' : 'always'}
+        onCreated={() => setLista(true)}
+      >
+        <color attach="background" args={[cielo.fondo]} />
+        {perfil.fog && <fog attach="fog" args={[cielo.niebla, 16, 42]} />}
+        <LuzMadre cielo={CIELOS.corral} perfil={perfil} />
+
+        <Suspense fallback={null}>
+          <Mundo perfil={perfil} params={params} clima={clima} reducedMotion={reducedMotion} />
+          {estaciones.map((e) => (
+            <Hotspot
+              key={e.id}
+              estacion={e}
+              abierta={abierta === e.id}
+              onToggle={() => setAbierta(abierta === e.id ? null : e.id)}
+            />
+          ))}
+        </Suspense>
+
+        <OrbitControls
+          target={[0, 1.1, 3.4]}
+          enablePan={false}
+          minDistance={7}
+          maxDistance={22}
+          maxPolarAngle={Math.PI / 2.15} /* no dejamos meter la cámara bajo tierra */
+          enableDamping={!reducedMotion}
+        />
+        <AdaptiveDpr pixelated />
+      </Canvas>
+
+      {/* ── TIERRA FRÍA / TIERRA CALIENTE: el mismo biodigestor, otro
+             rendimiento. En frío hay menos burbujas y más lentas, y aparece el
+             invernadero encima de la zanja. No es un filtro de color: es la
+             razón por la que en el páramo esto rinde menos ── */}
+      <div className="est-clima" role="group" aria-label="Clima del biodigestor">
+        {Object.values(CLIMAS).map((c) => (
+          <button
+            key={c.id}
+            className={`est-clima__btn ${clima === c.id ? 'est-clima__btn--on' : ''}`}
+            onClick={() => setClima(c.id)}
+            aria-pressed={clima === c.id}
+          >
+            {c.etiqueta}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/visual/mundo3d/estiercol/biodigestor.geom.js
+++ b/src/visual/mundo3d/estiercol/biodigestor.geom.js
@@ -1,0 +1,504 @@
+/*
+ * biodigestor.geom — LA MANGA POR DENTRO: la geometría del biodigestor tubular
+ * de polietileno ("tipo salchicha"), el modelo más común del campo colombiano,
+ * EN CORTE. Funciones puras (three-core, headless).
+ *
+ * ── POR QUÉ ESTE MODELO Y NO OTRO ──────────────────────────────────────────
+ * "El modelo más usado en Colombia —el tubular tipo salchicha de polietileno—
+ * nació pensado justo para el pequeño y mediano productor, porque es barato y
+ * se puede armar uno mismo." Es el más barato de todos los tipos que existen.
+ * Dibujar aquí un tanque de concreto de granja grande sería mentir sobre a
+ * quién le hablamos.
+ *
+ * ── EL CORTE ───────────────────────────────────────────────────────────────
+ * Todo se construye como un DIBUJO TÉCNICO EN 3D: cada pieza es una sección
+ * transversal extruida a lo largo del eje X, y TODO está cortado en el plano
+ * z=0 — justo el plano donde está la cámara. Se conserva la mitad de atrás
+ * (z<0) y se bota la de adelante. Resultado: uno mira la manga como si le
+ * hubieran pasado un serrucho a lo largo, y ve el lodo, el gas y las burbujas
+ * de verdad, no una insinuación.
+ *
+ * ── LA FÍSICA QUE HAY QUE RESPETAR (y que casi nadie dibuja bien) ──────────
+ *
+ *   1. LA MANGA NO ESTÁ LLENA. El lodo ocupa ~3/4 y el gas se acumula en el
+ *      cuarto de arriba: esa es LA CAMPANA. Por eso `NIVEL` está calculado
+ *      —no puesto a ojo— para que el área de lodo dé ~75% del círculo.
+ *
+ *   2. LA MANGA SE SELLA CON AGUA, NO CON TAPAS. Las bocas de los dos tubos
+ *      quedan POR DEBAJO del nivel del lodo: el propio líquido es el tapón que
+ *      impide que el gas se salga por ahí. Por eso `entrada` y `salida` mueren
+ *      bajo el nivel. Si un dibujo muestra los tubos al aire, el biodigestor
+ *      de ese dibujo no funcionaría.
+ *
+ *   3. EL LABIO DE LA SALIDA MANDA EL NIVEL. Vasos comunicantes: el lodo se
+ *      queda exactamente a la altura del labio por donde rebosa el biol. Por
+ *      eso `SALIDA.labioY === NIVEL`. No es un detalle: es lo que hace que
+ *      cargar por un lado saque biol por el otro, todos los días.
+ *
+ *   4. SIN AIRE. La fermentación es ANAEROBIA. Aquí no hay ventilación, no hay
+ *      rejilla, no hay respiradero. Solo la manguera del gas — y su sello.
+ *
+ * ── SEGURIDAD (el biogás es inflamable: no se dibuja bonito, se dibuja bien) ─
+ * La `VALVULA` de este módulo es el sello de agua real del campo: la manguera
+ * muere sumergida en un frasco con agua. Si la presión sube de más, el gas
+ * burbujea por el agua y se escapa — la manga no revienta. Es la pieza más
+ * barata y más importante de toda la instalación, y por eso está modelada.
+ * "Nunca revise fugas con fósforo o encendedor, use agua con jabón."
+ *
+ * ── HONESTIDAD ─────────────────────────────────────────────────────────────
+ * La manga lleva su PARCHE (esto se pincha y se remienda), la zanja lleva su
+ * barro y su cama de arena (si no, un objeto filoso se la lleva), y los
+ * amarres de neumático están a la vista. Esto no es un folleto: es una obra
+ * que costó plata, pala y trabajo.
+ */
+import * as THREE from 'three';
+import {
+  PALETA_ESTIERCOL,
+  torcerConLaMano,
+  recortarEnCorte,
+  amarreGeom,
+  rng,
+} from './estiercol.geom.js';
+
+/* ------------------------------------------------------------------ */
+/* LAS MEDIDAS — la manga y su zanja.                                   */
+/* ------------------------------------------------------------------ */
+
+/*
+ * El suelo de la finca es y=0. La manga va SEMIENTERRADA: la panza en la
+ * zanja y la campana de gas asomando — así se ve en el campo, y así se
+ * entiende de una que hay una parte llena y una parte con gas.
+ */
+export const MANGA = {
+  radio: 0.82,
+  largo: 4.4,
+  centroY: -0.3, // el eje: bajo tierra (la panza en la zanja, la campana afuera)
+  espesor: 0.035, // el canto del polietileno que se ve en el corte
+};
+
+/*
+ * EL NIVEL DEL LODO, calculado y no inventado. Para un círculo, la fracción de
+ * área bajo la altura h (con t = h/radio) es:
+ *
+ *     f(t) = 0.5 + (asin(t) + t·√(1-t²)) / π
+ *
+ * Con t = 0.4 → f ≈ 0.748. O sea: el lodo ocupa ~3/4 y el gas ~1/4, que es la
+ * proporción de trabajo de una manga tubular. Dejarlo a ojo es lo que produce
+ * los dibujos donde el biodigestor está lleno hasta el tope (y entonces no
+ * tendría dónde acumular el gas).
+ */
+export const T_NIVEL = 0.4;
+export const NIVEL = MANGA.centroY + T_NIVEL * MANGA.radio; // ≈ +0.03: casi a ras de suelo
+
+/** La fracción de área ocupada por el lodo (la fórmula de arriba, exportada
+ *  para que un test la verifique en vez de creerle al comentario). */
+export function fraccionLodo(t = T_NIVEL) {
+  return 0.5 + (Math.asin(t) + t * Math.sqrt(1 - t * t)) / Math.PI;
+}
+
+/* La zanja: cavada A MANO, más ancha arriba que abajo (así se sostiene la
+   pared de tierra y así queda cuando se cava con pala, nunca a escuadra). */
+export const ZANJA = {
+  fondoY: -1.14, // la manga se apoya aquí (centroY - radio = -1.12: descansa)
+  medioAnchoArriba: 1.26,
+  medioAnchoFondo: 0.98,
+  tierraHasta: 2.9, // hasta dónde se ve el bloque de tierra en el corte
+  tierraFondo: -1.55,
+};
+
+/* Los dos tubos. Fíjese en las `bocaY`: las DOS mueren bajo NIVEL. Ese es el
+   sello de agua que hace hermética la manga (ver cabecera §2). */
+export const ENTRADA = {
+  x: -MANGA.largo / 2 - 0.16,
+  radio: 0.13,
+  bocaY: -0.46, // BAJO el nivel: sellada por el propio lodo
+  topeY: 0.86, // arriba, afuera: aquí se vacía el balde todos los días
+  inclina: 0.42, // rad: se carga por gravedad, no a presión
+};
+
+export const SALIDA = {
+  x: MANGA.largo / 2 + 0.16,
+  radio: 0.13,
+  bocaY: -0.5, // BAJO el nivel: sellada
+  labioY: NIVEL, // vasos comunicantes: el labio MANDA el nivel del lodo
+  inclina: 0.34,
+};
+
+/* La toma de gas: un niple atravesando el lomo de la manga, arriba del todo,
+   donde se junta el biogás. Va corrido hacia un extremo, no al medio, porque
+   la manguera tiene que salir de la zanja sin cruzarse con nadie. */
+export const TOMA_GAS = { x: -1.0, y: MANGA.centroY + MANGA.radio, radio: 0.055 };
+
+/* El sello de agua: el frasco donde muere la manguera. La pieza más barata y
+   más importante (ver cabecera §Seguridad). `sumergido` es cuánto entra la
+   manguera al agua: eso —y nada más— es lo que fija la presión máxima. */
+export const VALVULA = {
+  pos: [-2.75, 0, 2.0],
+  radio: 0.17,
+  alto: 0.44,
+  aguaY: 0.3,
+  sumergido: 0.12,
+};
+
+/* La cocina, en coordenadas LOCALES del biodigestor (el grupo ya está puesto
+   en su sitio). Va PEGADA a la manga a propósito: el tramo de manguera tiene
+   que ser corto y revisable. Y al aire libre — el punto de consumo del biogás
+   va ventilado, nunca en un cuarto cerrado sin salida de aire. */
+export const COCINA = { pos: [-2.15, 0, 3.25], alto: 0.82 };
+
+/* ------------------------------------------------------------------ */
+/* EL RÉGIMEN TÉRMICO — "en tierra fría rinde menos".                   */
+/* ------------------------------------------------------------------ */
+
+/*
+ * "Las bacterias trabajan más rápido con más calor: en clima frío las mismas
+ * bacterias trabajan más lento y el estiércol necesita quedarse MUCHOS más
+ * días adentro para producir la misma cantidad de gas."
+ *
+ * OJO CON LOS NÚMEROS: el corpus se niega a dar cifras exactas de retención
+ * (dependen del diseño y del sitio), así que aquí NO se inventa ninguna. Lo
+ * que se modela es la RELACIÓN, que sí es firme y sí es lo que hay que
+ * entender: en frío hay menos burbujas, más lentas, y el mismo estiércol se
+ * queda mucho más tiempo adentro. La escena lo dice con burbujas, no con un
+ * número falso.
+ *
+ * Y la respuesta del campo al frío también se modela: `invernadero` — tapar la
+ * zanja con plástico para ganarle unos grados. "En tierra fría conviene poner
+ * el biodigestor donde le dé sol directo, o incluso taparlo con un invernadero
+ * plástico sencillo."
+ */
+export const CLIMAS = {
+  calido: {
+    id: 'calido',
+    etiqueta: 'tierra caliente',
+    burbujas: 1, // ritmo pleno
+    velocidad: 1,
+    invernadero: false, // aquí estorba: recalienta el plástico
+    nota: 'En caliente las bacterias trabajan rápido: el gas sale parejo y el estiércol se queda pocos días adentro. Aquí conviene sombra parcial, para que el sol no le queme la manga.',
+  },
+  frio: {
+    id: 'frio',
+    etiqueta: 'tierra fría',
+    burbujas: 0.38, // MENOS gas: se ve
+    velocidad: 0.55, // y más lento: se ve
+    invernadero: true, // la respuesta: ganarle grados al páramo
+    nota: 'En tierra fría rinde menos: las mismas bacterias trabajan lentas y el estiércol tiene que quedarse muchos más días adentro para dar el mismo gas. Por eso acá se le pone el invernadero encima y se le busca el sol.',
+  },
+};
+
+/* ------------------------------------------------------------------ */
+/* LAS SECCIONES — el corte, en el plano z=0.                           */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Convención (léala una vez y todo lo de abajo se entiende):
+ *
+ *   Una `THREE.Shape` se dibuja en su plano (u, v) y se extruye hacia +w.
+ *   `aEjeX()` la acuesta: w → +X (el largo de la manga), u → −Z (el fondo,
+ *   lejos de la cámara) y v → +Y (la altura, sin tocar).
+ *
+ *   Por eso TODA sección se dibuja con u ∈ [0, algo] (solo la mitad de atrás)
+ *   y su cara u=0 cae exacta en z=0: ESA es la cara del corte, la que mira la
+ *   cámara. No hay que recortar nada después: la pieza nace cortada.
+ */
+function aEjeX(geo, largo) {
+  geo.rotateY(Math.PI / 2); // w → +X, u → −Z
+  geo.translate(-largo / 2, 0, 0); // centrada en el origen
+  return geo;
+}
+
+function extruir(shape, largo) {
+  const geo = new THREE.ExtrudeGeometry(shape, {
+    depth: largo,
+    bevelEnabled: false,
+    curveSegments: 14,
+  });
+  return aEjeX(geo, largo);
+}
+
+/**
+ * EL LODO en corte: el segmento circular bajo `NIVEL`, mitad de atrás. Su cara
+ * plana en z=0 es lo que uno ve: la masa fermentando, con su superficie quieta.
+ */
+export function lodoGeom({ largo = MANGA.largo } = {}) {
+  const r = MANGA.radio;
+  const cy = MANGA.centroY;
+  const theta = Math.asin((NIVEL - cy) / r); // donde la superficie corta el círculo
+  const s = new THREE.Shape();
+  s.moveTo(0, cy - r); // el fondo de la manga
+  s.absarc(0, cy, r, -Math.PI / 2, theta, false); // la panza, por atrás
+  s.lineTo(0, NIVEL); // la superficie del lodo: plana y quieta
+  s.closePath();
+  return extruir(s, largo);
+}
+
+/**
+ * LA CAMPANA DE GAS en corte: el casquete sobre `NIVEL`. Es el cuarto de arriba
+ * de la manga — el que la gente no dibuja y es justo donde vive el biogás.
+ */
+export function campanaGeom({ largo = MANGA.largo } = {}) {
+  const r = MANGA.radio;
+  const cy = MANGA.centroY;
+  const theta = Math.asin((NIVEL - cy) / r);
+  const s = new THREE.Shape();
+  s.moveTo(0, NIVEL);
+  s.lineTo(r * Math.cos(theta), NIVEL); // la superficie, desde el eje hacia atrás
+  s.absarc(0, cy, r, theta, Math.PI / 2, false); // el lomo de la manga
+  s.closePath();
+  return extruir(s, largo);
+}
+
+/**
+ * LA MANGA (la pared de polietileno): media caña, la mitad de atrás. Abierta
+ * hacia la cámara — hay que montarla con `side: DoubleSide` para ver la cara
+ * interior del plástico, que es media escena.
+ *
+ * `torcerConLaMano` le quita la perfección de fábrica: una manga cargada está
+ * pandeada, nunca es un tubo de catálogo.
+ */
+export function mangaGeom({ largo = MANGA.largo, seg = 20 } = {}) {
+  const geo = new THREE.CylinderGeometry(
+    MANGA.radio,
+    MANGA.radio,
+    largo,
+    seg,
+    3,
+    true, // sin tapas: los extremos se amarran, no se tapan
+    Math.PI / 2, // ── solo la mitad de atrás (z<0): el resto se lo llevó el corte
+    Math.PI,
+  );
+  geo.rotateZ(Math.PI / 2); // el eje del cilindro → +X
+  geo.translate(0, MANGA.centroY, 0);
+  torcerConLaMano(geo, { amplitud: 0.022, seed: 17 });
+  return recortarEnCorte(geo); // el pandeo no puede asomar delante del corte
+}
+
+/**
+ * EL CANTO del corte: las dos líneas donde el serrucho pasó por el plástico
+ * (el lomo y la panza, en z=0). Un dibujo técnico marca el material cortado
+ * con línea gruesa; aquí es geometría de verdad, con su espesor.
+ * @returns {{ geo: THREE.BufferGeometry, y: number }[]}
+ */
+export function cantosManga({ largo = MANGA.largo } = {}) {
+  return [MANGA.centroY + MANGA.radio, MANGA.centroY - MANGA.radio].map((y, i) => ({
+    geo: new THREE.BoxGeometry(largo, MANGA.espesor, MANGA.espesor * 1.6),
+    y,
+    key: i,
+  }));
+}
+
+/**
+ * LA ZANJA en corte: el bloque de tierra con el hueco cavado. El polígono
+ * rodea el vacío — por eso la tierra que se ve bajo la manga y a su lado es
+ * una sola pieza, como en la realidad.
+ *
+ * Las paredes salen inclinadas (más ancha arriba) porque así se sostiene la
+ * tierra y así queda una zanja cavada con pala. Una zanja a escuadra es una
+ * zanja de render.
+ */
+export function zanjaGeom({ largo = MANGA.largo + 1.5 } = {}) {
+  const z = ZANJA;
+  const s = new THREE.Shape();
+  s.moveTo(0, z.tierraFondo);
+  s.lineTo(z.tierraHasta, z.tierraFondo);
+  s.lineTo(z.tierraHasta, 0); // la superficie del potrero
+  s.lineTo(z.medioAnchoArriba, 0); // el borde de la zanja
+  s.lineTo(z.medioAnchoFondo, z.fondoY); // la pared, inclinada
+  s.lineTo(0, z.fondoY); // el fondo
+  s.closePath();
+  const geo = extruir(s, largo);
+  torcerConLaMano(geo, { amplitud: 0.028, seed: 23 });
+  return recortarEnCorte(geo); // la tierra no se sale por delante de la sección
+}
+
+/**
+ * LA CAMA de la zanja: arena o paja bajo la manga. No es decoración — es lo
+ * que impide que una piedra o un palo le abran un hueco al polietileno. Sin
+ * esto, la manga dura meses en vez de años.
+ */
+export function camaZanjaGeom({ largo = MANGA.largo + 0.4 } = {}) {
+  const s = new THREE.Shape();
+  s.moveTo(0, ZANJA.fondoY);
+  s.lineTo(ZANJA.medioAnchoFondo * 0.96, ZANJA.fondoY);
+  s.lineTo(ZANJA.medioAnchoFondo * 0.92, ZANJA.fondoY + 0.09);
+  s.lineTo(0, ZANJA.fondoY + 0.11);
+  s.closePath();
+  return extruir(s, largo);
+}
+
+/**
+ * EL INVERNADERO: el arco de plástico sobre la zanja para ganarle grados al
+ * frío. Cortado igual que todo (solo el cuarto de atrás y arriba del suelo).
+ */
+export function invernaderoGeom({ largo = MANGA.largo + 1.1, radio = 1.42, seg = 16 } = {}) {
+  const geo = new THREE.CylinderGeometry(
+    radio,
+    radio,
+    largo,
+    seg,
+    1,
+    true,
+    Math.PI / 2, // ── mitad de atrás…
+    Math.PI / 2, // ── …y solo lo que queda sobre el suelo: un cuarto de tubo
+  );
+  geo.rotateZ(Math.PI / 2);
+  torcerConLaMano(geo, { amplitud: 0.03, seed: 29 });
+  return recortarEnCorte(geo);
+}
+
+/**
+ * EL PARCHE: el remiendo de polietileno sobre un pinchazo, pegado en el lomo.
+ * Está aquí por honestidad — la manga se pincha, se parcha y sigue. Un
+ * biodigestor sin parche es un biodigestor que no ha trabajado.
+ */
+export function parcheGeom() {
+  const geo = new THREE.CylinderGeometry(
+    MANGA.radio + 0.012,
+    MANGA.radio + 0.012,
+    0.42,
+    8,
+    1,
+    true,
+    Math.PI * 1.06, // en el lomo de atrás, donde se ve desde la cámara
+    0.5,
+  );
+  geo.rotateZ(Math.PI / 2);
+  geo.translate(1.5, MANGA.centroY, 0);
+  return geo;
+}
+
+/**
+ * LOS AMARRES: las tiras de neumático con que se aprieta la manga contra cada
+ * tubo. Así se sella de verdad en el campo — no con bridas de ferretería. El
+ * remate se ve.
+ */
+export function amarresGeom() {
+  return [
+    { geo: amarreGeom(ENTRADA.radio + 0.05, 0.038, 5), pos: [-MANGA.largo / 2 + 0.05, MANGA.centroY, 0], rot: [0, Math.PI / 2, 0] },
+    { geo: amarreGeom(ENTRADA.radio + 0.05, 0.038, 6), pos: [-MANGA.largo / 2 + 0.22, MANGA.centroY, 0], rot: [0, Math.PI / 2, 0] },
+    { geo: amarreGeom(SALIDA.radio + 0.05, 0.038, 7), pos: [MANGA.largo / 2 - 0.05, MANGA.centroY, 0], rot: [0, Math.PI / 2, 0] },
+    { geo: amarreGeom(SALIDA.radio + 0.05, 0.038, 8), pos: [MANGA.largo / 2 - 0.22, MANGA.centroY, 0], rot: [0, Math.PI / 2, 0] },
+  ];
+}
+
+/* ------------------------------------------------------------------ */
+/* LAS BURBUJAS — la fermentación que se ve.                            */
+/* ------------------------------------------------------------------ */
+
+/*
+ * El corazón de la escena. Suben del lodo a la campana: eso es el metano
+ * naciendo. Van DETRÁS del plano del corte (z ∈ [-0.66, -0.08]) para que se
+ * lean contra la pared interior de la manga y no floten por delante del corte.
+ *
+ * `clima` decide cuántas y qué tan rápido — así "en tierra fría rinde menos"
+ * se ve en vez de leerse (ver CLIMAS).
+ */
+export function burbujas(params, clima = CLIMAS.calido, seed = 41) {
+  const r = rng(seed);
+  const cuantas = Math.max(4, Math.round(params.burbujas * clima.burbujas));
+  const out = [];
+  for (let i = 0; i < cuantas; i += 1) {
+    const yFondo = MANGA.centroY - MANGA.radio * 0.72;
+    out.push({
+      x: (r() - 0.5) * MANGA.largo * 0.9,
+      z: -0.08 - r() * 0.58, // detrás del corte, contra la pared del fondo
+      y0: yFondo + r() * 0.18,
+      fase: r(),
+      vel: (0.16 + r() * 0.2) * clima.velocidad,
+      escala: 0.026 + r() * 0.042,
+    });
+  }
+  return out;
+}
+
+/** El recorrido de una burbuja: nace en el fondo y muere en la superficie del
+ *  lodo (ahí entrega su gas a la campana). */
+export const BURBUJA_TECHO = NIVEL - 0.02;
+
+/* ------------------------------------------------------------------ */
+/* LA MANGUERA DEL GAS — de la campana al frasco, y del frasco a la olla.
+/* ------------------------------------------------------------------ */
+
+/**
+ * El recorrido del biogás, con la manga colgando como cuelga una manguera
+ * (nunca tensa). Pasa por el PUNTO BAJO —la trampa de agua, donde se junta el
+ * condensado y se purga— antes de subir al sello y seguir a la cocina.
+ * @returns {{ curva: THREE.CatmullRomCurve3, trampa: THREE.Vector3 }}
+ */
+export function recorridoGas() {
+  const trampa = new THREE.Vector3(-1.85, 0.1, 1.05); // el punto bajo: aquí se purga
+  const pts = [
+    new THREE.Vector3(TOMA_GAS.x, TOMA_GAS.y + 0.04, -0.02),
+    new THREE.Vector3(TOMA_GAS.x - 0.35, TOMA_GAS.y + 0.26, 0.34),
+    new THREE.Vector3(-1.6, 0.42, 0.76),
+    trampa, // ── la manguera baja: el agua se junta acá y se saca
+    new THREE.Vector3(-2.3, 0.36, 1.5),
+    new THREE.Vector3(VALVULA.pos[0], VALVULA.aguaY + 0.5, VALVULA.pos[2] - 0.02), // al sello
+  ];
+  return { curva: new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.35), trampa };
+}
+
+/** Del sello de agua a la hornilla: el tramo que de verdad cocina. */
+export function recorridoCocina() {
+  const pts = [
+    new THREE.Vector3(VALVULA.pos[0] - 0.08, VALVULA.aguaY + 0.4, VALVULA.pos[2] + 0.06),
+    new THREE.Vector3(-2.6, 0.3, 2.5),
+    new THREE.Vector3(-2.4, 0.26, 2.95),
+    new THREE.Vector3(COCINA.pos[0] + 0.1, COCINA.alto - 0.16, COCINA.pos[2] - 0.24),
+  ];
+  return new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.4);
+}
+
+/** La manguera como tubo (aplica a los dos recorridos). */
+export function mangueraGeom(curva, params) {
+  return new THREE.TubeGeometry(curva, params.segTubo * 3, 0.032, 5, false);
+}
+
+/* ------------------------------------------------------------------ */
+/* LA LLAMA — biogás bien quemado.                                      */
+/* ------------------------------------------------------------------ */
+
+/*
+ * ARDE AZUL. No es una decisión de arte, es química: una llama de biogás bien
+ * regulada es azul. La llama AMARILLA es la mal ajustada (la que tizna la olla
+ * y desperdicia el gas), y por eso en este módulo NO se pinta amarilla — sería
+ * enseñar el error como si fuera el objetivo.
+ *
+ * Tres capas, de adentro hacia afuera: el corazón pálido, el cono azul y el
+ * borde que lame la olla. Bajita y pareja: una llama de biogás no es una
+ * fogata. Controlada y correcta, como debe verse cualquier fuego que este
+ * proyecto le muestre a alguien que lo va a copiar en su casa.
+ */
+export const LLAMA = {
+  capas: [
+    { r: 0.052, h: 0.2, color: PALETA_ESTIERCOL.llamaCorazon, opacidad: 0.95 },
+    { r: 0.082, h: 0.3, color: PALETA_ESTIERCOL.llama, opacidad: 0.8 },
+    { r: 0.105, h: 0.21, color: PALETA_ESTIERCOL.llamaBorde, opacidad: 0.45 },
+  ],
+  /* la corona de la hornilla: llamitas repartidas en círculo, como un quemador
+     de verdad (no una sola lengua de fuego en el centro) */
+  bocas: 7,
+  radioCorona: 0.11,
+};
+
+/** Las posiciones de las llamitas de la corona del quemador. */
+export function bocasLlama() {
+  const out = [];
+  for (let i = 0; i < LLAMA.bocas; i += 1) {
+    const a = (i / LLAMA.bocas) * Math.PI * 2;
+    out.push([Math.sin(a) * LLAMA.radioCorona, 0, Math.cos(a) * LLAMA.radioCorona]);
+  }
+  return out;
+}
+
+/** El cono de una capa de llama (lathe: la llama tiene cintura, no es un cono). */
+export function llamaGeom(capa, seg = 8) {
+  const pts = [
+    new THREE.Vector2(0.0001, 0),
+    new THREE.Vector2(capa.r * 0.9, capa.h * 0.12),
+    new THREE.Vector2(capa.r, capa.h * 0.38),
+    new THREE.Vector2(capa.r * 0.72, capa.h * 0.72),
+    new THREE.Vector2(0.0001, capa.h),
+  ];
+  return new THREE.LatheGeometry(pts, seg);
+}

--- a/src/visual/mundo3d/estiercol/compostera.geom.js
+++ b/src/visual/mundo3d/estiercol/compostera.geom.js
@@ -1,0 +1,436 @@
+/*
+ * compostera.geom — LA BIOCOMPOSTERA POR DENTRO: tres cajones, un techo y el
+ * estiércol volviéndose tierra, EN CORTE. Funciones puras (three-core).
+ *
+ * ── POR QUÉ TRES CAJONES Y NO UN MONTÓN ────────────────────────────────────
+ * Porque el compostaje no es un estado, es un VIAJE por temperaturas — y un
+ * montón solo no puede mostrarlo. Tres cajones muestran las tres fases al
+ * mismo tiempo, que es justo como se ve una compostera trabajando de verdad:
+ * uno cargando, uno volteando, uno madurando. "Una biocompostera fija, con
+ * paredes bajas o cajones, techo y buen drenaje en la base, ayuda a mantener
+ * forma, controlar la humedad y facilita el volteo."
+ *
+ * ── LAS TRES VERDADES QUE MANDAN AQUÍ ──────────────────────────────────────
+ *
+ *   1. EL CARBONO AMARRA EL NITRÓGENO. Por eso las capas se alternan y por eso
+ *      las de material seco son MÁS GRUESAS que las de estiércol (`GROSOR`):
+ *      "el estiércol solo es puro nitrógeno; cuando el nitrógeno no tiene con
+ *      qué amarrarse se escapa como amoníaco". Un dibujo con capas iguales, o
+ *      con más estiércol que carbono, está dibujando un montón que apesta.
+ *
+ *   2. EL CALOR ES EL QUE SANITIZA. "Ese calor no es un accidente, es la señal
+ *      de que el compostaje va bien" — y es lo que mata patógenos y semillas
+ *      de maleza. Por eso cada fase tiene su `temperatura` y su corazón
+ *      caliente dibujado, y por eso el volteo existe: para que el material de
+ *      las orillas (que se enfría) pase por el centro caliente.
+ *
+ *   3. LA LOMBRIZ LLEGA AL FINAL. NUNCA al principio. "El estiércol fresco
+ *      libera amoníaco y calor, y ambas cosas son tóxicas o letales para la
+ *      lombriz." Por eso `lombrices: true` SOLO existe en el cajón maduro y
+ *      frío. Dibujar lombrices en estiércol fresco es dibujar lombrices
+ *      muertas.
+ *
+ * ── EL OLOR, DIBUJADO ──────────────────────────────────────────────────────
+ * Los cajones sueltan VAPOR blanco (agua tibia: la señal de que va bien). El
+ * montón mal llevado de al lado —encharcado, sin carbono, sin voltear— suelta
+ * AMONÍACO verde que ni siquiera sube: se arrastra. Son el mismo gesto con
+ * lectura opuesta, y esa comparación es la lección entera del módulo. Ese
+ * montón está a propósito FUERA del anillo del ciclo: es la plata saliéndose.
+ */
+import * as THREE from 'three';
+import { PALETA_ESTIERCOL, torcerConLaMano, rng, manoAlzada } from './estiercol.geom.js';
+
+/* ------------------------------------------------------------------ */
+/* LAS MEDIDAS.                                                         */
+/* ------------------------------------------------------------------ */
+
+/*
+ * El cajón. `alto` bajo a propósito: la pared es una guía, no una caja — el
+ * montón la rebasa y se ve. "Una pila de metro y medio de alto suele ser buen
+ * tamaño: lo bastante grande para retener calor en el centro y lo bastante
+ * manejable para voltearla con pala o bieldo sin necesitar maquinaria."
+ * Aquí la pila llega ~1.35 sobre el piso del cajón: en ese orden, no más.
+ */
+export const CAJON = {
+  ancho: 1.5,
+  hondo: 1.2,
+  alto: 0.82,
+  tabla: 0.07,
+  separacion: 0.09,
+};
+
+/** El centro X de cada cajón (tres, en fila; el 0 es el que se está cargando). */
+export function cajonX(i) {
+  const paso = CAJON.ancho + CAJON.separacion;
+  return (i - 1) * paso;
+}
+
+/* Cuánto más gruesa es la capa de carbono que la de estiércol. El estiércol
+   es puro nitrógeno; para amarrarlo hace falta bastante más material seco que
+   estiércol. Que las capas se vean así de desiguales ES la enseñanza. */
+export const GROSOR = { estiercol: 0.075, carbono: 0.125 };
+
+/* ------------------------------------------------------------------ */
+/* LAS FASES — el viaje por la temperatura.                             */
+/* ------------------------------------------------------------------ */
+
+/*
+ * `temperatura` va de 0 (frío, maduro) a 1 (el corazón termófilo). Manda el
+ * color del corazón, cuánto vapor sale y —lo más importante— si la lombriz
+ * puede estar ahí o no.
+ */
+export const FASES = [
+  {
+    id: 'armado',
+    cajon: 0,
+    etiqueta: 'recién armado',
+    temperatura: 1,
+    capas: true, // las capas todavía se distinguen una por una
+    vapor: 1,
+    lombrices: false, // aquí la lombriz se muere: hay amoníaco y calor
+    nota: 'Capa de estiércol, capa de material seco, capa de estiércol. Fíjese que la capa seca es más gruesa: el estiércol es puro nitrógeno y necesita bastante carbono para amarrarlo. Sin eso, el nitrógeno se va al aire como amoníaco — y eso es plata.',
+  },
+  {
+    id: 'volteo',
+    cajon: 1,
+    etiqueta: 'el volteo',
+    temperatura: 0.62,
+    capas: false, // ya se revolvió: las capas se perdieron y está bien
+    vapor: 0.55,
+    lombrices: false, // todavía calienta
+    nota: 'Se voltea para llevarle aire a todo y para que el material de las orillas —que se enfría— pase por el centro caliente. Ese calor sostenido es el que mata patógenos y semillas de maleza. Si no voltea, la maleza del estiércol le germina después en la huerta.',
+  },
+  {
+    id: 'maduro',
+    cajon: 2,
+    etiqueta: 'maduro',
+    temperatura: 0.05,
+    capas: false,
+    vapor: 0.12,
+    lombrices: true, // AHORA sí: ya bajó la temperatura y se fue el amoníaco
+    nota: 'Oscuro, suelto, huele a tierra de bosque y ya no vuelve a calentar aunque lo voltee. Solo ahora llega la lombriz: en el fresco se le habría muerto por el amoníaco y el calor. Esto ya se le puede echar a la mata sin quemarla.',
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/* LAS CAPAS — el corte del montón.                                     */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Convención de corte, igual que en el biodigestor: todo vive en z ∈ [-hondo,
+ * 0] y la cara en z=0 es la del serrucho — la que mira la cámara. Aquí no hay
+ * extrusión: cada capa es una tabla de material, y su canto en z=0 dibuja la
+ * banda. Un montón real, visto en corte, es exactamente eso: bandas.
+ *
+ * El orden manda:
+ *   · abajo, el DRENAJE (palos, ramas gruesas): sin eso el fondo se encharca y
+ *     se vuelve anaerobio justo donde uno no lo ve.
+ *   · en medio, la alternancia carbono/estiércol, empezando y —esto importa—
+ *     TERMINANDO en carbono: la capa seca de encima es la que tapa el olor y
+ *     le quita el aterrizaje a la mosca.
+ *   · el montón se angosta hacia arriba (`merma`): así queda un montón hecho a
+ *     pala, no un ladrillo.
+ */
+export function capasDelMonton(fase, seed = 51) {
+  const r = rng(seed + fase.cajon * 7);
+  const capas = [];
+  let y = 0;
+
+  /* el drenaje del fondo: ramas y palos, para que el fondo respire */
+  capas.push({
+    y0: y,
+    alto: 0.1,
+    tipo: 'drenaje',
+    color: PALETA_ESTIERCOL.maderaVieja,
+    merma: 0,
+  });
+  y += 0.1;
+
+  const techo = 1.35; // el alto de trabajo del montón (ver CAJON)
+  let esCarbono = true; // arranca en seco: el fondo nunca va con estiércol
+  while (y < techo) {
+    const grosor = esCarbono ? GROSOR.carbono : GROSOR.estiercol;
+    const alto = grosor * (0.82 + r() * 0.36); // ninguna capa es pareja: se echó a pala
+    if (y + alto > techo) break;
+    capas.push({
+      y0: y,
+      alto,
+      tipo: esCarbono ? 'carbono' : 'estiercol',
+      color: esCarbono
+        ? r() > 0.5
+          ? PALETA_ESTIERCOL.carbono
+          : PALETA_ESTIERCOL.carbonoHoja
+        : PALETA_ESTIERCOL.estiercolFresco,
+      merma: (y / techo) * 0.3, // se angosta hacia arriba
+    });
+    y += alto;
+    esCarbono = !esCarbono;
+  }
+
+  /* la última capa SIEMPRE seca: es la que tapa el olor y la mosca */
+  capas.push({
+    y0: y,
+    alto: GROSOR.carbono * 0.9,
+    tipo: 'carbono',
+    color: PALETA_ESTIERCOL.carbonoHoja,
+    merma: 0.32,
+  });
+
+  /* ¿ya se volteó? entonces las capas NO existen: se revolvieron. Se devuelve
+     el mismo montón con el color mezclado, porque la FORMA sí sobrevive al
+     volteo — lo que se pierde es la lectura de las bandas. */
+  if (!fase.capas) {
+    const destino =
+      fase.temperatura > 0.3 ? PALETA_ESTIERCOL.compostJoven : PALETA_ESTIERCOL.compostMaduro;
+    return capas.map((c, i) =>
+      c.tipo === 'drenaje'
+        ? c
+        : {
+            ...c,
+            tipo: 'revuelto',
+            /* quedan vetas: un volteo a bieldo no es una licuadora */
+            color: i % 3 === 0 ? PALETA_ESTIERCOL.carbono : destino,
+          },
+    );
+  }
+  return capas;
+}
+
+/**
+ * La geometría de una capa: una caja con la mano encima (nada recto). Se corta
+ * en z=0 — el montón ocupa z ∈ [-hondo, 0].
+ */
+export function capaGeom(capa, seed = 3) {
+  const ancho = (CAJON.ancho - CAJON.tabla * 2) * (1 - capa.merma);
+  const hondo = (CAJON.hondo - CAJON.tabla) * (1 - capa.merma * 0.6);
+  const geo = new THREE.BoxGeometry(ancho, capa.alto, hondo, 3, 1, 2);
+  torcerConLaMano(geo, { amplitud: 0.016, seed: seed + Math.round(capa.y0 * 100) });
+  geo.translate(0, capa.y0 + capa.alto / 2, -hondo / 2); // ── cortada en z=0
+  return geo;
+}
+
+/**
+ * EL CORAZÓN CALIENTE: la lente de calor en el centro del montón. No es un
+ * efecto — es el sujeto. "¿Por qué la pila se pone caliente por dentro?"
+ * Porque las bacterias trabajando generan calor, y ese calor es el que
+ * sanitiza. Vive ADENTRO y arriba del centro geométrico, que es donde de
+ * verdad está lo más caliente (el fondo se enfría contra la tierra).
+ */
+export function corazonGeom(fase) {
+  /* el calor no solo se apaga: se ENCOGE. El montón maduro no tiene corazón
+     caliente en el centro, tiene apenas un rescoldo — por eso el radio sigue a
+     la temperatura de la fase. */
+  const radio = 0.2 + 0.24 * fase.temperatura;
+  const geo = new THREE.SphereGeometry(radio, 10, 8);
+  geo.scale(1.5, 0.86, 1);
+  geo.translate(0, 0.62, -CAJON.hondo * 0.45);
+  return geo;
+}
+
+/** El color del corazón según la fase: del ámbar-cochinilla al frío. */
+export function colorCorazon(fase) {
+  return fase.temperatura > 0.3 ? PALETA_ESTIERCOL.corazonCaliente : PALETA_ESTIERCOL.tibio;
+}
+
+/* ------------------------------------------------------------------ */
+/* LA ESTRUCTURA — cajones y techo, hechos a mano.                      */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Las tablas de un cajón: piso, fondo y dos costados. La CARA DE ADELANTE no
+ * existe — y eso es diegético, no una licencia: en una compostera de tablas
+ * los boards del frente se sacan para trabajar el montón. Los dos parales del
+ * frente sí quedan (son los que sostienen las tablas cuando están puestas).
+ */
+export function tablasCajon() {
+  const t = CAJON.tabla;
+  const h = CAJON.alto;
+  /* COORDENADAS LOCALES (x centrado en 0): quien monta el cajón ya lo puso en
+     su sitio con `cajonX(i)`. Sumar el offset aquí también lo correría dos
+     veces — el clásico. */
+  return [
+    /* el fondo */
+    { args: [CAJON.ancho, h, t], pos: [0, h / 2, -CAJON.hondo] },
+    /* los dos costados */
+    { args: [t, h, CAJON.hondo], pos: [-CAJON.ancho / 2, h / 2, -CAJON.hondo / 2] },
+    { args: [t, h, CAJON.hondo], pos: [CAJON.ancho / 2, h / 2, -CAJON.hondo / 2] },
+    /* los parales del frente: las tablas están afuera porque se está trabajando */
+    { args: [t * 1.5, h * 1.35, t * 1.5], pos: [-CAJON.ancho / 2, h * 0.68, -0.02] },
+    { args: [t * 1.5, h * 1.35, t * 1.5], pos: [CAJON.ancho / 2, h * 0.68, -0.02] },
+  ];
+}
+
+/**
+ * EL TECHO. "Un techo o una lona evita que la lluvia sature de agua la pila (lo
+ * que la vuelve anaeróbica y olorosa) y que el sol la reseque." Es la pieza que
+ * decide si el montón va bien o se pudre, y cuesta casi nada.
+ *
+ * Va inclinado (el agua tiene que correr para algún lado) y ondulado con la
+ * mano: es una lámina de zinc amarrada, no un plano de CAD.
+ */
+export function techoGeom() {
+  const ancho = CAJON.ancho * 3 + CAJON.separacion * 2 + 0.5;
+  const geo = new THREE.BoxGeometry(ancho, 0.035, CAJON.hondo + 0.75, 12, 1, 4);
+  const pos = geo.attributes.position;
+  for (let i = 0; i < pos.count; i += 1) {
+    const x = pos.getX(i);
+    /* la corrugación del zinc + el pandeo de los años */
+    pos.setY(i, pos.getY(i) + Math.sin(x * 9) * 0.012 + manoAlzada(x * 0.4, { amplitud: 0.03, seed: 71 }));
+  }
+  pos.needsUpdate = true;
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/** Los postes del techo: torcidos, porque son palos de la finca. */
+export function postesTecho() {
+  const ancho = CAJON.ancho * 3 + CAJON.separacion * 2;
+  return [
+    [-ancho / 2 + 0.1, 0, 0.12],
+    [ancho / 2 - 0.1, 0, 0.12],
+    [-ancho / 2 + 0.1, 0, -CAJON.hondo - 0.1],
+    [ancho / 2 - 0.1, 0, -CAJON.hondo - 0.1],
+  ];
+}
+
+export const TECHO = { alturaFrente: 2.05, alturaAtras: 1.72 }; // caída para el agua
+
+/* ------------------------------------------------------------------ */
+/* LAS HERRAMIENTAS Y LAS SEÑAS.                                        */
+/* ------------------------------------------------------------------ */
+
+/*
+ * LA PRUEBA DEL PUÑO, sin dibujar una mano: la bola que quedó apretada,
+ * puesta en el borde del cajón del volteo. "Si chorrea agua entre los dedos
+ * está muy húmedo; si se desmorona seco, le falta agua. El punto es cuando se
+ * pega formando una bola pero no gotea." Esta bola SE SOSTIENE y NO chorrea:
+ * es el punto bueno, hecho objeto. Las marcas de los dedos quedan.
+ */
+export function bolaPunoGeom() {
+  const geo = new THREE.SphereGeometry(0.075, 9, 7);
+  const pos = geo.attributes.position;
+  for (let i = 0; i < pos.count; i += 1) {
+    const x = pos.getX(i);
+    const y = pos.getY(i);
+    const z = pos.getZ(i);
+    /* los surcos de los cuatro dedos que la apretaron */
+    const surco = Math.sin(y * 42) * 0.006 + Math.cos(x * 30) * 0.005;
+    const l = Math.hypot(x, y, z) || 1;
+    pos.setXYZ(i, x + (x / l) * surco, y + (y / l) * surco, z + (z / l) * surco);
+  }
+  pos.needsUpdate = true;
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/** El bieldo clavado en el montón del volteo: cabo de palo y cuatro dientes. */
+export function bieldo() {
+  return {
+    cabo: { args: [0.022, 0.026, 1.15, 6], seed: 73 },
+    dientes: [-0.075, -0.025, 0.025, 0.075],
+    dienteAlto: 0.24,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* LAS LOMBRICES — y solo donde deben estar.                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * La roja californiana, en el cajón maduro y en ninguno más (ver FASES §3).
+ * Se reparten cerca de la superficie y del frente del corte: en un lecho real
+ * están en los primeros centímetros, no en el fondo.
+ */
+export function lombrices(params, seed = 81) {
+  if (!params.lombrices) return [];
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < params.lombrices; i += 1) {
+    out.push({
+      /* locales al cajón (igual que `tablasCajon`): el grupo del cajón ya está
+         puesto en su x. */
+      pos: [
+        (r() - 0.5) * CAJON.ancho * 0.72,
+        0.42 + r() * 0.52,
+        -0.06 - r() * 0.3, // asomadas al corte: se ven
+      ],
+      rot: [r() * 0.9 - 0.45, r() * Math.PI, r() * 0.7 - 0.35],
+      escala: 0.72 + r() * 0.55,
+      fase: r(),
+    });
+  }
+  return out;
+}
+
+/** El cuerpo de una lombriz: un tubo curvo y anillado (nunca una recta). */
+export function lombrizGeom() {
+  const curva = new THREE.CatmullRomCurve3([
+    new THREE.Vector3(-0.075, 0, 0),
+    new THREE.Vector3(-0.025, 0.016, 0.022),
+    new THREE.Vector3(0.028, -0.012, -0.016),
+    new THREE.Vector3(0.072, 0.008, 0.012),
+  ]);
+  return new THREE.TubeGeometry(curva, 10, 0.0085, 5, false);
+}
+
+/* ------------------------------------------------------------------ */
+/* EL MONTÓN MAL LLEVADO — el contraejemplo honesto.                    */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Sin carbono, sin techo, sin voltear, encharcado. "Se ve empantanado,
+ * pegajoso, con zonas oscuras y babosas, huele fuerte a huevo podrido o a
+ * amoníaco, y puede que ni siquiera esté caliente, porque la fermentación sin
+ * aire genera menos calor útil que la aeróbica."
+ *
+ * Está aquí porque sin él la escena sería un folleto. Y está FUERA DEL ANILLO
+ * a propósito: de este montón la materia no vuelve al suelo, se va al aire.
+ * Aplastado (`aplasta`) y sin corazón caliente: eso es lo que lo distingue de
+ * los cajones. Con moscas, que no vienen por el olor sino por el mismo
+ * material húmedo y blando donde ponen los huevos.
+ */
+/* Sin `pos`: vive en coordenadas LOCALES y lo ubica la escena, en la estación
+   'monton' — que es la única FUERA del anillo del ciclo. */
+export const MONTON_MALO = { radio: 0.72, alto: 0.46 };
+
+export function montonMaloGeom() {
+  const geo = new THREE.SphereGeometry(MONTON_MALO.radio, 12, 8, 0, Math.PI * 2, 0, Math.PI / 2);
+  geo.scale(1, MONTON_MALO.alto / MONTON_MALO.radio, 1.1); // se desparramó: no tiene forma
+  torcerConLaMano(geo, { amplitud: 0.055, seed: 91 });
+  return geo;
+}
+
+/** El charco a su pie: lo que escurre de un montón sin cama ni drenaje — y que
+ *  termina en la quebrada si nadie lo ataja. */
+export function charcoGeom() {
+  const geo = new THREE.CircleGeometry(MONTON_MALO.radio * 1.35, 14);
+  geo.rotateX(-Math.PI / 2);
+  const pos = geo.attributes.position;
+  for (let i = 0; i < pos.count; i += 1) {
+    pos.setY(i, Math.sin(pos.getX(i) * 6) * 0.012);
+  }
+  pos.needsUpdate = true;
+  return geo;
+}
+
+/**
+ * Las moscas: giran sobre el montón malo. "No vienen atraídas por el olor sino
+ * por el material húmedo y blando donde ponen sus huevos. Si tiene mucho olor,
+ * casi con seguridad también tiene mucha mosca: son la misma causa."
+ * Por eso NUNCA hay moscas sobre los cajones bien llevados.
+ */
+export function moscas(params, seed = 95) {
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < params.moscas; i += 1) {
+    out.push({
+      /* locales al montón: la escena ya lo puso en su sitio */
+      centro: [(r() - 0.5) * 0.9, MONTON_MALO.alto * (0.7 + r() * 1.5), (r() - 0.5) * 0.9],
+      radio: 0.09 + r() * 0.26,
+      vel: 1.4 + r() * 2.6,
+      fase: r() * Math.PI * 2,
+      escala: 0.5 + r() * 0.5,
+    });
+  }
+  return out;
+}

--- a/src/visual/mundo3d/estiercol/estiercol.css
+++ b/src/visual/mundo3d/estiercol/estiercol.css
@@ -1,0 +1,156 @@
+/*
+ * estiercol.css — el mínimo para el lienzo y los hotspots. Self-contained: se
+ * ve igual en un mockup suelto que dentro del host `<Mundo>`.
+ *
+ * Los colores salen de la paleta madre (los mismos hex de `paletaMadre.js`),
+ * porque el HTML de encima también es la obra: una pastilla gris de sistema
+ * operativo encima de una escena andina rompe el mundo.
+ */
+
+.est-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  transition: opacity 0.8s ease;
+}
+
+.est-canvas--lista {
+  opacity: 1;
+}
+
+/* ── el hotspot: un punto que se toca ── */
+.est-hot {
+  transform: translate(-50%, -120%);
+}
+
+.est-hot__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  max-width: 13rem;
+  padding: 0.3rem 0.62rem;
+  border: 0;
+  border-radius: 999px;
+  /* NEUTROS.tinta con alfa: negro CÁLIDO, nunca negro puro */
+  background: rgba(36, 26, 16, 0.84);
+  color: #fff8ec; /* NEUTROS.hueso */
+  font: 600 0.76rem/1.1 system-ui, sans-serif;
+  text-align: left;
+  cursor: pointer;
+  box-shadow:
+    0 2px 10px rgba(36, 26, 16, 0.4),
+    inset 0 0 0 1px rgba(217, 161, 59, 0.45); /* ACENTOS.ambar */
+  -webkit-tap-highlight-color: transparent;
+}
+
+.est-hot__btn:focus-visible {
+  outline: 2px solid #d9a13b; /* ACENTOS.ambar */
+  outline-offset: 2px;
+}
+
+.est-hot__pt {
+  flex: 0 0 auto;
+  width: 0.66rem;
+  height: 0.66rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #fff8ec, #d9a13b 70%);
+  box-shadow: 0 0 8px 2px rgba(217, 161, 59, 0.55);
+}
+
+/* el hotspot del montón mal llevado: el único que NO es ámbar. Verde-azufre,
+   el color del amoníaco — la seña de que ahí algo va mal. Es señal, no alarma:
+   esta casa no usa rojo de catástrofe. */
+.est-hot--malo .est-hot__btn {
+  box-shadow:
+    0 2px 10px rgba(36, 26, 16, 0.4),
+    inset 0 0 0 1px rgba(186, 178, 92, 0.6);
+}
+
+.est-hot--malo .est-hot__pt {
+  background: radial-gradient(circle at 35% 35%, #f2eecb, #bab25c 70%);
+  box-shadow: 0 0 8px 2px rgba(186, 178, 92, 0.5);
+}
+
+/* ── la ficha que se abre al tocar ── */
+.est-ficha {
+  transform: translate(-50%, -108%);
+  width: min(19rem, 68vw);
+  padding: 0.66rem 0.8rem;
+  border-radius: 0.7rem;
+  background: rgba(36, 26, 16, 0.93);
+  color: #fff8ec;
+  box-shadow:
+    0 6px 22px rgba(36, 26, 16, 0.5),
+    inset 0 0 0 1px rgba(217, 161, 59, 0.4);
+}
+
+.est-ficha__tit {
+  margin: 0 0 0.28rem;
+  color: #d9a13b;
+  font: 700 0.82rem/1.2 system-ui, sans-serif;
+  letter-spacing: 0.01em;
+}
+
+.est-ficha__txt {
+  margin: 0;
+  font: 400 0.78rem/1.42 system-ui, sans-serif;
+  color: #f3e7d4;
+}
+
+.est-ficha__cerrar {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.4rem;
+  padding: 0.1rem 0.3rem;
+  border: 0;
+  border-radius: 0.3rem;
+  background: transparent;
+  color: #b9a68a;
+  font: 700 0.9rem/1 system-ui, sans-serif;
+  cursor: pointer;
+}
+
+.est-ficha__cerrar:focus-visible {
+  outline: 2px solid #d9a13b;
+}
+
+/* ── el interruptor de clima (tierra fría / tierra caliente) ── */
+.est-clima {
+  position: absolute;
+  right: 0.7rem;
+  bottom: 0.7rem;
+  display: flex;
+  gap: 0.28rem;
+  padding: 0.28rem;
+  border-radius: 999px;
+  background: rgba(36, 26, 16, 0.8);
+  box-shadow: inset 0 0 0 1px rgba(217, 161, 59, 0.35);
+}
+
+.est-clima__btn {
+  padding: 0.3rem 0.66rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: #d8c7ab;
+  font: 600 0.72rem/1 system-ui, sans-serif;
+  cursor: pointer;
+}
+
+.est-clima__btn--on {
+  background: #d9a13b;
+  color: #241a10;
+}
+
+.est-clima__btn:focus-visible {
+  outline: 2px solid #fff8ec;
+  outline-offset: 1px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .est-canvas {
+    transition: none;
+  }
+}

--- a/src/visual/mundo3d/estiercol/estiercol.geom.js
+++ b/src/visual/mundo3d/estiercol/estiercol.geom.js
@@ -1,0 +1,564 @@
+/*
+ * estiercol.geom — el ADN COMPARTIDO del mundo "la mierda volviéndose gas y
+ * abono": paleta derivada, presupuesto por tier, la mano que dibuja torcido y
+ * EL ANILLO DEL CICLO. Funciones PURAS (three-core, corren headless: cero
+ * contexto GL, cero azar por frame, cero assets externos).
+ *
+ * ── LA VERDAD QUE ENSEÑA (corpus teacher-cerdos-gallinas, 150 pares) ────────
+ * El estiércol es el problema más real y menos glamoroso de la finca: apesta,
+ * cría mosca y pelea con el vecino. Y ese olor NO es un detalle estético — es
+ * NITRÓGENO VOLÁNDOSE, o sea plata que se va al aire en vez de quedarse en el
+ * abono. Todo el módulo está construido sobre esa sola frase.
+ *
+ * El corpus manda tres cosas que aquí son LEY VISUAL:
+ *
+ *   1. LA SEPARACIÓN ES EL ORIGEN. "Con una pendiente suave y un canal en el
+ *      punto más bajo, el orín escurre solo mientras el sólido queda arriba
+ *      para recogerlo seco. Mezclados, se pudren juntos y ahí nace el olor
+ *      fuerte." Por eso el ciclo se BIFURCA en la rejilla: el líquido baja al
+ *      biodigestor, el sólido sube a la compostera. Dos carriles, no uno.
+ *
+ *   2. EL CARBONO AMARRA EL NITRÓGENO. "El estiércol solo es puro nitrógeno;
+ *      cuando el nitrógeno no tiene con qué amarrarse se escapa como amoníaco."
+ *      Por eso hay DOS humos en esta paleta y no son lo mismo (ver HUMOS).
+ *
+ *   3. NADA DE ESTO ES MAGIA. "Representa una inversión real de plata y
+ *      trabajo, no es gratis." Por eso la manga lleva su PARCHE, la zanja su
+ *      barro y el montón mal llevado existe en la escena: si esto se ve como
+ *      postal de folleto, mentimos.
+ *
+ * ── EL ANILLO ──────────────────────────────────────────────────────────────
+ * La tesis es un círculo que cierra: animal → estiércol → biodigestor/
+ * compostera → gas + abono → suelo → comida → animal. Se dibuja LITERAL: un
+ * sendero circular hecho a mano con las estaciones encima y pulsos de materia
+ * corriendo por él. Donde el ciclo se rompe (el montón anaerobio), la materia
+ * SE SALE del anillo y se va al cielo: eso es la plata volándose, y se ve.
+ *
+ * Los componentes r3f (`Biodigestor.jsx`, `Biocompostera.jsx`,
+ * `CicloCerrado.jsx`) consumen esto y le ponen luz, material y vida.
+ */
+import * as THREE from 'three';
+import {
+  VERDES,
+  TIERRAS,
+  AGUAS,
+  ACENTOS,
+  NEUTROS,
+  LUCES,
+  PALETA,
+  mezclar,
+} from '../paleta/index.js';
+import { PALETA_ANDINA, rngArtesania } from '../artesaniaAndina.js';
+
+/* PRNG determinista (misma finca en cada carga; nada de Math.random). El
+   módulo entero hereda la receta LCG de artesaniaAndina: una sola aleatoriedad
+   en la casa. */
+export const rng = rngArtesania;
+
+/* ------------------------------------------------------------------ */
+/* LA MANO — nada recto, el remate se ve.                              */
+/* ------------------------------------------------------------------ */
+
+/*
+ * El ADN de artesania/: una finca real no tiene un solo borde recto. Ni la
+ * zanja, ni el cajón, ni el sendero. `manoAlzada` es el temblor honesto de
+ * quien cavó con pala: determinista (mismo seed → misma torcedura), suave
+ * (dos frecuencias, no ruido de TV) y proporcional (`amplitud` en unidades de
+ * mundo). Se aplica a POSICIONES, no a normales: el relieve es geometría.
+ */
+export function manoAlzada(t, { amplitud = 0.05, seed = 7 } = {}) {
+  const r = rng(seed);
+  const fase1 = r() * Math.PI * 2;
+  const fase2 = r() * Math.PI * 2;
+  return (
+    Math.sin(t * 5.3 + fase1) * amplitud * 0.62 +
+    Math.sin(t * 11.7 + fase2) * amplitud * 0.38
+  );
+}
+
+/*
+ * Tuerce una geometría entera con la mano: cada vértice se corre según su
+ * altura y su posición, como madera que se combó o tierra que se asentó.
+ * MUTA y devuelve la geometría (patrón de las geoms del bosque). Barato: una
+ * pasada por vértice, una vez por montaje.
+ */
+export function torcerConLaMano(geo, { amplitud = 0.03, seed = 11 } = {}) {
+  const pos = geo.attributes.position;
+  const r = rng(seed);
+  const f1 = r() * 10;
+  const f2 = r() * 10;
+  for (let i = 0; i < pos.count; i += 1) {
+    const x = pos.getX(i);
+    const y = pos.getY(i);
+    const z = pos.getZ(i);
+    pos.setX(i, x + Math.sin(y * 3.1 + f1) * amplitud);
+    pos.setZ(i, z + Math.sin(y * 2.7 + x * 1.9 + f2) * amplitud);
+  }
+  pos.needsUpdate = true;
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/*
+ * RECORTAR EN EL CORTE — el que da la mano, lo quita el serrucho.
+ *
+ * `torcerConLaMano` mueve vértices en Z, y en una pieza CORTADA (las del
+ * biodigestor viven todas en z ≤ 0) ese temblor empuja parte de la tierra o
+ * del plástico DELANTE del plano del corte. Se ve feísimo y además es mentira:
+ * un corte es un plano, no una sierra borracha. Esto aplasta contra z=0
+ * cualquier vértice que se haya salido — la torcedura se conserva en X e Y,
+ * que es donde de verdad se lee.
+ *
+ * Regla de la casa: TODA pieza cortada que pase por `torcerConLaMano` tiene
+ * que pasar después por aquí.
+ */
+export function recortarEnCorte(geo, z0 = 0) {
+  const pos = geo.attributes.position;
+  let toco = false;
+  for (let i = 0; i < pos.count; i += 1) {
+    if (pos.getZ(i) > z0) {
+      pos.setZ(i, z0);
+      toco = true;
+    }
+  }
+  if (toco) {
+    pos.needsUpdate = true;
+    geo.computeVertexNormals();
+  }
+  return geo;
+}
+
+/*
+ * EL REMATE SE VE: un amarre (la tira de neumático con que de verdad se sella
+ * la manga contra el tubo, o la cabuya del cajón). No es adorno — es la junta
+ * mostrada en vez de escondida. Devuelve la geometría de un anillo grueso.
+ */
+export function amarreGeom(radio, grosor = 0.045, seed = 5) {
+  const geo = new THREE.TorusGeometry(radio, grosor, 5, 12);
+  return torcerConLaMano(geo, { amplitud: 0.012, seed });
+}
+
+/* ------------------------------------------------------------------ */
+/* PALETA — derivada de la madre, ni un hex inventado sin parentesco.   */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Todo sale de `paleta/` por `mezclar()`, como manda GUIA.md §1. Los tres
+ * colores que esta escena SÍ tuvo que derivar (no existen arriba porque ningún
+ * mundo previo tuvo gas ni purín) quedan documentados aquí con su parentesco:
+ *
+ *   · llama*  — el biogás bien quemado ARDE AZUL; es física, no gusto. Se
+ *     deriva del único azul con permiso (AGUAS.viva) hacia el índigo textil,
+ *     que es el azul más hondo de la casa. La llama amarilla NO se pinta:
+ *     una llama amarilla es una llama mal ajustada (y aquí la llama enseña).
+ *   · amoniaco — el olor hecho color: verde-azufre agrio, el único color feo
+ *     de la paleta A PROPÓSITO. Es nitrógeno yéndose; tiene que dar antipatía.
+ *   · purin    — el líquido de la cochera: tierra de siembra hundida hacia la
+ *     grieta más honda (TIERRAS.cacao). Nunca negro puro.
+ */
+export const PALETA_ESTIERCOL = {
+  /* — el material crudo — */
+  estiercolFresco: mezclar(TIERRAS.siembra, TIERRAS.cacao, 0.45), // pardo húmedo
+  purin: mezclar(TIERRAS.cacao, VERDES.paramoHoja, 0.22), // el líquido de la cochera
+  carbono: mezclar(TIERRAS.vega, ACENTOS.maizGrano, 0.28), // aserrín, cascarilla, tamo
+  carbonoHoja: TIERRAS.pajonal, // hoja seca, tamo: el carbono con más cuerpo
+
+  /* — el biodigestor — */
+  polietileno: mezclar(NEUTROS.lamina, NEUTROS.hueso, 0.5), // la manga: plástico lechoso
+  polietilenoSol: mezclar(NEUTROS.hueso, ACENTOS.maizTextil, 0.14), // donde le pega el sol
+  parche: mezclar(NEUTROS.lamina, TIERRAS.cacao, 0.3), // el remiendo (más oscuro: se ve)
+  lodo: mezclar(TIERRAS.cacao, VERDES.paramoNiebla, 0.3), // la mezcla fermentando
+  lodoHondo: mezclar(TIERRAS.cacao, NEUTROS.tinta, 0.4), // el fondo, donde sedimenta
+  gas: mezclar(NEUTROS.hueso, AGUAS.viva, 0.18), // la campana: aire con algo de luz
+  burbuja: mezclar(NEUTROS.hueso, AGUAS.espuma, 0.5), // el metano subiendo
+  biol: mezclar(TIERRAS.camino, VERDES.calido, 0.35), // el efluente: abono líquido
+  manguera: mezclar(NEUTROS.tinta, TIERRAS.cacao, 0.25), // la manguera de gas
+
+  /* — la llama (biogás bien quemado: azul) — */
+  llama: mezclar(AGUAS.viva, ACENTOS.indigo, 0.42),
+  llamaCorazon: mezclar(AGUAS.espuma, AGUAS.viva, 0.55), // el cono interior, pálido
+  llamaBorde: mezclar(AGUAS.viva, VERDES.frioVivo, 0.3), // el borde que lame la olla
+
+  /* — la compostera — */
+  compostJoven: mezclar(TIERRAS.siembra, PALETA_ANDINA.terracota, 0.16),
+  compostMaduro: mezclar(TIERRAS.turba, NEUTROS.tinta, 0.22), // oscuro, suelto, huele a tierra
+  corazonCaliente: mezclar(ACENTOS.ambar, PALETA_ANDINA.cochinilla, 0.35), // la fase termófila
+  tibio: mezclar(ACENTOS.ambar, TIERRAS.siembra, 0.5), // el borde del calor
+  lombriz: mezclar(PALETA_ANDINA.cochinilla, ACENTOS.florDeMonte, 0.35), // la roja californiana
+
+  /* — los dos humos: uno es salud, el otro es plata — */
+  vapor: mezclar(NEUTROS.hueso, LUCES.sol, 0.22), // agua tibia: blanco cálido
+  amoniaco: mezclar(VERDES.paramoLiquen, ACENTOS.maizTextil, 0.42), // verde-azufre agrio
+
+  /* — la finca alrededor — */
+  madera: PALETA.madera,
+  maderaVieja: mezclar(PALETA.maderaOscura, NEUTROS.lamina, 0.28),
+  tierra: TIERRAS.siembra,
+  tierraHonda: TIERRAS.cacao,
+  pasto: VERDES.trabajo,
+  sendero: TIERRAS.camino,
+  mosca: mezclar(NEUTROS.tinta, VERDES.paramoMusgo, 0.25),
+};
+
+/*
+ * LOS DOS HUMOS — la lección que se ve antes de leerse.
+ *
+ * Los dos suben del montón. Los dos parecen "humo". Pero:
+ *
+ *   · VAPOR (blanco cálido, columna recta, se disuelve alto): es agua tibia.
+ *     La pila aeróbica CALIENTA porque las bacterias trabajan; ese calor mata
+ *     patógenos y semillas de maleza. El vapor es la señal de que va BIEN.
+ *
+ *   · AMONÍACO (verde-azufre, jirones bajos que se arrastran y no suben): es
+ *     NITRÓGENO ESCAPÁNDOSE. Es el olor que arde en la nariz. Es plata que se
+ *     va. Sale del montón encharcado sin carbono, y de la cama mal llevada.
+ *
+ * Misma silueta, lectura opuesta. El color y el comportamiento hacen la
+ * diferencia: el vapor sube y se va limpio; el amoníaco se queda pegado al
+ * suelo, amarillea el aire y se escapa del anillo del ciclo.
+ */
+export const HUMOS = {
+  vapor: {
+    color: PALETA_ESTIERCOL.vapor,
+    subida: 0.62, // sube decidido
+    deriva: 0.1, // casi vertical: sale del corazón caliente
+    opacidad: 0.3,
+    escala: [0.3, 0.62],
+    vida: 3.1,
+  },
+  amoniaco: {
+    color: PALETA_ESTIERCOL.amoniaco,
+    subida: 0.16, // NO sube: se arrastra (por eso se respira)
+    deriva: 0.5, // se desparrama hacia el vecino
+    opacidad: 0.24,
+    escala: [0.4, 0.9],
+    vida: 4.6,
+  },
+};
+
+/* ------------------------------------------------------------------ */
+/* PRESUPUESTO POR TIER (DR §6 / deviceTier).                          */
+/* ------------------------------------------------------------------ */
+
+/*
+ * El "wow" vive en 'alto'. 'medio' es frugal pero conserva LO QUE ENSEÑA (las
+ * burbujas, la llama, las capas, los dos humos): se recorta densidad, nunca
+ * lección. 'bajo' es el mínimo digno — la escena normalmente cae a su espejo
+ * 2D en equipo humilde, pero si algo la fuerza, aguanta.
+ */
+export const PARAMS_TIER = {
+  alto: {
+    burbujas: 44,
+    pulsos: 96,
+    humo: 26,
+    moscas: 14,
+    lombrices: 18,
+    segTubo: 20,
+    segRadial: 14,
+    invernadero: true,
+    montonMalo: true,
+    motasCarbono: 60,
+  },
+  medio: {
+    burbujas: 24,
+    pulsos: 48,
+    humo: 14,
+    moscas: 6,
+    lombrices: 9,
+    segTubo: 12,
+    segRadial: 10,
+    invernadero: true,
+    montonMalo: true,
+    motasCarbono: 24,
+  },
+  bajo: {
+    burbujas: 12,
+    pulsos: 0,
+    humo: 6,
+    moscas: 0,
+    lombrices: 4,
+    segTubo: 8,
+    segRadial: 8,
+    invernadero: false,
+    montonMalo: false,
+    motasCarbono: 0,
+  },
+};
+
+/** El presupuesto del tier (desconocido → frugal, nunca el caro). */
+export const paramsDeTier = (tier) => PARAMS_TIER[tier] || PARAMS_TIER.medio;
+
+/* ------------------------------------------------------------------ */
+/* EL ANILLO DEL CICLO — la tesis como geometría.                      */
+/* ------------------------------------------------------------------ */
+
+/* El radio del sendero circular y el ancho de los dos carriles. El carril de
+   AFUERA lleva el SÓLIDO (se camina con carretilla); el de ADENTRO lleva el
+   LÍQUIDO (escurre solo, por gravedad: por eso va por dentro y más bajo). */
+export const ANILLO = { radio: 6.4, carril: 0.7, ancho: 0.5 };
+
+/** Punto del anillo en el ángulo `a` (grados) y el carril `d` (offset radial). */
+export function puntoAnillo(a, d = 0, y = 0) {
+  const rad = (a * Math.PI) / 180;
+  const r = ANILLO.radio + d;
+  return new THREE.Vector3(Math.sin(rad) * r, y, Math.cos(rad) * r);
+}
+
+/*
+ * LAS ESTACIONES, en el orden en que el ciclo las visita. Los ángulos ponen a
+ * los dos héroes al FRENTE (donde mira la cámara) y mandan al animal al fondo:
+ * el que produce el problema está atrás; lo que hacemos con él, adelante.
+ *
+ * `nota` es contenido de identidad EN USTED (el corpus hablando), aquí para
+ * que el 3D y cualquier lámina 2D nombren la pieza IGUAL.
+ */
+export const ESTACIONES = [
+  {
+    id: 'corral',
+    ang: 200,
+    carril: 0,
+    etiqueta: 'el corral',
+    nota: 'Aquí nace el problema: el animal come y produce. Con cama profunda de material seco, el estiércol se absorbe en el sitio en vez de lavarse con manguera.',
+  },
+  {
+    id: 'separacion',
+    ang: 250,
+    carril: 0,
+    etiqueta: 'la rejilla',
+    nota: 'La mejora más rentable de todas: una pendiente suave y un canal. El líquido escurre solo hacia el biodigestor; el sólido queda arriba para recogerlo seco. Mezclados, se pudren juntos — y ahí nace el olor.',
+  },
+  {
+    id: 'biodigestor',
+    ang: 315,
+    carril: -ANILLO.carril,
+    etiqueta: 'el biodigestor',
+    nota: 'Una manga de polietileno enterrada en su zanja. Adentro, sin aire, unas bacterias se comen la materia y sueltan biogás para la estufa y biol para la huerta. No es magia: cuesta plata, trabajo y carga diaria.',
+  },
+  {
+    id: 'cocina',
+    /* `pos` explícita: la cocina NO vive en el anillo, vive pegada al
+       biodigestor (la manguera de gas tiene que ser corta). Es la posición de
+       mundo del grupo del biodigestor + su COCINA local. */
+    pos: [-6.18, 0.95, 7.28],
+    etiqueta: 'la llama azul',
+    nota: 'El momento que lo explica todo: la mierda de ayer cocinando el almuerzo de hoy. Bien quemado, el biogás arde AZUL. Y se respeta como una pipeta: nunca se busca una fuga con un fósforo, se busca con agua jabonosa.',
+  },
+  {
+    id: 'tanque',
+    ang: 0,
+    carril: -ANILLO.carril,
+    etiqueta: 'el tanque de biol',
+    nota: 'El biol no se aplica recién sale: reposa aquí y se aplica DILUIDO. La fermentación baja los patógenos, pero no es una sanitización completa.',
+  },
+  {
+    id: 'compostera',
+    ang: 40,
+    carril: ANILLO.carril,
+    etiqueta: 'la biocompostera',
+    nota: 'Tres cajones y un techo. El sólido entra en capas con material seco, calienta, se voltea, madura. Al final —solo al final— llega la lombriz.',
+  },
+  {
+    id: 'monton',
+    /* FUERA DEL ANILLO a propósito: de este montón la materia no vuelve al
+       suelo. Se va al aire. Es la única estación que no está en el círculo, y
+       esa es toda la lección. */
+    ang: 168,
+    carril: 2.3,
+    etiqueta: 'el montón mal llevado',
+    nota: 'Encharcado, sin carbono, sin techo y sin voltear. Apesta a amoníaco porque el nitrógeno se le está volando al aire — o sea, plata. Y tiene mosca, que no viene por el olor sino por el mismo material húmedo y blando. Fíjese que este montón está FUERA del círculo: de aquí nada vuelve al suelo.',
+  },
+  {
+    id: 'huerta',
+    ang: 75,
+    carril: 0,
+    etiqueta: 'el suelo',
+    nota: 'Aquí llegan los dos: el biol por el carril de adentro y el compost por el de afuera. El suelo es el que cobra.',
+  },
+  {
+    id: 'comida',
+    ang: 140,
+    carril: 0,
+    etiqueta: 'la comida',
+    nota: 'Lo que el suelo da vuelve al animal y a la mesa. Ahí el círculo cierra — y por eso el estiércol no es basura, es el principio.',
+  },
+];
+
+/** Una estación por id (para hotspots y cámara). */
+export const estacion = (id) => ESTACIONES.find((e) => e.id === id) || ESTACIONES[0];
+
+/** La posición de mundo de una estación (las de fuera del anillo traen `pos`). */
+export function posEstacion(id) {
+  const e = estacion(id);
+  if (e.pos) return new THREE.Vector3(...e.pos);
+  return puntoAnillo(e.ang, e.carril);
+}
+
+/*
+ * LOS TRAMOS del ciclo: cada uno es un arco del anillo con SU carga y SU color.
+ * Leídos juntos cuentan la frase completa. Los dos carriles corren en paralelo
+ * por el frente (la bifurcación de la rejilla) y se juntan otra vez en el suelo:
+ * eso es exactamente lo que enseña el corpus — separar en el origen, reunir en
+ * el suelo.
+ */
+export const TRAMOS = [
+  {
+    id: 'crudo',
+    desde: 200,
+    hasta: 250,
+    carril: 0,
+    color: PALETA_ESTIERCOL.estiercolFresco,
+    carga: 'el estiércol del día',
+  },
+  {
+    id: 'liquido',
+    desde: 250,
+    hasta: 315, // la rejilla → el biodigestor
+    carril: -ANILLO.carril,
+    color: PALETA_ESTIERCOL.purin,
+    carga: 'el líquido: escurre solo',
+  },
+  {
+    id: 'solido',
+    desde: 250,
+    hasta: 400, // la rejilla → (pasa de largo el biodigestor) → la compostera (40°)
+    carril: ANILLO.carril,
+    color: PALETA_ESTIERCOL.estiercolFresco,
+    carga: 'el sólido: se recoge seco',
+  },
+  {
+    id: 'biol',
+    desde: 315,
+    hasta: 435, // el biodigestor → el tanque (360°) → el suelo (75°)
+    carril: -ANILLO.carril,
+    color: PALETA_ESTIERCOL.biol,
+    carga: 'el biol: abono líquido',
+  },
+  {
+    id: 'compost',
+    desde: 400,
+    hasta: 435, // la compostera → el suelo
+    carril: ANILLO.carril,
+    color: PALETA_ESTIERCOL.compostMaduro,
+    carga: 'el compost: abono maduro',
+  },
+  {
+    id: 'cosecha',
+    desde: 435,
+    hasta: 500, // suelo → comida
+    carril: 0,
+    color: VERDES.brote,
+    carga: 'la comida',
+  },
+  {
+    id: 'vuelta',
+    desde: 500,
+    hasta: 560, // comida → corral: el círculo cierra
+    carril: 0,
+    color: VERDES.calido,
+    carga: 'y vuelve al animal',
+  },
+];
+
+/**
+ * La curva de un tramo, con la mano encima (un sendero de finca no es un
+ * compás). Determinista por el id del tramo.
+ * @returns {THREE.CatmullRomCurve3}
+ */
+export function curvaTramo(tramo, muestras = 14) {
+  const semilla = tramo.id.charCodeAt(0) + tramo.id.length * 13;
+  const pts = [];
+  for (let i = 0; i <= muestras; i += 1) {
+    const t = i / muestras;
+    const a = tramo.desde + (tramo.hasta - tramo.desde) * t;
+    /* el temblor va en el RADIO (el sendero serpentea), no en la altura */
+    const d = tramo.carril + manoAlzada(t * 3, { amplitud: 0.11, seed: semilla });
+    pts.push(puntoAnillo(a, d, 0.015));
+  }
+  return new THREE.CatmullRomCurve3(pts, false, 'catmullrom', 0.4);
+}
+
+/** El sendero de un tramo como tubo aplanado (una cinta pisada en la tierra). */
+export function geometriaTramo(tramo, params) {
+  const curva = curvaTramo(tramo);
+  const geo = new THREE.TubeGeometry(curva, params.segTubo * 2, ANILLO.ancho * 0.5, 4, false);
+  geo.scale(1, 0.09, 1); // aplastado: es un camino, no una manguera
+  return geo;
+}
+
+/*
+ * LOS PULSOS: la materia corriendo por el anillo. Cada uno lleva su tramo, su
+ * fase y su color. La escena los mueve por frame sobre la curva (un
+ * InstancedMesh para todos: un draw-call para el ciclo entero).
+ */
+export function pulsosDelCiclo(params, seed = 21) {
+  if (params.pulsos <= 0) return [];
+  const r = rng(seed);
+  const out = [];
+  const porTramo = Math.max(1, Math.round(params.pulsos / TRAMOS.length));
+  TRAMOS.forEach((tramo, ti) => {
+    const curva = curvaTramo(tramo);
+    for (let i = 0; i < porTramo; i += 1) {
+      out.push({
+        tramo: ti,
+        curva,
+        fase: (i + r() * 0.6) / porTramo,
+        vel: 0.055 + r() * 0.03,
+        escala: 0.055 + r() * 0.045,
+        color: new THREE.Color(tramo.color),
+      });
+    }
+  });
+  return out;
+}
+
+/* ------------------------------------------------------------------ */
+/* HUMO — la columna de partículas (vale para el vapor y el amoníaco).  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Una columna de humo: partículas con posición base, fase y escala. El tipo
+ * (`vapor` | `amoniaco`) decide el comportamiento en la escena — no es un
+ * color distinto del mismo efecto, es OTRO fenómeno (ver HUMOS).
+ */
+export function columnaHumo(origen, cantidad, tipo = 'vapor', seed = 31) {
+  const r = rng(seed);
+  const receta = HUMOS[tipo] || HUMOS.vapor;
+  const out = [];
+  for (let i = 0; i < cantidad; i += 1) {
+    out.push({
+      base: new THREE.Vector3(
+        origen[0] + (r() - 0.5) * 0.5,
+        origen[1],
+        origen[2] + (r() - 0.5) * 0.5,
+      ),
+      fase: r(),
+      vel: receta.subida * (0.7 + r() * 0.6),
+      deriva: (r() - 0.5) * receta.deriva,
+      giro: r() * Math.PI * 2,
+      escala: receta.escala[0] + r() * (receta.escala[1] - receta.escala[0]),
+    });
+  }
+  return out;
+}
+
+/* ------------------------------------------------------------------ */
+/* EL SUELO de la escena y el terreno de la finca.                      */
+/* ------------------------------------------------------------------ */
+
+/** La era donde vive todo: un disco de tierra pisada, ondulado con la mano. */
+export function eraGeom(radio = 8.6, seg = 30) {
+  const geo = new THREE.CircleGeometry(radio, seg);
+  geo.rotateX(-Math.PI / 2);
+  const pos = geo.attributes.position;
+  const r = rng(3);
+  const f = r() * 8;
+  for (let i = 0; i < pos.count; i += 1) {
+    const x = pos.getX(i);
+    const z = pos.getZ(i);
+    /* la era se hunde apenas hacia el borde: agua que corrió, pata que pisó */
+    pos.setY(i, Math.sin(x * 0.7 + f) * 0.035 + Math.cos(z * 0.55 + f) * 0.035);
+  }
+  pos.needsUpdate = true;
+  geo.computeVertexNormals();
+  return geo;
+}

--- a/src/visual/mundo3d/estiercol/index.js
+++ b/src/visual/mundo3d/estiercol/index.js
@@ -1,0 +1,68 @@
+/*
+ * estiercol/ — LA MIERDA VOLVIÉNDOSE GAS Y ABONO, en una sola puerta.
+ *
+ * El módulo del problema más real y menos glamoroso de la finca: el estiércol
+ * que apesta, cría mosca y pelea con el vecino. Dos piezas abiertas en canal
+ * (el biodigestor de manga y la biocompostera de tres cajones), el círculo que
+ * las une, y —afuera del círculo— el montón mal llevado soltando al aire la
+ * plata que se pierde.
+ *
+ * La verdad técnica sale de `Chagra-strategy/ops/corpus-maestros/
+ * teacher-cerdos-gallinas.jsonl` y está citada donde manda: cada cabecera dice
+ * qué regla del corpus obedece esa geometría. Si una lección cambia, se cambia
+ * ahí y aquí — no se maquilla.
+ *
+ * Uso (importar PEREZOSO: adentro vive three):
+ *
+ *   const EscenaEstiercol = lazy(() => import('../estiercol'));
+ *   <EscenaEstiercol tier={tier} reducedMotion={reducedMotion} />
+ *
+ * Las piezas se pueden montar sueltas dentro de OTRO `<Canvas>` (por ejemplo
+ * una lámina que solo quiera la manga en corte):
+ *
+ *   import { Biodigestor } from '../estiercol';
+ *   <Biodigestor perfil={perfilDeTier(tier)} params={paramsDeTier(tier)} clima="frio" />
+ *
+ * OJO con el corte: las piezas nacen cortadas en z=0 conservando la mitad de
+ * atrás. Se leen SOLO desde +Z — no las rote pensando que son modelos cerrados.
+ */
+export { default } from './EscenaEstiercol.jsx';
+export { default as EscenaEstiercol } from './EscenaEstiercol.jsx';
+
+export { default as Biodigestor } from './Biodigestor.jsx';
+export { default as Biocompostera, MontonMalLlevado } from './Biocompostera.jsx';
+export { default as CicloCerrado } from './CicloCerrado.jsx';
+
+/* el ADN compartido: paleta, tier, la mano que dibuja torcido y el anillo */
+export {
+  PALETA_ESTIERCOL,
+  HUMOS,
+  PARAMS_TIER,
+  paramsDeTier,
+  ANILLO,
+  ESTACIONES,
+  TRAMOS,
+  estacion,
+  posEstacion,
+  puntoAnillo,
+  manoAlzada,
+  torcerConLaMano,
+} from './estiercol.geom.js';
+
+/* la manga: medidas, física del sello de agua y régimen térmico */
+export {
+  MANGA,
+  NIVEL,
+  T_NIVEL,
+  ZANJA,
+  ENTRADA,
+  SALIDA,
+  VALVULA,
+  COCINA,
+  CLIMAS,
+  LLAMA,
+  fraccionLodo,
+} from './biodigestor.geom.js';
+
+/* la compostera: cajones, fases de temperatura y el contraejemplo */
+export { CAJON, FASES, GROSOR, MONTON_MALO, cajonX, capasDelMonton } from './compostera.geom.js';


### PR DESCRIPTION
## Qué aporta

Rescata `fable/biodigestor-15` (2026-07-15), **VIVA** en el triaje (`ops/TRIAJE-RAMAS-3D-2026-07-25.md`, #7 en orden de valor). Mundo 3D completo del biodigestor/biocompostera, 9 archivos: `Biodigestor.jsx`, `Biocompostera.jsx`, `CicloCerrado.jsx`, `EscenaEstiercol.jsx`, `biodigestor.geom.js`, `compostera.geom.js`, `estiercol.geom.js`, `estiercol.css`, `index.js`. Muestra el ciclo cerrado del estiércol (biodigestor + compostera en corte).

Parte de una serie numerada del mismo lote del 2026-07-15 (probablemente `queue/` 14-22): `ciclo-agua-14` y `diferencial-dano-18` ya tienen distinto estado; este (15), `olor-visible-16`, `red-bajo-glifosato-17`, `beneficos-21` y `semillas-criollas-22` quedaron completos y huérfanos — construidos y nunca cableados al router (patrón conocido "construido pero no cableado").

## Por qué estaba perdida

Sin PR, nunca integrada a `dev` por ningún camino (commit directo ni aplicación manual).

## Estado

- `npm run build` → **OK** (~44s).
- Merge sin conflictos — 9/9 archivos nuevos, dev nunca los tocó.
- Disponible pero **no cableado al router** (`src/config/rutasProdChagraApp.js`) ni al bundle — el mundo existe pero nadie puede navegar a él todavía.
- **NO mergeado.** Draft para revisión del operador.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>