### PR TITLE
fix(rutas): activar EntradaCampesina — el motivo de exclusión era falso

### DIFF
--- a/src/config/rutasProdChagraApp.js
+++ b/src/config/rutasProdChagraApp.js
@@ -411,6 +411,16 @@ export const NUCLEO_APP = [
     importLazy: 'src/components/dashboard/DashboardLive.jsx',
     categoria: '2D-app',
   },
+  // Reactivada (fix 2026-07-25, sacada de EXCLUIDO): tarjeta 2D de un solo
+  // pulgar para el camino simple (campesino, baja alfabetización). NO es
+  // duplicado de EntradaValle3D — ese motivo era falso, verificado con
+  // capturas (EXPERIENCIA-ONBOARDING-2026-07-25.md §1.4).
+  {
+    path: 'mockup_entrada_campesina',
+    componente: 'EntradaCampesina',
+    importLazy: 'src/mockups/EntradaCampesina.jsx',
+    categoria: '2D-app',
+  },
   {
     path: 'ubicacion-detectada',
     componente: 'LocationDetectedScreen',
@@ -1098,10 +1108,12 @@ export const EXCLUIDO = [
   },
 
   // ── Duplicados de Entrada ──────────────────────────────────────
-  {
-    path: 'mockup_entrada_campesina',
-    motivo: 'Duplicado de EntradaValle3D. EntradaValle3D es la definitiva.',
-  },
+  // `mockup_entrada_campesina` SALIÓ de acá (fix 2026-07-25): el motivo era
+  // falso — EntradaCampesina (tarjeta 2D de un solo pulgar) y EntradaValle3D
+  // (escena 3D navegable) NO son duplicados, son las dos vistas que el
+  // encargo pide (campesino simple vs. técnico completo). Verificado con
+  // capturas — ver `ops/EXPERIENCIA-ONBOARDING-2026-07-25.md §1.4`. Ahora
+  // vive en NUCLEO_APP.
   {
     path: 'mockup_home_campesino',
     motivo: 'Home duplicado. DashboardLive + AgentHero es el home real.',

--- a/src/prodApp/ProdChagraApp.jsx
+++ b/src/prodApp/ProdChagraApp.jsx
@@ -180,6 +180,8 @@ const LAZY_MAP = {
   AprenderConAgente: lazy(() => import('../components/Aprende/AprenderConAgente.jsx')),
   CursoChagra: lazy(() => import('../components/curso/CursoChagra.jsx')),
   DashboardLive: lazy(() => import('../components/dashboard/DashboardLive.jsx')),
+  // Reactivada (fix 2026-07-25, sacada de EXCLUIDO — ver rutasProdChagraApp.js).
+  EntradaCampesina: lazy(() => import('../mockups/EntradaCampesina.jsx')),
 
   // ── PENDIENTE_DECISION (operador dijo "nada afuera") ────────────
   OnboardingCondensado: lazy(() => import('../components/OnboardingCondensado.jsx')),


### PR DESCRIPTION
## Causa raíz

`src/config/rutasProdChagraApp.js` marcaba `mockup_entrada_campesina` como **EXCLUIDO** de `prod.chagra.app` con el motivo:

> "Duplicado de EntradaValle3D. EntradaValle3D es la definitiva."

**Ese motivo es falso, verificado con capturas** (ver `Chagra-strategy/ops/EXPERIENCIA-ONBOARDING-2026-07-25.md §1.4`): `EntradaCampesina` es una tarjeta 2D de **un solo pulgar** (franja del día, vereda + msnm, saludo por nombre, tres chips de estado, una sola acción grande — "Ver qué hacer") pensada para baja alfabetización/teléfono modesto. `EntradaValle3D` es una **escena 3D navegable** con minimapa y hotspots. No son duplicados — son las dos vistas que el propio encargo pide (campesino simple vs. técnico completo). El archivo propio de `EntradaCampesina.jsx` ya se autodeclara *"LA ENTRADA DEFINITIVA campesina"*.

**Mecanismo exacto**: `ProdChagraApp.jsx` (el shell data-driven de `prod.chagra.app`) solo registra en su mapa de rutas (`RUTAS`/`LAZY_MAP`) las entradas que aparecen en `NUCLEO_3D`/`NUCLEO_APP`/`PENDIENTE_DECISION` **y que además NO aparecen en `EXCLUIDO`**. `mockup_entrada_campesina` nunca estuvo en ninguna lista positiva — solo en `EXCLUIDO` — así que jamás se registraba, sin importar el motivo.

## Qué cambia

- `rutasProdChagraApp.js`: entrada sacada de `EXCLUIDO`, agregada a `NUCLEO_APP` (`componente: 'EntradaCampesina'`, `categoria: '2D-app'`).
- `ProdChagraApp.jsx`: agregado `LAZY_MAP.EntradaCampesina = lazy(() => import('../mockups/EntradaCampesina.jsx'))`.

La app clásica (`App.jsx`, ruta `#/mockups/entrada-campesina`) **ya la tenía cableada** desde antes — ese camino no formaba parte del bug, solo `prod.chagra.app`.

## Verificación

- `npm run build` — verde.
- `npm run build:prod` — verde.
- **Gate visual, ANTES/DESPUÉS del build de `prod.chagra.app`** (GPU real, ANGLE AMD Radeon Vega 10):
  - **Antes** (código sin el fix, `dist-prod` reconstruido desde el estado previo): navegar a `#mockup_entrada_campesina` cae al **login** (la ruta no estaba registrada → no es "pública" → gate de auth la bloquea).
  - **Después**: la misma URL renderiza `EntradaCampesina` completa — sin errores de consola (`page.on('pageerror')` vacío en las 3 capturas).
  - Referencia: la app clásica (`#/mockups/entrada-campesina`) se ve idéntica en ambos casos — no se tocó, seguía funcionando.
  - Capturas en `/home/kortux/Workspace/capturas-onboarding/30` a `32` (local al operador).

## Lo que no pude verificar

- El auth-gate de `ProdChagraApp.jsx` trata como "pública" (sin login) **cualquier** ruta registrada en `RUTAS`, no solo las 3D (el comentario del propio archivo dice que debería ser solo 3D + valle). Esto es **preexistente** — aplica igual a `dashboard`/otras rutas 2D-app ya registradas antes de este fix, no algo que este cambio introduzca o agrave. Lo señalo por transparencia; no lo toqué (fuera de alcance de este PR).
- No verifiqué el comportamiento en un teléfono de gama baja real (memoria conocida del proyecto: las capturas son con GPU de escritorio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)