### PR TITLE
fix(mundo3d): pageerror del mundo agua (ref sobre material) + pulido de la quebrada

### DIFF
--- a/src/visual/mundo3d/escenas/EscenaFlujo.jsx
+++ b/src/visual/mundo3d/escenas/EscenaFlujo.jsx
@@ -29,16 +29,33 @@ const CURVA_DEFAULT = [
   [-1.8, 2.2, 0.4], [-0.9, 1.4, 0.1], [0, 0.7, -0.2], [0.7, 0.1, 0.1], [1.4, -0.2, 0.5],
 ];
 
+/* El brillo interior de toda lámina de agua de la escena (mismo look probado
+   del mockup standalone MundoAgua3D): sin él, el Lambert plano se confunde
+   con la ladera y el agua no parece agua. */
+const AGUA_EMISIVO = '#2a6a86';
+
 function Cinta({ curva3, color, reducedMotion }) {
+  // El ref vive en el MATERIAL (no en el mesh): ref.current ES el material.
+  // Antes hacía `ref.current.material.opacity` → TypeError en cada frame
+  // (material.opacity de undefined) y el frame-loop del mundo moría.
   const ref = useRef(null);
   useFrame((state) => {
     if (reducedMotion || !ref.current) return;
-    ref.current.material.opacity = 0.72 + Math.sin(state.clock.elapsedTime * 2) * 0.08;
+    ref.current.opacity = 0.72 + Math.sin(state.clock.elapsedTime * 2) * 0.08;
   });
-  const geo = useMemo(() => new THREE.TubeGeometry(curva3, 48, 0.16, 6, false), [curva3]);
+  // radio 0.24: con 0.16 la quebrada se leía como un hilito perdido en la
+  // ladera (gate visual) — el agua es el PROTAGONISTA de este mundo.
+  const geo = useMemo(() => new THREE.TubeGeometry(curva3, 48, 0.24, 6, false), [curva3]);
   return (
     <mesh geometry={geo}>
-      <meshLambertMaterial ref={ref} color={color} transparent opacity={0.78} />
+      <meshLambertMaterial
+        ref={ref}
+        color={color}
+        transparent
+        opacity={0.78}
+        emissive={AGUA_EMISIVO}
+        emissiveIntensity={0.3}
+      />
     </mesh>
   );
 }
@@ -48,6 +65,11 @@ function Cinta({ curva3, color, reducedMotion }) {
 function Gotas({ curva3, color, reducedMotion }) {
   const refs = useRef([]);
   const bases = [0.15, 0.5, 0.85];
+  // Gotas más claras que la corriente: espuma que viaja, no canicas del mismo tinte.
+  const colorGota = useMemo(
+    () => `#${new THREE.Color(color).lerp(new THREE.Color('#eef8fb'), 0.45).getHexString()}`,
+    [color],
+  );
   useFrame((state) => {
     if (reducedMotion) return;
     const t = state.clock.elapsedTime * 0.08;
@@ -68,7 +90,7 @@ function Gotas({ curva3, color, reducedMotion }) {
             position={[p.x, p.y + 0.06, p.z]}
           >
             <sphereGeometry args={[0.09, 8, 6]} />
-            <meshBasicMaterial color={color} transparent opacity={0.9} />
+            <meshBasicMaterial color={colorGota} transparent opacity={0.9} />
           </mesh>
         );
       })}
@@ -107,7 +129,9 @@ function Ronda({ curva3, tramo = [0, 0.35], arboles = 5 }) {
       const lado = i % 2 === 0 ? 1 : -1;
       return {
         key: i,
-        pos: [p.x + lado * 0.42, p.y - 0.05, p.z + lado * 0.5],
+        // −0.12: las raíces buscan la superficie de la ladera (la curva viaja
+        // un pelo por encima de ella); con −0.05 el monte flotaba.
+        pos: [p.x + lado * 0.42, p.y - 0.12, p.z + lado * 0.5],
         escala: 0.8 + (i % 3) * 0.18,
       };
     });
@@ -130,7 +154,13 @@ function Bocatoma({ curva3, t = 0.68, color }) {
       </mesh>
       <mesh position={[0, 0.26, 0]}>
         <boxGeometry args={[0.34, 0.06, 0.34]} />
-        <meshLambertMaterial color={color} transparent opacity={0.8} />
+        <meshLambertMaterial
+          color={color}
+          transparent
+          opacity={0.8}
+          emissive={AGUA_EMISIVO}
+          emissiveIntensity={0.3}
+        />
       </mesh>
     </group>
   );
@@ -141,7 +171,7 @@ function Bocatoma({ curva3, t = 0.68, color }) {
 function PuntoCuidado({ curva3, t = 0.46, lado = 0.8 }) {
   const p = curva3.getPoint(t);
   return (
-    <group position={[p.x + lado * 0.4, p.y - 0.02, p.z + lado]}>
+    <group position={[p.x + lado * 0.4, p.y - 0.12, p.z + lado]}>
       <mesh position={[0, 0.16, 0]}>
         <cylinderGeometry args={[0.14, 0.14, 0.32, 10]} />
         <meshLambertMaterial color={PALETA.lamina} flatShading />
@@ -176,7 +206,13 @@ function Cultivo({ pos = [2.3, -0.3, -0.55], surcos = 4, desde, color }) {
       {canal && (
         <mesh position={canal.medio} rotation={[0, canal.angulo, 0]}>
           <boxGeometry args={[0.1, 0.06, canal.largo]} />
-          <meshLambertMaterial color={color} transparent opacity={0.75} />
+          <meshLambertMaterial
+            color={color}
+            transparent
+            opacity={0.75}
+            emissive={AGUA_EMISIVO}
+            emissiveIntensity={0.3}
+          />
         </mesh>
       )}
       <group position={[pos[0], pos[1], pos[2]]}>
@@ -202,22 +238,58 @@ function Diorama({ params, tinte, reducedMotion, fauna }) {
     const pts = (params?.curva || CURVA_DEFAULT).map((p) => new THREE.Vector3(p[0], p[1], p[2]));
     return new THREE.CatmullRomCurve3(pts);
   }, [params?.curva]);
-  const inicio = curva3.getPoint(0);
-  const fin = curva3.getPoint(1);
+  /* La ladera se ALINEA a la CUERDA del recorrido (inicio→fin de la curva).
+     Antes era una tabla fija ([-0.4,0.6,-0.3], −0.5 rad, 3.6 de largo) más
+     corta y menos empinada que la quebrada de mundoData (−0.6 rad, ~4.4):
+     enterraba la cinta a mitad de camino y dejaba el nacimiento flotando en
+     el aire — visto en el gate visual del fix del frame-loop. La superficie
+     queda ~0.2 bajo la cuerda: el CatmullRom se comba ~0.14 hacia adentro,
+     así la cinta viaja posada/half-nestled, nunca sepultada. */
+  const { inicio, fin, ladera } = useMemo(() => {
+    const a = curva3.getPoint(0);
+    const b = curva3.getPoint(1);
+    return {
+      inicio: a,
+      fin: b,
+      ladera: {
+        pos: [(a.x + b.x) / 2, (a.y + b.y) / 2 - 0.45, (a.z + b.z) / 2 - 0.2],
+        rot: Math.atan2(b.y - a.y, b.x - a.x),
+        largo: Math.hypot(b.x - a.x, b.y - a.y) + 1.1,
+      },
+    };
+  }, [curva3]);
+  /* El AGUA viaja por su propia curva, +0.12 sobre la de los datos: la comba
+     del CatmullRom hundía la cinta bajo la superficie en el tramo bajo (del
+     punto de cuidado al tanque el agua desaparecía — gate visual). Los
+     anclajes de TIERRA (ronda, bocatoma, cuidado) siguen en la curva
+     original, al ras de la ladera. */
+  const curvaAgua = useMemo(() => {
+    const pts = (params?.curva || CURVA_DEFAULT).map((p) => new THREE.Vector3(p[0], p[1] + 0.12, p[2]));
+    return new THREE.CatmullRomCurve3(pts);
+  }, [params?.curva]);
   return (
     <group>
       {/* la ladera por la que baja el agua */}
-      <mesh position={[-0.4, 0.6, -0.3]} rotation={[0, 0, -0.5]}>
-        <boxGeometry args={[3.6, 0.5, 2.4]} />
+      <mesh
+        position={/** @type {[number, number, number]} */ (ladera.pos)}
+        rotation={[0, 0, ladera.rot]}
+      >
+        <boxGeometry args={[ladera.largo, 0.55, 2.6]} />
         <meshLambertMaterial color="#7d9a5c" flatShading />
       </mesh>
       {/* el nacimiento arriba (donde arranca la curva) */}
-      <mesh position={[inicio.x, inicio.y + 0.05, inicio.z]}>
+      <mesh position={[inicio.x, inicio.y, inicio.z]}>
         <cylinderGeometry args={[0.34, 0.4, 0.16, 14]} />
-        <meshLambertMaterial color={color} transparent opacity={0.85} />
+        <meshLambertMaterial
+          color={color}
+          transparent
+          opacity={0.85}
+          emissive={AGUA_EMISIVO}
+          emissiveIntensity={0.32}
+        />
       </mesh>
-      <Cinta curva3={curva3} color={color} reducedMotion={reducedMotion} />
-      <Gotas curva3={curva3} color={color} reducedMotion={reducedMotion} />
+      <Cinta curva3={curvaAgua} color={color} reducedMotion={reducedMotion} />
+      <Gotas curva3={curvaAgua} color={color} reducedMotion={reducedMotion} />
       {/* el tanque que recibe el agua (donde termina la curva) */}
       <mesh position={[fin.x + 0.1, fin.y + 0.05, fin.z]}>
         <cylinderGeometry args={[0.55, 0.6, 0.7, 18]} />
@@ -225,7 +297,13 @@ function Diorama({ params, tinte, reducedMotion, fauna }) {
       </mesh>
       <mesh position={[fin.x + 0.1, fin.y + 0.25, fin.z]}>
         <cylinderGeometry args={[0.5, 0.5, 0.12, 18]} />
-        <meshLambertMaterial color={color} transparent opacity={0.8} />
+        <meshLambertMaterial
+          color={color}
+          transparent
+          opacity={0.8}
+          emissive={AGUA_EMISIVO}
+          emissiveIntensity={0.32}
+        />
       </mesh>
       {/* los hitos del recorrido (por datos; opcionales) */}
       {hitos?.ronda && <Ronda curva3={curva3} tramo={hitos.ronda.tramo} arboles={hitos.ronda.arboles} />}
@@ -245,12 +323,38 @@ function Diorama({ params, tinte, reducedMotion, fauna }) {
   );
 }
 
+/* ENCUADRE: la pose de reposo de la cámara (base compartida) mira al ORIGEN,
+   pero el recorrido de mundoData nace alto (y≈2.3) — el corazón del diorama
+   quedaba ~1.1 sobre el origen y el mundo se veía arriba-izquierda con medio
+   encuadre vacío (gate visual del fix). Se baja el CONJUNTO — diorama y
+   hotspots JUNTOS, para no desanclar las puertas — y la alfombra (`piso`)
+   acompaña. Solo presentación: los DATOS de mundoData no se tocan y el
+   gemelo 2D sigue leyendo la curva original. */
+const BAJADA = -0.55;
+
 export default function EscenaFlujo(props) {
   const cielo = CIELOS.agua;
   const fauna = faunaDeMundo(props.mundoId, { tier: props.tier });
+  const hotspots = useMemo(
+    () => props.hotspots?.map((h) => ({ ...h, pos: [h.pos[0], h.pos[1] + BAJADA, h.pos[2]] })),
+    [props.hotspots],
+  );
   return (
-    <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.9, 0.3] }}>
-      <Diorama params={props.params} tinte={props.tinte} reducedMotion={props.reducedMotion} fauna={fauna} />
+    <EscenaBase3D
+      {...props}
+      hotspots={hotspots}
+      cielo={cielo}
+      piso={-1.05}
+      entrada={{ ...props.entrada, zoom: 6, centro: [0, 0.35, 0.1] }}
+      /* Cámara propia del arquetipo: la de reposo compartida (elev. ~24°) veía
+         la ladera de 34° casi DE CANTO desde abajo y el agua desaparecía a
+         mitad de camino (gate visual). Más alta y frontal a la cara de la
+         pendiente (elev. ~36°, misma distancia): el recorrido se lee entero. */
+      camara={{ position: [3.6, 4.5, 5.1], fov: 42 }}
+    >
+      <group position={[0, BAJADA, 0]}>
+        <Diorama params={props.params} tinte={props.tinte} reducedMotion={props.reducedMotion} fauna={fauna} />
+      </group>
     </EscenaBase3D>
   );
 }


### PR DESCRIPTION
Bug: en EscenaFlujo el ref estaba en el material y useFrame hacía ref.current.material.opacity → undefined.opacity → TypeError por frame que mataba el frame-loop del mundo. Fix: ref.current.opacity. + pulido: ladera alineada a la curva de mundoData, quebrada turquesa continua nacimiento→tanque, encuadre. Gate GPU real, 0 pageerrors, Gemini OK, tests 7/7. 🤖 Generated with Claude Code