### PR TITLE
feat(jaguar): marcha de perfil real (pose 'camina') — fin del patinaje

### DIFF
--- a/src/visual/creatures/Jaguar.jsx
+++ b/src/visual/creatures/Jaguar.jsx
@@ -261,7 +261,19 @@ export function Jaguar({
      'anda' (base, con acecho de hombros) | 'celebra' (brinca con brazos en V +
      overshoot) | 'reposo' (respira hondo, agazapado) | 'señala' (se inclina al
      POI y apunta con la zarpa). Solo corren viva (animated); con animated=false
-     o reduced-motion queda en fotograma digno e imponente. */
+     o reduced-motion queda en fotograma digno e imponente.
+     ── 'camina' (MARCHA DE PERFIL): el host la pide cuando el jaguar SE
+     DESPLAZA por una escena (JaguarBillboard fase anda/acecha). El cuerpo
+     frontal cede a un rig LATERAL (.jaguar-lado) con ciclo de marcha real de
+     cuadrúpedo — 4 patas desfasadas en secuencia lateral (diagonales casi
+     juntas), bóveda del paso, omóplato que rueda, cola baja de contrapeso y
+     GRUÑIDO periódico — fiel al DR de Panthera onca (cuerpo compacto, patas
+     cortas y gruesas, cola corta, testa maciza baja, pupila REDONDA, paso
+     lento y pesado). El traslado ENTRE mundos NO usa esta pose: el jaguar es
+     místico y ahí se aparece (aparicion/revelacion), no trota. El espejo
+     según el rumbo lo pone el host (scaleX del wrapper, como ya hace el
+     billboard). Sin patinaje: la cadencia (1.05s/ciclo) casa con el paso
+     lento del billboard (V_ANDA 0.62 u/s). */
   pose = 'anda',
   animo = 'sereno',
   energia = 1,
@@ -367,6 +379,7 @@ export function Jaguar({
   const rugeFx = ruge || momento === 'ruge';
   const acechaFx = acecha || momento === 'acecha';
   const poseFx = momento === 'reposo' ? 'reposo' : pose;
+  const marchando = poseFx === 'camina';
 
   // CLIMA → cuerpo (determinista, una vez por render): tinte + opacidad al
   // contorno. El jaguar no tiene alas (velocidadAlas siempre 1: no se usa).
@@ -735,14 +748,197 @@ export function Jaguar({
     </g>
   );
 
+  // ── MARCHA DE PERFIL (.jaguar-lado, pose 'camina') ─────────────────────────
+  // El rig LATERAL con el que el jaguar CAMINA por una escena (el frontal
+  // sentado no puede caminar creíble — veredicto del operador). Fiel al DR:
+  // cuerpo compacto y profundo, patas cortas y GRUESAS (doble trazo tinta +
+  // pelaje), cola CORTA llevada baja con anillos y punta negra, testa maciza
+  // BAJA de depredador solapada al pecho, pupila REDONDA de gran felino,
+  // trufa grande, bigotes gruesos, rosetas anillo-roto ESPACIADAS (misma
+  // fuente <Roseta/>: la regla de oro anti-leopardo también de perfil) y la
+  // capa mística del DR chamánico (aura, estrellas del pelaje = la noche
+  // estrellada, glifo cobre, bruma, motas). La CADENCIA vive en creatures.css
+  // (jaguar-lado-*): ciclo 1.05s de 4 tiempos, gruñido cada 6.3s. Dibujado
+  // mirando a la DERECHA; el host espeja con scaleX según el rumbo.
+  const lado = marchando ? (
+    <g className="jaguar-lado" transform="translate(0 -3.6) scale(0.08)" filter={`url(#${glow})`}>
+      {/* aura mística que late (violeta espectral + calor del pelaje) */}
+      <g className="jaguar-lado-aura" aria-hidden="true">
+        <ellipse cx="0" cy="60" rx="235" ry="175" fill={P.espectral} opacity="0.12" filter={`url(#${blur})`} />
+        <ellipse cx="0" cy="75" rx="185" ry="135" fill={P.cuerpo} opacity={auraOp} filter={`url(#${blur})`} />
+      </g>
+      {/* sombra de suelo (peso) */}
+      <ellipse cx="5" cy="212" rx="180" ry="17" fill={P.sombraSuelo} filter={`url(#${blur})`} aria-hidden="true" />
+
+      <g className="jaguar-lado-tronco">
+        {/* COLA corta llevada BAJA (DR): manchas en la base → anillos → punta negra */}
+        <g className="jaguar-lado-cola">
+          <g className="jaguar-lado-colapunta">
+            <path d="M-128,50 C -172,66 -204,62 -226,38 C -238,24 -238,4 -228,-8"
+              fill="none" stroke={RH_INK} strokeWidth="24" strokeLinecap="round" />
+            <path d="M-128,50 C -172,66 -204,62 -226,38 C -238,24 -238,4 -228,-8"
+              fill="none" stroke={P.cuerpo} strokeWidth="18.5" strokeLinecap="round" />
+            <g fill={P.roseta} opacity="0.8">
+              <circle cx="-156" cy="58" r="4.6" /><circle cx="-178" cy="58" r="4.2" />
+            </g>
+            <path d="M-214,50 C -228,38 -236,20 -232,0"
+              fill="none" stroke={P.roseta} strokeWidth="19.5" strokeLinecap="butt"
+              strokeDasharray="7.5 11" strokeDashoffset="-3" />
+            <circle cx="-228" cy="-10" r="11.5" fill={P.roseta} />
+          </g>
+        </g>
+
+        {/* patas del lado de ALLÁ (pelaje en sombra — profundidad) */}
+        <g className="jaguar-lado-pata jaguar-lado-dl">
+          <path d="M68,108 C 72,140 70,168 66,190" fill="none" stroke={RH_INK} strokeWidth="30" strokeLinecap="round" />
+          <path d="M68,108 C 72,140 70,168 66,190" fill="none" stroke={P.cuerpoSombra} strokeWidth="23.5" strokeLinecap="round" />
+          <ellipse cx="66" cy="196" rx="23" ry="13" fill="#dcc9a2" stroke={RH_INK} strokeWidth="3.5" />
+        </g>
+        <g className="jaguar-lado-pata jaguar-lado-tl">
+          <path d="M-108,108 C -114,140 -112,168 -106,190" fill="none" stroke={RH_INK} strokeWidth="32" strokeLinecap="round" />
+          <path d="M-108,108 C -114,140 -112,168 -106,190" fill="none" stroke={P.cuerpoSombra} strokeWidth="25.5" strokeLinecap="round" />
+          <ellipse cx="-106" cy="196" rx="24" ry="13" fill="#dcc9a2" stroke={RH_INK} strokeWidth="3.5" />
+        </g>
+
+        {/* TRONCO compacto y PROFUNDO (DR: nada de silueta alargada) */}
+        <ellipse cx="-8" cy="84" rx="138" ry="77" fill={`url(#${pelaje})`} stroke={RH_INK} strokeWidth="5" />
+        <ellipse cx="-10" cy="132" rx="110" ry="26" fill={P.vientre} opacity="0.88" />
+        <g fill="none" stroke={RH_INK} strokeWidth="2.2" opacity="0.18" strokeLinecap="round" aria-hidden="true">
+          <path d="M-96,52 C -120,84 -118,120 -96,142" />
+          <path d="M96,60 C 112,88 110,118 92,138" />
+        </g>
+        {/* ROSETAS del flanco — misma <Roseta/> del frontal (anillo roto +
+            puntos internos), grandes y ESPACIADAS como manda el DR */}
+        <g aria-hidden="true">
+          <Roseta cx={-96} cy={52} r={20} rot={130} motas={2} ink={P.roseta} centro={P.rosetaCentro} />
+          <Roseta cx={-28} cy={40} r={23} rot={15} motas={3} ink={P.roseta} centro={P.rosetaCentro} />
+          <Roseta cx={44} cy={50} r={20} rot={250} motas={3} ink={P.roseta} centro={P.rosetaCentro} />
+          <Roseta cx={-118} cy={108} r={15} rot={320} motas={2} ink={P.roseta} centro={P.rosetaCentro} opacity={0.92} />
+          <Roseta cx={-58} cy={104} r={17.5} rot={40} motas={2} ink={P.roseta} centro={P.rosetaCentro} />
+          <Roseta cx={14} cy={102} r={16} rot={205} motas={2} ink={P.roseta} centro={P.rosetaCentro} opacity={0.92} />
+          <Roseta cx={82} cy={98} r={14} rot={85} motas={2} ink={P.roseta} centro={P.rosetaCentro} opacity={0.9} />
+          <Roseta cx={108} cy={40} r={13} rot={300} motas={1} ink={P.roseta} centro={P.rosetaCentro} opacity={0.9} />
+        </g>
+        {/* la noche estrellada sobre el pelaje (DR chamánico) */}
+        <g aria-hidden="true">
+          <Estrella cx={-44} cy={50} r={9} color={P.estrella} vivo={vivo} delay={0} />
+          <Estrella cx={28} cy={38} r={10} color={P.estrella} vivo={vivo} delay={-1.2} />
+          <Estrella cx={-98} cy={80} r={7.5} color={P.estrella} vivo={vivo} delay={-2.4} />
+          <Estrella cx={52} cy={80} r={8} color={P.estrella} vivo={vivo} delay={-3.1} />
+        </g>
+        {/* glifo espiral del hombro (ornamento, nunca arma) */}
+        <g className="jaguar-glifos" aria-hidden="true" fill="none" stroke={P.cobre}
+          strokeWidth="3" strokeLinecap="round" opacity="0.3">
+          <path transform="translate(52 52) scale(5.5)" d={GLIFO_ESPIRAL} />
+        </g>
+        {/* OMÓPLATO que rueda al andar (la seña del jaguar) */}
+        <g className="jaguar-lado-hombro">
+          <path d="M34,26 Q 76,-12 116,30 Q 76,12 34,26 Z" fill={P.hombro} stroke={RH_INK} strokeWidth="4" strokeLinejoin="round" />
+        </g>
+
+        {/* patas del lado de ACÁ */}
+        <g className="jaguar-lado-pata jaguar-lado-tc">
+          <path d="M-74,112 C -70,144 -72,172 -76,192" fill="none" stroke={RH_INK} strokeWidth="35" strokeLinecap="round" />
+          <path d="M-74,112 C -70,144 -72,172 -76,192" fill="none" stroke={`url(#${pelaje})`} strokeWidth="28.5" strokeLinecap="round" />
+          <g fill={P.roseta} opacity="0.55"><circle cx="-71" cy="140" r="3.6" /><circle cx="-74" cy="166" r="3" /></g>
+          <ellipse cx="-76" cy="197" rx="26" ry="14" fill={P.vientre} stroke={RH_INK} strokeWidth="4" />
+          <path d="M-86,190 L-86,204 M-76,192 L-76,206 M-66,190 L-66,204" stroke="#8a6a2e" strokeWidth="2.2" opacity="0.6" />
+        </g>
+        <g className="jaguar-lado-pata jaguar-lado-dc">
+          <path d="M96,112 C 102,144 100,172 96,192" fill="none" stroke={RH_INK} strokeWidth="34" strokeLinecap="round" />
+          <path d="M96,112 C 102,144 100,172 96,192" fill="none" stroke={`url(#${pelaje})`} strokeWidth="27.5" strokeLinecap="round" />
+          <g fill={P.roseta} opacity="0.55"><circle cx="100" cy="140" r="3.6" /><circle cx="98" cy="166" r="3" /></g>
+          <ellipse cx="96" cy="197" rx="26" ry="14" fill={P.vientre} stroke={RH_INK} strokeWidth="4" />
+          <path d="M86,190 L86,204 M96,192 L96,206 M106,190 L106,204" stroke="#8a6a2e" strokeWidth="2.2" opacity="0.6" />
+        </g>
+
+        {/* CUELLO/PECHO: la masa que une la testa baja con el tronco */}
+        <path d="M48,14 C 92,-20 158,-22 182,14 C 194,38 184,66 152,78 C 112,92 66,76 48,44 Z"
+          fill={`url(#${pelaje})`} stroke={RH_INK} strokeWidth="5" strokeLinejoin="round" />
+
+        {/* CABEZA de perfil: wrapper del GRUÑIDO + bob del paso. Porte BAJO de
+            depredador (DR: la testa puede ir más baja que los hombros). */}
+        <g className="jaguar-lado-grune">
+          <g className="jaguar-lado-cabeza">
+            <circle cx="138" cy="-34" r="22" fill={`url(#${pelaje})`} stroke={RH_INK} strokeWidth="4.5" />
+            <circle cx="138" cy="-32" r="10.5" fill={P.oreja} />
+            <circle cx="133" cy="-43" r="5" fill={P.roseta} />
+            {/* GRUÑIDO: garganta + colmillos (opacity 0 fuera del gruñido) */}
+            <g className="jaguar-lado-grunefx">
+              <path d="M208,28 C 230,22 250,24 260,20 C 258,42 238,54 212,48 Z" fill="#7e1d14" />
+              <path d="M244,24 L250,44 L234,30 Z" fill={P.colmillo} stroke={RH_INK} strokeWidth="1.2" />
+              <path d="M220,28 L224,42 L212,32 Z" fill={P.colmillo} stroke={RH_INK} strokeWidth="1" />
+            </g>
+            {/* MANDÍBULA (pivota al gruñir) */}
+            <g className="jaguar-lado-fauce">
+              <path d="M216,38 C 232,43 246,41 254,33 C 252,45 240,50 222,46 C 216,43 214,41 216,38 Z"
+                fill="#dcc49c" stroke={RH_INK} strokeWidth="3.2" strokeLinejoin="round" />
+              <path d="M246,34 L240,46 L233,36 Z" fill={P.colmillo} stroke={RH_INK} strokeWidth="1" />
+            </g>
+            {/* cráneo + morro corto y macizo */}
+            <ellipse cx="172" cy="0" rx="58" ry="51" fill={`url(#${pelaje})`} stroke={RH_INK} strokeWidth="5" />
+            <ellipse cx="234" cy="18" rx="31" ry="24" fill={`url(#${pelaje})`} stroke={RH_INK} strokeWidth="4" />
+            <path d="M228,14 C 243,9 256,13 260,19 C 256,27 243,30 230,27 Z" fill={P.hocico} opacity="0.95" />
+            <g fill={P.roseta} opacity="0.5" aria-hidden="true">
+              <circle cx="238" cy="18" r="1.8" /><circle cx="246" cy="21" r="1.5" /><circle cx="234" cy="24" r="1.5" />
+            </g>
+            {/* bigotes largos y gruesos (DR) */}
+            <g fill="none" stroke={P.vibrisa} strokeWidth="2.3" strokeLinecap="round" opacity="0.65" aria-hidden="true">
+              <path d="M244,16 C 262,10 278,10 290,4" />
+              <path d="M245,21 C 263,18 279,20 292,16" />
+              <path d="M243,26 C 259,27 273,32 285,32" />
+            </g>
+            {/* trufa GRANDE rosada-negruzca (DR) */}
+            <path d="M252,4 C 262,2 269,8 268,14 C 267,20 258,23 251,20 Z" fill="#6b3a34" stroke={RH_INK} strokeWidth="1.4" />
+            {/* puntos sólidos de la cara (patrón real por zona) */}
+            <g fill={P.roseta} opacity="0.6" aria-hidden="true">
+              <circle cx="166" cy="-28" r="2.8" /><circle cx="184" cy="-22" r="2.3" />
+              <circle cx="150" cy="-6" r="2.5" /><circle cx="204" cy="-14" r="2" />
+            </g>
+            <Roseta cx={152} cy={18} r={12} rot={25} motas={1} ink={P.roseta} centro={P.rosetaCentro} opacity={0.8} />
+            {/* CEJA fiera + OJO ámbar con pupila REDONDA de gran felino (DR) */}
+            <path d="M182,-26 L210,-17" stroke={RH_INK} strokeWidth="3.6" strokeLinecap="round" fill="none" />
+            <g>
+              <ellipse cx="200" cy="-6" rx="9" ry="9.6" fill="#fffbe8" stroke={RH_INK} strokeWidth="1.8" />
+              <circle cx="201" cy="-5" r="6.6" fill={P.iris} />
+              <circle cx="201.5" cy="-4.5" r="3.1" fill={P.roseta} />
+              <circle cx="204" cy="-8" r="1.7" fill="#fff" />
+            </g>
+            {/* tapetum: el ojo que devuelve la luz (místico, respira por CSS) */}
+            <circle className={vivo ? 'jaguar-ojo-brillo' : undefined} cx="201" cy="-5" r="7.5"
+              fill={P.ojoBrillo} opacity="0.4" filter={`url(#${blur})`} aria-hidden="true"
+              style={{ transformBox: 'fill-box', transformOrigin: 'center' }} />
+            <g aria-hidden="true">
+              <Estrella cx={158} cy={-22} r={7.5} color={P.estrella} vivo={vivo} delay={-1.8} />
+            </g>
+          </g>
+        </g>
+      </g>
+
+      {/* bruma etérea a los pies + motas del espíritu */}
+      <ellipse className={vivo ? 'jaguar-bruma' : undefined} cx="0" cy="206" rx="185" ry="20"
+        fill={P.bruma} opacity="0.09" filter={`url(#${blur})`}
+        style={{ transformBox: 'fill-box', transformOrigin: 'center' }} aria-hidden="true" />
+      <g aria-hidden="true" fill={P.mota}>
+        <circle className={vivo ? 'jaguar-mota' : undefined} cx="-160" cy="30" r="4.5" opacity="0.3" />
+        <circle className={vivo ? 'jaguar-mota' : undefined} cx="150" cy="-40" r="3.8" opacity="0.3"
+          style={vivo ? { animationDelay: '-2.4s' } : undefined} />
+        <circle className={vivo ? 'jaguar-mota' : undefined} cx="-60" cy="-70" r="3.4" opacity="0.3"
+          style={vivo ? { animationDelay: '-4.1s' } : undefined} />
+      </g>
+    </g>
+  ) : null;
+
   // Antics de VIDA (períodos co-primos) SOLO viva; nodos aparte para no pisar el
   // boil de `.crt-body`. El CSS los apaga con RM / tier bajo / ánimo bajo /
-  // durante los gestos (celebra/reposo/señala) y estados (ruge/acecha).
+  // durante los gestos (celebra/reposo/señala) y estados (ruge/acecha) — y en
+  // la MARCHA (pose camina, CSS), donde el perfil ya lleva su propia cadencia.
+  const figura = marchando ? lado : body;
   const conAntics = vivo ? (
     <g className="rh-antic">
-      <g className="rh-travieso">{body}</g>
+      <g className="rh-travieso">{figura}</g>
     </g>
-  ) : body;
+  ) : figura;
   // El line-boil (contorno que hierve) envuelve TODO el dibujo cuando se pide.
   const conBoil = lineBoil ? <g filter={`url(#${boil})`}>{conAntics}</g> : conAntics;
   // La LEVITACIÓN de la revelación envuelve todo (ingravidez del espíritu):

--- a/src/visual/creatures/creatures.css
+++ b/src/visual/creatures/creatures.css
@@ -1557,7 +1557,108 @@
   .jaguar-ojos { transition: none !important; }
   /* Aparición: NUNCA invisible — queda PRESENTE, opacidad plena y quieto. */
   .jaguar-aparicion { animation: none !important; opacity: 1 !important; transform: none !important; }
+  /* MARCHA de perfil: quieta a media zancada (fotograma digno, cero anim). */
+  .jaguar-lado-pata, .jaguar-lado-tronco, .jaguar-lado-hombro,
+  .jaguar-lado-cola, .jaguar-lado-colapunta, .jaguar-lado-cabeza,
+  .jaguar-lado-grune, .jaguar-lado-fauce, .jaguar-lado-grunefx,
+  .jaguar-lado-aura { animation: none !important; }
 }
+
+/* ───────────────────────────────────────────────────────────────────────────
+   JAGUAR — MARCHA DE PERFIL (pose 'camina', rig .jaguar-lado del componente).
+   El ciclo de paso REAL de un cuadrúpedo (DR Panthera onca): las patas NO van
+   en pares simétricos sino en SECUENCIA LATERAL de 4 tiempos con las
+   diagonales casi juntas (del-cerca 0 · tras-lejos -.14 · tras-cerca -.52 ·
+   del-lejos -.66 sobre T=1.05s — paso LENTO y pesado, jamás trote nervioso),
+   el tronco con la bóveda del paso (2 botes por ciclo), el omóplato que RUEDA
+   (la seña del felino), la cola baja de contrapeso y la testa con bob en
+   contratiempo… más el GRUÑIDO periódico (cada 6.3s, fuera de compás con el
+   paso): la testa baja y se adelanta, las fauces se abren con colmillos y la
+   garganta se enciende. Imponente y digno, nunca gore. Todo transform/opacity.
+   ─────────────────────────────────────────────────────────────────────────── */
+[data-creature='jaguar'][data-pose='camina'] { overflow: visible; }
+/* la marcha manda: antics genéricos fuera mientras camina */
+[data-pose='camina'] .rh-antic, [data-pose='camina'] .rh-travieso { animation: none; }
+
+.jaguar-lado-pata { transform-box: fill-box; transform-origin: 50% 4%; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-dc { animation: jaguar-paso-lado 1.05s ease-in-out infinite; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-tl { animation: jaguar-paso-lado 1.05s ease-in-out -0.14s infinite; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-tc { animation: jaguar-paso-lado 1.05s ease-in-out -0.52s infinite; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-dl { animation: jaguar-paso-lado 1.05s ease-in-out -0.66s infinite; }
+@keyframes jaguar-paso-lado {
+  0%, 100% { transform: rotate(14deg); }  /* zancada atrás: el apoyo que empuja */
+  50%      { transform: rotate(-15deg); } /* al frente: el vuelo del paso */
+}
+
+.jaguar-lado-tronco { transform-box: fill-box; transform-origin: 50% 60%; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-tronco { animation: jaguar-tronco-lado 0.525s ease-in-out infinite; }
+@keyframes jaguar-tronco-lado {
+  0%, 100% { transform: translateY(2.5px) rotate(0.5deg); }
+  50%      { transform: translateY(-3.5px) rotate(-0.3deg); }
+}
+
+.jaguar-lado-hombro { transform-box: fill-box; transform-origin: 50% 100%; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-hombro { animation: jaguar-hombro-lado 0.525s ease-in-out infinite; }
+@keyframes jaguar-hombro-lado {
+  0%, 100% { transform: translateY(0) scaleY(1); }
+  50%      { transform: translateY(-3px) scaleY(1.08); }
+}
+
+.jaguar-lado-cola { transform-box: fill-box; transform-origin: 97% 72%; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-cola { animation: jaguar-cola-lado 1.8s ease-in-out infinite alternate; }
+@keyframes jaguar-cola-lado {
+  from { transform: rotate(-3deg); }
+  to   { transform: rotate(5deg); }
+}
+.jaguar-lado-colapunta { transform-box: fill-box; transform-origin: 72% 55%; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-colapunta { animation: jaguar-colapunta-lado 1.8s ease-in-out -0.25s infinite alternate; }
+@keyframes jaguar-colapunta-lado {
+  from { transform: rotate(-5deg); }
+  to   { transform: rotate(6deg); }
+}
+
+.jaguar-lado-cabeza { transform-box: fill-box; transform-origin: 20% 80%; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-cabeza { animation: jaguar-cabeza-lado 0.525s ease-in-out -0.12s infinite; }
+@keyframes jaguar-cabeza-lado {
+  0%, 100% { transform: translateY(-1.5px) rotate(-0.7deg); }
+  50%      { transform: translateY(2px) rotate(0.7deg); }
+}
+
+/* EL GRUÑIDO — ciclo largo co-primo con el paso (6.3s vs 1.05s) */
+.jaguar-lado-grune { transform-box: fill-box; transform-origin: 15% 85%; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-grune { animation: jaguar-grune-lado 6.3s ease-in-out infinite; }
+@keyframes jaguar-grune-lado {
+  0%, 64%, 96%, 100% { transform: translateY(0) rotate(0deg); }
+  70%, 88%           { transform: translateY(11px) translateX(7px) rotate(5.5deg); } /* la testa baja: gruñe */
+}
+.jaguar-lado-fauce { transform-box: fill-box; transform-origin: 8% 12%; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-fauce { animation: jaguar-fauce-lado 6.3s ease-in-out infinite; }
+@keyframes jaguar-fauce-lado {
+  0%, 64%, 96%, 100% { transform: rotate(0deg); }
+  70% { transform: rotate(24deg); }   /* abre las fauces */
+  76% { transform: rotate(19deg); }   /* vibra el gruñido */
+  82% { transform: rotate(26deg); }
+  88% { transform: rotate(21deg); }
+}
+.jaguar-lado-grunefx { opacity: 0; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-grunefx { animation: jaguar-grunefx-lado 6.3s ease-in-out infinite; }
+@keyframes jaguar-grunefx-lado {
+  0%, 63%, 95%, 100% { opacity: 0; }
+  70%, 88%           { opacity: 1; } /* colmillos + garganta visibles */
+}
+
+/* el aura del perfil late como la espectral del frontal */
+.jaguar-lado-aura { transform-box: fill-box; transform-origin: 50% 50%; }
+[data-creature='jaguar'][data-pose='camina'] .jaguar-lado-aura { animation: jaguar-aura-espectral 5.2s ease-in-out infinite; }
+
+/* tier bajo: la marcha queda plantada a media zancada (sin ciclos continuos) */
+[data-tier='bajo'] .jaguar-lado-dc, [data-tier='bajo'] .jaguar-lado-dl,
+[data-tier='bajo'] .jaguar-lado-tc, [data-tier='bajo'] .jaguar-lado-tl,
+[data-tier='bajo'] .jaguar-lado-tronco, [data-tier='bajo'] .jaguar-lado-hombro,
+[data-tier='bajo'] .jaguar-lado-cola, [data-tier='bajo'] .jaguar-lado-colapunta,
+[data-tier='bajo'] .jaguar-lado-cabeza, [data-tier='bajo'] .jaguar-lado-grune,
+[data-tier='bajo'] .jaguar-lado-fauce, [data-tier='bajo'] .jaguar-lado-grunefx,
+[data-tier='bajo'] .jaguar-lado-aura { animation: none; }
 
 
 /* ═══════════════════════════════════════════════════════════════════════════

--- a/src/visual/mundo3d/fauna/JaguarBillboard.jsx
+++ b/src/visual/mundo3d/fauna/JaguarBillboard.jsx
@@ -104,6 +104,12 @@ export default function JaguarBillboard({
      omóplatos y baja la testa. Un data-attr en el wrapper no lo lograría: el
      CSS de creatures lee `[data-acecha]` en la RAÍZ del SVG, no en el padre. */
   const [acechando, setAcechando] = useState(false);
+  /* La MARCHA va por estado por la misma razón: cambia cada varios segundos.
+     Mientras el felino SE DESPLAZA (fases anda/acecha) el SVG recibe
+     pose='camina' — el rig de PERFIL con ciclo de patas real (sin esto el
+     billboard PATINA: se traslada con las patas quietas, el bug que reportó
+     el operador). Parado a observar vuelve al frontal majestuoso ('anda'). */
+  const [andando, setAndando] = useState(true);
 
   const yDe = (x, z) => (typeof suelo === 'function' ? suelo(x, z) : suelo);
 
@@ -130,7 +136,7 @@ export default function JaguarBillboard({
       px: inicio.x, pz: inicio.z,
       esp: 1, espT: 1,        // espejo (scaleX) suavizado
       proxAcecho: azar(26, 55),
-      lastTf: '', dataAcecha: false,
+      lastTf: '', dataAcecha: false, dataAnda: true,
       init: false,
     };
   }
@@ -205,6 +211,12 @@ export default function JaguarBillboard({
       s.dataAcecha = enAcecho;
       setAcechando(enAcecho);
     }
+    // ¿se está DESPLAZANDO? → marcha de perfil; ¿parado a observar? → frontal
+    const enMarcha = s.fase !== 'observa';
+    if (enMarcha !== s.dataAnda) {
+      s.dataAnda = enMarcha;
+      setAndando(enMarcha);
+    }
 
     /* ── SOMBRA DE CONTACTO pegada a las zarpas ────────────────────────────── */
     if (sombra.current) {
@@ -221,6 +233,7 @@ export default function JaguarBillboard({
           <div ref={capa} aria-hidden="true" data-vecino="jaguar" style={ESTILO_JAGUAR}>
             <Jaguar
               size={px}
+              pose={andando && animated ? 'camina' : 'anda'}
               animated={animated}
               tier={tier}
               clima={clima}


### PR DESCRIPTION
## El bug
Reporte del operador: *"el jaguar que se ve en el valle guatoc NO CAMINA, se ve rarísimo"*. `JaguarBillboard` desplazaba el SVG frontal por el terreno en pose `anda` — sin ciclo de patas: **patinaba**.

## El fix — dos movimientos distintos
1. **Dentro de escena: CAMINA.** Nueva pose opt-in `camina`: rig **lateral** `.jaguar-lado` en `Jaguar.jsx` con ciclo de marcha de cuadrúpedo real (4 patas en secuencia lateral, diagonales casi juntas, T=1.05s paso pesado), bóveda del paso, omóplato que rueda, cola baja de contrapeso, cabeza en contratiempo y **gruñido periódico** (fauces + colmillos + testa que baja, ciclo 6.3s co-primo con el paso). Silueta fiel al DR de *Panthera onca*: cuerpo compacto y profundo, patas cortas y gruesas, cola corta llevada baja con anillos y punta negra, testa maciza baja, **pupila redonda** de gran felino, rosetas anillo-roto espaciadas con puntos internos (`<Roseta/>`, la regla de oro anti-leopardo). Capa mística del DR chamánico: aura, noche estrellada sobre el pelaje, glifo cobre, bruma, motas.
2. **Entre mundos: NO camina — se aparece.** El traslado místico (`aparicion`/`revelacion`/invocación con mandala + estrellas) queda intacto; la marcha jamás lo pisa.

`JaguarBillboard` pasa `camina` solo mientras se desplaza (fases anda/acecha) y vuelve al frontal majestuoso al pararse a observar. Espejo por rumbo ya existente (scaleX). Gates reduced-motion / tier bajo: fotograma digno a media zancada.

## Espejo en demos-src
El mismo rig vive en `valle-guatoc` (blob `guias-arte.js` generado desde `jaguar-guia`): commits `3c6cbe8` + `31cb1f5`, desplegado en valle-guatoc.guatoc.co (verificado en vivo, +30% de tamaño pedido por el operador).

## Gate visual (GPU real — AMD Vega 10 radeonsi, no SwiftShader)
Secuencias en `Workspace/capturas-valle/`:
- `20260725-JAGUAR-ANTES-f*.png` — el patinaje original
- `20260725-JAGUAR-LADO-V4-f*.png` — ciclo de marcha del rig (cuadros)
- `20260725-JAGUAR-VIVO-MARCHA-f*.png` — caminando EN VIVO en el valle
- `20260725-JAGUAR-CHAGRA-f*.png` — caminando en el claro de chagra (esta rama)
- `20260725-JAGUAR-INVOCACION-f*.png` — la aparición mística (intacta)

Tests: `Jaguar.render.test.jsx` 23/23 verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)