### PR TITLE
feat(compai): el compañero 3D refleja el avatar elegido (no siempre la abeja)

### DIFF
--- a/src/visual/mundo3d/escenas/CompaiEscena.jsx
+++ b/src/visual/mundo3d/escenas/CompaiEscena.jsx
@@ -1,0 +1,31 @@
+/*
+ * CompaiEscena — EL COMPAÑERO DEL MUNDO 3D, SEGÚN EL AVATAR QUE EL USUARIO ELIGIÓ.
+ *
+ * Drop-in de AbejaEscena (mismas props). Cierra el bug "oso→abeja": antes el
+ * mundo montaba SIEMPRE a Angelita; ahora consulta el avatar elegido
+ * (useCompaiElegido) y monta la escena propia del compañero si la tiene. Hoy
+ * solo Angelita tiene arte 3D, así que maíz y zarigüeya caen a AbejaEscena (sin
+ * regresión). Cuando el Fable de compai (#5) registre su <XEscena> en
+ * compaiRegistry, este dispatcher la monta automáticamente — sin tocar este
+ * archivo ni EscenaBase3D ni las escenas de cada mundo.
+ *
+ * Vive en escenas/ (chunk perezoso vendor-three): AbejaEscena arrastra
+ * @react-three, así que este archivo NUNCA se importa desde el barrel base.
+ */
+import { AbejaEscena } from './useEntradaAbeja.jsx';
+import useCompaiElegido from './useCompaiElegido.js';
+
+/**
+ * @param {object} props  las MISMAS de AbejaEscena (foco, entrando, hablando,
+ *   rebote, animo, energia, estadoFinca, hayAlerta, reducedMotion, piso, tier,
+ *   mundoId, viajeRef, ...). Se pasan tal cual al compañero resuelto.
+ */
+export function CompaiEscena(props) {
+  const compai = useCompaiElegido();
+  if (compai.EscenaComponent) {
+    const Escena = compai.EscenaComponent;
+    return <Escena {...props} compai={compai} />;
+  }
+  // Fallback: Angelita (angelita nativa, o maíz/zarigüeya aún sin arte 3D).
+  return <AbejaEscena {...props} />;
+}

--- a/src/visual/mundo3d/escenas/EscenaBase3D.jsx
+++ b/src/visual/mundo3d/escenas/EscenaBase3D.jsx
@@ -24,7 +24,7 @@ import { Suspense, lazy, useMemo, useRef, useState } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Html, OrbitControls, Stars } from '@react-three/drei';
 import * as THREE from 'three';
-import { AbejaEscena } from './useEntradaAbeja.jsx';
+import { CompaiEscena } from './CompaiEscena.jsx';
 import CamaraDirector from './CamaraDirector.jsx';
 import { SombraContacto } from './SombraContacto.jsx';
 import { ESTADO_FINCA_MUESTRA } from './reaccionFinca.js';
@@ -311,11 +311,14 @@ function Contenido({
         );
       })}
 
-      {/* Angelita: una sola por mundo (la del footer se oculta dentro). `entrando`
-          vive AHORA en si hay hotspot activo — con foco se posa junto a la puerta,
-          sin foco RONDA (idle propio, ya no un fotograma clavado). `hablando` la
-          hace pulsar cuando el agente narra; `rebote` es el microrrebote del toque. */}
-      <AbejaEscena
+      {/* EL COMPAÑERO del mundo: según el avatar elegido (CompaiEscena resuelve
+          angelita/maíz/zarigüeya). Una sola por mundo (la del footer se oculta
+          dentro). `entrando` vive AHORA en si hay hotspot activo — con foco se
+          posa junto a la puerta, sin foco RONDA (idle propio, ya no un fotograma
+          clavado). `hablando` la hace pulsar cuando el agente narra; `rebote` es
+          el microrrebote del toque. Hoy maíz/zarigüeya caen a Angelita (fallback,
+          sin regresión) hasta que el Fable de compai (#5) les dé arte 3D. */}
+      <CompaiEscena
         foco={foco}
         entrando={!!activo}
         hablando={hablando}

--- a/src/visual/mundo3d/escenas/__tests__/compaiRegistry.test.js
+++ b/src/visual/mundo3d/escenas/__tests__/compaiRegistry.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { resolverCompai, COMPAI_REGISTRO } from '../compaiRegistry.js';
+import { ABEJA_PRESENCIA } from '../../../creatures/abejaIdentidad.js';
+import { AVATAR_TYPES } from '../../../../hooks/useAgentAvatarType.js';
+
+describe('compaiRegistry.resolverCompai', () => {
+  it('cubre TODOS los tipos de avatar reales (sin huérfanos)', () => {
+    for (const tipo of AVATAR_TYPES) {
+      expect(COMPAI_REGISTRO[tipo], `falta ${tipo} en el registro`).toBeDefined();
+    }
+  });
+
+  it('angelita = compañero nativo (sin fallback, no pendiente)', () => {
+    const c = resolverCompai('angelita');
+    expect(c.avatarType).toBe('angelita');
+    expect(c.especie).toBe('abeja-angelita');
+    expect(c.pendienteFable).toBe(false);
+    expect(c.presencia).toBe(ABEJA_PRESENCIA);
+  });
+
+  it('maíz y zarigüeya: pendientes de Fable → fallback a Angelita (sin regresión)', () => {
+    for (const tipo of ['maiz', 'zariguya']) {
+      const c = resolverCompai(tipo);
+      expect(c.avatarType).toBe(tipo);
+      expect(c.pendienteFable).toBe(true);
+      // Hoy caen a la abeja: sin escena propia y con la presencia de Angelita.
+      expect(c.EscenaComponent).toBeNull();
+      expect(c.esFallback).toBe(true);
+      expect(c.presencia).toBe(ABEJA_PRESENCIA);
+    }
+  });
+
+  it('tipo desconocido o vacío → default Angelita (nunca lanza)', () => {
+    for (const basura of ['colibri', 'oso', '', null, undefined]) {
+      const c = resolverCompai(basura);
+      expect(c.avatarType).toBe('angelita');
+      expect(c.EscenaComponent).toBeNull();
+    }
+  });
+
+  it('siempre devuelve una entrada usable (presencia + especie presentes)', () => {
+    const c = resolverCompai('maiz');
+    expect(c.presencia).toBeTruthy();
+    expect(typeof c.especie).toBe('string');
+    expect(typeof c.presencia.billboardBase).toBe('number');
+    expect(c.presencia.percha).toMatchObject({ x: expect.any(Number), y: expect.any(Number), z: expect.any(Number) });
+  });
+});

--- a/src/visual/mundo3d/escenas/compaiRegistry.js
+++ b/src/visual/mundo3d/escenas/compaiRegistry.js
@@ -1,0 +1,82 @@
+/*
+ * compaiRegistry — EL COMPAÑERO DEL MUNDO 3D SEGÚN EL AVATAR ELEGIDO.
+ *
+ * El bug histórico ("oso→abeja"): el compañero que vuela por los mundos 3D era
+ * SIEMPRE Angelita (AbejaEscena hard-wired en EscenaBase3D), sin mirar el avatar
+ * que el usuario eligió en el selector. Este registro es la mesa de ruteo:
+ *
+ *     avatarType ('angelita'|'maiz'|'zariguya')  →  cómo se presenta en 3D.
+ *
+ * REGLA DEL FALLBACK: hoy SOLO Angelita tiene presencia 3D propia (coreografía
+ * useEntradaAbeja + ABEJA_PRESENCIA). El maíz y la zarigüeya YA son opciones de
+ * avatar (useAgentAvatarType) pero todavía NO tienen arte 3D — esperan el Fable
+ * de compai (#5). Mientras tanto caen a Angelita: es mejor la abeja que un maíz
+ * o una zarigüeya "volando" con la coreografía de la abeja (sería peor). Cuando
+ * el Fable aterrice su <XEscena> + su presencia, se registran aquí y el mundo
+ * refleja la elección SIN tocar EscenaBase3D ni las escenas de cada mundo.
+ *
+ * SOLO DATOS + tipos: no arrastra three ni componentes de arte al importarse.
+ */
+import { ABEJA_PRESENCIA } from '../../creatures/abejaIdentidad.js';
+import { AVATAR_TYPES, DEFAULT_AVATAR_TYPE } from '../../../hooks/useAgentAvatarType.js';
+
+/**
+ * EL CONTRATO DE PRESENCIA 3D que todo compañero debe cumplir para vivir en un
+ * mundo (la referencia es ABEJA_PRESENCIA en abejaIdentidad.js):
+ * @typedef {Object} CompaiPresencia
+ * @property {number} billboardBase       px base del billboard <Html>.
+ * @property {number} billboardPorEnergia ganancia de px por energía (0..1).
+ * @property {number} distancia           distanceFactor de la cámara.
+ * @property {{x:number,y:number,z:number}} percha  su posición junto al foco.
+ * @property {number} rondaAltura         altura a la que ronda cuando no entra.
+ * @property {{radio:number,opacidad:number,opacidadBase:number,opacidadMin:number,atenuaPorAltura:number,ensanchaPorAltura:number}} sombra  su sombra de contacto.
+ *
+ * Además, el arte del compañero debe traer su FIRMA DE SILUETA (como
+ * ZARIGUYA_FIRMA / abejaIdentidad) — legible a tamaño billboard — y su idle /
+ * seguir-al-foco / reacción, al nivel de Angelita.
+ */
+
+/**
+ * @typedef {Object} CompaiEntry
+ * @property {string} avatarType  el tipo resuelto ('angelita'|'maiz'|'zariguya').
+ * @property {(import('react').ComponentType|null)} EscenaComponent  la escena 3D
+ *   PROPIA del compañero (coreografía + cuerpo). `null` → usa la coreografía y el
+ *   cuerpo de Angelita (AbejaEscena) como fallback, sin regresión.
+ * @property {CompaiPresencia} presencia  cómo se dimensiona/posa en 3D.
+ * @property {string} especie  slug `data-creature` del cuerpo activo.
+ * @property {boolean} pendienteFable  aún sin arte 3D propio (cae a la abeja).
+ * @property {boolean} esFallback  el tipo pedido no resolvió a una escena propia.
+ */
+
+/* El mapa. `EscenaComponent: null` = todavía lo dibuja Angelita. Fable rellena. */
+const REGISTRO = {
+  angelita: { EscenaComponent: null, presencia: ABEJA_PRESENCIA, especie: 'abeja-angelita', pendienteFable: false },
+  // TODO(fable #5): MaizCompaiEscena + maizIdentidad (presencia propia, brisa
+  //   asimétrica). Hoy: fallback a Angelita.
+  maiz: { EscenaComponent: null, presencia: ABEJA_PRESENCIA, especie: 'abeja-angelita', pendienteFable: true },
+  // TODO(fable #5): ZariguyaCompaiEscena + su presencia 3D. zariguyaIdentidad ya
+  //   trae FIRMA/PALETA/PROPORCION; falta _PRESENCIA + coreografía (marsupial
+  //   nocturno que camina, NO vuela). Hoy: fallback a Angelita.
+  zariguya: { EscenaComponent: null, presencia: ABEJA_PRESENCIA, especie: 'abeja-angelita', pendienteFable: true },
+};
+
+/**
+ * Resuelve el compañero 3D para un tipo de avatar. Tipo desconocido/ausente →
+ * el default (Angelita). Nunca lanza; siempre devuelve una entrada usable.
+ * @param {string} avatarType
+ * @returns {CompaiEntry}
+ */
+export function resolverCompai(avatarType) {
+  const pedido = AVATAR_TYPES.includes(avatarType) ? avatarType : DEFAULT_AVATAR_TYPE;
+  const base = REGISTRO[pedido] ?? REGISTRO[DEFAULT_AVATAR_TYPE];
+  return {
+    avatarType: pedido,
+    EscenaComponent: base.EscenaComponent ?? null,
+    presencia: base.presencia ?? ABEJA_PRESENCIA,
+    especie: base.especie ?? 'abeja-angelita',
+    pendienteFable: !!base.pendienteFable,
+    esFallback: base.EscenaComponent == null,
+  };
+}
+
+export { REGISTRO as COMPAI_REGISTRO };

--- a/src/visual/mundo3d/escenas/useCompaiElegido.js
+++ b/src/visual/mundo3d/escenas/useCompaiElegido.js
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import useAgentAvatarType from '../../../hooks/useAgentAvatarType.js';
+import { resolverCompai } from './compaiRegistry.js';
+
+/**
+ * Puente vivo entre la elección del usuario y el mundo 3D. Lee el avatar elegido
+ * (useAgentAvatarType, que ya sincroniza entre pestañas por el evento
+ * `chagra:agent-avatar-changed` y por `storage`) y devuelve el compañero 3D
+ * resuelto. Cuando el usuario cambia de avatar, este hook re-resuelve y la escena
+ * intercambia de compañero SIN recargar.
+ *
+ * @returns {import('./compaiRegistry.js').CompaiEntry}
+ */
+export default function useCompaiElegido() {
+  const [avatarType] = useAgentAvatarType();
+  return useMemo(() => resolverCompai(avatarType), [avatarType]);
+}


### PR DESCRIPTION
## Qué
El compañero que vuela por los mundos 3D era **siempre Angelita** (`AbejaEscena` hard-wired en `EscenaBase3D`), ignorando el avatar que el usuario eligió (maíz / zarigüeya). Cierra ese bug cableando el seam central.

## Cómo (solo wiring, cero arte)
- **`compaiRegistry.js`** — `avatarType → compañero 3D`, con el contrato de presencia documentado y **fallback a Angelita** para tipos sin arte 3D todavía.
- **`useCompaiElegido.js`** — puente vivo: lee `useAgentAvatarType` (sync entre pestañas) → resuelve el compañero.
- **`CompaiEscena.jsx`** — dispatcher drop-in de `AbejaEscena`: monta la escena propia del compañero si la tiene; si no, cae a Angelita (**sin regresión**).
- **`EscenaBase3D.jsx`** — monta `CompaiEscena` (único seam; no toca las escenas de cada mundo).

## Estado hoy
`AVATAR_TYPES` reales en dev = `['angelita','maiz','zariguya']` (el colibrí se jubiló). Solo Angelita tiene presencia 3D → **maíz y zarigüeya caen a Angelita (fallback)**. El arte 3D propio llega con el **Fable de compai (#5)**, que solo registra su `<XEscena>` + presencia en `compaiRegistry` y el mundo lo refleja sin tocar nada más.

## Verificación
- Smoke test `compaiRegistry.test.js` (5/5): cubre los 3 tipos + fallback + tipo desconocido.
- eslint `--max-warnings=0` limpio en los 5 archivos.
- Zero regresión: hoy todo resuelve a `AbejaEscena` como antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)