### PR TITLE
rescate: fable/diferencial-dano-18 — plaga vs enfermedad vs deficiencia

### DIFF
--- a/src/visual/diferencial/LaminaDiferencial.jsx
+++ b/src/visual/diferencial/LaminaDiferencial.jsx
@@ -1,0 +1,595 @@
+import React from 'react';
+import { blob, puntoEnHoja, frass as frassDe } from './formasHoja.js';
+import {
+  HojaBase,
+  PolvoRoya,
+  RoyaPorElHaz,
+  ManchaCercospora,
+  ClorosisHierro,
+  Gusano,
+  Frass,
+  Pliego,
+  Rotulo,
+  Lupa,
+  Vineta,
+} from './motivosDano.jsx';
+import {
+  PLIEGO,
+  TINTA,
+  HOJA_SANA,
+  PLAGA,
+  ENFERMEDAD,
+  DEFICIENCIA,
+  CATEGORIA,
+} from './paletaDano.js';
+
+/**
+ * LaminaDiferencial — LA lámina: plaga, enfermedad y deficiencia, lado a lado,
+ * sobre LA MISMA hoja de café.
+ *
+ * Por qué existe: es la confusión que más plata le cuesta al campesino. Le
+ * echa fungicida a un pulgón, o veneno a una falta de nitrógeno. Gasta, no
+ * resuelve, y de paso mata a los benéficos que le estaban trabajando gratis.
+ *
+ * El diseño entero está al servicio de UNA idea: **lo que distingue no es el
+ * color, es el ORDEN del daño.**
+ *   - la deficiencia es ORDENADA y simétrica (va parejo, sigue la nervadura);
+ *   - la enfermedad tiene FORMA (halo, borde que se sigue con el dedo, anillos);
+ *   - la plaga es un DESASTRE irregular (mordidas, huecos, rastro, el bicho).
+ *
+ * Cuatro decisiones de dibujo que sostienen eso:
+ *   1. LA HOJA ES LA MISMA en los tres paneles — misma geometría, calculada
+ *      una sola vez en `formasHoja`. Si la hoja cambiara, no se sabría si lo
+ *      distinto es el daño o el dibujo. Controlada la hoja, lo único que
+ *      varía es la marca.
+ *   2. Cada marca está calcada de una FOTO REAL de `public/plaga-images/`, no
+ *      inventada: el polvo de la roya es grano (no pintura naranja), la
+ *      mancha de hierro tiene su borde y su halo, la mordida tiene su filo
+ *      pardo cicatrizado.
+ *   3. La LUPA de cada columna no es un zoom del mismo dibujo: es la marca
+ *      redibujada con la información que uno gana al acercar la cara a la
+ *      mata. Y en la columna de la enfermedad, la lupa muestra EL ENVÉS —
+ *      porque ahí es donde está la respuesta y hay que voltear la hoja.
+ *   4. Los rótulos sobre la hoja son CORTOS (son punteros, no explicaciones);
+ *      lo que hay que entender va en las viñetas, que sí tienen ancho. Un
+ *      rótulo largo se le monta a la columna del vecino y se vuelve ilegible.
+ *
+ * Y el pie dice lo que ninguna lámina suele decir: que hay casos en que NO se
+ * puede saber sin ver la mata de cerca. La duda es parte del método.
+ *
+ * Estática, sin dependencias, sin animación, rsvg-safe. Papel y tinta de la
+ * casa (`src/visual/laminas`), para que el cuaderno se lea como uno solo.
+ *
+ * @param {Object} props
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Geometría de la página (todo medido, nada a ojo)                    */
+/* ------------------------------------------------------------------ */
+const W = 420;
+const H = 604;
+const COL = { plaga: 70, enfermedad: 210, deficiencia: 350 };
+const BASE_Y = 252; // dónde se para la hoja
+const ESC = 1; // la hoja mide 140 de largo y así entra en la columna
+
+/** Punto de la hoja (t a lo largo, u a lo ancho) llevado a la página. */
+const enPagina = (cx, t, u) => {
+  const p = puntoEnHoja(t, u);
+  return { x: cx + p.x * ESC, y: BASE_Y + p.y * ESC };
+};
+
+/** Una marca posada en coordenadas de hoja (así siempre cae DENTRO). */
+const marca = (t, u, r, semilla, extra = {}) => {
+  const p = puntoEnHoja(t, u);
+  return { cx: p.x, cy: p.y, r, semilla, ...extra };
+};
+
+/* --- PLAGA: lo que se comió el bicho ------------------------------- */
+const bocado = (t, u, r, semilla, extra = {}) =>
+  blob({ ...marca(t, u, r, semilla), lobulos: 4, rugosidad: 0.42, ...extra });
+
+/* Los huecos de en medio van ESTIRADOS en la dirección de la vena (unos -29°
+   por el lado derecho, +29° por el izquierdo): el gusano esquiva la nervadura
+   dura y se come lo blandito de entre vena y vena, así que el hueco sale
+   alargado, no redondo. Un hueco redondo perfecto sería un dibujo inventado
+   — y de paso parecería una florecita pegada en la hoja. */
+const VENA_DER = -29;
+const VENA_IZQ = 29;
+
+/* Una hoja masticada se reconoce por las BAHÍAS DEL BORDE, no por lunares:
+   el bicho arranca del filo hacia adentro. (Primer intento: ocho huecos
+   redonditos regados por la lámina — parecían florecitas pegadas, y con más
+   ruido parecían estrellas. La hoja mordida de verdad se come por la orilla.)
+   Van pocas y grandes, ni una igual a otra, y un solo hueco de en medio. */
+const MORDIDAS = [
+  /* Grandes, pero no tanto: la silueta de la hoja TIENE que sobrevivir. Si el
+     bicho se la come entera, se pierde que es la misma hoja de las otras dos
+     columnas — y ahí se cae la comparación, que es todo el punto. */
+  bocado(0.7, 1.06, 10.5, 12, { rugosidad: 0.34 }),
+  bocado(0.4, -1.08, 9, 23, { rugosidad: 0.36 }),
+  bocado(0.87, -1.02, 6, 34, { rugosidad: 0.34 }),
+  bocado(0.22, 1.06, 5.5, 67, { rugosidad: 0.32 }),
+  bocado(0.55, 0.46, 3, 45, { alargue: 1.9, rot: VENA_DER, lobulos: 3, rugosidad: 0.22 }),
+];
+
+/* La ventana: acá el gusano raspó lo blandito y dejó el costillar. */
+const VENTANAS = [
+  bocado(0.6, -0.44, 7.5, 91, { alargue: 1.5, rot: VENA_IZQ, lobulos: 3, rugosidad: 0.26 }),
+];
+
+/* --- ENFERMEDAD: roya (polvo) + mancha de hierro (patrón) ---------- */
+const ROYA = [
+  marca(0.7, 0.46, 7, 71, { alargue: 1.15, densidad: 150 }),
+  marca(0.5, -0.5, 5.4, 82, { alargue: 1.2, densidad: 120 }),
+  marca(0.33, 0.34, 3.8, 93, { alargue: 1, densidad: 70 }),
+];
+const CERCO = marca(0.62, -0.34, 7, 5);
+
+/* ------------------------------------------------------------------ */
+/* Piezas de la página                                                 */
+/* ------------------------------------------------------------------ */
+
+/** La pestaña con el nombre de la categoría. El color NO es un semáforo de
+ *  UI: es el color de la propia evidencia (el pardo del bicho, el naranja
+ *  del polvo, el amarillo del hambre). El color ya enseña antes de leer. */
+function Pestana({ cx, cat }) {
+  const c = CATEGORIA[cat];
+  return (
+    <g>
+      <rect x={cx - 58} y="50" width="116" height="19" rx="5" fill={c.chip} fillOpacity="0.32" stroke={c.tinta} strokeWidth="0.9" />
+      <text x={cx} y="63.5" textAnchor="middle" fontSize="10.5" fontWeight="800" fill={c.tinta} letterSpacing="0.08em">
+        {c.nombre}
+      </text>
+    </g>
+  );
+}
+
+/** El recuadro de "lo que NO sirve": la plata que se pierde por confundirse.
+ *  Con una equis dibujada a mano (nada de emoji: la lámina tiene que
+ *  sobrevivir a una captura con rsvg). */
+function NoSirve({ cx, cat, lineas }) {
+  const c = CATEGORIA[cat];
+  return (
+    <g>
+      <rect x={cx - 58} y="428" width="116" height="26" rx="4" fill={c.chip} fillOpacity="0.14" stroke={c.tinta} strokeWidth="0.7" strokeDasharray="3 2" opacity="0.95" />
+      <g stroke="#a33b28" strokeWidth="1.3" strokeLinecap="round">
+        <path d={`M${cx - 53} 437 l4.6 4.6`} />
+        <path d={`M${cx - 48.4} 437 l-4.6 4.6`} />
+      </g>
+      {lineas.map((l, i) => (
+        <text key={i} x={cx - 42} y={439 + i * 9} fontSize="6.6" fill={TINTA.media}>
+          {l}
+        </text>
+      ))}
+    </g>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Las tres lupas: la marca redibujada de cerca                        */
+/* ------------------------------------------------------------------ */
+
+/** PLAGA de cerca: el filo de la mordida.
+ *  El detalle que lo delata todo: el bicho se comió lo BLANDITO y dejó la
+ *  vena parada, asomada al vacío. Ningún hongo hace eso. */
+function LupaPlaga({ cx, cy, r }) {
+  const comido = blob({ cx: 22, cy: -14, r: 32, semilla: 12, lobulos: 4, rugosidad: 0.28 });
+  const cacas = frassDe({ cx: -18, cy: 22, n: 6, radio: 7, semilla: 77 });
+  return (
+    <Lupa cx={cx} cy={cy} r={r} titulo="LA MORDIDA, DE CERCA" tinta={CATEGORIA.plaga.tinta}>
+      <g transform={`translate(${cx} ${cy})`}>
+        <rect x="-40" y="-40" width="80" height="80" fill={HOJA_SANA.haz} />
+        {/* la lámina de cerca: se le ven las venitas finas y el abullonado */}
+        <g stroke={HOJA_SANA.venaSurco} strokeWidth="0.45" opacity="0.3" fill="none">
+          <path d="M-40 -4 Q -16 -8 10 -12" />
+          <path d="M-40 14 Q -14 10 14 6" />
+          <path d="M-40 30 Q -12 27 18 24" />
+          <path d="M-26 -40 Q -22 -8 -18 34" />
+        </g>
+        {/* el halo amarillo de la herida; encima, el hueco (se ve el papel) */}
+        <path d={comido} fill="none" stroke={PLAGA.mordidaHalo} strokeWidth="10" opacity="0.55" />
+        <path d={comido} fill={PLIEGO.papelHondo} />
+        <path d={comido} fill="none" stroke={PLAGA.mordidaFilo} strokeWidth="1.8" />
+        {/* LA VENA QUE QUEDÓ PARADA: se comió lo blandito de al lado y la
+            dejó asomada. Va con su surco y afinándose en la punta. */}
+        <path d="M-40 6 Q -8 0 20 -8" fill="none" stroke={HOJA_SANA.venaSurco} strokeWidth="3.4" strokeLinecap="round" opacity="0.55" />
+        <path d="M-40 6 Q -8 0 20 -8" fill="none" stroke={HOJA_SANA.vena} strokeWidth="2.4" strokeLinecap="round" />
+        <path d="M20 -8 q6 -1.6 10 -3" fill="none" stroke={HOJA_SANA.vena} strokeWidth="1.2" strokeLinecap="round" opacity="0.9" />
+        {/* el rastro: caquita, más grande de cerca */}
+        {cacas.map((b, i) => (
+          <g key={i} transform={`translate(${b.x} ${b.y}) rotate(${b.rot})`}>
+            <rect x={-b.w * 1.2} y={-b.h * 1.2} width={b.w * 2.4} height={b.h * 2.4} rx={b.h} fill={PLAGA.frass} />
+            <rect x={-b.w * 1.2} y={-b.h * 1.2} width={b.w * 2.4} height={b.h} rx={b.h * 0.5} fill={PLAGA.frassClaro} opacity="0.6" />
+          </g>
+        ))}
+      </g>
+    </Lupa>
+  );
+}
+
+/** ENFERMEDAD de cerca: EL ENVÉS. Acá está la respuesta, y por eso la lámina
+ *  manda a voltear la hoja. Por el haz uno solo ve una mancha amarilla
+ *  cualquiera; por debajo está el polvo naranja que no deja duda. */
+function LupaEnfermedad({ cx, cy, r }) {
+  return (
+    <Lupa cx={cx} cy={cy} r={r} titulo="EL ENVÉS, DE CERCA" tinta={CATEGORIA.enfermedad.tinta}>
+      <g transform={`translate(${cx} ${cy})`}>
+        <rect x="-40" y="-40" width="80" height="80" fill={HOJA_SANA.envesFondo} />
+        {/* en el envés la nervadura va SALIDA y pálida: por eso el envés se
+            reconoce de una, aunque uno no sepa por qué */}
+        <g fill="none" strokeLinecap="round">
+          <path d="M-42 26 Q -6 19 42 15" stroke={HOJA_SANA.venaSurco} strokeWidth="6.4" opacity="0.22" />
+          <path d="M-42 24 Q -6 17 42 13" stroke="#a8c07e" strokeWidth="4" />
+          <path d="M-42 23 Q -6 16 42 12" stroke="#c3d69c" strokeWidth="1.4" opacity="0.8" />
+          <path d="M-14 -40 Q -8 -12 -2 22" stroke="#a8c07e" strokeWidth="2.4" opacity="0.75" />
+        </g>
+        <PolvoRoya
+          manchas={[
+            { cx: -6, cy: -12, r: 15, semilla: 71, alargue: 1.15, densidad: 240 },
+            { cx: 19, cy: 6, r: 9, semilla: 82, alargue: 1, densidad: 130 },
+          ]}
+        />
+      </g>
+    </Lupa>
+  );
+}
+
+/** DEFICIENCIA de cerca: la prueba de que NO es una mancha.
+ *  El verde no se corta: se DESVANECE desde la vena hacia afuera. No hay
+ *  borde que uno pueda seguir con el dedo, no hay halo, no hay bicho.
+ *  Se dibuja con nervio y laterales de verdad (no una cruz) para que se lea
+ *  como tejido de hoja y no como un cruce de caminos. */
+function LupaDeficiencia({ cx, cy, r }) {
+  const nervio = 'M-34 34 Q -6 2 30 -30';
+  const laterales = [
+    'M-22 21 Q -8 6 6 -2',
+    'M-10 8 Q 6 -2 22 -6',
+    'M2 -6 Q 14 -14 26 -12',
+    'M-26 26 Q -30 8 -22 -8',
+  ];
+  return (
+    <Lupa cx={cx} cy={cy} r={r} titulo="EL AMARILLO, DE CERCA" tinta={CATEGORIA.deficiencia.tinta}>
+      <defs>
+        <filter id="lupafe-b" x="-40%" y="-40%" width="180%" height="180%">
+          <feGaussianBlur stdDeviation="3.4" />
+        </filter>
+      </defs>
+      <g transform={`translate(${cx} ${cy})`}>
+        <rect x="-40" y="-40" width="80" height="80" fill={DEFICIENCIA.hierroLamina} />
+        {/* el corredor verde que sobrevive pegado a la vena: se va apagando,
+            NO se corta. Ahí está toda la diferencia con una mancha. */}
+        <g filter="url(#lupafe-b)" fill="none" strokeLinecap="round">
+          <path d={nervio} stroke={DEFICIENCIA.hierroVenaHalo} strokeWidth="13" />
+          {laterales.map((d, i) => (
+            <path key={i} d={d} stroke={DEFICIENCIA.hierroVenaHalo} strokeWidth="8" opacity="0.9" />
+          ))}
+        </g>
+        <g fill="none" strokeLinecap="round" stroke={DEFICIENCIA.hierroVena}>
+          <path d={nervio} strokeWidth="3.4" />
+          {laterales.map((d, i) => (
+            <path key={i} d={d} strokeWidth="1.9" />
+          ))}
+        </g>
+      </g>
+    </Lupa>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Los glifos de LA LLAVE — la idea en 16 puntos de ancho              */
+/* ------------------------------------------------------------------ */
+
+/** El desorden: una hoja comida a pedazos. Silueta rota a propósito. */
+function GlifoDesorden() {
+  return (
+    <g>
+      <path
+        d="M8 -7 q6 3 6.5 7 q-0.5 4 -6.5 7 q-6 -3 -6.5 -7 q0.5 -4 6.5 -7Z"
+        fill={HOJA_SANA.haz}
+        stroke={HOJA_SANA.borde}
+        strokeWidth="0.5"
+      />
+      {/* mordidas: irregulares, cada una distinta */}
+      <path d="M14 -2 q-4 1 -3.4 4 q3.4 1 4.4 -1.6Z" fill={PLIEGO.papelHondo} stroke={PLAGA.mordidaFilo} strokeWidth="0.5" />
+      <path d="M2 4 q3 2.6 5.4 0.6 q-2 -2.6 -5 -1.6Z" fill={PLIEGO.papelHondo} stroke={PLAGA.mordidaFilo} strokeWidth="0.5" />
+      <path d="M7 -3.4 q2 1.4 0.4 2.6 q-2 -0.6 -1.4 -2.4Z" fill={PLIEGO.papelHondo} stroke={PLAGA.mordidaFilo} strokeWidth="0.4" />
+    </g>
+  );
+}
+
+/** La forma: halo, borde, centro. Se puede seguir con el dedo. */
+function GlifoForma() {
+  return (
+    <g>
+      <circle cx="8" cy="0" r="7.4" fill={ENFERMEDAD.cercoHalo} opacity="0.85" />
+      <circle cx="8" cy="0" r="4.4" fill={ENFERMEDAD.cercoCentro} stroke={ENFERMEDAD.cercoBorde} strokeWidth="0.8" />
+      <circle cx="8" cy="0" r="1.8" fill={ENFERMEDAD.cercoCentroPalido} />
+    </g>
+  );
+}
+
+/** La simetría: media hoja igualita a la otra, con su eje de doblez. */
+function GlifoSimetria() {
+  return (
+    <g>
+      <path d="M8 -8 q6.5 8 0 16 q-6.5 -8 0 -16Z" fill={DEFICIENCIA.hierroLamina} stroke={DEFICIENCIA.hierroVena} strokeWidth="0.5" />
+      <path d="M8 -4 q4.2 2.2 4.8 4.4 M8 -4 q-4.2 2.2 -4.8 4.4 M8 1.6 q3.2 1.6 3.6 3.4 M8 1.6 q-3.2 1.6 -3.6 3.4" fill="none" stroke={DEFICIENCIA.hierroVena} strokeWidth="0.6" />
+      <path d="M8 -9.6 L8 9.6" stroke={TINTA.guia} strokeWidth="0.7" strokeDasharray="1.6 1.4" />
+    </g>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* LA LÁMINA                                                           */
+/* ------------------------------------------------------------------ */
+export default function LaminaDiferencial({ className } = {}) {
+  /* dianas de los rótulos: calculadas de la hoja, no medidas a ojo */
+  const dHueco = enPagina(COL.plaga, 0.56, 0.4);
+  const dBicho = { x: COL.plaga - 14, y: BASE_Y - 42 };
+  const dCaca = enPagina(COL.plaga, 0.14, 0.3);
+  const dRoya = enPagina(COL.enfermedad, 0.7, 0.46);
+  const dCerco = enPagina(COL.enfermedad, 0.62, -0.34);
+  const dVena = enPagina(COL.deficiencia, 0.6, 0.44);
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-labelledby="lamdif-t lamdif-d"
+      className={['w-full h-auto select-none', className].filter(Boolean).join(' ')}
+      data-testid="lamina-diferencial"
+      style={{ fontFamily: 'ui-sans-serif, system-ui, sans-serif' }}
+    >
+      <title id="lamdif-t">Plaga, enfermedad o deficiencia: los tres daños en la misma hoja de café</title>
+      <desc id="lamdif-d">
+        Lámina de cuaderno de campo con tres columnas y la misma hoja de café dibujada en cada una.
+        En la primera, PLAGA: la hoja tiene mordidas irregulares y huecos con el filo pardo, un gusano
+        encima y su excremento; el daño empieza donde está el bicho. En la segunda, ENFERMEDAD: manchas
+        amarillas de roya y una mancha de hierro con borde definido y halo; la lupa muestra el envés,
+        cubierto de polvo naranja. En la tercera, DEFICIENCIA: la hoja amarillea pareja y la nervadura
+        se queda verde, formando una redecilla simétrica, sin bicho y sin borde. Al pie, la llave: la
+        plaga es un desastre irregular, la enfermedad tiene forma, el hambre va simétrica. Y una nota:
+        hay casos en que no se puede saber sin ver la mata de cerca.
+      </desc>
+
+      <Pliego w={W} h={H} />
+
+      {/* ---------------- encabezado ---------------- */}
+      <text x="16" y="26" fontSize="16.5" fontWeight="800" fill={TINTA.fuerte}>
+        ¿Plaga, enfermedad o hambre?
+      </text>
+      <text x="404" y="17" textAnchor="end" fontSize="8.5" fontStyle="italic" fill={TINTA.guia}>
+        cuaderno de campo
+      </text>
+      <text x="404" y="28" textAnchor="end" fontSize="8.5" fill={TINTA.suave}>
+        la misma hoja, tres daños
+      </text>
+      <text x="16" y="39" fontSize="9" fontStyle="italic" fill={TINTA.suave}>
+        Lo que los distingue no es el color: es el ORDEN del daño.
+      </text>
+      <line x1="14" y1="44" x2="406" y2="44" stroke={PLIEGO.borde} strokeWidth="1" />
+
+      <Pestana cx={COL.plaga} cat="plaga" />
+      <Pestana cx={COL.enfermedad} cat="enfermedad" />
+      <Pestana cx={COL.deficiencia} cat="deficiencia" />
+
+      {/* separadores entre columnas */}
+      <line x1="140" y1="74" x2="140" y2="456" stroke={PLIEGO.borde} strokeWidth="0.7" strokeDasharray="2 3" opacity="0.7" />
+      <line x1="280" y1="74" x2="280" y2="456" stroke={PLIEGO.borde} strokeWidth="0.7" strokeDasharray="2 3" opacity="0.7" />
+
+      {/* ================= COLUMNA 1 · PLAGA ================= */}
+      <g transform={`translate(${COL.plaga} ${BASE_Y}) scale(${ESC})`}>
+        <HojaBase
+          mordidas={MORDIDAS}
+          ventanas={VENTANAS}
+          encima={
+            <g>
+              <Frass cx={4} cy={-16} n={10} radio={6} semilla={31} />
+              <Frass cx={17} cy={-44} n={5} radio={4} semilla={97} />
+              {/* el bicho, comiendo justo en la bahía del borde que abrió */}
+              <Gusano x={-22} y={-55} rot={52} escala={0.95} />
+            </g>
+          }
+        />
+      </g>
+      <Rotulo
+        texto="hueco"
+        nota="filo pardo"
+        tx="100"
+        ty="150"
+        tam={8}
+        tinta={CATEGORIA.plaga.tinta}
+        guia={{ d: `M98 152 C 90 154 ${dHueco.x + 8} ${dHueco.y + 4} ${dHueco.x} ${dHueco.y}`, px: dHueco.x, py: dHueco.y }}
+      />
+      <Rotulo
+        texto="el bicho"
+        nota="o su rastro"
+        anchor="end"
+        tx="42"
+        ty="196"
+        tam={8}
+        tinta={CATEGORIA.plaga.tinta}
+        guia={{ d: `M44 194 C 50 196 54 202 ${dBicho.x} ${dBicho.y}`, px: dBicho.x, py: dBicho.y }}
+      />
+      <Rotulo
+        texto="caquita"
+        tx="100"
+        ty="240"
+        tam={8}
+        tinta={CATEGORIA.plaga.tinta}
+        guia={{ d: `M98 238 C 92 238 86 238 ${dCaca.x} ${dCaca.y}`, px: dCaca.x, py: dCaca.y }}
+      />
+      <text x={COL.plaga} y="266" textAnchor="middle" fontSize="7.5" fontStyle="italic" fill={CATEGORIA.plaga.tinta}>
+        ni una mordida igual a otra
+      </text>
+
+      <LupaPlaga cx={COL.plaga} cy={306} r={32} />
+
+      <Vineta
+        x={12}
+        y={366}
+        color={CATEGORIA.plaga.tinta}
+        lineas={[{ fuerte: 'IRREGULAR', resto: ' — no hay dos' }, 'mordidas iguales. Sin borde.']}
+      />
+      <Vineta
+        x={12}
+        y={389}
+        color={CATEGORIA.plaga.tinta}
+        lineas={[{ fuerte: 'EMPIEZA', resto: ' donde está el' }, 'bicho, no parejo en la mata.']}
+      />
+      <Vineta
+        x={12}
+        y={412}
+        color={CATEGORIA.plaga.tinta}
+        lineas={[{ fuerte: 'DEJA RASTRO', resto: ' — caquita,' }, 'telaraña, mielato. Voltee la hoja.']}
+      />
+      <NoSirve cx={COL.plaga} cat="plaga" lineas={['Fungicida no le hace nada al', 'bicho — y le mata al benéfico.']} />
+
+      {/* ================= COLUMNA 2 · ENFERMEDAD ================= */}
+      <g transform={`translate(${COL.enfermedad} ${BASE_Y}) scale(${ESC})`}>
+        <HojaBase>
+          <RoyaPorElHaz manchas={ROYA} />
+          <ManchaCercospora cx={CERCO.cx} cy={CERCO.cy} r={CERCO.r} semilla={5} />
+        </HojaBase>
+      </g>
+      <Rotulo
+        texto="roya"
+        nota="voltéela"
+        tx="244"
+        ty="140"
+        tam={8}
+        tinta={CATEGORIA.enfermedad.tinta}
+        guia={{ d: `M242 142 C 236 146 ${dRoya.x + 6} ${dRoya.y - 6} ${dRoya.x} ${dRoya.y}`, px: dRoya.x, py: dRoya.y }}
+      />
+      <Rotulo
+        texto="borde"
+        nota="y halo"
+        anchor="end"
+        tx="176"
+        ty="186"
+        tam={8}
+        tinta={CATEGORIA.enfermedad.tinta}
+        guia={{ d: `M178 184 C 184 184 ${dCerco.x - 6} ${dCerco.y + 4} ${dCerco.x} ${dCerco.y}`, px: dCerco.x, py: dCerco.y }}
+      />
+      <text x={COL.enfermedad} y="266" textAnchor="middle" fontSize="7.5" fontStyle="italic" fill={CATEGORIA.enfermedad.tinta}>
+        el borde se sigue con el dedo
+      </text>
+
+      <LupaEnfermedad cx={COL.enfermedad} cy={306} r={32} />
+
+      <Vineta
+        x={152}
+        y={366}
+        color={CATEGORIA.enfermedad.tinta}
+        lineas={[{ fuerte: 'TIENE FORMA', resto: ' — halo, borde' }, 'que usted sigue con el dedo.']}
+      />
+      <Vineta
+        x={152}
+        y={389}
+        color={CATEGORIA.enfermedad.tinta}
+        lineas={[{ fuerte: 'POR FOCOS', resto: ' — arranca en un' }, 'punto y se riega con la humedad.']}
+      />
+      <Vineta
+        x={152}
+        y={412}
+        color={CATEGORIA.enfermedad.tinta}
+        lineas={[{ fuerte: 'ROYA', resto: ' — polvo naranja en el' }, 'ENVÉS. Por el haz, solo amarillo.']}
+      />
+      <NoSirve cx={COL.enfermedad} cat="enfermedad" lineas={['Veneno de bichos no mata el', 'hongo. Plata perdida.']} />
+
+      {/* ================= COLUMNA 3 · DEFICIENCIA ================= */}
+      <g transform={`translate(${COL.deficiencia} ${BASE_Y}) scale(${ESC})`}>
+        <HojaBase tinteLamina={DEFICIENCIA.hierroLamina} conBrillo={false}>
+          <ClorosisHierro />
+        </HojaBase>
+      </g>
+      <Rotulo
+        texto="la vena"
+        nota="verde"
+        tx="382"
+        ty="150"
+        tam={8}
+        tinta={CATEGORIA.deficiencia.tinta}
+        guia={{ d: `M380 152 C 376 156 ${dVena.x + 6} ${dVena.y - 4} ${dVena.x} ${dVena.y}`, px: dVena.x, py: dVena.y }}
+      />
+      <text x={COL.deficiencia} y="266" textAnchor="middle" fontSize="7.5" fontStyle="italic" fill={CATEGORIA.deficiencia.tinta}>
+        sin bicho, sin borde, sin mancha
+      </text>
+
+      <LupaDeficiencia cx={COL.deficiencia} cy={306} r={32} />
+
+      <Vineta
+        x={292}
+        y={366}
+        color={CATEGORIA.deficiencia.tinta}
+        lineas={[{ fuerte: 'SIMÉTRICA', resto: ' — igualita a lado' }, 'y lado. Sigue la nervadura.']}
+      />
+      <Vineta
+        x={292}
+        y={389}
+        color={CATEGORIA.deficiencia.tinta}
+        lineas={[{ fuerte: 'POR EDAD', resto: ' — hierro: las hojas' }, 'NUEVAS. Nitrógeno: las VIEJAS.']}
+      />
+      <Vineta
+        x={292}
+        y={412}
+        color={CATEGORIA.deficiencia.tinta}
+        lineas={[{ fuerte: 'SIN BICHO Y SIN BORDE', resto: ' —' }, 'no hay mancha: hay hambre.']}
+      />
+      <NoSirve cx={COL.deficiencia} cat="deficiencia" lineas={['Fumigar no le da de comer:', 'esto se ALIMENTA, no se cura.']} />
+
+      {/* ================= LA LLAVE ================= */}
+      <rect x="14" y="462" width="392" height="62" rx="6" fill={PLIEGO.papelHondo} stroke={PLIEGO.borde} strokeWidth="1" />
+      <text x="24" y="476" fontSize="9.5" fontWeight="800" fill={TINTA.fuerte} letterSpacing="0.06em">
+        LA LLAVE
+      </text>
+      <text x="70" y="476" fontSize="8.5" fontStyle="italic" fill={TINTA.suave}>
+        — no se fije en el color; fíjese en el ORDEN.
+      </text>
+
+      <g transform="translate(28 491)">
+        <GlifoDesorden />
+      </g>
+      <text x="52" y="494" fontSize="8.4" fill={TINTA.media}>
+        <tspan fontWeight="800" fill={CATEGORIA.plaga.tinta}>La plaga</tspan>
+        <tspan> es un desastre irregular: mordidas distintas, y un animal detrás.</tspan>
+      </text>
+
+      <g transform="translate(28 504)">
+        <GlifoForma />
+      </g>
+      <text x="52" y="507" fontSize="8.4" fill={TINTA.media}>
+        <tspan fontWeight="800" fill={CATEGORIA.enfermedad.tinta}>La enfermedad</tspan>
+        <tspan> tiene forma: halo, borde definido, anillos. Se puede dibujar.</tspan>
+      </text>
+
+      <g transform="translate(28 517)">
+        <GlifoSimetria />
+      </g>
+      <text x="52" y="520" fontSize="8.4" fill={TINTA.media}>
+        <tspan fontWeight="800" fill={CATEGORIA.deficiencia.tinta}>El hambre</tspan>
+        <tspan> va ordenada: simétrica, siguiendo la nervadura, por edad de hoja.</tspan>
+      </text>
+
+      {/* ================= EL LÍMITE HONESTO ================= */}
+      <rect x="14" y="530" width="392" height="54" rx="6" fill="none" stroke={CATEGORIA.duda.tinta} strokeWidth="0.9" strokeDasharray="4 3" opacity="0.85" />
+      <text x="24" y="545" fontSize="9" fontWeight="800" fill={CATEGORIA.duda.tinta} letterSpacing="0.04em">
+        Y HAY VECES QUE NO SE PUEDE SABER.
+      </text>
+      <text x="24" y="557" fontSize="7.6" fill={TINTA.media}>
+        Muchos daños se parecen, y la diferencia está en detalles que no se ven de lejos. Cuando no alcanza
+      </text>
+      <text x="24" y="566.5" fontSize="7.6" fill={TINTA.media}>
+        a ver, lo correcto no es adivinar: es acercarse, voltear la hoja, sacar una matica y mirarle la raíz
+      </text>
+      <text x="24" y="576" fontSize="7.6" fill={TINTA.media}>
+        — o pedir la foto. <tspan fontStyle="italic" fontWeight="700" fill={CATEGORIA.duda.tinta}>La duda también es parte del método.</tspan>
+      </text>
+
+      <text x="16" y="594" fontSize="7" fontStyle="italic" fill={TINTA.guia}>
+        Dibujado sobre fotografías reales de campo · café (Coffea arabica) · roya, mancha de hierro, gusano
+      </text>
+    </svg>
+  );
+}

--- a/src/visual/diferencial/LaminaDuda.jsx
+++ b/src/visual/diferencial/LaminaDuda.jsx
@@ -1,0 +1,262 @@
+import React from 'react';
+import { prngDe } from './formasHoja.js';
+import { tubo } from './formasBicho.js';
+import { HojaBase, ClorosisNitrogeno, Pliego } from './motivosDano.jsx';
+import { PLIEGO, TINTA, DEFICIENCIA, CATEGORIA } from './paletaDano.js';
+
+/**
+ * LaminaDuda — cuando NO se puede saber sin ver la mata de cerca.
+ *
+ * Esta es la lámina que casi ninguna cartilla se atreve a hacer, y es la más
+ * honesta de las tres. Todo material de campo enseña a diagnosticar; casi
+ * ninguno enseña a RECONOCER QUE NO SE SABE. Y esa es una destreza de campo,
+ * no una falla: un fitopatólogo tampoco diagnostica a ciegas — por eso mismo
+ * existen las visitas de campo.
+ *
+ * El caso no es inventado para el ejemplo: es el que más se repite en el
+ * corpus. Una mata que amarillea PAREJA, hojas viejas primero, sin manchas y
+ * sin bichos, puede ser:
+ *   - falta de NITRÓGENO → se arregla con abono; o
+ *   - NEMATODO del nudo (Meloidogyne) en la raíz → amarillea igualito.
+ *
+ * Y por arriba NO SE DISTINGUEN. Por eso las dos hojas de esta lámina son,
+ * a propósito, el MISMO dibujo: el mismo componente, la misma semilla, el
+ * mismo trazo. No es pereza — es el argumento. Si el dibujante pudiera
+ * hacerlas distintas, la lámina estaría mintiendo.
+ *
+ * Pero la lámina no se queda en la duda, porque la duda sin salida es
+ * parálisis: abajo está la salida, que es barata y la puede hacer cualquiera
+ * — sacar una matica y mirarle la raíz. Ahí sí se distinguen, y sin lupa.
+ *
+ * Las agallas van calcadas de `public/plaga-images/meloidogyne.jpg`: son
+ * engrosamientos DE la raíz misma (la raíz pasa POR dentro del nudo, como
+ * cuentas ensartadas en una pita), no bolitas pegadas por fuera que uno pueda
+ * desprender. Ese detalle es el diagnóstico.
+ *
+ * @param {Object} props
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
+ */
+
+const W = 420;
+const H = 458;
+const IZQ = 110;
+const DER = 310;
+const BASE_Y = 200;
+const ESC = 0.82;
+
+/* ------------------------------------------------------------------ */
+/* LA RAÍZ — sana contra anudada                                       */
+/* ------------------------------------------------------------------ */
+const LARGO_RAIZ = 104;
+
+/* 70 muestras, no 30: cada agalla es una campana angosta, y con pocas
+   muestras el bulto sale lavado — la raíz parece ondulada en vez de anudada,
+   que es exactamente lo que NO hay que dibujar. */
+const ejeRaiz = (() => {
+  const pts = [];
+  const N = 70;
+  for (let i = 0; i < N; i += 1) {
+    const t = i / (N - 1);
+    pts.push({ x: Math.sin(t * 2.5) * 7, y: t * LARGO_RAIZ });
+  }
+  return pts;
+})();
+
+/** La raíz pivotante se va afinando hacia la punta. */
+const grosorBase = (t) => 3.3 * (1 - t * 0.74);
+
+/** Una campana suave: el bulto de una agalla. */
+const bulto = (t, c, w, h) => h * Math.exp(-((t - c) ** 2) / (2 * w * w));
+
+/* Los nudos NO son parejos ni están a la misma distancia: el nematodo pica
+   donde le queda cómodo. Un rosario regular se leería como decoración. */
+const AGALLAS = [
+  { c: 0.15, w: 0.032, h: 2.4 },
+  { c: 0.33, w: 0.038, h: 3.8 },
+  { c: 0.45, w: 0.026, h: 1.7 },
+  { c: 0.63, w: 0.035, h: 3.1 },
+  { c: 0.79, w: 0.028, h: 2.2 },
+  { c: 0.9, w: 0.022, h: 1.2 },
+];
+
+const RAIZ_SANA = tubo(ejeRaiz, grosorBase);
+const RAIZ_ANUDADA = tubo(ejeRaiz, (t) =>
+  grosorBase(t) * (1 + AGALLAS.reduce((s, a) => s + bulto(t, a.c, a.w, a.h), 0)),
+);
+
+/** Las raicitas finas: la mata come por ahí.
+ *  En la sana son muchas y largas; con nematodo quedan pocas y mochas —
+ *  el bicho le arruinó la boca a la mata, por eso amarillea aunque haya
+ *  abono en el suelo. Ese es el porqué, y es lo que hay que entender. */
+function raicillas({ sana, semilla }) {
+  const rnd = prngDe(semilla);
+  const n = sana ? 16 : 7;
+  const salidas = [];
+  for (let i = 0; i < n; i += 1) {
+    const t = 0.12 + (i / n) * 0.82 + (rnd() - 0.5) * 0.04;
+    const { p, nor } = RAIZ_SANA.en(t);
+    const lado = i % 2 === 0 ? 1 : -1;
+    const largo = sana ? 7 + rnd() * 9 : 2.6 + rnd() * 3;
+    const caida = 4 + rnd() * 5;
+    salidas.push(
+      `M${p.x.toFixed(2)} ${p.y.toFixed(2)} q${(nor.x * largo * lado * 0.7).toFixed(2)} ${(caida * 0.5).toFixed(2)} ${(nor.x * largo * lado).toFixed(2)} ${caida.toFixed(2)}`,
+    );
+  }
+  return salidas;
+}
+
+const PELOS_SANA = raicillas({ sana: true, semilla: 4 });
+const PELOS_MALA = raicillas({ sana: false, semilla: 9 });
+
+/* Los tonos de la raíz, de `meloidogyne.jpg`: crema marfil, nada de "café
+   tierra" — una raíz viva recién sacada es casi blanca. */
+const RAIZ = {
+  carne: '#dbcaa5',
+  sombra: '#bfa980',
+  linea: '#8e7551',
+};
+/* la agalla va un punto más amarilla y turgente que la raíz sana */
+const AGALLA_TONO = '#d6c185';
+
+function Raiz({ x, y, anudada }) {
+  const cuerpo = anudada ? RAIZ_ANUDADA : RAIZ_SANA;
+  const pelos = anudada ? PELOS_MALA : PELOS_SANA;
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      <g fill="none" stroke={RAIZ.linea} strokeLinecap="round" opacity="0.9">
+        {pelos.map((d, i) => (
+          <path key={i} d={d} strokeWidth={anudada ? 0.7 : 0.85} />
+        ))}
+      </g>
+      <path d={cuerpo.contorno} fill={anudada ? AGALLA_TONO : RAIZ.carne} stroke={RAIZ.linea} strokeWidth="0.9" />
+      {/* el lomo iluminado: la raíz es un cilindro, no una cinta */}
+      <path d={cuerpo.franja(-0.42)} fill="none" stroke="#f0e6cb" strokeWidth="1.1" opacity="0.7" />
+      <path d={cuerpo.franja(0.55)} fill="none" stroke={RAIZ.sombra} strokeWidth="1.3" opacity="0.55" />
+    </g>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* LA LÁMINA                                                           */
+/* ------------------------------------------------------------------ */
+export default function LaminaDuda({ className } = {}) {
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-labelledby="lamduda-t lamduda-d"
+      className={['w-full h-auto select-none', className].filter(Boolean).join(' ')}
+      data-testid="lamina-duda"
+      style={{ fontFamily: 'ui-sans-serif, system-ui, sans-serif' }}
+    >
+      <title id="lamduda-t">Cuando no se puede saber: la misma hoja amarilla puede ser hambre o nematodo</title>
+      <desc id="lamduda-d">
+        Lámina de cuaderno de campo sobre el límite del diagnóstico. Arriba, dos hojas de café
+        amarillas exactamente iguales: una rotulada ¿le falta nitrógeno? y la otra ¿o tiene nematodo?
+        Entre las dos, un signo de pregunta: por arriba no se distinguen y no se puede saber. Abajo,
+        la salida: sacar una matica y mirarle la raíz. Se dibujan dos raíces: la sana, lisa y con
+        muchas raicitas finas, y la del nematodo, con nudos o agallas engrosados en la raíz misma y
+        con pocas raicitas. Al pie, la regla: cuando no alcanza a ver, lo correcto no es adivinar.
+      </desc>
+
+      <Pliego w={W} h={H} />
+
+      <text x="16" y="26" fontSize="16.5" fontWeight="800" fill={TINTA.fuerte}>
+        Cuando NO se puede saber
+      </text>
+      <text x="404" y="17" textAnchor="end" fontSize="8.5" fontStyle="italic" fill={TINTA.guia}>
+        cuaderno de campo
+      </text>
+      <text x="404" y="28" textAnchor="end" fontSize="8.5" fill={TINTA.suave}>
+        el límite honesto
+      </text>
+      <text x="16" y="39" fontSize="9" fontStyle="italic" fill={TINTA.suave}>
+        Saber hasta dónde alcanza la vista también es saber de campo.
+      </text>
+      <line x1="14" y1="44" x2="406" y2="44" stroke={PLIEGO.borde} strokeWidth="1" />
+
+      {/* ---------- las dos hojas: EL MISMO DIBUJO, a propósito ---------- */}
+      <g transform={`translate(${IZQ} ${BASE_Y}) scale(${ESC})`}>
+        <HojaBase tinteLamina={DEFICIENCIA.nitroViejo} conBrillo={false}>
+          <ClorosisNitrogeno />
+        </HojaBase>
+      </g>
+      <g transform={`translate(${DER} ${BASE_Y}) scale(${ESC})`}>
+        <HojaBase tinteLamina={DEFICIENCIA.nitroViejo} conBrillo={false}>
+          <ClorosisNitrogeno />
+        </HojaBase>
+      </g>
+
+      {/* el signo de pregunta en la mitad: la lámina admite que no sabe */}
+      <text x="210" y="152" textAnchor="middle" fontSize="46" fontWeight="800" fill={CATEGORIA.duda.tinta} opacity="0.5">
+        ?
+      </text>
+      <text x="210" y="172" textAnchor="middle" fontSize="8" fontStyle="italic" fill={CATEGORIA.duda.tinta}>
+        la misma
+      </text>
+      <text x="210" y="182" textAnchor="middle" fontSize="8" fontStyle="italic" fill={CATEGORIA.duda.tinta}>
+        hoja
+      </text>
+
+      <text x={IZQ} y="220" textAnchor="middle" fontSize="9.5" fontWeight="800" fill={CATEGORIA.deficiencia.tinta}>
+        ¿le falta nitrógeno?
+      </text>
+      <text x={IZQ} y="230" textAnchor="middle" fontSize="7.5" fontStyle="italic" fill={TINTA.suave}>
+        amarillo parejo, las viejas primero
+      </text>
+      <text x={DER} y="220" textAnchor="middle" fontSize="9.5" fontWeight="800" fill={CATEGORIA.plaga.tinta}>
+        ¿o tiene nematodo?
+      </text>
+      <text x={DER} y="230" textAnchor="middle" fontSize="7.5" fontStyle="italic" fill={TINTA.suave}>
+        amarillo parejo, las viejas primero
+      </text>
+
+      {/* ---------- el veredicto honesto ---------- */}
+      <rect x="14" y="240" width="392" height="26" rx="5" fill={CATEGORIA.duda.chip} fillOpacity="0.2" stroke={CATEGORIA.duda.tinta} strokeWidth="0.9" strokeDasharray="4 3" />
+      <text x="210" y="251" textAnchor="middle" fontSize="9" fontWeight="800" fill={CATEGORIA.duda.tinta}>
+        POR ARRIBA SON LA MISMA HOJA. DE AQUÍ NO SE PUEDE SACAR EL DIAGNÓSTICO.
+      </text>
+      <text x="210" y="261" textAnchor="middle" fontSize="7.6" fontStyle="italic" fill={TINTA.media}>
+        Y no pasa nada: quiere decir que todavía falta un dato, no que usted no sepa mirar.
+      </text>
+
+      {/* ---------- la salida ---------- */}
+      <text x="16" y="284" fontSize="10" fontWeight="800" fill={TINTA.fuerte} letterSpacing="0.05em">
+        LA SALIDA
+      </text>
+      <text x="72" y="284" fontSize="8.6" fontStyle="italic" fill={TINTA.suave}>
+        — saque una matica de la orilla del lote y mírele la raíz. Ahí sí se ve, y sin lupa.
+      </text>
+
+      {/* línea del suelo */}
+      <line x1="40" y1="296" x2="380" y2="296" stroke={TINTA.guia} strokeWidth="1.1" strokeDasharray="5 4" opacity="0.8" />
+
+      <Raiz x={IZQ} y={296} anudada={false} />
+      <Raiz x={DER} y={296} anudada />
+
+      <text x={IZQ} y="416" textAnchor="middle" fontSize="9.5" fontWeight="800" fill={CATEGORIA.deficiencia.tinta}>
+        raíz lisa y con barbas
+      </text>
+      <text x={IZQ} y="426" textAnchor="middle" fontSize="7.5" fill={TINTA.media}>
+        era hambre → abone con materia
+      </text>
+      <text x={IZQ} y="435" textAnchor="middle" fontSize="7.5" fill={TINTA.media}>
+        orgánica y espere 2 o 3 semanas.
+      </text>
+
+      <text x={DER} y="416" textAnchor="middle" fontSize="9.5" fontWeight="800" fill={CATEGORIA.plaga.tinta}>
+        raíz con nudos
+      </text>
+      <text x={DER} y="426" textAnchor="middle" fontSize="7.5" fill={TINTA.media}>
+        era nematodo → el nudo es la raíz
+      </text>
+      <text x={DER} y="435" textAnchor="middle" fontSize="7.5" fill={TINTA.media}>
+        hinchada, no se desprende.
+      </text>
+
+      <text x="210" y="450" textAnchor="middle" fontSize="8" fontStyle="italic" fontWeight="700" fill={CATEGORIA.duda.tinta}>
+        Si no alcanza a ver, no adivine: acérquese, voltee la hoja, saque la mata — o mande la foto.
+      </text>
+    </svg>
+  );
+}

--- a/src/visual/diferencial/LaminaLlave.jsx
+++ b/src/visual/diferencial/LaminaLlave.jsx
@@ -1,0 +1,295 @@
+import React from 'react';
+import { blob, HOJA } from './formasHoja.js';
+import {
+  HojaBase,
+  HojaMini,
+  ClorosisHierro,
+  Pliego,
+  Lupa,
+  Vineta,
+} from './motivosDano.jsx';
+import {
+  PLIEGO,
+  TINTA,
+  HOJA_SANA,
+  ENFERMEDAD,
+  DEFICIENCIA,
+  CATEGORIA,
+} from './paletaDano.js';
+
+/**
+ * LaminaLlave — las tres pruebas que se hacen con la mano, sin comprar nada.
+ *
+ * `LaminaDiferencial` enseña a VER los tres daños. Esta enseña a DECIDIR, y
+ * son cosas distintas: en el lote uno no tiene la lámina al lado para
+ * comparar, tiene la mata y dos manos. Así que la llave se reparte en tres
+ * pruebas concretas, en orden de qué tan barato es hacerlas:
+ *
+ *   1. EL DOBLEZ  → ¿va parejo a lado y lado? Entonces es hambre.
+ *      (La simetría es la pista más fuerte que hay, y la más ignorada. Ni el
+ *      bicho ni el hongo saben de simetría: el bicho come por donde llegó y
+ *      el hongo brota donde le cayó la gota. Solo la mata —que reparte la
+ *      comida por igual a los dos lados del nervio— produce daño simétrico.
+ *      Por eso el doblez decide, y decide gratis.)
+ *
+ *   2. EL DEDO    → ¿le puede seguir el borde? Entonces tiene forma: hongo.
+ *
+ *   3. LA EDAD    → ¿cuáles hojas? Las viejas primero = nitrógeno (la mata se
+ *      lo puede mover y se lo quita a las de abajo). Las nuevas = hierro (no
+ *      se mueve, y el cogollo se queda sin). Ese detalle decide qué abonar.
+ *
+ * Es lámina de decisión, no de catálogo: cada prueba termina en un veredicto.
+ *
+ * @param {Object} props
+ * @param {string} [props.className] clases extra sobre el <svg> raíz.
+ */
+
+const W = 420;
+const H = 458;
+
+/* La mancha de la prueba del dedo y su calco: MISMA semilla, así el trazo
+   punteado va paralelo al borde de verdad — como el dedo, que puede seguirlo
+   justamente porque el borde existe. */
+const MANCHA = blob({ cx: 0, cy: 0, r: 14, semilla: 5, lobulos: 3, rugosidad: 0.12 });
+const CALCO = blob({ cx: 0, cy: 0, r: 19.5, semilla: 5, lobulos: 3, rugosidad: 0.12 });
+/* el halo tampoco es un círculo: se lo presta a la misma semilla */
+const HALO = blob({ cx: 0, cy: 0, r: 24, semilla: 5, lobulos: 3, rugosidad: 0.14 });
+
+/** Una rama con tres pares de hojas: abajo las viejas, arriba el cogollo. */
+function Rama({ x, y, viejasAmarillas }) {
+  const verde = HOJA_SANA.haz;
+  const amarillo = viejasAmarillas ? DEFICIENCIA.nitroViejo : DEFICIENCIA.hierroLamina;
+  /* pisos: 0 = abajo (las viejas) … 2 = arriba (el cogollo) */
+  const pisos = [0, 1, 2];
+  return (
+    <g transform={`translate(${x} ${y})`}>
+      <path d="M0 0 C 1 -18 -1 -36 0 -56" fill="none" stroke={HOJA_SANA.tallo} strokeWidth="2.6" strokeLinecap="round" />
+      {pisos.map((p) => {
+        const py = -6 - p * 21;
+        /* nitrógeno castiga abajo; hierro castiga arriba */
+        const amarilla = viejasAmarillas ? p === 0 : p === 2;
+        const tinte = amarilla ? amarillo : verde;
+        const venaVerde = amarilla && !viejasAmarillas; // la redecilla es del hierro
+        return (
+          <g key={p}>
+            <HojaMini x={0} y={py} rot={-118} escala={0.2} tinte={tinte} venaVerde={venaVerde} />
+            <HojaMini x={0} y={py} rot={118} escala={0.2} tinte={tinte} venaVerde={venaVerde} />
+          </g>
+        );
+      })}
+      {/* el cogollito de la punta */}
+      <path d="M0 -56 q3 -5 0 -9 q-3 4 0 9Z" fill={viejasAmarillas ? verde : amarillo} stroke={HOJA_SANA.borde} strokeWidth="0.5" />
+    </g>
+  );
+}
+
+export default function LaminaLlave({ className } = {}) {
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-labelledby="lamllave-t lamllave-d"
+      className={['w-full h-auto select-none', className].filter(Boolean).join(' ')}
+      data-testid="lamina-llave"
+      style={{ fontFamily: 'ui-sans-serif, system-ui, sans-serif' }}
+    >
+      <title id="lamllave-t">La llave: tres pruebas de mano para distinguir plaga, enfermedad y deficiencia</title>
+      <desc id="lamllave-d">
+        Lámina de cuaderno de campo con tres pruebas. Primera, la prueba del doblez: una hoja amarilla
+        con la nervadura verde y una línea de doblez por el nervio; si las dos mitades van igualitas,
+        es hambre, porque ni el bicho ni el hongo son simétricos. Segunda, la prueba del dedo: una
+        mancha con halo y borde definido, con una línea punteada calcando el borde; si se puede seguir
+        el borde, tiene forma y es hongo. Tercera, la prueba de la edad: dos ramas de café; en la
+        primera amarillean las hojas viejas de abajo, y eso es falta de nitrógeno; en la segunda
+        amarillean las hojas nuevas del cogollo con la nervadura verde, y eso es falta de hierro.
+      </desc>
+
+      <Pliego w={W} h={H} />
+
+      <text x="16" y="26" fontSize="16.5" fontWeight="800" fill={TINTA.fuerte}>
+        La llave: tres pruebas de mano
+      </text>
+      <text x="404" y="17" textAnchor="end" fontSize="8.5" fontStyle="italic" fill={TINTA.guia}>
+        cuaderno de campo
+      </text>
+      <text x="404" y="28" textAnchor="end" fontSize="8.5" fill={TINTA.suave}>
+        sin comprar nada
+      </text>
+      <text x="16" y="39" fontSize="9" fontStyle="italic" fill={TINTA.suave}>
+        En el lote no hay lámina al lado: hay la mata y dos manos. Con eso basta.
+      </text>
+      <line x1="14" y1="44" x2="406" y2="44" stroke={PLIEGO.borde} strokeWidth="1" />
+
+      {/* ============ 1. EL DOBLEZ ============ */}
+      <text x="16" y="62" fontSize="10.5" fontWeight="800" fill={CATEGORIA.deficiencia.tinta} letterSpacing="0.05em">
+        1 · LA PRUEBA DEL DOBLEZ
+      </text>
+      <text x="178" y="62" fontSize="8.6" fontStyle="italic" fill={TINTA.suave}>
+        — dóblela por el nervio.
+      </text>
+
+      <g transform="translate(74 178) scale(0.74)">
+        <HojaBase tinteLamina={DEFICIENCIA.hierroLamina} conBrillo={false}>
+          <ClorosisHierro />
+        </HojaBase>
+      </g>
+      {/* la línea del doblez, sobre el nervio */}
+      <g transform="translate(74 178) scale(0.74)">
+        <path d={HOJA.nervioCentral} fill="none" stroke={TINTA.fuerte} strokeWidth="1.6" strokeDasharray="5 4" opacity="0.85" />
+      </g>
+      {/* Un "=" en cada mitad: lo que hay que ver es que las dos son la
+          misma. (Primer intento: dos flechas cerrándose sobre el nervio —
+          se leían como antenas saliéndole a la hoja.) */}
+      <g stroke={TINTA.guia} strokeWidth="1.1" strokeLinecap="round" opacity="0.9">
+        <path d="M56 146 h7 M56 150 h7" />
+        <path d="M85 146 h7 M85 150 h7" />
+      </g>
+      <text x="74" y="196" textAnchor="middle" fontSize="7.6" fontStyle="italic" fill={TINTA.suave}>
+        las dos mitades, igualitas
+      </text>
+
+      <Vineta
+        x={152}
+        y={84}
+        color={CATEGORIA.deficiencia.tinta}
+        tam={8.6}
+        interlinea={10.4}
+        lineas={[
+          { fuerte: 'Si va parejo a lado y lado', resto: ' del nervio,' },
+          'y sigue la nervadura: es HAMBRE. Abone.',
+        ]}
+      />
+      <Vineta
+        x={152}
+        y={112}
+        color={TINTA.media}
+        tam={8.6}
+        interlinea={10.4}
+        lineas={[
+          'Ni el bicho ni el hongo saben de simetría:',
+          'el bicho come por donde llegó, y el hongo',
+          'brota donde le cayó la gota de agua.',
+        ]}
+      />
+      <Vineta
+        x={152}
+        y={152}
+        color={TINTA.media}
+        tam={8.6}
+        interlinea={10.4}
+        lineas={[
+          'La única que reparte parejo es la mata,',
+          'porque le manda la misma comida a los',
+          'dos lados. Por eso el doblez decide.',
+        ]}
+      />
+
+      <line x1="14" y1="208" x2="406" y2="208" stroke={PLIEGO.borde} strokeWidth="0.7" strokeDasharray="2 3" />
+
+      {/* ============ 2. EL DEDO ============ */}
+      <text x="16" y="226" fontSize="10.5" fontWeight="800" fill={CATEGORIA.enfermedad.tinta} letterSpacing="0.05em">
+        2 · LA PRUEBA DEL DEDO
+      </text>
+      <text x="166" y="226" fontSize="8.6" fontStyle="italic" fill={TINTA.suave}>
+        — ¿le puede seguir el borde?
+      </text>
+
+      <Lupa cx={74} cy={270} r={31} titulo="TIENE BORDE → HONGO" tinta={CATEGORIA.enfermedad.tinta}>
+        <g transform="translate(74 270)">
+          <rect x="-40" y="-40" width="80" height="80" fill={HOJA_SANA.haz} />
+          <path d={HALO} fill={ENFERMEDAD.cercoHalo} opacity="0.75" />
+          <path d={MANCHA} fill={ENFERMEDAD.cercoCentro} stroke={ENFERMEDAD.cercoBorde} strokeWidth="1.1" transform="translate(0 0)" />
+          <path
+            d={blob({ cx: -1, cy: -1, r: 7.4, semilla: 16, lobulos: 3, rugosidad: 0.16 })}
+            fill={ENFERMEDAD.cercoCentroPalido}
+            opacity="0.9"
+          />
+          {/* el calco del dedo: va paralelo al borde porque el borde EXISTE */}
+          <path d={CALCO} fill="none" stroke={TINTA.fuerte} strokeWidth="1.2" strokeDasharray="3.5 3" opacity="0.9" />
+        </g>
+      </Lupa>
+
+      <Vineta
+        x={152}
+        y={248}
+        color={CATEGORIA.enfermedad.tinta}
+        tam={8.6}
+        interlinea={10.4}
+        lineas={[
+          { fuerte: 'Si puede calcar el borde', resto: ' con el dedo —' },
+          'si tiene halo, orilla clara, anillos, o se',
+          'frena en seco en la vena: es HONGO.',
+        ]}
+      />
+      <Vineta
+        x={152}
+        y={288}
+        color={CATEGORIA.deficiencia.tinta}
+        tam={8.6}
+        interlinea={10.4}
+        lineas={[
+          { fuerte: 'Si el color se desvanece', resto: ' y usted no' },
+          'sabe dónde poner el dedo: NO es mancha.',
+          'Es hambre — y el fungicida es plata botada.',
+        ]}
+      />
+
+      <line x1="14" y1="322" x2="406" y2="322" stroke={PLIEGO.borde} strokeWidth="0.7" strokeDasharray="2 3" />
+
+      {/* ============ 3. LA EDAD ============ */}
+      <text x="16" y="340" fontSize="10.5" fontWeight="800" fill={CATEGORIA.deficiencia.tinta} letterSpacing="0.05em">
+        3 · LA PRUEBA DE LA EDAD
+      </text>
+      <text x="178" y="340" fontSize="8.6" fontStyle="italic" fill={TINTA.suave}>
+        — ¿cuáles hojas amarillean? Eso dice QUÉ le falta.
+      </text>
+
+      <g transform="translate(0 0)">
+        <Rama x={64} y={420} viejasAmarillas />
+        <Rama x={186} y={420} viejasAmarillas={false} />
+      </g>
+
+      {/* rótulos de las dos ramas */}
+      <text x="64" y="434" textAnchor="middle" fontSize="8.4" fontWeight="800" fill={CATEGORIA.deficiencia.tinta}>
+        NITRÓGENO
+      </text>
+      <text x="64" y="443" textAnchor="middle" fontSize="7.2" fontStyle="italic" fill={TINTA.suave}>
+        amarillean las VIEJAS
+      </text>
+      <text x="186" y="434" textAnchor="middle" fontSize="8.4" fontWeight="800" fill={CATEGORIA.deficiencia.tinta}>
+        HIERRO
+      </text>
+      <text x="186" y="443" textAnchor="middle" fontSize="7.2" fontStyle="italic" fill={TINTA.suave}>
+        amarillean las NUEVAS
+      </text>
+
+      <Vineta
+        x={244}
+        y={362}
+        color={CATEGORIA.deficiencia.tinta}
+        tam={8.2}
+        interlinea={9.8}
+        lineas={[
+          { fuerte: 'Viejas primero', resto: ' = NITRÓGENO. La mata' },
+          'sí lo sabe mover: se lo quita a las de',
+          'abajo para darle al cogollo.',
+        ]}
+      />
+      <Vineta
+        x={244}
+        y={398}
+        color={CATEGORIA.deficiencia.tinta}
+        tam={8.2}
+        interlinea={9.8}
+        lineas={[
+          { fuerte: 'Nuevas, con la vena verde', resto: ' = HIERRO.' },
+          'Ese no se mueve, y el cogollo se queda',
+          'sin. Por eso pega arriba y no abajo.',
+        ]}
+      />
+      <text x="244" y="440" fontSize="7.6" fontStyle="italic" fontWeight="700" fill={CATEGORIA.duda.tinta}>
+        ¿Amarillo parejo y no sabe cuál? Mírele la raíz.
+      </text>
+    </svg>
+  );
+}

--- a/src/visual/diferencial/README.md
+++ b/src/visual/diferencial/README.md
@@ -1,0 +1,122 @@
+# `src/visual/diferencial` — plaga vs enfermedad vs deficiencia
+
+La confusión que **más plata le cuesta al campesino**: le echa fungicida a un
+pulgón, o veneno a una falta de nitrógeno. Gasta, no resuelve, y de paso mata a
+los benéficos que le estaban trabajando gratis. Este módulo es el diferencial
+dibujado — y, sobre todo, **la llave para distinguirlos**.
+
+Hermana de [`src/visual/laminas`](../laminas/README.md): mismo papel crema,
+misma tinta sepia, misma firma de props (`width:100%` + `className`, sin
+`size`/`inline`). Vive aparte porque no es catálogo de matas: es un módulo con
+una tesis, y sus piezas se comparten entre las tres láminas.
+
+## La tesis
+
+> **Lo que distingue no es el color: es el ORDEN del daño.**
+>
+> - la **deficiencia** es ORDENADA y simétrica (va parejo, sigue la nervadura);
+> - la **enfermedad** tiene FORMA (halo, borde que se sigue con el dedo, anillos);
+> - la **plaga** es un DESASTRE irregular (mordidas distintas, rastro, el bicho).
+
+Y el corolario que casi ninguna cartilla se atreve a poner: **hay casos en que
+no se puede saber sin ver la mata de cerca, y ahí lo correcto es pedir la foto
+o ir a mirar. La duda es parte del método.**
+
+## Láminas
+
+| Componente | Qué enseña | Accesibilidad |
+|---|---|---|
+| `LaminaDiferencial` | Los tres daños **lado a lado, sobre la misma hoja**. Cada columna: la hoja, la lupa, tres pistas y **lo que NO sirve** (la plata que se pierde). | enseña (`role=img` + rótulos) |
+| `LaminaLlave` | Las tres **pruebas de mano**: el doblez (simetría), el dedo (forma), la edad (nitrógeno = viejas / hierro = nuevas). | enseña |
+| `LaminaDuda` | El límite honesto: nitrógeno o nematodo **no se distinguen por arriba**. La salida: sacar una matica y mirarle la raíz. | enseña |
+
+```jsx
+import { LaminaDiferencial, LaminaLlave, LaminaDuda } from '@/visual/diferencial';
+
+<LaminaDiferencial className="max-w-lg mx-auto" />
+```
+
+Props: solo `className` (clases extra sobre el `<svg>`; se **añaden** a las
+base `w-full h-auto select-none`). Ninguna lámina tiene prop de dominio: cada
+una dice una cosa y la dice completa.
+
+## Las reglas que sostienen el dibujo
+
+**1. La hoja es LA MISMA en los tres paneles.** Se construye una sola vez en
+`formasHoja.js` (tiempo de módulo: cero costo por render, cero `Math.random`,
+arte byte-idéntico entre capturas). Si la hoja cambiara de panel a panel, no se
+sabría si lo distinto es el daño o el dibujo. **Controlada la hoja, lo único
+que varía es la marca** — y ese es el experimento entero.
+
+**2. Cada marca está calcada de una foto real** de `public/plaga-images/`, no
+inventada. Es una lámina de campo: si la mancha no se parece a la foto, falló.
+
+| Marca | Foto | Lo que había que respetar |
+|---|---|---|
+| polvo de roya | `hemileia_vastatrix.jpg` | Es **grano**, no pintura naranja: cúrcuma regada. Denso al centro, deshilachado en la orilla, con esporas sueltas más allá. |
+| mancha de hierro | `cercospora_coffeicola.jpg` | Halo amarillo + **borde definido** + centro ceniza. LA figura de "tiene forma". |
+| anillos concéntricos | `alternaria_solani.jpg` | El tiro al blanco — y que la lesión **se frena en la vena**. |
+| mordida | hojas comidas | El **filo pardo cicatrizado** y su halo. Una herida no queda cortada a tijera. |
+| gusano | `spodoptera_frugiperda.jpg`, `mocis_latipes.jpg` | Bandas que siguen el cuerpo, cápsula cefálica, la "Y" invertida. **Sin cara.** |
+| agallas | `meloidogyne.jpg` | El nudo **es la raíz hinchada** (la raíz pasa por dentro), no una bolita pegada. |
+
+**3. Nada de geometría limpia.** En la naturaleza no hay círculos perfectos:
+toda mancha sale de `blob()` (contorno lobulado, frecuencias no armónicas,
+semilla fija). Un círculo naranja plano es la firma del dibujo inventado.
+
+**4. Los rótulos sobre la hoja son punteros, no explicaciones.** Cortos. Lo
+que hay que entender va en las viñetas, que sí tienen ancho: un rótulo largo se
+le monta a la columna del vecino.
+
+**5. La lupa no es un zoom.** Es la marca **redibujada** con la información que
+uno gana al acercar la cara a la mata — como en cualquier lámina botánica. Y en
+la columna de la enfermedad la lupa muestra **el envés**, porque ahí está la
+respuesta y hay que voltear la hoja.
+
+## Anatomía (para que no se note "inventado")
+
+La hoja de café de `formasHoja.js` respeta lo que se ve en las fotos:
+elíptico-oblonga (~2.5:1), base cuneada, punta **acuminada**, margen
+**ondulado**, y sobre todo **nervadura broquidódroma**: las laterales se
+arquean y **se cierran en lazo con la siguiente sin tocar el borde**. Dibujar
+venas que llegan al filo es el error de calco que delata todo lo demás.
+
+`puntoEnHoja(t, u)` posa cualquier marca en coordenadas de hoja (`t` a lo
+largo, `u` a lo ancho): así cae siempre dentro y sigue la forma, sin medir a
+ojo. Los huecos de mordisco van **estirados en la dirección de la vena**,
+porque el bicho esquiva la nervadura dura y se come lo blandito de en medio.
+
+## Errores ya cometidos acá (no repetirlos)
+
+- **Huecos que parecían flores.** `blob()` con armónicos (l, l+2) y poco ruido
+  da un trébol. Al subirle el ruido dio **estrellas**. Se arregló con
+  frecuencias no armónicas + ruido de verdad + `alargue`/`rot` — y, sobre todo,
+  entendiendo que **una hoja masticada se come por la orilla**, no a lunares.
+- **El filo flotando sobre el hueco.** El filo va montado en el borde del
+  mordisco, así que la mitad caía sobre el papel. Lleva `clip` (que no se salga
+  de la hoja) **y** `mask` (que borre la mitad del hueco), con el grosor al
+  doble para compensar.
+- **Agallas lavadas.** Campanas anchas + eje de pocas muestras = raíz ondulada
+  en vez de anudada. Angostas y con 70 muestras.
+- **El gusano plumoso.** Setas largas → parecía espiga de trigo.
+
+## Técnica
+
+- SVG puro, **cero dependencias nuevas**, estáticas, sin animación, GPU-nula.
+- **No importa `mundo3d/paleta`**: `paletaMadre` cuelga de `atmosferaMadre`, que
+  importa `three` — meter eso en un pliego de papel arrastraría el motor 3D
+  entero. Los colores viven en `paletaDano.js`, con la foto de origen anotada.
+- Ids de `<defs>` con **`useId`** (saneado: `useId()` trae `:` y rompe los
+  `url(#…)`), así una lámina se puede repetir en la misma página sin colisión.
+- **rsvg-safe** salvo por el `<text>`: sin emoji-en-SVG, sin filtros exóticos
+  (solo `feGaussianBlur`), aptas para captura del harness visual.
+- Paleta de papel/tinta **fija**: es un pliego prendido a la pantalla, legible
+  al sol y en los cuatro temas.
+
+## Fuentes
+
+Fotografías de campo de `public/plaga-images/` y el corpus de maestros de
+plagas y de MIP (el diferencial completo, las grandes de Colombia y los nombres
+folk desambiguados). La voz de los textos es la del corpus: *"voltee la hoja"*,
+*"mire si el patrón es al azar o parejo"*, *"si me manda foto del envés le afino
+el diagnóstico"*.

--- a/src/visual/diferencial/formasBicho.js
+++ b/src/visual/diferencial/formasBicho.js
@@ -1,0 +1,190 @@
+/*
+ * formasBicho — la geometría del gusano.
+ *
+ * Este es el elemento con más riesgo de arruinar la lámina: un gusano mal
+ * dibujado convierte una lámina de campo en una caricatura, y ahí se pierde
+ * la autoridad de todo lo demás. Así que NO se dibuja "a ojo" como un fideo
+ * con carita: se construye como en un dibujo de entomología.
+ *
+ * Método (mirando `spodoptera_frugiperda.jpg` y `mocis_latipes.jpg`):
+ *   1. Un EJE curvo (la larva descansa en C sobre la hoja, nunca recta).
+ *   2. Un TUBO alrededor del eje: el contorno se genera desplazando cada
+ *      punto por su NORMAL, con un perfil de grosor que adelgaza en los dos
+ *      extremos. Así el cuerpo tiene volumen real y sigue la curva.
+ *   3. Las BANDAS longitudinales no son rayas rectas: son el mismo eje
+ *      desplazado a una fracción del grosor, así que se curvan con el bicho.
+ *      Esto es lo que hace que se lea como un animal y no como un macarrón.
+ *   4. Los anillos de los segmentos, las pináculas (los puntos negros con
+ *      seta) y la cápsula cefálica con su "Y" invertida pálida.
+ *
+ * Lo que NO lleva, a propósito: ojos con brillito, boca, sonrisa. Un gusano
+ * de verdad no tiene cara. La lámina enseña a RECONOCERLO, no a quererlo.
+ */
+import { curvaAbierta, curvaCerrada, prngDe } from './formasHoja.js';
+
+/**
+ * Tubo sobre un eje: dado un eje y un perfil de grosor, devuelve el contorno
+ * cerrado y una función para sacar cualquier franja longitudinal.
+ *
+ * @param {Array<{x:number,y:number}>} eje puntos del eje, en orden.
+ * @param {(t:number)=>number} grosor media anchura en t (0..1 a lo largo).
+ */
+export function tubo(eje, grosor) {
+  const n = eje.length;
+  const normales = eje.map((p, i) => {
+    const a = eje[Math.max(0, i - 1)];
+    const b = eje[Math.min(n - 1, i + 1)];
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const len = Math.hypot(dx, dy) || 1;
+    return { x: -dy / len, y: dx / len };
+  });
+
+  /** Franja longitudinal a `k` (-1 = un flanco, 0 = el eje, 1 = el otro). */
+  const franja = (k, desde = 0, hasta = 1) => {
+    const pts = [];
+    for (let i = 0; i < n; i += 1) {
+      const t = i / (n - 1);
+      if (t < desde || t > hasta) continue;
+      const w = grosor(t) * k;
+      pts.push({ x: eje[i].x + normales[i].x * w, y: eje[i].y + normales[i].y * w });
+    }
+    return curvaAbierta(pts, 1);
+  };
+
+  /* contorno: un flanco de ida, el otro de vuelta. Los extremos quedan
+     redondeados solos porque el grosor tiende a cero ahí. */
+  const ida = [];
+  const vuelta = [];
+  for (let i = 0; i < n; i += 1) {
+    const t = i / (n - 1);
+    const w = grosor(t);
+    ida.push({ x: eje[i].x + normales[i].x * w, y: eje[i].y + normales[i].y * w });
+    vuelta.push({ x: eje[i].x - normales[i].x * w, y: eje[i].y - normales[i].y * w });
+  }
+  const contorno = curvaCerrada([...ida, ...vuelta.reverse()], 0.9);
+
+  /** Punto del eje + su normal en t (para posar patas, anillos, cabeza). */
+  const en = (t) => {
+    const i = Math.min(n - 1, Math.max(0, Math.round(t * (n - 1))));
+    return { p: eje[i], nor: normales[i], w: grosor(i / (n - 1)) };
+  };
+
+  return { contorno, franja, en, normales };
+}
+
+/**
+ * Construye el gusano completo.
+ *
+ * @param {Object} [cfg]
+ * @param {number} [cfg.largo] largo total del cuerpo.
+ * @param {number} [cfg.grueso] media anchura máxima.
+ * @param {number} [cfg.arco] cuánto se enrosca en C (0 = recto).
+ * @param {number} [cfg.segmentos] anillos del cuerpo.
+ * @param {number} [cfg.semilla]
+ */
+export function construirGusano(cfg = {}) {
+  const { largo = 46, grueso = 3.5, arco = 0.46, segmentos = 12, semilla = 21 } = cfg;
+  const rnd = prngDe(semilla);
+
+  /* El eje: una C abierta. La larva se recoge; el extremo de la cabeza baja
+     un poco más porque está comiendo pegada a la lámina. */
+  const N = 40;
+  const eje = [];
+  for (let i = 0; i < N; i += 1) {
+    const t = i / (N - 1);
+    const ang = (t - 0.5) * Math.PI * arco;
+    eje.push({
+      x: t * largo,
+      y: Math.sin(ang) * largo * 0.17 + Math.sin(t * Math.PI) * -largo * 0.05,
+    });
+  }
+
+  /* Perfil del grosor: el tórax (donde están las patas verdaderas) es más
+     angosto que el abdomen; el abdomen es el grueso; y el final se redondea.
+     Ese engrosamiento hacia atrás es lo que hace que NO parezca un macarrón. */
+  const grosor = (t) => {
+    const cuerpo = Math.pow(Math.sin(Math.PI * Math.pow(t, 0.72)), 0.42);
+    const abdomen = 0.82 + 0.18 * Math.sin(Math.min(1, t * 1.4) * Math.PI * 0.8);
+    return grueso * cuerpo * abdomen;
+  };
+
+  const t2 = tubo(eje, grosor);
+
+  /* Anillos de los segmentos: arquitos transversales, más juntos adelante. */
+  const anillos = [];
+  for (let s = 1; s <= segmentos; s += 1) {
+    const t = 0.1 + (s / (segmentos + 1)) * 0.86;
+    const { p, nor, w } = t2.en(t);
+    const a = { x: p.x + nor.x * w * 0.92, y: p.y + nor.y * w * 0.92 };
+    const b = { x: p.x - nor.x * w * 0.92, y: p.y - nor.y * w * 0.92 };
+    /* leve arco: el anillo abraza el cuerpo cilíndrico */
+    const cx = p.x + (nor.y * w) * 0.22;
+    const cy = p.y - (nor.x * w) * 0.22;
+    anillos.push(`M${a.x.toFixed(2)} ${a.y.toFixed(2)}Q${cx.toFixed(2)} ${cy.toFixed(2)} ${b.x.toFixed(2)} ${b.y.toFixed(2)}`);
+  }
+
+  /* Pináculas: los puntos oscuros con seta. En Spodoptera van en trapecio
+     sobre cada segmento; se ven clarito en la foto. */
+  const pinaculas = [];
+  for (let s = 2; s <= segmentos - 1; s += 1) {
+    const t = 0.1 + (s / (segmentos + 1)) * 0.86;
+    const { p, nor, w } = t2.en(t);
+    for (const k of [-0.52, 0.52]) {
+      const jitter = (rnd() - 0.5) * 0.3;
+      pinaculas.push({
+        x: p.x + nor.x * w * k + jitter,
+        y: p.y + nor.y * w * k + jitter,
+        r: 0.3 + rnd() * 0.12,
+        /* La seta: un pelito que sale del punto, hacia afuera. Corta: si se
+           alarga, el bicho se ve plumoso — parece una espiga de trigo y no
+           una larva. La larva tiene pelos, pero se le ven poco. */
+        seta: {
+          x: p.x + nor.x * w * (k * 1.34),
+          y: p.y + nor.y * w * (k * 1.34),
+        },
+      });
+    }
+  }
+
+  /* Patas: 3 pares torácicas (verdaderas, con garra) + falsas patas
+     abdominales (los ventosones) + las anales. Van del lado del vientre. */
+  const patas = [];
+  const ladoVientre = -1;
+  for (const t of [0.14, 0.2, 0.26]) {
+    const { p, nor, w } = t2.en(t);
+    patas.push({
+      x: p.x + nor.x * w * ladoVientre * 0.85,
+      y: p.y + nor.y * w * ladoVientre * 0.85,
+      dx: nor.x * 2.6 * ladoVientre,
+      dy: nor.y * 2.6 * ladoVientre,
+      tipo: 'toracica',
+    });
+  }
+  for (const t of [0.46, 0.56, 0.66, 0.76, 0.93]) {
+    const { p, nor, w } = t2.en(t);
+    patas.push({
+      x: p.x + nor.x * w * ladoVientre * 0.8,
+      y: p.y + nor.y * w * ladoVientre * 0.8,
+      dx: nor.x * 2.2 * ladoVientre,
+      dy: nor.y * 2.2 * ladoVientre,
+      tipo: 'falsa',
+    });
+  }
+
+  /* La cabeza: cápsula redonda, oscura y dura, un poco más angosta que el
+     cuerpo, inclinada hacia la hoja. */
+  const cab = t2.en(0.035);
+  const cabeza = {
+    x: cab.p.x - 1.1,
+    y: cab.p.y + 0.35,
+    r: grueso * 0.86,
+    /* la "Y" invertida pálida de la frente: la firma del cogollero */
+    y_invertida: true,
+  };
+
+  return { ...t2, eje, grosor, anillos, pinaculas, patas, cabeza, largo, grueso };
+}
+
+/** El gusano de la lámina: uno solo, calculado una vez. */
+export const GUSANO = construirGusano({ largo: 46, grueso: 4.5, arco: 0.46, semilla: 21 });

--- a/src/visual/diferencial/formasHoja.js
+++ b/src/visual/diferencial/formasHoja.js
@@ -1,0 +1,359 @@
+/*
+ * formasHoja — la geometría de LA HOJA (una sola) y de las marcas del daño.
+ *
+ * Todo el diferencial plaga/enfermedad/deficiencia se dibuja sobre la MISMA
+ * hoja de café, tres veces. Ese es el truco didáctico entero: si la hoja
+ * cambiara entre panel y panel, el campesino no sabría si lo que ve distinto
+ * es el daño o es la hoja. Controlando la hoja, lo único que varía es el daño.
+ *
+ * Por eso la hoja NO se dibuja a mano tres veces: se CONSTRUYE una vez acá,
+ * en tiempo de módulo (cero costo por render, cero `Math.random` en pintura,
+ * arte byte-idéntico entre capturas), y las tres láminas la consumen.
+ *
+ * Grounded — hoja de Coffea arabica, mirando las fotos reales del repo
+ * (`public/plaga-images/hemileia_vastatrix.jpg`, `cercospora_coffeicola.jpg`):
+ *   - elíptico-oblonga, ~2.5:1, base cuneada y punta ACUMINADA (la gotera);
+ *   - margen ONDULADO (ondea suave, no es un óvalo liso) — se ve clarito en
+ *     la foto de la roya, contra el dedo;
+ *   - nervadura BROQUIDÓDROMA: las laterales salen del nervio central, se
+ *     arquean hacia adelante y NO llegan al borde: se cierran en lazo con la
+ *     siguiente. Dibujar venas que tocan el borde es el error de calco que
+ *     delata a un dibujo inventado;
+ *   - lámina abullonada (bullada): entre vena y vena se infla, y por eso la
+ *     vena se lee como un surco hundido, no como una raya encima.
+ *
+ * Convención del sistema de coordenadas de la hoja:
+ *   la base (donde entra el pecíolo) en (0,0); la punta en (0,-L); el nervio
+ *   central sobre x=0. Es decir: la hoja está PARADA, punta arriba, como en
+ *   un herbario. El consumidor la rota/traslada con un <g transform>.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Utilería determinista                                               */
+/* ------------------------------------------------------------------ */
+
+/** PRNG mulberry32: mismo `semilla` → misma secuencia, siempre y en toda
+ *  máquina. Nunca `Math.random` en arte: rompe la captura byte-idéntica. */
+export function prngDe(semilla) {
+  let a = semilla >>> 0;
+  return function siguiente() {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Redondeo a 2 decimales: paths cortos y estables (diffs legibles). */
+const r2 = (n) => Math.round(n * 100) / 100;
+
+/** smoothstep clásico: 0 antes de `a`, 1 después de `b`, suave en medio. */
+export function suave(a, b, x) {
+  const t = Math.min(1, Math.max(0, (x - a) / (b - a)));
+  return t * t * (3 - 2 * t);
+}
+
+/** mezcla lineal de dos hex (#rrggbb). Para rampas de daño sin inventar hex. */
+export function mezclarHex(a, b, t) {
+  const ca = parseInt(a.slice(1), 16);
+  const cb = parseInt(b.slice(1), 16);
+  const f = (d) => {
+    const x = (ca >> d) & 255;
+    const y = (cb >> d) & 255;
+    return Math.round(x + (y - x) * t);
+  };
+  const v = (f(16) << 16) | (f(8) << 8) | f(0);
+  return `#${v.toString(16).padStart(6, '0')}`;
+}
+
+/* ------------------------------------------------------------------ */
+/* Suavizado Catmull-Rom → cúbicas de Bézier                           */
+/* (una curva orgánica de verdad, no un polígono con muchos lados)     */
+/* ------------------------------------------------------------------ */
+
+function tramo(p0, p1, p2, p3, tension) {
+  const c1x = p1.x + ((p2.x - p0.x) / 6) * tension;
+  const c1y = p1.y + ((p2.y - p0.y) / 6) * tension;
+  const c2x = p2.x - ((p3.x - p1.x) / 6) * tension;
+  const c2y = p2.y - ((p3.y - p1.y) / 6) * tension;
+  return `C${r2(c1x)} ${r2(c1y)} ${r2(c2x)} ${r2(c2y)} ${r2(p2.x)} ${r2(p2.y)}`;
+}
+
+/** Path cerrado y suave que pasa por todos los puntos. */
+export function curvaCerrada(pts, tension = 1) {
+  const n = pts.length;
+  const en = (i) => pts[((i % n) + n) % n];
+  let d = `M${r2(pts[0].x)} ${r2(pts[0].y)}`;
+  for (let i = 0; i < n; i += 1) d += tramo(en(i - 1), en(i), en(i + 1), en(i + 2), tension);
+  return `${d}Z`;
+}
+
+/** Path abierto y suave que pasa por todos los puntos (venas, contornos). */
+export function curvaAbierta(pts, tension = 1) {
+  const n = pts.length;
+  const en = (i) => pts[Math.min(n - 1, Math.max(0, i))];
+  let d = `M${r2(pts[0].x)} ${r2(pts[0].y)}`;
+  for (let i = 0; i < n - 1; i += 1) d += tramo(en(i - 1), en(i), en(i + 1), en(i + 2), tension);
+  return d;
+}
+
+/* ------------------------------------------------------------------ */
+/* EL PERFIL DE LA HOJA                                                */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Ancho relativo (0..1) de la media hoja a lo largo del eje.
+ * `t` = 0 en la base, 1 en la punta.
+ *
+ * Tres factores, cada uno con su razón botánica:
+ *   cuerpo → la elipse oblonga (el grueso de la hoja);
+ *   acumen → el pellizco del último cuarto = punta ACUMINADA (gotera);
+ *   base   → la cuña de la base (cuneada), no un ovalo que arranca ancho.
+ */
+export function perfilAncho(t) {
+  if (t <= 0 || t >= 1) return 0;
+  const cuerpo = Math.pow(Math.sin(Math.PI * Math.pow(t, 0.82)), 0.66);
+  const acumen = 1 - 0.44 * suave(0.72, 1, t);
+  const base = 0.68 + 0.32 * suave(0, 0.16, t);
+  return cuerpo * acumen * base;
+}
+
+/**
+ * Construye la hoja completa: contorno, nervio central, laterales con sus
+ * lazos broquidódromos y los "surcos" de la lámina abullonada.
+ *
+ * @param {Object} [cfg]
+ * @param {number} [cfg.L] largo de la hoja (base→punta).
+ * @param {number} [cfg.W] media anchura máxima.
+ * @param {number} [cfg.ondas] cuántas ondulaciones tiene el margen.
+ * @param {number} [cfg.amp] qué tan marcada es la ondulación (0..1).
+ * @param {number} [cfg.pares] pares de venas laterales.
+ * @param {number} [cfg.semilla] semilla del PRNG (asimetría viva).
+ */
+export function construirHoja(cfg = {}) {
+  const {
+    L = 140,
+    W = 26,
+    ondas = 6,
+    amp = 0.055,
+    pares = 8,
+    semilla = 7,
+  } = cfg;
+  const rnd = prngDe(semilla);
+
+  /* Cada lado lleva su propia fase de ondulación y un ~2% de diferencia de
+     anchura: una hoja real NO es un espejo perfecto. Es a propósito y es
+     honesto — y es poquito, porque la lección de la deficiencia ES la
+     simetría del DAÑO, y no queremos que el contorno la contradiga. */
+  const lados = [
+    { signo: 1, fase: rnd() * Math.PI * 2, escala: 1 },
+    { signo: -1, fase: rnd() * Math.PI * 2, escala: 0.98 },
+  ];
+
+  const anchoLado = (t, lado) => {
+    const onda = 1 + amp * Math.sin(ondas * Math.PI * 2 * t + lado.fase);
+    return perfilAncho(t) * W * onda * lado.escala;
+  };
+
+  /** Punto sobre el margen de un lado, a la altura `t`. */
+  const margen = (t, lado) => ({ x: lado.signo * anchoLado(t, lado), y: -t * L });
+
+  /* --- contorno: base → margen derecho → punta → margen izquierdo --- */
+  const N = 34;
+  const pts = [{ x: 0, y: 0 }];
+  for (let i = 1; i <= N; i += 1) pts.push(margen(0.008 + (i / (N + 1)) * 0.985, lados[0]));
+  pts.push({ x: 0, y: -L }); // la punta, exacta y aguda
+  for (let i = N; i >= 1; i -= 1) pts.push(margen(0.008 + (i / (N + 1)) * 0.985, lados[1]));
+
+  const contorno = curvaCerrada(pts, 0.92);
+
+  /* --- nervio central: no es recto, la hoja cuelga un poquito --- */
+  const eje = [];
+  for (let i = 0; i <= 10; i += 1) {
+    const t = i / 10;
+    eje.push({ x: Math.sin(t * 2.1) * 1.1, y: -t * L });
+  }
+  const nervioCentral = curvaAbierta(eje, 1);
+  /** x del nervio central a la altura t (la hoja se curva: hay que seguirlo). */
+  const ejeEn = (t) => Math.sin(Math.min(1, Math.max(0, t)) * 2.1) * 1.1;
+
+  /* --- laterales broquidódromas + lazos --- */
+  const laterales = [];
+  const t0 = 0.1;
+  const t1 = 0.88;
+  for (let i = 0; i < pares; i += 1) {
+    const t = t0 + ((t1 - t0) * i) / (pares - 1);
+    for (const lado of lados) {
+      const w = anchoLado(t, lado);
+      /* La vena muere al 78% del ancho: NO toca el borde (broquidódroma). */
+      const finT = t + 0.075 + 0.02 * rnd();
+      const fin = {
+        x: lado.signo * anchoLado(finT, lado) * 0.78,
+        y: -finT * L,
+      };
+      const ini = { x: ejeEn(t), y: -t * L };
+      const ctrl = { x: lado.signo * w * 0.44, y: -(t + 0.012) * L };
+      const d = `M${r2(ini.x)} ${r2(ini.y)}Q${r2(ctrl.x)} ${r2(ctrl.y)} ${r2(fin.x)} ${r2(fin.y)}`;
+      laterales.push({ d, fin, lado: lado.signo, t });
+    }
+  }
+
+  /* Los lazos: el arco que une la punta de una vena con la siguiente, por
+     fuera. Es la firma broquidódroma y casi nadie la dibuja. */
+  const lazos = [];
+  for (const signo of [1, -1]) {
+    const delLado = laterales.filter((v) => v.lado === signo);
+    for (let i = 0; i < delLado.length - 1; i += 1) {
+      const a = delLado[i].fin;
+      const b = delLado[i + 1];
+      /* llega a media vena de la siguiente, no a su punta */
+      const destino = { x: b.fin.x * 0.62, y: (b.fin.y + -b.t * L) / 2 };
+      const cx = signo * Math.max(Math.abs(a.x), Math.abs(destino.x)) * 1.12;
+      lazos.push(
+        `M${r2(a.x)} ${r2(a.y)}Q${r2(cx)} ${r2((a.y + destino.y) / 2)} ${r2(destino.x)} ${r2(destino.y)}`,
+      );
+    }
+  }
+
+  return { L, W, contorno, nervioCentral, laterales, lazos, ejeEn, anchoLado, lados };
+}
+
+/** LA hoja del diferencial. Una sola, compartida por las tres láminas. */
+export const HOJA = construirHoja({ L: 140, W: 26, ondas: 6, amp: 0.055, pares: 8, semilla: 7 });
+
+/**
+ * Punto DENTRO de la lámina, en coordenadas de hoja.
+ * @param {number} t 0=base, 1=punta (a lo largo del nervio).
+ * @param {number} u -1=margen izquierdo, 0=nervio, 1=margen derecho.
+ *
+ * Sirve para posar una mancha, un hueco o un bicho y que SIEMPRE caiga en la
+ * hoja y siga su forma — sin ir midiendo a ojo pixel por pixel.
+ */
+export function puntoEnHoja(t, u, hoja = HOJA) {
+  const lado = hoja.lados[u >= 0 ? 0 : 1];
+  const w = hoja.anchoLado(t, lado);
+  return { x: hoja.ejeEn(t) + u * w, y: -t * hoja.L };
+}
+
+/* ------------------------------------------------------------------ */
+/* MARCAS DEL DAÑO — cada una calcada de una foto real del repo         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Blob irregular: el contorno de una lesión que NO es un círculo.
+ * (Un círculo perfecto es la marca del dibujo inventado; en la foto de la
+ * roya las manchas son manchones lobulados que a veces se funden.)
+ *
+ * OJO — lección aprendida mirando el primer render: si se suman armónicos
+ * (l y l+2) con poco ruido, sale un TRÉBOL. Un hueco de mordisco dibujado
+ * así parece una flor pegada en la hoja, y arruina la lámina entera. Por eso
+ * acá van tres frecuencias NO armónicas (l, l+3, l+7), ruido de verdad
+ * encima, y `alargue`+`rot` para estirar la marca en la dirección que le toca
+ * (los huecos de mordisco se estiran ENTRE vena y vena, porque el bicho
+ * esquiva la nervadura dura).
+ *
+ * @param {number} [rot] giro de la marca, en grados.
+ */
+export function blob({ cx, cy, r, semilla, lobulos = 3, rugosidad = 0.22, alargue = 1, rot = 0 }) {
+  const rnd = prngDe(semilla);
+  const f1 = rnd() * Math.PI * 2;
+  const f2 = rnd() * Math.PI * 2;
+  const f3 = rnd() * Math.PI * 2;
+  const co = Math.cos((rot * Math.PI) / 180);
+  const si = Math.sin((rot * Math.PI) / 180);
+  const pts = [];
+  const N = 22;
+  for (let i = 0; i < N; i += 1) {
+    const a = (i / N) * Math.PI * 2;
+    const k =
+      1 +
+      rugosidad * Math.sin(lobulos * a + f1) +
+      rugosidad * 0.55 * Math.sin((lobulos + 3) * a + f2) +
+      rugosidad * 0.32 * Math.sin((lobulos + 7) * a + f3) +
+      (rnd() - 0.5) * rugosidad * 1.2;
+    const px = Math.cos(a) * r * k * alargue;
+    const py = Math.sin(a) * r * k;
+    pts.push({ x: cx + px * co - py * si, y: cy + px * si + py * co });
+  }
+  return curvaCerrada(pts, 1);
+}
+
+/**
+ * El POLVO de la roya: lo que de verdad se ve en `hemileia_vastatrix.jpg`.
+ *
+ * No es una mancha naranja plana — es POLVILLO: miles de uredosporas que
+ * reventaron por los estomas del envés. Se ve como cúrcuma regada: grano,
+ * no pintura. Denso en el centro, ralo en la orilla, y siempre con unas
+ * esporas sueltas más allá (el polvo que ya se regó — la pista de que la
+ * cosa se está moviendo).
+ *
+ * @returns {{granos: Array, sueltas: Array}} círculos listos para pintar.
+ */
+export function polvoRoya({ cx, cy, r, semilla, densidad = 150, alargue = 1 }) {
+  const rnd = prngDe(semilla);
+  const granos = [];
+  for (let i = 0; i < densidad; i += 1) {
+    const a = rnd() * Math.PI * 2;
+    /* sesgo al centro: ^1.15 apiña adentro y deja la orilla deshilachada */
+    const rho = Math.pow(rnd(), 1.15);
+    const ondul = 1 + 0.2 * Math.sin(3 * a + semilla);
+    const d = rho * r * ondul;
+    granos.push({
+      x: r2(cx + Math.cos(a) * d * alargue),
+      y: r2(cy + Math.sin(a) * d),
+      r: r2(0.34 + rnd() * 0.92 * (1 - rho * 0.45)),
+      /* el centro es naranja quemado; la orilla, amarillo pálido */
+      tono: rho,
+      op: r2(0.5 + (1 - rho) * 0.5),
+    });
+  }
+  /* esporas sueltas: el polvo que se cayó al voltear la hoja */
+  const sueltas = [];
+  for (let i = 0; i < Math.round(densidad * 0.12); i += 1) {
+    const a = rnd() * Math.PI * 2;
+    const d = r * (1.15 + rnd() * 1.5);
+    sueltas.push({
+      x: r2(cx + Math.cos(a) * d * alargue),
+      y: r2(cy + Math.sin(a) * d),
+      r: r2(0.3 + rnd() * 0.5),
+      op: r2(0.3 + rnd() * 0.4),
+    });
+  }
+  return { granos, sueltas };
+}
+
+/**
+ * Un mordisco: el trozo que se comió el bicho.
+ *
+ * Clave de realismo (foto `alternaria_solani.jpg`, borde comido; y cualquier
+ * hoja mordida de verdad): el mordisco NO es una muesca limpia de tijera.
+ * Es una bahía de borde irregular, y la herida CICATRIZA: queda un filito
+ * pardo y un halo amarillento alrededor del corte. Ese filito pardo es la
+ * diferencia entre un dibujo creíble y una hoja de caricatura con muescas.
+ */
+export function mordisco({ cx, cy, r, semilla }) {
+  return blob({ cx, cy, r, semilla, lobulos: 4, rugosidad: 0.3 });
+}
+
+/**
+ * Excremento de gusano (frass). No son puntos redondos: son barrilitos
+ * acanalados, verde-pardo, y se acumulan donde el bicho estuvo comiendo —
+ * en la horqueta de la vena o en el cogollo. Encontrar frass sin ver el
+ * bicho es prueba suficiente de plaga: el rastro cuenta.
+ */
+export function frass({ cx, cy, n, radio, semilla }) {
+  const rnd = prngDe(semilla);
+  const bolitas = [];
+  for (let i = 0; i < n; i += 1) {
+    const a = rnd() * Math.PI * 2;
+    const d = Math.pow(rnd(), 0.6) * radio;
+    bolitas.push({
+      x: r2(cx + Math.cos(a) * d),
+      y: r2(cy + Math.sin(a) * d * 0.8),
+      w: r2(2.1 + rnd() * 1.1),
+      h: r2(1.35 + rnd() * 0.6),
+      rot: r2(rnd() * 180),
+    });
+  }
+  return bolitas;
+}

--- a/src/visual/diferencial/index.js
+++ b/src/visual/diferencial/index.js
@@ -1,0 +1,68 @@
+/*
+ * Láminas del DIFERENCIAL DEL DAÑO: plaga vs enfermedad vs deficiencia.
+ *
+ * Es la confusión que más plata le cuesta al campesino — le echa fungicida a
+ * un pulgón, o veneno a una falta de nitrógeno: gasta, no resuelve, y mata a
+ * los benéficos. Estas tres láminas enseñan a distinguirlos, a decidir, y
+ * también a reconocer cuándo NO se puede saber.
+ *
+ * Hermana de `src/visual/laminas` (mismo papel, misma tinta, misma firma de
+ * props: `width:100%` + `className`, sin `size`/`inline`). Vive aparte porque
+ * no es un catálogo de matas: es un módulo con una tesis —el ORDEN del daño—
+ * y sus piezas (`formasHoja`, `formasBicho`, `motivosDano`, `paletaDano`) se
+ * comparten entre las tres para que LA HOJA sea siempre la misma.
+ *
+ * Cero dependencias, estáticas, sin animación, rsvg-safe.
+ */
+export { default as LaminaDiferencial } from './LaminaDiferencial.jsx';
+export { default as LaminaLlave } from './LaminaLlave.jsx';
+export { default as LaminaDuda } from './LaminaDuda.jsx';
+
+/* Las piezas, por si otro mundo necesita dibujar una hoja con daño y no una
+   lámina entera (regla de la casa: NO redibujar la hoja — reusar esta). */
+export { HOJA, construirHoja, puntoEnHoja, blob, polvoRoya, mezclarHex } from './formasHoja.js';
+export { GUSANO, construirGusano, tubo } from './formasBicho.js';
+export {
+  HojaBase,
+  HojaMini,
+  PolvoRoya,
+  RoyaPorElHaz,
+  ManchaCercospora,
+  ManchaAnillos,
+  ClorosisHierro,
+  ClorosisNitrogeno,
+  Gusano,
+  Frass,
+  Pliego,
+  Rotulo,
+  Lupa,
+  Vineta,
+} from './motivosDano.jsx';
+export * as PaletaDano from './paletaDano.js';
+
+import LaminaDiferencial from './LaminaDiferencial.jsx';
+import LaminaLlave from './LaminaLlave.jsx';
+import LaminaDuda from './LaminaDuda.jsx';
+
+/* Registro consultable: slug → componente + qué enseña. Todas "enseñan"
+   (role=img con título y descripción): ninguna es decorativa. */
+export const LAMINAS_DIFERENCIAL = {
+  diferencial: {
+    Component: LaminaDiferencial,
+    nombre: '¿Plaga, enfermedad o hambre?',
+    ensena: 'Los tres daños lado a lado, sobre la misma hoja de café.',
+    accesible: 'enseña',
+  },
+  llave: {
+    Component: LaminaLlave,
+    nombre: 'La llave: tres pruebas de mano',
+    ensena: 'El doblez (simetría), el dedo (forma) y la edad (cuál hoja).',
+    accesible: 'enseña',
+  },
+  duda: {
+    Component: LaminaDuda,
+    nombre: 'Cuando NO se puede saber',
+    ensena: 'Nitrógeno o nematodo: por arriba no se distinguen. Mire la raíz.',
+    accesible: 'enseña',
+  },
+};

--- a/src/visual/diferencial/motivosDano.jsx
+++ b/src/visual/diferencial/motivosDano.jsx
@@ -1,0 +1,720 @@
+import React, { useId } from 'react';
+import { HOJA, blob, polvoRoya, frass as frassDe, mezclarHex } from './formasHoja.js';
+import { GUSANO } from './formasBicho.js';
+import {
+  HOJA_SANA,
+  PLAGA,
+  ENFERMEDAD,
+  DEFICIENCIA,
+  TINTA,
+  PLIEGO,
+} from './paletaDano.js';
+
+/*
+ * motivosDano — las piezas sueltas del diferencial, para que las tres láminas
+ * dibujen LA MISMA hoja y LAS MISMAS marcas.
+ *
+ * Regla de oro de este módulo: ninguna marca es una figura de geometría
+ * limpia. En la naturaleza no hay círculos perfectos. Cada mancha sale de
+ * `blob()` (contorno lobulado) o de nubes de granos con semilla fija. Un
+ * círculo naranja plano sería un dibujo inventado; el polvo de la roya de la
+ * foto es GRANO, y así se pinta acá.
+ */
+
+/** useId trae ':' y eso rompe los url(#..) de SVG. Lo limpiamos. */
+function usarId(prefijo) {
+  return `${prefijo}-${useId().replace(/[^a-zA-Z0-9]/g, '')}`;
+}
+
+/* ------------------------------------------------------------------ */
+/* LA HOJA                                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * La hoja de café, base de los tres paneles. SIEMPRE la misma geometría.
+ *
+ * @param {Object} props
+ * @param {Array<string>} [props.mordidas] paths de lo que se comió el bicho
+ *   (se recortan de la lámina Y reciben su filo pardo cicatrizado).
+ * @param {React.ReactNode} [props.children] marcas SOBRE la lámina (manchas,
+ *   clorosis): van recortadas al contorno, no se salen de la hoja.
+ * @param {React.ReactNode} [props.encima] lo que se posa sobre la hoja y sí
+ *   puede sobresalir del borde (el bicho, el excremento).
+ * @param {'haz'|'enves'} [props.cara]
+ * @param {string} [props.tinteLamina] color de la lámina (para la clorosis).
+ */
+export function HojaBase({
+  mordidas = [],
+  ventanas = [],
+  children,
+  encima,
+  cara = 'haz',
+  tinteLamina,
+  conBrillo = true,
+}) {
+  const uid = usarId('hoja');
+  const clip = `${uid}-clip`;
+  const mask = `${uid}-mask`;
+  const grad = `${uid}-grad`;
+  const desenfoque = `${uid}-blur`;
+  const clipVent = `${uid}-vent`;
+  /* mordidas y ventanas se comen la lámina igual; la diferencia es que en la
+     ventana el bicho dejó el costillar de venas parado. */
+  const huecos = [...mordidas, ...ventanas];
+
+  const esEnves = cara === 'enves';
+  const base = tinteLamina || (esEnves ? HOJA_SANA.envesFondo : HOJA_SANA.haz);
+  const hondo = tinteLamina
+    ? mezclarHex(tinteLamina, HOJA_SANA.hazHondo, 0.25)
+    : esEnves
+      ? mezclarHex(HOJA_SANA.envesFondo, HOJA_SANA.hazHondo, 0.3)
+      : HOJA_SANA.hazHondo;
+
+  return (
+    <g>
+      <defs>
+        <clipPath id={clip}>
+          <path d={HOJA.contorno} />
+        </clipPath>
+        <mask id={mask}>
+          {/* blanco = hoja que sigue ahí; negro = lo que se comieron */}
+          <rect x="-80" y="-170" width="160" height="200" fill="#fff" />
+          {huecos.map((d, i) => (
+            <path key={i} d={d} fill="#000" />
+          ))}
+        </mask>
+        {ventanas.length > 0 && (
+          <clipPath id={clipVent}>
+            {ventanas.map((d, i) => (
+              <path key={i} d={d} />
+            ))}
+          </clipPath>
+        )}
+        <linearGradient id={grad} x1="0" y1="1" x2="1" y2="0">
+          <stop offset="0" stopColor={hondo} />
+          <stop offset="0.55" stopColor={base} />
+          <stop offset="1" stopColor={mezclarHex(base, HOJA_SANA.brillo, 0.28)} />
+        </linearGradient>
+        <filter id={desenfoque} x="-30%" y="-30%" width="160%" height="160%">
+          <feGaussianBlur stdDeviation="2.4" />
+        </filter>
+      </defs>
+
+      <g mask={`url(#${mask})`}>
+        {/* la lámina */}
+        <path d={HOJA.contorno} fill={`url(#${grad})`} />
+
+        <g clipPath={`url(#${clip})`}>
+          {/* Los SURCOS: la lámina es abullonada, así que la vena se lee
+              como un canal hundido y no como una raya encima. */}
+          <g fill="none" stroke={HOJA_SANA.venaSurco} strokeLinecap="round" opacity={esEnves ? 0.22 : 0.34}>
+            <path d={HOJA.nervioCentral} strokeWidth="4.2" />
+            {HOJA.laterales.map((v, i) => (
+              <path key={i} d={v.d} strokeWidth="1.9" />
+            ))}
+          </g>
+
+          {/* las venas: en el café van MÁS CLARAS que la lámina */}
+          <g fill="none" stroke={HOJA_SANA.vena} strokeLinecap="round">
+            {HOJA.laterales.map((v, i) => (
+              <path key={i} d={v.d} strokeWidth={esEnves ? 0.95 : 0.7} opacity="0.92" />
+            ))}
+            {/* los lazos broquidódromos: la vena NO llega al borde */}
+            {HOJA.lazos.map((d, i) => (
+              <path key={i} d={d} strokeWidth="0.5" opacity="0.55" />
+            ))}
+            <path d={HOJA.nervioCentral} strokeWidth={esEnves ? 2.3 : 1.7} opacity="0.95" />
+          </g>
+
+          {/* el lustre del haz (la hoja de café brilla) */}
+          {conBrillo && !esEnves && (
+            <path
+              d={blob({ cx: -9, cy: -84, r: 15, semilla: 3, lobulos: 2, rugosidad: 0.4, alargue: 0.55 })}
+              fill={HOJA_SANA.brillo}
+              opacity="0.28"
+              filter={`url(#${desenfoque})`}
+            />
+          )}
+
+          {/* las marcas del daño */}
+          {children}
+        </g>
+
+        <path d={HOJA.contorno} fill="none" stroke={HOJA_SANA.borde} strokeWidth="1.05" />
+      </g>
+
+      {/* LA VENTANA — el bicho se comió lo blandito de entre las venas y dejó
+          el costillar parado, como un encaje. Es de las firmas más claras del
+          masticador: ningún hongo respeta la nervadura de esa manera, y
+          ninguna deficiencia hace huecos. Las venas van resecas y pardas
+          porque quedaron al aire. */}
+      {ventanas.length > 0 && (
+        <g clipPath={`url(#${clipVent})`} fill="none" strokeLinecap="round">
+          {HOJA.laterales.map((v, i) => (
+            <path key={i} d={v.d} stroke={PLAGA.mordidaFilo} strokeWidth="1.5" opacity="0.85" />
+          ))}
+          {HOJA.laterales.map((v, i) => (
+            <path key={`c${i}`} d={v.d} stroke={mezclarHex(HOJA_SANA.vena, PLAGA.mordidaHalo, 0.5)} strokeWidth="0.8" />
+          ))}
+          {HOJA.lazos.map((d, i) => (
+            <path key={`l${i}`} d={d} stroke={PLAGA.mordidaFilo} strokeWidth="0.7" opacity="0.7" />
+          ))}
+        </g>
+      )}
+
+      {/* EL FILO DE LA MORDIDA — el detalle que hace creíble el dibujo.
+          Una hoja mordida no queda cortada a tijera: la herida cicatriza y
+          deja un filito pardo con un halo amarillo.
+
+          Ojo a la composición, que es sutil: el filo va montado JUSTO sobre
+          el borde del mordisco, así que la mitad de la línea caería sobre el
+          hueco — sobre el papel, donde ya no hay hoja — y se vería flotando.
+          La herida solo existe del lado donde todavía hay lámina. Por eso el
+          grupo lleva las DOS cosas: recortado al contorno (que no se salga de
+          la hoja) y con la máscara del mordisco (que borra la mitad que caía
+          en el hueco). Como solo sobrevive la mitad de cada línea, los
+          grosores van al doble. */}
+      {huecos.length > 0 && (
+        <g clipPath={`url(#${clip})`} mask={`url(#${mask})`} fill="none" strokeLinejoin="round">
+          {huecos.map((d, i) => (
+            <path key={`h${i}`} d={d} stroke={PLAGA.mordidaHalo} strokeWidth="4.6" opacity="0.42" />
+          ))}
+          {huecos.map((d, i) => (
+            <path key={`f${i}`} d={d} stroke={PLAGA.mordidaFilo} strokeWidth="2.6" opacity="0.95" />
+          ))}
+        </g>
+      )}
+
+      {/* pecíolo */}
+      <path d="M0 0 C 0.4 5 0.2 9 -0.4 13" fill="none" stroke={HOJA_SANA.peciolo} strokeWidth="2.6" strokeLinecap="round" />
+
+      {encima}
+    </g>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* ENFERMEDAD · ROYA — el polvo naranja                                */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Las pústulas de roya en el ENVÉS: polvillo, no pintura.
+ * Calcado de `public/plaga-images/hemileia_vastatrix.jpg`.
+ */
+export function PolvoRoya({ manchas }) {
+  const uid = usarId('roya');
+  const blur = `${uid}-blur`;
+  return (
+    <g>
+      <defs>
+        <filter id={blur} x="-40%" y="-40%" width="180%" height="180%">
+          <feGaussianBlur stdDeviation="3" />
+        </filter>
+      </defs>
+
+      {/* 1. el amarilleo clorótico: la hoja ya perdió el verde ahí debajo,
+             y el borde es DIFUSO (no tiene línea) */}
+      <g filter={`url(#${blur})`} opacity="0.75">
+        {manchas.map((m, i) => (
+          <path
+            key={i}
+            d={blob({ cx: m.cx, cy: m.cy, r: m.r * 1.5, semilla: m.semilla + 40, lobulos: 3, rugosidad: 0.26, alargue: m.alargue })}
+            fill={ENFERMEDAD.royaHalo}
+          />
+        ))}
+      </g>
+
+      {/* 2. EL POLVO. Grano por grano: así se ve la cúrcuma regada de la foto */}
+      {manchas.map((m, i) => {
+        const { granos, sueltas } = polvoRoya({
+          cx: m.cx,
+          cy: m.cy,
+          r: m.r,
+          semilla: m.semilla,
+          densidad: m.densidad || 150,
+          alargue: m.alargue,
+        });
+        return (
+          <g key={i}>
+            {/* la sombra del montoncito: el polvo tiene espesor */}
+            <path
+              d={blob({ cx: m.cx, cy: m.cy, r: m.r * 0.86, semilla: m.semilla, lobulos: 3, rugosidad: 0.24, alargue: m.alargue })}
+              fill={ENFERMEDAD.royaPalido}
+              opacity="0.5"
+            />
+            {granos.map((g, k) => (
+              <circle
+                key={k}
+                cx={g.x}
+                cy={g.y}
+                r={g.r}
+                fill={mezclarHex(ENFERMEDAD.royaCentro, ENFERMEDAD.royaPalido, Math.min(1, g.tono * 1.1))}
+                opacity={g.op}
+              />
+            ))}
+            {/* el polvo que ya se regó: la pista de que la cosa avanza */}
+            {sueltas.map((g, k) => (
+              <circle key={`s${k}`} cx={g.x} cy={g.y} r={g.r} fill={ENFERMEDAD.royaMedio} opacity={g.op} />
+            ))}
+          </g>
+        );
+      })}
+    </g>
+  );
+}
+
+/** Lo que se ve por el HAZ de la misma hoja con roya: solo una mancha
+ *  amarilla, sin gracia. Por eso hay que VOLTEAR la hoja. */
+export function RoyaPorElHaz({ manchas }) {
+  const uid = usarId('royahaz');
+  const blur = `${uid}-blur`;
+  return (
+    <g>
+      <defs>
+        {/* Poquito desenfoque: la mancha del haz NO tiene borde (por eso no
+            dice qué es), pero sí es una MANCHA. Con mucho desenfoque parece
+            una fuga de luz en la foto y deja de leerse como daño. */}
+        <filter id={blur} x="-40%" y="-40%" width="180%" height="180%">
+          <feGaussianBlur stdDeviation="1.6" />
+        </filter>
+      </defs>
+      <g filter={`url(#${blur})`}>
+        {manchas.map((m, i) => (
+          <g key={i}>
+            {/* la mancha clorótica: redondeada y bien amarilla, pero SIN borde
+                — de lejos es lo único que se ve, y no dice qué es. */}
+            <path
+              d={blob({ cx: m.cx, cy: m.cy, r: m.r * 1.45, semilla: m.semilla + 40, lobulos: 3, rugosidad: 0.26, alargue: m.alargue })}
+              fill={ENFERMEDAD.royaHazMancha}
+            />
+            <path
+              d={blob({ cx: m.cx, cy: m.cy, r: m.r * 1.05, semilla: m.semilla + 40, lobulos: 3, rugosidad: 0.24, alargue: m.alargue })}
+              fill={mezclarHex(ENFERMEDAD.royaHazMancha, ENFERMEDAD.royaPalido, 0.5)}
+            />
+            {/* el naranja que se alcanza a asomar por el haz cuando la cosa
+                ya está avanzada: la pista de que hay que voltearla */}
+            <path
+              d={blob({ cx: m.cx, cy: m.cy, r: m.r * 0.46, semilla: m.semilla + 9, lobulos: 3, rugosidad: 0.3, alargue: m.alargue })}
+              fill={ENFERMEDAD.royaMedio}
+              opacity="0.45"
+            />
+          </g>
+        ))}
+      </g>
+    </g>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* ENFERMEDAD · LA MANCHA CON PATRÓN                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Mancha de hierro / ojo de gallo (Cercospora coffeicola).
+ * Calcada de `public/plaga-images/cercospora_coffeicola.jpg`: halo amarillo
+ * brillante, borde OSCURO Y DEFINIDO, centro gris ceniza. Esta es LA figura
+ * de "la enfermedad tiene forma": se puede dibujar su borde con el dedo.
+ */
+export function ManchaCercospora({ cx, cy, r, semilla = 5 }) {
+  const uid = usarId('cerco');
+  const blur = `${uid}-blur`;
+  return (
+    <g>
+      <defs>
+        <filter id={blur} x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="1.9" />
+        </filter>
+      </defs>
+      {/* halo amarillo: difuso hacia afuera, pero rodea toda la mancha */}
+      <path
+        d={blob({ cx, cy, r: r * 1.85, semilla: semilla + 3, lobulos: 3, rugosidad: 0.14 })}
+        fill={ENFERMEDAD.cercoHalo}
+        opacity="0.85"
+        filter={`url(#${blur})`}
+      />
+      {/* el cuerpo de la lesión: BORDE DEFINIDO (aquí sí hay línea) */}
+      <path
+        d={blob({ cx, cy, r, semilla, lobulos: 3, rugosidad: 0.1 })}
+        fill={ENFERMEDAD.cercoCentro}
+        stroke={ENFERMEDAD.cercoBorde}
+        strokeWidth="0.85"
+      />
+      {/* el centro se seca y se aclara (ceniza) */}
+      <path
+        d={blob({ cx: cx - r * 0.08, cy: cy - r * 0.06, r: r * 0.52, semilla: semilla + 11, lobulos: 3, rugosidad: 0.16 })}
+        fill={ENFERMEDAD.cercoCentroPalido}
+        opacity="0.9"
+      />
+      <circle cx={cx + r * 0.12} cy={cy + r * 0.1} r={r * 0.16} fill={ENFERMEDAD.cercoBorde} opacity="0.5" />
+    </g>
+  );
+}
+
+/**
+ * La lesión con ANILLOS CONCÉNTRICOS (tipo Alternaria, `alternaria_solani.jpg`).
+ * El "tiro al blanco". Dato fino de la foto que casi nadie dibuja: la lesión
+ * SE FRENA en la vena y se vuelve angular — el hongo no puede cruzar la
+ * nervadura. Ningún bicho hace eso. Eso es patrón puro.
+ */
+export function ManchaAnillos({ cx, cy, r, semilla = 8 }) {
+  const uid = usarId('anillo');
+  const blur = `${uid}-blur`;
+  return (
+    <g>
+      <defs>
+        <filter id={blur} x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="1.7" />
+        </filter>
+      </defs>
+      <path
+        d={blob({ cx, cy, r: r * 1.5, semilla: semilla + 2, lobulos: 3, rugosidad: 0.2 })}
+        fill={ENFERMEDAD.anilloHalo}
+        opacity="0.7"
+        filter={`url(#${blur})`}
+      />
+      <path
+        d={blob({ cx, cy, r, semilla, lobulos: 4, rugosidad: 0.16 })}
+        fill={ENFERMEDAD.anilloFondo}
+        stroke={ENFERMEDAD.anilloLinea}
+        strokeWidth="0.7"
+      />
+      {/* los anillos: el hongo avanza a tirones, un anillo por empujón */}
+      {[0.78, 0.58, 0.38, 0.2].map((k, i) => (
+        <path
+          key={i}
+          d={blob({ cx, cy, r: r * k, semilla: semilla + i * 7, lobulos: 4, rugosidad: 0.13 })}
+          fill="none"
+          stroke={ENFERMEDAD.anilloLinea}
+          strokeWidth="0.55"
+          opacity={0.72 - i * 0.08}
+        />
+      ))}
+    </g>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* DEFICIENCIA · LA CLOROSIS                                           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Clorosis intervenal de HIERRO: la lámina amarillea y la nervadura SE QUEDA
+ * VERDE. Queda una redecilla verde sobre amarillo — ordenada, simétrica, sin
+ * bicho y sin borde. Ataca las hojas NUEVAS (el hierro no se mueve dentro de
+ * la mata: la hoja vieja no se lo puede prestar al cogollo).
+ *
+ * Se dibuja al revés que las otras marcas: la lámina ya viene amarilla desde
+ * `HojaBase tinteLamina`, y acá se repone EL VERDE que sobrevive pegado a la
+ * vena. Eso es exactamente lo que pasa en la mata.
+ */
+export function ClorosisHierro() {
+  const uid = usarId('fe');
+  const blur = `${uid}-blur`;
+  return (
+    <g>
+      <defs>
+        <filter id={blur} x="-30%" y="-30%" width="160%" height="160%">
+          <feGaussianBlur stdDeviation="1.5" />
+        </filter>
+      </defs>
+      {/* el corredor verde a lado y lado de cada vena: ancho, difuso, SIN
+          borde. Si tuviera borde sería una mancha, y esto no es una mancha. */}
+      <g filter={`url(#${blur})`} fill="none" strokeLinecap="round" opacity="0.9">
+        <path d={HOJA.nervioCentral} stroke={DEFICIENCIA.hierroVenaHalo} strokeWidth="5" />
+        {HOJA.laterales.map((v, i) => (
+          <path key={i} d={v.d} stroke={DEFICIENCIA.hierroVenaHalo} strokeWidth="3.2" />
+        ))}
+        {HOJA.lazos.map((d, i) => (
+          <path key={`l${i}`} d={d} stroke={DEFICIENCIA.hierroVenaHalo} strokeWidth="1.8" opacity="0.6" />
+        ))}
+      </g>
+      {/* la vena misma, verde franco. Fina: en la mata el amarillo MANDA y el
+          verde queda solo pegadito a la nervadura — si el verde ocupa media
+          hoja, ya no se lee como clorosis sino como hoja sana con manchas. */}
+      <g fill="none" stroke={DEFICIENCIA.hierroVena} strokeLinecap="round">
+        <path d={HOJA.nervioCentral} strokeWidth="2" />
+        {HOJA.laterales.map((v, i) => (
+          <path key={i} d={v.d} strokeWidth="1.15" />
+        ))}
+        {HOJA.lazos.map((d, i) => (
+          <path key={`l${i}`} d={d} strokeWidth="0.65" opacity="0.75" />
+        ))}
+      </g>
+    </g>
+  );
+}
+
+/**
+ * Clorosis de NITRÓGENO: la hoja amarillea PAREJA y entera.
+ *
+ * Es el daño más aburrido de dibujar y el más importante de reconocer: no
+ * hay nada. No hay mancha, no hay borde, no hay halo, no hay bicho. Solo una
+ * hoja que se apagó de a poquito, un tono más clara desde la punta.
+ *
+ * Y ataca las hojas VIEJAS primero, porque el nitrógeno la mata sí lo sabe
+ * mover: se lo quita a las de abajo para dárselo a los cogollos. Esa es la
+ * diferencia con el hierro, que no se mueve y por eso pega en las NUEVAS.
+ *
+ * Ojo — este dibujo tiene un gemelo peligroso: así mismo se ve una mata con
+ * nematodo en la raíz. Ver `LaminaDuda`.
+ */
+export function ClorosisNitrogeno() {
+  const uid = usarId('nitro');
+  const grad = `${uid}-g`;
+  return (
+    <g>
+      <defs>
+        <linearGradient id={grad} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor={DEFICIENCIA.nitroViejo} />
+          <stop offset="0.55" stopColor={DEFICIENCIA.nitroMedio} stopOpacity="0.5" />
+          <stop offset="1" stopColor={DEFICIENCIA.nitroVerdeQueQueda} stopOpacity="0.55" />
+        </linearGradient>
+      </defs>
+      {/* el apagón, de la punta hacia la base: SIN una sola línea de borde */}
+      <path d={HOJA.contorno} fill={`url(#${grad})`} />
+      {/* la nervadura apenas se insinúa: acá NO se queda verde como en el
+          hierro — se va apagando con toda la hoja, y por eso no hay redecilla */}
+      <g fill="none" stroke={DEFICIENCIA.nitroVerdeQueQueda} strokeLinecap="round" opacity="0.28">
+        <path d={HOJA.nervioCentral} strokeWidth="1.6" />
+        {HOJA.laterales.map((v, i) => (
+          <path key={i} d={v.d} strokeWidth="0.7" />
+        ))}
+      </g>
+    </g>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* PLAGA · EL BICHO Y SU RASTRO                                        */
+/* ------------------------------------------------------------------ */
+
+/** El excremento del gusano: barrilitos, no puntos. */
+export function Frass({ cx, cy, n = 9, radio = 5, semilla = 31 }) {
+  const bolitas = frassDe({ cx, cy, n, radio, semilla });
+  return (
+    <g>
+      {bolitas.map((b, i) => (
+        <g key={i} transform={`translate(${b.x} ${b.y}) rotate(${b.rot})`}>
+          <rect x={-b.w / 2} y={-b.h / 2} width={b.w} height={b.h} rx={b.h * 0.42} fill={PLAGA.frass} />
+          <rect x={-b.w / 2} y={-b.h / 2} width={b.w} height={b.h * 0.4} rx={b.h * 0.2} fill={PLAGA.frassClaro} opacity="0.55" />
+        </g>
+      ))}
+    </g>
+  );
+}
+
+/**
+ * El gusano. Dibujo de entomología, no personaje: sin ojos, sin boca.
+ * Bandas longitudinales que siguen la curva del cuerpo, anillos por segmento,
+ * pináculas con seta, cápsula cefálica con la "Y" invertida pálida.
+ */
+export function Gusano({ x = 0, y = 0, rot = 0, escala = 1, bicho = GUSANO }) {
+  const uid = usarId('gus');
+  const grad = `${uid}-grad`;
+  const clip = `${uid}-clip`;
+  const cab = bicho.cabeza;
+  return (
+    <g transform={`translate(${x} ${y}) rotate(${rot}) scale(${escala})`}>
+      <defs>
+        <linearGradient id={grad} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor={PLAGA.cuerpoClaro} />
+          <stop offset="0.5" stopColor={PLAGA.cuerpo} />
+          <stop offset="1" stopColor={mezclarHex(PLAGA.cuerpo, PLAGA.banda, 0.55)} />
+        </linearGradient>
+        <clipPath id={clip}>
+          <path d={bicho.contorno} />
+        </clipPath>
+      </defs>
+
+      {/* sombra de contacto: el bicho pesa sobre la hoja */}
+      <path d={bicho.contorno} fill={PLAGA.banda} opacity="0.2" transform="translate(0.6 1.4)" />
+
+      {/* las patas asoman por debajo del cuerpo */}
+      <g stroke={PLAGA.pata} strokeLinecap="round" fill="none">
+        {bicho.patas.map((p, i) => (
+          <path
+            key={i}
+            d={`M${p.x.toFixed(2)} ${p.y.toFixed(2)} q${(p.dx * 0.5).toFixed(2)} ${(p.dy * 0.7).toFixed(2)} ${p.dx.toFixed(2)} ${p.dy.toFixed(2)}`}
+            strokeWidth={p.tipo === 'toracica' ? 0.75 : 1.25}
+            opacity={p.tipo === 'toracica' ? 1 : 0.9}
+          />
+        ))}
+      </g>
+
+      <path d={bicho.contorno} fill={`url(#${grad})`} />
+
+      <g clipPath={`url(#${clip})`}>
+        {/* bandas longitudinales: se curvan CON el cuerpo (por eso el gusano
+            se lee como animal y no como macarrón pintado a rayas) */}
+        <path d={bicho.franja(0.62)} fill="none" stroke={PLAGA.banda} strokeWidth={bicho.grueso * 0.34} opacity="0.75" />
+        <path d={bicho.franja(-0.66)} fill="none" stroke={PLAGA.banda} strokeWidth={bicho.grueso * 0.3} opacity="0.62" />
+        <path d={bicho.franja(0.1)} fill="none" stroke={PLAGA.bandaFina} strokeWidth={bicho.grueso * 0.16} opacity="0.6" />
+        <path d={bicho.franja(0.34)} fill="none" stroke={PLAGA.cuerpoClaro} strokeWidth={bicho.grueso * 0.12} opacity="0.7" />
+        <path d={bicho.franja(-0.34)} fill="none" stroke={PLAGA.cuerpoClaro} strokeWidth={bicho.grueso * 0.1} opacity="0.55" />
+
+        {/* anillos de los segmentos */}
+        <g fill="none" stroke={PLAGA.banda} strokeWidth="0.32" opacity="0.5">
+          {bicho.anillos.map((d, i) => (
+            <path key={i} d={d} />
+          ))}
+        </g>
+      </g>
+
+      {/* pináculas con su seta */}
+      <g>
+        {bicho.pinaculas.map((p, i) => (
+          <g key={i}>
+            <path
+              d={`M${p.x.toFixed(2)} ${p.y.toFixed(2)} L${p.seta.x.toFixed(2)} ${p.seta.y.toFixed(2)}`}
+              stroke={PLAGA.banda}
+              strokeWidth="0.24"
+              opacity="0.75"
+            />
+            <circle cx={p.x} cy={p.y} r={p.r} fill={PLAGA.cabeza} opacity="0.85" />
+          </g>
+        ))}
+      </g>
+
+      <path d={bicho.contorno} fill="none" stroke={PLAGA.banda} strokeWidth="0.4" opacity="0.8" />
+
+      {/* la cabeza: cápsula dura, oscura, sin cara */}
+      <g>
+        <circle cx={cab.x} cy={cab.y} r={cab.r} fill={PLAGA.cabeza} />
+        <circle cx={cab.x} cy={cab.y} r={cab.r} fill="none" stroke={mezclarHex(PLAGA.cabeza, '#000000', 0.3)} strokeWidth="0.3" />
+        {/* la "Y" invertida pálida de la frente: la firma del cogollero */}
+        <path
+          d={`M${cab.x - cab.r * 0.45} ${cab.y - cab.r * 0.5} L${cab.x - cab.r * 0.05} ${cab.y + cab.r * 0.1} M${cab.x - cab.r * 0.05} ${cab.y + cab.r * 0.1} L${cab.x + cab.r * 0.42} ${cab.y - cab.r * 0.5} M${cab.x - cab.r * 0.05} ${cab.y + cab.r * 0.1} L${cab.x - cab.r * 0.02} ${cab.y + cab.r * 0.72}`}
+          fill="none"
+          stroke={PLAGA.cabezaMarca}
+          strokeWidth="0.42"
+          strokeLinecap="round"
+          opacity="0.9"
+        />
+      </g>
+    </g>
+  );
+}
+
+/**
+ * Hoja miniatura: la misma silueta, en chiquito y barata.
+ *
+ * Para dibujar una mata entera (seis hojas o más) no sirve `HojaBase`: cada
+ * una traería sus filtros, su máscara y sus gradientes, y una lámina con doce
+ * hojas se vuelve un archivo absurdo para un teléfono de gama baja. Esta usa
+ * EL MISMO contorno (así la mata se ve de la misma obra) con dos trazos.
+ *
+ * @param {string} props.tinte color de la lámina.
+ * @param {boolean} [props.venaVerde] la nervadura se queda verde (hierro).
+ */
+export function HojaMini({ x, y, rot = 0, escala = 0.26, tinte, venaVerde = false }) {
+  return (
+    <g transform={`translate(${x} ${y}) rotate(${rot}) scale(${escala})`}>
+      <path d={HOJA.contorno} fill={tinte} stroke={HOJA_SANA.borde} strokeWidth="2.6" />
+      {venaVerde && (
+        <g fill="none" stroke={DEFICIENCIA.hierroVena} strokeLinecap="round" opacity="0.95">
+          <path d={HOJA.nervioCentral} strokeWidth="5" />
+          {HOJA.laterales.map((v, i) => (
+            <path key={i} d={v.d} strokeWidth="3" />
+          ))}
+        </g>
+      )}
+      {!venaVerde && (
+        <path d={HOJA.nervioCentral} fill="none" stroke={HOJA_SANA.venaSurco} strokeWidth="3" opacity="0.4" />
+      )}
+    </g>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* PIEZAS DEL PLIEGO (papel, rótulos, lupa)                            */
+/* ------------------------------------------------------------------ */
+
+/** El pliego de papel del cuaderno. Mismo papel que `laminas/`. */
+export function Pliego({ w, h }) {
+  return (
+    <g>
+      <rect x="2" y="2" width={w - 4} height={h - 4} rx="10" fill={PLIEGO.papel} stroke={PLIEGO.borde} strokeWidth="2" />
+      <rect x="8" y="8" width={w - 16} height={h - 16} rx="7" fill="none" stroke={PLIEGO.bordeSuave} strokeWidth="1" />
+      <path d={`M${w - 8} ${h - 26} L${w - 26} ${h - 8} L${w - 8} ${h - 8} Z`} fill={PLIEGO.dobles} stroke="#d0bb8a" strokeWidth="0.8" />
+    </g>
+  );
+}
+
+/** Rótulo con línea guía y puntico, igual que en las láminas de la casa. */
+export function Rotulo({ tx, ty, anchor = 'start', texto, nota = null, guia, tinta = TINTA.media, tam = 10 }) {
+  const ta = /** @type {'start' | 'middle' | 'end'} */ (anchor);
+  return (
+    <g>
+      {guia && <path d={guia.d} fill="none" stroke={TINTA.guia} strokeWidth="0.8" />}
+      {guia && <circle cx={guia.px} cy={guia.py} r="1.5" fill={TINTA.punto} />}
+      <text x={tx} y={ty} textAnchor={ta} fontSize={tam} fontWeight="700" fill={tinta}>
+        {texto}
+      </text>
+      {nota && (
+        <text x={tx} y={Number(ty) + tam + 0.5} textAnchor={ta} fontSize={tam - 1.6} fontStyle="italic" fill={TINTA.suave}>
+          {nota}
+        </text>
+      )}
+    </g>
+  );
+}
+
+/**
+ * Viñeta de texto: un puntico del color de la categoría y una o dos líneas.
+ * SVG no reparte el texto solo, así que las líneas vienen ya partidas a mano
+ * (es una lámina, no un párrafo: cada línea está medida para su columna).
+ *
+ * @param {Array<string|{fuerte:string,resto:string}>} props.lineas
+ *   Un string es una línea normal; `{fuerte, resto}` arranca en negrilla —
+ *   la palabra que hay que llevarse a la memoria va en negrilla.
+ */
+export function Vineta({ x, y, color, lineas, tam = 7.6, interlinea = 9.4 }) {
+  return (
+    <g>
+      <circle cx={x + 1.6} cy={y - 2.5} r="1.5" fill={color} />
+      {lineas.map((l, i) => (
+        <text key={i} x={x + 7} y={y + i * interlinea} fontSize={tam} fill={TINTA.media}>
+          {typeof l === 'string' ? (
+            l
+          ) : (
+            <>
+              <tspan fontWeight="800" fill={color}>
+                {l.fuerte}
+              </tspan>
+              <tspan>{l.resto}</tspan>
+            </>
+          )}
+        </text>
+      ))}
+    </g>
+  );
+}
+
+/**
+ * La lupa: el recuadro redondo del detalle.
+ * En una lámina botánica el detalle NO es un zoom del mismo dibujo — se
+ * vuelve a dibujar con más información, que es justo lo que uno gana al
+ * acercar la cara a la mata. Así se hace acá.
+ */
+export function Lupa({ cx, cy, r, titulo, children, tinta = TINTA.media }) {
+  const uid = usarId('lupa');
+  const clip = `${uid}-clip`;
+  return (
+    <g>
+      <defs>
+        <clipPath id={clip}>
+          <circle cx={cx} cy={cy} r={r} />
+        </clipPath>
+      </defs>
+      <circle cx={cx} cy={cy} r={r} fill={PLIEGO.papelHondo} />
+      <g clipPath={`url(#${clip})`}>{children}</g>
+      <circle cx={cx} cy={cy} r={r} fill="none" stroke={TINTA.guia} strokeWidth="1.3" />
+      <circle cx={cx} cy={cy} r={r - 2.2} fill="none" stroke={PLIEGO.borde} strokeWidth="0.7" opacity="0.8" />
+      {titulo && (
+        <text x={cx} y={cy + r + 11} textAnchor="middle" fontSize="8" fontWeight="700" fill={tinta} letterSpacing="0.04em">
+          {titulo}
+        </text>
+      )}
+    </g>
+  );
+}

--- a/src/visual/diferencial/paletaDano.js
+++ b/src/visual/diferencial/paletaDano.js
@@ -1,0 +1,145 @@
+/*
+ * paletaDano — los colores del daño, sacados de las FOTOS, no del gusto.
+ *
+ * Por qué esta paleta no importa `../mundo3d/paleta`:
+ *   1. `paletaMadre` cuelga de `atmosferaMadre`, que importa `three`. Meter
+ *      eso en una lámina SVG arrastraría el motor 3D entero a un pliego de
+ *      papel. Las láminas son de CERO dependencias (regla de `src/visual/
+ *      laminas`), y así se quedan.
+ *   2. La paleta madre no tiene —ni debe tener— el naranja de la roya ni el
+ *      pardo de una pudrición. Esos colores no son decisión de arte: son el
+ *      color que TIENE la cosa en la foto. Inventarlos sería el error.
+ *
+ * Lo que sí se hereda es el criterio: papel crema + tinta sepia (idéntico a
+ * `laminas/LaminaCafeto`, para que el cuaderno se lea como uno solo), verdes
+ * andinos con tierra adentro, y CERO rojo-catástrofe de UI (regla 4 de la
+ * paleta madre: el rojo es cochinilla o cereza, no una alarma).
+ *
+ * Cada color de daño anota la foto de `public/plaga-images/` de donde salió.
+ */
+
+/* ------------------------------------------------------------------ */
+/* EL PLIEGO — mismo papel y misma tinta que las láminas de la casa.    */
+/* ------------------------------------------------------------------ */
+export const PLIEGO = {
+  papel: '#f4ead2',
+  papelHondo: '#efe3c6', // fondo de recuadro (detalle)
+  borde: '#d8c39a',
+  bordeSuave: '#e0d0a8',
+  dobles: '#e6d6ae', // la esquina doblada
+};
+
+export const TINTA = {
+  fuerte: '#3f2d17', // titulares
+  media: '#4f3a20', // rótulo
+  suave: '#8a7350', // nota al pie, cursiva
+  guia: '#9a8355', // líneas guía y reglas
+  punto: '#7a6540', // el puntico del rótulo
+};
+
+/* ------------------------------------------------------------------ */
+/* LA HOJA SANA — Coffea arabica, hoja brillante de sombrío.           */
+/* Verdes andinos "con tierra adentro" (criterio de la paleta madre:    */
+/* VERDES.trabajo #5f8a3f / VERDES.monte #3f6f3a son los parientes).    */
+/* Tomados de `hemileia_vastatrix.jpg` y `cercospora_coffeicola.jpg`.   */
+/* ------------------------------------------------------------------ */
+export const HOJA_SANA = {
+  haz: '#4d7a38', // la cara de arriba, verde franco
+  hazHondo: '#3a6029', // la lámina en sombra, entre venas
+  envesFondo: '#7d9a56', // el envés es MÁS PÁLIDO y mate que el haz
+  borde: '#2f4d20',
+  vena: '#6f9a4a', // las venas van más CLARAS que la lámina (foto)
+  venaSurco: '#33551f', // el surco hundido de la vena (lámina abullonada)
+  brillo: '#8fb463', // el lustre del haz (hoja glossy)
+  peciolo: '#6b7f33',
+  tallo: '#5f7a35',
+};
+
+/* ------------------------------------------------------------------ */
+/* PLAGA — el color de un animal y de su rastro.                       */
+/* De `spodoptera_frugiperda.jpg` + `mocis_latipes.jpg` (el gusano) y   */
+/* de `hypothenemus_hampei.jpg` (el aserrín de la broca).              */
+/* ------------------------------------------------------------------ */
+export const PLAGA = {
+  /* el gusano: pardo terroso con bandas, NUNCA un verde de caricatura */
+  cuerpo: '#a98a63',
+  cuerpoClaro: '#c3a781',
+  banda: '#6d5137', // la banda lateral oscura que recorre el cuerpo
+  bandaFina: '#8a6c48',
+  cabeza: '#6b4a2c', // cápsula cefálica, más oscura y dura
+  cabezaMarca: '#c9b48c', // la "Y" invertida pálida de la frente
+  pata: '#5b4128',
+  /* el rastro. Ojo: en la mata de verdad la caquita es verde-parda y casi no
+     se ve contra la hoja — por eso mismo la gente no la busca. En la lámina
+     va un punto más oscura, porque acá el trabajo es ENSEÑAR a verla; si se
+     mimetiza como en el campo, la lámina no enseña nada. */
+  frass: '#312811',
+  frassClaro: '#584a24',
+  mordidaFilo: '#5a3a1c', // EL FILO PARDO de la herida cicatrizada
+  mordidaHalo: '#b7a63f', // el amarilleo alrededor del corte
+  hueco: '#e8dcc0', // por el hueco se ve el papel (la hoja no está)
+};
+
+/* ------------------------------------------------------------------ */
+/* ENFERMEDAD — hongo. Cada uno con su color y su forma.               */
+/* ------------------------------------------------------------------ */
+export const ENFERMEDAD = {
+  /* ROYA · Hemileia vastatrix — `hemileia_vastatrix.jpg`.
+     El polvo naranja del envés. La rampa va del naranja quemado del centro
+     al amarillo pálido de la orilla: así se ve el montoncito de esporas. */
+  royaCentro: '#b4621a',
+  royaMedio: '#d98b2b',
+  royaBorde: '#e9a83c',
+  royaPalido: '#f0c862',
+  royaHalo: '#c9c057', // el amarilleo clorótico que rodea el polvo
+  royaHazMancha: '#c4bd52', // por el HAZ solo se ve una mancha amarilla
+
+  /* MANCHA DE HIERRO / ojo de gallo · Cercospora coffeicola —
+     `cercospora_coffeicola.jpg`. LA lección de "patrón": halo amarillo
+     brillante + borde definido + centro gris ceniza. */
+  cercoHalo: '#d3d84a',
+  cercoBorde: '#4a3b22',
+  cercoCentro: '#8d8676',
+  cercoCentroPalido: '#b5ad99',
+
+  /* ANILLOS CONCÉNTRICOS · Alternaria — `alternaria_solani.jpg`.
+     El "tiro al blanco": anillos dentro de la lesión parda. Y ojo al dato
+     fino: la lesión SE FRENA en la vena y se pone angular. */
+  anilloFondo: '#7d6944',
+  anilloLinea: '#3c2e1c',
+  anilloHalo: '#c6ce4d',
+};
+
+/* ------------------------------------------------------------------ */
+/* DEFICIENCIA — no hay bicho ni mancha: hay hambre.                   */
+/* Los amarillos de la clorosis: pálidos y LIMPIOS, sin borde pardo.   */
+/* ------------------------------------------------------------------ */
+export const DEFICIENCIA = {
+  /* HIERRO: la lámina amarillea y la NERVADURA SE QUEDA VERDE → queda una
+     redecilla verde sobre amarillo. Ataca las hojas NUEVAS. */
+  hierroLamina: '#e4de79',
+  hierroLaminaPalida: '#eee9a4',
+  hierroVena: '#4d7a38', // el verde que NO se fue (= HOJA_SANA.haz)
+  hierroVenaHalo: '#7ea24d', // el corredor verde a lado y lado de la vena
+
+  /* NITRÓGENO: amarillea PAREJO y entero, de la punta hacia adentro, y
+     empieza por las hojas VIEJAS (la mata se roba el nitrógeno de abajo
+     para darle a los cogollos). Sin borde, sin halo, sin nada. */
+  nitroViejo: '#cdc35c',
+  nitroMedio: '#b9c256',
+  nitroVerdeQueQueda: '#6d8f3f',
+};
+
+/* ------------------------------------------------------------------ */
+/* CÓDIGO DE COLOR DE LAS TRES COLUMNAS                                */
+/*                                                                     */
+/* No es color de UI ni semáforo: cada categoría se rotula con EL COLOR */
+/* DE SU PROPIA EVIDENCIA — el pardo del bicho, el naranja del polvo,   */
+/* el amarillo del hambre. El color ya enseña antes de leer la palabra. */
+/* ------------------------------------------------------------------ */
+export const CATEGORIA = {
+  plaga: { tinta: '#6b4a2a', chip: '#a98a63', nombre: 'PLAGA' },
+  enfermedad: { tinta: '#a35a18', chip: '#d98b2b', nombre: 'ENFERMEDAD' },
+  deficiencia: { tinta: '#8a7a20', chip: '#cdc35c', nombre: 'DEFICIENCIA' },
+  duda: { tinta: '#5d6a72', chip: '#9fb0b8', nombre: 'NO SE SABE' },
+};


### PR DESCRIPTION
## Qué aporta

Rescata `fable/diferencial-dano-18` (2026-07-15), **VIVA** en el triaje (#9 en orden de valor). NO toca 3D-core, pero es un sistema visual completo, 9 archivos: `LaminaDiferencial.jsx` (3 láminas comparativas), `LaminaDuda.jsx`, `LaminaLlave.jsx`, `formasBicho.js`, `formasHoja.js`, `motivosDano.jsx`, `paletaDano.js`, `README.md`, `index.js`.

Enseña a diferenciar visualmente plaga vs enfermedad vs deficiencia nutricional en una hoja — la pregunta más común en campo ("¿qué tiene esta mata?"). Parte del mismo lote de mundos/sistemas autónomos del 2026-07-15 (queue 14-22, item 18).

## Por qué estaba perdida

Sin PR, nunca integrada a `dev`.

## Estado

- `npm run build` → **OK** (~1min).
- Merge sin conflictos — 9/9 archivos nuevos.
- Disponible pero **no cableado a ninguna pantalla**.
- **NO mergeado.** Draft para revisión del operador.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>