### PR TITLE
feat(milpa): encuadre propio + tres hermanas legibles + nódulos de Rhizobium al frente

### DIFF
--- a/src/visual/mundo3d/escenas/EscenaCutaway.jsx
+++ b/src/visual/mundo3d/escenas/EscenaCutaway.jsx
@@ -132,61 +132,69 @@ function Fauna({ base, phase, deriva = 0, asomo = 0.05, reducedMotion, children 
    ella y abona, la calabaza cubre el suelo. Todas low-poly (cono/cilindro/esfera),
    sin cajas; no toca el corte de suelo/abono (va detrás de `params.milpa`). */
 
-/* MataMaiz: la caña = el tutor vivo. Cilindro + hojas cono + mazorca cápsula. */
+/* MataMaiz: la caña = el tutor vivo. Cilindro + hojas cono + mazorca cápsula.
+   Legibilidad (QA visual 2026-07-30): la caña iba delgada y oscura y al zoom del
+   manifiesto leía como palo seco, no como maíz — caña más gruesa y clara, hojas
+   más LARGAS y abiertas (el gesto de arco del maíz) en verde que canta contra el
+   cielo tierra, y mazorca/penacho un paso más grandes y dorados. */
 function MataMaiz({ base, alto = 1.7 }) {
   const [x, y, z] = base;
-  const hojas = [0.34, 0.52, 0.7, 0.86];
+  const hojas = [0.3, 0.46, 0.62, 0.78, 0.9];
   return (
     <group position={[x, y, z]}>
       <mesh position={[0, alto / 2, 0]}>
-        <cylinderGeometry args={[0.045, 0.075, alto, 7]} />
-        <meshLambertMaterial color="#88a24a" flatShading />
+        <cylinderGeometry args={[0.055, 0.09, alto, 7]} />
+        <meshLambertMaterial color="#9ab654" flatShading />
       </mesh>
       {hojas.map((f, i) => {
         const lado = i % 2 === 0 ? 1 : -1;
         return (
-          <mesh key={f} position={[lado * 0.11, alto * f, 0]} rotation={[0, i * 1.4, lado * -0.95]}>
-            <coneGeometry args={[0.05, 0.62, 4]} />
-            <meshLambertMaterial color="#6f9a45" flatShading />
+          <mesh key={f} position={[lado * 0.24, alto * f, 0]} rotation={[0, i * 1.4, lado * -1.15]}>
+            <coneGeometry args={[0.07, 0.85, 4]} />
+            <meshLambertMaterial color="#7cae4d" flatShading />
           </mesh>
         );
       })}
       {/* la mazorca: cápsula crema arrimada a la caña */}
-      <mesh position={[0.12, alto * 0.5, 0.05]} rotation={[0, 0, 0.5]}>
-        <capsuleGeometry args={[0.075, 0.2, 3, 7]} />
-        <meshLambertMaterial color="#ecd98f" flatShading />
+      <mesh position={[0.14, alto * 0.5, 0.05]} rotation={[0, 0, 0.5]}>
+        <capsuleGeometry args={[0.09, 0.24, 3, 7]} />
+        <meshLambertMaterial color="#f0dd96" flatShading />
       </mesh>
       {/* el penacho de arriba (la flor del maíz) */}
-      <mesh position={[0, alto + 0.14, 0]}>
-        <coneGeometry args={[0.06, 0.28, 5]} />
-        <meshLambertMaterial color="#d8c98a" flatShading />
+      <mesh position={[0, alto + 0.16, 0]}>
+        <coneGeometry args={[0.07, 0.34, 5]} />
+        <meshLambertMaterial color="#e0cd85" flatShading />
       </mesh>
     </group>
   );
 }
 
-/* GuiaFrijol: espiral fino que sube ciñéndose a la caña del maíz. */
+/* GuiaFrijol: espiral fino que sube ciñéndose a la caña del maíz. Legibilidad
+   (QA visual 2026-07-30): con cuentas de r=0.026 la guía desaparecía al zoom del
+   manifiesto y el "fríjol que trepa" era invisible — cuentas más gordas y MÁS
+   (la espiral se lee continua), radio de vuelta mayor (se despega de la caña) y
+   hojas trifoliadas más grandes en verde claro que contrasta con el maíz. */
 function GuiaFrijol({ base, alto = 1.5, vueltas = 4 }) {
   const [x, y, z] = base;
-  const N = 20;
+  const N = 26;
   const cuentas = Array.from({ length: N }, (_, i) => {
     const f = i / (N - 1);
     const ang = f * vueltas * Math.PI * 2;
-    const r = 0.1 + 0.02 * (1 - f);
-    return { key: i, pos: [Math.cos(ang) * r, alto * f + 0.06, Math.sin(ang) * r], hoja: i % 5 === 2, ang };
+    const r = 0.13 + 0.02 * (1 - f);
+    return { key: i, pos: [Math.cos(ang) * r, alto * f + 0.06, Math.sin(ang) * r], hoja: i % 4 === 2, ang };
   });
   return (
     <group position={[x, y, z]}>
       {cuentas.map((c) => (
         <group key={c.key}>
           <mesh position={/** @type {[number, number, number]} */ (c.pos)}>
-            <sphereGeometry args={[0.026, 5, 4]} />
-            <meshLambertMaterial color="#4f8a34" flatShading />
+            <sphereGeometry args={[0.036, 5, 4]} />
+            <meshLambertMaterial color="#55a138" flatShading />
           </mesh>
           {c.hoja && (
             <mesh position={/** @type {[number, number, number]} */ (c.pos)} rotation={[0, -c.ang, 0.6]}>
-              <coneGeometry args={[0.04, 0.15, 4]} />
-              <meshLambertMaterial color="#5f9a3f" flatShading />
+              <coneGeometry args={[0.055, 0.22, 4]} />
+              <meshLambertMaterial color="#6cb84a" flatShading />
             </mesh>
           )}
         </group>
@@ -214,20 +222,26 @@ function Calabaza({ base }) {
           <meshLambertMaterial color={PALETA.follaje} flatShading />
         </mesh>
       ))}
-      {/* el fruto: esfera achatada, color ahuyama */}
-      <mesh position={[0.5, 0.16, 0.05]} scale={[1, 0.72, 1]}>
-        <sphereGeometry args={[0.2, 8, 6]} />
-        <meshLambertMaterial color="#cf8f3c" flatShading />
+      {/* el fruto: esfera achatada, color ahuyama — un paso más grande y cálido
+          para que la tercera hermana se lea de lejos (QA visual 2026-07-30) */}
+      <mesh position={[0.5, 0.18, 0.05]} scale={[1, 0.72, 1]}>
+        <sphereGeometry args={[0.24, 8, 6]} />
+        <meshLambertMaterial color="#d9973e" flatShading />
+      </mesh>
+      {/* el pezón del fruto (lo hace calabaza, no piedra) */}
+      <mesh position={[0.5, 0.36, 0.05]}>
+        <cylinderGeometry args={[0.025, 0.04, 0.09, 5]} />
+        <meshLambertMaterial color="#8a9a4a" flatShading />
       </mesh>
       {/* la flor amarilla que llama a la abeja */}
       <group position={[-0.12, 0.12, 0.28]}>
         <mesh rotation={[0.5, 0, 0]}>
-          <coneGeometry args={[0.09, 0.16, 6]} />
-          <meshLambertMaterial color="#e8c34a" flatShading />
+          <coneGeometry args={[0.11, 0.18, 6]} />
+          <meshLambertMaterial color="#eac74e" flatShading />
         </mesh>
-        <mesh position={[0, 0.03, 0.03]}>
-          <sphereGeometry args={[0.032, 5, 4]} />
-          <meshBasicMaterial color="#f0d878" />
+        <mesh position={[0, 0.04, 0.04]}>
+          <sphereGeometry args={[0.04, 5, 4]} />
+          <meshBasicMaterial color="#f2dc80" />
         </mesh>
       </group>
     </group>
@@ -243,7 +257,7 @@ function RaizNodulos({ base, largo = 1.4 }) {
   const nodulos = Array.from({ length: M }, (_, i) => {
     const f = 0.18 + (i / M) * 0.78;
     const lado = i % 2 === 0 ? 1 : -1;
-    return { key: i, pos: [lado * (0.04 + (i % 3) * 0.05), -largo * f, 0.02 * lado], r: 0.038 + (i % 2) * 0.014 };
+    return { key: i, pos: [lado * (0.05 + (i % 3) * 0.055), -largo * f, 0.03], r: 0.046 + (i % 2) * 0.016 };
   });
   return (
     <group position={[x, y, z]}>
@@ -260,10 +274,15 @@ function RaizNodulos({ base, largo = 1.4 }) {
         <coneGeometry args={[0.022, largo * 0.44, 5]} />
         <meshLambertMaterial color="#bd9a5a" flatShading />
       </mesh>
+      {/* los nódulos, la estrella didáctica del corte: más gordos, rosado más
+          claro y SIEMPRE asomados hacia el frente (z fijo +0.03, no alternado
+          — la mitad quedaba hundida en la cara y el corte "prometía nódulos"
+          sin mostrarlos; QA visual 2026-07-30). MeshBasic = sin sombra propia:
+          leen como pelotitas rosadas aunque la hora apague el sol. */}
       {nodulos.map((nd) => (
         <mesh key={nd.key} position={/** @type {[number, number, number]} */ (nd.pos)}>
           <sphereGeometry args={[nd.r, 6, 5]} />
-          <meshLambertMaterial color="#e0a3ad" flatShading />
+          <meshBasicMaterial color="#eba9b6" />
         </mesh>
       ))}
     </group>
@@ -329,20 +348,34 @@ function AvispaParasitoide({ base, fase = 0, reducedMotion = false }) {
   );
 }
 
-/* El módulo de las tres hermanas, compuesto sobre la cara del corte. */
+/* El módulo de las tres hermanas, compuesto sobre la cara del corte.
+   QA visual 2026-07-30: una caña sola leía como "mata suelta", no como MILPA —
+   se siembra una segunda caña compañera (más baja, con su fríjol y su raíz
+   nodulada) y la asociación se lee como siembra viva. Las raíces van un pelín
+   más al frente (CARA-0.02) para que el relieve del corte las muestre. */
 function Milpa({ total, config, reducedMotion }) {
   const cfg = config === true ? {} : (config || {});
   const zF = CARA - 0.16; // el frente del corte, donde crecen las plantas
-  const zRaiz = CARA - 0.05; // pegado a la cara: las raíces se ven en el corte
+  const zRaiz = CARA - 0.02; // pegado a la cara: las raíces se ven en el corte
   const maizX = cfg.maiz?.x ?? -0.25;
-  const maizAlto = cfg.maiz?.alto ?? 1.7;
+  /* La caña del manifiesto (1.7) sobre un corte de 2.3 dejaba la composición de
+     4.3 unidades de alto — imposible de encuadrar con el target fijo del
+     framework (el origen) sin dejar el corte chiquito. 0.88 la modera sin
+     perderle el porte de tutor (QA visual 2026-07-30). */
+  const maizAlto = (cfg.maiz?.alto ?? 1.7) * 0.88;
   const calX = cfg.calabaza?.x ?? 0.7;
   const vueltas = cfg.frijol?.vueltas ?? 4;
+  const maiz2X = maizX - 1.15; // la caña compañera (la milpa nunca es una sola)
+  const maiz2Alto = maizAlto * 0.82;
   return (
     <group>
       <MataMaiz base={[maizX, total, zF]} alto={maizAlto} />
       <GuiaFrijol base={[maizX, total, zF]} alto={maizAlto * 0.9} vueltas={vueltas} />
       <RaizNodulos base={[maizX, total, zRaiz]} largo={total * 0.62} />
+      {/* la caña compañera con su fríjol y sus nódulos (siembra, no espécimen) */}
+      <MataMaiz base={[maiz2X, total, zF - 0.08]} alto={maiz2Alto} />
+      <GuiaFrijol base={[maiz2X, total, zF - 0.08]} alto={maiz2Alto * 0.9} vueltas={Math.max(3, vueltas - 1)} />
+      <RaizNodulos base={[maiz2X, total, zRaiz]} largo={total * 0.48} />
       <Calabaza base={[calX, total, zF - 0.05]} />
       {/* POLINIZADOR: la mariposa que visita la flor de la calabaza (vida, no relleno) */}
       <Fauna base={[calX - 0.15, total + 0.5, zF + 0.12]} phase={1.7} deriva={0.5} asomo={0.05} reducedMotion={reducedMotion}>
@@ -356,6 +389,12 @@ function Milpa({ total, config, reducedMotion }) {
 
 function Diorama({ params, reducedMotion }) {
   const vida = clamp01(params?.vida);
+  /* Con la milpa el diorama BAJA (precedente: DioramaPisos en EscenaEstratos):
+     las hermanas suben ~1.7 sobre el bloque y el target de reposo es el origen —
+     bajando el conjunto, corte + matas quedan centrados en el encuadre en vez de
+     regalar el tercio bajo del cuadro. Los hotspots del manifiesto siguen
+     cayendo sobre caña y corte (verificado contra sus alturas). */
+  const baja = params?.milpa ? 0.55 : 0;
 
   /* EL PISO DE LECTURA del corte (mismo remedio del cafetal/aguacatal, #2707):
      la cara cortada mira al frente (+z) y el sol de la franja — cenital de día,
@@ -452,7 +491,7 @@ function Diorama({ params, reducedMotion }) {
   }, [params, vida]);
 
   return (
-    <group position={[0, -total / 2, 0]}>
+    <group position={[0, -total / 2 - baja, 0]}>
       {/* el piso de lectura: relleno cálido + clave frontal hacia la cara del
           corte (target implícito en el origen del grupo, delante del bloque) */}
       <hemisphereLight color="#f2e6c8" groundColor="#4a3524" intensity={0.34 + 1.15 * refuerzo} />
@@ -495,15 +534,35 @@ function Diorama({ params, reducedMotion }) {
   );
 }
 
+/* Cielo propio de la MILPA: el perfil tierra con un pelín más de luz, para que
+   los verdes del maíz/fríjol y el ocre de la calabaza canten sobre el corte
+   (mismo remedio que EscenaSanidad; se sigue mezclando hacia la franja del día). */
+const CIELO_MILPA = { ...CIELOS.tierra, fondo: '#ead9b8', cielo: '#f6ecd2', intensidad: 1.12 };
+
+/* Encuadre de la MILPA: el corte + las hermanas suman ~4 unidades de alto y el
+   target de reposo del framework es el ORIGEN (centro del bloque) — con la pose
+   clásica el maíz salía decapitado del cuadro (QA visual 2026-07-30). Cámara
+   propia (patrón EscenaSanidad): un paso atrás y más baja, con el lente un pelín
+   más abierto — el corte llena el tercio bajo y las cañas rematan dentro del
+   cuadro. Suelo/abono conservan la pose clásica. */
+const CAMARA_MILPA = { position: [3.2, 2.4, 7.8], fov: 44 };
+
 export default function EscenaCutaway(props) {
   const alto = (props.params?.capas || []).reduce((s, c) => s + (c.alto || 0.6), 0) || 1.5;
-  const cielo = CIELOS.tierra;
+  const esMilpa = Boolean(props.params?.milpa);
+  const cielo = esMilpa ? CIELO_MILPA : CIELOS.tierra;
+  /* El centro del encuadre (la mirada del intro + anti-colisión de chips) sube
+     con la milpa a media composición; el corte pelado se queda donde estaba. */
+  const entrada = esMilpa
+    ? { ...props.entrada, zoom: 6.6, centro: [0, alto * 0.45, 0.5] }
+    : { ...props.entrada, centro: [0, alto * 0.2, 0.6] };
   return (
     <EscenaBase3D
       {...props}
       cielo={cielo}
-      entrada={{ ...props.entrada, centro: [0, alto * 0.2, 0.6] }}
-      piso={-alto / 2}
+      camara={esMilpa ? CAMARA_MILPA : props.camara}
+      entrada={entrada}
+      piso={-alto / 2 - (esMilpa ? 0.55 : 0)}
     >
       <Diorama params={props.params} reducedMotion={props.reducedMotion} />
     </EscenaBase3D>


### PR DESCRIPTION
Pule mundo3d-milpa (cargaba bien, era problema de lectura): cámara CAMARA_MILPA (el maíz salía decapitado al zoom 7), tres hermanas distinguibles (caña/fríjol/calabaza), nódulos de Rhizobium más gordos y asomados al frente del corte. Todo gateado a params.milpa en EscenaCutaway.jsx (suelo/abono intactos). Gemini 4/4, 0 pageerrors, eslint OK. 🤖 Generated with Claude Code