### PR TITLE
feat(navegacion): navegación unificada por pisos térmicos — 3 zooms (mini · mapa AoE · vista global lámina)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -356,6 +356,10 @@ const FrutalesAndinos3DMockup = lazy(() => import('./mockups/FrutalesAndinos3D')
 const CanaTrapiche3DMockup = lazy(() => import('./mockups/CanaTrapiche3D'));
 const CondorCielo3DMockup = lazy(() => import('./mockups/CondorCielo3D'));
 const NavegadorGrafoDemoMockup = lazy(() => import('./mockups/NavegadorGrafoDemo'));
+// La NAVEGACIÓN UNIFICADA por pisos térmicos: los tres zooms (minimapa de
+// esquina, mapa estratégico de terrazas y la vista global tipo lámina con el
+// nevado y la Chorrera arriba) leyendo el mismo dato mundo→piso.
+const NavegacionPisosMockup = lazy(() => import('./mockups/NavegacionPisosTermicos'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
@@ -818,6 +822,7 @@ const MOCKUP_HASH_ROUTES = {
   'mockups/cana-trapiche-3d': 'mockup_cana_trapiche_3d',
   'mockups/condor-cielo-3d': 'mockup_condor_cielo_3d',
   'mockups/navegador-grafo': 'mockup_navegador_grafo',
+  'mockups/navegacion-pisos': 'mockup_navegacion_pisos',
 };
 
 const HASH_VIEW_ROUTES = {
@@ -2718,6 +2723,18 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="El grafo de la finca">
               <NavegadorGrafoDemoMockup />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'mockup_navegacion_pisos':
+        // Navegación unificada por pisos térmicos: minimapa + mapa estratégico
+        // + vista global (lámina del paisaje con nevado y Chorrera). Tocar un
+        // mundo navega a su pantalla real. Ruta #/mockups/navegacion-pisos,
+        // sin auth.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Navegación por pisos térmicos">
+              <NavegacionPisosMockup onNavigate={navigate} onBack={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/mockups/NavegacionPisosTermicos.jsx
+++ b/src/mockups/NavegacionPisosTermicos.jsx
@@ -1,0 +1,50 @@
+/*
+ * NavegacionPisosTermicos — vitrina de la navegación unificada por pisos
+ * térmicos (ruta `#/mockups/navegacion-pisos`, sin auth).
+ *
+ * Monta el host real `NavegacionPisos` (los tres zooms: minimapa siempre
+ * visible, mapa estratégico y vista global) sobre un fondo sencillo que hace
+ * de "usted está en un mundo": aquí se valida la navegación, no el mundo.
+ * Demo con el usuario parado en el mundo del café (piso templado) para que
+ * el "usted está aquí" se vea en los tres zooms.
+ */
+import NavegacionPisos from '../visual/navegacion/NavegacionPisos.jsx';
+
+/**
+ * @param {object} props
+ * @param {(view: string, data?: object|null) => void} [props.onNavigate]
+ * @param {() => void} [props.onBack]
+ */
+export default function NavegacionPisosTermicos({ onNavigate, onBack }) {
+  return (
+    <div className="navv-fondo">
+      <style>{`
+        .navv-fondo { position: fixed; inset: 0; overflow: hidden;
+          background: linear-gradient(#b9d2df 0%, #d9e2d2 42%, #6f9e4a 70%, #4c6b33 100%); }
+        .navv-tarjeta { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+          max-width: 520px; padding: 22px 28px; border-radius: 16px; text-align: center;
+          background: rgba(20, 26, 20, 0.72); color: #f2ead4; font-family: 'Baloo 2', Georgia, serif; }
+        .navv-tarjeta h1 { margin: 0 0 8px; font-size: 22px; }
+        .navv-tarjeta p { margin: 0; font-size: 14.5px; line-height: 1.5; color: #ded5b8; }
+        .navv-volver { position: absolute; top: 14px; left: 14px; border: 1.5px solid #cdbf9b;
+          background: rgba(26, 32, 27, 0.82); color: #f2ead4; font: 600 14px 'Baloo 2', Georgia, serif;
+          padding: 8px 14px; border-radius: 999px; cursor: pointer; }
+      `}</style>
+      <div className="navv-tarjeta">
+        <h1>Navegación por pisos térmicos</h1>
+        <p>
+          Usted está en el mundo del café (piso templado). Use el minimapa de la
+          esquina para orientarse, el mapa de la finca para ver todas las fichas,
+          o la vista global para recorrer la lámina completa — del valle cálido
+          al páramo con su Chorrera, junto al nevado.
+        </p>
+      </div>
+      {onBack && (
+        <button type="button" className="navv-volver" onClick={onBack} aria-label="Volver">
+          ← Volver
+        </button>
+      )}
+      <NavegacionPisos mundoActual="cafe" onNavigate={onNavigate} />
+    </div>
+  );
+}

--- a/src/visual/navegacion/MapaEstrategicoPisos.jsx
+++ b/src/visual/navegacion/MapaEstrategicoPisos.jsx
@@ -1,0 +1,281 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+/*
+ * MapaEstrategicoPisos — el zoom MEDIO de la navegación por pisos térmicos.
+ *
+ * EL MAPA ESTRATÉGICO tipo Age of Empires: la finca-valle vista desde arriba
+ * en 3/4, como un tablero de campaña — CUATRO TERRAZAS isométricas apiladas
+ * (cálido, la más ancha, abajo; páramo, la más alta, arriba) y TODOS los
+ * mundos como FICHAS clicables sobre su terraza. Marco de pergamino, rosa de
+ * los vientos, niebla en los bordes: el "mapa del mundo" navegable.
+ *
+ * La quebrada baja de terraza en terraza desde el páramo (donde nace el agua,
+ * la Chorrera de la vista global) hasta el valle: el mismo relato del agua en
+ * los tres zooms.
+ *
+ * El dato mundo→piso NO vive aquí: se lee de `pisosNavegacion.js`, el mismo
+ * que leen el minimapa y la vista global (coherencia total). Tocar una ficha
+ * navega a la pantalla real del mundo.
+ */
+import { useEffect, useMemo } from 'react';
+import { mundosPorBanda } from './pisosNavegacion.js';
+import { GlifoEnt } from './glifosNavegacion.jsx';
+
+const ANCHO = 1240;
+const ALTO = 860;
+const CX = ANCHO / 2 + 60; // el tablero respira a la derecha del rótulo de pisos
+
+/*
+ * Las terrazas, de abajo (cálido, ancha) a arriba (páramo, angosta). El orden
+ * visual sale del índice de banda; aquí solo vive la geometría del tablero.
+ *   semiAncho — mitad del ancho del rombo isométrico.
+ *   cy        — centro vertical del rombo.
+ */
+const TERRAZAS = [
+  { semiAncho: 470, cy: 640 }, // cálido
+  { semiAncho: 375, cy: 486 }, // templado
+  { semiAncho: 285, cy: 356 }, // frío
+  { semiAncho: 200, cy: 246 }, // páramo
+];
+const PROFUNDIDAD = 30; // el grosor extruido del borde de cada terraza
+
+/* Aclara u oscurece un color hex (factor >1 aclara, <1 oscurece). */
+function tono(hex, factor) {
+  const n = parseInt(hex.slice(1), 16);
+  const canal = (v) => Math.max(0, Math.min(255, Math.round(v * factor)));
+  const r = canal((n >> 16) & 255);
+  const g = canal((n >> 8) & 255);
+  const b = canal(n & 255);
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
+}
+
+/* El rombo isométrico de una terraza (cara superior). */
+function rombo(cx, cy, semiAncho, semiAlto) {
+  return `M ${cx - semiAncho} ${cy} L ${cx} ${cy - semiAlto} L ${cx + semiAncho} ${cy} L ${cx} ${cy + semiAlto} Z`;
+}
+
+/* Una ficha de mundo: token de tablero clicable (emoji + rótulo). */
+function FichaMundo({ mundo, x, y, color, actual, onNavigate }) {
+  const activar = () => onNavigate?.(mundo);
+  return (
+    <g
+      className="navm-ficha"
+      transform={`translate(${x} ${y})`}
+      role="button"
+      tabIndex={0}
+      aria-label={`Ir a ${mundo.titulo}`}
+      onClick={activar}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          activar();
+        }
+      }}
+    >
+      {actual && <circle r="37" fill="none" stroke="#e5b54a" strokeWidth="3.5" className="navm-aqui" />}
+      <ellipse cx="0" cy="24" rx="22" ry="7" fill="#1c2418" opacity="0.35" />
+      <circle r="27" fill="#f7f0dd" stroke={tono(color, 0.72)} strokeWidth="3" />
+      <circle r="22" fill={tono(color, 1.35)} opacity="0.35" />
+      <text y="8" textAnchor="middle" fontSize="24" aria-hidden="true">
+        {mundo.emoji}
+      </text>
+      <text
+        y="47"
+        textAnchor="middle"
+        fontSize="14"
+        fontWeight="600"
+        fontFamily="Georgia, 'Times New Roman', serif"
+        fill="#241f14"
+        stroke="#efe6cd"
+        strokeWidth="4"
+        paintOrder="stroke"
+      >
+        {mundo.titulo}
+      </text>
+      {actual && (
+        <text
+          y="-40"
+          textAnchor="middle"
+          fontSize="13"
+          fontFamily="Georgia, 'Times New Roman', serif"
+          fill="#8a6a1f"
+          stroke="#f7f0dd"
+          strokeWidth="4"
+          paintOrder="stroke"
+        >
+          ★ Usted está aquí
+        </text>
+      )}
+    </g>
+  );
+}
+
+/**
+ * @param {object} props
+ * @param {string|null} [props.mundoActual] id del mundo donde está el usuario
+ * @param {(mundo: {id:string, destino:{view:string, data?:object}}) => void} [props.onNavigate]
+ * @param {() => void} [props.onCerrar]  volver al minimapa
+ * @param {() => void} [props.onGlobal]  saltar al zoom grande (vista global)
+ */
+export default function MapaEstrategicoPisos({ mundoActual = null, onNavigate, onCerrar, onGlobal }) {
+  // Fichas por terraza: reparto horizontal determinista dentro del rombo.
+  const tablero = useMemo(() => {
+    const grupos = mundosPorBanda();
+    return grupos.map(({ banda, mundos }, i) => {
+      const terraza = TERRAZAS[i] || TERRAZAS[TERRAZAS.length - 1];
+      const semiAlto = terraza.semiAncho * 0.34;
+      const fichas = mundos.map((mundo, j) => {
+        const n = mundos.length;
+        // Dos filas si hay muchas fichas, para no salirse del rombo.
+        const dosFilas = n > 4;
+        const fila = dosFilas ? j % 2 : 0;
+        const enFila = dosFilas ? Math.ceil(n / 2) : n;
+        const idx = dosFilas ? Math.floor(j / 2) : j;
+        const margen = 0.72 - fila * 0.16;
+        const x = terraza.cy === TERRAZAS[0].cy && n === 1
+          ? CX
+          : CX + ((idx + 0.5) / enFila - 0.5) * 2 * terraza.semiAncho * margen;
+        const y = terraza.cy + (fila === 0 ? -semiAlto * 0.22 : semiAlto * 0.38);
+        return { mundo, x, y };
+      });
+      return { banda, terraza, semiAlto, fichas };
+    });
+  }, []);
+
+  // ESC vuelve al minimapa.
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === 'Escape') onCerrar?.();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onCerrar]);
+
+  return (
+    <div className="navm-mapa" role="dialog" aria-label="Mapa estratégico de la finca por pisos térmicos">
+      <style>{`
+        .navm-mapa { position: fixed; inset: 0; z-index: 1200; background: #171d14;
+          display: flex; align-items: center; justify-content: center; }
+        .navm-mapa svg { display: block; width: min(100vw, 143vh); height: auto; max-height: 100vh; }
+        .navm-ficha { cursor: pointer; }
+        .navm-ficha:hover circle:nth-of-type(1), .navm-ficha:focus-visible circle:nth-of-type(1) { stroke-width: 5; }
+        .navm-ficha:focus-visible { outline: none; }
+        .navm-aqui { animation: navm-pulso 2.4s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+        .navm-botones { position: absolute; top: 14px; right: 14px; display: flex; gap: 8px; }
+        .navm-boton { border: 1.5px solid #cdbf9b; background: rgba(26, 32, 27, 0.82); color: #f2ead4;
+          font: 600 14px 'Baloo 2', Georgia, serif; padding: 8px 14px; border-radius: 999px; cursor: pointer; }
+        .navm-boton:hover { background: rgba(58, 66, 52, 0.92); }
+        @keyframes navm-pulso { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.12); opacity: 0.55; } }
+        @media (prefers-reduced-motion: reduce) { .navm-aqui { animation: none; } }
+      `}</style>
+      <svg viewBox={`0 0 ${ANCHO} ${ALTO}`} preserveAspectRatio="xMidYMid meet">
+        <defs>
+          <radialGradient id="navm-vineta" cx="0.5" cy="0.5" r="0.72">
+            <stop offset="0.62" stopColor="#000000" stopOpacity="0" />
+            <stop offset="1" stopColor="#0c110b" stopOpacity="0.85" />
+          </radialGradient>
+        </defs>
+
+        {/* El pergamino del tablero. */}
+        <rect x="10" y="10" width={ANCHO - 20} height={ALTO - 20} rx="14" fill="#e9dcbb" />
+        <rect x="22" y="22" width={ANCHO - 44} height={ALTO - 44} rx="10" fill="none" stroke="#8a734a" strokeWidth="2.5" />
+        <rect x="30" y="30" width={ANCHO - 60} height={ALTO - 60} rx="8" fill="none" stroke="#8a734a" strokeWidth="1" opacity="0.6" />
+
+        {/* ── LAS TERRAZAS, de la cima (atrás) al valle (adelante) ── */}
+        {[...tablero].reverse().map(({ banda, terraza, semiAlto }) => (
+          <g key={banda.id}>
+            {/* El borde extruido (la ladera de la terraza). */}
+            <path
+              d={`M ${CX - terraza.semiAncho} ${terraza.cy} L ${CX} ${terraza.cy + semiAlto} L ${CX} ${terraza.cy + semiAlto + PROFUNDIDAD} L ${CX - terraza.semiAncho} ${terraza.cy + PROFUNDIDAD} Z`}
+              fill={tono(banda.color, 0.62)}
+            />
+            <path
+              d={`M ${CX + terraza.semiAncho} ${terraza.cy} L ${CX} ${terraza.cy + semiAlto} L ${CX} ${terraza.cy + semiAlto + PROFUNDIDAD} L ${CX + terraza.semiAncho} ${terraza.cy + PROFUNDIDAD} Z`}
+              fill={tono(banda.color, 0.5)}
+            />
+            {/* La cara superior: el piso térmico. */}
+            <path d={rombo(CX, terraza.cy, terraza.semiAncho, semiAlto)} fill={tono(banda.color, 1.12)} stroke={tono(banda.color, 0.6)} strokeWidth="2" />
+            <path d={rombo(CX, terraza.cy, terraza.semiAncho * 0.94, semiAlto * 0.94)} fill="none" stroke={tono(banda.color, 1.4)} strokeWidth="1.2" opacity="0.7" />
+            {/* La placa del piso, al borde izquierdo del tablero. */}
+            <g fontFamily="Georgia, 'Times New Roman', serif">
+              <rect x="44" y={terraza.cy - 34} width="178" height="64" rx="6" fill="#f4ecd4" stroke="#8a734a" strokeWidth="1.4" />
+              <rect x="52" y={terraza.cy - 26} width="10" height="48" rx="3" fill={banda.color} />
+              <text x="70" y={terraza.cy - 8} fontSize="17" fontWeight="bold" letterSpacing="1" fill="#2c2a1e">
+                {banda.nombre.toUpperCase()}
+              </text>
+              <text x="70" y={terraza.cy + 12} fontSize="12.5" fontStyle="italic" fill="#4a4633">
+                {banda.rango} · {banda.emojiCultivo}
+              </text>
+              <text x="70" y={terraza.cy + 26} fontSize="11.5" fontStyle="italic" fill="#6a6146">
+                guardián: {banda.entNombre}
+              </text>
+              <line x1="222" y1={terraza.cy} x2={CX - terraza.semiAncho + 14} y2={terraza.cy} stroke="#8a734a" strokeWidth="1" strokeDasharray="4 4" opacity="0.7" />
+            </g>
+            {/* El Ent guardián plantado en la esquina de su terraza. */}
+            <g transform={`translate(${CX - terraza.semiAncho * 0.58} ${terraza.cy - semiAlto * 0.3}) scale(1.15)`} aria-hidden="true">
+              <GlifoEnt entId={banda.entId} color={tono(banda.color, 0.8)} />
+            </g>
+          </g>
+        ))}
+
+        {/* La quebrada que baja de la cima al valle, terraza por terraza. */}
+        <path
+          d={`M ${CX + 30} ${TERRAZAS[3].cy - 20} C ${CX + 90} ${TERRAZAS[3].cy + 60} ${CX - 60} ${TERRAZAS[2].cy} ${CX + 40} ${TERRAZAS[2].cy + 50} C ${CX + 120} ${TERRAZAS[2].cy + 100} ${CX - 40} ${TERRAZAS[1].cy + 30} ${CX + 50} ${TERRAZAS[1].cy + 80} C ${CX + 110} ${TERRAZAS[1].cy + 116} ${CX - 30} ${TERRAZAS[0].cy} ${CX + 30} ${TERRAZAS[0].cy + 60}`}
+          stroke="#7fb3c0"
+          strokeWidth="6"
+          fill="none"
+          opacity="0.55"
+          strokeLinecap="round"
+        />
+
+        {/* ── LAS FICHAS: cada mundo sobre su terraza (mismo dato en los 3 zooms) ── */}
+        {tablero.map(({ banda, fichas }) =>
+          fichas.map(({ mundo, x, y }) => (
+            <FichaMundo
+              key={mundo.id}
+              mundo={mundo}
+              x={x}
+              y={y}
+              color={banda.color}
+              actual={mundo.id === mundoActual}
+              onNavigate={onNavigate}
+            />
+          )),
+        )}
+
+        {/* La rosa de los vientos y el rótulo del tablero. */}
+        <g transform="translate(92 760)" fontFamily="Georgia, 'Times New Roman', serif" aria-hidden="true">
+          <circle r="34" fill="#f4ecd4" stroke="#8a734a" strokeWidth="1.6" />
+          <path d="M 0 -26 L 6 0 L 0 26 L -6 0 Z" fill="#8a734a" />
+          <path d="M -26 0 L 0 -5 L 26 0 L 0 5 Z" fill="#bfa76b" />
+          <text y="-38" textAnchor="middle" fontSize="14" fontWeight="bold" fill="#2c2a1e">N</text>
+          <text y="16" textAnchor="middle" fontSize="12" fill="#2c2a1e">⛰️</text>
+        </g>
+        <g fontFamily="Georgia, 'Times New Roman', serif">
+          <rect x={ANCHO / 2 - 250} y="38" width="500" height="62" rx="6" fill="#f4ecd4" stroke="#8a734a" strokeWidth="1.6" />
+          <text x={ANCHO / 2} y="65" textAnchor="middle" fontSize="22" fontWeight="bold" letterSpacing="2" fill="#2c2a1e">
+            MAPA DE LA FINCA
+          </text>
+          <text x={ANCHO / 2} y="88" textAnchor="middle" fontSize="13.5" fontStyle="italic" fill="#4a4633">
+            las terrazas de los pisos térmicos — toque una ficha para entrar
+          </text>
+        </g>
+
+        {/* Niebla de guerra en los bordes, como manda el género. */}
+        <rect x="10" y="10" width={ANCHO - 20} height={ALTO - 20} rx="14" fill="url(#navm-vineta)" pointerEvents="none" />
+      </svg>
+
+      <div className="navm-botones">
+        {onGlobal && (
+          <button type="button" className="navm-boton" onClick={onGlobal} aria-label="Abrir la vista global">
+            🏔️ Vista global
+          </button>
+        )}
+        {onCerrar && (
+          <button type="button" className="navm-boton" onClick={onCerrar} aria-label="Cerrar el mapa">
+            ✕ Cerrar
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/visual/navegacion/MapaEstrategicoPisos.jsx
+++ b/src/visual/navegacion/MapaEstrategicoPisos.jsx
@@ -71,40 +71,26 @@ function FichaMundo({ mundo, x, y, color, actual, onNavigate }) {
         }
       }}
     >
-      {actual && <circle r="37" fill="none" stroke="#e5b54a" strokeWidth="3.5" className="navm-aqui" />}
-      <ellipse cx="0" cy="24" rx="22" ry="7" fill="#1c2418" opacity="0.35" />
-      <circle r="27" fill="#f7f0dd" stroke={tono(color, 0.72)} strokeWidth="3" />
-      <circle r="22" fill={tono(color, 1.35)} opacity="0.35" />
-      <text y="8" textAnchor="middle" fontSize="24" aria-hidden="true">
+      {actual && <circle r="34" fill="none" stroke="#e5b54a" strokeWidth="3.5" className="navm-aqui" />}
+      <ellipse cx="0" cy="22" rx="20" ry="6.5" fill="#1c2418" opacity="0.35" />
+      <circle r="25" fill="#f7f0dd" stroke={tono(color, 0.72)} strokeWidth="3" />
+      <circle r="20" fill={tono(color, 1.35)} opacity="0.35" />
+      <text y="8" textAnchor="middle" fontSize="22" aria-hidden="true">
         {mundo.emoji}
       </text>
       <text
-        y="47"
+        y="45"
         textAnchor="middle"
-        fontSize="14"
+        fontSize="13.5"
         fontWeight="600"
         fontFamily="Georgia, 'Times New Roman', serif"
-        fill="#241f14"
+        fill={actual ? '#7c5c12' : '#241f14'}
         stroke="#efe6cd"
         strokeWidth="4"
         paintOrder="stroke"
       >
-        {mundo.titulo}
+        {actual ? `★ ${mundo.titulo}` : mundo.titulo}
       </text>
-      {actual && (
-        <text
-          y="-40"
-          textAnchor="middle"
-          fontSize="13"
-          fontFamily="Georgia, 'Times New Roman', serif"
-          fill="#8a6a1f"
-          stroke="#f7f0dd"
-          strokeWidth="4"
-          paintOrder="stroke"
-        >
-          ★ Usted está aquí
-        </text>
-      )}
     </g>
   );
 }
@@ -134,7 +120,9 @@ export default function MapaEstrategicoPisos({ mundoActual = null, onNavigate, o
         const x = terraza.cy === TERRAZAS[0].cy && n === 1
           ? CX
           : CX + ((idx + 0.5) / enFila - 0.5) * 2 * terraza.semiAncho * margen;
-        const y = terraza.cy + (fila === 0 ? -semiAlto * 0.22 : semiAlto * 0.38);
+        // Filas separadas para que los rótulos de la fila alta no choquen con
+        // las fichas de la baja (el diamante isométrico no da más alto útil).
+        const y = terraza.cy + (fila === 0 ? -semiAlto * 0.26 : semiAlto * 0.34);
         return { mundo, x, y };
       });
       return { banda, terraza, semiAlto, fichas };

--- a/src/visual/navegacion/MiniMapaPisos.jsx
+++ b/src/visual/navegacion/MiniMapaPisos.jsx
@@ -1,0 +1,142 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+/*
+ * MiniMapaPisos — el zoom MINI de la navegación por pisos térmicos.
+ *
+ * El minimapa de esquina, SIEMPRE visible y nada invasivo: una montañita con
+ * las cuatro bandas de altitud (cálido abajo → páramo y nieve arriba), un
+ * punto por mundo en su banda, y el "usted está aquí" latiendo en dorado.
+ * Orientación de un vistazo; tocar un punto navega; los dos botones abren
+ * los zooms mayores (mapa estratégico y vista global).
+ *
+ * El dato mundo→piso es el MISMO de los otros dos zooms
+ * (`pisosNavegacion.js`): coherencia total entre escalas.
+ */
+import { useMemo } from 'react';
+import { mundosPorBanda, pisoDeMundo, bandaPorId } from './pisosNavegacion.js';
+
+const ANCHO = 132;
+const ALTO = 128;
+
+/* La montañita: y de cada banda dentro del triángulo del minimapa. */
+const Y_BANDAS = [
+  { yTop: 96, yBot: 122 }, // cálido (la falda)
+  { yTop: 70, yBot: 96 }, // templado
+  { yTop: 46, yBot: 70 }, // frío
+  { yTop: 22, yBot: 46 }, // páramo (bajo la nieve)
+];
+
+/* Medio-ancho de la montaña a una altura y (triángulo, cima en y=10). */
+function semiAnchoEn(y) {
+  return ((y - 10) / (122 - 10)) * 56;
+}
+
+/**
+ * @param {object} props
+ * @param {string|null} [props.mundoActual] id del mundo donde está el usuario
+ * @param {(mundo: {id:string, destino:{view:string, data?:object}}) => void} [props.onNavigate]
+ * @param {() => void} [props.onMapa]    abrir el zoom medio (mapa estratégico)
+ * @param {() => void} [props.onGlobal]  abrir el zoom grande (vista global)
+ */
+export default function MiniMapaPisos({ mundoActual = null, onNavigate, onMapa, onGlobal }) {
+  const pisoActual = pisoDeMundo(mundoActual);
+  const bandaActual = bandaPorId(pisoActual);
+
+  // Puntos por banda: reparto horizontal determinista dentro de la montañita.
+  const puntos = useMemo(() => {
+    const out = [];
+    mundosPorBanda().forEach(({ banda, mundos }, i) => {
+      const zona = Y_BANDAS[i] || Y_BANDAS[Y_BANDAS.length - 1];
+      const n = mundos.length;
+      mundos.forEach((mundo, j) => {
+        const y = zona.yTop + ((j % 2) + 1) * ((zona.yBot - zona.yTop) / 3);
+        const semi = semiAnchoEn(y) * 0.8;
+        const x = 66 + (n === 1 ? 0 : ((j + 0.5) / n - 0.5) * 2 * semi);
+        out.push({ mundo, banda, x, y });
+      });
+    });
+    return out;
+  }, []);
+
+  return (
+    <div className="navp-mini" aria-label="Minimapa de la finca por pisos térmicos">
+      <style>{`
+        .navp-mini { position: fixed; right: 14px; bottom: 14px; z-index: 1100; width: 148px;
+          background: rgba(18, 24, 19, 0.86); border: 1.5px solid rgba(205, 191, 155, 0.55);
+          border-radius: 14px; padding: 8px 8px 9px; color: #f2ead4; backdrop-filter: blur(3px); }
+        .navp-mini svg { display: block; margin: 0 auto; }
+        .navp-punto { cursor: pointer; }
+        .navp-punto:hover circle, .navp-punto:focus-visible circle { stroke: #f2ead4; stroke-width: 1.6; }
+        .navp-punto:focus-visible { outline: none; }
+        .navp-aqui-lat { animation: navp-late 2s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+        .navp-chip { margin: 4px 2px 6px; text-align: center; font: 600 11px 'Baloo 2', Georgia, serif;
+          color: #e8dfc4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .navp-zoom { display: flex; gap: 6px; }
+        .navp-zoom button { flex: 1; border: 1px solid rgba(205, 191, 155, 0.5); background: rgba(46, 54, 42, 0.85);
+          color: #f2ead4; font: 600 11px 'Baloo 2', Georgia, serif; padding: 5px 2px; border-radius: 8px; cursor: pointer; }
+        .navp-zoom button:hover { background: rgba(74, 84, 62, 0.95); }
+        @keyframes navp-late { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.7); opacity: 0.35; } }
+        @media (prefers-reduced-motion: reduce) { .navp-aqui-lat { animation: none; } }
+      `}</style>
+      <svg width={ANCHO} height={ALTO} viewBox={`0 0 ${ANCHO} ${ALTO}`}>
+        {/* La montañita por bandas (triángulo apilado) + su nieve. */}
+        {mundosPorBanda().map(({ banda }, i) => {
+          const zona = Y_BANDAS[i] || Y_BANDAS[Y_BANDAS.length - 1];
+          const sT = semiAnchoEn(zona.yTop);
+          const sB = semiAnchoEn(zona.yBot);
+          return (
+            <path
+              key={banda.id}
+              d={`M ${66 - sB} ${zona.yBot} L ${66 - sT} ${zona.yTop} L ${66 + sT} ${zona.yTop} L ${66 + sB} ${zona.yBot} Z`}
+              fill={banda.color}
+              stroke="rgba(18,24,19,0.5)"
+              strokeWidth="1"
+              opacity={pisoActual && banda.id !== pisoActual ? 0.62 : 0.98}
+            />
+          );
+        })}
+        <path d={`M 66 10 L ${66 - semiAnchoEn(22)} 22 L ${66 + semiAnchoEn(22)} 22 Z`} fill="#f4f8fa" />
+
+        {/* Un punto por mundo, tocable, en su banda. */}
+        {puntos.map(({ mundo, x, y }) => {
+          const esActual = mundo.id === mundoActual;
+          return (
+            <g
+              key={mundo.id}
+              className="navp-punto"
+              role="button"
+              tabIndex={0}
+              aria-label={`Ir a ${mundo.titulo}`}
+              onClick={() => onNavigate?.(mundo)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onNavigate?.(mundo);
+                }
+              }}
+            >
+              {esActual && <circle cx={x} cy={y} r="7" fill="none" stroke="#e5b54a" strokeWidth="2" className="navp-aqui-lat" />}
+              <circle cx={x} cy={y} r={esActual ? 4.4 : 3.4} fill={esActual ? '#e5b54a' : '#f7f0dd'} stroke="rgba(18,24,19,0.6)" strokeWidth="1" >
+                <title>{mundo.titulo}</title>
+              </circle>
+            </g>
+          );
+        })}
+      </svg>
+      <div className="navp-chip">
+        {bandaActual ? `${bandaActual.nombre} · ${bandaActual.rango}` : 'La finca por pisos'}
+      </div>
+      <div className="navp-zoom">
+        {onMapa && (
+          <button type="button" onClick={onMapa} aria-label="Abrir el mapa de la finca">
+            🗺️ Mapa
+          </button>
+        )}
+        {onGlobal && (
+          <button type="button" onClick={onGlobal} aria-label="Abrir la vista global">
+            🏔️ Global
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/visual/navegacion/NavegacionPisos.jsx
+++ b/src/visual/navegacion/NavegacionPisos.jsx
@@ -1,0 +1,62 @@
+/*
+ * NavegacionPisos — el HOST de la navegación unificada por pisos térmicos.
+ *
+ * Orquesta los TRES zooms sobre el mismo dato (`pisosNavegacion.js`):
+ *   · MINI    — minimapa de esquina, siempre visible (orientación).
+ *   · MEDIO   — mapa estratégico tipo Age of Empires (toggle).
+ *   · GRANDE  — vista global de pantalla completa, la lámina del paisaje
+ *               con el nevado y la Chorrera (toggle).
+ *
+ * Tocar un mundo en CUALQUIER zoom navega a su pantalla real vía
+ * `onNavigate(view, data)` (la firma de `navigate` de App.jsx). Este host no
+ * dibuja nada propio: compone los tres zooms y les reparte el estado.
+ */
+import { useCallback, useState } from 'react';
+import MiniMapaPisos from './MiniMapaPisos.jsx';
+import MapaEstrategicoPisos from './MapaEstrategicoPisos.jsx';
+import VistaGlobalPisos from './VistaGlobalPisos.jsx';
+
+/**
+ * @param {object} props
+ * @param {string|null} [props.mundoActual]  id del mundo donde está el usuario
+ * @param {(view: string, data?: object|null) => void} [props.onNavigate]
+ * @param {'mini'|'medio'|'grande'} [props.zoomInicial]
+ */
+export default function NavegacionPisos({ mundoActual = null, onNavigate, zoomInicial = 'mini' }) {
+  const [zoom, setZoom] = useState(zoomInicial);
+
+  const navegarAMundo = useCallback(
+    (mundo) => {
+      setZoom('mini');
+      onNavigate?.(mundo.destino.view, mundo.destino.data || null);
+    },
+    [onNavigate],
+  );
+
+  return (
+    <>
+      <MiniMapaPisos
+        mundoActual={mundoActual}
+        onNavigate={navegarAMundo}
+        onMapa={() => setZoom('medio')}
+        onGlobal={() => setZoom('grande')}
+      />
+      {zoom === 'medio' && (
+        <MapaEstrategicoPisos
+          mundoActual={mundoActual}
+          onNavigate={navegarAMundo}
+          onCerrar={() => setZoom('mini')}
+          onGlobal={() => setZoom('grande')}
+        />
+      )}
+      {zoom === 'grande' && (
+        <VistaGlobalPisos
+          mundoActual={mundoActual}
+          onNavigate={navegarAMundo}
+          onCerrar={() => setZoom('mini')}
+          onMapa={() => setZoom('medio')}
+        />
+      )}
+    </>
+  );
+}

--- a/src/visual/navegacion/VistaGlobalPisos.jsx
+++ b/src/visual/navegacion/VistaGlobalPisos.jsx
@@ -70,15 +70,18 @@ function crestaSuave(rng, yCresta, amplitud, nPuntos = 9) {
   return d;
 }
 
-/* La cordillera nevada del fondo: picos AGUDOS (L, no Q) + manto de nieve. */
+/* La cordillera nevada del fondo: picos AGUDOS (L, no Q) + manto de nieve.
+   Irregular a dos escalas (base alternada + espolones altos ocasionales) para
+   que no lea como sierra de papel: cada pico con su propia altura. */
 function nevado(rng) {
-  const nPicos = 16;
+  const nPicos = 18;
   const cresta = [];
   for (let i = 0; i <= nPicos; i += 1) {
-    const x = (i / nPicos) * ANCHO;
+    const x = (i / nPicos) * ANCHO + (rng() - 0.5) * 34;
     const pico = i % 2 === 0;
-    const y = (pico ? 210 : 292) + (rng() - 0.5) * 58;
-    cresta.push([x, y]);
+    const espolon = pico && rng() < 0.28 ? -52 : 0;
+    const y = Math.max(168, (pico ? 222 : 298) + espolon + (rng() - 0.5) * 64);
+    cresta.push([i === 0 ? 0 : i === nPicos ? ANCHO : x, y]);
   }
   const linea = cresta.map(([x, y]) => `${x.toFixed(1)} ${y.toFixed(1)}`).join(' L ');
   const roca = `M -40 ${cresta[0][1]} L ${linea} L ${ANCHO + 40} ${cresta[nPicos][1]} L ${ANCHO + 40} 430 L -40 430 Z`;
@@ -112,7 +115,7 @@ const CAPAS = [
 const AJUSTE_ESTAMPA = {
   clima: [-170, -46],
   agua: [150, 8],
-  suelo: [-60, 26],
+  suelo: [64, 30], // a la derecha del rótulo TEMPLADO del eje (no taparlo)
   cafe: [30, -20],
   micorrizas: [40, 30],
   valle: [-30, 22],
@@ -232,16 +235,16 @@ export default function VistaGlobalPisos({ mundoActual = null, onNavigate, onCer
         .navg-estampa:focus-visible { outline: none; }
         .navg-aqui { animation: navg-pulso 2.4s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
         .navg-niebla { animation: navg-respira 9s ease-in-out infinite; }
-        .navg-agua-caida { stroke-dasharray: 10 7; animation: navg-cae 1.6s linear infinite; }
+        .navg-velo { animation: navg-velo-late 2.8s ease-in-out infinite; }
         .navg-botones { position: absolute; top: 14px; right: 14px; display: flex; gap: 8px; }
         .navg-boton { border: 1.5px solid #cdbf9b; background: rgba(26, 32, 27, 0.82); color: #f2ead4;
           font: 600 14px 'Baloo 2', Georgia, serif; padding: 8px 14px; border-radius: 999px; cursor: pointer; }
         .navg-boton:hover { background: rgba(58, 66, 52, 0.92); }
         @keyframes navg-pulso { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.12); opacity: 0.55; } }
         @keyframes navg-respira { 0%, 100% { opacity: 0.34; } 50% { opacity: 0.16; } }
-        @keyframes navg-cae { from { stroke-dashoffset: 0; } to { stroke-dashoffset: -34; } }
+        @keyframes navg-velo-late { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
         @media (prefers-reduced-motion: reduce) {
-          .navg-aqui, .navg-niebla, .navg-agua-caida { animation: none; }
+          .navg-aqui, .navg-niebla, .navg-velo { animation: none; }
         }
       `}</style>
       <svg viewBox={`0 0 ${ANCHO} ${ALTO}`} preserveAspectRatio="xMidYMid slice">
@@ -306,13 +309,33 @@ export default function VistaGlobalPisos({ mundoActual = null, onNavigate, onCer
 
         {/* ── NUESTRO APORTE, arriba junto al nevado: el páramo y LA CHORRERA ── */}
         <g aria-hidden="true">
-          {/* La peña de la cascada: un tajo de roca en la capa del páramo bajo. */}
-          <path d="M 985 402 L 1075 396 L 1092 520 L 968 526 Z" fill="#5c7280" />
-          <path d="M 1002 402 L 1022 400 L 1030 520 L 1006 522 Z" fill="#46596a" opacity="0.55" />
-          {/* El agua que cae: dos hebras blancas con caída animada. */}
-          <path className="navg-agua-caida" d="M 1024 402 C 1020 440 1030 470 1022 516" stroke="#f3f8f9" strokeWidth="9" fill="none" strokeLinecap="round" />
-          <path className="navg-agua-caida" d="M 1040 404 C 1042 442 1034 472 1044 514" stroke="#e8f1f3" strokeWidth="5" fill="none" strokeLinecap="round" style={{ animationDelay: '0.6s' }} />
-          <ellipse cx="1032" cy="522" rx="40" ry="12" fill="#eef5f6" opacity="0.85" filter="url(#navg-borroso)" />
+          {/* El peñón de la cascada: dos hombros de roca con la muesca por donde
+              se descuelga el agua (nada de trapecios: la peña tiene quiebres). */}
+          <path
+            d="M 972 428 L 1000 408 L 1014 414 L 1012 452 L 1004 500 L 1012 524 L 966 528 L 976 480 Z"
+            fill="#57666f"
+          />
+          <path
+            d="M 1052 412 L 1082 404 L 1102 430 L 1090 478 L 1098 524 L 1046 526 L 1054 486 L 1046 448 Z"
+            fill="#5c6d76"
+          />
+          <path d="M 972 428 L 1000 408 L 990 470 L 972 480 Z" fill="#43525b" opacity="0.8" />
+          <path d="M 1082 404 L 1102 430 L 1088 486 L 1076 452 Z" fill="#45545d" opacity="0.8" />
+          {/* El agua: una CINTA sólida que se abre al caer, con su velo interior. */}
+          <path
+            d="M 1018 414 C 1014 448 1022 470 1012 522 L 1048 522 C 1042 468 1050 446 1046 414 Z"
+            fill="#f2f8f9"
+            opacity="0.96"
+          />
+          <path
+            d="M 1026 414 C 1024 452 1030 480 1024 520 L 1036 520 C 1034 478 1038 450 1038 414 Z"
+            fill="#ffffff"
+            className="navg-velo"
+          />
+          <path d="M 1018 414 C 1030 420 1040 420 1046 414 L 1044 426 C 1036 431 1028 431 1020 426 Z" fill="#dcebee" />
+          {/* La bruma del golpe abajo, y el charco que arranca la quebrada. */}
+          <ellipse cx="1031" cy="526" rx="44" ry="13" fill="#eef5f6" opacity="0.9" filter="url(#navg-borroso)" />
+          <ellipse cx="1031" cy="514" rx="20" ry="7" fill="#ffffff" opacity="0.55" filter="url(#navg-borroso)" />
           {/* La quebrada que sigue ladera abajo, piso por piso, hasta el valle. */}
           <path
             d="M 1032 524 C 1010 570 1090 610 1052 660 C 1020 704 1090 750 1044 800 C 1010 844 1060 900 1020 952"

--- a/src/visual/navegacion/VistaGlobalPisos.jsx
+++ b/src/visual/navegacion/VistaGlobalPisos.jsx
@@ -1,0 +1,416 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
+/*
+ * VistaGlobalPisos — el zoom GRANDE de la navegación por pisos térmicos.
+ *
+ * LA LÁMINA: adaptación ilustrada (estilo lámina de Humboldt, nunca
+ * fotorrealista) del paisaje de referencia del operador — montañas en CAPAS
+ * con perspectiva aérea (oscuro adelante, azul-niebla atrás) y el NEVADO
+ * nítido al fondo. Sobre ese paisaje, los CUATRO pisos térmicos como bandas
+ * de altitud (cálido en el valle → páramo en la cima) con su eje de altitud
+ * al margen, como el Tableau Physique del Chimborazo.
+ *
+ * EL APORTE AL PAISAJE (palabras del operador): el PÁRAMO y la vista de LA
+ * CHORRERA van ARRIBA, cerca del nevado — la cascada cae del páramo, los
+ * frailejones peinan la niebla. Es nuestro pedazo dentro de esa foto.
+ *
+ * Cada mundo de Chagra es una ESTAMPA (medallón) ubicada en su banda; tocarla
+ * navega a su pantalla real. El dato mundo→piso NO vive aquí: lo comparten
+ * los tres zooms desde `pisosNavegacion.js` (coherencia total).
+ *
+ * Todo es SVG dibujado (cero assets externos, offline-first). El paisaje se
+ * genera con un RNG sembrado (mulberry32) → determinista, misma lámina en
+ * cada carga. Animación sutil (niebla que respira, agua que cae) apagada con
+ * prefers-reduced-motion.
+ */
+import { useEffect, useMemo } from 'react';
+import { BANDAS_NAVEGACION, mundosPorBanda } from './pisosNavegacion.js';
+import { GlifoEnt, Frailejon } from './glifosNavegacion.jsx';
+
+/* ── RNG sembrado (mulberry32): paisaje determinista, sin Math.random ────── */
+function mulberry32(semilla) {
+  let a = semilla >>> 0;
+  return function siguiente() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const ANCHO = 1600;
+const ALTO = 1000;
+
+/* Eje de altitud: 0 m en el valle (y=940) → 4200 m en la cima (y=310). */
+const Y_BASE = 940;
+const Y_CIMA = 310;
+function yDeAltitud(metros) {
+  const cima = BANDAS_NAVEGACION[BANDAS_NAVEGACION.length - 1].altMax;
+  return Y_BASE - (metros / cima) * (Y_BASE - Y_CIMA);
+}
+
+/* Una cresta de montaña suave: puntos con jitter sembrado + curvas Q. */
+function crestaSuave(rng, yCresta, amplitud, nPuntos = 9) {
+  const puntos = [];
+  for (let i = 0; i <= nPuntos; i += 1) {
+    const x = (i / nPuntos) * ANCHO;
+    const y = yCresta + (rng() - 0.5) * 2 * amplitud;
+    puntos.push([x, y]);
+  }
+  let d = `M ${-40} ${puntos[0][1].toFixed(1)}`;
+  for (let i = 0; i < puntos.length - 1; i += 1) {
+    const [x1, y1] = puntos[i];
+    const [x2, y2] = puntos[i + 1];
+    const mx = (x1 + x2) / 2;
+    const my = (y1 + y2) / 2;
+    d += ` Q ${x1.toFixed(1)} ${y1.toFixed(1)} ${mx.toFixed(1)} ${my.toFixed(1)}`;
+  }
+  const ultimo = puntos[puntos.length - 1];
+  d += ` L ${ANCHO + 40} ${ultimo[1].toFixed(1)} L ${ANCHO + 40} ${ALTO + 40} L ${-40} ${ALTO + 40} Z`;
+  return d;
+}
+
+/* La cordillera nevada del fondo: picos AGUDOS (L, no Q) + manto de nieve. */
+function nevado(rng) {
+  const nPicos = 16;
+  const cresta = [];
+  for (let i = 0; i <= nPicos; i += 1) {
+    const x = (i / nPicos) * ANCHO;
+    const pico = i % 2 === 0;
+    const y = (pico ? 210 : 292) + (rng() - 0.5) * 58;
+    cresta.push([x, y]);
+  }
+  const linea = cresta.map(([x, y]) => `${x.toFixed(1)} ${y.toFixed(1)}`).join(' L ');
+  const roca = `M -40 ${cresta[0][1]} L ${linea} L ${ANCHO + 40} ${cresta[nPicos][1]} L ${ANCHO + 40} 430 L -40 430 Z`;
+  // El manto de nieve: la misma cresta, cerrada contra una línea de nieve dentada.
+  const nieveBajo = [];
+  for (let i = nPicos; i >= 0; i -= 1) {
+    const [x, y] = cresta[i];
+    nieveBajo.push(`${x.toFixed(1)} ${(y + 34 + rng() * 30).toFixed(1)}`);
+  }
+  const nieve = `M -40 ${cresta[0][1]} L ${linea} L ${ANCHO + 40} ${cresta[nPicos][1]} L ${nieveBajo.join(' L ')} Z`;
+  return { roca, nieve };
+}
+
+/*
+ * Las CAPAS del paisaje, de atrás (alto, pálido por la niebla) hacia adelante
+ * (bajo, oscuro): la perspectiva aérea de la foto, en paleta de lámina.
+ * Cada cresta cae dentro de la banda térmica que le corresponde.
+ */
+const CAPAS = [
+  { seed: 11, y: 356, amp: 26, color: '#8fa9b8' }, // páramo alto, contra el nevado
+  { seed: 23, y: 432, amp: 30, color: '#7e9aa4' }, // páramo bajo (aquí cae la Chorrera)
+  { seed: 37, y: 516, amp: 30, color: '#65897b' }, // frío alto
+  { seed: 41, y: 592, amp: 32, color: '#527a62' }, // frío bajo
+  { seed: 53, y: 668, amp: 30, color: '#4d7141' }, // templado alto
+  { seed: 67, y: 744, amp: 30, color: '#3f5e31' }, // templado bajo
+  { seed: 79, y: 822, amp: 26, color: '#37502a' }, // cálido: la loma del valle
+];
+
+/* Ajuste fino ARTÍSTICO por mundo (dx, dy) sobre la posición calculada de su
+   banda — solo estética; si un mundo no está, cae en la posición automática. */
+const AJUSTE_ESTAMPA = {
+  clima: [-170, -46],
+  agua: [150, 8],
+  suelo: [-60, 26],
+  cafe: [30, -20],
+  micorrizas: [40, 30],
+  valle: [-30, 22],
+  mercado: [20, -14],
+  milpa: [30, 18],
+};
+
+/* Una estampa de mundo: medallón clicable de lámina, con su etiqueta. */
+function EstampaMundo({ mundo, x, y, color, actual, onNavigate }) {
+  const activar = () => onNavigate?.(mundo);
+  return (
+    <g
+      className="navg-estampa"
+      transform={`translate(${x} ${y})`}
+      role="button"
+      tabIndex={0}
+      aria-label={`Ir a ${mundo.titulo}`}
+      onClick={activar}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          activar();
+        }
+      }}
+    >
+      {actual && <circle r="42" fill="none" stroke="#e5b54a" strokeWidth="3" className="navg-aqui" />}
+      <circle r="31" fill="#f7f0dd" stroke={color} strokeWidth="3" />
+      <circle r="26" fill="none" stroke={color} strokeWidth="1" strokeDasharray="2 3" opacity="0.7" />
+      <text y="9" textAnchor="middle" fontSize="26" aria-hidden="true">
+        {mundo.emoji}
+      </text>
+      <text
+        y="52"
+        textAnchor="middle"
+        fontSize="15"
+        fontStyle="italic"
+        fontFamily="Georgia, 'Times New Roman', serif"
+        fill="#20261c"
+        stroke="#f2ead4"
+        strokeWidth="4"
+        paintOrder="stroke"
+      >
+        {mundo.titulo}
+      </text>
+      {actual && (
+        <text
+          y="70"
+          textAnchor="middle"
+          fontSize="12.5"
+          fontFamily="Georgia, 'Times New Roman', serif"
+          fill="#8a6a1f"
+          stroke="#f7f0dd"
+          strokeWidth="4"
+          paintOrder="stroke"
+        >
+          ★ Usted está aquí
+        </text>
+      )}
+    </g>
+  );
+}
+
+/**
+ * @param {object} props
+ * @param {string|null} [props.mundoActual] id del mundo donde está el usuario
+ * @param {(mundo: {id:string, destino:{view:string, data?:object}}) => void} [props.onNavigate]
+ * @param {() => void} [props.onCerrar]  volver al minimapa
+ * @param {() => void} [props.onMapa]    saltar al zoom medio (mapa estratégico)
+ */
+export default function VistaGlobalPisos({ mundoActual = null, onNavigate, onCerrar, onMapa }) {
+  // Paisaje determinista: crestas, nevado y frailejones se calculan una vez.
+  const paisaje = useMemo(() => {
+    const capas = CAPAS.map((c) => ({ ...c, d: crestaSuave(mulberry32(c.seed), c.y, c.amp) }));
+    const cordillera = nevado(mulberry32(101));
+    const rngF = mulberry32(202);
+    const frailejones = Array.from({ length: 9 }, (_, i) => ({
+      x: 150 + i * 150 + rngF() * 80,
+      y: 396 + rngF() * 66,
+      escala: 0.8 + rngF() * 0.5,
+    }));
+    return { capas, cordillera, frailejones };
+  }, []);
+
+  // Estampas: posición por banda (reparto horizontal determinista + ajuste fino).
+  const estampas = useMemo(() => {
+    const grupos = mundosPorBanda();
+    const out = [];
+    grupos.forEach(({ banda, mundos }) => {
+      const yCentro = (yDeAltitud(banda.altMin) + yDeAltitud(banda.altMax)) / 2;
+      const n = mundos.length;
+      mundos.forEach((mundo, i) => {
+        const x = 210 + ((i + 0.5) / n) * (ANCHO - 420);
+        const y = yCentro + (i % 2 === 0 ? -18 : 22);
+        const [dx, dy] = AJUSTE_ESTAMPA[mundo.id] || [0, 0];
+        out.push({ mundo, banda, x: x + dx, y: y + dy });
+      });
+    });
+    return out;
+  }, []);
+
+  // ESC vuelve al minimapa.
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === 'Escape') onCerrar?.();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onCerrar]);
+
+  return (
+    <div className="navg-global" role="dialog" aria-label="Vista global de la finca por pisos térmicos">
+      <style>{`
+        .navg-global { position: fixed; inset: 0; z-index: 1200; background: #0d1522; }
+        .navg-global svg { display: block; width: 100%; height: 100%; }
+        .navg-estampa { cursor: pointer; }
+        .navg-estampa:hover circle:nth-of-type(2), .navg-estampa:focus-visible circle:nth-of-type(2) { stroke-width: 5; }
+        .navg-estampa:focus-visible { outline: none; }
+        .navg-aqui { animation: navg-pulso 2.4s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+        .navg-niebla { animation: navg-respira 9s ease-in-out infinite; }
+        .navg-agua-caida { stroke-dasharray: 10 7; animation: navg-cae 1.6s linear infinite; }
+        .navg-botones { position: absolute; top: 14px; right: 14px; display: flex; gap: 8px; }
+        .navg-boton { border: 1.5px solid #cdbf9b; background: rgba(26, 32, 27, 0.82); color: #f2ead4;
+          font: 600 14px 'Baloo 2', Georgia, serif; padding: 8px 14px; border-radius: 999px; cursor: pointer; }
+        .navg-boton:hover { background: rgba(58, 66, 52, 0.92); }
+        @keyframes navg-pulso { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.12); opacity: 0.55; } }
+        @keyframes navg-respira { 0%, 100% { opacity: 0.34; } 50% { opacity: 0.16; } }
+        @keyframes navg-cae { from { stroke-dashoffset: 0; } to { stroke-dashoffset: -34; } }
+        @media (prefers-reduced-motion: reduce) {
+          .navg-aqui, .navg-niebla, .navg-agua-caida { animation: none; }
+        }
+      `}</style>
+      <svg viewBox={`0 0 ${ANCHO} ${ALTO}`} preserveAspectRatio="xMidYMid slice">
+        <defs>
+          <linearGradient id="navg-cielo" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="#bcd6e6" />
+            <stop offset="0.65" stopColor="#dbe4dd" />
+            <stop offset="1" stopColor="#e8dfc8" />
+          </linearGradient>
+          <linearGradient id="navg-niebla-grad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="#eef3f2" stopOpacity="0.9" />
+            <stop offset="1" stopColor="#eef3f2" stopOpacity="0" />
+          </linearGradient>
+          <linearGradient id="navg-agua-valle" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="#9db8a8" />
+            <stop offset="1" stopColor="#5d7f74" />
+          </linearGradient>
+          <filter id="navg-borroso" x="-30%" y="-30%" width="160%" height="160%">
+            <feGaussianBlur stdDeviation="7" />
+          </filter>
+        </defs>
+
+        {/* ── EL CIELO y la cordillera nevada, nítida al fondo (la foto) ── */}
+        <rect width={ANCHO} height={ALTO} fill="url(#navg-cielo)" />
+        <ellipse cx="360" cy="118" rx="200" ry="26" fill="#f4f7f8" opacity="0.75" filter="url(#navg-borroso)" />
+        <ellipse cx="1220" cy="86" rx="260" ry="30" fill="#f4f7f8" opacity="0.65" filter="url(#navg-borroso)" />
+        <path d={paisaje.cordillera.roca} fill="#7d93a2" />
+        <path d={paisaje.cordillera.nieve} fill="#f6fafc" />
+
+        {/* ── LAS CAPAS: perspectiva aérea, pálido atrás → oscuro adelante ── */}
+        {paisaje.capas.map((capa, i) => (
+          <g key={capa.seed}>
+            <path d={capa.d} fill={capa.color} />
+            {i < paisaje.capas.length - 1 && (
+              <rect
+                className="navg-niebla"
+                x="0"
+                y={capa.y + 16}
+                width={ANCHO}
+                height="72"
+                fill="url(#navg-niebla-grad)"
+                opacity={0.32 - i * 0.03}
+                style={{ animationDelay: `${i * 1.3}s` }}
+              />
+            )}
+          </g>
+        ))}
+
+        {/* Rayos de luz entre crestas (la niebla iluminada de la foto). */}
+        <polygon points="180,150 320,150 700,1000 380,1000" fill="#f2ead4" opacity="0.07" />
+        <polygon points="900,120 1010,120 1420,1000 1180,1000" fill="#f2ead4" opacity="0.06" />
+
+        {/* ── EL VALLE CÁLIDO al pie: campos dorados y el agua que llega ── */}
+        <path
+          d={`M -40 ${ALTO} L -40 905 Q 300 872 640 900 Q 1000 926 1640 892 L 1640 ${ALTO} Z`}
+          fill="#8c7a3d"
+        />
+        <path d="M -40 968 Q 400 934 820 958 Q 1200 978 1640 950 L 1640 1000 L -40 1000 Z" fill="url(#navg-agua-valle)" opacity="0.9" />
+        <path d="M 240 918 q 60 -14 130 -4 q -50 22 -130 4 Z" fill="#cba04a" opacity="0.8" />
+        <path d="M 980 924 q 74 -16 150 -2 q -64 24 -150 2 Z" fill="#cba04a" opacity="0.75" />
+        <path d="M 1330 900 q 60 -12 120 -2 q -48 20 -120 2 Z" fill="#b5913f" opacity="0.7" />
+
+        {/* ── NUESTRO APORTE, arriba junto al nevado: el páramo y LA CHORRERA ── */}
+        <g aria-hidden="true">
+          {/* La peña de la cascada: un tajo de roca en la capa del páramo bajo. */}
+          <path d="M 985 402 L 1075 396 L 1092 520 L 968 526 Z" fill="#5c7280" />
+          <path d="M 1002 402 L 1022 400 L 1030 520 L 1006 522 Z" fill="#46596a" opacity="0.55" />
+          {/* El agua que cae: dos hebras blancas con caída animada. */}
+          <path className="navg-agua-caida" d="M 1024 402 C 1020 440 1030 470 1022 516" stroke="#f3f8f9" strokeWidth="9" fill="none" strokeLinecap="round" />
+          <path className="navg-agua-caida" d="M 1040 404 C 1042 442 1034 472 1044 514" stroke="#e8f1f3" strokeWidth="5" fill="none" strokeLinecap="round" style={{ animationDelay: '0.6s' }} />
+          <ellipse cx="1032" cy="522" rx="40" ry="12" fill="#eef5f6" opacity="0.85" filter="url(#navg-borroso)" />
+          {/* La quebrada que sigue ladera abajo, piso por piso, hasta el valle. */}
+          <path
+            d="M 1032 524 C 1010 570 1090 610 1052 660 C 1020 704 1090 750 1044 800 C 1010 844 1060 900 1020 952"
+            stroke="#cfe3e4"
+            strokeWidth="4"
+            fill="none"
+            opacity="0.65"
+            strokeLinecap="round"
+          />
+          {/* Los frailejones del páramo, peinando la niebla junto a la cascada. */}
+          {paisaje.frailejones.map((f, i) => (
+            <Frailejon key={i} x={f.x} y={f.y} escala={f.escala} />
+          ))}
+        </g>
+        {/* Rótulo de lámina de la Chorrera, con su línea de anotación. */}
+        <g fontFamily="Georgia, 'Times New Roman', serif">
+          <line x1="1105" y1="446" x2="1188" y2="418" stroke="#2c3a40" strokeWidth="1" opacity="0.75" />
+          <text x="1194" y="414" fontSize="19" fontStyle="italic" fill="#273338" stroke="#e9e7d4" strokeWidth="4" paintOrder="stroke">
+            La Chorrera
+          </text>
+          <text x="1194" y="434" fontSize="13" fill="#41525a" stroke="#e9e7d4" strokeWidth="3.6" paintOrder="stroke">
+            el agua nace en el páramo
+          </text>
+        </g>
+
+        {/* ── EL EJE DE HUMBOLDT: la escala de altitud y sus bandas ── */}
+        <g fontFamily="Georgia, 'Times New Roman', serif">
+          <line x1="86" y1={Y_CIMA - 8} x2="86" y2={Y_BASE + 8} stroke="#2f3b33" strokeWidth="1.6" opacity="0.85" />
+          {BANDAS_NAVEGACION.map((banda) => {
+            const yTop = yDeAltitud(banda.altMax);
+            const yBot = yDeAltitud(banda.altMin);
+            return (
+              <g key={banda.id}>
+                <line x1="80" y1={yBot} x2="92" y2={yBot} stroke="#2f3b33" strokeWidth="1.6" />
+                <rect x="94" y={yTop} width="7" height={yBot - yTop} fill={banda.color} opacity="0.9" rx="2" />
+                <text x="110" y={(yTop + yBot) / 2 - 8} fontSize="20" fontWeight="bold" letterSpacing="2" fill="#243029" stroke="#e6e3cf" strokeWidth="4.5" paintOrder="stroke">
+                  {banda.nombre.toUpperCase()}
+                </text>
+                <text x="110" y={(yTop + yBot) / 2 + 14} fontSize="14" fontStyle="italic" fill="#3c4a40" stroke="#e6e3cf" strokeWidth="4" paintOrder="stroke">
+                  {banda.rango} · {banda.emojiCultivo} {banda.cultivo === 'frailejon' ? 'frailejón' : banda.cultivo}
+                </text>
+                <text x="46" y={yBot + 5} fontSize="13" textAnchor="end" fill="#2f3b33" stroke="#dfe4dd" strokeWidth="3.4" paintOrder="stroke">
+                  {banda.altMin} m
+                </text>
+                {/* El Ent guardián marca su banda, al borde derecho de la lámina. */}
+                <g transform={`translate(${ANCHO - 74} ${(yTop + yBot) / 2 - 6})`} aria-hidden="true">
+                  <GlifoEnt entId={banda.entId} color={banda.color} />
+                </g>
+                <text x={ANCHO - 74} y={(yTop + yBot) / 2 + 40} textAnchor="middle" fontSize="12.5" fontStyle="italic" fill="#2f3b33" stroke="#dfe4dd" strokeWidth="3.4" paintOrder="stroke">
+                  {banda.entNombre}
+                </text>
+              </g>
+            );
+          })}
+          <text x="46" y={Y_CIMA + 3} fontSize="13" textAnchor="end" fill="#2f3b33" stroke="#dfe4dd" strokeWidth="3.4" paintOrder="stroke">
+            4200 m
+          </text>
+        </g>
+
+        {/* ── LAS ESTAMPAS: cada mundo en su banda (mismo dato en los 3 zooms) ── */}
+        {estampas.map(({ mundo, banda, x, y }) => (
+          <EstampaMundo
+            key={mundo.id}
+            mundo={mundo}
+            x={x}
+            y={y}
+            color={banda.color}
+            actual={mundo.id === mundoActual}
+            onNavigate={onNavigate}
+          />
+        ))}
+
+        {/* ── LA CARTELA de la lámina ── */}
+        <g fontFamily="Georgia, 'Times New Roman', serif">
+          <rect x={ANCHO / 2 - 285} y="26" width="570" height="86" rx="6" fill="#f4edda" opacity="0.94" />
+          <rect x={ANCHO / 2 - 285} y="26" width="570" height="86" rx="6" fill="none" stroke="#6d6448" strokeWidth="1.6" />
+          <rect x={ANCHO / 2 - 279} y="32" width="558" height="74" rx="4" fill="none" stroke="#6d6448" strokeWidth="0.8" opacity="0.7" />
+          <text x={ANCHO / 2} y="62" textAnchor="middle" fontSize="26" fontWeight="bold" letterSpacing="3" fill="#2c2a1e">
+            LA FINCA POR PISOS TÉRMICOS
+          </text>
+          <text x={ANCHO / 2} y="90" textAnchor="middle" fontSize="15" fontStyle="italic" fill="#4a4633">
+            del valle cálido al páramo — toque un mundo para entrar
+          </text>
+        </g>
+      </svg>
+
+      <div className="navg-botones">
+        {onMapa && (
+          <button type="button" className="navg-boton" onClick={onMapa} aria-label="Abrir el mapa de la finca">
+            🗺️ Mapa de la finca
+          </button>
+        )}
+        {onCerrar && (
+          <button type="button" className="navg-boton" onClick={onCerrar} aria-label="Cerrar la vista global">
+            ✕ Cerrar
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/visual/navegacion/glifosNavegacion.jsx
+++ b/src/visual/navegacion/glifosNavegacion.jsx
@@ -1,0 +1,80 @@
+/*
+ * glifosNavegacion — glifos SVG compartidos por los zooms de navegación.
+ *
+ * Siluetas de lámina (no fotorrealistas) que marcan las bandas térmicas en
+ * cualquier zoom: el Ent guardián de cada piso (ceiba/roble/aliso/queñua,
+ * ids de `MAPA_PISO_ENT`) y el frailejón del páramo. Solo dibujo: cero
+ * estado, cero datos — los datos viven en `pisosNavegacion.js`.
+ */
+
+/**
+ * Silueta del Ent guardián de un piso. Se dibuja centrada en el origen del
+ * grupo que la contiene (usar `transform` para ubicarla y escalarla).
+ * @param {{ entId: string|null, color: string }} props
+ */
+export function GlifoEnt({ entId, color }) {
+  switch (entId) {
+    case 'quenua': // queñua: bajita, torcida, de corteza de papel rojizo
+      return (
+        <g>
+          <path d="M0 22 C -2 12 4 8 1 0" stroke="#7c5a4a" strokeWidth="3" fill="none" />
+          <ellipse cx="1" cy="-2" rx="11" ry="7" fill={color} />
+          <ellipse cx="-6" cy="4" rx="7" ry="5" fill={color} opacity="0.85" />
+        </g>
+      );
+    case 'aliso': // aliso: copa ovalada esbelta
+      return (
+        <g>
+          <rect x="-1.5" y="4" width="3" height="18" fill="#6b5442" />
+          <ellipse cx="0" cy="-2" rx="9" ry="13" fill={color} />
+        </g>
+      );
+    case 'roble': // roble andino: copa ancha y redonda
+      return (
+        <g>
+          <rect x="-2" y="6" width="4" height="16" fill="#5d4632" />
+          <circle cx="0" cy="-2" r="12" fill={color} />
+          <circle cx="-9" cy="3" r="7" fill={color} opacity="0.9" />
+          <circle cx="9" cy="3" r="7" fill={color} opacity="0.9" />
+        </g>
+      );
+    case 'ceiba': // ceiba: paraguas alto con bambas en la base
+      return (
+        <g>
+          <path d="M-2 22 L -7 22 L -2 8 L 2 8 L 7 22 L 2 22 L 2 10 L -2 10 Z" fill="#7a6248" />
+          <ellipse cx="0" cy="2" rx="15" ry="6.5" fill={color} />
+        </g>
+      );
+    default:
+      return null;
+  }
+}
+
+/**
+ * Un frailejón: roseta estrellada sobre tronco corto (silueta de lámina).
+ * @param {{ x: number, y: number, escala?: number }} props
+ */
+export function Frailejon({ x, y, escala = 1 }) {
+  const petalos = [];
+  for (let i = 0; i < 7; i += 1) {
+    const ang = (i / 7) * Math.PI * 2;
+    petalos.push(
+      <ellipse
+        key={i}
+        cx={Math.cos(ang) * 5}
+        cy={Math.sin(ang) * 3.4 - 8}
+        rx="4.6"
+        ry="1.7"
+        transform={`rotate(${(ang * 180) / Math.PI} ${Math.cos(ang) * 5} ${Math.sin(ang) * 3.4 - 8})`}
+        fill="#c9c489"
+      />,
+    );
+  }
+  return (
+    <g transform={`translate(${x} ${y}) scale(${escala})`}>
+      <rect x="-1.6" y="-6" width="3.2" height="9" rx="1.4" fill="#6d6a52" />
+      {petalos}
+      <circle cx="0" cy="-8" r="2.4" fill="#a8a468" />
+    </g>
+  );
+}

--- a/src/visual/navegacion/pisosNavegacion.js
+++ b/src/visual/navegacion/pisosNavegacion.js
@@ -1,0 +1,160 @@
+/*
+ * pisosNavegacion — EL DATO ÚNICO de la navegación por pisos térmicos.
+ *
+ * Los TRES zooms de navegación (minimapa, mapa estratégico, vista global)
+ * LEEN de aquí y solo de aquí: qué bandas de altitud existen, qué mundo vive
+ * en cuál banda y a dónde navega cada mundo al tocarlo. Coherencia total:
+ * cambiar el piso de un mundo en `mundoData.js` mueve su estampa en los tres
+ * zooms a la vez, sin tocar ningún componente.
+ *
+ * FUENTES (solo LECTURA, este módulo no las edita):
+ *   · `MUNDO` (mundoData.js) — cada mundo declara su `pisoTermico`, y el mundo
+ *     `pisos` trae el dato canónico de las 4 bandas (id, nombre, rango, color,
+ *     cultivo insignia). NO se inventan pisos ni colores: se leen.
+ *   · `MAPA_PISO_ENT` (pisosBosqueGradiente.js) — el Ent guardián de cada piso
+ *     (ceiba/roble/aliso/queñua), que marca su banda en los zooms.
+ *   · `MUNDO_BY_ID` (mundosFinca.js) — título/emoji/destino reales del home
+ *     para los mundos que viven en el manifiesto (no se duplican).
+ *
+ * Módulo PURO (sin React, sin three, sin DOM): testeable y seguro en el
+ * bundle base.
+ */
+import { MUNDO } from '../mundo3d/mundoData.js';
+import { MAPA_PISO_ENT } from '../mundo3d/bosque/pisosBosqueGradiente.js';
+import { MUNDO_BY_ID } from '../../components/dashboard/mundosFinca.js';
+
+/* Nombre legible del Ent guardián de cada piso (ids de MAPA_PISO_ENT). */
+const NOMBRE_ENT = {
+  ceiba: 'La ceiba',
+  roble: 'El roble',
+  aliso: 'El aliso',
+  quenua: 'La queñua',
+};
+
+/* Emoji del cultivo insignia de cada banda (el id viene del dato canónico). */
+const EMOJI_CULTIVO = {
+  platano: '🍌',
+  cafe: '☕',
+  papa: '🥔',
+  frailejon: '🌼',
+};
+
+/* Convierte el rango canónico ('3000–4200 m') en metros [min, max]. */
+function parsearRango(rango) {
+  const nums = String(rango).match(/\d+/g) || [];
+  const min = Number(nums[0] ?? 0);
+  const max = Number(nums[1] ?? min);
+  return [min, max];
+}
+
+/**
+ * LAS BANDAS de altitud, de abajo (cálido) a arriba (páramo), derivadas del
+ * dato canónico `MUNDO.pisos.params.pisos`. Cada banda:
+ *   { id, nombre, rango, color, altMin, altMax, cultivo, emojiCultivo,
+ *     entId, entNombre, niebla, protege, indice }
+ */
+export const BANDAS_NAVEGACION = Object.freeze(
+  MUNDO.pisos.params.pisos.map((piso, indice) => {
+    const [altMin, altMax] = parsearRango(piso.rango);
+    return Object.freeze({
+      id: piso.id,
+      nombre: piso.nombre,
+      rango: piso.rango,
+      color: piso.color,
+      altMin,
+      altMax,
+      cultivo: piso.cultivo,
+      emojiCultivo: EMOJI_CULTIVO[piso.cultivo] || '🌱',
+      entId: MAPA_PISO_ENT[piso.id] || null,
+      entNombre: NOMBRE_ENT[MAPA_PISO_ENT[piso.id]] || null,
+      niebla: Boolean(piso.niebla),
+      protege: Boolean(piso.protege),
+      indice,
+    });
+  }),
+);
+
+/** Banda por id ('calido' | 'templado' | 'frio' | 'paramo') o null. */
+export function bandaPorId(id) {
+  return BANDAS_NAVEGACION.find((b) => b.id === id) || null;
+}
+
+/** Altura máxima del gradiente (la cima del páramo, hoy 4200 m). */
+export const ALTITUD_CIMA = BANDAS_NAVEGACION[BANDAS_NAVEGACION.length - 1].altMax;
+
+/**
+ * Fracción 0..1 del CENTRO de una banda respecto a la cima (0 = valle,
+ * 1 = cima). Para ubicar bandas y estampas en el eje vertical de cualquier
+ * zoom sin duplicar aritmética.
+ */
+export function fraccionBanda(id) {
+  const banda = bandaPorId(id);
+  if (!banda) return 0;
+  return (banda.altMin + banda.altMax) / 2 / ALTITUD_CIMA;
+}
+
+/*
+ * Mundos del registro 3D que NO viven en el manifiesto del home
+ * (mundosFinca.js): título/emoji/destino propios, sin inventar vistas — cada
+ * `view` es un case real de App.jsx (las mismas que usan sus hotspots).
+ */
+const MUNDOS_FUERA_DE_MANIFIESTO = {
+  valle: {
+    titulo: 'El valle de la finca',
+    emoji: '🏞️',
+    destino: { view: 'dashboard' },
+    esCasa: true,
+  },
+  frutales: { titulo: 'Frutales de la finca', emoji: '🍊', destino: { view: 'frutales' } },
+  milpa: { titulo: 'La milpa', emoji: '🌽', destino: { view: 'milpa_cultivo' } },
+  pisos: { titulo: 'Qué siembro a mi altura', emoji: '🌡️', destino: { view: 'directorio' } },
+};
+
+/* El destino real de un mundo del manifiesto: directo > portada > pantalla
+   genérica de mundo (la misma regla que aplica la grilla del home). */
+function destinoDeManifiesto(id, manifiesto) {
+  if (manifiesto.directo) {
+    return { view: manifiesto.directo.view, data: manifiesto.directo.data || null };
+  }
+  if (manifiesto.portada) return { view: manifiesto.portada };
+  return { view: 'mundo', data: { mundo: id } };
+}
+
+/**
+ * TODOS los mundos navegables, cada uno con su banda:
+ *   { id, piso, titulo, emoji, destino: {view, data?}, esCasa }
+ * El piso sale de `MUNDO[id].pisoTermico` (la fase de datos ya lo asignó);
+ * título/emoji salen del manifiesto del home cuando el mundo vive allí.
+ */
+export const MUNDOS_NAVEGACION = Object.freeze(
+  Object.entries(MUNDO)
+    .filter(([, mundo]) => Boolean(mundo.pisoTermico))
+    .map(([id, mundo]) => {
+      const manifiesto = MUNDO_BY_ID[id] || null;
+      const propio = MUNDOS_FUERA_DE_MANIFIESTO[id] || null;
+      return Object.freeze({
+        id,
+        piso: mundo.pisoTermico,
+        titulo: manifiesto?.titulo || propio?.titulo || id,
+        emoji: manifiesto?.emoji || propio?.emoji || '🌱',
+        destino: manifiesto ? destinoDeManifiesto(id, manifiesto) : propio?.destino || { view: 'dashboard' },
+        esCasa: Boolean(propio?.esCasa),
+      });
+    }),
+);
+
+/**
+ * Los mundos agrupados por banda, en el orden altitudinal de las bandas:
+ *   [{ banda, mundos: [...] }, ...]  de cálido (abajo) a páramo (arriba).
+ */
+export function mundosPorBanda() {
+  return BANDAS_NAVEGACION.map((banda) => ({
+    banda,
+    mundos: MUNDOS_NAVEGACION.filter((m) => m.piso === banda.id),
+  }));
+}
+
+/** El piso de un mundo (id de banda) o null si no se conoce el mundo. */
+export function pisoDeMundo(mundoId) {
+  return MUNDOS_NAVEGACION.find((m) => m.id === mundoId)?.piso ?? null;
+}


### PR DESCRIPTION
## Qué es

La navegación UNIFICADA de todos los mundos de Chagra, organizados por **piso térmico**, en **tres zooms coherentes** que leen el MISMO dato mundo→piso. Reinterpretación fresca — no toca ni reusa el minimapa del valle viejo (`EntradaValle3D`/`Valle3D`), ni los mundos en curso.

## Los 3 zooms

1. **MINI** (`MiniMapaPisos`) — minimapa de esquina, siempre visible: la montañita por bandas de altitud, un punto por mundo, "usted está aquí" latiendo en dorado. Chiquito, no invasivo.
2. **MEDIO** (`MapaEstrategicoPisos`) — mapa estratégico **tipo Age of Empires**: cuatro terrazas isométricas (cálido, la ancha, abajo → páramo arriba), TODOS los mundos como fichas clicables, placas por piso con su Ent guardián, pergamino + rosa de los vientos + niebla en los bordes.
3. **GRANDE** (`VistaGlobalPisos`) — la vista global de pantalla completa: **adaptación ilustrada (lámina Humboldt) de la foto de referencia** — capas de montaña con perspectiva aérea (oscuro adelante → azul-niebla atrás) y el **nevado nítido al fondo**. Los 4 pisos como bandas de altitud con eje de metros al margen. **El páramo + LA CHORRERA van ARRIBA, junto al nevado** — los frailejones peinando la niebla y la cascada cayendo del piso alto, con la quebrada bajando piso a piso hasta el valle cálido: "nuestro aporte al paisaje dentro de esa foto".

## El dato (SSOT, cero invención)

`src/visual/navegacion/pisosNavegacion.js` deriva TODO por lectura (no edita fuentes):

- **Bandas**: `MUNDO.pisos.params.pisos` de `mundoData.js` — Cálido 0–1000 m `#cba04a` (plátano) · Templado 1000–2000 m `#6f9e4a` (café) · Frío 2000–3000 m `#4f8f7d` (papa) · Páramo 3000–4200 m `#aec7cf` (frailejón).
- **Mundo→piso**: el campo `pisoTermico` que cada mundo ya declara en `mundoData.js`:
  - **Cálido**: animales, valle, cultivos, frutales, mercado, milpa
  - **Templado**: suelo, disenio, abono, cafe, sanidad, semillero, micorrizas
  - **Frío**: pisos
  - **Páramo**: agua, clima
- **Ent por banda**: `MAPA_PISO_ENT` de `pisosBosqueGradiente.js` (ceiba/roble/aliso/queñua) — cada Ent marca su banda en los tres zooms.
- **Título/emoji/destino**: manifiesto real del home (`mundosFinca.js`), regla directo > portada > pantalla de mundo; los cuatro mundos fuera del manifiesto (valle/frutales/milpa/pisos) usan views reales de App.jsx.

Clic en un mundo en cualquier zoom → `navigate(view, data)` real.

## Dónde verlo

Ruta de vitrina sin auth: **`#/mockups/navegacion-pisos`** (demo con el usuario parado en el mundo del café, piso templado).

## Sin deuda

- Paisaje 100% SVG dibujado (RNG sembrado determinista, cero assets externos, offline-first).
- eslint `--max-warnings=0` limpio en archivos nuevos + App.jsx; tsc sin errores en archivos nuevos.
- `prefers-reduced-motion` apaga toda animación. Fichas/estampas/puntos con teclado (Enter/Espacio) y aria-labels.
- `mundoData.js` / `pisosBosqueGradiente.js` / `mundosFinca.js`: solo lectura.

Capturas del gate visual (mini/medio/grande, GPU headed) en el hilo de verificación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)