### PR TITLE
feat(paramo): guardián queñua + quinta vista + cámara de grúa en el nacedero

### DIFF
--- a/src/mockups/ParamoHumboldt3D.jsx
+++ b/src/mockups/ParamoHumboldt3D.jsx
@@ -92,16 +92,17 @@ const VISTAS = {
      se retrata en contrapicado) y el cuadro sube hasta la copa, que es donde
      está la lección: ahí es donde la niebla entra y no vuelve a salir. */
   quenua: {
-    /* a 16.5 del guardián: con menos aire la copa no cabía en el cuadro, y la
-       copa ES la lección — el retrato que la corta cuenta otra cosa. La cámara
-       queda justo sobre la boca de la portilla: se le mira desde la puerta por
-       donde su agua se va. */
+    /* a 18 del guardián: con menos aire la copa quedaba ROZANDO el borde del
+       cuadro, y la copa ES la lección — un retrato que se la corta (o se la
+       aprieta) cuenta otra cosa. A la corona se le deja cielo encima, como en
+       cualquier lámina que se respete. La cámara queda sobre la boca de la
+       portilla: se le mira desde la puerta por donde su agua se va. */
     pos: new THREE.Vector3(
-      GUARDIAN.x + Math.sin(GUARDIAN.rotY) * 16.5,
+      GUARDIAN.x + Math.sin(GUARDIAN.rotY) * 18,
       GUARDIAN.y + 2.1,
-      GUARDIAN.z + Math.cos(GUARDIAN.rotY) * 16.5,
+      GUARDIAN.z + Math.cos(GUARDIAN.rotY) * 18,
     ),
-    mira: new THREE.Vector3(GUARDIAN.x, GUARDIAN.y + 5.1, GUARDIAN.z),
+    mira: new THREE.Vector3(GUARDIAN.x, GUARDIAN.y + 5.0, GUARDIAN.z),
     fov: 50,
   },
   /* EL AGUA QUE BAJA: en la portilla, de espaldas al anfiteatro, viendo cómo

--- a/src/mockups/ParamoHumboldt3D.jsx
+++ b/src/mockups/ParamoHumboldt3D.jsx
@@ -16,12 +16,19 @@
  * cielo; adelante, por la portilla, la meseta se despeña y la quebrada se va
  * hecha hilo a la niebla — que es donde están las fincas.
  *
- * Las cuatro vistas cuentan el ciclo entero, en orden:
+ * Las cinco vistas cuentan el ciclo entero, en orden:
  *   1. EL NACEDERO   — el sitio: dónde nace el agua y cómo se ve por dentro.
  *   2. LA LÁMINA     — el corte: por qué la turba es una esponja y por qué el
  *                      agua sale toda a la misma altura de la pared.
  *   3. EL FRAILEJONAL— quién atrapa la niebla, y a qué velocidad (ninguna).
- *   4. EL AGUA QUE BAJA — a dónde va: al filo del mundo y al valle.
+ *   4. LA QUEÑUA     — el guardián: el árbol que le quita el agua a la niebla
+ *                      a lo grande, parado en el filo sobre su frailejonal.
+ *   5. EL AGUA QUE BAJA — a dónde va: al filo del mundo y al valle.
+ *
+ * La cámara es de GRÚA, no de ascensor: nace en el aire con el anfiteatro
+ * entero abajo (plano de establecimiento), baja a la portilla, y cada viaje
+ * entre vistas sube por un arco antes de asentarse — el páramo se cuenta
+ * épico porque lo es, no porque se le grite.
  *
  * Congruencia: paleta madre, materiales madre, `<LuzMadre>` con la familia de
  * cielo `ladera`. Cero rig de luz propio, cero assets externos.
@@ -31,8 +38,14 @@ import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { OrbitControls, AdaptiveDpr } from '@react-three/drei';
 import * as THREE from 'three';
 import EscenaNacederoParamo from '../visual/mundo3d/paramo/EscenaNacederoParamo.jsx';
+import { crearNacedero, puestoDelGuardian } from '../visual/mundo3d/paramo/nacederoParamo.geom.js';
 import { LuzMadre, CIELOS, mezclarCielo } from '../visual/mundo3d/paleta/index.js';
 import { decidirTier, perfilDeTier } from '../visual/mundo3d/deviceTier.js';
+
+/* El guardián manda sobre dos vistas, así que su puesto se resuelve también
+   aquí, con el MISMO campo de alturas determinista que monta la escena — son
+   puras clausuras (cero mallas): crearlo dos veces no cuesta ni diverge. */
+const GUARDIAN = puestoDelGuardian(crearNacedero());
 
 /* ══════════════════════════════════════════════════════════════════════════
    LAS VISTAS — dónde se para la cámara
@@ -62,12 +75,34 @@ const VISTAS = {
     mira: new THREE.Vector3(-2.0, 3.1, -7.0),
     fov: 50,
   },
-  /* EL FRAILEJONAL: arriba en la planicie, a la altura de una roseta, mirando
-     el gentío de todas las edades con el filo y el cielo detrás. */
+  /* EL FRAILEJONAL: arriba en la planicie, BAJO — a la altura de una roseta,
+     no por encima del gentío. El tele (fov corto) aprieta las edades unas
+     contra otras como en una lámina naturalista: roseta nueva, mozo, granado
+     y centenario en el mismo cuadro, y al fondo, sobre el filo, el guardián.
+     La mirada sube apenas: las rosetas quedan contra el cielo, no contra el
+     pasto — un frailejonal se retrata hacia arriba o no se retrata. */
   frailejonal: {
-    pos: new THREE.Vector3(-13.5, 9.0, 12.5),
-    mira: new THREE.Vector3(-2.0, 6.0, -1.0),
-    fov: 46,
+    pos: new THREE.Vector3(-15.5, 7.4, 14.5),
+    mira: new THREE.Vector3(-4.4, 6.8, -6.5),
+    fov: 45,
+  },
+  /* LA QUEÑUA: el retrato del guardián, tomado desde el aire del anfiteatro —
+     parado sobre el vacío que el agua abrió, mirando de abajo hacia arriba al
+     que la fabrica. La cámara queda un poco por debajo del rostro (el héroe
+     se retrata en contrapicado) y el cuadro sube hasta la copa, que es donde
+     está la lección: ahí es donde la niebla entra y no vuelve a salir. */
+  quenua: {
+    /* a 16.5 del guardián: con menos aire la copa no cabía en el cuadro, y la
+       copa ES la lección — el retrato que la corta cuenta otra cosa. La cámara
+       queda justo sobre la boca de la portilla: se le mira desde la puerta por
+       donde su agua se va. */
+    pos: new THREE.Vector3(
+      GUARDIAN.x + Math.sin(GUARDIAN.rotY) * 16.5,
+      GUARDIAN.y + 2.1,
+      GUARDIAN.z + Math.cos(GUARDIAN.rotY) * 16.5,
+    ),
+    mira: new THREE.Vector3(GUARDIAN.x, GUARDIAN.y + 5.1, GUARDIAN.z),
+    fov: 50,
   },
   /* EL AGUA QUE BAJA: en la portilla, de espaldas al anfiteatro, viendo cómo
      la quebrada se va al filo del mundo y se cae al valle. */
@@ -104,6 +139,15 @@ const LECCIONES = {
       + '—cosa de un centímetro al año—, así que un frailejón de un metro es más viejo que quien '
       + 'lo está mirando. Se quema en un rato y se demora una vida en volver.',
   },
+  quenua: {
+    titulo: 'La queñua es una fábrica de agua',
+    sub: 'Queñua o colorado · Polylepis · el árbol que llega más arriba',
+    texto: 'El guardián del frailejonal. Mírele la copa: la niebla le entra por ahí y no vuelve '
+      + 'a salir — la copa y su musgo la peinan, el agua se junta en gotas y escurre por el '
+      + 'tronco hasta la turba. Lo que rezuma allá abajo en la pared es esa misma agua. Donde '
+      + 'hay queñuales el nacedero no se seca: por eso el páramo se cuida también sembrando '
+      + 'su árbol.',
+  },
   agua: {
     titulo: 'De aquí para abajo',
     sub: 'La quebrada se va al valle',
@@ -118,6 +162,7 @@ const BOTONES = [
   { id: 'nacedero', texto: 'El nacedero' },
   { id: 'lamina', texto: 'La lámina' },
   { id: 'frailejonal', texto: 'El frailejonal' },
+  { id: 'quenua', texto: 'La queñua' },
   { id: 'agua', texto: 'El agua que baja' },
 ];
 
@@ -127,11 +172,21 @@ const BOTONES = [
 /* Lleva cámara Y objetivo de una vista a otra con interpolación exponencial
    (llega rápido, frena suave). Suelta el mando apenas el usuario toca la
    escena: si el lerp siguiera vivo mientras alguien arrastra, la cámara le
-   pelearía la mano. */
+   pelearía la mano.
+
+   Y el viaje NO es una recta: es un plano de GRÚA. La cámara sube por un arco
+   —proporcional al largo del viaje— y baja a asentarse en la vista. Una
+   recta entre dos vistas atraviesa el cuadro como un ascensor; el arco lo
+   cruza como un vuelo, y de paso enseña el anfiteatro desde arriba en cada
+   cambio, que es la mejor lección de geografía que este mundo puede dar. */
 function Camarografo({ vista, controls, reducedMotion }) {
   const size = useThree((s) => s.size);
   const invalidate = useThree((s) => s.invalidate);
   const animando = useRef(true);
+  /* la grúa del viaje en curso: el largo inicial (d0) fija cuánto sube (lift).
+     d0 en 0 = "mídase en el primer cuadro del viaje" — aquí no se puede leer
+     la cámara (esto corre en render), solo dentro del useFrame. */
+  const viaje = useRef({ d0: 0, lift: 0 });
 
   const destino = useMemo(() => {
     if (vista !== 'nacedero') return VISTAS[vista] || VISTAS.nacederoAncho;
@@ -143,6 +198,7 @@ function Camarografo({ vista, controls, reducedMotion }) {
      abajo jamás corría tras el clic y la cámara no viajaba. */
   useEffect(() => {
     animando.current = true;
+    viaje.current = { d0: 0, lift: 0 };
     invalidate();
   }, [destino, invalidate]);
 
@@ -175,8 +231,23 @@ function Camarografo({ vista, controls, reducedMotion }) {
       animando.current = false;
       return;
     }
+    const v = viaje.current;
+    if (v.d0 <= 0) {
+      v.d0 = Math.max(0.001, cam.position.distanceTo(destino.pos));
+      /* cuánto sube la grúa: con el viaje. Los saltos cortos (el reencuadre
+         ancho↔alto de un resize) casi ni despegan; el vuelo de entrada sube
+         los tres metros enteros. */
+      v.lift = Math.min(3.2, v.d0 * 0.16);
+    }
     const k = 1 - Math.exp(-Math.min(0.1, dt) * 3.0);
+    /* el progreso se lee ANTES del lerp; el seno hace el arco: despega suave,
+       cumbre a mitad de viaje, y aterriza en cero — así el arco jamás corre
+       la marca de llegada. El empujón va multiplicado por k porque el lerp
+       del cuadro siguiente se come justo esa fracción: empujar k cada cuadro
+       sostiene el arco entero, empujar el arco entero lo duplicaría. */
+    const prog = THREE.MathUtils.clamp(1 - cam.position.distanceTo(destino.pos) / v.d0, 0, 1);
     cam.position.lerp(destino.pos, k);
+    cam.position.y += Math.sin(prog * Math.PI) * v.lift * k;
     if (Math.abs(cam.fov - destino.fov) > 0.01) {
       cam.fov += (destino.fov - cam.fov) * k;
       cam.updateProjectionMatrix();
@@ -236,7 +307,7 @@ export default function ParamoHumboldt3D() {
 
   useEffect(() => {
     const alTeclear = (e) => {
-      const i = ['1', '2', '3', '4'].indexOf(e.key);
+      const i = ['1', '2', '3', '4', '5'].indexOf(e.key);
       if (i >= 0) setVista(BOTONES[i].id);
     };
     window.addEventListener('keydown', alTeclear);
@@ -255,7 +326,12 @@ export default function ParamoHumboldt3D() {
         style={{ opacity: listo ? 1 : 0, transition: 'opacity 1s ease' }}
         dpr={perfil.dpr}
         gl={{ antialias: perfil.antialias, powerPreference: 'high-performance' }}
-        camera={{ position: [0.9, 7.4, 12.8], fov: 58, near: 0.3, far: 400 }}
+        /* LA CÁMARA NACE EN EL AIRE, no en la portilla: el primer cuadro es el
+           plano de establecimiento —alto y afuera, el anfiteatro entero y el
+           filo del mundo abajo— y el camarógrafo la baja en grúa hasta la
+           vista madre (~2 s). Con reduced-motion no hay vuelo: el primer
+           cuadro del Camarografo es un corte seco a la portilla. */
+        camera={{ position: [7.5, 18.5, 30], fov: 58, near: 0.3, far: 400 }}
         shadows={!!perfil.sombras}
         frameloop={reducedMotion ? 'demand' : 'always'}
         onCreated={() => setListo(true)}

--- a/src/visual/mundo3d/paramo/EscenaNacederoParamo.jsx
+++ b/src/visual/mundo3d/paramo/EscenaNacederoParamo.jsx
@@ -18,6 +18,7 @@ import { useLayoutEffect, useMemo, useRef } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import SueloRico from '../terreno/SueloRico.jsx';
+import EntGradiente from '../bosque/EntGradiente.jsx';
 import {
   geomFrailejon, geomMortino, geomRomerillo, geomRoca, geomMusgo,
   geomEncenillo, geomAliso, geomGaque, calidadDeTier,
@@ -25,7 +26,7 @@ import {
 import {
   crearNacedero, filoDelNacedero, geomParedTurba, geomRaicesCornisa, geomBloquesTurba,
   geomHilosAgua, geomPoza, geomQuebrada, geomCordilleras, geomRocio,
-  siembraNacedero, EDADES_FRAILEJON, PROSCENIO_NACEDERO,
+  siembraNacedero, EDADES_FRAILEJON, PROSCENIO_NACEDERO, puestoDelGuardian,
 } from './nacederoParamo.geom.js';
 
 /* Un banco: una geometría, un material, N instancias (con cabeceo por mata). */
@@ -86,8 +87,12 @@ function texturaVaho() {
 const BANCOS_NIEBLA = [
   /* LA QUE SE DERRAMA POR EL FILO: se queda ARRIBA, en la boca del anfiteatro.
      Ni un vaho por delante de la pared: la lámina es lo que este mundo existe
-     para enseñar y un velo encima la convierte en un manchón pardo. */
-  { p: [-6.5, 8.4, -9.8], esc: [13, 3.0, 1], op: 0.34, fase: 0.0, amp: 2.4 },
+     para enseñar y un velo encima la convierte en un manchón pardo. El banco
+     izquierdo va BAJO y recostado al hombro del guardián: le envuelve el pie a
+     la queñua (que es su historia — la niebla es su materia prima) pero le
+     deja el rostro libre arriba. Velarle la cara al guardián con su propio
+     vaho es dejar el mundo sin mirador. */
+  { p: [-8.2, 7.3, -9.2], esc: [13, 3.0, 1], op: 0.34, fase: 0.0, amp: 2.4 },
   { p: [6.5, 8.9, -10.6], esc: [14, 3.2, 1], op: 0.32, fase: 1.7, amp: 2.1 },
   /* la bruma de fondo que despega el respaldo del frailejonal (profundidad) */
   { p: [0, 8.5, -22], esc: [86, 7, 1], op: 0.42, fase: 2.6, amp: 2.2 },
@@ -184,6 +189,11 @@ export default function EscenaNacederoParamo({ tier = 'alto', perfil, reducedMot
 
   const siembra = useMemo(() => siembraNacedero(nac, tier, filo), [nac, tier, filo]);
 
+  /* EL GUARDIÁN DEL FRAILEJONAL: la queñua, en el puesto que le resuelve el
+     campo de alturas (hombro izquierdo, afuera del filo, de cara a la
+     portilla — ver `puestoDelGuardian`). */
+  const guardian = useMemo(() => puestoDelGuardian(nac), [nac]);
+
   /* El proscenio: el marco fijo del cuadro (centenarios de primer plano). */
   const proscenio = useMemo(
     () => PROSCENIO_NACEDERO.map((p) => ({
@@ -251,7 +261,10 @@ export default function EscenaNacederoParamo({ tier = 'alto', perfil, reducedMot
   const anclas = useMemo(() => [
     ...proscenio.map((p) => ({ x: p.pos[0], z: p.pos[2], radio: 0.7 * p.escala })),
     ...(siembra.frailejones.centenario || []).map((p) => ({ x: p.pos[0], z: p.pos[2], radio: 0.55 * p.escala })),
-  ], [proscenio, siembra]);
+    /* el guardián también pisa: sin su sombra de contacto, un árbol de este
+       porte parado en la paja se lee flotando */
+    { x: guardian.x, z: guardian.z, radio: 2.0 },
+  ], [proscenio, siembra, guardian]);
 
   const segmentos = tier === 'alto' ? 156 : tier === 'medio' ? 104 : 72;
 
@@ -302,6 +315,20 @@ export default function EscenaNacederoParamo({ tier = 'alto', perfil, reducedMot
         />
       ))}
       <Banco geo={flora.centenario} mat={matTierra} items={proscenio} castShadow={!!perfil.sombras} />
+
+      {/* EL GUARDIÁN DEL FRAILEJONAL: la queñua — el árbol que llega más
+          arriba, asomado sobre el anfiteatro y de cara al sitio donde sale el
+          agua que su copa le quitó a la niebla. El Ent es el de la casa
+          (`EntGradiente`, el mismo del gradiente), tal cual: aquí solo se le
+          da su puesto. Su lección no se monta al pie porque ES el agua, y el
+          agua ya la dibuja este mundo entero. */}
+      <group
+        position={[guardian.x, guardian.y, guardian.z]}
+        rotation={[0, guardian.rotY, 0]}
+        scale={guardian.escala}
+      >
+        <EntGradiente especie="quenua" tier={tier} reducedMotion={reducedMotion} />
+      </group>
 
       {/* la niebla vuelta gota sobre la roseta del frente */}
       {tier !== 'bajo' && <Banco geo={flora.rocio} mat={matAgua} items={rocio} />}

--- a/src/visual/mundo3d/paramo/nacederoParamo.geom.js
+++ b/src/visual/mundo3d/paramo/nacederoParamo.geom.js
@@ -1111,6 +1111,48 @@ function tinte(r, amt) {
   return [cl(f + h), cl(f), cl(f - h * 0.6)];
 }
 
+/*
+ * EL PUESTO DEL GUARDIÁN — dónde se para la queñua.
+ *
+ * El Ent del páramo (la queñua: `MAPA_PISO_ENT.paramo` en
+ * `pisosBosqueGradiente.js`) monta guardia sobre el hombro izquierdo del
+ * anfiteatro: AFUERA del filo —el hueco es del agua, no de los árboles—, con
+ * el frailejonal alrededor y de cara a la portilla. Mira el sitio exacto donde
+ * el agua se escapa, porque ese es su oficio: la queñua es una fábrica de
+ * agua — su copa y su musgo le quitan el agua a la niebla y el suelo se la
+ * entrega al nacedero. El mundo la para en el único punto donde ese ciclo se
+ * ve entero: la niebla arriba, la turba abajo, el agua saliendo al frente.
+ *
+ * El puesto NO es un número a mano: se camina la dirección elegida hasta pisar
+ * tierra firme fuera del filo (con su holgura) y la cota la pone el campo de
+ * alturas — si mañana la herradura crece, el guardián se corre solo. La
+ * DIRECCIÓN sí es decisión de cuadro: atrás-izquierda, para que desde la vista
+ * madre quede al fondo, asomado sobre el anfiteatro, sin taparle la testera a
+ * la lámina (que es lo que este mundo existe para enseñar).
+ */
+export function puestoDelGuardian(nac) {
+  const l = Math.hypot(-0.42, -0.91);
+  const ux = -0.42 / l;
+  const uz = -0.91 / l;
+  let rad = 6;
+  while (rad < 24 && nac.distHueco(ux * rad, uz * rad) < 2.6) rad += 0.25;
+  rad += 0.7; // un paso más atrás del borde: las raíces no cuelgan del talud
+  const x = ux * rad;
+  const z = uz * rad;
+  return {
+    x,
+    z,
+    y: nac.alturaDe(x, z) - 0.08,
+    /* de cara a la portilla (el sitio de la cámara de reposo): el guardián
+       vigila la salida del agua, no al visitante — que mire ahí es lo que
+       hace que la lección se lea sola */
+    rotY: Math.atan2(0.9 - x, 12.8 - z),
+    /* talla de guardián: por encima del Ent de catálogo, pero de árbol, no de
+       torre — el frailejón centenario le llega a la rodilla, como en el páramo */
+    escala: 1.22,
+  };
+}
+
 /**
  * Reparte el páramo sobre el relieve. Devuelve, por banco, las instancias
  * {pos, rotY, escala, tint, tiltX, tiltZ} que consume el InstancedMesh.
@@ -1141,9 +1183,22 @@ export function siembraNacedero(nac, tier = 'alto', filo = null) {
     return EDADES_FRAILEJON[0];
   };
 
-  /* El sitio de la cámara de reposo, con su radio de respeto. */
-  const CAMARA = { x: 0.9, z: 12.8, radio: 3.4 };
-  const enCorredor = (x, z) => Math.hypot(x - CAMARA.x, z - CAMARA.z) < CAMARA.radio;
+  /* Los sitios de cámara, con su radio de respeto: el de reposo en la
+     portilla y el de la vista del frailejonal — un frailejón pegado al lente
+     convierte la lámina naturalista en una mancha verde sin nombre. */
+  const CAMARAS = [
+    { x: 0.9, z: 12.8, radio: 3.4 },
+    { x: -15.5, z: 14.5, radio: 2.8 },
+  ];
+  const enCorredor = (x, z) => CAMARAS.some((c) => Math.hypot(x - c.x, z - c.z) < c.radio);
+
+  /* El claro del guardián: la queñua necesita el pie libre. Un frailejón
+     metido ENTRE sus raíces se lee como injerto, no como cortejo — el cortejo
+     se queda alrededor, de este radio para afuera. El sotobosque bajo (musgo,
+     romerillo) sí puede arrimársele: eso es exactamente lo que hace en el
+     páramo real, y a un árbol se le ve bien el musgo en los pies. */
+  const guardian = puestoDelGuardian(nac);
+  const enClaro = (x, z) => Math.hypot(x - guardian.x, z - guardian.z) < 2.4;
 
   const meter = (e, x, z, opts = {}) => {
     const esc = (opts.eMin ?? e.eMin) + r() * ((opts.eMax ?? e.eMax) - (opts.eMin ?? e.eMin));
@@ -1170,6 +1225,7 @@ export function siembraNacedero(nac, tier = 'alto', filo = null) {
     if (z > nac.P.borde - 1.5) continue; // ni colgando del despeñadero
     if (nac.pendienteDe(x, z) > 0.85) continue;
     if (enCorredor(x, z)) continue;
+    if (enClaro(x, z)) continue;
     // densidad: cae con la distancia al filo (la niebla moja el borde)
     const cerca = 1 - ss(nac.distHueco(x, z), 1, 16);
     if (r() > 0.3 + cerca * 0.7) continue;
@@ -1192,6 +1248,7 @@ export function siembraNacedero(nac, tier = 'alto', filo = null) {
       const x = p.x + gx * fuera;
       const z = p.z + gz * fuera;
       if (enCorredor(x, z)) continue;
+      if (enClaro(x, z)) continue;
       const viejo = EDADES_FRAILEJON[r() > 0.45 ? 6 : 5];
       // se asoma: el cabeceo mira al vacío
       meter(viejo, x, z, {


### PR DESCRIPTION
## Qué hace

Integra el **Ent de la queñua** (`EntGradiente especie="quenua"`, el aprobado del gradiente — `MAPA_PISO_ENT.paramo`) en el mundo del páramo `#/mockups/paramo-humboldt-3d` (el que embebe `3d.guatoc.co/paramo/`), más una pasada estética de cámara.

### El guardián del frailejonal
- `puestoDelGuardian(nac)`: el puesto NO es un número a mano — se camina la dirección de cuadro hasta pisar tierra firme afuera del filo y la cota la pone el campo de alturas. Queda sobre el hombro izquierdo del anfiteatro, de cara a la portilla: mirando el sitio exacto donde sale el agua que su copa le quitó a la niebla.
- Claro al pie (frailejones no se le meten entre las raíces), sombra de contacto, y el banco de niebla izquierdo baja a envolverle el pie sin taparle el rostro.

### Quinta vista: La queñua
- Botón + tecla `5` + lección: **"La queñua es una fábrica de agua"** (texto derivado de la lección aprobada del gradiente).
- Retrato en contrapicado desde la boca de la portilla, con la copa entera en cuadro (la copa ES la lección).

### Cámara (pasada épica)
- **Plano de establecimiento**: la cámara nace en el aire con el anfiteatro entero abajo y baja en grúa a la vista madre (~2 s). Con `prefers-reduced-motion`: corte seco, como siempre.
- **Arco de grúa** en cada viaje entre vistas (proporcional al largo del viaje, aterriza en cero — no corre la marca de llegada).
- Vista frailejonal reencuadrada: baja, tele, rosetas contra el cielo — lámina naturalista con el guardián al fondo; corredor de cámara en la siembra para que ningún frailejón tape el lente.

## Qué NO toca
- Geografía de la Chorrera: intacta. Ninguna otra ruta de páramo, ningún otro mundo, `EntGradiente`/`pisosBosqueGradiente` solo lectura (se importa, no se edita).

## Verificación (GPU real M6000, shot3d --headed)
- 5/5 vistas capturadas, **0 pageerrors** en todas.
- Baseline prod (`3d.guatoc.co/paramo/`) comparado: vista madre y paleta intactas — cambio aditivo.
- Capturas en `Chagra-strategy/ops/briefs/artefactos/2026-07-30-paramo-humboldt-real-1509.png` (retrato queñua) y `...-nacedero-1509.png` (vista madre con el guardián al fondo).
- eslint `--max-warnings=0` limpio en los 3 archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)