### PR TITLE
fix(creatures): abeja Angelita — la ruana ya no tapa las alas

### DIFF
--- a/src/visual/creatures/AbejaAngelita.jsx
+++ b/src/visual/creatures/AbejaAngelita.jsx
@@ -228,6 +228,29 @@ export function AbejaAngelita({
       {/* aura viva */}
       <circle r={auraR} fill={ABEJA_PALETA.cuerpo} opacity={auraOp} filter={`url(#${blur})`} />
 
+      {/* RUANA primero, bajo las alas (ARREGLO "la abeja parece burro"):
+          `AccesoriosClima` es especie-agnóstico y pinta la ruana OPACA y de
+          último — antes se pintaba junto a sombrero/sudor, DESPUÉS de las
+          alas (más abajo), tapándolas. Las alas son el rasgo que hace
+          reconocible la silueta de una abeja (sin ellas se lee como un
+          bulto con patas — un burro con poncho); el poncho además sube en
+          arco sobre el cuello (el "cuello en V") hasta invadir el espacio de
+          la segunda ala. Bastó reordenar EL PINTADO: la ruana sola, antes
+          de las alas, para que estas queden ENCIMA — cero cambios en
+          `AccesoriosClima.jsx` (sigue sirviendo igual al oso/colibrí/etc.)
+          ni en la lógica de la hora/clima (`ropaDeClimaBicho`, intacta).
+          Sombrero/sudor NO se tocan: siguen su lugar de siempre, después de
+          la cabeza (más abajo) — ese orden ya era correcto (el sombrero va
+          ENCIMA de la cabeza). */}
+      {ropa?.ruana && (
+        <AccesoriosClima
+          estado={{ ruana: true }}
+          tronco={{ cx: 0, cy: 0, rx: ABEJA_PROPORCION.troncoRx, ry: ABEJA_PROPORCION.troncoRy }}
+          cabeza={{ cx: 8.6, cy: -1.0, r: ABEJA_PROPORCION.cabezaR }}
+          animated={vivo}
+        />
+      )}
+
       {/* alitas de tul con contorno + smear (crt-wingbeat ya lleva el estirón).
           La duración del aleteo la modula el clima real (wingDur): dorada rápida,
           lluvia pesada. celebra/reposo (data-pose) mandan por especificidad CSS. */}
@@ -303,10 +326,13 @@ export function AbejaAngelita({
         {gafas && <GafasSol puesta={gafas === 'poniendose' ? 'poniendose' : 'puesta'} animated={vivo} />}
       </g>
 
-      {/* Vestuario por clima+hora (ruana/sombrero/sudor) — solo con vestuario=true. */}
-      {ropa && (
+      {/* Sombrero + sudor por clima+hora — solo con vestuario=true. La ruana
+          YA se pintó arriba, antes de las alas (ver el bloque de más arriba);
+          este orden (después de la cabeza) sigue siendo el correcto para el
+          sombrero, que debe quedar ENCIMA de la cabeza. */}
+      {(ropa?.sombrero || ropa?.sudor) && (
         <AccesoriosClima
-          estado={ropa}
+          estado={{ sombrero: ropa.sombrero, sudor: ropa.sudor }}
           tronco={{ cx: 0, cy: 0, rx: ABEJA_PROPORCION.troncoRx, ry: ABEJA_PROPORCION.troncoRy }}
           cabeza={{ cx: 8.6, cy: -1.0, r: ABEJA_PROPORCION.cabezaR }}
           animated={vivo}


### PR DESCRIPTION
## Qué es esto

Arreglo 2 de dos (ver también `fix/etiquetas-encimadas-escena-base`, PR hermano). Continuación del gate visual del PR #2780.

`AbejaAngelita.jsx` pintaba la ruana (`AccesoriosClima`, opaca) junto con sombrero/sudor en una sola llamada `<AccesoriosClima estado={ropa}>`, **después** de las alas de tul. El poncho cubría las alitas — el rasgo que hace reconocible la silueta de una abeja sin él se lee como un bulto con patas — y además su arco de cuello (`Q{cx},{top-ry*0.7}`) invadía el rango de la segunda ala (medido: cuello sube a y≈-4.3, segunda ala ocupa y: -7.9 a -2.5, solape real).

## Qué se cambió

Se parte la única llamada en DOS: la ruana sola se pinta ANTES de las alas (justo después del aura viva), y sombrero+sudor se quedan exactamente donde estaban (después de la cabeza — ese orden ya era correcto, el sombrero necesita ir encima). Cero cambios en `AccesoriosClima.jsx` (sigue especie-agnóstico para oso/colibrí/ardilla/etc.) ni en la lógica de clima/hora (`creatureClimaCuerpo.js`, `ropaDeClimaBicho`).

## Matiz sobre "la firma" (reportado, no maquillado)

El campo `firma` real en `abejaIdentidad.js` describe la ESTRUCTURA DE VALORES de color (cabeza/tórax oscuros + abdomen ámbar liso), no la silueta/forma. La heurística de "las alas son lo que la hace leerse como abeja" es válida como criterio de reconocibilidad, pero no es literalmente ese campo documentado. El arreglo preserva ambas cosas: ala visible y estructura de color intacta.

## Verificación

- `npx vite build` → verde.
- Capturas ANTES/DESPUÉS con GPU real (Brave, NO SwiftShader), zoom 3x sobre la creature: en "antes" el cuerpo es un bloque marrón sólido con un chevron decorativo, sin cara ni abdomen distinguibles — se lee como una cajita/burro con poncho. En "después" se ve claramente el abdomen ámbar, la cabeza oscura con cara (ojos+sonrisa) y antenas — la silueta se lee como abeja. Capturas en `/home/kortux/Workspace/capturas-arreglos/abeja/`.
- **Hallazgo sin resolver, reportado tal cual**: no pude confirmar con certeza, a esta resolución de captura, que las DOS elipses de ala (`alaTul` `#cfeeff`, `alaTulClara` `#eafff8` — colores muy pálidos/casi blancos) se vean como formas diferenciadas superpuestas al cuerpo; se distingue un fragmento pálido/verdoso cerca de las antenas presente en AMBAS capturas (antes y después) que podría ser la punta de un ala, pero no crece de forma clara entre antes/después. La MEJORA de legibilidad del cuerpo es innegable e importante; la visibilidad específica de las alas como forma quedó sin confirmar de forma concluyente por el bajo contraste de esos colores contra fondos claros en la captura disponible.

## Test plan

- [ ] Abrir cualquier mundo con Angelita de noche/frío (ruana activa) y confirmar que se ve como abeja, no como bulto.
- [ ] Confirmar visualmente si las alas se distinguen como forma en distintos fondos/horas (pendiente, ver hallazgo arriba).

🤖 Generated with [Claude Code](https://claude.com/claude-code)