### PR TITLE
feat(animales): pulir corral — cámara cerca, hato en el anillo del abono, cebú legible

### DIFF
--- a/src/mockups/Mundo3DAnimales.css
+++ b/src/mockups/Mundo3DAnimales.css
@@ -46,9 +46,12 @@
   max-width: 46rem;
   margin: 0 auto;
 }
-/* El host <Mundo> llena este marco; en 3D necesita altura real. */
+/* El host <Mundo> llena este marco; en 3D necesita altura real. Con la cámara
+   cercana del corral (QA 2026-07-30) el diorama agradece un pelín más de aire
+   vertical: los overlays del framework (píldora, burbuja del acompañante,
+   invitación de audio) dejan de apilarse sobre el hato. */
 .m3dan__escena .mundo-root {
-  height: min(62vh, 30rem);
+  height: min(68vh, 33rem);
   min-height: 300px;
   border: 1px solid rgba(168, 106, 58, 0.28);
   box-shadow: 0 10px 28px rgba(74, 47, 22, 0.14);
@@ -56,6 +59,19 @@
 .m3dan__escena .mundo-root[data-dim='2d'] {
   height: auto;
   background: #fdf8ee;
+}
+/* Las píldoras de hotspot, a la escala del corral (QA visual 2026-07-30): con
+   la cámara de reposo cercana de este mundo el billboard crece ~1.5x y la
+   píldora central («Todos los animales») tapaba el hato entero. Solo en esta
+   vitrina: tipografía más contenida (todo lo interno es em; el piso táctil de
+   44px del framework queda intacto) y la píldora PLENA baja unos px hacia el
+   borde cercano del corral — queda posada sobre su puerta, no sobre las caras
+   de los animales. margin (no transform): cero pelea con el hover/focus. */
+.m3dan__escena .mundo-hotspot {
+  font-size: 0.8rem;
+}
+.m3dan__escena .mundo-hotspot[data-modo='plena'] {
+  margin-top: 2.6em;
 }
 
 .m3dan__barra {

--- a/src/visual/mundo3d/escenas/CorralVivo.jsx
+++ b/src/visual/mundo3d/escenas/CorralVivo.jsx
@@ -251,6 +251,35 @@ export function normalizarAnimales(lista) {
   });
 }
 
+/* ── La POSE del corral (NO exportada: solo el hato del corral; el mercado
+   posa sus vendidos aparte en AnimalMomento) ────────────────────────────────
+   El rumbo pseudo-aleatorio de normalizarAnimales es honesto pero CIEGO a la
+   cámara: a un animal le puede tocar quedar exactamente de espaldas al encuadre
+   de entrada y su silueta muere (QA visual 2026-07-30: Camilo, el cebú vendido,
+   leía "medio piedra" de espaldas — un lomo translúcido sin cabeza ni patas
+   visibles). Aquí cada animal se orienta TANGENTE al anillo del ciclo — el hato
+   CAMINA el anillo del abono, que es la tesis del mundo — con un jitter
+   determinista por animal (vida, no formación). En tangente, desde cualquier
+   borde del corral el animal queda de perfil o tres cuartos: la silueta
+   (cabeza, lomo, patas) siempre lee. Muta los objetos frescos que devuelve
+   normalizarAnimales; la función compartida no cambia. */
+const _posV = new THREE.Vector3();
+const _posQ = new THREE.Quaternion();
+const _posE = new THREE.Vector3();
+function posarHatoCorral(animales) {
+  for (const a of animales) {
+    const angulo = Math.atan2(a.pos[2], a.pos[0]);
+    const jitter = Math.sin(a.fase * 7.3) * 0.35;
+    const rumbo = -(angulo + Math.PI / 2) + jitter;
+    a.mat.compose(
+      _posV.set(a.pos[0], a.pos[1], a.pos[2]),
+      _posQ.setFromAxisAngle(EJE_Y, rumbo),
+      _posE.set(a.escala, a.escala, a.escala),
+    );
+  }
+  return animales;
+}
+
 /* El gesto de idle de la especie como matriz sobre el pivote del piso (las
    mismas amplitudes chicas del recinto original: vida, no espectáculo). */
 function matrizGesto(m, gesto, t, fase) {
@@ -339,7 +368,10 @@ function ParteInstanciada({ parte, lista, fantasma, animar, onPick }) {
         color={parte.porRaza ? '#ffffff' : parte.color}
         flatShading
         transparent={fantasma}
-        opacity={fantasma ? 0.35 : 1}
+        /* 0.35 sobre el piso de madera clara dejaba al fantasma casi invisible
+           (pelaje cebú #d9d2c4 ≈ el piso); 0.45 conserva la poética de la
+           huella pero la silueta vuelve a leer (QA visual 2026-07-30). */
+        opacity={fantasma ? 0.45 : 1}
         depthWrite={!fantasma}
       />
     </instancedMesh>
@@ -603,7 +635,7 @@ function PlacaAnimal({ animal, onCerrar }) {
  * grupos aparte), señales de preñez, carteles con nombre y la placa del toque.
  */
 export default function CorralVivo({ animales: lista, reducedMotion, tier = 'alto' }) {
-  const animales = useMemo(() => normalizarAnimales(lista || []), [lista]);
+  const animales = useMemo(() => posarHatoCorral(normalizarAnimales(lista || [])), [lista]);
   const [seleccion, setSeleccion] = useState(null);
   // GATE doble: reduced-motion apaga el idle; gama baja tampoco lo paga.
   const animar = !reducedMotion && tier !== 'bajo';

--- a/src/visual/mundo3d/escenas/EscenaRecinto.jsx
+++ b/src/visual/mundo3d/escenas/EscenaRecinto.jsx
@@ -22,6 +22,17 @@ import { CIELOS, PALETA } from '../atmosferaMadre.js';
    estercolero que procesa el estiércol y cierra el ciclo del abono— más
    POLINIZADORES por la cerca) vive en faunaFuncional.js, poblada por mundo. */
 
+/* ENCUADRE propio del corral (QA visual 2026-07-30): la escena es CHICA (cerca
+   en r=1.9) y el zoom genérico del registro (7) dejaba la cámara de reposo a
+   ~9 unidades — el hato se veía de manchitas y la píldora del hotspot central
+   tapaba medio corral. El arquetipo fija aquí su escala REAL: un `zoom` a la
+   medida del corral (niebla, alfombra y órbita proporcionales; permite acercarse
+   más a los animales) y una cámara de reposo más cercana y baja — la mirada de
+   quien se asoma por la cerca — con la que cada animal se lee entero. Solo este
+   arquetipo cambia: `camara`/`entrada.zoom` son contrato ya existente de la base. */
+const ZOOM_CORRAL = 4.6;
+const CAMARA_CORRAL = { position: [2.5, 2.5, 4.35], fov: 42 };
+
 /* Fallback si el mundo no trae hato (retrocompat con el recinto original):
    pocos animales en formato viejo — prueba viva de que el camino legado vive. */
 const HATO_LEGADO = [
@@ -76,7 +87,12 @@ export default function EscenaRecinto(props) {
   const cielo = CIELOS.corral;
   const fauna = faunaDeMundo(props.mundoId, { tier: props.tier });
   return (
-    <EscenaBase3D {...props} cielo={cielo} entrada={{ ...props.entrada, centro: [0, 0.4, 0] }}>
+    <EscenaBase3D
+      {...props}
+      cielo={cielo}
+      camara={CAMARA_CORRAL}
+      entrada={{ ...props.entrada, zoom: ZOOM_CORRAL, centro: [0, 0.4, 0] }}
+    >
       <Diorama
         params={props.params}
         reducedMotion={props.reducedMotion}


### PR DESCRIPTION
Pule mundo3d-animales (revivido por el fix CSP): zoom 7→4.6, animales tangentes al anillo del ciclo (caminan el abono), Camilo el cebú deja de leer 'piedra' (opacidad 0.35→0.45), píldoras a escala. AnimalMomento NO tocado (anti-tangle). Gemini OK, 0 pageerrors, tests 15/15. 🤖 Generated with Claude Code