### PR TITLE
fix(home): chagra.app abre en 2D + pide login para anónimos (offline-first preservado)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1359,9 +1359,14 @@ export default function App() {
     isAuthenticated().then((isAuth) => {
       if (!isAuth) {
         setSinSesion(true);
-        // La raíz sin sesión aterriza en el valle 3D (tema de entrada). El
-        // login sigue accesible con #login o el botón volver del valle.
-        navigate(hash === 'login' ? 'login' : 'valle3d');
+        // GATE DE LOGIN PARA ANÓNIMOS (2026-08-02): sin token la raíz aterriza
+        // en la pantalla de LOGIN (estado final), no en el valle 3D. chagra.app
+        // debe pedir login. Offline-first se preserva: esta rama SOLO corre para
+        // quien NO tiene token; el usuario ya autenticado (rama `isAuth` abajo)
+        // sigue entrando al dashboard y funcionando offline como siempre — su
+        // token cacheado lo saca de aquí. Las rutas públicas (onboarding-piloto,
+        // mockups, callback OAuth) ya se resolvieron ANTES de este check.
+        navigate('login');
         return;
       }
       const targetView = HASH_VIEW_ROUTES[hash] || 'dashboard';

--- a/src/store/usePrefsStore.js
+++ b/src/store/usePrefsStore.js
@@ -27,11 +27,14 @@ const SONIDO_MODES = ['off', 'suave', 'on'];
 // prende el flag en Perfil ve la banda de entrada en "Los mundos de su finca"
 // — y solo si su equipo aguanta 3D (device-tier alto/medio, deviceTier.js).
 const STORAGE_KEY_VALLE3D = 'chagra:prefs:valle3d';
-// Migración de salida: versiones anteriores podían dejar este flag apagado en
-// localStorage. Para destrabar la experiencia 3D en el build actual, la primera
-// carga posterior a esta migración lo vuelve a encender una sola vez y después
-// respeta el valor elegido por el usuario.
-const STORAGE_KEY_VALLE3D_MIGRATED = 'chagra:prefs:valle3d:migrated-v1';
+// Migración de ENTRADA a 2D-por-defecto (2026-08-02): chagra.app debe ABRIR en
+// 2D. La migración previa (migrated-v1) forzaba el valle 3D encendido en la
+// primera carga de cada usuario — por eso todos veían el valle 3D como home
+// aunque el default declarado fuera false. Esta migración v2 DESACTIVA el valle
+// 3D una sola vez para quienes quedaron con el flag encendido por la migración
+// vieja, y a partir de ahí respeta lo que el usuario elija en Perfil →
+// experiencia. Quien QUIERA el valle 3D lo prende ahí; el default es 2D.
+const STORAGE_KEY_VALLE3D_MIGRATED = 'chagra:prefs:valle3d:migrated-v2-2d-default';
 // Avatar del USUARIO (2026-07-13): el animal de la chagra que la persona
 // elige como su avatar (slug del registro CREATURES de src/visual/creatures).
 // Default: la abeja angelita. El store solo persiste el slug como string —
@@ -57,14 +60,16 @@ function loadValle3d() {
   try {
     const migrated = localStorage.getItem(STORAGE_KEY_VALLE3D_MIGRATED) === '1';
     if (!migrated) {
+      // Migración v2: apagar el valle 3D una sola vez (2D-por-defecto) y no
+      // volver a tocarlo. Después respeta la elección del usuario en Perfil.
       localStorage.setItem(STORAGE_KEY_VALLE3D_MIGRATED, '1');
-      localStorage.setItem(STORAGE_KEY_VALLE3D, JSON.stringify(true));
-      return true;
+      localStorage.setItem(STORAGE_KEY_VALLE3D, JSON.stringify(false));
+      return false;
     }
   } catch (_) {
-    return true;
+    return false;
   }
-  return load(STORAGE_KEY_VALLE3D, true);
+  return load(STORAGE_KEY_VALLE3D, false);
 }
 
 const usePrefsStore = create((set, _get) => ({


### PR DESCRIPTION
## Qué

Dos correcciones para que **chagra.app abra en 2D y pida login**, sin romper el offline-first.

### 1. Valle 3D OFF por defecto (`src/store/usePrefsStore.js`)
La migración `migrated-v1` de `loadValle3d()` **forzaba el valle 3D encendido en la primera carga de cada usuario**, pisando el default declarado `false`. Por eso todos veían el valle 3D como home. Nueva migración `migrated-v2-2d-default` lo apaga una sola vez y luego respeta la elección del usuario. Fallbacks de `load()` cambiados a `false`. Default = **2D**; el valle 3D queda **opt-in en Perfil → experiencia**.

### 2. Gate de login para anónimos (`src/App.jsx`, boot)
Sin token, la raíz ruteaba a `'valle3d'` en vez de pedir login (`navigate(hash === 'login' ? 'login' : 'valle3d')`). Ahora los anónimos van a **`login`** como estado final.

**Offline-first PRESERVADO**: la rama sólo corre para quien NO tiene token. El usuario ya autenticado (rama `isAuth`) entra al dashboard y funciona offline como siempre — su token cacheado lo saca de ahí. Las rutas públicas (onboarding-piloto, mockups, callback OAuth) se resuelven ANTES del check.

## Verificación

- **eslint** `--max-warnings=0` en ambos archivos → limpio. Voseo/secret/infra/strategic/pro-import scans → limpios.
- **Login E2E**: password grant (`client_id=farm`) contra farmOS vía proxy `/oauth/token` → **HTTP 200 + Bearer token**. En navegador: llenar usuario/contraseña → sale de login → entra al onboarding post-login.
- **Capturas incógnito fresco**: boot muestra pantalla de login 2D (sin canvas 3D); tras login, entra a la app.

## Por qué a `dev` (no deploy manual a prod)

El fix ya está desplegado manualmente en prod para desbloquear el dominio público, pero **debe entrar por el pipeline oficial**: si no, el próximo `push a main → deploy.yml` pisaría el deploy manual y volvería el bug. Estos cambios son correctos para todos los ambientes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)