### PR TITLE
rescate: fable/beneficos-21 — el ejército invisible que reemplaza al veneno

### DIFF
--- a/src/visual/mundo3d/beneficos/EscenaBeneficos.jsx
+++ b/src/visual/mundo3d/beneficos/EscenaBeneficos.jsx
@@ -1,0 +1,683 @@
+/*
+ * EscenaBeneficos — EL ESPEJO: el mismo cultivo con y sin su ejército.
+ *
+ * Dos parcelas gemelas de fríjol, lado a lado. El MISMO clima, la MISMA plaga,
+ * la MISMA semilla de siembra (los surcos son idénticos a propósito: si algo más
+ * cambiara, el campesino podría echarle la culpa a otra cosa). Cambia UNA
+ * decisión:
+ *
+ *   IZQUIERDA — tiene flores, refugio y algo de plaga siempre. No se fumiga.
+ *               El ejército llega solo y aplana la plaga ANTES del umbral.
+ *   DERECHA   — lote limpio, sin flores ni refugio. Al ver el primer bicho, se
+ *               fumiga de amplio espectro. Todo cae a cero… y después el pulgón,
+ *               que se reproduce rapidísimo, EXPLOTA sin nadie que lo pare.
+ *
+ * Nadie narra eso: lo dice la curva. Las poblaciones que se ven acá NO están
+ * animadas a mano — salen de `dinamicaPlaga.js`, que es un Lotka-Volterra con
+ * techo logístico. Si el modelo dijera otra cosa, la escena mostraría otra cosa.
+ * A un campesino que se juega la comida no se le hace propaganda.
+ *
+ * En primer plano, sobre una hoja, EL ARCO DE LA MARIQUITA: huevo → larva →
+ * pupa → adulto. Es la lección más rentable del mundo entero — el cocodrilito
+ * oscuro con manchas naranjas que todos matan ES la mariquita que todos quieren.
+ *
+ * REGISTRO: REALISTA (ver GUIA-RUBBERHOSE.md §1). Fauna secundaria, sin ojos de
+ * goma ni tinta ni line-boil. Los rubber-hose viven en `creatures/`.
+ *
+ * Tier-safe: 'alto' pleno (elenco completo, turno de noche, hongos, sombras de
+ * contacto); 'medio' frugal; 'bajo' la lección mínima y digna (larva + adulto +
+ * avispa + pulgón, sin noche ni hongos). Con `reducedMotion` el mundo monta
+ * QUIETO en su fotograma más elocuente: la semana 8, cuando la diferencia entre
+ * las dos parcelas ya es un abismo y no hace falta ver nada moverse.
+ *
+ * Un draw-call por especie (InstancedMesh + un material de vertex colors).
+ * Componente r3f: importa three → siempre perezoso, montado por un host que dé
+ * altura.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
+import * as THREE from 'three';
+import { LuzMadre, CIELOS, ATMOSFERA, mezclarCielo, crearMaterialVertexColors } from '../paleta/index.js';
+import { perfilDeTier } from '../deviceTier.js';
+/* La noche NO se improvisa atenuando el sol: la casa ya tiene su preset (luna
+   plata, relleno de fogata lejana, niebla que cierra el valle). Calcarlo a mano
+   sería justo la deriva que `paleta/` existe para eliminar. */
+import { CIELOS_HORA } from '../cielosHoraData.js';
+import {
+  PAL,
+  PARCELAS,
+  UMBRAL,
+  CICLO,
+  CUPO_POR_TIER,
+  ARCO_MARIQUITA,
+  elencoDeTier,
+  invisiblesDeTier,
+} from './beneficosIdentidad.js';
+import { espejo, muestra } from './dinamicaPlaga.js';
+import * as G from './beneficos.geom.js';
+
+const CSS = `
+.bnf-canvas { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 0; transition: opacity 0.8s ease; }
+.bnf-canvas--lista { opacity: 1; }
+@media (prefers-reduced-motion: reduce) { .bnf-canvas { transition: none; } }
+`;
+
+/* El fotograma congelado de reducedMotion: semana 8 de 12. Elegido porque es
+   donde la viva ya se dobló (plaga 0.28, ejército 0.53) y la limpia ya reventó
+   (plaga 0.90, ejército 0). Una sola imagen quieta y el pleito está contado. */
+const T_QUIETO = 8 / 12;
+
+/* -------------------------------------------------------------------------- */
+/*  Instanciado: un draw-call por especie                                      */
+/* -------------------------------------------------------------------------- */
+
+const _m4 = new THREE.Matrix4();
+const _q = new THREE.Quaternion();
+const _v = new THREE.Vector3();
+const _e = new THREE.Euler();
+
+/**
+ * Nube de bichos instanciada. `cuantos` viene de la dinámica: EL NÚMERO ES LA
+ * CURVA. No se escala un bicho gigante para "sentir" más plaga — se ponen más
+ * bichos, que es lo que pasa en la mata de verdad.
+ */
+function Nube({ geo, mat, sitios, cuantos, anim, reducedMotion, t }) {
+  const ref = useRef(null);
+  const n = Math.min(sitios.length, Math.max(0, Math.round(cuantos)));
+
+  const pintar = (tiempo) => {
+    const im = ref.current;
+    if (!im) return;
+    for (let i = 0; i < sitios.length; i++) {
+      const s = sitios[i];
+      if (i < n) {
+        const a = anim ? anim(s, i, tiempo) : null;
+        _v.set(s.pos[0] + (a ? a.dx : 0), s.pos[1] + (a ? a.dy : 0), s.pos[2] + (a ? a.dz : 0));
+        _e.set(0, (s.rot || 0) + (a ? a.giro : 0), 0);
+        _q.setFromEuler(_e);
+        const e = s.esc * (a ? a.esc : 1);
+        _m4.compose(_v, _q, { x: e, y: e, z: e });
+      } else {
+        /* Los que "no están" se mandan a escala cero: la población baja se ve
+           como AUSENCIA, no como bichos encogidos. */
+        _m4.makeScale(0, 0, 0);
+      }
+      im.setMatrixAt(i, _m4);
+    }
+    im.instanceMatrix.needsUpdate = true;
+  };
+
+  useEffect(() => {
+    pintar(reducedMotion ? T_QUIETO * CICLO.duracionSeg : 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [n, sitios, reducedMotion]);
+
+  useFrame(({ clock }) => {
+    if (reducedMotion || !anim) return;
+    pintar(clock.elapsedTime);
+  });
+
+  if (!geo || !sitios.length) return null;
+  return <instancedMesh ref={ref} args={[geo, mat, sitios.length]} frustumCulled={false} />;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  La columna del umbral: el gráfico hecho escultura (sin ejes ni números)     */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Una columna translúcida por parcela que SUBE con su plaga, y la banda del
+ * umbral cruzando las dos a la misma altura. Es lo más cerca de un "chart" que
+ * este mundo se permite, y se permite solo porque no tiene texto, ni ejes, ni
+ * números: es un nivel de agua. La viva trepa hacia la línea y se dobla antes;
+ * la limpia la atraviesa y se pone del rojo de la cereza.
+ *
+ * Ese cruce es el momento en que el campesino entiende, sin que nadie le diga,
+ * que el que fumigó terminó peor que el que no hizo nada.
+ */
+function ColumnaPlaga({ x, plaga, alto = 2.9 }) {
+  const nivel = Math.max(0.02, plaga) * alto;
+  const rota = plaga > UMBRAL.nivel;
+  return (
+    <group position={[x, 0.02, -2.6]}>
+      {/* El box unitario va de -0.5 a +0.5 en Y: se escala Y ANCLANDO la base al
+          suelo (position.y = nivel/2). Si no, la columna crecería para los dos
+          lados desde el aire y el "nivel de agua" no se leería. */}
+      <mesh position={[0, nivel / 2, 0]} scale={[1, nivel, 1]}>
+        <boxGeometry args={[0.34, 1, 0.34]} />
+        <meshBasicMaterial
+          color={rota ? PAL.umbralRoto : PAL.pulgonDenso}
+          transparent
+          opacity={0.5}
+          depthWrite={false}
+        />
+      </mesh>
+    </group>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  El veneno: lo ajeno al valle                                               */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La bomba de amplio espectro. Violeta-ceniza — un color que NO existe en la
+ * paleta andina, y esa es exactamente la idea. No se dibuja como un ataque
+ * espectacular: se dibuja como una veladura sucia que baja y lo apaga todo.
+ * Lo importante no es la nube, es lo que queda después: nada de los dos lados.
+ */
+function NieblaVeneno({ x, fuerza, reducedMotion }) {
+  const ref = useRef(null);
+  useFrame(({ clock }) => {
+    if (!ref.current || reducedMotion) return;
+    ref.current.position.y = 2.2 - Math.min(1, fuerza) * 1.4;
+    ref.current.rotation.y = clock.elapsedTime * 0.15;
+  });
+  if (fuerza <= 0.01) return null;
+  return (
+    <mesh ref={ref} position={[x, 1.6, 0]}>
+      <sphereGeometry args={[2.4, 8, 6]} />
+      <meshBasicMaterial
+        color={PAL.veneno}
+        transparent
+        opacity={Math.min(0.5, fuerza * 0.5)}
+        depthWrite={false}
+      />
+    </mesh>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL ARCO DE LA MARIQUITA — la lección, en primer plano                      */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Las cuatro etapas EN FILA sobre una hoja, a la misma escala y en orden. El ojo
+ * las recorre y aterriza en el bicho rojo que SÍ conoce — y en ese instante el
+ * cocodrilito de al lado deja de ser un gusano raro para siempre.
+ *
+ * Está al frente y en el centro, entre las dos parcelas, porque no le pertenece
+ * a ninguna: es lo que hay que saber ANTES de decidir. Y la larva va un poco más
+ * grande y más adelante que las otras tres: si el usuario mira una sola cosa de
+ * todo el mundo, que sea ella.
+ */
+function ArcoMariquita({ tier, mat, reducedMotion }) {
+  const ref = useRef(null);
+  const geos = useMemo(
+    () => ({
+      huevo: G.huevosMariquitaGeom(tier),
+      larva: G.larvaMariquitaGeom(tier),
+      pupa: G.pupaMariquitaGeom(tier),
+      adulto: G.mariquitaGeom(tier),
+    }),
+    [tier],
+  );
+  useEffect(() => () => Object.values(geos).forEach((g) => g && g.dispose()), [geos]);
+
+  /* La larva respira apenas y avanza un pelo: está comiendo, no posando. */
+  useFrame(({ clock }) => {
+    if (!ref.current || reducedMotion) return;
+    const t = clock.elapsedTime;
+    ref.current.position.z = 0.06 * Math.sin(t * 1.1);
+    ref.current.rotation.y = 0.08 * Math.sin(t * 0.7);
+  });
+
+  const paso = 0.62;
+  return (
+    <group position={[0, 0.12, 2.5]} rotation={[0, Math.PI, 0]}>
+      {/* LA HOJA: la tarima del arco. Un plano y nada más — todo el detalle que
+          este primer plano tiene para gastar se lo lleva la larva, no el
+          escenario. Que las cuatro etapas estén sobre la MISMA hoja es el punto:
+          es un solo bicho, no cuatro bichos distintos. */}
+      <mesh position={[0, -0.06, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[3.1, 1.15]} />
+        <meshLambertMaterial color={PAL.hoja} side={THREE.DoubleSide} />
+      </mesh>
+      {ARCO_MARIQUITA.map((e, i) => {
+        const x = (i - 1.5) * paso;
+        const esProta = e.protagonista;
+        const geo = geos[e.etapa === 'huevo' ? 'huevo' : e.etapa === 'adulto' ? 'adulto' : e.etapa];
+        if (!geo) return null;
+        return (
+          <group key={e.etapa} position={[x, 0, esProta ? -0.14 : 0]}>
+            <mesh
+              ref={esProta ? ref : undefined}
+              geometry={geo}
+              material={mat}
+              scale={esProta ? 0.42 : 0.34}
+              rotation={[0, esProta ? 0.3 : 0, 0]}
+            />
+          </group>
+        );
+      })}
+    </group>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Una parcela                                                                */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * EL TALLER — las geometrías se tallan UNA vez para todo el mundo.
+ *
+ * Las dos parcelas dibujan los mismos bichos: si cada una tallara los suyos,
+ * habría dos larvas de mariquita, dos pulgones, dos de cada cosa en memoria —
+ * el doble de geometría para dibujar exactamente lo mismo. En el teléfono para
+ * el que esto está hecho, eso no es un detalle. Se talla acá, se comparte allá,
+ * y cada parcela solo pone SUS matrices (que es lo único que de verdad difiere).
+ *
+ * Lo único que NO entra al taller es la mata: su forma depende de la SALUD, que
+ * es justamente lo que cambia entre parcelas. Esa sí es propia de cada una.
+ */
+function useTaller(tier) {
+  const taller = useMemo(() => {
+    const fAliado = {
+      'larva-mariquita': G.larvaMariquitaGeom,
+      mariquita: G.mariquitaGeom,
+      'crisopa-larva': G.larvaCrisopaGeom,
+      crisopa: G.crisopaGeom,
+      'avispa-parasitoide': G.avispaGeom,
+      'sirfido-larva': G.larvaSirfidoGeom,
+      arana: G.aranaGeom,
+      tijereta: G.tijeretaGeom,
+      carabido: G.carabidoGeom,
+      ave: G.aveGeom,
+      murcielago: G.murcielagoGeom,
+    };
+    const aliados = {};
+    elencoDeTier(tier).forEach((a) => {
+      if (fAliado[a.slug]) aliados[a.slug] = fAliado[a.slug](tier);
+    });
+    return {
+      aliados,
+      /* las dos caras del pulgón: colonia rala y colonia apretada */
+      pulgon: G.pulgonGeom(tier, false),
+      pulgonDenso: G.pulgonGeom(tier, true),
+      momia: G.momiaGeom(tier),
+      pedicelo: tier !== 'bajo' ? G.crisopaHuevosGeom(tier) : null,
+      flores: G.floresGeom(tier, 7, 14),
+      rastrojo: G.rastrojoGeom(tier, 21),
+      alambre: G.alambreGeom(tier),
+    };
+  }, [tier]);
+
+  useEffect(
+    () => () => {
+      Object.values(taller.aliados).forEach((g) => g && g.dispose());
+      [taller.pulgon, taller.pulgonDenso, taller.momia, taller.pedicelo, taller.flores, taller.rastrojo, taller.alambre].forEach(
+        (g) => g && g.dispose(),
+      );
+    },
+    [taller],
+  );
+
+  return taller;
+}
+
+function Parcela({ parcela, estado, tier, mat, perfil, reducedMotion, esNoche, taller }) {
+  const cupo = CUPO_POR_TIER[tier] || CUPO_POR_TIER.medio;
+  const lado = parcela.lado;
+  const conHabitat = parcela.habitat.length > 0;
+
+  /* Las matas: gemelas en las dos parcelas (misma semilla). Lo único que cambia
+     es su SALUD, que baja con la plaga — el daño se ve en la hoja, no en un
+     número. */
+  const salud = Math.max(0.35, 1 - estado.plaga * 0.75);
+  const sitiosMata = useMemo(() => G.sembrarMatas(lado), [lado]);
+  const geoMata = useMemo(
+    () => G.mataGeom(tier, 42, Math.round(salud * 4) / 4),
+    /* la salud se cuantiza en pasos de 1/4: la mata no se re-genera cada frame */
+    [tier, Math.round(salud * 4)],
+  );
+
+  /* El borde: flores + rastrojo (viva) o alambre pelado (limpia). LA TRIADA
+     dibujada — y su ausencia también dibujada. Del taller, no talladas acá. */
+  const geoBorde = conHabitat ? taller.flores : null;
+  const geoFondo = conHabitat ? taller.rastrojo : taller.alambre;
+
+  /* EL PULGÓN: su número ES la curva de la dinámica. La colonia se ve APRETADA
+     (más oscura) cuando pasa de media: el color también es dato. */
+  const geoPulgon = estado.plaga > 0.5 ? taller.pulgonDenso : taller.pulgon;
+  const sitiosPulgon = useMemo(() => {
+    const out = [];
+    sitiosMata.forEach((m, k) => {
+      G.sembrarPulgon(Math.ceil(cupo.pulgonMax / sitiosMata.length), 5 + k).forEach((s) => {
+        out.push({ ...s, pos: [m.pos[0] + s.pos[0], s.pos[1], m.pos[2] + s.pos[2]] });
+      });
+    });
+    return out;
+  }, [sitiosMata, cupo.pulgonMax]);
+
+  /* EL EJÉRCITO: idem — el número de aliados es la otra curva. */
+  const elenco = useMemo(() => elencoDeTier(tier), [tier]);
+  const enTurno = useMemo(
+    () => elenco.filter((a) => a.turno === 'siempre' || (esNoche ? a.turno === 'noche' : a.turno === 'dia')),
+    [elenco, esNoche],
+  );
+
+  const geosAliado = taller.aliados;
+
+  /* Dónde trabaja cada aliado. Determinista y con sentido: los de suelo abajo,
+     los voladores arriba, los de hoja en la mata. Nadie flota porque sí. */
+  const sitiosAliado = useMemo(() => {
+    const out = {};
+    const r = G.rng(909 + lado * 17);
+    enTurno.forEach((a) => {
+      const cuantos = Math.ceil(cupo.aliadosMax / Math.max(1, enTurno.length));
+      const arr = [];
+      for (let i = 0; i < cuantos; i++) {
+        const m = sitiosMata[Math.floor(r() * sitiosMata.length)];
+        const suelo = a.slug === 'carabido' || a.slug === 'tijereta';
+        const vuela = a.slug === 'ave' || a.slug === 'murcielago';
+        arr.push({
+          pos: vuela
+            ? [m.pos[0] + (r() - 0.5) * 2, 2.6 + r() * 0.8, m.pos[2] + (r() - 0.5) * 2]
+            : suelo
+              ? [m.pos[0] + (r() - 0.5) * 0.8, 0.08, m.pos[2] + (r() - 0.5) * 0.8]
+              : [m.pos[0] + (r() - 0.5) * 0.5, 0.9 + r() * 0.6, m.pos[2] + (r() - 0.5) * 0.5],
+          rot: r() * Math.PI * 2,
+          esc: (a.largo / 1.5) * (vuela ? 0.5 : 0.42),
+          fase: r() * Math.PI * 2,
+        });
+      }
+      out[a.slug] = arr;
+    });
+    return out;
+  }, [enTurno, sitiosMata, cupo.aliadosMax, lado]);
+
+  /* LA MOMIA y los huevos con pedicelo: solo donde hay ejército. Son la PRUEBA
+     física de que alguien trabajó — por eso no aparecen jamás en la parcela
+     fumigada, aunque quedarían lindos. */
+  const geoMomia = conHabitat ? taller.momia : null;
+  const geoPedicelo = conHabitat ? taller.pedicelo : null;
+
+  /* Solo se libera lo PROPIO de esta parcela (la mata, que depende de su salud).
+     Lo del taller lo libera el taller: liberar acá una geometría COMPARTIDA
+     dejaría a la otra parcela dibujando un buffer muerto. */
+  useEffect(() => () => geoMata && geoMata.dispose(), [geoMata]);
+
+  /* El vaivén de los bichos: cada uno con su fase (nada de metrónomo). */
+  const animPulgon = (s, i, t) => ({
+    dx: 0,
+    dy: Math.sin(t * 0.8 + i) * 0.004,
+    dz: 0,
+    giro: 0,
+    esc: 1,
+  });
+  const animAliado = (s, i, t) => {
+    const f = s.fase || 0;
+    return {
+      dx: Math.sin(t * 0.55 + f) * 0.14,
+      dy: Math.sin(t * 0.9 + f * 1.7) * 0.05,
+      dz: Math.cos(t * 0.5 + f) * 0.14,
+      giro: Math.sin(t * 0.3 + f) * 0.6,
+      esc: 1,
+    };
+  };
+
+  const nPulgon = estado.plaga * cupo.pulgonMax;
+  const centro = lado * 3.1;
+
+  return (
+    <group>
+      {/* el suelo de la parcela: vivo y oscuro (con materia orgánica) o pelado */}
+      <mesh position={[centro, 0, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow={perfil.sombras}>
+        <planeGeometry args={[4.4, 5.4]} />
+        <meshLambertMaterial color={conHabitat ? PAL.sueloVivo : PAL.sueloPelado} />
+      </mesh>
+
+      {/* las matas gemelas */}
+      {geoMata &&
+        sitiosMata.map((m, i) => (
+          <mesh
+            key={i}
+            geometry={geoMata}
+            material={mat}
+            position={m.pos}
+            rotation={[0, (i * 1.7) % (Math.PI * 2), 0]}
+            castShadow={perfil.sombras}
+          />
+        ))}
+
+      {/* EL BORDE FLORIDO (o su ausencia) */}
+      {geoBorde && <mesh geometry={geoBorde} material={mat} position={[centro, 0, 2.3]} />}
+      {geoFondo && <mesh geometry={geoFondo} material={mat} position={[centro, 0, -2.4]} />}
+
+      {/* LA PLAGA — el número es la curva */}
+      <Nube
+        geo={geoPulgon}
+        mat={mat}
+        sitios={sitiosPulgon}
+        cuantos={nPulgon}
+        anim={animPulgon}
+        reducedMotion={reducedMotion}
+      />
+
+      {/* EL EJÉRCITO — la otra curva */}
+      {enTurno.map((a) => (
+        <Nube
+          key={a.slug}
+          geo={geosAliado[a.slug]}
+          mat={mat}
+          sitios={sitiosAliado[a.slug] || []}
+          cuantos={estado.ejercito * (sitiosAliado[a.slug] || []).length}
+          anim={animAliado}
+          reducedMotion={reducedMotion}
+        />
+      ))}
+
+      {/* LA PRUEBA: la momia y los alfileres de la crisopa */}
+      {geoMomia && estado.ejercito > 0.2 && (
+        <mesh geometry={geoMomia} material={mat} position={[centro - 0.4, 1.25, 0.5]} scale={0.42} />
+      )}
+      {geoPedicelo && estado.ejercito > 0.3 && (
+        <mesh geometry={geoPedicelo} material={mat} position={[centro + 0.5, 1.15, -0.4]} scale={0.8} />
+      )}
+    </group>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Los invisibles: el hongo que se come al bicho                              */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Van SIEMPRE del lado vivo, y no por simetría: un hongo entomopatógeno vive en
+ * un suelo con materia orgánica y muere en un lote esterilizado a punta de
+ * químico. Que solo estén de un lado ES el dato.
+ */
+function Invisibles({ tier, mat, lado }) {
+  const lista = useMemo(() => invisiblesDeTier(tier), [tier]);
+  const geos = useMemo(() => {
+    const f = {
+      beauveria: G.beauveriaGeom,
+      metarhizium: G.metarhiziumGeom,
+      trichoderma: G.trichodermaGeom,
+    };
+    const out = {};
+    lista.forEach((h) => {
+      if (f[h.slug]) out[h.slug] = f[h.slug](tier);
+    });
+    return out;
+  }, [lista, tier]);
+  useEffect(() => () => Object.values(geos).forEach((g) => g && g.dispose()), [geos]);
+
+  const sitios = {
+    /* la broca cubierta de blanco: en la mata, donde el cafetero la ve */
+    beauveria: { pos: [lado * 4.4, 1.0, 1.5], esc: 0.55 },
+    /* Metarhizium: BAJO el suelo, que es donde pelea (la chiza come raíz) */
+    metarhizium: { pos: [lado * 2.2, 0.12, 2.0], esc: 0.5 },
+    /* Trichoderma: en la raíz de la plántula del semillero */
+    trichoderma: { pos: [lado * 4.6, 0.75, 2.5], esc: 0.7 },
+  };
+
+  return (
+    <group>
+      {lista.map((h) => {
+        const g = geos[h.slug];
+        const s = sitios[h.slug];
+        if (!g || !s) return null;
+        return <mesh key={h.slug} geometry={g} material={mat} position={s.pos} scale={s.esc} />;
+      })}
+    </group>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  El mundo                                                                   */
+/* -------------------------------------------------------------------------- */
+
+function Mundo({ tier, reducedMotion }) {
+  const perfil = useMemo(() => perfilDeTier(tier), [tier]);
+  /* UN material para TODO el mundo: vertex colors + merge/instancing = el
+     mundo entero cabe en un puñado de draw-calls. */
+  const mat = useMemo(() => crearMaterialVertexColors(perfil), [perfil]);
+  useEffect(() => () => mat.dispose(), [mat]);
+
+  /* las geometrías, talladas una sola vez y compartidas por las dos parcelas */
+  const taller = useTaller(tier);
+
+  /* LAS DOS SERIES: el modelo corre una vez, no por frame. */
+  const series = useMemo(() => espejo({ semanas: CICLO.semanas, fumigaSemana: 3 }), []);
+
+  /*
+   * EL RELOJ, CUANTIZADO — y esto NO es una optimización cosmética.
+   *
+   * `t` gobierna cuántos bichos hay, o sea el árbol entero. Si se hiciera
+   * `setT` en cada frame, React re-renderizaría todo el mundo 60 veces por
+   * segundo en un teléfono de gama baja: inaceptable en el aparato para el que
+   * esto está hecho. Se avanza en PASOS (≈3 re-renders/seg) y la vida continua
+   * —el vaivén de cada bicho— la ponen los `useFrame` de las Nubes, que mueven
+   * matrices sin tocar React. El ojo ve movimiento fluido; React ve casi nada.
+   */
+  const PASOS = 90;
+  const [paso, setPaso] = useState(reducedMotion ? Math.round(T_QUIETO * PASOS) : 0);
+  useFrame(({ clock }) => {
+    if (reducedMotion) return;
+    const p = Math.floor(((clock.elapsedTime % CICLO.duracionSeg) / CICLO.duracionSeg) * PASOS);
+    setPaso((prev) => (prev === p ? prev : p));
+  });
+  const t = paso / PASOS;
+
+  const viva = muestra(series.viva, t);
+  const limpia = muestra(series.limpia, t);
+
+  /* El día y la noche corren más rápido que las semanas: así el turno de noche
+     alcanza a mostrarse sin volver el mundo un estroboscopio. */
+  const faseDia = (t * CICLO.diasPorCiclo) % 1;
+  const esNoche = faseDia > 0.62;
+
+  /* La bomba: un fogonazo corto y una veladura que decae. */
+  const semanaFumiga = 3;
+  const tFumiga = semanaFumiga / CICLO.semanas;
+  const desde = t - tFumiga;
+  const fuerzaVeneno = desde > 0 && desde < 0.22 ? 1 - desde / 0.22 : 0;
+
+  /* El cielo de la hora: de día la madre (hora dorada), de noche el preset
+     canónico. `mezclarCielo` aplica la ley 60%-hacia-la-madre, igual que
+     EscenaBase3D — así este mundo es hijo del mismo valle que los demás. */
+  const madre = esNoche ? CIELOS_HORA.noche : ATMOSFERA;
+  const cielo = useMemo(() => mezclarCielo(CIELOS.ladera, madre), [madre]);
+  const geoBanda = useMemo(() => G.bandaUmbralGeom(9.2), []);
+  const geoTicks = useMemo(() => (tier === 'alto' ? G.ticksUmbralGeom(9.2) : null), [tier]);
+  useEffect(
+    () => () => {
+      geoBanda && geoBanda.dispose();
+      geoTicks && geoTicks.dispose();
+    },
+    [geoBanda, geoTicks],
+  );
+
+  const alturaCol = 2.9;
+
+  return (
+    <>
+      <color attach="background" args={[cielo.fondo]} />
+      {perfil.fog && (
+        <fog
+          attach="fog"
+          args={[cielo.niebla, madre.nieblaCerca ?? 10, madre.nieblaLejos ?? 34]}
+        />
+      )}
+      <LuzMadre madre={madre} cielo={CIELOS.ladera} perfil={perfil} />
+
+      {/* el camino que separa: el mismo mundo, dos decisiones */}
+      <mesh position={[0, 0.005, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[1.3, 5.4]} />
+        <meshLambertMaterial color={PAL.suelo} />
+      </mesh>
+
+      {PARCELAS.map((p) => (
+        <Parcela
+          key={p.id}
+          parcela={p}
+          estado={p.id === 'viva' ? viva : limpia}
+          tier={tier}
+          mat={mat}
+          perfil={perfil}
+          reducedMotion={reducedMotion}
+          esNoche={esNoche}
+          taller={taller}
+        />
+      ))}
+
+      {/* los hongos: solo donde el suelo está vivo */}
+      <Invisibles tier={tier} mat={mat} lado={-1} />
+
+      {/* EL UMBRAL: la MISMA línea para las dos. Ahí está todo el rigor. */}
+      <mesh geometry={geoBanda} material={mat} position={[0, UMBRAL.nivel * alturaCol, -2.6]} />
+      {geoTicks && (
+        <mesh geometry={geoTicks} material={mat} position={[0, UMBRAL.nivel * alturaCol, -2.6]} />
+      )}
+      <ColumnaPlaga x={-3.1} plaga={viva.plaga} alto={alturaCol} />
+      <ColumnaPlaga x={3.1} plaga={limpia.plaga} alto={alturaCol} />
+
+      {/* la bomba, sobre la parcela limpia y solo sobre ella */}
+      <NieblaVeneno x={3.1} fuerza={fuerzaVeneno} reducedMotion={reducedMotion} />
+
+      {/* LA LECCIÓN, al frente y en el medio: no le pertenece a ninguna parcela */}
+      <ArcoMariquita tier={tier} mat={mat} reducedMotion={reducedMotion} />
+    </>
+  );
+}
+
+/**
+ * El mundo de los benéficos. Montar dentro de un host que provea altura.
+ *
+ * @param {{tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ */
+export default function EscenaBeneficos({ tier = 'medio', reducedMotion = false }) {
+  const [lista, setLista] = useState(false);
+  const perfil = useMemo(() => perfilDeTier(tier), [tier]);
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setLista(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  return (
+    <>
+      <style>{CSS}</style>
+      <Canvas
+        className={`bnf-canvas${lista ? ' bnf-canvas--lista' : ''}`}
+        dpr={perfil.dpr}
+        gl={{ antialias: perfil.antialias, powerPreference: 'low-power' }}
+        shadows={perfil.sombras}
+        camera={{ position: [0, 3.4, 8.6], fov: 42 }}
+        /* Con reducedMotion el mundo monta QUIETO: se dibuja una vez y se calla. */
+        frameloop={reducedMotion ? 'demand' : 'always'}
+      >
+        <Mundo tier={tier} reducedMotion={reducedMotion} />
+        <AdaptiveDpr pixelated />
+        <OrbitControls
+          enablePan={false}
+          minDistance={4}
+          maxDistance={14}
+          maxPolarAngle={Math.PI / 2.15}
+          enableDamping={!reducedMotion}
+        />
+      </Canvas>
+    </>
+  );
+}

--- a/src/visual/mundo3d/beneficos/beneficos.geom.js
+++ b/src/visual/mundo3d/beneficos/beneficos.geom.js
@@ -1,0 +1,967 @@
+/*
+ * beneficos.geom — LA GEOMETRÍA DEL EJÉRCITO INVISIBLE, en funciones PURAS.
+ *
+ * three-core, corre headless: cero contexto GL, cero azar por frame (PRNG con
+ * semilla), cero assets externos. La escena (`EscenaBeneficos.jsx`) le pone luz,
+ * cadencia y la dinámica de `dinamicaPlaga.js`; acá solo vive la FORMA.
+ *
+ * ── REGISTRO: REALISTA (ver GUIA-RUBBERHOSE.md §1) ─────────────────────────
+ * Esto es fauna secundaria del monte, no personajes. Por construcción, en este
+ * archivo NO hay: ojos de goma, catchlight, contorno de tinta, chapetas,
+ * sonrisas, ni miembros-manguera. Hay proporciones de bicho. El único ojo que
+ * se dibuja es el de la crisopa (dorado, hemisférico, compuesto — anatomía, no
+ * expresión) y el de los vertebrados, que son puntos oscuros sin brillo.
+ * Si alguien viene a "darles vida" con una carita, está en el archivo
+ * equivocado: eso vive en `creatures/`.
+ *
+ * ── LA REGLA DE ORO DEL DIBUJO ─────────────────────────────────────────────
+ * Cada bicho se dibuja por su OFICIO, y el rasgo que lo hace reconocible en
+ * campo manda sobre lo bonito:
+ *   · la larva de mariquita → SEGMENTADA Y ALARGADA, con las manchas naranjas
+ *     que el campesino tiene que aprender a ver. Es la protagonista.
+ *   · la crisopa → sus huevos CON PEDICELO, que parecen alfileres.
+ *   · la avispa → la CINTURA y el ovipositor; y su obra: LA MOMIA.
+ *   · el sírfido → acá SOLO la larva (el adulto vive en `polinizadores/`).
+ *   · Beauveria → la PELUSA BLANCA que cubre; Metarhizium → el VERDE.
+ *
+ * ── GAMA BAJA (el teléfono del campesino manda) ────────────────────────────
+ * Todo es low-poly con vertex colors, para que la escena pueda fusionar
+ * (`mergeGeometries`) o instanciar (`InstancedMesh`) y bajar a ~1 draw-call por
+ * especie con UN material (`crearMaterialVertexColors`). Ninguna geometría de
+ * acá pasa de unas decenas de triángulos: son bichos de 3mm vistos de cerca, no
+ * héroes de cinemática. Los segmentos se piden por `det` (detalle por tier).
+ */
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { PAL } from './beneficosIdentidad.js';
+
+/* -------------------------------------------------------------------------- */
+/*  Utilidades                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/** PRNG determinista (misma huerta en cada carga; nada de Math.random). */
+export function rng(seed) {
+  let s = (seed >>> 0) || 1;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+/** Detalle por tier: los segmentos de las primitivas. */
+export const DET = {
+  alto: { rad: 8, alt: 6, tubo: 6 },
+  medio: { rad: 6, alt: 4, tubo: 4 },
+  bajo: { rad: 5, alt: 3, tubo: 3 },
+};
+export const detDeTier = (tier) => DET[tier] || DET.medio;
+
+/**
+ * Pinta una geometría entera de un color (crea el atributo `color`).
+ * Es lo que permite que 40 bichos distintos compartan UN material.
+ */
+export function pintar(geo, color) {
+  const c = new THREE.Color(color);
+  const n = geo.attributes.position.count;
+  const arr = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    arr[i * 3] = c.r;
+    arr[i * 3 + 1] = c.g;
+    arr[i * 3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(arr, 3));
+  return geo;
+}
+
+/** Coloca una geometría (escala → rota → traslada) y la devuelve. */
+export function poner(geo, { pos = [0, 0, 0], rot = [0, 0, 0], esc = [1, 1, 1] } = {}) {
+  const e = Array.isArray(esc) ? esc : [esc, esc, esc];
+  geo.scale(e[0], e[1], e[2]);
+  if (rot[0]) geo.rotateX(rot[0]);
+  if (rot[1]) geo.rotateY(rot[1]);
+  if (rot[2]) geo.rotateZ(rot[2]);
+  geo.translate(pos[0], pos[1], pos[2]);
+  return geo;
+}
+
+/** Fusiona piezas ya pintadas en una sola malla (el patrón floraParamo). */
+export function fundir(piezas) {
+  const buenas = piezas.filter(Boolean).map((g) => (g.index ? g.toNonIndexed() : g));
+  if (!buenas.length) return null;
+  /* Sin `color` en todas, el merge devuelve null: se pinta ANTES de fundir. */
+  return mergeGeometries(buenas, false);
+}
+
+/* Primitivas cortas, para que el dibujo se lea y no el boilerplate. */
+const esfera = (r, d, c) => pintar(new THREE.SphereGeometry(r, d.rad, d.alt), c);
+const capsula = (r, l, d, c) => pintar(new THREE.CapsuleGeometry(r, l, 2, d.rad), c);
+const cono = (r, h, d, c) => pintar(new THREE.ConeGeometry(r, h, d.rad), c);
+const cilindro = (r1, r2, h, d, c) =>
+  pintar(new THREE.CylinderGeometry(r1, r2, h, Math.max(3, d.tubo)), c);
+const plano = (w, h, c) => pintar(new THREE.PlaneGeometry(w, h), c);
+const disco = (r, d, c) => pintar(new THREE.CircleGeometry(r, d.rad), c);
+
+/* -------------------------------------------------------------------------- */
+/*  LA PLAGA — el pulgón (la presa, y también la despensa)                     */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Cuerpo de pera, blando, sin dureza, con los dos CORNÍCULOS traseros (los
+ * tubitos que lo delatan como áfido) y las patas apenas insinuadas. Es
+ * deliberadamente ANODINO: el pulgón no es el malo de una película, es un bicho
+ * que hace lo suyo. El drama no lo pone su cara: lo pone SU NÚMERO.
+ */
+export function pulgonGeom(tier = 'medio', denso = false) {
+  const d = detDeTier(tier);
+  const col = denso ? PAL.pulgonDenso : PAL.pulgon;
+  const p = [
+    poner(esfera(0.5, d, col), { esc: [0.82, 0.78, 1] }),
+    /* cabecita */
+    poner(esfera(0.26, d, col), { pos: [0, -0.04, 0.46] }),
+  ];
+  if (tier !== 'bajo') {
+    /* los cornículos: el rasgo de identificación del áfido */
+    p.push(
+      poner(cono(0.055, 0.24, d, col), { pos: [0.19, 0.16, -0.4], rot: [-0.5, 0, -0.2] }),
+      poner(cono(0.055, 0.24, d, col), { pos: [-0.19, 0.16, -0.4], rot: [-0.5, 0, 0.2] }),
+    );
+  }
+  return fundir(p);
+}
+
+/** La oruga (cogollero/medidor): el blanco del Bt y de la avispa. */
+export function orugaGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [];
+  const segs = tier === 'bajo' ? 5 : 8;
+  for (let i = 0; i < segs; i++) {
+    const t = i / (segs - 1);
+    /* Ahusada en las puntas, gorda en el medio: la silueta de oruga. */
+    const r = 0.3 * (0.55 + 0.45 * Math.sin(Math.PI * t));
+    p.push(poner(esfera(r, d, PAL.oruga), { pos: [0, 0, (t - 0.5) * 1.5] }));
+  }
+  return fundir(p);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LA PROTAGONISTA — la larva de mariquita (EL COCODRILITO)                   */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * ESTE ES EL DIBUJO MÁS IMPORTANTE DE TODO EL MUNDO.
+ *
+ * "Como un gusanito alargado y oscuro con manchas", "un cocodrilito negro con
+ * manchas naranjas, muy distinta al adulto redondo" — el campesino la ve, no la
+ * reconoce, y la mata. Está matando a la mariquita que más pulgón le come.
+ *
+ * Todo acá está al servicio de que se lea, se recuerde y no se confunda:
+ *   · SEGMENTADA y AHUSADA hacia la cola — la silueta de "cocodrilito", lo más
+ *     lejos posible del domo redondo del adulto. La confusión es el enemigo:
+ *     el dibujo tiene que gritar "NO me parezco a lo que vos conocés".
+ *   · TUBÉRCULOS laterales (las verruguitas erizadas de cada segmento): el
+ *     rasgo real que la hace ver "peligrosa" y que dispara el manotazo.
+ *   · LAS MANCHAS NARANJAS en dos pares de segmentos: la marca que hay que
+ *     aprender. Es LA información. Van en vertex color, no en textura, para que
+ *     sobrevivan intactas hasta el tier bajo — si algo se cae, las manchas no.
+ *   · Seis patas ágiles y visibles: esto CAMINA y CAZA, no repta como plaga.
+ *     La postura dice "depredador", no "gusano".
+ */
+export function larvaMariquitaGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [];
+  const segs = tier === 'bajo' ? 5 : 7;
+  const largo = 1.5;
+
+  for (let i = 0; i < segs; i++) {
+    const t = i / (segs - 1);
+    const z = (0.5 - t) * largo;
+    /* Ancho: gorda adelante, se va afilando a la cola (el "cocodrilito"). */
+    const r = 0.26 * (1 - 0.62 * t) * (i === 0 ? 0.86 : 1);
+    /* Los segmentos 2-3 y 5 llevan naranja (los pares de manchas). */
+    const esMancha = tier === 'bajo' ? i === 2 || i === 4 : i === 2 || i === 4;
+    const col = esMancha ? PAL.larvaMancha : PAL.larvaCuerpo;
+    p.push(poner(esfera(r, d, col), { pos: [0, 0, z], esc: [1.15, 0.9, 1] }));
+
+    /* TUBÉRCULOS: las verruguitas laterales erizadas de cada segmento. */
+    if (tier !== 'bajo' && i > 0 && i < segs - 1) {
+      const tc = esMancha ? PAL.larvaMancha : PAL.larvaCuerpo;
+      for (const s of [-1, 1]) {
+        p.push(
+          poner(cono(r * 0.34, r * 0.7, d, tc), {
+            pos: [s * r * 1.05, r * 0.34, z],
+            rot: [0, 0, (s * Math.PI) / 2.6],
+          }),
+        );
+      }
+    }
+  }
+
+  /* Cabeza: chata, oscura, con mandíbulas — la herramienta del oficio. */
+  p.push(poner(esfera(0.2, d, PAL.larvaCuerpo), { pos: [0, 0, largo * 0.5 + 0.1], esc: [1, 0.8, 1] }));
+  if (tier !== 'bajo') {
+    for (const s of [-1, 1]) {
+      p.push(
+        poner(cono(0.05, 0.19, d, PAL.larvaCuerpo), {
+          pos: [s * 0.08, 0, largo * 0.5 + 0.26],
+          rot: [Math.PI / 2, 0, s * 0.3],
+        }),
+      );
+    }
+  }
+
+  /* SEIS PATAS, adelante y bien plantadas: esto camina y caza. */
+  const patas = tier === 'bajo' ? 2 : 3;
+  for (let i = 0; i < patas; i++) {
+    const z = largo * 0.36 - i * 0.3;
+    for (const s of [-1, 1]) {
+      p.push(
+        poner(cilindro(0.032, 0.02, 0.34, d, PAL.larvaCuerpo), {
+          pos: [s * 0.26, -0.16, z],
+          rot: [0, 0, (s * Math.PI) / 3.4],
+        }),
+      );
+    }
+  }
+  return fundir(p);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL ARCO — huevo → larva → pupa → adulto (la lección, en una hoja)          */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La mariquita ADULTA: el domo rojo con puntos. La única que el campesino ya
+ * reconoce — y, en el reloj de su vida, la etapa MÁS CORTA. Se dibuja bien
+ * porque es el ancla: el ojo aterriza acá y entiende que el cocodrilito de al
+ * lado es el mismo bicho.
+ */
+export function mariquitaGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [];
+  /* Élitros: media esfera achatada (el domo inconfundible). */
+  const domo = new THREE.SphereGeometry(0.42, d.rad + 2, d.alt, 0, Math.PI * 2, 0, Math.PI / 2);
+  p.push(poner(pintar(domo, PAL.mariquita), { esc: [1, 0.72, 1.15] }));
+  /* Panza */
+  p.push(
+    poner(esfera(0.4, d, PAL.mariquitaPunto), { pos: [0, -0.02, 0], esc: [0.96, 0.3, 1.1] }),
+  );
+  /* Cabeza negra con el pronoto */
+  p.push(poner(esfera(0.17, d, PAL.mariquitaPunto), { pos: [0, 0.06, 0.42], esc: [1.2, 0.7, 0.8] }));
+
+  if (tier !== 'bajo') {
+    /* La sutura: la línea que parte los élitros en dos. */
+    p.push(poner(cilindro(0.012, 0.012, 0.8, d, PAL.mariquitaPunto), { pos: [0, 0.3, 0], rot: [Math.PI / 2, 0, 0] }));
+    /* LOS PUNTOS: tres por élitro, en domo. Sin puntos no es mariquita. */
+    const pts = [
+      [0.2, 0.24, 0.24],
+      [0.24, 0.2, -0.18],
+      [0.1, 0.32, 0.02],
+    ];
+    for (const [x, y, z] of pts) {
+      for (const s of [-1, 1]) {
+        p.push(poner(esfera(0.075, d, PAL.mariquitaPunto), { pos: [s * x, y, z], esc: [1, 0.4, 1] }));
+      }
+    }
+    /* Patitas */
+    for (let i = 0; i < 3; i++) {
+      for (const s of [-1, 1]) {
+        p.push(
+          poner(cilindro(0.025, 0.018, 0.24, d, PAL.mariquitaPunto), {
+            pos: [s * 0.3, -0.12, 0.22 - i * 0.22],
+            rot: [0, 0, (s * Math.PI) / 3.2],
+          }),
+        );
+      }
+    }
+  }
+  return fundir(p);
+}
+
+/*
+ * LOS HUEVOS: racimo de elipsoides PARADOS, amarillo-naranja, siempre junto a la
+ * colonia de pulgón — la madre le pone la mesa servida a la larva. Ese detalle
+ * (que estén JUNTO al pulgón) es información agronómica, no composición.
+ */
+export function huevosMariquitaGeom(tier = 'medio', n = 9) {
+  const d = detDeTier(tier);
+  const r = rng(1207);
+  const p = [];
+  const cuantos = tier === 'bajo' ? 5 : n;
+  for (let i = 0; i < cuantos; i++) {
+    const a = (i / cuantos) * Math.PI * 2;
+    const rad = 0.05 + r() * 0.07;
+    p.push(
+      poner(esfera(0.048, d, PAL.larvaMancha), {
+        pos: [Math.cos(a) * rad, 0.07, Math.sin(a) * rad],
+        rot: [r() * 0.3 - 0.15, 0, r() * 0.3 - 0.15],
+        esc: [1, 2.1, 1], // parados: así se ven en la hoja
+      }),
+    );
+  }
+  return fundir(p);
+}
+
+/*
+ * LA PUPA: quieta, pegada a la hoja, naranja con manchas oscuras. "Parece
+ * muerta: no la barra." Es el momento en que el campesino cree que hay basura
+ * en la hoja y la limpia — matando la mariquita justo antes de que emerja.
+ */
+export function pupaMariquitaGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [poner(esfera(0.3, d, PAL.mariquita), { esc: [0.9, 0.72, 1.3] })];
+  if (tier !== 'bajo') {
+    for (const z of [0.16, -0.06, -0.24]) {
+      p.push(poner(esfera(0.13, d, PAL.mariquitaPunto), { pos: [0, 0.16, z], esc: [1.5, 0.3, 0.6] }));
+    }
+  }
+  return fundir(p);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LA CRISOPA — y sus huevos con pedicelo (los alfileres)                     */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * La adulta: "alas verdes transparentes y cuerpo delicado", ojos dorados. No
+ * come plaga — come POLEN. Se dibuja frágil a propósito: es el argumento de las
+ * flores hecho cuerpo. Sin flor, esta no se queda, y sin ella no hay larvas.
+ */
+export function crisopaGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [
+    poner(capsula(0.07, 0.5, d, PAL.crisopaCuerpo), { rot: [Math.PI / 2, 0, 0] }),
+    poner(esfera(0.1, d, PAL.crisopaCuerpo), { pos: [0, 0, 0.32] }),
+  ];
+  /* Los ojos dorados: anatomía (ojo compuesto), NO expresión. Sin catchlight. */
+  for (const s of [-1, 1]) {
+    p.push(poner(esfera(0.05, d, PAL.crisopaOjo), { pos: [s * 0.07, 0.02, 0.36] }));
+  }
+  /* Cuatro alas venadas, largas, tejadas sobre el cuerpo. */
+  const alas = tier === 'bajo' ? [1] : [1, -1];
+  for (const lado of [-1, 1]) {
+    for (const par of alas) {
+      const ala = plano(0.62, 0.26, PAL.crisopaAla);
+      p.push(
+        poner(ala, {
+          pos: [lado * 0.24, 0.09 + (par === 1 ? 0.03 : 0), -0.05 + (par === 1 ? 0.06 : -0.08)],
+          rot: [Math.PI / 2 - 0.32, 0, lado * 0.28],
+        }),
+      );
+    }
+  }
+  if (tier !== 'bajo') {
+    /* Antenas largas: el gesto de la crisopa. */
+    for (const s of [-1, 1]) {
+      p.push(
+        poner(cilindro(0.012, 0.008, 0.4, d, PAL.crisopaCuerpo), {
+          pos: [s * 0.06, 0.06, 0.5],
+          rot: [1.25, 0, s * 0.25],
+        }),
+      );
+    }
+  }
+  return fundir(p);
+}
+
+/*
+ * LOS HUEVOS CON PEDICELO — ALFILERES CLAVADOS EN LA HOJA.
+ *
+ * De todo lo que la crisopa hace, esto es lo que el campesino SÍ puede ver a
+ * simple vista, y no tiene ni idea de qué es. Un hilito rígido de seda con una
+ * perla blanca en la punta. El pedicelo no es decorativo: mantiene al huevo
+ * lejos de las hormigas y de los hermanos recién nacidos, que son caníbales.
+ * Cuando alguien aprenda a reconocer ESTO en su hoja, este mundo ya sirvió.
+ */
+export function crisopaHuevosGeom(tier = 'medio', n = 5) {
+  const d = detDeTier(tier);
+  const r = rng(88);
+  const p = [];
+  const cuantos = tier === 'bajo' ? 3 : n;
+  for (let i = 0; i < cuantos; i++) {
+    const x = (i - (cuantos - 1) / 2) * 0.12 + (r() - 0.5) * 0.04;
+    const z = (r() - 0.5) * 0.1;
+    const alto = 0.3 + r() * 0.12;
+    const incl = (r() - 0.5) * 0.24;
+    /* el hilito */
+    p.push(
+      poner(cilindro(0.007, 0.005, alto, d, PAL.crisopaPedicelo), {
+        pos: [x, alto / 2, z],
+        rot: [0, 0, incl],
+      }),
+    );
+    /* la perla en la punta */
+    p.push(
+      poner(esfera(0.038, d, PAL.crisopaHuevo), {
+        pos: [x + Math.sin(incl) * alto, alto, z],
+        esc: [1, 1.5, 1],
+      }),
+    );
+  }
+  return fundir(p);
+}
+
+/** La larva de crisopa: el león de los áfidos. Mandíbulas de hoz enormes. */
+export function larvaCrisopaGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [];
+  const segs = tier === 'bajo' ? 4 : 6;
+  for (let i = 0; i < segs; i++) {
+    const t = i / (segs - 1);
+    const rr = 0.2 * (1 - 0.55 * t);
+    const col = i === 2 ? PAL.larvaMancha : PAL.crisopaCuerpo;
+    p.push(poner(esfera(rr, d, col), { pos: [0, 0, (0.5 - t) * 1.05], esc: [1.1, 0.85, 1] }));
+  }
+  /* LAS HOCES: por eso le dicen león. Curvas, hacia adelante, inconfundibles. */
+  for (const s of [-1, 1]) {
+    p.push(
+      poner(cono(0.04, 0.34, d, PAL.larvaCuerpo), {
+        pos: [s * 0.1, 0, 0.72],
+        rot: [Math.PI / 2.2, 0, s * 0.42],
+      }),
+    );
+  }
+  return fundir(p);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LA AVISPA PARASITOIDE — y LA MOMIA (su obra)                              */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Chiquita, negra con un dejo de miel, CINTURA marcada (el peciolo) y el
+ * ovipositor atrás. No pica a las personas: pone su huevo DENTRO de la plaga.
+ * Se dibuja pequeña de verdad — su invisibilidad es parte del argumento: es la
+ * que el amplio espectro borra sin que nadie se entere de lo que perdió.
+ */
+export function avispaGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [
+    /* cabeza */
+    poner(esfera(0.09, d, PAL.avispa), { pos: [0, 0, 0.26] }),
+    /* tórax */
+    poner(esfera(0.11, d, PAL.avispa), { pos: [0, 0, 0.08], esc: [1, 1, 1.3] }),
+    /* LA CINTURA: el peciolo finito. El rasgo de "avispa". */
+    poner(cilindro(0.022, 0.022, 0.12, d, PAL.avispa), { pos: [0, 0, -0.08], rot: [Math.PI / 2, 0, 0] }),
+    /* gáster */
+    poner(esfera(0.12, d, PAL.avispa), { pos: [0, 0, -0.24], esc: [0.85, 0.85, 1.4] }),
+  ];
+  if (tier !== 'bajo') {
+    /* el ovipositor: la jeringa con la que pone el huevo adentro */
+    p.push(
+      poner(cilindro(0.008, 0.004, 0.16, d, PAL.avispa), { pos: [0, -0.02, -0.44], rot: [Math.PI / 2, 0, 0] }),
+    );
+    /* alas */
+    for (const s of [-1, 1]) {
+      p.push(
+        poner(plano(0.34, 0.14, PAL.avispaAla), {
+          pos: [s * 0.14, 0.07, -0.02],
+          rot: [Math.PI / 2 - 0.25, 0, s * 0.3],
+        }),
+      );
+    }
+    /* antenas acodadas */
+    for (const s of [-1, 1]) {
+      p.push(
+        poner(cilindro(0.008, 0.006, 0.2, d, PAL.avispa), { pos: [s * 0.04, 0.05, 0.36], rot: [1.15, 0, s * 0.3] }),
+      );
+    }
+  }
+  return fundir(p);
+}
+
+/*
+ * ★ LA MOMIA ★ — lo más espectacular del control biológico, y lo que nadie mira.
+ *
+ * El pulgón parasitado se hincha, se pone RÍGIDO y BRONCE, y queda pegado a la
+ * hoja como una cáscara. Días después la avispa nueva le recorta una TAPA
+ * CIRCULAR perfecta y sale por ahí. Ese agujerito con tapa es una firma: si
+ * usted lo ve en su cultivo, es la prueba física de que un ejército que jamás
+ * vio le estuvo trabajando gratis.
+ *
+ * Se dibuja MÁS GRANDE que el pulgón vivo (está hinchada) y con la tapa bien
+ * legible: es la evidencia, y la evidencia tiene que verse.
+ */
+export function momiaGeom(tier = 'medio', abierta = true) {
+  const d = detDeTier(tier);
+  const p = [
+    /* hinchada y redonda: ya no tiene forma de pulgón, tiene forma de urna */
+    poner(esfera(0.34, d, PAL.momia), { esc: [0.92, 0.86, 1] }),
+  ];
+  if (abierta && tier !== 'bajo') {
+    /* EL HUECO DE SALIDA: el disco oscuro por donde se fue la avispa nueva. */
+    p.push(poner(disco(0.13, d, PAL.momiaTapa), { rot: [-Math.PI / 2, 0, 0], pos: [0, 0.29, -0.04] }));
+    /* LA TAPITA, medio levantada, colgando de su bisagra de quitina. Ese
+       detalle —que quede colgando y no desaparezca— es lo que hace que se lea
+       "acá salió algo vivo" y no "acá hay un hueco". */
+    p.push(poner(disco(0.13, d, PAL.momia), { rot: [-2.2, 0, 0], pos: [0, 0.36, -0.26] }));
+  }
+  return fundir(p);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL SÍRFIDO — solo la LARVA (el adulto vive en polinizadores/)              */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * OJO, LEER ANTES DE AGREGAR NADA ACÁ:
+ * el sírfido ADULTO (la mosca disfrazada de abeja) YA ESTÁ DIBUJADO en
+ * `mundo3d/polinizadores/`. Acá va SOLO su larva depredadora — la mitad del
+ * oficio que allá no está. Dibujar el adulto en este archivo sería duplicar un
+ * bicho aprobado y romper la consistencia de la casa. Ver `ADULTO_SIRFIDO` en
+ * `beneficosIdentidad.js`.
+ *
+ * La larva: un gusanito CIEGO y sin patas, translúcido, ahusado en punta. Se
+ * mueve a tientas entre la colonia de pulgón — y por eso mismo nadie sospecha
+ * que sea nada. Parece una babosita insignificante y come pulgón en cantidad.
+ */
+export function larvaSirfidoGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [];
+  const segs = tier === 'bajo' ? 5 : 8;
+  for (let i = 0; i < segs; i++) {
+    const t = i / (segs - 1);
+    /* Gordo atrás, en punta fina adelante: la silueta de la larva de sírfido. */
+    const rr = 0.22 * Math.pow(t, 0.65) * (1 - 0.15 * t);
+    p.push(
+      poner(esfera(Math.max(0.02, rr), d, PAL.sirfidoLarva), {
+        pos: [0, 0, (0.5 - t) * 1.15],
+        esc: [1, 0.82, 1],
+      }),
+    );
+  }
+  return fundir(p);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL TURNO DE NOCHE — los cazadores que nadie ve trabajar                    */
+/* -------------------------------------------------------------------------- */
+
+/** Araña: cefalotórax + abdomen + 8 patas dobladas. Caza de todo. */
+export function aranaGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [
+    poner(esfera(0.2, d, PAL.arana), { pos: [0, 0, -0.14], esc: [1, 0.85, 1.2] }),
+    poner(esfera(0.12, d, PAL.arana), { pos: [0, 0, 0.14] }),
+  ];
+  const pares = tier === 'bajo' ? 2 : 4;
+  for (let i = 0; i < pares; i++) {
+    const ang = -0.5 + i * 0.36;
+    for (const s of [-1, 1]) {
+      /* fémur */
+      p.push(
+        poner(cilindro(0.022, 0.016, 0.32, d, PAL.arana), {
+          pos: [s * 0.18, 0.1, 0.14 - i * 0.1],
+          rot: [ang * 0.4, 0, (s * Math.PI) / 2.6],
+        }),
+      );
+      /* tibia (la doblez que hace a la araña una araña) */
+      p.push(
+        poner(cilindro(0.016, 0.01, 0.3, d, PAL.arana), {
+          pos: [s * 0.36, -0.02, 0.16 - i * 0.13],
+          rot: [ang * 0.5, 0, (s * Math.PI) / 5],
+        }),
+      );
+    }
+  }
+  return fundir(p);
+}
+
+/** La tela: radios + espiral. Geometría de líneas (barata y legible). */
+export function telaGeom(radios = 10, vueltas = 4) {
+  const pts = [];
+  for (let i = 0; i < radios; i++) {
+    const a = (i / radios) * Math.PI * 2;
+    pts.push(0, 0, 0, Math.cos(a), Math.sin(a), 0);
+  }
+  const paso = 1 / vueltas;
+  for (let v = 1; v <= vueltas; v++) {
+    const r0 = v * paso;
+    for (let i = 0; i < radios; i++) {
+      const a0 = (i / radios) * Math.PI * 2;
+      const a1 = ((i + 1) / radios) * Math.PI * 2;
+      const r1 = r0 + paso / radios;
+      pts.push(Math.cos(a0) * r0, Math.sin(a0) * r0, 0, Math.cos(a1) * r1, Math.sin(a1) * r1, 0);
+    }
+  }
+  const g = new THREE.BufferGeometry();
+  g.setAttribute('position', new THREE.Float32BufferAttribute(pts, 3));
+  return g;
+}
+
+/** Tijereta: cuerpo alargado y LOS CERCOS (las "tijeras") en la cola. */
+export function tijeretaGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [
+    poner(capsula(0.1, 0.7, d, PAL.tijereta), { rot: [Math.PI / 2, 0, 0] }),
+    poner(esfera(0.11, d, PAL.tijereta), { pos: [0, 0, 0.46] }),
+  ];
+  /* LAS TIJERAS: lo único que la gente recuerda de ella. Curvadas, enfrentadas. */
+  for (const s of [-1, 1]) {
+    p.push(
+      poner(cono(0.03, 0.3, d, PAL.tijereta), {
+        pos: [s * 0.07, 0, -0.55],
+        rot: [-Math.PI / 2, 0, s * 0.3],
+      }),
+    );
+  }
+  if (tier !== 'bajo') {
+    for (const s of [-1, 1]) {
+      p.push(
+        poner(cilindro(0.01, 0.008, 0.26, d, PAL.tijereta), { pos: [s * 0.05, 0.04, 0.6], rot: [1.2, 0, s * 0.3] }),
+      );
+    }
+  }
+  return fundir(p);
+}
+
+/** Carábido: el escarabajo corredor del suelo. Negro con brillo azulado. */
+export function carabidoGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const domo = new THREE.SphereGeometry(0.3, d.rad + 1, d.alt, 0, Math.PI * 2, 0, Math.PI / 2);
+  const p = [
+    poner(pintar(domo, PAL.carabido), { esc: [0.85, 0.6, 1.5] }),
+    poner(esfera(0.16, d, PAL.carabidoBrillo), { pos: [0, 0.04, 0.4], esc: [1, 0.7, 0.9] }),
+    poner(esfera(0.11, d, PAL.carabido), { pos: [0, 0.03, 0.56], esc: [1, 0.8, 0.9] }),
+  ];
+  /* Patas largas de corredor: este bicho PATRULLA, no pasea. */
+  const patas = tier === 'bajo' ? 2 : 3;
+  for (let i = 0; i < patas; i++) {
+    for (const s of [-1, 1]) {
+      p.push(
+        poner(cilindro(0.024, 0.014, 0.42, d, PAL.carabido), {
+          pos: [s * 0.24, -0.06, 0.3 - i * 0.3],
+          rot: [(i - 1) * 0.3, 0, (s * Math.PI) / 3],
+        }),
+      );
+    }
+  }
+  return fundir(p);
+}
+
+/** Ave insectívora: silueta en vuelo. Necesita percha para trabajar. */
+export function aveGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [
+    poner(capsula(0.16, 0.4, d, PAL.ave), { rot: [Math.PI / 2, 0, 0] }),
+    poner(esfera(0.13, d, PAL.ave), { pos: [0, 0.05, 0.36] }),
+    poner(cono(0.05, 0.16, d, PAL.avePecho), { pos: [0, 0.02, 0.5], rot: [Math.PI / 2, 0, 0] }),
+    poner(esfera(0.12, d, PAL.avePecho), { pos: [0, -0.08, 0.1], esc: [0.8, 0.7, 1.2] }),
+    /* cola */
+    poner(cono(0.14, 0.34, d, PAL.ave), { pos: [0, 0, -0.42], rot: [-Math.PI / 2, 0, 0], esc: [1, 1, 0.3] }),
+  ];
+  /* alas: dos planos en delta */
+  for (const s of [-1, 1]) {
+    p.push(poner(plano(0.7, 0.3, PAL.ave), { pos: [s * 0.4, 0.06, 0], rot: [Math.PI / 2 - 0.2, 0, s * 0.2] }));
+  }
+  return fundir(p);
+}
+
+/** Murciélago: el turno de noche que se come las polillas del cogollero. */
+export function murcielagoGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [
+    poner(capsula(0.1, 0.3, d, PAL.murcielago), { rot: [Math.PI / 2, 0, 0] }),
+    poner(esfera(0.11, d, PAL.murcielago), { pos: [0, 0.02, 0.26] }),
+  ];
+  /* orejas: la firma del murciélago insectívoro (ecolocaliza con ellas) */
+  for (const s of [-1, 1]) {
+    p.push(poner(cono(0.05, 0.14, d, PAL.murcielago), { pos: [s * 0.06, 0.14, 0.26] }));
+  }
+  /* alas membranosas: dedos + membrana */
+  for (const s of [-1, 1]) {
+    p.push(poner(plano(0.62, 0.34, PAL.murcielago), { pos: [s * 0.36, 0.02, -0.04], rot: [Math.PI / 2, 0, s * 0.12] }));
+  }
+  return fundir(p);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  LOS INVISIBLES — el hongo que se come al bicho                             */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * BEAUVERIA: la broca CUBIERTA DE BLANCO. El hongo la mató por dentro y ahora
+ * la usa de balsa para esporular. Se dibuja como el bicho + una erupción de
+ * pelusa radial: no hay forma más honesta de decir "el hongo se lo comió".
+ * Es la imagen que un cafetero SÍ ha visto — solo que no sabía que era su aliado.
+ */
+export function beauveriaGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const r = rng(451);
+  /* el cuerpo de la broca: escarabajito negro, "del tamaño de una cabeza de
+     alfiler" — acá agrandado, porque si no, no se enseña nada. */
+  const p = [poner(esfera(0.26, d, PAL.mariquitaPunto), { esc: [0.8, 0.8, 1.25] })];
+  /* LA PELUSA: la erupción blanca que lo cubre todo. */
+  const pelos = tier === 'bajo' ? 10 : tier === 'medio' ? 22 : 40;
+  for (let i = 0; i < pelos; i++) {
+    const u = r() * Math.PI * 2;
+    const v = Math.acos(2 * r() - 1);
+    const rad = 0.24;
+    const x = Math.sin(v) * Math.cos(u) * rad * 0.8;
+    const y = Math.cos(v) * rad * 0.8;
+    const z = Math.sin(v) * Math.sin(u) * rad * 1.25;
+    p.push(
+      poner(cono(0.026, 0.14 + r() * 0.12, d, r() > 0.5 ? PAL.beauveria : PAL.beauveriaEspora), {
+        pos: [x, y, z],
+        rot: [v - Math.PI / 2, u, 0],
+      }),
+    );
+  }
+  return fundir(p);
+}
+
+/** METARHIZIUM: el verde. La chiza momificada en el suelo, cubierta de esporas. */
+export function metarhiziumGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const r = rng(77);
+  const p = [];
+  /* la chiza: "larva blanca, gorda, curvada en C" — acá ya verde, ya vencida. */
+  const segs = tier === 'bajo' ? 5 : 8;
+  for (let i = 0; i < segs; i++) {
+    const t = i / (segs - 1);
+    const a = -0.9 + t * 1.9; // la curva en C
+    const rr = 0.2 * (0.6 + 0.4 * Math.sin(Math.PI * t));
+    p.push(
+      poner(esfera(rr, d, PAL.metarhizium), {
+        pos: [Math.sin(a) * 0.42, 0, Math.cos(a) * 0.42],
+        esc: [1, 0.9, 1],
+      }),
+    );
+  }
+  const pelos = tier === 'bajo' ? 0 : 18;
+  for (let i = 0; i < pelos; i++) {
+    const t = r();
+    const a = -0.9 + t * 1.9;
+    p.push(
+      poner(cono(0.02, 0.1, d, PAL.metarhiziumEspora), {
+        pos: [Math.sin(a) * 0.42 + (r() - 0.5) * 0.2, 0.12 + r() * 0.1, Math.cos(a) * 0.42 + (r() - 0.5) * 0.2],
+        rot: [(r() - 0.5) * 0.6, 0, (r() - 0.5) * 0.6],
+      }),
+    );
+  }
+  return fundir(p);
+}
+
+/*
+ * TRICHODERMA: el que NO come insectos — pelea contra los HONGOS MALOS del suelo.
+ * Se dibuja como un HALO vivo que envuelve la raíz de la plántula, y afuera los
+ * hongos malos (Rhizoctonia/Fusarium: manchas violáceas) que no logran entrar.
+ * El matiz que casi siempre se pierde: esto es un GUARDAESPALDAS, no un cazador.
+ */
+export function trichodermaGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const r = rng(303);
+  const p = [];
+  /* la raicilla */
+  p.push(poner(cilindro(0.05, 0.02, 0.9, d, PAL.trichoderma), { pos: [0, -0.3, 0] }));
+  /* el halo: filamentos que la envuelven */
+  const hilos = tier === 'bajo' ? 6 : 16;
+  for (let i = 0; i < hilos; i++) {
+    const a = (i / hilos) * Math.PI * 2;
+    const rad = 0.14 + r() * 0.08;
+    const y = -0.7 + r() * 0.8;
+    p.push(
+      poner(cilindro(0.008, 0.005, 0.2 + r() * 0.14, d, PAL.trichoderma), {
+        pos: [Math.cos(a) * rad, y, Math.sin(a) * rad],
+        rot: [(r() - 0.5) * 1.4, a, (r() - 0.5) * 1.4],
+      }),
+    );
+  }
+  /* los hongos malos, afuera, sin poder entrar */
+  if (tier !== 'bajo') {
+    for (let i = 0; i < 5; i++) {
+      const a = r() * Math.PI * 2;
+      const rad = 0.36 + r() * 0.14;
+      p.push(
+        poner(esfera(0.05 + r() * 0.03, d, PAL.hongoMalo), {
+          pos: [Math.cos(a) * rad, -0.5 + r() * 0.6, Math.sin(a) * rad],
+        }),
+      );
+    }
+  }
+  return fundir(p);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL CULTIVO Y SU BORDE — la despensa y el refugio (o su ausencia)           */
+/* -------------------------------------------------------------------------- */
+
+/** Mata de fríjol: tallo + hojas trifoliadas. El escenario del pleito. */
+export function mataGeom(tier = 'medio', semilla = 1, salud = 1) {
+  const d = detDeTier(tier);
+  const r = rng(semilla);
+  const p = [];
+  const alto = 1.5 * (0.7 + salud * 0.3);
+  p.push(poner(cilindro(0.05, 0.03, alto, d, PAL.tallo), { pos: [0, alto / 2, 0] }));
+
+  const pisos = tier === 'bajo' ? 2 : 3;
+  for (let i = 0; i < pisos; i++) {
+    const y = alto * (0.4 + (i / pisos) * 0.55);
+    const base = r() * Math.PI * 2;
+    for (let j = 0; j < 3; j++) {
+      const a = base + (j / 3) * Math.PI * 2;
+      const largoP = 0.28;
+      /* pecíolo */
+      p.push(
+        poner(cilindro(0.016, 0.012, largoP, d, PAL.tallo), {
+          pos: [(Math.cos(a) * largoP) / 2, y, (Math.sin(a) * largoP) / 2],
+          rot: [Math.PI / 2 - 0.5, -a, 0],
+        }),
+      );
+      /* el trifolio: tres foliolos por hoja (así es el fríjol) */
+      const cHoja = salud > 0.6 ? (i === pisos - 1 ? PAL.hojaJoven : PAL.hoja) : PAL.hojaSombra;
+      for (const off of [-0.5, 0, 0.5]) {
+        const aa = a + off * 0.5;
+        const dist = largoP + (off === 0 ? 0.26 : 0.2);
+        p.push(
+          poner(plano(0.3 * salud + 0.1, 0.24 * salud + 0.08, cHoja), {
+            pos: [Math.cos(aa) * dist, y + 0.02, Math.sin(aa) * dist],
+            rot: [-Math.PI / 2 + 0.24, -aa + Math.PI / 2, 0],
+          }),
+        );
+      }
+    }
+  }
+  return fundir(p);
+}
+
+/*
+ * EL BORDE FLORIDO: flor CHIQUITA Y ABUNDANTE, la que de verdad sirve —
+ * cilantro a flor, hinojo (umbelas) y caléndula (capítulos). No es jardinería:
+ * es la CANTINA de los adultos de avispa, crisopa y sírfido. Sin esto, el
+ * ejército no se queda ni aunque uno no fumigue nunca.
+ */
+export function floresGeom(tier = 'medio', semilla = 7, n = 12) {
+  const d = detDeTier(tier);
+  const r = rng(semilla);
+  const p = [];
+  const cuantas = tier === 'bajo' ? Math.round(n * 0.45) : n;
+  for (let i = 0; i < cuantas; i++) {
+    const x = (r() - 0.5) * 2.6;
+    const z = (r() - 0.5) * 0.7;
+    const alto = 0.5 + r() * 0.45;
+    const tipo = r();
+    p.push(poner(cilindro(0.018, 0.012, alto, d, PAL.hoja), { pos: [x, alto / 2, z] }));
+
+    if (tipo < 0.5) {
+      /* UMBELA (cilantro/hinojo): el paragüitas de florecitas — la mesa abierta
+         donde una avispa diminuta SÍ alcanza el néctar. Por eso sirve tanto. */
+      const col = tipo < 0.25 ? PAL.florCilantro : PAL.florHinojo;
+      const rayos = tier === 'bajo' ? 4 : 7;
+      for (let k = 0; k < rayos; k++) {
+        const a = (k / rayos) * Math.PI * 2;
+        const rad = 0.1;
+        p.push(
+          poner(esfera(0.035, d, col), { pos: [x + Math.cos(a) * rad, alto + 0.03, z + Math.sin(a) * rad] }),
+        );
+      }
+      p.push(poner(esfera(0.03, d, col), { pos: [x, alto + 0.03, z] }));
+    } else {
+      /* CAPÍTULO (caléndula): el disco de compuesta, mirando al sol. */
+      p.push(poner(disco(0.11, d, PAL.florCalendula), { rot: [-Math.PI / 2, 0, 0], pos: [x, alto, z] }));
+      p.push(poner(esfera(0.04, d, PAL.florCentro), { pos: [x, alto + 0.02, z], esc: [1, 0.6, 1] }));
+    }
+  }
+  return fundir(p);
+}
+
+/** Rastrojo y cerca viva: el REFUGIO. Donde duerme el turno de noche. */
+export function rastrojoGeom(tier = 'medio', semilla = 21) {
+  const d = detDeTier(tier);
+  const r = rng(semilla);
+  const p = [];
+  const matojos = tier === 'bajo' ? 5 : 12;
+  for (let i = 0; i < matojos; i++) {
+    const x = (r() - 0.5) * 3;
+    const z = (r() - 0.5) * 0.6;
+    const h = 0.5 + r() * 0.7;
+    p.push(poner(cono(0.16 + r() * 0.1, h, d, r() > 0.5 ? PAL.hojaSombra : PAL.hoja), { pos: [x, h / 2, z] }));
+  }
+  /* postes de la cerca viva: percha para las aves */
+  for (let i = 0; i < 3; i++) {
+    const x = -1.2 + i * 1.2;
+    p.push(poner(cilindro(0.06, 0.05, 1.6, d, PAL.tallo), { pos: [x, 0.8, 0] }));
+    if (tier !== 'bajo') {
+      p.push(poner(esfera(0.3, d, PAL.hojaSombra), { pos: [x, 1.7, 0], esc: [1, 0.8, 1] }));
+    }
+  }
+  return fundir(p);
+}
+
+/** El borde PELADO: alambre y nada. La ausencia, dibujada. */
+export function alambreGeom(tier = 'medio') {
+  const d = detDeTier(tier);
+  const p = [];
+  for (let i = 0; i < 3; i++) {
+    const x = -1.2 + i * 1.2;
+    p.push(poner(cilindro(0.045, 0.04, 1.1, d, PAL.ceniza), { pos: [x, 0.55, 0] }));
+  }
+  /* dos hilos de alambre y ni una hoja: nadie vive acá */
+  for (const y of [0.6, 0.95]) {
+    p.push(poner(cilindro(0.008, 0.008, 3.2, d, PAL.ceniza), { pos: [0, y, 0], rot: [0, 0, Math.PI / 2] }));
+  }
+  return fundir(p);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  EL UMBRAL — la única línea "de gráfico" que este mundo se permite          */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Una banda tenue flotando a la misma altura sobre las DOS parcelas. No es un
+ * chart: es un nivel de agua. La viva sube hacia él y se dobla antes; la limpia
+ * lo revienta. Que sea LA MISMA línea para ambas es todo el rigor del
+ * experimento — y por eso es una sola geometría, no dos.
+ */
+export function bandaUmbralGeom(ancho = 9, grosor = 0.035) {
+  return pintar(new THREE.BoxGeometry(ancho, grosor, 0.02), PAL.umbral);
+}
+
+/** Los ticks de la banda: guiños de regla, cada metro. Solo tier alto. */
+export function ticksUmbralGeom(ancho = 9, cada = 1) {
+  const p = [];
+  for (let x = -ancho / 2; x <= ancho / 2; x += cada) {
+    p.push(poner(pintar(new THREE.BoxGeometry(0.02, 0.12, 0.02), PAL.umbral), { pos: [x, 0, 0] }));
+  }
+  return fundir(p);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Siembra: dónde va cada cosa (datos puros, sin three)                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Las posiciones de las matas de una parcela. Determinista: la misma huerta
+ * siempre. Las dos parcelas usan la MISMA semilla → surcos gemelos, para que el
+ * ojo compare peras con peras.
+ */
+export function sembrarMatas(lado, filas = 3, porFila = 4) {
+  const out = [];
+  for (let f = 0; f < filas; f++) {
+    for (let i = 0; i < porFila; i++) {
+      out.push({
+        pos: [lado * (1.5 + i * 0.85), 0, -1 + f * 1.0],
+        semilla: 100 + f * 10 + i,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Dónde se posan los pulgones: en los brotes tiernos (arriba), que es donde
+ * chupan de verdad. `cuantos` viene de la dinámica → el número ES la curva.
+ */
+export function sembrarPulgon(cuantos, semilla = 5) {
+  const r = rng(semilla);
+  const out = [];
+  for (let i = 0; i < cuantos; i++) {
+    const a = r() * Math.PI * 2;
+    const rad = 0.15 + r() * 0.3;
+    out.push({
+      pos: [Math.cos(a) * rad, 0.95 + r() * 0.5, Math.sin(a) * rad],
+      rot: r() * Math.PI * 2,
+      esc: 0.1 + r() * 0.04,
+    });
+  }
+  return out;
+}

--- a/src/visual/mundo3d/beneficos/beneficosIdentidad.js
+++ b/src/visual/mundo3d/beneficos/beneficosIdentidad.js
@@ -1,0 +1,634 @@
+/*
+ * beneficosIdentidad — LA VERDAD DE LOS ALIADOS INVISIBLES, COMO DATOS.
+ *
+ * El campesino ve un bicho y lo mata. No sabe que la mitad de esos bichos están
+ * de su lado. Y cuando fumiga de amplio espectro mata MÁS ALIADOS QUE PLAGAS —
+ * por eso al año siguiente hay más plaga, no menos. Este mundo existe para hacer
+ * visible ese ejército invisible, y para que el argumento se vea SIN TEXTO:
+ *
+ *              MATAR TODO = QUEDARSE SIN EJÉRCITO.
+ *
+ * ── DE DÓNDE SALE (grounded, no inventado) ──────────────────────────────────
+ * Del corpus maestro de MIP/poscosecha (140 pares) y de plagas (135 pares), voz
+ * de campo. Hechos que el corpus deja firmes y que el dibujo NO puede contradecir:
+ *
+ *   · LA LARVA DE MARIQUITA NO SE PARECE AL ADULTO. El adulto es redondo, rojo
+ *     con puntos; la larva es "un cocodrilito negro con manchas naranjas",
+ *     alargada. El campesino la mata creyendo que es plaga — y es la misma
+ *     mariquita en otra etapa, comiendo pulgón todo el día. ESTE ES EL GESTO
+ *     QUE MÁS VALE DE TODO EL MUNDO: por eso la larva es la PROTAGONISTA, y por
+ *     eso el arco huevo→larva→pupa→adulto se dibuja COMPLETO y en una sola hoja.
+ *   · La crisopa adulta es delicada, de alas verdes transparentes; LA QUE TRABAJA
+ *     es su larva ("león de los áfidos"). Sus huevos van colgados de un PEDICELO,
+ *     como alfileres clavados en la hoja.
+ *   · La avispa parasitoide pone su huevo DENTRO de la plaga; la larva se la come
+ *     por dentro y deja LA MOMIA: el pulgón hinchado, bronce, con una tapita
+ *     recortada por donde salió la avispa. No pican a las personas.
+ *   · El sírfido es una MOSCA disfrazada de abeja: el adulto POLINIZA y su larva
+ *     COME PULGÓN. Doble oficio, un solo bicho.
+ *   · Beauveria bassiana cubre a la plaga de BLANCO (la broca del café);
+ *     Metarhizium anisopliae la deja VERDE (la chiza en el suelo). El hongo que
+ *     se come al bicho.
+ *   · Trichoderma no ataca insectos: pelea contra OTROS HONGOS en el suelo
+ *     (Rhizoctonia, Pythium, Fusarium — la chupadera del semillero).
+ *   · Bacillus thuringiensis (Bt) solo mata ORUGAS, y solo si se la COMEN. Es
+ *     selectivo, pero no distingue una oruga plaga de una mariposa bonita.
+ *   · Un poco de plaga NO es un problema: ES LA COMIDA que mantiene vivo al
+ *     ejército. Un cultivo sin un solo insecto es un cultivo sin defensa.
+ *
+ * ── REGISTRO: REALISTA. NO RUBBER-HOSE. ────────────────────────────────────
+ * `GUIA-RUBBERHOSE.md` es tajante y este mundo obedece: esto es FAUNA SECUNDARIA
+ * del monte → proporciones naturales, SIN ojos de goma, SIN catchlight, SIN
+ * contorno de tinta, SIN chapetas, SIN line-boil. Los personajes rubber-hose son
+ * otros (los 9 bichos, Angelita) y viven en `creatures/`. Acá nadie tiene nombre
+ * propio ni carácter: tienen OFICIO. Un dibujo con ojos-catchlight en esta escena
+ * sería un bug de registro.
+ *
+ * REGLA DE ORO (la de `abejaIdentidad.js` / `polinizadoresIdentidad.js`): SOLO
+ * DATOS. Cero three, cero react → three-free, testeable headless, seguro en el
+ * bundle base. La GEOMETRÍA vive en `beneficos.geom.js`; la DINÁMICA (la curva
+ * de plaga que decide el desenlace) en `dinamicaPlaga.js`; la CADENCIA en la
+ * escena.
+ */
+/*
+ * OJO CON ESTE IMPORT: se entra por `paletaMadre.js`, NO por `../paleta` (el
+ * index). El index re-exporta `LuzMadre.jsx` y por ahí se cuela REACT — lo que
+ * mataría la promesa de arriba (three-free, headless, seguro en el bundle base)
+ * y metería un componente en un archivo de datos. `paletaMadre` es la puerta
+ * de los DATOS; el index es la puerta de las ESCENAS. Es la misma disciplina de
+ * `polinizadoresIdentidad.js`, que entra directo a `abejaIdentidad.js`.
+ */
+import { VERDES, TIERRAS, CORTEZAS, ACENTOS, NEUTROS, mezclar } from '../paleta/paletaMadre.js';
+
+/* -------------------------------------------------------------------------- */
+/*  Paleta del mundo — derivada de la madre, ni un hex suelto                  */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Una mañana de huerta templada: el verde de trabajo, la tierra de siembra y —
+ * el único color que grita— EL ROJO COCHINILLA DE LA MARIQUITA. Ese rojo ya
+ * existía en la paleta madre y ya venía anotado "(mariquita)": no se inventa
+ * nada, se cobra lo que ya estaba dicho.
+ *
+ * El criterio de color de este mundo es UNO y es semántico:
+ *   · ALIADO   → cochinilla/ámbar (los cálidos de la casa). Trabajan.
+ *   · PLAGA    → verde pálido enfermizo. Chupa, no aporta.
+ *   · VENENO   → un violeta-ceniza que NO pertenece a la paleta andina, y esa
+ *                es exactamente la idea: el veneno es lo ajeno al valle.
+ *   · MUERTO   → ceniza. Lo que el amplio espectro deja.
+ */
+export const PAL = {
+  /*
+   * NO HAY CIELO NI NIEBLA ACÁ, Y ES A PROPÓSITO: "los cielos los pone la
+   * atmósfera, no vos" (paleta/GUIA.md §1). La escena toma su día de `ATMOSFERA`
+   * y su noche de `CIELOS_HORA.noche`, mezclados con la ley 60%-hacia-la-madre.
+   * Declarar acá un `cieloNoche` propio era exactamente la deriva de calcos que
+   * el módulo `paleta/` existe para matar — se hizo, y se borró.
+   */
+
+  /* Suelo y mata */
+  suelo: TIERRAS.siembra,
+  sueloVivo: mezclar(TIERRAS.siembra, TIERRAS.turba, 0.5), // con materia orgánica
+  sueloPelado: mezclar(TIERRAS.camino, NEUTROS.concreto, 0.35), // el lote limpio
+  hoja: VERDES.trabajo,
+  hojaJoven: VERDES.brote,
+  hojaSombra: VERDES.monte,
+  tallo: mezclar(VERDES.monte, TIERRAS.camino, 0.3),
+
+  /* LA PLAGA: el pulgón. Verde pálido, translúcido, blando. */
+  pulgon: '#a9c47a',
+  pulgonDenso: '#8fb45f', // la colonia apretada, cuando ya se ve el daño
+  oruga: '#9fc06a', // el cogollero/medidor: verde clarito
+
+  /* LOS ALIADOS (el ejército) */
+  mariquita: ACENTOS.cochinilla, // ya venía anotado "(mariquita)" en la madre
+  mariquitaPunto: NEUTROS.tinta,
+  /* La larva: el cocodrilito. Oscura azulada con manchas naranjas — la razón
+     por la que el campesino la mata sin saber. */
+  larvaCuerpo: mezclar(NEUTROS.tinta, '#33305c', 0.45), // negro-azuloso
+  larvaMancha: '#e08a2e', // el naranja que la delata como aliada
+  crisopaAla: '#c6e39a', // alas verdes transparentes
+  crisopaCuerpo: '#7fb04f',
+  crisopaOjo: ACENTOS.ambar, // los ojos dorados de la crisopa adulta
+  crisopaHuevo: NEUTROS.hueso, // el alfiler
+  crisopaPedicelo: mezclar(NEUTROS.hueso, VERDES.brote, 0.35),
+  avispa: mezclar(NEUTROS.tinta, ACENTOS.ambar, 0.28), // negra con dejo de miel
+  avispaAla: '#e8ecdd',
+  /* LA MOMIA: el pulgón parasitado. Hinchado, bronce, rígido. Lo más
+     espectacular del control biológico — y lo que nadie mira. */
+  momia: ACENTOS.ambar,
+  momiaTapa: mezclar(ACENTOS.ambar, NEUTROS.tinta, 0.55), // el huequito de salida
+  sirfidoLarva: mezclar(VERDES.brote, ACENTOS.maizTextil, 0.3), // gusanito translúcido
+  arana: mezclar(TIERRAS.cacao, NEUTROS.tinta, 0.4),
+  tela: NEUTROS.hueso,
+  tijereta: mezclar(CORTEZAS.roble, NEUTROS.tinta, 0.5),
+  carabido: '#2f2a33', // el escarabajo cazador: negro con brillo azulado
+  carabidoBrillo: '#4a4a68',
+  ave: mezclar(VERDES.paramoHoja, NEUTROS.tinta, 0.25),
+  avePecho: ACENTOS.maizTextil,
+  murcielago: mezclar(TIERRAS.cacao, NEUTROS.tinta, 0.55),
+
+  /* LOS HONGOS Y LA BACTERIA (los que no se ven venir) */
+  beauveria: NEUTROS.hueso, // la broca cubierta de blanco
+  beauveriaEspora: '#fffdf7',
+  metarhizium: '#6f8f3a', // el verde de Metarhizium
+  metarhiziumEspora: '#93b352',
+  trichoderma: mezclar(NEUTROS.hueso, VERDES.brote, 0.45), // el halo de la raíz
+  hongoMalo: mezclar('#33305c', TIERRAS.cacao, 0.4), // Rhizoctonia/Fusarium
+  bt: mezclar(NEUTROS.cal, ACENTOS.ambar, 0.2), // la bacteria, polvo fino
+
+  /* LAS FLORES: la despensa. Flor chiquita y abundante (compuestas). */
+  florCilantro: NEUTROS.hueso,
+  florCalendula: ACENTOS.guayacan,
+  florHinojo: ACENTOS.maizTextil,
+  florCentro: ACENTOS.ambar,
+
+  /* EL VENENO Y LA MUERTE (lo ajeno) */
+  veneno: '#9d8fb5', // violeta-ceniza: NO es un color de este valle
+  venenoDenso: '#7d6f97',
+  ceniza: '#6b6357', // lo que queda cuando pasó la bomba
+  /* El umbral: la única línea "de gráfico" que este mundo se permite. Ámbar =
+     señal, alerta amable. Nunca rojo de UI (regla de la paleta madre). */
+  umbral: ACENTOS.ambar,
+  umbralRoto: ACENTOS.cafeCereza,
+};
+
+/* -------------------------------------------------------------------------- */
+/*  EL ELENCO — cada aliado con su OFICIO, no de adorno                        */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * `turno`: 'dia' | 'noche' | 'siempre' — el mundo corre un ciclo día/noche y
+ * el elenco CAMBIA con él. Los cazadores de la noche (araña, tijereta,
+ * carábido, murciélago) no son relleno: son el turno que nadie ve trabajar.
+ *
+ * `prioridad`: 1 = imprescindible (sale hasta en tier bajo), 2 = medio,
+ * 3 = solo tier alto. La lección mínima (larva de mariquita + su arco + pulgón)
+ * tiene que llegar hasta el teléfono más humilde. Si algo se cae, se cae el
+ * adorno, nunca el argumento.
+ *
+ * `lecciones`: lo que el dibujo TIENE que dejar dicho. Es el contrato del arte:
+ * si el bicho está pero su lección no se lee, el bicho está de adorno y sobra.
+ */
+export const ALIADOS = [
+  {
+    slug: 'larva-mariquita',
+    nombre: 'Larva de mariquita',
+    oficio: 'Se come el pulgón todo el día — más que el adulto.',
+    presa: ['pulgon'],
+    turno: 'dia',
+    prioridad: 1,
+    /* "Un cocodrilito negro con manchas naranjas, muy distinta al adulto
+       redondo" — literal del corpus. */
+    forma: 'cocodrilito',
+    largo: 0.62,
+    color: 'larvaCuerpo',
+    mancha: 'larvaMancha',
+    lecciones: [
+      'NO se parece al adulto: por eso la matan creyendo que es plaga.',
+      'Es la misma mariquita en otra etapa.',
+      'Come más pulgón que el adulto.',
+    ],
+  },
+  {
+    slug: 'mariquita',
+    nombre: 'Mariquita',
+    oficio: 'Come pulgón. La cara conocida del ejército.',
+    presa: ['pulgon'],
+    turno: 'dia',
+    prioridad: 1,
+    forma: 'domo',
+    largo: 0.44,
+    color: 'mariquita',
+    lecciones: ['La única que el campesino ya reconoce — su larva, no.'],
+  },
+  {
+    slug: 'crisopa-larva',
+    nombre: 'Larva de crisopa',
+    oficio: 'El león de los áfidos: hace el trabajo pesado.',
+    presa: ['pulgon', 'acaro', 'huevo'],
+    turno: 'dia',
+    prioridad: 2,
+    forma: 'cocodrilito',
+    largo: 0.5,
+    color: 'crisopaCuerpo',
+    mancha: 'larvaMancha',
+    lecciones: ['La delicada es la adulta; la que come es esta.'],
+  },
+  {
+    slug: 'crisopa',
+    nombre: 'Crisopa',
+    oficio: 'De adulta come polen; sus huevos van colgados de un alfiler.',
+    presa: [],
+    turno: 'dia',
+    prioridad: 2,
+    forma: 'alada-fina',
+    largo: 0.46,
+    color: 'crisopaCuerpo',
+    lecciones: [
+      'Necesita FLOR para comer de adulta: sin flores no se queda.',
+      'Sus huevos con pedicelo parecen alfileres clavados en la hoja.',
+    ],
+  },
+  {
+    slug: 'avispa-parasitoide',
+    nombre: 'Avispa parasitoide',
+    oficio: 'Pone su huevo DENTRO del gusano. No pica a las personas.',
+    presa: ['pulgon', 'oruga', 'broca'],
+    turno: 'dia',
+    prioridad: 1,
+    forma: 'avispa',
+    largo: 0.3,
+    color: 'avispa',
+    lecciones: [
+      'Lo más espectacular del control biológico — y lo más invisible.',
+      'La MOMIA es la prueba de que trabajó.',
+      'Es chiquita: por eso nadie la ve y el amplio espectro la borra.',
+    ],
+  },
+  {
+    slug: 'sirfido-larva',
+    nombre: 'Larva de sírfido',
+    oficio: 'Gusanito ciego que come pulgón en cantidad.',
+    presa: ['pulgon'],
+    turno: 'dia',
+    prioridad: 2,
+    forma: 'gusanito',
+    largo: 0.44,
+    color: 'sirfidoLarva',
+    /* EL ADULTO NO SE DIBUJA ACÁ. Ver ADULTO_SIRFIDO abajo. */
+    lecciones: [
+      'DOBLE OFICIO: el adulto poliniza, la larva depreda. Un solo bicho.',
+      'La mosca que parece abeja es aliada: no hay que espantarla.',
+    ],
+  },
+  {
+    slug: 'arana',
+    nombre: 'Araña',
+    oficio: 'Caza de todo, sin preguntar.',
+    presa: ['pulgon', 'oruga', 'mosca'],
+    turno: 'noche',
+    prioridad: 2,
+    forma: 'arana',
+    largo: 0.5,
+    color: 'arana',
+    lecciones: ['Turno de noche: trabaja cuando nadie mira.'],
+  },
+  {
+    slug: 'tijereta',
+    nombre: 'Tijereta',
+    oficio: 'Cazadora nocturna; se esconde de día.',
+    presa: ['pulgon', 'huevo'],
+    turno: 'noche',
+    prioridad: 3,
+    forma: 'tijereta',
+    largo: 0.5,
+    color: 'tijereta',
+    lecciones: ['Necesita refugio para pasar el día — rastrojo, no lote pelado.'],
+  },
+  {
+    slug: 'carabido',
+    nombre: 'Carábido',
+    oficio: 'El escarabajo que patrulla el suelo de noche.',
+    presa: ['oruga', 'larva', 'babosa'],
+    turno: 'noche',
+    prioridad: 3,
+    forma: 'escarabajo',
+    largo: 0.56,
+    color: 'carabido',
+    lecciones: ['Vive en el SUELO: la labranza brutal y el veneno lo borran.'],
+  },
+  {
+    slug: 'ave',
+    nombre: 'Ave insectívora',
+    oficio: 'Se lleva orugas del cultivo. Necesita percha.',
+    presa: ['oruga', 'larva'],
+    turno: 'dia',
+    prioridad: 3,
+    forma: 'ave',
+    largo: 1.1,
+    color: 'ave',
+    lecciones: ['Sin cerca viva ni árbol, no tiene dónde pararse a trabajar.'],
+  },
+  {
+    slug: 'murcielago',
+    nombre: 'Murciélago',
+    oficio: 'Se come las polillas que de día no se ven.',
+    presa: ['polilla'],
+    turno: 'noche',
+    prioridad: 3,
+    forma: 'murcielago',
+    largo: 1.3,
+    color: 'murcielago',
+    lecciones: [
+      'Las polillas que caza son las que ponen los huevos del cogollero.',
+      'Aliado silencioso que casi nadie tiene en cuenta.',
+    ],
+  },
+];
+
+/*
+ * EL SÍRFIDO ADULTO NO SE DIBUJA ACÁ — Y ES A PROPÓSITO.
+ *
+ * `mundo3d/polinizadores/` ya lo tiene resuelto como polinizador (es una de sus
+ * piezas: la mosca disfrazada de abeja). Redibujarlo sería exactamente el bug que
+ * la casa persigue: el mismo bicho con dos personalidades. Lo que ESTE mundo
+ * aporta es la MITAD QUE ALLÁ NO ESTÁ: la larva depredadora. Juntas cuentan el
+ * doble oficio; separadas, cada una cuenta la suya sin mentir.
+ *
+ * Cuando `polinizadores/` aterrice en `dev`, el cableado es un import — no un
+ * dibujo nuevo:
+ *
+ *     import { EnjambrePolinizadores } from '../polinizadores';
+ *
+ * Este puntero existe para que ese día nadie caiga en la tentación de dibujarlo
+ * de nuevo "para que combine".
+ */
+export const ADULTO_SIRFIDO = {
+  vive_en: 'src/visual/mundo3d/polinizadores/',
+  slug: 'sirfido',
+  motivo:
+    'El adulto ya está dibujado como polinizador. Acá solo va su larva ' +
+    'depredadora: el otro turno del mismo bicho.',
+};
+
+/* -------------------------------------------------------------------------- */
+/*  LOS INVISIBLES — hongos y bacteria: los que se comen al bicho por dentro   */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Estos no son "bichos buenos" con patas: son el ejército que NI SIQUIERA tiene
+ * cara. Se dibujan por su EFECTO, que es lo único que el campesino llega a ver:
+ * la broca cubierta de pelusa blanca, la chiza verde momificada en el suelo, el
+ * halo que protege la raíz. El efecto ES el personaje.
+ */
+export const INVISIBLES = [
+  {
+    slug: 'beauveria',
+    nombre: 'Beauveria bassiana',
+    tipo: 'hongo-entomopatogeno',
+    /* "La broca cubierta de blanco" — el efecto ES la imagen. */
+    efecto: 'cubre',
+    color: 'beauveria',
+    victima: ['broca', 'gusano-blanco', 'cogollero'],
+    donde: 'fruto/tallo',
+    prioridad: 2,
+    lecciones: [
+      'El hongo que se come al bicho — por dentro.',
+      'No es peligroso para personas, animales ni plantas.',
+      'AGROSAVIA: nim + Beauveria dio 96% de control del cogollero a 15 días.',
+    ],
+  },
+  {
+    slug: 'metarhizium',
+    nombre: 'Metarhizium anisopliae',
+    tipo: 'hongo-entomopatogeno',
+    efecto: 'cubre',
+    color: 'metarhizium',
+    victima: ['chiza', 'gusano-blanco'],
+    donde: 'suelo',
+    prioridad: 3,
+    lecciones: ['El verde: trabaja bajo tierra, contra la chiza y el gusano blanco.'],
+  },
+  {
+    slug: 'trichoderma',
+    nombre: 'Trichoderma',
+    tipo: 'hongo-antagonista',
+    /* No ataca insectos: PELEA CONTRA OTROS HONGOS. Es el matiz que casi
+       siempre se pierde y que este dibujo tiene que salvar. */
+    efecto: 'defiende',
+    color: 'trichoderma',
+    victima: ['rhizoctonia', 'pythium', 'fusarium'],
+    donde: 'raiz/semillero',
+    prioridad: 3,
+    lecciones: [
+      'NO come insectos: pelea contra los hongos malos del suelo.',
+      'Protege la plántula de la chupadera. Prevención, no cura.',
+    ],
+  },
+  {
+    slug: 'bt',
+    nombre: 'Bacillus thuringiensis',
+    tipo: 'bacteria',
+    efecto: 'ingesta',
+    color: 'bt',
+    victima: ['oruga'],
+    donde: 'hoja',
+    prioridad: 3,
+    lecciones: [
+      'Solo mata ORUGAS, y solo si se la comen.',
+      'Selectivo: no toca escarabajos, avispas ni mariquitas.',
+      'Honestidad: tampoco distingue una oruga plaga de una mariposa bonita.',
+    ],
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/*  EL ARCO DE LA MARIQUITA — la lección central, como datos                   */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Las cuatro etapas EN UNA SOLA HOJA, en orden y a la misma escala. No es una
+ * lámina de biología: es la respuesta visual a "¿por qué mato a mi propia
+ * aliada?". Cuando el ojo recorre huevo→larva→pupa→adulto y aterriza en el
+ * bicho rojo que SÍ conoce, la larva deja de ser un gusano raro para siempre.
+ *
+ * Esa es toda la pedagogía del mundo, y no gasta una sola palabra.
+ */
+export const ARCO_MARIQUITA = [
+  {
+    etapa: 'huevo',
+    dias: [0, 4],
+    forma: 'huevos-racimo',
+    color: 'larvaMancha',
+    /* Amarillo-naranja, en racimo parado, CERCA de la colonia de pulgón: la
+       madre pone la mesa servida. */
+    nota: 'Puestos junto al pulgón: la comida ya está ahí cuando nacen.',
+  },
+  {
+    etapa: 'larva',
+    dias: [4, 22],
+    forma: 'cocodrilito',
+    color: 'larvaCuerpo',
+    /* LA ETAPA LARGA: 18 de los ~30 días. La mayor parte de su vida la mariquita
+       ES esta cosa oscura — y es cuando más come. Por eso la escena le da el
+       primer plano a ella y no al adulto. */
+    nota: 'La etapa MÁS LARGA y la que más come. La que matan por error.',
+    protagonista: true,
+  },
+  {
+    etapa: 'pupa',
+    dias: [22, 28],
+    forma: 'pupa',
+    color: 'mariquita',
+    nota: 'Quieta, pegada a la hoja. Parece muerta: no la barra.',
+  },
+  {
+    etapa: 'adulto',
+    dias: [28, 30],
+    forma: 'domo',
+    color: 'mariquita',
+    nota: 'La única que todo el mundo reconoce — y la etapa más corta del cuento.',
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/*  LA TRIADA — qué necesitan para quedarse (o el ejército se va)              */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Del corpus, textual: "Necesitan tres cosas: comida (que incluye algo de plaga
+ * baja, no un cultivo completamente limpio), flores con floración escalonada
+ * todo el año, y refugio". Las tres se DIBUJAN en la parcela viva y se dibujan
+ * AUSENTES en la limpia. El contraste no se narra: se ve.
+ *
+ * La primera es la más difícil de tragar para el campesino, y por eso el mundo
+ * insiste: el lote impecable, sin un solo bicho, es un lote SIN DEFENSA. La
+ * plaga baja no es un fracaso — es la despensa.
+ */
+export const HABITAT = [
+  {
+    id: 'comida',
+    que: 'Algo de plaga baja — siempre.',
+    porque: 'Sin presa, el benéfico se va o se muere. El lote impecable es un lote indefenso.',
+    seVe: 'En la parcela viva SIEMPRE quedan unos pulgones. Nunca llega a cero.',
+  },
+  {
+    id: 'flores',
+    que: 'Flor chiquita y abundante, escalonada todo el año.',
+    /* Del corpus: cilantro a flor, hinojo, caléndula, compuestas. */
+    especies: ['cilantro a flor', 'hinojo', 'caléndula', 'compuestas'],
+    porque: 'Los adultos de avispa, crisopa y sírfido comen POLEN y NÉCTAR, no plaga.',
+    seVe: 'Un borde florecido en la parcela viva; borde pelado en la limpia.',
+  },
+  {
+    id: 'refugio',
+    que: 'Cerca viva, rastrojo, franja sin cultivar.',
+    porque: 'Es donde duermen de día los de turno de noche y donde se pasan la sequía.',
+    seVe: 'Rastrojo y cerca viva al fondo de la viva; alambre pelado en la limpia.',
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/*  EL UMBRAL — la línea que decide si vale la pena gastar                     */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * "El umbral existe justamente para que usted no fumigue por miedo, sino por
+ * evidencia". Es el concepto más caro de transmitir y el más rentable: fumigar
+ * ANTES del umbral es perder plata DOS VECES — la del veneno y la del ejército
+ * que uno mismo se acaba de matar.
+ *
+ * En la escena es una banda en el aire sobre las dos parcelas: la misma línea
+ * para ambas. La viva se le acerca y nunca la cruza (los benéficos la aplanan
+ * solos). La limpia la revienta después de fumigar. Nadie tiene que explicarlo.
+ */
+export const UMBRAL = {
+  /* El nivel, en la escala normalizada de `dinamicaPlaga` (0..1). */
+  nivel: 0.55,
+  que: 'El punto donde la plaga ya le baja la cosecha de verdad.',
+  antes: 'Gastar acá es perder plata Y matar al ejército. La plaga baja no duele.',
+  despues: 'Acá sí conviene actuar — con lo más selectivo que haya, no con la bomba.',
+  /* Un umbral REAL y citable, para que la banda no sea un número inventado:
+     Cenicafé fija la acción en broca por encima del 2% de frutos infestados,
+     con más de la mitad en posición A o B (recién entrando). */
+  ejemploReal: {
+    plaga: 'broca del café',
+    fuente: 'Cenicafé',
+    regla: '>2% de frutos infestados, con más de la mitad en posición A o B',
+  },
+  /* Y el contra-ejemplo que más se repite en el corpus: */
+  contraejemplo: {
+    caso: 'tres pulgones en una hoja',
+    respuesta: 'No se fumiga: se anota y se sigue mirando. Se resuelve solo en 1–2 semanas.',
+  },
+};
+
+/* -------------------------------------------------------------------------- */
+/*  LAS DOS PARCELAS — el espejo                                              */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * EL MISMO CULTIVO, LA MISMA PLAGA, EL MISMO CLIMA. Solo cambia una decisión.
+ * Todo lo demás es idéntico a propósito: si algo más cambiara, el campesino
+ * podría echarle la culpa a otra cosa. Es un experimento controlado dibujado.
+ */
+export const PARCELAS = [
+  {
+    id: 'viva',
+    lado: -1,
+    nombre: 'Con ejército',
+    borde: 'flores',
+    fondo: 'rastrojo',
+    suelo: 'sueloVivo',
+    fumiga: false,
+    /* Los benéficos VIVEN acá porque tienen las tres cosas. */
+    habitat: ['comida', 'flores', 'refugio'],
+  },
+  {
+    id: 'limpia',
+    lado: 1,
+    nombre: 'Sin ejército',
+    borde: 'pelado',
+    fondo: 'alambre',
+    suelo: 'sueloPelado',
+    /* Fumiga de amplio espectro apenas ve el primer bicho — por miedo, no por
+       evidencia. Es la decisión que el mundo entero está discutiendo. */
+    fumiga: true,
+    fumigaSemana: 3,
+    habitat: [],
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/*  EL RELATO — lo que la escena tiene que dejar dicho, sin una palabra        */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Contrato del arte. Si al final una de estas frases no se lee EN EL DIBUJO,
+ * el mundo falló, por bonito que haya quedado. Se dejan escritas acá para que
+ * cualquiera que toque esta carpeta pueda medir contra qué.
+ */
+export const RELATO = [
+  'Ese gusano oscuro con manchas naranjas es una mariquita bebé. No lo mate.',
+  'Matar todo = quedarse sin ejército. Y el que se recupera primero es el pulgón.',
+  'Los aliados trabajan gratis, todo el día y toda la noche.',
+  'Un poco de plaga es la comida que los mantiene. El lote impecable es indefenso.',
+  'Sin flores y sin refugio no se quedan, aunque no los fumigue.',
+  'Fumigar antes del umbral es pagar por perder.',
+];
+
+/* El ciclo del mundo: 12 semanas de cultivo en ~26 segundos. Suficiente para
+   que la curva se lea sin que nadie se aburra; el rebote de la parcela limpia
+   cae ~2/3 del ciclo, con tiempo de sobra para que la explosión se vea venir. */
+export const CICLO = {
+  semanas: 12,
+  duracionSeg: 26,
+  /* El día/noche corre más rápido que las semanas: 4 vueltas por ciclo, para
+     que el turno de noche alcance a mostrarse sin volver el mundo un estrobo. */
+  diasPorCiclo: 4,
+};
+
+/* Cuánto elenco aguanta cada tier. La lección mínima (prioridad 1) llega hasta
+   el teléfono más humilde: larva + adulto + avispa + pulgón. Lo demás es lujo,
+   y el lujo es lo primero que se cae. */
+export const CUPO_POR_TIER = {
+  alto: { prioridadMax: 3, pulgonMax: 120, aliadosMax: 26, hongos: true, noche: true },
+  medio: { prioridadMax: 2, pulgonMax: 70, aliadosMax: 14, hongos: true, noche: true },
+  bajo: { prioridadMax: 1, pulgonMax: 34, aliadosMax: 7, hongos: false, noche: false },
+};
+
+/** Los aliados que caben en un tier, ya filtrados por prioridad. */
+export function elencoDeTier(tier) {
+  const cupo = CUPO_POR_TIER[tier] || CUPO_POR_TIER.medio;
+  return ALIADOS.filter(
+    (a) => a.prioridad <= cupo.prioridadMax && (cupo.noche || a.turno !== 'noche'),
+  );
+}
+
+/** Los invisibles (hongos/bacteria) que caben en un tier. */
+export function invisiblesDeTier(tier) {
+  const cupo = CUPO_POR_TIER[tier] || CUPO_POR_TIER.medio;
+  if (!cupo.hongos) return [];
+  return INVISIBLES.filter((h) => h.prioridad <= cupo.prioridadMax);
+}

--- a/src/visual/mundo3d/beneficos/dinamicaPlaga.js
+++ b/src/visual/mundo3d/beneficos/dinamicaPlaga.js
@@ -1,0 +1,243 @@
+/*
+ * dinamicaPlaga — EL ARGUMENTO, HECHO NÚMEROS.
+ *
+ * Esta es la pieza que decide si el mundo dice la verdad o solo hace una
+ * animación bonita. La escena NO decide a mano "acá el pulgón explota porque
+ * queda dramático": corre este modelo y DIBUJA EL RESULTADO. Si el modelo dijera
+ * otra cosa, la escena mostraría otra cosa. Esa es la diferencia entre enseñar y
+ * hacer propaganda — y a un campesino que se juega la comida no se le hace
+ * propaganda.
+ *
+ * ── EL MODELO ───────────────────────────────────────────────────────────────
+ * Un Lotka-Volterra con techo logístico, discreto por semanas. Dos poblaciones
+ * normalizadas 0..1: PLAGA (pulgón) y EJÉRCITO (los benéficos).
+ *
+ *   plaga'    = r·plaga·(1 − plaga/K)  −  a·plaga·ejercito
+ *   ejercito' = e·a·plaga·ejercito  −  m·ejercito  +  inmigración(hábitat)
+ *
+ * El pulgón es r-estratega: se reproduce MUY rápido (r alto). El benéfico crece
+ * despacio y solo si hay presa. Esa asimetría —y no una opinión— es lo que hace
+ * que fumigar de amplio espectro se devuelva como un bumerán:
+ *
+ *   1. La bomba mata a los DOS por igual (no distingue: eso es "amplio espectro").
+ *   2. El pulgón, con r alto, se recupera en dos semanas.
+ *   3. El benéfico, con r bajo y SIN PRESA que comer, no se recupera: se fue o
+ *      se murió. Y si el lote no tiene flores ni refugio, tampoco llega de afuera.
+ *   4. Resultado: el pulgón crece SIN FRENO y pasa el umbral MUY por encima de
+ *      donde habría llegado si no se hubiera fumigado nunca.
+ *
+ * Eso se llama RESURGENCIA DE PLAGA y es de los fenómenos mejor documentados del
+ * MIP. Acá no está afirmado: está SIMULADO. Corré `serie()` y miralo salir.
+ *
+ * ── LO QUE EL MODELO NO ES ─────────────────────────────────────────────────
+ * No es una predicción de campo ni pretende serlo: es la CARICATURA HONESTA de
+ * una dinámica real, con números elegidos para que 12 semanas quepan en 26
+ * segundos y se lean en un teléfono. Los órdenes de magnitud y la FORMA de las
+ * curvas son fieles (r_plaga ≫ r_benéfico, rebote por encima del basal); los
+ * valores exactos son escénicos. Si algún día esto alimenta una recomendación
+ * agronómica de verdad, se calibra con datos de campo — hoy es dirección de arte
+ * con conciencia, y se dice de frente en vez de disimularlo.
+ *
+ * SIN THREE, SIN REACT: puro, determinista, testeable headless. La escena lo
+ * consume; nadie más necesita saber que existe.
+ */
+
+/* -------------------------------------------------------------------------- */
+/*  Parámetros — la asimetría es el mensaje                                    */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Estos números NO se eligieron a ojo: se barrieron hasta que la curva contara
+ * la verdad con la tensión correcta (ver la nota de calibración al pie).
+ */
+export const PARAMS = {
+  /* LA PLAGA: crece rapidísimo. "El pulgón se reproduce muy rápido" — corpus. */
+  rPlaga: 1.05, // tasa de crecimiento semanal (r-estratega)
+  kPlaga: 1.0, // techo: lo que el cultivo aguanta de alimento
+
+  /* EL EJÉRCITO: crece despacio, y SOLO si hay qué comer. */
+  ataque: 1.9, // a: eficiencia de depredación
+  conversion: 0.5, // e: cuánta presa se vuelve benéfico nuevo
+  mortalidad: 0.3, // m: se muere/emigra si no hay presa
+
+  /*
+   * LA INMIGRACIÓN: el goteo de benéficos que ENTRA desde el hábitat (flores +
+   * refugio). Es chiquito pero es LA DIFERENCIA ENTRE LAS DOS PARCELAS: la viva
+   * lo tiene, la limpia no. Un lote pelado no recibe refuerzos aunque quiera.
+   * Es, literalmente, el valor de sembrar flores — expresado como número.
+   */
+  inmigracionConHabitat: 0.04,
+  inmigracionSinHabitat: 0.0,
+
+  /* LA BOMBA de amplio espectro: mata parejo. Que el benéfico caiga MÁS que la
+     plaga no es capricho — es lo que reporta el campo (son más frágiles, están
+     expuestos encima de la hoja, y son muchos menos para empezar). */
+  venenoMataPlaga: 0.92, // 92% de la plaga
+  venenoMataEjercito: 0.97, // 97% del ejército  ← el detalle que arruina todo
+
+  /* Estado inicial: el cultivo arranca con una brizna de plaga y una brizna de
+     ejército. Ambas parcelas EXACTAMENTE IGUAL: si arrancaran distinto, el
+     experimento no probaría nada. */
+  plaga0: 0.06,
+  ejercito0: 0.065,
+};
+
+/*
+ * ── CALIBRACIÓN (por qué estos números y no otros) ──────────────────────────
+ * Barridos hasta que la curva contara la verdad CON la tensión correcta. Con los
+ * valores de arriba, `veredicto()` da:
+ *
+ *   picoViva    0.52  ← en la semana 5: SUBE HASTA ROZAR EL UMBRAL (0.55) Y NO
+ *                       LO CRUZA. Ese casi es el corazón de la escena: el
+ *                       campesino ve la plaga trepar hacia la línea, siente el
+ *                       impulso de sacar la bomba… y el ejército la dobla justo
+ *                       antes. Es el dibujo de "no fumigue por miedo, fumigue
+ *                       por evidencia".
+ *   finViva     0.16  ← queda plaga baja: LA DESPENSA. Nunca cero, nunca drama.
+ *   picoLimpia  0.99  ← revienta el umbral y satura el cultivo.
+ *   finLimpia   0.98  ← termina MUCHO peor que la parcela que nadie tocó.
+ *   ejercitoFinLimpia ≈ 0  ← y sin ejército, ya no hay vuelta: el año entrante
+ *                             arranca igual de indefenso. Ese cero es la factura.
+ *
+ * Una tentación que se rechazó: dejar que la parcela viva cruzara el umbral
+ * (con los parámetros iniciales picaba en 0.69). Es defendible en campo — el
+ * control biológico es un vaivén, no un muro — pero rompía la lectura: si la
+ * viva TAMBIÉN cruza, el dibujo parece decir "los benéficos tampoco alcanzan" y
+ * el mundo se pega un tiro en el pie. Se prefirió la versión donde el ejército
+ * aplana el pico ANTES de la línea, que es el caso típico bien documentado y el
+ * que el corpus describe ("si la presión es baja, la naturaleza sola lo controla
+ * en una a dos semanas"). Queda dicho para que nadie lo "arregle" sin saber.
+ */
+
+/* -------------------------------------------------------------------------- */
+/*  El paso                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Un paso semanal del sistema. Puro: (estado, opciones) → estado nuevo.
+ *
+ * @param {{plaga:number, ejercito:number}} s estado actual
+ * @param {{habitat?:boolean, veneno?:boolean, dt?:number}} [op]
+ *   habitat: ¿hay flores y refugio? (llega inmigración)
+ *   veneno:  ¿se fumigó de amplio espectro ESTA semana?
+ * @returns {{plaga:number, ejercito:number}}
+ */
+export function paso(s, op = {}) {
+  const { habitat = false, veneno = false, dt = 1 } = op;
+  const P = PARAMS;
+  let { plaga, ejercito } = s;
+
+  /* 1. La bomba, si cayó: primero y sin piedad, a los dos. */
+  if (veneno) {
+    plaga *= 1 - P.venenoMataPlaga;
+    ejercito *= 1 - P.venenoMataEjercito;
+  }
+
+  /* 2. La plaga crece contra su techo, menos lo que se comen. */
+  const depredado = P.ataque * plaga * ejercito;
+  const crecePlaga = P.rPlaga * plaga * (1 - plaga / P.kPlaga);
+  let plagaN = plaga + dt * (crecePlaga - depredado);
+
+  /* 3. El ejército crece con lo que comió, se muere si no comió, y recibe el
+        goteo del hábitat. Sin presa y sin hábitat: se apaga. */
+  const inmigra = habitat ? P.inmigracionConHabitat : P.inmigracionSinHabitat;
+  let ejercitoN = ejercito + dt * (P.conversion * depredado - P.mortalidad * ejercito + inmigra);
+
+  /* 4. Piso y techo. El piso de la plaga NO es cero a propósito: siempre queda
+        una brizna (viene de afuera, del monte, del vecino). Que no exista el
+        cero es parte de la lección — el lote estéril no existe, y tampoco se
+        quiere. */
+  plagaN = Math.min(1, Math.max(0.004, plagaN));
+  ejercitoN = Math.min(1, Math.max(0, ejercitoN));
+
+  return { plaga: plagaN, ejercito: ejercitoN };
+}
+
+/**
+ * La serie completa de una parcela, semana a semana.
+ *
+ * @param {{semanas?:number, habitat?:boolean, fumigaSemana?:number|null, sub?:number}} [op]
+ *   fumigaSemana: en qué semana cae la bomba (null = nunca)
+ *   sub: sub-pasos por semana (integración más suave para la curva dibujada)
+ * @returns {Array<{semana:number, plaga:number, ejercito:number, veneno:boolean}>}
+ */
+export function serie(op = {}) {
+  const { semanas = 12, habitat = false, fumigaSemana = null, sub = 4 } = op;
+  const out = [];
+  let s = { plaga: PARAMS.plaga0, ejercito: PARAMS.ejercito0 };
+  out.push({ semana: 0, plaga: s.plaga, ejercito: s.ejercito, veneno: false });
+
+  for (let w = 1; w <= semanas; w++) {
+    const fumiga = fumigaSemana != null && w === fumigaSemana;
+    for (let k = 0; k < sub; k++) {
+      s = paso(s, {
+        habitat,
+        /* La bomba cae UNA vez, en el primer sub-paso de esa semana. */
+        veneno: fumiga && k === 0,
+        dt: 1 / sub,
+      });
+    }
+    out.push({ semana: w, plaga: s.plaga, ejercito: s.ejercito, veneno: fumiga });
+  }
+  return out;
+}
+
+/**
+ * Muestreo continuo de una serie: interpola entre semanas para que la escena
+ * pueda pedir "cómo está el cultivo en t=0.63 del ciclo" y animar liso.
+ *
+ * @param {Array} serieDatos salida de `serie()`
+ * @param {number} t 0..1 del ciclo
+ */
+export function muestra(serieDatos, t) {
+  const n = serieDatos.length - 1;
+  const x = Math.min(n, Math.max(0, t * n));
+  const i = Math.floor(x);
+  const f = x - i;
+  const a = serieDatos[i];
+  const b = serieDatos[Math.min(n, i + 1)];
+  return {
+    semana: x,
+    plaga: a.plaga + (b.plaga - a.plaga) * f,
+    ejercito: a.ejercito + (b.ejercito - a.ejercito) * f,
+    /* El fogonazo del veneno dura poco: se usa para el flash de la niebla. */
+    veneno: b.veneno && f < 0.5,
+  };
+}
+
+/**
+ * Las dos series del espejo, ya listas para la escena. Mismo cultivo, misma
+ * plaga, mismo clima — UNA sola decisión de diferencia.
+ *
+ * @param {{semanas?:number, fumigaSemana?:number}} [op]
+ */
+export function espejo(op = {}) {
+  const { semanas = 12, fumigaSemana = 3 } = op;
+  return {
+    viva: serie({ semanas, habitat: true, fumigaSemana: null }),
+    limpia: serie({ semanas, habitat: false, fumigaSemana }),
+  };
+}
+
+/**
+ * El veredicto, para quien quiera auditar el modelo sin dibujarlo (o para un
+ * test que se asegure de que el mundo no está mintiendo). Devuelve los números
+ * que sostienen el argumento entero.
+ */
+export function veredicto(op = {}) {
+  const { viva, limpia } = espejo(op);
+  const pico = (s) => s.reduce((m, p) => Math.max(m, p.plaga), 0);
+  const fin = (s) => s[s.length - 1].plaga;
+  return {
+    picoViva: pico(viva),
+    picoLimpia: pico(limpia),
+    finViva: fin(viva),
+    finLimpia: fin(limpia),
+    ejercitoFinViva: viva[viva.length - 1].ejercito,
+    ejercitoFinLimpia: limpia[limpia.length - 1].ejercito,
+    /* La frase del mundo, verificable: la parcela fumigada termina PEOR que la
+       que nunca se tocó. Si esto diera `false`, el mundo no tendría derecho a
+       existir y habría que arreglar el modelo — no el dibujo. */
+    fumigarSalioPeor: fin(limpia) > fin(viva),
+  };
+}

--- a/src/visual/mundo3d/beneficos/index.js
+++ b/src/visual/mundo3d/beneficos/index.js
@@ -1,0 +1,66 @@
+/*
+ * beneficos/ — LOS ALIADOS INVISIBLES, en una sola puerta.
+ *
+ *   import { ALIADOS, UMBRAL, RELATO, veredicto } from '../beneficos';
+ *
+ * ── CÓMO SE MONTA ───────────────────────────────────────────────────────────
+ * Este barrel NO importa three (la regla de `polinizadores/index.js`): los datos
+ * y la dinámica son seguros en el bundle base y sirven para fichas, textos y
+ * tests. Los `*.geom.js` y el `.jsx` SÍ arrastran three → perezosos:
+ *
+ *   const Escena = React.lazy(() =>
+ *     import('.../visual/mundo3d/beneficos/EscenaBeneficos.jsx'));
+ *
+ *   <Escena tier={tier} reducedMotion={rm} />
+ *
+ * EL MUNDO en una frase: el campesino ve un bicho y lo mata; cuando fumiga de
+ * amplio espectro mata más aliados que plagas, y por eso al año siguiente hay
+ * MÁS plaga, no menos. Acá se ve el ejército que trabaja gratis, y se ve —en dos
+ * parcelas gemelas— lo que cuesta perderlo.
+ *
+ * Qué hay adentro:
+ *
+ *   beneficosIdentidad.js   LA VERDAD COMO DATOS (three-free): el elenco con su
+ *                           oficio, el arco de la mariquita, la triada del
+ *                           hábitat, el umbral, el relato. Grounded en el corpus
+ *                           maestro de MIP (140 pares) y plagas (135).
+ *   dinamicaPlaga.js        EL ARGUMENTO HECHO NÚMEROS (puro): Lotka-Volterra
+ *                           con techo. La escena DIBUJA su salida — no finge el
+ *                           desenlace. `veredicto()` lo deja auditar.
+ *   beneficos.geom.js       LA FORMA (three-core, headless): cada bicho por su
+ *                           oficio, low-poly con vertex colors.
+ *   EscenaBeneficos.jsx     EL ESPEJO: las dos parcelas + el arco en primer plano.
+ *
+ * REGISTRO: REALISTA. Esto es fauna secundaria (GUIA-RUBBERHOSE.md §1): sin ojos
+ * de goma, sin tinta, sin chapetas, sin line-boil. Los personajes rubber-hose
+ * (los 9 bichos, Angelita) viven en `creatures/` y NO se mezclan con esto.
+ *
+ * EL SÍRFIDO ADULTO NO ESTÁ ACÁ Y NO DEBE ESTARLO: ya vive en
+ * `mundo3d/polinizadores/`. Este módulo aporta su LARVA depredadora — la mitad
+ * del oficio que allá falta. Ver `ADULTO_SIRFIDO` en la identidad antes de
+ * ceder a la tentación de redibujarlo.
+ *
+ * La escena importa three → cargala perezosa desde el host:
+ *   const EscenaBeneficos = lazy(() => import('../beneficos/EscenaBeneficos.jsx'));
+ */
+export {
+  PAL,
+  ALIADOS,
+  INVISIBLES,
+  ADULTO_SIRFIDO,
+  ARCO_MARIQUITA,
+  HABITAT,
+  UMBRAL,
+  PARCELAS,
+  RELATO,
+  CICLO,
+  CUPO_POR_TIER,
+  elencoDeTier,
+  invisiblesDeTier,
+} from './beneficosIdentidad.js';
+
+export { PARAMS, paso, serie, muestra, espejo, veredicto } from './dinamicaPlaga.js';
+
+/* La escena NO se re-exporta acá a propósito: arrastraría three (y react-three)
+   al bundle base y este barrel dejaría de ser seguro. Se importa perezosa desde
+   el host, como manda la casa. */


### PR DESCRIPTION
## Qué aporta

Rescata `fable/beneficos-21` (2026-07-15), **VIVA** en el triaje (#8 en orden de valor). Mundo de insectos benéficos vs. dinámica de plaga, 5 archivos: `EscenaBeneficos.jsx`, `beneficos.geom.js`, `beneficosIdentidad.js`, `dinamicaPlaga.js`, `index.js`.

Parte del lote de mundos autónomos del 2026-07-15 (junto a `biodigestor-15`, `olor-visible-16`, `red-bajo-glifosato-17`, `semillas-criollas-22`). Con este PR quedan rescatados los 5 mundos completos del lote.

## Por qué estaba perdida

Sin PR, nunca integrada a `dev`.

## Estado

- `npm run build` → **OK** (~51s).
- Merge sin conflictos — 5/5 archivos nuevos.
- Disponible pero **no cableado al router**.
- **NO mergeado.** Draft para revisión del operador.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>