### PR TITLE
feat(vision): cablear cliente al juez async (no bloqueante)

### DIFF
--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -21,7 +21,7 @@
 
 import { streamOllama } from './ollamaStream';
 import { retrieve } from './ragRetriever';
-import { callTool, isSidecarEnabled, judgeVision } from './sidecarClient';
+import { callTool, isSidecarEnabled, judgeVisionAsync } from './sidecarClient';
 import { parseJsonTolerant } from '../utils/parseJsonTolerant';
 import { hashImage, getCached, setCached } from './visionCacheService';
 
@@ -499,10 +499,19 @@ export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
   // confirmó que el NOMBRE existe en catálogo, pero no que la imagen coincida
   // (el modelo de visión pudo alucinar el binomial). Best-effort: el sidecar
   // capa a 500 ms y nunca bloquea; cualquier fallo → null (no degrada la UX).
+  // Gate ASYNC (#328): el juez local tarda ~16-23s (minicpm-v:8b en CPU, fuera de
+  // la VRAM del agente); el sync `/judge-vision` lo abortaba el propio cliente a
+  // TOOL_TIMEOUT_MS=5s → veredicto SIEMPRE null (gate muerto). Encolamos SIN
+  // bloquear el diagnóstico (no metemos 20s de latencia a la foto). `_grounded.judge`
+  // queda `{status:'async', request_id}`; el veredicto se recoge luego con
+  // `judgeVisionResult(request_id)` (badge que se resuelve solo). Best-effort:
+  // cualquier fallo → null (no degrada la UX, igual que antes).
   const runJudge = async (speciesId) => {
     try {
       const b64 = await blobToBase64(imageBlob);
-      return await judgeVision(speciesId, b64);
+      const q = await judgeVisionAsync(speciesId, b64);
+      if (!q || !q.request_id) return null;
+      return { status: 'async', request_id: q.request_id };
     } catch (_) {
       return null;
     }

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -930,6 +930,47 @@ export async function judgeVision(speciesId, imageB64) {
 }
 
 /**
+ * Gate ASÍNCRONO del juez de visión (#328). El juez local tarda ~16-23s
+ * (minicpm-v:8b en CPU, fuera de la VRAM del agente) y el sync `/judge-vision`
+ * lo aborta el propio cliente a TOOL_TIMEOUT_MS=5s → veredicto siempre null.
+ * Este par desacopla: `judgeVisionAsync` ENCOLA (202 en ~11ms) y devuelve
+ * `{request_id}`; `judgeVisionResult` recoge el veredicto luego (poll). Así el
+ * diagnóstico NO se bloquea esperando al juez.
+ *
+ * @param {string} speciesId @param {string} imageB64
+ * @returns {Promise<null | {request_id: string}>}
+ */
+export async function judgeVisionAsync(speciesId, imageB64) {
+  if (!speciesId || typeof speciesId !== 'string') return null;
+  if (!imageB64 || typeof imageB64 !== 'string') return null;
+  const raw = await postJson(
+    '/judge-vision-async',
+    { species_id: speciesId, image_b64: imageB64 },
+    TOOL_TIMEOUT_MS,
+  );
+  if (!raw || typeof raw !== 'object' || typeof raw.request_id !== 'string') {
+    return null;
+  }
+  return { request_id: raw.request_id };
+}
+
+/**
+ * Recoge el veredicto async por `request_id`.
+ * @param {string} requestId
+ * @returns {Promise<null | {status:'done', plausible:boolean|null, confidence:number|null, motivo:string} | {status:'pending'} | {status:'error', reason?:string}>}
+ */
+export async function judgeVisionResult(requestId) {
+  if (!requestId || typeof requestId !== 'string') return null;
+  const raw = await getJson(
+    '/judge-vision-result',
+    { request_id: requestId },
+    TOOL_TIMEOUT_MS,
+  );
+  if (!raw || typeof raw !== 'object') return null;
+  return raw;
+}
+
+/**
  * Wrapper defensivo de `get_normativa_ica`. Validá la action localmente
  * para que el frontend NO pueda pedir paths arbitrarios al sidecar.
  *


### PR DESCRIPTION
Wirea el cliente PWA a los endpoints async del juez (#328). El sync `/judge-vision` lo abortaba el propio cliente a 5s (ningún VLM local juzga en <5s) → gate muerto. Ahora: `judgeVisionAsync` encola (202 en ~11ms) + `judgeVisionResult` recoge el veredicto; `runJudge` NO bloquea el diagnóstico. Juez = minicpm-v:8b en CPU (~16-23s, 0 VRAM, agente pineado intacto). Build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)