### PR TITLE
feat(juegos): Angelita real y mariposas que mueren con ella en el Ahorcado Contaminado

### DIFF
--- a/src/components/juego/AhorcadoContaminado.jsx
+++ b/src/components/juego/AhorcadoContaminado.jsx
@@ -128,6 +128,22 @@ function EscenaChagra({ errores, ganado, perdido }) {
         d="M0,152 Q40,116 90,134 Q150,152 200,126 Q262,100 320,132 Q345,144 360,138 L360,152 Z"
       />
 
+      {/* ── Nubes blancas amigables (se van cuando llega el químico) ── */}
+      <g className="jp-ah-nube-blanca" transform="translate(70 26)">
+        <g className="jp-ah-nube-blanca-forma">
+          <ellipse cx="0" cy="0" rx="21" ry="9" />
+          <ellipse cx="-13" cy="4" rx="12" ry="7" />
+          <ellipse cx="13" cy="4" rx="13" ry="7" />
+        </g>
+      </g>
+      <g className="jp-ah-nube-blanca nube-blanca-2" transform="translate(196 40) scale(0.65)">
+        <g className="jp-ah-nube-blanca-forma">
+          <ellipse cx="0" cy="0" rx="21" ry="9" />
+          <ellipse cx="-13" cy="4" rx="12" ry="7" />
+          <ellipse cx="13" cy="4" rx="13" ry="7" />
+        </g>
+      </g>
+
       {/* ── Frailejones de silueta en la loma (toque de páramo) ── */}
       <g className="jp-ah-frailejon" transform="translate(254 130)">
         <rect x="-2" y="-12" width="4" height="14" rx="2" />
@@ -136,6 +152,7 @@ function EscenaChagra({ errores, ganado, perdido }) {
             <ellipse key={a} cx="0" cy="-16" rx="2.6" ry="7.5" transform={`rotate(${a} 0 -10)`} />
           ))}
         </g>
+        <circle className="jp-ah-frailejon-flor" cx="0" cy="-24" r="2.2" />
       </g>
       <g className="jp-ah-frailejon" transform="translate(300 138) scale(0.7)">
         <rect x="-2" y="-12" width="4" height="14" rx="2" />
@@ -144,6 +161,7 @@ function EscenaChagra({ errores, ganado, perdido }) {
             <ellipse key={a} cx="0" cy="-16" rx="2.6" ry="7.5" transform={`rotate(${a} 0 -10)`} />
           ))}
         </g>
+        <circle className="jp-ah-frailejon-flor" cx="0" cy="-24" r="2.2" />
       </g>
 
       {/* ── Suelo (fértil → agrietado) ── */}
@@ -193,6 +211,19 @@ function EscenaChagra({ errores, ganado, perdido }) {
         </g>
       ))}
 
+      {/* ── Surco de brotecitos: la chagra es parcela cultivada ── */}
+      {[
+        [24, 160], [52, 166], [80, 172], [108, 178],
+      ].map(([x, y], i) => (
+        <g key={i} transform={`translate(${x} ${y})`}>
+          <g className={`jp-ah-brote brote-${i + 1}`}>
+            <path className="jp-ah-brote-tallo" d="M0,0 Q0,-4 0,-7" />
+            <path className="jp-ah-brote-hoja" d="M0,-6 C-3,-8 -6,-8 -8,-6 C-6,-4 -2,-4 0,-6 Z" />
+            <path className="jp-ah-brote-hoja" d="M0,-7 C3,-9 6,-9 8,-7 C6,-5 2,-5 0,-7 Z" />
+          </g>
+        </g>
+      ))}
+
       {/* ── Florecitas de victoria (brotan al ganar) ── */}
       {[
         [70, 151], [212, 154], [255, 151],
@@ -210,6 +241,7 @@ function EscenaChagra({ errores, ganado, perdido }) {
 
       {/* ── La mata protagonista (rubber-hose: respira, se marchita) ── */}
       <g className="jp-ah-mata-anclaje" transform="translate(118 149)">
+        <ellipse className="jp-ah-mata-sombra" cx="0" cy="1.5" rx="21" ry="3.4" />
         <g className="jp-ah-mata">
           <path className="jp-ah-tallo" d="M0,0 C-2,-22 2,-40 0,-58" />
           {/* Pares de hojas: la unión al tallo queda en el (0,0) local de cada
@@ -358,6 +390,23 @@ function EscenaChagra({ errores, ganado, perdido }) {
           <text className="z-1" x="8" y="-14">z</text>
           <text className="z-2" x="15" y="-22">z</text>
           <text className="z-3" x="23" y="-30">z</text>
+        </g>
+      </g>
+
+      {/* ── Mariposa: revolotea sana; con el químico se aleja de la chagra ── */}
+      <g className="jp-ah-mariposa-orbita">
+        <g className="jp-ah-mariposa">
+          <g className="jp-ah-mariposa-ala ala-m-izq">
+            <path d="M-1,0 C-6,-6 -11,-6 -11,-1 C-11,3 -6,4 -1,1 Z" />
+            <circle cx="-7" cy="-2" r="1.1" />
+          </g>
+          <g className="jp-ah-mariposa-ala ala-m-der">
+            <path d="M1,0 C6,-6 11,-6 11,-1 C11,3 6,4 1,1 Z" />
+            <circle cx="7" cy="-2" r="1.1" />
+          </g>
+          <ellipse className="jp-ah-mariposa-cuerpo" cx="0" cy="0" rx="1.4" ry="4" />
+          <path className="jp-ah-mariposa-antena" d="M-0.6,-3.6 Q-2,-6 -3,-6.6" />
+          <path className="jp-ah-mariposa-antena" d="M0.6,-3.6 Q2,-6 3,-6.6" />
         </g>
       </g>
 

--- a/src/components/juego/AhorcadoContaminado.jsx
+++ b/src/components/juego/AhorcadoContaminado.jsx
@@ -6,6 +6,11 @@ import {
   PALABRAS,
   PALABRAS_POR_CATEGORIA,
 } from '../../data/juegos/ahorcadoContaminado';
+// La abeja REAL de la casa (Tetragonisca angustula rubber-hose, la del compai):
+// import directo del componente — NO del index (el index arrastra el registry
+// con toda la fauna al chunk del juego). El componente compartido no se toca:
+// el juego solo lo DIRIGE por props + CSS propio (prefijo jp-ah-).
+import AbejaAngelita from '../../visual/creatures/AbejaAngelita.jsx';
 import './ahorcado-contaminado.css';
 
 const MAX_ERRORES = 6;
@@ -21,8 +26,8 @@ const ETAPAS_CONTAMINACION = [
   { clase: 'paso-2', texto: 'Las hojas se marchitan y empiezan a caer.' },
   { clase: 'paso-3', texto: 'El suelo fértil se agrieta y pierde su vida.' },
   { clase: 'paso-4', texto: 'El agua de riego se enturbió: ya no está limpia.' },
-  { clase: 'paso-5', texto: 'La abejita polinizadora tambalea, casi no puede volar.' },
-  { clase: 'paso-6', texto: 'La chagra quedó contaminada. La abejita no pudo más.' },
+  { clase: 'paso-5', texto: 'Angelita, la abejita polinizadora, tambalea: casi no puede volar.' },
+  { clase: 'paso-6', texto: 'La chagra quedó contaminada. Angelita y sus amigas no pudieron más.' },
 ];
 
 function normalizar(letra) {
@@ -51,13 +56,74 @@ function MedidorSalud({ errores }) {
 }
 
 /**
+ * actuacionAngelita — la DIRECCIÓN de escena de la protagonista.
+ *
+ * Angelita es el componente compartido (src/visual/creatures/AbejaAngelita):
+ * aquí no se redibuja nada, solo se le dan indicaciones de actuación por sus
+ * props públicos (pose/animo/energia/sed/polen/cejas) según cuántos errores
+ * lleva la partida. La trayectoria (órbita, tambaleo, caída) es del CSS del
+ * juego; la INTERPRETACIÓN (aleteo, parpadeo, jadeo, cejas) es toda suya.
+ */
+function actuacionAngelita(errores, ganado, perdido) {
+  if (ganado) {
+    // Revivió con la chagra: salto de celebración + polen otra vez.
+    return { pose: 'celebra', animo: 'pleno', energia: 1, sed: false, polen: true, cejas: 'alegres' };
+  }
+  if (perdido) {
+    // Desmayada, sin morbo: alitas plegadas (reposo), sin antics (descansa).
+    // Los ojitos cerrados + el gris los pone el CSS del juego (p6).
+    return { pose: 'reposo', animo: 'descansa', energia: 0.12, sed: false, polen: false, cejas: null };
+  }
+  if (errores >= 5) {
+    return { pose: 'vuela', animo: 'sediento', energia: 0.25, sed: true, polen: false, cejas: 'fruncidas' };
+  }
+  if (errores >= 4) {
+    // El agua se enturbió: jadea con la lengüita afuera (sed real del prop).
+    return { pose: 'vuela', animo: 'sediento', energia: 0.4, sed: true, polen: false, cejas: 'altas' };
+  }
+  if (errores >= 3) {
+    return { pose: 'vuela', animo: 'atento', energia: 0.55, sed: false, polen: false, cejas: 'altas' };
+  }
+  if (errores >= 2) {
+    return { pose: 'vuela', animo: 'sereno', energia: 0.75, sed: false, polen: false, cejas: null };
+  }
+  // Chagra sana: plena, cargada de polen (la loca de flor en flor).
+  return { pose: 'vuela', animo: 'pleno', energia: 1, sed: false, polen: true, cejas: null };
+}
+
+/**
+ * Mariposita — secundaria de la escena (dibujo propio del juego, a escala del
+ * paisaje). Secundaria pero NO desechable: ya no huye del químico — acompaña
+ * a Angelita en la degradación (aleteo pesado → tambaleo → cae marchita) y
+ * revive con ella al ganar. La coreografía completa vive en el CSS (jp-ah-).
+ */
+function Mariposita() {
+  return (
+    <g className="jp-ah-mariposa">
+      <g className="jp-ah-mariposa-ala ala-m-izq">
+        <path d="M-1,0 C-6,-6 -11,-6 -11,-1 C-11,3 -6,4 -1,1 Z" />
+        <circle cx="-7" cy="-2" r="1.1" />
+      </g>
+      <g className="jp-ah-mariposa-ala ala-m-der">
+        <path d="M1,0 C6,-6 11,-6 11,-1 C11,3 6,4 1,1 Z" />
+        <circle cx="7" cy="-2" r="1.1" />
+      </g>
+      <ellipse className="jp-ah-mariposa-cuerpo" cx="0" cy="0" rx="1.4" ry="4" />
+      <path className="jp-ah-mariposa-antena" d="M-0.6,-3.6 Q-2,-6 -3,-6.6" />
+      <path className="jp-ah-mariposa-antena" d="M0.6,-3.6 Q2,-6 3,-6.6" />
+    </g>
+  );
+}
+
+/**
  * EscenaChagra — la escena viva que reemplaza la horca (y los emojis).
  *
  * Una parcela andina dibujada en SVG (rubber-hose para los seres vivos:
  * squash&stretch, line-boil sutil) que se contamina un paso por cada error:
  * entra la nube de químico, la mata se marchita, el suelo se agrieta, el
- * agua se enturbia y la abejita tambalea hasta caer (desmayada, sin morbo:
- * esto es educativo). Al ganar, la escena revive y florece.
+ * agua se enturbia y Angelita — la abeja angelita REAL de la casa — tambalea
+ * hasta caer (desmayada, sin morbo: esto es educativo). Sus compañeras
+ * mariposas se apagan CON ella, no desaparecen. Al ganar, todas reviven.
  *
  * Los pasos se acumulan como clases p1..pN para que el CSS aplique cada
  * degradación de forma progresiva y con transiciones suaves.
@@ -66,6 +132,7 @@ function EscenaChagra({ errores, ganado, perdido }) {
   const n = Math.min(errores, MAX_ERRORES);
   const pasos = Array.from({ length: n }, (_, i) => `p${i + 1}`).join(' ');
   const estado = ganado ? 'gano' : perdido ? 'perdio' : '';
+  const angelita = actuacionAngelita(errores, ganado, perdido);
 
   return (
     <svg
@@ -349,43 +416,29 @@ function EscenaChagra({ errores, ganado, perdido }) {
         </g>
       </g>
 
-      {/* ── La abejita polinizadora (rubber-hose, vuela → tambalea → cae) ── */}
+      {/* ── Angelita, la protagonista (la abeja REAL de la casa) ──
+          El componente compartido entra en modo inline: el juego pone la
+          ÓRBITA (vuela → preocupada → tambalea → cae) en los wrappers, y la
+          actuación (aleteo, parpadeo, jadeo, cejas, polen) es del componente
+          vía props. El marco escala y ESPEJA (mira hacia la mata, que queda a
+          su izquierda) en un <g> sin clases animadas: las animaciones CSS de
+          los wrappers no le pisan el transform. */}
       <g className="jp-ah-abeja-orbita">
         <g className="jp-ah-abeja">
-          <g className="jp-ah-ala ala-izq">
-            <ellipse cx="-2" cy="-9" rx="4.6" ry="7" />
-          </g>
-          <g className="jp-ah-ala ala-der">
-            <ellipse cx="3" cy="-8" rx="4" ry="6" />
-          </g>
-          <ellipse className="jp-ah-abeja-cuerpo" cx="0" cy="0" rx="8.4" ry="5.8" />
-          <path className="jp-ah-franja" d="M-1,-5.6 C-2.4,-2 -2.4,2 -1,5.6 L2.4,5.4 C1,2 1,-2 2.4,-5.4 Z" />
-          <path className="jp-ah-franja" d="M4.6,-4.6 C3.6,-1.8 3.6,1.8 4.6,4.6 L7.4,3.4 C6.6,1.4 6.6,-1.4 7.4,-3.4 Z" />
-          <circle className="jp-ah-abeja-cabeza" cx="-9.6" cy="-1" r="4.4" />
-          <g className="jp-ah-antenas">
-            <path d="M-11.5,-4.5 C-13,-7 -14.5,-8 -15.5,-8.5" />
-            <circle cx="-15.8" cy="-8.8" r="1" />
-            <path d="M-9,-5 C-9.5,-8 -10.5,-9.5 -11,-10.5" />
-            <circle cx="-11.2" cy="-10.9" r="1" />
-          </g>
-          <g className="jp-ah-ojos-abiertos">
-            <ellipse cx="-11.2" cy="-1.6" rx="1.25" ry="1.8" />
-            <ellipse cx="-8.4" cy="-1.6" rx="1.25" ry="1.8" />
-            <circle className="jp-ah-pupila" cx="-11.4" cy="-1.3" r="0.55" />
-            <circle className="jp-ah-pupila" cx="-8.6" cy="-1.3" r="0.55" />
-            <path className="jp-ah-sonrisa" d="M-11.4,1.6 Q-9.9,2.8 -8.4,1.6" />
-          </g>
-          <g className="jp-ah-ojos-cerrados">
-            <path d="M-12.3,-1.4 Q-11.2,-0.3 -10.1,-1.4" />
-            <path d="M-9.5,-1.4 Q-8.4,-0.3 -7.3,-1.4" />
-          </g>
-          <g className="jp-ah-patitas">
-            <path d="M-3,5 q-1,2.5 -2.5,3" />
-            <path d="M1,5.6 q0,2.5 -1,3.2" />
-            <path d="M5,5 q1,2.5 0.5,3.4" />
+          <g className="jp-ah-angelita" transform="scale(-1.15 1.15)">
+            <AbejaAngelita
+              inline
+              animated
+              pose={angelita.pose}
+              animo={angelita.animo}
+              energia={angelita.energia}
+              sed={angelita.sed}
+              polen={angelita.polen}
+              cejas={angelita.cejas}
+            />
           </g>
         </g>
-        {/* zZz: la abejita quedó desmayada (educativo, sin morbo) */}
+        {/* zZz: Angelita quedó desmayada (educativo, sin morbo) */}
         <g className="jp-ah-zzz">
           <text className="z-1" x="8" y="-14">z</text>
           <text className="z-2" x="15" y="-22">z</text>
@@ -393,20 +446,15 @@ function EscenaChagra({ errores, ganado, perdido }) {
         </g>
       </g>
 
-      {/* ── Mariposa: revolotea sana; con el químico se aleja de la chagra ── */}
+      {/* ── Mariposas: secundarias que acompañan a Angelita — el químico ya no
+          las espanta fuera de escena: se van apagando CON ella (aleteo pesado
+          → tambaleo → caen marchitas al suelo) y reviven juntas al ganar. ── */}
       <g className="jp-ah-mariposa-orbita">
-        <g className="jp-ah-mariposa">
-          <g className="jp-ah-mariposa-ala ala-m-izq">
-            <path d="M-1,0 C-6,-6 -11,-6 -11,-1 C-11,3 -6,4 -1,1 Z" />
-            <circle cx="-7" cy="-2" r="1.1" />
-          </g>
-          <g className="jp-ah-mariposa-ala ala-m-der">
-            <path d="M1,0 C6,-6 11,-6 11,-1 C11,3 6,4 1,1 Z" />
-            <circle cx="7" cy="-2" r="1.1" />
-          </g>
-          <ellipse className="jp-ah-mariposa-cuerpo" cx="0" cy="0" rx="1.4" ry="4" />
-          <path className="jp-ah-mariposa-antena" d="M-0.6,-3.6 Q-2,-6 -3,-6.6" />
-          <path className="jp-ah-mariposa-antena" d="M0.6,-3.6 Q2,-6 3,-6.6" />
+        <Mariposita />
+      </g>
+      <g className="jp-ah-mariposa-orbita mariposa-orbita-2">
+        <g transform="scale(0.68)">
+          <Mariposita />
         </g>
       </g>
 

--- a/src/components/juego/AhorcadoContaminado.jsx
+++ b/src/components/juego/AhorcadoContaminado.jsx
@@ -11,21 +11,360 @@ import './ahorcado-contaminado.css';
 const MAX_ERRORES = 6;
 const TECLADO = 'ABCDEFGHIJKLMNÑOPQRSTUVWXYZ'.split('');
 
-// Los 6 pasos de la metáfora de "contaminación" en vez de horca: la finca se
-// va apagando paso a paso. Cada paso suma una etapa visible (planta, suelo,
-// agua) para que la penalización sea legible sin dibujar una soga.
+// Los 6 pasos de la metáfora de "contaminación" en vez de horca: la chagra se
+// va apagando paso a paso. Cada paso suma una etapa visible (nube química,
+// planta, suelo, agua, polinizadores) para que la penalización sea legible
+// sin dibujar una soga. La escena SVG (EscenaChagra) anima cada etapa.
 const ETAPAS_CONTAMINACION = [
-  { emoji: '🌱', clase: 'sana', texto: 'La finca está sana.' },
-  { emoji: '🥀', clase: 'paso-1', texto: 'La plantica se empieza a marchitar.' },
-  { emoji: '🍂', clase: 'paso-2', texto: 'Las hojas se caen antes de tiempo.' },
-  { emoji: '🟤', clase: 'paso-3', texto: 'El suelo se empieza a oscurecer.' },
-  { emoji: '💧', clase: 'paso-4', texto: 'El agua de riego se contamina.' },
-  { emoji: '🐝', clase: 'paso-5', texto: 'Las abejas y los polinizadores se alejan.' },
-  { emoji: '☠️', clase: 'paso-6', texto: 'La finca quedó contaminada del todo.' },
+  { clase: 'sana', texto: 'La chagra está viva y sana.' },
+  { clase: 'paso-1', texto: 'Una nube de químico asoma sobre la chagra.' },
+  { clase: 'paso-2', texto: 'Las hojas se marchitan y empiezan a caer.' },
+  { clase: 'paso-3', texto: 'El suelo fértil se agrieta y pierde su vida.' },
+  { clase: 'paso-4', texto: 'El agua de riego se enturbió: ya no está limpia.' },
+  { clase: 'paso-5', texto: 'La abejita polinizadora tambalea, casi no puede volar.' },
+  { clase: 'paso-6', texto: 'La chagra quedó contaminada. La abejita no pudo más.' },
 ];
 
 function normalizar(letra) {
   return letra.toUpperCase();
+}
+
+/**
+ * Medidor de vida: 6 hojitas que se van apagando (una por error).
+ * Refuerza la lectura de "cuántos intentos quedan" sin números fríos.
+ */
+function MedidorSalud({ errores }) {
+  return (
+    <div className="jp-ah-medidor" aria-hidden="true">
+      {Array.from({ length: MAX_ERRORES }, (_, i) => (
+        <svg
+          key={i}
+          viewBox="0 0 20 20"
+          className={`jp-ah-medidor-hoja ${i < errores ? 'apagada' : ''}`}
+        >
+          <path d="M10 18 C10 12 6 10 4 4 C10 5 15 8 15 13 C15 16 13 18 10 18 Z" />
+          <path d="M10 17 C10 13 8 10 6 6" className="jp-ah-medidor-vena" />
+        </svg>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * EscenaChagra — la escena viva que reemplaza la horca (y los emojis).
+ *
+ * Una parcela andina dibujada en SVG (rubber-hose para los seres vivos:
+ * squash&stretch, line-boil sutil) que se contamina un paso por cada error:
+ * entra la nube de químico, la mata se marchita, el suelo se agrieta, el
+ * agua se enturbia y la abejita tambalea hasta caer (desmayada, sin morbo:
+ * esto es educativo). Al ganar, la escena revive y florece.
+ *
+ * Los pasos se acumulan como clases p1..pN para que el CSS aplique cada
+ * degradación de forma progresiva y con transiciones suaves.
+ */
+function EscenaChagra({ errores, ganado, perdido }) {
+  const n = Math.min(errores, MAX_ERRORES);
+  const pasos = Array.from({ length: n }, (_, i) => `p${i + 1}`).join(' ');
+  const estado = ganado ? 'gano' : perdido ? 'perdio' : '';
+
+  return (
+    <svg
+      className={`jp-ah-vivo ${pasos} ${estado}`}
+      viewBox="0 0 360 200"
+      preserveAspectRatio="xMidYMid meet"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <defs>
+        {/* Cielo sano (amanecer andino) y cielo tóxico: crossfade por opacity */}
+        <linearGradient id="jpAhCieloSano" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#8ed0ec" />
+          <stop offset="0.7" stopColor="#cdeccc" />
+          <stop offset="1" stopColor="#f2f7d8" />
+        </linearGradient>
+        <linearGradient id="jpAhCieloToxico" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#565264" />
+          <stop offset="0.7" stopColor="#7a7f6c" />
+          <stop offset="1" stopColor="#8d8f74" />
+        </linearGradient>
+        {/* Line-boil (contorno que vibra, 3 seeds rotadas a pasos) */}
+        <filter id="jpAhBoil1" x="-20%" y="-20%" width="140%" height="140%">
+          <feTurbulence type="fractalNoise" baseFrequency="0.06" numOctaves="1" seed="3" result="r" />
+          <feDisplacementMap in="SourceGraphic" in2="r" scale="1.6" />
+        </filter>
+        <filter id="jpAhBoil2" x="-20%" y="-20%" width="140%" height="140%">
+          <feTurbulence type="fractalNoise" baseFrequency="0.06" numOctaves="1" seed="11" result="r" />
+          <feDisplacementMap in="SourceGraphic" in2="r" scale="1.6" />
+        </filter>
+        <filter id="jpAhBoil3" x="-20%" y="-20%" width="140%" height="140%">
+          <feTurbulence type="fractalNoise" baseFrequency="0.06" numOctaves="1" seed="27" result="r" />
+          <feDisplacementMap in="SourceGraphic" in2="r" scale="1.6" />
+        </filter>
+      </defs>
+
+      {/* ── Cielo (dos capas, crossfade) ── */}
+      <rect className="jp-ah-cielo-sano" x="0" y="0" width="360" height="152" fill="url(#jpAhCieloSano)" />
+      <rect className="jp-ah-cielo-toxico" x="0" y="0" width="360" height="152" fill="url(#jpAhCieloToxico)" />
+
+      {/* ── Sol con rayos que giran ── */}
+      <g className="jp-ah-sol" transform="translate(306 40)">
+        <circle className="jp-ah-sol-halo" r="26" />
+        <g className="jp-ah-sol-rayos">
+          {Array.from({ length: 8 }, (_, i) => (
+            <line key={i} x1="0" y1="-20" x2="0" y2="-26" transform={`rotate(${i * 45})`} />
+          ))}
+        </g>
+        <circle className="jp-ah-sol-disco" r="15" />
+      </g>
+
+      {/* ── Cordillera (dos planos + niebla, lámina Humboldt suave) ── */}
+      <path
+        className="jp-ah-montana-lejos"
+        d="M0,112 Q45,60 95,98 Q140,128 190,84 Q245,38 300,92 Q332,118 360,94 L360,152 L0,152 Z"
+      />
+      <ellipse className="jp-ah-niebla" cx="180" cy="116" rx="160" ry="13" />
+      <path
+        className="jp-ah-montana-cerca"
+        d="M0,152 Q40,116 90,134 Q150,152 200,126 Q262,100 320,132 Q345,144 360,138 L360,152 Z"
+      />
+
+      {/* ── Frailejones de silueta en la loma (toque de páramo) ── */}
+      <g className="jp-ah-frailejon" transform="translate(254 130)">
+        <rect x="-2" y="-12" width="4" height="14" rx="2" />
+        <g>
+          {[-64, -32, 0, 32, 64].map((a) => (
+            <ellipse key={a} cx="0" cy="-16" rx="2.6" ry="7.5" transform={`rotate(${a} 0 -10)`} />
+          ))}
+        </g>
+      </g>
+      <g className="jp-ah-frailejon" transform="translate(300 138) scale(0.7)">
+        <rect x="-2" y="-12" width="4" height="14" rx="2" />
+        <g>
+          {[-64, -32, 0, 32, 64].map((a) => (
+            <ellipse key={a} cx="0" cy="-16" rx="2.6" ry="7.5" transform={`rotate(${a} 0 -10)`} />
+          ))}
+        </g>
+      </g>
+
+      {/* ── Suelo (fértil → agrietado) ── */}
+      <path
+        className="jp-ah-suelo"
+        d="M0,148 Q60,142 120,146 Q200,153 268,146 Q320,141 360,146 L360,200 L0,200 Z"
+      />
+      <g className="jp-ah-humus">
+        <ellipse cx="42" cy="176" rx="3" ry="1.4" />
+        <ellipse cx="88" cy="188" rx="2.4" ry="1.2" />
+        <ellipse cx="150" cy="180" rx="3.2" ry="1.4" />
+        <ellipse cx="205" cy="190" rx="2.6" ry="1.2" />
+        <ellipse cx="252" cy="182" rx="2.2" ry="1" />
+        <ellipse cx="320" cy="190" rx="3" ry="1.3" />
+      </g>
+      <g className="jp-ah-grietas">
+        <path d="M36,164 l12,7 l-4,9 l13,6" />
+        <path d="M196,172 l14,5 l3,10" />
+        <path d="M92,184 l10,6 l9,-3" />
+        <path d="M290,186 l11,4 l-2,8" />
+      </g>
+
+      {/* ── Agua de riego (limpia → turbia) ── */}
+      <g className="jp-ah-agua" transform="translate(292 166)">
+        <path
+          className="jp-ah-agua-cuerpo"
+          d="M-54,0 Q-48,-10 -20,-11 Q10,-13 34,-8 Q54,-4 51,3 Q42,11 8,12 Q-38,12 -54,0 Z"
+        />
+        <path className="jp-ah-onda onda-1" d="M-40,-2 Q-30,-5 -18,-2 Q-6,1 6,-2" />
+        <path className="jp-ah-onda onda-2" d="M-16,4 Q-4,1 8,4 Q20,7 32,4" />
+        <ellipse className="jp-ah-destello" cx="24" cy="-4" rx="7" ry="1.6" />
+        <g className="jp-ah-burbujas">
+          <circle className="burbuja-1" cx="-24" cy="2" r="2" />
+          <circle className="burbuja-2" cx="4" cy="4" r="1.5" />
+          <circle className="burbuja-3" cx="26" cy="1" r="1.8" />
+        </g>
+      </g>
+
+      {/* ── Pastos que se marchitan ── */}
+      {[
+        [54, 152], [186, 154], [238, 152],
+      ].map(([x, y], i) => (
+        <g key={i} className={`jp-ah-pasto pasto-${i + 1}`} transform={`translate(${x} ${y})`}>
+          <path d="M0,0 Q-2,-8 -5,-12" />
+          <path d="M2,0 Q3,-10 1,-14" />
+          <path d="M5,0 Q7,-7 10,-11" />
+        </g>
+      ))}
+
+      {/* ── Florecitas de victoria (brotan al ganar) ── */}
+      {[
+        [70, 151], [212, 154], [255, 151],
+      ].map(([x, y], i) => (
+        <g key={i} transform={`translate(${x} ${y})`}>
+          <g className={`jp-ah-flor-extra florx-${i + 1}`}>
+            <path className="jp-ah-flor-extra-tallo" d="M0,0 Q0.5,-5 0,-9" />
+            {[0, 72, 144, 216, 288].map((a) => (
+              <ellipse key={a} className="jp-ah-flor-extra-petalo" cx="0" cy="-12" rx="1.8" ry="3" transform={`rotate(${a} 0 -9)`} />
+            ))}
+            <circle className="jp-ah-flor-extra-centro" cx="0" cy="-9" r="1.6" />
+          </g>
+        </g>
+      ))}
+
+      {/* ── La mata protagonista (rubber-hose: respira, se marchita) ── */}
+      <g className="jp-ah-mata-anclaje" transform="translate(118 149)">
+        <g className="jp-ah-mata">
+          <path className="jp-ah-tallo" d="M0,0 C-2,-22 2,-40 0,-58" />
+          {/* Pares de hojas: la unión al tallo queda en el (0,0) local de cada
+              hoja para que el droop (rotación CSS) gire desde la unión. */}
+          <g className="jp-ah-hoja-pos" transform="translate(-1 -14)">
+            <g className="jp-ah-hoja hoja-a">
+              <path className="jp-ah-hoja-forma" d="M0,0 C-9,-8 -22,-10 -30,-3 C-25,5 -10,5 0,0 Z" />
+              <path className="jp-ah-hoja-vena" d="M-3,-1 C-11,-4 -19,-4 -26,-3" />
+            </g>
+          </g>
+          <g className="jp-ah-hoja-pos" transform="translate(1 -22) scale(-1 1)">
+            <g className="jp-ah-hoja hoja-b">
+              <path className="jp-ah-hoja-forma" d="M0,0 C-9,-8 -22,-10 -30,-3 C-25,5 -10,5 0,0 Z" />
+              <path className="jp-ah-hoja-vena" d="M-3,-1 C-11,-4 -19,-4 -26,-3" />
+            </g>
+          </g>
+          <g className="jp-ah-hoja-pos" transform="translate(-1 -33) scale(0.85)">
+            <g className="jp-ah-hoja hoja-c">
+              <path className="jp-ah-hoja-forma" d="M0,0 C-9,-8 -22,-10 -30,-3 C-25,5 -10,5 0,0 Z" />
+              <path className="jp-ah-hoja-vena" d="M-3,-1 C-11,-4 -19,-4 -26,-3" />
+            </g>
+          </g>
+          <g className="jp-ah-hoja-pos" transform="translate(1 -41) scale(-0.85 0.85)">
+            <g className="jp-ah-hoja hoja-d">
+              <path className="jp-ah-hoja-forma" d="M0,0 C-9,-8 -22,-10 -30,-3 C-25,5 -10,5 0,0 Z" />
+              <path className="jp-ah-hoja-vena" d="M-3,-1 C-11,-4 -19,-4 -26,-3" />
+            </g>
+          </g>
+          <g className="jp-ah-hoja-pos" transform="translate(-1 -50) scale(0.62)">
+            <g className="jp-ah-hoja hoja-e">
+              <path className="jp-ah-hoja-forma" d="M0,0 C-9,-8 -22,-10 -30,-3 C-25,5 -10,5 0,0 Z" />
+              <path className="jp-ah-hoja-vena" d="M-3,-1 C-11,-4 -19,-4 -26,-3" />
+            </g>
+          </g>
+          <g className="jp-ah-hoja-pos" transform="translate(1 -54) scale(-0.62 0.62)">
+            <g className="jp-ah-hoja hoja-f">
+              <path className="jp-ah-hoja-forma" d="M0,0 C-9,-8 -22,-10 -30,-3 C-25,5 -10,5 0,0 Z" />
+              <path className="jp-ah-hoja-vena" d="M-3,-1 C-11,-4 -19,-4 -26,-3" />
+            </g>
+          </g>
+          {/* Flor: pétalos alrededor del centro, se cierra al marchitarse */}
+          <g className="jp-ah-flor" transform="translate(0 -58)">
+            <g className="jp-ah-flor-corola">
+              {[0, 60, 120, 180, 240, 300].map((a) => (
+                <ellipse key={a} className="jp-ah-petalo" cx="0" cy="-8" rx="4" ry="6.5" transform={`rotate(${a})`} />
+              ))}
+              <circle className="jp-ah-flor-centro" r="4.4" />
+            </g>
+          </g>
+        </g>
+        {/* Pétalos que se desprenden y caen (aparecen con los errores) */}
+        <g className="jp-ah-petalo-caido caido-1">
+          <ellipse cx="0" cy="-56" rx="4" ry="6.5" />
+        </g>
+        <g className="jp-ah-petalo-caido caido-2">
+          <ellipse cx="0" cy="-56" rx="4" ry="6.5" />
+        </g>
+        {/* Hojas sueltas que caen en bucle mientras la mata sufre */}
+        <g className="jp-ah-hoja-caida hcaida-1">
+          <path d="M0,0 C-4,-4 -10,-5 -14,-1 C-11,3 -4,3 0,0 Z" />
+        </g>
+        <g className="jp-ah-hoja-caida hcaida-2">
+          <path d="M0,0 C-4,-4 -10,-5 -14,-1 C-11,3 -4,3 0,0 Z" />
+        </g>
+      </g>
+
+      {/* ── Chispas de victoria alrededor de la flor ── */}
+      <g className="jp-ah-chispas" transform="translate(118 88)">
+        {[
+          [-24, -14, 1], [20, -22, 0.8], [-10, -34, 0.7], [28, 2, 0.9], [-30, 8, 0.65], [8, -44, 0.75],
+        ].map(([x, y, s], i) => (
+          <g key={i} transform={`translate(${x} ${y}) scale(${s})`}>
+            <path
+              className={`jp-ah-chispa chispa-${i + 1}`}
+              d="M0,-6 L1.6,-1.6 L6,0 L1.6,1.6 L0,6 L-1.6,1.6 L-6,0 L-1.6,-1.6 Z"
+            />
+          </g>
+        ))}
+      </g>
+
+      {/* ── Nube de químico (entra con el primer error, crece) ── */}
+      <g className="jp-ah-nube" transform="translate(86 34)">
+        <g className="jp-ah-nube-cuerpo">
+          <ellipse cx="-26" cy="6" rx="20" ry="12" />
+          <ellipse cx="0" cy="0" rx="30" ry="15" />
+          <ellipse cx="26" cy="7" rx="22" ry="12" />
+          <ellipse cx="0" cy="10" rx="34" ry="11" />
+        </g>
+        <g className="jp-ah-gotas">
+          <g transform="translate(-18 22)"><path className="gota gota-1" d="M0,0 C3,5 3,9 0,11 C-3,9 -3,5 0,0 Z" /></g>
+          <g transform="translate(2 24)"><path className="gota gota-2" d="M0,0 C3,5 3,9 0,11 C-3,9 -3,5 0,0 Z" /></g>
+          <g transform="translate(20 22)"><path className="gota gota-3" d="M0,0 C3,5 3,9 0,11 C-3,9 -3,5 0,0 Z" /></g>
+        </g>
+      </g>
+      {/* Segunda nube (los últimos pasos: el cielo se carga) */}
+      <g className="jp-ah-nube jp-ah-nube-2" transform="translate(250 26) scale(0.75)">
+        <g className="jp-ah-nube-cuerpo">
+          <ellipse cx="-26" cy="6" rx="20" ry="12" />
+          <ellipse cx="0" cy="0" rx="30" ry="15" />
+          <ellipse cx="26" cy="7" rx="22" ry="12" />
+        </g>
+        <g className="jp-ah-gotas">
+          <g transform="translate(-12 22)"><path className="gota gota-1" d="M0,0 C3,5 3,9 0,11 C-3,9 -3,5 0,0 Z" /></g>
+          <g transform="translate(14 22)"><path className="gota gota-3" d="M0,0 C3,5 3,9 0,11 C-3,9 -3,5 0,0 Z" /></g>
+        </g>
+      </g>
+
+      {/* ── La abejita polinizadora (rubber-hose, vuela → tambalea → cae) ── */}
+      <g className="jp-ah-abeja-orbita">
+        <g className="jp-ah-abeja">
+          <g className="jp-ah-ala ala-izq">
+            <ellipse cx="-2" cy="-9" rx="4.6" ry="7" />
+          </g>
+          <g className="jp-ah-ala ala-der">
+            <ellipse cx="3" cy="-8" rx="4" ry="6" />
+          </g>
+          <ellipse className="jp-ah-abeja-cuerpo" cx="0" cy="0" rx="8.4" ry="5.8" />
+          <path className="jp-ah-franja" d="M-1,-5.6 C-2.4,-2 -2.4,2 -1,5.6 L2.4,5.4 C1,2 1,-2 2.4,-5.4 Z" />
+          <path className="jp-ah-franja" d="M4.6,-4.6 C3.6,-1.8 3.6,1.8 4.6,4.6 L7.4,3.4 C6.6,1.4 6.6,-1.4 7.4,-3.4 Z" />
+          <circle className="jp-ah-abeja-cabeza" cx="-9.6" cy="-1" r="4.4" />
+          <g className="jp-ah-antenas">
+            <path d="M-11.5,-4.5 C-13,-7 -14.5,-8 -15.5,-8.5" />
+            <circle cx="-15.8" cy="-8.8" r="1" />
+            <path d="M-9,-5 C-9.5,-8 -10.5,-9.5 -11,-10.5" />
+            <circle cx="-11.2" cy="-10.9" r="1" />
+          </g>
+          <g className="jp-ah-ojos-abiertos">
+            <ellipse cx="-11.2" cy="-1.6" rx="1.25" ry="1.8" />
+            <ellipse cx="-8.4" cy="-1.6" rx="1.25" ry="1.8" />
+            <circle className="jp-ah-pupila" cx="-11.4" cy="-1.3" r="0.55" />
+            <circle className="jp-ah-pupila" cx="-8.6" cy="-1.3" r="0.55" />
+            <path className="jp-ah-sonrisa" d="M-11.4,1.6 Q-9.9,2.8 -8.4,1.6" />
+          </g>
+          <g className="jp-ah-ojos-cerrados">
+            <path d="M-12.3,-1.4 Q-11.2,-0.3 -10.1,-1.4" />
+            <path d="M-9.5,-1.4 Q-8.4,-0.3 -7.3,-1.4" />
+          </g>
+          <g className="jp-ah-patitas">
+            <path d="M-3,5 q-1,2.5 -2.5,3" />
+            <path d="M1,5.6 q0,2.5 -1,3.2" />
+            <path d="M5,5 q1,2.5 0.5,3.4" />
+          </g>
+        </g>
+        {/* zZz: la abejita quedó desmayada (educativo, sin morbo) */}
+        <g className="jp-ah-zzz">
+          <text className="z-1" x="8" y="-14">z</text>
+          <text className="z-2" x="15" y="-22">z</text>
+          <text className="z-3" x="23" y="-30">z</text>
+        </g>
+      </g>
+
+      {/* ── Bruma final (todo perdido) ── */}
+      <rect className="jp-ah-bruma" x="0" y="0" width="360" height="200" />
+    </svg>
+  );
 }
 
 function elegirPalabra(categoriaId) {
@@ -113,17 +452,23 @@ export default function AhorcadoContaminado() {
         ))}
       </div>
 
-      {/* Escena de contaminación (metáfora en vez de horca) */}
+      {/* Escena de contaminación (metáfora en vez de horca): una chagra viva
+          que se apaga paso a paso con cada error, y revive si ganás. */}
       <div
-        className={`jp-ah-escena ${etapa.clase}`}
+        className={`jp-ah-escena ${etapa.clase} ${ganado ? 'escena-gano' : ''}`}
         data-testid="escena-contaminacion"
         aria-live="polite"
       >
-        <span className="jp-ah-escena-emoji" aria-hidden="true">{etapa.emoji}</span>
-        <p className="jp-ah-escena-texto">{etapa.texto}</p>
-        <p className="jp-ah-intentos" data-testid="contador-intentos">
-          Intentos: {errores} / {MAX_ERRORES}
+        <EscenaChagra errores={errores} ganado={ganado} perdido={perdido} />
+        <p className="jp-ah-escena-texto">
+          {ganado ? '¡La chagra revivió y está floreciendo!' : etapa.texto}
         </p>
+        <div className="jp-ah-estado-fila">
+          <MedidorSalud errores={errores} />
+          <p className="jp-ah-intentos" data-testid="contador-intentos">
+            Intentos: {errores} / {MAX_ERRORES}
+          </p>
+        </div>
       </div>
 
       {/* Palabra oculta */}

--- a/src/components/juego/AhorcadoContaminado.jsx
+++ b/src/components/juego/AhorcadoContaminado.jsx
@@ -6,11 +6,17 @@ import {
   PALABRAS,
   PALABRAS_POR_CATEGORIA,
 } from '../../data/juegos/ahorcadoContaminado';
-// La abeja REAL de la casa (Tetragonisca angustula rubber-hose, la del compai):
-// import directo del componente — NO del index (el index arrastra el registry
-// con toda la fauna al chunk del juego). El componente compartido no se toca:
-// el juego solo lo DIRIGE por props + CSS propio (prefijo jp-ah-).
+// Las creatures REALES de la casa (familia rubber-hose compartida): imports
+// directos de cada componente — NO del index (el index arrastra el registry
+// con toda la fauna al chunk del juego). Los componentes compartidos no se
+// tocan: el juego solo los DIRIGE por props + CSS propio (prefijo jp-ah-).
+// Angelita protagoniza; colibrí, mariposa pasionaria, lombriz y escarabajo
+// la acompañan como secundarias (pedido del operador) y mueren CON ella.
 import AbejaAngelita from '../../visual/creatures/AbejaAngelita.jsx';
+import { Colibri } from '../../visual/creatures/Colibri.jsx';
+import { Escarabajo } from '../../visual/creatures/Escarabajo.jsx';
+import { Mariposa } from '../../visual/creatures/Mariposa.jsx';
+import { Lombriz } from '../../visual/creatures/Lombriz.jsx';
 import './ahorcado-contaminado.css';
 
 const MAX_ERRORES = 6;
@@ -122,8 +128,9 @@ function Mariposita() {
  * squash&stretch, line-boil sutil) que se contamina un paso por cada error:
  * entra la nube de químico, la mata se marchita, el suelo se agrieta, el
  * agua se enturbia y Angelita — la abeja angelita REAL de la casa — tambalea
- * hasta caer (desmayada, sin morbo: esto es educativo). Sus compañeras
- * mariposas se apagan CON ella, no desaparecen. Al ganar, todas reviven.
+ * hasta caer (desmayada, sin morbo: esto es educativo). Sus compañeras (la
+ * abejita obrera del arte anterior y las mariposas) se apagan CON ella, no
+ * desaparecen. Al ganar, todas reviven.
  *
  * Los pasos se acumulan como clases p1..pN para que el CSS aplique cada
  * degradación de forma progresiva y con transiciones suaves.
@@ -278,6 +285,19 @@ function EscenaChagra({ errores, ganado, perdido }) {
         </g>
       ))}
 
+      {/* ── La lombriz nativa (Lombriz REAL de la casa, Martiodrilus) ──
+          Secundaria de SUELO: asoma del suelo fértil con overshoot (su
+          entrada), se mece sana; cuando el suelo se agrieta (p3) palidece y
+          se retrae, y en p6 queda lánguida sobre la tierra muerta. Su
+          movimiento es de la escena (la creature no trae idle propio). */}
+      <g transform="translate(16 172)">
+        <g className="jp-ah-lombriz-marco">
+          <g className="jp-ah-lombriz-cuerpo" transform="scale(0.38)">
+            <Lombriz inline animated />
+          </g>
+        </g>
+      </g>
+
       {/* ── Surco de brotecitos: la chagra es parcela cultivada ── */}
       {[
         [24, 160], [52, 166], [80, 172], [108, 178],
@@ -375,6 +395,17 @@ function EscenaChagra({ errores, ganado, perdido }) {
         </g>
       </g>
 
+      {/* ── El escarabajo estercolero (Escarabajo REAL, Dichotomius belus) ──
+          Secundaria de SUELO: entra rodando su bola de abono desde el borde
+          (su entrada) y patrulla el primer plano. El suelo agrietado (p3) lo
+          arrastra, y en p6 queda volcado, quieto y gris — el suelo sin vida
+          no tiene abono que rodar. Espejado: empuja la bola hacia adelante. */}
+      <g className="jp-ah-escarabajo-orbita">
+        <g className="jp-ah-escarabajo-marco" transform="scale(-0.75 0.75)">
+          <Escarabajo inline animated />
+        </g>
+      </g>
+
       {/* ── Chispas de victoria alrededor de la flor ── */}
       <g className="jp-ah-chispas" transform="translate(118 88)">
         {[
@@ -446,6 +477,67 @@ function EscenaChagra({ errores, ganado, perdido }) {
         </g>
       </g>
 
+      {/* ── El colibrí chillón (Colibri REAL de la casa, hermano del kit) ──
+          Secundaria de AIRE: entra DARDEANDO desde fuera de cuadro con
+          anticipación y overshoot (la entrada espectacular de la familia) y
+          se cierne sobre la flor de la mata. Recibe la MISMA dirección de
+          actuación que Angelita (pose/animo/energia): se apaga con ella y en
+          p6 cae al pie de la mata, al otro lado de su amiga — los dos
+          polinizadores juntos. Al ganar re-entra celebrando. */}
+      <g className="jp-ah-colibri-orbita">
+        <g className="jp-ah-colibri-marco" transform="scale(0.8)">
+          <Colibri
+            inline
+            animated
+            pose={angelita.pose}
+            animo={angelita.animo}
+            energia={angelita.energia}
+          />
+        </g>
+      </g>
+
+      {/* ── La abejita obrera (la abeja del arte anterior) ──
+          Pedido del operador: NO se saca — queda como SECUNDARIA de Angelita.
+          Vuela al otro lado de la chagra (sobre el agua) y muere CON la
+          protagonista: aleteo pesado → tambaleo → cae desmayada a la orilla
+          (ojitos cerrados, alitas plegadas). Revive con todas al ganar. */}
+      <g className="jp-ah-abeja2-orbita">
+        <g className="jp-ah-abeja2">
+          <g className="jp-ah-ala ala-izq">
+            <ellipse cx="-2" cy="-9" rx="4.6" ry="7" />
+          </g>
+          <g className="jp-ah-ala ala-der">
+            <ellipse cx="3" cy="-8" rx="4" ry="6" />
+          </g>
+          <ellipse className="jp-ah-abeja-cuerpo" cx="0" cy="0" rx="8.4" ry="5.8" />
+          <path className="jp-ah-franja" d="M-1,-5.6 C-2.4,-2 -2.4,2 -1,5.6 L2.4,5.4 C1,2 1,-2 2.4,-5.4 Z" />
+          <path className="jp-ah-franja" d="M4.6,-4.6 C3.6,-1.8 3.6,1.8 4.6,4.6 L7.4,3.4 C6.6,1.4 6.6,-1.4 7.4,-3.4 Z" />
+          <circle className="jp-ah-abeja-cabeza" cx="-9.6" cy="-1" r="4.4" />
+          <g className="jp-ah-antenas">
+            <path d="M-11.5,-4.5 C-13,-7 -14.5,-8 -15.5,-8.5" />
+            <circle cx="-15.8" cy="-8.8" r="1" />
+            <path d="M-9,-5 C-9.5,-8 -10.5,-9.5 -11,-10.5" />
+            <circle cx="-11.2" cy="-10.9" r="1" />
+          </g>
+          <g className="jp-ah-ojos-abiertos">
+            <ellipse cx="-11.2" cy="-1.6" rx="1.25" ry="1.8" />
+            <ellipse cx="-8.4" cy="-1.6" rx="1.25" ry="1.8" />
+            <circle className="jp-ah-pupila" cx="-11.4" cy="-1.3" r="0.55" />
+            <circle className="jp-ah-pupila" cx="-8.6" cy="-1.3" r="0.55" />
+            <path className="jp-ah-sonrisa" d="M-11.4,1.6 Q-9.9,2.8 -8.4,1.6" />
+          </g>
+          <g className="jp-ah-ojos-cerrados">
+            <path d="M-12.3,-1.4 Q-11.2,-0.3 -10.1,-1.4" />
+            <path d="M-9.5,-1.4 Q-8.4,-0.3 -7.3,-1.4" />
+          </g>
+          <g className="jp-ah-patitas">
+            <path d="M-3,5 q-1,2.5 -2.5,3" />
+            <path d="M1,5.6 q0,2.5 -1,3.2" />
+            <path d="M5,5 q1,2.5 0.5,3.4" />
+          </g>
+        </g>
+      </g>
+
       {/* ── Mariposas: secundarias que acompañan a Angelita — el químico ya no
           las espanta fuera de escena: se van apagando CON ella (aleteo pesado
           → tambaleo → caen marchitas al suelo) y reviven juntas al ganar. ── */}
@@ -455,6 +547,17 @@ function EscenaChagra({ errores, ganado, perdido }) {
       <g className="jp-ah-mariposa-orbita mariposa-orbita-2">
         <g transform="scale(0.68)">
           <Mariposita />
+        </g>
+      </g>
+
+      {/* ── La mariposa pasionaria (Mariposa REAL de la casa, Dione juno) ──
+          La mariposa adicional que pidió el operador: la creature canónica
+          del kit (cuatro alas independientes, ocelos). Aletea alto sobre el
+          surco, se destiñe y tambalea con la contaminación, y en p6 cae
+          plegada junto a sus compañeras. Revive con todas al ganar. */}
+      <g className="jp-ah-dione-orbita">
+        <g className="jp-ah-dione-marco" transform="scale(0.5)">
+          <Mariposa inline animated />
         </g>
       </g>
 

--- a/src/components/juego/AhorcadoContaminado.jsx
+++ b/src/components/juego/AhorcadoContaminado.jsx
@@ -33,7 +33,7 @@ const ETAPAS_CONTAMINACION = [
   { clase: 'paso-3', texto: 'El suelo fértil se agrieta y pierde su vida.' },
   { clase: 'paso-4', texto: 'El agua de riego se enturbió: ya no está limpia.' },
   { clase: 'paso-5', texto: 'Angelita, la abejita polinizadora, tambalea: casi no puede volar.' },
-  { clase: 'paso-6', texto: 'La chagra quedó contaminada. Angelita y sus amigas no pudieron más.' },
+  { clase: 'paso-6', texto: 'La chagra quedó contaminada. Angelita cayó y las mariposas huyeron.' },
 ];
 
 function normalizar(letra) {
@@ -99,9 +99,10 @@ function actuacionAngelita(errores, ganado, perdido) {
 
 /**
  * Mariposita — secundaria de la escena (dibujo propio del juego, a escala del
- * paisaje). Secundaria pero NO desechable: ya no huye del químico — acompaña
- * a Angelita en la degradación (aleteo pesado → tambaleo → cae marchita) y
- * revive con ella al ganar. La coreografía completa vive en el CSS (jp-ah-).
+ * paisaje). Corrección del operador: "que la una mariposa muera, el resto
+ * huyen". La mariposa que MUERE es la Dione (la grande, más abajo); estas dos
+ * chiquitas son "el resto" → al ver caer a su compañera HUYEN de la escena
+ * (se asustan y se van de cuadro). Reviven al ganar. Coreografía en el CSS.
  */
 function Mariposita() {
   return (
@@ -128,9 +129,10 @@ function Mariposita() {
  * squash&stretch, line-boil sutil) que se contamina un paso por cada error:
  * entra la nube de químico, la mata se marchita, el suelo se agrieta, el
  * agua se enturbia y Angelita — la abeja angelita REAL de la casa — tambalea
- * hasta caer (desmayada, sin morbo: esto es educativo). Sus compañeras (la
- * abejita obrera del arte anterior y las mariposas) se apagan CON ella, no
- * desaparecen. Al ganar, todas reviven.
+ * hasta caer (desmayada, sin morbo: esto es educativo). La acompañan la
+ * abejita obrera y el colibrí (que caen CON ella) y las mariposas: UNA muere
+ * (la Dione cae) y las otras dos, al verla caer, HUYEN de la escena
+ * (corrección del operador). Al ganar, todas reviven y re-entran.
  *
  * Los pasos se acumulan como clases p1..pN para que el CSS aplique cada
  * degradación de forma progresiva y con transiciones suaves.
@@ -538,9 +540,11 @@ function EscenaChagra({ errores, ganado, perdido }) {
         </g>
       </g>
 
-      {/* ── Mariposas: secundarias que acompañan a Angelita — el químico ya no
-          las espanta fuera de escena: se van apagando CON ella (aleteo pesado
-          → tambaleo → caen marchitas al suelo) y reviven juntas al ganar. ── */}
+      {/* ── Mariposas chiquitas: "el resto" que HUYE (corrección del operador
+          "que la una mariposa muera, el resto huyen"). Cuando la Dione (abajo)
+          cae por la contaminación, estas dos se asustan y se van de cuadro
+          (aleteo nervioso → escapan volando fuera de la escena). Reviven y
+          re-entran al ganar. ── */}
       <g className="jp-ah-mariposa-orbita">
         <Mariposita />
       </g>
@@ -551,10 +555,11 @@ function EscenaChagra({ errores, ganado, perdido }) {
       </g>
 
       {/* ── La mariposa pasionaria (Mariposa REAL de la casa, Dione juno) ──
-          La mariposa adicional que pidió el operador: la creature canónica
+          LA mariposa que MUERE (corrección del operador): la creature canónica
           del kit (cuatro alas independientes, ocelos). Aletea alto sobre el
-          surco, se destiñe y tambalea con la contaminación, y en p6 cae
-          plegada junto a sus compañeras. Revive con todas al ganar. */}
+          surco, se destiñe y tambalea con la contaminación, y en p6 CAE
+          plegada al suelo — su caída es la que espanta al resto. Revive al
+          ganar. */}
       <g className="jp-ah-dione-orbita">
         <g className="jp-ah-dione-marco" transform="scale(0.5)">
           <Mariposa inline animated />

--- a/src/components/juego/ahorcado-contaminado.css
+++ b/src/components/juego/ahorcado-contaminado.css
@@ -274,7 +274,7 @@
 
 .jp-ah-niebla {
   fill: #ffffff;
-  opacity: 0.2;
+  opacity: 0.14;
 }
 
 .jp-ah-frailejon rect,
@@ -282,6 +282,40 @@
   fill: var(--frailejon);
   transition: fill 1.4s ease;
 }
+
+.jp-ah-frailejon-flor {
+  fill: #f4c945;
+  stroke: #c99a1e;
+  stroke-width: 0.7;
+  transition: fill 1.4s ease, opacity 1.4s ease;
+}
+
+.jp-ah-vivo.p5:not(.gano) .jp-ah-frailejon-flor { fill: #8f8a76; opacity: 0.5; }
+
+/* ── Nubes blancas amigables (huyen del químico) ── */
+
+.jp-ah-nube-blanca-forma ellipse {
+  fill: #ffffff;
+  opacity: 0.85;
+}
+
+.jp-ah-nube-blanca {
+  transition: opacity 1.4s ease;
+}
+
+.jp-ah-nube-blanca-forma {
+  animation: jp-ah-nube-blanca-deriva 9s ease-in-out infinite alternate;
+}
+
+.nube-blanca-2 .jp-ah-nube-blanca-forma { animation-delay: -4.5s; }
+
+@keyframes jp-ah-nube-blanca-deriva {
+  from { transform: translateX(-5px); }
+  to { transform: translateX(5px); }
+}
+
+.jp-ah-vivo.p1:not(.gano) .jp-ah-nube-blanca { opacity: 0.5; }
+.jp-ah-vivo.p3:not(.gano) .jp-ah-nube-blanca { opacity: 0; }
 
 .jp-ah-vivo.p3:not(.gano) { --montana-cerca: #87906f; }
 .jp-ah-vivo.p5:not(.gano) {
@@ -400,6 +434,41 @@
 .jp-ah-vivo.p3:not(.gano) .jp-ah-pasto path { animation: none; transform: rotate(-28deg); }
 .jp-ah-vivo.p5:not(.gano) { --pasto: #8a7a52; }
 .jp-ah-vivo.p5:not(.gano) .jp-ah-pasto path { transform: rotate(-52deg); }
+
+/* ── Surco de brotecitos (parcela cultivada) ── */
+
+.jp-ah-brote {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  transition: transform 1.2s ease, opacity 1.2s ease;
+}
+
+.jp-ah-brote-tallo {
+  fill: none;
+  stroke: var(--tallo);
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  transition: stroke 1.4s ease;
+}
+
+.jp-ah-brote-hoja {
+  fill: var(--hoja);
+  transition: fill 1.4s ease;
+}
+
+.jp-ah-vivo.p2:not(.gano) .jp-ah-brote { transform: rotate(-16deg) scale(0.94); }
+.jp-ah-vivo.p3:not(.gano) .jp-ah-brote { transform: rotate(-34deg) scale(0.8); }
+.jp-ah-vivo.p5:not(.gano) .jp-ah-brote { transform: rotate(-58deg) scale(0.66); opacity: 0.75; }
+
+/* ── Sombra de la mata (ancla al suelo, da profundidad) ── */
+
+.jp-ah-mata-sombra {
+  fill: #1d130b;
+  opacity: 0.16;
+  transition: opacity 1.4s ease;
+}
+
+.jp-ah-vivo.p5:not(.gano) .jp-ah-mata-sombra { opacity: 0.08; }
 
 /* ── La mata protagonista ──
  * Respira (squash&stretch con volumen preservado). El doblez por
@@ -834,6 +903,65 @@
 /* Celebración al ganar: vuelo alegre más vivo */
 .jp-ah-vivo.gano .jp-ah-abeja-orbita { animation-duration: 5s; }
 
+/* ── La mariposa: compañera de la abeja; el químico la espanta ── */
+
+.jp-ah-mariposa-orbita {
+  animation: jp-ah-mariposeo 11s ease-in-out infinite;
+  transition: opacity 2s ease;
+}
+
+@keyframes jp-ah-mariposeo {
+  0%, 100% { transform: translate(288px, 92px) rotate(6deg); }
+  20% { transform: translate(258px, 74px) rotate(-8deg); }
+  45% { transform: translate(300px, 62px) rotate(5deg); }
+  70% { transform: translate(322px, 88px) rotate(-6deg); }
+  85% { transform: translate(300px, 102px) rotate(4deg); }
+}
+
+.jp-ah-mariposa {
+  animation: jp-ah-abeja-bob 1.1s ease-in-out infinite alternate;
+}
+
+.jp-ah-mariposa-cuerpo { fill: #4a3524; }
+
+.jp-ah-mariposa-antena {
+  fill: none;
+  stroke: #4a3524;
+  stroke-width: 0.7;
+  stroke-linecap: round;
+}
+
+.jp-ah-mariposa-ala path {
+  fill: #f6a34c;
+  stroke: #c86f1d;
+  stroke-width: 0.8;
+}
+
+.jp-ah-mariposa-ala circle { fill: #fde68a; }
+
+.jp-ah-mariposa-ala {
+  transform-box: fill-box;
+  animation: jp-ah-mariposa-aleteo 0.34s ease-in-out infinite alternate;
+}
+
+.jp-ah-mariposa-ala.ala-m-izq { transform-origin: right center; }
+.jp-ah-mariposa-ala.ala-m-der { transform-origin: left center; animation-direction: alternate-reverse; }
+
+@keyframes jp-ah-mariposa-aleteo {
+  from { transform: scaleX(1); }
+  to { transform: scaleX(0.3); }
+}
+
+/* Con el segundo error la mariposa se ALEJA de la chagra (huye del químico) */
+.jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-orbita {
+  animation: jp-ah-mariposa-huye 2.6s ease-in both;
+}
+
+@keyframes jp-ah-mariposa-huye {
+  0% { transform: translate(288px, 92px) rotate(6deg); opacity: 1; }
+  100% { transform: translate(392px, 30px) rotate(-14deg); opacity: 0; }
+}
+
 /* ── Chispas + florecitas de victoria ── */
 
 .jp-ah-chispa {
@@ -860,10 +988,12 @@
   50% { opacity: 1; transform: scale(1.15) rotate(24deg); }
 }
 
+/* Las florecitas silvestres VIVEN en la chagra sana, se marchitan con la
+   contaminación y re-brotan con overshoot al ganar. */
 .jp-ah-flor-extra {
   transform-box: fill-box;
   transform-origin: bottom center;
-  transform: scale(0);
+  transition: transform 1.2s ease, opacity 1.2s ease;
 }
 
 .jp-ah-flor-extra-tallo {
@@ -871,10 +1001,30 @@
   stroke: #3f8f4f;
   stroke-width: 1.2;
   stroke-linecap: round;
+  transition: stroke 1.4s ease;
 }
 
-.jp-ah-flor-extra-petalo { fill: #fbd0e0; stroke: #e78fb3; stroke-width: 0.5; }
-.jp-ah-flor-extra-centro { fill: #f4b31c; }
+.jp-ah-flor-extra-petalo {
+  fill: #fbd0e0;
+  stroke: #e78fb3;
+  stroke-width: 0.5;
+  transition: fill 1.4s ease, stroke 1.4s ease;
+}
+
+.jp-ah-flor-extra-centro { fill: #f4b31c; transition: fill 1.4s ease; }
+
+.jp-ah-vivo.p2:not(.gano) .jp-ah-flor-extra {
+  transform: scale(0.7) rotate(-24deg);
+}
+
+.jp-ah-vivo.p2:not(.gano) .jp-ah-flor-extra-petalo { fill: #cbb3ba; stroke: #a98f96; }
+.jp-ah-vivo.p2:not(.gano) .jp-ah-flor-extra-centro { fill: #b09a6a; }
+.jp-ah-vivo.p2:not(.gano) .jp-ah-flor-extra-tallo { stroke: #8f9257; }
+
+.jp-ah-vivo.p3:not(.gano) .jp-ah-flor-extra {
+  transform: scale(0.45) rotate(-48deg);
+  opacity: 0;
+}
 
 .jp-ah-vivo.gano .jp-ah-flor-extra {
   animation: jp-ah-brotar 0.9s cubic-bezier(0.34, 1.56, 0.64, 1) both;
@@ -898,8 +1048,10 @@
     transition: none !important;
   }
 
-  /* La órbita animada posicionaba a la abeja: sin animación queda en (0,0),
-     así que la plantamos en un punto legible por estado. */
+  /* Las órbitas animadas posicionaban abeja y mariposa: sin animación quedan
+     en (0,0), así que las plantamos en un punto legible por estado. */
+  .jp-ah-mariposa-orbita { transform: translate(288px, 80px); }
+  .jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-orbita { opacity: 0; }
   .jp-ah-abeja-orbita { transform: translate(200px, 80px); }
   .jp-ah-vivo.p3:not(.gano) .jp-ah-abeja-orbita { transform: translate(185px, 105px); }
   .jp-ah-vivo.p5:not(.gano) .jp-ah-abeja-orbita { transform: translate(180px, 128px) rotate(-16deg); }

--- a/src/components/juego/ahorcado-contaminado.css
+++ b/src/components/juego/ahorcado-contaminado.css
@@ -1101,9 +1101,11 @@
 
 .jp-ah-vivo.p6:not(.gano) .jp-ah-colibri-marco .rh-mirada { animation: none; }
 
-/* ── La mariposa pasionaria: la adicional (Mariposa REAL del kit) ──
- * Aletea alto sobre el surco con sus cuatro alas independientes; se destiñe
- * (saturate progresivo), tambalea y cae plegada junto a sus compañeras. */
+/* ── La mariposa pasionaria: LA QUE MUERE (Mariposa REAL del kit) ──
+ * Corrección del operador "que la una mariposa muera": ESTA es la que muere.
+ * Aletea alto sobre el surco con sus cuatro alas; se destiñe (saturate
+ * progresivo), tambalea y CAE plegada al suelo — su caída es la que hace
+ * huir a las chiquitas. Revive al ganar. */
 
 .jp-ah-dione-orbita {
   animation:
@@ -1248,11 +1250,12 @@
   filter: grayscale(0.7) brightness(0.9);
 }
 
-/* ── Las mariposas: secundarias que acompañan a Angelita ──
- * Corrección del operador: NO se sacan y NO huyen de escena — el químico
- * también las mata. Se apagan CON la protagonista, por grados: aleteo
- * pesado y vuelo bajo (p2) → tambaleo (p4) → caen marchitas al suelo (p6).
- * Todo con :not(.gano): al ganar reviven solas con la escena. */
+/* ── Las mariposas chiquitas: "EL RESTO" que HUYE ──
+ * Corrección del operador: "que la una mariposa muera, el resto huyen". La que
+ * muere es la Dione (más arriba, cae al suelo en p6). ESTAS dos son el resto:
+ * revolotean sanas → con la contaminación se ponen nerviosas y se alejan (p2)
+ * → al ver caer a su compañera ESCAPAN fuera de cuadro (p6). No caen: huyen.
+ * Todo con :not(.gano): al ganar re-entran volando con la escena revivida. */
 
 .jp-ah-mariposa-orbita {
   animation: jp-ah-mariposeo 11s ease-in-out infinite;
@@ -1315,104 +1318,91 @@
   to { transform: scaleX(0.3); }
 }
 
-/* p2: el aleteo se hace PESADO y vuelan más bajo, cerca de la chagra que
-   sufre. El color de las alas empieza a apagarse (variables en transición). */
+/* p2: los colores se empiezan a apagar; siguen revoloteando pero más nerviosas
+   (aleteo un poco más rápido) — ya sienten el químico. */
 .jp-ah-vivo.p2:not(.gano) {
   --mar-ala: #dda45c;
   --mar-ala-borde: #a9722e;
 }
 
 .jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-orbita {
-  animation: jp-ah-mariposa-pesada 7s ease-in-out infinite;
+  animation: jp-ah-mariposa-nerviosa 6s ease-in-out infinite;
 }
 
 .jp-ah-vivo.p2:not(.gano) .mariposa-orbita-2 {
-  animation: jp-ah-mariposa-pesada-2 8s ease-in-out infinite;
+  animation: jp-ah-mariposa-nerviosa-2 6.5s ease-in-out infinite;
 }
 
-.jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-ala { animation-duration: 0.6s; }
+.jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-ala { animation-duration: 0.24s; }
 
-@keyframes jp-ah-mariposa-pesada {
-  0%, 100% { transform: translate(282px, 108px) rotate(4deg); }
-  30% { transform: translate(258px, 96px) rotate(-7deg); }
-  60% { transform: translate(300px, 116px) rotate(6deg); }
-  80% { transform: translate(272px, 122px) rotate(-4deg); }
+@keyframes jp-ah-mariposa-nerviosa {
+  0%, 100% { transform: translate(288px, 78px) rotate(6deg); }
+  25% { transform: translate(316px, 60px) rotate(-9deg); }
+  55% { transform: translate(300px, 52px) rotate(7deg); }
+  80% { transform: translate(322px, 70px) rotate(-6deg); }
 }
 
-@keyframes jp-ah-mariposa-pesada-2 {
-  0%, 100% { transform: translate(70px, 92px) rotate(5deg); }
-  35% { transform: translate(92px, 104px) rotate(-6deg); }
-  70% { transform: translate(58px, 112px) rotate(4deg); }
+@keyframes jp-ah-mariposa-nerviosa-2 {
+  0%, 100% { transform: translate(58px, 58px) rotate(-5deg); }
+  30% { transform: translate(40px, 44px) rotate(9deg); }
+  65% { transform: translate(70px, 50px) rotate(-7deg); }
 }
 
-/* p4: tambalean — el mismo lenguaje del tambaleo de Angelita (p5),
-   anticipándolo: las chiquitas caen primero que la protagonista. */
+/* p4: se alejan hacia los bordes (empiezan a huir), aleteo agitado. Suben y
+   se apartan de la chagra que se apaga — todavía dentro de cuadro. */
 .jp-ah-vivo.p4:not(.gano) {
-  --mar-ala: #bd9464;
-  --mar-ala-borde: #8a6a42;
-  --mar-mota: #dccda6;
+  --mar-ala: #cf9a58;
+  --mar-ala-borde: #9c6c34;
 }
 
 .jp-ah-vivo.p4:not(.gano) .jp-ah-mariposa-orbita {
-  animation: jp-ah-mariposa-tambalea 3.6s ease-in-out infinite;
+  animation: jp-ah-mariposa-aleja 4s ease-in-out infinite;
 }
 
 .jp-ah-vivo.p4:not(.gano) .mariposa-orbita-2 {
-  animation: jp-ah-mariposa-tambalea-2 3.2s ease-in-out infinite;
+  animation: jp-ah-mariposa-aleja-2 4.4s ease-in-out infinite;
 }
 
-.jp-ah-vivo.p4:not(.gano) .jp-ah-mariposa-ala { animation-duration: 0.95s; }
+.jp-ah-vivo.p4:not(.gano) .jp-ah-mariposa-ala { animation-duration: 0.2s; }
 
-@keyframes jp-ah-mariposa-tambalea {
-  0%, 100% { transform: translate(266px, 128px) rotate(-12deg); }
-  25% { transform: translate(280px, 140px) rotate(14deg); }
-  55% { transform: translate(254px, 146px) rotate(-16deg); }
-  80% { transform: translate(272px, 136px) rotate(10deg); }
+@keyframes jp-ah-mariposa-aleja {
+  0%, 100% { transform: translate(328px, 46px) rotate(-10deg); }
+  40% { transform: translate(342px, 30px) rotate(12deg); }
+  70% { transform: translate(320px, 38px) rotate(-8deg); }
 }
 
-@keyframes jp-ah-mariposa-tambalea-2 {
-  0%, 100% { transform: translate(76px, 118px) rotate(10deg); }
-  30% { transform: translate(62px, 132px) rotate(-14deg); }
-  65% { transform: translate(88px, 138px) rotate(12deg); }
+@keyframes jp-ah-mariposa-aleja-2 {
+  0%, 100% { transform: translate(34px, 40px) rotate(8deg); }
+  45% { transform: translate(20px, 26px) rotate(-11deg); }
+  75% { transform: translate(42px, 34px) rotate(9deg); }
 }
 
-/* p6: caen marchitas al suelo — de costado, alitas plegadas, quietas y
-   desteñidas. NO desaparecen: quedan en la chagra apagada, acompañando a
-   Angelita hasta el final (o hasta que el jugador gane y revivan todas). */
+/* p6: al caer la Dione (su compañera), ESCAPAN de la escena — se van volando
+   fuera de cuadro por lados opuestos, encogiéndose y desvaneciéndose. NO
+   caen: huyen. Al ganar re-entran (la animación base vuelve, :not(.gano)). */
 .jp-ah-vivo.p6:not(.gano) {
-  --mar-ala: #a08e77;
-  --mar-ala-borde: #6f6152;
-  --mar-mota: #b3a992;
-  --mar-cuerpo: #55483a;
+  --mar-ala: #cf9a58;
+  --mar-ala-borde: #9c6c34;
 }
 
 .jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-orbita {
-  animation: jp-ah-mariposa-cae 1.5s cubic-bezier(0.4, 0, 1, 1) both;
+  animation: jp-ah-mariposa-huye 1.6s ease-in both;
 }
 
 .jp-ah-vivo.p6:not(.gano) .mariposa-orbita-2 {
-  animation: jp-ah-mariposa-cae-2 1.7s cubic-bezier(0.4, 0, 1, 1) 0.25s both;
+  animation: jp-ah-mariposa-huye-2 1.8s ease-in 0.2s both;
 }
 
-.jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa { animation: none; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-ala { animation-duration: 0.18s; }
 
-.jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-ala {
-  animation: none;
-  transform: scaleX(0.2);
+@keyframes jp-ah-mariposa-huye {
+  0% { transform: translate(328px, 46px) rotate(-10deg) scale(1); opacity: 1; }
+  100% { transform: translate(404px, -32px) rotate(28deg) scale(0.4); opacity: 0; }
 }
 
-@keyframes jp-ah-mariposa-cae {
-  0% { transform: translate(258px, 140px) rotate(-10deg); }
-  60% { transform: translate(232px, 168px) rotate(52deg); }
-  76% { transform: translate(228px, 163px) rotate(62deg); }
-  100% { transform: translate(226px, 170px) rotate(74deg); }
-}
-
-@keyframes jp-ah-mariposa-cae-2 {
-  0% { transform: translate(78px, 130px) rotate(8deg); }
-  62% { transform: translate(64px, 170px) rotate(-48deg); }
-  78% { transform: translate(62px, 165px) rotate(-58deg); }
-  100% { transform: translate(60px, 172px) rotate(-68deg); }
+@keyframes jp-ah-mariposa-huye-2 {
+  0% { transform: translate(34px, 40px) rotate(8deg) scale(1); opacity: 1; }
+  100% { transform: translate(-52px, -28px) rotate(-30deg) scale(0.4); opacity: 0; }
 }
 
 /* ── Chispas + florecitas de victoria ── */
@@ -1503,17 +1493,16 @@
 
   /* Las órbitas animadas posicionaban a Angelita y las mariposas: sin
      animación quedan en (0,0), así que las plantamos en un punto legible por
-     estado. Las mariposas NO desaparecen: bajan y terminan caídas de costado
-     junto a la protagonista (mismo guion que con movimiento). */
+     estado. Las mariposas chiquitas son "el resto que huye": en p4 ya están en
+     los bordes y en p6 quedan FUERA de cuadro (opacity 0) — huyeron. */
   .jp-ah-mariposa-orbita { transform: translate(288px, 80px); }
   .mariposa-orbita-2 { transform: translate(84px, 64px); }
-  .jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-orbita { transform: translate(276px, 108px); }
-  .jp-ah-vivo.p2:not(.gano) .mariposa-orbita-2 { transform: translate(76px, 100px); }
-  .jp-ah-vivo.p4:not(.gano) .jp-ah-mariposa-orbita { transform: translate(266px, 136px) rotate(-10deg); }
-  .jp-ah-vivo.p4:not(.gano) .mariposa-orbita-2 { transform: translate(74px, 126px) rotate(8deg); }
-  .jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-orbita { transform: translate(226px, 170px) rotate(74deg); }
-  .jp-ah-vivo.p6:not(.gano) .mariposa-orbita-2 { transform: translate(60px, 172px) rotate(-68deg); }
-  .jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-ala { transform: scaleX(0.2); }
+  .jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-orbita { transform: translate(308px, 64px); }
+  .jp-ah-vivo.p2:not(.gano) .mariposa-orbita-2 { transform: translate(52px, 50px); }
+  .jp-ah-vivo.p4:not(.gano) .jp-ah-mariposa-orbita { transform: translate(332px, 36px) rotate(-10deg); }
+  .jp-ah-vivo.p4:not(.gano) .mariposa-orbita-2 { transform: translate(28px, 32px) rotate(8deg); }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-orbita { opacity: 0; }
+  .jp-ah-vivo.p6:not(.gano) .mariposa-orbita-2 { opacity: 0; }
   .jp-ah-abeja2-orbita { transform: translate(300px, 88px) scale(0.8); }
   .jp-ah-vivo.p2:not(.gano) .jp-ah-abeja2-orbita { transform: translate(290px, 112px) scale(0.8); }
   .jp-ah-vivo.p4:not(.gano) .jp-ah-abeja2-orbita { transform: translate(288px, 136px) rotate(-14deg) scale(0.8); }

--- a/src/components/juego/ahorcado-contaminado.css
+++ b/src/components/juego/ahorcado-contaminado.css
@@ -195,6 +195,12 @@
   --nube-y: -52px;
   --nube-x: 0px;
   --mata-doblez: 0deg;
+  /* Mariposas secundarias: sus colores viven en variables para que la
+     degradación (p2/p4/p6) las vaya apagando en transición, no de golpe. */
+  --mar-ala: #f6a34c;
+  --mar-ala-borde: #c86f1d;
+  --mar-mota: #fde68a;
+  --mar-cuerpo: #4a3524;
 }
 
 /* ── Cielo: crossfade sano → tóxico ── */
@@ -730,9 +736,13 @@
 
 .jp-ah-vivo.p6:not(.gano) .jp-ah-bruma { opacity: 0.2; }
 
-/* ── La abejita polinizadora ──
- * Órbita (trayectoria) en el grupo padre; aleteo, squash y expresión en los
- * hijos. Estados: feliz → preocupada → tambaleo → desmayada (sin morbo). */
+/* ── Angelita, la protagonista (AbejaAngelita REAL en modo inline) ──
+ * La ÓRBITA (trayectoria) vive en los wrappers del juego; el dibujo y su
+ * actuación (aleteo crt-wing, parpadeo rh-blink, antics rh-*, jadeo, cejas)
+ * son del componente compartido src/visual/creatures/AbejaAngelita — que NO
+ * se modifica: el juego solo lo dirige por props (pose/animo/energia/sed) y
+ * con estas riendas CSS de alcance jp-ah-. Estados: feliz → preocupada →
+ * tambaleo → desmayada (sin morbo). */
 
 .jp-ah-abeja-orbita {
   animation: jp-ah-vuelo-feliz 9s ease-in-out infinite;
@@ -755,69 +765,11 @@
   to { transform: translateY(2.5px); }
 }
 
-.jp-ah-abeja-cuerpo {
-  fill: #ffd23e;
-  stroke: #3a2c1a;
-  stroke-width: 1.3;
-  transition: fill 1.4s ease;
-}
-
-.jp-ah-franja { fill: #3a2c1a; }
-
-.jp-ah-abeja-cabeza {
-  fill: #3a2c1a;
-}
-
-.jp-ah-antenas path {
-  fill: none;
-  stroke: #3a2c1a;
-  stroke-width: 1.1;
-  stroke-linecap: round;
-  transform-box: fill-box;
-  transform-origin: bottom right;
-  transition: transform 1s ease;
-}
-
-.jp-ah-antenas circle { fill: #3a2c1a; }
-
-.jp-ah-ala ellipse {
-  fill: rgba(219, 234, 254, 0.8);
-  stroke: #93c5fd;
-  stroke-width: 0.9;
-}
-
-.jp-ah-ala {
-  transform-box: fill-box;
-  transform-origin: center bottom;
-  animation: jp-ah-aleteo 0.16s linear infinite alternate;
-  transition: transform 1s ease;
-}
-
-.jp-ah-ala.ala-der { animation-delay: -0.08s; }
-
-@keyframes jp-ah-aleteo {
-  from { transform: scaleY(1) rotate(-4deg); }
-  to { transform: scaleY(0.4) rotate(6deg); }
-}
-
-.jp-ah-ojos-abiertos ellipse { fill: #ffffff; }
-.jp-ah-ojos-abiertos .jp-ah-pupila { fill: #1c140c; }
-
-.jp-ah-sonrisa,
-.jp-ah-ojos-cerrados path {
-  fill: none;
-  stroke: #ffffff;
-  stroke-width: 0.8;
-  stroke-linecap: round;
-}
-
-.jp-ah-ojos-cerrados { opacity: 0; }
-
-.jp-ah-patitas path {
-  fill: none;
-  stroke: #3a2c1a;
-  stroke-width: 1;
-  stroke-linecap: round;
+/* El marco de Angelita: solo transiciona el FILTRO (el gris del desmayo
+   entra suave). Su transform (escala + espejo) va como atributo en el JSX y
+   este nodo no lleva animaciones CSS — nada se lo pisa. */
+.jp-ah-angelita {
+  transition: filter 1.4s ease;
 }
 
 .jp-ah-zzz { opacity: 0; }
@@ -829,7 +781,7 @@
   fill: #cbd5e1;
 }
 
-/* Estados de la abeja por paso */
+/* Estados de Angelita por paso */
 .jp-ah-vivo.p3:not(.gano) .jp-ah-abeja-orbita {
   animation: jp-ah-vuelo-preocupado 6s ease-in-out infinite;
 }
@@ -844,7 +796,10 @@
   animation: jp-ah-tambaleo 3s ease-in-out infinite;
 }
 
-.jp-ah-vivo.p5:not(.gano) .jp-ah-ala { animation-duration: 0.34s; }
+/* Alas de tul PESADAS: el aleteo del kit (crt-wingbeat 0.15s) se arrastra —
+   casi no puede volar. Sin clima en props, el componente no estampa duración
+   inline: esta rienda CSS manda. */
+.jp-ah-vivo.p5:not(.gano) .jp-ah-angelita .crt-wing { animation-duration: 0.42s; }
 
 @keyframes jp-ah-tambaleo {
   0%, 100% { transform: translate(182px, 116px) rotate(-16deg); }
@@ -875,16 +830,21 @@
   to { transform: scale(1.03, 0.97); }
 }
 
-.jp-ah-vivo.p6:not(.gano) .jp-ah-ala {
-  animation: none;
-  transform: scaleY(0.5) rotate(48deg);
-  opacity: 0.7;
+/* Desmayada: React ya la puso en pose reposo (alitas plegadas del kit) y
+   ánimo descansa (sin antics ni miradas). Aquí el juego le cierra los OJITOS
+   aplastando el grupo rh-blink del componente (su transform-box/origin ya
+   vienen inline del kit) y la destiñe con un gris suave que entra en
+   transición — dormida digna, sin morbo. */
+.jp-ah-vivo.p6:not(.gano) .jp-ah-angelita {
+  filter: grayscale(0.55) brightness(0.92);
 }
 
-.jp-ah-vivo.p6:not(.gano) .jp-ah-antenas path { transform: rotate(34deg); }
-.jp-ah-vivo.p6:not(.gano) .jp-ah-ojos-abiertos { opacity: 0; }
-.jp-ah-vivo.p6:not(.gano) .jp-ah-ojos-cerrados { opacity: 1; }
-.jp-ah-vivo.p6:not(.gano) .jp-ah-abeja-cuerpo { fill: #d9c383; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-angelita .rh-blink {
+  animation: none;
+  transform: scaleY(0.14);
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-angelita .rh-mirada { animation: none; }
 .jp-ah-vivo.p6:not(.gano) .jp-ah-zzz { opacity: 1; }
 
 .jp-ah-vivo.p6:not(.gano) .jp-ah-zzz text {
@@ -903,11 +863,14 @@
 /* Celebración al ganar: vuelo alegre más vivo */
 .jp-ah-vivo.gano .jp-ah-abeja-orbita { animation-duration: 5s; }
 
-/* ── La mariposa: compañera de la abeja; el químico la espanta ── */
+/* ── Las mariposas: secundarias que acompañan a Angelita ──
+ * Corrección del operador: NO se sacan y NO huyen de escena — el químico
+ * también las mata. Se apagan CON la protagonista, por grados: aleteo
+ * pesado y vuelo bajo (p2) → tambaleo (p4) → caen marchitas al suelo (p6).
+ * Todo con :not(.gano): al ganar reviven solas con la escena. */
 
 .jp-ah-mariposa-orbita {
   animation: jp-ah-mariposeo 11s ease-in-out infinite;
-  transition: opacity 2s ease;
 }
 
 @keyframes jp-ah-mariposeo {
@@ -918,26 +881,41 @@
   85% { transform: translate(300px, 102px) rotate(4deg); }
 }
 
+/* La mariposita chiquita baila su propia órbita al otro lado de la chagra,
+   sobre el surco de brotes — dos compañeras, no un clon en el mismo camino. */
+.mariposa-orbita-2 {
+  animation: jp-ah-mariposeo-2 13s ease-in-out infinite;
+}
+
+@keyframes jp-ah-mariposeo-2 {
+  0%, 100% { transform: translate(58px, 64px) rotate(-5deg); }
+  25% { transform: translate(86px, 50px) rotate(7deg); }
+  50% { transform: translate(100px, 68px) rotate(-4deg); }
+  75% { transform: translate(76px, 82px) rotate(6deg); }
+}
+
 .jp-ah-mariposa {
   animation: jp-ah-abeja-bob 1.1s ease-in-out infinite alternate;
 }
 
-.jp-ah-mariposa-cuerpo { fill: #4a3524; }
+.jp-ah-mariposa-cuerpo { fill: var(--mar-cuerpo); transition: fill 1.4s ease; }
 
 .jp-ah-mariposa-antena {
   fill: none;
-  stroke: #4a3524;
+  stroke: var(--mar-cuerpo);
   stroke-width: 0.7;
   stroke-linecap: round;
+  transition: stroke 1.4s ease;
 }
 
 .jp-ah-mariposa-ala path {
-  fill: #f6a34c;
-  stroke: #c86f1d;
+  fill: var(--mar-ala);
+  stroke: var(--mar-ala-borde);
   stroke-width: 0.8;
+  transition: fill 1.4s ease, stroke 1.4s ease;
 }
 
-.jp-ah-mariposa-ala circle { fill: #fde68a; }
+.jp-ah-mariposa-ala circle { fill: var(--mar-mota); transition: fill 1.4s ease; }
 
 .jp-ah-mariposa-ala {
   transform-box: fill-box;
@@ -952,14 +930,104 @@
   to { transform: scaleX(0.3); }
 }
 
-/* Con el segundo error la mariposa se ALEJA de la chagra (huye del químico) */
-.jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-orbita {
-  animation: jp-ah-mariposa-huye 2.6s ease-in both;
+/* p2: el aleteo se hace PESADO y vuelan más bajo, cerca de la chagra que
+   sufre. El color de las alas empieza a apagarse (variables en transición). */
+.jp-ah-vivo.p2:not(.gano) {
+  --mar-ala: #dda45c;
+  --mar-ala-borde: #a9722e;
 }
 
-@keyframes jp-ah-mariposa-huye {
-  0% { transform: translate(288px, 92px) rotate(6deg); opacity: 1; }
-  100% { transform: translate(392px, 30px) rotate(-14deg); opacity: 0; }
+.jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-orbita {
+  animation: jp-ah-mariposa-pesada 7s ease-in-out infinite;
+}
+
+.jp-ah-vivo.p2:not(.gano) .mariposa-orbita-2 {
+  animation: jp-ah-mariposa-pesada-2 8s ease-in-out infinite;
+}
+
+.jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-ala { animation-duration: 0.6s; }
+
+@keyframes jp-ah-mariposa-pesada {
+  0%, 100% { transform: translate(282px, 108px) rotate(4deg); }
+  30% { transform: translate(258px, 96px) rotate(-7deg); }
+  60% { transform: translate(300px, 116px) rotate(6deg); }
+  80% { transform: translate(272px, 122px) rotate(-4deg); }
+}
+
+@keyframes jp-ah-mariposa-pesada-2 {
+  0%, 100% { transform: translate(70px, 92px) rotate(5deg); }
+  35% { transform: translate(92px, 104px) rotate(-6deg); }
+  70% { transform: translate(58px, 112px) rotate(4deg); }
+}
+
+/* p4: tambalean — el mismo lenguaje del tambaleo de Angelita (p5),
+   anticipándolo: las chiquitas caen primero que la protagonista. */
+.jp-ah-vivo.p4:not(.gano) {
+  --mar-ala: #bd9464;
+  --mar-ala-borde: #8a6a42;
+  --mar-mota: #dccda6;
+}
+
+.jp-ah-vivo.p4:not(.gano) .jp-ah-mariposa-orbita {
+  animation: jp-ah-mariposa-tambalea 3.6s ease-in-out infinite;
+}
+
+.jp-ah-vivo.p4:not(.gano) .mariposa-orbita-2 {
+  animation: jp-ah-mariposa-tambalea-2 3.2s ease-in-out infinite;
+}
+
+.jp-ah-vivo.p4:not(.gano) .jp-ah-mariposa-ala { animation-duration: 0.95s; }
+
+@keyframes jp-ah-mariposa-tambalea {
+  0%, 100% { transform: translate(266px, 128px) rotate(-12deg); }
+  25% { transform: translate(280px, 140px) rotate(14deg); }
+  55% { transform: translate(254px, 146px) rotate(-16deg); }
+  80% { transform: translate(272px, 136px) rotate(10deg); }
+}
+
+@keyframes jp-ah-mariposa-tambalea-2 {
+  0%, 100% { transform: translate(76px, 118px) rotate(10deg); }
+  30% { transform: translate(62px, 132px) rotate(-14deg); }
+  65% { transform: translate(88px, 138px) rotate(12deg); }
+}
+
+/* p6: caen marchitas al suelo — de costado, alitas plegadas, quietas y
+   desteñidas. NO desaparecen: quedan en la chagra apagada, acompañando a
+   Angelita hasta el final (o hasta que el jugador gane y revivan todas). */
+.jp-ah-vivo.p6:not(.gano) {
+  --mar-ala: #a08e77;
+  --mar-ala-borde: #6f6152;
+  --mar-mota: #b3a992;
+  --mar-cuerpo: #55483a;
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-orbita {
+  animation: jp-ah-mariposa-cae 1.5s cubic-bezier(0.4, 0, 1, 1) both;
+}
+
+.jp-ah-vivo.p6:not(.gano) .mariposa-orbita-2 {
+  animation: jp-ah-mariposa-cae-2 1.7s cubic-bezier(0.4, 0, 1, 1) 0.25s both;
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa { animation: none; }
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-ala {
+  animation: none;
+  transform: scaleX(0.2);
+}
+
+@keyframes jp-ah-mariposa-cae {
+  0% { transform: translate(258px, 140px) rotate(-10deg); }
+  60% { transform: translate(232px, 168px) rotate(52deg); }
+  76% { transform: translate(228px, 163px) rotate(62deg); }
+  100% { transform: translate(226px, 170px) rotate(74deg); }
+}
+
+@keyframes jp-ah-mariposa-cae-2 {
+  0% { transform: translate(78px, 130px) rotate(8deg); }
+  62% { transform: translate(64px, 170px) rotate(-48deg); }
+  78% { transform: translate(62px, 165px) rotate(-58deg); }
+  100% { transform: translate(60px, 172px) rotate(-68deg); }
 }
 
 /* ── Chispas + florecitas de victoria ── */
@@ -1048,10 +1116,19 @@
     transition: none !important;
   }
 
-  /* Las órbitas animadas posicionaban abeja y mariposa: sin animación quedan
-     en (0,0), así que las plantamos en un punto legible por estado. */
+  /* Las órbitas animadas posicionaban a Angelita y las mariposas: sin
+     animación quedan en (0,0), así que las plantamos en un punto legible por
+     estado. Las mariposas NO desaparecen: bajan y terminan caídas de costado
+     junto a la protagonista (mismo guion que con movimiento). */
   .jp-ah-mariposa-orbita { transform: translate(288px, 80px); }
-  .jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-orbita { opacity: 0; }
+  .mariposa-orbita-2 { transform: translate(84px, 64px); }
+  .jp-ah-vivo.p2:not(.gano) .jp-ah-mariposa-orbita { transform: translate(276px, 108px); }
+  .jp-ah-vivo.p2:not(.gano) .mariposa-orbita-2 { transform: translate(76px, 100px); }
+  .jp-ah-vivo.p4:not(.gano) .jp-ah-mariposa-orbita { transform: translate(266px, 136px) rotate(-10deg); }
+  .jp-ah-vivo.p4:not(.gano) .mariposa-orbita-2 { transform: translate(74px, 126px) rotate(8deg); }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-orbita { transform: translate(226px, 170px) rotate(74deg); }
+  .jp-ah-vivo.p6:not(.gano) .mariposa-orbita-2 { transform: translate(60px, 172px) rotate(-68deg); }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-ala { transform: scaleX(0.2); }
   .jp-ah-abeja-orbita { transform: translate(200px, 80px); }
   .jp-ah-vivo.p3:not(.gano) .jp-ah-abeja-orbita { transform: translate(185px, 105px); }
   .jp-ah-vivo.p5:not(.gano) .jp-ah-abeja-orbita { transform: translate(180px, 128px) rotate(-16deg); }

--- a/src/components/juego/ahorcado-contaminado.css
+++ b/src/components/juego/ahorcado-contaminado.css
@@ -51,29 +51,36 @@
   color: #fff;
 }
 
-/* ── Escena de contaminación (reemplaza la horca) ─────────────────────── */
+/* ══ Escena viva de la chagra (reemplaza la horca y los emojis) ═════════
+ *
+ * Un SVG-paisaje andino (mata + abeja + agua + suelo + frailejones + sol)
+ * que se contamina paso a paso. Los errores se acumulan como clases p1..p6
+ * sobre .jp-ah-vivo; cada regla usa :not(.gano) para que al ganar la escena
+ * REVIVA sola con las mismas transiciones.
+ *
+ * Rubber-hose andino: squash&stretch con volumen preservado, follow-through
+ * escalonado en hojas, line-boil steps(3) en los seres vivos.
+ */
 
 .jp-ah-escena {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.35rem;
-  padding: 1.25rem 1rem;
+  gap: 0.5rem;
+  padding: 0.6rem 0.6rem 0.85rem;
   border-radius: 1.25rem;
   border: 2px solid rgba(148, 163, 184, 0.3);
   background: linear-gradient(180deg, rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.3));
-  transition: background 0.4s ease, border-color 0.4s ease;
+  transition: border-color 0.6s ease, box-shadow 0.6s ease;
 }
 
-.jp-ah-escena-emoji {
-  font-size: 3.5rem;
-  line-height: 1;
-  animation: jp-ah-parpadeo 2.4s ease-in-out infinite;
-}
-
-@keyframes jp-ah-parpadeo {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.05); }
+.jp-ah-vivo {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 42vh;
+  border-radius: 0.9rem;
+  overflow: hidden;
 }
 
 .jp-ah-escena-texto {
@@ -81,6 +88,17 @@
   font-weight: 600;
   text-align: center;
   margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.3;
+  min-height: 2.4em;
+  display: flex;
+  align-items: center;
+}
+
+.jp-ah-estado-fila {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .jp-ah-intentos {
@@ -89,38 +107,814 @@
   margin: 0;
 }
 
-/* Cada paso oscurece/enrojece progresivamente la escena: la metáfora visual
-   de "la finca se contamina", sin dibujar una horca. */
+/* Borde del marco: acompaña la degradación (verde → ocre → rojizo) */
 .jp-ah-escena.sana { border-color: rgba(74, 222, 128, 0.5); }
 .jp-ah-escena.paso-1 { border-color: rgba(163, 230, 53, 0.5); }
-.jp-ah-escena.paso-2 {
-  border-color: rgba(234, 179, 8, 0.5);
-  background: linear-gradient(180deg, rgba(66, 46, 15, 0.5), rgba(15, 23, 42, 0.3));
-}
-.jp-ah-escena.paso-3 {
-  border-color: rgba(217, 119, 6, 0.55);
-  background: linear-gradient(180deg, rgba(69, 39, 10, 0.6), rgba(15, 23, 42, 0.3));
-}
-.jp-ah-escena.paso-4 {
-  border-color: rgba(190, 24, 93, 0.55);
-  background: linear-gradient(180deg, rgba(76, 20, 40, 0.6), rgba(15, 23, 42, 0.3));
-}
-.jp-ah-escena.paso-5 {
-  border-color: rgba(220, 38, 38, 0.6);
-  background: linear-gradient(180deg, rgba(70, 15, 15, 0.65), rgba(15, 23, 42, 0.3));
-}
-.jp-ah-escena.paso-6 {
-  border-color: rgba(127, 29, 29, 0.8);
-  background: linear-gradient(180deg, rgba(40, 10, 10, 0.8), rgba(15, 23, 42, 0.5));
-}
-.jp-ah-escena.paso-6 .jp-ah-escena-emoji {
-  animation: none;
+.jp-ah-escena.paso-2 { border-color: rgba(234, 179, 8, 0.5); }
+.jp-ah-escena.paso-3 { border-color: rgba(217, 119, 6, 0.55); }
+.jp-ah-escena.paso-4 { border-color: rgba(190, 24, 93, 0.55); }
+.jp-ah-escena.paso-5 { border-color: rgba(220, 38, 38, 0.6); }
+.jp-ah-escena.paso-6 { border-color: rgba(127, 29, 29, 0.8); }
+.jp-ah-escena.escena-gano {
+  border-color: rgba(74, 222, 128, 0.9);
+  box-shadow: 0 0 18px rgba(74, 222, 128, 0.35);
 }
 
+/* ── Medidor de vida: 6 hojitas que se apagan ── */
+
+.jp-ah-medidor {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.jp-ah-medidor-hoja {
+  width: 1.1rem;
+  height: 1.1rem;
+  overflow: visible;
+  transition: transform 0.5s ease;
+  transform-origin: bottom center;
+}
+
+.jp-ah-medidor-hoja path {
+  fill: #4ade80;
+  stroke: #166534;
+  stroke-width: 1;
+  transition: fill 0.5s ease, stroke 0.5s ease;
+}
+
+.jp-ah-medidor-hoja .jp-ah-medidor-vena {
+  fill: none;
+  stroke: #166534;
+  stroke-width: 0.9;
+  stroke-linecap: round;
+}
+
+.jp-ah-medidor-hoja.apagada {
+  transform: rotate(38deg);
+}
+
+.jp-ah-medidor-hoja.apagada path {
+  fill: rgba(100, 116, 139, 0.45);
+  stroke: rgba(100, 116, 139, 0.7);
+}
+
+/* ── Variables de la escena (estado SANO por defecto) ──
+ * Los pasos p1..p6 (:not(.gano)) las degradan; ganar las restaura solas. */
+
+@property --nube-x {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 0px;
+}
+
+@property --nube-y {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 0px;
+}
+
+@property --mata-doblez {
+  syntax: '<angle>';
+  inherits: true;
+  initial-value: 0deg;
+}
+
+.jp-ah-vivo {
+  --montana-lejos: #9fbfae;
+  --montana-cerca: #6da26e;
+  --frailejon: #4e7d58;
+  --suelo: #5b4232;
+  --humus: #3a2a1e;
+  --agua: #74c7e8;
+  --tallo: #3f8f4f;
+  --hoja: #55a860;
+  --hoja-vena: #2f7a3e;
+  --petalo: #f2a7c3;
+  --flor-centro: #f4b31c;
+  --pasto: #4e9a58;
+  --nube-y: -52px;
+  --nube-x: 0px;
+  --mata-doblez: 0deg;
+}
+
+/* ── Cielo: crossfade sano → tóxico ── */
+
+.jp-ah-cielo-toxico {
+  opacity: 0;
+  transition: opacity 1.4s ease;
+}
+
+.jp-ah-vivo.p2:not(.gano) .jp-ah-cielo-toxico { opacity: 0.22; }
+.jp-ah-vivo.p3:not(.gano) .jp-ah-cielo-toxico { opacity: 0.45; }
+.jp-ah-vivo.p4:not(.gano) .jp-ah-cielo-toxico { opacity: 0.65; }
+.jp-ah-vivo.p5:not(.gano) .jp-ah-cielo-toxico { opacity: 0.85; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-cielo-toxico { opacity: 1; }
+
+/* ── Sol ── */
+
+.jp-ah-sol-disco {
+  fill: #ffd23e;
+  stroke: #e8a615;
+  stroke-width: 1.5;
+  transition: fill 1.2s ease, stroke 1.2s ease;
+}
+
+.jp-ah-sol-halo {
+  fill: #fff3b0;
+  opacity: 0.4;
+  animation: jp-ah-halo 4s ease-in-out infinite;
+  transition: opacity 1.2s ease;
+}
+
+@keyframes jp-ah-halo {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.12); }
+}
+
+.jp-ah-sol-rayos {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: jp-ah-girar 36s linear infinite;
+}
+
+.jp-ah-sol-rayos line {
+  stroke: #f4b31c;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  transition: opacity 1.2s ease;
+}
+
+@keyframes jp-ah-girar {
+  to { transform: rotate(360deg); }
+}
+
+.jp-ah-vivo.p4:not(.gano) .jp-ah-sol-disco { fill: #d9d0a2; stroke: #b3a97e; }
+.jp-ah-vivo.p4:not(.gano) .jp-ah-sol-halo { opacity: 0.12; }
+.jp-ah-vivo.p4:not(.gano) .jp-ah-sol-rayos line { opacity: 0.35; }
+.jp-ah-vivo.p5:not(.gano) .jp-ah-sol-disco { fill: #b8b49a; stroke: #96927c; }
+.jp-ah-vivo.p5:not(.gano) .jp-ah-sol-halo { opacity: 0; }
+.jp-ah-vivo.p5:not(.gano) .jp-ah-sol-rayos line { opacity: 0; }
+
+.jp-ah-vivo.gano .jp-ah-sol-halo {
+  opacity: 0.6;
+  animation-duration: 1.6s;
+}
+
+/* ── Cordillera + niebla + frailejones ── */
+
+.jp-ah-montana-lejos {
+  fill: var(--montana-lejos);
+  transition: fill 1.4s ease;
+}
+
+.jp-ah-montana-cerca {
+  fill: var(--montana-cerca);
+  transition: fill 1.4s ease;
+}
+
+.jp-ah-niebla {
+  fill: #ffffff;
+  opacity: 0.2;
+}
+
+.jp-ah-frailejon rect,
+.jp-ah-frailejon ellipse {
+  fill: var(--frailejon);
+  transition: fill 1.4s ease;
+}
+
+.jp-ah-vivo.p3:not(.gano) { --montana-cerca: #87906f; }
+.jp-ah-vivo.p5:not(.gano) {
+  --montana-lejos: #8a8a90;
+  --montana-cerca: #77776f;
+  --frailejon: #6f6f68;
+}
+
+/* ── Suelo: fértil → pálido y agrietado ── */
+
+.jp-ah-suelo {
+  fill: var(--suelo);
+  transition: fill 1.4s ease;
+}
+
+.jp-ah-humus ellipse {
+  fill: var(--humus);
+  transition: fill 1.4s ease, opacity 1.4s ease;
+}
+
+.jp-ah-grietas path {
+  fill: none;
+  stroke: #756450;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  opacity: 0;
+  transition: opacity 1.2s ease;
+}
+
+.jp-ah-vivo.p3:not(.gano) { --suelo: #7a6a52; --humus: #64553f; }
+.jp-ah-vivo.p3:not(.gano) .jp-ah-grietas path { opacity: 0.9; }
+.jp-ah-vivo.p5:not(.gano) { --suelo: #8b8271; --humus: #756c58; }
+.jp-ah-vivo.p6:not(.gano) { --suelo: #90897c; }
+
+/* ── Agua de riego: limpia → turbia ── */
+
+.jp-ah-agua-cuerpo {
+  fill: var(--agua);
+  stroke: rgba(30, 100, 140, 0.5);
+  stroke-width: 1.4;
+  transition: fill 1.4s ease, stroke 1.4s ease;
+}
+
+.jp-ah-onda {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.65);
+  stroke-width: 1.3;
+  stroke-linecap: round;
+  animation: jp-ah-ondear 3.2s ease-in-out infinite alternate;
+  transition: stroke 1.4s ease;
+}
+
+.jp-ah-onda.onda-2 { animation-delay: -1.6s; }
+
+@keyframes jp-ah-ondear {
+  from { transform: translateX(-3px); }
+  to { transform: translateX(3px); }
+}
+
+.jp-ah-destello {
+  fill: #ffffff;
+  opacity: 0.75;
+  animation: jp-ah-destellar 2.8s ease-in-out infinite;
+  transition: opacity 1s ease;
+}
+
+@keyframes jp-ah-destellar {
+  0%, 100% { opacity: 0.75; }
+  50% { opacity: 0.25; }
+}
+
+.jp-ah-burbujas circle {
+  fill: #9db35f;
+  opacity: 0;
+}
+
+.jp-ah-vivo.p4:not(.gano) { --agua: #8d7f5c; }
+.jp-ah-vivo.p4:not(.gano) .jp-ah-agua-cuerpo { stroke: rgba(90, 74, 40, 0.6); }
+.jp-ah-vivo.p4:not(.gano) .jp-ah-onda { stroke: rgba(60, 48, 26, 0.5); animation-duration: 6s; }
+.jp-ah-vivo.p4:not(.gano) .jp-ah-destello { opacity: 0; animation: none; }
+.jp-ah-vivo.p4:not(.gano) .jp-ah-burbujas circle { animation: jp-ah-burbujear 2.4s ease-out infinite; }
+.jp-ah-vivo.p4:not(.gano) .jp-ah-burbujas .burbuja-2 { animation-delay: 0.8s; }
+.jp-ah-vivo.p4:not(.gano) .jp-ah-burbujas .burbuja-3 { animation-delay: 1.5s; }
+.jp-ah-vivo.p6:not(.gano) { --agua: #7c6f58; }
+
+@keyframes jp-ah-burbujear {
+  0% { transform: translateY(2px); opacity: 0; }
+  30% { opacity: 0.85; }
+  100% { transform: translateY(-9px); opacity: 0; }
+}
+
+/* ── Pastos (sway idle → droop marchito) ── */
+
+.jp-ah-pasto path {
+  fill: none;
+  stroke: var(--pasto);
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  animation: jp-ah-sway 3.4s ease-in-out infinite alternate;
+  transition: stroke 1.4s ease, transform 1.2s ease;
+}
+
+.jp-ah-pasto path:nth-child(2) { animation-delay: -1.1s; }
+.jp-ah-pasto path:nth-child(3) { animation-delay: -2.3s; }
+.jp-ah-pasto.pasto-2 path { animation-delay: -0.6s; }
+.jp-ah-pasto.pasto-3 path { animation-delay: -1.8s; }
+
+@keyframes jp-ah-sway {
+  from { transform: rotate(-4deg); }
+  to { transform: rotate(4deg); }
+}
+
+.jp-ah-vivo.p3:not(.gano) { --pasto: #9a9257; }
+.jp-ah-vivo.p3:not(.gano) .jp-ah-pasto path { animation: none; transform: rotate(-28deg); }
+.jp-ah-vivo.p5:not(.gano) { --pasto: #8a7a52; }
+.jp-ah-vivo.p5:not(.gano) .jp-ah-pasto path { transform: rotate(-52deg); }
+
+/* ── La mata protagonista ──
+ * Respira (squash&stretch con volumen preservado). El doblez por
+ * contaminación entra como variable dentro de los keyframes para no pelear
+ * con la animación idle. */
+
+.jp-ah-mata {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  transition: --mata-doblez 1.2s ease;
+  animation:
+    jp-ah-respira 3.8s ease-in-out infinite,
+    jp-ah-boil 0.55s linear infinite;
+}
+
+@keyframes jp-ah-respira {
+  0%, 100% { transform: rotate(var(--mata-doblez, 0deg)) scale(1.015, 0.985); }
+  50% { transform: rotate(calc(var(--mata-doblez, 0deg) + 1.4deg)) scale(0.99, 1.014); }
+}
+
+@keyframes jp-ah-boil {
+  0%, 32.9% { filter: url(#jpAhBoil1); }
+  33%, 65.9% { filter: url(#jpAhBoil2); }
+  66%, 100% { filter: url(#jpAhBoil3); }
+}
+
+.jp-ah-tallo {
+  fill: none;
+  stroke: var(--tallo);
+  stroke-width: 4.5;
+  stroke-linecap: round;
+  transition: stroke 1.4s ease;
+}
+
+.jp-ah-hoja {
+  transform-box: fill-box;
+  transform-origin: right center;
+  transition: transform 1.1s cubic-bezier(0.34, 1.2, 0.64, 1);
+}
+
+.jp-ah-hoja-forma {
+  fill: var(--hoja);
+  stroke: var(--hoja-vena);
+  stroke-width: 1.1;
+  transition: fill 1.4s ease, stroke 1.4s ease;
+}
+
+.jp-ah-hoja-vena {
+  fill: none;
+  stroke: var(--hoja-vena);
+  stroke-width: 1;
+  stroke-linecap: round;
+  transition: stroke 1.4s ease;
+}
+
+/* Flutter idle con follow-through (delays escalonados por hoja) */
+.jp-ah-hoja path {
+  transform-box: fill-box;
+  transform-origin: right center;
+  animation: jp-ah-flutter 3.8s ease-in-out infinite;
+}
+
+.hoja-b path { animation-delay: -0.4s; }
+.hoja-c path { animation-delay: -0.9s; }
+.hoja-d path { animation-delay: -1.3s; }
+.hoja-e path { animation-delay: -1.8s; }
+.hoja-f path { animation-delay: -2.2s; }
+
+@keyframes jp-ah-flutter {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-2.6deg); }
+}
+
+/* Droop progresivo: cada error dobla más hojas (rotación desde la unión) */
+.jp-ah-vivo.p1:not(.gano) .hoja-a { transform: rotate(-20deg); }
+.jp-ah-vivo.p1:not(.gano) { --hoja: #7da457; }
+.jp-ah-vivo.p2:not(.gano) .hoja-a { transform: rotate(-42deg); }
+.jp-ah-vivo.p2:not(.gano) .hoja-b { transform: rotate(-30deg); }
+.jp-ah-vivo.p2:not(.gano) .hoja-c { transform: rotate(-14deg); }
+.jp-ah-vivo.p2:not(.gano) { --hoja: #98a24f; --petalo: #dfa8bb; }
+.jp-ah-vivo.p3:not(.gano) .hoja-b { transform: rotate(-48deg); }
+.jp-ah-vivo.p3:not(.gano) .hoja-c { transform: rotate(-30deg); }
+.jp-ah-vivo.p3:not(.gano) .hoja-d { transform: rotate(-22deg); }
+.jp-ah-vivo.p3:not(.gano) { --mata-doblez: 4deg; --hoja: #a89a4c; --tallo: #6e8f4a; }
+.jp-ah-vivo.p4:not(.gano) .hoja-e { transform: rotate(-26deg); }
+.jp-ah-vivo.p4:not(.gano) .hoja-f { transform: rotate(-20deg); }
+.jp-ah-vivo.p4:not(.gano) { --hoja: #ab8f49; --hoja-vena: #7a6a38; }
+.jp-ah-vivo.p5:not(.gano) .hoja-a { transform: rotate(-62deg); }
+.jp-ah-vivo.p5:not(.gano) .hoja-b { transform: rotate(-58deg); }
+.jp-ah-vivo.p5:not(.gano) .hoja-c { transform: rotate(-48deg); }
+.jp-ah-vivo.p5:not(.gano) .hoja-d { transform: rotate(-44deg); }
+.jp-ah-vivo.p5:not(.gano) .hoja-e { transform: rotate(-40deg); }
+.jp-ah-vivo.p5:not(.gano) .hoja-f { transform: rotate(-36deg); }
+.jp-ah-vivo.p5:not(.gano) { --mata-doblez: 9deg; --hoja: #b0894a; --tallo: #8a7a45; --petalo: #b9a08d; --flor-centro: #b08d4a; }
+.jp-ah-vivo.p6:not(.gano) { --hoja: #9c8663; --hoja-vena: #6e5f48; --tallo: #8a7a5c; --petalo: #a39288; --flor-centro: #96826a; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-mata {
+  animation: jp-ah-boil 0.55s linear infinite;
+  transform: rotate(15deg) scale(0.96, 0.8);
+  transition: transform 1.4s ease;
+}
+.jp-ah-vivo.p6:not(.gano) .jp-ah-hoja path { animation: none; }
+
+/* ── Flor: pulso idle, se cierra al marchitarse, bloom al ganar ── */
+
+.jp-ah-flor-corola {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: jp-ah-flor-pulso 3.8s ease-in-out infinite;
+  transition: transform 1.2s ease;
+}
+
+@keyframes jp-ah-flor-pulso {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.06); }
+}
+
+.jp-ah-petalo {
+  fill: var(--petalo);
+  stroke: rgba(160, 70, 110, 0.4);
+  stroke-width: 0.8;
+  transition: fill 1.4s ease;
+}
+
+.jp-ah-flor-centro {
+  fill: var(--flor-centro);
+  stroke: rgba(140, 90, 10, 0.5);
+  stroke-width: 1;
+  transition: fill 1.4s ease;
+}
+
+.jp-ah-vivo.p5:not(.gano) .jp-ah-flor-corola {
+  animation: none;
+  transform: scale(0.55) rotate(-14deg);
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-flor-corola {
+  animation: none;
+  transform: scale(0.42) rotate(-28deg);
+}
+
+/* Bloom de victoria: overshoot rubber-hose */
+.jp-ah-vivo.gano .jp-ah-flor-corola {
+  animation: jp-ah-bloom 1s cubic-bezier(0.34, 1.56, 0.64, 1) both,
+    jp-ah-flor-pulso 3.8s ease-in-out 1s infinite;
+}
+
+@keyframes jp-ah-bloom {
+  0% { transform: scale(0.5); }
+  60% { transform: scale(1.25); }
+  100% { transform: scale(1); }
+}
+
+/* ── Pétalos que se desprenden y hojas que caen ── */
+
+.jp-ah-petalo-caido ellipse {
+  fill: var(--petalo);
+  opacity: 0;
+}
+
+.jp-ah-vivo.p2:not(.gano) .jp-ah-petalo-caido.caido-1 {
+  animation: jp-ah-petalo-cae 1.8s ease-in both;
+}
+
+.jp-ah-vivo.p3:not(.gano) .jp-ah-petalo-caido.caido-2 {
+  animation: jp-ah-petalo-cae-2 2s ease-in both;
+}
+
+.jp-ah-vivo.p2:not(.gano) .jp-ah-petalo-caido.caido-1 ellipse,
+.jp-ah-vivo.p3:not(.gano) .jp-ah-petalo-caido.caido-2 ellipse {
+  opacity: 0.85;
+}
+
+@keyframes jp-ah-petalo-cae {
+  0% { transform: translate(0, 0) rotate(0deg); }
+  100% { transform: translate(-16px, 52px) rotate(-130deg); }
+}
+
+@keyframes jp-ah-petalo-cae-2 {
+  0% { transform: translate(0, 0) rotate(0deg); }
+  100% { transform: translate(12px, 54px) rotate(140deg); }
+}
+
+.jp-ah-hoja-caida path {
+  fill: var(--hoja);
+  opacity: 0;
+}
+
+.jp-ah-vivo.p2:not(.gano) .jp-ah-hoja-caida.hcaida-1 { animation: jp-ah-hoja-cae 3.6s linear infinite; }
+.jp-ah-vivo.p3:not(.gano) .jp-ah-hoja-caida.hcaida-2 { animation: jp-ah-hoja-cae 3.6s linear 1.8s infinite; }
+.jp-ah-vivo.p2:not(.gano) .jp-ah-hoja-caida.hcaida-1 path { opacity: 0.9; }
+.jp-ah-vivo.p3:not(.gano) .jp-ah-hoja-caida.hcaida-2 path { opacity: 0.9; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-hoja-caida { animation: none; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-hoja-caida path { opacity: 0; }
+
+@keyframes jp-ah-hoja-cae {
+  0% { transform: translate(10px, -46px) rotate(0deg); opacity: 0; }
+  10% { opacity: 1; }
+  33% { transform: translate(-4px, -32px) rotate(-60deg); }
+  66% { transform: translate(8px, -16px) rotate(-110deg); }
+  92% { opacity: 0.9; }
+  100% { transform: translate(-6px, -2px) rotate(-170deg); opacity: 0; }
+}
+
+/* ── Nube de químico: entra con el primer error, gotea, crece ── */
+
+.jp-ah-nube {
+  opacity: 0;
+  transition: opacity 1.4s ease, --nube-y 1.4s ease, --nube-x 1.4s ease;
+}
+
+.jp-ah-nube-cuerpo {
+  animation: jp-ah-nube-bob 5s ease-in-out infinite alternate;
+}
+
+.jp-ah-nube-cuerpo ellipse {
+  fill: #8e81a8;
+  stroke: #5f5478;
+  stroke-width: 1.2;
+  transition: fill 1.4s ease;
+}
+
+@keyframes jp-ah-nube-bob {
+  from { transform: translate(var(--nube-x, 0px), var(--nube-y, 0px)); }
+  to { transform: translate(var(--nube-x, 0px), calc(var(--nube-y, 0px) + 4px)); }
+}
+
+.jp-ah-gotas .gota {
+  fill: #a3e635;
+  stroke: #65a30d;
+  stroke-width: 0.9;
+  animation: jp-ah-gotear 1.7s ease-in infinite;
+  opacity: 0;
+}
+
+.jp-ah-gotas g:nth-child(2) .gota { animation-delay: 0.55s; }
+.jp-ah-gotas g:nth-child(3) .gota { animation-delay: 1.1s; }
+
+@keyframes jp-ah-gotear {
+  0% { transform: translateY(0); opacity: 0; }
+  12% { opacity: 0.95; }
+  78% { transform: translateY(24px); opacity: 0.9; }
+  100% { transform: translateY(29px); opacity: 0; }
+}
+
+.jp-ah-vivo.p1:not(.gano) .jp-ah-nube { opacity: 1; --nube-y: 0px; }
+.jp-ah-vivo.p1:not(.gano) .jp-ah-nube-2 { opacity: 0; }
+.jp-ah-vivo.p3:not(.gano) .jp-ah-nube-cuerpo ellipse { fill: #7a6d96; }
+.jp-ah-vivo.p5:not(.gano) .jp-ah-nube-2 { opacity: 1; }
+.jp-ah-vivo.gano .jp-ah-nube { opacity: 0; --nube-x: -160px; --nube-y: -30px; }
+
+/* ── Bruma final ── */
+
+.jp-ah-bruma {
+  fill: #6f7d63;
+  opacity: 0;
+  transition: opacity 1.6s ease;
+  pointer-events: none;
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-bruma { opacity: 0.2; }
+
+/* ── La abejita polinizadora ──
+ * Órbita (trayectoria) en el grupo padre; aleteo, squash y expresión en los
+ * hijos. Estados: feliz → preocupada → tambaleo → desmayada (sin morbo). */
+
+.jp-ah-abeja-orbita {
+  animation: jp-ah-vuelo-feliz 9s ease-in-out infinite;
+}
+
+@keyframes jp-ah-vuelo-feliz {
+  0%, 100% { transform: translate(188px, 60px) rotate(-4deg); }
+  25% { transform: translate(240px, 82px) rotate(5deg); }
+  50% { transform: translate(206px, 102px) rotate(-3deg); }
+  75% { transform: translate(148px, 82px) rotate(4deg); }
+}
+
+.jp-ah-abeja {
+  animation: jp-ah-abeja-bob 1.3s ease-in-out infinite alternate,
+    jp-ah-boil 0.55s linear infinite;
+}
+
+@keyframes jp-ah-abeja-bob {
+  from { transform: translateY(-2.5px); }
+  to { transform: translateY(2.5px); }
+}
+
+.jp-ah-abeja-cuerpo {
+  fill: #ffd23e;
+  stroke: #3a2c1a;
+  stroke-width: 1.3;
+  transition: fill 1.4s ease;
+}
+
+.jp-ah-franja { fill: #3a2c1a; }
+
+.jp-ah-abeja-cabeza {
+  fill: #3a2c1a;
+}
+
+.jp-ah-antenas path {
+  fill: none;
+  stroke: #3a2c1a;
+  stroke-width: 1.1;
+  stroke-linecap: round;
+  transform-box: fill-box;
+  transform-origin: bottom right;
+  transition: transform 1s ease;
+}
+
+.jp-ah-antenas circle { fill: #3a2c1a; }
+
+.jp-ah-ala ellipse {
+  fill: rgba(219, 234, 254, 0.8);
+  stroke: #93c5fd;
+  stroke-width: 0.9;
+}
+
+.jp-ah-ala {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: jp-ah-aleteo 0.16s linear infinite alternate;
+  transition: transform 1s ease;
+}
+
+.jp-ah-ala.ala-der { animation-delay: -0.08s; }
+
+@keyframes jp-ah-aleteo {
+  from { transform: scaleY(1) rotate(-4deg); }
+  to { transform: scaleY(0.4) rotate(6deg); }
+}
+
+.jp-ah-ojos-abiertos ellipse { fill: #ffffff; }
+.jp-ah-ojos-abiertos .jp-ah-pupila { fill: #1c140c; }
+
+.jp-ah-sonrisa,
+.jp-ah-ojos-cerrados path {
+  fill: none;
+  stroke: #ffffff;
+  stroke-width: 0.8;
+  stroke-linecap: round;
+}
+
+.jp-ah-ojos-cerrados { opacity: 0; }
+
+.jp-ah-patitas path {
+  fill: none;
+  stroke: #3a2c1a;
+  stroke-width: 1;
+  stroke-linecap: round;
+}
+
+.jp-ah-zzz { opacity: 0; }
+
+.jp-ah-zzz text {
+  font-family: inherit;
+  font-size: 9px;
+  font-weight: 800;
+  fill: #cbd5e1;
+}
+
+/* Estados de la abeja por paso */
+.jp-ah-vivo.p3:not(.gano) .jp-ah-abeja-orbita {
+  animation: jp-ah-vuelo-preocupado 6s ease-in-out infinite;
+}
+
+@keyframes jp-ah-vuelo-preocupado {
+  0%, 100% { transform: translate(178px, 96px) rotate(-8deg); }
+  30% { transform: translate(212px, 112px) rotate(9deg); }
+  60% { transform: translate(160px, 110px) rotate(-10deg); }
+}
+
+.jp-ah-vivo.p5:not(.gano) .jp-ah-abeja-orbita {
+  animation: jp-ah-tambaleo 3s ease-in-out infinite;
+}
+
+.jp-ah-vivo.p5:not(.gano) .jp-ah-ala { animation-duration: 0.34s; }
+
+@keyframes jp-ah-tambaleo {
+  0%, 100% { transform: translate(182px, 116px) rotate(-16deg); }
+  20% { transform: translate(198px, 128px) rotate(18deg); }
+  45% { transform: translate(172px, 136px) rotate(-22deg); }
+  70% { transform: translate(192px, 124px) rotate(14deg); }
+  85% { transform: translate(178px, 134px) rotate(-12deg); }
+}
+
+/* Cayó: desmayada junto a la mata (ojitos cerrados + zZz, sin morbo) */
+.jp-ah-vivo.p6:not(.gano) .jp-ah-abeja-orbita {
+  animation: jp-ah-caer 1.3s cubic-bezier(0.4, 0, 1, 1) both;
+}
+
+@keyframes jp-ah-caer {
+  0% { transform: translate(178px, 128px) rotate(-10deg); }
+  62% { transform: translate(162px, 158px) rotate(26deg); }
+  74% { transform: translate(160px, 153px) rotate(20deg); }
+  100% { transform: translate(158px, 159px) rotate(18deg); }
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-abeja {
+  animation: jp-ah-desmayo 3s ease-in-out infinite alternate;
+}
+
+@keyframes jp-ah-desmayo {
+  from { transform: scale(1, 1); }
+  to { transform: scale(1.03, 0.97); }
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-ala {
+  animation: none;
+  transform: scaleY(0.5) rotate(48deg);
+  opacity: 0.7;
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-antenas path { transform: rotate(34deg); }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-ojos-abiertos { opacity: 0; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-ojos-cerrados { opacity: 1; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-abeja-cuerpo { fill: #d9c383; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-zzz { opacity: 1; }
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-zzz text {
+  animation: jp-ah-zzz-flota 2.6s ease-out infinite;
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-zzz .z-2 { animation-delay: 0.85s; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-zzz .z-3 { animation-delay: 1.7s; }
+
+@keyframes jp-ah-zzz-flota {
+  0% { transform: translateY(3px); opacity: 0; }
+  30% { opacity: 0.9; }
+  100% { transform: translateY(-7px); opacity: 0; }
+}
+
+/* Celebración al ganar: vuelo alegre más vivo */
+.jp-ah-vivo.gano .jp-ah-abeja-orbita { animation-duration: 5s; }
+
+/* ── Chispas + florecitas de victoria ── */
+
+.jp-ah-chispa {
+  fill: #ffe58a;
+  stroke: #f4b31c;
+  stroke-width: 0.6;
+  opacity: 0;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.jp-ah-vivo.gano .jp-ah-chispa {
+  animation: jp-ah-twinkle 1.4s ease-in-out infinite;
+}
+
+.jp-ah-vivo.gano .chispa-2 { animation-delay: 0.25s; }
+.jp-ah-vivo.gano .chispa-3 { animation-delay: 0.5s; }
+.jp-ah-vivo.gano .chispa-4 { animation-delay: 0.75s; }
+.jp-ah-vivo.gano .chispa-5 { animation-delay: 1s; }
+.jp-ah-vivo.gano .chispa-6 { animation-delay: 1.2s; }
+
+@keyframes jp-ah-twinkle {
+  0%, 100% { opacity: 0; transform: scale(0.4) rotate(0deg); }
+  50% { opacity: 1; transform: scale(1.15) rotate(24deg); }
+}
+
+.jp-ah-flor-extra {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  transform: scale(0);
+}
+
+.jp-ah-flor-extra-tallo {
+  fill: none;
+  stroke: #3f8f4f;
+  stroke-width: 1.2;
+  stroke-linecap: round;
+}
+
+.jp-ah-flor-extra-petalo { fill: #fbd0e0; stroke: #e78fb3; stroke-width: 0.5; }
+.jp-ah-flor-extra-centro { fill: #f4b31c; }
+
+.jp-ah-vivo.gano .jp-ah-flor-extra {
+  animation: jp-ah-brotar 0.9s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.jp-ah-vivo.gano .florx-2 { animation-delay: 0.3s; }
+.jp-ah-vivo.gano .florx-3 { animation-delay: 0.55s; }
+
+@keyframes jp-ah-brotar {
+  0% { transform: scale(0); }
+  70% { transform: scale(1.2); }
+  100% { transform: scale(1); }
+}
+
+/* ── prefers-reduced-motion: congelar en estados claros, sin animar ── */
+
 @media (prefers-reduced-motion: reduce) {
-  .jp-ah-escena-emoji {
-    animation: none;
+  .jp-ah-vivo *,
+  .jp-ah-vivo {
+    animation: none !important;
+    transition: none !important;
   }
+
+  /* La órbita animada posicionaba a la abeja: sin animación queda en (0,0),
+     así que la plantamos en un punto legible por estado. */
+  .jp-ah-abeja-orbita { transform: translate(200px, 80px); }
+  .jp-ah-vivo.p3:not(.gano) .jp-ah-abeja-orbita { transform: translate(185px, 105px); }
+  .jp-ah-vivo.p5:not(.gano) .jp-ah-abeja-orbita { transform: translate(180px, 128px) rotate(-16deg); }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-abeja-orbita { transform: translate(158px, 159px) rotate(18deg); }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-zzz { opacity: 1; }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-zzz text { opacity: 0.8; }
+
+  /* Los elementos "aparecen por animación" deben quedar visibles fijos */
+  .jp-ah-vivo.gano .jp-ah-chispa { opacity: 0.9; transform: scale(1); }
+  .jp-ah-vivo.gano .jp-ah-flor-extra { transform: scale(1); }
+  .jp-ah-vivo.p2:not(.gano) .jp-ah-petalo-caido.caido-1 { transform: translate(-16px, 52px) rotate(-130deg); }
+  .jp-ah-vivo.p3:not(.gano) .jp-ah-petalo-caido.caido-2 { transform: translate(12px, 54px) rotate(140deg); }
+  .jp-ah-vivo.p2:not(.gano) .jp-ah-hoja-caida path,
+  .jp-ah-vivo.p3:not(.gano) .jp-ah-hoja-caida path { opacity: 0; }
+  .jp-ah-gotas .gota { opacity: 0.9; transform: translateY(10px); }
 }
 
 /* ── Palabra oculta ────────────────────────────────────────────────────── */

--- a/src/components/juego/ahorcado-contaminado.css
+++ b/src/components/juego/ahorcado-contaminado.css
@@ -744,8 +744,23 @@
  * con estas riendas CSS de alcance jp-ah-. Estados: feliz → preocupada →
  * tambaleo → desmayada (sin morbo). */
 
+/* ENTRADA espectacular (el lenguaje del cruce de Angelita, AbejaTransicion:
+   anticipa → se CLAVA en barrel roll → rebasa → asienta): corre UNA vez al
+   montar la escena y, mejor aún, se RE-DISPARA sola al ganar desde p3+ (las
+   reglas de órbita por paso llevan :not(.gano); al volver a la animación base
+   el nombre cambia y la entrada vuelve a correr = revivir espectacular). */
 .jp-ah-abeja-orbita {
-  animation: jp-ah-vuelo-feliz 9s ease-in-out infinite;
+  animation:
+    jp-ah-angelita-entrada 1.6s cubic-bezier(0.33, 1, 0.55, 1) both,
+    jp-ah-vuelo-feliz 9s ease-in-out 1.6s infinite;
+}
+
+@keyframes jp-ah-angelita-entrada {
+  0% { transform: translate(392px, 4px) rotate(356deg) scale(0.3); }
+  16% { transform: translate(366px, 16px) rotate(370deg) scale(0.42); }
+  62% { transform: translate(206px, 96px) rotate(-30deg) scale(1.12); }
+  82% { transform: translate(180px, 52px) rotate(5deg) scale(0.96); }
+  100% { transform: translate(188px, 60px) rotate(-4deg) scale(1); }
 }
 
 @keyframes jp-ah-vuelo-feliz {
@@ -860,8 +875,378 @@
   100% { transform: translateY(-7px); opacity: 0; }
 }
 
-/* Celebración al ganar: vuelo alegre más vivo */
-.jp-ah-vivo.gano .jp-ah-abeja-orbita { animation-duration: 5s; }
+/* Celebración al ganar: re-entrada rápida + vuelo alegre más vivo (dos
+   duraciones: la primera es de la entrada, la segunda de la órbita). */
+.jp-ah-vivo.gano .jp-ah-abeja-orbita { animation-duration: 1.2s, 5s; }
+
+/* ── La abejita obrera: la abeja del arte anterior, ahora SECUNDARIA ──
+ * Pedido del operador: no se saca. Vuela al otro lado de la chagra (sobre el
+ * agua) y muere CON Angelita: aleteo pesado (p2) → tambaleo (p4) → cae
+ * desmayada a la orilla (p6: ojitos cerrados, alitas plegadas, desteñida).
+ * Todo con :not(.gano): al ganar revive con las demás. */
+
+.jp-ah-abeja2-orbita {
+  animation: jp-ah-abeja2-vuelo 10s ease-in-out infinite;
+}
+
+@keyframes jp-ah-abeja2-vuelo {
+  0%, 100% { transform: translate(300px, 74px) rotate(4deg) scale(0.8); }
+  30% { transform: translate(262px, 92px) rotate(-6deg) scale(0.8); }
+  60% { transform: translate(318px, 104px) rotate(5deg) scale(0.8); }
+  80% { transform: translate(330px, 82px) rotate(-4deg) scale(0.8); }
+}
+
+.jp-ah-abeja2 {
+  animation: jp-ah-abeja-bob 1.3s ease-in-out infinite alternate,
+    jp-ah-boil 0.55s linear infinite;
+}
+
+.jp-ah-abeja-cuerpo {
+  fill: #ffd23e;
+  stroke: #3a2c1a;
+  stroke-width: 1.3;
+  transition: fill 1.4s ease;
+}
+
+.jp-ah-franja { fill: #3a2c1a; }
+
+.jp-ah-abeja-cabeza {
+  fill: #3a2c1a;
+}
+
+.jp-ah-antenas path {
+  fill: none;
+  stroke: #3a2c1a;
+  stroke-width: 1.1;
+  stroke-linecap: round;
+  transform-box: fill-box;
+  transform-origin: bottom right;
+  transition: transform 1s ease;
+}
+
+.jp-ah-antenas circle { fill: #3a2c1a; }
+
+.jp-ah-ala ellipse {
+  fill: rgba(219, 234, 254, 0.8);
+  stroke: #93c5fd;
+  stroke-width: 0.9;
+}
+
+.jp-ah-ala {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: jp-ah-aleteo 0.16s linear infinite alternate;
+  transition: transform 1s ease;
+}
+
+.jp-ah-ala.ala-der { animation-delay: -0.08s; }
+
+@keyframes jp-ah-aleteo {
+  from { transform: scaleY(1) rotate(-4deg); }
+  to { transform: scaleY(0.4) rotate(6deg); }
+}
+
+.jp-ah-ojos-abiertos ellipse { fill: #ffffff; }
+.jp-ah-ojos-abiertos .jp-ah-pupila { fill: #1c140c; }
+
+.jp-ah-sonrisa,
+.jp-ah-ojos-cerrados path {
+  fill: none;
+  stroke: #ffffff;
+  stroke-width: 0.8;
+  stroke-linecap: round;
+}
+
+.jp-ah-ojos-cerrados { opacity: 0; }
+
+.jp-ah-patitas path {
+  fill: none;
+  stroke: #3a2c1a;
+  stroke-width: 1;
+  stroke-linecap: round;
+}
+
+/* p2: el aleteo se le hace pesado y baja a volar cerca del agua. */
+.jp-ah-vivo.p2:not(.gano) .jp-ah-abeja2-orbita {
+  animation: jp-ah-abeja2-pesada 7s ease-in-out infinite;
+}
+
+.jp-ah-vivo.p2:not(.gano) .jp-ah-ala { animation-duration: 0.3s; }
+
+@keyframes jp-ah-abeja2-pesada {
+  0%, 100% { transform: translate(296px, 104px) rotate(-5deg) scale(0.8); }
+  35% { transform: translate(268px, 118px) rotate(7deg) scale(0.8); }
+  70% { transform: translate(316px, 124px) rotate(-6deg) scale(0.8); }
+}
+
+/* p4: tambalea igual que su compañera grande. */
+.jp-ah-vivo.p4:not(.gano) .jp-ah-abeja2-orbita {
+  animation: jp-ah-abeja2-tambalea 3.4s ease-in-out infinite;
+}
+
+.jp-ah-vivo.p4:not(.gano) .jp-ah-ala { animation-duration: 0.45s; }
+
+@keyframes jp-ah-abeja2-tambalea {
+  0%, 100% { transform: translate(288px, 128px) rotate(-14deg) scale(0.8); }
+  25% { transform: translate(302px, 140px) rotate(16deg) scale(0.8); }
+  55% { transform: translate(276px, 146px) rotate(-18deg) scale(0.8); }
+  80% { transform: translate(294px, 136px) rotate(12deg) scale(0.8); }
+}
+
+/* p6: cae desmayada a la orilla del agua turbia, junto a la chagra apagada. */
+.jp-ah-vivo.p6:not(.gano) .jp-ah-abeja2-orbita {
+  animation: jp-ah-abeja2-cae 1.4s cubic-bezier(0.4, 0, 1, 1) 0.15s both;
+}
+
+@keyframes jp-ah-abeja2-cae {
+  0% { transform: translate(288px, 138px) rotate(-10deg) scale(0.8); }
+  62% { transform: translate(310px, 182px) rotate(24deg) scale(0.8); }
+  76% { transform: translate(312px, 177px) rotate(19deg) scale(0.8); }
+  100% { transform: translate(314px, 184px) rotate(16deg) scale(0.8); }
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-abeja2 {
+  animation: jp-ah-desmayo 3s ease-in-out infinite alternate;
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-ala {
+  animation: none;
+  transform: scaleY(0.5) rotate(48deg);
+  opacity: 0.7;
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-antenas path { transform: rotate(34deg); }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-ojos-abiertos { opacity: 0; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-ojos-cerrados { opacity: 1; }
+.jp-ah-vivo.p6:not(.gano) .jp-ah-abeja-cuerpo { fill: #d9c383; }
+
+/* ── El colibrí chillón: secundaria de aire (Colibri REAL del kit) ──
+ * Entra DARDEANDO desde fuera de cuadro (entrada espectacular de la casa:
+ * dardo que se pasa → corrige con overshoot → se asienta) y se cierne sobre
+ * la flor. Su actuación (dardos, estelas, parpadeo) es del componente vía
+ * los MISMOS props de Angelita; aquí van la órbita y el desmayo (p6: caído
+ * al pie de la mata, ojitos cerrados con el truco rh-blink, gris suave). */
+
+.jp-ah-colibri-orbita {
+  animation:
+    jp-ah-colibri-entrada 1.3s cubic-bezier(0.3, 1.4, 0.5, 1) both,
+    jp-ah-colibri-vuelo 7s ease-in-out 1.3s infinite;
+}
+
+.jp-ah-colibri-marco { transition: filter 1.4s ease; }
+
+@keyframes jp-ah-colibri-entrada {
+  0% { transform: translate(-34px, 12px); }
+  55% { transform: translate(152px, 32px); }
+  75% { transform: translate(96px, 46px); }
+  100% { transform: translate(108px, 38px); }
+}
+
+@keyframes jp-ah-colibri-vuelo {
+  0%, 100% { transform: translate(108px, 38px); }
+  20% { transform: translate(148px, 30px); }
+  45% { transform: translate(158px, 50px); }
+  70% { transform: translate(118px, 54px); }
+}
+
+.jp-ah-vivo.p2:not(.gano) .jp-ah-colibri-marco { filter: saturate(0.8); }
+
+.jp-ah-vivo.p3:not(.gano) .jp-ah-colibri-orbita {
+  animation: jp-ah-colibri-preocupado 5s ease-in-out infinite;
+}
+
+@keyframes jp-ah-colibri-preocupado {
+  0%, 100% { transform: translate(122px, 62px) rotate(-6deg); }
+  35% { transform: translate(146px, 72px) rotate(7deg); }
+  70% { transform: translate(108px, 76px) rotate(-8deg); }
+}
+
+.jp-ah-vivo.p4:not(.gano) .jp-ah-colibri-marco { filter: saturate(0.6) brightness(0.96); }
+
+.jp-ah-vivo.p5:not(.gano) .jp-ah-colibri-orbita {
+  animation: jp-ah-colibri-tambalea 2.8s ease-in-out infinite;
+}
+
+.jp-ah-vivo.p5:not(.gano) .jp-ah-colibri-marco .crt-wing { animation-duration: 0.34s; }
+
+@keyframes jp-ah-colibri-tambalea {
+  0%, 100% { transform: translate(112px, 80px) rotate(-14deg); }
+  25% { transform: translate(128px, 92px) rotate(15deg); }
+  55% { transform: translate(100px, 96px) rotate(-17deg); }
+  80% { transform: translate(120px, 88px) rotate(11deg); }
+}
+
+/* p6: cae al pie de la mata, del lado contrario a Angelita — los dos
+   polinizadores juntos. React ya lo puso en reposo/descansa (posado, alitas
+   plegadas, respirando); el juego cierra ojitos y destiñe. */
+.jp-ah-vivo.p6:not(.gano) .jp-ah-colibri-orbita {
+  animation: jp-ah-colibri-cae 1.4s cubic-bezier(0.4, 0, 1, 1) 0.1s both;
+}
+
+@keyframes jp-ah-colibri-cae {
+  0% { transform: translate(114px, 84px) rotate(-10deg); }
+  60% { transform: translate(96px, 156px) rotate(-30deg); }
+  78% { transform: translate(93px, 150px) rotate(-24deg); }
+  100% { transform: translate(92px, 162px) rotate(-20deg); }
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-colibri-marco {
+  filter: grayscale(0.55) brightness(0.92);
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-colibri-marco .rh-blink {
+  animation: none;
+  transform: scaleY(0.14);
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-colibri-marco .rh-mirada { animation: none; }
+
+/* ── La mariposa pasionaria: la adicional (Mariposa REAL del kit) ──
+ * Aletea alto sobre el surco con sus cuatro alas independientes; se destiñe
+ * (saturate progresivo), tambalea y cae plegada junto a sus compañeras. */
+
+.jp-ah-dione-orbita {
+  animation:
+    jp-ah-dione-entrada 1.8s cubic-bezier(0.34, 1.3, 0.6, 1) both,
+    jp-ah-dione-vuelo 12s ease-in-out 1.8s infinite;
+}
+
+.jp-ah-dione-marco { transition: filter 1.4s ease; }
+
+@keyframes jp-ah-dione-entrada {
+  0% { transform: translate(-32px, 152px) rotate(-20deg); }
+  60% { transform: translate(74px, 92px) rotate(14deg); }
+  100% { transform: translate(56px, 112px) rotate(4deg); }
+}
+
+@keyframes jp-ah-dione-vuelo {
+  0%, 100% { transform: translate(56px, 112px) rotate(4deg); }
+  30% { transform: translate(84px, 100px) rotate(-6deg); }
+  55% { transform: translate(96px, 120px) rotate(5deg); }
+  80% { transform: translate(66px, 126px) rotate(-5deg); }
+}
+
+.jp-ah-vivo.p2:not(.gano) .jp-ah-dione-marco { filter: saturate(0.75); }
+.jp-ah-vivo.p2:not(.gano) .jp-ah-dione-marco .crt-fwing { animation-duration: 0.6s; }
+
+.jp-ah-vivo.p4:not(.gano) .jp-ah-dione-orbita {
+  animation: jp-ah-dione-tambalea 3.8s ease-in-out infinite;
+}
+
+.jp-ah-vivo.p4:not(.gano) .jp-ah-dione-marco { filter: saturate(0.5) brightness(0.95); }
+.jp-ah-vivo.p4:not(.gano) .jp-ah-dione-marco .crt-fwing { animation-duration: 0.9s; }
+
+@keyframes jp-ah-dione-tambalea {
+  0%, 100% { transform: translate(70px, 132px) rotate(-10deg); }
+  30% { transform: translate(88px, 142px) rotate(12deg); }
+  65% { transform: translate(58px, 148px) rotate(-13deg); }
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-dione-orbita {
+  animation: jp-ah-dione-cae 1.6s cubic-bezier(0.4, 0, 1, 1) 0.2s both;
+}
+
+@keyframes jp-ah-dione-cae {
+  0% { transform: translate(70px, 140px) rotate(-8deg); }
+  62% { transform: translate(44px, 164px) rotate(-60deg); }
+  78% { transform: translate(42px, 159px) rotate(-52deg); }
+  100% { transform: translate(40px, 168px) rotate(-75deg); }
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-dione-marco { filter: grayscale(0.75) brightness(0.9); }
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-dione-marco .crt-fwing {
+  animation: none;
+  transform: scaleX(0.3);
+}
+
+/* ── El escarabajo estercolero: secundaria de suelo (Escarabajo REAL) ──
+ * Entra RODANDO su bola desde el borde (frena con un pasito de arrastre) y
+ * patrulla el primer plano. El suelo agrietado (p3) lo pone lento; en p5 se
+ * frena donde va (play-state paused: sin saltos) y en p6 se VUELCA gris —
+ * un suelo muerto no tiene abono que rodar. */
+
+.jp-ah-escarabajo-orbita {
+  animation:
+    jp-ah-escarabajo-entrada 1.8s cubic-bezier(0.3, 1.2, 0.5, 1) both,
+    jp-ah-escarabajo-camina 16s ease-in-out 1.8s infinite alternate;
+}
+
+.jp-ah-escarabajo-marco {
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: filter 1.4s ease, transform 1.2s ease;
+}
+
+@keyframes jp-ah-escarabajo-entrada {
+  0% { transform: translate(392px, 186px); }
+  70% { transform: translate(208px, 184px); }
+  85% { transform: translate(219px, 184px); }
+  100% { transform: translate(214px, 185px); }
+}
+
+@keyframes jp-ah-escarabajo-camina {
+  from { transform: translate(214px, 185px); }
+  to { transform: translate(140px, 187px); }
+}
+
+.jp-ah-vivo.p3:not(.gano) .jp-ah-escarabajo-orbita { animation-duration: 1.8s, 34s; }
+.jp-ah-vivo.p3:not(.gano) .jp-ah-escarabajo-marco { filter: saturate(0.7); }
+
+.jp-ah-vivo.p5:not(.gano) .jp-ah-escarabajo-orbita { animation-play-state: paused, paused; }
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-escarabajo-orbita { animation-play-state: paused, paused; }
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-escarabajo-marco {
+  transform: scale(-0.75, 0.75) rotate(160deg);
+  filter: grayscale(0.7) brightness(0.9);
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-escarabajo-marco .crt-legs,
+.jp-ah-vivo.p6:not(.gano) .jp-ah-escarabajo-marco .crt-ball { animation: none; }
+
+/* ── La lombriz nativa: secundaria de suelo (Lombriz REAL del kit) ──
+ * BROTA del suelo fértil con overshoot (su entrada) y se mece; el suelo
+ * agrietado la retrae y palidece, y en p6 queda lánguida sobre la tierra
+ * muerta. Al ganar re-brota — el suelo vivo vuelve. */
+
+.jp-ah-lombriz-marco {
+  transform-box: fill-box;
+  transform-origin: bottom center;
+  animation:
+    jp-ah-lombriz-brota 1.4s cubic-bezier(0.34, 1.56, 0.64, 1) both,
+    jp-ah-lombriz-mece 4.6s ease-in-out 1.4s infinite alternate;
+  transition: filter 1.4s ease, transform 1.2s ease;
+}
+
+@keyframes jp-ah-lombriz-brota {
+  0% { transform: translateY(16px) scaleY(0.2); }
+  70% { transform: translateY(-2px) scaleY(1.08); }
+  100% { transform: translateY(0) scaleY(1); }
+}
+
+@keyframes jp-ah-lombriz-mece {
+  from { transform: rotate(-6deg); }
+  to { transform: rotate(7deg); }
+}
+
+.jp-ah-vivo.p3:not(.gano) .jp-ah-lombriz-marco {
+  animation: none;
+  transform: translateY(7px) rotate(24deg);
+  filter: saturate(0.6) brightness(0.95);
+}
+
+.jp-ah-vivo.p5:not(.gano) .jp-ah-lombriz-marco {
+  animation: none;
+  transform: translateY(9px) rotate(52deg);
+  filter: saturate(0.4) brightness(0.92);
+}
+
+.jp-ah-vivo.p6:not(.gano) .jp-ah-lombriz-marco {
+  animation: none;
+  transform: translateY(10px) rotate(80deg);
+  filter: grayscale(0.7) brightness(0.9);
+}
 
 /* ── Las mariposas: secundarias que acompañan a Angelita ──
  * Corrección del operador: NO se sacan y NO huyen de escena — el químico
@@ -1129,6 +1514,22 @@
   .jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-orbita { transform: translate(226px, 170px) rotate(74deg); }
   .jp-ah-vivo.p6:not(.gano) .mariposa-orbita-2 { transform: translate(60px, 172px) rotate(-68deg); }
   .jp-ah-vivo.p6:not(.gano) .jp-ah-mariposa-ala { transform: scaleX(0.2); }
+  .jp-ah-abeja2-orbita { transform: translate(300px, 88px) scale(0.8); }
+  .jp-ah-vivo.p2:not(.gano) .jp-ah-abeja2-orbita { transform: translate(290px, 112px) scale(0.8); }
+  .jp-ah-vivo.p4:not(.gano) .jp-ah-abeja2-orbita { transform: translate(288px, 136px) rotate(-14deg) scale(0.8); }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-abeja2-orbita { transform: translate(314px, 184px) rotate(16deg) scale(0.8); }
+  .jp-ah-colibri-orbita { transform: translate(120px, 42px); }
+  .jp-ah-vivo.p3:not(.gano) .jp-ah-colibri-orbita { transform: translate(122px, 66px); }
+  .jp-ah-vivo.p5:not(.gano) .jp-ah-colibri-orbita { transform: translate(112px, 84px) rotate(-12deg); }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-colibri-orbita { transform: translate(92px, 162px) rotate(-20deg); }
+  .jp-ah-dione-orbita { transform: translate(64px, 112px); }
+  .jp-ah-vivo.p4:not(.gano) .jp-ah-dione-orbita { transform: translate(72px, 136px) rotate(-8deg); }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-dione-orbita { transform: translate(40px, 168px) rotate(-75deg); }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-dione-marco .crt-fwing { transform: scaleX(0.3); }
+  .jp-ah-escarabajo-orbita { transform: translate(200px, 185px); }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-ala { transform: scaleY(0.5) rotate(48deg); }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-ojos-cerrados { opacity: 1; }
+  .jp-ah-vivo.p6:not(.gano) .jp-ah-ojos-abiertos { opacity: 0; }
   .jp-ah-abeja-orbita { transform: translate(200px, 80px); }
   .jp-ah-vivo.p3:not(.gano) .jp-ah-abeja-orbita { transform: translate(185px, 105px); }
   .jp-ah-vivo.p5:not(.gano) .jp-ah-abeja-orbita { transform: translate(180px, 128px) rotate(-16deg); }


### PR DESCRIPTION
## Qué hace

Correcciones del operador sobre la escena animada del Ahorcado Contaminado (base: arte del PR #2824):

1. **Angelita REAL, no abeja genérica.** La escena usa el componente compartido `AbejaAngelita` (Tetragonisca angustula rubber-hose: squash&stretch, aleteo de tul, parpadeo, cachetes, antenas con follow-through) en modo `inline`. El juego solo la **dirige**: `pose/animo/energia/sed/polen/cejas` por props según los errores (plena con polen → atenta → sedienta con jadeo → desmayada en reposo) + riendas CSS de alcance `jp-ah-` (alas pesadas en p5, ojitos cerrados vía `rh-blink` + gris suave en p6). **Ningún componente compartido se modifica.**

2. **Las secundarias mueren CON ella, no desaparecen ni huyen.** Y el elenco creció por pedido del operador:
   - **La abejita obrera** (la abeja del arte anterior — se conserva): vuela sobre el agua, tambalea y cae a la orilla con ojitos cerrados.
   - **Colibrí REAL** del kit (misma dirección de actuación que Angelita): dardea, se apaga y cae al pie de la mata — los dos polinizadores juntos.
   - **Mariposa pasionaria REAL** (Dione juno) + las 2 mariposas de la escena: se destiñen por variables CSS en transición, tambalean y caen plegadas.
   - **Lombriz REAL**: brota del suelo fértil, palidece cuando el suelo se agrieta, queda lánguida en p6.
   - **Escarabajo REAL**: patrulla con su bola de abono, el suelo agrietado lo arrastra, en p6 queda volcado gris.

3. **Entrada y salida espectacular** (el lenguaje del cruce de `AbejaTransicion`, reusado como coreografía CSS): Angelita entra clavándose en barrel roll con anticipación y overshoot; el colibrí dardea desde fuera de cuadro; el escarabajo entra rodando con frenada; la lombriz brota con overshoot. Al ganar desde p3+ las órbitas base se re-disparan solas (`:not(.gano)`) = revivir con re-entrada espectacular. La salida = caídas cinematográficas escalonadas.

Se mantiene todo lo demás del arte: chagra que se contamina en 6 pasos, revivir al ganar, `prefers-reduced-motion` (estados plantados por paso, ninguna criatura desaparece).

## Verificación

- Smoke tests del juego: 4/4 verdes
- eslint `--max-warnings=0` + lefthook completo verdes
- `npm run build` verde; chunk `AhorcadoContaminado-*.js` en dist con las creatures cableadas
- Gate visual headed (GPU real, alpha X11): 4 estados jugados de verdad (Math.random pineado → NAUSEA), **0 pageerrors**. PNGs en `Chagra-strategy/ops/briefs/artefactos/2026-07-30-ahorcado-angelita-{sano,contaminado,perdido,ganado}-202607302005.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)