### PR TITLE
feat(corpus): rescatar #2593 — corpus del sidecar (pgvector+reranker) al chat (dev)

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -60,6 +60,16 @@ jobs:
           # deploy.yml (prod) → prod conserva el colibrí 2D / video actual.
           VITE_COLIBRI: "true"
           VITE_CHAGRA_MCP_TOKEN: ${{ secrets.VITE_CHAGRA_MCP_TOKEN }}
+          # #2593 corpus→chat: base del sidecar (nginx-proxied). DEBE ser
+          # /api/mcp/agro (no /api) o corpusRetriever pega a /api/hybrid-retrieve
+          # → 404 → [] silencioso → el corpus NO se cablea aunque el flag esté ON.
+          # Alineado con sidecarClient.getBaseUrl(). Verificado 2026-07-29.
+          VITE_SIDECAR_URL: "/api/mcp/agro"
+          # #2593 corpus→chat: cablea los ~5900 chunks del corpus server-side
+          # (pgvector + reranker neural bge-reranker-v2-m3 + gate low_relevance)
+          # al RAG del chat. ON en DEV para medir relevancia/latencia; AUSENTE en
+          # deploy.yml (prod) hasta visto bueno. Fail-soft: si falla, RAG cliente.
+          VITE_USE_CORPUS_RETRIEVAL: "true"
           # AVATAR-ESPIRITU / módulos Pro: mismo valor y patrón que deploy.yml
           # (prod). Sin esta variable, loadProModules.js ni intenta el import
           # dinámico y en dev #/espiritu caía SIEMPRE al fallback "no

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -48,6 +48,7 @@ import { createStreamDeadline } from '../../services/streamDeadline';
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
 import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, pisoTermicoGuard, confusionEspecieGuard, pestVsDiseaseGuard, companionSpeciesGuard, toxicSafetyGuard, postValidate, getClimaIdeam, isToolAllowed } from '../../services/sidecarClient';
+import { retrieveCorpus } from '../../services/corpusRetriever';
 // CHIPS DE MODO (A3/A4, decisión operador 2026-06-02): el router PURO mapea
 // la intención forzada del chip → tool determinístico, SALTANDO el NLU
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
@@ -1484,7 +1485,15 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       await addTurn(operatorId, { role: 'user', content: text.trim() });
 
       const contextMemory = wasFreshSession ? '' : await getContextString(operatorId, 10);
-      const contextCorpus = await retrieve(textForLLM, TOP_N_RAG, 'agente');
+      const contextCorpusBase = await retrieve(textForLLM, TOP_N_RAG, 'agente');
+      // #2593 corpus→chat: suma los chunks del corpus server-side (pgvector +
+      // reranker neural bge-reranker-v2-m3 + gate low_relevance) vía
+      // /hybrid-retrieve. Gated por VITE_USE_CORPUS_RETRIEVAL (OFF por defecto)
+      // y fail-soft (devuelve [] si falla) → sin el flag, cero cambio en el chat.
+      const corpusExtra = await retrieveCorpus(textForLLM, 3);
+      const contextCorpus = corpusExtra.length
+        ? [...contextCorpusBase, ...corpusExtra]
+        : contextCorpusBase;
 
       // ADR-045 Fase 2 Step B/C — sidecar NLU + MCP tool grounding.
       // Solo si flag VITE_USE_SIDECAR_AGRO_MCP=true Y estamos online.

--- a/src/services/__tests__/corpusRetriever.test.js
+++ b/src/services/__tests__/corpusRetriever.test.js
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+/* eslint-disable no-undef */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { retrieveCorpus, isCorpusRetrievalEnabled } from '../corpusRetriever';
+
+describe('corpusRetriever', () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    vi.stubEnv('VITE_SIDECAR_URL', '/api/mcp/agro');
+    vi.stubEnv('VITE_CHAGRA_MCP_TOKEN', 'test-token');
+    vi.stubEnv('VITE_USE_CORPUS_RETRIEVAL', '');
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  describe('isCorpusRetrievalEnabled', () => {
+    it('OFF por defecto', () => {
+      expect(isCorpusRetrievalEnabled()).toBe(false);
+    });
+    it('reconoce true/1/on', () => {
+      for (const v of ['true', '1', 'on', 'TRUE']) {
+        vi.stubEnv('VITE_USE_CORPUS_RETRIEVAL', v);
+        expect(isCorpusRetrievalEnabled()).toBe(true);
+      }
+    });
+  });
+
+  describe('retrieveCorpus', () => {
+    it('devuelve [] cuando el flag está OFF (sin fetch)', async () => {
+      global.fetch = vi.fn();
+      const r = await retrieveCorpus('cafe abono');
+      expect(r).toEqual([]);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('devuelve [] con query vacía', async () => {
+      vi.stubEnv('VITE_USE_CORPUS_RETRIEVAL', 'true');
+      global.fetch = vi.fn();
+      expect(await retrieveCorpus('   ')).toEqual([]);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('mapea results del corpus a pasajes {key,text,score,title}', async () => {
+      vi.stubEnv('VITE_USE_CORPUS_RETRIEVAL', 'true');
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          degraded: false,
+          counts: { vector: 8, graph: 8 },
+          results: [
+            { chunk_key: 'species:coffea_arabica:ficha', content: 'El café necesita sombra.', title: 'Café', similarity: 0.82, source_type: 'species_ficha' },
+            { chunk_key: 'dr:abono-organico', content: 'El compost mejora el suelo.', title: 'Abono', similarity: 0.71, source_type: 'dr-fanout' },
+          ],
+        }),
+      });
+      const r = await retrieveCorpus('cafe abono', 2);
+      expect(r).toHaveLength(2);
+      expect(r[0]).toMatchObject({ key: 'corpus:species:coffea_arabica:ficha', text: 'El café necesita sombra.', score: 0.82, title: 'Café' });
+      const [url, opts] = vi.mocked(global.fetch).mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/hybrid-retrieve');
+      expect(opts.headers['X-Chagra-Token']).toBe('test-token');
+      expect(JSON.parse(opts.body)).toMatchObject({ query: 'cafe abono', top_k: 2 });
+    });
+
+    it('devuelve [] si degraded=true', async () => {
+      vi.stubEnv('VITE_USE_CORPUS_RETRIEVAL', 'true');
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ degraded: true, results: [] }) });
+      expect(await retrieveCorpus('x')).toEqual([]);
+    });
+
+    it('fail-soft: [] si fetch rechaza', async () => {
+      vi.stubEnv('VITE_USE_CORPUS_RETRIEVAL', 'true');
+      global.fetch = vi.fn().mockRejectedValue(new Error('network'));
+      await expect(retrieveCorpus('x')).resolves.toEqual([]);
+    });
+
+    it('filtra results sin content', async () => {
+      vi.stubEnv('VITE_USE_CORPUS_RETRIEVAL', 'true');
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ degraded: false, results: [{ chunk_key: 'a', content: '' }, { chunk_key: 'b', content: 'ok', similarity: 0.5 }] }),
+      });
+      const r = await retrieveCorpus('x');
+      expect(r).toHaveLength(1);
+      expect(r[0].key).toBe('corpus:b');
+    });
+  });
+});

--- a/src/services/corpusRetriever.js
+++ b/src/services/corpusRetriever.js
@@ -1,0 +1,104 @@
+/**
+ * corpusRetriever.js — cablea el corpus del sidecar (5647 chunks dr-fanout +
+ * fichas, pgvector nomic 768d) al chat del agente. Complementa el RAG cliente
+ * (ragRetriever, 501 fichas arctic 1024d) llamando al endpoint /hybrid-retrieve
+ * del sidecar y devolviendo pasajes en la MISMA forma { key, text, score } que
+ * consume buildCorpusVariants — así se mezclan sin tocar el ensamblado del prompt.
+ *
+ * Gated por VITE_USE_CORPUS_RETRIEVAL (OFF por defecto → cero cambio en el flujo
+ * RAG). Fail-soft: cualquier error/timeout devuelve [] (nunca degrada la UX).
+ *
+ * ¿Por qué separado del RAG cliente? El corpus vive server-side (768d nomic, con
+ * su índice HNSW), el cliente es 1024d arctic — embeddings incompatibles. Se
+ * consultan como dos piernas y se fusionan a nivel de pasajes, no de vectores.
+ */
+
+const CORPUS_TIMEOUT_MS = 5000;
+const TEXT_MAX = 4000; // cota por chunk (evita inflar el prompt)
+
+/** ¿Retrieval del corpus activo? Gated por env. OFF por defecto. */
+export function isCorpusRetrievalEnabled() {
+  try {
+    const raw = import.meta.env?.VITE_USE_CORPUS_RETRIEVAL;
+    if (raw === true) return true;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1' || v === 'on';
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+function getBaseUrl() {
+  try {
+    const raw = import.meta.env?.VITE_SIDECAR_URL;
+    if (typeof raw === 'string' && raw.trim()) return raw.trim().replace(/\/+$/, '');
+  } catch (_) { /* ignore */ }
+  // Default alineado con sidecarClient.getBaseUrl() (/api/mcp/agro): el sidecar
+  // vive detrás de nginx en /api/mcp/agro/, NO en /api. Con el default viejo
+  // '/api' el fetch pegaba a /api/hybrid-retrieve (404) → [] silencioso → el
+  // corpus jamás se cableaba aunque el flag estuviera ON. Verificado 2026-07-29.
+  return '/api/mcp/agro';
+}
+
+function getToken() {
+  try {
+    const raw = import.meta.env?.VITE_CHAGRA_MCP_TOKEN;
+    return typeof raw === 'string' ? raw : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+function clip(s) {
+  return typeof s === 'string' ? s.slice(0, TEXT_MAX) : '';
+}
+
+/**
+ * Recupera pasajes del corpus del sidecar. Devuelve [] si está deshabilitado,
+ * si falla, o si no hay resultados. Nunca lanza.
+ * @param {string} query
+ * @param {number} [topK=3]
+ * @returns {Promise<Array<{key:string,text:string,score:number,title?:string,foreign?:boolean}>>}
+ */
+export async function retrieveCorpus(query, topK = 3) {
+  if (!isCorpusRetrievalEnabled()) return [];
+  const q = (query ?? '').trim();
+  if (!q) return [];
+
+  const url = `${getBaseUrl()}/hybrid-retrieve`;
+  const headers = { 'Content-Type': 'application/json' };
+  const token = getToken();
+  if (token) headers['X-Chagra-Token'] = token;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), CORPUS_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query: q, top_k: Math.max(1, Math.min(topK, 10)) }),
+      signal: controller.signal,
+    });
+    if (!res.ok) return [];
+    const data = await res.json();
+    if (!data || data.degraded || !Array.isArray(data.results)) return [];
+    return data.results
+      .filter((r) => r && typeof r.content === 'string' && r.content.trim())
+      .map((r) => ({
+        // key con prefijo 'corpus:' → ragOriginReconciler lo trata como pasaje
+        // del corpus server-side; el chunk_key preserva la trazabilidad.
+        key: `corpus:${r.chunk_key ?? 'sin-key'}`,
+        text: clip(r.content),
+        score: typeof r.similarity === 'number' ? r.similarity : 0,
+        title: typeof r.title === 'string' ? r.title : undefined,
+        source_type: typeof r.source_type === 'string' ? r.source_type : undefined,
+      }));
+  } catch (_) {
+    return []; // fail-soft
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
Rescate de #2593 rebasado sobre dev. Cablea el corpus server-side (hybrid-retrieve: pgvector 5906 chunks + reranker neural bge-reranker-v2-m3 + gate low_relevance) al RAG del chat. Aditivo, fail-soft, flag ON solo en dev.

**FIX vs el PR original**: corpusRetriever base default '/api'→'/api/mcp/agro' + VITE_SIDECAR_URL en dev-deploy.yml. Sin esto el flag ON era no-op silencioso (404→[]).

Contrato verificado contra /hybrid-retrieve vivo. Tests 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)