### PR TITLE
feat(compai): Ola 2 batch 3 — cruce de compañero + responder por voz al tip (#96, #91)

### DIFF
--- a/src/compai/nucleo/__tests__/elenco.test.js
+++ b/src/compai/nucleo/__tests__/elenco.test.js
@@ -81,6 +81,11 @@ describe('leerCompanero', () => {
     expect(leerCompanero(null)).toBe(COMPANERO_DEFECTO);
   });
 
+  it('zariguya es un slug válido (entró al elenco 2026-07-25, PR #2783)', () => {
+    const st = new StorageFalso({ [LLAVE_COMPANERO]: 'zariguya' });
+    expect(leerCompanero(st)).toBe('zariguya');
+  });
+
   it('no lanza si el storage tira excepción (modo privado)', () => {
     expect(() => leerCompanero(new StorageRoto())).not.toThrow();
     expect(leerCompanero(new StorageRoto())).toBe(COMPANERO_DEFECTO);

--- a/src/compai/nucleo/elenco.js
+++ b/src/compai/nucleo/elenco.js
@@ -34,6 +34,13 @@ export const TAMANO_CANONICO = 14.2;
 export const ELENCO = {
   angelita: { nombre: 'Angelita', gentilicio: 'la abeja de la casa', enPWA: true },
   maiz: { nombre: 'Maíz', gentilicio: 'la planta de maíz', enPWA: true },
+  // La zarigüeya entró al elenco de la PWA el 2026-07-25 (PR #2783, crías al
+  // lomo) — DESPUÉS de que este núcleo se escribió el 2026-07-26 y se le
+  // olvidó incluirla aquí. Sin esta entrada, normalizarCompanero('zariguya')
+  // devolvía null y leerCompanero/escribirCompanero la rechazaban en
+  // silencio: la tercera opción de useAgentAvatarType.js nunca sobrevivía
+  // el cruce por el núcleo (bug encontrado cableando #96).
+  zariguya: { nombre: 'Zarigüeya', gentilicio: 'la zarigüeya', enPWA: true },
   oso: { nombre: 'Oso andino', gentilicio: 'el oso andino', enPWA: false },
   jaguar: { nombre: 'Jaguar', gentilicio: 'el jaguar', enPWA: false },
   guacamaya: { nombre: 'Guacamaya', gentilicio: 'la guacamaya', enPWA: false },

--- a/src/hooks/useAgentAvatarType.js
+++ b/src/hooks/useAgentAvatarType.js
@@ -1,6 +1,13 @@
 import { useEffect, useState, useCallback } from 'react';
+import { LLAVE_COMPANERO, LLAVES_HEREDADAS, leerCompanero, escribirCompanero } from '../compai/nucleo/elenco.js';
 
 const STORAGE_KEY = 'chagra:agent-avatar-type';
+
+// Las llaves que un evento 'storage' de OTRA pestaña puede tocar y que nos
+// interesan: la canónica (#96, compai/nucleo/elenco.js) y la vieja de este
+// mismo stack. 'guatoc.guia' también dispara refresco — es la del otro lado
+// (3d.guatoc.co) — así una elección allá se refleja aquí sin recargar.
+const LLAVES_RELEVANTES = new Set([LLAVE_COMPANERO, STORAGE_KEY, ...LLAVES_HEREDADAS]);
 
 // 'angelita' = Angelita, la abeja angelita (Tetragonisca angustula). ES el
 // agente de Chagra desde 2026-07-16 ("Angelita como el agente, jubila el
@@ -31,10 +38,20 @@ export const AVATAR_NOMBRE = {
 // ambos colibríes migran a Angelita sin que el usuario haga nada.
 const LEGACY_TYPES = { colibri: 'angelita', colibri_svg: 'angelita' };
 
+/**
+ * Lee la preferencia con la MISMA precedencia que el núcleo compai (#96: una
+ * sola llave canónica cruzando PWA y 3d.guatoc.co) — pero acotada a los tres
+ * avatares que hoy tienen cuerpo dibujado en esta PWA (`AVATAR_TYPES`). Si el
+ * núcleo devuelve un guía sin arte aquí todavía (jaguar, oso…), esta PWA cae
+ * al default — el otro stack sigue mostrando la elección real.
+ */
 function readPref() {
     try {
+        const canonico = leerCompanero();
+        if (canonico && AVATAR_TYPES.includes(canonico)) return canonico;
+        // Compatibilidad con instalaciones que sólo tienen la llave vieja de
+        // este stack con un slug que el núcleo todavía no conoce (LEGACY_TYPES).
         const raw = localStorage.getItem(STORAGE_KEY);
-        if (raw && AVATAR_TYPES.includes(raw)) return raw;
         if (raw && LEGACY_TYPES[raw]) return LEGACY_TYPES[raw];
     } catch {
         // private mode / quota → fallback
@@ -44,8 +61,9 @@ function readPref() {
 
 /**
  * Hook que gestiona el tipo de avatar del agente. Lee la preferencia desde
- * localStorage y permite actualizarla con sincronización entre pestañas
- * mediante eventos 'storage' y 'chagra:agent-avatar-changed'.
+ * la llave canónica del compañero (compai/nucleo/elenco.js, #96) y permite
+ * actualizarla con sincronización entre pestañas mediante eventos 'storage'
+ * y 'chagra:agent-avatar-changed'.
  *
  * @returns {[string, Function]} Tupla con [0] tipo de avatar actual, [1] función para actualizarlo (updateType).
  */
@@ -54,7 +72,7 @@ export default function useAgentAvatarType() {
 
     useEffect(() => {
         function onStorage(e) {
-            if (e.key === STORAGE_KEY) setType(readPref());
+            if (e.key && LLAVES_RELEVANTES.has(e.key)) setType(readPref());
         }
         function onCustom(e) {
             if (e.detail && AVATAR_TYPES.includes(e.detail)) setType(e.detail);
@@ -69,11 +87,10 @@ export default function useAgentAvatarType() {
 
     const updateType = useCallback((next) => {
         if (!AVATAR_TYPES.includes(next)) return;
-        try {
-            localStorage.setItem(STORAGE_KEY, next);
-        } catch {
-            // ignore, banner-stateful only
-        }
+        // escribirCompanero deja la llave canónica Y las dos heredadas
+        // (incluida STORAGE_KEY) en el mismo valor — así 3d.guatoc.co recibe
+        // el cambio sin que esta PWA sepa que ese stack existe.
+        escribirCompanero(next);
         setType(next);
         window.dispatchEvent(
             new CustomEvent('chagra:agent-avatar-changed', { detail: next }),

--- a/src/visual/agente/AngelitaGuia.jsx
+++ b/src/visual/agente/AngelitaGuia.jsx
@@ -90,6 +90,7 @@ export function AngelitaGuia({
             mensaje={guia.parada.texto}
             tipo={guia.parada.tipo}
             className="ang-guia__burbuja"
+            permiteEscucha
           />
           <div className="ang-guia__nav">
             {guia.total > 1 && (

--- a/src/visual/agente/BurbujaAngelita.jsx
+++ b/src/visual/agente/BurbujaAngelita.jsx
@@ -1,57 +1,10 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { Mic } from 'lucide-react';
 import Typewriter from '../../components/Typewriter';
 import { aparienciaDeTipo } from './angelitaAvisoTipos';
+import { activarEscucha } from '../../services/escuchaService';
+import { correccionEnPantalla, recortarAviso } from './burbujaAngelitaUtils.js';
 import './angelitaBurbuja.css';
-
-/** Aire mínimo entre la burbuja y el borde de la pantalla (px). */
-const MARGEN_PANTALLA = 10;
-
-/**
- * Cuánto hay que correr la burbuja para que quepa entera en la pantalla.
- *
- * EL BUG QUE ARREGLA (visto en captura, 430 px de ancho): la burbuja va
- * anclada al personaje con `<Html center>` — o sea CENTRADA en su posición de
- * pantalla. Cuando el compAI anda cerca de un borde, media burbuja se sale y
- * el aviso queda cortado. En un teléfono modesto —que es el aparato del
- * usuario— eso significa que el tip sencillamente no se puede leer.
- *
- * Es la misma regla que ya aplica `useAngelitaGuia.calcularPuestoGuia` para
- * las paradas de la guía: nunca tapar, nunca salirse. Pura y testeable — no
- * toca el DOM, sólo calcula.
- *
- * @param {{left:number,right:number}} caja — rect de la burbuja.
- * @param {number} anchoPantalla
- * @param {number} [margen]
- * @returns {number} px a sumar en X (negativo = correr a la izquierda).
- */
-export function correccionEnPantalla(caja, anchoPantalla, margen = MARGEN_PANTALLA) {
-  if (!caja || !Number.isFinite(anchoPantalla) || anchoPantalla <= 0) return 0;
-  const sobraDerecha = caja.right - (anchoPantalla - margen);
-  const faltaIzquierda = margen - caja.left;
-  // Si se sale por los DOS lados es que no cabe: se pega a la izquierda y el
-  // `max-width` del CSS se encarga del resto. Peor sería centrarla y perder
-  // texto por ambos bordes.
-  if (sobraDerecha > 0 && faltaIzquierda > 0) return faltaIzquierda;
-  if (sobraDerecha > 0) return -sobraDerecha;
-  if (faltaIzquierda > 0) return faltaIzquierda;
-  return 0;
-}
-
-/* Un aviso que no se lee de un vistazo no sirve (feedback del operador: "los
-   avisos son muy largos y entre más largos más difíciles de leer"). Se corta
-   en la primera frontera de frase que quepa; si no hay ninguna, en la última
-   palabra completa. Además evita que la máquina de escribir reserve un cajón
-   enorme y vacío mientras arranca. */
-const TOPE_AVISO = 105;
-export function recortarAviso(texto, tope = TOPE_AVISO) {
-  const t = String(texto || '').trim();
-  if (t.length <= tope) return t;
-  const cabe = t.slice(0, tope);
-  const frase = Math.max(cabe.lastIndexOf('. '), cabe.lastIndexOf('? '), cabe.lastIndexOf('! '));
-  if (frase > tope * 0.45) return t.slice(0, frase + 1).trim();
-  const palabra = cabe.lastIndexOf(' ');
-  return `${(palabra > 0 ? cabe.slice(0, palabra) : cabe).trim()}…`;
-}
 
 /**
  * <BurbujaAngelita> — la burbuja con la voz de Angelita: typewriter + color
@@ -71,6 +24,14 @@ export function recortarAviso(texto, tope = TOPE_AVISO) {
  *   - prefers-reduced-motion: el Typewriter muestra todo de una y la entrada
  *     de la burbuja no anima (CSS).
  *
+ * RESPONDER POR VOZ (#91): con `permiteEscucha`, la burbuja suma un botón de
+ * micrófono que dispara `activarEscucha({ fuente: 'tip' })` — el mismo
+ * contrato desacoplado que ya usa EscuchaFab (services/escuchaService.js):
+ * abre el overlay "Chagra está escuchando" con el pipeline Whisper/Kokoro
+ * real, sin que la burbuja sepa nada de grabar audio. Apagado por defecto:
+ * cada llamador decide si el tip que muestra amerita una respuesta hablada
+ * (un tip informativo no la necesita; un aviso que pregunta algo, sí).
+ *
  * @param {Object} props
  * @param {string|null} props.mensaje — lo que dice Angelita (null → no pinta).
  * @param {string} [props.tipo] — uno de TIPOS_AVISO (angelitaAvisoTipos).
@@ -78,6 +39,8 @@ export function recortarAviso(texto, tope = TOPE_AVISO) {
  *   del respeto automático a prefers-reduced-motion).
  * @param {number} [props.velocidadMs=26] — ritmo del typewriter.
  * @param {string} [props.className] — clases extra (posicionamiento del host).
+ * @param {boolean} [props.permiteEscucha=false] — muestra el botón de
+ *   "responder por voz" (#91).
  */
 export default function BurbujaAngelita({
   mensaje,
@@ -85,6 +48,7 @@ export default function BurbujaAngelita({
   animado = true,
   velocidadMs = 16,
   className = '',
+  permiteEscucha = false,
 }) {
   /* NO SE SALE DE LA PANTALLA. Se mide después de pintar y se corrige en X.
      Los hooks van ANTES del `return null` — si no, React ve un número
@@ -159,6 +123,17 @@ export default function BurbujaAngelita({
         <span className="angelita-burbuja__sr">{spec.aria}: </span>
         <Typewriter texto={texto} animado={animado} velocidadMs={velocidadMs} />
       </span>
+      {permiteEscucha && (
+        <button
+          type="button"
+          className="angelita-burbuja__escuchar"
+          onClick={() => activarEscucha({ fuente: 'tip' })}
+          aria-label="Responder por voz a este aviso"
+          title="Hablar con Chagra sobre esto"
+        >
+          <Mic size={14} strokeWidth={2.4} aria-hidden="true" />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/visual/agente/__tests__/BurbujaAngelita.test.jsx
+++ b/src/visual/agente/__tests__/BurbujaAngelita.test.jsx
@@ -1,0 +1,47 @@
+/**
+ * BurbujaAngelita.test.jsx — el botón de "responder por voz" (#91).
+ *
+ * El resto del componente (recorte de texto, corrección de posición en
+ * pantalla) ya está cubierto por burbujaEnPantalla.test.js contra las
+ * funciones puras; aquí sólo se prueba lo nuevo: `permiteEscucha` cablea
+ * activarEscucha({ fuente: 'tip' }) — el mismo contrato desacoplado que
+ * usa EscuchaFab, sin que la burbuja sepa nada de grabar audio.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import BurbujaAngelita from '../BurbujaAngelita.jsx';
+import { EVENTO_ESCUCHA } from '../../../services/escuchaService.js';
+
+afterEach(cleanup);
+
+describe('<BurbujaAngelita> — botón de responder por voz (#91)', () => {
+  it('permiteEscucha=false (default): no pinta el botón de micrófono', () => {
+    const { container } = render(<BurbujaAngelita mensaje="Riegue temprano." />);
+    expect(container.querySelector('.angelita-burbuja__escuchar')).toBeNull();
+  });
+
+  it('permiteEscucha=true: pinta el botón con su aria-label', () => {
+    const { getByLabelText } = render(
+      <BurbujaAngelita mensaje="Riegue temprano." permiteEscucha />,
+    );
+    expect(getByLabelText('Responder por voz a este aviso')).toBeInTheDocument();
+  });
+
+  it('tocar el botón dispara activarEscucha({ fuente: "tip" }) — llega el CustomEvent global', () => {
+    const oyente = vi.fn();
+    window.addEventListener(EVENTO_ESCUCHA, oyente);
+    const { getByLabelText } = render(
+      <BurbujaAngelita mensaje="Riegue temprano." permiteEscucha />,
+    );
+    fireEvent.click(getByLabelText('Responder por voz a este aviso'));
+    window.removeEventListener(EVENTO_ESCUCHA, oyente);
+
+    expect(oyente).toHaveBeenCalledTimes(1);
+    expect(oyente.mock.calls[0][0].detail).toMatchObject({ fuente: 'tip' });
+  });
+
+  it('sin mensaje no pinta nada, ni siquiera con permiteEscucha=true', () => {
+    const { container } = render(<BurbujaAngelita mensaje={null} permiteEscucha />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/visual/agente/__tests__/burbujaEnPantalla.test.js
+++ b/src/visual/agente/__tests__/burbujaEnPantalla.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { correccionEnPantalla } from '../BurbujaAngelita';
+import { correccionEnPantalla } from '../burbujaAngelitaUtils.js';
 
 /**
  * La burbuja del compAI va anclada al personaje con `<Html center>`, o sea

--- a/src/visual/agente/angelitaBurbuja.css
+++ b/src/visual/agente/angelitaBurbuja.css
@@ -85,6 +85,35 @@
   font-size: 0.82rem;
 }
 
+/* El botón de "responder por voz" (#91): disco pequeño alineado con el
+   ícono del tipo, mismo lenguaje visual que EscuchaFab pero en miniatura —
+   no compite con el texto, vive pegado al borde derecho de la burbuja. */
+.angelita-burbuja__escuchar {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 1.55rem;
+  height: 1.55rem;
+  margin-top: 0.12rem;
+  border: none;
+  border-radius: 50%;
+  background: var(--ab-fondo-icono);
+  box-shadow: inset 0 0 0 1px var(--ab-borde);
+  color: var(--ab-acento);
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+.angelita-burbuja__escuchar:hover,
+.angelita-burbuja__escuchar:focus-visible {
+  background: var(--ab-acento);
+  color: rgba(10, 20, 30, 0.92);
+}
+
+.angelita-burbuja__escuchar:active {
+  transform: scale(0.9);
+}
+
 /* Solo para lectores de pantalla (el tipo narrado). */
 .angelita-burbuja__sr {
   position: absolute;

--- a/src/visual/agente/burbujaAngelitaUtils.js
+++ b/src/visual/agente/burbujaAngelitaUtils.js
@@ -1,0 +1,60 @@
+/**
+ * burbujaAngelitaUtils.js — la geometría y el recorte de texto de
+ * <BurbujaAngelita>, puros y sin React.
+ *
+ * Separado de BurbujaAngelita.jsx (2026-07-30) porque react-refresh exige
+ * que un archivo de componente sólo exporte componentes — mezclar estas dos
+ * funciones puras con el default export rompía el fast-refresh y el lint
+ * (`react-refresh/only-export-components`). Cero cambio de comportamiento:
+ * mismo código, nuevo domicilio.
+ */
+
+/** Aire mínimo entre la burbuja y el borde de la pantalla (px). */
+const MARGEN_PANTALLA = 10;
+
+/**
+ * Cuánto hay que correr la burbuja para que quepa entera en la pantalla.
+ *
+ * EL BUG QUE ARREGLA (visto en captura, 430 px de ancho): la burbuja va
+ * anclada al personaje con `<Html center>` — o sea CENTRADA en su posición de
+ * pantalla. Cuando el compAI anda cerca de un borde, media burbuja se sale y
+ * el aviso queda cortado. En un teléfono modesto —que es el aparato del
+ * usuario— eso significa que el tip sencillamente no se puede leer.
+ *
+ * Es la misma regla que ya aplica `useAngelitaGuia.calcularPuestoGuia` para
+ * las paradas de la guía: nunca tapar, nunca salirse. Pura y testeable — no
+ * toca el DOM, sólo calcula.
+ *
+ * @param {{left:number,right:number}} caja — rect de la burbuja.
+ * @param {number} anchoPantalla
+ * @param {number} [margen]
+ * @returns {number} px a sumar en X (negativo = correr a la izquierda).
+ */
+export function correccionEnPantalla(caja, anchoPantalla, margen = MARGEN_PANTALLA) {
+  if (!caja || !Number.isFinite(anchoPantalla) || anchoPantalla <= 0) return 0;
+  const sobraDerecha = caja.right - (anchoPantalla - margen);
+  const faltaIzquierda = margen - caja.left;
+  // Si se sale por los DOS lados es que no cabe: se pega a la izquierda y el
+  // `max-width` del CSS se encarga del resto. Peor sería centrarla y perder
+  // texto por ambos bordes.
+  if (sobraDerecha > 0 && faltaIzquierda > 0) return faltaIzquierda;
+  if (sobraDerecha > 0) return -sobraDerecha;
+  if (faltaIzquierda > 0) return faltaIzquierda;
+  return 0;
+}
+
+/* Un aviso que no se lee de un vistazo no sirve (feedback del operador: "los
+   avisos son muy largos y entre más largos más difíciles de leer"). Se corta
+   en la primera frontera de frase que quepa; si no hay ninguna, en la última
+   palabra completa. Además evita que la máquina de escribir reserve un cajón
+   enorme y vacío mientras arranca. */
+const TOPE_AVISO = 105;
+export function recortarAviso(texto, tope = TOPE_AVISO) {
+  const t = String(texto || '').trim();
+  if (t.length <= tope) return t;
+  const cabe = t.slice(0, tope);
+  const frase = Math.max(cabe.lastIndexOf('. '), cabe.lastIndexOf('? '), cabe.lastIndexOf('! '));
+  if (frase > tope * 0.45) return t.slice(0, frase + 1).trim();
+  const palabra = cabe.lastIndexOf(' ');
+  return `${(palabra > 0 ? cabe.slice(0, palabra) : cabe).trim()}…`;
+}


### PR DESCRIPTION
## Resumen

Dos ítems de alto ROI del listado de 47 pendientes de compAI
(`chagra-pendientes-compai.md`), elegidos por estar **construidos y sin
conectar** (o con el bug bloqueando el cableado) — no requieren hardware
ausente ni tocan `mundo3d/*`, `láminas2d` ni `Valle3D.jsx` más allá de un
import sin cambios.

### #96 — una sola llave de compañero, cruce A/↔V/ real
`compai/nucleo/elenco.js` (el núcleo portable) ya tenía la llave canónica
del compañero lista desde hace días, pero `useAgentAvatarType.js` —el hook
que la PWA usa de verdad— seguía leyendo/escribiendo SOLO
`chagra:agent-avatar-type`, ignorando el núcleo. Cableado: el hook ahora usa
`leerCompanero()`/`escribirCompanero()`, acotado a los 3 avatares con arte
real en esta PWA.

De paso encontré y arreglé un bug en el propio núcleo: `ELENCO` nunca incluyó
`'zariguya'` (entró a la PWA el 2026-07-25, un día antes de escribirse el
núcleo) — sin el fix, elegir la zarigüeya no sobrevivía el cruce por la
llave canónica. Lo cazaron los tests de smoke existentes.

**Call-site que prueba que está vivo**: `AgentAvatarSelector.jsx` (Settings
del perfil) → `useAgentAvatarType()` → `leerCompanero()`/`escribirCompanero()`
→ las tres llaves de localStorage (`compai:companero`,
`chagra:agent-avatar-type`, `guatoc.guia`) quedan sincronizadas en cada
cambio.

### #91 — responder por voz a un tip de la guía
`<BurbujaAngelita>` suma un botón de micrófono opcional (`permiteEscucha`)
que llama `activarEscucha({ fuente: 'tip' })` — el mismo contrato
desacoplado que ya usa `EscuchaFab` (`services/escuchaService.js`): un
`CustomEvent` global que `EscuchaOverlay` resuelve con el pipeline
Whisper/Kokoro real.

**Call-site que prueba que está vivo**: `<AngelitaGuia permiteEscucha>` en
`BurbujaAngelita` — el mecanismo reutilizable que ya vive en
`HoyEnFincaScreen` (el paseo autónomo, #2820) y en cualquier otra pantalla
que adopte la guía. Cada parada comentada ahora puede responderse hablando
sin salir de la vista actual.

De paso: `correccionEnPantalla`/`recortarAviso` se mudaron a
`burbujaAngelitaUtils.js` (funciones puras) porque mezclarlas con el default
export de `BurbujaAngelita.jsx` rompía `react-refresh/only-export-components`
— lint error preexistente en `dev`, ahora corregido de raíz. Cero cambio de
comportamiento.

## Qué NO entró (investigado y descartado con evidencia)

- **#78, #38, #44** (cosecha/ENSO reales, husmeo con datos reales, cruce al
  valle) — ya resueltos por batch1 (#2809) y el propio `Valle3D.jsx`, pese a
  que el `.md` fuente los sigue listando desactualizados.
- **#97** (cruce de cooldown/último-dicho A/↔V/) — el otro lado
  (`3d.guatoc.co` / `valle-guatoc`) es un repo externo que no vive en este
  workspace; no accionable desde aquí.
- **#103/#101** (silenciar desde el personaje, gesto largo) — ya resuelto
  (`AgentFab.jsx`, pulsación larga de 600ms + botón visible), aunque el `.md`
  lo listaba como pendiente.
- **#80** (ampliar el catálogo de insights de 7 a más cultivos) — requiere
  investigación agronómica por especie (grounding real), no es "cablear".
- **#67** (pipeline de foto con especie/diagnóstico real) —
  `DiagnosticoSobreFoto.jsx` es explícitamente "MOCKUP... no hay modelo real
  detrás"; cablearlo a un modelo de visión real excede el alcance de este
  batch.
- **#66/#69/#70/#102** (dos-opciones-al-tocar, unificar con el FAB de
  micrófono) — `AgentFab.jsx` ya tiene un patrón cerrado y coherente (toque
  = hablar, doble-click = TTS, pulsación larga = silenciar); sumar una
  tercera rama de gesto ("enviar foto") sin poder validar en dispositivo real
  es alto riesgo para un solo batch.
- **#82** (ayuda sobre la propia app) — no existe ni una línea de código; es
  construir desde cero, no cablear.

## Test plan

- [x] `npx vitest run` sobre cada suite tocada (elenco, useAgentAvatarType,
      AgentAvatarSelector.smoke, AngelitaGuia, BurbujaAngelita nuevo,
      burbujaEnPantalla) — todo verde.
- [x] `npx eslint --max-warnings=0` sobre todos los archivos tocados.
- [x] Confirmado que `Valle3D.jsx` y `mundo3d/*` no cambiaron de contenido
      (sólo siguen importando el mismo default export sin tocar).
- [ ] CI (suite completa no corrió local por timeout — igual que el batch
      anterior, se confía en el pipeline).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>