### PR TITLE
fix(compai): sync-compai-nucleo apuntaba a un destino inexistente

### DIFF
--- a/scripts/sync-compai-nucleo.mjs
+++ b/scripts/sync-compai-nucleo.mjs
@@ -32,7 +32,10 @@ import { fileURLToPath } from 'node:url';
 
 const AQUI = dirname(fileURLToPath(import.meta.url));
 const ORIGEN = resolve(AQUI, '../src/compai/nucleo');
-const DESTINO_DEFECTO = resolve(AQUI, '../../../demos-src/valle-guatoc/compai');
+// Valle guatoc = ~/demos/3d/ (servido en 3d.guatoc.co raíz) — NO
+// ~/demos-src/valle-guatoc/ (ruta vieja/inexistente) ni ~/demos/valle-guatoc/
+// (basura descartada). Ver memoria feedback_valle_canonico_3d_guatoc.
+const DESTINO_DEFECTO = resolve(AQUI, '../../../demos/3d/compai');
 
 const args = process.argv.slice(2);
 const soloVerificar = args.includes('--check');


### PR DESCRIPTION
## Contexto

Se me pidió implementar los PASOS 1-2 del `PLAN-ASISTENTE-UNIFICADO.md` (portar el núcleo compai a la PWA + unificar identidad `useAgentAvatarType`/`ChagraAgentAvatar` vía `elenco.js`, dual-write de llaves `compai:companero` ⟷ `chagra:agent-avatar-type`).

**Verificación previa (worktree limpio desde `origin/dev`):** ambos pasos ya están implementados y mergeados en `dev` (histórico `feat(compai): ...` #2809-#2841). El núcleo vive en `chagra/src/compai/nucleo/` (no `chagra/src/core/compai/` como sugería el borrador del plan), `useAgentAvatarType.js` ya lee/escribe vía `leerCompanero`/`escribirCompanero` de `elenco.js`, el default ya es `angelita` (colibrí jubilado), y `scripts/sync-compai-nucleo.mjs` ya existe con `--check` por md5.

## Lo que encontré roto y arreglo aquí

`DESTINO_DEFECTO` del sync script resolvía a `~/demos-src/valle-guatoc/compai` — una ruta que **no existe**. El valle guatoc real es `~/demos/3d/` (servido en `3d.guatoc.co` raíz — memoria `feedback_valle_canonico_3d_guatoc`). Con la ruta rota, `--check` no podía detectar deriva real: corría contra un directorio vacío/inexistente, así que el gate anti-divergencia que promete el `MANIFIESTO.md` no funcionaba.

Corregida la ruta y re-sincronizado el núcleo real (`node scripts/sync-compai-nucleo.mjs`, sin `--check`) — 4 archivos habían derivado entre `chagra/` y el valle: `elenco.js`, `comentarista.js`, `gestos.js` (cambios menores/cosméticos) y `agroecologia.js` (archivo entero faltante en el valle, de un commit reciente de `dev`). Esa copia vive fuera de este repo (`~/demos/3d/`, su propio git), así que no aparece en este diff.

## Test plan
- [x] `npx vitest run src/hooks/__tests__/useAgentAvatarType.test.jsx src/components/__tests__/ChagraAgentAvatar.test.jsx` → 20/20 pasan
- [x] `npx vitest run src/compai/nucleo/__tests__/` → 80/80 pasan
- [x] `npx eslint src/hooks/useAgentAvatarType.js src/components/ChagraAgentAvatar.jsx src/compai/nucleo/*.js scripts/sync-compai-nucleo.mjs --max-warnings=0` → limpio
- [x] `node scripts/sync-compai-nucleo.mjs --check` → `✓ sin deriva` (antes: fallaba siempre, exit 1)
- [ ] 2 fallas preexistentes en `src/visual/creatures/__tests__/vidaEstados.test.js` (registro de fauna `borugo`/`condor`/`danta`) — confirmadas preexistentes en `origin/dev` HEAD, sin relación con este cambio, fuera de scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)