### PR TITLE
feat(red): redService — cliente PWA de la RED de trueque (Chagra #7, Fase 1)

### DIFF
--- a/src/services/redService.js
+++ b/src/services/redService.js
@@ -1,0 +1,100 @@
+/**
+ * redService.js — cliente PWA de la RED de trueque campesino↔campesino (Chagra #7, Fase 1).
+ *
+ * Andamiaje del servicio cliente (SIN pantallas todavía): envuelve los 4 endpoints
+ * del sidecar de la RED (Fase 0, ADR-051) para que las pantallas de Fase 1 los
+ * consuman sin repetir plumbing. Reusa `postJson` de sidecarClient (mismo auth,
+ * tier header, timeout y degrade-to-null → offline-friendly).
+ *
+ * Contrato (ADR-051): el trueque es GRATIS y de vecindario; la geo es DIFUSA
+ * (centroide de vereda, NUNCA GPS de la finca); las necesidades predichas se
+ * etiquetan como sugerencia; la reputación se registra pero (MVP) no modera.
+ *
+ * Todas las funciones degradan a `null` si el sidecar no responde (offline/timeout)
+ * — la UI debe tratar `null` como "sin red por ahora", nunca como error duro.
+ * Español colombiano (tú/usted).
+ */
+import { postJson, TOOL_TIMEOUT_MS } from './sidecarClient.js';
+
+/**
+ * @typedef {Object} ZonaDifusa
+ * @property {number} lat  latitud del centroide de la vereda (NO de la finca)
+ * @property {number} lng  longitud del centroide
+ * @property {string} [vereda] nombre legible de la vereda
+ */
+
+/**
+ * Publica un excedente disponible para trueque. Idealmente derivado de una cosecha
+ * real (`fromHarvestId`) para no fabricar oferta.
+ * @param {{fincaId:string, speciesId:string, zona:ZonaDifusa, cantidad?:number,
+ *   unidad?:string, vigencia?:string, fromHarvestId?:string}} o
+ * @returns {Promise<{persisted:boolean, log_id?:string}|null>}
+ */
+export async function publicarOferta(o) {
+  if (!o?.fincaId || !o?.speciesId || !o?.zona) return null;
+  return postJson('/red-oferta', {
+    finca_id: o.fincaId,
+    species_id: o.speciesId,
+    zona: o.zona,
+    cantidad: o.cantidad,
+    unidad: o.unidad,
+    vigencia: o.vigencia,
+    from_harvest_id: o.fromHarvestId,
+  }, TOOL_TIMEOUT_MS);
+}
+
+/**
+ * Publica una necesidad de la finca. `predicted:true` la marca como sugerencia
+ * anticipada (fenología) — la UI debe mostrarla claramente como propuesta, no como hecho.
+ * @param {{fincaId:string, speciesId:string, zona:ZonaDifusa, cantidad?:number,
+ *   predicted?:boolean}} n
+ * @returns {Promise<{persisted:boolean, log_id?:string}|null>}
+ */
+export async function publicarNecesidad(n) {
+  if (!n?.fincaId || !n?.speciesId || !n?.zona) return null;
+  return postJson('/red-necesidad', {
+    finca_id: n.fincaId,
+    species_id: n.speciesId,
+    zona: n.zona,
+    cantidad: n.cantidad,
+    predicted: n.predicted === true,
+  }, TOOL_TIMEOUT_MS);
+}
+
+/**
+ * Registra un trueque. El estado inicial es "acordado"; un cambio posterior
+ * ("cumplido"/"incumplido") se registra con OTRA llamada pasando `rootId` del
+ * trueque original (el backend NO muta — ADR-019). La reputación se deriva de esto.
+ * @param {{fincaA:string, fincaB:string, speciesA:string, speciesB:string,
+ *   estado?:'acordado'|'cumplido'|'incumplido', rootId?:string}} t
+ * @returns {Promise<{persisted:boolean, log_id?:string}|null>}
+ */
+export async function registrarTrueque(t) {
+  if (!t?.fincaA || !t?.fincaB || !t?.speciesA || !t?.speciesB) return null;
+  return postJson('/red-trueque', {
+    finca_a: t.fincaA,
+    finca_b: t.fincaB,
+    species_a: t.speciesA,
+    species_b: t.speciesB,
+    estado: t.estado || 'acordado',
+    root_id: t.rootId,
+  }, TOOL_TIMEOUT_MS);
+}
+
+/**
+ * Busca matches de trueque del vecindario para una finca. Devuelve los vecinos
+ * ordenados por VALOR del match (bidireccional + reputación − distancia), no por
+ * cercanía sola. `radioKm` acota el vecindario (default backend 5km).
+ * @param {{fincaId:string, radioKm?:number}} q
+ * @returns {Promise<{finca_id:string, radio_km:number, mi_reputacion:object,
+ *   total:number, matches:Array<{finca_id:string, zona?:string, distancia_km:number,
+ *   bidireccional:boolean, ofrece_lo_que_necesito:string[],
+ *   necesita_lo_que_ofrezco:string[], reputacion:object, score:number}>}|null>}
+ */
+export async function buscarMatches(q) {
+  if (!q?.fincaId) return null;
+  return postJson('/red-match', {
+    finca_id: q.fincaId,
+    radio_km: q.radioKm,
+  }, TOOL_TIMEOUT_MS);
+}

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -148,10 +148,12 @@ async function getJson(path, query, timeoutMs) {
 }
 
 /**
- * Wrapper interno: POST con timeout + headers + degrade-to-null.
- * No exportado — el contrato público son planNlu y callTool.
+ * Wrapper POST con timeout + headers + degrade-to-null (offline/timeout/non-2xx → null).
+ * Exportado como primitivo compartido para servicios de feature que hablan con el
+ * mismo sidecar (p.ej. redService.js / RED de trueque). Mantiene el mismo auth-retry,
+ * tier header y degradación graceful que el resto del cliente.
  */
-async function postJson(path, body, timeoutMs) {
+export async function postJson(path, body, timeoutMs) {
   if (!isSidecarEnabled()) return null;
   if (typeof navigator !== 'undefined' && navigator.onLine === false) {
     console.debug('[sidecar] offline — skip', path);


### PR DESCRIPTION
## Qué (andamiaje Fase 1, SIN pantallas)
Servicio cliente de la **RED de trueque campesino↔campesino** que envuelve los 4 endpoints del sidecar (Fase 0, PR chagra-pro #342). Sin UI todavía — es el plumbing para que las pantallas de Fase 1 lo consuman.

- `publicarOferta` · `publicarNecesidad` · `registrarTrueque` · `buscarMatches`.
- Reusa `postJson` de `sidecarClient` (mismo auth-retry, tier header, timeout, **degrade-to-null offline-friendly**), que se **exporta** ahora como primitivo compartido para servicios de feature.
- Mapea camelCase JS → snake_case API. Degrada a `null` si el sidecar no responde (la UI trata `null` como "sin red por ahora", nunca error duro).

## Contrato (ADR-051, privado)
Trueque GRATIS, geo **difusa** (centroide de vereda, nunca GPS), necesidades predichas etiquetadas, reputación registrada pero no-moderadora en MVP.

## Alcance / impacto
**Aún NO importado por ninguna pantalla** → cero impacto en el bundle/runtime de prod hasta que Fase 1 lo cablee. eslint limpio. La UI (publicar excedente desde cosecha real, ver matches del vecindario) es el siguiente paso, con sus decisiones de UX + arte.