### PR TITLE
feat(agente): el cruce 3D → plano — la abeja cruza el túnel y aterriza hecha avatar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -149,6 +149,8 @@ const MontanaMundosCampesinoMockup = lazy(() => import('./mockups/MontanaMundosC
 const EntradaCampesinaMockup = lazy(() => import('./mockups/EntradaCampesina'));
 const HomeCampesinoMockup = lazy(() => import('./mockups/HomeCampesino'));
 const BotonAnarquiaMockup = lazy(() => import('./mockups/BotonAnarquia'));
+// El cruce del agente 3D → plano (la abeja cruza el túnel y aterriza de avatar).
+const TransicionAgentePlanoMockup = lazy(() => import('./mockups/TransicionAgentePlano'));
 const AvatarGameBiopunk = lazy(() => import('./mockups/AvatarGameBiopunk'));
 const AvatarGameVerdeVivo = lazy(() => import('./mockups/AvatarGameVerdeVivo'));
 const AvatarGameLibre = lazy(() => import('./mockups/AvatarGameLibre'));
@@ -754,6 +756,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/entrada-campesina': 'mockup_entrada_campesina',
   'mockups/home-campesino': 'mockup_home_campesino',
   'mockups/boton-anarquia': 'mockup_boton_anarquia',
+  'mockups/transicion-agente-plano': 'mockup_transicion_agente_plano',
   'mockups/avatar-biopunk': 'mockup_avatar_biopunk',
   'mockups/avatar-verde-vivo': 'mockup_avatar_verde_vivo',
   'mockups/avatar-libre': 'mockup_avatar_libre',
@@ -2070,6 +2073,14 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Botón anarquía">
               <BotonAnarquiaMockup onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_transicion_agente_plano':
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="El agente cruza a lo plano">
+              <TransicionAgentePlanoMockup />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/TransicionAgentePlano.jsx
+++ b/src/mockups/TransicionAgentePlano.jsx
@@ -1,0 +1,277 @@
+/*
+ * TransicionAgentePlano — vitrina del CRUCE DEL AGENTE 3D → PLANO.
+ *
+ * La tesis: cuando el valle 3D abre una pantalla plana, el compañero NO debe
+ * morir con el canvas — cruza CON usted. Esta vitrina monta el flujo real de
+ * punta a punta con las piezas de producción:
+ *
+ *   · TunelLamina ('saliendo' / 'entrando') — el túnel Odyssey que ya cruza
+ *     la pantalla en la entrada del valle;
+ *   · AgentePlanoPuente + senalAgentePlano — el puente del agente: la abeja
+ *     se clava al túnel, cruza el destello hecha cometa, aterriza con squash
+ *     & stretch y SE APLANA contra el vidrio hasta ser el avatar plano;
+ *   · BurbujaAngelita — la voz de siempre, que retoma del otro lado.
+ *
+ * El lado "valle" es una lámina de páramo al atardecer (CSS puro, cero
+ * three: la vitrina demuestra el CRUCE, no el mundo). El lado "pantalla" es
+ * una pantalla de la gente: la del agua, con el compAI en su esquina.
+ *
+ * El intercambio valle ↔ pantalla pasa DEBAJO del destello (onCubierto del
+ * túnel) mientras el overlay del agente vuela POR ENCIMA — la misma
+ * arquitectura que necesita el shell real (el puente vive en la raíz que
+ * persiste; la señal cruza el swap). Reduced-motion: corte directo digno,
+ * el avatar plano simplemente aparece.
+ */
+import { useCallback, useRef, useState } from 'react';
+import { AbejaAngelita } from '../visual/creatures/AbejaAngelita.jsx';
+import BurbujaAngelita from '../visual/agente/BurbujaAngelita.jsx';
+import { AgentePlanoPuente } from '../visual/agente/AgentePlanoTransicion.jsx';
+import { posarAgente, alzarAgente } from '../visual/agente/senalAgentePlano.js';
+import {
+  destinoFabPorDefecto,
+  FAB_MARGEN_DER,
+  FAB_MARGEN_ABAJO,
+  FAB_LADO,
+  LADO_VUELO,
+} from '../visual/agente/agentePlanoData.js';
+import TunelLamina from '../visual/mundo3d/transiciones/TunelLamina.jsx';
+import { rectDeOrigen } from '../visual/mundo3d/transiciones/tunelLaminaData.js';
+import { decidirTier } from '../visual/mundo3d/deviceTier.js';
+import './transicionAgentePlano.css';
+
+/* La percha del compañero en la lámina del valle (fracciones del viewport,
+   compartidas entre el CSS de la escena y el rect de llegada al alzar —
+   así el aterrizaje de vuelta es píxel-exacto). */
+const PERCHA_FX = 0.3;
+const PERCHA_FY = 0.42;
+
+const SALUDO_PLANO =
+  'Aquí sigo con usted. El tanque va en 74 % y anoche llovió lo suficiente: su agua está tranquila.';
+
+/* Un frailejón de lámina (silueta digna, sin pretensión botánica). */
+function Frailejon({ left, bottom, size = 64 }) {
+  return (
+    <svg
+      className="tap-frailejon"
+      style={{ left, bottom, width: size, height: size * 1.5 }}
+      viewBox="0 0 40 60"
+      aria-hidden="true"
+    >
+      <rect x="17" y="22" width="6" height="38" rx="3" fill="#4a4132" />
+      <g fill="#7fae7a">
+        <ellipse cx="20" cy="16" rx="4" ry="13" />
+        <ellipse cx="20" cy="16" rx="4" ry="13" transform="rotate(40 20 16)" />
+        <ellipse cx="20" cy="16" rx="4" ry="13" transform="rotate(-40 20 16)" />
+        <ellipse cx="20" cy="16" rx="4" ry="13" transform="rotate(75 20 16)" />
+        <ellipse cx="20" cy="16" rx="4" ry="13" transform="rotate(-75 20 16)" />
+      </g>
+      <circle cx="20" cy="15" r="4.5" fill="#e8c95a" />
+    </svg>
+  );
+}
+
+export default function TransicionAgentePlanoMockup() {
+  const [equipo] = useState(decidirTier);
+  const reducedMotion =
+    typeof window !== 'undefined' &&
+    !!window.matchMedia &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const [vista, setVista] = useState('valle'); // 'valle' | 'pantalla'
+  const [tunel, setTunel] = useState(null); // null | { fase, destino, rect }
+  const [abejaViva, setAbejaViva] = useState(true); // la compañera en la lámina
+  const [chipVisible, setChipVisible] = useState(false); // el avatar plano posado
+  const [cruzando, setCruzando] = useState(false);
+
+  const refAbeja = useRef(null);
+  const refChip = useRef(null);
+
+  // ── ZARPAR: valle 3D → pantalla plana. El overlay del agente retoma a la
+  //    abeja en su percha EXACTA (rect medido) y la escena la esconde en el
+  //    mismo instante: una sola alma, cero abejas dobles.
+  const abrirPantalla = useCallback(
+    (ev) => {
+      if (cruzando) return;
+      setCruzando(true);
+      const desde = rectDeOrigen(refAbeja.current);
+      setAbejaViva(false);
+      if (reducedMotion) {
+        setVista('pantalla');
+      } else {
+        setTunel({ fase: 'saliendo', destino: 'agua', rect: rectDeOrigen(ev) });
+      }
+      posarAgente({ desde, animo: 'sereno', energia: 1 });
+    },
+    [cruzando, reducedMotion],
+  );
+
+  // ── VOLVER: pantalla plana → valle. El avatar se despega del vidrio y el
+  //    overlay vuela de vuelta a la percha (mismas fracciones que la escena).
+  const volverAlValle = useCallback(
+    (ev) => {
+      if (cruzando) return;
+      setCruzando(true);
+      const desde = rectDeOrigen(refChip.current);
+      setChipVisible(false);
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const hasta = {
+        x: vw * PERCHA_FX - LADO_VUELO / 2,
+        y: vh * PERCHA_FY - LADO_VUELO / 2,
+        width: LADO_VUELO,
+        height: LADO_VUELO,
+      };
+      if (reducedMotion) {
+        setVista('valle');
+      } else {
+        setTunel({ fase: 'entrando', destino: 'valle', rect: rectDeOrigen(ev) });
+      }
+      alzarAgente({ desde, hasta });
+    },
+    [cruzando, reducedMotion],
+  );
+
+  // El puente avisa: posado (revelar el avatar del lado que recibe) y fin.
+  const onPosadaPuente = useCallback((sentido) => {
+    if (sentido === 'posar') setChipVisible(true);
+    else setAbejaViva(true);
+  }, []);
+  const onFinPuente = useCallback(() => setCruzando(false), []);
+
+  const fab = typeof window === 'undefined'
+    ? { x: 0, y: 0 }
+    : destinoFabPorDefecto({ ancho: window.innerWidth, alto: window.innerHeight });
+
+  return (
+    <div className="tap" data-vista={vista}>
+      {vista === 'valle' && (
+        <section className="tap-valle" aria-label="El valle de la finca al atardecer">
+          {/* La lámina: cielo, cordones de montaña, niebla y frailejones. */}
+          <div className="tap-cielo" aria-hidden="true" />
+          <div className="tap-sol" aria-hidden="true" />
+          <div className="tap-loma tap-loma--lejos" aria-hidden="true" />
+          <div className="tap-loma tap-loma--media" aria-hidden="true" />
+          <div className="tap-niebla" aria-hidden="true" />
+          <div className="tap-loma tap-loma--cerca" aria-hidden="true" />
+          <Frailejon left="14%" bottom="16%" size={46} />
+          <Frailejon left="24%" bottom="9%" size={72} />
+          <Frailejon left="66%" bottom="13%" size={56} />
+          <Frailejon left="82%" bottom="7%" size={84} />
+
+          {/* La compañera, VIVA en el mundo: flota con su sombra debajo
+              (el volumen que luego va a rendir contra el vidrio). */}
+          {abejaViva && (
+            <div
+              className="tap-percha"
+              style={{ left: `${PERCHA_FX * 100}%`, top: `${PERCHA_FY * 100}%` }}
+            >
+              <div className="tap-abeja" ref={refAbeja}>
+                <AbejaAngelita size={LADO_VUELO} animo="sereno" energia={1} animated />
+              </div>
+              <span className="tap-abeja-sombra" aria-hidden="true" />
+            </div>
+          )}
+
+          <header className="tap-encabezado">
+            <span className="tap-eyebrow">Vitrina · el agente cruza a lo plano</span>
+            <h1>El valle, con su compañera</h1>
+          </header>
+
+          <aside className="tap-panel">
+            <h2>El agua de su finca</h2>
+            <p>
+              Al abrir la pantalla, el túnel cruza — y ella cruza con usted:
+              se clava a la luz y aterriza hecha el agente de su pantalla.
+            </p>
+            <button type="button" className="tap-cta" onClick={abrirPantalla} disabled={cruzando}>
+              Abrir la pantalla del agua »
+            </button>
+          </aside>
+        </section>
+      )}
+
+      {vista === 'pantalla' && (
+        <section className="tap-pantalla" aria-label="La pantalla del agua">
+          <header className="tap-pantalla-encabezado">
+            <button
+              type="button"
+              className="tap-volver"
+              onClick={volverAlValle}
+              disabled={cruzando}
+            >
+              ‹ Volver al valle
+            </button>
+            <h1>El agua de mi finca</h1>
+          </header>
+
+          <div className="tap-tarjetas">
+            <article className="tap-tarjeta">
+              <span className="tap-tarjeta-dato">74 %</span>
+              <p>Tanque principal — nivel sano para la semana.</p>
+            </article>
+            <article className="tap-tarjeta">
+              <span className="tap-tarjeta-dato">12 mm</span>
+              <p>Lluvia de anoche sobre la vereda.</p>
+            </article>
+            <article className="tap-tarjeta">
+              <span className="tap-tarjeta-dato">Al día</span>
+              <p>El reservorio y las canales no reportan novedades.</p>
+            </article>
+          </div>
+
+          {/* El AGENTE PLANO: el mismo compañero, ahora calcomanía viva en la
+              esquina de toda pantalla — revelado en el instante exacto en que
+              el overlay lo posa (empalme sin hueco). */}
+          {chipVisible && (
+            <>
+              <div
+                className="tap-chip"
+                ref={refChip}
+                style={{ right: FAB_MARGEN_DER, bottom: FAB_MARGEN_ABAJO, width: FAB_LADO, height: FAB_LADO }}
+              >
+                <AbejaAngelita size={FAB_LADO - 12} animo="sereno" energia={1} animated />
+              </div>
+              <div
+                className="tap-burbuja"
+                style={{ right: FAB_MARGEN_DER, bottom: FAB_MARGEN_ABAJO + FAB_LADO + 14 }}
+              >
+                <BurbujaAngelita mensaje={SALUDO_PLANO} tipo="informativa" />
+              </div>
+            </>
+          )}
+          {/* Ancla fantasma del aterrizaje (depurable): coincide con
+              destinoFabPorDefecto — el overlay aterriza aquí. */}
+          <span
+            className="tap-ancla"
+            style={{ left: fab.x, top: fab.y, width: FAB_LADO, height: FAB_LADO }}
+            aria-hidden="true"
+          />
+        </section>
+      )}
+
+      {/* El TÚNEL real de producción: cruza la pantalla; el swap va debajo
+          del destello (onCubierto). */}
+      {tunel && (
+        <TunelLamina
+          fase={tunel.fase}
+          destino={tunel.destino}
+          rect={tunel.rect}
+          tier={equipo.tier}
+          reducedMotion={reducedMotion}
+          letrero={tunel.fase === 'saliendo' ? 'A la pantalla del agua…' : 'De vuelta al valle…'}
+          onCubierto={() => setVista(tunel.fase === 'saliendo' ? 'pantalla' : 'valle')}
+          onFin={() => setTunel(null)}
+        />
+      )}
+
+      {/* El PUENTE del agente: vive en esta raíz (persiste al swap) y corre
+          el cruce por encima del túnel. */}
+      <AgentePlanoPuente
+        tier={equipo.tier}
+        reducedMotion={reducedMotion}
+        onPosada={onPosadaPuente}
+        onFin={onFinPuente}
+      />
+    </div>
+  );
+}

--- a/src/mockups/transicionAgentePlano.css
+++ b/src/mockups/transicionAgentePlano.css
@@ -115,9 +115,12 @@
   justify-content: center;
   flex-direction: column;
 }
+/* Sin drop-shadow CSS sobre el sprite: el filtro del wrapper interactúa mal
+   con los filtros SVG internos de la creature (boil/aura) y pinta la REGIÓN
+   del filtro como un cuadro — verificado en captura GPU. La profundidad la
+   vende la sombra-elipse dedicada de abajo. */
 .tap-abeja {
   will-change: transform;
-  filter: drop-shadow(0 6px 14px rgba(20, 30, 15, 0.35));
   animation: tapFlota 3.4s ease-in-out infinite;
 }
 @keyframes tapFlota {

--- a/src/mockups/transicionAgentePlano.css
+++ b/src/mockups/transicionAgentePlano.css
@@ -1,0 +1,313 @@
+/*
+ * transicionAgentePlano.css — la vitrina del cruce del agente 3D → plano.
+ *
+ * Dos escenarios: la LÁMINA del valle (páramo al atardecer — lámina Humboldt
+ * dibujada en CSS puro, cero fotorealismo) y la PANTALLA de la gente (la del
+ * agua). El cruce en sí vive en agentePlano.css + tunelLamina.css — este
+ * archivo solo viste los dos lados. Solo transform/opacity en lo animado.
+ */
+
+.tap {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+  background: #0d1509;
+}
+
+/* ══ EL VALLE: lámina de páramo al atardecer ═════════════════════════════ */
+
+.tap-valle {
+  position: absolute;
+  inset: 0;
+}
+
+.tap-cielo {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    #1b2a4a 0%,
+    #37517c 34%,
+    #b4788a 58%,
+    #e8a05c 74%,
+    #f2c064 84%
+  );
+}
+
+.tap-sol {
+  position: absolute;
+  left: 58%;
+  top: 56%;
+  width: 30vmin;
+  height: 30vmin;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: radial-gradient(
+    circle,
+    rgba(255, 236, 170, 0.95) 0%,
+    rgba(255, 210, 120, 0.5) 34%,
+    rgba(255, 190, 100, 0) 70%
+  );
+}
+
+/* Cordones de montaña: siluetas superpuestas, de la bruma al primer plano. */
+.tap-loma {
+  position: absolute;
+  left: -4%;
+  right: -4%;
+  bottom: 0;
+}
+.tap-loma--lejos {
+  height: 46%;
+  background: #45577a;
+  clip-path: polygon(0 62%, 12% 40%, 26% 58%, 43% 26%, 58% 52%, 74% 34%, 88% 56%, 100% 44%, 100% 100%, 0 100%);
+  opacity: 0.85;
+}
+.tap-loma--media {
+  height: 38%;
+  background: #3c5a4a;
+  clip-path: polygon(0 48%, 15% 66%, 32% 38%, 49% 62%, 66% 42%, 82% 64%, 100% 50%, 100% 100%, 0 100%);
+}
+.tap-loma--cerca {
+  height: 26%;
+  background: linear-gradient(180deg, #2c4433 0%, #1c2e1f 100%);
+  clip-path: polygon(0 34%, 18% 52%, 38% 30%, 60% 54%, 79% 38%, 100% 56%, 100% 100%, 0 100%);
+}
+
+/* La niebla del páramo: una banda que respira despacio entre cordones. */
+.tap-niebla {
+  position: absolute;
+  left: -10%;
+  right: -10%;
+  bottom: 24%;
+  height: 16%;
+  background: linear-gradient(
+    90deg,
+    rgba(236, 240, 238, 0) 0%,
+    rgba(236, 240, 238, 0.34) 22%,
+    rgba(236, 240, 238, 0.16) 48%,
+    rgba(236, 240, 238, 0.38) 74%,
+    rgba(236, 240, 238, 0) 100%
+  );
+  filter: blur(6px);
+  animation: tapNiebla 26s ease-in-out infinite alternate;
+  will-change: transform;
+}
+@keyframes tapNiebla {
+  0% { transform: translateX(-3%); }
+  100% { transform: translateX(3%); }
+}
+
+.tap-frailejon {
+  position: absolute;
+  display: block;
+  filter: drop-shadow(0 3px 4px rgba(13, 21, 9, 0.4));
+}
+
+/* ── La compañera viva en la lámina: flota con sombra debajo (volumen). ── */
+.tap-percha {
+  position: absolute;
+  width: 0;
+  height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+.tap-abeja {
+  will-change: transform;
+  filter: drop-shadow(0 6px 14px rgba(20, 30, 15, 0.35));
+  animation: tapFlota 3.4s ease-in-out infinite;
+}
+@keyframes tapFlota {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-9px); }
+}
+.tap-abeja-sombra {
+  width: 44px;
+  height: 12px;
+  margin-top: 8px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(13, 21, 9, 0.42) 0%, rgba(13, 21, 9, 0) 70%);
+  will-change: transform, opacity;
+  animation: tapFlotaSombra 3.4s ease-in-out infinite;
+}
+@keyframes tapFlotaSombra {
+  0%, 100% { transform: scale(1); opacity: 0.8; }
+  50% { transform: scale(0.78); opacity: 0.5; }
+}
+
+.tap-encabezado {
+  position: absolute;
+  top: max(18px, env(safe-area-inset-top));
+  left: 22px;
+  right: 22px;
+  color: #f6f1e4;
+  text-shadow: 0 2px 8px rgba(13, 21, 9, 0.6);
+}
+.tap-eyebrow {
+  display: block;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.85;
+  margin-bottom: 4px;
+}
+.tap-encabezado h1 {
+  margin: 0;
+  font-size: clamp(20px, 4.6vw, 30px);
+  font-weight: 700;
+}
+
+.tap-panel {
+  position: absolute;
+  left: 22px;
+  bottom: max(24px, env(safe-area-inset-bottom));
+  max-width: min(340px, calc(100vw - 44px));
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: rgba(20, 30, 18, 0.78);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(246, 241, 228, 0.14);
+  color: #f6f1e4;
+}
+.tap-panel h2 {
+  margin: 0 0 6px;
+  font-size: 18px;
+}
+.tap-panel p {
+  margin: 0 0 12px;
+  font-size: 13.5px;
+  line-height: 1.45;
+  opacity: 0.88;
+}
+.tap-cta {
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 14.5px;
+  font-weight: 700;
+  color: #241a05;
+  background: linear-gradient(180deg, #ffe08a 0%, #ffd54a 100%);
+  box-shadow: 0 4px 14px rgba(255, 213, 74, 0.35);
+  cursor: pointer;
+}
+.tap-cta:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* ══ LA PANTALLA DE LA GENTE: la del agua ════════════════════════════════ */
+
+.tap-pantalla {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, #f4f8f4 0%, #e8f0ea 100%);
+  color: #1f2d22;
+  overflow-y: auto;
+}
+
+.tap-pantalla-encabezado {
+  padding: max(18px, env(safe-area-inset-top)) 20px 8px;
+}
+.tap-volver {
+  appearance: none;
+  border: 0;
+  background: none;
+  padding: 6px 0;
+  font-size: 14.5px;
+  font-weight: 600;
+  color: #2e6b46;
+  cursor: pointer;
+}
+.tap-volver:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.tap-pantalla-encabezado h1 {
+  margin: 2px 0 0;
+  font-size: clamp(22px, 5vw, 30px);
+  font-weight: 800;
+}
+
+.tap-tarjetas {
+  display: grid;
+  gap: 12px;
+  padding: 14px 20px 140px;
+  max-width: 560px;
+}
+.tap-tarjeta {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: #fff;
+  border: 1px solid rgba(31, 45, 34, 0.08);
+  box-shadow: 0 2px 8px rgba(31, 45, 34, 0.06);
+}
+.tap-tarjeta-dato {
+  min-width: 74px;
+  font-size: 20px;
+  font-weight: 800;
+  color: #2e6b46;
+}
+.tap-tarjeta p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+/* El AGENTE PLANO posado: calcomanía viva en la esquina — halo de vidrio,
+   SIN sombra proyectada (el volumen se quedó en el mundo). */
+.tap-chip {
+  position: fixed;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 30%, #fffdf4 0%, #fdf2cf 62%, #f5df9a 100%);
+  border: 2px solid rgba(255, 213, 74, 0.9);
+  box-shadow:
+    0 0 0 4px rgba(255, 213, 74, 0.18),
+    0 2px 10px rgba(31, 45, 34, 0.18);
+  animation: tapChipNace 260ms ease-out both;
+}
+@keyframes tapChipNace {
+  0% { transform: scale(0.9); opacity: 0.4; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+.tap-burbuja {
+  position: fixed;
+  max-width: min(320px, calc(100vw - 36px));
+  display: flex;
+  justify-content: flex-end;
+  animation: tapBurbujaNace 340ms ease-out 180ms both;
+}
+@keyframes tapBurbujaNace {
+  0% { transform: translateY(8px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+}
+
+/* El ancla del aterrizaje (invisible; existe para depurar el empalme). */
+.tap-ancla {
+  position: fixed;
+  pointer-events: none;
+  opacity: 0;
+}
+
+/* Reduced-motion: la lámina queda quieta y digna; los nacimientos, sin brinco. */
+@media (prefers-reduced-motion: reduce) {
+  .tap-niebla,
+  .tap-abeja,
+  .tap-abeja-sombra {
+    animation: none;
+  }
+  .tap-chip,
+  .tap-burbuja {
+    animation: none;
+  }
+}

--- a/src/visual/agente/AgentePlanoTransicion.jsx
+++ b/src/visual/agente/AgentePlanoTransicion.jsx
@@ -1,0 +1,237 @@
+/*
+ * AgentePlanoTransicion — el CRUCE del agente 3D → AGENTE PLANO (el alma que
+ * viaja con usted a la pantalla de la gente).
+ *
+ * Hoy el túnel Odyssey (TunelLamina 'saliendo') cruza la PANTALLA, pero el
+ * compañero no: la criatura 3D muere con el canvas (stopSpeak y chao) y la
+ * burbuja/avatar 2D nace aparte, sin puente. Dos almas, un corte seco. Este
+ * overlay DOM puro (CERO three, seguro en el bundle base) cierra ese hueco
+ * CRONOMETRANDO el viaje del agente con el reloj del túnel (una sola fuente,
+ * agentePlanoData ← tunelLaminaData):
+ *
+ *   posar:  la abeja SIENTE la llamada (brinquito + pulso de aura), ANTICIPA
+ *           (se echa atrás, coge impulso) y se CLAVA en barrel roll hacia la
+ *           boca del túnel — muere SECA en el mismo instante en que el
+ *           destello cubre y el host intercambia pantallas debajo
+ *           (momentoCubiertoTunel). Cruza el destello convertida en COMETA
+ *           de luz dorada; al revelarse la pantalla plana, la estela se
+ *           CONDENSA de vuelta en abeja, frena en arco (doble eje: x e y con
+ *           easings distintos), ATERRIZA en el ancla del agente con squash &
+ *           stretch, y SE APLANA contra el vidrio: la sombra que decía "yo
+ *           floto en un mundo" se funde con ella, una onda recorre el
+ *           cristal, y queda hecha el avatar plano. Una sola alma que voló
+ *           del mundo 3D al vidrio de su pantalla.
+ *   alzar:  el reverso — el avatar se DESPEGA del vidrio (la onda lo suelta,
+ *           la sombra vuelve a nacer debajo: recupera volumen), anticipa y
+ *           se clava al túnel 'entrando'; cruza como cometa y sale del otro
+ *           lado a posarse en su percha del mundo.
+ *
+ * El tiempo lo manejan timers JS deterministas (nunca `animationend`): el
+ * mismo contrato de TransicionMundo/TunelLamina — testeable y a prueba de
+ * pestañas en segundo plano. El CSS anima "a ciegas" con las mismas
+ * variables (--apt-*). `onPosada` dispara cuando el agente ya está posado y
+ * plano (el host revela su avatar real debajo); `onFin` cuando el overlay
+ * terminó de fundirse ENCIMA de ese avatar (solape a propósito: cubre el
+ * relevo de capas sin hueco).
+ *
+ * `reduced-motion`: no se monta nada y los callbacks disparan de inmediato
+ * (corte digno — el avatar plano simplemente aparece). Tier 'bajo': queda el
+ * cruce esencial (dos vuelos + aterrizaje con squash) sin barrel roll, sin
+ * cometa y sin onda — el CSS gatea por [data-tier].
+ *
+ * ── ADOPCIÓN (las 3 líneas del host que persiste, p. ej. App) ──────────────
+ *   1. Montar una vez: `<AgentePlanoPuente tier={tier} reducedMotion={rm} />`
+ *      en una raíz que sobreviva el cambio de pantalla.
+ *   2. Al zarpar del 3D a lo plano (junto al túnel):
+ *      `posarAgente({ desde: rectDelCompanero, animo, energia })`.
+ *   3. Al volver al mundo: `alzarAgente({ desde: rectDelAvatar, hasta: percha })`.
+ *   La señal vive en senalAgentePlano.js; sin `hasta`, el agente aterriza en
+ *   la esquina estándar del compAI (destinoFabPorDefecto).
+ */
+import { useEffect, useMemo, useRef } from 'react';
+import { AbejaAngelita } from '../creatures/AbejaAngelita.jsx';
+import { relojAgentePlano, varsDeCruce, LADO_VUELO } from './agentePlanoData.js';
+import { useCruceAgentePlano, limpiarCruceAgente } from './senalAgentePlano.js';
+import './agentePlano.css';
+
+export default function AgentePlanoTransicion({
+  sentido = 'posar', // 'posar' (3D → vidrio) | 'alzar' (vidrio → 3D)
+  desde = null,
+  hasta = null,
+  animo = 'sereno',
+  energia = 1,
+  tier = 'alto',
+  reducedMotion = false,
+  onPosada = undefined,
+  onFin = undefined,
+}) {
+  const posadaRef = useRef(onPosada);
+  const finRef = useRef(onFin);
+  useEffect(() => {
+    posadaRef.current = onPosada;
+    finRef.current = onFin;
+  });
+
+  const reloj = useMemo(
+    () =>
+      relojAgentePlano(
+        /** @type {'posar'|'alzar'} */ (sentido),
+        /** @type {'alto'|'medio'|'bajo'} */ (tier),
+        reducedMotion,
+      ),
+    [sentido, tier, reducedMotion],
+  );
+
+  // La geometría se congela por activación (rect y viewport son un snapshot:
+  // un resize a mitad de un cruce de ~2 s no amerita re-coreografía).
+  const geo = useMemo(() => {
+    const viewport =
+      typeof window === 'undefined'
+        ? { ancho: 1, alto: 1 }
+        : { ancho: window.innerWidth, alto: window.innerHeight };
+    return varsDeCruce(desde, hasta, viewport);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sentido, desde, hasta]);
+
+  useEffect(() => {
+    let hechoPosada = false;
+    let hechoFin = false;
+    const tPosada = setTimeout(() => {
+      if (!hechoPosada) {
+        hechoPosada = true;
+        posadaRef.current?.();
+      }
+    }, reloj.posada);
+    const tFin = setTimeout(() => {
+      if (!hechoFin) {
+        hechoFin = true;
+        finRef.current?.();
+      }
+    }, reloj.total);
+    return () => {
+      hechoPosada = true;
+      hechoFin = true;
+      clearTimeout(tPosada);
+      clearTimeout(tFin);
+    };
+  }, [reloj]);
+
+  if (reducedMotion) return null;
+
+  const estilo = {
+    '--apt-x0': `${geo.x0.toFixed(1)}px`,
+    '--apt-y0': `${geo.y0.toFixed(1)}px`,
+    '--apt-bx': `${geo.bx.toFixed(1)}px`,
+    '--apt-by': `${geo.by.toFixed(1)}px`,
+    '--apt-dx-ida': `${geo.dxIda.toFixed(1)}px`,
+    '--apt-dy-ida': `${geo.dyIda.toFixed(1)}px`,
+    '--apt-dx-lleg': `${geo.dxLleg.toFixed(1)}px`,
+    '--apt-dy-lleg': `${geo.dyLleg.toFixed(1)}px`,
+    '--apt-ang': `${geo.ang.toFixed(1)}deg`,
+    '--apt-s1': (geo.ladoPosada / LADO_VUELO).toFixed(3),
+    '--apt-ida-ms': `${reloj.ida}ms`,
+    '--apt-cometa-ini': `${reloj.cometaIni}ms`,
+    '--apt-cometa-ms': `${reloj.cometaMs}ms`,
+    '--apt-salida-ms': `${reloj.salida}ms`,
+    '--apt-vuelo2-ms': `${reloj.vuelo2Ms}ms`,
+    '--apt-aplane-ms': `${reloj.aplaneMs}ms`,
+    '--apt-empalme-ms': `${reloj.total - reloj.posada}ms`,
+  };
+
+  const conCometa = tier !== 'bajo';
+  return (
+    <div
+      className={`apt apt--${sentido}`}
+      data-tier={tier}
+      style={estilo}
+      aria-hidden="true"
+      data-testid="agente-plano-transicion"
+    >
+      {/* TRAMO IDA: la llamada + el clavado a la boca del túnel. */}
+      <div className="apt__ida">
+        <span className="apt__pulso" />
+        <div className="apt__vuelo">
+          <div className="apt__giro">
+            <AbejaAngelita size={LADO_VUELO} animo={animo} energia={energia} animated />
+          </div>
+        </div>
+        <span className="apt__puff" />
+      </div>
+
+      {/* EL COMETA: la estela de luz que cruza el destello (el alma en tránsito). */}
+      {conCometa && (
+        <div className="apt__cometa">
+          <span className="apt__estela" />
+          <span className="apt__nucleo" />
+        </div>
+      )}
+
+      {/* TRAMO LLEGADA: condensa, frena en arco, aterriza y (al posar) se
+          APLANA contra el vidrio. Doble eje: el nodo exterior lleva la X y el
+          interior la Y con easings distintos — la recta se vuelve arco. */}
+      <div className="apt__llegada">
+        <div className="apt__arcoX">
+          <div className="apt__arcoY">
+            <span className="apt__sombra" />
+            <div className="apt__cuerpo">
+              <AbejaAngelita size={LADO_VUELO} animo={animo} energia={energia} animated />
+            </div>
+            <span className="apt__onda" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * <AgentePlanoPuente> — el puente que SOBREVIVE al swap de pantallas.
+ *
+ * Se monta UNA vez en una raíz persistente (App, o la raíz de una vitrina) y
+ * escucha la señal (senalAgentePlano). Cuando un host zarpa
+ * (`posarAgente(...)` / `alzarAgente(...)`), el puente corre el overlay
+ * completo por encima del intercambio de pantallas y limpia la señal al
+ * terminar. `onPosada`/`onFin` del host del puente reciben el sentido del
+ * cruce (para revelar el avatar plano o la percha del mundo).
+ */
+export function AgentePlanoPuente({
+  tier = 'alto',
+  reducedMotion = false,
+  onPosada = undefined,
+  onFin = undefined,
+}) {
+  const cruce = useCruceAgentePlano();
+  const posadaRef = useRef(onPosada);
+  const finRef = useRef(onFin);
+  useEffect(() => {
+    posadaRef.current = onPosada;
+    finRef.current = onFin;
+  });
+
+  // Con reduced-motion el overlay no monta, pero el contrato se honra igual:
+  // posada y fin disparan de inmediato y la señal queda limpia.
+  useEffect(() => {
+    if (!cruce || !reducedMotion) return;
+    posadaRef.current?.(cruce.sentido);
+    finRef.current?.(cruce.sentido);
+    limpiarCruceAgente();
+  }, [cruce, reducedMotion]);
+
+  if (!cruce || reducedMotion) return null;
+  return (
+    <AgentePlanoTransicion
+      sentido={cruce.sentido}
+      desde={cruce.desde}
+      hasta={cruce.hasta}
+      animo={cruce.animo}
+      energia={cruce.energia}
+      tier={tier}
+      reducedMotion={reducedMotion}
+      onPosada={() => posadaRef.current?.(cruce.sentido)}
+      onFin={() => {
+        finRef.current?.(cruce.sentido);
+        limpiarCruceAgente();
+      }}
+    />
+  );
+}

--- a/src/visual/agente/__tests__/agentePlano.test.jsx
+++ b/src/visual/agente/__tests__/agentePlano.test.jsx
@@ -1,0 +1,214 @@
+/*
+ * agentePlano — contrato del CRUCE DEL AGENTE 3D → PLANO (three-free).
+ *
+ * Congela:
+ *   · el reloj se DERIVA del reloj del túnel: la abeja es tragada exactamente
+ *     en `momentoCubiertoTunel` y todo instante posterior queda ordenado
+ *     (cubierto < salida < posada < total); tier 'bajo' acorta; RM colapsa;
+ *   · la geometría (varsDeCruce) apunta a la boca del túnel (FUGA_Y) y cae
+ *     con dignidad sin rects (percha por defecto, esquina del compAI);
+ *   · `onPosada`/`onFin` disparan UNA vez, cronometrados por timers JS;
+ *   · reduced-motion: no monta nada, pero el contrato se honra de inmediato;
+ *   · la señal (senalAgentePlano) cruza el swap: el puente monta el overlay
+ *     al recibirla y la limpia al terminar.
+ */
+import React from 'react';
+import { render, cleanup, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import AgentePlanoTransicion, { AgentePlanoPuente } from '../AgentePlanoTransicion.jsx';
+import {
+  relojAgentePlano,
+  varsDeCruce,
+  destinoFabPorDefecto,
+  FAB_LADO,
+  EMPALME_MS,
+} from '../agentePlanoData.js';
+import {
+  posarAgente,
+  alzarAgente,
+  limpiarCruceAgente,
+} from '../senalAgentePlano.js';
+import {
+  duracionTunel,
+  momentoCubiertoTunel,
+  FUGA_Y,
+} from '../../mundo3d/transiciones/tunelLaminaData.js';
+
+afterEach(() => {
+  cleanup();
+  limpiarCruceAgente();
+  vi.useRealTimers();
+});
+
+describe('relojAgentePlano — derivado del reloj del túnel', () => {
+  it('posar: la ida muere exactamente en el cubierto del túnel "saliendo"', () => {
+    const r = relojAgentePlano('posar', 'alto', false);
+    expect(r.ida).toBe(momentoCubiertoTunel('saliendo', 'alto', false));
+  });
+
+  it('alzar: monta sobre el túnel "entrando"', () => {
+    const r = relojAgentePlano('alzar', 'alto', false);
+    expect(r.ida).toBe(momentoCubiertoTunel('entrando', 'alto', false));
+  });
+
+  it('los instantes quedan ordenados: cubierto < salida < posada < total', () => {
+    for (const sentido of /** @type {('posar'|'alzar')[]} */ (['posar', 'alzar'])) {
+      for (const tier of /** @type {('alto'|'medio'|'bajo')[]} */ (['alto', 'medio', 'bajo'])) {
+        const r = relojAgentePlano(sentido, tier, false);
+        expect(r.ida).toBeLessThan(r.salida);
+        expect(r.salida).toBeLessThan(r.posada);
+        expect(r.posada).toBeLessThan(r.total);
+        // La llegada arranca cuando el túnel ya está revelando (tras la meseta).
+        expect(r.salida).toBeGreaterThan(r.ida);
+        expect(r.salida).toBeLessThan(duracionTunel(sentido === 'posar' ? 'saliendo' : 'entrando', tier, false) + 1);
+      }
+    }
+  });
+
+  it('posar aplana (aplaneMs > 0); alzar no (el volumen regresa, no se rinde)', () => {
+    expect(relojAgentePlano('posar', 'alto', false).aplaneMs).toBeGreaterThan(0);
+    expect(relojAgentePlano('alzar', 'alto', false).aplaneMs).toBe(0);
+  });
+
+  it('tier bajo acorta el cruce completo', () => {
+    expect(relojAgentePlano('posar', 'bajo', false).total).toBeLessThan(
+      relojAgentePlano('posar', 'alto', false).total,
+    );
+  });
+
+  it('reduced-motion colapsa todo a 0 (corte digno)', () => {
+    const r = relojAgentePlano('posar', 'alto', true);
+    expect(r.posada).toBe(0);
+    expect(r.total).toBe(0);
+  });
+
+  it('el empalme final solapa encima del avatar real (total = posada + empalme)', () => {
+    const r = relojAgentePlano('posar', 'alto', false);
+    expect(r.total - r.posada).toBe(EMPALME_MS);
+  });
+});
+
+describe('varsDeCruce — geometría de los dos tramos', () => {
+  const viewport = { ancho: 1000, alto: 800 };
+
+  it('la boca del túnel es el punto de fuga del lenguaje (centro, FUGA_Y)', () => {
+    const g = varsDeCruce(null, null, viewport);
+    expect(g.bx).toBe(500);
+    expect(g.by).toBe(800 * FUGA_Y);
+  });
+
+  it('con rects reales, los tramos van centro a centro', () => {
+    const desde = { x: 100, y: 200, width: 80, height: 80 };
+    const hasta = { x: 900, y: 700, width: 56, height: 56 };
+    const g = varsDeCruce(desde, hasta, viewport);
+    expect(g.x0).toBe(140);
+    expect(g.y0).toBe(240);
+    expect(g.dxIda).toBe(g.bx - 140);
+    expect(g.dxLleg).toBe(928 - g.bx);
+    expect(g.dyLleg).toBe(728 - g.by);
+  });
+
+  it('sin `hasta` aterriza en la esquina del compAI (destinoFabPorDefecto)', () => {
+    const g = varsDeCruce(null, null, viewport);
+    const fab = destinoFabPorDefecto(viewport);
+    expect(g.x1).toBe(fab.x + FAB_LADO / 2);
+    expect(g.y1).toBe(fab.y + FAB_LADO / 2);
+  });
+
+  it('la escala del posado queda acotada (avatar chico digno, nunca gigante)', () => {
+    const enorme = { x: 0, y: 0, width: 900, height: 900 };
+    const minusculo = { x: 0, y: 0, width: 8, height: 8 };
+    expect(varsDeCruce(null, enorme, viewport).ladoPosada).toBeLessThanOrEqual(64);
+    expect(varsDeCruce(null, minusculo, viewport).ladoPosada).toBeGreaterThanOrEqual(40);
+  });
+});
+
+describe('<AgentePlanoTransicion> — contrato temporal', () => {
+  it('onPosada y onFin disparan UNA vez, en su instante', () => {
+    vi.useFakeTimers();
+    const onPosada = vi.fn();
+    const onFin = vi.fn();
+    const r = relojAgentePlano('posar', 'alto', false);
+    const { container } = render(
+      <AgentePlanoTransicion sentido="posar" tier="alto" onPosada={onPosada} onFin={onFin} />,
+    );
+    expect(container.querySelector('.apt--posar')).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(r.posada - 1));
+    expect(onPosada).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(2));
+    expect(onPosada).toHaveBeenCalledTimes(1);
+    expect(onFin).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(r.total));
+    expect(onFin).toHaveBeenCalledTimes(1);
+    expect(onPosada).toHaveBeenCalledTimes(1);
+  });
+
+  it('desmontar a mitad de cruce cancela los timers (ni posada ni fin fantasma)', () => {
+    vi.useFakeTimers();
+    const onPosada = vi.fn();
+    const onFin = vi.fn();
+    const { unmount } = render(
+      <AgentePlanoTransicion sentido="posar" tier="alto" onPosada={onPosada} onFin={onFin} />,
+    );
+    unmount();
+    act(() => vi.advanceTimersByTime(10000));
+    expect(onPosada).not.toHaveBeenCalled();
+    expect(onFin).not.toHaveBeenCalled();
+  });
+
+  it('reduced-motion: no monta nada y el contrato dispara de inmediato', () => {
+    vi.useFakeTimers();
+    const onPosada = vi.fn();
+    const onFin = vi.fn();
+    const { container } = render(
+      <AgentePlanoTransicion sentido="posar" reducedMotion onPosada={onPosada} onFin={onFin} />,
+    );
+    expect(container.firstChild).toBeNull();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onPosada).toHaveBeenCalledTimes(1);
+    expect(onFin).toHaveBeenCalledTimes(1);
+  });
+
+  it('tier bajo no monta el cometa; alto sí', () => {
+    const bajo = render(<AgentePlanoTransicion sentido="posar" tier="bajo" />);
+    expect(bajo.container.querySelector('.apt__cometa')).toBeNull();
+    bajo.unmount();
+    const alto = render(<AgentePlanoTransicion sentido="posar" tier="alto" />);
+    expect(alto.container.querySelector('.apt__cometa')).toBeInTheDocument();
+  });
+});
+
+describe('<AgentePlanoPuente> + señal — el cruce sobrevive al swap', () => {
+  it('sin señal no monta nada; con posarAgente monta el overlay "posar"', () => {
+    const { container } = render(<AgentePlanoPuente tier="alto" />);
+    expect(container.firstChild).toBeNull();
+    act(() => posarAgente({ desde: { x: 10, y: 10, width: 76, height: 76 } }));
+    expect(container.querySelector('.apt--posar')).toBeInTheDocument();
+  });
+
+  it('al terminar limpia la señal y desmonta (listo para el próximo cruce)', () => {
+    vi.useFakeTimers();
+    const onFin = vi.fn();
+    const { container } = render(<AgentePlanoPuente tier="alto" onFin={onFin} />);
+    act(() => alzarAgente({}));
+    expect(container.querySelector('.apt--alzar')).toBeInTheDocument();
+    act(() => vi.advanceTimersByTime(relojAgentePlano('alzar', 'alto', false).total + 1));
+    expect(onFin).toHaveBeenCalledWith('alzar');
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('reduced-motion: honra posada y fin al instante y limpia la señal', () => {
+    const onPosada = vi.fn();
+    const onFin = vi.fn();
+    const { container } = render(
+      <AgentePlanoPuente reducedMotion onPosada={onPosada} onFin={onFin} />,
+    );
+    act(() => posarAgente({}));
+    expect(container.firstChild).toBeNull();
+    expect(onPosada).toHaveBeenCalledWith('posar');
+    expect(onFin).toHaveBeenCalledWith('posar');
+  });
+});

--- a/src/visual/agente/agentePlano.css
+++ b/src/visual/agente/agentePlano.css
@@ -78,12 +78,15 @@
 /* EL VUELO de ida: brinquito de llamada → anticipación (se echa atrás,
    CONTRA el sentido del viaje, con squash) → se clava a la boca del túnel
    estirándose y encogiéndose — la opacidad muere SECA en el cubierto. */
+/* Sin drop-shadow CSS sobre el sprite: un filter del wrapper interactúa mal
+   con los filtros SVG internos de la creature (boil/aura) y pinta la REGIÓN
+   del filtro como un cuadro — verificado en captura GPU. La profundidad del
+   personaje la venden su propia aura y la sombra-elipse de la llegada. */
 .apt__vuelo {
   display: flex;
   align-items: center;
   justify-content: center;
   will-change: transform, opacity;
-  filter: drop-shadow(0 6px 14px rgba(20, 30, 15, 0.35));
   animation: aptIda var(--apt-ida-ms) cubic-bezier(0.55, -0.1, 0.7, 0.92) both;
 }
 @keyframes aptIda {
@@ -248,7 +251,6 @@
   align-items: center;
   justify-content: center;
   will-change: transform, opacity;
-  filter: drop-shadow(0 5px 12px rgba(20, 30, 15, 0.32));
   animation:
     aptCondensa var(--apt-vuelo2-ms) cubic-bezier(0.3, 0.6, 0.35, 1) var(--apt-salida-ms) both,
     aptAplana var(--apt-aplane-ms) cubic-bezier(0.34, 1.4, 0.64, 1)

--- a/src/visual/agente/agentePlano.css
+++ b/src/visual/agente/agentePlano.css
@@ -1,0 +1,343 @@
+/*
+ * agentePlano.css — coreografías del CRUCE DEL AGENTE 3D → PLANO
+ * (AgentePlanoTransicion.jsx).
+ *
+ * Contrato compartido con agentePlanoData.js (NO cambiar uno sin el otro):
+ * el reloj del agente se deriva del reloj del túnel; el CSS anima "a ciegas"
+ * con las variables que setea el componente:
+ *
+ *   --apt-x0 / --apt-y0          percha de partida (centro del rect `desde`)
+ *   --apt-bx / --apt-by          boca del túnel (centro, FUGA_Y del lenguaje)
+ *   --apt-dx-ida / --apt-dy-ida  delta percha → boca
+ *   --apt-dx-lleg / --apt-dy-lleg  delta boca → ancla de llegada
+ *   --apt-ang                    ángulo boca → ancla (orienta la estela)
+ *   --apt-s1                     escala del avatar posado (lado / LADO_VUELO)
+ *   --apt-ida-ms                 ventana del tramo ida (0 → cubierto)
+ *   --apt-cometa-ini/-ms         ventana de la estela sobre el destello
+ *   --apt-salida-ms/--apt-vuelo2-ms  ventana del tramo llegada
+ *   --apt-aplane-ms              presión contra el vidrio (solo posar)
+ *   --apt-empalme-ms             fundido final encima del avatar real
+ *
+ * SOLO transform/opacity en todo lo animado (compositor puro). El overlay
+ * vuela POR ENCIMA del túnel (z 48 > 47): el alma cruza sobre el destello.
+ * Los callbacks los disparan timers JS del componente, nunca `animationend`.
+ */
+
+.apt {
+  position: fixed;
+  inset: 0;
+  z-index: 48; /* sobre el túnel lámina (47): la abeja vuela sobre el destello */
+  overflow: hidden;
+  pointer-events: none;
+}
+
+/* Escalas de arranque/llegada por sentido (unifican los keyframes):
+   posar parte a tamaño de mundo y termina a tamaño de avatar; alzar parte
+   del avatar posado y termina a tamaño de mundo. */
+.apt--posar {
+  --apt-s-ini: 1;
+  --apt-s-fin: var(--apt-s1);
+}
+.apt--alzar {
+  --apt-s-ini: var(--apt-s1);
+  --apt-s-fin: 0.92;
+}
+
+/* ══ TRAMO IDA: la llamada + el clavado a la boca del túnel ══════════════ */
+
+/* Ancla 0×0 en la percha de partida: el flex centra al hijo sobre el punto. */
+.apt__ida {
+  position: absolute;
+  left: var(--apt-x0);
+  top: var(--apt-y0);
+  width: 0;
+  height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* LA LLAMADA: un pulso de aura — "me llaman al otro lado". Vive en el primer
+   tercio de la ida y muere solo. */
+.apt__pulso {
+  position: absolute;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  border: 2.5px solid rgba(255, 213, 74, 0.85);
+  opacity: 0;
+  transform: scale(0.4);
+  will-change: transform, opacity;
+  animation: aptPulso calc(var(--apt-ida-ms) * 0.32) ease-out both;
+}
+@keyframes aptPulso {
+  0% { transform: scale(0.4); opacity: 0.9; }
+  100% { transform: scale(1.5); opacity: 0; }
+}
+
+/* EL VUELO de ida: brinquito de llamada → anticipación (se echa atrás,
+   CONTRA el sentido del viaje, con squash) → se clava a la boca del túnel
+   estirándose y encogiéndose — la opacidad muere SECA en el cubierto. */
+.apt__vuelo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  will-change: transform, opacity;
+  filter: drop-shadow(0 6px 14px rgba(20, 30, 15, 0.35));
+  animation: aptIda var(--apt-ida-ms) cubic-bezier(0.55, -0.1, 0.7, 0.92) both;
+}
+@keyframes aptIda {
+  0% {
+    transform: translate(0, 0) scale(var(--apt-s-ini));
+    opacity: 1;
+  }
+  14% {
+    /* la llamada: brinquito atento hacia arriba */
+    transform: translate(0, -7px) scale(calc(var(--apt-s-ini) * 1.06), calc(var(--apt-s-ini) * 0.98));
+    opacity: 1;
+  }
+  32% {
+    /* anticipación: se echa atrás y coge impulso (squash) */
+    transform:
+      translate(calc(var(--apt-dx-ida) * -0.07), calc(var(--apt-dy-ida) * -0.07 + 5px))
+      scale(calc(var(--apt-s-ini) * 1.12), calc(var(--apt-s-ini) * 0.8));
+  }
+  44% {
+    /* suelta el resorte: estirada en el despegue */
+    transform:
+      translate(calc(var(--apt-dx-ida) * 0.06), calc(var(--apt-dy-ida) * 0.06))
+      scale(calc(var(--apt-s-ini) * 0.82), calc(var(--apt-s-ini) * 1.18));
+  }
+  96% { opacity: 1; }
+  100% {
+    /* tragada por la boca del túnel, SECA, en el instante del cubierto */
+    transform: translate(var(--apt-dx-ida), var(--apt-dy-ida)) scale(0.1);
+    opacity: 0;
+  }
+}
+
+/* El barrel roll del clavado (arranca tras la anticipación). */
+.apt__giro {
+  will-change: transform;
+  animation: aptGira var(--apt-ida-ms) cubic-bezier(0.6, 0, 0.6, 1) both;
+}
+.apt__giro > svg { display: block; }
+@keyframes aptGira {
+  0%, 34% { transform: rotate(0deg); }
+  42% { transform: rotate(-15deg); } /* wind-up */
+  100% { transform: rotate(324deg); }
+}
+
+/* El puff del tragado: un anillo revienta en la boca del túnel donde la
+   abeja desapareció (vende el "pop" del cruce de capa). */
+.apt__puff {
+  position: absolute;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 214, 106, 0.9);
+  opacity: 0;
+  transform: translate(var(--apt-dx-ida), var(--apt-dy-ida)) scale(0.2);
+  will-change: transform, opacity;
+  animation: aptPuff 300ms ease-out calc(var(--apt-ida-ms) - 60ms) both;
+}
+@keyframes aptPuff {
+  0% { transform: translate(var(--apt-dx-ida), var(--apt-dy-ida)) scale(0.2); opacity: 0.9; }
+  100% { transform: translate(var(--apt-dx-ida), var(--apt-dy-ida)) scale(1.5); opacity: 0; }
+}
+
+/* ══ EL COMETA: el alma en tránsito sobre el destello ════════════════════ */
+
+/* Nace en la boca del túnel y corre hacia el ancla de llegada mientras la
+   pantalla está cubierta: la continuidad VISIBLE a través del intercambio.
+   Semilla oscura + estela dorada: lee sobre destellos claros y oscuros. */
+.apt__cometa {
+  position: absolute;
+  left: var(--apt-bx);
+  top: var(--apt-by);
+  width: 0;
+  height: 0;
+  will-change: transform, opacity;
+  opacity: 0;
+  animation: aptCometa var(--apt-cometa-ms) cubic-bezier(0.4, 0.1, 0.5, 1)
+    var(--apt-cometa-ini) both;
+}
+@keyframes aptCometa {
+  0% { transform: translate(0, 0); opacity: 0; }
+  14% { opacity: 1; }
+  82% { opacity: 1; }
+  100% {
+    transform: translate(calc(var(--apt-dx-lleg) * 0.46), calc(var(--apt-dy-lleg) * 0.46));
+    opacity: 0;
+  }
+}
+.apt__estela {
+  position: absolute;
+  left: -86px;
+  top: -3px;
+  width: 86px;
+  height: 6px;
+  border-radius: 3px;
+  transform-origin: 100% 50%;
+  transform: rotate(var(--apt-ang));
+  background: linear-gradient(
+    90deg,
+    rgba(255, 213, 74, 0) 0%,
+    rgba(255, 213, 74, 0.55) 55%,
+    rgba(255, 240, 190, 0.95) 100%
+  );
+  filter: drop-shadow(0 0 8px rgba(255, 213, 74, 0.7));
+}
+.apt__nucleo {
+  position: absolute;
+  left: -6px;
+  top: -6px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff7dd 0%, #ffd54a 55%, rgba(58, 42, 8, 0.9) 100%);
+}
+
+/* ══ TRAMO LLEGADA: condensa, frena en arco, aterriza y se aplana ════════ */
+
+/* Ancla 0×0 en la boca; el arco lo hacen DOS ejes con easings distintos:
+   la X sale disparada y frena largo; la Y arranca perezosa y cae al final.
+   La recta se vuelve un arco por encima, sin path ni layout. */
+.apt__llegada {
+  position: absolute;
+  left: var(--apt-bx);
+  top: var(--apt-by);
+  width: 0;
+  height: 0;
+  animation: aptEmpalme var(--apt-empalme-ms) ease-out
+    calc(var(--apt-salida-ms) + var(--apt-vuelo2-ms) + var(--apt-aplane-ms)) both;
+}
+@keyframes aptEmpalme {
+  0% { opacity: 1; }
+  100% { opacity: 0; } /* se funde ENCIMA del avatar real ya revelado */
+}
+.apt__arcoX {
+  will-change: transform;
+  animation: aptLlegaX var(--apt-vuelo2-ms) cubic-bezier(0.16, 0.8, 0.3, 1)
+    var(--apt-salida-ms) both;
+}
+@keyframes aptLlegaX {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(var(--apt-dx-lleg)); }
+}
+.apt__arcoY {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  perspective: 480px; /* el aplane: la abeja se presiona DENTRO del vidrio */
+  will-change: transform;
+  animation: aptLlegaY var(--apt-vuelo2-ms) cubic-bezier(0.62, 0.02, 0.48, 1)
+    var(--apt-salida-ms) both;
+}
+@keyframes aptLlegaY {
+  0% { transform: translateY(0); }
+  100% { transform: translateY(var(--apt-dy-lleg)); }
+}
+
+/* EL CUERPO: sale del destello hecho luz (estirado, casi estela), se condensa
+   en abeja a mitad de vuelo, frena, ATERRIZA con squash & stretch y asienta.
+   Después del vuelo, el APLANE (segunda animación): una presión con rotateX
+   que colapsa — el volumen se rinde y queda calcomanía sobre el vidrio. */
+.apt__cuerpo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  will-change: transform, opacity;
+  filter: drop-shadow(0 5px 12px rgba(20, 30, 15, 0.32));
+  animation:
+    aptCondensa var(--apt-vuelo2-ms) cubic-bezier(0.3, 0.6, 0.35, 1) var(--apt-salida-ms) both,
+    aptAplana var(--apt-aplane-ms) cubic-bezier(0.34, 1.4, 0.64, 1)
+      calc(var(--apt-salida-ms) + var(--apt-vuelo2-ms)) both;
+}
+@keyframes aptCondensa {
+  0% { transform: scale(0.14, 1.25); opacity: 0; }
+  12% { transform: scale(0.4, 1.18); opacity: 1; } /* la luz se condensa */
+  52% { transform: scale(0.96); } /* abeja plena, planeando */
+  76% { transform: scale(calc(var(--apt-s-fin) * 1.05)); }
+  83% {
+    /* touchdown: squash franco contra el vidrio */
+    transform: translateY(3px) scale(calc(var(--apt-s-fin) * 1.22), calc(var(--apt-s-fin) * 0.74));
+  }
+  92% {
+    /* rebote que rebasa (stretch) y … */
+    transform: translateY(-2px) scale(calc(var(--apt-s-fin) * 0.94), calc(var(--apt-s-fin) * 1.1));
+  }
+  100% { transform: translateY(0) scale(var(--apt-s-fin)); } /* …asienta */
+}
+@keyframes aptAplana {
+  0% { transform: rotateX(0deg) scale(var(--apt-s-fin)); }
+  42% { transform: rotateX(17deg) scale(calc(var(--apt-s-fin) * 1.05)); }
+  100% { transform: rotateX(0deg) scale(var(--apt-s-fin)); }
+}
+/* Al alzar no hay aplane (aplane-ms = 0): el cuerpo termina a escala de
+   mundo y la sombra que RENACE debajo le devuelve el volumen. */
+
+/* LA SOMBRA: lo que dice "yo floto en un mundo". En el vuelo de llegada nace
+   tímida y crece con la cercanía del piso; en el aplane SE FUNDE con la abeja
+   (el volumen muere: eso ES volverse plano). Al alzar corre solo la primera
+   parte — la sombra se queda (el volumen regresó). */
+.apt__sombra {
+  position: absolute;
+  top: 26px;
+  width: 42px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(20, 30, 15, 0.4) 0%, rgba(20, 30, 15, 0) 70%);
+  will-change: transform, opacity;
+  opacity: 0;
+  animation: aptSombraNace var(--apt-vuelo2-ms) ease-out var(--apt-salida-ms) both;
+}
+@keyframes aptSombraNace {
+  0% { transform: translateY(10px) scale(0.3); opacity: 0; }
+  55% { transform: translateY(6px) scale(0.55); opacity: 0.18; }
+  100% { transform: translateY(0) scale(1); opacity: 0.4; }
+}
+.apt--posar .apt__sombra {
+  animation:
+    aptSombraNace var(--apt-vuelo2-ms) ease-out var(--apt-salida-ms) both,
+    aptSombraFunde var(--apt-aplane-ms) ease-in
+      calc(var(--apt-salida-ms) + var(--apt-vuelo2-ms)) both;
+}
+@keyframes aptSombraFunde {
+  0% { transform: translateY(0) scale(1); opacity: 0.4; }
+  100% { transform: translateY(-12px) scale(0.4, 0.2); opacity: 0; } /* sube y muere en ella */
+}
+
+/* LA ONDA del vidrio: al momento del aplane, un anillo recorre el cristal —
+   "tocó SU pantalla". Solo al posar. */
+.apt__onda {
+  position: absolute;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 213, 74, 0.75);
+  opacity: 0;
+  transform: scale(0.3);
+  will-change: transform, opacity;
+}
+.apt--posar .apt__onda {
+  animation: aptOnda 420ms ease-out calc(var(--apt-salida-ms) + var(--apt-vuelo2-ms)) both;
+}
+@keyframes aptOnda {
+  0% { transform: scale(0.3); opacity: 0.85; }
+  100% { transform: scale(1.7); opacity: 0; }
+}
+
+/* ══ Gama baja: queda el cruce esencial (dos vuelos + squash del aterrizaje,
+   que son el empalme) sin barrel roll, pulso, puff ni onda. El cometa no lo
+   monta el JS. ══ */
+[data-tier='bajo'].apt .apt__giro { animation: none; }
+[data-tier='bajo'].apt .apt__pulso,
+[data-tier='bajo'].apt .apt__puff,
+[data-tier='bajo'].apt .apt__onda { animation: none; opacity: 0; }
+
+/* RM defensivo: el componente ya no monta nada con reduced-motion; si algún
+   host se equivoca, no se anima ni se ve nada. */
+@media (prefers-reduced-motion: reduce) {
+  .apt { display: none; }
+}

--- a/src/visual/agente/agentePlanoData.js
+++ b/src/visual/agente/agentePlanoData.js
@@ -1,0 +1,170 @@
+/*
+ * agentePlanoData — reloj y geometría del CRUCE DEL AGENTE 3D → PLANO, en
+ * datos puros (cero DOM, cero three). Es la mitad "de datos" de
+ * AgentePlanoTransicion.jsx.
+ *
+ * QUÉ ES ESTE CRUCE
+ * Hoy, cuando el valle 3D abre una pantalla plana (TunelLamina 'saliendo'),
+ * el compañero NO viaja: la criatura 3D muere con el canvas y la burbuja 2D
+ * nace aparte — dos almas, cero puente. Este módulo cronometra el puente:
+ * la abeja se CLAVA al túnel junto con la hoja, cruza el destello convertida
+ * en COMETA de luz, sale del otro lado, ATERRIZA sobre el vidrio de la
+ * pantalla plana (squash & stretch) y SE APLANA hasta ser el avatar plano.
+ * Una sola alma que cruza de capa — el mismo principio que AbejaTransicion
+ * cerró para el cruce valle ↔ mundo, ahora para 3D → pantalla de la gente.
+ *
+ * HERENCIA DEL LENGUAJE (tunelLaminaData/velosData — no duplicar, importar):
+ *   · el reloj del agente se DERIVA del reloj del túnel: si el túnel cambia,
+ *     el agente lo sigue solo (una sola fuente de verdad temporal);
+ *   · la abeja es tragada EXACTAMENTE en `momentoCubiertoTunel` — el mismo
+ *     instante en que el host intercambia las pantallas debajo del destello;
+ *   · misma asimetría: posarse (ir a lo plano) respira; alzarse (volver al
+ *     mundo) monta sobre el túnel 'entrando' y no se demora de más;
+ *   · tier bajo acorta con FACTOR_TIER_BAJO; reduced-motion colapsa a corte
+ *     digno (nada se monta, los callbacks disparan de inmediato).
+ *
+ * GEOMETRÍA: dos tramos rectos que el CSS curva con doble eje (x e y con
+ * easings distintos = arco). Tramo IDA: de la percha del compañero a la BOCA
+ * del túnel (centro, FUGA_Y — el mismo punto de fuga de la hoja). Tramo
+ * LLEGADA: de la boca al ancla del agente plano (la esquina donde vive el
+ * compAI en toda pantalla). `varsDeCruce` lo calcula como función pura para
+ * poder testearlo sin montar nada.
+ */
+import {
+  FUGA_Y,
+  duracionTunel,
+  momentoCubiertoTunel,
+} from '../mundo3d/transiciones/tunelLaminaData.js';
+import { FACTOR_TIER_BAJO } from '../mundo3d/transiciones/velosData.js';
+
+/** El sentido del cruce → la fase del túnel que corre debajo (una fuente). */
+export const FASE_TUNEL_POR_SENTIDO = Object.freeze({
+  posar: 'saliendo', // 3D → pantalla plana: el túnel escupe hacia el cuaderno
+  alzar: 'entrando', // plano → 3D: la lámina vuelve a tragar hacia el mundo
+});
+
+/** Empalme final (ms): el overlay se funde ENCIMA del avatar plano real ya
+    revelado — el pequeño solape es a propósito (cubre el relevo de capas sin
+    hueco, mismo contrato que CRUCE_SUELTA_MS en AbejaTransicion). */
+export const EMPALME_MS = 180;
+
+/** El aplane (ms, tier alto): la abeja ya posada se PRESIONA contra el vidrio
+    (rotateX que colapsa, la sombra se funde con ella, una onda en el cristal)
+    y queda plana — el momento conceptual del cruce. Solo al posar. */
+export const APLANE_MS = 360;
+
+/** Tamaño de la abeja en vuelo (px) y tope del avatar posado. */
+export const LADO_VUELO = 76;
+export const LADO_POSADA_MIN = 40;
+export const LADO_POSADA_MAX = 64;
+
+/** El ancla del agente plano en las pantallas de la gente: la esquina del
+    compAI (AgentFab). Margen y lado compartidos con quien pinte el avatar
+    receptor, para que el aterrizaje sea píxel-exacto. */
+export const FAB_MARGEN_DER = 18;
+export const FAB_MARGEN_ABAJO = 92;
+export const FAB_LADO = 56;
+
+/**
+ * Rect por defecto donde vive el agente plano (esquina inferior derecha),
+ * cuando el host no presta el rect real de su avatar.
+ * @param {{ancho:number, alto:number}} viewport
+ * @returns {{x:number, y:number, width:number, height:number}}
+ */
+export function destinoFabPorDefecto(viewport) {
+  const vw = Math.max(1, viewport?.ancho || 1);
+  const vh = Math.max(1, viewport?.alto || 1);
+  return {
+    x: vw - FAB_MARGEN_DER - FAB_LADO,
+    y: vh - FAB_MARGEN_ABAJO - FAB_LADO,
+    width: FAB_LADO,
+    height: FAB_LADO,
+  };
+}
+
+/**
+ * EL RELOJ del cruce, derivado del reloj del túnel (ms desde el arranque).
+ * Todos los instantes que el CSS anima "a ciegas" y los timers JS disparan:
+ *
+ *   ida      0 → cubierto      la llamada + el clavado (muere SECA al cubierto)
+ *   cometa   ~cubierto → …     la estela de luz que cruza el destello
+ *   llegada  salida → posada   el arco de frenado + aterrizaje + asentado
+ *   aplane   (solo posar)      presión contra el vidrio, sombra que se funde
+ *   posada                     instante de `onPosada` (el host revela su avatar)
+ *   total                      instante de `onFin` (el overlay ya se fundió)
+ *
+ * @param {'posar'|'alzar'} sentido
+ * @param {'alto'|'medio'|'bajo'} tier
+ * @param {boolean} reducedMotion
+ */
+export function relojAgentePlano(sentido, tier, reducedMotion) {
+  if (reducedMotion) {
+    // Corte digno: nada se anima; posada y fin son inmediatos.
+    return { ida: 0, cometaIni: 0, cometaMs: 0, salida: 0, vuelo2Ms: 0, aplaneMs: 0, posada: 0, total: 0 };
+  }
+  const fase = FASE_TUNEL_POR_SENTIDO[sentido] || 'saliendo';
+  const cub = momentoCubiertoTunel(fase, tier, false);
+  const fin = duracionTunel(fase, tier, false);
+  const k = tier === 'bajo' ? FACTOR_TIER_BAJO : 1;
+
+  const ida = cub;
+  const cometaIni = Math.max(0, cub - 60);
+  const cometaMs = Math.round((fin - cub) * 0.78);
+  const salida = Math.round(fin * 0.78);
+  // Asimetría: posarse frena con calma (0.53·fin); alzarse no se demora (0.42).
+  const vuelo2Ms = Math.round(fin * (sentido === 'posar' ? 0.53 : 0.42));
+  const aplaneMs = sentido === 'posar' ? Math.round(APLANE_MS * k) : 0;
+  const posada = salida + vuelo2Ms + aplaneMs;
+  const total = posada + Math.round(EMPALME_MS * k);
+  return { ida, cometaIni, cometaMs, salida, vuelo2Ms, aplaneMs, posada, total };
+}
+
+/**
+ * LA GEOMETRÍA del cruce: puntos y deltas de los dos tramos, listos para ser
+ * variables CSS. Centros de rect; sin `desde` la abeja parte de un costado
+ * digno; sin `hasta` aterriza en la esquina del compAI.
+ *
+ * @param {{x:number,y:number,width:number,height:number}|null} desde
+ *   rect del compañero en el 3D (o del avatar plano, al alzar).
+ * @param {{x:number,y:number,width:number,height:number}|null} hasta
+ *   rect del ancla de llegada.
+ * @param {{ancho:number, alto:number}} viewport
+ * @returns {{
+ *   x0:number, y0:number, bx:number, by:number, x1:number, y1:number,
+ *   dxIda:number, dyIda:number, dxLleg:number, dyLleg:number,
+ *   ang:number, ladoPosada:number
+ * }}
+ */
+export function varsDeCruce(desde, hasta, viewport) {
+  const vw = Math.max(1, viewport?.ancho || 1);
+  const vh = Math.max(1, viewport?.alto || 1);
+  // La boca del túnel: el mismo punto de fuga de la hoja (centro, 46% de alto).
+  const bx = vw / 2;
+  const by = vh * FUGA_Y;
+
+  const centro = (r) => ({ cx: r.x + r.width / 2, cy: r.y + r.height / 2 });
+  const o = desde ? centro(desde) : { cx: vw * 0.3, cy: vh * 0.42 };
+  const fab = destinoFabPorDefecto({ ancho: vw, alto: vh });
+  const d = hasta ? centro(hasta) : centro(fab);
+
+  const dxLleg = d.cx - bx;
+  const dyLleg = d.cy - by;
+  const ang = Math.atan2(dyLleg, dxLleg) * (180 / Math.PI);
+  const ladoHasta = hasta ? Math.min(hasta.width, hasta.height) : FAB_LADO;
+  const ladoPosada = Math.max(LADO_POSADA_MIN, Math.min(LADO_POSADA_MAX, ladoHasta));
+
+  return {
+    x0: o.cx,
+    y0: o.cy,
+    bx,
+    by,
+    x1: d.cx,
+    y1: d.cy,
+    dxIda: bx - o.cx,
+    dyIda: by - o.cy,
+    dxLleg,
+    dyLleg,
+    ang,
+    ladoPosada,
+  };
+}

--- a/src/visual/agente/senalAgentePlano.js
+++ b/src/visual/agente/senalAgentePlano.js
@@ -1,0 +1,62 @@
+/*
+ * LA SEÑAL DEL CRUCE 3D → PLANO del agente (host → puente, sin prop-drilling).
+ *
+ * Parte del cruce del agente a lo plano (ver AgentePlanoTransicion.jsx). El
+ * problema que resuelve: el intercambio de pantallas (hash swap bajo el
+ * destello del túnel) DESMONTA al host 3D — un overlay montado por él muere
+ * a mitad de vuelo. El canal es un store externo mínimo (useSyncExternalStore,
+ * mismo patrón que senalSalidaAbeja.js): el host que zarpa avisa "el agente
+ * cruza" y el PUENTE (AgentePlanoPuente, montado en una raíz que persiste —
+ * App o la raíz de la vitrina) corre el overlay completo por encima del swap.
+ *
+ * El puente limpia la señal solo al terminar (onFin) — sin ese reset, el
+ * próximo montaje nacería "cruzando" un cruce viejo. Módulo propio (no dentro
+ * del componente) para que el archivo de componentes quede
+ * fast-refresh-limpio.
+ */
+import { useSyncExternalStore } from 'react';
+
+/**
+ * @typedef {Object} CruceAgentePlano
+ * @property {'posar'|'alzar'} sentido
+ * @property {{x:number,y:number,width:number,height:number}|null} desde
+ * @property {{x:number,y:number,width:number,height:number}|null} hasta
+ * @property {string} [animo]
+ * @property {number} [energia]
+ */
+
+/** @type {CruceAgentePlano|null} */
+let cruceActual = null;
+const suscriptores = new Set();
+
+function emitir(v) {
+  if (cruceActual === v) return;
+  cruceActual = v;
+  suscriptores.forEach((fn) => fn());
+}
+
+/** El host 3D la llama al zarpar hacia una pantalla plana (junto al túnel). */
+export function posarAgente({ desde = null, hasta = null, animo = 'sereno', energia = 1 } = {}) {
+  emitir({ sentido: 'posar', desde, hasta, animo, energia });
+}
+
+/** La pantalla plana la llama al devolver a la persona al mundo 3D. */
+export function alzarAgente({ desde = null, hasta = null, animo = 'sereno', energia = 1 } = {}) {
+  emitir({ sentido: 'alzar', desde, hasta, animo, energia });
+}
+
+/** Apaga el cruce (el puente lo hace solo en su onFin). */
+export function limpiarCruceAgente() {
+  emitir(null);
+}
+
+function suscribir(fn) {
+  suscriptores.add(fn);
+  return () => suscriptores.delete(fn);
+}
+const leer = () => cruceActual;
+
+/** El cruce en curso (o null) — reactivo; cruza cualquier swap de pantallas. */
+export function useCruceAgentePlano() {
+  return useSyncExternalStore(suscribir, leer, leer);
+}


### PR DESCRIPTION
## Qué transición encontré (auditoría)

La transición REAL 3D → pantalla-de-la-gente que "sirve y funciona" es **TunelLamina `'saliendo'`** (EntradaValle3D `abrirPantalla()`): la hoja despega del CTA, los anillos Odyssey pasan, el destello cubre al 54% (`onCubierto` → swap de hash) y revela la pantalla plana. **Pero el agente no cruza**: la criatura 3D recibe `stopSpeak()` y muere con el canvas; la burbuja/avatar 2D nace aparte. Dos almas, un corte seco — el mismo hueco que `AbejaTransicion` ya cerró para valle↔mundo, nadie lo había cerrado para 3D→plano.

## La reinterpretación

Una sola alma que cruza de capa, montada SOBRE el túnel existente (z 48 > 47), cronometrada con SU reloj (una sola fuente de verdad temporal):

1. **La llamada** — pulso de aura: "me llaman al otro lado".
2. **El clavado** — anticipación (se echa atrás con squash), barrel roll hacia la boca del túnel (el mismo punto de fuga de la hoja, `FUGA_Y`), muere SECA en `momentoCubiertoTunel` — el instante exacto del swap — con puff de tragado.
3. **El cometa** — cruza el destello hecha estela de luz dorada: la continuidad VISIBLE a través del intercambio de pantallas.
4. **La posada** — se condensa del otro lado, frena en ARCO (doble eje: X e Y con easings distintos), aterriza en el ancla del compAI con squash & stretch franco.
5. **El aplane** — el momento conceptual: rotateX que colapsa, la sombra (el volumen) se funde con ella, una onda recorre el vidrio — queda hecha el **agente plano**. `onPosada` revela el avatar real debajo; el overlay se funde encima (empalme sin hueco, contrato de `CRUCE_SUELTA_MS`).

**`alzar`** es el reverso asimétrico (se despega del vidrio, la sombra renace: recupera volumen, vuelve a su percha). **Tier bajo**: cruce esencial sin barrel roll/cometa/onda. **Reduced-motion**: nada se monta, callbacks inmediatos — corte digno.

## Arquitectura (cero cambios a compartidos)

- `src/visual/agente/agentePlanoData.js` — reloj derivado de `tunelLaminaData` + geometría pura (testeable).
- `src/visual/agente/senalAgentePlano.js` — señal externa (patrón `senalSalidaAbeja`): el cruce **sobrevive al swap de pantallas** (el host 3D se desmonta bajo el destello; el puente vive en la raíz que persiste).
- `src/visual/agente/AgentePlanoTransicion.jsx` + `agentePlano.css` — overlay DOM puro (cero three, timers JS deterministas, CSS a ciegas con `--apt-*`) + `AgentePlanoPuente` (adopción en 3 líneas).
- `src/mockups/TransicionAgentePlano.jsx` — vitrina `#/mockups/transicion-agente-plano`: flujo de punta a punta con el `TunelLamina` REAL de producción (lámina de páramo al atardecer ↔ pantalla del agua).
- `App.jsx`: solo el registro aditivo estándar de la vitrina (lazy + slug + case).
- NO se tocó `EntradaValle3D`, `valle/Valle3D`, mundos en curso ni la esencia de Angelita/creatures.

### Adopción en el shell real (cuando se levante el veto, 3 líneas)
```jsx
<AgentePlanoPuente tier={tier} reducedMotion={rm} />   // raíz persistente (App)
posarAgente({ desde: rectDelCompanero, animo, energia }); // junto al túnel, al zarpar
alzarAgente({ desde: rectDelAvatar, hasta: percha });     // al volver al mundo
```

## Verificación

- eslint `--max-warnings=0` sobre los archivos nuevos: limpio.
- `tsc --noEmit -p jsconfig.json`: 0 errores en archivos nuevos.
- 18/18 tests (contrato temporal, geometría, señal, tiers, RM, desmonte a mitad de cruce).
- Gate visual (capturas GPU + juez): en curso — se adjunta en comentario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)