### PR TITLE
rescate: fable/dante-oliver-juegos — Dante y Oliver, la dupla que huele y trae

### DIFF
--- a/src/mockups/MetalSlugCampo.jsx
+++ b/src/mockups/MetalSlugCampo.jsx
@@ -232,11 +232,12 @@ function simularDuo(w) {
 
   switch (d.fase) {
     case 'trote': {
-      /* Dante trota ATRÁS del jugador, sin afán; si queda muy lejos apura
-         apenas (15 años: dignidad antes que velocidad). */
+      /* Dante trota ATRÁS del jugador, sin afán; la banda elástica crece con
+         la distancia (15 años: dignidad primero, pero JAMÁS se queda — la
+         dupla nunca se parte en dos pantallas). */
       const atras = j.x - j.mira * 88;
-      const lejos = Math.abs(atras - dante.x) > 340;
-      perroHacia(dante, atras, lejos ? DANTE_MAX : DANTE_VEL);
+      const exceso = Math.max(0, Math.abs(atras - dante.x) - 140);
+      perroHacia(dante, atras, Math.min(DANTE_MAX + exceso / 90, MOVE_SPEED * 1.5));
       /* Oliver ORBITA juguetón entre Dante y el jugador: se adelanta, vuelve,
          nunca abandona al viejo (la seña de la dupla). Sin ENCIMÁRSELE al
          viejo: si la órbita cae sobre Dante, se corre un cuerpo. */
@@ -313,12 +314,18 @@ function simularDuo(w) {
       break;
     }
     case 'celebra': {
-      /* Fiesta junto al oso liberado: Dante aúlla, Oliver brinca y menea. */
-      perroHacia(dante, w.rehen.x - 64, DANTE_MAX);
-      perroHacia(oliver, w.rehen.x + 96, OLIVER_VEL);
-      if (d.faseT >= CELEBRA_S) {
+      /* Fiesta junto al oso liberado: Dante aúlla, Oliver brinca y menea.
+         La cuenta NO corre hasta que AMBOS lleguen (la fiesta es de la dupla
+         completa: si el viejo viene en camino, el oso espera el aullido). */
+      const llegoD = perroHacia(dante, w.rehen.x - 64, DANTE_MAX + 1.6);
+      const llegoO = perroHacia(oliver, w.rehen.x + 96, OLIVER_DASH);
+      dante.fiesta = llegoD;
+      if (!(llegoD && llegoO)) {
+        d.faseT = Math.min(d.faseT, CELEBRA_S - 2.8);
+      } else if (d.faseT >= CELEBRA_S) {
         d.fase = 'trote';
         d.faseT = 0;
+        dante.fiesta = false;
       }
       break;
     }
@@ -881,7 +888,7 @@ function Juego({ tier, reducedMotion, arsenal, onSalirIntro }) {
                     tier={tier}
                     reducedMotion={reducedMotion}
                     olfatea={w.duo.fase === 'rastreo' || w.duo.fase === 'busca'}
-                    aulla={w.duo.fase === 'celebra'}
+                    aulla={w.duo.fase === 'celebra' && !!w.duo.dante.fiesta}
                     senala={!!w.duo.pista}
                   />
                 </div>

--- a/src/mockups/MetalSlugCampo.jsx
+++ b/src/mockups/MetalSlugCampo.jsx
@@ -238,8 +238,12 @@ function simularDuo(w) {
       const lejos = Math.abs(atras - dante.x) > 340;
       perroHacia(dante, atras, lejos ? DANTE_MAX : DANTE_VEL);
       /* Oliver ORBITA juguetón entre Dante y el jugador: se adelanta, vuelve,
-         nunca abandona al viejo (la seña de la dupla). */
-      const orbita = j.x + Math.sin(w.reloj * 1.7) * 95 - j.mira * 18;
+         nunca abandona al viejo (la seña de la dupla). Sin ENCIMÁRSELE al
+         viejo: si la órbita cae sobre Dante, se corre un cuerpo. */
+      let orbita = j.x + Math.sin(w.reloj * 1.7) * 95 - j.mira * 18;
+      if (Math.abs(orbita - dante.x) < 44) {
+        orbita = dante.x + 44 * (orbita >= dante.x ? 1 : -1);
+      }
       perroHacia(oliver, orbita, OLIVER_VEL);
       /* ¿hay escondite cerca sin descubrir? La trufa lo agarra primero. */
       const i = w.escondites.findIndex(
@@ -509,6 +513,8 @@ export default function MetalSlugCampo({ onBack }) {
   return (
     <div className="msc-root" data-tier={tier} data-rm={reducedMotion ? '1' : '0'}>
       <StyleMSC />
+      {/* estilos de la dupla en la RAÍZ: la intro también los usa (retratos) */}
+      <StyleDuoPerros />
       <button type="button" className="msc-volver" onClick={onBack}>
         ← Volver
       </button>
@@ -761,7 +767,6 @@ function Juego({ tier, reducedMotion, arsenal, onSalirIntro }) {
     <div className="msc-juego">
       <div ref={vistaRef} className="msc-vista">
         <StyleJuice />
-        <StyleDuoPerros />
 
         {/* fondo por piso térmico (cielo + lomas + ambiente) */}
         {/* eslint-disable-next-line react/no-unknown-property */}

--- a/src/mockups/MetalSlugCampo.jsx
+++ b/src/mockups/MetalSlugCampo.jsx
@@ -11,7 +11,10 @@
  *     (`avanzarFisica`, `rectsOverlap`).
  *   - Lógica de disparo/par arma↔plaga/rescate → `metalSlugCampoEngine` (puro, testeado).
  *   - Data agronómica REAL → `../data/metalSlugCampoData` (enemigos, armas, rehenes, nivel).
- *   - Sprites rubber-hose canónicos → `../visual/creatures` (Abeja héroe, Oso rehén).
+ *   - Sprites rubber-hose canónicos → `../visual/creatures` (Abeja héroe, Oso rehén,
+ *     y LA DUPLA de la casa: Dante el beagle viejo + Oliver el dálmata — compañeros
+ *     automáticos vía `./metalslug/DuoPerros.jsx`: Dante HUELE escondites y señala
+ *     el arma correcta tras un tiro errado; Oliver corre, desentierra y TRAE).
  *   - Tier + reduced-motion → `../visual/mundo3d/deviceTier` (mismo criterio que el Odyssey).
  *
  * Determinismo: la simulación corre a PASO FIJO (1/60 s) con acumulador, así el
@@ -57,6 +60,15 @@ import StyleJuice, {
   BarraVida,
   IndicadorMunicion,
 } from './metalslug/JuiceMetalSlug.jsx';
+import {
+  SpriteDante,
+  SpriteOliver,
+  PistaDante,
+  Escondite,
+  DuoIntro,
+  DuoCelebra,
+  StyleDuoPerros,
+} from './metalslug/DuoPerros.jsx';
 
 /* ── Geometría del mundo (coords diseño; x→derecha, y→abajo). ───────────────── */
 const ALTO_2D = 520; // alto de diseño de la vista
@@ -87,6 +99,27 @@ const COLOR_POR_TIPO = Object.freeze({
 /* Arsenal CURADO del prototipo: intersección con el arsenal real del nivel (sin
    invento). Enseña los pares que de verdad se enfrentan en el nivel 1. */
 const ARSENAL_CURADO = ['bt', 'catarina', 'beauveria', 'crisopa'];
+
+/* ── LA DUPLA: Dante y Oliver (siempre juntos, complementarios). ──────────────
+   Dante (beagle, 15 años) es la NARIZ: huele los escondites enterrados y, si
+   el jugador yerra de arma, señala el control biológico correcto. Oliver
+   (dálmata joven) son las PATAS: desentierra y TRAE la merienda al jugador.
+   Compañeros automáticos — cero botones nuevos, cero daño recibido. */
+const DANTE_VEL = 2.5; // px/tick — trote sereno de perro de 15 años
+const DANTE_MAX = 3.8; // catch-up suave (nunca se queda del todo atrás)
+const OLIVER_VEL = 5.2; // px/tick — trote eléctrico de perro joven
+const OLIVER_DASH = 8.4; // px/tick — el disparado por la merienda
+const DANTE_S = 56; // lado del sprite (bajito y orejón)
+const OLIVER_S = 70; // lado del sprite (alto y esbelto)
+const PIES = 0.84; // fracción del sprite donde apoyan las patas (viewBox canónico)
+const PUNTOS_ESCONDITE = 75; // premio si la energía ya está llena
+const OLFATEO_S = 1.6; // lo que Dante tarda confirmando el rastro
+const CAVA_S = 0.55; // lo que Oliver tarda desenterrando
+const CELEBRA_S = 4.2; // fiesta de la dupla al liberar al oso
+const PISTA_S = 4.5; // vida de la burbuja-pista de Dante
+
+/* Escondites enterrados del nivel (deterministas, lejos de matas y del rehén). */
+const ESCONDITES_NIVEL = [{ x: 800 }, { x: 1650 }, { x: 2260 }];
 
 /* Instancias de plaga sembradas por el nivel (grounding: todas son de NIVEL.enemigos). */
 const SIEMBRA_PLAGAS = [
@@ -135,6 +168,16 @@ function crearMundo() {
     enemigos,
     proyectiles: [],
     rehen: { x: 2500, y: SUELO_Y - 88, w: 80, h: 88, liberado: false },
+    escondites: ESCONDITES_NIVEL.map((e, i) => ({ id: `esc${i}`, x: e.x, estado: 'oculto' })),
+    duo: {
+      dante: { x: 46, mira: 1, anda: false },
+      oliver: { x: 86, mira: 1, anda: false, carga: false },
+      fase: 'trote', // 'trote'|'rastreo'|'busca'|'entrega'|'celebra'
+      faseT: 0,
+      escIdx: -1,
+      marcaT: 0, // sub-reloj (olfateo confirmando / cavada)
+      pista: null, // { armaId, hasta } — la seña de Dante tras un tiro errado
+    },
     cam: 0,
     puntaje: 0,
     armaIdx: 0,
@@ -155,6 +198,130 @@ function sembrarEfecto(w, tipo, x, y) {
 const FX_VIDA_S = 0.6; // duración visible del estallido (s)
 
 /* ── SIMULACIÓN (scope de módulo: sin estado React, muta el mundo `w`). ──────── */
+
+/* Acerca a un perro hacia `objetivo` a `vel` px/tick. Devuelve true al llegar.
+   Marca `anda` (gate del galope CSS) y `mira` (flip del sprite). */
+function perroHacia(p, objetivo, vel) {
+  const dx = objetivo - p.x;
+  if (Math.abs(dx) <= 3) {
+    p.anda = false;
+    return true;
+  }
+  p.x = Math.max(16, Math.min(MUNDO_W - 30, p.x + Math.sign(dx) * Math.min(vel, Math.abs(dx))));
+  p.mira = dx > 0 ? 1 : -1;
+  p.anda = true;
+  return false;
+}
+
+/**
+ * Un tick de la DUPLA (paso fijo, determinista — cero Math.random).
+ * Máquina de fases: trote (siguen al jugador) → rastreo (Dante huele el
+ * escondite) → busca (Oliver dash al hallazgo) → entrega (Oliver trae la
+ * merienda) → trote. 'celebra' la dispara el rescate del oso.
+ * @param {Object} w mundo mutable.
+ */
+function simularDuo(w) {
+  const d = w.duo;
+  const j = w.jugador;
+  const dante = d.dante;
+  const oliver = d.oliver;
+  d.faseT += STEP;
+
+  /* la pista de Dante caduca sola */
+  if (d.pista && w.reloj > d.pista.hasta) d.pista = null;
+
+  switch (d.fase) {
+    case 'trote': {
+      /* Dante trota ATRÁS del jugador, sin afán; si queda muy lejos apura
+         apenas (15 años: dignidad antes que velocidad). */
+      const atras = j.x - j.mira * 88;
+      const lejos = Math.abs(atras - dante.x) > 340;
+      perroHacia(dante, atras, lejos ? DANTE_MAX : DANTE_VEL);
+      /* Oliver ORBITA juguetón entre Dante y el jugador: se adelanta, vuelve,
+         nunca abandona al viejo (la seña de la dupla). */
+      const orbita = j.x + Math.sin(w.reloj * 1.7) * 95 - j.mira * 18;
+      perroHacia(oliver, orbita, OLIVER_VEL);
+      /* ¿hay escondite cerca sin descubrir? La trufa lo agarra primero. */
+      const i = w.escondites.findIndex(
+        (e) => e.estado === 'oculto' && Math.abs(j.x - e.x) < 230,
+      );
+      if (i >= 0) {
+        w.escondites[i].estado = 'olido';
+        d.fase = 'rastreo';
+        d.escIdx = i;
+        d.faseT = 0;
+        d.marcaT = 0;
+      }
+      break;
+    }
+    case 'rastreo': {
+      /* Dante va al montículo y CONFIRMA con la trufa (olfatea, cabeza al
+         suelo). Oliver espera a su lado ladeando la cabeza (no entiende
+         de olores, entiende de correr). */
+      const esc = w.escondites[d.escIdx];
+      const llego = perroHacia(dante, esc.x - 26, DANTE_VEL * 1.2);
+      perroHacia(oliver, esc.x - 78, OLIVER_VEL);
+      if (llego) {
+        d.marcaT += STEP;
+        if (d.marcaT >= OLFATEO_S) {
+          esc.estado = 'revelado';
+          d.fase = 'busca';
+          d.faseT = 0;
+          d.marcaT = 0;
+        }
+      }
+      break;
+    }
+    case 'busca': {
+      /* Oliver sale DISPARADO al hallazgo y desentierra. Dante se queda
+         plantado junto al montículo (trabajo hecho, orgullo de sabueso). */
+      const esc = w.escondites[d.escIdx];
+      const llego = perroHacia(oliver, esc.x + 6, OLIVER_DASH);
+      if (llego) {
+        d.marcaT += STEP;
+        if (d.marcaT >= CAVA_S) {
+          esc.estado = 'recogido';
+          oliver.carga = true;
+          d.fase = 'entrega';
+          d.faseT = 0;
+          d.marcaT = 0;
+          sembrarEfecto(w, 'errado', esc.x, SUELO_Y - 14); // polvareda de cavada
+        }
+      }
+      break;
+    }
+    case 'entrega': {
+      /* Oliver TRAE el atadito hasta el jugador; Dante retoma su puesto. */
+      const llego = perroHacia(oliver, j.x + j.mira * 8, OLIVER_DASH);
+      perroHacia(dante, j.x - j.mira * 88, DANTE_MAX);
+      if (llego) {
+        oliver.carga = false;
+        w.escondites[d.escIdx].estado = 'entregado';
+        const premio = j.energia < ENERGIA_INICIAL ? 'energia' : 'semillas';
+        if (premio === 'energia') j.energia += 1;
+        else w.puntaje += PUNTOS_ESCONDITE;
+        w._eventoEntrega = premio;
+        sembrarEfecto(w, 'rescate', j.x + j.w / 2, j.y + 10);
+        d.fase = 'trote';
+        d.escIdx = -1;
+        d.faseT = 0;
+      }
+      break;
+    }
+    case 'celebra': {
+      /* Fiesta junto al oso liberado: Dante aúlla, Oliver brinca y menea. */
+      perroHacia(dante, w.rehen.x - 64, DANTE_MAX);
+      perroHacia(oliver, w.rehen.x + 96, OLIVER_VEL);
+      if (d.faseT >= CELEBRA_S) {
+        d.fase = 'trote';
+        d.faseT = 0;
+      }
+      break;
+    }
+    default:
+      d.fase = 'trote';
+  }
+}
 
 /**
  * Un tick de simulación de PASO FIJO (STEP s). Muta `w` en sitio y marca eventos
@@ -217,6 +384,11 @@ function simularTick(w, ahora, teclas, reducedMotion) {
         w._eventoErrado = impacto.enemigoId;
         w._shake = Math.max(w._shake || 0, reducedMotion ? 0 : 3);
         sembrarEfecto(w, 'errado', ix, iy);
+        /* Dante SEÑALA el aliado correcto (pedagogía del par arma↔plaga:
+           la trufa del viejo sabe qué controla a qué). */
+        const en = getEnemigo(impacto.enemigoId);
+        const armaOk = en?.controladores?.find((a) => ARSENAL_CURADO.includes(a));
+        if (armaOk) w.duo.pista = { armaId: armaOk, hasta: w.reloj + PISTA_S };
       }
       // proyectil consumido: no se reencola
     } else {
@@ -246,7 +418,13 @@ function simularTick(w, ahora, teclas, reducedMotion) {
     w._eventoRehen = true;
     w._shake = Math.max(w._shake || 0, reducedMotion ? 0 : 6);
     sembrarEfecto(w, 'rescate', w.rehen.x + w.rehen.w / 2, w.rehen.y + w.rehen.h / 2);
+    /* la dupla se une a la fiesta: Dante aúlla, Oliver cola-helicóptero */
+    w.duo.fase = 'celebra';
+    w.duo.faseT = 0;
   }
+
+  /* la dupla (Dante y Oliver): siempre juntos, complementarios */
+  simularDuo(w);
 
   /* envejecer estallidos visuales (solo arte) */
   if (w.efectos.length) {
@@ -283,8 +461,21 @@ function despacharEventos(w, reducedMotion, d) {
   }
   if (w._eventoErrado) {
     const e = getEnemigo(w._eventoErrado);
-    d.setToast(`Ese control no le sirve a ${e?.nombre_comun || 'esa plaga'}. Pruebe con su aliado correcto.`);
+    d.setToast({
+      texto: `Ese control no le sirve a ${e?.nombre_comun || 'esa plaga'}. Pruebe con su aliado correcto.`,
+      tono: 'reganio',
+    });
     w._eventoErrado = null;
+  }
+  if (w._eventoEntrega) {
+    d.setToast({
+      texto:
+        w._eventoEntrega === 'energia'
+          ? '¡Dante lo olió y Oliver se lo trajo! Merienda campesina: +1 de energía.'
+          : `¡Dante lo olió y Oliver se lo trajo! Semillas criollas: +${PUNTOS_ESCONDITE} puntos.`,
+      tono: 'duo',
+    });
+    w._eventoEntrega = null;
   }
   if (w._eventoGolpe) {
     d.setFlashDano((n) => n + 1);
@@ -323,7 +514,13 @@ export default function MetalSlugCampo({ onBack }) {
       </button>
 
       {pantalla === 'intro' ? (
-        <Intro nivel={NIVEL} arsenal={arsenal} onJugar={() => setPantalla('juego')} />
+        <Intro
+          nivel={NIVEL}
+          arsenal={arsenal}
+          tier={tier}
+          reducedMotion={reducedMotion}
+          onJugar={() => setPantalla('juego')}
+        />
       ) : (
         <Juego
           tier={tier}
@@ -337,7 +534,7 @@ export default function MetalSlugCampo({ onBack }) {
 }
 
 /* ── Pantalla de inicio: contexto del nivel + arsenal. ──────────────────────── */
-function Intro({ nivel, arsenal, onJugar }) {
+function Intro({ nivel, arsenal, tier, reducedMotion, onJugar }) {
   return (
     <div className="msc-intro">
       <div className="msc-intro-card">
@@ -357,6 +554,9 @@ function Intro({ nivel, arsenal, onJugar }) {
             })}
           </ul>
         </div>
+        {/* la dupla de la casa: presentados con nombre propio */}
+        {/* @ts-ignore IntrinsicAttributes & object - memo-wrapped component */}
+        <DuoIntro tier={tier} reducedMotion={reducedMotion} />
         <p className="msc-ayuda">
           Muévase con <kbd>←</kbd> <kbd>→</kbd>, salte con <kbd>espacio</kbd>, dispare con <kbd>J</kbd>{' '}
           y cambie de control biológico con <kbd>K</kbd>. En el celular, use los botones de abajo.
@@ -561,6 +761,7 @@ function Juego({ tier, reducedMotion, arsenal, onSalirIntro }) {
     <div className="msc-juego">
       <div ref={vistaRef} className="msc-vista">
         <StyleJuice />
+        <StyleDuoPerros />
 
         {/* fondo por piso térmico (cielo + lomas + ambiente) */}
         {/* eslint-disable-next-line react/no-unknown-property */}
@@ -643,6 +844,81 @@ function Juego({ tier, reducedMotion, arsenal, onSalirIntro }) {
               ),
             )}
 
+            {/* escondites enterrados (los encuentra la trufa de Dante) */}
+            {w.escondites.map((e) => (
+              <div
+                key={e.id}
+                className="msc-escondite"
+                data-estado={e.estado}
+                style={{ left: e.x - 22, top: SUELO_Y - 18, width: 44, height: 22 }}
+              >
+                {/* @ts-ignore IntrinsicAttributes & object - memo-wrapped component */}
+                <Escondite estado={e.estado} reducedMotion={reducedMotion} />
+              </div>
+            ))}
+
+            {/* LA DUPLA: Dante (nariz) y Oliver (patas) — siempre juntos */}
+            <div
+              className="msc-perro msc-perro--dante"
+              data-mira={w.duo.dante.mira}
+              data-anda={w.duo.dante.anda ? '1' : '0'}
+              style={{
+                left: w.duo.dante.x - DANTE_S / 2,
+                top: SUELO_Y - DANTE_S * PIES,
+                width: DANTE_S,
+                height: DANTE_S,
+              }}
+            >
+              <div className="msc-perro-flip">
+                <div className="msc-perro-bob">
+                  {/* @ts-ignore IntrinsicAttributes & object - memo-wrapped component */}
+                  <SpriteDante
+                    tier={tier}
+                    reducedMotion={reducedMotion}
+                    olfatea={w.duo.fase === 'rastreo' || w.duo.fase === 'busca'}
+                    aulla={w.duo.fase === 'celebra'}
+                    senala={!!w.duo.pista}
+                  />
+                </div>
+              </div>
+              {w.duo.pista && (() => {
+                const armaPista = getArma(w.duo.pista.armaId);
+                return armaPista ? (
+                  /* @ts-ignore IntrinsicAttributes & object - memo-wrapped component */
+                  <PistaDante
+                    nombre={armaPista.nombre}
+                    color={COLOR_POR_TIPO[armaPista.tipo] || '#2bb3a3'}
+                  />
+                ) : null;
+              })()}
+            </div>
+            <div
+              className="msc-perro msc-perro--oliver"
+              data-mira={w.duo.oliver.mira}
+              data-anda={w.duo.oliver.anda ? '1' : '0'}
+              data-dash={w.duo.fase === 'busca' || w.duo.fase === 'entrega' ? '1' : '0'}
+              style={{
+                left: w.duo.oliver.x - OLIVER_S / 2,
+                top: SUELO_Y - OLIVER_S * PIES,
+                width: OLIVER_S,
+                height: OLIVER_S,
+              }}
+            >
+              <div className="msc-perro-flip">
+                <div className="msc-perro-bob">
+                  {/* @ts-ignore IntrinsicAttributes & object - memo-wrapped component */}
+                  <SpriteOliver
+                    tier={tier}
+                    reducedMotion={reducedMotion}
+                    menea={w.duo.fase === 'celebra' || w.duo.oliver.carga}
+                    ladea={w.duo.fase === 'rastreo'}
+                    celebra={w.duo.fase === 'celebra'}
+                    carga={w.duo.oliver.carga}
+                  />
+                </div>
+              </div>
+            </div>
+
             {/* rehén (oso andino) */}
             <div
               className={`msc-rehen ${w.rehen.liberado ? 'msc-rehen--libre' : 'msc-rehen--preso'}`}
@@ -700,13 +976,18 @@ function Juego({ tier, reducedMotion, arsenal, onSalirIntro }) {
         {avisoRehen && <AvisoConservacion rehen={avisoRehen} onCerrar={() => setAvisoRehen(null)} />}
 
         {/* toast de arma equivocada */}
-        {toast && <div className="msc-toast" role="status">{toast}</div>}
+        {toast && (
+          <div className={`msc-toast msc-toast--${toast.tono}`} role="status">
+            {toast.texto}
+          </div>
+        )}
 
         {/* fin de nivel */}
         {fin && (
           <FinNivel
             fin={fin}
             puntaje={w.puntaje}
+            reducedMotion={reducedMotion}
             onReintentar={reiniciar}
             onSalir={onSalirIntro}
           />
@@ -841,11 +1122,16 @@ function AvisoConservacion({ rehen, onCerrar }) {
 }
 
 /* ── Fin de nivel. ──────────────────────────────────────────────────────────── */
-function FinNivel({ fin, puntaje, onReintentar, onSalir }) {
+function FinNivel({ fin, puntaje, reducedMotion, onReintentar, onSalir }) {
   const gano = fin.estado === 'gano';
   return (
     <div className="msc-overlay msc-overlay--fin" role="dialog" aria-label="Fin del nivel">
       <div className={`msc-fin ${gano ? 'msc-fin--gano' : 'msc-fin--perdio'}`}>
+        {/* la dupla celebra la victoria: Dante aúlla, Oliver cola-helicóptero */}
+        {gano && (
+          /* @ts-ignore IntrinsicAttributes & object - memo-wrapped component */
+          <DuoCelebra reducedMotion={reducedMotion} />
+        )}
         <h2>{gano ? '¡Finca cuidada!' : 'Se acabó la energía'}</h2>
         <p>{fin.razon}</p>
         <p className="msc-fin-puntaje">{puntaje} puntos</p>

--- a/src/mockups/metalslug/DuoPerros.jsx
+++ b/src/mockups/metalslug/DuoPerros.jsx
@@ -1,0 +1,258 @@
+/**
+ * DuoPerros — Dante y Oliver en el Metal Slug del campo (SOLO ARTE).
+ *
+ * La dupla de la casa entra al juego SIEMPRE JUNTA y complementaria:
+ *   - Dante (beagle, 15 años): lento y sabio. Huele lo enterrado (olfatea),
+ *     y cuando el jugador yerra de control biológico, SEÑALA el aliado
+ *     correcto (la nariz sabe). Celebra AULLANDO al cielo.
+ *   - Oliver (dálmata de Julieta): joven y eléctrico. Corre, desentierra y
+ *     TRAE la merienda hasta el jugador (dash con estiramiento), celebra con
+ *     brinco y cola-helicóptero (menea).
+ *
+ * REÚSA los sprites canónicos `Beagle` y `Dalmata` de src/visual/creatures
+ * (mismas señas del valle: hocico escarchado de Dante, parche en el ojo de
+ * Oliver, plaquitas de latón) — cero redibujo. Aquí solo viven los WRAPPERS
+ * de juego (locomoción, dash, carga, burbuja de pista, escondites) y su CSS.
+ * La SIMULACIÓN de la dupla vive en MetalSlugCampo.jsx junto al resto del
+ * mundo (paso fijo, determinista). Todo se poda con reducedMotion/tier.
+ */
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- arte de juego es-CO. */
+import { memo } from 'react';
+import { Beagle, Dalmata } from '../../visual/creatures';
+
+const TINTA = '#2c1e12';
+
+/* ── Dante (beagle viejo y sabio). El flip de mira lo pone el host en
+      .msc-perro-flip; la pose la dicta la fase de la dupla. ────────────────── */
+export const SpriteDante = memo(function SpriteDante(
+  /** @type {{ tier: any, reducedMotion: boolean, olfatea?: boolean, aulla?: boolean, senala?: boolean }} */
+  { tier, reducedMotion, olfatea = false, aulla = false, senala = false },
+) {
+  return (
+    <Beagle
+      size="100%"
+      inline={false}
+      animated={!reducedMotion}
+      tier={tier}
+      vida={false}
+      olfatea={olfatea}
+      aulla={aulla}
+      pose={senala && !olfatea && !aulla ? 'señala' : 'anda'}
+      title="Dante"
+    />
+  );
+});
+
+/* ── Oliver (dálmata joven de Julieta). `carga` le pone el ATADITO en el
+      hocico (la merienda que trae); `celebra` es el brinco con cola-helicóptero. */
+export const SpriteOliver = memo(function SpriteOliver(
+  /** @type {{ tier: any, reducedMotion: boolean, menea?: boolean, ladea?: boolean, celebra?: boolean, carga?: boolean }} */
+  { tier, reducedMotion, menea = false, ladea = false, celebra = false, carga = false },
+) {
+  return (
+    <span className="msc-oliver-cuerpo">
+      <Dalmata
+        size="100%"
+        inline={false}
+        animated={!reducedMotion}
+        tier={tier}
+        vida={false}
+        menea={menea}
+        ladea={ladea}
+        pose={celebra ? 'celebra' : 'anda'}
+        title="Oliver"
+      />
+      {/* el ATADITO campesino (pañuelo anudado) que Oliver trae en el hocico */}
+      {carga && (
+        <svg className="msc-oliver-atadito" viewBox="0 0 20 16" aria-hidden="true">
+          <path d="M4,9 C4,4.5 16,4.5 16,9 C16,13.5 4,13.5 4,9 Z" fill="#e8b04a" stroke={TINTA} strokeWidth="1.2" />
+          <path d="M8,5.4 L10,2.2 L12,5.4" fill="none" stroke={TINTA} strokeWidth="1.2" strokeLinecap="round" />
+          <circle cx="10" cy="2.2" r="1.3" fill="#c9552e" stroke={TINTA} strokeWidth="0.8" />
+          {/* lunares del pañuelo */}
+          <circle cx="7.6" cy="9" r="0.9" fill="#c9552e" opacity="0.85" />
+          <circle cx="12.4" cy="9.6" r="0.9" fill="#c9552e" opacity="0.85" />
+          <circle cx="10" cy="11.4" r="0.7" fill="#c9552e" opacity="0.85" />
+        </svg>
+      )}
+    </span>
+  );
+});
+
+/* ── Burbuja de PISTA de Dante: "a esa plaga le sirve ESTE aliado" (el color
+      es el rol biológico del arma correcta — el mismo código de color del HUD). */
+export const PistaDante = memo(function PistaDante(
+  /** @type {{ nombre: string, color: string }} */ { nombre, color },
+) {
+  return (
+    <div className="msc-pista" role="status" style={{ '--pista-c': color }}>
+      {/* la huellita del sabueso (firmó la pista con la pata) */}
+      <svg viewBox="0 0 20 20" className="msc-pista-huella" aria-hidden="true">
+        <ellipse cx="10" cy="12.6" rx="4.6" ry="3.6" fill={color} />
+        <circle cx="4.6" cy="8.2" r="1.9" fill={color} />
+        <circle cx="8.2" cy="5.8" r="1.9" fill={color} />
+        <circle cx="11.8" cy="5.8" r="1.9" fill={color} />
+        <circle cx="15.4" cy="8.2" r="1.9" fill={color} />
+      </svg>
+      <span className="msc-pista-txt">
+        ¡Dante huele el remedio! <b>{nombre}</b>
+      </span>
+    </div>
+  );
+});
+
+/* ── Escondite enterrado: montículo → rastro de olor → destello → hueco. ────── */
+export const Escondite = memo(function Escondite(
+  /** @type {{ estado: 'oculto'|'olido'|'revelado'|'recogido'|'entregado', reducedMotion: boolean }} */
+  { estado, reducedMotion },
+) {
+  const excavado = estado === 'recogido' || estado === 'entregado';
+  return (
+    <svg viewBox="0 0 44 22" width="100%" height="100%" aria-hidden="true" className="msc-esc-svg">
+      {excavado ? (
+        /* el hueco honesto que quedó (Oliver ya se llevó la merienda) */
+        <g>
+          <ellipse cx="22" cy="16" rx="10" ry="4" fill="#4a341f" stroke={TINTA} strokeWidth="1" />
+          <ellipse cx="22" cy="15.2" rx="6.6" ry="2.4" fill="#2e1f11" />
+          <circle cx="9" cy="17" r="1.6" fill="#5c4326" />
+          <circle cx="35.5" cy="16.4" r="1.9" fill="#5c4326" />
+        </g>
+      ) : (
+        <g>
+          {/* montículo de tierra recién movida (apenas se nota si nadie olfatea) */}
+          <path d="M8,18 C12,10.5 32,10.5 36,18 Z" fill="#6b4d2a" stroke={TINTA} strokeWidth="1.1" />
+          <path d="M14,15.5 C17,12 27,12 30,15.5" fill="none" stroke="#8a6a3e" strokeWidth="1.4" strokeLinecap="round" />
+          {/* pastico encima (disimulado) */}
+          <path d="M12,17.6 l-1.4,-3 M22,16.4 l0,-3.2 M32,17.6 l1.4,-3" stroke="#5f9345" strokeWidth="1.3" strokeLinecap="round" />
+          {/* RASTRO DE OLOR: las volutas que solo la trufa de Dante encuentra */}
+          {(estado === 'olido' || estado === 'revelado') && (
+            <g className={reducedMotion ? undefined : 'msc-esc-olor'} fill="none">
+              <path className="msc-esc-voluta msc-esc-voluta--1" d="M14,12 q-2,-3 0,-6 q2,-3 0,-5" stroke="#e6d9a8" strokeWidth="1.5" strokeLinecap="round" />
+              <path className="msc-esc-voluta msc-esc-voluta--2" d="M22,11 q2,-3 0,-6 q-2,-3 0,-5" stroke="#e6d9a8" strokeWidth="1.5" strokeLinecap="round" />
+              <path className="msc-esc-voluta msc-esc-voluta--3" d="M30,12 q-2,-3 0,-6 q2,-3 0,-5" stroke="#e6d9a8" strokeWidth="1.5" strokeLinecap="round" />
+            </g>
+          )}
+          {/* REVELADO: asoma la puntica del atadito con su destello */}
+          {estado === 'revelado' && (
+            <g className={reducedMotion ? undefined : 'msc-esc-brillo'}>
+              <path d="M19,14 C19,11.2 25,11.2 25,14 Z" fill="#e8b04a" stroke={TINTA} strokeWidth="1" />
+              <path d="M16,9 l1.2,2 M28,9 l-1.2,2 M22,7.4 l0,2.2" stroke="#ffe9a8" strokeWidth="1.4" strokeLinecap="round" />
+            </g>
+          )}
+        </g>
+      )}
+    </svg>
+  );
+});
+
+/* ── Presentación de la dupla en la INTRO (la primera cara del juego). ──────── */
+export const DuoIntro = memo(function DuoIntro(
+  /** @type {{ tier: any, reducedMotion: boolean }} */ { tier, reducedMotion },
+) {
+  return (
+    <div className="msc-duo-intro">
+      <div className="msc-duo-retratos" aria-hidden="true">
+        <figure className="msc-duo-fig">
+          <Beagle size={58} animated={!reducedMotion} tier={tier} vida={false} title="Dante" />
+          <figcaption>Dante</figcaption>
+        </figure>
+        <figure className="msc-duo-fig msc-duo-fig--oliver">
+          <Dalmata size={68} animated={!reducedMotion} tier={tier} vida={false} menea title="Oliver" />
+          <figcaption>Oliver</figcaption>
+        </figure>
+      </div>
+      <p className="msc-duo-lema">
+        Lo acompañan <b>Dante</b> (quince años de nariz sabia: lo huele TODO) y{' '}
+        <b>Oliver</b> (patas jóvenes: lo alcanza TODO). Si Dante se pone a
+        olfatear, espere el regalo; si usted yerra de aliado, mírelo a él —
+        la trufa nunca se equivoca.
+      </p>
+    </div>
+  );
+});
+
+/* ── La dupla celebrando (pantalla de victoria): Dante aúlla, Oliver brinca. ── */
+export const DuoCelebra = memo(function DuoCelebra(
+  /** @type {{ reducedMotion: boolean }} */ { reducedMotion },
+) {
+  return (
+    <div className="msc-duo-fin" aria-hidden="true">
+      <Beagle size={56} animated={!reducedMotion} vida={false} aulla title="Dante celebra" />
+      <Dalmata size={66} animated={!reducedMotion} vida={false} menea pose="celebra" title="Oliver celebra" />
+    </div>
+  );
+});
+
+/* ── Hoja de estilos de la dupla (montar UNA vez, junto a StyleJuice). ──────── */
+export function StyleDuoPerros() {
+  return (
+    <style>{`
+/* wrappers de juego: posición la pone el host; aquí locomoción y capas.
+   Estructura: .msc-perro (pos) > .msc-perro-flip (mira) > .msc-perro-bob
+   (galope) > sprite. La burbuja de pista es hermana del flip: NUNCA se espeja. */
+.msc-perro{position:absolute;pointer-events:none;will-change:transform;}
+.msc-perro-flip,.msc-perro-bob{width:100%;height:100%;display:block;}
+.msc-perro[data-mira="-1"] .msc-perro-flip{transform:scaleX(-1);}
+.msc-perro .msc-perro-flip{filter:drop-shadow(0 3px 2px rgba(0,0,0,.16));}
+
+/* DANTE: ambladura de perro viejo — bob corto, digno, sin prisa. */
+@keyframes msc-dante-amble{0%,100%{transform:translateY(0) rotate(-.6deg)}50%{transform:translateY(-1.6px) rotate(.6deg)}}
+.msc-perro--dante[data-anda="1"] .msc-perro-bob{animation:msc-dante-amble .72s ease-in-out infinite;}
+
+/* OLIVER: trote elástico de perro joven — bob alto y rápido. */
+@keyframes msc-oliver-trote{0%,100%{transform:translateY(0)}50%{transform:translateY(-3.4px)}}
+.msc-perro--oliver[data-anda="1"] .msc-perro-bob{animation:msc-oliver-trote .34s ease-in-out infinite;}
+
+/* DASH de Oliver (busca/entrega): estiramiento squash&stretch + líneas de
+   velocidad detrás (la física del caricato: se LEE la carrera). */
+@keyframes msc-oliver-dash{0%,100%{transform:translateY(-1px) scale(1.14,.92) rotate(-2deg)}50%{transform:translateY(-4px) scale(1.06,.98) rotate(-1deg)}}
+.msc-perro--oliver[data-dash="1"] .msc-perro-bob{animation:msc-oliver-dash .22s ease-in-out infinite;}
+.msc-perro--oliver[data-dash="1"] .msc-perro-flip::before{
+  content:"";position:absolute;top:38%;right:92%;width:26px;height:14px;opacity:.75;
+  background:repeating-linear-gradient(180deg,rgba(255,255,255,.85) 0 2px,transparent 2px 6px);
+  border-radius:2px;animation:msc-oliver-estela .22s linear infinite;}
+@keyframes msc-oliver-estela{from{transform:translateX(0);opacity:.75}to{transform:translateX(-8px);opacity:.2}}
+
+/* el atadito en el hocico de Oliver (posición sobre el sprite cuadrado) */
+.msc-oliver-cuerpo{position:relative;display:block;width:100%;height:100%;}
+.msc-oliver-atadito{position:absolute;left:56%;top:26%;width:34%;height:auto;transform:rotate(8deg);}
+
+/* burbuja de pista de Dante (no se espeja: hermana del flip) */
+.msc-pista{position:absolute;bottom:104%;left:50%;transform:translateX(-50%);display:flex;align-items:center;gap:6px;background:#fffbee;border:2.5px solid ${TINTA};border-radius:13px;padding:5px 10px;white-space:nowrap;box-shadow:0 4px 0 rgba(0,0,0,.25);animation:msc-pista-pop .22s cubic-bezier(.34,1.56,.64,1);}
+.msc-pista::after{content:"";position:absolute;top:100%;left:50%;transform:translateX(-50%);border:7px solid transparent;border-top-color:${TINTA};}
+.msc-pista-huella{width:17px;height:17px;flex:none;}
+.msc-pista-txt{font-size:12.5px;font-weight:700;color:#3a2a1a;}
+.msc-pista-txt b{color:var(--pista-c,#2bb3a3);font-weight:900;}
+@keyframes msc-pista-pop{from{transform:translateX(-50%) scale(.6);opacity:0}to{transform:translateX(-50%) scale(1);opacity:1}}
+
+/* escondites: volutas de olor que suben + brillo del hallazgo */
+.msc-escondite{position:absolute;pointer-events:none;}
+.msc-esc-svg{display:block;overflow:visible;}
+@keyframes msc-esc-olor-sube{0%{transform:translateY(2px);opacity:0}30%{opacity:.9}100%{transform:translateY(-5px);opacity:0}}
+.msc-esc-voluta{transform-box:fill-box;animation:msc-esc-olor-sube 1.5s ease-out infinite;}
+.msc-esc-voluta--2{animation-delay:.45s;}
+.msc-esc-voluta--3{animation-delay:.9s;}
+@keyframes msc-esc-brilla{0%,100%{opacity:.75}50%{opacity:1}}
+.msc-esc-brillo{animation:msc-esc-brilla .8s ease-in-out infinite;}
+
+/* intro y fin: la dupla presentada con nombre propio */
+.msc-duo-intro{background:#eef5e2;border:2px dashed #8fae6a;border-radius:13px;padding:8px 14px 10px;margin-bottom:12px;}
+.msc-duo-retratos{display:flex;align-items:flex-end;justify-content:center;gap:4px;}
+.msc-duo-fig{margin:0;display:flex;flex-direction:column;align-items:center;}
+.msc-duo-fig figcaption{font-weight:900;font-size:12.5px;color:#3a5a28;margin-top:-4px;}
+.msc-duo-lema{margin:6px 0 0;font-size:13.5px;line-height:1.38;color:#43552f;text-align:center;}
+.msc-duo-fin{display:flex;align-items:flex-end;justify-content:center;gap:2px;margin-bottom:2px;}
+
+/* toast de la dupla (verde regalo, no el rojo del regaño) */
+.msc-toast--duo{background:rgba(61,139,58,.95);}
+
+/* reduced-motion: locomoción esencial sí, decoración no */
+.msc-root[data-rm="1"] .msc-perro-bob{animation:none;}
+.msc-root[data-rm="1"] .msc-perro--oliver [class]{animation:none;}
+.msc-root[data-rm="1"] .msc-esc-voluta,.msc-root[data-rm="1"] .msc-esc-brillo{animation:none;}
+.msc-root[data-rm="1"] .msc-pista{animation:none;}
+@media (prefers-reduced-motion: reduce){
+  .msc-perro-bob,.msc-esc-voluta,.msc-esc-brillo,.msc-pista{animation:none;}
+}
+`}</style>
+  );
+}


### PR DESCRIPTION
## Qué aporta

Rescata `fable/dante-oliver-juegos` (2026-07-19), **VIVA** en el triaje (#11 en orden de valor). Lógica de juego del dúo de perros guardianes (Dante el beagle, Oliver el dálmata) para `MetalSlugCampo.jsx`: `src/mockups/metalslug/DuoPerros.jsx` (258 líneas nuevas) + integración en `MetalSlugCampo.jsx` (banda elástica para que Dante nunca se quede atrás, estilos de la dupla, Oliver sin encimarse a Dante — 3 commits de iteración).

`MetalSlugCampo.jsx` fue tocado por `dev` 1.5h ANTES del primer commit de esta rama (corre sobre esa base) y no lo ha vuelto a tocar desde entonces — merge sin conflictos.

Ya existe `#2596` (draft) para esta misma rama, pero contra `integra/todo-3d-a-prod` (base vieja). Este PR es el equivalente contra `dev`.

## Por qué estaba perdida

Aunque tiene PR abierto (#2596), nunca fue contra `dev` ni se mergeó por ningún camino.

## Estado

- `npm run build` → **OK** (~59s).
- Merge sin conflictos.
- Estado de cableado: `DuoPerros.jsx` se integra en `MetalSlugCampo.jsx`, que ya es parte del juego existente — falta verificar en runtime si el juego arranca con la dupla sin regresiones (no se corrió el gate visual).
- **NO mergeado.** Draft para revisión del operador.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>