### PR TITLE
fix(compai): el compAI elegido aparece en toda la app (+ zarigüeya como 3ra opción)

### DIFF
--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import Angelita from '../visual/agente/Angelita';
+import ChagraAgentAvatar from './ChagraAgentAvatar';
 import useAgentNotificationStore from '../store/useAgentNotificationStore';
 import usePrefsStore from '../store/usePrefsStore';
 import { isSpeaking, stop, replayLast, isKokoroAvailable } from '../services/ttsService';
@@ -16,13 +16,15 @@ import { notificacionesInteligentes } from '../services/angelitaInteligencia';
 import './agent-fab-skin.css';
 
 /**
- * AgentFab — Angelita, el agente vivo presente en TODA pantalla.
+ * AgentFab — el compAI elegido por el usuario, vivo, presente en TODA pantalla.
  *
  * Decisión del operador (2026-07-16): "Angelita como el agente, jubila el
- * colibrí". El FAB deja de ser un porthole con foto de colibrí: es Angelita
- * volando libre en la esquina — compañía, no interrupción. El colibrí
- * (barbudito) se retira del rol de asistente y queda de decoración en los
- * mundos 3D (faunaFuncional, rol polinizador).
+ * colibrí". El FAB deja de ser un porthole con foto de colibrí: es el compAI
+ * elegido (Angelita por defecto, o la planta de maíz si el usuario la
+ * escogió — `useAgentAvatarType`, ver fix 2026-07-25) volando/creciendo libre
+ * en la esquina — compañía, no interrupción. El colibrí (barbudito) se retira
+ * del rol de asistente y queda de decoración en los mundos 3D (faunaFuncional,
+ * rol polinizador).
  *
  * Sus tres momentos (rubber-hose, angelitaEstados.js):
  *   - default        → 'acompana': idle-cerebro vivo (flota, se acicala, se
@@ -122,11 +124,11 @@ export default function AgentFab({ onNavigate, pantalla = null }) {
     <button
       type="button"
       className={fvhSkinClass(`chagra-fab${hover ? ' is-hover' : ''}${responseReady ? ' is-ready' : ''}`)}
-      aria-label={responseReady ? 'Angelita (Chagra IA) tiene respuesta nueva' : 'Angelita, la asistente Chagra IA'}
+      aria-label={responseReady ? 'Chagra IA tiene respuesta nueva' : 'Chagra IA, su compañero de Chagra'}
       title={
         responseReady
-          ? 'Angelita tiene respuesta nueva. Doble click silencia o reactiva la voz'
-          : 'Hablar con Angelita. Doble click silencia o reactiva la voz'
+          ? 'Chagra IA tiene respuesta nueva. Doble click silencia o reactiva la voz'
+          : 'Hablar con Chagra IA. Doble click silencia o reactiva la voz'
       }
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
@@ -166,17 +168,21 @@ export default function AgentFab({ onNavigate, pantalla = null }) {
       }}
     >
       {/* pointer-events:none — CRÍTICO: el click debe caer en el BOTÓN, nunca
-          en el SVG. Angelita se REMONTA al cambiar de estado (key=estado en su
-          .agt-vuelo) y hover/pressed cambian el estado: si el mousedown cae en
-          un nodo del dibujo que se desconecta antes del mouseup, el navegador
-          se traga el click (verificado con playwright 2026-07-16). */}
+          en el SVG. Angelita (o el maíz) se REMONTA al cambiar de estado
+          (key=estado en su .agt-vuelo) y hover/pressed cambian el estado: si
+          el mousedown cae en un nodo del dibujo que se desconecta antes del
+          mouseup, el navegador se traga el click (verificado con playwright
+          2026-07-16). `estado` viaja en el vocabulario RICO de Angelita —
+          ChagraAgentAvatar lo traduce si el usuario eligió maíz (fix
+          2026-07-25: antes este FAB ignoraba la elección por completo). */}
       <span style={{ pointerEvents: 'none', display: 'flex' }} aria-hidden="true">
-        <Angelita
+        <ChagraAgentAvatar
           estado={estado}
           size={82}
           direccion="izquierda"
           className={responseReady ? 'agt-avatar-glow' : undefined}
-          title="Angelita, la asistente de Chagra"
+          title="Chagra IA"
+          ariaLabel="Chagra IA"
         />
       </span>
     </button>

--- a/src/components/BienvenidaFinca.jsx
+++ b/src/components/BienvenidaFinca.jsx
@@ -3,7 +3,7 @@
    exportarse junto al componente (mismo patrón que NotifPermissionPrompt). */
 import React, { useEffect, useRef, useState } from 'react';
 import { Mic, Camera, BadgeCheck, MapPin, ArrowRight, Volume2, Sparkles, Glasses, Share, Download, WifiOff, Save, Smartphone, Check } from 'lucide-react';
-import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
+import ChagraAgentAvatar from './ChagraAgentAvatar';
 import usePwaInstall from '../hooks/usePwaInstall';
 import { MSG } from '../config/messages.js';
 
@@ -13,8 +13,10 @@ import { MSG } from '../config/messages.js';
  * Secuencia de 5 "momentos" a pantalla completa, pensada para que en ~40
  * segundos el campesino sienta "esto es MÍO y me entiende":
  *
- *   1. Bienvenida — el colibrí del abutilón (avatar del agente) saluda con la
- *      identidad cuaderno-de-campo / finca viva. Nada de wizard corporativo.
+ *   1. Bienvenida — el compAI elegido (Angelita la abeja por defecto, fix
+ *      2026-07-25: antes SIEMPRE el colibrí, jubilado como cara del agente
+ *      desde 2026-07-18) saluda con la identidad cuaderno-de-campo / finca
+ *      viva. Nada de wizard corporativo.
  *   2. Capacidades estrella — hablarle por voz, mostrarle una foto de la mata,
  *      y respuestas verificadas (LA COSTURA: la tarjeta lleva el borde cosido).
  *   3. "Hola Chagra" (modo campo, manos ocupadas) — foto real de manos en la
@@ -260,7 +262,7 @@ export default function BienvenidaFinca({ onUbicar, onClose, onExplorarEjemplo =
         {paso === 0 && (
           <>
             <div className="bienvenida-item bienvenida-flotar" style={{ '--bv-delay': '0ms' }}>
-              <ChagraAgentAvatarAngelita size={188} state="idle" ariaLabel="Angelita, la abeja de Chagra" />
+              <ChagraAgentAvatar size={188} state="idle" ariaLabel="Chagra IA" />
             </div>
             <div className="bienvenida-item flex flex-col gap-3" style={{ '--bv-delay': '120ms' }}>
               <p className="text-xs font-bold uppercase tracking-[0.2em] text-emerald-400">

--- a/src/components/ChagraAgentAvatar.jsx
+++ b/src/components/ChagraAgentAvatar.jsx
@@ -1,5 +1,6 @@
 import ChagraAgentAvatarMaiz from './ChagraAgentAvatarMaiz';
 import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
+import Angelita from '../visual/agente/Angelita';
 import useAgentAvatarType from '../hooks/useAgentAvatarType';
 
 /**
@@ -22,9 +23,37 @@ import useAgentAvatarType from '../hooks/useAgentAvatarType';
  * Mismas props que los avatares hijos: state, size, withLabel, onClick,
  * onDoubleClick, glow, className, ariaLabel (+ visema/confianza que
  * Angelita entiende y el maíz ignora).
+ *
+ * API "rica" (fix 2026-07-25 — bug: varios call-sites que necesitaban el
+ * vocabulario Spanish completo de Angelita, `angelitaEstados.js` —p.ej.
+ * 'contenta', 'invita', 'acompana'— importaban `<Angelita>` CRUDO, sin pasar
+ * por este dispatcher, así que ignoraban la elección del usuario (AgentFab,
+ * AgentHero, FincaVivaHero, ColibriTransition). Se acepta ahora una prop
+ * alterna `estado` (en vez de `state`) para esos call-sites: si type==='maiz'
+ * se traduce al vocabulario angosto que el maíz entiende; si es Angelita, pasa
+ * directo sin perder fidelidad.
  */
-export default function ChagraAgentAvatar(props) {
+const STATE_DE_ESTADO_RICO = {
+    acompana: 'idle',
+    escuchando: 'listening',
+    pensando: 'thinking',
+    respondiendo: 'speaking',
+    contenta: 'speaking',
+    invita: 'speaking',
+};
+
+export default function ChagraAgentAvatar({ estado, ...props }) {
     const [type] = useAgentAvatarType();
+
+    if (estado !== undefined) {
+        // Call-site "rico": solo Angelita entiende el vocabulario completo;
+        // el maíz recibe la traducción angosta (idle/thinking/speaking/listening).
+        if (type === 'maiz') {
+            return <ChagraAgentAvatarMaiz state={STATE_DE_ESTADO_RICO[estado] || 'idle'} {...props} />;
+        }
+        return <Angelita estado={estado} {...props} />;
+    }
+
     if (type === 'maiz') return <ChagraAgentAvatarMaiz {...props} />;
     // default → Angelita, el agente de Chagra.
     return <ChagraAgentAvatarAngelita {...props} />;

--- a/src/components/ChagraAgentAvatar.jsx
+++ b/src/components/ChagraAgentAvatar.jsx
@@ -1,5 +1,6 @@
 import ChagraAgentAvatarMaiz from './ChagraAgentAvatarMaiz';
 import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
+import ChagraAgentAvatarZariguya from './ChagraAgentAvatarZariguya';
 import Angelita from '../visual/agente/Angelita';
 import useAgentAvatarType from '../hooks/useAgentAvatarType';
 
@@ -29,9 +30,13 @@ import useAgentAvatarType from '../hooks/useAgentAvatarType';
  * 'contenta', 'invita', 'acompana'— importaban `<Angelita>` CRUDO, sin pasar
  * por este dispatcher, así que ignoraban la elección del usuario (AgentFab,
  * AgentHero, FincaVivaHero, ColibriTransition). Se acepta ahora una prop
- * alterna `estado` (en vez de `state`) para esos call-sites: si type==='maiz'
- * se traduce al vocabulario angosto que el maíz entiende; si es Angelita, pasa
+ * alterna `estado` (en vez de `state`) para esos call-sites: si el tipo
+ * elegido no es Angelita, se traduce al vocabulario angosto (idle/thinking/
+ * speaking/listening) que maíz y zarigüeya entienden; si es Angelita, pasa
  * directo sin perder fidelidad.
+ *
+ * 3ra opción (2026-07-25): 'zariguya' — la zarigüeya (crías al lomo, PR
+ * #2783), adaptador en ChagraAgentAvatarZariguya.jsx.
  */
 const STATE_DE_ESTADO_RICO = {
     acompana: 'idle',
@@ -42,19 +47,26 @@ const STATE_DE_ESTADO_RICO = {
     invita: 'speaking',
 };
 
+const AVATAR_ANGOSTO = {
+    maiz: ChagraAgentAvatarMaiz,
+    zariguya: ChagraAgentAvatarZariguya,
+};
+
 export default function ChagraAgentAvatar({ estado, ...props }) {
     const [type] = useAgentAvatarType();
+    const ComponenteAngosto = AVATAR_ANGOSTO[type];
 
     if (estado !== undefined) {
         // Call-site "rico": solo Angelita entiende el vocabulario completo;
-        // el maíz recibe la traducción angosta (idle/thinking/speaking/listening).
-        if (type === 'maiz') {
-            return <ChagraAgentAvatarMaiz state={STATE_DE_ESTADO_RICO[estado] || 'idle'} {...props} />;
+        // maíz/zarigüeya reciben la traducción angosta (idle/thinking/
+        // speaking/listening).
+        if (ComponenteAngosto) {
+            return <ComponenteAngosto state={STATE_DE_ESTADO_RICO[estado] || 'idle'} {...props} />;
         }
         return <Angelita estado={estado} {...props} />;
     }
 
-    if (type === 'maiz') return <ChagraAgentAvatarMaiz {...props} />;
+    if (ComponenteAngosto) return <ComponenteAngosto {...props} />;
     // default → Angelita, el agente de Chagra.
     return <ChagraAgentAvatarAngelita {...props} />;
 }

--- a/src/components/ChagraAgentAvatarZariguya.jsx
+++ b/src/components/ChagraAgentAvatarZariguya.jsx
@@ -1,0 +1,97 @@
+import Zariguya from '../visual/creatures/Zariguya';
+
+/**
+ * ChagraAgentAvatarZariguya — la zarigüeya (crías al lomo) como CARA del
+ * agente de Chagra, 3ra opción junto a Angelita y el maíz (operador
+ * 2026-07-25, tras el merge de `art(creatures): la zarigüeya entra al elenco
+ * — con las crías al lomo (#2783)`).
+ *
+ * Adaptador puro (mismo contrato que ChagraAgentAvatarAngelita/Maiz): traduce
+ * la API histórica del avatar del agente (state 'idle'|'thinking'|'speaking'|
+ * 'listening', glow, withLabel, onClick/onDoubleClick) al vocabulario de VIDA
+ * de `Zariguya.jsx` (`visual/creatures/`) — el registro rubber-hose CÁLIDO
+ * del elenco canónico. OJO: existe otra zarigüeya en
+ * `dashboard/CriaturasNocturnas.jsx`, biopunk oscuro/neón — esa NO se usa acá
+ * (mezclar registros es un error de diseño ya señalado). Cero lógica nueva de
+ * agente, cero cambios en `visual/creatures/` (solo lectura/import, igual que
+ * el resto de adaptadores de este archivo con Angelita).
+ *
+ * La zarigüeya no tiene vocabulario conversacional propio (es una criatura de
+ * VIDA — pose/husmea/tanatosis — no un chat-avatar como Angelita): el mapeo
+ * es de mejor esfuerzo:
+ *   - idle       → pose 'anda' (base, viva pero sin urgencia).
+ *   - thinking   → pose 'anda' + `husmea=true`: su reacción-firma (la cuña
+ *                  del hocico se alza y tantea) leída como "buscando/pensando".
+ *   - speaking   → pose 'celebra' (la más expresiva) + visema del lip-sync
+ *                  sobre su sonrisa.
+ *   - listening  → pose 'reposo': se posa erguida y atenta.
+ */
+const POSE_DE_STATE = {
+    idle: 'anda',
+    thinking: 'anda',
+    speaking: 'celebra',
+    listening: 'reposo',
+};
+
+const HUSMEA_DE_STATE = {
+    thinking: true,
+};
+
+// eslint-disable-next-line chagra-i18n/no-hardcoded-spanish
+const VISEMA_DE_STATE = {
+    speaking: 'V2',
+};
+
+export default function ChagraAgentAvatarZariguya({
+    state = 'idle',
+    size = 48,
+    withLabel = false,
+    onClick = undefined,
+    onDoubleClick = undefined,
+    glow = false,
+    className = '',
+    ariaLabel = 'Chagra IA',
+}) {
+    const pose = POSE_DE_STATE[state] || 'anda';
+    const husmea = !!HUSMEA_DE_STATE[state];
+    const visema = VISEMA_DE_STATE[state] || null;
+
+    const bicho = (
+        <Zariguya
+            pose={pose}
+            husmea={husmea}
+            visema={visema}
+            size={size}
+            title={ariaLabel}
+            className={className}
+            style={glow ? { filter: 'drop-shadow(0 0 10px rgba(255,158,203,0.65))' } : undefined}
+        />
+    );
+
+    const contenido = withLabel ? (
+        <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+            {bicho}
+            <span style={{ font: '600 0.7rem/1 system-ui, sans-serif', color: '#94a3b8' }}>
+                Zarigüeya
+            </span>
+        </span>
+    ) : bicho;
+
+    // Paridad con los avatares hermanos: con handlers, botón real (teclado +
+    // lector de pantalla); sin handlers, solo el dibujo.
+    if (onClick || onDoubleClick) {
+        return (
+            <button
+                type="button"
+                onClick={onClick}
+                onDoubleClick={onDoubleClick}
+                aria-label={ariaLabel}
+                title={ariaLabel}
+                style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', lineHeight: 0 }}
+            >
+                {contenido}
+            </button>
+        );
+    }
+    return contenido;
+}

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -6,7 +6,7 @@ import { setCurrentOperator } from '../services/operatorIdentityService';
 import { setActiveTenantId } from '../services/tenantContext';
 import { version as APP_VERSION } from '../../package.json';
 import ChagraGrowLoader from './ChagraGrowLoader';
-import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
+import ChagraAgentAvatar from './ChagraAgentAvatar';
 import LegalLinks from './LegalLinks';
 import WelcomeStatsHero from './WelcomeStatsHero';
 import useOllamaWarmStore from '../store/useOllamaWarmStore';
@@ -186,7 +186,10 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
 
       <main className="relative z-10 w-full max-w-md flex flex-col items-center gap-7 animate-fadeIn">
         {/* ─────────────────────────────────────────────────────────────
-            MARCA — el Colibrí Barbudito (avatar botánico de Chagra IA)
+            MARCA — el compAI que el usuario eligió (ChagraAgentAvatar lee
+            `chagra:agent-avatar-type`; Angelita la abeja por defecto, o su
+            planta de maíz si la escogió en Perfil — fix 2026-07-25: antes
+            este header ignoraba la elección e importaba a Angelita directo)
             posado en un orbe neón. Personaje adulto y elegante, no mascota;
             reemplaza el ícono genérico anterior por el rostro de la marca.
             ───────────────────────────────────────────────────────────── */}
@@ -196,10 +199,10 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
               aria-hidden="true"
               className="absolute inset-0 rounded-full ring-1 ring-muzo/20 animate-pulse"
             />
-            <ChagraAgentAvatarAngelita
+            <ChagraAgentAvatar
               state="idle"
               size={108}
-              ariaLabel="Angelita, la abeja de Chagra"
+              ariaLabel="Chagra IA"
             />
           </div>
 

--- a/src/components/OnboardingCondensado.jsx
+++ b/src/components/OnboardingCondensado.jsx
@@ -13,7 +13,8 @@ import {
   AlertCircle,
   SkipForward,
 } from 'lucide-react';
-import ChagraAgentAvatarAngelita from './ChagraAgentAvatarAngelita';
+import ChagraAgentAvatar from './ChagraAgentAvatar';
+import useAgentAvatarType, { AVATAR_NOMBRE, DEFAULT_AVATAR_TYPE } from '../hooks/useAgentAvatarType';
 import AvatarSelector from './Settings/AvatarSelector';
 import { useGeolocation } from '../hooks/useGeolocation';
 import {
@@ -65,9 +66,11 @@ import usePerfilFincaStore from '../store/usePerfilFincaStore';
  * la ubicación GUARDADA del perfil).
  *
  * Visual: tokens de tema existentes (onboarding-piso-primary/secondary,
- * bienvenida-costura como progreso), colibrí como guía, botón "Escuchar"
- * (TTS perezoso), tarjetas grandes con emoji (baja alfabetización), avance
- * automático en elección única. Español colombiano (usted, SIN voseo).
+ * bienvenida-costura como progreso), el compAI elegido como guía (fix
+ * 2026-07-25: antes decía "colibrí", jubilado como cara del agente desde
+ * 2026-07-18), botón "Escuchar" (TTS perezoso), tarjetas grandes con emoji
+ * (baja alfabetización), avance automático en elección única. Español
+ * colombiano (usted, SIN voseo).
  *
  * Props:
  *   - onComplete(profile): al terminar o saltar todo.
@@ -352,6 +355,11 @@ export default function OnboardingCondensado({
 }) {
   const [paso, setPaso] = useState(0);
   const [sembrando, setSembrando] = useState(false);
+  // El compAI que el usuario ya eligió (o Angelita por defecto, ver
+  // useAgentAvatarType) — fix 2026-07-25: antes esta pantalla mostraba
+  // Angelita SIEMPRE, sin importar la elección, y despedía al usuario
+  // nombrando al colibrí jubilado.
+  const [avatarType] = useAgentAvatarType();
   // Marca de inicio para onboarding_tiempo_segundos (regla react: nada impuro
   // en render — se fija una sola vez al montar).
   const startedAtRef = useRef(null);
@@ -667,7 +675,7 @@ export default function OnboardingCondensado({
           <>
             <div className="flex items-center gap-4">
               <div className="shrink-0">
-                <ChagraAgentAvatarAngelita size={96} state="idle" ariaLabel="Angelita, la abeja de Chagra" />
+                <ChagraAgentAvatar size={96} state="idle" ariaLabel="Chagra IA" />
               </div>
               <div className="min-w-0">
                 <h1 className="text-2xl font-black leading-tight text-slate-100">
@@ -1159,7 +1167,7 @@ export default function OnboardingCondensado({
         {/* ═══ LISTO ═══ */}
         {paso === 6 && (
           <div className="flex-1 flex flex-col items-center justify-center text-center gap-5">
-            <ChagraAgentAvatarAngelita size={168} state="speaking" ariaLabel="Angelita, la abeja de Chagra" />
+            <ChagraAgentAvatar size={168} state="speaking" ariaLabel="Chagra IA" />
             <div className="flex flex-col gap-2">
               <h1 className="text-3xl font-black leading-tight text-slate-100">
                 Su finca está lista 🌱
@@ -1169,7 +1177,7 @@ export default function OnboardingCondensado({
                 {pisoInfo ? ` · clima ${pisoInfo.label.toLowerCase()}` : ''}
               </p>
               <p className="text-sm text-slate-400">
-                Ahora háblele al colibrí: «Hola Chagra, ¿cuándo abono el café?»
+                Ahora háblele a {AVATAR_NOMBRE[avatarType] || AVATAR_NOMBRE[DEFAULT_AVATAR_TYPE]}: «Hola Chagra, ¿cuándo abono el café?»
               </p>
             </div>
           </div>

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -1110,7 +1110,9 @@ export default function ProfileScreen({ onBack, onHome }) {
  *
  * Toggle "Voz del agente activa" persistido en usePrefsStore (key
  * `chagra:prefs:tts-enabled`). Al desactivar, stop() inmediato del
- * ttsService. Equivalente al doble-click del avatar colibrí.
+ * ttsService. Equivalente al doble-click del avatar del agente (Angelita
+ * por defecto, o el que el usuario haya elegido — fix 2026-07-25: el copy
+ * de abajo decía "colibrí", jubilado como cara del agente desde 2026-07-18).
  */
 function AgentVoiceSection() {
   const ttsEnabled = usePrefsStore((s) => s.ttsEnabled);
@@ -1137,7 +1139,7 @@ function AgentVoiceSection() {
           <span className="text-sm font-bold text-slate-200">Voz del agente activa</span>
           <span className="text-xs text-slate-400 leading-snug">
             Cuando está activa, Chagra IA lee en voz alta sus respuestas con una
-            sola voz natural. Doble click en el avatar colibrí silencia o
+            sola voz natural. Doble click en el avatar del agente silencia o
             reactiva sin abrir esta pantalla.
           </span>
         </div>

--- a/src/components/Settings/AgentAvatarSelector.jsx
+++ b/src/components/Settings/AgentAvatarSelector.jsx
@@ -2,18 +2,24 @@ import { Check } from 'lucide-react';
 import useAgentAvatarType from '../../hooks/useAgentAvatarType';
 import ChagraAgentAvatarAngelita from '../ChagraAgentAvatarAngelita';
 import ChagraAgentAvatarMaiz from '../ChagraAgentAvatarMaiz';
+import ChagraAgentAvatarZariguya from '../ChagraAgentAvatarZariguya';
 
 /**
  * AgentAvatarSelector — selector visual para el avatar del agente IA.
  *
- * 2 opciones: Angelita la abeja (default) o planta de maíz. Persiste vía
- * useAgentAvatarType (localStorage `chagra:agent-avatar-type`). Cambio
- * inmediato — afecta a todas las instancias del avatar en la app.
+ * 3 opciones: Angelita la abeja (default), planta de maíz, o la zarigüeya
+ * (crías al lomo). Persiste vía useAgentAvatarType (localStorage
+ * `chagra:agent-avatar-type`). Cambio inmediato — afecta a todas las
+ * instancias del avatar en la app (FAB, login, chat, onboarding — ver
+ * ChagraAgentAvatar.jsx, el dispatcher del que dependen).
  *
  * 2026-07-16 (operador): "Angelita como el agente, jubila el colibrí".
  * 2026-07-18 (operador): el colibrí sale también de las opciones — "solo
  * abejita". Los slugs viejos 'colibri'/'colibri_svg' migran a 'angelita'
  * en el hook, sin acción del usuario.
+ * 2026-07-25 (operador): 3ra opción, la zarigüeya (PR #2783, registro
+ * rubber-hose cálido de `visual/creatures/Zariguya.jsx` — NO la zarigüeya
+ * oscura/neón de `dashboard/CriaturasNocturnas.jsx`).
  */
 export default function AgentAvatarSelector() {
     const [type, setType] = useAgentAvatarType();
@@ -31,6 +37,12 @@ export default function AgentAvatarSelector() {
             sub: 'Cultivo ancestral originario',
             Component: ChagraAgentAvatarMaiz,
         },
+        {
+            id: 'zariguya',
+            label: 'Zarigüeya',
+            sub: 'La que carga a sus crías al lomo',
+            Component: ChagraAgentAvatarZariguya,
+        },
     ];
 
     return (
@@ -41,7 +53,7 @@ export default function AgentAvatarSelector() {
                     Elige cómo se ve la IA en la app. Cambio inmediato.
                 </p>
             </div>
-            <div className="grid grid-cols-2 gap-2.5">
+            <div className="grid grid-cols-3 gap-2">
                 {OPTIONS.map((opt) => {
                     const selected = type === opt.id;
                     return (
@@ -50,18 +62,18 @@ export default function AgentAvatarSelector() {
                             type="button"
                             onClick={() => setType(opt.id)}
                             aria-pressed={selected}
-                            className={`relative flex flex-col items-center gap-2 px-2 py-4 rounded-xl border-2 transition-all active:scale-95 ${
+                            className={`relative flex flex-col items-center gap-1.5 px-1.5 py-3 rounded-xl border-2 transition-all active:scale-95 ${
                                 selected
                                     ? 'border-emerald-500 bg-emerald-900/20 ring-2 ring-emerald-500/40'
                                     : 'border-slate-700 bg-slate-900 hover:border-slate-600'
                             }`}
                         >
                             {selected && (
-                                <span className="absolute top-2 right-2 inline-flex items-center justify-center w-5 h-5 rounded-full bg-emerald-500 text-white">
+                                <span className="absolute top-1.5 right-1.5 inline-flex items-center justify-center w-5 h-5 rounded-full bg-emerald-500 text-white">
                                     <Check size={12} strokeWidth={3} aria-hidden="true" />
                                 </span>
                             )}
-                            <opt.Component state={selected ? 'thinking' : 'idle'} size={84} onDoubleClick={() => {}} ariaLabel={opt.label} />
+                            <opt.Component state={selected ? 'thinking' : 'idle'} size={64} onDoubleClick={() => {}} ariaLabel={opt.label} />
                             <div className="text-center">
                                 <p className="text-xs sm:text-sm font-bold text-slate-100 leading-tight">{opt.label}</p>
                                 <p className="text-[10px] text-slate-500 mt-0.5 leading-tight">{opt.sub}</p>

--- a/src/components/Settings/__tests__/AgentAvatarSelector.smoke.test.jsx
+++ b/src/components/Settings/__tests__/AgentAvatarSelector.smoke.test.jsx
@@ -7,11 +7,29 @@ describe('AgentAvatarSelector smoke', () => {
         localStorage.clear();
     });
 
-    it('renderiza 2 opciones: angelita + maiz (el colibrí jubiló)', () => {
+    it('renderiza 3 opciones: angelita + maiz + zarigüeya (el colibrí jubiló)', () => {
         render(<AgentAvatarSelector />);
         expect(screen.getByText('Angelita, la abeja', { selector: 'p' })).toBeInTheDocument();
         expect(screen.getByText('Planta de maíz')).toBeInTheDocument();
+        expect(screen.getByText('Zarigüeya', { selector: 'p' })).toBeInTheDocument();
         expect(screen.queryByText(/colibrí/i)).toBeNull();
+    });
+
+    it('click en zarigüeya cambia la preferencia y persiste en localStorage', () => {
+        render(<AgentAvatarSelector />);
+        const zariguyaBtn = screen.getByText('Zarigüeya', { selector: 'p' }).closest('button');
+        fireEvent.click(zariguyaBtn);
+        expect(zariguyaBtn).toHaveAttribute('aria-pressed', 'true');
+        expect(localStorage.getItem('chagra:agent-avatar-type')).toBe('zariguya');
+        const angelitaBtn = screen.getByText('Angelita, la abeja', { selector: 'p' }).closest('button');
+        expect(angelitaBtn).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('localStorage zariguya preselecciona zarigüeya al montar', () => {
+        localStorage.setItem('chagra:agent-avatar-type', 'zariguya');
+        render(<AgentAvatarSelector />);
+        const zariguyaBtn = screen.getByText('Zarigüeya', { selector: 'p' }).closest('button');
+        expect(zariguyaBtn).toHaveAttribute('aria-pressed', 'true');
     });
 
     it('angelita seleccionada por default', () => {

--- a/src/components/agent/ColibriTransition.jsx
+++ b/src/components/agent/ColibriTransition.jsx
@@ -1,18 +1,22 @@
 import { useEffect, useRef, useState } from 'react';
-import Angelita from '../../visual/agente/Angelita';
+import ChagraAgentAvatar from '../ChagraAgentAvatar';
+import useAgentAvatarType, { AVATAR_NOMBRE, DEFAULT_AVATAR_TYPE } from '../../hooks/useAgentAvatarType';
 
 /**
- * Transición home → conversación (~2s): ANGELITA, la abeja agente.
+ * Transición home → conversación (~2s): el compAI que el usuario eligió.
  *
  * Al enviar desde el hero del home, en vez de un corte seco hacia AgentScreen,
- * Angelita aparece a pantalla completa sobre un fondo oscuro suave — grande,
+ * el compAI aparece a pantalla completa sobre un fondo oscuro suave — grande,
  * invitándolo a la conversación ('invita': se inclina y hace "venga" con la
  * manita) — y el overlay se desvanece dejando la conversación montada detrás.
  *
  * 2026-07-18 (operador): "solo abejita". Este overlay mostraba el VIDEO del
  * colibrí (webm foto-realista) como cara del agente; el colibrí queda jubilado
  * del rol de asistente (fauna decorativa en los mundos 3D, nada más) y la
- * transición pasa a ser Angelita — la misma del FAB, el chat y el hero.
+ * transición pasa a ser Angelita por defecto — la misma del FAB, el chat y el
+ * hero — o la planta de maíz si el usuario la eligió (fix 2026-07-25: antes
+ * este overlay mostraba a Angelita SIEMPRE, ignorando la elección, incluido
+ * el rótulo de texto con su nombre).
  * El archivo conserva su nombre para no mover imports; el componente exportado
  * mantiene el contrato de siempre.
  *
@@ -79,6 +83,8 @@ const CSS = `
 function AngelitaOverlay({ onDone }) {
   const [leaving, setLeaving] = useState(false);
   const doneRef = useRef(null);
+  const [avatarType] = useAgentAvatarType();
+  const nombreAgente = AVATAR_NOMBRE[avatarType] || AVATAR_NOMBRE[DEFAULT_AVATAR_TYPE];
 
   // ref-latest del callback fuera de render (react-hooks/refs).
   useEffect(() => { doneRef.current = onDone; });

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -21,7 +21,6 @@ import { buildCropSuggestions } from '../../data/cropSuggestions';
 import { syncManager } from '../../services/syncManager';
 import { iconForTheme } from './themeIcon';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
-import Angelita from '../../visual/agente/Angelita';
 import { lunarPhase, solarTimes, moonPathD } from '../../utils/skyEphemeris';
 import { resolveClimaLocation, getCachedClimaSnapshot } from '../../services/climaService';
 import {
@@ -1698,12 +1697,14 @@ export default function AgentHero({ onNavigate }) {
                     <div className="agentport-horizon" />
                 </div>
 
-                {/* — ANGELITA — la abeja agente vuela en bio-punk y nature
-                     ("solo abejita", operador 2026-07-18: el colibrí jubiló).
-                     En minimalista se oculta vía CSS: el demo limpio no lleva
-                     fauna. — */}
+                {/* — EL COMPAI ELEGIDO — Angelita la abeja por defecto, o el
+                     maíz si el usuario lo escogió (fix 2026-07-25: antes
+                     Angelita SIEMPRE, ignorando la elección). Vuela/crece en
+                     bio-punk y nature ("solo abejita", operador 2026-07-18:
+                     el colibrí jubiló). En minimalista se oculta vía CSS: el
+                     demo limpio no lleva fauna. — */}
                 <div className="agentport-hummer">
-                    <Angelita estado="acompana" size={68} title="Angelita acompaña la portada" />
+                    <ChagraAgentAvatar estado="acompana" size={68} title="Chagra IA" ariaLabel="Chagra IA" />
                 </div>
             </div>
 

--- a/src/components/dashboard/FincaVivaHero.jsx
+++ b/src/components/dashboard/FincaVivaHero.jsx
@@ -23,7 +23,7 @@ import { useTheme, resolveAutoTheme } from '../../hooks/useTheme';
 import { iconForTheme } from './themeIcon';
 import { colibriRealActivo } from '../../config/colibriFlag';
 import { BarbuditoIlustrado, BarbuditoRealLoop } from '../colibri/Barbudito';
-import Angelita from '../../visual/agente/Angelita';
+import ChagraAgentAvatar from '../ChagraAgentAvatar';
 // Campana de notificaciones en el header F2 (regresión 2026-07-04): con la flag
 // F2 ON el TopBar legacy (que la montaba) NO se renderiza, así que el home se
 // quedó sin campana. `variant="f2"` es la misma píldora redonda que ya usa
@@ -645,7 +645,7 @@ export default function FincaVivaHero({ onNavigate, onOpenAgent, onGestionar, on
                       </>
                     ) : (
                       <span className="fvh-bicho fvh-colibri-vuela" style={{ left: '60%', top: '14%' }}>
-                        <Angelita estado="acompana" size={72} title="Angelita acompaña la finca" />
+                        <ChagraAgentAvatar estado="acompana" size={72} title="Chagra IA" ariaLabel="Chagra IA" />
                       </span>
                     )}
                     {poblada && (

--- a/src/hooks/useAgentAvatarType.js
+++ b/src/hooks/useAgentAvatarType.js
@@ -9,7 +9,11 @@ const STORAGE_KEY = 'chagra:agent-avatar-type';
 // nunca como cara del agente.
 //
 // 'maiz' = planta de maíz, alternativa cultural ancestral.
-export const AVATAR_TYPES = ['angelita', 'maiz'];
+//
+// 'zariguya' = la zarigüeya (crías al lomo), 3ra opción (2026-07-25, tras el
+// merge de `art(creatures): la zarigüeya entra al elenco — con las crías al
+// lomo (#2783)`). Adaptador en ChagraAgentAvatarZariguya.jsx.
+export const AVATAR_TYPES = ['angelita', 'maiz', 'zariguya'];
 export const DEFAULT_AVATAR_TYPE = 'angelita';
 
 // Nombre propio para copy que necesita NOMBRAR al compAI elegido (ej. "hábletele
@@ -20,6 +24,7 @@ export const DEFAULT_AVATAR_TYPE = 'angelita';
 export const AVATAR_NOMBRE = {
     angelita: 'Angelita',
     maiz: 'su planta de maíz',
+    zariguya: 'su zarigüeya',
 };
 
 // Slugs históricos guardados en localStorage de instalaciones viejas:

--- a/src/hooks/useAgentAvatarType.js
+++ b/src/hooks/useAgentAvatarType.js
@@ -12,6 +12,16 @@ const STORAGE_KEY = 'chagra:agent-avatar-type';
 export const AVATAR_TYPES = ['angelita', 'maiz'];
 export const DEFAULT_AVATAR_TYPE = 'angelita';
 
+// Nombre propio para copy que necesita NOMBRAR al compAI elegido (ej. "hábletele
+// a X", el rótulo visible de la transición home→conversación). Los ariaLabel
+// genéricos de los avatares siguen diciendo "Chagra IA" (convención ya usada
+// en WelcomeStatsHero, ChatBubble, AgentHero, InsightProactivoCard, etc.) —
+// este mapa es SOLO para los pocos textos que sí necesitan el nombre propio.
+export const AVATAR_NOMBRE = {
+    angelita: 'Angelita',
+    maiz: 'su planta de maíz',
+};
+
 // Slugs históricos guardados en localStorage de instalaciones viejas:
 // ambos colibríes migran a Angelita sin que el usuario haga nada.
 const LEGACY_TYPES = { colibri: 'angelita', colibri_svg: 'angelita' };

--- a/tests/visual/compai-gate-harness.html
+++ b/tests/visual/compai-gate-harness.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<!--
+  compai-gate-harness.html — Harness AISLADO, temporal, para verificar EN
+  VIVO el fix "el compAI elegido aparece en toda la app" (2026-07-25):
+  monta AgentAvatarSelector (real, 3 opciones) y AgentFab (real, boton
+  flotante) uno junto al otro, SIN pasar por login/auth (el backend de
+  autenticacion no esta disponible en este entorno de desarrollo). Clic en
+  una tarjeta del selector debe cambiar el FAB al instante (mismo hook
+  useAgentAvatarType + evento 'chagra:agent-avatar-changed').
+
+  NO participa de ningun test de regresion visual con snapshots (a
+  diferencia de component-harness.html) — es solo para captura manual de
+  la verificacion de este fix. Ver tests/visual/compai-gate-harness.jsx.
+
+  Uso: npx vite tests/visual/compai-gate-harness.html
+-->
+<html lang="es-CO">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>compAI gate — selector + FAB</title>
+  </head>
+  <body class="bg-slate-950 text-white">
+    <div id="gate-root"></div>
+    <script type="module" src="./compai-gate-harness.jsx"></script>
+  </body>
+</html>

--- a/tests/visual/compai-gate-harness.jsx
+++ b/tests/visual/compai-gate-harness.jsx
@@ -1,0 +1,40 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish --
+ * Harness de test: strings fijas intencionales, solo para verificacion manual. */
+/**
+ * compai-gate-harness.jsx — verificacion visual manual del fix "el compAI
+ * elegido aparece en toda la app" (2026-07-25).
+ *
+ * Monta AgentAvatarSelector (Perfil → Apariencia, real, 3 opciones desde el
+ * merge de la zarigüeya #2783) y AgentFab (el boton flotante, real) uno
+ * junto al otro. Antes del fix, AgentFab importaba `Angelita` cruda
+ * (visual/agente/Angelita.jsx) y punto — elegir maiz o zarigüeya en el
+ * selector no cambiaba nada en el FAB. Con el fix, ambos leen
+ * useAgentAvatarType() (via el dispatcher ChagraAgentAvatar), asi que un
+ * clic en la tarjeta de la zarigüeya debe cambiar el FAB al instante (mismo
+ * evento 'chagra:agent-avatar-changed').
+ *
+ * Temporal — no se importa desde ningun otro archivo del repo ni de ningun
+ * spec.js con snapshots (a diferencia de component-harness.html/.jsx).
+ */
+import { createRoot } from 'react-dom/client';
+import '../../src/index.css';
+import AgentAvatarSelector from '../../src/components/Settings/AgentAvatarSelector.jsx';
+import AgentFab from '../../src/components/AgentFab.jsx';
+
+function Gate() {
+  return (
+    <div style={{ maxWidth: 480, margin: '0 auto', padding: 24 }}>
+      <h1 className="text-xl font-black text-white mb-1">
+        Verificación — el compAI elegido aparece en toda la app
+      </h1>
+      <p className="text-xs text-slate-400 mb-6">
+        Elija una tarjeta abajo. El botón flotante (esquina inferior derecha
+        de la ventana) debe cambiar al instante.
+      </p>
+      <AgentAvatarSelector />
+      <AgentFab onNavigate={() => {}} />
+    </div>
+  );
+}
+
+createRoot(document.getElementById('gate-root')).render(<Gate />);


### PR DESCRIPTION
## Causa raíz

El operador pidió que "desde el login se vea cuál compAI eligió el usuario, y sea el mismo en toda la app". En la práctica era mentira: el usuario elegía en Perfil → Apariencia (`AgentAvatarSelector`), pero varios puntos de la app importaban el avatar **hardcodeado**, sin pasar por el dispatcher `ChagraAgentAvatar` (que lee `useAgentAvatarType()` / `localStorage['chagra:agent-avatar-type']`):

- `AgentFab.jsx:2,174` — el botón flotante, **el avatar más visible de toda la app**, importaba `Angelita` cruda (`visual/agente/Angelita.jsx`) directo.
- `LoginScreen.jsx:199` — importaba `ChagraAgentAvatarAngelita` directo.
- Barrido (`git grep`) encontró el mismo bug en `BienvenidaFinca.jsx`, `dashboard/AgentHero.jsx`, `dashboard/FincaVivaHero.jsx` y `agent/ColibriTransition.jsx` (este último incluso mostraba el nombre "Angelita" como texto visible en la transición home→conversación).
- `OnboardingCondensado.jsx:1172` decía *"Ahora háblele al colibrí"* — el colibrí fue jubilado como cara del agente el 2026-07-18; la app despedía al usuario nombrando un personaje que ya no existe.

Mientras tanto se mergeó la zarigüeya al elenco (#2783, "las crías al lomo") y el operador pidió agregarla como 3ra opción del selector — lo cual sirve además como **la prueba definitiva** de que el fix funciona: elegir zarigüeya y verla aparecer en el FAB y en el login.

## Qué cambia

**Dispatcher (`ChagraAgentAvatar.jsx`)**: acepta ahora también una prop `estado` (vocabulario rico en español de Angelita — `acompana/escuchando/pensando/respondiendo/contenta/invita`) para los call-sites que necesitaban esa finura y por eso bypaseaban el dispatcher. Se traduce a la angosta (`idle/thinking/speaking/listening`) cuando el tipo elegido no es Angelita. 100% backward-compatible (ningún consumidor existente pasaba `estado`).

**Nuevo**: `ChagraAgentAvatarZariguya.jsx` — adaptador (mismo contrato que los otros dos) sobre `visual/creatures/Zariguya.jsx` (el registro rubber-hose cálido del elenco canónico — **no** la zarigüeya oscura/neón de `dashboard/CriaturasNocturnas.jsx`). Cero cambios en `src/visual/creatures/` (solo lectura/import).

**Archivos con el swap al dispatcher**: `AgentFab.jsx`, `LoginScreen.jsx`, `OnboardingCondensado.jsx` (+ copy muerto del colibrí reemplazado por el nombre del compAI real elegido), `BienvenidaFinca.jsx`, `dashboard/AgentHero.jsx`, `dashboard/FincaVivaHero.jsx`, `agent/ColibriTransition.jsx`.

**`AgentAvatarSelector.jsx`**: 3ra tarjeta (Zarigüeya) + grid responsivo a 3 columnas (antes fijo a 2, sin restricción estructural — solo el CSS).

**Default explícito**: ya existía y queda documentado — `DEFAULT_AVATAR_TYPE = 'angelita'`.

## Barrido de "colibrí" en copy visible (pedido explícito del encargo)

- **Bug real, arreglado**: `ProfileScreen.jsx:1140` decía *"Doble click en el avatar colibrí silencia o reactiva sin abrir esta pantalla"* — nombraba al avatar jubilado. Cambiado a "el avatar del agente" (genérico, misma convención del resto del PR).
- **Limítrofes, NO tocados a propósito**: `OnboardingTour.jsx`, `dashboard/GuardianEspiritu.jsx`, y los `ariaLabel` de `FincaVivaHero.jsx:638,642` (detrás de la flag `VITE_COLIBRI`, apagada en producción) — ahí el colibrí es **fauna real** (especie, parte de la funcionalidad "espíritu guardián"), no la cara del agente. Borrar ese copy rompería contenido legítimo.
- **Confirmado limpio**: `AgentAvatarSelector.jsx`, `OnboardingCondensado.jsx` (ya arreglado en este PR), `TopBar.jsx`, `ChagraAgentAvatar*.jsx`, `messages.js` — cero coincidencias de "colibrí" como cara del agente.
- **Código muerto confirmado, NO borrado en este PR**: `ChagraAgentAvatarColibri.jsx` y `ChagraAgentAvatarColibriPhoto.jsx` no tienen un solo call-site fuera de sí mismos. No los borro acá para no mezclar un borrado con un fix de comportamiento (complica la revisión) — quedan anotados como **candidatos a eliminar en un PR de limpieza aparte**.

## Verificación

- `vitest run` de los archivos afectados: 28/28 verde (incluye 2 tests nuevos de zarigüeya) + 11/11 verde en `ProfileScreen.*.test.jsx` tras el fix del copy.
- `npm run build`: verde.
- **Gate visual** (GPU real, ANGLE AMD Radeon Vega 10 — ver `_gpu-renderer-compai.json`), harness aislado nuevo `tests/visual/compai-gate-harness.html` (sin auth, que no está disponible en este entorno):
  - Selector con 3 opciones, Angelita por default, FAB reflejándola.
  - Clic en Zarigüeya → el FAB cambia **al instante** a la zarigüeya (crías al lomo visibles).
  - Login real (`#login`) con la preferencia forzada por localStorage: Angelita vs. zarigüeya, mismo componente, avatar distinto.
  - Capturas en `/home/kortux/Workspace/capturas-onboarding/20` a `24` (local al operador).

## Lo que no pude verificar

- Flujo de login real de punta a punta (autenticación real) — el backend correspondiente no está disponible en este entorno de desarrollo; la verificación del login usó localStorage forzado sobre el componente real, sin submit de credenciales.
- No se tocó `src/visual/creatures/` (jaguar en curso por otro proceso) — la integración de la zarigüeya es 100% vía import/lectura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
