### PR TITLE
fix(mundo3d): anti-colisión de hotspots en EscenaBase3D (11 arquetipos)

### DIFF
--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -21,7 +21,7 @@
  * las sombras de contacto; solo cutaway lo necesita (su bloque centra en 0).
  */
 import { Suspense, lazy, useMemo, useRef, useState } from 'react';
-import { Canvas } from '@react-three/fiber';
+import { Canvas, useFrame } from '@react-three/fiber';
 import { Html, OrbitControls, Stars } from '@react-three/drei';
 import * as THREE from 'three';
 import { AbejaEscena } from './useEntradaAbeja.jsx';
@@ -44,11 +44,40 @@ import useCicloDia from '../useCicloDia.js';
 import { presetDeHora } from '../cielosHoraData.js';
 import { perfilDeTier } from '../deviceTier.js';
 import CapaVivaMundo from '../CapaVivaMundo.jsx';
+/* Álgebra pura de anti-colisión de etiquetas 3D→pantalla (proyección + cajas
+   AABB), la MISMA que ya generaliza `RotulosLugares` (Valle3D.jsx) para el kit
+   `EtiquetasMundo` — se reusa aquí en vez de duplicarla una tercera vez; solo
+   la POLÍTICA de foco (abajo) es propia de los hotspots. */
+import { proyectarAPantalla, rectanguloDe, seSolapan } from '../kit/etiquetasAntiColision.js';
 
 /* El bloom sutil de la hora dorada: chunk LAZY con gate ESTRICTO
    `tier === 'alto' && !reducedMotion` — medio y bajo NI LO DESCARGAN
    (el import dinámico solo dispara cuando el elemento llega a renderizarse). */
 const BloomSutil = lazy(() => import('./BloomSutil.jsx'));
+
+/* ── ANTI-COLISIÓN de hotspots en pantalla (ARREGLO ETIQUETAS ENCIMADAS,
+ * SPEC-UX-01): el MISMO criterio ya aprobado de `RotulosLugares` (Valle3D.jsx)
+ * y su port `CartelesNombres` (CorralVivo.jsx) — portado a la base compartida
+ * por los 9 arquetipos que la componen (los otros 2 de la familia de 11 — el
+ * valle y su calma — no la usan: el valle ya trae su propio RotulosLugares,
+ * la calma no tiene hotspots).
+ *
+ * Sin esto, `EscenaBase3D` pintaba la etiqueta COMPLETA de cada hotspot sin
+ * saber de las demás: dos puntos de interés cercanos EN PANTALLA (cámara
+ * alejada, auto-rotate) quedaban con sus rótulos encimados e ilegibles.
+ *
+ * NOTA de política (por qué NO se llama `resolverModos` del kit tal cual):
+ * `resolverModos` deja que CUALQUIER punto intente 'pleno' (útil para chips
+ * didácticos sueltos). Los hotspots son botones de NAVEGACIÓN, no chips, y el
+ * criterio YA aprobado para ellos (RotulosLugares banda 'media' / CorralVivo
+ * `CartelesNombres`) es más calmo: SOLO el activo/enfocado intenta 'pleno' —
+ * los demás van derecho a 'punto'. Se reusa la geometría pura del kit
+ * (`proyectarAPantalla`/`rectanguloDe`/`seSolapan`) pero se mantiene ESA
+ * política aquí, para no romper la lectura ya validada del valle/corral.
+ *
+ * Reusado el scratch (cero basura de GC en el hilo caliente del useFrame).
+ */
+const _projHotspot = new THREE.Vector3();
 
 function Contenido({
   params, hotspots, entrada, tinte, reducedMotion, onHotspot, cielo, animo, energia, piso = 0,
@@ -66,6 +95,12 @@ function Contenido({
   // Háptica del tap (DR-3D-HAPTICA): un tick seco al tocar un hotspot —
   // "toqué algo vivo, respondió". Gate triple interno; no-op en iOS.
   const haptics = useHaptics({ reducedMotion });
+  // Anti-colisión de hotspots (ver bloque de arriba): refs de los botones +
+  // memoria del último "candidato" (histéresis anti-parpadeo, mismo criterio
+  // de RotulosLugares/CartelesNombres).
+  const botonesHotspot = useRef({});
+  const plenaHotspot = useRef(null);
+  const tickHotspot = useRef(0);
   const zoom = entrada?.zoom ?? 6.5;
   const acento = (tinte && tinte[0]) || '#3f8f4e';
   const centro = entrada?.centro || /** @type {[number, number, number]} */ ([0, (params?.alto ?? 1.1) * 0.5, 0]);
@@ -104,6 +139,63 @@ function Contenido({
       setResaltado({ id: focoId, token: focoToken });
     }
   }
+
+  // Anti-colisión de hotspots en pantalla (ver `rectoDeHotspot`/`seSolapanHotspot`
+  // arriba): ~12 pasadas/s (corre en el PRIMER frame — importa con
+  // frameloop='demand' de reduced-motion, que renderiza pocos frames), imperativo
+  // sobre `dataset` (cero re-render de React por cuadro). El hotspot `activo`
+  // (tocado, o el que acaba de enfocar un comando de voz — ambos setean `activo`
+  // arriba) manda su espacio primero; si no hay ninguno activo, el más cercano
+  // al centro del encuadre, con histéresis (solo cambia si otro queda 20% más
+  // centrado — anti-parpadeo). Los demás ceden a un punto-chip con solo el
+  // emoji; quien ni así cabe cede del todo (el CSS lo trae de vuelta si el
+  // teclado lo enfoca — mismo contrato que `.v3d-poi` del valle).
+  useFrame(({ camera, size }) => {
+    if (!hotspots || !hotspots.length) return;
+    if (tickHotspot.current++ % 5 !== 0) return;
+
+    const pts = hotspots.map((h) => {
+      _projHotspot.set(h.pos[0], h.pos[1], h.pos[2]);
+      const p = proyectarAPantalla(_projHotspot, _projHotspot, camera, size);
+      return {
+        id: h.id,
+        label: h.label || '',
+        ...p,
+        dc: Math.hypot(p.x - size.width / 2, p.y - size.height / 2),
+      };
+    });
+
+    let candidata = null;
+    if (activo && pts.some((p) => p.id === activo && !p.detras)) {
+      candidata = activo;
+    } else {
+      const previa = pts.find((p) => p.id === plenaHotspot.current && !p.detras);
+      const cercana = pts.filter((p) => !p.detras).sort((a, b) => a.dc - b.dc)[0];
+      candidata = previa && cercana && cercana.dc > previa.dc * 0.8 ? previa.id : (cercana?.id ?? null);
+    }
+    plenaHotspot.current = candidata;
+
+    const tomados = [];
+    const pisa = (r) => tomados.some((o) => seSolapan(r, o));
+    const orden = [...pts].sort((a, b) =>
+      a.id === candidata ? -1 : b.id === candidata ? 1 : a.dc - b.dc,
+    );
+    for (const p of orden) {
+      let modo = 'oculto';
+      if (!p.detras) {
+        const esPlena = p.id === candidata;
+        const r = esPlena
+          ? rectanguloDe(p.x, p.y, 76 + p.label.length * 9, 48)
+          : rectanguloDe(p.x, p.y, 44, 44);
+        if (!pisa(r)) {
+          tomados.push(r);
+          modo = esPlena ? 'plena' : 'punto';
+        }
+      }
+      const btn = botonesHotspot.current[p.id];
+      if (btn && btn.dataset.modo !== modo) btn.dataset.modo = modo;
+    }
+  });
 
   return (
     <>
@@ -183,7 +275,11 @@ function Contenido({
           <group key={h.id} position={h.pos}>
             <Html center distanceFactor={zoom + 2} zIndexRange={[30, 0]}>
               <button
+                ref={(el) => {
+                  botonesHotspot.current[h.id] = el;
+                }}
                 type="button"
+                data-modo={h.id === activo ? 'plena' : 'punto'}
                 className={`mundo-hotspot${activo === h.id ? ' mundo-hotspot--activo' : ''}${esComando ? ' mundo-hotspot--comando' : ''}`}
                 style={{ '--hs-tinte': acento }}
                 onPointerDown={(e) => e.stopPropagation()}

--- a/src/visual/mundo3d/kit/etiquetasAntiColision.js
+++ b/src/visual/mundo3d/kit/etiquetasAntiColision.js
@@ -1,0 +1,121 @@
+/*
+ * etiquetasAntiColision — el ÁLGEBRA pura para que las etiquetas 3D→pantalla
+ * NO SE PISEN (BUG real detectado en `#/mockups/mundo3d-sanidad`: varias
+ * `<Html>` ancladas en puntos distintos del mundo pero CERCA entre sí quedan
+ * amontonadas/ilegibles en pantalla en cuanto la cámara se aleja lo bastante
+ * para que dos anclas proyecten sobre el mismo parche de pixeles).
+ *
+ * Es la MISMA técnica que ya resuelve esto hoy en el valle 3D de producción
+ * — `RotulosLugares` en `mockups/valle/Valle3D.jsx` — extraída a GENÉRICA:
+ * proyectar cada ancla a pantalla, calcular su caja aproximada y dejar que la
+ * más relevante (el foco, si hay) se quede con su espacio primero; quien cae
+ * ENCIMA de una caja ya tomada cede un modo (de nombre completo a chip
+ * mínimo, y de ahí a invisible) en vez de pisarse con la otra. Aquí queda
+ * SOLO el algoritmo de resolución de espacio en pantalla — nada de las
+ * nociones propias del valle (zoom semántico, "la cosa del día", etc.) — para
+ * que cualquier escena con Html's agrupadas lo reuse sin arrastrar ese
+ * contexto. El consumidor de referencia es `EtiquetasMundo.jsx` (mismo
+ * directorio), que lo llama dentro de un `useFrame` y escribe el resultado
+ * imperativamente en `dataset` (cero re-render de React por cuadro).
+ *
+ * Puro: sin refs, sin efectos, sin montar nada. Testeable sin GPU.
+ */
+
+/**
+ * Proyecta un Vector3 de MUNDO a coordenadas de pantalla (px) usando la
+ * cámara y el tamaño del canvas actuales. Reusa el `scratch` (Vector3) que le
+ * pase el llamador para no generar basura por cuadro.
+ *
+ * @param {import('three').Vector3} scratch  vector reusable (se muta)
+ * @param {import('three').Vector3} puntoMundo
+ * @param {import('three').Camera} camera
+ * @param {{ width: number, height: number }} size
+ * @returns {{ x: number, y: number, detras: boolean }}
+ */
+export function proyectarAPantalla(scratch, puntoMundo, camera, size) {
+  scratch.copy(puntoMundo).project(camera);
+  return {
+    x: (scratch.x * 0.5 + 0.5) * size.width,
+    y: (0.5 - scratch.y * 0.5) * size.height,
+    detras: scratch.z > 1,
+  };
+}
+
+/** Caja AABB centrada en (x,y) de ancho/alto `w`/`h`, con `margen` px de aire
+ *  contra sus vecinas (dos chips pegados sin espacio no se leen). */
+export function rectanguloDe(x, y, w, h, margen = 8) {
+  return {
+    x0: x - w / 2 - margen,
+    x1: x + w / 2 + margen,
+    y0: y - h / 2 - margen,
+    y1: y + h / 2 + margen,
+  };
+}
+
+/** ¿Se solapan dos cajas AABB? */
+export function seSolapan(a, b) {
+  return a.x0 < b.x1 && a.x1 > b.x0 && a.y0 < b.y1 && a.y1 > b.y0;
+}
+
+/** Clampa v al rango [mitad, total-mitad] (deja `mitad` px de aire contra
+ *  cada borde). Si el rango se invierte — un chip más ancho que la pantalla —
+ *  cede al centro: mejor centrado que cortado contra el filo. */
+export function clamp1D(v, mitad, total) {
+  const lo = mitad;
+  const hi = total - mitad;
+  if (lo > hi) return total / 2;
+  return Math.min(Math.max(v, lo), hi);
+}
+
+/** Ancho aproximado (px) del chip según su modo: 'pleno' crece con el título,
+ *  'punto'/'oculto' es el círculo mínimo fijo (44px = piso táctil WCAG 2.5.5). */
+export function anchoDeChip(modo, titulo, { anchoPunto = 44, base = 76, porLetra = 9 } = {}) {
+  return modo === 'pleno' ? base + (titulo?.length || 0) * porLetra : anchoPunto;
+}
+
+/**
+ * Resuelve, para un conjunto de anclas YA proyectadas a pantalla, el modo de
+ * cada una: 'pleno' (nombre completo, cabe sin pisar a nadie), 'punto' (cedió
+ * el nombre pero conserva su lugar como chip mínimo) u 'oculto' (cedió del
+ * todo — ya ni el punto cabe, o quedó detrás de la cámara).
+ *
+ * Orden de reclamo: el `focoId` (si lo hay y es elegible) entra PRIMERO a
+ * tomar su espacio; el resto, por `prioridad` ascendente (por defecto, el
+ * orden en que llegó el arreglo). Cada ancla intenta primero 'pleno'; si pisa
+ * una caja ya tomada, cae a 'punto'; si tampoco cabe, cae a 'oculto'.
+ *
+ * @param {Array<{id: string, x: number, y: number, titulo: string, detras?: boolean, prioridad?: number}>} puntos
+ * @param {{ focoId?: string|null, altoPunto?: number, altoPleno?: number, margen?: number }} [opts]
+ * @returns {Map<string, 'pleno'|'punto'|'oculto'>}
+ */
+export function resolverModos(puntos, { focoId = null, altoPunto = 44, altoPleno = 48, margen = 8 } = {}) {
+  const tomados = [];
+  const pisa = (r) => tomados.some((o) => seSolapan(r, o));
+  const orden = [...puntos].sort((a, b) => {
+    if (a.id === focoId) return -1;
+    if (b.id === focoId) return 1;
+    return (a.prioridad ?? 0) - (b.prioridad ?? 0);
+  });
+
+  const modos = new Map();
+  for (const p of orden) {
+    if (p.detras) {
+      modos.set(p.id, 'oculto');
+      continue;
+    }
+    const rPleno = rectanguloDe(p.x, p.y, anchoDeChip('pleno', p.titulo), altoPleno, margen);
+    if (!pisa(rPleno)) {
+      tomados.push(rPleno);
+      modos.set(p.id, 'pleno');
+      continue;
+    }
+    const rPunto = rectanguloDe(p.x, p.y, anchoDeChip('punto', p.titulo), altoPunto, margen);
+    if (!pisa(rPunto)) {
+      tomados.push(rPunto);
+      modos.set(p.id, 'punto');
+      continue;
+    }
+    modos.set(p.id, 'oculto');
+  }
+  return modos;
+}

--- a/src/visual/mundo3d/mundo.css
+++ b/src/visual/mundo3d/mundo.css
@@ -105,6 +105,51 @@
   line-height: 1;
 }
 
+/* ── ANTI-COLISIÓN en pantalla (SPEC-UX-01 — mismo criterio de `.v3d-poi` del
+      valle 3D / `RotulosLugares`, portado a los hotspots del framework base):
+      con dos o más puntos de interés cerca EN PANTALLA (cámara alejada,
+      auto-rotate), el botón deja de crecer con su texto y se calma a un
+      punto-chip de 44px — `data-modo` lo escribe `EscenaBase3D` en un
+      `useFrame` imperativo (cero re-render). El activo (tocado, o el más
+      cercano al centro del encuadre) conserva su nombre completo. ── */
+.mundo-hotspot[data-modo='punto'] {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  gap: 0;
+}
+.mundo-hotspot[data-modo='punto'] .mundo-hotspot__txt {
+  display: none;
+}
+.mundo-hotspot[data-modo='punto'] .mundo-hotspot__emoji {
+  font-size: 1.35rem;
+}
+/* Cedió del todo el espacio (ni el punto-chip cabe ya): se retira de la vista
+   y del toque MIENTRAS esté oculto. El teclado (Tab) lo trae de vuelta
+   entero — nunca deja una puerta del mundo inalcanzable. */
+.mundo-hotspot[data-modo='oculto'] {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+.mundo-hotspot[data-modo='oculto']:focus-visible {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+  width: auto;
+  height: auto;
+  padding: 0.4em 0.85em 0.4em 0.5em;
+  gap: 0.4em;
+}
+.mundo-hotspot[data-modo='oculto']:focus-visible .mundo-hotspot__txt {
+  display: inline;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mundo-hotspot[data-modo] {
+    transition: none;
+  }
+}
+
 /* ── Placa del animal (corral-espejo): el toque abre nombre + raza + tamaño
       (+ estado). Misma familia de papel que el hotspot; tocar de nuevo cierra.
       Piso táctil ≥44px (WCAG 2.5.5) y señal de estado que no es solo color. */


### PR DESCRIPTION
## Qué es esto

Arreglo 1 de dos (ver también `fix/abeja-ruana-alas-visibles`, PR hermano). Parte de la continuación de la tarea de gate visual del PR #2780.

`EscenaBase3D.jsx` pintaba cada hotspot con su emoji+texto SIEMPRE completo, sin proyección a pantalla ni resolución de colisión — a diferencia de `RotulosLugares` (Valle3D.jsx, producción) y su port `CartelesNombres` (CorralVivo.jsx), que sí la tienen. Con la cámara alejada o en auto-rotate, dos o más rótulos cercanos EN PANTALLA quedaban encimados e ilegibles.

## Discrepancia resuelta (importante)

El PR #2780 (`feat/efectos-funcionales-libreria`) aplicó su librería anti-colisión a `src/mockups/MundoSanidad3D.jsx` — pero ese archivo es un **huérfano de dev**: solo lo importa `ProdChagraApp.jsx`/`main-prod.jsx` (build de producción), NO `App.jsx`. La ruta real `#/mockups/mundo3d-sanidad` (la que ve el operador en `npm run dev`) renderiza `Mundo3DSanidad.jsx` → `Mundo` (`visual/mundo3d/index.js`) → `EscenaSanidad.jsx` → **`EscenaBase3D.jsx`** — el archivo que este PR arregla. Es decir: el bug que reportó el operador seguía vivo tras el #2780; este PR es el que realmente lo resuelve para esa ruta (y de paso para los otros 8 arquetipos que comparten la base).

## Qué se cambió

- `EscenaBase3D.jsx`: nuevo `useFrame` en `Contenido` que proyecta cada hotspot a pantalla, calcula cajas AABB y resuelve `data-modo` (`plena`/`punto`/`oculto`) imperativamente sobre `dataset` (~12 pasadas/s, cero re-render de React). Reusa el álgebra pura (`proyectarAPantalla`/`rectanguloDe`/`seSolapan`) de `kit/etiquetasAntiColision.js` — la misma que generaliza el kit `EtiquetasMundo` del PR #2780 — para no duplicarla una tercera vez. La política de foco es propia de los hotspots (solo el activo/enfocado intenta `plena`; mismo criterio ya aprobado de `RotulosLugares`/`CartelesNombres`), documentada en el comentario del archivo.
- `mundo.css`: reglas `.mundo-hotspot[data-modo=...]` (colapsa a punto-chip de 44px, o se oculta del todo — recuperable con Tab/`:focus-visible`, nunca deja una puerta del mundo inalcanzable por teclado).
- `kit/etiquetasAntiColision.js`: se agrega a `dev` (ya vive en `feat/efectos-funcionales-libreria`/PR #2780, aún no mergeado a `dev`; este PR lo trae porque `EscenaBase3D` depende de él).

Beneficia a los 9 arquetipos que componen `EscenaBase3D` (boveda, cafe, cutaway, estratos, flujo, mercado, recinto, sanidad, semillero). Los otros 2 de la familia de 11 (valle, calma) no lo necesitan: el valle ya trae su propio `RotulosLugares` y la calma no tiene hotspots.

## Verificación

- `npx vite build` → verde.
- Capturas ANTES/DESPUÉS con GPU real (Brave, NO SwiftShader) en **cafe**, **sanidad** y **semillero**: en los tres, antes había 3-4 etiquetas visualmente encimadas/ilegibles; después solo la más cercana al centro se ve completa, las demás colapsan a un chip de icono o ceden del todo. Capturas en `/home/kortux/Workspace/capturas-arreglos/etiquetas/` (no se suben al PR, son artefacto de trabajo local).
- **No verificado**: `mercado` — la captura previa quedó en blanco (tomada antes de que cargara/desplazara al canvas 3D) y no se pudo re-tomar en esta sesión por falta de herramienta de automatización de navegador (sin `claude-in-chrome` conectado, sin `wtype`/`ydotool` para hacer scroll dentro de la página). El código es idéntico al de los otros 8 arquetipos (misma base `EscenaBase3D`), así que el riesgo es bajo, pero queda como hallazgo pendiente de confirmar visualmente.

## Test plan

- [ ] Abrir `#/mockups/mundo3d-sanidad`, alejar la cámara / dejar auto-rotate, confirmar que las etiquetas de las estaciones ya no se solapan.
- [ ] Repetir en `#/mockups/mundo3d-cafe` y `#/mockups/mundo3d-semillero`.
- [ ] Confirmar con teclado (Tab) que ningún hotspot oculto queda inalcanzable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)