### PR TITLE
feat(vision): portar juez de visión async (revive el gate muerto por timeout)

### DIFF
--- a/src/services/__tests__/sidecarClient.judgeVision.test.js
+++ b/src/services/__tests__/sidecarClient.judgeVision.test.js
@@ -93,3 +93,86 @@ describe('judgeVision — V-08 cross-verify visión', () => {
     expect(res).toBeNull();
   });
 });
+
+describe('judgeVisionAsync — gate async #328 (encola, 202)', () => {
+  it('POSTea a /judge-vision-async y devuelve {request_id}', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(202, { request_id: 'jv-abc-123' }));
+    const { judgeVisionAsync } = await importFresh();
+
+    const res = await judgeVisionAsync('coffea_arabica', 'BASE64DATA');
+
+    expect(res).toEqual({ request_id: 'jv-abc-123' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/mcp/agro/judge-vision-async');
+    expect(fetchMock.mock.calls[0][1].method).toBe('POST');
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      species_id: 'coffea_arabica',
+      image_b64: 'BASE64DATA',
+    });
+  });
+
+  it('devuelve null sin fetch cuando falta species_id o image_b64', async () => {
+    const { judgeVisionAsync } = await importFresh();
+
+    expect(await judgeVisionAsync('', 'IMG')).toBeNull();
+    expect(await judgeVisionAsync('coffea_arabica', '')).toBeNull();
+    expect(await judgeVisionAsync(null, 'IMG')).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('devuelve null si el sidecar responde sin request_id', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(202, { ok: true }));
+    const { judgeVisionAsync } = await importFresh();
+
+    const res = await judgeVisionAsync('zea_mays', 'IMG');
+    expect(res).toBeNull();
+  });
+
+  it('devuelve null cuando el sidecar falla (no-2xx)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(503, { error: 'queue full' }));
+    const { judgeVisionAsync } = await importFresh();
+
+    const res = await judgeVisionAsync('coffea_arabica', 'IMG');
+    expect(res).toBeNull();
+  });
+});
+
+describe('judgeVisionResult — poll del veredicto async #328', () => {
+  it('GETea /judge-vision-result con ?request_id y pasa el body crudo (done)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { status: 'done', plausible: true, confidence: 77, motivo: 'coincide' }),
+    );
+    const { judgeVisionResult } = await importFresh();
+
+    const res = await judgeVisionResult('jv-abc-123');
+
+    expect(res).toEqual({ status: 'done', plausible: true, confidence: 77, motivo: 'coincide' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/mcp/agro/judge-vision-result?request_id=jv-abc-123');
+    expect(fetchMock.mock.calls[0][1].method).toBe('GET');
+  });
+
+  it('pasa el estado pending tal cual (aún juzgando)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { status: 'pending' }));
+    const { judgeVisionResult } = await importFresh();
+
+    const res = await judgeVisionResult('jv-pending');
+    expect(res).toEqual({ status: 'pending' });
+  });
+
+  it('devuelve null sin fetch cuando falta request_id', async () => {
+    const { judgeVisionResult } = await importFresh();
+
+    expect(await judgeVisionResult('')).toBeNull();
+    expect(await judgeVisionResult(null)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('devuelve null cuando el sidecar falla (no-200)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(500, { error: 'gone' }));
+    const { judgeVisionResult } = await importFresh();
+
+    const res = await judgeVisionResult('jv-abc-123');
+    expect(res).toBeNull();
+  });
+});

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -21,7 +21,7 @@
 
 import { streamOllama } from './ollamaStream';
 import { retrieve } from './ragRetriever';
-import { callTool, isSidecarEnabled, judgeVision } from './sidecarClient';
+import { callTool, isSidecarEnabled, judgeVisionAsync } from './sidecarClient';
 import { parseJsonTolerant } from '../utils/parseJsonTolerant';
 import { hashImage, getCached, setCached } from './visionCacheService';
 import { ENV } from '../config/env';
@@ -508,10 +508,19 @@ export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
   // confirmó que el NOMBRE existe en catálogo, pero no que la imagen coincida
   // (el modelo de visión pudo alucinar el binomial). Best-effort: el sidecar
   // capa a 500 ms y nunca bloquea; cualquier fallo → null (no degrada la UX).
+  // Gate ASYNC (#328): el juez local tarda ~16-23s (minicpm-v:8b en CPU, fuera de
+  // la VRAM del agente); el sync `/judge-vision` lo abortaba el propio cliente a
+  // TOOL_TIMEOUT_MS=5s → veredicto SIEMPRE null (gate muerto). Encolamos SIN
+  // bloquear el diagnóstico (no metemos 20s de latencia a la foto). `_grounded.judge`
+  // queda `{status:'async', request_id}`; el veredicto se recoge luego con
+  // `judgeVisionResult(request_id)` (badge que se resuelve solo). Best-effort:
+  // cualquier fallo → null (no degrada la UX, igual que antes).
   const runJudge = async (speciesId) => {
     try {
       const b64 = await blobToBase64(imageBlob);
-      return await judgeVision(speciesId, b64);
+      const q = await judgeVisionAsync(speciesId, b64);
+      if (!q || !q.request_id) return null;
+      return { status: 'async', request_id: q.request_id };
     } catch (_) {
       return null;
     }

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -970,6 +970,51 @@ export async function judgeVision(speciesId, imageB64) {
 }
 
 /**
+ * Gate ASÍNCRONO del juez de visión (#328). El juez local tarda ~16-23s
+ * (minicpm-v:8b en CPU, fuera de la VRAM del agente) y el sync `/judge-vision`
+ * lo aborta el propio cliente a TOOL_TIMEOUT_MS=5s → veredicto siempre null
+ * (gate muerto). Este par desacopla: `judgeVisionAsync` ENCOLA (202 en ~11ms)
+ * y devuelve `{request_id}`; `judgeVisionResult` recoge el veredicto luego
+ * (poll). Así el diagnóstico NO se bloquea esperando al juez.
+ *
+ * @param {string} speciesId @param {string} imageB64
+ * @returns {Promise<null | {request_id: string}>}
+ */
+export async function judgeVisionAsync(speciesId, imageB64) {
+  if (!speciesId || typeof speciesId !== 'string') return null;
+  if (!imageB64 || typeof imageB64 !== 'string') return null;
+  const raw = await postJson(
+    '/judge-vision-async',
+    { species_id: speciesId, image_b64: imageB64 },
+    TOOL_TIMEOUT_MS,
+  );
+  if (!raw || typeof raw !== 'object' || typeof raw.request_id !== 'string') {
+    return null;
+  }
+  return { request_id: raw.request_id };
+}
+
+/**
+ * Recoge el veredicto async por `request_id` (poll del gate #328). El sidecar
+ * devuelve `{status:'pending'}` mientras el juez CPU no termina, `{status:'done',
+ * plausible, confidence, motivo}` cuando resuelve, o `{status:'error', reason}`.
+ * Pasa el body crudo del sidecar tal cual (el consumidor decide por `status`).
+ *
+ * @param {string} requestId
+ * @returns {Promise<null | {status:'done', plausible:boolean|null, confidence:number|null, motivo:string} | {status:'pending'} | {status:'error', reason?:string}>}
+ */
+export async function judgeVisionResult(requestId) {
+  if (!requestId || typeof requestId !== 'string') return null;
+  const raw = await getJson(
+    '/judge-vision-result',
+    { request_id: requestId },
+    TOOL_TIMEOUT_MS,
+  );
+  if (!raw || typeof raw !== 'object') return null;
+  return raw;
+}
+
+/**
  * Wrapper defensivo de `get_normativa_ica`. Validá la action localmente
  * para que el frontend NO pueda pedir paths arbitrarios al sidecar.
  *


### PR DESCRIPTION
## Bug
El juez de visión de `dev` estaba MUERTO. El cliente usa el gate SÍNCRONO (`judgeVision` → `POST /judge-vision`) y lo aborta a `TOOL_TIMEOUT_MS=5s`, pero el juez CPU (`minicpm-v:8b`, fuera de la VRAM del agente) tarda 16-23s → el veredicto era **SIEMPRE null**. El gate anti-alucinación de visión (V-08 #229) no aportaba nada.

## Causa raíz
Mismatch de timeouts: 5s de abort del cliente vs 16-23s del juez multimodal en CPU. `main` (commit `cd88a118`, PR #2791) ya lo resolvió con un juez ASÍNCRONO no bloqueante. El endpoint async ya existe en el sidecar (`/judge-vision-async` POST → 202 `request_id`, `/judge-vision-result` GET/poll), común a dev y prod — no se toca el sidecar, solo se cablea el cliente.

## Cambios
- `src/services/sidecarClient.js`: agrega `judgeVisionAsync` (POST `/judge-vision-async`, encola, devuelve `{request_id}`) y `judgeVisionResult` (GET `/judge-vision-result?request_id=`, poll, pasa el body crudo del sidecar). Ambas reutilizan `postJson`/`getJson` de dev → mismo `getBaseUrl()` (`/api/mcp/agro`), header `X-Chagra-Token`, degrade-to-null. La `judgeVision` sync se conserva (no se rompe nada).
- `src/services/aiService.js`: `runJudge` ahora encola con `judgeVisionAsync` en vez de bloquear con `judgeVision`; deja `_grounded.judge = {status:'async', request_id}` para recoger el veredicto luego (badge que se resuelve solo). No mete 20s de latencia a la foto. El import pasa a `judgeVisionAsync` (sin dejar imports sin usar → eslint max-warnings=0 limpio).
- `src/services/__tests__/sidecarClient.judgeVision.test.js`: +8 casos para las dos funciones nuevas.

## Nota base-URL
El gotcha de `getBaseUrl` default a `/api` (404 silencioso) NO aplica: el `getBaseUrl` de dev ya default a `/api/mcp/agro`. Verificado.

## Tests
- **12/12 vitest passing** en `sidecarClient.judgeVision.test.js` (4 sync originales + 8 nuevos: encola 202, valida args, respuesta sin request_id, no-2xx, poll done, poll pending, sin request_id, no-200).
- **33/33 passing** en `aiService.grounded` + `aiService.visionCache` + `visionQueueService` (el cableado async no rompe el flujo de grounding).
- lefthook completo verde (eslint sobre los servicios sin OOM, conventional, secret/infra/strategic scans).
- El fallo pre-existente `reconciliación allow-list ↔ NLU` en `sidecarClient.test.js` es de `dev` base (falla igual sin este cambio) — ajeno a este PR.

## Verificación end-to-end (sidecar vivo :7880)
- `POST /judge-vision-async` con `X-Chagra-Token` → **202** `{"status":"queued","request_id":"..."}` (contrato de `judgeVisionAsync`).
- `GET /judge-vision-result?request_id=...` → **200** `{"status":"pending"}` mientras el juez CPU trabaja (contrato de `judgeVisionResult`).
- Sin token → **401** (auth OK).

Refs: PR #2791 (`cd88a118`), incidente gate visión muerto por timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)