### PR TITLE
feat(paramo): queñua-Ent por piso térmico + vecino aliso + frailejón-paisaje (mundo)

### DIFF
--- a/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
+++ b/src/visual/mundo3d/bosque/EscenaBosqueVivo.jsx
@@ -14,9 +14,16 @@
  *   · DE SueloDemo3D (archivado): el SUELO RICO como terreno (ya era la base
  *     del anfiteatro; ahora viste su paleta dorada de páramo) + las PEÑAS de
  *     hito sembradas con distribuirDetalle.
- *   · FUERA el Ent y el campesino ("están horribles"): ni EntQuenua ni la
- *     figura de escala. El centro del claro lo toma el PATRIARCA — el
- *     frailejón más viejo y más alto del rodal — con su queñua matriarca.
+ *
+ * ── EL ENT VUELVE, PERO ES LA QUEÑUA (2026-07-30) ──────────────────────────
+ * El operador había sacado el Ent ("está horrible") — pero eso era la vieja
+ * `EntQuenua` standalone, de otra mano. Cerró la decisión de reintegrarlo con
+ * el cincel RECONCILIADO (`EntGradiente especie="quenua"`, el aprobado en
+ * `tres-ents-gradiente`): el guardián del páramo es la QUEÑUA (Polylepis), y el
+ * FRAILEJÓN pasa a PAISAJE (frailejonal + patriarca en flor de acompañamiento).
+ * El Ent y su vecino salen del mapa compartido `pisosBosqueGradiente` (no a
+ * mano): protagonista = queñua; vecino visible = el piso de abajo (frío =
+ * aliso) en silueta ladera abajo. Máximo dos. El campesino sigue fuera.
  *
  * La pared del anfiteatro conserva el abrigo del cuenco SALVO por la ABRA
  * (bosqueTakeA): la ventana angular por donde la meseta se despeña hacia la
@@ -39,7 +46,9 @@ import { geomPiedraSuelo, distribuirDetalle } from '../terreno/sueloRico.geom.js
 import FloraParamo from './FloraParamo.jsx';
 import FaunaBosque from './FaunaBosque.jsx';
 import FondoParamo from './fondoParamo.jsx';
+import EntGradiente from './EntGradiente.jsx';
 import { geomFrailejon, calidadDeTier } from './floraParamo.geom.js';
+import { MAPA_PISO_ENT, protagonistaDePiso, vecinoDePiso } from './pisosBosqueGradiente.js';
 import {
   alturaBosque,
   sueloDelBosque,
@@ -50,6 +59,19 @@ import {
   geomTroncosCaidos,
   curvaArroyo,
 } from './bosqueTakeA.geom.js';
+
+/* ── EL ENT POR PISO TÉRMICO (cerrando el gap: antes esto solo lo consumía el
+      mockup `tres-ents-gradiente`) ────────────────────────────────────────────
+   Este mundo ES el páramo, el tope del gradiente. Su Ent protagonista y su
+   único vecino visible salen del MISMO mapa compartido que la ladera de los
+   cuatro maestros (`pisosBosqueGradiente.js`, ya aprobado y testeado), no de
+   un valor a mano: así el día que se retoque el gradiente, este mundo lo
+   hereda. Protagonista = la QUEÑUA (Polylepis); vecino = el piso de ABAJO
+   (frío → ALISO), que se dibuja SOLO como silueta ladera abajo (máximo dos). */
+const PISO_MUNDO = 'paramo';
+const ENT_PROTAGONISTA = MAPA_PISO_ENT[protagonistaDePiso(PISO_MUNDO)]; // 'quenua'
+const PISO_VECINO = vecinoDePiso(PISO_MUNDO); // 'frio'
+const ENT_VECINO = PISO_VECINO ? MAPA_PISO_ENT[PISO_VECINO] : null; // 'aliso'
 
 /* ── LA ATMÓSFERA DEL BOSQUE DE NIEBLA ─────────────────────────────────────
       Los presets del día salen de CIELOS_HORA (la misma familia del valle:
@@ -369,18 +391,27 @@ function Arroyo({ nocturno, perfil }) {
   );
 }
 
-/* ── EL CORAZÓN DEL CLARO: el PATRIARCA y su corte ─────────────────────────
-      Donde vivía el Ent ahora manda el frailejón MÁS VIEJO del rodal — el
-      patriarca en flor, por encima de los héroes del proscenio — con un
-      acompañante, la queñua matriarca (el árbol del páramo, sin rostro) y las
-      piedras del claro. La mirada de reposo cae exactamente aquí. */
+/* ── EL CORAZÓN DEL CLARO: la QUEÑUA-ENT y su corte de frailejones ──────────
+      El operador cerró la decisión (2026-07-30): el guardián del páramo VUELVE,
+      pero es la QUEÑUA (el cincel reconciliado de `EntGradiente`, el que aprobó
+      en `tres-ents-gradiente` — NO la vieja `EntQuenua` standalone que sacó por
+      "horrible"). El FRAILEJÓN pasa a PAISAJE: el patriarca en flor y su segundo
+      quedan de acompañantes contundentes, flanqueando al Ent sin taparle la
+      cara. La queñua se sale ADELANTE y a un lado del proscenio para que la
+      mirada de reposo caiga en su rostro, con el frailejonal desplegándose
+      alrededor. La lección (el agua que nace aquí y baja al valle) la señala su
+      brazo maestro y la cuenta el panel del mundo (entGuion, la queñua). */
 const CENTRO = {
-  patriarca: { x: -1.6, z: 0.6, escala: 2.55, rotY: 0.8 },
-  segundo: { x: 1.9, z: 1.7, escala: 1.3, rotY: 2.4 },
-  matriarca: { x: 4.1, z: -3.9, escala: 1.5, rotY: 1.1 },
+  /* La queñua-Ent: adelante-izquierda del claro, girada a encarar la cámara de
+     reposo (que se para en +x/+z). Base posada sobre el relieve. */
+  ent: { x: -1.2, z: 1.4, rotY: 0.62 },
+  /* Frailejones de PAISAJE (ya no protagonistas): el patriarca en flor a la
+     derecha del Ent y un segundo detrás-izquierda, más un joven al frente. */
+  patriarca: { x: 3.0, z: 0.2, escala: 2.15, rotY: 0.8 },
+  segundo: { x: -4.2, z: -1.1, escala: 1.45, rotY: 2.4 },
   rocas: [
-    { x: -2.7, z: 1.8, escala: 1.9, rotY: 0.4 },
-    { x: 1.0, z: 2.9, escala: 1.2, rotY: 2.1 },
+    { x: -2.7, z: 2.4, escala: 1.9, rotY: 0.4 },
+    { x: 1.6, z: 2.9, escala: 1.2, rotY: 2.1 },
     { x: 2.3, z: -1.3, escala: 1.5, rotY: 4.4 },
   ],
 };
@@ -393,13 +424,11 @@ const posarCentro = (p, hundir = 0) => ({
   tint: [1, 1, 1],
 });
 
-function CentroParamo({ tier, perfil }) {
-  const q = tier === 'alto' ? 1 : tier === 'medio' ? 0.62 : 0.45;
+function CentroParamo({ tier, perfil, reducedMotion }) {
   const geoPatriarca = useMemo(
     () => geomFrailejon({ flor: true, q: calidadDeTier(tier), edad: 1 }, 407),
     [tier],
   );
-  const geoQuenua = useMemo(() => geomQuenua({ q }, 33), [q]);
   const geoRoca = useMemo(
     () => geomPiedraSuelo(sueloDelBosque.opts.seed + 555, sueloDelBosque.opts.paleta),
     [],
@@ -411,18 +440,28 @@ function CentroParamo({ tier, perfil }) {
     [perfil.materialRico],
   );
   const frailejones = useMemo(() => [posarCentro(CENTRO.patriarca), posarCentro(CENTRO.segundo)], []);
-  const quenua = useMemo(() => [posarCentro(CENTRO.matriarca)], []);
   const rocas = useMemo(() => CENTRO.rocas.map((r) => posarCentro(r, 0.1)), []);
+  /* La queñua-Ent se HUNDE un palmo: el pie del fuste es un anillo abierto y,
+     al ras, por el lado de abajo se le vería el hueco del tubo (igual que en la
+     ladera de los cuatro maestros). */
+  const entY = alturaBosque(CENTRO.ent.x, CENTRO.ent.z) - 0.22;
   useLayoutEffect(() => () => {
     geoPatriarca.dispose();
-    geoQuenua.dispose();
     geoRoca.dispose();
     mat.dispose();
-  }, [geoPatriarca, geoQuenua, geoRoca, mat]);
+  }, [geoPatriarca, geoRoca, mat]);
   return (
     <group>
+      {/* EL GUARDIÁN: la queñua-Ent, protagonista del piso páramo. */}
+      <group
+        name={`ent-${ENT_PROTAGONISTA}`}
+        position={[CENTRO.ent.x, entY, CENTRO.ent.z]}
+        rotation={[0, CENTRO.ent.rotY, 0]}
+      >
+        <EntGradiente especie={ENT_PROTAGONISTA} tier={tier} reducedMotion={reducedMotion} />
+      </group>
+      {/* EL PAISAJE: frailejones en flor de acompañamiento + las piedras. */}
       <Instancias geo={geoPatriarca} mat={mat} items={frailejones} castShadow={perfil.sombras} />
-      <Instancias geo={geoQuenua} mat={mat} items={quenua} castShadow={perfil.sombras} />
       <Instancias geo={geoRoca} mat={mat} items={rocas} castShadow={perfil.sombras} />
     </group>
   );
@@ -733,13 +772,16 @@ function BrumaParallax({ franja, reducedMotion }) {
    cielo lechoso del páramo ocupa el tercio alto (la firma: planicie abierta,
    cielo grande). La queñua Ent queda de acento vertical/guardián al fondo, ya no
    como muro de copas. fov 45→46 para que entre más frailejonal. */
-const POSE_BOSQUE = { position: [12.0, 5.8, 17.6], fov: 46, mira: [0, 2.5, 0] };
+/* La mirada de reposo se corre un pelo hacia la queñua-Ent (adelante-izquierda
+   del claro) y sube apenas: el rostro tallado del guardián queda legible sin
+   perder la planicie de frailejonal que se despliega a la derecha. */
+const POSE_BOSQUE = { position: [12.0, 5.8, 17.6], fov: 46, mira: [-0.7, 3.0, 0.6] };
 
-/* Anclas de sombra de contacto que la escena le pasa a SueloRico: el patriarca
-   y la queñua matriarca del centro (los objetos mayores del claro). */
+/* Anclas de sombra de contacto que la escena le pasa a SueloRico: la queñua-Ent
+   (el guardián) y el frailejón patriarca (los objetos mayores del claro). */
 const ANCLAS_SUELO = [
-  { x: -1.6, z: 0.6, radio: 1.6 },
-  { x: 4.1, z: -3.9, radio: 2.1 },
+  { x: -1.2, z: 1.4, radio: 1.7 },
+  { x: 3.0, z: 0.2, radio: 1.6 },
 ];
 
 function poseBosqueParaAspecto(aspect) {
@@ -775,8 +817,16 @@ function Diorama({ tier, reducedMotion, pose }) {
       <AtmosferaBosque franja={franja} perfil={perfil} reducedMotion={reducedMotion} />
 
       {/* LA INMENSIDAD (del páramo viejo): bóveda, cordillera, mar de nubes,
-          falda que se despeña por la abra y el frailejonal del horizonte. */}
-      <FondoParamo franja={franja} tier={tier} reducedMotion={reducedMotion} />
+          falda que se despeña por la abra y el frailejonal del horizonte. Y el
+          VECINO de abajo (frío = aliso) en silueta ladera abajo + la chorrera
+          que amarra el agua del páramo con ese piso (máximo dos, decisión
+          2026-07-30 vía `pisosBosqueGradiente`). */}
+      <FondoParamo
+        franja={franja}
+        tier={tier}
+        reducedMotion={reducedMotion}
+        vecino={ENT_VECINO}
+      />
       {fracEstrellas > 0 && perfil.estrellas > 0 && (
         <Stars
           radius={60}
@@ -826,17 +876,18 @@ function Diorama({ tier, reducedMotion, pose }) {
       {/* La bruma con parallax que da profundidad física al orbitar. */}
       {perfil.fog && <BrumaParallax franja={franja} reducedMotion={reducedMotion} />}
 
-      {/* ══ EL CENTRO DEL CLARO ══ el patriarca en flor, la queñua matriarca y
-          las piedras (aquí vivía el Ent; el operador lo sacó: "está horrible").
-          Las PEÑAS de hito (SueloDemo3D) recortan su silueta contra la niebla. */}
-      <CentroParamo tier={tier} perfil={perfil} />
+      {/* ══ EL CENTRO DEL CLARO ══ la QUEÑUA-ENT (el guardián del páramo, de
+          vuelta con el cincel reconciliado) con el frailejonal en flor de
+          paisaje a su lado y las piedras. Las PEÑAS de hito (SueloDemo3D)
+          recortan su silueta contra la niebla. */}
+      <CentroParamo tier={tier} perfil={perfil} reducedMotion={reducedMotion} />
       {tier !== 'bajo' && <Penas perfil={perfil} />}
 
-      {/* Sombra de contacto del patriarca. En alto/medio la pone SueloRico
+      {/* Sombra de contacto de la queñua-Ent. En alto/medio la pone SueloRico
           (anclas de la escena); en 'bajo' SueloRico no dibuja sombras, así que
-          el kit la planta acá para que el frailejón mayor no flote. */}
+          el kit la planta acá para que el guardián no flote. */}
       {!perfil.sombrasContacto && (
-        <SombraContacto pos={[-1.6, 0.04, 0.6]} radio={1.5} color="#20281c" opacidad={0.34} orden={2} />
+        <SombraContacto pos={[-1.2, 0.04, 1.4]} radio={1.6} color="#20281c" opacidad={0.34} orden={2} />
       )}
 
       {/* LA LLEGADA (Jackson) o el reposo orbitable: nunca los dos a la vez. */}

--- a/src/visual/mundo3d/bosque/FaunaBosque.jsx
+++ b/src/visual/mundo3d/bosque/FaunaBosque.jsx
@@ -1,11 +1,12 @@
 /*
  * FaunaBosque — LA VIDA del Bosque Vivo. Un bosque sin bichos es un decorado.
  *
- * EL REGISTRO (decisión del operador, 2026-07): la fauna EMBLEMÁTICA del
- * bosque — oso (el GUARDIÁN NEGRO; el café y el borugo están archivados y no
- * se surfacean), rana, colibrí, jaguar — va con los SVG rubber-hose de
+ * EL REGISTRO (decisión del operador, 2026-07, afinado 2026-07-29): la fauna
+ * EMBLEMÁTICA del páramo — rana y colibrí — va con los SVG rubber-hose de
  * `src/visual/creatures/` como billboards <Html>: son el estándar de calidad
- * de la casa. La fauna AMBIENTAL de fondo —
+ * de la casa. El OSO y el JAGUAR SALIERON del elenco del páramo por orden del
+ * operador (feedback mundos 2026-07-29); siguen en CREATURES para otros
+ * mundos. La fauna AMBIENTAL de fondo —
  * cóndor, venado en la niebla, bandada, quetzal fugaz, mariposas, abejas,
  * escarabajo, luciérnagas — sí es geometría mínima procedural (siluetas que
  * el fog completa). Hubo un intento de oso/rana procedurales: quedó jubilado
@@ -19,10 +20,8 @@
  *   · MEDIO  — los VECINOS rubber-hose en SU casa, ya no muebles: un
  *     IDLE-CEREBRO local (el patrón useVidaIdle de PR #2482, adaptado) hojea
  *     el repertorio que cada bicho YA sabe hacer con un reloj con jitter —
- *     el oso PASEA unos pasos y vuelve (movimiento 3D real del billboard),
- *     resopla, se rasca, se sienta; el jaguar acecha y ruge en la niebla; el
- *     borugo olfatea y se acurruca; la rana pega su brinquito. Nunca el
- *     mismo gesto dos veces seguidas, nunca al unísono.
+ *     la rana pega su brinquito y reposa. Nunca el mismo gesto dos veces
+ *     seguidas, nunca al unísono.
  *   · CERCA — MARIPOSAS (la Morpho azul manda) y ABEJAS sobre el frailejonar,
  *     el COLIBRÍ que llega a una flor, liba y se va a otra (y a veces se
  *     pierde un rato del cuadro), un ESCARABAJO arrastrándose por el musgo y
@@ -31,7 +30,7 @@
  * Ritmo, no metrónomo: cada bicho lleva su fase, su reloj y su jitter propios
  * (nada aparece ni parpadea al unísono, ningún ciclo se siente en loop). La
  * franja del día sale de useCicloDia (?ciclo= para fotografiar una hora).
- * Tier-safe: bajo = solo el oso y el colibrí, quietos; medio = vecinos vivos +
+ * Tier-safe: bajo = solo la rana y el colibrí, quietos; medio = vecinos vivos +
  * cóndor + visitantes + pocas mariposas; alto = todo. reducedMotion = nada
  * animado ni intermitente: fotograma digno.
  *
@@ -54,7 +53,7 @@ const azar = (a, b) => a + Math.random() * (b - a);
    Un reloj con jitter: descanso (identidad) → gesto → descanso → otro
    gesto… Nunca repite el mismo gesto dos veces seguidas. El primer compás
    llega rápido (el bosque no arranca muerto) y `primero` deja fijar el
-   gesto de apertura (el oso SIEMPRE abre paseando: se ve que está vivo).
+   gesto de apertura (un bicho que abre moviéndose se ve que está vivo).
    Gate `activo=false` (reduced-motion, tier bajo) = ni un timer vivo. */
 function useRelojDeVida(vida, activo) {
   const [momento, setMomento] = useState(/** @type {string|null} */ (null));
@@ -562,6 +561,10 @@ function QuetzalFugaz() {
    con su rumbo y su compás propios — nunca en fila ni al unísono). */
 const VECINOS_BOSQUE = [
   {
+    /* ORDEN DEL OPERADOR (feedback mundos 2026-07-29): del elenco del páramo
+       SALEN el oso y el jaguar — y se QUEDAN el colibrí y los pájaros
+       dibujados ("se ven espectacular"). El oso-guardian y el jaguar siguen
+       vivos en CREATURES para otros mundos; este roster ya no los llama. */
     slug: 'rana-andina',
     pos: [3.1, 0.32, 3.2],
     px: 24,
@@ -575,55 +578,12 @@ const VECINOS_BOSQUE = [
       },
     },
   },
-  {
-    /* EL OSO — el GUARDIÁN NEGRO de la luna (OsoGuardian, la dirección vigente
-       del oso de anteojos; el café está archivado y NO vuelve). Vive en el
-       borde del arbolado, asomado al claro — nunca al pie del Ent: el guardián
-       del bosque manda el centro. Abre paseando (se ve que está VIVO), resopla
-       su vaho de páramo, se remece el peso y reposa.
-
-       NOTA de puesta en escena (operador, 2026-07): aquí vivía la danta a
-       billboard grande en pleno centro del claro — a ese tamaño su silueta
-       parada leía como el oso café archivado flotando frente al Ent. La danta
-       sigue en el elenco (vitrina, páramo); esta escena se compone sin ella. */
-    slug: 'oso-guardian',
-    pos: [-3.6, 0.34, 3.2],
-    px: 64,
-    factor: 15,
-    franjas: null,
-    vida: {
-      primero: 'pasea',
-      descanso: [5000, 11000],
-      momentos: {
-        pasea: { dur: 9000, props: { pose: 'anda' }, paseo: [1.7, 0, 1.0] },
-        resopla: { dur: 4500, props: { resopla: true } },
-        seAcomoda: { dur: 5200, props: { rasca: true } },
-        reposo: { dur: 4600, props: { pose: 'reposo' } },
-      },
-    },
-  },
-  {
-    slug: 'jaguar',
-    pos: [-6.8, 0.7, -4.8],
-    px: 44,
-    factor: 15,
-    mistico: true,
-    franjas: ['amanecer', 'atardecer', 'noche'],
-    vida: {
-      primero: 'acecha',
-      descanso: [14000, 30000],
-      momentos: {
-        acecha: { dur: 6000, props: { acecha: true } },
-        ruge: { dur: 2600, props: { ruge: true } },
-      },
-    },
-  },
 ];
 
-/* En tier bajo solo queda el oso, quieto (el colibrí va aparte): el slug DEBE
-   ser uno del roster de arriba — apuntaba al 'oso-andino' archivado y el tier
-   bajo se quedaba sin un solo vecino. */
-const VECINOS_TIER_BAJO = new Set(['oso-guardian']);
+/* En tier bajo queda la rana, quieta (el colibrí va aparte): el slug DEBE ser
+   uno del roster de arriba — con el oso fuera del elenco (orden del operador),
+   la rana es la única vecina de a pie que queda en el páramo. */
+const VECINOS_TIER_BAJO = new Set(['rana-andina']);
 
 const ESTILO_CRITTER = {
   filter: 'drop-shadow(0 2px 3px rgba(25, 32, 28, 0.35))',

--- a/src/visual/mundo3d/bosque/MundoEntBosque.jsx
+++ b/src/visual/mundo3d/bosque/MundoEntBosque.jsx
@@ -5,10 +5,14 @@
  * microsuelo (EscenaEntMaestro). El operador revisó los tres mundos con piezas
  * de páramo y cerró la decisión: queda UNO solo — la escena del páramo
  * definitivo (EscenaBosqueVivo, ahora armada con la cámara y la inmensidad del
- * páramo viejo + el suelo rico dorado) y SIN el Ent ni el campesino ("están
- * horribles"). EscenaEntMaestro se desmonta de aquí sin redibujarse: era un
- * import aparte, sale limpio. El archivo sigue en el repo por si otra
- * composición retoma la lección de las cinco capas.
+ * páramo viejo + el suelo rico dorado). EscenaEntMaestro se desmonta de aquí
+ * sin redibujarse: era un import aparte, sale limpio.
+ *
+ * 2026-07-30: el ENT VUELVE al páramo, pero como la QUEÑUA (Polylepis) con el
+ * cincel reconciliado de `EntGradiente` (el aprobado en `tres-ents-gradiente`,
+ * NO la vieja `EntQuenua` "horrible"). El panel del mundo ya no da la lección
+ * genérica del frailejón: da la LECCIÓN DE LA QUEÑUA (entGuion, grounded) — el
+ * árbol que sostiene el suelo y guarda el agua sobre los 4.000 m.
  *
  * Contrato de mundos: acepta `{tier, reducedMotion}` y llena a su padre. Copy
  * en español de Colombia, en "usted". Autocontenido: CSS embebido, cero
@@ -19,10 +23,26 @@ import { useMemo } from 'react';
 import EscenaBosqueVivo from './EscenaBosqueVivo.jsx';
 import PanelPasos from '../PanelPasos.jsx';
 import { decidirTier, permite3D } from '../deviceTier.js';
+import { getPieza } from '../../../data/entGuion.js';
 
 const CSS = `
 .entb { position: relative; width: 100%; height: 100%; overflow: hidden; background: #c3cfce; }
 `;
+
+/* LA LECCIÓN DE LA QUEÑUA-ENT — la enseñanza del guardián del páramo, tomada
+   del guion pedagógico (`entGuion`, grounded contra el catálogo v3.2). La
+   queñua (coloradito, *Polylepis*) sostiene el suelo sobre los 4.000 m y guarda
+   el agua que baja al valle: es la lección que el brazo del Ent señala y que el
+   panel pone en palabras. Fallback digno por si el id cambiara. */
+const PIEZA_QUENUA = getPieza('coloradito_regula_agua_alta_montana');
+const LECCION_QUENUA = {
+  etiqueta: 'La queñua del páramo',
+  kicker: 'El agua que baja al valle',
+  texto: PIEZA_QUENUA?.snippet_pedagogico
+    || 'La queñua crece donde casi ningún árbol se atreve, arriba de los cuatro '
+    + 'mil metros. Sus raíces sujetan el suelo del páramo y guardan el agua que '
+    + 'baja a los valles. Sin ella, el páramo se deslava.',
+};
 
 /* Acento del páramo para el panel compartido (pajonal dorado y bruma fría). */
 const TEMA_PANEL = {
@@ -54,9 +74,9 @@ export default function MundoEntBosque({ tier: tierProp, reducedMotion: rmProp }
       <style>{CSS}</style>
       <EscenaBosqueVivo tier={tier} reducedMotion={reducedMotion} />
       <PanelPasos
-        etiqueta="El páramo"
-        kicker="La fábrica de agua"
-        texto="Los frailejones peinan la niebla con sus hojas de lana y el musgo la guarda como una esponja. De aquí, gota a gota, nace el agua que baja a su finca."
+        etiqueta={LECCION_QUENUA.etiqueta}
+        kicker={LECCION_QUENUA.kicker}
+        texto={LECCION_QUENUA.texto}
         tema={TEMA_PANEL}
         reducedMotion={reducedMotion}
       />

--- a/src/visual/mundo3d/bosque/fondoParamo.jsx
+++ b/src/visual/mundo3d/bosque/fondoParamo.jsx
@@ -31,8 +31,8 @@ import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { CIELOS_HORA, mezclaHex } from '../cielosHoraData.js';
 import { crearRng } from '../particulasData.js';
-import { alturaBosque } from './bosqueTakeA.geom.js';
-import { geomFrailejon } from './floraParamo.geom.js';
+import { alturaBosque, abraParamo, ABRA } from './bosqueTakeA.geom.js';
+import { geomFrailejon, geomAliso } from './floraParamo.geom.js';
 
 const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
 const smoothstep = (a, b, x) => {
@@ -462,6 +462,140 @@ function FrailejonalHorizonte({ n, q }) {
   return <instancedMesh ref={ref} args={[geo, mat, sitios.length]} frustumCulled={false} />;
 }
 
+/* ── EL ALISAL DEL VECINO — el piso FRÍO, en silueta ladera abajo ───────────
+      Decisión del operador (2026-07-30): el páramo es el TOPE del gradiente,
+      así que su único vecino visible es el piso de ABAJO (frío = ALISO), como
+      SILUETA ladera abajo por la abra — cuenta "a dónde va el agua que aquí
+      nace" sin abrir un segundo mundo navegable. Máximo dos: la queñua al
+      frente, el alisal al fondo (`pisosBosqueGradiente.vecinoDePiso`).
+      El rodal vive SOBRE LA FALDA (misma fórmula de cota que la malla, como
+      el frailejonal del horizonte) pero por DEBAJO del filo del páramo — donde
+      el frailejón ya no crece, empieza el bosque del vecino. Se dibuja SIN fog
+      con el lavado de aire horneado en su color: cuando la marea de niebla
+      cierra, el alisal queda asomado entre la bruma como una línea de monte —
+      que es exactamente como se ve un alisal desde un páramo real. */
+function AlisalVecino({ pal, n }) {
+  const ref = useRef(null);
+  const geo = useMemo(() => geomAliso({ q: 0.45 }, 941), []);
+  // Silueta, no retrato: un solo color plano (la geometría trae su color por
+  // vértice, pero a esta distancia el detalle miente — el aire lo aplana).
+  const color = useMemo(
+    () => mezclaHex(mezclaHex(pal.cuchilla, '#2f4636', 0.5), pal.aireAzul, 0.36),
+    [pal],
+  );
+  const mat = useMemo(() => new THREE.MeshBasicMaterial({ color, fog: false }), [color]);
+  const sitios = useMemo(() => {
+    const rng = crearRng(947);
+    const lista = [];
+    let intentos = 0;
+    while (lista.length < n && intentos < n * 40) {
+      intentos += 1;
+      // Por PASO de la falda (la cota sale de la misma fórmula que la malla).
+      // La banda del alisal se planta ALTO en la falda —justo por debajo del
+      // filo del páramo— y CEÑIDA al corredor de la abra: así aparece como una
+      // línea de monte oscuro sobre el horizonte, en el hueco por donde el
+      // frailejonal se abre y el agua se despeña. Más abajo se hunde en el mar
+      // de nubes y ya no se lee.
+      const t = 0.2 + rng() * rng() * 0.16;
+      const r = faldaRadio(t);
+      // El azimut se sortea CERCA del rumbo de la abra (no en todo el anillo):
+      // el alisal es una mancha en el corredor, no un cinturón alrededor. Va en
+      // la convención de `abraParamo` (θ = atan2(z, x)): wx=cos·r, wz=sin·r.
+      const theta = ABRA.az + (rng() - 0.5) * ABRA.ancho * 1.4;
+      const wx = Math.cos(theta) * r, wz = Math.sin(theta) * r;
+      if (abraParamo(wx, wz) < 0.5) continue; // solo el corredor de la abra
+      const y = faldaAltura(t, wx, wz);
+      if (y > 0.4 || y < -12) continue; // ladera abajo, pero sobre el mar
+      lista.push({
+        wx, wz, y,
+        esc: 1.9 + rng() * 1.8,
+        giro: rng() * Math.PI * 2,
+        ladeo: (rng() - 0.5) * 0.16,
+      });
+    }
+    return lista;
+  }, [n]);
+  useLayoutEffect(() => {
+    const mesh = ref.current;
+    if (!mesh || !sitios.length) return;
+    const dummy = new THREE.Object3D();
+    sitios.forEach((s, i) => {
+      dummy.position.set(s.wx, s.y, s.wz);
+      dummy.rotation.set(s.ladeo, s.giro, 0);
+      dummy.scale.setScalar(s.esc);
+      dummy.updateMatrix();
+      mesh.setMatrixAt(i, dummy.matrix);
+    });
+    mesh.instanceMatrix.needsUpdate = true;
+  }, [sitios]);
+  useLayoutEffect(() => () => {
+    geo.dispose();
+    mat.dispose();
+  }, [geo, mat]);
+  if (!sitios.length) return null;
+  return (
+    <instancedMesh ref={ref} args={[geo, mat, sitios.length]} frustumCulled={false} renderOrder={-68} />
+  );
+}
+
+/* ── LA CHORRERA DE LA ABRA — el agua que nace aquí, yéndose ────────────────
+      El feedback recurrente: "la caída se simula, pero NO conecta el paisaje
+      con la cascada". Este hilo la amarra: en el azimut exacto de la abra, la
+      quebrada del páramo se despeña por la falda hecha un hilo blanco que se
+      pierde hacia el alisal del vecino — nacedero → filo → caída → el piso de
+      abajo, en un solo trazo. Una cinta de triángulos sobre la falda (misma
+      cota que la malla + un palmo), lechosa arriba y lavada al aire abajo. */
+function construirChorrera(pal, aOff = 0) {
+  // El rumbo del corredor de la abra, en la convención de `abraParamo`
+  // (θ = atan2(z, x)): la caída baja recta por el eje de la abra.
+  const theta = ABRA.az + aOff;
+  const dirx = Math.cos(theta), dirz = Math.sin(theta);
+  // perpendicular en planta (para el ancho de la cinta)
+  const perpx = -dirz, perpz = dirx;
+  const pasos = 16;
+  const pos = [];
+  const col = [];
+  const cAlta = new THREE.Color(mezclaHex(LECHOSA, pal.nube, 0.3));
+  const cBaja = new THREE.Color(mezclaHex(pal.aireAzul, LECHOSA, 0.35));
+  const c = new THREE.Color();
+  const punto = (t, lado) => {
+    const r = faldaRadio(t);
+    const wx = dirx * r, wz = dirz * r;
+    // ancho perpendicular al rumbo (en planta): crece al caer, como una caída real
+    const w = (0.22 + t * 1.5) * lado;
+    return [wx + perpx * w, faldaAltura(t, wx, wz) + 0.14, wz + perpz * w];
+  };
+  for (let i = 0; i < pasos; i++) {
+    const t0 = 0.16 + (i / pasos) * 0.36;
+    const t1 = 0.16 + ((i + 1) / pasos) * 0.36;
+    const a0 = punto(t0, -1), b0 = punto(t0, 1), a1 = punto(t1, -1), b1 = punto(t1, 1);
+    c.copy(cAlta).lerp(cBaja, i / pasos);
+    const meter = (p) => { pos.push(p[0], p[1], p[2]); col.push(c.r, c.g, c.b); };
+    meter(a0); meter(a1); meter(b0);
+    meter(b0); meter(a1); meter(b1);
+  }
+  const g = new THREE.BufferGeometry();
+  g.setAttribute('position', new THREE.BufferAttribute(new Float32Array(pos), 3));
+  g.setAttribute('color', new THREE.BufferAttribute(new Float32Array(col), 3));
+  return g;
+}
+function ChorreraDeLaAbra({ pal }) {
+  const geo = useMemo(() => construirChorrera(pal), [pal]);
+  useLayoutEffect(() => () => geo.dispose(), [geo]);
+  return (
+    <mesh geometry={geo} renderOrder={-67} frustumCulled={false}>
+      <meshBasicMaterial
+        vertexColors
+        transparent
+        opacity={0.62}
+        depthWrite={false}
+        fog={false}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
 /* ── EL SOL VELADO ──────────────────────────────────────────────────────────
       La mancha pálida tras la niebla, dibujada EXACTO donde la franja pone su
       luz direccional: lo que el ojo ve como fuente es de verdad la fuente. De
@@ -492,12 +626,16 @@ function SolVelado({ pal, franja }) {
 /**
  * El fondo de inmensidad del páramo definitivo. Montar dentro del <Canvas>.
  * Mira hacia la ABRA (bosqueTakeA): por ahí se despeña la falda y se ve el mar.
- * @param {{franja: string, tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean}} props
+ * `vecino` = el árbol del piso térmico de abajo ('aliso' | null): si viene, el
+ * rodal del vecino se dibuja en silueta ladera abajo por la abra, con la
+ * chorrera que amarra el agua del páramo con ese piso (decisión 2026-07-30).
+ * @param {{franja: string, tier?: 'alto'|'medio'|'bajo', reducedMotion?: boolean, vecino?: string|null}} props
  */
-export default function FondoParamo({ franja, tier = 'alto', reducedMotion = false }) {
+export default function FondoParamo({ franja, tier = 'alto', reducedMotion = false, vecino = null }) {
   const pal = useMemo(() => paletaFondo(franja), [franja]);
   const nNubes = tier === 'alto' ? 46 : tier === 'medio' ? 28 : 14;
   const nHorizonte = tier === 'alto' ? 64 : tier === 'medio' ? 36 : 0;
+  const nAlisal = tier === 'alto' ? 16 : tier === 'medio' ? 10 : 6;
   const q = tier === 'alto' ? 0.5 : 0.42;
   return (
     <group>
@@ -508,6 +646,8 @@ export default function FondoParamo({ franja, tier = 'alto', reducedMotion = fal
       {tier !== 'bajo' && <NubesAltas pal={pal} n={tier === 'alto' ? 5 : 3} />}
       <FaldaParamo pal={pal} />
       {nHorizonte > 0 && <FrailejonalHorizonte n={nHorizonte} q={q} />}
+      {vecino === 'aliso' && <AlisalVecino pal={pal} n={nAlisal} />}
+      {vecino === 'aliso' && <ChorreraDeLaAbra pal={pal} />}
     </group>
   );
 }


### PR DESCRIPTION
Integra el mundo del páramo (paramo-definitivo): la queñua-Ent se monta por piso térmico desde pisosBosqueGradiente, frailejón = paisaje, vecino aliso al fondo, fuera oso/jaguar, lección grounded. Gate visual: 4 PNG (día/noche/ent/valle) GPU real. NO toca el valle viejo (removido). 🤖 Generated with Claude Code