### PR TITLE
feat(juegos): juego Ahorcado Contaminado cableado al hub (#93)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -614,6 +614,10 @@ const MundoSubsuelo = lazy(() => import('./components/juego/MundoSubsuelo'));
 // en asociaciones-comparativa.json. Rescatado de "construido-pero-no-cableado"
 // (audit juegos 2026-07-16): existía exportado en juego/index.js pero sin ruta.
 const MonoVsPoliSimulator = lazy(() => import('./components/juego/MonoVsPoliSimulator'));
+// Ahorcado Contaminado: ahorcado clásico con metáfora de contaminación,
+// consume el dataset fundamentado de síntomas/plaguicidas vetados/
+// alternativas agroecológicas (Tarea #38) — juego construido en Tarea #93.
+const AhorcadoContaminado = lazy(() => import('./components/juego/AhorcadoContaminado'));
 // Modo extensionista (panel supervisor multi-finca, ADR-048 MVP). Gateado por
 // feature flag VITE_FEATURE_EXTENSIONISTA + rol (ver config/extensionistaAccess).
 const ExtensionistaScreen = lazy(() => import('./components/ExtensionistaScreen'));
@@ -878,6 +882,7 @@ const HASH_VIEW_ROUTES = {
   'mi-finca-odyssey': 'finca_odyssey',
   'mono-vs-poli': 'mono_vs_poli',
   'monocultivo-policultivo': 'mono_vs_poli',
+  'ahorcado-contaminado': 'ahorcado_contaminado',
   toxicologia: 'toxicologia',
   suelo: 'suelo',
   agua: 'agua',
@@ -1036,7 +1041,7 @@ const MODULE_VIEWS = new Set([
   'biodiversidad', 'informes', 'perfil', 'ayuda', 'help',
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'estiercol', 'compost',
   'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas', 'animales_conejos', 'animales_caprinos', 'estiercol',
-  'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'finca_odyssey', 'mono_vs_poli', 'sembrar', 'cosechar', 'mi_cosecha', 'insumos', 'biopreparados',
+  'hoy_finca',   'faq', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'subsuelo', 'finca_odyssey', 'mono_vs_poli', 'ahorcado_contaminado', 'sembrar', 'cosechar', 'mi_cosecha', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'sanidad_sintoma', 'mantenimiento', 'new_task',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'aromaticas', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
   'agente', 'voz', 'voz_planta', 'procesos', 'registro_voz', 'registro_unificado', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'calendario_finca', 'suelo', 'agua', 'cafe', 'uchuva', 'frutales', 'clima_boletin', 'salud_suelo', 'semilla', 'poscosecha', 'almacenamiento', 'nutricion', 'toxicologia', 'aprende', 'curso', 'directorio', 'mercados',
@@ -2897,6 +2902,19 @@ export default function App() {
             <ErrorFallback moduleName="Monocultivo vs Policultivo">
               <ScreenShell title="Mono vs Poli" onBack={() => navigate('juego')} onHome={() => navigate('dashboard')}>
                 <MonoVsPoliSimulator />
+              </ScreenShell>
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'ahorcado_contaminado':
+        // Ahorcado clásico con metáfora de contaminación (Tarea #93, dataset de
+        // la Tarea #38). No trae navegación propia → lo envolvemos en
+        // ScreenShell (como 'subsuelo'/'mono_vs_poli') para dar Volver/Inicio.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Ahorcado Contaminado">
+              <ScreenShell title="Ahorcado Contaminado" onBack={() => navigate('juego')} onHome={() => navigate('dashboard')}>
+                <AhorcadoContaminado />
               </ScreenShell>
             </ErrorFallback>
           </ErrorBoundary>

--- a/src/components/juego/AhorcadoContaminado.jsx
+++ b/src/components/juego/AhorcadoContaminado.jsx
@@ -1,0 +1,244 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Sparkles, ShieldAlert, RotateCcw } from 'lucide-react';
+import {
+  CATEGORIAS,
+  FUENTES,
+  PALABRAS,
+  PALABRAS_POR_CATEGORIA,
+} from '../../data/juegos/ahorcadoContaminado';
+import './ahorcado-contaminado.css';
+
+const MAX_ERRORES = 6;
+const TECLADO = 'ABCDEFGHIJKLMNÑOPQRSTUVWXYZ'.split('');
+
+// Los 6 pasos de la metáfora de "contaminación" en vez de horca: la finca se
+// va apagando paso a paso. Cada paso suma una etapa visible (planta, suelo,
+// agua) para que la penalización sea legible sin dibujar una soga.
+const ETAPAS_CONTAMINACION = [
+  { emoji: '🌱', clase: 'sana', texto: 'La finca está sana.' },
+  { emoji: '🥀', clase: 'paso-1', texto: 'La plantica se empieza a marchitar.' },
+  { emoji: '🍂', clase: 'paso-2', texto: 'Las hojas se caen antes de tiempo.' },
+  { emoji: '🟤', clase: 'paso-3', texto: 'El suelo se empieza a oscurecer.' },
+  { emoji: '💧', clase: 'paso-4', texto: 'El agua de riego se contamina.' },
+  { emoji: '🐝', clase: 'paso-5', texto: 'Las abejas y los polinizadores se alejan.' },
+  { emoji: '☠️', clase: 'paso-6', texto: 'La finca quedó contaminada del todo.' },
+];
+
+function normalizar(letra) {
+  return letra.toUpperCase();
+}
+
+function elegirPalabra(categoriaId) {
+  const banco = categoriaId === 'mezcla' || !categoriaId
+    ? PALABRAS
+    : (PALABRAS_POR_CATEGORIA[categoriaId] || PALABRAS);
+  const idx = Math.floor(Math.random() * banco.length);
+  return banco[idx];
+}
+
+/**
+ * Ahorcado Contaminado — ahorcado clásico con la metáfora de contaminación
+ * (Tarea #93). Consume el dataset fundamentado de la Tarea #38
+ * (src/data/juegos/ahorcadoContaminado.js): NO inventa palabras ni fuentes.
+ *
+ * Cada letra errada avanza un paso de contaminación (6 pasos, sin horca).
+ * Ganar o perder revela la pista educativa + la fuente (anti-gamificación
+ * tóxica: educativo también al perder, no solo al ganar).
+ */
+export default function AhorcadoContaminado() {
+  const [categoriaId, setCategoriaId] = useState('mezcla');
+  const [entrada, setEntrada] = useState(() => elegirPalabra('mezcla'));
+  const [letrasUsadas, setLetrasUsadas] = useState([]);
+  const [errores, setErrores] = useState(0);
+  const [advertenciaAbierta, setAdvertenciaAbierta] = useState(false);
+
+  const palabra = entrada.palabra;
+  const letrasUnicas = useMemo(
+    () => new Set(palabra.replace(/[^A-ZÑ]/gi, '').split('').map(normalizar)),
+    [palabra],
+  );
+
+  const ganado = useMemo(
+    () => [...letrasUnicas].every((l) => letrasUsadas.includes(l)),
+    [letrasUnicas, letrasUsadas],
+  );
+  const perdido = errores >= MAX_ERRORES;
+  const terminado = ganado || perdido;
+
+  const etapa = ETAPAS_CONTAMINACION[Math.min(errores, MAX_ERRORES)];
+  const fuente = FUENTES[entrada.fuenteId];
+
+  const jugarLetra = useCallback((letraCruda) => {
+    if (terminado) return;
+    const letra = normalizar(letraCruda);
+    if (letrasUsadas.includes(letra)) return;
+
+    setLetrasUsadas((prev) => [...prev, letra]);
+    if (!letrasUnicas.has(letra)) {
+      setErrores((prev) => Math.min(prev + 1, MAX_ERRORES));
+    }
+  }, [letrasUsadas, letrasUnicas, terminado]);
+
+  const nuevaPalabra = useCallback((nuevaCategoria) => {
+    const cat = nuevaCategoria ?? categoriaId;
+    setCategoriaId(cat);
+    setEntrada(elegirPalabra(cat));
+    setLetrasUsadas([]);
+    setErrores(0);
+  }, [categoriaId]);
+
+  return (
+    <div className="jp-ahorcado" data-testid="ahorcado-contaminado">
+      {/* Selector de categoría */}
+      <div className="jp-ah-categorias" role="group" aria-label="Elegir categoría de palabras">
+        <button
+          type="button"
+          data-testid="categoria-mezcla"
+          className={`jp-ah-chip ${categoriaId === 'mezcla' ? 'activo' : ''}`}
+          onClick={() => nuevaPalabra('mezcla')}
+        >
+          🎲 Mezcla
+        </button>
+        {Object.values(CATEGORIAS).map((cat) => (
+          <button
+            key={cat.id}
+            type="button"
+            data-testid={`categoria-${cat.id}`}
+            className={`jp-ah-chip ${categoriaId === cat.id ? 'activo' : ''}`}
+            onClick={() => nuevaPalabra(cat.id)}
+            title={cat.descripcion}
+          >
+            {cat.emoji} {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Escena de contaminación (metáfora en vez de horca) */}
+      <div
+        className={`jp-ah-escena ${etapa.clase}`}
+        data-testid="escena-contaminacion"
+        aria-live="polite"
+      >
+        <span className="jp-ah-escena-emoji" aria-hidden="true">{etapa.emoji}</span>
+        <p className="jp-ah-escena-texto">{etapa.texto}</p>
+        <p className="jp-ah-intentos" data-testid="contador-intentos">
+          Intentos: {errores} / {MAX_ERRORES}
+        </p>
+      </div>
+
+      {/* Palabra oculta */}
+      <div className="jp-ah-palabra" data-testid="palabra-oculta" aria-label={`Palabra con ${letrasUnicas.size} letras distintas`}>
+        {palabra.split('').map((caracter, i) => {
+          if (caracter === ' ') {
+            return <span key={i} className="jp-ah-espacio" aria-hidden="true" />;
+          }
+          const visible = terminado || letrasUsadas.includes(normalizar(caracter));
+          return (
+            <span key={i} className="jp-ah-letra-casillero">
+              {visible ? normalizar(caracter) : ''}
+            </span>
+          );
+        })}
+      </div>
+
+      {/* Resultado educativo (gana o pierde: siempre se revela el dato) */}
+      {terminado && (
+        <div
+          className={`jp-ah-resultado ${ganado ? 'gano' : 'perdio'}`}
+          data-testid="resultado-juego"
+          role="status"
+        >
+          <p className="jp-ah-resultado-titulo">
+            {ganado ? '¡La finca se salvó! Adivinaste la palabra.' : 'Esta vez la finca se contaminó.'}
+          </p>
+          <p className="jp-ah-resultado-palabra">La palabra era: <strong>{palabra}</strong></p>
+          <p className="jp-ah-resultado-pista" data-testid="pista-educativa">{entrada.pista}</p>
+          {fuente && (
+            <p className="jp-ah-resultado-fuente" data-testid="fuente-dato">
+              Fuente: {fuente.label}
+            </p>
+          )}
+          <button
+            type="button"
+            data-testid="jugar-otra-vez"
+            className="jp-ah-btn-otra"
+            onClick={() => nuevaPalabra()}
+          >
+            <RotateCcw size={18} aria-hidden="true" /> Jugar otra palabra
+          </button>
+        </div>
+      )}
+
+      {/* Teclado en pantalla (táctil) */}
+      {!terminado && (
+        <div className="jp-ah-teclado" role="group" aria-label="Teclado para adivinar letras">
+          {TECLADO.map((letra) => {
+            const usada = letrasUsadas.includes(letra);
+            const acierto = usada && letrasUnicas.has(letra);
+            const fallo = usada && !letrasUnicas.has(letra);
+            return (
+              <button
+                key={letra}
+                type="button"
+                data-testid={`tecla-${letra}`}
+                onClick={() => jugarLetra(letra)}
+                disabled={usada}
+                aria-pressed={usada}
+                aria-label={`Letra ${letra}${fallo ? ', ya intentada, no está en la palabra' : ''}${acierto ? ', ya intentada, acertaste' : ''}`}
+                className={`jp-ah-tecla ${acierto ? 'acierto' : ''} ${fallo ? 'fallo' : ''}`}
+              >
+                {letra}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Pie con advertencia toxicológica obligatoria */}
+      <div className="jp-ah-pie">
+        <button
+          type="button"
+          data-testid="abrir-advertencia"
+          className="jp-ah-btn-advertencia"
+          onClick={() => setAdvertenciaAbierta(true)}
+        >
+          <ShieldAlert size={16} aria-hidden="true" /> Advertencia toxicológica
+        </button>
+      </div>
+
+      {advertenciaAbierta && (
+        <div
+          className="jp-ah-modal-fondo"
+          data-testid="modal-advertencia"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="jp-ah-modal-titulo"
+        >
+          <div className="jp-ah-modal">
+            <h3 id="jp-ah-modal-titulo">
+              <ShieldAlert size={20} aria-hidden="true" /> Datos educativos, no diagnóstico
+            </h3>
+            <p>
+              Los datos de este juego son <strong>educativos</strong>, no son diagnóstico
+              médico ni protocolo de primeros auxilios. Ante una sospecha de intoxicación
+              por agroquímicos: retire a la persona de la exposición, quítele la ropa
+              contaminada y llame ya a la línea de toxicología.
+            </p>
+            <p>
+              En Colombia: <strong>Centro de Información y Asesoría Toxicológica (CIATOX)</strong>
+              {' '}y línea de urgencias <strong>123</strong>.
+            </p>
+            <button
+              type="button"
+              data-testid="cerrar-advertencia"
+              className="jp-ah-btn-otra"
+              onClick={() => setAdvertenciaAbierta(false)}
+            >
+              <Sparkles size={16} aria-hidden="true" /> Entendido
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/juego/MiFincaVivaScreen.jsx
+++ b/src/components/juego/MiFincaVivaScreen.jsx
@@ -342,6 +342,26 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
           <Scale size={22} className="text-amber-200 shrink-0" aria-hidden="true" />
         </button>
 
+        {/* Ahorcado Contaminado: ahorcado clásico con metáfora de contaminación,
+            dataset fundamentado de síntomas/plaguicidas vetados/alternativas
+            agroecológicas (Tarea #38, juego construido en Tarea #93). */}
+        <button
+          type="button"
+          data-testid="entrada-ahorcado-contaminado"
+          onClick={() => irAccion('ahorcado_contaminado')}
+          className="jp-mfv-entrada w-full text-left rounded-2xl p-4 bg-gradient-to-br from-rose-700/40 to-emerald-800/40 border-2 border-rose-400/40 hover:border-rose-300/60 active:scale-[0.99] transition flex items-center gap-3"
+        >
+          <span className="text-4xl shrink-0" aria-hidden="true">☠️</span>
+          <span className="flex-1 min-w-0">
+            <span className="jp-tinta block text-base font-black text-white">Ahorcado Contaminado</span>
+            <span className="jp-tinta-suave block text-sm text-rose-100/90 leading-snug">
+              Adivina la palabra antes de que la finca se contamine. Síntomas de
+              intoxicación, plaguicidas vetados y alternativas que sí sirven.
+            </span>
+          </span>
+          <Sprout size={22} className="text-rose-200 shrink-0" aria-hidden="true" />
+        </button>
+
         {/* Barra de progreso del mundo (alegre, pero honesta: % real) */}
         <div>
           <div className="flex items-center justify-between mb-1.5">

--- a/src/components/juego/__tests__/AhorcadoContaminado.test.jsx
+++ b/src/components/juego/__tests__/AhorcadoContaminado.test.jsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AhorcadoContaminado from '../AhorcadoContaminado';
+import { PALABRAS } from '../../../data/juegos/ahorcadoContaminado';
+
+// El juego elige palabra al azar (Math.random). Para un smoke determinista,
+// forzamos Math.random a 0: siempre cae en la primera palabra del banco
+// activo (mezcla → PALABRAS[0] = 'NAUSEA', categoría sintoma).
+describe('AhorcadoContaminado', () => {
+  let randomSpy;
+
+  beforeEach(() => {
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    randomSpy.mockRestore();
+  });
+
+  it('renderiza el juego con la escena de contaminacion, palabra oculta y teclado', () => {
+    render(<AhorcadoContaminado />);
+
+    expect(screen.getByTestId('ahorcado-contaminado')).toBeInTheDocument();
+    expect(screen.getByTestId('escena-contaminacion')).toBeInTheDocument();
+    expect(screen.getByTestId('palabra-oculta')).toBeInTheDocument();
+    expect(screen.getByTestId('contador-intentos')).toHaveTextContent('Intentos: 0 / 6');
+    expect(screen.getByTestId('tecla-A')).toBeInTheDocument();
+  });
+
+  it('una jugada ganadora revela la pista educativa y la fuente', () => {
+    render(<AhorcadoContaminado />);
+
+    // Con Math.random mockeado a 0, la palabra activa es PALABRAS[0].
+    const palabra = PALABRAS[0].palabra;
+    const letrasUnicas = [...new Set(palabra.replace(/[^A-ZÑ]/gi, '').split(''))];
+
+    letrasUnicas.forEach((letra) => {
+      fireEvent.click(screen.getByTestId(`tecla-${letra}`));
+    });
+
+    expect(screen.getByTestId('resultado-juego')).toBeInTheDocument();
+    expect(screen.getByTestId('resultado-juego')).toHaveClass('gano');
+    expect(screen.getByTestId('pista-educativa')).toHaveTextContent(PALABRAS[0].pista);
+    expect(screen.getByTestId('fuente-dato')).toBeInTheDocument();
+  });
+
+  it('una jugada perdida tambien revela la palabra y la pista (educativo, no punitivo)', () => {
+    render(<AhorcadoContaminado />);
+
+    // Letras que casi seguro no están en 'NAUSEA' para forzar 6 errores.
+    const fallos = ['B', 'C', 'D', 'F', 'G', 'H'];
+    fallos.forEach((letra) => {
+      fireEvent.click(screen.getByTestId(`tecla-${letra}`));
+    });
+
+    expect(screen.getByTestId('contador-intentos')).toHaveTextContent('Intentos: 6 / 6');
+    expect(screen.getByTestId('resultado-juego')).toHaveClass('perdio');
+    expect(screen.getByTestId('pista-educativa')).toHaveTextContent(PALABRAS[0].pista);
+  });
+
+  it('muestra la advertencia toxicologica al abrir el modal del pie', () => {
+    render(<AhorcadoContaminado />);
+
+    fireEvent.click(screen.getByTestId('abrir-advertencia'));
+
+    expect(screen.getByTestId('modal-advertencia')).toBeInTheDocument();
+    expect(screen.getByText(/CIATOX/)).toBeInTheDocument();
+    expect(screen.getByText(/123/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('cerrar-advertencia'));
+    expect(screen.queryByTestId('modal-advertencia')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/juego/ahorcado-contaminado.css
+++ b/src/components/juego/ahorcado-contaminado.css
@@ -1,0 +1,321 @@
+/*
+ * ahorcado-contaminado.css — capa visual del juego "Ahorcado Contaminado"
+ * (Tarea #93). Ahorcado clásico con metáfora de CONTAMINACIÓN en vez de
+ * horca: la finca se va apagando en 6 pasos con cada letra errada.
+ *
+ * Prefijo `jp-ah-` para no chocar con otros temas de juego (jp-ms-*, msx-*).
+ * CSS puro (offline-first, sin libs), respeta prefers-reduced-motion.
+ */
+
+.jp-ahorcado {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0.5rem 0 2rem;
+  max-width: 40rem;
+  margin: 0 auto;
+}
+
+/* ── Selector de categoría ────────────────────────────────────────────── */
+
+.jp-ah-categorias {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.jp-ah-chip {
+  border: 2px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.5);
+  color: #e2e8f0;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, transform 0.1s;
+}
+
+.jp-ah-chip:hover {
+  border-color: rgba(74, 222, 128, 0.6);
+}
+
+.jp-ah-chip:active {
+  transform: scale(0.97);
+}
+
+.jp-ah-chip.activo {
+  background: rgba(22, 163, 74, 0.35);
+  border-color: rgba(74, 222, 128, 0.8);
+  color: #fff;
+}
+
+/* ── Escena de contaminación (reemplaza la horca) ─────────────────────── */
+
+.jp-ah-escena {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 1.25rem 1rem;
+  border-radius: 1.25rem;
+  border: 2px solid rgba(148, 163, 184, 0.3);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.3));
+  transition: background 0.4s ease, border-color 0.4s ease;
+}
+
+.jp-ah-escena-emoji {
+  font-size: 3.5rem;
+  line-height: 1;
+  animation: jp-ah-parpadeo 2.4s ease-in-out infinite;
+}
+
+@keyframes jp-ah-parpadeo {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+}
+
+.jp-ah-escena-texto {
+  color: #f1f5f9;
+  font-weight: 600;
+  text-align: center;
+  margin: 0;
+}
+
+.jp-ah-intentos {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+/* Cada paso oscurece/enrojece progresivamente la escena: la metáfora visual
+   de "la finca se contamina", sin dibujar una horca. */
+.jp-ah-escena.sana { border-color: rgba(74, 222, 128, 0.5); }
+.jp-ah-escena.paso-1 { border-color: rgba(163, 230, 53, 0.5); }
+.jp-ah-escena.paso-2 {
+  border-color: rgba(234, 179, 8, 0.5);
+  background: linear-gradient(180deg, rgba(66, 46, 15, 0.5), rgba(15, 23, 42, 0.3));
+}
+.jp-ah-escena.paso-3 {
+  border-color: rgba(217, 119, 6, 0.55);
+  background: linear-gradient(180deg, rgba(69, 39, 10, 0.6), rgba(15, 23, 42, 0.3));
+}
+.jp-ah-escena.paso-4 {
+  border-color: rgba(190, 24, 93, 0.55);
+  background: linear-gradient(180deg, rgba(76, 20, 40, 0.6), rgba(15, 23, 42, 0.3));
+}
+.jp-ah-escena.paso-5 {
+  border-color: rgba(220, 38, 38, 0.6);
+  background: linear-gradient(180deg, rgba(70, 15, 15, 0.65), rgba(15, 23, 42, 0.3));
+}
+.jp-ah-escena.paso-6 {
+  border-color: rgba(127, 29, 29, 0.8);
+  background: linear-gradient(180deg, rgba(40, 10, 10, 0.8), rgba(15, 23, 42, 0.5));
+}
+.jp-ah-escena.paso-6 .jp-ah-escena-emoji {
+  animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .jp-ah-escena-emoji {
+    animation: none;
+  }
+}
+
+/* ── Palabra oculta ────────────────────────────────────────────────────── */
+
+.jp-ah-palabra {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+.jp-ah-letra-casillero {
+  min-width: 1.9rem;
+  height: 2.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-bottom: 3px solid rgba(148, 163, 184, 0.6);
+  color: #fff;
+  font-weight: 800;
+  font-size: 1.3rem;
+  font-family: ui-monospace, monospace;
+}
+
+.jp-ah-espacio {
+  width: 1rem;
+}
+
+/* ── Resultado educativo (gana o pierde: siempre revela el dato) ───────── */
+
+.jp-ah-resultado {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1rem;
+  border: 2px solid;
+}
+
+.jp-ah-resultado.gano {
+  background: rgba(22, 101, 52, 0.35);
+  border-color: rgba(74, 222, 128, 0.6);
+}
+
+.jp-ah-resultado.perdio {
+  background: rgba(120, 53, 15, 0.35);
+  border-color: rgba(251, 191, 36, 0.5);
+}
+
+.jp-ah-resultado-titulo {
+  margin: 0;
+  font-weight: 800;
+  color: #fff;
+  font-size: 1.05rem;
+}
+
+.jp-ah-resultado-palabra {
+  margin: 0;
+  color: #e2e8f0;
+}
+
+.jp-ah-resultado-pista {
+  margin: 0;
+  color: #f1f5f9;
+  line-height: 1.4;
+}
+
+.jp-ah-resultado-fuente {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.8rem;
+  font-style: italic;
+}
+
+.jp-ah-btn-otra {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.25rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(74, 222, 128, 0.9);
+  color: #052e16;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.jp-ah-btn-otra:active {
+  transform: scale(0.97);
+}
+
+/* ── Teclado en pantalla (táctil, PWA móvil) ────────────────────────────── */
+
+.jp-ah-teclado {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.4rem;
+}
+
+@media (min-width: 30rem) {
+  .jp-ah-teclado {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+}
+
+.jp-ah-tecla {
+  min-height: 2.6rem;
+  border-radius: 0.6rem;
+  border: 2px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.7);
+  color: #f1f5f9;
+  font-weight: 700;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.jp-ah-tecla:active {
+  transform: scale(0.94);
+}
+
+.jp-ah-tecla:disabled {
+  cursor: default;
+}
+
+.jp-ah-tecla.acierto {
+  background: rgba(22, 163, 74, 0.6);
+  border-color: rgba(74, 222, 128, 0.8);
+  color: #fff;
+}
+
+.jp-ah-tecla.fallo {
+  background: rgba(153, 27, 27, 0.5);
+  border-color: rgba(248, 113, 113, 0.6);
+  color: #fecaca;
+}
+
+/* ── Pie con advertencia toxicológica ────────────────────────────────────── */
+
+.jp-ah-pie {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.jp-ah-btn-advertencia {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(251, 191, 36, 0.5);
+  background: rgba(120, 53, 15, 0.25);
+  color: #fde68a;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.jp-ah-modal-fondo {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  z-index: 60;
+}
+
+.jp-ah-modal {
+  max-width: 28rem;
+  width: 100%;
+  background: #0f172a;
+  border: 2px solid rgba(251, 191, 36, 0.5);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.jp-ah-modal h3 {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #fde68a;
+  font-size: 1.05rem;
+}
+
+.jp-ah-modal p {
+  margin: 0;
+  color: #e2e8f0;
+  line-height: 1.5;
+  font-size: 0.9rem;
+}

--- a/src/data/juegos/ahorcadoContaminado.js
+++ b/src/data/juegos/ahorcadoContaminado.js
@@ -1,0 +1,458 @@
+/**
+ * ahorcadoContaminado.js — DATASET de contenido para el juego "Ahorcado
+ * Contaminado" (un ahorcado / hangman cuyo tema es la contaminación por
+ * agroquímicos y su reemplazo agroecológico).
+ *
+ * ⚠️  ESTO ES SOLO EL CONTENIDO (Tarea #38 del PLAN-RETOMA). El juego en sí
+ *     (mecánica, UI, pantalla) se construye aparte en la Tarea #93. Aquí NO hay
+ *     lógica de juego: solo palabras, pistas educativas, fuentes y confianza.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * ADVERTENCIA TOXICOLÓGICA (regla inviolable de contenido sensible):
+ *   Los datos de intoxicación son EDUCATIVOS, NO son diagnóstico médico ni
+ *   protocolo de primeros auxilios. Ante una sospecha de intoxicación por
+ *   agroquímicos: retirar a la persona de la exposición, quitar ropa
+ *   contaminada, y llamar YA a la línea de toxicología. En Colombia:
+ *   Centro de Información y Asesoría Toxicológica (CIATOX) y línea de urgencias
+ *   123. Este dataset describe SÍNTOMAS RECONOCIDOS en la literatura para
+ *   sensibilizar; nunca los usa para "auto-diagnosticar" gravedad.
+ *
+ * ANTI-FABRICACIÓN (política Chagra "dato con fuente o no va"):
+ *   - Cada plaguicida marcado como vetado/restringido trae su norma real
+ *     (Resolución ICA con número/año, y/o convenio internacional que Colombia
+ *     ratificó: Estocolmo — Ley 994/2005; Rotterdam — Ley 1159/2007). Donde el
+ *     número exacto de la resolución no se pudo confirmar con certeza total, el
+ *     hecho de la PROHIBICIÓN/RESTRICCIÓN en Colombia sí está documentado y se
+ *     baja el nivel de `confianza` a 'media' y se aclara en la `nota`.
+ *   - Cada síntoma trae su marco (IARC 2015 para glifosato; clasificación OMS
+ *     por peligrosidad; hojas de seguridad / literatura clínica de
+ *     intoxicaciones). No se exageran efectos ni se inventan.
+ *   - Las alternativas agroecológicas reusan los nombres canónicos del catálogo
+ *     de biopreparados (catalog/biopreparados-seed.json): caldo bordelés,
+ *     caldo sulfocálcico, Trichoderma, etc. — no se inventan recetas.
+ *
+ * FUENTES CLAVE CONSULTADAS (procedencia top-level, ver `FUENTES`):
+ *   - IARC / OMS. Monografía Vol. 112 (2015): glifosato = Grupo 2A
+ *     ("probablemente carcinogénico para humanos"). Malatión, diazinón también
+ *     2A en la misma monografía.
+ *   - Convenio de Estocolmo sobre Contaminantes Orgánicos Persistentes (COP),
+ *     ratificado por Colombia mediante Ley 994 de 2005.
+ *   - Convenio de Rotterdam (consentimiento fundamentado previo, PIC),
+ *     ratificado por Colombia mediante Ley 1159 de 2007.
+ *   - ICA — Instituto Colombiano Agropecuario. Resoluciones de prohibición y
+ *     restricción de plaguicidas de uso agrícola; Resolución ICA 698 de 2011
+ *     (registro de bioinsumos y extractos vegetales de uso agrícola).
+ *   - OMS — Clasificación recomendada de plaguicidas por su peligrosidad
+ *     ("The WHO Recommended Classification of Pesticides by Hazard").
+ *   - Restrepo Rivera, J. — "ABC de la agricultura orgánica" / "Manual práctico
+ *     de biofertilizantes" (para las alternativas agroecológicas).
+ *
+ * Español colombiano (tú/usted). Sin voseo (guard lefthook).
+ */
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * FUENTES — catálogo de procedencia. Cada palabra referencia por `fuenteId`.
+ * ────────────────────────────────────────────────────────────────────────── */
+export const FUENTES = {
+  iarc112: {
+    id: 'iarc112',
+    label: 'IARC (OMS) — Monografía Vol. 112, 2015',
+    detalle:
+      'Agencia Internacional para la Investigación sobre el Cáncer. Clasificó '
+      + 'el glifosato como Grupo 2A: probablemente carcinogénico para humanos.',
+  },
+  omsClasif: {
+    id: 'omsClasif',
+    label: 'OMS — Clasificación de plaguicidas por peligrosidad',
+    detalle:
+      '"The WHO Recommended Classification of Pesticides by Hazard". Ordena los '
+      + 'plaguicidas de Clase Ia (extremadamente peligroso) a Clase U.',
+  },
+  estocolmo: {
+    id: 'estocolmo',
+    label: 'Convenio de Estocolmo (COP) — Ley 994 de 2005 (Colombia)',
+    detalle:
+      'Tratado que elimina o restringe Contaminantes Orgánicos Persistentes. '
+      + 'Colombia lo ratificó por la Ley 994 de 2005. Cubre plaguicidas como '
+      + 'DDT, aldrín, dieldrín, endrín, clordano, heptacloro, endosulfán, lindano.',
+  },
+  rotterdam: {
+    id: 'rotterdam',
+    label: 'Convenio de Rotterdam (PIC) — Ley 1159 de 2007 (Colombia)',
+    detalle:
+      'Procedimiento de consentimiento fundamentado previo para plaguicidas y '
+      + 'químicos peligrosos en comercio internacional. Colombia lo ratificó por '
+      + 'la Ley 1159 de 2007.',
+  },
+  icaProhibicion: {
+    id: 'icaProhibicion',
+    label: 'ICA — Resoluciones de prohibición/restricción de plaguicidas',
+    detalle:
+      'El Instituto Colombiano Agropecuario prohíbe y restringe ingredientes '
+      + 'activos de uso agrícola mediante resoluciones. Donde no se pudo confirmar '
+      + 'el número exacto de la resolución, se baja la confianza y se aclara.',
+  },
+  ica698: {
+    id: 'ica698',
+    label: 'ICA — Resolución 698 de 2011',
+    detalle:
+      'Reglamenta el registro de bioinsumos y extractos vegetales de uso '
+      + 'agrícola en Colombia. Marco de las alternativas agroecológicas.',
+  },
+  restrepo: {
+    id: 'restrepo',
+    label: 'Restrepo Rivera, J. — ABC de la agricultura orgánica / biofertilizantes',
+    detalle:
+      'Manuales de referencia de la agroecología latinoamericana. Base de las '
+      + 'recetas de biopreparados (caldos, purines, biofermentos).',
+  },
+  literaturaClinica: {
+    id: 'literaturaClinica',
+    label: 'Literatura clínica de intoxicaciones + hojas de seguridad (SDS)',
+    detalle:
+      'Cuadros clínicos reconocidos de intoxicación aguda por plaguicidas '
+      + '(organofosforados/carbamatos: síndrome colinérgico; herbicidas: '
+      + 'irritación) y fichas de datos de seguridad de los productos.',
+  },
+};
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * CATEGORÍAS del juego. Cada palabra pertenece a una.
+ * ────────────────────────────────────────────────────────────────────────── */
+export const CATEGORIAS = {
+  sintoma: {
+    id: 'sintoma',
+    label: 'Señales del cuerpo',
+    descripcion:
+      'Síntomas reconocidos de intoxicación por agroquímicos. Educativos, NO '
+      + 'diagnóstico: ante sospecha, llame a toxicología (CIATOX) y a urgencias 123.',
+    emoji: '🩺',
+  },
+  vetado: {
+    id: 'vetado',
+    label: 'Lo que está prohibido',
+    descripcion:
+      'Plaguicidas prohibidos o restringidos en Colombia por resolución del ICA '
+      + 'o por convenios internacionales (Estocolmo, Rotterdam) que el país ratificó.',
+    emoji: '🚫',
+  },
+  alternativa: {
+    id: 'alternativa',
+    label: 'Lo que SÍ',
+    descripcion:
+      'Alternativas agroecológicas que reemplazan al químico: biopreparados y '
+      + 'manejo. Nombres tomados del catálogo de biopreparados de Chagra.',
+    emoji: '🌱',
+  },
+};
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * PALABRAS — el dataset. `confianza`: alta | media | baja.
+ *   - alta  = hecho y fuente confirmados sin ambigüedad.
+ *   - media = el hecho está documentado pero un detalle (nº exacto de norma,
+ *             fecha precisa) no se pudo confirmar con certeza total.
+ *   - baja  = NO se incluye; si aparece 'baja' es porque el dato quedó como
+ *             pendiente de verificación y NO debe usarse en producción.
+ * ────────────────────────────────────────────────────────────────────────── */
+export const PALABRAS = [
+  /* ── SÍNTOMAS de intoxicación por agroquímicos ─────────────────────────── */
+  {
+    palabra: 'NAUSEA',
+    categoria: 'sintoma',
+    pista: 'Malestar en el estómago con ganas de vomitar; señal temprana común tras respirar o tragar plaguicida.',
+    fuenteId: 'literaturaClinica',
+    confianza: 'alta',
+    nota: 'Síntoma inespecífico pero frecuente en intoxicación aguda por muchos plaguicidas.',
+  },
+  {
+    palabra: 'VOMITO',
+    categoria: 'sintoma',
+    pista: 'El cuerpo expulsa lo ingerido; aparece en intoxicaciones por organofosforados y otros agroquímicos.',
+    fuenteId: 'literaturaClinica',
+    confianza: 'alta',
+    nota: 'Parte del síndrome colinérgico y de la irritación gastrointestinal por ingesta.',
+  },
+  {
+    palabra: 'MAREO',
+    categoria: 'sintoma',
+    pista: 'Sensación de que todo da vueltas; frecuente al fumigar sin protección en espacio cerrado.',
+    fuenteId: 'literaturaClinica',
+    confianza: 'alta',
+    nota: 'Efecto neurológico temprano y también por inhalación de solventes del producto.',
+  },
+  {
+    palabra: 'DOLOR DE CABEZA',
+    categoria: 'sintoma',
+    pista: 'Uno de los primeros avisos tras la exposición a los vapores del plaguicida.',
+    fuenteId: 'literaturaClinica',
+    confianza: 'alta',
+    nota: 'Síntoma leve y muy común; por sí solo no indica gravedad.',
+  },
+  {
+    palabra: 'IRRITACION DERMICA',
+    categoria: 'sintoma',
+    pista: 'Ardor, enrojecimiento o ronchas en la piel que tocó el químico; por eso se exige guantes y ropa cubierta.',
+    fuenteId: 'literaturaClinica',
+    confianza: 'alta',
+    nota: 'La piel es una vía de entrada real; los herbicidas como el paraquat irritan al contacto.',
+  },
+  {
+    palabra: 'LAGRIMEO',
+    categoria: 'sintoma',
+    pista: 'Los ojos lloran solos; signo del síndrome colinérgico por organofosforados y carbamatos.',
+    fuenteId: 'literaturaClinica',
+    confianza: 'alta',
+    nota: 'Lagrimeo, salivación y sudoración excesiva son la tríada de "secreciones" colinérgicas.',
+  },
+  {
+    palabra: 'SALIVACION EXCESIVA',
+    categoria: 'sintoma',
+    pista: 'Producir mucha saliva de golpe; alarma clásica de intoxicación por insecticidas organofosforados.',
+    fuenteId: 'literaturaClinica',
+    confianza: 'alta',
+    nota: 'Marcador del bloqueo de la colinesterasa; requiere atención médica urgente.',
+  },
+  {
+    palabra: 'VISION BORROSA',
+    categoria: 'sintoma',
+    pista: 'La vista se nubla; efecto sobre la pupila en intoxicaciones por organofosforados y carbamatos.',
+    fuenteId: 'literaturaClinica',
+    confianza: 'alta',
+    nota: 'Suele acompañarse de pupilas contraídas (miosis) en el cuadro colinérgico.',
+  },
+  {
+    palabra: 'DIFICULTAD PARA RESPIRAR',
+    categoria: 'sintoma',
+    pista: 'Falta de aire u opresión en el pecho; en intoxicación grave por plaguicidas es una urgencia vital.',
+    fuenteId: 'literaturaClinica',
+    confianza: 'alta',
+    nota: 'Señal de gravedad. Retirar de la exposición y llamar a urgencias 123 de inmediato.',
+  },
+  {
+    palabra: 'TEMBLOR',
+    categoria: 'sintoma',
+    pista: 'Manos o cuerpo que tiemblan sin control; efecto sobre el sistema nervioso.',
+    fuenteId: 'literaturaClinica',
+    confianza: 'alta',
+    nota: 'Temblor, calambres y fasciculaciones aparecen en la intoxicación colinérgica.',
+  },
+  {
+    palabra: 'DIARREA',
+    categoria: 'sintoma',
+    pista: 'Descomposición estomacal; parte del cuadro colinérgico por organofosforados y carbamatos.',
+    fuenteId: 'literaturaClinica',
+    confianza: 'alta',
+    nota: 'Junto con náusea, vómito y dolor abdominal, completa los síntomas digestivos.',
+  },
+
+  /* ── PLAGUICIDAS VETADOS / RESTRINGIDOS en Colombia ────────────────────── */
+  {
+    palabra: 'DDT',
+    categoria: 'vetado',
+    pista: 'Insecticida organoclorado persistente; prohibido en agricultura por acumularse en el ambiente y la grasa.',
+    fuenteId: 'estocolmo',
+    confianza: 'alta',
+    nota:
+      'Contaminante Orgánico Persistente listado en el Convenio de Estocolmo '
+      + '(Ley 994/2005). Prohibido para uso agrícola; Colombia también lo restringió '
+      + 'por resolución del ICA décadas atrás.',
+  },
+  {
+    palabra: 'ENDOSULFAN',
+    categoria: 'vetado',
+    pista: 'Insecticida organoclorado muy tóxico para peces y personas; prohibido en Colombia y a nivel mundial.',
+    fuenteId: 'estocolmo',
+    confianza: 'alta',
+    nota:
+      'Añadido al Convenio de Estocolmo en 2011 para eliminación mundial. '
+      + 'El ICA prohibió su uso en Colombia (Resolución ICA de 2011); si el número '
+      + 'exacto se cita en el juego, verificar contra el registro del ICA.',
+  },
+  {
+    palabra: 'ALDRIN',
+    categoria: 'vetado',
+    pista: 'Insecticida organoclorado del grupo de la "docena sucia"; prohibido por persistente y tóxico.',
+    fuenteId: 'estocolmo',
+    confianza: 'alta',
+    nota: 'Uno de los COP originales del Convenio de Estocolmo (Ley 994/2005).',
+  },
+  {
+    palabra: 'DIELDRIN',
+    categoria: 'vetado',
+    pista: 'Organoclorado emparentado con el aldrín; contaminante persistente prohibido para uso agrícola.',
+    fuenteId: 'estocolmo',
+    confianza: 'alta',
+    nota: 'COP original del Convenio de Estocolmo (Ley 994/2005).',
+  },
+  {
+    palabra: 'HEPTACLORO',
+    categoria: 'vetado',
+    pista: 'Organoclorado de la "docena sucia"; prohibido por persistir en suelo y acumularse en la cadena trófica.',
+    fuenteId: 'estocolmo',
+    confianza: 'alta',
+    nota: 'COP original del Convenio de Estocolmo (Ley 994/2005).',
+  },
+  {
+    palabra: 'LINDANO',
+    categoria: 'vetado',
+    pista: 'Organoclorado (HCH gamma) usado como insecticida; restringido/prohibido por tóxico y persistente.',
+    fuenteId: 'estocolmo',
+    confianza: 'alta',
+    nota:
+      'Incorporado al Convenio de Estocolmo en 2009. Su uso agrícola está '
+      + 'prohibido; en Colombia el ICA lo restringió por resolución.',
+  },
+  {
+    palabra: 'PARATION',
+    categoria: 'vetado',
+    pista: 'Insecticida organofosforado extremadamente tóxico (Clase Ia OMS); prohibido para uso agrícola.',
+    fuenteId: 'omsClasif',
+    confianza: 'alta',
+    nota:
+      'Etil y metil paratión son Clase Ia/Ib (OMS). El ICA prohibió estos '
+      + 'ingredientes activos en Colombia por resolución; también figura en Rotterdam.',
+  },
+  {
+    palabra: 'MONOCROTOFOS',
+    categoria: 'vetado',
+    pista: 'Organofosforado de altísima toxicidad aguda (Clase Ib OMS); prohibido en Colombia y muchos países.',
+    fuenteId: 'omsClasif',
+    confianza: 'alta',
+    nota:
+      'Clase Ib de la OMS. El ICA prohibió el monocrotofos en Colombia por '
+      + 'resolución; verificar el número exacto contra el registro del ICA si se cita.',
+  },
+  {
+    palabra: 'ALDICARB',
+    categoria: 'vetado',
+    pista: 'Carbamato extremadamente tóxico (el "Temik"); prohibido por su altísimo riesgo para personas y fauna.',
+    fuenteId: 'omsClasif',
+    confianza: 'alta',
+    nota:
+      'Clase Ia de la OMS. Prohibido en Colombia por el ICA; su uso indebido '
+      + 'ha causado intoxicaciones y envenenamiento de animales.',
+  },
+  {
+    palabra: 'CARBOFURAN',
+    categoria: 'vetado',
+    pista: 'Insecticida carbamato muy tóxico para aves y personas; prohibido/restringido por su peligrosidad.',
+    fuenteId: 'icaProhibicion',
+    confianza: 'media',
+    nota:
+      'Restringido/prohibido por el ICA por su toxicidad. Se marca confianza '
+      + 'media porque el número y alcance exactos de la resolución vigente deben '
+      + 'confirmarse contra el registro del ICA antes de citarlos textualmente.',
+  },
+  {
+    palabra: 'PARAQUAT',
+    categoria: 'vetado',
+    pista: 'Herbicida de uso restringido; una ingesta pequeña puede ser mortal y no tiene antídoto específico.',
+    fuenteId: 'icaProhibicion',
+    confianza: 'media',
+    nota:
+      'En Colombia es de USO RESTRINGIDO (no está prohibido del todo como el DDT). '
+      + 'Prohibido en la Unión Europea. Se incluye como caso de "altamente '
+      + 'restringido" y se aclara la diferencia con los prohibidos totales.',
+  },
+
+  /* ── ALTERNATIVAS agroecológicas (lo que SÍ) ───────────────────────────── */
+  {
+    palabra: 'CALDO BORDELES',
+    categoria: 'alternativa',
+    pista: 'Cobre + cal contra hongos; reemplaza fungicidas de síntesis. Uso restringido en certificación orgánica.',
+    fuenteId: 'restrepo',
+    confianza: 'alta',
+    nota:
+      'Fungicida mineral de la agroecología (Restrepo). Lleva cobre: usar dosis '
+      + 'y protección adecuadas; su uso es restringido en orgánico certificado.',
+  },
+  {
+    palabra: 'CALDO SULFOCALCICO',
+    categoria: 'alternativa',
+    pista: 'Azufre + cal cocidos; fungicida y acaricida casero que reemplaza productos de síntesis.',
+    fuenteId: 'restrepo',
+    confianza: 'alta',
+    nota: 'Biopreparado del catálogo Chagra. Controla ácaros y algunos hongos.',
+  },
+  {
+    palabra: 'BOCASHI',
+    categoria: 'alternativa',
+    pista: 'Abono fermentado rápido con melaza y microorganismos; nutre el suelo sin fertilizante químico.',
+    fuenteId: 'restrepo',
+    confianza: 'alta',
+    nota: 'Receta de Restrepo Rivera; reemplaza abonos de síntesis nutriendo la vida del suelo.',
+  },
+  {
+    palabra: 'PURIN DE ORTIGA',
+    categoria: 'alternativa',
+    pista: 'Ortiga fermentada en agua; bioestimulante tradicional que fortalece la planta sin agroquímicos.',
+    fuenteId: 'restrepo',
+    confianza: 'alta',
+    nota: 'Biopreparado del catálogo Chagra; aporta silicio y estimula el crecimiento.',
+  },
+  {
+    palabra: 'TRICHODERMA',
+    categoria: 'alternativa',
+    pista: 'Hongo benéfico que controla otros hongos del suelo; control biológico en vez de fungicida químico.',
+    fuenteId: 'ica698',
+    confianza: 'alta',
+    nota:
+      'Trichoderma harzianum: existen formulaciones registradas ante el ICA '
+      + '(Resolución 698/2011, bioinsumos). Antagonista de patógenos del suelo.',
+  },
+];
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * DESCARTADOS — lo que NO se incluyó por no poder fundamentarse con certeza.
+ * Se deja documentado (transparencia anti-fabricación), no entra al juego.
+ * ────────────────────────────────────────────────────────────────────────── */
+export const DESCARTADOS = [
+  {
+    candidato: 'glifosato = "cancerígeno"',
+    motivo:
+      'La IARC (2015, Vol. 112) lo clasificó Grupo 2A: "probablemente '
+      + 'carcinogénico". Afirmar sin matiz "el glifosato causa cáncer" sobrepasa '
+      + 'la evidencia. En el juego el glifosato aparece asociado a síntomas de '
+      + 'irritación reconocidos, no como sentencia de cáncer. Como palabra de '
+      + 'categoría "vetado" NO entra: el glifosato NO está prohibido en Colombia.',
+  },
+  {
+    candidato: 'número exacto de varias resoluciones ICA',
+    motivo:
+      'El hecho de la prohibición/restricción está documentado, pero el número '
+      + 'y año exactos de algunas resoluciones (carbofurán, monocrotofos, '
+      + 'endosulfán) deben verificarse contra el registro vivo del ICA '
+      + '(datos.gov.co) antes de citarse textualmente. Por eso esas entradas '
+      + 'llevan confianza "media" y una nota de verificación.',
+  },
+  {
+    candidato: 'síntomas graves específicos como "convulsiones = X producto"',
+    motivo:
+      'Atribuir un síntoma grave a un producto concreto como si fuera '
+      + 'diagnóstico es peligroso y fuera de alcance educativo. Se incluyen '
+      + 'síntomas reconocidos de forma general, sin prometer identificar el '
+      + 'agente ni la gravedad.',
+  },
+  {
+    candidato: 'dosis letales / cantidades ("X ml matan")',
+    motivo:
+      'No se incluye ninguna cifra de letalidad. Dar números de dosis mortal es '
+      + 'morboso e innecesario para el objetivo educativo, y roza la fabricación '
+      + 'si no viene de una ficha toxicológica exacta.',
+  },
+];
+
+/* Índice por categoría (conveniencia para el build #93). */
+export const PALABRAS_POR_CATEGORIA = {
+  sintoma: PALABRAS.filter((p) => p.categoria === 'sintoma'),
+  vetado: PALABRAS.filter((p) => p.categoria === 'vetado'),
+  alternativa: PALABRAS.filter((p) => p.categoria === 'alternativa'),
+};
+
+export default {
+  FUENTES,
+  CATEGORIAS,
+  PALABRAS,
+  PALABRAS_POR_CATEGORIA,
+  DESCARTADOS,
+};


### PR DESCRIPTION
## Resumen
- Ahorcado clásico con metáfora de **contaminación** en vez de horca: 6 pasos donde la finca se marchita/oscurece/contamina con cada letra errada (CSS/emoji progresivo).
- Consume el dataset fundamentado de la Tarea #38 (`src/data/juegos/ahorcadoContaminado.js`: 27 palabras, 3 categorías — síntomas de intoxicación / plaguicidas vetados / alternativas agroecológicas) **sin modificarlo**.
- Gana o pierde: siempre se revela la palabra + pista educativa + fuente (anti-gamificación tóxica, educativo también al perder).
- Selector de categoría, teclado en pantalla (táctil, PWA móvil), contador de intentos, modal con la advertencia toxicológica obligatoria (CIATOX / urgencias 123).
- Español colombiano, sin voseo. Accesible (aria-live en la escena, aria-pressed/aria-label en el teclado, dialog modal).

## Cableado al hub (Tarea #93)
- `src/App.jsx`: lazy import `AhorcadoContaminado` + `case 'ahorcado_contaminado':` (patrón `mono_vs_poli`/`subsuelo`, envuelto en `ErrorBoundary` + `ErrorFallback` + `ScreenShell`). Alias de ruta `ahorcado-contaminado` y entrada en `MODULE_VIEWS`.
- `src/components/juego/MiFincaVivaScreen.jsx`: botón de entrada `data-testid="entrada-ahorcado-contaminado"` → `irAccion('ahorcado_contaminado')`.

## Test plan
- [x] Test de smoke (`AhorcadoContaminado.test.jsx`): render, jugada ganada (revela pista+fuente), jugada perdida (revela igual, educativo no punitivo), modal de advertencia toxicológica.
- [x] `npx vitest run src/components/juego/` — 149/149 tests verdes (incluye MiFincaVivaScreen, App cableado indirecto).
- [x] `npm run build` verde, chunk propio `AhorcadoContaminado-*.js/css` confirmado en `dist/assets/` (prueba de que el lazy import quedó vivo en el bundle).
- [x] `eslint --max-warnings=0` limpio en los archivos nuevos/tocados (AhorcadoContaminado.jsx, test, MiFincaVivaScreen.jsx, App.jsx).
- [x] Captura Playwright (chromium del sistema, Xvfb en alpha) navegando directo a `#ahorcado-contaminado`: juego montado (27 teclas, 4 categorías, advertencia), 0 `pageerror`. Los 3 `console.error` observados (`VITE_FARMOS_CLIENT_ID`, dos 404) son ruido preexistente del preview local sin `.env` — reproducidos igual en `#mono-vs-poli` (pantalla ajena, sin tocar). PNG en `Chagra-strategy/ops/briefs/artefactos/2026-07-30-juego-ahorcado-contaminado.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)