### PR TITLE
feat(efectos): librería de etiquetas 3D anti-colisión + dedup rubber-hose

### DIFF
--- a/src/mockups/EfectosFuncionalesDemo.jsx
+++ b/src/mockups/EfectosFuncionalesDemo.jsx
@@ -20,9 +20,13 @@
  * amanecer; el de la sequía, la luz blanca del mediodía), el device-tiering real
  * (decidirTier/perfilDeTier), el PRNG determinista de particulasData (crearRng —
  * cero Math.random en render), el kit ParticulasAmbientales (polen ambiental y
- * el vaho del microclima) y las piezas InvernaderoTunel/AlmacenBodega de
+ * el vaho del microclima), las piezas InvernaderoTunel/AlmacenBodega de
  * piezasInfra (importadas tal cual; el reservorio es propio porque su nivel de
- * agua debe ANIMARSE, y el disco del TanqueAgua del catálogo es fijo).
+ * agua debe ANIMARSE, y el disco del TanqueAgua del catálogo es fijo) y el
+ * VOCABULARIO rubber-hose ya canónico de momentosData.js/kit/ruido.js
+ * (clamp01/easeOutBack/arcoDeVuelo, smoothstep): este demo antes reimplementaba
+ * su propio `reboteSuave`/`suave` a mano — la MISMA curva que ya vive en
+ * MomentosFinca.jsx (el vuelo del fruto al canasto). Ahora hay una sola.
  *
  * FRUGALIDAD bajo frameloop="demand": nada corre por frame en reposo. Cada
  * transición se auto-sostiene con invalidate() dentro de su useFrame y SUELTA el
@@ -43,6 +47,8 @@ import {
   InvernaderoTunel,
   AlmacenBodega,
 } from '../visual/mundo3d/infraestructura/piezasInfra.jsx';
+import { clamp01, easeOutBack, arcoDeVuelo } from '../visual/mundo3d/momentosData.js';
+import { smoothstep } from '../visual/mundo3d/kit/ruido.js';
 
 /* ── Dirección de arte local (derivada de la madre, nunca inventada) ───────── */
 
@@ -56,18 +62,6 @@ const PASTO_SECO = '#b8a35f'; // el mismo reseco de los efectos de vida del cat�
 const CIELO_BASE = new THREE.Color(ATMOSFERA.fondo);
 const CIELO_LLUVIA = new THREE.Color(mezclar(ATMOSFERA.fondo, CIELOS_HORA.amanecer.relleno, 0.55));
 const CIELO_SEQUIA = new THREE.Color(mezclar(ATMOSFERA.fondo, CIELOS_HORA.mediodia.luz, 0.6));
-
-/* ── Helpers puros (rubber-hose) ───────────────────────────────────────────── */
-
-const clamp01 = (v) => Math.min(1, Math.max(0, v));
-const suave = (t) => t * t * (3 - 2 * t); // smoothstep: arranca y llega sin golpe
-
-/* ease-out-back: llega, se pasa tantico y asienta (overshoot rubber-hose). */
-function reboteSuave(t) {
-  const c1 = 1.70158;
-  const c3 = c1 + 1;
-  return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
-}
 
 /* ── Constantes de cada diorama ────────────────────────────────────────────── */
 
@@ -227,7 +221,7 @@ function EscenaInvernadero({ prendido, tier, reducedMotion }) {
       const paso = Math.min(Math.abs(dif), Math.min(delta, 0.05) / DUR_CRECIDA);
       crecida.current += Math.sign(dif) * paso;
     }
-    const e = reboteSuave(clamp01(crecida.current));
+    const e = easeOutBack(clamp01(crecida.current));
     g.scale.set(0.84 + e * 0.16, 0.72 + e * 0.58, 0.84 + e * 0.16);
     if (!reducedMotion && Math.abs(objetivo - crecida.current) > 1e-4) invalidate();
   });
@@ -350,15 +344,16 @@ function EscenaAlmacen({ guardadas, volando, alAterrizar, reducedMotion }) {
         const g = sacosVuelo.current[i];
         if (!g) continue;
         const ti = clamp01((t - i * ESCALON_SACO) / DUR_SACO);
-        const e = suave(ti);
+        const e = smoothstep(0, 1, ti);
+        const arco = arcoDeVuelo(e);
         const o = ORIGENES_SACO[i];
         const d = destinos[i];
         g.position.set(
           o[0] + (d[0] - o[0]) * e,
-          o[1] + (d[1] - o[1]) * e + Math.sin(Math.PI * e) * ALTURA_ARCO,
+          o[1] + (d[1] - o[1]) * e + arco * ALTURA_ARCO,
           o[2] + (d[2] - o[2]) * e,
         );
-        const sy = 1 + 0.35 * Math.sin(Math.PI * e);
+        const sy = 1 + 0.35 * arco;
         const sxz = 1 / Math.sqrt(sy);
         g.scale.set(sxz, sy, sxz);
       }

--- a/src/mockups/MundoSanidad3D.jsx
+++ b/src/mockups/MundoSanidad3D.jsx
@@ -53,6 +53,7 @@ import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
 import { ParticulasAmbientales } from '../visual/mundo3d/ParticulasAmbientales.jsx';
 import { crearRng } from '../visual/mundo3d/particulasData.js';
 import { Bicho } from '../visual/mundo3d/escenas/FaunaEscena.jsx';
+import EtiquetasMundo from '../visual/mundo3d/kit/EtiquetasMundo.jsx';
 import { MariquitaRubber } from '../visual/creatures/FaunaRubberhose.jsx';
 import { Crisopa } from '../visual/creatures/Crisopa.jsx';
 import { Trichogramma } from '../visual/creatures/Trichogramma.jsx';
@@ -219,19 +220,13 @@ function NubesDia() {
   );
 }
 
-/* Etiqueta didáctica sobre la escena (solo en modo «ver las estaciones»). */
-function Etiqueta({ pos, texto, paso }) {
-  return (
-    <group position={pos}>
-      <Html center distanceFactor={9} zIndexRange={[30, 0]}>
-        <div className="clivo-chip" aria-hidden="true">
-          {paso != null && <b>{paso}</b>}
-          {texto}
-        </div>
-      </Html>
-    </group>
-  );
-}
+/* Las etiquetas didácticas (solo en modo «ver las estaciones») ya NO se pisan
+   entre sí: cada estación pasa TODAS sus etiquetas juntas a <EtiquetasMundo>
+   (kit/EtiquetasMundo.jsx), que las resuelve contra la pantalla cada cuadro
+   — la que no cabe entera cede a un punto mínimo, y la que ni así cabe cede
+   del todo (mismo `.clivo-chip` de siempre; solo cambia CÓMO se decide quién
+   se ve, ver reglas `[data-modo]` arriba en el CSS). Antes cada `Etiqueta`
+   montaba su propio <Html> sin saber de las demás — el BUG reportado. */
 
 /* ══════════════════════ LA HOJA-LÁMINA Y SUS SÍNTOMAS ══════════════════════ */
 
@@ -400,10 +395,13 @@ function TableroComparacion({ etiquetas }) {
       </mesh>
 
       {etiquetas && (
-        <>
-          <Etiqueta pos={[-0.68, 2.72, 0.2]} texto="Hoja sana" />
-          <Etiqueta pos={[0.72, 2.72, 0.2]} texto="Hoja enferma" />
-        </>
+        <EtiquetasMundo
+          className="clivo-chip"
+          items={[
+            { id: 'tablero-sana', pos: [-0.68, 2.72, 0.2], titulo: 'Hoja sana' },
+            { id: 'tablero-enferma', pos: [0.72, 2.72, 0.2], titulo: 'Hoja enferma' },
+          ]}
+        />
       )}
     </group>
   );
@@ -569,12 +567,15 @@ function EstanteLaminas({ etiquetas }) {
       </group>
 
       {etiquetas && (
-        <>
-          <Etiqueta pos={[-1.5, 2.28, 0.2]} texto="Broca" />
-          <Etiqueta pos={[-0.5, 2.32, 0.2]} texto="Minador" />
-          <Etiqueta pos={[0.5, 2.32, 0.2]} texto="Áfidos / cochinilla" />
-          <Etiqueta pos={[1.5, 2.32, 0.2]} texto="Gota (tizón)" />
-        </>
+        <EtiquetasMundo
+          className="clivo-chip"
+          items={[
+            { id: 'lamina-broca', pos: [-1.5, 2.28, 0.2], titulo: 'Broca' },
+            { id: 'lamina-minador', pos: [-0.5, 2.32, 0.2], titulo: 'Minador' },
+            { id: 'lamina-afidos', pos: [0.5, 2.32, 0.2], titulo: 'Áfidos / cochinilla' },
+            { id: 'lamina-gota', pos: [1.5, 2.32, 0.2], titulo: 'Gota (tizón)' },
+          ]}
+        />
       )}
     </group>
   );
@@ -648,10 +649,13 @@ function CartelDistincion({ etiquetas }) {
       </group>
 
       {etiquetas && (
-        <>
-          <Etiqueta pos={[-0.5, 2.16, 0.1]} texto="Se mueve" />
-          <Etiqueta pos={[0.5, 2.16, 0.1]} texto="Se expande" />
-        </>
+        <EtiquetasMundo
+          className="clivo-chip"
+          items={[
+            { id: 'cartel-mueve', pos: [-0.5, 2.16, 0.1], titulo: 'Se mueve' },
+            { id: 'cartel-expande', pos: [0.5, 2.16, 0.1], titulo: 'Se expande' },
+          ]}
+        />
       )}
     </group>
   );
@@ -823,11 +827,14 @@ function JardinAliados({ reducedMotion, etiquetas }) {
       />
 
       {etiquetas && (
-        <>
-          <Etiqueta pos={[7.0, Y_SUELO + 2.4, 3.2]} texto="Los aliados" />
-          <Etiqueta pos={[8.6, Y_SUELO + 1.85, 2.0]} texto="Trampa (para medir)" />
-          <Etiqueta pos={[6.4, Y_SUELO + 1.1, 4.6]} texto="Caldo y poda" />
-        </>
+        <EtiquetasMundo
+          className="clivo-chip"
+          items={[
+            { id: 'jardin-aliados', pos: [7.0, Y_SUELO + 2.4, 3.2], titulo: 'Los aliados' },
+            { id: 'jardin-trampa', pos: [8.6, Y_SUELO + 1.85, 2.0], titulo: 'Trampa (para medir)' },
+            { id: 'jardin-caldo', pos: [6.4, Y_SUELO + 1.1, 4.6], titulo: 'Caldo y poda' },
+          ]}
+        />
       )}
     </group>
   );
@@ -1023,11 +1030,14 @@ function CultivoVivo({ reducedMotion, etiquetas }) {
       </group>
 
       {etiquetas && (
-        <>
-          <Etiqueta pos={[-8.4, Y_SUELO + 2.5, 3.0]} texto="Cafeto sano" />
-          <Etiqueta pos={[-6.4, Y_SUELO + 2.5, 4.6]} texto="Cafeto con señas" />
-          <Etiqueta pos={[-4.9, Y_SUELO + 1.15, 6.2]} texto="Papa con gota" />
-        </>
+        <EtiquetasMundo
+          className="clivo-chip"
+          items={[
+            { id: 'cultivo-sano', pos: [-8.4, Y_SUELO + 2.5, 3.0], titulo: 'Cafeto sano' },
+            { id: 'cultivo-senas', pos: [-6.4, Y_SUELO + 2.5, 4.6], titulo: 'Cafeto con señas' },
+            { id: 'cultivo-gota', pos: [-4.9, Y_SUELO + 1.15, 6.2], titulo: 'Papa con gota' },
+          ]}
+        />
       )}
     </group>
   );
@@ -1131,8 +1141,16 @@ const CSS_CLIVO = `
 .clivo-boton { pointer-events: auto; appearance: none; border: 1px solid rgba(56,64,31,0.35); border-radius: 999px; padding: 0.44rem 1rem; background: rgba(250,247,232,0.85); color: #43481c; font: 600 0.8rem/1.1 system-ui, sans-serif; cursor: pointer; backdrop-filter: blur(3px); transition: background 0.2s ease, border-color 0.2s ease; }
 .clivo-boton:hover, .clivo-boton:focus-visible { background: rgba(255,255,255,0.95); border-color: rgba(56,64,31,0.6); outline: none; }
 .clivo-boton[aria-pressed='true'] { background: #dbe6ac; border-color: rgba(67,72,28,0.75); color: #38401f; }
-.clivo-chip { pointer-events: none; display: inline-flex; align-items: center; gap: 0.3em; padding: 2px 8px; border-radius: 999px; background: rgba(40,44,24,0.82); color: #f3f6df; font: 600 10px/1.5 system-ui, sans-serif; white-space: nowrap; box-shadow: 0 2px 6px rgba(28,30,10,0.3); }
+.clivo-chip { pointer-events: none; display: inline-flex; align-items: center; gap: 0.3em; padding: 2px 8px; border-radius: 999px; background: rgba(40,44,24,0.82); color: #f3f6df; font: 600 10px/1.5 system-ui, sans-serif; white-space: nowrap; box-shadow: 0 2px 6px rgba(28,30,10,0.3); transition: opacity 0.18s ease; }
 .clivo-chip b { display: inline-flex; align-items: center; justify-content: center; width: 1.35em; height: 1.35em; border-radius: 50%; background: #8bab4a; color: #24300f; font-size: 9px; }
+/* anti-colisión (EtiquetasMundo, kit/etiquetasAntiColision.js): dos etiquetas
+   que quedarían pisándose en pantalla ceden — primero el texto (queda un
+   punto mínimo), luego el punto entero (BUG arreglado: antes cada estación
+   montaba sus chips sueltos, sin saber unos de otros). */
+.clivo-chip[data-modo='punto'] { width: 10px; height: 10px; min-width: 0; padding: 0; border-radius: 50%; }
+.clivo-chip[data-modo='punto'] > * { display: none; }
+.clivo-chip[data-modo='oculto'] { opacity: 0; }
+@media (prefers-reduced-motion: reduce) { .clivo-chip { transition: none; } }
 .mundo-fauna { pointer-events: none; filter: drop-shadow(0 2px 5px rgba(30, 30, 10, 0.24)); }
 .clivo-leyenda { padding: 1.4rem 1rem 0; }
 .clivo-leyenda h2 { margin: 0 0 0.3rem; font-size: 1.12rem; color: #38401f; }

--- a/src/visual/mundo3d/kit/EtiquetasMundo.jsx
+++ b/src/visual/mundo3d/kit/EtiquetasMundo.jsx
@@ -1,0 +1,108 @@
+/*
+ * EtiquetasMundo — grupo de chips de etiqueta 3D→pantalla que NUNCA se pisan
+ * entre sí (arreglo directo del BUG de `#/mockups/mundo3d-sanidad`: ahí cada
+ * estación educativa montaba 2-4 `<Html>` sueltas, cada una su propia
+ * etiqueta sin saber de las demás — en cuanto la cámara se aleja, las que
+ * quedan cerca en el mundo se amontonan y quedan ilegibles).
+ *
+ * Este componente reemplaza ESE patrón: recibe TODAS las etiquetas de un
+ * grupo a la vez (una estación, un diorama, cualquier racimo de puntos de
+ * interés) y las resuelve JUNTAS cada cuadro contra la pantalla (proyección +
+ * caja de colisión), con la misma técnica que ya usa `RotulosLugares` en el
+ * valle 3D de producción (`mockups/valle/Valle3D.jsx`) — aquí, GENÉRICA y sin
+ * las nociones propias del valle (zoom semántico, "la cosa del día"). El
+ * álgebra pura vive en `etiquetasAntiColision.js` (mismo directorio).
+ *
+ * Uso:
+ *   <EtiquetasMundo
+ *     items={[
+ *       { id: 'hoja-sana', pos: [-0.68, 2.72, 0.2], titulo: 'Hoja sana' },
+ *       { id: 'hoja-enferma', pos: [0.72, 2.72, 0.2], titulo: 'Hoja enferma' },
+ *     ]}
+ *     focoId={idOpcional}      // cuál se prioriza si no caben todas
+ *     className="mi-chip"      // opcional: estilo propio del consumidor
+ *   />
+ *
+ * `pos` es LOCAL: como cualquier `<group>` de r3f, hereda la transformación
+ * del padre — se puede anidar dentro de una estación ya rotada/desplazada sin
+ * recalcular nada (el mundo real de cada ancla se lee con
+ * `getWorldPosition()` para la proyección, así que la anti-colisión es
+ * correcta aunque el padre esté rotado).
+ *
+ * Modos por chip (mismo contrato visual del valle, ver etiquetasMundo.css):
+ *   'pleno'  → nombre completo (cupo sin pisar a nadie);
+ *   'punto'  → chip mínimo (cedió el nombre, no el lugar);
+ *   'oculto' → cedió del todo (ya no cabe ni el punto, o quedó tras la cámara).
+ * Con `reduced-motion` la resolución de colisión SIGUE viva (es legibilidad,
+ * no movimiento); el CSS por defecto ya respeta `prefers-reduced-motion`
+ * apagando solo la transición de entrada/salida.
+ *
+ * Frugal: UNA sola pasada de useFrame para todo el grupo (no una por chip),
+ * a ~12 pasadas/s, imperativo sobre `dataset` — cero re-render de React por
+ * cuadro.
+ */
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import * as THREE from 'three';
+import { proyectarAPantalla, resolverModos } from './etiquetasAntiColision.js';
+import './etiquetasMundo.css';
+
+const _mundo = new THREE.Vector3();
+const _proj = new THREE.Vector3();
+
+export default function EtiquetasMundo({ items, focoId = null, className = 'mundo-etiqueta' }) {
+  const grupos = useRef({});
+  const chips = useRef({});
+  const tick = useRef(0);
+
+  useFrame(({ camera, size }) => {
+    // ~12 pasadas/s alcanzan: es texto que no persigue el cuadro a 60fps.
+    if (tick.current++ % 5 !== 0) return;
+
+    const puntos = [];
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i];
+      const g = grupos.current[it.id];
+      if (!g) continue;
+      g.getWorldPosition(_mundo);
+      const p = proyectarAPantalla(_proj, _mundo, camera, size);
+      puntos.push({ id: it.id, titulo: it.titulo, prioridad: i, ...p });
+    }
+    const modos = resolverModos(puntos, { focoId });
+    for (const p of puntos) {
+      const el = chips.current[p.id];
+      if (!el) continue;
+      const modo = modos.get(p.id) || 'oculto';
+      if (el.dataset.modo !== modo) el.dataset.modo = modo;
+    }
+  });
+
+  return (
+    <>
+      {items.map((it) => (
+        <group
+          key={it.id}
+          position={it.pos}
+          ref={(el) => {
+            grupos.current[it.id] = el;
+          }}
+        >
+          <Html center zIndexRange={[30, 0]}>
+            <div
+              ref={(el) => {
+                chips.current[it.id] = el;
+              }}
+              className={className}
+              data-modo="pleno"
+              aria-hidden="true"
+            >
+              {it.paso != null && <b>{it.paso}</b>}
+              {it.titulo}
+            </div>
+          </Html>
+        </group>
+      ))}
+    </>
+  );
+}

--- a/src/visual/mundo3d/kit/etiquetasAntiColision.js
+++ b/src/visual/mundo3d/kit/etiquetasAntiColision.js
@@ -1,0 +1,121 @@
+/*
+ * etiquetasAntiColision — el ÁLGEBRA pura para que las etiquetas 3D→pantalla
+ * NO SE PISEN (BUG real detectado en `#/mockups/mundo3d-sanidad`: varias
+ * `<Html>` ancladas en puntos distintos del mundo pero CERCA entre sí quedan
+ * amontonadas/ilegibles en pantalla en cuanto la cámara se aleja lo bastante
+ * para que dos anclas proyecten sobre el mismo parche de pixeles).
+ *
+ * Es la MISMA técnica que ya resuelve esto hoy en el valle 3D de producción
+ * — `RotulosLugares` en `mockups/valle/Valle3D.jsx` — extraída a GENÉRICA:
+ * proyectar cada ancla a pantalla, calcular su caja aproximada y dejar que la
+ * más relevante (el foco, si hay) se quede con su espacio primero; quien cae
+ * ENCIMA de una caja ya tomada cede un modo (de nombre completo a chip
+ * mínimo, y de ahí a invisible) en vez de pisarse con la otra. Aquí queda
+ * SOLO el algoritmo de resolución de espacio en pantalla — nada de las
+ * nociones propias del valle (zoom semántico, "la cosa del día", etc.) — para
+ * que cualquier escena con Html's agrupadas lo reuse sin arrastrar ese
+ * contexto. El consumidor de referencia es `EtiquetasMundo.jsx` (mismo
+ * directorio), que lo llama dentro de un `useFrame` y escribe el resultado
+ * imperativamente en `dataset` (cero re-render de React por cuadro).
+ *
+ * Puro: sin refs, sin efectos, sin montar nada. Testeable sin GPU.
+ */
+
+/**
+ * Proyecta un Vector3 de MUNDO a coordenadas de pantalla (px) usando la
+ * cámara y el tamaño del canvas actuales. Reusa el `scratch` (Vector3) que le
+ * pase el llamador para no generar basura por cuadro.
+ *
+ * @param {import('three').Vector3} scratch  vector reusable (se muta)
+ * @param {import('three').Vector3} puntoMundo
+ * @param {import('three').Camera} camera
+ * @param {{ width: number, height: number }} size
+ * @returns {{ x: number, y: number, detras: boolean }}
+ */
+export function proyectarAPantalla(scratch, puntoMundo, camera, size) {
+  scratch.copy(puntoMundo).project(camera);
+  return {
+    x: (scratch.x * 0.5 + 0.5) * size.width,
+    y: (0.5 - scratch.y * 0.5) * size.height,
+    detras: scratch.z > 1,
+  };
+}
+
+/** Caja AABB centrada en (x,y) de ancho/alto `w`/`h`, con `margen` px de aire
+ *  contra sus vecinas (dos chips pegados sin espacio no se leen). */
+export function rectanguloDe(x, y, w, h, margen = 8) {
+  return {
+    x0: x - w / 2 - margen,
+    x1: x + w / 2 + margen,
+    y0: y - h / 2 - margen,
+    y1: y + h / 2 + margen,
+  };
+}
+
+/** ¿Se solapan dos cajas AABB? */
+export function seSolapan(a, b) {
+  return a.x0 < b.x1 && a.x1 > b.x0 && a.y0 < b.y1 && a.y1 > b.y0;
+}
+
+/** Clampa v al rango [mitad, total-mitad] (deja `mitad` px de aire contra
+ *  cada borde). Si el rango se invierte — un chip más ancho que la pantalla —
+ *  cede al centro: mejor centrado que cortado contra el filo. */
+export function clamp1D(v, mitad, total) {
+  const lo = mitad;
+  const hi = total - mitad;
+  if (lo > hi) return total / 2;
+  return Math.min(Math.max(v, lo), hi);
+}
+
+/** Ancho aproximado (px) del chip según su modo: 'pleno' crece con el título,
+ *  'punto'/'oculto' es el círculo mínimo fijo (44px = piso táctil WCAG 2.5.5). */
+export function anchoDeChip(modo, titulo, { anchoPunto = 44, base = 76, porLetra = 9 } = {}) {
+  return modo === 'pleno' ? base + (titulo?.length || 0) * porLetra : anchoPunto;
+}
+
+/**
+ * Resuelve, para un conjunto de anclas YA proyectadas a pantalla, el modo de
+ * cada una: 'pleno' (nombre completo, cabe sin pisar a nadie), 'punto' (cedió
+ * el nombre pero conserva su lugar como chip mínimo) u 'oculto' (cedió del
+ * todo — ya ni el punto cabe, o quedó detrás de la cámara).
+ *
+ * Orden de reclamo: el `focoId` (si lo hay y es elegible) entra PRIMERO a
+ * tomar su espacio; el resto, por `prioridad` ascendente (por defecto, el
+ * orden en que llegó el arreglo). Cada ancla intenta primero 'pleno'; si pisa
+ * una caja ya tomada, cae a 'punto'; si tampoco cabe, cae a 'oculto'.
+ *
+ * @param {Array<{id: string, x: number, y: number, titulo: string, detras?: boolean, prioridad?: number}>} puntos
+ * @param {{ focoId?: string|null, altoPunto?: number, altoPleno?: number, margen?: number }} [opts]
+ * @returns {Map<string, 'pleno'|'punto'|'oculto'>}
+ */
+export function resolverModos(puntos, { focoId = null, altoPunto = 44, altoPleno = 48, margen = 8 } = {}) {
+  const tomados = [];
+  const pisa = (r) => tomados.some((o) => seSolapan(r, o));
+  const orden = [...puntos].sort((a, b) => {
+    if (a.id === focoId) return -1;
+    if (b.id === focoId) return 1;
+    return (a.prioridad ?? 0) - (b.prioridad ?? 0);
+  });
+
+  const modos = new Map();
+  for (const p of orden) {
+    if (p.detras) {
+      modos.set(p.id, 'oculto');
+      continue;
+    }
+    const rPleno = rectanguloDe(p.x, p.y, anchoDeChip('pleno', p.titulo), altoPleno, margen);
+    if (!pisa(rPleno)) {
+      tomados.push(rPleno);
+      modos.set(p.id, 'pleno');
+      continue;
+    }
+    const rPunto = rectanguloDe(p.x, p.y, anchoDeChip('punto', p.titulo), altoPunto, margen);
+    if (!pisa(rPunto)) {
+      tomados.push(rPunto);
+      modos.set(p.id, 'punto');
+      continue;
+    }
+    modos.set(p.id, 'oculto');
+  }
+  return modos;
+}

--- a/src/visual/mundo3d/kit/etiquetasMundo.css
+++ b/src/visual/mundo3d/kit/etiquetasMundo.css
@@ -1,0 +1,59 @@
+/*
+ * etiquetasMundo.css — estilo POR DEFECTO de `<EtiquetasMundo>` (kit 3D
+ * compartido). Un consumidor con su propia línea gráfica pasa su
+ * `className` propio (ver `EstanteLaminas`/etc. en MundoSanidad3D.jsx, que
+ * reusan su chip `.clivo-chip` ya existente) — estas reglas solo entran
+ * cuando no se pasa nada.
+ *
+ * Mismo contrato de modos que `rotulosValle3D.css` (valle 3D de producción):
+ *   data-modo='pleno'  → chip con texto, tamaño normal;
+ *   data-modo='punto'  → círculo mínimo (44px, piso táctil WCAG 2.5.5), sin
+ *                        texto — el consumidor decide si el punto lleva un
+ *                        marcador propio (emoji/color) vía su propio CSS;
+ *   data-modo='oculto' → invisible y fuera de toque (anti-colisión: cedió su
+ *                        espacio en pantalla, o quedó tras la cámara).
+ */
+.mundo-etiqueta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  padding: 0.3em 0.65em;
+  border-radius: 999px;
+  background: rgba(20, 26, 16, 0.86);
+  color: #fdf6e3;
+  font: 600 0.82rem/1.3 system-ui, -apple-system, sans-serif;
+  white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.28);
+  transition: opacity 0.18s ease;
+}
+.mundo-etiqueta b {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.35em;
+  height: 1.35em;
+  border-radius: 50%;
+  background: #8bab4a;
+  color: #24300f;
+  font-size: 0.72em;
+}
+.mundo-etiqueta[data-modo='punto'] {
+  width: 12px;
+  height: 12px;
+  min-width: 0;
+  padding: 0;
+  border-radius: 50%;
+}
+.mundo-etiqueta[data-modo='punto'] > *,
+.mundo-etiqueta[data-modo='oculto'] > * {
+  display: none;
+}
+.mundo-etiqueta[data-modo='oculto'] {
+  opacity: 0;
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mundo-etiqueta {
+    transition: none;
+  }
+}

--- a/src/visual/mundo3d/kit/index.js
+++ b/src/visual/mundo3d/kit/index.js
@@ -27,6 +27,8 @@
  *   · terreno.js      construirTerreno (heightfield con color por vértice)
  *   · atmosfera.js    atmosferaDeFamilia + useAtmosferaMundo (hora viva del valle)
  *   · AtmosferaMundo  el drop-in <color>/<fog>/luces/estrellas/sombras
+ *   · EtiquetasMundo  etiquetas 3D→pantalla que NUNCA se pisan (anti-colisión
+ *                     + foco), extraído de `RotulosLugares` del valle
  *   + re-exports de las piezas madre ya probadas (paleta, cielos, tier, cámara,
  *     transiciones, sombra de contacto, ciclo diurno).
  */
@@ -68,6 +70,12 @@ export { decidirTier, permite3D, perfilDeTier } from '../deviceTier.js';
 
 /* ── Sombra de contacto / AO barato ─────────────────────────────────────────── */
 export { SombraContacto } from '../escenas/SombraContacto.jsx';
+
+/* ── Etiquetas 3D→pantalla que no se pisan (anti-colisión + foco) ──────────── */
+export { default as EtiquetasMundo } from './EtiquetasMundo.jsx';
+export {
+  proyectarAPantalla, rectanguloDe, seSolapan, clamp1D, anchoDeChip, resolverModos,
+} from './etiquetasAntiColision.js';
 
 /* ── Cámara (establishing shot + encuadres por mundo) ───────────────────────── */
 export { default as CamaraDirector } from '../escenas/CamaraDirector.jsx';

--- a/src/visual/mundo3d/momentosData.js
+++ b/src/visual/mundo3d/momentosData.js
@@ -31,6 +31,19 @@ export const easeOutBack = (p) => {
   return 1 + c3 * (p - 1) ** 3 + c1 * (p - 1) ** 2;
 };
 
+/* Forma del arco de un vuelo balístico con estirón (parábola simple: 0 en los
+   extremos, 1 en el pico e=0.5). Es la MISMA curva que ya vive repetida a
+   mano en dos sitios — el fruto que vuela al canasto (`FASES_MOMENTO.cosecha`
+   más abajo, `Math.sin(Math.PI*e)` en MomentosFinca.jsx) y el costal que
+   vuela al almacén (EfectosFuncionalesDemo) — cualquier "llevar un objeto de
+   A a B" del framework la puede reusar en vez de reescribirla:
+   `y += arcoDeVuelo(e) * alturaArco` (altura del arco) y
+   `escalaEje = 1 + arcoDeVuelo(e) * estiron` con `escalaCruzada = 1/√escalaEje`
+   (estirón que conserva volumen: se alarga en el eje de vuelo, se afina en
+   los otros dos).
+   @param {number} e  progreso del vuelo, 0..1 (se clampa por si acaso). */
+export const arcoDeVuelo = (e) => Math.sin(Math.PI * clamp01(e));
+
 /* Progreso LOCAL de una fase: mapea p∈[0,1] global al tramo [ini,fin] y lo
    normaliza a [0,1] con clamp. Las fases se SOLAPAN un poco a propósito
    (follow-through: la acción siguiente arranca antes de que muera la previa). */


### PR DESCRIPTION
## Qué es esto

Parte del encargo "inventariar los efectos funcionales de Chagra y convertir en librería los generalizables". Inventario completo (solo-lectura) en `Chagra-strategy/ops/EFECTOS-INVENTARIO-2026-07-25.md` — este PR es SOLO la parte que sí toca código: los dos GENERALIZABLES que se extrajeron.

## Qué se extrajo y por qué

### 1. `EtiquetasMundo` — etiquetas 3D→pantalla que no se pisan (nuevo)

`src/visual/mundo3d/kit/etiquetasAntiColision.js` (álgebra pura: proyección a pantalla, cajas AABB, `resolverModos`) + `EtiquetasMundo.jsx` (componente r3f) + `etiquetasMundo.css`.

Generalizado a partir de `RotulosLugares` (el sistema de anti-colisión de rótulos del valle 3D de producción, `mockups/valle/Valle3D.jsx`), quitando sus conceptos propios (zoom semántico, "la cosa del día") para que cualquier escena con varias `<Html>` agrupadas lo reuse.

**Arregla el bug reportado en `#/mockups/mundo3d-sanidad`**: `MundoSanidad3D.jsx` montaba 2-4 `<Etiqueta>` sueltas por estación educativa, cada una su propio `<Html distanceFactor={9}>` sin saber de las demás — con anclas a ~1 unidad de distancia, se solapaban en pantalla en cuanto la cámara se alejaba. Los 5 sitios (`TableroComparacion`, `EstanteLaminas`, `CartelDistincion`, `JardinAliados`, `CultivoVivo`) ahora pasan todas sus etiquetas juntas a `<EtiquetasMundo className="clivo-chip" items={[...]} />`, que las resuelve entre sí cada cuadro (pleno → punto → oculto). Mismo estilo visual exacto (`.clivo-chip`), solo se agregan las reglas `[data-modo]`.

No se tocó `Valle3D.jsx` (producción, sin gate visual disponible en este agente).

### 2. Dedup del vocabulario rubber-hose en `EfectosFuncionalesDemo.jsx`

`momentosData.js` gana `arcoDeVuelo(e)` — la curva de arco parabólico (`Math.sin(Math.PI·e)`) que ya vivía **duplicada a mano** en dos sitios: el vuelo del fruto al canasto (`MomentosFinca.jsx`, sin tocar) y el vuelo del costal al almacén (`EfectosFuncionalesDemo.jsx`). Además `EfectosFuncionalesDemo.jsx` importa ahora `clamp01`/`easeOutBack` de `momentosData.js` y `smoothstep` de `kit/ruido.js` en vez de sus propios `reboteSuave`/`suave`/`clamp01` locales (mismo polinomio `1.70158`, mismo `t·t·(3-2t)` — verificado término a término, cero cambio de comportamiento).

## Verificación

- `npm run build` (dist/) → verde.
- `npm run build:prod` (dist-prod/) → verde. **Nota**: `MundoSanidad3D.jsx` NO entra al grafo del build normal (solo lo importa `ProdChagraApp.jsx`/`main-prod.jsx`) — hubo que correr `build:prod` aparte para que el fix se compilara de verdad.
- `npx eslint` sobre los 6 archivos tocados → limpio.
- `npx vitest run` sobre los tests de `mundo3d`/`kit` → 2 fallas preexistentes (fixtures de fecha/otro, no relacionadas), confirmadas en `origin/dev` sin estos cambios vía `git stash`.
- **No se verificó nada visualmente** (sin screenshot/gate visual desde este agente) — el fix del bug de etiquetas está razonado por código (mismo álgebra que ya funciona en el valle) pero no confirmado con una captura del diorama de sanidad.

## Test plan

- [ ] Abrir `#/mockups/mundo3d-sanidad` (vía `main-prod`/`ProdChagraApp`), activar "Ver las estaciones" y confirmar que las etiquetas de cada estación ya no se solapan al alejar la cámara.
- [ ] Abrir `#/mockups/efectos-funcionales` y confirmar que el invernadero (brote), el almacén (vuelo de costales) y el reservorio se ven idénticos a antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)