### PR TITLE
feat(agent): activar Deep Research + cerrar brecha de 4 tools en grounding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,11 @@ jobs:
           # Si sidecar timeout/5xx/red caida, sidecarClient devuelve null y el
           # comportamiento es identico al pre-wiring.
           VITE_USE_SIDECAR_AGRO_MCP: "true"
+          # Deep Research (2026-07-25): activa el chip 🔬 "Investigacion profunda"
+          # (informe local multi-hop citado sobre grafo AGE + corpus + tools MCP).
+          # Gated ademas por tier Pro (tierService PRO_USERNAMES: admin + ana maria);
+          # endpoint capacity-limited (1 job) y Pro-only server-side (403 free).
+          VITE_DEEP_RESEARCH_ENABLED: "true"
           # GO-LIVE 2026-07-04: home finca-viva a produccion (biopunk2 default,
           # biopunk original de respaldo). Autorizado por el operador. Antes solo
           # en dev-deploy.yml; ahora prod renderiza el home de 4 portales + escenas

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -393,6 +393,15 @@ const ALLOWED_TOOLS = new Set([
   'get_cultivos_viables',
   'get_diseno_finca',
   'get_dosis_biopreparado',
+  // ── Reconciliación 41→46 (fix grounding P0, 2026-07-25): el sidecar/NLU creció
+  //    a 46 tools; estas 4 quedaron ruteables por el NLU pero fuera del whitelist
+  //    → el cliente las rechazaba con not_allowed y el turno degradaba a RAG SIN
+  //    grounding EN SILENCIO. Son read-only del grafo/catálogo con args que el NLU
+  //    SÍ rellena desde una frase de chat (mismo patrón que las ya expuestas):
+  'get_aporte_nutricional', //      aporte nutricional (energía/proteína) por alimento
+  'get_canales_comercializacion', // dónde vender + régimen INVIMA/MADR por cultivo
+  'get_folk_sintoma', //            síntoma campesino → patógeno (muy ruteada por el NLU)
+  'get_practicas_agua', //          prácticas de agua + IRCA rural + protección de cauces
   // FASE 2 (deferidas, NO exponer aún):
   //  - get_grado_dia: requiere `fecha_siembra` (ISO YYYY-MM-DD, sin default) que
   //    el NLU no puede sintetizar con fiabilidad desde una frase libre de chat.


### PR DESCRIPTION
## Qué

Dos cambios que salieron del audit del stack de agente:

### 1. Activar Deep Research
`VITE_DEEP_RESEARCH_ENABLED=true` en `deploy.yml` → el chip **🔬 Investigación profunda** queda visible en prod. Doble gate ya existente: feature flag + **tier Pro** (`tierService` PRO_USERNAMES = admin + ana maria). Endpoint capacity-limited (1 job, 429) y Pro-only server-side (403 free).

**Evaluado (10 consultas difíciles):** 10/10 completadas, **0 `degraded`** (nunca fallback), medias 5.6 sub-preguntas · 19.8 citas · 6373 chars. Multi-fuente (corpus + tools ICA/ENSO en vivo). Disciplina anti-alucinación sólida (marca vacíos, no inventa). *Nota: el cuello es la precisión del retrieval en cultivos poco cubiertos por el corpus, no el modelo.*

### 2. Cerrar brecha de grounding (4 tools)
El sidecar/NLU creció de 41 → **46 tools**, pero el whitelist `ALLOWED_TOOLS` del cliente no se actualizó. Estas 4 quedaban **ruteables por el NLU pero rechazadas por el cliente** (`not_allowed`) → el turno degradaba a **RAG SIN grounding, en silencio**:

- `get_aporte_nutricional` — aporte nutricional por alimento
- `get_canales_comercializacion` — dónde vender + régimen INVIMA/MADR
- `get_folk_sintoma` — síntoma campesino → patógeno (**muy ruteada** por el NLU)
- `get_practicas_agua` — prácticas de agua + IRCA rural + protección de cauces

Todas read-only del grafo/catálogo con args chat-fillable (mismo patrón que las ya expuestas). `get_grado_dia` sigue deferida a propósito (necesita `fecha_siembra` ISO que el NLU no puede sintetizar).

**Excluidas a propósito (sin cambio):** las 7 que exigen auth farmOS/device/DIAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)