### PR TITLE
feat(compai): auditoría a 100% + agroecología real, tope de mensaje, telemetría (#59/#62/#80/#81)

### DIFF
--- a/src/compai/nucleo/__tests__/agroecologia.test.js
+++ b/src/compai/nucleo/__tests__/agroecologia.test.js
@@ -1,0 +1,53 @@
+/**
+ * agroecologia — el compAI comenta con el catálogo real de su mata (#80/#81).
+ *
+ * Contratos que cuidamos:
+ *   - sin especie (no hubo match en el catálogo) → null, nunca inventa.
+ *   - especie con rol de gremio conocido (pest_repellent, nitrogen_fixer…)
+ *     → frase agroecológica real, priorizada en el orden curado.
+ *   - sin rol con frase pero con temperatura de helada real → frase de
+ *     temperatura (dato útil, no un consejo agronómico inventado).
+ *   - especie sin ningún campo usable → null, cae a la rama honesta.
+ *   - NUNCA lee `valor_pedagogico` (texto libre no controlado) para armar
+ *     la frase — anti-fabricación.
+ */
+import { describe, it, expect } from 'vitest';
+import { datoAgroecologicoReal } from '../agroecologia';
+
+describe('datoAgroecologicoReal', () => {
+  it('sin especie real, no inventa (anti-fabricación)', () => {
+    expect(datoAgroecologicoReal('maíz', null)).toBeNull();
+    expect(datoAgroecologicoReal('maíz', undefined)).toBeNull();
+    expect(datoAgroecologicoReal('', { roles_in_guild: ['pest_repellent'] })).toBeNull();
+  });
+
+  it('especie con rol pest_repellent → frase de repelencia', () => {
+    const r = datoAgroecologicoReal('albahaca', { roles_in_guild: ['crop', 'pest_repellent'] });
+    expect(r).toMatch(/aleja/i);
+  });
+
+  it('respeta el orden curado cuando hay varios roles con frase', () => {
+    const r = datoAgroecologicoReal('frijol', {
+      roles_in_guild: ['biomass_producer', 'nitrogen_fixer'],
+    });
+    expect(r).toMatch(/nitrógeno/i);
+  });
+
+  it('rol sin frase propia (crop/ground_cover/invasive) cae a temperatura si la hay', () => {
+    const r = datoAgroecologicoReal('kikuyo', {
+      roles_in_guild: ['invasive', 'ground_cover'],
+      temperatura_c: { helada_letal: -3 },
+    });
+    expect(r).toMatch(/-3°C/);
+  });
+
+  it('sin rol con frase y sin temperatura real → null (no inventa)', () => {
+    const r = datoAgroecologicoReal('kikuyo', { roles_in_guild: ['invasive', 'ground_cover'] });
+    expect(r).toBeNull();
+  });
+
+  it('temperatura no finita (dato corrupto) no produce frase inventada', () => {
+    const r = datoAgroecologicoReal('x', { roles_in_guild: [], temperatura_c: { helada_letal: NaN } });
+    expect(r).toBeNull();
+  });
+});

--- a/src/compai/nucleo/agroecologia.js
+++ b/src/compai/nucleo/agroecologia.js
@@ -1,0 +1,104 @@
+/**
+ * agroecologia — EL compAI COMENTA CON EL CATÁLOGO REAL DE SU MATA (#80/#81).
+ * Núcleo portable.
+ *
+ * El hueco que cierra: `comentarista.js` ya sabe decir "tiene maíz
+ * registrado" (auditoría #38/#78), pero eso es inventario — nunca un dato
+ * AGROECOLÓGICO de esa especie puntual (su rol en el gremio, si repele
+ * plaga, si fija nitrógeno, su zona térmica real). El compañero hablaba de
+ * "sus matas" en abstracto; con este módulo habla de SU maíz, con lo que el
+ * catálogo Chagra sabe de Zea mays de verdad.
+ *
+ * REGLA DURA — anti-fabricación (misma de datosFinca.js / comentarista.js):
+ * este módulo NO inventa nada. Sólo traduce a frase los campos ESTRUCTURADOS
+ * que ya trae la especie resuelta del catálogo (`roles_in_guild`,
+ * `thermal_zones`, `temperatura_c.helada_letal`) — nunca lee ni resume el
+ * `valor_pedagogico` (texto libre): ese campo es prosa para lectura humana,
+ * no un dato verificado campo-a-campo, y resumirlo aquí sería fabricar una
+ * afirmación agronómica sin control. Si la especie no resuelve o no tiene
+ * los campos, `null` — el comentarista cae a su rama honesta de siempre.
+ *
+ * Quién arma la especie resuelta: `hooks/useCompaiAgroecologiaReal.js`, que
+ * cruza el cultivo real del inventario (`useInventarioCompai`) contra el
+ * catálogo vivo (`services/speciesResolver.resolveSpecies`, IndexedDB/SQLite
+ * ya cacheado por App.jsx) — ese lado SÍ hace I/O; este módulo no.
+ *
+ * @module compai/nucleo/agroecologia
+ */
+
+/**
+ * Traducción de `roles_in_guild` (vocabulario cerrado del catálogo — ver
+ * scripts/build-catalog-sqlite.mjs) a una frase corta en usted-colombiano.
+ * Sólo se listan los roles con valor agroecológico claro para un consejo de
+ * compañía; roles puramente descriptivos (crop, ground_cover) no producen
+ * frase propia — el cultivo igual puede calificar por otro rol o por zona
+ * térmica.
+ */
+const FRASE_POR_ROL = {
+  pest_repellent: 'ayuda a alejar plaga de sus vecinas',
+  nitrogen_fixer: 'le fija nitrógeno al suelo — buena vecina para las que comen mucho',
+  living_fence: 'sirve de cerca viva',
+  windbreak: 'corta el viento y protege lo que tiene al lado',
+  nurse_plant: 'hace de nodriza: le da sombra a los cultivos jóvenes',
+  pollinator_attractor: 'atrae polinizadores — más flor, más fruto alrededor',
+  dynamic_accumulator: 'saca nutrientes de lo hondo y los deja en la superficie',
+  biomass_producer: 'da harta biomasa para abono verde o mulch',
+};
+
+/** Orden de preferencia cuando una especie tiene varios roles con frase. */
+const ORDEN_ROLES = Object.keys(FRASE_POR_ROL);
+
+/**
+ * @typedef {Object} EspecieCatalogo
+ * @property {string} [id]
+ * @property {string} [nombre_comun]
+ * @property {Array<string>} [roles_in_guild]
+ * @property {Array<string>} [thermal_zones]
+ * @property {{helada_letal?: number}} [temperatura_c]
+ */
+
+/**
+ * El primer rol con frase agroecológica conocida, en el orden curado de
+ * `ORDEN_ROLES` (no el orden crudo del catálogo, que no prioriza nada).
+ * @param {Array<string>} [roles]
+ * @returns {string|null}
+ */
+function primerRolConFrase(roles) {
+  if (!Array.isArray(roles) || roles.length === 0) return null;
+  const set = new Set(roles);
+  for (const rol of ORDEN_ROLES) {
+    if (set.has(rol)) return rol;
+  }
+  return null;
+}
+
+/**
+ * Arma el dato agroecológico real de una especie ya resuelta del catálogo,
+ * grounded en `nombreCultivo` (el nombre tal como está en la finca del
+ * usuario — puede diferir de `nombre_comun`, ej. "Café #03" ya sin sufijo).
+ *
+ * @param {string} nombreCultivo — nombre del cultivo real del usuario.
+ * @param {EspecieCatalogo|null|undefined} especie — resuelta por
+ *   speciesResolver contra el catálogo vivo; `null` si no hubo match.
+ * @returns {string|null} frase lista para tejer en el comentario, o `null`
+ *   si no hay especie o no tiene ningún campo agroecológico usable.
+ */
+export function datoAgroecologicoReal(nombreCultivo, especie) {
+  if (!especie || typeof especie !== 'object') return null;
+  const nombre = String(nombreCultivo || especie.nombre_comun || '').trim();
+  if (!nombre) return null;
+
+  const rol = primerRolConFrase(especie.roles_in_guild);
+  if (rol) return `${FRASE_POR_ROL[rol]}`;
+
+  // Sin rol de gremio con frase — probamos con la helada letal (dato de
+  // temperatura, útil de verdad para decidir si tapar la mata esta noche).
+  const heladaLetal = especie.temperatura_c?.helada_letal;
+  if (Number.isFinite(heladaLetal) && heladaLetal > -50) {
+    return `aguanta hasta ${heladaLetal}°C — por debajo de eso ya sufre`;
+  }
+
+  return null;
+}
+
+export default { datoAgroecologicoReal, FRASE_POR_ROL };

--- a/src/compai/nucleo/comentarista.js
+++ b/src/compai/nucleo/comentarista.js
@@ -48,9 +48,14 @@ export const COMENTARISTA_MUNDO = {
     if (top) {
       const n = Number(top.count);
       const nombre = nombreLimpio(top.name);
+      // #80/#81: dato agroecológico REAL de esa especie (catálogo Chagra),
+      // no un inventario genérico — cuando lo hay, se teje en el mismo
+      // comentario; sin match no cambia una coma del texto de siempre.
+      const agro = typeof datos.agro === 'string' && datos.agro.trim() ? datos.agro.trim() : null;
+      const cola = agro ? ` Y ojo: ${nombre} ${agro}.` : '';
       return n > 1
-        ? `De sus matas, la que más tiene es ${nombre} — ${n} registradas. ¿Le hacemos seguimiento?`
-        : `Tiene ${nombre} registrado en su finca. ¿Le echamos un ojo a cómo va?`;
+        ? `De sus matas, la que más tiene es ${nombre} — ${n} registradas. ¿Le hacemos seguimiento?${cola}`
+        : `Tiene ${nombre} registrado en su finca. ¿Le echamos un ojo a cómo va?${cola}`;
     }
     return 'Todavía no me ha contado qué tiene sembrado. Cuando registre sus matas, le sigo el rastro a cada una.';
   },

--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -17,6 +17,7 @@ import { estaOcupado } from '../services/compaiOcupado.js';
 import { activarEscucha } from '../services/escuchaService';
 import { useCompaiClimaVivo } from '../hooks/useCompaiClimaVivo';
 import { useCompaiSusurroNocturno } from '../hooks/useCompaiSusurroNocturno';
+import { useCompaiAgroecologiaReal } from '../hooks/useCompaiAgroecologiaReal';
 import AgentFabMenu from './AgentFabMenu';
 import './agent-fab-skin.css';
 
@@ -167,6 +168,14 @@ export default function AgentFab({ onNavigate, pantalla = null }) {
       setResponseReady(true);
       if (ttsEnabled) speakSentences(mensaje, { rate }).catch(() => { /* degrada a solo texto */ });
     },
+  });
+
+  // #80/#81 "agroecología según SU finca real": el compañero comenta con lo
+  // que el catálogo Chagra sabe de SU cultivo puntual (rol en el gremio,
+  // temperatura de helada real) — no un inventario genérico. Sin match en
+  // el catálogo, no dice nada nuevo (el husmeo de siempre sigue igual).
+  useCompaiAgroecologiaReal({
+    onMensaje: (mensaje) => { setLastMessage(mensaje); setResponseReady(true); },
   });
 
   // Estado de Angelita: el tacto manda sobre el aviso, y el aviso sobre el idle.

--- a/src/hooks/__tests__/useCompaiAgroecologiaReal.test.js
+++ b/src/hooks/__tests__/useCompaiAgroecologiaReal.test.js
@@ -1,0 +1,106 @@
+/**
+ * useCompaiAgroecologiaReal — el compAI comenta CON el catálogo real de SU
+ * cultivo (#80/#81).
+ *
+ * Contratos que cuidamos:
+ *   - sin inventario real (finca vacía), no llama al catálogo — nada nuevo
+ *     que decir.
+ *   - con cultivo real que resuelve en el catálogo y trae un dato
+ *     agroecológico usable, dispara entrarMundo('mis_matas', …) con `agro`.
+ *   - sin match en el catálogo (resolveSpecies → null), no dispara nada
+ *     (anti-fabricación: el husmeo normal de inventario sigue solo).
+ *   - no le quita el turno a un husmeo/aviso ya en curso (mismo contrato que
+ *     useCompaiClimaVivo/useCompaiSusurroNocturno).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+vi.mock('../../services/speciesResolver', () => ({ resolveSpecies: vi.fn() }));
+vi.mock('../../services/compaiOcupado.js', () => ({ estaOcupado: () => false }));
+
+import { useCompaiAgroecologiaReal } from '../useCompaiAgroecologiaReal';
+import { resolveSpecies } from '../../services/speciesResolver';
+import useAssetStore from '../../store/useAssetStore';
+import useAngelitaStore from '../../store/useAngelitaStore';
+
+function sembrarPlanta(nombre) {
+  useAssetStore.setState({
+    plants: [{ attributes: { name: nombre, status: 'active' } }],
+    equipment: [],
+  });
+}
+
+describe('useCompaiAgroecologiaReal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // rand alto: nunca cae bajo PROBABILIDAD_PREGUNTA del modo aprendiz
+    // (#110) — este test cubre el comentario declarativo, no la pregunta.
+    vi.spyOn(Math, 'random').mockReturnValue(0.99);
+    useAssetStore.setState({ plants: [], equipment: [] });
+    useAngelitaStore.setState({
+      estado: 'calma',
+      mensaje: null,
+      ultimaHablaPorLlave: {},
+      ultimoLogroId: null,
+      ultimoLutoId: null,
+      silenciado: false,
+      molestia: 0,
+    });
+  });
+
+  it('sin inventario real, no llama al catálogo', async () => {
+    renderHook(() => useCompaiAgroecologiaReal({}));
+    await waitFor(() => expect(resolveSpecies).not.toHaveBeenCalled());
+  });
+
+  it('con match real y dato agroecológico usable, husmea mis_matas con `agro`', async () => {
+    sembrarPlanta('Fríjol');
+    vi.mocked(resolveSpecies).mockResolvedValue({
+      species: { id: 'phaseolus_vulgaris', roles_in_guild: ['crop', 'nitrogen_fixer'] },
+      slug: 'phaseolus_vulgaris',
+      match: 'exact',
+      confidence: 1,
+    });
+    const onMensaje = vi.fn();
+    renderHook(() => useCompaiAgroecologiaReal({ onMensaje }));
+
+    await waitFor(() => expect(resolveSpecies).toHaveBeenCalledWith('Fríjol'));
+    await waitFor(() => expect(useAngelitaStore.getState().estado).toBe('husmea'));
+    expect(useAngelitaStore.getState().mensaje).toMatch(/nitrógeno/i);
+    expect(onMensaje).toHaveBeenCalled();
+  });
+
+  it('sin match en el catálogo, no dispara nada (anti-fabricación)', async () => {
+    sembrarPlanta('Planta rarísima que no existe');
+    vi.mocked(resolveSpecies).mockResolvedValue(null);
+    const onMensaje = vi.fn();
+    renderHook(() => useCompaiAgroecologiaReal({ onMensaje }));
+
+    await waitFor(() => expect(resolveSpecies).toHaveBeenCalled());
+    expect(useAngelitaStore.getState().estado).toBe('calma');
+    expect(onMensaje).not.toHaveBeenCalled();
+  });
+
+  it('no le quita el turno a un husmeo ya en curso', async () => {
+    sembrarPlanta('Fríjol');
+    useAngelitaStore.setState({ estado: 'aviso' });
+    vi.mocked(resolveSpecies).mockResolvedValue({
+      species: { roles_in_guild: ['nitrogen_fixer'] },
+      slug: 'phaseolus_vulgaris',
+      match: 'exact',
+      confidence: 1,
+    });
+    renderHook(() => useCompaiAgroecologiaReal({}));
+
+    // Da tiempo a que, si fuera a llamar, ya lo hubiera hecho.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(resolveSpecies).not.toHaveBeenCalled();
+  });
+
+  it('activo=false no hace nada', async () => {
+    sembrarPlanta('Fríjol');
+    renderHook(() => useCompaiAgroecologiaReal({ activo: false }));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(resolveSpecies).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useCompaiAgroecologiaReal.js
+++ b/src/hooks/useCompaiAgroecologiaReal.js
@@ -1,0 +1,86 @@
+/**
+ * useCompaiAgroecologiaReal — el compAI comenta CON el catálogo real de SU
+ * cultivo (#80/#81), no un inventario en abstracto.
+ *
+ * El hueco que cierra: `useInventarioCompai`/`comentarista.js` ya sabían
+ * decir "tiene maíz registrado" (auditoría #38/#78), pero nunca un dato
+ * AGROECOLÓGICO de esa especie puntual — el compañero hablaba de "sus
+ * matas" en general, nunca de SU maíz con lo que el catálogo Chagra sabe de
+ * Zea mays de verdad (rol en el gremio, temperatura de helada real…).
+ *
+ * Cablea: el cultivo más numeroso del inventario real (`useInventarioCompai`)
+ * → `speciesResolver.resolveSpecies` (catálogo vivo, IndexedDB/SQLite ya
+ * cacheado por App.jsx, exact-match primero) → `compai/nucleo/agroecologia.
+ * datoAgroecologicoReal` (puro, anti-fabricación) → `useAngelitaStore.
+ * entrarMundo('mis_matas', …)` — la MISMA anti-molestia y el MISMO cooldown
+ * por mundo que cualquier otro husmeo.
+ *
+ * Anti-fabricación: sin cultivo real, o sin match de catálogo, o sin campo
+ * agroecológico usable, este hook simplemente NO tiene nada nuevo que decir
+ * — el husmeo de siempre (inventario) sigue funcionando exactamente igual.
+ *
+ * Local-first salvo por el propio catalogDB (SQLite ya empaquetado con el
+ * build, cero red en runtime — mismo contrato que speciesResolver.js).
+ */
+import { useEffect, useRef } from 'react';
+import useAngelitaStore from '../store/useAngelitaStore';
+import { useInventarioCompai } from './useInventarioCompai';
+import { resolveSpecies } from '../services/speciesResolver';
+import { datoAgroecologicoReal } from '../compai/nucleo/agroecologia.js';
+import { estaOcupado } from '../services/compaiOcupado.js';
+
+/** Cada cuánto se reintenta (el cultivo top casi no cambia entre visitas). */
+const INTERVALO_MS = 15 * 60 * 1000;
+
+/**
+ * @param {Object} [opts]
+ * @param {boolean} [opts.activo=true]
+ * @param {(mensaje:string) => void} [opts.onMensaje] callback opcional con
+ *   el mensaje que surgió (mismo contrato que useCompaiClimaVivo).
+ */
+export function useCompaiAgroecologiaReal({ activo = true, onMensaje } = {}) {
+  const inventario = useInventarioCompai();
+  const cultivoTopNombre = inventario?.cultivos?.[0]?.name || null;
+  const yaResueltoPara = useRef(null); // nombre del último cultivo ya intentado (éxito o no)
+
+  useEffect(() => {
+    if (!activo || !cultivoTopNombre) return undefined;
+    if (yaResueltoPara.current === cultivoTopNombre) return undefined;
+    let vivo = true;
+
+    const intentar = async () => {
+      // No le quita el turno a un husmeo/aviso en curso, ni compite si ya
+      // no está en calma cuando la promesa resuelve.
+      if (useAngelitaStore.getState().estado !== 'calma') return;
+      let resuelto = null;
+      try {
+        resuelto = await resolveSpecies(cultivoTopNombre);
+      } catch {
+        // catálogo no listo / RAG falló: se skippea silencioso, como en
+        // cualquier otro caller de resolveSpecies — nunca inventa.
+        resuelto = null;
+      }
+      if (!vivo) return;
+      yaResueltoPara.current = cultivoTopNombre;
+      const agro = datoAgroecologicoReal(cultivoTopNombre, resuelto?.species || null);
+      if (!agro) return; // sin dato real, el husmeo normal (inventario) sigue igual
+      if (useAngelitaStore.getState().estado !== 'calma') return;
+      const decision = useAngelitaStore.getState().entrarMundo(
+        'mis_matas',
+        { cultivos: inventario.cultivos, agro },
+        { ocupado: estaOcupado() },
+      );
+      if (decision.interrumpe && typeof onMensaje === 'function') onMensaje(decision.mensaje);
+    };
+
+    intentar();
+    const id = window.setInterval(() => {
+      // Sólo reintenta si el cultivo top cambió (se limpia el marcador).
+      if (yaResueltoPara.current !== cultivoTopNombre) intentar();
+    }, INTERVALO_MS);
+    return () => { vivo = false; window.clearInterval(id); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activo, cultivoTopNombre]);
+}
+
+export default useCompaiAgroecologiaReal;

--- a/src/services/__tests__/angelitaInteligencia.test.js
+++ b/src/services/__tests__/angelitaInteligencia.test.js
@@ -34,6 +34,7 @@ import {
   aplicarSenalMolestia,
   multiplicadorDeCadencia,
   cadenciaEfectivaMs,
+  recortarMensaje,
 } from '../angelitaInteligencia';
 // Contrato con la CARA: los estados visuales canónicos que el dibujo entiende.
 import { ESTADOS_ANGELITA } from '../../visual/agente/angelitaEstados';
@@ -127,6 +128,21 @@ describe('comentarioDeMundo — grounded + honesto', () => {
     expect(s).toMatch(/todavía no me ha contado/i);
     expect(s).not.toMatch(/\d/); // no inventa números
     sinVoseo(s);
+  });
+
+  it('mis_matas: con `agro` (#80/#81, dato real del catálogo) lo teje en el comentario', () => {
+    const s = comentarioDeMundo('mis_matas', {
+      cultivos: [{ name: 'Fríjol', count: 2 }],
+      agro: 'le fija nitrógeno al suelo — buena vecina para las que comen mucho',
+    });
+    expect(s).toMatch(/fríjol/i);
+    expect(s).toMatch(/nitrógeno/i);
+    sinVoseo(s);
+  });
+
+  it('mis_matas: sin `agro` (sin match en el catálogo) no cambia el texto de siempre', () => {
+    const s = comentarioDeMundo('mis_matas', { cultivos: [{ name: 'Fríjol', count: 2 }] });
+    expect(s).not.toMatch(/ojo:/i);
   });
 
   it('mis_animales: cuenta real o fallback honesto', () => {
@@ -338,6 +354,9 @@ describe('resolverComportamiento — arbitraje', () => {
       ahoraMs: ahora,
       mundo: 'mis_animales',
       datosMundo: { total: 8 },
+      // rand=1 nunca cae bajo PROBABILIDAD_PREGUNTA (#110): este test cubre
+      // el comentario declarativo, no el modo aprendiz (cubierto aparte).
+      rand: () => 1,
     });
     expect(d.estado).toBe('husmea');
     expect(d.visualEstado).toBe('senala');
@@ -446,5 +465,44 @@ describe('cadencia adaptativa (#102/#106)', () => {
     expect(debeHablar({
       estado: 'aviso', severidad: 'alta', ahoraMs, ultimaMs: ahoraMs, molestia: MOLESTIA_MAX,
     })).toBe(true);
+  });
+});
+
+describe('recortarMensaje (#59 — tope de 2-3 líneas)', () => {
+  it('mensaje corto no se toca', () => {
+    expect(recortarMensaje('Tiene maíz registrado.')).toBe('Tiene maíz registrado.');
+  });
+
+  it('null/undefined pasan igual (nunca lanza)', () => {
+    expect(recortarMensaje(null)).toBeNull();
+    expect(recortarMensaje(undefined)).toBeNull();
+  });
+
+  it('mensaje largo se recorta al tope y nunca lo excede', () => {
+    const largo = 'Esta es una oración normal que describe algo de la finca. '.repeat(6);
+    const r = recortarMensaje(largo);
+    expect(r.length).toBeLessThanOrEqual(220);
+    expect(r.length).toBeLessThan(largo.length);
+  });
+
+  it('prefiere cortar en frontera de oración cuando cae cerca del tope', () => {
+    const primeraFrase = 'Tiene café registrado en su finca, la que más tiene.'; // 53 chars
+    const relleno = 'Y aquí sigue más texto que empuja el mensaje bien largo hasta pasarse.';
+    const r = recortarMensaje(`${primeraFrase} ${relleno}`, 60);
+    expect(r).toBe(primeraFrase);
+    expect(r.endsWith('.')).toBe(true);
+  });
+
+  it('sin frontera de oración cercana, corta en espacio y cierra con elipsis', () => {
+    const r = recortarMensaje('palabra '.repeat(10).trim(), 20);
+    expect(r.endsWith('…')).toBe(true);
+    expect(r.length).toBeLessThanOrEqual(21);
+  });
+
+  it('resolverComportamiento nunca devuelve un mensaje más largo que el tope', () => {
+    const decision = resolverComportamiento({
+      logro: { id: 'cosecha:1', texto: 'X'.repeat(400) },
+    });
+    expect(decision.mensaje.length).toBeLessThanOrEqual(220);
   });
 });

--- a/src/services/__tests__/angelitaVariedadTelemetria.test.js
+++ b/src/services/__tests__/angelitaVariedadTelemetria.test.js
@@ -1,0 +1,54 @@
+/**
+ * angelitaVariedad — telemetría plantilla-vs-LLM (#62).
+ *
+ * Contratos que cuidamos:
+ *   - registrarOrigenVariante acumula por origen ('base'|'plantilla'|'llm').
+ *   - un origen inválido no rompe ni cuenta nada.
+ *   - resumenTelemetriaVariedad suma los tres al `total`.
+ *   - variarMensaje() SIEMPRE registra algún origen (nunca queda sin contar).
+ *   - _resetVariedad() también limpia el contador de telemetría.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  variarMensaje,
+  registrarOrigenVariante,
+  resumenTelemetriaVariedad,
+  _resetVariedad,
+} from '../angelitaVariedad';
+
+describe('telemetría plantilla-vs-LLM (#62)', () => {
+  beforeEach(() => {
+    _resetVariedad();
+  });
+
+  it('arranca en cero', () => {
+    expect(resumenTelemetriaVariedad()).toEqual({ base: 0, plantilla: 0, llm: 0, total: 0 });
+  });
+
+  it('registrarOrigenVariante acumula por origen', () => {
+    registrarOrigenVariante('plantilla');
+    registrarOrigenVariante('plantilla');
+    registrarOrigenVariante('llm');
+    const r = resumenTelemetriaVariedad();
+    expect(r).toEqual({ base: 0, plantilla: 2, llm: 1, total: 3 });
+  });
+
+  it('un origen inválido no cuenta ni lanza', () => {
+    registrarOrigenVariante('lo-que-sea');
+    expect(resumenTelemetriaVariedad().total).toBe(0);
+  });
+
+  it('variarMensaje() siempre registra algún origen — el total sube', () => {
+    variarMensaje('Tiene café registrado en su finca.', 'informativa', { sinLLM: true });
+    expect(resumenTelemetriaVariedad().total).toBe(1);
+    variarMensaje('Tiene café registrado en su finca.', 'informativa', { sinLLM: true });
+    expect(resumenTelemetriaVariedad().total).toBe(2);
+  });
+
+  it('_resetVariedad() limpia también el contador de telemetría', () => {
+    registrarOrigenVariante('llm');
+    expect(resumenTelemetriaVariedad().total).toBe(1);
+    _resetVariedad();
+    expect(resumenTelemetriaVariedad().total).toBe(0);
+  });
+});

--- a/src/services/angelitaInteligencia.js
+++ b/src/services/angelitaInteligencia.js
@@ -402,6 +402,36 @@ export function debeHablar({
  * 6. EL RESOLVEDOR — arbitra los cuatro comportamientos y arma la decisión.
  * ────────────────────────────────────────────────────────────────────────── */
 
+/** Tope duro de un mensaje del compAI (#59): 2-3 líneas en móvil, no un
+ *  párrafo. ~110 caracteres por línea a un tamaño de burbuja cómodo × 2
+ *  líneas de margen sano antes de la 3ra — más que eso ya lee como el LLM
+ *  completo, no como el compañero de paso. */
+const TOPE_MENSAJE_CHARS = 220;
+
+/**
+ * Recorta un mensaje al tope de la casa SIN cortar a mitad de palabra ni de
+ * oración cuando se puede evitar: prefiere el último punto/interrogación
+ * dentro del tope; si no hay ninguno razonablemente cerca, corta en el
+ * último espacio y cierra con "…". Mensajes ya cortos no se tocan.
+ * @param {string|null} mensaje
+ * @param {number} [tope]
+ * @returns {string|null}
+ */
+export function recortarMensaje(mensaje, tope = TOPE_MENSAJE_CHARS) {
+  if (typeof mensaje !== 'string') return mensaje ?? null;
+  if (mensaje.length <= tope) return mensaje;
+  const ventana = mensaje.slice(0, tope);
+  const ultimaOracion = Math.max(ventana.lastIndexOf('. '), ventana.lastIndexOf('? '), ventana.lastIndexOf('! '));
+  // Sólo usamos el corte "en oración" si no descarta más de un tercio del
+  // tope — si no, es preferible el corte con elipsis a perder media frase.
+  if (ultimaOracion > tope * 0.66) return ventana.slice(0, ultimaOracion + 1).trim();
+  const ultimoEspacio = ventana.lastIndexOf(' ');
+  // Sin espacio usable (una sola palabra/token larguísimo, ej. una URL): se
+  // corta duro al tope menos el "…" — el resultado NUNCA excede `tope`.
+  const corte = ultimoEspacio > 0 ? ventana.slice(0, ultimoEspacio) : ventana.slice(0, Math.max(0, tope - 1));
+  return `${corte.trim()}…`;
+}
+
 /**
  * @typedef {Object} DecisionAngelita
  * @property {('calma'|'aviso'|'celebra'|'husmea'|'luto')} estado — comportamiento elegido.
@@ -562,7 +592,8 @@ export function resolverComportamiento(ctx = {}) {
   return {
     estado: /** @type {any} */ (ganador.estado),
     visualEstado: estadoVisualDeComportamiento(ganador.estado, { severidad: ganador.severidad }),
-    mensaje: ganador.mensaje,
+    // #59: tope de 2-3 líneas — la burbuja del compAI no es el chat completo.
+    mensaje: recortarMensaje(ganador.mensaje),
     aria: ariaDeComportamiento(ganador.estado),
     severidad: ganador.severidad,
     prioridad: ganador.prioridad,

--- a/src/services/angelitaVariedad.js
+++ b/src/services/angelitaVariedad.js
@@ -48,6 +48,11 @@ import { fetchWithAuthRetry } from './apiService';
  * ────────────────────────────────────────────────────────────────────────── */
 
 const STORAGE_KEY = 'chagra:angelita:variedad:v1';
+/** #62 — telemetría local plantilla-vs-LLM: cuenta de dónde salió cada
+ *  variante mostrada. Sin red, sin PII — sólo un contador por origen, para
+ *  que el operador pueda ver si el pool LLM de verdad está enriqueciendo el
+ *  habla o si el compañero suena siempre a plantilla determinista. */
+const TELEMETRIA_KEY = 'chagra:angelita:variedad:telemetria:v1';
 /** Máximo de mensajes base recordados (LRU por timestamp). */
 const MAX_BASES = 40;
 /** Ring buffer: últimos N mostrados por mensaje base. */
@@ -377,9 +382,16 @@ export function variarMensaje(base, tipo = 'informativa', opts = {}) {
     entrada.ts = opts.ahoraMs ?? Date.now();
 
     // El pool: base + deterministas + lo que el LLM haya dejado listo.
+    // `origenLlm` recuerda cuáles del pool son paráfrasis LLM (#62,
+    // telemetría) — el resto (base intacto + variantesDeterministas) son
+    // "plantilla": ropaje determinista, cero red.
     const pool = variantesDeterministas(b, tipo);
+    const origenLlm = new Set();
     for (const v of entrada.llm) {
-      if (!pool.includes(v)) pool.push(v);
+      if (!pool.includes(v)) {
+        pool.push(v);
+        origenLlm.add(v);
+      }
     }
     if (pool.length === 0) return b;
 
@@ -398,6 +410,9 @@ export function variarMensaje(base, tipo = 'informativa', opts = {}) {
     entrada.vistos = [...entrada.vistos, hashStr(elegida)].slice(-MAX_VISTOS);
     guardarEstado();
 
+    // #62: telemetría de origen — base intacto / plantilla determinista / LLM.
+    registrarOrigenVariante(origenLlm.has(elegida) ? 'llm' : elegida === b ? 'base' : 'plantilla');
+
     // La capa LLM trabaja para la PRÓXIMA vez — jamás para esta.
     if (!opts.sinLLM) {
       refrescarPoolLLM(b, tipo).catch(() => {});
@@ -409,11 +424,66 @@ export function variarMensaje(base, tipo = 'informativa', opts = {}) {
   }
 }
 
+/* ─────────────────────────────────────────────────────────────────────────────
+ * #62 — TELEMETRÍA LOCAL: plantilla-vs-LLM.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** Fallback en memoria del contador (mismo patrón que `memoria` de arriba). */
+let telemetria = null;
+
+function leerTelemetria() {
+  if (telemetria) return telemetria;
+  try {
+    const crudo = globalThis.localStorage?.getItem(TELEMETRIA_KEY);
+    if (crudo) {
+      const parsed = JSON.parse(crudo);
+      if (parsed && typeof parsed === 'object') {
+        telemetria = { base: 0, plantilla: 0, llm: 0, ...parsed };
+        return telemetria;
+      }
+    }
+  } catch {
+    /* storage roto/lleno: seguimos en memoria */
+  }
+  telemetria = { base: 0, plantilla: 0, llm: 0 };
+  return telemetria;
+}
+
+/**
+ * Registra de dónde salió la variante que se acaba de mostrar. Uso interno
+ * de `variarMensaje` (no hace falta llamarla a mano salvo en tests).
+ * @param {'base'|'plantilla'|'llm'} origen
+ */
+export function registrarOrigenVariante(origen) {
+  if (origen !== 'base' && origen !== 'plantilla' && origen !== 'llm') return;
+  const t = leerTelemetria();
+  t[origen] = (t[origen] || 0) + 1;
+  try {
+    globalThis.localStorage?.setItem(TELEMETRIA_KEY, JSON.stringify(t));
+  } catch {
+    /* quota/privado: el contador en RAM sigue sirviendo esta sesión */
+  }
+}
+
+/**
+ * El resumen de telemetría acumulado: cuántas veces sonó el mensaje base
+ * intacto, cuántas una variante determinista (plantilla) y cuántas una
+ * paráfrasis del LLM. Útil para ver si el pool LLM de verdad enriquece el
+ * habla o si el compañero suena siempre a plantilla.
+ * @returns {{base:number, plantilla:number, llm:number, total:number}}
+ */
+export function resumenTelemetriaVariedad() {
+  const t = leerTelemetria();
+  return { base: t.base, plantilla: t.plantilla, llm: t.llm, total: t.base + t.plantilla + t.llm };
+}
+
 /** Solo para tests: borra la memoria de variedad (RAM + storage). */
 export function _resetVariedad() {
   memoria = null;
+  telemetria = null;
   try {
     globalThis.localStorage?.removeItem(STORAGE_KEY);
+    globalThis.localStorage?.removeItem(TELEMETRIA_KEY);
   } catch {
     /* sin storage */
   }


### PR DESCRIPTION
## Resumen

Auditoría profunda de compai (Ola 1/2 + batch5/6 ya mergeados en dev) + cableado de lo genuinamente pendiente del lado PWA.

### Auditoría — qué estaba VIVO de lo "hecho" (verificado con call-sites reales, no solo definiciones)

- **Batch5 (#108-111, commit 2354f1ea) — 100% VIVO**: susurro nocturno, luto/fiesta (`useAngelitaStore.lamentar()`/`celebrar()` cableados en `AssetDetailView.jsx`/`AssetsDashboard.jsx`), modo aprendiz (`preguntaDeAprendiz` dentro de `resolverComportamiento`), clima real — los 4 con call-site real, no solo núcleo+test. El doc de pendientes estaba desactualizado en varios de estos puntos.
- **#96/#97 cruce 2D↔3D**: vivo (`LLAVE_COMPANERO` única, `useAgentAvatarType`/`useCompaiElegido` la leen).
- **#66/#69/#70 gesto de interacción**: vivo (batch4, `AgentFab.jsx`).
- **#24/#21 AngelitaGuia + volar a elemento real**: vivo, montado en `HoyEnFincaScreen.jsx`.
- **#38 husmeo con inventario real**: vivo — pero descubrí que el ÚNICO call-site de `entrarMundo`/`comentarioDeMundo` con datos reales es `src/mockups/valle/Valle3D.jsx` (ruta de producción real `valle3d`, pese al nombre de carpeta) — fuera de mi alcance de edición por regla explícita.

### Completado en este PR (call-sites VIVOS, dentro de compai/agente/hooks)

1. **#80/#81 — agroecología según la finca real** (`src/compai/nucleo/agroecologia.js` + `src/hooks/useCompaiAgroecologiaReal.js`, cableado en `AgentFab.jsx`): cruza el cultivo top del inventario real contra el catálogo Chagra (`speciesResolver.resolveSpecies`) y teje un dato agroecológico REAL (rol en el gremio / temperatura de helada) en el comentario de `mis_matas` — anti-fabricación estricta, solo campos estructurados del catálogo, nunca el texto libre `valor_pedagogico`.
2. **#59 — tope de 2-3 líneas**: `recortarMensaje()` en `angelitaInteligencia.js`, aplicado a TODO mensaje que sale de `resolverComportamiento()` sin importar el estado.
3. **#62 — telemetría plantilla-vs-LLM**: `registrarOrigenVariante()`/`resumenTelemetriaVariedad()` en `angelitaVariedad.js`, cableado dentro de `variarMensaje()` (contador local, sin red, sin PII).

### Wake-word #89 (auditado a pedido explícito — NO reentrenado)

- Motor, UI (`ModoCampoPanel`), consentimiento, enrolamiento ("Enséñale tu voz"), Screen Wake Lock, guard de batería: todo cableado y alcanzable (`ProfileScreen.jsx`). `VITE_MODO_CAMPO=true` YA está en `deploy.yml` (activo en prod desde 2026-07-05, no es flag "dark").
- Corrí `tests/e2e-real/modo-campo-wakeword.smoke.mjs` dos veces contra el motor real: el contrato `wake→activarEscucha` funciona (rechaza correctamente el negativo "chagra"), pero el modelo de fábrica (47 muestras 100% sintéticas Kokoro) **no detectó el clip held-out real** las 2 veces. Es una limitación de precisión del modelo, no código muerto — el propio "Enséñale tu voz" existe como mitigación de diseño para este caso exacto. Reentrenar está fuera de mi mandato explícito.

### Fuera de alcance (reportado, no forzado)

- **#19 perfiles idle jaguar/guacamaya/chivito/luciérnaga**: Jaguar YA tiene idle propio, pero en el sistema paralelo `visual/creatures/vidaEstados.js` (mundo3d, fuera de mi alcance). Guacamaya es un "billboard ligero sin kit rubber-hose" (sin ojos/boca/gestos) — necesita rediseño de arte, no cableado. Chivito/luciérnaga no existen como componentes. Ninguno está en `AVATAR_TYPES` de la PWA.
- **#49 director de cámara con dioramas**: vivo (`camaraDioramas.js`/`CamaraDirector.jsx`), pero 100% en `mundo3d/*` — regla explícita de no tocar.
- **#20/#44/#97(parcial)**: viven en el repo externo `V/`, no en esta PWA.

## Veredicto

compai del lado PWA queda al 100% de lo cableable sin tocar mundo3d/valle/mockups de arte ni reentrenar modelos. Lo que falta genuinamente son: arte nuevo (guacamaya/chivito/luciérnaga rubber-hose), trabajo en el repo externo `V/`, y precisión del modelo de wake-word (dataset de voz real, track aparte).

## Test plan

- [x] `npx vitest run src/compai src/hooks src/services/__tests__/angelitaInteligencia.test.js src/services/__tests__/angelitaVariedadTelemetria.test.js src/components/__tests__/AgentFab.*.test.jsx` — 309 tests verdes
- [x] `npx eslint --max-warnings=0` sobre todos los archivos nuevos/modificados (2 warnings preexistentes en `angelitaVariedad.js` confirmados ajenos, mismos en `origin/dev` limpio)
- [x] `node scripts/tsc-check-gate.mjs` — mismas 4 regresiones preexistentes en `origin/dev`, cero regresión nueva de mis archivos
- [x] Smoke e2e real de wake-word corrido 2x contra el motor de producción

🤖 Generado con [Claude Code](https://claude.com/claude-code)