### PR TITLE
fix(redirect): agregar 3d.guatoc.co a la whitelist del canonicalHostRedirect

### DIFF
--- a/src/services/__tests__/canonicalHostRedirect.test.js
+++ b/src/services/__tests__/canonicalHostRedirect.test.js
@@ -39,6 +39,18 @@ describe('canonicalHostRedirect', () => {
     expect(isAllowedHost('preview.chagra.app')).toBe(true);
   });
 
+  it('permite 3d.guatoc.co (mundos 3D standalone) sin redirigir', () => {
+    expect(isAllowedHost('3d.guatoc.co')).toBe(true);
+  });
+
+  it('NO permite otros subdominios de guatoc.co (host exacto, no wildcard)', () => {
+    // chagra.guatoc.co es el dominio legado de produccion: debe seguir
+    // rebotando a chagra.app, por eso 3d.guatoc.co se agrega como host
+    // exacto y no como *.guatoc.co.
+    expect(isAllowedHost('chagra.guatoc.co')).toBe(false);
+    expect(isAllowedHost('otra-cosa.guatoc.co')).toBe(false);
+  });
+
   it('redirige una sola vez desde un host externo al canonico', () => {
     const redirect = vi.fn();
     const location = {

--- a/src/services/canonicalHostRedirect.js
+++ b/src/services/canonicalHostRedirect.js
@@ -53,12 +53,23 @@ export function isProdAppHost(hostname) {
   return normalizeHostname(hostname) === 'prod.chagra.app';
 }
 
+export function isThreeDWorldHost(hostname) {
+  // 3d.guatoc.co = despliegue standalone de los mundos 3D auditados (build
+  // app-3d), fuera del dominio chagra.app. Igual que prod.chagra.app, NO debe
+  // redirigir al canónico. Host EXACTO (no wildcard *.guatoc.co): otros
+  // subdominios de guatoc.co — p.ej. chagra.guatoc.co, el dominio legado de
+  // producción — deben seguir rebotando a chagra.app (ver test de
+  // canonicalHostRedirect que lo asume explícitamente).
+  return normalizeHostname(hostname) === '3d.guatoc.co';
+}
+
 export function isAllowedHost(hostname) {
   return (
     isCanonicalHost(hostname) ||
     isLocalDevHost(hostname) ||
     isPreviewHost(hostname) ||
-    isProdAppHost(hostname)
+    isProdAppHost(hostname) ||
+    isThreeDWorldHost(hostname)
   );
 }
 


### PR DESCRIPTION
## Resumen
- `3d.guatoc.co` sirve el standalone de los 19 mundos 3D auditados, pero al no estar en `isAllowedHost` (`src/services/canonicalHostRedirect.js`), `runCanonicalHostRedirectGuard` lo expulsaba con `location.replace` a `chagra.app` antes de que React montara.
- Se agrega `isThreeDWorldHost()` con match **exacto** (no `*.guatoc.co`): un wildcard habilitaría también `chagra.guatoc.co`, el dominio legado de producción, que el test existente (`canonicalHostRedirect.test.js`) ya asume que debe seguir rebotando al canónico.
- Se agregan 2 tests: permite `3d.guatoc.co`, y confirma que otros subdominios de `guatoc.co` (incluido `chagra.guatoc.co`) siguen bloqueados.

## Test plan
- [x] `npx vitest run src/services/__tests__/canonicalHostRedirect.test.js` — 6/6 verde.
- [x] `npx vite build` — verde.
- [x] Verificación manual con Playwright + Chrome real (`--host-resolver-rules` simulando el hostname sobre un `vite preview` local): `3d.guatoc.co` monta la app completa (título "Chagra", DB/catálogo/AlertEngine arrancan) sin ninguna navegación fuera del host; un hostname de control fuera de la lista sí dispara `location.replace` real hacia `https://chagra.app/`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>