### PR TITLE
feat(ci): despliegue automático de /app/ en 3d.guatoc.co desde push a dev

### DIFF
--- a/.github/workflows/deploy-3d-guatoc.yml
+++ b/.github/workflows/deploy-3d-guatoc.yml
@@ -1,0 +1,119 @@
+name: Deploy mundos 3D (3d.guatoc.co)
+
+# Despliegue automatico del SPA publico (build --base=/app/) que sirve los 19
+# mundos aprobados en 3d.guatoc.co, cada uno via su stub /<slug>/ ->
+# /app/#/mockups/<slug> (ver ops/bitacora/montar-19-mundos.md en
+# Chagra-strategy, repo privado, para el detalle completo).
+#
+# ALCANCE: este workflow SOLO redespliega /app/ (el bundle de la SPA con los
+# mockups). NO toca el valle (3d.guatoc.co/ raiz, vendorizado en un repo APARTE
+# sin remoto, ~/demos-src/valle-guatoc en el host de deploy) ni el indice
+# /mundos/ (paginas estaticas de mano, cambian poco). Decision documentada:
+# ampliar esto a un pipeline que tambien reconstruya el valle requiere mover
+# ese repo a algo con su propio trigger -- no se resuelve aqui.
+#
+# Target: /home/kortux/demos/3d/app/ en alpha, servido por microapp-3d.service
+# (systemd --user + tunel Cloudflare ya configurado, ver ~/.local/bin/microapp-deploy).
+# El runner de GH Actions corre en alpha como usuario "runner", miembro del
+# grupo "users" (mismo grupo dueno del arbol ~/demos/3d/); el directorio se
+# dejo group-writable (chmod g+w + setgid) para que este workflow pueda
+# escribir sin sudo -- el rsync de abajo mantiene ese modo en cada corrida.
+
+on:
+  push:
+    branches: ['dev', 'dev/*']
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+
+concurrency:
+  group: deploy-3d-guatoc-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: [self-hosted, alpha]
+    timeout-minutes: 30
+    steps:
+      - name: Detect runner identity
+        run: |
+          if echo "$HOME" | grep -q claude-runner; then
+            echo "SKIP_DEPLOY=1" >> "$GITHUB_ENV"
+          fi
+
+      - if: env.SKIP_DEPLOY != '1'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Install dependencies
+        run: npm ci
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Build (base=/app/, mismas envs publicas que dev-deploy.yml)
+        run: npx vite build --base=/app/
+        env:
+          VITE_FARMOS_URL: ""
+          VITE_FARMOS_CLIENT_ID: farm
+          VITE_USE_SIDECAR_AGRO_MCP: "true"
+          VITE_FINCA_VIVA_HOME_PERFIL: "true"
+          VITE_REGISTRO_UNIFICADO: "true"
+          VITE_COLIBRI: "true"
+          VITE_CHAGRA_MCP_TOKEN: ${{ secrets.VITE_CHAGRA_MCP_TOKEN }}
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Deploy a ~/demos/3d/app/
+        run: |
+          set -e
+          TARGET="$HOME/demos/3d/app"
+          mkdir -p "$TARGET"
+          umask 002
+          # --chmod mantiene el arbol group-writable en cada corrida (el
+          # runner escribe como usuario "runner", grupo "users" -- mismo
+          # grupo dueno del arbol; sin esto, un rsync -a heredaria el umask
+          # por defecto y la SIGUIENTE corrida podria perder el permiso).
+          rsync -a --delete --chmod=Du=rwx,Dg=rwx,Do=rx,Fu=rw,Fg=rw,Fo=r \
+            dist/ "$TARGET/"
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Verify deployment
+        run: |
+          TARGET="$HOME/demos/3d/app"
+          test -f "$TARGET/index.html" || exit 1
+          HASH=$(sha256sum "$TARGET/index.html" | cut -d' ' -f1)
+          echo "3d.guatoc.co/app deploy OK: $(date -Iseconds) | index.html sha256: ${HASH:0:12}"
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Verify referenced assets exist
+        run: |
+          set -euo pipefail
+          TARGET="$HOME/demos/3d/app"
+          INDEX="$TARGET/index.html"
+          test -f "$INDEX" || { echo "index.html ausente en $TARGET"; exit 1; }
+          refs=$(grep -oE '/app/assets/[A-Za-z0-9._/-]+\.(js|css)' "$INDEX" | sort -u || true)
+          missing=0
+          while IFS= read -r ref; do
+            [ -z "$ref" ] && continue
+            file="$TARGET${ref#/app}"
+            if [ -f "$file" ]; then
+              echo "ok   $ref"
+            else
+              echo "FALTA $ref  (esperado en $file)"
+              missing=$((missing + 1))
+            fi
+          done <<< "$refs"
+          if [ "$missing" -gt 0 ]; then
+            echo "Deploy INCOMPLETO: $missing asset(s) referenciados por index.html no existen en disco."
+            exit 1
+          fi
+          echo "Integridad de assets OK."
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: curl smoke test (200 en 3 rutas)
+        run: |
+          sleep 5
+          for p in "" "cafetal-vivo-3d/" "bosque-tres-estratos/"; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "https://3d.guatoc.co/$p" || echo 000)
+            echo "https://3d.guatoc.co/$p -> $code"
+          done


### PR DESCRIPTION
## Qué hace
Cablea la decisión del operador (brief `montar-19-mundos-3d-guatoc.md`, decisión 3: "despliegue automático desde `dev`, nada de copia manual") para la parte reproducible por CI: el bundle SPA (`vite build --base=/app/`) que sirve los 19 mockups aprobados en `3d.guatoc.co/app/`, consumido por 20 stubs de redirect por-mundo (`/cafetal-vivo-3d/`, `/bosque-tres-estratos/`, etc.).

Mismo patrón que `.github/workflows/dev-deploy.yml` (self-hosted `alpha`, guard `SKIP_DEPLOY` si el runner es `claude-runner`, verificación de integridad de assets antes de dar el deploy por bueno).

## Alcance — qué NO cubre (a propósito)
- **El valle** (`3d.guatoc.co/` raíz, three.js vendorizado) vive en `~/demos-src/valle-guatoc`, un repo **aparte, sin remoto**, en el host de deploy. Este workflow no puede tocarlo porque no dispara desde ahí. Ampliarlo requeriría moverlo a un repo con su propio trigger — decisión de arquitectura que no tomé sin el operador.
- **El índice `/mundos/`** (ruta de desarrollo/utilidad, piso térmico) son páginas estáticas armadas a mano, cambian poco, tampoco están en este repo.

Detalle completo de la sesión que montó los 19 mundos: `Chagra-strategy/ops/bitacora/montar-19-mundos.md` (repo privado).

## Requisito de permisos (ya aplicado, sin sudo)
`~/demos/3d/app` en alpha se dejó group-writable (`chmod g+w` + `g+s`, sobre un árbol que ya era mío) para que el runner `runner` (miembro del grupo `users`, dueño del árbol) pueda escribir sin sudo. El `rsync --chmod=...` del workflow mantiene ese modo en cada corrida futura.

## No verificado
- **No corrí este workflow de punta a punta todavía** — no hay forma de disparar un `push a dev` de prueba sin mergear. El patrón replica exactamente `dev-deploy.yml` (que sí corre en producción hace tiempo), pero el paso "Deploy a ~/demos/3d/app/" y el permiso group-writable son nuevos y no tienen corrida real registrada.
- Recomiendo mergear y observar el primer run antes de confiar en él ciegamente.

## Test plan
- [ ] Mergear a `dev` y confirmar que el job corre en verde en Actions.
- [ ] `curl https://3d.guatoc.co/app/` → 200 tras el deploy.
- [ ] `curl https://3d.guatoc.co/cafetal-vivo-3d/` → 200 (smoke test del propio workflow).
- [ ] Confirmar que `~/demos/3d/app` en alpha sigue siendo group-writable tras la corrida (no se rompió el permiso).

🤖 Generado con [Claude Code](https://claude.com/claude-code)