### PR TITLE
fix(voz): voz del asistente por defecto em_santa — retira ef_dora (gringa)

### DIFF
--- a/src/components/Settings/__tests__/VoiceSelector.test.jsx
+++ b/src/components/Settings/__tests__/VoiceSelector.test.jsx
@@ -56,9 +56,9 @@ describe('VoiceSelector — rediseño mínima fricción', () => {
   });
 
   test('respeta la voz preferida persistida', () => {
-    localStorage.setItem('chagra:tts:voice', 'pm_santa');
+    localStorage.setItem('chagra:tts:voice', 'em_alex');
     render(<VoiceSelector />);
-    expect(screen.getByTestId('voice-puesta-pm_santa')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-puesta-em_alex')).toBeInTheDocument();
   });
 
   test('UN toque reproduce la voz Y la persiste de una (sin Guardar)', async () => {
@@ -77,7 +77,7 @@ describe('VoiceSelector — rediseño mínima fricción', () => {
 
   test('tocar corta el audio previo antes de reproducir (evita overlap)', async () => {
     render(<VoiceSelector />);
-    fireEvent.click(screen.getByTestId('voice-option-pm_santa'));
+    fireEvent.click(screen.getByTestId('voice-option-em_santa'));
     await waitFor(() => {
       expect(stopTTS).toHaveBeenCalled();
       expect(speakKokoro).toHaveBeenCalledTimes(1);

--- a/src/services/__tests__/ttsService.voice.test.js
+++ b/src/services/__tests__/ttsService.voice.test.js
@@ -153,15 +153,15 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
     });
 
     it('sin voice explícito usa la voz preferida persistida', async () => {
-      setPreferredVoice('ef_dora');
+      setPreferredVoice('em_alex');
       await speakKokoro('Hola mundo');
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
-      expect(body.voice).toBe('ef_dora');
+      expect(body.voice).toBe('em_alex');
     });
 
     it('voice explícito en options gana sobre la voz preferida (backwards compat)', async () => {
-      setPreferredVoice('em_alex');
+      setPreferredVoice('em_santa');
       await speakKokoro('Hola mundo', { voice: 'em_alex' });
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
@@ -169,18 +169,22 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
     });
 
     it('voice explícito gana aunque sea distinto del default (no se "promueve" preferencia)', async () => {
-      setPreferredVoice('em_alex');
-      await speakKokoro('Hola', { voice: 'ef_dora' });
-      const [, init] = fetchMock.mock.calls[0];
-      const body = JSON.parse(init.body);
-      expect(body.voice).toBe('ef_dora');
-    });
-
-    it('coerciona ef_dora (no servible) a la default santa: dora NUNCA viaja al server', async () => {
-      await speakKokoro('Hola', { voice: 'ef_dora' });
+      setPreferredVoice('em_santa');
+      await speakKokoro('Hola', { voice: 'em_alex' });
       const [, init] = fetchMock.mock.calls[0];
       const body = JSON.parse(init.body);
       expect(body.voice).toBe('em_alex');
+    });
+
+    it('coerciona ef_dora (no servible) a la default santa: dora NUNCA viaja al server', async () => {
+      // ef_dora fue retirada del catálogo (suena "gringa", 2026-08-02): al no
+      // estar en KOKORO_VOICES, toServableVoice la coerciona al DEFAULT (santa).
+      await speakKokoro('Hola', { voice: 'ef_dora' });
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse(init.body);
+      expect(body.voice).toBe(DEFAULT_KOKORO_VOICE);
+      expect(body.voice).toBe('em_santa');
+      expect(body.voice).not.toBe('ef_dora');
     });
 
     it('coerciona voces inglesas inexistentes (ef_aoede/ef_kore) a santa, no a dora', async () => {
@@ -188,7 +192,7 @@ describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
       await speakKokoro('Hola', { voice: 'ef_kore' });
       for (const call of fetchMock.mock.calls) {
         const body = JSON.parse(call[1].body);
-        expect(body.voice).toBe('em_alex');
+        expect(body.voice).toBe('em_santa');
         expect(body.voice).not.toBe('ef_dora');
       }
     });

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -79,8 +79,14 @@ function applyVoseoGuard(text) {
  * GOTCHA: ante una voz no servible el server cae SILENCIOSO a la DEFAULT_VOICE.
  * `em_santa` (Santa) es la voz elegida por el operador — es la Santa ESPAÑOLA
  * de Kokoro (voz baked-in del modelo, prefijo `em_` = español masculino), NO la
- * portuguesa `pm_santa` que sonaba robótica. `em_alex`/`ef_dora` quedan como
- * alternativas, también en español.
+ * portuguesa `pm_santa` que sonaba robótica. `em_alex` queda como alternativa,
+ * también en español.
+ *
+ * DORA FUERA (2026-08-02) — el operador reportó que `ef_dora` suena "gringa"
+ * (prosodia anglo) y pidió que NUNCA se oiga. Se retira de KOKORO_VOICES para
+ * que `toServableVoice` la coercione a santa (dora no viaja al server ni por
+ * fallback silencioso) y para que el selector no la ofrezca. Ver PR #2240/#2304
+ * (dora había reaparecido en el catálogo por error) y el reporte de voz.
  */
 export const KOKORO_VOICES = Object.freeze([
   {
@@ -95,14 +101,12 @@ export const KOKORO_VOICES = Object.freeze([
     description: 'Voz de hombre, natural y clara.',
     gender: 'masculina',
   },
-  {
-    id: 'ef_dora',
-    label: 'Dora',
-    description: 'Voz de mujer, suave y clara.',
-    gender: 'femenina',
-  },
 ]);
 
+// Punto único de la voz del asistente (Compai = Angelita = Colibrí = Agente:
+// una sola entidad con varias pieles). getPreferredVoice() y toServableVoice()
+// cuelgan de aquí; este es también el gancho para una futura voz clonada
+// personalizada — cambiar la voz por defecto se hace SOLO aquí.
 export const DEFAULT_KOKORO_VOICE = 'em_santa';
 export const DEFAULT_KOKORO_RATE = 1.0;
 export const KOKORO_RATE_MIN = 0.85;


### PR DESCRIPTION
## Qué

Cierra la voz del asistente de punta a punta: el asistente (Compai/Angelita/Colibrí/Agente = la misma entidad) habla con **`em_santa`** (voz española natural de Kokoro) y **`ef_dora` deja de sonar** — el operador la reportó como "gringa" (prosodia anglo).

## Contexto / causa raíz

- El default ya era `em_santa` (mergeado en #2304), y la respuesta del asistente ya dispara TTS (`AgentScreen` → `speakSentences` → `getPreferredVoice()` → `em_santa`).
- **Pero** #2304 reintrodujo `ef_dora` en `KOKORO_VOICES` mientras arreglaba el default, deshaciendo la retirada de #2240. Con dora servible:
  - el selector volvía a ofrecerla,
  - `toServableVoice('ef_dora')` la dejaba pasar al server,
  - **5 tests de voz quedaban en rojo silencioso** (esperaban dora coercionada a santa y ausente del selector).
- El servidor kokoro tiene `default_voice: ef_dora` → ante cualquier voz desconocida cae **silenciosamente** a dora. Por eso `toServableVoice` debe coercionar todo lo no-catalogado a `em_santa`; para eso dora **no** puede estar en el catálogo.

## Cambios

- `src/services/ttsService.js`: quita `ef_dora` de `KOKORO_VOICES`; marca `DEFAULT_KOKORO_VOICE = 'em_santa'` como el **punto único** de la voz del asistente (y gancho para una futura voz clonada personalizada).
- Sincroniza dos test files stale (objetivo de coerción `em_alex` → `em_santa`; voces de ejemplo `pm_santa` → `em_alex`/`em_santa`).

## Verificación en vivo (no silencio)

Contra el servidor kokoro (`:8088`) **y** el path real de la PWA vía nginx (`/api/kokoro/tts`), voz `em_santa`, texto "Buenas, mijo, ¿qué sembró hoy?":

- HTTP 200, 88 KB `audio/wav`, **1.83 s**, 24 kHz mono 16-bit.
- Peak 21513/32767 (66% full-scale), RMS 2497, 77% muestras no-silenciosas → **audio real, no silencio**.
- Whisper (`:10301`) lo transcribe de vuelta como **"Buenas, mijo, que sembró hoy."** → español correcto e inteligible.

## Tests

- `ttsService.voice.test.js` + `VoiceSelector.test.jsx`: **26/26 verdes** (antes 5 rojos).
- Resto de la suite TTS (consistency/sanitize/streaming/xtts/speakingState): **58/58 verdes**.
- eslint `--max-warnings=0` limpio en los 3 archivos.

## No rompe nada bench-sensible

Solo toca `ttsService.js` (cliente PWA) + sus tests. Cero cambios en el sidecar agro-mcp, NLU, RAG, grafo o cualquier ruta de bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)