### PR TITLE
rescate: fable/olor-visible-16 — el mundo sensorial que hace ver el amoniaco

### DIFF
--- a/src/visual/mundo3d/olor/CocheraEnCorte.jsx
+++ b/src/visual/mundo3d/olor/CocheraEnCorte.jsx
@@ -1,0 +1,249 @@
+/*
+ * CocheraEnCorte — la misma cochera, cortada por la mitad. Para el teléfono humilde.
+ *
+ * El equipo de gama baja no descarga three, pero NO se queda sin la pieza. Se
+ * lleva este corte, que pesa lo que un ícono y —esto es lo raro— cuenta el
+ * argumento MEJOR que la 3D.
+ *
+ * Porque el argumento de toda esta pieza es una ALTURA:
+ *
+ *   "Si a usted le arden los ojos al entrar al gallinero, la gallina lleva horas
+ *    así."
+ *
+ * Y un corte de perfil es exactamente el dibujo que un ingeniero hace cuando lo
+ * que importa es a qué altura está cada cosa. Acá la gallina, el cerdo y el
+ * dueño están parados sobre la misma línea de piso, a su estatura de verdad, y
+ * el velo de amoníaco es una franja con un borde que pasa por encima de ella y
+ * por debajo de él. No hay perspectiva, ni cámara, ni nada que interpretar: es
+ * una regla vertical y tres cabezas. Se entiende en un segundo y sin girar nada.
+ *
+ * La 3D deja meterse adentro y sentirlo; el corte lo deja ver de una. Son dos
+ * lecturas del mismo dato, no una versión pobre y una rica.
+ *
+ * EL MISMO MODELO. Este archivo importa `aire()` y `densidadEnAltura()` — las
+ * mismísimas funciones que mueven la escena 3D. No hay una "versión 2D" de la
+ * física con números aparte: si mañana se afina la curva del amoníaco, se afinan
+ * las dos a la vez. Es la regla de la casa (una sola fuente de verdad) y acá
+ * además evita que el corte y la escena se contradigan, que sería fatal en una
+ * pieza cuyo tema es "esto es lo que de verdad está pasando".
+ *
+ * SVG puro: cero three, cero canvas, cero costo. Corre en cualquier cosa.
+ */
+import { useMemo } from 'react';
+import { aire, densidadEnAltura, ALTURAS } from './aireCargado.js';
+import { COLORES } from './olor.geom.js';
+
+/* La escala del corte: 1 metro = 100 unidades de SVG. Un dibujo a escala, como
+   el del maestro de obra — porque de eso se trata. */
+const M = 100;
+const ALTO = 3.4 * M;
+const ANCHO = 7.2 * M;
+const PISO = ALTO - 0.35 * M; // deja aire abajo para la fosa
+
+/** metros → y del SVG */
+const y = (m) => PISO - m * M;
+
+/* Cuántas franjas dibuja el velo. Suficientes para que se lea el degradé y el
+   borde, pocas para que no pese. */
+const FRANJAS = 26;
+
+/**
+ * El corte de la cochera.
+ * @param {{ carbono?: number }} props
+ */
+export default function CocheraEnCorte({ carbono = 0 }) {
+  const a = useMemo(() => aire(carbono), [carbono]);
+
+  /* Las franjas del velo: cada una con la densidad REAL de su altura, sacada de
+     la misma curva que usa la escena 3D. El borde superior aparece solo. */
+  const franjas = useMemo(() => {
+    const arr = [];
+    const tope = a.alturaVelo * 1.45;
+    for (let i = 0; i < FRANJAS; i++) {
+      const m0 = (i / FRANJAS) * tope;
+      const m1 = ((i + 1) / FRANJAS) * tope;
+      const d = densidadEnAltura((m0 + m1) / 2, a.alturaVelo);
+      arr.push({ m0, m1, o: d * a.amoniaco * 0.62 });
+    }
+    return arr;
+  }, [a]);
+
+  /* Las motas de oro: subiendo, escalonadas. Las que no se van están sentadas
+     en la cama. El mismo reparto de la 3D — el oro se conserva. */
+  const motas = useMemo(() => {
+    const arr = [];
+    const n = 26;
+    for (let i = 0; i < n; i++) {
+      const u = (i + 0.5) / n;
+      const seVa = u < a.nitrogeno.aire;
+      /* Pseudoaleatorio estable: mismo dibujo en cada render. */
+      const rx = ((i * 73) % 100) / 100;
+      const ry = ((i * 137) % 100) / 100;
+      arr.push({
+        i,
+        seVa,
+        x: 0.85 * M + rx * 4.4 * M,
+        /* Si se va: repartida en toda la columna hasta el caballete y más allá.
+           Si se queda: sentada adentro del colchón. */
+        yM: seVa ? 0.1 + ry * 3.1 : (0.02 + carbono * 0.28) * (0.25 + ry * 0.6),
+        r: seVa ? 2.6 : 3.1,
+      });
+    }
+    return arr;
+  }, [a, carbono]);
+
+  const espesorCama = 0.02 + carbono * 0.28;
+
+  return (
+    <svg
+      className="ol__corte"
+      viewBox={`0 0 ${ANCHO} ${ALTO}`}
+      role="img"
+      aria-label={
+        a.amoniaco > 0.35
+          ? 'Corte de la cochera: el aire cargado de amoníaco se acuesta sobre la cama, a la altura de la cabeza de la gallina, mientras el nitrógeno se escapa por el caballete.'
+          : 'Corte de la cochera: con cama profunda el aire está limpio y el nitrógeno se queda guardado en el colchón.'
+      }
+    >
+      <defs>
+        {/* El cielo de la tarde de finca, ensuciándose con el olor. */}
+        <linearGradient id="olCielo" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#f6ead2" />
+          <stop offset="100%" stopColor={COLORES.velo} stopOpacity={0.25 + a.amoniaco * 0.5} />
+        </linearGradient>
+      </defs>
+
+      <rect x="0" y="0" width={ANCHO} height={ALTO} fill="url(#olCielo)" />
+
+      {/* ── La estructura, en línea: postes, techo a un agua, caballete ── */}
+      <g stroke={COLORES.poste} strokeWidth="7" strokeLinecap="round" fill="none" opacity="0.9">
+        <line x1={0.55 * M} y1={y(0)} x2={0.55 * M} y2={y(ALTURAS.caballete - 0.55)} />
+        <line x1={6.1 * M} y1={y(0)} x2={6.1 * M} y2={y(ALTURAS.caballete)} />
+        {/* Los dos faldones, con el hueco del caballete entre ellos. */}
+        <line x1={0.35 * M} y1={y(2.32)} x2={3.15 * M} y2={y(2.78)} strokeWidth="9" stroke={COLORES.techo} />
+        <line x1={3.55 * M} y1={y(2.72)} x2={6.35 * M} y2={y(3.05)} strokeWidth="9" stroke={COLORES.techo} />
+      </g>
+
+      {/* El muro bajo del frente, cortado: por encima de él sale el aire. */}
+      <rect x={0.4 * M} y={y(1.05)} width={0.14 * M} height={1.05 * M} fill={COLORES.muro} opacity="0.9" />
+
+      {/* ── EL VELO: franjas horizontales con su densidad real ──
+          Denso contra la cama, ralo arriba. El borde sale solo de la curva. */}
+      <g>
+        {franjas.map((f, i) => (
+          <rect
+            key={i}
+            x={0.5 * M}
+            y={y(f.m1)}
+            width={5.7 * M}
+            height={(f.m1 - f.m0) * M + 0.6}
+            fill={i < FRANJAS * 0.35 ? COLORES.veloHondo : COLORES.velo}
+            opacity={f.o}
+          />
+        ))}
+      </g>
+
+      {/* ── El piso y las camas ── */}
+      <rect x={0.35 * M} y={y(0)} width={5.9 * M} height={0.1 * M} fill={COLORES.piso} />
+      {/* La cama vencida: siempre debajo. */}
+      <rect x={0.5 * M} y={y(0.045)} width={5.6 * M} height={0.045 * M} fill={COLORES.camaSucia} />
+      {/* El colchón nuevo, que se levanta con el material seco. */}
+      {carbono > 0.01 && (
+        <rect
+          x={0.5 * M}
+          y={y(espesorCama)}
+          width={5.6 * M}
+          height={espesorCama * M}
+          fill={COLORES.camaSeca}
+          rx="2"
+        />
+      )}
+
+      {/* ── EL ORO ── */}
+      <g>
+        {motas.map((m) => (
+          <circle
+            key={m.i}
+            cx={m.x}
+            cy={y(m.yM)}
+            r={m.r}
+            fill={m.seVa ? COLORES.nitrogeno : COLORES.nitrogenoCama}
+            opacity={m.seVa ? 0.9 - (m.yM / 3.4) * 0.45 : 0.95}
+          />
+        ))}
+      </g>
+
+      {/* ── LOS CUERPOS, a su altura de verdad. El argumento entero. ──
+          Sin cotas ni flechas: tres siluetas paradas en el mismo piso. */}
+      <g fill={COLORES.cuerpo} opacity="0.85">
+        {/* La gallina: cabeza a 0.26 m. Adentro del velo. */}
+        <g transform={`translate(${1.5 * M}, ${y(0)}) scale(${M / 100})`}>
+          <path
+            d="M 0,0 L -3,0 C -14,-2 -20,-8 -19,-16 C -18,-23 -12,-27 -4,-26
+               C 0,-28 4,-30 6,-27 C 6,-31 9,-34 11,-31 C 13,-34 17,-32 16,-28
+               C 20,-27 21,-24 18,-23 L 23,-21 L 17,-20 C 15,-15 12,-11 8,-8
+               L 9,0 L 6,0 L 4,-7 C 1,-6 -1,-6 -3,-6 L -2,0 Z"
+            transform="scale(1,1)"
+          />
+        </g>
+        {/* El cerdo echado: la trompa a 0.38 m. Adentro también. */}
+        <g transform={`translate(${3.5 * M}, ${y(0)}) scale(${M / 100})`}>
+          <path
+            d="M -52,0 C -58,-12 -55,-24 -46,-30 C -30,-44 -5,-50 16,-46
+               C 20,-52 26,-53 29,-47 C 36,-46 42,-42 46,-36
+               C 54,-33 58,-30 57,-26 C 60,-24 59,-20 55,-19
+               C 50,-14 44,-10 36,-9 L 34,0 L 26,0 L 27,-10
+               C 10,-6 -10,-5 -28,-8 L -30,0 L -38,0 L -37,-9
+               C -45,-8 -50,-5 -52,0 Z"
+          />
+        </g>
+        {/* El dueño: la nariz a 1.58 m. Por encima del velo — y aun así le arde. */}
+        <g transform={`translate(${5.5 * M}, ${y(0)}) scale(${M / 100})`}>
+          <path
+            d="M -9,0 L 11,0 L 6,-6 C 5,-40 4,-60 6,-86
+               C 12,-90 14,-100 13,-112 C 13,-120 11,-130 10,-138
+               C 14,-140 16,-144 15,-148 C 16,-153 14,-156 12,-157
+               C 16,-160 17,-168 12,-172 C 6,-176 -2,-173 -3,-166
+               C -6,-162 -5,-157 -2,-155 C -8,-150 -10,-142 -10,-130
+               C -11,-115 -9,-100 -7,-88 C -11,-60 -12,-30 -9,0 Z"
+          />
+        </g>
+      </g>
+
+      {/*
+        LA LÍNEA DE FLOTACIÓN. Lo único que se dibuja "de más" en todo el corte:
+        una raya punteada tenue en el borde del velo. No es una cota ni lleva
+        número — es la superficie del agua en la que la gallina vive ahogada y
+        el dueño tiene la cabeza afuera. Solo aparece cuando hay algo que ver.
+      */}
+      {a.amoniaco > 0.12 && (
+        <line
+          x1={0.5 * M}
+          y1={y(a.alturaVelo)}
+          x2={6.2 * M}
+          y2={y(a.alturaVelo)}
+          stroke={COLORES.veloHondo}
+          strokeWidth="1.5"
+          strokeDasharray="7 6"
+          opacity={0.28 + a.amoniaco * 0.3}
+        />
+      )}
+
+      {/* ── La fosa, abajo a la izquierda: el que calla ──
+          Sin espectáculo. Una mancha quieta en un hueco. */}
+      <g>
+        <rect x={0.06 * M} y={y(0)} width={0.28 * M} height={0.34 * M} fill={COLORES.lodo} opacity="0.5" />
+        {a.sulfhidrico > 0.02 && (
+          <rect
+            x={0.06 * M}
+            y={y(0.02)}
+            width={0.28 * M}
+            height={0.16 * M}
+            fill={COLORES.sulfhidrico}
+            opacity={a.sulfhidrico * 0.75}
+          />
+        )}
+      </g>
+    </svg>
+  );
+}

--- a/src/visual/mundo3d/olor/EscenaOlorVisible.jsx
+++ b/src/visual/mundo3d/olor/EscenaOlorVisible.jsx
@@ -1,0 +1,429 @@
+/*
+ * EscenaOlorVisible — la misma cochera, dos veces.
+ *
+ * Una cochera. Un bulto de cascarilla arrimado al poste. Nada más.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * POR QUÉ ES LA MISMA COCHERA Y NO DOS
+ *
+ * El antes/después de las cartillas se dibuja en dos viñetas: a la izquierda la
+ * cochera del descuidado, a la derecha la del que hace las cosas bien. Y no
+ * enseña nada, porque el que mira ve dos fincas: la suya y la de un señor con
+ * plata. "A ese le alcanza".
+ *
+ * Acá hay UNA. La misma cámara, el mismo cerdo, el mismo bebedero rebosado, el
+ * mismo dueño parado en la puerta. Lo único que se mueve es cuánto material seco
+ * hay en la cama. Y eso convierte el después en una promesa concreta: no es otra
+ * finca — es ESTA finca el mes entrante. El contraste enseña porque el sujeto
+ * no cambia.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * TODO CUELGA DE UN NÚMERO
+ *
+ * `aire(carbono)` decide el velo, el oro, las moscas, el charco, la nube del
+ * vecino, el pozo, el fog y hasta el espesor del colchón. No hay dos escenas
+ * iluminadas a mano ni un estado "sucio" y otro "limpio": hay una cantidad de
+ * aserrín y sus consecuencias, calculadas. Igual que en la ladera de
+ * restauración todo colgaba de `dosel(anio)`.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * LA CÁMARA — y por qué se puede agachar
+ *
+ * Arranca a metro y medio del piso: la altura de los ojos del que llega a mirar
+ * su cochera. Desde ahí el velo se ve de lejos, un poco sucio, "no es para
+ * tanto".
+ *
+ * Pero `maxPolarAngle` llega casi a la horizontal, y eso es deliberado: uno
+ * puede arrastrar el dedo hacia abajo y AGACHARSE hasta quedar a la altura de la
+ * gallina. Cuando lo hace, la lámina de aire sucio le queda a la altura de los
+ * ojos y la escena entera se ensucia. No hay texto que diga "así vive ella":
+ * hay que ponerse ahí. Es la frase del maestro convertida en un gesto de la
+ * mano —
+ *
+ *   "Si a usted le arden los ojos al entrar al gallinero, la gallina lleva
+ *    horas así."
+ *
+ * — y creo que es lo mejor que tiene esta pieza.
+ *
+ * La cámara no gira sola: acá el que se mueve es el manejo, no el punto de
+ * vista. Y el encuadre inicial trae los tres actos en una sola toma: la fosa en
+ * primer plano (el que calla), la cochera en el medio (el que roba) y la casa
+ * del vecino al fondo (el que reclama).
+ *
+ * Importa three/@react-three → montar SOLO perezosa (lazy) desde el host.
+ */
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import * as THREE from 'three';
+import { perfilDeTier } from '../deviceTier.js';
+import { LuzMadre, CIELOS, mezclarCielo, crearMaterialVertexColors } from '../paleta/index.js';
+import { aire, olorDeTier } from './aireCargado.js';
+import {
+  COLORES,
+  geomPiso,
+  geomCamaSucia,
+  geomCamaBuena,
+  geomEstructura,
+  geomBebedero,
+  geomCharco,
+  geomFosa,
+  geomFosaLiquido,
+  geomCerca,
+  geomCasaVecino,
+  geomBulto,
+  geomPala,
+  geomCuerpos,
+  geomPatio,
+} from './olor.geom.js';
+import VeloQuePesa from './VeloQuePesa.jsx';
+import NitrogenoQueSeVa from './NitrogenoQueSeVa.jsx';
+import MoscasDelCharco from './MoscasDelCharco.jsx';
+import PozoQueCalla from './PozoQueCalla.jsx';
+import NubeQueCruzaLaCerca from './NubeQueCruzaLaCerca.jsx';
+
+/* El espesor del colchón cuando está bien hecho (coincide con geomCamaBuena). */
+const CAMA_ALTA = 0.28;
+
+/* -------------------------------------------------------------------------- */
+/*  El reloj: la única variable de la pieza                                    */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Lleva el carbono hacia donde pide el control, pero SUAVE — y despacio a
+ * propósito (3.0, no 8). Sin esto, soltar el deslizador en "cama profunda"
+ * apagaría el olor de un golpe: un truco de magia, un producto milagroso. Con
+ * esto, el oro se va SENTANDO mota por mota y el velo se va HUNDIENDO, que es
+ * como pasa de verdad:
+ *
+ *   "Esos cambios reducen el olor de forma progresiva a medida que la cama nueva
+ *    reemplaza la vieja y el compostaje va tomando ritmo, no de un día para otro
+ *    con un producto mágico."
+ *
+ * El `aireRef` es un ref y no estado de React: cambia 60 veces por segundo y no
+ * puede estar re-renderizando el árbol. La escena lo lee sola.
+ */
+function Reloj({ carbonoRef, aireRef, camaRef, objetivo, reducedMotion }) {
+  const { invalidate } = useThree();
+
+  useEffect(() => {
+    if (!reducedMotion) return;
+    carbonoRef.current = objetivo;
+    aireRef.current = aire(objetivo);
+    camaRef.current = 0.02 + objetivo * CAMA_ALTA;
+    invalidate();
+  }, [objetivo, reducedMotion, carbonoRef, aireRef, camaRef, invalidate]);
+
+  useFrame((_, dt) => {
+    if (reducedMotion) return;
+    const d = objetivo - carbonoRef.current;
+    if (Math.abs(d) > 0.0005) {
+      carbonoRef.current += d * Math.min(1, dt * 3.0);
+    } else {
+      carbonoRef.current = objetivo;
+    }
+    aireRef.current = aire(carbonoRef.current);
+    camaRef.current = 0.02 + carbonoRef.current * CAMA_ALTA;
+  });
+
+  return null;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  La atmósfera: el aire cargado se come el color                             */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Acá está la mitad de la incomodidad de la pieza, y no la pone el gas: la pone
+ * el FOG.
+ *
+ * Cuando la cochera huele, la niebla de la escena se acerca y se ensucia hacia
+ * el turbio del velo. No es "hay una nube fea en un rincón": es que TODA la
+ * escena —la cerca, el patio, la casa del vecino, el cerdo— se ve enferma,
+ * lavada, sin color. El aire malo no es un objeto en el cuarto: es el cuarto.
+ *
+ * Y al echar el material seco, la niebla se destapa y se va lejos, y de golpe
+ * vuelven los verdes y el dorado de la tarde de finca (`CIELOS.corral`). Ese
+ * regreso del color es la recompensa de la pieza y no cuesta un solo objeto
+ * nuevo: es la misma escena, respirando.
+ */
+function Atmosfera({ aireRef, perfil }) {
+  const { scene } = useThree();
+
+  const c = useMemo(() => {
+    const limpio = mezclarCielo(CIELOS.corral);
+    return {
+      fondoLimpio: new THREE.Color(limpio.fondo),
+      fondoSucio: new THREE.Color(COLORES.velo),
+      nieblaLimpia: new THREE.Color(limpio.niebla),
+      nieblaSucia: new THREE.Color(COLORES.veloHondo),
+      fondo: new THREE.Color(limpio.fondo),
+      limpio,
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    scene.background = c.fondo;
+    if (perfil.fog) scene.fog = new THREE.Fog(c.nieblaLimpia.getHex(), 14, 60);
+    return () => {
+      scene.fog = null;
+      scene.background = null;
+    };
+  }, [scene, c, perfil.fog]);
+
+  useFrame(() => {
+    const a = aireRef.current;
+    if (!a) return;
+    /* El fondo se ensucia solo un poco (0.42): el cielo no es el problema, pero
+       tampoco puede quedar impecable mientras abajo no se respira. */
+    c.fondo.copy(c.fondoLimpio).lerp(c.fondoSucio, a.amoniaco * 0.42);
+    if (scene.fog && 'near' in scene.fog) {
+      const f = /** @type {THREE.Fog} */ (scene.fog);
+      f.color.copy(c.nieblaLimpia).lerp(c.nieblaSucia, a.amoniaco * 0.72);
+      /* Con olor, el aire se cierra: se ve hasta la cerca y no más. Sin olor,
+         se ve hasta el otro lado del valle. La finca se agranda al respirar. */
+      f.near = 14 - a.amoniaco * 11;
+      f.far = 60 - a.amoniaco * 34;
+    }
+  });
+
+  return null;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  La materia                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Todas las mallas de la cochera son geometrías fusionadas con el color horneado
+ * en los vértices → UN material para casi todo, una draw-call por pieza. El
+ * patrón de floraParamo/fincaRealista, calcado. La gama baja también tiene
+ * cochera.
+ */
+function Cochera({ perfil, aireRef, camaRef }) {
+  const mat = useMemo(() => crearMaterialVertexColors(perfil), [perfil]);
+
+  /* Las siluetas son MeshBasic: tinta plana, sin luz. Son sombras con altura,
+     no cuerpos con volumen — si les pegara la luz serían personajes. */
+  const matSilueta = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        vertexColors: true,
+        side: THREE.DoubleSide,
+        transparent: true,
+        opacity: 0.82,
+        fog: true,
+      }),
+    [],
+  );
+
+  /* El charco aparece y desaparece con la humedad → material propio. */
+  const matCharco = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        vertexColors: true,
+        transparent: true,
+        opacity: 0,
+        depthWrite: false,
+        fog: true,
+      }),
+    [],
+  );
+
+  const g = useMemo(
+    () => ({
+      patio: geomPatio(),
+      piso: geomPiso(),
+      camaSucia: geomCamaSucia(),
+      camaBuena: geomCamaBuena(),
+      estructura: geomEstructura(),
+      bebedero: geomBebedero(),
+      charco: geomCharco(),
+      fosa: geomFosa(),
+      fosaLiquido: geomFosaLiquido(),
+      cerca: geomCerca(),
+      casa: geomCasaVecino(),
+      bulto: geomBulto(),
+      pala: geomPala(),
+      cuerpos: geomCuerpos(),
+    }),
+    [],
+  );
+
+  const camaBuena = useRef(null);
+  const charco = useRef(null);
+
+  useLayoutEffect(
+    () => () => {
+      mat.dispose();
+      matSilueta.dispose();
+      matCharco.dispose();
+      Object.values(g).forEach((x) => x && x.dispose());
+    },
+    [mat, matSilueta, matCharco, g],
+  );
+
+  useFrame(() => {
+    const a = aireRef.current;
+    if (!a) return;
+    /*
+     * EL COLCHÓN CRECE. No hay crossfade entre "cama sucia" y "cama buena": la
+     * cama buena se LEVANTA desde el piso, tapando la vieja, porque así es como
+     * pasa — el material seco se echa ENCIMA, no reemplaza nada. La cama vieja
+     * sigue ahí abajo, volviéndose abono.
+     */
+    if (camaBuena.current) {
+      const s = Math.max(0.008, a.carbono);
+      camaBuena.current.scale.y = s;
+      camaBuena.current.visible = a.carbono > 0.01;
+    }
+    /* El charco: hijo del agua de más, igual que las moscas. */
+    if (charco.current) {
+      charco.current.material.opacity = Math.max(0, (a.saturacion - 0.18) / 0.82) * 0.9;
+      charco.current.visible = charco.current.material.opacity > 0.01;
+    }
+  });
+
+  return (
+    <group>
+      <mesh geometry={g.patio} material={mat} receiveShadow={perfil.sombras} />
+      <mesh geometry={g.piso} material={mat} receiveShadow={perfil.sombras} />
+
+      {/* La cama vencida: siempre ahí, debajo de todo. */}
+      <mesh geometry={g.camaSucia} material={mat} receiveShadow={perfil.sombras} />
+      {/* El colchón nuevo, que se levanta con el carbono. */}
+      <mesh ref={camaBuena} geometry={g.camaBuena} material={mat} receiveShadow={perfil.sombras} />
+
+      <mesh geometry={g.estructura} material={mat} castShadow={perfil.sombras} receiveShadow={perfil.sombras} />
+      <mesh geometry={g.bebedero} material={mat} castShadow={perfil.sombras} />
+      <mesh ref={charco} geometry={g.charco} material={matCharco} renderOrder={1} />
+
+      {/* La fosa y su líquido quieto. */}
+      <mesh geometry={g.fosa} material={mat} receiveShadow={perfil.sombras} />
+      <mesh geometry={g.fosaLiquido} material={mat} />
+
+      {/* El lindero y lo que hay del otro lado. */}
+      <mesh geometry={g.cerca} material={mat} castShadow={perfil.sombras} />
+      <mesh geometry={g.casa} material={mat} castShadow={perfil.sombras} />
+
+      {/* El remedio, arrimado al poste desde el principio. */}
+      <mesh geometry={g.bulto} material={mat} castShadow={perfil.sombras} />
+      <mesh geometry={g.pala} material={mat} />
+
+      {/* Los cuerpos, cada uno a su altura de verdad. */}
+      <mesh geometry={g.cuerpos} material={matSilueta} renderOrder={6} />
+    </group>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  El diorama                                                                 */
+/* -------------------------------------------------------------------------- */
+
+function Diorama({ carbono, tier, reducedMotion }) {
+  const perfil = perfilDeTier(tier);
+  const conteos = olorDeTier(tier);
+
+  const carbonoRef = useRef(carbono);
+  const aireRef = useRef(aire(carbono));
+  const camaRef = useRef(0.02 + carbono * CAMA_ALTA);
+
+  return (
+    <>
+      {/* Primero el reloj: pone el aire antes de que nadie lo lea. */}
+      <Reloj
+        carbonoRef={carbonoRef}
+        aireRef={aireRef}
+        camaRef={camaRef}
+        objetivo={carbono}
+        reducedMotion={reducedMotion}
+      />
+      <Atmosfera aireRef={aireRef} perfil={perfil} />
+      {/* La luz de la casa, sin calcar números: tarde de finca. */}
+      <LuzMadre cielo={CIELOS.corral} perfil={perfil} />
+
+      <Cochera perfil={perfil} aireRef={aireRef} camaRef={camaRef} />
+
+      {/* El amoníaco: se acuesta sobre la cama y tiene un borde. */}
+      <VeloQuePesa aireRef={aireRef} n={conteos.estratos} reducedMotion={reducedMotion} />
+
+      {/* El oro: o sube y se pierde, o se sienta en la cama. Nunca desaparece. */}
+      <NitrogenoQueSeVa
+        aireRef={aireRef}
+        camaRef={camaRef}
+        n={conteos.motas}
+        reducedMotion={reducedMotion}
+      />
+
+      {/* Las moscas: hijas de la humedad, no del olor. */}
+      <MoscasDelCharco aireRef={aireRef} n={conteos.moscas} reducedMotion={reducedMotion} />
+
+      {/* El que calla, en el hueco. */}
+      <PozoQueCalla aireRef={aireRef} />
+
+      {/* Lo que cruza el lindero, y tarda en dejar de cruzarlo. */}
+      <NubeQueCruzaLaCerca aireRef={aireRef} reducedMotion={reducedMotion} />
+
+      {/*
+        Sin autoRotate: el que se mueve acá es el manejo, no el punto de vista.
+        `maxPolarAngle` casi horizontal (1.53) es LA decisión de esta escena:
+        deja que uno se agache hasta la altura de la gallina y respire lo que
+        ella respira. `target` a 0.55 m — no al centro geométrico de la cochera,
+        sino a la altura de la cama, que es de lo que trata todo esto.
+      */}
+      <OrbitControls
+        makeDefault
+        target={[-0.6, 0.55, 1.2]}
+        enablePan={false}
+        enableZoom
+        minDistance={4}
+        maxDistance={20}
+        minPolarAngle={0.35}
+        maxPolarAngle={1.53}
+        enableDamping
+        dampingFactor={0.08}
+        autoRotate={false}
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * La cochera y su aire. Montar SOLO perezosa (lazy).
+ *
+ * @param {{
+ *   carbono?: number,
+ *   tier?: 'alto'|'medio'|'bajo',
+ *   reducedMotion?: boolean,
+ * }} props  `carbono`: 0 = piso pelado lavado con manguera · 1 = cama profunda.
+ */
+export default function EscenaOlorVisible({ carbono = 0, tier = 'alto', reducedMotion = false }) {
+  const perfil = perfilDeTier(tier);
+  const [listo, setListo] = useState(false);
+
+  /*
+   * La cámara arranca donde se para el que llega a mirar su cochera: a metro y
+   * medio, un poco de lado. Desde acá entran los tres actos en una toma — la
+   * fosa cerca (el que calla), la cochera en el medio (el que roba) y la casa
+   * del vecino al fondo (el que reclama).
+   */
+  const camara = useMemo(
+    () => ({ position: /** @type {[number, number, number]} */ ([-7.4, 1.55, 6.8]), fov: 48 }),
+    [],
+  );
+
+  return (
+    <Canvas
+      className={`olor-canvas${listo ? ' olor-canvas--lista' : ''}`}
+      dpr={perfil.dpr}
+      gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
+      shadows={perfil.sombras ? 'soft' : false}
+      camera={camara}
+      frameloop={reducedMotion ? 'demand' : 'always'}
+      onCreated={() => setListo(true)}
+    >
+      <Diorama carbono={carbono} tier={tier} reducedMotion={reducedMotion} />
+    </Canvas>
+  );
+}

--- a/src/visual/mundo3d/olor/MoscasDelCharco.jsx
+++ b/src/visual/mundo3d/olor/MoscasDelCharco.jsx
@@ -1,0 +1,143 @@
+/*
+ * MoscasDelCharco — las moscas. Y de dónde salen DE VERDAD.
+ *
+ * "Las moscas no vienen atraídas por el olor en sí, sino por el mismo material
+ *  húmedo, blando y rico en materia orgánica donde ese olor se produce: ahí
+ *  ponen sus huevos y las larvas se desarrollan en pocos días. (...) Si tiene
+ *  mucho olor, casi con seguridad también tiene mucha mosca; son la misma causa."
+ *
+ * EL DETALLE QUE HACE HONESTA ESTA ESCENA: acá las moscas cuelgan de
+ * `aire.saturacion` —el material empapado—, NO de `aire.amoniaco`. Se ve en la
+ * primera línea del useFrame y es la diferencia entre enseñar y decorar.
+ *
+ * Si colgaran del olor, la escena diría "las moscas vienen por la peste" — que
+ * es lo que todo el mundo cree, y es falso. Vienen por el material húmedo y
+ * blando donde ponen los huevos. El olor y la mosca son PRIMOS, no padre e hijo:
+ * comparten mamá, que es el agua de más.
+ *
+ * Y de ahí sale todo lo demás sin necesidad de explicarlo:
+ *   · Por qué fumigar no sirve — "mata las moscas adultas de ese momento, pero
+ *     si no cambia el manejo del estiércol, en pocos días vuelve a haber otra
+ *     generación". Se mata a las de hoy; la cama sigue siendo criadero.
+ *   · Por qué el mismo puñado de aserrín apaga el olor Y la mosca de un solo
+ *     golpe: les quita a las dos la mamá.
+ *
+ * Nacen en el charco del bebedero, que es donde el maestro dice que nacen
+ * ("aunque el resto de la cama esté seca"), y no repartidas parejo por la
+ * escena como confeti.
+ *
+ * El movimiento es RÁPIDO y quebrado, a propósito: es lo único nervioso de una
+ * pieza donde todo lo demás pesa y se arrastra. El velo agobia; la mosca
+ * exaspera. Son las dos formas de la misma incomodidad.
+ *
+ * Barato: un THREE.Points negro, sin textura, y `setDrawRange` para que se
+ * vayan yendo de a una.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { rng } from '../bosque/entQuenua.geom.js';
+import { COLORES, BEBEDERO } from './olor.geom.js';
+
+/**
+ * @param {{ aireRef: { current: any }, n?: number, reducedMotion?: boolean }} props
+ */
+export default function MoscasDelCharco({ aireRef, n = 26, reducedMotion = false }) {
+  const puntos = useRef(null);
+
+  /*
+   * Cada mosca ronda un punto propio cerca del charco, con tres frecuencias
+   * primas entre sí. Eso es lo que da el vuelo quebrado: nunca repite el mismo
+   * lazo, y el ojo no le encuentra el patrón (que es exactamente lo que
+   * enloquece de una mosca de verdad).
+   */
+  const moscas = useMemo(() => {
+    const r = rng(707);
+    const cx = new Float32Array(n);
+    const cy = new Float32Array(n);
+    const cz = new Float32Array(n);
+    const radio = new Float32Array(n);
+    const f1 = new Float32Array(n);
+    const f2 = new Float32Array(n);
+    const f3 = new Float32Array(n);
+    const fase = new Float32Array(n);
+    for (let i = 0; i < n; i++) {
+      /* Racimo apretado sobre el charco, con unas pocas dispersas. */
+      const lejos = r() < 0.22;
+      const ang = r() * Math.PI * 2;
+      const rad = (lejos ? 1.3 + r() * 1.9 : Math.sqrt(r()) * 0.95);
+      cx[i] = BEBEDERO.x + Math.cos(ang) * rad;
+      cz[i] = BEBEDERO.z + Math.sin(ang) * rad;
+      cy[i] = 0.09 + r() * 0.5;
+      radio[i] = 0.09 + r() * 0.22;
+      f1[i] = 2.2 + r() * 3.1;
+      f2[i] = 1.7 + r() * 2.6;
+      f3[i] = 3.1 + r() * 4.2;
+      fase[i] = r() * 100;
+    }
+    return { cx, cy, cz, radio, f1, f2, f3, fase };
+  }, [n]);
+
+  const geo = useMemo(() => {
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.BufferAttribute(new Float32Array(n * 3), 3));
+    g.boundingSphere = new THREE.Sphere(new THREE.Vector3(BEBEDERO.x, 0.5, BEBEDERO.z), 5);
+    return g;
+  }, [n]);
+
+  const mat = useMemo(
+    () =>
+      new THREE.PointsMaterial({
+        size: 0.032,
+        color: COLORES.mosca, // tinta: negro cálido de la casa, nunca negro puro
+        transparent: true,
+        opacity: 0.9,
+        depthWrite: false,
+        sizeAttenuation: true,
+        fog: false,
+      }),
+    [],
+  );
+
+  useLayoutEffect(
+    () => () => {
+      geo.dispose();
+      mat.dispose();
+    },
+    [geo, mat],
+  );
+
+  useFrame((state) => {
+    const p = puntos.current;
+    const a = aireRef.current;
+    if (!p || !a) return;
+
+    /*
+     * LA LÍNEA. Las moscas siguen al AGUA, no al olor. Cambiar
+     * `a.moscas` (que sale de la saturación) por `a.amoniaco` acá sería repetir
+     * la creencia que esta pieza vino a corregir.
+     */
+    const cuantas = Math.round(n * a.moscas);
+    geo.setDrawRange(0, cuantas);
+    p.visible = cuantas > 0;
+    if (!p.visible) return;
+
+    /* Con movimiento reducido: la nube se queda quieta, pero sigue estando.
+       El problema no es la animación — es la cantidad. */
+    const t = reducedMotion ? 3.2 : state.clock.elapsedTime;
+    const pos = geo.attributes.position.array;
+
+    for (let i = 0; i < cuantas; i++) {
+      const j = i * 3;
+      const ph = moscas.fase[i];
+      /* Tres senos desalineados: el lazo que nunca cierra. */
+      pos[j] = moscas.cx[i] + Math.sin(t * moscas.f1[i] + ph) * moscas.radio[i];
+      pos[j + 1] =
+        moscas.cy[i] + Math.sin(t * moscas.f3[i] + ph * 1.7) * moscas.radio[i] * 0.55;
+      pos[j + 2] = moscas.cz[i] + Math.cos(t * moscas.f2[i] + ph * 0.6) * moscas.radio[i];
+    }
+    geo.attributes.position.needsUpdate = true;
+  });
+
+  return <points ref={puntos} geometry={geo} material={mat} frustumCulled={false} />;
+}

--- a/src/visual/mundo3d/olor/NitrogenoQueSeVa.jsx
+++ b/src/visual/mundo3d/olor/NitrogenoQueSeVa.jsx
@@ -1,0 +1,226 @@
+/*
+ * NitrogenoQueSeVa — el oro. La pieza que tiene que doler.
+ *
+ * "Ese olor fuerte es nitrógeno que se le está volando al aire, o sea plata que
+ *  se le está yendo, porque ese mismo nitrógeno podría quedar en abono para la
+ *  huerta."
+ *
+ * "Cada bocanada de amoníaco que se le vuela es menos abono para sus cultivos y
+ *  más plata que tuvo que gastar en fertilizante comprado."
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * POR QUÉ ES DORADO Y NO VERDE
+ *
+ * Acá se juega la pieza entera. Si el amoníaco se pinta verde-tóxico, el
+ * mensaje que llega es "hay veneno en su cochera, sáquelo". Cierto pero inútil:
+ * el campesino ya sabe que huele feo y aprendió a vivir con eso, porque cree que
+ * es el precio de tener marranos.
+ *
+ * Estas motas son del color del GRANO DE MAÍZ (`ACENTOS.maizGrano`, el mismo
+ * amarillo de la mazorca en la paleta de la casa). Porque eso es lo que son: el
+ * nitrógeno que el animal ya comió y que el dueño ya pagó en el bulto de
+ * concentrado, subiendo y saliéndose por el caballete. No es un gas: es la
+ * cosecha del año entrante evaporándose.
+ *
+ * Duele porque es bonito y se va.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * LA CONSERVACIÓN — por qué es UN solo sistema de partículas
+ *
+ * Hay UN arreglo de motas. No dos. El nitrógeno no se crea ni se destruye:
+ *
+ *     nitrogeno.aire + nitrogeno.cama = 1
+ *
+ * Cada mota tiene un número `u` fijo entre 0 y 1, y lo compara con cuánto
+ * nitrógeno se está volando. Si su `u` cae del lado del aire, sube y se pierde.
+ * Si cae del lado de la cama, se sienta adentro del colchón y brilla ahí, más
+ * honda y más quieta — abono.
+ *
+ * Cuando uno echa material seco, no aparecen motas nuevas ni desaparecen las
+ * viejas: LAS MISMAS MOTAS SE SIENTAN. Una por una, empiezan a caer del cielo a
+ * la cama, como si la cochera se las estuviera tragando de vuelta. Ese es el
+ * único momento didáctico de la pieza y no lleva una sola palabra: el oro no
+ * desapareció, cambió de lugar. Estaba en el aire, ahora está en el suelo, y
+ * mañana está en la huerta.
+ *
+ * Barato: un THREE.Points, una draw-call, textura de canvas. Corre en gama baja.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { rng } from '../bosque/entQuenua.geom.js';
+import { COLORES, COCHERA } from './olor.geom.js';
+import { ALTURAS, rampa } from './aireCargado.js';
+import { texturaMota } from './texturasOlor.js';
+
+/* Hasta dónde sube antes de perderse del todo. Pasa el caballete: la fuga no
+   termina en el techo — termina donde uno ya no puede hacer nada. */
+const CIELO = 4.6;
+
+/**
+ * El nitrógeno, como motas de oro.
+ *
+ * @param {{
+ *   aireRef: { current: any },
+ *   n?: number,
+ *   camaRef?: { current: number },
+ *   reducedMotion?: boolean,
+ * }} props
+ */
+export default function NitrogenoQueSeVa({ aireRef, n = 420, camaRef, reducedMotion = false }) {
+  const puntos = useRef(null);
+  const tex = useMemo(() => texturaMota(), []);
+
+  /*
+   * Las motas. Cada una nace con:
+   *   u     — su lugar en la fila. Decide si se va o se queda. NUNCA cambia:
+   *           lo que cambia es el umbral, o sea el manejo de la cochera.
+   *   x,z   — dónde vive en la cama. Sesgadas hacia el charco del bebedero y la
+   *           zona donde se echa el cerdo: el nitrógeno tiene domicilio.
+   *   vel   — qué tan rápido sube (las hay livianas y pesadas).
+   *   fase  — para que no suban todas en fila india.
+   */
+  const motas = useMemo(() => {
+    const r = rng(303);
+    const u = new Float32Array(n);
+    const bx = new Float32Array(n);
+    const bz = new Float32Array(n);
+    const vel = new Float32Array(n);
+    const fase = new Float32Array(n);
+    for (let i = 0; i < n; i++) {
+      u[i] = r();
+      /* Reparto en la huella de la cama, con un sesgo hacia el bebedero. */
+      const haciaCharco = r() < 0.3;
+      if (haciaCharco) {
+        const ang = r() * Math.PI * 2;
+        const rad = Math.sqrt(r()) * 1.05;
+        bx[i] = -1.5 + Math.cos(ang) * rad;
+        bz[i] = 1.15 + Math.sin(ang) * rad;
+      } else {
+        bx[i] = (r() - 0.5) * (COCHERA.ancho - 0.7);
+        bz[i] = (r() - 0.5) * (COCHERA.fondo - 0.6);
+      }
+      vel[i] = 0.16 + r() * 0.26;
+      fase[i] = r();
+    }
+    return { u, bx, bz, vel, fase };
+  }, [n]);
+
+  const geo = useMemo(() => {
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.BufferAttribute(new Float32Array(n * 3), 3));
+    g.setAttribute('color', new THREE.BufferAttribute(new Float32Array(n * 3), 3));
+    /* La caja de recorte a mano: las motas se mueven solas y three no puede
+       adivinar el bulto. Sin esto parpadean al salir del frustum calculado. */
+    g.boundingSphere = new THREE.Sphere(new THREE.Vector3(0, CIELO / 2, 0), 12);
+    return g;
+  }, [n]);
+
+  const mat = useMemo(
+    () =>
+      new THREE.PointsMaterial({
+        size: 0.055,
+        map: tex,
+        vertexColors: true,
+        transparent: true,
+        opacity: 0.95,
+        depthWrite: false,
+        sizeAttenuation: true,
+        /* NormalBlending y no additive: el cielo del valle es claro y el
+           additive se lavaría justo cuando el oro tiene que verse. Además el
+           oro no es luz, es MATERIA — grano, abono. Debe pesar. */
+        blending: THREE.NormalBlending,
+        fog: false,
+      }),
+    [tex],
+  );
+
+  /* Los tres colores del viaje del oro. */
+  const cCama = useMemo(() => new THREE.Color(COLORES.nitrogenoCama), []);
+  const cAire = useMemo(() => new THREE.Color(COLORES.nitrogeno), []);
+  const cFuga = useMemo(() => new THREE.Color(COLORES.nitrogenoFuga), []);
+  const tmp = useMemo(() => new THREE.Color(), []);
+
+  useLayoutEffect(
+    () => () => {
+      tex.dispose();
+      geo.dispose();
+      mat.dispose();
+    },
+    [tex, geo, mat],
+  );
+
+  useFrame((state) => {
+    const p = puntos.current;
+    const a = aireRef.current;
+    if (!p || !a) return;
+
+    const t = reducedMotion ? 8 : state.clock.elapsedTime;
+    const pos = geo.attributes.position.array;
+    const col = geo.attributes.color.array;
+    /* La cama sube de espesor con el carbono: el oro sedimentado se sienta
+       ENCIMA del colchón que lo está agarrando, no flotando sobre el piso. */
+    const yCama = camaRef ? camaRef.current : 0.05;
+
+    for (let i = 0; i < n; i++) {
+      /*
+       * ¿Esta mota se va o se queda? Compara su lugar en la fila con cuánto
+       * nitrógeno se está volando. La rampa de ±0.05 es lo que hace que las
+       * motas cambien de bando UNA POR UNA y no todas de golpe: al echar
+       * aserrín uno ve el oro sentándose de a poco, como nieve al revés.
+       */
+      const fuga = rampa(motas.u[i] - 0.05, motas.u[i] + 0.05, a.nitrogeno.aire);
+
+      /* — La que se queda: sentada en la cama, quieta, honda — */
+      const xQ = motas.bx[i];
+      const zQ = motas.bz[i];
+      const yQ = yCama * (0.35 + (motas.fase[i] % 0.5)) + 0.012;
+
+      /* — La que se va: sube desde la cama, se ladea y se pierde arriba — */
+      const sube = ((t * motas.vel[i] + motas.fase[i] * 7) % CIELO) / CIELO; // 0..1
+      const yV = sube * CIELO + 0.03;
+      /*
+       * Al subir se abre: el aire caliente sale por el caballete y arrastra.
+       * El ladeo crece con la altura — abajo el gas está quieto sobre la cama,
+       * arriba ya va de salida. Y se ladea hacia +x, que es donde está el alero
+       * alto (y detrás, la cerca del vecino). El oro no se va derecho al cielo:
+       * se va PARA LA CASA DE AL LADO.
+       */
+      const abre = sube * sube;
+      const xV = motas.bx[i] + Math.sin(t * 0.5 + motas.fase[i] * 9) * 0.12 * abre + abre * 1.5;
+      const zV = motas.bz[i] + Math.cos(t * 0.4 + motas.fase[i] * 6) * 0.1 * abre + abre * 0.9;
+
+      /* Mezcla de los dos destinos: eso hace la transición continua. */
+      const j = i * 3;
+      pos[j] = xQ + (xV - xQ) * fuga;
+      pos[j + 1] = yQ + (yV - yQ) * fuga;
+      pos[j + 2] = zQ + (zV - zQ) * fuga;
+
+      /*
+       * El color cuenta el viaje: ámbar hondo mientras es abono, oro de mazorca
+       * al soltarse, y lavado hacia la niebla al perderse allá arriba. La mota
+       * que se va no se apaga de golpe: se DILUYE. Se sigue viendo un rato,
+       * como una deuda.
+       */
+      tmp.copy(cCama).lerp(cAire, fuga);
+      if (fuga > 0.5) tmp.lerp(cFuga, sube * 0.85 * ((fuga - 0.5) * 2));
+      /* Titileo tenue del oro sentado: la cama fermentando, viva. */
+      const brillo = fuga > 0.5 ? 1 : 0.86 + Math.sin(t * 0.8 + motas.fase[i] * 12) * 0.14;
+      col[j] = tmp.r * brillo;
+      col[j + 1] = tmp.g * brillo;
+      col[j + 2] = tmp.b * brillo;
+    }
+
+    geo.attributes.position.needsUpdate = true;
+    geo.attributes.color.needsUpdate = true;
+
+    /* Las motas del aire se desvanecen al llegar arriba; las de la cama no.
+       Un solo material, así que la opacidad global se mueve con la fuga. */
+    mat.size = 0.04 + a.nitrogeno.aire * 0.022;
+  });
+
+  return <points ref={puntos} geometry={geo} material={mat} frustumCulled={false} />;
+}
+
+/* Altura de referencia del caballete, para quien quiera encuadrar la fuga. */
+export const ALTURA_FUGA = ALTURAS.caballete;

--- a/src/visual/mundo3d/olor/NubeQueCruzaLaCerca.jsx
+++ b/src/visual/mundo3d/olor/NubeQueCruzaLaCerca.jsx
@@ -1,0 +1,166 @@
+/*
+ * NubeQueCruzaLaCerca — el vecino. El olor no es un asunto privado.
+ *
+ * "El olor no es solo un capricho del vecino, es una señal de que algo en el
+ *  manejo se puede mejorar."
+ *
+ * "Muchas veces el conflicto crece más por sentirse ignorado que por el olor
+ *  mismo; resolverlo a tiempo con buen manejo es más barato que un conflicto de
+ *  vecinos o una queja ante la autoridad ambiental."
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * El aire no sabe dónde termina el lote.
+ *
+ * La cerca está dibujada con precisión —once postes, tres alambres— y no sirve
+ * para nada. Ese es el chiste amargo de este archivo: el lindero existe en el
+ * papel del POT, en la cabeza del dueño y en el alambre de púa. En el aire no
+ * existe. La nube pasa por encima de los tres alambres sin enterarse y llega a
+ * la ventana de la casa de al lado, donde hay gente.
+ *
+ * Por eso la nube va DERECHO A LA CASA y no en cualquier dirección: si derivara
+ * al azar sería clima. Yendo a la ventana es un vecino.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * SIN SERMÓN — la regla más difícil de esta pieza.
+ *
+ * Lo que NO hay acá: ningún vecino con cara de asco, ninguna manito tapándose
+ * la nariz, ningún globo de diálogo, ninguna marca roja sobre la casa. Habría
+ * sido facilísimo y habría arruinado la pieza entera, porque convierte un
+ * problema técnico en una acusación moral — y el campesino no tiene la culpa de
+ * que su cochera huela: nadie le explicó.
+ *
+ * Lo único que hay es una nube que llega hasta una ventana. El que mira saca su
+ * propia conclusión, que es la única que sirve.
+ *
+ * Y el detalle que lo cierra: la nube tarda en irse. Cuando uno echa el aserrín,
+ * el velo de adentro se apaga rápido pero las cartas que ya cruzaron TERMINAN SU
+ * VIAJE — siguen andando hacia la casa y se disuelven allá. Es fiel al dato y es
+ * lo más honesto que tiene la escena:
+ *
+ *   "Esos cambios reducen el olor de forma progresiva a medida que la cama nueva
+ *    reemplaza la vieja (...), no de un día para otro con un producto mágico.
+ *    Mostrarle que ya empezó a actuar (aunque el resultado tarde unas semanas)
+ *    suele calmar más al vecino que una promesa vaga."
+ *
+ * Uno arregla el manejo hoy y el vecino sigue oliendo lo de ayer un rato más.
+ * Eso no es un bug de la animación: es la parte que hay que aguantarse.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { COLORES } from './olor.geom.js';
+import { texturaAire } from './texturasOlor.js';
+
+/* De la cochera a la ventana del vecino. */
+const SALIDA = 1.6; // z donde arranca (borde de la cochera)
+const LLEGADA = 8.6; // z de la casa
+const VIAJE = LLEGADA - SALIDA;
+
+/**
+ * @param {{ aireRef: { current: any }, n?: number, reducedMotion?: boolean }} props
+ */
+export default function NubeQueCruzaLaCerca({ aireRef, n = 5, reducedMotion = false }) {
+  const grupo = useRef(null);
+  const tex = useMemo(() => texturaAire(29), []);
+
+  /* Cartas anchas y bajas: la nube va acostada, como todo el gas de esta pieza. */
+  const geo = useMemo(() => {
+    const g = new THREE.PlaneGeometry(4.6, 3.2, 8, 6);
+    g.rotateX(-Math.PI / 2);
+    return g;
+  }, []);
+
+  const mats = useMemo(
+    () =>
+      Array.from(
+        { length: n },
+        () =>
+          new THREE.MeshBasicMaterial({
+            map: tex,
+            color: COLORES.velo,
+            transparent: true,
+            opacity: 0,
+            depthWrite: false,
+            side: THREE.DoubleSide,
+            fog: false,
+          }),
+      ),
+    [tex, n],
+  );
+
+  const cartas = useMemo(
+    () =>
+      Array.from({ length: n }, (_, i) => ({
+        fase: i / n, // escalonadas: la nube es un rosario, no un bloque
+        x: -1.4 + (i % 3) * 1.5,
+        alto: 0.75 + (i % 2) * 0.5,
+        vel: 0.055 + (i % 3) * 0.012,
+      })),
+    [n],
+  );
+
+  /*
+   * La memoria de la nube. Sube rápido con el olor y BAJA LENTO (una décima
+   * parte de rápido): es la inercia del conflicto. El aire que ya cruzó no se
+   * devuelve porque uno se haya arrepentido.
+   */
+  const memoria = useRef(0);
+
+  useLayoutEffect(
+    () => () => {
+      tex.dispose();
+      geo.dispose();
+      mats.forEach((m) => m.dispose());
+    },
+    [tex, geo, mats],
+  );
+
+  useFrame((state, dt) => {
+    const g = grupo.current;
+    const a = aireRef.current;
+    if (!g || !a) return;
+
+    /* Persigue al olor de adentro: rápido para empeorar, lento para sanar. */
+    const objetivo = a.vecino;
+    const paso = objetivo > memoria.current ? 0.9 : 0.09;
+    memoria.current += (objetivo - memoria.current) * Math.min(1, dt * paso * 3);
+    const m = memoria.current;
+
+    g.visible = m > 0.015;
+    if (!g.visible) return;
+
+    const t = reducedMotion ? 0.35 : state.clock.elapsedTime;
+
+    for (let i = 0; i < g.children.length; i++) {
+      const carta = /** @type {THREE.Mesh & { material: THREE.MeshBasicMaterial }} */ (g.children[i]);
+      const c = cartas[i];
+
+      /* Cuánto lleva andado, 0..1. En bucle: el olor sale todo el día. */
+      const avance = reducedMotion ? c.fase : (t * c.vel + c.fase) % 1;
+
+      carta.position.z = SALIDA + avance * VIAJE;
+      carta.position.x = c.x + Math.sin(avance * 3.1 + c.fase * 6) * 0.7;
+      /* Va bajando: el aire cargado se enfría y se acuesta sobre el patio del
+         vecino. Llega a la altura de una ventana, que es donde duele. */
+      carta.position.y = c.alto + (1 - avance) * 0.5;
+
+      /*
+       * Entra difuminada, se ve entera a mitad de camino y se disuelve contra
+       * la casa. Nunca alcanza a "chocar" con la pared: se deshace un poco
+       * antes, porque el olor tampoco golpea — llega.
+       */
+      const entrada = Math.min(1, avance * 4);
+      const salida = 1 - Math.max(0, (avance - 0.62) / 0.38);
+      carta.material.opacity = m * entrada * salida * 0.3;
+      carta.rotation.y = Math.sin(avance * 2 + c.fase * 4) * 0.2;
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {cartas.map((c, i) => (
+        <mesh key={i} geometry={geo} material={mats[i]} renderOrder={12 + i} />
+      ))}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/olor/OlorVisible.jsx
+++ b/src/visual/mundo3d/olor/OlorVisible.jsx
@@ -1,0 +1,70 @@
+/*
+ * OlorVisible — la pieza completa: la cochera y su aire.
+ *
+ * El anfitrión. Junta las tres cosas y no hace nada más:
+ *   · decide el tier del equipo (`decidirTier`),
+ *   · monta la cochera —3D si el equipo da, corte de perfil si no—,
+ *   · le pone abajo la palada de material seco.
+ *
+ * El carbono vive ACÁ, en un estado de React, y baja como un simple número.
+ * Adentro del <Canvas> ese número entra a un ref y de ahí no vuelve a salir: la
+ * escena se mueve sola, sin re-renderizar el árbol sesenta veces por segundo.
+ *
+ * La 3D va SOLO perezosa (lazy): un equipo de gama baja jamás se descarga three.
+ * Y no se queda sin la pieza — se lleva el corte SVG, que cuenta lo mismo con el
+ * mismo modelo y pesa lo que pesa un ícono. En esta pieza el corte además tiene
+ * una ventaja propia: el argumento es una altura, y el perfil es el dibujo que
+ * mejor muestra alturas. No es la versión pobre; es la otra lectura.
+ *
+ * ARRANCA EN CERO, y eso no es un default cualquiera: la pieza empieza en la
+ * cochera que el que mira ya tiene. Primero se reconoce, después se mueve.
+ *
+ * Demo aislada: se monta sola, sin rutas ni datos de finca. Es un cuadro, no una
+ * pantalla del app.
+ */
+import { lazy, Suspense, useMemo, useState } from 'react';
+import { decidirTier, permite3D } from '../deviceTier.js';
+import PaladaDeSeco from './PaladaDeSeco.jsx';
+import CocheraEnCorte from './CocheraEnCorte.jsx';
+import './olor.css';
+
+/* three + @react-three entran acá y en ningún otro lado. */
+const EscenaOlorVisible = lazy(() => import('./EscenaOlorVisible.jsx'));
+
+/**
+ * @param {{
+ *   tier?: 'alto'|'medio'|'bajo',
+ *   reducedMotion?: boolean,
+ *   carbonoInicial?: number,
+ * }} props
+ */
+export default function OlorVisible({
+  tier: tierForzado,
+  reducedMotion: calmaForzada,
+  carbonoInicial = 0,
+}) {
+  // Se decide UNA vez: el equipo no cambia a mitad de camino.
+  const decision = useMemo(() => decidirTier(), []);
+  const tier = tierForzado || decision.tier;
+  const reducedMotion = calmaForzada ?? decision.reducedMotion;
+
+  const [carbono, setCarbono] = useState(carbonoInicial);
+
+  const conTres = permite3D(tier);
+
+  return (
+    <div className="olor">
+      <div className="olor__lienzo">
+        {conTres ? (
+          <Suspense fallback={<div className="olor__esperando" aria-hidden="true" />}>
+            <EscenaOlorVisible carbono={carbono} tier={tier} reducedMotion={reducedMotion} />
+          </Suspense>
+        ) : (
+          <CocheraEnCorte carbono={carbono} />
+        )}
+      </div>
+
+      <PaladaDeSeco carbono={carbono} onCarbono={setCarbono} />
+    </div>
+  );
+}

--- a/src/visual/mundo3d/olor/PaladaDeSeco.jsx
+++ b/src/visual/mundo3d/olor/PaladaDeSeco.jsx
@@ -1,0 +1,158 @@
+/*
+ * PaladaDeSeco — el control. Una palada de material seco, agarrada con el dedo.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * QUÉ MIDE EL RIEL, Y POR QUÉ ESO ES TODO
+ *
+ * El riel NO dice "qué tan limpia está la cochera" ni "qué tan buen productor
+ * es usted". Dice CUÁNTO MATERIAL SECO HAY EN LA CAMA. Nada más.
+ *
+ * Y ese recorte es la pieza entera, porque contradice lo que todo el mundo cree:
+ *
+ *   "Casi siempre el problema no es que limpie poco, sino que limpia sin agregar
+ *    suficiente material carbonado nuevo."
+ *
+ * El hombre que lava con manguera dos veces al día está trabajando MÁS que el
+ * vecino y su cochera huele PEOR. Si este control se llamara "aseo", la pieza
+ * repetiría el error que vino a corregir y encima lo haría sentir culpable de
+ * algo que ya está haciendo. Se llama aserrín. Es más barato y funciona.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * EL RIEL NO ES LINEAL
+ *
+ * La primera mitad del riel se come apenas un tercio del material. Al arrastrar,
+ * uno siente que las primeras paladas CAMBIAN MUCHO —el lodo cede, el velo se
+ * desinfla, las moscas se ralean— y que después la cosa se pone lenta y hay que
+ * seguir echando para ganar poquito.
+ *
+ * Esa resistencia en el dedo es el dato: la primera palada es la que más rinde
+ * ("cualquier material carbonado seco es mejor que no echar nada") y la cama
+ * profunda de verdad es tozudez, no un truco. El que llega hasta el final del
+ * riel sintió lo que cuesta.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * LO QUE NO HAY
+ *
+ * · Ni un número. Ni ppm, ni C:N, ni centímetros, ni "78% de eficiencia". El
+ *   maestro no da cifras (ver `senalesDelCuerpo.js`) y esta pieza tampoco.
+ *   Lo que se lee son las tres señales del cuerpo: el puño, los ojos, la mosca.
+ * · Ni barra de progreso, ni verificado verde, ni "¡Felicitaciones!". Llegar a
+ *   cama profunda no es ganar un nivel: es que la cochera dejó de robarle. La
+ *   dirección educativa de la casa es observación, no gamificación.
+ * · Ni un regaño. Ninguna frase dice "debe" ni "no debe".
+ *
+ * Es un <input type=range> de verdad: anda con el dedo, con las flechas del
+ * teclado y con lector de pantalla, y en un teléfono humilde no cuesta nada.
+ * Blancos de 44px, para mano de campo con barro y sol en la pantalla.
+ *
+ * En "usted", como toda la UI de la casa.
+ */
+import { useCallback } from 'react';
+import { aire } from './aireCargado.js';
+import { PARADAS, paradaDe, senalesDe } from './senalesDelCuerpo.js';
+import './olor.css';
+
+/*
+ * La curva del riel. `pos` (lo que uno arrastra, 0..1) → `carbono` (lo que hay
+ * en la cama). Potencia 1.6: la mitad del riel entrega como un tercio del
+ * material. Las primeras paladas rinden; las últimas hay que sudarlas.
+ */
+const carbonoDesdePos = (p) => Math.pow(Math.min(1, Math.max(0, p)), 1.6);
+const posDesdeCarbono = (c) => Math.pow(Math.min(1, Math.max(0, c)), 1 / 1.6);
+
+/**
+ * @param {{
+ *   carbono: number,
+ *   onCarbono: (v: number) => void,
+ * }} props
+ */
+export default function PaladaDeSeco({ carbono, onCarbono }) {
+  const a = aire(carbono);
+  const parada = paradaDe(carbono);
+  const senales = senalesDe(a);
+  const pos = posDesdeCarbono(carbono);
+
+  const arrastrar = useCallback(
+    (e) => onCarbono(carbonoDesdePos(Number(e.target.value) / 1000)),
+    [onCarbono],
+  );
+
+  return (
+    <div className="ol">
+      {/* Dónde está la cama, ahora. */}
+      <div className="ol__cabeza">
+        <div className="ol__titulo" aria-live="polite">
+          {parada.titulo}
+        </div>
+      </div>
+
+      {/* Qué está pasando ahí adentro. Física, no orden. */}
+      <p className="ol__texto">{parada.texto}</p>
+
+      {/* El riel: cuánto material seco. */}
+      <div className="ol__riel">
+        <div className="ol__pista" aria-hidden="true">
+          {/* Se llena del color del material seco, no de un verde de "correcto". */}
+          <div className="ol__seco" style={{ width: `${pos * 100}%` }} />
+          {PARADAS.map((p) => (
+            <span key={p.clave} className="ol__hito" style={{ left: `${posDesdeCarbono(p.carbono) * 100}%` }} />
+          ))}
+        </div>
+        <input
+          className="ol__input"
+          type="range"
+          min={0}
+          max={1000}
+          step={1}
+          value={Math.round(pos * 1000)}
+          onChange={arrastrar}
+          aria-label="Material seco en la cama: aserrín, cascarilla de arroz, cisco de café, hoja seca"
+          aria-valuetext={`${parada.titulo}. ${senales.map((s) => s.texto).join('. ')}`}
+        />
+      </div>
+
+      {/* Las paradas del camino. Se puede tocar cualquiera. */}
+      <div className="ol__paradas">
+        {PARADAS.map((p) => (
+          <button
+            key={p.clave}
+            type="button"
+            className={`ol__parada${p.clave === parada.clave ? ' ol__parada--aqui' : ''}`}
+            style={{ left: `${posDesdeCarbono(p.carbono) * 100}%` }}
+            onClick={() => onCarbono(p.carbono)}
+            aria-current={p.clave === parada.clave ? 'step' : undefined}
+          >
+            {p.titulo}
+          </button>
+        ))}
+      </div>
+
+      {/*
+        Las señales del cuerpo. Esto reemplaza al HUD que esta pieza no tiene:
+        no hay aparato, hay mano, ojos y nariz. Cada una se pinta apenas de
+        ámbar o de verde — nunca de rojo de alarma, que en la paleta de la casa
+        no existe (el rojo es cochinilla y café cereza, textil y fruto).
+      */}
+      <ul className="ol__senales">
+        {senales.map((s) => (
+          <li key={s.texto} className={`ol__senal${s.bien ? ' ol__senal--bien' : ''}`}>
+            <span className="ol__senalTexto">{s.texto}</span>
+            {/* El aparte: la frase del maestro que traduce lo que uno siente.
+                Sale sola, cuando toca, y se calla cuando no. */}
+            {s.aparte && <span className="ol__aparte">{s.aparte}</span>}
+          </li>
+        ))}
+      </ul>
+
+      {/*
+        La tesis, en letra chica y sin subrayarla. Si la pieza está bien hecha,
+        para cuando uno lee esto ya lo sabía: lo vio subirse por el techo.
+      */}
+      <p className="ol__tesis">
+        {a.amoniaco > 0.35
+          ? 'Ese olor no es normal: es nitrógeno volándose. Abono que ya pagó, saliéndose por el techo.'
+          : 'El mismo nitrógeno que se volaba ahora está en la cama. De ahí sale para la huerta.'}
+      </p>
+    </div>
+  );
+}

--- a/src/visual/mundo3d/olor/PozoQueCalla.jsx
+++ b/src/visual/mundo3d/olor/PozoQueCalla.jsx
@@ -1,0 +1,141 @@
+/*
+ * PozoQueCalla — el ácido sulfhídrico. El que no hace espectáculo.
+ *
+ * "El H₂S es traicionero porque a concentraciones muy altas anula el sentido del
+ *  olfato, así que uno deja de olerlo justo cuando es más peligroso, y además es
+ *  más pesado que el aire, así que se acumula en pozos, fosas y espacios bajos
+ *  cerrados."
+ *
+ * "Ha habido casos donde muere la primera persona por los gases y luego mueren
+ *  quienes entran a rescatarla sin protección."
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * LA FÍSICA OPUESTA ES LA LECCIÓN
+ *
+ * Este archivo existe para contradecir al de al lado. Todo lo que hace el
+ * amoníaco, el sulfhídrico lo hace al revés — y esas oposiciones NO son estilo:
+ * son las dos químicas, dibujadas.
+ *
+ *   Amoníaco (VeloQuePesa)          Sulfhídrico (este archivo)
+ *   ─────────────────────           ──────────────────────────
+ *   SUBE, se va por el caballete    BAJA, se sienta en el hueco
+ *   dorado: se ve venir             pardo muerto: el ojo le resbala
+ *   ronda, ondula, está vivo        QUIETO. No se mueve nunca.
+ *   arde: AVISA                     no huele a nada: CALLA
+ *   sale del descuido               sale del encharcamiento (otra causa)
+ *   es plata que se pierde          es una persona que se muere
+ *
+ * Uno le roba a usted. El otro lo mata.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * LA DECISIÓN DE ARTE MÁS RARA DE LA PIEZA: que casi no se vea.
+ *
+ * La tentación era pintarlo alarmante — morado brillante, calaveras, pulso
+ * rojo. Sería traicionar el dato: si el H₂S se viera, no mataría a nadie. Mata
+ * PORQUE no se ve y porque deja de olerse justo cuando abunda.
+ *
+ * Así que acá el peligro es una lámina pardo-violácea, opaca y absolutamente
+ * inmóvil, que llena el hueco hasta el ras del brocal — como si la fosa
+ * estuviera llena de un agua que no refleja. No hay burbujas, no hay volutas,
+ * no pasa nada. El que se asoma mete la cabeza adentro sin enterarse.
+ *
+ * La quietud, al lado del oro que revolotea a tres metros, es lo más inquietante
+ * que se podía dibujar. Que el ojo del que mira la escena pase de largo por la
+ * fosa es EXACTAMENTE lo que le pasa al que se asoma a la fosa.
+ *
+ * Y por eso el borde del líquido es lo único con un poco de contraste: es la
+ * línea que uno tiene que aprender a ver.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { COLORES, COCHERA } from './olor.geom.js';
+
+/* El hueco de la fosa, en metros. Coincide con `geomFosa`. */
+const FOSA = { x: COCHERA.fosaX, z: 1.2, w: 0.95, d: 1.72, boca: 0.02, fondo: -0.16 };
+
+/**
+ * El gas que se acuesta en la fosa.
+ *
+ * @param {{ aireRef: { current: any }, n?: number }} props
+ */
+export default function PozoQueCalla({ aireRef, n = 4 }) {
+  const grupo = useRef(null);
+
+  const geo = useMemo(() => {
+    const g = new THREE.PlaneGeometry(FOSA.w, FOSA.d);
+    g.rotateX(-Math.PI / 2);
+    return g;
+  }, []);
+
+  /*
+   * Cuatro láminas apiladas en catorce centímetros. Todas del mismo color, sin
+   * degradé: el gas pesado no se ralea con la altura como el amoníaco — se
+   * queda macizo hasta el borde y ahí se corta. Es un líquido invisible.
+   */
+  const mats = useMemo(
+    () =>
+      Array.from(
+        { length: n },
+        () =>
+          new THREE.MeshBasicMaterial({
+            color: COLORES.sulfhidrico,
+            transparent: true,
+            opacity: 0,
+            depthWrite: false,
+            side: THREE.DoubleSide,
+            fog: false,
+          }),
+      ),
+    [n],
+  );
+
+  const alturas = useMemo(
+    () => Array.from({ length: n }, (_, i) => FOSA.fondo + ((i + 1) / n) * (FOSA.boca - FOSA.fondo)),
+    [n],
+  );
+
+  useLayoutEffect(
+    () => () => {
+      geo.dispose();
+      mats.forEach((m) => m.dispose());
+    },
+    [geo, mats],
+  );
+
+  useFrame(() => {
+    const g = grupo.current;
+    const a = aireRef.current;
+    if (!g || !a) return;
+
+    /*
+     * Umbral, no rampa: no aparece porque la cama esté regular. Aparece cuando
+     * hay agua empozada pudriéndose sin aire. Mientras tanto NO EXISTE — y esa
+     * es la otra mitad del dato: el descuido leve huele a amoníaco, no a huevo
+     * podrido. Son diagnósticos distintos.
+     */
+    g.visible = a.sulfhidrico > 0.02;
+    if (!g.visible) return;
+
+    for (let i = 0; i < g.children.length; i++) {
+      const lam = /** @type {THREE.Mesh & { material: THREE.MeshBasicMaterial }} */ (g.children[i]);
+      /* La de más arriba, la del ras del brocal, es la más opaca: es el borde
+         que hay que aprender a ver antes de asomarse. */
+      const alRas = i / Math.max(1, n - 1);
+      lam.material.opacity = a.sulfhidrico * (0.3 + alRas * 0.42);
+      /*
+       * SIN useFrame que lo mueva. Ni una oscilación, ni un pulso, ni un
+       * titileo. Está escrito así a propósito y no es un pendiente: la quietud
+       * absoluta ES el personaje. Si esto respirara, avisaría — y no avisa.
+       */
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {alturas.map((y, i) => (
+        <mesh key={i} geometry={geo} material={mats[i]} position={[FOSA.x, y, FOSA.z]} renderOrder={20 + i} />
+      ))}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/olor/VeloQuePesa.jsx
+++ b/src/visual/mundo3d/olor/VeloQuePesa.jsx
@@ -1,0 +1,182 @@
+/*
+ * VeloQuePesa — el amoníaco. El problema entero de esta pieza, en un archivo.
+ *
+ * EL RETO: dibujar un gas incoloro sin caer en el humito verde de caricatura.
+ *
+ * Lo que NO se hizo, y por qué:
+ *   · Humito verde saliendo en volutas → mentira dos veces. El amoníaco es
+ *     incoloro, y el verde-tóxico le dice al campesino "eso es veneno ajeno,
+ *     sáquelo de acá", cuando lo que hay que decirle es "eso es SUYO".
+ *   · Nube que sube en columna → una chimenea es un evento, algo que pasa. El
+ *     amoníaco no pasa: ESTÁ. Todo el día, quieto, encima de los animales.
+ *   · Partículas verdes flotando → convierte el aire en un efecto de videojuego.
+ *     Lo que se busca es incomodidad, no VFX.
+ *
+ * Lo que SÍ: EL VELO SE ACUESTA.
+ *
+ * El amoníaco de esta escena es un ESTRATO — una lámina de aire sucio que se
+ * echa sobre la cama y tiene un BORDE horizontal. No sube: pesa. No se mueve
+ * de un lado a otro: se queda. Y su color no es tóxico sino turbio, un
+ * amarillo de orina vieja que no pertenece a ninguna hora del día (`COLORES.velo`,
+ * derivado de la niebla dorada de la casa revolcada en pajonal y apagada contra
+ * el zinc). Lo desagradable no está en el tono: está en que ese velo SE COME EL
+ * COLOR de todo lo que queda detrás. La cama, el cerdo, el muro — todo lo que
+ * está adentro del estrato se ve enfermo. El aire ensucia lo que toca.
+ *
+ * Y el borde es el argumento. Porque el borde deja a la gallina ADENTRO (cabeza
+ * a 0.26 m) y al dueño AFUERA (nariz a 1.58 m). Los dos en el mismo cuarto:
+ *
+ *   "Si a usted le arden los ojos al entrar al gallinero, la gallina lleva
+ *    horas así."
+ *
+ * Esa frase es esto: una línea de flotación. El humano tiene la cabeza fuera del
+ * agua y cree que no es para tanto. La gallina vive en el fondo.
+ *
+ * TÉCNICA: estratos horizontales (planos, NO billboards — un billboard giraría
+ * hacia la cámara y volvería el gas una "cosa"; el plano horizontal se ve como
+ * lo que es, aire acostado). Cada estrato lleva su opacidad de
+ * `densidadEnAltura`, se desplaza lentísimo (el aire quieto no está quieto:
+ * ronda) y ondula sin cambiar de altura. MeshBasic + textura de ruido en canvas:
+ * cero assets, corre en gama baja.
+ */
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { COLORES, COCHERA } from './olor.geom.js';
+import { densidadEnAltura } from './aireCargado.js';
+import { texturaAire } from './texturasOlor.js';
+
+/* ------------------------------------------------------------------ */
+
+/**
+ * El estrato de amoníaco sobre la cama.
+ *
+ * @param {{
+ *   aireRef: { current: ReturnType<typeof import('./aireCargado.js').aire> },
+ *   n?: number,
+ *   reducedMotion?: boolean,
+ * }} props
+ */
+export default function VeloQuePesa({ aireRef, n = 7, reducedMotion = false }) {
+  const grupo = useRef(null);
+
+  const tex = useMemo(() => texturaAire(11), []);
+
+  /*
+   * La geometría: un plano ancho, más grande que la cochera (el aire no respeta
+   * los muros bajos: se derrama por encima de ellos y por eso el vecino existe).
+   * Subdividido para poder ondularlo sin que se note la grilla.
+   */
+  const geo = useMemo(() => {
+    const g = new THREE.PlaneGeometry(COCHERA.ancho + 3.4, COCHERA.fondo + 2.6, 14, 10);
+    g.rotateX(-Math.PI / 2);
+    return g;
+  }, []);
+
+  /* Un material POR estrato: cada lámina lleva SU opacidad y SU color, porque
+     el de abajo está más sucio que el de arriba. Se crean una vez. */
+  const mats = useMemo(
+    () =>
+      Array.from(
+        { length: n },
+        () =>
+          new THREE.MeshBasicMaterial({
+            map: tex,
+            transparent: true,
+            opacity: 0,
+            depthWrite: false, // el gas no tapa: vela
+            side: THREE.DoubleSide, // se mira desde arriba y desde abajo
+            fog: false,
+            blending: THREE.NormalBlending, // NO additive: el gas ENSUCIA, no ilumina
+          }),
+      ),
+    [tex, n],
+  );
+
+  /*
+   * Las alturas de los estratos. Repartidos con sesgo HACIA ABAJO (potencia
+   * 1.6): la mitad de las láminas viven en el primer palmo, porque ahí es donde
+   * pasa todo — es la franja de la gallina y del cerdo. Arriba quedan pocas y
+   * ralas: el resto que le llega a la nariz del dueño.
+   */
+  const estratos = useMemo(() => {
+    const arr = [];
+    for (let i = 0; i < n; i++) {
+      const t = n === 1 ? 0 : i / (n - 1);
+      arr.push({
+        alturaRel: Math.pow(t, 1.6), // 0..1 relativo al techo del velo
+        fase: i * 1.7,
+        deriva: 0.4 + (i % 3) * 0.25,
+        col: new THREE.Color(),
+      });
+    }
+    return arr;
+  }, [n]);
+
+  const colHondo = useMemo(() => new THREE.Color(COLORES.veloHondo), []);
+  const colAlto = useMemo(() => new THREE.Color(COLORES.velo), []);
+
+  useLayoutEffect(
+    () => () => {
+      tex.dispose();
+      geo.dispose();
+      mats.forEach((m) => m.dispose());
+    },
+    [tex, geo, mats],
+  );
+
+  useFrame((state) => {
+    const g = grupo.current;
+    const a = aireRef.current;
+    if (!g || !a) return;
+
+    /* Sin amoníaco no hay velo: el grupo entero se apaga y deja de costar. */
+    g.visible = a.amoniaco > 0.012;
+    if (!g.visible) return;
+
+    const t = reducedMotion ? 0 : state.clock.elapsedTime;
+
+    for (let i = 0; i < g.children.length; i++) {
+      const lam = /** @type {THREE.Mesh & { material: THREE.MeshBasicMaterial }} */ (g.children[i]);
+      const e = estratos[i];
+
+      /* La altura REAL de esta lámina: el techo del velo lo manda el aire. */
+      const y = 0.015 + e.alturaRel * a.alturaVelo * 1.25;
+      const dens = densidadEnAltura(y, a.alturaVelo);
+
+      /*
+       * La opacidad: densidad × cuánto amoníaco hay. El techo de 0.5 por lámina
+       * es a propósito — ninguna capa sola tapa nada. Lo que ciega es la SUMA
+       * de siete láminas, igual que en la cochera de verdad: no hay una nube,
+       * hay aire, y el aire junto no deja ver.
+       */
+      lam.material.opacity = dens * a.amoniaco * 0.5 * (0.82 + Math.sin(t * 0.13 + e.fase) * 0.18);
+
+      /* El color: sucio abajo, más lavado arriba. */
+      e.col.copy(colHondo).lerp(colAlto, Math.min(1, e.alturaRel * 1.3));
+      lam.material.color.copy(e.col);
+
+      lam.position.y = y;
+
+      if (!reducedMotion) {
+        /*
+         * La deriva: el estrato RONDA, no vuela. Centímetros por segundo, sin
+         * rumbo. Es lo que hace que el aire se sienta pesado — si esto se
+         * moviera rápido, sería viento, y el viento sería una buena noticia.
+         */
+        lam.position.x = Math.sin(t * 0.055 + e.fase) * e.deriva;
+        lam.position.z = Math.cos(t * 0.041 + e.fase * 0.7) * e.deriva * 0.7;
+        /* Un giro imperceptible: mata la grilla de planos paralelos. */
+        lam.rotation.y = Math.sin(t * 0.03 + e.fase) * 0.09;
+      }
+    }
+  });
+
+  return (
+    <group ref={grupo}>
+      {estratos.map((e, i) => (
+        <mesh key={i} geometry={geo} material={mats[i]} position={[0, 0.02, 0]} renderOrder={2 + i} />
+      ))}
+    </group>
+  );
+}

--- a/src/visual/mundo3d/olor/aireCargado.js
+++ b/src/visual/mundo3d/olor/aireCargado.js
@@ -1,0 +1,279 @@
+/*
+ * aireCargado — el MODELO del olor. Una sola variable manda: el material seco.
+ *
+ * Toda esta pieza cuelga de un número: `carbono` ∈ [0,1] — cuánto material seco
+ * (aserrín, cascarilla de arroz, cisco de café, hoja seca) tiene la cama. No hay
+ * cinco escenas pintadas a mano: hay UNA cochera y una cantidad de aserrín.
+ * El amoníaco, las moscas, el charco, la nube que cruza la cerca y el pozo que
+ * calla son CONSECUENCIAS calculadas de ese número, igual que en la ladera de
+ * restauración todo colgaba de `dosel(anio)`.
+ *
+ * Por qué el carbono y no "el aseo": porque esa es la tesis del maestro, y es
+ * contraintuitiva —
+ *
+ *   "Casi siempre el problema no es que limpie poco, sino que limpia sin
+ *    agregar suficiente material carbonado nuevo."
+ *
+ * El campesino que lava con manguera todos los días está trabajando MÁS y
+ * oliendo PEOR. Si el deslizador de esta pieza fuera "cuánto limpia", la pieza
+ * mentiría. Es cuánto carbono. Ese es el reencuadre entero.
+ *
+ * LA LEY DE ESTE ARCHIVO — la conservación del nitrógeno:
+ *
+ *   nitrogeno.aire + nitrogeno.cama = 1   (siempre, para todo carbono)
+ *
+ * El nitrógeno no se crea ni se destruye: o se vuela como amoníaco, o queda
+ * amarrado en la cama como abono. Por eso las motas doradas de la escena son UN
+ * solo sistema de partículas: las mismas motas que se fugaban por el caballete
+ * ahora se sedimentan y brillan dentro del colchón. El oro no desaparece —
+ * cambia de lugar. Ese es el argumento de la pieza en una sola línea de código.
+ *
+ * SIN CIFRAS INVENTADAS. El corpus del maestro (56 pares sobre olores) es
+ * deliberadamente pobre en números: no da ppm de amoníaco, ni relación C:N, ni
+ * centímetros de cama, y cuando se lo preguntan responde "no le voy a inventar
+ * un número" y remite a la UMATA. Su pedagogía está construida sobre señales
+ * del cuerpo —la prueba del puño, el ardor de ojos, el olor a tierra— PRECISA-
+ * MENTE en lugar de métricas. Así que acá no hay HUD con ppm ni barra de
+ * "eficiencia": las curvas de abajo son dirección de ARTE (cómo se ve el gas),
+ * no una tabla de laboratorio. El que juzga es el ojo, como en la finca.
+ *
+ * Puro: números adentro, números afuera. Cero three, cero costo por frame.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Las alturas — LA MEDIDA QUE ARGUMENTA.                              */
+/* ------------------------------------------------------------------ */
+
+/*
+ * La escena está en metros (1 unidad = 1 m) y estas alturas son el corazón de
+ * la pieza, no decoración:
+ *
+ *   "Si a usted le arden los ojos al entrar al gallinero, la gallina lleva
+ *    horas así."
+ *
+ * El amoníaco no se reparte parejo: es denso abajo y ralo arriba. La gallina
+ * vive con la cabeza a un palmo del piso — o sea, DENTRO del estrato malo, todo
+ * el día. El humano entra, le arde, y su nariz está a metro y medio: le arde
+ * estando AFUERA de lo peor. Ese contraste no se explica con texto en esta
+ * pieza; se ve, porque los cuerpos están parados a su altura real y el velo
+ * tiene un borde.
+ */
+export const ALTURAS = {
+  cama: 0.0, // la superficie de la cama: donde nace todo
+  gallina: 0.26, // cabeza de la gallina picoteando: adentro del velo
+  cerdo: 0.38, // nariz del cerdo echado: adentro del velo
+  nariz: 1.58, // nariz del que entra: por encima — y aun así le arde
+  caballete: 2.9, // la salida de aire de arriba: por donde se fuga el oro
+};
+
+/* ------------------------------------------------------------------ */
+/* Curvas — la forma de cada consecuencia.                             */
+/* ------------------------------------------------------------------ */
+
+const cortar = (v, a = 0, b = 1) => (v < a ? a : v > b ? b : v);
+const suave = (t) => t * t * (3 - 2 * t);
+
+/**
+ * Rampa suave entre dos umbrales (el `smoothstep` de la casa).
+ * @param {number} a  donde empieza
+ * @param {number} b  donde termina
+ * @param {number} v  el valor
+ */
+export const rampa = (a, b, v) => suave(cortar((v - a) / (b - a)));
+
+/* ------------------------------------------------------------------ */
+/* EL MODELO.                                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * El estado del aire para una cantidad de material seco.
+ *
+ * @param {number} carbono  0 = piso pelado lavado con manguera (puro estiércol
+ *                          y orín revueltos) · 1 = cama profunda bien hecha,
+ *                          seca y suelta.
+ * @returns {{
+ *   carbono: number, saturacion: number, humedad: number, amoniaco: number,
+ *   sulfhidrico: number,
+ *   moscas: number, vecino: number, fermento: number, arde: number,
+ *   nitrogeno: { aire: number, cama: number },
+ *   alturaVelo: number,
+ * }}
+ */
+export function aire(carbono) {
+  const c = cortar(carbono);
+
+  /*
+   * SATURACIÓN — cuánta agua de más hay ahogando la cama.
+   *
+   * Es el motor de todo lo malo: el agua saca el aire de entre las partículas y
+   * ahí empieza el problema. El material seco absorbe —ese es su primer oficio,
+   * antes que el químico— y la curva cae rápido al principio (la primera palada
+   * de aserrín se nota muchísimo: pasa de lodo a suelo pisable) y después se
+   * aplana. De ahí la potencia 0.7 y no una recta.
+   *
+   *   "El agua desplaza el aire de los espacios entre el estiércol y la cama, y
+   *    el proceso pasa de ser aeróbico (con aire, más limpio) a anaeróbico (sin
+   *    aire, el que produce el ácido sulfhídrico y más amoníaco)."
+   */
+  const saturacion = Math.pow(1 - c, 0.7);
+
+  /*
+   * HUMEDAD — la del PUÑO, que es otra cosa, y confundirlas arruinaba la pieza.
+   *
+   * La cama profunda bien hecha NO está seca como un papel: está viva. Fermenta
+   * suave, genera calor y para eso necesita humedad. El punto bueno es "húmeda
+   * al tacto, se pega en bola, no gotea" — no cero.
+   *
+   * Por eso la humedad nunca baja de ~0.3 por más aserrín que uno eche: una cama
+   * trabajando siempre tiene su agua. Si esto cayera a cero, la prueba del puño
+   * marcaría "se desmorona seca" justo en el estado ideal, y la pieza terminaría
+   * regañando al que hizo todo bien.
+   *
+   * Y ojo con la asimetría: en la PILA de compost pasarse de seco sí existe (el
+   * proceso se frena sin agua). En la CAMA no: el maestro nunca dice "se pasó de
+   * cascarilla", dice "cualquier material carbonado seco es mejor que no echar
+   * nada". Acá más carbono nunca es peor. Por eso hay un piso y no un óptimo.
+   */
+  const humedad = 0.3 + 0.7 * saturacion;
+
+  /*
+   * AMONÍACO — el nitrógeno sin con qué amarrarse.
+   *   "El estiércol solo es puro nitrógeno (poco carbono), y cuando el
+   *    nitrógeno no tiene con qué 'amarrarse' se escapa como amoníaco oloroso."
+   *
+   * Dos factores que se multiplican, porque el maestro nombra dos oficios
+   * distintos del mismo puñado de aserrín:
+   *   - `libre`: el nitrógeno que no encontró carbono con qué quedarse.
+   *   - `saturacion`: hasta el nitrógeno amarrado se vuela si el material está
+   *     empapado (el agua saca el aire y dispara el olor amoniacal).
+   * Por eso el carbono entra dos veces: absorbe Y amarra. Un solo puñado hace
+   * los dos trabajos — y por eso la curva se desploma tan rápido.
+   */
+  const libre = Math.pow(1 - c, 1.35);
+  const amoniaco = cortar(libre * (0.45 + 0.55 * saturacion));
+
+  /*
+   * ÁCIDO SULFHÍDRICO — el otro olor, que NO es el mismo problema.
+   * Esto no es "más amoníaco": es otra química, la de lo podrido SIN AIRE.
+   * Por eso tiene UMBRAL y no rampa: no aparece porque la cama esté regular,
+   * aparece cuando hay agua empozada y el material se pudre ahogado. Mientras
+   * quede algo de aire entre las partículas, sencillamente no existe. Un
+   * descuido leve huele a amoníaco; solo el encharcamiento huele a huevo podrido.
+   */
+  const sulfhidrico = rampa(0.62, 0.98, saturacion);
+
+  /*
+   * MOSCAS — atención: NO cuelgan del amoníaco, cuelgan de la SATURACIÓN.
+   *   "Las moscas no vienen atraídas por el olor en sí, sino por el mismo
+   *    material húmedo, blando y rico en materia orgánica donde ese olor se
+   *    produce. (...) Si tiene mucho olor, casi con seguridad también tiene
+   *    mucha mosca; son la misma causa."
+   *
+   * Que en el código dependan de `saturacion` y no de `amoniaco` es lo que hace
+   * honesta la escena: olor y mosca son PRIMOS (misma causa), no padre e hijo.
+   * Por eso fumigar no sirve —mata la generación de hoy y la cama sigue siendo
+   * criadero— y por eso el mismo puñado de aserrín apaga los dos a la vez.
+   */
+  const moscas = cortar(Math.pow(saturacion, 1.25));
+
+  /*
+   * EL VECINO — lo que cruza la cerca.
+   * Va después del amoníaco: primero tiene que haber de sobra adentro para que
+   * salga y viaje. Con manejo mediano el olor existe pero se queda en la
+   * cochera; el conflicto arranca cuando desborda el lindero.
+   */
+  const vecino = cortar(rampa(0.28, 0.95, amoniaco));
+
+  /*
+   * FERMENTO — la cama buena no es "la ausencia de olor": está VIVA.
+   *   "Bien manejada, la cama fermenta suavemente, genera algo de calor,
+   *    controla el olor y al final se saca como abono ya semicompostado."
+   * Aparece solo en el tramo bueno. Es la recompensa: donde había gas hay calor,
+   * y ese calor huele a tierra. El final de la pieza no es un vacío — es trabajo.
+   */
+  const fermento = rampa(0.55, 1, c);
+
+  /*
+   * ARDE — la señal del cuerpo, lo único que el maestro acepta como medida.
+   * No es un ppm: es "¿le arden los ojos al entrar?". Se enciende antes de que
+   * el amoníaco esté al tope, porque el ojo humano es sensible desde
+   * concentraciones bajas — y esa sensibilidad temprana es justamente la alarma.
+   */
+  const arde = rampa(0.18, 0.7, amoniaco);
+
+  /*
+   * LA CONSERVACIÓN — el corazón.
+   * Lo que no se voló, está en la cama. Ni un grano se pierde en el camino:
+   * `aire + cama === 1`. La escena pinta esta línea literalmente con las mismas
+   * partículas doradas.
+   */
+  const nitrogeno = { aire: amoniaco, cama: 1 - amoniaco };
+
+  /*
+   * ALTURA DEL VELO — hasta dónde llega el aire cargado.
+   * Con la cama empapada el estrato le pasa por encima a la gallina y le lame
+   * la cara; con cama buena se hunde hasta ser una lámina al ras que ni ella
+   * respira. Nunca llega a la nariz del humano: no hace falta para que le arda,
+   * y fingir que sí sería el humito de caricatura que esta pieza evita.
+   */
+  const alturaVelo = 0.1 + amoniaco * 0.72;
+
+  return {
+    carbono: c,
+    saturacion,
+    humedad,
+    amoniaco,
+    sulfhidrico,
+    moscas,
+    vecino,
+    fermento,
+    arde,
+    nitrogeno,
+    alturaVelo,
+  };
+}
+
+/**
+ * Densidad del velo a una altura dada — la curva que ARGUMENTA la pieza.
+ *
+ * El gas no llena el galpón como un vaso de agua: se acuesta. Es denso contra
+ * la cama (ahí nace) y se ralea hacia arriba. Esta función es la razón por la
+ * que la gallina y el humano no viven en el mismo aire aunque estén en el mismo
+ * cuarto — y por la que el humano cree que "no es para tanto".
+ *
+ * El exponente 2.4 no es tuneo: es lo que hace que a la altura de la gallina
+ * (0.26 m) la densidad sea varias veces la que hay en la nariz del humano
+ * (1.58 m). La distancia entre esos dos números es el mensaje de la pieza.
+ *
+ * @param {number} y      altura en metros sobre la cama
+ * @param {number} techo  `alturaVelo` del estado del aire
+ * @returns {number} 0..1
+ */
+export function densidadEnAltura(y, techo) {
+  if (y <= 0) return 1;
+  const t = cortar(y / Math.max(0.001, techo));
+  /* Cola larga: por encima del velo el aire NO está limpio de golpe — queda un
+     resto que sube hasta el caballete. Es lo que le arde al que entra. */
+  const nucleo = Math.pow(1 - t, 2.4);
+  const cola = 0.16 * Math.exp(-y * 0.55);
+  return cortar(nucleo + cola);
+}
+
+/* ------------------------------------------------------------------ */
+/* Tier — cuántas motas, cuántas moscas.                               */
+/* ------------------------------------------------------------------ */
+
+/*
+ * La gama baja también tiene cochera. El argumento de la pieza no puede vivir
+ * en el conteo de partículas: con 90 motas y 3 estratos la lectura es la misma
+ * —el oro se va o se queda, el velo pesa a la altura de la gallina— y ese es el
+ * único criterio que decide estos números.
+ */
+const CONTEOS = {
+  alto: { motas: 420, moscas: 26, estratos: 7, cuerpos: true },
+  medio: { motas: 200, moscas: 14, estratos: 5, cuerpos: true },
+  bajo: { motas: 90, moscas: 7, estratos: 3, cuerpos: true },
+};
+
+/** @param {'alto'|'medio'|'bajo'} tier */
+export const olorDeTier = (tier) => CONTEOS[tier] || CONTEOS.medio;

--- a/src/visual/mundo3d/olor/index.js
+++ b/src/visual/mundo3d/olor/index.js
@@ -1,0 +1,98 @@
+/*
+ * olor/ — EL OLOR VISIBLE. Hacer ver lo que solo se huele.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * LA IDEA QUE ORDENA TODO
+ *
+ *   El olor no es "normal": es nitrógeno perdiéndose. O sea, plata volándose.
+ *
+ * El campesino cree que el olor es el precio de tener marranos. No lo es: es un
+ * recurso mal manejado escapándose al aire. Todo este módulo existe para hacer
+ * ver eso, y para hacerlo SIN REGAÑAR — él no tiene la culpa de que su cochera
+ * huela; nadie le explicó.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * LAS TRES DECISIONES DE ARTE
+ *
+ * 1. EL AMONÍACO ES DORADO, NO VERDE. Un humito verde tóxico es mentira dos
+ *    veces: el amoníaco es incoloro, y "verde veneno" dice "sáquelo de acá"
+ *    cuando hay que decir "eso es SUYO, no lo deje ir". Las motas son del color
+ *    del grano de maíz, porque eso son: el abono que ya pagó, saliéndose por el
+ *    techo. Duele porque es bonito y se va.
+ *
+ * 2. EL NITRÓGENO SE CONSERVA, Y ES UN SOLO SISTEMA DE PARTÍCULAS.
+ *    `nitrogeno.aire + nitrogeno.cama = 1`. Las mismas motas que se fugaban se
+ *    SIENTAN en el colchón cuando uno echa material seco. El oro no desaparece:
+ *    cambia de lugar. Ese es el argumento entero, y no lleva una sola palabra.
+ *
+ * 3. EL VELO SE ACUESTA, Y TIENE UN BORDE. El gas no sube en volutas: es un
+ *    estrato que pesa sobre la cama. Y ese borde deja a la gallina adentro
+ *    (cabeza a 0.26 m) y al dueño afuera (nariz a 1.58 m) —
+ *
+ *      "Si a usted le arden los ojos al entrar al gallinero, la gallina lleva
+ *       horas así."
+ *
+ *    — que es la frase madre del corpus, convertida en una línea de flotación.
+ *
+ * Y la física opuesta enseña sola: el amoníaco SUBE, es dorado, ronda y AVISA
+ * con ardor; el sulfhídrico BAJA, es pardo muerto, está inmóvil y CALLA. Uno le
+ * roba; el otro lo mata.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * TODO CUELGA DE UN NÚMERO
+ *
+ * `aire(carbono)` — cuánto material seco hay en la cama. De ahí salen el velo,
+ * el oro, las moscas, el charco, la nube del vecino, el pozo, el fog y el
+ * espesor del colchón. No hay un estado "sucio" y otro "limpio" pintados a
+ * mano: hay una cantidad de aserrín y sus consecuencias, calculadas. Es la
+ * regla del carbono hecha interfaz — y el antes/después es la MISMA cochera,
+ * que es lo que lo vuelve una promesa y no la finca de otro señor.
+ *
+ * SIN CIFRAS. El corpus del maestro (56 pares sobre olores) no da ni una: no
+ * hay ppm, ni C:N, ni centímetros de cama. Da señales del cuerpo —la prueba del
+ * puño, el ardor de ojos, la nube de mosca— porque el puño está siempre y el
+ * laboratorio queda a cuatro horas. Esta pieza respeta eso: no hay HUD.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * LA PUERTA
+ *
+ *   import OlorVisible from '.../olor';
+ *   <OlorVisible />                      // decide tier solo, arranca en cero
+ *
+ * `OlorVisible` es el anfitrión: monta la escena 3D (lazy — la gama baja jamás
+ * descarga three) o el corte de perfil, y abajo la palada de material seco.
+ *
+ * Complementa a `../estiercol/` (el biodigestor y la compostera): allá está la
+ * SOLUCIÓN, acá el PROBLEMA. Este módulo termina justo donde aquel empieza —
+ * en la cama que sale como abono semicompostado.
+ */
+export { default } from './OlorVisible.jsx';
+export { default as OlorVisible } from './OlorVisible.jsx';
+
+/* La pieza por partes (para galerías, previews o montaje propio). */
+export { default as CocheraEnCorte } from './CocheraEnCorte.jsx';
+export { default as PaladaDeSeco } from './PaladaDeSeco.jsx';
+
+/* El modelo: la función madre y sus consecuencias. Puro, sin three. */
+export { aire, densidadEnAltura, olorDeTier, rampa, ALTURAS } from './aireCargado.js';
+
+/* Las señales del cuerpo — el HUD que esta pieza NO tiene. */
+export {
+  PARADAS,
+  paradaDe,
+  senalesDe,
+  senalPuno,
+  senalOjos,
+  senalMosca,
+  senalVecino,
+  senalPozo,
+} from './senalesDelCuerpo.js';
+
+/* Los colores y las medidas de la cochera. */
+export { COLORES, COCHERA, BEBEDERO } from './olor.geom.js';
+
+/*
+ * EscenaOlorVisible NO se re-exporta acá a propósito: importa three y
+ * @react-three, y este índice lo consume gente que no quiere ese peso. Se monta
+ * perezosa desde OlorVisible.jsx y en ningún otro lado.
+ */

--- a/src/visual/mundo3d/olor/olor.css
+++ b/src/visual/mundo3d/olor/olor.css
@@ -1,0 +1,332 @@
+/*
+ * olor.css — el vestido del control.
+ *
+ * Sobrio a propósito: la protagonista es la cochera, no el widget. Nada brilla,
+ * nada pulsa, nada felicita.
+ *
+ * NI UN ROJO DE ALARMA. En la paleta de la casa el rojo es cochinilla y café
+ * cereza —textil y fruto—, nunca "rojo catástrofe de UI". Y acá eso además es
+ * de fondo: pintar de rojo la cochera del que mira sería exactamente el regaño
+ * que la pieza evita. Cuando algo va mal, se dice en ÁMBAR (la señal amable de
+ * la casa, `ACENTOS.ambar`); cuando va bien, en el verde de trabajo. Y el único
+ * ámbar cargado es el de la fosa, porque ahí sí se muere gente.
+ *
+ * El riel se llena del color del MATERIAL SECO (la vega clara del aserrín y la
+ * cascarilla), no de un verde de "correcto". Uno no está completando una barra
+ * de progreso: está echando cascarilla.
+ *
+ * Blancos sobre un velo oscuro: la escena de atrás va de un aire turbio a una
+ * tarde de finca limpia, así que el panel no puede depender del fondo.
+ *
+ * Blancos de toque de 44px para mano de campo (guante, barro, sol en la
+ * pantalla).
+ */
+
+/* ----------------------------------------------------------- la pieza --- */
+
+/*
+ * El cuadro: la cochera arriba, la palada abajo. Nada más. Sin marco, sin
+ * título, sin botonera — el que llega ve una cochera y un deslizador, y eso ya
+ * es una pregunta.
+ */
+.olor {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 22rem;
+  overflow: hidden;
+  background: #ecdcc2; /* = CIELOS.corral.fondo: la tarde de finca, mientras carga */
+}
+
+.olor__lienzo {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.olor__lienzo canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* La escena entra con un fundido corto: nunca un salto en negro. */
+.olor-canvas {
+  opacity: 0;
+  transition: opacity 0.45s ease-out;
+}
+
+.olor-canvas--lista {
+  opacity: 1;
+}
+
+/* Mientras baja three: el fondo de la tarde de finca, quieto. Sin "Cargando…",
+   sin spinner. La cochera va a estar ahí en un segundo. */
+.olor__esperando {
+  position: absolute;
+  inset: 0;
+  background: #ecdcc2;
+}
+
+/* El corte de perfil (gama baja): ocupa el lienzo completo, respirando. */
+.ol__corte {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+/* ---------------------------------------------------------- el control --- */
+
+.ol {
+  /* Los tokens, derivados de la paleta madre — ni un hex de gusto propio.
+     ámbar = ACENTOS.ambar (#d9a13b) · verde = VERDES.trabajo (#5f8a3f)
+     seco  = TIERRAS.vega  (#c9b593) · tinta = NEUTROS.tinta  (#241a10) */
+  --ol-tinta: 250 248 240;
+  --ol-tenue: rgb(250 248 240 / 0.62);
+  --ol-linea: rgb(250 248 240 / 0.22);
+  --ol-ambar: 217 161 59;
+  --ol-verde: 122 154 63;
+  --ol-seco: 201 181 147;
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 0.9rem 1.05rem 0.8rem;
+  color: rgb(var(--ol-tinta));
+  /* Pardo cálido, no gris de app: esto pasa en una finca. */
+  background: linear-gradient(to top, rgb(26 20 14 / 0.88), rgb(26 20 14 / 0.64));
+  backdrop-filter: blur(7px);
+  border-top: 1px solid var(--ol-linea);
+  font-family: inherit;
+}
+
+/* ---------------------------------------------------------------- cabeza --- */
+
+.ol__cabeza {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.ol__titulo {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+
+.ol__texto {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--ol-tenue);
+  max-width: 46ch;
+}
+
+/* ------------------------------------------------------------------ riel --- */
+
+.ol__riel {
+  position: relative;
+  height: 44px; /* mano de campo */
+  display: flex;
+  align-items: center;
+}
+
+.ol__pista {
+  position: absolute;
+  inset-inline: 0;
+  height: 6px;
+  border-radius: 3px;
+  background: rgb(250 248 240 / 0.16);
+  overflow: visible;
+}
+
+/* Lo lleno es el material seco: cascarilla, aserrín. No un verde de aprobado. */
+.ol__seco {
+  height: 100%;
+  border-radius: 3px;
+  background: linear-gradient(to right, rgb(var(--ol-seco) / 0.55), rgb(var(--ol-seco)));
+  transition: width 0.08s linear;
+}
+
+.ol__hito {
+  position: absolute;
+  top: 50%;
+  width: 2px;
+  height: 10px;
+  margin-left: -1px;
+  transform: translateY(-50%);
+  background: rgb(250 248 240 / 0.34);
+  border-radius: 1px;
+}
+
+/* El input de verdad, invisible encima del riel dibujado. */
+.ol__input {
+  position: relative;
+  width: 100%;
+  height: 44px;
+  margin: 0;
+  background: transparent;
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+}
+
+.ol__input:focus-visible {
+  outline: 2px solid rgb(var(--ol-ambar));
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
+.ol__input::-webkit-slider-thumb {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: rgb(var(--ol-seco));
+  border: 2px solid rgb(26 20 14 / 0.5);
+  box-shadow: 0 1px 5px rgb(0 0 0 / 0.4);
+  cursor: grab;
+}
+
+.ol__input::-moz-range-thumb {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: rgb(var(--ol-seco));
+  border: 2px solid rgb(26 20 14 / 0.5);
+  box-shadow: 0 1px 5px rgb(0 0 0 / 0.4);
+  cursor: grab;
+}
+
+.ol__input:active::-webkit-slider-thumb {
+  cursor: grabbing;
+}
+
+.ol__input::-webkit-slider-runnable-track,
+.ol__input::-moz-range-track {
+  background: transparent;
+  border: none;
+}
+
+/* --------------------------------------------------------------- paradas --- */
+
+.ol__paradas {
+  position: relative;
+  height: 1.9rem;
+}
+
+.ol__parada {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  padding: 0.2rem 0.4rem;
+  min-width: 44px;
+  min-height: 30px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--ol-tenue);
+  font: inherit;
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+/* Las de los extremos no se salen del panel. */
+.ol__parada:first-child {
+  transform: translateX(-8%);
+}
+
+.ol__parada:last-child {
+  transform: translateX(-92%);
+}
+
+.ol__parada:hover {
+  color: rgb(var(--ol-tinta));
+}
+
+.ol__parada--aqui {
+  color: rgb(var(--ol-tinta));
+  background: rgb(250 248 240 / 0.1);
+}
+
+.ol__parada:focus-visible {
+  outline: 2px solid rgb(var(--ol-ambar));
+  outline-offset: 1px;
+}
+
+/* -------------------------------------------------------------- señales --- */
+
+/*
+ * Las tres señales del cuerpo: el puño, los ojos, la mosca. Esto es lo que en
+ * otra app sería un panel de métricas. Acá son frases, porque el maestro no da
+ * cifras: da señales que uno puede comprobar con la mano.
+ */
+.ol__senales {
+  display: flex;
+  flex-direction: column;
+  gap: 0.28rem;
+  margin: 0.1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ol__senal {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding-left: 0.7rem;
+  border-left: 2px solid rgb(var(--ol-ambar) / 0.75);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  color: rgb(var(--ol-tinta) / 0.92);
+}
+
+.ol__senal--bien {
+  border-left-color: rgb(var(--ol-verde));
+  color: var(--ol-tenue);
+}
+
+.ol__senalTexto {
+  font-weight: 500;
+}
+
+/*
+ * El aparte: la frase que traduce lo que uno está sintiendo. Va en cursiva y en
+ * ámbar tenue — es el maestro hablando bajito al lado de uno, no un cartel de
+ * advertencia. Si esto fuera un banner rojo, sería un regaño.
+ */
+.ol__aparte {
+  font-size: 0.72rem;
+  font-style: italic;
+  line-height: 1.35;
+  color: rgb(var(--ol-ambar));
+  max-width: 44ch;
+}
+
+/* ------------------------------------------------------------------ pie --- */
+
+.ol__tesis {
+  margin: 0.15rem 0 0;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  color: var(--ol-tenue);
+  max-width: 48ch;
+}
+
+/* ---------------------------------------------------------------- calma --- */
+
+@media (prefers-reduced-motion: reduce) {
+  .ol__seco {
+    transition: none;
+  }
+}

--- a/src/visual/mundo3d/olor/olor.geom.js
+++ b/src/visual/mundo3d/olor/olor.geom.js
@@ -1,0 +1,668 @@
+/*
+ * olor.geom — la cochera, la cama, la fosa, la cerca y los cuerpos.
+ *
+ * El escenario del problema. Todo en METROS (1 unidad = 1 m) y eso no es un
+ * detalle técnico: es la pieza. Si la gallina no mide lo que mide una gallina,
+ * el argumento —que ella respira un aire y el dueño respira otro, en el mismo
+ * cuarto— se cae. Las alturas viven en `aireCargado.ALTURAS` y acá se obedecen.
+ *
+ * Qué hay:
+ *   · Piso          — losa con PENDIENTE hacia un canal. La pendiente es el
+ *                     personaje silencioso: es lo que separa el sólido del
+ *                     líquido, y separarlos es media solución.
+ *   · Cama          — el colchón de material seco. Su espesor lo manda el
+ *                     carbono; su superficie es irregular porque la pisan.
+ *   · Estructura    — media agua de finca: muros bajos, postes, techo a un
+ *                     agua con CABALLETE ABIERTO arriba (por ahí se fuga el
+ *                     oro y por ahí entra el remedio).
+ *   · Bebedero      — el foco. "Una de las causas más comunes de mal olor
+ *                     localizado (...) aunque el resto de la cama esté seca."
+ *   · Fosa          — el hueco donde se sienta el que calla.
+ *   · Cerca         — el lindero. Del otro lado hay una casa con gente.
+ *   · Bulto         — la cascarilla arrimada contra el poste. El remedio ya
+ *                     está ahí, apoyado. Nadie le ha dicho para qué sirve.
+ *   · Cuerpos       — gallina, cerdo, persona: siluetas planas a escala real.
+ *
+ * Los cuerpos son SILUETAS, no personajes. Decisión de arte deliberada: los
+ * bichos rubber-hose de Chagra son actores con nombre y carisma, y acá un actor
+ * carismático robaría la escena — el protagonista es el aire. Estas son figuras
+ * de referencia, como las de un plano de arquitectura: están para decir "a esta
+ * altura hay una cabeza viva". Planas, oscuras, calladas.
+ *
+ * TÉCNICA (calcada de floraParamo/sucesion): cada pieza se FUSIONA en UNA
+ * geometría con el color horneado en vertexColors → una draw-call. Cero assets,
+ * todo procedural, corre headless.
+ *
+ * Solo mallas y datos: nada de WebGL ni de r3f acá.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { rng } from '../bosque/entQuenua.geom.js';
+import { mezclar, TIERRAS, CORTEZAS, NEUTROS, ACENTOS, NIEBLAS, PALETA, AGUAS } from '../paleta/index.js';
+
+/* ------------------------------------------------------------------ */
+/* COLORES — derivados de la paleta madre, ni un hex suelto.           */
+/* ------------------------------------------------------------------ */
+
+/*
+ * LA DECISIÓN DE ARTE DE TODA LA PIEZA está en dos líneas de acá abajo.
+ *
+ * El amoníaco NO se pinta de verde tóxico. El humito verde de caricatura es
+ * mentira dos veces: el amoníaco es incoloro, y "verde tóxico" le dice al
+ * campesino "eso es veneno, sáquelo" — cuando lo que hay que decirle es "eso
+ * es SUYO, no lo deje ir".
+ *
+ * Se pinta DORADO. El color del grano de maíz, del abono, de la cosecha:
+ *   `nitrogeno: ACENTOS.maizGrano` — el mismo amarillo del grano en la mazorca.
+ * Porque eso es literalmente lo que se está volando. Cuando el campesino ve
+ * subir el oro por el caballete, no está viendo un gas: está viendo lo que
+ * pagó en el bulto de concentrado saliéndose por el techo. Duele porque es
+ * bonito y se va.
+ *
+ * Lo desagradable no lo pone el color del gas, lo pone el VELO: un turbio
+ * amarillo-sucio, desaturado, sin nada de brillo, que se acuesta sobre la cama
+ * y se come el color de todo lo que hay detrás. Ahí está la incomodidad —
+ * no en un tono asqueroso, sino en un aire que ensucia lo que toca.
+ */
+export const COLORES = {
+  /* — el gas — */
+
+  /* El velo del amoníaco: la niebla dorada de la casa, revolcada en pajonal y
+     apagada contra el zinc. Queda un amarillo turbio de orina vieja que no
+     pertenece a ninguna hora del día — y esa es la idea: es aire que sobra. */
+  velo: mezclar(mezclar(NIEBLAS.dorada, TIERRAS.pajonal, 0.62), NEUTROS.lamina, 0.44),
+  /* El corazón del estrato, contra la cama: más sucio todavía. */
+  veloHondo: mezclar(mezclar(TIERRAS.pajonal, NEUTROS.lamina, 0.5), TIERRAS.turba, 0.3),
+
+  /* EL ORO. El nitrógeno. Lo que se va o se queda. */
+  nitrogeno: ACENTOS.maizGrano, // en el aire: el grano de la mazorca, fugándose
+  nitrogenoCama: ACENTOS.ambar, // ya sentado en la cama: el mismo oro, más hondo
+  nitrogenoFuga: mezclar(ACENTOS.maizGrano, NIEBLAS.lechosa, 0.35), // arriba, al perderse
+
+  /* El que calla. Pardo violáceo muerto: ni brilla ni sube ni avisa. El
+     índigo del mortiño ahogado en la tierra más honda — un color que el ojo
+     resbala, y ese resbalón ES el peligro. */
+  sulfhidrico: mezclar(TIERRAS.cacao, ACENTOS.indigo, 0.46),
+
+  /* — la materia — */
+  lodo: mezclar(TIERRAS.cacao, NEUTROS.tinta, 0.38), // el barro de la manguera
+  charco: mezclar(mezclar(TIERRAS.cacao, AGUAS.viva, 0.25), NEUTROS.tinta, 0.2),
+  camaSeca: mezclar(TIERRAS.vega, TIERRAS.camino, 0.34), // cascarilla, aserrín
+  camaSecaClara: mezclar(TIERRAS.vega, NIEBLAS.lechosa, 0.4), // la viruta al sol
+  camaSucia: mezclar(TIERRAS.turba, NEUTROS.tinta, 0.28), // la cama vencida
+  estiercol: mezclar(TIERRAS.turba, TIERRAS.cacao, 0.5),
+
+  /* — la obra — */
+  piso: NEUTROS.concreto,
+  pisoMojado: mezclar(NEUTROS.concreto, TIERRAS.cacao, 0.5),
+  muro: mezclar(NEUTROS.cal, TIERRAS.vega, 0.3),
+  poste: CORTEZAS.roble,
+  madera: PALETA.madera,
+  techo: NEUTROS.lamina,
+  techoSol: mezclar(NEUTROS.lamina, NIEBLAS.dorada, 0.28),
+
+  /* — los cuerpos: tinta, siempre. Son sombras con altura, no personajes. — */
+  cuerpo: NEUTROS.tinta,
+  mosca: NEUTROS.tinta,
+
+  /* — el otro lado de la cerca — */
+  casaVecino: mezclar(NEUTROS.cal, NIEBLAS.dorada, 0.3),
+  tejaVecino: mezclar(CORTEZAS.sieteCueros, NEUTROS.lamina, 0.35),
+};
+
+/* ------------------------------------------------------------------ */
+/* La cochera — medidas.                                               */
+/* ------------------------------------------------------------------ */
+
+export const COCHERA = {
+  ancho: 6.2, // x
+  fondo: 4.0, // z
+  muro: 1.05, // altura del muro bajo: el cerdo no salta, el aire sí sale
+  aleroBajo: 2.35, // el techo a un agua, lado bajo
+  aleroAlto: 3.05, // lado alto
+  canalX: -2.6, // el canal corre pegado al muro bajo
+  fosaX: -4.3, // la fosa, afuera, en el punto más bajo
+  cercaZ: 4.9, // el lindero del vecino
+};
+
+/* ------------------------------------------------------------------ */
+/* Utilidades de horneado (patrón de la casa).                         */
+/* ------------------------------------------------------------------ */
+
+/** Hornea un color en los vértices y devuelve la misma geometría. */
+function pintar(geo, color, variacion = 0, r = null) {
+  const c = new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  const pos = geo.attributes.position;
+  for (let i = 0; i < n; i++) {
+    let cr = c.r;
+    let cg = c.g;
+    let cb = c.b;
+    if (variacion > 0) {
+      /* Variación por ALTURA del vértice, no aleatoria pura: así la cama se ve
+         más clara arriba (donde le da la luz y está la viruta fresca) y más
+         oscura abajo. Le da volumen sin costar una sola luz. */
+      const t = 1 + (pos.getY(i) * 0.5 + (r ? r() - 0.5 : 0)) * variacion;
+      cr *= t;
+      cg *= t;
+      cb *= t;
+    }
+    arr[i * 3] = cr;
+    arr[i * 3 + 1] = cg;
+    arr[i * 3 + 2] = cb;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Caja pintada, ubicada y rotada. */
+function caja(w, h, d, color, [x, y, z], rot = null, variacion = 0, r = null) {
+  const g = new THREE.BoxGeometry(w, h, d);
+  pintar(g, color, variacion, r);
+  if (rot) g.rotateZ(rot);
+  g.translate(x, y, z);
+  return g;
+}
+
+/** Fusiona descartando nulos (mergeGeometries se cae con un solo hueco). */
+function fusionar(lista) {
+  const buenas = lista.filter(Boolean);
+  if (!buenas.length) return null;
+  const g = mergeGeometries(buenas, false);
+  buenas.forEach((b) => b.dispose());
+  return g;
+}
+
+/* ------------------------------------------------------------------ */
+/* EL PISO — la pendiente que separa el sólido del líquido.            */
+/* ------------------------------------------------------------------ */
+
+/*
+ * "Un piso liso sin pendiente hace que el líquido se quede empozado (...) y eso
+ *  favorece la fermentación anaeróbica y el olor a huevo podrido."
+ *
+ * La losa cae suavemente hacia el canal. Es la pieza más aburrida de la escena
+ * y la que más trabaja: si el orín escurre solo, el sólido se queda seco arriba
+ * y se puede recoger con pala; si no, se revuelven y se pudren juntos. La obra
+ * que evita el problema no se ve — por eso hay que dibujarla.
+ */
+export function geomPiso() {
+  const { ancho, fondo, canalX } = COCHERA;
+  const segX = 24;
+  const segZ = 16;
+  const g = new THREE.PlaneGeometry(ancho, fondo, segX, segZ);
+  g.rotateX(-Math.PI / 2);
+  const pos = g.attributes.position;
+  for (let i = 0; i < pos.count; i++) {
+    const x = pos.getX(i);
+    /* Caída suave hacia el canal (unos pocos centímetros por metro: la
+       pendiente "suave" del maestro, que él se negó a poner en porcentaje). */
+    const caida = (x - ancho / 2) * -0.022;
+    /* El canal: una vaguada angosta pegada al muro bajo. */
+    const d = Math.abs(x - canalX);
+    const canal = d < 0.28 ? -0.09 * Math.cos((d / 0.28) * Math.PI * 0.5) : 0;
+    pos.setY(i, caida + canal);
+  }
+  g.computeVertexNormals();
+  pintar(g, COLORES.piso, 0.06, rng(7));
+  return g;
+}
+
+/* ------------------------------------------------------------------ */
+/* LA CAMA — el colchón que decide todo.                               */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Dos geometrías, la MISMA huella: la cama vencida (delgada, apelmazada,
+ * brillante de humedad) y la cama profunda (gruesa, mullida, con relieve de
+ * material suelto). La escena las cruza con el deslizador. Que sean el mismo
+ * pedazo de piso es todo el argumento del antes/después: no es otra finca ni
+ * otro dueño con más plata — es la misma cochera el mes entrante.
+ *
+ * "Mientras esté seca y suelta, controla el olor; en cuanto se compacta y moja,
+ *  hay que voltearla o renovarla."
+ *
+ * El espesor lo dice el maestro sin números: "una capa de varios centímetros y
+ * seguir agregando (...) hasta lograr un colchón grueso". Así que la vencida es
+ * una lámina pegada al piso y la buena es un colchón que se nota al pisarlo.
+ */
+function camaBase(espesor, rugosidad, semilla) {
+  const { ancho, fondo } = COCHERA;
+  const g = new THREE.PlaneGeometry(ancho - 0.5, fondo - 0.4, 30, 20);
+  g.rotateX(-Math.PI / 2);
+  const pos = g.attributes.position;
+  const r = rng(semilla);
+  for (let i = 0; i < pos.count; i++) {
+    const x = pos.getX(i);
+    const z = pos.getZ(i);
+    /* Relieve de material suelto: ondas cruzadas + grano. La cama buena tiene
+       textura porque está SUELTA; la vencida es un piso pegado. */
+    const onda = Math.sin(x * 1.7 + z * 0.9) * 0.5 + Math.sin(z * 2.3 - x * 1.1) * 0.5;
+    /* Hundido donde pisan y se echan (el centro-derecha, junto al comedero). */
+    const huella = Math.exp(-((x - 1.1) ** 2 + (z - 0.2) ** 2) * 0.35) * 0.45;
+    pos.setY(i, espesor * (1 - huella) + onda * rugosidad + (r() - 0.5) * rugosidad * 0.8);
+  }
+  g.computeVertexNormals();
+  return g;
+}
+
+/** La cama vencida: lámina apelmazada, oscura, mojada. */
+export function geomCamaSucia() {
+  const g = camaBase(0.045, 0.012, 21);
+  pintar(g, COLORES.camaSucia, 0.5, rng(22));
+  return g;
+}
+
+/** La cama profunda: colchón grueso, suelto, claro. */
+export function geomCamaBuena() {
+  const g = camaBase(0.28, 0.055, 21);
+  pintar(g, COLORES.camaSeca, 0.85, rng(23));
+  return g;
+}
+
+/* ------------------------------------------------------------------ */
+/* LA ESTRUCTURA — media agua con caballete abierto.                   */
+/* ------------------------------------------------------------------ */
+
+/*
+ * "Un techo a un agua con caballete abierto o rejilla arriba deja salir el aire
+ *  caliente cargado de amoníaco (...) mientras entra aire fresco por los lados."
+ *
+ * La estructura ES el diagnóstico. El muro bajo y el caballete abierto no son
+ * estilo de finca: son la ventilación cruzada dibujada. Y el caballete tiene un
+ * doble filo que la escena aprovecha: por esa misma boca por donde entra el
+ * remedio (el aire), se fuga el oro. Cuando el manejo es malo, el caballete es
+ * la herida por donde la finca se desangra en dorado.
+ */
+export function geomEstructura() {
+  const { ancho, fondo, muro, aleroBajo, aleroAlto } = COCHERA;
+  const p = [];
+  const hx = ancho / 2;
+  const hz = fondo / 2;
+
+  /* Muros bajos: tres lados. El frente queda abierto (por ahí miramos). */
+  p.push(caja(0.12, muro, fondo, COLORES.muro, [-hx, muro / 2, 0], null, 0.12, rng(31)));
+  p.push(caja(0.12, muro, fondo, COLORES.muro, [hx, muro / 2, 0], null, 0.12, rng(32)));
+  p.push(caja(ancho, muro, 0.12, COLORES.muro, [0, muro / 2, -hz], null, 0.12, rng(33)));
+
+  /* Postes: hasta el techo, en las cuatro esquinas y dos intermedios. */
+  const postes = [
+    [-hx, -hz, aleroBajo],
+    [-hx, hz, aleroBajo],
+    [hx, -hz, aleroAlto],
+    [hx, hz, aleroAlto],
+    [0, -hz, (aleroBajo + aleroAlto) / 2],
+    [0, hz, (aleroBajo + aleroAlto) / 2],
+  ];
+  postes.forEach(([x, z, h], i) => {
+    p.push(caja(0.14, h, 0.14, COLORES.poste, [x, h / 2, z], null, 0.18, rng(40 + i)));
+  });
+
+  /* Vigas del alero. */
+  p.push(caja(ancho + 0.3, 0.1, 0.12, COLORES.madera, [0, aleroBajo, -hz], null, 0.1, rng(50)));
+  p.push(caja(0.12, 0.1, fondo, COLORES.madera, [-hx, aleroBajo, 0], null, 0.1, rng(51)));
+  p.push(caja(0.12, 0.1, fondo, COLORES.madera, [hx, aleroAlto, 0], null, 0.1, rng(52)));
+
+  /*
+   * El techo: dos faldones a un agua que NO se tocan arriba. Ese espacio entre
+   * ellos es el caballete abierto — la boca por donde respira la cochera. Está
+   * dibujado como un hueco, no como una pieza: lo importante es el vacío.
+   */
+  const inclina = Math.atan2(aleroAlto - aleroBajo, ancho);
+  const largo = Math.hypot(ancho, aleroAlto - aleroBajo);
+  const faldon = new THREE.BoxGeometry(largo * 0.52, 0.05, fondo + 0.5);
+  pintar(faldon, COLORES.techoSol, 0.08, rng(60));
+  faldon.rotateZ(inclina);
+  faldon.translate(-ancho * 0.26, (aleroBajo + aleroAlto) / 2 - 0.16, 0);
+  p.push(faldon);
+
+  const faldon2 = new THREE.BoxGeometry(largo * 0.42, 0.05, fondo + 0.5);
+  pintar(faldon2, COLORES.techo, 0.08, rng(61));
+  faldon2.rotateZ(inclina);
+  faldon2.translate(ancho * 0.29, (aleroBajo + aleroAlto) / 2 + 0.28, 0);
+  p.push(faldon2);
+
+  return fusionar(p);
+}
+
+/* ------------------------------------------------------------------ */
+/* EL BEBEDERO — el foco localizado.                                   */
+/* ------------------------------------------------------------------ */
+
+/*
+ * "Esa zona mojada alrededor del bebedero se vuelve un foco de fermentación
+ *  anaeróbica y amoníaco, además de criadero de moscas, AUNQUE EL RESTO DE LA
+ *  CAMA ESTÉ SECA."
+ *
+ * Por eso el bebedero está aquí y por eso el charco y las moscas nacen justo en
+ * este punto y no repartidos parejo. El olor tiene domicilio.
+ */
+export const BEBEDERO = { x: -1.5, z: 1.15, r: 0.34 };
+
+export function geomBebedero() {
+  const p = [];
+  const t = new THREE.CylinderGeometry(BEBEDERO.r, BEBEDERO.r * 0.86, 0.24, 12);
+  pintar(t, COLORES.techo, 0.1, rng(70));
+  t.translate(BEBEDERO.x, 0.12, BEBEDERO.z);
+  p.push(t);
+  /* El agua adentro, rebosada (por eso hay charco). */
+  const a = new THREE.CylinderGeometry(BEBEDERO.r * 0.9, BEBEDERO.r * 0.9, 0.02, 12);
+  pintar(a, AGUAS.viva, 0);
+  a.translate(BEBEDERO.x, 0.235, BEBEDERO.z);
+  p.push(a);
+  return fusionar(p);
+}
+
+/** El charco: la mancha que rebosa del bebedero. Aparece con la humedad. */
+export function geomCharco() {
+  const g = new THREE.CircleGeometry(1.15, 22);
+  g.rotateX(-Math.PI / 2);
+  const pos = g.attributes.position;
+  const r = rng(75);
+  /* Borde irregular: el agua no hace círculos. */
+  for (let i = 0; i < pos.count; i++) {
+    const x = pos.getX(i);
+    const z = pos.getZ(i);
+    const d = Math.hypot(x, z);
+    if (d > 0.01) {
+      const f = 1 + Math.sin(Math.atan2(z, x) * 3.7) * 0.16 + (r() - 0.5) * 0.1;
+      pos.setX(i, x * f);
+      pos.setZ(i, z * f);
+    }
+  }
+  pintar(g, COLORES.charco, 0);
+  g.translate(BEBEDERO.x, 0.012, BEBEDERO.z);
+  return g;
+}
+
+/* ------------------------------------------------------------------ */
+/* LA FOSA — el hueco donde se sienta el que calla.                    */
+/* ------------------------------------------------------------------ */
+
+/*
+ * "Es más pesado que el aire, así que se acumula en pozos, fosas y espacios
+ *  bajos cerrados."
+ *
+ * La fosa está AFUERA de la cochera, en el punto más bajo, donde el canal
+ * entrega. Es un hueco en la tierra con un brocal de piedra. Nada más. Su
+ * quietud es el punto: mientras el amoníaco monta un espectáculo dorado adentro,
+ * acá afuera no pasa nada visible — y esto es lo que mata.
+ */
+export function geomFosa() {
+  const p = [];
+  const { fosaX } = COCHERA;
+  const z = 1.2;
+  /* Brocal: cuatro piedras largas alrededor del hueco. */
+  const b = [
+    [0.98, 0.16, 0.12, 0, 0.9],
+    [0.98, 0.16, 0.12, 0, -0.9],
+    [0.12, 0.16, 1.8, 0.55, 0],
+    [0.12, 0.16, 1.8, -0.55, 0],
+  ];
+  b.forEach(([w, h, d, dx, dz], i) => {
+    p.push(caja(w, h, d, TIERRAS.piedra, [fosaX + dx, 0.02, z + dz], null, 0.14, rng(80 + i)));
+  });
+  /* Las paredes del hueco: un cajón hundido, oscuro. */
+  const hueco = new THREE.BoxGeometry(1.05, 0.9, 1.85);
+  pintar(hueco, mezclar(TIERRAS.piedra, NEUTROS.tinta, 0.55), 0.2, rng(85));
+  hueco.translate(fosaX, -0.45, z);
+  p.push(hueco);
+  return fusionar(p);
+}
+
+/** La superficie del líquido en la fosa: quieta, opaca, sin reflejo. */
+export function geomFosaLiquido() {
+  const g = new THREE.PlaneGeometry(0.95, 1.72);
+  g.rotateX(-Math.PI / 2);
+  pintar(g, COLORES.lodo, 0);
+  g.translate(COCHERA.fosaX, -0.16, 1.2);
+  return g;
+}
+
+/* ------------------------------------------------------------------ */
+/* LA CERCA Y EL VECINO — el conflicto tiene dirección.                */
+/* ------------------------------------------------------------------ */
+
+/*
+ * "El olor no es solo un capricho del vecino, es una señal de que algo en el
+ *  manejo se puede mejorar. (...) Muchas veces el conflicto crece más por
+ *  sentirse ignorado que por el olor mismo."
+ *
+ * La casa del vecino está ahí, cerca, con su ventana. No es paisaje de relleno:
+ * es la razón por la que esto no es un asunto privado. El aire no respeta el
+ * lindero — pero la cerca sí lo dibuja, y por eso hay que verla.
+ */
+export function geomCerca() {
+  const p = [];
+  const z = COCHERA.cercaZ;
+  for (let i = 0; i < 11; i++) {
+    const x = -5.5 + i * 1.1;
+    const h = 1.25 + ((i * 7) % 3) * 0.04;
+    p.push(caja(0.09, h, 0.09, COLORES.poste, [x, h / 2, z], null, 0.2, rng(90 + i)));
+  }
+  /* Tres alambres. Delgados, como debe ser: la cerca es una idea, no un muro. */
+  for (let a = 0; a < 3; a++) {
+    const y = 0.42 + a * 0.36;
+    p.push(caja(12.1, 0.018, 0.018, NEUTROS.lamina, [-0.5, y, z], null, 0, null));
+  }
+  return fusionar(p);
+}
+
+/** La casa del otro lado. Con su ventana. Hay gente ahí. */
+export function geomCasaVecino() {
+  const p = [];
+  const x = 1.6;
+  const z = 9.4;
+  p.push(caja(4.4, 2.5, 3.4, COLORES.casaVecino, [x, 1.25, z], null, 0.08, rng(100)));
+  /* Techo a dos aguas, simple. */
+  const t1 = new THREE.BoxGeometry(2.6, 0.08, 3.7);
+  pintar(t1, COLORES.tejaVecino, 0.1, rng(101));
+  t1.rotateZ(0.42);
+  t1.translate(x - 1.1, 2.9, z);
+  p.push(t1);
+  const t2 = new THREE.BoxGeometry(2.6, 0.08, 3.7);
+  pintar(t2, COLORES.tejaVecino, 0.1, rng(102));
+  t2.rotateZ(-0.42);
+  t2.translate(x + 1.1, 2.9, z);
+  p.push(t2);
+  /* La ventana: el detalle que la vuelve una casa habitada y no un cubo. */
+  p.push(caja(0.8, 0.7, 0.06, mezclar(NEUTROS.tinta, ACENTOS.ambar, 0.25), [x - 0.9, 1.5, z - 1.72], null, 0, null));
+  p.push(caja(0.7, 1.55, 0.06, mezclar(COLORES.madera, NEUTROS.tinta, 0.3), [x + 1.2, 0.78, z - 1.72], null, 0, null));
+  return fusionar(p);
+}
+
+/* ------------------------------------------------------------------ */
+/* EL BULTO — el remedio, arrimado contra el poste.                    */
+/* ------------------------------------------------------------------ */
+
+/*
+ * "Es cualquier material seco rico en carbono: aserrín, viruta, cascarilla de
+ *  arroz, cascarilla o cisco de café, tamo de trigo o cebada, hoja seca."
+ *
+ * El bulto de cascarilla está apoyado ahí desde el principio, en la esquina,
+ * antes de que uno mueva nada. Eso es a propósito y es lo menos sermoneador que
+ * encontré: la solución no es un producto que hay que ir a comprar al pueblo ni
+ * un tanque de veinte millones — es el subproducto que ya está tirado en el
+ * patio. El campesino no tiene la culpa de que su cochera huela: nadie le dijo
+ * para qué servía ese bulto. La escena no se lo dice tampoco. Se lo muestra.
+ */
+export function geomBulto() {
+  const p = [];
+  const x = 3.4;
+  const z = -1.5;
+  /* El costal: un cilindro gordo, un poco vencido, con la boca abierta. */
+  const s = new THREE.CylinderGeometry(0.3, 0.34, 0.72, 10, 2);
+  pintar(s, mezclar(TIERRAS.vega, CORTEZAS.aliso, 0.4), 0.16, rng(110));
+  s.rotateZ(0.13);
+  s.translate(x, 0.36, z);
+  p.push(s);
+  /* La cascarilla asomando por la boca: el remedio, visible. */
+  const c = new THREE.SphereGeometry(0.26, 10, 6, 0, Math.PI * 2, 0, Math.PI * 0.5);
+  pintar(c, COLORES.camaSecaClara, 0.5, rng(111));
+  c.translate(x + 0.09, 0.7, z);
+  p.push(c);
+  /* Un puñado derramado al pie: alguien ya echó una palada alguna vez. */
+  const d = new THREE.CircleGeometry(0.4, 12);
+  d.rotateX(-Math.PI / 2);
+  pintar(d, COLORES.camaSeca, 0.3, rng(112));
+  d.translate(x - 0.35, 0.012, z + 0.3);
+  p.push(d);
+  return fusionar(p);
+}
+
+/** La pala, recostada en el poste. El gesto es de mano, no de máquina. */
+export function geomPala() {
+  const p = [];
+  const x = 2.75;
+  const z = -1.75;
+  const cabo = new THREE.CylinderGeometry(0.028, 0.028, 1.35, 6);
+  pintar(cabo, COLORES.madera, 0.12, rng(115));
+  cabo.rotateZ(0.22);
+  cabo.translate(x, 0.72, z);
+  p.push(cabo);
+  const hoja = new THREE.BoxGeometry(0.22, 0.3, 0.02);
+  pintar(hoja, NEUTROS.lamina, 0.1, rng(116));
+  hoja.rotateZ(0.22);
+  hoja.translate(x - 0.17, 0.14, z);
+  p.push(hoja);
+  return fusionar(p);
+}
+
+/* ------------------------------------------------------------------ */
+/* LOS CUERPOS — siluetas planas a escala real.                        */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Acá está el argumento de la pieza, y es de tamaños.
+ *
+ * La gallina tiene la cabeza a 0.26 m. El cerdo, el hocico a 0.38 m. El dueño,
+ * la nariz a 1.58 m. Los tres en el mismo cuarto, respirando aires distintos:
+ *
+ *   "Significa que sus gallinas llevan horas respirando ese mismo amoníaco
+ *    antes de que usted entrara (...) están ahí todo el día con la cabeza cerca
+ *    del piso."
+ *
+ * No hay flecha, ni cota, ni cartel. Están parados a su altura de verdad y el
+ * velo tiene un borde: se ve solo quién está adentro y quién está afuera.
+ */
+
+/** Silueta de gallina, de perfil. Alto real ≈ 0.34 m con cresta. */
+function shapeGallina() {
+  const s = new THREE.Shape();
+  s.moveTo(-0.16, 0.0); // cola, abajo
+  s.bezierCurveTo(-0.22, 0.1, -0.2, 0.2, -0.13, 0.22); // cola alzada
+  s.bezierCurveTo(-0.18, 0.26, -0.14, 0.3, -0.08, 0.26); // punta de la cola
+  s.bezierCurveTo(-0.02, 0.28, 0.04, 0.27, 0.07, 0.23); // lomo
+  s.bezierCurveTo(0.11, 0.28, 0.13, 0.3, 0.115, 0.315); // cuello subiendo
+  s.lineTo(0.1, 0.325);
+  s.bezierCurveTo(0.13, 0.35, 0.15, 0.33, 0.145, 0.305); // cresta
+  s.bezierCurveTo(0.175, 0.3, 0.185, 0.285, 0.17, 0.27); // cabeza
+  s.lineTo(0.21, 0.25); // el pico: mirando al piso, picoteando
+  s.lineTo(0.165, 0.245);
+  s.bezierCurveTo(0.15, 0.22, 0.14, 0.19, 0.115, 0.16); // papada y pecho
+  s.bezierCurveTo(0.14, 0.1, 0.1, 0.04, 0.04, 0.03); // pecho hasta el piso
+  s.lineTo(0.03, 0.0); // pata delantera
+  s.lineTo(0.015, 0.0);
+  s.lineTo(0.02, 0.055);
+  s.bezierCurveTo(-0.04, 0.04, -0.1, 0.03, -0.14, 0.055); // panza
+  s.lineTo(-0.145, 0.0); // pata trasera
+  s.lineTo(-0.16, 0.0);
+  return s;
+}
+
+/** Silueta de cerdo echado, de perfil. Alto real ≈ 0.52 m. */
+function shapeCerdo() {
+  const s = new THREE.Shape();
+  s.moveTo(-0.52, 0.0);
+  s.bezierCurveTo(-0.58, 0.12, -0.55, 0.24, -0.46, 0.3); // anca
+  s.bezierCurveTo(-0.3, 0.44, -0.05, 0.5, 0.16, 0.46); // lomo
+  s.bezierCurveTo(0.2, 0.52, 0.26, 0.53, 0.29, 0.47); // oreja
+  s.bezierCurveTo(0.36, 0.46, 0.42, 0.42, 0.46, 0.36); // frente
+  s.bezierCurveTo(0.54, 0.33, 0.58, 0.3, 0.575, 0.26); // hocico
+  s.bezierCurveTo(0.6, 0.24, 0.59, 0.2, 0.55, 0.19); // trompa: al ras de la cama
+  s.bezierCurveTo(0.5, 0.14, 0.44, 0.1, 0.36, 0.09); // quijada
+  s.lineTo(0.34, 0.0); // mano
+  s.lineTo(0.26, 0.0);
+  s.lineTo(0.27, 0.1);
+  s.bezierCurveTo(0.1, 0.06, -0.1, 0.05, -0.28, 0.08); // panza contra la cama
+  s.lineTo(-0.3, 0.0); // pata
+  s.lineTo(-0.38, 0.0);
+  s.lineTo(-0.37, 0.09);
+  s.bezierCurveTo(-0.45, 0.08, -0.5, 0.05, -0.52, 0.0);
+  return s;
+}
+
+/** Silueta de persona de pie, de perfil. Alto real ≈ 1.7 m. */
+function shapePersona() {
+  const s = new THREE.Shape();
+  s.moveTo(-0.09, 0.0); // talón
+  s.lineTo(0.11, 0.0); // pie
+  s.lineTo(0.06, 0.06);
+  s.bezierCurveTo(0.05, 0.4, 0.04, 0.6, 0.06, 0.86); // pierna delantera
+  s.bezierCurveTo(0.12, 0.9, 0.14, 1.0, 0.13, 1.12); // cadera y torso
+  s.bezierCurveTo(0.13, 1.2, 0.11, 1.3, 0.1, 1.38); // pecho
+  s.bezierCurveTo(0.14, 1.4, 0.16, 1.44, 0.15, 1.48); // hombro
+  s.bezierCurveTo(0.16, 1.53, 0.14, 1.56, 0.12, 1.57); // cuello
+  s.bezierCurveTo(0.16, 1.6, 0.17, 1.68, 0.12, 1.72); // cara
+  s.bezierCurveTo(0.06, 1.76, -0.02, 1.73, -0.03, 1.66); // nuca
+  s.bezierCurveTo(-0.06, 1.62, -0.05, 1.57, -0.02, 1.55); // nuca al hombro
+  s.bezierCurveTo(-0.08, 1.5, -0.1, 1.42, -0.1, 1.3); // espalda
+  s.bezierCurveTo(-0.11, 1.15, -0.09, 1.0, -0.07, 0.88); // espalda baja
+  s.bezierCurveTo(-0.11, 0.6, -0.12, 0.3, -0.09, 0.0); // pierna trasera
+  return s;
+}
+
+/**
+ * Los cuerpos, como siluetas planas encaradas al frente (billboard fijo: la
+ * cámara de esta escena no da vueltas, así que no hace falta pagar el `lookAt`
+ * por frame). Devuelve UNA geometría fusionada, en su posición y a su escala.
+ */
+export function geomCuerpos() {
+  const p = [];
+
+  const poner = (shape, [x, y, z], esc, voltear) => {
+    const g = new THREE.ShapeGeometry(shape, 8);
+    pintar(g, COLORES.cuerpo, 0);
+    g.scale(voltear ? -esc : esc, esc, 1);
+    g.translate(x, y, z);
+    return g;
+  };
+
+  /* Dos gallinas picoteando la cama. La cabeza les queda DENTRO del velo. */
+  p.push(poner(shapeGallina(), [0.55, 0.0, 1.5], 1.0, false));
+  p.push(poner(shapeGallina(), [-0.35, 0.0, 0.55], 0.94, true));
+
+  /* El cerdo echado: la trompa al ras del material. Es el que peor la lleva. */
+  p.push(poner(shapeCerdo(), [1.55, 0.0, -0.35], 1.0, true));
+
+  /*
+   * El dueño, de pie en la boca de la cochera. Su nariz a 1.58 m: por encima
+   * del velo. Le arde igual — y por eso cree que "no es para tanto". Está
+   * mirando hacia adentro. No hace nada. Todavía.
+   */
+  p.push(poner(shapePersona(), [-2.15, 0.0, 2.5], 1.0, true));
+
+  return fusionar(p);
+}
+
+/* ------------------------------------------------------------------ */
+/* EL SUELO DE AFUERA — el patio donde todo esto pasa.                 */
+/* ------------------------------------------------------------------ */
+
+export function geomPatio() {
+  const g = new THREE.PlaneGeometry(30, 30, 24, 24);
+  g.rotateX(-Math.PI / 2);
+  const pos = g.attributes.position;
+  const r = rng(120);
+  for (let i = 0; i < pos.count; i++) {
+    const x = pos.getX(i);
+    const z = pos.getZ(i);
+    /* Lomas suaves lejos de la cochera; plano donde está la obra. */
+    const lejos = Math.min(1, Math.max(0, (Math.hypot(x, z) - 6) / 8));
+    pos.setY(i, (Math.sin(x * 0.3) * 0.18 + Math.sin(z * 0.24) * 0.14 + (r() - 0.5) * 0.05) * lejos - 0.02);
+  }
+  g.computeVertexNormals();
+  pintar(g, mezclar(TIERRAS.camino, TIERRAS.pajonal, 0.45), 0.18, rng(121));
+  return g;
+}

--- a/src/visual/mundo3d/olor/senalesDelCuerpo.js
+++ b/src/visual/mundo3d/olor/senalesDelCuerpo.js
@@ -1,0 +1,223 @@
+/*
+ * senalesDelCuerpo — cómo se lee una cochera sin un solo aparato.
+ *
+ * "Confíe en sus sentidos, son buenos indicadores: si al entrar no le arden los
+ *  ojos ni la nariz de entrada, si la cama al apretarla con la mano se siente
+ *  húmeda pero no gotea, y si no hay nubes de mosca sobre el material, va bien.
+ *  El buen manejo se nota, no hay que esperar un análisis de laboratorio para
+ *  saber si algo anda mal."
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * POR QUÉ ACÁ NO HAY NI UN NÚMERO
+ *
+ * Esto no es una omisión ni una simplificación para campesinos: es la tesis del
+ * maestro, y hay que defenderla.
+ *
+ * En los 56 pares del corpus sobre olores NO HAY UNA SOLA CIFRA. No da ppm de
+ * amoníaco. No da la relación carbono:nitrógeno. No da centímetros de cama ni
+ * días de la mosca ni porcentaje de pendiente. Y no es que no sepa: es que
+ * cuando se lo preguntan, contesta cosas como "no le voy a inventar un
+ * porcentaje exacto sin conocer su terreno" y remite a la UMATA. En vez del
+ * número, entrega SIEMPRE una señal del cuerpo:
+ *
+ *   ¿cuántos centímetros de cama?   → apriete un puñado; si gotea, le falta seco
+ *   ¿cuándo la cambio?              → "no es un número de días fijo": el olor
+ *   ¿cuánto amoníaco es mucho?      → ¿le arden los ojos al entrar?
+ *   ¿ya está listo el compost?      → huele a tierra, no a huevo podrido
+ *
+ * Eso es coherente, no rústico. Un ppm exige un aparato que no hay, un
+ * laboratorio que queda a cuatro horas y una plata que no está. El puño está
+ * siempre. La pedagogía del maestro es deliberadamente PORTÁTIL.
+ *
+ * Ponerle a esta pieza un HUD con "NH₃: 34 ppm" habría sido traicionar el
+ * material dos veces: inventando un dato que él se negó a dar, y cambiando un
+ * saber que el campesino puede usar mañana por una cifra que solo puede mirar.
+ *
+ * Así que lo que se lee acá abajo es lo que se siente en el cuerpo. Nada más.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * Y SIN REGAÑO.
+ *
+ * Ni una sola de estas frases dice qué hacer, ni usa "debe", ni "no debe", ni
+ * "recuerde que". Son descripciones de lo que está pasando ahí, ahora. El
+ * campesino no tiene la culpa de que su cochera huela — nadie le explicó — y el
+ * que llega a explicarle con el dedo levantado ya perdió.
+ *
+ * Se le muestra. Él saca la cuenta.
+ *
+ * En "usted", como toda la UI de la casa.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Las paradas del riel — no son pantallas, son puntos del camino.     */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Cuatro paradas. Los textos cuentan QUÉ PASA (física), nunca qué hacer
+ * (orden). Y ninguna se llama "mal" o "bien": se llaman por lo que hay.
+ */
+export const PARADAS = [
+  {
+    clave: 'pelado',
+    carbono: 0,
+    titulo: 'Piso pelado',
+    texto:
+      'Estiércol y orín revueltos, lavados con manguera. Mezclados se pudren juntos, y de ahí sale el olor fuerte. Ese amoníaco es nitrógeno que se va al aire: abono que no va a llegar a la huerta.',
+  },
+  {
+    clave: 'capita',
+    carbono: 0.32,
+    titulo: 'Una capa delgada',
+    texto:
+      'Ya hay algo seco que absorbe. El lodo cede y el olor baja, pero la capa no alcanza a cubrir donde más orinan: el nitrógeno sigue encontrando por dónde volarse.',
+  },
+  {
+    clave: 'cubre',
+    carbono: 0.66,
+    titulo: 'Ya cubre',
+    texto:
+      'El material seco cubre toda el área. El nitrógeno encuentra carbono con qué amarrarse y se queda en la cama en vez de irse al aire. Las moscas se van quedando sin dónde poner.',
+  },
+  {
+    clave: 'profunda',
+    carbono: 1,
+    titulo: 'Cama profunda',
+    texto:
+      'Un colchón grueso, seco y suelto. Fermenta despacio, genera algo de calor y huele a tierra. Todo ese oro que se estaba volando ahora está guardado ahí abajo: sale como abono semicompostado.',
+  },
+];
+
+/** La parada más cercana al carbono actual. */
+export function paradaDe(carbono) {
+  let mejor = PARADAS[0];
+  let dist = Infinity;
+  for (const p of PARADAS) {
+    const d = Math.abs(p.carbono - carbono);
+    if (d < dist) {
+      dist = d;
+      mejor = p;
+    }
+  }
+  return mejor;
+}
+
+/* ------------------------------------------------------------------ */
+/* Las tres señales — puño, ojos, mosca.                               */
+/* ------------------------------------------------------------------ */
+
+/*
+ * LA PRUEBA DEL PUÑO. El laboratorio del maestro: gratis, portátil, en la mano.
+ *
+ *   "Si al apretar un puñado de la cama sale mojada goteando o huele fuerte, le
+ *    falta material seco. Vaya agregando poco a poco y observando."
+ *
+ *   "Si la cama al apretarla con la mano se siente húmeda pero no gotea (...),
+ *    va bien."
+ *
+ * OJO CON LA ASIMETRÍA — acá se cometía un error fácil. En la PILA DE COMPOST
+ * pasarse de seco sí existe: "si se desmorona completamente seco, le falta agua
+ * y el proceso se frena". Pero eso es de la pila, no de la CAMA. Sobre la cama
+ * el maestro nunca dice "se pasó de cascarilla"; dice lo contrario: "cualquier
+ * material carbonado seco es mejor que no echar nada".
+ *
+ * Por eso acá solo hay tres estados y el último es el bueno: en la cama, el puño
+ * detecta EXCESO DE AGUA, no falta. Una cama profunda viva siempre conserva su
+ * humedad (fermenta, calienta), así que "se desmorona seca" no existe en esta
+ * pieza — y si existiera, estaríamos regañando al que hizo todo bien.
+ */
+export function senalPuno(a) {
+  /* Los cortes están calzados con las paradas del riel, no puestos a ojo: el
+     lodo deja de chorrear justo cuando la primera capa de seco ya absorbe
+     ("Una capa delgada": el lodo cede), y la bola aparece cuando el material
+     alcanza a cubrir ("Ya cubre"). Si el puño y el texto de la parada dijeran
+     cosas distintas, el que mira le creería al puño — y con razón. */
+  if (a.humedad > 0.86) return { texto: 'Chorrea agua entre los dedos', bien: false };
+  if (a.humedad > 0.64) return { texto: 'Sale pastosa y le mancha la mano', bien: false };
+  return { texto: 'Se pega en bola y no gotea', bien: true };
+}
+
+/*
+ * EL ARDOR. La alarma que el cuerpo da gratis — y la frase madre del corpus:
+ *
+ *   "Significa que sus gallinas llevan horas respirando ese mismo amoníaco antes
+ *    de que usted entrara (...). El ojo humano es sensible al amoníaco desde
+ *    concentraciones bajas, así que si a usted le arde, para las gallinas —que
+ *    están ahí todo el día con la cabeza cerca del piso— la exposición es mucho
+ *    peor. Tómelo como una alarma real, no como una molestia pasajera."
+ *
+ * El `aparte` es esa frase, y aparece SOLO cuando arde. No es un consejo: es la
+ * traducción de lo que uno está sintiendo en ese momento. Uno siente el ardor y
+ * el texto le dice qué significa. Ese es el momento en que la escena hace clic —
+ * y por eso está redactado como un dato y no como un reproche.
+ */
+export function senalOjos(a) {
+  if (a.arde > 0.66)
+    return {
+      texto: 'Le arden los ojos apenas entra',
+      bien: false,
+      aparte: 'A usted le arde parado. La gallina lleva horas con la cabeza ahí abajo.',
+    };
+  if (a.arde > 0.3)
+    return {
+      texto: 'Al rato le pica la nariz',
+      bien: false,
+      aparte: 'Abajo, donde ella respira, está mucho más cargado.',
+    };
+  if (a.arde > 0.07) return { texto: 'Se alcanza a sentir, pero se aguanta', bien: false };
+  return { texto: 'No arde. Huele a tierra', bien: true };
+}
+
+/*
+ * LAS MOSCAS. Cuelgan de la humedad, no del olor — son primas, no hijas. Por
+ * eso el texto del final nombra la cama y no la peste: el que entiende que la
+ * mosca sale del material húmedo deja de comprar veneno.
+ */
+export function senalMosca(a) {
+  if (a.moscas > 0.62) return { texto: 'Nube de moscas sobre el bebedero', bien: false };
+  if (a.moscas > 0.3) return { texto: 'Hay moscas rondando el charco', bien: false };
+  if (a.moscas > 0.08) return { texto: 'Alguna mosca suelta', bien: false };
+  return { texto: 'Sin moscas: no tienen dónde poner', bien: true };
+}
+
+/*
+ * EL VECINO. Aparece solo cuando el olor desborda el lindero, porque hasta
+ * entonces no es asunto de nadie más. Y cuando el manejo ya está bueno pero la
+ * nube todavía va llegando, dice lo que hay que decir:
+ *
+ *   "Mostrarle que ya empezó a actuar (aunque el resultado tarde unas semanas)
+ *    suele calmar más al vecino que una promesa vaga."
+ */
+export function senalVecino(a) {
+  if (a.vecino > 0.45) return { texto: 'El olor le está pasando la cerca', bien: false };
+  if (a.vecino > 0.12) return { texto: 'Llega apenas al lindero', bien: false };
+  return null;
+}
+
+/*
+ * EL POZO. Solo habla cuando hay encharcamiento — y entonces cambia de tono,
+ * porque cambió de tema. Acá se rompe la regla de "sin alarma" a propósito: el
+ * amoníaco roba, el sulfhídrico mata, y con eso no se hace pedagogía suave.
+ *
+ *   "Puede noquear o matar a una persona en segundos (...). Ha habido casos
+ *    donde muere la primera persona por los gases y luego mueren quienes entran
+ *    a rescatarla sin protección."
+ *
+ * Es el único texto de la pieza que sí es una advertencia. Un maestro que no
+ * avisa de esto no es amable: es cómplice.
+ */
+export function senalPozo(a) {
+  if (a.sulfhidrico > 0.35)
+    return {
+      texto: 'Huele a huevo podrido en la fosa',
+      bien: false,
+      aparte: 'Ese gas pesa y se queda en el hueco. No avisa: a lo último deja de olerse. A esa fosa no se asoma nadie solo.',
+    };
+  if (a.sulfhidrico > 0.06)
+    return { texto: 'Un tufo raro cerca de la fosa', bien: false };
+  return null;
+}
+
+/** Todas las señales que hay que mostrar, en orden de lectura. */
+export function senalesDe(a) {
+  return [senalPuno(a), senalOjos(a), senalMosca(a), senalVecino(a), senalPozo(a)].filter(Boolean);
+}

--- a/src/visual/mundo3d/olor/texturasOlor.js
+++ b/src/visual/mundo3d/olor/texturasOlor.js
@@ -1,0 +1,97 @@
+/*
+ * texturasOlor — las dos texturas de la pieza, dibujadas en runtime.
+ *
+ * Cero assets (regla de la casa: todo procedural, corre headless y no pesa un
+ * byte en el bundle). Son dos, y son opuestas a propósito:
+ *
+ *   · `texturaAire`  — manchas SIN borde. El aire cargado no tiene silueta,
+ *                      tiene densidad. Si tuviera contorno reconocible sería
+ *                      una nube de dibujo animado, que es justo lo que esta
+ *                      pieza no quiere ser.
+ *   · `texturaMota`  — un grano de luz con centro duro. El nitrógeno SÍ es una
+ *                      cosa: es materia, es grano, se puede contar. Por eso
+ *                      tiene núcleo y el aire no.
+ *
+ * Esa diferencia —lo que se cuenta contra lo que solo se sufre— es la pieza.
+ */
+import * as THREE from 'three';
+
+/**
+ * El ruido del aire sucio: tres octavas de manchones suaves, con los bordes
+ * desvanecidos para que el estrato no termine nunca en un rectángulo.
+ *
+ * @param {number} [semilla]
+ * @returns {THREE.CanvasTexture}
+ */
+export function texturaAire(semilla = 1) {
+  const s = 256;
+  const cv = document.createElement('canvas');
+  cv.width = cv.height = s;
+  const ctx = cv.getContext('2d');
+
+  ctx.fillStyle = 'rgba(255,255,255,0)';
+  ctx.fillRect(0, 0, s, s);
+
+  let sd = semilla >>> 0 || 1;
+  const r = () => {
+    sd = (sd * 1664525 + 1013904223) >>> 0;
+    return sd / 4294967296;
+  };
+
+  /* Manchones grandes, medianos y grano: densidad, no forma. */
+  const octavas = [
+    { n: 9, rad: 95, a: 0.5 },
+    { n: 22, rad: 46, a: 0.3 },
+    { n: 54, rad: 20, a: 0.16 },
+  ];
+  ctx.globalCompositeOperation = 'lighter';
+  octavas.forEach(({ n, rad, a }) => {
+    for (let i = 0; i < n; i++) {
+      const x = r() * s;
+      const y = r() * s;
+      const rr = rad * (0.55 + r() * 0.9);
+      const g = ctx.createRadialGradient(x, y, 0, x, y, rr);
+      g.addColorStop(0, `rgba(255,255,255,${a})`);
+      g.addColorStop(0.55, `rgba(255,255,255,${a * 0.4})`);
+      g.addColorStop(1, 'rgba(255,255,255,0)');
+      ctx.fillStyle = g;
+      ctx.beginPath();
+      ctx.arc(x, y, rr, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  });
+
+  /* El estrato se desvanece hacia afuera: el aire no tiene canto. */
+  ctx.globalCompositeOperation = 'destination-in';
+  const b = ctx.createRadialGradient(s / 2, s / 2, s * 0.18, s / 2, s / 2, s * 0.5);
+  b.addColorStop(0, 'rgba(255,255,255,1)');
+  b.addColorStop(0.7, 'rgba(255,255,255,0.75)');
+  b.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = b;
+  ctx.fillRect(0, 0, s, s);
+
+  const tex = new THREE.CanvasTexture(cv);
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+/**
+ * El grano de oro: un punto suave con núcleo. Es materia, no vaho.
+ * @returns {THREE.CanvasTexture}
+ */
+export function texturaMota() {
+  const s = 64;
+  const cv = document.createElement('canvas');
+  cv.width = cv.height = s;
+  const ctx = cv.getContext('2d');
+  const g = ctx.createRadialGradient(s / 2, s / 2, 0, s / 2, s / 2, s / 2);
+  g.addColorStop(0, 'rgba(255,255,255,1)');
+  g.addColorStop(0.35, 'rgba(255,255,255,0.75)');
+  g.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, s, s);
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}


### PR DESCRIPTION
## Qué aporta

Rescata `fable/olor-visible-16` (2026-07-15), **VIVA** en el triaje (#4 en orden de valor). Mundo sensorial "olor visible" completo, 15 archivos: `EscenaOlorVisible.jsx`, `CocheraEnCorte.jsx`, `MoscasDelCharco.jsx`, `NitrogenoQueSeVa.jsx`, `NubeQueCruzaLaCerca.jsx`, `OlorVisible.jsx`, `PaladaDeSeco.jsx`, `PozoQueCalla.jsx`, `VeloQuePesa.jsx` + `aireCargado.js`, `senalesDelCuerpo.js`, `texturasOlor.js`, `olor.geom.js`, `olor.css`, `index.js`.

Concepto único: visualizar lo invisible/oloroso (fuga de amoniaco/nitrógeno de la cochera) — nada parecido existe hoy en `dev`. Parte del mismo lote de mundos autónomos del 2026-07-15 (`biodigestor-15`, `red-bajo-glifosato-17`, `semillas-criollas-22`, `beneficos-21`).

## Por qué estaba perdida

Sin PR, nunca integrada a `dev`.

## Estado

- `npm run build` → **OK** (~48s).
- Merge sin conflictos — 15/15 archivos nuevos.
- Disponible pero **no cableado al router** — mundo completo, sin punto de entrada navegable todavía.
- **NO mergeado.** Draft para revisión del operador.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>