### PR TITLE
fix(huerfanos): cablear restauracion-tiempo, yuca y quinua (3D)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -172,6 +172,13 @@ const HojaPruebaValleMockup = lazy(() => import('./mockups/HojaPruebaValle'));
 // operador). Reemplaza a BosqueVivo3D, MundoParamo3D y SueloDemo3D (los tres
 // archivados en src/mockups/_archivo/). Ruta #/mockups/paramo-definitivo.
 const ParamoDefinitivoMockup = lazy(() => import('./visual/mundo3d/bosque/MundoEntBosque.jsx'));
+// 3D: EL MONTE QUE VUELVE — el potrero volviéndose bosque, a través del
+// tiempo (50 años, riel no lineal). Rescate de huérfano (deuda
+// "construido-no-cableado": RestauracionEnElTiempo.jsx y su escena
+// EscenaRestauracion/AguaQueVuelve no tenían NINGÚN consumidor). Device-
+// tiering real (3D en equipo que da, corte SVG LaderaEnFranjas si no). Ruta
+// #/mockups/restauracion-tiempo-3d, sin auth.
+const RestauracionTiempo3DMockup = lazy(() => import('./mockups/RestauracionTiempo3D'));
 // 3D: el MUNDO DEL CAFÉ — el cafetal bajo sombra del piso templado: surcos a
 // curva de nivel, cereza madurando verde→pintón→rojo por instancia, el sombrío
 // de guamos y nogales, y la casa-beneficiadero en la bruma. Device-tiering
@@ -205,6 +212,19 @@ const CacaoVivo3DMockup = lazy(() => import('./mockups/CacaoVivo3D'));
 // blanca por instancia, la cosecha de criollas (amarilla/roja/morada) y los
 // frailejones en silueta. Device-tiering real. Ruta #/mockups/papa-viva-3d, sin auth.
 const PapaVivo3DMockup = lazy(() => import('./mockups/PapaVivo3D'));
+// 3D: el MUNDO DE LA YUCA — el yucal de clima medio en el arranque: el tallo
+// leñoso pelado y anillado de cicatrices, el follaje arriba no más, el
+// semillero de estacas inclinadas y el racimo de raíces recién destapado.
+// Rescate de huérfano (construido-no-cableado): YucaViva3D.jsx no tenía
+// entrada en el router. Device-tiering real. Ruta #/mockups/yuca-viva-3d, sin
+// auth.
+const YucaViva3DMockup = lazy(() => import('./mockups/YucaViva3D'));
+// 3D: el MUNDO DE LA QUINUA — el quinual maduro de tierra fría (2.500-3.200
+// m): la ladera a manchas de color por variedad y la era donde se trilla, se
+// avienta y se le lava lo amargo. Rescate de huérfano (construido-no-
+// cableado): QuinuaViva3D.jsx no tenía entrada en el router. Device-tiering
+// real. Ruta #/mockups/quinua-viva-3d, sin auth.
+const QuinuaViva3DMockup = lazy(() => import('./mockups/QuinuaViva3D'));
 // 3D: el MUNDO DE LOS FRUTALES — mango y cítricos juntos, porque juntos
 // enseñan el PISO TÉRMICO: el mango es de tierra caliente y el cítrico sube al
 // clima medio. La escala relativa es la lección: el mango eclipsa al cítrico.
@@ -700,6 +720,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/mundo3d-milpa': 'mockup_mundo3d_milpa',
   'mockups/mundo3d-bosque': 'mockup_mundo3d_bosque',
   'mockups/paramo-definitivo': 'mockup_paramo_definitivo',
+  'mockups/restauracion-tiempo-3d': 'mockup_restauracion_tiempo_3d',
   'mockups/cafetal-vivo-3d': 'mockup_cafetal_vivo_3d',
   'mockups/aguacatal-vivo-3d': 'mockup_aguacatal_vivo_3d',
   'mockups/microcuenca': 'mockup_microcuenca',
@@ -709,6 +730,8 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/invernadero-vivo-3d': 'mockup_invernadero_vivo_3d',
   'mockups/cacao-vivo-3d': 'mockup_cacao_vivo_3d',
   'mockups/papa-viva-3d': 'mockup_papa_viva_3d',
+  'mockups/yuca-viva-3d': 'mockup_yuca_viva_3d',
+  'mockups/quinua-viva-3d': 'mockup_quinua_viva_3d',
   'mockups/frutales-vivo-3d': 'mockup_frutales_vivo_3d',
   'mockups/mundo-piscicultura-3d': 'mockup_mundo_piscicultura_3d',
   'mockups/lecheria-viva-3d': 'mockup_lecheria_viva_3d',
@@ -1721,6 +1744,17 @@ export default function App() {
             </ErrorFallback>
           </ErrorBoundary>
         );
+      case 'mockup_restauracion_tiempo_3d':
+        // EL MONTE QUE VUELVE: el potrero volviéndose bosque a través del
+        // tiempo (50 años, riel no lineal). Ruta #/mockups/restauracion-
+        // tiempo-3d, sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El monte que vuelve">
+              <RestauracionTiempo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
       case 'mundo_casa_adentro':
         return (
           <ErrorBoundary>
@@ -1807,6 +1841,32 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El mundo de la papa">
               <PapaVivo3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_yuca_viva_3d':
+        // Vitrina pública del MUNDO DE LA YUCA: el yucal de clima medio en 3D
+        // REAL — el tallo leñoso pelado y anillado de cicatrices, el follaje
+        // arriba no más, el semillero de estacas inclinadas y el racimo de
+        // raíces recién destapado. En equipo humilde muestra la ficha del
+        // corte. Ruta #/mockups/yuca-viva-3d.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo de la yuca">
+              <YucaViva3DMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_quinua_viva_3d':
+        // Vitrina pública del MUNDO DE LA QUINUA: el quinual maduro de tierra
+        // fría en 3D REAL — la ladera a manchas de color por variedad y la
+        // era donde se trilla, se avienta y se le lava lo amargo. En equipo
+        // humilde muestra la ficha de las dos panojas. Ruta
+        // #/mockups/quinua-viva-3d.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El mundo de la quinua">
+              <QuinuaViva3DMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/RestauracionTiempo3D.css
+++ b/src/mockups/RestauracionTiempo3D.css
@@ -1,0 +1,45 @@
+/*
+ * RestauracionTiempo3D.css — vitrina pública del mundo de restauración
+ * (#/mockups/restauracion-tiempo-3d). Autocontenida, móvil-first desde 320px.
+ */
+
+.rt3d {
+  --rt3d-a: #4a6d3c;
+  --rt3d-b: #eef1e4;
+  min-height: 100vh;
+  min-height: 100dvh;
+  padding: 1rem 0.9rem 2.5rem;
+  background: linear-gradient(180deg, var(--rt3d-b) 0%, #f4f6ec 44%, #e6ead9 100%);
+  color: #26301f;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+.rt3d__head {
+  max-width: 46rem;
+  margin: 0 auto 1rem;
+}
+.rt3d__kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--rt3d-a);
+}
+.rt3d__head h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.2rem);
+  line-height: 1.15;
+  color: #263a1c;
+}
+.rt3d__lema {
+  margin: 0.4rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  max-width: 38rem;
+}
+
+.rt3d__escena {
+  max-width: 46rem;
+  margin: 0 auto;
+}

--- a/src/mockups/RestauracionTiempo3D.jsx
+++ b/src/mockups/RestauracionTiempo3D.jsx
@@ -1,0 +1,43 @@
+/*
+ * RestauracionTiempo3D — vitrina pública (#/mockups/restauracion-tiempo-3d) del
+ * mundo "el potrero volviéndose monte, a través del tiempo".
+ *
+ * CABLEO (rescate de huérfano, patrón feedback_construido_pero_no_cableado):
+ * `RestauracionEnElTiempo.jsx` (src/visual/mundo3d/restauracion/) es LA PIEZA
+ * COMPLETA — su propia cabecera dice "demo aislada: se monta sola, sin rutas
+ * ni datos de finca. Es un cuadro, no una pantalla del app". Nada la montaba:
+ * ni App.jsx (el shell clásico que sirve 3d.guatoc.co/app) ni ningún otro
+ * mockup. Este wrapper hace exactamente lo que pide su cabecera — montarla
+ * directo — con el encabezado didáctico que usan las vitrinas hermanas
+ * (Mundo3DAgua, Mundo3DSuelo).
+ *
+ * NO reimplementa nada: `RestauracionEnElTiempo` ya trae su propio
+ * device-tiering (decidirTier/permite3D → 3D en equipo que da, corte SVG
+ * LaderaEnFranjas en gama baja) y su línea de tiempo (LineaTiempo, riel no
+ * lineal + reduced-motion). Este mockup solo agrega el marco de vitrina.
+ *
+ * Autocontenida: cero CDN/imágenes externas. Móvil-first (320px). Copy en
+ * español de Colombia, en "usted".
+ */
+import RestauracionEnElTiempo from '../visual/mundo3d/restauracion/RestauracionEnElTiempo.jsx';
+import './RestauracionTiempo3D.css';
+
+export default function RestauracionTiempo3D() {
+  return (
+    <main className="rt3d">
+      <header className="rt3d__head">
+        <p className="rt3d__kicker">Los mundos de su finca · vitrina</p>
+        <h1>El monte que vuelve</h1>
+        <p className="rt3d__lema">
+          Camine los años de un potrero que se hace monte otra vez: qué llega
+          primero, qué llega después y por qué. Restaurar es lento — cada año
+          de estos es un año de verdad.
+        </p>
+      </header>
+
+      <section className="rt3d__escena" aria-label="La ladera a través del tiempo">
+        <RestauracionEnElTiempo />
+      </section>
+    </main>
+  );
+}

--- a/src/mockups/__tests__/quinuaViva3D.smoke.test.jsx
+++ b/src/mockups/__tests__/quinuaViva3D.smoke.test.jsx
@@ -1,0 +1,41 @@
+/*
+ * Vitrina #/mockups/quinua-viva-3d — smoke (jsdom = equipo humilde).
+ *
+ * En jsdom no hay WebGL, así que `decidirTier()` cae a 'bajo' y la vitrina
+ * monta la FICHA con las dos panojas (three-free) en vez de `MundoQuinua`
+ * (Canvas/@react-three): exactamente el camino real del device-tiering en
+ * gama baja. Congela que el cableo del huérfano (QuinuaViva3D.jsx no tenía
+ * entrada en el router de App.jsx) quedó completo:
+ *   · la página renderiza título + la ficha didáctica, sin tocar three;
+ *   · la ficha trae las dos panojas (glomerulada y amarantiforme) rotuladas;
+ *   · los 4 saberes del quinual aparecen.
+ */
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import QuinuaViva3D from '../QuinuaViva3D.jsx';
+
+afterEach(() => cleanup());
+
+describe('vitrina del mundo de la quinua (mockups/quinua-viva-3d)', () => {
+  test('renderiza la ficha 2D digna con su lección', () => {
+    const { container } = render(<QuinuaViva3D />);
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'El quinual maduro de la tierra fría' }),
+    ).toBeInTheDocument();
+
+    // jsdom no tiene WebGL → ficha con las dos panojas (three-free)
+    expect(container.querySelector('.qviva__ficha')).toBeInTheDocument();
+    expect(container.querySelector('canvas')).toBeNull();
+    expect(container.querySelector('.qviva__panoja--glom')).toBeInTheDocument();
+    expect(container.querySelector('.qviva__panoja--amar')).toBeInTheDocument();
+
+    // los 4 saberes verificados del quinual
+    expect(screen.getByText('Hay dos formas de panoja', { selector: 'b' })).toBeInTheDocument();
+    expect(screen.getByText('El color dice la variedad', { selector: 'b' })).toBeInTheDocument();
+    expect(screen.getByText('Se trilla y se avienta', { selector: 'b' })).toBeInTheDocument();
+    expect(screen.getByText('Y se le lava lo amargo', { selector: 'b' })).toBeInTheDocument();
+  });
+});

--- a/src/mockups/__tests__/restauracionTiempo3D.smoke.test.jsx
+++ b/src/mockups/__tests__/restauracionTiempo3D.smoke.test.jsx
@@ -1,0 +1,50 @@
+/*
+ * Vitrina #/mockups/restauracion-tiempo-3d — smoke (jsdom = equipo humilde).
+ *
+ * En jsdom no hay WebGL, así que `decidirTier()` cae a 'bajo' y
+ * `RestauracionEnElTiempo` monta el CORTE SVG `LaderaEnFranjas` (three-free)
+ * en vez de `EscenaRestauracion` (Canvas/@react-three): exactamente el camino
+ * real del device-tiering en gama baja. Congela que el cableo del huérfano
+ * (RestauracionEnElTiempo.jsx / EscenaRestauracion.jsx / AguaQueVuelve.jsx —
+ * ninguno tenía consumidor) quedó completo:
+ *   · la página renderiza título + el host `RestauracionEnElTiempo`;
+ *   · el gemelo 2D (corte de la ladera, SVG puro, cero <canvas>) monta;
+ *   · la línea de tiempo (riel + etapas) está viva y responde al arrastre.
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import RestauracionTiempo3D from '../RestauracionTiempo3D.jsx';
+
+afterEach(() => cleanup());
+
+describe('vitrina del monte que vuelve (mockups/restauracion-tiempo-3d)', () => {
+  test('renderiza el corte 2D digno con la línea de tiempo', () => {
+    const { container } = render(<RestauracionTiempo3D />);
+    expect(screen.getByRole('heading', { level: 1, name: 'El monte que vuelve' })).toBeInTheDocument();
+
+    // jsdom no tiene WebGL → LaderaEnFranjas (SVG puro), nunca un Canvas roto
+    expect(container.querySelector('svg.rest__franjas')).toBeInTheDocument();
+    expect(container.querySelector('canvas')).toBeNull();
+
+    // la línea de tiempo: riel accesible + las etapas del recorrido
+    const riel = screen.getByRole('slider', { name: 'Años desde que empezó la restauración' });
+    expect(riel).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Véalo pasar/ })).toBeInTheDocument();
+  });
+
+  test('arrastrar el riel avanza el año y mueve el corte', () => {
+    render(<RestauracionTiempo3D />);
+    const riel = screen.getByRole('slider', { name: 'Años desde que empezó la restauración' });
+
+    // año 0: el árbol semilla está solo (aria-label del corte lo confirma)
+    expect(screen.getByLabelText('Corte de la ladera en el año 0')).toBeInTheDocument();
+
+    fireEvent.change(riel, { target: { value: '1000' } });
+
+    // el riel al máximo aterriza en el año 50 (tope de ETAPAS/ANIO_MAX)
+    expect(screen.getByLabelText(/Corte de la ladera en el año 50/)).toBeInTheDocument();
+  });
+});

--- a/src/mockups/__tests__/yucaViva3D.smoke.test.jsx
+++ b/src/mockups/__tests__/yucaViva3D.smoke.test.jsx
@@ -1,0 +1,39 @@
+/*
+ * Vitrina #/mockups/yuca-viva-3d — smoke (jsdom = equipo humilde).
+ *
+ * En jsdom no hay WebGL, así que `decidirTier()` cae a 'bajo' y la vitrina
+ * monta la FICHA en corte (three-free) en vez de `MundoYuca` (Canvas/
+ * @react-three): exactamente el camino real del device-tiering en gama baja.
+ * Congela que el cableo del huérfano (YucaViva3D.jsx no tenía entrada en el
+ * router de App.jsx) quedó completo:
+ *   · la página renderiza título + la ficha didáctica, sin tocar three;
+ *   · la ficha trae el tallo anillado y el racimo de raíces (rotulados);
+ *   · los 4 saberes del yucal aparecen.
+ */
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach } from 'vitest';
+
+import YucaViva3D from '../YucaViva3D.jsx';
+
+afterEach(() => cleanup());
+
+describe('vitrina del mundo de la yuca (mockups/yuca-viva-3d)', () => {
+  test('renderiza la ficha 2D digna con su lección', () => {
+    const { container } = render(<YucaViva3D />);
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'El yucal de clima medio, en el arranque' }),
+    ).toBeInTheDocument();
+
+    // jsdom no tiene WebGL → ficha en corte (three-free), nunca un Canvas roto
+    expect(container.querySelector('.yviva__ficha')).toBeInTheDocument();
+    expect(container.querySelector('canvas')).toBeNull();
+
+    // los 4 saberes verificados del yucal
+    expect(screen.getByText('El tallo lleva la cuenta', { selector: 'b' })).toBeInTheDocument();
+    expect(screen.getByText('Se siembra de tallo', { selector: 'b' })).toBeInTheDocument();
+    expect(screen.getByText('La raíz sale en racimo', { selector: 'b' })).toBeInTheDocument();
+    expect(screen.getByText('Dulce o amarga, cocida siempre', { selector: 'b' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Qué hace

Rescata 3 huérfanos de la deuda "construido-no-cableado" (`feedback_construido_pero_no_cableado`): mundos 3D completos y terminados que ningún route en `src/App.jsx` alcanzaba, aunque `App.jsx` es el shell que efectivamente sirve `3d.guatoc.co/app` (confirmado leyendo `.github/workflows/deploy-3d-guatoc.yml`).

### Cableados en este PR

| Ruta | Componente montado | Estado previo |
|---|---|---|
| `#/mockups/restauracion-tiempo-3d` | `RestauracionEnElTiempo.jsx` (`src/visual/mundo3d/restauracion/`) — el potrero volviéndose monte en 50 años | Wrapper nuevo `RestauracionTiempo3D.jsx`, ningún consumidor previo (caso #1 del encargo) |
| `#/mockups/yuca-viva-3d` | `MundoYuca.jsx` vía `YucaViva3D.jsx` (ya existía completo) | Mockup completo, sin entrada en `MOCKUP_HASH_ROUTES` |
| `#/mockups/quinua-viva-3d` | `MundoQuinua.jsx` vía `QuinuaViva3D.jsx` (ya existía completo) | Mockup completo, sin entrada en `MOCKUP_HASH_ROUTES` |

Cada ruta sigue el molde exacto de las hermanas ya vivas (`PapaVivo3D`, `CacaoVivo3D`): lazy import + entrada en `MOCKUP_HASH_ROUTES` + `case` en el switch de render, envuelto en `ErrorBoundary`/`ErrorFallback`, sin auth.

### Verificación de ruta viva (no solo build verde)

- `npm run build`: verde, chunks nuevos confirmados en `dist/assets/` (`RestauracionTiempo3D-*.js`, `YucaViva3D-*.js`, `QuinuaViva3D-*.js` + sus mundos 3D `EscenaRestauracion-*.js`, `MundoYuca-*.js`, `MundoQuinua-*.js`).
- `eslint --max-warnings=0` limpio en todos los archivos tocados/nuevos.
- Verificación empírica con **chromium headless contra el build de producción real** (`vite preview` + `chromium --headless=new --dump-dom`) en las 3 rutas: título correcto presente, `ErrorBoundary` ("Algo falló") ausente, DOM > 20KB (no pantalla en blanco).
- 3 smoke tests nuevos (`vitest`, patrón jsdom-sin-WebGL → `decidirTier()` cae a `'bajo'` → gemelo 2D, igual que `mundo3dSuelo.smoke.test.jsx`): pasan.

### Huérfanos evaluados y NO cableados (con motivo)

- **`DemoAtmosferaViva.jsx`** (`mundo3d/atmosfera/`): su propia cabecera dice explícitamente *"NO está cableada a ninguna ruta (contrato A4: demo aislada propia). Quien quiera verla la monta donde guste"*. Es una decisión de diseño documentada (demo de QA/arte), no deuda — no se fuerza.
- **`EscenaFaunaEmblematica.jsx`** (`mundo3d/fauna/`): mundo completo ("la senda del páramo, con los guardianes andando") pero temáticamente es fauna del páramo — fuera de alcance por la regla del encargo de no tocar esa zona (otro Fable puede estar trabajando ahí).
- **`mundo3d/artesania`, `beneficos`, `estiercol`, `kit`, `laminas2d`, `olor`, `semillas`, `suelo-comparado`, `terreno`**: revisadas — o son helpers/geometrías de soporte ya consumidos indirectamente por otros mundos cableados (ej. `kit/terreno.js` lo usa `MundoPiscicultura3D`), o no hay evidencia suficiente de que valgan una vitrina propia sin dirección de arte del operador. Quedan pendientes de triaje explícito, no se fuerzan acá.

### Nota sobre el auditor previo

Un sub-agente de auditoría reportó inicialmente varios falsos positivos (`papa-viva-3d`, `navegador-grafo`, `catalogo-infra`, `entrada-3d`, `grafo`, `infraestructura` como "no cableados") — verificados manualmente con grep directo contra `App.jsx` y **están cableados**. Solo `YucaViva3D` y `QuinuaViva3D` resultaron huérfanos reales tras verificación independiente.

## Reglas respetadas

- ⛔ No se tocó `src/mockups/valle/Valle3D.jsx`, `ParamoDensoValle.jsx`, `MundoEntBosque`/`EscenaBosqueVivo`.
- Worktree aislado (`fix/cablear-huerfanos-3d` desde `origin/dev`), sin pisar otros worktrees activos (bosque/páramo).

## Test plan

- [x] `npm run build` verde
- [x] `eslint --max-warnings=0` en archivos tocados
- [x] 3 smoke tests nuevos pasan
- [x] Verificación chromium headless de las 3 rutas contra `dist/` real (sin ErrorBoundary, título correcto)
- [ ] Revisión visual del operador en dev tras merge (patrón estándar del repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)