### PR TITLE
fix(services): 3 alertas CodeQL (missing-await FP + comparación redundante)

### DIFF
--- a/src/services/climaService.js
+++ b/src/services/climaService.js
@@ -245,12 +245,13 @@ export async function fetchClimaSnapshot({ lat, lng, elevation, forceRefresh = f
         }
         return payload ? withEffectiveEnso(memCache?.payload || payload) : payload;
     })();
-    inFlight = { key, promise };
+    const inFlightToken = {};
+    inFlight = { key, promise, token: inFlightToken };
 
     try {
         return await promise;
     } finally {
-        if (inFlight && inFlight.promise === promise) inFlight = null;
+        if (inFlight && inFlight.token === inFlightToken) inFlight = null;
     }
 }
 

--- a/src/services/skyConditionService.js
+++ b/src/services/skyConditionService.js
@@ -428,11 +428,12 @@ export async function fetchSkyConditions(opts = /** @type {any} */ ({})) {
       return null;
     }
   })();
-  inFlight = { key, promise };
+  const inFlightToken = {};
+  inFlight = { key, promise, token: inFlightToken };
   try {
     return await promise;
   } finally {
-    if (inFlight && inFlight.promise === promise) inFlight = null;
+    if (inFlight && inFlight.token === inFlightToken) inFlight = null;
   }
 }
 

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -573,7 +573,7 @@ function playSentenceBlob(url, rate) {
     // mundo, o un efecto que re-dispara) apilan voces "papá noel" que se pisan
     // y se quedan en loop. speak()/speakSentences() ya cortan; este path no lo
     // hacía y era la raíz del solape/loop de la voz em_santa.
-    if (currentKokoroAudio && currentKokoroAudio !== null) {
+    if (currentKokoroAudio) {
       try {
         currentKokoroAudio.pause();
         currentKokoroAudio.onended = null;


### PR DESCRIPTION
Cierra las 3 alertas CodeQL restantes en `src/services` tras el triage 2026-07-29 (221→0). clima/sky: token en el finally del dedup in-flight (idéntico comportamiento); tts: quita `!== null` redundante.