### PR TITLE
rescate: fable/red-bajo-glifosato-17 — la red micorrízica encendida y apagada

### DIFF
--- a/src/visual/mundo3d/suelo-comparado/EscenaSueloComparado.jsx
+++ b/src/visual/mundo3d/suelo-comparado/EscenaSueloComparado.jsx
@@ -1,0 +1,987 @@
+/*
+ * EscenaSueloComparado — EL MISMO SUELO, DOS VECES: la red micorrízica encendida
+ * y la red apagada bajo fumigación repetida.
+ *
+ * La cámara está bajo tierra, como en una vitrina de acuario. A un lado la red
+ * corriendo: los hilos del hongo enlazando raíz con raíz, el azúcar bajando, el
+ * fósforo y el agua subiendo, la lombriz en su túnel, la tierra en grumos. Al
+ * otro, el mismo suelo después de fumigar seguido: los hilos partidos, los
+ * pulsos frenándose contra el corte, el fósforo ahí mismo pero pegado y quieto,
+ * el túnel vacío, la tierra en polvo.
+ *
+ * En el medio no hay una raya: hay un FRENTE que se puede mover. Empujelo a la
+ * izquierda ("fumigar seguido") y el suelo se apaga rápido. Empujelo a la
+ * derecha ("parar") y la red se vuelve a tejer — lento, como es en la vida.
+ *
+ * ── LO QUE NO VA A ENCONTRAR ACÁ, Y ES A PROPÓSITO ─────────────────────────
+ * Ni una calavera, ni un rojo de alarma, ni una mata muriéndose, ni una palabra
+ * sobre cáncer. Las razones largas están en `sueloComparado.geom.js`; el resumen
+ * es que esta pieza va del SUELO —donde la evidencia es clara y el argumento es
+ * del propio bolsillo del campesino— y que la mata del lado fumigado se dibuja
+ * VIVA Y VERDE porque en la finca está viva y verde, y ese es justamente el
+ * problema. Si dibujáramos la mata muerta, el campesino diría "mentira, las mías
+ * están bien", y tendría razón, y perderíamos todo.
+ *
+ * ── TIER ──────────────────────────────────────────────────────────────────
+ * 'alto' pleno; 'medio' frugal; 'bajo' mínimo digno. Lo que NUNCA se pierde,
+ * ni en el equipo más humilde, es el CONTRASTE: la red rota, el fósforo quieto y
+ * la lombriz que falta se ven en los tres tiers. Se caen los pulsos, las motas y
+ * los poros — nunca el argumento. Con `reducedMotion` la escena monta QUIETA
+ * (frameloop a demanda) y el frente salta sin animar.
+ *
+ * Componente r3f: montar SOLO dentro de un host que provea altura. Importa
+ * three → siempre perezoso.
+ */
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr, Html } from '@react-three/drei';
+import * as THREE from 'three';
+import {
+  PALETA,
+  SUELO,
+  paramsDeTier,
+  saludEn,
+  avanzarFrente,
+  sistemaRaices,
+  nodosLibres,
+  construirRed,
+  geometriaRed,
+  geometriaRaices,
+  raicillasFinas,
+  pulsosDeRed,
+  colorPulso,
+  fosforoPegado,
+  lombricesYTuneles,
+  agregados,
+  porosAgua,
+  bancoEsporas,
+  hojarascaSuperficie,
+} from './sueloComparado.geom.js';
+import {
+  TITULO,
+  LADOS as TEXTO_LADOS,
+  HOTSPOTS,
+  CIERRE,
+  CONCESION,
+  CONTROL,
+} from './sueloComparadoTextos.js';
+
+/* Los tres destinos del frente. salud=1 donde x << frente: entonces frente muy a
+   la derecha = todo vivo; muy a la izquierda = todo apagado; en 0 = el corte,
+   que es como arranca la pieza (los dos suelos a la vez, que es el punto). */
+const FRENTE = {
+  medio: 0,
+  todoApagado: -SUELO.ancho / 2 - 0.8,
+  todoVivo: SUELO.ancho / 2 + 0.8,
+};
+const BORROSIDAD = 1.25; // debe coincidir con el default de saludEn()
+
+/* ── CSS self-contained (sirve igual en el mockup y en el host `<Mundo>`) ─── */
+const CSS = `
+.suco { position: absolute; inset: 0; overflow: hidden; background: #0b0806; }
+.suco__lienzo { position: absolute; inset: 0; opacity: 0; transition: opacity 0.8s ease; }
+.suco__lienzo--lista { opacity: 1; }
+
+.suco__titulo { position: absolute; top: 0; left: 0; right: 0; padding: 0.9rem 1rem 1.6rem; pointer-events: none; background: linear-gradient(to bottom, rgba(11, 8, 6, 0.85), transparent); z-index: 2; }
+.suco__titulo h2 { margin: 0; color: #f4ecdd; font: 700 1.05rem/1.2 system-ui, sans-serif; letter-spacing: 0.01em; }
+.suco__titulo p { margin: 0.2rem 0 0; color: #b9ac97; font: 400 0.82rem/1.3 system-ui, sans-serif; }
+
+/* los rótulos de cada lado: viven sobre el lienzo, sin robarle la escena */
+.suco__lados { position: absolute; top: 3.6rem; left: 0; right: 0; display: flex; justify-content: space-between; padding: 0 1rem; pointer-events: none; z-index: 2; }
+.suco__lado { max-width: 8.5rem; }
+.suco__lado b { display: block; color: #eafff6; font: 700 0.76rem/1.2 system-ui, sans-serif; }
+.suco__lado--apagado b { color: #d8cbb4; }
+.suco__lado span { display: block; margin-top: 0.15rem; color: #94897a; font: 400 0.7rem/1.25 system-ui, sans-serif; }
+.suco__lado--apagado { text-align: right; }
+
+/* el control: dos botones grandes, pulgar de campo, nada de sliders finitos */
+.suco__control { position: absolute; bottom: 0; left: 0; right: 0; display: flex; gap: 0.5rem; padding: 0.7rem 0.8rem 0.9rem; background: linear-gradient(to top, rgba(11, 8, 6, 0.92), transparent); z-index: 3; }
+.suco__btn { flex: 1; min-height: 2.9rem; padding: 0.5rem 0.7rem; border: 0; border-radius: 0.7rem; background: rgba(28, 40, 36, 0.9); color: #d9ccb6; font: 600 0.8rem/1.15 system-ui, sans-serif; cursor: pointer; -webkit-tap-highlight-color: transparent; box-shadow: inset 0 0 0 1px rgba(160, 150, 130, 0.25); transition: background 0.25s ease, color 0.25s ease, box-shadow 0.25s ease; }
+.suco__btn--on { background: rgba(20, 62, 52, 0.95); color: #eafff6; box-shadow: inset 0 0 0 1px rgba(126, 240, 200, 0.55); }
+.suco__btn:focus-visible { outline: 2px solid #7ef0c8; outline-offset: 2px; }
+.suco__ayuda { position: absolute; bottom: 3.6rem; left: 0; right: 0; text-align: center; color: #7d7365; font: 400 0.68rem/1.2 system-ui, sans-serif; pointer-events: none; z-index: 2; }
+
+/* los hotspots */
+.suco-hot { transform: translate(-50%, -50%); }
+.suco-hot__btn { width: 1.15rem; height: 1.15rem; padding: 0; border: 0; border-radius: 50%; background: radial-gradient(circle at 35% 35%, #eafff6, #37d6b0 70%); box-shadow: 0 0 9px 2px rgba(55, 214, 176, 0.55); cursor: pointer; -webkit-tap-highlight-color: transparent; }
+.suco-hot__btn--apagado { background: radial-gradient(circle at 35% 35%, #fff2d8, #d9a13b 70%); box-shadow: 0 0 9px 2px rgba(217, 161, 59, 0.5); }
+.suco-hot__btn:focus-visible { outline: 2px solid #fff8ec; outline-offset: 3px; }
+
+/* la ficha de lectura */
+.suco__ficha { position: absolute; left: 0.8rem; right: 0.8rem; bottom: 4.6rem; padding: 0.8rem 0.9rem; border-radius: 0.8rem; background: rgba(14, 22, 20, 0.96); box-shadow: 0 6px 26px rgba(0, 0, 0, 0.5), inset 0 0 0 1px rgba(126, 240, 200, 0.28); z-index: 4; }
+.suco__ficha h3 { margin: 0 0 0.3rem; color: #eafff6; font: 700 0.86rem/1.2 system-ui, sans-serif; }
+.suco__ficha p { margin: 0; color: #c3b9a6; font: 400 0.78rem/1.45 system-ui, sans-serif; }
+.suco__ficha button { position: absolute; top: 0.4rem; right: 0.5rem; width: 1.7rem; height: 1.7rem; border: 0; border-radius: 50%; background: transparent; color: #8c8171; font: 700 1rem/1 system-ui, sans-serif; cursor: pointer; }
+.suco__ficha button:focus-visible { outline: 2px solid #7ef0c8; }
+
+/* el cierre: la asimetría y la esperanza, en ese orden (ver textos) */
+.suco__cierre { position: absolute; left: 0.8rem; right: 0.8rem; bottom: 4.6rem; padding: 0.85rem 0.95rem; border-radius: 0.8rem; background: rgba(14, 22, 20, 0.96); box-shadow: 0 6px 26px rgba(0, 0, 0, 0.5), inset 0 0 0 1px rgba(216, 182, 240, 0.3); z-index: 4; }
+.suco__cierre h3 { margin: 0 0 0.25rem; color: #e6d3f7; font: 700 0.86rem/1.2 system-ui, sans-serif; }
+.suco__cierre p { margin: 0 0 0.55rem; color: #c3b9a6; font: 400 0.78rem/1.45 system-ui, sans-serif; }
+.suco__cierre p:last-of-type { margin-bottom: 0; }
+
+@media (prefers-reduced-motion: reduce) {
+  .suco__lienzo, .suco__btn { transition: none; }
+}
+@media (max-width: 22rem) {
+  .suco__titulo h2 { font-size: 0.95rem; }
+  .suco__lado { max-width: 6.6rem; }
+}
+`;
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * EL SHADER DE LA RED — el corazón técnico de la pieza.
+ *
+ * Un solo uniform (`uFrente`) apaga o prende la red entera, sin reconstruir un
+ * solo vértice. Eso es lo que hace que esto corra en el teléfono del campesino
+ * y no solo en la máquina del que lo programó.
+ *
+ * OJO — LA REGLA QUE NO SE PUEDE ROMPER: este `smoothstep` y la `saludEn()` de
+ * `sueloComparado.geom.js` calculan EXACTAMENTE lo mismo, y tienen que seguir
+ * calculándolo. GLSL: smoothstep(e0,e1,x) = suave(clamp((x-e0)/(e1-e0),0,1));
+ * con e0=frente-b y e1=frente+b eso es idéntico a la fórmula del módulo. Si
+ * alguien toca una y no la otra, la escena empieza a mentir: los pulsos (que
+ * usan la de JS) se frenarían en un punto y los hilos (que usan esta) se
+ * cortarían en otro. Se vería como un bug menor de sincronía y sería, en
+ * realidad, la pieza contradiciéndose a sí misma.
+ * ══════════════════════════════════════════════════════════════════════════ */
+const VERT_RED = `
+attribute vec3 aCentro;
+attribute float aT;
+attribute float aFase;
+attribute float aPuente;
+
+uniform float uFrente;
+uniform float uBorrosidad;
+uniform vec3 uMicelio;
+uniform vec3 uPuente;
+uniform vec3 uMicelioTenue;
+uniform vec3 uMuerto;
+uniform vec3 uFantasma;
+
+varying vec3 vColor;
+varying float vSalud;
+
+void main() {
+  // la salud de ESTE anillo (no la del hilo): un hilo largo que cruza el frente
+  // se apaga A LO LARGO, gradual, como pasa en el suelo — no de un golpe
+  float s = 1.0 - smoothstep(uFrente - uBorrosidad, uFrente + uBorrosidad, aCentro.x);
+  vSalud = s;
+
+  // EL CORTE. Con salud baja se abren huecos: la hifa se pica y después se
+  // parte. Colapsar el anillo entero a su centro deja triángulos de área cero
+  // (invisibles) y nos ahorra el "discard", que en gama baja se paga caro.
+  // (Ojo: nada de acentos graves acá adentro — esto es un template literal de
+  // JS y un acento grave suelto lo parte en dos. Ya pasó.)
+  float corte = 1.0;
+  if (s < 0.72) {
+    float onda = sin((aT * mix(3.0, 9.0, 1.0 - s) + aFase) * 6.2831853);
+    float umbral = mix(-1.05, 0.75, 1.0 - s);
+    corte = onda > umbral ? 0.0 : 1.0;
+  }
+
+  // el hilo vivo es grueso; el apagado adelgaza hasta ser una traza
+  float rad = mix(0.28, 1.0, smoothstep(0.0, 1.0, s)) * corte;
+  vec3 p = mix(aCentro, position, rad);
+
+  // turquesa vivo (más claro si es puente) → ceniza → traza fantasma
+  if (s > 0.5) {
+    vec3 base = mix(uMicelio, uPuente, aPuente);
+    vColor = mix(base, uMicelioTenue, 1.0 - smoothstep(0.0, 1.0, (s - 0.5) * 2.0));
+  } else {
+    vColor = mix(uMuerto, uFantasma, 1.0 - smoothstep(0.0, 1.0, s * 2.0));
+  }
+
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(p, 1.0);
+}
+`;
+
+const FRAG_RED = `
+uniform float uOpacidad;
+varying vec3 vColor;
+varying float vSalud;
+
+void main() {
+  // La red viva brilla; la apagada apenas se insinúa. La TRAZA FANTASMA (lo que
+  // queda donde la red pasaba) es recurso de arte, no afirmación biológica: dice
+  // "aquí HABÍA" y "aquí PUEDE volver". Sin ella el lado apagado sería un vacío
+  // y se leería "acá nunca hubo nada" — justo la mentira que la pieza combate.
+  float a = uOpacidad * mix(0.30, 1.0, smoothstep(0.0, 1.0, vSalud));
+  gl_FragColor = vec4(vColor, a);
+}
+`;
+
+/* ── EL RELOJ: mueve el frente y lo deja donde todos lo leen ──────────────
+   UN solo lugar integra el frente. Los demás lo leen de `frenteRef` y cada uno
+   se pinta como quiera — nadie le escribe a nadie.
+
+   El `priority -1` lo hace correr antes que los otros useFrame, para que todos
+   lean el frente del mismo instante (no desactiva el render automático: eso solo
+   pasa con prioridad positiva). */
+function Reloj({ frenteRef, destino, reducedMotion }) {
+  useFrame((_, dt) => {
+    /* con reducedMotion no hay viaje: salta y ya (la escena monta quieta) */
+    frenteRef.current = reducedMotion
+      ? destino
+      : avanzarFrente(frenteRef.current, destino, Math.min(dt, 0.05));
+  }, -1);
+  return null;
+}
+
+/* Un repintado cuando la escena es a demanda (reducedMotion). */
+function Repintar({ dep }) {
+  const invalidate = useThree((s) => s.invalidate);
+  useEffect(() => { invalidate(); }, [dep, invalidate]);
+  return null;
+}
+
+/* ── LA RED: una sola malla, un solo draw-call, un solo uniform ───────────
+   Ella misma lee el frente y escribe su uniform. Mover el frente entero cuesta
+   un float: ni un vértice se reconstruye. Eso es lo que hace que esto corra en
+   el teléfono del campesino y no solo en la máquina del que lo programó. */
+function RedMicelio({ geo, frenteRef, reducedMotion }) {
+  const mat = useMemo(
+    () => new THREE.ShaderMaterial({
+      vertexShader: VERT_RED,
+      fragmentShader: FRAG_RED,
+      uniforms: {
+        /* arranca en el corte (los dos suelos a la vez); el primer useFrame lo
+           pone donde toque. Constante y no `frenteRef.current`: leer un ref en
+           render es justo lo que no se hace. */
+        uFrente: { value: FRENTE.medio },
+        uBorrosidad: { value: BORROSIDAD },
+        uOpacidad: { value: 0.92 },
+        uMicelio: { value: new THREE.Color().copy(PALETA.micelio) },
+        uPuente: { value: new THREE.Color().copy(PALETA.puente) },
+        uMicelioTenue: { value: new THREE.Color().copy(PALETA.micelioTenue) },
+        uMuerto: { value: new THREE.Color().copy(PALETA.micelioMuerto) },
+        uFantasma: { value: new THREE.Color().copy(PALETA.trazaFantasma) },
+      },
+      transparent: true,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    }),
+    [],
+  );
+  useLayoutEffect(() => () => mat.dispose(), [mat]);
+  useFrame((st) => {
+    const u = mat.uniforms;
+    u.uFrente.value = frenteRef.current;
+    /* la red respira apenas: está viva, no es un diagrama */
+    u.uOpacidad.value = reducedMotion
+      ? 0.9
+      : 0.86 + Math.sin(st.clock.elapsedTime * 0.9) * 0.08;
+  });
+  return <mesh geometry={geo} material={mat} frustumCulled={false} />;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+ * REGLA DE `reducedMotion` EN ESTA ESCENA — se rompe fácil, léala.
+ *
+ * `reducedMotion` congela EL RELOJ, no el estado. Los componentes que leen el
+ * frente tienen que seguir corriendo su `useFrame` aunque `reducedMotion` esté
+ * activo: si no, el usuario toca "Fumigar seguido", la red se apaga (es un
+ * uniform) y la lombriz, el fósforo y los grumos se quedan como estaban. Media
+ * escena diciendo una cosa y la otra media diciendo otra.
+ *
+ * No cuesta nada: con `reducedMotion` el Canvas va en `frameloop="demand"`, así
+ * que estos `useFrame` solo corren cuando algo invalida (un toque, el
+ * OrbitControls). En reposo el costo es cero igual.
+ *
+ * Entonces: NO ponga `if (reducedMotion) return` en un componente que lee
+ * `frenteRef`. Lo que sí se apaga es el tiempo — el latido, la deriva, el avance
+ * del pulso — pasando 0 en vez de `elapsedTime`.
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+/* ── LOS NODOS: arbúsculos (intercambio) y uniones del micelio ─────────── */
+function NodosRed({ nodos, frenteRef }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.OctahedronGeometry(0.05, 0), []);
+  const mat = useMemo(
+    () => new THREE.MeshBasicMaterial({ transparent: true, opacity: 0.95, blending: THREE.AdditiveBlending, depthWrite: false }),
+    [],
+  );
+  const tmp = useMemo(() => ({ m: new THREE.Matrix4(), q: new THREE.Quaternion(), s: new THREE.Vector3(), p: new THREE.Vector3(), c: new THREE.Color() }), []);
+
+  const escribir = () => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const { m, q, s, p, c } = tmp;
+    const frente = frenteRef.current;
+    for (let i = 0; i < nodos.length; i++) {
+      const n = nodos[i];
+      const sal = saludEn(n.pos.x, frente);
+      const base = n.tipo === 'raiz' ? 1.5 : 0.9;
+      /* el arbúsculo y la unión se apagan con la red; el nodo no desaparece del
+         todo: queda el punto donde estuvo */
+      const esc = base * (0.28 + sal * 0.72);
+      p.copy(n.pos); s.setScalar(esc);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      c.copy(n.tipo === 'raiz' ? PALETA.arbusculo : PALETA.nodo)
+        .lerp(PALETA.micelioMuerto, 1 - sal);
+      mesh.setColorAt(i, c);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  };
+
+  useLayoutEffect(() => {
+    escribir(); // pose inicial
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodos]);
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+  useFrame(() => escribir()); // lee el frente: corre siempre (ver regla arriba)
+  if (!nodos.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, nodos.length]} frustumCulled={false} />;
+}
+
+/* ── EL BANCO DE ESPORAS: las luces que cruzan el frente enteras ──────────
+   Componente aparte de NodosRed a propósito: son las ÚNICAS que no leen la
+   salud. Separarlas en su propio mesh es la forma de garantizar, en código, que
+   nadie las apague por descuido el día que refactorice los nodos. */
+function Esporas({ esporas, reducedMotion }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.IcosahedronGeometry(0.055, 0), []);
+  const mat = useMemo(
+    () => new THREE.MeshBasicMaterial({ color: PALETA.espora, transparent: true, opacity: 0.9, blending: THREE.AdditiveBlending, depthWrite: false }),
+    [],
+  );
+  const tmp = useMemo(() => ({ m: new THREE.Matrix4(), q: new THREE.Quaternion(), s: new THREE.Vector3(), p: new THREE.Vector3() }), []);
+  const escribir = (time) => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const { m, q, s, p } = tmp;
+    for (let i = 0; i < esporas.length; i++) {
+      const e = esporas[i];
+      /* laten despacio: están esperando, no dormidas (el corpus no dice
+         "dormidas" y la pieza tampoco lo dice) */
+      const late = reducedMotion ? 1 : 0.86 + Math.sin(time * 0.7 + e.semilla * 6.28) * 0.14;
+      p.copy(e.pos); s.setScalar(e.esc * late);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  };
+  useLayoutEffect(() => {
+    escribir(0); // pose inicial
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [esporas]);
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+  useFrame((st) => { if (!reducedMotion) escribir(st.clock.elapsedTime); });
+  if (!esporas.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, esporas.length]} frustumCulled={false} />;
+}
+
+/* ── LOS PULSOS: el intercambio, y su frenón ──────────────────────────────
+   Cada pulso corre su hilo. Al entrar en la zona apagada se pone LENTO, se
+   achica y se queda quieto contra el corte. No es un apagón: es un atasco. Y del
+   lado de la mata el azúcar sigue saliendo hacia un hilo que ya no devuelve —
+   la mata pagando por un servicio que no existe. Esa es la imagen. */
+function Pulsos({ curvas, pulsos, frenteRef, reducedMotion }) {
+  const ref = useRef(null);
+  /* El AVANCE de cada pulso es estado de ESTE componente, no de los datos: el
+     módulo de geometría los entrega con su `t0` y no se toca más. (Primero los
+     mutaba en el propio array de `pulsos` — o sea, mutando una prop. Anda, y es
+     una porquería: cualquiera que reusara esos datos se llevaría el estado de
+     una animación ajena pegado.) */
+  const avance = useRef(null);
+  const geo = useMemo(() => new THREE.SphereGeometry(0.045, 7, 6), []);
+  const mat = useMemo(
+    () => new THREE.MeshBasicMaterial({ transparent: true, opacity: 0.95, blending: THREE.AdditiveBlending, depthWrite: false }),
+    [],
+  );
+  const tmp = useMemo(() => ({ m: new THREE.Matrix4(), q: new THREE.Quaternion(), s: new THREE.Vector3(), p: new THREE.Vector3(), c: new THREE.Color() }), []);
+
+  useLayoutEffect(() => {
+    avance.current = Float32Array.from(pulsos, (pu) => pu.t0);
+  }, [pulsos]);
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+
+  const escribir = (dt) => {
+    const mesh = ref.current;
+    const ts = avance.current;
+    if (!mesh || !ts) return;
+    const { m, q, s, p, c } = tmp;
+    const frente = frenteRef.current;
+    for (let i = 0; i < pulsos.length; i++) {
+      const pu = pulsos[i];
+      const cur = curvas[pu.hilo];
+      if (!cur) { s.setScalar(0); m.compose(p.set(0, 0, 0), q, s); mesh.setMatrixAt(i, m); continue; }
+      cur.getPoint(ts[i], p);
+      const sal = saludEn(p.x, frente);
+
+      if (dt > 0) {
+        /* frena al entrar en lo apagado: a salud 0 queda casi detenido */
+        const vel = pu.vel * (0.04 + 0.96 * sal);
+        let t = ts[i] + (pu.sube ? 1 : -1) * vel * dt;
+        t -= Math.floor(t); // envolver a [0,1)
+        ts[i] = t;
+      }
+
+      /* se enciende a media hebra y se entrega en las puntas; y se apaga con la
+         salud del sitio (un pulso no vive en un hilo roto) */
+      const brote = Math.sin(ts[i] * Math.PI);
+      s.setScalar((0.35 + brote * 0.85) * (0.1 + sal * 0.9));
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      c.copy(colorPulso(pu.tipo)).lerp(PALETA.micelioMuerto, (1 - sal) * 0.75);
+      mesh.setColorAt(i, c);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  };
+
+  // dt=0 congela el avance, pero igual se recolocan segun el frente
+  useFrame((_, dt) => escribir(reducedMotion ? 0 : Math.min(dt, 0.05)));
+  if (!pulsos.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, pulsos.length]} frustumCulled={false} />;
+}
+
+/* ── LA TRAMPA: EL FÓSFORO QUE SÍ ESTÁ, PEGADO ────────────────────────────
+   El argumento más fuerte de la pieza. En el lado vivo estas motas se sueltan y
+   flotan (el hongo las está soltando [21]). En el lado apagado están QUIETAS,
+   pegadas a su partícula de hierro, a un centímetro de la raíz, y la mata no las
+   alcanza. La quietud ES el mensaje: no falta comida — se cortó el que la traía.
+   Por eso toca comprar bulto, y por eso el bulto no lo saca del hueco. */
+function FosforoPegado({ motas, frenteRef, reducedMotion }) {
+  const refP = useRef(null);
+  const refH = useRef(null);
+  const geoP = useMemo(() => new THREE.SphereGeometry(0.036, 6, 5), []);
+  const geoH = useMemo(() => new THREE.IcosahedronGeometry(0.06, 0), []);
+  const matP = useMemo(() => new THREE.MeshBasicMaterial({ transparent: true, opacity: 0.95, blending: THREE.AdditiveBlending, depthWrite: false }), []);
+  const matH = useMemo(() => new THREE.MeshLambertMaterial({ color: PALETA.particulaHierro, flatShading: true }), []);
+  const tmp = useMemo(() => ({ m: new THREE.Matrix4(), q: new THREE.Quaternion(), s: new THREE.Vector3(), p: new THREE.Vector3(), c: new THREE.Color() }), []);
+
+  /* la partícula de hierro/arcilla no cambia: siempre está ahí, agarrando */
+  useLayoutEffect(() => {
+    const mesh = refH.current;
+    if (!mesh) return;
+    const { m, q, s, p } = tmp;
+    for (let i = 0; i < motas.length; i++) {
+      p.copy(motas[i].pos); s.setScalar(motas[i].esc);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [motas, tmp]);
+
+  const escribir = (time) => {
+    const mesh = refP.current;
+    if (!mesh) return;
+    const { m, q, s, p, c } = tmp;
+    const frente = frenteRef.current;
+    for (let i = 0; i < motas.length; i++) {
+      const mo = motas[i];
+      const sal = saludEn(mo.pos.x, frente);
+      /* VIVO: se suelta y sube (el hongo la despegó). APAGADO: quieta, pegada. */
+      const suelta = sal * sal; // solo con red buena de verdad se despega
+      const sube = reducedMotion ? suelta * 0.12 : suelta * (0.1 + Math.abs(Math.sin(time * 0.5 + mo.semilla * 6.28)) * 0.22);
+      p.set(
+        mo.pos.x + (reducedMotion ? 0 : Math.cos(time * 0.4 + mo.semilla * 6.28) * 0.05 * suelta),
+        mo.pos.y + sube,
+        mo.pos.z,
+      );
+      s.setScalar(mo.esc * (0.7 + suelta * 0.5));
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      /* ámbar vivo cuando va corriendo; ámbar apagado cuando está agarrada */
+      c.copy(PALETA.fosforoPegado).lerp(PALETA.fosforo, suelta);
+      mesh.setColorAt(i, c);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  };
+
+  useLayoutEffect(() => {
+    escribir(0); // pose inicial
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [motas]);
+  useLayoutEffect(() => () => { geoP.dispose(); geoH.dispose(); matP.dispose(); matH.dispose(); }, [geoP, geoH, matP, matH]);
+  useFrame((st) => escribir(reducedMotion ? 0 : st.clock.elapsedTime));
+  if (!motas.length) return null;
+  return (
+    <group>
+      <instancedMesh ref={refH} args={[geoH, matH, motas.length]} frustumCulled={false} />
+      <instancedMesh ref={refP} args={[geoP, matP, motas.length]} frustumCulled={false} />
+    </group>
+  );
+}
+
+/* ── LAS RAÍCES: lo que NO cambia ─────────────────────────────────────────
+   Estáticas, iguales de los dos lados. La mata está viva. Ver la nota larga en
+   `tuboRaizGeom` — es la decisión que le da permiso a toda la pieza. */
+function Raices({ geo }) {
+  const mat = useMemo(
+    () => new THREE.MeshLambertMaterial({ vertexColors: true, transparent: true, opacity: 0.96 }),
+    [],
+  );
+  useLayoutEffect(() => () => mat.dispose(), [mat]);
+  if (!geo) return null;
+  return <mesh geometry={geo} material={mat} frustumCulled={false} />;
+}
+
+/* ── LA RAICILLA ALGODONOSA: lo que SÍ se pierde ──────────────────────────
+   La señal verificable con una pala [100]. Cave, mire la raíz, vea si está el
+   pelito blanco. No hay que creernos nada. */
+function Raicillas({ mechones, frenteRef }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.IcosahedronGeometry(0.05, 0), []);
+  const mat = useMemo(
+    () => new THREE.MeshBasicMaterial({ color: PALETA.raizFina, transparent: true, opacity: 0.62, blending: THREE.AdditiveBlending, depthWrite: false }),
+    [],
+  );
+  const tmp = useMemo(() => ({ m: new THREE.Matrix4(), q: new THREE.Quaternion(), s: new THREE.Vector3(), p: new THREE.Vector3() }), []);
+  const escribir = () => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const { m, q, s, p } = tmp;
+    const frente = frenteRef.current;
+    for (let i = 0; i < mechones.length; i++) {
+      const me = mechones[i];
+      const sal = saludEn(me.pos.x, frente);
+      /* al cubo: el pelito blanco es lo PRIMERO que se pierde, y no vuelve fácil */
+      p.copy(me.pos); s.setScalar(me.esc * sal * sal * sal);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  };
+  useLayoutEffect(() => {
+    escribir(); // pose inicial
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mechones]);
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+  useFrame(() => escribir()); // lee el frente: corre siempre
+  if (!mechones.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, mechones.length]} frustumCulled={false} />;
+}
+
+/* ── LA LOMBRIZ Y SU TÚNEL ────────────────────────────────────────────────
+   [102] "si al cavar no aparece ninguna... es una alerta". El TÚNEL SE QUEDA
+   aunque ella no: no hay cadáver, hay ausencia — y la casa sigue lista para
+   cuando vuelva. Un túnel vacío dice más que una lombriz muerta, y además es lo
+   que de verdad pasa. */
+function Lombrices({ lombrices, frenteRef, reducedMotion }) {
+  const grupo = useRef([]);
+  const matTunel = useMemo(() => new THREE.MeshBasicMaterial({ color: PALETA.tunelVacio, transparent: true, opacity: 0.5, depthWrite: false }), []);
+  const matLombriz = useMemo(() => new THREE.MeshLambertMaterial({ color: PALETA.lombriz }), []);
+  const geos = useMemo(
+    () => lombrices.map((lo) => new THREE.TubeGeometry(lo.curva, 14, 0.055, 5, false)),
+    [lombrices],
+  );
+  const cuerpo = useMemo(() => new THREE.CapsuleGeometry(0.05, 0.16, 3, 6), []);
+  const tmp = useMemo(() => ({ p: new THREE.Vector3(), p2: new THREE.Vector3() }), []);
+
+  useLayoutEffect(() => () => {
+    geos.forEach((g) => g.dispose());
+    cuerpo.dispose(); matTunel.dispose(); matLombriz.dispose();
+  }, [geos, cuerpo, matTunel, matLombriz]);
+
+  useFrame((st) => {
+    const frente = frenteRef.current;
+    const { p, p2 } = tmp;
+    for (let i = 0; i < lombrices.length; i++) {
+      const nodo = grupo.current[i];
+      if (!nodo) continue;
+      const lo = lombrices[i];
+      const sal = saludEn(lo.x, frente);
+      const t = reducedMotion ? 0.5 : (lo.t + st.clock.elapsedTime * lo.vel) % 1;
+      lo.curva.getPoint(t, p);
+      nodo.position.copy(p);
+      /* mira hacia donde va (sin cuentas raras: dos puntos y listo) */
+      lo.curva.getPoint(Math.min(0.999, t + 0.03), p2);
+      nodo.lookAt(p2);
+      nodo.rotateX(Math.PI / 2); // la cápsula nace en Y
+      /* se va con la salud: donde el suelo se apagó, no aparece ninguna */
+      nodo.scale.setScalar(Math.max(0.001, sal * sal));
+      nodo.visible = sal > 0.06;
+    }
+  });
+
+  return (
+    <group>
+      {lombrices.map((lo, i) => (
+        <group key={`lo-${i}`}>
+          {/* el túnel: se queda siempre */}
+          <mesh geometry={geos[i]} material={matTunel} frustumCulled={false} />
+          {/* ella: solo donde el suelo está vivo */}
+          <mesh
+            ref={(n) => { grupo.current[i] = n; }}
+            geometry={cuerpo}
+            material={matLombriz}
+            frustumCulled={false}
+          />
+        </group>
+      ))}
+    </group>
+  );
+}
+
+/* ── LOS GRUMOS Y EL POLVO ────────────────────────────────────────────────
+   La MISMA partícula: apretada en su miga cuando algo la está pegando [6][105],
+   suelta y caída cuando ya no. No cambia la tierra — cambia si algo la agarra.
+   Se puede comprobar con la mano: agarre un puñado y vea si se rompe en grumitos
+   o se le va en polvo [100]. */
+function Agregados({ granos, frenteRef }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.IcosahedronGeometry(0.045, 0), []);
+  const mat = useMemo(() => new THREE.MeshLambertMaterial({ flatShading: true }), []);
+  const tmp = useMemo(() => ({ m: new THREE.Matrix4(), q: new THREE.Quaternion(), s: new THREE.Vector3(), p: new THREE.Vector3(), c: new THREE.Color() }), []);
+  const escribir = () => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const { m, q, s, p, c } = tmp;
+    const frente = frenteRef.current;
+    for (let i = 0; i < granos.length; i++) {
+      const g = granos[i];
+      const sal = saludEn(g.juntos.x, frente);
+      p.copy(g.sueltos).lerp(g.juntos, sal);
+      s.setScalar(g.esc);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+      c.copy(PALETA.polvo).lerp(PALETA.grumo, sal);
+      mesh.setColorAt(i, c);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  };
+  useLayoutEffect(() => {
+    escribir(); // pose inicial
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [granos]);
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+  useFrame(() => escribir()); // lee el frente: corre siempre
+  if (!granos.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, granos.length]} frustumCulled={false} />;
+}
+
+/* ── LOS POROS Y SU AGUA ──────────────────────────────────────────────────
+   [22] los hilos llegan a poros chiquiticos "donde queda agua atrapada después
+   de que la superficie ya se secó". Esa es el agua del verano. Sin red se queda
+   ahí sin que nadie la saque. */
+function PorosAgua({ poros, frenteRef, reducedMotion }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.SphereGeometry(0.03, 6, 5), []);
+  const mat = useMemo(
+    () => new THREE.MeshBasicMaterial({ color: PALETA.gotaAgua, transparent: true, opacity: 0.55, blending: THREE.AdditiveBlending, depthWrite: false }),
+    [],
+  );
+  const tmp = useMemo(() => ({ m: new THREE.Matrix4(), q: new THREE.Quaternion(), s: new THREE.Vector3(), p: new THREE.Vector3() }), []);
+  const escribir = (time) => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const { m, q, s, p } = tmp;
+    const frente = frenteRef.current;
+    for (let i = 0; i < poros.length; i++) {
+      const po = poros[i];
+      const sal = saludEn(po.pos.x, frente);
+      const late = reducedMotion ? 1 : 0.9 + Math.sin(time * 0.6 + po.semilla * 6.28) * 0.1;
+      p.copy(po.pos);
+      s.setScalar(po.esc * sal * late);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  };
+  useLayoutEffect(() => {
+    escribir(0); // pose inicial
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [poros]);
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+  useFrame((st) => escribir(reducedMotion ? 0 : st.clock.elapsedTime));
+  if (!poros.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, poros.length]} frustumCulled={false} />;
+}
+
+/* ── LA SUPERFICIE ────────────────────────────────────────────────────────
+   Arriba del corte: de un lado hojarasca (la cobertura que ahoga la maleza y
+   además abona [2]); del otro, tierra pelada al sol [40][50]. Es lo único que el
+   campesino ve sin cavar — y por eso los TALLITOS están verdes de los DOS lados.
+   La mata se ve bien igual. Ese es el problema. */
+function Superficie({ matas, hojas, frenteRef }) {
+  const ref = useRef(null);
+  const geoH = useMemo(() => new THREE.PlaneGeometry(0.16, 0.1), []);
+  const matH = useMemo(
+    () => new THREE.MeshLambertMaterial({ color: PALETA.hojarasca, side: THREE.DoubleSide, transparent: true }),
+    [],
+  );
+  const tmp = useMemo(() => ({ m: new THREE.Matrix4(), q: new THREE.Quaternion(), s: new THREE.Vector3(), p: new THREE.Vector3(), e: new THREE.Euler() }), []);
+  const escribir = () => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const { m, q, s, p, e } = tmp;
+    const frente = frenteRef.current;
+    for (let i = 0; i < hojas.length; i++) {
+      const h = hojas[i];
+      const sal = saludEn(h.pos.x, frente);
+      e.set(-Math.PI / 2, 0, h.rot);
+      q.setFromEuler(e);
+      p.copy(h.pos);
+      s.setScalar(h.esc * sal);
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  };
+  useLayoutEffect(() => {
+    escribir(); // pose inicial
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hojas]);
+  useLayoutEffect(() => () => { geoH.dispose(); matH.dispose(); }, [geoH, matH]);
+  useFrame(() => escribir()); // lee el frente: corre siempre
+
+  const zMedio = SUELO.zAtras + (SUELO.z0 - SUELO.zAtras) / 2;
+  return (
+    <group>
+      {/* la lámina de tierra vista desde abajo: el techo del mundo subterráneo */}
+      <mesh position={[0, 0, zMedio]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[SUELO.ancho + 1.5, SUELO.z0 - SUELO.zAtras + 1.2]} />
+        <meshBasicMaterial color={PALETA.tierraAlta} transparent opacity={0.55} depthWrite={false} side={THREE.DoubleSide} />
+      </mesh>
+      {/* los tallitos: VERDES DE LOS DOS LADOS. La mata está viva. Ese es el
+          punto entero de la pieza. */}
+      {matas.map((mata) => (
+        <group key={`ta-${mata.id}`} position={[mata.base.x, 0, mata.base.z]}>
+          <mesh position={[0, 0.28, 0]}>
+            <cylinderGeometry args={[0.03, 0.05, 0.56, 6]} />
+            <meshLambertMaterial color={PALETA.tallo} />
+          </mesh>
+          <mesh position={[0.09, 0.42, 0]} rotation={[0, 0, -0.7]}>
+            <coneGeometry args={[0.05, 0.3, 4]} />
+            <meshLambertMaterial color={PALETA.tallo} flatShading />
+          </mesh>
+        </group>
+      ))}
+      {hojas.length > 0 && (
+        <instancedMesh ref={ref} args={[geoH, matH, hojas.length]} frustumCulled={false} />
+      )}
+    </group>
+  );
+}
+
+/* ── LOS HOTSPOTS ─────────────────────────────────────────────────────────
+   Anclas fijas: cada punto vive donde está la cosa de la que habla. Los de
+   'ambos' se ponen dos veces (uno por lado) porque la gracia es comparar la
+   MISMA cosa a lado y lado. */
+const ANCLAS = {
+  intercambio: [-2.9, -1.5, 0.2],
+  red: [-1.7, -2.7, 0.1],
+  raicilla: [-3.5, -2.4, 0.3],
+  'hilo-roto': [2.0, -1.6, 0.2],
+  'fosforo-pegado': [3.1, -2.5, 0.25],
+  trampa: [2.4, -3.5, 0.1],
+  rebrote: [3.7, -0.75, 0.3],
+  espora: [1.5, -3.6, 0.2],
+  /* los de 'ambos': [lado vivo, lado apagado] */
+  grumo: [[-3.9, -3.3, 0.3], [3.9, -3.3, 0.3]],
+  lombriz: [[-2.4, -3.9, 0.2], [2.9, -3.9, 0.2]],
+  olor: [[-4.1, -0.7, 0.35], [4.1, -0.7, 0.35]],
+  agua: [[-0.9, -4.1, 0.2], [1.1, -4.4, 0.2]],
+};
+
+function Hotspots({ onAbrir, tier }) {
+  /* en gama baja el DOM sobre el canvas cuesta: solo los que cargan el argumento */
+  const lista = tier === 'bajo'
+    ? HOTSPOTS.filter((h) => ['fosforo-pegado', 'lombriz', 'trampa', 'espora'].includes(h.id))
+    : HOTSPOTS;
+  const puntos = [];
+  for (const h of lista) {
+    const a = ANCLAS[h.id];
+    if (!a) continue;
+    if (Array.isArray(a[0])) {
+      puntos.push({ h, pos: a[0], k: `${h.id}-v`, apagado: false });
+      puntos.push({ h, pos: a[1], k: `${h.id}-a`, apagado: true });
+    } else {
+      puntos.push({ h, pos: a, k: h.id, apagado: h.lado === 'apagado' });
+    }
+  }
+  return puntos.map(({ h, pos, k, apagado }) => (
+    <Html key={k} position={pos} center className="suco-hot" zIndexRange={[5, 0]}>
+      <button
+        type="button"
+        className={`suco-hot__btn${apagado ? ' suco-hot__btn--apagado' : ''}`}
+        onClick={() => onAbrir(h)}
+        aria-label={h.titulo}
+      />
+    </Html>
+  ));
+}
+
+/* ── EL MUNDO ─────────────────────────────────────────────────────────────── */
+function Mundo({ tier, reducedMotion, frenteRef, destino, onAbrir }) {
+  const params = useMemo(() => paramsDeTier(tier), [tier]);
+
+  const { matas, puntas } = useMemo(() => sistemaRaices(params), [params]);
+  const libres = useMemo(() => nodosLibres(params), [params]);
+  /* `matas` no es opcional acá: sin ellas no se tejen los PUENTES y la red no
+     cruza de una mata a otra — que es lo único que esta escena existe para
+     mostrar. Ver la nota en `construirRed`. */
+  const { nodos, hilos } = useMemo(
+    () => construirRed(puntas, libres, params, matas),
+    [puntas, libres, params, matas],
+  );
+  const { geo: geoRed, curvas } = useMemo(
+    () => geometriaRed(nodos, hilos, params),
+    [nodos, hilos, params],
+  );
+  const geoRaices = useMemo(() => geometriaRaices(matas, params), [matas, params]);
+  const mechones = useMemo(() => raicillasFinas(matas, params), [matas, params]);
+  const pulsos = useMemo(() => pulsosDeRed(hilos, params), [hilos, params]);
+  const motasP = useMemo(() => fosforoPegado(params), [params]);
+  const lombrices = useMemo(() => lombricesYTuneles(params), [params]);
+  const granos = useMemo(() => agregados(params), [params]);
+  const poros = useMemo(() => porosAgua(params), [params]);
+  const esporas = useMemo(() => bancoEsporas(params), [params]);
+  const hojas = useMemo(() => hojarascaSuperficie(params), [params]);
+
+  useLayoutEffect(() => () => { geoRed.dispose(); geoRaices.dispose(); }, [geoRed, geoRaices]);
+
+  return (
+    <>
+      <Reloj frenteRef={frenteRef} destino={destino} reducedMotion={reducedMotion} />
+      {/* luz mínima y cálida: esto es un subsuelo, no un quirófano. Lo que
+          brilla, brilla por sí solo (aditivo); la luz solo le da cuerpo a la
+          raíz, la lombriz y los grumos. */}
+      <ambientLight intensity={0.55} color="#ffe6ba" />
+      <directionalLight position={[2, 4, 3]} intensity={0.7} color="#ffd79a" />
+      <directionalLight position={[-3, -1, -2]} intensity={0.25} color="#9db8d9" />
+
+      <Superficie matas={matas} hojas={hojas} frenteRef={frenteRef} />
+      <Raices geo={geoRaices} />
+      <Raicillas mechones={mechones} frenteRef={frenteRef} />
+      <Agregados granos={granos} frenteRef={frenteRef} />
+      <PorosAgua poros={poros} frenteRef={frenteRef} reducedMotion={reducedMotion} />
+      <Lombrices lombrices={lombrices} frenteRef={frenteRef} reducedMotion={reducedMotion} />
+      <FosforoPegado motas={motasP} frenteRef={frenteRef} reducedMotion={reducedMotion} />
+      <RedMicelio geo={geoRed} frenteRef={frenteRef} reducedMotion={reducedMotion} />
+      <NodosRed nodos={nodos} frenteRef={frenteRef} />
+      <Esporas esporas={esporas} reducedMotion={reducedMotion} />
+      <Pulsos curvas={curvas} pulsos={pulsos} frenteRef={frenteRef} reducedMotion={reducedMotion} />
+      <Hotspots onAbrir={onAbrir} tier={tier} />
+    </>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════════════════ */
+/**
+ * La escena. Montar dentro de un host con altura.
+ * @param {{ tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean }} props
+ */
+export default function EscenaSueloComparado({ tier = 'medio', reducedMotion = false }) {
+  const [lista, setLista] = useState(false);
+  const [ficha, setFicha] = useState(null);
+  /* 'medio' = los dos suelos a la vez (así arranca: el corte es el argumento).
+     'apagar' = fumigar seguido. 'recuperar' = parar y dejarla volver. */
+  const [modo, setModo] = useState('medio');
+  const frenteRef = useRef(FRENTE.medio);
+
+  const destino = modo === 'apagar' ? FRENTE.todoApagado
+    : modo === 'recuperar' ? FRENTE.todoVivo
+      : FRENTE.medio;
+
+  /* el cierre aparece solo cuando el campesino ya movió el frente: primero que
+     vea, después le hablamos. Y en el orden que manda el corpus — la asimetría
+     antes que la esperanza (ver `CIERRE` en los textos). */
+  const cierre = modo === 'apagar' ? CIERRE.asimetria : modo === 'recuperar' ? CIERRE.esperanza : null;
+
+  useEffect(() => { const t = setTimeout(() => setLista(true), 60); return () => clearTimeout(t); }, []);
+
+  const alternar = (m) => { setModo((v) => (v === m ? 'medio' : m)); setFicha(null); };
+
+  return (
+    <div className="suco">
+      <style>{CSS}</style>
+
+      <Canvas
+        className={`suco__lienzo${lista ? ' suco__lienzo--lista' : ''}`}
+        dpr={tier === 'alto' ? [1, 1.8] : tier === 'medio' ? [1, 1.3] : 1}
+        gl={{ antialias: tier === 'alto', powerPreference: 'high-performance' }}
+        camera={{ position: [0, -1.6, 8.4], fov: 42 }}
+        frameloop={reducedMotion ? 'demand' : 'always'}
+      >
+        <color attach="background" args={[`#${PALETA.tierra.getHexString()}`]} />
+        <fog attach="fog" args={[`#${PALETA.tierra.getHexString()}`, 9, 20]} />
+        <Mundo
+          tier={tier}
+          reducedMotion={reducedMotion}
+          frenteRef={frenteRef}
+          destino={destino}
+          onAbrir={setFicha}
+        />
+        <OrbitControls
+          enablePan={false}
+          minDistance={4.5}
+          maxDistance={11}
+          minPolarAngle={Math.PI * 0.22}
+          maxPolarAngle={Math.PI * 0.78}
+          enableDamping={!reducedMotion}
+        />
+        <AdaptiveDpr pixelated />
+        <Repintar dep={modo} />
+      </Canvas>
+
+      <header className="suco__titulo">
+        <h2>{TITULO.titulo}</h2>
+        <p>{TITULO.bajada}</p>
+      </header>
+
+      <div className="suco__lados">
+        <div className="suco__lado">
+          <b>{TEXTO_LADOS.vivo.nombre}</b>
+          <span>{TEXTO_LADOS.vivo.pie}</span>
+        </div>
+        <div className="suco__lado suco__lado--apagado">
+          <b>{TEXTO_LADOS.apagado.nombre}</b>
+          <span>{TEXTO_LADOS.apagado.pie}</span>
+        </div>
+      </div>
+
+      {!ficha && !cierre && <p className="suco__ayuda">{CONTROL.ayuda}</p>}
+
+      {ficha && (
+        <article className="suco__ficha">
+          <button type="button" onClick={() => setFicha(null)} aria-label="Cerrar">×</button>
+          <h3>{ficha.titulo}</h3>
+          <p>{ficha.texto}</p>
+        </article>
+      )}
+
+      {!ficha && cierre && (
+        <article className="suco__cierre">
+          <h3>{cierre.titulo}</h3>
+          <p>{cierre.texto}</p>
+          {modo === 'recuperar' && <p><b>{CIERRE.primerPaso.titulo}.</b> {CIERRE.primerPaso.texto}</p>}
+          {modo === 'apagar' && <p><b>{CONCESION.titulo}.</b> {CONCESION.texto}</p>}
+        </article>
+      )}
+
+      <div className="suco__control">
+        <button
+          type="button"
+          className={`suco__btn${modo === 'apagar' ? ' suco__btn--on' : ''}`}
+          onClick={() => alternar('apagar')}
+          aria-pressed={modo === 'apagar'}
+        >
+          {CONTROL.apagar}
+        </button>
+        <button
+          type="button"
+          className={`suco__btn${modo === 'recuperar' ? ' suco__btn--on' : ''}`}
+          onClick={() => alternar('recuperar')}
+          aria-pressed={modo === 'recuperar'}
+        >
+          {CONTROL.recuperar}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* Las dos cadencias (`CADENCIAS` en los textos) son la rima que remata la pieza:
+   el bulto dice "repita cada tres o cuatro semanas" y la guadaña dice "repita el
+   corte cada tres o cuatro semanas". Mismo ritmo, mismo trabajo, otro destino.
+   No está montada acá todavía: va en la lámina 2D que acompaña la escena, donde
+   el texto puede respirar. Queda anotado para que no se pierda — es el mejor
+   hallazgo del corpus y sería una lástima. */
+export { FRENTE };

--- a/src/visual/mundo3d/suelo-comparado/index.js
+++ b/src/visual/mundo3d/suelo-comparado/index.js
@@ -1,0 +1,84 @@
+/*
+ * suelo-comparado/ — EL MISMO SUELO, DOS VECES: la red micorrízica encendida y
+ * la red apagada bajo fumigación repetida.
+ *
+ * El argumento contra el glifosato que NO es moral y por eso funciona: no le
+ * decimos al campesino que es mala persona (no le sirve, y además el químico es
+ * barato y sirve). Le mostramos que le está apagando el suelo que le da de
+ * comer, y que un suelo apagado lo vuelve dependiente del bulto.
+ *
+ *   import EscenaSueloComparado from '../suelo-comparado';
+ *   <EscenaSueloComparado tier="medio" reducedMotion={false} />
+ *
+ * Monta dentro de un host que provea altura. Importa three → siempre perezoso.
+ *
+ * ── ANTES DE TOCAR ESTO, LEA ESTO ─────────────────────────────────────────
+ * La pieza tiene reglas duras de honestidad, y no son decoración: son la razón
+ * por la que le creen. Están largas en `sueloComparado.geom.js` (cabecera) y en
+ * `sueloComparadoTextos.js`. El resumen:
+ *
+ *   1. NADA de cáncer ni salud humana. Esto va del SUELO, donde la evidencia es
+ *      clara y el argumento es del propio bolsillo del campesino. La salud
+ *      humana está en disputa real y una disputa no se dibuja como hecho.
+ *   2. NADA de quelación, manganeso, AMPA ni "resistencia de malezas": CERO
+ *      hits en el corpus (verificado por grep sobre los 20 .jsonl). No están →
+ *      no se dicen. Lo que sí está —y es mejor argumento— es que la micorriza
+ *      DESPEGA el fósforo del hierro y la arcilla: matás la red y el fósforo
+ *      sigue ahí, quieto, sin que la mata lo alcance. Ahí está la trampa.
+ *   3. LA MATA NO SE MUERE. Se dibuja viva y verde de los dos lados, porque en
+ *      la finca está viva y verde. Ese es el problema, y esa honestidad es lo
+ *      que nos da permiso para todo lo demás.
+ *   4. Ni calaveras, ni rojo de alarma, ni panfleto. El lado apagado no es
+ *      horror: es silencio.
+ *   5. La concesión de la voz del corpus ("un uso puntual y focalizado puede ser
+ *      la única salida... lo que no hacemos es recetarlo como rutina de
+ *      calendario") SE QUEDA. Un arte que no concede nada no lo creen.
+ *
+ * Fuentes: `Chagra-strategy/ops/corpus-maestros/teacher-micorrizas.jsonl` y
+ * `dpo-frontera-agroecologica.jsonl` (las 7 entradas de glifosato; ojo que las
+ * cifras de dosis viven en el campo `rejected` — son la voz que el corpus
+ * RECHAZA, nunca la nuestra). Cada afirmación de la pieza lleva su cita.
+ */
+export { default } from './EscenaSueloComparado.jsx';
+export { default as EscenaSueloComparado, FRENTE } from './EscenaSueloComparado.jsx';
+
+/* la geometría pura (headless, testeable: cero GL, cero azar por frame) */
+export {
+  PALETA,
+  SUELO,
+  LADOS,
+  PARAMS_TIER,
+  VELOCIDAD,
+  paramsDeTier,
+  saludEn,
+  avanzarFrente,
+  rng,
+  sistemaRaices,
+  nodosLibres,
+  construirRed,
+  curvaHilo,
+  geometriaRed,
+  geometriaRaices,
+  tuboRaizGeom,
+  raicillasFinas,
+  pulsosDeRed,
+  colorPulso,
+  fosforoPegado,
+  lombricesYTuneles,
+  agregados,
+  porosAgua,
+  bancoEsporas,
+  hojarascaSuperficie,
+} from './sueloComparado.geom.js';
+
+/* la voz (con la fuente de cada frase pegada al lado) */
+export {
+  TITULO,
+  LADOS as TEXTO_LADOS,
+  HOTSPOTS,
+  CIERRE,
+  CONCESION,
+  CADENCIAS,
+  CONTROL,
+  hotspotsDe,
+} from './sueloComparadoTextos.js';

--- a/src/visual/mundo3d/suelo-comparado/sueloComparado.geom.js
+++ b/src/visual/mundo3d/suelo-comparado/sueloComparado.geom.js
@@ -1,0 +1,1007 @@
+/*
+ * sueloComparado.geom — la GEOMETRÍA del MISMO SUELO EN DOS ESTADOS: la red
+ * micorrízica encendida y la red apagada bajo fumigación repetida.
+ *
+ * Funciones PURAS y testeables (three-core, corre headless — cero contexto GL,
+ * cero azar por frame, cero assets externos). El componente r3f
+ * (`EscenaSueloComparado.jsx`) le pone luz, material aditivo y tiempo.
+ *
+ * ── EL ARGUMENTO QUE DIBUJA (y por qué este, y no otro) ─────────────────────
+ * Al campesino el argumento moral no le sirve: el glifosato es barato, es
+ * efectivo y se lo vendieron. El argumento que SÍ le sirve es de su propio
+ * bolsillo: le está apagando el suelo que le da de comer, y un suelo apagado lo
+ * vuelve dependiente del bulto.
+ *
+ * La pieza NO es un panfleto. No hay calaveras, no hay rojo de catástrofe, no
+ * hay muerte gótica. El lado apagado no es horror: es SILENCIO. Tierra pálida,
+ * quieta, sin olor. Así lo dice el propio corpus — "un suelo sin ningún olor
+ * particular puede indicar poca vida biológica". La ausencia asusta más que la
+ * calavera, y además es verdad.
+ *
+ * ── LO QUE ESTA PIEZA AFIRMA (todo con fuente en el corpus de Chagra) ───────
+ *   La red y el intercambio (teacher-micorrizas):
+ *     [19] "La planta le paga al hongo con azúcares que ella misma fabrica con
+ *          la luz del sol... A cambio, el hongo usa sus hilos finísimos para
+ *          buscar FÓSFORO y AGUA en rincones del suelo donde la raíz sola nunca
+ *          llegaría." → los pulsos: carbono BAJA, fósforo/agua SUBEN.
+ *     [25] el hongo también aporta "micronutrientes como el ZINC y el COBRE".
+ *          (OJO: zinc y cobre. NO manganeso, NO hierro — ver abajo.)
+ *     [20] el azúcar que la mata entrega "no es un regalo que la debilite: es
+ *          una inversión".
+ *   El daño (teacher-micorrizas + dpo-frontera-agroecologica):
+ *     [36] arar de más "corta físicamente esos hilos finísimos del hongo que
+ *          tardan MESES en reconstruirse" → los hilos rotos, con hueco.
+ *     [45] los herbicidas "eliminan de golpe muchas raíces vivas que
+ *          alimentaban a la red". El mismo corpus se frena ahí: "algunos
+ *          componentes activos han mostrado efectos negativos sobre
+ *          microorganismos del suelo en distintos estudios. NO LE PUEDO DAR UNA
+ *          CIFRA EXACTA." Ese freno es parte del material.
+ *     [40] el hongo "necesita una raíz viva para sobrevivir" → suelo pelado = la
+ *          red "se muere de hambre por falta de raíces que alimentar".
+ *   dpo-frontera-agroecologica (la voz buena, el `chosen`):
+ *     [0]  el glifosato "mata la raíz y también se lleva la vida del suelo que
+ *          usted necesita para el potrero de después: hongos, lombriz, todo".
+ *     [2]  "mata microorganismos del suelo y contamina agua si hay quebrada
+ *          cerca".
+ *     [18] "deja el suelo más pobre en vida microbiana, y con suelo pobre usted
+ *          termina DEPENDIENDO DE COMPRAR CADA VEZ MÁS INSUMO" → el círculo.
+ *     [16] el kikuyo "se riega por RIZOMA, y el químico solo lo quema por
+ *          encima; a las semanas rebrota de la raíz que quedó viva" → el
+ *          círculo vicioso REAL, que es rebrote, no resistencia.
+ *   La trampa del fósforo (LA pieza central del argumento):
+ *     [21] las micorrizas "liberan sustancias que ayudan a SOLTAR el fósforo que
+ *          está 'pegado' a partículas de arcilla o hierro".
+ *     [30] "en suelos ácidos como muchos de ladera andina, [el fósforo] se pega
+ *          al hierro y al aluminio".
+ *     [32] sin red, "la planta queda más vulnerable, dependiendo del insumo
+ *          comprado en vez de la relación natural del suelo. AHÍ ESTÁ LA
+ *          TRAMPA."
+ *          → Por eso el fósforo del lado apagado se dibuja PRESENTE PERO QUIETO,
+ *            pegado a su partícula. Está ahí. La mata no lo alcanza. Es el
+ *            argumento entero en un solo gesto visual.
+ *   Las señales que el campesino puede ver con una pala (teacher-micorrizas):
+ *     [100] "huela un puñado de tierra húmeda... busque LOMBRICES al cavar,
+ *           fíjese si hay raíces finas blancas con textura algodonosa... y vea
+ *           si el suelo se rompe en GRUMOS en vez de ser polvo suelto".
+ *     [102] "si al cavar no aparece ninguna [lombriz]... es una alerta".
+ *     [105] los grumos son "pequeñas migas de pan húmedas que no se deshacen
+ *           fácil al tocarlas" → agregados vs polvo.
+ *     [22]  los hilos del hongo llegan "a poros muy pequeños del suelo donde
+ *           queda agua atrapada después de que la superficie ya se secó".
+ *   La esperanza (y no es blandita — es la parte mejor documentada):
+ *     [49] "La micorriza puede recuperarse si cambia el manejo... puede tomar
+ *          VARIAS TEMPORADAS, pero EL SUELO TIENE MEMORIA BIOLÓGICA y con buenas
+ *          prácticas sostenidas LA RED VUELVE A TEJERSE, sobre todo si cerca hay
+ *          un rastrojo o bosque que sirva de FUENTE DE ESPORAS."
+ *     [65] el "BANCO DE ESPORAS que ya existe en su propia región".
+ *     [80] la asimetría: "mucho más rápido de perder que de ganar".
+ *          → Y por eso el frente AVANZA rápido y RETROCEDE lento. La asimetría
+ *            no es un gusto de animación: es el dato.
+ *     [82] "la naturaleza sabe reconstruirse si uno deja de interrumpirla".
+ *
+ * ── LO QUE ESTA PIEZA *NO* AFIRMA (regla dura — no la rompás) ───────────────
+ * Si mañana alguien quiere "mejorar" esto agregando lo de abajo: NO. Está fuera
+ * a propósito, y cada exclusión tiene su razón.
+ *
+ *   1. NADA sobre glifosato y cáncer o salud humana. Esta pieza va del SUELO,
+ *      donde la evidencia es clara y el argumento es del propio interés del
+ *      campesino. La salud humana está en disputa real (IARC lo llama
+ *      probablemente cancerígeno; Bayer apartó ~US$10.900M por demandas; una
+ *      corte anuló la evaluación de la EPA) — y una disputa no se dibuja como
+ *      hecho. Además no hace falta: el argumento del suelo es más fuerte
+ *      PRECISAMENTE porque no necesita asustar a nadie.
+ *   2. NADA de quelación de micronutrientes, ni manganeso, ni AMPA, ni ruta del
+ *      shikimato. Se verificó por grep sobre los 20 .jsonl del corpus: CERO
+ *      coincidencias. No están. No se inventan. (El corpus sí da zinc y cobre
+ *      como aportes del hongo, y hierro/aluminio como lo que PEGA el fósforo —
+ *      eso es lo que se dibuja, y es mejor argumento que la quelación.)
+ *   3. NADA de "resistencia de malezas". CERO hits en el corpus. Lo que sí hay
+ *      es el REBROTE del rizoma del kikuyo [16], que es otra cosa y es honesto.
+ *      El círculo vicioso se dibuja con eso.
+ *   4. NINGUNA cifra de dosis como si fuera dato de la casa. Las cifras que
+ *      existen ("3-4 litros por hectárea", "en ocho días ve el potrero limpio",
+ *      "repita cada tres o cuatro semanas") viven TODAS en el campo `rejected`
+ *      del DPO: son la voz que el corpus RECHAZA. Si aparecen, aparecen marcadas
+ *      como la voz del bulto — nunca en boca de la pieza.
+ *   5. NADA de calaveras, rojo de alarma, insectos muertos, goteo tóxico verde
+ *      fosforescente. La paleta madre es explícita: el rojo es cochinilla y café
+ *      cereza, "nunca rojo catástrofe de UI".
+ *   6. NADA de absolutismo. El corpus mismo [17] concede: "en una invasión muy
+ *      agresiva... un uso puntual y muy focalizado puede ser la única salida
+ *      real, y no se lo voy a negar solo por principio. Pero eso es la
+ *      excepción... Lo que no hacemos acá es recetarlo como rutina de
+ *      calendario." Esa concesión VA en la pieza. Un arte que no concede nada no
+ *      lo creen, y con razón.
+ *
+ * ── EL MODELO ──────────────────────────────────────────────────────────────
+ * UN solo suelo, visto como vitrina de acuario (la cámara bajo tierra). No hay
+ * dos escenas ni una línea divisoria dura: hay un CAMPO DE SALUD continuo
+ * `saludEn(x, frente)` que va de 1 (red encendida) a 0 (red apagada) a lo largo
+ * del eje X. Cada elemento —hilo, nodo, pulso, lombriz, grumo, poro— lee su
+ * propia salud de su posición y se dibuja en consecuencia.
+ *
+ * Mover `frente` es toda la narrativa: hacia la izquierda, el suelo se apaga;
+ * hacia la derecha, la red vuelve a tejerse desde el banco de esporas. Un solo
+ * número cuenta la historia entera, en los dos sentidos, con la asimetría de
+ * velocidad que manda el corpus.
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+
+/* PRNG determinista: el mismo suelo en cada carga, en cada equipo, en cada
+   test. Nada de Math.random (un suelo que cambia de forma al recargar no es un
+   suelo, es un salvapantallas). */
+export function rng(seed) {
+  let s = (seed >>> 0) || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+/* smoothstep: la transición de la casa. El suelo no tiene bordes duros. */
+const suave = (t) => t * t * (3 - 2 * t);
+const mezcla = (a, b, t) => a + (b - a) * t;
+
+/*
+ * PALETA. Hermana de la de `micorrizas.geom.js` (mismo mundo, mismo idioma
+ * bioluminiscente) pero DECLARADA LOCAL a propósito: la rama `capas-suelo-b2`
+ * está reescribiendo ese módulo ahora mismo, y esta pieza no puede romperse
+ * cuando aquella aterrice. Los tonos de tierra/raíz salen de la paleta madre
+ * (`../paleta`): TIERRAS.cacao, TIERRAS.turba, CORTEZAS.raicilla.
+ *
+ * La regla de color de la pieza, y es toda la dirección de arte:
+ *   VIVO   = luz fría de luciérnaga (turquesa) + el ámbar del mineral que sube.
+ *   APAGADO= no es negro ni rojo: es PÁLIDO Y SECO. El color se va, no se
+ *            ensucia. Un suelo apagado no grita — se calla.
+ */
+export const PALETA = {
+  /* la tierra (de la paleta madre, oscurecida para la vitrina) */
+  tierra: new THREE.Color('#120c09'), // fondo hondo, cálido casi negro
+  tierraAlta: new THREE.Color('#241811'), // cerca de la superficie
+  tierraSeca: new THREE.Color('#6b5a48'), // el lado apagado: pálido, polvoso
+
+  /* la red encendida */
+  micelio: new THREE.Color('#37d6b0'), // hifa: turquesa de hongo
+  micelioTenue: new THREE.Color('#1c6f63'), // hifa lejana
+  puente: new THREE.Color('#7ef0c8'), // el hilo que cruza de mata a mata
+  nodo: new THREE.Color('#9df5da'), // unión del micelio
+  arbusculo: new THREE.Color('#ffd27a'), // punta de raíz: sitio de intercambio
+
+  /* la red apagada — el mismo hilo, sin luz. No muerto: APAGADO. */
+  micelioMuerto: new THREE.Color('#4a4237'), // hifa rota, color de ceniza tibia
+  trazaFantasma: new THREE.Color('#2e2a23'), // por donde la red PASABA (ver nota)
+
+  /* los pulsos: el intercambio hablando por color */
+  fosforo: new THREE.Color('#ffc766'), // mineral que SUBE a la mata
+  agua: new THREE.Color('#8fd4ff'), // agua que SUBE
+  carbono: new THREE.Color('#8ef06a'), // azúcar que BAJA al hongo
+  zinc: new THREE.Color('#cfe3f0'), // zinc/cobre [25]: el aporte menor
+
+  /* la trampa: el fósforo que SÍ está, pegado al hierro y la arcilla [21][30] */
+  fosforoPegado: new THREE.Color('#8a6b3c'), // ámbar apagado: presente, inalcanzable
+  particulaHierro: new THREE.Color('#7a4a38'), // la partícula que lo agarra
+
+  /* la vida que se ve con una pala [100] */
+  lombriz: new THREE.Color('#d9a08a'), // la lombriz rosada del suelo vivo
+  tunelVacio: new THREE.Color('#3a3129'), // su túnel, cuando ya no está
+  grumo: new THREE.Color('#5a3d28'), // = TIERRAS.turba: la miga de pan húmeda
+  polvo: new THREE.Color('#9a8b74'), // = TIERRAS.piedra: polvo suelto
+  gotaAgua: new THREE.Color('#6fb8d8'), // el agua en el poro
+
+  /* la esperanza, y no se apaga nunca */
+  espora: new THREE.Color('#d8b6f0'), // perla malva: el banco de esporas [65]
+
+  /* arriba */
+  raiz: new THREE.Color('#c8a878'), // raíz viva
+  raizFina: new THREE.Color('#f0e4cc'), // la raicilla blanca algodonosa [100]
+  tallo: new THREE.Color('#5f8a3a'), // = VERDES.trabajo
+  hojarasca: new THREE.Color('#8a6a44'), // = TIERRAS.camino: la cobertura
+};
+
+/*
+ * Volumen del suelo (metros-escena). Superficie en y=0; abajo negativo. Ancho y
+ * de poca profundidad en Z: una vitrina de acuario de tierra. El eje X es el eje
+ * del argumento — izquierda vivo, derecha apagado.
+ */
+export const SUELO = { ancho: 9.2, hondo: 5.0, z0: 0.85, zAtras: -1.4 };
+
+/* Los extremos del eje X, con nombre (para cámara, hotspots y tests). */
+export const LADOS = {
+  vivo: -SUELO.ancho / 2 + 1.2,
+  apagado: SUELO.ancho / 2 - 1.2,
+};
+
+/*
+ * PARÁMETROS por tier (tier-safe). El "wow" vive en 'alto'; 'medio' es frugal;
+ * 'bajo' es el mínimo digno — se lee la red y se lee el contraste, que es lo
+ * único que esta pieza NO puede perder. En gama baja el argumento sigue
+ * entrando: menos hilos, sin pulsos, pero el fósforo pegado y la lombriz que
+ * falta se ven igual. Esa es la prioridad de degradación.
+ */
+export const PARAMS_TIER = {
+  alto: {
+    matas: 5, nodosLibres: 26, pulsos: 140, tubK: 18, tubM: 6, radioHilo: 0.016,
+    vecinos: 2, radialRaiz: 7, lombrices: 5, grumos: 120, poros: 46,
+    fosforoPegado: 34, esporas: 16, motas: 90, hojarasca: 40,
+  },
+  medio: {
+    matas: 4, nodosLibres: 16, pulsos: 58, tubK: 12, tubM: 5, radioHilo: 0.015,
+    vecinos: 2, radialRaiz: 6, lombrices: 3, grumos: 60, poros: 24,
+    fosforoPegado: 20, esporas: 10, motas: 40, hojarasca: 20,
+  },
+  bajo: {
+    matas: 3, nodosLibres: 9, pulsos: 0, tubK: 7, tubM: 4, radioHilo: 0.015,
+    vecinos: 1, radialRaiz: 5, lombrices: 2, grumos: 26, poros: 0,
+    fosforoPegado: 12, esporas: 6, motas: 0, hojarasca: 0,
+  },
+};
+
+/** Parámetros para un tier (desconocido → 'medio'). */
+export const paramsDeTier = (tier) => PARAMS_TIER[tier] || PARAMS_TIER.medio;
+
+/* ── EL CAMPO DE SALUD ─────────────────────────────────────────────────────
+ * El corazón del modelo. `frente` es la X donde la red se está apagando;
+ * `borrosidad` es qué tan difusa es esa transición (nunca 0: en el suelo real no
+ * hay una raya pintada).
+ *
+ * salud = 1 → red encendida, intercambio corriendo.
+ * salud = 0 → red apagada, el mineral quieto, la mata comiendo del bulto.
+ */
+/**
+ * Salud de la red en la coordenada `x`.
+ * @param {number} x  coordenada del eje del argumento
+ * @param {number} frente  X del frente de avance
+ * @param {number} [borrosidad]  ancho de la transición (media anchura)
+ * @returns {number} 1 (vivo) → 0 (apagado)
+ */
+export function saludEn(x, frente, borrosidad = 1.25) {
+  const b = Math.max(borrosidad, 1e-3);
+  const t = THREE.MathUtils.clamp((x - frente + b) / (2 * b), 0, 1);
+  return 1 - suave(t);
+}
+
+/* ── LAS MATAS Y SUS RAÍCES ────────────────────────────────────────────────
+ * Las matas están a lo largo del eje: las mismas plantas, el mismo suelo. Ojo
+ * con la trampa narrativa: las matas del lado apagado NO se dibujan muertas. El
+ * campesino fumiga y la mata sigue ahí, verde, viva. Ese es el punto —
+ * exactamente por eso no ve el problema. Lo que cambia bajo tierra es la
+ * RAICILLA FINA ALGODONOSA [100] y la red que la alimentaba.
+ */
+/**
+ * Sistema de raíces de las matas, a lo ancho del suelo.
+ * @param {ReturnType<typeof paramsDeTier>} params
+ * @param {number} [seed]
+ * @returns {{ matas: Array, puntas: Array }}
+ */
+export function sistemaRaices(params, seed = 20260714) {
+  const r = rng(seed);
+  const matas = [];
+  const puntas = [];
+  const n = params.matas;
+  for (let i = 0; i < n; i++) {
+    /* repartidas a lo ancho, con un jitter que las saca de la grilla */
+    const x = mezcla(-SUELO.ancho / 2 + 1.0, SUELO.ancho / 2 - 1.0, n === 1 ? 0.5 : i / (n - 1))
+      + (r() - 0.5) * 0.45;
+    const z = mezcla(SUELO.zAtras + 0.4, SUELO.z0 - 0.3, r());
+    const mata = { id: i, base: new THREE.Vector3(x, 0, z), ramas: [], puntas: [] };
+
+    /* el eje principal baja y se abre */
+    const hondo = mezcla(SUELO.hondo * 0.42, SUELO.hondo * 0.72, r());
+    for (let k = 0; k < params.radialRaiz; k++) {
+      const ang = (k / params.radialRaiz) * Math.PI * 2 + r() * 0.5;
+      const largo = hondo * mezcla(0.45, 1.0, r());
+      const abre = mezcla(0.35, 1.05, r());
+      const pts = [];
+      const pasos = 5;
+      for (let s = 0; s <= pasos; s++) {
+        const t = s / pasos;
+        pts.push(new THREE.Vector3(
+          x + Math.cos(ang) * abre * t * mezcla(0.8, 1.2, r()),
+          -largo * suave(t),
+          z + Math.sin(ang) * abre * t * 0.55,
+        ));
+      }
+      const curva = new THREE.CatmullRomCurve3(pts);
+      const punta = pts[pts.length - 1].clone();
+      mata.ramas.push({ curva, grosor: mezcla(0.6, 1.0, r()) });
+      mata.puntas.push(punta);
+      /* las puntas son los ARBÚSCULOS: donde de verdad ocurre el intercambio */
+      puntas.push({ pos: punta, mata: i });
+    }
+    matas.push(mata);
+  }
+  return { matas, puntas };
+}
+
+/* ── LOS NODOS LIBRES DEL MICELIO ──────────────────────────────────────────
+ * Uniones del micelio lejos de las raíces: la red no es solo "pelito en la
+ * raíz", es un tejido que ocupa el suelo entero [78] ("es más bien la capa que
+ * conecta a todas las demás entre sí").
+ */
+/**
+ * Nodos de micelio repartidos por el volumen del suelo.
+ * @returns {Array<{pos: THREE.Vector3, mata: null, tipo: string}>}
+ */
+export function nodosLibres(params, seed = 991) {
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < params.nodosLibres; i++) {
+    out.push({
+      pos: new THREE.Vector3(
+        mezcla(-SUELO.ancho / 2 + 0.5, SUELO.ancho / 2 - 0.5, r()),
+        -mezcla(0.35, SUELO.hondo * 0.85, r()),
+        mezcla(SUELO.zAtras + 0.3, SUELO.z0 - 0.2, r()),
+      ),
+      mata: null,
+      tipo: 'nodo',
+    });
+  }
+  return out;
+}
+
+/* ── LA RED ────────────────────────────────────────────────────────────────
+ * Grafo: cada nodo se enlaza a sus vecinos más cercanos. Un hilo que une nodos
+ * de matas DISTINTAS es un PUENTE: ahí se lee el reparto (por qué el maíz, el
+ * fríjol y la ahuyama se ayudan por debajo, y por qué el árbol grande alimenta
+ * a la matica de su sombra [3]).
+ */
+/*
+ * LOS PUENTES NO SALEN SOLOS. HAY QUE TEJERLOS A MANO.
+ *
+ * Esto se me fue completo y lo cazó el chequeo headless: CERO puentes en los
+ * tres tiers. La red se veía preciosa y no cruzaba de una mata a otra ni una
+ * vez — o sea, faltaba justo lo único que esta escena existe para mostrar.
+ *
+ * El motivo, obvio en retrospectiva: el vecino más cercano de una punta de raíz
+ * del maíz es SIEMPRE otra punta del maíz. Están todas en la misma mata, a
+ * centímetros. Un grafo de "los k vecinos más cercanos" jamás va a saltar los
+ * dos metros que hay hasta el fríjol. El puente es exactamente la conexión que
+ * la cercanía NO produce — por eso hay que pedirla explícita.
+ *
+ * Y es la falla más cara posible: no truena, no se ve rara. Simplemente el
+ * "wood-wide web" no conectaba nada y la pieza entera argumentaba en falso, en
+ * silencio. Como las matas de `sucesion.geom.js` que se caían sin avisar.
+ *
+ * Se tejen entre matas VECINAS en el eje (no todas contra todas: eso sería una
+ * maraña y además falso — la red es un tejido local, no un cableado de central
+ * telefónica), uniendo el par de puntas más cercano de cada par de matas.
+ */
+function tejerPuentes(nodos, hilos, matas, params, vistos) {
+  const porMata = new Map();
+  nodos.forEach((n, i) => {
+    if (n.mata === null) return;
+    if (!porMata.has(n.mata)) porMata.set(n.mata, []);
+    porMata.get(n.mata).push(i);
+  });
+  /* de izquierda a derecha: cada mata se une con la siguiente */
+  const orden = [...matas].sort((a, b) => a.base.x - b.base.x).map((m) => m.id);
+  const cuantos = params.vecinos >= 2 ? 2 : 1;
+
+  for (let k = 0; k + 1 < orden.length; k++) {
+    const A = porMata.get(orden[k]) || [];
+    const B = porMata.get(orden[k + 1]) || [];
+    const pares = [];
+    for (const i of A) for (const j of B) pares.push({ i, j, d: nodos[i].pos.distanceTo(nodos[j].pos) });
+    pares.sort((x, y) => x.d - y.d);
+    let puestos = 0;
+    for (const p of pares) {
+      if (puestos >= cuantos) break;
+      const clave = p.i < p.j ? `${p.i}-${p.j}` : `${p.j}-${p.i}`;
+      if (vistos.has(clave)) continue;
+      vistos.add(clave);
+      hilos.push({ a: p.i, b: p.j, puente: true, largo: p.d });
+      puestos++;
+    }
+  }
+  return hilos;
+}
+
+/**
+ * Construye el grafo de la red: puntas de raíz + nodos libres, enlazados por
+ * cercanía, MÁS los puentes explícitos entre matas vecinas (ver arriba: sin eso
+ * la red no cruza nunca y la escena miente).
+ * @returns {{ nodos: Array, hilos: Array }}
+ */
+export function construirRed(puntas, libres, params, matas = []) {
+  const nodos = [
+    ...puntas.map((p) => ({ pos: p.pos, mata: p.mata, tipo: 'raiz' })),
+    ...libres,
+  ];
+  const hilos = [];
+  const vistos = new Set();
+  for (let i = 0; i < nodos.length; i++) {
+    /* los vecinos más cercanos de i */
+    const cerca = nodos
+      .map((n, j) => ({ j, d: nodos[i].pos.distanceTo(n.pos) }))
+      .filter((c) => c.j !== i)
+      .sort((a, b) => a.d - b.d)
+      .slice(0, params.vecinos);
+    for (const c of cerca) {
+      const clave = i < c.j ? `${i}-${c.j}` : `${c.j}-${i}`;
+      if (vistos.has(clave)) continue;
+      vistos.add(clave);
+      const a = nodos[i];
+      const b = nodos[c.j];
+      /* por cercanía esto casi nunca es puente; se marca igual por si acaso */
+      const puente = a.mata !== null && b.mata !== null && a.mata !== b.mata;
+      hilos.push({ a: i, b: c.j, puente, largo: c.d });
+    }
+  }
+  tejerPuentes(nodos, hilos, matas, params, vistos);
+  return { nodos, hilos };
+}
+
+/**
+ * La curva de un hilo: nunca recto. Una hifa busca, no traza.
+ * El pandeo sale del PRNG por índice → determinista y estable entre frames.
+ */
+export function curvaHilo(pa, pb, idx) {
+  const r = rng(idx * 7919 + 13);
+  const med = pa.clone().add(pb).multiplyScalar(0.5);
+  const d = pb.clone().sub(pa).length();
+  med.x += (r() - 0.5) * d * 0.35;
+  med.y += (r() - 0.5) * d * 0.3;
+  med.z += (r() - 0.5) * d * 0.3;
+  return new THREE.CatmullRomCurve3([pa.clone(), med, pb.clone()]);
+}
+
+/* ── LA GEOMETRÍA DE LA RED: UN SOLO DRAW-CALL ─────────────────────────────
+ * Toda la red (viva, rota y fantasma) en UNA malla fundida con color por
+ * vértice. El estado de cada hilo NO es un material distinto: es color.
+ *
+ * EL GESTO CENTRAL DE LA PIEZA — cómo se rompe un hilo:
+ * Un hilo con salud baja no se borra de golpe (eso sería un interruptor, y el
+ * suelo no tiene interruptor). Se FRAGMENTA: se le abren HUECOS, y lo que queda
+ * pierde la luz. El corpus [36] dice "corta físicamente esos hilos finísimos" —
+ * y eso es literal, así que el corte se dibuja literal.
+ *
+ * La TRAZA FANTASMA: donde el hilo estaba, queda un rastro apenas visible. Es un
+ * recurso de ARTE, no una afirmación biológica — no digo que quede un fideo
+ * muerto en el suelo. Dice dos cosas a la vez: aquí HABÍA red (el campesino
+ * perdió algo que no sabía que tenía), y aquí PUEDE volver (la traza es el molde
+ * por donde se re-teje [49]). Sin la traza, el lado apagado sería un vacío y no
+ * se leería la pérdida — se leería "acá nunca hubo nada", que es justo la
+ * mentira que la pieza combate.
+ */
+/*
+ * POR QUÉ ESTA GEOMETRÍA NO SABE DÓNDE ESTÁ EL FRENTE
+ *
+ * El frente se MUEVE (esa es la narrativa), y reconstruir ~100 tubos por frame
+ * en un teléfono de gama baja no es una opción: es la diferencia entre una pieza
+ * que se ve y una que el campesino cierra a los tres segundos.
+ *
+ * Entonces la malla se construye UNA VEZ, a radio pleno y sin cortes, y lleva
+ * horneado lo que el shader necesita para decidir por sí mismo, por vértice:
+ *   aCentro — el punto de la línea central (para colapsar el anillo y hacer el
+ *             hueco: si el anillo entero se va al centro, el triángulo queda de
+ *             área cero y no se dibuja. Ese es el truco del corte: sale gratis y
+ *             no necesita `discard`, que en gama baja se paga caro).
+ *   aT      — el parámetro a lo largo del hilo (para la onda de los huecos).
+ *   aFase   — la fase del hilo (para que no se piquen todos igual).
+ *   aPuente — 1 si el hilo cruza de una mata a otra.
+ *
+ * Con eso, mover el frente cuesta UN uniform (`uFrente`). Cero rebuilds, cero
+ * basura por frame, un solo draw-call para toda la red — viva, rota y fantasma.
+ *
+ * El módulo sigue puro y headless: emite números, no GLSL. El shader vive en el
+ * .jsx, que es donde va el look. `saludEn()` de acá y el `smoothstep` de allá
+ * calculan LO MISMO a propósito (ver la nota en el shader): así el test en Node
+ * y el pixel en pantalla no se pueden contradecir.
+ */
+/**
+ * Malla fundida de la red completa, con los atributos que el shader necesita
+ * para apagarla y prenderla solo.
+ * @param {Array} nodos
+ * @param {Array} hilos
+ * @param {ReturnType<typeof paramsDeTier>} params
+ * @returns {{ geo: THREE.BufferGeometry, curvas: Array }}
+ */
+export function geometriaRed(nodos, hilos, params) {
+  const pos = [];
+  const centro = [];
+  const ts = [];
+  const fases = [];
+  const puentes = [];
+  const idx = [];
+  const curvas = [];
+  const K = params.tubK;
+  const M = params.tubM;
+  let base = 0;
+
+  for (let h = 0; h < hilos.length; h++) {
+    const hilo = hilos[h];
+    const curva = curvaHilo(nodos[hilo.a].pos, nodos[hilo.b].pos, h);
+    curvas.push(curva);
+
+    /* la fase del picado, determinista por hilo: sin esto todos los hilos se
+       romperían con el mismo ritmo y se vería una reja, no un tejido */
+    const faseHueco = rng(h * 104729 + 7)();
+    const rVivo = params.radioHilo * (hilo.puente ? 1.25 : 1);
+    const pts = curva.getPoints(K);
+
+    for (let i = 0; i <= K; i++) {
+      const t = i / K;
+      const tang = curva.getTangent(t);
+      const up = Math.abs(tang.y) > 0.9 ? new THREE.Vector3(1, 0, 0) : new THREE.Vector3(0, 1, 0);
+      const n1 = new THREE.Vector3().crossVectors(tang, up).normalize();
+      const n2 = new THREE.Vector3().crossVectors(tang, n1).normalize();
+      for (let j = 0; j < M; j++) {
+        const a = (j / M) * Math.PI * 2;
+        const off = n1.clone().multiplyScalar(Math.cos(a) * rVivo)
+          .add(n2.clone().multiplyScalar(Math.sin(a) * rVivo));
+        pos.push(pts[i].x + off.x, pts[i].y + off.y, pts[i].z + off.z);
+        centro.push(pts[i].x, pts[i].y, pts[i].z);
+        ts.push(t);
+        fases.push(faseHueco);
+        puentes.push(hilo.puente ? 1 : 0);
+      }
+    }
+    for (let i = 0; i < K; i++) {
+      for (let j = 0; j < M; j++) {
+        const a = base + i * M + j;
+        const b = base + i * M + ((j + 1) % M);
+        const d = base + (i + 1) * M + j;
+        const e = base + (i + 1) * M + ((j + 1) % M);
+        idx.push(a, d, b, b, d, e);
+      }
+    }
+    base += (K + 1) * M;
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
+  geo.setAttribute('aCentro', new THREE.Float32BufferAttribute(centro, 3));
+  geo.setAttribute('aT', new THREE.Float32BufferAttribute(ts, 1));
+  geo.setAttribute('aFase', new THREE.Float32BufferAttribute(fases, 1));
+  geo.setAttribute('aPuente', new THREE.Float32BufferAttribute(puentes, 1));
+  geo.setIndex(idx);
+  geo.computeVertexNormals();
+  return { geo, curvas };
+}
+
+/* ── LOS PULSOS: EL INTERCAMBIO HABLANDO ───────────────────────────────────
+ * Por los hilos vivos corren los nutrientes. El color dice el sentido, y el
+ * sentido ES el argumento [19]:
+ *   carbono (verde)  BAJA  — el azúcar que la mata paga con luz de sol.
+ *   fósforo (ámbar)  SUBE  — el mineral que la raíz sola no alcanzaba.
+ *   agua    (azul)   SUBE  — de los poros chiquitos que ya se secaron arriba [22].
+ *   zinc    (pálido) SUBE  — el aporte menor pero real [25].
+ *
+ * EL GESTO: en un hilo apagado el pulso NO llega. Y no desaparece de golpe —
+ * FRENA. Se va poniendo lento a medida que entra en la zona apagada, se achica,
+ * y se queda quieto contra el corte. El ojo lee un atasco, no un apagón.
+ *
+ * Eso importa: el intercambio no se "reduce" un 30%, se INTERRUMPE. Y del lado
+ * de la mata el azúcar sigue saliendo (la mata no sabe que el hilo está roto:
+ * sigue pagando). Un pulso verde bajando hacia un hilo cortado, que se frena y
+ * se apaga sin que nada vuelva, es la imagen más honesta que tiene esta pieza —
+ * la mata pagando por un servicio que ya no existe.
+ *
+ * Por eso el pulso se integra por frame contra el frente VIVO, en vez de
+ * repartirse por una salud congelada al construir.
+ *
+ * Estos datos son INMUTABLES: `t0` es solo el arranque. El avance lo lleva la
+ * escena en su propio estado — así estos pulsos se pueden reusar, testear o
+ * pintar dos veces sin arrastrar el `t` de una animación ajena.
+ */
+/**
+ * Pulsos repartidos por los hilos (datos inmutables; el avance lo lleva quien
+ * los anima, arrancando en `t0`).
+ * @returns {Array<{hilo:number, t0:number, vel:number, tipo:string, sube:boolean}>}
+ */
+export function pulsosDeRed(hilos, params, seed = 4242) {
+  if (!params.pulsos || !hilos.length) return [];
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < params.pulsos; i++) {
+    const h = Math.min(hilos.length - 1, Math.floor(r() * hilos.length));
+    const dado = r();
+    /* más mineral subiendo que azúcar bajando: así es el trato, le sale
+       ganancioso a la mata [20] */
+    const sube = dado > 0.42;
+    const tipo = sube
+      ? (dado > 0.82 ? 'agua' : dado > 0.74 ? 'zinc' : 'fosforo')
+      : 'carbono';
+    const t0 = r();
+    out.push({ hilo: h, t0, vel: mezcla(0.16, 0.42, r()), tipo, sube });
+  }
+  return out;
+}
+
+/** El color de un pulso por tipo. */
+export const colorPulso = (tipo) => PALETA[tipo] || PALETA.fosforo;
+
+/* ── LA TRAMPA: EL FÓSFORO QUE SÍ ESTÁ, PEGADO ─────────────────────────────
+ * El argumento más fuerte de toda la pieza, y el que más cuesta dibujar bien.
+ *
+ * En suelo de ladera andina el fósforo se pega al hierro y al aluminio [30]. La
+ * micorriza es la que lo SUELTA [21]. Apagá la red y el fósforo no se va a
+ * ninguna parte: SIGUE AHÍ, pegado a su partícula, a centímetros de la raíz, y
+ * la mata no lo alcanza. Entonces toca comprarlo en bulto. Y como se sigue
+ * pegando, toca comprar más. "Ahí está la trampa" [32].
+ *
+ * Cómo se dibuja: motas de ámbar APAGADO pegadas a partículas de hierro. En el
+ * lado vivo, esas motas se sueltan y se van por la red (se vuelven pulso). En el
+ * lado apagado están QUIETAS. La quietud es el mensaje: no es que falte comida,
+ * es que se cortó el que la traía. Un campesino que ve esto entiende en dos
+ * segundos por qué el bulto no lo saca del hueco — lo mete más adentro.
+ */
+/**
+ * Motas de fósforo pegado a partículas de hierro/arcilla.
+ * @returns {Array<{pos:THREE.Vector3, esc:number, semilla:number}>}
+ */
+export function fosforoPegado(params, seed = 3131) {
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < params.fosforoPegado; i++) {
+    out.push({
+      pos: new THREE.Vector3(
+        mezcla(-SUELO.ancho / 2 + 0.4, SUELO.ancho / 2 - 0.4, r()),
+        -mezcla(0.3, SUELO.hondo * 0.8, r()),
+        mezcla(SUELO.zAtras + 0.25, SUELO.z0 - 0.15, r()),
+      ),
+      esc: mezcla(0.7, 1.35, r()),
+      semilla: r(),
+    });
+  }
+  return out;
+}
+
+/* ── LAS LOMBRICES Y SUS TÚNELES ───────────────────────────────────────────
+ * La señal que el campesino puede comprobar HOY con una pala, sin creerle a
+ * nadie: [102] "si al cavar no aparece ninguna en un suelo que debería tenerlas,
+ * es una alerta". [0] el glifosato "se lleva la vida del suelo... hongos,
+ * lombriz, todo".
+ *
+ * El gesto: el TÚNEL SE QUEDA aunque la lombriz no. Un túnel vacío es más
+ * elocuente que una lombriz muerta — no hay cadáver, hay ausencia. Y el túnel
+ * vacío también dice que la casa sigue lista para cuando vuelva.
+ */
+/**
+ * Lombrices y sus túneles, a lo ancho del suelo.
+ * @returns {Array<{curva:THREE.CatmullRomCurve3, x:number, t:number, vel:number}>}
+ */
+export function lombricesYTuneles(params, seed = 777) {
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < params.lombrices; i++) {
+    const x = mezcla(-SUELO.ancho / 2 + 0.8, SUELO.ancho / 2 - 0.8, r());
+    const y = -mezcla(0.5, SUELO.hondo * 0.65, r());
+    const z = mezcla(SUELO.zAtras + 0.4, SUELO.z0 - 0.25, r());
+    /* el túnel serpentea: una lombriz no cava en línea recta */
+    const pts = [];
+    const largo = mezcla(0.9, 1.9, r());
+    for (let s = 0; s <= 4; s++) {
+      const t = s / 4;
+      pts.push(new THREE.Vector3(
+        x + mezcla(-largo, largo, t),
+        y + Math.sin(t * Math.PI * mezcla(1.2, 2.4, r())) * 0.28,
+        z + (r() - 0.5) * 0.25,
+      ));
+    }
+    out.push({
+      curva: new THREE.CatmullRomCurve3(pts),
+      x,
+      t: r(),
+      vel: mezcla(0.05, 0.13, r()),
+    });
+  }
+  return out;
+}
+
+/* ── LOS GRUMOS Y EL POLVO ─────────────────────────────────────────────────
+ * [105] el suelo vivo se rompe en "pequeñas migas de pan húmedas que no se
+ * deshacen fácil"; el apagado es "polvo suelto o un bloque duro" [100].
+ *
+ * Es la MISMA partícula: en el lado vivo está apretada con sus hermanas en un
+ * grumo (algo las pega: la red y la materia orgánica [6] "grumitos que no se
+ * caen fácil, señal de que algo está manteniendo esas partículas unidas"); en el
+ * lado apagado están sueltas y dispersas. No cambia la tierra — cambia si algo
+ * la está agarrando. La escena interpola posición y color por salud.
+ */
+/**
+ * Partículas de suelo con su posición agrupada (viva) y dispersa (apagada).
+ * @returns {Array<{juntos:THREE.Vector3, sueltos:THREE.Vector3, esc:number}>}
+ */
+export function agregados(params, seed = 5150) {
+  const r = rng(seed);
+  const out = [];
+  const porGrumo = 5;
+  const n = Math.ceil(params.grumos / porGrumo);
+  for (let g = 0; g < n; g++) {
+    /* el centro del grumo */
+    const cx = mezcla(-SUELO.ancho / 2 + 0.4, SUELO.ancho / 2 - 0.4, r());
+    const cy = -mezcla(0.25, SUELO.hondo * 0.75, r());
+    const cz = mezcla(SUELO.zAtras + 0.3, SUELO.z0 - 0.2, r());
+    for (let i = 0; i < porGrumo; i++) {
+      /* juntos: apretados alrededor del centro (la miga) */
+      const juntos = new THREE.Vector3(
+        cx + (r() - 0.5) * 0.16,
+        cy + (r() - 0.5) * 0.16,
+        cz + (r() - 0.5) * 0.14,
+      );
+      /* sueltos: la misma partícula, dispersa y caída (el polvo) */
+      const sueltos = new THREE.Vector3(
+        cx + (r() - 0.5) * 0.72,
+        cy - r() * 0.34,
+        cz + (r() - 0.5) * 0.5,
+      );
+      out.push({ juntos, sueltos, esc: mezcla(0.6, 1.2, r()) });
+    }
+  }
+  return out;
+}
+
+/* ── LOS POROS Y EL AGUA ───────────────────────────────────────────────────
+ * [22] los hilos del hongo llegan "a poros muy pequeños del suelo donde queda
+ * agua atrapada después de que la superficie ya se secó". Suelo vivo = poros con
+ * su gota. Suelo apretado y sin red = poros cerrados, sin reserva. [44] la
+ * compactación "saca el aire de los poros".
+ */
+/**
+ * Poros del suelo con su gota de agua.
+ * @returns {Array<{pos:THREE.Vector3, esc:number, semilla:number}>}
+ */
+export function porosAgua(params, seed = 6060) {
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < params.poros; i++) {
+    out.push({
+      pos: new THREE.Vector3(
+        mezcla(-SUELO.ancho / 2 + 0.4, SUELO.ancho / 2 - 0.4, r()),
+        -mezcla(0.3, SUELO.hondo * 0.7, r()),
+        mezcla(SUELO.zAtras + 0.3, SUELO.z0 - 0.2, r()),
+      ),
+      esc: mezcla(0.5, 1.1, r()),
+      semilla: r(),
+    });
+  }
+  return out;
+}
+
+/* ── EL BANCO DE ESPORAS: LA ESPERANZA, Y ES DATO ──────────────────────────
+ * [65] "el banco de esporas que ya existe en su propia región". [49] "el suelo
+ * tiene memoria biológica y con buenas prácticas sostenidas la red vuelve a
+ * tejerse, sobre todo si cerca hay un rastrojo o bosque que sirva de fuente de
+ * esporas."
+ *
+ * LA REGLA DURA DE ESTA PIEZA: las esporas NO se apagan nunca. Ni en el lado más
+ * castigado. Son las únicas luces que cruzan el frente enteras, y esa terquedad
+ * es deliberada: la pieza no termina en regaño. Si el campesino para, la red
+ * vuelve a tejerse desde estas perlas.
+ *
+ * Honestidad: el corpus dice que el banco existe y que sirve de fuente. NO dice
+ * que las esporas estén "dormidas", ni cuánto duran, ni cuántas hay. La pieza no
+ * lo dice tampoco — solo las deja encendidas, que es lo que el dato aguanta.
+ */
+/**
+ * El banco de esporas: las perlas que no se apagan.
+ * @returns {Array<{pos:THREE.Vector3, esc:number, semilla:number}>}
+ */
+export function bancoEsporas(params, seed = 8080) {
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < params.esporas; i++) {
+    /* sesgadas hacia el lado apagado: ahí es donde tienen que decir algo */
+    const t = Math.pow(r(), 0.65);
+    out.push({
+      pos: new THREE.Vector3(
+        mezcla(-SUELO.ancho / 2 + 0.6, SUELO.ancho / 2 - 0.6, t),
+        -mezcla(0.4, SUELO.hondo * 0.8, r()),
+        mezcla(SUELO.zAtras + 0.3, SUELO.z0 - 0.2, r()),
+      ),
+      esc: mezcla(0.8, 1.4, r()),
+      semilla: r(),
+    });
+  }
+  return out;
+}
+
+/* ── LA SUPERFICIE: COBERTURA vs SUELO PELADO ──────────────────────────────
+ * [40] "El hongo necesita una raíz viva para sobrevivir... la red micorrízica se
+ * muere de hambre por falta de raíces que alimentar." [50] "Lo primero y más
+ * barato: dejar de dejar el suelo pelado."
+ *
+ * Arriba del corte: de un lado hojarasca y arvenses (la cobertura muerta que
+ * ahoga la maleza y además abona [2]); del otro, tierra pelada al sol. La
+ * superficie ANUNCIA lo que pasa abajo — y es lo único que el campesino ve sin
+ * cavar.
+ */
+/**
+ * Hojarasca / cobertura sobre la superficie.
+ * @returns {Array<{pos:THREE.Vector3, rot:number, esc:number}>}
+ */
+export function hojarascaSuperficie(params, seed = 9090) {
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < params.hojarasca; i++) {
+    out.push({
+      pos: new THREE.Vector3(
+        mezcla(-SUELO.ancho / 2 + 0.3, SUELO.ancho / 2 - 0.3, r()),
+        0.012 + r() * 0.03,
+        mezcla(SUELO.zAtras + 0.3, SUELO.z0 - 0.1, r()),
+      ),
+      rot: r() * Math.PI * 2,
+      esc: mezcla(0.7, 1.3, r()),
+    });
+  }
+  return out;
+}
+
+/* ── EL TUBO DE UNA RAÍZ: LO QUE *NO* CAMBIA ───────────────────────────────
+ * Acá hay una decisión de arte que es la más importante de toda la pieza, y es
+ * una decisión sobre lo que NO se dibuja:
+ *
+ * LA RAÍZ NO SE MUERE. La raíz gruesa se ve IGUAL de los dos lados del frente:
+ * no cambia de color, no se marchita, no se pone gris. Es estática a propósito y
+ * no depende del frente.
+ *
+ * ¿Por qué? Porque así es en la finca, y porque ESE ES EL PROBLEMA. El campesino
+ * fumiga la maleza, su mata sigue verde, la cosecha sale, y no ve nada malo. Si
+ * esta pieza dibujara la mata muriéndose, el campesino la miraría y diría "eso
+ * es mentira, mis matas están bien" — y tendría razón, y perderíamos todo.
+ *
+ * La honestidad ACÁ es lo que nos da permiso para el resto: la mata está bien.
+ * Lo que se apagó fue con quién. El daño no está en lo que se ve; está en la red
+ * que la acompañaba y en el mineral que ya nadie le suelta. Por eso el daño se
+ * cuenta con la red, con el fósforo quieto y con la lombriz que falta — nunca
+ * con un cadáver.
+ */
+/**
+ * Malla de una rama de raíz. NO depende del frente: la raíz vive igual en los
+ * dos lados (ver la nota de arriba — es deliberado).
+ * @returns {THREE.BufferGeometry}
+ */
+export function tuboRaizGeom(curva, grosor, params) {
+  const K = Math.max(6, Math.round(params.tubK * 0.6));
+  const M = params.tubM;
+  const pos = [];
+  const col = [];
+  const idx = [];
+  const pts = curva.getPoints(K);
+  const c = new THREE.Color();
+  for (let i = 0; i <= K; i++) {
+    const t = i / K;
+    /* adelgaza hacia la punta; el color solo aclara con el calibre */
+    const rad = 0.03 * grosor * mezcla(1, 0.35, t);
+    c.copy(PALETA.raiz).lerp(PALETA.raizFina, suave(t) * 0.35);
+    const tang = curva.getTangent(t);
+    const up = Math.abs(tang.y) > 0.9 ? new THREE.Vector3(1, 0, 0) : new THREE.Vector3(0, 1, 0);
+    const n1 = new THREE.Vector3().crossVectors(tang, up).normalize();
+    const n2 = new THREE.Vector3().crossVectors(tang, n1).normalize();
+    for (let j = 0; j < M; j++) {
+      const a = (j / M) * Math.PI * 2;
+      const off = n1.clone().multiplyScalar(Math.cos(a) * rad)
+        .add(n2.clone().multiplyScalar(Math.sin(a) * rad));
+      pos.push(pts[i].x + off.x, pts[i].y + off.y, pts[i].z + off.z);
+      col.push(c.r, c.g, c.b);
+    }
+  }
+  for (let i = 0; i < K; i++) {
+    for (let j = 0; j < M; j++) {
+      const a = i * M + j;
+      const b = i * M + ((j + 1) % M);
+      const d = (i + 1) * M + j;
+      const e = (i + 1) * M + ((j + 1) % M);
+      idx.push(a, d, b, b, d, e);
+    }
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
+  geo.setAttribute('color', new THREE.Float32BufferAttribute(col, 3));
+  geo.setIndex(idx);
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/*
+ * Fusiona las ramas de todas las matas en UNA geometría (un draw-call).
+ *
+ * LA TRAMPA, que ya nos costó caro y está documentada en `sucesion.geom.js`:
+ * `mergeGeometries` exige que TODAS las partes coincidan en el indexado ("index
+ * attribute exists among all geometries, or in none of them"). Si no coinciden,
+ * NO tira excepción: devuelve `null` y escupe un console.error. Y como el
+ * componente r3f hace `if (!geo) return null`, la malla simplemente NO SE DIBUJA
+ * y nadie se entera — que es peor que un crash.
+ *
+ * Acá todas las partes salen de `tuboRaizGeom` (todas indexadas, mismos
+ * atributos), así que hoy no debería fallar. Igual se desindexa y se TRUENA si
+ * falla: el día que alguien meta una parte de otra fábrica, quiero un error, no
+ * unas raíces que se esfumaron en silencio.
+ */
+/**
+ * Malla única con todas las raíces de todas las matas.
+ * @returns {THREE.BufferGeometry}
+ */
+export function geometriaRaices(matas, params) {
+  const partes = [];
+  for (const mata of matas) {
+    for (const rama of mata.ramas) partes.push(tuboRaizGeom(rama.curva, rama.grosor, params));
+  }
+  const buenas = partes.filter(Boolean).map((g) => (g.index ? g.toNonIndexed() : g));
+  if (!buenas.length) throw new Error('sueloComparado.geom: no hay raíces que fusionar');
+  const geo = mergeGeometries(buenas, false);
+  if (!geo) throw new Error('sueloComparado.geom: la fusión de raíces falló (partes incompatibles)');
+  for (const g of buenas) g.dispose();
+  return geo;
+}
+
+/* ── LA RAICILLA ALGODONOSA: LO QUE SÍ SE PIERDE ───────────────────────────
+ * [100] "fíjese si hay raíces finas blancas con textura algodonosa alrededor".
+ * [103] "hilos finísimos, blanquecinos, casi como telaraña, pegados a la raíz".
+ *
+ * El complemento exacto de la nota de arriba: si la raíz gruesa es lo que NO
+ * cambia, esto es lo que SÍ. Va aparte de la raíz justamente para poder decir
+ * las dos cosas a la vez sin contradecirse — la mata está entera, y sin embargo
+ * perdió algo.
+ *
+ * Y es la señal más útil de toda la pieza porque es VERIFICABLE. El campesino no
+ * tiene que creernos: cava un huequito, mira la raíz y ve si está el pelito
+ * blanco o no está. Una pieza de arte que se puede comprobar con una pala vale
+ * más que cien que hay que creer.
+ */
+/**
+ * Mechones de raicilla fina sobre las ramas de raíz. Su escala la maneja la
+ * escena según la salud del punto donde está cada uno.
+ * @returns {Array<{pos:THREE.Vector3, esc:number, semilla:number}>}
+ */
+export function raicillasFinas(matas, params, seed = 1717) {
+  const r = rng(seed);
+  const out = [];
+  const porRama = params.tubM > 4 ? 3 : 2;
+  for (const mata of matas) {
+    for (const rama of mata.ramas) {
+      for (let i = 0; i < porRama; i++) {
+        /* pegadas al tercio final de la rama: ahí es donde se agarra el hongo */
+        const t = mezcla(0.42, 0.97, r());
+        const p = rama.curva.getPoint(t);
+        out.push({
+          pos: new THREE.Vector3(
+            p.x + (r() - 0.5) * 0.1,
+            p.y + (r() - 0.5) * 0.1,
+            p.z + (r() - 0.5) * 0.08,
+          ),
+          esc: mezcla(0.6, 1.25, r()),
+          semilla: r(),
+        });
+      }
+    }
+  }
+  return out;
+}
+
+/* ── EL FRENTE EN EL TIEMPO: LA ASIMETRÍA ES EL DATO ───────────────────────
+ * [80] "mucho más rápido de perder que de ganar: un par de quemas o aradas
+ * fuertes pueden borrar en poco tiempo lo que costó años construir."
+ * [36] los hilos cortados "tardan MESES en reconstruirse".
+ * [49] la recuperación "puede tomar VARIAS TEMPORADAS".
+ * [91, teacher-agua-suelo] "subir la materia orgánica un solo punto porcentual
+ *      puede tardar hasta 20 AÑOS con buen manejo".
+ *
+ * Por eso APAGAR es ~6x más rápido que RECUPERAR. Si las dos velocidades fueran
+ * iguales, la pieza estaría mintiendo con la animación aunque el texto dijera la
+ * verdad — y el ojo le cree al movimiento antes que a la letra. El que mira debe
+ * SENTIR en el cuerpo que deshacer es un rato y rehacer es una vida.
+ */
+export const VELOCIDAD = {
+  apagar: 1.0, // unidades de X por segundo: una pasada y ya
+  recuperar: 0.17, // ~6x más lento: varias temporadas
+};
+
+/**
+ * Avanza el frente hacia su destino con la velocidad asimétrica que manda el
+ * corpus. PURA: devuelve la X nueva.
+ * @param {number} frente  X actual
+ * @param {number} destino  X objetivo
+ * @param {number} dt  delta en segundos
+ * @returns {number}
+ */
+export function avanzarFrente(frente, destino, dt) {
+  const apagando = destino < frente; // el frente baja de X = el suelo se apaga
+  const v = apagando ? VELOCIDAD.apagar : VELOCIDAD.recuperar;
+  const paso = v * dt;
+  const d = destino - frente;
+  if (Math.abs(d) <= paso) return destino;
+  return frente + Math.sign(d) * paso;
+}

--- a/src/visual/mundo3d/suelo-comparado/sueloComparadoTextos.js
+++ b/src/visual/mundo3d/suelo-comparado/sueloComparadoTextos.js
@@ -1,0 +1,300 @@
+/*
+ * sueloComparadoTextos — LA VOZ de la pieza. Todo el texto en un solo lugar,
+ * cada afirmación con su fuente, y las exclusiones explícitas.
+ *
+ * ── EL REGISTRO (copiado del corpus, no inventado) ──────────────────────────
+ * El corpus de Chagra tiene una voz muy precisa y hay que respetarla, porque es
+ * la razón por la que le creen. Es sistemáticamente ANTI-PROMESA:
+ *   - valida al campesino antes de contradecirlo: "Entiendo el afán, eso
+ *     enmontado da rabia";
+ *   - reconoce el costo de lo que propone: "Es más trabajo las primeras veces";
+ *   - y se FRENA antes de exagerar: "no es magia", "No hay una cifra exacta que
+ *     le pueda dar con certeza", "No conviene atribuirle todo a la micorriza",
+ *     "Yo no le prometería que sus matas 'se avisan' como personas".
+ *
+ * Ese freno no es timidez: es el activo. La voz del veneno (el campo `rejected`
+ * del DPO) es toda superlativos y calendarios fijos — "santo remedio",
+ * "impecable", "en ocho días", "sin ninguna maleza visible". Si esta pieza habla
+ * con superlativos, suena igualita al bulto y pierde. Gana por contraste de
+ * registro, no por gritar más duro.
+ *
+ * Tono: USTED, colombiano, campesino. Nada de argentinismos, nada de
+ * "toca cambiar el paradigma", nada de ONG. Frases cortas. Verbos de campo.
+ *
+ * ── HONESTIDAD: QUÉ NO DICE ESTA PIEZA ─────────────────────────────────────
+ * (el detalle largo y las fuentes están en `sueloComparado.geom.js`)
+ *   1. NADA de cáncer ni salud humana. La pieza va del SUELO. La salud humana
+ *      está en disputa real y una disputa no se dibuja como hecho.
+ *   2. NADA de quelación, manganeso, AMPA ni shikimato: CERO hits en el corpus
+ *      (verificado por grep sobre los 20 .jsonl). No están → no se dicen.
+ *   3. NADA de "resistencia de malezas": CERO hits. El círculo vicioso se cuenta
+ *      con el REBROTE DEL RIZOMA del kikuyo [16], que sí está y es honesto.
+ *   4. Las cifras de dosis SOLO aparecen marcadas como la voz del bulto, porque
+ *      viven todas en el `rejected` del DPO.
+ *   5. La concesión de [17] VA. Un arte que no concede nada no lo creen.
+ */
+
+/* ── El encabezado ───────────────────────────────────────────────────────── */
+export const TITULO = {
+  titulo: 'El mismo suelo, dos veces',
+  bajada: 'Lo de arriba se ve igual. Lo de abajo no.',
+};
+
+/* ── Los dos lados. Ojo con el nombre: el lado castigado NO se llama "muerto".
+      Se llama APAGADO, y eso es a propósito — un suelo apagado se puede volver a
+      prender, y el corpus dice que sí [49]. Si lo llamamos muerto, cerramos la
+      puerta que la pieza entera quiere dejar abierta. ─────────────────────── */
+export const LADOS = {
+  vivo: {
+    id: 'vivo',
+    nombre: 'Suelo con red',
+    pie: 'La mata no come sola. Tiene con quién.',
+  },
+  apagado: {
+    id: 'apagado',
+    nombre: 'Suelo fumigado seguido',
+    pie: 'La mata está viva. Lo que se apagó fue con quién.',
+  },
+};
+
+/*
+ * ── LOS HOTSPOTS ────────────────────────────────────────────────────────────
+ * Cada uno: `punto` (dónde toca), `titulo` (lo que se lee de una), `texto` (la
+ * explicación en voz de campo) y `fuente` (de dónde salió — NO se muestra en
+ * pantalla, es para el que mantiene esto y para poder auditar la pieza).
+ *
+ * `lado` decide en qué X vive: 'vivo', 'apagado' o 'ambos' (los que cruzan).
+ */
+export const HOTSPOTS = [
+  {
+    id: 'intercambio',
+    lado: 'vivo',
+    titulo: 'El trato',
+    texto:
+      'La mata le paga al hongo con azúcar que ella fabrica con la luz del sol. '
+      + 'El hongo no puede hacer fotosíntesis: sin esa azúcar se muere de hambre. '
+      + 'A cambio le busca fósforo y agua donde la raíz sola nunca llegaría. '
+      + 'No es un regalo que la debilite: es una inversión, y le sale ganancioso.',
+    fuente: 'teacher-micorrizas [19], [20]',
+  },
+  {
+    id: 'red',
+    lado: 'vivo',
+    titulo: 'La red',
+    texto:
+      'Estos hilos no se quedan en una mata: pasan de una a otra. Por eso el maíz, '
+      + 'el fríjol y la ahuyama se ayudan por debajo, y por eso un palo grande le '
+      + 'manda de lo suyo a las maticas de su sombra. Es la parte de la finca que '
+      + 'trabaja calladita, sin pedir crédito — y por eso la más fácil de dañar sin '
+      + 'darse cuenta.',
+    fuente: 'teacher-micorrizas [3], [9]',
+  },
+  {
+    id: 'raicilla',
+    lado: 'vivo',
+    titulo: 'El pelito blanco',
+    texto:
+      'Esas raíces finas blancas, como algodón, alrededor de la raíz: eso es la red '
+      + 'agarrada. Cave un huequito y búsquelas. Es gratis y no tiene que creerle a '
+      + 'nadie.',
+    fuente: 'teacher-micorrizas [100], [103]',
+  },
+  {
+    id: 'grumo',
+    lado: 'ambos',
+    titulo: 'Grumo o polvo',
+    texto:
+      'Agarre un puñado. Si se rompe en grumitos como migas de pan húmedas que no se '
+      + 'deshacen fácil, hay algo vivo manteniendo esa tierra pegada. Si se le va en '
+      + 'polvo suelto o sale un bloque duro, ya no.',
+    fuente: 'teacher-micorrizas [6], [100], [105]',
+  },
+  {
+    id: 'lombriz',
+    lado: 'ambos',
+    titulo: 'La lombriz',
+    texto:
+      'Cave y cuente. Si no aparece ninguna en un suelo que debería tenerlas, eso es '
+      + 'una alerta — sea por químico, por sequedad o porque está muy apretado. Fíjese '
+      + 'que el túnel queda: la casa está lista, la que no está es ella.',
+    fuente: 'teacher-micorrizas [102]; dpo-frontera-agroecologica [0]',
+  },
+  {
+    id: 'olor',
+    lado: 'ambos',
+    titulo: 'El olor',
+    texto:
+      'Huela un puñado húmedo. Debe oler a tierra de bosque. Si huele a podrido o a '
+      + 'huevo dañado, le falta aire. Y ojo con esta: un suelo que no huele a nada '
+      + 'puede ser un suelo con poca vida.',
+    fuente: 'teacher-micorrizas [100], [101]',
+  },
+  {
+    id: 'hilo-roto',
+    lado: 'apagado',
+    titulo: 'El hilo cortado',
+    texto:
+      'Los hilos del hongo son finísimos y se parten. Una vez partidos, tardan meses '
+      + 'en volverse a tejer. Y el herbicida se lleva de golpe muchas raíces vivas: '
+      + 'las que le daban de comer a la red.',
+    fuente: 'teacher-micorrizas [36], [45]',
+  },
+  {
+    id: 'fosforo-pegado',
+    lado: 'apagado',
+    titulo: 'El fósforo está ahí',
+    texto:
+      'Mírelo bien: el fósforo no se fue. Está ahí, quieto, pegado al hierro y a la '
+      + 'arcilla — en suelo de ladera se pega así. El que lo soltaba era el hongo. '
+      + 'Sin él, su mata tiene la comida a un centímetro y no la alcanza. Por eso '
+      + 'toca comprarla en bulto.',
+    fuente: 'teacher-micorrizas [21], [30]',
+  },
+  {
+    id: 'trampa',
+    lado: 'apagado',
+    titulo: 'Ahí está la trampa',
+    texto:
+      'Fumiga seguido, el suelo queda más pobre en vida. Con el suelo pobre le toca '
+      + 'comprar más insumo. Y mientras más compra, menos le hace falta la red — hasta '
+      + 'que un día ya no la tiene y no puede parar de comprar. Lo más rápido hoy le '
+      + 'sale más caro mañana.',
+    fuente: 'dpo-frontera-agroecologica [18]; teacher-micorrizas [32]',
+  },
+  {
+    id: 'rebrote',
+    lado: 'apagado',
+    titulo: 'Y vuelve a salir',
+    texto:
+      'El kikuyo se riega por rizoma. El químico se lo quema por encima, pero a las '
+      + 'semanas rebrota de la raíz que quedó viva. Entonces toca volver a fumigar. Y '
+      + 'otra vez. Cada vuelta le cuesta plata y le cuesta suelo.',
+    fuente: 'dpo-frontera-agroecologica [16]',
+  },
+  {
+    id: 'agua',
+    lado: 'ambos',
+    titulo: 'El agua escondida',
+    texto:
+      'Los hilos del hongo llegan a poros chiquiticos donde queda agua guardada '
+      + 'después de que la superficie ya se secó. Esa es agua que su mata se toma en '
+      + 'el verano y que sin la red se queda ahí sin que nadie la saque.',
+    fuente: 'teacher-micorrizas [22]',
+  },
+  {
+    id: 'espora',
+    lado: 'apagado',
+    titulo: 'Lo que no se apagó',
+    texto:
+      'Esas perlitas siguen prendidas hasta en lo más castigado: es el banco de '
+      + 'esporas que ya está en su tierra. Si para, de ahí vuelve a arrancar la red — '
+      + 'más si tiene un rastrojo o un monte cerquita que le mande más.',
+    fuente: 'teacher-micorrizas [49], [65], [66]',
+  },
+];
+
+/*
+ * ── EL CIERRE ───────────────────────────────────────────────────────────────
+ * La pieza NO termina en regaño. Termina en que se puede.
+ *
+ * Pero ojo con el orden, que es deliberado: primero la asimetría (perder es
+ * rápido, ganar es lento), DESPUÉS la esperanza. Al revés sonaría a que no pasa
+ * nada. Y la esperanza va con su precio puesto — "varias temporadas", "no es
+ * magia" — porque una esperanza sin precio es una promesa, y las promesas son
+ * el idioma del bulto, no el nuestro.
+ */
+export const CIERRE = {
+  asimetria: {
+    titulo: 'Se pierde más rápido de lo que se gana',
+    texto:
+      'Un par de pasadas fuertes le borran en poco tiempo lo que costó años armar. '
+      + 'Los hilos cortados tardan meses en volver. Subir la materia orgánica un solo '
+      + 'punto puede tomarle hasta veinte años con buen manejo. Así de disparejo es el '
+      + 'trato.',
+    fuente: 'teacher-micorrizas [36], [80]; teacher-agua-suelo [91]',
+  },
+  esperanza: {
+    titulo: 'Pero vuelve',
+    texto:
+      'No es para siempre. Si cambia el manejo —menos arada, más cobertura, compost y '
+      + 'tiempo— la red se vuelve a tejer. No es de un día para otro: puede tomar '
+      + 'varias temporadas. Pero el suelo tiene memoria biológica, y la naturaleza '
+      + 'sabe reconstruirse si uno deja de interrumpirla.',
+    fuente: 'teacher-micorrizas [49], [82]',
+  },
+  primerPaso: {
+    titulo: 'Lo primero es lo más barato',
+    texto:
+      'Dejar de dejar el suelo pelado. Lo que más falta hace no es comprar hongo: es '
+      + 'dejar de dañar el que ya está ahí.',
+    fuente: 'teacher-micorrizas [50], [63]',
+  },
+};
+
+/*
+ * ── LA CONCESIÓN ────────────────────────────────────────────────────────────
+ * Esto NO es un descargo legal ni una debilidad de la pieza. Es la frase que
+ * hace que le crean todo lo demás. Un campesino que ya oyó a cien predicadores
+ * reconoce al que le está vendiendo algo: el que no concede NADA está vendiendo.
+ * El corpus concede, y por eso el corpus convence. Se queda.
+ */
+export const CONCESION = {
+  titulo: 'Sin fanatismo',
+  texto:
+    'Entiendo el afán: eso enmontado da rabia, y el químico es barato y sirve. En una '
+    + 'invasión muy brava de una maleza que no sale con nada, una aplicación puntual y '
+    + 'bien dirigida puede ser la única salida real, y no se la vamos a negar solo por '
+    + 'principio. Eso es la excepción. Lo que no hacemos acá es recetarlo como rutina '
+    + 'de calendario.',
+  fuente: 'dpo-frontera-agroecologica [17]',
+};
+
+/*
+ * ── LAS DOS CADENCIAS ───────────────────────────────────────────────────────
+ * El hallazgo más lindo del corpus, y es una rima que estaba ahí sin que nadie
+ * la buscara: LAS DOS PRÁCTICAS TIENEN EL MISMO CALENDARIO.
+ *
+ *   El bulto:  "repita la aplicación cada tres o cuatro semanas"   [rejected]
+ *   La guadaña: "toca repetir el corte cada tres o cuatro semanas" [chosen]
+ *
+ * Mismo ritmo. Mismo trabajo. Una le apaga el suelo y la otra se lo abona. Puesto
+ * lado a lado, el argumento se arma solo y sin que nadie regañe a nadie: no es
+ * "trabaje más", es "el mismo trabajo, para otro lado".
+ *
+ * OJO CON LA CIFRA: "3-4 litros por hectárea" y "en ocho días ve el potrero
+ * limpio" salen del `rejected` — son la voz que el corpus RECHAZA. Van marcadas
+ * como cita del bulto (`esVozDelBulto: true`), NUNCA en boca de la pieza. Si
+ * alguien las muestra sin esa marca, rompió la regla.
+ */
+export const CADENCIAS = {
+  titulo: 'El mismo trabajo, para otro lado',
+  bulto: {
+    voz: 'Lo que dice el bulto',
+    texto: 'Repita la aplicación cada tres o cuatro semanas.',
+    esVozDelBulto: true,
+    fuente: 'dpo-frontera-agroecologica [0, 5, 9, 18] — campo `rejected`',
+  },
+  guadana: {
+    voz: 'Lo que hacemos acá',
+    texto:
+      'Corte antes de que la maleza florezca y déjela ahí encima como cobertura '
+      + 'muerta: eso ahoga la que va naciendo y además abona. Toca repetir el corte '
+      + 'cada tres o cuatro semanas. No es magia, pero el suelo se lo agradece con el '
+      + 'tiempo.',
+    esVozDelBulto: false,
+    fuente: 'dpo-frontera-agroecologica [2] — campo `chosen`',
+  },
+};
+
+/* ── El control (usted, colombiano) ──────────────────────────────────────── */
+export const CONTROL = {
+  apagar: 'Fumigar seguido',
+  recuperar: 'Parar y dejarla volver',
+  vivo: 'Suelo con red',
+  apagado: 'Suelo fumigado',
+  ayuda: 'Toque y arrastre para mover el suelo. Toque los puntos para leer.',
+};
+
+/** Los hotspots de un lado ('vivo' | 'apagado'), incluyendo los de 'ambos'. */
+export const hotspotsDe = (lado) =>
+  HOTSPOTS.filter((h) => h.lado === lado || h.lado === 'ambos');


### PR DESCRIPTION
## Qué aporta

Rescata `fable/red-bajo-glifosato-17` (2026-07-15), **VIVA** en el triaje (#5 en orden de valor). Mundo "suelo comparado": la red micorrízica del suelo bajo glifosato (apagada) vs sin (encendida), 4 archivos: `EscenaSueloComparado.jsx`, `sueloComparado.geom.js`, `sueloComparadoTextos.js`, `index.js`.

Parte del lote de mundos autónomos del 2026-07-15 (junto a `biodigestor-15`, `olor-visible-16`, `semillas-criollas-22`, `beneficos-21`).

## Por qué estaba perdida

Sin PR, nunca integrada a `dev`.

## Estado

- `npm run build` → **OK** (~49s).
- Merge sin conflictos — 4/4 archivos nuevos.
- Disponible pero **no cableado al router**.
- **NO mergeado.** Draft para revisión del operador.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>