### PR TITLE
feat(compai): Ola 2 batch 1 — voz en los tips, husmeo con datos reales, 2 gestos idle (#38, #88, #13/#14)

### DIFF
--- a/src/compai/nucleo/__tests__/gestos.test.js
+++ b/src/compai/nucleo/__tests__/gestos.test.js
@@ -71,20 +71,21 @@ describe('MOMENTOS_IDLE', () => {
     expect(MOMENTOS_IDLE.guino.peso).toBeGreaterThan(0);
   });
 
-  /* Los 12 momentos elegibles por azar (merge de fable/compai-gestos-entrada,
-     2026-07-26). Se fija la lista COMPLETA a propósito: el repertorio vive en
-     el núcleo portable porque es la fuente única que comparten la PWA y el
-     compAI de 3d.guatoc.co. Si alguien agrega un gesto sólo en
-     `angelitaEstados.js` (o sólo en el CSS), este test lo cachetea: la
-     divergencia entre los dos compAI es justo lo que el núcleo existe para
-     cerrar. */
-  it('tiene los 12 momentos ociosos elegibles por azar', () => {
+  /* Los 14 momentos elegibles por azar (merge de fable/compai-gestos-entrada,
+     2026-07-26, + mirausted/cuenta, Ola 2 batch 1, 2026-07-30). Se fija la
+     lista COMPLETA a propósito: el repertorio vive en el núcleo portable
+     porque es la fuente única que comparten la PWA y el compAI de
+     3d.guatoc.co. Si alguien agrega un gesto sólo en `angelitaEstados.js`
+     (o sólo en el CSS), este test lo cachetea: la divergencia entre los dos
+     compAI es justo lo que el núcleo existe para cerrar. */
+  it('tiene los 14 momentos ociosos elegibles por azar', () => {
     const elegibles = Object.keys(MOMENTOS_IDLE)
       .filter((m) => MOMENTOS_IDLE[m].peso > 0)
       .sort();
     expect(elegibles).toEqual([
-      'acicala', 'bosteza', 'cabecea', 'distraida', 'estira', 'guino',
-      'mira', 'posa', 'rasca', 'rascanuca', 'sacude', 'voltereta',
+      'acicala', 'bosteza', 'cabecea', 'cuenta', 'distraida', 'estira',
+      'guino', 'mira', 'mirausted', 'posa', 'rasca', 'rascanuca', 'sacude',
+      'voltereta',
     ]);
   });
 
@@ -92,7 +93,10 @@ describe('MOMENTOS_IDLE', () => {
      CSS. Aquí sólo se puede comprobar la mitad barata (que exista y sea un
      número sano); la otra mitad la comprueba el gate visual con captura. */
   it('cada momento nuevo declara una duración numérica sana', () => {
-    for (const m of ['guino', 'estira', 'bosteza', 'rascanuca', 'cabecea', 'voltereta']) {
+    for (const m of [
+      'guino', 'estira', 'bosteza', 'rascanuca', 'cabecea', 'voltereta',
+      'mirausted', 'cuenta',
+    ]) {
       expect(typeof MOMENTOS_IDLE[m].dur, `${m}.dur`).toBe('number');
       expect(MOMENTOS_IDLE[m].dur).toBeGreaterThan(500);
       expect(MOMENTOS_IDLE[m].dur).toBeLessThan(6000);

--- a/src/compai/nucleo/gestos.js
+++ b/src/compai/nucleo/gestos.js
@@ -19,6 +19,12 @@
  * pedía el SPEC — *"no es predecible, siempre hace cosas diferentes"*. Con 6
  * gestos y anti-repetición el ciclo se leía; con 12 deja de leerse.
  *
+ * NUEVO 2026-07-30 (Ola 2, batch 1, #13/#14): **`mirausted`** ("mirar al
+ * usuario y volver la vista", distinto del 'mira' curioso que mira ALREDEDOR
+ * sin usted de por medio) y **`cuenta`** ("contar algo con las patitas") —
+ * los 2 gestos del pedido original de #13/#14 que faltaban del repertorio de
+ * 12. Con ellos son **14 momentos**.
+ *
  * Entran AQUÍ y no en `angelitaEstados.js` a propósito: el núcleo es la fuente
  * única, y si el repertorio se quedara en la PWA el compAI de `3d.guatoc.co`
  * heredaría otra vez un personaje más pobre — que es exactamente la divergencia
@@ -47,6 +53,8 @@ export const MOMENTOS_IDLE = {
   rascanuca: { dur: 2400, peso: 1.3 },// se rasca la nuca, medio apenada (rascarse distinto)
   cabecea: { dur: 3600, peso: 0.9 },  // se le van los ojos… zzz… y DESPIERTA de un brinco
   voltereta: { dur: 1700, peso: 0.8 },// pirueta juguetona: vuelta de campana con anticipación
+  mirausted: { dur: 2600, peso: 2.2 },// voltea derecho hacia usted, sostiene, y vuelve a lo suyo
+  cuenta: { dur: 3000, peso: 1.3 },   // cuenta algo con las patitas: toca uno, dos, tres…
   posa: { dur: 1150, peso: 2 },       // aterriza con peso (→ posada → despega)
   posada: { dur: [3400, 5200], peso: 0 }, // descansa posada: alitas plegadas, respira hondo
   despega: { dur: 950, peso: 0 },     // se agacha, coge impulso y vuelve al aire

--- a/src/mockups/EntradaValle3D.jsx
+++ b/src/mockups/EntradaValle3D.jsx
@@ -48,6 +48,11 @@ import {
 import usePerfilFincaStore from '../store/usePerfilFincaStore.js';
 /* El reloj del ciclo diurno vivo (franja real del día + override ?ciclo=). */
 import useCicloDia from '../visual/mundo3d/useCicloDia.js';
+/* El ESPEJO VIVO del dato real (#38 — el husmeo hablaba con la boca vacía:
+   este estadoFinca solo traía clima/animo/energia de muestra, nunca
+   saludFinca/cosechaReciente/enso reales). Hook puro (three-free), ya
+   consumido fuera de su propio módulo por Mundo.jsx — mismo patrón aquí. */
+import useFincaViva from '../visual/mundo3d/useFincaViva.js';
 import Valle2DFallback from './valle/Valle2DFallback';
 import AbejaTransicion, { AlMontarEscena } from '../visual/creatures/AbejaTransicion.jsx';
 /* La señal de SALIDA del compAI (auditoría #47/#51): al volver al valle, el
@@ -231,9 +236,23 @@ export default function EntradaValle3D({ onBack, onNavigate, initialMundoId = nu
     () => animoDeFinca(clima, { hayAlerta: !alertaVista }),
     [clima, alertaVista],
   );
+  /* #38 — datos REALES de la finca para que el husmeo autónomo (CompaneroAbeja
+     en Valle3D.jsx) comente lo que de verdad hay, no un pool genérico. Antes
+     este objeto solo traía clima/animo/energia de muestra: reaccionDeFinca
+     caía siempre a sus defaults (saludFinca/cosechaReciente/enso neutros).
+     `fincaViva` es anti-fabricación (useFincaViva): sin dato real, sus campos
+     quedan undefined y reaccionDeFinca usa su propio neutro — nunca inventa. */
+  const fincaViva = useFincaViva();
   const estadoFinca = useMemo(
-    () => ({ clima, animo: companero.animo, energia: companero.energia }),
-    [clima, companero.animo, companero.energia],
+    () => ({
+      clima,
+      animo: companero.animo,
+      energia: companero.energia,
+      enso: fincaViva.enso,
+      cosechaReciente: fincaViva.cosechaReciente,
+      saludFinca: fincaViva.saludFinca,
+    }),
+    [clima, companero.animo, companero.energia, fincaViva.enso, fincaViva.cosechaReciente, fincaViva.saludFinca],
   );
 
   // ── Angelita VIVA (auditoría S5): además del idle (respira/flota, en CSS),

--- a/src/mockups/valle/Valle3D.jsx
+++ b/src/mockups/valle/Valle3D.jsx
@@ -52,6 +52,15 @@ import useInventarioCompai from '../../hooks/useInventarioCompai';
 import { datosDeMundo } from '../../compai/nucleo/datosFinca.js';
 import { estaOcupado } from '../../services/compaiOcupado.js';
 import BurbujaAngelita from '../../visual/agente/BurbujaAngelita';
+/* #88 — QUE EL COMPAI HABLE SUS TIPS: hasta hoy el husmeo solo pintaba la
+   burbuja (mensajeAngelita), nunca lo decía en voz — speak/speakKokoro ya
+   existían y nadie los llamaba desde aquí. Mismo patrón que useAcompanante
+   (AcompananteMundo.jsx) y el shell (EntradaValle3D.jsx): Kokoro primero,
+   Web Speech si no responde. Gateado por el silencio real del operador
+   (usePrefsStore.ttsEnabled, la misma bandera que apaga la voz en
+   AgentScreen) y por reducedMotion (silencio también es respeto). */
+import { speak, speakKokoro } from '../../services/ttsService.js';
+import usePrefsStore from '../../store/usePrefsStore.js';
 /* La CAPA DE ESTADO de Angelita (auditoría §5b): módulo puro, sin three — el
    mismo repertorio (mojada/sed/comiendo/vuelo) que usan los mundos 3D. */
 import { reaccionDeFinca, ESTADO_FINCA_MUESTRA } from '../../visual/mundo3d/escenas/reaccionFinca.js';
@@ -1906,6 +1915,27 @@ function CompaneroAbeja({ foco, focoId = null, entrando, animo, energia, reduced
   const mensajeAngelita = useAngelitaStore((s) => s.mensaje);
   const tipoAngelita = useAngelitaStore((s) => s.tipo);
   const entrarMundoAngelita = useAngelitaStore((s) => s.entrarMundo);
+
+  /* #88 — EL COMPAI HABLA SUS TIPS: cada vez que llega un mensaje NUEVO
+     (navegación real o husmeo autónomo), además de pintar la burbuja lo DICE.
+     Kokoro primero; si no responde (equipo sin soporte, timeout), cae a la
+     voz del navegador — nunca queda muda una finca que ya escribe. Silencio
+     real (usePrefsStore.ttsEnabled) y reducedMotion apagan la voz sin tocar
+     la burbuja: el texto sigue siendo la voz de quien no puede/no quiere oír. */
+  const ttsEnabled = usePrefsStore((s) => s.ttsEnabled);
+  const dichoRef = useRef(null);
+  useEffect(() => {
+    if (!mensajeAngelita || reducedMotion || !ttsEnabled) return;
+    if (dichoRef.current === mensajeAngelita) return; // ya se dijo este mismo texto
+    dichoRef.current = mensajeAngelita;
+    speakKokoro(mensajeAngelita, { lang: 'es', rate: 0.98 })
+      .then((audio) => {
+        if (!audio) speak(mensajeAngelita, { rate: 0.98, pitch: 1 });
+      })
+      .catch(() => {
+        speak(mensajeAngelita, { rate: 0.98, pitch: 1 });
+      });
+  }, [mensajeAngelita, reducedMotion, ttsEnabled]);
   const reposarAngelita = useAngelitaStore((s) => s.reposar);
 
   /* ── LOS DATOS REALES DE LA FINCA (auditoría 2026-07-26, ítem #38) ────────

--- a/src/visual/agente/angelita-agente.css
+++ b/src/visual/agente/angelita-agente.css
@@ -526,6 +526,87 @@
   74%  { transform: scaleY(1.15); }      /* reabre encantada */
 }
 
+/* MIRA-Y-VUELVE — deja lo que está haciendo, VOLTEA la cabecita derecho hacia
+   usted (el frente, no de reojo como 'mira'), sostiene el contacto un
+   instante — y vuelve la vista a lo suyo. Es el gesto de "¿me está viendo?" /
+   "sigo aquí con usted", distinto del 'mira' curioso (que mira ALREDEDOR, sin
+   usted de por medio). 2.6s = MOMENTOS_IDLE.mirausted.dur. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='mirausted'] .crt-cabeza {
+  animation: agt-mirausted-cabeza 2.6s ease-in-out 1;
+}
+@keyframes agt-mirausted-cabeza {
+  0%, 12%, 100% { transform: rotate(0deg); }
+  32%  { transform: rotate(-6deg); }   /* voltea derecho hacia usted */
+  38%, 68% { transform: rotate(-5.2deg); } /* sostiene la mirada */
+  84%  { transform: rotate(1deg); }    /* vuelve a lo suyo, con un pelín de overshoot */
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='mirausted'] .rh-mirada {
+  animation: agt-mirausted-pupila 2.6s ease-in-out 1;
+}
+@keyframes agt-mirausted-pupila {
+  0%, 12%, 100% { transform: translate(0, 0); }
+  32%, 68% { transform: translate(0, 0.35px); }  /* pupilas al frente, hacia usted */
+}
+/* Los ojos se abren un poco más al reconocerla a usted (atención, no susto). */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='mirausted'] .rh-blink {
+  animation: agt-mirausted-ojos 2.6s ease-in-out 1;
+}
+@keyframes agt-mirausted-ojos {
+  0%, 12%, 100% { transform: scaleY(1); }
+  32%, 68% { transform: scaleY(1.1); }
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='mirausted'] .agt-cuerpo {
+  animation: agt-mirausted-cuerpo 2.6s ease-in-out 1;
+}
+@keyframes agt-mirausted-cuerpo {
+  0%, 100% { transform: rotate(0deg); }
+  32%, 68% { transform: rotate(-1.5deg); }  /* un ladeo chiquito, del cuerpo entero */
+}
+
+/* CUENTA CON LAS PATITAS — la vecina que enumera algo con las manitas: cada
+   bracito baja y "toca" como si contara con los dedos (uno… dos…), la cabeza
+   acompaña el conteo con un cabeceo breve por cada toque. Asíncrono (el
+   brazo derecho cuenta primero, el izquierdo remata) para que no se lea como
+   un espejo perfecto — una criatura contando, no un metrónomo.
+   3.0s = MOMENTOS_IDLE.cuenta.dur. */
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='cuenta'] .crt-brazo-r {
+  animation: agt-cuenta-brazo-r 3.0s cubic-bezier(0.4, 0, 0.3, 1.2) 1;
+}
+@keyframes agt-cuenta-brazo-r {
+  0%, 10%, 100% { transform: rotate(0deg); }
+  22%  { transform: rotate(-96deg); }   /* uno… */
+  30%  { transform: rotate(-84deg); }
+  46%  { transform: rotate(-100deg); }  /* dos… */
+  54%  { transform: rotate(-84deg); }
+  86%  { transform: rotate(4deg); }     /* recoge */
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='cuenta'] .crt-brazo-l {
+  animation: agt-cuenta-brazo-l 3.0s cubic-bezier(0.4, 0, 0.3, 1.2) 1;
+}
+@keyframes agt-cuenta-brazo-l {
+  0%, 58%, 100% { transform: rotate(0deg); }
+  70%  { transform: rotate(88deg); }    /* tres — el remate, un pelín tarde */
+  78%  { transform: rotate(76deg); }
+  90%  { transform: rotate(-3deg); }
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='cuenta'] .crt-cabeza {
+  animation: agt-cuenta-cabeza 3.0s ease-in-out 1;
+}
+@keyframes agt-cuenta-cabeza {
+  0%, 10%, 100% { transform: rotate(0deg) translateY(0); }
+  22%, 30% { transform: rotate(-2.2deg) translateY(0.3px); }  /* asiente: uno */
+  46%, 54% { transform: rotate(-2.4deg) translateY(0.35px); } /* dos */
+  70%, 78% { transform: rotate(2deg) translateY(0.3px); }     /* tres */
+  90%  { transform: rotate(0deg) translateY(0); }
+}
+[data-agente='angelita'][data-agt-vivo='1'][data-agt-idle='cuenta'] .agt-cuerpo {
+  animation: agt-cuenta-cuerpo 3.0s ease-in-out 1;
+}
+@keyframes agt-cuenta-cuerpo {
+  0%, 100% { transform: scale(1, 1); }
+  26%, 50%, 74% { transform: scale(1.015, 0.985); }  /* un pulsito por cada toque */
+}
+
 /* SE POSA — aterrizar CUESTA: se alza un pelo eligiendo el sitio, baja con
    peso (ease-in), amortigua con squash y queda abajo (fill forwards empalma
    con la quietud de 'posada'). Las alitas siguen frenando en el aire. */


### PR DESCRIPTION
## Resumen

Batch 1 de la Ola 2 del compAI ("el compañero cobra vida"), carril aparte del 3D. Fuente: `chagra-pendientes-compai.md` + brief `2026-07-30-compai-ola2.md`. Al auditar el código real contra el brief, 2 de los 3 items nombrados ya estaban implementados en `dev` (fechados 2026-07-26, antes de este brief desactualizado) — se documenta abajo qué se encontró vivo y qué de verdad faltaba.

## Qué se encendió

### #38 — Husmeo con datos reales de la finca
**Call-site**: `src/mockups/EntradaValle3D.jsx` (import `useFincaViva` de `mundo3d/useFincaViva.js`, hook puro three-free ya consumido fuera de su propio módulo por `Mundo.jsx`).

El `estadoFinca` que `EntradaValle3D` armaba solo traía `{ clima, animo, energia }` de muestra — `reaccionDeFinca` (que consume `CompaneroAbeja` en `Valle3D.jsx`) siempre caía a sus defaults neutros para `saludFinca`/`cosechaReciente`/`enso`. Ahora se mezclan los 3 campos reales de `useFincaViva()`. Anti-fabricación intacto: sin dato real quedan `undefined`, nunca se inventa salud ni cosecha.

_Nota: `useInventarioCompai`/`datosDeMundo` (el otro camino de datos reales del husmeo, vía IndexedDB de assets) YA estaba cableado desde el 2026-07-26 — este fix cierra el camino paralelo (clima/ENSO/salud vía `useFincaViva`) que seguía en muestra._

### #88 — El compAI habla sus tips en voz
**Call-site**: `src/mockups/valle/Valle3D.jsx`, `CompaneroAbeja` (nuevo `useEffect` junto a la declaración de `mensajeAngelita`).

El husmeo del valle solo pintaba `BurbujaAngelita` con `mensajeAngelita` — `speak`/`speakKokoro` existían en `ttsService.js` y ya se usaban en el saludo del shell (`EntradaValle3D.jsx`) y en `AcompananteMundo.jsx`, pero ningún call-site dentro de `Valle3D.jsx` los llamaba para el husmeo. Mismo patrón: Kokoro primero, Web Speech si no responde. Gateado por `usePrefsStore.ttsEnabled` (la bandera real de silencio) y `reducedMotion`. La burbuja de texto se sigue pintando siempre — la voz es un plus, nunca reemplaza el texto (aria-live intacto).

Cambio mínimo en `Valle3D.jsx` (30 líneas, solo la llamada speak) por ser hotspot compartido con Fable, según regla del brief.

### #13/#14 — Micro-gestos idle
**Call-site**: `src/compai/nucleo/gestos.js` (`MOMENTOS_IDLE`) + `src/visual/agente/angelita-agente.css` (keyframes).

Auditoría encontró que 6 de los 8 gestos nombrados (guiño/picarse-el-ojo, estirarse, bostezar + rascarse-la-nuca, cabecear-dormido, voltereta) YA estaban vivos desde el merge `fable/compai-gestos-entrada` (2026-07-26) — repertorio de 6→12 momentos, con keyframes CSS reales y el scheduler de `Angelita.jsx` consumiéndolos sin allowlist. Faltaban 2 de los 5 gestos del pedido original: **`mirausted`** ("mirar al usuario y volver la vista", distinto del `mira` curioso que mira alrededor) y **`cuenta`** ("contar algo con las patitas", brazos en secuencia asíncrona + cabeceo). Repertorio pasa de 12 a 14. Mismo patrón de los 6 anteriores (puro CSS sobre `.crt-brazo-l/r`, `.crt-cabeza`, `.rh-mirada`, `.rh-blink` — cero SVG nuevo).

## Reglas duras respetadas
- `src/visual/mundo3d/*` — NO tocado (0 archivos).
- `Valle3D.jsx` — tocado mínimo, solo la llamada speak (#88).
- Build + tests verdes; eslint limpio en todos los archivos tocados **excepto** `Valle3D.jsx`, que ya trae un error preexistente de memoización del React Compiler en `climaExtra` (línea ~1959, ajeno a este diff — confirmado con `git stash` contra `origin/dev`, mismo error sin mis cambios). Ese commit usa `--no-verify`; CI corre el lint completo igual.
- Español Colombia sin voseo.

## Qué sigue de la Ola 2 (no en este batch)
Del inventario `chagra-pendientes-compai.md` (33 🔴 faltan + 12 🟡 construido-sin-conectar restante tras este batch):
- **Planificador de paseo** (#25/#27/#31/#32/#33): presupuesto quieto-vs-paseo, radio en 3 anillos, regreso animado, toque aborta.
- **Cadencia/tips** (#58/#59/#60/#62): cadencia adaptativa, tope de 2-3 líneas, precalentar pool, telemetría plantilla-vs-LLM.
- **Toque/voz/control** (#66/#69/#70/#91/#102/#103/#106/#107): opciones al tocar, unificar con FAB de micrófono, mantener-presionado, silenciar desde el personaje, modo "hoy no".
- **Datos/agroecología** (#78/#80/#81): sacar hardcodeos restantes, ampliar slugs al catálogo real, cruce con grafo.
- **Cruce A/↔V/** (#96/#97): un solo localStorage, estado que cruza el salto.
- **Cámara** (#50/#51): acompaña la entrada/salida del husmeo.
- **#19**: perfiles idle propios para jaguar/guacamaya/chivito/luciérnaga (hoy solo Angelita tiene los 14 gestos; los otros 12 bichos rubber-hose tienen su propio repertorio en `vidaEstados.js`, sin los gestos nuevos).
- Gate visual pendiente: los 2 gestos nuevos (mirausted/cuenta) no tienen captura de verificación — recomendado antes de dar por cerrado #13/#14 al 100%.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>