### PR TITLE
feat(cacao): ceiba-Ent del piso cálido en el cacaotal + lección grounded

### DIFF
--- a/src/data/entGuion.js
+++ b/src/data/entGuion.js
@@ -344,6 +344,30 @@ export const ENT_GUION = Object.freeze([
     dato_conservacion:
       'Caryocaraceae, árbol emergente amazónico; nativo_silvestre. Dispersión zoócora primaria por agutí (Dasyprocta fuliginosa), danta (Tapirus terrestris) y roedores silvestres como el borugo.',
   },
+
+  /* ── CONSERVACION — la ceiba: el guardián del piso CÁLIDO ───────────────
+     La pieza que le faltaba a la ceiba-Ent (`EntGradiente` especie="ceiba", el
+     guardián de tierra caliente del gradiente). NO le inventa una simbiosis —
+     la geom de la ceiba es explícita: "ni micorrizas ni simbiosis... dibujamos
+     el árbol, no una lección que todavía no tenemos". Por eso esta lección es
+     sobre el ÁRBOL MISMO (como la de la queñua es el agua y el suelo): el
+     emergente del bosque seco tropical, su sombrío para el cacao/café joven y
+     su papel de refugio de biodiversidad — todo tomado del `valor_pedagogico`
+     de `ceiba_pentandra` en el catálogo v3.2 (los campos copiados coinciden
+     textualmente, invariante del test). */
+  {
+    id: 'ceiba_sombrio_refugio_biodiversidad',
+    tema: 'conservacion',
+    especie_id: 'ceiba_pentandra',
+    nombre_comun: 'Ceiba algodón',
+    nombre_cientifico: 'Ceiba pentandra (L.) Gaertn.',
+    familia_botanica: 'Malvaceae',
+    thermal_zones: ['calido'],
+    snippet_pedagogico:
+      'La ceiba es el árbol más grande del bosque seco tropical: saca su copa muy por encima del monte y le da sombra al cacao y al café cuando están pequeños. Una sola ceiba vieja es casa de orquídeas, aves, micos y perezosos. Cuídela: es sagrada y refugio de vida.',
+    dato_conservacion:
+      'Malvaceae; nativo_silvestre del bosque seco tropical colombiano (Caribe, valle del Magdalena, Pacífico). Emergente de hasta 70 m con raíces tablares; la polinizan murciélagos nectarívoros y una sola ceiba adulta sostiene epífitas, aves y mamíferos arborícolas. Patrimonio bio-cultural de las culturas indígenas del Caribe.',
+  },
 ]);
 
 /* ────────────────────────────────────────────────────────────────────────

--- a/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
+++ b/src/visual/mundo3d/cacao/EscenaCacaoVivo.jsx
@@ -29,6 +29,9 @@ import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import { perfilDeTier } from '../deviceTier.js';
 import { Fauna } from '../escenas/FaunaEscena.jsx';
 import FaunaCalido from '../escenas/FaunaCalido.jsx';
+import { SombraContacto } from '../escenas/SombraContacto.jsx';
+import EntGradiente from '../bosque/EntGradiente.jsx';
+import { MAPA_PISO_ENT, protagonistaDePiso, vecinoDePiso } from '../bosque/pisosBosqueGradiente.js';
 import FloraCacao from './FloraCacao.jsx';
 import { ANCHO, FONDO, alturaVega, SITIO_CASA } from './floraCacao.geom.js';
 import {
@@ -63,6 +66,31 @@ const RADIO_CACAOTAL = 10;
 
 /* El frustum de sombra a medida de la vega (la luz colada del sombrío). */
 const SOMBRA_CACAOTAL = { left: -16, right: 16, top: 16, bottom: -6, far: 40 };
+
+/* ── EL ENT POR PISO TÉRMICO (mismo mapa compartido que la ladera, el bosque y
+      el páramo — `pisosBosqueGradiente`, ya aprobado y testeado) ──────────────
+   El cacaotal ES tierra caliente (0–1.200 m), así que su guardián es la CEIBA
+   (*Ceiba pentandra*), el emergente del bosque seco tropical. Y aquí no es
+   decorado: la ceiba juvenil es sombrío DOCUMENTADO del cacao y el café en el
+   Caribe-Magdalena (catálogo v3.2) — el paso 2 de este mundo pregunta justo
+   "¿por qué bajo sombra?", y la ceiba es esa sombra hecha guardián. El
+   protagonista y su único vecino salen del MISMO módulo compartido (no a mano):
+   protagonista = ceiba (cálido); vecino = el piso de ARRIBA (templado → ROBLE),
+   dibujado SOLO como silueta apagada en la loma del fondo (máximo dos). */
+const PISO_MUNDO = 'calido';
+const ENT_PROTAGONISTA = MAPA_PISO_ENT[protagonistaDePiso(PISO_MUNDO)]; // 'ceiba'
+const PISO_VECINO = vecinoDePiso(PISO_MUNDO); // 'templado'
+const ENT_VECINO = PISO_VECINO ? MAPA_PISO_ENT[PISO_VECINO] : null; // 'roble'
+
+/* Dónde se posan (con `alturaVega`, hundidos un palmo como en la ladera: el pie
+   del fuste es un anillo abierto). La CEIBA emergente va atrás-izquierda del
+   cacaotal, su copa-parasol oversailando las matas (el sombrío) y el fuste
+   sacando la cabeza por encima de todo — lejos de la casa/pasera (que viven
+   atrás-derecha, en SITIO_CASA). El ROBLE-vecino, apagado y chico, en la loma
+   del fondo: un guiño al piso de arriba, no un árbol del lote (misma gramática
+   que el bosque y el páramo). */
+const SITIO_ENT = { x: -6.6, z: -5.6, rotY: 0.5 };
+const SITIO_VECINO = { x: -2.6, z: -14.6, rotY: -0.4, escala: 0.72 };
 
 /* La malla de la vega — el heightfield del KIT (mismo andamiaje que todos los
    mundos) con la pintura PROPIA del piso cálido: el mantillo pardo de
@@ -256,6 +284,62 @@ const FAUNA_CALIDO_CACAO = [
   { tipo: 'morfo', base: [-1.8, 2.7, 3.0], patron: 'morfo', size: 40, fase: 0.6, df: 9, title: 'Morfo azul (Morpho peleides)' },
 ];
 
+/* ── EL GUARDIÁN DEL CACAOTAL: la CEIBA-ENT emergente + el ROBLE-vecino ──────
+   La ceiba maestra plantada como sombrío del cálido, con su rostro tallado y su
+   copa-parasol por encima de las matas; el roble del piso de arriba, apagado y
+   chico, al fondo. Reusa `EntGradiente` (el cincel reconciliado, mismo que el
+   bosque y el páramo) — cero geometría nueva. La ceiba NO monta lección al pie
+   (ni setas ni nódulos: la geom es explícita, no se le inventa simbiosis). */
+function GuardianCacaotal({ tier, perfil, reducedMotion }) {
+  const entY = alturaVega(SITIO_ENT.x, SITIO_ENT.z) - 0.22;
+  const vecY = alturaVega(SITIO_VECINO.x, SITIO_VECINO.z) - 0.16;
+  return (
+    <group>
+      {/* EL GUARDIÁN: la ceiba-Ent, protagonista del piso cálido. */}
+      <group
+        name={`ent-${ENT_PROTAGONISTA}`}
+        position={[SITIO_ENT.x, entY, SITIO_ENT.z]}
+        rotation={[0, SITIO_ENT.rotY, 0]}
+      >
+        <EntGradiente especie={ENT_PROTAGONISTA} tier={tier} reducedMotion={reducedMotion} />
+      </group>
+
+      {/* Su sombra de contacto cuando NO hay shadow-map real (gama baja): el
+          gigante no puede flotar. En alto/medio la planta el directional. */}
+      {!perfil.sombras && (
+        <SombraContacto
+          pos={[SITIO_ENT.x, alturaVega(SITIO_ENT.x, SITIO_ENT.z) + 0.05, SITIO_ENT.z]}
+          radio={2.3}
+          color="#241a10"
+          opacidad={0.32}
+          orden={2}
+        />
+      )}
+
+      {/* EL VECINO: el roble del piso de ARRIBA (templado), apagado y chico, en
+          la loma del fondo — la silueta que insinúa a dónde sube el gradiente.
+          Sin su lección al pie (`leccion={false}`): es fondo, no protagonista.
+          Solo si sobra GPU. */}
+      {ENT_VECINO && tier !== 'bajo' && (
+        <group
+          name={`ent-vecino-${ENT_VECINO}`}
+          position={[SITIO_VECINO.x, vecY, SITIO_VECINO.z]}
+          rotation={[0, SITIO_VECINO.rotY, 0]}
+          scale={SITIO_VECINO.escala}
+        >
+          <EntGradiente
+            especie={ENT_VECINO}
+            tier={tier}
+            reducedMotion={reducedMotion}
+            apagado
+            leccion={false}
+          />
+        </group>
+      )}
+    </group>
+  );
+}
+
 function Diorama({ tier, reducedMotion, foco }) {
   const perfil = perfilDeTier(tier);
 
@@ -338,6 +422,10 @@ function Diorama({ tier, reducedMotion, foco }) {
 
       {/* EL CACAOTAL: matas, mazorcas, sombrío, plátano, luz colada */}
       <FloraCacao tier={tier} reducedMotion={reducedMotion} />
+
+      {/* EL GUARDIÁN del piso cálido: la ceiba-Ent emergente (el sombrío hecho
+          maestro) + el roble-vecino apagado en la loma del fondo. */}
+      <GuardianCacaotal tier={tier} perfil={perfil} reducedMotion={reducedMotion} />
 
       {/* la casa con su cajón de fermentar y la pasera, en la lomita */}
       <CasaSecadero pos={[SITIO_CASA[0], casaY, SITIO_CASA[1]]} />

--- a/src/visual/mundo3d/cacao/MundoCacao.jsx
+++ b/src/visual/mundo3d/cacao/MundoCacao.jsx
@@ -17,6 +17,7 @@ import EscenaCacaoVivo from './EscenaCacaoVivo.jsx';
 import PanelPasos from '../PanelPasos.jsx';
 import { decidirTier, permite3D } from '../deviceTier.js';
 import { alturaVega } from './floraCacao.geom.js';
+import { getPieza } from '../../../data/entGuion.js';
 
 /* Los cuatro pasos de la lección. Cada `foco` es el punto de la vega que el
    anillo señala mientras se lee (coordenadas del mundo, y sobre el terreno). */
@@ -52,10 +53,28 @@ const PASOS = [
   },
 ];
 
+/* LA LECCIÓN DE LA CEIBA-ENT — el guardián del cacaotal (piso cálido) habla con
+   su pieza del guion pedagógico grounded (`entGuion`, verificada contra el
+   catálogo v3.2). Va APARTE de los cuatro pasos del cultivo, como el guardián
+   del bosque de tres estratos: los pasos enseñan el cacao; la ceiba, por qué el
+   monte grande lo cobija. Fallback digno por si el id cambiara. */
+const LECCION_CEIBA = getPieza('ceiba_sombrio_refugio_biodiversidad');
+
 const CSS = `
 .mcacao { position: relative; width: 100%; height: 100%; overflow: hidden; background: #dce4bd; }
 .mcacao canvas { opacity: 0; transition: opacity 0.9s ease; }
 .mcacao .cacao-canvas--lista canvas, .mcacao canvas.cacao-canvas--lista { opacity: 1; }
+/* La carta del guardián: rincón superior izquierdo (los pasos viven abajo a la
+   izquierda; el sujeto, en el centro). Display-only — deja pasar la órbita. */
+.mcacao-guardian { position: absolute; top: 0.8rem; left: 0.8rem; z-index: 6; max-width: 21rem; margin: 0; padding: 0.55rem 0.9rem 0.62rem; border-radius: 0.8rem; background: rgba(30, 20, 10, 0.72); backdrop-filter: blur(4px); color: #f4ecda; pointer-events: none; }
+.mcacao-guardian h3 { margin: 0 0 0.25rem; font: 700 0.9rem/1.25 system-ui, sans-serif; }
+.mcacao-guardian h3 em { font-weight: 500; font-style: italic; opacity: 0.85; }
+.mcacao-guardian p { margin: 0; font: 500 0.78rem/1.5 system-ui, sans-serif; }
+@media (max-width: 460px) {
+  .mcacao-guardian { max-width: calc(100% - 1.2rem); top: 0.6rem; left: 0.6rem; padding: 0.5rem 0.75rem 0.56rem; }
+  .mcacao-guardian h3 { font-size: 0.84rem; }
+  .mcacao-guardian p { font-size: 0.74rem; }
+}
 @media (prefers-reduced-motion: reduce) {
   .mcacao canvas { transition: none; }
 }
@@ -92,6 +111,19 @@ export default function MundoCacao({ tier: tierProp, reducedMotion: rmProp } = {
     <div className="mcacao">
       <style>{CSS}</style>
       <EscenaCacaoVivo tier={tier} reducedMotion={reducedMotion} foco={actual.foco} />
+
+      {/* EL GUARDIÁN habla: la lección grounded de la ceiba-Ent (el sombrío
+          emergente del cálido), aparte de los pasos del cultivo. Nunca muda. */}
+      {LECCION_CEIBA && (
+        <article className="mcacao-guardian" role="status">
+          <h3>
+            {LECCION_CEIBA.nombre_comun}
+            {' '}
+            <em>{LECCION_CEIBA.nombre_cientifico}</em>
+          </h3>
+          <p>{LECCION_CEIBA.snippet_pedagogico}</p>
+        </article>
+      )}
 
       <PanelPasos
         etiqueta="La lección del cacaotal"


### PR DESCRIPTION
Completa el Ent-por-piso: cálido→ceiba (sombrío del cacao), vecino roble al fondo. Pieza de ceiba en entGuion (sobre el árbol, sin simbiosis inventada). NO toca páramo/bosque/valle/módulo compartido. Gate GPU real, 0 page errors, Gemini OK. 🤖 Generated with Claude Code