### PR TITLE
rescate: fable/semillas-criollas-22 — el banco de semillas criollas, el mosaico de la autonomía

### DIFF
--- a/src/visual/mundo3d/semillas/EscenaBancoSemillas.jsx
+++ b/src/visual/mundo3d/semillas/EscenaBancoSemillas.jsx
@@ -1,0 +1,741 @@
+/*
+ * EscenaBancoSemillas — el MUNDO "Banco de Semillas Criollas": la autonomía
+ * que cabe en un frasco, en 3D real y con el máximo cuidado visual.
+ *
+ * Un rincón de guardado campesino a la hora dorada: la TROJA contra la pared
+ * encalada carga el MOSAICO — trece frascos, trece herencias: maíces de la
+ * cordillera, fríjoles de mil pintas, papas de colores. De la viga cuelgan
+ * CALABAZOS curados; en el piso, el costal de fique, la vasija de chamba y el
+ * frasco con su capa de CENIZA — y el GORGOJO rondando por fuera, que no
+ * puede entrar. Al sol, el parche con la MATA MADRE marcada viva con su cinta
+ * de cochinilla (la semilla se escoge mata, no grano). Y la semilla VIAJA:
+ * del frasco criollo al surco y DE VUELTA (la que se puede volver a sembrar),
+ * y entre dos canastos de vecinos (el trueque: la semilla circula, no se
+ * acumula). La bolsa certificada también está, digna, sin burla: saber la
+ * diferencia es la autonomía, no el sermón.
+ *
+ * Toda la geometría es procedural (cero CDN/imágenes) y vive en
+ * `bancoSemillas.geom.js` (puro, testeable); los textos y variedades en
+ * `semillasData.js` (three-free). Paleta/luz/materiales: LA CASA (paleta/,
+ * GUIA.md): ni un hex suelto, LuzMadre, recetas madre, cielo `tierra`.
+ *
+ * Tier-safe: 'alto' pleno (copetes densos, pintas del cargamanto, gorgojo,
+ * flujos); 'medio' frugal; 'bajo' mínimo digno (quieto, sin flujos ni bicho).
+ * Con `reducedMotion` monta QUIETO (frameloop a demanda, flujos congelados).
+ *
+ * Componente r3f: montar SOLO perezoso dentro de un host con altura.
+ */
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr, Html } from '@react-three/drei';
+import * as THREE from 'three';
+import {
+  CIELOS,
+  PALETA,
+  TIERRAS,
+  VERDES,
+  ACENTOS,
+  NEUTROS,
+  LUCES,
+  mezclar,
+  mezclarCielo,
+  crearMaterialMadre,
+  LuzMadre,
+} from '../paleta';
+import { perfilDeTier } from '../deviceTier.js';
+import { PERFILES_VASIJA } from '../artesaniaAndina.js';
+import { VARIEDADES, TINTES_BANCO, HOTSPOTS_BANCO } from './semillasData.js';
+import {
+  BANCO,
+  PERFIL_FRASCO,
+  PERFIL_CALABAZO,
+  PERFIL_COSTAL,
+  puntosLathe,
+  paramsDeSemillas,
+  distribuirFrascos,
+  semillasDelBanco,
+  flujosDelBanco,
+  particulasDeFlujo,
+  matasDelParche,
+  brotesDelSurco,
+} from './bancoSemillas.geom.js';
+
+/* CSS mínimo del lienzo (self-contained). Burbuja de hotspot en los tonos
+   cálidos de la casa (tinta tibia + maíz), no el turquesa del subsuelo. */
+const CSS = `
+.bsem-canvas { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 0; transition: opacity 0.8s ease; }
+.bsem-canvas--lista { opacity: 1; }
+.bsem-hot { transform: translate(-50%, -120%); }
+.bsem-hot__btn { display: inline-flex; align-items: center; gap: 0.34rem; max-width: 13rem; padding: 0.3rem 0.6rem; border: 0; border-radius: 999px; background: rgba(36, 26, 16, 0.84); color: #fff8ec; font: 600 0.76rem/1.1 system-ui, sans-serif; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35), inset 0 0 0 1px rgba(244, 197, 66, 0.42); cursor: pointer; -webkit-tap-highlight-color: transparent; text-align: left; }
+.bsem-hot__btn:focus-visible { outline: 2px solid #f4c542; outline-offset: 2px; }
+.bsem-hot__pt { width: 0.66rem; height: 0.66rem; border-radius: 50%; background: radial-gradient(circle at 35% 35%, #fff8ec, #e2c04c 70%); box-shadow: 0 0 8px 2px rgba(226, 192, 76, 0.65); flex: 0 0 auto; }
+@media (prefers-reduced-motion: reduce) { .bsem-canvas { transition: none; } }
+`;
+
+/* Material madre memoizado + liberado (patrón GUIA.md §2). */
+function useMaterialMadre(nombre, perfil, extra) {
+  const mat = useMemo(
+    () => crearMaterialMadre(nombre, perfil, extra),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [nombre, perfil],
+  );
+  useLayoutEffect(() => () => mat.dispose(), [mat]);
+  return mat;
+}
+
+/* Sombra de contacto rubber-hose: la elipse tibia que asienta la pieza. */
+function SombraContacto({ pos, r = 0.3, opacidad = 0.2 }) {
+  return (
+    <mesh position={[pos[0], 0.012, pos[2]]} rotation={[-Math.PI / 2, 0, 0]}>
+      <circleGeometry args={[r, 14]} />
+      <meshBasicMaterial color={LUCES.sombra} transparent opacity={opacidad} depthWrite={false} />
+    </mesh>
+  );
+}
+
+/* ── LA TROJA: pared encalada, piso de tierra, parales, tablas y viga. ── */
+function Troja({ perfil }) {
+  const matCal = useMaterialMadre('cal', perfil);
+  const matTabla = useMaterialMadre('madera', perfil, { color: PALETA.maderaClara });
+  const matParal = useMaterialMadre('madera', perfil, { color: PALETA.maderaOscura });
+  const matPiso = useMaterialMadre('tierra', perfil, { color: TIERRAS.camino });
+  const { pared, piso, estante, viga } = BANCO;
+  const altoParal = estante.tablas[2] + 0.22;
+  return (
+    <group>
+      {/* el piso de tierra pisada */}
+      <mesh position={[0, -0.02, 0.6]} material={matPiso}>
+        <boxGeometry args={[piso.ancho, 0.04, piso.fondo]} />
+      </mesh>
+      {/* la pared encalada */}
+      <mesh position={[0, pared.alto / 2, pared.z - 0.07]} material={matCal}>
+        <boxGeometry args={[pared.ancho, pared.alto, 0.14]} />
+      </mesh>
+      {/* el zócalo de tierra que toda pared de tapia luce */}
+      <mesh position={[0, 0.14, pared.z + 0.005]} material={matPiso}>
+        <boxGeometry args={[pared.ancho, 0.28, 0.02]} />
+      </mesh>
+      {/* los dos parales */}
+      {[-1, 1].map((s) => (
+        <mesh key={s} position={[estante.x + (s * estante.ancho) / 2, altoParal / 2, estante.z]} material={matParal}>
+          <cylinderGeometry args={[0.045, 0.055, altoParal, 7]} />
+        </mesh>
+      ))}
+      {/* las tres tablas */}
+      {estante.tablas.map((y) => (
+        <mesh key={y} position={[estante.x, y - estante.grosorTabla / 2, estante.z]} material={matTabla}>
+          <boxGeometry args={[estante.ancho + 0.18, estante.grosorTabla, estante.fondoTabla]} />
+        </mesh>
+      ))}
+      {/* la viga de colgar */}
+      <mesh position={[0, viga.y, viga.z]} material={matParal}>
+        <boxGeometry args={[viga.largo, 0.09, 0.09]} />
+      </mesh>
+      <SombraContacto pos={[estante.x, 0, estante.z + 0.1]} r={1.7} opacidad={0.14} />
+    </group>
+  );
+}
+
+/* ── UN FRASCO: vidrio lathe + la masa de semillas adentro + tapa/ceniza. ── */
+function Frasco({ pos, alto, radio, rotY = 0, color, matVidrio, seg, conCorcho = true, conCeniza = false }) {
+  const relleno = useMemo(() => new THREE.Color(color).multiplyScalar(0.86), [color]);
+  return (
+    <group position={pos} rotation={[0, rotY, 0]}>
+      {/* la masa de semillas (el color de la herencia, leído de lejos) */}
+      <mesh position={[0, alto * 0.28, 0]}>
+        <cylinderGeometry args={[radio * 0.68, radio * 0.6, alto * 0.52, seg]} />
+        <meshLambertMaterial color={relleno} flatShading />
+      </mesh>
+      {/* la capa de ceniza que guarda (solo el frasco curado) */}
+      {conCeniza && (
+        <mesh position={[0, alto * 0.575, 0]}>
+          <cylinderGeometry args={[radio * 0.66, radio * 0.68, 0.035, seg]} />
+          <meshLambertMaterial color={TINTES_BANCO.ceniza} />
+        </mesh>
+      )}
+      {/* el vidrio */}
+      <mesh material={matVidrio} renderOrder={2}>
+        <latheGeometry args={[puntosLathe(PERFIL_FRASCO, alto, radio), seg]} />
+      </mesh>
+      {/* el corcho / la tapa de totumo */}
+      {conCorcho && (
+        <mesh position={[0, alto + 0.018, 0]}>
+          <cylinderGeometry args={[radio * 0.5, radio * 0.44, 0.05, seg]} />
+          <meshLambertMaterial color={TINTES_BANCO.corcho} flatShading />
+        </mesh>
+      )}
+    </group>
+  );
+}
+
+/* ── TODAS las semillas visibles: UN InstancedMesh (color por instancia). ── */
+function SemillasInstanciadas({ items }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.SphereGeometry(1, 7, 5), []);
+  const mat = useMemo(() => new THREE.MeshLambertMaterial({ color: '#ffffff' }), []);
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const eu = new THREE.Euler();
+    for (let i = 0; i < items.length; i += 1) {
+      const s = items[i];
+      q.setFromEuler(eu.set(0, s.rotY, 0));
+      m.compose(s.pos, q, s.escala);
+      mesh.setMatrixAt(i, m);
+      mesh.setColorAt(i, s.color);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+  if (!items.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, items.length]} frustumCulled={false} />;
+}
+
+/* ── Las PINTAS del cargamanto (tier alto): motas sobre el grano moteado. ── */
+function PintasInstanciadas({ items }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.SphereGeometry(1, 5, 4), []);
+  const mat = useMemo(() => new THREE.MeshLambertMaterial({ color: '#ffffff' }), []);
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const m = new THREE.Matrix4();
+    const q = new THREE.Quaternion();
+    const s = new THREE.Vector3();
+    for (let i = 0; i < items.length; i += 1) {
+      const p = items[i];
+      s.setScalar(p.escala);
+      m.compose(p.pos, q, s);
+      mesh.setMatrixAt(i, m);
+      mesh.setColorAt(i, p.color);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [items]);
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+  if (!items.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, items.length]} frustumCulled={false} />;
+}
+
+/* ── Los CALABAZOS curados, colgados de la viga con su fique. Se mecen
+      apenas (solo si el movimiento está permitido): aire de casa viva. ── */
+function Calabazos({ seg, reducedMotion }) {
+  const ref = useRef(null);
+  useFrame((st) => {
+    const g = ref.current;
+    if (!g || reducedMotion) return;
+    const t = st.clock.elapsedTime;
+    for (let i = 0; i < g.children.length; i += 1) {
+      g.children[i].rotation.z = Math.sin(t * 0.5 + i * 1.7) * 0.022;
+    }
+  });
+  const { viga, calabazos } = BANCO;
+  return (
+    <group ref={ref}>
+      {calabazos.map((c, i) => {
+        const radio = c.alto * 0.42;
+        return (
+          /* el pivote es el punto de amarre en la viga: el vaivén es péndulo */
+          <group key={c.x} position={[c.x, viga.y - 0.04, viga.z]}>
+            <mesh position={[0, -c.cuelga / 2, 0]}>
+              <cylinderGeometry args={[0.008, 0.008, c.cuelga, 5]} />
+              <meshLambertMaterial color={TINTES_BANCO.fique} />
+            </mesh>
+            <group position={[0, -c.cuelga - c.alto, 0]}>
+              <mesh>
+                <latheGeometry args={[puntosLathe(PERFIL_CALABAZO, c.alto, radio), seg]} />
+                <meshLambertMaterial color={TINTES_BANCO.calabazo} flatShading={i !== 1} />
+              </mesh>
+              {/* el nudo de fique en el cuello */}
+              <mesh position={[0, c.alto * 0.92, 0]} rotation={[Math.PI / 2, 0, 0]}>
+                <torusGeometry args={[c.alto * 0.1, 0.014, 5, 8]} />
+                <meshLambertMaterial color={TINTES_BANCO.fique} />
+              </mesh>
+            </group>
+          </group>
+        );
+      })}
+    </group>
+  );
+}
+
+/* ── El COSTAL de fique: panzudo, amarrado, con sus franjas tejidas. ── */
+function CostalFique({ seg }) {
+  const { pos, alto } = BANCO.costal;
+  const radio = alto * 0.55;
+  return (
+    <group position={pos}>
+      <mesh>
+        <latheGeometry args={[puntosLathe(PERFIL_COSTAL, alto, radio), seg]} />
+        <meshLambertMaterial color={TINTES_BANCO.fique} flatShading />
+      </mesh>
+      {/* las franjas del tejido (el ritmo del textil, a cucharadas) */}
+      {[
+        { y: 0.3, k: 0.985, color: ACENTOS.indigo },
+        { y: 0.46, k: 0.94, color: ACENTOS.cochinilla },
+      ].map((f) => (
+        <mesh key={f.y} position={[0, alto * f.y, 0]} rotation={[Math.PI / 2, 0, 0]}>
+          <torusGeometry args={[radio * f.k * 0.97, 0.013, 5, seg]} />
+          <meshLambertMaterial color={f.color} />
+        </mesh>
+      ))}
+      {/* el amarre de la boca */}
+      <mesh position={[0, alto * 0.95, 0]} rotation={[Math.PI / 2, 0, 0]}>
+        <torusGeometry args={[radio * 0.24, 0.018, 5, 8]} />
+        <meshLambertMaterial color={NEUTROS.tinta} />
+      </mesh>
+      <SombraContacto pos={[0, 0, 0]} r={radio * 1.15} />
+    </group>
+  );
+}
+
+/* ── La VASIJA DE CHAMBA: barro negro brillado (guarda fresca la semilla).
+      En tier alto es Standard con brillo de bruñido; frugal, Lambert. ── */
+function VasijaChamba({ perfil, seg }) {
+  const { pos, alto } = BANCO.chamba;
+  const mat = useMemo(
+    () => (perfil.materialRico
+      ? new THREE.MeshStandardMaterial({ color: TINTES_BANCO.chamba, roughness: 0.38, metalness: 0.06 })
+      : new THREE.MeshLambertMaterial({ color: TINTES_BANCO.chamba })),
+    [perfil],
+  );
+  useLayoutEffect(() => () => mat.dispose(), [mat]);
+  return (
+    <group position={pos}>
+      <mesh material={mat}>
+        <latheGeometry args={[puntosLathe(PERFILES_VASIJA.cantaro, alto, alto * 0.5), seg]} />
+      </mesh>
+      <SombraContacto pos={[0, 0, 0]} r={alto * 0.42} />
+    </group>
+  );
+}
+
+/* ── Un CANASTO de rollo: tronco de cono + los aros del enrollado. ── */
+function Canasto({ pos, seg }) {
+  return (
+    <group position={pos}>
+      <mesh position={[0, 0.09, 0]}>
+        <cylinderGeometry args={[0.16, 0.115, 0.18, seg, 1, true]} />
+        <meshLambertMaterial color={PALETA.maderaClara} flatShading side={THREE.DoubleSide} />
+      </mesh>
+      {/* el fondo del canasto (para que no se vea hueco) */}
+      <mesh position={[0, 0.012, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[0.115, seg]} />
+        <meshLambertMaterial color={PALETA.maderaClara} />
+      </mesh>
+      {/* los rollos del tejido: aros que suben */}
+      {[0.05, 0.12, 0.18].map((y, i) => (
+        <mesh key={y} position={[0, y, 0]} rotation={[Math.PI / 2, 0, 0]}>
+          <torusGeometry args={[0.118 + i * 0.02, 0.014, 5, seg]} />
+          <meshLambertMaterial color={PALETA.madera} />
+        </mesh>
+      ))}
+      <SombraContacto pos={[0, 0, 0]} r={0.2} />
+    </group>
+  );
+}
+
+/* ── El PARCHE de la MATA MADRE: la mejor mata se escoge VIVA, en el lote,
+      y se marca con la cinta ANTES de cosechar. Ese gesto es todo. ── */
+function MataMaiz({ mata, reducedMotion }) {
+  const cintaRef = useRef(null);
+  useFrame((st) => {
+    const c = cintaRef.current;
+    if (!c || reducedMotion) return;
+    const t = st.clock.elapsedTime;
+    c.rotation.y = Math.sin(t * 1.3) * 0.3;
+    c.rotation.x = Math.sin(t * 0.9 + 1) * 0.12;
+  });
+  const verde = mata.madre ? VERDES.trabajo : mezclar(VERDES.trabajo, TIERRAS.pajonal, 0.35);
+  const hojas = mata.madre ? 4 : 3;
+  return (
+    <group position={[mata.x, 0, mata.z]} rotation={[0, 0, mata.lean]}>
+      {/* la caña */}
+      <mesh position={[0, mata.alto / 2, 0]}>
+        <cylinderGeometry args={[0.02, 0.034, mata.alto, 6]} />
+        <meshLambertMaterial color={verde} />
+      </mesh>
+      {/* las hojas: cintas que salen y caen */}
+      {Array.from({ length: hojas }, (_, i) => {
+        const a = (i / hojas) * Math.PI * 2 + (mata.madre ? 0.4 : 0);
+        const hy = mata.alto * (0.35 + 0.16 * i);
+        return (
+          <mesh
+            key={i}
+            position={[Math.cos(a) * 0.09, hy, Math.sin(a) * 0.09]}
+            rotation={[Math.sin(a) * 1.1, -a, Math.cos(a) * 1.1]}
+          >
+            <coneGeometry args={[0.035, mata.alto * 0.55, 4]} />
+            <meshLambertMaterial color={verde} flatShading />
+          </mesh>
+        );
+      })}
+      {/* la espiga */}
+      <mesh position={[0, mata.alto + 0.06, 0]}>
+        <coneGeometry args={[0.025, 0.16, 5]} />
+        <meshLambertMaterial color={mezclar(verde, ACENTOS.maizGrano, 0.55)} flatShading />
+      </mesh>
+      {mata.madre && (
+        <>
+          {/* la mazorca que carga parejo */}
+          <group position={[0.055, mata.alto * 0.52, 0.02]} rotation={[0, 0, -0.35]}>
+            <mesh scale={[0.045, 0.1, 0.045]}>
+              <sphereGeometry args={[1, 7, 6]} />
+              <meshLambertMaterial color={ACENTOS.maizGrano} flatShading />
+            </mesh>
+            <mesh position={[0, -0.05, 0]} rotation={[0, 0, 0.25]}>
+              <coneGeometry args={[0.035, 0.12, 4]} />
+              <meshLambertMaterial color={verde} flatShading />
+            </mesh>
+          </group>
+          {/* LA CINTA: el nudo y las dos colas que el viento mueve */}
+          <group position={[0, mata.alto * 0.68, 0]}>
+            <mesh rotation={[Math.PI / 2, 0, 0]}>
+              <torusGeometry args={[0.032, 0.011, 5, 8]} />
+              <meshLambertMaterial color={TINTES_BANCO.cinta} />
+            </mesh>
+            <group ref={cintaRef}>
+              {[-0.2, 0.55].map((rz) => (
+                <mesh key={rz} position={[0.035, -0.055, 0]} rotation={[0, 0, rz]}>
+                  <boxGeometry args={[0.022, 0.11, 0.006]} />
+                  <meshLambertMaterial color={TINTES_BANCO.cinta} side={THREE.DoubleSide} />
+                </mesh>
+              ))}
+            </group>
+          </group>
+        </>
+      )}
+    </group>
+  );
+}
+
+function ParcheMataMadre({ matas, reducedMotion }) {
+  const { pos, radio } = BANCO.parche;
+  return (
+    <group>
+      <mesh position={[pos[0], 0.028, pos[2]]}>
+        <cylinderGeometry args={[radio, radio * 1.06, 0.06, 12]} />
+        <meshLambertMaterial color={TIERRAS.siembra} flatShading />
+      </mesh>
+      {matas.map((m) => (
+        <MataMaiz key={`${m.x}-${m.z}`} mata={m} reducedMotion={reducedMotion} />
+      ))}
+      <SombraContacto pos={pos} r={radio * 1.05} opacidad={0.12} />
+    </group>
+  );
+}
+
+/* ── El GORGOJO: el enemigo del guardado, rubber-hose y chiquito. Ronda el
+      frasco curado con ceniza, se arrima, no puede entrar, y sigue rondando.
+      Sin terror: es la comedia del bicho que se quedó por fuera. ── */
+function Gorgojo({ reducedMotion }) {
+  const ref = useRef(null);
+  const fc = BANCO.frascoCeniza;
+  useFrame((st) => {
+    const g = ref.current;
+    if (!g) return;
+    const t = reducedMotion ? 1.2 : st.clock.elapsedTime;
+    const ang = t * 0.42;
+    /* se arrima y se retira tres veces por vuelta (huele, no alcanza) */
+    const cerca = 0.5 + 0.5 * Math.sin(ang * 3);
+    const rad = fc.radio + 0.3 - cerca * 0.13;
+    g.position.set(fc.pos[0] + Math.cos(ang) * rad, 0.045, fc.pos[2] + Math.sin(ang) * rad);
+    g.rotation.y = -ang - Math.PI / 2 + (reducedMotion ? 0 : Math.sin(t * 7) * 0.12 * cerca);
+    if (!reducedMotion) {
+      const paso = 1 + Math.abs(Math.sin(t * 8)) * 0.06;
+      g.scale.set(1, paso, 1); // el trotecito
+    }
+  });
+  const tinte = TINTES_BANCO.gorgojo;
+  return (
+    <group ref={ref} scale={1}>
+      {/* cuerpo y cabeza */}
+      <mesh scale={[0.05, 0.042, 0.062]}>
+        <sphereGeometry args={[1, 7, 6]} />
+        <meshLambertMaterial color={tinte} flatShading />
+      </mesh>
+      <mesh position={[0, 0.012, 0.062]} scale={[0.026, 0.024, 0.028]}>
+        <sphereGeometry args={[1, 6, 5]} />
+        <meshLambertMaterial color={tinte} />
+      </mesh>
+      {/* el pico de gorgojo (su firma) con terminal redonda rubber-hose */}
+      <mesh position={[0, 0.004, 0.1]} rotation={[Math.PI / 2 - 0.35, 0, 0]}>
+        <cylinderGeometry args={[0.005, 0.007, 0.05, 5]} />
+        <meshLambertMaterial color={tinte} />
+      </mesh>
+      <mesh position={[0, -0.004, 0.122]}>
+        <sphereGeometry args={[0.009, 5, 4]} />
+        <meshLambertMaterial color={tinte} />
+      </mesh>
+      {/* ojos de hueso (la mirada golosa) */}
+      {[-1, 1].map((s) => (
+        <mesh key={s} position={[s * 0.016, 0.03, 0.07]}>
+          <sphereGeometry args={[0.008, 5, 4]} />
+          <meshLambertMaterial color={NEUTROS.hueso} />
+        </mesh>
+      ))}
+      {/* antenas con bolita (terminales redondas SIEMPRE) */}
+      {[-1, 1].map((s) => (
+        <group key={s} position={[s * 0.014, 0.03, 0.085]} rotation={[0.5, 0, s * 0.7]}>
+          <mesh position={[0, 0.02, 0]}>
+            <cylinderGeometry args={[0.0035, 0.0035, 0.04, 4]} />
+            <meshLambertMaterial color={tinte} />
+          </mesh>
+          <mesh position={[0, 0.045, 0]}>
+            <sphereGeometry args={[0.008, 5, 4]} />
+            <meshLambertMaterial color={tinte} />
+          </mesh>
+        </group>
+      ))}
+      {/* paticas: seis muñones de trote */}
+      {[-1, 1].map((s) => (
+        [0.03, 0, -0.03].map((z) => (
+          <mesh key={`${s}-${z}`} position={[s * 0.042, -0.03, z]} rotation={[0, 0, s * 0.5]}>
+            <cylinderGeometry args={[0.006, 0.006, 0.03, 4]} />
+            <meshLambertMaterial color={tinte} />
+          </mesh>
+        ))
+      ))}
+    </group>
+  );
+}
+
+/* ── Un FLUJO de semillas viajando por su curva (InstancedMesh chiquito).
+      Con reducedMotion las semillas quedan quietas, repartidas a lo largo:
+      el camino se LEE aunque nada se mueva. ── */
+function FlujoSemillas({ flujo, particulas, reducedMotion }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => new THREE.SphereGeometry(0.026, 6, 5), []);
+  const mat = useMemo(() => new THREE.MeshLambertMaterial({ color: flujo.color }), [flujo.color]);
+  const tmp = useMemo(
+    () => ({ m: new THREE.Matrix4(), q: new THREE.Quaternion(), s: new THREE.Vector3(), p: new THREE.Vector3() }),
+    [],
+  );
+  useLayoutEffect(() => () => { geo.dispose(); mat.dispose(); }, [geo, mat]);
+  const escribir = (time) => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const { m, q, s, p } = tmp;
+    for (let i = 0; i < particulas.length; i += 1) {
+      const pa = particulas[i];
+      let t = reducedMotion ? pa.t0 : pa.t0 + time * pa.vel;
+      t -= Math.floor(t);
+      flujo.curva.getPoint(t, p);
+      /* nace del origen, vuela y se ENTREGA en el destino */
+      s.setScalar(pa.tam * (0.4 + Math.sin(t * Math.PI) * 0.7));
+      m.compose(p, q, s);
+      mesh.setMatrixAt(i, m);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  };
+  useLayoutEffect(() => { escribir(0); // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [particulas, flujo]);
+  useFrame((st) => { if (!reducedMotion) escribir(st.clock.elapsedTime); });
+  if (!particulas.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, particulas.length]} frustumCulled={false} />;
+}
+
+/* ── El SURCO con sus brotes (la criolla nace) y la BOLSA certificada al
+      lado — digna, sin burla: la diferencia se muestra, no se sermonea. ── */
+function SurcoYBolsa({ brotes, perfil }) {
+  const matTierra = useMaterialMadre('tierra', perfil);
+  const { surco, bolsa } = BANCO;
+  return (
+    <group>
+      <mesh position={[surco.pos[0], 0.05, surco.pos[2]]} rotation={[0, 0.5, 0]} material={matTierra}>
+        <boxGeometry args={[surco.largo, 0.1, surco.ancho]} />
+      </mesh>
+      {brotes.map((b) => (
+        <group key={`${b.x}`} position={[b.x, 0.1, b.z]} rotation={[0, b.rot, 0]}>
+          {[-0.5, 0.5].map((rz) => (
+            <mesh key={rz} position={[rz * 0.02, b.alto / 2, 0]} rotation={[0, 0, rz]}>
+              <coneGeometry args={[0.014, b.alto, 4]} />
+              <meshLambertMaterial color={VERDES.brote} flatShading />
+            </mesh>
+          ))}
+        </group>
+      ))}
+      {/* la bolsa de semilla certificada: existe, sirve a veces, y de ella
+          no se guarda semilla — eso es todo lo que la escena dice */}
+      <group position={bolsa.pos} rotation={[0, -0.4, 0.05]}>
+        <mesh position={[0, 0.15, 0]}>
+          <boxGeometry args={[0.17, 0.3, 0.09]} />
+          <meshLambertMaterial color={TINTES_BANCO.bolsa} />
+        </mesh>
+        <mesh position={[0, 0.19, 0]}>
+          <boxGeometry args={[0.175, 0.07, 0.095]} />
+          <meshLambertMaterial color={PALETA.ambar} />
+        </mesh>
+        <mesh position={[0, 0.305, 0]} rotation={[0, 0, 0.1]}>
+          <boxGeometry args={[0.16, 0.02, 0.06]} />
+          <meshLambertMaterial color={TINTES_BANCO.bolsa} />
+        </mesh>
+        <SombraContacto pos={[0, 0, 0]} r={0.13} />
+      </group>
+    </group>
+  );
+}
+
+/* Un hotspot 3D → burbuja tocable anclada en el mundo (contrato del host). */
+function Hotspot({ pos, label, onClick }) {
+  return (
+    <Html position={pos} center zIndexRange={[30, 10]} className="bsem-hot">
+      <button type="button" className="bsem-hot__btn" onClick={onClick} aria-label={label}>
+        <span className="bsem-hot__pt" aria-hidden="true" />
+        <span>{label}</span>
+      </button>
+    </Html>
+  );
+}
+
+function Mundo({ tier, reducedMotion, hotspots, onHotspot }) {
+  const perfil = perfilDeTier(tier);
+  const P = paramsDeSemillas(tier);
+
+  /* el cielo de FAMILIA tierra, mezclado 60% hacia la madre (ley de la casa) */
+  const cielo = useMemo(() => mezclarCielo(CIELOS.tierra), []);
+
+  /* vidrio compartido por todos los frascos (un solo material) */
+  const matVidrio = useMemo(
+    () => new THREE.MeshLambertMaterial({
+      color: TINTES_BANCO.vidrio,
+      transparent: true,
+      opacity: 0.22,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    }),
+    [],
+  );
+  useLayoutEffect(() => () => matVidrio.dispose(), [matVidrio]);
+
+  /* datos del banco (una vez por tier) */
+  const datos = useMemo(() => {
+    const frascos = distribuirFrascos(VARIEDADES);
+    const { semillas, pintas } = semillasDelBanco(frascos, VARIEDADES, P);
+    const flujos = P.particulasFlujo > 0 ? flujosDelBanco(VARIEDADES) : [];
+    const particulas = flujos.map((f, i) => particulasDeFlujo(P.particulasFlujo, 41 + i * 13));
+    return { frascos, semillas, pintas, flujos, particulas, matas: matasDelParche(), brotes: brotesDelSurco() };
+  }, [P]);
+
+  const spots = hotspots || HOTSPOTS_BANCO;
+  const fc = BANCO.frascoCeniza;
+  const fcr = BANCO.frascoCriollo;
+
+  return (
+    <>
+      <color attach="background" args={[cielo.fondo]} />
+      {perfil.fog && <fog attach="fog" args={[cielo.niebla, 10, 24]} />}
+      <LuzMadre cielo={CIELOS.tierra} perfil={perfil} />
+
+      <Troja perfil={perfil} />
+
+      {/* EL MOSAICO: cada frasco una herencia */}
+      {datos.frascos.map((f) => (
+        <Frasco
+          key={f.variedad.id}
+          pos={f.pos}
+          alto={f.alto}
+          radio={f.radio}
+          rotY={f.rotY}
+          color={f.variedad.color}
+          matVidrio={matVidrio}
+          seg={P.segLathe}
+        />
+      ))}
+      <SemillasInstanciadas items={datos.semillas} />
+      {P.pintas && <PintasInstanciadas items={datos.pintas} />}
+
+      {/* el guardado: calabazos, costal, chamba */}
+      <Calabazos seg={P.segLathe} reducedMotion={reducedMotion} />
+      <CostalFique seg={P.segLathe} />
+      <VasijaChamba perfil={perfil} seg={P.segLathe} />
+
+      {/* el frasco curado con ceniza… y el gorgojo que se quedó por fuera */}
+      <Frasco
+        pos={fc.pos}
+        alto={fc.alto}
+        radio={fc.radio}
+        color={VARIEDADES[5].color}
+        matVidrio={matVidrio}
+        seg={P.segLathe}
+        conCorcho={false}
+        conCeniza
+      />
+      <SombraContacto pos={fc.pos} r={fc.radio * 1.4} />
+      {P.gorgojo && <Gorgojo reducedMotion={reducedMotion} />}
+
+      {/* el ciclo criollo: el frasco que siembra y la cosecha que vuelve */}
+      <Frasco
+        pos={fcr.pos}
+        alto={fcr.alto}
+        radio={fcr.radio}
+        color={VARIEDADES[0].color}
+        matVidrio={matVidrio}
+        seg={P.segLathe}
+        conCorcho={false}
+      />
+      <SombraContacto pos={fcr.pos} r={fcr.radio * 1.4} />
+      <SurcoYBolsa brotes={datos.brotes} perfil={perfil} />
+
+      {/* el trueque: dos canastos de vecinos, dos variedades que se cruzan */}
+      <Canasto pos={BANCO.canastoA.pos} seg={P.segLathe} />
+      <Canasto pos={BANCO.canastoB.pos} seg={P.segLathe} />
+
+      {datos.flujos.map((f, i) => (
+        <FlujoSemillas key={f.id} flujo={f} particulas={datos.particulas[i]} reducedMotion={reducedMotion} />
+      ))}
+
+      {/* la mata madre, marcada VIVA en el lote */}
+      <ParcheMataMadre matas={datos.matas} reducedMotion={reducedMotion} />
+
+      {spots.map((h) => (
+        <Hotspot key={h.id} pos={h.pos} label={h.label} onClick={() => onHotspot?.(h.view, h.data)} />
+      ))}
+
+      <OrbitControls
+        makeDefault
+        target={[0.2, 1.15, -0.7]}
+        enablePan={false}
+        enableZoom
+        minDistance={3.2}
+        maxDistance={9}
+        minPolarAngle={0.55}
+        maxPolarAngle={1.52}
+        minAzimuthAngle={-1.05}
+        maxAzimuthAngle={1.05}
+        enableDamping
+        dampingFactor={0.08}
+      />
+      <AdaptiveDpr pixelated />
+    </>
+  );
+}
+
+/**
+ * El mundo Banco de Semillas Criollas. Montar SOLO perezoso dentro de un host
+ * con altura. Acepta el contrato del framework de mundos (props extra
+ * ignoradas); sin `hotspots` usa los HOTSPOTS_BANCO por defecto.
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, hotspots?: Array, onHotspot?: Function}} props
+ */
+export default function EscenaBancoSemillas({ tier = 'alto', reducedMotion = false, hotspots, onHotspot }) {
+  const [listo, setListo] = useState(false);
+  const dpr = tier === 'alto' ? [1, 1.8] : tier === 'medio' ? [1, 1.3] : 1;
+  return (
+    <>
+      <style>{CSS}</style>
+      <Canvas
+        className={`bsem-canvas${listo ? ' bsem-canvas--lista' : ''}`}
+        dpr={dpr}
+        gl={{ antialias: tier === 'alto', powerPreference: 'high-performance' }}
+        camera={{ position: [0.7, 1.9, 6.3], fov: 44 }}
+        frameloop={reducedMotion ? 'demand' : 'always'}
+        onCreated={() => setListo(true)}
+      >
+        <Mundo tier={tier} reducedMotion={reducedMotion} hotspots={hotspots} onHotspot={onHotspot} />
+      </Canvas>
+    </>
+  );
+}

--- a/src/visual/mundo3d/semillas/bancoSemillas.geom.js
+++ b/src/visual/mundo3d/semillas/bancoSemillas.geom.js
@@ -1,0 +1,377 @@
+/*
+ * bancoSemillas.geom — la GEOMETRÍA del banco de semillas criollas, en
+ * funciones PURAS y testeables (three-core, corre headless: cero contexto GL,
+ * cero azar por frame, cero assets externos).
+ *
+ * ── LO QUE ESTE ARCHIVO CONSTRUYE ───────────────────────────────────────────
+ * Un rincón de guardado campesino: la TROJA (estante de madera contra pared
+ * encalada) con el MOSAICO de frascos —cada uno una variedad criolla—, los
+ * calabazos colgados de la viga, el costal de fique, la vasija de chamba, el
+ * frasco con su capa de CENIZA (y el gorgojo rondando por fuera), la MATA
+ * MADRE marcada viva en su parche, y los FLUJOS de semilla que viajan: la
+ * criolla que vuelve del surco al frasco, y el trueque entre canastos.
+ *
+ * Convenciones de la casa:
+ *   - Perfiles lathe como pares [radio, y] normalizados (y ∈ 0..1), pocos
+ *     puntos A PROPÓSITO: el facetado ES el estilo (artesaniaAndina).
+ *   - PRNG determinista LCG (misma receta de micorrizas/artesanía): el banco
+ *     se ve IGUAL en cada carga; nada de Math.random.
+ *   - El componente r3f (`EscenaBancoSemillas.jsx`) consume esto y le pone
+ *     luz de la casa (LuzMadre), materiales madre y vida.
+ */
+import * as THREE from 'three';
+import { FORMAS_SEMILLA } from './semillasData.js';
+
+/* PRNG determinista (mismo banco en cada carga). */
+export function rng(seed) {
+  let s = (seed >>> 0) || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* PRESUPUESTO por tier: el banco degrada SOLO (contrato deviceTier).  */
+/* ------------------------------------------------------------------ */
+export function paramsDeSemillas(tier) {
+  if (tier === 'alto') {
+    return {
+      semillasPorFrasco: 26, // el copete visible del frasco
+      pintas: true, // el moteado del cargamanto (mil pintas)
+      gorgojo: true, // el bicho ronda animado
+      particulasFlujo: 9, // semillas viajando por cada curva
+      segLathe: 12, // facetado cálido (el look, no un bug)
+      montonSuelto: 16, // semillas regadas junto al costal
+    };
+  }
+  if (tier === 'medio') {
+    return {
+      semillasPorFrasco: 14,
+      pintas: false,
+      gorgojo: true,
+      particulasFlujo: 6,
+      segLathe: 10,
+      montonSuelto: 10,
+    };
+  }
+  return {
+    semillasPorFrasco: 8,
+    pintas: false,
+    gorgojo: false, // quieto ni lo monta: fill-rate al mínimo
+    particulasFlujo: 0, // los flujos no viajan en gama baja
+    segLathe: 8,
+    montonSuelto: 6,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* LAYOUT — un solo lugar decide dónde vive cada cosa (los hotspots     */
+/* de semillasData apuntan a ESTAS coordenadas).                        */
+/* ------------------------------------------------------------------ */
+export const BANCO = {
+  /* la pared encalada del fondo y el piso de tierra pisada */
+  pared: { z: -2.6, ancho: 7.2, alto: 3.3 },
+  piso: { ancho: 9, fondo: 7 },
+  /* la troja: dos parales y tres tablas */
+  estante: {
+    x: -0.8, // centro
+    ancho: 3.1,
+    z: -2.18,
+    tablas: [0.78, 1.46, 2.14], // altura de la CARA superior de cada tabla
+    grosorTabla: 0.06,
+    fondoTabla: 0.5,
+  },
+  /* la viga de los calabazos */
+  viga: { y: 2.86, z: -1.9, largo: 6.8 },
+  calabazos: [
+    { x: 1.55, alto: 0.52, cuelga: 0.5 },
+    { x: 2.15, alto: 0.62, cuelga: 0.34 },
+    { x: 2.72, alto: 0.45, cuelga: 0.62 },
+  ],
+  /* piezas de piso */
+  costal: { pos: [1.9, 0, -1.35], alto: 0.78 },
+  chamba: { pos: [-2.75, 0, -1.5], alto: 0.62 },
+  frascoCeniza: { pos: [-0.5, 0, -0.55], alto: 0.5, radio: 0.19 },
+  /* el ciclo de la criolla (frasco ↔ surco) y la bolsa certificada al lado */
+  frascoCriollo: { pos: [-2.6, 0, 0.35], alto: 0.44, radio: 0.16 },
+  surco: { pos: [-3.35, 0, 0.95], largo: 0.9, ancho: 0.42 },
+  bolsa: { pos: [-2.05, 0, 0.95] },
+  /* el trueque: dos canastos frente a frente */
+  canastoA: { pos: [1.15, 0, 0.7] },
+  canastoB: { pos: [2.05, 0, 1.1] },
+  /* la mata madre, en su parche al sol (fuera de la troja) */
+  parche: { pos: [3.5, 0, -0.55], radio: 0.85 },
+};
+
+/* ------------------------------------------------------------------ */
+/* PERFILES lathe [radio, y] normalizados (y ∈ 0..1 de base a boca).    */
+/* ------------------------------------------------------------------ */
+
+/* El frasco de vidrio: panza, hombro alto (proporción andina) y labio. */
+export const PERFIL_FRASCO = [
+  [0, 0], [0.3, 0], [0.35, 0.06], [0.37, 0.32], [0.36, 0.6],
+  [0.3, 0.74], [0.24, 0.8], [0.235, 0.92], [0.26, 0.97], [0.26, 1],
+];
+
+/* El calabazo curado (totumo de guardar): doble panza y cuello de amarre. */
+export const PERFIL_CALABAZO = [
+  [0, 0], [0.17, 0.01], [0.3, 0.12], [0.34, 0.3], [0.26, 0.48],
+  [0.16, 0.58], [0.2, 0.72], [0.22, 0.84], [0.13, 0.94], [0.05, 1],
+];
+
+/* El costal de fique: panzudo, asentado, con la boca amarrada. */
+export const PERFIL_COSTAL = [
+  [0, 0], [0.4, 0.02], [0.48, 0.18], [0.47, 0.46], [0.42, 0.68],
+  [0.3, 0.82], [0.13, 0.94], [0.1, 1],
+];
+
+/* La bolsa de semilla certificada: paralelepípedo digno (va como box). */
+
+/**
+ * Escala un perfil a THREE.Vector2[] listos para `latheGeometry`.
+ * `radio` es el radio MÁXIMO real de la pieza (el perfil se normaliza a él),
+ * para que BANCO hable en unidades de mundo y no en factores mágicos.
+ */
+export function puntosLathe(perfil, alto, radio) {
+  const rmax = perfil.reduce((m, [r]) => Math.max(m, r), 0) || 1;
+  const k = radio != null ? radio / rmax : alto;
+  return perfil.map(([r, y]) => new THREE.Vector2(r * k, y * alto));
+}
+
+/* ------------------------------------------------------------------ */
+/* EL MOSAICO — distribuir los frascos por las tablas de la troja.      */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Reparte las variedades en frascos sobre las tres tablas, con vaivén
+ * determinista de tamaño y giro (ningún frasco es clon del vecino).
+ * @param {Array} variedades  VARIEDADES de semillasData
+ * @param {number} [seed]
+ * @returns {Array<{ variedad, pos:[x,y,z], alto:number, radio:number, rotY:number }>}
+ */
+export function distribuirFrascos(variedades, seed = 17) {
+  const r = rng(seed);
+  const { estante } = BANCO;
+  const porTabla = [5, 4, 4]; // 13 variedades: abajo lo pesado, arriba lo fino
+  const frascos = [];
+  let vi = 0;
+  for (let t = 0; t < porTabla.length && vi < variedades.length; t += 1) {
+    const n = Math.min(porTabla[t], variedades.length - vi);
+    const paso = (estante.ancho - 0.36) / n;
+    const x0 = estante.x - (estante.ancho - 0.36) / 2 + paso / 2;
+    for (let i = 0; i < n; i += 1, vi += 1) {
+      const alto = 0.3 + r() * 0.12;
+      frascos.push({
+        variedad: variedades[vi],
+        pos: [
+          x0 + paso * i + (r() - 0.5) * 0.06,
+          estante.tablas[t],
+          estante.z + (r() - 0.5) * 0.08,
+        ],
+        alto,
+        radio: 0.125 + r() * 0.035,
+        rotY: (r() - 0.5) * 0.9, // el labio facetado gira: vida, no grilla
+      });
+    }
+  }
+  return frascos;
+}
+
+/* ------------------------------------------------------------------ */
+/* LAS SEMILLAS — el copete visible de cada frasco, TODO en un solo     */
+/* InstancedMesh (posiciones, escalas y colores precalculados).         */
+/* ------------------------------------------------------------------ */
+
+const BASE_SEMILLA = 0.03; // radio base de la esfera low-poly compartida
+
+/* Jitter de color determinista: el grano vivo no es plano. */
+function colorGrano(hex, r) {
+  const c = new THREE.Color(hex);
+  c.offsetHSL((r() - 0.5) * 0.02, (r() - 0.5) * 0.08, (r() - 0.5) * 0.09);
+  return c;
+}
+
+/**
+ * El copete de semillas de UN recipiente: puntos sobre un domo suave.
+ * @param {[number,number,number]} pos    base del recipiente (piso o tabla)
+ * @param {number} radioInterno           radio útil de la boca
+ * @param {number} yLleno                 altura del llenado (donde arranca el domo)
+ * @param {object} variedad               entrada de VARIEDADES
+ * @param {number} n                      cuántas semillas visibles
+ * @param {Function} r                    rng ya sembrado
+ * @param {Array} destino                 array de instancias a llenar
+ */
+export function copeteDeSemillas(pos, radioInterno, yLleno, variedad, n, r, destino) {
+  const esc = FORMAS_SEMILLA[variedad.forma] || FORMAS_SEMILLA.redonda;
+  for (let i = 0; i < n; i += 1) {
+    const rr = Math.sqrt(r()) * radioInterno;
+    const th = r() * Math.PI * 2;
+    const domo = (1 - (rr / radioInterno) ** 2) * radioInterno * 0.4;
+    destino.push({
+      pos: new THREE.Vector3(
+        pos[0] + Math.cos(th) * rr,
+        pos[1] + yLleno + domo + BASE_SEMILLA * esc[1] * 0.6,
+        pos[2] + Math.sin(th) * rr,
+      ),
+      escala: new THREE.Vector3(
+        BASE_SEMILLA * esc[0] * (0.85 + r() * 0.3),
+        BASE_SEMILLA * esc[1] * (0.85 + r() * 0.3),
+        BASE_SEMILLA * esc[2] * (0.85 + r() * 0.3),
+      ),
+      rotY: r() * Math.PI * 2,
+      color: colorGrano(variedad.color, r),
+      pinta: variedad.pinta || null,
+    });
+  }
+}
+
+/**
+ * TODAS las semillas visibles del banco: los copetes de los frascos de la
+ * troja + el frasco de ceniza + el frasco criollo + los dos canastos del
+ * trueque + el montoncito regado del costal. Una pasada, un InstancedMesh.
+ *
+ * @returns {{ semillas: Array, pintas: Array }} instancias + motas de pinta
+ */
+export function semillasDelBanco(frascos, variedades, P, seed = 29) {
+  const r = rng(seed);
+  const semillas = [];
+
+  /* los frascos de la troja (el mosaico) */
+  for (const f of frascos) {
+    copeteDeSemillas(f.pos, f.radio * 0.62, f.alto * 0.55, f.variedad, P.semillasPorFrasco, r, semillas);
+  }
+
+  /* el frasco criollo del ciclo (maíz amarillo: el que vuelve) */
+  const criollo = variedades[0];
+  const fc = BANCO.frascoCriollo;
+  copeteDeSemillas(fc.pos, fc.radio * 0.6, fc.alto * 0.52, criollo, Math.ceil(P.semillasPorFrasco * 0.7), r, semillas);
+
+  /* los canastos del trueque: cada uno trae SU variedad (circula diversidad) */
+  const a = variedades[4] || criollo; // cargamanto
+  const b = variedades[8] || criollo; // papa morada
+  copeteDeSemillas(BANCO.canastoA.pos, 0.13, 0.17, a, Math.ceil(P.semillasPorFrasco * 0.6), r, semillas);
+  copeteDeSemillas(BANCO.canastoB.pos, 0.13, 0.17, b, Math.ceil(P.semillasPorFrasco * 0.6), r, semillas);
+
+  /* el montoncito regado frente al costal (quinua: se riega, es menuda) */
+  const quinua = variedades[9] || criollo;
+  const [cx, , cz] = BANCO.costal.pos;
+  copeteDeSemillas([cx - 0.25, 0, cz + 0.55], 0.2, 0.005, quinua, P.montonSuelto, r, semillas);
+
+  /* las PINTAS del cargamanto (solo tier alto): motas sobre granos moteados */
+  const pintas = [];
+  if (P.pintas) {
+    for (const s of semillas) {
+      if (!s.pinta) continue;
+      const nP = 1 + Math.floor(r() * 2);
+      for (let k = 0; k < nP; k += 1) {
+        const th = r() * Math.PI * 2;
+        pintas.push({
+          pos: new THREE.Vector3(
+            s.pos.x + Math.cos(th) * s.escala.x * 0.55,
+            s.pos.y + s.escala.y * 0.55,
+            s.pos.z + Math.sin(th) * s.escala.z * 0.55,
+          ),
+          escala: s.escala.x * 0.34,
+          color: new THREE.Color(s.pinta),
+        });
+      }
+    }
+  }
+  return { semillas, pintas };
+}
+
+/* ------------------------------------------------------------------ */
+/* LOS FLUJOS — la semilla que viaja (ciclo criollo y trueque).         */
+/* ------------------------------------------------------------------ */
+
+/** Curva de vuelo entre dos puntos con arco `alza` (Bezier cuadrática). */
+export function curvaFlujo(a, b, alza = 0.7) {
+  const pa = new THREE.Vector3(...a);
+  const pb = new THREE.Vector3(...b);
+  const medio = pa.clone().lerp(pb, 0.5);
+  medio.y = Math.max(pa.y, pb.y) + alza;
+  return new THREE.QuadraticBezierCurve3(pa, medio, pb);
+}
+
+/**
+ * Los flujos del banco, ya curvados y con su color:
+ *  - ciclo: frasco criollo → surco (siembra) y surco → frasco (la cosecha
+ *    que VUELVE: eso es poder guardar semilla).
+ *  - trueque: canasto A → B y B → A (variedades distintas se cruzan).
+ * @param {Array} variedades VARIEDADES
+ */
+export function flujosDelBanco(variedades) {
+  const fc = BANCO.frascoCriollo;
+  const su = BANCO.surco;
+  const bocaFrasco = [fc.pos[0], fc.alto + 0.05, fc.pos[2]];
+  const tierra = [su.pos[0], 0.1, su.pos[2]];
+  const bordeA = [BANCO.canastoA.pos[0], 0.24, BANCO.canastoA.pos[2]];
+  const bordeB = [BANCO.canastoB.pos[0], 0.24, BANCO.canastoB.pos[2]];
+  const criollo = variedades[0];
+  const varA = variedades[4] || criollo;
+  const varB = variedades[8] || criollo;
+  return [
+    { id: 'siembra', curva: curvaFlujo(bocaFrasco, tierra, 0.55), color: criollo.color },
+    { id: 'vuelve', curva: curvaFlujo(tierra, bocaFrasco, 0.95), color: criollo.color },
+    { id: 'trueque-ida', curva: curvaFlujo(bordeA, bordeB, 0.5), color: varA.color },
+    { id: 'trueque-vuelta', curva: curvaFlujo(bordeB, bordeA, 0.8), color: varB.color },
+  ];
+}
+
+/** Las partículas de un flujo (fases y tamaños deterministas). */
+export function particulasDeFlujo(n, seed = 41) {
+  const r = rng(seed);
+  const out = [];
+  for (let i = 0; i < n; i += 1) {
+    out.push({
+      t0: i / n + r() * 0.04, // repartidas a lo largo, con respiro
+      vel: 0.085 + r() * 0.035, // lento: semilla que viaja, no bala
+      tam: 0.8 + r() * 0.5,
+    });
+  }
+  return out;
+}
+
+/* ------------------------------------------------------------------ */
+/* LA MATA MADRE — el parche de maíz con UNA mata marcada viva.         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Las matas del parche: tres del montón y LA madre (más alta, más pareja,
+ * con su mazorca y su cinta). Deterministas.
+ * @returns {Array<{ x:number, z:number, alto:number, lean:number, madre:boolean }>}
+ */
+export function matasDelParche(seed = 53) {
+  const r = rng(seed);
+  const { pos, radio } = BANCO.parche;
+  const puestos = [
+    [-0.55, 0.3], [0.5, 0.42], [0.42, -0.5], [-0.12, -0.1], // la madre, al centro-frente
+  ];
+  return puestos.map(([dx, dz], i) => {
+    const madre = i === 3;
+    return {
+      x: pos[0] + dx * radio,
+      z: pos[2] + dz * radio,
+      alto: madre ? 1.2 : 0.62 + r() * 0.18,
+      lean: madre ? 0.04 : (r() - 0.5) * 0.3, // las del montón se ladean; la madre, derecha
+      madre,
+    };
+  });
+}
+
+/** Los brotecitos del surco (la criolla sembrada, naciendo). */
+export function brotesDelSurco(seed = 61) {
+  const r = rng(seed);
+  const { pos, largo } = BANCO.surco;
+  const brotes = [];
+  for (let i = 0; i < 3; i += 1) {
+    brotes.push({
+      x: pos[0] - largo / 2 + (largo / 3) * (i + 0.5),
+      z: pos[2] + (r() - 0.5) * 0.1,
+      alto: 0.12 + r() * 0.08,
+      rot: r() * Math.PI,
+    });
+  }
+  return brotes;
+}

--- a/src/visual/mundo3d/semillas/semillasData.js
+++ b/src/visual/mundo3d/semillas/semillasData.js
@@ -1,0 +1,250 @@
+/*
+ * semillasData — el BANCO DE SEMILLAS CRIOLLAS en datos (three-free).
+ *
+ * La soberanía alimentaria es razón de ser de Chagra, y la semilla es su
+ * corazón: quien guarda su semilla no depende de nadie. Este módulo es la
+ * MEMORIA del banco: las variedades del mosaico (papas de colores, fríjoles
+ * de mil pintas, maíces de la cordillera), los textos en usted y los
+ * hotspots que la escena 3D (`EscenaBancoSemillas.jsx`) vuelve materia.
+ *
+ * REGLAS DE LA CASA que este archivo honra:
+ *   - Ni un hex inventado: todo color viene de la paleta madre o se deriva
+ *     con `mezclar` de un pariente aprobado (GUIA.md §1), con su porqué.
+ *   - SIN MORALINA: la criolla se muestra por su valor (se adapta a SU tierra,
+ *     se puede volver a sembrar), no regañando a quien compra certificada.
+ *   - Solo datos y derivaciones (nada por frame). OJO: importa `../paleta`,
+ *     que trae three por `mezclar` — cargar perezoso junto a la escena, como
+ *     todo lo de mundo3d.
+ *
+ * Fuente de contenido: corpus teacher-soberania (selección de mata madre,
+ *  secado, ceniza contra el gorgojo, custodios, casas de semillas, híbridos).
+ */
+import { ACENTOS, TIERRAS, VERDES, NEUTROS, mezclar } from '../paleta';
+import { PALETA_ANDINA } from '../artesaniaAndina.js';
+
+/* ------------------------------------------------------------------ */
+/* FORMAS de semilla: una sola esfera low-poly instanciada, escalada    */
+/* no-uniforme por forma. La silueta hace la especie, no la textura.    */
+/* ------------------------------------------------------------------ */
+export const FORMAS_SEMILLA = {
+  grano: [1, 0.72, 0.55], // el diente de maíz: ancho, achatado
+  rinon: [1.2, 0.68, 0.72], // el fríjol y el haba: alargado, panzudo
+  redonda: [1, 0.94, 1], // papa de semilla, arveja
+  menuda: [0.48, 0.4, 0.48], // quinua, amaranto: puntico de luz
+  pepa: [1.15, 0.32, 0.8], // ahuyama, ají: plana y ancha
+};
+
+/* ------------------------------------------------------------------ */
+/* EL MOSAICO — las variedades del banco. La variedad ES la riqueza:    */
+/* no una semilla, muchas. Cada frasco es una herencia con nombre.      */
+/* `color` es el grano; `pinta` (si hay) es el moteado del textil vivo. */
+/* Notas en usted, cortas, para tooltips — saber campesino, no cátedra. */
+/* ------------------------------------------------------------------ */
+export const VARIEDADES = [
+  {
+    id: 'maizAmarillo',
+    nombre: 'Maíz amarillo de la cordillera',
+    color: ACENTOS.maizGrano,
+    pinta: null,
+    forma: 'grano',
+    nota: 'El de las arepas de la casa. Guarde las mazorcas del centro de la mata madre.',
+  },
+  {
+    id: 'maizBlanco',
+    nombre: 'Maíz blanco harinoso',
+    /* grano lechoso: el hueso de la casa apenas entibiado hacia el maíz */
+    color: mezclar(NEUTROS.hueso, ACENTOS.maizGrano, 0.22),
+    pinta: null,
+    forma: 'grano',
+    nota: 'Harinoso, de mute y envuelto. Sesenta años de adaptación caben en un puño.',
+  },
+  {
+    id: 'maizMorado',
+    nombre: 'Maíz morado',
+    /* el índigo del mortiño con un dejo de cochinilla: grano de chicha */
+    color: mezclar(ACENTOS.indigo, ACENTOS.cochinilla, 0.28),
+    pinta: null,
+    forma: 'grano',
+    nota: 'El de la chicha. Si se pierde, no hay casa comercial que lo venda de vuelta.',
+  },
+  {
+    id: 'maizCapio',
+    nombre: 'Maíz rojo capio',
+    /* cochinilla aterrada: el rojo del grano curado, no el rojo de UI */
+    color: mezclar(ACENTOS.cochinilla, TIERRAS.cacao, 0.4),
+    pinta: null,
+    forma: 'grano',
+    nota: 'Rojo de tierra fría. En la misma mazorca a veces vienen tres colores.',
+  },
+  {
+    id: 'frijolCargamanto',
+    nombre: 'Fríjol cargamanto',
+    /* crema moteada: la cal de la pared apenas sonrojada… y sus mil pintas */
+    color: mezclar(NEUTROS.cal, ACENTOS.cochinilla, 0.22),
+    pinta: mezclar(ACENTOS.cochinilla, TIERRAS.cacao, 0.3),
+    forma: 'rinon',
+    nota: 'El de las mil pintas: no hay dos granos iguales, y todos son de la casa.',
+  },
+  {
+    id: 'frijolNegro',
+    nombre: 'Fríjol negro de vara',
+    color: NEUTROS.tinta,
+    pinta: null,
+    forma: 'rinon',
+    nota: 'Trepa por la caña del maíz: las dos semillas se guardan juntas.',
+  },
+  {
+    id: 'frijolRojo',
+    nombre: 'Fríjol rojo cerinza',
+    /* cochinilla honda, hacia la tinta: el rojo vino del grano seco */
+    color: mezclar(ACENTOS.cochinilla, NEUTROS.tinta, 0.3),
+    pinta: null,
+    forma: 'rinon',
+    nota: 'De ladera fría. Escoja la mata que cargó parejo, no el grano más grande del bulto.',
+  },
+  {
+    id: 'papaCriolla',
+    nombre: 'Papa criolla amarilla',
+    /* el maíz textil aterrado: la piel dorada de la criolla */
+    color: mezclar(ACENTOS.maizTextil, TIERRAS.camino, 0.34),
+    pinta: null,
+    forma: 'redonda',
+    nota: 'La semilla es el tubérculo sano de la mejor mata. Se guarda con luz difusa, que verdee.',
+  },
+  {
+    id: 'papaMorada',
+    nombre: 'Papa morada de páramo',
+    /* índigo con tierra de siembra: la piel morada, opaca, de altura */
+    color: mezclar(ACENTOS.indigo, TIERRAS.siembra, 0.36),
+    pinta: null,
+    forma: 'redonda',
+    nota: 'De las papas de colores que ya casi nadie siembra. Quien la guarda es biblioteca viva.',
+  },
+  {
+    id: 'quinua',
+    nombre: 'Quinua dorada',
+    /* la vega clara dorada hacia el grano: puntitos de sol */
+    color: mezclar(TIERRAS.vega, ACENTOS.maizGrano, 0.42),
+    pinta: null,
+    forma: 'menuda',
+    nota: 'Menuda y brava para el frío. Bien seca suena como arena fina: esa es la señal.',
+  },
+  {
+    id: 'arveja',
+    nombre: 'Arveja de enredo',
+    /* el brote secado hacia la vega: verde de grano curado, no de mata */
+    color: mezclar(VERDES.brote, TIERRAS.vega, 0.38),
+    pinta: null,
+    forma: 'redonda',
+    nota: 'Se deja secar en la mata, en la vaina, y se desgrana en la sombra.',
+  },
+  {
+    id: 'haba',
+    nombre: 'Haba de tierra fría',
+    color: TIERRAS.camino,
+    pinta: null,
+    forma: 'rinon',
+    nota: 'Grandota y noble. La vaina se cosecha ya parda, cuando cruje.',
+  },
+  {
+    id: 'ahuyama',
+    nombre: 'Ahuyama abuela',
+    /* la pepa plana, clara: cal dorada hacia el maíz */
+    color: mezclar(NEUTROS.cal, ACENTOS.maizGrano, 0.4),
+    pinta: null,
+    forma: 'pepa',
+    nota: 'Las pepas se lavan de la baba, se secan a la sombra y quedan para el otro año.',
+  },
+];
+
+/* La variedad por id (para hotspots y láminas). */
+export const variedadPorId = (id) => VARIEDADES.find((v) => v.id === id) || null;
+
+/* ------------------------------------------------------------------ */
+/* COLORES DE LA ESCENA derivados (con su porqué, jamás hex suelto).    */
+/* ------------------------------------------------------------------ */
+export const TINTES_BANCO = {
+  /* vasija de chamba: barro negro brillado — la tinta de la casa respirando
+     apenas hacia la terracota del horno (así se ve la chamba real) */
+  chamba: mezclar(NEUTROS.tinta, PALETA_ANDINA.terracota, 0.22),
+  /* ceniza contra el gorgojo: la cal apagada hacia el gris cálido de lámina */
+  ceniza: mezclar(NEUTROS.cal, NEUTROS.lamina, 0.45),
+  /* vidrio del frasco: el hueso de la casa, casi aire */
+  vidrio: NEUTROS.hueso,
+  /* corcho / tapa de totumo: madera clara hacia la vega */
+  corcho: mezclar(TIERRAS.vega, TIERRAS.camino, 0.5),
+  /* calabazo curado: la vega dorada hacia el maíz (totumo seco al humo) */
+  calabazo: mezclar(TIERRAS.vega, ACENTOS.maizGrano, 0.25),
+  /* fique sin teñir: el crudo del textil andino (artesaniaAndina) */
+  fique: PALETA_ANDINA.crudo,
+  /* el gorgojo: tinta cálida apenas aterrada (bicho de costal, no de terror) */
+  gorgojo: mezclar(NEUTROS.tinta, TIERRAS.turba, 0.35),
+  /* la cinta de la mata madre: LA cochinilla del textil — se ve de lejos */
+  cinta: ACENTOS.cochinilla,
+  /* bolsa de semilla certificada: lámina impresa, digna (sin burla) */
+  bolsa: NEUTROS.lamina,
+};
+
+/* ------------------------------------------------------------------ */
+/* TEXTOS — en usted, colombiano, sin moralina. La escena los sirve     */
+/* en hotspots; una lámina 2D puede servirlos igual.                    */
+/* ------------------------------------------------------------------ */
+export const TEXTOS_BANCO = {
+  titulo: 'El banco de semillas',
+  lema: 'La autonomía que cabe en un frasco.',
+  mosaico:
+    'Cada frasco es una herencia: papas de colores, fríjoles de mil pintas, maíces de la cordillera. La variedad ES la riqueza.',
+  mataMadre:
+    'La semilla no se escoge del bulto: se escoge LA MATA, viva, en el lote — la más sana, la que cargó parejo. Se marca con una cinta antes de cosechar.',
+  guardado:
+    'Seca, fresca y oscura: así se guarda. Frascos bien tapados, calabazos, costales de fique. Una capa de ceniza y el gorgojo se queda por fuera.',
+  trueque:
+    'La semilla circula, no se acumula: se cambia entre vecinos, se presta y se devuelve con creces. Así ha viajado la comida por la cordillera.',
+  criolla:
+    'La criolla se puede volver a sembrar: cada año se adapta más a SU tierra. De la híbrida no se guarda semilla — hay que comprarla otra vez. Las dos existen; saber la diferencia es la autonomía.',
+  custodios:
+    'Hay gente que guarda variedades que ya nadie siembra. Son bibliotecas vivas: sesenta años de ladera en un puñado de granos.',
+};
+
+/* ------------------------------------------------------------------ */
+/* HOTSPOTS por defecto — mismo contrato del framework de mundos        */
+/* ({ id, pos, label, view, data }); el host decide qué hace `view`.    */
+/* Posiciones en coordenadas de la escena (ver layout del .geom).       */
+/* ------------------------------------------------------------------ */
+export const HOTSPOTS_BANCO = [
+  {
+    id: 'mosaico',
+    pos: [-0.8, 2.62, -2.1],
+    label: 'Cada frasco es una herencia',
+    view: 'semillas-mosaico',
+    data: { texto: TEXTOS_BANCO.mosaico },
+  },
+  {
+    id: 'mata-madre',
+    pos: [3.45, 1.75, -0.5],
+    label: 'La mata madre se marca viva',
+    view: 'semillas-mata-madre',
+    data: { texto: TEXTOS_BANCO.mataMadre },
+  },
+  {
+    id: 'gorgojo',
+    pos: [-0.42, 0.95, -0.55],
+    label: 'La ceniza guarda, el gorgojo ronda',
+    view: 'semillas-guardado',
+    data: { texto: TEXTOS_BANCO.guardado },
+  },
+  {
+    id: 'trueque',
+    pos: [1.5, 1.05, 0.9],
+    label: 'La semilla circula',
+    view: 'semillas-trueque',
+    data: { texto: TEXTOS_BANCO.trueque },
+  },
+  {
+    id: 'criolla',
+    pos: [-3.0, 1.3, 0.55],
+    label: 'La criolla vuelve cada año',
+    view: 'semillas-criolla',
+    data: { texto: TEXTOS_BANCO.criolla },
+  },
+];


### PR DESCRIPTION
## Qué aporta

Rescata `fable/semillas-criollas-22` (2026-07-15), **VIVA** en el triaje (#6 en orden de valor). Mundo del banco de semillas criollas, 3 archivos: `EscenaBancoSemillas.jsx`, `bancoSemillas.geom.js`, `semillasData.js`.

Parte del lote de mundos autónomos del 2026-07-15 (junto a `biodigestor-15`, `olor-visible-16`, `red-bajo-glifosato-17`, `beneficos-21`).

## Por qué estaba perdida

Sin PR, nunca integrada a `dev`.

## Estado

- `npm run build` → **OK** (~1min).
- Merge sin conflictos — 3/3 archivos nuevos.
- Disponible pero **no cableado al router**.
- **NO mergeado.** Draft para revisión del operador.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>